### PR TITLE
refactor(channels): migrate irc, nextcloud-talk, zalouser, slack, and matrix group policy onto the scope tree

### DIFF
--- a/extensions/irc/src/channel.ts
+++ b/extensions/irc/src/channel.ts
@@ -44,7 +44,7 @@ import {
   resolveIrcOutboundSessionRoute,
 } from "./normalize.js";
 import { ircOutboundBaseAdapter } from "./outbound-base.js";
-import { resolveIrcGroupMatch, resolveIrcRequireMention } from "./policy.js";
+import { resolveIrcGroupRequireMention, resolveIrcGroupToolPolicy } from "./policy.js";
 import { probeIrc } from "./probe.js";
 import { collectRuntimeConfigAssignments, secretTargetRegistryEntries } from "./secret-contract.js";
 import { ircSetupAdapter } from "./setup-core.js";
@@ -214,19 +214,14 @@ export const ircPlugin: ChannelPlugin<ResolvedIrcAccount, IrcProbe> = createChat
         if (!groupId) {
           return true;
         }
-        const match = resolveIrcGroupMatch({ groups: account.config.groups, target: groupId });
-        return resolveIrcRequireMention({
-          groupConfig: match.groupConfig,
-          wildcardConfig: match.wildcardConfig,
-        });
+        return resolveIrcGroupRequireMention({ groups: account.config.groups, target: groupId });
       },
       resolveToolPolicy: ({ cfg, accountId, groupId }) => {
         const account = resolveIrcAccount({ cfg: cfg as CoreConfig, accountId });
         if (!groupId) {
           return undefined;
         }
-        const match = resolveIrcGroupMatch({ groups: account.config.groups, target: groupId });
-        return match.groupConfig?.tools ?? match.wildcardConfig?.tools;
+        return resolveIrcGroupToolPolicy({ groups: account.config.groups, target: groupId });
       },
     },
     messaging: {

--- a/extensions/irc/src/inbound.ts
+++ b/extensions/irc/src/inbound.ts
@@ -28,7 +28,7 @@ import {
 } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { ResolvedIrcAccount } from "./accounts.js";
 import { buildIrcAllowlistCandidates, normalizeIrcAllowEntry } from "./normalize.js";
-import { resolveIrcGroupMatch, resolveIrcRequireMention } from "./policy.js";
+import { resolveIrcGroupMatch, resolveIrcGroupRequireMention } from "./policy.js";
 import { getIrcRuntime } from "./runtime.js";
 import { sendMessageIrc } from "./send.js";
 import type { CoreConfig, IrcInboundMessage } from "./types.js";
@@ -253,10 +253,7 @@ export async function handleIrcInbound(params: {
     core.channel.mentions.matchesMentionPatterns(rawBody, mentionRegexes) ||
     (explicitMentionRegex ? explicitMentionRegex.test(rawBody) : false);
   const requireMention = message.isGroup
-    ? resolveIrcRequireMention({
-        groupConfig: groupMatch.groupConfig,
-        wildcardConfig: groupMatch.wildcardConfig,
-      })
+    ? resolveIrcGroupRequireMention({ groups: account.config.groups, target: message.target })
     : false;
   const routeGroupAllowFrom = normalizeStringEntries(
     groupMatch.groupConfig?.allowFrom?.length

--- a/extensions/irc/src/policy.test.ts
+++ b/extensions/irc/src/policy.test.ts
@@ -1,7 +1,11 @@
 // Irc tests cover policy plugin behavior.
 import { resolveChannelGroupPolicy } from "openclaw/plugin-sdk/channel-policy";
 import { describe, expect, it } from "vitest";
-import { resolveIrcGroupMatch, resolveIrcRequireMention } from "./policy.js";
+import {
+  resolveIrcGroupMatch,
+  resolveIrcGroupRequireMention,
+  resolveIrcGroupToolPolicy,
+} from "./policy.js";
 
 describe("irc policy", () => {
   it("matches direct and wildcard group entries", () => {
@@ -12,7 +16,12 @@ describe("irc policy", () => {
       target: "#ops",
     });
     expect(direct.allowed).toBe(true);
-    expect(resolveIrcRequireMention({ groupConfig: direct.groupConfig })).toBe(false);
+    expect(
+      resolveIrcGroupRequireMention({
+        groups: { "#ops": { requireMention: false } },
+        target: "#ops",
+      }),
+    ).toBe(false);
 
     const wildcard = resolveIrcGroupMatch({
       groups: {
@@ -21,7 +30,12 @@ describe("irc policy", () => {
       target: "#random",
     });
     expect(wildcard.allowed).toBe(true);
-    expect(resolveIrcRequireMention({ wildcardConfig: wildcard.wildcardConfig })).toBe(true);
+    expect(
+      resolveIrcGroupRequireMention({
+        groups: { "*": { requireMention: true } },
+        target: "#random",
+      }),
+    ).toBe(true);
   });
 
   it("keeps case-insensitive group matching aligned with shared channel policy resolution", () => {
@@ -52,5 +66,26 @@ describe("irc policy", () => {
     });
     expect(sharedDisabled.allowed).toBe(inboundDisabled.allowed);
     expect(inboundDisabled.groupConfig?.enabled).toBe(false);
+  });
+
+  it("uses exact keys before case-insensitive matches", () => {
+    const groups = {
+      "#Ops": { requireMention: false },
+      "#ops": { requireMention: true },
+    };
+
+    expect(resolveIrcGroupRequireMention({ groups, target: "#ops" })).toBe(true);
+  });
+
+  it("falls through to wildcard fields when the matched field is unset", () => {
+    const groups = {
+      "#ops": { toolsBySender: { "*": { allow: ["sessions.list"] } } },
+      "*": { requireMention: false, tools: { deny: ["exec"] } },
+    };
+
+    expect(resolveIrcGroupRequireMention({ groups, target: "#ops" })).toBe(false);
+    expect(resolveIrcGroupToolPolicy({ groups, target: "#ops" })).toEqual({
+      deny: ["exec"],
+    });
   });
 });

--- a/extensions/irc/src/policy.ts
+++ b/extensions/irc/src/policy.ts
@@ -39,7 +39,7 @@ export function resolveIrcGroupMatch(params: {
   groups?: Record<string, IrcChannelConfig>;
   target: string;
 }): IrcGroupMatch {
-  const { tree, path } = resolveIrcGroupScope(params);
+  const { path } = resolveIrcGroupScope(params);
   const key = path[0];
   const groupConfig = key ? params.groups?.[key] : undefined;
   const wildcardConfig = params.groups?.["*"];

--- a/extensions/irc/src/policy.ts
+++ b/extensions/irc/src/policy.ts
@@ -1,5 +1,11 @@
 // Irc plugin module implements policy behavior.
-import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
+import {
+  resolveScopeKeyCaseInsensitive,
+  resolveScopeRequireMention,
+  resolveScopeToolsPolicy,
+  type GroupToolPolicyConfig,
+  type ScopeTree,
+} from "openclaw/plugin-sdk/channel-policy";
 import type { IrcChannelConfig } from "./types.js";
 
 type IrcGroupMatch = {
@@ -9,71 +15,54 @@ type IrcGroupMatch = {
   hasConfiguredGroups: boolean;
 };
 
+function resolveIrcGroupScope(params: {
+  groups?: Record<string, IrcChannelConfig>;
+  target: string;
+}) {
+  const { "*": wildcard, ...groups } = params.groups ?? {};
+  // This adapter historically reads tools only; do not widen it to toolsBySender.
+  const project = (entry: IrcChannelConfig) => ({
+    requireMention: entry.requireMention,
+    tools: entry.tools,
+  });
+  const tree: ScopeTree = {
+    defaults: wildcard ? project(wildcard) : undefined,
+    scopes: Object.fromEntries(Object.entries(groups).map(([key, entry]) => [key, project(entry)])),
+  };
+  // Legacy IRC matching checks exact keys before case-insensitive keys;
+  // the canonical helper preserves that order.
+  const key = resolveScopeKeyCaseInsensitive(tree, params.target);
+  return { tree, path: key ? [key] : [] };
+}
+
 export function resolveIrcGroupMatch(params: {
   groups?: Record<string, IrcChannelConfig>;
   target: string;
 }): IrcGroupMatch {
-  const groups = params.groups ?? {};
-  const hasConfiguredGroups = Object.keys(groups).length > 0;
-
-  // IRC channel targets are case-insensitive, but config keys are plain strings.
-  // To avoid surprising drops (e.g. "#TUIRC-DEV" vs "#tuirc-dev"), match
-  // group config keys case-insensitively.
-  const direct = groups[params.target];
-  if (direct) {
-    return {
-      // "allowed" means the target matched an allowlisted key.
-      // Explicit disables are represented later as ingress route facts.
-      allowed: true,
-      groupConfig: direct,
-      wildcardConfig: groups["*"],
-      hasConfiguredGroups,
-    };
-  }
-
-  const targetLower = normalizeLowercaseStringOrEmpty(params.target);
-  const directKey = Object.keys(groups).find(
-    (key) => normalizeLowercaseStringOrEmpty(key) === targetLower,
-  );
-  if (directKey) {
-    const matched = groups[directKey];
-    if (matched) {
-      return {
-        // "allowed" means the target matched an allowlisted key.
-        // Explicit disables are represented later as ingress route facts.
-        allowed: true,
-        groupConfig: matched,
-        wildcardConfig: groups["*"],
-        hasConfiguredGroups,
-      };
-    }
-  }
-
-  const wildcard = groups["*"];
-  if (wildcard) {
-    return {
-      // "allowed" means the target matched an allowlisted key.
-      // Explicit disables are represented later as ingress route facts.
-      allowed: true,
-      wildcardConfig: wildcard,
-      hasConfiguredGroups,
-    };
-  }
+  const { tree, path } = resolveIrcGroupScope(params);
+  const key = path[0];
+  const groupConfig = key ? params.groups?.[key] : undefined;
+  const wildcardConfig = params.groups?.["*"];
   return {
-    allowed: false,
-    hasConfiguredGroups,
+    allowed: Boolean(groupConfig ?? wildcardConfig),
+    groupConfig,
+    wildcardConfig,
+    hasConfiguredGroups: Object.keys(params.groups ?? {}).length > 0,
   };
 }
 
-export function resolveIrcRequireMention(params: {
-  groupConfig?: IrcChannelConfig;
-  wildcardConfig?: IrcChannelConfig;
+export function resolveIrcGroupRequireMention(params: {
+  groups?: Record<string, IrcChannelConfig>;
+  target: string;
 }): boolean {
-  if (params.groupConfig?.requireMention !== undefined) {
-    return params.groupConfig.requireMention;
-  }
-  if (params.wildcardConfig?.requireMention !== undefined) {
-    return params.wildcardConfig.requireMention;
-  }
-  return true;
+  const { tree, path } = resolveIrcGroupScope(params);
+  return resolveScopeRequireMention({ tree, path });
+}
+
+export function resolveIrcGroupToolPolicy(params: {
+  groups?: Record<string, IrcChannelConfig>;
+  target: string;
+}): GroupToolPolicyConfig | undefined {
+  const { tree, path } = resolveIrcGroupScope(params);
+  return resolveScopeToolsPolicy({ tree, path });
 }

--- a/extensions/matrix/src/group-mentions.test.ts
+++ b/extensions/matrix/src/group-mentions.test.ts
@@ -1,6 +1,9 @@
 // Matrix tests cover group mentions plugin behavior.
 import { describe, expect, it } from "vitest";
-import { resolveMatrixGroupToolPolicy } from "./group-mentions.js";
+import {
+  resolveMatrixGroupRequireMention,
+  resolveMatrixGroupToolPolicy,
+} from "./group-mentions.js";
 
 describe("Matrix group policy", () => {
   it("resolves room tool policy from the case-preserved Matrix room id", () => {
@@ -26,5 +29,41 @@ describe("Matrix group policy", () => {
     });
 
     expect(policy).toEqual({ allow: ["sessions_spawn"] });
+  });
+
+  it("keeps wildcard fields hidden by a matched whole entry", () => {
+    const params = {
+      accountId: "default",
+      cfg: {
+        channels: {
+          matrix: {
+            groups: {
+              "!room:example.org": {},
+              "*": { requireMention: false, tools: { deny: ["exec"] } },
+            },
+          },
+        },
+      },
+      groupId: "!room:example.org",
+    };
+
+    expect(resolveMatrixGroupRequireMention(params)).toBe(true);
+    expect(resolveMatrixGroupToolPolicy(params)).toBeUndefined();
+  });
+
+  it("projects autoReply ahead of requireMention", () => {
+    const cfg = {
+      channels: {
+        matrix: {
+          rooms: {
+            "!auto:example.org": { autoReply: true, requireMention: true },
+            "!manual:example.org": { autoReply: false, requireMention: false },
+          },
+        },
+      },
+    };
+
+    expect(resolveMatrixGroupRequireMention({ cfg, groupId: "!auto:example.org" })).toBe(false);
+    expect(resolveMatrixGroupRequireMention({ cfg, groupId: "!manual:example.org" })).toBe(true);
   });
 });

--- a/extensions/matrix/src/group-mentions.ts
+++ b/extensions/matrix/src/group-mentions.ts
@@ -1,42 +1,35 @@
 // Matrix plugin module implements group mentions behavior.
+import {
+  resolveScopeRequireMention,
+  resolveScopeToolsPolicy,
+  type GroupToolPolicyConfig,
+} from "openclaw/plugin-sdk/channel-policy";
 import { resolveMatrixAccountConfig } from "./matrix/accounts.js";
-import { resolveMatrixRoomConfig } from "./matrix/monitor/rooms.js";
+import { buildMatrixRoomScopeTree, resolveMatrixRoomScopePath } from "./matrix/monitor/rooms.js";
 import { normalizeMatrixResolvableTarget } from "./matrix/target-ids.js";
-import type { ChannelGroupContext, GroupToolPolicyConfig } from "./runtime-api.js";
+import type { ChannelGroupContext } from "./runtime-api.js";
 import type { CoreConfig } from "./types.js";
 
-function resolveMatrixRoomConfigForGroup(params: ChannelGroupContext) {
+function resolveMatrixGroupScope(params: ChannelGroupContext) {
+  const matrixConfig = resolveMatrixAccountConfig({
+    cfg: params.cfg as CoreConfig,
+    accountId: params.accountId,
+  });
+  const tree = buildMatrixRoomScopeTree(matrixConfig.groups ?? matrixConfig.rooms);
   const roomId = normalizeMatrixResolvableTarget(params.groupId?.trim() ?? "");
-  const groupChannel = params.groupChannel?.trim() ?? "";
-  const aliases = groupChannel ? [normalizeMatrixResolvableTarget(groupChannel)] : [];
-  const cfg = params.cfg as CoreConfig;
-  const matrixConfig = resolveMatrixAccountConfig({ cfg, accountId: params.accountId });
-  return resolveMatrixRoomConfig({
-    rooms: matrixConfig.groups ?? matrixConfig.rooms,
-    roomId,
-    aliases,
-  }).config;
+  const groupChannel = normalizeMatrixResolvableTarget(params.groupChannel?.trim() ?? "");
+  return {
+    tree,
+    path: resolveMatrixRoomScopePath({ tree, roomId, aliases: groupChannel ? [groupChannel] : [] }),
+  };
 }
 
 export function resolveMatrixGroupRequireMention(params: ChannelGroupContext): boolean {
-  const resolved = resolveMatrixRoomConfigForGroup(params);
-  if (resolved) {
-    if (resolved.autoReply === true) {
-      return false;
-    }
-    if (resolved.autoReply === false) {
-      return true;
-    }
-    if (typeof resolved.requireMention === "boolean") {
-      return resolved.requireMention;
-    }
-  }
-  return true;
+  return resolveScopeRequireMention(resolveMatrixGroupScope(params));
 }
 
 export function resolveMatrixGroupToolPolicy(
   params: ChannelGroupContext,
 ): GroupToolPolicyConfig | undefined {
-  const resolved = resolveMatrixRoomConfigForGroup(params);
-  return resolved?.tools;
+  return resolveScopeToolsPolicy(resolveMatrixGroupScope(params));
 }

--- a/extensions/matrix/src/matrix/monitor/rooms.ts
+++ b/extensions/matrix/src/matrix/monitor/rooms.ts
@@ -1,53 +1,53 @@
 // Matrix plugin module implements rooms behavior.
+import type { ScopeNode, ScopePath, ScopeTree } from "openclaw/plugin-sdk/channel-policy";
 import type { MatrixRoomConfig } from "../../types.js";
-import { buildChannelKeyCandidates, resolveChannelEntryMatch } from "./runtime-api.js";
+import { buildChannelKeyCandidates } from "./runtime-api.js";
 
-type MatrixRoomConfigResolved = {
-  allowed: boolean;
-  allowlistConfigured: boolean;
-  config?: MatrixRoomConfig;
-  matchKey?: string;
-  matchSource?: "direct" | "wildcard";
-};
+type MatrixRooms = Record<string, MatrixRoomConfig>;
+type MatrixRoomLookup = { roomId: string; aliases: string[] };
+type MatrixRoomScopeLookup = MatrixRoomLookup & { tree: ScopeTree };
+type MatrixRoomConfigLookup = MatrixRoomLookup & { rooms?: MatrixRooms };
 
 function readLegacyRoomAllowAlias(room: MatrixRoomConfig | undefined): boolean | undefined {
   const rawRoom = room as Record<string, unknown> | undefined;
   return typeof rawRoom?.allow === "boolean" ? rawRoom.allow : undefined;
 }
 
-export function resolveMatrixRoomConfig(params: {
-  rooms?: Record<string, MatrixRoomConfig>;
-  roomId: string;
-  aliases: string[];
-}): MatrixRoomConfigResolved {
-  const rooms = params.rooms ?? {};
-  const keys = Object.keys(rooms);
-  const allowlistConfigured = keys.length > 0;
+export function buildMatrixRoomScopeTree(rooms: MatrixRooms | undefined): ScopeTree {
+  // Whole-entry selection keeps "*" matchable; exact rooms hide every wildcard field.
+  // Build-time autoReply projection gives resolution one deterministic mention value.
+  const scopes: Record<string, ScopeNode> = {};
+  for (const [key, room] of Object.entries(rooms ?? {})) {
+    const requireMention =
+      typeof room.autoReply === "boolean" ? !room.autoReply : room.requireMention;
+    scopes[key] = { requireMention, tools: room.tools };
+  }
+  return { scopes };
+}
+
+export function resolveMatrixRoomScopePath(params: MatrixRoomScopeLookup): ScopePath {
   const candidates = buildChannelKeyCandidates(
     params.roomId,
     `room:${params.roomId}`,
     ...params.aliases,
   );
-  const {
-    entry: matched,
-    key: matchedKey,
-    wildcardEntry,
-    wildcardKey,
-  } = resolveChannelEntryMatch({
-    entries: rooms,
-    keys: candidates,
-    wildcardKey: "*",
-  });
-  const resolved = matched ?? wildcardEntry;
+  const key =
+    candidates.find((candidate) => Object.hasOwn(params.tree.scopes, candidate)) ??
+    (Object.hasOwn(params.tree.scopes, "*") ? "*" : undefined);
+  return key ? [key] : [];
+}
+
+export function resolveMatrixRoomConfig(params: MatrixRoomConfigLookup) {
+  const rooms = params.rooms ?? {};
+  const tree: ScopeTree = { scopes: rooms };
+  const [matchKey] = resolveMatrixRoomScopePath({ ...params, tree });
+  const resolved = matchKey ? rooms[matchKey] : undefined;
   const legacyAllow = readLegacyRoomAllowAlias(resolved);
-  const allowed = resolved ? resolved.enabled !== false && legacyAllow !== false : false;
-  const matchKey = matchedKey ?? wildcardKey;
-  const matchSource = matched ? "direct" : wildcardEntry ? "wildcard" : undefined;
   return {
-    allowed,
-    allowlistConfigured,
+    allowed: resolved ? resolved.enabled !== false && legacyAllow !== false : false,
+    allowlistConfigured: Object.keys(rooms).length > 0,
     config: resolved,
     matchKey,
-    matchSource,
+    matchSource: resolved ? (matchKey === "*" ? "wildcard" : "direct") : undefined,
   };
 }

--- a/extensions/nextcloud-talk/src/channel.ts
+++ b/extensions/nextcloud-talk/src/channel.ts
@@ -9,7 +9,7 @@ import {
   createDefaultChannelRuntimeState,
 } from "openclaw/plugin-sdk/status-helpers";
 import { sanitizeAssistantVisibleText } from "openclaw/plugin-sdk/text-chunking";
-import { resolveNextcloudTalkAccount, type ResolvedNextcloudTalkAccount } from "./accounts.js";
+import type { ResolvedNextcloudTalkAccount } from "./accounts.js";
 import { nextcloudTalkApprovalAuth } from "./approval-auth.js";
 import { probeNextcloudTalkBotResponseFeature } from "./bot-preflight.js";
 import { buildChannelConfigSchema, DEFAULT_ACCOUNT_ID, type ChannelPlugin } from "./channel-api.js";
@@ -27,13 +27,15 @@ import {
   looksLikeNextcloudTalkTargetId,
   normalizeNextcloudTalkMessagingTarget,
 } from "./normalize.js";
-import { resolveNextcloudTalkGroupToolPolicy } from "./policy.js";
+import {
+  resolveNextcloudTalkGroupRequireMention,
+  resolveNextcloudTalkGroupToolPolicy,
+} from "./policy.js";
 import { getNextcloudTalkRuntime } from "./runtime.js";
 import { collectRuntimeConfigAssignments, secretTargetRegistryEntries } from "./secret-contract.js";
 import { resolveNextcloudTalkOutboundSessionRoute } from "./session-route.js";
 import { nextcloudTalkSetupAdapter } from "./setup-core.js";
 import { nextcloudTalkSetupWizard } from "./setup-surface.js";
-import type { CoreConfig } from "./types.js";
 
 const meta = {
   id: "nextcloud-talk",
@@ -101,25 +103,7 @@ export const nextcloudTalkPlugin: ChannelPlugin<ResolvedNextcloudTalkAccount> =
       approvalCapability: nextcloudTalkApprovalAuth,
       doctor: nextcloudTalkDoctor,
       groups: {
-        resolveRequireMention: ({ cfg, accountId, groupId }) => {
-          const account = resolveNextcloudTalkAccount({ cfg: cfg as CoreConfig, accountId });
-          const rooms = account.config.rooms;
-          if (!rooms || !groupId) {
-            return true;
-          }
-
-          const roomConfig = rooms[groupId];
-          if (roomConfig?.requireMention !== undefined) {
-            return roomConfig.requireMention;
-          }
-
-          const wildcardConfig = rooms["*"];
-          if (wildcardConfig?.requireMention !== undefined) {
-            return wildcardConfig.requireMention;
-          }
-
-          return true;
-        },
+        resolveRequireMention: resolveNextcloudTalkGroupRequireMention,
         resolveToolPolicy: resolveNextcloudTalkGroupToolPolicy,
       },
       messaging: {

--- a/extensions/nextcloud-talk/src/inbound.ts
+++ b/extensions/nextcloud-talk/src/inbound.ts
@@ -27,8 +27,8 @@ import type { ResolvedNextcloudTalkAccount } from "./accounts.js";
 import {
   normalizeNextcloudTalkAllowEntry,
   normalizeNextcloudTalkAllowlist,
+  resolveNextcloudTalkGroupRequireMention,
   resolveNextcloudTalkAllowlistMatch,
-  resolveNextcloudTalkRequireMention,
   resolveNextcloudTalkRoomMatch,
 } from "./policy.js";
 import { resolveNextcloudTalkRoomKind } from "./room-info.js";
@@ -159,9 +159,10 @@ export async function handleNextcloudTalkInbound(params: {
   });
   const hasControlCommand = core.channel.text.hasControlCommand(rawBody, config as OpenClawConfig);
   const shouldRequireMention = isGroup
-    ? resolveNextcloudTalkRequireMention({
-        roomConfig,
-        wildcardConfig: roomMatch.wildcardConfig,
+    ? resolveNextcloudTalkGroupRequireMention({
+        cfg: config as OpenClawConfig,
+        accountId: account.accountId,
+        groupId: roomToken,
       })
     : false;
   const { groupPolicy, providerMissingFallbackApplied } =

--- a/extensions/nextcloud-talk/src/policy.test.ts
+++ b/extensions/nextcloud-talk/src/policy.test.ts
@@ -1,0 +1,48 @@
+// Nextcloud Talk tests cover group policy plugin behavior.
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { describe, expect, it } from "vitest";
+import {
+  resolveNextcloudTalkGroupRequireMention,
+  resolveNextcloudTalkGroupToolPolicy,
+} from "./policy.js";
+
+describe("nextcloud-talk group policy", () => {
+  it("keeps exact mention matching separate from slug-matched tools", () => {
+    const cfg = {
+      channels: {
+        "nextcloud-talk": {
+          rooms: {
+            "team-room": {
+              requireMention: false,
+              tools: { allow: ["sessions.list"] },
+            },
+            "*": { requireMention: true, tools: { deny: ["exec"] } },
+          },
+        },
+      },
+    } as OpenClawConfig;
+    const params = { cfg, groupId: "Team Room" };
+
+    expect(resolveNextcloudTalkGroupRequireMention(params)).toBe(true);
+    expect(resolveNextcloudTalkGroupToolPolicy(params)).toEqual({
+      allow: ["sessions.list"],
+    });
+  });
+
+  it("falls through to wildcard fields when the exact room field is unset", () => {
+    const cfg = {
+      channels: {
+        "nextcloud-talk": {
+          rooms: {
+            "team-room": {},
+            "*": { requireMention: false, tools: { deny: ["exec"] } },
+          },
+        },
+      },
+    } as OpenClawConfig;
+    const params = { cfg, groupId: "team-room" };
+
+    expect(resolveNextcloudTalkGroupRequireMention(params)).toBe(false);
+    expect(resolveNextcloudTalkGroupToolPolicy(params)).toEqual({ deny: ["exec"] });
+  });
+});

--- a/extensions/nextcloud-talk/src/policy.ts
+++ b/extensions/nextcloud-talk/src/policy.ts
@@ -1,12 +1,17 @@
+import {
+  resolveScopeRequireMention,
+  resolveScopeToolsPolicy,
+  type ScopeTree,
+} from "openclaw/plugin-sdk/channel-policy";
 // Nextcloud Talk plugin module implements policy behavior.
 import {
   buildChannelKeyCandidates,
   normalizeChannelSlug,
   resolveChannelEntryMatchWithFallback,
-  resolveNestedAllowlistDecision,
 } from "openclaw/plugin-sdk/channel-targets";
 import type { AllowlistMatch, ChannelGroupContext, GroupToolPolicyConfig } from "../runtime-api.js";
-import type { NextcloudTalkRoomConfig } from "./types.js";
+import { resolveNextcloudTalkAccount } from "./accounts.js";
+import type { CoreConfig, NextcloudTalkRoomConfig } from "./types.js";
 
 export function normalizeNextcloudTalkAllowEntry(raw: string): string {
   return raw
@@ -35,41 +40,25 @@ export function resolveNextcloudTalkAllowlistMatch(params: {
     return { allowed: true, matchKey: "*", matchSource: "wildcard" };
   }
   const senderId = normalizeNextcloudTalkAllowEntry(params.senderId);
-  if (allowFrom.includes(senderId)) {
-    return { allowed: true, matchKey: senderId, matchSource: "id" };
-  }
-  return { allowed: false };
+  return allowFrom.includes(senderId)
+    ? { allowed: true, matchKey: senderId, matchSource: "id" }
+    : { allowed: false };
 }
-
-type NextcloudTalkRoomMatch = {
-  roomConfig?: NextcloudTalkRoomConfig;
-  wildcardConfig?: NextcloudTalkRoomConfig;
-  roomKey?: string;
-  matchSource?: "direct" | "parent" | "wildcard";
-  allowed: boolean;
-  allowlistConfigured: boolean;
-};
 
 export function resolveNextcloudTalkRoomMatch(params: {
   rooms?: Record<string, NextcloudTalkRoomConfig>;
   roomToken: string;
-}): NextcloudTalkRoomMatch {
+}) {
   const rooms = params.rooms ?? {};
   const allowlistConfigured = Object.keys(rooms).length > 0;
-  const roomCandidates = buildChannelKeyCandidates(params.roomToken);
   const match = resolveChannelEntryMatchWithFallback({
     entries: rooms,
-    keys: roomCandidates,
+    keys: buildChannelKeyCandidates(params.roomToken),
     wildcardKey: "*",
     normalizeKey: normalizeChannelSlug,
   });
   const roomConfig = match.entry;
-  const allowed = resolveNestedAllowlistDecision({
-    outerConfigured: allowlistConfigured,
-    outerMatched: Boolean(roomConfig),
-    innerConfigured: false,
-    innerMatched: false,
-  });
+  const allowed = !allowlistConfigured || Boolean(roomConfig);
 
   return {
     roomConfig,
@@ -84,29 +73,43 @@ export function resolveNextcloudTalkRoomMatch(params: {
 export function resolveNextcloudTalkGroupToolPolicy(
   params: ChannelGroupContext,
 ): GroupToolPolicyConfig | undefined {
-  const cfg = params.cfg as {
-    channels?: { "nextcloud-talk"?: { rooms?: Record<string, NextcloudTalkRoomConfig> } };
-  };
   const roomToken = params.groupId?.trim();
   if (!roomToken) {
     return undefined;
   }
-  const match = resolveNextcloudTalkRoomMatch({
-    rooms: cfg.channels?.["nextcloud-talk"]?.rooms,
-    roomToken,
+  const account = resolveNextcloudTalkAccount({
+    cfg: params.cfg as CoreConfig,
+    accountId: params.accountId,
   });
-  return match.roomConfig?.tools ?? match.wildcardConfig?.tools;
+  const { tree, toolsPath } = buildNextcloudTalkRoomScope(account.config.rooms, roomToken);
+  return resolveScopeToolsPolicy({ tree, path: toolsPath });
 }
 
-export function resolveNextcloudTalkRequireMention(params: {
-  roomConfig?: NextcloudTalkRoomConfig;
-  wildcardConfig?: NextcloudTalkRoomConfig;
-}): boolean {
-  if (typeof params.roomConfig?.requireMention === "boolean") {
-    return params.roomConfig.requireMention;
+function buildNextcloudTalkRoomScope(
+  rooms: Record<string, NextcloudTalkRoomConfig> | undefined,
+  roomToken: string,
+) {
+  const { "*": defaults, ...scopes } = rooms ?? {};
+  const tree: ScopeTree = { defaults, scopes };
+  // Mentions use exact room tokens; tools retain legacy slug matching.
+  // Separate paths prevent one question from widening the other.
+  const exactPath = Object.hasOwn(scopes, roomToken) ? [roomToken] : [];
+  const toolsMatch = resolveChannelEntryMatchWithFallback({
+    entries: scopes,
+    keys: buildChannelKeyCandidates(roomToken),
+    normalizeKey: normalizeChannelSlug,
+  });
+  return { tree, exactPath, toolsPath: toolsMatch.matchKey ? [toolsMatch.matchKey] : [] };
+}
+
+export function resolveNextcloudTalkGroupRequireMention(params: ChannelGroupContext): boolean {
+  if (!params.groupId) {
+    return true;
   }
-  if (typeof params.wildcardConfig?.requireMention === "boolean") {
-    return params.wildcardConfig.requireMention;
-  }
-  return true;
+  const account = resolveNextcloudTalkAccount({
+    cfg: params.cfg as CoreConfig,
+    accountId: params.accountId,
+  });
+  const { tree, exactPath } = buildNextcloudTalkRoomScope(account.config.rooms, params.groupId);
+  return resolveScopeRequireMention({ tree, path: exactPath });
 }

--- a/extensions/slack/src/group-policy.test.ts
+++ b/extensions/slack/src/group-policy.test.ts
@@ -1,5 +1,5 @@
-import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 // Slack tests cover group policy plugin behavior.
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { describe, expect, it } from "vitest";
 import { resolveSlackGroupRequireMention, resolveSlackGroupToolPolicy } from "./group-policy.js";
 
@@ -52,5 +52,46 @@ describe("slack group policy", () => {
       senderId: "user:bob",
     });
     expect(wildcardTools).toEqual({ deny: ["exec"] });
+  });
+
+  it("keeps wildcard fields hidden by a matched whole entry", () => {
+    const partialCfg = {
+      channels: {
+        slack: {
+          channels: {
+            partial: {},
+            "*": { requireMention: false, tools: { deny: ["exec"] } },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(resolveSlackGroupRequireMention({ cfg: partialCfg, groupId: "partial" })).toBe(true);
+    expect(resolveSlackGroupToolPolicy({ cfg: partialCfg, groupId: "partial" })).toBeUndefined();
+  });
+
+  it("does not match channel-prefixed toolsBySender without a message provider", () => {
+    const channelSenderCfg = {
+      channels: {
+        slack: {
+          channels: {
+            alerts: {
+              tools: { deny: ["exec"] },
+              toolsBySender: {
+                "channel:slack:user:alice": { allow: ["exec"] },
+              },
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(
+      resolveSlackGroupToolPolicy({
+        cfg: channelSenderCfg,
+        groupId: "alerts",
+        senderId: "user:alice",
+      }),
+    ).toEqual({ deny: ["exec"] });
   });
 });

--- a/extensions/slack/src/group-policy.ts
+++ b/extensions/slack/src/group-policy.ts
@@ -2,9 +2,11 @@
 import { normalizeAccountId } from "openclaw/plugin-sdk/account-resolution";
 import type { ChannelGroupContext } from "openclaw/plugin-sdk/channel-contract";
 import {
-  resolveToolsBySender,
+  resolveScopeRequireMention,
+  resolveScopeToolsPolicy,
   type GroupToolPolicyBySenderConfig,
   type GroupToolPolicyConfig,
+  type ScopeTree,
 } from "openclaw/plugin-sdk/channel-policy";
 import { normalizeHyphenSlug } from "openclaw/plugin-sdk/string-normalization-runtime";
 import { mergeSlackAccountConfig, resolveDefaultSlackAccountId } from "./accounts.js";
@@ -15,64 +17,45 @@ type SlackChannelPolicyEntry = {
   toolsBySender?: GroupToolPolicyBySenderConfig;
 };
 
-function resolveSlackChannelPolicyEntry(
-  params: ChannelGroupContext,
-): SlackChannelPolicyEntry | undefined {
+function resolveSlackChannelPolicyScope(params: ChannelGroupContext) {
   const accountId = normalizeAccountId(
     params.accountId ?? resolveDefaultSlackAccountId(params.cfg),
   );
   const channels = mergeSlackAccountConfig(params.cfg, accountId).channels as
     | Record<string, SlackChannelPolicyEntry>
     | undefined;
-  const channelMap = channels ?? {};
-  if (Object.keys(channelMap).length === 0) {
-    return undefined;
-  }
+  // Whole-entry selection: an exact channel hides every wildcard field.
+  // The wildcard is a normal scope selected only after all candidates miss.
+  const tree: ScopeTree = { scopes: channels ?? {} };
   const channelId = params.groupId?.trim();
-  const groupChannel = params.groupChannel;
-  const channelName = groupChannel?.replace(/^#/, "");
-  const normalizedName = normalizeHyphenSlug(channelName);
+  const channelName = params.groupChannel?.replace(/^#/, "");
   const candidates = [
-    channelId ?? "",
-    channelName ? `#${channelName}` : "",
-    channelName ?? "",
-    normalizedName,
-  ].filter(Boolean);
-  for (const candidate of candidates) {
-    if (candidate && channelMap[candidate]) {
-      return channelMap[candidate];
-    }
-  }
-  return channelMap["*"];
-}
-
-function resolveSenderToolsEntry(
-  entry: SlackChannelPolicyEntry | undefined,
-  params: ChannelGroupContext,
-): GroupToolPolicyConfig | undefined {
-  if (!entry) {
-    return undefined;
-  }
-  const senderPolicy = resolveToolsBySender({
-    toolsBySender: entry.toolsBySender,
-    senderId: params.senderId,
-    senderName: params.senderName,
-    senderUsername: params.senderUsername,
-    senderE164: params.senderE164,
-  });
-  return senderPolicy ?? entry.tools;
+    channelId,
+    channelName ? `#${channelName}` : undefined,
+    channelName,
+    normalizeHyphenSlug(channelName),
+  ].filter((candidate): candidate is string => Boolean(candidate));
+  const key =
+    candidates.find((candidate) => Object.hasOwn(tree.scopes, candidate)) ??
+    (Object.hasOwn(tree.scopes, "*") ? "*" : undefined);
+  return { tree, path: key ? [key] : [] };
 }
 
 export function resolveSlackGroupRequireMention(params: ChannelGroupContext): boolean {
-  const resolved = resolveSlackChannelPolicyEntry(params);
-  if (typeof resolved?.requireMention === "boolean") {
-    return resolved.requireMention;
-  }
-  return true;
+  // The adapter intentionally ignores root requireMention; the monitor resolves that default.
+  return resolveScopeRequireMention(resolveSlackChannelPolicyScope(params));
 }
 
 export function resolveSlackGroupToolPolicy(
   params: ChannelGroupContext,
 ): GroupToolPolicyConfig | undefined {
-  return resolveSenderToolsEntry(resolveSlackChannelPolicyEntry(params), params);
+  const scope = resolveSlackChannelPolicyScope(params);
+  // No messageProvider: this path historically never matched channel-prefixed sender keys.
+  return resolveScopeToolsPolicy({
+    ...scope,
+    senderId: params.senderId,
+    senderName: params.senderName,
+    senderUsername: params.senderUsername,
+    senderE164: params.senderE164,
+  });
 }

--- a/extensions/zalouser/src/channel.adapters.ts
+++ b/extensions/zalouser/src/channel.adapters.ts
@@ -103,7 +103,7 @@ function resolveZalouserGroupPolicyScope(params: ChannelGroupContext) {
     buildZalouserGroupCandidates({
       groupId: params.groupId,
       groupChannel: params.groupChannel,
-      includeWildcard: false,
+      // The adapter falls back to the "*" entry when no candidate matches.
       allowNameMatching: isDangerousNameMatchingEnabled(account.config),
     }),
   );

--- a/extensions/zalouser/src/channel.adapters.ts
+++ b/extensions/zalouser/src/channel.adapters.ts
@@ -6,6 +6,10 @@ import {
 } from "openclaw/plugin-sdk/channel-outbound";
 import { createPairingPrefixStripper } from "openclaw/plugin-sdk/channel-pairing";
 import {
+  resolveScopeRequireMention,
+  resolveScopeToolsPolicy,
+} from "openclaw/plugin-sdk/channel-policy";
+import {
   createEmptyChannelResult,
   type ChannelOutboundAdapter,
   type OutboundDeliveryResult,
@@ -35,7 +39,7 @@ import {
   normalizeAccountId,
   sendPayloadWithChunkedTextAndMedia,
 } from "./channel-api.js";
-import { buildZalouserGroupCandidates, findZalouserGroupEntry } from "./group-policy.js";
+import { buildZalouserGroupCandidates, resolveZalouserGroupScope } from "./group-policy.js";
 import { resolveZalouserReactionMessageIds } from "./message-sid.js";
 import { writeQrDataUrlToTempFile } from "./qr-temp-file.js";
 import { getZalouserRuntime } from "./runtime.js";
@@ -89,18 +93,17 @@ function toZalouserMessageSendResult(result: ZaloSendResult): ChannelMessageSend
   };
 }
 
-function resolveZalouserGroupPolicyEntry(params: ChannelGroupContext) {
+function resolveZalouserGroupPolicyScope(params: ChannelGroupContext) {
   const account = resolveZalouserAccountSync({
     cfg: params.cfg,
     accountId: params.accountId ?? undefined,
   });
-  const groups = account.config.groups ?? {};
-  return findZalouserGroupEntry(
-    groups,
+  return resolveZalouserGroupScope(
+    account.config.groups,
     buildZalouserGroupCandidates({
       groupId: params.groupId,
       groupChannel: params.groupChannel,
-      includeWildcard: true,
+      includeWildcard: false,
       allowNameMatching: isDangerousNameMatchingEnabled(account.config),
     }),
   );
@@ -109,15 +112,11 @@ function resolveZalouserGroupPolicyEntry(params: ChannelGroupContext) {
 function resolveZalouserGroupToolPolicy(
   params: ChannelGroupContext,
 ): GroupToolPolicyConfig | undefined {
-  return resolveZalouserGroupPolicyEntry(params)?.tools;
+  return resolveScopeToolsPolicy(resolveZalouserGroupPolicyScope(params));
 }
 
 function resolveZalouserRequireMention(params: ChannelGroupContext): boolean {
-  const entry = resolveZalouserGroupPolicyEntry(params);
-  if (typeof entry?.requireMention === "boolean") {
-    return entry.requireMention;
-  }
-  return true;
+  return resolveScopeRequireMention(resolveZalouserGroupPolicyScope(params));
 }
 
 async function sendZalouserTextFromContext({

--- a/extensions/zalouser/src/group-policy.test.ts
+++ b/extensions/zalouser/src/group-policy.test.ts
@@ -1,10 +1,15 @@
 // Zalouser tests cover group policy plugin behavior.
+import {
+  resolveScopeRequireMention,
+  resolveScopeToolsPolicy,
+} from "openclaw/plugin-sdk/channel-policy";
 import { describe, expect, it } from "vitest";
 import {
   buildZalouserGroupCandidates,
   findZalouserGroupEntry,
   isZalouserGroupEntryAllowed,
   normalizeZalouserGroupSlug,
+  resolveZalouserGroupScope,
 } from "./group-policy.js";
 
 describe("zalouser group policy helpers", () => {
@@ -24,7 +29,7 @@ describe("zalouser group policy helpers", () => {
     ).toEqual(["123", "group:123", "chan-1", "Team Alpha", "team-alpha", "*"]);
   });
 
-  it("builds id-only candidates when name matching is disabled", () => {
+  it("gates name candidates behind dangerouslyAllowNameMatching", () => {
     expect(
       buildZalouserGroupCandidates({
         groupId: "123",
@@ -58,5 +63,38 @@ describe("zalouser group policy helpers", () => {
     expect(isZalouserGroupEntryAllowed({ allow: false } as never)).toBe(false);
     expect(isZalouserGroupEntryAllowed({ enabled: false })).toBe(false);
     expect(isZalouserGroupEntryAllowed(undefined)).toBe(false);
+  });
+
+  it("keeps wildcard fields hidden by a matched whole entry", () => {
+    const scope = resolveZalouserGroupScope(
+      {
+        "123": {},
+        "*": { requireMention: false, tools: { deny: ["exec"] } },
+      },
+      ["123"],
+    );
+
+    expect(resolveScopeRequireMention(scope)).toBe(true);
+    expect(resolveScopeToolsPolicy(scope)).toBeUndefined();
+  });
+
+  it("selects name candidates only when dangerous name matching is enabled", () => {
+    const groups = {
+      "team-alpha": { requireMention: false },
+      "*": { requireMention: true },
+    };
+    const buildScope = (allowNameMatching: boolean) =>
+      resolveZalouserGroupScope(
+        groups,
+        buildZalouserGroupCandidates({
+          groupId: "123",
+          groupName: "Team Alpha",
+          includeWildcard: false,
+          allowNameMatching,
+        }),
+      );
+
+    expect(resolveScopeRequireMention(buildScope(false))).toBe(true);
+    expect(resolveScopeRequireMention(buildScope(true))).toBe(false);
   });
 });

--- a/extensions/zalouser/src/group-policy.ts
+++ b/extensions/zalouser/src/group-policy.ts
@@ -65,11 +65,12 @@ export function resolveZalouserGroupScope(
   candidates: string[],
 ) {
   // Whole-entry selection: an exact candidate hides every wildcard field.
-  // The wildcard is selected only when all explicit candidates miss.
+  // Callers opt into the wildcard by including "*" in candidates
+  // (buildZalouserGroupCandidates honors includeWildcard: false).
   const tree: ScopeTree = { scopes: groups ?? {} };
   const key =
     candidates.find((candidate) => candidate !== "*" && Object.hasOwn(tree.scopes, candidate)) ??
-    (Object.hasOwn(tree.scopes, "*") ? "*" : undefined);
+    (candidates.includes("*") && Object.hasOwn(tree.scopes, "*") ? "*" : undefined);
   return { tree, path: key ? [key] : [] };
 }
 

--- a/extensions/zalouser/src/group-policy.ts
+++ b/extensions/zalouser/src/group-policy.ts
@@ -1,18 +1,14 @@
 // Zalouser plugin module implements group policy behavior.
+import type { ScopeTree } from "openclaw/plugin-sdk/channel-policy";
 import { normalizeOptionalLowercaseString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { ZalouserGroupConfig } from "./types.js";
 
 type ZalouserGroups = Record<string, ZalouserGroupConfig>;
 
-function toGroupCandidate(value?: string | null): string {
-  return value?.trim() ?? "";
-}
+const toGroupCandidate = (value?: string | null) => value?.trim() ?? "";
 
 export function normalizeZalouserGroupSlug(raw?: string | null): string {
   const trimmed = normalizeOptionalLowercaseString(raw) ?? "";
-  if (!trimmed) {
-    return "";
-  }
   return trimmed
     .replace(/^#/, "")
     .replace(/[^a-z0-9]+/g, "-")
@@ -47,11 +43,7 @@ export function buildZalouserGroupCandidates(params: {
     push(`group:${groupId}`);
   }
   if (params.allowNameMatching !== false) {
-    push(groupChannel);
-    push(groupName);
-    if (groupName) {
-      push(normalizeZalouserGroupSlug(groupName));
-    }
+    [groupChannel, groupName, normalizeZalouserGroupSlug(groupName)].forEach(push);
   }
   if (params.includeWildcard !== false) {
     push("*");
@@ -63,16 +55,22 @@ export function findZalouserGroupEntry(
   groups: ZalouserGroups | undefined,
   candidates: string[],
 ): ZalouserGroupConfig | undefined {
-  if (!groups) {
-    return undefined;
-  }
-  for (const candidate of candidates) {
-    const entry = groups[candidate];
-    if (entry) {
-      return entry;
-    }
-  }
-  return undefined;
+  const { tree, path } = resolveZalouserGroupScope(groups, candidates);
+  const key = path[0];
+  return key ? (tree.scopes[key] as ZalouserGroupConfig | undefined) : undefined;
+}
+
+export function resolveZalouserGroupScope(
+  groups: ZalouserGroups | undefined,
+  candidates: string[],
+) {
+  // Whole-entry selection: an exact candidate hides every wildcard field.
+  // The wildcard is selected only when all explicit candidates miss.
+  const tree: ScopeTree = { scopes: groups ?? {} };
+  const key =
+    candidates.find((candidate) => candidate !== "*" && Object.hasOwn(tree.scopes, candidate)) ??
+    (Object.hasOwn(tree.scopes, "*") ? "*" : undefined);
+  return { tree, path: key ? [key] : [] };
 }
 
 export function isZalouserGroupEntryAllowed(entry: ZalouserGroupConfig | undefined): boolean {


### PR DESCRIPTION
## What Problem This Solves

Third and fourth channel batches of the group-policy scope normalization: irc, nextcloud-talk, zalouser, slack, and matrix still resolved group `requireMention`/tool policy through private walkers over channel-specific config shapes. Eleven of sixteen adapters now share the canonical ScopeTree resolver.

## Why This Change Was Made

Continues #106846 (core resolver + first six channels). The parity-critical distinction this batch encodes: irc and nextcloud-talk use FIELD-LEVEL wildcard fallback (a matched entry's unset field falls through to `"*"`, expressed as the tree's defaults node), while slack, matrix, and zalouser use WHOLE-ENTRY selection (the first candidate hit hides the wildcard entirely, expressed as `"*"` being an ordinary scope key selected only when all candidates miss) — each builder documents its contract. Matrix's `autoReply` precedence is projected into `requireMention` at build time; slack/matrix continue to omit `messageProvider` so `channel:`-prefixed sender keys stay dead on those paths; nextcloud's requireMention (exact-key) vs tools (slug-normalized) matching asymmetry is preserved and its dead duplicate resolver deleted; irc/nextcloud inbound paths were deduplicated onto the same resolvers. Zalo was intentionally skipped: its adapter is a constant `true`, already the leanest expression.

## User Impact

None — behavior parity pinned per channel: whole-entry channels return the default when the matched entry lacks a field even though `"*"` has it; field-level channels fall through; matrix autoReply beats requireMention; slack `channel:`-prefixed toolsBySender keys do not match; zalouser wildcard lookup stays opt-in for explicit-only candidate lists (review-caught and fixed, with the adapter opting in); irc exact keys beat case-insensitive matches.

## Evidence

- Blacksmith Testbox: `pnpm test extensions/irc extensions/nextcloud-talk extensions/zalouser extensions/slack extensions/matrix src/config/group-scope-tree.test.ts` all green; `check:changed` green through every lane (typecheck extensions, lint extensions, LOC ratchet, SDK baseline — no SDK surface changes in this batch).
- Autoreview (codex gpt-5.6-sol, xhigh): one real finding — zalouser wildcard fallback ignoring `includeWildcard: false` — fixed (resolver honors candidates; adapter opts in); final pass clean, "patch is correct (0.9)".
- New/extended parity tests across all five channels incl. a new nextcloud-talk policy test file.
