### PR TITLE
test: isolate queued CLI progress ordering

### DIFF
--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -2293,7 +2293,7 @@ describe("createFollowupRunner runtime config", () => {
         },
       });
       return {
-        payloads: [{ text: "final" }],
+        payloads: [],
         meta: { agentMeta: { provider: "claude-cli", model: "claude-opus-4-7" } },
       };
     });
@@ -2312,12 +2312,13 @@ describe("createFollowupRunner runtime config", () => {
 
     await runner(
       createQueuedRun({
-        originatingChannel: "mattermost",
+        originatingChannel: undefined,
+        originatingTo: undefined,
         run: {
           config: runtimeConfig,
           provider: "anthropic",
           model: "claude-opus-4-7",
-          messageProvider: "mattermost",
+          messageProvider: undefined,
           sourceReplyDeliveryMode: "message_tool_only",
           verboseLevel: "on",
         },


### PR DESCRIPTION
## What Problem This Solves

`src/auto-reply/reply/followup-runner.test.ts` spent most of its runtime initializing source-channel delivery for a test that only verifies CLI progress callback ordering.

## Why This Change Was Made

The ordering test now uses an empty terminal result with no source route. That keeps the exercised tool/commentary bridge unchanged while avoiding unrelated channel normalization and final-delivery work covered by the dedicated delivery tests in the same file.

## User Impact

No runtime behavior changes. The 149-test file completes substantially faster in CI.

## Evidence

- Blacksmith Testbox `tbx_01kxfktgkzj38gkabh4e092w0b`: full file, 149 passed; Vitest duration 27.20s before and 6.93s after.
- Focused ordering test passed; 10.10s before and 3.27s after in clean verbose runs.
- `pnpm check:changed` passed, including format, test typecheck, and lint.
- Mandatory autoreview: clean, no actionable findings.
