### PR TITLE
fix: Teams Graph and media work with RFC2544 proxy DNS

### DIFF
--- a/extensions/msteams/src/attachments/shared.test.ts
+++ b/extensions/msteams/src/attachments/shared.test.ts
@@ -126,6 +126,7 @@ describe("msteams attachment allowlists", () => {
   it("builds shared SSRF policy from suffix allowlist", () => {
     expect(resolveMediaSsrfPolicy(["sharepoint.com"])).toEqual({
       hostnameAllowlist: ["sharepoint.com", "*.sharepoint.com"],
+      allowRfc2544BenchmarkRange: true,
     });
     expect(resolveMediaSsrfPolicy(["*"])).toBeUndefined();
   });

--- a/extensions/msteams/src/attachments/shared.test.ts
+++ b/extensions/msteams/src/attachments/shared.test.ts
@@ -36,7 +36,6 @@ async function safeFetch(params: SafeFetchParams) {
   const { allowHosts, authorizationAllowHosts, ...request } = params;
   return await safeFetchWithPolicy({
     ...request,
-    resolveFn: request.resolveFn,
     policy: {
       allowHosts,
       authAllowHosts: authorizationAllowHosts ?? [],

--- a/extensions/msteams/src/attachments/shared.test.ts
+++ b/extensions/msteams/src/attachments/shared.test.ts
@@ -36,6 +36,7 @@ async function safeFetch(params: SafeFetchParams) {
   const { allowHosts, authorizationAllowHosts, ...request } = params;
   return await safeFetchWithPolicy({
     ...request,
+    resolveFn: request.resolveFn,
     policy: {
       allowHosts,
       authAllowHosts: authorizationAllowHosts ?? [],

--- a/extensions/msteams/src/attachments/shared.ts
+++ b/extensions/msteams/src/attachments/shared.ts
@@ -538,7 +538,14 @@ export function applyAuthorizationHeaderForUrl(params: {
 }
 
 export function resolveMediaSsrfPolicy(allowHosts: string[]): SsrFPolicy | undefined {
-  return buildHostnameAllowlistPolicyFromSuffixAllowlist(allowHosts);
+  const policy = buildHostnameAllowlistPolicyFromSuffixAllowlist(allowHosts);
+  if (!policy?.hostnameAllowlist?.length) {
+    return policy;
+  }
+  return {
+    ...policy,
+    allowRfc2544BenchmarkRange: true,
+  };
 }
 
 /**

--- a/extensions/msteams/src/attachments/shared.ts
+++ b/extensions/msteams/src/attachments/shared.ts
@@ -88,8 +88,7 @@ const DEFAULT_MEDIA_AUTH_HOST_ALLOWLIST = [
 export const GRAPH_ROOT = "https://graph.microsoft.com/v1.0";
 export { isRecord };
 
-// Keep this local; importing the broad media-runtime SDK barrel pulls image/audio runtimes into
-// hot MSTeams attachment tests for one tiny estimator.
+// Keep this local; the broad media-runtime barrel pulls image/audio runtimes into hot tests.
 function estimateBase64DecodedBytes(base64: string): number {
   let effectiveLen = 0;
   for (let i = 0; i < base64.length; i += 1) {
@@ -539,13 +538,7 @@ export function applyAuthorizationHeaderForUrl(params: {
 
 export function resolveMediaSsrfPolicy(allowHosts: string[]): SsrFPolicy | undefined {
   const policy = buildHostnameAllowlistPolicyFromSuffixAllowlist(allowHosts);
-  if (!policy?.hostnameAllowlist?.length) {
-    return policy;
-  }
-  return {
-    ...policy,
-    allowRfc2544BenchmarkRange: true,
-  };
+  return policy ? { ...policy, allowRfc2544BenchmarkRange: true } : undefined;
 }
 
 /**

--- a/extensions/msteams/src/graph.test.ts
+++ b/extensions/msteams/src/graph.test.ts
@@ -235,6 +235,25 @@ describe("msteams graph helpers", () => {
     expect(fetchWithSsrFGuardMock.mock.calls[0]?.[0]).not.toHaveProperty("fetchImpl");
   });
 
+  it("passes a host-scoped RFC2544 SSRF policy to relative Graph requests", async () => {
+    mockGraphCollection();
+
+    await fetchGraphJson({
+      token: graphToken,
+      path: "/groups",
+    });
+
+    expect(fetchWithSsrFGuardMock.mock.calls[0]?.[0]).toEqual(
+      expect.objectContaining({
+        url: "https://graph.microsoft.com/v1.0/groups",
+        policy: {
+          hostnameAllowlist: ["graph.microsoft.com"],
+          allowRfc2544BenchmarkRange: true,
+        },
+      }),
+    );
+  });
+
   it("fetches Graph JSON and surfaces Graph errors with response text", async () => {
     mockGraphCollection(groupOne);
 
@@ -320,7 +339,28 @@ describe("msteams graph helpers", () => {
     });
 
     expect(fetchWithSsrFGuardMock).toHaveBeenCalledWith(
-      expect.objectContaining({ timeoutMs: 30_000 }),
+      expect.objectContaining({
+        timeoutMs: 30_000,
+        policy: {
+          hostnameAllowlist: ["graph.microsoft.com"],
+          allowRfc2544BenchmarkRange: true,
+        },
+      }),
+    );
+  });
+
+  it("does not add the RFC2544 Graph policy to non-Graph absolute URLs", async () => {
+    mockGraphCollection(groupOne);
+
+    await fetchGraphAbsoluteUrl({
+      token: graphToken,
+      url: "https://example.com/not-graph",
+    });
+
+    expect(fetchWithSsrFGuardMock).toHaveBeenCalledWith(
+      expect.not.objectContaining({
+        policy: expect.anything(),
+      }),
     );
   });
 

--- a/extensions/msteams/src/graph.ts
+++ b/extensions/msteams/src/graph.ts
@@ -1,6 +1,6 @@
 // Msteams plugin module implements graph behavior.
 import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
-import { fetchWithSsrFGuard, type MSTeamsConfig } from "../runtime-api.js";
+import { fetchWithSsrFGuard, type MSTeamsConfig, type SsrFPolicy } from "../runtime-api.js";
 import { GRAPH_ROOT } from "./attachments/shared.js";
 import { resolveMSTeamsSdkCloudOptions } from "./cloud.js";
 import { createMSTeamsHttpError } from "./http-error.js";
@@ -16,6 +16,31 @@ import { resolveDelegatedAccessToken, resolveMSTeamsCredentials } from "./token.
 import { buildUserAgent } from "./user-agent.js";
 
 const GRAPH_BETA = "https://graph.microsoft.com/beta";
+const GRAPH_RFC2544_HOSTNAME_ALLOWLIST = new Set([
+  "graph.microsoft.com",
+  "graph.microsoft.us",
+  "graph.microsoft.de",
+  "graph.microsoft.cn",
+]);
+
+function resolveGraphSsrfPolicy(url: string): SsrFPolicy | undefined {
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      return undefined;
+    }
+    const hostname = parsed.hostname.toLowerCase();
+    if (!GRAPH_RFC2544_HOSTNAME_ALLOWLIST.has(hostname)) {
+      return undefined;
+    }
+    return {
+      hostnameAllowlist: [hostname],
+      allowRfc2544BenchmarkRange: true,
+    };
+  } catch {
+    return undefined;
+  }
+}
 
 export type GraphUser = {
   id?: string;
@@ -69,6 +94,7 @@ async function requestGraph(params: {
       body: hasBody ? JSON.stringify(params.body) : undefined,
     },
     auditContext: "msteams.graph",
+    policy: resolveGraphSsrfPolicy(url),
     timeoutMs: resolveMSTeamsRequestTimeoutMs(params.deadline),
   });
   let releaseInFinally = true;
@@ -138,6 +164,7 @@ export async function fetchGraphAbsoluteUrl<T>(params: {
       },
     },
     auditContext: "msteams.graph.absolute",
+    policy: resolveGraphSsrfPolicy(params.url),
     timeoutMs: MSTEAMS_REQUEST_TIMEOUT_MS,
   });
   try {


### PR DESCRIPTION
Closes #107163

## What Problem This Solves

Fixes an issue where Microsoft Teams plugin users in host-proxied deployments could have Graph requests and media downloads blocked when DNS resolves allowed external hosts to RFC2544 fake-IP addresses before egress interception.

## Why This Change Was Made

The Teams plugin now passes a host-scoped SSRF policy with `allowRfc2544BenchmarkRange` for known Microsoft Graph hosts, and media downloads add the same RFC2544 opt-in only when the configured media host suffixes produce an actual hostname allowlist. The change stays in the Teams plugin boundary and does not allow arbitrary private-network targets.

## User Impact

Teams Graph-backed operations and attachment/media handling can work in RFC2544 fake-IP proxy environments while keeping the existing hostname restrictions for Graph and media URLs.

## Evidence

Behavior addressed: Microsoft Teams Graph and media guarded fetches rejected RFC2544 fake-IP DNS results before host-proxied egress could intercept the request.

Real environment tested: Local OpenClaw worktree with the Microsoft Teams extension Vitest config. Remote Blacksmith Testbox was attempted but blocked because the installed Crabbox binary reported version `0.12.0`, while this repo requires Crabbox `>=0.22.0` for the Blacksmith Testbox provider.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs extensions/msteams/src/graph.test.ts extensions/msteams/src/attachments/shared.test.ts` and `git diff --check`.

Evidence after fix:
```shell
[test] starting test/vitest/vitest.extension-msteams.config.ts

 RUN  v4.1.9 /home/galini/GitHub/worktrees/bug-055-msteams-rfc2544-policy


 Test Files  2 passed (2)
      Tests  78 passed (78)
   Start at  05:21:03
   Duration  11.99s (transform 7.89s, setup 887ms, import 12.32s, tests 342ms, environment 0ms)

[test] passed 1 Vitest shard in 17.34s
```

Observed result after fix: The focused Teams tests pass, including assertions that relative Graph requests and absolute Graph pagination URLs carry a Graph-host-scoped RFC2544 policy, non-Graph absolute URLs do not receive that policy, media suffix allowlists add the RFC2544 opt-in, and wildcard media allowlists still return no SSRF policy.

What was not tested: No live Microsoft Teams tenant or host-proxied container was available, and no raw failed gateway run was present in the bug bundle. Remote Testbox proof was blocked by the local Crabbox version mismatch described above.

Before evidence:
```shell
Current-main source proof before the patch:
extensions/msteams/src/graph.ts requestGraph called fetchWithSsrFGuard without a policy.
extensions/msteams/src/graph.ts fetchGraphAbsoluteUrl called fetchWithSsrFGuard without a policy.
extensions/msteams/src/attachments/shared.ts resolveMediaSsrfPolicy returned only buildHostnameAllowlistPolicyFromSuffixAllowlist(allowHosts).
```
