### PR TITLE
fix(memory): hide QMD transport metadata from recalled content

### DIFF
--- a/extensions/memory-core/src/memory/qmd-manager-search-support.ts
+++ b/extensions/memory-core/src/memory/qmd-manager-search-support.ts
@@ -29,7 +29,8 @@ import {
   writeQmdMultiCollectionProbeCache,
 } from "./qmd-runtime-cache.js";
 
-const SNIPPET_HEADER_RE = /@@\s*-([0-9]+),([0-9]+)/;
+const SNIPPET_HEADER_RE =
+  /^\uFEFF?(?:\d+:\s*)?@@\s*-([1-9]\d*),([1-9]\d*)(?:\s*@@(?:\s*\(\d+\s+before,\s*\d+\s+after\))?)?(?:\r?\n|$)/;
 
 export abstract class QmdManagerSearchSupport extends QmdManagerLifecycle {
   protected recordSearchPlanDebug(params: {
@@ -121,6 +122,7 @@ export abstract class QmdManagerSearchSupport extends QmdManagerLifecycle {
   protected resolveSnippetLines(
     entry: QmdQueryResult,
     snippet: string,
+    fallbackSnippet = snippet,
   ): { startLine: number; endLine: number } {
     const explicitStart = this.normalizeSnippetLine(entry.startLine);
     const explicitEnd = this.normalizeSnippetLine(entry.endLine);
@@ -153,7 +155,7 @@ export abstract class QmdManagerSearchSupport extends QmdManagerLifecycle {
     if (headerLines) {
       return headerLines;
     }
-    return { startLine: 1, endLine: snippet.split("\n").length };
+    return { startLine: 1, endLine: fallbackSnippet.split("\n").length };
   }
 
   protected normalizeSnippetLine(value: unknown): number | undefined {
@@ -169,7 +171,7 @@ export abstract class QmdManagerSearchSupport extends QmdManagerLifecycle {
     }
     const start = Number(match[1]);
     const count = Number(match[2]);
-    if (Number.isFinite(start) && Number.isFinite(count)) {
+    if (Number.isSafeInteger(start) && Number.isSafeInteger(start + count - 1)) {
       return { startLine: start, endLine: start + count - 1 };
     }
     return null;

--- a/extensions/memory-core/src/memory/qmd-manager-search.ts
+++ b/extensions/memory-core/src/memory/qmd-manager-search.ts
@@ -1,4 +1,3 @@
-import { truncateUtf16Safe } from "openclaw/plugin-sdk/memory-core-host-engine-foundation";
 import type { QmdQueryResult } from "openclaw/plugin-sdk/memory-core-host-engine-qmd";
 import type {
   MemoryEntryProvenance,
@@ -14,6 +13,7 @@ import {
 import { asQmdAbortError, isMissingCollectionSearchError } from "./qmd-command-errors.js";
 import { qmdManagerLog } from "./qmd-manager-base.js";
 import { QmdManagerSearchSupport } from "./qmd-manager-search-support.js";
+import { parseQmdSnippet } from "./qmd-snippet.js";
 import {
   MEMORY_SEARCH_DEADLINE_CONTROL,
   type MemorySearchDeadlineControlOptions,
@@ -237,8 +237,14 @@ export abstract class QmdManagerSearch extends QmdManagerSearchSupport {
       if (!doc) {
         continue;
       }
-      const snippet = truncateUtf16Safe(entry.snippet ?? "", this.qmd.limits.maxSnippetChars);
-      const lines = this.resolveSnippetLines(entry, snippet);
+      const rawSnippet = entry.snippet ?? "";
+      const parsedSnippet = parseQmdSnippet(
+        rawSnippet,
+        mcporterEnabled ? "mcp" : "cli",
+        this.qmd.limits.maxSnippetChars,
+      );
+      const lines = this.resolveSnippetLines(entry, rawSnippet, parsedSnippet.snippet);
+      const snippet = parsedSnippet.snippet;
       const score = typeof entry.score === "number" ? entry.score : 0;
       const minScore = opts?.minScore ?? 0;
       if (score < minScore) {

--- a/extensions/memory-core/src/memory/qmd-manager.slugified-paths.test.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.slugified-paths.test.ts
@@ -272,7 +272,7 @@ describe("QmdMemoryManager slugified path resolution", () => {
         startLine: 2,
         endLine: 2,
         score: 0.73,
-        snippet: "@@ -2,1\nline-2",
+        snippet: "line-2",
         source: "memory",
         provenance: {
           originClass: "untrusted",
@@ -350,7 +350,7 @@ describe("QmdMemoryManager slugified path resolution", () => {
         startLine: 1,
         endLine: 1,
         score: 0.81,
-        snippet: "@@ -1,1\nvault memory",
+        snippet: "vault memory",
         source: "memory",
         provenance: {
           originClass: "untrusted",
@@ -415,7 +415,7 @@ describe("QmdMemoryManager slugified path resolution", () => {
         startLine: 1,
         endLine: 1,
         score: 0.79,
-        snippet: "@@ -1,1\nexact slugified path",
+        snippet: "exact slugified path",
         source: "memory",
         provenance: {
           originClass: "untrusted",

--- a/extensions/memory-core/src/memory/qmd-manager.test.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.test.ts
@@ -2702,7 +2702,7 @@ describe("QmdMemoryManager", () => {
         startLine: 7,
         endLine: 7,
         score: 0.93,
-        snippet: "@@ -7,1\nrouter glacier backup",
+        snippet: "router glacier backup",
         source: "memory",
         provenance: expectedQmdProvenance("untrusted"),
       },
@@ -2837,7 +2837,7 @@ describe("QmdMemoryManager", () => {
         startLine: 1,
         endLine: 1,
         score: 1,
-        snippet: "@@ -1,1\nremember this",
+        snippet: "remember this",
         source: "memory",
         provenance: expectedQmdProvenance("agent"),
       },
@@ -3690,7 +3690,7 @@ describe("QmdMemoryManager", () => {
                 start_line: 8,
                 end_line: 10,
                 snippet:
-                  "@@ -20,3\nline one\nline two\nline three <!-- project: github.com/acme/Alpha -->",
+                  "3: @@ -20,3\n4: line one\n5: line two\n6: line three <!-- project: github.com/acme/Alpha -->",
               },
             ],
           }),
@@ -3725,7 +3725,7 @@ describe("QmdMemoryManager", () => {
         startLine: 8,
         endLine: 10,
         score: 0.91,
-        snippet: "@@ -20,3\nline one\nline two\nline three <!-- project: github.com/acme/Alpha -->",
+        snippet: "line one\nline two\nline three <!-- project: github.com/acme/Alpha -->",
         source: "memory",
         provenance: expectedQmdProvenance("untrusted"),
       },
@@ -3736,7 +3736,7 @@ describe("QmdMemoryManager", () => {
 
   it("keeps per-result and aggregate QMD snippet limits UTF-16 safe", async () => {
     const expectedDocId = "unicode-boundary";
-    const snippet = "@@ -1,1\nabc😀tail";
+    const snippet = "abc😀tail\nsecond line";
     spawnMock.mockImplementation((cmd: string, args: string[]) => {
       const child = createMockChild({ autoClose: false });
       if (isMcporterCommand(cmd) && args[0] === "call") {
@@ -3795,11 +3795,11 @@ describe("QmdMemoryManager", () => {
       return results;
     };
 
-    await expect(searchWithLimits({ maxSnippetChars: 12, maxInjectedChars: 100 })).resolves.toEqual(
-      [expect.objectContaining({ snippet: "@@ -1,1\nabc" })],
-    );
+    await expect(searchWithLimits({ maxSnippetChars: 9, maxInjectedChars: 100 })).resolves.toEqual([
+      expect.objectContaining({ snippet: "abc😀tail", startLine: 1, endLine: 1 }),
+    ]);
     await expect(searchWithLimits({ maxSnippetChars: 100, maxInjectedChars: 12 })).resolves.toEqual(
-      [expect.objectContaining({ snippet: "@@ -1,1\nabc" })],
+      [expect.objectContaining({ snippet: "abc😀tail\nse", startLine: 1, endLine: 2 })],
     );
   });
 
@@ -3824,7 +3824,7 @@ describe("QmdMemoryManager", () => {
                 score: 0.73,
                 collection: "workspace-main",
                 start_line: 8,
-                snippet: "@@ -20,3\nline one\nline two\nline three",
+                snippet: "3: @@ -20,3\n4: line one\n5: line two\n6: line three",
               },
             ],
           }),
@@ -3859,7 +3859,7 @@ describe("QmdMemoryManager", () => {
         startLine: 8,
         endLine: 10,
         score: 0.73,
-        snippet: "@@ -20,3\nline one\nline two\nline three",
+        snippet: "line one\nline two\nline three",
         source: "memory",
         provenance: expectedQmdProvenance("untrusted"),
       },
@@ -5695,7 +5695,7 @@ describe("QmdMemoryManager", () => {
         startLine: 5,
         endLine: 6,
         score: 1,
-        snippet: "@@ -5,2\nremember this\nnext line",
+        snippet: "remember this\nnext line",
         source: "memory",
         provenance: expectedQmdProvenance("untrusted"),
       },
@@ -5763,7 +5763,7 @@ describe("QmdMemoryManager", () => {
         startLine: 3,
         endLine: 3,
         score: 0.9,
-        snippet: "@@ -3,1\nworkspace hit",
+        snippet: "workspace hit",
         source: "memory",
         provenance: expectedQmdProvenance("untrusted"),
       },
@@ -5804,7 +5804,7 @@ describe("QmdMemoryManager", () => {
         startLine: 4,
         endLine: 4,
         score: 0.71,
-        snippet: "@@ -4,1\ntoken unlock",
+        snippet: "token unlock",
         source: "memory",
         provenance: expectedQmdProvenance("untrusted"),
       },
@@ -5860,7 +5860,7 @@ describe("QmdMemoryManager", () => {
         startLine: 2,
         endLine: 2,
         score: 0.84,
-        snippet: "@@ -2,1\nsession canary",
+        snippet: "session canary",
         source: "sessions",
         provenance: expectedQmdProvenance("untrusted"),
       },
@@ -5952,7 +5952,7 @@ describe("QmdMemoryManager", () => {
         startLine: 2,
         endLine: 2,
         score: 0.8,
-        snippet: "@@ -2,1\nsession hit",
+        snippet: "session hit",
         source: "sessions",
         provenance: expectedQmdProvenance("untrusted"),
       },
@@ -6021,7 +6021,7 @@ describe("QmdMemoryManager", () => {
         startLine: 2,
         endLine: 2,
         score: 0.8,
-        snippet: "@@ -2,1\nworkspace fact",
+        snippet: "workspace fact",
         source: "memory",
         provenance: expectedQmdProvenance("untrusted"),
       },
@@ -6030,7 +6030,7 @@ describe("QmdMemoryManager", () => {
         startLine: 1,
         endLine: 1,
         score: 0.7,
-        snippet: "@@ -1,1\nnotes guide",
+        snippet: "notes guide",
         source: "memory",
         provenance: expectedQmdProvenance("untrusted"),
       },
@@ -6123,7 +6123,7 @@ describe("QmdMemoryManager", () => {
         startLine: 3,
         endLine: 3,
         score: 0.91,
-        snippet: "@@ -3,1\nQMD activation",
+        snippet: "QMD activation",
         source: "memory",
         provenance: expectedQmdProvenance("untrusted"),
       },
@@ -6176,7 +6176,7 @@ describe("QmdMemoryManager", () => {
         startLine: 3,
         endLine: 3,
         score: 0.91,
-        snippet: "@@ -3,1\nQMD activation",
+        snippet: "QMD activation",
         source: "memory",
         provenance: expectedQmdProvenance("untrusted"),
       },
@@ -6197,7 +6197,7 @@ describe("QmdMemoryManager", () => {
         startLine: 3,
         endLine: 3,
         score: 0.91,
-        snippet: "@@ -3,1\nQMD activation",
+        snippet: "QMD activation",
         source: "memory",
         provenance: expectedQmdProvenance("untrusted"),
       },

--- a/extensions/memory-core/src/memory/qmd-snippet.test.ts
+++ b/extensions/memory-core/src/memory/qmd-snippet.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { parseQmdSnippet } from "./qmd-snippet.js";
+
+describe("parseQmdSnippet", () => {
+  it.each([
+    ["cli", "\uFEFF@@ -2,1 @@ (1 before, 3 after)\r\ncontent\r\n", "content\r\n", 2, 2],
+    [
+      "mcp",
+      "11: @@ -10,4 @@ (9 before, 0 after)\n12: first\n13:\n14: 12: document prose\n",
+      "first\n\n12: document prose\n",
+      10,
+      13,
+    ],
+    ["mcp", "11: @@ -10,2\n12: first\n14: second", "12: first\n14: second", 10, 11],
+    ["cli", "@@ -1,2\n@@ -8,1\nreal", "@@ -8,1\nreal", 1, 2],
+    ["mcp", "@@ -7,1\ncontent", "@@ -7,1\ncontent", 0, 0],
+    ["cli", "prefix\n@@ -7,1\ncontent", "prefix\n@@ -7,1\ncontent", 0, 0],
+    [
+      "mcp",
+      "11: @@ -10,1 @@ trailing junk\n12: content",
+      "11: @@ -10,1 @@ trailing junk\n12: content",
+      0,
+      0,
+    ],
+  ] as const)("handles %s envelopes", (transport, raw, snippet, startLine, endLine) => {
+    const expected = startLine ? { snippet, startLine, endLine } : { snippet };
+    expect(parseQmdSnippet(raw, transport, 1000)).toEqual(expected);
+  });
+
+  it("retains the configured MCP cap after stripping line prefixes", () => {
+    const body = Array.from({ length: 6000 }, (_, index) => `${index + 2}: x`).join("\n");
+    expect(parseQmdSnippet(`1: @@ -1,6000\n${body}`, "mcp", 5000).snippet).toBe("x\n".repeat(2500));
+  });
+});

--- a/extensions/memory-core/src/memory/qmd-snippet.ts
+++ b/extensions/memory-core/src/memory/qmd-snippet.ts
@@ -1,0 +1,50 @@
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/memory-core-host-engine-foundation";
+
+type ParsedQmdSnippet = { snippet: string; startLine?: number; endLine?: number };
+
+const QMD_ENVELOPE_RE =
+  /^\uFEFF?(?:(\d+): ?)?@@\s*-(\d+),(\d+)(?:\s*@@(?:\s*\(\d+\s+before,\s*\d+\s+after\))?)?(?:\r?\n|$)/;
+const MCP_NUMBERED_LINE_RE = /^(\d+):(?: ?)(.*)$/;
+const positiveSafeInteger = (value: number) => Number.isSafeInteger(value) && value > 0;
+
+export function parseQmdSnippet(
+  raw: string,
+  transport: "cli" | "mcp",
+  maxChars: number,
+): ParsedQmdSnippet {
+  const truncate = (value: string) => truncateUtf16Safe(value, maxChars);
+  const scanChars = Math.min(
+    Number.MAX_SAFE_INTEGER,
+    maxChars * (transport === "mcp" ? 20 : 1) + 4096,
+  );
+  const bounded = truncateUtf16Safe(raw, scanChars);
+  const match = QMD_ENVELOPE_RE.exec(bounded);
+  const headerNumber = Number(match?.[1]);
+  const startLine = Number(match?.[2]);
+  const count = Number(match?.[3]);
+  const endLine = startLine + count - 1;
+  const expectedTransport =
+    transport === "mcp" ? positiveSafeInteger(headerNumber) : match?.[1] === undefined;
+  if (!match || !expectedTransport || ![startLine, count, endLine].every(positiveSafeInteger)) {
+    return { snippet: truncate(raw) };
+  }
+
+  const body = bounded.slice(match[0].length);
+  if (transport === "cli") {
+    return { snippet: truncate(body), startLine, endLine };
+  }
+  const newline = body.includes("\r\n") ? "\r\n" : "\n";
+  const lines = body.split(/\r?\n/);
+  const trailingNewline = body.length > 0 && lines.at(-1) === "";
+  if (trailingNewline) {
+    lines.pop();
+  }
+  const numbered = lines.map((line) => MCP_NUMBERED_LINE_RE.exec(line));
+  const complete = numbered.every(
+    (line, index) => line && Number(line[1]) === headerNumber + index + 1,
+  );
+  const cleaned = complete
+    ? numbered.map((line) => line![2]!).join(newline) + (trailingNewline ? newline : "")
+    : body;
+  return { snippet: truncate(cleaned), startLine, endLine };
+}


### PR DESCRIPTION
## What Problem This Solves

QMD search results include transport-only location envelopes. Direct QMD emits a leading `@@ -start,count @@` line, while the MCP path numbers that envelope and every returned body line. Memory Core previously exposed those transport markers as recalled text.

Related: #106937

## Scope

This is an adapter-only normalization fix. It does not migrate, invalidate, rewrite, or otherwise touch session state, short-term recall state, Dreaming signals, QMD indexes, or source memory files.

## Implementation

- Direct CLI and MCP results use explicit transport modes instead of guessing from document text.
- Direct CLI strips one strict leading raw QMD envelope.
- MCP strips one strict numbered envelope and removes body prefixes only when the complete bounded body is consecutively numbered.
- Explicit QMD/MCP `startLine` and `endLine` fields retain precedence over envelope-derived ranges.
- Parsing is bounded before splitting or regex work. MCP scanning includes a bounded worst-case line-prefix allowance so the configured cleaned-snippet budget remains available, then output is truncated UTF-16-safely.
- Malformed envelopes, mid-snippet markers, nonconsecutive MCP numbering, and copied header-like prose are preserved.

## Evidence

Exact PR head: `2e54ba706`

- `176/176` affected tests pass:
  - `qmd-snippet.test.ts`: 8
  - `qmd-manager.slugified-paths.test.ts`: 3
  - `qmd-manager.test.ts`: 165
- `pnpm tsgo:extensions` and `pnpm tsgo:extensions:test` pass.
- Scoped extension oxlint reports 0 warnings and 0 errors.
- `pnpm deadcode:full` passes.
- `oxfmt --check` and `git diff --check` pass.
- The high-limit MCP regression proves 5,000 cleaned characters remain available after stripping prefixes from 6,000 numbered lines.
- Patch size is 122 additions + 30 deletions = 152 changed lines, which is `size: S` under the repository labeler (`<200`).

### Real transport proof

The probe used QMD `2.5.3`, mcporter `0.13.0`, one temporary document, and isolated temporary config/cache/index paths under `/tmp/qmd-proof-107152`. It did not use or modify a running OpenClaw agent, session, gateway, service, or production QMD index.

Direct QMD returned the raw envelope:

```text
"snippet": "@@ -2,4 @@ (1 before, 0 after)\n\nalpha transport canary\nbeta document line\n"
```

A real mcporter MCP `query` call returned the numbered transport form:

```text
"snippet": "3: @@ -2,4 @@ (1 before, 0 after)\n4: \n5: alpha transport canary\n6: beta document line\n7: "
```

The unit and manager tests exercise both exact transport shapes and assert clean recalled text with preserved structured line ranges.

### After-fix OpenClaw product-path proof

The patched product path was then exercised at exact head `2e54ba70643ef31131981f82336c4016a906958f` with `OPENCLAW_STATE_DIR`, workspace, config, and QMD index all isolated under `/tmp/openclaw-proof-107152`. No running agent, session, gateway, service, source memory, or production index was used or modified.

Direct OpenClaw CLI (`pnpm openclaw memory search "transport canary" --agent main --json`) returned:

```json
{
  "results": [
    {
      "path": "MEMORY.md",
      "startLine": 2,
      "endLine": 5,
      "score": 0,
      "snippet": "\nalpha transport canary\nbeta document line\n",
      "source": "memory"
    }
  ]
}
```

The same exact-head `QmdMemoryManager.search()` product path was exercised through a real mcporter `qmd.query` call (the resolved internal MCP compatibility switch was enabled only in the isolated harness). It returned:

```json
{
  "transport": "mcp",
  "results": [
    {
      "path": "MEMORY.md",
      "startLine": 2,
      "endLine": 5,
      "score": 1,
      "snippet": "\nalpha transport canary\nbeta document line\n",
      "source": "memory"
    }
  ]
}
```

Both real transports therefore remove the transport envelope/body numbering while preserving the same structured source range.

## AI Assistance

This patch was refreshed with Codex assistance and validated before push.
