### PR TITLE
test: accelerate session status suite

### DIFF
--- a/src/agents/openclaw-tools.session-status.test.ts
+++ b/src/agents/openclaw-tools.session-status.test.ts
@@ -315,6 +315,12 @@ vi.mock("../agents/provider-model-normalization.runtime.js", () => ({
 vi.mock("../plugins/current-plugin-metadata-snapshot.js", () => ({
   getCurrentPluginMetadataSnapshot: () => emptyPluginMetadataSnapshot,
 }));
+vi.mock("../plugins/provider-thinking.js", () => ({
+  resolveProviderBinaryThinking: () => undefined,
+  resolveProviderDefaultThinkingLevel: () => undefined,
+  resolveProviderThinkingProfile: () => undefined,
+  resolveProviderXHighThinking: () => undefined,
+}));
 // Keep provider-runtime/plugin activation out of this focused tool test. The
 // session_status surface only needs model selection semantics here, not real
 // bundled provider registration.


### PR DESCRIPTION
## What Problem This Solves

The focused session-status test loaded bundled provider-thinking policy artifacts. That unrelated cold-start work dominated the suite, consuming about eight seconds before assertions ran.

## Why This Change Was Made

Stub the provider-thinking hooks to their neutral result in this focused tool test. The suite still exercises configured defaults, runtime catalog hydration, and status-card propagation. Provider-specific thinking behavior remains covered by the dedicated thinking and external-policy suites.

## User Impact

No runtime behavior change. Faster, lower-memory CI for the agents test shard.

## Evidence

- Fresh Testbox cold baseline: 66/66 tests, Vitest 12.08s, wall 15.20s, max RSS 1,551,680 KB.
- Fresh Testbox cold result: 66/66 tests, Vitest 4.47s, wall 7.26s, max RSS 886,660 KB.
- Session-status + thinking + external provider-policy suites: 130/130 tests passed.
- `pnpm check:changed`: passed.
- Fresh autoreview: clean, no accepted/actionable findings.
