### PR TITLE
fix(release): make closeout recovery shell-safe

### DIFF
--- a/.github/workflows/openclaw-stable-main-closeout.yml
+++ b/.github/workflows/openclaw-stable-main-closeout.yml
@@ -475,76 +475,77 @@ jobs:
               > "$windows_node_run_json"
             parent_head_sha="$(jq -r '.headSha // empty' "$RUNNER_TEMP/release-publish-run.json")"
             PARENT_HEAD_SHA="$parent_head_sha" \
-              node --input-type=module - "$windows_node_run_json" <<'NODE'
-            import { readFileSync } from "node:fs";
-            const run = JSON.parse(readFileSync(process.argv[2], "utf8"));
-            for (const [key, expected] of [
-              ["workflowName", "Windows Node Release"],
-              ["event", "workflow_dispatch"],
-              ["status", "completed"],
-              ["conclusion", "success"],
-              ["headSha", process.env.PARENT_HEAD_SHA],
-            ]) {
-              if (run[key] !== expected) {
-                throw new Error(`Windows Node Release must have ${key}=${expected}, got ${run[key] ?? "<missing>"}.`);
+              node --input-type=module -e '
+              import { readFileSync } from "node:fs";
+              const run = JSON.parse(readFileSync(process.argv[1], "utf8"));
+              for (const [key, expected] of [
+                ["workflowName", "Windows Node Release"],
+                ["event", "workflow_dispatch"],
+                ["status", "completed"],
+                ["conclusion", "success"],
+                ["headSha", process.env.PARENT_HEAD_SHA],
+              ]) {
+                if (run[key] !== expected) {
+                  throw new Error(`Windows Node Release must have ${key}=${expected}, got ${run[key] ?? "<missing>"}.`);
+                }
               }
-            }
-            const jobs = (run.jobs ?? []).filter(
-              (job) => job.name === "Promote signed Windows installers" && job.conclusion === "success",
-            );
-            if (jobs.length !== 1) {
-              throw new Error("Windows Node Release must contain one successful signed-installer promotion job.");
-            }
-            for (const name of [
-              "Validate inputs",
-              "Verify Authenticode signatures",
-              "Upload to OpenClaw release",
-              "Verify promoted release asset contract",
-            ]) {
-              const steps = (jobs[0].steps ?? []).filter(
-                (step) => step.name === name && step.conclusion === "success",
+              const jobs = (run.jobs ?? []).filter(
+                (job) => job.name === "Promote signed Windows installers" && job.conclusion === "success",
               );
-              if (steps.length !== 1) {
-                throw new Error(`Windows Node Release is missing successful step: ${name}.`);
+              if (jobs.length !== 1) {
+                throw new Error("Windows Node Release must contain one successful signed-installer promotion job.");
               }
-            }
-            NODE
+              for (const name of [
+                "Validate inputs",
+                "Verify Authenticode signatures",
+                "Upload to OpenClaw release",
+                "Verify promoted release asset contract",
+              ]) {
+                const steps = (jobs[0].steps ?? []).filter(
+                  (step) => step.name === name && step.conclusion === "success",
+                );
+                if (steps.length !== 1) {
+                  throw new Error(`Windows Node Release is missing successful step: ${name}.`);
+                }
+              }
+              ' "$windows_node_run_json"
             windows_node_log="$RUNNER_TEMP/windows-node-release-run.log"
             gh_with_retry run view "$windows_node_run_id" --repo "$GITHUB_REPOSITORY" --log \
               > "$windows_node_log"
-            windows_node_installer_digests="$(node --input-type=module - "$windows_node_log" <<'NODE'
-            import { readFileSync } from "node:fs";
-            const log = readFileSync(process.argv[2], "utf8");
-            const marker = "EXPECTED_INSTALLER_DIGESTS:";
-            const names = [
-              "OpenClawCompanion-Setup-arm64.exe",
-              "OpenClawCompanion-Setup-x64.exe",
-            ];
-            const contracts = new Set();
-            for (const line of log.split(/\r?\n/u)) {
-              const markerIndex = line.indexOf(marker);
-              if (markerIndex === -1) continue;
-              const candidate = line.slice(markerIndex + marker.length).trim();
-              let parsed;
-              try {
-                parsed = JSON.parse(candidate);
-              } catch {
-                continue;
+            windows_node_installer_digests="$(
+              node --input-type=module -e '
+              import { readFileSync } from "node:fs";
+              const log = readFileSync(process.argv[1], "utf8");
+              const marker = "EXPECTED_INSTALLER_DIGESTS:";
+              const names = [
+                "OpenClawCompanion-Setup-arm64.exe",
+                "OpenClawCompanion-Setup-x64.exe",
+              ];
+              const contracts = new Set();
+              for (const line of log.split(/\r?\n/u)) {
+                const markerIndex = line.indexOf(marker);
+                if (markerIndex === -1) continue;
+                const candidate = line.slice(markerIndex + marker.length).trim();
+                let parsed;
+                try {
+                  parsed = JSON.parse(candidate);
+                } catch {
+                  continue;
+                }
+                const keys = Object.keys(parsed).toSorted((left, right) => left.localeCompare(right));
+                if (
+                  JSON.stringify(keys) !== JSON.stringify(names) ||
+                  !names.every((name) => /^sha256:[0-9a-f]{64}$/u.test(parsed[name] ?? ""))
+                ) {
+                  continue;
+                }
+                contracts.add(JSON.stringify(Object.fromEntries(names.map((name) => [name, parsed[name]]))));
               }
-              const keys = Object.keys(parsed).toSorted((left, right) => left.localeCompare(right));
-              if (
-                JSON.stringify(keys) !== JSON.stringify(names) ||
-                !names.every((name) => /^sha256:[0-9a-f]{64}$/u.test(parsed[name] ?? ""))
-              ) {
-                continue;
+              if (contracts.size !== 1) {
+                throw new Error(`Windows Node Release logs must contain exactly one candidate-approved digest contract, got ${contracts.size}.`);
               }
-              contracts.add(JSON.stringify(Object.fromEntries(names.map((name) => [name, parsed[name]]))));
-            }
-            if (contracts.size !== 1) {
-              throw new Error(`Windows Node Release logs must contain exactly one candidate-approved digest contract, got ${contracts.size}.`);
-            }
-            process.stdout.write([...contracts][0]);
-            NODE
+              process.stdout.write([...contracts][0]);
+              ' "$windows_node_log"
             )"
             {
               echo "WINDOWS_NODE_RELEASE_RUN_ID=$windows_node_run_id"

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -446,7 +446,12 @@ describe("package acceptance workflow", () => {
     const rollbackDrillPushSkipIndex = workflow.indexOf(
       "Stable closeout skipped: rollback drill repository variables are missing",
     );
+    const evidenceScriptSyntax = spawnSync("bash", ["-n"], {
+      encoding: "utf8",
+      input: evidenceStep.run,
+    });
 
+    expect(evidenceScriptSyntax.status, evidenceScriptSyntax.stderr).toBe(0);
     expect(workflow).toContain('evidence_checksum_asset="${evidence_asset}.sha256"');
     expect(workflow).toContain('--pattern "$evidence_checksum_asset"');
     expect(workflow).toContain('fallback_package_version="${BASH_REMATCH[1]}"');


### PR DESCRIPTION
## What Problem This Solves

The evidence-backed stable closeout recovery path failed before validating repaired Windows artifacts. Its nested JavaScript heredocs retained shell indentation after YAML extraction, so Bash never found either terminator.

## Why This Change Was Made

Run both recovery-only JavaScript checks through `node -e`, preserving their validation logic without indentation-sensitive heredoc delimiters. Add a regression assertion that parses the workflow and runs `bash -n` over the full evidence step.

## User Impact

Stable releases with repaired late platform assets can complete immutable main-closeout verification. Normal release and runtime behavior are unchanged.

## Evidence

- Reproduced in OpenClaw Stable Main Closeout run 29301050634.
- Blacksmith Testbox `tbx_01kxf77xs45gah5zr78dtj6vwr`: `pnpm test test/scripts/package-acceptance-workflow.test.ts` — 72 passed.
- Same Testbox: `node scripts/check-workflows.mjs` — actionlint, zizmor, and repository workflow guards passed.
- `git diff --check` passed.
- Autoreview: clean, confidence 0.98.
