### PR TITLE
fix(control-ui): restore native context menu when text is selected (#106765)

### DIFF
--- a/ui/src/e2e/chat-message-actions.e2e.test.ts
+++ b/ui/src/e2e/chat-message-actions.e2e.test.ts
@@ -166,10 +166,11 @@ describeControlUiE2e("Control UI chat message actions", () => {
     try {
       await page.goto(`${server.baseUrl}chat`);
       await page.evaluate(() => document.documentElement.setAttribute("data-theme-mode", "dark"));
+      const commandPaletteShortcut = process.platform === "darwin" ? "⌘K" : "Ctrl K";
       await expectHoverTooltip(page.getByRole("button", { name: "New thread" }), "New thread");
       await expectHoverTooltip(
         page.getByRole("button", { name: "Open command palette" }),
-        "Open command palette (⌘K)",
+        `Open command palette (${commandPaletteShortcut})`,
       );
       await expectHoverTooltip(
         page.getByRole("button", { name: "Collapse sidebar" }),
@@ -251,9 +252,51 @@ describeControlUiE2e("Control UI chat message actions", () => {
       await screenshot(page, "02-reply-preview.png");
       await replyPreview.getByRole("button", { name: "Cancel reply" }).click();
 
-      await bubble.click({ button: "right" });
       const menu = page.locator(".chat-reply-context-menu");
+      await bubble.evaluate((element) => {
+        const selection = window.getSelection();
+        const range = document.createRange();
+        range.selectNodeContents(element);
+        selection?.removeAllRanges();
+        selection?.addRange(range);
+      });
+      await page.evaluate(() => {
+        document.addEventListener(
+          "contextmenu",
+          (event) => {
+            (window as Window & { __contextMenuDefaultPrevented?: boolean })[
+              "__contextMenuDefaultPrevented"
+            ] = event.defaultPrevented;
+          },
+          { once: true },
+        );
+      });
+      await bubble.click({ button: "right" });
+      expect(
+        await page.evaluate(
+          () =>
+            (window as Window & { __contextMenuDefaultPrevented?: boolean })[
+              "__contextMenuDefaultPrevented"
+            ],
+        ),
+      ).toBe(false);
+      expect(await menu.count()).toBe(0);
+      await screenshot(page, "03-selected-text-native-menu.png");
+
+      await thinkingGroup.locator(".chat-bubble").evaluate((element) => {
+        const selection = window.getSelection();
+        const range = document.createRange();
+        range.selectNodeContents(element);
+        selection?.removeAllRanges();
+        selection?.addRange(range);
+      });
+      const disjointDefaultPrevented = await bubble.evaluate((element) => {
+        const event = new MouseEvent("contextmenu", { bubbles: true, cancelable: true });
+        element.dispatchEvent(event);
+        return event.defaultPrevented;
+      });
       await menu.waitFor({ state: "visible" });
+      expect(disjointDefaultPrevented).toBe(true);
       expect(await menu.getByRole("menuitem").allTextContents()).toEqual([
         "Reply",
         "Hide message",
@@ -263,13 +306,14 @@ describeControlUiE2e("Control UI chat message actions", () => {
       expect(
         await menu.getByRole("menuitem", { name: "Reply to message" }).locator("svg").count(),
       ).toBe(0);
-      await screenshot(page, "03-context-menu.png");
+      await screenshot(page, "04-context-menu.png");
 
       await menu.getByRole("menuitem", { name: "Copy as markdown" }).click();
       await expect
         .poll(() => page.evaluate(() => navigator.clipboard.readText()))
         .toBe(messageText);
 
+      await page.evaluate(() => window.getSelection()?.removeAllRanges());
       await bubble.click({ button: "right" });
       await page.getByRole("menuitem", { name: "Open in canvas" }).click();
       const markdownSidebar = page.locator(".sidebar-markdown");

--- a/ui/src/e2e/chat-message-actions.e2e.test.ts
+++ b/ui/src/e2e/chat-message-actions.e2e.test.ts
@@ -253,50 +253,49 @@ describeControlUiE2e("Control UI chat message actions", () => {
       await replyPreview.getByRole("button", { name: "Cancel reply" }).click();
 
       const menu = page.locator(".chat-reply-context-menu");
-      await bubble.evaluate((element) => {
+      const selectedText = "context menu";
+      await bubble.evaluate((element, text) => {
         const selection = window.getSelection();
+        const walker = document.createTreeWalker(element, NodeFilter.SHOW_TEXT);
+        let textNode: Text | null = null;
+        let start = -1;
+        while (walker.nextNode()) {
+          const candidate = walker.currentNode;
+          const candidateText = candidate.textContent ?? "";
+          const candidateStart = candidateText.indexOf(text);
+          if (candidate instanceof Text && candidateStart >= 0) {
+            textNode = candidate;
+            start = candidateStart;
+            break;
+          }
+        }
+        if (!textNode) {
+          throw new Error(`Could not find selectable text: ${text}`);
+        }
         const range = document.createRange();
-        range.selectNodeContents(element);
+        range.setStart(textNode, start);
+        range.setEnd(textNode, start + text.length);
         selection?.removeAllRanges();
         selection?.addRange(range);
-      });
-      await page.evaluate(() => {
-        document.addEventListener(
-          "contextmenu",
-          (event) => {
-            (window as Window & { __contextMenuDefaultPrevented?: boolean })[
-              "__contextMenuDefaultPrevented"
-            ] = event.defaultPrevented;
-          },
-          { once: true },
-        );
-      });
+      }, selectedText);
       await bubble.click({ button: "right" });
-      expect(
-        await page.evaluate(
-          () =>
-            (window as Window & { __contextMenuDefaultPrevented?: boolean })[
-              "__contextMenuDefaultPrevented"
-            ],
-        ),
-      ).toBe(false);
-      expect(await menu.count()).toBe(0);
-      await screenshot(page, "03-selected-text-native-menu.png");
-
-      await thinkingGroup.locator(".chat-bubble").evaluate((element) => {
-        const selection = window.getSelection();
-        const range = document.createRange();
-        range.selectNodeContents(element);
-        selection?.removeAllRanges();
-        selection?.addRange(range);
-      });
-      const disjointDefaultPrevented = await bubble.evaluate((element) => {
-        const event = new MouseEvent("contextmenu", { bubbles: true, cancelable: true });
-        element.dispatchEvent(event);
-        return event.defaultPrevented;
-      });
       await menu.waitFor({ state: "visible" });
-      expect(disjointDefaultPrevented).toBe(true);
+      expect(await menu.getByRole("menuitem").allTextContents()).toEqual([
+        "Copy",
+        "Reply",
+        "Hide message",
+        "Open in canvas",
+        "Copy as markdown",
+      ]);
+      await screenshot(page, "03-selected-text-context-menu.png");
+      await menu.getByRole("menuitem", { name: "Copy", exact: true }).click();
+      await expect
+        .poll(() => page.evaluate(() => navigator.clipboard.readText()))
+        .toBe(selectedText);
+
+      await page.evaluate(() => window.getSelection()?.removeAllRanges());
+      await bubble.click({ button: "right" });
+      await menu.waitFor({ state: "visible" });
       expect(await menu.getByRole("menuitem").allTextContents()).toEqual([
         "Reply",
         "Hide message",
@@ -313,7 +312,6 @@ describeControlUiE2e("Control UI chat message actions", () => {
         .poll(() => page.evaluate(() => navigator.clipboard.readText()))
         .toBe(messageText);
 
-      await page.evaluate(() => window.getSelection()?.removeAllRanges());
       await bubble.click({ button: "right" });
       await page.getByRole("menuitem", { name: "Open in canvas" }).click();
       const markdownSidebar = page.locator(".sidebar-markdown");

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -3922,6 +3922,7 @@ export const en: TranslationMap = {
     },
     messages: {
       activity: "Activity",
+      copySelection: "Copy",
       forkFromHere: "Fork from here",
       hide: "Hide",
       hideConfirm: "Hide this message in this browser? The agent still sees it.",

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -6078,7 +6078,7 @@ describe("right-click Reply", () => {
     expect(document.querySelector(".chat-reply-context-menu")).toBeNull();
   });
 
-  it("preserves the native context menu when text is selected inside the bubble", () => {
+  it("uses the native menu only when the selection intersects the clicked bubble", () => {
     const container = renderChatView({ onSetReply: vi.fn() });
     const section = container.querySelector<HTMLElement>(".card.chat");
     expect(section).not.toBeNull();
@@ -6090,58 +6090,38 @@ describe("right-click Reply", () => {
     bubble.dataset.messageId = "msg-1";
     bubble.dataset.messageText = "selectable text";
     bubble.textContent = "selectable text";
-    group.appendChild(bubble);
+    const otherBubble = document.createElement("div");
+    otherBubble.className = "chat-bubble";
+    otherBubble.dataset.messageText = "other text";
+    otherBubble.textContent = "other text";
+    group.append(bubble, otherBubble);
     section!.querySelector(".chat-thread-inner")!.appendChild(group);
 
-    // Simulate a non-collapsed text selection inside the same bubble
-    const range = document.createRange();
-    range.selectNodeContents(bubble);
+    const bubbleText = expectDefined(bubble.firstChild, "bubble text node");
+    const otherText = expectDefined(otherBubble.firstChild, "other bubble text node");
+    let selectedRange = document.createRange();
+    selectedRange.setStart(bubbleText, 0);
+    selectedRange.setEnd(otherText, otherText.textContent?.length ?? 0);
     const mockSelection = {
       isCollapsed: false,
       rangeCount: 1,
-      getRangeAt: () => range,
-      toString: () => "selectable text",
+      getRangeAt: () => selectedRange,
     } as unknown as Selection;
-    const getSelectionSpy = vi.spyOn(window, "getSelection").mockReturnValue(mockSelection);
+    vi.spyOn(window, "getSelection").mockReturnValue(mockSelection);
 
-    const evt = new MouseEvent("contextmenu", { bubbles: true, cancelable: true });
-    bubble.dispatchEvent(evt);
+    const selectedEvent = new MouseEvent("contextmenu", { bubbles: true, cancelable: true });
+    bubble.dispatchEvent(selectedEvent);
 
-    // The handler should NOT prevent the native menu
-    expect(evt.defaultPrevented).toBe(false);
+    expect(selectedEvent.defaultPrevented).toBe(false);
     expect(document.querySelector(".chat-reply-context-menu")).toBeNull();
 
-    getSelectionSpy.mockRestore();
-  });
+    selectedRange = document.createRange();
+    selectedRange.selectNodeContents(otherBubble);
+    const disjointEvent = new MouseEvent("contextmenu", { bubbles: true, cancelable: true });
+    bubble.dispatchEvent(disjointEvent);
 
-  it("shows the Reply menu when clicking without a text selection", () => {
-    const container = renderChatView({ onSetReply: vi.fn() });
-    const section = container.querySelector<HTMLElement>(".card.chat");
-    expect(section).not.toBeNull();
-
-    const group = document.createElement("div");
-    group.className = "chat-group";
-    const bubble = document.createElement("div");
-    bubble.className = "chat-bubble";
-    bubble.dataset.messageId = "msg-1";
-    bubble.dataset.messageText = "some text";
-    group.appendChild(bubble);
-    section!.querySelector(".chat-thread-inner")!.appendChild(group);
-
-    // No selection: getSelection returns collapsed or null
-    const mockSelection = {
-      isCollapsed: true,
-      rangeCount: 0,
-    } as unknown as Selection;
-    const getSelectionSpy = vi.spyOn(window, "getSelection").mockReturnValue(mockSelection);
-
-    const evt = new MouseEvent("contextmenu", { bubbles: true, cancelable: true });
-    bubble.dispatchEvent(evt);
-
-    expect(evt.defaultPrevented).toBe(true);
+    expect(disjointEvent.defaultPrevented).toBe(true);
     expect(document.querySelector(".chat-reply-context-menu")).not.toBeNull();
-
-    getSelectionSpy.mockRestore();
   });
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -6078,7 +6078,9 @@ describe("right-click Reply", () => {
     expect(document.querySelector(".chat-reply-context-menu")).toBeNull();
   });
 
-  it("uses the native menu only when the selection intersects the clicked bubble", () => {
+  it("adds Copy for an intersecting selection without changing the unselected menu", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal("navigator", { clipboard: { writeText } });
     const container = renderChatView({ onSetReply: vi.fn() });
     const section = container.querySelector<HTMLElement>(".card.chat");
     expect(section).not.toBeNull();
@@ -6106,14 +6108,21 @@ describe("right-click Reply", () => {
       isCollapsed: false,
       rangeCount: 1,
       getRangeAt: () => selectedRange,
+      toString: () => "selectable",
     } as unknown as Selection;
     vi.spyOn(window, "getSelection").mockReturnValue(mockSelection);
 
     const selectedEvent = new MouseEvent("contextmenu", { bubbles: true, cancelable: true });
     bubble.dispatchEvent(selectedEvent);
 
-    expect(selectedEvent.defaultPrevented).toBe(false);
-    expect(document.querySelector(".chat-reply-context-menu")).toBeNull();
+    expect(selectedEvent.defaultPrevented).toBe(true);
+    expect(
+      [...document.querySelectorAll(".chat-reply-context-menu button")].map((button) =>
+        button.textContent?.trim(),
+      ),
+    ).toEqual(["Copy", "Reply"]);
+    document.querySelector<HTMLButtonElement>('[aria-label="Copy"]')!.click();
+    await vi.waitFor(() => expect(writeText).toHaveBeenCalledWith("selectable"));
 
     selectedRange = document.createRange();
     selectedRange.selectNodeContents(otherBubble);
@@ -6121,7 +6130,11 @@ describe("right-click Reply", () => {
     bubble.dispatchEvent(disjointEvent);
 
     expect(disjointEvent.defaultPrevented).toBe(true);
-    expect(document.querySelector(".chat-reply-context-menu")).not.toBeNull();
+    expect(
+      [...document.querySelectorAll(".chat-reply-context-menu button")].map((button) =>
+        button.textContent?.trim(),
+      ),
+    ).toEqual(["Reply"]);
   });
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -6077,5 +6077,71 @@ describe("right-click Reply", () => {
     // Without onSetReply, the handler returns early and no menu is created
     expect(document.querySelector(".chat-reply-context-menu")).toBeNull();
   });
+
+  it("preserves the native context menu when text is selected inside the bubble", () => {
+    const container = renderChatView({ onSetReply: vi.fn() });
+    const section = container.querySelector<HTMLElement>(".card.chat");
+    expect(section).not.toBeNull();
+
+    const group = document.createElement("div");
+    group.className = "chat-group";
+    const bubble = document.createElement("div");
+    bubble.className = "chat-bubble";
+    bubble.dataset.messageId = "msg-1";
+    bubble.dataset.messageText = "selectable text";
+    bubble.textContent = "selectable text";
+    group.appendChild(bubble);
+    section!.querySelector(".chat-thread-inner")!.appendChild(group);
+
+    // Simulate a non-collapsed text selection inside the same bubble
+    const range = document.createRange();
+    range.selectNodeContents(bubble);
+    const mockSelection = {
+      isCollapsed: false,
+      rangeCount: 1,
+      getRangeAt: () => range,
+      toString: () => "selectable text",
+    } as unknown as Selection;
+    const getSelectionSpy = vi.spyOn(window, "getSelection").mockReturnValue(mockSelection);
+
+    const evt = new MouseEvent("contextmenu", { bubbles: true, cancelable: true });
+    bubble.dispatchEvent(evt);
+
+    // The handler should NOT prevent the native menu
+    expect(evt.defaultPrevented).toBe(false);
+    expect(document.querySelector(".chat-reply-context-menu")).toBeNull();
+
+    getSelectionSpy.mockRestore();
+  });
+
+  it("shows the Reply menu when clicking without a text selection", () => {
+    const container = renderChatView({ onSetReply: vi.fn() });
+    const section = container.querySelector<HTMLElement>(".card.chat");
+    expect(section).not.toBeNull();
+
+    const group = document.createElement("div");
+    group.className = "chat-group";
+    const bubble = document.createElement("div");
+    bubble.className = "chat-bubble";
+    bubble.dataset.messageId = "msg-1";
+    bubble.dataset.messageText = "some text";
+    group.appendChild(bubble);
+    section!.querySelector(".chat-thread-inner")!.appendChild(group);
+
+    // No selection: getSelection returns collapsed or null
+    const mockSelection = {
+      isCollapsed: true,
+      rangeCount: 0,
+    } as unknown as Selection;
+    const getSelectionSpy = vi.spyOn(window, "getSelection").mockReturnValue(mockSelection);
+
+    const evt = new MouseEvent("contextmenu", { bubbles: true, cancelable: true });
+    bubble.dispatchEvent(evt);
+
+    expect(evt.defaultPrevented).toBe(true);
+    expect(document.querySelector(".chat-reply-context-menu")).not.toBeNull();
+
+    getSelectionSpy.mockRestore();
+  });
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/ui/src/pages/chat/components/chat-thread.ts
+++ b/ui/src/pages/chat/components/chat-thread.ts
@@ -785,6 +785,18 @@ function handleChatThreadSelectionPointerUp(event: PointerEvent, props: ChatThre
   });
 }
 
+function selectionIntersectsElement(selection: Selection | null, element: Element): boolean {
+  if (!selection || selection.isCollapsed) {
+    return false;
+  }
+  for (let index = 0; index < selection.rangeCount; index += 1) {
+    if (selection.getRangeAt(index).intersectsNode(element)) {
+      return true;
+    }
+  }
+  return false;
+}
+
 function handleChatContextMenu(event: MouseEvent, props: ChatThreadProps) {
   if (event.composedPath().some((target) => target instanceof HTMLAnchorElement)) {
     return;
@@ -827,19 +839,8 @@ function handleChatContextMenu(event: MouseEvent, props: ChatThreadProps) {
     return;
   }
 
-  // When text is selected inside the right-clicked bubble, defer to the
-  // browser's native context menu (Copy, Search, spell-check, etc.) instead
-  // of the custom Reply menu.
-  const selection = window.getSelection();
-  if (selection && !selection.isCollapsed && selection.rangeCount > 0) {
-    const range = selection.getRangeAt(0);
-    const container =
-      range.commonAncestorContainer instanceof Element
-        ? range.commonAncestorContainer
-        : range.commonAncestorContainer.parentElement;
-    if (container && bubble.contains(container)) {
-      return;
-    }
+  if (selectionIntersectsElement(window.getSelection(), bubble)) {
+    return;
   }
 
   event.preventDefault();

--- a/ui/src/pages/chat/components/chat-thread.ts
+++ b/ui/src/pages/chat/components/chat-thread.ts
@@ -826,6 +826,22 @@ function handleChatContextMenu(event: MouseEvent, props: ChatThreadProps) {
   if (!canReply && !canRewind && !canHide && !canOpenInCanvas && !canCopy && !canFork) {
     return;
   }
+
+  // When text is selected inside the right-clicked bubble, defer to the
+  // browser's native context menu (Copy, Search, spell-check, etc.) instead
+  // of the custom Reply menu.
+  const selection = window.getSelection();
+  if (selection && !selection.isCollapsed && selection.rangeCount > 0) {
+    const range = selection.getRangeAt(0);
+    const container =
+      range.commonAncestorContainer instanceof Element
+        ? range.commonAncestorContainer
+        : range.commonAncestorContainer.parentElement;
+    if (container && bubble.contains(container)) {
+      return;
+    }
+  }
+
   event.preventDefault();
   event.stopPropagation();
   removeReplyContextMenu();

--- a/ui/src/pages/chat/components/chat-thread.ts
+++ b/ui/src/pages/chat/components/chat-thread.ts
@@ -38,6 +38,7 @@ import {
   combineSideChatComposerDraft,
 } from "../../../lib/chat/side-question.ts";
 import type { EmbedSandboxMode } from "../../../lib/chat/tool-display.ts";
+import { copyToClipboard } from "../../../lib/clipboard.ts";
 import {
   areUiSessionKeysEquivalent,
   isUiGlobalScopeConfigured,
@@ -839,9 +840,8 @@ function handleChatContextMenu(event: MouseEvent, props: ChatThreadProps) {
     return;
   }
 
-  if (selectionIntersectsElement(window.getSelection(), bubble)) {
-    return;
-  }
+  const selection = window.getSelection();
+  const selectedText = selectionIntersectsElement(selection, bubble) ? selection?.toString() : "";
 
   event.preventDefault();
   event.stopPropagation();
@@ -853,6 +853,19 @@ function handleChatContextMenu(event: MouseEvent, props: ChatThreadProps) {
   menu.style.left = `${event.clientX}px`;
   menu.style.top = `${event.clientY}px`;
   const focusCandidates: HTMLButtonElement[] = [];
+  if (selectedText) {
+    const action = createMessageActionContextButton({
+      label: t("chat.messages.copySelection"),
+      disabled: false,
+      tooltip: t("chat.messages.copySelection"),
+      onClick: () => {
+        void copyToClipboard(selectedText);
+        removeReplyContextMenu();
+      },
+    });
+    menu.append(action.element);
+    focusCandidates.push(action.button);
+  }
   if (canReply) {
     const replyMessageId = messageId || stableReplyMessageId(senderLabel, text);
     const replyButton = createReplyContextMenuButton(() => {


### PR DESCRIPTION
Closes #106765

## What Problem This Solves

Selecting text in a Control UI chat message and right-clicking used to suppress the browser's mouse-driven Copy path. The first version of this PR restored the native Chromium menu, but that traded away OpenClaw's message actions whenever text was selected.

This revision implements Peter's hybrid decision: selected text stays highlighted while the existing custom Message actions menu remains available, with an exact-selection **Copy** entry added at the top.

## Why This Change Was Made

The chat thread already owns a complete custom menu for Reply, Hide message, Open in canvas, Copy as markdown, Rewind, and Fork. The clean owner-boundary fix is to keep that one menu and prepend selection-owned actions only when the browser Selection intersects the clicked message bubble.

The new Copy action uses the shared clipboard helper, including its plain-HTTP fallback, and captures the exact selected substring before focus moves into the menu. With no selection, the action list and ordering are unchanged.

Chromium's privileged native Look Up and Translate context-menu commands are not exposed to ordinary page JavaScript, so this patch does not add misleading search/translation substitutes.

## User Impact

- **Selected text + right-click:** shows Copy plus all applicable OpenClaw message actions in one menu; Copy writes exactly the selected text.
- **No selection + right-click:** preserves the existing custom menu unchanged.
- **No configuration change:** the behavior is automatic and adds no setting or environment surface.

## Evidence

### Before: selection leaves the custom menu path

![Selected text before the hybrid menu](https://91b59577e757131d68d55a471fe32aca.r2.cloudflarestorage.com/clickclack-uploads/openclaw/pr-107137/context-menu/f1f7f9f7979/before-selected-native-path.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=5a8f3de6b66c3d9123e6b9c98c768b4a%2F20260721%2Fauto%2Fs3%2Faws4_request&X-Amz-Date=20260721T072015Z&X-Amz-Expires=604800&X-Amz-SignedHeaders=host&X-Amz-Signature=c7195322cfdb052317004d893de61077c03148b971cef9c2becd2dff1277e874)

### After: selected text and OpenClaw actions coexist

![Selected text with Copy and message actions](https://91b59577e757131d68d55a471fe32aca.r2.cloudflarestorage.com/clickclack-uploads/openclaw/pr-107137/context-menu/f1f7f9f7979/after-hybrid-selected.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=5a8f3de6b66c3d9123e6b9c98c768b4a%2F20260721%2Fauto%2Fs3%2Faws4_request&X-Amz-Date=20260721T072012Z&X-Amz-Expires=604800&X-Amz-SignedHeaders=host&X-Amz-Signature=d2e561693ba65750562050f0c0d1a1a77aef2718e2c628b78f5b37a6d7fb7023)

### After: no-selection menu remains unchanged

![Unselected message with the original action list](https://91b59577e757131d68d55a471fe32aca.r2.cloudflarestorage.com/clickclack-uploads/openclaw/pr-107137/context-menu/f1f7f9f7979/after-unselected.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=5a8f3de6b66c3d9123e6b9c98c768b4a%2F20260721%2Fauto%2Fs3%2Faws4_request&X-Amz-Date=20260721T072013Z&X-Amz-Expires=604800&X-Amz-SignedHeaders=host&X-Amz-Signature=f6f28a2b72f195834af2b22074ecb1aad974095620cbacb9a50eb2a0bb30ff90)

[Crabbox artifact manifest](https://91b59577e757131d68d55a471fe32aca.r2.cloudflarestorage.com/clickclack-uploads/openclaw/pr-107137/context-menu/f1f7f9f7979/artifact-manifest.json?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=5a8f3de6b66c3d9123e6b9c98c768b4a%2F20260721%2Fauto%2Fs3%2Faws4_request&X-Amz-Date=20260721T072016Z&X-Amz-Expires=604800&X-Amz-SignedHeaders=host&X-Amz-Signature=6dcd693f84009c4517d5ddb6450d83f5243eefd6a17879c643606c5c60178f10)

Rendered proof used a deterministic mocked Gateway in real Playwright Chromium on direct AWS Crabbox `cbx_8871c5bf4d45`:

- `run_a1144fe7b2a1`: focused right-click Reply suite, 19 passed.
- `run_1757eef64d3f`: real Chromium selected/unselected menu flow and clipboard readback, 1 passed.
- `MISE_NODE_VERSION=24.18.0 CI=1 node scripts/check-changed.mjs -- ui/src/pages/chat/components/chat-thread.ts ui/src/pages/chat/chat-view.test.ts ui/src/e2e/chat-message-actions.e2e.test.ts ui/src/i18n/locales/en.ts`: formatting, i18n, guards, core-test/UI typecheck, and targeted lint passed.
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted`: clean; no accepted/actionable findings.

The Crabbox R2 links are signed for Peter's review window. Screenshots and videos are not committed to the repository.

Contributor credit is preserved for Qiong (@yangxiansheng), including the original diagnosis and implementation commit; the hybrid commit carries `Co-authored-by: Qiong <yang.ji2@xydigit.com>`.

---

This PR is AI-assisted. Analysis, implementation, and testing were performed using AI tools with maintainer review.
