### PR TITLE
fix(whatsapp): normalize hosted JIDs consistently with Baileys

### DIFF
--- a/extensions/whatsapp/setup-entry.test.ts
+++ b/extensions/whatsapp/setup-entry.test.ts
@@ -9,6 +9,10 @@ vi.mock("baileys", () => {
   throw new Error("setup plugin load must not load Baileys");
 });
 
+vi.mock("./src/auth-store.js", () => {
+  throw new Error("setup auth checks must not load auth-store");
+});
+
 vi.mock("./src/setup-finalize.js", () => {
   throw new Error("setup status load must not load finalize");
 });
@@ -40,6 +44,17 @@ describe("whatsapp setup entry", () => {
   it("loads the setup plugin without installing runtime dependencies", () => {
     const whatsappSetupPlugin = setupEntry.loadSetupPlugin(setupEntryLoadOptions);
     expect(whatsappSetupPlugin.id).toBe("whatsapp");
+  });
+
+  it("checks setup auth state without importing runtime auth dependencies", async () => {
+    const whatsappSetupPlugin = setupEntry.loadSetupPlugin(setupEntryLoadOptions);
+
+    await expect(
+      whatsappSetupPlugin.config.isConfigured?.(
+        { authDir: "/tmp/openclaw-whatsapp-unconfigured-setup-entry" } as never,
+        {} as never,
+      ),
+    ).resolves.toBe(false);
   });
 
   it("loads legacy setup helpers without importing runtime dependencies", () => {

--- a/extensions/whatsapp/src/action-runtime-target-auth.ts
+++ b/extensions/whatsapp/src/action-runtime-target-auth.ts
@@ -18,6 +18,8 @@ export function resolveAuthorizedWhatsAppOutboundTarget(params: {
     to: params.chatJid,
     allowFrom: account.allowFrom ?? [],
     mode: "implicit",
+    cfg: params.cfg,
+    accountId: account.accountId,
   });
   if (!resolution.ok) {
     throw new ToolAuthorizationError(

--- a/extensions/whatsapp/src/agent-tools-call.test.ts
+++ b/extensions/whatsapp/src/agent-tools-call.test.ts
@@ -172,7 +172,10 @@ describe("WhatsApp call tool", () => {
         termination: "exit" as const,
       };
     }) as OpenClawPluginApi["runtime"]["system"]["runCommandWithTimeout"];
-    const tool = resolveRegisteredCallTool(createApi({ runCommand }), createContext());
+    const tool = resolveRegisteredCallTool(
+      createApi({ runCommand }),
+      createContext({ requesterSenderId: "15551234567:2@c.us" }),
+    );
 
     const result = await tool?.execute("call-2", {
       action: "call",

--- a/extensions/whatsapp/src/agent-tools-call.ts
+++ b/extensions/whatsapp/src/agent-tools-call.ts
@@ -18,6 +18,7 @@ import { Type } from "typebox";
 import { resolveWhatsAppAccount } from "./accounts.js";
 import { getWhatsAppConnectionController } from "./connection-controller-runtime-context.js";
 import { resolveJidToE164 } from "./targets-runtime.js";
+import { classifyWhatsAppJid } from "./whatsapp-jid.js";
 
 const MEOWCALLER_COMMAND = "meowcaller";
 const SESSION_DATABASE = "wa-voip.db";
@@ -147,7 +148,11 @@ async function resolveRequesterE164(params: {
   requesterSenderId: string;
 }): Promise<string | null> {
   const senderId = params.requesterSenderId.trim();
-  if (!senderId.includes("@")) {
+  const classified = classifyWhatsAppJid(senderId);
+  if (classified.kind !== "pn" && classified.kind !== "lid") {
+    if (senderId.includes("@")) {
+      return null;
+    }
     try {
       return normalizeE164(senderId.replace(/^whatsapp:/i, ""));
     } catch {
@@ -158,7 +163,7 @@ async function resolveRequesterE164(params: {
   const account = resolveWhatsAppAccount({ cfg: params.cfg, accountId: params.accountId });
   const lidLookup = getWhatsAppConnectionController(params.accountId)?.getCurrentSock()
     ?.signalRepository.lidMapping;
-  return await resolveJidToE164(senderId, { authDir: account.authDir, lidLookup });
+  return await resolveJidToE164(classified.jid, { authDir: account.authDir, lidLookup });
 }
 
 async function resolveLinkedWhatsAppSelfE164(params: {

--- a/extensions/whatsapp/src/allowlist-doctor.ts
+++ b/extensions/whatsapp/src/allowlist-doctor.ts
@@ -1,0 +1,222 @@
+// Whatsapp plugin module migrates shipped LID-form allowlist entries.
+import { DEFAULT_ACCOUNT_ID, resolveAccountEntry } from "openclaw/plugin-sdk/account-core";
+import type {
+  ChannelDoctorConfigMutation,
+  ChannelDoctorLegacyConfigRule,
+} from "openclaw/plugin-sdk/channel-contract";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { asObjectRecord } from "openclaw/plugin-sdk/runtime-doctor";
+import { listWhatsAppAccountIds, resolveWhatsAppAuthDir } from "./accounts.js";
+import { readWhatsAppLidToPnMappings } from "./lid-mapping-files.js";
+import {
+  parseWhatsAppDirectJidSyntax,
+  stripWhatsAppTargetPrefixes,
+} from "./whatsapp-jid-syntax.js";
+
+function parseLidAllowlistEntry(value: unknown) {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const parsed = parseWhatsAppDirectJidSyntax(stripWhatsAppTargetPrefixes(value));
+  return parsed?.server === "lid" || parsed?.server === "hosted.lid" ? parsed : null;
+}
+
+const WHATSAPP_ALLOWLIST_KEYS = ["allowFrom", "groupAllowFrom"] as const;
+type WhatsAppAllowlistKey = (typeof WHATSAPP_ALLOWLIST_KEYS)[number];
+
+function containsLidAllowlist(value: unknown): boolean {
+  const entry = asObjectRecord(value);
+  return WHATSAPP_ALLOWLIST_KEYS.some((key) => {
+    const entries = entry?.[key];
+    return Array.isArray(entries) && entries.some(parseLidAllowlistEntry);
+  });
+}
+
+export const whatsAppLidAllowlistLegacyRules: ChannelDoctorLegacyConfigRule[] = [
+  {
+    path: ["channels", "whatsapp"],
+    message:
+      "WhatsApp allowFrom or groupAllowFrom contains LID JIDs. Run doctor --fix to migrate entries backed by verified LID→PN mappings; replace any unresolved entries with E.164 numbers.",
+    match: containsLidAllowlist,
+  },
+  {
+    path: ["channels", "whatsapp", "accounts"],
+    message:
+      "A WhatsApp account allowFrom or groupAllowFrom contains LID JIDs. Run doctor --fix to migrate entries backed by verified LID→PN mappings; replace any unresolved entries with E.164 numbers.",
+    match: (value) => {
+      const accounts = asObjectRecord(value);
+      return Boolean(accounts && Object.values(accounts).some(containsLidAllowlist));
+    },
+  },
+];
+
+function migrateLidAllowlistEntries(params: {
+  entries: unknown[];
+  configPath: string;
+  mappingScopes: readonly (readonly string[])[];
+  changes: string[];
+  warnings: string[];
+}): unknown[] | null {
+  let changed = false;
+  const entries = params.entries.map((entry) => {
+    const parsed = parseLidAllowlistEntry(entry);
+    if (!parsed) {
+      return entry;
+    }
+    const mappingsByScope = params.mappingScopes.map((mappingDirs) =>
+      readWhatsAppLidToPnMappings({ lid: parsed.user, mappingDirs }),
+    );
+    const mappings = new Set(mappingsByScope.flat());
+    const everyScopeMapped = mappingsByScope.every((scopeMappings) => scopeMappings.length === 1);
+    if (!everyScopeMapped || mappings.size !== 1) {
+      const reason =
+        mappings.size <= 1
+          ? "no verified LID→PN mapping was found"
+          : "conflicting LID→PN mappings were found";
+      params.warnings.push(
+        `${params.configPath} entry "${String(entry).trim()}" was not migrated because ${reason}; replace it with the sender's E.164 number.`,
+      );
+      return entry;
+    }
+    const phoneDigits = [...mappings][0]?.slice(1);
+    if (!phoneDigits) {
+      return entry;
+    }
+    changed = true;
+    params.changes.push(
+      `Migrated ${params.configPath} entry "${String(entry).trim()}" → "${phoneDigits}" using its verified LID→PN mapping.`,
+    );
+    return phoneDigits;
+  });
+  return changed ? entries : null;
+}
+
+function resolveAllowlistMappingScopes(params: {
+  cfg: OpenClawConfig;
+  accounts: Record<string, unknown> | null;
+  key: WhatsAppAllowlistKey;
+  accountId?: string;
+}): string[][] {
+  const ownerAccountId = params.accountId?.trim();
+  const ownerId = ownerAccountId?.toLowerCase();
+  if (ownerAccountId && ownerId !== DEFAULT_ACCOUNT_ID) {
+    return [[resolveWhatsAppAuthDir({ cfg: params.cfg, accountId: ownerAccountId }).authDir]];
+  }
+  const defaultEntry = asObjectRecord(
+    resolveAccountEntry(params.accounts ?? undefined, DEFAULT_ACCOUNT_ID),
+  );
+  const defaultOverridesRoot = Array.isArray(defaultEntry?.[params.key]);
+  return listWhatsAppAccountIds(params.cfg).flatMap((accountId) => {
+    const normalizedAccountId = accountId.trim().toLowerCase();
+    const accountEntry = asObjectRecord(
+      resolveAccountEntry(params.accounts ?? undefined, accountId),
+    );
+    const accountOverridesInherited = Array.isArray(accountEntry?.[params.key]);
+    const inheritsOwner =
+      ownerId === DEFAULT_ACCOUNT_ID
+        ? normalizedAccountId === DEFAULT_ACCOUNT_ID || !accountOverridesInherited
+        : !accountOverridesInherited &&
+          (normalizedAccountId === DEFAULT_ACCOUNT_ID || !defaultOverridesRoot);
+    if (!inheritsOwner) {
+      return [];
+    }
+    return [[resolveWhatsAppAuthDir({ cfg: params.cfg, accountId }).authDir]];
+  });
+}
+
+function migrateLidAllowlistFields(params: {
+  entry: Record<string, unknown>;
+  configPath: string;
+  resolveMappingScopes: (key: WhatsAppAllowlistKey) => readonly (readonly string[])[];
+  changes: string[];
+  warnings: string[];
+}): Record<string, unknown> | null {
+  let nextEntry: Record<string, unknown> | null = null;
+  for (const key of WHATSAPP_ALLOWLIST_KEYS) {
+    const entries = params.entry[key];
+    if (!Array.isArray(entries)) {
+      continue;
+    }
+    const migrated = migrateLidAllowlistEntries({
+      entries,
+      configPath: `${params.configPath}.${key}`,
+      mappingScopes: params.resolveMappingScopes(key),
+      changes: params.changes,
+      warnings: params.warnings,
+    });
+    if (migrated) {
+      nextEntry ??= { ...params.entry };
+      nextEntry[key] = migrated;
+    }
+  }
+  return nextEntry;
+}
+
+export function migrateWhatsAppLidAllowlistsConfig(
+  cfg: OpenClawConfig,
+): ChannelDoctorConfigMutation {
+  const channels = cfg.channels as Record<string, unknown> | undefined;
+  const entry = asObjectRecord(channels?.whatsapp);
+  if (!entry) {
+    return { config: cfg, changes: [], warnings: [] };
+  }
+
+  const changes: string[] = [];
+  const warnings: string[] = [];
+  let nextEntry = entry;
+  const accounts = asObjectRecord(entry.accounts);
+  const migratedRoot = migrateLidAllowlistFields({
+    entry,
+    configPath: "channels.whatsapp",
+    resolveMappingScopes: (key) => resolveAllowlistMappingScopes({ cfg, accounts, key }),
+    changes,
+    warnings,
+  });
+  if (migratedRoot) {
+    nextEntry = migratedRoot;
+  }
+
+  let accountsChanged = false;
+  const nextAccounts = accounts
+    ? Object.fromEntries(
+        Object.entries(accounts).map(([accountId, rawAccount]) => {
+          const account = asObjectRecord(rawAccount);
+          if (!account) {
+            return [accountId, rawAccount];
+          }
+          const migrated = migrateLidAllowlistFields({
+            entry: account,
+            configPath: `channels.whatsapp.accounts.${accountId}`,
+            // Default-account policy is inherited by named accounts. Require a
+            // unanimous mapping across every account that consumes each field.
+            resolveMappingScopes: (key) =>
+              resolveAllowlistMappingScopes({ cfg, accounts, key, accountId }),
+            changes,
+            warnings,
+          });
+          if (!migrated) {
+            return [accountId, rawAccount];
+          }
+          accountsChanged = true;
+          return [accountId, migrated];
+        }),
+      )
+    : accounts;
+  if (accountsChanged) {
+    nextEntry = { ...nextEntry, accounts: nextAccounts };
+  }
+  if (nextEntry === entry) {
+    return { config: cfg, changes, warnings: [...new Set(warnings)] };
+  }
+  return {
+    config: {
+      ...cfg,
+      channels: {
+        ...channels,
+        whatsapp: nextEntry,
+      },
+    } as OpenClawConfig,
+    changes,
+    warnings: [...new Set(warnings)],
+  };
+}

--- a/extensions/whatsapp/src/allowlist-format.test.ts
+++ b/extensions/whatsapp/src/allowlist-format.test.ts
@@ -1,0 +1,41 @@
+// Whatsapp tests cover setup/runtime allowlist formatting parity.
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { describe, expect, it } from "vitest";
+import { whatsappPlugin } from "./channel.js";
+import { whatsappSetupPlugin } from "./channel.setup.js";
+
+describe("WhatsApp allowlist formatting", () => {
+  it("uses the same canonical formatter in setup and runtime", () => {
+    const allowFrom: Array<string | number> = [
+      " WhatsApp:whatsapp:+1 (555) 123-4567 ",
+      "+15551234567",
+      "15551230001@s.whatsapp.net",
+      "15551230001:4@c.us",
+      "15551230002:7@hosted",
+      "15551230006_128:1@s.whatsapp.net",
+      "15551230007_128:2@hosted",
+      "277038292303944_1:2@s.whatsapp.net",
+      "277038292303945_129:3@s.whatsapp.net",
+      "*",
+      15551230003,
+      " ",
+      "abc@s.whatsapp.net",
+      "15551230004:bad@hosted",
+      "15551230005@lid",
+      "telegram:+15551230006",
+    ];
+    const params = { cfg: {} as OpenClawConfig, allowFrom };
+    const expected = [
+      "15551234567",
+      "15551230001",
+      "15551230002",
+      "15551230006",
+      "15551230007",
+      "*",
+      "15551230003",
+    ];
+
+    expect(whatsappSetupPlugin.config.formatAllowFrom?.(params)).toEqual(expected);
+    expect(whatsappPlugin.config.formatAllowFrom?.(params)).toEqual(expected);
+  });
+});

--- a/extensions/whatsapp/src/allowlist-format.ts
+++ b/extensions/whatsapp/src/allowlist-format.ts
@@ -1,0 +1,38 @@
+// Whatsapp plugin module owns dependency-light allowlist formatting.
+import { normalizeE164 } from "openclaw/plugin-sdk/account-resolution";
+import { normalizeStringEntries, uniqueStrings } from "openclaw/plugin-sdk/string-coerce-runtime";
+import {
+  parseWhatsAppDirectJidSyntax,
+  stripWhatsAppTargetPrefixes,
+} from "./whatsapp-jid-syntax.js";
+
+const NON_WHATSAPP_PROVIDER_PREFIX_RE = /^[a-z][a-z0-9-]*:/i;
+
+export function normalizeWhatsAppAllowFromEntry(entry: string): string | null {
+  if (entry === "*") {
+    return entry;
+  }
+  const candidate = stripWhatsAppTargetPrefixes(entry);
+  const directJid = parseWhatsAppDirectJidSyntax(candidate);
+  if (directJid) {
+    if (directJid.server !== "s.whatsapp.net" && directJid.server !== "hosted") {
+      return null;
+    }
+    return directJid.user;
+  }
+  if (candidate.includes("@") || NON_WHATSAPP_PROVIDER_PREFIX_RE.test(candidate)) {
+    return null;
+  }
+  const normalized = normalizeE164(candidate);
+  return normalized.length > 1 ? normalized.slice(1) : null;
+}
+
+export function formatWhatsAppConfigAllowFromEntries(allowFrom: Array<string | number>): string[] {
+  return uniqueStrings(
+    normalizeStringEntries(allowFrom)
+      .map(normalizeWhatsAppAllowFromEntry)
+      .filter((entry): entry is string => entry !== null),
+  );
+}
+
+export const normalizeWhatsAppAllowFromEntries = formatWhatsAppConfigAllowFromEntries;

--- a/extensions/whatsapp/src/approval-auth.test.ts
+++ b/extensions/whatsapp/src/approval-auth.test.ts
@@ -59,4 +59,41 @@ describe("whatsappApprovalAuth", () => {
       }),
     ).toEqual({ authorized: true });
   });
+
+  it("canonicalizes PN domains and device ids for approval authorization", () => {
+    for (const senderId of ["15551230000:3@c.us", "15551230000:4@hosted"]) {
+      expect(
+        whatsappApprovalAuth.authorizeActorAction({
+          cfg: { channels: { whatsapp: { allowFrom: ["+15551230000"] } } },
+          senderId,
+          action: "approve",
+          approvalKind: "exec",
+        }),
+      ).toEqual({ authorized: true });
+    }
+  });
+
+  it("does not authorize a same-digit LID without an explicit mapping", () => {
+    expect(
+      whatsappApprovalAuth.authorizeActorAction({
+        cfg: { channels: { whatsapp: { allowFrom: ["+15551230000"] } } },
+        senderId: "15551230000@lid",
+        action: "approve",
+        approvalKind: "exec",
+      }),
+    ).toMatchObject({ authorized: false });
+    expect(
+      getWhatsAppApprovalApprovers({
+        cfg: { channels: { whatsapp: { allowFrom: ["15551230000@hosted.lid"] } } },
+      }),
+    ).toEqual([]);
+    expect(
+      whatsappApprovalAuth.authorizeActorAction({
+        cfg: { channels: { whatsapp: { allowFrom: ["15551230000@hosted.lid"] } } },
+        senderId: "15551230000@hosted.lid",
+        action: "approve",
+        approvalKind: "exec",
+      }),
+    ).toMatchObject({ authorized: false });
+  });
 });

--- a/extensions/whatsapp/src/approval-auth.ts
+++ b/extensions/whatsapp/src/approval-auth.ts
@@ -1,14 +1,14 @@
 // Whatsapp plugin module implements approval auth behavior.
-import { createChannelApprovalAuth } from "openclaw/plugin-sdk/approval-auth-runtime";
+import {
+  createChannelApprovalAuth,
+  isImplicitSameChatApprovalAuthorization,
+} from "openclaw/plugin-sdk/approval-auth-runtime";
+import { normalizeStringEntries } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { resolveWhatsAppAccount } from "./accounts.js";
-import { normalizeWhatsAppTarget } from "./normalize.js";
+import { normalizeWhatsAppDirectPhone } from "./normalize-target.js";
 
 function normalizeWhatsAppApproverId(value: string | number): string | undefined {
-  const normalized = normalizeWhatsAppTarget(String(value));
-  if (!normalized || normalized.endsWith("@g.us")) {
-    return undefined;
-  }
-  return normalized;
+  return normalizeWhatsAppDirectPhone(String(value)) ?? undefined;
 }
 
 function normalizeWhatsAppApproverEntry(value: string | number): string | undefined {
@@ -19,6 +19,8 @@ const whatsappApproval = createChannelApprovalAuth({
   channelLabel: "WhatsApp",
   resolveInputs: ({ cfg, accountId }) => {
     const account = resolveWhatsAppAccount({ cfg, accountId });
+    // `defaultTo` owns delivery routing, not approval policy; inferring from it
+    // would grant approval authority to a target that was never an operator.
     return { allowFrom: account.allowFrom };
   },
   normalizeApprover: normalizeWhatsAppApproverEntry,
@@ -27,4 +29,23 @@ const whatsappApproval = createChannelApprovalAuth({
 });
 
 export const getWhatsAppApprovalApprovers = whatsappApproval.resolveApprovers;
-export const whatsappApprovalAuth = whatsappApproval.approvalAuth;
+export const whatsappApprovalAuth = {
+  authorizeActorAction(
+    input: Parameters<typeof whatsappApproval.approvalAuth.authorizeActorAction>[0],
+  ) {
+    const result = whatsappApproval.approvalAuth.authorizeActorAction(input);
+    if (!isImplicitSameChatApprovalAuthorization(result)) {
+      return result;
+    }
+    const account = resolveWhatsAppAccount({ cfg: input.cfg, accountId: input.accountId });
+    if (normalizeStringEntries(account.allowFrom ?? []).length === 0) {
+      return result;
+    }
+    // A configured but unsupported allowlist must not collapse into the
+    // no-allowlist same-chat fallback.
+    return {
+      authorized: false,
+      reason: `❌ You are not authorized to approve ${input.approvalKind} requests on WhatsApp.`,
+    } as const;
+  },
+};

--- a/extensions/whatsapp/src/approval-reactions.test.ts
+++ b/extensions/whatsapp/src/approval-reactions.test.ts
@@ -45,8 +45,10 @@ function registerExecApprovalTarget(params: { remoteJid: string; approvalId?: st
 
 function buildReactionMessage(params: {
   remoteJid: string;
+  remoteJidAlt?: string;
   reactionRemoteJid?: string;
   participant?: string;
+  participantAlt?: string;
   fromMe?: boolean;
   reactionFromMe?: boolean;
 }) {
@@ -54,7 +56,9 @@ function buildReactionMessage(params: {
     key: {
       id: "reaction-message",
       remoteJid: params.remoteJid,
+      ...(params.remoteJidAlt ? { remoteJidAlt: params.remoteJidAlt } : {}),
       ...(params?.participant ? { participant: params.participant } : {}),
+      ...(params.participantAlt ? { participantAlt: params.participantAlt } : {}),
       fromMe: params.fromMe ?? false,
     },
     message: {
@@ -174,6 +178,48 @@ describe("WhatsApp approval reactions", () => {
       cfg: approvalConfig(["+15551230000"]),
       approvalId: "plugin:abc",
       approvalKind: "plugin",
+      decision: "allow-once",
+      senderId: "+15551230000",
+      gatewayUrl: undefined,
+    });
+  });
+
+  it.each([
+    {
+      name: "direct chat",
+      remoteJid: "812345678901234@lid",
+      remoteJidAlt: "15551230000:2@s.whatsapp.net",
+    },
+    {
+      name: "group chat",
+      remoteJid: "120363401234567890@g.us",
+      participant: "812345678901234@lid",
+      participantAlt: "15551230000:2@s.whatsapp.net",
+    },
+  ])("authorizes a $name reaction from its observed alternate PN", async (testCase) => {
+    registerWhatsAppApprovalReactionTarget({
+      accountId: "default",
+      remoteJid: testCase.remoteJid,
+      messageId: "approval-message",
+      approvalId: "exec-observed-pn",
+      approvalKind: "exec",
+      allowedDecisions: ["allow-once"],
+    });
+    const resolveInboundJid = vi.fn().mockResolvedValue(null);
+
+    const handled = await maybeResolveWhatsAppApprovalReaction({
+      cfg: approvalConfig(["+15551230000"]),
+      accountId: "default",
+      msg: buildReactionMessage(testCase),
+      resolveInboundJid,
+    });
+
+    expect(handled).toBe(true);
+    expect(resolveInboundJid).not.toHaveBeenCalled();
+    expect(resolverMocks.resolveWhatsAppApproval).toHaveBeenCalledWith({
+      cfg: approvalConfig(["+15551230000"]),
+      approvalId: "exec-observed-pn",
+      approvalKind: "exec",
       decision: "allow-once",
       senderId: "+15551230000",
       gatewayUrl: undefined,

--- a/extensions/whatsapp/src/approval-reactions.ts
+++ b/extensions/whatsapp/src/approval-reactions.ts
@@ -15,6 +15,7 @@ import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
 import { resolveWhatsAppAccount } from "./accounts.js";
 import { getWhatsAppApprovalApprovers, whatsappApprovalAuth } from "./approval-auth.js";
+import { prepareWhatsAppInboundActor, type PreparedWhatsAppInboundActor } from "./identity.js";
 import { getOptionalWhatsAppRuntime } from "./runtime.js";
 
 const PERSISTENT_NAMESPACE = "whatsapp.approval-reactions";
@@ -46,7 +47,7 @@ type WhatsAppApprovalReactionTarget = ApprovalReactionTargetRecord & {
 type WhatsAppApprovalReactionEvent = {
   remoteJids: string[];
   messageId: string;
-  actorJid: string;
+  actor: PreparedWhatsAppInboundActor | null;
   reactionKey: string;
 };
 
@@ -531,18 +532,30 @@ function readWhatsAppApprovalReactionEvent(params: {
   const remoteJids: string[] = [];
   addCandidateRemoteJid(remoteJids, reaction?.key?.remoteJid);
   addCandidateRemoteJid(remoteJids, msg.key?.remoteJid);
-  const actorJid =
-    msg.key?.participant?.trim() ||
-    (msg.key?.fromMe
-      ? (params.selfLid?.trim() ?? params.selfJid?.trim() ?? "")
-      : (msg.key?.remoteJid?.trim() ?? ""));
-  if (!reactionKey || !messageId || remoteJids.length === 0 || !actorJid) {
+  const participantJid = msg.key?.participant?.trim();
+  const selfLid = params.selfLid?.trim();
+  const selfJid = params.selfJid?.trim();
+  const actor = participantJid
+    ? prepareWhatsAppInboundActor({
+        primaryJid: participantJid,
+        alternateJid: msg.key?.participantAlt,
+      })
+    : msg.key?.fromMe
+      ? prepareWhatsAppInboundActor({
+          primaryJid: selfLid || selfJid,
+          alternateJid: selfJid || selfLid,
+        })
+      : prepareWhatsAppInboundActor({
+          primaryJid: msg.key?.remoteJid,
+          alternateJid: msg.key?.remoteJidAlt,
+        });
+  if (!reactionKey || !messageId || remoteJids.length === 0) {
     return null;
   }
   return {
     remoteJids,
     messageId,
-    actorJid,
+    actor,
     reactionKey,
   };
 }
@@ -578,7 +591,9 @@ export async function maybeResolveWhatsAppApprovalReaction(params: {
     return false;
   }
 
-  const actorId = await params.resolveInboundJid(event.actorJid);
+  const actorId = event.actor
+    ? (event.actor.e164 ?? (await params.resolveInboundJid(event.actor.transportJid)))
+    : null;
   if (!actorId) {
     params.logVerboseMessage?.(
       `whatsapp: approval reaction ignored for ${target.approvalId}; missing actor identity`,

--- a/extensions/whatsapp/src/auth-state.ts
+++ b/extensions/whatsapp/src/auth-state.ts
@@ -1,0 +1,84 @@
+// Whatsapp plugin module implements dependency-light auth state inspection.
+import { getChildLogger } from "openclaw/plugin-sdk/logging-core";
+import { resolveUserPath } from "openclaw/plugin-sdk/text-utility-runtime";
+import { readWebCredsJsonRaw, resolveWebCredsPath } from "./creds-files.js";
+import {
+  waitForCredsSaveQueueWithTimeout,
+  type CredsQueueWaitResult,
+} from "./creds-persistence.js";
+
+const authStateLogger = getChildLogger({ module: "web-auth-store" });
+
+export type WhatsAppWebAuthState = "linked" | "not-linked" | "unstable";
+
+export async function waitForWebAuthBarrier(
+  authDir: string,
+  context: string,
+): Promise<CredsQueueWaitResult> {
+  const result = await waitForCredsSaveQueueWithTimeout(authDir);
+  if (result === "timed_out") {
+    authStateLogger.warn(
+      {
+        authDir,
+        context,
+      },
+      "timed out waiting for queued WhatsApp creds save before auth read",
+    );
+  }
+  return result;
+}
+
+export async function webAuthExistsAt(authDir: string): Promise<boolean> {
+  const resolvedAuthDir = resolveUserPath(authDir);
+  const raw = await readWebCredsJsonRaw(resolveWebCredsPath(resolvedAuthDir));
+  if (!raw) {
+    return false;
+  }
+  try {
+    JSON.parse(raw);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function resolveWebAuthState(params: {
+  linked: boolean;
+  barrierResult: CredsQueueWaitResult;
+}): WhatsAppWebAuthState {
+  if (params.barrierResult === "timed_out") {
+    return "unstable";
+  }
+  return params.linked ? "linked" : "not-linked";
+}
+
+export async function readWebAuthStateDetails(
+  authDir: string,
+  context: string,
+): Promise<{ authDir: string; linked: boolean; state: WhatsAppWebAuthState }> {
+  const resolvedAuthDir = resolveUserPath(authDir);
+  const barrierResult = await waitForWebAuthBarrier(resolvedAuthDir, context);
+  const linked = await webAuthExistsAt(resolvedAuthDir);
+  return {
+    authDir: resolvedAuthDir,
+    linked,
+    state: resolveWebAuthState({ linked, barrierResult }),
+  };
+}
+
+export function formatWhatsAppWebAuthStatusState(state: WhatsAppWebAuthState): string {
+  switch (state) {
+    case "linked":
+      return "linked";
+    case "not-linked":
+      return "not linked";
+    case "unstable":
+      return "auth stabilizing";
+  }
+  const exhaustive: never = state;
+  return exhaustive;
+}
+
+export async function readWebAuthState(authDir: string): Promise<WhatsAppWebAuthState> {
+  return (await readWebAuthStateDetails(authDir, "readWebAuthState")).state;
+}

--- a/extensions/whatsapp/src/auth-store.ts
+++ b/extensions/whatsapp/src/auth-store.ts
@@ -6,6 +6,12 @@ import { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk/routing";
 import { info, success } from "openclaw/plugin-sdk/runtime-env";
 import { getChildLogger } from "openclaw/plugin-sdk/runtime-env";
 import { defaultRuntime, type RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
+import {
+  readWebAuthStateDetails,
+  waitForWebAuthBarrier,
+  webAuthExistsAt,
+  type WhatsAppWebAuthState,
+} from "./auth-state.js";
 import { resolveOAuthDir } from "./auth-store.runtime.js";
 import {
   assertWebCredsPathRegularFileOrMissing,
@@ -16,20 +22,15 @@ import {
   resolveWebCredsPath,
   statWebCredsFileSync,
 } from "./creds-files.js";
-import {
-  waitForCredsSaveQueueWithTimeout,
-  writeWebCredsRawAtomically,
-  type CredsQueueWaitResult,
-} from "./creds-persistence.js";
+import { writeWebCredsRawAtomically } from "./creds-persistence.js";
 import { resolveComparableIdentity, type WhatsAppSelfIdentity } from "./identity.js";
 import { resolveUserPath, type WebChannel } from "./text-runtime.js";
 export { hasWebCredsSync, resolveWebCredsBackupPath, resolveWebCredsPath };
+export { formatWhatsAppWebAuthStatusState, type WhatsAppWebAuthState } from "./auth-state.js";
 
 export const WHATSAPP_AUTH_UNSTABLE_CODE = "whatsapp-auth-unstable";
 
-const authStoreLogger = getChildLogger({ module: "web-auth-store" });
 const emptyWebSelfId = () => ({ e164: null, jid: null, lid: null }) as const;
-export type WhatsAppWebAuthState = "linked" | "not-linked" | "unstable";
 
 export class WhatsAppAuthUnstableError extends Error {
   readonly code = WHATSAPP_AUTH_UNSTABLE_CODE;
@@ -48,23 +49,6 @@ export const WA_WEB_AUTH_DIR = resolveDefaultWebAuthDir();
 
 export function readCredsJsonRaw(filePath: string): string | null {
   return readWebCredsJsonRawSync(filePath);
-}
-
-async function waitForWebAuthBarrier(
-  authDir: string,
-  context: string,
-): Promise<CredsQueueWaitResult> {
-  const result = await waitForCredsSaveQueueWithTimeout(authDir);
-  if (result === "timed_out") {
-    authStoreLogger.warn(
-      {
-        authDir,
-        context,
-      },
-      "timed out waiting for queued WhatsApp creds save before auth read",
-    );
-  }
-  return result;
 }
 
 function isValidJson(raw: string): boolean {
@@ -128,65 +112,17 @@ export async function restoreCredsFromBackupIfNeeded(
 }
 
 export async function webAuthExists(authDir: string = resolveDefaultWebAuthDir()) {
-  const resolvedAuthDir = resolveUserPath(authDir);
-  const credsPath = resolveWebCredsPath(resolvedAuthDir);
-  const raw = await readWebCredsJsonRaw(credsPath);
-  if (!raw) {
-    return false;
-  }
-  try {
-    JSON.parse(raw);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-function resolveWebAuthState(params: {
-  linked: boolean;
-  barrierResult: CredsQueueWaitResult;
-}): WhatsAppWebAuthState {
-  if (params.barrierResult === "timed_out") {
-    return "unstable";
-  }
-  return params.linked ? "linked" : "not-linked";
-}
-
-async function readWebAuthStateCore(
-  authDir: string,
-  context: string,
-): Promise<{ authDir: string; linked: boolean; state: WhatsAppWebAuthState }> {
-  const resolvedAuthDir = resolveUserPath(authDir);
-  const barrierResult = await waitForWebAuthBarrier(resolvedAuthDir, context);
-  const linked = await webAuthExists(resolvedAuthDir);
-  return {
-    authDir: resolvedAuthDir,
-    linked,
-    state: resolveWebAuthState({ linked, barrierResult }),
-  };
-}
-
-export function formatWhatsAppWebAuthStatusState(state: WhatsAppWebAuthState): string {
-  switch (state) {
-    case "linked":
-      return "linked";
-    case "not-linked":
-      return "not linked";
-    case "unstable":
-      return "auth stabilizing";
-  }
-  const exhaustive: never = state;
-  return exhaustive;
+  return await webAuthExistsAt(authDir);
 }
 
 export async function readWebAuthState(
   authDir: string = resolveDefaultWebAuthDir(),
 ): Promise<WhatsAppWebAuthState> {
-  return (await readWebAuthStateCore(authDir, "readWebAuthState")).state;
+  return (await readWebAuthStateDetails(authDir, "readWebAuthState")).state;
 }
 
 export async function readWebAuthSnapshot(authDir: string = resolveDefaultWebAuthDir()) {
-  const auth = await readWebAuthStateCore(authDir, "readWebAuthSnapshot");
+  const auth = await readWebAuthStateDetails(authDir, "readWebAuthSnapshot");
   return {
     state: auth.state,
     authAgeMs: auth.state === "linked" ? getWebAuthAgeMs(auth.authDir) : null,

--- a/extensions/whatsapp/src/channel-outbound.test.ts
+++ b/extensions/whatsapp/src/channel-outbound.test.ts
@@ -456,7 +456,7 @@ describe("whatsappChannelOutbound", () => {
       gifPlayback: undefined,
       quotedMessageKey: {
         id: "reply-live-1",
-        remoteJid: "5511999999999@c.us",
+        remoteJid: "5511999999999@s.whatsapp.net",
         fromMe: false,
         participant: "5511999999999@s.whatsapp.net",
         messageText: "original live body",
@@ -497,7 +497,7 @@ describe("whatsappChannelOutbound", () => {
       forceDocument: undefined,
       quotedMessageKey: {
         id: "reply-media-1",
-        remoteJid: "5511999999999@c.us",
+        remoteJid: "5511999999999@s.whatsapp.net",
         fromMe: false,
         participant: "5511999999999@s.whatsapp.net",
         messageText: "original media body",

--- a/extensions/whatsapp/src/channel-outbound.ts
+++ b/extensions/whatsapp/src/channel-outbound.ts
@@ -67,8 +67,8 @@ export const whatsappChannelOutbound = {
       }),
     sendPollWhatsApp,
     shouldLogVerbose: () => getWhatsAppRuntime().logging.shouldLogVerbose(),
-    resolveTarget: ({ to, allowFrom, mode }) =>
-      resolveWhatsAppOutboundTarget({ to, allowFrom, mode }),
+    resolveTarget: ({ to, allowFrom, mode, cfg, accountId }) =>
+      resolveWhatsAppOutboundTarget({ to, allowFrom, mode, cfg, accountId }),
     normalizeText: normalizeWhatsAppChannelSendText,
   }),
   sendTextOnlyErrorPayloads: true,

--- a/extensions/whatsapp/src/channel.setup.test.ts
+++ b/extensions/whatsapp/src/channel.setup.test.ts
@@ -106,8 +106,15 @@ vi.mock("./auth-store.js", async () => {
   const actual = await vi.importActual<typeof import("./auth-store.js")>("./auth-store.js");
   return {
     ...actual,
-    readWebAuthState: hoisted.readWebAuthState,
     readWebAuthExistsForDecision: hoisted.readWebAuthExistsForDecision,
+  };
+});
+
+vi.mock("./auth-state.js", async () => {
+  const actual = await vi.importActual<typeof import("./auth-state.js")>("./auth-state.js");
+  return {
+    ...actual,
+    readWebAuthState: hoisted.readWebAuthState,
   };
 });
 

--- a/extensions/whatsapp/src/channel.setup.ts
+++ b/extensions/whatsapp/src/channel.setup.ts
@@ -1,7 +1,8 @@
 // Whatsapp plugin module implements channel.setup behavior.
 import type { ChannelPlugin } from "openclaw/plugin-sdk/core";
 import type { ResolvedWhatsAppAccount } from "./accounts.js";
-import { isWhatsAppAuthConfigured } from "./channel-runtime-loader.js";
+import { formatWhatsAppConfigAllowFromEntries } from "./allowlist-format.js";
+import { readWebAuthState } from "./auth-state.js";
 import {
   resolveWhatsAppGroupRequireMention,
   resolveWhatsAppGroupToolPolicy,
@@ -9,6 +10,10 @@ import {
 import { whatsappSetupAdapter } from "./setup-core.js";
 import { createWhatsAppPluginBase, whatsappSetupWizardProxy } from "./shared.js";
 import { detectWhatsAppLegacyStateMigrations } from "./state-migrations.js";
+
+async function isWhatsAppAuthConfigured(account: ResolvedWhatsAppAccount): Promise<boolean> {
+  return (await readWebAuthState(account.authDir)) === "linked";
+}
 
 export const whatsappSetupPlugin: ChannelPlugin<ResolvedWhatsAppAccount> = {
   ...createWhatsAppPluginBase({
@@ -18,7 +23,8 @@ export const whatsappSetupPlugin: ChannelPlugin<ResolvedWhatsAppAccount> = {
     },
     setupWizard: whatsappSetupWizardProxy,
     setup: whatsappSetupAdapter,
-    isConfigured: async (account) => await isWhatsAppAuthConfigured(account.authDir),
+    formatAllowFrom: formatWhatsAppConfigAllowFromEntries,
+    isConfigured: isWhatsAppAuthConfigured,
   }),
   lifecycle: {
     detectLegacyStateMigrations: ({ oauthDir }) =>

--- a/extensions/whatsapp/src/channel.ts
+++ b/extensions/whatsapp/src/channel.ts
@@ -9,6 +9,7 @@ import {
 } from "openclaw/plugin-sdk/status-helpers";
 import { resolveWhatsAppAccount, type ResolvedWhatsAppAccount } from "./accounts.js";
 import { createWhatsAppLoginTool } from "./agent-tools-login.js";
+import { formatWhatsAppConfigAllowFromEntries } from "./allowlist-format.js";
 import { whatsappApprovalCapability } from "./approval-native.js";
 import type { WebChannelStatus } from "./auto-reply/types.js";
 import {
@@ -18,7 +19,6 @@ import {
 import { whatsappChannelOutbound, whatsappMessageAdapter } from "./channel-outbound.js";
 import { isWhatsAppAuthConfigured, loadWhatsAppChannelRuntime } from "./channel-runtime-loader.js";
 import { whatsappCommandPolicy } from "./command-policy.js";
-import { formatWhatsAppConfigAllowFromEntries } from "./config-accessors.js";
 import { resolveWhatsAppMentionStripRegexes } from "./group-intro.js";
 import {
   resolveWhatsAppGroupRequireMention,
@@ -82,6 +82,7 @@ export const whatsappPlugin: ChannelPlugin<ResolvedWhatsAppAccount> =
         },
         setupWizard: whatsappSetupWizardProxy,
         setup: whatsappSetupAdapter,
+        formatAllowFrom: formatWhatsAppConfigAllowFromEntries,
         isConfigured: async (account) => await isWhatsAppAuthConfigured(account.authDir),
       }),
       agentTools: () => [createWhatsAppLoginTool()],

--- a/extensions/whatsapp/src/config-accessors.ts
+++ b/extensions/whatsapp/src/config-accessors.ts
@@ -1,17 +1,13 @@
 // Whatsapp helper module supports config accessors behavior.
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { resolveWhatsAppAccount } from "./accounts.js";
-import { normalizeWhatsAppAllowFromEntries } from "./normalize-target.js";
+export { formatWhatsAppConfigAllowFromEntries } from "./allowlist-format.js";
 
 export function resolveWhatsAppConfigAllowFrom(params: {
   cfg: OpenClawConfig;
   accountId?: string | null;
 }): string[] {
   return [...(resolveWhatsAppAccount(params).allowFrom ?? [])];
-}
-
-export function formatWhatsAppConfigAllowFromEntries(allowFrom: Array<string | number>): string[] {
-  return normalizeWhatsAppAllowFromEntries(allowFrom);
 }
 
 export function resolveWhatsAppConfigDefaultTo(params: {

--- a/extensions/whatsapp/src/doctor-contract.test.ts
+++ b/extensions/whatsapp/src/doctor-contract.test.ts
@@ -1,10 +1,17 @@
 // Whatsapp tests cover doctor contract plugin behavior.
+import fs from "node:fs/promises";
+import path from "node:path";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import { describe, expect, it } from "vitest";
+import { withStateDirEnv, withTempDir } from "openclaw/plugin-sdk/test-env";
+import { describe, expect, it, vi } from "vitest";
 import { legacyConfigRules, normalizeCompatibilityConfig } from "./doctor-contract.js";
 
 function whatsappConfig(entry: Record<string, unknown>): OpenClawConfig {
   return { channels: { whatsapp: entry } } as never;
+}
+
+async function writeLidMapping(dir: string, lid: string, phone: string | number): Promise<void> {
+  await fs.writeFile(path.join(dir, `lid-mapping-${lid}_reverse.json`), JSON.stringify(phone));
 }
 
 describe("whatsapp streaming legacy config rules", () => {
@@ -116,5 +123,260 @@ describe("whatsapp normalizeCompatibilityConfig streaming aliases", () => {
 
     const second = normalizeCompatibilityConfig({ cfg: first.config });
     expect(second.changes).toEqual([]);
+  });
+});
+
+describe("whatsapp allowlist LID upgrade", () => {
+  it("reports LID entries at channel and account scope", () => {
+    const rootRule = legacyConfigRules.find((rule) =>
+      rule.message.startsWith("WhatsApp allowFrom or groupAllowFrom contains LID JIDs"),
+    );
+    const accountsRule = legacyConfigRules.find((rule) =>
+      rule.message.startsWith("A WhatsApp account allowFrom or groupAllowFrom contains LID JIDs"),
+    );
+
+    expect(rootRule?.match?.({ allowFrom: ["whatsapp:777:2@hosted.lid"] }, {})).toBe(true);
+    expect(rootRule?.match?.({ groupAllowFrom: ["whatsapp:777:2@hosted.lid"] }, {})).toBe(true);
+    expect(rootRule?.match?.({ allowFrom: ["+15551230000"] }, {})).toBe(false);
+    expect(accountsRule?.match?.({ work: { allowFrom: ["888@lid"] } }, {})).toBe(true);
+    expect(accountsRule?.match?.({ work: { groupAllowFrom: ["888@lid"] } }, {})).toBe(true);
+  });
+
+  it("migrates only entries backed by a stored reverse mapping", async () => {
+    await withTempDir("openclaw-whatsapp-doctor-", async (authDir) => {
+      await writeLidMapping(authDir, "777", "15551230001");
+      await writeLidMapping(authDir, "888", 15551230002);
+      const result = normalizeCompatibilityConfig({
+        cfg: whatsappConfig({
+          authDir,
+          allowFrom: ["777:4@lid", "whatsapp:888@hosted.lid", "15551239999@lid", "+15551230003"],
+        }),
+      });
+
+      expect(result.config.channels?.whatsapp?.allowFrom).toEqual([
+        "15551230001",
+        "15551230002",
+        "15551239999@lid",
+        "+15551230003",
+      ]);
+      expect(result.changes).toHaveLength(2);
+      expect(result.warnings).toEqual([
+        expect.stringContaining(
+          'channels.whatsapp.allowFrom entry "15551239999@lid" was not migrated because no verified LID→PN mapping was found',
+        ),
+      ]);
+    });
+  });
+
+  it("uses the owning account auth directory", async () => {
+    await withTempDir("openclaw-whatsapp-doctor-account-", async (authDir) => {
+      await writeLidMapping(authDir, "999", "447700900123");
+      const result = normalizeCompatibilityConfig({
+        cfg: whatsappConfig({
+          accounts: {
+            work: {
+              authDir,
+              allowFrom: ["999:2@hosted.lid"],
+              groupAllowFrom: ["999:3@lid"],
+            },
+          },
+        }),
+      });
+
+      const accounts = result.config.channels?.whatsapp?.accounts as Record<
+        string,
+        { allowFrom?: string[]; groupAllowFrom?: string[] }
+      >;
+      expect(accounts.work?.allowFrom).toEqual(["447700900123"]);
+      expect(accounts.work?.groupAllowFrom).toEqual(["447700900123"]);
+      expect(result.warnings).toEqual([]);
+    });
+  });
+
+  it.each(["allowFrom", "groupAllowFrom"] as const)(
+    "requires every account inheriting accounts.default %s to verify the mapping",
+    async (key) => {
+      await withTempDir("openclaw-whatsapp-doctor-default-scope-", async (rootDir) => {
+        const defaultAuthDir = path.join(rootDir, "default");
+        const workAuthDir = path.join(rootDir, "work");
+        await fs.mkdir(defaultAuthDir);
+        await fs.mkdir(workAuthDir);
+        await writeLidMapping(defaultAuthDir, "456", "15550000456");
+        const cfg = whatsappConfig({
+          accounts: {
+            default: { authDir: defaultAuthDir, [key]: ["456@lid"] },
+            work: { authDir: workAuthDir },
+          },
+        });
+
+        const unresolved = normalizeCompatibilityConfig({ cfg });
+        const unresolvedAccounts = unresolved.config.channels?.whatsapp?.accounts as Record<
+          string,
+          Record<string, unknown>
+        >;
+        expect(unresolvedAccounts.default?.[key]).toEqual(["456@lid"]);
+        expect(unresolved.warnings).toEqual([
+          expect.stringContaining("no verified LID→PN mapping was found"),
+        ]);
+
+        await writeLidMapping(workAuthDir, "456", "15550000456");
+        const migrated = normalizeCompatibilityConfig({ cfg });
+        const migratedAccounts = migrated.config.channels?.whatsapp?.accounts as Record<
+          string,
+          Record<string, unknown>
+        >;
+        expect(migratedAccounts.default?.[key]).toEqual(["15550000456"]);
+        expect(migrated.warnings).toEqual([]);
+      });
+    },
+  );
+
+  it("excludes a named account's own allowlist from default-account mapping scopes", async () => {
+    await withTempDir("openclaw-whatsapp-doctor-default-override-", async (rootDir) => {
+      const defaultAuthDir = path.join(rootDir, "default");
+      const workAuthDir = path.join(rootDir, "work");
+      await fs.mkdir(defaultAuthDir);
+      await fs.mkdir(workAuthDir);
+      await writeLidMapping(defaultAuthDir, "654", "15550000654");
+      const result = normalizeCompatibilityConfig({
+        cfg: whatsappConfig({
+          accounts: {
+            default: { authDir: defaultAuthDir, allowFrom: ["654@lid"] },
+            work: { authDir: workAuthDir, allowFrom: ["+15550000999"] },
+          },
+        }),
+      });
+
+      const accounts = result.config.channels?.whatsapp?.accounts as Record<
+        string,
+        { allowFrom?: string[] }
+      >;
+      expect(accounts.default?.allowFrom).toEqual(["15550000654"]);
+      expect(result.warnings).toEqual([]);
+    });
+  });
+
+  it("does not migrate a named account from the legacy shared mapping directory", async () => {
+    await withStateDirEnv("openclaw-whatsapp-doctor-shared-", async ({ stateDir }) => {
+      const credentialsDir = path.join(stateDir, "credentials");
+      const accountAuthDir = path.join(stateDir, "work-auth");
+      await fs.mkdir(credentialsDir, { recursive: true });
+      await fs.mkdir(accountAuthDir);
+      await writeLidMapping(credentialsDir, "321", "15550000321");
+      vi.resetModules();
+      try {
+        const { normalizeCompatibilityConfig: normalizeFreshConfig } =
+          await import("./doctor-contract.js");
+        const result = normalizeFreshConfig({
+          cfg: whatsappConfig({
+            accounts: {
+              work: {
+                authDir: accountAuthDir,
+                allowFrom: ["321@lid"],
+              },
+            },
+          }),
+        });
+
+        const accounts = result.config.channels?.whatsapp?.accounts as Record<
+          string,
+          { allowFrom?: string[] }
+        >;
+        expect(accounts.work?.allowFrom).toEqual(["321@lid"]);
+        expect(result.changes).toEqual([]);
+        expect(result.warnings).toEqual([
+          expect.stringContaining("no verified LID→PN mapping was found"),
+        ]);
+      } finally {
+        vi.resetModules();
+      }
+    });
+  });
+
+  it.each(["allowFrom", "groupAllowFrom"] as const)(
+    "requires a root mapping in every account that inherits root %s",
+    async (key) => {
+      await withTempDir("openclaw-whatsapp-doctor-root-scope-", async (rootDir) => {
+        const otherKey = key === "allowFrom" ? "groupAllowFrom" : "allowFrom";
+        const firstAuthDir = path.join(rootDir, "first");
+        const secondAuthDir = path.join(rootDir, "second");
+        await fs.mkdir(firstAuthDir);
+        await fs.mkdir(secondAuthDir);
+        await writeLidMapping(firstAuthDir, "456", "15550000456");
+        const result = normalizeCompatibilityConfig({
+          cfg: whatsappConfig({
+            [key]: ["456@lid"],
+            accounts: {
+              first: { authDir: firstAuthDir },
+              second: { authDir: secondAuthDir, [otherKey]: ["+15550000999"] },
+            },
+          }),
+        });
+
+        const whatsapp = result.config.channels?.whatsapp as Record<string, unknown> | undefined;
+        expect(whatsapp?.[key]).toEqual(["456@lid"]);
+        expect(result.changes).toEqual([]);
+        expect(result.warnings).toEqual([
+          expect.stringContaining(
+            `channels.whatsapp.${key} entry "456@lid" was not migrated because no verified LID→PN mapping was found`,
+          ),
+        ]);
+      });
+    },
+  );
+
+  it.each(["allowFrom", "groupAllowFrom"] as const)(
+    "does not require root %s mappings from accounts with their own override",
+    async (key) => {
+      await withTempDir("openclaw-whatsapp-doctor-root-override-", async (rootDir) => {
+        const inheritedAuthDir = path.join(rootDir, "inherited");
+        const overridingAuthDir = path.join(rootDir, "overriding");
+        await fs.mkdir(inheritedAuthDir);
+        await fs.mkdir(overridingAuthDir);
+        await writeLidMapping(inheritedAuthDir, "654", "15550000654");
+        const result = normalizeCompatibilityConfig({
+          cfg: whatsappConfig({
+            [key]: ["654@lid"],
+            accounts: {
+              inherited: { authDir: inheritedAuthDir },
+              overriding: {
+                authDir: overridingAuthDir,
+                [key]: ["+15550000999"],
+              },
+            },
+          }),
+        });
+
+        const whatsapp = result.config.channels?.whatsapp as Record<string, unknown> | undefined;
+        expect(whatsapp?.[key]).toEqual(["15550000654"]);
+        expect(result.warnings).toEqual([]);
+      });
+    },
+  );
+
+  it("leaves an entry unchanged when stored mappings conflict", async () => {
+    await withTempDir("openclaw-whatsapp-doctor-conflict-", async (rootDir) => {
+      const firstAuthDir = path.join(rootDir, "first");
+      const secondAuthDir = path.join(rootDir, "second");
+      await fs.mkdir(firstAuthDir);
+      await fs.mkdir(secondAuthDir);
+      await writeLidMapping(firstAuthDir, "123", "15550000001");
+      await writeLidMapping(secondAuthDir, "123", "15550000002");
+      const result = normalizeCompatibilityConfig({
+        cfg: whatsappConfig({
+          allowFrom: ["123@lid"],
+          accounts: {
+            first: { authDir: firstAuthDir },
+            second: { authDir: secondAuthDir },
+          },
+        }),
+      });
+
+      expect(result.config.channels?.whatsapp?.allowFrom).toEqual(["123@lid"]);
+      expect(result.changes).toEqual([]);
+      expect(result.warnings).toEqual([
+        expect.stringContaining("conflicting LID→PN mappings were found"),
+      ]);
+    });
   });
 });

--- a/extensions/whatsapp/src/doctor-contract.ts
+++ b/extensions/whatsapp/src/doctor-contract.ts
@@ -7,6 +7,10 @@ import type {
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { mergeDeep } from "openclaw/plugin-sdk/plugin-config-runtime";
 import { asObjectRecord, defineChannelAliasMigration } from "openclaw/plugin-sdk/runtime-doctor";
+import {
+  migrateWhatsAppLidAllowlistsConfig,
+  whatsAppLidAllowlistLegacyRules,
+} from "./allowlist-doctor.js";
 import { normalizeCompatibilityConfig as normalizeAckReactionConfig } from "./doctor.js";
 
 // WhatsApp's nested streaming schema is delivery-only ({chunkMode, block});
@@ -25,6 +29,7 @@ const hasExposeErrorText = (value: unknown): boolean =>
 
 export const legacyConfigRules: ChannelDoctorLegacyConfigRule[] = [
   ...streamingAliasMigration.legacyConfigRules,
+  ...whatsAppLidAllowlistLegacyRules,
   {
     path: ["channels", "whatsapp", "exposeErrorText"],
     message:
@@ -159,12 +164,15 @@ export function normalizeCompatibilityConfig({
     cfg: retiredConfig,
     changes: ackReaction.changes,
   });
-  return {
-    config: materializeMigratedAccountStreaming({
-      cfg: aliases.config,
-      accountsBefore,
-      changes: aliases.changes,
-    }),
+  const materialized = materializeMigratedAccountStreaming({
+    cfg: aliases.config,
+    accountsBefore,
     changes: aliases.changes,
+  });
+  const lidAllowlists = migrateWhatsAppLidAllowlistsConfig(materialized);
+  return {
+    config: lidAllowlists.config,
+    changes: [...aliases.changes, ...lidAllowlists.changes],
+    warnings: lidAllowlists.warnings,
   };
 }

--- a/extensions/whatsapp/src/group-session-contract.test.ts
+++ b/extensions/whatsapp/src/group-session-contract.test.ts
@@ -1,0 +1,21 @@
+// Whatsapp tests cover group session contract plugin behavior.
+import { describe, expect, it } from "vitest";
+import { resolveLegacyGroupSessionKey } from "./group-session-contract.js";
+
+describe("whatsapp group session contract", () => {
+  it("returns the canonical group JID", () => {
+    expect(resolveLegacyGroupSessionKey({ From: " 120363000000000000@G.US " })).toEqual({
+      key: "whatsapp:group:120363000000000000@g.us",
+      channel: "whatsapp",
+      id: "120363000000000000@g.us",
+      chatType: "group",
+    });
+  });
+
+  it.each(["120363000000000000:2@g.us", "120363000000000000@g.us@evil.example"])(
+    "rejects malformed group JID %s",
+    (from) => {
+      expect(resolveLegacyGroupSessionKey({ From: from })).toBeNull();
+    },
+  );
+});

--- a/extensions/whatsapp/src/group-session-contract.ts
+++ b/extensions/whatsapp/src/group-session-contract.ts
@@ -1,5 +1,5 @@
 // Whatsapp plugin module implements group session contract behavior.
-import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { canonicalizeWhatsAppGroupJid } from "./whatsapp-jid-syntax.js";
 
 export function resolveLegacyGroupSessionKey(ctx: { From?: string }): {
   key: string;
@@ -7,15 +7,14 @@ export function resolveLegacyGroupSessionKey(ctx: { From?: string }): {
   id: string;
   chatType: "group";
 } | null {
-  const from = typeof ctx.From === "string" ? ctx.From.trim() : "";
-  const normalized = normalizeLowercaseStringOrEmpty(from);
-  if (!from || from.includes(":") || !normalized.endsWith("@g.us")) {
+  const groupJid = canonicalizeWhatsAppGroupJid(ctx.From);
+  if (!groupJid) {
     return null;
   }
   return {
-    key: `whatsapp:group:${normalized}`,
+    key: `whatsapp:group:${groupJid}`,
     channel: "whatsapp",
-    id: normalized,
+    id: groupJid,
     chatType: "group",
   };
 }

--- a/extensions/whatsapp/src/identity.test.ts
+++ b/extensions/whatsapp/src/identity.test.ts
@@ -1,0 +1,117 @@
+// Whatsapp tests cover comparable identity JID semantics.
+import { describe, expect, it } from "vitest";
+import {
+  identitiesOverlap,
+  prepareWhatsAppDirectInboundActor,
+  resolveComparableIdentity,
+} from "./identity.js";
+
+describe("resolveComparableIdentity", () => {
+  it("canonicalizes PN and LID identities through the shared JID contract", () => {
+    expect(resolveComparableIdentity({ jid: "15551230000:2@c.us" })).toMatchObject({
+      jid: "15551230000@s.whatsapp.net",
+      lid: null,
+      e164: "+15551230000",
+    });
+    expect(resolveComparableIdentity({ jid: "277038292303944:3@hosted.lid" })).toMatchObject({
+      jid: null,
+      lid: "277038292303944@hosted.lid",
+      e164: null,
+    });
+  });
+
+  it("does not overlap same-digit PN and LID identities without a mapping", () => {
+    expect(
+      identitiesOverlap({ jid: "812345678901234@s.whatsapp.net" }, { jid: "812345678901234@lid" }),
+    ).toBe(false);
+  });
+
+  it("overlaps hosted and standard forms of the same identity class", () => {
+    expect(
+      identitiesOverlap({ jid: "15551230000@hosted" }, { jid: "15551230000@s.whatsapp.net" }),
+    ).toBe(true);
+    expect(
+      identitiesOverlap({ lid: "277038292303944@hosted.lid" }, { lid: "277038292303944@lid" }),
+    ).toBe(true);
+  });
+
+  it("rejects malformed direct identities instead of partially normalizing them", () => {
+    expect(resolveComparableIdentity({ jid: "15551230000:bad@s.whatsapp.net" })).toMatchObject({
+      jid: null,
+      lid: null,
+      e164: null,
+    });
+  });
+});
+
+describe("prepareWhatsAppDirectInboundActor", () => {
+  const self = {
+    jid: "15550000000@s.whatsapp.net",
+    lid: "800000000000000@lid",
+    e164: "+15550000000",
+  };
+
+  it("treats alternate JIDs as forms of the sender for incoming messages", () => {
+    expect(
+      prepareWhatsAppDirectInboundActor({
+        remoteJid: "812345678901234:2@lid",
+        remoteJidAlt: "15551234567:3@s.whatsapp.net",
+        fromMe: false,
+        self,
+      }),
+    ).toEqual({
+      transportJid: "812345678901234:2@lid",
+      e164: "+15551234567",
+      comparableJids: ["812345678901234@lid", "15551234567@s.whatsapp.net"],
+    });
+  });
+
+  it("keeps an outgoing peer recipient separate from the sender alternate", () => {
+    expect(
+      prepareWhatsAppDirectInboundActor({
+        remoteJid: "812345678901234:2@lid",
+        remoteJidAlt: "15550000000:3@s.whatsapp.net",
+        fromMe: true,
+        self,
+      }),
+    ).toEqual({
+      transportJid: "812345678901234:2@lid",
+      e164: null,
+      comparableJids: ["812345678901234@lid"],
+    });
+  });
+
+  it("recognizes a self-chat from the recipient identity without using the sender alternate", () => {
+    expect(
+      prepareWhatsAppDirectInboundActor({
+        remoteJid: "800000000000000:2@lid",
+        remoteJidAlt: "15550000000:3@s.whatsapp.net",
+        fromMe: true,
+        self,
+      }),
+    ).toEqual({
+      transportJid: "800000000000000:2@lid",
+      e164: "+15550000000",
+      comparableJids: ["800000000000000@lid", "15550000000@s.whatsapp.net"],
+    });
+  });
+
+  it("recognizes hosted and standard LID forms as the same self-chat actor", () => {
+    expect(
+      prepareWhatsAppDirectInboundActor({
+        remoteJid: "800000000000000:2@hosted.lid",
+        remoteJidAlt: "15550000000:3@s.whatsapp.net",
+        fromMe: true,
+        self,
+      }),
+    ).toEqual({
+      transportJid: "800000000000000:2@hosted.lid",
+      e164: "+15550000000",
+      comparableJids: [
+        "800000000000000@hosted.lid",
+        "15550000000@s.whatsapp.net",
+        "800000000000000@lid",
+      ],
+    });
+  });
+});

--- a/extensions/whatsapp/src/identity.ts
+++ b/extensions/whatsapp/src/identity.ts
@@ -1,7 +1,10 @@
 // Whatsapp plugin module implements identity behavior.
 import { jidToE164, normalizeE164 } from "./text-runtime.js";
-
-const WHATSAPP_LID_RE = /@(lid|hosted\.lid)$/i;
+import {
+  areSameWhatsAppJid,
+  canonicalizeWhatsAppDirectJids,
+  classifyWhatsAppDirectJid,
+} from "./whatsapp-jid.js";
 
 export type WhatsAppIdentity = {
   jid?: string | null;
@@ -15,6 +18,11 @@ export type WhatsAppSelfIdentity = {
   jid?: string | null;
   lid?: string | null;
   e164?: string | null;
+};
+
+export type PreparedWhatsAppInboundActor = {
+  transportJid: string;
+  e164: string | null;
 };
 
 export type WhatsAppReplyContext = {
@@ -62,22 +70,15 @@ type LegacyMentionsLike = {
   };
 };
 
-function normalizeDeviceScopedJid(jid: string | null | undefined): string | null {
-  return jid ? jid.replace(/:\d+/, "") : null;
-}
-
-function isLidJid(jid: string | null | undefined): boolean {
-  return Boolean(jid && WHATSAPP_LID_RE.test(jid));
-}
-
 export function resolveComparableIdentity(
   identity: WhatsAppIdentity | WhatsAppSelfIdentity | null | undefined,
   authDir?: string,
 ): WhatsAppIdentity {
-  const rawJid = normalizeDeviceScopedJid(identity?.jid);
-  const rawLid = normalizeDeviceScopedJid(identity?.lid);
-  const lid = rawLid ?? (isLidJid(rawJid) ? rawJid : null);
-  const jid = rawJid && !isLidJid(rawJid) ? rawJid : null;
+  const rawJid = classifyWhatsAppDirectJid(identity?.jid);
+  const rawLid = classifyWhatsAppDirectJid(identity?.lid);
+  const lid =
+    (rawLid?.kind === "lid" ? rawLid.jid : null) ?? (rawJid?.kind === "lid" ? rawJid.jid : null);
+  const jid = rawJid?.kind === "pn" ? rawJid.jid : null;
   const e164 =
     identity?.e164 != null
       ? normalizeE164(identity.e164)
@@ -88,6 +89,82 @@ export function resolveComparableIdentity(
     jid,
     lid,
     e164,
+  };
+}
+
+export function prepareWhatsAppInboundActor(params: {
+  primaryJid: string | null | undefined;
+  alternateJid?: string | null;
+}): PreparedWhatsAppInboundActor | null {
+  const transportJid = params.primaryJid?.trim();
+  if (!transportJid) {
+    return null;
+  }
+  const primary = classifyWhatsAppDirectJid(transportJid);
+  if (!primary) {
+    return null;
+  }
+  const alternate = classifyWhatsAppDirectJid(params.alternateJid);
+  // Baileys has already observed this PN/LID pair on the inbound envelope.
+  // Keep the primary transport identity while carrying its PN fact forward.
+  const phone = primary.kind === "pn" ? primary : alternate?.kind === "pn" ? alternate : null;
+  return {
+    transportJid,
+    e164: phone ? `+${phone.user}` : null,
+  };
+}
+
+function isObservedSelfDirectJid(
+  directJid: NonNullable<ReturnType<typeof classifyWhatsAppDirectJid>>,
+  self: WhatsAppSelfIdentity,
+): boolean {
+  if (
+    canonicalizeWhatsAppDirectJids([self.jid, self.lid]).some((jid) =>
+      areSameWhatsAppJid(directJid.jid, jid),
+    )
+  ) {
+    return true;
+  }
+  return (
+    directJid.kind === "pn" &&
+    self.e164 != null &&
+    normalizeE164(self.e164) === `+${directJid.user}`
+  );
+}
+
+export function prepareWhatsAppDirectInboundActor(params: {
+  remoteJid: string | null | undefined;
+  remoteJidAlt?: string | null;
+  fromMe: boolean;
+  self: WhatsAppSelfIdentity;
+}): (PreparedWhatsAppInboundActor & { comparableJids: string[] }) | null {
+  // For incoming DMs Baileys reports two forms of the sender. For outgoing DMs,
+  // remoteJid is the recipient while remoteJidAlt is the sender; pairing those
+  // identities can make an outbound peer look like the linked account.
+  const actor = prepareWhatsAppInboundActor({
+    primaryJid: params.remoteJid,
+    alternateJid: params.fromMe ? null : params.remoteJidAlt,
+  });
+  if (!actor) {
+    return null;
+  }
+  if (!params.fromMe) {
+    return {
+      ...actor,
+      comparableJids: canonicalizeWhatsAppDirectJids([params.remoteJid, params.remoteJidAlt]),
+    };
+  }
+
+  const primary = classifyWhatsAppDirectJid(params.remoteJid);
+  const isSelfChat = primary ? isObservedSelfDirectJid(primary, params.self) : false;
+  const selfE164 = params.self.e164 != null ? normalizeE164(params.self.e164) : null;
+  return {
+    ...actor,
+    e164: actor.e164 ?? (isSelfChat ? selfE164 : null),
+    comparableJids: canonicalizeWhatsAppDirectJids([
+      params.remoteJid,
+      ...(isSelfChat ? [params.self.jid, params.self.lid] : []),
+    ]),
   };
 }
 
@@ -104,11 +181,15 @@ export function identitiesOverlap(
   left: WhatsAppIdentity | WhatsAppSelfIdentity | null | undefined,
   right: WhatsAppIdentity | WhatsAppSelfIdentity | null | undefined,
 ): boolean {
-  const leftValues = new Set(getComparableIdentityValues(left));
-  if (leftValues.size === 0) {
+  const leftValues = getComparableIdentityValues(left);
+  if (leftValues.length === 0) {
     return false;
   }
-  return getComparableIdentityValues(right).some((value) => leftValues.has(value));
+  return getComparableIdentityValues(right).some((rightValue) =>
+    leftValues.some(
+      (leftValue) => leftValue === rightValue || areSameWhatsAppJid(leftValue, rightValue),
+    ),
+  );
 }
 
 export function getSenderIdentity(msg: LegacySenderLike, authDir?: string): WhatsAppIdentity {

--- a/extensions/whatsapp/src/inbound-policy.ts
+++ b/extensions/whatsapp/src/inbound-policy.ts
@@ -16,8 +16,9 @@ import { getSelfIdentity, getSenderIdentity } from "./identity.js";
 import { requireWhatsAppInboundAdmission } from "./inbound/admission.js";
 import { resolveWhatsAppGroupConversationId } from "./inbound/group-conversation.js";
 import type { AdmittedWebInboundMessage } from "./inbound/types.js";
+import { normalizeWhatsAppDirectPhone } from "./normalize-target.js";
 import { resolveWhatsAppRuntimeGroupPolicy } from "./runtime-group-policy.js";
-import { isSelfChatMode, normalizeE164 } from "./text-runtime.js";
+import { isSelfChatMode } from "./text-runtime.js";
 
 type ResolvedWhatsAppInboundPolicy = {
   account: ResolvedWhatsAppAccount;
@@ -32,14 +33,6 @@ type ResolvedWhatsAppInboundPolicy = {
   resolveConversationGroupPolicy: (conversationId: string) => ChannelGroupPolicy;
   resolveConversationRequireMention: (conversationId: string) => boolean;
 };
-
-function normalizeWhatsAppIngressPhone(value: string): string | null {
-  const trimmed = value.trim();
-  if (!trimmed) {
-    return null;
-  }
-  return normalizeE164(trimmed);
-}
 
 function maybeSamePhoneDmAllowFrom(params: {
   isGroup: boolean;
@@ -146,7 +139,7 @@ export async function resolveWhatsAppIngressAccess(params: {
     identity: {
       key: "whatsapp-sender-phone",
       kind: "phone",
-      normalize: normalizeWhatsAppIngressPhone,
+      normalize: normalizeWhatsAppDirectPhone,
       sensitivity: "pii",
       entryIdPrefix: "whatsapp-entry",
     },
@@ -193,7 +186,7 @@ export async function resolveWhatsAppCommandAuthorized(params: {
   const sender = getSenderIdentity(params.msg, params.authDir);
   const dmSender = sender.e164 ?? admission.conversation.id;
   const groupSender = sender.e164 ?? "";
-  if (!normalizeE164(isGroup ? groupSender : dmSender)) {
+  if (!normalizeWhatsAppDirectPhone(isGroup ? groupSender : dmSender)) {
     return false;
   }
 

--- a/extensions/whatsapp/src/inbound/access-control.test.ts
+++ b/extensions/whatsapp/src/inbound/access-control.test.ts
@@ -302,6 +302,59 @@ describe("checkInboundAccessControl admission contract", () => {
     expect(result.allowed).toBe(false);
     expect("admission" in result).toBe(false);
   });
+
+  it.each(["15550001111@lid", "15550001111@hosted.lid"])(
+    "does not authorize a PN sender from same-digit LID allowFrom entry %s",
+    async (lidEntry) => {
+      const cfg = {
+        channels: {
+          whatsapp: {
+            dmPolicy: "allowlist",
+            accounts: { work: { allowFrom: [lidEntry] } },
+          },
+        },
+      };
+      setAccessControlTestConfig(cfg);
+
+      const result = await checkUnauthorizedWorkDmSender();
+      const commandAuthorized = await checkCommandAuthorizedForDm({ cfg });
+
+      expectSilentlyBlocked(result);
+      expect(commandAuthorized).toBe(false);
+    },
+  );
+
+  it.each(["15550001111@lid", "15550001111@hosted.lid"])(
+    "does not authorize a group PN sender from same-digit LID allowlist entry %s",
+    async (lidEntry) => {
+      const cfg = {
+        channels: {
+          whatsapp: {
+            groupPolicy: "allowlist",
+            groupAllowFrom: [lidEntry],
+          },
+        },
+      };
+      setAccessControlTestConfig(cfg);
+
+      const result = await checkInboundAccessControl({
+        cfg: getAccessControlTestConfig() as never,
+        accountId: "work",
+        from: "120363401234567890@g.us",
+        selfE164: "+15550009999",
+        senderE164: "+15550001111",
+        group: true,
+        pushName: "Sam",
+        isFromMe: false,
+        sock: { sendMessage: sendMessageMock },
+        remoteJid: "120363401234567890@g.us",
+      });
+      const commandAuthorized = await checkCommandAuthorizedForGroup({ cfg });
+
+      expectSilentlyBlocked(result);
+      expect(commandAuthorized).toBe(false);
+    },
+  );
 });
 
 describe("checkInboundAccessControl pairing grace", () => {

--- a/extensions/whatsapp/src/inbound/monitor.ts
+++ b/extensions/whatsapp/src/inbound/monitor.ts
@@ -26,7 +26,14 @@ import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
 import { maybeResolveWhatsAppApprovalReaction } from "../approval-reactions.js";
 import { readWebSelfIdentityForDecision, WhatsAppAuthUnstableError } from "../auth-store.js";
 import { getWhatsAppConnectionController } from "../connection-controller-runtime-context.js";
-import { getPrimaryIdentityId, identitiesOverlap, resolveComparableIdentity } from "../identity.js";
+import {
+  getPrimaryIdentityId,
+  identitiesOverlap,
+  prepareWhatsAppDirectInboundActor,
+  prepareWhatsAppInboundActor,
+  resolveComparableIdentity,
+  type PreparedWhatsAppInboundActor,
+} from "../identity.js";
 import { addWhatsAppImagePreviewFields } from "../image-preview.js";
 import { maybeResolveWhatsAppQuestionReaction } from "../question-reactions.js";
 import { cacheInboundMessageMeta } from "../quoted-message.js";
@@ -39,7 +46,6 @@ import {
   resolveWhatsAppSocketOperationTimeoutMs,
   resolveWhatsAppSocketTiming,
   withWhatsAppSocketOperationTimeout,
-  type WhatsAppSocketOperationAdapter,
   type WhatsAppSocketTimingOptions,
 } from "../socket-timing.js";
 import {
@@ -48,6 +54,7 @@ import {
   toWhatsappJid,
   toWhatsappJidWithLid,
 } from "../text-runtime.js";
+import { classifyWhatsAppDirectJid, classifyWhatsAppJid } from "../whatsapp-jid.js";
 import {
   checkInboundAccessControl,
   type AcceptedInboundAccessControlResult,
@@ -56,7 +63,7 @@ import {
   requireAdmittedWhatsAppInboundMessage,
   requireWhatsAppInboundAdmission,
 } from "./admission.js";
-import { isRecentOutboundMessage, rememberRecentOutboundMessage } from "./dedupe.js";
+import { isRecentOutboundMessage } from "./dedupe.js";
 import {
   createWhatsAppDurableInboundMessageId,
   createWhatsAppDurableInboundQueue,
@@ -90,8 +97,9 @@ import {
   resolveWhatsAppOutboundMentions,
   type WhatsAppOutboundMentionParticipant,
 } from "./outbound-mentions.js";
-import { DisconnectReason, isJidGroup } from "./runtime-api.js";
-import { createWebSendApi } from "./send-api.js";
+import { createWhatsAppOutboundMessageRecorder } from "./outbound-message-cache.js";
+import { DisconnectReason } from "./runtime-api.js";
+import { createWebSendApi, type WhatsAppPreparedOutboundIdentity } from "./send-api.js";
 import { normalizeWhatsAppSendResult } from "./send-result.js";
 import type {
   AdmittedWebInboundMessage,
@@ -235,10 +243,6 @@ function logWhatsAppVerbose(enabled: boolean | undefined, message: string) {
     return;
   }
   defaultRuntime.log(message);
-}
-
-function isDirectUserJid(jid: string): boolean {
-  return /^(\d+)(?::\d+)?@(s\.whatsapp\.net|c\.us|lid|hosted|hosted\.lid)$/i.test(jid.trim());
 }
 
 function getActiveReachoutTimelock(
@@ -676,8 +680,15 @@ export async function attachWebInboxToSocket(
 
   const resolveInboundJid = async (jid: string | null | undefined): Promise<string | null> =>
     resolveJidToE164(jid, { authDir: options.authDir, lidLookup });
-  const resolveReactionTargetJids = async (jid: string): Promise<string[]> =>
-    resolveEquivalentWhatsAppDirectChatJids(jid, { authDir: options.authDir, lidLookup });
+  const resolveReactionTargetJids = async (
+    jid: string,
+    knownE164?: string | null,
+  ): Promise<string[]> =>
+    resolveEquivalentWhatsAppDirectChatJids(jid, {
+      authDir: options.authDir,
+      lidLookup,
+      knownE164,
+    });
 
   const rememberBaileysMessage = (
     remoteJid: string | null | undefined,
@@ -695,41 +706,11 @@ export async function attachWebInboxToSocket(
     );
   };
 
-  const rememberOutboundMessage = (remoteJid: string, result: unknown) => {
-    const messageId =
-      typeof result === "object" && result && "key" in result
-        ? ((result as { key?: { id?: string } }).key?.id ?? "")
-        : "";
-    if (!messageId) {
-      return;
-    }
-    rememberRecentOutboundMessage({
+  const { remember: rememberOutboundMessage, trackLateAccepted: trackLateAcceptedSend } =
+    createWhatsAppOutboundMessageRecorder({
       accountId: options.accountId,
-      remoteJid,
-      messageId,
+      rememberBaileysMessage,
     });
-    const message =
-      typeof result === "object" && result && "message" in result
-        ? (result as { message?: proto.IMessage }).message
-        : undefined;
-    rememberBaileysMessage(remoteJid, messageId, message);
-    // Baileys derives the participant for fromMe quotes from its own userJid.
-    // Retain only the facts needed to avoid the cache-miss fromMe=false fallback.
-    cacheInboundMessageMeta(options.accountId, remoteJid, messageId, {
-      fromMe: true,
-      body: extractText(message ?? undefined),
-    });
-  };
-  const trackLateAcceptedSend = (jid: string, promise: Promise<WAMessage | undefined>) => {
-    // The local send has failed terminally, but Baileys may still deliver it.
-    // Track a late message id only to suppress the resulting self-echo.
-    void promise.then(
-      (result) => {
-        rememberOutboundMessage(jid, result);
-      },
-      () => {},
-    );
-  };
   let reachoutTimeLock: ReachoutTimelockState | undefined;
   let reachoutTimeLockFetch: Promise<ReachoutTimelockState | undefined> | undefined;
   let reachoutTimeLockVersion = 0;
@@ -790,7 +771,7 @@ export async function attachWebInboxToSocket(
     currentSock: WASocket,
     readinessOptions?: { rememberReady?: boolean; useVerifiedReady?: boolean },
   ) => {
-    if (!isDirectUserJid(jid)) {
+    if (!classifyWhatsAppDirectJid(jid)) {
       return;
     }
     if (readinessOptions?.useVerifiedReady && consumeVerifiedSendReady(jid, currentSock)) {
@@ -824,6 +805,7 @@ export async function attachWebInboxToSocket(
     jid: string,
     content: AnyMessageContent,
     sendOptions?: MiscMessageGenerationOptions,
+    identity?: WhatsAppPreparedOutboundIdentity,
   ) => {
     let lastErr: unknown = new Error(RECONNECT_IN_PROGRESS_ERROR);
     for (let attempt = 1; ; attempt++) {
@@ -836,11 +818,11 @@ export async function attachWebInboxToSocket(
             sendOperationTimeoutMs,
             {
               onSendMessageTimeout: ({ jid: timedOutJid, promise }) => {
-                trackLateAcceptedSend(timedOutJid, promise);
+                trackLateAcceptedSend(timedOutJid, promise, identity);
               },
             },
           ).sendMessage(jid, content, sendOptions);
-          rememberOutboundMessage(jid, result);
+          rememberOutboundMessage(jid, result, identity);
           return result;
         } catch (err) {
           if (!shouldRetryDisconnect() || !isRetryableSendDisconnectError(err)) {
@@ -873,8 +855,13 @@ export async function attachWebInboxToSocket(
       }
     }
   };
-  const sendApiSocketOperations: WhatsAppSocketOperationAdapter = {
-    sendMessage: (jid, content, sendOptions) => sendTrackedMessage(jid, content, sendOptions),
+  const sendApiSocketOperations: Parameters<typeof createWebSendApi>[0]["sock"] = {
+    sendMessage: (
+      jid: string,
+      content: AnyMessageContent,
+      sendOptions?: MiscMessageGenerationOptions,
+      identity?: WhatsAppPreparedOutboundIdentity,
+    ) => sendTrackedMessage(jid, content, sendOptions, identity),
     sendPresenceUpdate: async (presenceLocal, jid) => {
       const currentSock = getCurrentSock();
       if (!currentSock) {
@@ -962,7 +949,7 @@ export async function attachWebInboxToSocket(
     jid: string,
     text: string,
   ): Promise<{ text: string; mentionedJids: string[] }> => {
-    if (isJidGroup(jid) !== true || !mayContainWhatsAppOutboundMention(text)) {
+    if (classifyWhatsAppJid(jid).kind !== "group" || !mayContainWhatsAppOutboundMention(text)) {
       return { text, mentionedJids: [] };
     }
     const meta = await getGroupMeta(jid);
@@ -1002,6 +989,7 @@ export async function attachWebInboxToSocket(
     participantJid?: string;
     from: string;
     senderE164: string | null;
+    directComparableJids?: string[];
     groupSubject?: string;
     groupParticipants?: string[];
     messageTimestampMs?: number;
@@ -1030,6 +1018,10 @@ export async function attachWebInboxToSocket(
     return true;
   };
 
+  const resolveInboundActorE164 = async (
+    actor: PreparedWhatsAppInboundActor,
+  ): Promise<string | null> => actor.e164 ?? resolveInboundJid(actor.transportJid);
+
   const normalizeInboundMessage = async (
     msg: WAMessage,
   ): Promise<NormalizedInboundMessage | null> => {
@@ -1038,11 +1030,13 @@ export async function attachWebInboxToSocket(
     if (!remoteJid) {
       return null;
     }
-    if (remoteJid.endsWith("@status") || remoteJid.endsWith("@broadcast")) {
+    const conversationJid = classifyWhatsAppJid(remoteJid);
+    // Only direct chats and groups are inbound conversation surfaces. Reject
+    // status/broadcast and newsletter traffic before participant authorization.
+    if (conversationJid.kind === "unsupported" || conversationJid.kind === "newsletter") {
       return null;
     }
-
-    const group = isJidGroup(remoteJid) === true;
+    const group = conversationJid.kind === "group";
     // Drop echoes of messages the gateway itself sent (tracked by sendTrackedMessage).
     // Applies to both groups and DMs/self-chat — without this, self-chat mode
     // re-processes the bot's own replies as new inbound user messages.
@@ -1061,16 +1055,28 @@ export async function attachWebInboxToSocket(
       return null;
     }
 
-    const participantJid = msg.key?.participant ?? undefined;
-    const from = group ? remoteJid : await resolveInboundJid(remoteJid);
+    const directActor = group
+      ? null
+      : prepareWhatsAppDirectInboundActor({
+          remoteJid,
+          remoteJidAlt: msg.key?.remoteJidAlt,
+          fromMe: Boolean(msg.key?.fromMe),
+          self,
+        });
+    const actor = group
+      ? prepareWhatsAppInboundActor({
+          primaryJid: msg.key?.participant,
+          alternateJid: msg.key?.participantAlt,
+        })
+      : directActor;
+    const participantJid = group
+      ? (actor?.transportJid ?? msg.key?.participant ?? undefined)
+      : undefined;
+    const from = group ? remoteJid : actor ? await resolveInboundActorE164(actor) : null;
     if (!from) {
       return null;
     }
-    const senderE164 = group
-      ? participantJid
-        ? await resolveInboundJid(participantJid)
-        : null
-      : from;
+    const senderE164 = group ? (actor ? await resolveInboundActorE164(actor) : null) : from;
 
     let groupSubject: string | undefined;
     let groupParticipants: string[] | undefined;
@@ -1113,6 +1119,7 @@ export async function attachWebInboxToSocket(
       participantJid,
       from,
       senderE164,
+      directComparableJids: directActor?.comparableJids,
       groupSubject,
       groupParticipants,
       messageTimestampMs,
@@ -1306,6 +1313,7 @@ export async function attachWebInboxToSocket(
         chatJid,
         addWhatsAppOutboundMentionsToContent({ text: resolved.text }, resolved.mentionedJids),
         optionsResult,
+        { remoteE164: inbound.group ? undefined : (inbound.senderE164 ?? undefined) },
       );
       return normalizeWhatsAppSendResult(result, "text");
     };
@@ -1318,6 +1326,7 @@ export async function attachWebInboxToSocket(
         chatJid,
         await applyOutboundMentionsToContent(chatJid, previewPayload),
         optionsValue,
+        { remoteE164: inbound.group ? undefined : (inbound.senderE164 ?? undefined) },
       );
       return normalizeWhatsAppSendResult(result, "media");
     };
@@ -1439,16 +1448,20 @@ export async function attachWebInboxToSocket(
     }
     if (inboundMessage.event.id) {
       const admission = requireWhatsAppInboundAdmission(inboundMessage);
+      // Cache only identity facts already established by ingress and Baileys.
+      // Quote lookup compares E.164 too; alias discovery here would delay delivery.
       cacheInboundMessageMeta(
         admission.accountId,
         inboundMessage.platform.chatJid,
         inboundMessage.event.id,
         {
           participant: inboundMessage.platform.senderJid,
-          participantE164:
+          remoteE164:
             admission.conversation.kind === "direct"
               ? inboundMessage.platform.senderE164
               : undefined,
+          remoteJids:
+            admission.conversation.kind === "direct" ? inbound.directComparableJids : undefined,
           body: inboundMessage.payload.body,
           fromMe: inboundMessage.platform.fromMe,
         },

--- a/extensions/whatsapp/src/inbound/outbound-mentions.test.ts
+++ b/extensions/whatsapp/src/inbound/outbound-mentions.test.ts
@@ -52,6 +52,24 @@ describe("resolveWhatsAppOutboundMentions", () => {
     });
   });
 
+  it("preserves hosted LID mentions while using PN metadata for token lookup", () => {
+    expect(
+      resolveWhatsAppOutboundMentions({
+        chatJid: "120363000000000000@g.us",
+        text: "ping @+15551234567",
+        participants: [
+          {
+            id: "277038292303944:2@hosted.lid",
+            phoneNumber: "15551234567:4@hosted",
+          },
+        ],
+      }),
+    ).toEqual({
+      text: "ping @277038292303944",
+      mentionedJids: ["277038292303944@hosted.lid"],
+    });
+  });
+
   it("prefers explicit LID metadata over a phone JID id", () => {
     expect(
       resolveWhatsAppOutboundMentions({
@@ -140,7 +158,11 @@ describe("resolveWhatsAppOutboundMentions", () => {
       resolveWhatsAppOutboundMentions({
         chatJid: "120363000000000000@g.us",
         text: "hi @+15551234567",
-        participants: [{ id: "15550000000@s.whatsapp.net" }],
+        participants: [
+          { id: "15550000000@s.whatsapp.net" },
+          { id: "abc@hosted" },
+          { id: "120363000000000000@newsletter" },
+        ],
       }),
     ).toEqual({ text: "hi @+15551234567", mentionedJids: [] });
   });

--- a/extensions/whatsapp/src/inbound/outbound-mentions.ts
+++ b/extensions/whatsapp/src/inbound/outbound-mentions.ts
@@ -1,5 +1,11 @@
 // Whatsapp plugin module implements outbound mentions behavior.
 import type { AnyMessageContent } from "baileys";
+import { stripWhatsAppTargetPrefixes } from "../whatsapp-jid-syntax.js";
+import {
+  classifyWhatsAppDirectJid,
+  classifyWhatsAppJid,
+  encodeWhatsAppJid,
+} from "../whatsapp-jid.js";
 
 export type WhatsAppOutboundMentionParticipant =
   | string
@@ -18,9 +24,6 @@ export type WhatsAppOutboundMentionResolution = {
 const CODE_FENCE_RE = /```[\s\S]*?```/g;
 const INLINE_CODE_RE = /`[^`\n]+`/g;
 const OUTBOUND_MENTION_RE = /@(\+?\d+)/g;
-const KNOWN_USER_JID_RE = /^(\d+)(?::\d+)?@(s\.whatsapp\.net|hosted|lid|hosted\.lid|c\.us)$/i;
-const PHONE_JID_DOMAIN_RE = /^(s\.whatsapp\.net|hosted|c\.us)$/i;
-const LID_JID_DOMAIN_RE = /^(lid|hosted\.lid)$/i;
 
 type TextRange = {
   start: number;
@@ -33,7 +36,7 @@ type MentionTarget = {
 };
 
 function isWhatsAppGroupJid(jid: string): boolean {
-  return jid.endsWith("@g.us");
+  return classifyWhatsAppJid(jid).kind === "group";
 }
 
 export function mayContainWhatsAppOutboundMention(text: string): boolean {
@@ -60,68 +63,47 @@ function isInRange(index: number, ranges: readonly TextRange[]): boolean {
 }
 
 function normalizeKnownUserJid(value: string): string | null {
-  const trimmed = value.replace(/^whatsapp:/i, "").trim();
-  const jidMatch = trimmed.match(KNOWN_USER_JID_RE);
-  if (jidMatch) {
-    const user = jidMatch[1];
-    const rawDomain = jidMatch[2];
-    if (!user || !rawDomain) {
-      return null;
-    }
-    const domain = rawDomain.toLowerCase() === "c.us" ? "s.whatsapp.net" : rawDomain.toLowerCase();
-    return `${user}@${domain}`;
+  const trimmed = stripWhatsAppTargetPrefixes(value);
+  const classified = classifyWhatsAppJid(trimmed);
+  if (classified.kind === "pn" || classified.kind === "lid") {
+    return classified.jid;
   }
   const digits = trimmed.startsWith("+")
     ? trimmed.replace(/\D/g, "")
     : /^\d+$/.test(trimmed)
       ? trimmed
       : "";
-  return digits ? `${digits}@s.whatsapp.net` : null;
-}
-
-function extractKnownJidParts(value: string): { user: string; domain: string } | null {
-  const normalized = normalizeKnownUserJid(value);
-  if (!normalized) {
-    return null;
-  }
-  const match = normalized.match(/^(\d+)@(.+)$/);
-  const user = match?.[1];
-  const domain = match?.[2];
-  return user && domain ? { user, domain } : null;
+  return digits ? encodeWhatsAppJid(digits, "s.whatsapp.net") : null;
 }
 
 function extractPhoneDigits(value: string | null | undefined): string | null {
   if (!value) {
     return null;
   }
-  const trimmed = value.replace(/^whatsapp:/i, "").trim();
+  const trimmed = stripWhatsAppTargetPrefixes(value);
   if (trimmed.startsWith("+") || /^\d+$/.test(trimmed)) {
     const digits = trimmed.replace(/\D/g, "");
     return digits || null;
   }
-  const parts = extractKnownJidParts(trimmed);
-  return parts && PHONE_JID_DOMAIN_RE.test(parts.domain) ? parts.user : null;
+  const classified = classifyWhatsAppDirectJid(normalizeKnownUserJid(trimmed));
+  return classified?.kind === "pn" ? classified.user : null;
 }
 
 function extractLidDigits(value: string | null | undefined): string | null {
   if (!value) {
     return null;
   }
-  const parts = extractKnownJidParts(value);
-  return parts && LID_JID_DOMAIN_RE.test(parts.domain) ? parts.user : null;
+  const classified = classifyWhatsAppDirectJid(normalizeKnownUserJid(value));
+  return classified?.kind === "lid" ? classified.user : null;
 }
 
 function isLidJid(jid: string): boolean {
-  const parts = extractKnownJidParts(jid);
-  return Boolean(parts && LID_JID_DOMAIN_RE.test(parts.domain));
+  return classifyWhatsAppDirectJid(jid)?.kind === "lid";
 }
 
 function lidReplacementText(jid: string): string | undefined {
-  const parts = extractKnownJidParts(jid);
-  if (!parts || !LID_JID_DOMAIN_RE.test(parts.domain)) {
-    return undefined;
-  }
-  return `@${parts.user}`;
+  const classified = classifyWhatsAppDirectJid(jid);
+  return classified?.kind === "lid" ? `@${classified.user}` : undefined;
 }
 
 function participantValues(participant: WhatsAppOutboundMentionParticipant): {

--- a/extensions/whatsapp/src/inbound/outbound-message-cache.test.ts
+++ b/extensions/whatsapp/src/inbound/outbound-message-cache.test.ts
@@ -1,0 +1,36 @@
+// Whatsapp tests cover native outbound message metadata recording.
+import type { WAMessage } from "baileys";
+import { describe, expect, it, vi } from "vitest";
+import { lookupInboundMessageMetaForTarget } from "../quoted-message.js";
+import { createWhatsAppOutboundMessageRecorder } from "./outbound-message-cache.js";
+
+describe("WhatsApp outbound message recorder", () => {
+  it("retains prepared PN identity when a timed-out LID send is accepted late", async () => {
+    const rememberBaileysMessage = vi.fn();
+    const recorder = createWhatsAppOutboundMessageRecorder({
+      accountId: "mapped-send",
+      rememberBaileysMessage,
+    });
+    const message = { conversation: "sent through LID" };
+
+    recorder.trackLateAccepted(
+      "277038292303944@lid",
+      Promise.resolve({ key: { id: "sent-1" }, message } as WAMessage),
+      {
+        remoteE164: "+15551230000",
+        remoteJids: ["15551230000@s.whatsapp.net", "277038292303944@lid"],
+      },
+    );
+
+    await vi.waitFor(() => {
+      expect(
+        lookupInboundMessageMetaForTarget("mapped-send", "15551230000@s.whatsapp.net", "sent-1"),
+      ).toMatchObject({
+        remoteJid: "277038292303944@lid",
+        body: "sent through LID",
+        fromMe: true,
+      });
+    });
+    expect(rememberBaileysMessage).toHaveBeenCalledWith("277038292303944@lid", "sent-1", message);
+  });
+});

--- a/extensions/whatsapp/src/inbound/outbound-message-cache.ts
+++ b/extensions/whatsapp/src/inbound/outbound-message-cache.ts
@@ -1,0 +1,58 @@
+// Whatsapp plugin module records metadata for accepted native sends.
+import type { proto, WAMessage } from "baileys";
+import { cacheInboundMessageMeta } from "../quoted-message.js";
+import { rememberRecentOutboundMessage } from "./dedupe.js";
+import { extractText } from "./extract.js";
+import type { WhatsAppPreparedOutboundIdentity } from "./send-api.js";
+
+export function createWhatsAppOutboundMessageRecorder(params: {
+  accountId: string;
+  rememberBaileysMessage: (
+    remoteJid: string,
+    messageId: string,
+    message: proto.IMessage | null | undefined,
+  ) => void;
+}) {
+  const remember = (
+    remoteJid: string,
+    result: WAMessage | undefined,
+    identity?: WhatsAppPreparedOutboundIdentity,
+  ) => {
+    const messageId = result?.key.id ?? "";
+    if (!messageId) {
+      return;
+    }
+    rememberRecentOutboundMessage({
+      accountId: params.accountId,
+      remoteJid,
+      messageId,
+    });
+    const message = result?.message;
+    params.rememberBaileysMessage(remoteJid, messageId, message);
+    // Baileys derives the participant for fromMe quotes from its own userJid.
+    // Retain only the facts needed to avoid the cache-miss fromMe=false fallback.
+    cacheInboundMessageMeta(params.accountId, remoteJid, messageId, {
+      fromMe: true,
+      remoteE164: identity?.remoteE164,
+      remoteJids: identity?.remoteJids,
+      body: extractText(message ?? undefined),
+    });
+  };
+
+  const trackLateAccepted = (
+    jid: string,
+    promise: Promise<WAMessage | undefined>,
+    identity?: WhatsAppPreparedOutboundIdentity,
+  ) => {
+    // The local send has failed terminally, but Baileys may still deliver it.
+    // Track a late message id only to suppress the resulting self-echo.
+    void promise.then(
+      (result) => {
+        remember(jid, result, identity);
+      },
+      () => {},
+    );
+  };
+
+  return { remember, trackLateAccepted } as const;
+}

--- a/extensions/whatsapp/src/inbound/runtime-api.ts
+++ b/extensions/whatsapp/src/inbound/runtime-api.ts
@@ -1,7 +1,2 @@
 // Whatsapp API module exposes the plugin public contract.
-export {
-  DisconnectReason,
-  downloadMediaMessage,
-  isJidGroup,
-  normalizeMessageContent,
-} from "baileys";
+export { DisconnectReason, downloadMediaMessage, normalizeMessageContent } from "baileys";

--- a/extensions/whatsapp/src/inbound/send-api.test.ts
+++ b/extensions/whatsapp/src/inbound/send-api.test.ts
@@ -106,6 +106,13 @@ describe("createWebSendApi", () => {
     expectRecordFields(requireSendContent(callIndex), fields);
   }
 
+  function expectSendIdentity(callIndex: number, remoteE164: string) {
+    expect(requireMockArg(sendMessage, callIndex, 3, "sent message identity")).toEqual({
+      remoteE164,
+      remoteJids: [`${remoteE164.slice(1)}@s.whatsapp.net`],
+    });
+  }
+
   function expectSendResultFields(result: WhatsAppSendResult, fields: Record<string, unknown>) {
     expectRecordFields(requireRecord(result, "send result"), fields);
   }
@@ -169,15 +176,13 @@ describe("createWebSendApi", () => {
       asDocument: true,
       fileName: "promo.png",
     });
-    expect(sendMessage).toHaveBeenCalledWith(
-      "1555@s.whatsapp.net",
-      expect.objectContaining({
-        document: payload,
-        fileName: "promo.png",
-        caption: "promo",
-        mimetype: "image/png",
-      }),
-    );
+    expectFirstSendJid("1555@s.whatsapp.net");
+    expectSendContentFields(0, {
+      document: payload,
+      fileName: "promo.png",
+      caption: "promo",
+      mimetype: "image/png",
+    });
   });
 
   it("uses MIME-aware filename fallback for forced visual documents", async () => {
@@ -186,15 +191,13 @@ describe("createWebSendApi", () => {
       asDocument: true,
     });
 
-    expect(sendMessage).toHaveBeenCalledWith(
-      "1555@s.whatsapp.net",
-      expect.objectContaining({
-        document: payload,
-        fileName: "file.png",
-        caption: "promo",
-        mimetype: "image/png",
-      }),
-    );
+    expectFirstSendJid("1555@s.whatsapp.net");
+    expectSendContentFields(0, {
+      document: payload,
+      fileName: "file.png",
+      caption: "promo",
+      mimetype: "image/png",
+    });
   });
 
   it("does not force audio media onto the document branch", async () => {
@@ -204,7 +207,8 @@ describe("createWebSendApi", () => {
       fileName: "voice.ogg",
     });
 
-    expect(sendMessage).toHaveBeenCalledWith("1555@s.whatsapp.net", {
+    expectFirstSendJid("1555@s.whatsapp.net");
+    expectSendContentFields(0, {
       audio: payload,
       ptt: true,
       mimetype: "audio/ogg",
@@ -213,7 +217,9 @@ describe("createWebSendApi", () => {
 
   it("sends plain text messages", async () => {
     const res = await api.sendMessage("+1555", "hello");
-    expect(sendMessage).toHaveBeenCalledWith("1555@s.whatsapp.net", { text: "hello" });
+    expectFirstSendJid("1555@s.whatsapp.net");
+    expectSendContentFields(0, { text: "hello" });
+    expectSendIdentity(0, "+1555");
     expectSendResultFields(res, {
       kind: "text",
       messageId: "msg-1",
@@ -233,7 +239,8 @@ describe("createWebSendApi", () => {
       vcard: "BEGIN:VCARD\nFN:QA Contact\nEND:VCARD",
     });
 
-    expect(sendMessage).toHaveBeenCalledWith("1555@s.whatsapp.net", {
+    expectFirstSendJid("1555@s.whatsapp.net");
+    expectSendContentFields(0, {
       contacts: {
         displayName: "QA Contact",
         contacts: [
@@ -263,7 +270,8 @@ describe("createWebSendApi", () => {
       name: "QA Location",
     });
 
-    expect(sendMessage).toHaveBeenCalledWith("1555@s.whatsapp.net", {
+    expectFirstSendJid("1555@s.whatsapp.net");
+    expectSendContentFields(0, {
       location: {
         address: undefined,
         degreesLatitude: 37.7749,
@@ -282,7 +290,8 @@ describe("createWebSendApi", () => {
     const payload = Buffer.from("webp");
     const res = await api.sendSticker("+1555", payload);
 
-    expect(sendMessage).toHaveBeenCalledWith("1555@s.whatsapp.net", {
+    expectFirstSendJid("1555@s.whatsapp.net");
+    expectSendContentFields(0, {
       sticker: payload,
       mimetype: "image/webp",
     });
@@ -312,7 +321,8 @@ describe("createWebSendApi", () => {
 
     await api.sendMessage("120363000000000000@g.us", "ping @+5511976136970");
 
-    expect(sendMessage).toHaveBeenCalledWith("120363000000000000@g.us", {
+    expectFirstSendJid("120363000000000000@g.us");
+    expectSendContentFields(0, {
       text: "ping @277038292303944",
       mentions: ["277038292303944@lid"],
     });
@@ -438,9 +448,8 @@ describe("createWebSendApi", () => {
       ptt: true,
       mimetype: "audio/ogg",
     });
-    expect(sendMessage).toHaveBeenNthCalledWith(2, "1555@s.whatsapp.net", {
-      text: "voice text",
-    });
+    expect(requireMockArg(sendMessage, 1, 0, "sent voice text")).toBe("1555@s.whatsapp.net");
+    expectSendContentFields(1, { text: "voice text" });
     expectSendResultFields(res, {
       kind: "media",
       messageId: "voice-1",
@@ -559,9 +568,8 @@ describe("createWebSendApi", () => {
 
   it("preserves newsletter JIDs for outbound sends", async () => {
     await api.sendMessage("120363401234567890@newsletter", "hello");
-    expect(sendMessage).toHaveBeenCalledWith("120363401234567890@newsletter", {
-      text: "hello",
-    });
+    expectFirstSendJid("120363401234567890@newsletter");
+    expectSendContentFields(0, { text: "hello" });
   });
 
   it("sends media as document when mediaType is undefined", async () => {
@@ -579,7 +587,8 @@ describe("createWebSendApi", () => {
   it("does not set mediaType when mediaBuffer is absent", async () => {
     await api.sendMessage("123", "hello");
 
-    expect(sendMessage).toHaveBeenCalledWith("123@s.whatsapp.net", { text: "hello" });
+    expectFirstSendJid("123@s.whatsapp.net");
+    expectSendContentFields(0, { text: "hello" });
   });
 
   it("preserves the quoted remoteJid provided by the outbound adapter", async () => {
@@ -622,6 +631,10 @@ describe("createWebSendApi LID resolution (issue #67378)", () => {
     vi.clearAllMocks();
     authDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-wa-lid-"));
     fs.writeFileSync(path.join(authDir, "lid-mapping-15555550000.json"), JSON.stringify("987654"));
+    fs.writeFileSync(
+      path.join(authDir, "lid-mapping-987654_reverse.json"),
+      JSON.stringify("15555550000"),
+    );
   });
 
   afterEach(() => {
@@ -635,7 +648,12 @@ describe("createWebSendApi LID resolution (issue #67378)", () => {
       authDir,
     });
     await api.sendMessage("+15555550000", "hello");
-    expect(sendMessage).toHaveBeenCalledWith("987654@lid", { text: "hello" });
+    expect(requireMockArg(sendMessage, 0, 0, "mapped send")).toBe("987654@lid");
+    expect(requireMockArg(sendMessage, 0, 1, "mapped send")).toEqual({ text: "hello" });
+    expect(requireMockArg(sendMessage, 0, 3, "mapped send identity")).toEqual({
+      remoteE164: "+15555550000",
+      remoteJids: ["15555550000@s.whatsapp.net", "987654@lid"],
+    });
   });
 
   it("falls back to PN s.whatsapp.net when no LID mapping exists", async () => {
@@ -645,7 +663,47 @@ describe("createWebSendApi LID resolution (issue #67378)", () => {
       authDir,
     });
     await api.sendMessage("+33123456789", "hello");
-    expect(sendMessage).toHaveBeenCalledWith("33123456789@s.whatsapp.net", { text: "hello" });
+    expect(requireMockArg(sendMessage, 0, 0, "unmapped send")).toBe("33123456789@s.whatsapp.net");
+    expect(requireMockArg(sendMessage, 0, 1, "unmapped send")).toEqual({ text: "hello" });
+  });
+
+  it.each([
+    {
+      target: "987654@lid",
+      mappedPn: "15555550000@s.whatsapp.net",
+    },
+    {
+      target: "987654@hosted.lid",
+      mappedPn: "15555550000@hosted",
+    },
+  ])(
+    "prepares the verified PN alias for an explicit $target send",
+    async ({ target, mappedPn }) => {
+      const api = createWebSendApi({
+        sock: { sendMessage, sendPresenceUpdate },
+        defaultAccountId: "main",
+        authDir,
+      });
+      await api.sendMessage(target, "hello");
+      expect(requireMockArg(sendMessage, 0, 0, "mapped send")).toBe(target);
+      expect(requireMockArg(sendMessage, 0, 3, "mapped send identity")).toEqual({
+        remoteE164: "+15555550000",
+        remoteJids: [target, mappedPn],
+      });
+    },
+  );
+
+  it("keeps an unmapped same-digit LID distinct from its apparent PN", async () => {
+    const api = createWebSendApi({
+      sock: { sendMessage, sendPresenceUpdate },
+      defaultAccountId: "main",
+      authDir,
+    });
+    await api.sendMessage("15555550000@lid", "hello");
+    expect(requireMockArg(sendMessage, 0, 3, "unmapped send identity")).toEqual({
+      remoteE164: undefined,
+      remoteJids: ["15555550000@lid"],
+    });
   });
 
   it("resolves PN to LID for sendPoll", async () => {
@@ -712,6 +770,7 @@ describe("createWebSendApi LID resolution (issue #67378)", () => {
       // authDir intentionally omitted
     });
     await api.sendMessage("+15555550000", "hello");
-    expect(sendMessage).toHaveBeenCalledWith("15555550000@s.whatsapp.net", { text: "hello" });
+    expect(requireMockArg(sendMessage, 0, 0, "PN-only send")).toBe("15555550000@s.whatsapp.net");
+    expect(requireMockArg(sendMessage, 0, 1, "PN-only send")).toEqual({ text: "hello" });
   });
 });

--- a/extensions/whatsapp/src/inbound/send-api.ts
+++ b/extensions/whatsapp/src/inbound/send-api.ts
@@ -8,9 +8,11 @@ import type {
 import { recordChannelActivity } from "openclaw/plugin-sdk/channel-activity-runtime";
 import { resolveWhatsAppDocumentFileName } from "../document-filename.js";
 import { addWhatsAppImagePreviewFields } from "../image-preview.js";
+import { readWhatsAppLidToPnMappings } from "../lid-mapping-files.js";
 import { isWhatsAppNewsletterJid } from "../normalize.js";
 import { buildQuotedMessageOptions } from "../quoted-message.js";
 import { toWhatsappJid, toWhatsappJidWithLid } from "../text-runtime.js";
+import { classifyWhatsAppJid, encodeWhatsAppJid } from "../whatsapp-jid.js";
 import {
   addWhatsAppOutboundMentionsToContent,
   type WhatsAppOutboundMentionResolution,
@@ -39,6 +41,16 @@ type StructuredStickerSendOptions = {
   mimetype?: string;
 };
 
+export type WhatsAppPreparedOutboundIdentity = {
+  remoteE164?: string;
+  remoteJids?: string[];
+};
+
+type WhatsAppOutboundRoute = {
+  jid: string;
+  identity: WhatsAppPreparedOutboundIdentity;
+};
+
 function recordWhatsAppOutbound(accountId: string) {
   recordChannelActivity({
     channel: "whatsapp",
@@ -51,12 +63,44 @@ function supportsForcedDocumentMediaType(mediaType: string): boolean {
   return mediaType.startsWith("image/") || mediaType.startsWith("video/");
 }
 
+function prepareOutboundIdentity(params: {
+  requestedJid: string;
+  routedJid: string;
+  authDir?: string;
+}): WhatsAppPreparedOutboundIdentity {
+  const requested = classifyWhatsAppJid(params.requestedJid);
+  if (requested.kind !== "pn" && requested.kind !== "lid") {
+    return {};
+  }
+
+  let remoteE164 = requested.kind === "pn" ? `+${requested.user}` : undefined;
+  const remoteJids = new Set([params.requestedJid, params.routedJid]);
+  if (requested.kind === "lid" && params.authDir) {
+    const mappings = readWhatsAppLidToPnMappings({
+      lid: requested.user,
+      mappingDirs: [params.authDir],
+    });
+    const mappedE164 = mappings.length === 1 ? mappings[0] : undefined;
+    if (mappedE164) {
+      remoteE164 = mappedE164;
+      remoteJids.add(
+        encodeWhatsAppJid(
+          mappedE164.slice(1),
+          requested.server === "hosted.lid" ? "hosted" : "s.whatsapp.net",
+        ),
+      );
+    }
+  }
+  return { remoteE164, remoteJids: [...remoteJids] };
+}
+
 export function createWebSendApi(params: {
   sock: {
     sendMessage: (
       jid: string,
       content: AnyMessageContent,
       options?: MiscMessageGenerationOptions,
+      identity?: WhatsAppPreparedOutboundIdentity,
     ) => Promise<WAMessage | undefined>;
     sendPresenceUpdate: (presence: WAPresence, jid?: string) => Promise<unknown>;
   };
@@ -71,10 +115,20 @@ export function createWebSendApi(params: {
   // ending up in a sender-only ghost chat (#67378). Defaults to PN-only.
   authDir?: string;
 }) {
-  const resolveOutboundJid = (recipient: string): string =>
-    params.authDir
+  const resolveOutboundRoute = (recipient: string): WhatsAppOutboundRoute => {
+    const requestedJid = toWhatsappJid(recipient);
+    const jid = params.authDir
       ? toWhatsappJidWithLid(recipient, { authDir: params.authDir })
-      : toWhatsappJid(recipient);
+      : requestedJid;
+    return {
+      jid,
+      identity: prepareOutboundIdentity({
+        requestedJid,
+        routedJid: jid,
+        authDir: params.authDir,
+      }),
+    };
+  };
   const resolveMentions = async (
     jid: string,
     text: string,
@@ -87,8 +141,8 @@ export function createWebSendApi(params: {
     content: AnyMessageContent,
     kind: WhatsAppSendKind,
   ): Promise<WhatsAppSendResult> => {
-    const jid = resolveOutboundJid(to);
-    const result = await params.sock.sendMessage(jid, content);
+    const route = resolveOutboundRoute(to);
+    const result = await params.sock.sendMessage(route.jid, content, undefined, route.identity);
     recordWhatsAppOutbound(params.defaultAccountId);
     return normalizeWhatsAppSendResult(result, kind);
   };
@@ -102,7 +156,8 @@ export function createWebSendApi(params: {
       sendOptions?: ActiveWebSendOptions,
     ): Promise<WhatsAppSendResult> => {
       let mediaType = mediaTypeInput;
-      const jid = resolveOutboundJid(to);
+      const route = resolveOutboundRoute(to);
+      const jid = route.jid;
       let payload: AnyMessageContent;
       if (mediaBuffer) {
         mediaType ??= "application/octet-stream";
@@ -165,8 +220,8 @@ export function createWebSendApi(params: {
         messageText: sendOptions?.quotedMessageKey?.messageText,
       });
       const result = quotedOpts
-        ? await params.sock.sendMessage(jid, payload, quotedOpts)
-        : await params.sock.sendMessage(jid, payload);
+        ? await params.sock.sendMessage(jid, payload, quotedOpts, route.identity)
+        : await params.sock.sendMessage(jid, payload, undefined, route.identity);
       const results = [normalizeWhatsAppSendResult(result, mediaBuffer ? "media" : "text")];
       if (shouldSendAudioText) {
         const resolvedAudioText = await resolveMentions(jid, text);
@@ -175,8 +230,8 @@ export function createWebSendApi(params: {
           resolvedAudioText.mentionedJids,
         );
         const textResult = quotedOpts
-          ? await params.sock.sendMessage(jid, textPayload, quotedOpts)
-          : await params.sock.sendMessage(jid, textPayload);
+          ? await params.sock.sendMessage(jid, textPayload, quotedOpts, route.identity)
+          : await params.sock.sendMessage(jid, textPayload, undefined, route.identity);
         results.push(normalizeWhatsAppSendResult(textResult, "text"));
       }
       const accountId = sendOptions?.accountId ?? params.defaultAccountId;
@@ -259,22 +314,28 @@ export function createWebSendApi(params: {
     ): Promise<WhatsAppSendResult> => {
       // Resolve DM targets through the same LID-aware path as normal sends so
       // reactions land on the delivered WhatsApp message key.
-      const jid = resolveOutboundJid(chatJid);
-      const result = await params.sock.sendMessage(jid, {
-        react: {
-          text: emoji,
-          key: {
-            remoteJid: jid,
-            id: messageId,
-            fromMe,
-            participant: participant ? toWhatsappJid(participant) : undefined,
+      const route = resolveOutboundRoute(chatJid);
+      const jid = route.jid;
+      const result = await params.sock.sendMessage(
+        jid,
+        {
+          react: {
+            text: emoji,
+            key: {
+              remoteJid: jid,
+              id: messageId,
+              fromMe,
+              participant: participant ? toWhatsappJid(participant) : undefined,
+            },
           },
-        },
-      } as AnyMessageContent);
+        } as AnyMessageContent,
+        undefined,
+        route.identity,
+      );
       return normalizeWhatsAppSendResult(result, "reaction");
     },
     sendComposingTo: async (to: string): Promise<void> => {
-      const jid = resolveOutboundJid(to);
+      const jid = resolveOutboundRoute(to).jid;
       if (isWhatsAppNewsletterJid(jid)) {
         return;
       }

--- a/extensions/whatsapp/src/lid-mapping-files.ts
+++ b/extensions/whatsapp/src/lid-mapping-files.ts
@@ -1,0 +1,90 @@
+// Whatsapp plugin module reads Baileys' persisted LID mapping entries.
+import path from "node:path";
+import { normalizeE164 } from "openclaw/plugin-sdk/account-resolution";
+import { loadJsonFile } from "openclaw/plugin-sdk/json-store";
+import { CONFIG_DIR, resolveUserPath } from "openclaw/plugin-sdk/text-utility-runtime";
+
+export type WhatsAppLidMappingFileOptions = {
+  authDir?: string;
+  lidMappingDirs?: string[];
+};
+
+function resolveLidMappingDirs(options?: WhatsAppLidMappingFileOptions): string[] {
+  const candidates = [
+    options?.authDir,
+    ...(options?.lidMappingDirs ?? []),
+    CONFIG_DIR,
+    path.join(CONFIG_DIR, "credentials"),
+  ];
+  return [
+    ...new Set(
+      candidates.filter((dir): dir is string => Boolean(dir)).map((dir) => resolveUserPath(dir)),
+    ),
+  ];
+}
+
+function readMappingFile(
+  mappingPath: string,
+  normalize: (candidate: string) => string | null,
+): string | null {
+  const value = loadJsonFile<string | number>(mappingPath);
+  return value === undefined ? null : normalize(String(value).trim());
+}
+
+function* readMappingCandidates(
+  mappingFilename: string,
+  mappingDirs: readonly string[],
+  normalize: (candidate: string) => string | null,
+): Generator<string> {
+  for (const dir of new Set(mappingDirs.map((candidate) => resolveUserPath(candidate)))) {
+    const mapping = readMappingFile(path.join(dir, mappingFilename), normalize);
+    if (mapping) {
+      yield mapping;
+    }
+  }
+}
+
+const normalizePhone = (candidate: string) =>
+  /^\+?\d+$/.test(candidate) ? normalizeE164(candidate) : null;
+const normalizeLid = (candidate: string) => (/^\d+$/.test(candidate) ? candidate : null);
+
+export function readWhatsAppLidToPnMappings(params: {
+  lid: string;
+  mappingDirs: readonly string[];
+}): string[] {
+  return [
+    ...new Set(
+      readMappingCandidates(
+        `lid-mapping-${params.lid}_reverse.json`,
+        params.mappingDirs,
+        normalizePhone,
+      ),
+    ),
+  ];
+}
+
+export function readWhatsAppLidToPnMapping(params: {
+  lid: string;
+  options?: WhatsAppLidMappingFileOptions;
+}): string | null {
+  return (
+    readMappingCandidates(
+      `lid-mapping-${params.lid}_reverse.json`,
+      resolveLidMappingDirs(params.options),
+      normalizePhone,
+    ).next().value ?? null
+  );
+}
+
+export function readWhatsAppPnToLidMapping(params: {
+  phoneDigits: string;
+  options?: WhatsAppLidMappingFileOptions;
+}): string | null {
+  return (
+    readMappingCandidates(
+      `lid-mapping-${params.phoneDigits}.json`,
+      resolveLidMappingDirs(params.options),
+      normalizeLid,
+    ).next().value ?? null
+  );
+}

--- a/extensions/whatsapp/src/monitor-inbox.streams-inbound-messages.test-support.ts
+++ b/extensions/whatsapp/src/monitor-inbox.streams-inbound-messages.test-support.ts
@@ -22,13 +22,14 @@ import {
   getAuthDir,
   getSock,
   installWebMonitorInboxUnitTestHooks,
+  mockLoadConfig,
   resetWebInboundDedupeForTests,
   settleInboundWork,
   startInboxMonitor,
   waitForMessageCalls,
 } from "./monitor-inbox.test-harness.js";
 import type { InboxOnMessage } from "./monitor-inbox.test-harness.js";
-import { lookupInboundMessageMeta } from "./quoted-message.js";
+import { lookupInboundMessageMeta, lookupInboundMessageMetaForTarget } from "./quoted-message.js";
 import { DEFAULT_WHATSAPP_SOCKET_TIMING } from "./socket-timing.js";
 
 const { controllerContexts, imageOps, sleepWithAbortMock } = vi.hoisted(() => ({
@@ -328,6 +329,29 @@ describe("web monitor inbox", () => {
       text: "flat media works",
     });
 
+    await listener.close();
+  });
+
+  it("ignores inbound newsletter conversations", async () => {
+    const remoteJid = "120363401234567890@newsletter";
+    const onMessage = vi.fn(async () => undefined);
+    const { listener, sock } = await startInboxMonitor(onMessage as InboxOnMessage);
+
+    sock.ev.emit(
+      "messages.upsert",
+      buildNotifyMessageUpsert({
+        id: nextMessageId("unsupported-conversation"),
+        remoteJid,
+        participant: "999@s.whatsapp.net",
+        text: "status content",
+        timestamp: 1_700_000_000,
+        pushName: "Tester",
+      }),
+    );
+    await settleInboundWork();
+
+    expect(onMessage).not.toHaveBeenCalled();
+    expect(sock.readMessages).not.toHaveBeenCalled();
     await listener.close();
   });
 
@@ -1243,6 +1267,27 @@ describe("web monitor inbox", () => {
     }
   });
 
+  it("applies the reachout timelock to a hosted LID", async () => {
+    const target = "277038292303944:6@hosted.lid";
+    const onMessage = vi.fn(async () => undefined);
+    const { listener, sock } = await startInboxMonitor(onMessage as InboxOnMessage);
+    sock.ev.emit("connection.update", {
+      reachoutTimeLock: {
+        isActive: true,
+        enforcementType: "WEB_COMPANION_ONLY",
+      },
+    });
+
+    try {
+      await expect(listener.sendMessage(target, "hello")).rejects.toThrow(
+        "WhatsApp reachout timelock is active",
+      );
+      expect(sock.sendMessage).not.toHaveBeenCalled();
+    } finally {
+      await listener.close();
+    }
+  });
+
   it("uses connection.update reachout timelock state before direct sends", async () => {
     const onMessage = vi.fn(async () => undefined);
     const { listener, sock } = await startInboxMonitor(onMessage as InboxOnMessage);
@@ -1901,14 +1946,149 @@ describe("web monitor inbox", () => {
     await listener.close();
   });
 
+  it("normalizes a legacy c.us inbound JID", async () => {
+    const remoteJid = "15551234567:2@c.us";
+    const onMessage = vi.fn(async () => {});
+    const { listener, sock } = await startInboxMonitor(onMessage as InboxOnMessage);
+    const upsert = buildNotifyMessageUpsert({
+      id: nextMessageId("direct-domain"),
+      remoteJid,
+      text: "ping",
+      timestamp: 1_700_000_000,
+      pushName: "Tester",
+    });
+
+    sock.ev.emit("messages.upsert", upsert);
+    await waitForMessageCalls(onMessage, 1);
+
+    expect(inboundMessage(onMessage).admission?.conversation.id).toBe("+15551234567");
+    await listener.close();
+  });
+
+  it.each([
+    {
+      name: "LID alias for a PN-addressed message",
+      remoteJid: "15551234567:2@s.whatsapp.net",
+      remoteJidAlt: "812345678901234:2@lid",
+      targetJid: "812345678901234@lid",
+      cachedRemoteJid: "15551234567@s.whatsapp.net",
+    },
+    {
+      name: "PN alias for a LID-addressed message",
+      remoteJid: "812345678901234:2@lid",
+      remoteJidAlt: "15551234567:2@s.whatsapp.net",
+      targetJid: "15551234567@s.whatsapp.net",
+      cachedRemoteJid: "812345678901234@lid",
+      conversationId: "+15551234567",
+    },
+  ])("caches Baileys' prepared $name without mapping discovery", async (testCase) => {
+    const onMessage = vi.fn(async () => {});
+    const { listener, sock } = await startInboxMonitor(onMessage as InboxOnMessage);
+    const getLIDForPN = vi.spyOn(sock.signalRepository.lidMapping, "getLIDForPN");
+    const getPNForLID = vi.spyOn(sock.signalRepository.lidMapping, "getPNForLID");
+    const messageId = nextMessageId("prepared-direct-alias");
+
+    sock.ev.emit(
+      "messages.upsert",
+      buildNotifyMessageUpsert({
+        id: messageId,
+        remoteJid: testCase.remoteJid,
+        remoteJidAlt: testCase.remoteJidAlt,
+        fromMe: false,
+        text: "ping",
+        timestamp: 1_700_000_000,
+        pushName: "Tester",
+      }),
+    );
+    await waitForMessageCalls(onMessage, 1);
+
+    expect(getLIDForPN).not.toHaveBeenCalled();
+    expect(getPNForLID).not.toHaveBeenCalled();
+    if (testCase.conversationId) {
+      expect(inboundMessage(onMessage).admission?.conversation.id).toBe(testCase.conversationId);
+    }
+    expect(
+      lookupInboundMessageMetaForTarget(DEFAULT_ACCOUNT_ID, testCase.targetJid, messageId),
+    ).toMatchObject({ remoteJid: testCase.cachedRemoteJid, body: "ping" });
+
+    await listener.close();
+  });
+
+  it("keeps a direct fromMe peer recipient separate from the sender alternate", async () => {
+    getSock().user = {
+      id: "123@s.whatsapp.net",
+      lid: "800000000000000@lid",
+    };
+    const onMessage = vi.fn(async () => {});
+    const { listener, sock } = await startInboxMonitor(onMessage as InboxOnMessage);
+    const getPNForLID = vi.spyOn(sock.signalRepository.lidMapping, "getPNForLID");
+
+    sock.ev.emit(
+      "messages.upsert",
+      buildNotifyMessageUpsert({
+        id: nextMessageId("from-me-peer-lid"),
+        remoteJid: "812345678901234@lid",
+        remoteJidAlt: "123@s.whatsapp.net",
+        fromMe: true,
+        text: "sent from the linked phone to a peer",
+        timestamp: 1_700_000_000,
+      }),
+    );
+    await settleInboundWork();
+
+    expect(getPNForLID).toHaveBeenCalledWith("812345678901234@lid");
+    expect(onMessage).not.toHaveBeenCalled();
+
+    await listener.close();
+  });
+
+  it("preserves a direct fromMe self-chat identified by its recipient LID", async () => {
+    getSock().user = {
+      id: "123@s.whatsapp.net",
+      lid: "800000000000000@lid",
+    };
+    const onMessage = vi.fn(async () => {});
+    const { listener, sock } = await startInboxMonitor(onMessage as InboxOnMessage);
+    const getPNForLID = vi.spyOn(sock.signalRepository.lidMapping, "getPNForLID");
+    const messageId = nextMessageId("from-me-self-chat-lid");
+
+    sock.ev.emit(
+      "messages.upsert",
+      buildNotifyMessageUpsert({
+        id: messageId,
+        remoteJid: "800000000000000:2@lid",
+        remoteJidAlt: "123:3@s.whatsapp.net",
+        fromMe: true,
+        text: "self-chat note",
+        timestamp: 1_700_000_000,
+      }),
+    );
+    await waitForMessageCalls(onMessage, 1);
+
+    expect(getPNForLID).not.toHaveBeenCalled();
+    expect(inboundMessage(onMessage)).toMatchObject({
+      admission: { conversation: { id: "+123", kind: "direct" } },
+      platform: { chatJid: "800000000000000:2@lid", fromMe: true },
+    });
+    expect(
+      lookupInboundMessageMetaForTarget(DEFAULT_ACCOUNT_ID, "123@s.whatsapp.net", messageId),
+    ).toMatchObject({
+      remoteJid: "800000000000000@lid",
+      fromMe: true,
+    });
+
+    await listener.close();
+  });
+
   it("resolves LID JIDs using Baileys LID mapping store", async () => {
     const onMessage = vi.fn(async () => {});
 
     const { listener, sock } = await startInboxMonitor(onMessage as InboxOnMessage);
     const getPNForLID = vi.spyOn(sock.signalRepository.lidMapping, "getPNForLID");
     sock.signalRepository.lidMapping.getPNForLID.mockResolvedValueOnce("999:0@s.whatsapp.net");
+    const messageId = nextMessageId("lid-store");
     const upsert = buildNotifyMessageUpsert({
-      id: nextMessageId("lid-store"),
+      id: messageId,
       remoteJid: "999@lid",
       text: "ping",
       timestamp: 1_700_000_000,
@@ -1924,6 +2104,12 @@ describe("web monitor inbox", () => {
     expect(inbound.payload.body).toBe("ping");
     expect(inbound.admission?.conversation.id).toBe("+999");
     expect(inbound.platform.recipientJid).toBe("+123");
+    expect(
+      lookupInboundMessageMetaForTarget(DEFAULT_ACCOUNT_ID, "999@s.whatsapp.net", messageId),
+    ).toMatchObject({
+      remoteJid: "999@lid",
+      body: "ping",
+    });
 
     await listener.close();
   });
@@ -1980,6 +2166,46 @@ describe("web monitor inbox", () => {
     expect(inbound.admission?.conversation.id).toBe("123@g.us");
     expect(inbound.platform.senderE164).toBe("+444");
     expect(inbound.admission?.conversation.kind).toBe("group");
+
+    await listener.close();
+  });
+
+  it("uses an observed group participant PN without mapping discovery", async () => {
+    mockLoadConfig.mockReturnValue({
+      channels: {
+        whatsapp: {
+          groupAllowFrom: ["+15551234567"],
+          groupPolicy: "allowlist",
+        },
+      },
+    });
+    const onMessage = vi.fn(async () => {});
+    const { listener, sock } = await startInboxMonitor(onMessage as InboxOnMessage);
+    const getLIDForPN = vi.spyOn(sock.signalRepository.lidMapping, "getLIDForPN");
+    const getPNForLID = vi.spyOn(sock.signalRepository.lidMapping, "getPNForLID");
+
+    sock.ev.emit(
+      "messages.upsert",
+      buildNotifyMessageUpsert({
+        id: nextMessageId("group-observed-pn"),
+        remoteJid: "123@g.us",
+        participant: "812345678901234@lid",
+        participantAlt: "15551234567:2@s.whatsapp.net",
+        text: "authorized group sender",
+        timestamp: 1_700_000_000,
+      }),
+    );
+    await waitForMessageCalls(onMessage, 1);
+
+    expect(getLIDForPN).not.toHaveBeenCalled();
+    expect(getPNForLID).not.toHaveBeenCalled();
+    const inbound = inboundMessage(onMessage);
+    expect(inbound.platform.senderE164).toBe("+15551234567");
+    expect(inbound.platform.senderJid).toBe("812345678901234@lid");
+    expect(inbound.platform.sender).toMatchObject({
+      lid: "812345678901234@lid",
+      e164: "+15551234567",
+    });
 
     await listener.close();
   });

--- a/extensions/whatsapp/src/monitor-inbox.test-harness.ts
+++ b/extensions/whatsapp/src/monitor-inbox.test-harness.ts
@@ -45,10 +45,11 @@ type MockSock = {
   logger: Record<string, unknown>;
   signalRepository: {
     lidMapping: {
+      getLIDForPN: AnyMockFn;
       getPNForLID: AnyMockFn;
     };
   };
-  user: { id: string };
+  user: { id: string; lid?: string };
 };
 
 const sessionState = vi.hoisted(() => ({
@@ -225,6 +226,7 @@ function createMockSock(): MockSock {
     logger: {},
     signalRepository: {
       lidMapping: {
+        getLIDForPN: vi.fn().mockResolvedValue(null),
         getPNForLID: vi.fn().mockResolvedValue(null),
       },
     },
@@ -344,6 +346,9 @@ export function buildNotifyMessageUpsert(params: {
   timestamp: number;
   pushName?: string;
   participant?: string;
+  participantAlt?: string;
+  remoteJidAlt?: string;
+  fromMe?: boolean;
 }) {
   return {
     type: "notify",
@@ -351,9 +356,11 @@ export function buildNotifyMessageUpsert(params: {
       {
         key: {
           id: params.id,
-          fromMe: false,
+          fromMe: params.fromMe ?? false,
           remoteJid: params.remoteJid,
+          remoteJidAlt: params.remoteJidAlt,
           participant: params.participant,
+          participantAlt: params.participantAlt,
         },
         message: { conversation: params.text },
         messageTimestamp: params.timestamp,

--- a/extensions/whatsapp/src/normalize-target.ts
+++ b/extensions/whatsapp/src/normalize-target.ts
@@ -1,78 +1,50 @@
 // Whatsapp helper module supports normalize target behavior.
 import { normalizeE164 } from "openclaw/plugin-sdk/account-resolution";
 import {
-  normalizeLowercaseStringOrEmpty,
-  normalizeStringEntries,
-  uniqueStrings,
-} from "openclaw/plugin-sdk/string-coerce-runtime";
+  normalizeWhatsAppAllowFromEntries,
+  normalizeWhatsAppAllowFromEntry,
+} from "./allowlist-format.js";
+import { stripWhatsAppTargetPrefixes } from "./whatsapp-jid-syntax.js";
+import { classifyWhatsAppJid, type WhatsAppJid } from "./whatsapp-jid.js";
 
-const WHATSAPP_USER_JID_RE = /^(\d+)(?::\d+)?@s\.whatsapp\.net$/i;
-const WHATSAPP_LEGACY_USER_JID_RE = /^(\d+)@c\.us$/i;
-const WHATSAPP_LID_RE = /^(\d+)@lid$/i;
+export { normalizeWhatsAppAllowFromEntries, normalizeWhatsAppAllowFromEntry };
+
 const NON_WHATSAPP_PROVIDER_PREFIX_RE = /^[a-z][a-z0-9-]*:/i;
-const WHATSAPP_NEWSLETTER_JID_RE = /^([0-9]+)@newsletter$/i;
 
-function stripWhatsAppTargetPrefixes(value: string): string {
-  let candidate = value.trim();
-  for (;;) {
-    const before = candidate;
-    candidate = candidate.replace(/^whatsapp:/i, "").trim();
-    if (candidate === before) {
-      return candidate;
-    }
+function classifyWhatsAppTargetJid(value: string): WhatsAppJid {
+  const candidate = stripWhatsAppTargetPrefixes(value);
+  if (/^group:/i.test(candidate)) {
+    const classified = classifyWhatsAppJid(candidate.replace(/^group:/i, "").trim());
+    return classified.kind === "group" ? classified : { kind: "unsupported" };
   }
-}
-
-function normalizeWhatsAppGroupJid(value: string): string | null {
-  const candidate = stripWhatsAppTargetPrefixes(value)
-    .replace(/^group:/i, "")
-    .trim();
-  const lower = normalizeLowercaseStringOrEmpty(candidate);
-  if (!lower.endsWith("@g.us")) {
-    return null;
-  }
-  const localPart = candidate.slice(0, candidate.length - "@g.us".length);
-  if (!localPart || localPart.includes("@")) {
-    return null;
-  }
-  return /^[0-9]+(-[0-9]+)*$/.test(localPart) ? `${localPart}@g.us` : null;
+  return classifyWhatsAppJid(candidate);
 }
 
 export function isWhatsAppGroupJid(value: string): boolean {
-  return normalizeWhatsAppGroupJid(value) !== null;
+  return classifyWhatsAppTargetJid(value).kind === "group";
 }
 
 export function isWhatsAppNewsletterJid(value: string): boolean {
-  const candidate = stripWhatsAppTargetPrefixes(value);
-  return WHATSAPP_NEWSLETTER_JID_RE.test(candidate);
+  return classifyWhatsAppTargetJid(value).kind === "newsletter";
 }
 
 export function isWhatsAppUserTarget(value: string): boolean {
-  const candidate = stripWhatsAppTargetPrefixes(value);
-  return (
-    WHATSAPP_USER_JID_RE.test(candidate) ||
-    WHATSAPP_LEGACY_USER_JID_RE.test(candidate) ||
-    WHATSAPP_LID_RE.test(candidate)
-  );
+  const classified = classifyWhatsAppTargetJid(value);
+  return classified.kind === "pn" || classified.kind === "lid";
 }
 
-function extractUserJidPhone(jid: string): string | null {
-  const userMatch = jid.match(WHATSAPP_USER_JID_RE);
-  if (userMatch) {
-    const phone = userMatch[1];
-    return phone ? phone : null;
+export function normalizeWhatsAppDirectPhone(value: string): string | null {
+  const candidate = stripWhatsAppTargetPrefixes(value);
+  const classified = classifyWhatsAppJid(candidate);
+  if (classified.kind === "pn") {
+    const normalized = normalizeE164(classified.user);
+    return normalized.length > 1 ? normalized : null;
   }
-  const legacyUserMatch = jid.match(WHATSAPP_LEGACY_USER_JID_RE);
-  if (legacyUserMatch) {
-    const phone = legacyUserMatch[1];
-    return phone ? phone : null;
+  if (candidate.includes("@") || NON_WHATSAPP_PROVIDER_PREFIX_RE.test(candidate)) {
+    return null;
   }
-  const lidMatch = jid.match(WHATSAPP_LID_RE);
-  if (lidMatch) {
-    const phone = lidMatch[1];
-    return phone ? phone : null;
-  }
-  return null;
+  const normalized = normalizeE164(candidate);
+  return normalized.length > 1 ? normalized : null;
 }
 
 export function normalizeWhatsAppTarget(value: string): string | null {
@@ -80,30 +52,18 @@ export function normalizeWhatsAppTarget(value: string): string | null {
   if (!candidate) {
     return null;
   }
-  const groupJid = normalizeWhatsAppGroupJid(candidate);
-  if (groupJid) {
-    return groupJid;
+  const classified = classifyWhatsAppTargetJid(candidate);
+  if (classified.kind === "unsupported") {
+    return normalizeWhatsAppDirectPhone(candidate);
   }
-  if (isWhatsAppNewsletterJid(candidate)) {
-    const match = candidate.match(WHATSAPP_NEWSLETTER_JID_RE);
-    return match ? `${match[1]}@newsletter` : null;
+  if (classified.kind !== "pn") {
+    return classified.jid;
   }
-  if (isWhatsAppUserTarget(candidate)) {
-    const phone = extractUserJidPhone(candidate);
-    if (!phone) {
-      return null;
-    }
-    const normalized = normalizeE164(phone);
-    return normalized.length > 1 ? normalized : null;
-  }
-  if (candidate.includes("@")) {
-    return null;
-  }
-  if (NON_WHATSAPP_PROVIDER_PREFIX_RE.test(candidate)) {
-    return null;
-  }
-  const normalized = normalizeE164(candidate);
-  return normalized.length > 1 ? normalized : null;
+  // Hostedness affects routing, so preserve hosted PN JIDs. Standard and
+  // legacy c.us targets retain the public E.164 normalization contract.
+  return classified.server === "hosted"
+    ? classified.jid
+    : normalizeWhatsAppDirectPhone(classified.jid);
 }
 
 export function normalizeWhatsAppMessagingTarget(raw: string): string | undefined {
@@ -112,25 +72,6 @@ export function normalizeWhatsAppMessagingTarget(raw: string): string | undefine
     return undefined;
   }
   return normalizeWhatsAppTarget(trimmed) ?? undefined;
-}
-
-export function normalizeWhatsAppAllowFromEntries(allowFrom: Array<string | number>): string[] {
-  return uniqueStrings(
-    normalizeStringEntries(allowFrom)
-      .map(normalizeWhatsAppAllowFromEntry)
-      .filter((entry): entry is string => Boolean(entry)),
-  );
-}
-
-export function normalizeWhatsAppAllowFromEntry(entry: string): string | null {
-  if (entry === "*") {
-    return entry;
-  }
-  const normalized = normalizeWhatsAppTarget(entry);
-  if (!normalized) {
-    return null;
-  }
-  return normalized.startsWith("+") ? normalized.slice(1) : normalized;
 }
 
 export function looksLikeWhatsAppTargetId(raw: string): boolean {

--- a/extensions/whatsapp/src/outbound-adapter.ts
+++ b/extensions/whatsapp/src/outbound-adapter.ts
@@ -24,8 +24,8 @@ export const whatsappOutbound: ChannelOutboundAdapter = createWhatsAppOutboundBa
   sendPollWhatsApp: async (to, poll, options) =>
     await (await loadWhatsAppSendModule()).sendPollWhatsApp(to, poll, options),
   shouldLogVerbose: () => shouldLogVerbose(),
-  resolveTarget: ({ to, allowFrom, mode }) =>
-    resolveWhatsAppOutboundTarget({ to, allowFrom, mode }),
+  resolveTarget: ({ to, allowFrom, mode, cfg, accountId }) =>
+    resolveWhatsAppOutboundTarget({ to, allowFrom, mode, cfg, accountId }),
   normalizeText: normalizeOutboundText,
   skipEmptyText: true,
 });

--- a/extensions/whatsapp/src/outbound-base.test.ts
+++ b/extensions/whatsapp/src/outbound-base.test.ts
@@ -186,7 +186,7 @@ describe("createWhatsAppOutboundBase", () => {
     });
   });
 
-  it("uses the implicit authDir default account for quote metadata lookup", async () => {
+  it("uses the implicit default account for quote metadata lookup", async () => {
     cacheInboundMessageMeta("default", "15551234567@s.whatsapp.net", "reply-auth-dir", {
       participant: "444@s.whatsapp.net",
       body: "implicit default body",

--- a/extensions/whatsapp/src/outbound-payload.contract.test.ts
+++ b/extensions/whatsapp/src/outbound-payload.contract.test.ts
@@ -126,7 +126,7 @@ describe("WhatsApp outbound payload contract", () => {
         gifPlayback: undefined,
         quotedMessageKey: {
           id: "msg-1",
-          remoteJid: "5511999999999@c.us",
+          remoteJid: "5511999999999@s.whatsapp.net",
           fromMe: false,
           participant: undefined,
           messageText: undefined,
@@ -198,7 +198,7 @@ describe("WhatsApp outbound payload contract", () => {
               gifPlayback: undefined,
               quotedMessageKey: {
                 id: "msg-1",
-                remoteJid: "5511999999999@c.us",
+                remoteJid: "5511999999999@s.whatsapp.net",
                 fromMe: false,
                 participant: undefined,
                 messageText: undefined,

--- a/extensions/whatsapp/src/quoted-message.test.ts
+++ b/extensions/whatsapp/src/quoted-message.test.ts
@@ -8,6 +8,9 @@ import {
   lookupInboundMessageMetaForTarget,
 } from "./quoted-message.js";
 
+const lookupForTarget = (accountId: string, targetJid: string, messageId: string) =>
+  lookupInboundMessageMetaForTarget(accountId, targetJid, messageId);
+
 describe("quoted message metadata cache", () => {
   it("scopes cached metadata by account id", () => {
     cacheInboundMessageMeta("account-a", "1555@s.whatsapp.net", "msg-1", {
@@ -40,37 +43,100 @@ describe("quoted message metadata cache", () => {
       fromMe: true,
     });
 
-    expect(
-      lookupInboundMessageMetaForTarget("account-c", "5511976136970@s.whatsapp.net", "msg-2"),
-    ).toEqual({
+    expect(lookupForTarget("account-c", "5511976136970@s.whatsapp.net", "msg-2")).toEqual({
       remoteJid: "277038292303944@lid",
       participant: "5511976136970@s.whatsapp.net",
       body: "hello from lid chat",
       fromMe: true,
     });
-    expect(
-      lookupInboundMessageMetaForTarget("account-c", "99999999999@s.whatsapp.net", "msg-2"),
-    ).toBeUndefined();
-    expect(
-      lookupInboundMessageMetaForTarget("missing", "5511976136970@s.whatsapp.net", "msg-2"),
-    ).toBeUndefined();
+    expect(lookupForTarget("account-c", "99999999999@s.whatsapp.net", "msg-2")).toBeUndefined();
+    expect(lookupForTarget("missing", "5511976136970@s.whatsapp.net", "msg-2")).toBeUndefined();
   });
 
-  it("can recover a direct-chat remoteJid when only sender E164 was cached", () => {
+  it("can recover a direct-chat remoteJid when only its E164 was cached", () => {
     cacheInboundMessageMeta("account-e", "277038292303944@lid", "msg-4", {
-      participantE164: "+5511976136970",
+      remoteE164: "+5511976136970",
       body: "hello from e164 participant",
     });
 
-    expect(
-      lookupInboundMessageMetaForTarget("account-e", "5511976136970@s.whatsapp.net", "msg-4"),
-    ).toEqual({
+    expect(lookupForTarget("account-e", "5511976136970@s.whatsapp.net", "msg-4")).toEqual({
       remoteJid: "277038292303944@lid",
       participant: undefined,
-      participantE164: "+5511976136970",
       body: "hello from e164 participant",
       fromMe: undefined,
     });
+  });
+
+  it("canonicalizes device-qualified and c.us cache identities", () => {
+    cacheInboundMessageMeta("account-canonical", "15551230000:2@c.us", "msg-canonical", {
+      participant: "15557654321:3@hosted",
+      body: "canonical",
+    });
+
+    expect(
+      lookupForTarget("account-canonical", "15551230000@s.whatsapp.net", "msg-canonical"),
+    ).toEqual({
+      remoteJid: "15551230000@s.whatsapp.net",
+      participant: "15557654321@hosted",
+      body: "canonical",
+      fromMe: undefined,
+    });
+  });
+
+  it("does not match same-digit PN and LID conversations without a mapping", () => {
+    cacheInboundMessageMeta("account-unmapped", "812345678901234@lid", "msg-unmapped", {
+      body: "unmapped lid",
+    });
+
+    expect(
+      lookupForTarget("account-unmapped", "812345678901234@s.whatsapp.net", "msg-unmapped"),
+    ).toBeUndefined();
+  });
+
+  it("matches hosted and standard forms of the same direct identity", () => {
+    cacheInboundMessageMeta("account-hosted", "277038292303944@lid", "msg-hosted", {
+      body: "same lid actor",
+    });
+
+    expect(lookupForTarget("account-hosted", "277038292303944@hosted.lid", "msg-hosted")).toEqual({
+      remoteJid: "277038292303944@lid",
+      participant: undefined,
+      body: "same lid actor",
+      fromMe: undefined,
+    });
+  });
+
+  it("uses the prepared direct-chat identity for hosted PN/LID quote equivalence", () => {
+    cacheInboundMessageMeta(
+      "account-hosted-map",
+      "277038292303944:2@hosted.lid",
+      "msg-hosted-map",
+      { remoteE164: "+15551230000", body: "mapped hosted lid" },
+    );
+
+    expect(lookupForTarget("account-hosted-map", "15551230000:4@hosted", "msg-hosted-map")).toEqual(
+      {
+        remoteJid: "277038292303944@hosted.lid",
+        participant: undefined,
+        body: "mapped hosted lid",
+        fromMe: undefined,
+      },
+    );
+  });
+
+  it("rejects ambiguous prepared identity matches", () => {
+    cacheInboundMessageMeta("account-ambiguous", "111111111111111@lid", "msg-ambiguous", {
+      remoteE164: "+15551230000",
+      body: "first",
+    });
+    cacheInboundMessageMeta("account-ambiguous", "222222222222222@lid", "msg-ambiguous", {
+      remoteE164: "+15551230000",
+      body: "second",
+    });
+
+    expect(
+      lookupForTarget("account-ambiguous", "15551230000@s.whatsapp.net", "msg-ambiguous"),
+    ).toBeUndefined();
   });
 
   it("lets Baileys encode the self participant for a cached outbound quote (#91445)", () => {
@@ -112,8 +178,6 @@ describe("quoted message metadata cache", () => {
       body: "group secret",
     });
 
-    expect(
-      lookupInboundMessageMetaForTarget("account-d", "222@s.whatsapp.net", "msg-3"),
-    ).toBeUndefined();
+    expect(lookupForTarget("account-d", "222@s.whatsapp.net", "msg-3")).toBeUndefined();
   });
 });

--- a/extensions/whatsapp/src/quoted-message.ts
+++ b/extensions/whatsapp/src/quoted-message.ts
@@ -1,21 +1,29 @@
 // Whatsapp plugin module implements quoted message behavior.
 import type { MiscMessageGenerationOptions } from "baileys";
-import { jidToE164 } from "./text-runtime.js";
+import { pruneMapToMaxSize } from "openclaw/plugin-sdk/collection-runtime";
+import {
+  areSameWhatsAppJid,
+  canonicalizeWhatsAppDirectJids,
+  classifyWhatsAppJid,
+} from "./whatsapp-jid.js";
 
 // ── Inbound message metadata cache ──────────────────────────────────────
-// Maps messageId → { participant, participantE164, body, fromMe } so the
-// outbound adapter can
-// populate the quote key with the sender JID and preview text even though
-// the outbound path only receives a bare messageId string.
+// Retains canonical JIDs plus identity facts prepared while mapping context is
+// already available, so outbound quote lookup stays a pure cache operation.
 
 type QuotedMeta = {
   participant?: string;
-  participantE164?: string;
   body?: string;
   fromMe?: boolean;
 };
-type CacheEntry = QuotedMeta & { ts: number };
+type ComparableIdentityFacts = {
+  /** Prepared direct-chat identity; mapping discovery belongs at message ingestion/send time. */
+  remoteE164?: string;
+  remoteJids?: string[];
+};
 type QuotedMetaLookup = QuotedMeta & { remoteJid: string };
+type QuotedMetaCandidate = QuotedMetaLookup & ComparableIdentityFacts;
+type CacheEntry = QuotedMetaCandidate & { ts: number };
 
 const CACHE_TTL_MS = 10 * 60 * 1000;
 const MAX_ENTRIES = 500;
@@ -25,22 +33,45 @@ function makeCacheKey(accountId: string, remoteJid: string, messageId: string): 
   return `${accountId}:${remoteJid}:${messageId}`;
 }
 
+function toQuotedMeta(meta: QuotedMeta): QuotedMeta {
+  return { participant: meta.participant, body: meta.body, fromMe: meta.fromMe };
+}
+
+function canonicalizeSupportedJid(jid: string | null | undefined): string | undefined {
+  const classified = classifyWhatsAppJid(jid);
+  return classified.kind === "unsupported" ? undefined : classified.jid;
+}
+
+function canonicalizeComparableE164(value: string | null | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed && /^\+\d+$/.test(trimmed) ? trimmed : undefined;
+}
+
+function directPnE164(jid: string | null | undefined): string | undefined {
+  const classified = classifyWhatsAppJid(jid);
+  return classified.kind === "pn" ? `+${classified.user}` : undefined;
+}
+
 export function cacheInboundMessageMeta(
   accountId: string,
   remoteJid: string,
   messageId: string,
-  meta: QuotedMeta,
+  meta: QuotedMeta & ComparableIdentityFacts,
 ): void {
-  if (!accountId || !messageId || !remoteJid) {
+  const canonicalRemoteJid = canonicalizeSupportedJid(remoteJid);
+  if (!accountId || !messageId || !canonicalRemoteJid) {
     return;
   }
-  if (cache.size >= MAX_ENTRIES) {
-    const oldest = cache.keys().next().value;
-    if (oldest) {
-      cache.delete(oldest);
-    }
-  }
-  cache.set(makeCacheKey(accountId, remoteJid, messageId), { ...meta, ts: Date.now() });
+  const remoteJids = canonicalizeWhatsAppDirectJids(meta.remoteJids ?? []);
+  cache.set(makeCacheKey(accountId, canonicalRemoteJid, messageId), {
+    ...meta,
+    remoteJid: canonicalRemoteJid,
+    participant: canonicalizeSupportedJid(meta.participant),
+    remoteE164: canonicalizeComparableE164(meta.remoteE164),
+    remoteJids: remoteJids.length > 0 ? remoteJids : undefined,
+    ts: Date.now(),
+  });
+  pruneMapToMaxSize(cache, MAX_ENTRIES);
 }
 
 export function lookupInboundMessageMeta(
@@ -48,7 +79,11 @@ export function lookupInboundMessageMeta(
   remoteJid: string,
   messageId: string,
 ): QuotedMeta | undefined {
-  const cacheKey = makeCacheKey(accountId, remoteJid, messageId);
+  const canonicalRemoteJid = canonicalizeSupportedJid(remoteJid);
+  if (!canonicalRemoteJid) {
+    return undefined;
+  }
+  const cacheKey = makeCacheKey(accountId, canonicalRemoteJid, messageId);
   const entry = cache.get(cacheKey);
   if (!entry) {
     return undefined;
@@ -57,56 +92,30 @@ export function lookupInboundMessageMeta(
     cache.delete(cacheKey);
     return undefined;
   }
-  return {
-    participant: entry.participant,
-    participantE164: entry.participantE164,
-    body: entry.body,
-    fromMe: entry.fromMe,
-  };
-}
-
-function normalizeComparableJid(jid: string | undefined): string | undefined {
-  const normalized = jid?.trim().replace(/:\d+/, "").toLowerCase();
-  return normalized || undefined;
+  return toQuotedMeta(entry);
 }
 
 function isGroupJid(jid: string | undefined): boolean {
-  return Boolean(jid && jid.endsWith("@g.us"));
+  return classifyWhatsAppJid(jid).kind === "group";
 }
 
-function areComparableE164sEqual(left: string | undefined, right: string | undefined): boolean {
-  const normalizedLeft = left?.trim();
-  const normalizedRight = right?.trim();
-  if (!normalizedLeft || !normalizedRight) {
-    return false;
-  }
-  return normalizedLeft === normalizedRight;
-}
-
-function areComparableJidsEqual(left: string | undefined, right: string | undefined): boolean {
-  const normalizedLeft = normalizeComparableJid(left);
-  const normalizedRight = normalizeComparableJid(right);
-  if (!normalizedLeft || !normalizedRight) {
-    return false;
-  }
-  if (normalizedLeft === normalizedRight) {
-    return true;
-  }
-  const leftE164 = jidToE164(normalizedLeft);
-  const rightE164 = jidToE164(normalizedRight);
-  return Boolean(leftE164 && rightE164 && leftE164 === rightE164);
-}
-
-function matchesQuotedConversationTarget(targetJid: string, candidate: QuotedMetaLookup): boolean {
-  if (areComparableJidsEqual(targetJid, candidate.remoteJid)) {
+function matchesQuotedConversationTarget(
+  targetJid: string,
+  candidate: QuotedMetaCandidate,
+): boolean {
+  if (areSameWhatsAppJid(targetJid, candidate.remoteJid)) {
     return true;
   }
   if (isGroupJid(targetJid) || isGroupJid(candidate.remoteJid)) {
     return false;
   }
+  if (candidate.remoteJids?.some((jid) => areSameWhatsAppJid(targetJid, jid))) {
+    return true;
+  }
+  const targetE164 = directPnE164(targetJid);
   return (
-    areComparableJidsEqual(targetJid, candidate.participant) ||
-    areComparableE164sEqual(jidToE164(targetJid) ?? undefined, candidate.participantE164)
+    areSameWhatsAppJid(targetJid, candidate.participant) ||
+    (targetE164 !== undefined && targetE164 === candidate.remoteE164)
   );
 }
 
@@ -115,22 +124,17 @@ export function lookupInboundMessageMetaForTarget(
   targetJid: string,
   messageId: string,
 ): QuotedMetaLookup | undefined {
-  if (!accountId || !messageId || !targetJid) {
+  const canonicalTargetJid = canonicalizeSupportedJid(targetJid);
+  if (!accountId || !messageId || !canonicalTargetJid) {
     return undefined;
   }
-  const exact = lookupInboundMessageMeta(accountId, targetJid, messageId);
+  const exact = lookupInboundMessageMeta(accountId, canonicalTargetJid, messageId);
   if (exact) {
-    return {
-      remoteJid: targetJid,
-      participant: exact.participant,
-      participantE164: exact.participantE164,
-      body: exact.body,
-      fromMe: exact.fromMe,
-    };
+    return { remoteJid: canonicalTargetJid, ...exact };
   }
   const prefix = `${accountId}:`;
   const suffix = `:${messageId}`;
-  let matched: QuotedMetaLookup | undefined;
+  let matched: QuotedMetaCandidate | undefined;
   for (const [cacheKey, entry] of cache.entries()) {
     if (!cacheKey.startsWith(prefix) || !cacheKey.endsWith(suffix)) {
       continue;
@@ -139,23 +143,15 @@ export function lookupInboundMessageMetaForTarget(
       cache.delete(cacheKey);
       continue;
     }
-    const remoteJid = cacheKey.slice(prefix.length, cacheKey.length - suffix.length);
-    const candidate = {
-      remoteJid,
-      participant: entry.participant,
-      participantE164: entry.participantE164,
-      body: entry.body,
-      fromMe: entry.fromMe,
-    };
-    if (!matchesQuotedConversationTarget(targetJid, candidate)) {
+    if (!matchesQuotedConversationTarget(canonicalTargetJid, entry)) {
       continue;
     }
     if (matched) {
       return undefined;
     }
-    matched = candidate;
+    matched = entry;
   }
-  return matched;
+  return matched ? { remoteJid: matched.remoteJid, ...toQuotedMeta(matched) } : undefined;
 }
 
 export function buildQuotedMessageOptions(params: {

--- a/extensions/whatsapp/src/resolve-outbound-target.mapping.test.ts
+++ b/extensions/whatsapp/src/resolve-outbound-target.mapping.test.ts
@@ -1,0 +1,54 @@
+// Whatsapp tests cover account-scoped LID authorization behavior.
+import fs from "node:fs/promises";
+import path from "node:path";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { withTempDir } from "openclaw/plugin-sdk/test-env";
+import { describe, expect, it } from "vitest";
+import { resolveWhatsAppOutboundTarget } from "./resolve-outbound-target.js";
+
+async function writeLidMapping(authDir: string, lid: string, phone: string): Promise<void> {
+  await fs.writeFile(path.join(authDir, `lid-mapping-${lid}_reverse.json`), JSON.stringify(phone));
+}
+
+function whatsappConfig(accounts: Record<string, { authDir: string }>): OpenClawConfig {
+  return { channels: { whatsapp: { accounts } } } as never;
+}
+
+describe("resolveWhatsAppOutboundTarget LID mappings", () => {
+  it("authorizes a LID target through the owning account's verified PN mapping", async () => {
+    await withTempDir("openclaw-whatsapp-outbound-lid-", async (authDir) => {
+      await writeLidMapping(authDir, "777", "15551230000");
+
+      expect(
+        resolveWhatsAppOutboundTarget({
+          to: "777:2@hosted.lid",
+          allowFrom: ["15551230000"],
+          mode: "implicit",
+          cfg: whatsappConfig({ work: { authDir } }),
+          accountId: "work",
+        }),
+      ).toEqual({ ok: true, to: "777@hosted.lid" });
+    });
+  });
+
+  it("does not authorize a LID target from another account's mapping", async () => {
+    await withTempDir("openclaw-whatsapp-outbound-owner-", async (ownerAuthDir) => {
+      await withTempDir("openclaw-whatsapp-outbound-other-", async (otherAuthDir) => {
+        await writeLidMapping(ownerAuthDir, "777", "15551230000");
+
+        const result = resolveWhatsAppOutboundTarget({
+          to: "777@lid",
+          allowFrom: ["15551230000"],
+          mode: "implicit",
+          cfg: whatsappConfig({
+            owner: { authDir: ownerAuthDir },
+            other: { authDir: otherAuthDir },
+          }),
+          accountId: "other",
+        });
+
+        expect(result.ok).toBe(false);
+      });
+    });
+  });
+});

--- a/extensions/whatsapp/src/resolve-outbound-target.test.ts
+++ b/extensions/whatsapp/src/resolve-outbound-target.test.ts
@@ -38,9 +38,7 @@ function expectResolutionOk(params: ResolveParams, expectedTarget: string) {
 
 function mockNormalizedDirectMessage(...values: Array<string | null>) {
   const normalizeMock = vi.mocked(normalize.normalizeWhatsAppTarget);
-  for (const value of values) {
-    normalizeMock.mockReturnValueOnce(value);
-  }
+  normalizeMock.mockReturnValueOnce(values[0] ?? null);
   vi.mocked(normalize.isWhatsAppGroupJid).mockReturnValueOnce(false);
 }
 
@@ -76,6 +74,7 @@ describe("resolveWhatsAppOutboundTarget", () => {
   beforeEach(async () => {
     vi.resetModules();
     vi.resetAllMocks();
+    vi.mocked(normalize.normalizeWhatsAppDirectPhone).mockImplementation((value) => value.trim());
     ({ resolveWhatsAppOutboundTarget } = await import("./resolve-outbound-target.js"));
   });
 
@@ -199,10 +198,7 @@ describe("resolveWhatsAppOutboundTarget", () => {
     });
 
     it("handles mixed numeric and string allowList entries", () => {
-      vi.mocked(normalize.normalizeWhatsAppTarget)
-        .mockReturnValueOnce("+11234567890")
-        .mockReturnValueOnce("+11234567890")
-        .mockReturnValueOnce("+11234567890");
+      vi.mocked(normalize.normalizeWhatsAppTarget).mockReturnValueOnce("+11234567890");
       vi.mocked(normalize.isWhatsAppGroupJid).mockReturnValueOnce(false);
 
       expectAllowedForTarget({
@@ -212,10 +208,10 @@ describe("resolveWhatsAppOutboundTarget", () => {
     });
 
     it("filters out invalid normalized entries from allowList", () => {
-      vi.mocked(normalize.normalizeWhatsAppTarget)
-        .mockReturnValueOnce("+11234567890")
-        .mockReturnValueOnce(null)
-        .mockReturnValueOnce("+11234567890");
+      vi.mocked(normalize.normalizeWhatsAppTarget).mockReturnValueOnce("+11234567890");
+      vi.mocked(normalize.normalizeWhatsAppDirectPhone).mockImplementation((value) =>
+        value === "invalid" ? null : value.trim(),
+      );
       vi.mocked(normalize.isWhatsAppGroupJid).mockReturnValueOnce(false);
 
       expectAllowedForTarget({
@@ -250,6 +246,9 @@ describe("resolveWhatsAppOutboundTarget", () => {
 
     it("enforces allowList in custom mode string", () => {
       mockNormalizedDirectMessage(SECONDARY_TARGET, PRIMARY_TARGET);
+      vi.mocked(normalize.normalizeWhatsAppDirectPhone)
+        .mockReturnValueOnce(PRIMARY_TARGET)
+        .mockReturnValueOnce(SECONDARY_TARGET);
       expectDeniedForTarget({ allowFrom: [SECONDARY_TARGET], mode: "broadcast" });
     });
 
@@ -283,7 +282,9 @@ describe("resolveWhatsAppOutboundTarget", () => {
         mode: undefined,
       });
 
-      expect(vi.mocked(normalize.normalizeWhatsAppTarget)).toHaveBeenCalledWith(PRIMARY_TARGET);
+      expect(vi.mocked(normalize.normalizeWhatsAppDirectPhone)).toHaveBeenCalledWith(
+        PRIMARY_TARGET,
+      );
     });
   });
 });

--- a/extensions/whatsapp/src/resolve-outbound-target.ts
+++ b/extensions/whatsapp/src/resolve-outbound-target.ts
@@ -1,11 +1,16 @@
 // Whatsapp plugin module implements resolve outbound target behavior.
 import { missingTargetError } from "openclaw/plugin-sdk/channel-feedback";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { normalizeStringEntries } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { resolveWhatsAppAccount } from "./accounts.js";
+import { readWhatsAppLidToPnMappings } from "./lid-mapping-files.js";
 import {
   isWhatsAppGroupJid,
   isWhatsAppNewsletterJid,
+  normalizeWhatsAppDirectPhone,
   normalizeWhatsAppTarget,
 } from "./normalize-target.js";
+import { classifyWhatsAppDirectJid } from "./whatsapp-jid.js";
 
 type WhatsAppOutboundTargetResolution = { ok: true; to: string } | { ok: false; error: Error };
 
@@ -13,10 +18,33 @@ function whatsappAllowFromPolicyError(target: string): Error {
   return new Error(`Target "${target}" is not listed in the configured WhatsApp allowFrom policy.`);
 }
 
+function resolveAuthorizedTargetPhone(params: {
+  target: string;
+  cfg?: OpenClawConfig;
+  accountId?: string | null;
+}): string | null {
+  const directPhone = normalizeWhatsAppDirectPhone(params.target);
+  if (directPhone || !params.cfg) {
+    return directPhone;
+  }
+  const directJid = classifyWhatsAppDirectJid(params.target);
+  if (directJid?.kind !== "lid") {
+    return null;
+  }
+  const account = resolveWhatsAppAccount({ cfg: params.cfg, accountId: params.accountId });
+  const mappings = readWhatsAppLidToPnMappings({
+    lid: directJid.user,
+    mappingDirs: [account.authDir],
+  });
+  return mappings.length === 1 ? (mappings[0] ?? null) : null;
+}
+
 export function resolveWhatsAppOutboundTarget(params: {
   to: string | null | undefined;
   allowFrom: Array<string | number> | null | undefined;
   mode: string | null | undefined;
+  cfg?: OpenClawConfig;
+  accountId?: string | null;
 }): WhatsAppOutboundTargetResolution {
   const trimmed = params.to?.trim() ?? "";
   if (!trimmed) {
@@ -39,14 +67,19 @@ export function resolveWhatsAppOutboundTarget(params: {
 
   const allowListRaw = normalizeStringEntries(params.allowFrom ?? []);
   const hasWildcard = allowListRaw.includes("*");
-  const allowList = allowListRaw
-    .filter((entry) => entry !== "*")
-    .map((entry) => normalizeWhatsAppTarget(entry))
+  const constrainedEntries = allowListRaw.filter((entry) => entry !== "*");
+  const allowList = constrainedEntries
+    .map((entry) => normalizeWhatsAppDirectPhone(entry))
     .filter((entry): entry is string => Boolean(entry));
-  if (hasWildcard || allowList.length === 0) {
+  if (hasWildcard || constrainedEntries.length === 0) {
     return { ok: true, to: normalizedTo };
   }
-  if (allowList.includes(normalizedTo)) {
+  const normalizedTargetPhone = resolveAuthorizedTargetPhone({
+    target: normalizedTo,
+    cfg: params.cfg,
+    accountId: params.accountId,
+  });
+  if (normalizedTargetPhone && allowList.includes(normalizedTargetPhone)) {
     return { ok: true, to: normalizedTo };
   }
   return {

--- a/extensions/whatsapp/src/resolve-target.test.ts
+++ b/extensions/whatsapp/src/resolve-target.test.ts
@@ -38,8 +38,10 @@ describe("normalizeWhatsAppTarget", () => {
     );
   });
 
-  it("normalizes direct JIDs to E.164", () => {
+  it("normalizes standard and legacy PN JIDs to E.164", () => {
     expect(normalizeWhatsAppTarget("1555123@s.whatsapp.net")).toBe("+1555123");
+    expect(normalizeWhatsAppTarget("1555123@c.us")).toBe("+1555123");
+    expect(normalizeWhatsAppTarget("1555123:4@c.us")).toBe("+1555123");
   });
 
   it("normalizes user JIDs with device suffix to E.164", () => {
@@ -48,9 +50,11 @@ describe("normalizeWhatsAppTarget", () => {
     expect(normalizeWhatsAppTarget("41796666864@s.whatsapp.net")).toBe("+41796666864");
   });
 
-  it("normalizes LID JIDs to E.164", () => {
-    expect(normalizeWhatsAppTarget("123456789@lid")).toBe("+123456789");
-    expect(normalizeWhatsAppTarget("123456789@LID")).toBe("+123456789");
+  it("preserves hosted and LID routing identities while stripping devices", () => {
+    expect(normalizeWhatsAppTarget("1555123:4@hosted")).toBe("1555123@hosted");
+    expect(normalizeWhatsAppTarget("123456789:2@lid")).toBe("123456789@lid");
+    expect(normalizeWhatsAppTarget("123456789@LID")).toBe("123456789@lid");
+    expect(normalizeWhatsAppTarget("123456789:3@hosted.lid")).toBe("123456789@hosted.lid");
   });
 
   it("rejects invalid targets", () => {
@@ -62,6 +66,8 @@ describe("normalizeWhatsAppTarget", () => {
     expect(normalizeWhatsAppTarget("group:abc@g.us")).toBeNull();
     expect(normalizeWhatsAppTarget("group:120363401234567890@newsletter")).toBeNull();
     expect(normalizeWhatsAppTarget("abc@s.whatsapp.net")).toBeNull();
+    expect(normalizeWhatsAppTarget("123:bad@s.whatsapp.net")).toBeNull();
+    expect(normalizeWhatsAppTarget("123:1:2@hosted")).toBeNull();
     expect(normalizeWhatsAppTarget("abc@newsletter")).toBeNull();
   });
 
@@ -82,8 +88,11 @@ describe("isWhatsAppUserTarget", () => {
   it("detects user JIDs with various formats", () => {
     expect(isWhatsAppUserTarget("41796666864:0@s.whatsapp.net")).toBe(true);
     expect(isWhatsAppUserTarget("1234567890@s.whatsapp.net")).toBe(true);
+    expect(isWhatsAppUserTarget("1234567890:3@c.us")).toBe(true);
+    expect(isWhatsAppUserTarget("1234567890:3@hosted")).toBe(true);
     expect(isWhatsAppUserTarget("123456789@lid")).toBe(true);
     expect(isWhatsAppUserTarget("123456789@LID")).toBe(true);
+    expect(isWhatsAppUserTarget("123456789:4@hosted.lid")).toBe(true);
     expect(isWhatsAppUserTarget("123@lid:0")).toBe(false);
     expect(isWhatsAppUserTarget("abc@s.whatsapp.net")).toBe(false);
     expect(isWhatsAppUserTarget("123456789-987654321@g.us")).toBe(false);
@@ -127,6 +136,8 @@ describe("normalizeWhatsAppAllowFromEntries", () => {
       normalizeWhatsAppAllowFromEntries([
         " +1 (555) 123-4567 ",
         "15551234567@s.whatsapp.net",
+        "15551234567:3@hosted",
+        "15551234567@lid",
         15551234567,
         " ",
         "invalid",
@@ -155,5 +166,35 @@ describe("resolveWhatsAppOutboundTarget", () => {
         mode: "explicit",
       }),
     ).toEqual({ ok: true, to: "120363401234567890@g.us" });
+  });
+
+  it("preserves hosted PN targets while applying the E.164 allowlist policy", () => {
+    expect(
+      resolveWhatsAppOutboundTarget({
+        to: "15551230000:4@hosted",
+        allowFrom: ["+15551230000"],
+        mode: "explicit",
+      }),
+    ).toEqual({ ok: true, to: "15551230000@hosted" });
+  });
+
+  it("does not equate an unmapped LID with the same digits in an E.164 allowlist", () => {
+    expect(
+      resolveWhatsAppOutboundTarget({
+        to: "15551230000@lid",
+        allowFrom: ["+15551230000"],
+        mode: "explicit",
+      }),
+    ).toMatchObject({ ok: false });
+  });
+
+  it("fails closed when configured allowlist entries are not E.164 identities", () => {
+    expect(
+      resolveWhatsAppOutboundTarget({
+        to: "+15551230000",
+        allowFrom: ["15551230000@lid", "not-a-phone"],
+        mode: "explicit",
+      }),
+    ).toMatchObject({ ok: false });
   });
 });

--- a/extensions/whatsapp/src/session-contract.test.ts
+++ b/extensions/whatsapp/src/session-contract.test.ts
@@ -17,6 +17,9 @@ describe("whatsapp legacy session contract", () => {
     expect(canonicalizeLegacySessionKey({ key: "whatsapp:123@g.us", agentId: "main" })).toBe(
       "agent:main:whatsapp:group:123@g.us",
     );
+    expect(canonicalizeLegacySessionKey({ key: " GROUP:123@G.US ", agentId: "MAIN" })).toBe(
+      "agent:main:whatsapp:group:123@g.us",
+    );
   });
 
   it("does not claim generic non-WhatsApp group keys", () => {
@@ -24,6 +27,15 @@ describe("whatsapp legacy session contract", () => {
     expect(deriveLegacySessionChatType("group:abc")).toBeUndefined();
     expect(canonicalizeLegacySessionKey({ key: "group:abc", agentId: "main" })).toBeNull();
   });
+
+  it.each(["group:123:2@g.us", "whatsapp:123@g.us@evil.example"])(
+    "rejects malformed legacy group key %s",
+    (key) => {
+      expect(isLegacyGroupSessionKey(key)).toBe(false);
+      expect(deriveLegacySessionChatType(key)).toBeUndefined();
+      expect(canonicalizeLegacySessionKey({ key, agentId: "main" })).toBeNull();
+    },
+  );
 
   it("derives chat type for legacy WhatsApp group keys", () => {
     expect(deriveLegacySessionChatType("123@g.us")).toBe("group");

--- a/extensions/whatsapp/src/session-contract.ts
+++ b/extensions/whatsapp/src/session-contract.ts
@@ -1,26 +1,23 @@
 // Whatsapp plugin module implements session contract behavior.
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { canonicalizeWhatsAppGroupJid } from "./whatsapp-jid-syntax.js";
 
 function extractLegacyWhatsAppGroupId(key: string): string | null {
   const trimmed = key.trim();
   if (!trimmed) {
     return null;
   }
-  const lower = normalizeLowercaseStringOrEmpty(trimmed);
-  if (trimmed.startsWith("group:")) {
-    const id = trimmed.slice("group:".length).trim();
-    return normalizeLowercaseStringOrEmpty(id).includes("@g.us") ? id : null;
-  }
-  if (!lower.includes("@g.us")) {
-    return null;
+  const normalizedKey = trimmed.toLowerCase();
+  if (normalizedKey.startsWith("group:")) {
+    return canonicalizeWhatsAppGroupJid(trimmed.slice("group:".length));
   }
   if (!trimmed.includes(":")) {
-    return trimmed;
+    return canonicalizeWhatsAppGroupJid(trimmed);
   }
-  if (lower.startsWith("whatsapp:") && !trimmed.includes(":group:")) {
+  if (normalizedKey.startsWith("whatsapp:") && !normalizedKey.includes(":group:")) {
     const remainder = trimmed.slice("whatsapp:".length).trim();
     const cleaned = remainder.replace(/^group:/i, "").trim();
-    return cleaned || null;
+    return canonicalizeWhatsAppGroupJid(cleaned);
   }
   return null;
 }
@@ -39,6 +36,6 @@ export function canonicalizeLegacySessionKey(params: {
 }): string | null {
   const legacyGroupId = extractLegacyWhatsAppGroupId(params.key);
   return legacyGroupId
-    ? `agent:${normalizeLowercaseStringOrEmpty(params.agentId)}:whatsapp:group:${normalizeLowercaseStringOrEmpty(legacyGroupId)}`
+    ? `agent:${normalizeLowercaseStringOrEmpty(params.agentId)}:whatsapp:group:${legacyGroupId}`
     : null;
 }

--- a/extensions/whatsapp/src/setup-surface.test.ts
+++ b/extensions/whatsapp/src/setup-surface.test.ts
@@ -82,8 +82,8 @@ vi.mock("./accounts.js", async () => {
   });
 });
 
-vi.mock("./auth-store.js", async () => {
-  const actual = await vi.importActual<typeof import("./auth-store.js")>("./auth-store.js");
+vi.mock("./auth-state.js", async () => {
+  const actual = await vi.importActual<typeof import("./auth-state.js")>("./auth-state.js");
   return Object.assign({}, actual, {
     readWebAuthState: hoisted.readWebAuthState,
   });

--- a/extensions/whatsapp/src/setup-surface.ts
+++ b/extensions/whatsapp/src/setup-surface.ts
@@ -7,7 +7,7 @@ import {
   type OpenClawConfig,
 } from "openclaw/plugin-sdk/setup";
 import { listWhatsAppAccountIds, resolveWhatsAppAuthDir } from "./accounts.js";
-import { formatWhatsAppWebAuthStatusState, readWebAuthState } from "./auth-store.js";
+import { formatWhatsAppWebAuthStatusState, readWebAuthState } from "./auth-state.js";
 
 const t = createSetupTranslator();
 

--- a/extensions/whatsapp/src/shared.ts
+++ b/extensions/whatsapp/src/shared.ts
@@ -23,7 +23,6 @@ import {
   resolveWhatsAppAccount,
   type ResolvedWhatsAppAccount,
 } from "./accounts.js";
-import { formatWhatsAppConfigAllowFromEntries } from "./config-accessors.js";
 import { WhatsAppChannelConfigSchema } from "./config-schema.js";
 import { whatsappDoctor } from "./doctor.js";
 import { resolveWhatsAppConfigPath } from "./group-config-path.js";
@@ -48,18 +47,6 @@ async function loadWhatsAppSetupSurface() {
 export const whatsappSetupWizardProxy = createWhatsAppSetupWizardProxy(
   async () => (await loadWhatsAppSetupSurface()).whatsappSetupWizard,
 );
-
-const whatsappConfigAdapter = createScopedChannelConfigAdapter<ResolvedWhatsAppAccount>({
-  sectionKey: WHATSAPP_CHANNEL,
-  listAccountIds: listWhatsAppAccountIds,
-  resolveAccount: adaptScopedAccountAccessor(resolveWhatsAppAccount),
-  defaultAccountId: resolveDefaultWhatsAppAccountId,
-  clearBaseFields: [],
-  allowTopLevel: false,
-  resolveAllowFrom: (account) => account.allowFrom,
-  formatAllowFrom: (allowFrom) => formatWhatsAppConfigAllowFromEntries(allowFrom),
-  resolveDefaultTo: (account) => account.defaultTo,
-});
 
 const whatsappResolveDmPolicy = createScopedDmSecurityResolver<ResolvedWhatsAppAccount>({
   channelKey: WHATSAPP_CHANNEL,
@@ -108,7 +95,19 @@ export function createWhatsAppPluginBase(params: {
   setupWizard: NonNullable<ChannelPlugin<ResolvedWhatsAppAccount>["setupWizard"]>;
   setup: NonNullable<ChannelPlugin<ResolvedWhatsAppAccount>["setup"]>;
   isConfigured: NonNullable<ChannelPlugin<ResolvedWhatsAppAccount>["config"]>["isConfigured"];
+  formatAllowFrom: (allowFrom: Array<string | number>) => string[];
 }) {
+  const whatsappConfigAdapter = createScopedChannelConfigAdapter<ResolvedWhatsAppAccount>({
+    sectionKey: WHATSAPP_CHANNEL,
+    listAccountIds: listWhatsAppAccountIds,
+    resolveAccount: adaptScopedAccountAccessor(resolveWhatsAppAccount),
+    defaultAccountId: resolveDefaultWhatsAppAccountId,
+    clearBaseFields: [],
+    allowTopLevel: false,
+    resolveAllowFrom: (account) => account.allowFrom,
+    formatAllowFrom: params.formatAllowFrom,
+    resolveDefaultTo: (account) => account.defaultTo,
+  });
   const collectWhatsAppSecurityWarnings = createAllowlistProviderGroupPolicyWarningCollector<{
     account: ResolvedWhatsAppAccount;
     cfg: Parameters<typeof resolveWhatsAppAccount>[0]["cfg"];

--- a/extensions/whatsapp/src/socket-timing.ts
+++ b/extensions/whatsapp/src/socket-timing.ts
@@ -16,7 +16,7 @@ export type WhatsAppSocketTimingOptions = {
   defaultQueryTimeoutMs?: number;
 };
 
-export type WhatsAppSocketOperationAdapter = {
+type WhatsAppSocketOperationAdapter = {
   sendMessage: (
     jid: string,
     content: AnyMessageContent,

--- a/extensions/whatsapp/src/targets-runtime.ts
+++ b/extensions/whatsapp/src/targets-runtime.ts
@@ -1,10 +1,20 @@
 // Whatsapp plugin module implements targets runtime behavior.
-import fs from "node:fs";
-import path from "node:path";
 import { normalizeE164 } from "openclaw/plugin-sdk/account-resolution";
 import { logVerbose, shouldLogVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { escapeRegExp } from "openclaw/plugin-sdk/text-utility-runtime";
-import { CONFIG_DIR, resolveUserPath } from "openclaw/plugin-sdk/text-utility-runtime";
+import { normalizeWhatsAppAllowFromEntry } from "./allowlist-format.js";
+import {
+  readWhatsAppLidToPnMapping,
+  readWhatsAppPnToLidMapping,
+  type WhatsAppLidMappingFileOptions,
+} from "./lid-mapping-files.js";
+import { stripWhatsAppTargetPrefixes } from "./whatsapp-jid-syntax.js";
+import {
+  classifyWhatsAppDirectJid,
+  classifyWhatsAppJid,
+  encodeWhatsAppJid,
+  type WhatsAppDirectJid,
+} from "./whatsapp-jid.js";
 
 const WHATSAPP_FENCE_PLACEHOLDER = "\x00FENCE";
 const WHATSAPP_INLINE_CODE_PLACEHOLDER = "\x00CODE";
@@ -30,27 +40,28 @@ export function isSelfChatMode(
   if (!Array.isArray(allowFrom) || allowFrom.length === 0) {
     return false;
   }
-  const normalizedSelf = normalizeE164(selfE164);
+  const normalizedSelf = normalizeWhatsAppAllowFromEntry(selfE164);
+  if (!normalizedSelf || normalizedSelf === "*") {
+    return false;
+  }
   return allowFrom.some((n) => {
-    if (n === "*") {
-      return false;
-    }
-    try {
-      return normalizeE164(String(n)) === normalizedSelf;
-    } catch {
-      return false;
-    }
+    const normalized = normalizeWhatsAppAllowFromEntry(String(n));
+    return normalized !== "*" && normalized === normalizedSelf;
   });
 }
 
 export function toWhatsappJid(number: string): string {
-  const withoutPrefix = number.replace(/^whatsapp:/i, "").trim();
+  const withoutPrefix = stripWhatsAppTargetPrefixes(number);
   if (withoutPrefix.includes("@")) {
-    return withoutPrefix;
+    const classified = classifyWhatsAppJid(withoutPrefix);
+    if (classified.kind === "unsupported") {
+      throw new Error(`Invalid WhatsApp JID: ${withoutPrefix}`);
+    }
+    return classified.jid;
   }
   const e164 = normalizeE164(withoutPrefix);
   const digits = e164.replace(/\D/g, "");
-  return `${digits}@s.whatsapp.net`;
+  return encodeWhatsAppJid(digits, "s.whatsapp.net");
 }
 
 // LID-aware outbound JID resolver. When a forward mapping file
@@ -59,19 +70,17 @@ export function toWhatsappJid(number: string): string {
 // ghost-chat failure mode where messages route to a sender-only thread that
 // never reaches recipients whose contact is internally LID-based (#67378).
 export function toWhatsappJidWithLid(number: string, opts?: JidToE164Options): string {
-  const stripped = number.replace(/^whatsapp:/i, "").trim();
+  const stripped = stripWhatsAppTargetPrefixes(number);
   if (stripped.includes("@")) {
-    return stripped;
+    return toWhatsappJid(stripped);
   }
   const e164 = normalizeE164(stripped);
   const phoneDigits = e164.replace(/\D/g, "");
-  const lid = readLidForwardMapping({ phoneDigits, opts });
-  return lid ? `${lid}@lid` : `${phoneDigits}@s.whatsapp.net`;
+  const lid = readWhatsAppPnToLidMapping({ phoneDigits, options: opts });
+  return lid ? encodeWhatsAppJid(lid, "lid") : encodeWhatsAppJid(phoneDigits, "s.whatsapp.net");
 }
 
-export type JidToE164Options = {
-  authDir?: string;
-  lidMappingDirs?: string[];
+export type JidToE164Options = WhatsAppLidMappingFileOptions & {
   logMissing?: boolean;
 };
 
@@ -103,156 +112,82 @@ async function tryLookupMappedJid(
   }
 }
 
-const DIRECT_PN_JID_RE = /^(\d+)(?::\d+)?@(s\.whatsapp\.net|hosted)$/i;
-const DIRECT_LID_JID_RE = /^(\d+)(?::\d+)?@(lid|hosted\.lid)$/i;
-
-function addEquivalentDirectChatCandidate(target: string[], jid: string | null | undefined): void {
-  addUniqueString(target, jid);
-  const pnMatch = jid?.match(DIRECT_PN_JID_RE);
-  if (pnMatch) {
-    addUniqueString(target, `${pnMatch[1]}@${pnMatch[2]}`);
+function addEquivalentDirectChatCandidate(
+  target: string[],
+  jid: string | null | undefined,
+  expectedKind?: WhatsAppDirectJid["kind"],
+): void {
+  const classified = classifyWhatsAppDirectJid(jid);
+  if (!classified || (expectedKind && classified.kind !== expectedKind)) {
     return;
   }
-  const lidMatch = jid?.match(DIRECT_LID_JID_RE);
-  if (lidMatch) {
-    addUniqueString(target, `${lidMatch[1]}@${lidMatch[2]}`);
-  }
+  addUniqueString(target, classified.jid);
 }
 
 export async function resolveEquivalentWhatsAppDirectChatJids(
   jid: string | null | undefined,
-  opts?: JidToE164Options & { lidLookup?: LidLookup },
+  opts?: JidToE164Options & { lidLookup?: LidLookup; knownE164?: string | null },
 ): Promise<string[]> {
-  const normalized = jid?.trim();
-  if (!normalized) {
+  const directJid = classifyWhatsAppDirectJid(jid);
+  if (!directJid) {
     return [];
   }
 
   const candidates: string[] = [];
-  addEquivalentDirectChatCandidate(candidates, normalized);
-  const pnMatch = normalized.match(DIRECT_PN_JID_RE);
-  if (pnMatch) {
-    const mappedLid = await tryLookupMappedJid(() => opts?.lidLookup?.getLIDForPN?.(normalized));
-    addEquivalentDirectChatCandidate(candidates, mappedLid);
+  addEquivalentDirectChatCandidate(candidates, directJid.jid);
+  if (directJid.kind === "pn") {
+    const mappedLid = await tryLookupMappedJid(() => opts?.lidLookup?.getLIDForPN?.(directJid.jid));
+    addEquivalentDirectChatCandidate(candidates, mappedLid, "lid");
 
-    const phoneDigits = pnMatch[1];
-    const pnDomain = pnMatch[2];
-    if (!phoneDigits || !pnDomain) {
-      return candidates;
-    }
-    const mappedLocalLid = readLidForwardMapping({ phoneDigits, opts });
-    const localLidDomain = pnDomain.toLowerCase() === "hosted" ? "hosted.lid" : "lid";
-    addUniqueString(candidates, mappedLocalLid ? `${mappedLocalLid}@${localLidDomain}` : null);
+    const mappedLocalLid = readWhatsAppPnToLidMapping({
+      phoneDigits: directJid.user,
+      options: opts,
+    });
+    const localLidDomain = directJid.server === "hosted" ? "hosted.lid" : "lid";
+    addUniqueString(
+      candidates,
+      mappedLocalLid ? encodeWhatsAppJid(mappedLocalLid, localLidDomain) : null,
+    );
     return candidates;
   }
 
-  const lidMatch = normalized.match(DIRECT_LID_JID_RE);
-  if (lidMatch) {
-    const mappedPn = await tryLookupMappedJid(() => opts?.lidLookup?.getPNForLID?.(normalized));
-    addEquivalentDirectChatCandidate(candidates, mappedPn);
-
-    const lidDomain = lidMatch[2];
-    if (!lidMatch[1] || !lidDomain) {
-      return candidates;
-    }
-    const e164 = jidToE164(normalized, { ...opts, logMissing: false });
-    const localPnJid =
-      e164 && lidDomain.toLowerCase() === "hosted.lid"
-        ? `${e164.replace(/\D/g, "")}@hosted`
-        : e164
-          ? toWhatsappJid(e164)
-          : null;
-    addUniqueString(candidates, localPnJid);
+  const knownPhoneDigits = opts?.knownE164?.match(/^\+(\d+)$/)?.[1];
+  if (knownPhoneDigits) {
+    const knownPnDomain = directJid.server === "hosted.lid" ? "hosted" : "s.whatsapp.net";
+    addUniqueString(candidates, encodeWhatsAppJid(knownPhoneDigits, knownPnDomain));
+    return candidates;
   }
+
+  const mappedPn = await tryLookupMappedJid(() => opts?.lidLookup?.getPNForLID?.(directJid.jid));
+  addEquivalentDirectChatCandidate(candidates, mappedPn, "pn");
+
+  const e164 = jidToE164(directJid.jid, { ...opts, logMissing: false });
+  const localPnDomain = directJid.server === "hosted.lid" ? "hosted" : "s.whatsapp.net";
+  addUniqueString(
+    candidates,
+    e164 ? encodeWhatsAppJid(e164.replace(/\D/g, ""), localPnDomain) : null,
+  );
   return candidates;
 }
 
-function resolveLidMappingDirs(params: { opts?: JidToE164Options }): string[] {
-  const dirs = new Set<string>();
-  const addDir = (dir?: string | null) => {
-    if (!dir) {
-      return;
-    }
-    dirs.add(resolveUserPath(dir));
-  };
-  addDir(params.opts?.authDir);
-  for (const dir of params.opts?.lidMappingDirs ?? []) {
-    addDir(dir);
-  }
-  addDir(CONFIG_DIR);
-  addDir(path.join(CONFIG_DIR, "credentials"));
-  return [...dirs];
-}
-
-function readLidReverseMapping(params: { lid: string; opts?: JidToE164Options }): string | null {
-  const mappingFilename = `lid-mapping-${params.lid}_reverse.json`;
-  const mappingDirs = resolveLidMappingDirs({ opts: params.opts });
-  for (const dir of mappingDirs) {
-    const mappingPath = path.join(dir, mappingFilename);
-    try {
-      const data = fs.readFileSync(mappingPath, "utf8");
-      const phone = JSON.parse(data) as string | number | null;
-      if (phone === null || phone === undefined) {
-        continue;
-      }
-      return normalizeE164(String(phone));
-    } catch {
-      // next location
-    }
-  }
-  return null;
-}
-
-function readLidForwardMapping(params: {
-  phoneDigits: string;
-  opts?: JidToE164Options;
-}): string | null {
-  const mappingFilename = `lid-mapping-${params.phoneDigits}.json`;
-  const mappingDirs = resolveLidMappingDirs({ opts: params.opts });
-  for (const dir of mappingDirs) {
-    const mappingPath = path.join(dir, mappingFilename);
-    try {
-      const data = fs.readFileSync(mappingPath, "utf8");
-      const lid = JSON.parse(data) as string | number | null;
-      if (lid === null || lid === undefined) {
-        continue;
-      }
-      const digits = String(lid).replace(/\D/g, "");
-      if (digits) {
-        return digits;
-      }
-    } catch {
-      // next location
-    }
-  }
-  return null;
-}
-
 export function jidToE164(jid: string, opts?: JidToE164Options): string | null {
-  const match = jid.match(/^(\d+)(?::\d+)?@(s\.whatsapp\.net|hosted)$/);
-  const phoneDigits = match?.[1];
-  if (phoneDigits) {
-    return `+${phoneDigits}`;
-  }
-
-  const lidMatch = jid.match(/^(\d+)(?::\d+)?@(lid|hosted\.lid)$/);
-  if (!lidMatch) {
+  const directJid = classifyWhatsAppDirectJid(jid);
+  if (!directJid) {
     return null;
   }
-  const lid = lidMatch[1];
-  if (!lid) {
-    return null;
+  if (directJid.kind === "pn") {
+    return `+${directJid.user}`;
   }
-  const phone = readLidReverseMapping({
-    lid,
-    opts,
+  const phone = readWhatsAppLidToPnMapping({
+    lid: directJid.user,
+    options: opts,
   });
   if (phone) {
     return phone;
   }
   const shouldLog = opts?.logMissing ?? shouldLogVerbose();
   if (shouldLog) {
-    logVerbose(`LID mapping not found for ${lidMatch[1]}; skipping inbound message`);
+    logVerbose(`LID mapping not found for ${directJid.user}; skipping inbound message`);
   }
   return null;
 }
@@ -264,22 +199,26 @@ export async function resolveJidToE164(
   if (!jid) {
     return null;
   }
-  const direct = jidToE164(jid, opts);
+  const directJid = classifyWhatsAppDirectJid(jid);
+  if (!directJid) {
+    return null;
+  }
+  const direct = jidToE164(directJid.jid, opts);
   if (direct) {
     return direct;
   }
-  if (!/(@lid|@hosted\.lid)$/.test(jid) || !opts?.lidLookup?.getPNForLID) {
+  if (directJid.kind !== "lid" || !opts?.lidLookup?.getPNForLID) {
     return null;
   }
   try {
-    const pnJid = await opts.lidLookup.getPNForLID(jid);
+    const pnJid = await opts.lidLookup.getPNForLID(directJid.jid);
     if (!pnJid) {
       return null;
     }
     return jidToE164(pnJid, opts);
   } catch (err) {
     if (shouldLogVerbose()) {
-      logVerbose(`LID mapping lookup failed for ${jid}: ${String(err)}`);
+      logVerbose(`LID mapping lookup failed for ${directJid.jid}: ${String(err)}`);
     }
     return null;
   }

--- a/extensions/whatsapp/src/text-runtime.test.ts
+++ b/extensions/whatsapp/src/text-runtime.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import {
   assertWebChannel,
+  isSelfChatMode,
   jidToE164,
   markdownToWhatsApp,
   resolveEquivalentWhatsAppDirectChatJids,
@@ -91,6 +92,15 @@ describe("assertWebChannel", () => {
   });
 });
 
+describe("isSelfChatMode", () => {
+  it("accepts PN forms but not same-digit LID forms", () => {
+    expect(isSelfChatMode("+15551230000", ["15551230000:3@c.us"])).toBe(true);
+    expect(isSelfChatMode("+15551230000", ["15551230000:4@hosted"])).toBe(true);
+    expect(isSelfChatMode("+15551230000", ["15551230000@lid"])).toBe(false);
+    expect(isSelfChatMode("+15551230000", ["15551230000@hosted.lid"])).toBe(false);
+  });
+});
+
 describe("toWhatsappJid", () => {
   it("strips formatting and prefixes", () => {
     expect(toWhatsappJid("whatsapp:+555 123 4567")).toBe("5551234567@s.whatsapp.net");
@@ -100,6 +110,12 @@ describe("toWhatsappJid", () => {
     expect(toWhatsappJid("123456789-987654321@g.us")).toBe("123456789-987654321@g.us");
     expect(toWhatsappJid("whatsapp:123456789-987654321@g.us")).toBe("123456789-987654321@g.us");
     expect(toWhatsappJid("1555123@s.whatsapp.net")).toBe("1555123@s.whatsapp.net");
+    expect(toWhatsappJid("1555123:3@c.us")).toBe("1555123@s.whatsapp.net");
+    expect(toWhatsappJid("1555123:4@hosted")).toBe("1555123@hosted");
+  });
+
+  it("rejects malformed existing JIDs", () => {
+    expect(() => toWhatsappJid("1555123:bad@s.whatsapp.net")).toThrow("Invalid WhatsApp JID");
   });
 });
 
@@ -149,9 +165,16 @@ describe("jidToE164", () => {
     expect(jidToE164("1555000:2@hosted")).toBe("+1555000");
   });
 
+  it("accepts legacy c.us PN JIDs and rejects malformed users", () => {
+    expect(jidToE164("1555000:2@c.us")).toBe("+1555000");
+    expect(jidToE164("not-a-phone@s.whatsapp.net")).toBeNull();
+    expect(jidToE164("1555000:bad@s.whatsapp.net")).toBeNull();
+  });
+
   it("falls back through lidMappingDirs in order", async () => {
     await withTempDir("openclaw-lid-a-", async (first) => {
       await withTempDir("openclaw-lid-b-", (second) => {
+        fs.writeFileSync(path.join(first, "lid-mapping-321_reverse.json"), JSON.stringify("bad"));
         const mappingPath = path.join(second, "lid-mapping-321_reverse.json");
         fs.writeFileSync(mappingPath, JSON.stringify("123321"));
         expect(jidToE164("321@lid", { lidMappingDirs: [first, second] })).toBe("+123321");
@@ -169,8 +192,9 @@ describe("toWhatsappJidWithLid (issue #67378)", () => {
     });
   });
 
-  it("falls back to PN s.whatsapp.net JID when no forward mapping exists", async () => {
+  it("falls back to PN when the forward mapping is missing or malformed", async () => {
     await withTempDir("openclaw-fwd-", (authDir) => {
+      fs.writeFileSync(path.join(authDir, "lid-mapping-33123456789.json"), JSON.stringify("bad"));
       expect(toWhatsappJidWithLid("+33123456789", { authDir })).toBe("33123456789@s.whatsapp.net");
     });
   });
@@ -229,11 +253,27 @@ describe("resolveEquivalentWhatsAppDirectChatJids", () => {
     ["15551230000:2@hosted", "15551230000@hosted"],
     ["777:1@lid", "777@lid"],
     ["777:2@hosted.lid", "777@hosted.lid"],
-  ])("includes the bare direct-chat form for %s", async (observedJid, bareJid) => {
-    await expect(resolveEquivalentWhatsAppDirectChatJids(observedJid)).resolves.toEqual([
-      observedJid,
-      bareJid,
+  ])("canonicalizes the direct-chat candidate for %s", async (observedJid, bareJid) => {
+    await expect(resolveEquivalentWhatsAppDirectChatJids(observedJid)).resolves.toEqual([bareJid]);
+  });
+
+  it("keeps same-digit PN and LID identities distinct without a mapping", async () => {
+    await expect(resolveEquivalentWhatsAppDirectChatJids("123@s.whatsapp.net")).resolves.toEqual([
+      "123@s.whatsapp.net",
     ]);
+    await expect(resolveEquivalentWhatsAppDirectChatJids("123@lid")).resolves.toEqual(["123@lid"]);
+  });
+
+  it("uses a prepared E164 without consulting the LID mapping store", async () => {
+    const getPNForLID = vi.fn();
+
+    await expect(
+      resolveEquivalentWhatsAppDirectChatJids("777@hosted.lid", {
+        knownE164: "+15551230000",
+        lidLookup: { getPNForLID },
+      }),
+    ).resolves.toEqual(["777@hosted.lid", "15551230000@hosted"]);
+    expect(getPNForLID).not.toHaveBeenCalled();
   });
 
   it("preserves hosted direct-chat domains for local PN/LID mappings", async () => {

--- a/extensions/whatsapp/src/whatsapp-jid-syntax.ts
+++ b/extensions/whatsapp/src/whatsapp-jid-syntax.ts
@@ -1,0 +1,146 @@
+// Whatsapp plugin module owns dependency-free JID syntax checks.
+
+// Baileys encodes direct JIDs as user[_agent][:device]@server. Validate every
+// numeric component before its normalizer strips agent and device metadata.
+const DIRECT_LOCAL_PART_RE = /^(\d+)(?:_(\d+))?(?::(\d+))?$/;
+const GROUP_LOCAL_PART_RE = /^[0-9]+(?:-[0-9]+)*$/;
+const NUMERIC_LOCAL_PART_RE = /^\d+$/;
+
+type WhatsAppDirectJidInputServer = "s.whatsapp.net" | "c.us" | "hosted" | "lid" | "hosted.lid";
+type WhatsAppDirectJidSyntaxServer = Exclude<WhatsAppDirectJidInputServer, "c.us">;
+type WhatsAppJidDomainType = 0 | 1 | 128 | 129;
+
+const DIRECT_JID_SERVERS = new Set<WhatsAppDirectJidInputServer>([
+  "s.whatsapp.net",
+  "c.us",
+  "hosted",
+  "lid",
+  "hosted.lid",
+]);
+
+// These byte values mirror Baileys WAJIDDomains. Setup imports this dependency-free
+// parser; the runtime classifier cross-checks them against Baileys jidDecode.
+const DOMAIN_TYPE_BY_SERVER: Record<WhatsAppDirectJidSyntaxServer, WhatsAppJidDomainType> = {
+  "s.whatsapp.net": 0,
+  lid: 1,
+  hosted: 128,
+  "hosted.lid": 129,
+};
+const SERVER_BY_DOMAIN_TYPE: Record<WhatsAppJidDomainType, WhatsAppDirectJidSyntaxServer> = {
+  0: "s.whatsapp.net",
+  1: "lid",
+  128: "hosted",
+  129: "hosted.lid",
+};
+
+type WhatsAppDirectJidSyntax = {
+  kind: "pn" | "lid";
+  user: string;
+  server: WhatsAppDirectJidSyntaxServer;
+  input: string;
+  domainType: WhatsAppJidDomainType;
+  device?: number;
+};
+
+type WhatsAppJidSyntax =
+  | WhatsAppDirectJidSyntax
+  | {
+      kind: "group" | "newsletter";
+      user: string;
+      server: "g.us" | "newsletter";
+      input: string;
+    };
+
+function parseUint8(value: string | undefined): number | undefined | null {
+  if (value === undefined) {
+    return undefined;
+  }
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed >= 0 && parsed <= 255 ? parsed : null;
+}
+
+function isWhatsAppJidDomainType(value: number): value is WhatsAppJidDomainType {
+  return value === 0 || value === 1 || value === 128 || value === 129;
+}
+
+function parseDirectJidSyntax(
+  localPart: string,
+  inputServer: WhatsAppDirectJidInputServer,
+): WhatsAppDirectJidSyntax | null {
+  const match = DIRECT_LOCAL_PART_RE.exec(localPart);
+  const user = match?.[1];
+  if (!user) {
+    return null;
+  }
+  const agent = parseUint8(match[2]);
+  const device = parseUint8(match[3]);
+  if (agent === null || device === null) {
+    return null;
+  }
+
+  const textualServer = inputServer === "c.us" ? "s.whatsapp.net" : inputServer;
+  const textualDomainType = DOMAIN_TYPE_BY_SERVER[textualServer];
+  if (agent !== undefined && !isWhatsAppJidDomainType(agent)) {
+    return null;
+  }
+  if (agent !== undefined && textualDomainType !== 0 && agent !== textualDomainType) {
+    return null;
+  }
+  const domainType = agent ?? textualDomainType;
+  const server = SERVER_BY_DOMAIN_TYPE[domainType];
+  if (device === 99 && server !== "hosted" && server !== "hosted.lid") {
+    return null;
+  }
+  return {
+    kind: server === "lid" || server === "hosted.lid" ? "lid" : "pn",
+    user,
+    server,
+    input: `${localPart}@${inputServer}`,
+    domainType,
+    device,
+  };
+}
+
+export function parseWhatsAppJidSyntax(value: string | null | undefined): WhatsAppJidSyntax | null {
+  const trimmed = value?.trim();
+  const separatorIndex = trimmed?.indexOf("@") ?? -1;
+  if (!trimmed || separatorIndex <= 0 || separatorIndex !== trimmed.lastIndexOf("@")) {
+    return null;
+  }
+
+  const localPart = trimmed.slice(0, separatorIndex);
+  const server = trimmed.slice(separatorIndex + 1).toLowerCase();
+  if (DIRECT_JID_SERVERS.has(server as WhatsAppDirectJidInputServer)) {
+    return parseDirectJidSyntax(localPart, server as WhatsAppDirectJidInputServer);
+  }
+  if (server === "g.us" && GROUP_LOCAL_PART_RE.test(localPart)) {
+    return { kind: "group", user: localPart, server, input: `${localPart}@${server}` };
+  }
+  if (server === "newsletter" && NUMERIC_LOCAL_PART_RE.test(localPart)) {
+    return { kind: "newsletter", user: localPart, server, input: `${localPart}@${server}` };
+  }
+  return null;
+}
+
+export function parseWhatsAppDirectJidSyntax(
+  value: string | null | undefined,
+): WhatsAppDirectJidSyntax | null {
+  const parsed = parseWhatsAppJidSyntax(value);
+  return parsed?.kind === "pn" || parsed?.kind === "lid" ? parsed : null;
+}
+
+export function stripWhatsAppTargetPrefixes(value: string): string {
+  let candidate = value.trim();
+  for (;;) {
+    const before = candidate;
+    candidate = candidate.replace(/^whatsapp:/i, "").trim();
+    if (candidate === before) {
+      return candidate;
+    }
+  }
+}
+
+export function canonicalizeWhatsAppGroupJid(value: string | null | undefined): string | null {
+  const parsed = parseWhatsAppJidSyntax(value);
+  return parsed?.kind === "group" ? parsed.input : null;
+}

--- a/extensions/whatsapp/src/whatsapp-jid.test.ts
+++ b/extensions/whatsapp/src/whatsapp-jid.test.ts
@@ -1,0 +1,120 @@
+// Whatsapp tests cover canonical JID parsing and classification.
+import { describe, expect, it } from "vitest";
+import {
+  areSameWhatsAppJid,
+  canonicalizeWhatsAppDirectJids,
+  classifyWhatsAppJid,
+  encodeWhatsAppJid,
+} from "./whatsapp-jid.js";
+
+describe("classifyWhatsAppJid", () => {
+  it.each([
+    ["15551230000@s.whatsapp.net", "pn", "s.whatsapp.net", "15551230000@s.whatsapp.net"],
+    ["15551230000:0@s.whatsapp.net", "pn", "s.whatsapp.net", "15551230000@s.whatsapp.net"],
+    ["15551230000_0:1@s.whatsapp.net", "pn", "s.whatsapp.net", "15551230000@s.whatsapp.net"],
+    ["277038292303944_1:2@s.whatsapp.net", "lid", "lid", "277038292303944@lid"],
+    ["15551230000_128:1@s.whatsapp.net", "pn", "hosted", "15551230000@hosted"],
+    ["277038292303944_129:3@s.whatsapp.net", "lid", "hosted.lid", "277038292303944@hosted.lid"],
+    ["15551230000@c.us", "pn", "s.whatsapp.net", "15551230000@s.whatsapp.net"],
+    ["15551230000:7@c.us", "pn", "s.whatsapp.net", "15551230000@s.whatsapp.net"],
+    ["15551230000_128:1@c.us", "pn", "hosted", "15551230000@hosted"],
+    ["15551230000@hosted", "pn", "hosted", "15551230000@hosted"],
+    ["15551230000:9@hosted", "pn", "hosted", "15551230000@hosted"],
+    ["15551230000:255@hosted", "pn", "hosted", "15551230000@hosted"],
+    ["15551230000:99@hosted", "pn", "hosted", "15551230000@hosted"],
+    ["15551230000_128:1@hosted", "pn", "hosted", "15551230000@hosted"],
+    ["277038292303944@lid", "lid", "lid", "277038292303944@lid"],
+    ["277038292303944:2@lid", "lid", "lid", "277038292303944@lid"],
+    ["277038292303944_1:2@lid", "lid", "lid", "277038292303944@lid"],
+    ["277038292303944@hosted.lid", "lid", "hosted.lid", "277038292303944@hosted.lid"],
+    ["277038292303944:3@hosted.lid", "lid", "hosted.lid", "277038292303944@hosted.lid"],
+    ["277038292303944:99@hosted.lid", "lid", "hosted.lid", "277038292303944@hosted.lid"],
+    ["277038292303944_129:3@hosted.lid", "lid", "hosted.lid", "277038292303944@hosted.lid"],
+    ["120363401234567890-123@g.us", "group", "g.us", "120363401234567890-123@g.us"],
+    ["120363401234567890@newsletter", "newsletter", "newsletter", "120363401234567890@newsletter"],
+  ] as const)("classifies and canonicalizes %s", (input, kind, server, jid) => {
+    expect(classifyWhatsAppJid(input)).toEqual({
+      kind,
+      server,
+      user: jid.slice(0, jid.indexOf("@")),
+      jid,
+    });
+  });
+
+  it("preserves case-insensitive server compatibility", () => {
+    expect(classifyWhatsAppJid("15551230000:4@HOSTED")).toEqual({
+      kind: "pn",
+      server: "hosted",
+      user: "15551230000",
+      jid: "15551230000@hosted",
+    });
+  });
+
+  it.each([
+    "",
+    "15551230000",
+    "@s.whatsapp.net",
+    "15551230000@",
+    "15551230000@unknown",
+    "15551230000@foo@s.whatsapp.net",
+    "abc@s.whatsapp.net",
+    "15551230000:abc@s.whatsapp.net",
+    "15551230000:-1@s.whatsapp.net",
+    "15551230000:1:2@s.whatsapp.net",
+    "15551230000_bad:1@s.whatsapp.net",
+    "15551230000_128:bad@s.whatsapp.net",
+    "15551230000_128:1:2@s.whatsapp.net",
+    "15551230000_2:1@s.whatsapp.net",
+    "15551230000_129:1@hosted",
+    "15551230000_128:1@lid",
+    "15551230000:99@s.whatsapp.net",
+    "277038292303944:99@lid",
+    "15551230000:256@hosted",
+    "15551230000_256:1@s.whatsapp.net",
+    "15551230000 :1@s.whatsapp.net",
+    "120363401234567890:1@g.us",
+    "120363401234567890--123@g.us",
+    "abc@g.us",
+    "120363401234567890:1@newsletter",
+    "status@broadcast",
+    "123@broadcast",
+  ])("rejects unsupported or malformed JID %j", (input) => {
+    expect(classifyWhatsAppJid(input)).toEqual({ kind: "unsupported" });
+  });
+});
+
+describe("encodeWhatsAppJid", () => {
+  it("encodes only valid canonical JIDs", () => {
+    expect(encodeWhatsAppJid("15551230000", "s.whatsapp.net")).toBe("15551230000@s.whatsapp.net");
+    expect(encodeWhatsAppJid("277038292303944", "hosted.lid")).toBe("277038292303944@hosted.lid");
+    expect(() => encodeWhatsAppJid("not-a-phone", "hosted")).toThrow(
+      "Invalid WhatsApp hosted JID user",
+    );
+  });
+});
+
+describe("canonicalizeWhatsAppDirectJids", () => {
+  it("filters unsupported values and preserves canonical first-seen order", () => {
+    expect(
+      canonicalizeWhatsAppDirectJids([
+        "15551230000:2@c.us",
+        "277038292303944_129:3@s.whatsapp.net",
+        "bad",
+        "15551230000@s.whatsapp.net",
+        "120363401234567890-123@g.us",
+      ]),
+    ).toEqual(["15551230000@s.whatsapp.net", "277038292303944@hosted.lid"]);
+  });
+});
+
+describe("areSameWhatsAppJid", () => {
+  it("compares decoded users within the same identity class", () => {
+    expect(areSameWhatsAppJid("15551230000:2@c.us", "15551230000@s.whatsapp.net")).toBe(true);
+    expect(areSameWhatsAppJid("277038292303944:2@lid", "277038292303944@lid")).toBe(true);
+    expect(areSameWhatsAppJid("15551230000@hosted", "15551230000@s.whatsapp.net")).toBe(true);
+    expect(areSameWhatsAppJid("277038292303944@hosted.lid", "277038292303944@lid")).toBe(true);
+    expect(areSameWhatsAppJid("123@s.whatsapp.net", "123@lid")).toBe(false);
+    expect(areSameWhatsAppJid("123@g.us", "123@newsletter")).toBe(false);
+    expect(areSameWhatsAppJid("bad", "bad")).toBe(false);
+  });
+});

--- a/extensions/whatsapp/src/whatsapp-jid.ts
+++ b/extensions/whatsapp/src/whatsapp-jid.ts
@@ -1,0 +1,140 @@
+// Whatsapp plugin module owns canonical JID parsing and classification.
+import {
+  getServerFromDomainType,
+  isHostedLidUser,
+  isHostedPnUser,
+  isJidGroup,
+  isJidNewsletter,
+  isLidUser,
+  isPnUser,
+  jidDecode,
+  jidEncode,
+  WAJIDDomains,
+} from "baileys";
+import { parseWhatsAppJidSyntax } from "./whatsapp-jid-syntax.js";
+
+type WhatsAppJidServer = "s.whatsapp.net" | "hosted" | "lid" | "hosted.lid" | "g.us" | "newsletter";
+
+type ClassifiedWhatsAppJid<Kind extends string, Server extends string> = {
+  kind: Kind;
+  server: Server;
+  user: string;
+  jid: string;
+};
+
+export type WhatsAppDirectJid =
+  | ClassifiedWhatsAppJid<"pn", "s.whatsapp.net" | "hosted">
+  | ClassifiedWhatsAppJid<"lid", "lid" | "hosted.lid">;
+
+type WhatsAppRoomJid =
+  | ClassifiedWhatsAppJid<"group", "g.us">
+  | ClassifiedWhatsAppJid<"newsletter", "newsletter">;
+
+export type WhatsAppJid = WhatsAppDirectJid | WhatsAppRoomJid | { kind: "unsupported" };
+
+const UNSUPPORTED_JID = { kind: "unsupported" } as const;
+
+function classifyCanonicalJid(jid: string): WhatsAppJid {
+  const decoded = jidDecode(jid);
+  const user = decoded?.user;
+  if (!user) {
+    return UNSUPPORTED_JID;
+  }
+  if (isPnUser(jid) === true) {
+    return { kind: "pn", server: "s.whatsapp.net", user, jid: jidEncode(user, "s.whatsapp.net") };
+  }
+  if (isHostedPnUser(jid) === true) {
+    return { kind: "pn", server: "hosted", user, jid: jidEncode(user, "hosted") };
+  }
+  if (isLidUser(jid) === true) {
+    return { kind: "lid", server: "lid", user, jid: jidEncode(user, "lid") };
+  }
+  if (isHostedLidUser(jid) === true) {
+    return { kind: "lid", server: "hosted.lid", user, jid: jidEncode(user, "hosted.lid") };
+  }
+  if (isJidGroup(jid) === true) {
+    return { kind: "group", server: "g.us", user, jid: jidEncode(user, "g.us") };
+  }
+  if (isJidNewsletter(jid) === true) {
+    return { kind: "newsletter", server: "newsletter", user, jid: jidEncode(user, "newsletter") };
+  }
+  return UNSUPPORTED_JID;
+}
+
+export function classifyWhatsAppJid(value: string | null | undefined): WhatsAppJid {
+  const parsed = parseWhatsAppJidSyntax(value);
+  if (!parsed) {
+    return UNSUPPORTED_JID;
+  }
+  const decoded = jidDecode(parsed.input);
+  if (!decoded || decoded.user !== parsed.user) {
+    return UNSUPPORTED_JID;
+  }
+
+  let canonicalInput = parsed.input;
+  if (parsed.kind === "pn" || parsed.kind === "lid") {
+    const decodedServer = decoded.server === "c.us" ? "s.whatsapp.net" : decoded.server;
+    const domainServer = getServerFromDomainType(decodedServer, decoded.domainType as WAJIDDomains);
+    if (
+      decoded.domainType !== parsed.domainType ||
+      decoded.device !== parsed.device ||
+      domainServer !== parsed.server
+    ) {
+      return UNSUPPORTED_JID;
+    }
+    canonicalInput = jidEncode(parsed.user, parsed.server);
+  } else if (decoded.server !== parsed.server || decoded.device !== undefined) {
+    return UNSUPPORTED_JID;
+  }
+
+  // Syntax validation keeps Baileys' domain and device metadata intact until
+  // the canonical routing server is known; only then is device state removed.
+  const classified = classifyCanonicalJid(canonicalInput);
+  return classified.kind === parsed.kind ? classified : UNSUPPORTED_JID;
+}
+
+export function encodeWhatsAppJid(user: string, server: WhatsAppJidServer): string {
+  const parsed = parseWhatsAppJidSyntax(`${user}@${server}`);
+  if (!parsed || parsed.user !== user) {
+    throw new Error(`Invalid WhatsApp ${server} JID user`);
+  }
+  const classified = classifyWhatsAppJid(jidEncode(user, server));
+  if (classified.kind === "unsupported") {
+    throw new Error(`Invalid WhatsApp ${server} JID user`);
+  }
+  return classified.jid;
+}
+
+export function classifyWhatsAppDirectJid(
+  value: string | null | undefined,
+): WhatsAppDirectJid | null {
+  const classified = classifyWhatsAppJid(value);
+  return classified.kind === "pn" || classified.kind === "lid" ? classified : null;
+}
+
+export function canonicalizeWhatsAppDirectJids(
+  values: ReadonlyArray<string | null | undefined>,
+): string[] {
+  const canonical = new Set<string>();
+  for (const value of values) {
+    const classified = classifyWhatsAppDirectJid(value);
+    if (classified) {
+      canonical.add(classified.jid);
+    }
+  }
+  return [...canonical];
+}
+
+export function areSameWhatsAppJid(
+  left: string | null | undefined,
+  right: string | null | undefined,
+): boolean {
+  const leftJid = classifyWhatsAppJid(left);
+  const rightJid = classifyWhatsAppJid(right);
+  if (leftJid.kind === "unsupported" || rightJid.kind === "unsupported") {
+    return false;
+  }
+  // Baileys cleanMessage collapses hosted routing domains into their standard
+  // PN/LID form. Cross-class PN/LID equality still requires a verified mapping.
+  return leftJid.kind === rightJid.kind && leftJid.user === rightJid.user;
+}

--- a/src/channels/plugins/doctor-contract-api.ts
+++ b/src/channels/plugins/doctor-contract-api.ts
@@ -6,14 +6,7 @@
 import type { LegacyConfigRule } from "../../config/legacy.shared.js";
 import type { OpenClawConfig } from "../../config/types.js";
 import { loadBundledPluginPublicArtifactModuleSync } from "../../plugins/public-surface-loader.js";
-
-/**
- * Config returned after a bundled channel normalizes legacy compatibility state.
- */
-type BundledChannelDoctorCompatibilityMutation = {
-  config: OpenClawConfig;
-  changes: string[];
-};
+import type { ChannelDoctorConfigMutation } from "./types.adapters.js";
 
 /**
  * Public doctor hooks exported by bundled channel plugins.
@@ -23,9 +16,7 @@ type BundledChannelDoctorCompatibilityMutation = {
  */
 type BundledChannelDoctorContractApi = {
   legacyConfigRules?: readonly LegacyConfigRule[];
-  normalizeCompatibilityConfig?: (params: {
-    cfg: OpenClawConfig;
-  }) => BundledChannelDoctorCompatibilityMutation;
+  normalizeCompatibilityConfig?: (params: { cfg: OpenClawConfig }) => ChannelDoctorConfigMutation;
 };
 
 /**

--- a/src/commands/doctor-config-flow.test.ts
+++ b/src/commands/doctor-config-flow.test.ts
@@ -19,6 +19,9 @@ const callGatewayMock = vi.hoisted(() => vi.fn());
 const runDoctorRepairSequenceMock = vi.hoisted(() => vi.fn());
 const runDoctorConfigPreflightOptionsMock = vi.hoisted(() => vi.fn());
 const collectDoctorPreviewNotesParamsMock = vi.hoisted(() => vi.fn());
+const applyChannelDoctorCompatibilityMigrationsMock = vi.hoisted(() =>
+  vi.fn((cfg: Record<string, unknown>) => ({ next: cfg, changes: [], warnings: [] as string[] })),
+);
 const collectImplicitFallbackClobberWarningsMock = vi.hoisted(() =>
   vi.fn<(cfg: unknown) => string[]>(() => []),
 );
@@ -634,10 +637,8 @@ vi.mock("../channels/plugins/setup-promotion-helpers.js", () => {
 });
 
 vi.mock("./doctor/shared/channel-legacy-config-migrate.js", () => ({
-  applyChannelDoctorCompatibilityMigrations: (cfg: Record<string, unknown>) => ({
-    next: cfg,
-    changes: [],
-  }),
+  applyChannelDoctorCompatibilityMigrations: (cfg: Record<string, unknown>) =>
+    applyChannelDoctorCompatibilityMigrationsMock(cfg),
 }));
 
 vi.mock("./doctor/shared/legacy-config-migrate.js", () => ({
@@ -1536,6 +1537,29 @@ describe("doctor config flow", () => {
     collectImplicitFallbackClobberWarningsMock.mockReturnValue([]);
     noteImplicitFallbackClobberWarningsMock.mockClear();
     runDoctorConfigPreflightOptionsMock.mockClear();
+    applyChannelDoctorCompatibilityMigrationsMock.mockReset();
+    applyChannelDoctorCompatibilityMigrationsMock.mockImplementation((cfg) => ({
+      next: cfg,
+      changes: [],
+      warnings: [],
+    }));
+  });
+
+  it("shows exact WhatsApp compatibility warnings when no config can be migrated", async () => {
+    const warning =
+      'channels.whatsapp.allowFrom entry "15551239999@lid" was not migrated because no verified LID→PN mapping was found; replace it with the sender\'s E.164 number.';
+    applyChannelDoctorCompatibilityMigrationsMock.mockImplementationOnce((cfg) => ({
+      next: cfg,
+      changes: [],
+      warnings: [warning],
+    }));
+
+    await runDoctorConfigWithInput({
+      config: { channels: { whatsapp: { allowFrom: ["15551239999@lid"] } } },
+      run: loadAndMaybeMigrateDoctorConfig,
+    });
+
+    expect(terminalNoteMock).toHaveBeenCalledWith(warning, "Doctor warnings");
   });
 
   it("preserves invalid config for doctor repairs", async () => {

--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -251,6 +251,7 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
   const normalized = normalizeCompatibilityConfigValues(candidate, {
     blockedModelIdentities: blockedCodexModelIdentities,
   });
+  emitDoctorNotes({ note, warningNotes: normalized.warnings });
   if (normalized.changes.length > 0) {
     emitDoctorChangesPanel(normalized.changes, shouldRepair);
     ({ cfg, candidate, pendingChanges, fixHints } = applyDoctorConfigMutation({

--- a/src/commands/doctor-legacy-config.migrations.test.ts
+++ b/src/commands/doctor-legacy-config.migrations.test.ts
@@ -62,6 +62,7 @@ vi.mock("./doctor/shared/channel-legacy-config-migrate.js", () => ({
   applyChannelDoctorCompatibilityMigrations: (cfg: OpenClawConfig) => ({
     next: cfg,
     changes: [],
+    warnings: [],
   }),
 }));
 

--- a/src/commands/doctor/shared/channel-doctor.test.ts
+++ b/src/commands/doctor/shared/channel-doctor.test.ts
@@ -210,6 +210,25 @@ describe("channel doctor compatibility mutations", () => {
     expect(mocks.getBundledChannelSetupPlugin).not.toHaveBeenCalledWith("discord");
   });
 
+  it("preserves warning-only compatibility results without applying their config", () => {
+    const cfg = createMatrixEnabledConfig();
+    mockReadOnlyMatrixPlugin({
+      normalizeCompatibilityConfig: vi.fn(() => ({
+        config: { channels: { matrix: { enabled: false } } },
+        changes: [],
+        warnings: ["Matrix compatibility warning."],
+      })),
+    });
+
+    expect(collectChannelDoctorCompatibilityMutations(cfg as never)).toEqual([
+      {
+        config: cfg,
+        changes: [],
+        warnings: ["Matrix compatibility warning."],
+      },
+    ]);
+  });
+
   it("keeps unresolved SecretRef preview reads non-fatal", async () => {
     const collectPreviewWarnings = vi.fn(() => {
       normalizeResolvedSecretInputString({

--- a/src/commands/doctor/shared/channel-doctor.ts
+++ b/src/commands/doctor/shared/channel-doctor.ts
@@ -328,6 +328,9 @@ export function collectChannelDoctorCompatibilityMutations(
   for (const entry of listChannelDoctorEntries(channelIds, { cfg, env: options.env })) {
     const mutation = entry.doctor.normalizeCompatibilityConfig?.({ cfg: nextCfg });
     if (!mutation || mutation.changes.length === 0) {
+      if (mutation?.warnings?.length) {
+        mutations.push({ config: nextCfg, changes: [], warnings: mutation.warnings });
+      }
       continue;
     }
     mutations.push(mutation);

--- a/src/commands/doctor/shared/channel-legacy-config-migrate.test.ts
+++ b/src/commands/doctor/shared/channel-legacy-config-migrate.test.ts
@@ -68,6 +68,7 @@ describe("bundled channel legacy config migrations", () => {
                 },
               },
               changes: ["Normalized channels.slack via bundled doctor contract."],
+              warnings: ["Slack compatibility warning."],
             }),
           }
         : undefined,
@@ -90,6 +91,25 @@ describe("bundled channel legacy config migrations", () => {
     expect(nextChannels.slack?.streaming).toBe(true);
     expect(nextChannels.slack?.normalizedByBundledContract).toBe(true);
     expect(result.changes).toEqual(["Normalized channels.slack via bundled doctor contract."]);
+    expect(result.warnings).toEqual(["Slack compatibility warning."]);
+  });
+
+  it("preserves warning-only bundled channel results without applying their config", () => {
+    collectRelevantDoctorPluginIds.mockReturnValueOnce([]);
+    loadBundledChannelDoctorContractApi.mockReturnValueOnce({
+      normalizeCompatibilityConfig: ({ cfg }: { cfg: Record<string, unknown> }) => ({
+        config: { ...cfg, warningOnlyMutation: true },
+        changes: [],
+        warnings: ["Replace the unresolved channel identity manually."],
+      }),
+    });
+
+    const config = { channels: { whatsapp: { allowFrom: ["123@lid"] } } };
+    const result = applyChannelDoctorCompatibilityMigrations(config);
+
+    expect(result.next).toBe(config);
+    expect(result.changes).toEqual([]);
+    expect(result.warnings).toEqual(["Replace the unresolved channel identity manually."]);
   });
 
   it("normalizes legacy private-network aliases exposed through bundled contract surfaces", () => {
@@ -117,6 +137,7 @@ describe("bundled channel legacy config migrations", () => {
         "Moved channels.mattermost.allowPrivateNetwork → channels.mattermost.network.dangerouslyAllowPrivateNetwork (true).",
         "Moved channels.mattermost.accounts.work.allowPrivateNetwork → channels.mattermost.accounts.work.network.dangerouslyAllowPrivateNetwork (false).",
       ],
+      warnings: ["Mattermost compatibility warning."],
     });
 
     const result = applyChannelDoctorCompatibilityMigrations({
@@ -169,6 +190,7 @@ describe("bundled channel legacy config migrations", () => {
       "Moved channels.mattermost.allowPrivateNetwork → channels.mattermost.network.dangerouslyAllowPrivateNetwork (true).",
       "Moved channels.mattermost.accounts.work.allowPrivateNetwork → channels.mattermost.accounts.work.network.dangerouslyAllowPrivateNetwork (false).",
     ]);
+    expect(result.warnings).toEqual(["Mattermost compatibility warning."]);
   });
 
   it("applies plugin doctor normalizers for configured non-channel plugin entries", () => {
@@ -187,6 +209,7 @@ describe("bundled channel legacy config migrations", () => {
         },
       },
       changes: ["Configured plugins.entries.lossless-claw.llm.allowedModels."],
+      warnings: ["Review the remaining lossless-claw model entries."],
     });
 
     const config = {
@@ -210,5 +233,6 @@ describe("bundled channel legacy config migrations", () => {
       pluginIds: ["lossless-claw"],
     });
     expect(result.changes).toEqual(["Configured plugins.entries.lossless-claw.llm.allowedModels."]);
+    expect(result.warnings).toEqual(["Review the remaining lossless-claw model entries."]);
   });
 });

--- a/src/commands/doctor/shared/channel-legacy-config-migrate.ts
+++ b/src/commands/doctor/shared/channel-legacy-config-migrate.ts
@@ -1,6 +1,7 @@
 // Legacy config migration bridge for channel doctor compatibility contracts.
 import { getBootstrapChannelPlugin } from "../../../channels/plugins/bootstrap-registry.js";
 import { loadBundledChannelDoctorContractApi } from "../../../channels/plugins/doctor-contract-api.js";
+import type { ChannelDoctorConfigMutation } from "../../../channels/plugins/types.adapters.js";
 import type { OpenClawConfig } from "../../../config/types.js";
 import {
   applyPluginDoctorCompatibilityMigrations,
@@ -8,14 +9,9 @@ import {
 } from "../../../plugins/doctor-contract-registry.js";
 import { isRecord } from "./legacy-config-record-shared.js";
 
-type ChannelDoctorCompatibilityMutation = {
-  config: OpenClawConfig;
-  changes: string[];
-};
-
 type ChannelDoctorCompatibilityNormalizer = (params: {
   cfg: OpenClawConfig;
-}) => ChannelDoctorCompatibilityMutation;
+}) => ChannelDoctorConfigMutation;
 
 function collectRelevantDoctorChannelIds(raw: unknown): string[] {
   const channels = isRecord(raw) && isRecord(raw.channels) ? raw.channels : null;
@@ -57,9 +53,11 @@ function collectPluginDoctorCompatibilityIds(params: {
 export function applyChannelDoctorCompatibilityMigrations(cfg: Record<string, unknown>): {
   next: Record<string, unknown>;
   changes: string[];
+  warnings: string[];
 } {
   let nextCfg = cfg as OpenClawConfig;
   const changes: string[] = [];
+  const warnings: string[] = [];
   const unresolvedChannelIds: string[] = [];
 
   for (const channelId of collectRelevantDoctorChannelIds(cfg)) {
@@ -69,11 +67,14 @@ export function applyChannelDoctorCompatibilityMigrations(cfg: Record<string, un
       continue;
     }
     const mutation = normalizeCompatibilityConfig({ cfg: nextCfg });
-    if (!mutation || mutation.changes.length === 0) {
+    if (!mutation) {
       continue;
     }
-    nextCfg = mutation.config;
-    changes.push(...mutation.changes);
+    warnings.push(...(mutation.warnings ?? []));
+    if (mutation.changes.length > 0) {
+      nextCfg = mutation.config;
+      changes.push(...mutation.changes);
+    }
   }
 
   const pluginIds = collectPluginDoctorCompatibilityIds({ raw: cfg, unresolvedChannelIds });
@@ -84,10 +85,12 @@ export function applyChannelDoctorCompatibilityMigrations(cfg: Record<string, un
     });
     nextCfg = compat.config;
     changes.push(...compat.changes);
+    warnings.push(...compat.warnings);
   }
 
   return {
     next: nextCfg as OpenClawConfig & Record<string, unknown>,
     changes,
+    warnings,
   };
 }

--- a/src/commands/doctor/shared/legacy-config-core-migrate.ts
+++ b/src/commands/doctor/shared/legacy-config-core-migrate.ts
@@ -55,8 +55,10 @@ export function normalizeCompatibilityConfigValues(
 ): {
   config: OpenClawConfig;
   changes: string[];
+  warnings: string[];
 } {
   const changes: string[] = [];
+  const warnings: string[] = [];
   let next = normalizeBaseCompatibilityConfigValues(
     cfg,
     changes,
@@ -73,6 +75,7 @@ export function normalizeCompatibilityConfigValues(
     options.blockedModelIdentities,
   );
   const channelMigrations = applyChannelDoctorCompatibilityMigrations(next);
+  warnings.push(...channelMigrations.warnings);
   if (channelMigrations.changes.length > 0) {
     next = channelMigrations.next;
     changes.push(...channelMigrations.changes);
@@ -86,5 +89,5 @@ export function normalizeCompatibilityConfigValues(
   next = repairNullAgentWorkspaces(next, changes);
   next = pruneBindingsForMissingAgents(next, changes);
 
-  return { config: next, changes };
+  return { config: next, changes, warnings };
 }

--- a/src/commands/doctor/shared/missing-configured-plugin-install.test.ts
+++ b/src/commands/doctor/shared/missing-configured-plugin-install.test.ts
@@ -202,6 +202,7 @@ vi.mock("../../../plugins/doctor-contract-registry.js", async (importOriginal) =
   applyPluginDoctorCompatibilityMigrations: (cfg: OpenClawConfig) => ({
     config: cfg,
     changes: [],
+    warnings: [],
   }),
 }));
 
@@ -242,6 +243,7 @@ vi.mock("../../../plugins/doctor-contract-registry.js", async (importOriginal) =
     applyPluginDoctorCompatibilityMigrations: (cfg: OpenClawConfig) => ({
       config: cfg,
       changes: [],
+      warnings: [],
     }),
   };
 });

--- a/src/config/io.write-config.test.ts
+++ b/src/config/io.write-config.test.ts
@@ -70,7 +70,11 @@ vi.mock("../plugins/doctor-contract-registry.js", async (importOriginal) => {
   return {
     ...actual,
     listPluginDoctorLegacyConfigRules: () => [],
-    applyPluginDoctorCompatibilityMigrations: () => ({ next: null, changes: [] }),
+    applyPluginDoctorCompatibilityMigrations: (config: OpenClawConfig) => ({
+      config,
+      changes: [],
+      warnings: [],
+    }),
   };
 });
 

--- a/src/config/validation.channel-metadata.test.ts
+++ b/src/config/validation.channel-metadata.test.ts
@@ -3,6 +3,7 @@
 import { expectDefined } from "@openclaw/normalization-core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { PluginManifestRecord, PluginManifestRegistry } from "../plugins/manifest-registry.js";
+import type { OpenClawConfig } from "./types.openclaw.js";
 import {
   validateConfigObjectRawWithPlugins,
   validateConfigObjectWithPlugins,
@@ -240,7 +241,11 @@ vi.mock("../plugins/plugin-metadata-snapshot.js", () => ({
 vi.mock("../plugins/doctor-contract-registry.js", () => ({
   collectRelevantDoctorPluginIds: () => [],
   listPluginDoctorLegacyConfigRules: () => [],
-  applyPluginDoctorCompatibilityMigrations: () => ({ next: null, changes: [] }),
+  applyPluginDoctorCompatibilityMigrations: (config: OpenClawConfig) => ({
+    config,
+    changes: [],
+    warnings: [],
+  }),
 }));
 
 vi.mock("../secrets/target-registry-data.js", () => ({

--- a/src/plugins/doctor-contract-registry.test.ts
+++ b/src/plugins/doctor-contract-registry.test.ts
@@ -437,6 +437,7 @@ describe("doctor-contract-registry module loader", () => {
           },
         },
         changes: ["normalized ollama cloud provider endpoint"],
+        warnings: ["review the remaining ollama cloud settings"],
       }),
     }));
     mocks.loadPluginManifestRegistry.mockReturnValue({
@@ -468,10 +469,38 @@ describe("doctor-contract-registry module loader", () => {
     });
 
     expect(result.changes).toEqual(["normalized ollama cloud provider endpoint"]);
+    expect(result.warnings).toEqual(["review the remaining ollama cloud settings"]);
     expect(result.config.models?.providers?.["ollama-cloud"]).toEqual({
       baseUrl: "https://ollama.com",
       models: [],
     });
+  });
+
+  it("preserves warning-only plugin compatibility results without applying their config", () => {
+    const pluginRoot = makeTempDir();
+    fs.writeFileSync(path.join(pluginRoot, "doctor-contract-api.ts"), "export {};\n", "utf-8");
+    mocks.createJiti.mockImplementation(() => () => ({
+      normalizeCompatibilityConfig: ({ cfg }: { cfg: Record<string, unknown> }) => ({
+        config: { ...cfg, gateway: { mode: "local" as const } },
+        changes: [],
+        warnings: ["replace the unresolved plugin identity manually"],
+      }),
+    }));
+    mocks.loadPluginManifestRegistry.mockReturnValue({
+      plugins: [{ id: "warning-only", rootDir: pluginRoot, channels: ["warning-only"] }],
+      diagnostics: [],
+    });
+    const config = { channels: { "warning-only": {} } };
+
+    const result = applyPluginDoctorCompatibilityMigrations(config, {
+      config,
+      env: {},
+      pluginIds: ["warning-only"],
+    });
+
+    expect(result.config).toBe(config);
+    expect(result.changes).toEqual([]);
+    expect(result.warnings).toEqual(["replace the unresolved plugin identity manually"]);
   });
 
   it("narrows touched-path doctor ids for scoped dry-run validation", () => {

--- a/src/plugins/doctor-contract-registry.ts
+++ b/src/plugins/doctor-contract-registry.ts
@@ -34,6 +34,7 @@ type PluginDoctorContractModule = {
 type PluginDoctorCompatibilityMutation = {
   config: OpenClawConfig;
   changes: string[];
+  warnings?: string[];
 };
 
 type PluginDoctorCompatibilityNormalizer = (params: {
@@ -517,16 +518,21 @@ export function applyPluginDoctorCompatibilityMigrations(
 ): {
   config: OpenClawConfig;
   changes: string[];
+  warnings: string[];
 } {
   let nextCfg = cfg;
   const changes: string[] = [];
+  const warnings: string[] = [];
   for (const entry of resolvePluginDoctorContracts(params)) {
     const mutation = entry.normalizeCompatibilityConfig?.({ cfg: nextCfg });
-    if (!mutation || mutation.changes.length === 0) {
+    if (!mutation) {
       continue;
     }
-    nextCfg = mutation.config;
-    changes.push(...mutation.changes);
+    warnings.push(...(mutation.warnings ?? []));
+    if (mutation.changes.length > 0) {
+      nextCfg = mutation.config;
+      changes.push(...mutation.changes);
+    }
   }
-  return { config: nextCfg, changes };
+  return { config: nextCfg, changes, warnings };
 }


### PR DESCRIPTION
## What Problem This Solves

WhatsApp JID semantics were independently implemented across target normalization, ingress, allowlists, mentions, approvals, identities, sessions, and quote lookup. Those implementations disagreed about hosted identities and device-qualified JIDs, so the same sender could be accepted by ingress but rejected or compared differently elsewhere.

Stable releases also accepted LID-form `allowFrom` entries. The canonical E.164 policy now rejects those entries, so upgrades need an explicit, fail-closed migration rather than silently changing authorization.

## Why This Change Was Made

This introduces one typed WhatsApp JID classifier backed by Baileys' public JID parser, encoder, normalizer, and domain classifiers. The WhatsApp plugin now uses that owner for PN, LID, hosted PN/LID, group, newsletter, device stripping, and `c.us` normalization.

WhatsApp application policy remains layered above the protocol parser:

- target prefixes and E.164 allowlist rules stay plugin-owned;
- PN/LID equality still requires a verified mapping and never uses same-digit inference;
- group/session identifiers persist canonical group JIDs;
- setup auth checks remain dependency-light, and setup/runtime share one allowlist formatter;
- quote lookup is pure over cached identity facts;
- inbound delivery uses Baileys' prepared `remoteJidAlt` when present and never performs optional PN-to-LID discovery before enqueueing;
- `openclaw doctor --fix` migrates shipped LID-form allowlist entries only when the owning account has a verified mapping. Root entries require the same mapping in every account inheriting the root allowlist. Missing or conflicting mappings stay unchanged and produce warnings.

The branch is rebased onto current `main`. Main's setup cleanup, implicit-mention policy, and persistent inbound replay protection are preserved.

The change is confined to `extensions/whatsapp/**`. It does not change core or Plugin SDK source, contracts, exports, or configuration surfaces.

## User Impact

Hosted identities, device-qualified JIDs, groups, newsletters, mentions, approvals, quote matching, and PN/LID mappings now follow one canonical domain model.

Inbound delivery and read receipts are no longer delayed by optional PN-to-LID alias discovery. Existing LID allowlists fail closed on upgrade: verified entries become E.164 numbers, while unresolved or ambiguous entries are retained for operator repair with a clear doctor warning.

## Evidence

- Focused latest-main proof: 4 files, 177 tests passed.
- Broader WhatsApp proof: 9 files, 215 tests passed.
- `pnpm tsgo:extensions`: passed.
- `pnpm tsgo:extensions:test`: passed.
- `pnpm check:changed`: passed, including formatting, extension lint, dependency/export guards, package boundaries, database-first storage guard, and runtime cycle checks.
- `pnpm build`: passed, including bundled plugin assets, CLI bootstrap guards, Plugin SDK export verification, runtime post-build checks, and Control UI build/performance checks.
- Autoreview accepted and fixed the cross-account migration risk. The final remaining suggestion was rejected because it would restore optional PN-to-LID discovery when Baileys supplied no alternate identity—the hot-path behavior this change explicitly removes. PN targets continue to match the verified cached E.164, and LID targets match the canonical LID.
- Blacksmith Testbox: `tbx_01kxpr1vk57gzsj92cv1se1he2` (`golden-lobster`).
- Testbox run: https://github.com/openclaw/openclaw/actions/runs/29545249060
