### PR TITLE
fix(plugin-sdk): refresh API baseline hash

### DIFF
--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-f9f7217a414edeee7369ad6ca6b904b1e18f5a6a878be321d65fd172c1182ba4  plugin-sdk-api-baseline.json
-5ab2fa584b775aec3238e25bfcdd2a19f3d830fede2035a43696ad5f9e1dc646  plugin-sdk-api-baseline.jsonl
+5cc5b1f35c16b3b65871942b262467b1eee065652f4f90a24ddd65eb1096aa3c  plugin-sdk-api-baseline.json
+aaeb88388cf472b788ba2332890811d5bee64208a99596c975b2f11f7d40c04e  plugin-sdk-api-baseline.jsonl


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where `pnpm check:changed` fails on current `main` because the tracked Plugin SDK API checksum does not match the exact-tree generator output.

## Why This Change Was Made

Regenerate the sole tracked API-baseline statefile. The exact generated JSONL diff against the pre-Workboard tree contains only the already-landed `agentId` and `requireCurrentConfig` additions to `resolveSandboxContext` in the `agent-harness` and `agent-harness-runtime` entrypoints. The JSON and JSONL artifacts remain intentionally gitignored and local-only.

## User Impact

No new runtime behavior or API change. Plugin SDK baseline checks once again describe the API already present on `main`, unblocking changed-file validation.

## Evidence

- Exact generator check: `node --max-old-space-size=8192 --import tsx scripts/generate-plugin-sdk-api-baseline.ts --check`
- Blacksmith Testbox `tbx_01kxfesprn3qwmgrktn04ry1ep`: Plugin SDK API check and scoped `check:changed` passed.
- Generated baseline comparison: only two declaration records changed, both for the already-landed `resolveSandboxContext` optional parameters.
- Fresh `gpt-5.6-sol` medium autoreview: clean, confidence 0.99.
- `git diff --check` passed.

No changelog entry: this repairs generated validation metadata only.
