### PR TITLE
fix(ui): keep native context menu on selected chat text

### DIFF
--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -5390,6 +5390,69 @@ describe("right-click Reply", () => {
     expect(document.querySelector(".chat-reply-context-menu")).toBeNull();
   });
 
+  it("keeps the native context menu when message text is selected", () => {
+    const onSetReply = vi.fn();
+    const container = renderChatView({ onSetReply });
+    // Selection APIs only retain ranges for connected document nodes (jsdom).
+    document.body.appendChild(container);
+    const section = container.querySelector<HTMLElement>(".card.chat");
+    expect(section).not.toBeNull();
+
+    const group = document.createElement("div");
+    group.className = "chat-group";
+    const bubble = document.createElement("div");
+    bubble.className = "chat-bubble";
+    bubble.dataset.messageText = "copy me please";
+    const textNode = document.createTextNode("copy me please");
+    bubble.appendChild(textNode);
+    group.appendChild(bubble);
+    section!.querySelector(".chat-thread-inner")!.appendChild(group);
+
+    const range = document.createRange();
+    range.setStart(textNode, 0);
+    range.setEnd(textNode, 7);
+    const selection = window.getSelection();
+    selection?.removeAllRanges();
+    selection?.addRange(range);
+    expect(selection?.isCollapsed).toBe(false);
+
+    const evt = new MouseEvent("contextmenu", { bubbles: true, cancelable: true });
+    bubble.dispatchEvent(evt);
+
+    expect(evt.defaultPrevented).toBe(false);
+    expect(document.querySelector(".chat-reply-context-menu")).toBeNull();
+    expect(onSetReply).not.toHaveBeenCalled();
+
+    selection?.removeAllRanges();
+    container.remove();
+  });
+
+  it("still opens Reply menu when selection is collapsed", () => {
+    const onSetReply = vi.fn();
+    const container = renderChatView({ onSetReply });
+    document.body.appendChild(container);
+    const section = container.querySelector<HTMLElement>(".card.chat");
+    const group = document.createElement("div");
+    group.className = "chat-group";
+    const bubble = document.createElement("div");
+    bubble.className = "chat-bubble";
+    bubble.dataset.messageText = "reply without selection";
+    const textNode = document.createTextNode("reply without selection");
+    bubble.appendChild(textNode);
+    group.appendChild(bubble);
+    section!.querySelector(".chat-thread-inner")!.appendChild(group);
+
+    window.getSelection()?.removeAllRanges();
+
+    const evt = new MouseEvent("contextmenu", { bubbles: true, cancelable: true });
+    bubble.dispatchEvent(evt);
+
+    expect(evt.defaultPrevented).toBe(true);
+    expect(document.querySelector(".chat-reply-context-menu")).not.toBeNull();
+    document.querySelector(".chat-reply-context-menu")?.remove();
+    container.remove();
+  });
+
   it("dismisses the reply context menu with Escape after delayed listeners register", () => {
     const onSetReply = vi.fn();
     const frameCallbacks: FrameRequestCallback[] = [];

--- a/ui/src/pages/chat/components/chat-thread.ts
+++ b/ui/src/pages/chat/components/chat-thread.ts
@@ -597,6 +597,43 @@ function handleChatThreadSelectionPointerUp(event: PointerEvent, props: ChatThre
   });
 }
 
+/**
+ * True when the user has a non-collapsed selection that intersects this
+ * message bubble. In that case the custom Reply menu must not call
+ * preventDefault — otherwise native Copy/Search/accessibility menus are lost.
+ */
+function hasNonCollapsedSelectionInBubble(bubble: Element): boolean {
+  const selection = window.getSelection();
+  if (!selection || selection.isCollapsed || selection.rangeCount === 0) {
+    return false;
+  }
+  // Prefer anchor/focus containment: reliable in jsdom and real browsers when
+  // the selection lives inside the bubble text nodes.
+  if (
+    [selection.anchorNode, selection.focusNode].some(
+      (node) => node !== null && bubble.contains(node),
+    )
+  ) {
+    return Boolean(selection.toString().trim());
+  }
+  try {
+    if (selection.getRangeAt(0).intersectsNode(bubble)) {
+      return Boolean(selection.toString().trim());
+    }
+  } catch {
+    // Range.intersectsNode can throw if the node is not in the live tree.
+  }
+  // Fallback: common ancestor inside this bubble.
+  const container = selection.getRangeAt(0).commonAncestorContainer;
+  const element = container instanceof Element ? container : container.parentElement;
+  const selectedBubble = element?.closest(".chat-bubble");
+  return (
+    selectedBubble != null &&
+    (selectedBubble === bubble || bubble.contains(selectedBubble)) &&
+    Boolean(selection.toString().trim())
+  );
+}
+
 function handleChatContextMenu(event: MouseEvent, props: ChatThreadProps) {
   const bubble = (event.target as HTMLElement).closest(".chat-bubble");
   if (!bubble || typeof props.onSetReply !== "function") {
@@ -610,6 +647,11 @@ function handleChatContextMenu(event: MouseEvent, props: ChatThreadProps) {
     group.querySelector(".chat-reading-indicator") ||
     group.querySelector(".chat-bubble.streaming")
   ) {
+    return;
+  }
+  // Preserve native browser context menu (Copy, Search, spell-check) when the
+  // user has selected message text. Custom Reply remains for empty selection.
+  if (hasNonCollapsedSelectionInBubble(bubble)) {
     return;
   }
   const senderEl = group.querySelector(".chat-sender-name");


### PR DESCRIPTION
Closes #106765

## What Problem This Solves

Fixes an issue where users highlighting text in Control UI chat and right-clicking would not get the browser’s native context menu (Copy, Search, spell-check). The custom Reply menu always called `preventDefault`, so mouse-driven copy/accessibility workflows were blocked even though keyboard Ctrl+C still worked.

## Why This Change Was Made

When a non-collapsed selection intersects the message bubble being right-clicked, the chat thread leaves the `contextmenu` event alone so the native menu can open. When selection is collapsed (or outside that bubble), the existing custom Reply menu is unchanged. No new settings or config surface.

Fix quality: compatibility — preserves Reply for empty selection; performance — O(1) selection checks on contextmenu only; usability — restores familiar mouse copy/search; security — no auth, secrets, or trust-boundary changes.

## User Impact

Users can highlight chat text and right-click to Copy, Search, or use other native browser actions again. Right-click with no selection still opens Reply as before.

## Evidence

Verification host: local macOS (Crabbox bypass).

Focused suite (primary behavior):

```text
node scripts/run-vitest.mjs ui/src/pages/chat/chat-view.test.ts -t "right-click Reply"
# Test Files  1 passed (1)
# Tests  13 passed | 165 skipped (178)
```

New coverage:
- keeps the native context menu when message text is selected (`defaultPrevented === false`, no custom menu)
- still opens Reply menu when selection is collapsed

Static: `git diff --check` clean on touched files. Closeout used quality-preserving focused Vitest after `pnpm exec oxfmt` expanded into a hung install; format was verified by trailing-whitespace/tab scan on the two changed files.

## Real behavior proof

- Behavior addressed: Right-click on selected chat message text must not suppress the native browser context menu; Reply menu remains for empty selection.
- Environment: local macOS + openclaw checkout at `fix/106765-chat-native-context-menu-on-selection` (`2faf276c9`); Control UI Vitest/jsdom harness.
- Current-main contrast: On main, `handleChatContextMenu` always `preventDefault`s when Reply is available, so a non-collapsed selection still opens only the custom Reply menu and blocks native Copy/Search.
- Exact steps or command run after this patch:
  1. `node scripts/run-vitest.mjs ui/src/pages/chat/chat-view.test.ts -t "right-click Reply"`
  2. Case “keeps the native context menu when message text is selected”: connect bubble to `document`, select text, dispatch `contextmenu`, assert `defaultPrevented === false` and no `.chat-reply-context-menu`.
  3. Case “still opens Reply menu when selection is collapsed”: empty selection still prevents default and shows Reply.
- Evidence after fix: focused suite **13 passed** including both selection and collapsed paths (see Evidence above).
- Control check: Only the selection-aware early return is new; existing Reply open/dismiss/Escape cases still pass in the same suite.
- Observed result after fix: Selected text right-click no longer cancels the native menu path; collapsed selection still gets Reply.
- What was not tested: Live Chrome Control UI screenshot of the native OS menu (jsdom cannot open a real browser menu); keyboard Ctrl+C (unchanged path).

## AI disclosure

This PR was authored with AI assistance (Grok).
