### PR TITLE
chore: omit live-only tooling leaf shards

### DIFF
--- a/scripts/test-projects.test-support.mjs
+++ b/scripts/test-projects.test-support.mjs
@@ -2539,7 +2539,13 @@ function listToolingFullSuiteTestTargets(cwd) {
       fs.existsSync(root) ? listRepoFilesRecursive(root, cwd) : [],
     ),
   )
-    .filter((file) => file.endsWith(".test.ts") && classifyTarget(file, cwd) === "tooling")
+    // Explicit leaf targets bypass the config's live-test exclusion and produce an empty shard.
+    .filter(
+      (file) =>
+        file.endsWith(".test.ts") &&
+        !file.endsWith(".live.test.ts") &&
+        classifyTarget(file, cwd) === "tooling",
+    )
     .toSorted((left, right) => left.localeCompare(right));
   cachedToolingFullSuiteTestTargetsCwd = cwd;
   return cachedToolingFullSuiteTestTargets;

--- a/test/scripts/test-projects.test.ts
+++ b/test/scripts/test-projects.test.ts
@@ -4530,6 +4530,7 @@ describe("scripts/test-projects full-suite sharding", () => {
     expect(new Set(toolingTargets).size).toBe(toolingTargets.length);
     expect(toolingTargets).toContain("test/scripts/test-group-report.test.ts");
     expect(toolingTargets).toContain("src/scripts/control-ui-i18n-report.test.ts");
+    expect(toolingTargets.some((target) => target.endsWith(".live.test.ts"))).toBe(false);
     expect(toolingTargets).not.toContain("test/scripts/docker-build-helper.test.ts");
     expect(toolingTargets).not.toContain("test/scripts/openclaw-e2e-instance.test.ts");
     expect(


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the full-suite performance report failed while expanding tooling tests into leaf shards. A two-file shard contained only live image-generation tests, which the normal tooling configuration excludes, so Vitest returned an empty report.

## Why This Change Was Made

The tooling leaf inventory now omits `.live.test.ts` files before explicit chunks are created, matching the existing non-live full-suite contract. A regression assertion keeps live-only targets out of future tooling leaf plans.

## User Impact

No product behavior changes. Maintainers get a valid full-suite performance baseline without a useless empty tooling shard.

## Evidence

- Before: Blacksmith Testbox `tbx_01kxf94qk3sk4ybw7a4h93dd08` reported `tooling-12 status=1`, `253.2ms`, with an empty `testResults` array. Its explicit targets were the two image-generation `.live.test.ts` files.
- After: Blacksmith Testbox `tbx_01kxfbs52swyrfh38bb087y0e8` passed `corepack pnpm test test/scripts/test-projects.test.ts` with 194/194 tests.
- The exact rebased head passed path-scoped `check:changed` for both touched files.
- Final autoreview: clean, no accepted/actionable findings (0.98 confidence).
