### PR TITLE
refactor(whatsapp): let SDK own inbound command context

### DIFF
--- a/extensions/whatsapp/src/auto-reply.web-auto-reply.connection-and-logging.e2e.test.ts
+++ b/extensions/whatsapp/src/auto-reply.web-auto-reply.connection-and-logging.e2e.test.ts
@@ -1045,6 +1045,11 @@ describe("web auto-reply connection", () => {
 
     expect(capture.getLastOptions()?.shouldDebounce?.(msg)).toBe(true);
     expect(
+      capture
+        .getLastOptions()
+        ?.shouldDebounce?.(createTestWebInboundMessage({ payload: { body: "   " } })),
+    ).toBe(false);
+    expect(
       capture.getLastOptions()?.shouldDebounce?.(
         createTestWebInboundMessage({
           payload: {

--- a/extensions/whatsapp/src/auto-reply/monitor.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor.ts
@@ -2,10 +2,10 @@
 import type { WAMessageKey } from "baileys";
 import { resolveAccountEntry } from "openclaw/plugin-sdk/account-core";
 import { CHANNEL_APPROVAL_NATIVE_RUNTIME_CONTEXT_CAPABILITY } from "openclaw/plugin-sdk/approval-handler-runtime";
+import { shouldDebounceTextInbound } from "openclaw/plugin-sdk/channel-inbound";
 import { resolveInboundDebounceMs } from "openclaw/plugin-sdk/channel-inbound-debounce";
 import { registerChannelRuntimeContext } from "openclaw/plugin-sdk/channel-runtime-context";
 import { formatCliCommand } from "openclaw/plugin-sdk/cli-runtime";
-import { isControlCommandMessage } from "openclaw/plugin-sdk/command-detection";
 import { drainPendingDeliveries } from "openclaw/plugin-sdk/delivery-queue-runtime";
 import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import { DEFAULT_GROUP_HISTORY_LIMIT } from "openclaw/plugin-sdk/reply-history";
@@ -265,19 +265,16 @@ export async function monitorWebChannel(
       });
       const shouldDebounce = (msg: WebInboundMessageInput) => {
         const normalized = normalizeWebInboundMessage(msg);
-        if (normalized.payload.media?.path || normalized.payload.media?.type) {
-          return false;
-        }
-        if (normalized.payload.location) {
-          return false;
-        }
-        if (normalized.quote?.id || normalized.quote?.body) {
-          return false;
-        }
-        return !isControlCommandMessage(
-          normalized.payload.commandBody ?? normalized.payload.body,
+        return shouldDebounceTextInbound({
+          text: normalized.payload.commandBody ?? normalized.payload.body,
           cfg,
-        );
+          hasMedia: Boolean(normalized.payload.media?.path || normalized.payload.media?.type),
+          allowDebounce: !(
+            normalized.payload.location ||
+            normalized.quote?.id ||
+            normalized.quote?.body
+          ),
+        });
       };
 
       let connection;

--- a/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.runtime.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.runtime.ts
@@ -2,7 +2,6 @@
 export {
   createChannelMessageReplyPipeline,
   dispatchReplyWithBufferedBlockDispatcher,
-  finalizeInboundContext,
   getAgentScopedMediaLocalRoots,
   jidToE164,
   logVerbose,

--- a/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.test.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.test.ts
@@ -34,6 +34,7 @@ type CapturedDispatchParams = {
 const {
   dispatchReplyWithBufferedBlockDispatcherMock,
   deliverInboundReplyWithMessageSendContextMock,
+  sourceReplyDeliveryModeContexts,
 } = vi.hoisted(() => ({
   dispatchReplyWithBufferedBlockDispatcherMock: vi.fn(async (params: CapturedDispatchParams) => {
     capturedDispatchParams = params;
@@ -42,6 +43,7 @@ const {
   deliverInboundReplyWithMessageSendContextMock: vi.fn<(...args: unknown[]) => Promise<unknown>>(
     async () => null,
   ),
+  sourceReplyDeliveryModeContexts: [] as unknown[],
 }));
 
 vi.mock("openclaw/plugin-sdk/channel-outbound", async (importOriginal) => {
@@ -53,12 +55,8 @@ vi.mock("openclaw/plugin-sdk/channel-outbound", async (importOriginal) => {
 });
 
 vi.mock("./runtime-api.js", async () => {
-  const { finalizeInboundContext } = await vi.importActual<
-    typeof import("openclaw/plugin-sdk/reply-runtime")
-  >("openclaw/plugin-sdk/reply-runtime");
   return {
     dispatchReplyWithBufferedBlockDispatcher: dispatchReplyWithBufferedBlockDispatcherMock,
-    finalizeInboundContext,
     getAgentScopedMediaLocalRoots: () => [],
     jidToE164: (value: string) => {
       const phone = value.split("@")[0]?.replace(/[^\d]/g, "");
@@ -77,6 +75,7 @@ vi.mock("./runtime-api.js", async () => {
       };
       ctx: { ChatType?: string; CommandSource?: "native" | "text"; CommandAuthorized?: boolean };
     }) => {
+      sourceReplyDeliveryModeContexts.push(ctx);
       if (
         ctx.CommandSource === "native" ||
         (ctx.CommandSource === "text" && ctx.CommandAuthorized === true)
@@ -277,6 +276,15 @@ function expectRememberSentContextFields(
 }
 
 type BufferedReplyParams = Parameters<typeof dispatchWhatsAppBufferedReply>[0];
+type BufferedReplyOverrides = Partial<Omit<BufferedReplyParams, "context">> & {
+  context?: Partial<BufferedReplyParams["context"]>;
+};
+
+function finalizedContext(
+  overrides: Partial<BufferedReplyParams["context"]> = {},
+): BufferedReplyParams["context"] {
+  return { CommandAuthorized: false, ...overrides };
+}
 
 function makeReplyLogger(): BufferedReplyParams["replyLogger"] {
   return {
@@ -310,11 +318,11 @@ function unacceptedDeliveryResult() {
   };
 }
 
-async function dispatchBufferedReply(overrides: Partial<BufferedReplyParams> = {}) {
+async function dispatchBufferedReply(overrides: BufferedReplyOverrides = {}) {
   const params: BufferedReplyParams = {
     cfg: { channels: { whatsapp: { streaming: { block: { enabled: true } } } } } as never,
     connectionId: "conn",
-    context: { Body: "hi" },
+    context: finalizedContext({ Body: "hi" }),
     deliverReply: async () => acceptedDeliveryResult(),
     groupHistories: new Map(),
     groupHistoryKey: "+1000",
@@ -328,12 +336,17 @@ async function dispatchBufferedReply(overrides: Partial<BufferedReplyParams> = {
     shouldClearGroupHistory: false,
   };
 
-  return dispatchWhatsAppBufferedReply({ ...params, ...overrides });
+  return dispatchWhatsAppBufferedReply({
+    ...params,
+    ...overrides,
+    context: finalizedContext({ ...params.context, ...overrides.context }),
+  });
 }
 
 describe("whatsapp inbound dispatch", () => {
   beforeEach(() => {
     capturedDispatchParams = undefined;
+    sourceReplyDeliveryModeContexts.length = 0;
     dispatchReplyWithBufferedBlockDispatcherMock.mockClear();
     deliverInboundReplyWithMessageSendContextMock.mockReset();
     deliverInboundReplyWithMessageSendContextMock.mockResolvedValue({
@@ -388,7 +401,11 @@ describe("whatsapp inbound dispatch", () => {
     const ctx = await buildWhatsAppInboundContext({
       bodyForAgent: "spoken transcript",
       combinedBody: "spoken transcript",
-      commandBody: "<media:audio>",
+      command: {
+        kind: "normal",
+        body: "<media:audio>",
+        authorized: false,
+      },
       msg: makeMsg({
         payload: {
           body: "<media:audio>",
@@ -444,11 +461,8 @@ describe("whatsapp inbound dispatch", () => {
   it("marks authorized text slash commands as text command turns", async () => {
     const ctx = await buildWhatsAppInboundContext({
       combinedBody: "/status",
-      commandBody: "/status",
-      commandAuthorized: true,
-      commandTurn: {
+      command: {
         kind: "text-slash",
-        source: "text",
         authorized: true,
         body: "/status",
       },
@@ -480,6 +494,34 @@ describe("whatsapp inbound dispatch", () => {
       Provider: "whatsapp",
       Surface: "whatsapp",
       OriginatingChannel: "whatsapp",
+    });
+  });
+
+  it("keeps authorization metadata on normal command-fact turns", async () => {
+    const body = "please inspect `/tmp/foo`";
+    const ctx = await buildWhatsAppInboundContext({
+      combinedBody: body,
+      command: {
+        kind: "normal",
+        authorized: true,
+        body,
+      },
+      msg: makeMsg({ payload: { body } }),
+      rawBody: body,
+      route: makeRoute(),
+      sender: { e164: "+1000" },
+    });
+
+    expectRecordFields(requireRecord(ctx, "normal command context"), {
+      CommandAuthorized: true,
+      CommandSource: undefined,
+      CommandTurn: {
+        kind: "normal",
+        source: "message",
+        authorized: false,
+        commandName: undefined,
+        body,
+      },
     });
   });
 
@@ -1183,17 +1225,18 @@ describe("whatsapp inbound dispatch", () => {
   });
 
   it("delivers authorized WhatsApp group text slash command replies visibly", async () => {
+    const context = finalizedContext({
+      Body: "/status",
+      ChatType: "group",
+      CommandAuthorized: true,
+      CommandSource: "text",
+    });
     await dispatchBufferedReply({
       cfg: {
         channels: { whatsapp: { streaming: { block: { enabled: true } } } },
         messages: { groupChat: { visibleReplies: "message_tool" } },
       } as never,
-      context: {
-        Body: "/status",
-        ChatType: "group",
-        CommandAuthorized: true,
-        CommandSource: "text",
-      },
+      context,
       msg: makeMsg({
         payload: { body: "/status" },
         admission: groupAdmission("120363000000000000@g.us"),
@@ -1205,6 +1248,7 @@ describe("whatsapp inbound dispatch", () => {
       disableBlockStreaming: false,
       suppressTyping: false,
     });
+    expect(sourceReplyDeliveryModeContexts).toEqual([context]);
   });
 
   it("honors automatic visible replies for WhatsApp groups", async () => {
@@ -1359,7 +1403,7 @@ describe("whatsapp inbound dispatch", () => {
       dispatchWhatsAppBufferedReply({
         cfg: { channels: { whatsapp: { streaming: { block: { enabled: true } } } } } as never,
         connectionId: "conn",
-        context: { Body: "hi" },
+        context: finalizedContext({ Body: "hi" }),
         deliverReply,
         groupHistories: new Map(),
         groupHistoryKey: "+1000",

--- a/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.ts
@@ -5,7 +5,7 @@ import {
 } from "openclaw/plugin-sdk/channel-feedback";
 import {
   buildChannelInboundEventContext,
-  type CommandTurnContext,
+  type CommandFacts,
   toInboundMediaFacts,
 } from "openclaw/plugin-sdk/channel-inbound";
 import { hasVisibleInboundReplyDispatch } from "openclaw/plugin-sdk/channel-inbound";
@@ -30,7 +30,6 @@ import type { GroupHistoryEntry } from "./inbound-context.js";
 import {
   createChannelMessageReplyPipeline,
   dispatchReplyWithBufferedBlockDispatcher,
-  finalizeInboundContext,
   getAgentScopedMediaLocalRoots,
   jidToE164,
   logVerbose,
@@ -149,7 +148,7 @@ function logWhatsAppReplyDeliveryError(params: {
 }
 
 function resolveWhatsAppDurableReplyToId(params: {
-  context: Record<string, unknown>;
+  context: FinalizedMsgContext;
   info: ReplyDeliveryInfo;
   msg: AdmittedWebInboundMessage;
   payload: DeliverableWhatsAppOutboundPayload<ReplyPayload>;
@@ -298,10 +297,7 @@ export function resolveWhatsAppResponsePrefix(params: {
 export async function buildWhatsAppInboundContext(params: {
   bodyForAgent?: string;
   combinedBody: string;
-  commandBody?: string;
-  commandAuthorized?: boolean;
-  commandTurn?: CommandTurnContext;
-  commandSource?: "text";
+  command?: CommandFacts;
   groupHistory?: GroupHistoryEntry[];
   groupMemberRoster?: Map<string, string>;
   groupSystemPrompt?: string;
@@ -346,7 +342,6 @@ export async function buildWhatsAppInboundContext(params: {
   );
   return buildChannelInboundEventContext({
     channel: "whatsapp",
-    finalize: finalizeInboundContext,
     supplemental: {
       quote: params.visibleReplyTo
         ? {
@@ -385,7 +380,7 @@ export async function buildWhatsAppInboundContext(params: {
       bodyForAgent: params.bodyForAgent ?? params.msg.payload.body,
       inboundHistory,
       rawBody: params.rawBody ?? params.msg.payload.body,
-      commandBody: params.commandBody ?? params.msg.payload.body,
+      commandBody: params.command?.body ?? params.msg.payload.body,
     },
     access: {
       ...(wasMentioned !== undefined
@@ -398,10 +393,10 @@ export async function buildWhatsAppInboundContext(params: {
           }
         : {}),
       commands: {
-        authorized: params.commandAuthorized === true,
+        authorized: params.command?.authorized === true,
       },
     },
-    commandTurn: params.commandTurn,
+    command: params.command,
     extra: {
       Transcript: params.transcript,
       GroupSubject: params.msg.group?.subject,
@@ -411,53 +406,11 @@ export async function buildWhatsAppInboundContext(params: {
         fallbackE164: params.sender.e164,
       }),
       SenderE164: params.sender.e164,
-      CommandSource:
-        params.commandSource ??
-        (params.commandTurn?.source === "native" || params.commandTurn?.source === "text"
-          ? params.commandTurn.source
-          : undefined),
       ReplyThreading: params.replyThreading,
       SuppressMessageReceivedHooks: params.suppressMessageReceivedHooks,
       ...(params.msg.payload.location ? toLocationContext(params.msg.payload.location) : {}),
     },
   });
-}
-
-function normalizeCommandTurnFromContext(value: unknown): CommandTurnContext | undefined {
-  if (!value || typeof value !== "object") {
-    return undefined;
-  }
-  const record = value as Partial<CommandTurnContext>;
-  const kind = record.kind;
-  const source = record.source;
-  if (kind === "native" && source === "native" && typeof record.authorized === "boolean") {
-    return {
-      kind: "native",
-      source: "native",
-      authorized: record.authorized,
-      commandName: typeof record.commandName === "string" ? record.commandName : undefined,
-      body: typeof record.body === "string" ? record.body : undefined,
-    };
-  }
-  if (kind === "text-slash" && source === "text" && typeof record.authorized === "boolean") {
-    return {
-      kind: "text-slash",
-      source: "text",
-      authorized: record.authorized,
-      commandName: typeof record.commandName === "string" ? record.commandName : undefined,
-      body: typeof record.body === "string" ? record.body : undefined,
-    };
-  }
-  if (kind === "normal" && source === "message") {
-    return {
-      kind: "normal",
-      source: "message",
-      authorized: false,
-      commandName: typeof record.commandName === "string" ? record.commandName : undefined,
-      body: typeof record.body === "string" ? record.body : undefined,
-    };
-  }
-  return undefined;
 }
 
 export function resolveWhatsAppDmRouteTarget(params: {
@@ -539,7 +492,7 @@ export function updateWhatsAppMainLastRoute(params: {
 export async function dispatchWhatsAppBufferedReply(params: {
   cfg: ReturnType<LoadConfigFn>;
   connectionId: string;
-  context: Record<string, unknown>;
+  context: FinalizedMsgContext;
   deliverReply: (params: {
     replyResult: ReplyPayload;
     normalizedReplyResult?: DeliverableWhatsAppOutboundPayload<ReplyPayload>;
@@ -591,27 +544,11 @@ export async function dispatchWhatsAppBufferedReply(params: {
     accountId: params.route.accountId,
   });
   const mediaLocalRoots = getAgentScopedMediaLocalRoots(params.cfg, params.route.agentId);
-  const sourceReplyChatType =
-    typeof params.context.ChatType === "string" ? params.context.ChatType : conversationKind;
-  const sourceReplyCommandSource =
-    params.context.CommandSource === "native" || params.context.CommandSource === "text"
-      ? params.context.CommandSource
-      : undefined;
-  const sourceReplyCommandTurn = normalizeCommandTurnFromContext(params.context.CommandTurn);
-  const sourceReplyCommandAuthorized =
-    typeof params.context.CommandAuthorized === "boolean"
-      ? params.context.CommandAuthorized
-      : undefined;
   const sourceReplyDeliveryMode =
-    sourceReplyChatType === "group" || sourceReplyChatType === "channel"
+    params.context.ChatType === "group" || params.context.ChatType === "channel"
       ? resolveChannelMessageSourceReplyDeliveryMode({
           cfg: params.cfg,
-          ctx: {
-            ChatType: sourceReplyChatType,
-            CommandTurn: sourceReplyCommandTurn,
-            CommandSource: sourceReplyCommandSource,
-            CommandAuthorized: sourceReplyCommandAuthorized,
-          },
+          ctx: params.context,
         })
       : undefined;
   const sourceRepliesAreToolOnly = sourceReplyDeliveryMode === "message_tool_only";
@@ -719,7 +656,7 @@ export async function dispatchWhatsAppBufferedReply(params: {
               channel: "whatsapp",
               accountId: params.route.accountId,
               agentId: params.route.agentId,
-              ctxPayload: params.context as FinalizedMsgContext,
+              ctxPayload: params.context,
               payload: normalizedDeliveryPayload,
               info,
               to: conversationId,

--- a/extensions/whatsapp/src/auto-reply/monitor/process-message.test.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/process-message.test.ts
@@ -317,11 +317,8 @@ describe("processMessage group system prompt wiring", () => {
     expect(shouldComputeCommandAuthorizedMock).toHaveBeenCalledWith("/status", {});
     expect(isControlCommandMessageMock).toHaveBeenCalledWith("/status", {});
     expect(mockCallArg(buildContextMock, "buildWhatsAppInboundContext")).toMatchObject({
-      commandBody: "/status",
-      commandAuthorized: true,
-      commandTurn: {
+      command: {
         kind: "text-slash",
-        source: "text",
         authorized: true,
         body: "/status",
       },
@@ -345,7 +342,11 @@ describe("processMessage group system prompt wiring", () => {
     expect(isControlCommandMessageMock).toHaveBeenCalledWith("/reset", {});
     expect(mockCallArg(buildContextMock, "buildWhatsAppInboundContext")).toMatchObject({
       bodyForAgent: "/reset\n\n[whatsapp attachment unavailable]",
-      commandBody: "/reset",
+      command: {
+        kind: "text-slash",
+        authorized: true,
+        body: "/reset",
+      },
       rawBody: "/reset",
     });
   });
@@ -360,19 +361,13 @@ describe("processMessage group system prompt wiring", () => {
     });
 
     expect(mockCallArg(buildContextMock, "buildWhatsAppInboundContext")).toMatchObject({
-      commandBody: "please inspect `/tmp/foo`",
-      commandAuthorized: true,
-      commandTurn: {
+      command: {
         kind: "normal",
-        source: "message",
-        authorized: false,
+        authorized: true,
         body: "please inspect `/tmp/foo`",
       },
       rawBody: "please inspect `/tmp/foo`",
     });
-    expect(
-      mockCallArg(buildContextMock, "buildWhatsAppInboundContext").commandSource,
-    ).toBeUndefined();
   });
 
   it("passes pending group history from the history window into inbound context", async () => {

--- a/extensions/whatsapp/src/auto-reply/monitor/process-message.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/process-message.ts
@@ -4,10 +4,7 @@ import {
   removeAckReactionHandleAfterReply,
   type AckReactionHandle,
 } from "openclaw/plugin-sdk/channel-feedback";
-import {
-  runChannelInboundEvent,
-  type CommandTurnContext,
-} from "openclaw/plugin-sdk/channel-inbound";
+import { runChannelInboundEvent } from "openclaw/plugin-sdk/channel-inbound";
 import { recordInboundSession } from "openclaw/plugin-sdk/conversation-runtime";
 import {
   createInternalHookEvent,
@@ -438,19 +435,6 @@ export async function processMessage(params: {
         authDir: account.authDir,
       })
     : undefined;
-  const commandTurn: CommandTurnContext = isTextCommand
-    ? {
-        kind: "text-slash",
-        source: "text",
-        authorized: Boolean(commandAuthorized),
-        body: commandBody,
-      }
-    : {
-        kind: "normal",
-        source: "message",
-        authorized: false,
-        body: commandBody,
-      };
   const { onModelSelected, ...replyPipeline } = createChannelMessageReplyPipeline({
     cfg: params.cfg,
     agentId: params.route.agentId,
@@ -483,9 +467,11 @@ export async function processMessage(params: {
   const ctxPayload = await buildWhatsAppInboundContext({
     bodyForAgent: msgForAgent.payload.body,
     combinedBody,
-    commandBody,
-    commandAuthorized,
-    commandTurn,
+    command: {
+      kind: isTextCommand ? "text-slash" : "normal",
+      body: commandBody,
+      authorized: commandAuthorized,
+    },
     groupHistory: visibleGroupHistory,
     groupMemberRoster: params.groupMemberNames.get(params.groupHistoryKey),
     groupSystemPrompt: conversationSystemPrompt,

--- a/extensions/whatsapp/src/auto-reply/monitor/runtime-api.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/runtime-api.ts
@@ -21,7 +21,6 @@ export {
 export { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-payload";
 export {
   dispatchReplyWithBufferedBlockDispatcher,
-  finalizeInboundContext,
   resolveChunkMode,
   resolveTextChunkLimit,
   type getReplyFromConfig,

--- a/extensions/whatsapp/src/test-helpers.ts
+++ b/extensions/whatsapp/src/test-helpers.ts
@@ -480,7 +480,6 @@ vi.mock("./inbound/runtime-api.js", () => ({
 vi.mock("./auto-reply/monitor/inbound-dispatch.runtime.js", () => ({
   createChannelMessageReplyPipeline: createChannelMessageReplyPipelineMock,
   dispatchReplyWithBufferedBlockDispatcher: createBufferedDispatchReplyMock(),
-  finalizeInboundContext: <T>(ctx: T) => ctx,
   getAgentScopedMediaLocalRoots: () => [] as string[],
   jidToE164: normalizePhoneLikeToE164,
   logVerbose: (_msg: string) => undefined,
@@ -510,7 +509,6 @@ vi.mock("./auto-reply/monitor/runtime-api.js", () => ({
   },
   createChannelMessageReplyPipeline: createChannelMessageReplyPipelineMock,
   dispatchReplyWithBufferedBlockDispatcher: createBufferedDispatchReplyMock(),
-  finalizeInboundContext: <T>(ctx: T) => ctx,
   formatInboundEnvelope: formatInboundEnvelopeMock,
   getAgentScopedMediaLocalRoots: () => [] as string[],
   isControlCommandMessage: () => false,


### PR DESCRIPTION
## What Problem This Solves

WhatsApp currently reconstructs command turns, command sources, inbound-context finalization, source-reply inputs, and text-debounce eligibility that are already canonical SDK policy. Keeping these parallel implementations makes WhatsApp behavior vulnerable to drifting from other channels as the shared contracts evolve.

## Why This Change Was Made

This change passes `CommandFacts` into the shared inbound-context builder and consumes the resulting finalized context directly. It removes WhatsApp's local command-turn/source normalization, sends the complete finalized context to source-reply delivery policy, and delegates debounce eligibility to `shouldDebounceTextInbound` while preserving WhatsApp-specific media, location, and quoted-message filtering.

## User Impact

No intentional user-visible behavior change. WhatsApp command authorization, source-reply delivery, and text batching now follow the same canonical SDK policy as other channels, with regression coverage for normal and slash command metadata and blank-text debounce handling.

## Evidence

- Blacksmith Testbox `tbx_01kxf9vwtnhn36se9grb7245mz`: 65 focused WhatsApp inbound-context and dispatch tests passed.
- The focused blank-text debounce regression passed independently.
- `pnpm check:changed` passed, including extension production/test typechecks, formatting, lint, SDK API baseline, and import-cycle checks.
- Fresh autoreview reported no accepted or actionable findings.
- A broader connection/logging E2E-file run passed 26 tests, including the new debounce assertion, but two untouched listener-readiness cases failed while waiting for the active listener. The changed regression was rerun independently and passed; the broader timing failures were not reproduced against `main`.
