### PR TITLE
perf(plugins): reuse current snapshot in isPluginProvidersLoadInFlight to avoid repeated disk I/O

### DIFF
--- a/src/plugins/providers.runtime.ts
+++ b/src/plugins/providers.runtime.ts
@@ -25,6 +25,9 @@ import {
   resolveOwningPluginIdsForProviderRef,
   withBundledProviderVitestCompat,
 } from "./providers.js";
+import { getCurrentPluginMetadataSnapshot } from "./current-plugin-metadata-snapshot.js";
+import type { InstalledPluginIndex } from "./installed-plugin-index-types.js";
+import type { PluginManifestRegistry } from "./manifest-registry.js";
 import { getActivePluginRegistryWorkspaceDir } from "./runtime.js";
 import {
   buildPluginRuntimeLoadOptionsFromValues,
@@ -302,15 +305,64 @@ function resolveRuntimeProviderPluginLoadState(
   return { loadOptions };
 }
 
+// try to reuse the process-current plugin metadata snapshot when compatible
+// with the request parameters, avoiding repeated disk I/O for metadata lookups
+function tryGetCompatibleCurrentSnapshot(
+  params: { config?: PluginLoadOptions["config"]; workspaceDir?: string; env?: NodeJS.ProcessEnv },
+): {
+  manifestRegistry: PluginManifestRegistry;
+  index: InstalledPluginIndex;
+  workspaceDir: string;
+} | undefined {
+  const resolvedWorkspaceDir = params.workspaceDir ?? getActivePluginRegistryWorkspaceDir();
+  const current = getCurrentPluginMetadataSnapshot({
+    config: params.config,
+    env: params.env,
+    ...(resolvedWorkspaceDir !== undefined ? { workspaceDir: resolvedWorkspaceDir } : {}),
+  });
+  if (!current || !current.workspaceDir) {
+    return undefined;
+  }
+  return {
+    manifestRegistry: current.manifestRegistry,
+    index: current.index,
+    workspaceDir: current.workspaceDir,
+  };
+}
+
+// dispatch to setup/runtime load state based on mode
+function computeLoadState(
+  params: Parameters<typeof resolvePluginProviders>[0],
+  base: ReturnType<typeof resolvePluginProviderLoadBase>,
+  snapshot: PluginMetadataRegistryView,
+): { loadOptions: PluginLoadOptions } | undefined {
+  return params.mode === "setup"
+    ? resolveSetupProviderPluginLoadState(params, base, snapshot)
+    : resolveRuntimeProviderPluginLoadState(params, base, snapshot);
+}
+
 export function isPluginProvidersLoadInFlight(
   params: Parameters<typeof resolvePluginProviders>[0],
 ): boolean {
+  // fast path: reuse the current snapshot to avoid repeated disk I/O
+  const compatibleSnapshot = tryGetCompatibleCurrentSnapshot(params);
+  if (compatibleSnapshot && !params.pluginMetadataSnapshot) {
+    const snapshot: PluginMetadataRegistryView = {
+      index: compatibleSnapshot.index,
+      manifestRegistry: compatibleSnapshot.manifestRegistry,
+    };
+    const base = resolvePluginProviderLoadBase(
+      { ...params, workspaceDir: compatibleSnapshot.workspaceDir, env: params.env ?? process.env },
+      snapshot,
+    );
+    const loadState = computeLoadState(params, base, snapshot);
+    return loadState ? isPluginRegistryLoadInFlight(loadState.loadOptions) : false;
+  }
+
+  // fallback: full metadata lookup
   const { env, workspaceDir, snapshot } = resolveProviderMetadataLookup(params);
   const base = resolvePluginProviderLoadBase({ ...params, workspaceDir, env }, snapshot);
-  const loadState =
-    params.mode === "setup"
-      ? resolveSetupProviderPluginLoadState(params, base, snapshot)
-      : resolveRuntimeProviderPluginLoadState(params, base, snapshot);
+  const loadState = computeLoadState(params, base, snapshot);
   if (!loadState) {
     return false;
   }


### PR DESCRIPTION
## What Problem This Solves

High-frequency calls to `isPluginProvidersLoadInFlight` (during provider hook resolution, model fallback, and catalog enumeration) each trigger a full `resolvePluginMetadataSnapshot` call that reads `package.json` from all installed plugins, parses manifest registries, and builds index views. This wastes disk I/O when the process-current plugin metadata snapshot is already available and compatible.

## Why This Change Was Made

Two new helpers are added:

- **`tryGetCompatibleCurrentSnapshot`** — checks whether the process-current plugin metadata snapshot (`getCurrentPluginMetadataSnapshot`) is compatible with the request parameters (config, env, workspace directory). Returns `{ manifestRegistry, index, workspaceDir }` when compatible, `undefined` otherwise.

- **`computeLoadState`** — extracts the setup/runtime mode dispatch (`resolveSetupProviderPluginLoadState` / `resolveRuntimeProviderPluginLoadState`) into a shared helper, eliminating duplication between the fast path and fallback.

`isPluginProvidersLoadInFlight` now consults the current snapshot first. When compatible and no explicit `pluginMetadataSnapshot` parameter is provided, it constructs a `PluginMetadataRegistryView` directly and skips `resolveProviderMetadataLookup` entirely. Falls back to the full disk-based lookup when no compatible snapshot exists. Fully backward compatible.

## User Impact

Reduced latency on provider hook resolution and model enumeration hot paths. No user-visible behavior change — the optimization is internal and backward compatible. All existing caller paths work unchanged.

## Evidence

The co-located test file `src/plugins/providers.runtime.consult-current-snapshot.test.ts` covers the fast-path routing:

- Reuses a compatible current snapshot without invoking disk loaders
- Falls back to disk load when no current snapshot is registered
- Falls back to disk load when the workspace does not match
- Preserves setup/doctor behavior on the fallback disk load
- Covers `resolvePluginProviders` and `resolveExternalAuthProfilesWithPlugins` snapshot reuse
