### PR TITLE
fix: Pond baseline fails with chaos MCP tool

### DIFF
--- a/scripts/e2e/node-plugin-tools-pond.mjs
+++ b/scripts/e2e/node-plugin-tools-pond.mjs
@@ -73,7 +73,13 @@ async function availableLoopbackPort() {
   const address = server.address();
   const port = typeof address === "object" && address ? address.port : 0;
   await new Promise((resolve, reject) => {
-    server.close((error) => (error ? reject(error) : resolve()));
+    server.close((error) => {
+      if (error) {
+        reject(error instanceof Error ? error : new Error(String(error)));
+        return;
+      }
+      resolve();
+    });
   });
   if (!port) {
     throw new Error("failed to allocate pond gateway port");
@@ -304,6 +310,8 @@ async function prepareRoleState(baseDir, role, token, nodeLabel, options = {}) {
                     command: process.execPath,
                     args: [mcpServerPath],
                     transport: "stdio",
+                    // Keep the baseline surface singular; the hot-plug scenario owns the slow tool.
+                    toolFilter: { include: [MCP_TOOL_NAME] },
                   },
                 },
               },


### PR DESCRIPTION
AI-assisted: yes. I reviewed the final diff and understand the behavior.

## What Problem This Solves

Fixes an issue where the Gateway/node Pond baseline always timed out waiting for one effective MCP proof tool because its fixture also exposed the slow tool reserved for the hot-plug chaos tour.

## Why This Change Was Made

The baseline node now publishes only `pond_echo`; the hot-plug scenario remains the sole owner of `pond_slow`. The same touched script also normalizes the loopback-server close rejection to an `Error`, clearing its changed-file lint gate.

## User Impact

No shipped runtime behavior changes. Maintainers can run the baseline Gateway/node Pond proof without an extra chaos-only MCP tool polluting the model-visible surface.

## Evidence

- Before: live baseline timed out at `one effective MCP proof tool`; inventory showed both `pond_pond_echo` and `pond_pond_slow`.
- After: three-peer Crabbox Pond passed two-node discovery, device/node pairing, collision-disambiguated tool calls, 8/8 concurrent verifier runs, node loss/rejoin, and full Gateway restart/reconnect.
- Live `openai/gpt-5.4` baseline called the node MCP tool, followed the node skill, and selected the Pond B collision-disambiguated tool.
- Live hot-plug tour passed add/use, mid-call node loss with bounded degradation, reconnect/retry, and final MCP/skill removal with no stale inventory.
- Blacksmith Testbox `tbx_01kxfe2ga4hynwq9jrfj9qnjy8`: `node scripts/e2e/node-plugin-tools-pond.mjs local --build` passed.
- Blacksmith Testbox `tbx_01kxfebgztakzzbh3x519j9kdt`: `pnpm check:changed` passed. Actions: https://github.com/openclaw/openclaw/actions/runs/29306218295
- Structured autoreview: clean, no accepted/actionable findings.
