### PR TITLE
refactor(agents): privatize prompt error outcome

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt-prompt-error.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-error.ts
@@ -17,7 +17,7 @@ type PromptErrorSessionLockController = Pick<
 >;
 type WithOwnedSessionWriteLock = <T>(operation: () => Promise<T> | T) => Promise<T>;
 
-export type EmbeddedAttemptPromptErrorOutcome = {
+type EmbeddedAttemptPromptErrorOutcome = {
   promptFailure?: {
     error: unknown;
     source: "prompt";


### PR DESCRIPTION
## What Problem This Solves

Production Knip reports `EmbeddedAttemptPromptErrorOutcome` as a new unused export, which would force the shrink-only dead-export baseline to grow.

## Why This Change Was Made

The type only describes the return value of `handleEmbeddedAttemptPromptError` in its owner module. Removing the export preserves runtime and type behavior while keeping the internal surface private.

## User Impact

None. Internal type-surface cleanup only.

## Evidence

- Focused prompt-error tests: 4 passed.
- Core tsgo types: passed.
- Production dead-export regeneration: the agents finding disappeared; only the separately owned bootstrap drift remained.
- Fresh autoreview: clean, 0.98.
