### PR TITLE
test(mattermost): fix slash response mock type

### DIFF
--- a/extensions/mattermost/src/mattermost/slash-state.test.ts
+++ b/extensions/mattermost/src/mattermost/slash-state.test.ts
@@ -93,7 +93,7 @@ function createResponse(): { res: ServerResponse; getBody: () => string } {
     end(chunk?: string | Buffer) {
       body = chunk ? String(chunk) : "";
     },
-  } as ServerResponse;
+  } as unknown as ServerResponse;
   return { res, getBody: () => body };
 }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes the Mattermost slash-state test fixture failing extension test-type validation because its intentionally partial HTTP response mock was asserted directly as a full Node `ServerResponse`.

## Why This Change Was Made

The test-only mock now uses the established double-assertion form for intentionally partial `ServerResponse` fixtures. Runtime code and the dead-export baseline are unchanged.

## User Impact

No user-visible impact. The extension test-type gate is restored.

## Evidence

- Testbox `tbx_01kxfbkdn4jv0n1m7tv5k4hcw2`: 6 focused slash-state tests passed; formatting, type-aware lint, and extension test types passed.
- Fresh autoreview: clean, confidence 0.99.
