### PR TITLE
fix(telegram): report degraded inline controls to agents

### DIFF
--- a/extensions/telegram/src/action-runtime.test.ts
+++ b/extensions/telegram/src/action-runtime.test.ts
@@ -1761,6 +1761,22 @@ describe("handleTelegramAction", () => {
     ).rejects.toThrow(/cannot be combined/i);
   });
 
+  it("rejects location sends mixed with presentation text", async () => {
+    await expect(
+      handleTelegramAction(
+        {
+          action: "sendMessage",
+          to: "123456",
+          location: { latitude: 1, longitude: 2 },
+          presentation: {
+            blocks: [{ type: "text", text: "caption" }],
+          },
+        },
+        telegramConfig(),
+      ),
+    ).rejects.toThrow(/cannot be combined/i);
+  });
+
   it("renders presentation text when message content is omitted", async () => {
     await handleTelegramAction(
       {

--- a/extensions/telegram/src/action-runtime.test.ts
+++ b/extensions/telegram/src/action-runtime.test.ts
@@ -1872,6 +1872,95 @@ describe("handleTelegramAction", () => {
     ]);
   });
 
+  it("reports dropped controls and delivers their readable fallback", async () => {
+    const result = await handleTelegramAction(
+      {
+        action: "sendMessage",
+        to: "123456",
+        content: "Choose",
+        presentation: {
+          blocks: [
+            {
+              type: "buttons",
+              buttons: [
+                { label: "Retry", value: "retry" },
+                { label: "Copy manually", value: "x".repeat(65) },
+              ],
+            },
+          ],
+        },
+      },
+      telegramConfig({ capabilities: { inlineButtons: "all" } }),
+    );
+
+    const call = mockCall(sendMessageTelegram, 0, "degraded controls");
+    expect(call[1]).toBe("Choose\n\n- Copy manually");
+    expect(requireRecord(call[2], "degraded controls options").buttons).toEqual([
+      [{ text: "Retry", callback_data: "retry" }],
+    ]);
+    expect(resultDetails(result)).toMatchObject({
+      ok: true,
+      warning: "Telegram delivered 1 unencodable control as readable text.",
+      degradedDelivery: {
+        droppedControls: 1,
+        fallback: "text",
+        reasons: ["callback_data_too_long"],
+        callbackDataLimitBytes: 64,
+      },
+    });
+  });
+
+  it("keeps a 64-byte Unicode callback native without a degradation warning", async () => {
+    const callbackData = "😀".repeat(16);
+    const result = await handleTelegramAction(
+      {
+        action: "sendMessage",
+        to: "123456",
+        content: "Choose",
+        presentation: {
+          blocks: [{ type: "buttons", buttons: [{ label: "Exact", value: callbackData }] }],
+        },
+      },
+      telegramConfig({ capabilities: { inlineButtons: "all" } }),
+    );
+
+    const call = mockCall(sendMessageTelegram, 0, "64-byte callback");
+    expect(requireRecord(call[2], "64-byte callback options").buttons).toEqual([
+      [{ text: "Exact", callback_data: callbackData }],
+    ]);
+    expect(resultDetails(result)).not.toHaveProperty("degradedDelivery");
+  });
+
+  it("delivers control fallback text before a standalone location", async () => {
+    const result = await handleTelegramAction(
+      {
+        action: "sendMessage",
+        to: "123456",
+        location: { latitude: 48.858844, longitude: 2.294351 },
+        presentation: {
+          blocks: [
+            { type: "buttons", buttons: [{ label: "Copy manually", value: "x".repeat(65) }] },
+          ],
+        },
+      },
+      telegramConfig({ capabilities: { inlineButtons: "all" } }),
+    );
+
+    const durableCall = mockCall(sendDurableMessageBatch, 0, "degraded location");
+    expect(requireRecord(durableCall[0], "degraded location params")).toMatchObject({
+      payloads: [
+        {
+          text: "- Copy manually",
+          location: { latitude: 48.858844, longitude: 2.294351 },
+        },
+      ],
+    });
+    expect(resultDetails(result)).toMatchObject({
+      ok: true,
+      degradedDelivery: { droppedControls: 1, fallback: "text" },
+    });
+  });
+
   it("edits reply markup when editMessage only changes buttons", async () => {
     await handleTelegramAction(
       {
@@ -1896,6 +1985,60 @@ describe("handleTelegramAction", () => {
     expect(call[1]).toBe(321);
     expect(call[2]).toEqual([[{ text: "Open", url: "https://example.com" }]]);
     expect(requireRecord(call[3], "reply markup edit options").token).toBe("tok");
+  });
+
+  it("reports controls dropped from a reply-markup edit", async () => {
+    const result = await handleTelegramAction(
+      {
+        action: "editMessage",
+        chatId: "123456",
+        messageId: 321,
+        presentation: {
+          blocks: [
+            {
+              type: "buttons",
+              buttons: [
+                { label: "Open", value: "open" },
+                { label: "Copy manually", value: "x".repeat(65) },
+              ],
+            },
+          ],
+        },
+      },
+      telegramConfig({ capabilities: { inlineButtons: "all" } }),
+    );
+
+    const call = mockCall(editMessageReplyMarkupTelegram, 0, "degraded reply markup edit");
+    expect(call[2]).toEqual([[{ text: "Open", callback_data: "open" }]]);
+    expect(resultDetails(result)).toMatchObject({
+      ok: true,
+      warning: "Telegram could not deliver 1 control.",
+      degradedDelivery: { droppedControls: 1, fallback: "not_delivered" },
+    });
+  });
+
+  it("returns a recoverable result when every edited control is unencodable", async () => {
+    const result = await handleTelegramAction(
+      {
+        action: "editMessage",
+        chatId: "123456",
+        messageId: 321,
+        presentation: {
+          blocks: [
+            { type: "buttons", buttons: [{ label: "Copy manually", value: "x".repeat(65) }] },
+          ],
+        },
+      },
+      telegramConfig({ capabilities: { inlineButtons: "all" } }),
+    );
+
+    expect(editMessageTelegram).not.toHaveBeenCalled();
+    expect(editMessageReplyMarkupTelegram).not.toHaveBeenCalled();
+    expect(resultDetails(result)).toMatchObject({
+      ok: false,
+      warning: "Telegram could not deliver 1 control.",
+      degradedDelivery: { droppedControls: 1, fallback: "not_delivered" },
+    });
   });
 
   it.each([

--- a/extensions/telegram/src/action-runtime.ts
+++ b/extensions/telegram/src/action-runtime.ts
@@ -556,12 +556,16 @@ export async function handleTelegramAction(
       droppedControls.length > 0 && resolvedContent.hasExplicitContent
         ? appendTelegramDroppedControlFallback(resolvedContent.content, droppedControls)
         : resolvedContent.content;
+    const droppedControlFallback =
+      droppedControls.length > 0 ? renderTelegramDroppedControlFallback(droppedControls) : "";
+    const hasOnlyDroppedControlFallback =
+      !resolvedContent.hasExplicitContent &&
+      droppedControlFallback.length > 0 &&
+      content.trim() === droppedControlFallback.trim();
     const asVideoNote = readBooleanParam(params, "asVideoNote") ?? false;
     if (
       location &&
-      ((resolvedContent.hasExplicitContent && content.trim()) ||
-        mediaUrls.length > 0 ||
-        asVideoNote)
+      ((content.trim() && !hasOnlyDroppedControlFallback) || mediaUrls.length > 0 || asVideoNote)
     ) {
       throw new Error("Telegram location sends cannot be combined with message text or media.");
     }

--- a/extensions/telegram/src/action-runtime.ts
+++ b/extensions/telegram/src/action-runtime.ts
@@ -31,7 +31,12 @@ import {
   resolveDefaultTelegramAccountId,
   resolveTelegramPollActionGateState,
 } from "./accounts.js";
-import { resolveTelegramInlineButtons } from "./button-types.js";
+import { TELEGRAM_CALLBACK_DATA_MAX_BYTES } from "./approval-callback-data.js";
+import {
+  resolveTelegramInlineButtons,
+  type TelegramButtonBuildOptions,
+  type TelegramDroppedControl,
+} from "./button-types.js";
 import { telegramInboundEventDelivery } from "./inbound-event-delivery.js";
 import {
   resolveTelegramInlineButtonsScope,
@@ -219,7 +224,7 @@ function readTelegramSendMediaUrls(params: Record<string, unknown>) {
 function resolveTelegramButtonsFromParams(
   params: Record<string, unknown>,
   presentation = normalizeMessagePresentation(params.presentation),
-  options?: { allowWebAppButtons?: boolean },
+  options?: TelegramButtonBuildOptions,
 ) {
   return resolveTelegramInlineButtons(
     {
@@ -272,7 +277,59 @@ function readTelegramSendContent(params: {
   if (content == null && !params.mediaUrl && !params.hasButtons && !params.hasLocation) {
     throw new Error("content required.");
   }
-  return content ?? "";
+  return {
+    content: content ?? "",
+    hasExplicitContent: explicitContent != null,
+  };
+}
+
+function renderTelegramDroppedControlFallback(controls: readonly TelegramDroppedControl[]): string {
+  return renderMessagePresentationFallbackText({
+    presentation: {
+      blocks: [
+        {
+          type: "buttons",
+          buttons: controls.map((control) => ({ label: control.label, value: "unavailable" })),
+        },
+      ],
+    },
+  });
+}
+
+function appendTelegramDroppedControlFallback(
+  text: string,
+  controls: readonly TelegramDroppedControl[],
+): string {
+  const fallback = renderTelegramDroppedControlFallback(controls);
+  if (!fallback || text === fallback || text.endsWith(`\n\n${fallback}`)) {
+    return text;
+  }
+  return [text, fallback].filter(Boolean).join("\n\n");
+}
+
+function buildTelegramControlDegradation(
+  controls: readonly TelegramDroppedControl[],
+  fallbackDelivered: boolean,
+) {
+  if (controls.length === 0) {
+    return undefined;
+  }
+  const reasons = [...new Set(controls.map((control) => control.reason))];
+  const hasOverflow = reasons.includes("callback_data_too_long");
+  return {
+    warning: fallbackDelivered
+      ? `Telegram delivered ${controls.length} unencodable control${controls.length === 1 ? "" : "s"} as readable text.`
+      : `Telegram could not deliver ${controls.length} control${controls.length === 1 ? "" : "s"}.`,
+    degradedDelivery: {
+      droppedControls: controls.length,
+      fallback: fallbackDelivered ? "text" : "not_delivered",
+      reasons,
+      ...(hasOverflow ? { callbackDataLimitBytes: TELEGRAM_CALLBACK_DATA_MAX_BYTES } : {}),
+      guidance: hasOverflow
+        ? `Shorten callback data to at most ${TELEGRAM_CALLBACK_DATA_MAX_BYTES} UTF-8 bytes and retry if clickable controls are required.`
+        : "Retry with a supported control action if clickable controls are required.",
+    },
+  };
 }
 
 function normalizeTelegramDeliveryPin(params: Record<string, unknown>) {
@@ -482,10 +539,12 @@ export async function handleTelegramAction(
     const firstMediaUrl = mediaUrls[0];
     const location = normalizeOutboundLocation(params.location);
     const presentation = normalizeMessagePresentation(params.presentation);
+    const droppedControls: TelegramDroppedControl[] = [];
     const buttons = resolveTelegramButtonsFromParams(params, presentation, {
       allowWebAppButtons: resolveTelegramTargetChatType(to) === "direct",
+      onDroppedControl: (control) => droppedControls.push(control),
     });
-    const content = readTelegramSendContent({
+    const resolvedContent = readTelegramSendContent({
       args: params,
       mediaUrl: firstMediaUrl,
       hasButtons: Array.isArray(buttons) && buttons.length > 0,
@@ -493,8 +552,17 @@ export async function handleTelegramAction(
       interactive: params.interactive,
       presentation,
     });
+    const content =
+      droppedControls.length > 0 && resolvedContent.hasExplicitContent
+        ? appendTelegramDroppedControlFallback(resolvedContent.content, droppedControls)
+        : resolvedContent.content;
     const asVideoNote = readBooleanParam(params, "asVideoNote") ?? false;
-    if (location && (content.trim() || mediaUrls.length > 0 || asVideoNote)) {
+    if (
+      location &&
+      ((resolvedContent.hasExplicitContent && content.trim()) ||
+        mediaUrls.length > 0 ||
+        asVideoNote)
+    ) {
       throw new Error("Telegram location sends cannot be combined with message text or media.");
     }
     if (asVideoNote && mediaUrls.length !== 1) {
@@ -602,6 +670,7 @@ export async function handleTelegramAction(
       ok: true,
       messageId: result.messageId,
       chatId: result.chatId,
+      ...buildTelegramControlDegradation(droppedControls, Boolean(content.trim())),
     });
   }
 
@@ -738,15 +807,28 @@ export async function handleTelegramAction(
       accountId,
       context: options,
     });
-    const content =
+    let content =
       readStringParam(params, "content", { allowEmpty: false }) ??
       readStringParam(params, "message", { allowEmpty: false });
     // Telegram treats an explicit empty caption as a request to remove it.
-    const caption = readStringParam(params, "caption", { allowEmpty: true });
+    let caption = readStringParam(params, "caption", { allowEmpty: true });
+    const droppedControls: TelegramDroppedControl[] = [];
     const buttons = resolveTelegramButtonsFromParams(params, undefined, {
       allowWebAppButtons: resolveTelegramTargetChatType(chatId ?? "") === "direct",
+      onDroppedControl: (control) => droppedControls.push(control),
     });
+    if (droppedControls.length > 0) {
+      if (caption != null) {
+        caption = appendTelegramDroppedControlFallback(caption, droppedControls);
+      } else if (content != null) {
+        content = appendTelegramDroppedControlFallback(content, droppedControls);
+      }
+    }
     if (content == null && caption == null && buttons === undefined) {
+      const degradation = buildTelegramControlDegradation(droppedControls, false);
+      if (degradation) {
+        return jsonResult({ ok: false, ...degradation });
+      }
       throw new Error("content required.");
     }
     if (buttons !== undefined) {
@@ -782,6 +864,7 @@ export async function handleTelegramAction(
         ok: true,
         messageId: result.messageId,
         chatId: result.chatId,
+        ...buildTelegramControlDegradation(droppedControls, false),
       });
     }
     const result = await telegramActionRuntime.editMessageTelegram(
@@ -801,6 +884,7 @@ export async function handleTelegramAction(
       ok: true,
       messageId: result.messageId,
       chatId: result.chatId,
+      ...buildTelegramControlDegradation(droppedControls, true),
     });
   }
 

--- a/extensions/telegram/src/approval-callback-data.ts
+++ b/extensions/telegram/src/approval-callback-data.ts
@@ -2,7 +2,7 @@
 import { buildApprovalResolutionRef } from "openclaw/plugin-sdk/approval-reference-runtime";
 import type { MessagePresentationAction } from "openclaw/plugin-sdk/interactive-runtime";
 
-const TELEGRAM_CALLBACK_DATA_MAX_BYTES = 64;
+export const TELEGRAM_CALLBACK_DATA_MAX_BYTES = 64;
 const TELEGRAM_APPROVAL_CALLBACK_PREFIX = "tga1:";
 
 export type TelegramApprovalCallback = Extract<MessagePresentationAction, { type: "approval" }>;

--- a/extensions/telegram/src/button-types.test.ts
+++ b/extensions/telegram/src/button-types.test.ts
@@ -647,6 +647,25 @@ describe("buildTelegramPresentationButtons", () => {
     ).toBeUndefined();
   });
 
+  it("records Web App gating separately from callback overflow", () => {
+    const dropped: Array<{ reason: string; callbackDataBytes?: number }> = [];
+    buildTelegramPresentationButtons(
+      {
+        blocks: [
+          {
+            type: "buttons",
+            buttons: [
+              { label: "App", action: { type: "web-app", url: "https://example.com/app" } },
+            ],
+          },
+        ],
+      },
+      { onDroppedControl: (control) => dropped.push(control) },
+    );
+
+    expect(dropped).toEqual([{ label: "App", reason: "web_app_unavailable" }]);
+  });
+
   it("skips hosted widget actions without a Telegram web app URL", () => {
     expect(
       buildTelegramPresentationButtons({

--- a/extensions/telegram/src/button-types.ts
+++ b/extensions/telegram/src/button-types.ts
@@ -13,6 +13,7 @@ import {
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
 import {
   buildTelegramApprovalCallbackData,
+  TELEGRAM_CALLBACK_DATA_MAX_BYTES,
   hasTelegramApprovalCallbackPrefix,
   rewriteTelegramApprovalDecisionAlias,
   sanitizeTelegramCallbackData,
@@ -38,10 +39,21 @@ type TelegramInlineButton = {
 
 export type TelegramInlineButtons = ReadonlyArray<ReadonlyArray<TelegramInlineButton>>;
 
+export type TelegramDroppedControl = {
+  label: string;
+  reason:
+    | "callback_data_too_long"
+    | "invalid_action"
+    | "question_context_unavailable"
+    | "web_app_unavailable";
+  callbackDataBytes?: number;
+};
+
 type TelegramQuestionOptionIndices = ReadonlyMap<string, ReadonlyMap<string, number>>;
 
 export type TelegramButtonBuildOptions = {
   allowWebAppButtons?: boolean;
+  onDroppedControl?: (control: TelegramDroppedControl) => void;
   questionOptionIndices?: TelegramQuestionOptionIndices;
 };
 
@@ -89,6 +101,24 @@ function toTelegramButtonStyle(
   return style === "danger" || style === "success" || style === "primary" ? style : undefined;
 }
 
+function recordDroppedControl(
+  button: MessagePresentationButton,
+  options: TelegramButtonBuildOptions | undefined,
+  reason: Exclude<TelegramDroppedControl["reason"], "callback_data_too_long">,
+  callbackData?: string,
+): undefined {
+  const callbackDataBytes = callbackData ? Buffer.byteLength(callbackData, "utf8") : undefined;
+  options?.onDroppedControl?.({
+    label: button.label,
+    reason:
+      callbackDataBytes !== undefined && callbackDataBytes > TELEGRAM_CALLBACK_DATA_MAX_BYTES
+        ? "callback_data_too_long"
+        : reason,
+    ...(callbackDataBytes !== undefined ? { callbackDataBytes } : {}),
+  });
+  return undefined;
+}
+
 function toTelegramInlineButton(
   button: MessagePresentationButton,
   options?: TelegramButtonBuildOptions,
@@ -96,7 +126,7 @@ function toTelegramInlineButton(
   const style = toTelegramButtonStyle(button.style);
   const action = resolveMessagePresentationButtonAction(button);
   if (!action) {
-    return undefined;
+    return recordDroppedControl(button, options, "invalid_action");
   }
   if (action.type === "url") {
     return { text: button.label, url: action.url, style };
@@ -104,11 +134,13 @@ function toTelegramInlineButton(
   if (action.type === "web-app") {
     return options?.allowWebAppButtons === true && action.url
       ? { text: button.label, web_app: { url: action.url }, style }
-      : undefined;
+      : recordDroppedControl(button, options, "web_app_unavailable");
   }
   if (action.type === "approval") {
     const callbackData = buildTelegramApprovalCallbackData(action);
-    return callbackData ? { text: button.label, callback_data: callbackData, style } : undefined;
+    return callbackData
+      ? { text: button.label, callback_data: callbackData, style }
+      : recordDroppedControl(button, options, "invalid_action");
   }
   if (action.type === "question") {
     const normalizedOptionValue = action.optionValue.trim().toLowerCase();
@@ -116,29 +148,32 @@ function toTelegramInlineButton(
       ?.get(action.questionId)
       ?.get(normalizedOptionValue);
     if (optionIndex === undefined) {
-      return undefined;
+      return recordDroppedControl(button, options, "question_context_unavailable");
     }
     const callbackData = buildTelegramQuestionCallbackData({
       questionId: action.questionId,
       optionIndex,
     });
     if (!callbackData) {
-      return undefined;
+      return recordDroppedControl(button, options, "invalid_action");
     }
     // Presentation order is not authoritative; only Gateway-owned option order can choose an index.
     return { text: button.label, callback_data: callbackData, style };
   }
   if (action.type === "command") {
     const command = rewriteTelegramApprovalDecisionAlias(action.command.trim());
-    const nativeCallbackData = command
-      ? sanitizeTelegramCallbackData(buildTelegramNativeCommandCallbackData(command))
+    const nativeCandidate = command ? buildTelegramNativeCommandCallbackData(command) : undefined;
+    const nativeCallbackData = nativeCandidate
+      ? sanitizeTelegramCallbackData(nativeCandidate)
       : undefined;
     // Historical approval commands may consume the full callback budget. Preserve
     // their authorized raw-command path when tgcmd: is the only overflow.
     const callbackData =
       nativeCallbackData ??
       (parseExecApprovalCommandText(command) ? sanitizeTelegramCallbackData(command) : undefined);
-    return callbackData ? { text: button.label, callback_data: callbackData, style } : undefined;
+    return callbackData
+      ? { text: button.label, callback_data: callbackData, style }
+      : recordDroppedControl(button, options, "invalid_action", nativeCandidate);
   }
   // Reserve the full approval prefix, including malformed values, so legacy
   // plugin callbacks cannot be consumed by the approval handler.
@@ -147,10 +182,13 @@ function toTelegramInlineButton(
     Boolean(button.action) ||
     hasTelegramApprovalCallbackPrefix(normalizedCallbackValue) ||
     hasTelegramQuestionCallbackPrefix(normalizedCallbackValue);
-  const callbackData = sanitizeTelegramCallbackData(
-    needsOpaqueEnvelope ? buildTelegramOpaqueCallbackData(action.value) : action.value,
-  );
-  return callbackData ? { text: button.label, callback_data: callbackData, style } : undefined;
+  const callbackDataCandidate = needsOpaqueEnvelope
+    ? buildTelegramOpaqueCallbackData(action.value)
+    : action.value;
+  const callbackData = sanitizeTelegramCallbackData(callbackDataCandidate);
+  return callbackData
+    ? { text: button.label, callback_data: callbackData, style }
+    : recordDroppedControl(button, options, "invalid_action", callbackDataCandidate);
 }
 
 function chunkInteractiveButtons(


### PR DESCRIPTION
## What problem this solves

Telegram rejects inline-keyboard `callback_data` over 64 UTF-8 bytes. The converter correctly omitted those controls, but the direct `message.send` action discarded that fact and returned bare `ok: true`. The model therefore believed every requested control shipped.

## What changed

- Record the exact drop reason where each Telegram control is encoded.
- Preserve readable fallback text for controls Telegram cannot encode.
- Return a bounded `degradedDelivery` result with the dropped count, exact reasons, Telegram's byte limit, fallback state, and recovery guidance.
- Cover send, standalone-location delivery, and edit actions.
- Preserve the standalone-location contract: caller and presentation text remain invalid; only the exact generated dropped-control fallback is exempt.
- Keep non-overflow failures distinct; Web App gating is not reported as callback overflow.

This deliberately replaces the stale logger-only patch. A log warning cannot repair the model's false belief about what it sent.

## Product fit

This removes a silent default-path failure. The recipient still gets an actionable text fallback, while the model gets the recorded transport fact and knows how to retry with a clickable control.

No config or default surfaces changed.

## Verification

Exact head: `b348469f83ac5cce5b59f54b002a388a1a09104a`

- `node scripts/run-vitest.mjs extensions/telegram/src/action-runtime.test.ts extensions/telegram/src/button-types.test.ts extensions/telegram/src/interactive-fallback.test.ts extensions/telegram/src/approval-callback-data.test.ts`
  - 4 files, 171 tests passed.
- `node scripts/check-changed.mjs -- <five changed files>`
  - Extension/test typechecks, lint, format, boundaries, dead exports, database-first guard, sidecar guard, and import-cycle guard passed. Blacksmith routing was unavailable, so the documented trusted-source local fallback ran.
- `$autoreview`
  - Codex `gpt-5.6-sol`, high reasoning: clean, correctness 0.98.
- `git diff --check`
  - Passed.

### Real Telegram user proof

Used `$telegram-e2e-userbot` with its dedicated QA user, a fresh exact-head gateway, deterministic mock provider, and an isolated DM. No Mantis.

```text
E2E_MOCK_SERVER_PATH=<deterministic message-tool fixture> \
node $TELEGRAM_E2E_SKILL_DIR/scripts/run-mock-sut-user-e2e.mjs \
  --dm --timeout-ms 30000 \
  --text 'Run the callback overflow verification.' \
  --record <proof>/events.ndjson --output <proof>/summary.json
```

Observed facts:

- One SUT response arrived 2.952s after recording began; the event stream recorded two typing events and no duplicate final message.
- Visible text: `Choose an action` followed by `Copy manually` as fallback text.
- Inline keyboard: exactly one button, `Retry`, with callback `retry`.
- The 65-byte `Copy manually` callback was absent from the keyboard.
- Provider requests: 2. The second request contained this message-tool result:

```json
{
  "ok": true,
  "warning": "Telegram delivered 1 unencodable control as readable text.",
  "degradedDelivery": {
    "droppedControls": 1,
    "fallback": "text",
    "reasons": ["callback_data_too_long"],
    "callbackDataLimitBytes": 64,
    "guidance": "Shorten callback data to at most 64 UTF-8 bytes and retry if clickable controls are required."
  }
}
```

## Review metrics

- Production: +146 / -20 lines. Growth implements the encoding-owner fact, model-visible degradation contract, and standalone-location invariant.
- Tests: +178 / -0 lines.
- Config/default surfaces: 0 added, changed, or removed.

Related to #106996. Co-authored by @Guoji-XYDT.
