### PR TITLE
refactor(agents): extract attempt prompt execution lifecycle

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt-prompt-error.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-error.test.ts
@@ -1,0 +1,137 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const hoisted = vi.hoisted(() => ({
+  handleMidTurnPrecheckRequest: vi.fn(),
+  isMidTurnPrecheckSignal: vi.fn(() => false),
+  isSessionsYieldAbortError: vi.fn(() => false),
+  markYieldAborted: vi.fn(),
+  persistSessionsYieldContextMessage: vi.fn(async () => undefined),
+  releaseHeldLockForAbort: vi.fn(async () => undefined),
+  releaseLeasedSteering: vi.fn(),
+  stripSessionsYieldArtifacts: vi.fn(),
+  waitForSessionEvents: vi.fn(async () => undefined),
+  waitForSessionsYieldAbortSettle: vi.fn(async () => undefined),
+  withOwnedSessionWriteLock: vi.fn(async (operation: () => unknown) => await operation()),
+}));
+
+vi.mock("./attempt.sessions-yield.js", () => ({
+  isSessionsYieldAbortError: hoisted.isSessionsYieldAbortError,
+  persistSessionsYieldContextMessage: hoisted.persistSessionsYieldContextMessage,
+  stripSessionsYieldArtifacts: hoisted.stripSessionsYieldArtifacts,
+  waitForSessionsYieldAbortSettle: hoisted.waitForSessionsYieldAbortSettle,
+}));
+vi.mock("./midturn-precheck.js", () => ({
+  isMidTurnPrecheckSignal: hoisted.isMidTurnPrecheckSignal,
+}));
+
+import { handleEmbeddedAttemptPromptError } from "./attempt-prompt-error.js";
+
+type PromptErrorInput = Parameters<typeof handleEmbeddedAttemptPromptError>[0];
+
+function createInput(overrides: Partial<PromptErrorInput> = {}): PromptErrorInput {
+  return {
+    activeSession: { agent: { state: { messages: [] } }, messages: [] },
+    attempt: { runId: "run-1", sessionId: "session-1" },
+    error: new Error("prompt failed"),
+    handleMidTurnPrecheckRequest: hoisted.handleMidTurnPrecheckRequest,
+    markYieldAborted: hoisted.markYieldAborted,
+    releaseLeasedSteering: hoisted.releaseLeasedSteering,
+    sessionLockController: {
+      releaseHeldLockForAbort: hoisted.releaseHeldLockForAbort,
+      waitForSessionEvents: hoisted.waitForSessionEvents,
+    },
+    withOwnedSessionWriteLock: hoisted.withOwnedSessionWriteLock,
+    yieldAbortSettled: null,
+    yieldDetected: false,
+    yieldMessage: null,
+    ...overrides,
+  } as PromptErrorInput;
+}
+
+describe("handleEmbeddedAttemptPromptError", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    hoisted.isMidTurnPrecheckSignal.mockReturnValue(false);
+    hoisted.isSessionsYieldAbortError.mockReturnValue(false);
+  });
+
+  it("returns ordinary provider failures to the prompt state owner", async () => {
+    const error = new Error("provider failed");
+
+    await expect(handleEmbeddedAttemptPromptError(createInput({ error }))).resolves.toEqual({
+      promptFailure: { error, source: "prompt" },
+    });
+
+    expect(hoisted.releaseLeasedSteering).toHaveBeenCalledWith(error);
+    expect(hoisted.waitForSessionEvents).not.toHaveBeenCalled();
+  });
+
+  it("routes mid-turn prechecks under the owned session lock", async () => {
+    const request = {
+      route: "compact_only",
+      estimatedPromptTokens: 12,
+      promptBudgetBeforeReserve: 10,
+      overflowTokens: 2,
+      toolResultReducibleChars: 0,
+      effectiveReserveTokens: 1,
+    } as const;
+    const error = { request };
+    hoisted.isMidTurnPrecheckSignal.mockReturnValue(true);
+
+    await expect(handleEmbeddedAttemptPromptError(createInput({ error }))).resolves.toEqual({});
+
+    expect(hoisted.waitForSessionEvents).toHaveBeenCalledOnce();
+    expect(hoisted.withOwnedSessionWriteLock).toHaveBeenCalledOnce();
+    expect(hoisted.handleMidTurnPrecheckRequest).toHaveBeenCalledWith(request);
+  });
+
+  it("settles yield aborts, strips artifacts, and persists handoff context", async () => {
+    const settlePromise = Promise.resolve();
+    const error = new Error("yield handoff");
+    const input = createInput({
+      error,
+      yieldAbortSettled: settlePromise,
+      yieldDetected: true,
+      yieldMessage: "wait for follow-up",
+    });
+    hoisted.isSessionsYieldAbortError.mockReturnValue(true);
+
+    await expect(handleEmbeddedAttemptPromptError(input)).resolves.toEqual({});
+
+    expect(hoisted.markYieldAborted).toHaveBeenCalledOnce();
+    expect(hoisted.waitForSessionsYieldAbortSettle).toHaveBeenCalledWith({
+      settlePromise,
+      runId: "run-1",
+      sessionId: "session-1",
+    });
+    expect(hoisted.releaseHeldLockForAbort).toHaveBeenCalledOnce();
+    expect(hoisted.waitForSessionEvents).toHaveBeenCalledWith(input.activeSession);
+    expect(hoisted.stripSessionsYieldArtifacts).toHaveBeenCalledWith(input.activeSession);
+    expect(hoisted.persistSessionsYieldContextMessage).toHaveBeenCalledWith(
+      input.activeSession,
+      "wait for follow-up",
+    );
+  });
+
+  it("marks yield state before fallible recovery begins", async () => {
+    const recoveryError = new Error("settle failed");
+    let marked = false;
+    hoisted.isSessionsYieldAbortError.mockReturnValue(true);
+    hoisted.waitForSessionsYieldAbortSettle.mockImplementationOnce(async () => {
+      expect(marked).toBe(true);
+      throw recoveryError;
+    });
+
+    await expect(
+      handleEmbeddedAttemptPromptError(
+        createInput({
+          error: new Error("yield handoff"),
+          markYieldAborted: () => {
+            marked = true;
+          },
+          yieldDetected: true,
+        }),
+      ),
+    ).rejects.toBe(recoveryError);
+  });
+});

--- a/src/agents/embedded-agent-runner/run/attempt-prompt-error.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-error.ts
@@ -1,0 +1,76 @@
+/** Classifies prompt failures and performs yield or mid-turn recovery. */
+import type { AgentSession } from "../../sessions/index.js";
+import type { EmbeddedAttemptSessionLockController } from "./attempt.session-lock.js";
+import {
+  isSessionsYieldAbortError,
+  persistSessionsYieldContextMessage,
+  stripSessionsYieldArtifacts,
+  waitForSessionsYieldAbortSettle,
+} from "./attempt.sessions-yield.js";
+import { isMidTurnPrecheckSignal, type MidTurnPrecheckRequest } from "./midturn-precheck.js";
+import type { EmbeddedRunAttemptParams } from "./types.js";
+
+type PromptErrorAttempt = Pick<EmbeddedRunAttemptParams, "runId" | "sessionId">;
+type PromptErrorSessionLockController = Pick<
+  EmbeddedAttemptSessionLockController,
+  "releaseHeldLockForAbort" | "waitForSessionEvents"
+>;
+type WithOwnedSessionWriteLock = <T>(operation: () => Promise<T> | T) => Promise<T>;
+
+export type EmbeddedAttemptPromptErrorOutcome = {
+  promptFailure?: {
+    error: unknown;
+    source: "prompt";
+  };
+};
+
+export async function handleEmbeddedAttemptPromptError(input: {
+  activeSession: AgentSession;
+  attempt: PromptErrorAttempt;
+  error: unknown;
+  handleMidTurnPrecheckRequest: (request: MidTurnPrecheckRequest) => void;
+  markYieldAborted: () => void;
+  releaseLeasedSteering: (error?: unknown) => void;
+  sessionLockController: PromptErrorSessionLockController;
+  withOwnedSessionWriteLock: WithOwnedSessionWriteLock;
+  yieldAbortSettled: Promise<void> | null;
+  yieldDetected: boolean;
+  yieldMessage: string | null;
+}): Promise<EmbeddedAttemptPromptErrorOutcome> {
+  input.releaseLeasedSteering(input.error);
+  const yieldAborted = input.yieldDetected && isSessionsYieldAbortError(input.error);
+  if (yieldAborted) {
+    // Publish terminal state before fallible recovery so outer cleanup still recognizes the yield.
+    input.markYieldAborted();
+    await waitForSessionsYieldAbortSettle({
+      settlePromise: input.yieldAbortSettled,
+      runId: input.attempt.runId,
+      sessionId: input.attempt.sessionId,
+    });
+    await input.sessionLockController.releaseHeldLockForAbort();
+    await input.sessionLockController.waitForSessionEvents(input.activeSession);
+    await input.withOwnedSessionWriteLock(async () => {
+      stripSessionsYieldArtifacts(input.activeSession);
+      if (input.yieldMessage) {
+        await persistSessionsYieldContextMessage(input.activeSession, input.yieldMessage);
+      }
+    });
+    return {};
+  }
+
+  if (isMidTurnPrecheckSignal(input.error)) {
+    const request = input.error.request;
+    await input.sessionLockController.waitForSessionEvents(input.activeSession);
+    await input.withOwnedSessionWriteLock(() => {
+      input.handleMidTurnPrecheckRequest(request);
+    });
+    return {};
+  }
+
+  return {
+    promptFailure: {
+      error: input.error,
+      source: "prompt",
+    },
+  };
+}

--- a/src/agents/embedded-agent-runner/run/attempt-prompt-execution-prepare.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-execution-prepare.test.ts
@@ -1,0 +1,155 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const hoisted = vi.hoisted(() => ({
+  canAdvanceSessionEntryCache: vi.fn(() => true),
+  detectAndLoadPromptImages: vi.fn(),
+  installPromptSubmissionLockRelease: vi.fn((_input: Record<string, unknown>) => undefined),
+  publishOwnedSessionFileSnapshot: vi.fn(() => true),
+  reacquireAfterPrompt: vi.fn(async () => undefined),
+  releaseForPrompt: vi.fn(async () => undefined),
+  resolveImageSanitizationLimits: vi.fn(() => ({ maxDimensionPx: 2048 })),
+  waitForSessionEvents: vi.fn(async () => undefined),
+  withSessionWriteLock: vi.fn(async (operation: () => unknown) => await operation()),
+}));
+
+vi.mock("@openclaw/media-core/constants", () => ({ MAX_IMAGE_BYTES: 1_234 }));
+vi.mock("../../image-sanitization.js", () => ({
+  resolveImageSanitizationLimits: hoisted.resolveImageSanitizationLimits,
+}));
+vi.mock("./images.js", () => ({
+  detectAndLoadPromptImages: hoisted.detectAndLoadPromptImages,
+}));
+vi.mock("./attempt.session-lock.js", () => ({
+  installPromptSubmissionLockRelease: hoisted.installPromptSubmissionLockRelease,
+}));
+
+import { prepareEmbeddedAttemptPromptExecution } from "./attempt-prompt-execution-prepare.js";
+
+type PromptExecutionInput = Parameters<typeof prepareEmbeddedAttemptPromptExecution>[0];
+
+function createInput(overrides: Partial<PromptExecutionInput> = {}): PromptExecutionInput {
+  return {
+    attempt: {
+      config: { agents: { defaults: { imageMaxDimensionPx: 2048 } } },
+      imageOrder: ["inline"],
+      images: [{ type: "image", data: "data", mimeType: "image/png" }],
+      model: {
+        api: "google-generative-ai",
+        id: "model-1",
+        input: ["text", "image"],
+        provider: "provider-1",
+      },
+      sessionFile: "/tmp/session.jsonl",
+      sessionKey: "agent:main:session-1",
+    },
+    effectiveFsWorkspaceOnly: true,
+    effectiveWorkspace: "/tmp/workspace",
+    prompt: "inspect image.png",
+    sandbox: {
+      enabled: true,
+      fsBridge: { readFile: vi.fn() },
+      workspaceDir: "/sandbox/workspace",
+    },
+    session: { agent: { streamFn: vi.fn() } },
+    sessionLockController: {
+      canAdvanceSessionEntryCache: hoisted.canAdvanceSessionEntryCache,
+      publishOwnedSessionFileSnapshot: hoisted.publishOwnedSessionFileSnapshot,
+      reacquireAfterPrompt: hoisted.reacquireAfterPrompt,
+      releaseForPrompt: hoisted.releaseForPrompt,
+      waitForSessionEvents: hoisted.waitForSessionEvents,
+      withSessionWriteLock: hoisted.withSessionWriteLock,
+    },
+    skipPromptSubmission: false,
+    ...overrides,
+  } as PromptExecutionInput;
+}
+
+describe("prepareEmbeddedAttemptPromptExecution", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    hoisted.resolveImageSanitizationLimits.mockReturnValue({ maxDimensionPx: 2048 });
+    hoisted.detectAndLoadPromptImages.mockResolvedValue({
+      images: [{ type: "image", data: "loaded", mimeType: "image/png" }],
+      detectedRefs: [],
+      loadedCount: 1,
+      skippedCount: 0,
+    });
+  });
+
+  it("returns an isolated empty image result when prompt submission is already skipped", async () => {
+    const first = await prepareEmbeddedAttemptPromptExecution(
+      createInput({ skipPromptSubmission: true }),
+    );
+    first.images.push({ type: "image", data: "mutated", mimeType: "image/png" });
+    const second = await prepareEmbeddedAttemptPromptExecution(
+      createInput({ skipPromptSubmission: true }),
+    );
+
+    expect(second).toEqual({
+      images: [],
+      detectedRefs: [],
+      loadedCount: 0,
+      skippedCount: 0,
+    });
+    expect(hoisted.installPromptSubmissionLockRelease).not.toHaveBeenCalled();
+    expect(hoisted.detectAndLoadPromptImages).not.toHaveBeenCalled();
+  });
+
+  it("installs the lock handoff before loading prompt images", async () => {
+    const input = createInput();
+
+    const result = await prepareEmbeddedAttemptPromptExecution(input);
+
+    expect(hoisted.installPromptSubmissionLockRelease).toHaveBeenCalledWith(
+      expect.objectContaining({
+        session: input.session,
+        sessionFile: "/tmp/session.jsonl",
+        sessionKey: "agent:main:session-1",
+      }),
+    );
+    const lockHandoff = hoisted.installPromptSubmissionLockRelease.mock.calls[0]?.[0] as
+      | {
+          reacquireAfterPrompt: () => Promise<void>;
+          releaseForPrompt: () => Promise<void>;
+          waitForSessionEvents: (session: unknown) => Promise<void>;
+        }
+      | undefined;
+    await lockHandoff?.waitForSessionEvents(input.session);
+    await lockHandoff?.releaseForPrompt();
+    await lockHandoff?.reacquireAfterPrompt();
+    expect(hoisted.waitForSessionEvents).toHaveBeenCalledWith(input.session);
+    expect(hoisted.releaseForPrompt).toHaveBeenCalledOnce();
+    expect(hoisted.reacquireAfterPrompt).toHaveBeenCalledOnce();
+    expect(hoisted.detectAndLoadPromptImages).toHaveBeenCalledWith({
+      prompt: "inspect image.png",
+      workspaceDir: "/tmp/workspace",
+      model: input.attempt.model,
+      existingImages: input.attempt.images,
+      imageOrder: ["inline"],
+      maxBytes: 1_234,
+      maxDimensionPx: 2048,
+      workspaceOnly: true,
+      sandbox: {
+        root: "/sandbox/workspace",
+        bridge: input.sandbox?.fsBridge,
+      },
+    });
+    expect(result).toEqual({
+      images: [{ type: "image", data: "loaded", mimeType: "image/png" }],
+      detectedRefs: [],
+      loadedCount: 1,
+      skippedCount: 0,
+    });
+  });
+
+  it("omits sandbox constraints when no sandbox bridge is active", async () => {
+    const input = createInput({ sandbox: null });
+
+    await prepareEmbeddedAttemptPromptExecution(input);
+
+    expect(hoisted.installPromptSubmissionLockRelease).toHaveBeenCalledOnce();
+    expect(hoisted.detectAndLoadPromptImages).toHaveBeenCalledWith(
+      expect.objectContaining({ sandbox: undefined }),
+    );
+  });
+});

--- a/src/agents/embedded-agent-runner/run/attempt-prompt-execution-prepare.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-execution-prepare.ts
@@ -1,0 +1,74 @@
+/** Prepares prompt-lock ownership and prompt-local images for submission. */
+import { MAX_IMAGE_BYTES } from "@openclaw/media-core/constants";
+import type { OwnedSessionTranscriptCacheSnapshot } from "../../../config/sessions/transcript-write-context.js";
+import { resolveImageSanitizationLimits } from "../../image-sanitization.js";
+import type { SandboxContext } from "../../sandbox/types.js";
+import type { AgentSession } from "../../sessions/index.js";
+import {
+  type EmbeddedAttemptSessionLockController,
+  installPromptSubmissionLockRelease,
+} from "./attempt.session-lock.js";
+import { detectAndLoadPromptImages } from "./images.js";
+import type { EmbeddedRunAttemptParams } from "./types.js";
+
+type PromptExecutionAttempt = Pick<
+  EmbeddedRunAttemptParams,
+  "config" | "imageOrder" | "images" | "model" | "sessionFile" | "sessionKey"
+>;
+type PromptImageResult = Awaited<ReturnType<typeof detectAndLoadPromptImages>>;
+
+function emptyPromptImages(): PromptImageResult {
+  return {
+    images: [],
+    detectedRefs: [],
+    loadedCount: 0,
+    skippedCount: 0,
+  };
+}
+
+export async function prepareEmbeddedAttemptPromptExecution(input: {
+  attempt: PromptExecutionAttempt;
+  effectiveFsWorkspaceOnly: boolean;
+  effectiveWorkspace: string;
+  prompt: string;
+  sandbox?: SandboxContext | null;
+  session: AgentSession;
+  sessionLockController: EmbeddedAttemptSessionLockController;
+  skipPromptSubmission: boolean;
+}): Promise<PromptImageResult> {
+  if (input.skipPromptSubmission) {
+    return emptyPromptImages();
+  }
+
+  const { attempt } = input;
+  installPromptSubmissionLockRelease({
+    session: input.session,
+    waitForSessionEvents: (sessionToDrain) =>
+      input.sessionLockController.waitForSessionEvents(sessionToDrain),
+    releaseForPrompt: () => input.sessionLockController.releaseForPrompt(),
+    reacquireAfterPrompt: () => input.sessionLockController.reacquireAfterPrompt(),
+    sessionKey: attempt.sessionKey,
+    sessionFile: attempt.sessionFile,
+    withSessionWriteLock: (run, options) =>
+      input.sessionLockController.withSessionWriteLock(run, options),
+    canAdvanceSessionEntryCache: (snapshot: OwnedSessionTranscriptCacheSnapshot) =>
+      input.sessionLockController.canAdvanceSessionEntryCache(snapshot),
+    publishSessionFileSnapshot: (snapshot: OwnedSessionTranscriptCacheSnapshot) =>
+      input.sessionLockController.publishOwnedSessionFileSnapshot(snapshot),
+  });
+
+  return await detectAndLoadPromptImages({
+    prompt: input.prompt,
+    workspaceDir: input.effectiveWorkspace,
+    model: attempt.model,
+    existingImages: attempt.images,
+    imageOrder: attempt.imageOrder,
+    maxBytes: MAX_IMAGE_BYTES,
+    maxDimensionPx: resolveImageSanitizationLimits(attempt.config).maxDimensionPx,
+    workspaceOnly: input.effectiveFsWorkspaceOnly,
+    sandbox:
+      input.sandbox?.enabled && input.sandbox.fsBridge
+        ? { root: input.sandbox.workspaceDir, bridge: input.sandbox.fsBridge }
+        : undefined,
+  });
+}

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -1,7 +1,6 @@
 /**
  * Orchestrates one embedded-agent attempt from prompt setup through stream result.
  */
-import { MAX_IMAGE_BYTES } from "@openclaw/media-core/constants";
 import {
   bindOwnedSessionTranscriptWrites,
   type OwnedSessionTranscriptCacheSnapshot,
@@ -20,7 +19,6 @@ import { materializeBundleMcpToolsForRun } from "../../agent-bundle-mcp-tools.js
 import { resolveAgentDir, resolveSessionAgentIds } from "../../agent-scope.js";
 import { createAnthropicPayloadLogger } from "../../anthropic-payload-log.js";
 import { createCacheTrace } from "../../cache-trace.js";
-import { resolveImageSanitizationLimits } from "../../image-sanitization.js";
 import type { AgentMessage } from "../../runtime/index.js";
 import type { guardSessionManager } from "../../session-tool-result-guard-wrapper.js";
 import { acquireSessionWriteLock } from "../../session-write-lock.js";
@@ -54,6 +52,8 @@ import { installEmbeddedAttemptContextGuards } from "./attempt-context-guards.js
 import { prepareEmbeddedAttemptHistory } from "./attempt-history-prepare.js";
 import { prepareEmbeddedAttemptPromptAssembly } from "./attempt-prompt-assembly.js";
 import { prepareEmbeddedAttemptPromptContext } from "./attempt-prompt-context.js";
+import { handleEmbeddedAttemptPromptError } from "./attempt-prompt-error.js";
+import { prepareEmbeddedAttemptPromptExecution } from "./attempt-prompt-execution-prepare.js";
 import { observeEmbeddedAttemptPrompt } from "./attempt-prompt-observability.js";
 import {
   handleEmbeddedAttemptMidTurnPrecheck,
@@ -88,18 +88,12 @@ import {
   acquireEmbeddedAttemptSessionFileOwner,
   type EmbeddedAttemptSessionFileOwner,
   createEmbeddedAttemptSessionLockController,
-  installPromptSubmissionLockRelease,
 } from "./attempt.session-lock.js";
 import {
-  isSessionsYieldAbortError,
-  persistSessionsYieldContextMessage,
   queueSessionsYieldInterruptMessage,
   SESSIONS_YIELD_ABORT_REASON,
-  stripSessionsYieldArtifacts,
-  waitForSessionsYieldAbortSettle,
 } from "./attempt.sessions-yield.js";
-import { detectAndLoadPromptImages } from "./images.js";
-import { isMidTurnPrecheckSignal, type MidTurnPrecheckRequest } from "./midturn-precheck.js";
+import type { MidTurnPrecheckRequest } from "./midturn-precheck.js";
 import { PREEMPTIVE_OVERFLOW_ERROR_TEXT } from "./preemptive-compaction.js";
 import { clearToolActivityRun } from "./tool-activity-heartbeat.js";
 import type { EmbeddedRunAttemptParams, EmbeddedRunAttemptResult } from "./types.js";
@@ -940,47 +934,18 @@ export async function runEmbeddedAttempt(
             if (googlePromptCacheStreamFn) {
               activeSession.agent.streamFn = googlePromptCacheStreamFn;
             }
-            installPromptSubmissionLockRelease({
-              session: activeSession,
-              waitForSessionEvents: (sessionToDrain) =>
-                sessionLockController.waitForSessionEvents(sessionToDrain),
-              releaseForPrompt: () => sessionLockController.releaseForPrompt(),
-              reacquireAfterPrompt: () => sessionLockController.reacquireAfterPrompt(),
-              sessionKey: params.sessionKey,
-              sessionFile: params.sessionFile,
-              withSessionWriteLock: (run, options) =>
-                sessionLockController.withSessionWriteLock(run, options),
-              canAdvanceSessionEntryCache: (snapshot: OwnedSessionTranscriptCacheSnapshot) =>
-                sessionLockController.canAdvanceSessionEntryCache(snapshot),
-              publishSessionFileSnapshot: (snapshot: OwnedSessionTranscriptCacheSnapshot) =>
-                sessionLockController.publishOwnedSessionFileSnapshot(snapshot),
-            });
           }
 
-          // Detect and load images referenced in the visible prompt for vision-capable models.
-          // Images are prompt-local only.
-          const imageResult = skipPromptSubmission
-            ? {
-                images: [],
-                detectedRefs: [],
-                loadedCount: 0,
-                skippedCount: 0,
-              }
-            : await detectAndLoadPromptImages({
-                prompt: promptSubmission.prompt,
-                workspaceDir: effectiveWorkspace,
-                model: params.model,
-                existingImages: params.images,
-                imageOrder: params.imageOrder,
-                maxBytes: MAX_IMAGE_BYTES,
-                maxDimensionPx: resolveImageSanitizationLimits(params.config).maxDimensionPx,
-                workspaceOnly: effectiveFsWorkspaceOnly,
-                // Enforce sandbox path restrictions when sandbox is enabled
-                sandbox:
-                  sandbox?.enabled && sandbox?.fsBridge
-                    ? { root: sandbox.workspaceDir, bridge: sandbox.fsBridge }
-                    : undefined,
-              });
+          const imageResult = await prepareEmbeddedAttemptPromptExecution({
+            attempt: params,
+            effectiveFsWorkspaceOnly,
+            effectiveWorkspace,
+            prompt: promptSubmission.prompt,
+            sandbox,
+            session: activeSession,
+            sessionLockController,
+            skipPromptSubmission,
+          });
 
           const reserveTokens = settingsManager.getCompactionReserveTokens();
           skipPromptSubmission = observeEmbeddedAttemptPrompt({
@@ -1083,32 +1048,26 @@ export async function runEmbeddedAttempt(
             releaseLeasedSteering(promptError ?? "prompt submission skipped");
           }
         } catch (err) {
-          releaseLeasedSteering(err);
-          yieldAborted = yieldDetected && isSessionsYieldAbortError(err);
-          cleanupYieldAborted = yieldAborted;
-          if (yieldAborted) {
-            aborted = false;
-            await waitForSessionsYieldAbortSettle({
-              settlePromise: yieldAbortSettled,
-              runId: params.runId,
-              sessionId: params.sessionId,
-            });
-            await sessionLockController.releaseHeldLockForAbort();
-            await sessionLockController.waitForSessionEvents(activeSession);
-            await withOwnedSessionWriteLock(async () => {
-              stripSessionsYieldArtifacts(activeSession);
-              if (yieldMessage) {
-                await persistSessionsYieldContextMessage(activeSession, yieldMessage);
-              }
-            });
-          } else if (isMidTurnPrecheckSignal(err)) {
-            await sessionLockController.waitForSessionEvents(activeSession);
-            await withOwnedSessionWriteLock(() => {
-              handleMidTurnPrecheckRequest(err.request);
-            });
-          } else {
-            promptError = err;
-            promptErrorSource = "prompt";
+          const promptErrorOutcome = await handleEmbeddedAttemptPromptError({
+            activeSession,
+            attempt: params,
+            error: err,
+            handleMidTurnPrecheckRequest,
+            markYieldAborted: () => {
+              yieldAborted = true;
+              cleanupYieldAborted = true;
+              aborted = false;
+            },
+            releaseLeasedSteering,
+            sessionLockController,
+            withOwnedSessionWriteLock,
+            yieldAbortSettled,
+            yieldDetected,
+            yieldMessage,
+          });
+          if (promptErrorOutcome.promptFailure) {
+            promptError = promptErrorOutcome.promptFailure.error;
+            promptErrorSource = promptErrorOutcome.promptFailure.source;
           }
         } finally {
           stopAcceptingSteerMessages();


### PR DESCRIPTION
## What Problem This Solves

`runEmbeddedAttempt` still owned prompt-local lock handoff, image preparation, and prompt failure recovery. These separable phases kept the attempt orchestrator large and made lifecycle ordering difficult to test directly.

## Why This Change Was Made

- Extract prompt lock handoff and prompt-local image preparation into `attempt-prompt-execution-prepare.ts`.
- Extract ordinary prompt failures, mid-turn precheck recovery, and sessions-yield recovery into `attempt-prompt-error.ts`.
- Preserve the yield-abort ordering contract by publishing terminal state before any fallible recovery await.
- Add direct helper tests, including the recovery-rejection ordering case.

## User Impact

No intended behavior change. `attempt.ts` drops from 1,378 to 1,337 lines, while prompt execution and recovery phases become independently testable.

## Evidence

- Testbox `tbx_01kxfb53hkfdds559x55rc3y6a`: 84/84 focused agent tests passed on head `c40ff63e1a382915f63caf6656e69df0e1c949c5`.
- Blacksmith run: https://github.com/openclaw/openclaw/actions/runs/29303925152
- `tsgo:core`, `tsgo:core:test`, targeted oxlint, and the TypeScript LOC ratchet passed for the unchanged patch before the final unrelated-main rebase.
- Fresh branch autoreview: no actionable findings, confidence 0.97.
