### PR TITLE
fix: explain and control native session discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Native session discovery diagnostics:** add independent Codex and Claude Code sidebar discovery toggles in plugin Settings, preserve paired-node list failure causes, and point sidebar warnings to the relevant Settings controls. Fixes #107112.
 - **ClawHub plugin API ranges:** delegate each supported comparator to `semver` so tilde, partial-wildcard, and prerelease caret bounds are correct while preserving OpenClaw version normalization and the existing restricted range grammar. (#106877)
 - **Web Readability relative links:** seed parsed documents with the request URL so article links resolve correctly while removing the plugin's duplicate lazy-loader facade. (#106860)
 - **Browser auto-routing:** fall back to the Gateway host when an implicitly selected browser node reports that its control host is unreachable, while preserving explicit node pins and ambiguous action failures.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Native session discovery diagnostics:** add independent Codex and Claude Code sidebar discovery toggles in plugin Settings, preserve paired-node list failure causes, and point sidebar warnings to the relevant Settings controls. Fixes #107112.
 - **ClawHub plugin API ranges:** delegate each supported comparator to `semver` so tilde, partial-wildcard, and prerelease caret bounds are correct while preserving OpenClaw version normalization and the existing restricted range grammar. (#106877)
 - **Web Readability relative links:** seed parsed documents with the request URL so article links resolve correctly while removing the plugin's duplicate lazy-loader facade. (#106860)
 - **Browser auto-routing:** fall back to the Gateway host when an implicitly selected browser node reports that its control host is unreachable, while preserving explicit node pins and ambiguous action failures.

--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewayProtocol.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewayProtocol.kt
@@ -401,6 +401,7 @@ enum class GatewayEvent(
   NodePairResolved("node.pair.resolved"),
   NodePresence("node.presence"),
   NodeInvokeCancel("node.invoke.cancel"),
+  NodeInvokeInput("node.invoke.input"),
   NodeInvokeRequest("node.invoke.request"),
   DevicePairRequested("device.pair.requested"),
   DevicePairResolved("device.pair.resolved"),

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -2155,6 +2155,32 @@ public struct NodeInvokeParams: Codable, Sendable {
     }
 }
 
+public struct NodeInvokeInputEvent: Codable, Sendable {
+    public let id: String
+    public let nodeid: String
+    public let seq: Int
+    public let payloadjson: String
+
+    public init(
+        id: String,
+        nodeid: String,
+        seq: Int,
+        payloadjson: String)
+    {
+        self.id = id
+        self.nodeid = nodeid
+        self.seq = seq
+        self.payloadjson = payloadjson
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case nodeid = "nodeId"
+        case seq
+        case payloadjson = "payloadJSON"
+    }
+}
+
 public struct NodeInvokeProgressParams: Codable, Sendable {
     public let invokeid: String
     public let nodeid: String
@@ -2212,6 +2238,40 @@ public struct NodeInvokeResultParams: Codable, Sendable {
         case payload
         case payloadjson = "payloadJSON"
         case error
+    }
+}
+
+public struct NodeInvokeRequestEvent: Codable, Sendable {
+    public let id: String
+    public let nodeid: String
+    public let command: String
+    public let paramsjson: String?
+    public let timeoutms: Int?
+    public let idempotencykey: String?
+
+    public init(
+        id: String,
+        nodeid: String,
+        command: String,
+        paramsjson: String? = nil,
+        timeoutms: Int? = nil,
+        idempotencykey: String? = nil)
+    {
+        self.id = id
+        self.nodeid = nodeid
+        self.command = command
+        self.paramsjson = paramsjson
+        self.timeoutms = timeoutms
+        self.idempotencykey = idempotencykey
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case nodeid = "nodeId"
+        case command
+        case paramsjson = "paramsJSON"
+        case timeoutms = "timeoutMs"
+        case idempotencykey = "idempotencyKey"
     }
 }
 
@@ -2416,40 +2476,6 @@ public struct NodePendingEnqueueResult: Codable, Sendable {
         case revision
         case queued
         case waketriggered = "wakeTriggered"
-    }
-}
-
-public struct NodeInvokeRequestEvent: Codable, Sendable {
-    public let id: String
-    public let nodeid: String
-    public let command: String
-    public let paramsjson: String?
-    public let timeoutms: Int?
-    public let idempotencykey: String?
-
-    public init(
-        id: String,
-        nodeid: String,
-        command: String,
-        paramsjson: String? = nil,
-        timeoutms: Int? = nil,
-        idempotencykey: String? = nil)
-    {
-        self.id = id
-        self.nodeid = nodeid
-        self.command = command
-        self.paramsjson = paramsjson
-        self.timeoutms = timeoutms
-        self.idempotencykey = idempotencykey
-    }
-
-    private enum CodingKeys: String, CodingKey {
-        case id
-        case nodeid = "nodeId"
-        case command
-        case paramsjson = "paramsJSON"
-        case timeoutms = "timeoutMs"
-        case idempotencykey = "idempotencyKey"
     }
 }
 
@@ -2671,21 +2697,25 @@ public struct SessionCatalogCapabilities: Codable, Sendable {
     public let continuesession: Bool
     public let archive: Bool
     public let createsession: [String: AnyCodable]?
+    public let openterminal: Bool?
 
     public init(
         continuesession: Bool,
         archive: Bool,
-        createsession: [String: AnyCodable]? = nil)
+        createsession: [String: AnyCodable]? = nil,
+        openterminal: Bool? = nil)
     {
         self.continuesession = continuesession
         self.archive = archive
         self.createsession = createsession
+        self.openterminal = openterminal
     }
 
     private enum CodingKeys: String, CodingKey {
         case continuesession = "continueSession"
         case archive
         case createsession = "createSession"
+        case openterminal = "openTerminal"
     }
 }
 
@@ -2727,6 +2757,7 @@ public struct SessionCatalogSession: Codable, Sendable {
     public let openclawsessionkey: String?
     public let cancontinue: Bool
     public let canarchive: Bool
+    public let canopenterminal: Bool?
 
     public init(
         threadid: String,
@@ -2743,7 +2774,8 @@ public struct SessionCatalogSession: Codable, Sendable {
         archived: Bool,
         openclawsessionkey: String? = nil,
         cancontinue: Bool,
-        canarchive: Bool)
+        canarchive: Bool,
+        canopenterminal: Bool? = nil)
     {
         self.threadid = threadid
         self.name = name
@@ -2760,6 +2792,7 @@ public struct SessionCatalogSession: Codable, Sendable {
         self.openclawsessionkey = openclawsessionkey
         self.cancontinue = cancontinue
         self.canarchive = canarchive
+        self.canopenterminal = canopenterminal
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -2778,6 +2811,7 @@ public struct SessionCatalogSession: Codable, Sendable {
         case openclawsessionkey = "openClawSessionKey"
         case cancontinue = "canContinue"
         case canarchive = "canArchive"
+        case canopenterminal = "canOpenTerminal"
     }
 }
 
@@ -10789,21 +10823,25 @@ public struct MigrationsMemoryApplyResult: Codable, Sendable {
 
 public struct TerminalOpenParams: Codable, Sendable {
     public let agentid: String?
+    public let catalog: SessionsCatalogContinueParams?
     public let cols: Int
     public let rows: Int
 
     public init(
         agentid: String? = nil,
+        catalog: SessionsCatalogContinueParams? = nil,
         cols: Int,
         rows: Int)
     {
         self.agentid = agentid
+        self.catalog = catalog
         self.cols = cols
         self.rows = rows
     }
 
     private enum CodingKeys: String, CodingKey {
         case agentid = "agentId"
+        case catalog
         case cols
         case rows
     }
@@ -10815,19 +10853,22 @@ public struct TerminalOpenResult: Codable, Sendable {
     public let shell: String
     public let cwd: String
     public let confined: Bool
+    public let title: String?
 
     public init(
         sessionid: String,
         agentid: String,
         shell: String,
         cwd: String,
-        confined: Bool)
+        confined: Bool,
+        title: String? = nil)
     {
         self.sessionid = sessionid
         self.agentid = agentid
         self.shell = shell
         self.cwd = cwd
         self.confined = confined
+        self.title = title
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -10836,6 +10877,7 @@ public struct TerminalOpenResult: Codable, Sendable {
         case shell
         case cwd
         case confined
+        case title
     }
 }
 

--- a/docs/nodes/index.md
+++ b/docs/nodes/index.md
@@ -289,6 +289,9 @@ A desktop or server node can expose chat-capable models from an Ollama server ru
 The official `codex` plugin can expose non-archived Codex sessions on a
 headless node host or native macOS node. Catalog registration no longer depends
 on `supervision.enabled`; that option gates the agent-facing supervision tools.
+Set `sessionCatalog.enabled: false` in the Codex plugin config to disable the
+operator catalog and paired-node catalog commands without disabling the
+provider or harness.
 The plugin must still be active on both computers, and the node setting remains
 local consent: enabling only the Gateway cannot read another computer's Codex
 state.
@@ -316,8 +319,11 @@ pagination, local continuation, and the metadata security boundary.
 ### Claude sessions and transcripts
 
 The bundled `anthropic` plugin discovers non-archived Claude CLI and Claude
-Desktop sessions on the Gateway and paired nodes. Unlike Codex supervision,
-this needs no separate opt-in: a remote macOS app node advertises
+Desktop sessions on the Gateway and paired nodes by default. Set
+`plugins.entries.anthropic.config.sessionCatalog.enabled: false` to disable the
+operator catalog and paired-node catalog commands without disabling Anthropic
+models or the Claude CLI backend.
+A remote macOS app node advertises
 `anthropic.claude.sessions.list.v1` and `anthropic.claude.sessions.read.v1`
 when the Anthropic plugin is enabled and `~/.claude/projects/` exists. Approve
 the node pairing upgrade when those commands first appear.

--- a/docs/plugins/codex-harness-reference.md
+++ b/docs/plugins/codex-harness-reference.md
@@ -46,12 +46,13 @@ Top-level fields:
 | `codexDynamicToolsExclude` | `[]`                     | Additional OpenClaw dynamic tool names to omit from Codex app-server turns.                                                                    |
 | `codexPlugins`             | disabled                 | Native Codex plugin/app support, including opt-in access to connected account apps. See [Native Codex plugins](/plugins/codex-native-plugins). |
 | `computerUse`              | disabled                 | Codex Computer Use setup. See [Codex Computer Use](/plugins/codex-computer-use).                                                               |
-| `supervision`              | disabled                 | Non-archived native-session catalog, local branch continuation, and agent-tool policy. See [Codex supervision](/plugins/codex-supervision).    |
+| `sessionCatalog`           | enabled                  | Native Codex session discovery for the sidebar. Set `enabled: false` to disable discovery without disabling the provider or harness.           |
+| `supervision`              | disabled                 | Agent-facing native-session transcript and write-control policy. See [Codex supervision](/plugins/codex-supervision).                          |
 
 ## Supervision
 
-Supervision lists non-archived Codex sessions from the Gateway computer and
-opted-in paired nodes. Enable it independently from the agent harness:
+Native session discovery lists non-archived Codex sessions from the Gateway
+computer and opted-in paired nodes by default. Disable only that catalog with:
 
 ```json5
 {
@@ -60,8 +61,8 @@ opted-in paired nodes. Enable it independently from the agent harness:
       codex: {
         enabled: true,
         config: {
-          supervision: {
-            enabled: true,
+          sessionCatalog: {
+            enabled: false,
           },
         },
       },
@@ -70,11 +71,11 @@ opted-in paired nodes. Enable it independently from the agent harness:
 }
 ```
 
-`supervision` fields:
+`supervision` separately controls agent-facing tools:
 
 | Field                 | Default                 | Meaning                                                                                                                                                                                                                                   |
 | --------------------- | ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `enabled`             | `false`                 | Advertise the local session catalog and, on the Gateway, aggregate opted-in paired-node catalogs for the Codex Sessions page.                                                                                                             |
+| `enabled`             | `false`                 | Enable agent-facing Codex supervision tools. This does not control the authenticated operator session catalog.                                                                                                                            |
 | `endpoints`           | built-in local endpoint | Compatibility and advanced endpoint targets for the retained Codex supervision agent and standalone MCP tools. The human catalog and branch flow ignore these targets and use the supervision App Server resolved from `appServer`.       |
 | `allowRawTranscripts` | `false`                 | With supervision enabled, allow autonomous agent or standalone MCP transcript reads and transcript-derived list fields. `codex_threads` metadata-only reads remain available. Does not control authenticated Control UI continuation.     |
 | `allowWriteControls`  | `false`                 | With supervision enabled, allow autonomous `codex_threads` fork, rename, archive, and unarchive mutations plus standalone MCP send, steer, and interrupt operations. Does not bypass other binding, host, status, or confirmation checks. |

--- a/docs/plugins/codex-harness.md
+++ b/docs/plugins/codex-harness.md
@@ -153,9 +153,10 @@ stdio App Servers. Codex coordinates live writers inside one App Server, not
 across separate processes. Forking is the safe coexistence path for ordinary
 user-home stdio sessions.
 
-`appServer.homeScope: "user"` alone does not enable the fleet catalog. Use
-`supervision.enabled: true` when you want native sessions to appear in the
-OpenClaw sidebar. Supervision uses a separate supervision connection; without
+`appServer.homeScope: "user"` alone does not control the fleet catalog. Native
+session discovery is enabled while the plugin is active; set
+`sessionCatalog.enabled: false` to remove it from the OpenClaw sidebar without
+disabling Codex. The catalog uses a separate supervision connection; without
 explicit `appServer` connection settings, that connection defaults to managed
 user-home stdio while the ordinary harness stays agent-scoped. Explicit
 `appServer` settings are honored by both paths. Set `homeScope: "user"`
@@ -183,7 +184,7 @@ rules, paired-node limits, metadata exposure, and troubleshooting.
 | Need                                                | Set                                                                                              | Where                              |
 | --------------------------------------------------- | ------------------------------------------------------------------------------------------------ | ---------------------------------- |
 | Enable the harness                                  | `plugins.entries.codex.enabled: true`                                                            | OpenClaw config                    |
-| Show non-archived Codex sessions                    | `plugins.entries.codex.config.supervision.enabled: true`                                         | Codex plugin config                |
+| Hide native Codex session discovery                 | `plugins.entries.codex.config.sessionCatalog.enabled: false`                                     | Codex plugin config                |
 | Keep an allowlisted plugin install                  | Include `codex` in `plugins.allow`                                                               | OpenClaw config                    |
 | Allow eligible OpenAI turns to use Codex implicitly | Exact official HTTPS Responses/ChatGPT route, no authored request override, runtime unset/`auto` | OpenAI provider/model config       |
 | Sign in with ChatGPT/Codex OAuth                    | `openclaw models auth login --provider openai`                                                   | CLI auth profile                   |
@@ -673,7 +674,8 @@ Supported top-level Codex plugin fields:
 | `codexDynamicToolsLoading` | `"searchable"` | Use `"direct"` to put OpenClaw dynamic tools directly in the initial Codex tool context. |
 | `codexDynamicToolsExclude` | `[]`           | Additional OpenClaw dynamic tool names to omit from Codex app-server turns.              |
 | `codexPlugins`             | disabled       | Native Codex plugin/app support for migrated source-installed curated plugins.           |
-| `supervision`              | disabled       | Non-archived native-session catalog, local branch continuation, and agent-tool policy.   |
+| `sessionCatalog`           | enabled        | Sidebar discovery for native Codex sessions on this Gateway and eligible paired nodes.   |
+| `supervision`              | disabled       | Agent-facing native-session transcript and write-control policy.                         |
 
 Supported `appServer` fields:
 

--- a/docs/plugins/codex-supervision.md
+++ b/docs/plugins/codex-supervision.md
@@ -58,7 +58,10 @@ plugin activation succeeds. App Server availability is checked when
 supervision first connects. An explicit Codex plugin disable or policy block
 prevents opportunistic activation, and an existing explicit
 `supervision.enabled: false` disables agent-facing supervision tools; the
-operator catalog remains registered whenever the Codex plugin is active.
+operator catalog remains registered whenever the Codex plugin is active unless
+`sessionCatalog.enabled: false` disables it. This separate switch leaves the
+Codex provider, harness, and agent-facing supervision policy unchanged while
+also removing the paired-node catalog list/read commands from this host.
 Existing installations can enable the same capability manually:
 
 Enable the `codex` plugin and its supervision capability in `openclaw.json`:
@@ -141,6 +144,13 @@ describes a host refresh; an unavailable host returns no fresh session rows and
 does not change a thread's native status to `offline`. Session rows use Codex
 statuses such as `idle`, `active`, `notLoaded`, or error. A failed host does not
 hide results from healthy hosts.
+
+The sidebar warning includes the catalog error code and the safe underlying
+Gateway error. Open **Settings > Automation > Plugins > Codex > Native Session
+Discovery** to disable discovery without disabling Codex. For
+`NODE_LIST_FAILED`, compare `openclaw nodes list` and **Settings > Devices**;
+the detailed cause identifies the pairing-store, node-registry, permission, or
+Gateway lifecycle failure that needs repair.
 
 ## Use the operator CLI
 

--- a/docs/specs/codex-supervision.md
+++ b/docs/specs/codex-supervision.md
@@ -21,8 +21,14 @@ Supervisor plugin or second Codex protocol implementation.
 
 ## Product boundary
 
-The catalog registers whenever the Codex plugin is active. Enable agent-facing
-supervision tools with:
+The catalog registers whenever the Codex plugin is active unless native session
+discovery is explicitly disabled with:
+
+```text
+plugins.entries.codex.config.sessionCatalog.enabled = false
+```
+
+Enable agent-facing supervision tools with:
 
 ```text
 plugins.entries.codex.config.supervision.enabled = true
@@ -54,7 +60,9 @@ backend passes its live check, independently of which primary backend the user
 selects. Supervision activates only when that opportunistic plugin setup
 succeeds. An explicit disabled plugin, policy block, or
 `supervision.enabled: false` remains authoritative for supervision tools, but
-does not disable the operator session catalog.
+does not disable the operator session catalog. `sessionCatalog.enabled: false`
+disables operator discovery and paired-node catalog commands; the Codex
+provider and harness remain active.
 
 ## Ownership
 

--- a/extensions/anthropic/index.test.ts
+++ b/extensions/anthropic/index.test.ts
@@ -3,6 +3,7 @@ import type {
   ProviderResolveDynamicModelContext,
   ProviderRuntimeModel,
 } from "openclaw/plugin-sdk/plugin-entry";
+import { createTestPluginApi } from "openclaw/plugin-sdk/plugin-test-api";
 import {
   capturePluginRegistration,
   registerSingleProviderPlugin,
@@ -90,6 +91,31 @@ describe("anthropic provider replay hooks", () => {
       modelArg: "--model",
       sessionArg: "--session-id",
     });
+  });
+
+  it("lets native session discovery be disabled without disabling Anthropic", () => {
+    const registerCliBackend = vi.fn();
+    const registerNodeHostCommand = vi.fn();
+    const registerProvider = vi.fn();
+    const registerSessionCatalog = vi.fn();
+    anthropicPlugin.register(
+      createTestPluginApi({
+        id: "anthropic",
+        name: "Anthropic",
+        source: "test",
+        config: {},
+        pluginConfig: { sessionCatalog: { enabled: false } },
+        registerCliBackend,
+        registerNodeHostCommand,
+        registerProvider,
+        registerSessionCatalog,
+      }),
+    );
+
+    expect(registerCliBackend).toHaveBeenCalledOnce();
+    expect(registerProvider).toHaveBeenCalledOnce();
+    expect(registerNodeHostCommand).not.toHaveBeenCalled();
+    expect(registerSessionCatalog).not.toHaveBeenCalled();
   });
 
   it("publishes Claude Sonnet 5 CLI metadata without downgrading its API contract", () => {

--- a/extensions/anthropic/openclaw.plugin.json
+++ b/extensions/anthropic/openclaw.plugin.json
@@ -317,6 +317,24 @@
   "configSchema": {
     "type": "object",
     "additionalProperties": false,
-    "properties": {}
+    "properties": {
+      "sessionCatalog": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "enabled": { "type": "boolean", "default": true }
+        }
+      }
+    }
+  },
+  "uiHints": {
+    "sessionCatalog": {
+      "label": "Native Session Discovery",
+      "help": "Controls whether Claude Code sessions from this Gateway and paired nodes appear in the sidebar. Disabling also removes this host's paired-node catalog commands without disabling Anthropic models or the Claude CLI backend. Node-list failures usually indicate a Gateway pairing-store or node-registry problem; verify Settings > Devices or run openclaw nodes list. Changes require a Gateway restart."
+    },
+    "sessionCatalog.enabled": {
+      "label": "Discover Claude Code Sessions",
+      "help": "List native Claude Code sessions in the sidebar from this Gateway and eligible paired nodes."
+    }
   }
 }

--- a/extensions/anthropic/register.runtime.ts
+++ b/extensions/anthropic/register.runtime.ts
@@ -101,6 +101,18 @@ const ANTHROPIC_SETUP_TOKEN_NOTE_LINES = [
   `If you want a direct API billing path instead, use ${formatCliCommand("openclaw models auth login --provider anthropic --method api-key --set-default")} or ${formatCliCommand("openclaw models auth login --provider anthropic --method cli --set-default")}.`,
 ] as const;
 
+function isClaudeSessionCatalogEnabled(pluginConfig: unknown): boolean {
+  if (!pluginConfig || typeof pluginConfig !== "object") {
+    return true;
+  }
+  const sessionCatalog = (pluginConfig as { sessionCatalog?: unknown }).sessionCatalog;
+  return !(
+    sessionCatalog &&
+    typeof sessionCatalog === "object" &&
+    (sessionCatalog as { enabled?: unknown }).enabled === false
+  );
+}
+
 function resolveAnthropicSonnet5Cost(nowMs: number = Date.now()) {
   return nowMs >= ANTHROPIC_SONNET_5_STANDARD_PRICING_START_MS
     ? ANTHROPIC_SONNET_5_STANDARD_COST
@@ -922,9 +934,12 @@ export function registerAnthropicPlugin(api: OpenClawPluginApi): void {
   api.registerCliBackend(buildAnthropicCliBackend());
   api.registerProvider(buildAnthropicProvider());
   api.registerMediaUnderstandingProvider(anthropicMediaUnderstandingProvider);
-  registerClaudeSessionCatalog(api);
-  for (const command of createClaudeSessionNodeHostCommands()) {
-    api.registerNodeHostCommand(command);
+  const sessionCatalogEnabled = isClaudeSessionCatalogEnabled(api.pluginConfig);
+  if (sessionCatalogEnabled) {
+    registerClaudeSessionCatalog(api);
+    for (const command of createClaudeSessionNodeHostCommands()) {
+      api.registerNodeHostCommand(command);
+    }
   }
   for (const policy of createClaudeSessionNodeInvokePolicies()) {
     api.registerNodeInvokePolicy(policy);

--- a/extensions/anthropic/register.runtime.ts
+++ b/extensions/anthropic/register.runtime.ts
@@ -54,11 +54,8 @@ import {
   normalizeAnthropicProviderConfigForProvider,
 } from "./config-defaults.js";
 import { anthropicMediaUnderstandingProvider } from "./media-understanding-provider.js";
-import {
-  createClaudeSessionNodeHostCommands,
-  createClaudeSessionNodeInvokePolicies,
-} from "./session-catalog-node-commands.js";
-import { registerClaudeSessionCatalog } from "./session-catalog.js";
+import { createClaudeSessionNodeInvokePolicies } from "./session-catalog-node-commands.js";
+import { registerClaudeSessionDiscovery } from "./session-catalog-registration.js";
 import { wrapAnthropicProviderStream } from "./stream-wrappers.js";
 import { fetchAnthropicUsage, resolveAnthropicUsageAuth } from "./usage.js";
 
@@ -100,18 +97,6 @@ const ANTHROPIC_SETUP_TOKEN_NOTE_LINES = [
   "Anthropic staff told us this OpenClaw path is allowed again.",
   `If you want a direct API billing path instead, use ${formatCliCommand("openclaw models auth login --provider anthropic --method api-key --set-default")} or ${formatCliCommand("openclaw models auth login --provider anthropic --method cli --set-default")}.`,
 ] as const;
-
-function isClaudeSessionCatalogEnabled(pluginConfig: unknown): boolean {
-  if (!pluginConfig || typeof pluginConfig !== "object") {
-    return true;
-  }
-  const sessionCatalog = (pluginConfig as { sessionCatalog?: unknown }).sessionCatalog;
-  return !(
-    sessionCatalog &&
-    typeof sessionCatalog === "object" &&
-    (sessionCatalog as { enabled?: unknown }).enabled === false
-  );
-}
 
 function resolveAnthropicSonnet5Cost(nowMs: number = Date.now()) {
   return nowMs >= ANTHROPIC_SONNET_5_STANDARD_PRICING_START_MS
@@ -934,13 +919,7 @@ export function registerAnthropicPlugin(api: OpenClawPluginApi): void {
   api.registerCliBackend(buildAnthropicCliBackend());
   api.registerProvider(buildAnthropicProvider());
   api.registerMediaUnderstandingProvider(anthropicMediaUnderstandingProvider);
-  const sessionCatalogEnabled = isClaudeSessionCatalogEnabled(api.pluginConfig);
-  if (sessionCatalogEnabled) {
-    registerClaudeSessionCatalog(api);
-    for (const command of createClaudeSessionNodeHostCommands()) {
-      api.registerNodeHostCommand(command);
-    }
-  }
+  registerClaudeSessionDiscovery(api);
   for (const policy of createClaudeSessionNodeInvokePolicies()) {
     api.registerNodeInvokePolicy(policy);
   }

--- a/extensions/anthropic/session-catalog-node-helpers.ts
+++ b/extensions/anthropic/session-catalog-node-helpers.ts
@@ -1,0 +1,17 @@
+export function createNodeListFailedError(error: unknown): { code: string; message: string } {
+  const detail =
+    error instanceof Error ? error.message.trim() : typeof error === "string" ? error.trim() : "";
+  const summary = "Paired nodes could not be listed";
+  return {
+    code: "NODE_LIST_FAILED",
+    message: detail && detail !== summary ? `${summary}: ${detail}` : summary,
+  };
+}
+
+export function resolveNodeLabel(node: {
+  displayName?: string;
+  remoteIp?: string;
+  nodeId: string;
+}): string {
+  return node.displayName?.trim() || node.remoteIp?.trim() || node.nodeId;
+}

--- a/extensions/anthropic/session-catalog-registration.ts
+++ b/extensions/anthropic/session-catalog-registration.ts
@@ -1,0 +1,25 @@
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
+import { createClaudeSessionNodeHostCommands } from "./session-catalog-node-commands.js";
+import { registerClaudeSessionCatalog } from "./session-catalog.js";
+
+function isClaudeSessionCatalogEnabled(pluginConfig: unknown): boolean {
+  if (!pluginConfig || typeof pluginConfig !== "object") {
+    return true;
+  }
+  const sessionCatalog = (pluginConfig as { sessionCatalog?: unknown }).sessionCatalog;
+  return !(
+    sessionCatalog &&
+    typeof sessionCatalog === "object" &&
+    (sessionCatalog as { enabled?: unknown }).enabled === false
+  );
+}
+
+export function registerClaudeSessionDiscovery(api: OpenClawPluginApi): void {
+  if (!isClaudeSessionCatalogEnabled(api.pluginConfig)) {
+    return;
+  }
+  registerClaudeSessionCatalog(api);
+  for (const command of createClaudeSessionNodeHostCommands()) {
+    api.registerNodeHostCommand(command);
+  }
+}

--- a/extensions/anthropic/session-catalog.test.ts
+++ b/extensions/anthropic/session-catalog.test.ts
@@ -1079,6 +1079,29 @@ describe("Claude session catalog", () => {
     ]);
   });
 
+  it("keeps the underlying paired-node list failure", async () => {
+    const runtime = {
+      nodes: {
+        list: vi.fn().mockRejectedValue(new Error("paired store is unreadable")),
+      },
+    } as unknown as PluginRuntime;
+
+    const result = await listClaudeSessionCatalog({
+      runtime,
+      query: { hostIds: ["node:registry"] },
+    });
+
+    expect(result.hosts).toEqual([
+      expect.objectContaining({
+        hostId: "node:registry",
+        error: {
+          code: "NODE_LIST_FAILED",
+          message: "Paired nodes could not be listed: paired store is unreadable",
+        },
+      }),
+    ]);
+  });
+
   it("rejects malformed fields returned by a paired node", async () => {
     const runtime = {
       nodes: {

--- a/extensions/anthropic/session-catalog.ts
+++ b/extensions/anthropic/session-catalog.ts
@@ -901,7 +901,10 @@ export async function listClaudeSessionCatalog(params: {
   let nodes: Awaited<ReturnType<PluginRuntime["nodes"]["list"]>>["nodes"];
   try {
     nodes = (await params.runtime.nodes.list()).nodes;
-  } catch {
+  } catch (error) {
+    const detail =
+      error instanceof Error ? error.message.trim() : typeof error === "string" ? error.trim() : "";
+    const summary = "Paired nodes could not be listed";
     return {
       hosts: [
         ...hosts,
@@ -911,7 +914,10 @@ export async function listClaudeSessionCatalog(params: {
           kind: "node",
           connected: false,
           sessions: [],
-          error: { code: "NODE_LIST_FAILED", message: "Paired nodes could not be listed" },
+          error: {
+            code: "NODE_LIST_FAILED",
+            message: detail && detail !== summary ? `${summary}: ${detail}` : summary,
+          },
         },
       ],
     };

--- a/extensions/anthropic/session-catalog.ts
+++ b/extensions/anthropic/session-catalog.ts
@@ -19,6 +19,7 @@ import {
   adoptedSourceKey,
   CLAUDE_LOCAL_SESSION_HOST_ID,
 } from "./session-catalog-adoption.js";
+import { createNodeListFailedError, resolveNodeLabel } from "./session-catalog-node-helpers.js";
 import {
   currentClaudeSessionCatalogConfig,
   listBoundClaudeSessions,
@@ -796,10 +797,6 @@ function unwrapNodePayload(value: unknown): unknown {
   return value;
 }
 
-function nodeLabel(node: { displayName?: string; remoteIp?: string; nodeId: string }): string {
-  return node.displayName?.trim() || node.remoteIp?.trim() || node.nodeId;
-}
-
 function parseGatewayQuery(value: unknown): {
   search?: string;
   limitPerHost: number;
@@ -902,9 +899,6 @@ export async function listClaudeSessionCatalog(params: {
   try {
     nodes = (await params.runtime.nodes.list()).nodes;
   } catch (error) {
-    const detail =
-      error instanceof Error ? error.message.trim() : typeof error === "string" ? error.trim() : "";
-    const summary = "Paired nodes could not be listed";
     return {
       hosts: [
         ...hosts,
@@ -914,10 +908,7 @@ export async function listClaudeSessionCatalog(params: {
           kind: "node",
           connected: false,
           sessions: [],
-          error: {
-            code: "NODE_LIST_FAILED",
-            message: detail && detail !== summary ? `${summary}: ${detail}` : summary,
-          },
+          error: createNodeListFailedError(error),
         },
       ],
     };
@@ -929,13 +920,13 @@ export async function listClaudeSessionCatalog(params: {
         (!requested || requested.has(`node:${node.nodeId}`)),
     )
     .slice(0, MAX_HOSTS - hosts.length)
-    .toSorted((left, right) => nodeLabel(left).localeCompare(nodeLabel(right)));
+    .toSorted((left, right) => resolveNodeLabel(left).localeCompare(resolveNodeLabel(right)));
   const nodeHosts = await Promise.all(
     eligible.map(async (node): Promise<ClaudeSessionCatalogHost> => {
       const hostId = `node:${node.nodeId}`;
       const common = {
         hostId,
-        label: nodeLabel(node),
+        label: resolveNodeLabel(node),
         kind: "node" as const,
         connected: node.connected === true,
         nodeId: node.nodeId,
@@ -1033,7 +1024,7 @@ async function readClaudeSessionTranscript(params: {
   }
   return {
     hostId: params.hostId,
-    label: nodeLabel(node),
+    label: resolveNodeLabel(node),
     threadId: params.threadId,
     items: page.items as ClaudeTranscriptItem[],
     ...(optionalString(page.nextCursor, MAX_CURSOR_LENGTH)

--- a/extensions/codex/index.test.ts
+++ b/extensions/codex/index.test.ts
@@ -138,6 +138,42 @@ describe("codex plugin", () => {
     expect(typeof bindingResolvedRegistration?.[0]).toBe("function");
   });
 
+  it("lets native session discovery be disabled without disabling the Codex plugin", () => {
+    const registerAgentHarness = vi.fn();
+    const registerNodeHostCommand = vi.fn();
+    const registerProvider = vi.fn();
+    const registerSessionCatalog = vi.fn();
+    plugin.register(
+      createTestPluginApi({
+        id: "codex",
+        name: "Codex",
+        source: "test",
+        config: {},
+        pluginConfig: { sessionCatalog: { enabled: false } },
+        runtime: createCodexTestRuntime(),
+        registerAgentHarness,
+        registerCommand: vi.fn(),
+        registerMediaUnderstandingProvider: vi.fn(),
+        registerMigrationProvider: vi.fn(),
+        registerNodeHostCommand,
+        registerProvider,
+        registerSessionCatalog,
+        registerTool: vi.fn(),
+        on: vi.fn(),
+      }),
+    );
+
+    expect(registerAgentHarness).toHaveBeenCalledOnce();
+    expect(registerProvider).toHaveBeenCalledOnce();
+    const nodeCommands = registerNodeHostCommand.mock.calls.map(
+      ([command]) => (command as { command: string }).command,
+    );
+    expect(nodeCommands).toEqual(["codex.cli.sessions.list", "codex.cli.session.resume"]);
+    expect(nodeCommands).not.toContain("codex.appServer.threads.list.v1");
+    expect(nodeCommands).not.toContain("codex.appServer.thread.turns.list.v1");
+    expect(registerSessionCatalog).not.toHaveBeenCalled();
+  });
+
   it("registers the five shipped supervision tools only when supervision is enabled", () => {
     const registerTool = vi.fn();
     plugin.register(

--- a/extensions/codex/index.ts
+++ b/extensions/codex/index.ts
@@ -98,14 +98,18 @@ export default definePluginEntry({
       getPluginConfig: resolveCurrentPluginConfig,
       getRuntimeConfig: resolveCurrentConfig,
     });
-    codexSessionCatalogRuntime.register({
-      api,
-      bindingStore,
-      control: sessionCatalogControl,
-      getRuntimeConfig: resolveCurrentConfig,
-    });
-    for (const command of createCodexSessionCatalogNodeHostCommands(sessionCatalogControl)) {
-      api.registerNodeHostCommand(command);
+    const sessionCatalogEnabled =
+      readCodexPluginConfig(resolveCurrentPluginConfig()).sessionCatalog?.enabled !== false;
+    if (sessionCatalogEnabled) {
+      codexSessionCatalogRuntime.register({
+        api,
+        bindingStore,
+        control: sessionCatalogControl,
+        getRuntimeConfig: resolveCurrentConfig,
+      });
+      for (const command of createCodexSessionCatalogNodeHostCommands(sessionCatalogControl)) {
+        api.registerNodeHostCommand(command);
+      }
     }
     for (const policy of createCodexSessionCatalogNodeInvokePolicies()) {
       api.registerNodeInvokePolicy(policy);

--- a/extensions/codex/openclaw.plugin.json
+++ b/extensions/codex/openclaw.plugin.json
@@ -31,7 +31,10 @@
     "onStartup": false,
     "onAgentHarnesses": ["codex"],
     "onCommands": ["codex"],
-    "onConfigPaths": ["plugins.entries.codex.config.supervision.enabled"]
+    "onConfigPaths": [
+      "plugins.entries.codex.config.sessionCatalog.enabled",
+      "plugins.entries.codex.config.supervision.enabled"
+    ]
   },
   "commandAliases": [
     {
@@ -53,6 +56,13 @@
         "type": "array",
         "items": { "type": "string" },
         "default": []
+      },
+      "sessionCatalog": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "enabled": { "type": "boolean", "default": true }
+        }
       },
       "discovery": {
         "type": "object",
@@ -354,6 +364,14 @@
     }
   },
   "uiHints": {
+    "sessionCatalog": {
+      "label": "Native Session Discovery",
+      "help": "Controls whether Codex sessions from this Gateway and paired nodes appear in the sidebar. Disabling also removes this host's paired-node catalog commands without disabling the Codex provider or harness. Node-list failures usually indicate a Gateway pairing-store or node-registry problem; verify Settings > Devices or run openclaw nodes list. Changes require a Gateway restart."
+    },
+    "sessionCatalog.enabled": {
+      "label": "Discover Codex Sessions",
+      "help": "List native Codex sessions in the sidebar from this Gateway and eligible paired nodes."
+    },
     "codexDynamicToolsLoading": {
       "label": "Dynamic Tools Loading",
       "help": "Use searchable to defer OpenClaw dynamic tools behind Codex tool search, or direct to expose them in the initial context.",

--- a/extensions/codex/src/app-server/config.test.ts
+++ b/extensions/codex/src/app-server/config.test.ts
@@ -353,6 +353,12 @@ describe("Codex app-server config", () => {
     ).toStrictEqual({});
   });
 
+  it("parses the native session discovery toggle", () => {
+    expect(readCodexPluginConfig({ sessionCatalog: { enabled: false } }).sessionCatalog).toEqual({
+      enabled: false,
+    });
+  });
+
   it("rejects unknown app-server fields", () => {
     expect(
       readCodexPluginConfig({

--- a/extensions/codex/src/app-server/config.ts
+++ b/extensions/codex/src/app-server/config.ts
@@ -29,6 +29,10 @@ import type {
   JsonObject,
   JsonValue,
 } from "./protocol.js";
+import {
+  codexDiscoveryConfigSchema,
+  codexSessionCatalogConfigSchema,
+} from "./session-discovery-config.js";
 
 const START_OPTIONS_KEY_SECRET_SYMBOL = Symbol.for("openclaw.codexAppServerStartOptionsKeySecret");
 const START_OPTIONS_KEY_SECRET = getStartOptionsKeySecret();
@@ -256,13 +260,8 @@ type CodexModelBackedReviewerContext = {
 export type CodexPluginConfig = {
   codexDynamicToolsLoading?: CodexDynamicToolsLoading;
   codexDynamicToolsExclude?: string[];
-  sessionCatalog?: {
-    enabled?: boolean;
-  };
-  discovery?: {
-    enabled?: boolean;
-    timeoutMs?: number;
-  };
+  sessionCatalog?: z.infer<typeof codexSessionCatalogConfigSchema>;
+  discovery?: z.infer<typeof codexDiscoveryConfigSchema>;
   computerUse?: CodexComputerUseConfig;
   codexPlugins?: CodexPluginsConfig;
   supervision?: CodexSupervisionConfig;
@@ -424,19 +423,8 @@ const codexPluginConfigSchema = z
   .object({
     codexDynamicToolsLoading: codexDynamicToolsLoadingSchema.optional(),
     codexDynamicToolsExclude: z.array(z.string()).optional(),
-    sessionCatalog: z
-      .object({
-        enabled: z.boolean().optional(),
-      })
-      .strict()
-      .optional(),
-    discovery: z
-      .object({
-        enabled: z.boolean().optional(),
-        timeoutMs: z.number().positive().optional(),
-      })
-      .strict()
-      .optional(),
+    sessionCatalog: codexSessionCatalogConfigSchema.optional(),
+    discovery: codexDiscoveryConfigSchema.optional(),
     computerUse: z
       .object({
         enabled: z.boolean().optional(),

--- a/extensions/codex/src/app-server/config.ts
+++ b/extensions/codex/src/app-server/config.ts
@@ -256,6 +256,9 @@ type CodexModelBackedReviewerContext = {
 export type CodexPluginConfig = {
   codexDynamicToolsLoading?: CodexDynamicToolsLoading;
   codexDynamicToolsExclude?: string[];
+  sessionCatalog?: {
+    enabled?: boolean;
+  };
   discovery?: {
     enabled?: boolean;
     timeoutMs?: number;
@@ -421,6 +424,12 @@ const codexPluginConfigSchema = z
   .object({
     codexDynamicToolsLoading: codexDynamicToolsLoadingSchema.optional(),
     codexDynamicToolsExclude: z.array(z.string()).optional(),
+    sessionCatalog: z
+      .object({
+        enabled: z.boolean().optional(),
+      })
+      .strict()
+      .optional(),
     discovery: z
       .object({
         enabled: z.boolean().optional(),

--- a/extensions/codex/src/app-server/session-discovery-config.ts
+++ b/extensions/codex/src/app-server/session-discovery-config.ts
@@ -1,0 +1,12 @@
+import { z } from "zod";
+
+export const codexSessionCatalogConfigSchema = z
+  .object({ enabled: z.boolean().optional() })
+  .strict();
+
+export const codexDiscoveryConfigSchema = z
+  .object({
+    enabled: z.boolean().optional(),
+    timeoutMs: z.number().positive().optional(),
+  })
+  .strict();

--- a/extensions/codex/src/session-catalog-parsing.ts
+++ b/extensions/codex/src/session-catalog-parsing.ts
@@ -424,13 +424,31 @@ export function unwrapNodeInvokePayload(value: unknown): unknown {
   return "payload" in value ? value.payload : value;
 }
 
-export function catalogError(code: string, _error: unknown): CodexSessionCatalogError {
+function catalogErrorDetail(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message.trim();
+  }
+  if (typeof error === "string") {
+    return error.trim();
+  }
+  if (error && typeof error === "object" && "message" in error) {
+    const message = (error as { message?: unknown }).message;
+    return typeof message === "string" ? message.trim() : "";
+  }
+  return "";
+}
+
+export function catalogError(code: string, error: unknown): CodexSessionCatalogError {
   const messages: Record<string, string> = {
     APP_SERVER_UNAVAILABLE: "Codex app-server is unavailable on this host",
     NODE_INVOKE_FAILED: "The paired node could not return its Codex session catalog",
     NODE_LIST_FAILED: "Paired nodes could not be listed",
   };
-  return { code, message: messages[code] ?? "Codex session catalog request failed" };
+  const summary = messages[code] ?? "Codex session catalog request failed";
+  // Node-list failures are operator diagnostics from the local Gateway. Other
+  // catalog errors may cross node/App Server boundaries and keep their bounded summary.
+  const detail = code === "NODE_LIST_FAILED" ? catalogErrorDetail(error) : "";
+  return { code, message: detail && detail !== summary ? `${summary}: ${detail}` : summary };
 }
 
 export function parseTranscriptPage(value: unknown): CodexThreadTurnsListResponse {

--- a/extensions/codex/src/session-catalog.test.ts
+++ b/extensions/codex/src/session-catalog.test.ts
@@ -17,6 +17,7 @@ import {
   type CodexAppServerBindingStore,
   type CodexAppServerThreadBinding,
 } from "./app-server/session-binding.test-helpers.js";
+import { catalogError } from "./session-catalog-parsing.js";
 import {
   CODEX_LOCAL_SESSION_HOST_ID,
   CODEX_TERMINAL_RESUME_COMMAND,
@@ -367,6 +368,15 @@ beforeEach(() => {
 afterEach(async () => {
   process.env.PATH = originalPath;
   await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
+describe("Codex session catalog errors", () => {
+  it("keeps the underlying paired-node list failure", () => {
+    expect(catalogError("NODE_LIST_FAILED", new Error("paired store is unreadable"))).toEqual({
+      code: "NODE_LIST_FAILED",
+      message: "Paired nodes could not be listed: paired store is unreadable",
+    });
+  });
 });
 
 describe("Codex supervision catalog", () => {

--- a/ui/src/components/app-sidebar-session-catalogs.ts
+++ b/ui/src/components/app-sidebar-session-catalogs.ts
@@ -153,8 +153,10 @@ export function renderSessionCatalogGroups(params: SessionCatalogGroupsParams) {
     const hasMore = hosts.some((host) => Boolean(host.nextCursor));
     const canCreateSession = catalog.capabilities.createSession !== undefined;
     const errorMessages = [
-      ...(catalog.error ? [catalog.error.message] : []),
-      ...hosts.flatMap((host) => (host.error ? [host.error.message] : [])),
+      ...(catalog.error ? [`[${catalog.error.code}] ${catalog.error.message}`] : []),
+      ...hosts.flatMap((host) =>
+        host.error ? [`[${host.error.code}] ${host.error.message}`] : [],
+      ),
     ];
     const hasError = errorMessages.length > 0;
     // Keep provider failures distinguishable from successful empty results.
@@ -163,6 +165,7 @@ export function renderSessionCatalogGroups(params: SessionCatalogGroupsParams) {
       return nothing;
     }
     const errorMessage = errorMessages.join("; ");
+    const errorHelp = `${errorMessage}. Configure native session discovery in Settings > Automation > Plugins.`;
     return html`
       <div class="sidebar-recent-sessions__group" data-session-section=${sectionId}>
         <div class="sidebar-recent-sessions__head">
@@ -170,8 +173,8 @@ export function renderSessionCatalogGroups(params: SessionCatalogGroupsParams) {
             type="button"
             class="sidebar-session-group-toggle"
             aria-expanded=${String(!collapsed)}
-            aria-label=${hasError ? `${catalog.label}: ${errorMessage}` : catalog.label}
-            title=${hasError ? errorMessage : nothing}
+            aria-label=${hasError ? `${catalog.label}: ${errorHelp}` : catalog.label}
+            title=${hasError ? errorHelp : nothing}
             @click=${() => params.onToggleSection(sectionId)}
           >
             <span class="sidebar-session-group-toggle__icon" aria-hidden="true"

--- a/ui/src/components/app-sidebar.test.ts
+++ b/ui/src/components/app-sidebar.test.ts
@@ -1135,10 +1135,13 @@ describe("AppSidebar session catalog pagination", () => {
       );
       expect(
         codexSection?.querySelector(".sidebar-session-group-toggle")?.getAttribute("aria-label"),
-      ).toContain("Codex provider unavailable");
+      ).toContain("[unavailable] Codex provider unavailable");
       expect(
         claudeSection?.querySelector(".sidebar-session-group-toggle")?.getAttribute("aria-label"),
-      ).toContain("Claude host unavailable");
+      ).toContain("[unavailable] Claude host unavailable");
+      expect(
+        codexSection?.querySelector(".sidebar-session-group-toggle")?.getAttribute("title"),
+      ).toContain("Settings > Automation > Plugins");
       expect(codexSection?.querySelector('[data-session-catalog-error="codex"]')).not.toBeNull();
       expect(claudeSection?.querySelector('[data-session-catalog-error="claude"]')).not.toBeNull();
     } finally {

--- a/ui/src/e2e/codex-sessions.e2e.test.ts
+++ b/ui/src/e2e/codex-sessions.e2e.test.ts
@@ -1,3 +1,5 @@
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
 import { chromium, type Browser } from "playwright";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import {
@@ -15,6 +17,13 @@ const suite = available || !allowMissing ? describe : describe.skip;
 
 let browser: Browser;
 let server: ControlUiE2eServer;
+const captureUiProofEnabled = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
+const uiProofArtifactDir = path.join(
+  process.cwd(),
+  ".artifacts",
+  "control-ui-e2e",
+  "native-session-discovery",
+);
 
 suite("Codex native session catalog", () => {
   beforeAll(async () => {
@@ -77,6 +86,185 @@ suite("Codex native session catalog", () => {
     expect(await page.locator('[data-session-section="catalog:codex"]').count()).toBe(0);
     expect(await page.locator('[data-session-section="catalog:claude"]').count()).toBe(0);
     await page.close();
+  });
+
+  it("explains node-list failures and exposes independent discovery settings", async () => {
+    const page = await browser.newPage({ viewport: { height: 1100, width: 1440 } });
+    await installMockGateway(page, {
+      featureMethods: [
+        "chat.metadata",
+        "chat.startup",
+        "config.get",
+        "config.schema",
+        "sessions.catalog.list",
+      ],
+      methodResponses: {
+        "config.get": {
+          config: {
+            plugins: {
+              entries: {
+                anthropic: { config: { sessionCatalog: { enabled: false } } },
+                codex: { config: { sessionCatalog: { enabled: true } } },
+              },
+            },
+          },
+          hash: "native-session-discovery-e2e",
+        },
+        "config.schema": {
+          schema: {
+            type: "object",
+            properties: {
+              plugins: {
+                type: "object",
+                properties: {
+                  entries: {
+                    type: "object",
+                    properties: {
+                      anthropic: {
+                        type: "object",
+                        properties: {
+                          config: {
+                            type: "object",
+                            properties: {
+                              sessionCatalog: {
+                                type: "object",
+                                properties: { enabled: { type: "boolean", default: true } },
+                              },
+                            },
+                          },
+                        },
+                      },
+                      codex: {
+                        type: "object",
+                        properties: {
+                          config: {
+                            type: "object",
+                            properties: {
+                              sessionCatalog: {
+                                type: "object",
+                                properties: { enabled: { type: "boolean", default: true } },
+                              },
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+          uiHints: {
+            "plugins.entries.anthropic.config.sessionCatalog.enabled": {
+              label: "Discover Claude Code Sessions",
+              help: "List native Claude Code sessions in the sidebar from this Gateway and eligible paired nodes.",
+            },
+            "plugins.entries.codex.config.sessionCatalog.enabled": {
+              label: "Discover Codex Sessions",
+              help: "List native Codex sessions in the sidebar from this Gateway and eligible paired nodes.",
+            },
+          },
+          version: "e2e",
+          generatedAt: "2026-07-14T00:00:00.000Z",
+        },
+        "sessions.catalog.list": {
+          catalogs: [
+            {
+              id: "codex",
+              label: "Codex",
+              capabilities: { continueSession: true, archive: true },
+              hosts: [
+                {
+                  hostId: "node:registry",
+                  label: "Paired nodes",
+                  kind: "node",
+                  connected: false,
+                  sessions: [],
+                  error: {
+                    code: "NODE_LIST_FAILED",
+                    message: "Paired nodes could not be listed: pairing database is locked",
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      },
+    });
+
+    try {
+      await page.goto(`${server.baseUrl}chat`);
+      const warning = page.locator(
+        '[data-session-section="catalog:codex"] .sidebar-session-group-toggle',
+      );
+      await warning.waitFor({ state: "visible" });
+      await expect.poll(() => warning.getAttribute("title")).toContain("[NODE_LIST_FAILED]");
+      await expect
+        .poll(() => warning.getAttribute("title"))
+        .toContain("pairing database is locked");
+      await expect
+        .poll(() => warning.getAttribute("title"))
+        .toContain("Settings > Automation > Plugins");
+
+      if (captureUiProofEnabled) {
+        await mkdir(uiProofArtifactDir, { recursive: true });
+        await page.screenshot({
+          animations: "disabled",
+          fullPage: true,
+          path: path.join(uiProofArtifactDir, "01-actionable-sidebar-error.png"),
+        });
+      }
+
+      await page.goto(`${server.baseUrl}settings/automation?section=plugins`);
+      const expandPluginSetting = async (pluginLabel: string) => {
+        const pluginGroup = page
+          .getByText(pluginLabel, { exact: true })
+          .locator("xpath=ancestor::details[1]");
+        await pluginGroup.locator(":scope > summary").click();
+        const configGroup = pluginGroup
+          .getByText("Config", { exact: true })
+          .locator("xpath=ancestor::details[1]");
+        await configGroup.locator(":scope > summary").click();
+        const catalogGroup = configGroup
+          .getByText("Session Catalog", { exact: true })
+          .locator("xpath=ancestor::details[1]");
+        await catalogGroup.locator(":scope > summary").click();
+      };
+      await expandPluginSetting("Anthropic");
+      await expandPluginSetting("Codex");
+      const codexSetting = page.locator(".settings-row", { hasText: "Discover Codex Sessions" });
+      const claudeSetting = page.locator(".settings-row", {
+        hasText: "Discover Claude Code Sessions",
+      });
+      await codexSetting.waitFor({ state: "visible" });
+      await claudeSetting.waitFor({ state: "visible" });
+      expect(await codexSetting.getByText("eligible paired nodes.", { exact: false }).count()).toBe(
+        1,
+      );
+      expect(
+        await claudeSetting.getByText("eligible paired nodes.", { exact: false }).count(),
+      ).toBe(1);
+      expect(
+        await codexSetting
+          .locator("wa-switch")
+          .evaluate((element) => (element as HTMLElement & { checked: boolean }).checked),
+      ).toBe(true);
+      expect(
+        await claudeSetting
+          .locator("wa-switch")
+          .evaluate((element) => (element as HTMLElement & { checked: boolean }).checked),
+      ).toBe(false);
+
+      if (captureUiProofEnabled) {
+        await page.screenshot({
+          animations: "disabled",
+          fullPage: true,
+          path: path.join(uiProofArtifactDir, "02-independent-settings-toggles.png"),
+        });
+      }
+    } finally {
+      await page.close();
+    }
   });
 
   it("shows a catalog Load More rejection without losing the retry cursor", async () => {

--- a/ui/src/pages/chat/components/chat-tool-cards.test.ts
+++ b/ui/src/pages/chat/components/chat-tool-cards.test.ts
@@ -1,7 +1,7 @@
 /* @vitest-environment jsdom */
 
 import { render } from "lit";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { t } from "../../../i18n/index.ts";
 import {
   formatDistinctCollapsedToolSummaryText,
@@ -10,14 +10,6 @@ import {
   resolveCollapsedToolArgumentPreview,
 } from "../../../lib/chat/tool-cards.ts";
 import { renderToolCard, renderToolPreview } from "./chat-tool-cards.ts";
-
-const lazyElementMocks = vi.hoisted(() => ({
-  ensureCustomElementDefined: vi.fn<
-    (tagName: string, loadModule: () => Promise<unknown>) => Promise<void>
-  >(() => Promise.resolve()),
-}));
-
-vi.mock("../../../app/lazy-custom-element.ts", () => lazyElementMocks);
 
 function requireFirstMockArg(
   mock: ReturnType<typeof vi.fn>,
@@ -47,10 +39,6 @@ function pointerClick(element: Element) {
 }
 
 describe("tool-cards", () => {
-  beforeEach(() => {
-    lazyElementMocks.ensureCustomElementDefined.mockClear();
-  });
-
   it("routes MCP App previews through the dedicated double-iframe host", async () => {
     const container = document.createElement("div");
     render(
@@ -74,16 +62,11 @@ describe("tool-cards", () => {
     expect((view as { sessionKey?: string }).sessionKey).toBe("agent:main:main");
     expect((view as { viewId?: string }).viewId).toBe("cv_app");
     expect((view as { height?: number }).height).toBe(600);
-    expect(lazyElementMocks.ensureCustomElementDefined).toHaveBeenCalledOnce();
-    const [tagName, loadModule] = lazyElementMocks.ensureCustomElementDefined.mock.calls[0]!;
-    expect(tagName).toBe("mcp-app-view");
-    expect(loadModule).toBeTypeOf("function");
-    await loadModule();
+    await customElements.whenDefined("mcp-app-view");
     expect(customElements.get("mcp-app-view")).toBeDefined();
     expect((view as { sessionKey?: string }).sessionKey).toBe("agent:main:main");
     expect((view as { viewId?: string }).viewId).toBe("cv_app");
 
-    lazyElementMocks.ensureCustomElementDefined.mockClear();
     const toolContainer = document.createElement("div");
     render(
       renderToolPreview(
@@ -99,7 +82,6 @@ describe("tool-cards", () => {
       toolContainer,
     );
     expect(toolContainer.querySelector("mcp-app-view")).toBeNull();
-    expect(lazyElementMocks.ensureCustomElementDefined).not.toHaveBeenCalled();
   });
 
   it("keeps ordinary canvas previews off the MCP Apps chunk", () => {
@@ -120,7 +102,6 @@ describe("tool-cards", () => {
     );
 
     expect(container.querySelector("iframe")).not.toBeNull();
-    expect(lazyElementMocks.ensureCustomElementDefined).not.toHaveBeenCalled();
   });
 
   it("keeps selected summary text from toggling the disclosure", () => {


### PR DESCRIPTION
Fixes #107112

## What Problem This Solves

Fixes an issue where the Codex and Claude Code session catalogs could show the opaque warning `Paired nodes could not be listed` when paired-node discovery failed, with no usable cause or settings control.

## Why This Change Was Made

Native session discovery is now independently configurable for the Codex and Anthropic plugins under **Settings > Automation > Plugins**. Catalog errors preserve a bounded diagnostic cause and point users to that settings path; disabling discovery removes the local sidebar catalog and paired-node catalog commands while leaving provider, harness, and CLI behavior enabled.

Config/default surfaces: 2 added booleans, `plugins.entries.codex.config.sessionCatalog.enabled` and `plugins.entries.anthropic.config.sessionCatalog.enabled`, both defaulting to `true`. A Gateway restart applies either setting.

## User Impact

Users can disable Codex or Claude Code session discovery independently. When discovery remains enabled and a node-list call fails, the sidebar explains the underlying failure instead of showing only a generic message.

## Evidence

- Reproduced against OpenClaw `2026.7.2` on the affected macOS host: direct `nodes list` succeeded while the nested catalog response intermittently returned `NODE_LIST_FAILED` with the generic message.
- Built the patched source on the affected host and exercised an isolated Gateway: disabling Codex returned only the Claude catalog; disabling Claude returned only Codex. Provider, harness, and CLI registration remained available.
- Browser E2E proof covers the actionable sidebar diagnostic and both independent settings toggles.
- Product patch parent, Blacksmith Testbox `tbx_01kxfhehpe8wcpxrx7v7px5fm1`: 365 focused tests passed across Codex, Anthropic, sidebar, and browser E2E suites.
- Exact head `d649afdb55e`: CI run `29313128484` passed with 45 successful jobs and 10 expected skips, including bundled protocol generation and the Control UI gate.
- Blacksmith Testbox `tbx_01kxfpd7y182ezdd0kzecpxkz8`: the full Control UI suite passed (255 files, 3,760 tests), plus targeted oxfmt verification.
- Rebase onto the newly landed terminal-session feature exposed stale generated Swift/Kotlin protocol models on `main`; this PR refreshes those models, and the bundled-protocol CI gate now passes.
- Pre-rebase patch head: scoped changed gate and full build passed, including Control UI performance budgets.
- Fresh autoreview: no accepted or actionable findings.
