### PR TITLE
fix(ui): remove duplicate New Session rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
-- **Control UI agent switcher:** remove the repeated per-agent New Session rows while keeping session creation available from the sidebar's primary controls.
 - **Skill Workshop history review:** add a manual, newest-first session scan that progressively searches older substantial work for conservative skill ideas, stores only SQLite cursor metadata, and leaves up to three results as pending proposals even when autonomous self-learning is disabled. (#106182)
 - **SQLite snapshots:** add `openclaw backup sqlite create|list|verify|restore` for compact, verified global and per-agent database artifacts with fresh-target-only restore. (#94805) Thanks @giodl73-repo.
 - **GPT-5.6 Ultra and runtime switching:** support Sol, Terra, and Luna across OpenClaw and Codex engines; keep model, runtime, and thinking selection atomic through `/model` and fallback; and add live matrix coverage for both harnesses. (#98021) Thanks @anyech.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- **Control UI agent switcher:** remove the repeated per-agent New Session rows while keeping session creation available from the sidebar's primary controls.
 - **Skill Workshop history review:** add a manual, newest-first session scan that progressively searches older substantial work for conservative skill ideas, stores only SQLite cursor metadata, and leaves up to three results as pending proposals even when autonomous self-learning is disabled. (#106182)
 - **SQLite snapshots:** add `openclaw backup sqlite create|list|verify|restore` for compact, verified global and per-agent database artifacts with fresh-target-only restore. (#94805) Thanks @giodl73-repo.
 - **GPT-5.6 Ultra and runtime switching:** support Sol, Terra, and Luna across OpenClaw and Codex engines; keep model, runtime, and thinking selection atomic through `/model` and fallback; and add live matrix coverage for both harnesses. (#98021) Thanks @anyech.

--- a/ui/src/components/app-sidebar-agent-menu.ts
+++ b/ui/src/components/app-sidebar-agent-menu.ts
@@ -37,7 +37,6 @@ const AGENT_MENU_LINKS: ReadonlyArray<{ href: string; icon: IconName; label: () 
 /** Above this roster size the chip menu switches to pinned agents + filter. */
 const QUICK_SWITCH_AGENT_LIMIT = 10;
 const AGENT_VALUE_PREFIX = "agent:";
-const NEW_SESSION_VALUE_PREFIX = "new-session:";
 const COMMAND_VALUE_PREFIX = "command:";
 const LINK_VALUE_PREFIX = "link:";
 
@@ -59,7 +58,6 @@ type SidebarAgentMenuParams = {
   onFilterChange: (next: string) => void;
   onSwitchAgent: (agentId: string) => void;
   onAskCapabilities: (agentId: string) => void;
-  onOpenNewSession: (agentId: string) => void;
   onTabAway: () => void;
   onClose: (restoreFocus?: boolean) => void;
   onNavigate: (routeId: NavigationRouteId, options?: ApplicationNavigationOptions) => void;
@@ -151,16 +149,6 @@ function renderAgentRow(agent: AgentMenuAgent, params: SidebarAgentMenuParams) {
           ></span>`
         : nothing}
     </wa-dropdown-item>
-    <wa-dropdown-item
-      class="sidebar-customize-menu__item sidebar-agent-menu__new"
-      value=${`${NEW_SESSION_VALUE_PREFIX}${encodeURIComponent(agentId)}`}
-      ?disabled=${!params.connected}
-    >
-      <span slot="icon" class="nav-item__icon" aria-hidden="true">${icons.plus}</span>
-      <span class="sidebar-customize-menu__text">
-        ${t("chat.runControls.newSession")} — ${label}
-      </span>
-    </wa-dropdown-item>
   `;
 }
 
@@ -223,12 +211,6 @@ export function renderSidebarAgentMenu(params: SidebarAgentMenuParams) {
           params.onClose(false);
           if (value.startsWith(AGENT_VALUE_PREFIX)) {
             params.onSwitchAgent(decodeURIComponent(value.slice(AGENT_VALUE_PREFIX.length)));
-            return;
-          }
-          if (value.startsWith(NEW_SESSION_VALUE_PREFIX)) {
-            params.onOpenNewSession(
-              decodeURIComponent(value.slice(NEW_SESSION_VALUE_PREFIX.length)),
-            );
             return;
           }
           if (value.startsWith(LINK_VALUE_PREFIX)) {

--- a/ui/src/components/app-sidebar.test.ts
+++ b/ui/src/components/app-sidebar.test.ts
@@ -494,11 +494,9 @@ describe("AppSidebar agent chip", () => {
       TWO_AGENTS,
     );
     const onNavigate = vi.fn();
-    const onOpenNewSession = vi.fn();
     sidebar.connected = true;
     sidebar.canPairDevice = true;
     sidebar.onNavigate = onNavigate;
-    sidebar.onOpenNewSession = onOpenNewSession;
     await sidebar.updateComplete;
 
     expect(sidebar.querySelector(".sidebar-agent-chip__name")?.textContent?.trim()).toBe("Molty");
@@ -547,20 +545,8 @@ describe("AppSidebar agent chip", () => {
       ...(reopenedMenu?.querySelectorAll('wa-dropdown-item[type="checkbox"]') ?? []),
     ];
     expect(agentRows).toHaveLength(2);
-    const newSessionItem = [
-      ...(reopenedMenu?.querySelectorAll<HTMLElement>(".sidebar-agent-menu__new") ?? []),
-    ].find((item) => item.textContent?.includes("research"));
-    expect(newSessionItem).toBeDefined();
-    reopenedMenu?.dispatchEvent(
-      new CustomEvent("wa-select", { detail: { item: newSessionItem }, bubbles: true }),
-    );
-    await sidebar.updateComplete;
-    expect(onOpenNewSession).toHaveBeenCalledWith("research");
-    expect(sidebar.querySelector(".sidebar-agent-menu")).toBeNull();
-
-    sidebar.querySelector<HTMLButtonElement>(".sidebar-agent-chip__main")?.click();
-    await sidebar.updateComplete;
-    const switchMenu = sidebar.querySelector<HTMLElement>(".sidebar-agent-menu");
+    expect(reopenedMenu?.querySelector(".sidebar-agent-menu__new")).toBeNull();
+    const switchMenu = reopenedMenu;
     const researchRow = [
       ...(switchMenu?.querySelectorAll<HTMLElement>('wa-dropdown-item[type="checkbox"]') ?? []),
     ].find((row) => row.textContent?.includes("research"));

--- a/ui/src/components/app-sidebar.ts
+++ b/ui/src/components/app-sidebar.ts
@@ -2061,7 +2061,6 @@ class AppSidebar extends OpenClawLightDomContentsElement {
       },
       onSwitchAgent: (agentId) => this.switchChipAgent(agentId),
       onAskCapabilities: (agentId) => this.askAgentCapabilities(agentId),
-      onOpenNewSession: (agentId) => this.onOpenNewSession?.(agentId),
       onTabAway: () => trigger?.focus(),
       onClose: (restoreFocus) => {
         // An old Web Awesome menu can finish hiding after its replacement opens.

--- a/ui/src/e2e/sidebar-customization.e2e.test.ts
+++ b/ui/src/e2e/sidebar-customization.e2e.test.ts
@@ -772,7 +772,7 @@ describeControlUiE2e("Control UI sidebar customization mocked Gateway E2E", () =
     }
   });
 
-  it("reaches per-agent new-session actions with menu keys", async () => {
+  it("shows one row per agent and reaches agent switches with menu keys", async () => {
     const context = await browser.newContext({
       locale: "en-US",
       serviceWorkers: "block",
@@ -808,33 +808,25 @@ describeControlUiE2e("Control UI sidebar customization mocked Gateway E2E", () =
       const menu = sidebar.locator("wa-dropdown.sidebar-agent-menu");
       const mainSwitch = menu.getByRole("menuitemradio", { name: "Main" });
       const researchSwitch = menu.getByRole("menuitemradio", { name: "Research" });
-      const researchNewSession = menu.getByRole("menuitem", {
-        name: "New session — Research",
-      });
-
-      // Web Awesome only includes direct light-DOM items in its roving focus model.
       await expect
         .poll(() =>
-          researchNewSession.evaluate(
+          researchSwitch.evaluate(
             (element) => element.parentElement?.matches("wa-dropdown.sidebar-agent-menu") ?? false,
           ),
         )
         .toBe(true);
+      await expect.poll(() => menu.getByText(/^New session —/).count()).toBe(0);
       await expect
         .poll(() => mainSwitch.evaluate((element) => element === document.activeElement))
         .toBe(true);
       await page.keyboard.press("ArrowDown");
-      await page.keyboard.press("ArrowDown");
       await expect
         .poll(() => researchSwitch.evaluate((element) => element === document.activeElement))
         .toBe(true);
-      await page.keyboard.press("ArrowDown");
-      await expect
-        .poll(() => researchNewSession.evaluate((element) => element === document.activeElement))
-        .toBe(true);
+      await captureUiProof(page, "agent-menu-without-new-session-rows.png");
       await page.keyboard.press("Enter");
-      await expect.poll(() => new URL(page.url()).pathname).toBe("/new");
-      expect(new URL(page.url()).searchParams.get("agent")).toBe("research");
+      await expect.poll(() => new URL(page.url()).pathname).toBe("/chat");
+      expect(new URL(page.url()).searchParams.get("session")).toBe("agent:research:main");
     } finally {
       await context.close();
     }

--- a/ui/src/pages/chat/components/chat-tool-cards.test.ts
+++ b/ui/src/pages/chat/components/chat-tool-cards.test.ts
@@ -52,9 +52,13 @@ describe("tool-cards", () => {
   });
 
   it("routes MCP App previews through the dedicated double-iframe host", async () => {
+    vi.resetModules();
+    const { renderToolPreview: renderToolPreviewWithLazyMock } = await import(
+      "./chat-tool-cards.ts"
+    );
     const container = document.createElement("div");
     render(
-      renderToolPreview(
+      renderToolPreviewWithLazyMock(
         {
           kind: "canvas",
           surface: "assistant_message",
@@ -86,7 +90,7 @@ describe("tool-cards", () => {
     lazyElementMocks.ensureCustomElementDefined.mockClear();
     const toolContainer = document.createElement("div");
     render(
-      renderToolPreview(
+      renderToolPreviewWithLazyMock(
         {
           kind: "canvas",
           surface: "assistant_message",

--- a/ui/src/pages/chat/components/chat-tool-cards.test.ts
+++ b/ui/src/pages/chat/components/chat-tool-cards.test.ts
@@ -53,9 +53,8 @@ describe("tool-cards", () => {
 
   it("routes MCP App previews through the dedicated double-iframe host", async () => {
     vi.resetModules();
-    const { renderToolPreview: renderToolPreviewWithLazyMock } = await import(
-      "./chat-tool-cards.ts"
-    );
+    const { renderToolPreview: renderToolPreviewWithLazyMock } =
+      await import("./chat-tool-cards.ts");
     const container = document.createElement("div");
     render(
       renderToolPreviewWithLazyMock(

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -2242,15 +2242,6 @@ wa-dropdown.sidebar-session-sort-menu::part(menu) {
   min-width: 0;
 }
 
-.sidebar-agent-menu__new {
-  padding-inline-start: 26px;
-}
-
-.sidebar-agent-menu__new:disabled {
-  opacity: 0.42;
-  cursor: not-allowed;
-}
-
 /* The docs row is the menu's only real hyperlink; keep it looking like a row. */
 .sidebar-agent-menu a.sidebar-customize-menu__item {
   color: inherit;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where opening the Control UI agent switcher showed a redundant “New session” row beneath every agent, making the menu twice as long and obscuring its primary job: switching agents.

## Why This Change Was Made

The switcher now renders exactly one selectable row per agent. Session creation remains available through the sidebar’s primary New Session controls, so the duplicate per-agent actions and their routing/style plumbing are removed rather than hidden.

The PR also isolates an existing MCP preview unit test from Vitest's shared module cache after that unrelated test blocked the UI lane on three consecutive exact-head CI attempts.

## User Impact

The agent switcher is shorter and easier to scan. Users can still start a new session from the existing sidebar controls and can switch agents with mouse or keyboard.

## Evidence

- Control UI browser E2E: `sidebar-customization.e2e.test.ts` — 8/8 passed, including no “New session —” rows and keyboard switching.
- Component tests: `app-sidebar.test.ts` — 75/75 passed.
- `pnpm check:changed` — passed (format, TypeScript, lint, repository guards).
- Blacksmith Testbox: `tbx_01kxfk01rdty47fgmhtjhxz0at`; Actions run 29309738162.
- Fresh autoreview: no accepted/actionable findings.
- CI stabilization review: `chat-tool-cards.test.ts` now imports its module under test only after resetting the module registry, ensuring its hoisted lazy-loader mock is active.

AI-assisted implementation; maintainer-directed behavior and validation.
