### PR TITLE
fix(logbook): reject invalid 12-hour analysis clocks

### DIFF
--- a/extensions/logbook/src/analyze.test.ts
+++ b/extensions/logbook/src/analyze.test.ts
@@ -162,7 +162,7 @@ describe("parseCardsJson", () => {
 
   it("reports actionable errors for the correction round-trip", () => {
     const result = parseCardsJson({
-      raw: JSON.stringify([card({ startTime: "later that day" })]),
+      raw: JSON.stringify([card({ startTime: "13:05 pm" })]),
       day: DAY,
       windowStartMs,
       windowEndMs,

--- a/extensions/logbook/src/analyze.test.ts
+++ b/extensions/logbook/src/analyze.test.ts
@@ -31,6 +31,8 @@ describe("clockToMs", () => {
 
   it("rejects malformed input", () => {
     expect(clockToMs(DAY, "25:00:00")).toBeNull();
+    expect(clockToMs(DAY, "13:05 pm")).toBeNull();
+    expect(clockToMs(DAY, "00:05 am")).toBeNull();
     expect(clockToMs(DAY, "half past nine")).toBeNull();
     expect(clockToMs("not-a-day", "10:00:00")).toBeNull();
   });

--- a/extensions/logbook/src/analyze.ts
+++ b/extensions/logbook/src/analyze.ts
@@ -24,6 +24,9 @@ export function clockToMs(day: string, clock: string): number | null {
   const minutes = Number(match[2]);
   const seconds = Number(match[3] ?? "0");
   const meridiem = match[4]?.toLowerCase();
+  if (meridiem && (hours < 1 || hours > 12)) {
+    return null;
+  }
   if (meridiem === "pm" && hours < 12) {
     hours += 12;
   }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Logbook analysis could accept invalid 12-hour times from model output, such as `13:05 pm` or `00:05 am`, when parsing observations, timeline cards, and distraction ranges.

## Why This Change Was Made

The shared Logbook clock parser now rejects meridiem-formatted hours outside the valid 1–12 range before applying the existing AM/PM conversion. This keeps the validation at the common owner boundary, preserves valid 24-hour input, and avoids duplicated checks in each model-output consumer. The maintainer refinement preserves @qingminglong's original authored fix and makes the card-synthesis correction path exercise the malformed meridiem case directly.

## User Impact

Logbook analysis no longer turns malformed 12-hour model output into misleading timeline timestamps. Invalid observation segments are discarded, invalid card times enter the existing correction round-trip, and invalid distraction ranges are filtered by the same shared parser.

## Evidence

- Source-level before proof: the parser shipped in `v2026.7.1` applied AM/PM conversion without first requiring a 1–12 hour, so `13:05 pm` remained a valid 13:05 timestamp and `00:05 pm` normalized to 12:05.
- Focused Testbox proof on the final patch bytes: `corepack pnpm test extensions/logbook/src/analyze.test.ts` passed 24/24 tests on `tbx_01kxgm8cj4j2b3022sn62gwvgf`.
- Path-scoped Testbox gate: `corepack pnpm check:changed -- extensions/logbook/src/analyze.ts extensions/logbook/src/analyze.test.ts` passed formatting, extension production/test type checks, lint, database/media/runtime guards, and import-cycle checks on the same Testbox.
- Fresh exact-head review: `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` reported no accepted/actionable findings after the patch-identical rebase.
- Pushed head: `2253418718fbf4dde8cd9b9f04968f1bee5267c5`.
