### PR TITLE
fix(plugins): keep run context available after registration

### DIFF
--- a/src/plugins/api-lifecycle.ts
+++ b/src/plugins/api-lifecycle.ts
@@ -18,10 +18,13 @@ type PluginApiLifecyclePolicy = {
 };
 
 const PLUGIN_API_METHOD_POLICIES: Partial<Record<PluginApiMethodName, PluginApiLifecyclePolicy>> = {
+  clearRunContext: { phase: "runtime", lateCallable: true },
   emitAgentEvent: { phase: "runtime", lateCallable: true },
   enqueueNextTurnInjection: { phase: "runtime", lateCallable: true },
+  getRunContext: { phase: "runtime", lateCallable: true },
   sendSessionAttachment: { phase: "runtime", lateCallable: true },
   scheduleSessionTurn: { phase: "runtime", lateCallable: true },
+  setRunContext: { phase: "runtime", lateCallable: true },
   unscheduleSessionTurnsByTag: { phase: "runtime", lateCallable: true },
 };
 

--- a/src/plugins/contracts/run-context-lifecycle.contract.test.ts
+++ b/src/plugins/contracts/run-context-lifecycle.contract.test.ts
@@ -21,6 +21,7 @@ import {
   listPluginSessionSchedulerJobs,
   PLUGIN_TERMINAL_EVENT_CLEANUP_WAIT_MS,
 } from "../host-hook-runtime.test-fixtures.js";
+import { runPluginRegisterSync } from "../loader-module-runtime.js";
 import { createEmptyPluginRegistry } from "../registry-empty.js";
 import { setActivePluginRegistry } from "../runtime.js";
 import { createPluginRecord } from "../status.test-helpers.js";
@@ -57,7 +58,52 @@ describe("plugin run context lifecycle", () => {
     resetAgentEventsForTest();
   });
 
-  it("blocks stale plugin API run-context mutations after registry replacement", () => {
+  it("keeps run-context APIs callable after registration closes", () => {
+    const { config, registry } = createPluginRegistryFixture();
+    let capturedApi: OpenClawPluginApi | undefined;
+    registerTestPlugin({
+      registry,
+      config,
+      record: createPluginRecord({
+        id: "late-run-context-plugin",
+        name: "Late Run Context Plugin",
+      }),
+      register(api) {
+        runPluginRegisterSync((guardedApi) => {
+          capturedApi = guardedApi;
+        }, api);
+      },
+    });
+    setActivePluginRegistry(registry.registry);
+
+    capturedApi?.registerGatewayMethod("late-run-context.blocked", () => {});
+    expect(Object.keys(registry.registry.gatewayHandlers)).not.toContain(
+      "late-run-context.blocked",
+    );
+    expect(
+      capturedApi?.runContext.setRunContext({
+        runId: "late-run",
+        namespace: "state",
+        value: { available: true },
+      }),
+    ).toBe(true);
+    expect(
+      capturedApi?.runContext.getRunContext({
+        runId: "late-run",
+        namespace: "state",
+      }),
+    ).toEqual({ available: true });
+
+    capturedApi?.runContext.clearRunContext({ runId: "late-run", namespace: "state" });
+    expect(
+      capturedApi?.runContext.getRunContext({
+        runId: "late-run",
+        namespace: "state",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("blocks stale plugin API run-context access after registry replacement", () => {
     const { config, registry } = createPluginRegistryFixture();
     let capturedApi: OpenClawPluginApi | undefined;
     registerTestPlugin({
@@ -94,6 +140,10 @@ describe("plugin run context lifecycle", () => {
         patch: { runId: "stale-run", namespace: "state", value: { live: true } },
       }),
     ).toBe(true);
+    expect(capturedApi?.getRunContext({ runId: "stale-run", namespace: "state" })).toBeUndefined();
+    expect(
+      capturedApi?.runContext.getRunContext({ runId: "stale-run", namespace: "state" }),
+    ).toBeUndefined();
     capturedApi?.runContext?.clearRunContext({ runId: "stale-run", namespace: "state" });
     expect(
       getPluginRunContext({

--- a/src/plugins/registry-api.ts
+++ b/src/plugins/registry-api.ts
@@ -286,7 +286,11 @@ export function createPluginApiFactory(
                 shouldCommitWorkflowSideEffect()
                   ? setPluginRunContext({ pluginId: record.id, patch })
                   : false,
-              getRunContext: (get) => getPluginRunContext({ pluginId: record.id, get }),
+              getRunContext: (get) =>
+                registryParams.activateGlobalSideEffects !== false &&
+                shouldCommitWorkflowSideEffect()
+                  ? getPluginRunContext({ pluginId: record.id, get })
+                  : undefined,
               clearRunContext: (paramsLocal) => {
                 if (
                   registryParams.activateGlobalSideEffects === false ||


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where plugins using `api.runContext` from runtime callbacks would receive no-op writes and `undefined` reads after their synchronous `register()` function returned.

## Why This Change Was Made

Run-context operations are runtime APIs, so the centralized plugin lifecycle policy now keeps `setRunContext`, `getRunContext`, and `clearRunContext` callable after registration closes. Reads also use the existing active-registry guard, preventing a retired plugin API from observing state owned by a replacement registry.

## User Impact

Plugin runtime callbacks can persist, read, and clear run-scoped state as documented. Registration-only APIs remain blocked after registration, and stale plugin instances cannot access or delete replacement-registry state.

## Evidence

- Exact-head installed-plugin/Gateway proof passed on `6eb9fa5ed78ce1bd742c9e82a2b85a5808ee9ae3`: a built Gateway loaded an external fixture plugin, invoked its registered runtime callback after registration closed, and returned `set: true`, the expected marker from `get`, and empty state after `clear`.
- 16 focused lifecycle contract tests passed on the exact head, including active post-registration set/get/clear and retired-registry denial.
- The current-main rebase conflict was limited to preserving both #111131's `enqueueNextTurnInjection` lifecycle policy and this PR's `getRunContext` policy.
- Targeted format, lint, build, and `git diff --check` passed.
- Fresh exact-head autoreview reported no actionable findings (0.91 confidence).
