### PR TITLE
fix: restore main dead-export gate

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt-session-boundary.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-session-boundary.ts
@@ -24,9 +24,7 @@ type SessionBoundaryAttempt = Pick<
 
 type LlmBoundaryOptions = NonNullable<Parameters<typeof normalizeMessagesForLlmBoundary>[1]>;
 
-export type CurrentUserTimestampOverride = NonNullable<
-  LlmBoundaryOptions["currentUserTimestampOverride"]
->;
+type CurrentUserTimestampOverride = NonNullable<LlmBoundaryOptions["currentUserTimestampOverride"]>;
 
 export function prepareEmbeddedAttemptSessionBoundary(input: {
   activeSession: Pick<AgentSession, "agent">;


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where main CI's dependency gate fails after the attempt-session-boundary extraction exposed an internal-only timestamp helper type.

## Why This Change Was Made

The type remains local to its owning module. Its runtime behavior and all local annotations stay unchanged.

## User Impact

No user-visible behavior change. Main CI can pass its dead-export contract again.

## Evidence

- Failing hosted check: `CurrentUserTimestampOverride` reported as an unexpected unused export: https://github.com/openclaw/openclaw/actions/runs/29301228330/job/86985299105
- Blacksmith Testbox through Crabbox `tbx_01kxf7mr232e6srm0ypbq41mqk`: dead-export gate and targeted formatting passed: https://github.com/openclaw/openclaw/actions/runs/29301430275
- Fresh structured autoreview: clean, confidence 0.99
- `git diff --check`: passed
