### PR TITLE
refactor(codex): use native SemVer floor comparison

### DIFF
--- a/extensions/codex/src/app-server/client.ts
+++ b/extensions/codex/src/app-server/client.ts
@@ -6,7 +6,7 @@ import { randomUUID } from "node:crypto";
 import { createInterface, type Interface as ReadlineInterface } from "node:readline";
 import { embeddedAgentLog, OPENCLAW_VERSION } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
-import { compare as compareSemver, parse as parseSemver } from "semver";
+import { parse as parseSemver } from "semver";
 import { resolveCodexAppServerRuntimeOptions, type CodexAppServerStartOptions } from "./config.js";
 import {
   type CodexAppServerRequestMethod,
@@ -896,9 +896,13 @@ class CodexAppServerVersionError extends Error {
 
 function assertSupportedCodexAppServerVersion(response: CodexInitializeResponse): string {
   const detectedVersion = readCodexVersionFromUserAgent(response.userAgent);
+  const parsedVersion = parseSemver(detectedVersion ?? "");
   if (
     !detectedVersion ||
-    compareCodexAppServerVersions(detectedVersion, MIN_CODEX_APP_SERVER_VERSION) < 0
+    !parsedVersion ||
+    parsedVersion.compare(MIN_CODEX_APP_SERVER_VERSION) < 0 ||
+    // SemVer ignores build metadata for precedence; custom builds at the exact floor stay unstable.
+    (parsedVersion.version === MIN_CODEX_APP_SERVER_VERSION && parsedVersion.build.length > 0)
   ) {
     throw new CodexAppServerVersionError(detectedVersion);
   }
@@ -940,30 +944,6 @@ function readCodexVersionFromUserAgent(userAgent: string | undefined): string | 
     /^[^/]+\/(\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?)(?:[\s(]|$)/,
   );
   return match?.[1];
-}
-
-/** Compares stable Codex app-server versions for protocol floor checks. */
-function compareCodexAppServerVersions(left: string, right: string): number {
-  const leftVersion = parseSemver(left);
-  const rightVersion = parseSemver(right);
-  if (!leftVersion || !rightVersion) {
-    // Invalid detected versions fail below a valid protocol floor instead of bypassing it.
-    return leftVersion ? 1 : rightVersion ? -1 : 0;
-  }
-  const precedence = compareSemver(leftVersion, rightVersion);
-  if (precedence !== 0) {
-    return precedence;
-  }
-  // Build metadata has no SemVer precedence, but custom Codex builds must not satisfy a stable floor.
-  const leftUnstable = leftVersion.prerelease.length > 0 || leftVersion.build.length > 0;
-  const rightUnstable = rightVersion.prerelease.length > 0 || rightVersion.build.length > 0;
-  if (leftUnstable && !rightUnstable) {
-    return -1;
-  }
-  if (!leftUnstable && rightUnstable) {
-    return 1;
-  }
-  return 0;
 }
 
 function redactCodexAppServerLinePreview(value: string): string {


### PR DESCRIPTION
## What Problem This Solves

The Codex app-server version floor carried a 30-line custom comparison helper around `semver` to preserve one build-metadata edge case.

## Why This Change Was Made

Parse once, use the dependency's native `SemVer.compare`, and keep the exact-floor build-metadata rejection inline. This preserves the existing protocol-floor behavior while deleting the generic comparator.

## User Impact

No behavior change. Missing or invalid versions, versions below `0.143.0`, prereleases at the floor, and builds exactly at the floor still fail. Stable `0.143.0` and all later versions still pass.

## Evidence

- Exact `semver@7.8.5` implementation and types inspected for parse, comparison, version formatting, and build metadata.
- Sibling Codex source inspected at `2f7d89b1419bf7064346855b0acde23514b1ebc5` for initialize user-agent production and parsing.
- 65 generated invalid, stable, prerelease, and build cases: old/new decisions matched with zero mismatches.
- `oxfmt`, targeted `oxlint`, and `git diff --check`: pass.
- Fresh autoreview: clean, correctness 0.99.
- Focused Testbox run [29306469580](https://github.com/openclaw/openclaw/actions/runs/29306469580) was blocked by infrastructure: two fresh leases shut down before repository code executed. Per maintainer direction, hosted CI is not awaited.

Net: 26 deletions, 6 additions (20 fewer lines).
