### PR TITLE
improve: speed up session concurrency tests

### DIFF
--- a/src/config/sessions/session-accessor.reply-init-concurrency.test.ts
+++ b/src/config/sessions/session-accessor.reply-init-concurrency.test.ts
@@ -4,7 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import process from "node:process";
 import { pathToFileURL } from "node:url";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import {
   appendTranscriptMessage,
@@ -48,210 +48,351 @@ type TranscriptRewriteChildResult =
       ok: false;
     };
 
-const POLL_MS = 20;
+type ConcurrencyWorkerRequest =
+  | {
+      kind: "reply-init";
+      preparedUpdatedAt: number;
+      storePath: string;
+    }
+  | {
+      kind: "transcript-rewrite";
+      rewriteMode: "read-then-replace" | "replace-twice";
+      sessionId: string;
+      storePath: string;
+    };
+
+type ConcurrencyWorkerReady<TRequest extends ConcurrencyWorkerRequest> = TRequest extends {
+  kind: "reply-init";
+}
+  ? { currentEntry?: unknown; revision: string }
+  : { eventCount: number };
+
+type ConcurrencyWorkerResult<TRequest extends ConcurrencyWorkerRequest> = TRequest extends {
+  kind: "reply-init";
+}
+  ? ChildResult
+  : TranscriptRewriteChildResult;
+
+type ConcurrencyWorkerMessage =
+  | { phase: "booted" }
+  | { error: { message: string; name: string }; phase: "error"; requestId: number }
+  | { phase: "ready"; requestId: number; value: unknown }
+  | { phase: "result"; requestId: number; value: unknown };
+
 const WAIT_TIMEOUT_MS = 10_000;
 const SESSION_KEY = "agent:main:main";
 const AGENT_ID = "main";
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+// Preserve the OS-process boundary while paying tsx/module startup once per file.
+// Every request still uses an isolated store path.
+let concurrencyWorker: ReturnType<typeof spawn> | undefined;
+let nextRequestId = 0;
 
-async function waitForFile(filePath: string): Promise<void> {
-  const deadline = Date.now() + WAIT_TIMEOUT_MS;
-  while (Date.now() < deadline) {
-    try {
-      await fs.access(filePath);
-      return;
-    } catch {
-      await new Promise((resolve) => {
-        setTimeout(resolve, POLL_MS);
-      });
-    }
-  }
-  throw new Error(`timeout waiting for ${filePath}`);
-}
-
-async function readJsonFile<T>(filePath: string): Promise<T> {
-  return JSON.parse(await fs.readFile(filePath, "utf8")) as T;
-}
-
-function createReplyInitChildScript(sessionAccessorUrl: string): string {
+function createConcurrencyWorkerScript(sessionAccessorUrl: string): string {
   return `
-const fs = await import("node:fs/promises");
 const {
   commitReplySessionInitialization,
   loadReplySessionInitializationSnapshot,
+  withTranscriptWriteLock,
 } = await import(${JSON.stringify(sessionAccessorUrl)});
 
-const POLL_MS = ${POLL_MS};
-const WAIT_TIMEOUT_MS = ${WAIT_TIMEOUT_MS};
 const SESSION_KEY = ${JSON.stringify(SESSION_KEY)};
 const AGENT_ID = ${JSON.stringify(AGENT_ID)};
+const proceedResolvers = new Map();
 
-async function waitForFile(filePath) {
-  const deadline = Date.now() + WAIT_TIMEOUT_MS;
-  while (Date.now() < deadline) {
-    try {
-      await fs.access(filePath);
-      return;
-    } catch {
-      await new Promise((resolve) => {
-        setTimeout(resolve, POLL_MS);
-      });
-    }
+function send(message) {
+  process.send?.(message);
+}
+
+function waitForProceed(requestId) {
+  return new Promise((resolve) => {
+    proceedResolvers.set(requestId, resolve);
+  });
+}
+
+async function runReplyInit(request) {
+  const snapshot = loadReplySessionInitializationSnapshot({
+    sessionKey: SESSION_KEY,
+    storePath: request.storePath,
+  });
+  const proceed = waitForProceed(request.requestId);
+  send({
+    phase: "ready",
+    requestId: request.requestId,
+    value: {
+      currentEntry: snapshot.currentEntry,
+      revision: snapshot.revision,
+    },
+  });
+  await proceed;
+  return commitReplySessionInitialization({
+    activeSessionKey: SESSION_KEY,
+    agentId: AGENT_ID,
+    expectedRevision: snapshot.revision,
+    sessionEntry: {
+      sessionId: "existing-session",
+      updatedAt: request.preparedUpdatedAt,
+    },
+    sessionKey: SESSION_KEY,
+    snapshotEntry: snapshot.currentEntry,
+    storePath: request.storePath,
+  });
+}
+
+async function runTranscriptRewrite(request) {
+  let result;
+  try {
+    await withTranscriptWriteLock(
+      {
+        agentId: AGENT_ID,
+        sessionId: request.sessionId,
+        sessionKey: SESSION_KEY,
+        storePath: request.storePath,
+      },
+      async (transcript) => {
+        if (request.rewriteMode === "replace-twice") {
+          const firstReplacement = [
+            { type: "session", version: 3, id: request.sessionId },
+            {
+              type: "message",
+              id: "first-replacement",
+              parentId: null,
+              message: { role: "assistant", content: "first replacement" },
+            },
+          ];
+          await transcript.replaceEvents(firstReplacement);
+          const proceed = waitForProceed(request.requestId);
+          send({
+            phase: "ready",
+            requestId: request.requestId,
+            value: { eventCount: firstReplacement.length },
+          });
+          await proceed;
+          await transcript.replaceEvents([
+            firstReplacement[0],
+            {
+              type: "message",
+              id: "first-replacement",
+              parentId: null,
+              message: { role: "assistant", content: "second replacement" },
+            },
+          ]);
+          return;
+        }
+        const events = await transcript.readEvents();
+        const proceed = waitForProceed(request.requestId);
+        send({
+          phase: "ready",
+          requestId: request.requestId,
+          value: { eventCount: events.length },
+        });
+        await proceed;
+        const rewrittenEvents = events.map((event) => {
+          if (
+            typeof event !== "object" ||
+            event === null ||
+            Array.isArray(event) ||
+            event.id !== "rewrite-target"
+          ) {
+            return event;
+          }
+          return {
+            ...event,
+            message: {
+              ...event.message,
+              content: "rewritten content",
+            },
+          };
+        });
+        await transcript.replaceEvents(rewrittenEvents);
+      },
+    );
+    result = { ok: true };
+  } catch (error) {
+    result = {
+      ok: false,
+      name: error instanceof Error ? error.name : typeof error,
+      message: error instanceof Error ? error.message : String(error),
+    };
   }
-  throw new Error(\`timeout waiting for \${filePath}\`);
+  return result;
 }
 
-async function writeJsonFile(filePath, value) {
-  // The parent treats file existence as the readiness signal, so publish atomically.
-  const tempPath = filePath + "." + process.pid + ".tmp";
-  await fs.writeFile(tempPath, \`\${JSON.stringify(value, null, 2)}\\n\`, "utf8");
-  await fs.rename(tempPath, filePath);
-}
-
-const storePath = process.env.REPLY_INIT_STORE_PATH;
-const readyPath = process.env.REPLY_INIT_READY_PATH;
-const proceedPath = process.env.REPLY_INIT_PROCEED_PATH;
-const resultPath = process.env.REPLY_INIT_RESULT_PATH;
-const preparedUpdatedAt = process.env.REPLY_INIT_PREPARED_UPDATED_AT;
-if (!storePath || !readyPath || !proceedPath || !resultPath || !preparedUpdatedAt) {
-  throw new Error("reply initialization child env is incomplete");
-}
-
-const snapshot = loadReplySessionInitializationSnapshot({
-  sessionKey: SESSION_KEY,
-  storePath,
+process.on("message", (request) => {
+  if (!request || typeof request !== "object") {
+    return;
+  }
+  if (request.kind === "shutdown") {
+    process.exit(0);
+  }
+  if (request.kind === "proceed") {
+    const resolve = proceedResolvers.get(request.requestId);
+    proceedResolvers.delete(request.requestId);
+    resolve?.();
+    return;
+  }
+  if (!Number.isInteger(request.requestId)) {
+    return;
+  }
+  void (async () => {
+    const value =
+      request.kind === "reply-init"
+        ? await runReplyInit(request)
+        : await runTranscriptRewrite(request);
+    send({ phase: "result", requestId: request.requestId, value });
+  })().catch((error) => {
+    send({
+      error: {
+        message: error instanceof Error ? error.message : String(error),
+        name: error instanceof Error ? error.name : typeof error,
+      },
+      phase: "error",
+      requestId: request.requestId,
+    });
+  });
 });
-await writeJsonFile(readyPath, {
-  currentEntry: snapshot.currentEntry,
-  revision: snapshot.revision,
-});
 
-await waitForFile(proceedPath);
-
-const committed = await commitReplySessionInitialization({
-  activeSessionKey: SESSION_KEY,
-  agentId: AGENT_ID,
-  expectedRevision: snapshot.revision,
-  sessionEntry: {
-    sessionId: "existing-session",
-    updatedAt: Number(preparedUpdatedAt),
-  },
-  sessionKey: SESSION_KEY,
-  snapshotEntry: snapshot.currentEntry,
-  storePath,
-});
-await writeJsonFile(resultPath, committed);
+process.on("disconnect", () => process.exit(0));
+send({ phase: "booted" });
 `;
 }
 
-function createTranscriptRewriteChildScript(sessionAccessorUrl: string): string {
-  return `
-const fs = await import("node:fs/promises");
-const { withTranscriptWriteLock } = await import(${JSON.stringify(sessionAccessorUrl)});
-
-const POLL_MS = ${POLL_MS};
-const WAIT_TIMEOUT_MS = ${WAIT_TIMEOUT_MS};
-const SESSION_KEY = ${JSON.stringify(SESSION_KEY)};
-const AGENT_ID = ${JSON.stringify(AGENT_ID)};
-
-async function waitForFile(filePath) {
-  const deadline = Date.now() + WAIT_TIMEOUT_MS;
-  while (Date.now() < deadline) {
-    try {
-      await fs.access(filePath);
-      return;
-    } catch {
-      await new Promise((resolve) => {
-        setTimeout(resolve, POLL_MS);
-      });
-    }
-  }
-  throw new Error(\`timeout waiting for \${filePath}\`);
+function isWorkerMessage(message: unknown): message is ConcurrencyWorkerMessage {
+  return typeof message === "object" && message !== null && "phase" in message;
 }
 
-async function writeJsonFile(filePath, value) {
-  const tempPath = filePath + "." + process.pid + ".tmp";
-  await fs.writeFile(tempPath, \`\${JSON.stringify(value, null, 2)}\\n\`, "utf8");
-  await fs.rename(tempPath, filePath);
-}
-
-const storePath = process.env.TRANSCRIPT_REWRITE_STORE_PATH;
-const sessionId = process.env.TRANSCRIPT_REWRITE_SESSION_ID;
-const readyPath = process.env.TRANSCRIPT_REWRITE_READY_PATH;
-const proceedPath = process.env.TRANSCRIPT_REWRITE_PROCEED_PATH;
-const resultPath = process.env.TRANSCRIPT_REWRITE_RESULT_PATH;
-const rewriteMode = process.env.TRANSCRIPT_REWRITE_MODE ?? "read-then-replace";
-if (!storePath || !sessionId || !readyPath || !proceedPath || !resultPath) {
-  throw new Error("transcript rewrite child env is incomplete");
-}
-
-let result;
-try {
-  await withTranscriptWriteLock(
-    {
-      agentId: AGENT_ID,
-      sessionId,
-      sessionKey: SESSION_KEY,
-      storePath,
-    },
-    async (transcript) => {
-      if (rewriteMode === "replace-twice") {
-        const firstReplacement = [
-          { type: "session", version: 3, id: sessionId },
-          {
-            type: "message",
-            id: "first-replacement",
-            parentId: null,
-            message: { role: "assistant", content: "first replacement" },
-          },
-        ];
-        await transcript.replaceEvents(firstReplacement);
-        await writeJsonFile(readyPath, { eventCount: firstReplacement.length });
-        await waitForFile(proceedPath);
-        await transcript.replaceEvents([
-          firstReplacement[0],
-          {
-            type: "message",
-            id: "first-replacement",
-            parentId: null,
-            message: { role: "assistant", content: "second replacement" },
-          },
-        ]);
+async function waitForWorkerBoot(child: ReturnType<typeof spawn>): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      cleanup();
+      reject(new Error("timeout waiting for concurrency worker startup"));
+    }, WAIT_TIMEOUT_MS);
+    const cleanup = () => {
+      clearTimeout(timeout);
+      child.off("error", onError);
+      child.off("exit", onExit);
+      child.off("message", onMessage);
+    };
+    const onError = (error: Error) => {
+      cleanup();
+      reject(error);
+    };
+    const onExit = (code: number | null, signal: NodeJS.Signals | null) => {
+      cleanup();
+      reject(
+        new Error(
+          `concurrency worker exited during startup code=${String(code)} signal=${String(signal)}`,
+        ),
+      );
+    };
+    const onMessage = (message: unknown) => {
+      if (!isWorkerMessage(message) || message.phase !== "booted") {
         return;
       }
-      const events = await transcript.readEvents();
-      await writeJsonFile(readyPath, { eventCount: events.length });
-      await waitForFile(proceedPath);
-      const rewrittenEvents = events.map((event) => {
-        if (
-          typeof event !== "object" ||
-          event === null ||
-          Array.isArray(event) ||
-          event.id !== "rewrite-target"
-        ) {
-          return event;
-        }
-        return {
-          ...event,
-          message: {
-            ...event.message,
-            content: "rewritten content",
-          },
-        };
-      });
-      await transcript.replaceEvents(rewrittenEvents);
-    },
-  );
-  result = { ok: true };
-} catch (error) {
-  result = {
-    ok: false,
-    name: error instanceof Error ? error.name : typeof error,
-    message: error instanceof Error ? error.message : String(error),
-  };
+      cleanup();
+      resolve();
+    };
+    child.once("error", onError);
+    child.once("exit", onExit);
+    child.on("message", onMessage);
+  });
 }
-await writeJsonFile(resultPath, result);
-`;
+
+async function getConcurrencyWorker(): Promise<ReturnType<typeof spawn>> {
+  if (concurrencyWorker) {
+    return concurrencyWorker;
+  }
+  const sessionAccessorUrl = pathToFileURL(
+    path.resolve("src/config/sessions/session-accessor.ts"),
+  ).href;
+  const child = spawn(
+    process.execPath,
+    [
+      "--import",
+      "tsx",
+      "--input-type=module",
+      "--eval",
+      createConcurrencyWorkerScript(sessionAccessorUrl),
+    ],
+    { stdio: ["ignore", "pipe", "pipe", "ipc"] },
+  );
+  try {
+    await waitForWorkerBoot(child);
+  } catch (error) {
+    child.kill();
+    throw error;
+  }
+  concurrencyWorker = child;
+  return child;
+}
+
+async function runConcurrencyScenario<TRequest extends ConcurrencyWorkerRequest>(
+  request: TRequest,
+  onReady: (value: ConcurrencyWorkerReady<TRequest>) => Promise<void> | void,
+): Promise<ConcurrencyWorkerResult<TRequest>> {
+  const child = await getConcurrencyWorker();
+  const requestId = ++nextRequestId;
+  return await new Promise<ConcurrencyWorkerResult<TRequest>>((resolve, reject) => {
+    let readyHandled = false;
+    const timeout = setTimeout(() => {
+      fail(new Error(`timeout waiting for concurrency worker ${request.kind}`));
+    }, WAIT_TIMEOUT_MS);
+    const cleanup = () => {
+      clearTimeout(timeout);
+      child.off("error", onError);
+      child.off("exit", onExit);
+      child.off("message", onMessage);
+    };
+    const fail = (error: Error) => {
+      cleanup();
+      reject(error);
+    };
+    const onError = (error: Error) => fail(error);
+    const onExit = (code: number | null, signal: NodeJS.Signals | null) => {
+      fail(new Error(`concurrency worker exited code=${String(code)} signal=${String(signal)}`));
+    };
+    const onMessage = (message: unknown) => {
+      if (
+        !isWorkerMessage(message) ||
+        !("requestId" in message) ||
+        message.requestId !== requestId
+      ) {
+        return;
+      }
+      if (message.phase === "error") {
+        const error = new Error(message.error.message);
+        error.name = message.error.name;
+        fail(error);
+        return;
+      }
+      if (message.phase === "ready" && !readyHandled) {
+        readyHandled = true;
+        void Promise.resolve(onReady(message.value as ConcurrencyWorkerReady<TRequest>)).then(
+          () => {
+            child.send({ kind: "proceed", requestId }, (error) => {
+              if (error) {
+                fail(error);
+              }
+            });
+          },
+          fail,
+        );
+        return;
+      }
+      if (message.phase === "result") {
+        cleanup();
+        resolve(message.value as ConcurrencyWorkerResult<TRequest>);
+      }
+    };
+    child.once("error", onError);
+    child.once("exit", onExit);
+    child.on("message", onMessage);
+    child.send({ ...request, requestId }, (error) => {
+      if (error) {
+        fail(error);
+      }
+    });
+  });
 }
 
 async function waitForChild(child: ReturnType<typeof spawn>, label: string): Promise<void> {
@@ -266,8 +407,8 @@ async function waitForChild(child: ReturnType<typeof spawn>, label: string): Pro
     childStderr += String(chunk);
   });
 
-  // The file handshake can complete immediately before this waiter attaches.
-  // Honor an already-observed exit or the test will wait forever for a spent event.
+  // The child can exit immediately before this waiter attaches. Honor an
+  // already-observed exit or the test will wait forever for a spent event.
   const childExit =
     child.exitCode !== null || child.signalCode !== null
       ? { code: child.exitCode, signal: child.signalCode }
@@ -285,6 +426,18 @@ async function waitForChild(child: ReturnType<typeof spawn>, label: string): Pro
 }
 
 describe("session accessor cross-process concurrency", () => {
+  afterAll(async () => {
+    const child = concurrencyWorker;
+    concurrencyWorker = undefined;
+    if (!child) {
+      return;
+    }
+    if (child.exitCode === null && child.signalCode === null) {
+      child.send({ kind: "shutdown" });
+    }
+    await waitForChild(child, "concurrency worker shutdown");
+  });
+
   it("observes a child that exited before the waiter attached", async () => {
     const child = spawn(process.execPath, ["--eval", ""], {
       stdio: ["ignore", "pipe", "pipe"],
@@ -299,13 +452,7 @@ describe("session accessor cross-process concurrency", () => {
 
   it("commits after same-session activity from another process", async () => {
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-reply-init-"));
-    const sessionAccessorUrl = pathToFileURL(
-      path.resolve("src/config/sessions/session-accessor.ts"),
-    ).href;
     const storePath = path.join(tempDir, "sessions.json");
-    const readyPath = path.join(tempDir, "snapshot-ready.json");
-    const proceedPath = path.join(tempDir, "proceed");
-    const resultPath = path.join(tempDir, "result.json");
     try {
       await upsertSessionEntry(
         { sessionKey: SESSION_KEY, storePath },
@@ -325,40 +472,21 @@ describe("session accessor cross-process concurrency", () => {
       const activeTurnUpdatedAt = initialUpdatedAt + 20;
       const preparedUpdatedAt = initialUpdatedAt + 30;
 
-      const child = spawn(
-        process.execPath,
-        [
-          "--import",
-          "tsx",
-          "--input-type=module",
-          "--eval",
-          createReplyInitChildScript(sessionAccessorUrl),
-        ],
+      const result = await runConcurrencyScenario(
         {
-          env: {
-            ...process.env,
-            REPLY_INIT_PREPARED_UPDATED_AT: String(preparedUpdatedAt),
-            REPLY_INIT_PROCEED_PATH: proceedPath,
-            REPLY_INIT_READY_PATH: readyPath,
-            REPLY_INIT_RESULT_PATH: resultPath,
-            REPLY_INIT_STORE_PATH: storePath,
-          },
-          stdio: ["ignore", "pipe", "pipe"],
+          kind: "reply-init",
+          preparedUpdatedAt,
+          storePath,
+        },
+        async (snapshot) => {
+          expect(snapshot.revision).toBe(JSON.stringify({ sessionId: "existing-session" }));
+          await updateSessionEntry(
+            { sessionKey: SESSION_KEY, storePath },
+            () => ({ updatedAt: activeTurnUpdatedAt }),
+            { skipMaintenance: true },
+          );
         },
       );
-      await waitForFile(readyPath);
-      const snapshot = await readJsonFile<{ currentEntry?: unknown; revision: string }>(readyPath);
-      expect(snapshot.revision).toBe(JSON.stringify({ sessionId: "existing-session" }));
-
-      await updateSessionEntry(
-        { sessionKey: SESSION_KEY, storePath },
-        () => ({ updatedAt: activeTurnUpdatedAt }),
-        { skipMaintenance: true },
-      );
-      await fs.writeFile(proceedPath, "go\n", "utf8");
-      await waitForChild(child, "reply initialization");
-
-      const result = await readJsonFile<ChildResult>(resultPath);
       expect(result).toMatchObject({
         ok: true,
         sessionEntry: {
@@ -379,13 +507,7 @@ describe("session accessor cross-process concurrency", () => {
 
   it("rejects a transcript rewrite after another process commits an append", async () => {
     const tempDir = tempDirs.make("openclaw-transcript-rewrite-");
-    const sessionAccessorUrl = pathToFileURL(
-      path.resolve("src/config/sessions/session-accessor.ts"),
-    ).href;
     const storePath = path.join(tempDir, "sessions.json");
-    const readyPath = path.join(tempDir, "rewrite-ready.json");
-    const proceedPath = path.join(tempDir, "proceed");
-    const resultPath = path.join(tempDir, "result.json");
     const sessionId = "cross-process-transcript";
     const scope = {
       agentId: AGENT_ID,
@@ -393,8 +515,6 @@ describe("session accessor cross-process concurrency", () => {
       sessionKey: SESSION_KEY,
       storePath,
     };
-    let child: ReturnType<typeof spawn> | undefined;
-
     try {
       await upsertSessionEntry(scope, {
         sessionId,
@@ -410,42 +530,25 @@ describe("session accessor cross-process concurrency", () => {
         },
       ]);
 
-      child = spawn(
-        process.execPath,
-        [
-          "--import",
-          "tsx",
-          "--input-type=module",
-          "--eval",
-          createTranscriptRewriteChildScript(sessionAccessorUrl),
-        ],
+      const result = await runConcurrencyScenario(
         {
-          env: {
-            ...process.env,
-            TRANSCRIPT_REWRITE_PROCEED_PATH: proceedPath,
-            TRANSCRIPT_REWRITE_READY_PATH: readyPath,
-            TRANSCRIPT_REWRITE_RESULT_PATH: resultPath,
-            TRANSCRIPT_REWRITE_SESSION_ID: sessionId,
-            TRANSCRIPT_REWRITE_STORE_PATH: storePath,
-          },
-          stdio: ["ignore", "pipe", "pipe"],
+          kind: "transcript-rewrite",
+          rewriteMode: "read-then-replace",
+          sessionId,
+          storePath,
+        },
+        async (ready) => {
+          expect(ready).toEqual({ eventCount: 2 });
+          await appendTranscriptMessage(scope, {
+            cwd: tempDir,
+            message: {
+              role: "user",
+              content: "committed concurrent append",
+              timestamp: Date.now(),
+            },
+          });
         },
       );
-      await waitForFile(readyPath);
-      expect(await readJsonFile<{ eventCount: number }>(readyPath)).toEqual({ eventCount: 2 });
-
-      await appendTranscriptMessage(scope, {
-        cwd: tempDir,
-        message: {
-          role: "user",
-          content: "committed concurrent append",
-          timestamp: Date.now(),
-        },
-      });
-      await fs.writeFile(proceedPath, "go\n", "utf8");
-      await waitForChild(child, "transcript rewrite");
-
-      const result = await readJsonFile<TranscriptRewriteChildResult>(resultPath);
       expect(result).toMatchObject({
         ok: false,
         name: "SqliteTranscriptMutationConflictError",
@@ -468,9 +571,6 @@ describe("session accessor cross-process concurrency", () => {
         }),
       ]);
     } finally {
-      if (child?.exitCode === null) {
-        child.kill();
-      }
       await fs.rm(tempDir, { recursive: true, force: true });
     }
   }, 15_000);
@@ -509,13 +609,7 @@ describe("session accessor cross-process concurrency", () => {
 
   it("guards a second replace after replacing without a prior read", async () => {
     const tempDir = tempDirs.make("openclaw-transcript-double-replace-");
-    const sessionAccessorUrl = pathToFileURL(
-      path.resolve("src/config/sessions/session-accessor.ts"),
-    ).href;
     const storePath = path.join(tempDir, "sessions.json");
-    const readyPath = path.join(tempDir, "rewrite-ready.json");
-    const proceedPath = path.join(tempDir, "rewrite-proceed");
-    const resultPath = path.join(tempDir, "rewrite-result.json");
     const sessionId = "double-replace-without-read";
     const scope = {
       agentId: AGENT_ID,
@@ -532,44 +626,26 @@ describe("session accessor cross-process concurrency", () => {
         message: { role: "assistant", content: "first replacement" },
       },
     ];
-    let child: ReturnType<typeof spawn> | undefined;
-
     try {
       await upsertSessionEntry(scope, { sessionId, updatedAt: Date.now() });
-      child = spawn(
-        process.execPath,
-        [
-          "--import",
-          "tsx",
-          "--input-type=module",
-          "--eval",
-          createTranscriptRewriteChildScript(sessionAccessorUrl),
-        ],
+      const result = await runConcurrencyScenario(
         {
-          env: {
-            ...process.env,
-            TRANSCRIPT_REWRITE_MODE: "replace-twice",
-            TRANSCRIPT_REWRITE_PROCEED_PATH: proceedPath,
-            TRANSCRIPT_REWRITE_READY_PATH: readyPath,
-            TRANSCRIPT_REWRITE_RESULT_PATH: resultPath,
-            TRANSCRIPT_REWRITE_SESSION_ID: sessionId,
-            TRANSCRIPT_REWRITE_STORE_PATH: storePath,
-          },
-          stdio: ["ignore", "pipe", "pipe"],
+          kind: "transcript-rewrite",
+          rewriteMode: "replace-twice",
+          sessionId,
+          storePath,
+        },
+        async (ready) => {
+          expect(ready).toEqual({ eventCount: 2 });
+          await appendTranscriptMessage(scope, {
+            cwd: tempDir,
+            eventId: "concurrent-append",
+            message: { role: "user", content: "concurrent append" },
+            parentId: "first-replacement",
+          });
         },
       );
-      await waitForFile(readyPath);
-      expect(await readJsonFile<{ eventCount: number }>(readyPath)).toEqual({ eventCount: 2 });
-      await appendTranscriptMessage(scope, {
-        cwd: tempDir,
-        eventId: "concurrent-append",
-        message: { role: "user", content: "concurrent append" },
-        parentId: "first-replacement",
-      });
-      await fs.writeFile(proceedPath, "go\n", "utf8");
-      await waitForChild(child, "double transcript rewrite");
-
-      expect(await readJsonFile<TranscriptRewriteChildResult>(resultPath)).toMatchObject({
+      expect(result).toMatchObject({
         ok: false,
         name: "SqliteTranscriptMutationConflictError",
         message: `SQLite transcript changed while preparing rewrite for ${sessionId}`,
@@ -587,9 +663,6 @@ describe("session accessor cross-process concurrency", () => {
         }),
       ]);
     } finally {
-      if (child?.exitCode === null) {
-        child.kill();
-      }
       await fs.rm(tempDir, { recursive: true, force: true });
     }
   }, 15_000);


### PR DESCRIPTION
## What Problem This Solves

The cross-process session concurrency suite repeatedly booted TypeScript child processes. Three loader/module startups dominated this six-test file, adding avoidable CI latency and memory pressure.

## Why This Change Was Made

Reuse one child process for the three concurrency scenarios and coordinate each isolated store through correlated IPC barriers. The tests retain a real OS-process boundary while paying the TypeScript/module startup cost once.

## User Impact

No user-visible behavior changes. Maintainers get faster, lighter CI coverage for session and transcript concurrency.

## Evidence

- Fresh Blacksmith Testbox baseline: Vitest 5.44s, wall 7.56s, peak RSS 872,992 KB.
- Fresh exact-head Testbox `tbx_01kxfjjn7y1hqmdwfzfx9qbf8a`: Vitest 4.53s, wall 6.85s, peak RSS 839,996 KB; 6/6 tests passed.
- Warm exact-head rerun: Vitest 1.72s, wall 3.87s, peak RSS 597,472 KB.
- Exact-head `check:changed` passed formatting, core-test types, and type-aware lint.
- Autoreview clean: no accepted or actionable findings.
