### PR TITLE
💚 fix(plugins): fully restore failed registration state

### DIFF
--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -2327,7 +2327,10 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
           if (registrationMode === "setup-runtime") {
             const registerSetupRuntime = mergedSetupRegistration.registerSetupRuntime;
             if (registerSetupRuntime) {
-              const transaction = createPluginRegistrationTransaction({ registry });
+              const transaction = createPluginRegistrationTransaction({
+                registry,
+                currentRecord: record,
+              });
               try {
                 runPluginRegisterSync(
                   (registrationApi) => registerSetupRuntime(registrationApi),
@@ -2474,6 +2477,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
       });
       const transaction = createPluginRegistrationTransaction({
         registry,
+        currentRecord: record,
         rollbackGlobalSideEffects: () => rollbackPluginGlobalSideEffects(record.id),
       });
 
@@ -2950,7 +2954,7 @@ export async function loadOpenClawPluginCliRegistry(
       },
     });
 
-    const transaction = createPluginRegistrationTransaction({ registry });
+    const transaction = createPluginRegistrationTransaction({ registry, currentRecord: record });
     try {
       withProfile({ pluginId: record.id, source: record.source }, "cli-metadata:register", () =>
         runPluginRegisterSync(register, api),

--- a/src/plugins/plugin-registration-transaction.test.ts
+++ b/src/plugins/plugin-registration-transaction.test.ts
@@ -10,6 +10,7 @@ import {
   snapshotPluginProcessGlobalState,
 } from "./plugin-registration-transaction.js";
 import { createEmptyPluginRegistry } from "./registry-empty.js";
+import { createPluginRecord } from "./status.test-helpers.js";
 
 describe("plugin registration transaction", () => {
   let initialProcessGlobalState: PluginProcessGlobalState;
@@ -50,6 +51,51 @@ describe("plugin registration transaction", () => {
       pluginId: "active-memory",
       capability: { promptBuilder: activePromptBuilder },
     });
+  });
+
+  it("restores the current record after a failed registration", () => {
+    const registry = createEmptyPluginRegistry();
+    const record = createPluginRecord({ id: "failed-plugin" });
+    const toolNames = record.toolNames;
+
+    const transaction = createPluginRegistrationTransaction({ registry, currentRecord: record });
+    record.httpRoutes += 1;
+    record.hookCount += 1;
+    record.toolNames.push("failed-tool");
+    record.contextEngineIds = ["failed-engine"];
+    record.error = "failed registration";
+
+    transaction.rollback();
+
+    expect(registry.plugins).toEqual([]);
+    expect(record.httpRoutes).toBe(0);
+    expect(record.hookCount).toBe(0);
+    expect(record.toolNames).toEqual([]);
+    expect(record.toolNames).not.toBe(toolNames);
+    expect(record.contextEngineIds).toEqual([]);
+    expect(record).not.toHaveProperty("error");
+  });
+
+  it("restores in-place mutations to existing registry entries", () => {
+    const registry = createEmptyPluginRegistry();
+    const rawHandler = async () => undefined;
+    registry.agentToolResultMiddlewares.push({
+      pluginId: "existing-plugin",
+      handler: rawHandler,
+      rawHandler,
+      runtimes: ["openclaw"],
+    });
+    const originalEntry = registry.agentToolResultMiddlewares[0];
+
+    const transaction = createPluginRegistrationTransaction({ registry });
+    originalEntry.runtimes.push("codex");
+
+    transaction.rollback();
+
+    expect(registry.agentToolResultMiddlewares).toHaveLength(1);
+    expect(registry.agentToolResultMiddlewares[0]).not.toBe(originalEntry);
+    expect(registry.agentToolResultMiddlewares[0]?.rawHandler).toBe(rawHandler);
+    expect(registry.agentToolResultMiddlewares[0]?.runtimes).toEqual(["openclaw"]);
   });
 
   it("keeps snapshot registry writes while restoring globals for non-activating commits", () => {

--- a/src/plugins/plugin-registration-transaction.test.ts
+++ b/src/plugins/plugin-registration-transaction.test.ts
@@ -84,8 +84,9 @@ describe("plugin registration transaction", () => {
       handler: rawHandler,
       rawHandler,
       runtimes: ["openclaw"],
+      source: "test",
     });
-    const originalEntry = registry.agentToolResultMiddlewares[0];
+    const originalEntry = registry.agentToolResultMiddlewares[0]!;
 
     const transaction = createPluginRegistrationTransaction({ registry });
     originalEntry.runtimes.push("codex");

--- a/src/plugins/plugin-registration-transaction.ts
+++ b/src/plugins/plugin-registration-transaction.ts
@@ -30,7 +30,7 @@ import {
   listMemoryPromptSupplements,
   restoreMemoryPluginState,
 } from "./memory-state.js";
-import type { PluginRegistry } from "./registry-types.js";
+import type { PluginRecord, PluginRegistry } from "./registry-types.js";
 
 export type PluginProcessGlobalState = {
   agentHarnesses: ReturnType<typeof listRegisteredAgentHarnesses>;
@@ -75,25 +75,103 @@ export function restorePluginProcessGlobalState(state: PluginProcessGlobalState)
   });
 }
 
-function snapshotPluginRegistry(registry: PluginRegistry): PluginRegistry {
-  return Object.fromEntries(
-    Object.entries(registry).map(([key, value]) => {
-      if (Array.isArray(value)) {
-        return [key, [...value]];
-      }
-      if (value instanceof Map) {
-        return [key, new Map(value)];
-      }
-      if (value && typeof value === "object") {
-        return [key, { ...value }];
-      }
-      return [key, value];
-    }),
-  ) as PluginRegistry;
+type ObjectStateSnapshot = Map<PropertyKey, PropertyDescriptor>;
+
+type PluginRecordSnapshot = {
+  record: PluginRecord;
+  state: ObjectStateSnapshot;
+};
+
+type PluginRegistrySnapshot = {
+  registry: PluginRegistry;
+  pluginRecords: PluginRecordSnapshot[];
+};
+
+function cloneMutablePropertyValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return [...value];
+  }
+  if (value instanceof Date) {
+    return new Date(value);
+  }
+  return value;
 }
 
-function restorePluginRegistry(registry: PluginRegistry, snapshot: PluginRegistry): void {
-  Object.assign(registry, snapshot);
+function snapshotObjectState(value: object): ObjectStateSnapshot {
+  return new Map(
+    Reflect.ownKeys(value).map((key) => {
+      const descriptor = Object.getOwnPropertyDescriptor(value, key);
+      if (!descriptor) {
+        throw new Error(`missing property descriptor for ${String(key)}`);
+      }
+      return [
+        key,
+        "value" in descriptor
+          ? { ...descriptor, value: cloneMutablePropertyValue(descriptor.value) }
+          : descriptor,
+      ];
+    }),
+  );
+}
+
+function restoreObjectState(value: object, snapshot: ObjectStateSnapshot): void {
+  for (const key of Reflect.ownKeys(value)) {
+    if (!snapshot.has(key)) {
+      Reflect.deleteProperty(value, key);
+    }
+  }
+  for (const [key, descriptor] of snapshot) {
+    Object.defineProperty(
+      value,
+      key,
+      "value" in descriptor
+        ? { ...descriptor, value: cloneMutablePropertyValue(descriptor.value) }
+        : descriptor,
+    );
+  }
+}
+
+function cloneRegistryArrayEntry<T>(entry: T): T {
+  if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+    return entry;
+  }
+  const clone = Object.create(Object.getPrototypeOf(entry));
+  restoreObjectState(clone, snapshotObjectState(entry));
+  return clone as T;
+}
+
+function snapshotPluginRegistry(
+  registry: PluginRegistry,
+  currentRecord?: PluginRecord,
+): PluginRegistrySnapshot {
+  const records = currentRecord ? [...registry.plugins, currentRecord] : registry.plugins;
+  return {
+    registry: Object.fromEntries(
+      Object.entries(registry).map(([key, value]) => {
+        if (Array.isArray(value)) {
+          return [key, value.map((entry) => cloneRegistryArrayEntry(entry))];
+        }
+        if (value instanceof Map) {
+          return [key, new Map(value)];
+        }
+        if (value && typeof value === "object") {
+          return [key, cloneRegistryArrayEntry(value)];
+        }
+        return [key, value];
+      }),
+    ) as PluginRegistry,
+    pluginRecords: [...new Set(records)].map((record) => ({
+      record,
+      state: snapshotObjectState(record),
+    })),
+  };
+}
+
+function restorePluginRegistry(registry: PluginRegistry, snapshot: PluginRegistrySnapshot): void {
+  for (const { record, state } of snapshot.pluginRecords) {
+    restoreObjectState(record, state);
+  }
+  Object.assign(registry, snapshot.registry);
 }
 
 type PluginRegistrationTransaction = {
@@ -103,9 +181,10 @@ type PluginRegistrationTransaction = {
 
 export function createPluginRegistrationTransaction(params: {
   registry: PluginRegistry;
+  currentRecord?: PluginRecord;
   rollbackGlobalSideEffects?: () => void;
 }): PluginRegistrationTransaction {
-  const registrySnapshot = snapshotPluginRegistry(params.registry);
+  const registrySnapshot = snapshotPluginRegistry(params.registry, params.currentRecord);
   const processGlobalState = snapshotPluginProcessGlobalState();
   let settled = false;
 


### PR DESCRIPTION
Closes #106647

AI-assisted: yes. I reviewed and understand the implementation and validation below.

## What Problem This Solves

Fixes an issue where a plugin that fails during registration can leave partially mutated plugin metadata and existing registry entries behind, despite the registration transaction rolling back.

## Why This Change Was Made

The transaction now snapshots the current `PluginRecord` explicitly, including before it is added to `registry.plugins`, and restores its original property descriptors and mutable array/date values after failure. Registry array entries are snapshotted as separate objects so in-place updates such as middleware runtime extension or channel replacement cannot leak through rollback, while function/live-object references remain intact.

## User Impact

Failed plugin registrations no longer publish stale capabilities such as tools, hooks, routes, commands, or context engines, and they no longer mutate pre-existing middleware/channel registrations. Operators can retry or inspect a failed plugin without registry state contaminated by the failed attempt.

## Evidence

- Regression test demonstrated the pre-fix behavior: current-record mutations survived rollback.
- `pnpm vitest run src/plugins/plugin-registration-transaction.test.ts` — 4/4 passed.
- `pnpm test:contracts:plugins` — 42 files, 987 tests passed.
- `pnpm format:check` — passed.
- Focused oxlint on the three changed files — 0 warnings/errors.
- `pnpm tsgo` — passed.
- `git diff --check` — passed.
- Full `pnpm lint:core` found one pre-existing unrelated error in `src/agents/model-fallback.test.ts:3764`; the `src/plugins` shard and focused changed-file lint both passed.
- `pnpm check:changed` could not delegate because the local `crabbox` binary failed its version/help sanity check; CI remains the remote validation source for that lane.
