### PR TITLE
refactor(agents): extract session lock preparation

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt-session-lock-prepare.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-session-lock-prepare.test.ts
@@ -1,0 +1,174 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  acquireSessionFileOwner: vi.fn(),
+  acquireSessionWriteLock: vi.fn(),
+  createSessionLockController: vi.fn(),
+  resolveCompactionTimeoutMs: vi.fn(() => 30_000),
+  resolveSessionWriteLockOptions: vi.fn(() => ({
+    timeoutMs: 100,
+    staleMs: 200,
+    maxHoldMs: 300,
+  })),
+}));
+
+vi.mock("../../session-write-lock.js", () => ({
+  acquireSessionWriteLock: mocks.acquireSessionWriteLock,
+}));
+vi.mock("../compaction-safety-timeout.js", () => ({
+  resolveCompactionTimeoutMs: mocks.resolveCompactionTimeoutMs,
+}));
+vi.mock("./attempt.run-decisions.js", () => ({
+  resolveEmbeddedAttemptSessionWriteLockOptions: mocks.resolveSessionWriteLockOptions,
+}));
+vi.mock("./attempt.session-lock.js", () => ({
+  acquireEmbeddedAttemptSessionFileOwner: mocks.acquireSessionFileOwner,
+  createEmbeddedAttemptSessionLockController: mocks.createSessionLockController,
+}));
+
+import { prepareEmbeddedAttemptSessionLock } from "./attempt-session-lock-prepare.js";
+
+type PrepareInput = Parameters<typeof prepareEmbeddedAttemptSessionLock>[0];
+type CreateControllerInput = {
+  acquireSessionWriteLock: unknown;
+  initialAcquireSignal?: AbortSignal;
+  lockOptions: {
+    sessionFile: string;
+    timeoutMs: number;
+    staleMs: number;
+    maxHoldMs: number;
+  };
+  mergePromptReleasedSessionEntries: (entries: never[]) => unknown;
+  reloadPromptReleasedSessionFile: () => void;
+};
+
+function createFixture(options?: { rejectPostArmFence?: Error }) {
+  const order: string[] = [];
+  const sessionFileOwner = { release: vi.fn() };
+  const sessionManager = {
+    mergePromptReleasedSessionEntries: vi.fn(() => "merged"),
+    setSessionFile: vi.fn(),
+  };
+  const sessionLockController = {
+    canAdvanceSessionEntryCache: vi.fn(() => true),
+    dispose: vi.fn(async () => undefined),
+    publishOwnedSessionFileSnapshot: vi.fn(() => true),
+    withSessionWriteLock: vi.fn(async <T>(operation: () => Promise<T> | T) => await operation()),
+  };
+  mocks.acquireSessionFileOwner.mockImplementation(async () => {
+    order.push("file-owner");
+    return sessionFileOwner;
+  });
+  mocks.createSessionLockController.mockImplementation(async () => {
+    order.push("session-lock");
+    return sessionLockController;
+  });
+
+  let fenceCount = 0;
+  const externalAbortController = {
+    arm: vi.fn(() => {
+      order.push("arm");
+    }),
+    throwIfFiredAfterPrepCleanup: vi.fn(async () => {
+      fenceCount += 1;
+      order.push(`abort-fence-${fenceCount}`);
+      if (fenceCount === 2 && options?.rejectPostArmFence) {
+        throw options.rejectPostArmFence;
+      }
+    }),
+  };
+  let releaseSessionLock: (() => Promise<void>) | undefined;
+  const input = {
+    attempt: {
+      abortSignal: new AbortController().signal,
+      config: {},
+      sessionFile: "/tmp/session.jsonl",
+      sessionKey: "agent:main:session-1",
+    },
+    externalAbortController,
+    getSessionManager: () => sessionManager,
+    onSessionFileOwnerAcquired: vi.fn(() => {
+      order.push("publish-file-owner");
+    }),
+    onSessionLockReleaseReady: vi.fn((release) => {
+      order.push("publish-session-lock");
+      releaseSessionLock = release;
+    }),
+  } as unknown as PrepareInput;
+
+  return {
+    externalAbortController,
+    input,
+    order,
+    releaseSessionLock: () => releaseSessionLock,
+    sessionFileOwner,
+    sessionLockController,
+    sessionManager,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("prepareEmbeddedAttemptSessionLock", () => {
+  it("publishes ownership before arming and exposes owned transcript writes", async () => {
+    const fixture = createFixture();
+
+    const result = await prepareEmbeddedAttemptSessionLock(fixture.input);
+
+    expect(fixture.order).toEqual([
+      "abort-fence-1",
+      "file-owner",
+      "publish-file-owner",
+      "session-lock",
+      "publish-session-lock",
+      "arm",
+      "abort-fence-2",
+    ]);
+    expect(result.compactionTimeoutMs).toBe(30_000);
+    expect(mocks.acquireSessionFileOwner).toHaveBeenCalledWith({
+      sessionFile: "/tmp/session.jsonl",
+      timeoutMs: 300,
+      signal: fixture.input.attempt.abortSignal,
+    });
+
+    const controllerInput = mocks.createSessionLockController.mock.calls[0]?.[0] as
+      | CreateControllerInput
+      | undefined;
+    expect(controllerInput).toEqual(
+      expect.objectContaining({
+        acquireSessionWriteLock: mocks.acquireSessionWriteLock,
+        initialAcquireSignal: fixture.input.attempt.abortSignal,
+        lockOptions: {
+          sessionFile: "/tmp/session.jsonl",
+          timeoutMs: 100,
+          staleMs: 200,
+          maxHoldMs: 300,
+        },
+      }),
+    );
+    expect(controllerInput?.mergePromptReleasedSessionEntries([])).toBe("merged");
+    expect(fixture.sessionManager.mergePromptReleasedSessionEntries).toHaveBeenCalledWith([], {
+      persistLeaf: true,
+    });
+    controllerInput?.reloadPromptReleasedSessionFile();
+    expect(fixture.sessionManager.setSessionFile).toHaveBeenCalledWith("/tmp/session.jsonl");
+
+    await expect(result.withOwnedSessionWriteLock(async () => "done")).resolves.toBe("done");
+    expect(fixture.sessionLockController.withSessionWriteLock).toHaveBeenCalledOnce();
+    await fixture.releaseSessionLock()?.();
+    expect(fixture.sessionLockController.dispose).toHaveBeenCalledOnce();
+  });
+
+  it("publishes both cleanup handles before a post-arm abort fence fails", async () => {
+    const abortError = new Error("aborted during lock acquisition");
+    const fixture = createFixture({ rejectPostArmFence: abortError });
+
+    await expect(prepareEmbeddedAttemptSessionLock(fixture.input)).rejects.toBe(abortError);
+
+    expect(fixture.input.onSessionFileOwnerAcquired).toHaveBeenCalledWith(fixture.sessionFileOwner);
+    expect(fixture.input.onSessionLockReleaseReady).toHaveBeenCalledOnce();
+    expect(fixture.externalAbortController.arm).toHaveBeenCalledOnce();
+  });
+});

--- a/src/agents/embedded-agent-runner/run/attempt-session-lock-prepare.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-session-lock-prepare.ts
@@ -1,0 +1,102 @@
+/** Acquires and publishes the session-write ownership used by one attempt. */
+import { withOwnedSessionTranscriptWrites } from "../../../config/sessions/transcript-write-context.js";
+import type { guardSessionManager } from "../../session-tool-result-guard-wrapper.js";
+import { acquireSessionWriteLock } from "../../session-write-lock.js";
+import { resolveCompactionTimeoutMs } from "../compaction-safety-timeout.js";
+import { resolveEmbeddedAttemptSessionWriteLockOptions } from "./attempt.run-decisions.js";
+import {
+  acquireEmbeddedAttemptSessionFileOwner,
+  type EmbeddedAttemptSessionFileOwner,
+  createEmbeddedAttemptSessionLockController,
+} from "./attempt.session-lock.js";
+import type { EmbeddedRunAttemptParams } from "./types.js";
+
+type AttemptSessionLockController = Awaited<
+  ReturnType<typeof createEmbeddedAttemptSessionLockController>
+>;
+type OwnedTranscriptWriteContext = Parameters<typeof withOwnedSessionTranscriptWrites>[0];
+type WithOwnedSessionWriteLock = <T>(operation: () => Promise<T> | T) => Promise<T>;
+
+export async function prepareEmbeddedAttemptSessionLock(input: {
+  attempt: Pick<EmbeddedRunAttemptParams, "abortSignal" | "config" | "sessionFile" | "sessionKey">;
+  externalAbortController: {
+    arm: () => void;
+    throwIfFiredAfterPrepCleanup: () => Promise<void>;
+  };
+  getSessionManager: () => ReturnType<typeof guardSessionManager> | undefined;
+  onSessionFileOwnerAcquired: (owner: EmbeddedAttemptSessionFileOwner) => void;
+  onSessionLockReleaseReady: (release: () => Promise<void>) => void;
+}): Promise<{
+  compactionTimeoutMs: number;
+  ownedTranscriptWriteContext: OwnedTranscriptWriteContext;
+  sessionLockController: AttemptSessionLockController;
+  withOwnedSessionWriteLock: WithOwnedSessionWriteLock;
+}> {
+  const { attempt, externalAbortController } = input;
+  const compactionTimeoutMs = resolveCompactionTimeoutMs(attempt.config);
+  const sessionWriteLockOptions = resolveEmbeddedAttemptSessionWriteLockOptions({
+    config: attempt.config,
+    compactionTimeoutMs,
+  });
+
+  await externalAbortController.throwIfFiredAfterPrepCleanup();
+  const sessionFileOwner = await acquireEmbeddedAttemptSessionFileOwner({
+    sessionFile: attempt.sessionFile,
+    timeoutMs: sessionWriteLockOptions.maxHoldMs,
+    signal: attempt.abortSignal,
+  });
+  // Publish ownership immediately so outer teardown can release it if later
+  // controller setup or the post-arm abort fence fails.
+  input.onSessionFileOwnerAcquired(sessionFileOwner);
+
+  const getSessionManager = (operation: "entry merge" | "file reload") => {
+    const sessionManager = input.getSessionManager();
+    if (!sessionManager) {
+      throw new Error(`session manager unavailable during prompt-released ${operation}`);
+    }
+    return sessionManager;
+  };
+  const sessionLockController = await createEmbeddedAttemptSessionLockController({
+    acquireSessionWriteLock,
+    initialAcquireSignal: attempt.abortSignal,
+    lockOptions: {
+      sessionFile: attempt.sessionFile,
+      ...sessionWriteLockOptions,
+    },
+    mergePromptReleasedSessionEntries: (entries) =>
+      getSessionManager("entry merge").mergePromptReleasedSessionEntries(entries, {
+        persistLeaf: true,
+      }),
+    reloadPromptReleasedSessionFile: () => {
+      getSessionManager("file reload").setSessionFile(attempt.sessionFile);
+    },
+  });
+  input.onSessionLockReleaseReady(() => sessionLockController.dispose());
+
+  const ownedTranscriptWriteContext: OwnedTranscriptWriteContext = {
+    sessionFile: attempt.sessionFile,
+    sessionKey: attempt.sessionKey,
+    canAdvanceSessionEntryCache: (snapshot) =>
+      sessionLockController.canAdvanceSessionEntryCache(snapshot),
+    publishSessionFileSnapshot: (snapshot) =>
+      sessionLockController.publishOwnedSessionFileSnapshot(snapshot),
+    withSessionWriteLock: (operation, options) =>
+      sessionLockController.withSessionWriteLock(operation, options),
+  };
+  const withOwnedSessionWriteLock: WithOwnedSessionWriteLock = (operation) =>
+    withOwnedSessionTranscriptWrites(ownedTranscriptWriteContext, async () =>
+      sessionLockController.withSessionWriteLock(operation),
+    );
+
+  externalAbortController.arm();
+  // The signal can fire while the eager lock is acquired. Recheck after arming
+  // so a stopped run never reaches session creation or provider prompt.
+  await externalAbortController.throwIfFiredAfterPrepCleanup();
+
+  return {
+    compactionTimeoutMs,
+    ownedTranscriptWriteContext,
+    sessionLockController,
+    withOwnedSessionWriteLock,
+  };
+}

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -3,8 +3,6 @@
  */
 import {
   bindOwnedSessionTranscriptWrites,
-  type OwnedSessionTranscriptCacheSnapshot,
-  type OwnedSessionTranscriptWriteOptions,
   withOwnedSessionTranscriptWrites,
 } from "../../../config/sessions/transcript-write-context.js";
 import {
@@ -21,7 +19,6 @@ import { createAnthropicPayloadLogger } from "../../anthropic-payload-log.js";
 import { createCacheTrace } from "../../cache-trace.js";
 import type { AgentMessage } from "../../runtime/index.js";
 import type { guardSessionManager } from "../../session-tool-result-guard-wrapper.js";
-import { acquireSessionWriteLock } from "../../session-write-lock.js";
 import type { AgentSession } from "../../sessions/index.js";
 import { releasePendingAgentSteeringItems } from "../../subagent-registry.js";
 import {
@@ -30,7 +27,6 @@ import {
   type ToolSearchCatalogToolExecutor,
 } from "../../tool-search.js";
 import type { NormalizedUsage } from "../../usage.js";
-import { resolveCompactionTimeoutMs } from "../compaction-safety-timeout.js";
 import { prepareGooglePromptCacheStreamFn } from "../google-prompt-cache.js";
 import { log } from "../logger.js";
 import type { PromptCacheBreak, PromptCacheChange } from "../prompt-cache-observability.js";
@@ -62,6 +58,7 @@ import { submitEmbeddedAttemptPrompt } from "./attempt-prompt-submit.js";
 import { completeEmbeddedAttemptResult } from "./attempt-result.js";
 import { prepareEmbeddedAttemptSessionBoundary } from "./attempt-session-boundary.js";
 import { cleanupEmbeddedAttemptSessionPhase } from "./attempt-session-cleanup.js";
+import { prepareEmbeddedAttemptSessionLock } from "./attempt-session-lock-prepare.js";
 import { prepareEmbeddedAttemptSessionManager } from "./attempt-session-manager-prepare.js";
 import { createEmbeddedAttemptSessionSettleTracker } from "./attempt-session-settle.js";
 import { prepareEmbeddedAttemptAgentSession } from "./attempt-session.js";
@@ -82,12 +79,7 @@ import { prepareEmbeddedAttemptToolBase } from "./attempt-tool-base-prepare.js";
 import { prepareEmbeddedAttemptToolCatalog } from "./attempt-tool-catalog.js";
 import { prepareEmbeddedAttemptTrajectory } from "./attempt-trajectory.js";
 import { removeTrailingMidTurnPrecheckAssistantError } from "./attempt-transcript-helpers.js";
-import { resolveEmbeddedAttemptSessionWriteLockOptions } from "./attempt.run-decisions.js";
-import {
-  acquireEmbeddedAttemptSessionFileOwner,
-  type EmbeddedAttemptSessionFileOwner,
-  createEmbeddedAttemptSessionLockController,
-} from "./attempt.session-lock.js";
+import type { EmbeddedAttemptSessionFileOwner } from "./attempt.session-lock.js";
 import {
   queueSessionsYieldInterruptMessage,
   SESSIONS_YIELD_ABORT_REASON,
@@ -358,59 +350,23 @@ export async function runEmbeddedAttempt(
     const { runtimeChannel, runtimeInfo, systemPromptReport } = preparedSystemPrompt;
     let systemPromptText = preparedSystemPrompt.systemPromptText;
 
-    const compactionTimeoutMs = resolveCompactionTimeoutMs(params.config);
-    const sessionWriteLockOptions = resolveEmbeddedAttemptSessionWriteLockOptions({
-      config: params.config,
-      compactionTimeoutMs,
-    });
-    await externalAbortController.throwIfFiredAfterPrepCleanup();
-    retainedSessionFileOwner = await acquireEmbeddedAttemptSessionFileOwner({
-      sessionFile: params.sessionFile,
-      timeoutMs: sessionWriteLockOptions.maxHoldMs,
-      signal: params.abortSignal,
-    });
     let sessionManager: ReturnType<typeof guardSessionManager> | undefined;
-    const sessionLockController = await createEmbeddedAttemptSessionLockController({
-      acquireSessionWriteLock,
-      initialAcquireSignal: params.abortSignal,
-      lockOptions: {
-        sessionFile: params.sessionFile,
-        ...sessionWriteLockOptions,
+    const {
+      compactionTimeoutMs,
+      ownedTranscriptWriteContext,
+      sessionLockController,
+      withOwnedSessionWriteLock,
+    } = await prepareEmbeddedAttemptSessionLock({
+      attempt: params,
+      externalAbortController,
+      getSessionManager: () => sessionManager,
+      onSessionFileOwnerAcquired: (owner) => {
+        retainedSessionFileOwner = owner;
       },
-      mergePromptReleasedSessionEntries: (entries) => {
-        if (!sessionManager) {
-          throw new Error("session manager unavailable during prompt-released entry merge");
-        }
-        return sessionManager.mergePromptReleasedSessionEntries(entries, { persistLeaf: true });
-      },
-      reloadPromptReleasedSessionFile: () => {
-        if (!sessionManager) {
-          throw new Error("session manager unavailable during prompt-released file reload");
-        }
-        sessionManager.setSessionFile(params.sessionFile);
+      onSessionLockReleaseReady: (release) => {
+        releaseRetainedSessionLock = release;
       },
     });
-    releaseRetainedSessionLock = () => sessionLockController.dispose();
-    const ownedTranscriptWriteContext = {
-      sessionFile: params.sessionFile,
-      sessionKey: params.sessionKey,
-      canAdvanceSessionEntryCache: (snapshot: OwnedSessionTranscriptCacheSnapshot) =>
-        sessionLockController.canAdvanceSessionEntryCache(snapshot),
-      publishSessionFileSnapshot: (snapshot: OwnedSessionTranscriptCacheSnapshot) =>
-        sessionLockController.publishOwnedSessionFileSnapshot(snapshot),
-      withSessionWriteLock: <T>(
-        operation: () => Promise<T> | T,
-        options?: OwnedSessionTranscriptWriteOptions<T>,
-      ) => sessionLockController.withSessionWriteLock(operation, options),
-    };
-    const withOwnedSessionWriteLock = <T>(operation: () => Promise<T> | T): Promise<T> =>
-      withOwnedSessionTranscriptWrites(ownedTranscriptWriteContext, async () =>
-        sessionLockController.withSessionWriteLock(operation),
-      );
-    externalAbortController.arm();
-    // The signal can fire while the eager session lock is being acquired.
-    // Recheck after arming so a stopped run never reaches session creation or provider prompt.
-    await externalAbortController.throwIfFiredAfterPrepCleanup();
 
     let session: AgentSession | undefined;
     let removeToolResultContextGuard: (() => void) | undefined;


### PR DESCRIPTION
Related: #106449

## What Problem This Solves

The embedded attempt runner still owned session-file ownership, eager write-lock acquisition, transcript-write binding, and abort fencing inline. Those ordering-sensitive setup responsibilities made the lifecycle orchestrator larger and harder to test directly.

## Why This Change Was Made

Extract one typed session-lock preparation phase. The helper preserves the existing acquire and abort-fence order, and publishes both cleanup handles before any later setup step can fail so outer teardown retains ownership.

## User Impact

No user-visible behavior change. Maintainers get a smaller attempt runner and focused proof for its session-lock setup invariant.

## Evidence

- `attempt.ts` reduced from 1,310 to 1,266 lines.
- Focused Blacksmith Testbox proof: 225 tests passed across session-lock preparation, session-lock behavior, attempt, and session tests.
- Full `check:changed` passed on Testbox `tbx_01kxfc2rpwkrshyb41mg36ts9n`.
- Exact-commit autoreview reported no accepted or actionable findings.
