### PR TITLE
refactor(scripts): use dependency metadata parsers

### DIFF
--- a/scripts/gh-read.ts
+++ b/scripts/gh-read.ts
@@ -1,11 +1,17 @@
 // Gh Read script supports OpenClaw repository automation.
-import { execFileSync, spawnSync } from "node:child_process";
+import { spawnSync } from "node:child_process";
 import { createPrivateKey, createSign } from "node:crypto";
 import { readFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 import { expectDefined } from "../packages/normalization-core/src/expect.js";
 import { readBoundedResponseText } from "./lib/bounded-response.ts";
 import { parseStrictIntegerOption } from "./lib/dev-tooling-safety.ts";
+import {
+  normalizeGitHubRepo as normalizeRepo,
+  resolveGitHubRepoFromOrigin,
+} from "./lib/github-repo.ts";
+
+export { normalizeRepo };
 
 const APP_ID_ENV = "OPENCLAW_GH_READ_APP_ID";
 const KEY_FILE_ENV = "OPENCLAW_GH_READ_PRIVATE_KEY_FILE";
@@ -63,23 +69,6 @@ export function parseRepoArg(args: string[]): string | null {
     }
   }
   return null;
-}
-
-export function normalizeRepo(value: string | null | undefined): string | null {
-  const trimmed = value?.trim();
-  if (!trimmed) {
-    return null;
-  }
-
-  const withoutProtocol = trimmed.replace(/^[a-z]+:\/\//i, "");
-  const withoutHost = withoutProtocol.replace(/^(?:[^@/]+@)?github\.com[:/]/i, "");
-  const normalized = withoutHost.replace(/\.git$/i, "").replace(/^\/+|\/+$/g, "");
-  const parts = normalized.split("/").filter(Boolean);
-  if (parts.length < 2) {
-    return null;
-  }
-
-  return `${parts[parts.length - 2]}/${parts[parts.length - 1]}`;
 }
 
 export function parsePermissionKeys(raw: string | null | undefined): string[] {
@@ -147,11 +136,7 @@ function resolveRepo(args: string[]): string | null {
   }
 
   try {
-    const remote = execFileSync("git", ["config", "--get", "remote.origin.url"], {
-      encoding: "utf8",
-      stdio: ["ignore", "pipe", "ignore"],
-    }).trim();
-    return normalizeRepo(remote);
+    return resolveGitHubRepoFromOrigin();
   } catch {
     return null;
   }

--- a/scripts/label-open-issues.ts
+++ b/scripts/label-open-issues.ts
@@ -7,6 +7,7 @@ import { pathToFileURL } from "node:url";
 import { isRecord } from "../src/utils.js";
 import { readBoundedResponseText as readBoundedBodyText } from "./lib/bounded-response.ts";
 import { parseStrictIntegerOption } from "./lib/dev-tooling-safety.ts";
+import { resolveGitHubRepoFromOrigin } from "./lib/github-repo.ts";
 
 function writeStdoutLine(message = ""): void {
   process.stdout.write(`${message}\n`);
@@ -466,33 +467,8 @@ function runGh(args: string[]): string {
 }
 
 function resolveRepo(): RepoInfo {
-  const remote = execFileSync("git", ["config", "--get", "remote.origin.url"], {
-    encoding: "utf8",
-  }).trim();
-
-  if (!remote) {
-    throw new Error("Unable to determine repository from git remote.");
-  }
-
-  const normalized = remote.replace(/\.git$/, "");
-
-  if (normalized.startsWith("git@github.com:")) {
-    const slug = normalized.replace("git@github.com:", "");
-    const [owner, name] = slug.split("/");
-    if (owner && name) {
-      return { owner, name };
-    }
-  }
-
-  if (normalized.startsWith("https://github.com/")) {
-    const slug = normalized.replace("https://github.com/", "");
-    const [owner, name] = slug.split("/");
-    if (owner && name) {
-      return { owner, name };
-    }
-  }
-
-  throw new Error(`Unsupported GitHub remote: ${remote}`);
+  const [owner, name] = resolveGitHubRepoFromOrigin().split("/") as [string, string];
+  return { owner, name };
 }
 
 function fetchIssuePage(repo: RepoInfo, after: string | null): IssuePage {

--- a/scripts/lib/github-repo.ts
+++ b/scripts/lib/github-repo.ts
@@ -1,0 +1,31 @@
+import { execFileSync } from "node:child_process";
+import hostedGitInfo from "hosted-git-info";
+
+export function normalizeGitHubRepo(value: string | null | undefined): string | null {
+  const trimmed = value?.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  const candidate = /^github\.com\//i.test(trimmed) ? `https://${trimmed}` : trimmed;
+  const info = hostedGitInfo.fromUrl(candidate);
+  return info?.type === "github" && info.user && info.project
+    ? `${info.user}/${info.project}`
+    : null;
+}
+
+export function resolveGitHubRepoFromOrigin(): string {
+  const remote = execFileSync("git", ["config", "--get", "remote.origin.url"], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "ignore"],
+  }).trim();
+  if (!remote) {
+    throw new Error("Unable to determine repository from git remote.");
+  }
+
+  const repo = normalizeGitHubRepo(remote);
+  if (!repo) {
+    throw new Error(`Unsupported GitHub remote: ${remote}`);
+  }
+  return repo;
+}

--- a/scripts/sync-labels.ts
+++ b/scripts/sync-labels.ts
@@ -2,6 +2,8 @@
 import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
+import { parse } from "yaml";
+import { resolveGitHubRepoFromOrigin } from "./lib/github-repo.ts";
 
 type RepoLabel = {
   name: string;
@@ -48,15 +50,10 @@ const EXTRA_LABELS = [
   "size: XL",
   "beta-blocker",
 ] as const;
-const labelNames = [
-  ...new Set([...extractLabelNames(readFileSync(configPath, "utf8")), ...EXTRA_LABELS]),
-];
+const labelerConfig = parse(readFileSync(configPath, "utf8")) as Record<string, unknown>;
+const labelNames = [...new Set([...Object.keys(labelerConfig), ...EXTRA_LABELS])];
 
-if (!labelNames.length) {
-  throw new Error("labeler.yml must declare at least one label.");
-}
-
-const repo = resolveRepo();
+const repo = resolveGitHubRepoFromOrigin();
 const existing = fetchExistingLabels(repo);
 
 const missing = labelNames.filter((label) => !existing.has(label));
@@ -84,26 +81,6 @@ for (const label of missing) {
   console.log(`Created label: ${label}`);
 }
 
-function extractLabelNames(contents: string): string[] {
-  const labels: string[] = [];
-  for (const line of contents.split("\n")) {
-    if (!line.trim() || line.trimStart().startsWith("#")) {
-      continue;
-    }
-    if (/^\s/.test(line)) {
-      continue;
-    }
-    const match = line.match(/^(["'])(.+)\1\s*:/) ?? line.match(/^([^:]+):/);
-    if (match) {
-      const name = (match[2] ?? match[1] ?? "").trim();
-      if (name) {
-        labels.push(name);
-      }
-    }
-  }
-  return labels;
-}
-
 function resolveLabelMetadata(label: string): { color: string; description?: string } {
   const extraMetadata = EXTRA_LABEL_METADATA.get(label);
   if (extraMetadata) {
@@ -111,26 +88,6 @@ function resolveLabelMetadata(label: string): { color: string; description?: str
   }
   const prefix = label.includes(":") ? label.slice(0, label.indexOf(":")).trim() : label.trim();
   return { color: COLOR_BY_PREFIX.get(prefix) ?? "ededed" };
-}
-
-function resolveRepo(): string {
-  const remote = execFileSync("git", ["config", "--get", "remote.origin.url"], {
-    encoding: "utf8",
-  }).trim();
-
-  if (!remote) {
-    throw new Error("Unable to determine repository from git remote.");
-  }
-
-  if (remote.startsWith("git@github.com:")) {
-    return remote.replace("git@github.com:", "").replace(/\.git$/, "");
-  }
-
-  if (remote.startsWith("https://github.com/")) {
-    return remote.replace("https://github.com/", "").replace(/\.git$/, "");
-  }
-
-  throw new Error(`Unsupported GitHub remote: ${remote}`);
 }
 
 function fetchExistingLabels(repoLocal: string): Map<string, RepoLabel> {

--- a/test/scripts/gh-read.test.ts
+++ b/test/scripts/gh-read.test.ts
@@ -42,8 +42,10 @@ describe("gh-read helpers", () => {
   it("normalizes repo strings from common git formats", () => {
     expect(normalizeRepo("openclaw/openclaw")).toBe("openclaw/openclaw");
     expect(normalizeRepo("github.com/openclaw/openclaw")).toBe("openclaw/openclaw");
+    expect(normalizeRepo("github:openclaw/openclaw")).toBe("openclaw/openclaw");
     expect(normalizeRepo("https://github.com/openclaw/openclaw.git")).toBe("openclaw/openclaw");
     expect(normalizeRepo("git@github.com:openclaw/openclaw.git")).toBe("openclaw/openclaw");
+    expect(normalizeRepo("https://gitlab.com/openclaw/openclaw.git")).toBeNull();
     expect(normalizeRepo("invalid")).toBeNull();
   });
 


### PR DESCRIPTION
## What Problem This Solves

Three repository-maintenance scripts each parsed GitHub remotes by hand, and the label sync script scanned YAML with line regexes. These duplicate parsers added 80 lines around behavior already owned by installed dependencies.

## Why This Change Was Made

Use `hosted-git-info@10.1.1` behind one shared GitHub repository helper and `yaml@2.9.0` for labeler config keys. The shared helper also stops accepting non-GitHub URLs as GitHub repositories.

## User Impact

Internal maintainer scripts keep their accepted GitHub URL forms while gaining one canonical parser. Net repository reduction: 49 lines.

## Evidence

- Exact installed source/types inspected for `hosted-git-info@10.1.1` and `yaml@2.9.0`.
- Blacksmith Testbox: 22/22 focused script tests passed.
- `pnpm check:changed` passed script/test typechecks, format, lint, LOC ratchet, and repository guards.
- The YAML parser returned the same 140 top-level labels as the removed scanner.
- Fresh autoreview: clean, confidence 0.92.
