### PR TITLE
fix(docs): replace unsupported pnpm approve-builds -g

### DIFF
--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -89,13 +89,12 @@ If you already manage Node yourself:
   </Tab>
   <Tab title="pnpm">
     ```bash
-    pnpm add -g openclaw@latest
-    pnpm approve-builds -g
+    pnpm add -g openclaw@latest --allow-build
     openclaw onboard --install-daemon
     ```
 
     <Note>
-    pnpm requires explicit approval for packages with build scripts. Run `pnpm approve-builds -g` after the first install.
+    pnpm requires explicit approval for packages with build scripts. Use `--allow-build` at install time (pnpm 11+ removed global `approve-builds` support).
     </Note>
 
   </Tab>

--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -89,12 +89,12 @@ If you already manage Node yourself:
   </Tab>
   <Tab title="pnpm">
     ```bash
-    pnpm add -g openclaw@latest --allow-build
+    pnpm add -g openclaw@latest --allow-build=openclaw
     openclaw onboard --install-daemon
     ```
 
     <Note>
-    pnpm requires explicit approval for packages with build scripts. Use `--allow-build` at install time (pnpm 11+ removed global `approve-builds` support).
+    pnpm requires explicit approval for packages with build scripts. Use `--allow-build=openclaw` at install time (pnpm 11+ removed global `approve-builds` support).
     </Note>
 
   </Tab>


### PR DESCRIPTION
pnpm 11+ removed global pprove-builds support for global packages. Use --allow-build at install time instead, which is the documented pnpm alternative.

Closes #106166

<!--
Optional linked context:
Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
below this comment.

Required PR title:
type: user-facing description
Use a parenthesized scope only when it adds clarity:
fix(auth): login redirect loops when session cookie is expired

Types: feat, fix, improve, refactor, docs, chore.
For fixes, describe the user-visible symptom and trigger:
fix: task list fails to load when user has no environments
Avoid implementation details such as:
fix: add null check to task query
-->

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves
Fixes an issue where users following the pnpm global installation instructions would encounter ERR_PNPM_APPROVE_BUILDS_NOT_SUPPORTED_WITH_GLOBAL error when running pnpm approve-builds -g , because pnpm 11+ removed global support for the approve-builds command.

Affected surface: The installation documentation page at docs/install/index.md under the pnpm tab.


## Why This Change Was Made
The shipped documentation instructed users to run pnpm approve-builds -g after installing OpenClaw globally, but pnpm 11+ explicitly removed this global-mode approval command. The fix replaces the two-step install-then-approve flow with a single pnpm add -g openclaw@latest --allow-build command, which uses pnpm's documented install-time approval alternative. This is the narrowest maintainable fix that aligns with current pnpm behavior while keeping the source-checkout approval guidance unchanged.

## User Impact
Users installing OpenClaw via pnpm global install can now successfully complete the installation without encountering an unsupported command error. The installation flow remains straightforward with a single command, and the note explains why the change was made for users upgrading from older pnpm versions.

## Evidence
- Before: Running pnpm approve-builds -g with pnpm 11+ produces: "approve-builds" is not supported with global packages (see pnpm issue #11447 )
- After: pnpm add -g openclaw@latest --allow-build=openclaw successfully installs and builds OpenClaw in one step
- Source change: Modified docs/install/index.md — replaces the separate approval step with the --allow-build flag at install time