### PR TITLE
refactor(agents): extract attempt stream finalization

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt-stream-finalize.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-stream-finalize.test.ts
@@ -1,0 +1,196 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  completeAfterTurn: vi.fn(),
+  settleStream: vi.fn(),
+}));
+
+vi.mock("./attempt-after-turn.js", () => ({
+  completeEmbeddedAttemptAfterTurn: mocks.completeAfterTurn,
+}));
+vi.mock("./attempt-stream-settle.js", () => ({
+  settleEmbeddedAttemptStream: mocks.settleStream,
+}));
+
+import { finalizeEmbeddedAttemptStreamPhase } from "./attempt-stream-finalize.js";
+
+type FinalizeInput = Parameters<typeof finalizeEmbeddedAttemptStreamPhase>[0];
+type SettleMockInput = {
+  state: {
+    promptError: unknown;
+    promptErrorSource: unknown;
+  };
+};
+
+function createFixture(overrides?: Partial<FinalizeInput>) {
+  const order: string[] = [];
+  const repairedMessages = [{ role: "user", content: "repaired" }];
+  const activeSession = {
+    agent: { state: { messages: [] } },
+  };
+  const phaseState: ReturnType<FinalizeInput["getState"]> = {
+    promptError: null,
+    promptErrorSource: null,
+    yieldAborted: false,
+    sessionIdUsed: "initial-session",
+    sessionFileUsed: "initial.jsonl",
+  };
+  const input = {
+    attempt: { runId: "run-1" },
+    activeSession,
+    sessionManager: {
+      buildSessionContext: () => ({ messages: repairedMessages }),
+    },
+    sessionLockController: {
+      waitForSessionEvents: vi.fn(async () => {
+        order.push("session-events");
+      }),
+      releaseForPrompt: vi.fn(async () => {
+        order.push("release-prompt-lock");
+      }),
+    },
+    withOwnedSessionWriteLock: vi.fn(),
+    waitForPendingEvents: vi.fn(async () => {
+      order.push("pending-events");
+    }),
+    repairedRejectedThinkingReplay: true,
+    getRunAbortDeadlineAtMs: () => 123,
+    shouldFlushForContextEngine: () => true,
+    getBeforeAgentFinalizeRevisionReason: () => "revision changed",
+    getContextEngineAfterTurnCheckpoint: () => 7,
+    onSettleErrorState: vi.fn(),
+    onSettled: vi.fn(() => {
+      order.push("settled-published");
+    }),
+    getState: () => phaseState,
+    settle: {
+      subscription: {},
+      readLifecycleState: () => ({
+        aborted: false,
+        timedOut: false,
+        timedOutDuringCompaction: false,
+      }),
+      markTimedOutDuringCompaction: vi.fn(),
+      runAbortSignal: new AbortController().signal,
+      isProbeSession: false,
+      abortable: async <T>(promise: Promise<T>) => await promise,
+      prePromptMessageCount: 3,
+      toolSearchTargetTranscriptProjections: [],
+      cache: {
+        observabilityEnabled: false,
+        changesForTurn: null,
+        retention: undefined,
+      },
+    },
+    afterTurn: {
+      readLifecycleState: () => ({
+        aborted: false,
+        timedOut: false,
+        idleTimedOut: false,
+        timedOutDuringCompaction: false,
+      }),
+      runtime: {},
+    },
+    ...overrides,
+  } as unknown as FinalizeInput;
+
+  return { activeSession, input, order, phaseState, repairedMessages };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("finalizeEmbeddedAttemptStreamPhase", () => {
+  it("settles the stream before publishing state and running after-turn work", async () => {
+    const fixture = createFixture();
+    const pendingError = new Error("pending event failed");
+    fixture.input.waitForPendingEvents = vi.fn(async () => {
+      fixture.order.push("pending-events");
+      fixture.phaseState.promptError = pendingError;
+      fixture.phaseState.promptErrorSource = "prompt";
+    });
+    const settledStream = {
+      promptError: null,
+      promptErrorSource: null,
+      timedOutDuringCompaction: false,
+      compactionOccurredThisAttempt: true,
+      messagesSnapshot: [{ role: "assistant", content: [] }],
+      sessionIdUsed: "settled-session",
+      lastAssistant: undefined,
+      currentAttemptAssistant: undefined,
+      attemptUsage: undefined,
+      cacheBreak: null,
+      lastCallUsage: undefined,
+      promptCache: undefined,
+    };
+    mocks.settleStream.mockImplementation(async (input: SettleMockInput) => {
+      fixture.order.push("settle");
+      expect(input.state.promptError).toBe(pendingError);
+      expect(input.state.promptErrorSource).toBe("prompt");
+      fixture.phaseState.yieldAborted = true;
+      return settledStream;
+    });
+    mocks.completeAfterTurn.mockImplementation(async () => {
+      fixture.order.push("after-turn");
+      return { sessionIdUsed: "after-session", sessionFileUsed: "after.jsonl" };
+    });
+
+    await expect(finalizeEmbeddedAttemptStreamPhase(fixture.input)).resolves.toEqual({
+      sessionIdUsed: "after-session",
+      sessionFileUsed: "after.jsonl",
+    });
+
+    expect(fixture.activeSession.agent.state.messages).toBe(fixture.repairedMessages);
+    expect(fixture.order).toEqual([
+      "session-events",
+      "pending-events",
+      "release-prompt-lock",
+      "settle",
+      "settled-published",
+      "after-turn",
+    ]);
+    expect(mocks.settleStream).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runAbortDeadlineAtMs: 123,
+        shouldFlushForContextEngine: true,
+      }),
+    );
+    expect(fixture.input.onSettled).toHaveBeenCalledWith(settledStream);
+    expect(mocks.completeAfterTurn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        state: expect.objectContaining({
+          beforeAgentFinalizeRevisionReason: "revision changed",
+          compactionOccurredThisAttempt: true,
+          contextEngineAfterTurnCheckpoint: 7,
+          messagesSnapshot: settledStream.messagesSnapshot,
+          prePromptMessageCount: 3,
+          sessionIdUsed: "settled-session",
+          yieldAborted: true,
+        }),
+      }),
+    );
+  });
+
+  it("publishes mutated settlement error state before rethrowing", async () => {
+    const fixture = createFixture({ repairedRejectedThinkingReplay: false });
+    const settlementError = new Error("settlement failed");
+    const promptError = new Error("prompt failed");
+    mocks.settleStream.mockImplementation(async (input: SettleMockInput) => {
+      input.state.promptError = promptError;
+      input.state.promptErrorSource = "compaction";
+      throw settlementError;
+    });
+
+    await expect(finalizeEmbeddedAttemptStreamPhase(fixture.input)).rejects.toBe(settlementError);
+
+    expect(fixture.input.onSettleErrorState).toHaveBeenCalledWith(
+      expect.objectContaining({
+        promptError,
+        promptErrorSource: "compaction",
+      }),
+    );
+    expect(fixture.input.onSettled).not.toHaveBeenCalled();
+    expect(mocks.completeAfterTurn).not.toHaveBeenCalled();
+  });
+});

--- a/src/agents/embedded-agent-runner/run/attempt-stream-finalize.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-stream-finalize.ts
@@ -1,0 +1,104 @@
+/** Settles the provider stream and completes the post-turn lifecycle phase. */
+import { completeEmbeddedAttemptAfterTurn } from "./attempt-after-turn.js";
+import { settleEmbeddedAttemptStream } from "./attempt-stream-settle.js";
+
+type StreamSettleInput = Parameters<typeof settleEmbeddedAttemptStream>[0];
+type StreamSettleResult = Awaited<ReturnType<typeof settleEmbeddedAttemptStream>>;
+type AfterTurnInput = Parameters<typeof completeEmbeddedAttemptAfterTurn>[0];
+type FinalizePhaseState = StreamSettleInput["state"] & {
+  sessionFileUsed?: string;
+};
+
+type SharedPhaseInputKeys =
+  | "attempt"
+  | "activeSession"
+  | "sessionManager"
+  | "sessionLockController"
+  | "withOwnedSessionWriteLock";
+
+export async function finalizeEmbeddedAttemptStreamPhase(input: {
+  attempt: StreamSettleInput["attempt"];
+  activeSession: StreamSettleInput["activeSession"];
+  sessionManager: StreamSettleInput["sessionManager"];
+  sessionLockController: StreamSettleInput["sessionLockController"];
+  withOwnedSessionWriteLock: StreamSettleInput["withOwnedSessionWriteLock"];
+  waitForPendingEvents: () => Promise<void>;
+  repairedRejectedThinkingReplay: boolean;
+  getRunAbortDeadlineAtMs: () => number;
+  shouldFlushForContextEngine: () => boolean;
+  getBeforeAgentFinalizeRevisionReason: () => string | undefined;
+  getContextEngineAfterTurnCheckpoint: () => number | null;
+  onSettleErrorState: (state: {
+    promptError: unknown;
+    promptErrorSource: StreamSettleInput["state"]["promptErrorSource"];
+  }) => void;
+  onSettled: (result: StreamSettleResult) => void;
+  getState: () => FinalizePhaseState;
+  settle: Omit<
+    StreamSettleInput,
+    SharedPhaseInputKeys | "state" | "runAbortDeadlineAtMs" | "shouldFlushForContextEngine"
+  >;
+  afterTurn: Omit<AfterTurnInput, SharedPhaseInputKeys | "state">;
+}): Promise<{ sessionIdUsed: string; sessionFileUsed?: string }> {
+  const { activeSession, sessionManager, sessionLockController, withOwnedSessionWriteLock } = input;
+
+  await sessionLockController.waitForSessionEvents(activeSession);
+  await input.waitForPendingEvents();
+  if (input.repairedRejectedThinkingReplay) {
+    activeSession.agent.state.messages = sessionManager.buildSessionContext().messages;
+  }
+  await sessionLockController.releaseForPrompt();
+
+  const currentState = input.getState();
+  const streamSettleState = {
+    promptError: currentState.promptError,
+    promptErrorSource: currentState.promptErrorSource,
+    yieldAborted: currentState.yieldAborted,
+    sessionIdUsed: currentState.sessionIdUsed,
+  };
+  const settledStream = await settleEmbeddedAttemptStream({
+    attempt: input.attempt,
+    activeSession,
+    sessionManager,
+    sessionLockController,
+    withOwnedSessionWriteLock,
+    state: streamSettleState,
+    ...input.settle,
+    runAbortDeadlineAtMs: input.getRunAbortDeadlineAtMs(),
+    shouldFlushForContextEngine: input.shouldFlushForContextEngine(),
+  }).catch((error: unknown) => {
+    // Settlement mutates this shared state before some failures. Publish it so
+    // outer teardown keeps the recorded prompt error and attribution.
+    input.onSettleErrorState(streamSettleState);
+    throw error;
+  });
+  // Publish settled fields before after-turn hooks: those hooks may throw, and
+  // outer teardown still needs the completed stream snapshot and usage state.
+  input.onSettled(settledStream);
+
+  const afterSettleState = input.getState();
+  const beforeAgentFinalizeRevisionReason = input.getBeforeAgentFinalizeRevisionReason();
+  const afterTurn = await completeEmbeddedAttemptAfterTurn({
+    attempt: input.attempt,
+    activeSession,
+    sessionManager,
+    sessionLockController,
+    withOwnedSessionWriteLock,
+    ...input.afterTurn,
+    state: {
+      promptError: settledStream.promptError,
+      yieldAborted: afterSettleState.yieldAborted,
+      sessionIdUsed: settledStream.sessionIdUsed,
+      sessionFileUsed: afterSettleState.sessionFileUsed,
+      messagesSnapshot: settledStream.messagesSnapshot,
+      prePromptMessageCount: input.settle.prePromptMessageCount,
+      contextEngineAfterTurnCheckpoint: input.getContextEngineAfterTurnCheckpoint(),
+      lastCallUsage: settledStream.lastCallUsage,
+      promptCache: settledStream.promptCache,
+      ...(beforeAgentFinalizeRevisionReason ? { beforeAgentFinalizeRevisionReason } : {}),
+      compactionOccurredThisAttempt: settledStream.compactionOccurredThisAttempt,
+    },
+  });
+
+  return afterTurn;
+}

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -44,7 +44,6 @@ import {
   createEmbeddedAttemptRunAbort,
   type EmbeddedAttemptAbortStatePort,
 } from "./attempt-abort.js";
-import { completeEmbeddedAttemptAfterTurn } from "./attempt-after-turn.js";
 import { runEmbeddedAttemptBeforeAgentRun } from "./attempt-before-agent-run.js";
 import { prepareEmbeddedAttemptBootstrap } from "./attempt-bootstrap-prepare.js";
 import { prepareEmbeddedAttemptBundleTools } from "./attempt-bundle-tools.js";
@@ -73,8 +72,8 @@ import {
   startEmbeddedAttemptDiagnostics,
   type EmitDiagnosticRunCompleted,
 } from "./attempt-startup.js";
+import { finalizeEmbeddedAttemptStreamPhase } from "./attempt-stream-finalize.js";
 import { prepareEmbeddedAttemptStream } from "./attempt-stream-prepare.js";
-import { settleEmbeddedAttemptStream } from "./attempt-stream-settle.js";
 import { prepareEmbeddedAttemptTransport } from "./attempt-stream-transport.js";
 import { installEmbeddedAttemptStreamGuards } from "./attempt-stream.js";
 import { prepareEmbeddedAttemptSystemPrompt } from "./attempt-system-prompt-prepare.js";
@@ -733,9 +732,7 @@ export async function runEmbeddedAttempt(
       let currentAttemptAssistant: EmbeddedRunAttemptResult["currentAttemptAssistant"];
       let attemptUsage: NormalizedUsage | undefined;
       let cacheBreak: PromptCacheBreak | null = null;
-      let lastCallUsage: NormalizedUsage | undefined;
       let contextBudgetStatus: EmbeddedRunAttemptResult["contextBudgetStatus"];
-      let compactionOccurredThisAttempt = false;
       let finalPromptText: string | undefined;
       queueHandleRef.current = queueHandle;
 
@@ -1093,112 +1090,88 @@ export async function runEmbeddedAttempt(
           });
         }
 
-        await sessionLockController.waitForSessionEvents(activeSession);
-        await waitForPendingEvents();
-        if (repairedRejectedThinkingReplay) {
-          activeSession.agent.state.messages = activeSessionManager.buildSessionContext().messages;
-        }
-        await sessionLockController.releaseForPrompt();
-
-        const streamSettleState = {
-          promptError,
-          promptErrorSource,
-          yieldAborted,
-          sessionIdUsed,
-        };
-        const settledStream = await settleEmbeddedAttemptStream({
+        const afterTurn = await finalizeEmbeddedAttemptStreamPhase({
           attempt: params,
           activeSession,
           sessionManager: activeSessionManager,
           sessionLockController,
           withOwnedSessionWriteLock,
-          subscription,
-          state: streamSettleState,
-          readLifecycleState: () => ({
-            aborted,
-            timedOut,
-            timedOutDuringCompaction,
-          }),
-          markTimedOutDuringCompaction: () => {
-            timedOutDuringCompaction = true;
+          waitForPendingEvents,
+          repairedRejectedThinkingReplay,
+          getRunAbortDeadlineAtMs,
+          shouldFlushForContextEngine: () =>
+            Boolean(activeContextEngine && !getBeforeAgentFinalizeRevisionReason()),
+          getBeforeAgentFinalizeRevisionReason,
+          getContextEngineAfterTurnCheckpoint: contextGuards.getAfterTurnCheckpoint,
+          onSettleErrorState: (state) => {
+            promptError = state.promptError;
+            promptErrorSource = state.promptErrorSource;
           },
-          runAbortDeadlineAtMs: getRunAbortDeadlineAtMs(),
-          runAbortSignal: runAbortController.signal,
-          isProbeSession,
-          onBlockReplyFlush,
-          abortable,
-          prePromptMessageCount,
-          toolSearchTargetTranscriptProjections,
-          cache: {
-            observabilityEnabled: cacheObservabilityEnabled,
-            changesForTurn: promptCacheChangesForTurn,
-            retention: effectivePromptCacheRetention,
+          onSettled: (settledStream) => {
+            promptError = settledStream.promptError;
+            promptErrorSource = settledStream.promptErrorSource;
+            timedOutDuringCompaction = settledStream.timedOutDuringCompaction;
+            messagesSnapshot = settledStream.messagesSnapshot;
+            sessionIdUsed = settledStream.sessionIdUsed;
+            lastAssistant = settledStream.lastAssistant;
+            currentAttemptAssistant = settledStream.currentAttemptAssistant;
+            attemptUsage = settledStream.attemptUsage;
+            cacheBreak = settledStream.cacheBreak;
+            promptCache = settledStream.promptCache;
           },
-          shouldFlushForContextEngine: Boolean(
-            activeContextEngine && !getBeforeAgentFinalizeRevisionReason(),
-          ),
-        }).catch((err: unknown) => {
-          // Preserve the outer lifecycle flags when settlement fails after
-          // recording a timeout or prompt error.
-          promptError = streamSettleState.promptError;
-          promptErrorSource = streamSettleState.promptErrorSource;
-          throw err;
-        });
-        promptError = settledStream.promptError;
-        promptErrorSource = settledStream.promptErrorSource;
-        timedOutDuringCompaction = settledStream.timedOutDuringCompaction;
-        compactionOccurredThisAttempt = settledStream.compactionOccurredThisAttempt;
-        messagesSnapshot = settledStream.messagesSnapshot;
-        sessionIdUsed = settledStream.sessionIdUsed;
-        lastAssistant = settledStream.lastAssistant;
-        currentAttemptAssistant = settledStream.currentAttemptAssistant;
-        attemptUsage = settledStream.attemptUsage;
-        cacheBreak = settledStream.cacheBreak;
-        lastCallUsage = settledStream.lastCallUsage;
-        promptCache = settledStream.promptCache;
-
-        const beforeAgentFinalizeRevisionReason = getBeforeAgentFinalizeRevisionReason();
-        const afterTurn = await completeEmbeddedAttemptAfterTurn({
-          attempt: params,
-          activeContextEngine,
-          activeSession,
-          sessionManager: activeSessionManager,
-          sessionLockController,
-          withOwnedSessionWriteLock,
-          state: {
+          getState: () => ({
             promptError,
+            promptErrorSource,
             yieldAborted,
             sessionIdUsed,
             sessionFileUsed,
-            messagesSnapshot,
-            prePromptMessageCount,
-            contextEngineAfterTurnCheckpoint: contextGuards.getAfterTurnCheckpoint(),
-            lastCallUsage,
-            promptCache,
-            ...(beforeAgentFinalizeRevisionReason ? { beforeAgentFinalizeRevisionReason } : {}),
-            compactionOccurredThisAttempt,
-          },
-          readLifecycleState: () => ({
-            aborted,
-            timedOut,
-            idleTimedOut,
-            timedOutDuringCompaction,
           }),
-          runtime: {
-            effectiveWorkspace,
-            agentDir,
-            sessionAgentId,
-            resolveActiveContextEnginePluginId,
-            shouldRecordCompletedBootstrapTurn,
-            cacheTrace,
-            anthropicPayloadLogger,
-            hookAgentId,
-            diagnosticTrace,
-            skillWorkshopAvailable: uncompactedEffectiveTools.some(
-              (tool) => tool.name === "skill_workshop",
-            ),
-            hookRunner,
-            promptStartedAt,
+          settle: {
+            subscription,
+            readLifecycleState: () => ({
+              aborted,
+              timedOut,
+              timedOutDuringCompaction,
+            }),
+            markTimedOutDuringCompaction: () => {
+              timedOutDuringCompaction = true;
+            },
+            runAbortSignal: runAbortController.signal,
+            isProbeSession,
+            onBlockReplyFlush,
+            abortable,
+            prePromptMessageCount,
+            toolSearchTargetTranscriptProjections,
+            cache: {
+              observabilityEnabled: cacheObservabilityEnabled,
+              changesForTurn: promptCacheChangesForTurn,
+              retention: effectivePromptCacheRetention,
+            },
+          },
+          afterTurn: {
+            activeContextEngine,
+            readLifecycleState: () => ({
+              aborted,
+              timedOut,
+              idleTimedOut,
+              timedOutDuringCompaction,
+            }),
+            runtime: {
+              effectiveWorkspace,
+              agentDir,
+              sessionAgentId,
+              resolveActiveContextEnginePluginId,
+              shouldRecordCompletedBootstrapTurn,
+              cacheTrace,
+              anthropicPayloadLogger,
+              hookAgentId,
+              diagnosticTrace,
+              skillWorkshopAvailable: uncompactedEffectiveTools.some(
+                (tool) => tool.name === "skill_workshop",
+              ),
+              hookRunner,
+              promptStartedAt,
+            },
           },
         });
         sessionIdUsed = afterTurn.sessionIdUsed;


### PR DESCRIPTION
Related: #106449

## What Problem This Solves

The embedded attempt runner still owns stream settlement, rejected-thinking replay repair, prompt-lock release, and post-turn lifecycle orchestration in one large function. That makes ordering-sensitive cleanup difficult to review and change safely.

## Why This Change Was Made

Extract the complete stream-finalization phase behind one helper while keeping the existing settlement and after-turn helpers as the owners of their detailed behavior. Mutable error and yield state is sampled at the same lifecycle boundaries as before, including after pending-event drains and after settlement.

## User Impact

No user-visible behavior change. Maintainers get a smaller attempt runner and a directly tested finalization boundary.

## Evidence

- Focused Testbox proof: 125 tests passed across the new phase tests, attempt tests, and session tests.
- Full `check:changed` passed on Blacksmith Testbox `tbx_01kxfb8gqtw40ct6644ac10egh`.
- TypeScript LOC ratchet, production/test typechecks, formatting, lint, import-cycle, and database-first guards passed.
- Exact-commit autoreview reported no accepted or actionable findings.
