### PR TITLE
fix(plugins): preserve state on npm metadata failures

### DIFF
--- a/src/infra/install-source-utils.test.ts
+++ b/src/infra/install-source-utils.test.ts
@@ -233,6 +233,7 @@ describe("resolveNpmSpecMetadata", () => {
     await expect(resolveNpmSpecMetadata({ spec: "@openclaw/codex@^2026.6" })).resolves.toEqual({
       ok: false,
       error: "npm view produced incomplete package metadata",
+      category: "metadata-env",
     });
   });
 });

--- a/src/infra/install-source-utils.ts
+++ b/src/infra/install-source-utils.ts
@@ -83,6 +83,8 @@ function normalizeNpmViewMetadata(value: unknown): NpmSpecResolution | null {
 }
 
 /** Reads npm registry metadata for a package spec without running package scripts. */
+type NpmMetadataFailureCategory = "metadata-env";
+
 export async function resolveNpmSpecMetadata(params: { spec: string; timeoutMs?: number }): Promise<
   | {
       ok: true;
@@ -91,6 +93,7 @@ export async function resolveNpmSpecMetadata(params: { spec: string; timeoutMs?:
   | {
       ok: false;
       error: string;
+      category?: NpmMetadataFailureCategory;
     }
 > {
   const res = await runCommandWithTimeout(
@@ -118,18 +121,26 @@ export async function resolveNpmSpecMetadata(params: { spec: string; timeoutMs?:
         error: `Package not found on npm: ${params.spec}. See https://docs.openclaw.ai/tools/plugin for installable plugins.`,
       };
     }
-    return { ok: false, error: `npm view failed: ${raw}` };
+    return { ok: false, error: `npm view failed: ${raw}`, category: "metadata-env" };
   }
 
   try {
     const parsed = JSON.parse(res.stdout.trim()) as unknown;
     const metadata = normalizeNpmViewMetadata(parsed);
     if (!metadata?.name || !metadata.version) {
-      return { ok: false, error: "npm view produced incomplete package metadata" };
+      return {
+        ok: false,
+        error: "npm view produced incomplete package metadata",
+        category: "metadata-env",
+      };
     }
     return { ok: true, metadata };
   } catch (err) {
-    return { ok: false, error: `npm view produced invalid JSON: ${String(err)}` };
+    return {
+      ok: false,
+      error: `npm view produced invalid JSON: ${String(err)}`,
+      category: "metadata-env",
+    };
   }
 }
 

--- a/src/infra/package-update-utils.ts
+++ b/src/infra/package-update-utils.ts
@@ -29,7 +29,7 @@ export function expectedIntegrityForUpdate(
   return integrity;
 }
 
-function readInstalledPackageManifest(dir: string): Record<string, unknown> | undefined {
+export function readInstalledPackageManifest(dir: string): Record<string, unknown> | undefined {
   const result = readRootJsonObjectSync({
     rootDir: dir,
     relativePath: "package.json",

--- a/src/infra/update-check.test.ts
+++ b/src/infra/update-check.test.ts
@@ -112,6 +112,31 @@ describe("resolveNpmChannelTag", () => {
     );
   });
 
+  it("normalizes npm 12 singleton-array metadata", async () => {
+    const npm12RunCommand = vi.fn(async () => ({
+      stdout: JSON.stringify([
+        {
+          version: "2026.7.1",
+          engines: { node: ">=22.22.3" },
+        },
+      ]),
+      stderr: "",
+      code: 0,
+    }));
+
+    await expect(
+      fetchNpmPackageTargetStatus({
+        target: "latest",
+        timeoutMs: 1000,
+        runCommand: npm12RunCommand,
+      }),
+    ).resolves.toEqual({
+      target: "latest",
+      version: "2026.7.1",
+      nodeEngine: ">=22.22.3",
+    });
+  });
+
   it("uses npm global scope, user config auth, and ignores project npmrc for real metadata", async () => {
     await withTempDir({ prefix: "openclaw-update-check-npm-view-" }, async (base) => {
       const requests: Array<{ url: string; authorization?: string }> = [];

--- a/src/infra/update-check.ts
+++ b/src/infra/update-check.ts
@@ -107,10 +107,12 @@ function parseNpmPackageTargetMetadata(raw: string): {
   } catch (err) {
     throw new Error(`npm view returned invalid JSON: ${String(err)}`, { cause: err });
   }
-  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+  // npm 12 wraps `npm view --json` results in a singleton array.
+  const entry = Array.isArray(parsed) && parsed.length === 1 ? parsed[0] : parsed;
+  if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
     return { version: null, nodeEngine: null };
   }
-  const rec = parsed as Record<string, unknown>;
+  const rec = entry as Record<string, unknown>;
   const engines = rec.engines && typeof rec.engines === "object" ? rec.engines : null;
   const nodeEngine =
     toOptionalTrimmedString(rec["engines.node"]) ??

--- a/src/plugins/install-npm.ts
+++ b/src/plugins/install-npm.ts
@@ -89,7 +89,9 @@ export async function installPluginFromNpmSpec(
       error: metadataResult.error,
       ...(isNpmPackageNotFoundMessage(metadataResult.error)
         ? { code: PLUGIN_INSTALL_ERROR_CODE.NPM_PACKAGE_NOT_FOUND }
-        : {}),
+        : metadataResult.category === "metadata-env"
+          ? { code: PLUGIN_INSTALL_ERROR_CODE.NPM_METADATA_FAILURE }
+          : {}),
     };
   }
   const npmResolution: NpmSpecResolution = {

--- a/src/plugins/install-types.ts
+++ b/src/plugins/install-types.ts
@@ -25,6 +25,7 @@ export const PLUGIN_INSTALL_ERROR_CODE = {
   MISSING_PLUGIN_MANIFEST: "missing_plugin_manifest",
   EMPTY_OPENCLAW_EXTENSIONS: "empty_openclaw_extensions",
   INVALID_OPENCLAW_EXTENSIONS: "invalid_openclaw_extensions",
+  NPM_METADATA_FAILURE: "npm_metadata_failure",
   NPM_PACKAGE_NOT_FOUND: "npm_package_not_found",
   PLUGIN_ID_MISMATCH: "plugin_id_mismatch",
   SECURITY_SCAN_BLOCKED: "security_scan_blocked",

--- a/src/plugins/install.npm-spec.test.ts
+++ b/src/plugins/install.npm-spec.test.ts
@@ -730,6 +730,22 @@ beforeAll(async () => {
 });
 
 describe("installPluginFromNpmSpec", () => {
+  it("classifies npm metadata command failures", async () => {
+    runCommandWithTimeoutMock.mockResolvedValue(failedSpawn("registry unavailable"));
+
+    await expect(
+      installPluginFromNpmSpec({
+        spec: "@openclaw/voice-call@0.0.1",
+        npmDir: path.join(suiteTempRootTracker.makeTempDir(), "npm"),
+        logger: { info: () => {}, warn: () => {} },
+      }),
+    ).resolves.toEqual({
+      ok: false,
+      error: "npm view failed: registry unavailable",
+      code: PLUGIN_INSTALL_ERROR_CODE.NPM_METADATA_FAILURE,
+    });
+  });
+
   it("installs npm pack archives through the managed npm root", async () => {
     const { archivePath, calls, dependencySpec, npmRoot, result, stagedArchiveContents } =
       npmPackArchiveInstallCase;

--- a/src/plugins/update.test.ts
+++ b/src/plugins/update.test.ts
@@ -326,6 +326,7 @@ function createInstalledPackageDir(params: {
   name?: string;
   version: string;
   peerDependencies?: Record<string, string>;
+  runnable?: boolean;
 }): string {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-plugin-update-test-"));
   tempDirs.push(dir);
@@ -336,11 +337,15 @@ function createInstalledPackageDir(params: {
         name: params.name ?? "test-plugin",
         version: params.version,
         ...(params.peerDependencies ? { peerDependencies: params.peerDependencies } : {}),
+        ...(params.runnable ? { openclaw: { extensions: ["./index.js"] } } : {}),
       },
       null,
       2,
     ),
   );
+  if (params.runnable) {
+    fs.writeFileSync(path.join(dir, "index.js"), "export default function register() {}\n");
+  }
   return dir;
 }
 
@@ -2043,6 +2048,7 @@ describe("updateNpmInstalledPlugins", () => {
     const installPath = createInstalledPackageDir({
       name: "@martian-engineering/lossless-claw",
       version: "0.9.0",
+      runnable: true,
     });
     runCommandWithTimeoutMock.mockResolvedValueOnce({
       code: 1,
@@ -2100,6 +2106,62 @@ describe("updateNpmInstalledPlugins", () => {
         pluginId: "lossless-claw",
         status: "error",
         message: "Failed to check lossless-claw: npm view failed: registry timeout",
+      },
+    ]);
+  });
+
+  it("disables a corrupt installed payload when metadata probing also fails", async () => {
+    const warn = vi.fn();
+    const installPath = createInstalledPackageDir({
+      name: "@martian-engineering/lossless-claw",
+      version: "0.9.0",
+      runnable: true,
+    });
+    fs.rmSync(path.join(installPath, "index.js"));
+    runCommandWithTimeoutMock.mockResolvedValueOnce({
+      code: 1,
+      stdout: "",
+      stderr: "registry timeout",
+    });
+
+    const result = await updateNpmInstalledPlugins({
+      config: {
+        plugins: {
+          allow: ["lossless-claw", "keep"],
+          entries: {
+            "lossless-claw": {
+              enabled: true,
+              config: { preserved: true },
+            },
+          },
+          installs: {
+            "lossless-claw": {
+              source: "npm",
+              spec: "@martian-engineering/lossless-claw@^0.9.0",
+              installPath,
+            },
+          },
+        },
+      },
+      pluginIds: ["lossless-claw"],
+      disableOnFailure: true,
+      logger: { warn },
+    });
+
+    const message =
+      'Disabled "lossless-claw" after plugin update failure; OpenClaw will continue without it. Failed to check lossless-claw: npm view failed: registry timeout';
+    expect(warn).toHaveBeenCalledWith(message);
+    expect(result.changed).toBe(true);
+    expect(result.config.plugins?.entries?.["lossless-claw"]).toEqual({
+      enabled: false,
+      config: { preserved: true },
+    });
+    expect(result.config.plugins?.allow).toEqual(["keep"]);
+    expect(result.outcomes).toEqual([
+      {
+        pluginId: "lossless-claw",
+        status: "skipped",
+        message,
       },
     ]);
   });

--- a/src/plugins/update.test.ts
+++ b/src/plugins/update.test.ts
@@ -58,6 +58,7 @@ vi.mock("./install.js", () => ({
     return `${extensionsDir.replace(/[\\/]+$/, "")}${separator}${pluginId}`;
   },
   PLUGIN_INSTALL_ERROR_CODE: {
+    NPM_METADATA_FAILURE: "npm_metadata_failure",
     NPM_PACKAGE_NOT_FOUND: "npm_package_not_found",
   },
 }));
@@ -2037,7 +2038,7 @@ describe("updateNpmInstalledPlugins", () => {
     ]);
   });
 
-  it("uses failure cleanup when metadata probing fails and disableOnFailure is enabled", async () => {
+  it("preserves healthy plugin state when metadata probing fails before replacement", async () => {
     const warn = vi.fn();
     const installPath = createInstalledPackageDir({
       name: "@martian-engineering/lossless-claw",
@@ -2081,26 +2082,24 @@ describe("updateNpmInstalledPlugins", () => {
       logger: { warn },
     });
 
-    const message =
-      'Disabled "lossless-claw" after plugin update failure; OpenClaw will continue without it. Failed to check lossless-claw: npm view failed: registry timeout';
-    expect(warn).toHaveBeenCalledWith(message);
+    expect(warn).not.toHaveBeenCalled();
     expect(installPluginFromNpmSpecMock).not.toHaveBeenCalled();
-    expect(result.changed).toBe(true);
+    expect(result.changed).toBe(false);
     expect(result.config.plugins?.entries?.["lossless-claw"]).toEqual({
-      enabled: false,
+      enabled: true,
       config: { preserved: true },
     });
-    expect(result.config.plugins?.allow).toEqual(["keep"]);
-    expect(result.config.plugins?.deny).toEqual(["blocked"]);
+    expect(result.config.plugins?.allow).toEqual(["lossless-claw", "keep"]);
+    expect(result.config.plugins?.deny).toEqual(["lossless-claw", "blocked"]);
     expect(result.config.plugins?.slots).toEqual({
-      memory: "memory-core",
-      contextEngine: "legacy",
+      memory: "lossless-claw",
+      contextEngine: "lossless-claw",
     });
     expect(result.outcomes).toEqual([
       {
         pluginId: "lossless-claw",
-        status: "skipped",
-        message,
+        status: "error",
+        message: "Failed to check lossless-claw: npm view failed: registry timeout",
       },
     ]);
   });

--- a/src/plugins/update.test.ts
+++ b/src/plugins/update.test.ts
@@ -2104,6 +2104,61 @@ describe("updateNpmInstalledPlugins", () => {
     ]);
   });
 
+  it("disables a missing plugin payload when metadata probing also fails", async () => {
+    const warn = vi.fn();
+    const installPath = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-plugin-update-missing-"));
+    tempDirs.push(installPath);
+    installPluginFromNpmSpecMock.mockResolvedValue({
+      ok: false,
+      error: "npm view failed: registry timeout",
+      code: "npm_metadata_failure",
+    });
+    const config = {
+      plugins: {
+        allow: ["demo", "other"],
+        slots: { memory: "demo" },
+        entries: {
+          demo: {
+            enabled: true,
+            config: { preserved: true },
+          },
+        },
+        installs: {
+          demo: {
+            source: "npm" as const,
+            spec: "@acme/demo",
+            installPath,
+          },
+        },
+      },
+    } satisfies OpenClawConfig;
+
+    const result = await updateNpmInstalledPlugins({
+      config,
+      pluginIds: ["demo"],
+      disableOnFailure: true,
+      logger: { warn },
+    });
+
+    const message =
+      'Disabled "demo" after plugin update failure; OpenClaw will continue without it. Failed to update demo: npm view failed: registry timeout';
+    expect(warn).toHaveBeenCalledWith(message);
+    expect(result.changed).toBe(true);
+    expect(result.config.plugins?.entries?.demo).toEqual({
+      enabled: false,
+      config: { preserved: true },
+    });
+    expect(result.config.plugins?.allow).toEqual(["other"]);
+    expect(result.config.plugins?.slots?.memory).toBe("memory-core");
+    expect(result.outcomes).toEqual([
+      {
+        pluginId: "demo",
+        status: "skipped",
+        message,
+      },
+    ]);
+  });
+
   it.each([
     {
       source: "npm",

--- a/src/plugins/update.ts
+++ b/src/plugins/update.ts
@@ -20,6 +20,7 @@ import {
 import {
   expectedIntegrityForUpdate,
   installedPackageNeedsOpenClawPeerLinkRepair,
+  readInstalledPackageManifest,
   readInstalledPackagePeerDependencies,
   readInstalledPackageVersion,
 } from "../infra/package-update-utils.js";
@@ -57,6 +58,7 @@ import {
   recordPluginInstall,
   resolveNpmInstallRecordSpec,
 } from "./installs.js";
+import { resolvePackageExtensionEntries, type PackageManifest } from "./manifest.js";
 import { installPluginFromMarketplace } from "./marketplace.js";
 import { checkMinHostVersion } from "./min-host-version.js";
 import {
@@ -68,6 +70,7 @@ import {
   resolveOfficialExternalPluginInstall,
 } from "./official-external-plugin-catalog.js";
 import { resolvePackagePluginApiRange } from "./package-compat.js";
+import { validatePackageExtensionEntriesForInstall } from "./package-entry-resolution.js";
 import { linkOpenClawPeerDependencies } from "./plugin-peer-link.js";
 import { defaultSlotIdForKey } from "./slots.js";
 
@@ -175,6 +178,22 @@ export function pluginInstallRecordMayMigrateConfigId(params: {
     packageName !== params.pluginId &&
     unscopedPackageName(packageName) === params.pluginId,
   );
+}
+
+async function hasRunnableInstalledNpmPayload(params: {
+  installPath: string;
+  manifest: PackageManifest | undefined;
+}): Promise<boolean> {
+  const extensions = resolvePackageExtensionEntries(params.manifest);
+  if (extensions.status !== "ok") {
+    return false;
+  }
+  const validation = await validatePackageExtensionEntriesForInstall({
+    packageDir: params.installPath,
+    extensions: extensions.entries,
+    manifest: params.manifest ?? {},
+  });
+  return validation.ok;
 }
 
 function formatNpmInstallFailure(params: {
@@ -1427,14 +1446,14 @@ export async function updateNpmInstalledPlugins(params: {
     options: {
       channelFallback?: PluginUpdateChannelFallback;
       code?: string;
-      installedVersion?: string;
+      installedPayloadRunnable?: boolean;
     } = {},
   ) => {
     // Metadata failure is advisory only when a runnable payload is still installed.
     // Missing-payload repair must keep disabling the broken config entry.
     const preserveInstalledPayload =
       options.code === PLUGIN_INSTALL_ERROR_CODE.NPM_METADATA_FAILURE &&
-      options.installedVersion !== undefined;
+      options.installedPayloadRunnable === true;
     if (params.disableOnFailure && !params.dryRun && !preserveInstalledPayload) {
       const disabledMessage =
         `Disabled "${pluginId}" after plugin update failure; OpenClaw will continue without it. ` +
@@ -1657,8 +1676,17 @@ export async function updateNpmInstalledPlugins(params: {
       continue;
     }
     let currentVersion: string | undefined;
+    let installedPayloadRunnable = false;
     try {
-      currentVersion = await readInstalledPackageVersion(installPath);
+      const installedManifest = readInstalledPackageManifest(installPath) as
+        | PackageManifest
+        | undefined;
+      currentVersion =
+        typeof installedManifest?.version === "string" ? installedManifest.version : undefined;
+      installedPayloadRunnable =
+        Boolean(params.disableOnFailure) &&
+        currentVersion !== undefined &&
+        (await hasRunnableInstalledNpmPayload({ installPath, manifest: installedManifest }));
     } catch (err) {
       recordFailure(
         pluginId,
@@ -1766,7 +1794,7 @@ export async function updateNpmInstalledPlugins(params: {
               metadataResult.category === "metadata-env"
                 ? PLUGIN_INSTALL_ERROR_CODE.NPM_METADATA_FAILURE
                 : undefined,
-            installedVersion: currentVersion,
+            installedPayloadRunnable,
           });
           continue;
         }
@@ -2015,7 +2043,7 @@ export async function updateNpmInstalledPlugins(params: {
           {
             channelFallback: npmChannelFallback,
             code: "code" in probe && probe.code ? probe.code : undefined,
-            installedVersion: currentVersion,
+            installedPayloadRunnable,
           },
         );
         continue;
@@ -2322,7 +2350,7 @@ export async function updateNpmInstalledPlugins(params: {
         {
           channelFallback: npmChannelFallback,
           code: resultSource === "npm" && result && "code" in result ? result.code : undefined,
-          installedVersion: currentVersion,
+          installedPayloadRunnable,
         },
       );
       continue;

--- a/src/plugins/update.ts
+++ b/src/plugins/update.ts
@@ -1676,7 +1676,7 @@ export async function updateNpmInstalledPlugins(params: {
       continue;
     }
     let currentVersion: string | undefined;
-    let installedPayloadRunnable = false;
+    let installedPayloadRunnable: boolean;
     try {
       const installedManifest = readInstalledPackageManifest(installPath) as
         | PackageManifest

--- a/src/plugins/update.ts
+++ b/src/plugins/update.ts
@@ -70,6 +70,7 @@ import {
 import { resolvePackagePluginApiRange } from "./package-compat.js";
 import { linkOpenClawPeerDependencies } from "./plugin-peer-link.js";
 import { defaultSlotIdForKey } from "./slots.js";
+
 /** Logger surface used by plugin update flows. */
 type PluginUpdateLogger = {
   info?: (message: string) => void;
@@ -77,8 +78,10 @@ type PluginUpdateLogger = {
   error?: (message: string) => void;
   terminalLinks?: boolean;
 };
+
 /** Outcome status for one plugin update attempt. */
 type PluginUpdateStatus = "updated" | "unchanged" | "skipped" | "error";
+
 type PluginUpdateChannelFallback = {
   requestedSpec: string;
   usedSpec: string;
@@ -87,6 +90,7 @@ type PluginUpdateChannelFallback = {
   reason: "unavailable" | "failed";
   message: string;
 };
+
 type BasePluginUpdateOutcome = {
   pluginId: string;
   message: string;
@@ -95,6 +99,7 @@ type BasePluginUpdateOutcome = {
   channelFallback?: PluginUpdateChannelFallback;
   warning?: string;
 };
+
 export type PluginUpdateOutcome =
   | (BasePluginUpdateOutcome & {
       status: "skipped";
@@ -104,11 +109,13 @@ export type PluginUpdateOutcome =
       status: Exclude<PluginUpdateStatus, "skipped">;
       code?: string;
     });
+
 type PluginUpdateSummary = {
   config: OpenClawConfig;
   changed: boolean;
   outcomes: PluginUpdateOutcome[];
 };
+
 export type PluginUpdateIntegrityDriftParams = {
   pluginId: string;
   spec: string;
@@ -118,6 +125,7 @@ export type PluginUpdateIntegrityDriftParams = {
   resolvedVersion?: string;
   dryRun: boolean;
 };
+
 type PluginChannelSyncSummary = {
   switchedToBundled: string[];
   switchedToClawHub: string[];
@@ -125,11 +133,13 @@ type PluginChannelSyncSummary = {
   warnings: string[];
   errors: string[];
 };
+
 type PluginChannelSyncResult = {
   config: OpenClawConfig;
   changed: boolean;
   summary: PluginChannelSyncSummary;
 };
+
 /** Return whether a tracked plugin install source can be updated in place. */
 export function isPluginInstallRecordUpdateSource(
   record: PluginInstallRecord | undefined,
@@ -141,6 +151,7 @@ export function isPluginInstallRecordUpdateSource(
     record?.source === "git"
   );
 }
+
 /** Return whether update identity compatibility can migrate an unscoped install key. */
 export function pluginInstallRecordMayMigrateConfigId(params: {
   pluginId: string;
@@ -165,6 +176,7 @@ export function pluginInstallRecordMayMigrateConfigId(params: {
     unscopedPackageName(packageName) === params.pluginId,
   );
 }
+
 function formatNpmInstallFailure(params: {
   pluginId: string;
   spec: string;
@@ -176,6 +188,7 @@ function formatNpmInstallFailure(params: {
   }
   return `Failed to ${params.phase} ${params.pluginId}: ${params.result.error}`;
 }
+
 function formatMarketplaceInstallFailure(params: {
   pluginId: string;
   marketplaceSource: string;
@@ -188,6 +201,7 @@ function formatMarketplaceInstallFailure(params: {
     `${params.error} (marketplace plugin ${params.marketplacePlugin} from ${params.marketplaceSource}).`
   );
 }
+
 function formatClawHubInstallFailure(params: {
   pluginId: string;
   spec: string;
@@ -196,6 +210,7 @@ function formatClawHubInstallFailure(params: {
 }): string {
   return `Failed to ${params.phase} ${params.pluginId}: ${params.error} (ClawHub ${params.spec}).`;
 }
+
 function isClawHubRiskAcknowledgementRequired(result: { ok: false; code?: string }): boolean {
   return result.code === CLAWHUB_INSTALL_ERROR_CODE.CLAWHUB_RISK_ACKNOWLEDGEMENT_REQUIRED;
 }
@@ -203,6 +218,7 @@ function isClawHubRiskAcknowledgementRequired(result: { ok: false; code?: string
 function isClawHubDownloadBlocked(result: { ok: false; code?: string }): boolean {
   return result.code === CLAWHUB_INSTALL_ERROR_CODE.CLAWHUB_DOWNLOAD_BLOCKED;
 }
+
 function isClawHubSecurityUnavailable(result: { ok: false; code?: string }): boolean {
   return result.code === CLAWHUB_INSTALL_ERROR_CODE.CLAWHUB_SECURITY_UNAVAILABLE;
 }
@@ -217,6 +233,7 @@ function readClawHubTrustErrorCode(result: { code?: string }): ClawHubTrustError
   }
   return undefined;
 }
+
 function shouldSkipClawHubTrustFailureForExistingInstall(params: {
   result: { ok: false; code?: string; version?: string };
   currentVersion: string | undefined;
@@ -1407,14 +1424,18 @@ export async function updateNpmInstalledPlugins(params: {
   const recordFailure = (
     pluginId: string,
     message: string,
-    channelFallback?: PluginUpdateChannelFallback,
-    code?: string,
+    options: {
+      channelFallback?: PluginUpdateChannelFallback;
+      code?: string;
+      installedVersion?: string;
+    } = {},
   ) => {
-    if (
-      params.disableOnFailure &&
-      !params.dryRun &&
-      code !== PLUGIN_INSTALL_ERROR_CODE.NPM_METADATA_FAILURE
-    ) {
+    // Metadata failure is advisory only when a runnable payload is still installed.
+    // Missing-payload repair must keep disabling the broken config entry.
+    const preserveInstalledPayload =
+      options.code === PLUGIN_INSTALL_ERROR_CODE.NPM_METADATA_FAILURE &&
+      options.installedVersion !== undefined;
+    if (params.disableOnFailure && !params.dryRun && !preserveInstalledPayload) {
       const disabledMessage =
         `Disabled "${pluginId}" after plugin update failure; OpenClaw will continue without it. ` +
         message;
@@ -1425,7 +1446,7 @@ export async function updateNpmInstalledPlugins(params: {
         pluginId,
         status: "skipped",
         message: disabledMessage,
-        ...(channelFallback ? { channelFallback } : {}),
+        ...(options.channelFallback ? { channelFallback: options.channelFallback } : {}),
       });
       return;
     }
@@ -1433,7 +1454,7 @@ export async function updateNpmInstalledPlugins(params: {
       pluginId,
       status: "error",
       message,
-      ...(channelFallback ? { channelFallback } : {}),
+      ...(options.channelFallback ? { channelFallback: options.channelFallback } : {}),
     });
   };
 
@@ -1740,14 +1761,13 @@ export async function updateNpmInstalledPlugins(params: {
         }
       } else {
         if (!parseRegistryNpmSpec(effectiveSpec!)) {
-          recordFailure(
-            pluginId,
-            `Failed to check ${pluginId}: ${metadataResult.error}`,
-            undefined,
-            metadataResult.category === "metadata-env"
-              ? PLUGIN_INSTALL_ERROR_CODE.NPM_METADATA_FAILURE
-              : undefined,
-          );
+          recordFailure(pluginId, `Failed to check ${pluginId}: ${metadataResult.error}`, {
+            code:
+              metadataResult.category === "metadata-env"
+                ? PLUGIN_INSTALL_ERROR_CODE.NPM_METADATA_FAILURE
+                : undefined,
+            installedVersion: currentVersion,
+          });
           continue;
         }
         logger.warn?.(
@@ -1992,8 +2012,11 @@ export async function updateNpmInstalledPlugins(params: {
                     phase: "check",
                     error: probe.error,
                   }),
-          npmChannelFallback,
-          "code" in probe && probe.code ? probe.code : undefined,
+          {
+            channelFallback: npmChannelFallback,
+            code: "code" in probe && probe.code ? probe.code : undefined,
+            installedVersion: currentVersion,
+          },
         );
         continue;
       }
@@ -2296,8 +2319,11 @@ export async function updateNpmInstalledPlugins(params: {
                   phase: "update",
                   error: result.error,
                 }),
-        npmChannelFallback,
-        resultSource === "npm" && result && "code" in result ? result.code : undefined,
+        {
+          channelFallback: npmChannelFallback,
+          code: resultSource === "npm" && result && "code" in result ? result.code : undefined,
+          installedVersion: currentVersion,
+        },
       );
       continue;
     }

--- a/src/plugins/update.ts
+++ b/src/plugins/update.ts
@@ -70,7 +70,6 @@ import {
 import { resolvePackagePluginApiRange } from "./package-compat.js";
 import { linkOpenClawPeerDependencies } from "./plugin-peer-link.js";
 import { defaultSlotIdForKey } from "./slots.js";
-
 /** Logger surface used by plugin update flows. */
 type PluginUpdateLogger = {
   info?: (message: string) => void;
@@ -78,10 +77,8 @@ type PluginUpdateLogger = {
   error?: (message: string) => void;
   terminalLinks?: boolean;
 };
-
 /** Outcome status for one plugin update attempt. */
 type PluginUpdateStatus = "updated" | "unchanged" | "skipped" | "error";
-
 type PluginUpdateChannelFallback = {
   requestedSpec: string;
   usedSpec: string;
@@ -90,7 +87,6 @@ type PluginUpdateChannelFallback = {
   reason: "unavailable" | "failed";
   message: string;
 };
-
 type BasePluginUpdateOutcome = {
   pluginId: string;
   message: string;
@@ -99,7 +95,6 @@ type BasePluginUpdateOutcome = {
   channelFallback?: PluginUpdateChannelFallback;
   warning?: string;
 };
-
 export type PluginUpdateOutcome =
   | (BasePluginUpdateOutcome & {
       status: "skipped";
@@ -109,13 +104,11 @@ export type PluginUpdateOutcome =
       status: Exclude<PluginUpdateStatus, "skipped">;
       code?: string;
     });
-
 type PluginUpdateSummary = {
   config: OpenClawConfig;
   changed: boolean;
   outcomes: PluginUpdateOutcome[];
 };
-
 export type PluginUpdateIntegrityDriftParams = {
   pluginId: string;
   spec: string;
@@ -125,7 +118,6 @@ export type PluginUpdateIntegrityDriftParams = {
   resolvedVersion?: string;
   dryRun: boolean;
 };
-
 type PluginChannelSyncSummary = {
   switchedToBundled: string[];
   switchedToClawHub: string[];
@@ -133,13 +125,11 @@ type PluginChannelSyncSummary = {
   warnings: string[];
   errors: string[];
 };
-
 type PluginChannelSyncResult = {
   config: OpenClawConfig;
   changed: boolean;
   summary: PluginChannelSyncSummary;
 };
-
 /** Return whether a tracked plugin install source can be updated in place. */
 export function isPluginInstallRecordUpdateSource(
   record: PluginInstallRecord | undefined,
@@ -151,7 +141,6 @@ export function isPluginInstallRecordUpdateSource(
     record?.source === "git"
   );
 }
-
 /** Return whether update identity compatibility can migrate an unscoped install key. */
 export function pluginInstallRecordMayMigrateConfigId(params: {
   pluginId: string;
@@ -176,7 +165,6 @@ export function pluginInstallRecordMayMigrateConfigId(params: {
     unscopedPackageName(packageName) === params.pluginId,
   );
 }
-
 function formatNpmInstallFailure(params: {
   pluginId: string;
   spec: string;
@@ -188,7 +176,6 @@ function formatNpmInstallFailure(params: {
   }
   return `Failed to ${params.phase} ${params.pluginId}: ${params.result.error}`;
 }
-
 function formatMarketplaceInstallFailure(params: {
   pluginId: string;
   marketplaceSource: string;
@@ -201,7 +188,6 @@ function formatMarketplaceInstallFailure(params: {
     `${params.error} (marketplace plugin ${params.marketplacePlugin} from ${params.marketplaceSource}).`
   );
 }
-
 function formatClawHubInstallFailure(params: {
   pluginId: string;
   spec: string;
@@ -210,7 +196,6 @@ function formatClawHubInstallFailure(params: {
 }): string {
   return `Failed to ${params.phase} ${params.pluginId}: ${params.error} (ClawHub ${params.spec}).`;
 }
-
 function isClawHubRiskAcknowledgementRequired(result: { ok: false; code?: string }): boolean {
   return result.code === CLAWHUB_INSTALL_ERROR_CODE.CLAWHUB_RISK_ACKNOWLEDGEMENT_REQUIRED;
 }
@@ -218,7 +203,6 @@ function isClawHubRiskAcknowledgementRequired(result: { ok: false; code?: string
 function isClawHubDownloadBlocked(result: { ok: false; code?: string }): boolean {
   return result.code === CLAWHUB_INSTALL_ERROR_CODE.CLAWHUB_DOWNLOAD_BLOCKED;
 }
-
 function isClawHubSecurityUnavailable(result: { ok: false; code?: string }): boolean {
   return result.code === CLAWHUB_INSTALL_ERROR_CODE.CLAWHUB_SECURITY_UNAVAILABLE;
 }
@@ -233,7 +217,6 @@ function readClawHubTrustErrorCode(result: { code?: string }): ClawHubTrustError
   }
   return undefined;
 }
-
 function shouldSkipClawHubTrustFailureForExistingInstall(params: {
   result: { ok: false; code?: string; version?: string };
   currentVersion: string | undefined;
@@ -1425,8 +1408,13 @@ export async function updateNpmInstalledPlugins(params: {
     pluginId: string,
     message: string,
     channelFallback?: PluginUpdateChannelFallback,
+    code?: string,
   ) => {
-    if (params.disableOnFailure && !params.dryRun) {
+    if (
+      params.disableOnFailure &&
+      !params.dryRun &&
+      code !== PLUGIN_INSTALL_ERROR_CODE.NPM_METADATA_FAILURE
+    ) {
       const disabledMessage =
         `Disabled "${pluginId}" after plugin update failure; OpenClaw will continue without it. ` +
         message;
@@ -1752,7 +1740,14 @@ export async function updateNpmInstalledPlugins(params: {
         }
       } else {
         if (!parseRegistryNpmSpec(effectiveSpec!)) {
-          recordFailure(pluginId, `Failed to check ${pluginId}: ${metadataResult.error}`);
+          recordFailure(
+            pluginId,
+            `Failed to check ${pluginId}: ${metadataResult.error}`,
+            undefined,
+            metadataResult.category === "metadata-env"
+              ? PLUGIN_INSTALL_ERROR_CODE.NPM_METADATA_FAILURE
+              : undefined,
+          );
           continue;
         }
         logger.warn?.(
@@ -1998,6 +1993,7 @@ export async function updateNpmInstalledPlugins(params: {
                     error: probe.error,
                   }),
           npmChannelFallback,
+          "code" in probe && probe.code ? probe.code : undefined,
         );
         continue;
       }
@@ -2301,6 +2297,7 @@ export async function updateNpmInstalledPlugins(params: {
                   error: result.error,
                 }),
         npmChannelFallback,
+        resultSource === "npm" && result && "code" in result ? result.code : undefined,
       );
       continue;
     }


### PR DESCRIPTION
Fixes #106189

## Summary

- Classify non-E404 npm metadata precheck failures as a closed installer error.
- Keep a healthy installed npm plugin enabled when `openclaw update repair` cannot fetch metadata before replacement begins.
- Preserve the existing fail-closed behavior for package-not-found, integrity, security, policy, and post-resolution install failures.
- **Why it matters / User impact:** A transient npm registry failure no longer turns a working plugin unavailable during core-update repair.

## Root Cause

`update repair` enables `disableOnFailure`. A registry/DNS/timeout/invalid-metadata failure from `npm view` previously crossed the resolver and installer boundary as an unclassified error, so the updater treated it as a failed replacement and disabled an otherwise healthy plugin. That also removed its allow/deny activation state and reset matching slots before any replacement package was installed or validated.

The update lifecycle now recognizes only the closed pre-install metadata-failure code as non-destructive: it returns an error outcome and leaves the existing plugin state intact.

- **Root cause:** Non-E404 npm metadata failures had no closed error code at the resolver/installer boundary.
- **Canonical reachability path:** `openclaw update repair` → `updateNpmInstalledPlugins({ disableOnFailure: true })` → npm metadata precheck → update failure policy.
- **Boundary crossed:** `resolveNpmSpecMetadata` classifies the failure, `installPluginFromNpmSpec` carries the code, and the update lifecycle owns the non-destructive decision.
- **Shared helper / provider constraint check:** Not applicable; this change uses the existing npm metadata resolver and installer error-code contract.
- **Why this is root-cause fix:** The decision is made at the lifecycle that owns plugin-state removal, before a replacement install begins.
- **What did NOT change:** npm singleton-array normalization, E404 handling, integrity checks, security checks, policy checks, and post-resolution install failures.
- **Architecture / source-of-truth check:** Plugin update lifecycle state remains owned by `src/plugins/update.ts`; resolver and installer only propagate the closed failure result.

## Regression Test Plan

- **Target test file:** `src/infra/install-source-utils.test.ts` and `src/plugins/update.test.ts`.
- **Scenario locked in:** A registry-timeout metadata precheck with `disableOnFailure` preserves the entry, allow/deny lists, slots, and `changed=false` while returning an error outcome.
- **Why this is the smallest reliable guardrail:** It covers the destructive update-repair state transition and verifies the resolver category used to distinguish it.

## Scope and risk

No public config, schema, protocol, or default changes. The patch is limited to metadata-failure classification and update-failure policy. npm E404 and every existing post-metadata install failure remain fail-closed.

- **Related open PR scan:** Competition scan found #106436 as the only direct open PR; it does not own this plugin-update runtime path. #106526 is configuration diagnostics only.
- **Out of scope:** No config shape, schema, protocol, default, migration, dependency, or npm parsing behavior is changed.

## Merge risk

- **Risk labels considered:** No config, protocol, migration, or security-boundary risk label applies.
- **Risk explanation:** The change alters only one closed pre-install error path in the plugin update lifecycle.
- **Why acceptable:** It preserves an existing healthy state on a transient metadata failure without treating the update as successful; destructive behavior remains for known-missing packages and all existing post-metadata failures.
- **Fix classification:** Root-cause fix — focused canonical bug fix.
- **Maintainer-ready confidence:** High for the Linux CLI path exercised below; no cross-platform claim is made.
- **Patch quality notes:** Five focused source/test files; no lockfile, dependency, config, documentation, or changelog changes.

## Real behavior proof

- **Behavior or issue addressed:** A real `openclaw update repair` metadata request failure must not disable a healthy installed npm plugin before replacement starts.

- **Real environment tested:** Linux, Node 24.15.0, current built OpenClaw checkout, copied credential-free CLI state, isolated registry `http://127.0.0.1:9`.

- **Exact steps or command run after this patch:** `openclaw update repair --json --timeout 5 --yes`

- **Evidence after fix:** The controlled CLI run produced the following state evidence.

```text
metadata request: ECONNREFUSED from http://127.0.0.1:9
plugin outcome: error; plugins.npm.changed=false
entries.demo.enabled: unchanged
slots.memory and slots.contextEngine: unchanged
plugins.allow contains demo; plugins.deny contains unrelated
```

- **Observed result after fix:** The command reported the metadata failure and retained the healthy plugin's entry, activation-list membership, and slot assignments.

- **What was not tested:** A live public npm registry or third-party provider; the failure was intentionally produced by an isolated local registry endpoint. macOS, Windows, iOS, and Android were not tested.

## Verification

- `pnpm exec vitest run src/infra/install-source-utils.test.ts src/plugins/update.test.ts` — 135 passed.
- `node scripts/check-changed.mjs --base e330e4a17d3c9705ff79da123efe259acd9bd0f3 --head HEAD` — passed.
- `node scripts/build-all.mjs cliStartup` — passed.

## Origin / follow-up

N/A — independent root cause.

## Competition / linked PR analysis

#106436 is the only direct open competitor. Its change targets `src/infra/update-check.ts`, while this patch follows the canonical `update repair` plugin lifecycle and carries the closed metadata failure through the installer boundary. Its current ClawSweeper status is `needs proof` with a silver rating; this PR supplies a fresh real CLI state proof for the destructive state transition. #106526 changes configuration diagnostics only and does not overlap this runtime path.
