### PR TITLE
fix(cli): restore plugin authoring LOC ratchet

### DIFF
--- a/src/cli/plugins-authoring-command.ts
+++ b/src/cli/plugins-authoring-command.ts
@@ -2,7 +2,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
-import { tryProcessCwd } from "../infra/safe-cwd.js";
+import { formatCwdRelativePathOrAbsolute as formatOutputPath } from "../infra/safe-cwd.js";
 import { getToolPluginMetadata, type ToolPluginMetadata } from "../plugin-sdk/tool-plugin.js";
 import {
   loadPluginManifest,
@@ -61,13 +61,6 @@ function readJsonFile(filePath: string): JsonObject {
 
 function writeJsonFile(filePath: string, value: unknown): void {
   fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`);
-}
-
-// A removed launch directory must not turn completed authoring work into an
-// uv_cwd failure while rendering the final path.
-function formatOutputPath(targetPath: string, fallback: string): string {
-  const cwd = tryProcessCwd();
-  return cwd ? path.relative(cwd, targetPath) || fallback : targetPath;
 }
 
 function jsStringLiteral(value: string): string {

--- a/src/infra/safe-cwd.ts
+++ b/src/infra/safe-cwd.ts
@@ -1,3 +1,5 @@
+import path from "node:path";
+
 // A removed launch directory makes Node's process.cwd() throw before callers can recover.
 // Keep the absence explicit so each trust boundary chooses whether to skip, fail, or fall back.
 export function tryProcessCwd(): string | undefined {
@@ -6,4 +8,12 @@ export function tryProcessCwd(): string | undefined {
   } catch {
     return undefined;
   }
+}
+
+export function formatCwdRelativePathOrAbsolute(
+  targetPath: string,
+  samePathFallback: string,
+): string {
+  const cwd = tryProcessCwd();
+  return cwd ? path.relative(cwd, targetPath) || samePathFallback : targetPath;
 }


### PR DESCRIPTION
Related: #106425

## What Problem This Solves

Resolves a problem where the plugin-authoring cwd fix in #106425 caused main CI to fail the TypeScript LOC ratchet because the oversized authoring module grew from 812 to 818 lines.

## Why This Change Was Made

Moves generic cwd-safe relative-or-absolute path rendering into the existing safe-cwd owner. This preserves the behavior and all three call sites from #106425 while reducing the authoring module to 811 lines.

## User Impact

No user-visible behavior change. Plugin authoring remains resilient when its launch directory disappears, and main's LOC quality gate is restored.

## Evidence

- Failing main CI job: https://github.com/openclaw/openclaw/actions/runs/29299919386/job/86981615425
- Blacksmith Testbox `tbx_01kxf5vf81qejf6f7tm88gt83s`: https://github.com/openclaw/openclaw/actions/runs/29300130215
- `corepack pnpm test src/cli/plugins-authoring-command.test.ts`: 13/13 passed
- Remote-child `corepack pnpm check:changed`: passed, including the TypeScript LOC ratchet over both changed production files, formatting, plugin SDK baseline, tsgo core/test, lint, and guards
- Fresh autoreview: no findings; patch correct at 0.99 confidence

AI-assisted: yes
