### PR TITLE
refactor(skills): use chokidar all events

### DIFF
--- a/src/skills/runtime/refresh.test.ts
+++ b/src/skills/runtime/refresh.test.ts
@@ -9,7 +9,7 @@ import {
   type SkillsChangeEvent,
 } from "./refresh-state.js";
 
-type WatchEvent = "add" | "addDir" | "change" | "unlink" | "unlinkDir" | "raw" | "error";
+type WatchEvent = "add" | "addDir" | "all" | "change" | "unlink" | "unlinkDir" | "raw" | "error";
 type WatchCallback = (...args: unknown[]) => void;
 
 function createMockWatcher() {
@@ -207,7 +207,7 @@ describe("ensureSkillsWatcher", () => {
       expect(calls[firstIndex]?.[1]?.depth).toBe(7);
 
       const changedPath = path.join(workspaceDir, "skills", "group", "demo", "SKILL.md");
-      createdWatchers[firstIndex]?.emit("change", changedPath);
+      createdWatchers[firstIndex]?.emit("all", "change", changedPath);
       await vi.advanceTimersByTimeAsync(10);
 
       expect(seen).toEqual([
@@ -714,7 +714,7 @@ describe("ensureSkillsWatcher", () => {
         config: { skills: { load: { watchDebounceMs: 10 } } },
       });
 
-      createdWatchers[0]?.emit(event, "/tmp/workspace/skills/demo/SKILL.md");
+      createdWatchers[0]?.emit("all", event, "/tmp/workspace/skills/demo/SKILL.md");
       await vi.advanceTimersByTimeAsync(10);
 
       expect(seen).toEqual([
@@ -794,7 +794,7 @@ describe("ensureSkillsWatcher", () => {
     const sharedIndex = callPaths.findIndex((target) => target.includes("/tmp/shared"));
     expect(sharedIndex).toBeGreaterThanOrEqual(0);
 
-    createdWatchers[sharedIndex]?.emit("change", "/tmp/shared/demo/SKILL.md");
+    createdWatchers[sharedIndex]?.emit("all", "change", "/tmp/shared/demo/SKILL.md");
     await vi.advanceTimersByTimeAsync(10);
 
     expect(seen).toContainEqual({
@@ -836,7 +836,7 @@ describe("ensureSkillsWatcher", () => {
     const sharedIndex = callPaths.findIndex((target) => target.includes("/tmp/shared"));
     expect(sharedIndex).toBeGreaterThanOrEqual(0);
 
-    createdWatchers[sharedIndex]?.emit("change", "/tmp/shared/demo/SKILL.md");
+    createdWatchers[sharedIndex]?.emit("all", "change", "/tmp/shared/demo/SKILL.md");
     await vi.advanceTimersByTimeAsync(10);
 
     expect(seen).toContainEqual({
@@ -970,7 +970,7 @@ describe("ensureSkillsWatcher", () => {
     expect(callPaths2.filter((target) => target === "/tmp/shared/skills")).toHaveLength(2);
     const liveSharedIndex = sharedIndices[sharedIndices.length - 1] ?? -1;
 
-    createdWatchers[liveSharedIndex]?.emit("change", "/tmp/shared/demo/SKILL.md");
+    createdWatchers[liveSharedIndex]?.emit("all", "change", "/tmp/shared/demo/SKILL.md");
     await vi.advanceTimersByTimeAsync(50);
 
     expect(seen).toContainEqual({

--- a/src/skills/runtime/refresh.ts
+++ b/src/skills/runtime/refresh.ts
@@ -554,11 +554,7 @@ function createSkillsPathWatcher(target: WatchTarget, debounceMs: number): Skill
       .then(() => schedule(changedPath));
   };
 
-  watcher.on("addDir", (p) => schedule(p));
-  watcher.on("add", (p) => schedule(p));
-  watcher.on("change", (p) => schedule(p));
-  watcher.on("unlink", (p) => schedule(p));
-  watcher.on("unlinkDir", (p) => schedule(p));
+  watcher.on("all", (_event, changedPath) => schedule(changedPath));
   watcher.on("raw", (_eventName, rawPath, details) => {
     const rawPathText = rawPathToString(rawPath);
     if (!rawPathText) {


### PR DESCRIPTION
## What Problem This Solves

The skills refresh watcher registered five identical callbacks for Chokidar's add, addDir, change, unlink, and unlinkDir events. Chokidar 5 already emits each of those through its typed `all` event, leaving duplicated subscription code and duplicated test plumbing.

## Why This Change Was Made

- Subscribe once to Chokidar's native `all` event.
- Keep raw filesystem events and watcher errors on their dedicated handlers.
- Update watcher tests to emit Chokidar's actual `all` callback tuple: event name followed by changed path.

## User Impact

No behavior change. Skill snapshots still refresh for all five filesystem event classes. Net source reduction: 4 lines.

## Evidence

- `pnpm test src/skills/runtime/refresh.test.ts` — 35 tests passed.
- Targeted oxlint — 0 warnings, 0 errors.
- `oxfmt --check` and `git diff --check` — passed.
- Fresh autoreview — clean, confidence 0.98.
- Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/29308599619
