### PR TITLE
refactor: privatize new internal helpers

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt-prompt-error.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-error.ts
@@ -17,7 +17,7 @@ type PromptErrorSessionLockController = Pick<
 >;
 type WithOwnedSessionWriteLock = <T>(operation: () => Promise<T> | T) => Promise<T>;
 
-export type EmbeddedAttemptPromptErrorOutcome = {
+type EmbeddedAttemptPromptErrorOutcome = {
   promptFailure?: {
     error: unknown;
     source: "prompt";

--- a/src/bootstrap/node-extra-ca-certs.test.ts
+++ b/src/bootstrap/node-extra-ca-certs.test.ts
@@ -1,10 +1,6 @@
 // Covers automatic NODE_EXTRA_CA_CERTS discovery and validation.
 import { describe, expect, it } from "vitest";
-import {
-  isNodeVersionManagerRuntime,
-  resolveAutoNodeExtraCaCerts,
-  resolveLinuxSystemCaBundle,
-} from "./node-extra-ca-certs.js";
+import { resolveAutoNodeExtraCaCerts } from "./node-extra-ca-certs.js";
 
 const DEBIAN_CA_BUNDLE_PATH = "/etc/ssl/certs/ca-certificates.crt";
 const FEDORA_CA_BUNDLE_PATH = "/etc/pki/tls/certs/ca-bundle.crt";
@@ -16,6 +12,33 @@ function allowOnly(path: string) {
       throw new Error("ENOENT");
     }
   };
+}
+
+type ResolveAutoParams = NonNullable<Parameters<typeof resolveAutoNodeExtraCaCerts>[0]>;
+
+// Exercise private detection through the public resolver without widening production exports.
+function resolveLinuxSystemCaBundle(
+  params: Pick<ResolveAutoParams, "platform" | "accessSync">,
+): string | undefined {
+  return resolveAutoNodeExtraCaCerts({
+    env: { NVM_DIR: "/home/test/.nvm" },
+    execPath: "/usr/bin/node",
+    ...params,
+  });
+}
+
+function isNodeVersionManagerRuntime(
+  env: Record<string, string | undefined>,
+  execPath: string,
+): boolean {
+  return (
+    resolveAutoNodeExtraCaCerts({
+      env,
+      platform: "linux",
+      execPath,
+      accessSync: allowOnly(DEBIAN_CA_BUNDLE_PATH),
+    }) === DEBIAN_CA_BUNDLE_PATH
+  );
 }
 
 describe("resolveLinuxSystemCaBundle", () => {

--- a/src/bootstrap/node-extra-ca-certs.ts
+++ b/src/bootstrap/node-extra-ca-certs.ts
@@ -10,7 +10,7 @@ const LINUX_CA_BUNDLE_PATHS = [
 export type EnvMap = Record<string, string | undefined>;
 type AccessSyncFn = (path: string, mode?: number) => void;
 
-export function resolveLinuxSystemCaBundle(
+function resolveLinuxSystemCaBundle(
   params: {
     platform?: NodeJS.Platform;
     accessSync?: AccessSyncFn;
@@ -54,7 +54,7 @@ const VERSION_MANAGER_PATH_MARKERS: readonly string[] = [
   "/.nvs/",
 ];
 
-export function isNodeVersionManagerRuntime(
+function isNodeVersionManagerRuntime(
   env: EnvMap = process.env as EnvMap,
   execPath: string = process.execPath,
 ): boolean {

--- a/src/daemon/service-env.test.ts
+++ b/src/daemon/service-env.test.ts
@@ -3,10 +3,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
-import {
-  isNodeVersionManagerRuntime,
-  resolveLinuxSystemCaBundle,
-} from "../bootstrap/node-extra-ca-certs.js";
+import { resolveNodeStartupTlsEnvironment } from "../bootstrap/node-startup-env.js";
 import { resolveGatewayStateDir } from "./paths.js";
 import {
   buildNodeServiceEnvironment,
@@ -925,31 +922,6 @@ describe("resolveGatewayStateDir", () => {
   });
 });
 
-describe("isNodeVersionManagerRuntime", () => {
-  it("returns true when NVM_DIR env var is set", () => {
-    expect(isNodeVersionManagerRuntime({ NVM_DIR: "/home/user/.nvm" })).toBe(true);
-  });
-
-  it("returns true when execPath contains /.nvm/", () => {
-    expect(isNodeVersionManagerRuntime({}, "/home/user/.nvm/versions/node/v22.22.0/bin/node")).toBe(
-      true,
-    );
-  });
-
-  it("returns false when neither NVM_DIR nor nvm execPath", () => {
-    expect(isNodeVersionManagerRuntime({}, "/usr/bin/node")).toBe(false);
-  });
-});
-
-describe("resolveLinuxSystemCaBundle", () => {
-  it("returns a known CA bundle path when one exists", () => {
-    const result = resolveLinuxSystemCaBundle();
-    if (process.platform === "linux") {
-      expect(result).toMatch(/\.(crt|pem)$/);
-    }
-  });
-});
-
 describe("shared Node TLS env defaults focused", () => {
   it("sets macOS TLS defaults for gateway services", () => {
     const env = buildServiceEnvironment({
@@ -971,7 +943,11 @@ describe("shared Node TLS env defaults focused", () => {
   });
 
   it("defaults NODE_EXTRA_CA_CERTS on Linux when NVM_DIR is set", () => {
-    const expected = resolveLinuxSystemCaBundle({ platform: "linux" });
+    const expected = resolveNodeStartupTlsEnvironment({
+      env: { HOME: "/home/user", NVM_DIR: "/home/user/.nvm" },
+      platform: "linux",
+      execPath: "/usr/bin/node",
+    }).NODE_EXTRA_CA_CERTS;
     const env = buildServiceEnvironment({
       env: { HOME: "/home/user", NVM_DIR: "/home/user/.nvm" },
       port: 18789,
@@ -982,7 +958,11 @@ describe("shared Node TLS env defaults focused", () => {
   });
 
   it("defaults NODE_EXTRA_CA_CERTS on Linux when execPath is under nvm", () => {
-    const expected = resolveLinuxSystemCaBundle({ platform: "linux" });
+    const expected = resolveNodeStartupTlsEnvironment({
+      env: { HOME: "/home/user" },
+      platform: "linux",
+      execPath: "/home/user/.nvm/versions/node/v22.22.0/bin/node",
+    }).NODE_EXTRA_CA_CERTS;
     const env = buildNodeServiceEnvironment({
       env: { HOME: "/home/user" },
       platform: "linux",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where main and downstream pull request CI failed the dead-export ratchet after recent agents and Node bootstrap refactors.

## Why This Change Was Made

The prompt-error outcome type and two Node CA detection helpers are implementation details, so they are now private. Their tests exercise the same behavior through the public `resolveAutoNodeExtraCaCerts` and startup-TLS surfaces instead of widening production exports for tests.

## User Impact

No runtime behavior change. Main CI and pull requests based on main can complete the dead-export gate again.

## Evidence

- Before: https://github.com/openclaw/openclaw/actions/runs/29304250568/job/86994320817 reported the three unexpected exports.
- Blacksmith Testbox `tbx_01kxfbw0m53q5fg1fzdbmbfpcj`: focused oxlint passed; 100 focused tests passed; `pnpm deadcode:exports` passed; production type lanes passed.
- Full test-type validation reached an unrelated `slash-state.test.ts` main regression, subsequently fixed by #107084.
- Fresh autoreview: clean, no accepted/actionable findings; confidence 0.97.
