### PR TITLE
refactor(agents): extract attempt prompt phase

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt-prompt-phase.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-phase.test.ts
@@ -1,0 +1,338 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  beforeAgentRun: vi.fn(),
+  dispatchPrompt: vi.fn(),
+  handlePromptError: vi.fn(),
+  handleMidTurnPrecheck: vi.fn(),
+  prepareGooglePromptCache: vi.fn(),
+  preparePromptAssembly: vi.fn(),
+  preparePromptContext: vi.fn(),
+  releasePendingSteering: vi.fn(),
+  removeTrailingPrecheckError: vi.fn(),
+  resolveApiKey: vi.fn(),
+  debug: vi.fn(),
+  warn: vi.fn(),
+}));
+
+vi.mock("../../subagent-registry.js", () => ({
+  releasePendingAgentSteeringItems: mocks.releasePendingSteering,
+}));
+vi.mock("../google-prompt-cache.js", () => ({
+  prepareGooglePromptCacheStreamFn: mocks.prepareGooglePromptCache,
+}));
+vi.mock("../logger.js", () => ({
+  log: { debug: mocks.debug, warn: mocks.warn },
+}));
+vi.mock("../stream-resolution.js", () => ({
+  resolveEmbeddedAgentApiKey() {
+    return mocks.resolveApiKey();
+  },
+}));
+vi.mock("./attempt-before-agent-run.js", () => ({
+  runEmbeddedAttemptBeforeAgentRun: mocks.beforeAgentRun,
+}));
+vi.mock("./attempt-prompt-assembly.js", () => ({
+  prepareEmbeddedAttemptPromptAssembly: mocks.preparePromptAssembly,
+}));
+vi.mock("./attempt-prompt-context.js", () => ({
+  prepareEmbeddedAttemptPromptContext: mocks.preparePromptContext,
+}));
+vi.mock("./attempt-prompt-dispatch.js", () => ({
+  dispatchEmbeddedAttemptPrompt: mocks.dispatchPrompt,
+}));
+vi.mock("./attempt-prompt-error.js", () => ({
+  handleEmbeddedAttemptPromptError: mocks.handlePromptError,
+}));
+vi.mock("./attempt-prompt-preflight.js", () => ({
+  handleEmbeddedAttemptMidTurnPrecheck: mocks.handleMidTurnPrecheck,
+}));
+vi.mock("./attempt-transcript-helpers.js", () => ({
+  removeTrailingMidTurnPrecheckAssistantError: mocks.removeTrailingPrecheckError,
+}));
+
+import { runEmbeddedAttemptPromptPhase } from "./attempt-prompt-phase.js";
+
+type PromptPhaseInput = Parameters<typeof runEmbeddedAttemptPromptPhase>[0];
+type PromptPhaseState = ReturnType<PromptPhaseInput["lifecycle"]["readState"]>;
+type AssemblyCall = {
+  setLeasedSteering: (lease: { leaseId: string; runIds: string[] }) => void;
+};
+type DispatchCall = {
+  getCompactionReserveTokens: () => number;
+  publishState: (state: PromptPhaseState & { skipPromptSubmission: boolean }) => void;
+  state: PromptPhaseState & { skipPromptSubmission: boolean };
+  submission: {
+    onFinalPromptText: (prompt: string) => void;
+    onSteeringAcknowledged: () => void;
+  };
+};
+type PromptErrorCall = {
+  error: unknown;
+  markYieldAborted: () => void;
+  releaseLeasedSteering: (error?: unknown) => void;
+  yieldAbortSettled: Promise<void> | null;
+  yieldDetected: boolean;
+  yieldMessage: string | null;
+};
+
+function createFixture() {
+  const order: string[] = [];
+  const state: PromptPhaseState = {
+    contextBudgetStatus: undefined,
+    preflightRecovery: undefined,
+    promptError: null,
+    promptErrorSource: null,
+  };
+  const yieldState = {
+    yieldAbortSettled: null as Promise<void> | null,
+    yieldDetected: false,
+    yieldMessage: null as string | null,
+  };
+  let prePromptMessageCount = 1;
+
+  const setPrePromptMessageCount = vi.fn((count: number) => {
+    prePromptMessageCount = count;
+  });
+  const setPromptCacheChangesForTurn = vi.fn();
+  const setFinalPromptText = vi.fn();
+  const markBeforeAgentRunBlocked = vi.fn();
+  const markYieldAborted = vi.fn(() => {
+    order.push("yield-aborted");
+  });
+  const stopAcceptingSteerMessages = vi.fn(() => {
+    order.push("stop-steering");
+  });
+
+  mocks.preparePromptAssembly.mockImplementation(async (input: AssemblyCall) => {
+    order.push("assembly");
+    const lease = { leaseId: "lease-1", runIds: ["run-1"] };
+    input.setLeasedSteering(lease);
+    return {
+      hookCtx: {},
+      promptCacheChangesForTurn: [],
+      leasedSteering: lease,
+      transcriptLeafId: "leaf-1",
+    };
+  });
+  mocks.preparePromptContext.mockImplementation(() => {
+    order.push("context");
+    return {
+      aggregatePressureEngaged: false,
+      contextTokenBudget: 32_000,
+      currentUserTimestampOverride: { timestamp: 123, text: "hello" },
+      effectivePrompt: "hello",
+      hookMessagesForCurrentPrompt: [],
+      llmBoundaryPromptForPrecheck: "hello",
+      prePromptMessageCount: 2,
+      promptForModel: "hello",
+      promptForSession: "hello",
+      promptSubmission: { prompt: "hello", runtimeOnly: false },
+      promptToolResultAggregateMaxChars: 2_000,
+      promptToolResultMaxChars: 1_000,
+      runtimeContextMessageForCurrentTurn: undefined,
+      systemPromptForHook: "system",
+    };
+  });
+  mocks.beforeAgentRun.mockImplementation(async () => {
+    order.push("before-agent-run");
+    return undefined;
+  });
+  mocks.resolveApiKey.mockResolvedValue("test-key");
+  mocks.prepareGooglePromptCache.mockImplementation(async () => {
+    order.push("google-cache");
+    return undefined;
+  });
+  mocks.dispatchPrompt.mockImplementation(async (input: DispatchCall) => {
+    order.push("dispatch");
+    expect(input.getCompactionReserveTokens()).toBe(77);
+    input.submission.onFinalPromptText("hello");
+    input.submission.onSteeringAcknowledged();
+    const nextState = { ...input.state, skipPromptSubmission: false };
+    input.publishState(nextState);
+    return nextState;
+  });
+
+  const activeSession = {
+    messages: [],
+    agent: {
+      state: { messages: [] },
+      streamFn: vi.fn(),
+    },
+  };
+  const sessionManager = {
+    appendCustomEntry: vi.fn(),
+    getEntries: vi.fn(() => []),
+  };
+  const sessionLockController = {
+    waitForSessionEvents: vi.fn(async () => undefined),
+  };
+  const input = {
+    attempt: {
+      model: { id: "model-1", provider: "test" },
+      modelId: "model-1",
+      provider: "test",
+      runId: "run-1",
+      sessionId: "session-1",
+    },
+    activeSession,
+    sessionManager,
+    sessionLockController,
+    withOwnedSessionWriteLock: async <T>(operation: () => Promise<T> | T) => await operation(),
+    getCompactionReserveTokens: () => 77,
+    assembly: {
+      hookRunner: null,
+      hookAgentId: "main",
+      diagnosticTrace: {},
+      isRawModelRun: false,
+      sessionAgentId: "main",
+      runtimeModel: "model-1",
+      systemPromptText: "system",
+      setActiveSessionSystemPrompt: vi.fn(),
+      cache: {},
+    },
+    context: {
+      includeBoundaryTimestamp: false,
+      isRawModelRun: false,
+      sessionAgentId: "main",
+      setActiveSessionSystemPrompt: vi.fn(),
+      systemPromptText: "system",
+      toolResultPromptProjectionState: {},
+    },
+    execution: {
+      effectiveFsWorkspaceOnly: false,
+      effectiveWorkspace: "/tmp/workspace",
+      sandbox: null,
+    },
+    googlePromptCache: {
+      extraParams: {},
+      signal: new AbortController().signal,
+    },
+    observation: {
+      cacheTrace: null,
+      diagnosticTrace: {},
+      effectiveTools: [],
+      hookAgentId: "main",
+      hookRunner: null,
+      isRawModelRun: false,
+      runTrace: {},
+      streamStrategy: "default",
+      systemPromptText: "system",
+      toolSearchCompacted: false,
+      tools: [],
+      trajectoryRecorder: null,
+      transport: "sse",
+      uncompactedEffectiveTools: [],
+    },
+    preflight: {
+      contextEngineAssemblySucceeded: false,
+      contextEnginePromptAuthority: "assembled",
+      includeBoundaryTimestamp: false,
+      sessionAgentId: "main",
+    },
+    submission: {
+      promptActiveSession: vi.fn(),
+      sessionPromptState: {},
+      toolResultPromptProjectionState: {},
+      trajectoryRecorder: null,
+    },
+    lifecycle: {
+      readState: () => state,
+      writeState: (nextState: PromptPhaseState) => Object.assign(state, nextState),
+      getPrePromptMessageCount: () => prePromptMessageCount,
+      setPrePromptMessageCount,
+      setCurrentUserTimestampOverride: vi.fn(),
+      setPromptCacheChangesForTurn,
+      setFinalPromptText,
+      markBeforeAgentRunBlocked,
+      markYieldAborted,
+      readYieldState: () => yieldState,
+      stopAcceptingSteerMessages,
+      takePendingMidTurnPrecheckRequest: () => undefined,
+    },
+  } as unknown as PromptPhaseInput;
+
+  return {
+    input,
+    markYieldAborted,
+    order,
+    setFinalPromptText,
+    setPrePromptMessageCount,
+    setPromptCacheChangesForTurn,
+    state,
+    yieldState,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("runEmbeddedAttemptPromptPhase", () => {
+  it("runs prompt work in phase order and publishes prompt outputs", async () => {
+    const fixture = createFixture();
+
+    await expect(runEmbeddedAttemptPromptPhase(fixture.input)).resolves.toEqual({
+      promptStartedAt: expect.any(Number),
+    });
+
+    expect(fixture.order).toEqual([
+      "assembly",
+      "context",
+      "before-agent-run",
+      "google-cache",
+      "dispatch",
+      "stop-steering",
+    ]);
+    expect(fixture.setPrePromptMessageCount).toHaveBeenCalledWith(2);
+    expect(fixture.setPromptCacheChangesForTurn).toHaveBeenCalledWith([]);
+    expect(fixture.setFinalPromptText).toHaveBeenCalledWith("hello");
+    expect(mocks.dispatchPrompt).toHaveBeenCalledWith(
+      expect.objectContaining({
+        observation: expect.objectContaining({ transcriptLeafId: "leaf-1" }),
+        submission: expect.objectContaining({
+          leasedSteering: { leaseId: "lease-1", runIds: ["run-1"] },
+          transcriptLeafId: "leaf-1",
+        }),
+      }),
+    );
+    expect(mocks.releasePendingSteering).not.toHaveBeenCalled();
+  });
+
+  it("reads yield state after submission fails and publishes abort state before recovery", async () => {
+    const fixture = createFixture();
+    const submissionError = new Error("submission failed");
+    const yieldAbortSettled = Promise.resolve();
+    mocks.dispatchPrompt.mockImplementation(async () => {
+      fixture.order.push("dispatch");
+      fixture.yieldState.yieldDetected = true;
+      fixture.yieldState.yieldAbortSettled = yieldAbortSettled;
+      fixture.yieldState.yieldMessage = "yield context";
+      throw submissionError;
+    });
+    mocks.handlePromptError.mockImplementation(async (input: PromptErrorCall) => {
+      fixture.order.push("prompt-error");
+      expect(input.yieldDetected).toBe(true);
+      expect(input.yieldAbortSettled).toBe(yieldAbortSettled);
+      expect(input.yieldMessage).toBe("yield context");
+      input.releaseLeasedSteering(input.error);
+      input.markYieldAborted();
+      return {};
+    });
+
+    await expect(runEmbeddedAttemptPromptPhase(fixture.input)).resolves.toEqual({
+      promptStartedAt: expect.any(Number),
+    });
+
+    expect(fixture.order.slice(-4)).toEqual([
+      "dispatch",
+      "prompt-error",
+      "yield-aborted",
+      "stop-steering",
+    ]);
+    expect(fixture.markYieldAborted).toHaveBeenCalledOnce();
+    expect(mocks.releasePendingSteering).toHaveBeenCalledWith(
+      expect.objectContaining({ leaseId: "lease-1", runIds: ["run-1"] }),
+    );
+  });
+});

--- a/src/agents/embedded-agent-runner/run/attempt-prompt-phase.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-phase.ts
@@ -1,0 +1,314 @@
+/** Runs prompt assembly, admission, submission, and prompt-local recovery. */
+import { formatErrorMessage } from "../../../infra/errors.js";
+import { releasePendingAgentSteeringItems } from "../../subagent-registry.js";
+import { prepareGooglePromptCacheStreamFn } from "../google-prompt-cache.js";
+import { log } from "../logger.js";
+import { resolveEmbeddedAgentApiKey } from "../stream-resolution.js";
+import { runEmbeddedAttemptBeforeAgentRun } from "./attempt-before-agent-run.js";
+import { prepareEmbeddedAttemptPromptAssembly } from "./attempt-prompt-assembly.js";
+import { prepareEmbeddedAttemptPromptContext } from "./attempt-prompt-context.js";
+import { dispatchEmbeddedAttemptPrompt } from "./attempt-prompt-dispatch.js";
+import { handleEmbeddedAttemptPromptError } from "./attempt-prompt-error.js";
+import { handleEmbeddedAttemptMidTurnPrecheck } from "./attempt-prompt-preflight.js";
+import { removeTrailingMidTurnPrecheckAssistantError } from "./attempt-transcript-helpers.js";
+import type { MidTurnPrecheckRequest } from "./midturn-precheck.js";
+import { PREEMPTIVE_OVERFLOW_ERROR_TEXT } from "./preemptive-compaction.js";
+
+type PromptAssemblyInput = Parameters<typeof prepareEmbeddedAttemptPromptAssembly>[0];
+type PromptAssemblyResult = Awaited<ReturnType<typeof prepareEmbeddedAttemptPromptAssembly>>;
+type PromptContextInput = Parameters<typeof prepareEmbeddedAttemptPromptContext>[0];
+type PromptContextResult = ReturnType<typeof prepareEmbeddedAttemptPromptContext>;
+type PromptDispatchInput = Parameters<typeof dispatchEmbeddedAttemptPrompt>[0];
+type PromptErrorInput = Parameters<typeof handleEmbeddedAttemptPromptError>[0];
+type BeforeAgentRunOutcome = NonNullable<
+  Awaited<ReturnType<typeof runEmbeddedAttemptBeforeAgentRun>>
+>;
+type PromptPhaseState = Omit<PromptDispatchInput["state"], "skipPromptSubmission">;
+
+type PromptAssemblyPhaseInput = Omit<
+  PromptAssemblyInput,
+  "attempt" | "activeSession" | "sessionManager" | "setLeasedSteering"
+>;
+type PromptContextPhaseInput = Omit<
+  PromptContextInput,
+  "attempt" | "messages" | "prompt" | "replaceSessionMessages"
+>;
+type PromptExecutionPhaseInput = Omit<PromptDispatchInput["execution"], "sessionLockController">;
+type PromptObservationPhaseInput = Omit<PromptDispatchInput["observation"], "transcriptLeafId">;
+type PromptPreflightPhaseInput = Omit<
+  PromptDispatchInput["preflight"],
+  "sessionManager" | "withOwnedSessionWriteLock"
+> & {
+  activeContextEngine?: PromptDispatchInput["activeContextEngine"];
+};
+type PromptSubmissionPhaseInput = Pick<
+  PromptDispatchInput["submission"],
+  | "promptActiveSession"
+  | "sessionPromptState"
+  | "toolResultPromptProjectionState"
+  | "trajectoryRecorder"
+>;
+
+export async function runEmbeddedAttemptPromptPhase(input: {
+  attempt: PromptAssemblyInput["attempt"];
+  activeSession: PromptAssemblyInput["activeSession"];
+  sessionManager: PromptAssemblyInput["sessionManager"];
+  sessionLockController: PromptDispatchInput["execution"]["sessionLockController"];
+  withOwnedSessionWriteLock: PromptDispatchInput["preflight"]["withOwnedSessionWriteLock"];
+  getCompactionReserveTokens: () => number;
+  emptyExplicitToolAllowlistError?: Error;
+  assembly: PromptAssemblyPhaseInput;
+  context: PromptContextPhaseInput;
+  execution: PromptExecutionPhaseInput;
+  googlePromptCache: {
+    extraParams: Parameters<typeof prepareGooglePromptCacheStreamFn>[0]["extraParams"];
+    signal: AbortSignal;
+  };
+  observation: PromptObservationPhaseInput;
+  preflight: PromptPreflightPhaseInput;
+  submission: PromptSubmissionPhaseInput;
+  lifecycle: {
+    readState: () => PromptPhaseState;
+    writeState: (state: PromptPhaseState) => void;
+    getPrePromptMessageCount: () => number;
+    setPrePromptMessageCount: (count: number) => void;
+    setCurrentUserTimestampOverride: (
+      override: PromptContextResult["currentUserTimestampOverride"],
+    ) => void;
+    setPromptCacheChangesForTurn: (
+      changes: PromptAssemblyResult["promptCacheChangesForTurn"],
+    ) => void;
+    setFinalPromptText: (prompt: string) => void;
+    markBeforeAgentRunBlocked: (outcome: BeforeAgentRunOutcome) => void;
+    markYieldAborted: () => void;
+    readYieldState: () => Pick<
+      PromptErrorInput,
+      "yieldAbortSettled" | "yieldDetected" | "yieldMessage"
+    >;
+    stopAcceptingSteerMessages: () => void;
+    takePendingMidTurnPrecheckRequest: () => MidTurnPrecheckRequest | null | undefined;
+  };
+}): Promise<{ promptStartedAt: number }> {
+  const { activeSession, attempt, sessionManager } = input;
+  let skipPromptSubmission = false;
+  let leasedSteering: PromptAssemblyResult["leasedSteering"];
+
+  const patchState = (patch: Partial<PromptPhaseState>) => {
+    input.lifecycle.writeState({ ...input.lifecycle.readState(), ...patch });
+  };
+  const publishDispatchState = (state: PromptDispatchInput["state"]) => {
+    const { skipPromptSubmission: nextSkipPromptSubmission, ...phaseState } = state;
+    skipPromptSubmission = nextSkipPromptSubmission;
+    input.lifecycle.writeState(phaseState);
+  };
+  const releaseLeasedSteering = (error?: unknown) => {
+    if (!leasedSteering) {
+      return;
+    }
+    releasePendingAgentSteeringItems({
+      runIds: leasedSteering.runIds,
+      leaseId: leasedSteering.leaseId,
+      error: error ? formatErrorMessage(error) : undefined,
+    });
+    leasedSteering = undefined;
+  };
+  const handleMidTurnPrecheckRequest = (request: MidTurnPrecheckRequest) => {
+    const outcome = handleEmbeddedAttemptMidTurnPrecheck({
+      attempt,
+      request,
+      sessionAgentId: input.context.sessionAgentId,
+      sessionManager,
+      prePromptMessageCount: input.lifecycle.getPrePromptMessageCount(),
+      replaceSessionMessages: (messages) => {
+        activeSession.agent.state.messages = messages;
+      },
+    });
+    patchState({
+      preflightRecovery: outcome.preflightRecovery,
+      ...(outcome.promptError
+        ? { promptError: outcome.promptError, promptErrorSource: "precheck" }
+        : {}),
+    });
+  };
+
+  const promptStartedAt = Date.now();
+  if (input.emptyExplicitToolAllowlistError) {
+    patchState({
+      promptError: input.emptyExplicitToolAllowlistError,
+      promptErrorSource: "precheck",
+    });
+    skipPromptSubmission = true;
+    log.warn(`[tools] ${input.emptyExplicitToolAllowlistError.message}`);
+  }
+
+  const promptAssembly = await prepareEmbeddedAttemptPromptAssembly({
+    attempt,
+    activeSession,
+    sessionManager,
+    ...input.assembly,
+    setLeasedSteering: (lease) => {
+      leasedSteering = lease;
+    },
+  });
+  const { hookCtx, promptBuildPrependContext, promptBuildAppendContext, transcriptLeafId } =
+    promptAssembly;
+  leasedSteering = promptAssembly.leasedSteering ?? leasedSteering;
+  input.lifecycle.setPromptCacheChangesForTurn(promptAssembly.promptCacheChangesForTurn);
+
+  try {
+    const promptContext = prepareEmbeddedAttemptPromptContext({
+      attempt,
+      messages: activeSession.messages,
+      prompt: promptAssembly,
+      replaceSessionMessages: (messages) => {
+        activeSession.agent.state.messages = messages;
+      },
+      ...input.context,
+    });
+    const {
+      aggregatePressureEngaged,
+      hookMessagesForCurrentPrompt,
+      promptForModel,
+      systemPromptForHook,
+    } = promptContext;
+    input.lifecycle.setPrePromptMessageCount(promptContext.prePromptMessageCount);
+    input.lifecycle.setCurrentUserTimestampOverride(promptContext.currentUserTimestampOverride);
+    if (aggregatePressureEngaged) {
+      // Compaction and aggregate truncation both target about half the window;
+      // compact-then-truncate prevents re-hitting the same cap on the next turn.
+      patchState({
+        preflightRecovery: { route: "compact_then_truncate" },
+        promptError: new Error(PREEMPTIVE_OVERFLOW_ERROR_TEXT),
+        promptErrorSource: "precheck",
+      });
+      skipPromptSubmission = true;
+    }
+
+    const beforeAgentRunOutcome = await runEmbeddedAttemptBeforeAgentRun({
+      attempt,
+      activeSession,
+      hookContext: hookCtx,
+      hookMessages: hookMessagesForCurrentPrompt,
+      hookRunner: input.assembly.hookRunner,
+      modelPrompt: promptForModel,
+      sessionManager,
+      systemPrompt: systemPromptForHook,
+      withOwnedSessionWriteLock: input.withOwnedSessionWriteLock,
+    });
+    if (beforeAgentRunOutcome) {
+      input.lifecycle.markBeforeAgentRunBlocked(beforeAgentRunOutcome);
+      patchState({
+        promptError: beforeAgentRunOutcome.promptError,
+        promptErrorSource: "hook:before_agent_run",
+      });
+      skipPromptSubmission = true;
+    }
+
+    if (!skipPromptSubmission) {
+      const { resolvedApiKey } = attempt;
+      const googlePromptCacheStreamFn = await prepareGooglePromptCacheStreamFn({
+        apiKey: await resolveEmbeddedAgentApiKey({
+          provider: attempt.provider,
+          resolvedApiKey,
+          authStorage: attempt.authStorage,
+        }),
+        extraParams: input.googlePromptCache.extraParams,
+        model: attempt.model,
+        modelId: attempt.modelId,
+        provider: attempt.provider,
+        sessionManager: {
+          appendCustomEntry: async (customType, data) => {
+            await input.withOwnedSessionWriteLock(() => {
+              sessionManager.appendCustomEntry(customType, data);
+            });
+          },
+          getEntries: () => sessionManager.getEntries(),
+        },
+        signal: input.googlePromptCache.signal,
+        streamFn: activeSession.agent.streamFn,
+        systemPrompt: input.assembly.systemPromptText,
+      });
+      if (googlePromptCacheStreamFn) {
+        activeSession.agent.streamFn = googlePromptCacheStreamFn;
+      }
+    }
+
+    const { activeContextEngine, ...preflight } = input.preflight;
+    const dispatchState = await dispatchEmbeddedAttemptPrompt({
+      attempt,
+      ...(activeContextEngine ? { activeContextEngine } : {}),
+      activeSession,
+      promptContext,
+      getCompactionReserveTokens: input.getCompactionReserveTokens,
+      publishState: publishDispatchState,
+      releaseLeasedSteering,
+      state: {
+        ...input.lifecycle.readState(),
+        skipPromptSubmission,
+      },
+      execution: {
+        ...input.execution,
+        sessionLockController: input.sessionLockController,
+      },
+      observation: {
+        ...input.observation,
+        transcriptLeafId,
+      },
+      preflight: {
+        ...preflight,
+        sessionManager,
+        withOwnedSessionWriteLock: input.withOwnedSessionWriteLock,
+      },
+      submission: {
+        ...(promptBuildAppendContext ? { appendContext: promptBuildAppendContext } : {}),
+        ...(leasedSteering ? { leasedSteering } : {}),
+        onFinalPromptText: input.lifecycle.setFinalPromptText,
+        onSteeringAcknowledged: () => {
+          leasedSteering = undefined;
+        },
+        ...(promptBuildPrependContext ? { prependContext: promptBuildPrependContext } : {}),
+        transcriptLeafId,
+        ...input.submission,
+      },
+    });
+    publishDispatchState(dispatchState);
+  } catch (error) {
+    const promptErrorOutcome = await handleEmbeddedAttemptPromptError({
+      activeSession,
+      attempt,
+      error,
+      handleMidTurnPrecheckRequest,
+      markYieldAborted: input.lifecycle.markYieldAborted,
+      releaseLeasedSteering,
+      sessionLockController: input.sessionLockController,
+      withOwnedSessionWriteLock: input.withOwnedSessionWriteLock,
+      ...input.lifecycle.readYieldState(),
+    });
+    if (promptErrorOutcome.promptFailure) {
+      patchState({
+        promptError: promptErrorOutcome.promptFailure.error,
+        promptErrorSource: promptErrorOutcome.promptFailure.source,
+      });
+    }
+  } finally {
+    input.lifecycle.stopAcceptingSteerMessages();
+    log.debug(
+      `embedded run prompt end: runId=${attempt.runId} sessionId=${attempt.sessionId} durationMs=${Date.now() - promptStartedAt}`,
+    );
+  }
+
+  const pendingMidTurnPrecheckRequest = input.lifecycle.takePendingMidTurnPrecheckRequest();
+  if (pendingMidTurnPrecheckRequest) {
+    await input.sessionLockController.waitForSessionEvents(activeSession);
+    await input.withOwnedSessionWriteLock(() => {
+      removeTrailingMidTurnPrecheckAssistantError({ activeSession, sessionManager });
+      const state = input.lifecycle.readState();
+      if (!state.preflightRecovery && state.promptErrorSource !== "precheck") {
+        patchState({ promptError: null, promptErrorSource: null });
+        handleMidTurnPrecheckRequest(pendingMidTurnPrecheckRequest);
+      }
+    });
+  }
+
+  return { promptStartedAt };
+}

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -10,7 +10,6 @@ import {
   OPENCLAW_EMBEDDED_CONTEXT_ENGINE_HOST,
 } from "../../../context-engine/host-compat.js";
 import { resolveContextEngineOwnerPluginId } from "../../../context-engine/registry.js";
-import { formatErrorMessage } from "../../../infra/errors.js";
 import type { AssistantMessage } from "../../../llm/types.js";
 import { createBundleLspToolRuntime } from "../../agent-bundle-lsp-runtime.js";
 import { materializeBundleMcpToolsForRun } from "../../agent-bundle-mcp-tools.js";
@@ -20,19 +19,16 @@ import { createCacheTrace } from "../../cache-trace.js";
 import type { AgentMessage } from "../../runtime/index.js";
 import type { guardSessionManager } from "../../session-tool-result-guard-wrapper.js";
 import type { AgentSession } from "../../sessions/index.js";
-import { releasePendingAgentSteeringItems } from "../../subagent-registry.js";
 import {
   clearToolSearchCatalog,
   type ToolSearchCatalogRef,
   type ToolSearchCatalogToolExecutor,
 } from "../../tool-search.js";
 import type { NormalizedUsage } from "../../usage.js";
-import { prepareGooglePromptCacheStreamFn } from "../google-prompt-cache.js";
 import { log } from "../logger.js";
 import type { PromptCacheBreak, PromptCacheChange } from "../prompt-cache-observability.js";
 import { clearActiveEmbeddedRun, type EmbeddedAgentQueueHandle } from "../runs.js";
 import { getEmbeddedSessionPromptState } from "../session-prompt-state.js";
-import { resolveEmbeddedAgentApiKey } from "../stream-resolution.js";
 import { flushPendingToolResultsAfterIdle } from "../wait-for-idle-before-flush.js";
 import { abortable as abortableWithSignal } from "./abortable.js";
 import {
@@ -40,16 +36,11 @@ import {
   createEmbeddedAttemptRunAbort,
   type EmbeddedAttemptAbortStatePort,
 } from "./attempt-abort.js";
-import { runEmbeddedAttemptBeforeAgentRun } from "./attempt-before-agent-run.js";
 import { prepareEmbeddedAttemptBootstrap } from "./attempt-bootstrap-prepare.js";
 import { prepareEmbeddedAttemptBundleTools } from "./attempt-bundle-tools.js";
 import { installEmbeddedAttemptContextGuards } from "./attempt-context-guards.js";
 import { prepareEmbeddedAttemptHistory } from "./attempt-history-prepare.js";
-import { prepareEmbeddedAttemptPromptAssembly } from "./attempt-prompt-assembly.js";
-import { prepareEmbeddedAttemptPromptContext } from "./attempt-prompt-context.js";
-import { dispatchEmbeddedAttemptPrompt } from "./attempt-prompt-dispatch.js";
-import { handleEmbeddedAttemptPromptError } from "./attempt-prompt-error.js";
-import { handleEmbeddedAttemptMidTurnPrecheck } from "./attempt-prompt-preflight.js";
+import { runEmbeddedAttemptPromptPhase } from "./attempt-prompt-phase.js";
 import { completeEmbeddedAttemptResult } from "./attempt-result.js";
 import { prepareEmbeddedAttemptSessionBoundary } from "./attempt-session-boundary.js";
 import { cleanupEmbeddedAttemptSessionPhase } from "./attempt-session-cleanup.js";
@@ -73,14 +64,11 @@ import { prepareEmbeddedAttemptTimeout } from "./attempt-timeout-prepare.js";
 import { prepareEmbeddedAttemptToolBase } from "./attempt-tool-base-prepare.js";
 import { prepareEmbeddedAttemptToolCatalog } from "./attempt-tool-catalog.js";
 import { prepareEmbeddedAttemptTrajectory } from "./attempt-trajectory.js";
-import { removeTrailingMidTurnPrecheckAssistantError } from "./attempt-transcript-helpers.js";
 import type { EmbeddedAttemptSessionFileOwner } from "./attempt.session-lock.js";
 import {
   queueSessionsYieldInterruptMessage,
   SESSIONS_YIELD_ABORT_REASON,
 } from "./attempt.sessions-yield.js";
-import type { MidTurnPrecheckRequest } from "./midturn-precheck.js";
-import { PREEMPTIVE_OVERFLOW_ERROR_TEXT } from "./preemptive-compaction.js";
 import { clearToolActivityRun } from "./tool-activity-heartbeat.js";
 import type { EmbeddedRunAttemptParams, EmbeddedRunAttemptResult } from "./types.js";
 
@@ -716,290 +704,129 @@ export async function runEmbeddedAttempt(
       const activeSessionManager = sessionManager;
       let preflightRecovery: EmbeddedRunAttemptResult["preflightRecovery"];
       let promptErrorSource: EmbeddedRunAttemptResult["promptErrorSource"] = null;
-      const handleMidTurnPrecheckRequest = (request: MidTurnPrecheckRequest) => {
-        const outcome = handleEmbeddedAttemptMidTurnPrecheck({
-          attempt: params,
-          request,
-          sessionAgentId,
-          sessionManager: activeSessionManager,
-          prePromptMessageCount,
-          replaceSessionMessages: (messages) => {
-            activeSession.agent.state.messages = messages;
-          },
-        });
-        preflightRecovery = outcome.preflightRecovery;
-        if (outcome.promptError) {
-          promptError = outcome.promptError;
-          promptErrorSource = "precheck";
-        }
-      };
-      let skipPromptSubmission = false;
-      let leasedSteering:
-        | {
-            leaseId: string;
-            runIds: readonly string[];
-          }
-        | undefined;
-      const releaseLeasedSteering = (error?: unknown) => {
-        if (!leasedSteering) {
-          return;
-        }
-        releasePendingAgentSteeringItems({
-          runIds: leasedSteering.runIds,
-          leaseId: leasedSteering.leaseId,
-          error: error ? formatErrorMessage(error) : undefined,
-        });
-        leasedSteering = undefined;
-      };
       try {
-        const promptStartedAt = Date.now();
-        if (emptyExplicitToolAllowlistError) {
-          promptError = emptyExplicitToolAllowlistError;
-          promptErrorSource = "precheck";
-          skipPromptSubmission = true;
-          log.warn(`[tools] ${emptyExplicitToolAllowlistError.message}`);
-        }
-
-        const promptAssembly = await prepareEmbeddedAttemptPromptAssembly({
+        const { promptStartedAt } = await runEmbeddedAttemptPromptPhase({
           attempt: params,
           activeSession,
-          sessionManager,
-          hookRunner,
-          hookAgentId,
-          diagnosticTrace,
-          isRawModelRun,
-          ...(orphanRepair ? { orphanRepair } : {}),
-          sessionAgentId,
-          runtimeModel: runtimeInfo.model,
-          systemPromptText,
-          setActiveSessionSystemPrompt,
-          setLeasedSteering: (lease) => {
-            leasedSteering = lease;
+          sessionManager: activeSessionManager,
+          sessionLockController,
+          withOwnedSessionWriteLock,
+          getCompactionReserveTokens: () => settingsManager.getCompactionReserveTokens(),
+          ...(emptyExplicitToolAllowlistError ? { emptyExplicitToolAllowlistError } : {}),
+          assembly: {
+            hookRunner,
+            hookAgentId,
+            diagnosticTrace,
+            isRawModelRun,
+            ...(orphanRepair ? { orphanRepair } : {}),
+            sessionAgentId,
+            runtimeModel: runtimeInfo.model,
+            systemPromptText,
+            setActiveSessionSystemPrompt,
+            cache: {
+              observabilityEnabled: cacheObservabilityEnabled,
+              retention: effectivePromptCacheRetention,
+              streamStrategy,
+              transport: effectiveAgentTransport,
+              toolNames: promptCacheToolNames,
+              trace: cacheTrace,
+            },
           },
-          cache: {
-            observabilityEnabled: cacheObservabilityEnabled,
-            retention: effectivePromptCacheRetention,
-            streamStrategy,
-            transport: effectiveAgentTransport,
-            toolNames: promptCacheToolNames,
-            trace: cacheTrace,
-          },
-        });
-        const { hookCtx, promptBuildPrependContext, promptBuildAppendContext, transcriptLeafId } =
-          promptAssembly;
-        leasedSteering = promptAssembly.leasedSteering ?? leasedSteering;
-        promptCacheChangesForTurn = promptAssembly.promptCacheChangesForTurn;
-
-        try {
-          const promptContext = prepareEmbeddedAttemptPromptContext({
-            attempt: params,
+          context: {
             ...(boundaryTimezone ? { boundaryTimezone } : {}),
             includeBoundaryTimestamp,
             isRawModelRun,
-            messages: activeSession.messages,
             ...(typeof preparedUserTurnMessage?.timestamp === "number"
               ? { preparedUserTurnTimestamp: preparedUserTurnMessage.timestamp }
               : {}),
-            prompt: promptAssembly,
-            replaceSessionMessages: (messages) => {
-              activeSession.agent.state.messages = messages;
-            },
             sessionAgentId,
             setActiveSessionSystemPrompt,
             ...(systemPromptReport ? { systemPromptReport } : {}),
             systemPromptText,
             toolResultPromptProjectionState,
-          });
-          const {
-            aggregatePressureEngaged,
-            hookMessagesForCurrentPrompt,
-            promptForModel,
-            systemPromptForHook,
-          } = promptContext;
-          prePromptMessageCount = promptContext.prePromptMessageCount;
-          sessionBoundary.setCurrentUserTimestampOverride(
-            promptContext.currentUserTimestampOverride,
-          );
-          if (aggregatePressureEngaged) {
-            // Compaction and aggregate truncation both target about half the window;
-            // compact-then-truncate prevents re-hitting the same cap on the next turn.
-            preflightRecovery = { route: "compact_then_truncate" };
-            promptError = new Error(PREEMPTIVE_OVERFLOW_ERROR_TEXT);
-            promptErrorSource = "precheck";
-            skipPromptSubmission = true;
-          }
-
-          const beforeAgentRunOutcome = await runEmbeddedAttemptBeforeAgentRun({
-            attempt: params,
-            activeSession,
-            hookContext: hookCtx,
-            hookMessages: hookMessagesForCurrentPrompt,
+          },
+          execution: {
+            effectiveFsWorkspaceOnly,
+            effectiveWorkspace,
+            sandbox,
+          },
+          googlePromptCache: {
+            extraParams: effectiveExtraParams,
+            signal: runAbortController.signal,
+          },
+          observation: {
+            cacheTrace,
+            diagnosticTrace,
+            effectiveTools,
+            hookAgentId,
             hookRunner,
-            modelPrompt: promptForModel,
-            sessionManager: activeSessionManager,
-            systemPrompt: systemPromptForHook,
-            withOwnedSessionWriteLock,
-          });
-          if (beforeAgentRunOutcome) {
-            beforeAgentRunBlocked = true;
-            beforeAgentRunBlockedBy = beforeAgentRunOutcome.blockedBy;
-            promptError = beforeAgentRunOutcome.promptError;
-            promptErrorSource = "hook:before_agent_run";
-            skipPromptSubmission = true;
-          }
-
-          if (!skipPromptSubmission) {
-            const googlePromptCacheStreamFn = await prepareGooglePromptCacheStreamFn({
-              apiKey: await resolveEmbeddedAgentApiKey({
-                provider: params.provider,
-                resolvedApiKey: params.resolvedApiKey,
-                authStorage: params.authStorage,
-              }),
-              extraParams: effectiveExtraParams,
-              model: params.model,
-              modelId: params.modelId,
-              provider: params.provider,
-              sessionManager: {
-                appendCustomEntry: async (customType, data) => {
-                  await withOwnedSessionWriteLock(() => {
-                    activeSessionManager.appendCustomEntry(customType, data);
-                  });
-                },
-                getEntries: () => activeSessionManager.getEntries(),
-              },
-              signal: runAbortController.signal,
-              streamFn: activeSession.agent.streamFn,
-              systemPrompt: systemPromptText,
-            });
-            if (googlePromptCacheStreamFn) {
-              activeSession.agent.streamFn = googlePromptCacheStreamFn;
-            }
-          }
-
-          ({
-            contextBudgetStatus,
-            preflightRecovery,
-            promptError,
-            promptErrorSource,
-            skipPromptSubmission,
-          } = await dispatchEmbeddedAttemptPrompt({
-            attempt: params,
+            isRawModelRun,
+            runTrace,
+            streamStrategy,
+            systemPromptText,
+            toolSearchCompacted: toolSearch.compacted,
+            tools,
+            trajectoryRecorder,
+            transport: effectiveAgentTransport,
+            uncompactedEffectiveTools,
+          },
+          preflight: {
             ...(activeContextEngine ? { activeContextEngine } : {}),
-            activeSession,
-            promptContext,
-            getCompactionReserveTokens: () => settingsManager.getCompactionReserveTokens(),
-            publishState: (state) => {
-              contextBudgetStatus = state.contextBudgetStatus;
-              preflightRecovery = state.preflightRecovery;
-              promptError = state.promptError;
-              promptErrorSource = state.promptErrorSource;
-              skipPromptSubmission = state.skipPromptSubmission;
-            },
-            releaseLeasedSteering,
-            state: {
+            contextEngineAssemblySucceeded,
+            contextEnginePromptAuthority,
+            includeBoundaryTimestamp,
+            sessionAgentId,
+            ...(boundaryTimezone ? { timezone: boundaryTimezone } : {}),
+            ...(unwindowedContextEngineMessagesForPrecheck
+              ? { unwindowedContextEngineMessagesForPrecheck }
+              : {}),
+          },
+          submission: {
+            promptActiveSession,
+            sessionPromptState,
+            toolResultPromptProjectionState,
+            trajectoryRecorder,
+          },
+          lifecycle: {
+            readState: () => ({
               contextBudgetStatus,
               preflightRecovery,
               promptError,
               promptErrorSource,
-              skipPromptSubmission,
+            }),
+            writeState: (state) => {
+              contextBudgetStatus = state.contextBudgetStatus;
+              preflightRecovery = state.preflightRecovery;
+              promptError = state.promptError;
+              promptErrorSource = state.promptErrorSource;
             },
-            execution: {
-              effectiveFsWorkspaceOnly,
-              effectiveWorkspace,
-              sandbox,
-              sessionLockController,
+            getPrePromptMessageCount: () => prePromptMessageCount,
+            setPrePromptMessageCount: (count) => {
+              prePromptMessageCount = count;
             },
-            observation: {
-              cacheTrace,
-              diagnosticTrace,
-              effectiveTools,
-              hookAgentId,
-              hookRunner,
-              isRawModelRun,
-              runTrace,
-              streamStrategy,
-              systemPromptText,
-              toolSearchCompacted: toolSearch.compacted,
-              tools,
-              trajectoryRecorder,
-              transcriptLeafId,
-              transport: effectiveAgentTransport,
-              uncompactedEffectiveTools,
+            setCurrentUserTimestampOverride: (override) => {
+              sessionBoundary.setCurrentUserTimestampOverride(override);
             },
-            preflight: {
-              contextEngineAssemblySucceeded,
-              contextEnginePromptAuthority,
-              includeBoundaryTimestamp,
-              sessionAgentId,
-              sessionManager: activeSessionManager,
-              ...(boundaryTimezone ? { timezone: boundaryTimezone } : {}),
-              ...(unwindowedContextEngineMessagesForPrecheck
-                ? { unwindowedContextEngineMessagesForPrecheck }
-                : {}),
-              withOwnedSessionWriteLock,
+            setPromptCacheChangesForTurn: (changes) => {
+              promptCacheChangesForTurn = changes;
             },
-            submission: {
-              ...(promptBuildAppendContext ? { appendContext: promptBuildAppendContext } : {}),
-              ...(leasedSteering ? { leasedSteering } : {}),
-              onFinalPromptText: (prompt) => {
-                finalPromptText = prompt;
-              },
-              onSteeringAcknowledged: () => {
-                leasedSteering = undefined;
-              },
-              ...(promptBuildPrependContext ? { prependContext: promptBuildPrependContext } : {}),
-              promptActiveSession,
-              sessionPromptState,
-              toolResultPromptProjectionState,
-              trajectoryRecorder,
-              transcriptLeafId,
+            setFinalPromptText: (prompt) => {
+              finalPromptText = prompt;
             },
-          }));
-        } catch (err) {
-          const promptErrorOutcome = await handleEmbeddedAttemptPromptError({
-            activeSession,
-            attempt: params,
-            error: err,
-            handleMidTurnPrecheckRequest,
+            markBeforeAgentRunBlocked: (outcome) => {
+              beforeAgentRunBlocked = true;
+              beforeAgentRunBlockedBy = outcome.blockedBy;
+            },
             markYieldAborted: () => {
               yieldAborted = true;
               cleanupYieldAborted = true;
               aborted = false;
             },
-            releaseLeasedSteering,
-            sessionLockController,
-            withOwnedSessionWriteLock,
-            yieldAbortSettled,
-            yieldDetected,
-            yieldMessage,
-          });
-          if (promptErrorOutcome.promptFailure) {
-            promptError = promptErrorOutcome.promptFailure.error;
-            promptErrorSource = promptErrorOutcome.promptFailure.source;
-          }
-        } finally {
-          stopAcceptingSteerMessages();
-          log.debug(
-            `embedded run prompt end: runId=${params.runId} sessionId=${params.sessionId} durationMs=${Date.now() - promptStartedAt}`,
-          );
-        }
-
-        const pendingMidTurnPrecheckRequest = contextGuards.takePendingMidTurnPrecheckRequest();
-        if (pendingMidTurnPrecheckRequest) {
-          const request = pendingMidTurnPrecheckRequest;
-          await sessionLockController.waitForSessionEvents(activeSession);
-          await withOwnedSessionWriteLock(() => {
-            removeTrailingMidTurnPrecheckAssistantError({
-              activeSession,
-              sessionManager: activeSessionManager,
-            });
-            if (!preflightRecovery && promptErrorSource !== "precheck") {
-              promptError = null;
-              promptErrorSource = null;
-              handleMidTurnPrecheckRequest(request);
-            }
-          });
-        }
+            readYieldState: () => ({ yieldAbortSettled, yieldDetected, yieldMessage }),
+            stopAcceptingSteerMessages,
+            takePendingMidTurnPrecheckRequest: contextGuards.takePendingMidTurnPrecheckRequest,
+          },
+        });
 
         const afterTurn = await finalizeEmbeddedAttemptStreamPhase({
           attempt: params,


### PR DESCRIPTION
Related: #106449

## What Problem This Solves

The embedded attempt handler still owns a long, high-churn prompt lifecycle spanning assembly, hook admission, cache setup, dispatch, error recovery, yield handling, and pending precheck recovery. This keeps unrelated prompt concerns coupled inside the hot orchestration file.

## Why This Change Was Made

Extract the complete prompt lifecycle into one typed phase helper. The phase composes the prompt-dispatch helper already on main, preserves live lifecycle state through explicit ports, and leaves stream finalization in the handler.

## User Impact

No user-visible behavior change. Maintainers get a smaller attempt orchestrator and isolated prompt-phase tests, while the TypeScript LOC ratchet continues guarding both changed production files.

## Evidence

- attempt.ts: 1,221 to 1,048 lines on this base; new prompt-phase helper: 314 lines.
- Blacksmith Testbox tbx_01kxfdm8n3ds9rvbqg5hxr5rn2: 143 focused tests passed across the phase, dispatch, context, error, preflight, submit, lifecycle, and attempt suites.
- The same Testbox passed pnpm check:changed, including the LOC ratchet, core and core-test tsgo, formatting, lint, import cycles, and repository guards.
- Exact commit autoreview: clean, no accepted or actionable findings; correctness confidence 0.97.
