### PR TITLE
fix(channels): bound draft-stream flush loop to prevent runaway sends

### DIFF
--- a/src/channels/draft-stream-loop.test.ts
+++ b/src/channels/draft-stream-loop.test.ts
@@ -259,4 +259,45 @@ describe("createDraftStreamLoop", () => {
     expect(sendOrEditStreamMessage).toHaveBeenNthCalledWith(1, "hello");
     expect(sendOrEditStreamMessage).toHaveBeenNthCalledWith(2, "hello");
   });
+
+  it("bounds consecutive sends per flush and preserves pending text instead of looping unbounded (#106644)", async () => {
+    // A producer that keeps appending new text between iterations would spin the
+    // flush() while-loop forever. flush() must instead terminate after a bounded
+    // number of sends, keep the pending text, and hand the remainder back to the
+    // throttle timer rather than discarding it.
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    try {
+      let sends = 0;
+      const loop = createDraftStreamLoop({
+        throttleMs: 100,
+        isStopped: () => false,
+        sendOrEditStreamMessage: async () => {
+          sends += 1;
+          // Replenish pending text as a microtask so it lands while flush() is
+          // awaiting this send (inFlightPromise is set) — mirroring a real
+          // streaming producer appending text between iterations.
+          void Promise.resolve().then(() => loop.update(`text-${sends + 1}`));
+          return true;
+        },
+      });
+
+      loop.update("text-1");
+      // Must terminate (not hang) even though pending text is always replenished.
+      await loop.flush();
+
+      // flush() yielded after the batch cap instead of looping forever...
+      expect(sends).toBe(20);
+      // ...armed a follow-up flush through the throttle timer...
+      expect(vi.getTimerCount()).toBe(1);
+      // ...and preserved the pending text rather than dropping it (no data loss).
+      expect(loop.takePending()).toBe("text-21");
+
+      loop.stop();
+    } finally {
+      vi.clearAllTimers();
+      vi.useRealTimers();
+      vi.restoreAllMocks();
+    }
+  });
 });

--- a/src/channels/draft-stream-loop.ts
+++ b/src/channels/draft-stream-loop.ts
@@ -21,6 +21,14 @@ type CreatedDraftStreamLoop = DraftStreamLoop & {
   takePending: () => string;
 };
 
+/**
+ * Upper bound on consecutive sends performed by a single flush() invocation.
+ * When a producer keeps replenishing pendingText between iterations, flush()
+ * yields after this many sends and reschedules the remaining text through the
+ * throttle timer instead of looping unbounded (issue #106644).
+ */
+const MAX_FLUSH_SENDS_PER_INVOCATION = 20;
+
 /** Creates a single-flight draft stream loop that preserves the newest pending text. */
 export function createDraftStreamLoop(params: {
   throttleMs: number;
@@ -39,6 +47,7 @@ export function createDraftStreamLoop(params: {
       clearTimeout(timer);
       timer = undefined;
     }
+    let sendCount = 0;
     while (!params.isStopped()) {
       if (inFlightPromise) {
         await inFlightPromise;
@@ -75,6 +84,15 @@ export function createDraftStreamLoop(params: {
       }
       lastSentAt = Date.now();
       if (!pendingText) {
+        return;
+      }
+      // Bound the number of consecutive sends per flush() invocation. When a
+      // producer keeps replenishing pendingText between iterations, yield back
+      // to the event loop and reschedule the remaining text through the throttle
+      // timer instead of looping unbounded (issue #106644). pendingText is
+      // preserved here so no draft text is dropped.
+      if (++sendCount >= MAX_FLUSH_SENDS_PER_INVOCATION) {
+        schedule();
         return;
       }
     }


### PR DESCRIPTION
## Summary

**Problem**: `createDraftStreamLoop().flush()` had a `while (!isStopped())` loop whose only exit was "no pending text after a send". A producer that keeps appending text between iterations keeps `pendingText` non-empty forever, so the loop never returns — the flush promise never settles, channel edit API calls fire back-to-back with no throttle, and the event-loop segment is starved (issue #106644).

**Solution**: bound each `flush()` invocation to at most `MAX_FLUSH_SENDS_PER_INVOCATION` (20) consecutive sends; on hitting the cap while text is still pending, hand the remainder back to the existing throttle timer via `schedule()` and return, yielding to the event loop without dropping the pending text.

**What changed**: added the `MAX_FLUSH_SENDS_PER_INVOCATION` bound plus reschedule in `flush()` (`src/channels/draft-stream-loop.ts`) and a regression test.

**What did NOT change**: throttle policy, channel adapters, and the controls layer are untouched; normal bursts stop replenishing and never reach the cap, so latency and existing behavior are unchanged.

Design note: preserving `pendingText` and rescheduling (rather than clearing it) is deliberate — clearing on the cap would silently drop the newest draft text. This matches the issue's "yield back to the main event loop" guidance.

Fixes #106644

---

## Root Cause

**Trigger condition**: `sendOrEditStreamMessage` keeps succeeding while new text is appended via `update()` between iterations, so `pendingText` is never empty when the loop checks `if (!pendingText) return`.

**Root cause analysis**: `flush()`'s while-loop lacked a per-invocation send bound. The throttle only gates `update()` -> `schedule()`, not the inner send loop, so a fast producer drives unbounded, un-throttled sends. Root: a missing loop boundary in `src/channels/draft-stream-loop.ts`.

**Affected scope**: channels using `createDraftStreamLoop` via `draft-stream-controls.ts` (streaming preview edits). `draft-stream-controls.ts` has no loop of its own and needs no change; its finalize paths mark the stream final before flushing, which blocks further `update()`, so the cap is never reached there.

---

## Linked context

- **Issue**: #106644
- **In scope**: per-invocation send bound plus reschedule in `flush()`; a regression test.
- **Out of scope**: throttle policy, channel adapters, and the controls layer.

---

## Real behavior proof

**Behavior addressed**: `flush()` no longer loops forever when pending draft text is continuously replenished; it terminates after a bounded batch and reschedules the remainder instead of blocking and hammering the channel edit API.

**Real environment tested**: Linux x86_64, Node v24.13.1, vitest v4.1.9; real process execution (not mocked) of the draft-stream-loop suite against the original vs patched source.

**Exact steps or command run after this patch**: run the suite against the unbounded original, then against the bounded patch.
```bash
# node vitest runs — Before fix (unbounded flush) then After fix (bounded flush)
git checkout HEAD~1 -- src/channels/draft-stream-loop.ts    # Before fix: remove the bound
timeout 60 node node_modules/.bin/vitest run src/channels/draft-stream-loop.test.ts --testTimeout=25000
git checkout HEAD -- src/channels/draft-stream-loop.ts      # After fix: restore the bound
node node_modules/.bin/vitest run src/channels/draft-stream-loop.test.ts --no-coverage
```

**After-fix evidence**:
```
Before fix (unbounded flush): the process never returns; it is killed by the
outer timeout. The microtask loop starves even vitest's own --testTimeout=25000,
so the runaway test cannot self-terminate:
    $ timeout 60 node ... vitest ... --testTimeout=25000
    exit 124     # process-level SIGTERM at 60s, test never completed

After fix (bounded flush):
    RUN  v4.1.9
    Test Files  1 passed (1)
         Tests  8 passed (8)
      Duration  1.10s
```

**Observed result after the fix**: the identical runaway scenario terminates in ~1s; before the patch it never completes and must be killed. The new test also asserts `takePending() === "text-21"`, proving the pending text is preserved (not dropped) when the cap engages.

**What was not tested**: a full live Telegram/Discord channel runaway (needs external channel accounts plus an adversarial rapid producer, unavailable in this environment); substituted by the real before/after suite execution above. Finalize paths are covered by `draft-stream-controls.test.ts` (12/12).

## Tests and validation

### Unit tests
```
$ node node_modules/.bin/vitest run src/channels/draft-stream-loop.test.ts --no-coverage
 Test Files  1 passed (1)
      Tests  8 passed (8)      # includes the new #106644 runaway regression test

$ node node_modules/.bin/vitest run src/channels/draft-stream-controls.test.ts --no-coverage
 Test Files  1 passed (1)
      Tests  12 passed (12)    # controls / finalize regression

$ node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental ...   # exit 0 (typecheck)
$ node node_modules/.bin/oxlint src/channels/draft-stream-loop.ts src/channels/draft-stream-loop.test.ts   # exit 0 (lint)
```

## Risk checklist

merge-risk: Low

- [x] This change is backwards compatible
- [x] This change has been tested with existing configurations
- [x] I have updated relevant documentation (N/A — internal utility, no public API/config/CLI surface)
- [x] Breaking changes (if any) are documented in Summary (none)

Mitigation: the bound only engages under continuous replenishment; normal bursts are unaffected, and the pending text is rescheduled rather than dropped, so there is no behavioral change for existing callers.

## Current review state

- [x] Self-review completed
- [ ] At least one maintainer review
- [ ] All CI checks passed

---

> AI-assisted: root-cause analysis, implementation, and tests were prepared with AI assistance and human-reviewed.
