### PR TITLE
fix(tui): preserve input across gateway restarts

### DIFF
--- a/src/tui/tui-session-actions.test.ts
+++ b/src/tui/tui-session-actions.test.ts
@@ -1308,6 +1308,67 @@ describe("tui session actions", () => {
     expect(result).toEqual({ loaded: true, inFlightRunId: null });
   });
 
+  it("releases a pending submit when reconnect history proves it was accepted", async () => {
+    const loadHistory = vi.fn().mockResolvedValue({
+      sessionId: "session-main",
+      messages: [{ role: "user", content: "persisted", timestamp: 2_000 }],
+    });
+    const chatLog = {
+      addSystem: vi.fn(),
+      addUser: vi.fn(),
+      finalizeAssistant: vi.fn(),
+      clearAll: vi.fn(),
+      reconcilePendingUsers: vi.fn().mockReturnValue(["run-pending"]),
+      restorePendingUsers: vi.fn(),
+    };
+    const state = createBaseState({
+      pendingChatRunId: "run-pending",
+      pendingOptimisticUserMessage: true,
+      pendingSubmitDraft: { runId: "run-pending", text: "persisted" },
+    });
+
+    const { loadHistory: runLoadHistory } = createTestSessionActions({
+      client: { listSessions: vi.fn(), loadHistory } as unknown as TuiBackend,
+      chatLog: chatLog as unknown as import("./components/chat-log.js").ChatLog,
+      state,
+    });
+
+    await runLoadHistory();
+
+    expect(state.pendingChatRunId).toBeNull();
+    expect(state.pendingOptimisticUserMessage).toBe(false);
+    expect(state.pendingSubmitDraft).toBeNull();
+  });
+
+  it("keeps a pending submit when reconnect history has not accepted it", async () => {
+    const loadHistory = vi.fn().mockResolvedValue({ sessionId: "session-main", messages: [] });
+    const chatLog = {
+      addSystem: vi.fn(),
+      addUser: vi.fn(),
+      finalizeAssistant: vi.fn(),
+      clearAll: vi.fn(),
+      reconcilePendingUsers: vi.fn().mockReturnValue([]),
+      restorePendingUsers: vi.fn(),
+    };
+    const state = createBaseState({
+      pendingChatRunId: "run-pending",
+      pendingOptimisticUserMessage: true,
+      pendingSubmitDraft: { runId: "run-pending", text: "not persisted" },
+    });
+
+    const { loadHistory: runLoadHistory } = createTestSessionActions({
+      client: { listSessions: vi.fn(), loadHistory } as unknown as TuiBackend,
+      chatLog: chatLog as unknown as import("./components/chat-log.js").ChatLog,
+      state,
+    });
+
+    await runLoadHistory();
+
+    expect(state.pendingChatRunId).toBe("run-pending");
+    expect(state.pendingOptimisticUserMessage).toBe(true);
+    expect(state.pendingSubmitDraft).toEqual({ runId: "run-pending", text: "not persisted" });
+  });
+
   it("force-renders after rebuilding chat history so transient status rows are cleared", async () => {
     const loadHistory = vi.fn().mockResolvedValue({
       sessionId: "session-main",

--- a/src/tui/tui-session-actions.ts
+++ b/src/tui/tui-session-actions.ts
@@ -14,6 +14,7 @@ import type { ChatLog } from "./components/chat-log.js";
 import type { TuiAgentsList, TuiBackend, TuiSessionMutationResult } from "./tui-backend.js";
 import { asString, extractTextFromMessage, isCommandMessage } from "./tui-formatters.js";
 import { TUI_SESSION_LOOKUP_LIMIT } from "./tui-session-list-policy.js";
+import { reconcilePendingSubmitHistory } from "./tui-submit.js";
 import type { SessionInfo, TuiHistoryLoadResult, TuiOptions, TuiStateAccess } from "./tui-types.js";
 
 type SessionActionBtwPresenter = {
@@ -540,22 +541,7 @@ export function createSessionActions(context: SessionActionContext) {
           );
         }
       }
-      const reconciledRunIds = chatLog.reconcilePendingUsers(historyUsers);
-      const reconciledRunIdSet = new Set(reconciledRunIds);
-      const pendingAdmissionRunId = state.pendingChatRunId;
-      const pendingDraftRunId = state.pendingSubmitDraft?.runId;
-      if (
-        (pendingAdmissionRunId && reconciledRunIdSet.has(pendingAdmissionRunId)) ||
-        (pendingDraftRunId && reconciledRunIdSet.has(pendingDraftRunId))
-      ) {
-        // History proves the Gateway accepted this submit even if reconnect hid
-        // its registration event. Release the admission gate or the idle TUI stays blocked.
-        state.pendingChatRunId = null;
-        state.pendingOptimisticUserMessage = false;
-        if (pendingDraftRunId && reconciledRunIdSet.has(pendingDraftRunId)) {
-          state.pendingSubmitDraft = null;
-        }
-      }
+      reconcilePendingSubmitHistory(state, chatLog.reconcilePendingUsers(historyUsers));
       chatLog.restorePendingUsers();
       // Restore a run still streaming for this session+agent that the gateway
       // reports as in-flight. Its live deltas were delivered to a per-agent key

--- a/src/tui/tui-session-actions.ts
+++ b/src/tui/tui-session-actions.ts
@@ -541,8 +541,20 @@ export function createSessionActions(context: SessionActionContext) {
         }
       }
       const reconciledRunIds = chatLog.reconcilePendingUsers(historyUsers);
-      if (state.pendingSubmitDraft && reconciledRunIds.includes(state.pendingSubmitDraft.runId)) {
-        state.pendingSubmitDraft = null;
+      const reconciledRunIdSet = new Set(reconciledRunIds);
+      const pendingAdmissionRunId = state.pendingChatRunId;
+      const pendingDraftRunId = state.pendingSubmitDraft?.runId;
+      if (
+        (pendingAdmissionRunId && reconciledRunIdSet.has(pendingAdmissionRunId)) ||
+        (pendingDraftRunId && reconciledRunIdSet.has(pendingDraftRunId))
+      ) {
+        // History proves the Gateway accepted this submit even if reconnect hid
+        // its registration event. Release the admission gate or the idle TUI stays blocked.
+        state.pendingChatRunId = null;
+        state.pendingOptimisticUserMessage = false;
+        if (pendingDraftRunId && reconciledRunIdSet.has(pendingDraftRunId)) {
+          state.pendingSubmitDraft = null;
+        }
       }
       chatLog.restorePendingUsers();
       // Restore a run still streaming for this session+agent that the gateway

--- a/src/tui/tui-submit.ts
+++ b/src/tui/tui-submit.ts
@@ -1,7 +1,47 @@
 // Handles TUI input submission and command dispatch.
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
+import { isChatStopCommandText } from "../gateway/chat-abort.js";
+import type { TuiStateAccess } from "./tui-types.js";
 
 export type TuiSubmitAction = "local shell" | "command" | "message";
+
+export function canSubmitTuiChatMessage(params: {
+  isConnected?: boolean;
+  activeChatRunId?: string | null;
+  pendingChatRunId?: string | null;
+  pendingOptimisticUserMessage?: boolean;
+  message?: string;
+}): boolean {
+  if (params.isConnected === false) {
+    return false;
+  }
+  const stopText = params.message ? isChatStopCommandText(params.message) : false;
+  if (stopText && (params.activeChatRunId || params.pendingChatRunId)) {
+    return true;
+  }
+  return !params.pendingChatRunId && params.pendingOptimisticUserMessage !== true;
+}
+
+export function reconcilePendingSubmitHistory(
+  state: TuiStateAccess,
+  reconciledRunIds: readonly string[],
+): void {
+  const reconciledRunIdSet = new Set(reconciledRunIds);
+  const pendingAdmissionRunId = state.pendingChatRunId;
+  const pendingDraftRunId = state.pendingSubmitDraft?.runId;
+  if (
+    (pendingAdmissionRunId && reconciledRunIdSet.has(pendingAdmissionRunId)) ||
+    (pendingDraftRunId && reconciledRunIdSet.has(pendingDraftRunId))
+  ) {
+    // History proves the Gateway accepted this submit even if reconnect hid
+    // its registration event. Release the admission gate or the idle TUI stays blocked.
+    state.pendingChatRunId = null;
+    state.pendingOptimisticUserMessage = false;
+    if (pendingDraftRunId && reconciledRunIdSet.has(pendingDraftRunId)) {
+      state.pendingSubmitDraft = null;
+    }
+  }
+}
 
 function runSubmitAction(
   action: TuiSubmitAction,

--- a/src/tui/tui.test.ts
+++ b/src/tui/tui.test.ts
@@ -6,9 +6,9 @@ import { MAX_TIMER_TIMEOUT_MS } from "../infra/parse-finite-number.js";
 import { MALFORMED_STREAMING_FRAGMENT_ERROR_MESSAGE } from "../shared/assistant-error-format.js";
 import { withEnv } from "../test-utils/env.js";
 import { getSlashCommands, parseCommand } from "./commands.js";
+import { canSubmitTuiChatMessage } from "./tui-submit.js";
 import {
   createBackspaceDeduper,
-  canSubmitTuiChatMessage,
   createDeferredTuiFinish,
   drainAndStopTuiSafely,
   installTuiTerminalLossExitHandler,

--- a/src/tui/tui.test.ts
+++ b/src/tui/tui.test.ts
@@ -139,6 +139,15 @@ describe("canSubmitTuiChatMessage", () => {
     ).toBe(true);
   });
 
+  it("blocks message submit while disconnected so the editor preserves the draft", () => {
+    expect(
+      canSubmitTuiChatMessage({
+        isConnected: false,
+        message: "send after reconnect",
+      }),
+    ).toBe(false);
+  });
+
   it("allows stop text while a run is active", () => {
     expect(
       canSubmitTuiChatMessage({

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -415,11 +415,15 @@ export async function drainAndStopTuiSafely(tui: DrainableTui): Promise<void> {
 }
 
 export function canSubmitTuiChatMessage(params: {
+  isConnected?: boolean;
   activeChatRunId?: string | null;
   pendingChatRunId?: string | null;
   pendingOptimisticUserMessage?: boolean;
   message?: string;
 }): boolean {
+  if (params.isConnected === false) {
+    return false;
+  }
   const stopText = params.message ? isChatStopCommandText(params.message) : false;
   if (stopText && (params.activeChatRunId || params.pendingChatRunId)) {
     return true;
@@ -1463,13 +1467,23 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
   updateAutocompleteProvider();
   const canSubmitChatMessage = (message: string) =>
     canSubmitTuiChatMessage({
+      isConnected: state.isConnected,
       activeChatRunId: state.activeChatRunId,
       pendingChatRunId: state.pendingChatRunId,
       pendingOptimisticUserMessage: state.pendingOptimisticUserMessage,
       message,
     });
   const notifyBlockedChatSubmit = () => {
-    addBlockedChatSubmitNotice(chatLog);
+    if (state.isConnected) {
+      addBlockedChatSubmitNotice(chatLog);
+    } else {
+      chatLog.addSystem(
+        opts.local
+          ? "local runtime not ready — message not sent"
+          : "not connected to gateway — message not sent",
+      );
+      setActivityStatus("disconnected");
+    }
     tui.requestRender();
   };
   const notifySubmitError = (action: TuiSubmitAction, error: unknown) => {

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -17,7 +17,6 @@ import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/st
 import type { CommandEntry } from "../../packages/gateway-protocol/src/index.js";
 import { resolveAgentIdByWorkspacePath, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { getRuntimeConfig, type OpenClawConfig } from "../config/config.js";
-import { isChatStopCommandText } from "../gateway/chat-abort.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { tryProcessCwd } from "../infra/safe-cwd.js";
 import { registerUncaughtExceptionHandler } from "../infra/unhandled-rejections.js";
@@ -62,6 +61,7 @@ import { createTuiPluginApprovalController } from "./tui-plugin-approvals.js";
 import { createSessionActions } from "./tui-session-actions.js";
 import { TUI_SESSION_LOOKUP_LIMIT } from "./tui-session-list-policy.js";
 import {
+  canSubmitTuiChatMessage,
   createEditorSubmitHandler,
   createSubmitBurstCoalescer,
   shouldEnableWindowsGitBashPasteFallback,
@@ -412,23 +412,6 @@ export async function drainAndStopTuiSafely(tui: DrainableTui): Promise<void> {
     }
   }
   stopTuiSafely(() => tui.stop());
-}
-
-export function canSubmitTuiChatMessage(params: {
-  isConnected?: boolean;
-  activeChatRunId?: string | null;
-  pendingChatRunId?: string | null;
-  pendingOptimisticUserMessage?: boolean;
-  message?: string;
-}): boolean {
-  if (params.isConnected === false) {
-    return false;
-  }
-  const stopText = params.message ? isChatStopCommandText(params.message) : false;
-  if (stopText && (params.activeChatRunId || params.pendingChatRunId)) {
-    return true;
-  }
-  return !params.pendingChatRunId && params.pendingOptimisticUserMessage !== true;
 }
 
 const TUI_BUSY_ACTIVITY_STATUSES = new Set([


### PR DESCRIPTION
Related: #86205

## What Problem This Solves

Fixes an issue where TUI users could reconnect after a Gateway restart, see an idle status, and still have every new prompt rejected as busy when the submit-registration event was missed during the disconnect.

Also fixes disconnected submits clearing the editor even though the TUI reports that the message was not sent.

## Why This Change Was Made

Authoritative session history now releases a pending submit admission only after it proves that the matching optimistic user message was persisted. Unmatched pending submits remain guarded. Normal message submission also stops at the editor admission gate while disconnected, preserving the typed draft while slash commands remain available.

This is AI-assisted work. I reviewed the state transitions, live behavior, and generated patch.

## User Impact

After a Gateway restart, the TUI accepts prompts again once persisted history reconciles the interrupted submit. If a user presses Enter while disconnected, the unsent text remains in the editor for retry after reconnect.

## Evidence

- Live pre-fix Crabbox/tmux reproduction: an interrupted submit left the reconnected idle TUI in the busy gate; a disconnected submit then printed the not-connected notice and erased the draft (`run_7ed133941888`).
- Live post-fix Crabbox/tmux stress: real OpenAI API key, direct Responses API calls, model switches between `openai/gpt-5.2` and `openai/gpt-5.4`, Gateway stop/restart during submission, and terminal sizes `40x8`, `200x60`, `60x12`, `120x35`, and `80x24`. Result: both model calls rendered, reconnect accepted a new prompt, disconnected draft remained, and every resize kept the TUI pane alive (`run_fa1411a91394`).
- Redacted Gateway transport proof: both models issued `POST https://api.openai.com/v1/responses` and returned HTTP 200 (`run_5b733c94b9e2`).
- Live model-picker resize and settings-overlay checks passed in tmux (`run_30753833906a`, `run_7dd6a1635104`).
- Focused remote tests: `pnpm test src/tui/tui-session-actions.test.ts src/tui/tui.test.ts src/tui/tui.submit-handler.test.ts` — 126 passed. Targeted `oxfmt --check` passed (`run_58646b5ac576`).
- Remote `pnpm build` passed (`run_9b7361be48ba`).
- CI surfaced the TypeScript LOC ratchet on the two oversized legacy modules. The follow-up moved submit-state helpers into the focused 215-line `tui-submit.ts` owner; both legacy modules now shrink versus the CI base. Testbox Actions run `29306500475` repeated all 126 tests, targeted format, and the exact LOC ratchet successfully.
- `.agents/skills/autoreview/scripts/autoreview --mode local` — clean before and after the LOC refactor, no accepted/actionable findings.
- `git diff --check` — clean.

Known gap: no separate visual recording was retained; the tmux assertions and redacted provider transport logs are the live proof.
