### PR TITLE
fix(agents): forward agent/session/run identity to tool-result middleware

### DIFF
--- a/config/knip.config.ts
+++ b/config/knip.config.ts
@@ -82,6 +82,7 @@ const repositoryScriptEntries = [
   "scripts/verify-stable-main-closeout.mjs!",
   "scripts/write-package-dist-inventory.ts!",
   "scripts/write-plugin-sdk-entry-dts.ts!",
+  "scripts/proof-tool-result-middleware-identity.mjs!",
   "security/opengrep/check-rule-metadata.mjs!",
   "security/opengrep/compile-rules.mjs!",
   "skills/meme-maker/scripts/meme.mjs!",

--- a/scripts/proof-tool-result-middleware-identity.mjs
+++ b/scripts/proof-tool-result-middleware-identity.mjs
@@ -1,0 +1,103 @@
+/**
+ * Runtime proof for openclaw/openclaw#107000.
+ * Registers an installed AgentToolResultMiddleware, builds embedded extension
+ * factories with agent/session/run identity, fires a tool_result event, and
+ * prints the identity fields the middleware actually received.
+ *
+ * Run: node --import tsx scripts/proof-tool-result-middleware-identity.mjs
+ */
+import { SessionManager } from "openclaw/plugin-sdk/agent-sessions";
+import { buildEmbeddedExtensionFactories } from "../src/agents/embedded-agent-runner/extensions.ts";
+import { createEmptyPluginRegistry } from "../src/plugins/registry.ts";
+import { setActivePluginRegistry } from "../src/plugins/runtime.ts";
+
+const observed = [];
+
+const registry = createEmptyPluginRegistry();
+registry.agentToolResultMiddlewares.push({
+  pluginId: "proof-identity",
+  pluginName: "proof-identity",
+  rawHandler: () => undefined,
+  handler: (event, ctx) => {
+    observed.push({
+      toolName: event.toolName,
+      toolCallId: event.toolCallId,
+      runtime: ctx.runtime,
+      agentId: ctx.agentId,
+      sessionId: ctx.sessionId,
+      sessionKey: ctx.sessionKey,
+      runId: ctx.runId,
+    });
+    return {
+      result: {
+        content: [{ type: "text", text: "middleware-ok" }],
+        details: {},
+      },
+    };
+  },
+  runtimes: ["openclaw"],
+  source: "proof",
+});
+setActivePluginRegistry(registry);
+
+const sessionManager = SessionManager.inMemory();
+const factories = buildEmbeddedExtensionFactories({
+  cfg: undefined,
+  sessionManager,
+  provider: "openai",
+  modelId: "gpt-5.4",
+  model: undefined,
+  runId: "run-proof-107000",
+  agentId: "main",
+  sessionId: "session-proof-107000",
+  sessionKey: "agent:main:chat",
+});
+
+if (!factories.length) {
+  console.error("FAIL: no extension factories");
+  process.exit(1);
+}
+
+const handlers = new Map();
+await factories[0]({
+  on(event, handler) {
+    handlers.set(event, handler);
+  },
+});
+
+const toolResult = handlers.get("tool_result");
+if (!toolResult) {
+  console.error("FAIL: no tool_result handler");
+  process.exit(1);
+}
+
+const result = await toolResult(
+  {
+    toolName: "read",
+    toolCallId: "call-proof-1",
+    content: [{ type: "text", text: "raw" }],
+    details: {},
+  },
+  { cwd: "/tmp" },
+);
+
+console.log("INSTALLED middleware observations:");
+console.log(JSON.stringify(observed, null, 2));
+console.log("handler result content:", JSON.stringify(result?.content ?? result));
+
+const ctx = observed[0];
+const ok =
+  ctx &&
+  ctx.runtime === "openclaw" &&
+  ctx.agentId === "main" &&
+  ctx.sessionId === "session-proof-107000" &&
+  ctx.sessionKey === "agent:main:chat" &&
+  ctx.runId === "run-proof-107000" &&
+  ctx.toolName === "read";
+
+console.log(
+  ok
+    ? "RESULT: PASS — installed middleware received agent/session/run identity"
+    : "RESULT: FAIL — missing identity fields",
+);
+process.exit(ok ? 0 : 1);

--- a/src/agents/embedded-agent-runner/compact.ts
+++ b/src/agents/embedded-agent-runner/compact.ts
@@ -1449,6 +1449,10 @@ async function compactEmbeddedAgentSessionDirectOnce(
         provider,
         modelId,
         model: effectiveModel,
+        runId: params.runId ?? params.sessionId,
+        agentId: sessionAgentId,
+        sessionId: params.sessionId,
+        sessionKey: params.sessionKey ?? params.sandboxSessionKey,
       });
       const resourceLoader = createEmbeddedAgentResourceLoader({
         cwd: effectiveCwd,

--- a/src/agents/embedded-agent-runner/extensions.test.ts
+++ b/src/agents/embedded-agent-runner/extensions.test.ts
@@ -19,6 +19,17 @@ vi.mock("../../plugins/provider-hook-runtime.js", () => ({
   resolveProviderRuntimePlugin: () => undefined,
 }));
 
+const createAgentToolResultMiddlewareRunnerMock = vi.hoisted(() =>
+  vi.fn((ctx: { runtime: string }) => ({
+    applyToolResultMiddleware: async (event: { result: unknown }) => event.result,
+    context: ctx,
+  })),
+);
+
+vi.mock("../harness/tool-result-middleware.js", () => ({
+  createAgentToolResultMiddlewareRunner: createAgentToolResultMiddlewareRunnerMock,
+}));
+
 function buildSafeguardFactories(cfg: OpenClawConfig, workspaceDir?: string) {
   // The safeguard runtime attaches to the session manager, so tests keep the
   // same manager instance around for both factory construction and inspection.
@@ -144,5 +155,54 @@ describe("buildEmbeddedExtensionFactories", () => {
     });
 
     expect(factories).toContain(contextPruningExtension);
+  });
+
+  it("forwards agent/session/run identity into OpenClaw tool-result middleware context", () => {
+    createAgentToolResultMiddlewareRunnerMock.mockClear();
+    const sessionManager = {
+      getSessionId: () => "session-from-manager",
+    } as SessionManager;
+
+    buildEmbeddedExtensionFactories({
+      cfg: undefined,
+      sessionManager,
+      provider: "anthropic",
+      modelId: "claude-sonnet-4-20250514",
+      model: { id: "claude-sonnet-4-20250514", contextWindow: 200_000 } as Model,
+      runId: "run-abc",
+      agentId: "main",
+      sessionId: "session-explicit",
+      sessionKey: "agent:main:discord:group:1",
+    });
+
+    expect(createAgentToolResultMiddlewareRunnerMock).toHaveBeenCalledWith({
+      runtime: "openclaw",
+      agentId: "main",
+      sessionId: "session-explicit",
+      sessionKey: "agent:main:discord:group:1",
+      runId: "run-abc",
+    });
+  });
+
+  it("falls back to SessionManager.getSessionId when sessionId is omitted", () => {
+    createAgentToolResultMiddlewareRunnerMock.mockClear();
+    const sessionManager = {
+      getSessionId: () => "session-from-manager",
+    } as SessionManager;
+
+    buildEmbeddedExtensionFactories({
+      cfg: undefined,
+      sessionManager,
+      provider: "anthropic",
+      modelId: "claude-sonnet-4-20250514",
+      model: { id: "claude-sonnet-4-20250514", contextWindow: 200_000 } as Model,
+      runId: "run-def",
+    });
+
+    expect(createAgentToolResultMiddlewareRunnerMock).toHaveBeenCalledWith({
+      runtime: "openclaw",
+      sessionId: "session-from-manager",
+      runId: "run-def",
+    });
   });
 });

--- a/src/agents/embedded-agent-runner/extensions.ts
+++ b/src/agents/embedded-agent-runner/extensions.ts
@@ -52,9 +52,24 @@ function snapshotToolSendReceipt(details: unknown): unknown {
 
 function buildAgentToolResultMiddlewareFactory(
   sessionManager: SessionManager,
-  runId?: string,
+  context?: {
+    runId?: string;
+    agentId?: string;
+    sessionId?: string;
+    sessionKey?: string;
+  },
 ): ExtensionFactory {
-  const runner = createAgentToolResultMiddlewareRunner({ runtime: "openclaw" });
+  const runId = context?.runId;
+  const sessionIdFromManager =
+    typeof sessionManager.getSessionId === "function" ? sessionManager.getSessionId() : undefined;
+  const sessionId = context?.sessionId ?? sessionIdFromManager;
+  const runner = createAgentToolResultMiddlewareRunner({
+    runtime: "openclaw",
+    ...(context?.agentId ? { agentId: context.agentId } : {}),
+    ...(sessionId ? { sessionId } : {}),
+    ...(context?.sessionKey ? { sessionKey: context.sessionKey } : {}),
+    ...(runId ? { runId } : {}),
+  });
   return (agent) => {
     agent.on("tool_result", async (rawEvent: unknown, ctx: { cwd?: string }) => {
       const event = recordFromUnknown(rawEvent) as AgentToolResultEvent;
@@ -179,6 +194,9 @@ export function buildEmbeddedExtensionFactories(params: {
   modelId: string;
   model: ProviderRuntimeModel | undefined;
   runId?: string;
+  agentId?: string;
+  sessionId?: string;
+  sessionKey?: string;
 }): ExtensionFactory[] {
   const factories: ExtensionFactory[] = [];
   if (resolveEffectiveCompactionMode(params.cfg) === "safeguard") {
@@ -212,6 +230,13 @@ export function buildEmbeddedExtensionFactories(params: {
   if (pruningFactory) {
     factories.push(pruningFactory);
   }
-  factories.push(buildAgentToolResultMiddlewareFactory(params.sessionManager, params.runId));
+  factories.push(
+    buildAgentToolResultMiddlewareFactory(params.sessionManager, {
+      runId: params.runId,
+      agentId: params.agentId,
+      sessionId: params.sessionId,
+      sessionKey: params.sessionKey,
+    }),
+  );
   return factories;
 }

--- a/src/agents/embedded-agent-runner/run/attempt-session.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-session.ts
@@ -83,6 +83,9 @@ export async function prepareEmbeddedAttemptAgentSession(input: {
     modelId: attempt.modelId,
     model: attempt.model,
     runId: attempt.runId,
+    agentId: input.sessionAgentId ?? attempt.agentId,
+    sessionId: attempt.sessionId,
+    sessionKey: attempt.sessionKey ?? attempt.sandboxSessionKey,
   });
   const resourceLoader = createEmbeddedAgentResourceLoader({
     cwd: input.effectiveCwd,


### PR DESCRIPTION
Closes #106910

## What Problem This Solves

Fixes an issue where installed `AgentToolResultMiddleware` handlers on the
OpenClaw embedded runtime never received `agentId`, `sessionId`,
`sessionKey`, or `runId`, even though those fields are part of the public
middleware context and the Codex path already forwards them. Middleware
used for audit, telemetry, or session-scoped policy therefore could not
attribute OpenClaw tool-result events.

## Why This Change Was Made

`buildAgentToolResultMiddlewareFactory` constructed
`createAgentToolResultMiddlewareRunner({ runtime: "openclaw" })` only.
Pass agent/session/run identity from the embedded attempt (and compact)
call sites into that runner, matching the Codex `toToolResultHookContext`
shape. Fall back to `SessionManager.getSessionId()` when an explicit
session id is not provided.

## User Impact

Installed middleware that declares OpenClaw runtime support can now see
the same agent/session/run identity fields on OpenClaw tool results that
it already receives on Codex.

## Evidence

Installed middleware observed identity fields during an embedded OpenClaw
tool_result event (production buildEmbeddedExtensionFactories path):

```console
$ node --import tsx scripts/proof-tool-result-middleware-identity.mjs
[state/db] state database schema migration pending; verifying integrity first
INSTALLED middleware observations:
[
  {
    "toolName": "read",
    "toolCallId": "call-proof-1",
    "runtime": "openclaw",
    "agentId": "main",
    "sessionId": "session-proof-107000",
    "sessionKey": "agent:main:chat",
    "runId": "run-proof-107000"
  }
]
handler result content: [{"type":"text","text":"middleware-ok"}]
RESULT: PASS — installed middleware received agent/session/run identity
```

Factory-level regression tests still cover explicit context construction and
SessionManager sessionId fallback.


## Real behavior proof

Behavior addressed: Installed AgentToolResultMiddleware handlers on the OpenClaw embedded runtime never received agentId/sessionId/sessionKey/runId; they now receive the same identity fields as Codex.

Real environment tested: macOS darwin arm64, worktree /tmp/oc-proof-107000 on branch fix/tool-result-middleware-context rebased onto current upstream/main, Node via node --import tsx.

Exact steps or command run after this patch:
```bash
cd /tmp/oc-proof-107000
CI=true pnpm install --frozen-lockfile
node --import tsx scripts/proof-tool-result-middleware-identity.mjs
```

Evidence after fix: terminal output copied below.

```console
[state/db] state database schema migration pending; verifying integrity first
INSTALLED middleware observations:
[
  {
    "toolName": "read",
    "toolCallId": "call-proof-1",
    "runtime": "openclaw",
    "agentId": "main",
    "sessionId": "session-proof-107000",
    "sessionKey": "agent:main:chat",
    "runId": "run-proof-107000"
  }
]
handler result content: [{"type":"text","text":"middleware-ok"}]
RESULT: PASS — installed middleware received agent/session/run identity
```

Observed result after fix: The installed plugin middleware handler received runtime=openclaw, agentId=main, sessionId=session-proof-107000, sessionKey=agent:main:chat, runId=run-proof-107000 for a real tool_result event dispatched through the embedded extension factory.

What was not tested: Full gateway Discord/WhatsApp turn with a published marketplace middleware package (plugin registry path was exercised via createEmptyPluginRegistry + setActivePluginRegistry).


## Summary

- Thread agentId/sessionId/sessionKey/runId into OpenClaw tool-result middleware context
- Wire from `prepareEmbeddedAttemptAgentSession` and compact
- Regression tests for explicit context and SessionManager fallback

