### PR TITLE
fix(voice-call): show ngrok errors when startup output is fragmented

### DIFF
--- a/extensions/voice-call/src/tunnel.test.ts
+++ b/extensions/voice-call/src/tunnel.test.ts
@@ -195,6 +195,65 @@ describe("voice-call tunnels", () => {
     await expect(result).rejects.toThrow("ngrok error:");
   });
 
+  it("detects ERR_NGROK marker split across stderr chunks", async () => {
+    const proc = nextProcess();
+    const result = startNgrokTunnel({ port: 3334, path: "/hook" });
+
+    // Emit the ERR_NGROK marker split across two chunks
+    proc.stderr.emit("data", Buffer.from("ERR_NG"));
+    proc.stderr.emit("data", Buffer.from("ROK_108: invalid tunnel config"));
+
+    await expect(result).rejects.toThrow("ngrok error:");
+    await expect(result).rejects.toThrow("ERR_NGROK_108");
+  });
+
+  it("detects ERR_NGROK in a large combined tail that exceeds the retention window", async () => {
+    const proc = nextProcess();
+    const result = startNgrokTunnel({ port: 3334, path: "/hook" });
+
+    // First chunk has the marker prefix only
+    proc.stderr.emit("data", Buffer.from("ERR_NG"));
+    // Second chunk completes the marker then adds noise so the combined
+    // length exceeds the 512-byte retention window.  Classify-before-truncate
+    // must detect the completed marker before the tail is sliced.
+    const tail = "ROK_108: invalid tunnel config " + "x".repeat(800);
+    proc.stderr.emit("data", Buffer.from(tail));
+
+    await expect(result).rejects.toThrow("ngrok error:");
+    await expect(result).rejects.toThrow("ERR_NGROK_108");
+  });
+
+  it("rejects with generic exit when non-ERR_NGROK stderr is split across chunks", async () => {
+    const proc = nextProcess();
+    const result = startNgrokTunnel({ port: 3334, path: "/hook" });
+
+    // Non-bind error split across chunks — must NOT match ERR_NGROK
+    proc.stderr.emit("data", Buffer.from("some erro"));
+    proc.stderr.emit("data", Buffer.from("r message"));
+
+    // Close with non-zero code — should get generic exit, not ngrok error
+    proc.close(1);
+
+    await expect(result).rejects.toThrow("ngrok exited unexpectedly with code 1");
+    await expect(result).rejects.not.toThrow("ngrok error:");
+  });
+
+  it("detects ERR_NGROK when final fragment arrives after stdout close but before stderr close", async () => {
+    // Node can deliver the final stderr chunk between 'close' events on
+    // different streams.  The combined-tail check must still fire.
+    const proc = nextProcess();
+    const result = startNgrokTunnel({ port: 3334, path: "/hook" });
+
+    proc.stderr.emit("data", Buffer.from("ERR_NG"));
+    // stdout "closes" first (in real ngrok the TCP connection may half-close)
+    proc.stdout.emit("close");
+    // stderr final fragment arrives
+    proc.stderr.emit("data", Buffer.from("ROK_108: invalid tunnel config"));
+
+    await expect(result).rejects.toThrow("ngrok error:");
+    await expect(result).rejects.toThrow("ERR_NGROK_108");
+  });
+
   it("starts Tailscale serve using the resolved tailnet DNS name", async () => {
     mocks.getTailscaleDnsName.mockResolvedValue("host.tailnet.ts.net");
     const tunnel = await startTailscaleTunnel({

--- a/extensions/voice-call/src/tunnel.test.ts
+++ b/extensions/voice-call/src/tunnel.test.ts
@@ -192,66 +192,21 @@ describe("voice-call tunnels", () => {
 
     proc.stderr.emit("data", Buffer.from("ERR_NGROK_3200: invalid auth token"));
 
-    await expect(result).rejects.toThrow("ngrok error:");
+    await expect(result).rejects.toThrow("ngrok error: ERR_NGROK_3200: invalid auth token");
   });
 
-  it("detects ERR_NGROK marker split across stderr chunks", async () => {
+  it("preserves split ngrok errors across a UTF-16-safe bounded tail", async () => {
     const proc = nextProcess();
     const result = startNgrokTunnel({ port: 3334, path: "/hook" });
+    const firstChunk = "🤖xERR_NG";
 
-    // Emit the ERR_NGROK marker split across two chunks
-    proc.stderr.emit("data", Buffer.from("ERR_NG"));
+    // A raw marker-length tail starts on the low surrogate. Production must
+    // discard that dangling half while retaining the split marker prefix.
+    expect(firstChunk.slice(-8).charCodeAt(0)).toBe(0xdd16);
+    proc.stderr.emit("data", Buffer.from(firstChunk));
     proc.stderr.emit("data", Buffer.from("ROK_108: invalid tunnel config"));
 
-    await expect(result).rejects.toThrow("ngrok error:");
-    await expect(result).rejects.toThrow("ERR_NGROK_108");
-  });
-
-  it("detects ERR_NGROK in a large combined tail that exceeds the retention window", async () => {
-    const proc = nextProcess();
-    const result = startNgrokTunnel({ port: 3334, path: "/hook" });
-
-    // First chunk has the marker prefix only
-    proc.stderr.emit("data", Buffer.from("ERR_NG"));
-    // Second chunk completes the marker then adds noise so the combined
-    // length exceeds the 512-byte retention window.  Classify-before-truncate
-    // must detect the completed marker before the tail is sliced.
-    const tail = "ROK_108: invalid tunnel config " + "x".repeat(800);
-    proc.stderr.emit("data", Buffer.from(tail));
-
-    await expect(result).rejects.toThrow("ngrok error:");
-    await expect(result).rejects.toThrow("ERR_NGROK_108");
-  });
-
-  it("rejects with generic exit when non-ERR_NGROK stderr is split across chunks", async () => {
-    const proc = nextProcess();
-    const result = startNgrokTunnel({ port: 3334, path: "/hook" });
-
-    // Non-bind error split across chunks — must NOT match ERR_NGROK
-    proc.stderr.emit("data", Buffer.from("some erro"));
-    proc.stderr.emit("data", Buffer.from("r message"));
-
-    // Close with non-zero code — should get generic exit, not ngrok error
-    proc.close(1);
-
-    await expect(result).rejects.toThrow("ngrok exited unexpectedly with code 1");
-    await expect(result).rejects.not.toThrow("ngrok error:");
-  });
-
-  it("detects ERR_NGROK when final fragment arrives after stdout close but before stderr close", async () => {
-    // Node can deliver the final stderr chunk between 'close' events on
-    // different streams.  The combined-tail check must still fire.
-    const proc = nextProcess();
-    const result = startNgrokTunnel({ port: 3334, path: "/hook" });
-
-    proc.stderr.emit("data", Buffer.from("ERR_NG"));
-    // stdout "closes" first (in real ngrok the TCP connection may half-close)
-    proc.stdout.emit("close");
-    // stderr final fragment arrives
-    proc.stderr.emit("data", Buffer.from("ROK_108: invalid tunnel config"));
-
-    await expect(result).rejects.toThrow("ngrok error:");
-    await expect(result).rejects.toThrow("ERR_NGROK_108");
+    await expect(result).rejects.toThrow("ngrok error: xERR_NGROK_108: invalid tunnel config");
   });
 
   it("starts Tailscale serve using the resolved tailnet DNS name", async () => {

--- a/extensions/voice-call/src/tunnel.ts
+++ b/extensions/voice-call/src/tunnel.ts
@@ -88,6 +88,10 @@ async function startNgrokTunnel(config: {
     let closed = false;
     let publicUrl: string | null = null;
     let outputBuffer = "";
+    // Carry a bounded stderr tail across chunks so split ERR_NGROK markers
+    // (e.g. "ERR_NG" + "ROK_108") are classified before close rejects with a
+    // generic exit message and the caller waits out the 30 s timeout.
+    let stderrTail = "";
 
     const timeout = setTimeout(() => {
       if (!resolved) {
@@ -185,16 +189,19 @@ async function startNgrokTunnel(config: {
       }
     });
     proc.stderr.on("data", (data: Buffer) => {
-      const msg = data.toString();
-      // Check for common errors
-      if (msg.includes("ERR_NGROK")) {
+      const chunk = data.toString();
+      // Classify the untruncated combined text so a cross-chunk
+      // ERR_NGROK marker (e.g. "ERR_NG" + "ROK_108") is detected.
+      const combined = stderrTail + chunk;
+      if (combined.includes("ERR_NGROK")) {
         rejectIfPending(
           `ngrok error: ${formatBoundedChildOutput(
-            appendBoundedChildOutput(emptyBoundedChildOutput(), msg),
+            appendBoundedChildOutput(emptyBoundedChildOutput(), combined),
           )}`,
           true,
         );
       }
+      stderrTail = combined.slice(-512);
     });
     listenForChildStreamErrors(proc, (stream, error) => {
       rejectIfPending(`ngrok ${stream} error: ${error.message}`, true);

--- a/extensions/voice-call/src/tunnel.ts
+++ b/extensions/voice-call/src/tunnel.ts
@@ -10,6 +10,8 @@ import {
 import { getTailscaleDnsName } from "./webhook/tailscale.js";
 
 const NGROK_LOG_BUFFER_MAX_CHARS = 16_384;
+const NGROK_ERROR_MARKER = "ERR_NGROK";
+const NGROK_STDERR_TAIL_MAX_CHARS = NGROK_ERROR_MARKER.length - 1;
 const TUNNEL_COMMAND_OUTPUT_MAX_BYTES = 16_384;
 
 function listenForChildStreamErrors(
@@ -88,9 +90,8 @@ async function startNgrokTunnel(config: {
     let closed = false;
     let publicUrl: string | null = null;
     let outputBuffer = "";
-    // Carry a bounded stderr tail across chunks so split ERR_NGROK markers
-    // (e.g. "ERR_NG" + "ROK_108") are classified before close rejects with a
-    // generic exit message and the caller waits out the 30 s timeout.
+    // Keep only enough UTF-16-safe suffix to recognize an error marker split
+    // at the next stream chunk boundary; otherwise the caller loses the code.
     let stderrTail = "";
 
     const timeout = setTimeout(() => {
@@ -189,11 +190,8 @@ async function startNgrokTunnel(config: {
       }
     });
     proc.stderr.on("data", (data: Buffer) => {
-      const chunk = data.toString();
-      // Classify the untruncated combined text so a cross-chunk
-      // ERR_NGROK marker (e.g. "ERR_NG" + "ROK_108") is detected.
-      const combined = stderrTail + chunk;
-      if (combined.includes("ERR_NGROK")) {
+      const combined = stderrTail + data.toString();
+      if (combined.includes(NGROK_ERROR_MARKER)) {
         rejectIfPending(
           `ngrok error: ${formatBoundedChildOutput(
             appendBoundedChildOutput(emptyBoundedChildOutput(), combined),
@@ -201,7 +199,7 @@ async function startNgrokTunnel(config: {
           true,
         );
       }
-      stderrTail = combined.slice(-512);
+      stderrTail = sliceUtf16Safe(combined, -NGROK_STDERR_TAIL_MAX_CHARS);
     });
     listenForChildStreamErrors(proc, (stream, error) => {
       rejectIfPending(`ngrok ${stream} error: ${error.message}`, true);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Voice Call users could receive only a generic ngrok startup failure when ngrok split an `ERR_NGROK` diagnostic across stderr chunks. The actionable ngrok error code and message were then lost.

## Why This Change Was Made

The ngrok tunnel owner now retains only the longest possible proper marker prefix between chunks, using the existing UTF-16-safe slicing helper. Classification still happens before trimming. This keeps the state bounded to eight characters, preserves complete error text, and leaves unrelated stderr and Tailscale behavior unchanged.

AI-assisted: yes.

## User Impact

Users and operators now see the original `ERR_NGROK` diagnostic even when the child process fragments it, making tunnel configuration and authentication failures directly actionable.

Release-note credit: Thanks @wahaha1223.

## Evidence

Real child-process proof used the public `startTunnel` entry point and a temporary executable named `ngrok` on `PATH`; no spawn mock or live credentials were used.

- Baseline: timed writes of `ERR_NG` then `ROK_108: invalid tunnel config` returned `ngrok exited unexpectedly with code 1`.
- Fixed: the same timed writes returned `ngrok error: ERR_NGROK_108: invalid tunnel config`.
- Negative control: timed unrelated fragments still returned `ngrok exited unexpectedly with code 1`.
- The final rebase preserved the reviewed Voice Call code diff byte-for-byte.

Validation:

- `pnpm test extensions/voice-call/src/tunnel.test.ts` — 1 file, 15 tests passed on Blacksmith Testbox `tbx_01kxft6m7xk63vr7szq0q2g5v7` ([run 29316428344](https://github.com/openclaw/openclaw/actions/runs/29316428344)).
- `pnpm check:changed` — extension production/test typechecks, lint, formatting, API baseline, and repository guards passed on the same Testbox run.
- `pnpm test:extension voice-call` — 49 files, 527 tests passed on code-identical head Testbox `tbx_01kxfscvk82b84yssnb7gzwzy2` ([run 29315632370](https://github.com/openclaw/openclaw/actions/runs/29315632370)).
- Canonical Sol/high autoreview — clean, no accepted/actionable findings (0.97 correctness confidence).
- `git diff --check` — passed.

Not tested: a live ngrok account or successful public tunnel, because the changed path is local stderr framing before any successful tunnel response.
