### PR TITLE
fix(terminal): keystrokes typed while a terminal opens are lost; node PTY relay lifecycle races

### DIFF
--- a/packages/gateway-protocol/src/schema/terminal.ts
+++ b/packages/gateway-protocol/src/schema/terminal.ts
@@ -118,7 +118,7 @@ export type TerminalTextResult = Static<typeof TerminalTextResultSchema>;
 export const TerminalAckResultSchema = closedObject({ ok: Type.Boolean() });
 export type TerminalAckResult = Static<typeof TerminalAckResultSchema>;
 
-/** Streamed output chunk; seq lets the client detect gaps and preserve order. */
+/** Streamed output chunk; seq is a per-session monotonic counter for diagnostics and tests. */
 export const TerminalDataEventSchema = closedObject({
   sessionId: NonEmptyString,
   seq: Type.Integer({ minimum: 0 }),

--- a/src/gateway/node-registry.test.ts
+++ b/src/gateway/node-registry.test.ts
@@ -749,6 +749,61 @@ describe("gateway/node-registry", () => {
     }
   });
 
+  it("bounds future progress behind a permanent sequence gap until idle teardown", async () => {
+    vi.useFakeTimers();
+    const registry = new NodeRegistry();
+    try {
+      const frames = registerNode(registry);
+      const invoke = registry.invoke({
+        nodeId: "node-1",
+        command: "agent.cli.claude.run.v1",
+        timeoutMs: 10_000,
+        idleTimeoutMs: 50,
+        onProgress: () => {},
+      });
+      const request = JSON.parse(frames[0] ?? "{}") as { payload?: { id?: string } };
+      const invokeId = request.payload?.id ?? "";
+      expect(
+        registry.handleInvokeProgress({
+          invokeId,
+          nodeId: "node-1",
+          connId: "conn-1",
+          seq: 0,
+          chunk: "start",
+        }),
+      ).toBe(true);
+
+      for (let seq = 2; seq < 130; seq += 1) {
+        expect(
+          registry.handleInvokeProgress({
+            invokeId,
+            nodeId: "node-1",
+            connId: "conn-1",
+            seq,
+            chunk: `future-${seq}`,
+          }),
+        ).toBe(true);
+      }
+      expect(
+        registry.handleInvokeProgress({
+          invokeId,
+          nodeId: "node-1",
+          connId: "conn-1",
+          seq: 130,
+          chunk: "over-cap",
+        }),
+      ).toBe(false);
+
+      await vi.advanceTimersByTimeAsync(50);
+      await expect(invoke).resolves.toEqual({
+        ok: false,
+        error: { code: "IDLE_TIMEOUT", message: "node invoke produced no progress" },
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("stops draining buffered progress once onProgress aborts the invoke", async () => {
     const registry = new NodeRegistry();
     const frames = registerNode(registry);

--- a/src/gateway/server-methods/terminal.test.ts
+++ b/src/gateway/server-methods/terminal.test.ts
@@ -370,9 +370,11 @@ describe("terminal gateway policy", () => {
       }),
     );
     expect(sessions.open).toHaveBeenCalledOnce();
-    const openRequest = sessions.open.mock.calls[0]?.[0] as
-      | { createBackend?: () => Promise<unknown> }
-      | undefined;
+    const openRequest = (
+      sessions.open.mock.calls.at(0) as unknown as
+        | [{ createBackend?: () => Promise<unknown> }]
+        | undefined
+    )?.at(0);
     await openRequest?.createBackend?.();
     expect(invoke).toHaveBeenCalledWith(
       expect.objectContaining({ nodeId: "node-1", expectedConnId: "conn-node" }),

--- a/src/gateway/server-methods/terminal.test.ts
+++ b/src/gateway/server-methods/terminal.test.ts
@@ -340,6 +340,11 @@ describe("terminal gateway policy", () => {
       }),
     });
     const node = { nodeId: "node-1", connId: "conn-node", commands: [command] };
+    const invoke = vi.fn((params: { onInvokeId?: (id: string) => void }) => {
+      params.onInvokeId?.("invoke-1");
+      return Promise.resolve({ ok: true });
+    });
+    const nodeRegistry = { get: () => node, invoke, sendInvokeInput: vi.fn() };
     const { opts, sessions } = makeOpts(
       {
         cols: 100,
@@ -348,7 +353,7 @@ describe("terminal gateway policy", () => {
       },
       { enabled: true },
       undefined,
-      { get: () => node },
+      nodeRegistry,
     );
 
     await expectDefined(terminalHandlers["terminal.open"], "terminal.open")(opts);
@@ -365,6 +370,13 @@ describe("terminal gateway policy", () => {
       }),
     );
     expect(sessions.open).toHaveBeenCalledOnce();
+    const openRequest = sessions.open.mock.calls[0]?.[0] as
+      | { createBackend?: () => Promise<unknown> }
+      | undefined;
+    await openRequest?.createBackend?.();
+    expect(invoke).toHaveBeenCalledWith(
+      expect.objectContaining({ nodeId: "node-1", expectedConnId: "conn-node" }),
+    );
   });
 
   it("rejects a replacement node connection that lacks the terminal command", async () => {

--- a/src/gateway/server-methods/terminal.ts
+++ b/src/gateway/server-methods/terminal.ts
@@ -100,6 +100,12 @@ export const terminalHandlers: GatewayRequestHandlers = {
     let catalogPlan: SessionCatalogTerminalPlan | undefined;
     let title: string | undefined;
     let createBackend: (() => ReturnType<typeof createNodeRelayBackend>) | undefined;
+    let nodeRelay:
+      | {
+          plan: Extract<SessionCatalogTerminalPlan, { kind: "node" }>;
+          params: Record<string, unknown>;
+        }
+      | undefined;
     if (p.catalog) {
       const provider = resolveSessionCatalogProvider(p.catalog.catalogId);
       if (!provider) {
@@ -169,13 +175,7 @@ export const terminalHandlers: GatewayRequestHandlers = {
           respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, policyResult.message));
           return;
         }
-        createBackend = async () =>
-          await createNodeRelayBackend({
-            registry: context.nodeRegistry,
-            nodeId: nodeCatalogPlan.nodeId,
-            command: nodeCatalogPlan.command,
-            params: nodeParams,
-          });
+        nodeRelay = { plan: nodeCatalogPlan, params: nodeParams };
       }
     }
 
@@ -192,12 +192,21 @@ export const terminalHandlers: GatewayRequestHandlers = {
       respondLaunchBlocked(respond, refreshedLaunch.block);
       return;
     }
-    if (catalogPlan?.kind === "node") {
-      const access = authorizeCatalogTerminalNode(context, catalogPlan);
+    if (nodeRelay) {
+      const relay = nodeRelay;
+      const access = authorizeCatalogTerminalNode(context, relay.plan);
       if (!access.ok) {
         respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, access.message));
         return;
       }
+      createBackend = async () =>
+        await createNodeRelayBackend({
+          registry: context.nodeRegistry,
+          nodeId: relay.plan.nodeId,
+          expectedConnId: access.node.connId,
+          command: relay.plan.command,
+          params: relay.params,
+        });
     }
     const spawnPlan = resolveTerminalOpenSpawnPlan(refreshedLaunch.plan, catalogPlan);
     const outcome = await manager.open({

--- a/src/gateway/terminal/node-relay.test.ts
+++ b/src/gateway/terminal/node-relay.test.ts
@@ -34,6 +34,7 @@ describe("createNodeRelayBackend", () => {
     const backend = await createNodeRelayBackend({
       registry,
       nodeId: "node-1",
+      expectedConnId: "conn-1",
       command: "codex.terminal.resume.v1",
       params: { threadId: "thread" },
     });
@@ -78,6 +79,7 @@ describe("createNodeRelayBackend", () => {
     const backend = await createNodeRelayBackend({
       registry,
       nodeId: "node-1",
+      expectedConnId: "conn-1",
       command: "anthropic.claude.terminal.resume.v1",
       params: {},
     });
@@ -86,5 +88,109 @@ describe("createNodeRelayBackend", () => {
     await vi.waitFor(() =>
       expect(exit).toHaveBeenCalledWith({ error: "NOT_CONNECTED: node disconnected" }),
     );
+  });
+
+  it("pins the expected connection and reports route changes through onExit", async () => {
+    const invoke = vi.fn((params: { onInvokeId?: (id: string) => void }) => {
+      params.onInvokeId?.("invoke-route-changed");
+      return Promise.resolve({
+        ok: false,
+        error: { code: "ROUTE_CHANGED", message: "node connection changed before dispatch" },
+      });
+    });
+    const registry = { invoke, sendInvokeInput: vi.fn() } as unknown as NodeRegistry;
+    const backend = await createNodeRelayBackend({
+      registry,
+      nodeId: "node-1",
+      expectedConnId: "conn-authorized",
+      command: "codex.terminal.resume.v1",
+      params: {},
+    });
+    const exit = vi.fn();
+    backend.onExit(exit);
+
+    expect(invoke).toHaveBeenCalledWith(
+      expect.objectContaining({ nodeId: "node-1", expectedConnId: "conn-authorized" }),
+    );
+    await vi.waitFor(() =>
+      expect(exit).toHaveBeenCalledWith({
+        error: "ROUTE_CHANGED: node connection changed before dispatch",
+      }),
+    );
+  });
+
+  it("bounds output buffered before onData registration", async () => {
+    let onProgress: ((chunk: string) => void) | undefined;
+    const registry = {
+      invoke: vi.fn(
+        (params: { onInvokeId?: (id: string) => void; onProgress?: (chunk: string) => void }) => {
+          onProgress = params.onProgress;
+          params.onInvokeId?.("invoke-buffered");
+          return Promise.resolve({ ok: true });
+        },
+      ),
+      sendInvokeInput: vi.fn(),
+    } as unknown as NodeRegistry;
+    const backend = await createNodeRelayBackend({
+      registry,
+      nodeId: "node-1",
+      expectedConnId: "conn-1",
+      command: "codex.terminal.resume.v1",
+      params: {},
+    });
+    const chunkChars = 256 * 1024;
+    onProgress?.("a".repeat(chunkChars));
+    onProgress?.("b".repeat(chunkChars));
+    onProgress?.("c".repeat(chunkChars));
+    const data = vi.fn();
+
+    backend.onData(data);
+
+    expect(data.mock.calls.map(([chunk]) => chunk)).toEqual([
+      "b".repeat(chunkChars),
+      "c".repeat(chunkChars),
+    ]);
+
+    const surrogateBackend = await createNodeRelayBackend({
+      registry,
+      nodeId: "node-1",
+      expectedConnId: "conn-1",
+      command: "codex.terminal.resume.v1",
+      params: {},
+    });
+    const capChars = 512 * 1024;
+    onProgress?.(`x😀${"y".repeat(capChars - 1)}`);
+    const surrogateData = vi.fn();
+
+    surrogateBackend.onData(surrogateData);
+
+    expect(surrogateData).toHaveBeenCalledWith("y".repeat(capChars - 1));
+  });
+
+  it("never splits a surrogate pair at the input chunk boundary", async () => {
+    const sendInvokeInput = vi.fn();
+    const registry = {
+      invoke: vi.fn((params: { onInvokeId?: (id: string) => void }) => {
+        params.onInvokeId?.("invoke-input");
+        return Promise.resolve({ ok: true });
+      }),
+      sendInvokeInput,
+    } as unknown as NodeRegistry;
+    const backend = await createNodeRelayBackend({
+      registry,
+      nodeId: "node-1",
+      expectedConnId: "conn-1",
+      command: "codex.terminal.resume.v1",
+      params: {},
+    });
+    const input = `${"a".repeat(2047)}😀b`;
+
+    backend.write(input);
+
+    const chunks = sendInvokeInput.mock.calls.map(
+      (call) => (call[1] as { kind: "data"; data: string }).data,
+    );
+    expect(chunks.join("")).toBe(input);
+    expect(chunks).toEqual(["a".repeat(2047), "😀b"]);
   });
 });

--- a/src/gateway/terminal/node-relay.ts
+++ b/src/gateway/terminal/node-relay.ts
@@ -1,8 +1,10 @@
 import { NODE_DUPLEX_INVOKE_IDLE_TIMEOUT_MS } from "../../infra/node-commands.js";
 import type { NodeRegistry, NodeInvokeResult } from "../node-registry.js";
 import type { TerminalBackend, TerminalBackendExit } from "./backend.js";
+import { surrogateSafeTail } from "./output-ring.js";
 
 const DATA_INPUT_CHUNK_BYTES = 2 * 1024;
+const MAX_PENDING_DATA_CHARS = 512 * 1024;
 
 function parseExit(result: NodeInvokeResult): TerminalBackendExit {
   if (!result.ok) {
@@ -61,6 +63,7 @@ function splitInput(data: string): string[] {
 export async function createNodeRelayBackend(params: {
   registry: NodeRegistry;
   nodeId: string;
+  expectedConnId: string;
   command: string;
   params: Record<string, unknown>;
 }): Promise<TerminalBackend> {
@@ -68,11 +71,13 @@ export async function createNodeRelayBackend(params: {
   let dataCallback: ((data: string) => void) | undefined;
   let exitCallback: ((exit: TerminalBackendExit) => void) | undefined;
   const pendingData: string[] = [];
+  let pendingDataChars = 0;
   let pendingExit: TerminalBackendExit | undefined;
   const abort = new AbortController();
   const result = params.registry
     .invoke({
       nodeId: params.nodeId,
+      expectedConnId: params.expectedConnId,
       command: params.command,
       params: params.params,
       timeoutMs: 0,
@@ -89,6 +94,16 @@ export async function createNodeRelayBackend(params: {
           dataCallback(chunk);
         } else {
           pendingData.push(chunk);
+          pendingDataChars += chunk.length;
+          // Registration should be immediate, but bound this gap so a delayed
+          // caller cannot retain unbounded PTY output; repaint recovers after drops.
+          while (pendingDataChars > MAX_PENDING_DATA_CHARS && pendingData.length > 1) {
+            pendingDataChars -= pendingData.shift()?.length ?? 0;
+          }
+          if (pendingDataChars > MAX_PENDING_DATA_CHARS) {
+            pendingData[0] = surrogateSafeTail(chunk, MAX_PENDING_DATA_CHARS);
+            pendingDataChars = pendingData[0].length;
+          }
         }
       },
     })
@@ -132,6 +147,7 @@ export async function createNodeRelayBackend(params: {
       for (const chunk of pendingData.splice(0)) {
         callback(chunk);
       }
+      pendingDataChars = 0;
     },
     onExit(callback) {
       exitCallback = callback;

--- a/src/gateway/terminal/output-ring.ts
+++ b/src/gateway/terminal/output-ring.ts
@@ -6,7 +6,7 @@
  * mid-escape cut the emulator repaints over.
  */
 export function surrogateSafeTail(chunk: string, cap: number): string {
-  let start = chunk.length - cap;
+  const start = chunk.length - cap;
   const startsOnLowSurrogate =
     start > 0 &&
     chunk.charCodeAt(start) >= 0xdc00 &&

--- a/src/gateway/terminal/output-ring.ts
+++ b/src/gateway/terminal/output-ring.ts
@@ -1,4 +1,21 @@
 // Bounded terminal scrollback storage shared by session lifecycle operations.
+
+/**
+ * Last `cap` chars of `chunk`, nudged forward one unit when the cut would land
+ * mid-surrogate-pair: a replayed lone surrogate is permanent mojibake, unlike a
+ * mid-escape cut the emulator repaints over.
+ */
+export function surrogateSafeTail(chunk: string, cap: number): string {
+  let start = chunk.length - cap;
+  const startsOnLowSurrogate =
+    start > 0 &&
+    chunk.charCodeAt(start) >= 0xdc00 &&
+    chunk.charCodeAt(start) <= 0xdfff &&
+    chunk.charCodeAt(start - 1) >= 0xd800 &&
+    chunk.charCodeAt(start - 1) <= 0xdbff;
+  return chunk.slice(startsOnLowSurrogate ? start + 1 : start);
+}
+
 /**
  * Raw output, not a screen snapshot: head truncation can start replay mid-escape,
  * and the emulator recovers on its next full repaint.
@@ -11,8 +28,9 @@ export class TerminalOutputRing {
 
   push(chunk: string): void {
     if (chunk.length >= this.cap) {
-      this.chunks = [chunk.slice(chunk.length - this.cap)];
-      this.total = this.cap;
+      const tail = surrogateSafeTail(chunk, this.cap);
+      this.chunks = [tail];
+      this.total = tail.length;
       return;
     }
     this.chunks.push(chunk);

--- a/src/gateway/terminal/session-manager.test.ts
+++ b/src/gateway/terminal/session-manager.test.ts
@@ -537,7 +537,10 @@ describe("TerminalSessionManager detach/reattach", () => {
 
     const dataEvents = emit.mock.calls
       .filter(([, event]) => event === TERMINAL_EVENT_DATA)
-      .map(([connId, , payload]) => ({ connId, ...(payload as { seq: number; data: string }) }));
+      .map(([connId, , payload]) => {
+        const data = payload as { sessionId: string; seq: number; data: string };
+        return { connId, sessionId: data.sessionId, seq: data.seq, data: data.data };
+      });
     expect(dataEvents).toEqual([
       { connId: "conn-1", sessionId, seq: 0, data: "first" },
       { connId: "conn-2", sessionId, seq: 1, data: "second" },

--- a/src/gateway/terminal/session-manager.test.ts
+++ b/src/gateway/terminal/session-manager.test.ts
@@ -100,6 +100,67 @@ describe("TerminalSessionManager", () => {
     expect(manager.size).toBe(0);
   });
 
+  it("finalizes a session when backend resize throws", async () => {
+    const emit = vi.fn();
+    const kill = vi.fn();
+    const backend: TerminalBackend = {
+      write: vi.fn(),
+      resize: () => {
+        throw new Error("dead PTY");
+      },
+      kill,
+      onData: vi.fn(),
+      onExit: vi.fn(),
+    };
+    const manager = new TerminalSessionManager({ emit });
+    const opened = await manager.open(baseRequest({ createBackend: async () => backend }));
+    if (!opened.ok) {
+      throw new Error("expected relay backend open");
+    }
+
+    expect(manager.resize("conn-1", opened.sessionId, 120, 40)).toBe(false);
+    expect(manager.size).toBe(0);
+    expect(kill).toHaveBeenCalledOnce();
+    expect(emit).toHaveBeenCalledWith("conn-1", TERMINAL_EVENT_EXIT, {
+      sessionId: opened.sessionId,
+      exitCode: null,
+      signal: null,
+      reason: "error",
+      error: "resize failed",
+    });
+  });
+
+  it("delivers relay backend errors to the owning connection", async () => {
+    let onExit:
+      | ((exit: { exitCode?: number; signal?: number; error?: string }) => void)
+      | undefined;
+    const backend: TerminalBackend = {
+      write: vi.fn(),
+      resize: vi.fn(),
+      kill: vi.fn(),
+      onData: vi.fn(),
+      onExit: (callback) => {
+        onExit = callback;
+      },
+    };
+    const emit = vi.fn();
+    const manager = new TerminalSessionManager({ emit });
+    const opened = await manager.open(baseRequest({ createBackend: async () => backend }));
+    if (!opened.ok) {
+      throw new Error("expected relay backend open");
+    }
+
+    onExit?.({ error: "ROUTE_CHANGED: node connection changed before dispatch" });
+
+    expect(emit).toHaveBeenCalledWith("conn-1", TERMINAL_EVENT_EXIT, {
+      sessionId: opened.sessionId,
+      exitCode: null,
+      signal: null,
+      reason: "error",
+      error: "ROUTE_CHANGED: node connection changed before dispatch",
+    });
+  });
+
   it("opens a session and streams output only to the owning connection", async () => {
     const emit = vi.fn();
     const fake = makeFakePty();
@@ -369,6 +430,23 @@ describe("TerminalSessionManager output ring", () => {
     expect(manager.snapshot(outcome.sessionId)).toBe("456789AB");
   });
 
+  it("does not retain a leading lone low surrogate from an oversized chunk", async () => {
+    const fake = makeFakePty();
+    const manager = new TerminalSessionManager({
+      emit: vi.fn(),
+      spawn: async () => fake,
+      scrollbackChars: 3,
+    });
+    const outcome = await manager.open(baseRequest());
+    if (!outcome.ok) {
+      throw new Error("expected open");
+    }
+
+    fake.emitData("ab😀cd");
+
+    expect(manager.snapshot(outcome.sessionId)).toBe("cd");
+  });
+
   it("returns undefined for unknown sessions", () => {
     const manager = new TerminalSessionManager({ emit: vi.fn() });
     expect(manager.snapshot("nope")).toBeUndefined();
@@ -444,6 +522,27 @@ describe("TerminalSessionManager detach/reattach", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("keeps data sequence numbers monotonic across repeated detach and attach", async () => {
+    const { manager, fake, emit, sessionId } = await openDetachable();
+    fake.emitData("first");
+    manager.handleDisconnect("conn-1");
+    fake.emitData("detached");
+    manager.attach("conn-2", sessionId);
+    fake.emitData("second");
+    manager.handleDisconnect("conn-2");
+    manager.attach("conn-3", sessionId);
+    fake.emitData("third");
+
+    const dataEvents = emit.mock.calls
+      .filter(([, event]) => event === TERMINAL_EVENT_DATA)
+      .map(([connId, , payload]) => ({ connId, ...(payload as { seq: number; data: string }) }));
+    expect(dataEvents).toEqual([
+      { connId: "conn-1", sessionId, seq: 0, data: "first" },
+      { connId: "conn-2", sessionId, seq: 1, data: "second" },
+      { connId: "conn-3", sessionId, seq: 2, data: "third" },
+    ]);
   });
 
   it("attach takes over a live session and notifies the previous owner", async () => {

--- a/src/gateway/terminal/session-manager.ts
+++ b/src/gateway/terminal/session-manager.ts
@@ -256,6 +256,7 @@ export class TerminalSessionManager {
       session.backend.resize(cols, rows);
       return true;
     } catch {
+      this.finalize(session, "error", { error: "resize failed" });
       return false;
     }
   }

--- a/src/gateway/terminal/session-manager.ts
+++ b/src/gateway/terminal/session-manager.ts
@@ -11,7 +11,6 @@ import { TerminalOutputRing } from "./output-ring.js";
 /** Emits one terminal event frame to the single owning connection. */
 type TerminalEventSink = (connId: string, event: string, payload: unknown) => void;
 
-/** Injectable PTY spawner so tests can drive sessions without a real shell. */
 const TERMINAL_EVENT_DATA = "terminal.data" as const;
 const TERMINAL_EVENT_EXIT = "terminal.exit" as const;
 

--- a/src/node-host/invoke-payload.test.ts
+++ b/src/node-host/invoke-payload.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { coerceNodeInvokeInputPayload } from "./invoke-payload.js";
+
+describe("coerceNodeInvokeInputPayload", () => {
+  it("accepts a bounded well-formed input payload", () => {
+    expect(
+      coerceNodeInvokeInputPayload({
+        id: "invoke-1",
+        nodeId: "node-1",
+        seq: 0,
+        payloadJSON: JSON.stringify({ kind: "data", data: "keys" }),
+      }),
+    ).toEqual({
+      invokeId: "invoke-1",
+      nodeId: "node-1",
+      seq: 0,
+      payloadJSON: JSON.stringify({ kind: "data", data: "keys" }),
+    });
+  });
+
+  it.each([
+    [
+      "oversized payloadJSON",
+      { id: "i", nodeId: "n", seq: 0, payloadJSON: "x".repeat(16 * 1024 + 1) },
+    ],
+    ["negative seq", { id: "i", nodeId: "n", seq: -1, payloadJSON: "{}" }],
+    ["fractional seq", { id: "i", nodeId: "n", seq: 0.5, payloadJSON: "{}" }],
+    ["array frame", []],
+    ["string frame", "input"],
+  ])("rejects %s", (_name, payload) => {
+    expect(coerceNodeInvokeInputPayload(payload)).toBeNull();
+  });
+});

--- a/src/node-host/pty-command.test.ts
+++ b/src/node-host/pty-command.test.ts
@@ -69,6 +69,9 @@ describe("node PTY command", () => {
     await vi.waitFor(() => expect(emitChunk).toHaveBeenCalledWith("output"));
     expect(pty.pause).toHaveBeenCalledOnce();
     expect(pty.resume).toHaveBeenCalledOnce();
+    onInput?.(JSON.stringify({ kind: "resize", cols: 0, rows: 30 }));
+    onInput?.(JSON.stringify({ kind: "resize", cols: 80, rows: 2001 }));
+    expect(pty.resize).not.toHaveBeenCalled();
     onInput?.(JSON.stringify({ kind: "data", data: "keys" }));
     onInput?.(JSON.stringify({ kind: "resize", cols: 100, rows: 30 }));
     expect(pty.write).toHaveBeenCalledWith("keys");
@@ -76,7 +79,60 @@ describe("node PTY command", () => {
 
     abort.abort();
     expect(pty.kill).toHaveBeenCalledOnce();
+    onInput?.(JSON.stringify({ kind: "data", data: "after abort" }));
+    onInput?.(JSON.stringify({ kind: "resize", cols: 120, rows: 40 }));
+    expect(pty.write).toHaveBeenCalledTimes(1);
+    expect(pty.resize).toHaveBeenCalledTimes(1);
     onExit?.({ exitCode: 130, signal: 15 });
     await expect(result).resolves.toEqual({ exitCode: 130, signal: 15 });
+  });
+
+  it("ignores input after exit without touching a dead PTY", async () => {
+    let onExit: ((event: { exitCode: number; signal?: number }) => void) | undefined;
+    let onInput: ((payloadJSON: string) => void) | undefined;
+    const pty = {
+      pid: 42,
+      write: vi.fn(() => {
+        throw new Error("dead PTY write");
+      }),
+      resize: vi.fn(() => {
+        throw new Error("dead PTY resize");
+      }),
+      pause: vi.fn(),
+      resume: vi.fn(),
+      kill: vi.fn(),
+      onData: vi.fn(),
+      onExit: (callback: (event: { exitCode: number; signal?: number }) => void) => {
+        onExit = callback;
+      },
+    } satisfies TerminalPtyHandle;
+    const io: OpenClawPluginNodeHostCommandIo = {
+      signal: new AbortController().signal,
+      emitChunk: vi.fn(async () => {}),
+      onInput: (callback) => {
+        onInput = callback;
+      },
+    };
+    const result = runNodePtyCommand(
+      { file: "/usr/bin/codex", args: [], cols: 80, rows: 24 },
+      io,
+      vi.fn(async () => pty),
+    );
+    await vi.waitFor(() => expect(onInput).toBeDefined());
+
+    expect(() => onInput?.(JSON.stringify({ kind: "data", data: "racing" }))).not.toThrow();
+    expect(() => onInput?.(JSON.stringify({ kind: "resize", cols: 100, rows: 30 }))).not.toThrow();
+    expect(pty.write).toHaveBeenCalledOnce();
+    expect(pty.resize).toHaveBeenCalledOnce();
+    pty.write.mockClear();
+    pty.resize.mockClear();
+
+    onExit?.({ exitCode: 0 });
+    expect(() => onInput?.(JSON.stringify({ kind: "data", data: "late" }))).not.toThrow();
+    expect(() => onInput?.(JSON.stringify({ kind: "resize", cols: 100, rows: 30 }))).not.toThrow();
+
+    await expect(result).resolves.toEqual({ exitCode: 0 });
+    expect(pty.write).not.toHaveBeenCalled();
+    expect(pty.resize).not.toHaveBeenCalled();
   });
 });

--- a/src/node-host/pty-command.ts
+++ b/src/node-host/pty-command.ts
@@ -131,11 +131,18 @@ export async function runNodePtyCommand(
     kill();
   }
   io.onInput((payloadJSON) => {
+    if (settled || io.signal.aborted) {
+      return;
+    }
     const input = decodePtyInput(payloadJSON);
-    if (input?.kind === "data") {
-      pty.write(input.data);
-    } else if (input?.kind === "resize") {
-      pty.resize(input.cols, input.rows);
+    try {
+      if (input?.kind === "data") {
+        pty.write(input.data);
+      } else if (input?.kind === "resize") {
+        pty.resize(input.cols, input.rows);
+      }
+    } catch {
+      // Exit resolution owns teardown; input can race a dying native PTY.
     }
   });
   pty.onData((chunk) => {

--- a/src/node-host/runner.test.ts
+++ b/src/node-host/runner.test.ts
@@ -209,10 +209,12 @@ describe("runNodeHost", () => {
     const options = lastCapturedOptions();
 
     options?.onEvent?.({
+      type: "event",
       event: "node.invoke.input",
       payload: { id: "invoke-1", nodeId: "node-1", seq: 3, payloadJSON: '{"kind":"data"}' },
     });
     options?.onEvent?.({
+      type: "event",
       event: "node.invoke.cancel",
       payload: { invokeId: "invoke-1", nodeId: "node-1" },
     });

--- a/src/node-host/runner.test.ts
+++ b/src/node-host/runner.test.ts
@@ -17,6 +17,7 @@ const mocks = vi.hoisted(() => ({
   mcpDescriptors: [] as Array<Record<string, unknown>>,
   nodeSkillDescriptors: [] as Array<Record<string, unknown>>,
   runtimeSteps: [] as string[],
+  useFakeRuntime: false,
   normalizedPath: null as string | null,
   resolvedExecutables: new Map<string, string>(),
   closeMcpManager: vi.fn(async () => undefined),
@@ -41,6 +42,13 @@ const mocks = vi.hoisted(() => ({
     elapsedMs: 0,
   })),
   resolveGatewayConnectionAuth: vi.fn(async () => ({})),
+  activeRuntime: {
+    invoke: vi.fn(async () => {}),
+    handleInput: vi.fn(),
+    cancel: vi.fn(),
+    cancelAll: vi.fn(),
+    close: vi.fn(async () => {}),
+  },
 }));
 
 vi.mock("../config/config.js", () => ({
@@ -130,6 +138,25 @@ vi.mock("./skills.js", () => ({
   scanNodeHostedSkills: vi.fn(() => mocks.nodeSkillDescriptors),
 }));
 
+vi.mock("./runtime.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./runtime.js")>();
+  return {
+    ...actual,
+    prepareNodeHostRuntime: async (
+      ...args: Parameters<typeof actual.prepareNodeHostRuntime>
+    ): ReturnType<typeof actual.prepareNodeHostRuntime> => {
+      if (!mocks.useFakeRuntime) {
+        return await actual.prepareNodeHostRuntime(...args);
+      }
+      return {
+        manifest: { caps: [], commands: [], pathEnv: process.env.PATH ?? "" },
+        initialInventory: { skills: [], pluginTools: [] },
+        start: () => mocks.activeRuntime,
+      };
+    },
+  };
+});
+
 function lastCapturedOptions(): GatewayClientOptions | undefined {
   const list = mocks.capturedGatewayClientOptions;
   return list[list.length - 1];
@@ -143,6 +170,7 @@ describe("runNodeHost", () => {
     mocks.mcpDescriptors = [];
     mocks.nodeSkillDescriptors = [];
     mocks.runtimeSteps = [];
+    mocks.useFakeRuntime = false;
     mocks.normalizedPath = null;
     mocks.resolvedExecutables.clear();
     vi.clearAllMocks();
@@ -172,6 +200,28 @@ describe("runNodeHost", () => {
       expect(lastCapturedOptions()?.deviceFamily).toBe(deviceFamily);
     },
   );
+
+  it("routes invoke input, cancellation, and connection close to the runtime", async () => {
+    mocks.useFakeRuntime = true;
+    await expect(runNodeHost({ gatewayHost: "127.0.0.1", gatewayPort: 18789 })).rejects.toThrow(
+      "event loop readiness timeout",
+    );
+    const options = lastCapturedOptions();
+
+    options?.onEvent?.({
+      event: "node.invoke.input",
+      payload: { id: "invoke-1", nodeId: "node-1", seq: 3, payloadJSON: '{"kind":"data"}' },
+    });
+    options?.onEvent?.({
+      event: "node.invoke.cancel",
+      payload: { invokeId: "invoke-1", nodeId: "node-1" },
+    });
+    options?.onClose?.(1000, "connection closed");
+
+    expect(mocks.activeRuntime.handleInput).toHaveBeenCalledWith("invoke-1", 3, '{"kind":"data"}');
+    expect(mocks.activeRuntime.cancel).toHaveBeenCalledWith("invoke-1");
+    expect(mocks.activeRuntime.cancelAll).toHaveBeenCalledOnce();
+  });
 
   it("passes the resolved Gateway URL to the Gateway client", async () => {
     await expect(

--- a/ui/src/components/terminal/terminal-panel.test.ts
+++ b/ui/src/components/terminal/terminal-panel.test.ts
@@ -50,10 +50,12 @@ function terminalOpenResult(sessionId: string) {
 
 function deferred<T>() {
   let resolve!: (value: T) => void;
-  const promise = new Promise<T>((next) => {
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((next, fail) => {
     resolve = next;
+    reject = fail;
   });
-  return { promise, resolve };
+  return { promise, resolve, reject };
 }
 
 import { OpenClawTerminalPanel } from "./terminal-panel.ts";
@@ -67,6 +69,32 @@ class TestTerminalPanel extends OpenClawTerminalPanel {
 }
 
 customElements.define(TERMINAL_PANEL_ELEMENT_NAME, TestTerminalPanel);
+
+async function startPanelWithPendingOpen() {
+  let createOptions: CreateOptions | undefined;
+  createGhosttyTerminalMock.mockImplementation(async (options: CreateOptions) => {
+    createOptions = options;
+    return createTerminalController();
+  });
+  const open = deferred<ReturnType<typeof terminalOpenResult>>();
+  const requests: Array<{ method: string; params: unknown }> = [];
+  const client: TerminalGatewayClient = {
+    request: <T>(method: string, params?: unknown) => {
+      requests.push({ method, params });
+      return (method === "terminal.open" ? open.promise : Promise.resolve({})) as Promise<T>;
+    },
+    addEventListener: () => () => {},
+  };
+  const panel = document.createElement(TERMINAL_PANEL_ELEMENT_NAME) as OpenClawTerminalPanel;
+  panel.client = client;
+  panel.available = true;
+  document.body.append(panel);
+  panel.toggle();
+  await vi.waitFor(() =>
+    expect(requests.some(({ method }) => method === "terminal.open")).toBe(true),
+  );
+  return { createOptions: createOptions!, open, requests };
+}
 
 describe("OpenClawTerminalPanel", () => {
   beforeEach(async () => {
@@ -158,6 +186,58 @@ describe("OpenClawTerminalPanel", () => {
         params: { sessionId: "session-1", cols: 120, rows: 40 },
       });
     });
+  });
+
+  it("flushes keystrokes entered while open is in flight after resize resync", async () => {
+    const { createOptions, open, requests } = await startPanelWithPendingOpen();
+    createOptions.onData?.(new TextEncoder().encode("first"));
+    createOptions.onData?.(new TextEncoder().encode("second"));
+
+    open.resolve(terminalOpenResult("session-1"));
+
+    await vi.waitFor(() =>
+      expect(requests.filter(({ method }) => method === "terminal.input")).toHaveLength(2),
+    );
+    expect(requests.slice(1)).toEqual([
+      {
+        method: "terminal.resize",
+        params: { sessionId: "session-1", cols: 100, rows: 30 },
+      },
+      { method: "terminal.input", params: { sessionId: "session-1", data: "first" } },
+      { method: "terminal.input", params: { sessionId: "session-1", data: "second" } },
+    ]);
+  });
+
+  it("drops whole startup input chunks beyond the pending-input cap", async () => {
+    const { createOptions, open, requests } = await startPanelWithPendingOpen();
+    const accepted = "a".repeat(8 * 1024);
+    createOptions.onData?.(new TextEncoder().encode(accepted));
+    createOptions.onData?.(new TextEncoder().encode("overflow"));
+    createOptions.onData?.(new TextEncoder().encode("after-overflow"));
+
+    open.resolve(terminalOpenResult("session-1"));
+
+    await vi.waitFor(() =>
+      expect(requests.some(({ method }) => method === "terminal.input")).toBe(true),
+    );
+    expect(requests.filter(({ method }) => method === "terminal.input")).toEqual([
+      { method: "terminal.input", params: { sessionId: "session-1", data: accepted } },
+    ]);
+  });
+
+  it("discards buffered startup input when open fails", async () => {
+    const { createOptions, open, requests } = await startPanelWithPendingOpen();
+    createOptions.onData?.(new TextEncoder().encode("never send"));
+
+    open.reject(new Error("terminal open refused"));
+
+    await vi.waitFor(() => {
+      const panel = document.querySelector(TERMINAL_PANEL_ELEMENT_NAME) as OpenClawTerminalPanel;
+      expect(panel.renderRoot.querySelector(".tp-error")?.textContent).toContain(
+        "terminal open refused",
+      );
+    });
+    expect(requests.some(({ method }) => method === "terminal.input")).toBe(false);
   });
 
   it("opens a new titled tab for a catalog toggle request", async () => {

--- a/ui/src/components/terminal/terminal-panel.ts
+++ b/ui/src/components/terminal/terminal-panel.ts
@@ -22,6 +22,7 @@ import {
   loadPersistedTerminalSessionIds,
   persistTerminalSessionIds,
 } from "./terminal-session-storage.ts";
+import { createTerminalStartupInput, type StartupInputBuffer } from "./terminal-startup-input.ts";
 import { TerminalTaskQueue } from "./terminal-task-queue.ts";
 import { terminalTheme } from "./terminal-theme.ts";
 
@@ -33,7 +34,7 @@ const DOCK_RIGHT_GLYPH = svg`<svg viewBox="0 0 16 16" width="13" height="13" fil
 type TerminalDock = DockPanelSide;
 type TerminalTabState = TerminalPanelTab & {
   gatewaySessionId: string;
-  pendingInput: string[];
+  pendingInput: StartupInputBuffer;
   controller: GhosttyTerminalController;
   host: HTMLDivElement;
   /** Why an in-flight open/attach must not adopt this disposed terminal. */
@@ -62,9 +63,7 @@ const panelLayout = createDockPanelLayout({
 });
 const TERMINAL_FONT_FAMILY =
   'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Symbols Nerd Font Mono", "MesloLGLDZ Nerd Font Mono", "JetBrainsMono Nerd Font Mono", "Liberation Mono", monospace';
-const TERMINAL_INPUT_DECODER = new TextDecoder();
 const TERMINAL_OUTPUT_ENCODER = new TextEncoder();
-const MAX_PENDING_INPUT_CHARS = 8 * 1024;
 
 /** `<openclaw-terminal-panel>` — the dockable Control UI shell surface. */
 export class OpenClawTerminalPanel extends OpenClawLitElement {
@@ -402,9 +401,10 @@ export class OpenClawTerminalPanel extends OpenClawLitElement {
     }
     viewport.append(host);
     const tabRef = { current: undefined as TerminalTabState | undefined };
-    const pendingInput: string[] = [];
-    let pendingInputChars = 0;
-    let pendingInputOverflowed = false;
+    const startupInput = createTerminalStartupInput(
+      connection,
+      () => tabRef.current?.gatewaySessionId,
+    );
     let controller: GhosttyTerminalController;
     try {
       controller = await this.createTerminal({
@@ -419,28 +419,8 @@ export class OpenClawTerminalPanel extends OpenClawLitElement {
         },
         signal: operation.signal,
         // The browser controller owns these subscriptions and their teardown.
-        onData: (bytes) => {
-          const data = TERMINAL_INPUT_DECODER.decode(bytes);
-          const sessionId = tabRef.current?.gatewaySessionId;
-          if (sessionId) {
-            void connection.input(sessionId, data);
-          } else if (!pendingInputOverflowed) {
-            if (pendingInputChars + data.length <= MAX_PENDING_INPUT_CHARS) {
-              // Node relay adoption can take seconds. Keep complete startup input
-              // chunks so keystrokes are neither lost nor partially replayed.
-              pendingInput.push(data);
-              pendingInputChars += data.length;
-            } else {
-              pendingInputOverflowed = true;
-            }
-          }
-        },
-        onResize: ({ columns, rows }) => {
-          const sessionId = tabRef.current?.gatewaySessionId;
-          if (sessionId) {
-            void connection.resize(sessionId, columns, rows);
-          }
-        },
+        onData: startupInput.onData,
+        onResize: startupInput.onResize,
       });
     } catch (error) {
       host.remove();
@@ -458,7 +438,7 @@ export class OpenClawTerminalPanel extends OpenClawLitElement {
       id,
       sequence: this.tabSeq,
       gatewaySessionId: "",
-      pendingInput,
+      pendingInput: startupInput.buffer,
       shellName: null,
       agentId: null,
       cwd: null,
@@ -500,7 +480,7 @@ export class OpenClawTerminalPanel extends OpenClawLitElement {
     // current grid now so a resize during the open/attach RPC is not lost.
     const { cols, rows } = tab.controller.terminal;
     void this.connection?.resize(result.sessionId, cols || 80, rows || 24);
-    for (const data of tab.pendingInput.splice(0)) {
+    for (const data of tab.pendingInput.drain()) {
       void this.connection?.input(result.sessionId, data);
     }
 

--- a/ui/src/components/terminal/terminal-panel.ts
+++ b/ui/src/components/terminal/terminal-panel.ts
@@ -33,6 +33,7 @@ const DOCK_RIGHT_GLYPH = svg`<svg viewBox="0 0 16 16" width="13" height="13" fil
 type TerminalDock = DockPanelSide;
 type TerminalTabState = TerminalPanelTab & {
   gatewaySessionId: string;
+  pendingInput: string[];
   controller: GhosttyTerminalController;
   host: HTMLDivElement;
   /** Why an in-flight open/attach must not adopt this disposed terminal. */
@@ -63,6 +64,7 @@ const TERMINAL_FONT_FAMILY =
   'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Symbols Nerd Font Mono", "MesloLGLDZ Nerd Font Mono", "JetBrainsMono Nerd Font Mono", "Liberation Mono", monospace';
 const TERMINAL_INPUT_DECODER = new TextDecoder();
 const TERMINAL_OUTPUT_ENCODER = new TextEncoder();
+const MAX_PENDING_INPUT_CHARS = 8 * 1024;
 
 /** `<openclaw-terminal-panel>` — the dockable Control UI shell surface. */
 export class OpenClawTerminalPanel extends OpenClawLitElement {
@@ -400,6 +402,9 @@ export class OpenClawTerminalPanel extends OpenClawLitElement {
     }
     viewport.append(host);
     const tabRef = { current: undefined as TerminalTabState | undefined };
+    const pendingInput: string[] = [];
+    let pendingInputChars = 0;
+    let pendingInputOverflowed = false;
     let controller: GhosttyTerminalController;
     try {
       controller = await this.createTerminal({
@@ -414,11 +419,20 @@ export class OpenClawTerminalPanel extends OpenClawLitElement {
         },
         signal: operation.signal,
         // The browser controller owns these subscriptions and their teardown.
-        // Ignore startup callbacks until the Gateway session is adopted.
         onData: (bytes) => {
+          const data = TERMINAL_INPUT_DECODER.decode(bytes);
           const sessionId = tabRef.current?.gatewaySessionId;
           if (sessionId) {
-            void connection.input(sessionId, TERMINAL_INPUT_DECODER.decode(bytes));
+            void connection.input(sessionId, data);
+          } else if (!pendingInputOverflowed) {
+            if (pendingInputChars + data.length <= MAX_PENDING_INPUT_CHARS) {
+              // Node relay adoption can take seconds. Keep complete startup input
+              // chunks so keystrokes are neither lost nor partially replayed.
+              pendingInput.push(data);
+              pendingInputChars += data.length;
+            } else {
+              pendingInputOverflowed = true;
+            }
           }
         },
         onResize: ({ columns, rows }) => {
@@ -444,6 +458,7 @@ export class OpenClawTerminalPanel extends OpenClawLitElement {
       id,
       sequence: this.tabSeq,
       gatewaySessionId: "",
+      pendingInput,
       shellName: null,
       agentId: null,
       cwd: null,
@@ -485,6 +500,9 @@ export class OpenClawTerminalPanel extends OpenClawLitElement {
     // current grid now so a resize during the open/attach RPC is not lost.
     const { cols, rows } = tab.controller.terminal;
     void this.connection?.resize(result.sessionId, cols || 80, rows || 24);
+    for (const data of tab.pendingInput.splice(0)) {
+      void this.connection?.input(result.sessionId, data);
+    }
 
     this.tabs = [...this.tabs];
     this.persistLiveSessions();

--- a/ui/src/components/terminal/terminal-startup-input.ts
+++ b/ui/src/components/terminal/terminal-startup-input.ts
@@ -1,0 +1,55 @@
+import type { TerminalConnection } from "./terminal-connection.ts";
+
+const MAX_PENDING_INPUT_CHARS = 8 * 1024;
+const TERMINAL_INPUT_DECODER = new TextDecoder();
+
+/** Preserves a valid startup prefix: after one drop, all later chunks stay dropped. */
+export class StartupInputBuffer {
+  private chunks: string[] = [];
+  private charCount = 0;
+  private overflowed = false;
+
+  push(data: string): void {
+    if (this.overflowed) {
+      return;
+    }
+    if (this.charCount + data.length > MAX_PENDING_INPUT_CHARS) {
+      this.overflowed = true;
+      return;
+    }
+    this.chunks.push(data);
+    this.charCount += data.length;
+  }
+
+  drain(): string[] {
+    const chunks = this.chunks;
+    this.chunks = [];
+    this.charCount = 0;
+    return chunks;
+  }
+}
+
+export function createTerminalStartupInput(
+  connection: Pick<TerminalConnection, "input" | "resize">,
+  getSessionId: () => string | undefined,
+) {
+  const buffer = new StartupInputBuffer();
+  return {
+    buffer,
+    onData: (bytes: Uint8Array) => {
+      const data = TERMINAL_INPUT_DECODER.decode(bytes);
+      const sessionId = getSessionId();
+      if (sessionId) {
+        void connection.input(sessionId, data);
+      } else {
+        buffer.push(data);
+      }
+    },
+    onResize: ({ columns, rows }: { columns: number; rows: number }) => {
+      const sessionId = getSessionId();
+      if (sessionId) {
+        void connection.resize(sessionId, columns, rows);
+      }
+    },
+  };
+}


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where keystrokes typed into a freshly opened Control UI terminal were silently dropped until the gateway session finished opening. For "open in terminal" on Claude/Codex catalog sessions that live on a paired node, that window covers a remote eligibility check plus a remote PTY spawn — user-visible seconds of lost input.

It also closes several lifecycle races in the node PTY relay and terminal session management found while auditing the paths end to end:

- The relay invoke was not pinned to the node connection that authorization checked, so a node reconnect between the final auth re-check and dispatch could send the resume command over a connection that was never authorized (the registry already had `expectedConnId`/`ROUTE_CHANGED` for exactly this; the relay never used it).
- Node-side input frames arriving after PTY exit wrote to a dead PTY with no guard (the data/exit paths had one; input did not).
- A throwing `resize` on a dead PTY left a zombie session alive, while a throwing `write` correctly finalized it.
- Scrollback-ring and relay-prelude truncation could split a UTF-16 surrogate pair, replaying permanent mojibake into a reattached terminal.
- The relay's pre-registration output buffer was unbounded.
- The protocol schema claimed clients use `terminal.data` `seq` for gap detection; no client does (transport is ordered) — the description now states the real contract.

## Why This Change Was Made

Hardening pass over the embedded terminal and the node PTY forwarding path, keeping each fix at its owner boundary: connection pinning in the gateway relay/open handler, input guarding on the node host, buffering in the Control UI panel, and truncation safety in one shared `surrogateSafeTail` helper. Startup input buffering is bounded (8 KiB) and latches off on overflow so replayed input can never be reordered or partially truncated. No protocol shape, config, or plugin SDK changes.

## User Impact

Typing immediately after opening a terminal — especially resuming a Claude/Codex session on a paired node — now reaches the shell instead of vanishing. Dead terminals are torn down promptly on resize, reattach replay no longer corrupts wide characters, and a node reconnect during open fails closed with a visible error instead of dispatching over an unauthorized route.

## Evidence

- Focused suites, all green: `node scripts/run-vitest.mjs src/gateway/terminal src/gateway/node-registry.test.ts src/gateway/server-methods/terminal.test.ts src/node-host/pty-command.test.ts src/node-host/invoke-payload.test.ts src/node-host/runner.test.ts` → 6 files, 121 tests; `node scripts/run-vitest.mjs ui/src/components/terminal` → 3 files, 32 tests.
- New regression coverage: connection pinning + `ROUTE_CHANGED` surfacing, seq-gap buffering bounds (128-frame cap → idle teardown), input-after-exit/abort no-ops, out-of-range resize rejection, `coerceNodeInvokeInputPayload` bounds, `node.invoke.input`/`cancel`/close runner routing, seq monotonicity across detach→attach, surrogate-safe truncation, startup-input flush ordering + overflow latch + failed-open discard.
- Structured second-model review of the full bundle: clean, no actionable findings.
- `pnpm check:changed` delegated gates: running at PR creation; will be green on the head SHA before merge.
