### PR TITLE
fix(nodes): keep Linux nodes online after logout

### DIFF
--- a/docs/cli/node.md
+++ b/docs/cli/node.md
@@ -140,6 +140,12 @@ Use `openclaw node run` for a foreground node host (no service).
 
 Service commands accept `--json` for machine-readable output.
 
+On Linux, the node runs as a systemd user service. `node install` checks whether
+systemd lingering is enabled and tries to enable it non-interactively. If that
+is not permitted, it prints a warning; run
+`sudo loginctl enable-linger $(whoami)` so the node stays online after you log
+out. See [Node troubleshooting](/nodes/troubleshooting#linux-service-stops-after-logout).
+
 The node host retries Gateway restart and network closes in-process. If the
 Gateway reports a terminal token/password/bootstrap auth pause, the node host
 logs the close detail and exits non-zero so launchd/systemd/Task Scheduler can

--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -4966,6 +4966,7 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
 - Headings:
   - H2: Command ladder
   - H2: Foreground requirements
+  - H2: Linux service stops after logout
   - H2: Permissions matrix
   - H2: Pairing versus approvals
   - H2: Common node error codes

--- a/docs/nodes/index.md
+++ b/docs/nodes/index.md
@@ -130,6 +130,12 @@ openclaw node restart
 
 `node install` also accepts `--context-path`, `--tls`, `--tls-fingerprint`, `--node-id` (legacy client instance ID only), `--runtime <node>` (default: node), and `--force` to reinstall. `node status`, `node stop`, and `node uninstall` are also available.
 
+Linux installs use a systemd user service. The installer checks systemd
+lingering and tries to enable it non-interactively; if it cannot, follow the
+printed warning and run `sudo loginctl enable-linger $(whoami)`. Without
+lingering, the node goes offline when the user's login session ends. See
+[Node troubleshooting](/nodes/troubleshooting#linux-service-stops-after-logout).
+
 ### Pair + name
 
 On the gateway host:

--- a/docs/nodes/troubleshooting.md
+++ b/docs/nodes/troubleshooting.md
@@ -46,6 +46,26 @@ openclaw logs --follow
 
 If you see `NODE_BACKGROUND_UNAVAILABLE`, bring the node app to the foreground and retry.
 
+## Linux service stops after logout
+
+`openclaw node install` creates a systemd user service on Linux. That service
+needs systemd lingering to remain active after the user's final login session
+ends. The installer checks this state and tries to enable it non-interactively.
+If it prints a warning, run:
+
+```bash
+sudo loginctl enable-linger $(whoami)
+openclaw node restart
+```
+
+Verify the setting with:
+
+```bash
+loginctl show-user $(whoami) -p Linger
+```
+
+The expected result is `Linger=yes`.
+
 ## Permissions matrix
 
 | Capability                   | iOS                                     | Android                                      | macOS node app                   | Typical failure code                          |

--- a/src/cli/node-cli/daemon.test.ts
+++ b/src/cli/node-cli/daemon.test.ts
@@ -31,6 +31,11 @@ const mocks = vi.hoisted(() => {
       environment: {},
       environmentValueSources: {},
     })),
+    ensureSystemdUserLingerNonInteractive: vi.fn(
+      async ({ warn }: { warn: (message: string) => void }) => {
+        warn("Systemd lingering is disabled for alice. Run: sudo loginctl enable-linger alice");
+      },
+    ),
     loadNodeHostConfig: vi.fn(),
   };
 });
@@ -45,6 +50,10 @@ vi.mock("../../daemon/node-service.js", () => ({
 
 vi.mock("../../commands/node-daemon-install-helpers.js", () => ({
   buildNodeInstallPlan: mocks.buildNodeInstallPlan,
+}));
+
+vi.mock("../../commands/systemd-linger.js", () => ({
+  ensureSystemdUserLingerNonInteractive: mocks.ensureSystemdUserLingerNonInteractive,
 }));
 
 vi.mock("../../node-host/config.js", () => ({
@@ -102,6 +111,7 @@ describe("runNodeDaemonInstall", () => {
       environment: {},
       environmentValueSources: {},
     });
+    mocks.ensureSystemdUserLingerNonInteractive.mockClear();
     mocks.loadNodeHostConfig.mockReset().mockResolvedValue({
       gateway: {
         host: "saved-gateway.local",
@@ -151,6 +161,25 @@ describe("runNodeDaemonInstall", () => {
       expect.objectContaining({
         tls: true,
         tlsFingerprint: "saved-fingerprint",
+      }),
+    );
+  });
+
+  it("includes a systemd linger warning in JSON install output", async () => {
+    await runNodeDaemonInstall({ force: true, json: true });
+
+    expect(mocks.service.install).toHaveBeenCalledTimes(1);
+    expect(mocks.ensureSystemdUserLingerNonInteractive).toHaveBeenCalledTimes(1);
+    expect(mocks.service.install.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.ensureSystemdUserLingerNonInteractive.mock.invocationCallOrder[0] ?? 0,
+    );
+    expect(mocks.runtime.writeJson).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ok: true,
+        result: "installed",
+        warnings: [
+          "Systemd lingering is disabled for alice. Run: sudo loginctl enable-linger alice",
+        ],
       }),
     );
   });

--- a/src/cli/node-cli/daemon.ts
+++ b/src/cli/node-cli/daemon.ts
@@ -6,6 +6,7 @@ import {
   isGatewayDaemonRuntime,
 } from "../../commands/daemon-runtime.js";
 import { buildNodeInstallPlan } from "../../commands/node-daemon-install-helpers.js";
+import { ensureSystemdUserLingerNonInteractive } from "../../commands/systemd-linger.js";
 import {
   resolveNodeLaunchAgentLabel,
   resolveNodeSystemdServiceName,
@@ -195,6 +196,12 @@ export async function runNodeDaemonInstall(opts: NodeDaemonInstallOptions) {
         environment,
         environmentValueSources,
         description,
+      });
+      await ensureSystemdUserLingerNonInteractive({
+        // Keep successful enablement chatter out of --json, while preserving an
+        // actionable failure in the response's structured warnings.
+        runtime: json ? { ...defaultRuntime, log: () => undefined } : defaultRuntime,
+        warn,
       });
     },
   });

--- a/src/commands/systemd-linger.test.ts
+++ b/src/commands/systemd-linger.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ensureSystemdUserLingerNonInteractive } from "./systemd-linger.js";
+
+const mocks = vi.hoisted(() => ({
+  enableSystemdUserLinger: vi.fn(),
+  isSystemdUserServiceAvailable: vi.fn(async () => true),
+  readSystemdUserLingerStatus: vi.fn(async () => ({ user: "alice", linger: "no" as const })),
+}));
+
+vi.mock("../daemon/systemd.js", () => mocks);
+
+describe("ensureSystemdUserLingerNonInteractive", () => {
+  const originalPlatform = process.platform;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.defineProperty(process, "platform", { configurable: true, value: "linux" });
+    mocks.isSystemdUserServiceAvailable.mockResolvedValue(true);
+    mocks.readSystemdUserLingerStatus.mockResolvedValue({ user: "alice", linger: "no" });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process, "platform", {
+      configurable: true,
+      value: originalPlatform,
+    });
+  });
+
+  it("routes failed non-interactive enablement through the warning callback", async () => {
+    mocks.enableSystemdUserLinger.mockResolvedValue({
+      ok: false,
+      stdout: "",
+      stderr: "sudo: a password is required",
+      code: 1,
+    });
+    const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
+    const warn = vi.fn();
+
+    await ensureSystemdUserLingerNonInteractive({ runtime, warn });
+
+    expect(warn).toHaveBeenCalledWith(
+      "Systemd lingering is disabled for alice. Run: sudo loginctl enable-linger alice",
+    );
+    expect(runtime.log).not.toHaveBeenCalled();
+  });
+
+  it("keeps successful enablement as informational output", async () => {
+    mocks.enableSystemdUserLinger.mockResolvedValue({
+      ok: true,
+      stdout: "",
+      stderr: "",
+      code: 0,
+    });
+    const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
+    const warn = vi.fn();
+
+    await ensureSystemdUserLingerNonInteractive({ runtime, warn });
+
+    expect(runtime.log).toHaveBeenCalledWith("Enabled systemd lingering for alice.");
+    expect(warn).not.toHaveBeenCalled();
+  });
+});

--- a/src/commands/systemd-linger.ts
+++ b/src/commands/systemd-linger.ts
@@ -97,6 +97,7 @@ export async function ensureSystemdUserLingerInteractive(params: {
 export async function ensureSystemdUserLingerNonInteractive(params: {
   runtime: RuntimeEnv;
   env?: NodeJS.ProcessEnv;
+  warn?: (message: string) => void;
 }): Promise<void> {
   if (process.platform !== "linux") {
     return;
@@ -120,7 +121,6 @@ export async function ensureSystemdUserLingerNonInteractive(params: {
     return;
   }
 
-  params.runtime.log(
-    `Systemd lingering is disabled for ${status.user}. Run: sudo loginctl enable-linger ${status.user}`,
-  );
+  const message = `Systemd lingering is disabled for ${status.user}. Run: sudo loginctl enable-linger ${status.user}`;
+  (params.warn ?? params.runtime.log)(message);
 }


### PR DESCRIPTION
Closes #107033

## What Problem This Solves

Fixes an issue where Linux node hosts installed as systemd user services could appear healthy during setup, then go offline after the operator logged out because systemd lingering was disabled.

## Why This Change Was Made

The node installer now uses the existing systemd linger flow after a successful service install, attempting non-interactive enablement and returning an actionable warning when that is not permitted. The same recovery guidance is linked from node setup, CLI reference, and troubleshooting documentation.

## User Impact

Linux node hosts can remain online after SSH logout. When OpenClaw cannot enable lingering automatically, text output shows the exact recovery command and `--json` returns it in `warnings` without corrupting machine-readable output.

## Evidence

Premise checked against the installed systemd 255 `loginctl(1)` documentation: `enable-linger` starts a user manager at boot and keeps it running after logout, allowing long-running user services. Current main installed the node systemd user service without invoking the existing linger flow.

Focused regression proof:

```text
$ OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/commands/systemd-linger.test.ts src/cli/node-cli/daemon.test.ts src/commands/onboard-non-interactive/local/daemon-install.test.ts src/commands/configure.daemon.test.ts
Test Files  4 passed (4)
Tests       20 passed (20)
```

The new regressions verify that the service is installed before the linger check, that failed non-interactive enablement is preserved in structured JSON warnings, and that successful enablement remains informational output. Existing interactive and non-interactive gateway linger callers remain green.

Documentation checks:

```text
$ node scripts/check-docs-mdx.mjs docs/cli/node.md docs/nodes/index.md docs/nodes/troubleshooting.md
Docs MDX check passed (3 files, 81ms).

$ node scripts/docs-link-audit.mjs
checked_internal_links=5976
broken_links=0

$ node scripts/check-docs-i18n-glossary.mjs --base upstream/main
# exit 0

$ node scripts/generate-docs-map.mjs --check
docs:map: docs/docs_map.md is up to date.

$ node_modules/.bin/oxfmt --check src/commands/systemd-linger.ts src/cli/node-cli/daemon.ts src/cli/node-cli/daemon.test.ts docs/cli/node.md docs/nodes/index.md docs/nodes/troubleshooting.md
All matched files use the correct format.

$ git diff --check
# exit 0
```

The local Linux environment does not expose a systemd user bus, so I could not run a real SSH logout cycle here; CI provides the full build, typecheck, and test gates.

AI-assisted; the source review and focused proof above were run locally.
