### PR TITLE
fix(ui): stop Raw config editor asking users to switch to Raw

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Control UI raw config warning:** show form-editor safety guidance only while Form mode is active, removing the contradictory instruction from the Raw editor. Fixes #107106.
 - **ClawHub plugin API ranges:** delegate each supported comparator to `semver` so tilde, partial-wildcard, and prerelease caret bounds are correct while preserving OpenClaw version normalization and the existing restricted range grammar. (#106877)
 - **Web Readability relative links:** seed parsed documents with the request URL so article links resolve correctly while removing the plugin's duplicate lazy-loader facade. (#106860)
 - **Browser auto-routing:** fall back to the Gateway host when an implicitly selected browser node reports that its control host is unreachable, while preserving explicit node pins and ambiguous action failures.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Control UI raw config warning:** show form-editor safety guidance only while Form mode is active, removing the contradictory instruction from the Raw editor. Fixes #107106.
 - **ClawHub plugin API ranges:** delegate each supported comparator to `semver` so tilde, partial-wildcard, and prerelease caret bounds are correct while preserving OpenClaw version normalization and the existing restricted range grammar. (#106877)
 - **Web Readability relative links:** seed parsed documents with the request URL so article links resolve correctly while removing the plugin's duplicate lazy-loader facade. (#106860)
 - **Browser auto-routing:** fall back to the Gateway host when an implicitly selected browser node reports that its control host is unreachable, while preserving explicit node pins and ambiguous action failures.

--- a/ui/src/pages/config/view.browser.test.ts
+++ b/ui/src/pages/config/view.browser.test.ts
@@ -336,6 +336,34 @@ describe("config view", () => {
     expect(onFormModeChange).toHaveBeenCalledWith("raw");
   });
 
+  it("shows the form safety warning only in form mode", () => {
+    const container = document.createElement("div");
+    const props = {
+      ...baseProps(),
+      schema: {
+        type: "object",
+        properties: {
+          lastTouchedAt: {
+            anyOf: [{ type: "string" }, {}],
+          },
+        },
+      },
+      formValue: { lastTouchedAt: "2026-07-13T00:00:00.000Z" },
+      originalValue: { lastTouchedAt: "2026-07-13T00:00:00.000Z" },
+    };
+
+    render(renderConfig({ ...props, formMode: "form" }), container);
+    expect(normalizedText(container)).toContain(
+      "Your config contains fields the form editor can't safely represent. Use Raw mode to edit those entries.",
+    );
+
+    render(renderConfig({ ...props, formMode: "raw" }), container);
+    expect(normalizedText(container)).not.toContain(
+      "Your config contains fields the form editor can't safely represent. Use Raw mode to edit those entries.",
+    );
+    expect(container.querySelector(".config-raw-field")).not.toBeNull();
+  });
+
   it("forces Form mode and disables Raw mode when raw text is unavailable", () => {
     const onFormModeChange = vi.fn();
     const { container } = renderConfigView({

--- a/ui/src/pages/config/view.ts
+++ b/ui/src/pages/config/view.ts
@@ -1941,6 +1941,13 @@ export function renderConfig(props: ConfigProps) {
                 : nothing
               : formMode === "form"
                 ? html`
+                    ${formUnsafe && showModeToggle && rawAvailable
+                      ? html`
+                          <div class="callout info" style="margin-bottom: 12px">
+                            ${t("configView.formUnsafe")}
+                          </div>
+                        `
+                      : nothing}
                     ${showAppearanceOnRoot ? renderAppearanceSection(props) : nothing}
                     ${props.schemaLoading
                       ? html`
@@ -1997,13 +2004,6 @@ export function renderConfig(props: ConfigProps) {
                     );
                     const blurred = sensitiveCount > 0 && !viewState.rawRevealed;
                     return html`
-                      ${formUnsafe
-                        ? html`
-                            <div class="callout info" style="margin-bottom: 12px">
-                              ${t("configView.formUnsafe")}
-                            </div>
-                          `
-                        : nothing}
                       <div class="field config-raw-field">
                         <span style="display:flex;align-items:center;gap:8px;">
                           ${t("configView.rawConfig")}


### PR DESCRIPTION
Closes #107106

## What Problem This Solves

Fixes an issue where users who switched the advanced config editor to Raw mode still saw a warning telling them to use Raw mode for unsupported Form fields.

## Why This Change Was Made

The form-safety callout now renders only in Form mode, and only when Raw mode is available. Field-level unsupported-schema guidance remains in Form mode, while Raw mode keeps its existing sensitive-value redaction guard.

## User Impact

The advanced config editor no longer displays contradictory guidance after users follow its instruction to switch to Raw mode.

## Evidence

- Regression test: `corepack pnpm test ui/src/pages/config/view.browser.test.ts` — 31 passed.
- Changed-surface gate: `corepack pnpm check:changed` — passed on Blacksmith Testbox.
- Existing-profile Chrome validation: Form warning visible; Raw warning absent; redaction guard intact; returning to Form restores the warning.
- Before: reported screenshot in #107106.
- After: screenshot attachment will be added before merge.

AI-assisted: yes. Codex implemented and validated the change under maintainer supervision.
