### PR TITLE
refactor(tailscale): use exec timeout directly

### DIFF
--- a/src/infra/tailscale.ts
+++ b/src/infra/tailscale.ts
@@ -39,20 +39,7 @@ export async function findTailscaleBinary(): Promise<string | null> {
       return false;
     }
     try {
-      // Use Promise.race with runExec to implement timeout
-      let timer: ReturnType<typeof setTimeout> | undefined;
-      try {
-        await Promise.race([
-          runExec(path, ["--version"], { timeoutMs: 3000 }),
-          new Promise<never>((_, reject) => {
-            timer = setTimeout(() => reject(new Error("timeout")), 3000);
-          }),
-        ]);
-      } finally {
-        if (timer) {
-          clearTimeout(timer);
-        }
-      }
+      await runExec(path, ["--version"], { timeoutMs: 3000 });
       return true;
     } catch {
       return false;


### PR DESCRIPTION
## What Problem This Solves

Tailscale binary detection wrapped `runExec` in a second timeout race even though the canonical exec path already delegates timeout, process termination, and stream settlement to Execa.

## Why This Change Was Made

Use the existing `runExec(..., { timeoutMs: 3000 })` contract directly. Execa remains the single lifecycle owner for timeout kill and cleanup.

## User Impact

No intended behavior change. Tailscale discovery still rejects slow or invalid binaries after the configured timeout, with 13 fewer maintained lines and no background loser promise.

## Evidence

- Blacksmith Testbox `tbx_01kxfaebzn6gm6dms34y615xjj`
- Tailscale and process suites: 64 passed, 1 skipped
- Core and test TypeScript gates: passed
- Targeted oxlint and `git diff --check`: passed
- Fresh autoreview: clean, 0.98 confidence
- Diff: 1 addition, 14 deletions; net -13 lines
