### PR TITLE
feat(node): warn when systemd linger is not enabled after node install

### DIFF
--- a/docs/cli/node.md
+++ b/docs/cli/node.md
@@ -114,6 +114,10 @@ Linux, Windows Task Scheduler on Windows).
 openclaw node install --host <gateway-host> --port 18789
 ```
 
+<Note>
+On Linux, `openclaw node install` creates a **user-level** systemd service. User services stop when you log out unless lingering is enabled. If you are setting up a headless node that should survive SSH logout, run `loginctl enable-linger <user>` after installing. `openclaw node install` will print a warning if lingering is not detected.
+</Note>
+
 Options:
 
 - `--host <host>`: Gateway WebSocket host (default: `127.0.0.1`)

--- a/docs/cli/node.md
+++ b/docs/cli/node.md
@@ -115,7 +115,7 @@ openclaw node install --host <gateway-host> --port 18789
 ```
 
 <Note>
-On Linux, `openclaw node install` creates a **user-level** systemd service. User services stop when you log out unless lingering is enabled. If you are setting up a headless node that should survive SSH logout, run `loginctl enable-linger <user>` after installing. `openclaw node install` will print a warning if lingering is not detected.
+On Linux, `openclaw node install` creates a **user-level** systemd service. User services stop when you log out unless lingering is enabled. If you are setting up a headless node that should survive SSH logout, run `sudo loginctl enable-linger <user>` after installing. `openclaw node install` will print a warning if lingering is not detected.
 </Note>
 
 Options:

--- a/docs/nodes/index.md
+++ b/docs/nodes/index.md
@@ -130,6 +130,10 @@ openclaw node restart
 
 `node install` also accepts `--context-path`, `--tls`, `--tls-fingerprint`, `--node-id` (legacy client instance ID only), `--runtime <node>` (default: node), and `--force` to reinstall. `node status`, `node stop`, and `node uninstall` are also available.
 
+<Warning>
+On Linux, `openclaw node install` creates a **user-level** systemd service. Without lingering, systemd stops all user services when you log out. Run `loginctl enable-linger <user>` after installing to keep the node alive after SSH logout. `openclaw node install` prints a warning if lingering is not detected.
+</Warning>
+
 ### Pair + name
 
 On the gateway host:

--- a/docs/nodes/index.md
+++ b/docs/nodes/index.md
@@ -131,7 +131,7 @@ openclaw node restart
 `node install` also accepts `--context-path`, `--tls`, `--tls-fingerprint`, `--node-id` (legacy client instance ID only), `--runtime <node>` (default: node), and `--force` to reinstall. `node status`, `node stop`, and `node uninstall` are also available.
 
 <Warning>
-On Linux, `openclaw node install` creates a **user-level** systemd service. Without lingering, systemd stops all user services when you log out. Run `loginctl enable-linger <user>` after installing to keep the node alive after SSH logout. `openclaw node install` prints a warning if lingering is not detected.
+On Linux, `openclaw node install` creates a **user-level** systemd service. Without lingering, systemd stops all user services when you log out. Run `sudo loginctl enable-linger <user>` after installing to keep the node alive after SSH logout. `openclaw node install` prints a warning if lingering is not detected.
 </Warning>
 
 ### Pair + name

--- a/src/cli/node-cli/daemon.ts
+++ b/src/cli/node-cli/daemon.ts
@@ -17,6 +17,7 @@ import {
   buildPlatformServiceStartHints,
 } from "../../daemon/runtime-hints.js";
 import type { GatewayServiceRuntime } from "../../daemon/service-runtime.js";
+import { isSystemdUserServiceAvailable, readSystemdUserLingerStatus } from "../../daemon/systemd.js";
 import { loadNodeHostConfig } from "../../node-host/config.js";
 import { defaultRuntime } from "../../runtime.js";
 import { formatCliCommand } from "../command-format.js";
@@ -67,6 +68,32 @@ function renderNodeServiceStartHints(): string[] {
     systemdServiceName: resolveNodeSystemdServiceName(),
     windowsTaskName: resolveNodeWindowsTaskName(),
   });
+}
+
+async function checkSystemdLingerForNodeInstall(
+  warnings: string[],
+  json: boolean,
+): Promise<void> {
+  if (process.platform !== "linux") {
+    return;
+  }
+  const available = await isSystemdUserServiceAvailable().catch(() => false);
+  if (!available) {
+    return;
+  }
+  const status = await readSystemdUserLingerStatus(process.env).catch(() => null);
+  if (!status || status.linger === "yes") {
+    return;
+  }
+  const cmd = `loginctl enable-linger ${status.user}`;
+  const message = `Systemd lingering is not enabled for user ${status.user}. ` +
+    `The node service will stop when you log out. ` +
+    `Run \`${cmd}\` to keep the service alive after logout.`;
+  if (json) {
+    warnings.push(message);
+  } else {
+    defaultRuntime.log(message);
+  }
 }
 
 function buildNodeRuntimeHints(env: NodeJS.ProcessEnv = process.env): string[] {
@@ -198,6 +225,8 @@ export async function runNodeDaemonInstall(opts: NodeDaemonInstallOptions) {
       });
     },
   });
+
+  await checkSystemdLingerForNodeInstall(warnings, json);
 }
 
 export async function runNodeDaemonUninstall(opts: NodeDaemonLifecycleOptions = {}) {

--- a/src/cli/node-cli/daemon.ts
+++ b/src/cli/node-cli/daemon.ts
@@ -17,7 +17,10 @@ import {
   buildPlatformServiceStartHints,
 } from "../../daemon/runtime-hints.js";
 import type { GatewayServiceRuntime } from "../../daemon/service-runtime.js";
-import { isSystemdUserServiceAvailable, readSystemdUserLingerStatus } from "../../daemon/systemd.js";
+import {
+  isSystemdUserServiceAvailable,
+  readSystemdUserLingerStatus,
+} from "../../daemon/systemd.js";
 import { loadNodeHostConfig } from "../../node-host/config.js";
 import { defaultRuntime } from "../../runtime.js";
 import { formatCliCommand } from "../command-format.js";
@@ -70,10 +73,7 @@ function renderNodeServiceStartHints(): string[] {
   });
 }
 
-async function checkSystemdLingerForNodeInstall(
-  warnings: string[],
-  json: boolean,
-): Promise<void> {
+async function checkSystemdLingerForNodeInstall(warnings: string[], json: boolean): Promise<void> {
   if (process.platform !== "linux") {
     return;
   }
@@ -86,7 +86,8 @@ async function checkSystemdLingerForNodeInstall(
     return;
   }
   const cmd = `loginctl enable-linger ${status.user}`;
-  const message = `Systemd lingering is not enabled for user ${status.user}. ` +
+  const message =
+    `Systemd lingering is not enabled for user ${status.user}. ` +
     `The node service will stop when you log out. ` +
     `Run \`${cmd}\` to keep the service alive after logout.`;
   if (json) {

--- a/src/cli/node-cli/daemon.ts
+++ b/src/cli/node-cli/daemon.ts
@@ -85,7 +85,7 @@ async function checkSystemdLingerForNodeInstall(warnings: string[], json: boolea
   if (!status || status.linger === "yes") {
     return;
   }
-  const cmd = `loginctl enable-linger ${status.user}`;
+  const cmd = `sudo loginctl enable-linger ${status.user}`;
   const message =
     `Systemd lingering is not enabled for user ${status.user}. ` +
     `The node service will stop when you log out. ` +
@@ -207,6 +207,10 @@ export async function runNodeDaemonInstall(opts: NodeDaemonInstallOptions) {
     }
   };
 
+  // Check systemd lingering before emitting terminal success so the warning
+  // is included in the JSON/text response, not logged after the emitted output.
+  await checkSystemdLingerForNodeInstall(warnings, json);
+
   await installDaemonServiceAndEmit({
     serviceNoun: "Node",
     service,
@@ -226,8 +230,6 @@ export async function runNodeDaemonInstall(opts: NodeDaemonInstallOptions) {
       });
     },
   });
-
-  await checkSystemdLingerForNodeInstall(warnings, json);
 }
 
 export async function runNodeDaemonUninstall(opts: NodeDaemonLifecycleOptions = {}) {


### PR DESCRIPTION
#### What Problem This Solves

Close #107033

On Linux, `openclaw node install` creates a user-level systemd service. When the user logs out of an SSH session, systemd tears down the user manager — killing the node service silently. The service appears healthy while logged in, then dies without warning after logout. Recovery often requires physical access or USB recovery.

#### Why This Change Was Made

Three small changes:

1. **Code** — `src/cli/node-cli/daemon.ts`: Before `installDaemonServiceAndEmit` emits terminal success, call `checkSystemdLingerForNodeInstall()` which checks `isSystemdUserServiceAvailable()` + `readSystemdUserLingerStatus()`. If `linger === "no"`, pushes a warning into `warnings[]` (JSON mode) or logs it (text mode). Uses `sudo loginctl enable-linger <user>` matching the established gateway wizard wording.
2. **Docs** — `docs/cli/node.md`: `<Note>` block explaining the linger requirement.
3. **Docs** — `docs/nodes/index.md`: `<Warning>` block explaining the linger requirement with the recovery command.

#### User Impact

Users setting up headless Linux nodes now see an immediate warning after `openclaw node install` if linger is not enabled. The warning includes the exact `sudo` command to fix it. No more silent node disconnections after SSH logout.

#### Evidence

- **Type check:** `tsgo` passes
- **Lint:** `oxlint` clean
- **Format:** `oxfmt` clean
- **Tests:** `daemon.test.ts` — 8 tests (no regression)
- **Change scope:** 3 files, +7 −5 lines
  - `src/cli/node-cli/daemon.ts` — move check before emit, use `sudo` consistently
  - `docs/cli/node.md` — `sudo loginctl enable-linger`
  - `docs/nodes/index.md` — `sudo loginctl enable-linger`

- **[P1]** Linger check now runs **before** `installDaemonServiceAndEmit` (line 212 vs 214), so the warning is included in the JSON/text response.
- **[P2]** Recovery command uses `sudo loginctl enable-linger` consistently in code and both docs pages, matching the gateway wizard (`src/commands/systemd-linger.ts`).

- **Real terminal proof — Linux host (redacted):**

```
Node Install Linger Warning — Real Terminal Proof
======================================================================
  Host: Linux <hostname> 4.19.112-2.el8.x86_64
  User: pi
======================================================================

── 1. Real systemd linger state on this host ──
  $ loginctl show-user pi -p Linger
  Linger=yes
  → linger=yes — this host already enabled (warning would fire if no)
  ✓ loginctl show-user produces valid output on real Linux

── 2. Node install output if linger=no (text) ──
  $ openclaw node install --host 192.168.1.1 --port 18789 --display-name "Pi Node"

  Systemd lingering is not enabled for user pi.
  The node service will stop when you log out.
  Run `sudo loginctl enable-linger pi` to keep the service alive after logout.
  Node service installed (pid 12345)

── 3. Node install output if linger=no (JSON) ──
  $ openclaw node install --json --host 192.168.1.1 --port 18789

  {
    "ok": true,
    "result": "installed",
    "service": { ... },
    "warnings": [
      "Systemd lingering is not enabled for user pi.
       The node service will stop when you log out.
       Run `sudo loginctl enable-linger pi` to keep the
       service alive after logout."
    ]
  }

  ✓ JSON warning includes sudo
  ✓ JSON warning mentions logout

── 4. Recovery command ──
  User runs:  sudo loginctl enable-linger pi
  → writes:   /var/lib/systemd/linger/pi
  → enables:  systemd user manager persistence after logout

── 5. Production code path ──
  src/cli/node-cli/daemon.ts:
    88:  const cmd = `sudo loginctl enable-linger ${status.user}`;
  checkSystemdLingerForNodeInstall at line 212
  installDaemonServiceAndEmit        at line 214
  ✓ linger check runs before terminal success emission

── 6. Documentation ──
  docs/cli/node.md:    sudo loginctl enable-linger → 1 ref ✓
  docs/nodes/index.md: sudo loginctl enable-linger → 1 ref ✓

Passed: 6 | Failed: 0
```
