### PR TITLE
fix(infra): preserve APNs proxy error cause

### DIFF
--- a/src/infra/push-apns-http2.ts
+++ b/src/infra/push-apns-http2.ts
@@ -149,7 +149,7 @@ async function openApnsTlsTunnel(params: {
     const failure = abortController.signal.aborted ? abortController.signal.reason : err;
     throw new Error(
       `Proxy CONNECT failed via ${proxyUrl.origin}: ${failure instanceof Error ? failure.message : String(failure)}`,
-      { cause: failure },
+      { cause: err },
     );
   } finally {
     if (timeout) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where main CI rejected APNs proxy error wrapping because the original caught error was not preserved as the wrapper cause.

## Why This Change Was Made

The wrapper now retains the caught proxy/TLS error as `cause` while keeping the normalized timeout or abort reason in the user-facing message.

## User Impact

No behavior change. Main lint passes and APNs proxy diagnostics retain their original error chain.

## Evidence

- Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/29303388452
- `pnpm exec oxlint src/infra/push-apns-http2.ts`
- `pnpm test src/infra/push-apns-http2.test.ts` — 12 passed
- Autoreview clean: no accepted/actionable findings
