### PR TITLE
improve(gateway): avoid redundant plugin route lookup

### DIFF
--- a/src/gateway/server-runtime-state.test.ts
+++ b/src/gateway/server-runtime-state.test.ts
@@ -16,6 +16,7 @@ import {
   resolveActivePluginHttpRouteRegistry,
   setActivePluginRegistry,
 } from "../plugins/runtime.js";
+import { createRequest, createResponse, dispatchRequest } from "./server-http.test-harness.js";
 import { createGatewayRuntimeStateForTest } from "./test-helpers.server-runtime-state.js";
 
 const mocks = vi.hoisted(() => ({
@@ -82,6 +83,56 @@ describe("createGatewayRuntimeState", () => {
     expect(resolveActivePluginHttpRouteRegistry(fallbackRegistry)).toBe(startupRegistry);
     expect(getActivePluginSessionExtensionRegistry()).toBe(startupRegistry);
     expect(getActivePluginChannelRegistry()).toBe(startupRegistry);
+  });
+
+  it("avoids the wrapper registry lookup after the plugin request handler loads", async () => {
+    const startupRegistry = createRegistryWithRoute("/plugin");
+    startupRegistry.httpRoutes[0]!.handler = (_req, res) => {
+      res.end("startup");
+      return true;
+    };
+    const repinnedRegistry = createRegistryWithRoute("/plugin");
+    repinnedRegistry.httpRoutes[0]!.handler = (_req, res) => {
+      res.end("repinned");
+      return true;
+    };
+    let activeRegistry = startupRegistry;
+    const getPluginRouteRegistry = vi.fn(() => activeRegistry);
+    const runtimeState = await createGatewayRuntimeStateForTest(startupRegistry, {
+      getPluginRouteRegistry,
+    });
+
+    const firstResponse = createResponse();
+    await dispatchRequest(
+      runtimeState.httpServer,
+      createRequest({ path: "/plugin" }),
+      firstResponse.res,
+    );
+    const firstRequestLookups = getPluginRouteRegistry.mock.calls.length;
+
+    activeRegistry = createEmptyPluginRegistry();
+    const removedRouteResponse = createResponse();
+    await dispatchRequest(
+      runtimeState.httpServer,
+      createRequest({ path: "/plugin" }),
+      removedRouteResponse.res,
+    );
+    const removedRouteLookups = getPluginRouteRegistry.mock.calls.length;
+
+    activeRegistry = repinnedRegistry;
+    const repinnedRouteResponse = createResponse();
+    await dispatchRequest(
+      runtimeState.httpServer,
+      createRequest({ path: "/plugin" }),
+      repinnedRouteResponse.res,
+    );
+
+    expect(firstResponse.getBody()).toBe("startup");
+    expect(removedRouteResponse.res.statusCode).toBe(404);
+    expect(repinnedRouteResponse.getBody()).toBe("repinned");
+    expect(firstRequestLookups).toBe(4);
+    expect(removedRouteLookups - firstRequestLookups).toBe(3);
+    expect(getPluginRouteRegistry.mock.calls.length - removedRouteLookups).toBe(3);
   });
 
   it("fails startup when the required IPv4 loopback alias cannot bind", async () => {

--- a/src/gateway/server-runtime-state.ts
+++ b/src/gateway/server-runtime-state.ts
@@ -222,21 +222,22 @@ export async function createGatewayRuntimeState(params: {
       pathContext,
       dispatchContext,
     ) => {
+      if (loadedPluginRequestHandler) {
+        return await loadedPluginRequestHandler(req, res, pathContext, dispatchContext);
+      }
       const registry = resolvePluginRouteRegistry();
       if ((registry.httpRoutes ?? []).length === 0) {
         return false;
       }
-      if (!loadedPluginRequestHandler) {
-        // Route registries can be re-pinned after bootstrap; keep the handler lazy and route
-        // lookup dynamic so plugin HTTP routes follow the active registry snapshot.
-        const { createGatewayPluginRequestHandler } = await loadGatewayPluginsHttpModule();
-        loadedPluginRequestHandler = createGatewayPluginRequestHandler({
-          registry: params.pluginRegistry,
-          getRouteRegistry: resolvePluginRouteRegistry,
-          log: params.logPlugins,
-          getGatewayRequestContext: params.getGatewayRequestContext,
-        });
-      }
+      // Route registries can be re-pinned after bootstrap. The loaded handler keeps its route
+      // lookup dynamic, while this wrapper only needs to guard the initial lazy import.
+      const { createGatewayPluginRequestHandler } = await loadGatewayPluginsHttpModule();
+      loadedPluginRequestHandler = createGatewayPluginRequestHandler({
+        registry: params.pluginRegistry,
+        getRouteRegistry: resolvePluginRouteRegistry,
+        log: params.logPlugins,
+        getGatewayRequestContext: params.getGatewayRequestContext,
+      });
       return await loadedPluginRequestHandler(req, res, pathContext, dispatchContext);
     };
     const handlePluginUpgrade: GatewayPluginUpgradeHandler = async (


### PR DESCRIPTION
Closes #106649

## What Problem This Solves

Warmed plugin HTTP requests resolved the active route registry in both the Gateway dispatch wrapper and the loaded handler. The wrapper lookup was redundant after lazy initialization and added one accessor call to every plugin API request.

## Solution

Once the plugin request handler is loaded, the wrapper delegates directly to it. The cold-path empty-registry guard still prevents importing the plugin HTTP runtime when no routes exist. The loaded handler continues to resolve the current registry on every request, so route removal and re-pinning remain dynamic.

## Impact

Warmed plugin HTTP requests use 3 route-registry lookups instead of 4, a 25% reduction in registry accessor calls on this dispatch path. Source behavior is unchanged for cold startup, removed routes, and replacement registries.

## Evidence

Exact head: `ed07096896fef68669ab6fad98928c9ac498604f`

An isolated production Gateway HTTP runtime was bound to a real loopback TCP listener. Requests used `fetch` over HTTP; the active plugin route registry was then removed and replaced in-process.

```text
cold:    status=200 body="startup"  lookups=4
warm:    status=200 body="startup"  lookups=7  (+3)
removed: status=404 body="Not Found" lookups=10 (+3)
repinned: status=200 body="repinned" lookups=13 (+3)
```

This demonstrates that warmed requests eliminate the extra wrapper lookup while dynamic removal and re-pinning still affect the next real HTTP request.

## Validation

- `OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs run src/gateway/server-runtime-state.test.ts src/gateway/server/plugins-http.test.ts` -> 2 files, 30 tests passed
- Exact current-head loopback Gateway proof -> 1 temporary proof test passed with the transcript above; the temporary proof harness was removed after capture
- `pnpm exec oxfmt --check src/gateway/server-runtime-state.ts src/gateway/server-runtime-state.test.ts` -> passed
- `git diff --check` -> passed
- `codex review --base upstream/main` -> no actionable regression found
- Broad checks are running in GitHub CI on the rebased head

AI-assisted: yes. I reviewed the production call path, regression coverage, live proof, generated diff, and validation output.

Signed-off-by: Ho Lim <subhoya@gmail.com>


