### PR TITLE
refactor(concurrency): use native p-limit APIs

### DIFF
--- a/extensions/openshell/src/mirror.ts
+++ b/extensions/openshell/src/mirror.ts
@@ -35,7 +35,7 @@ async function copyTreeWithoutSymlinks(params: {
     return;
   }
   if (stats.isDirectory()) {
-    await runLimitedFs(async () => await fs.mkdir(params.targetPath, { recursive: true }));
+    await runLimitedFs(fs.mkdir, params.targetPath, { recursive: true });
     const entries = await runLimitedFs(async () => await fs.readdir(params.sourcePath));
     await Promise.all(
       entries.map(async (entry) => {
@@ -49,9 +49,7 @@ async function copyTreeWithoutSymlinks(params: {
     return;
   }
   if (stats.isFile()) {
-    await runLimitedFs(
-      async () => await fs.mkdir(path.dirname(params.targetPath), { recursive: true }),
-    );
+    await runLimitedFs(fs.mkdir, path.dirname(params.targetPath), { recursive: true });
     await runLimitedFs(async () => await fs.copyFile(params.sourcePath, params.targetPath));
   }
 }
@@ -74,13 +72,7 @@ export async function replaceDirectoryContents(params: {
         if (stats?.isSymbolicLink()) {
           return;
         }
-        await runLimitedFs(
-          async () =>
-            await fs.rm(targetPath, {
-              recursive: true,
-              force: true,
-            }),
-        );
+        await runLimitedFs(fs.rm, targetPath, { recursive: true, force: true });
       }),
   );
   const sourceEntries = await fs.readdir(params.sourceDir);

--- a/extensions/qa-lab/src/evidence-gallery.ts
+++ b/extensions/qa-lab/src/evidence-gallery.ts
@@ -892,21 +892,19 @@ export async function buildQaEvidenceGalleryModel(params: {
           repoRoot,
         });
       return {
-        artifacts: await Promise.all(
-          (entry.execution?.artifacts ?? []).map((artifact, artifactIndex) =>
-            limitArtifactView(() =>
-              buildArtifactView({
-                allowedArtifactFiles,
-                artifact,
-                artifactIndex,
-                evidenceDir,
-                entryIndex,
-                extraRoots: [requestedRepoRoot],
-                hrefEvidencePath,
-                repoRoot,
-              }),
-            ),
-          ),
+        artifacts: await limitArtifactView.map(
+          entry.execution?.artifacts ?? [],
+          (artifact, artifactIndex) =>
+            buildArtifactView({
+              allowedArtifactFiles,
+              artifact,
+              artifactIndex,
+              evidenceDir,
+              entryIndex,
+              extraRoots: [requestedRepoRoot],
+              hrefEvidencePath,
+              repoRoot,
+            }),
         ),
         coverage: entry.coverage.map((coverage) => ({
           id: sanitizeEntryText(coverage.id),

--- a/src/infra/bonjour-discovery.ts
+++ b/src/infra/bonjour-discovery.ts
@@ -5,6 +5,7 @@ import {
   normalizeStringEntries,
   uniqueStrings,
 } from "@openclaw/normalization-core/string-normalization";
+import pLimit from "p-limit";
 import { runCommandWithTimeout } from "../process/exec.js";
 import { parseStrictInteger } from "./parse-finite-number.js";
 import { isTailnetIPv4 } from "./tailnet.js";
@@ -362,45 +363,31 @@ async function discoverWideAreaViaTailnetDns(
 
   const probeName = `${GATEWAY_SERVICE_TYPE}.${domain.replace(/\.$/, "")}`;
 
-  const concurrency = 6;
-  let nextIndex = 0;
   let nameserver: string | null = null;
   let ptrs: string[] = [];
 
-  const worker = async () => {
-    while (nameserver === null) {
-      const budget = remainingMs();
-      if (budget <= 0) {
-        return;
-      }
-      const i = nextIndex;
-      nextIndex += 1;
-      if (i >= ips.length) {
-        return;
-      }
-      const ip = ips[i] ?? "";
-      if (!ip) {
-        continue;
-      }
-      try {
-        const probe = await run(
-          ["dig", "+short", "+time=1", "+tries=1", `@${ip}`, probeName, "PTR"],
-          { timeoutMs: Math.max(1, Math.min(250, budget)) },
-        );
-        const lines = parseDigShortLines(probe.stdout);
-        if (lines.length === 0) {
-          continue;
-        }
+  await pLimit(6).map(ips, async (ip) => {
+    if (nameserver !== null) {
+      return;
+    }
+    const budget = remainingMs();
+    if (budget <= 0 || !ip) {
+      return;
+    }
+    try {
+      const probe = await run(
+        ["dig", "+short", "+time=1", "+tries=1", `@${ip}`, probeName, "PTR"],
+        { timeoutMs: Math.max(1, Math.min(250, budget)) },
+      );
+      const lines = parseDigShortLines(probe.stdout);
+      if (lines.length > 0) {
         nameserver = ip;
         ptrs = lines;
-        return;
-      } catch {
-        // ignore
       }
+    } catch {
+      // ignore
     }
-  };
-
-  await Promise.all(Array.from({ length: Math.min(concurrency, ips.length) }, () => worker()));
+  });
 
   if (!nameserver || ptrs.length === 0) {
     return [];


### PR DESCRIPTION
## What Problem This Solves

Three bounded-concurrency paths manually rebuilt behavior already provided by the installed p-limit dependency: a worker/index pool, a nested limited `Promise.all`, and closure-wrapped filesystem calls.

## Why This Change Was Made

Use `p-limit@7.3.0`'s native `map()` and variadic call APIs. Existing concurrency limits, queue order, result order, timeout checks, and filesystem behavior stay unchanged.

## User Impact

No intended behavior change. Tailnet Bonjour fallback, QA evidence rendering, and OpenShell mirroring keep the same bounds with 23 fewer maintained lines.

## Evidence

- Blacksmith Testbox `tbx_01kxf9xv0q949kkb82n4x9eams`
- Three focused suites: 17 tests passed
- Core, core-test, extensions, and extension-test TypeScript gates: passed
- Targeted oxlint and `git diff --check`: passed
- Fresh autoreview: clean, 0.97 confidence
- Diff: 35 additions, 58 deletions; net -23 lines
