### PR TITLE
refactor(agents): extract attempt runtime guards

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt-runtime-guards.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-runtime-guards.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it, vi } from "vitest";
+import type { AgentMessage } from "../../runtime/index.js";
+import type { guardSessionManager } from "../../session-tool-result-guard-wrapper.js";
+import type { AgentSession, SettingsManager } from "../../sessions/index.js";
+import type { ComputerContextEpoch } from "../../tools/computer-tool.js";
+import { installEmbeddedAttemptRuntimeGuards } from "./attempt-runtime-guards.js";
+import type { AttemptContextEngine } from "./attempt.context-engine-helpers.js";
+import type { EmbeddedRunAttemptParams } from "./types.js";
+
+type TransformAgent = {
+  transformContext?: (
+    messages: AgentMessage[],
+    signal?: AbortSignal,
+  ) => AgentMessage[] | Promise<AgentMessage[]>;
+};
+
+function createHarness(
+  options: {
+    activeContextEngine?: AttemptContextEngine;
+    midTurnPrecheck?: boolean;
+    prePromptMessageCount?: number;
+    systemPrompt?: string;
+  } = {},
+) {
+  const originalTransform = vi.fn(async (messages: AgentMessage[]) => messages);
+  const agent: TransformAgent = { transformContext: originalTransform };
+  const computerContextEpoch: ComputerContextEpoch = {
+    value: 0,
+    frameToolCallId: "computer-call",
+    frameImageIdentity: "frame",
+  };
+  const attempt = {
+    bootstrapContextRunKind: "default",
+    config: options.midTurnPrecheck
+      ? { agents: { defaults: { compaction: { midTurnPrecheck: { enabled: true } } } } }
+      : {},
+    contextTokenBudget: options.midTurnPrecheck ? 256 : 8_192,
+    model: { contextWindow: 8_192, maxTokens: 4_096 },
+    modelId: "test-model",
+    provider: "test-provider",
+    requestedModelId: "test-model",
+    sessionFile: "/tmp/session.jsonl",
+    sessionId: "session-1",
+  } as unknown as EmbeddedRunAttemptParams;
+  const settingsManager = {
+    getBlockImages: () => true,
+    getCompactionReserveTokens: () => 0,
+  } as Pick<SettingsManager, "getBlockImages" | "getCompactionReserveTokens">;
+  const guards = installEmbeddedAttemptRuntimeGuards({
+    activeContextEngine: options.activeContextEngine,
+    activeSession: { agent } as unknown as Pick<AgentSession, "agent">,
+    agentDir: "/tmp/agent",
+    attempt,
+    computerContextEpoch,
+    effectiveCwd: "/tmp/workspace",
+    effectiveWorkspace: "/tmp/workspace",
+    getEffectivePromptCacheRetention: () => "none",
+    getPrePromptMessageCount: () => options.prePromptMessageCount ?? 1,
+    getPromptCache: () => ({ retention: "none" }),
+    getSystemPrompt: () => options.systemPrompt ?? "",
+    isOpenAIResponsesApi: false,
+    repairToolUseResultPairing: false,
+    sessionAgentId: "agent-1",
+    sessionManager: {} as ReturnType<typeof guardSessionManager>,
+    settingsManager,
+  });
+  return { agent, computerContextEpoch, guards, originalTransform };
+}
+
+async function transform(agent: TransformAgent, messages: AgentMessage[]) {
+  if (!agent.transformContext) {
+    throw new Error("missing transformContext");
+  }
+  return await agent.transformContext(messages, new AbortController().signal);
+}
+
+describe("installEmbeddedAttemptRuntimeGuards", () => {
+  it("restores the original transform after layered guard cleanup", async () => {
+    const { agent, computerContextEpoch, guards, originalTransform } = createHarness();
+
+    await transform(agent, [{ role: "user", content: "hello", timestamp: 1 }]);
+    expect(computerContextEpoch.frameToolCallId).toBeUndefined();
+    expect(agent.transformContext).not.toBe(originalTransform);
+
+    guards.cleanup();
+    expect(agent.transformContext).toBe(originalTransform);
+  });
+
+  it("queues and consumes a mid-turn overflow request once", async () => {
+    const { agent, guards } = createHarness({
+      midTurnPrecheck: true,
+      systemPrompt: "system ".repeat(20_000),
+    });
+    const messages = [
+      { role: "user", content: "go", timestamp: 1 },
+      {
+        role: "toolResult",
+        toolCallId: "tool-1",
+        toolName: "read",
+        content: [{ type: "text", text: "result" }],
+        isError: false,
+        timestamp: 2,
+      },
+    ] as AgentMessage[];
+
+    await expect(transform(agent, messages)).rejects.toMatchObject({
+      name: "MidTurnPrecheckSignal",
+    });
+    expect(guards.takePendingMidTurnPrecheckRequest()).toMatchObject({
+      route: expect.not.stringMatching(/^fits$/u),
+    });
+    expect(guards.takePendingMidTurnPrecheckRequest()).toBeNull();
+    guards.cleanup();
+  });
+
+  it("reports the context-engine checkpoint produced inside the tool loop", async () => {
+    const afterTurn = vi.fn(async () => undefined);
+    const activeContextEngine = {
+      info: { id: "test-engine", ownsCompaction: true },
+      afterTurn,
+      assemble: vi.fn(async ({ messages }: { messages: AgentMessage[] }) => ({ messages })),
+    } as unknown as AttemptContextEngine;
+    const { agent, guards } = createHarness({
+      activeContextEngine,
+      prePromptMessageCount: 0,
+    });
+
+    await transform(agent, [{ role: "user", content: "hello", timestamp: 1 }]);
+    expect(afterTurn).toHaveBeenCalledOnce();
+    expect(guards.getContextEngineAfterTurnCheckpoint()).toBe(1);
+    guards.cleanup();
+  });
+});

--- a/src/agents/embedded-agent-runner/run/attempt-runtime-guards.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-runtime-guards.ts
@@ -1,0 +1,191 @@
+/** Installs per-attempt context-engine, overflow, image, and computer-frame guards. */
+import { OPENCLAW_EMBEDDED_CONTEXT_ENGINE_HOST } from "../../../context-engine/host-compat.js";
+import { buildContextEngineRuntimeSettings } from "../../../context-engine/runtime-settings.js";
+import { isHeartbeatLifecycleRunKind } from "../../bootstrap-mode.js";
+import { DEFAULT_CONTEXT_TOKENS } from "../../defaults.js";
+import type { guardSessionManager } from "../../session-tool-result-guard-wrapper.js";
+import type { AgentSession, SettingsManager } from "../../sessions/index.js";
+import {
+  type ComputerContextEpoch,
+  invalidateComputerFrameIfMissing,
+} from "../../tools/computer-tool.js";
+import { readLastCacheTtlTimestamp } from "../cache-ttl.js";
+import {
+  installContextEngineLoopHook,
+  installToolResultContextGuard,
+} from "../tool-result-context-guard.js";
+import { resolveLiveToolResultMaxChars } from "../tool-result-truncation.js";
+import { repairAttemptToolUseResultPairing } from "./attempt-transcript-helpers.js";
+import {
+  buildLoopPromptCacheInfo,
+  type AttemptContextEngine,
+} from "./attempt.context-engine-helpers.js";
+import { buildAfterTurnRuntimeContext } from "./attempt.prompt-helpers.js";
+import { installHistoryImagePruneContextTransform } from "./history-image-prune.js";
+import type { MidTurnPrecheckRequest } from "./midturn-precheck.js";
+import type { EmbeddedRunAttemptParams, EmbeddedRunAttemptResult } from "./types.js";
+
+type RuntimeGuardSettingsManager = Pick<
+  SettingsManager,
+  "getBlockImages" | "getCompactionReserveTokens"
+>;
+
+export function installEmbeddedAttemptRuntimeGuards(input: {
+  activeContextEngine?: AttemptContextEngine;
+  activeSession: Pick<AgentSession, "agent">;
+  agentDir: string;
+  attempt: EmbeddedRunAttemptParams;
+  computerContextEpoch: ComputerContextEpoch;
+  effectiveCwd: string;
+  effectiveWorkspace: string;
+  getEffectivePromptCacheRetention: () => "none" | "short" | "long" | undefined;
+  getPrePromptMessageCount: () => number;
+  getPromptCache: () => EmbeddedRunAttemptResult["promptCache"];
+  getSystemPrompt: () => string;
+  isOpenAIResponsesApi: boolean;
+  repairToolUseResultPairing: boolean;
+  sessionAgentId: string;
+  sessionManager: ReturnType<typeof guardSessionManager>;
+  settingsManager: RuntimeGuardSettingsManager;
+}): {
+  cleanup: () => void;
+  getContextEngineAfterTurnCheckpoint: () => number | null;
+  takePendingMidTurnPrecheckRequest: () => MidTurnPrecheckRequest | null;
+} {
+  const { activeContextEngine, activeSession, attempt, settingsManager } = input;
+  const contextTokenBudgetForGuard = Math.max(
+    1,
+    Math.floor(
+      attempt.contextTokenBudget ??
+        attempt.model.contextWindow ??
+        attempt.model.maxTokens ??
+        DEFAULT_CONTEXT_TOKENS,
+    ),
+  );
+  const toolResultMaxCharsForGuard = resolveLiveToolResultMaxChars({
+    contextWindowTokens: contextTokenBudgetForGuard,
+    cfg: attempt.config,
+    agentId: input.sessionAgentId,
+  });
+  let pendingMidTurnPrecheckRequest: MidTurnPrecheckRequest | null = null;
+  const midTurnPrecheckOptions =
+    attempt.config?.agents?.defaults?.compaction?.midTurnPrecheck?.enabled === true
+      ? {
+          midTurnPrecheck: {
+            enabled: true,
+            contextTokenBudget: contextTokenBudgetForGuard,
+            reserveTokens: () => settingsManager.getCompactionReserveTokens(),
+            toolResultMaxChars: toolResultMaxCharsForGuard,
+            getSystemPrompt: input.getSystemPrompt,
+            getPrePromptMessageCount: input.getPrePromptMessageCount,
+            onMidTurnPrecheck: (request: MidTurnPrecheckRequest) => {
+              pendingMidTurnPrecheckRequest = request;
+            },
+          },
+        }
+      : {};
+
+  let contextEngineAfterTurnCheckpoint: number | null = null;
+  let removeLoopContextGuard: () => void;
+  if (activeContextEngine?.info.ownsCompaction === true) {
+    const selectedContextEngineId = activeContextEngine.info.id;
+    const removeContextEngineLoopHook = installContextEngineLoopHook({
+      agent: activeSession.agent,
+      contextEngine: activeContextEngine,
+      sessionId: attempt.sessionId,
+      sessionKey: attempt.sessionKey,
+      sessionTarget: attempt.sessionTarget,
+      sessionFile: attempt.sessionFile,
+      tokenBudget: attempt.contextTokenBudget,
+      modelId: attempt.modelId,
+      ...(input.repairToolUseResultPairing
+        ? {
+            repairAssembledMessages: (messages) =>
+              repairAttemptToolUseResultPairing(messages, input.isOpenAIResponsesApi),
+          }
+        : {}),
+      getPrePromptMessageCount: input.getPrePromptMessageCount,
+      onAfterTurnCheckpoint: (messageCount) => {
+        contextEngineAfterTurnCheckpoint = messageCount;
+      },
+      getRuntimeContext: ({ messages, prePromptMessageCount }) =>
+        buildAfterTurnRuntimeContext({
+          attempt,
+          workspaceDir: input.effectiveWorkspace,
+          cwd: input.effectiveCwd,
+          agentDir: input.agentDir,
+          tokenBudget: attempt.contextTokenBudget,
+          promptCache:
+            input.getPromptCache() ??
+            buildLoopPromptCacheInfo({
+              messagesSnapshot: messages,
+              prePromptMessageCount,
+              retention: input.getEffectivePromptCacheRetention(),
+              fallbackLastCacheTouchAt: readLastCacheTtlTimestamp(input.sessionManager, {
+                provider: attempt.provider,
+                modelId: attempt.modelId,
+              }),
+            }),
+        }),
+      runtimeSettings: buildContextEngineRuntimeSettings({
+        contextEngineHost: OPENCLAW_EMBEDDED_CONTEXT_ENGINE_HOST,
+        provider: attempt.provider,
+        requestedModel: attempt.requestedModelId,
+        resolvedModel: attempt.modelId,
+        selectedContextEngineId,
+        contextEngineSelectionSource:
+          selectedContextEngineId === "legacy" ? "default" : "configured",
+        promptTokenBudget: attempt.contextTokenBudget,
+        fallbackReason: attempt.fallbackReason,
+        degradedReason: attempt.degradedReason,
+      }),
+      isHeartbeat: isHeartbeatLifecycleRunKind(attempt.bootstrapContextRunKind),
+    });
+    const removeToolResultGuard = installToolResultContextGuard({
+      agent: activeSession.agent,
+      contextWindowTokens: contextTokenBudgetForGuard,
+      ...midTurnPrecheckOptions,
+    });
+    removeLoopContextGuard = () => {
+      removeToolResultGuard();
+      removeContextEngineLoopHook();
+    };
+  } else {
+    removeLoopContextGuard = installToolResultContextGuard({
+      agent: activeSession.agent,
+      contextWindowTokens: contextTokenBudgetForGuard,
+      ...midTurnPrecheckOptions,
+    });
+  }
+
+  const removeHistoryImagePruneContextTransform = installHistoryImagePruneContextTransform(
+    activeSession.agent,
+  );
+  const previousComputerFrameTransform = activeSession.agent.transformContext;
+  activeSession.agent.transformContext = async (messages, signal) => {
+    const transformed = previousComputerFrameTransform
+      ? await previousComputerFrameTransform.call(activeSession.agent, messages, signal)
+      : messages;
+    const modelContext = Array.isArray(transformed) ? transformed : messages;
+    invalidateComputerFrameIfMissing({
+      contextEpoch: input.computerContextEpoch,
+      messages: modelContext,
+      imagesBlocked: settingsManager.getBlockImages(),
+    });
+    return modelContext;
+  };
+
+  return {
+    cleanup: () => {
+      activeSession.agent.transformContext = previousComputerFrameTransform;
+      removeHistoryImagePruneContextTransform();
+      removeLoopContextGuard();
+    },
+    getContextEngineAfterTurnCheckpoint: () => contextEngineAfterTurnCheckpoint,
+    takePendingMidTurnPrecheckRequest: () => {
+      const request = pendingMidTurnPrecheckRequest;
+      pendingMidTurnPrecheckRequest = null;
+      return request;
+    },
+  };
+}

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -13,7 +13,6 @@ import {
   OPENCLAW_EMBEDDED_CONTEXT_ENGINE_HOST,
 } from "../../../context-engine/host-compat.js";
 import { resolveContextEngineOwnerPluginId } from "../../../context-engine/registry.js";
-import { buildContextEngineRuntimeSettings } from "../../../context-engine/runtime-settings.js";
 import { emitTrustedDiagnosticEvent } from "../../../infra/diagnostic-events.js";
 import {
   createChildDiagnosticTraceContext,
@@ -34,9 +33,7 @@ import { createBundleLspToolRuntime } from "../../agent-bundle-lsp-runtime.js";
 import { materializeBundleMcpToolsForRun } from "../../agent-bundle-mcp-tools.js";
 import { resolveAgentDir, resolveSessionAgentIds } from "../../agent-scope.js";
 import { createAnthropicPayloadLogger } from "../../anthropic-payload-log.js";
-import { isHeartbeatLifecycleRunKind } from "../../bootstrap-mode.js";
 import { createCacheTrace } from "../../cache-trace.js";
-import { DEFAULT_CONTEXT_TOKENS } from "../../defaults.js";
 import { countActiveToolExecutions } from "../../embedded-agent-subscribe.handlers.tools.js";
 import { isSignalTimeoutReason } from "../../failover-error.js";
 import { resolveImageSanitizationLimits } from "../../image-sanitization.js";
@@ -50,9 +47,7 @@ import {
   type ToolSearchCatalogRef,
   type ToolSearchCatalogToolExecutor,
 } from "../../tool-search.js";
-import { invalidateComputerFrameIfMissing } from "../../tools/computer-tool.js";
 import type { NormalizedUsage } from "../../usage.js";
-import { readLastCacheTtlTimestamp } from "../cache-ttl.js";
 import { resolveCompactionTimeoutMs } from "../compaction-safety-timeout.js";
 import { prepareGooglePromptCacheStreamFn } from "../google-prompt-cache.js";
 import { log } from "../logger.js";
@@ -64,11 +59,6 @@ import {
 } from "../runs.js";
 import { getEmbeddedSessionPromptState } from "../session-prompt-state.js";
 import { resolveEmbeddedAgentApiKey } from "../stream-resolution.js";
-import {
-  installContextEngineLoopHook,
-  installToolResultContextGuard,
-} from "../tool-result-context-guard.js";
-import { resolveLiveToolResultMaxChars } from "../tool-result-truncation.js";
 import { flushPendingToolResultsAfterIdle } from "../wait-for-idle-before-flush.js";
 import { abortable as abortableWithSignal } from "./abortable.js";
 import { releaseEmbeddedAttemptSessionLockForAbort } from "./attempt-abort.js";
@@ -86,6 +76,7 @@ import {
 } from "./attempt-prompt-preflight.js";
 import { submitEmbeddedAttemptPrompt } from "./attempt-prompt-submit.js";
 import { completeEmbeddedAttemptResult } from "./attempt-result.js";
+import { installEmbeddedAttemptRuntimeGuards } from "./attempt-runtime-guards.js";
 import { prepareEmbeddedAttemptSessionBoundary } from "./attempt-session-boundary.js";
 import { cleanupEmbeddedAttemptSessionPhase } from "./attempt-session-cleanup.js";
 import { prepareEmbeddedAttemptSessionManager } from "./attempt-session-manager-prepare.js";
@@ -109,14 +100,9 @@ import { prepareEmbeddedAttemptToolCatalog } from "./attempt-tool-catalog.js";
 import {
   cloneHookMessages,
   removeTrailingMidTurnPrecheckAssistantError,
-  repairAttemptToolUseResultPairing,
   resolveAttemptTrajectorySessionFile,
 } from "./attempt-transcript-helpers.js";
-import { buildLoopPromptCacheInfo } from "./attempt.context-engine-helpers.js";
-import {
-  buildAfterTurnRuntimeContext,
-  resolvePromptSubmissionSkipReason,
-} from "./attempt.prompt-helpers.js";
+import { resolvePromptSubmissionSkipReason } from "./attempt.prompt-helpers.js";
 import { resolveEmbeddedAttemptSessionWriteLockOptions } from "./attempt.run-decisions.js";
 import {
   acquireEmbeddedAttemptSessionFileOwner,
@@ -133,7 +119,6 @@ import {
   waitForSessionsYieldAbortSettle,
 } from "./attempt.sessions-yield.js";
 import { shouldFlagCompactionTimeout } from "./compaction-timeout.js";
-import { installHistoryImagePruneContextTransform } from "./history-image-prune.js";
 import { detectAndLoadPromptImages } from "./images.js";
 import { isMidTurnPrecheckSignal, type MidTurnPrecheckRequest } from "./midturn-precheck.js";
 import { PREEMPTIVE_OVERFLOW_ERROR_TEXT } from "./preemptive-compaction.js";
@@ -595,7 +580,6 @@ export async function runEmbeddedAttempt(
       // cannot rewrite the provider prompt-cache tail between turns (#99495).
       const sessionPromptState = getEmbeddedSessionPromptState(params.sessionId);
       const toolResultPromptProjectionState = sessionPromptState.toolResults;
-      let contextEngineAfterTurnCheckpoint: number | null = null;
       const sessionSettleTracker = createEmbeddedAttemptSessionSettleTracker(activeSession);
       const { abortActiveSession, trackPromptSettlePromise } = sessionSettleTracker;
       abortActiveSessionForExternalSignal = abortActiveSession;
@@ -606,132 +590,25 @@ export async function runEmbeddedAttempt(
       queueYieldInterruptForSession = () => {
         queueSessionsYieldInterruptMessage(activeSession);
       };
-      const contextTokenBudgetForGuard = Math.max(
-        1,
-        Math.floor(
-          params.contextTokenBudget ??
-            params.model.contextWindow ??
-            params.model.maxTokens ??
-            DEFAULT_CONTEXT_TOKENS,
-        ),
-      );
-      const toolResultMaxCharsForGuard = resolveLiveToolResultMaxChars({
-        contextWindowTokens: contextTokenBudgetForGuard,
-        cfg: params.config,
-        agentId: sessionAgentId,
+      const runtimeGuards = installEmbeddedAttemptRuntimeGuards({
+        activeContextEngine,
+        activeSession,
+        agentDir,
+        attempt: params,
+        computerContextEpoch,
+        effectiveCwd,
+        effectiveWorkspace,
+        getEffectivePromptCacheRetention: () => effectivePromptCacheRetention,
+        getPrePromptMessageCount: () => prePromptMessageCount,
+        getPromptCache: () => promptCache,
+        getSystemPrompt: () => systemPromptText,
+        isOpenAIResponsesApi,
+        repairToolUseResultPairing: transcriptPolicy.repairToolUseResultPairing,
+        sessionAgentId,
+        sessionManager,
+        settingsManager,
       });
-      const midTurnPrecheckEnabled =
-        params.config?.agents?.defaults?.compaction?.midTurnPrecheck?.enabled === true;
-      let pendingMidTurnPrecheckRequest: MidTurnPrecheckRequest | null = null;
-      const onMidTurnPrecheck = (request: MidTurnPrecheckRequest) => {
-        pendingMidTurnPrecheckRequest = request;
-      };
-      const midTurnPrecheckOptions = midTurnPrecheckEnabled
-        ? {
-            midTurnPrecheck: {
-              enabled: true,
-              contextTokenBudget: contextTokenBudgetForGuard,
-              reserveTokens: () => settingsManager.getCompactionReserveTokens(),
-              toolResultMaxChars: toolResultMaxCharsForGuard,
-              getSystemPrompt: () => systemPromptText,
-              getPrePromptMessageCount: () => prePromptMessageCount,
-              onMidTurnPrecheck,
-            },
-          }
-        : {};
-      if (activeContextEngine?.info.ownsCompaction === true) {
-        const selectedContextEngineId = activeContextEngine.info.id;
-        const contextEngineLoopRuntimeSettings = buildContextEngineRuntimeSettings({
-          contextEngineHost: OPENCLAW_EMBEDDED_CONTEXT_ENGINE_HOST,
-          provider: params.provider,
-          requestedModel: params.requestedModelId,
-          resolvedModel: params.modelId,
-          selectedContextEngineId,
-          contextEngineSelectionSource:
-            selectedContextEngineId === "legacy" ? "default" : "configured",
-          promptTokenBudget: params.contextTokenBudget,
-          fallbackReason: params.fallbackReason,
-          degradedReason: params.degradedReason,
-        });
-        const removeContextEngineLoopHook = installContextEngineLoopHook({
-          agent: activeSession.agent,
-          contextEngine: activeContextEngine,
-          sessionId: params.sessionId,
-          sessionKey: params.sessionKey,
-          sessionTarget: params.sessionTarget,
-          sessionFile: params.sessionFile,
-          tokenBudget: params.contextTokenBudget,
-          modelId: params.modelId,
-          ...(transcriptPolicy.repairToolUseResultPairing
-            ? {
-                repairAssembledMessages: (messages) =>
-                  repairAttemptToolUseResultPairing(messages, isOpenAIResponsesApi),
-              }
-            : {}),
-          getPrePromptMessageCount: () => prePromptMessageCount,
-          onAfterTurnCheckpoint: (messageCount) => {
-            contextEngineAfterTurnCheckpoint = messageCount;
-          },
-          getRuntimeContext: ({ messages, prePromptMessageCount: loopPrePromptMessageCount }) =>
-            buildAfterTurnRuntimeContext({
-              attempt: params,
-              workspaceDir: effectiveWorkspace,
-              cwd: effectiveCwd,
-              agentDir,
-              tokenBudget: params.contextTokenBudget,
-              promptCache:
-                promptCache ??
-                buildLoopPromptCacheInfo({
-                  messagesSnapshot: messages,
-                  prePromptMessageCount: loopPrePromptMessageCount,
-                  retention: effectivePromptCacheRetention,
-                  fallbackLastCacheTouchAt: readLastCacheTtlTimestamp(sessionManager, {
-                    provider: params.provider,
-                    modelId: params.modelId,
-                  }),
-                }),
-            }),
-          runtimeSettings: contextEngineLoopRuntimeSettings,
-          isHeartbeat: isHeartbeatLifecycleRunKind(params.bootstrapContextRunKind),
-        });
-        const removeGuard = installToolResultContextGuard({
-          agent: activeSession.agent,
-          contextWindowTokens: contextTokenBudgetForGuard,
-          ...midTurnPrecheckOptions,
-        });
-        removeToolResultContextGuard = () => {
-          removeGuard();
-          removeContextEngineLoopHook();
-        };
-      } else {
-        removeToolResultContextGuard = installToolResultContextGuard({
-          agent: activeSession.agent,
-          contextWindowTokens: contextTokenBudgetForGuard,
-          ...midTurnPrecheckOptions,
-        });
-      }
-      const removeLoopContextGuard = removeToolResultContextGuard;
-      const removeHistoryImagePruneContextTransform = installHistoryImagePruneContextTransform(
-        activeSession.agent,
-      );
-      const previousComputerFrameTransform = activeSession.agent.transformContext;
-      activeSession.agent.transformContext = async (messages, signal) => {
-        const transformed = previousComputerFrameTransform
-          ? await previousComputerFrameTransform.call(activeSession.agent, messages, signal)
-          : messages;
-        const modelContext = Array.isArray(transformed) ? transformed : messages;
-        invalidateComputerFrameIfMissing({
-          contextEpoch: computerContextEpoch,
-          messages: modelContext,
-          imagesBlocked: settingsManager.getBlockImages(),
-        });
-        return modelContext;
-      };
-      removeToolResultContextGuard = () => {
-        activeSession.agent.transformContext = previousComputerFrameTransform;
-        removeHistoryImagePruneContextTransform();
-        removeLoopContextGuard?.();
-      };
+      removeToolResultContextGuard = runtimeGuards.cleanup;
       const cacheTrace = createCacheTrace({
         cfg: params.config,
         env: process.env,
@@ -1501,9 +1378,9 @@ export async function runEmbeddedAttempt(
           );
         }
 
+        const pendingMidTurnPrecheckRequest = runtimeGuards.takePendingMidTurnPrecheckRequest();
         if (pendingMidTurnPrecheckRequest) {
           const request = pendingMidTurnPrecheckRequest;
-          pendingMidTurnPrecheckRequest = null;
           await sessionLockController.waitForSessionEvents(activeSession);
           await withOwnedSessionWriteLock(() => {
             removeTrailingMidTurnPrecheckAssistantError({
@@ -1597,7 +1474,7 @@ export async function runEmbeddedAttempt(
             sessionFileUsed,
             messagesSnapshot,
             prePromptMessageCount,
-            contextEngineAfterTurnCheckpoint,
+            contextEngineAfterTurnCheckpoint: runtimeGuards.getContextEngineAfterTurnCheckpoint(),
             lastCallUsage,
             promptCache,
             ...(beforeAgentFinalizeRevisionReason ? { beforeAgentFinalizeRevisionReason } : {}),


### PR DESCRIPTION
## What Problem This Solves

`runEmbeddedAttempt` still installed and coordinated four independent prompt-runtime guards inline: context-engine loop compaction, tool-result overflow prechecks, history-image pruning, and computer-frame invalidation. Their shared transform stack and cleanup ordering formed a cohesive lifecycle unit but occupied more than 140 lines inside the main orchestration function.

## Why This Change Was Made

This extracts that lifecycle into `attempt-runtime-guards.ts`. The helper owns transform layering, cleanup symmetry, one-shot mid-turn precheck consumption, and the context-engine after-turn checkpoint; `attempt.ts` now only supplies live state accessors and consumes the two resulting signals. Focused tests exercise cleanup restoration, overflow request consumption, and context-engine checkpoint propagation.

## User Impact

No intended behavior change. `attempt.ts` drops from 1,762 to 1,639 lines while the runtime guard boundary gains direct unit coverage. No changelog entry is needed for this internal refactor.

## Evidence

- Blacksmith Testbox focused surface: 139/139 tests passed across the new helper, tool-result guard, history-image prune, and context-engine integration suites.
- Blacksmith Testbox `check:changed`: core and coreTests lanes passed, including the TypeScript LOC ratchet, typechecks, lint, import-cycle, storage, and boundary guards.
- Fresh full-branch autoreview: clean; no accepted/actionable findings.
- Hosted CI was not awaited, per maintainer instruction.
