### PR TITLE
fix: prevent duplicate Teams broker retry turns

### DIFF
--- a/extensions/msteams/src/monitor.lifecycle.test.ts
+++ b/extensions/msteams/src/monitor.lifecycle.test.ts
@@ -133,6 +133,57 @@ const registerMSTeamsHandlers = vi.hoisted(() =>
 const isSigninInvokeAuthorized = vi.hoisted(() => vi.fn(async () => true));
 const isCardActionInvokeAuthorized = vi.hoisted(() => vi.fn(async () => true));
 const runMSTeamsFileConsentInvokeHandler = vi.hoisted(() => vi.fn(async () => {}));
+const createClaimableDedupe = vi.hoisted(() =>
+  vi.fn(() => {
+    const inFlight = new Map<
+      string,
+      {
+        promise: Promise<boolean>;
+        resolve: (value: boolean) => void;
+        reject: (error: unknown) => void;
+      }
+    >();
+    const completed = new Set<string>();
+    return {
+      claim: vi.fn(async (key: string) => {
+        const pending = inFlight.get(key);
+        if (pending) {
+          return { kind: "inflight", pending: pending.promise };
+        }
+        if (completed.has(key)) {
+          return { kind: "duplicate" };
+        }
+        let resolve!: (value: boolean) => void;
+        let reject!: (error: unknown) => void;
+        const pendingClaim = new Promise<boolean>((resolvePromise, rejectPromise) => {
+          resolve = resolvePromise;
+          reject = rejectPromise;
+        });
+        void pendingClaim.catch(() => {});
+        inFlight.set(key, { promise: pendingClaim, resolve, reject });
+        return { kind: "claimed" };
+      }),
+      commit: vi.fn(async (key: string) => {
+        completed.add(key);
+        inFlight.get(key)?.resolve(true);
+        inFlight.delete(key);
+        return true;
+      }),
+      release: vi.fn((key: string) => {
+        inFlight.get(key)?.reject(new Error("released"));
+        inFlight.delete(key);
+      }),
+      hasRecent: vi.fn(async (key: string) => completed.has(key)),
+      forget: vi.fn(async (key: string) => completed.delete(key)),
+      warmup: vi.fn(async () => 0),
+      clearMemory: vi.fn(() => {
+        inFlight.clear();
+        completed.clear();
+      }),
+      memorySize: vi.fn(() => inFlight.size + completed.size),
+    };
+  }),
+);
 const loadMSTeamsSdkWithAuth = vi.hoisted(() =>
   vi.fn(async (_creds?: unknown, _options?: unknown) => ({
     app: {
@@ -157,6 +208,10 @@ const ssoTokenStore = vi.hoisted(() => ({
 
 vi.mock("@microsoft/teams.apps", () => ({
   ExpressAdapter: vi.fn(),
+}));
+
+vi.mock("openclaw/plugin-sdk/persistent-dedupe", () => ({
+  createClaimableDedupe,
 }));
 
 vi.mock("./monitor-handler.js", () => ({
@@ -291,6 +346,7 @@ describe("monitorMSTeamsProvider lifecycle", () => {
     resolveAllowlistMocks.resolveMSTeamsUserAllowlist.mockReset().mockResolvedValue([]);
     isSigninInvokeAuthorized.mockReset().mockResolvedValue(true);
     isCardActionInvokeAuthorized.mockReset().mockResolvedValue(true);
+    createClaimableDedupe.mockClear();
     runMSTeamsFileConsentInvokeHandler.mockReset().mockResolvedValue(undefined);
     ssoTokenStore.get.mockClear();
     ssoTokenStore.save.mockClear();
@@ -353,12 +409,13 @@ describe("monitorMSTeamsProvider lifecycle", () => {
 
     const app = expressControl.apps.at(-1);
     expect(app).toBeDefined();
-    // Three middlewares are installed before the SDK route registers:
+    // Four middlewares are installed before the SDK route registers:
     // [0] = bearer-presence gate — rejects unauthenticated requests cheaply.
     // [1] = `express.json({ limit })` — caps bearer-shaped inbound bodies
     //       before the SDK's later json() can parse them.
-    // [2] = JSON parser error handler — keeps 413 responses JSON-shaped.
-    expect(app!.use.mock.calls.length).toBeGreaterThanOrEqual(3);
+    // [2] = brokered delivery-id projection from request headers.
+    // [3] = JSON parser error handler — keeps 413 responses JSON-shaped.
+    expect(app!.use.mock.calls.length).toBeGreaterThanOrEqual(4);
 
     const bearerMiddleware = app!.use.mock.calls[0]?.[0] as (
       req: Request,
@@ -401,7 +458,7 @@ describe("monitorMSTeamsProvider lifecycle", () => {
     });
 
     const app = expressControl.apps.at(-1);
-    const jsonErrorMiddleware = app!.use.mock.calls[2]?.[0] as (
+    const jsonErrorMiddleware = app!.use.mock.calls[3]?.[0] as (
       err: unknown,
       req: Request,
       res: Response,
@@ -416,6 +473,46 @@ describe("monitorMSTeamsProvider lifecycle", () => {
     expect(status).toHaveBeenCalledWith(413);
     expect(json).toHaveBeenCalledWith({ error: "Payload too large" });
     expect(next).not.toHaveBeenCalled();
+
+    abort.abort();
+    await task;
+  });
+
+  it("projects brokered delivery ids from request headers into activity channelData", async () => {
+    const abort = new AbortController();
+    const task = monitorMSTeamsProvider({
+      cfg: createConfig(0),
+      runtime: createRuntime(),
+      abortSignal: abort.signal,
+      conversationStore: createStores().conversationStore,
+      pollStore: createStores().pollStore,
+    });
+
+    await vi.waitFor(() => {
+      expect(expressControl.apps.length).toBeGreaterThan(0);
+    });
+
+    const app = expressControl.apps.at(-1);
+    const deliveryProjection = app!.use.mock.calls[2]?.[0] as (
+      req: Request,
+      res: Response,
+      next: (err?: unknown) => void,
+    ) => void;
+    const next = vi.fn();
+    const req = {
+      headers: { "x-teams-delivery-id": " broker-delivery-1 " },
+      body: { type: "message", channelData: { existing: true } },
+    } as unknown as Request;
+
+    deliveryProjection(req, {} as Response, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(req.body).toMatchObject({
+      channelData: {
+        existing: true,
+        lobsterDeliveryId: "broker-delivery-1",
+      },
+    });
 
     abort.abort();
     await task;
@@ -568,6 +665,14 @@ describe("monitorMSTeamsProvider lifecycle", () => {
     await vi.waitFor(() => {
       expect(registerMSTeamsHandlers).toHaveBeenCalled();
     });
+    expect(createClaimableDedupe).toHaveBeenCalledWith(
+      expect.objectContaining({
+        pluginId: "msteams",
+        namespacePrefix: "brokered-delivery",
+        memoryMaxSize: 5000,
+        stateMaxEntries: 50000,
+      }),
+    );
 
     const sdkResultPromise = loadMSTeamsSdkWithAuth.mock.results[0]?.value;
     if (!sdkResultPromise) {
@@ -796,6 +901,382 @@ describe("monitorMSTeamsProvider lifecycle", () => {
     expect(run).toHaveBeenCalledTimes(1);
     releaseDispatch?.();
     await dispatchWork;
+
+    abort.abort();
+    await task;
+  });
+
+  it("suppresses duplicate non-poll card action dispatches while in-flight and after success", async () => {
+    const abort = new AbortController();
+    const task = monitorMSTeamsProvider({
+      cfg: createConfig(0),
+      runtime: createRuntime(),
+      abortSignal: abort.signal,
+      conversationStore: createStores().conversationStore,
+      pollStore: createStores().pollStore,
+    });
+
+    await vi.waitFor(() => {
+      expect(registerMSTeamsHandlers).toHaveBeenCalled();
+    });
+
+    const sdkResultPromise = loadMSTeamsSdkWithAuth.mock.results[0]?.value;
+    if (!sdkResultPromise) {
+      throw new Error("expected loadMSTeamsSdkWithAuth result");
+    }
+    const app = (await sdkResultPromise).app;
+    const cardActionHandler = app.on.mock.calls.find(
+      (call: [string, unknown]) => call[0] === "card.action",
+    )?.[1];
+    if (typeof cardActionHandler !== "function") {
+      throw new Error("expected card.action handler");
+    }
+    const registeredHandler = registerMSTeamsHandlers.mock.calls[0]?.[0];
+    if (!registeredHandler) {
+      throw new Error("expected registered Teams handler");
+    }
+
+    let releaseDispatch: (() => void) | undefined;
+    const dispatchWork = new Promise<void>((resolve) => {
+      releaseDispatch = resolve;
+    });
+    const run = vi.spyOn(registeredHandler, "run").mockReturnValueOnce(dispatchWork);
+    const ctx = {
+      activity: {
+        type: "invoke",
+        name: "adaptiveCard/action",
+        channelData: { lobsterDeliveryId: "broker-delivery-1" },
+        value: { action: { data: { action: "nonPoll" } } },
+      },
+    };
+
+    await cardActionHandler(ctx);
+    await cardActionHandler(ctx);
+
+    expect(run).toHaveBeenCalledTimes(1);
+    releaseDispatch?.();
+    await dispatchWork;
+    await vi.waitFor(() => {
+      expect(run).toHaveBeenCalledTimes(1);
+    });
+
+    await cardActionHandler(ctx);
+    expect(run).toHaveBeenCalledTimes(1);
+
+    abort.abort();
+    await task;
+  });
+
+  it("dedupes activity dispatches by activity id after success", async () => {
+    const abort = new AbortController();
+    const task = monitorMSTeamsProvider({
+      cfg: createConfig(0),
+      runtime: createRuntime(),
+      abortSignal: abort.signal,
+      conversationStore: createStores().conversationStore,
+      pollStore: createStores().pollStore,
+    });
+
+    await vi.waitFor(() => {
+      expect(registerMSTeamsHandlers).toHaveBeenCalled();
+    });
+
+    const sdkResultPromise = loadMSTeamsSdkWithAuth.mock.results[0]?.value;
+    if (!sdkResultPromise) {
+      throw new Error("expected loadMSTeamsSdkWithAuth result");
+    }
+    const app = (await sdkResultPromise).app;
+    const activityHandler = app.on.mock.calls.find(
+      (call: [string, unknown]) => call[0] === "activity",
+    )?.[1];
+    if (typeof activityHandler !== "function") {
+      throw new Error("expected activity handler");
+    }
+    const registeredHandler = registerMSTeamsHandlers.mock.calls[0]?.[0];
+    if (!registeredHandler) {
+      throw new Error("expected registered Teams handler");
+    }
+    const run = vi.spyOn(registeredHandler, "run");
+    const ctx = {
+      activity: {
+        id: "activity-delivery-1",
+        type: "message",
+        text: "hello",
+      },
+    };
+
+    await activityHandler(ctx);
+    await activityHandler(ctx);
+
+    expect(run).toHaveBeenCalledTimes(1);
+
+    abort.abort();
+    await task;
+  });
+
+  it("lets an in-flight retry process the activity when the owner dispatch fails", async () => {
+    const abort = new AbortController();
+    const task = monitorMSTeamsProvider({
+      cfg: createConfig(0),
+      runtime: createRuntime(),
+      abortSignal: abort.signal,
+      conversationStore: createStores().conversationStore,
+      pollStore: createStores().pollStore,
+    });
+
+    await vi.waitFor(() => {
+      expect(registerMSTeamsHandlers).toHaveBeenCalled();
+    });
+
+    const sdkResultPromise = loadMSTeamsSdkWithAuth.mock.results[0]?.value;
+    if (!sdkResultPromise) {
+      throw new Error("expected loadMSTeamsSdkWithAuth result");
+    }
+    const app = (await sdkResultPromise).app;
+    const activityHandler = app.on.mock.calls.find(
+      (call: [string, unknown]) => call[0] === "activity",
+    )?.[1];
+    if (typeof activityHandler !== "function") {
+      throw new Error("expected activity handler");
+    }
+    const registeredHandler = registerMSTeamsHandlers.mock.calls[0]?.[0];
+    if (!registeredHandler) {
+      throw new Error("expected registered Teams handler");
+    }
+    let rejectFirst: ((error: Error) => void) | undefined;
+    const firstDispatch = new Promise<void>((_resolve, reject) => {
+      rejectFirst = reject;
+    });
+    const run = vi
+      .spyOn(registeredHandler, "run")
+      .mockReturnValueOnce(firstDispatch)
+      .mockResolvedValueOnce(undefined);
+    const ctx = {
+      activity: {
+        id: "activity-delivery-1",
+        type: "message",
+        conversation: { id: "conversation-1" },
+        text: "hello",
+      },
+    };
+
+    const first = activityHandler(ctx);
+    const retry = activityHandler(ctx);
+    await vi.waitFor(() => {
+      expect(run).toHaveBeenCalledTimes(1);
+    });
+    rejectFirst?.(new Error("transient dispatch failure"));
+    await first;
+    await retry;
+
+    expect(run).toHaveBeenCalledTimes(2);
+
+    abort.abort();
+    await task;
+  });
+
+  it("keeps brokered delivery ids separate from fallback activity ids", async () => {
+    const abort = new AbortController();
+    const task = monitorMSTeamsProvider({
+      cfg: createConfig(0),
+      runtime: createRuntime(),
+      abortSignal: abort.signal,
+      conversationStore: createStores().conversationStore,
+      pollStore: createStores().pollStore,
+    });
+
+    await vi.waitFor(() => {
+      expect(registerMSTeamsHandlers).toHaveBeenCalled();
+    });
+
+    const sdkResultPromise = loadMSTeamsSdkWithAuth.mock.results[0]?.value;
+    if (!sdkResultPromise) {
+      throw new Error("expected loadMSTeamsSdkWithAuth result");
+    }
+    const app = (await sdkResultPromise).app;
+    const cardActionHandler = app.on.mock.calls.find(
+      (call: [string, unknown]) => call[0] === "card.action",
+    )?.[1];
+    const activityHandler = app.on.mock.calls.find(
+      (call: [string, unknown]) => call[0] === "activity",
+    )?.[1];
+    if (typeof cardActionHandler !== "function" || typeof activityHandler !== "function") {
+      throw new Error("expected card.action and activity handlers");
+    }
+    const registeredHandler = registerMSTeamsHandlers.mock.calls[0]?.[0];
+    if (!registeredHandler) {
+      throw new Error("expected registered Teams handler");
+    }
+    const run = vi.spyOn(registeredHandler, "run");
+
+    await cardActionHandler({
+      activity: {
+        type: "invoke",
+        name: "adaptiveCard/action",
+        id: "shared-id",
+        conversation: { id: "conversation-1" },
+        channelData: { lobsterDeliveryId: "shared-id" },
+        value: { action: { data: { action: "nonPoll" } } },
+      },
+    });
+    await activityHandler({
+      activity: {
+        id: "shared-id",
+        type: "message",
+        conversation: { id: "conversation-1" },
+        text: "hello",
+      },
+    });
+
+    expect(run).toHaveBeenCalledTimes(2);
+
+    abort.abort();
+    await task;
+  });
+
+  it("keeps fallback activity ids scoped by conversation", async () => {
+    const abort = new AbortController();
+    const task = monitorMSTeamsProvider({
+      cfg: createConfig(0),
+      runtime: createRuntime(),
+      abortSignal: abort.signal,
+      conversationStore: createStores().conversationStore,
+      pollStore: createStores().pollStore,
+    });
+
+    await vi.waitFor(() => {
+      expect(registerMSTeamsHandlers).toHaveBeenCalled();
+    });
+
+    const sdkResultPromise = loadMSTeamsSdkWithAuth.mock.results[0]?.value;
+    if (!sdkResultPromise) {
+      throw new Error("expected loadMSTeamsSdkWithAuth result");
+    }
+    const app = (await sdkResultPromise).app;
+    const activityHandler = app.on.mock.calls.find(
+      (call: [string, unknown]) => call[0] === "activity",
+    )?.[1];
+    if (typeof activityHandler !== "function") {
+      throw new Error("expected activity handler");
+    }
+    const registeredHandler = registerMSTeamsHandlers.mock.calls[0]?.[0];
+    if (!registeredHandler) {
+      throw new Error("expected registered Teams handler");
+    }
+    const run = vi.spyOn(registeredHandler, "run");
+
+    await activityHandler({
+      activity: {
+        id: "activity-delivery-1",
+        type: "message",
+        conversation: { id: "conversation-1" },
+        text: "hello",
+      },
+    });
+    await activityHandler({
+      activity: {
+        id: "activity-delivery-1",
+        type: "message",
+        conversation: { id: "conversation-2" },
+        text: "hello",
+      },
+    });
+
+    expect(run).toHaveBeenCalledTimes(2);
+
+    abort.abort();
+    await task;
+  });
+
+  it("does not dedupe message updates by bare activity id", async () => {
+    const abort = new AbortController();
+    const task = monitorMSTeamsProvider({
+      cfg: createConfig(0),
+      runtime: createRuntime(),
+      abortSignal: abort.signal,
+      conversationStore: createStores().conversationStore,
+      pollStore: createStores().pollStore,
+    });
+
+    await vi.waitFor(() => {
+      expect(registerMSTeamsHandlers).toHaveBeenCalled();
+    });
+
+    const sdkResultPromise = loadMSTeamsSdkWithAuth.mock.results[0]?.value;
+    if (!sdkResultPromise) {
+      throw new Error("expected loadMSTeamsSdkWithAuth result");
+    }
+    const app = (await sdkResultPromise).app;
+    const activityHandler = app.on.mock.calls.find(
+      (call: [string, unknown]) => call[0] === "activity",
+    )?.[1];
+    if (typeof activityHandler !== "function") {
+      throw new Error("expected activity handler");
+    }
+    const registeredHandler = registerMSTeamsHandlers.mock.calls[0]?.[0];
+    if (!registeredHandler) {
+      throw new Error("expected registered Teams handler");
+    }
+    const run = vi.spyOn(registeredHandler, "run");
+    const ctx = {
+      activity: {
+        id: "edited-message-id",
+        type: "messageUpdate",
+        conversation: { id: "conversation-1" },
+        text: "edited",
+      },
+    };
+
+    await activityHandler(ctx);
+    await activityHandler(ctx);
+
+    expect(run).toHaveBeenCalledTimes(2);
+
+    abort.abort();
+    await task;
+  });
+
+  it("does not dedupe activity dispatches without a stable delivery id", async () => {
+    const abort = new AbortController();
+    const task = monitorMSTeamsProvider({
+      cfg: createConfig(0),
+      runtime: createRuntime(),
+      abortSignal: abort.signal,
+      conversationStore: createStores().conversationStore,
+      pollStore: createStores().pollStore,
+    });
+
+    await vi.waitFor(() => {
+      expect(registerMSTeamsHandlers).toHaveBeenCalled();
+    });
+
+    const sdkResultPromise = loadMSTeamsSdkWithAuth.mock.results[0]?.value;
+    if (!sdkResultPromise) {
+      throw new Error("expected loadMSTeamsSdkWithAuth result");
+    }
+    const app = (await sdkResultPromise).app;
+    const activityHandler = app.on.mock.calls.find(
+      (call: [string, unknown]) => call[0] === "activity",
+    )?.[1];
+    if (typeof activityHandler !== "function") {
+      throw new Error("expected activity handler");
+    }
+    const registeredHandler = registerMSTeamsHandlers.mock.calls[0]?.[0];
+    if (!registeredHandler) {
+      throw new Error("expected registered Teams handler");
+    }
+    const run = vi.spyOn(registeredHandler, "run");
+    const ctx = {
+      activity: {
+        type: "message",
+        text: "hello",
+      },
+    };
+
+    await activityHandler(ctx);
+    await activityHandler(ctx);
+
+    expect(run).toHaveBeenCalledTimes(2);
 
     abort.abort();
     await task;

--- a/extensions/msteams/src/monitor.ts
+++ b/extensions/msteams/src/monitor.ts
@@ -1,5 +1,6 @@
 // Msteams plugin module implements monitor behavior.
 import type { Request, Response } from "express";
+import { createClaimableDedupe } from "openclaw/plugin-sdk/persistent-dedupe";
 import {
   DEFAULT_WEBHOOK_MAX_BODY_BYTES,
   isDangerousNameMatchingEnabled,
@@ -59,6 +60,12 @@ type MonitorMSTeamsResult = {
   app: unknown;
   shutdown: () => Promise<void>;
 };
+
+const MSTEAMS_BROKERED_DELIVERY_ID_HEADER = "x-teams-delivery-id";
+const MSTEAMS_BROKERED_DELIVERY_ID_CHANNEL_DATA_KEY = "lobsterDeliveryId";
+const MSTEAMS_BROKERED_DELIVERY_DEDUPE_TTL_MS = 30 * 60 * 1000;
+const MSTEAMS_BROKERED_DELIVERY_DEDUPE_MEMORY_MAX_SIZE = 5000;
+const MSTEAMS_BROKERED_DELIVERY_DEDUPE_STATE_MAX_ENTRIES = 50_000;
 
 export async function monitorMSTeamsProvider(
   opts: MonitorMSTeamsOpts,
@@ -206,6 +213,10 @@ export async function monitorMSTeamsProvider(
     next();
   });
   expressApp.use(express.json({ limit: DEFAULT_WEBHOOK_MAX_BODY_BYTES }));
+  expressApp.use((req: Request, _res: Response, next: (err?: unknown) => void) => {
+    projectBrokeredDeliveryIdHeader(req);
+    next();
+  });
   expressApp.use((err: unknown, _req: Request, res: Response, next: (err?: unknown) => void) => {
     if (err && typeof err === "object" && "status" in err && err.status === 413) {
       res.status(413).json({ error: "Payload too large" });
@@ -290,6 +301,13 @@ export async function monitorMSTeamsProvider(
     log,
   };
   registerMSTeamsHandlers(handler, handlerDeps);
+  const brokeredDeliveryDedupe = createBrokeredDeliveryDedupe({
+    onDiskError: (err) => {
+      log.warn?.("msteams delivery dedupe persistence failed", {
+        error: formatUnknownError(err),
+      });
+    },
+  });
 
   // Handle adaptiveCard/action invokes (Action.Execute Universal Action Model).
   // We must return an InvokeResponse-shaped value so Teams updates the card UI;
@@ -376,9 +394,18 @@ export async function monitorMSTeamsProvider(
       }
       // Non-poll card actions may dispatch into the agent. Acknowledge the
       // invoke immediately so Teams does not time out while that work runs.
-      void handler.run!(adaptedCtx).catch((err: unknown) => {
-        log.error("msteams card.action dispatch failed", { error: formatUnknownError(err) });
-      });
+      void brokeredDeliveryDedupe
+        .runOnce(adaptedCtx.activity, () => handler.run!(adaptedCtx))
+        .then((started) => {
+          if (!started) {
+            log.debug?.("msteams card.action duplicate delivery suppressed", {
+              deliveryKey: resolveMSTeamsDeliveryDedupeKey(adaptedCtx.activity)?.source,
+            });
+          }
+        })
+        .catch((err: unknown) => {
+          log.error("msteams card.action dispatch failed", { error: formatUnknownError(err) });
+        });
       return {
         statusCode: 200,
         type: "application/vnd.microsoft.activity.message",
@@ -526,7 +553,14 @@ export async function monitorMSTeamsProvider(
           return;
         }
       }
-      await handler.run!(adaptedCtx);
+      const started = await brokeredDeliveryDedupe.runOnce(activity, () =>
+        handler.run!(adaptedCtx),
+      );
+      if (!started) {
+        log.debug?.("msteams activity duplicate delivery suppressed", {
+          deliveryKey: resolveMSTeamsDeliveryDedupeKey(activity)?.source,
+        });
+      }
     } catch (err) {
       log.error("msteams webhook failed", { error: formatUnknownError(err) });
     }
@@ -592,6 +626,169 @@ function toLintErrorObject(value: unknown, fallbackMessage: string): Error {
     Object.assign(error, value);
   }
   return error;
+}
+
+function projectBrokeredDeliveryIdHeader(req: Request): void {
+  const deliveryId = normalizeDeliveryIdHeader(req.headers[MSTEAMS_BROKERED_DELIVERY_ID_HEADER]);
+  if (!deliveryId) {
+    return;
+  }
+  const body = req.body;
+  if (!isMutableRecord(body)) {
+    return;
+  }
+  const channelData = isMutableRecord(body.channelData) ? body.channelData : {};
+  channelData[MSTEAMS_BROKERED_DELIVERY_ID_CHANNEL_DATA_KEY] = deliveryId;
+  body.channelData = channelData;
+}
+
+function normalizeDeliveryIdHeader(value: Request["headers"][string]): string | undefined {
+  const first = Array.isArray(value) ? value[0] : value;
+  return typeof first === "string" && first.trim() ? first.trim() : undefined;
+}
+
+function createBrokeredDeliveryDedupe(options?: { onDiskError?: (error: unknown) => void }) {
+  const dedupe = createClaimableDedupe({
+    pluginId: "msteams",
+    namespacePrefix: "brokered-delivery",
+    ttlMs: MSTEAMS_BROKERED_DELIVERY_DEDUPE_TTL_MS,
+    memoryMaxSize: MSTEAMS_BROKERED_DELIVERY_DEDUPE_MEMORY_MAX_SIZE,
+    stateMaxEntries: MSTEAMS_BROKERED_DELIVERY_DEDUPE_STATE_MAX_ENTRIES,
+    ...(options?.onDiskError ? { onDiskError: options.onDiskError } : {}),
+  });
+  return {
+    async runOnce(activity: unknown, run: () => Promise<void>): Promise<boolean> {
+      const deliveryKey = resolveMSTeamsDeliveryDedupeKey(activity);
+      if (!deliveryKey) {
+        await run();
+        return true;
+      }
+
+      for (;;) {
+        const claim = await dedupe.claim(deliveryKey.key);
+        if (claim.kind === "duplicate") {
+          return false;
+        }
+        if (claim.kind === "inflight") {
+          try {
+            if (await claim.pending) {
+              return false;
+            }
+          } catch {
+            // The owner released instead of committing, so this retry remains
+            // eligible to claim and process the delivery.
+          }
+          continue;
+        }
+
+        // Claim before dispatch and commit only after success. Broker retries are
+        // suppressed while work is active, but failures stay retryable.
+        try {
+          await run();
+          await dedupe.commit(deliveryKey.key);
+          return true;
+        } catch (err) {
+          dedupe.release(deliveryKey.key, { error: err });
+          throw err;
+        }
+      }
+    },
+  };
+}
+
+function resolveMSTeamsDeliveryDedupeKey(
+  activity: unknown,
+): { key: string; source: string } | undefined {
+  if (!isMutableRecord(activity)) {
+    return undefined;
+  }
+  const channelData = activity.channelData;
+  const brokeredDeliveryId = isMutableRecord(channelData)
+    ? normalizeStableDeliveryId(channelData[MSTEAMS_BROKERED_DELIVERY_ID_CHANNEL_DATA_KEY])
+    : undefined;
+  const activityType = normalizeStableDeliveryId(activity.type) ?? "activity";
+  const tenantId = resolveMSTeamsTenantScope(channelData);
+  const conversationId = resolveNestedString(activity.conversation, "id") ?? "";
+  if (brokeredDeliveryId) {
+    return {
+      source: "brokered-delivery-id",
+      key: JSON.stringify([
+        "msteams",
+        "brokered-delivery-id",
+        tenantId,
+        conversationId,
+        activityType,
+        brokeredDeliveryId,
+      ]),
+    };
+  }
+  const activityId = normalizeStableDeliveryId(activity.id);
+  if (!activityId) {
+    return undefined;
+  }
+  const eventVersion =
+    normalizeStableDeliveryId(activity.timestamp) ??
+    normalizeStableDeliveryId(activity.localTimestamp);
+  if (isMutableRecord(channelData)) {
+    const channelDataEventVersion =
+      normalizeStableDeliveryId(channelData.eventId) ??
+      normalizeStableDeliveryId(channelData.eventSequence) ??
+      normalizeStableDeliveryId(channelData.eventVersion);
+    if (channelDataEventVersion) {
+      return {
+        source: "activity-id",
+        key: JSON.stringify([
+          "msteams",
+          "activity-id",
+          tenantId,
+          conversationId,
+          normalizeStableDeliveryId(activity.serviceUrl) ?? "",
+          activityType,
+          activityId,
+          channelDataEventVersion,
+        ]),
+      };
+    }
+  }
+  if (!eventVersion && activityType !== "message" && activityType !== "invoke") {
+    return undefined;
+  }
+  return {
+    source: "activity-id",
+    key: JSON.stringify([
+      "msteams",
+      "activity-id",
+      tenantId,
+      conversationId,
+      normalizeStableDeliveryId(activity.serviceUrl) ?? "",
+      activityType,
+      activityId,
+      eventVersion ?? "",
+    ]),
+  };
+}
+
+function normalizeStableDeliveryId(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function resolveMSTeamsTenantScope(channelData: unknown): string {
+  if (!isMutableRecord(channelData)) {
+    return "";
+  }
+  return (
+    resolveNestedString(channelData.tenant, "id") ??
+    normalizeStableDeliveryId(channelData.tenantId) ??
+    ""
+  );
+}
+
+function resolveNestedString(value: unknown, key: string): string | undefined {
+  return isMutableRecord(value) ? normalizeStableDeliveryId(value[key]) : undefined;
+}
+
+function isMutableRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 /**


### PR DESCRIPTION
Closes #107170

## What Problem This Solves

Fixes an issue where Microsoft Teams users could see duplicate agent replies or repeated side effects when a brokered Teams webhook delivery is retried while the first delivery is in flight or within the retry window after success.

## Why This Change Was Made

The Teams monitor now projects the broker delivery header into the activity before SDK dispatch and uses the shared persistent claimable dedupe helper around both Teams agent-dispatch paths. The guard commits only after successful dispatch, releases failed claims so retries remain eligible, scopes fallback activity keys by source and Teams context, and skips fallback suppression when no stable event identity exists.

## User Impact

Teams broker retries with the same stable delivery id no longer start duplicate agent turns. Normal Teams events without a stable delivery id continue to dispatch rather than being guessed into a dedupe key.

## Evidence

Before evidence:
```shell
rg -n "x-teams-delivery-id|lobsterDeliveryId|createBrokeredDeliveryDedupe|runBrokeredDeliveryOnce" extensions/msteams/src
# no matches on current main
```

After-fix focused test output:
```shell
node scripts/run-vitest.mjs extensions/msteams/src/monitor.lifecycle.test.ts
[test] starting test/vitest/vitest.extension-msteams.config.ts

 RUN  v4.1.9 <repo>

 Test Files  1 passed (1)
      Tests  24 passed (24)
   Duration  3.94s

[test] passed 1 Vitest shard in 9.02s
```

Patch hygiene:
```shell
git diff --check -- extensions/msteams/src/monitor.ts extensions/msteams/src/monitor.lifecycle.test.ts
# passed with no output
```

Structured review:
```shell
autoreview --mode commit --commit HEAD
autoreview clean: no accepted/actionable findings reported
overall: patch is correct (0.82)
```

## Real behavior proof

Behavior addressed: Microsoft Teams brokered webhook retries with the same stable delivery id can no longer start duplicate agent turns through the monitor dispatch path.

Real environment tested: Local repo checkout with focused Microsoft Teams monitor lifecycle tests. The tests exercise the real monitor registration and dispatch wrapper with mocked Teams SDK routes and mocked persistent dedupe factory to avoid writing test state to the user database.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs extensions/msteams/src/monitor.lifecycle.test.ts` and `git diff --check -- extensions/msteams/src/monitor.ts extensions/msteams/src/monitor.lifecycle.test.ts`.

Evidence after fix: Terminal capture above shows the focused Teams lifecycle suite passed with 24 tests and patch whitespace check passed with no output.

Observed result after fix: The new tests prove duplicate non-poll card actions are suppressed while in flight and after success, activity-id fallback dedupes only stable scoped events, in-flight retries process after owner failure, message updates are not suppressed by bare message id, and events without a stable id are not suppressed.

What was not tested: No live Microsoft Teams broker replay was run; the local bug evidence did not include credentials or a raw duplicate live Teams turn log. Remote Testbox was unavailable in the initial environment because the installed Crabbox wrapper was too old.
