### PR TITLE
Report declined exec results as blocked

### DIFF
--- a/src/agents/embedded-agent-runner/run/payloads.test.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.test.ts
@@ -570,21 +570,23 @@ describe("buildEmbeddedRunPayloads tool-error warnings", () => {
     });
   });
 
-  it("surfaces declined Codex native command errors for aborted empty turns", () => {
+  it("surfaces declined Codex native command errors as blocked for aborted empty turns", () => {
     const payloads = buildPayloads({
       assistantTexts: [],
       lastToolError: {
         toolName: "bash",
         error: "codex native tool blocked",
+        blocked: true,
         mutatingAction: true,
       },
       runAborted: true,
     });
 
-    expectSingleToolErrorPayload(payloads, {
-      title: "Bash",
-      absentDetail: "codex native tool blocked",
-    });
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]?.isError).toBe(true);
+    expect(payloads[0]?.text).toContain("Bash blocked");
+    expect(payloads[0]?.text).not.toContain("Bash failed");
+    expect(payloads[0]?.text).not.toContain("codex native tool blocked");
   });
 
   it("surfaces exec tool errors for cron sessions even when verbose mode is off", () => {

--- a/src/agents/embedded-agent-runner/run/payloads.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.ts
@@ -221,6 +221,7 @@ function formatToolErrorWarningText(params: {
   includeDetails: boolean;
   useMarkdown: boolean;
 }): string {
+  const failureLabel = params.lastToolError.blocked ? "blocked" : "failed";
   if (isExecLikeToolName(params.lastToolError.toolName)) {
     const toolLabel = formatToolAggregate(params.lastToolError.toolName, undefined, {
       markdown: params.useMarkdown,
@@ -229,11 +230,12 @@ function formatToolErrorWarningText(params: {
     const conciseExitSuffix = params.includeDetails
       ? ""
       : formatConciseExecExitSuffix(params.lastToolError.error);
+    const blockedSuffix = params.lastToolError.blocked ? "" : conciseExitSuffix;
     const errorSuffix =
       params.includeDetails && params.lastToolError.error ? `: ${params.lastToolError.error}` : "";
     return subject
-      ? `⚠️ ${toolLabel} failed: ${subject}${conciseExitSuffix}${errorSuffix}`
-      : `⚠️ ${toolLabel} failed${conciseExitSuffix}${errorSuffix}`;
+      ? `⚠️ ${toolLabel} ${failureLabel}: ${subject}${blockedSuffix}${errorSuffix}`
+      : `⚠️ ${toolLabel} ${failureLabel}${blockedSuffix}${errorSuffix}`;
   }
 
   const toolSummary = formatToolAggregate(
@@ -243,7 +245,7 @@ function formatToolErrorWarningText(params: {
   );
   const errorSuffix =
     params.includeDetails && params.lastToolError.error ? `: ${params.lastToolError.error}` : "";
-  return `⚠️ ${toolSummary} failed${errorSuffix}`;
+  return `⚠️ ${toolSummary} ${failureLabel}${errorSuffix}`;
 }
 
 function formatExecLikeFailureSubject(meta: string | undefined, markdown: boolean): string {

--- a/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
@@ -2671,6 +2671,77 @@ describe("handleToolExecutionEnd derived tool events", () => {
     });
   });
 
+  it("emits declined exec results as blocked instead of failed command output", async () => {
+    const { ctx, onAgentEvent } = createTestContext();
+
+    await handleToolExecutionStart(
+      ctx as never,
+      {
+        type: "tool_execution_start",
+        toolName: "exec",
+        toolCallId: "tool-exec-declined",
+        args: { command: "sed -n '1,20p' docs/internal/bugs.md" },
+      } as never,
+    );
+
+    await handleToolExecutionEnd(
+      ctx as never,
+      {
+        type: "tool_execution_end",
+        toolName: "exec",
+        toolCallId: "tool-exec-declined",
+        isError: false,
+        result: {
+          details: {
+            status: "declined",
+            exitCode: null,
+            durationMs: null,
+          },
+        },
+      } as never,
+    );
+
+    expect(ctx.state.lastToolError).toMatchObject({
+      toolName: "exec",
+      blocked: true,
+      error: "declined",
+    });
+
+    const commandItemEvent = requireRecord(
+      onAgentEvent.mock.calls
+        .map((call) => call[0])
+        .find((event) => {
+          const candidate = event as {
+            stream?: string;
+            data?: { itemId?: string; phase?: string; status?: string };
+          };
+          return (
+            candidate.stream === "item" &&
+            candidate.data?.phase === "end" &&
+            candidate.data?.itemId === "command:tool-exec-declined"
+          );
+        }),
+      "declined command item event",
+    );
+    expectRecordFields(commandItemEvent.data, "declined command item event data", {
+      status: "blocked",
+    });
+
+    const commandOutputEvent = requireRecord(
+      onAgentEvent.mock.calls
+        .map((call) => call[0])
+        .find((event) => (event as { stream?: string })?.stream === "command_output"),
+      "declined command output event",
+    );
+    expectRecordFields(commandOutputEvent.data, "declined command output event data", {
+      itemId: "command:tool-exec-declined",
+      phase: "end",
+      status: "blocked",
+      exitCode: null,
+    });
+    expect(commandOutputEvent.data).not.toHaveProperty("durationMs");
+  });
+
   it("emits patch summary events for apply_patch results", async () => {
     const { ctx, onAgentEvent } = createTestContext();
 

--- a/src/agents/embedded-agent-subscribe.handlers.tools.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.ts
@@ -93,7 +93,7 @@ import {
 } from "./tool-error-summary.js";
 import { buildToolMutationState, isSameToolMutationAction } from "./tool-mutation.js";
 import { normalizeToolName } from "./tool-policy.js";
-import { readToolResultDetails } from "./tool-result-error.js";
+import { readToolResultDetails, resolveToolResultFailureKind } from "./tool-result-error.js";
 
 type ExecApprovalReplyModule = typeof import("../infra/exec-approval-reply.js");
 type HookRunnerGlobalModule = typeof import("../plugins/hook-runner-global.js");
@@ -1242,6 +1242,7 @@ export async function handleToolExecutionEnd(
   const toolSendReceiptResult = ctx.consumeToolSendReceipt?.(toolCallId);
   const observerIsError = isError || isToolResultError(result);
   const sanitizedResult = sanitizeToolResult(result);
+  const toolResultFailureKind = resolveToolResultFailureKind(sanitizedResult);
   const approvalUnavailable =
     isExecToolName(toolName) &&
     readExecToolDetails(sanitizedResult)?.status === "approval-unavailable";
@@ -1319,6 +1320,7 @@ export async function handleToolExecutionEnd(
       error: errorMessage,
       ...(validationErrorSummary ? { validationErrorSummary } : {}),
       timedOut: isToolResultTimedOut(sanitizedResult) || undefined,
+      blocked: toolResultFailureKind === "blocked" || undefined,
       middlewareError: isMiddlewareToolResultError(sanitizedResult) || undefined,
       mutatingAction: attemptedMutatingAction,
       actionFingerprint: attemptedMutatingAction ? callSummary.actionFingerprint : undefined,
@@ -1472,12 +1474,14 @@ export async function handleToolExecutionEnd(
   });
   const endedAt = Date.now();
   const itemId = buildToolItemId(toolCallId);
+  const itemStatus =
+    toolResultFailureKind === "blocked" ? "blocked" : isToolError ? "failed" : "completed";
   const itemData: AgentItemEventData = {
     itemId,
     phase: "end",
     kind: "tool",
     title: buildToolItemTitle(toolName, meta),
-    status: isToolError ? "failed" : "completed",
+    status: itemStatus,
     name: toolName,
     meta,
     toolCallId,
@@ -1566,7 +1570,11 @@ export async function handleToolExecutionEnd(
       const output = extractLiveExecOutput(eventResult);
       const rawOutput = extractExecOutput(sanitizedResult);
       const commandStatus =
-        execDetails?.status === "failed" || isToolError ? "failed" : "completed";
+        toolResultFailureKind === "blocked"
+          ? "blocked"
+          : execDetails?.status === "failed" || isToolError
+            ? "failed"
+            : "completed";
       emitTrackedItemEvent(ctx, {
         itemId: commandItemId,
         phase: "end",
@@ -1592,7 +1600,7 @@ export async function handleToolExecutionEnd(
         ...(output ? { output } : {}),
         status: commandStatus,
         ...(execDetails && "exitCode" in execDetails ? { exitCode: execDetails.exitCode } : {}),
-        ...(execDetails && "durationMs" in execDetails
+        ...(execDetails && "durationMs" in execDetails && typeof execDetails.durationMs === "number"
           ? { durationMs: execDetails.durationMs }
           : {}),
         ...(execDetails && "cwd" in execDetails && typeof execDetails.cwd === "string"

--- a/src/agents/embedded-agent-subscribe.tools.ts
+++ b/src/agents/embedded-agent-subscribe.tools.ts
@@ -112,7 +112,9 @@ function isErrorLikeStatus(status: string): boolean {
   ) {
     return false;
   }
-  return /error|fail|timeout|timed[_\s-]?out|denied|cancel|invalid|forbidden/.test(normalized);
+  return /error|fail|timeout|timed[_\s-]?out|declined|denied|cancel|invalid|forbidden/.test(
+    normalized,
+  );
 }
 
 function readErrorCandidate(value: unknown): string | undefined {

--- a/src/agents/tool-error-summary.ts
+++ b/src/agents/tool-error-summary.ts
@@ -13,6 +13,7 @@ export type ToolErrorSummary = {
   error?: string;
   validationErrorSummary?: string;
   timedOut?: boolean;
+  blocked?: boolean;
   middlewareError?: boolean;
   mutatingAction?: boolean;
   actionFingerprint?: string;

--- a/src/agents/tool-result-error.test.ts
+++ b/src/agents/tool-result-error.test.ts
@@ -32,6 +32,10 @@ describe("resolveToolExecutionErrorKind", () => {
 });
 
 describe("resolveToolResultFailureKind", () => {
+  it("classifies declined tool results as blocked", () => {
+    expect(resolveToolResultFailureKind({ details: { status: "declined" } })).toBe("blocked");
+  });
+
   it("contains hostile structured result fields", () => {
     const hostileDetails = new Proxy(
       {},

--- a/src/agents/tool-result-error.ts
+++ b/src/agents/tool-result-error.ts
@@ -90,6 +90,7 @@ export function isToolResultError(result: unknown): boolean {
     normalized === "timeout" ||
     normalized === "timed_out" ||
     normalized === "blocked" ||
+    normalized === "declined" ||
     normalized === "denied" ||
     normalized === "forbidden" ||
     normalized === "unavailable" ||
@@ -140,6 +141,7 @@ export function resolveToolResultFailureKind(result: unknown): ToolResultFailure
   const status = readToolResultStatus(result);
   if (
     status === "blocked" ||
+    status === "declined" ||
     status === "denied" ||
     status === "forbidden" ||
     status === "disabled" ||


### PR DESCRIPTION
## Summary

Fixes #107202.

This changes declined/pre-execution tool results so they are treated as blocked instead of failed. In chat, a declined exec/Bash result now surfaces as blocked rather than `Bash failed`, which avoids implying the shell actually ran.

## What Changed

- Classify structured `status: declined` tool results as blocked failures.
- Preserve that blocked state on the last tool error summary.
- Emit blocked item/command-output status for declined exec results.
- Avoid forwarding `durationMs: null` in command-output telemetry.
- Use `blocked` in user-facing tool warnings when the failure was a block/decline.

## Validation

- `node scripts/test-projects.mjs src/agents/tool-result-error.test.ts src/agents/embedded-agent-subscribe.handlers.tools.test.ts src/agents/embedded-agent-runner/run/payloads.test.ts`
- `pnpm tsgo:core`
