### PR TITLE
fix(release): preserve closeout asset names

### DIFF
--- a/.github/workflows/openclaw-stable-main-closeout.yml
+++ b/.github/workflows/openclaw-stable-main-closeout.yml
@@ -688,7 +688,11 @@ jobs:
               }
               return
             fi
-            gh_with_retry release upload "$RELEASE_TAG" "$source_path#$asset_name" --repo "$GITHUB_REPOSITORY"
+            # The #suffix is only a display label. Stage the desired basename so
+            # GitHub stores the versioned asset name used by repair lookups.
+            cp -- "$source_path" "$existing_dir/$asset_name"
+            gh_with_retry release upload "$RELEASE_TAG" \
+              "$existing_dir/$asset_name#$asset_name" --repo "$GITHUB_REPOSITORY"
           }
           attach_or_verify \
             "$CLOSEOUT_DIR/stable-main-closeout.json" \

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -426,6 +426,10 @@ describe("package acceptance workflow", () => {
       workflowJob(STABLE_MAIN_CLOSEOUT_WORKFLOW, "verify"),
       "Verify release workflow evidence",
     );
+    const attachStep = workflowStep(
+      workflowJob(STABLE_MAIN_CLOSEOUT_WORKFLOW, "verify"),
+      "Attach immutable closeout evidence",
+    );
     const checksumIndex = workflow.indexOf(
       'sha256sum --strict --status -c "$evidence_checksum_asset"',
     );
@@ -450,8 +454,13 @@ describe("package acceptance workflow", () => {
       encoding: "utf8",
       input: evidenceStep.run,
     });
+    const attachScriptSyntax = spawnSync("bash", ["-n"], {
+      encoding: "utf8",
+      input: attachStep.run,
+    });
 
     expect(evidenceScriptSyntax.status, evidenceScriptSyntax.stderr).toBe(0);
+    expect(attachScriptSyntax.status, attachScriptSyntax.stderr).toBe(0);
     expect(workflow).toContain('evidence_checksum_asset="${evidence_asset}.sha256"');
     expect(workflow).toContain('--pattern "$evidence_checksum_asset"');
     expect(workflow).toContain('fallback_package_version="${BASH_REMATCH[1]}"');
@@ -538,6 +547,11 @@ describe("package acceptance workflow", () => {
       'awk -v asset="openclaw-${release_version}-stable-main-closeout.json"',
     );
     expect(workflow).toContain("attach_or_verify \\");
+    expect(attachStep.run).toContain('cp -- "$source_path" "$existing_dir/$asset_name"');
+    expect(attachStep.run).toContain(
+      '"$existing_dir/$asset_name#$asset_name" --repo "$GITHUB_REPOSITORY"',
+    );
+    expect(attachStep.run).not.toContain('"$source_path#$asset_name"');
     expect(workflow).toContain(
       "full_release_validation_run_attempt: ${{ steps.inputs.outputs.full_release_validation_run_attempt }}",
     );


### PR DESCRIPTION
## What Problem This Solves

Stable closeout uploaded correctly versioned evidence labels but generic asset filenames. GitHub CLI treats the `#suffix` as a display label; the stored asset name still comes from the local file basename. Later repair lookups require the versioned filename.

## Why This Change Was Made

Stage each evidence file under its intended versioned basename before upload. Keep the matching display label. Extend workflow tests to syntax-check the attachment step and lock the staged upload path.

## User Impact

Stable release closeout assets remain discoverable and idempotent across repair runs. No runtime or package behavior changes.

## Evidence

- Live closeout run 29302553990 exposed generic filenames with versioned labels; the v2026.7.1 assets were renamed without changing IDs, sizes, or digests and their checksum was reverified.
- GitHub CLI `gh help release upload` documents `#suffix` as a display label.
- Blacksmith Testbox `tbx_01kxf9e0xp9259pgfa9msdxh7m`, run 29302700975: 72 focused tests passed; actionlint, zizmor, and repository workflow guards passed.
- `git diff --check` passed.
- Fresh autoreview: clean, confidence 0.96.
