### PR TITLE
refactor(agents): extract attempt execution phases

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt-execution-phase.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-execution-phase.test.ts
@@ -1,0 +1,224 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  prepareStreamRuntime: vi.fn(),
+  runSettledPhase: vi.fn(),
+}));
+
+vi.mock("./attempt-stream-runtime-prepare.js", () => ({
+  prepareEmbeddedAttemptStreamRuntime: mocks.prepareStreamRuntime,
+}));
+vi.mock("./attempt-execution-settle.js", () => ({
+  runEmbeddedAttemptSettledPhase: mocks.runSettledPhase,
+}));
+
+import { runEmbeddedAttemptExecutionPhase } from "./attempt-execution-phase.js";
+
+type ExecutionInput = Parameters<typeof runEmbeddedAttemptExecutionPhase>[0];
+
+function createFixture() {
+  const order: string[] = [];
+  const activeSession = { sessionId: "active-session" };
+  const sessionManager = { kind: "session-manager" };
+  const abortActiveSession = vi.fn(async () => undefined);
+  const trackPromptSettlePromise = vi.fn((promise: Promise<void>) => promise);
+  const toolSearchCatalogExecutor = vi.fn();
+  const result = { messages: [] };
+  const preparedStreamRuntime = { stream: { queueHandle: { kind: "embedded" } } };
+  const state = {
+    aborted: false,
+    beforeAgentRunBlocked: false,
+    beforeAgentRunBlockedBy: undefined,
+    cleanupYieldAborted: false,
+    externalAbort: false,
+    idleTimedOut: false,
+    promptError: null,
+    timedOut: false,
+    timedOutByRunBudget: false,
+    timedOutDuringCompaction: false,
+    timedOutDuringToolExecution: false,
+    trajectoryEndRecorded: false,
+  };
+  const prepStages = { mark: vi.fn() };
+  const emitPrepStageSummary = vi.fn();
+  const setToolSearchCatalogExecutor = vi.fn();
+  const replaySafeTool = { name: "read" };
+  const sessionRuntime = {
+    agentSession: {
+      activeSession,
+      allCustomTools: [{ name: "custom" }],
+      builtinToolNames: new Set(["read"]),
+      clientToolCallSlots: [],
+      clientToolLoopDetection: {},
+      hasDeliveredSourceReply: vi.fn(() => false),
+      hookRunner: {},
+      markSourceReplyDelivered: vi.fn(),
+      replaySafeToolNames: new Set(["read"]),
+      replaySafeTools: new Set([replaySafeTool]),
+      setActiveSessionSystemPrompt: vi.fn(),
+      settingsManager: {},
+    },
+    anthropicPayloadLogger: {},
+    boundary: { orphanRepair: { removeLeaf: true } },
+    cacheTrace: {},
+    isOpenAIResponsesApi: true,
+    sessionManager,
+    settleTracker: { abortActiveSession, trackPromptSettlePromise },
+    state: { systemPromptText: "system prompt" },
+    transcriptPolicy: { repairToolUseResultPairing: true },
+    transport: {
+      effectiveAgentTransport: "sse",
+      providerTextTransforms: { input: [] },
+    },
+  };
+  const input = {
+    attempt: { runId: "run-1", sessionId: "session-1" },
+    activeContextEngine: { info: { id: "engine" } },
+    agentDir: "/agent",
+    isRawModelRun: false,
+    resolveActiveContextEnginePluginId: vi.fn(),
+    runAbortController: new AbortController(),
+    externalAbortController: {},
+    abortState: {},
+    prepared: {
+      bootstrap: {},
+      bundleTools: {},
+      sessionRuntime,
+      systemPrompt: { runtimeChannel: "telegram" },
+      toolBase: { toolSearchTargetTranscriptProjections: new Map() },
+      toolCatalog: {
+        toolSearchRunPlan: {
+          capabilityToolNames: new Set(["read"]),
+          liveAllowedToolNames: new Set(["read"]),
+          replayAllowedToolNames: new Set(["read"]),
+        },
+      },
+    },
+    sessionLock: {
+      compactionTimeoutMs: 1_000,
+      ownedTranscriptWriteContext: {},
+      sessionLockController: {},
+      withOwnedSessionWriteLock: vi.fn(),
+    },
+    setup: {
+      effectiveFsWorkspaceOnly: false,
+      effectiveWorkspace: "/workspace",
+      emitPrepStageSummary,
+      prepStages,
+      sandbox: null,
+      sandboxSessionKey: "sandbox-1",
+      sessionAgentId: "main",
+    },
+    diagnostics: { diagnosticTrace: {}, runTrace: {} },
+    state,
+    lifecycle: {
+      readYieldState: () => ({
+        yieldAbortSettled: null,
+        yieldDetected: true,
+        yieldMessage: "yield",
+      }),
+      setToolSearchCatalogExecutor,
+    },
+  } as unknown as ExecutionInput;
+
+  mocks.prepareStreamRuntime.mockImplementation(async (streamInput) => {
+    order.push("stream-runtime");
+    streamInput.lifecycle.markStreamReady();
+    streamInput.lifecycle.markIdleTimedOut();
+    streamInput.lifecycle.markExternalAbort();
+    streamInput.lifecycle.markTimedOutDuringCompaction();
+    streamInput.lifecycle.markTimedOutByRunBudget();
+    streamInput.lifecycle.setToolSearchCatalogExecutor(toolSearchCatalogExecutor);
+    return preparedStreamRuntime;
+  });
+  mocks.runSettledPhase.mockImplementation(async (settledInput) => {
+    order.push("settled-phase");
+    expect(settledInput.getRepairedRejectedThinkingReplay()).toBe(false);
+    const streamInput = mocks.prepareStreamRuntime.mock.calls[0]?.[0];
+    streamInput.lifecycle.markRejectedThinkingReplayRepaired();
+    expect(settledInput.getRepairedRejectedThinkingReplay()).toBe(true);
+    return result;
+  });
+
+  return {
+    abortActiveSession,
+    activeSession,
+    emitPrepStageSummary,
+    input,
+    order,
+    prepStages,
+    preparedStreamRuntime,
+    replaySafeTool,
+    result,
+    sessionManager,
+    setToolSearchCatalogExecutor,
+    state,
+    toolSearchCatalogExecutor,
+    trackPromptSettlePromise,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("runEmbeddedAttemptExecutionPhase", () => {
+  it("prepares the guarded stream and delegates settlement with live lifecycle state", async () => {
+    const fixture = createFixture();
+
+    const result = await runEmbeddedAttemptExecutionPhase(fixture.input);
+
+    expect(result).toBe(fixture.result);
+    expect(fixture.order).toEqual(["stream-runtime", "settled-phase"]);
+    expect(fixture.state).toEqual(
+      expect.objectContaining({
+        externalAbort: true,
+        idleTimedOut: true,
+        timedOutByRunBudget: true,
+        timedOutDuringCompaction: true,
+      }),
+    );
+    expect(fixture.prepStages.mark).toHaveBeenCalledWith("stream-setup");
+    expect(fixture.emitPrepStageSummary).toHaveBeenCalledWith("stream-ready");
+    expect(fixture.setToolSearchCatalogExecutor).toHaveBeenCalledWith(
+      fixture.toolSearchCatalogExecutor,
+    );
+    expect(mocks.runSettledPhase).toHaveBeenCalledWith(
+      expect.objectContaining({
+        getRepairedRejectedThinkingReplay: expect.any(Function),
+        preparedStreamRuntime: fixture.preparedStreamRuntime,
+      }),
+    );
+    const settledInput = mocks.runSettledPhase.mock.calls[0]?.[0];
+    expect(settledInput.getRepairedRejectedThinkingReplay()).toBe(true);
+
+    const streamInput = mocks.prepareStreamRuntime.mock.calls[0]?.[0];
+    expect(streamInput).toEqual(
+      expect.objectContaining({
+        activeSession: fixture.activeSession,
+        sessionManager: fixture.sessionManager,
+        abortActiveSession: fixture.abortActiveSession,
+        trackPromptSettlePromise: fixture.trackPromptSettlePromise,
+      }),
+    );
+    expect(streamInput.lifecycle.isYieldDetected()).toBe(true);
+    expect(streamInput.lifecycle.readRunState()).toEqual({
+      aborted: false,
+      promptError: null,
+      timedOut: false,
+      yieldDetected: true,
+    });
+    expect(streamInput.stream.isReplaySafeTool(fixture.replaySafeTool)).toBe(true);
+  });
+
+  it("does not enter settlement when stream preparation fails", async () => {
+    const fixture = createFixture();
+    mocks.prepareStreamRuntime.mockRejectedValueOnce(new Error("stream setup failed"));
+
+    await expect(runEmbeddedAttemptExecutionPhase(fixture.input)).rejects.toThrow(
+      "stream setup failed",
+    );
+
+    expect(mocks.runSettledPhase).not.toHaveBeenCalled();
+  });
+});

--- a/src/agents/embedded-agent-runner/run/attempt-execution-phase.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-execution-phase.ts
@@ -1,0 +1,135 @@
+/** Prepares the guarded stream runtime before prompt execution and settlement. */
+import { runEmbeddedAttemptSettledPhase } from "./attempt-execution-settle.js";
+import type { EmbeddedAttemptExecutionPhaseInput } from "./attempt-execution-types.js";
+import { prepareEmbeddedAttemptStreamRuntime } from "./attempt-stream-runtime-prepare.js";
+import type { EmbeddedRunAttemptResult } from "./types.js";
+
+export async function runEmbeddedAttemptExecutionPhase(
+  input: EmbeddedAttemptExecutionPhaseInput,
+): Promise<EmbeddedRunAttemptResult> {
+  const { attempt, state } = input;
+  const { sessionRuntime, systemPrompt, toolBase, toolCatalog } = input.prepared;
+  const {
+    agentSession: {
+      activeSession,
+      allCustomTools,
+      builtinToolNames,
+      clientToolCallSlots,
+      clientToolLoopDetection,
+      hasDeliveredSourceReply,
+      hookRunner,
+      markSourceReplyDelivered,
+      replaySafeToolNames,
+      replaySafeTools,
+      setActiveSessionSystemPrompt,
+      settingsManager,
+    },
+    anthropicPayloadLogger,
+    cacheTrace,
+    isOpenAIResponsesApi,
+    sessionManager,
+    settleTracker: { abortActiveSession, trackPromptSettlePromise },
+    state: sessionRuntimeState,
+    transcriptPolicy,
+    transport: { effectiveAgentTransport, providerTextTransforms },
+  } = sessionRuntime;
+  const { orphanRepair } = sessionRuntime.boundary;
+  const { capabilityToolNames, liveAllowedToolNames, replayAllowedToolNames } =
+    toolCatalog.toolSearchRunPlan;
+  const { runtimeChannel } = systemPrompt;
+  const { toolSearchTargetTranscriptProjections } = toolBase;
+  const hookAgentId = input.setup.sessionAgentId;
+  let repairedRejectedThinkingReplay = false;
+
+  const preparedStreamRuntime = await prepareEmbeddedAttemptStreamRuntime({
+    attempt,
+    activeSession,
+    sessionManager,
+    sessionLockController: input.sessionLock.sessionLockController,
+    ownedTranscriptWriteContext: input.sessionLock.ownedTranscriptWriteContext,
+    runAbortController: input.runAbortController,
+    externalAbortController: input.externalAbortController,
+    abortActiveSession,
+    abortState: input.abortState,
+    trackPromptSettlePromise,
+    compactionTimeoutMs: input.sessionLock.compactionTimeoutMs,
+    guards: {
+      sessionAgentId: input.setup.sessionAgentId,
+      cacheTrace,
+      allCustomTools,
+      systemPromptText: sessionRuntimeState.systemPromptText,
+      transcriptPolicy,
+      isOpenAIResponsesApi,
+      replayAllowedToolNames,
+      liveAllowedToolNames,
+      clientToolLoopDetection,
+      anthropicPayloadLogger,
+      effectiveAgentTransport,
+      providerTextTransforms,
+      runTrace: input.diagnostics.runTrace,
+    },
+    history: {
+      ...(input.activeContextEngine ? { activeContextEngine: input.activeContextEngine } : {}),
+      cacheTrace,
+      capabilityToolNames,
+      effectiveWorkspace: input.setup.effectiveWorkspace,
+      isOpenAIResponsesApi,
+      isRawModelRun: input.isRawModelRun,
+      ...(orphanRepair ? { orphanRepair } : {}),
+      replayAllowedToolNames,
+      sessionAgentId: input.setup.sessionAgentId,
+      settingsManager,
+      systemPromptText: sessionRuntimeState.systemPromptText,
+      transcriptPolicy,
+      setActiveSessionSystemPrompt,
+    },
+    stream: {
+      runtimeChannel,
+      hookRunner,
+      hookAgentId,
+      diagnosticTrace: input.diagnostics.diagnosticTrace,
+      clientToolCallSlots,
+      toolSearchTargetTranscriptProjections,
+      isReplaySafeTool: (tool) => replaySafeTools.has(tool as never),
+      hasDeliveredSourceReply,
+      markSourceReplyDelivered,
+      sandboxSessionKey: input.setup.sandboxSessionKey,
+      builtinToolNames,
+      replaySafeToolNames,
+    },
+    lifecycle: {
+      isYieldDetected: () => input.lifecycle.readYieldState().yieldDetected,
+      markRejectedThinkingReplayRepaired: () => {
+        repairedRejectedThinkingReplay = true;
+      },
+      markStreamReady: () => {
+        input.setup.prepStages.mark("stream-setup");
+        input.setup.emitPrepStageSummary("stream-ready");
+      },
+      markIdleTimedOut: () => {
+        state.idleTimedOut = true;
+      },
+      markExternalAbort: () => {
+        state.externalAbort = true;
+      },
+      markTimedOutDuringCompaction: () => {
+        state.timedOutDuringCompaction = true;
+      },
+      markTimedOutByRunBudget: () => {
+        state.timedOutByRunBudget = true;
+      },
+      readRunState: () => ({
+        aborted: state.aborted,
+        promptError: state.promptError,
+        timedOut: state.timedOut,
+        yieldDetected: input.lifecycle.readYieldState().yieldDetected,
+      }),
+      setToolSearchCatalogExecutor: input.lifecycle.setToolSearchCatalogExecutor,
+    },
+  });
+  return await runEmbeddedAttemptSettledPhase({
+    ...input,
+    preparedStreamRuntime,
+    getRepairedRejectedThinkingReplay: () => repairedRejectedThinkingReplay,
+  });
+}

--- a/src/agents/embedded-agent-runner/run/attempt-execution-settle.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-execution-settle.test.ts
@@ -1,0 +1,315 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  clearActiveEmbeddedRun: vi.fn(),
+  completeResult: vi.fn(),
+  finalizeStream: vi.fn(),
+  logDebug: vi.fn(),
+  logError: vi.fn(),
+  runPrompt: vi.fn(),
+}));
+
+vi.mock("../logger.js", () => ({
+  log: { debug: mocks.logDebug, error: mocks.logError },
+}));
+vi.mock("../runs.js", () => ({ clearActiveEmbeddedRun: mocks.clearActiveEmbeddedRun }));
+vi.mock("./attempt-prompt-phase.js", () => ({
+  runEmbeddedAttemptPromptPhase: mocks.runPrompt,
+}));
+vi.mock("./attempt-result.js", () => ({
+  completeEmbeddedAttemptResult: mocks.completeResult,
+}));
+vi.mock("./attempt-stream-finalize.js", () => ({
+  finalizeEmbeddedAttemptStreamPhase: mocks.finalizeStream,
+}));
+
+import { runEmbeddedAttemptSettledPhase } from "./attempt-execution-settle.js";
+
+type SettledInput = Parameters<typeof runEmbeddedAttemptSettledPhase>[0];
+
+function createFixture() {
+  const order: string[] = [];
+  const queueHandle = { kind: "embedded", runId: "run-1" };
+  const unsubscribe = vi.fn(() => order.push("unsubscribe"));
+  const waitForPendingEvents = vi.fn(async () => undefined);
+  const subscription = { unsubscribe, waitForPendingEvents };
+  const detachBackend = vi.fn(() => order.push("detach-backend"));
+  const clearTimers = vi.fn(() => order.push("clear-timers"));
+  const removeAbortSignalListener = vi.fn(() => order.push("remove-abort-listener"));
+  const getBeforeAgentFinalizeRevisionReason = vi.fn(() => "revision");
+  const promptActiveSession = vi.fn(async () => undefined);
+  const activeSession = { sessionId: "active-session" };
+  const sessionManager = { kind: "session-manager" };
+  const hookRunner = { kind: "hook-runner" };
+  const cacheTrace = { kind: "cache-trace" };
+  const trajectoryRecorder = { kind: "trajectory" };
+  const toolResultPromptProjectionState = { kind: "tool-result-projection" };
+  const sessionPromptState = { toolResults: toolResultPromptProjectionState };
+  const sessionRuntimeState = {
+    prePromptMessageCount: 2,
+    promptCache: undefined,
+    systemPromptText: "system prompt",
+  };
+  const state = {
+    aborted: false,
+    beforeAgentRunBlocked: false,
+    beforeAgentRunBlockedBy: undefined,
+    cleanupYieldAborted: false,
+    externalAbort: false,
+    idleTimedOut: false,
+    promptError: null,
+    timedOut: false,
+    timedOutByRunBudget: false,
+    timedOutDuringCompaction: false,
+    timedOutDuringToolExecution: false,
+    trajectoryEndRecorded: false,
+  };
+  const result = { messages: [{ role: "assistant", content: "done" }] };
+  const preparedStreamRuntime = {
+    abortable: (promise: Promise<unknown>) => promise,
+    cache: {
+      observabilityEnabled: true,
+      promptToolNames: new Set(["read"]),
+    },
+    history: {
+      contextEnginePromptAuthority: "assembled",
+      contextEngineAssemblySucceeded: true,
+      unwindowedContextEngineMessagesForPrecheck: [{ role: "user", content: "history" }],
+    },
+    isProbeSession: false,
+    onBlockReplyFlush: vi.fn(),
+    promptActiveSession,
+    stream: {
+      subscription,
+      queueHandle,
+      stopAcceptingSteerMessages: vi.fn(),
+      getBeforeAgentFinalizeRevisionReason,
+    },
+    timeout: {
+      getRunAbortDeadlineAtMs: vi.fn(() => 123),
+      clearTimers,
+      removeAbortSignalListener,
+    },
+  };
+  const sessionRuntime = {
+    agentSession: {
+      activeSession,
+      clientToolCallSlots: [],
+      hasDeliveredSourceReply: vi.fn(() => true),
+      hookRunner,
+      setActiveSessionSystemPrompt: vi.fn(),
+      settingsManager: { getCompactionReserveTokens: vi.fn(() => 1_000) },
+    },
+    anthropicPayloadLogger: {},
+    boundary: {
+      boundaryTimezone: "UTC",
+      includeBoundaryTimestamp: true,
+      orphanRepair: undefined,
+      setCurrentUserTimestampOverride: vi.fn(),
+    },
+    cacheTrace,
+    contextGuards: {
+      getAfterTurnCheckpoint: vi.fn(() => 2),
+      takePendingMidTurnPrecheckRequest: vi.fn(() => null),
+    },
+    preparedUserTurnMessage: { timestamp: 100 },
+    sessionManager,
+    sessionPromptState,
+    state: sessionRuntimeState,
+    toolResultPromptProjectionState,
+    trajectoryRecorder,
+    transport: {
+      effectiveAgentTransport: "sse",
+      effectiveExtraParams: {},
+      effectivePromptCacheRetention: "long",
+      streamStrategy: "provider",
+    },
+  };
+  const input = {
+    attempt: {
+      replyOperation: { detachBackend },
+      runId: "run-1",
+      sessionFile: "/tmp/session.jsonl",
+      sessionId: "session-1",
+      sessionKey: "agent:main",
+    },
+    agentDir: "/agent",
+    isRawModelRun: false,
+    resolveActiveContextEnginePluginId: vi.fn(),
+    runAbortController: new AbortController(),
+    prepared: {
+      bootstrap: {
+        bootstrapPromptWarning: undefined,
+        shouldRecordCompletedBootstrapTurn: false,
+      },
+      bundleTools: {
+        tools: [{ name: "read" }],
+        uncompactedEffectiveTools: [{ name: "read" }],
+      },
+      sessionRuntime,
+      systemPrompt: {
+        runtimeInfo: { model: { id: "model" } },
+        systemPromptReport: { chars: 13 },
+      },
+      toolBase: { toolSearchTargetTranscriptProjections: new Map() },
+      toolCatalog: {
+        effectiveTools: [{ name: "read" }],
+        emptyExplicitToolAllowlistError: undefined,
+        toolSearch: { compacted: false },
+      },
+    },
+    sessionLock: {
+      sessionLockController: {},
+      withOwnedSessionWriteLock: vi.fn(),
+    },
+    setup: {
+      effectiveFsWorkspaceOnly: false,
+      effectiveWorkspace: "/workspace",
+      sandbox: null,
+      sessionAgentId: "main",
+    },
+    diagnostics: { diagnosticTrace: {}, runTrace: {} },
+    state,
+    lifecycle: {
+      readYieldState: () => ({
+        yieldAbortSettled: null,
+        yieldDetected: true,
+        yieldMessage: "yield",
+      }),
+    },
+    getRepairedRejectedThinkingReplay: () => true,
+    preparedStreamRuntime,
+  } as unknown as SettledInput;
+
+  mocks.runPrompt.mockImplementation(async (promptInput) => {
+    order.push("prompt");
+    promptInput.lifecycle.writeState({
+      contextBudgetStatus: { status: "ok" },
+      preflightRecovery: { attempted: false },
+      promptError: null,
+      promptErrorSource: null,
+    });
+    promptInput.lifecycle.setPrePromptMessageCount(4);
+    promptInput.lifecycle.setPromptCacheChangesForTurn([{ type: "cache" }]);
+    promptInput.lifecycle.setFinalPromptText("final prompt");
+    promptInput.lifecycle.markBeforeAgentRunBlocked({ blockedBy: "before_agent" });
+    return { promptStartedAt: 100 };
+  });
+  mocks.finalizeStream.mockImplementation(async (finalizeInput) => {
+    order.push("finalize");
+    finalizeInput.onSettled({
+      promptError: null,
+      promptErrorSource: null,
+      timedOutDuringCompaction: false,
+      messagesSnapshot: [{ role: "assistant", content: "done" }],
+      sessionIdUsed: "settled-session",
+      lastAssistant: { role: "assistant", content: "done" },
+      currentAttemptAssistant: { role: "assistant", content: "done" },
+      attemptUsage: { input: 1, output: 2, total: 3 },
+      cacheBreak: null,
+      promptCache: { cacheRead: 1 },
+    });
+    return { sessionIdUsed: "final-session", sessionFileUsed: "/tmp/final.jsonl" };
+  });
+  mocks.completeResult.mockImplementation(() => {
+    order.push("result");
+    return result;
+  });
+  mocks.clearActiveEmbeddedRun.mockImplementation(() => order.push("clear-active-run"));
+
+  return {
+    cacheTrace,
+    clearTimers,
+    detachBackend,
+    getBeforeAgentFinalizeRevisionReason,
+    input,
+    order,
+    queueHandle,
+    removeAbortSignalListener,
+    result,
+    sessionRuntimeState,
+    state,
+    subscription,
+    trajectoryRecorder,
+    unsubscribe,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("runEmbeddedAttemptSettledPhase", () => {
+  it("runs prompt and finalization, cleans stream resources, then projects the result", async () => {
+    const fixture = createFixture();
+
+    const result = await runEmbeddedAttemptSettledPhase(fixture.input);
+
+    expect(result).toBe(fixture.result);
+    expect(fixture.order).toEqual([
+      "prompt",
+      "finalize",
+      "clear-timers",
+      "unsubscribe",
+      "detach-backend",
+      "clear-active-run",
+      "remove-abort-listener",
+      "result",
+    ]);
+    expect(fixture.state).toEqual(
+      expect.objectContaining({
+        beforeAgentRunBlocked: true,
+        beforeAgentRunBlockedBy: "before_agent",
+        promptError: null,
+        trajectoryEndRecorded: true,
+      }),
+    );
+    expect(fixture.sessionRuntimeState).toEqual(
+      expect.objectContaining({
+        prePromptMessageCount: 4,
+        promptCache: { cacheRead: 1 },
+      }),
+    );
+    expect(mocks.completeResult).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cache: expect.objectContaining({ trace: fixture.cacheTrace }),
+        state: expect.objectContaining({
+          beforeAgentFinalizeRevisionReason: "revision",
+          sessionIdUsed: "final-session",
+          sessionFileUsed: "/tmp/final.jsonl",
+          yieldDetected: true,
+        }),
+        subscription: fixture.subscription,
+        trajectoryRecorder: fixture.trajectoryRecorder,
+      }),
+    );
+    expect(fixture.detachBackend).toHaveBeenCalledWith(fixture.queueHandle);
+    expect(mocks.clearActiveEmbeddedRun).toHaveBeenCalledWith(
+      "session-1",
+      fixture.queueHandle,
+      "agent:main",
+      "/tmp/session.jsonl",
+    );
+  });
+
+  it("preserves a prompt failure while still completing stream cleanup", async () => {
+    const fixture = createFixture();
+    const failure = new Error("prompt failed");
+    mocks.runPrompt.mockRejectedValueOnce(failure);
+    fixture.unsubscribe.mockImplementationOnce(() => {
+      fixture.order.push("unsubscribe");
+      throw new Error("unsubscribe failed");
+    });
+
+    await expect(runEmbeddedAttemptSettledPhase(fixture.input)).rejects.toBe(failure);
+
+    expect(mocks.finalizeStream).not.toHaveBeenCalled();
+    expect(mocks.completeResult).not.toHaveBeenCalled();
+    expect(fixture.clearTimers).toHaveBeenCalledOnce();
+    expect(fixture.detachBackend).toHaveBeenCalledWith(fixture.queueHandle);
+    expect(fixture.removeAbortSignalListener).toHaveBeenCalledOnce();
+    expect(mocks.logError).toHaveBeenCalledWith(
+      expect.stringContaining("unsubscribe failed, possible resource leak"),
+    );
+  });
+});

--- a/src/agents/embedded-agent-runner/run/attempt-execution-settle.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-execution-settle.ts
@@ -1,0 +1,413 @@
+/** Runs prompt dispatch, stream settlement, cleanup, and result projection. */
+import type { AssistantMessage } from "../../../llm/types.js";
+import type { AgentMessage } from "../../runtime/index.js";
+import type { NormalizedUsage } from "../../usage.js";
+import { log } from "../logger.js";
+import type { PromptCacheBreak, PromptCacheChange } from "../prompt-cache-observability.js";
+import { clearActiveEmbeddedRun } from "../runs.js";
+import type {
+  EmbeddedAttemptExecutionPhaseInput,
+  EmbeddedAttemptExecutionState,
+} from "./attempt-execution-types.js";
+import { runEmbeddedAttemptPromptPhase } from "./attempt-prompt-phase.js";
+import { completeEmbeddedAttemptResult } from "./attempt-result.js";
+import { finalizeEmbeddedAttemptStreamPhase } from "./attempt-stream-finalize.js";
+import type { prepareEmbeddedAttemptStreamRuntime } from "./attempt-stream-runtime-prepare.js";
+import type { EmbeddedRunAttemptParams, EmbeddedRunAttemptResult } from "./types.js";
+
+type PreparedStreamRuntime = Awaited<ReturnType<typeof prepareEmbeddedAttemptStreamRuntime>>;
+
+type StreamCleanupInput = {
+  attempt: EmbeddedRunAttemptParams;
+  clearAttemptTimeoutTimers: () => void;
+  isProbeSession: boolean;
+  queueHandle: PreparedStreamRuntime["stream"]["queueHandle"];
+  removeAttemptAbortSignalListener: () => void;
+  state: EmbeddedAttemptExecutionState;
+  unsubscribe: () => void;
+};
+
+function cleanupEmbeddedAttemptStreamExecution(input: StreamCleanupInput): void {
+  const { attempt, state } = input;
+  input.clearAttemptTimeoutTimers();
+  if (
+    !input.isProbeSession &&
+    (state.aborted || state.timedOut) &&
+    !state.timedOutDuringCompaction
+  ) {
+    log.debug(
+      `run cleanup: runId=${attempt.runId} sessionId=${attempt.sessionId} aborted=${state.aborted} timedOut=${state.timedOut}`,
+    );
+  }
+  try {
+    input.unsubscribe();
+  } catch (error) {
+    // A throwing unsubscribe indicates a resource leak, but must not mask the run error.
+    log.error(
+      `CRITICAL: unsubscribe failed, possible resource leak: runId=${attempt.runId} ${String(error)}`,
+    );
+  }
+  attempt.replyOperation?.detachBackend(input.queueHandle);
+  clearActiveEmbeddedRun(
+    attempt.sessionId,
+    input.queueHandle,
+    attempt.sessionKey,
+    attempt.sessionFile,
+  );
+  input.removeAttemptAbortSignalListener();
+}
+
+export async function runEmbeddedAttemptSettledPhase(
+  input: EmbeddedAttemptExecutionPhaseInput & {
+    getRepairedRejectedThinkingReplay: () => boolean;
+    preparedStreamRuntime: PreparedStreamRuntime;
+  },
+): Promise<EmbeddedRunAttemptResult> {
+  const { attempt, state } = input;
+  const { bootstrap, bundleTools, sessionRuntime, systemPrompt, toolBase, toolCatalog } =
+    input.prepared;
+  const {
+    agentSession: {
+      activeSession,
+      clientToolCallSlots,
+      hasDeliveredSourceReply,
+      hookRunner,
+      setActiveSessionSystemPrompt,
+      settingsManager,
+    },
+    anthropicPayloadLogger,
+    boundary: sessionBoundary,
+    cacheTrace,
+    contextGuards,
+    preparedUserTurnMessage,
+    sessionManager,
+    sessionPromptState,
+    state: sessionRuntimeState,
+    toolResultPromptProjectionState,
+    trajectoryRecorder,
+    transport: {
+      effectiveAgentTransport,
+      effectiveExtraParams,
+      effectivePromptCacheRetention,
+      streamStrategy,
+    },
+  } = sessionRuntime;
+  const { boundaryTimezone, includeBoundaryTimestamp, orphanRepair } = sessionBoundary;
+  const { runtimeInfo, systemPromptReport } = systemPrompt;
+  const { bootstrapPromptWarning, shouldRecordCompletedBootstrapTurn } = bootstrap;
+  const { effectiveTools, emptyExplicitToolAllowlistError, toolSearch } = toolCatalog;
+  const { tools, uncompactedEffectiveTools } = bundleTools;
+  const { toolSearchTargetTranscriptProjections } = toolBase;
+  const hookAgentId = input.setup.sessionAgentId;
+  let yieldAborted = false;
+  const preparedStreamRuntime = input.preparedStreamRuntime;
+  const {
+    abortable,
+    cache: {
+      observabilityEnabled: cacheObservabilityEnabled,
+      promptToolNames: promptCacheToolNames,
+    },
+    history: {
+      contextEnginePromptAuthority,
+      contextEngineAssemblySucceeded,
+      unwindowedContextEngineMessagesForPrecheck,
+    },
+    isProbeSession,
+    onBlockReplyFlush,
+    promptActiveSession,
+    stream: preparedStream,
+    timeout: attemptTimeout,
+  } = preparedStreamRuntime;
+  const {
+    subscription,
+    queueHandle,
+    stopAcceptingSteerMessages,
+    getBeforeAgentFinalizeRevisionReason,
+  } = preparedStream;
+  const { unsubscribe, waitForPendingEvents } = subscription;
+  const {
+    getRunAbortDeadlineAtMs,
+    clearTimers: clearAttemptTimeoutTimers,
+    removeAbortSignalListener: removeAttemptAbortSignalListener,
+  } = attemptTimeout;
+  let promptCacheChangesForTurn: PromptCacheChange[] | null = null;
+  let lastAssistant: AssistantMessage | undefined;
+  let currentAttemptAssistant: EmbeddedRunAttemptResult["currentAttemptAssistant"];
+  let attemptUsage: NormalizedUsage | undefined;
+  let cacheBreak: PromptCacheBreak | null = null;
+  let contextBudgetStatus: EmbeddedRunAttemptResult["contextBudgetStatus"];
+  let finalPromptText: string | undefined;
+  let messagesSnapshot: AgentMessage[] = [];
+  let sessionIdUsed = activeSession.sessionId;
+  let sessionFileUsed: string | undefined = attempt.sessionFile;
+  let preflightRecovery: EmbeddedRunAttemptResult["preflightRecovery"];
+  let promptErrorSource: EmbeddedRunAttemptResult["promptErrorSource"] = null;
+
+  try {
+    const { promptStartedAt } = await runEmbeddedAttemptPromptPhase({
+      attempt,
+      activeSession,
+      sessionManager,
+      sessionLockController: input.sessionLock.sessionLockController,
+      withOwnedSessionWriteLock: input.sessionLock.withOwnedSessionWriteLock,
+      getCompactionReserveTokens: () => settingsManager.getCompactionReserveTokens(),
+      ...(emptyExplicitToolAllowlistError ? { emptyExplicitToolAllowlistError } : {}),
+      assembly: {
+        hookRunner,
+        hookAgentId,
+        diagnosticTrace: input.diagnostics.diagnosticTrace,
+        isRawModelRun: input.isRawModelRun,
+        ...(orphanRepair ? { orphanRepair } : {}),
+        sessionAgentId: input.setup.sessionAgentId,
+        runtimeModel: runtimeInfo.model,
+        systemPromptText: sessionRuntimeState.systemPromptText,
+        setActiveSessionSystemPrompt,
+        cache: {
+          observabilityEnabled: cacheObservabilityEnabled,
+          retention: effectivePromptCacheRetention,
+          streamStrategy,
+          transport: effectiveAgentTransport,
+          toolNames: promptCacheToolNames,
+          trace: cacheTrace,
+        },
+      },
+      context: {
+        ...(boundaryTimezone ? { boundaryTimezone } : {}),
+        includeBoundaryTimestamp,
+        isRawModelRun: input.isRawModelRun,
+        ...(typeof preparedUserTurnMessage?.timestamp === "number"
+          ? { preparedUserTurnTimestamp: preparedUserTurnMessage.timestamp }
+          : {}),
+        sessionAgentId: input.setup.sessionAgentId,
+        setActiveSessionSystemPrompt,
+        ...(systemPromptReport ? { systemPromptReport } : {}),
+        systemPromptText: sessionRuntimeState.systemPromptText,
+        toolResultPromptProjectionState,
+      },
+      execution: {
+        effectiveFsWorkspaceOnly: input.setup.effectiveFsWorkspaceOnly,
+        effectiveWorkspace: input.setup.effectiveWorkspace,
+        sandbox: input.setup.sandbox,
+      },
+      googlePromptCache: {
+        extraParams: effectiveExtraParams,
+        signal: input.runAbortController.signal,
+      },
+      observation: {
+        cacheTrace,
+        diagnosticTrace: input.diagnostics.diagnosticTrace,
+        effectiveTools,
+        hookAgentId,
+        hookRunner,
+        isRawModelRun: input.isRawModelRun,
+        runTrace: input.diagnostics.runTrace,
+        streamStrategy,
+        systemPromptText: sessionRuntimeState.systemPromptText,
+        toolSearchCompacted: toolSearch.compacted,
+        tools,
+        trajectoryRecorder,
+        transport: effectiveAgentTransport,
+        uncompactedEffectiveTools,
+      },
+      preflight: {
+        ...(input.activeContextEngine ? { activeContextEngine: input.activeContextEngine } : {}),
+        contextEngineAssemblySucceeded,
+        contextEnginePromptAuthority,
+        includeBoundaryTimestamp,
+        sessionAgentId: input.setup.sessionAgentId,
+        ...(boundaryTimezone ? { timezone: boundaryTimezone } : {}),
+        ...(unwindowedContextEngineMessagesForPrecheck
+          ? { unwindowedContextEngineMessagesForPrecheck }
+          : {}),
+      },
+      submission: {
+        promptActiveSession,
+        sessionPromptState,
+        toolResultPromptProjectionState,
+        trajectoryRecorder,
+      },
+      lifecycle: {
+        readState: () => ({
+          contextBudgetStatus,
+          preflightRecovery,
+          promptError: state.promptError,
+          promptErrorSource,
+        }),
+        writeState: (nextState) => {
+          contextBudgetStatus = nextState.contextBudgetStatus;
+          preflightRecovery = nextState.preflightRecovery;
+          state.promptError = nextState.promptError;
+          promptErrorSource = nextState.promptErrorSource;
+        },
+        getPrePromptMessageCount: () => sessionRuntimeState.prePromptMessageCount,
+        setPrePromptMessageCount: (count) => {
+          sessionRuntimeState.prePromptMessageCount = count;
+        },
+        setCurrentUserTimestampOverride: (override) => {
+          sessionBoundary.setCurrentUserTimestampOverride(override);
+        },
+        setPromptCacheChangesForTurn: (changes) => {
+          promptCacheChangesForTurn = changes;
+        },
+        setFinalPromptText: (prompt) => {
+          finalPromptText = prompt;
+        },
+        markBeforeAgentRunBlocked: (outcome) => {
+          state.beforeAgentRunBlocked = true;
+          state.beforeAgentRunBlockedBy = outcome.blockedBy;
+        },
+        markYieldAborted: () => {
+          yieldAborted = true;
+          state.cleanupYieldAborted = true;
+          state.aborted = false;
+        },
+        readYieldState: input.lifecycle.readYieldState,
+        stopAcceptingSteerMessages,
+        takePendingMidTurnPrecheckRequest: contextGuards.takePendingMidTurnPrecheckRequest,
+      },
+    });
+
+    const afterTurn = await finalizeEmbeddedAttemptStreamPhase({
+      attempt,
+      activeSession,
+      sessionManager,
+      sessionLockController: input.sessionLock.sessionLockController,
+      withOwnedSessionWriteLock: input.sessionLock.withOwnedSessionWriteLock,
+      waitForPendingEvents,
+      repairedRejectedThinkingReplay: input.getRepairedRejectedThinkingReplay(),
+      getRunAbortDeadlineAtMs,
+      shouldFlushForContextEngine: () =>
+        Boolean(input.activeContextEngine && !getBeforeAgentFinalizeRevisionReason()),
+      getBeforeAgentFinalizeRevisionReason,
+      getContextEngineAfterTurnCheckpoint: contextGuards.getAfterTurnCheckpoint,
+      onSettleErrorState: (settleState) => {
+        state.promptError = settleState.promptError;
+        promptErrorSource = settleState.promptErrorSource;
+      },
+      onSettled: (settledStream) => {
+        state.promptError = settledStream.promptError;
+        promptErrorSource = settledStream.promptErrorSource;
+        state.timedOutDuringCompaction = settledStream.timedOutDuringCompaction;
+        messagesSnapshot = settledStream.messagesSnapshot;
+        sessionIdUsed = settledStream.sessionIdUsed;
+        lastAssistant = settledStream.lastAssistant;
+        currentAttemptAssistant = settledStream.currentAttemptAssistant;
+        attemptUsage = settledStream.attemptUsage;
+        cacheBreak = settledStream.cacheBreak;
+        sessionRuntimeState.promptCache = settledStream.promptCache;
+      },
+      getState: () => ({
+        promptError: state.promptError,
+        promptErrorSource,
+        yieldAborted,
+        sessionIdUsed,
+        sessionFileUsed,
+      }),
+      settle: {
+        subscription,
+        readLifecycleState: () => ({
+          aborted: state.aborted,
+          timedOut: state.timedOut,
+          timedOutDuringCompaction: state.timedOutDuringCompaction,
+        }),
+        markTimedOutDuringCompaction: () => {
+          state.timedOutDuringCompaction = true;
+        },
+        runAbortSignal: input.runAbortController.signal,
+        isProbeSession,
+        onBlockReplyFlush,
+        abortable,
+        prePromptMessageCount: sessionRuntimeState.prePromptMessageCount,
+        toolSearchTargetTranscriptProjections,
+        cache: {
+          observabilityEnabled: cacheObservabilityEnabled,
+          changesForTurn: promptCacheChangesForTurn,
+          retention: effectivePromptCacheRetention,
+        },
+      },
+      afterTurn: {
+        activeContextEngine: input.activeContextEngine,
+        readLifecycleState: () => ({
+          aborted: state.aborted,
+          timedOut: state.timedOut,
+          idleTimedOut: state.idleTimedOut,
+          timedOutDuringCompaction: state.timedOutDuringCompaction,
+        }),
+        runtime: {
+          effectiveWorkspace: input.setup.effectiveWorkspace,
+          agentDir: input.agentDir,
+          sessionAgentId: input.setup.sessionAgentId,
+          resolveActiveContextEnginePluginId: input.resolveActiveContextEnginePluginId,
+          shouldRecordCompletedBootstrapTurn,
+          cacheTrace,
+          anthropicPayloadLogger,
+          hookAgentId,
+          diagnosticTrace: input.diagnostics.diagnosticTrace,
+          skillWorkshopAvailable: uncompactedEffectiveTools.some(
+            (tool) => tool.name === "skill_workshop",
+          ),
+          hookRunner,
+          promptStartedAt,
+        },
+      },
+    });
+    sessionIdUsed = afterTurn.sessionIdUsed;
+    sessionFileUsed = afterTurn.sessionFileUsed;
+  } finally {
+    cleanupEmbeddedAttemptStreamExecution({
+      attempt,
+      clearAttemptTimeoutTimers,
+      isProbeSession,
+      queueHandle,
+      removeAttemptAbortSignalListener,
+      state,
+      unsubscribe,
+    });
+  }
+
+  const beforeAgentFinalizeRevisionReason = getBeforeAgentFinalizeRevisionReason();
+  const result = completeEmbeddedAttemptResult({
+    attempt,
+    subscription,
+    state: {
+      aborted: state.aborted,
+      externalAbort: state.externalAbort,
+      timedOut: state.timedOut,
+      idleTimedOut: state.idleTimedOut,
+      timedOutDuringCompaction: state.timedOutDuringCompaction,
+      timedOutDuringToolExecution: state.timedOutDuringToolExecution,
+      timedOutByRunBudget: state.timedOutByRunBudget,
+      promptError: state.promptError,
+      promptErrorSource,
+      preflightRecovery,
+      sessionIdUsed,
+      sessionFileUsed,
+      diagnosticTrace: input.diagnostics.diagnosticTrace,
+      systemPromptReport,
+      finalPromptText,
+      messagesSnapshot,
+      ...(beforeAgentFinalizeRevisionReason ? { beforeAgentFinalizeRevisionReason } : {}),
+      lastAssistant,
+      currentAttemptAssistant,
+      attemptUsage,
+      promptCache: sessionRuntimeState.promptCache,
+      contextBudgetStatus,
+      yieldDetected: input.lifecycle.readYieldState().yieldDetected,
+      didDeliverSourceReplyViaMessageTool: hasDeliveredSourceReply(),
+    },
+    clientToolCallSlots,
+    hookRunner,
+    hookAgentId,
+    bootstrapPromptWarning,
+    cache: {
+      observabilityEnabled: cacheObservabilityEnabled,
+      trace: cacheTrace,
+      break: cacheBreak,
+      changesForTurn: promptCacheChangesForTurn,
+      streamStrategy,
+    },
+    trajectoryRecorder,
+  });
+  state.trajectoryEndRecorded = true;
+  return result;
+}

--- a/src/agents/embedded-agent-runner/run/attempt-execution-types.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-execution-types.ts
@@ -1,0 +1,88 @@
+/** Shared contracts for the prepared attempt execution phases. */
+import type {
+  createEmbeddedAttemptExternalAbortController,
+  EmbeddedAttemptAbortStatePort,
+} from "./attempt-abort.js";
+import type { prepareEmbeddedAttemptBootstrap } from "./attempt-bootstrap-prepare.js";
+import type { prepareEmbeddedAttemptBundleTools } from "./attempt-bundle-tools.js";
+import type { prepareEmbeddedAttemptSessionLock } from "./attempt-session-lock-prepare.js";
+import type { prepareEmbeddedAttemptSessionRuntime } from "./attempt-session-runtime-prepare.js";
+import type { prepareEmbeddedAttemptSetup } from "./attempt-setup.js";
+import type { prepareEmbeddedAttemptStreamRuntime } from "./attempt-stream-runtime-prepare.js";
+import type { prepareEmbeddedAttemptSystemPrompt } from "./attempt-system-prompt-prepare.js";
+import type { prepareEmbeddedAttemptToolBase } from "./attempt-tool-base-prepare.js";
+import type { prepareEmbeddedAttemptToolCatalog } from "./attempt-tool-catalog.js";
+import type { EmbeddedRunAttemptParams } from "./types.js";
+
+type Prepared<T extends (...args: never[]) => unknown> = Awaited<ReturnType<T>>;
+type PreparedSetup = Prepared<typeof prepareEmbeddedAttemptSetup>;
+type PreparedSessionLock = Prepared<typeof prepareEmbeddedAttemptSessionLock>;
+type StreamRuntimeInput = Parameters<typeof prepareEmbeddedAttemptStreamRuntime>[0];
+type AttemptContextEngine = NonNullable<StreamRuntimeInput["history"]["activeContextEngine"]>;
+
+export type EmbeddedAttemptExecutionState = {
+  aborted: boolean;
+  beforeAgentRunBlocked: boolean;
+  beforeAgentRunBlockedBy: string | undefined;
+  cleanupYieldAborted: boolean;
+  externalAbort: boolean;
+  idleTimedOut: boolean;
+  promptError: unknown;
+  timedOut: boolean;
+  timedOutByRunBudget: boolean;
+  timedOutDuringCompaction: boolean;
+  timedOutDuringToolExecution: boolean;
+  trajectoryEndRecorded: boolean;
+};
+
+export type EmbeddedAttemptExecutionPhaseInput = {
+  attempt: EmbeddedRunAttemptParams;
+  activeContextEngine?: AttemptContextEngine;
+  agentDir: string;
+  isRawModelRun: boolean;
+  resolveActiveContextEnginePluginId: () => string | undefined;
+  runAbortController: AbortController;
+  externalAbortController: Pick<
+    ReturnType<typeof createEmbeddedAttemptExternalAbortController>,
+    "setCompactionState" | "setRunAbort"
+  >;
+  abortState: EmbeddedAttemptAbortStatePort;
+  prepared: {
+    bootstrap: Prepared<typeof prepareEmbeddedAttemptBootstrap>;
+    bundleTools: Prepared<typeof prepareEmbeddedAttemptBundleTools>;
+    sessionRuntime: Prepared<typeof prepareEmbeddedAttemptSessionRuntime>;
+    systemPrompt: Prepared<typeof prepareEmbeddedAttemptSystemPrompt>;
+    toolBase: ReturnType<typeof prepareEmbeddedAttemptToolBase>;
+    toolCatalog: ReturnType<typeof prepareEmbeddedAttemptToolCatalog>;
+  };
+  sessionLock: Pick<
+    PreparedSessionLock,
+    | "compactionTimeoutMs"
+    | "ownedTranscriptWriteContext"
+    | "sessionLockController"
+    | "withOwnedSessionWriteLock"
+  >;
+  setup: Pick<
+    PreparedSetup,
+    | "effectiveFsWorkspaceOnly"
+    | "effectiveWorkspace"
+    | "emitPrepStageSummary"
+    | "prepStages"
+    | "sandbox"
+    | "sandboxSessionKey"
+    | "sessionAgentId"
+  >;
+  diagnostics: {
+    diagnosticTrace: StreamRuntimeInput["stream"]["diagnosticTrace"];
+    runTrace: StreamRuntimeInput["guards"]["runTrace"];
+  };
+  state: EmbeddedAttemptExecutionState;
+  lifecycle: {
+    readYieldState: () => {
+      yieldAbortSettled: Promise<void> | null;
+      yieldDetected: boolean;
+      yieldMessage: string | null;
+    };
+    setToolSearchCatalogExecutor: StreamRuntimeInput["lifecycle"]["setToolSearchCatalogExecutor"];
+  };
+};

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -1,16 +1,12 @@
-/**
- * Orchestrates one embedded-agent attempt from prompt setup through stream result.
- */
+/** Orchestrates one embedded-agent attempt from prompt setup through stream result. */
 import {
   assertContextEngineHostSupport,
   OPENCLAW_EMBEDDED_CONTEXT_ENGINE_HOST,
 } from "../../../context-engine/host-compat.js";
 import { resolveContextEngineOwnerPluginId } from "../../../context-engine/registry.js";
-import type { AssistantMessage } from "../../../llm/types.js";
 import { createBundleLspToolRuntime } from "../../agent-bundle-lsp-runtime.js";
 import { materializeBundleMcpToolsForRun } from "../../agent-bundle-mcp-tools.js";
 import { resolveAgentDir, resolveSessionAgentIds } from "../../agent-scope.js";
-import type { AgentMessage } from "../../runtime/index.js";
 import type { guardSessionManager } from "../../session-tool-result-guard-wrapper.js";
 import type { AgentSession } from "../../sessions/index.js";
 import {
@@ -18,18 +14,15 @@ import {
   type ToolSearchCatalogRef,
   type ToolSearchCatalogToolExecutor,
 } from "../../tool-search.js";
-import type { NormalizedUsage } from "../../usage.js";
 import { log } from "../logger.js";
-import type { PromptCacheBreak, PromptCacheChange } from "../prompt-cache-observability.js";
-import { clearActiveEmbeddedRun } from "../runs.js";
 import {
   createEmbeddedAttemptExternalAbortController,
   type EmbeddedAttemptAbortStatePort,
 } from "./attempt-abort.js";
 import { prepareEmbeddedAttemptBootstrap } from "./attempt-bootstrap-prepare.js";
 import { prepareEmbeddedAttemptBundleTools } from "./attempt-bundle-tools.js";
-import { runEmbeddedAttemptPromptPhase } from "./attempt-prompt-phase.js";
-import { completeEmbeddedAttemptResult } from "./attempt-result.js";
+import { runEmbeddedAttemptExecutionPhase } from "./attempt-execution-phase.js";
+import type { EmbeddedAttemptExecutionState } from "./attempt-execution-types.js";
 import { cleanupEmbeddedAttemptSessionPhase } from "./attempt-session-cleanup.js";
 import { prepareEmbeddedAttemptSessionLock } from "./attempt-session-lock-prepare.js";
 import { prepareEmbeddedAttemptSessionRuntime } from "./attempt-session-runtime-prepare.js";
@@ -40,8 +33,6 @@ import {
   startEmbeddedAttemptDiagnostics,
   type EmitDiagnosticRunCompleted,
 } from "./attempt-startup.js";
-import { finalizeEmbeddedAttemptStreamPhase } from "./attempt-stream-finalize.js";
-import { prepareEmbeddedAttemptStreamRuntime } from "./attempt-stream-runtime-prepare.js";
 import { prepareEmbeddedAttemptSystemPrompt } from "./attempt-system-prompt-prepare.js";
 import { prepareEmbeddedAttemptToolBase } from "./attempt-tool-base-prepare.js";
 import { prepareEmbeddedAttemptToolCatalog } from "./attempt-tool-catalog.js";
@@ -76,17 +67,21 @@ export async function runEmbeddedAttempt(
   } = await prepareEmbeddedAttemptSetup(params);
 
   let restoreSkillEnv: (() => void) | undefined;
-  let aborted = Boolean(params.abortSignal?.aborted);
-  let externalAbort = false;
-  let timedOut = false;
-  let idleTimedOut = false;
-  let timedOutDuringCompaction = false;
-  let timedOutDuringToolExecution = false;
-  let timedOutByRunBudget = false;
-  let promptError: unknown = null;
+  const executionState: EmbeddedAttemptExecutionState = {
+    aborted: Boolean(params.abortSignal?.aborted),
+    beforeAgentRunBlocked: false,
+    beforeAgentRunBlockedBy: undefined,
+    cleanupYieldAborted: false,
+    externalAbort: false,
+    idleTimedOut: false,
+    promptError: null,
+    timedOut: false,
+    timedOutByRunBudget: false,
+    timedOutDuringCompaction: false,
+    timedOutDuringToolExecution: false,
+    trajectoryEndRecorded: false,
+  };
   let emitDiagnosticRunCompleted: EmitDiagnosticRunCompleted | undefined;
-  let beforeAgentRunBlocked = false;
-  let beforeAgentRunBlockedBy: string | undefined;
   // Releases the eager session lock if post-prompt code exits before cleanup.
   let releaseRetainedSessionLock: (() => Promise<void>) | undefined;
   let retainedSessionFileOwner: EmbeddedAttemptSessionFileOwner | undefined;
@@ -94,7 +89,6 @@ export async function runEmbeddedAttempt(
   let bundleLspRuntime: Awaited<ReturnType<typeof createBundleLspToolRuntime>> | undefined;
   let toolSearchCatalogRef: ToolSearchCatalogRef | undefined;
   let toolSearchCatalogApplied = false;
-  const sessionCleanupOwnsEmbeddedResources = false;
   const cleanupEmbeddedPrepResourcesAfterEarlyExit = async () => {
     if (toolSearchCatalogApplied) {
       clearToolSearchCatalog({
@@ -123,23 +117,23 @@ export async function runEmbeddedAttempt(
   };
   const abortState: EmbeddedAttemptAbortStatePort = {
     markAborted: () => {
-      aborted = true;
+      executionState.aborted = true;
     },
     markExternalAbort: () => {
-      externalAbort = true;
+      executionState.externalAbort = true;
     },
     markTimedOut: () => {
-      timedOut = true;
+      executionState.timedOut = true;
     },
     markTimedOutDuringCompaction: () => {
-      timedOutDuringCompaction = true;
+      executionState.timedOutDuringCompaction = true;
     },
     markTimedOutDuringToolExecution: () => {
-      timedOutDuringToolExecution = true;
+      executionState.timedOutDuringToolExecution = true;
     },
-    readTimedOutDuringCompaction: () => timedOutDuringCompaction,
+    readTimedOutDuringCompaction: () => executionState.timedOutDuringCompaction,
     setPromptError: (error) => {
-      promptError = error;
+      executionState.promptError = error;
     },
   };
   const externalAbortController = createEmbeddedAttemptExternalAbortController({
@@ -160,7 +154,6 @@ export async function runEmbeddedAttempt(
     const { skillUsagePaths, skillsPrompt, skillsSnapshotForRun } = preparedSkills;
     prepStages.mark("skills");
 
-    const sessionLabel = params.sessionKey ?? params.sessionId;
     const isRawModelRun = params.modelRun === true || params.promptMode === "none";
     if (isRawModelRun && log.isEnabled("debug")) {
       log.debug(
@@ -217,7 +210,6 @@ export async function runEmbeddedAttempt(
       localModelLeanEnabled,
       replaySafetyOptions,
       toolSearchRuntimeConfig,
-      toolSearchTargetTranscriptProjections,
       toolsEnabled,
       toolsRaw,
     } = preparedToolBase;
@@ -231,10 +223,8 @@ export async function runEmbeddedAttempt(
       markStage: (name) => prepStages.mark(name),
       resolvedWorkspace,
       sessionAgentId,
-      sessionLabel,
+      sessionLabel: params.sessionKey ?? params.sessionId,
     });
-    const { bootstrapPromptWarning, shouldRecordCompletedBootstrapTurn } = preparedBootstrap;
-
     const { defaultAgentId } = resolveSessionAgentIds({
       sessionKey: params.sessionKey,
       config: params.config,
@@ -259,7 +249,7 @@ export async function runEmbeddedAttempt(
     });
     bundleMcpRuntime = preparedBundleTools.bundleMcpRuntime;
     bundleLspRuntime = preparedBundleTools.bundleLspRuntime;
-    const { clientTools, tools, uncompactedEffectiveTools } = preparedBundleTools;
+    const { clientTools, uncompactedEffectiveTools } = preparedBundleTools;
     const preparedToolCatalog = prepareEmbeddedAttemptToolCatalog({
       attempt: params,
       preparedToolBase,
@@ -283,19 +273,13 @@ export async function runEmbeddedAttempt(
       catalogToolHookContext,
       deferredDirectoryToolsCallable,
       effectiveTools,
-      emptyExplicitToolAllowlistError,
-      toolSearch,
       toolSearchRunPlan,
     } = preparedToolCatalog;
-    const replayAllowedToolNames = toolSearchRunPlan.replayAllowedToolNames;
-    const liveAllowedToolNames = toolSearchRunPlan.liveAllowedToolNames;
-    const capabilityToolNames = toolSearchRunPlan.capabilityToolNames;
-
     const preparedSystemPrompt = await prepareEmbeddedAttemptSystemPrompt({
       activeContextEngine,
       attempt: params,
       bootstrap: preparedBootstrap,
-      capabilityToolNames,
+      capabilityToolNames: toolSearchRunPlan.capabilityToolNames,
       defaultAgentId,
       deferredDirectoryToolsCallable,
       effectiveCwd,
@@ -311,9 +295,6 @@ export async function runEmbeddedAttempt(
       skillsPrompt,
       toolSearchCatalogRef,
     });
-    const { runtimeChannel, runtimeInfo, systemPromptReport } = preparedSystemPrompt;
-    const initialSystemPromptText = preparedSystemPrompt.systemPromptText;
-
     let sessionManager: ReturnType<typeof guardSessionManager> | undefined;
     const {
       compactionTimeoutMs,
@@ -337,10 +318,7 @@ export async function runEmbeddedAttempt(
     let trajectoryRecorder: Awaited<
       ReturnType<typeof prepareEmbeddedAttemptSessionRuntime>
     >["trajectoryRecorder"] = null;
-    let trajectoryEndRecorded = false;
     let buildAbortSettlePromise: () => Promise<void> | null = () => null;
-    let cleanupYieldAborted = false;
-    let repairedRejectedThinkingReplay = false;
     try {
       const preparedSessionRuntime = await prepareEmbeddedAttemptSessionRuntime({
         attempt: params,
@@ -348,10 +326,10 @@ export async function runEmbeddedAttempt(
         agentDir,
         effectiveCwd,
         effectiveWorkspace,
-        initialSystemPrompt: initialSystemPromptText,
+        initialSystemPrompt: preparedSystemPrompt.systemPromptText,
         isRawModelRun,
         sessionManager: {
-          replayAllowedToolNames,
+          replayAllowedToolNames: toolSearchRunPlan.replayAllowedToolNames,
           resolveActiveContextEnginePluginId,
           sessionAgentId,
           sessionLockController,
@@ -381,7 +359,9 @@ export async function runEmbeddedAttempt(
         trajectory: {
           effectiveToolCount: effectiveTools.length,
           localModelLeanEnabled,
-          ...(systemPromptReport ? { systemPromptReport } : {}),
+          ...(preparedSystemPrompt.systemPromptReport
+            ? { systemPromptReport: preparedSystemPrompt.systemPromptReport }
+            : {}),
         },
         transport: {
           abortSignal: runAbortController.signal,
@@ -418,453 +398,47 @@ export async function runEmbeddedAttempt(
           },
         },
       });
-      const {
-        agentSession: {
-          activeSession,
-          allCustomTools,
-          builtinToolNames,
-          clientToolCallSlots,
-          clientToolLoopDetection,
-          hasDeliveredSourceReply,
-          hookRunner,
-          markSourceReplyDelivered,
-          replaySafeToolNames,
-          replaySafeTools,
-          setActiveSessionSystemPrompt,
-          settingsManager,
-        },
-        anthropicPayloadLogger,
-        boundary: sessionBoundary,
-        cacheTrace,
-        contextGuards,
-        isOpenAIResponsesApi,
-        preparedUserTurnMessage,
-        sessionManager: activeSessionManager,
-        sessionPromptState,
-        settleTracker: { abortActiveSession, trackPromptSettlePromise },
-        state: sessionRuntimeState,
-        toolResultPromptProjectionState,
-        transcriptPolicy,
-        transport: {
-          effectiveAgentTransport,
-          effectiveExtraParams,
-          effectivePromptCacheRetention,
-          providerTextTransforms,
-          streamStrategy,
-        },
-      } = preparedSessionRuntime;
-      const { boundaryTimezone, includeBoundaryTimestamp, orphanRepair } = sessionBoundary;
-      let yieldAborted = false;
-      const hookAgentId = sessionAgentId;
-      const preparedStreamRuntime = await prepareEmbeddedAttemptStreamRuntime({
+      return await runEmbeddedAttemptExecutionPhase({
         attempt: params,
-        activeSession,
-        sessionManager: activeSessionManager,
-        sessionLockController,
-        ownedTranscriptWriteContext,
+        ...(activeContextEngine ? { activeContextEngine } : {}),
+        agentDir,
+        isRawModelRun,
+        resolveActiveContextEnginePluginId,
         runAbortController,
         externalAbortController,
-        abortActiveSession,
         abortState,
-        trackPromptSettlePromise,
-        compactionTimeoutMs,
-        guards: {
-          sessionAgentId,
-          cacheTrace,
-          allCustomTools,
-          systemPromptText: sessionRuntimeState.systemPromptText,
-          transcriptPolicy,
-          isOpenAIResponsesApi,
-          replayAllowedToolNames,
-          liveAllowedToolNames,
-          clientToolLoopDetection,
-          anthropicPayloadLogger,
-          effectiveAgentTransport,
-          providerTextTransforms,
-          runTrace,
+        prepared: {
+          bootstrap: preparedBootstrap,
+          bundleTools: preparedBundleTools,
+          sessionRuntime: preparedSessionRuntime,
+          systemPrompt: preparedSystemPrompt,
+          toolBase: preparedToolBase,
+          toolCatalog: preparedToolCatalog,
         },
-        history: {
-          ...(activeContextEngine ? { activeContextEngine } : {}),
-          cacheTrace,
-          capabilityToolNames,
+        sessionLock: {
+          compactionTimeoutMs,
+          ownedTranscriptWriteContext,
+          sessionLockController,
+          withOwnedSessionWriteLock,
+        },
+        setup: {
+          effectiveFsWorkspaceOnly,
           effectiveWorkspace,
-          isOpenAIResponsesApi,
-          isRawModelRun,
-          ...(orphanRepair ? { orphanRepair } : {}),
-          replayAllowedToolNames,
-          sessionAgentId,
-          settingsManager,
-          systemPromptText: sessionRuntimeState.systemPromptText,
-          transcriptPolicy,
-          setActiveSessionSystemPrompt,
-        },
-        stream: {
-          runtimeChannel,
-          hookRunner,
-          hookAgentId,
-          diagnosticTrace,
-          clientToolCallSlots,
-          toolSearchTargetTranscriptProjections,
-          isReplaySafeTool: (tool) => replaySafeTools.has(tool as never),
-          hasDeliveredSourceReply,
-          markSourceReplyDelivered,
+          emitPrepStageSummary,
+          prepStages,
+          sandbox,
           sandboxSessionKey,
-          builtinToolNames,
-          replaySafeToolNames,
+          sessionAgentId,
         },
+        diagnostics: { diagnosticTrace, runTrace },
+        state: executionState,
         lifecycle: {
-          isYieldDetected: () => yieldDetected,
-          markRejectedThinkingReplayRepaired: () => {
-            repairedRejectedThinkingReplay = true;
-          },
-          markStreamReady: () => {
-            prepStages.mark("stream-setup");
-            emitPrepStageSummary("stream-ready");
-          },
-          markIdleTimedOut: () => {
-            idleTimedOut = true;
-          },
-          markExternalAbort: () => {
-            externalAbort = true;
-          },
-          markTimedOutDuringCompaction: () => {
-            timedOutDuringCompaction = true;
-          },
-          markTimedOutByRunBudget: () => {
-            timedOutByRunBudget = true;
-          },
-          readRunState: () => ({ aborted, promptError, timedOut, yieldDetected }),
+          readYieldState: () => ({ yieldAbortSettled, yieldDetected, yieldMessage }),
           setToolSearchCatalogExecutor: (executor) => {
             toolSearchCatalogExecutor = executor;
           },
         },
       });
-      const {
-        abortable,
-        cache: {
-          observabilityEnabled: cacheObservabilityEnabled,
-          promptToolNames: promptCacheToolNames,
-        },
-        history: {
-          contextEnginePromptAuthority,
-          contextEngineAssemblySucceeded,
-          unwindowedContextEngineMessagesForPrecheck,
-        },
-        isProbeSession,
-        onBlockReplyFlush,
-        promptActiveSession,
-        stream: preparedStream,
-        timeout: attemptTimeout,
-      } = preparedStreamRuntime;
-      let promptCacheChangesForTurn: PromptCacheChange[] | null = null;
-      const {
-        subscription,
-        queueHandle,
-        stopAcceptingSteerMessages,
-        getBeforeAgentFinalizeRevisionReason,
-      } = preparedStream;
-      const { unsubscribe, waitForPendingEvents } = subscription;
-      let lastAssistant: AssistantMessage | undefined;
-      let currentAttemptAssistant: EmbeddedRunAttemptResult["currentAttemptAssistant"];
-      let attemptUsage: NormalizedUsage | undefined;
-      let cacheBreak: PromptCacheBreak | null = null;
-      let contextBudgetStatus: EmbeddedRunAttemptResult["contextBudgetStatus"];
-      let finalPromptText: string | undefined;
-      const {
-        getRunAbortDeadlineAtMs,
-        clearTimers: clearAttemptTimeoutTimers,
-        removeAbortSignalListener: removeAttemptAbortSignalListener,
-      } = attemptTimeout;
-      let messagesSnapshot: AgentMessage[] = [];
-      let sessionIdUsed = activeSession.sessionId;
-      let sessionFileUsed: string | undefined = params.sessionFile;
-
-      let preflightRecovery: EmbeddedRunAttemptResult["preflightRecovery"];
-      let promptErrorSource: EmbeddedRunAttemptResult["promptErrorSource"] = null;
-      try {
-        const { promptStartedAt } = await runEmbeddedAttemptPromptPhase({
-          attempt: params,
-          activeSession,
-          sessionManager: activeSessionManager,
-          sessionLockController,
-          withOwnedSessionWriteLock,
-          getCompactionReserveTokens: () => settingsManager.getCompactionReserveTokens(),
-          ...(emptyExplicitToolAllowlistError ? { emptyExplicitToolAllowlistError } : {}),
-          assembly: {
-            hookRunner,
-            hookAgentId,
-            diagnosticTrace,
-            isRawModelRun,
-            ...(orphanRepair ? { orphanRepair } : {}),
-            sessionAgentId,
-            runtimeModel: runtimeInfo.model,
-            systemPromptText: sessionRuntimeState.systemPromptText,
-            setActiveSessionSystemPrompt,
-            cache: {
-              observabilityEnabled: cacheObservabilityEnabled,
-              retention: effectivePromptCacheRetention,
-              streamStrategy,
-              transport: effectiveAgentTransport,
-              toolNames: promptCacheToolNames,
-              trace: cacheTrace,
-            },
-          },
-          context: {
-            ...(boundaryTimezone ? { boundaryTimezone } : {}),
-            includeBoundaryTimestamp,
-            isRawModelRun,
-            ...(typeof preparedUserTurnMessage?.timestamp === "number"
-              ? { preparedUserTurnTimestamp: preparedUserTurnMessage.timestamp }
-              : {}),
-            sessionAgentId,
-            setActiveSessionSystemPrompt,
-            ...(systemPromptReport ? { systemPromptReport } : {}),
-            systemPromptText: sessionRuntimeState.systemPromptText,
-            toolResultPromptProjectionState,
-          },
-          execution: {
-            effectiveFsWorkspaceOnly,
-            effectiveWorkspace,
-            sandbox,
-          },
-          googlePromptCache: {
-            extraParams: effectiveExtraParams,
-            signal: runAbortController.signal,
-          },
-          observation: {
-            cacheTrace,
-            diagnosticTrace,
-            effectiveTools,
-            hookAgentId,
-            hookRunner,
-            isRawModelRun,
-            runTrace,
-            streamStrategy,
-            systemPromptText: sessionRuntimeState.systemPromptText,
-            toolSearchCompacted: toolSearch.compacted,
-            tools,
-            trajectoryRecorder,
-            transport: effectiveAgentTransport,
-            uncompactedEffectiveTools,
-          },
-          preflight: {
-            ...(activeContextEngine ? { activeContextEngine } : {}),
-            contextEngineAssemblySucceeded,
-            contextEnginePromptAuthority,
-            includeBoundaryTimestamp,
-            sessionAgentId,
-            ...(boundaryTimezone ? { timezone: boundaryTimezone } : {}),
-            ...(unwindowedContextEngineMessagesForPrecheck
-              ? { unwindowedContextEngineMessagesForPrecheck }
-              : {}),
-          },
-          submission: {
-            promptActiveSession,
-            sessionPromptState,
-            toolResultPromptProjectionState,
-            trajectoryRecorder,
-          },
-          lifecycle: {
-            readState: () => ({
-              contextBudgetStatus,
-              preflightRecovery,
-              promptError,
-              promptErrorSource,
-            }),
-            writeState: (state) => {
-              contextBudgetStatus = state.contextBudgetStatus;
-              preflightRecovery = state.preflightRecovery;
-              promptError = state.promptError;
-              promptErrorSource = state.promptErrorSource;
-            },
-            getPrePromptMessageCount: () => sessionRuntimeState.prePromptMessageCount,
-            setPrePromptMessageCount: (count) => {
-              sessionRuntimeState.prePromptMessageCount = count;
-            },
-            setCurrentUserTimestampOverride: (override) => {
-              sessionBoundary.setCurrentUserTimestampOverride(override);
-            },
-            setPromptCacheChangesForTurn: (changes) => {
-              promptCacheChangesForTurn = changes;
-            },
-            setFinalPromptText: (prompt) => {
-              finalPromptText = prompt;
-            },
-            markBeforeAgentRunBlocked: (outcome) => {
-              beforeAgentRunBlocked = true;
-              beforeAgentRunBlockedBy = outcome.blockedBy;
-            },
-            markYieldAborted: () => {
-              yieldAborted = true;
-              cleanupYieldAborted = true;
-              aborted = false;
-            },
-            readYieldState: () => ({ yieldAbortSettled, yieldDetected, yieldMessage }),
-            stopAcceptingSteerMessages,
-            takePendingMidTurnPrecheckRequest: contextGuards.takePendingMidTurnPrecheckRequest,
-          },
-        });
-
-        const afterTurn = await finalizeEmbeddedAttemptStreamPhase({
-          attempt: params,
-          activeSession,
-          sessionManager: activeSessionManager,
-          sessionLockController,
-          withOwnedSessionWriteLock,
-          waitForPendingEvents,
-          repairedRejectedThinkingReplay,
-          getRunAbortDeadlineAtMs,
-          shouldFlushForContextEngine: () =>
-            Boolean(activeContextEngine && !getBeforeAgentFinalizeRevisionReason()),
-          getBeforeAgentFinalizeRevisionReason,
-          getContextEngineAfterTurnCheckpoint: contextGuards.getAfterTurnCheckpoint,
-          onSettleErrorState: (state) => {
-            promptError = state.promptError;
-            promptErrorSource = state.promptErrorSource;
-          },
-          onSettled: (settledStream) => {
-            promptError = settledStream.promptError;
-            promptErrorSource = settledStream.promptErrorSource;
-            timedOutDuringCompaction = settledStream.timedOutDuringCompaction;
-            messagesSnapshot = settledStream.messagesSnapshot;
-            sessionIdUsed = settledStream.sessionIdUsed;
-            lastAssistant = settledStream.lastAssistant;
-            currentAttemptAssistant = settledStream.currentAttemptAssistant;
-            attemptUsage = settledStream.attemptUsage;
-            cacheBreak = settledStream.cacheBreak;
-            sessionRuntimeState.promptCache = settledStream.promptCache;
-          },
-          getState: () => ({
-            promptError,
-            promptErrorSource,
-            yieldAborted,
-            sessionIdUsed,
-            sessionFileUsed,
-          }),
-          settle: {
-            subscription,
-            readLifecycleState: () => ({
-              aborted,
-              timedOut,
-              timedOutDuringCompaction,
-            }),
-            markTimedOutDuringCompaction: () => {
-              timedOutDuringCompaction = true;
-            },
-            runAbortSignal: runAbortController.signal,
-            isProbeSession,
-            onBlockReplyFlush,
-            abortable,
-            prePromptMessageCount: sessionRuntimeState.prePromptMessageCount,
-            toolSearchTargetTranscriptProjections,
-            cache: {
-              observabilityEnabled: cacheObservabilityEnabled,
-              changesForTurn: promptCacheChangesForTurn,
-              retention: effectivePromptCacheRetention,
-            },
-          },
-          afterTurn: {
-            activeContextEngine,
-            readLifecycleState: () => ({
-              aborted,
-              timedOut,
-              idleTimedOut,
-              timedOutDuringCompaction,
-            }),
-            runtime: {
-              effectiveWorkspace,
-              agentDir,
-              sessionAgentId,
-              resolveActiveContextEnginePluginId,
-              shouldRecordCompletedBootstrapTurn,
-              cacheTrace,
-              anthropicPayloadLogger,
-              hookAgentId,
-              diagnosticTrace,
-              skillWorkshopAvailable: uncompactedEffectiveTools.some(
-                (tool) => tool.name === "skill_workshop",
-              ),
-              hookRunner,
-              promptStartedAt,
-            },
-          },
-        });
-        sessionIdUsed = afterTurn.sessionIdUsed;
-        sessionFileUsed = afterTurn.sessionFileUsed;
-      } finally {
-        clearAttemptTimeoutTimers();
-        if (!isProbeSession && (aborted || timedOut) && !timedOutDuringCompaction) {
-          log.debug(
-            `run cleanup: runId=${params.runId} sessionId=${params.sessionId} aborted=${aborted} timedOut=${timedOut}`,
-          );
-        }
-        try {
-          unsubscribe();
-        } catch (err) {
-          // unsubscribe() should never throw; if it does, it indicates a serious bug.
-          // Log at error level to ensure visibility, but don't rethrow in finally block
-          // as it would mask any exception from the try block above.
-          log.error(
-            `CRITICAL: unsubscribe failed, possible resource leak: runId=${params.runId} ${String(err)}`,
-          );
-        }
-        if (params.replyOperation) {
-          params.replyOperation.detachBackend(queueHandle);
-        }
-        clearActiveEmbeddedRun(
-          params.sessionId,
-          queueHandle,
-          params.sessionKey,
-          params.sessionFile,
-        );
-        removeAttemptAbortSignalListener();
-      }
-
-      const beforeAgentFinalizeRevisionReason = getBeforeAgentFinalizeRevisionReason();
-      const finalizedResult = completeEmbeddedAttemptResult({
-        attempt: params,
-        subscription,
-        state: {
-          aborted,
-          externalAbort,
-          timedOut,
-          idleTimedOut,
-          timedOutDuringCompaction,
-          timedOutDuringToolExecution,
-          timedOutByRunBudget,
-          promptError,
-          promptErrorSource,
-          preflightRecovery,
-          sessionIdUsed,
-          sessionFileUsed,
-          diagnosticTrace,
-          systemPromptReport,
-          finalPromptText,
-          messagesSnapshot,
-          ...(beforeAgentFinalizeRevisionReason ? { beforeAgentFinalizeRevisionReason } : {}),
-          lastAssistant,
-          currentAttemptAssistant,
-          attemptUsage,
-          promptCache: sessionRuntimeState.promptCache,
-          contextBudgetStatus,
-          yieldDetected,
-          didDeliverSourceReplyViaMessageTool: hasDeliveredSourceReply(),
-        },
-        clientToolCallSlots,
-        hookRunner,
-        hookAgentId,
-        bootstrapPromptWarning,
-        cache: {
-          observabilityEnabled: cacheObservabilityEnabled,
-          trace: cacheTrace,
-          break: cacheBreak,
-          changesForTurn: promptCacheChangesForTurn,
-          streamStrategy,
-        },
-        trajectoryRecorder,
-      });
-      trajectoryEndRecorded = true;
-      return finalizedResult;
     } finally {
       await cleanupEmbeddedAttemptSessionPhase({
         attempt: params,
@@ -879,34 +453,32 @@ export async function runEmbeddedAttempt(
         sessionAgentId,
         buildAbortSettlePromise,
         trajectoryRecorder,
-        trajectoryEndRecorded,
-        cleanupYieldAborted,
+        trajectoryEndRecorded: executionState.trajectoryEndRecorded,
+        cleanupYieldAborted: executionState.cleanupYieldAborted,
         emitDiagnosticRunCompleted,
         readState: () => ({
-          aborted,
-          externalAbort,
-          timedOut,
-          idleTimedOut,
-          timedOutDuringCompaction,
-          timedOutDuringToolExecution,
-          timedOutByRunBudget,
-          promptError,
-          beforeAgentRunBlocked,
-          beforeAgentRunBlockedBy,
+          aborted: executionState.aborted,
+          externalAbort: executionState.externalAbort,
+          timedOut: executionState.timedOut,
+          idleTimedOut: executionState.idleTimedOut,
+          timedOutDuringCompaction: executionState.timedOutDuringCompaction,
+          timedOutDuringToolExecution: executionState.timedOutDuringToolExecution,
+          timedOutByRunBudget: executionState.timedOutByRunBudget,
+          promptError: executionState.promptError,
+          beforeAgentRunBlocked: executionState.beforeAgentRunBlocked,
+          beforeAgentRunBlockedBy: executionState.beforeAgentRunBlockedBy,
         }),
       });
     }
   } finally {
     externalAbortController.dispose();
     clearToolActivityRun(params.runId);
-    if (!sessionCleanupOwnsEmbeddedResources) {
-      try {
-        await cleanupEmbeddedPrepResourcesAfterEarlyExit();
-      } catch (cleanupErr) {
-        log.warn(
-          `failed to clean up embedded prep resources after early attempt exit: runId=${params.runId} ${String(cleanupErr)}`,
-        );
-      }
+    try {
+      await cleanupEmbeddedPrepResourcesAfterEarlyExit();
+    } catch (cleanupErr) {
+      log.warn(
+        `failed to clean up embedded prep resources after early attempt exit: runId=${params.runId} ${String(cleanupErr)}`,
+      );
     }
     try {
       await releaseRetainedSessionLock?.();
@@ -917,8 +489,8 @@ export async function runEmbeddedAttempt(
     }
     retainedSessionFileOwner?.release();
     emitDiagnosticRunCompleted?.(
-      aborted ? "aborted" : "error",
-      promptError ?? new Error("run exited before diagnostic completion"),
+      executionState.aborted ? "aborted" : "error",
+      executionState.promptError ?? new Error("run exited before diagnostic completion"),
     );
     restoreSkillEnv?.();
   }


### PR DESCRIPTION
## What Problem This Solves

`runEmbeddedAttempt` still owned stream setup, prompt dispatch, settlement, cleanup, and result projection after the prior session-runtime extraction. The hot `attempt.ts` remained 925 lines and above the TypeScript LOC ratchet ceiling.

## Why This Change Was Made

Extract the guarded stream preparation and settled execution phases into focused modules, with one shared lifecycle-state contract. Preserve the original prompt -> finalize -> cleanup -> result ordering and live lifecycle callbacks while leaving `attempt.ts` responsible for top-level setup and session cleanup.

## User Impact

No intended behavior change. `attempt.ts` drops from 925 to 497 lines; every new production module remains below 500 lines.

## Evidence

- Blacksmith Testbox `tbx_01kxfjsfxe2nnbkshv7btwtdty`: 83 focused tests passed.
- `pnpm tsgo:core`
- `pnpm tsgo:core:test`
- targeted oxlint across all six changed files
- `pnpm check:loc`
- fresh branch autoreview: clean
