### PR TITLE
fix(ui): lock the app root scroll in every host, not just standalone PWAs

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -87,9 +87,11 @@
 
       .mount-fallback {
         box-sizing: border-box;
-        height: 100vh;
         /* The app stylesheet clips the root scrollers, so this pre-app error
-           surface must own its scrolling on short windows. */
+           surface must own its scrolling on short windows. dvh keeps the
+           scroll range inside the visible mobile viewport; vh is the fallback. */
+        height: 100vh;
+        height: 100dvh;
         overflow-y: auto;
         padding: 24px;
         place-items: center;

--- a/ui/index.html
+++ b/ui/index.html
@@ -87,9 +87,13 @@
 
       .mount-fallback {
         box-sizing: border-box;
-        min-height: 100vh;
+        height: 100vh;
+        /* The app stylesheet clips the root scrollers, so this pre-app error
+           surface must own its scrolling on short windows. */
+        overflow-y: auto;
         padding: 24px;
         place-items: center;
+        place-items: safe center;
       }
 
       .mount-fallback:not([hidden]) {

--- a/ui/src/e2e/native-nav-sidebar-toggle.e2e.test.ts
+++ b/ui/src/e2e/native-nav-sidebar-toggle.e2e.test.ts
@@ -255,6 +255,31 @@ describeControlUiE2e("Control UI native-nav sidebar toggle E2E", () => {
     await expect.poll(() => toolbar.getByRole("button", { name: "New session" }).count()).toBe(0);
   });
 
+  it("keeps the document root scroll-locked in the Settings takeover", async () => {
+    const page = await openPage({ webChrome: true });
+    const response = await page.goto(`${server.baseUrl}settings/general`);
+    expect(response?.status()).toBe(200);
+    await page.locator(".settings-sidebar").waitFor({ state: "visible" });
+
+    // WKWebView scrolls the document whenever it overflows, dragging the
+    // settings sidebar and content along. Force overflow the way stray
+    // content would, then confirm the root refuses to move.
+    const metrics = await page.evaluate(() => {
+      const spacer = document.createElement("div");
+      spacer.style.height = "3000px";
+      document.body.append(spacer);
+      window.scrollTo(0, 500);
+      document.documentElement.scrollTop = 500;
+      document.body.scrollTop = 500;
+      return {
+        bodyScrollTop: document.body.scrollTop,
+        htmlScrollTop: document.documentElement.scrollTop,
+        rootScrollY: window.scrollY,
+      };
+    });
+    expect(metrics).toEqual({ bodyScrollTop: 0, htmlScrollTop: 0, rootScrollY: 0 });
+  });
+
   it("keeps the drawer hamburger at narrow widths in plain browsers", async () => {
     const page = await openPage({ nativeNav: false, width: 900 });
     await expect.poll(() => page.locator(".topbar-nav-toggle").isVisible()).toBe(true);

--- a/ui/src/styles/base.css
+++ b/ui/src/styles/base.css
@@ -509,9 +509,12 @@
 html,
 body {
   height: 100%;
-  /* App shell: inner panes scroll, the root never should. Without this the
-     macOS WKWebView (Mac app) and Safari rubber-band the whole window, even
-     when nothing overflows. */
+  /* App shell: inner panes scroll, the root never does — in every host
+     (browser tab, PWA, Mac app WKWebView). WKWebView drag/rubber-band scrolls
+     the document even when nothing overflows, dragging the whole shell with
+     it; `clip` also blocks programmatic root scrolls (focus/scrollIntoView)
+     that `hidden` would let strand the shell off-screen. */
+  overflow: clip;
   overscroll-behavior: none;
   /* iOS WKWebView font boosting inflates rendered text without re-running
      layout, so labels spill out of fixed-size chrome (welcome chips, badges).
@@ -573,17 +576,10 @@ openclaw-app {
   display: block;
   position: relative;
   z-index: 1;
-  min-height: 100vh;
+  height: 100%;
 }
 
 @media (display-mode: standalone) {
-  html,
-  body {
-    width: 100%;
-    height: 100%;
-    overflow: hidden;
-  }
-
   @supports (height: 100dvh) {
     html,
     body {
@@ -598,14 +594,6 @@ openclaw-app {
     padding-right: var(--safe-area-right);
     padding-bottom: var(--safe-area-bottom);
     padding-left: var(--safe-area-left);
-  }
-
-  openclaw-app {
-    width: 100%;
-    height: 100%;
-    min-width: 0;
-    min-height: 0;
-    overflow: hidden;
   }
 }
 


### PR DESCRIPTION
## What Problem This Solves

In the macOS app (Settings takeover, e.g. Settings → About), scrolling the content pane could drag the whole page up — settings sidebar, titlebar clearance, everything — leaving the sidebar header stranded under the traffic lights. The page-level scroll should never move; only the settings content pane or the sidebar nav list should scroll.

## Why This Change Was Made

`ui/src/styles/base.css` already documents the contract — "inner panes scroll, the root never should" — but the actual root scroll lock (`overflow: hidden` on `html`/`body`/`openclaw-app`) was gated behind `@media (display-mode: standalone)`. The macOS app's WKWebView is native web chrome (`html.openclaw-native-web-chrome`), not PWA-standalone, so the document stayed scrollable and WKWebView happily scrolled/rubber-banded the whole shell.

Fix: hoist the root lock out of the standalone gate so it applies in every host (browser tab, PWA, Mac app WKWebView):

- `html, body { overflow: clip }` — `clip` instead of `hidden` because `hidden` roots can still be displaced programmatically (focus/`scrollIntoView`), which would strand the shell off-screen with no way to scroll back; `clip` forbids all root scrolling.
- `openclaw-app` becomes `height: 100%` (was `min-height: 100vh`), matching what the standalone block already did.
- The standalone media block keeps only what is genuinely standalone-specific (dvh sizing, fixed body + safe-area insets); its duplicate overflow/size rules are deleted.
- The pre-app `.mount-fallback` error surface in `ui/index.html` gets its own scroller since the body no longer scrolls for it.

All top-level surfaces already own their scrolling (`.shell` is `100dvh`/`overflow: hidden` with `.content` and `.settings-sidebar__nav` as scrollers; login gate and approval page are self-contained `100dvh` boxes with `overflow-y: auto`), so nothing legitimately relied on document scroll. The two window-level scroll listeners (`github-link-hovercard`, `chat-selection-popup`) use capture and keep hearing inner-scroller events.

## User Impact

macOS app users can no longer scroll the whole Settings page (or any page) as one unit; the settings sidebar stays pinned while the content pane and sidebar nav scroll independently. Same guarantee now holds for browser tabs and PWA installs.

## Evidence

- Live repro in the Control UI mock harness (`pnpm dev:ui:mock`) with the Mac app's native web chrome injection simulated (classes + 52px titlebar CSS from `DashboardWindowController.installNativeChromeScript`), on `/settings/about`:
  - Before: root had no lock outside standalone (`html` computed `overflow-y: visible`).
  - After: `html`/`body` compute `overflow-y: clip`; `window.scrollTo(0, 999)` + `scrollIntoView` leave `window.scrollY`, `documentElement.scrollTop`, `body.scrollTop` all `0`, while `.content` (`scrollTop` 229/229 max) and `.settings-sidebar__nav` (200/274) scroll independently with the sidebar header pinned.
  - Chat route and 375×812 mobile viewport verified visually — thread scrolls, composer pinned, no layout regressions.
- New regression test in `ui/src/e2e/native-nav-sidebar-toggle.e2e.test.ts`: forces document overflow in the Settings takeover under web chrome and asserts the root refuses to scroll (fails before this fix, passes after).
- `pnpm check:changed` + focused e2e run on Blacksmith Testbox (IDs in comments below).
