### PR TITLE
fix(perplexity): send Search API date filters with official field names

### DIFF
--- a/extensions/perplexity/src/perplexity-web-search-provider.runtime.ts
+++ b/extensions/perplexity/src/perplexity-web-search-provider.runtime.ts
@@ -68,49 +68,6 @@ type PerplexitySearchApiResponse = {
   }>;
 };
 
-function buildPerplexitySearchApiBody(params: {
-  query: string;
-  count: number;
-  country?: string;
-  searchDomainFilter?: string[];
-  searchRecencyFilter?: string;
-  searchLanguageFilter?: string[];
-  searchAfterDate?: string;
-  searchBeforeDate?: string;
-  maxTokens?: number;
-  maxTokensPerPage?: number;
-}): Record<string, unknown> {
-  const body: Record<string, unknown> = {
-    query: params.query,
-    max_results: params.count,
-  };
-  if (params.country) {
-    body.country = params.country;
-  }
-  if (params.searchDomainFilter?.length) {
-    body.search_domain_filter = params.searchDomainFilter;
-  }
-  if (params.searchRecencyFilter) {
-    body.search_recency_filter = params.searchRecencyFilter;
-  }
-  if (params.searchLanguageFilter?.length) {
-    body.search_language_filter = params.searchLanguageFilter;
-  }
-  if (params.searchAfterDate) {
-    body.search_after_date_filter = params.searchAfterDate;
-  }
-  if (params.searchBeforeDate) {
-    body.search_before_date_filter = params.searchBeforeDate;
-  }
-  if (params.maxTokens !== undefined) {
-    body.max_tokens = params.maxTokens;
-  }
-  if (params.maxTokensPerPage !== undefined) {
-    body.max_tokens_per_page = params.maxTokensPerPage;
-  }
-  return body;
-}
-
 function resolvePerplexityConfig(searchConfig?: SearchConfigRecord): PerplexityConfig {
   const perplexity = searchConfig?.perplexity;
   return perplexity && typeof perplexity === "object" && !Array.isArray(perplexity)
@@ -253,7 +210,34 @@ async function runPerplexitySearchApi(params: {
   maxTokens?: number;
   maxTokensPerPage?: number;
 }): Promise<Array<Record<string, unknown>>> {
-  const body = buildPerplexitySearchApiBody(params);
+  const body: Record<string, unknown> = {
+    query: params.query,
+    max_results: params.count,
+  };
+  if (params.country) {
+    body.country = params.country;
+  }
+  if (params.searchDomainFilter?.length) {
+    body.search_domain_filter = params.searchDomainFilter;
+  }
+  if (params.searchRecencyFilter) {
+    body.search_recency_filter = params.searchRecencyFilter;
+  }
+  if (params.searchLanguageFilter?.length) {
+    body.search_language_filter = params.searchLanguageFilter;
+  }
+  if (params.searchAfterDate) {
+    body.search_after_date_filter = params.searchAfterDate;
+  }
+  if (params.searchBeforeDate) {
+    body.search_before_date_filter = params.searchBeforeDate;
+  }
+  if (params.maxTokens !== undefined) {
+    body.max_tokens = params.maxTokens;
+  }
+  if (params.maxTokensPerPage !== undefined) {
+    body.max_tokens_per_page = params.maxTokensPerPage;
+  }
 
   return withTrustedWebSearchEndpoint(
     {
@@ -572,6 +556,5 @@ export const testing = {
   readPerplexityJsonResponse,
   normalizeToIsoDate,
   isoToPerplexityDate,
-  buildPerplexitySearchApiBody,
 } as const;
 export { testing as __testing };

--- a/extensions/perplexity/src/perplexity-web-search-provider.runtime.ts
+++ b/extensions/perplexity/src/perplexity-web-search-provider.runtime.ts
@@ -68,6 +68,49 @@ type PerplexitySearchApiResponse = {
   }>;
 };
 
+function buildPerplexitySearchApiBody(params: {
+  query: string;
+  count: number;
+  country?: string;
+  searchDomainFilter?: string[];
+  searchRecencyFilter?: string;
+  searchLanguageFilter?: string[];
+  searchAfterDate?: string;
+  searchBeforeDate?: string;
+  maxTokens?: number;
+  maxTokensPerPage?: number;
+}): Record<string, unknown> {
+  const body: Record<string, unknown> = {
+    query: params.query,
+    max_results: params.count,
+  };
+  if (params.country) {
+    body.country = params.country;
+  }
+  if (params.searchDomainFilter?.length) {
+    body.search_domain_filter = params.searchDomainFilter;
+  }
+  if (params.searchRecencyFilter) {
+    body.search_recency_filter = params.searchRecencyFilter;
+  }
+  if (params.searchLanguageFilter?.length) {
+    body.search_language_filter = params.searchLanguageFilter;
+  }
+  if (params.searchAfterDate) {
+    body.search_after_date_filter = params.searchAfterDate;
+  }
+  if (params.searchBeforeDate) {
+    body.search_before_date_filter = params.searchBeforeDate;
+  }
+  if (params.maxTokens !== undefined) {
+    body.max_tokens = params.maxTokens;
+  }
+  if (params.maxTokensPerPage !== undefined) {
+    body.max_tokens_per_page = params.maxTokensPerPage;
+  }
+  return body;
+}
+
 function resolvePerplexityConfig(searchConfig?: SearchConfigRecord): PerplexityConfig {
   const perplexity = searchConfig?.perplexity;
   return perplexity && typeof perplexity === "object" && !Array.isArray(perplexity)
@@ -210,34 +253,7 @@ async function runPerplexitySearchApi(params: {
   maxTokens?: number;
   maxTokensPerPage?: number;
 }): Promise<Array<Record<string, unknown>>> {
-  const body: Record<string, unknown> = {
-    query: params.query,
-    max_results: params.count,
-  };
-  if (params.country) {
-    body.country = params.country;
-  }
-  if (params.searchDomainFilter?.length) {
-    body.search_domain_filter = params.searchDomainFilter;
-  }
-  if (params.searchRecencyFilter) {
-    body.search_recency_filter = params.searchRecencyFilter;
-  }
-  if (params.searchLanguageFilter?.length) {
-    body.search_language_filter = params.searchLanguageFilter;
-  }
-  if (params.searchAfterDate) {
-    body.search_after_date = params.searchAfterDate;
-  }
-  if (params.searchBeforeDate) {
-    body.search_before_date = params.searchBeforeDate;
-  }
-  if (params.maxTokens !== undefined) {
-    body.max_tokens = params.maxTokens;
-  }
-  if (params.maxTokensPerPage !== undefined) {
-    body.max_tokens_per_page = params.maxTokensPerPage;
-  }
+  const body = buildPerplexitySearchApiBody(params);
 
   return withTrustedWebSearchEndpoint(
     {
@@ -556,5 +572,6 @@ export const testing = {
   readPerplexityJsonResponse,
   normalizeToIsoDate,
   isoToPerplexityDate,
+  buildPerplexitySearchApiBody,
 } as const;
 export { testing as __testing };

--- a/extensions/perplexity/src/perplexity-web-search-provider.test.ts
+++ b/extensions/perplexity/src/perplexity-web-search-provider.test.ts
@@ -1,33 +1,15 @@
 // Perplexity tests cover perplexity web search provider plugin behavior.
 import { withEnv, withEnvAsync } from "openclaw/plugin-sdk/test-env";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { createStreamingResponse } from "../../test-support/streaming-error-response.js";
 
-type EndpointCall = {
-  url: string;
-  timeoutSeconds: number;
-  init: RequestInit;
-};
-
-const endpointMockState = vi.hoisted(() => ({
-  calls: [] as EndpointCall[],
-  responses: [] as Response[],
-}));
+const withTrustedWebSearchEndpointMock = vi.hoisted(() => vi.fn());
 
 vi.mock("openclaw/plugin-sdk/provider-web-search", async (importOriginal) => {
   const actual = await importOriginal<typeof import("openclaw/plugin-sdk/provider-web-search")>();
   return {
     ...actual,
-    withTrustedWebSearchEndpoint: vi.fn(
-      async (params: EndpointCall, run: (response: Response) => Promise<unknown>) => {
-        endpointMockState.calls.push(params);
-        const response = endpointMockState.responses.shift();
-        if (!response) {
-          throw new Error("Missing mocked Perplexity response.");
-        }
-        return await run(response);
-      },
-    ),
+    withTrustedWebSearchEndpoint: withTrustedWebSearchEndpointMock,
   };
 });
 
@@ -41,11 +23,6 @@ const directPerplexityApiKey = ["pplx", "test"].join("-");
 const enterprisePerplexityApiKey = ["enterprise", "perplexity", "test"].join("-");
 
 describe("perplexity web search provider", () => {
-  beforeEach(() => {
-    endpointMockState.calls = [];
-    endpointMockState.responses = [];
-  });
-
   it("points missing-key users to fetch/browser alternatives", async () => {
     await withEnvAsync(
       { [perplexityApiKeyEnv]: undefined, [openRouterApiKeyEnv]: undefined },
@@ -174,11 +151,17 @@ describe("perplexity web search provider", () => {
   });
 
   it("sends official date filter fields in the Search API request body", async () => {
-    endpointMockState.responses.push(
-      new Response(JSON.stringify({ results: [] }), {
-        status: 200,
-        headers: { "Content-Type": "application/json" },
-      }),
+    withTrustedWebSearchEndpointMock.mockImplementationOnce(
+      async (
+        _params: { init: RequestInit },
+        run: (response: Response) => Promise<unknown>,
+      ) =>
+        await run(
+          new Response(JSON.stringify({ results: [] }), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+        ),
     );
 
     await withEnvAsync(
@@ -198,8 +181,11 @@ describe("perplexity web search provider", () => {
       },
     );
 
-    expect(endpointMockState.calls).toHaveLength(1);
-    expect(JSON.parse(endpointMockState.calls[0]?.init.body as string)).toEqual({
+    expect(withTrustedWebSearchEndpointMock).toHaveBeenCalledOnce();
+    const [request] = withTrustedWebSearchEndpointMock.mock.calls[0] as [
+      { init: RequestInit },
+    ];
+    expect(JSON.parse(request.init.body as string)).toEqual({
       query: "OpenClaw releases",
       max_results: 5,
       search_after_date_filter: "1/1/2024",

--- a/extensions/perplexity/src/perplexity-web-search-provider.test.ts
+++ b/extensions/perplexity/src/perplexity-web-search-provider.test.ts
@@ -1,7 +1,36 @@
 // Perplexity tests cover perplexity web search provider plugin behavior.
 import { withEnv, withEnvAsync } from "openclaw/plugin-sdk/test-env";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createStreamingResponse } from "../../test-support/streaming-error-response.js";
+
+type EndpointCall = {
+  url: string;
+  timeoutSeconds: number;
+  init: RequestInit;
+};
+
+const endpointMockState = vi.hoisted(() => ({
+  calls: [] as EndpointCall[],
+  responses: [] as Response[],
+}));
+
+vi.mock("openclaw/plugin-sdk/provider-web-search", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/provider-web-search")>();
+  return {
+    ...actual,
+    withTrustedWebSearchEndpoint: vi.fn(
+      async (params: EndpointCall, run: (response: Response) => Promise<unknown>) => {
+        endpointMockState.calls.push(params);
+        const response = endpointMockState.responses.shift();
+        if (!response) {
+          throw new Error("Missing mocked Perplexity response.");
+        }
+        return await run(response);
+      },
+    ),
+  };
+});
+
 import { createPerplexityWebSearchProvider } from "./perplexity-web-search-provider.js";
 import { testing } from "./perplexity-web-search-provider.runtime.js";
 
@@ -12,6 +41,11 @@ const directPerplexityApiKey = ["pplx", "test"].join("-");
 const enterprisePerplexityApiKey = ["enterprise", "perplexity", "test"].join("-");
 
 describe("perplexity web search provider", () => {
+  beforeEach(() => {
+    endpointMockState.calls = [];
+    endpointMockState.responses = [];
+  });
+
   it("points missing-key users to fetch/browser alternatives", async () => {
     await withEnvAsync(
       { [perplexityApiKeyEnv]: undefined, [openRouterApiKeyEnv]: undefined },
@@ -139,15 +173,33 @@ describe("perplexity web search provider", () => {
     });
   });
 
-  it("uses Perplexity Search API date filter field names", () => {
-    expect(
-      testing.buildPerplexitySearchApiBody({
-        query: "OpenClaw releases",
-        count: 5,
-        searchAfterDate: "1/1/2024",
-        searchBeforeDate: "6/30/2024",
+  it("sends official date filter fields in the Search API request body", async () => {
+    endpointMockState.responses.push(
+      new Response(JSON.stringify({ results: [] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
       }),
-    ).toEqual({
+    );
+
+    await withEnvAsync(
+      { [perplexityApiKeyEnv]: directPerplexityApiKey, [openRouterApiKeyEnv]: undefined },
+      async () => {
+        const provider = createPerplexityWebSearchProvider();
+        const tool = provider.createTool({ config: {}, searchConfig: {} });
+        if (!tool) {
+          throw new Error("Expected tool definition");
+        }
+
+        await tool.execute({
+          query: "OpenClaw releases",
+          date_after: "2024-01-01",
+          date_before: "2024-06-30",
+        });
+      },
+    );
+
+    expect(endpointMockState.calls).toHaveLength(1);
+    expect(JSON.parse(endpointMockState.calls[0]?.init.body as string)).toEqual({
       query: "OpenClaw releases",
       max_results: 5,
       search_after_date_filter: "1/1/2024",

--- a/extensions/perplexity/src/perplexity-web-search-provider.test.ts
+++ b/extensions/perplexity/src/perplexity-web-search-provider.test.ts
@@ -152,10 +152,7 @@ describe("perplexity web search provider", () => {
 
   it("sends official date filter fields in the Search API request body", async () => {
     withTrustedWebSearchEndpointMock.mockImplementationOnce(
-      async (
-        _params: { init: RequestInit },
-        run: (response: Response) => Promise<unknown>,
-      ) =>
+      async (_params: { init: RequestInit }, run: (response: Response) => Promise<unknown>) =>
         await run(
           new Response(JSON.stringify({ results: [] }), {
             status: 200,
@@ -182,9 +179,7 @@ describe("perplexity web search provider", () => {
     );
 
     expect(withTrustedWebSearchEndpointMock).toHaveBeenCalledOnce();
-    const [request] = withTrustedWebSearchEndpointMock.mock.calls[0] as [
-      { init: RequestInit },
-    ];
+    const [request] = withTrustedWebSearchEndpointMock.mock.calls[0] as [{ init: RequestInit }];
     expect(JSON.parse(request.init.body as string)).toEqual({
       query: "OpenClaw releases",
       max_results: 5,

--- a/extensions/perplexity/src/perplexity-web-search-provider.test.ts
+++ b/extensions/perplexity/src/perplexity-web-search-provider.test.ts
@@ -139,6 +139,22 @@ describe("perplexity web search provider", () => {
     });
   });
 
+  it("uses Perplexity Search API date filter field names", () => {
+    expect(
+      testing.buildPerplexitySearchApiBody({
+        query: "OpenClaw releases",
+        count: 5,
+        searchAfterDate: "1/1/2024",
+        searchBeforeDate: "6/30/2024",
+      }),
+    ).toEqual({
+      query: "OpenClaw releases",
+      max_results: 5,
+      search_after_date_filter: "1/1/2024",
+      search_before_date_filter: "6/30/2024",
+    });
+  });
+
   it.each([
     ["max_tokens", 0, "max_tokens must be a positive integer."],
     ["max_tokens", 1.5, "max_tokens must be a positive integer."],


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users who run Perplexity web search with `date_after` or `date_before` would not get the requested published-date filtering on the native Perplexity Search API path.

OpenClaw exposes `date_after` and `date_before` as user-facing web search parameters. Those values are validated and converted from `YYYY-MM-DD` into Perplexity's expected `M/D/YYYY` date format, but the final native Search API request used the wrong JSON field names:

- `search_after_date`
- `search_before_date`

Perplexity's Search API documents the fields as:

- `search_after_date_filter`
- `search_before_date_filter`

Example before this change:

```json
{
  "query": "OpenClaw releases",
  "date_after": "2024-01-01",
  "date_before": "2024-06-30"
}
```

OpenClaw correctly validated the date range and converted it to Perplexity-style dates, but the outbound request body used non-contract field names:

```json
{
  "query": "OpenClaw releases",
  "max_results": 5,
  "search_after_date": "1/1/2024",
  "search_before_date": "6/30/2024"
}
```

That means users asking for a bounded Perplexity search could receive an API validation error or unbounded results instead of results constrained to the requested publication window.

## Why This Change Was Made

The Perplexity native Search API request body now uses the documented date-filter fields while preserving OpenClaw's existing user-facing `date_after` / `date_before` parameter names.

The request body construction is kept local to the Perplexity provider runtime and reused by the existing Search API dispatch path. This keeps the fix scoped to the provider-owned API mapping and does not add configuration, SDK surface, new provider behavior, or any OpenRouter/chat-completions compatibility changes.

The OpenRouter and Perplexity chat-completions path is intentionally unchanged. OpenClaw already rejects Search API-only filters on that path with explicit user-facing errors.

## User Impact

Users can now rely on Perplexity native Search API date filters to constrain results by publication date.

This matters for workflows such as:

- searching only releases or announcements published in a specific window
- excluding stale search results when investigating recent behavior
- comparing search results before and after a product or dependency change
- running date-bounded research prompts through OpenClaw's web search tool

The visible user-facing parameters remain the same:

```json
{
  "date_after": "2024-01-01",
  "date_before": "2024-06-30"
}
```

Only the provider-facing Perplexity request body changes.

## Evidence

Source and contract evidence:

- OpenClaw's Perplexity provider advertises `date_after` and `date_before` for the native Search API path: `extensions/perplexity/src/perplexity-web-search-provider.ts`
- The runtime validates `date_after` / `date_before`, rejects invalid ranges, and converts ISO dates through `isoToPerplexityDate`: `extensions/perplexity/src/perplexity-web-search-provider.runtime.ts`
- Before this change, the Perplexity native Search API body used `search_after_date` and `search_before_date`: `extensions/perplexity/src/perplexity-web-search-provider.runtime.ts`
- Perplexity's official Search API reference documents `search_after_date_filter` and `search_before_date_filter`: https://docs.perplexity.ai/api-reference/search-post

Focused regression coverage:

- `extensions/perplexity/src/perplexity-web-search-provider.test.ts` executes the provider tool and inspects the serialized native Search API request body at the guarded-endpoint seam.
- It verifies both official field names and the existing `YYYY-MM-DD` to `M/D/YYYY` conversion without exporting a production-only test helper.

Focused validation:

```bash
node scripts/run-vitest.mjs extensions/perplexity/src/perplexity-web-search-provider.test.ts
```

Result:

```text
Test Files  1 passed (1)
Tests       17 passed (17)
[test] passed 1 Vitest shard in 5.29s
```

Live Perplexity proof at head `980f609336c0c88df420eac6317bb2a9769d0aab`:

- Ran the real `createPerplexityWebSearchProvider` tool path with `date_after=2024-01-01` and `date_before=2024-06-30` against `https://api.perplexity.ai/search`.
- The API accepted the request and returned 5 dated results; all 5 dates were inside the requested range.

```json
{"error":null,"provider":"perplexity","count":5,"datedCount":5,"dates":["2024-05-13","2024-05-01","2024-05-09","2024-06-10","2024-05-13"],"allDatedResultsWithinRange":true}
```

Hosted changed gate:

```bash
node scripts/check-changed.mjs -- extensions/perplexity/src/perplexity-web-search-provider.runtime.ts extensions/perplexity/src/perplexity-web-search-provider.test.ts
```

Result: passed on Blacksmith Testbox `tbx_01kxs5y6dst8v3myxhgby7vt9k`, including formatting, Plugin SDK manifest, extension production/test typechecks, lint, boundary guards, and import-cycle checks: https://github.com/openclaw/openclaw/actions/runs/29620301305
