### PR TITLE
refactor(packages): remove dead internal helpers

### DIFF
--- a/packages/gateway-client/src/client.ts
+++ b/packages/gateway-client/src/client.ts
@@ -378,18 +378,6 @@ export type GatewayClientConnectionMetadata = {
   preauthHandshakeTimeoutMs?: number;
 };
 
-export const GATEWAY_CLOSE_CODE_HINTS: Readonly<Record<number, string>> = {
-  1000: "normal closure",
-  1006: "abnormal closure (no close frame)",
-  1008: "policy violation",
-  1012: "service restart",
-  1013: "try again later",
-};
-
-export function describeGatewayCloseCode(code: number): string | undefined {
-  return GATEWAY_CLOSE_CODE_HINTS[code];
-}
-
 function readConnectChallengeTimeoutOverride(
   opts: Pick<GatewayClientOptions, "connectChallengeTimeoutMs">,
 ): number | undefined {
@@ -417,7 +405,7 @@ function formatGatewayClientErrorForLog(err: unknown): string {
   return redactedUrlLikeString;
 }
 
-export function resolveGatewayClientConnectChallengeTimeoutMs(
+function resolveGatewayClientConnectChallengeTimeoutMs(
   opts: Pick<
     GatewayClientOptions,
     "connectChallengeTimeoutMs" | "env" | "preauthHandshakeTimeoutMs"

--- a/packages/gateway-client/src/client.watchdog.test.ts
+++ b/packages/gateway-client/src/client.watchdog.test.ts
@@ -3,14 +3,9 @@ import { createServer as createHttpsServer } from "node:https";
 import { createServer } from "node:net";
 import { afterEach, describe, expect, test, vi } from "vitest";
 import { WebSocket, WebSocketServer } from "ws";
-import { GatewayClient, resolveGatewayClientConnectChallengeTimeoutMs } from "./client.js";
+import { GatewayClient } from "./client.js";
 import type { GatewayProtocolSocket } from "./protocol-client.js";
-import {
-  DEFAULT_PREAUTH_HANDSHAKE_TIMEOUT_MS,
-  MAX_SAFE_TIMEOUT_DELAY_MS,
-  MAX_CONNECT_CHALLENGE_TIMEOUT_MS,
-  MIN_CONNECT_CHALLENGE_TIMEOUT_MS,
-} from "./timeouts.js";
+import { MAX_SAFE_TIMEOUT_DELAY_MS } from "./timeouts.js";
 
 async function getFreePort(): Promise<number> {
   return await new Promise((resolve, reject) => {
@@ -174,39 +169,6 @@ describe("GatewayClient", () => {
 
     await expect(receivedOrigin).resolves.toBe(`http://127.0.0.1:${port}`);
     client.stop();
-  });
-
-  test("resolves connectChallengeTimeoutMs with clamping and config fallback", () => {
-    expect(resolveGatewayClientConnectChallengeTimeoutMs({})).toBe(
-      DEFAULT_PREAUTH_HANDSHAKE_TIMEOUT_MS,
-    );
-    expect(resolveGatewayClientConnectChallengeTimeoutMs({ connectChallengeTimeoutMs: 0 })).toBe(
-      MIN_CONNECT_CHALLENGE_TIMEOUT_MS,
-    );
-    expect(
-      resolveGatewayClientConnectChallengeTimeoutMs({ connectChallengeTimeoutMs: 20_000 }),
-    ).toBe(MAX_CONNECT_CHALLENGE_TIMEOUT_MS);
-    expect(
-      resolveGatewayClientConnectChallengeTimeoutMs({
-        connectChallengeTimeoutMs: 5_000,
-      }),
-    ).toBe(5_000);
-    expect(
-      resolveGatewayClientConnectChallengeTimeoutMs({
-        preauthHandshakeTimeoutMs: 30_000,
-      }),
-    ).toBe(30_000);
-    expect(
-      resolveGatewayClientConnectChallengeTimeoutMs({
-        connectChallengeTimeoutMs: 45_000,
-        preauthHandshakeTimeoutMs: 30_000,
-      }),
-    ).toBe(30_000);
-    expect(
-      resolveGatewayClientConnectChallengeTimeoutMs({
-        env: { OPENCLAW_CONNECT_CHALLENGE_TIMEOUT_MS: "6000" },
-      }),
-    ).toBe(6_000);
   });
 
   test("returns non-sensitive connection metadata", () => {

--- a/packages/gateway-client/src/timeouts.test.ts
+++ b/packages/gateway-client/src/timeouts.test.ts
@@ -3,10 +3,9 @@ import { describe, expect, it } from "vitest";
 import {
   addSafeTimeoutDelayGraceMs,
   getConnectChallengeTimeoutMsFromEnv,
-  getPreauthHandshakeTimeoutMsFromEnv,
   MAX_SAFE_TIMEOUT_DELAY_MS,
-  resolveFiniteTimeoutDelayMs,
   resolveConnectChallengeTimeoutMs,
+  resolveFiniteTimeoutDelayMs,
   resolvePreauthHandshakeTimeoutMs,
   resolveSafeTimeoutDelayMs,
 } from "./timeouts.js";
@@ -58,8 +57,8 @@ describe("resolveFiniteTimeoutDelayMs", () => {
 describe("gateway client handshake timeouts", () => {
   it("caps preauth handshake timeout env and config values to the safe timer range", () => {
     expect(
-      getPreauthHandshakeTimeoutMsFromEnv({
-        OPENCLAW_HANDSHAKE_TIMEOUT_MS: "3000000000",
+      resolvePreauthHandshakeTimeoutMs({
+        env: { OPENCLAW_HANDSHAKE_TIMEOUT_MS: "3000000000" },
       }),
     ).toBe(MAX_SAFE_TIMEOUT_DELAY_MS);
     expect(
@@ -72,8 +71,8 @@ describe("gateway client handshake timeouts", () => {
 
   it("accepts existing strict timeout env integer forms", () => {
     expect(
-      getPreauthHandshakeTimeoutMsFromEnv({
-        OPENCLAW_HANDSHAKE_TIMEOUT_MS: " +75000 ",
+      resolvePreauthHandshakeTimeoutMs({
+        env: { OPENCLAW_HANDSHAKE_TIMEOUT_MS: " +75000 " },
       }),
     ).toBe(75_000);
     expect(

--- a/packages/gateway-client/src/timeouts.ts
+++ b/packages/gateway-client/src/timeouts.ts
@@ -111,19 +111,6 @@ export function resolveConnectChallengeTimeoutMs(
   return clampConnectChallengeTimeoutMs(configuredPreauthTimeoutMs, maxTimeoutMs);
 }
 
-/** Reads the preauth handshake timeout override from environment variables. */
-export function getPreauthHandshakeTimeoutMsFromEnv(env: NodeJS.ProcessEnv = process.env): number {
-  const configuredTimeout =
-    env.OPENCLAW_HANDSHAKE_TIMEOUT_MS || (env.VITEST && env.OPENCLAW_TEST_HANDSHAKE_TIMEOUT_MS);
-  if (configuredTimeout) {
-    const parsed = parseStrictPositiveInteger(configuredTimeout);
-    if (parsed !== undefined) {
-      return resolveSafeTimeoutDelayMs(parsed);
-    }
-  }
-  return DEFAULT_PREAUTH_HANDSHAKE_TIMEOUT_MS;
-}
-
 /** Resolves the server preauth timeout from env, explicit config, or default. */
 export function resolvePreauthHandshakeTimeoutMs(params?: {
   env?: NodeJS.ProcessEnv;

--- a/packages/model-catalog-core/src/configured-model-refs.test.ts
+++ b/packages/model-catalog-core/src/configured-model-refs.test.ts
@@ -3,7 +3,6 @@ import { describe, expect, it } from "vitest";
 import {
   collectConfiguredModelRefs,
   collectConfiguredModelRefValues,
-  extractProviderFromModelRef,
 } from "./configured-model-refs.js";
 
 describe("configured model refs", () => {
@@ -76,10 +75,5 @@ describe("configured model refs", () => {
         },
       }),
     ).toEqual([]);
-  });
-
-  it("extracts normalized providers from provider-prefixed refs", () => {
-    expect(extractProviderFromModelRef(" OpenAI/gpt-5.5 ")).toBe("openai");
-    expect(extractProviderFromModelRef("gpt-5.5")).toBeNull();
   });
 });

--- a/packages/model-catalog-core/src/configured-model-refs.ts
+++ b/packages/model-catalog-core/src/configured-model-refs.ts
@@ -1,6 +1,3 @@
-// Model Catalog Core module implements configured model refs behavior.
-import { parseModelCatalogRef } from "./model-catalog-refs.js";
-
 // Collects configured model references from OpenClaw config-shaped objects.
 
 /** Narrow unknown values to plain records. */
@@ -131,9 +128,4 @@ export function collectConfiguredModelRefValues(
   options?: { includeChannelModelOverrides?: boolean },
 ): string[] {
   return collectConfiguredModelRefs(config, options).map((ref) => ref.value);
-}
-
-/** Extract a normalized provider id from a provider/model reference. */
-export function extractProviderFromModelRef(value: string): string | null {
-  return parseModelCatalogRef(value)?.provider ?? null;
 }

--- a/packages/speech-core/voice-models.ts
+++ b/packages/speech-core/voice-models.ts
@@ -81,7 +81,7 @@ export function providerMatchesId(provider: VoiceModelProvider, providerId?: str
 }
 
 /** Find the provider metadata for a configured provider id or alias. */
-export function findVoiceModelProvider<T extends VoiceModelProvider>(params: {
+function findVoiceModelProvider<T extends VoiceModelProvider>(params: {
   providers: readonly T[];
   providerId?: string;
 }): T | undefined {

--- a/src/gateway/call.test.ts
+++ b/src/gateway/call.test.ts
@@ -151,15 +151,6 @@ function startStubGatewayClient() {
 }
 
 vi.mock("./client.js", () => ({
-  describeGatewayCloseCode: (code: number) => {
-    if (code === 1000) {
-      return "normal closure";
-    }
-    if (code === 1006) {
-      return "abnormal closure (no close frame)";
-    }
-    return undefined;
-  },
   isGatewayConnectAssemblyError: (value: unknown) => connectAssemblyErrorState.has(value),
   GatewayClient: class {
     constructor(opts: {


### PR DESCRIPTION
## What Problem This Solves

Internal workspace packages exposed several helpers that had no production consumers or existed only to support direct tests. Those exports widened package surfaces, duplicated canonical timeout/provider logic, and left a stale gateway mock behind.

## Why This Change Was Made

Delete three unused helpers and their test-only coverage, remove the stale gateway mock, and keep the two remaining package-local helpers private. Existing tests now exercise the canonical timeout resolver instead of a duplicate wrapper. There are no config, protocol, or runtime behavior changes.

## User Impact

No user-visible behavior change. Maintainers get narrower internal package APIs and fewer duplicate ownership paths.

## Evidence

- Exact-head Testbox `tbx_01kxfb747ekyq4ng0pxy79r66a`: 193 focused tests passed across unit, gateway, and gateway-client shards.
- `pnpm check:changed -- <8 touched files>` passed on commit `6677128c34f3a5806190c99ea6e98e03ea7ff6db`.
- `pnpm deadcode:exports` matched the 1,072-entry baseline.
- Full `pnpm build` passed for the patch before rebasing over two unrelated infra-only main commits; exact-head tests and changed gates were rerun after the rebase.
- Fresh full codebase-memory graph: 314,079 nodes / 1,303,171 edges. The three deleted symbols return zero exact-file matches; retained timeout and voice helpers resolve only to their intended internal callers.
- Fresh structured review: no findings; patch correct at 0.91 confidence.
- Testbox hydration run: https://github.com/openclaw/openclaw/actions/runs/29303967691

AI-assisted: yes. The change and evidence were manually verified.
