### PR TITLE
test(mattermost): satisfy stricter lint checks

### DIFF
--- a/extensions/mattermost/src/mattermost/interactions.test.ts
+++ b/extensions/mattermost/src/mattermost/interactions.test.ts
@@ -44,10 +44,11 @@ function requireAction(attachments: ButtonAttachments, index = 0): ButtonAction 
 }
 
 function generateInteractionToken(context: Record<string, unknown>, accountId?: string): string {
+  const actionId = context.action_id;
   const attachments = buildButtonAttachments({
     callbackUrl: "https://gateway.example.com/mattermost/interactions/test",
     accountId,
-    buttons: [{ id: String(context.action_id ?? "test"), name: "Test", context }],
+    buttons: [{ id: typeof actionId === "string" ? actionId : "test", name: "Test", context }],
   });
   return String(requireAction(attachments).integration.context["_token"]);
 }

--- a/extensions/mattermost/src/mattermost/slash-http.test.ts
+++ b/extensions/mattermost/src/mattermost/slash-http.test.ts
@@ -175,9 +175,7 @@ async function validateMattermostSlashCommandToken(params: {
     log: params.log,
   });
   const req = createRequest({
-    body: new URLSearchParams(
-      Object.entries(params.payload).map(([key, value]) => [key, String(value)]),
-    ).toString(),
+    body: new URLSearchParams(Object.entries(params.payload)).toString(),
   });
   const response = createResponse();
   try {


### PR DESCRIPTION
## What Problem This Solves

`main` fails the extension lint lane after #107062. Two new Mattermost test helpers trigger `typescript/no-base-to-string` and `typescript/no-unnecessary-type-conversion`, blocking unrelated PRs that run the full lint gate.

## Why This Change Was Made

Keep the production refactor intact and tighten only the test helpers: accept string action IDs explicitly and pass the already-string Mattermost payload entries directly to `URLSearchParams`.

## User Impact

No runtime behavior change. Restores green lint/type gates for Mattermost tests and unblocks unrelated PRs.

## Evidence

- Blacksmith Testbox `tbx_01kxfc1rkv5gw6bdwawcymza0y`
- `corepack pnpm test extensions/mattermost/src/mattermost/slash-http.test.ts extensions/mattermost/src/mattermost/interactions.test.ts extensions/mattermost/src/mattermost/slash-state.test.ts` — 75 tests passed
- `corepack pnpm check:changed` — extension test types, format, and lint passed with 0 warnings/errors
- Fresh autoreview: no findings, patch correct (0.97)
