### PR TITLE
fix(workboard): require admin for managed worktree sources

### DIFF
--- a/docs/concepts/managed-worktrees.md
+++ b/docs/concepts/managed-worktrees.md
@@ -108,6 +108,6 @@ The bundled [Workboard plugin](/plugins/workboard) can materialize a card worksp
 }
 ```
 
-`path` identifies the source git checkout. `branch` is optional and becomes the base ref. When dispatch starts the card's worker, Workboard creates or reuses `wb-<card-id>`, runs the subagent with the managed checkout as its working directory, and writes the resolved path and branch back to the card. Gateway-triggered materialization requires `operator.admin`. On run end, Workboard removes the checkout only when it is provably lossless; dirty work or unpushed commits remain available.
+`path` identifies the source git checkout. `branch` is optional and becomes the base ref. Introducing or replacing that source path through a Workboard Gateway mutation requires `operator.admin`; ordinary `operator.write` callers can still edit the rest of an existing card. Agent tools cannot authorize a new worktree source path. When dispatch starts the card's worker, Workboard creates or reuses `wb-<card-id>`, runs the subagent with the managed checkout as its working directory, and writes the resolved path and branch back to the card. Gateway-triggered materialization also requires `operator.admin`. On run end, Workboard removes the checkout only when it is provably lossless; dirty work or unpushed commits remain available.
 
 Sandboxed embedded agents currently reject a task working directory outside their configured agent workspace. Use an unsandboxed target agent for Workboard managed-worktree cards until the sandbox runtime supports an additive checkout mount.

--- a/docs/plugins/workboard.md
+++ b/docs/plugins/workboard.md
@@ -147,6 +147,11 @@ seeing a usable token. Recovery goes through
 `workboard_promote`/`workboard_reassign`/`workboard_reclaim`, which do not
 require the token.
 
+Agent tools can attach scratch or directory workspace metadata, but they
+cannot introduce or replace a managed-worktree source path. Set that host path
+through a Workboard Gateway mutation from an `operator.admin` client; ordinary
+`operator.write` clients can still edit other fields on the card.
+
 ## Dispatch
 
 Dispatch is Gateway-local: it does not spawn arbitrary OS processes. Normal

--- a/extensions/workboard/src/command.test.ts
+++ b/extensions/workboard/src/command.test.ts
@@ -115,11 +115,15 @@ describe("handleWorkboardCommand", () => {
       path: "/state/worktrees/fingerprint/wb-card",
       branch: "openclaw/wb-card",
     });
-    await store.create({
-      title: "Denied checkout",
-      status: "ready",
-      workspace: { kind: "worktree", path: "/repo-denied" },
-    });
+    await store.create(
+      {
+        title: "Denied checkout",
+        status: "ready",
+        workspace: { kind: "worktree", path: "/repo-denied" },
+      },
+      undefined,
+      "operator.admin",
+    );
 
     await expect(
       handleWorkboardCommand({
@@ -136,11 +140,15 @@ describe("handleWorkboardCommand", () => {
     expect(denied).toMatchObject({ status: "ready" });
     await store.update(denied!.id, { status: "blocked" });
 
-    const allowed = await store.create({
-      title: "Allowed checkout",
-      status: "ready",
-      workspace: { kind: "worktree", path: "/repo-allowed" },
-    });
+    const allowed = await store.create(
+      {
+        title: "Allowed checkout",
+        status: "ready",
+        workspace: { kind: "worktree", path: "/repo-allowed" },
+      },
+      undefined,
+      "operator.admin",
+    );
     await handleWorkboardCommand({
       api,
       store,

--- a/extensions/workboard/src/dispatcher.test.ts
+++ b/extensions/workboard/src/dispatcher.test.ts
@@ -24,11 +24,15 @@ function createMemoryStore<T = PersistedWorkboardCard>(): WorkboardKeyedStore<T>
 describe("dispatchAndStartWorkboardCards", () => {
   it("materializes managed worktrees, supplies cwd, persists them, and cleans up on run end", async () => {
     const store = new WorkboardStore(createMemoryStore());
-    const card = await store.create({
-      title: "Isolated worker",
-      status: "ready",
-      workspace: { kind: "worktree", path: "/repo", branch: "main" },
-    });
+    const card = await store.create(
+      {
+        title: "Isolated worker",
+        status: "ready",
+        workspace: { kind: "worktree", path: "/repo", branch: "main" },
+      },
+      undefined,
+      "operator.admin",
+    );
     const run = vi.fn().mockResolvedValue({ runId: "run-worktree" });
     const worktrees = {
       create: vi.fn().mockResolvedValue({
@@ -80,11 +84,15 @@ describe("dispatchAndStartWorkboardCards", () => {
 
   it("requires gateway admin authorization before materializing a worktree", async () => {
     const store = new WorkboardStore(createMemoryStore());
-    const card = await store.create({
-      title: "Protected checkout",
-      status: "ready",
-      workspace: { kind: "worktree", path: "/repo" },
-    });
+    const card = await store.create(
+      {
+        title: "Protected checkout",
+        status: "ready",
+        workspace: { kind: "worktree", path: "/repo" },
+      },
+      undefined,
+      "operator.admin",
+    );
     const worktrees = {
       create: vi.fn(),
       release: vi.fn(),
@@ -110,16 +118,20 @@ describe("dispatchAndStartWorkboardCards", () => {
 
   it("does not reuse a generated branch as an omitted source base", async () => {
     const store = new WorkboardStore(createMemoryStore());
-    const card = await store.create({
-      title: "Branchless retry",
-      status: "ready",
-      workspace: {
-        kind: "worktree",
-        path: "/state/worktrees/fingerprint/wb-card",
-        branch: "openclaw/wb-card",
-        sourcePath: "/repo",
+    const card = await store.create(
+      {
+        title: "Branchless retry",
+        status: "ready",
+        workspace: {
+          kind: "worktree",
+          path: "/state/worktrees/fingerprint/wb-card",
+          branch: "openclaw/wb-card",
+          sourcePath: "/repo",
+        },
       },
-    });
+      undefined,
+      "operator.admin",
+    );
     const create = vi.fn().mockResolvedValue({
       id: "managed-id",
       path: "/state/worktrees/fingerprint/wb-card",

--- a/extensions/workboard/src/gateway-helpers.ts
+++ b/extensions/workboard/src/gateway-helpers.ts
@@ -5,6 +5,7 @@ import type { OpenClawPluginApi } from "../api.js";
 import { dispatchAndStartWorkboardCards } from "./dispatcher.js";
 import type { WorkboardStore } from "./store.js";
 import type { WorkboardCard } from "./types.js";
+import { resolveManagedWorktreeSourceAuthorization } from "./workspace-authorization.js";
 
 type GatewayMethodContext = Parameters<
   Parameters<OpenClawPluginApi["registerGatewayMethod"]>[1]
@@ -83,8 +84,7 @@ export function createWorkboardDispatchHandler(params: {
           boardId: typeof boardId === "string" ? boardId : undefined,
           ...(maxStarts !== undefined ? { maxStarts } : {}),
           allowManagedWorktrees:
-            Array.isArray(client?.connect?.scopes) &&
-            client.connect.scopes.includes("operator.admin"),
+            resolveManagedWorktreeSourceAuthorization(client) === "operator.admin",
         },
       });
       respond(true, {

--- a/extensions/workboard/src/gateway-workspace-methods.ts
+++ b/extensions/workboard/src/gateway-workspace-methods.ts
@@ -1,0 +1,130 @@
+import type { OpenClawPluginApi } from "../api.js";
+import { readId, readPatch, respondError } from "./gateway-helpers.js";
+import type { WorkboardStore } from "./store.js";
+import type { WorkboardCard } from "./types.js";
+import { resolveManagedWorktreeSourceAuthorization as workspaceAuth } from "./workspace-authorization.js";
+
+type RegistrationParams = {
+  api: OpenClawPluginApi;
+  store: WorkboardStore;
+  redactCard: (card: WorkboardCard) => WorkboardCard;
+};
+
+const WRITE_SCOPE = "operator.write" as const;
+
+export function registerWorkboardCardCreateMethod(params: RegistrationParams) {
+  params.api.registerGatewayMethod(
+    "workboard.cards.create",
+    async ({ params: requestParams, respond, client }) => {
+      try {
+        respond(true, {
+          card: params.redactCard(
+            await params.store.create(requestParams, undefined, workspaceAuth(client)),
+          ),
+        });
+      } catch (error) {
+        respondError(respond, error);
+      }
+    },
+    { scope: WRITE_SCOPE },
+  );
+}
+
+export function registerWorkboardCardUpdateMethod(params: RegistrationParams) {
+  params.api.registerGatewayMethod(
+    "workboard.cards.update",
+    async ({ params: requestParams, respond, client }) => {
+      try {
+        respond(true, {
+          card: params.redactCard(
+            await params.store.update(
+              readId(requestParams),
+              readPatch(requestParams),
+              workspaceAuth(client),
+            ),
+          ),
+        });
+      } catch (error) {
+        respondError(respond, error);
+      }
+    },
+    { scope: WRITE_SCOPE },
+  );
+}
+
+export function registerWorkboardCardBulkMethod(params: RegistrationParams) {
+  params.api.registerGatewayMethod(
+    "workboard.cards.bulk",
+    async ({ params: requestParams, respond, client }) => {
+      try {
+        const result = await params.store.bulkUpdate(requestParams, workspaceAuth(client));
+        respond(true, { cards: result.cards.map(params.redactCard) });
+      } catch (error) {
+        respondError(respond, error);
+      }
+    },
+    { scope: WRITE_SCOPE },
+  );
+}
+
+export function registerWorkboardBoardUpsertMethod(params: RegistrationParams) {
+  params.api.registerGatewayMethod(
+    "workboard.boards.upsert",
+    async ({ params: requestParams, respond, client }) => {
+      try {
+        respond(true, {
+          board: await params.store.upsertBoard(requestParams, workspaceAuth(client)),
+        });
+      } catch (error) {
+        respondError(respond, error);
+      }
+    },
+    { scope: WRITE_SCOPE },
+  );
+}
+
+export function registerWorkboardCardSpecifyMethod(params: RegistrationParams) {
+  params.api.registerGatewayMethod(
+    "workboard.cards.specify",
+    async ({ params: requestParams, respond, client }) => {
+      try {
+        respond(true, {
+          card: params.redactCard(
+            await params.store.specify(
+              readId(requestParams),
+              requestParams,
+              null,
+              workspaceAuth(client),
+            ),
+          ),
+        });
+      } catch (error) {
+        respondError(respond, error);
+      }
+    },
+    { scope: WRITE_SCOPE },
+  );
+}
+
+export function registerWorkboardCardDecomposeMethod(params: RegistrationParams) {
+  params.api.registerGatewayMethod(
+    "workboard.cards.decompose",
+    async ({ params: requestParams, respond, client }) => {
+      try {
+        const result = await params.store.decompose(
+          readId(requestParams),
+          requestParams,
+          null,
+          workspaceAuth(client),
+        );
+        respond(true, {
+          parent: params.redactCard(result.parent),
+          children: result.children.map(params.redactCard),
+        });
+      } catch (error) {
+        respondError(respond, error);
+      }
+    },
+    { scope: WRITE_SCOPE },
+  );
+}

--- a/extensions/workboard/src/gateway.test.ts
+++ b/extensions/workboard/src/gateway.test.ts
@@ -219,6 +219,71 @@ describe("workboard gateway methods", () => {
     });
   });
 
+  it("requires admin scope to introduce or replace managed-worktree sources", async () => {
+    type RegisteredMethod = {
+      handler: Parameters<OpenClawPluginApi["registerGatewayMethod"]>[1];
+      opts: Parameters<OpenClawPluginApi["registerGatewayMethod"]>[2];
+    };
+    const methods = new Map<string, RegisteredMethod>();
+    const store = new WorkboardStore(createMemoryStore());
+    const api = {
+      runtime: {},
+      registerGatewayMethod: vi.fn(
+        (method: string, handler: RegisteredMethod["handler"], opts: RegisteredMethod["opts"]) => {
+          methods.set(method, { handler, opts });
+        },
+      ),
+    } as unknown as OpenClawPluginApi;
+    registerWorkboardGatewayMethods({ api, store });
+
+    const deniedCreate = vi.fn();
+    await methods.get("workboard.cards.create")?.handler({
+      params: { title: "Denied source", workspace: { kind: "worktree", path: "/repo-a" } },
+      client: { connect: { scopes: ["operator.write"] } },
+      respond: deniedCreate,
+    } as never);
+    expect(deniedCreate.mock.calls[0]?.[0]).toBe(false);
+    expect(deniedCreate.mock.calls[0]?.[2]?.message).toBe(
+      "managed worktree source changes require operator.admin.",
+    );
+
+    const allowedCreate = vi.fn();
+    await methods.get("workboard.cards.create")?.handler({
+      params: { title: "Allowed source", workspace: { kind: "worktree", path: "/repo-a" } },
+      client: { connect: { scopes: ["operator.admin"] } },
+      respond: allowedCreate,
+    } as never);
+    expect(allowedCreate.mock.calls[0]?.[0]).toBe(true);
+    const cardId = allowedCreate.mock.calls[0]?.[1]?.card.id;
+
+    const ordinaryUpdate = vi.fn();
+    await methods.get("workboard.cards.update")?.handler({
+      params: { id: cardId, patch: { title: "Still editable" } },
+      client: { connect: { scopes: ["operator.write"] } },
+      respond: ordinaryUpdate,
+    } as never);
+    expect(ordinaryUpdate.mock.calls[0]?.[0]).toBe(true);
+
+    const deniedUpdate = vi.fn();
+    await methods.get("workboard.cards.update")?.handler({
+      params: { id: cardId, patch: { workspace: { kind: "worktree", path: "/repo-b" } } },
+      client: { connect: { scopes: ["operator.write"] } },
+      respond: deniedUpdate,
+    } as never);
+    expect(deniedUpdate.mock.calls[0]?.[0]).toBe(false);
+
+    const allowedBoard = vi.fn();
+    await methods.get("workboard.boards.upsert")?.handler({
+      params: {
+        id: "ops",
+        defaultWorkspace: { kind: "worktree", path: "/repo-board" },
+      },
+      client: { connect: { scopes: ["operator.admin"] } },
+      respond: allowedBoard,
+    } as never);
+    expect(allowedBoard.mock.calls[0]?.[0]).toBe(true);
+  });
+
   it("dispatches workboard cards when gateway params are omitted", async () => {
     type RegisteredMethod = {
       handler: Parameters<OpenClawPluginApi["registerGatewayMethod"]>[1];
@@ -367,11 +432,15 @@ describe("workboard gateway methods", () => {
       ),
     } as unknown as OpenClawPluginApi;
     const store = new WorkboardStore(createMemoryStore());
-    const denied = await store.create({
-      title: "Denied checkout",
-      status: "ready",
-      workspace: { kind: "worktree", path: "/repo-denied" },
-    });
+    const denied = await store.create(
+      {
+        title: "Denied checkout",
+        status: "ready",
+        workspace: { kind: "worktree", path: "/repo-denied" },
+      },
+      undefined,
+      "operator.admin",
+    );
     registerWorkboardGatewayMethods({ api, store });
     const handler = methods.get("workboard.cards.dispatch")?.handler;
 
@@ -393,11 +462,15 @@ describe("workboard gateway methods", () => {
     await expect(store.get(denied.id)).resolves.toMatchObject({ status: "ready" });
     await store.update(denied.id, { status: "blocked" });
 
-    const allowed = await store.create({
-      title: "Allowed checkout",
-      status: "ready",
-      workspace: { kind: "worktree", path: "/repo-allowed" },
-    });
+    const allowed = await store.create(
+      {
+        title: "Allowed checkout",
+        status: "ready",
+        workspace: { kind: "worktree", path: "/repo-allowed" },
+      },
+      undefined,
+      "operator.admin",
+    );
     await handler?.({
       client: { connect: { scopes: ["operator.admin"] } },
       respond: vi.fn(),

--- a/extensions/workboard/src/gateway.ts
+++ b/extensions/workboard/src/gateway.ts
@@ -4,9 +4,16 @@ import {
   assertNoCursorAdvance,
   createWorkboardDispatchHandler,
   readId,
-  readPatch,
   respondError,
 } from "./gateway-helpers.js";
+import {
+  registerWorkboardBoardUpsertMethod,
+  registerWorkboardCardBulkMethod,
+  registerWorkboardCardCreateMethod,
+  registerWorkboardCardDecomposeMethod,
+  registerWorkboardCardSpecifyMethod,
+  registerWorkboardCardUpdateMethod,
+} from "./gateway-workspace-methods.js";
 import { WorkboardStore } from "./store.js";
 import { WORKBOARD_STATUSES, type WorkboardCard } from "./types.js";
 
@@ -64,33 +71,9 @@ export function registerWorkboardGatewayMethods(params: {
     { scope: READ_SCOPE },
   );
 
-  api.registerGatewayMethod(
-    "workboard.cards.create",
-    async ({ params: requestParams, respond }) => {
-      try {
-        respond(true, { card: redactClaimToken(await store.create(requestParams)) });
-      } catch (error) {
-        respondError(respond, error);
-      }
-    },
-    { scope: WRITE_SCOPE },
-  );
-
-  api.registerGatewayMethod(
-    "workboard.cards.update",
-    async ({ params: requestParams, respond }) => {
-      try {
-        respond(true, {
-          card: redactClaimToken(
-            await store.update(readId(requestParams), readPatch(requestParams)),
-          ),
-        });
-      } catch (error) {
-        respondError(respond, error);
-      }
-    },
-    { scope: WRITE_SCOPE },
-  );
+  const workspaceMethodParams = { api, store, redactCard: redactClaimToken };
+  registerWorkboardCardCreateMethod(workspaceMethodParams);
+  registerWorkboardCardUpdateMethod(workspaceMethodParams);
 
   api.registerGatewayMethod(
     "workboard.cards.move",
@@ -320,18 +303,7 @@ export function registerWorkboardGatewayMethods(params: {
     { scope: WRITE_SCOPE },
   );
 
-  api.registerGatewayMethod(
-    "workboard.cards.bulk",
-    async ({ params: requestParams, respond }) => {
-      try {
-        const result = await store.bulkUpdate(requestParams);
-        respond(true, { cards: result.cards.map(redactClaimToken) });
-      } catch (error) {
-        respondError(respond, error);
-      }
-    },
-    { scope: WRITE_SCOPE },
-  );
+  registerWorkboardCardBulkMethod(workspaceMethodParams);
 
   api.registerGatewayMethod(
     "workboard.cards.diagnostics",
@@ -381,17 +353,7 @@ export function registerWorkboardGatewayMethods(params: {
     { scope: READ_SCOPE },
   );
 
-  api.registerGatewayMethod(
-    "workboard.boards.upsert",
-    async ({ params: requestParams, respond }) => {
-      try {
-        respond(true, { board: await store.upsertBoard(requestParams) });
-      } catch (error) {
-        respondError(respond, error);
-      }
-    },
-    { scope: WRITE_SCOPE },
-  );
+  registerWorkboardBoardUpsertMethod(workspaceMethodParams);
 
   api.registerGatewayMethod(
     "workboard.boards.archive",
@@ -444,35 +406,8 @@ export function registerWorkboardGatewayMethods(params: {
     { scope: READ_SCOPE },
   );
 
-  api.registerGatewayMethod(
-    "workboard.cards.specify",
-    async ({ params: requestParams, respond }) => {
-      try {
-        respond(true, {
-          card: redactClaimToken(await store.specify(readId(requestParams), requestParams, null)),
-        });
-      } catch (error) {
-        respondError(respond, error);
-      }
-    },
-    { scope: WRITE_SCOPE },
-  );
-
-  api.registerGatewayMethod(
-    "workboard.cards.decompose",
-    async ({ params: requestParams, respond }) => {
-      try {
-        const result = await store.decompose(readId(requestParams), requestParams, null);
-        respond(true, {
-          parent: redactClaimToken(result.parent),
-          children: result.children.map(redactClaimToken),
-        });
-      } catch (error) {
-        respondError(respond, error);
-      }
-    },
-    { scope: WRITE_SCOPE },
-  );
+  registerWorkboardCardSpecifyMethod(workspaceMethodParams);
+  registerWorkboardCardDecomposeMethod(workspaceMethodParams);
 
   api.registerGatewayMethod(
     "workboard.notifications.subscribe",

--- a/extensions/workboard/src/store-core.ts
+++ b/extensions/workboard/src/store-core.ts
@@ -56,6 +56,7 @@ import {
   syncExecutionSessionKey,
   trimMetadataToBudget,
 } from "./store-normalizers.js";
+import { buildWorkboardBoardSummaries } from "./store-projections.js";
 import type {
   WorkboardBoardMetadata,
   WorkboardCard,
@@ -63,6 +64,10 @@ import type {
   WorkboardMetadata,
   WorkboardStatus,
 } from "./types.js";
+import {
+  assertManagedWorktreeSourceMutationAllowed,
+  type WorkboardWorkspaceMutationAuthorization,
+} from "./workspace-authorization.js";
 
 export class WorkboardCoreStore {
   private mutationQueue: Promise<unknown> = Promise.resolve();
@@ -142,70 +147,22 @@ export class WorkboardCoreStore {
   }
 
   async listBoards(): Promise<{ boards: WorkboardBoardSummary[] }> {
-    const boards = new Map<string, WorkboardBoardSummary>();
-    for (const entry of await this.boardStore.entries()) {
-      if (entry.value?.version !== 1 || !entry.value.board?.id) {
-        continue;
-      }
-      const board = entry.value.board;
-      boards.set(board.id, {
-        id: board.id,
-        ...(board.name ? { name: board.name } : {}),
-        ...(board.description ? { description: board.description } : {}),
-        ...(board.icon ? { icon: board.icon } : {}),
-        ...(board.color ? { color: board.color } : {}),
-        ...(board.defaultWorkspace ? { defaultWorkspace: board.defaultWorkspace } : {}),
-        ...(board.orchestration ? { orchestration: board.orchestration } : {}),
-        total: 0,
-        active: 0,
-        archived: 0,
-        byStatus: {},
-        updatedAt: board.updatedAt,
-        ...(board.archivedAt ? { archivedAt: board.archivedAt } : {}),
-      });
-    }
-    if (!boards.has("default")) {
-      boards.set("default", {
-        id: "default",
-        total: 0,
-        active: 0,
-        archived: 0,
-        byStatus: {},
-      });
-    }
-    for (const card of await this.list()) {
-      const boardId = cardBoardId(card);
-      const summary =
-        boards.get(boardId) ??
-        ({
-          id: boardId,
-          total: 0,
-          active: 0,
-          archived: 0,
-          byStatus: {},
-        } satisfies WorkboardBoardSummary);
-      summary.total += 1;
-      if (card.metadata?.archivedAt) {
-        summary.archived += 1;
-      } else {
-        summary.active += 1;
-      }
-      summary.byStatus[card.status] = (summary.byStatus[card.status] ?? 0) + 1;
-      summary.updatedAt = Math.max(summary.updatedAt ?? 0, card.updatedAt);
-      boards.set(boardId, summary);
-    }
-    return {
-      boards: [...boards.values()].toSorted((a, b) =>
-        a.id === "default" ? -1 : b.id === "default" ? 1 : a.id.localeCompare(b.id),
-      ),
-    };
+    return buildWorkboardBoardSummaries(await this.boardStore.entries(), await this.list());
   }
 
-  async upsertBoard(input: WorkboardBoardInput): Promise<WorkboardBoardMetadata> {
+  async upsertBoard(
+    input: WorkboardBoardInput,
+    authorization?: WorkboardWorkspaceMutationAuthorization,
+  ): Promise<WorkboardBoardMetadata> {
     return await this.enqueueMutation(async () => {
       const id = normalizeBoardIdRequired(input.id);
       const existing = await this.boardStore.lookup(id);
       const board = normalizeBoardMetadata({ ...input, id }, existing?.board);
+      assertManagedWorktreeSourceMutationAllowed(
+        existing?.board.defaultWorkspace,
+        board.defaultWorkspace,
+        authorization,
+      );
       await this.boardStore.register(id, { version: 1, board });
       return board;
     });
@@ -287,13 +244,17 @@ export class WorkboardCoreStore {
   async create(
     input: WorkboardLinkedCreateInput,
     scope?: WorkboardMutationScope,
+    authorization?: WorkboardWorkspaceMutationAuthorization,
   ): Promise<WorkboardCard> {
-    return await this.enqueueMutation(async () => await this.createDirect(input, scope));
+    return await this.enqueueMutation(
+      async () => await this.createDirect(input, scope, authorization),
+    );
   }
 
   protected async createDirect(
     input: WorkboardLinkedCreateInput,
     scope?: WorkboardMutationScope,
+    authorization?: WorkboardWorkspaceMutationAuthorization,
   ): Promise<WorkboardCard> {
     const now = Date.now();
     const requestedStatus = normalizeStatus(input.status, "todo");
@@ -381,6 +342,11 @@ export class WorkboardCoreStore {
     const syncedMetadata = trimMetadataToBudget(
       syncExecutionAttemptMetadata(metadata, execution, now),
     );
+    assertManagedWorktreeSourceMutationAllowed(
+      undefined,
+      syncedMetadata.automation?.workspace,
+      authorization,
+    );
     const boardId = syncedMetadata.automation?.boardId ?? "default";
     const position = Number.isFinite(normalizedPosition)
       ? normalizedPosition
@@ -436,12 +402,17 @@ export class WorkboardCoreStore {
     return card;
   }
 
-  async update(id: string, patch: WorkboardCardPatch): Promise<WorkboardCard> {
+  async update(
+    id: string,
+    patch: WorkboardCardPatch,
+    authorization?: WorkboardWorkspaceMutationAuthorization,
+  ): Promise<WorkboardCard> {
     return await this.enqueueMutation(
       async () =>
         await this.updateCard(id, patch, {
           allowMetadataDependencyLinks: false,
           enforceStatusHolds: true,
+          workspaceAuthorization: authorization,
         }),
     );
   }
@@ -449,7 +420,11 @@ export class WorkboardCoreStore {
   protected async updateCard(
     id: string,
     patch: WorkboardCardPatch,
-    options: { allowMetadataDependencyLinks?: boolean; enforceStatusHolds?: boolean } = {},
+    options: {
+      allowMetadataDependencyLinks?: boolean;
+      enforceStatusHolds?: boolean;
+      workspaceAuthorization?: WorkboardWorkspaceMutationAuthorization;
+    } = {},
   ): Promise<WorkboardCard> {
     const existing = await this.get(id);
     if (!existing) {
@@ -582,6 +557,11 @@ export class WorkboardCoreStore {
     });
     next.metadata = trimMetadataToBudget(
       syncExecutionAttemptMetadata(next.metadata ?? {}, execution, now),
+    );
+    assertManagedWorktreeSourceMutationAllowed(
+      existing.metadata?.automation?.workspace,
+      next.metadata?.automation?.workspace,
+      options.workspaceAuthorization,
     );
     next.events = appendEvent(next, updateEvent(existing, next), now);
     if (options.enforceStatusHolds && effectivePatch.status !== undefined) {

--- a/extensions/workboard/src/store-projections.ts
+++ b/extensions/workboard/src/store-projections.ts
@@ -1,0 +1,89 @@
+import type { PersistedWorkboardBoard } from "./persistence-types.js";
+import { cardBoardId } from "./store-card-helpers.js";
+import type { WorkboardBoardSummary } from "./store-inputs.js";
+import type { WorkboardAttachment, WorkboardCard, WorkboardRunAttempt } from "./types.js";
+
+export function buildWorkboardBoardSummaries(
+  entries: Array<{ key: string; value: PersistedWorkboardBoard }>,
+  cards: WorkboardCard[],
+): { boards: WorkboardBoardSummary[] } {
+  const boards = new Map<string, WorkboardBoardSummary>();
+  for (const entry of entries) {
+    if (entry.value?.version !== 1 || !entry.value.board?.id) {
+      continue;
+    }
+    const board = entry.value.board;
+    boards.set(board.id, {
+      id: board.id,
+      ...(board.name ? { name: board.name } : {}),
+      ...(board.description ? { description: board.description } : {}),
+      ...(board.icon ? { icon: board.icon } : {}),
+      ...(board.color ? { color: board.color } : {}),
+      ...(board.defaultWorkspace ? { defaultWorkspace: board.defaultWorkspace } : {}),
+      ...(board.orchestration ? { orchestration: board.orchestration } : {}),
+      total: 0,
+      active: 0,
+      archived: 0,
+      byStatus: {},
+      updatedAt: board.updatedAt,
+      ...(board.archivedAt ? { archivedAt: board.archivedAt } : {}),
+    });
+  }
+  if (!boards.has("default")) {
+    boards.set("default", {
+      id: "default",
+      total: 0,
+      active: 0,
+      archived: 0,
+      byStatus: {},
+    });
+  }
+  for (const card of cards) {
+    const boardId = cardBoardId(card);
+    const summary =
+      boards.get(boardId) ??
+      ({
+        id: boardId,
+        total: 0,
+        active: 0,
+        archived: 0,
+        byStatus: {},
+      } satisfies WorkboardBoardSummary);
+    summary.total += 1;
+    if (card.metadata?.archivedAt) {
+      summary.archived += 1;
+    } else {
+      summary.active += 1;
+    }
+    summary.byStatus[card.status] = (summary.byStatus[card.status] ?? 0) + 1;
+    summary.updatedAt = Math.max(summary.updatedAt ?? 0, card.updatedAt);
+    boards.set(boardId, summary);
+  }
+  return {
+    boards: [...boards.values()].toSorted((a, b) =>
+      a.id === "default" ? -1 : b.id === "default" ? 1 : a.id.localeCompare(b.id),
+    ),
+  };
+}
+
+export function buildWorkboardExport(cards: WorkboardCard[]): {
+  cards: WorkboardCard[];
+  attachments: WorkboardAttachment[];
+  exportedAt: number;
+} {
+  return {
+    cards,
+    attachments: cards.flatMap((card) => card.metadata?.attachments ?? []),
+    exportedAt: Date.now(),
+  };
+}
+
+export function buildWorkboardRuns(
+  card: WorkboardCard | undefined,
+  id: string,
+): { card: WorkboardCard; attempts: WorkboardRunAttempt[] } {
+  if (!card) {
+    throw new Error(`card not found: ${id}`);
+  }
+  return { card, attempts: card.metadata?.attempts ?? [] };
+}

--- a/extensions/workboard/src/store-workflow.ts
+++ b/extensions/workboard/src/store-workflow.ts
@@ -47,6 +47,7 @@ import {
   normalizeStringList,
   removeUndefinedMetadataFields,
 } from "./store-normalizers.js";
+import { buildWorkboardRuns } from "./store-projections.js";
 import type {
   WorkboardArtifact,
   WorkboardCard,
@@ -460,17 +461,14 @@ export class WorkboardWorkflowStore extends WorkboardEnrichmentStore {
   }
 
   async runs(id: string): Promise<{ card: WorkboardCard; attempts: WorkboardRunAttempt[] }> {
-    const card = await this.get(id);
-    if (!card) {
-      throw new Error(`card not found: ${id}`);
-    }
-    return { card, attempts: card.metadata?.attempts ?? [] };
+    return buildWorkboardRuns(await this.get(id), id);
   }
 
   async specify(
     id: string,
     input: WorkboardSpecifyInput = {},
     scope?: WorkboardMutationScope | null,
+    authorization?: "operator.admin",
   ): Promise<WorkboardCard> {
     return await this.enqueueMutation(async () => {
       const existing = await this.get(id);
@@ -515,7 +513,7 @@ export class WorkboardWorkflowStore extends WorkboardEnrichmentStore {
           status: "todo",
           metadata,
         },
-        { enforceStatusHolds: true },
+        { enforceStatusHolds: true, workspaceAuthorization: authorization },
       );
       const specified = {
         ...updated,
@@ -530,6 +528,7 @@ export class WorkboardWorkflowStore extends WorkboardEnrichmentStore {
     id: string,
     input: WorkboardDecomposeInput = {},
     scope?: WorkboardMutationScope | null,
+    authorization?: "operator.admin",
   ): Promise<{ parent: WorkboardCard; children: WorkboardCard[] }> {
     return await this.enqueueMutation(async () => {
       const parent = await this.get(id);
@@ -566,6 +565,7 @@ export class WorkboardWorkflowStore extends WorkboardEnrichmentStore {
                 deriveChildIdempotencyKey(parentAutomation?.idempotencyKey, children.length + 1),
             },
             scope === null ? undefined : scope,
+            authorization,
           );
           const reusedUnlinkedChild =
             existingCardIds.has(created.id) && !cardParentIds(created).includes(parent.id);

--- a/extensions/workboard/src/store.test.ts
+++ b/extensions/workboard/src/store.test.ts
@@ -1204,6 +1204,54 @@ describe("WorkboardStore", () => {
     ).rejects.toThrow(/absolute/);
   });
 
+  it("defaults managed-worktree source mutations to denied across store workflows", async () => {
+    const store = new WorkboardStore(createMemoryStore());
+    const worktree = { kind: "worktree" as const, path: "/repo" };
+    const authorization = "operator.admin";
+
+    await expect(store.create({ title: "Denied create", workspace: worktree })).rejects.toThrow(
+      /operator\.admin/,
+    );
+    const card = await store.create({ title: "Mutable card" });
+    await expect(store.update(card.id, { workspace: worktree })).rejects.toThrow(/operator\.admin/);
+    await expect(
+      store.bulkUpdate({ ids: [card.id], patch: { workspace: worktree } }),
+    ).rejects.toThrow(/operator\.admin/);
+
+    const triage = await store.create({ title: "Specify me", status: "triage" });
+    await expect(store.specify(triage.id, { workspace: worktree })).rejects.toThrow(
+      /operator\.admin/,
+    );
+    await expect(
+      store.decompose(triage.id, {
+        completeParent: false,
+        children: [{ title: "Denied child", workspace: worktree }],
+      }),
+    ).rejects.toThrow(/operator\.admin/);
+    await expect(store.upsertBoard({ id: "denied", defaultWorkspace: worktree })).rejects.toThrow(
+      /operator\.admin/,
+    );
+
+    const allowed = await store.create(
+      { title: "Allowed create", workspace: worktree },
+      undefined,
+      authorization,
+    );
+    await expect(store.update(allowed.id, { title: "Ordinary update" })).resolves.toMatchObject({
+      title: "Ordinary update",
+      metadata: { automation: { workspace: worktree } },
+    });
+    await expect(
+      store.update(
+        allowed.id,
+        { workspace: { kind: "worktree", path: "/repo-next" } },
+        authorization,
+      ),
+    ).resolves.toMatchObject({
+      metadata: { automation: { workspace: { kind: "worktree", path: "/repo-next" } } },
+    });
+  });
+
   it("keeps future scheduled cards scheduled until their time arrives", async () => {
     vi.useFakeTimers();
     try {

--- a/extensions/workboard/src/store.ts
+++ b/extensions/workboard/src/store.ts
@@ -39,7 +39,8 @@ import {
   trimMetadataToBudget,
 } from "./store-normalizers.js";
 import { WorkboardNotificationStore } from "./store-notifications.js";
-import type { WorkboardAttachment, WorkboardCard } from "./types.js";
+import { buildWorkboardExport } from "./store-projections.js";
+import type { WorkboardCard } from "./types.js";
 
 export type {
   PersistedWorkboardAttachment,
@@ -161,7 +162,10 @@ export class WorkboardStore extends WorkboardNotificationStore {
     });
   }
 
-  async bulkUpdate(input: WorkboardBulkInput): Promise<{ cards: WorkboardCard[] }> {
+  async bulkUpdate(
+    input: WorkboardBulkInput,
+    authorization?: "operator.admin",
+  ): Promise<{ cards: WorkboardCard[] }> {
     const ids = Array.isArray(input.ids)
       ? input.ids.filter((id): id is string => typeof id === "string" && id.trim() !== "")
       : [];
@@ -176,7 +180,7 @@ export class WorkboardStore extends WorkboardNotificationStore {
     for (const id of ids) {
       const updated =
         input.archived === undefined
-          ? await this.update(id, patch)
+          ? await this.update(id, patch, authorization)
           : await this.archive(id, input.archived);
       cards.push(updated);
     }
@@ -191,14 +195,8 @@ export class WorkboardStore extends WorkboardNotificationStore {
     }));
   }
 
-  async exportCards(): Promise<{
-    cards: WorkboardCard[];
-    attachments: WorkboardAttachment[];
-    exportedAt: number;
-  }> {
-    const cards = await this.list();
-    const attachments = cards.flatMap((card) => card.metadata?.attachments ?? []);
-    return { cards, attachments, exportedAt: Date.now() };
+  async exportCards() {
+    return buildWorkboardExport(await this.list());
   }
 
   async diagnostics(now = Date.now()): Promise<WorkboardDiagnosticsResult> {

--- a/extensions/workboard/src/tools.test.ts
+++ b/extensions/workboard/src/tools.test.ts
@@ -297,6 +297,33 @@ describe("workboard tools", () => {
     expect(dispatch.promoted).toEqual([expect.objectContaining({ id: child.id, status: "ready" })]);
   });
 
+  it("does not let agent tools authorize managed-worktree source paths", async () => {
+    const keyed = createMemoryStore();
+    const api = {
+      runtime: { state: { openKeyedStore: vi.fn(() => keyed) } },
+    } as unknown as OpenClawPluginApi;
+    const tools = new Map(
+      createWorkboardTools({
+        api,
+        store: new WorkboardStore(keyed),
+        context: { agentId: "main" } as never,
+      }).map((tool) => [tool.name, tool]),
+    );
+
+    await expect(
+      tools.get("workboard_create")?.execute("call-worktree", {
+        title: "Denied source",
+        workspace: { kind: "worktree", path: "/repo" },
+      }),
+    ).rejects.toThrow(/operator\.admin/);
+    await expect(
+      tools.get("workboard_board_create")?.execute("call-board-worktree", {
+        id: "denied",
+        defaultWorkspace: { kind: "worktree", path: "/repo" },
+      }),
+    ).rejects.toThrow(/operator\.admin/);
+  });
+
   it("redacts claim tokens from dispatch tool results", async () => {
     const keyed = createMemoryStore();
     const api = {

--- a/extensions/workboard/src/tools.ts
+++ b/extensions/workboard/src/tools.ts
@@ -290,8 +290,8 @@ export function createWorkboardTools(params: {
           workspace: Type.Optional(
             Type.Object(
               {
-                kind: Type.String({ description: "scratch, dir, or worktree." }),
-                path: Type.Optional(Type.String({ description: "Absolute dir/worktree path." })),
+                kind: Type.String({ description: "scratch or dir." }),
+                path: Type.Optional(Type.String({ description: "Absolute directory path." })),
                 branch: Type.Optional(Type.String({ description: "Suggested branch." })),
               },
               { additionalProperties: false },
@@ -644,8 +644,8 @@ export function createWorkboardTools(params: {
           defaultWorkspace: Type.Optional(
             Type.Object(
               {
-                kind: Type.String({ description: "scratch, dir, or worktree." }),
-                path: Type.Optional(Type.String({ description: "Absolute dir/worktree path." })),
+                kind: Type.String({ description: "scratch or dir." }),
+                path: Type.Optional(Type.String({ description: "Absolute directory path." })),
                 branch: Type.Optional(Type.String({ description: "Suggested branch." })),
               },
               { additionalProperties: false },
@@ -748,8 +748,8 @@ export function createWorkboardTools(params: {
           workspace: Type.Optional(
             Type.Object(
               {
-                kind: Type.String({ description: "scratch, dir, or worktree." }),
-                path: Type.Optional(Type.String({ description: "Absolute dir/worktree path." })),
+                kind: Type.String({ description: "scratch or dir." }),
+                path: Type.Optional(Type.String({ description: "Absolute directory path." })),
                 branch: Type.Optional(Type.String({ description: "Suggested branch." })),
               },
               { additionalProperties: false },
@@ -802,10 +802,8 @@ export function createWorkboardTools(params: {
                 workspace: Type.Optional(
                   Type.Object(
                     {
-                      kind: Type.String({ description: "scratch, dir, or worktree." }),
-                      path: Type.Optional(
-                        Type.String({ description: "Absolute dir/worktree path." }),
-                      ),
+                      kind: Type.String({ description: "scratch or dir." }),
+                      path: Type.Optional(Type.String({ description: "Absolute directory path." })),
                       branch: Type.Optional(Type.String({ description: "Suggested branch." })),
                     },
                     { additionalProperties: false },

--- a/extensions/workboard/src/workspace-authorization.ts
+++ b/extensions/workboard/src/workspace-authorization.ts
@@ -1,0 +1,30 @@
+import type { WorkboardWorkspace } from "./types.js";
+
+export type WorkboardWorkspaceMutationAuthorization = "operator.admin" | undefined;
+
+export function resolveManagedWorktreeSourceAuthorization(
+  client: unknown,
+): WorkboardWorkspaceMutationAuthorization {
+  const scopes = (client as { connect?: { scopes?: unknown } } | undefined)?.connect?.scopes;
+  return Array.isArray(scopes) && scopes.includes("operator.admin") ? "operator.admin" : undefined;
+}
+
+function managedWorktreeSource(workspace: WorkboardWorkspace | undefined): string | undefined {
+  return workspace?.kind === "worktree" ? (workspace.sourcePath ?? workspace.path) : undefined;
+}
+
+export function assertManagedWorktreeSourceMutationAllowed(
+  previous: WorkboardWorkspace | undefined,
+  next: WorkboardWorkspace | undefined,
+  authorization: WorkboardWorkspaceMutationAuthorization,
+): void {
+  const previousSource = managedWorktreeSource(previous);
+  const nextSource = managedWorktreeSource(next);
+  const introducesSource =
+    nextSource !== undefined && (previous?.kind !== "worktree" || previousSource !== nextSource);
+  // The stored source is later consumed by an admin-only worktree operation.
+  // Reject planting or replacing it unless this mutation carries the same authority.
+  if (introducesSource && authorization !== "operator.admin") {
+    throw new Error("managed worktree source changes require operator.admin.");
+  }
+}


### PR DESCRIPTION
Closes #103057

## What Problem This Solves

Fixes an issue where a write-scoped Workboard caller could persist a managed-worktree source path that should require administrator authority.

## Why This Change Was Made

Managed-worktree source paths now default to denied at the Workboard store boundary. Gateway create, update, bulk, board-default, specify, and decompose mutations carry explicit `operator.admin` authorization; agent tools cannot grant that authority. Existing cards remain editable when their source path is unchanged.

Release-note context: Workboard now requires `operator.admin` to introduce or replace managed-worktree source paths.

## User Impact

Operators can continue editing ordinary Workboard fields with `operator.write`. Creating or changing an explicit managed-worktree source path requires an `operator.admin` Gateway client; agent tools continue to support scratch and directory workspaces.

## Evidence

- `pnpm test extensions/workboard/src/gateway.test.ts extensions/workboard/src/store.test.ts extensions/workboard/src/tools.test.ts extensions/workboard/src/dispatcher.test.ts extensions/workboard/src/command.test.ts` — 110 tests passed.
- `pnpm check:changed` — format, production and test typechecks, extension lint, database-first guard, sidecar guard, and import-cycle checks passed.
- Blacksmith Testbox `tbx_01kxfdyvpwn2730q4kp5x9m7hr`, run https://github.com/openclaw/openclaw/actions/runs/29305939325.
- Fresh autoreview: clean; no accepted/actionable findings.

Behavior-validator note: source-blind execution was blocked because the acting agent had already inspected the implementation; no separate validator agent was authorized. The Gateway registration and store workflows are covered by the focused remote tests above.
