### PR TITLE
refactor(core): privatize new internal helpers

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt-prompt-error.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-error.ts
@@ -17,7 +17,7 @@ type PromptErrorSessionLockController = Pick<
 >;
 type WithOwnedSessionWriteLock = <T>(operation: () => Promise<T> | T) => Promise<T>;
 
-export type EmbeddedAttemptPromptErrorOutcome = {
+type EmbeddedAttemptPromptErrorOutcome = {
   promptFailure?: {
     error: unknown;
     source: "prompt";

--- a/src/bootstrap/node-extra-ca-certs.test.ts
+++ b/src/bootstrap/node-extra-ca-certs.test.ts
@@ -1,14 +1,23 @@
 // Covers automatic NODE_EXTRA_CA_CERTS discovery and validation.
 import { describe, expect, it } from "vitest";
-import {
-  isNodeVersionManagerRuntime,
-  resolveAutoNodeExtraCaCerts,
-  resolveLinuxSystemCaBundle,
-} from "./node-extra-ca-certs.js";
+import { resolveAutoNodeExtraCaCerts } from "./node-extra-ca-certs.js";
 
 const DEBIAN_CA_BUNDLE_PATH = "/etc/ssl/certs/ca-certificates.crt";
 const FEDORA_CA_BUNDLE_PATH = "/etc/pki/tls/certs/ca-bundle.crt";
 const GENERIC_CA_BUNDLE_PATH = "/etc/ssl/ca-bundle.pem";
+const VERSION_MANAGER_EXEC_PATHS = [
+  ["nvm", "/home/test/.nvm/versions/node/v22/bin/node"],
+  ["fnm", "/home/test/.fnm/node-versions/v22/installation/bin/node"],
+  ["fnm XDG data", "/home/test/.local/share/fnm/node-versions/v22/installation/bin/node"],
+  ["nvs dotted home", "/home/test/.nvs/node/22.14.0/x64/bin/node"],
+  ["volta", "/home/test/.volta/tools/image/node/22.14.0/bin/node"],
+  ["asdf", "/home/test/.asdf/installs/nodejs/22.14.0/bin/node"],
+  ["mise", "/home/test/.local/share/mise/installs/node/22.14.0/bin/node"],
+  ["n", "/home/test/.n/bin/node"],
+  ["nodenv", "/home/test/.nodenv/versions/22.14.0/bin/node"],
+  ["nodebrew", "/home/test/.nodebrew/node/v22.14.0/bin/node"],
+  ["nvs", "/home/test/nvs/node/22.14.0/x64/bin/node"],
+] as const;
 
 function allowOnly(path: string) {
   return (candidate: string) => {
@@ -18,10 +27,11 @@ function allowOnly(path: string) {
   };
 }
 
-describe("resolveLinuxSystemCaBundle", () => {
+describe("resolveAutoNodeExtraCaCerts", () => {
   it("returns undefined on non-linux platforms", () => {
     expect(
-      resolveLinuxSystemCaBundle({
+      resolveAutoNodeExtraCaCerts({
+        env: { NVM_DIR: "/home/test/.nvm" },
         platform: "darwin",
         accessSync: allowOnly(DEBIAN_CA_BUNDLE_PATH),
       }),
@@ -30,91 +40,26 @@ describe("resolveLinuxSystemCaBundle", () => {
 
   it("returns the first readable Linux CA bundle", () => {
     expect(
-      resolveLinuxSystemCaBundle({
+      resolveAutoNodeExtraCaCerts({
+        env: { NVM_DIR: "/home/test/.nvm" },
         platform: "linux",
+        execPath: "/usr/bin/node",
         accessSync: allowOnly(FEDORA_CA_BUNDLE_PATH),
       }),
     ).toBe(FEDORA_CA_BUNDLE_PATH);
   });
-});
 
-describe("isNodeVersionManagerRuntime", () => {
-  it("detects nvm via NVM_DIR", () => {
-    expect(isNodeVersionManagerRuntime({ NVM_DIR: "/home/test/.nvm" }, "/usr/bin/node")).toBe(true);
-  });
-
-  it("detects nvm via execPath", () => {
-    expect(isNodeVersionManagerRuntime({}, "/home/test/.nvm/versions/node/v22/bin/node")).toBe(
-      true,
-    );
-  });
-
-  it("returns false for non-nvm node paths", () => {
-    expect(isNodeVersionManagerRuntime({}, "/usr/bin/node")).toBe(false);
-  });
-
-  it("detects fnm via execPath", () => {
+  it.each(VERSION_MANAGER_EXEC_PATHS)("detects %s via execPath", (_manager, execPath) => {
     expect(
-      isNodeVersionManagerRuntime({}, "/home/test/.fnm/node-versions/v22/installation/bin/node"),
-    ).toBe(true);
+      resolveAutoNodeExtraCaCerts({
+        env: {},
+        platform: "linux",
+        execPath,
+        accessSync: allowOnly(GENERIC_CA_BUNDLE_PATH),
+      }),
+    ).toBe(GENERIC_CA_BUNDLE_PATH);
   });
 
-  it("detects fnm via XDG data path", () => {
-    expect(
-      isNodeVersionManagerRuntime(
-        {},
-        "/home/test/.local/share/fnm/node-versions/v22/installation/bin/node",
-      ),
-    ).toBe(true);
-  });
-
-  it("detects nvs via dotted home path", () => {
-    expect(isNodeVersionManagerRuntime({}, "/home/test/.nvs/node/22.14.0/x64/bin/node")).toBe(true);
-  });
-
-  it("detects volta via execPath", () => {
-    expect(
-      isNodeVersionManagerRuntime({}, "/home/test/.volta/tools/image/node/22.14.0/bin/node"),
-    ).toBe(true);
-  });
-
-  it("detects asdf via execPath", () => {
-    expect(
-      isNodeVersionManagerRuntime({}, "/home/test/.asdf/installs/nodejs/22.14.0/bin/node"),
-    ).toBe(true);
-  });
-
-  it("detects mise via execPath", () => {
-    expect(
-      isNodeVersionManagerRuntime(
-        {},
-        "/home/test/.local/share/mise/installs/node/22.14.0/bin/node",
-      ),
-    ).toBe(true);
-  });
-
-  it("detects n via execPath", () => {
-    expect(isNodeVersionManagerRuntime({}, "/home/test/.n/bin/node")).toBe(true);
-  });
-
-  it("detects nodenv via execPath", () => {
-    expect(isNodeVersionManagerRuntime({}, "/home/test/.nodenv/versions/22.14.0/bin/node")).toBe(
-      true,
-    );
-  });
-
-  it("detects nodebrew via execPath", () => {
-    expect(isNodeVersionManagerRuntime({}, "/home/test/.nodebrew/node/v22.14.0/bin/node")).toBe(
-      true,
-    );
-  });
-
-  it("detects nvs via execPath", () => {
-    expect(isNodeVersionManagerRuntime({}, "/home/test/nvs/node/22.14.0/x64/bin/node")).toBe(true);
-  });
-});
-
-describe("resolveAutoNodeExtraCaCerts", () => {
   it("returns undefined when NODE_EXTRA_CA_CERTS is already set", () => {
     expect(
       resolveAutoNodeExtraCaCerts({

--- a/src/bootstrap/node-extra-ca-certs.ts
+++ b/src/bootstrap/node-extra-ca-certs.ts
@@ -10,7 +10,7 @@ const LINUX_CA_BUNDLE_PATHS = [
 export type EnvMap = Record<string, string | undefined>;
 type AccessSyncFn = (path: string, mode?: number) => void;
 
-export function resolveLinuxSystemCaBundle(
+function resolveLinuxSystemCaBundle(
   params: {
     platform?: NodeJS.Platform;
     accessSync?: AccessSyncFn;
@@ -54,7 +54,7 @@ const VERSION_MANAGER_PATH_MARKERS: readonly string[] = [
   "/.nvs/",
 ];
 
-export function isNodeVersionManagerRuntime(
+function isNodeVersionManagerRuntime(
   env: EnvMap = process.env as EnvMap,
   execPath: string = process.execPath,
 ): boolean {

--- a/src/daemon/service-env.test.ts
+++ b/src/daemon/service-env.test.ts
@@ -3,10 +3,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
-import {
-  isNodeVersionManagerRuntime,
-  resolveLinuxSystemCaBundle,
-} from "../bootstrap/node-extra-ca-certs.js";
+import { resolveAutoNodeExtraCaCerts } from "../bootstrap/node-extra-ca-certs.js";
 import { resolveGatewayStateDir } from "./paths.js";
 import {
   buildNodeServiceEnvironment,
@@ -925,31 +922,6 @@ describe("resolveGatewayStateDir", () => {
   });
 });
 
-describe("isNodeVersionManagerRuntime", () => {
-  it("returns true when NVM_DIR env var is set", () => {
-    expect(isNodeVersionManagerRuntime({ NVM_DIR: "/home/user/.nvm" })).toBe(true);
-  });
-
-  it("returns true when execPath contains /.nvm/", () => {
-    expect(isNodeVersionManagerRuntime({}, "/home/user/.nvm/versions/node/v22.22.0/bin/node")).toBe(
-      true,
-    );
-  });
-
-  it("returns false when neither NVM_DIR nor nvm execPath", () => {
-    expect(isNodeVersionManagerRuntime({}, "/usr/bin/node")).toBe(false);
-  });
-});
-
-describe("resolveLinuxSystemCaBundle", () => {
-  it("returns a known CA bundle path when one exists", () => {
-    const result = resolveLinuxSystemCaBundle();
-    if (process.platform === "linux") {
-      expect(result).toMatch(/\.(crt|pem)$/);
-    }
-  });
-});
-
 describe("shared Node TLS env defaults focused", () => {
   it("sets macOS TLS defaults for gateway services", () => {
     const env = buildServiceEnvironment({
@@ -971,9 +943,14 @@ describe("shared Node TLS env defaults focused", () => {
   });
 
   it("defaults NODE_EXTRA_CA_CERTS on Linux when NVM_DIR is set", () => {
-    const expected = resolveLinuxSystemCaBundle({ platform: "linux" });
+    const sourceEnv = { HOME: "/home/user", NVM_DIR: "/home/user/.nvm" };
+    const expected = resolveAutoNodeExtraCaCerts({
+      env: sourceEnv,
+      platform: "linux",
+      execPath: "/usr/bin/node",
+    });
     const env = buildServiceEnvironment({
-      env: { HOME: "/home/user", NVM_DIR: "/home/user/.nvm" },
+      env: sourceEnv,
       port: 18789,
       platform: "linux",
       execPath: "/usr/bin/node",
@@ -982,11 +959,17 @@ describe("shared Node TLS env defaults focused", () => {
   });
 
   it("defaults NODE_EXTRA_CA_CERTS on Linux when execPath is under nvm", () => {
-    const expected = resolveLinuxSystemCaBundle({ platform: "linux" });
-    const env = buildNodeServiceEnvironment({
-      env: { HOME: "/home/user" },
+    const sourceEnv = { HOME: "/home/user" };
+    const execPath = "/home/user/.nvm/versions/node/v22.22.0/bin/node";
+    const expected = resolveAutoNodeExtraCaCerts({
+      env: sourceEnv,
       platform: "linux",
-      execPath: "/home/user/.nvm/versions/node/v22.22.0/bin/node",
+      execPath,
+    });
+    const env = buildNodeServiceEnvironment({
+      env: sourceEnv,
+      platform: "linux",
+      execPath,
     });
     expect(env.NODE_EXTRA_CA_CERTS).toBe(expected);
   });


### PR DESCRIPTION
Related: #107075

## What Problem This Solves

The exact-main dead-export gate became red after recent prompt-lifecycle and daemon cleanup changes exposed three helpers that have no external runtime consumers. Two bootstrap internals were then imported directly by tests, widening the production module surface for test convenience.

## Why This Change Was Made

Make the prompt error outcome type and both CA-detection helpers module-private. Preserve the CA behavior coverage through the production `resolveAutoNodeExtraCaCerts` API, including all supported version-manager paths, and keep daemon tests on the public bootstrap boundary.

## User Impact

No user-visible behavior change. The dead-export gate returns to green and the bootstrap/agent modules expose only their intended owner APIs.

## Evidence

- Testbox: 103 focused tests passed across agent, bootstrap, and daemon shards.
- Exact-head `pnpm check:changed -- <4 touched files>` passed on fresh Testbox `tbx_01kxfc777z8w3pd203ve6hmg8q`.
- `pnpm deadcode:exports` matched the current 1,054-entry baseline after the three exports were privatized.
- Fresh full codebase-memory graph: 314,125 nodes / 1,304,461 edges; the CA helpers retain one runtime caller through `resolveAutoNodeExtraCaCerts`, and the prompt outcome type has zero graph degree.
- Fresh `gpt-5.6-sol` medium autoreview: no findings; patch correct at 0.92 confidence.
- Testbox hydration run: https://github.com/openclaw/openclaw/actions/runs/29304661476

AI-assisted: yes. The change and evidence were manually verified.
