### PR TITLE
refactor(matrix): use native media types

### DIFF
--- a/extensions/matrix/src/matrix/monitor/media.ts
+++ b/extensions/matrix/src/matrix/monitor/media.ts
@@ -1,22 +1,7 @@
 // Matrix plugin module implements media behavior.
 import { getMatrixRuntime } from "../../runtime.js";
 import { MatrixMediaSizeLimitError, isMatrixMediaSizeLimitError } from "../media-errors.js";
-import type { MatrixClient } from "../sdk.js";
-
-// Type for encrypted file info
-type EncryptedFile = {
-  url: string;
-  key: {
-    kty: string;
-    key_ops: string[];
-    alg: string;
-    k: string;
-    ext: boolean;
-  };
-  iv: string;
-  hashes: Record<string, string>;
-  v: string;
-};
+import type { EncryptedFile, MatrixClient } from "../sdk.js";
 
 const MATRIX_MEDIA_DOWNLOAD_IDLE_TIMEOUT_MS = 30_000;
 
@@ -52,13 +37,10 @@ async function fetchEncryptedMediaBuffer(params: {
     throw new Error("Cannot decrypt media: crypto not enabled");
   }
 
-  const decrypted = await params.client.crypto.decryptMedia(
-    params.file as Parameters<typeof params.client.crypto.decryptMedia>[0],
-    {
-      maxBytes: params.maxBytes,
-      readIdleTimeoutMs: MATRIX_MEDIA_DOWNLOAD_IDLE_TIMEOUT_MS,
-    },
-  );
+  const decrypted = await params.client.crypto.decryptMedia(params.file, {
+    maxBytes: params.maxBytes,
+    readIdleTimeoutMs: MATRIX_MEDIA_DOWNLOAD_IDLE_TIMEOUT_MS,
+  });
 
   if (decrypted.byteLength > params.maxBytes) {
     throw new MatrixMediaSizeLimitError();

--- a/extensions/matrix/src/matrix/sdk/types.ts
+++ b/extensions/matrix/src/matrix/sdk/types.ts
@@ -1,4 +1,5 @@
 // Matrix type declarations define plugin contracts.
+import type * as MatrixSdkTypes from "matrix-js-sdk/lib/types.js";
 import type { MatrixSyncState } from "../sync-state.js";
 import type {
   MatrixVerificationRequestLike,
@@ -39,46 +40,11 @@ export type MatrixClientEventMap = {
   "verification.summary": [summary: MatrixVerificationSummary];
 };
 
-export type EncryptedFile = {
-  url: string;
-  key: {
-    kty: string;
-    key_ops: string[];
-    alg: string;
-    k: string;
-    ext: boolean;
-  };
-  iv: string;
-  hashes: Record<string, string>;
-  v: string;
-};
-
-export type FileWithThumbnailInfo = {
-  size?: number;
-  mimetype?: string;
-  thumbnail_url?: string;
-  thumbnail_file?: EncryptedFile;
-  thumbnail_info?: {
-    w?: number;
-    h?: number;
-    mimetype?: string;
-    size?: number;
-  };
-};
-
-export type DimensionalFileInfo = FileWithThumbnailInfo & {
-  w?: number;
-  h?: number;
-};
-
-export type TimedFileInfo = FileWithThumbnailInfo & {
-  duration?: number;
-};
-
-export type VideoFileInfo = DimensionalFileInfo &
-  TimedFileInfo & {
-    duration?: number;
-  };
+export type EncryptedFile = MatrixSdkTypes.EncryptedFile;
+export type FileWithThumbnailInfo = MatrixSdkTypes.FileInfo;
+export type DimensionalFileInfo = MatrixSdkTypes.ImageInfo;
+export type TimedFileInfo = MatrixSdkTypes.FileInfo & MatrixSdkTypes.AudioInfo;
+export type VideoFileInfo = MatrixSdkTypes.VideoInfo;
 
 export type MessageEventContent = {
   msgtype?: string;
@@ -88,7 +54,7 @@ export type MessageEventContent = {
   filename?: string;
   url?: string;
   file?: EncryptedFile;
-  info?: Record<string, unknown>;
+  info?: MatrixSdkTypes.MediaEventInfo | Record<string, unknown>;
   "m.relates_to"?: Record<string, unknown>;
   "m.new_content"?: unknown;
   "m.mentions"?: {


### PR DESCRIPTION
## What Problem This Solves

The Matrix plugin duplicated media metadata types already published by its pinned SDK dependency, including a second encrypted-file declaration in the download path.

## Why This Change Was Made

`matrix-js-sdk@41.9.0-rc.0` exports the exact `EncryptedFile`, `FileInfo`, `ImageInfo`, `AudioInfo`, `VideoInfo`, and `MediaEventInfo` contracts through `matrix-js-sdk/lib/types.js`. Reusing them removes local declarations and the decrypt-media assertion while preserving OpenClaw's thumbnail-capable audio shape.

## User Impact

No runtime behavior change. Matrix media send/download types now track the installed SDK contract directly, with 52 fewer source lines.

## Evidence

- Inspected the exact installed Matrix SDK source and declarations for every adopted media type.
- Blacksmith Testbox `tbx_01kxfjg1nbqq9rxcq4ktfkc6b9`: `extensions/matrix/src/matrix/send.test.ts` and `extensions/matrix/src/matrix/monitor/media.test.ts` passed 48/48.
- Full changed-surface gate passed, including Matrix production/test typechecks, targeted lint/format, SDK baseline, database/media/runtime guards, and import-cycle check.
- Testbox run: https://github.com/openclaw/openclaw/actions/runs/29309340881
- Fresh exact-commit autoreview: clean, confidence 0.98.
- `git diff --check`: passed.
- Net change: 64 deletions, 12 additions.
- Hosted PR CI intentionally not awaited per maintainer instruction.
