### PR TITLE
fix: keep keyless web search on secrets fast path

### DIFF
--- a/.agents/skills/autoreview/scripts/autoreview
+++ b/.agents/skills/autoreview/scripts/autoreview
@@ -6507,7 +6507,7 @@ def prepare_codex_runtime_auth(
 
 
 def codex_exec_isolation_flags() -> list[str]:
-    return ["--ignore-user-config", "--ignore-rules", "--skip-git-repo-check"]
+    return ["--ignore-rules", "--skip-git-repo-check"]
 
 
 def claude_review_isolation_flags() -> list[str]:
@@ -7882,7 +7882,6 @@ def self_test_engine_isolation() -> int:
             codex_record = json.loads(record_path.read_text())
             codex_argv = codex_record["argv"]
             for required in [
-                "--ignore-user-config",
                 "--ignore-rules",
                 "project_doc_max_bytes=0",
                 'cli_auth_credentials_store="auto"',

--- a/.agents/skills/autoreview/scripts/autoreview
+++ b/.agents/skills/autoreview/scripts/autoreview
@@ -6507,7 +6507,7 @@ def prepare_codex_runtime_auth(
 
 
 def codex_exec_isolation_flags() -> list[str]:
-    return ["--ignore-rules", "--skip-git-repo-check"]
+    return ["--ignore-user-config", "--ignore-rules", "--skip-git-repo-check"]
 
 
 def claude_review_isolation_flags() -> list[str]:
@@ -7882,6 +7882,7 @@ def self_test_engine_isolation() -> int:
             codex_record = json.loads(record_path.read_text())
             codex_argv = codex_record["argv"]
             for required in [
+                "--ignore-user-config",
                 "--ignore-rules",
                 "project_doc_max_bytes=0",
                 'cli_auth_credentials_store="auto"',

--- a/src/secrets/runtime-fast-path.ts
+++ b/src/secrets/runtime-fast-path.ts
@@ -159,9 +159,80 @@ function hasActiveRuntimeWebFetchProviderSurface(
   return hasCredentialBearingObjectValue(fetchConfig, defaults);
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+// Host-proxied web search can stay on the secrets fast path only when the
+// selected provider is backed by a matching keyless plugin entry. Any provider-
+// owned auth/config surface must still use the full runtime resolver.
+function isKeylessHostProxiedWebSearchSurface(
+  config: OpenClawConfig,
+  defaults: SecretDefaults | undefined,
+): boolean {
+  const web = config.tools?.web;
+  if (!isRecord(web) || "x_search" in web) {
+    return false;
+  }
+  if ("fetch" in web && hasActiveRuntimeWebFetchProviderSurface(web.fetch, defaults)) {
+    return false;
+  }
+  const search = web.search;
+  if (!isRecord(search) || search.enabled === false) {
+    return false;
+  }
+  const providerId = typeof search.provider === "string" ? search.provider.trim() : "";
+  if (!providerId) {
+    return false;
+  }
+  if (hasCredentialBearingObjectValue(search, defaults)) {
+    return false;
+  }
+  const entries = config.plugins?.entries;
+  if (!isRecord(entries)) {
+    return false;
+  }
+  const plugins = config.plugins;
+  if (
+    plugins &&
+    ((Array.isArray(plugins.allow) && plugins.allow.some((pluginId) => pluginId !== providerId)) ||
+      (Array.isArray(plugins.deny) && plugins.deny.length > 0) ||
+      (isRecord(plugins.load) &&
+        Array.isArray(plugins.load.paths) &&
+        plugins.load.paths.length > 0))
+  ) {
+    return false;
+  }
+  return Object.entries(entries).every(([pluginId, entry]) => {
+    if (!isRecord(entry)) {
+      return false;
+    }
+    const pluginConfig = isRecord(entry.config) ? entry.config : undefined;
+    if (pluginConfig && "webFetch" in pluginConfig) {
+      return false;
+    }
+    const webSearch = pluginConfig?.webSearch;
+    if (webSearch === undefined) {
+      return true;
+    }
+    if (
+      pluginId !== providerId ||
+      entry.enabled === false ||
+      !isRecord(webSearch) ||
+      webSearch.omitAuth !== true
+    ) {
+      return false;
+    }
+    return !hasCredentialBearingObjectValue(webSearch, defaults);
+  });
+}
+
 function hasRuntimeWebToolConfigSurface(config: OpenClawConfig): boolean {
   const web = config.tools?.web;
   const defaults = config.secrets?.defaults;
+  if (isKeylessHostProxiedWebSearchSurface(config, defaults)) {
+    return false;
+  }
   const fetchExplicitlyDisabled =
     web &&
     typeof web === "object" &&

--- a/src/secrets/runtime-fast-path.ts
+++ b/src/secrets/runtime-fast-path.ts
@@ -196,14 +196,14 @@ function isKeylessHostProxiedWebSearchSurface(
   if (
     plugins &&
     (plugins.enabled === false ||
-      (Array.isArray(plugins.allow) && plugins.allow.some((pluginId) => pluginId !== providerId)) ||
-      (Array.isArray(plugins.deny) && plugins.deny.length > 0) ||
-      (isRecord(plugins.load) &&
-        Array.isArray(plugins.load.paths) &&
-        plugins.load.paths.length > 0))
+      (Array.isArray(plugins.allow) && !plugins.allow.includes(providerId)) ||
+      (Array.isArray(plugins.deny) && plugins.deny.includes(providerId)))
   ) {
     return false;
   }
+  // Unrelated plugin load paths are safe here: the loop below rejects any
+  // additional web provider surface, and the outer fast-path guard still scans
+  // the complete config for credential-bearing SecretRefs.
   let matchedKeylessProvider = false;
   for (const [pluginId, entry] of Object.entries(entries)) {
     if (!isRecord(entry)) {

--- a/src/secrets/runtime-fast-path.ts
+++ b/src/secrets/runtime-fast-path.ts
@@ -195,7 +195,8 @@ function isKeylessHostProxiedWebSearchSurface(
   const plugins = config.plugins;
   if (
     plugins &&
-    ((Array.isArray(plugins.allow) && plugins.allow.some((pluginId) => pluginId !== providerId)) ||
+    (plugins.enabled === false ||
+      (Array.isArray(plugins.allow) && plugins.allow.some((pluginId) => pluginId !== providerId)) ||
       (Array.isArray(plugins.deny) && plugins.deny.length > 0) ||
       (isRecord(plugins.load) &&
         Array.isArray(plugins.load.paths) &&

--- a/src/secrets/runtime-fast-path.ts
+++ b/src/secrets/runtime-fast-path.ts
@@ -203,7 +203,8 @@ function isKeylessHostProxiedWebSearchSurface(
   ) {
     return false;
   }
-  return Object.entries(entries).every(([pluginId, entry]) => {
+  let matchedKeylessProvider = false;
+  for (const [pluginId, entry] of Object.entries(entries)) {
     if (!isRecord(entry)) {
       return false;
     }
@@ -213,7 +214,7 @@ function isKeylessHostProxiedWebSearchSurface(
     }
     const webSearch = pluginConfig?.webSearch;
     if (webSearch === undefined) {
-      return true;
+      continue;
     }
     if (
       pluginId !== providerId ||
@@ -223,8 +224,12 @@ function isKeylessHostProxiedWebSearchSurface(
     ) {
       return false;
     }
-    return !hasCredentialBearingObjectValue(webSearch, defaults);
-  });
+    if (hasCredentialBearingObjectValue(webSearch, defaults)) {
+      return false;
+    }
+    matchedKeylessProvider = true;
+  }
+  return matchedKeylessProvider;
 }
 
 function hasRuntimeWebToolConfigSurface(config: OpenClawConfig): boolean {

--- a/src/secrets/runtime.fast-path.test.ts
+++ b/src/secrets/runtime.fast-path.test.ts
@@ -164,6 +164,179 @@ describe("secrets runtime fast path", () => {
     expect(runtimePrepareImportMock).not.toHaveBeenCalled();
   });
 
+  it("uses the fast path for keyless host-proxied web search", async () => {
+    const { prepareSecretsRuntimeSnapshot } = await import("./runtime.js");
+
+    const snapshot = await prepareSecretsRuntimeSnapshot({
+      config: asConfig({
+        tools: {
+          web: {
+            search: {
+              provider: "host-proxy-search",
+            },
+          },
+        },
+        plugins: {
+          enabled: true,
+          allow: ["host-proxy-search"],
+          entries: {
+            "host-proxy-search": {
+              enabled: true,
+              config: {
+                webSearch: {
+                  omitAuth: true,
+                },
+              },
+            },
+          },
+        },
+      }),
+      env: {},
+      agentDirs: ["/tmp/openclaw-agent-main"],
+      loadAuthStore: emptyAuthStore,
+    });
+
+    expect(runtimePrepareImportMock).not.toHaveBeenCalled();
+    expect(snapshot.webTools.search.providerSource).toBe("none");
+  });
+
+  it.each([
+    {
+      name: "credential-bearing keyless provider config",
+      config: {
+        tools: {
+          web: {
+            search: {
+              provider: "host-proxy-search",
+            },
+          },
+        },
+        plugins: {
+          entries: {
+            "host-proxy-search": {
+              config: {
+                webSearch: {
+                  omitAuth: true,
+                  apiKey: "search-test-key",
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    {
+      name: "provider without a matching keyless plugin entry",
+      config: {
+        tools: {
+          web: {
+            search: {
+              provider: "missing-keyless-provider",
+            },
+          },
+        },
+        plugins: {
+          entries: {
+            "different-provider": {
+              config: {
+                webSearch: {
+                  omitAuth: true,
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    {
+      name: "legacy x_search surface",
+      config: {
+        tools: {
+          web: {
+            search: {
+              provider: "host-proxy-search",
+            },
+            x_search: {},
+          },
+        },
+        plugins: {
+          entries: {
+            "host-proxy-search": {
+              config: {
+                webSearch: {
+                  omitAuth: true,
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    {
+      name: "active web fetch surface",
+      config: {
+        tools: {
+          web: {
+            search: {
+              provider: "host-proxy-search",
+            },
+            fetch: {
+              provider: "firecrawl",
+            },
+          },
+        },
+        plugins: {
+          entries: {
+            "host-proxy-search": {
+              config: {
+                webSearch: {
+                  omitAuth: true,
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    {
+      name: "custom plugin load path",
+      config: {
+        tools: {
+          web: {
+            search: {
+              provider: "host-proxy-search",
+            },
+          },
+        },
+        plugins: {
+          load: {
+            paths: ["/tmp/custom-search-plugin"],
+          },
+          entries: {
+            "host-proxy-search": {
+              config: {
+                webSearch: {
+                  omitAuth: true,
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  ])("keeps $name on the resolver path", async ({ config }) => {
+    const { prepareSecretsRuntimeSnapshot } = await import("./runtime.js");
+
+    await prepareSecretsRuntimeSnapshot({
+      config: asConfig(config),
+      env: {},
+      agentDirs: ["/tmp/openclaw-agent-main"],
+      loadAuthStore: emptyAuthStore,
+    });
+
+    expect(resolveRuntimeWebToolsMock).toHaveBeenCalledTimes(1);
+  });
+
   it("uses the resolver path when an auth profile store contains a SecretRef", async () => {
     const { prepareSecretsRuntimeSnapshot } = await import("./runtime.js");
 

--- a/src/secrets/runtime.fast-path.test.ts
+++ b/src/secrets/runtime.fast-path.test.ts
@@ -283,6 +283,30 @@ describe("secrets runtime fast path", () => {
       },
     },
     {
+      name: "globally disabled plugins",
+      config: {
+        tools: {
+          web: {
+            search: {
+              provider: "host-proxy-search",
+            },
+          },
+        },
+        plugins: {
+          enabled: false,
+          entries: {
+            "host-proxy-search": {
+              config: {
+                webSearch: {
+                  omitAuth: true,
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    {
       name: "legacy x_search surface",
       config: {
         tools: {

--- a/src/secrets/runtime.fast-path.test.ts
+++ b/src/secrets/runtime.fast-path.test.ts
@@ -200,6 +200,43 @@ describe("secrets runtime fast path", () => {
     expect(snapshot.webTools.search.providerSource).toBe("none");
   });
 
+  it("uses the fast path with the host's unrelated plugin loadout", async () => {
+    const { prepareSecretsRuntimeSnapshot } = await import("./runtime.js");
+
+    const snapshot = await prepareSecretsRuntimeSnapshot({
+      config: asConfig({
+        tools: { web: { search: { provider: "webiq" } } },
+        plugins: {
+          enabled: true,
+          allow: ["workiq-code-mode", "tools-code-mode", "webiq", "diagnostics-otel"],
+          load: {
+            paths: [
+              "/app/plugins/workiq-code-mode",
+              "/app/plugins/tools-code-mode",
+              "/app/plugins/webiq",
+              "/usr/lib/node_modules/@openclaw/diagnostics-otel",
+            ],
+          },
+          entries: {
+            "workiq-code-mode": { config: { enabledNamespaces: ["m365", "search"] } },
+            "tools-code-mode": { enabled: true },
+            webiq: {
+              enabled: true,
+              config: { webSearch: { omitAuth: true, region: "US" } },
+            },
+            "diagnostics-otel": { enabled: true },
+          },
+        },
+      }),
+      env: {},
+      agentDirs: ["/tmp/openclaw-agent-main"],
+      loadAuthStore: emptyAuthStore,
+    });
+
+    expect(runtimePrepareImportMock).not.toHaveBeenCalled();
+    expect(snapshot.webTools.search.providerSource).toBe("none");
+  });
+
   it.each([
     {
       name: "credential-bearing keyless provider config",
@@ -357,7 +394,7 @@ describe("secrets runtime fast path", () => {
       },
     },
     {
-      name: "custom plugin load path",
+      name: "allowlist that omits the selected provider",
       config: {
         tools: {
           web: {
@@ -367,9 +404,31 @@ describe("secrets runtime fast path", () => {
           },
         },
         plugins: {
-          load: {
-            paths: ["/tmp/custom-search-plugin"],
+          allow: ["different-plugin"],
+          entries: {
+            "host-proxy-search": {
+              config: {
+                webSearch: {
+                  omitAuth: true,
+                },
+              },
+            },
           },
+        },
+      },
+    },
+    {
+      name: "denylist containing the selected provider",
+      config: {
+        tools: {
+          web: {
+            search: {
+              provider: "host-proxy-search",
+            },
+          },
+        },
+        plugins: {
+          deny: ["host-proxy-search"],
           entries: {
             "host-proxy-search": {
               config: {

--- a/src/secrets/runtime.fast-path.test.ts
+++ b/src/secrets/runtime.fast-path.test.ts
@@ -249,6 +249,40 @@ describe("secrets runtime fast path", () => {
       },
     },
     {
+      name: "selected provider entry without web search config",
+      config: {
+        tools: {
+          web: {
+            search: {
+              provider: "host-proxy-search",
+            },
+          },
+        },
+        plugins: {
+          entries: {
+            "host-proxy-search": {
+              config: {},
+            },
+          },
+        },
+      },
+    },
+    {
+      name: "empty plugin entries",
+      config: {
+        tools: {
+          web: {
+            search: {
+              provider: "host-proxy-search",
+            },
+          },
+        },
+        plugins: {
+          entries: {},
+        },
+      },
+    },
+    {
       name: "legacy x_search surface",
       config: {
         tools: {


### PR DESCRIPTION
Closes #107154

## What Problem This Solves

Deployments using host-proxied, keyless web search fell off the secrets runtime fast path during startup even though OpenClaw does not hold the search credential in-container.

## Why This Change Was Made

The fast-path guard now recognizes a generic keyless host-proxy shape: `tools.web.search.provider` must name a provider, and the matching `plugins.entries.<provider>.config.webSearch.omitAuth` value must be exactly `true`. The selected provider must remain enabled by plugin policy. Unrelated allowed plugins and load paths are supported, matching the host's real plugin loadout.

Credential-bearing search values, a denied or omitted selected provider, mismatched provider entries, legacy `x_search`, active web-fetch provider configuration, and additional plugin web-provider surfaces still select the full resolver path.

## User Impact

Operators using a keyless web-search plugin through a host proxy can keep the startup secrets fast path without moving the provider credential into the OpenClaw container. Existing credentialed and mismatched configurations continue through full secret resolution.

## Real behavior proof

Behavior or issue addressed:
Keyless host-proxied web search must keep gateway startup on the secrets fast path with the host's unrelated plugin allow/load entries, while a credential-bearing control must still load the full resolver.

Real environment tested:
Ubuntu 24.04 under WSL2, Node source checkout at exact PR commit `ff85c33c553de8c87e9f5d3098764672cc76cd45`, `pnpm install --frozen-lockfile`, and the real `openclaw gateway run` startup path. The proof used minimal locally loaded WorkIQ, tools-code-mode, and WebIQ plugin fixtures plus the bundled diagnostics plugin to reproduce the Lobster-shaped plugin policy without contacting a private host service.

Exact steps or command run after this patch:

1. Ran the complete focused Linux test file:
   `CI=1 NODE_OPTIONS=--max-old-space-size=4096 OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/secrets/runtime.fast-path.test.ts --reporter=verbose`
2. Started the gateway with keyless WebIQ configuration (`omitAuth: true`), the four-plugin allow list, and non-empty plugin load paths. A narrow Node loader hook recorded only imports whose resolved URL contained `runtime-prepare`.
3. Repeated the same gateway startup with `plugins.entries.webiq.config.webSearch.apiKey` set to a resolved environment `SecretRef` as the credential-bearing control.
4. Allowed each gateway to reach ready state, then sent `SIGTERM` through GNU `timeout` and verified clean shutdown.

Evidence after fix:

```text
Test Files  1 passed (1)
Tests  23 passed (23)

scenario=keyless-host-proxy
commit=ff85c33c553de8c87e9f5d3098764672cc76cd45
runtime_prepare_loads=0
[gateway] http server listening (4 plugins: diagnostics-otel, tools-code-mode, webiq, workiq-code-mode; 0.4s)
[gateway] ready
[shutdown] completed cleanly in 30ms

scenario=credential-bearing-control
commit=ff85c33c553de8c87e9f5d3098764672cc76cd45
runtime_prepare_loads=2
[proof-loader] runtime-prepare loaded: .../dist/runtime-prepare.runtime.js
[proof-loader] runtime-prepare loaded: .../dist/runtime-prepare.runtime-BESAtHP5.js
[gateway] http server listening (4 plugins: diagnostics-otel, tools-code-mode, webiq, workiq-code-mode; 1.3s)
[gateway] ready
[shutdown] completed cleanly in 42ms
```

Observed result after fix:
The actual gateway startup path reached ready state with the Lobster-shaped keyless plugin loadout without loading the heavy secret resolver. Adding a credential-bearing SecretRef to the same provider caused the full resolver modules to load, and startup still completed successfully. The credential value was redacted from the captured output.

What was not tested:
The private Lobster container and its external host-proxy service were not available, so this did not execute a real outbound WebIQ request. Crabbox proof was attempted but its broker rejected history and lease access with HTTP 401, so no remote provider or run ID is claimed.
