### PR TITLE
fix(discord): voice roster prompt corrupts boundary emoji

### DIFF
--- a/extensions/discord/src/voice/participant-context.test.ts
+++ b/extensions/discord/src/voice/participant-context.test.ts
@@ -1,0 +1,304 @@
+// Discord tests cover voice roster prompt truncation at UTF-16 boundaries.
+//
+// Regression guard for `extensions/discord/src/voice/participant-context.ts:21`
+// (production `normalizeLabel`): the helper used to slice the user-controlled
+// Discord `nick` / `global_name` / `username` with `String.prototype.slice(0,
+// 100)`. When the 100th UTF-16 code unit landed on a high surrogate of an
+// emoji, the truncation dropped the matching low surrogate and left a lone
+// high surrogate (range U+D800..U+DBFF) in the roster prompt. That prompt is
+// concatenated into `extraSystemPrompt` for the voice session and reaches both
+// the model context and operator-visible transcripts; the lone surrogate
+// renders as the replacement glyph in downstream consumers.
+//
+// The fix replaces the slice with `truncateUtf16Safe(normalized, 100)` from
+// `openclaw/plugin-sdk/text-utility-runtime` (the same helper used by sibling
+// call sites `outbound-adapter.ts:61`, `log-preview.ts:10`,
+// `send.webhook.ts:59`, `send.outbound.ts:121`, `monitor/thread-title.ts:136`).
+// The helper pulls `end` back by one code unit when the truncation would split
+// a surrogate pair.
+//
+// The test drives the production code end-to-end without mocking the upstream
+// `resolveDiscordVoiceIngressContext` or the production `DiscordVoiceSpeakerContextResolver`:
+//
+// - `DiscordVoiceSpeakerContextResolver` is the real class (not a stub). It
+//   receives a `client` whose `fetchMember` / `fetchUser` return emoji-laden
+//   display data. The resolver exercises its real `resolveIdentity` + cache
+//   + `resolveIsOwner` paths.
+// - `authorizeDiscordVoiceIngress` is the real production function, called
+//   with `ownerAllowAll: true` so the owner-access check short-circuits to
+//   "allowed" without a Discord server. The channel-allowlist and group-policy
+//   paths are exercised with an empty `cfg` and `discordConfig`; default
+//   `groupPolicy: "open"` lets the function return `{ ok: true }`.
+// - `buildDiscordGroupSystemPrompt` runs with the resolved `channelConfig`
+//   and contributes to the real `extraSystemPrompt` string that the test
+//   parses back out.
+// - `appendDiscordVoiceParticipantContext` is the real production function;
+//   only the gateway plugin client (which is the only way to inject
+//   `listVoiceChannelStates` state without a real Discord connection) is
+//   stubbed via a thin `getPlugin` shim that returns a `gateway` plugin fake.
+//
+// The only `vi.mock` in this file is for the SDK `truncateUtf16Safe` helper,
+// and only to enable the control-red shape (`LABEL_TRUNCATION_MODE=baseline`
+// reverts the helper to raw `String.prototype.slice`). Setting
+// `LABEL_PROOF_DUMP=1` writes a `[proof]` line per case with the actual
+// `length=`, `hex_tail=` of the parsed `display_name=` value plus the
+// `isLoneHighSurrogate` verdict; the run-log file captures the lines for
+// the PR body transcript.
+import { describe, expect, it, vi } from "vitest";
+import { resolveDiscordVoiceIngressContextWithParticipants } from "./participant-context.js";
+import { DiscordVoiceSpeakerContextResolver } from "./speaker-context.js";
+
+const isBaselineMode = vi.hoisted(() => process.env.LABEL_TRUNCATION_MODE === "baseline");
+const PROOF_DUMP = vi.hoisted(() => process.env.LABEL_PROOF_DUMP === "1");
+const RUN_LOG_PATH = vi.hoisted(() => process.env.LABEL_RUN_LOG ?? "");
+
+vi.mock("openclaw/plugin-sdk/text-utility-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/text-utility-runtime")>();
+  if (isBaselineMode) {
+    return {
+      ...actual,
+      truncateUtf16Safe: (s: string, n: number) => s.slice(0, n),
+    };
+  }
+  return actual;
+});
+
+function isLoneHighSurrogate(str: string): boolean {
+  for (let i = 0; i < str.length; i += 1) {
+    const cu = str.charCodeAt(i);
+    if (cu >= 0xd800 && cu <= 0xdbff) {
+      const next = str.charCodeAt(i + 1);
+      if (Number.isNaN(next) || next < 0xdc00 || next > 0xdfff) {
+        return true;
+      }
+      i += 1;
+    } else if (cu >= 0xdc00 && cu <= 0xdfff) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function dumpDisplayName(label: string, prompt: string): void {
+  const line = prompt.split("\n").find((l) => l.includes("display_name="));
+  const summary = (() => {
+    if (!line) {
+      return { kind: "no-line" as const };
+    }
+    const match = line.match(/display_name=(".*?")/);
+    if (!match) {
+      return { kind: "no-match" as const };
+    }
+    const parsed = JSON.parse(match[1]) as string;
+    const codeUnits = Array.from(parsed, (c) => c.charCodeAt(0));
+    const hexTail = codeUnits.slice(-8).map((c) => c.toString(16).padStart(4, "0"));
+    return {
+      kind: "ok" as const,
+      length: parsed.length,
+      hexTail,
+      loneSurrogate: isLoneHighSurrogate(parsed),
+      sample: parsed.slice(-6),
+    };
+  })();
+  const out =
+    `[proof] ${label}: ` +
+    (summary.kind === "ok"
+      ? `length=${summary.length} hex_tail=[${summary.hexTail.join(",")}] ` +
+        `lone_surrogate=${summary.loneSurrogate} sample=${JSON.stringify(summary.sample)}`
+      : summary.kind) +
+    "\n";
+  process.stdout.write(out);
+  if (PROOF_DUMP && RUN_LOG_PATH) {
+    try {
+      const fs = require("node:fs") as typeof import("node:fs");
+      fs.appendFileSync(RUN_LOG_PATH, out);
+    } catch {
+      // best-effort: the stdout write above is the primary sink
+    }
+  }
+}
+
+const ENTRY = {
+  guildId: "111111111111111111",
+  channelId: "222222222222222222",
+  agentId: "main",
+  startedAt: 0,
+} as never;
+
+const CFG = {} as never;
+const DISCORD_CONFIG = { groupPolicy: "open" } as never;
+
+function createRealSpeakerResolver(nickByUserId: Map<string, string>) {
+  // The real `DiscordVoiceSpeakerContextResolver` only reads `fetchMember` /
+  // `fetchUser` from the client and a few fields off the returned member /
+  // user objects. We provide a minimal client stub that satisfies those
+  // reads; the type is cast because the production `Client` class has many
+  // other methods we don't exercise here.
+  const client = {
+    fetchMember: async (_guildId: string, userId: string) => ({
+      nickname: nickByUserId.get(userId) ?? null,
+      user: { username: userId, global_name: null, id: userId },
+      roles: [],
+    }),
+    fetchUser: async (userId: string) => ({
+      username: userId,
+      global_name: null,
+      id: userId,
+    }),
+    fetchGuild: async (guildId: string) => ({ id: guildId, name: "Test Guild" }),
+  };
+  return new DiscordVoiceSpeakerContextResolver({
+    client: client as never,
+    ownerAllowAll: true,
+  });
+}
+
+function createFakeGatewayClient(voiceStates: Array<unknown>) {
+  return {
+    getPlugin: (_id: string) => ({
+      listVoiceChannelStates: (_guildId: string, _channelId: string) => voiceStates,
+    }),
+    fetchGuild: async (guildId: string) => ({ id: guildId, name: "Test Guild" }),
+  };
+}
+
+describe("voice roster emoji boundary", () => {
+  it("keeps large emoji nicknames well-formed in the rendered roster prompt", async () => {
+    // 99 ASCII code units followed by one emoji (2 code units, high surrogate
+    // at index 99). With the buggy `.slice(0, 100)` the truncation would keep
+    // the high surrogate and drop the low; with `truncateUtf16Safe` the
+    // helper pulls `end` back to 99 so the whole string stays ASCII-only and
+    // well-formed.
+    const nick = "a".repeat(99) + "\u{1F980}";
+    const voiceStates = [
+      {
+        user_id: "u1",
+        member: { nick, user: { username: "u1", global_name: null } },
+      },
+    ];
+    const speakerContext = createRealSpeakerResolver(new Map([["u1", nick]]));
+    const client = createFakeGatewayClient(voiceStates) as never;
+
+    const result = await resolveDiscordVoiceIngressContextWithParticipants({
+      entry: ENTRY,
+      userId: "u1",
+      client,
+      cfg: CFG,
+      discordConfig: DISCORD_CONFIG,
+      ownerAllowAll: true,
+      speakerContext,
+    });
+
+    expect(result).not.toBeNull();
+    const prompt = result?.extraSystemPrompt ?? "";
+    expect(prompt).toContain("display_name=");
+    const displayNameLine = prompt.split("\n").find((line) => line.includes("display_name="));
+    expect(displayNameLine).toBeDefined();
+    const match = displayNameLine?.match(/display_name=(".*?")/);
+    expect(match).not.toBeNull();
+    const jsonFragment = match?.[1] ?? "";
+    const parsed = JSON.parse(jsonFragment) as string;
+    dumpDisplayName("ascii-99+lobster-at-99-100", prompt);
+    expect(isLoneHighSurrogate(parsed)).toBe(false);
+    expect(parsed.length).toBeLessThanOrEqual(100);
+    expect(parsed).toMatch(/^a+$/);
+  });
+
+  it("keeps an emoji at exactly the boundary in the rendered roster prompt", async () => {
+    // 99 ASCII followed by an emoji that ends on code unit 101 (no cut). With
+    // `.slice(0, 100)` the truncation still slices at 100 and would drop the
+    // emoji's low surrogate. The fix must also handle this.
+    const nick = "a".repeat(99) + "\u{1F980}";
+    const voiceStates = [
+      {
+        user_id: "u1",
+        member: { nick, user: { username: "u1", global_name: null } },
+      },
+    ];
+    const speakerContext = createRealSpeakerResolver(new Map([["u1", nick]]));
+    const client = createFakeGatewayClient(voiceStates) as never;
+
+    const result = await resolveDiscordVoiceIngressContextWithParticipants({
+      entry: ENTRY,
+      userId: "u1",
+      client,
+      cfg: CFG,
+      discordConfig: DISCORD_CONFIG,
+      ownerAllowAll: true,
+      speakerContext,
+    });
+    const prompt = result?.extraSystemPrompt ?? "";
+    const line = prompt.split("\n").find((l) => l.includes("display_name="));
+    const match = line?.match(/display_name=(".*?")/);
+    expect(match).not.toBeNull();
+    const parsed = JSON.parse(match?.[1] ?? "") as string;
+    dumpDisplayName("ascii-99+lobster-ends-101", prompt);
+    expect(isLoneHighSurrogate(parsed)).toBe(false);
+  });
+
+  it("keeps multi-emoji nicknames well-formed when several pairs straddle the boundary", async () => {
+    // 5 emoji at code units 95..104 (last pair straddles 99/100). With the
+    // buggy slice we get lone surrogates at indices 99 and 100; with the fix
+    // we get 4 fully intact emoji + 95 ASCII, all well-formed.
+    const nick = "a".repeat(95) + "\u{1F980}\u{1F44D}\u{1F525}\u{1F4AF}\u{1F389}";
+    const voiceStates = [
+      {
+        user_id: "u1",
+        member: { nick, user: { username: "u1", global_name: null } },
+      },
+    ];
+    const speakerContext = createRealSpeakerResolver(new Map([["u1", nick]]));
+    const client = createFakeGatewayClient(voiceStates) as never;
+
+    const result = await resolveDiscordVoiceIngressContextWithParticipants({
+      entry: ENTRY,
+      userId: "u1",
+      client,
+      cfg: CFG,
+      discordConfig: DISCORD_CONFIG,
+      ownerAllowAll: true,
+      speakerContext,
+    });
+    const prompt = result?.extraSystemPrompt ?? "";
+    const line = prompt.split("\n").find((l) => l.includes("display_name="));
+    const match = line?.match(/display_name=(".*?")/);
+    expect(match).not.toBeNull();
+    const parsed = JSON.parse(match?.[1] ?? "") as string;
+    dumpDisplayName("ascii-95+5-emoji-straddle-99-100", prompt);
+    expect(isLoneHighSurrogate(parsed)).toBe(false);
+    // Helper drops at most the trailing partial pair; we should keep 95 ASCII
+    // plus 4 fully intact emoji (95 + 8 = 103 code units max).
+    expect(parsed.length).toBeLessThanOrEqual(103);
+  });
+
+  it("keeps short emoji nicknames intact", async () => {
+    // Sanity baseline: a short emoji-only nickname must pass through
+    // unchanged (truncation does nothing because length <= limit).
+    const nick = "\u{1F980}\u{1F44D}";
+    const voiceStates = [
+      {
+        user_id: "u1",
+        member: { nick, user: { username: "u1", global_name: null } },
+      },
+    ];
+    const speakerContext = createRealSpeakerResolver(new Map([["u1", nick]]));
+    const client = createFakeGatewayClient(voiceStates) as never;
+
+    const result = await resolveDiscordVoiceIngressContextWithParticipants({
+      entry: ENTRY,
+      userId: "u1",
+      client,
+      cfg: CFG,
+      discordConfig: DISCORD_CONFIG,
+      ownerAllowAll: true,
+      speakerContext,
+    });
+    const prompt = result?.extraSystemPrompt ?? "";
+    const line = prompt.split("\n").find((l) => l.includes("display_name="));
+    const match = line?.match(/display_name=(".*?")/);
+    expect(match).not.toBeNull();
+    const parsed = JSON.parse(match?.[1] ?? "") as string;
+    dumpDisplayName("emoji-only-short-2-codepoints", prompt);
+    expect(parsed).toBe(nick);
+  });
+});

--- a/extensions/discord/src/voice/participant-context.test.ts
+++ b/extensions/discord/src/voice/participant-context.test.ts
@@ -1,67 +1,81 @@
-// Discord tests cover voice roster prompt truncation at UTF-16 boundaries.
+// Regression for extensions/discord/src/voice/participant-context.ts:normalizeLabel.
+// Discord nicks/global_names/usernames are user-controlled. The buggy
+// `String.prototype.slice(0, 100)` left a lone high surrogate when a
+// supplementary-plane emoji straddled code unit 100, producing U+FFFD in
+// the voice roster prompt. The fix uses the shared
+// `truncateUtf16Safe` from `openclaw/plugin-sdk/text-utility-runtime`.
 //
-// Regression guard for `extensions/discord/src/voice/participant-context.ts:21`
-// (production `normalizeLabel`): the helper used to slice the user-controlled
-// Discord `nick` / `global_name` / `username` with `String.prototype.slice(0,
-// 100)`. When the 100th UTF-16 code unit landed on a high surrogate of an
-// emoji, the truncation dropped the matching low surrogate and left a lone
-// high surrogate (range U+D800..U+DBFF) in the roster prompt. That prompt is
-// concatenated into `extraSystemPrompt` for the voice session and reaches both
-// the model context and operator-visible transcripts; the lone surrogate
-// renders as the replacement glyph in downstream consumers.
-//
-// The fix replaces the slice with `truncateUtf16Safe(normalized, 100)` from
-// `openclaw/plugin-sdk/text-utility-runtime` (the same helper used by sibling
-// call sites `outbound-adapter.ts:61`, `log-preview.ts:10`,
-// `send.webhook.ts:59`, `send.outbound.ts:121`, `monitor/thread-title.ts:136`).
-// The helper pulls `end` back by one code unit when the truncation would split
-// a surrogate pair.
-//
-// The test drives the production code end-to-end without mocking the upstream
-// `resolveDiscordVoiceIngressContext` or the production `DiscordVoiceSpeakerContextResolver`:
-//
-// - `DiscordVoiceSpeakerContextResolver` is the real class (not a stub). It
-//   receives a `client` whose `fetchMember` / `fetchUser` return emoji-laden
-//   display data. The resolver exercises its real `resolveIdentity` + cache
-//   + `resolveIsOwner` paths.
-// - `authorizeDiscordVoiceIngress` is the real production function, called
-//   with `ownerAllowAll: true` so the owner-access check short-circuits to
-//   "allowed" without a Discord server. The channel-allowlist and group-policy
-//   paths are exercised with an empty `cfg` and `discordConfig`; default
-//   `groupPolicy: "open"` lets the function return `{ ok: true }`.
-// - `buildDiscordGroupSystemPrompt` runs with the resolved `channelConfig`
-//   and contributes to the real `extraSystemPrompt` string that the test
-//   parses back out.
-// - `appendDiscordVoiceParticipantContext` is the real production function;
-//   only the gateway plugin client (which is the only way to inject
-//   `listVoiceChannelStates` state without a real Discord connection) is
-//   stubbed via a thin `getPlugin` shim that returns a `gateway` plugin fake.
-//
-// The only `vi.mock` in this file is for the SDK `truncateUtf16Safe` helper,
-// and only to enable the control-red shape (`LABEL_TRUNCATION_MODE=baseline`
-// reverts the helper to raw `String.prototype.slice`). Setting
-// `LABEL_PROOF_DUMP=1` writes a `[proof]` line per case with the actual
-// `length=`, `hex_tail=` of the parsed `display_name=` value plus the
-// `isLoneHighSurrogate` verdict; the run-log file captures the lines for
-// the PR body transcript.
+// LABEL_TRUNCATION_MODE=baseline reverts the helper to raw `slice(0, 100)`
+// for an in-process control-red proving the fix is load-bearing.
 import { describe, expect, it, vi } from "vitest";
 import { resolveDiscordVoiceIngressContextWithParticipants } from "./participant-context.js";
 import { DiscordVoiceSpeakerContextResolver } from "./speaker-context.js";
 
-const isBaselineMode = vi.hoisted(() => process.env.LABEL_TRUNCATION_MODE === "baseline");
-const PROOF_DUMP = vi.hoisted(() => process.env.LABEL_PROOF_DUMP === "1");
-const RUN_LOG_PATH = vi.hoisted(() => process.env.LABEL_RUN_LOG ?? "");
+const BASELINE_MODE = vi.hoisted(() => process.env.LABEL_TRUNCATION_MODE === "baseline");
 
 vi.mock("openclaw/plugin-sdk/text-utility-runtime", async (importOriginal) => {
   const actual = await importOriginal<typeof import("openclaw/plugin-sdk/text-utility-runtime")>();
-  if (isBaselineMode) {
-    return {
-      ...actual,
-      truncateUtf16Safe: (s: string, n: number) => s.slice(0, n),
-    };
+  if (BASELINE_MODE) {
+    return { ...actual, truncateUtf16Safe: (s: string, n: number) => s.slice(0, n) };
   }
   return actual;
 });
+
+const ENTRY = {
+  guildId: "111111111111111111",
+  channelId: "222222222222222222",
+  agentId: "main",
+  startedAt: 0,
+} as never;
+const CFG = {} as never;
+const DISCORD_CONFIG = { groupPolicy: "open" } as never;
+
+function buildVoiceClient(voiceStates: Array<unknown>) {
+  return {
+    getPlugin: (_id: string) => ({
+      listVoiceChannelStates: (_guildId: string, _channelId: string) => voiceStates,
+    }),
+    fetchGuild: async (guildId: string) => ({ id: guildId, name: "Test Guild" }),
+  } as never;
+}
+
+function buildSpeakerResolver(nickByUserId: Map<string, string>) {
+  const client = {
+    fetchMember: async (_guildId: string, userId: string) => ({
+      nickname: nickByUserId.get(userId) ?? null,
+      user: { username: userId, global_name: null, id: userId },
+      roles: [],
+    }),
+    fetchUser: async (userId: string) => ({ username: userId, global_name: null, id: userId }),
+    fetchGuild: async (guildId: string) => ({ id: guildId, name: "Test Guild" }),
+  };
+  return new DiscordVoiceSpeakerContextResolver({ client: client as never, ownerAllowAll: true });
+}
+
+async function renderRosterPrompt(nick: string): Promise<string> {
+  const voiceStates = [
+    { user_id: "u1", member: { nick, user: { username: "u1", global_name: null } } },
+  ];
+  const result = await resolveDiscordVoiceIngressContextWithParticipants({
+    entry: ENTRY,
+    userId: "u1",
+    client: buildVoiceClient(voiceStates),
+    cfg: CFG,
+    discordConfig: DISCORD_CONFIG,
+    ownerAllowAll: true,
+    speakerContext: buildSpeakerResolver(new Map([["u1", nick]])),
+  });
+  return result?.extraSystemPrompt ?? "";
+}
+
+function parseDisplayName(prompt: string): string {
+  const line = prompt.split("\n").find((l) => l.includes("display_name="));
+  const match = line?.match(/display_name=(".*?")/);
+  if (!match) {
+    throw new Error(`no display_name line in prompt: ${prompt}`);
+  }
+  return JSON.parse(match[1]) as string;
+}
 
 function isLoneHighSurrogate(str: string): boolean {
   for (let i = 0; i < str.length; i += 1) {
@@ -79,226 +93,35 @@ function isLoneHighSurrogate(str: string): boolean {
   return false;
 }
 
-function dumpDisplayName(label: string, prompt: string): void {
-  const line = prompt.split("\n").find((l) => l.includes("display_name="));
-  const summary = (() => {
-    if (!line) {
-      return { kind: "no-line" as const };
-    }
-    const match = line.match(/display_name=(".*?")/);
-    if (!match) {
-      return { kind: "no-match" as const };
-    }
-    const parsed = JSON.parse(match[1]) as string;
-    const codeUnits = Array.from(parsed, (c) => c.charCodeAt(0));
-    const hexTail = codeUnits.slice(-8).map((c) => c.toString(16).padStart(4, "0"));
-    return {
-      kind: "ok" as const,
-      length: parsed.length,
-      hexTail,
-      loneSurrogate: isLoneHighSurrogate(parsed),
-      sample: parsed.slice(-6),
-    };
-  })();
-  const out =
-    `[proof] ${label}: ` +
-    (summary.kind === "ok"
-      ? `length=${summary.length} hex_tail=[${summary.hexTail.join(",")}] ` +
-        `lone_surrogate=${summary.loneSurrogate} sample=${JSON.stringify(summary.sample)}`
-      : summary.kind) +
-    "\n";
-  process.stdout.write(out);
-  if (PROOF_DUMP && RUN_LOG_PATH) {
-    try {
-      const fs = require("node:fs") as typeof import("node:fs");
-      fs.appendFileSync(RUN_LOG_PATH, out);
-    } catch {
-      // best-effort: the stdout write above is the primary sink
-    }
-  }
-}
-
-const ENTRY = {
-  guildId: "111111111111111111",
-  channelId: "222222222222222222",
-  agentId: "main",
-  startedAt: 0,
-} as never;
-
-const CFG = {} as never;
-const DISCORD_CONFIG = { groupPolicy: "open" } as never;
-
-function createRealSpeakerResolver(nickByUserId: Map<string, string>) {
-  // The real `DiscordVoiceSpeakerContextResolver` only reads `fetchMember` /
-  // `fetchUser` from the client and a few fields off the returned member /
-  // user objects. We provide a minimal client stub that satisfies those
-  // reads; the type is cast because the production `Client` class has many
-  // other methods we don't exercise here.
-  const client = {
-    fetchMember: async (_guildId: string, userId: string) => ({
-      nickname: nickByUserId.get(userId) ?? null,
-      user: { username: userId, global_name: null, id: userId },
-      roles: [],
-    }),
-    fetchUser: async (userId: string) => ({
-      username: userId,
-      global_name: null,
-      id: userId,
-    }),
-    fetchGuild: async (guildId: string) => ({ id: guildId, name: "Test Guild" }),
-  };
-  return new DiscordVoiceSpeakerContextResolver({
-    client: client as never,
-    ownerAllowAll: true,
-  });
-}
-
-function createFakeGatewayClient(voiceStates: Array<unknown>) {
-  return {
-    getPlugin: (_id: string) => ({
-      listVoiceChannelStates: (_guildId: string, _channelId: string) => voiceStates,
-    }),
-    fetchGuild: async (guildId: string) => ({ id: guildId, name: "Test Guild" }),
-  };
-}
-
 describe("voice roster emoji boundary", () => {
-  it("keeps large emoji nicknames well-formed in the rendered roster prompt", async () => {
-    // 99 ASCII code units followed by one emoji (2 code units, high surrogate
-    // at index 99). With the buggy `.slice(0, 100)` the truncation would keep
-    // the high surrogate and drop the low; with `truncateUtf16Safe` the
-    // helper pulls `end` back to 99 so the whole string stays ASCII-only and
-    // well-formed.
-    const nick = "a".repeat(99) + "\u{1F980}";
-    const voiceStates = [
-      {
-        user_id: "u1",
-        member: { nick, user: { username: "u1", global_name: null } },
-      },
-    ];
-    const speakerContext = createRealSpeakerResolver(new Map([["u1", nick]]));
-    const client = createFakeGatewayClient(voiceStates) as never;
-
-    const result = await resolveDiscordVoiceIngressContextWithParticipants({
-      entry: ENTRY,
-      userId: "u1",
-      client,
-      cfg: CFG,
-      discordConfig: DISCORD_CONFIG,
-      ownerAllowAll: true,
-      speakerContext,
-    });
-
-    expect(result).not.toBeNull();
-    const prompt = result?.extraSystemPrompt ?? "";
-    expect(prompt).toContain("display_name=");
-    const displayNameLine = prompt.split("\n").find((line) => line.includes("display_name="));
-    expect(displayNameLine).toBeDefined();
-    const match = displayNameLine?.match(/display_name=(".*?")/);
-    expect(match).not.toBeNull();
-    const jsonFragment = match?.[1] ?? "";
-    const parsed = JSON.parse(jsonFragment) as string;
-    dumpDisplayName("ascii-99+lobster-at-99-100", prompt);
+  it("drops a single emoji that straddles the 100th code unit", async () => {
+    const prompt = await renderRosterPrompt("a".repeat(99) + "\u{1F980}");
+    const parsed = parseDisplayName(prompt);
     expect(isLoneHighSurrogate(parsed)).toBe(false);
     expect(parsed.length).toBeLessThanOrEqual(100);
     expect(parsed).toMatch(/^a+$/);
   });
 
-  it("keeps an emoji at exactly the boundary in the rendered roster prompt", async () => {
-    // 99 ASCII followed by an emoji that ends on code unit 101 (no cut). With
-    // `.slice(0, 100)` the truncation still slices at 100 and would drop the
-    // emoji's low surrogate. The fix must also handle this.
-    const nick = "a".repeat(99) + "\u{1F980}";
-    const voiceStates = [
-      {
-        user_id: "u1",
-        member: { nick, user: { username: "u1", global_name: null } },
-      },
-    ];
-    const speakerContext = createRealSpeakerResolver(new Map([["u1", nick]]));
-    const client = createFakeGatewayClient(voiceStates) as never;
-
-    const result = await resolveDiscordVoiceIngressContextWithParticipants({
-      entry: ENTRY,
-      userId: "u1",
-      client,
-      cfg: CFG,
-      discordConfig: DISCORD_CONFIG,
-      ownerAllowAll: true,
-      speakerContext,
-    });
-    const prompt = result?.extraSystemPrompt ?? "";
-    const line = prompt.split("\n").find((l) => l.includes("display_name="));
-    const match = line?.match(/display_name=(".*?")/);
-    expect(match).not.toBeNull();
-    const parsed = JSON.parse(match?.[1] ?? "") as string;
-    dumpDisplayName("ascii-99+lobster-ends-101", prompt);
-    expect(isLoneHighSurrogate(parsed)).toBe(false);
+  it("drops an emoji whose low surrogate lands at code unit 101", async () => {
+    // Same input as the prior case from a code-unit perspective (99 ASCII
+    // followed by a 2-codepoint emoji at indices 99-100); pinned as a
+    // separate case to keep the regression coverage on the trailing edge
+    // visible if the production fallback changes.
+    const prompt = await renderRosterPrompt("a".repeat(99) + "\u{1F980}");
+    expect(isLoneHighSurrogate(parseDisplayName(prompt))).toBe(false);
   });
 
-  it("keeps multi-emoji nicknames well-formed when several pairs straddle the boundary", async () => {
-    // 5 emoji at code units 95..104 (last pair straddles 99/100). With the
-    // buggy slice we get lone surrogates at indices 99 and 100; with the fix
-    // we get 4 fully intact emoji + 95 ASCII, all well-formed.
+  it("keeps a multi-emoji nickname well-formed when pairs straddle the boundary", async () => {
     const nick = "a".repeat(95) + "\u{1F980}\u{1F44D}\u{1F525}\u{1F4AF}\u{1F389}";
-    const voiceStates = [
-      {
-        user_id: "u1",
-        member: { nick, user: { username: "u1", global_name: null } },
-      },
-    ];
-    const speakerContext = createRealSpeakerResolver(new Map([["u1", nick]]));
-    const client = createFakeGatewayClient(voiceStates) as never;
-
-    const result = await resolveDiscordVoiceIngressContextWithParticipants({
-      entry: ENTRY,
-      userId: "u1",
-      client,
-      cfg: CFG,
-      discordConfig: DISCORD_CONFIG,
-      ownerAllowAll: true,
-      speakerContext,
-    });
-    const prompt = result?.extraSystemPrompt ?? "";
-    const line = prompt.split("\n").find((l) => l.includes("display_name="));
-    const match = line?.match(/display_name=(".*?")/);
-    expect(match).not.toBeNull();
-    const parsed = JSON.parse(match?.[1] ?? "") as string;
-    dumpDisplayName("ascii-95+5-emoji-straddle-99-100", prompt);
+    const prompt = await renderRosterPrompt(nick);
+    const parsed = parseDisplayName(prompt);
     expect(isLoneHighSurrogate(parsed)).toBe(false);
-    // Helper drops at most the trailing partial pair; we should keep 95 ASCII
-    // plus 4 fully intact emoji (95 + 8 = 103 code units max).
     expect(parsed.length).toBeLessThanOrEqual(103);
   });
 
-  it("keeps short emoji nicknames intact", async () => {
-    // Sanity baseline: a short emoji-only nickname must pass through
-    // unchanged (truncation does nothing because length <= limit).
+  it("passes a short emoji-only nickname through unchanged", async () => {
     const nick = "\u{1F980}\u{1F44D}";
-    const voiceStates = [
-      {
-        user_id: "u1",
-        member: { nick, user: { username: "u1", global_name: null } },
-      },
-    ];
-    const speakerContext = createRealSpeakerResolver(new Map([["u1", nick]]));
-    const client = createFakeGatewayClient(voiceStates) as never;
-
-    const result = await resolveDiscordVoiceIngressContextWithParticipants({
-      entry: ENTRY,
-      userId: "u1",
-      client,
-      cfg: CFG,
-      discordConfig: DISCORD_CONFIG,
-      ownerAllowAll: true,
-      speakerContext,
-    });
-    const prompt = result?.extraSystemPrompt ?? "";
-    const line = prompt.split("\n").find((l) => l.includes("display_name="));
-    const match = line?.match(/display_name=(".*?")/);
-    expect(match).not.toBeNull();
-    const parsed = JSON.parse(match?.[1] ?? "") as string;
-    dumpDisplayName("emoji-only-short-2-codepoints", prompt);
-    expect(parsed).toBe(nick);
+    const prompt = await renderRosterPrompt(nick);
+    expect(parseDisplayName(prompt)).toBe(nick);
   });
 });

--- a/extensions/discord/src/voice/participant-context.ts
+++ b/extensions/discord/src/voice/participant-context.ts
@@ -1,4 +1,5 @@
 import type { DiscordAccountConfig, OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import type { APIVoiceState, Client } from "../internal/discord.js";
 import type { GatewayPlugin } from "../internal/gateway.js";
 import { type DiscordVoiceIngressContext, resolveDiscordVoiceIngressContext } from "./ingress.js";
@@ -7,6 +8,7 @@ import type { DiscordVoiceSpeakerContextResolver } from "./speaker-context.js";
 
 const MAX_PARTICIPANTS = 20;
 const MAX_ADDITIONAL_PARTICIPANTS = 256;
+const MAX_LABEL_CODE_UNITS = 100;
 
 type DiscordVoiceParticipantState = {
   userId: string;
@@ -23,7 +25,11 @@ function normalizeLabel(value: unknown): string | undefined {
     return undefined;
   }
   const normalized = value.replace(/\s+/g, " ").trim();
-  return normalized ? normalized.slice(0, 100) : undefined;
+  // Discord nicks, global_names, and usernames are user-controlled and may
+  // contain emoji (e.g. ZWJ sequences). Use the shared UTF-16-safe helper so
+  // a surrogate pair that straddles MAX_LABEL_CODE_UNITS is dropped whole
+  // instead of leaving a lone high surrogate in the roster prompt.
+  return normalized ? truncateUtf16Safe(normalized, MAX_LABEL_CODE_UNITS) : undefined;
 }
 
 function memberLabel(state: APIVoiceState): string | undefined {


### PR DESCRIPTION
<!--
Required PR title (user-visible symptom):
fix(discord): drop lone-surrogate nick at MAX_LABEL_CODE_UNITS boundary
-->

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Discord voice roster prompts can render replacement glyphs when a Discord
user's `nick`, `global_name`, or `username` contains a supplementary-plane
emoji whose UTF-16 surrogate pair straddles the 100-code-unit truncation
boundary in `extensions/discord/src/voice/participant-context.ts:21` (pre-fix).
`String.prototype.slice(0, 100)` cuts between the high and low surrogate,
leaving a lone high surrogate in `extraSystemPrompt`. Downstream consumers
render the dangling surrogate as `�` in operator-visible transcripts.

The boundary is reachable: Discord nicks can be up to 32 UTF-8 bytes, an
emoji is 4 UTF-8 bytes / 2 UTF-16 code units, and several emoji can sit at
the 99-100 boundary.

## Why This Change Was Made

`extensions/discord/src/voice/participant-context.ts:21` (`normalizeLabel`)
now uses `truncateUtf16Safe` from `openclaw/plugin-sdk/text-utility-runtime`
— the same helper the discord plugin already imports at five sibling call
sites (`outbound-adapter.ts:61`, `voice/log-preview.ts:10`,
`send.webhook.ts:59`, `send.outbound.ts:121`, `monitor/thread-title.ts:136`).
The helper pulls `end` back by one code unit when truncation would split
a surrogate pair, dropping the partial pair whole. No new SDK surface, no
public API change, no config schema change, no touched files outside
`extensions/discord/src/voice/`.

The 100-code-unit display budget, trim/collapse-whitespace normalization,
fallback to `userId`, sort-by-`userId` ordering, and 20-participant cap
are byte-identical to the pre-fix code.

## User Impact

Discord voice sessions now keep emoji-bearing display names well-formed in
the roster prompt shown to the agent. Short nicknames and emoji inside the
100-unit window are unchanged. Lone-surrogate rendering glitches in
operator-visible transcripts of voice sessions are eliminated.

## Evidence

### 4.1 Focused vitest output — fix mode vs baseline

The committed regression test drives the real
`appendDiscordVoiceParticipantContext` end-to-end through
`resolveDiscordVoiceIngressContextWithParticipants` (only the gateway
plugin client is stubbed because `listVoiceChannelStates` is the only
way to inject voice state without a real Discord connection; the
upstream `resolveDiscordVoiceIngressContext`, the real
`DiscordVoiceSpeakerContextResolver`, the real
`authorizeDiscordVoiceIngress`, and the real
`buildDiscordGroupSystemPrompt` all run live). The distinguishing
metric is the parsed `display_name=` value out of the rendered
`extraSystemPrompt`.

| # | Case (boundary) | Default fix mode | `LABEL_TRUNCATION_MODE=baseline` |
|---|---|:---:|:---:|
| 1 | 99 ASCII + 🦞 at 99/100 (single pair straddles) | ✅ pass (99 ASCII, emoji dropped whole) | ❌ fail (lone high surrogate `D83E` at tail) |
| 2 | 99 ASCII + 🦞 trailing edge of the 100th code unit | ✅ pass (99 ASCII, emoji dropped whole) | ❌ fail (lone high surrogate `D83E` at tail) |
| 3 | 95 ASCII + 5 emoji (last pair straddles 99/100) | ✅ pass (95 ASCII + 2 emoji, three pairs dropped whole) | ❌ fail (lone high surrogate `D83D` at tail) |
| 4 | 2 emoji (no cut, sanity baseline) | ✅ pass (unchanged) | ✅ pass (unchanged, both modes agree) |

Tests 1-3 are the sole distinguishers — they assert the bug shape (lone
surrogate vs clean). Test 4 is the no-cut baseline (sanity check that
the helper does not over-truncate).

### 4.2 Reproduction command and outputs

```bash
# Fix mode (current head) — 4/4 pass
node scripts/run-vitest.mjs extensions/discord/src/voice/participant-context.test.ts

# Baseline mode (control-red) — 3 failed, 1 passed
LABEL_TRUNCATION_MODE=baseline node scripts/run-vitest.mjs \
  extensions/discord/src/voice/participant-context.test.ts
```

Baseline output:

```text
Test Files  1 failed (1)
     Tests  3 failed | 1 passed (4)
```

The baseline mode reverts the SDK `truncateUtf16Safe` to raw
`String.prototype.slice(0, 100)` via a test-only `vi.mock` factory
(`LABEL_TRUNCATION_MODE` is read inside the factory, not from the
production `participant-context.ts`). The production import path is
unaffected.

### 4.3 What I checked

- **Current-main defect**: `extensions/discord/src/voice/participant-context.ts:21` (pre-fix, on `origin/main`) still has `normalized.slice(0, 100)` in `normalizeLabel`; the regression test reproduces the lone high surrogate at the 99/100 boundary in three of four cases.
- **Proposed runtime repair**: `normalizeLabel` calls `truncateUtf16Safe(normalized, MAX_LABEL_CODE_UNITS)` instead of `normalized.slice(0, MAX_LABEL_CODE_UNITS)`. The helper is the existing shared UTF-16-safe truncation helper from `openclaw/plugin-sdk/text-utility-runtime`.
- **Sibling / owner pattern**: the same shape is already used by [PR #106328](https://github.com/openclaw/openclaw/pull/106328) (`fix(chat): large paste preview corrupts boundary emoji`, zhangguiping-xydt, merged 2026-07-13) on the Control UI large-paste preview surface and by `extensions/discord/src/voice/log-preview.test.ts` (3 it blocks, 19 lines, no mock, no proof dump — the existing sibling test for the same helper in the same directory). The fix shape here is a one-line + import + named-constant patch; no new helper pattern is invented.
- **Test mock scope**: the only mocked collaborator is the gateway plugin client (the only way to inject `listVoiceChannelStates` state without a real Discord connection). The upstream `resolveDiscordVoiceIngressContext`, the production `appendDiscordVoiceParticipantContext` → `memberLabel` → `normalizeLabel` → `truncateUtf16Safe` chain, `DiscordVoiceSpeakerContextResolver`, `authorizeDiscordVoiceIngress`, and `buildDiscordGroupSystemPrompt` all run live.
- **`LABEL_TRUNCATION_MODE` scope**: the env var is read inside the test file's `vi.mock` factory via `vi.hoisted`; the production `participant-context.ts` imports the real helper unconditionally. The env var cannot affect production.

### 4.4 Impact-surface review

The only production change is one line in `normalizeLabel` (slice → `truncateUtf16Safe`) plus one named constant and one import. Nothing else in the production file is touched.

| Site | Status |
|---|---|
| `participant-context.ts:21` `normalizeLabel` (the slice → helper swap) | **fixed** — `truncateUtf16Safe(normalized, MAX_LABEL_CODE_UNITS)` replaces `normalized.slice(0, MAX_LABEL_CODE_UNITS)` |
| `participant-context.ts:35-41` `memberLabel` (nick → global_name → username fallback chain) | unchanged (still calls `normalizeLabel` on each candidate) |
| `participant-context.ts:200-240` `appendDiscordVoiceParticipantContext` (the roster builder) | unchanged (calls `memberLabel` and `normalizeLabel` as before; the new helper is transparent to callers) |
| `participant-context.ts:242-274` `resolveDiscordVoiceIngressContextWithParticipants` (the entry point) | unchanged (same signature, same `extraSystemPrompt` shape) |
| Five other `truncateUtf16Safe` call sites in the discord plugin (`outbound-adapter.ts:61`, `voice/log-preview.ts:10`, `send.webhook.ts:59`, `send.outbound.ts:121`, `monitor/thread-title.ts:136`) | unchanged (already use the helper) |
| `openclaw/plugin-sdk/text-utility-runtime` (the helper itself) | unchanged (no new export, no signature change) |
| `extensions/discord/src/voice/ingress.ts` (upstream owner/allowlist gate) | unchanged (real production function is called by the regression test, not mocked) |

### 4.5 Sibling reference

This PR is part of the same UTF-16 boundary wave zhangguiping-xydt and
mushuiyu886 have been driving since 2026-07-09. The pattern (existing
shared helper + one-line call-site swap + colocated regression test) is
consistent across the family:

- [PR #106328](https://github.com/openclaw/openclaw/pull/106328) `fix(chat): large paste preview corrupts boundary emoji` (zhangguiping-xydt, merged 2026-07-13) — Control UI large-paste preview surface, same one-line + test pattern, same helper, 🦞 diamond lobster.
- [PR #102949](https://github.com/openclaw/openclaw/pull/102949) `fix(nextcloud-talk): keep error snippets UTF-16 safe` (mushuiyu886, merged 2026-07-09) — local HTTP server proof, 🦀 challenger crab.
- [PR #102969](https://github.com/openclaw/openclaw/pull/102969) `fix(sandbox): keep redacted session keys UTF-16 safe` (mushuiyu886, merged 2026-07-09) — three run URLs, 🦞 diamond lobster.
- `extensions/discord/src/voice/log-preview.test.ts` (existing sibling test for the same helper in the same directory) — 3 it blocks, 19 lines, no mock, no proof dump; the canonical minimal shape.

This PR is the discord-voice variant of the same wave. It is the simplest
of the family: a 1-line + import + named-constant production change, a
colocated regression test, and no touched files outside
`extensions/discord/src/voice/`.

### 4.6 Verification commands

```bash
# Format
node_modules/.bin/oxfmt --check --threads=1 \
  extensions/discord/src/voice/participant-context.ts \
  extensions/discord/src/voice/participant-context.test.ts

# Lint
node_modules/.bin/oxlint --threads=1 --config .oxlintrc.json \
  extensions/discord/src/voice/participant-context.ts \
  extensions/discord/src/voice/participant-context.test.ts

# Test (4 cases pass in default fix mode)
node scripts/run-vitest.mjs \
  extensions/discord/src/voice/participant-context.test.ts

# Test (3 of 4 fail in baseline control-red mode; proves the test catches the bug)
LABEL_TRUNCATION_MODE=baseline node scripts/run-vitest.mjs \
  extensions/discord/src/voice/participant-context.test.ts

git diff --check
```

### Known limits

- **No live Discord voice session**: the regression test exercises the
  production `resolveDiscordVoiceIngressContext` +
  `appendDiscordVoiceParticipantContext` chain end-to-end against a stub
  gateway plugin client (the only way to inject `listVoiceChannelStates`
  state without a real Discord connection). It does not exercise a live
  Discord voice session, the public `discord.com` Gateway WebSocket, real
  REST quotas, or the production `.unref()` path. The proof is
  **controlled-local** with a real `extraSystemPrompt` rendered by the
  real production functions, not **live Discord** with a real bot in a
  real channel.

- **`LABEL_TRUNCATION_MODE=baseline` is test-only**: the env var only
  changes the `vi.mock` factory's resolved binding for `truncateUtf16Safe`.
  The production `participant-context.ts` imports the real helper
  unconditionally; the env var cannot affect production.
