### PR TITLE
perf(test): isolate auth planner provider hooks

### DIFF
--- a/src/agents/runtime-plan/prepare-auth.test.ts
+++ b/src/agents/runtime-plan/prepare-auth.test.ts
@@ -11,6 +11,14 @@ import {
   preparedAgentRuntimeProfileAttemptHasCandidate,
 } from "./prepare-auth.js";
 
+// This suite owns generic auth planning. Provider-hook behavior has dedicated
+// coverage; keep those runtimes out of this focused planner test.
+vi.mock("../../plugins/provider-runtime.js", () => ({
+  buildProviderMissingAuthMessageWithPlugin: () => undefined,
+  resolveProviderSyntheticAuthWithPlugin: () => undefined,
+  shouldDeferProviderSyntheticProfileAuthWithPlugin: () => undefined,
+}));
+
 function prepareAgentRuntimeAuthPlan(params: Parameters<typeof prepareAgentRuntimeAuth>[0]) {
   return prepareAgentRuntimeAuth(params).plan;
 }


### PR DESCRIPTION
## What Problem This Solves

The generic auth-planner test suite loaded real provider plugin runtimes while resolving one ordinary stored API-key profile. That one test took about 68 seconds and pushed the focused file to 76 seconds wall time and 1.89 GB RSS.

## Why This Change Was Made

Use an explicit provider-runtime mock factory for the three hook exports imported by model auth. This suite owns generic auth planning; synthetic-provider deferral and plugin composition retain dedicated coverage in `src/agents/model-auth.test.ts` and `src/plugins/provider-runtime.test.ts`.

## User Impact

No product behavior change. Maintainers and CI get substantially faster auth-planner feedback without dropping generic or provider-hook coverage.

## Evidence

- Blacksmith same-lease baseline: 76.20s wall, 1,891,768 KB maximum RSS; the slow generic ordering test took 67.76s.
- After: 7.26s wall, 753,988 KB maximum RSS; repeat run 5.95s wall. This is about 90% less wall time and 60% less peak RSS.
- Focused auth planner: 58/58 passed.
- Combined planner, model-auth, and provider-runtime suites: 195/195 passed.
- Changed gate: passed.
- Fresh exact-head autoreview: zero findings, 0.98 confidence.
