### PR TITLE
refactor(agents): extract attempt abort lifecycle

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt-abort.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-abort.test.ts
@@ -1,6 +1,215 @@
-// Coverage for releasing session locks from abort paths.
-import { describe, expect, it, vi } from "vitest";
-import { releaseEmbeddedAttemptSessionLockForAbort } from "./attempt-abort.js";
+// Coverage for external cancellation, timeout, and session-lock release paths.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { EmbeddedAgentQueueHandle } from "../runs.js";
+import {
+  createEmbeddedAttemptExternalAbortController,
+  createEmbeddedAttemptRunAbort,
+  releaseEmbeddedAttemptSessionLockForAbort,
+  type EmbeddedAttemptAbortStatePort,
+} from "./attempt-abort.js";
+
+const mocks = vi.hoisted(() => ({
+  countActiveToolExecutions: vi.fn(() => 0),
+  markActiveEmbeddedRunAbandoned: vi.fn(),
+}));
+
+vi.mock("../../embedded-agent-subscribe.handlers.tools.js", () => ({
+  countActiveToolExecutions: mocks.countActiveToolExecutions,
+}));
+
+vi.mock("../runs.js", () => ({
+  markActiveEmbeddedRunAbandoned: mocks.markActiveEmbeddedRunAbandoned,
+}));
+
+function createAbortState() {
+  let timedOutDuringCompaction = false;
+  const markAborted = vi.fn();
+  const markExternalAbort = vi.fn();
+  const markTimedOut = vi.fn();
+  const markTimedOutDuringCompaction = vi.fn(() => {
+    timedOutDuringCompaction = true;
+  });
+  const markTimedOutDuringToolExecution = vi.fn();
+  const readTimedOutDuringCompaction = vi.fn(() => timedOutDuringCompaction);
+  const setPromptError = vi.fn();
+  const port: EmbeddedAttemptAbortStatePort = {
+    markAborted,
+    markExternalAbort,
+    markTimedOut,
+    markTimedOutDuringCompaction,
+    markTimedOutDuringToolExecution,
+    readTimedOutDuringCompaction,
+    setPromptError,
+  };
+  return {
+    port,
+    markAborted,
+    markExternalAbort,
+    markTimedOut,
+    markTimedOutDuringCompaction,
+    markTimedOutDuringToolExecution,
+    setPromptError,
+  };
+}
+
+beforeEach(() => {
+  mocks.countActiveToolExecutions.mockReset().mockReturnValue(0);
+  mocks.markActiveEmbeddedRunAbandoned.mockReset();
+});
+
+describe("createEmbeddedAttemptExternalAbortController", () => {
+  it("aborts setup state before the live run handler is installed", () => {
+    const source = new AbortController();
+    const runAbortController = new AbortController();
+    const state = createAbortState();
+    const abortActiveSession = vi.fn(async () => {});
+    const controller = createEmbeddedAttemptExternalAbortController({
+      abortSignal: source.signal,
+      cleanupAfterEarlyAbort: vi.fn(async () => {}),
+      runAbortController,
+      runId: "run-external",
+      state: state.port,
+    });
+    controller.setActiveSessionAbort(abortActiveSession);
+    controller.arm();
+    const reason = new Error("cancelled");
+
+    source.abort(reason);
+
+    expect(state.markExternalAbort).toHaveBeenCalledTimes(1);
+    expect(state.markAborted).toHaveBeenCalledTimes(1);
+    expect(state.setPromptError).toHaveBeenCalledWith(reason);
+    expect(runAbortController.signal.reason).toBe(reason);
+    expect(abortActiveSession).toHaveBeenCalledTimes(1);
+    controller.dispose();
+  });
+
+  it("classifies timeout during compaction without also blaming a tool", () => {
+    const source = new AbortController();
+    const runAbortController = new AbortController();
+    const state = createAbortState();
+    mocks.countActiveToolExecutions.mockReturnValue(1);
+    const controller = createEmbeddedAttemptExternalAbortController({
+      abortSignal: source.signal,
+      cleanupAfterEarlyAbort: vi.fn(async () => {}),
+      runAbortController,
+      runId: "run-compaction-timeout",
+      state: state.port,
+    });
+    controller.setCompactionState({
+      isPendingOrRetrying: () => true,
+      isInFlight: () => false,
+    });
+    controller.arm();
+    const reason = new Error("deadline");
+    reason.name = "TimeoutError";
+
+    source.abort(reason);
+
+    expect(state.markTimedOutDuringCompaction).toHaveBeenCalledTimes(1);
+    expect(state.markTimedOut).toHaveBeenCalledTimes(1);
+    expect(state.markTimedOutDuringToolExecution).not.toHaveBeenCalled();
+    expect(runAbortController.signal.reason).toBe(reason);
+    controller.dispose();
+  });
+
+  it("hands cancellation to the live run handler once installed", () => {
+    const source = new AbortController();
+    const state = createAbortState();
+    const abortRun = vi.fn();
+    const controller = createEmbeddedAttemptExternalAbortController({
+      abortSignal: source.signal,
+      cleanupAfterEarlyAbort: vi.fn(async () => {}),
+      runAbortController: new AbortController(),
+      runId: "run-live",
+      state: state.port,
+    });
+    controller.setRunAbort(abortRun);
+    controller.arm();
+    const reason = new Error("cancelled live run");
+
+    source.abort(reason);
+
+    expect(state.markExternalAbort).toHaveBeenCalledTimes(1);
+    expect(abortRun).toHaveBeenCalledWith(false, reason);
+    expect(state.markAborted).not.toHaveBeenCalled();
+    expect(state.setPromptError).not.toHaveBeenCalled();
+    controller.dispose();
+  });
+
+  it("cleans prepared resources before rejecting a pre-fired signal", async () => {
+    const source = new AbortController();
+    const reason = new Error("cancelled during setup");
+    source.abort(reason);
+    const cleanupAfterEarlyAbort = vi.fn(async () => {});
+    const state = createAbortState();
+    const controller = createEmbeddedAttemptExternalAbortController({
+      abortSignal: source.signal,
+      cleanupAfterEarlyAbort,
+      runAbortController: new AbortController(),
+      runId: "run-setup",
+      state: state.port,
+    });
+
+    await expect(controller.throwIfFiredAfterPrepCleanup()).rejects.toBe(reason);
+
+    expect(cleanupAfterEarlyAbort).toHaveBeenCalledTimes(1);
+    expect(state.markAborted).toHaveBeenCalledTimes(1);
+    expect(state.markExternalAbort).toHaveBeenCalledTimes(1);
+    expect(state.setPromptError).toHaveBeenCalledWith(reason);
+  });
+});
+
+describe("createEmbeddedAttemptRunAbort", () => {
+  it("settles timeout state, session work, queue ownership, and the lock", async () => {
+    const state = createAbortState();
+    const timeoutReason = new Error("attempt deadline");
+    timeoutReason.name = "TimeoutError";
+    const abortCompaction = vi.fn();
+    const abortActiveSession = vi.fn(async () => {});
+    const onAttemptTimeout = vi.fn();
+    const releaseHeldLockForAbort = vi.fn(async () => {});
+    const queueHandle = {} as EmbeddedAgentQueueHandle;
+    const runAbortController = new AbortController();
+    mocks.countActiveToolExecutions.mockReturnValue(1);
+    const abortRun = createEmbeddedAttemptRunAbort({
+      abortActiveSession,
+      activeSession: { abortCompaction, isCompacting: true },
+      attempt: {
+        onAttemptTimeout,
+        runId: "run-timeout",
+        sessionFile: "/tmp/session.jsonl",
+        sessionId: "session-timeout",
+        sessionKey: "agent:main",
+      },
+      getQueueHandle: () => queueHandle,
+      isProbeSession: false,
+      log: { warn: vi.fn() },
+      runAbortController,
+      sessionLockController: { releaseHeldLockForAbort },
+      state: state.port,
+    });
+
+    abortRun(true, timeoutReason);
+    await Promise.resolve();
+
+    expect(state.markAborted).toHaveBeenCalledTimes(1);
+    expect(state.markTimedOut).toHaveBeenCalledTimes(1);
+    expect(state.markTimedOutDuringToolExecution).toHaveBeenCalledTimes(1);
+    expect(onAttemptTimeout).toHaveBeenCalledWith(timeoutReason);
+    expect(runAbortController.signal.reason).toBe(timeoutReason);
+    expect(abortCompaction).toHaveBeenCalledTimes(1);
+    expect(abortActiveSession).toHaveBeenCalledTimes(1);
+    expect(mocks.markActiveEmbeddedRunAbandoned).toHaveBeenCalledWith({
+      sessionId: "session-timeout",
+      handle: queueHandle,
+      sessionKey: "agent:main",
+      sessionFile: "/tmp/session.jsonl",
+      reason: "timeout",
+    });
+    expect(releaseHeldLockForAbort).toHaveBeenCalledTimes(1);
+  });
+});
 
 describe("releaseEmbeddedAttemptSessionLockForAbort", () => {
   it("releases the retained session lock for manual aborts", async () => {

--- a/src/agents/embedded-agent-runner/run/attempt-abort.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-abort.ts
@@ -1,11 +1,228 @@
 /**
  * Releases attempt resources when an embedded-agent run aborts.
  */
+import { countActiveToolExecutions } from "../../embedded-agent-subscribe.handlers.tools.js";
+import { isSignalTimeoutReason } from "../../failover-error.js";
+import type { AgentSession } from "../../sessions/index.js";
+import { markActiveEmbeddedRunAbandoned, type EmbeddedAgentQueueHandle } from "../runs.js";
 import type { EmbeddedAttemptSessionLockController } from "./attempt.session-lock.js";
+import { shouldFlagCompactionTimeout } from "./compaction-timeout.js";
+import type { EmbeddedRunAttemptParams } from "./types.js";
 
 type AbortLockReleaseLog = {
   warn(message: string): void;
 };
+
+export type EmbeddedAttemptAbortStatePort = {
+  markAborted: () => void;
+  markExternalAbort: () => void;
+  markTimedOut: () => void;
+  markTimedOutDuringCompaction: () => void;
+  markTimedOutDuringToolExecution: () => void;
+  readTimedOutDuringCompaction: () => boolean;
+  setPromptError: (error: unknown) => void;
+};
+
+type ActiveSessionAbort = (reason?: unknown) => Promise<void>;
+type RunAbort = (isTimeout?: boolean, reason?: unknown) => void;
+
+function createAttemptAbortError(signal: AbortSignal): Error {
+  if (signal.reason instanceof Error) {
+    return signal.reason;
+  }
+  const error = new Error("request aborted", { cause: signal.reason });
+  error.name = "AbortError";
+  return error;
+}
+
+function getAbortReason(signal: AbortSignal): unknown {
+  return "reason" in signal ? (signal as { reason?: unknown }).reason : undefined;
+}
+
+function createTimeoutAbortReason(): Error {
+  const error = new Error("request timed out");
+  error.name = "TimeoutError";
+  return error;
+}
+
+/** Owns the external AbortSignal listener and its handoff to the live session. */
+export function createEmbeddedAttemptExternalAbortController(input: {
+  abortSignal?: AbortSignal;
+  cleanupAfterEarlyAbort: () => Promise<void>;
+  runAbortController: AbortController;
+  runId: string;
+  state: EmbeddedAttemptAbortStatePort;
+}): {
+  arm: () => void;
+  dispose: () => void;
+  setActiveSessionAbort: (abort: ActiveSessionAbort) => void;
+  setCompactionState: (state: {
+    isInFlight: () => boolean;
+    isPendingOrRetrying: () => boolean;
+  }) => void;
+  setRunAbort: (abort: RunAbort) => void;
+  throwIfFiredAfterPrepCleanup: () => Promise<void>;
+} {
+  let abortActiveSession: ActiveSessionAbort | undefined;
+  let abortRun: RunAbort | undefined;
+  let isCompactionPendingOrRetrying: (() => boolean) | undefined;
+  let isCompactionInFlight: (() => boolean) | undefined;
+  let removeListener: (() => void) | undefined;
+
+  const onAbort = () => {
+    const signal = input.abortSignal;
+    if (!signal) {
+      return;
+    }
+    input.state.markExternalAbort();
+    const reason = getAbortReason(signal);
+    const isTimeout = reason ? isSignalTimeoutReason(reason) : false;
+    if (
+      shouldFlagCompactionTimeout({
+        isTimeout,
+        isCompactionPendingOrRetrying: isCompactionPendingOrRetrying?.() ?? false,
+        isCompactionInFlight: isCompactionInFlight?.() ?? false,
+      })
+    ) {
+      input.state.markTimedOutDuringCompaction();
+    }
+    if (abortRun) {
+      abortRun(isTimeout, reason);
+      return;
+    }
+    input.state.markAborted();
+    if (isTimeout) {
+      input.state.markTimedOut();
+      if (
+        !input.state.readTimedOutDuringCompaction() &&
+        countActiveToolExecutions(input.runId) > 0
+      ) {
+        input.state.markTimedOutDuringToolExecution();
+      }
+    }
+    input.state.setPromptError(createAttemptAbortError(signal));
+    if (!input.runAbortController.signal.aborted) {
+      input.runAbortController.abort(isTimeout ? (reason ?? createTimeoutAbortReason()) : reason);
+    }
+    void abortActiveSession?.();
+  };
+
+  return {
+    arm: () => {
+      const signal = input.abortSignal;
+      if (!signal || removeListener) {
+        return;
+      }
+      if (signal.aborted) {
+        onAbort();
+        return;
+      }
+      signal.addEventListener("abort", onAbort, { once: true });
+      removeListener = () => {
+        signal.removeEventListener("abort", onAbort);
+        removeListener = undefined;
+      };
+    },
+    dispose: () => {
+      removeListener?.();
+    },
+    setActiveSessionAbort: (abort) => {
+      abortActiveSession = abort;
+    },
+    setCompactionState: (state) => {
+      isCompactionPendingOrRetrying = state.isPendingOrRetrying;
+      isCompactionInFlight = state.isInFlight;
+    },
+    setRunAbort: (abort) => {
+      abortRun = abort;
+    },
+    throwIfFiredAfterPrepCleanup: async () => {
+      const signal = input.abortSignal;
+      if (!signal?.aborted) {
+        return;
+      }
+      const abortError = createAttemptAbortError(signal);
+      input.state.markAborted();
+      input.state.markExternalAbort();
+      input.state.setPromptError(abortError);
+      await input.cleanupAfterEarlyAbort();
+      throw abortError;
+    },
+  };
+}
+
+/** Builds the live-session abort handler shared by timeouts and explicit cancellation. */
+export function createEmbeddedAttemptRunAbort(input: {
+  abortActiveSession: ActiveSessionAbort;
+  activeSession: Pick<AgentSession, "abortCompaction" | "isCompacting">;
+  attempt: Pick<
+    EmbeddedRunAttemptParams,
+    "onAttemptTimeout" | "runId" | "sessionFile" | "sessionId" | "sessionKey"
+  >;
+  getQueueHandle: () => EmbeddedAgentQueueHandle | undefined;
+  isProbeSession: boolean;
+  log: AbortLockReleaseLog;
+  runAbortController: AbortController;
+  sessionLockController: Pick<EmbeddedAttemptSessionLockController, "releaseHeldLockForAbort">;
+  state: Pick<
+    EmbeddedAttemptAbortStatePort,
+    | "markAborted"
+    | "markTimedOut"
+    | "markTimedOutDuringToolExecution"
+    | "readTimedOutDuringCompaction"
+  >;
+}): RunAbort {
+  const abortCompaction = () => {
+    if (!input.activeSession.isCompacting) {
+      return;
+    }
+    try {
+      input.activeSession.abortCompaction();
+    } catch (error) {
+      if (!input.isProbeSession) {
+        input.log.warn(
+          `embedded run abortCompaction failed: runId=${input.attempt.runId} sessionId=${input.attempt.sessionId} err=${String(error)}`,
+        );
+      }
+    }
+  };
+
+  return (isTimeout = false, reason?: unknown) => {
+    input.state.markAborted();
+    if (isTimeout) {
+      input.state.markTimedOut();
+      if (
+        !input.state.readTimedOutDuringCompaction() &&
+        countActiveToolExecutions(input.attempt.runId) > 0
+      ) {
+        input.state.markTimedOutDuringToolExecution();
+      }
+      const timeoutReason = reason instanceof Error ? reason : createTimeoutAbortReason();
+      input.attempt.onAttemptTimeout?.(timeoutReason);
+      input.runAbortController.abort(timeoutReason);
+    } else {
+      input.runAbortController.abort(reason);
+    }
+    abortCompaction();
+    void input.abortActiveSession();
+    const queueHandle = input.getQueueHandle();
+    if (isTimeout && queueHandle) {
+      markActiveEmbeddedRunAbandoned({
+        sessionId: input.attempt.sessionId,
+        handle: queueHandle,
+        sessionKey: input.attempt.sessionKey,
+        sessionFile: input.attempt.sessionFile,
+        reason: "timeout",
+      });
+    }
+    releaseEmbeddedAttemptSessionLockForAbort({
+      sessionLockController: input.sessionLockController,
+      log: input.log,
+      runId: input.attempt.runId,
+      abortKind: isTimeout ? "timeout abort" : "abort",
+    });
+  };
+}
 
 /**
  * Releases the held session lock after an abort without blocking abort

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -30,8 +30,6 @@ import { materializeBundleMcpToolsForRun } from "../../agent-bundle-mcp-tools.js
 import { resolveAgentDir, resolveSessionAgentIds } from "../../agent-scope.js";
 import { createAnthropicPayloadLogger } from "../../anthropic-payload-log.js";
 import { createCacheTrace } from "../../cache-trace.js";
-import { countActiveToolExecutions } from "../../embedded-agent-subscribe.handlers.tools.js";
-import { isSignalTimeoutReason } from "../../failover-error.js";
 import { resolveImageSanitizationLimits } from "../../image-sanitization.js";
 import type { AgentMessage } from "../../runtime/index.js";
 import type { guardSessionManager } from "../../session-tool-result-guard-wrapper.js";
@@ -48,16 +46,16 @@ import { resolveCompactionTimeoutMs } from "../compaction-safety-timeout.js";
 import { prepareGooglePromptCacheStreamFn } from "../google-prompt-cache.js";
 import { log } from "../logger.js";
 import type { PromptCacheBreak, PromptCacheChange } from "../prompt-cache-observability.js";
-import {
-  clearActiveEmbeddedRun,
-  type EmbeddedAgentQueueHandle,
-  markActiveEmbeddedRunAbandoned,
-} from "../runs.js";
+import { clearActiveEmbeddedRun, type EmbeddedAgentQueueHandle } from "../runs.js";
 import { getEmbeddedSessionPromptState } from "../session-prompt-state.js";
 import { resolveEmbeddedAgentApiKey } from "../stream-resolution.js";
 import { flushPendingToolResultsAfterIdle } from "../wait-for-idle-before-flush.js";
 import { abortable as abortableWithSignal } from "./abortable.js";
-import { releaseEmbeddedAttemptSessionLockForAbort } from "./attempt-abort.js";
+import {
+  createEmbeddedAttemptExternalAbortController,
+  createEmbeddedAttemptRunAbort,
+  type EmbeddedAttemptAbortStatePort,
+} from "./attempt-abort.js";
 import { completeEmbeddedAttemptAfterTurn } from "./attempt-after-turn.js";
 import { runEmbeddedAttemptBeforeAgentRun } from "./attempt-before-agent-run.js";
 import { prepareEmbeddedAttemptBootstrap } from "./attempt-bootstrap-prepare.js";
@@ -114,7 +112,6 @@ import {
   stripSessionsYieldArtifacts,
   waitForSessionsYieldAbortSettle,
 } from "./attempt.sessions-yield.js";
-import { shouldFlagCompactionTimeout } from "./compaction-timeout.js";
 import { detectAndLoadPromptImages } from "./images.js";
 import { isMidTurnPrecheckSignal, type MidTurnPrecheckRequest } from "./midturn-precheck.js";
 import { PREEMPTIVE_OVERFLOW_ERROR_TEXT } from "./preemptive-compaction.js";
@@ -163,26 +160,6 @@ export async function runEmbeddedAttempt(
   let toolSearchCatalogRef: ToolSearchCatalogRef | undefined;
   let toolSearchCatalogApplied = false;
   const sessionCleanupOwnsEmbeddedResources = false;
-  let abortActiveSessionForExternalSignal: (() => Promise<void>) | undefined;
-  let abortRunForExternalSignal: ((isTimeout?: boolean, reason?: unknown) => void) | undefined;
-  let isCompactionPendingForExternalSignal: (() => boolean) | undefined;
-  let isCompactionInFlightForExternalSignal: (() => boolean) | undefined;
-  let removeExternalAbortSignalListener: (() => void) | undefined;
-  const createAttemptAbortError = (signal: AbortSignal): Error => {
-    if (signal.reason instanceof Error) {
-      return signal.reason;
-    }
-    const err = new Error("request aborted", { cause: signal.reason });
-    err.name = "AbortError";
-    return err;
-  };
-  const getAbortReason = (signal: AbortSignal): unknown =>
-    "reason" in signal ? (signal as { reason?: unknown }).reason : undefined;
-  const makeTimeoutAbortReason = (): Error => {
-    const err = new Error("request timed out");
-    err.name = "TimeoutError";
-    return err;
-  };
   const cleanupEmbeddedPrepResourcesAfterEarlyExit = async () => {
     if (toolSearchCatalogApplied) {
       clearToolSearchCatalog({
@@ -209,65 +186,34 @@ export async function runEmbeddedAttempt(
       bundleLspRuntime = undefined;
     }
   };
-  const onExternalAbortSignal = () => {
-    const signal = params.abortSignal;
-    if (!signal) {
-      return;
-    }
-    externalAbort = true;
-    const reason = getAbortReason(signal);
-    const timeout = reason ? isSignalTimeoutReason(reason) : false;
-    if (
-      shouldFlagCompactionTimeout({
-        isTimeout: timeout,
-        isCompactionPendingOrRetrying: isCompactionPendingForExternalSignal?.() ?? false,
-        isCompactionInFlight: isCompactionInFlightForExternalSignal?.() ?? false,
-      })
-    ) {
-      timedOutDuringCompaction = true;
-    }
-    if (abortRunForExternalSignal) {
-      abortRunForExternalSignal(timeout, reason);
-      return;
-    }
-    aborted = true;
-    if (timeout) {
-      timedOut = true;
-      if (!timedOutDuringCompaction && countActiveToolExecutions(params.runId) > 0) {
-        timedOutDuringToolExecution = true;
-      }
-    }
-    promptError = createAttemptAbortError(signal);
-    if (!runAbortController.signal.aborted) {
-      runAbortController.abort(timeout ? (reason ?? makeTimeoutAbortReason()) : reason);
-    }
-    void abortActiveSessionForExternalSignal?.();
-  };
-  const armExternalAbortSignal = () => {
-    const signal = params.abortSignal;
-    if (!signal || removeExternalAbortSignalListener) {
-      return;
-    }
-    if (signal.aborted) {
-      onExternalAbortSignal();
-      return;
-    }
-    signal.addEventListener("abort", onExternalAbortSignal, { once: true });
-    removeExternalAbortSignalListener = () => {
-      signal.removeEventListener("abort", onExternalAbortSignal);
-      removeExternalAbortSignalListener = undefined;
-    };
-  };
-  const throwIfAttemptAbortSignalFiredAfterPrepCleanup = async () => {
-    if (params.abortSignal?.aborted === true) {
-      const abortError = createAttemptAbortError(params.abortSignal);
+  const abortState: EmbeddedAttemptAbortStatePort = {
+    markAborted: () => {
       aborted = true;
+    },
+    markExternalAbort: () => {
       externalAbort = true;
-      promptError = abortError;
-      await cleanupEmbeddedPrepResourcesAfterEarlyExit();
-      throw abortError;
-    }
+    },
+    markTimedOut: () => {
+      timedOut = true;
+    },
+    markTimedOutDuringCompaction: () => {
+      timedOutDuringCompaction = true;
+    },
+    markTimedOutDuringToolExecution: () => {
+      timedOutDuringToolExecution = true;
+    },
+    readTimedOutDuringCompaction: () => timedOutDuringCompaction,
+    setPromptError: (error) => {
+      promptError = error;
+    },
   };
+  const externalAbortController = createEmbeddedAttemptExternalAbortController({
+    abortSignal: params.abortSignal,
+    cleanupAfterEarlyAbort: cleanupEmbeddedPrepResourcesAfterEarlyExit,
+    runAbortController,
+    runId: params.runId,
+    state: abortState,
+  });
   try {
     const preparedSkills = prepareEmbeddedAttemptSkills({
       attempt: params,
@@ -438,7 +384,7 @@ export async function runEmbeddedAttempt(
       config: params.config,
       compactionTimeoutMs,
     });
-    await throwIfAttemptAbortSignalFiredAfterPrepCleanup();
+    await externalAbortController.throwIfFiredAfterPrepCleanup();
     retainedSessionFileOwner = await acquireEmbeddedAttemptSessionFileOwner({
       sessionFile: params.sessionFile,
       timeoutMs: sessionWriteLockOptions.maxHoldMs,
@@ -482,10 +428,10 @@ export async function runEmbeddedAttempt(
       withOwnedSessionTranscriptWrites(ownedTranscriptWriteContext, async () =>
         sessionLockController.withSessionWriteLock(operation),
       );
-    armExternalAbortSignal();
+    externalAbortController.arm();
     // The signal can fire while the eager session lock is being acquired.
     // Recheck after arming so a stopped run never reaches session creation or provider prompt.
-    await throwIfAttemptAbortSignalFiredAfterPrepCleanup();
+    await externalAbortController.throwIfFiredAfterPrepCleanup();
 
     let session: AgentSession | undefined;
     let removeToolResultContextGuard: (() => void) | undefined;
@@ -579,7 +525,7 @@ export async function runEmbeddedAttempt(
       let promptCache: EmbeddedRunAttemptResult["promptCache"];
       const sessionSettleTracker = createEmbeddedAttemptSessionSettleTracker(activeSession);
       const { abortActiveSession, trackPromptSettlePromise } = sessionSettleTracker;
-      abortActiveSessionForExternalSignal = abortActiveSession;
+      externalAbortController.setActiveSessionAbort(abortActiveSession);
       buildAbortSettlePromise = sessionSettleTracker.buildAbortSettlePromise;
       abortSessionForYield = () => {
         yieldAbortSettled = abortActiveSession(SESSIONS_YIELD_ABORT_REASON);
@@ -728,54 +674,19 @@ export async function runEmbeddedAttempt(
 
       let yieldAborted = false;
       const isProbeSession = params.sessionId?.startsWith("probe-") ?? false;
-      const abortCompaction = () => {
-        if (!activeSession.isCompacting) {
-          return;
-        }
-        try {
-          activeSession.abortCompaction();
-        } catch (err) {
-          if (!isProbeSession) {
-            log.warn(
-              `embedded run abortCompaction failed: runId=${params.runId} sessionId=${params.sessionId} err=${String(err)}`,
-            );
-          }
-        }
-      };
-      const abortRun = (isTimeout = false, reason?: unknown) => {
-        aborted = true;
-        if (isTimeout) {
-          timedOut = true;
-          if (!timedOutDuringCompaction && countActiveToolExecutions(params.runId) > 0) {
-            timedOutDuringToolExecution = true;
-          }
-        }
-        if (isTimeout) {
-          const timeoutReason = reason instanceof Error ? reason : makeTimeoutAbortReason();
-          params.onAttemptTimeout?.(timeoutReason);
-          runAbortController.abort(timeoutReason);
-        } else {
-          runAbortController.abort(reason);
-        }
-        abortCompaction();
-        void abortActiveSession();
-        if (isTimeout && queueHandleForAbandonment) {
-          markActiveEmbeddedRunAbandoned({
-            sessionId: params.sessionId,
-            handle: queueHandleForAbandonment,
-            sessionKey: params.sessionKey,
-            sessionFile: params.sessionFile,
-            reason: "timeout",
-          });
-        }
-        releaseEmbeddedAttemptSessionLockForAbort({
-          sessionLockController,
-          log,
-          runId: params.runId,
-          abortKind: isTimeout ? "timeout abort" : "abort",
-        });
-      };
-      abortRunForExternalSignal = abortRun;
+      const queueHandleRef: { current?: EmbeddedAgentQueueHandle } = {};
+      const abortRun = createEmbeddedAttemptRunAbort({
+        abortActiveSession,
+        activeSession,
+        attempt: params,
+        getQueueHandle: () => queueHandleRef.current,
+        isProbeSession,
+        log,
+        runAbortController,
+        sessionLockController,
+        state: abortState,
+      });
+      externalAbortController.setRunAbort(abortRun);
       const idleTimeoutTrigger: ((error: Error) => void) | undefined = (error) => {
         idleTimedOut = true;
         abortRun(true, error);
@@ -834,8 +745,10 @@ export async function runEmbeddedAttempt(
       } = preparedStream;
       const { unsubscribe, waitForPendingEvents } = subscription;
       toolSearchCatalogExecutor = preparedStream.toolSearchCatalogExecutor;
-      isCompactionPendingForExternalSignal = subscription.isCompacting;
-      isCompactionInFlightForExternalSignal = () => activeSession.isCompacting;
+      externalAbortController.setCompactionState({
+        isPendingOrRetrying: subscription.isCompacting,
+        isInFlight: () => activeSession.isCompacting,
+      });
       let lastAssistant: AssistantMessage | undefined;
       let currentAttemptAssistant: EmbeddedRunAttemptResult["currentAttemptAssistant"];
       let attemptUsage: NormalizedUsage | undefined;
@@ -844,7 +757,7 @@ export async function runEmbeddedAttempt(
       let contextBudgetStatus: EmbeddedRunAttemptResult["contextBudgetStatus"];
       let compactionOccurredThisAttempt = false;
       let finalPromptText: string | undefined;
-      const queueHandleForAbandonment: EmbeddedAgentQueueHandle | undefined = queueHandle;
+      queueHandleRef.current = queueHandle;
 
       const attemptTimeout = prepareEmbeddedAttemptTimeout({
         attempt: params,
@@ -1557,7 +1470,7 @@ export async function runEmbeddedAttempt(
       });
     }
   } finally {
-    removeExternalAbortSignalListener?.();
+    externalAbortController.dispose();
     clearToolActivityRun(params.runId);
     if (!sessionCleanupOwnsEmbeddedResources) {
       try {


### PR DESCRIPTION
## What Problem This Solves

`runEmbeddedAttempt` still owned the external `AbortSignal` listener, timeout classification, active-session cancellation, compaction abort, queue abandonment, and session-lock release inline. That lifecycle coupling kept `attempt.ts` large and made abort ordering hard to test without the full runner.

## Why This Change Was Made

Move the abort lifecycle into focused controllers in `attempt-abort.ts`, with a typed state port back into the orchestration function. Keep the runner responsible only for wiring the live session and stream handles. The queue handle now uses an explicit reference cell, so an abort during stream setup cannot touch a later-declared binding.

Related to #106449.

## User Impact

No intended behavior change. External cancellation and timeouts retain the existing compaction classification, active-session abort, abandoned-queue marking, and session-lock release ordering. `attempt.ts` falls from 1,585 to 1,498 lines.

## Evidence

- Blacksmith Testbox `tbx_01kxf8sd0v4r2q6h4t86407bbx` at patch-equivalent head `6412f4f359e`: 130/130 focused tests passed across `attempt-abort.test.ts`, `attempt.test.ts`, and `attempt-session.test.ts`.
- `pnpm check:changed` at `6412f4f359e`: passed (core/core-test tsgo, changed-file Oxlint, LOC ratchet, import-cycle and policy guards).
- Final base-only rebase crossed disjoint paths; the three-file patch stayed unchanged.
- Final-head autoreview: clean, 0.94 confidence.
- `git diff origin/main...HEAD --check`: passed.
