### PR TITLE
refactor: use native minimatch list matching

### DIFF
--- a/src/agents/sessions/package-manager.ts
+++ b/src/agents/sessions/package-manager.ts
@@ -541,34 +541,25 @@ function isRealPathWithinRoot(root: string, candidate: string): boolean {
   );
 }
 
-function matchesAnyPattern(filePath: string, patterns: string[], baseDir: string): boolean {
-  const rel = toPosixPath(relative(baseDir, filePath));
+function getMatchCandidates(filePath: string, baseDir: string, includeNames: boolean): string[] {
   const name = basename(filePath);
-  const filePathPosix = toPosixPath(filePath);
-  const isSkillFile = name === "SKILL.md";
-  const parentDir = isSkillFile ? dirname(filePath) : undefined;
-  const parentRel = isSkillFile ? toPosixPath(relative(baseDir, parentDir!)) : undefined;
-  const parentName = isSkillFile ? basename(parentDir!) : undefined;
-  const parentDirPosix = isSkillFile ? toPosixPath(parentDir!) : undefined;
+  const candidates = [toPosixPath(relative(baseDir, filePath)), toPosixPath(filePath)];
+  if (includeNames) {
+    candidates.push(name);
+  }
+  if (name === "SKILL.md") {
+    const parentDir = dirname(filePath);
+    candidates.push(toPosixPath(relative(baseDir, parentDir)), toPosixPath(parentDir));
+    if (includeNames) {
+      candidates.push(basename(parentDir));
+    }
+  }
+  return candidates;
+}
 
-  return patterns.some((pattern) => {
-    const normalizedPattern = toPosixPath(pattern);
-    if (
-      minimatch(rel, normalizedPattern) ||
-      minimatch(name, normalizedPattern) ||
-      minimatch(filePathPosix, normalizedPattern)
-    ) {
-      return true;
-    }
-    if (!isSkillFile) {
-      return false;
-    }
-    return (
-      minimatch(parentRel!, normalizedPattern) ||
-      minimatch(parentName!, normalizedPattern) ||
-      minimatch(parentDirPosix!, normalizedPattern)
-    );
-  });
+function matchesAnyPattern(filePath: string, patterns: string[], baseDir: string): boolean {
+  const candidates = getMatchCandidates(filePath, baseDir, true);
+  return patterns.some((pattern) => minimatch.match(candidates, toPosixPath(pattern)).length > 0);
 }
 
 function normalizeExactPattern(pattern: string): string {
@@ -578,58 +569,12 @@ function normalizeExactPattern(pattern: string): string {
 }
 
 function matchesAnyExactPattern(filePath: string, patterns: string[], baseDir: string): boolean {
-  if (patterns.length === 0) {
-    return false;
-  }
-  const rel = toPosixPath(relative(baseDir, filePath));
-  const name = basename(filePath);
-  const filePathPosix = toPosixPath(filePath);
-  const isSkillFile = name === "SKILL.md";
-  const parentDir = isSkillFile ? dirname(filePath) : undefined;
-  const parentRel = isSkillFile ? toPosixPath(relative(baseDir, parentDir!)) : undefined;
-  const parentDirPosix = isSkillFile ? toPosixPath(parentDir!) : undefined;
-
-  return patterns.some((pattern) => {
-    const normalized = normalizeExactPattern(pattern);
-    if (normalized === rel || normalized === filePathPosix) {
-      return true;
-    }
-    if (!isSkillFile) {
-      return false;
-    }
-    return normalized === parentRel || normalized === parentDirPosix;
-  });
-}
-
-function getOverridePatterns(entries: string[]): string[] {
-  return entries.filter(
-    (pattern) => pattern.startsWith("!") || pattern.startsWith("+") || pattern.startsWith("-"),
-  );
+  const candidates = new Set(getMatchCandidates(filePath, baseDir, false));
+  return patterns.some((pattern) => candidates.has(normalizeExactPattern(pattern)));
 }
 
 function isEnabledByOverrides(filePath: string, patterns: string[], baseDir: string): boolean {
-  const overrides = getOverridePatterns(patterns);
-  const excludes = overrides
-    .filter((pattern) => pattern.startsWith("!"))
-    .map((pattern) => pattern.slice(1));
-  const forceIncludes = overrides
-    .filter((pattern) => pattern.startsWith("+"))
-    .map((pattern) => pattern.slice(1));
-  const forceExcludes = overrides
-    .filter((pattern) => pattern.startsWith("-"))
-    .map((pattern) => pattern.slice(1));
-
-  let enabled = true;
-  if (excludes.length > 0 && matchesAnyPattern(filePath, excludes, baseDir)) {
-    enabled = false;
-  }
-  if (forceIncludes.length > 0 && matchesAnyExactPattern(filePath, forceIncludes, baseDir)) {
-    enabled = true;
-  }
-  if (forceExcludes.length > 0 && matchesAnyExactPattern(filePath, forceExcludes, baseDir)) {
-    enabled = false;
-  }
-  return enabled;
+  return applyPatterns([filePath], patterns.filter(isOverridePattern), baseDir).has(filePath);
 }
 
 /**


### PR DESCRIPTION
## What Problem This Solves

Resource override matching maintained separate candidate construction and override-precedence paths around minimatch. The duplicated logic made this small discovery boundary harder to verify and repeatedly parsed the same glob for each candidate path.

## Why This Change Was Made

Use minimatch's native list matcher so each glob is compiled once against a shared candidate list. Route auto-discovered resource overrides through the existing canonical pattern application path, preserving include, exclude, force-include, and force-exclude precedence.

AI-assisted: yes.

## User Impact

No user-visible behavior change. Resource discovery keeps the same matching semantics with 55 fewer source lines and one override engine.

## Evidence

- Blacksmith Testbox `tbx_01kxfayr58egbaz8acfs2krd0w`: `pnpm test src/agents/sessions/package-manager.test.ts src/agents/sessions/resource-loader.test.ts` (7 passed)
- Blacksmith Testbox: `pnpm tsgo:core`
- Blacksmith Testbox: `pnpm tsgo:core:test`
- `node scripts/run-oxlint.mjs src/agents/sessions/package-manager.ts`
- Generated parity probes: 600 candidate comparisons and 243 override combinations
- Fresh autoreview: clean, correctness confidence 0.96
