### PR TITLE
chore(android): verify the Gradle wrapper distribution

### DIFF
--- a/apps/android/gradle/wrapper/gradle-wrapper.properties
+++ b/apps/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-# AGP 9.2 emits deprecated project-dependency notation on Gradle 9.5+.
+# Gradle 9.5+ exposes deprecated project-dependency notation inside AGP 9.2.1.
+distributionSha256Sum=2ab2958f2a1e51120c326cad6f385153bb11ee93b3c216c5fccebfdfbb7ec6cb
 distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 networkTimeout=10000
 retries=0


### PR DESCRIPTION
## What Problem This Solves

The Android Gradle wrapper downloaded its pinned distribution without verifying the archive against Gradle's published checksum. A direct move to Gradle 9.6.1 is not warning-free with the latest stable Android Gradle Plugin 9.2.1: AGP still uses deprecated project-dependency notation, and this repository correctly treats that warning as an error.

## Why This Change Was Made

This pins Gradle's official SHA-256 for the latest mutually compatible stable toolchain: AGP 9.2.1 with Gradle 9.4.1. The wrapper bootstrap itself remains the latest stable 9.6.1 binary. Gradle 9.5+ remains deferred until AGP 9.3 reaches stable; no preview dependency or warning suppression is introduced.

The other requested native tools were audited and already use their current stable releases: SwiftFormat 0.62.1, SwiftLint 0.65.0, XcodeGen 2.45.4, and the ktlint Gradle plugin 14.2.0.

AI-assisted: yes. I reviewed and understand the change.

## User Impact

No product behavior changes. Android builds now fail closed if the downloaded Gradle archive does not match the official release artifact.

## Evidence

- Official Gradle 9.4.1 binary distribution checksum: `2ab2958f2a1e51120c326cad6f385153bb11ee93b3c216c5fccebfdfbb7ec6cb`.
- Blacksmith Testbox `tbx_01kxfjpk0dba6rfw9vwfg826vk`: Gradle 9.4.1, both app-flavor unit-test lanes, both APK builds, both Android lint lanes, benchmark build, and app/benchmark ktlint all passed under warning-as-error (`172 actionable tasks`, `BUILD SUCCESSFUL`).
- Exact-head manual CI [run 29310124506](https://github.com/openclaw/openclaw/actions/runs/29310124506): macOS Swift format/lint, release build, and 1,168 tests; iOS Swift format/lint and app build; Android unit tests, ktlint, and app build all passed. SwiftLint reported zero violations and the native build logs contain no compiler warnings.
- PR CI [run 29310101323](https://github.com/openclaw/openclaw/actions/runs/29310101323): all four Android jobs passed on the source SHA.
- The broad manual dispatch also reproduced an unrelated generated-protocol baseline failure already present in the source branch's exact `main` base, [run 29309282688](https://github.com/openclaw/openclaw/actions/runs/29309282688); this PR changes only the Gradle wrapper properties.
- Fresh structured autoreview: clean, no accepted/actionable findings.
- `git diff --check` passed.
