### PR TITLE
fix(skills): log ClawHub skill verification errors instead of swallowing

### DIFF
--- a/src/gateway/server-methods/skills.clawhub.test.ts
+++ b/src/gateway/server-methods/skills.clawhub.test.ts
@@ -279,6 +279,7 @@ describe("skills gateway handlers (clawhub)", () => {
       slug: "calendar",
       version: "1.2.3",
       force: false,
+      logger: expect.objectContaining({ warn: expect.any(Function) }),
       config: {},
     });
     expect(ok).toBe(true);
@@ -376,6 +377,7 @@ describe("skills gateway handlers (clawhub)", () => {
       version: "1.2.3",
       force: false,
       acknowledgeClawHubRisk: true,
+      logger: expect.objectContaining({ warn: expect.any(Function) }),
       config: {},
     });
     expect(ok).toBe(true);
@@ -407,6 +409,7 @@ describe("skills gateway handlers (clawhub)", () => {
       slug: "calendar",
       version: "1.2.3",
       force: false,
+      logger: expect.objectContaining({ warn: expect.any(Function) }),
       config: {},
     });
     expect(ok).toBe(true);
@@ -464,6 +467,7 @@ describe("skills gateway handlers (clawhub)", () => {
     expect(updateSkillsFromClawHubMock).toHaveBeenCalledWith({
       workspaceDir: "/tmp/workspace",
       slug: "calendar",
+      logger: expect.objectContaining({ warn: expect.any(Function) }),
       config: {},
     });
     expect(ok).toBe(true);
@@ -512,6 +516,7 @@ describe("skills gateway handlers (clawhub)", () => {
       workspaceDir: "/tmp/workspace",
       slug: "calendar",
       acknowledgeClawHubRisk: true,
+      logger: expect.objectContaining({ warn: expect.any(Function) }),
       config: {},
     });
     expect(ok).toBe(true);

--- a/src/gateway/server-methods/skills.test-helpers.ts
+++ b/src/gateway/server-methods/skills.test-helpers.ts
@@ -14,7 +14,12 @@ type CapturedGatewayResponse = {
 function makeGatewayHandlerTestContext(): GatewayRequestContext {
   return {
     getRuntimeConfig: () => ({}),
-    logGateway: vi.fn(),
+    logGateway: {
+      debug: vi.fn(),
+      error: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+    },
   } as unknown as GatewayRequestContext;
 }
 

--- a/src/gateway/server-methods/skills.ts
+++ b/src/gateway/server-methods/skills.ts
@@ -583,6 +583,7 @@ export const skillsHandlers: GatewayRequestHandlers = {
         version: p.version,
         force: Boolean(p.force),
         ...(p.acknowledgeClawHubRisk ? { acknowledgeClawHubRisk: true } : {}),
+        logger: context.logGateway,
         config: cfg,
       });
       const errorDetails = result.ok ? undefined : buildClawHubTrustErrorDetails(result);
@@ -705,6 +706,7 @@ export const skillsHandlers: GatewayRequestHandlers = {
         workspaceDir: resolved.workspaceDir,
         slug: p.slug,
         ...(p.acknowledgeClawHubRisk ? { acknowledgeClawHubRisk: true } : {}),
+        logger: context.logGateway,
         config: resolved.cfg,
       });
       const errors = results.filter((result) => !result.ok);

--- a/src/skills/lifecycle/clawhub.test.ts
+++ b/src/skills/lifecycle/clawhub.test.ts
@@ -1045,6 +1045,7 @@ describe("skills-clawhub", () => {
 
   it("persists install artifact and verification provenance in the ClawHub lockfile", async () => {
     const workspaceDir = await tempDirs.make("openclaw-skills-lock-");
+    const warn = vi.fn();
     const skillContent = "---\nname: agentreceipt\ndescription: Receipt helper\n---\n";
     const skillSha256 = createHash("sha256").update(skillContent).digest("hex");
     installPackageDirMock.mockImplementationOnce(async (params: { targetDir: string }) => {
@@ -1057,6 +1058,7 @@ describe("skills-clawhub", () => {
       const result = await installSkillFromClawHub({
         workspaceDir,
         slug: "agentreceipt",
+        logger: { warn },
       });
 
       expectInstalledSkill(result, {
@@ -1069,6 +1071,7 @@ describe("skills-clawhub", () => {
         version: "1.0.0",
         baseUrl: undefined,
       });
+      expect(warn).not.toHaveBeenCalled();
       const lock = JSON.parse(
         await fs.readFile(path.join(workspaceDir, ".clawhub", "lock.json"), "utf8"),
       ) as { skills: Record<string, Record<string, unknown>> };
@@ -1335,6 +1338,7 @@ describe("skills-clawhub", () => {
 
   it("keeps installing when the ClawHub verification snapshot is unavailable", async () => {
     const workspaceDir = await tempDirs.make("openclaw-skills-lock-");
+    const warn = vi.fn();
     fetchClawHubSkillVerificationMock.mockRejectedValueOnce(new Error("verification down"));
     installPackageDirMock.mockImplementationOnce(async (params: { targetDir: string }) => {
       await fs.mkdir(params.targetDir, { recursive: true });
@@ -1346,9 +1350,14 @@ describe("skills-clawhub", () => {
       const result = await installSkillFromClawHub({
         workspaceDir,
         slug: "agentreceipt",
+        logger: { warn },
       });
 
       expectInstalledSkill(result, { slug: "agentreceipt", version: "1.0.0" });
+      expect(warn).toHaveBeenCalledOnce();
+      expect(warn).toHaveBeenCalledWith(
+        "Skill verification for agentreceipt failed: verification down",
+      );
       const lock = JSON.parse(
         await fs.readFile(path.join(workspaceDir, ".clawhub", "lock.json"), "utf8"),
       ) as { skills: Record<string, Record<string, unknown>> };

--- a/src/skills/lifecycle/clawhub.ts
+++ b/src/skills/lifecycle/clawhub.ts
@@ -180,7 +180,6 @@ function normalizeClawHubOwnerHandle(raw: string): string {
   }
   return ownerHandle;
 }
-
 function parseRequestedClawHubSkillRef(raw: string): ClawHubSkillRef {
   const value = raw.trim();
   if (!value.startsWith("@")) {
@@ -389,13 +388,11 @@ function readRealPathSync(candidate: string): string | undefined {
 function normalizeOptionalStringValue(raw: unknown): string | undefined {
   return typeof raw === "string" && raw.trim() ? raw.trim() : undefined;
 }
-
 function asRecord(raw: unknown): Record<string, unknown> | undefined {
   return raw && typeof raw === "object" && !Array.isArray(raw)
     ? (raw as Record<string, unknown>)
     : undefined;
 }
-
 function normalizeGitHubRepoName(raw: unknown): string | undefined {
   const repo = normalizeOptionalStringValue(raw);
   if (!repo) {
@@ -407,7 +404,6 @@ function normalizeGitHubRepoName(raw: unknown): string | undefined {
   }
   return repo;
 }
-
 function normalizeGitHubCommitSegment(raw: unknown): string | undefined {
   const commit = normalizeOptionalStringValue(raw);
   if (!commit || !/^[0-9a-f]{40}$/i.test(commit)) {
@@ -487,6 +483,7 @@ async function fetchInstallVerificationLock(params: {
   ownerHandle?: string;
   version?: string;
   baseUrl?: string;
+  logger?: Logger;
 }): Promise<ClawHubSkillVerificationLock | undefined> {
   try {
     const verification = await fetchClawHubSkillVerification({
@@ -496,11 +493,13 @@ async function fetchInstallVerificationLock(params: {
       baseUrl: params.baseUrl,
     });
     return snapshotClawHubSkillVerification(verification);
-  } catch {
+  } catch (err) {
+    params.logger?.warn?.(
+      `Skill verification for ${params.slug} failed: ${formatErrorMessage(err)}`,
+    );
     return undefined;
   }
 }
-
 async function readInstalledSkillFileLock(
   skillDir: string,
 ): Promise<ClawHubSkillFileLock | undefined> {
@@ -1472,6 +1471,7 @@ async function performClawHubSkillInstall(
           ...(params.ownerHandle ? { ownerHandle: params.ownerHandle } : {}),
           version: verificationVersion,
           baseUrl: params.baseUrl,
+          logger: params.logger,
         }),
       ]);
       const sourceUrl =

--- a/src/skills/lifecycle/clawhub.ts
+++ b/src/skills/lifecycle/clawhub.ts
@@ -180,6 +180,7 @@ function normalizeClawHubOwnerHandle(raw: string): string {
   }
   return ownerHandle;
 }
+
 function parseRequestedClawHubSkillRef(raw: string): ClawHubSkillRef {
   const value = raw.trim();
   if (!value.startsWith("@")) {
@@ -388,11 +389,13 @@ function readRealPathSync(candidate: string): string | undefined {
 function normalizeOptionalStringValue(raw: unknown): string | undefined {
   return typeof raw === "string" && raw.trim() ? raw.trim() : undefined;
 }
+
 function asRecord(raw: unknown): Record<string, unknown> | undefined {
   return raw && typeof raw === "object" && !Array.isArray(raw)
     ? (raw as Record<string, unknown>)
     : undefined;
 }
+
 function normalizeGitHubRepoName(raw: unknown): string | undefined {
   const repo = normalizeOptionalStringValue(raw);
   if (!repo) {
@@ -404,6 +407,7 @@ function normalizeGitHubRepoName(raw: unknown): string | undefined {
   }
   return repo;
 }
+
 function normalizeGitHubCommitSegment(raw: unknown): string | undefined {
   const commit = normalizeOptionalStringValue(raw);
   if (!commit || !/^[0-9a-f]{40}$/i.test(commit)) {
@@ -495,11 +499,12 @@ async function fetchInstallVerificationLock(params: {
     return snapshotClawHubSkillVerification(verification);
   } catch (err) {
     params.logger?.warn?.(
-      `Skill verification for ${params.slug} failed: ${formatErrorMessage(err)}`,
+      `Skill verification for ${formatClawHubSkillRef(params)} failed: ${formatErrorMessage(err)}`,
     );
     return undefined;
   }
 }
+
 async function readInstalledSkillFileLock(
   skillDir: string,
 ): Promise<ClawHubSkillFileLock | undefined> {


### PR DESCRIPTION
## What Problem This Solves

ClawHub skill install verification is intentionally best-effort, but network, HTTP, and malformed-response failures were swallowed. Installation continued without provenance metadata and without any operator-visible reason.

## Why This Change Was Made

The lifecycle helper now warns through its existing optional logger while preserving the non-blocking fallback. Gateway install and update calls now pass the existing gateway logger, matching the CLI entrypoints. The warning uses the owner-qualified ClawHub skill reference so scoped installs remain identifiable.

## User Impact

Operators now receive a warning when ClawHub verification fails. Skill installation and update still proceed, preserving the existing availability behavior.

## Evidence

- Prepared head: `0e259b855e9576c4fb85db97c66520b6cbb0eeca`, rebased onto `04e523a73bf01b2e7f67ade565746a4b1234ec22`.
- AWS Crabbox `run_07c8d12fdf13`: `pnpm test src/skills/lifecycle/clawhub.test.ts src/gateway/server-methods/skills.clawhub.test.ts` — 90 tests passed.
- AWS Crabbox `run_b7d3745ce5a5`: targeted oxfmt, oxlint, production tsgo, and test tsgo passed.
- Full-branch autoreview `019f6184-c8b8-7280-870b-320ecb57f3bf`: clean, no actionable findings.
- Regression coverage asserts successful verification emits no warning and failed verification emits one warning without blocking installation; gateway install/update tests assert logger propagation.

Known proof gap: generic `check:changed` could not run in the direct AWS synced workspace because that workspace omitted `.git`; the touched-surface format, lint, production type, and test type gates were run directly instead. No live ClawHub registry E2E was run.

---

AI-assisted.
