### PR TITLE
refactor(ai): remove redundant tool argument finalization

### DIFF
--- a/extensions/amazon-bedrock/stream.runtime.ts
+++ b/extensions/amazon-bedrock/stream.runtime.ts
@@ -596,7 +596,6 @@ function handleContentBlockStop(
       });
       break;
     case "toolCall":
-      block.arguments = parseStreamingJson(block.partialJson);
       // Finalize in-place and strip the scratch buffer so replay only
       // carries parsed arguments.
       delete (block as Block).partialJson;

--- a/packages/ai/src/providers/mistral.ts
+++ b/packages/ai/src/providers/mistral.ts
@@ -771,7 +771,6 @@ async function consumeChatStream(
       continue;
     }
     const toolBlock = block as ToolCall & { partialArgs?: string };
-    toolBlock.arguments = parseStreamingJson(toolBlock.partialArgs);
     // Finalize in-place and strip the scratch buffer so replay only
     // carries parsed arguments.
     delete toolBlock.partialArgs;

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -244,7 +244,6 @@ export const streamOpenAICompletions: StreamFunction<
             partial: output,
           });
         } else if (block.type === "toolCall") {
-          block.arguments = parseStreamingJson(block.partialArgs);
           // Finalize in-place and strip the scratch buffers so replay only
           // carries parsed arguments.
           delete block.partialArgs;

--- a/packages/ai/src/utils/json-parse.ts
+++ b/packages/ai/src/utils/json-parse.ts
@@ -105,11 +105,7 @@ export function repairJson(json: string): string {
 }
 
 export function parseJsonWithRepair(json: string): unknown {
-  const repairedJson = repairJson(json);
-  if (repairedJson !== json) {
-    return JSON.parse(repairedJson) as unknown;
-  }
-  return JSON.parse(json) as unknown;
+  return JSON.parse(repairJson(json)) as unknown;
 }
 
 function looksLikeWindowsPathPrefix(prefix: string): boolean {
@@ -139,12 +135,10 @@ export function parseStreamingJson(partialJson: string | undefined): Record<stri
     return asStreamingJsonRecord(parseJsonWithRepair(partialJson));
   } catch {
     try {
-      const result = partialParse(partialJson);
-      return asStreamingJsonRecord(result);
+      return asStreamingJsonRecord(partialParse(partialJson));
     } catch {
       try {
-        const result = partialParse(repairJson(partialJson));
-        return asStreamingJsonRecord(result);
+        return asStreamingJsonRecord(partialParse(repairJson(partialJson)));
       } catch {
         return {};
       }

--- a/src/agents/anthropic-transport-stream.ts
+++ b/src/agents/anthropic-transport-stream.ts
@@ -1750,9 +1750,6 @@ export function createAnthropicMessagesTransportStreamFn(): StreamFn {
               continue;
             }
             if (block.type === "toolCall") {
-              if (typeof block.partialJson === "string" && block.partialJson.length > 0) {
-                block.arguments = parseAnthropicToolCallArguments(block.partialJson);
-              }
               delete block.partialJson;
               eventSink.push({
                 type: "toolcall_end",

--- a/src/agents/openai-completions-transport.ts
+++ b/src/agents/openai-completions-transport.ts
@@ -398,19 +398,6 @@ async function processOpenAICompletionsStream(
     chunkPushedEvent = true;
     stream.push(event);
   };
-  const finishCurrentBlock = () => {
-    if (!currentBlock) {
-      return;
-    }
-    if (currentBlock.type === "toolCall") {
-      currentBlock.arguments = parseStreamingJson(currentBlock.partialArgs);
-    }
-  };
-  const finishAllToolCallBlocks = () => {
-    for (const block of toolCallBlocksByIndex.values()) {
-      block.arguments = parseStreamingJson(block.partialArgs);
-    }
-  };
   const queuePostToolCallDelta = (next: CompletionsReasoningDelta) => {
     const nextBytes = measureUtf8Bytes(next.text);
     if (pendingPostToolCallBytes + nextBytes > MAX_POST_TOOL_CALL_BUFFER_BYTES) {
@@ -434,7 +421,6 @@ async function processOpenAICompletionsStream(
   };
   const appendThinkingDeltaInternal = (reasoningDelta: { signature: string; text: string }) => {
     if (!currentBlock || currentBlock.type !== "thinking") {
-      finishCurrentBlock();
       currentBlock = {
         type: "thinking",
         thinking: "",
@@ -453,7 +439,6 @@ async function processOpenAICompletionsStream(
   };
   const appendTextDeltaInternal = (text: string) => {
     if (!currentBlock || currentBlock.type !== "text") {
-      finishCurrentBlock();
       currentBlock = { type: "text", text: "" };
       output.content.push(currentBlock);
       pushStreamEvent({ type: "text_start", contentIndex: blockIndex(), partial: output });
@@ -506,7 +491,6 @@ async function processOpenAICompletionsStream(
   };
   const appendRecoveredToolCall = (toolCall: RecoveredDeepSeekDsmlToolCall) => {
     const switchingToolCall = currentBlock?.type === "toolCall";
-    finishCurrentBlock();
     if (switchingToolCall) {
       currentBlock = null;
       flushPendingPostToolCallDeltas();
@@ -731,7 +715,6 @@ async function processOpenAICompletionsStream(
         }
         if (!block) {
           const switchingToolCall = currentBlock?.type === "toolCall";
-          finishCurrentBlock();
           if (switchingToolCall) {
             currentBlock = null;
             flushPendingPostToolCallDeltas();
@@ -793,7 +776,6 @@ async function processOpenAICompletionsStream(
   flushReasoningTagTextPartitionerAtEnd();
   flushDeepSeekToolCallRecovererAtEnd();
   flushDeepSeekTextFilterAtEnd();
-  finishAllToolCallBlocks();
   currentBlock = null;
   flushPendingPostToolCallDeltas();
   const hasToolCalls = output.content.some((block) => block.type === "toolCall");


### PR DESCRIPTION
## What Problem This Solves

Streaming tool-call parsers reparsed the same accumulated JSON argument buffer when a block or stream finished, even though every buffer update had already parsed that exact string.

## Why This Change Was Made

Keep incremental `partial-json` parsing as the single canonical update path. Remove only deterministic final reparses across the Mistral, OpenAI, Anthropic, and Bedrock stream adapters, and simplify the shared repair wrapper without changing fallback order.

## User Impact

No user-visible behavior change. Tool arguments, start-only blocks, empty inputs, recovered DSML blocks, unsafe integers, and parse-error timing remain unchanged. The implementation is 30 lines smaller.

## Evidence

- Directly inspected installed `partial-json@0.1.7` source, types, and README.
- Blacksmith Testbox `tbx_01kxfd2975jv5fkq1ghyzdn0c6`: 547 focused tests passed across shared JSON parsing and all touched stream adapters.
- `pnpm tsgo:core`
- `pnpm tsgo:core:test`
- `pnpm tsgo:extensions`
- `pnpm tsgo:extensions:test`
- Targeted `oxfmt`, `oxlint`, and `git diff --check` passed.
- Fresh autoreview: no findings; patch correct at 0.98 confidence.

Hosted CI intentionally not awaited per maintainer direction.
