### PR TITLE
refactor(agents): privatize attempt lifecycle details

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt-abort.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-abort.test.ts
@@ -4,7 +4,6 @@ import type { EmbeddedAgentQueueHandle } from "../runs.js";
 import {
   createEmbeddedAttemptExternalAbortController,
   createEmbeddedAttemptRunAbort,
-  releaseEmbeddedAttemptSessionLockForAbort,
   type EmbeddedAttemptAbortStatePort,
 } from "./attempt-abort.js";
 
@@ -209,48 +208,45 @@ describe("createEmbeddedAttemptRunAbort", () => {
     });
     expect(releaseHeldLockForAbort).toHaveBeenCalledTimes(1);
   });
-});
 
-describe("releaseEmbeddedAttemptSessionLockForAbort", () => {
-  it("releases the retained session lock for manual aborts", async () => {
-    const releaseHeldLockForAbort = vi.fn(async () => {});
-    const warn = vi.fn();
-
-    releaseEmbeddedAttemptSessionLockForAbort({
-      sessionLockController: { releaseHeldLockForAbort },
-      log: { warn },
-      runId: "run-manual",
-      abortKind: "abort",
-    });
-
-    await Promise.resolve();
-
-    expect(releaseHeldLockForAbort).toHaveBeenCalledTimes(1);
-    expect(warn).not.toHaveBeenCalled();
-  });
-
-  it("logs release failures without throwing from the abort path", async () => {
+  it("logs lock release failures without replacing the manual abort reason", async () => {
     // Abort cleanup must not replace the original timeout/manual-abort reason
     // with a secondary lock-release failure.
+    const state = createAbortState();
+    const abortReason = new Error("manual abort");
     const releaseError = new Error("locked");
     const releaseHeldLockForAbort = vi.fn(async () => {
       throw releaseError;
     });
     const warn = vi.fn();
-
-    releaseEmbeddedAttemptSessionLockForAbort({
-      sessionLockController: { releaseHeldLockForAbort },
+    const runAbortController = new AbortController();
+    const abortRun = createEmbeddedAttemptRunAbort({
+      abortActiveSession: vi.fn(async () => {}),
+      activeSession: { abortCompaction: vi.fn(), isCompacting: false },
+      attempt: {
+        onAttemptTimeout: vi.fn(),
+        runId: "run-manual",
+        sessionFile: "/tmp/session.jsonl",
+        sessionId: "session-manual",
+        sessionKey: "agent:main",
+      },
+      getQueueHandle: () => undefined,
+      isProbeSession: false,
       log: { warn },
-      runId: "run-timeout",
-      abortKind: "timeout abort",
+      runAbortController,
+      sessionLockController: { releaseHeldLockForAbort },
+      state: state.port,
     });
 
+    abortRun(false, abortReason);
+
     await Promise.resolve();
     await Promise.resolve();
 
+    expect(runAbortController.signal.reason).toBe(abortReason);
     expect(releaseHeldLockForAbort).toHaveBeenCalledTimes(1);
     expect(warn).toHaveBeenCalledWith(
-      "failed to release session lock on timeout abort: runId=run-timeout Error: locked",
+      "failed to release session lock on abort: runId=run-manual Error: locked",
     );
   });
 });

--- a/src/agents/embedded-agent-runner/run/attempt-abort.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-abort.ts
@@ -229,7 +229,7 @@ export function createEmbeddedAttemptRunAbort(input: {
  * propagation. Release failures are logged because the caller is already
  * unwinding the run and cannot safely await lock cleanup there.
  */
-export function releaseEmbeddedAttemptSessionLockForAbort(params: {
+function releaseEmbeddedAttemptSessionLockForAbort(params: {
   sessionLockController: Pick<EmbeddedAttemptSessionLockController, "releaseHeldLockForAbort">;
   log: AbortLockReleaseLog;
   runId: string;

--- a/src/agents/embedded-agent-runner/run/attempt-prompt-skip.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-skip.ts
@@ -1,4 +1,4 @@
-export type PromptSubmissionSkipReason = "blank_user_prompt" | "empty_prompt_history_images";
+type PromptSubmissionSkipReason = "blank_user_prompt" | "empty_prompt_history_images";
 
 /** Classifies prompt submissions that have no visible current-turn content. */
 export function resolvePromptSubmissionSkipReason(params: {


### PR DESCRIPTION
## What Problem This Solves

Production Knip found two newly exposed internal agent exports after recent attempt-lifecycle extraction work. Keeping them exported would force dead-export baseline growth.

## Why This Change Was Made

Make `releaseEmbeddedAttemptSessionLockForAbort` and `PromptSubmissionSkipReason` module-private. Retarget lock-release failure coverage through the retained `createEmbeddedAttemptRunAbort` production path.

## User Impact

No public API or runtime behavior change. Manual aborts still preserve their original reason, release the held session lock, and log secondary release failures.

## Evidence

- Dead-export regeneration byte-stable at 1,103 entries; no baseline change.
- Exact dead-export check passed.
- Focused agent tests: 21 passed.
- Touched formatting and typed lint passed.
- Fresh autoreview: clean, confidence 0.91.
- Testbox: `tbx_01kxf9wbtm9xynqsqgq3jrrkfq`; focused run 29303030989; exact latest-main regeneration run 29303237640.
