### PR TITLE
refactor(agents): extract attempt context guards and trajectory

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt-context-guards.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-context-guards.test.ts
@@ -1,0 +1,142 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { AgentMessage } from "../../runtime/index.js";
+import type { AgentSession } from "../../sessions/index.js";
+import type { MidTurnPrecheckRequest } from "./midturn-precheck.js";
+
+const hoisted = vi.hoisted(() => ({
+  installContextEngineLoopHook: vi.fn(),
+  installToolResultContextGuard: vi.fn(),
+  installHistoryImagePruneContextTransform: vi.fn(),
+  invalidateComputerFrameIfMissing: vi.fn(),
+}));
+
+vi.mock("../tool-result-context-guard.js", () => ({
+  installContextEngineLoopHook: hoisted.installContextEngineLoopHook,
+  installToolResultContextGuard: hoisted.installToolResultContextGuard,
+}));
+vi.mock("./history-image-prune.js", () => ({
+  installHistoryImagePruneContextTransform: hoisted.installHistoryImagePruneContextTransform,
+}));
+vi.mock("../../tools/computer-tool.js", () => ({
+  invalidateComputerFrameIfMissing: hoisted.invalidateComputerFrameIfMissing,
+}));
+
+import { installEmbeddedAttemptContextGuards } from "./attempt-context-guards.js";
+
+function createInput(overrides: Record<string, unknown> = {}) {
+  const activeSession = {
+    agent: { transformContext: undefined },
+  } as unknown as AgentSession;
+  const settingsManager = {
+    getBlockImages: vi.fn(() => false),
+    getCompactionReserveTokens: vi.fn(() => 64),
+  } as unknown as AgentSession["settingsManager"];
+  return {
+    activeSession,
+    agentDir: "/tmp/agent",
+    attempt: {
+      config: {
+        agents: { defaults: { compaction: { midTurnPrecheck: { enabled: true } } } },
+      },
+      contextTokenBudget: 1_024,
+      model: { api: "anthropic-messages", contextWindow: 2_048 },
+      modelId: "model-1",
+      provider: "provider-1",
+      sessionFile: "/tmp/session.jsonl",
+    },
+    computerContextEpoch: { value: 3 },
+    effectiveCwd: "/tmp/workspace",
+    effectiveWorkspace: "/tmp/workspace",
+    getPrePromptMessageCount: () => 4,
+    getPromptCache: () => undefined,
+    getPromptCacheRetention: () => "short" as const,
+    getSystemPrompt: () => "system prompt",
+    isOpenAIResponsesApi: false,
+    repairToolUseResultPairing: false,
+    sessionAgentId: "main",
+    sessionManager: {},
+    settingsManager,
+    ...overrides,
+  };
+}
+
+describe("installEmbeddedAttemptContextGuards", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    hoisted.installContextEngineLoopHook.mockReturnValue(vi.fn());
+    hoisted.installToolResultContextGuard.mockReturnValue(vi.fn());
+    hoisted.installHistoryImagePruneContextTransform.mockReturnValue(vi.fn());
+  });
+
+  it("tracks mid-turn requests and restores attempt-local transforms", async () => {
+    const input = createInput();
+    const originalTransform = input.activeSession.agent.transformContext;
+    const guards = installEmbeddedAttemptContextGuards(input as never);
+    const guardOptions = hoisted.installToolResultContextGuard.mock.calls[0]?.[0];
+    const request: MidTurnPrecheckRequest = {
+      route: "compact_then_truncate",
+      estimatedPromptTokens: 1_200,
+      promptBudgetBeforeReserve: 1_024,
+      overflowTokens: 176,
+      toolResultReducibleChars: 800,
+      effectiveReserveTokens: 64,
+    };
+    guardOptions.midTurnPrecheck.onMidTurnPrecheck(request);
+
+    expect(guards.takePendingMidTurnPrecheckRequest()).toBe(request);
+    expect(guards.takePendingMidTurnPrecheckRequest()).toBeNull();
+    expect(guardOptions).toMatchObject({
+      contextWindowTokens: 1_024,
+      midTurnPrecheck: {
+        enabled: true,
+        contextTokenBudget: 1_024,
+        toolResultMaxChars: expect.any(Number),
+      },
+    });
+
+    const messages: AgentMessage[] = [
+      { role: "user", content: [{ type: "text", text: "hello" }], timestamp: 1 },
+    ];
+    await input.activeSession.agent.transformContext?.(messages, new AbortController().signal);
+    expect(hoisted.invalidateComputerFrameIfMissing).toHaveBeenCalledWith({
+      contextEpoch: input.computerContextEpoch,
+      imagesBlocked: false,
+      messages,
+    });
+
+    const removeToolResultGuard = hoisted.installToolResultContextGuard.mock.results[0]?.value;
+    const removeHistoryGuard =
+      hoisted.installHistoryImagePruneContextTransform.mock.results[0]?.value;
+    guards.remove();
+    expect(input.activeSession.agent.transformContext).toBe(originalTransform);
+    expect(removeHistoryGuard).toHaveBeenCalledOnce();
+    expect(removeToolResultGuard).toHaveBeenCalledOnce();
+  });
+
+  it("composes context-engine and tool-result cleanup while exposing checkpoints", () => {
+    const activeContextEngine = {
+      info: { id: "test-engine", ownsCompaction: true },
+    };
+    const guards = installEmbeddedAttemptContextGuards(
+      createInput({
+        activeContextEngine,
+        repairToolUseResultPairing: true,
+      }) as never,
+    );
+    const loopOptions = hoisted.installContextEngineLoopHook.mock.calls[0]?.[0];
+    loopOptions.onAfterTurnCheckpoint(17);
+
+    expect(guards.getAfterTurnCheckpoint()).toBe(17);
+    expect(loopOptions).toMatchObject({
+      contextEngine: activeContextEngine,
+      modelId: "model-1",
+      repairAssembledMessages: expect.any(Function),
+    });
+
+    const removeLoopHook = hoisted.installContextEngineLoopHook.mock.results[0]?.value;
+    const removeToolResultGuard = hoisted.installToolResultContextGuard.mock.results[0]?.value;
+    guards.remove();
+    expect(removeToolResultGuard).toHaveBeenCalledOnce();
+    expect(removeLoopHook).toHaveBeenCalledOnce();
+  });
+});

--- a/src/agents/embedded-agent-runner/run/attempt-context-guards.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-context-guards.ts
@@ -1,0 +1,183 @@
+/** Installs attempt-local context engine, tool-result, image, and frame guards. */
+import { OPENCLAW_EMBEDDED_CONTEXT_ENGINE_HOST } from "../../../context-engine/host-compat.js";
+import { buildContextEngineRuntimeSettings } from "../../../context-engine/runtime-settings.js";
+import type { ContextEngine } from "../../../context-engine/types.js";
+import { isHeartbeatLifecycleRunKind } from "../../bootstrap-mode.js";
+import { DEFAULT_CONTEXT_TOKENS } from "../../defaults.js";
+import type { guardSessionManager } from "../../session-tool-result-guard-wrapper.js";
+import type { AgentSession } from "../../sessions/index.js";
+import { invalidateComputerFrameIfMissing } from "../../tools/computer-tool.js";
+import { readLastCacheTtlTimestamp } from "../cache-ttl.js";
+import {
+  installContextEngineLoopHook,
+  installToolResultContextGuard,
+} from "../tool-result-context-guard.js";
+import { resolveLiveToolResultMaxChars } from "../tool-result-truncation.js";
+import { repairAttemptToolUseResultPairing } from "./attempt-transcript-helpers.js";
+import { buildLoopPromptCacheInfo } from "./attempt.context-engine-helpers.js";
+import { buildAfterTurnRuntimeContext } from "./attempt.prompt-helpers.js";
+import { installHistoryImagePruneContextTransform } from "./history-image-prune.js";
+import type { MidTurnPrecheckRequest } from "./midturn-precheck.js";
+import type { EmbeddedRunAttemptParams, EmbeddedRunAttemptResult } from "./types.js";
+
+type PromptCacheRetention = Parameters<typeof buildLoopPromptCacheInfo>[0]["retention"];
+
+export function installEmbeddedAttemptContextGuards(input: {
+  activeContextEngine?: ContextEngine;
+  activeSession: AgentSession;
+  agentDir: string;
+  attempt: EmbeddedRunAttemptParams;
+  computerContextEpoch: { value: number };
+  effectiveCwd: string;
+  effectiveWorkspace: string;
+  getPrePromptMessageCount: () => number;
+  getPromptCache: () => EmbeddedRunAttemptResult["promptCache"];
+  getPromptCacheRetention: () => PromptCacheRetention;
+  getSystemPrompt: () => string;
+  isOpenAIResponsesApi: boolean;
+  repairToolUseResultPairing: boolean;
+  sessionAgentId: string;
+  sessionManager: ReturnType<typeof guardSessionManager>;
+  settingsManager: AgentSession["settingsManager"];
+}): {
+  getAfterTurnCheckpoint: () => number | null;
+  remove: () => void;
+  takePendingMidTurnPrecheckRequest: () => MidTurnPrecheckRequest | null;
+} {
+  const { activeContextEngine, activeSession, attempt, settingsManager } = input;
+  const contextTokenBudget = Math.max(
+    1,
+    Math.floor(
+      attempt.contextTokenBudget ??
+        attempt.model.contextWindow ??
+        attempt.model.maxTokens ??
+        DEFAULT_CONTEXT_TOKENS,
+    ),
+  );
+  const toolResultMaxChars = resolveLiveToolResultMaxChars({
+    contextWindowTokens: contextTokenBudget,
+    cfg: attempt.config,
+    agentId: input.sessionAgentId,
+  });
+  let pendingMidTurnPrecheckRequest: MidTurnPrecheckRequest | null = null;
+  let afterTurnCheckpoint: number | null = null;
+  const midTurnPrecheckOptions =
+    attempt.config?.agents?.defaults?.compaction?.midTurnPrecheck?.enabled === true
+      ? {
+          midTurnPrecheck: {
+            enabled: true,
+            contextTokenBudget,
+            reserveTokens: () => settingsManager.getCompactionReserveTokens(),
+            toolResultMaxChars,
+            getSystemPrompt: input.getSystemPrompt,
+            getPrePromptMessageCount: input.getPrePromptMessageCount,
+            onMidTurnPrecheck: (request: MidTurnPrecheckRequest) => {
+              pendingMidTurnPrecheckRequest = request;
+            },
+          },
+        }
+      : {};
+
+  let removeLoopGuard: () => void;
+  if (activeContextEngine?.info.ownsCompaction === true) {
+    const selectedContextEngineId = activeContextEngine.info.id;
+    const runtimeSettings = buildContextEngineRuntimeSettings({
+      contextEngineHost: OPENCLAW_EMBEDDED_CONTEXT_ENGINE_HOST,
+      provider: attempt.provider,
+      requestedModel: attempt.requestedModelId,
+      resolvedModel: attempt.modelId,
+      selectedContextEngineId,
+      contextEngineSelectionSource: selectedContextEngineId === "legacy" ? "default" : "configured",
+      promptTokenBudget: attempt.contextTokenBudget,
+      fallbackReason: attempt.fallbackReason,
+      degradedReason: attempt.degradedReason,
+    });
+    const removeContextEngineLoopHook = installContextEngineLoopHook({
+      agent: activeSession.agent,
+      contextEngine: activeContextEngine,
+      sessionId: attempt.sessionId,
+      sessionKey: attempt.sessionKey,
+      sessionTarget: attempt.sessionTarget,
+      sessionFile: attempt.sessionFile,
+      tokenBudget: attempt.contextTokenBudget,
+      modelId: attempt.modelId,
+      ...(input.repairToolUseResultPairing
+        ? {
+            repairAssembledMessages: (messages) =>
+              repairAttemptToolUseResultPairing(messages, input.isOpenAIResponsesApi),
+          }
+        : {}),
+      getPrePromptMessageCount: input.getPrePromptMessageCount,
+      onAfterTurnCheckpoint: (messageCount) => {
+        afterTurnCheckpoint = messageCount;
+      },
+      getRuntimeContext: ({ messages, prePromptMessageCount }) =>
+        buildAfterTurnRuntimeContext({
+          attempt,
+          workspaceDir: input.effectiveWorkspace,
+          cwd: input.effectiveCwd,
+          agentDir: input.agentDir,
+          tokenBudget: attempt.contextTokenBudget,
+          promptCache:
+            input.getPromptCache() ??
+            buildLoopPromptCacheInfo({
+              messagesSnapshot: messages,
+              prePromptMessageCount,
+              retention: input.getPromptCacheRetention(),
+              fallbackLastCacheTouchAt: readLastCacheTtlTimestamp(input.sessionManager, {
+                provider: attempt.provider,
+                modelId: attempt.modelId,
+              }),
+            }),
+        }),
+      runtimeSettings,
+      isHeartbeat: isHeartbeatLifecycleRunKind(attempt.bootstrapContextRunKind),
+    });
+    const removeToolResultGuard = installToolResultContextGuard({
+      agent: activeSession.agent,
+      contextWindowTokens: contextTokenBudget,
+      ...midTurnPrecheckOptions,
+    });
+    removeLoopGuard = () => {
+      removeToolResultGuard();
+      removeContextEngineLoopHook();
+    };
+  } else {
+    removeLoopGuard = installToolResultContextGuard({
+      agent: activeSession.agent,
+      contextWindowTokens: contextTokenBudget,
+      ...midTurnPrecheckOptions,
+    });
+  }
+
+  const removeHistoryImagePruneContextTransform = installHistoryImagePruneContextTransform(
+    activeSession.agent,
+  );
+  const previousComputerFrameTransform = activeSession.agent.transformContext;
+  activeSession.agent.transformContext = async (messages, signal) => {
+    const transformed = previousComputerFrameTransform
+      ? await previousComputerFrameTransform.call(activeSession.agent, messages, signal)
+      : messages;
+    const modelContext = Array.isArray(transformed) ? transformed : messages;
+    invalidateComputerFrameIfMissing({
+      contextEpoch: input.computerContextEpoch,
+      messages: modelContext,
+      imagesBlocked: settingsManager.getBlockImages(),
+    });
+    return modelContext;
+  };
+
+  return {
+    getAfterTurnCheckpoint: () => afterTurnCheckpoint,
+    remove: () => {
+      activeSession.agent.transformContext = previousComputerFrameTransform;
+      removeHistoryImagePruneContextTransform();
+      removeLoopGuard();
+    },
+    takePendingMidTurnPrecheckRequest: () => {
+      const request = pendingMidTurnPrecheckRequest;
+      pendingMidTurnPrecheckRequest = null;
+      return request;
+    },
+  };
+}

--- a/src/agents/embedded-agent-runner/run/attempt-trajectory.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-trajectory.test.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const hoisted = vi.hoisted(() => ({
+  buildTrajectoryRunMetadata: vi.fn(() => ({ trace: "metadata" })),
+  createTrajectoryRuntimeRecorder: vi.fn(),
+  resolveAttemptTrajectorySessionFile: vi.fn(async () => "/tmp/trajectory.jsonl"),
+}));
+
+vi.mock("../../../trajectory/metadata.js", () => ({
+  buildTrajectoryRunMetadata: hoisted.buildTrajectoryRunMetadata,
+}));
+vi.mock("../../../trajectory/runtime.js", () => ({
+  createTrajectoryRuntimeRecorder: hoisted.createTrajectoryRuntimeRecorder,
+}));
+vi.mock("./attempt-transcript-helpers.js", () => ({
+  resolveAttemptTrajectorySessionFile: hoisted.resolveAttemptTrajectorySessionFile,
+}));
+
+import { prepareEmbeddedAttemptTrajectory } from "./attempt-trajectory.js";
+
+function createInput(disableTrajectory = false) {
+  return {
+    activeSession: { sessionId: "session-1" },
+    attempt: {
+      config: {},
+      disableTrajectory,
+      fastMode: true,
+      model: { api: "anthropic-messages" },
+      modelId: "model-1",
+      provider: "provider-1",
+      runId: "run-1",
+      sessionFile: "/tmp/session.jsonl",
+      sessionKey: "agent:main:session-1",
+      thinkLevel: "medium",
+      trigger: "user",
+      workspaceDir: "/tmp/workspace",
+    },
+    clientToolCount: 2,
+    effectiveToolCount: 7,
+    effectiveWorkspace: "/tmp/workspace",
+    localModelLeanEnabled: false,
+    sessionAgentId: "main",
+  };
+}
+
+describe("prepareEmbeddedAttemptTrajectory", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("creates the recorder and seeds session and trace metadata", async () => {
+    const recorder = { recordEvent: vi.fn() };
+    hoisted.createTrajectoryRuntimeRecorder.mockReturnValue(recorder);
+
+    const result = await prepareEmbeddedAttemptTrajectory(createInput() as never);
+
+    expect(result).toBe(recorder);
+    expect(hoisted.resolveAttemptTrajectorySessionFile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentId: "main",
+        sessionFile: "/tmp/session.jsonl",
+        sessionId: "session-1",
+      }),
+    );
+    expect(hoisted.createTrajectoryRuntimeRecorder).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runId: "run-1",
+        sessionFile: "/tmp/trajectory.jsonl",
+        sessionId: "session-1",
+      }),
+    );
+    expect(recorder.recordEvent).toHaveBeenNthCalledWith(
+      1,
+      "session.started",
+      expect.objectContaining({ toolCount: 7, clientToolCount: 2 }),
+    );
+    expect(recorder.recordEvent).toHaveBeenNthCalledWith(2, "trace.metadata", {
+      trace: "metadata",
+    });
+    expect(hoisted.buildTrajectoryRunMetadata).toHaveBeenCalledWith(
+      expect.objectContaining({ fastMode: true, provider: "provider-1" }),
+    );
+  });
+
+  it("keeps trajectory path resolution but skips recorder creation when disabled", async () => {
+    await expect(prepareEmbeddedAttemptTrajectory(createInput(true) as never)).resolves.toBeNull();
+
+    expect(hoisted.resolveAttemptTrajectorySessionFile).toHaveBeenCalledOnce();
+    expect(hoisted.createTrajectoryRuntimeRecorder).not.toHaveBeenCalled();
+    expect(hoisted.buildTrajectoryRunMetadata).not.toHaveBeenCalled();
+  });
+});

--- a/src/agents/embedded-agent-runner/run/attempt-trajectory.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-trajectory.ts
@@ -1,0 +1,81 @@
+/** Creates and seeds the attempt-local trajectory recorder. */
+import type { SessionSystemPromptReport } from "../../../config/sessions/types.js";
+import { buildTrajectoryRunMetadata } from "../../../trajectory/metadata.js";
+import { createTrajectoryRuntimeRecorder } from "../../../trajectory/runtime.js";
+import type { AgentSession } from "../../sessions/index.js";
+import { resolveAttemptTrajectorySessionFile } from "./attempt-transcript-helpers.js";
+import type { EmbeddedRunAttemptParams } from "./types.js";
+
+export async function prepareEmbeddedAttemptTrajectory(input: {
+  activeSession: Pick<AgentSession, "sessionId">;
+  attempt: EmbeddedRunAttemptParams;
+  clientToolCount: number;
+  effectiveToolCount: number;
+  effectiveWorkspace: string;
+  localModelLeanEnabled: boolean;
+  sessionAgentId: string;
+  systemPromptReport?: SessionSystemPromptReport;
+}): Promise<ReturnType<typeof createTrajectoryRuntimeRecorder> | null> {
+  const { activeSession, attempt } = input;
+  const trajectorySessionFile = await resolveAttemptTrajectorySessionFile({
+    agentId: input.sessionAgentId,
+    config: attempt.config,
+    sessionFile: attempt.sessionFile,
+    sessionId: activeSession.sessionId,
+    sessionKey: attempt.sessionKey,
+    sessionTarget: attempt.sessionTarget,
+  });
+  const recorder = attempt.disableTrajectory
+    ? null
+    : createTrajectoryRuntimeRecorder({
+        cfg: attempt.config,
+        env: process.env,
+        runId: attempt.runId,
+        sessionId: activeSession.sessionId,
+        sessionKey: attempt.sessionKey,
+        sessionFile: trajectorySessionFile,
+        provider: attempt.provider,
+        modelId: attempt.modelId,
+        modelApi: attempt.model.api,
+        workspaceDir: attempt.workspaceDir,
+      });
+  recorder?.recordEvent("session.started", {
+    trigger: attempt.trigger,
+    sessionFile: attempt.sessionFile,
+    workspaceDir: input.effectiveWorkspace,
+    agentId: input.sessionAgentId,
+    messageProvider: attempt.messageProvider,
+    messageChannel: attempt.messageChannel,
+    localModelLean: input.localModelLeanEnabled,
+    toolCount: input.effectiveToolCount,
+    clientToolCount: input.clientToolCount,
+  });
+  const fastMode = typeof attempt.fastMode === "boolean" ? attempt.fastMode : undefined;
+  recorder?.recordEvent(
+    "trace.metadata",
+    buildTrajectoryRunMetadata({
+      env: process.env,
+      config: attempt.config,
+      workspaceDir: input.effectiveWorkspace,
+      sessionFile: attempt.sessionFile,
+      sessionKey: attempt.sessionKey,
+      agentId: input.sessionAgentId,
+      trigger: attempt.trigger,
+      messageProvider: attempt.messageProvider,
+      messageChannel: attempt.messageChannel,
+      provider: attempt.provider,
+      modelId: attempt.modelId,
+      modelApi: attempt.model.api,
+      timeoutMs: attempt.timeoutMs,
+      fastMode,
+      thinkLevel: attempt.thinkLevel,
+      reasoningLevel: attempt.reasoningLevel,
+      toolResultFormat: attempt.toolResultFormat,
+      disableTools: attempt.disableTools,
+      toolsAllow: attempt.toolsAllow,
+      skillsSnapshot: attempt.skillsSnapshot,
+      systemPromptReport: input.systemPromptReport,
+    }),
+  );
+  return recorder;
+}

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -13,7 +13,6 @@ import {
   OPENCLAW_EMBEDDED_CONTEXT_ENGINE_HOST,
 } from "../../../context-engine/host-compat.js";
 import { resolveContextEngineOwnerPluginId } from "../../../context-engine/registry.js";
-import { buildContextEngineRuntimeSettings } from "../../../context-engine/runtime-settings.js";
 import { emitTrustedDiagnosticEvent } from "../../../infra/diagnostic-events.js";
 import {
   createChildDiagnosticTraceContext,
@@ -25,18 +24,12 @@ import {
   buildAgentHookContextChannelFields,
   buildAgentHookContextIdentityFields,
 } from "../../../plugins/hook-agent-context.js";
-import { buildTrajectoryRunMetadata } from "../../../trajectory/metadata.js";
-import {
-  createTrajectoryRuntimeRecorder,
-  toTrajectoryToolDefinitions,
-} from "../../../trajectory/runtime.js";
+import { toTrajectoryToolDefinitions } from "../../../trajectory/runtime.js";
 import { createBundleLspToolRuntime } from "../../agent-bundle-lsp-runtime.js";
 import { materializeBundleMcpToolsForRun } from "../../agent-bundle-mcp-tools.js";
 import { resolveAgentDir, resolveSessionAgentIds } from "../../agent-scope.js";
 import { createAnthropicPayloadLogger } from "../../anthropic-payload-log.js";
-import { isHeartbeatLifecycleRunKind } from "../../bootstrap-mode.js";
 import { createCacheTrace } from "../../cache-trace.js";
-import { DEFAULT_CONTEXT_TOKENS } from "../../defaults.js";
 import { countActiveToolExecutions } from "../../embedded-agent-subscribe.handlers.tools.js";
 import { isSignalTimeoutReason } from "../../failover-error.js";
 import { resolveImageSanitizationLimits } from "../../image-sanitization.js";
@@ -50,9 +43,7 @@ import {
   type ToolSearchCatalogRef,
   type ToolSearchCatalogToolExecutor,
 } from "../../tool-search.js";
-import { invalidateComputerFrameIfMissing } from "../../tools/computer-tool.js";
 import type { NormalizedUsage } from "../../usage.js";
-import { readLastCacheTtlTimestamp } from "../cache-ttl.js";
 import { resolveCompactionTimeoutMs } from "../compaction-safety-timeout.js";
 import { prepareGooglePromptCacheStreamFn } from "../google-prompt-cache.js";
 import { log } from "../logger.js";
@@ -64,11 +55,6 @@ import {
 } from "../runs.js";
 import { getEmbeddedSessionPromptState } from "../session-prompt-state.js";
 import { resolveEmbeddedAgentApiKey } from "../stream-resolution.js";
-import {
-  installContextEngineLoopHook,
-  installToolResultContextGuard,
-} from "../tool-result-context-guard.js";
-import { resolveLiveToolResultMaxChars } from "../tool-result-truncation.js";
 import { flushPendingToolResultsAfterIdle } from "../wait-for-idle-before-flush.js";
 import { abortable as abortableWithSignal } from "./abortable.js";
 import { releaseEmbeddedAttemptSessionLockForAbort } from "./attempt-abort.js";
@@ -76,6 +62,7 @@ import { completeEmbeddedAttemptAfterTurn } from "./attempt-after-turn.js";
 import { runEmbeddedAttemptBeforeAgentRun } from "./attempt-before-agent-run.js";
 import { prepareEmbeddedAttemptBootstrap } from "./attempt-bootstrap-prepare.js";
 import { prepareEmbeddedAttemptBundleTools } from "./attempt-bundle-tools.js";
+import { installEmbeddedAttemptContextGuards } from "./attempt-context-guards.js";
 import { summarizeSessionContext } from "./attempt-context-summary.js";
 import { prepareEmbeddedAttemptHistory } from "./attempt-history-prepare.js";
 import { prepareEmbeddedAttemptPromptAssembly } from "./attempt-prompt-assembly.js";
@@ -106,17 +93,12 @@ import { prepareEmbeddedAttemptSystemPrompt } from "./attempt-system-prompt-prep
 import { prepareEmbeddedAttemptTimeout } from "./attempt-timeout-prepare.js";
 import { prepareEmbeddedAttemptToolBase } from "./attempt-tool-base-prepare.js";
 import { prepareEmbeddedAttemptToolCatalog } from "./attempt-tool-catalog.js";
+import { prepareEmbeddedAttemptTrajectory } from "./attempt-trajectory.js";
 import {
   cloneHookMessages,
   removeTrailingMidTurnPrecheckAssistantError,
-  repairAttemptToolUseResultPairing,
-  resolveAttemptTrajectorySessionFile,
 } from "./attempt-transcript-helpers.js";
-import { buildLoopPromptCacheInfo } from "./attempt.context-engine-helpers.js";
-import {
-  buildAfterTurnRuntimeContext,
-  resolvePromptSubmissionSkipReason,
-} from "./attempt.prompt-helpers.js";
+import { resolvePromptSubmissionSkipReason } from "./attempt.prompt-helpers.js";
 import { resolveEmbeddedAttemptSessionWriteLockOptions } from "./attempt.run-decisions.js";
 import {
   acquireEmbeddedAttemptSessionFileOwner,
@@ -133,7 +115,6 @@ import {
   waitForSessionsYieldAbortSettle,
 } from "./attempt.sessions-yield.js";
 import { shouldFlagCompactionTimeout } from "./compaction-timeout.js";
-import { installHistoryImagePruneContextTransform } from "./history-image-prune.js";
 import { detectAndLoadPromptImages } from "./images.js";
 import { isMidTurnPrecheckSignal, type MidTurnPrecheckRequest } from "./midturn-precheck.js";
 import { PREEMPTIVE_OVERFLOW_ERROR_TEXT } from "./preemptive-compaction.js";
@@ -508,7 +489,7 @@ export async function runEmbeddedAttempt(
 
     let session: AgentSession | undefined;
     let removeToolResultContextGuard: (() => void) | undefined;
-    let trajectoryRecorder: ReturnType<typeof createTrajectoryRuntimeRecorder> | null = null;
+    let trajectoryRecorder: Awaited<ReturnType<typeof prepareEmbeddedAttemptTrajectory>> = null;
     let trajectoryEndRecorded = false;
     let buildAbortSettlePromise: () => Promise<void> | null = () => null;
     let cleanupYieldAborted = false;
@@ -595,7 +576,7 @@ export async function runEmbeddedAttempt(
       // cannot rewrite the provider prompt-cache tail between turns (#99495).
       const sessionPromptState = getEmbeddedSessionPromptState(params.sessionId);
       const toolResultPromptProjectionState = sessionPromptState.toolResults;
-      let contextEngineAfterTurnCheckpoint: number | null = null;
+      let promptCache: EmbeddedRunAttemptResult["promptCache"];
       const sessionSettleTracker = createEmbeddedAttemptSessionSettleTracker(activeSession);
       const { abortActiveSession, trackPromptSettlePromise } = sessionSettleTracker;
       abortActiveSessionForExternalSignal = abortActiveSession;
@@ -606,132 +587,25 @@ export async function runEmbeddedAttempt(
       queueYieldInterruptForSession = () => {
         queueSessionsYieldInterruptMessage(activeSession);
       };
-      const contextTokenBudgetForGuard = Math.max(
-        1,
-        Math.floor(
-          params.contextTokenBudget ??
-            params.model.contextWindow ??
-            params.model.maxTokens ??
-            DEFAULT_CONTEXT_TOKENS,
-        ),
-      );
-      const toolResultMaxCharsForGuard = resolveLiveToolResultMaxChars({
-        contextWindowTokens: contextTokenBudgetForGuard,
-        cfg: params.config,
-        agentId: sessionAgentId,
+      const contextGuards = installEmbeddedAttemptContextGuards({
+        activeContextEngine,
+        activeSession,
+        agentDir,
+        attempt: params,
+        computerContextEpoch,
+        effectiveCwd,
+        effectiveWorkspace,
+        getPrePromptMessageCount: () => prePromptMessageCount,
+        getPromptCache: () => promptCache,
+        getPromptCacheRetention: () => effectivePromptCacheRetention,
+        getSystemPrompt: () => systemPromptText,
+        isOpenAIResponsesApi,
+        repairToolUseResultPairing: transcriptPolicy.repairToolUseResultPairing,
+        sessionAgentId,
+        sessionManager,
+        settingsManager,
       });
-      const midTurnPrecheckEnabled =
-        params.config?.agents?.defaults?.compaction?.midTurnPrecheck?.enabled === true;
-      let pendingMidTurnPrecheckRequest: MidTurnPrecheckRequest | null = null;
-      const onMidTurnPrecheck = (request: MidTurnPrecheckRequest) => {
-        pendingMidTurnPrecheckRequest = request;
-      };
-      const midTurnPrecheckOptions = midTurnPrecheckEnabled
-        ? {
-            midTurnPrecheck: {
-              enabled: true,
-              contextTokenBudget: contextTokenBudgetForGuard,
-              reserveTokens: () => settingsManager.getCompactionReserveTokens(),
-              toolResultMaxChars: toolResultMaxCharsForGuard,
-              getSystemPrompt: () => systemPromptText,
-              getPrePromptMessageCount: () => prePromptMessageCount,
-              onMidTurnPrecheck,
-            },
-          }
-        : {};
-      if (activeContextEngine?.info.ownsCompaction === true) {
-        const selectedContextEngineId = activeContextEngine.info.id;
-        const contextEngineLoopRuntimeSettings = buildContextEngineRuntimeSettings({
-          contextEngineHost: OPENCLAW_EMBEDDED_CONTEXT_ENGINE_HOST,
-          provider: params.provider,
-          requestedModel: params.requestedModelId,
-          resolvedModel: params.modelId,
-          selectedContextEngineId,
-          contextEngineSelectionSource:
-            selectedContextEngineId === "legacy" ? "default" : "configured",
-          promptTokenBudget: params.contextTokenBudget,
-          fallbackReason: params.fallbackReason,
-          degradedReason: params.degradedReason,
-        });
-        const removeContextEngineLoopHook = installContextEngineLoopHook({
-          agent: activeSession.agent,
-          contextEngine: activeContextEngine,
-          sessionId: params.sessionId,
-          sessionKey: params.sessionKey,
-          sessionTarget: params.sessionTarget,
-          sessionFile: params.sessionFile,
-          tokenBudget: params.contextTokenBudget,
-          modelId: params.modelId,
-          ...(transcriptPolicy.repairToolUseResultPairing
-            ? {
-                repairAssembledMessages: (messages) =>
-                  repairAttemptToolUseResultPairing(messages, isOpenAIResponsesApi),
-              }
-            : {}),
-          getPrePromptMessageCount: () => prePromptMessageCount,
-          onAfterTurnCheckpoint: (messageCount) => {
-            contextEngineAfterTurnCheckpoint = messageCount;
-          },
-          getRuntimeContext: ({ messages, prePromptMessageCount: loopPrePromptMessageCount }) =>
-            buildAfterTurnRuntimeContext({
-              attempt: params,
-              workspaceDir: effectiveWorkspace,
-              cwd: effectiveCwd,
-              agentDir,
-              tokenBudget: params.contextTokenBudget,
-              promptCache:
-                promptCache ??
-                buildLoopPromptCacheInfo({
-                  messagesSnapshot: messages,
-                  prePromptMessageCount: loopPrePromptMessageCount,
-                  retention: effectivePromptCacheRetention,
-                  fallbackLastCacheTouchAt: readLastCacheTtlTimestamp(sessionManager, {
-                    provider: params.provider,
-                    modelId: params.modelId,
-                  }),
-                }),
-            }),
-          runtimeSettings: contextEngineLoopRuntimeSettings,
-          isHeartbeat: isHeartbeatLifecycleRunKind(params.bootstrapContextRunKind),
-        });
-        const removeGuard = installToolResultContextGuard({
-          agent: activeSession.agent,
-          contextWindowTokens: contextTokenBudgetForGuard,
-          ...midTurnPrecheckOptions,
-        });
-        removeToolResultContextGuard = () => {
-          removeGuard();
-          removeContextEngineLoopHook();
-        };
-      } else {
-        removeToolResultContextGuard = installToolResultContextGuard({
-          agent: activeSession.agent,
-          contextWindowTokens: contextTokenBudgetForGuard,
-          ...midTurnPrecheckOptions,
-        });
-      }
-      const removeLoopContextGuard = removeToolResultContextGuard;
-      const removeHistoryImagePruneContextTransform = installHistoryImagePruneContextTransform(
-        activeSession.agent,
-      );
-      const previousComputerFrameTransform = activeSession.agent.transformContext;
-      activeSession.agent.transformContext = async (messages, signal) => {
-        const transformed = previousComputerFrameTransform
-          ? await previousComputerFrameTransform.call(activeSession.agent, messages, signal)
-          : messages;
-        const modelContext = Array.isArray(transformed) ? transformed : messages;
-        invalidateComputerFrameIfMissing({
-          contextEpoch: computerContextEpoch,
-          messages: modelContext,
-          imagesBlocked: settingsManager.getBlockImages(),
-        });
-        return modelContext;
-      };
-      removeToolResultContextGuard = () => {
-        activeSession.agent.transformContext = previousComputerFrameTransform;
-        removeHistoryImagePruneContextTransform();
-        removeLoopContextGuard?.();
-      };
+      removeToolResultContextGuard = contextGuards.remove;
       const cacheTrace = createCacheTrace({
         cfg: params.config,
         env: process.env,
@@ -753,66 +627,16 @@ export async function runEmbeddedAttempt(
         modelApi: params.model.api,
         workspaceDir: params.workspaceDir,
       });
-      const trajectorySessionFile = await resolveAttemptTrajectorySessionFile({
-        agentId: sessionAgentId,
-        config: params.config,
-        sessionFile: params.sessionFile,
-        sessionId: activeSession.sessionId,
-        sessionKey: params.sessionKey,
-        sessionTarget: params.sessionTarget,
-      });
-      trajectoryRecorder = params.disableTrajectory
-        ? null
-        : createTrajectoryRuntimeRecorder({
-            cfg: params.config,
-            env: process.env,
-            runId: params.runId,
-            sessionId: activeSession.sessionId,
-            sessionKey: params.sessionKey,
-            sessionFile: trajectorySessionFile,
-            provider: params.provider,
-            modelId: params.modelId,
-            modelApi: params.model.api,
-            workspaceDir: params.workspaceDir,
-          });
-      trajectoryRecorder?.recordEvent("session.started", {
-        trigger: params.trigger,
-        sessionFile: params.sessionFile,
-        workspaceDir: effectiveWorkspace,
-        agentId: sessionAgentId,
-        messageProvider: params.messageProvider,
-        messageChannel: params.messageChannel,
-        localModelLean: localModelLeanEnabled,
-        toolCount: effectiveTools.length,
+      trajectoryRecorder = await prepareEmbeddedAttemptTrajectory({
+        activeSession,
+        attempt: params,
         clientToolCount: clientToolDefs.length,
+        effectiveToolCount: effectiveTools.length,
+        effectiveWorkspace,
+        localModelLeanEnabled,
+        sessionAgentId,
+        ...(systemPromptReport ? { systemPromptReport } : {}),
       });
-      const trajectoryFastMode = typeof params.fastMode === "boolean" ? params.fastMode : undefined;
-      trajectoryRecorder?.recordEvent(
-        "trace.metadata",
-        buildTrajectoryRunMetadata({
-          env: process.env,
-          config: params.config,
-          workspaceDir: effectiveWorkspace,
-          sessionFile: params.sessionFile,
-          sessionKey: params.sessionKey,
-          agentId: sessionAgentId,
-          trigger: params.trigger,
-          messageProvider: params.messageProvider,
-          messageChannel: params.messageChannel,
-          provider: params.provider,
-          modelId: params.modelId,
-          modelApi: params.model.api,
-          timeoutMs: params.timeoutMs,
-          fastMode: trajectoryFastMode,
-          thinkLevel: params.thinkLevel,
-          reasoningLevel: params.reasoningLevel,
-          toolResultFormat: params.toolResultFormat,
-          disableTools: params.disableTools,
-          toolsAllow: params.toolsAllow,
-          skillsSnapshot: params.skillsSnapshot,
-          systemPromptReport,
-        }),
-      );
 
       const {
         effectiveAgentTransport,
@@ -1016,7 +840,6 @@ export async function runEmbeddedAttempt(
       let currentAttemptAssistant: EmbeddedRunAttemptResult["currentAttemptAssistant"];
       let attemptUsage: NormalizedUsage | undefined;
       let cacheBreak: PromptCacheBreak | null = null;
-      let promptCache: EmbeddedRunAttemptResult["promptCache"];
       let lastCallUsage: NormalizedUsage | undefined;
       let contextBudgetStatus: EmbeddedRunAttemptResult["contextBudgetStatus"];
       let compactionOccurredThisAttempt = false;
@@ -1501,9 +1324,9 @@ export async function runEmbeddedAttempt(
           );
         }
 
+        const pendingMidTurnPrecheckRequest = contextGuards.takePendingMidTurnPrecheckRequest();
         if (pendingMidTurnPrecheckRequest) {
           const request = pendingMidTurnPrecheckRequest;
-          pendingMidTurnPrecheckRequest = null;
           await sessionLockController.waitForSessionEvents(activeSession);
           await withOwnedSessionWriteLock(() => {
             removeTrailingMidTurnPrecheckAssistantError({
@@ -1597,7 +1420,7 @@ export async function runEmbeddedAttempt(
             sessionFileUsed,
             messagesSnapshot,
             prePromptMessageCount,
-            contextEngineAfterTurnCheckpoint,
+            contextEngineAfterTurnCheckpoint: contextGuards.getAfterTurnCheckpoint(),
             lastCallUsage,
             promptCache,
             ...(beforeAgentFinalizeRevisionReason ? { beforeAgentFinalizeRevisionReason } : {}),


### PR DESCRIPTION
## What Problem This Solves

After the session-boundary extraction landed, `runEmbeddedAttempt` still directly installed context-engine/tool-result/image/frame guards and initialized trajectory recording. Those separable setup concerns obscured the remaining orchestration flow and lacked direct composition tests.

## Why This Change Was Made

Extract `installEmbeddedAttemptContextGuards` and `prepareEmbeddedAttemptTrajectory`, preserving dynamic prompt-cache getters, mid-turn precheck consumption, context-engine checkpoints, transform restoration order, trajectory path resolution, and metadata fields. Add direct unit coverage for both helpers.

Related #72072.

## User Impact

No intended behavior change. `attempt.ts` drops from 1,762 to 1,585 lines.

## Evidence

- Blacksmith Testbox `tbx_01kxf7a00xt2dh1vhcdv43cctx`: 127 focused context-guard, trajectory, runner, and session tests passed.
- Exact-main `pnpm check:changed` passed all selected gates in 3m53s, including core/core-test `tsgo`, changed-file Oxlint, TypeScript LOC ratchet, formatting, runtime import cycles, and repository policy guards.
- Fresh exact-head autoreview after latest-main rebase: no accepted or actionable findings; correctness 0.97.
- Hosted CI intentionally not awaited per maintainer instruction.
