### PR TITLE
refactor(agents): privatize attempt internals

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt-abort.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-abort.test.ts
@@ -4,7 +4,6 @@ import type { EmbeddedAgentQueueHandle } from "../runs.js";
 import {
   createEmbeddedAttemptExternalAbortController,
   createEmbeddedAttemptRunAbort,
-  releaseEmbeddedAttemptSessionLockForAbort,
   type EmbeddedAttemptAbortStatePort,
 } from "./attempt-abort.js";
 
@@ -209,27 +208,8 @@ describe("createEmbeddedAttemptRunAbort", () => {
     });
     expect(releaseHeldLockForAbort).toHaveBeenCalledTimes(1);
   });
-});
 
-describe("releaseEmbeddedAttemptSessionLockForAbort", () => {
-  it("releases the retained session lock for manual aborts", async () => {
-    const releaseHeldLockForAbort = vi.fn(async () => {});
-    const warn = vi.fn();
-
-    releaseEmbeddedAttemptSessionLockForAbort({
-      sessionLockController: { releaseHeldLockForAbort },
-      log: { warn },
-      runId: "run-manual",
-      abortKind: "abort",
-    });
-
-    await Promise.resolve();
-
-    expect(releaseHeldLockForAbort).toHaveBeenCalledTimes(1);
-    expect(warn).not.toHaveBeenCalled();
-  });
-
-  it("logs release failures without throwing from the abort path", async () => {
+  it("logs lock release failures without replacing the manual abort", async () => {
     // Abort cleanup must not replace the original timeout/manual-abort reason
     // with a secondary lock-release failure.
     const releaseError = new Error("locked");
@@ -237,20 +217,35 @@ describe("releaseEmbeddedAttemptSessionLockForAbort", () => {
       throw releaseError;
     });
     const warn = vi.fn();
-
-    releaseEmbeddedAttemptSessionLockForAbort({
-      sessionLockController: { releaseHeldLockForAbort },
+    const abortReason = new Error("cancelled");
+    const abortActiveSession = vi.fn(async () => {});
+    const runAbortController = new AbortController();
+    const abortRun = createEmbeddedAttemptRunAbort({
+      abortActiveSession,
+      activeSession: { abortCompaction: vi.fn(), isCompacting: false },
+      attempt: {
+        runId: "run-manual",
+        sessionFile: "/tmp/session.jsonl",
+        sessionId: "session-manual",
+        sessionKey: "agent:main",
+      },
+      getQueueHandle: () => undefined,
+      isProbeSession: false,
       log: { warn },
-      runId: "run-timeout",
-      abortKind: "timeout abort",
+      runAbortController,
+      sessionLockController: { releaseHeldLockForAbort },
+      state: createAbortState().port,
     });
 
+    abortRun(false, abortReason);
     await Promise.resolve();
     await Promise.resolve();
 
+    expect(runAbortController.signal.reason).toBe(abortReason);
+    expect(abortActiveSession).toHaveBeenCalledTimes(1);
     expect(releaseHeldLockForAbort).toHaveBeenCalledTimes(1);
     expect(warn).toHaveBeenCalledWith(
-      "failed to release session lock on timeout abort: runId=run-timeout Error: locked",
+      "failed to release session lock on abort: runId=run-manual Error: locked",
     );
   });
 });

--- a/src/agents/embedded-agent-runner/run/attempt-abort.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-abort.ts
@@ -229,7 +229,7 @@ export function createEmbeddedAttemptRunAbort(input: {
  * propagation. Release failures are logged because the caller is already
  * unwinding the run and cannot safely await lock cleanup there.
  */
-export function releaseEmbeddedAttemptSessionLockForAbort(params: {
+function releaseEmbeddedAttemptSessionLockForAbort(params: {
   sessionLockController: Pick<EmbeddedAttemptSessionLockController, "releaseHeldLockForAbort">;
   log: AbortLockReleaseLog;
   runId: string;

--- a/src/agents/embedded-agent-runner/run/attempt-prompt-skip.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-skip.ts
@@ -1,4 +1,4 @@
-export type PromptSubmissionSkipReason = "blank_user_prompt" | "empty_prompt_history_images";
+type PromptSubmissionSkipReason = "blank_user_prompt" | "empty_prompt_history_images";
 
 /** Classifies prompt submissions that have no visible current-turn content. */
 export function resolvePromptSubmissionSkipReason(params: {


### PR DESCRIPTION
## What Problem This Solves

Two recent embedded-attempt refactors exposed implementation details that have no external production consumers:

- `releaseEmbeddedAttemptSessionLockForAbort`
- `PromptSubmissionSkipReason`

The first export existed so its test could bypass the real abort controller. The second type never leaves its defining module. Both caused the exact-main dead-export gate to fail.

## Why This Change Was Made

- Make the lock-release helper private to `attempt-abort.ts`.
- Make the prompt skip-reason type private to `attempt-prompt-skip.ts`.
- Move lock-release failure coverage through `createEmbeddedAttemptRunAbort`, preserving the real manual-abort path instead of testing an internal helper directly.

The code graph confirms the lock-release helper has one production owner, `createEmbeddedAttemptRunAbort`, which is called by `runEmbeddedAttempt`. `PromptSubmissionSkipReason` has no external consumer; it only annotates the module-local classifier return type.

## User Impact

No user-visible behavior changes. Manual aborts and timeouts still release the retained session lock without replacing the original abort reason when cleanup fails.

## Evidence

- Testbox `tbx_01kxf9x7bn911pjjwm8d1bkk7h`
- `pnpm test:serial src/agents/embedded-agent-runner/run/attempt-abort.test.ts src/agents/embedded-agent-runner/run/attempt-prompt-observability.test.ts src/agents/embedded-agent-runner/run/attempt.prompt-helpers.test.ts`
  - 24 tests passed
- `pnpm deadcode:exports`
  - baseline matched 1,103 entries
- `pnpm check:changed -- src/agents/embedded-agent-runner/run/attempt-abort.ts src/agents/embedded-agent-runner/run/attempt-abort.test.ts src/agents/embedded-agent-runner/run/attempt-prompt-skip.ts`
  - `core` and `coreTests` lanes passed
- `oxfmt`, `oxlint --deny-warnings`, and `git diff --check`
- Fresh `gpt-5.6-sol` medium autoreview: no findings, confidence 0.95
- Net diff: 24 additions, 29 deletions
