### PR TITLE
fix(agents): reject partial fallback skip TTL env values

### DIFF
--- a/src/agents/fallback-skip-cache.test.ts
+++ b/src/agents/fallback-skip-cache.test.ts
@@ -1,5 +1,5 @@
 // Exercises per-session fallback skip markers, TTL expiry, and opt-in cache defaults.
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   resetFallbackSkipCacheForTest,
   getFallbackCandidateSkipReason,
@@ -13,6 +13,7 @@ describe("fallback-skip-cache", () => {
   });
 
   afterEach(() => {
+    vi.unstubAllEnvs();
     resetFallbackSkipCacheForTest();
   });
 
@@ -262,99 +263,49 @@ describe("fallback-skip-cache", () => {
     ).toBe(false);
   });
 
-  it("rejects partial OPENCLAW_FALLBACK_SKIP_TTL_MS values with non-digit suffixes", () => {
-    const previous = process.env.OPENCLAW_FALLBACK_SKIP_TTL_MS;
-    process.env.OPENCLAW_FALLBACK_SKIP_TTL_MS = "1000ms";
-    try {
-      markFallbackCandidateSkipped({
+  it("does not enable the cache for a suffixed TTL value", () => {
+    vi.stubEnv("OPENCLAW_FALLBACK_SKIP_TTL_MS", "1000ms");
+    markFallbackCandidateSkipped({
+      sessionId: "s1",
+      provider: "anthropic",
+      model: "claude-opus-4-7",
+      reason: "auth",
+      now: 1_000,
+    });
+    expect(
+      isFallbackCandidateSkipped({
         sessionId: "s1",
         provider: "anthropic",
         model: "claude-opus-4-7",
-        reason: "auth",
         now: 1_000,
-      });
-      expect(
-        isFallbackCandidateSkipped({
-          sessionId: "s1",
-          provider: "anthropic",
-          model: "claude-opus-4-7",
-          now: 1_000,
-        }),
-      ).toBe(false);
-    } finally {
-      if (previous === undefined) {
-        delete process.env.OPENCLAW_FALLBACK_SKIP_TTL_MS;
-      } else {
-        process.env.OPENCLAW_FALLBACK_SKIP_TTL_MS = previous;
-      }
-    }
-  });
-
-  it("rejects malformed OPENCLAW_FALLBACK_SKIP_TTL_MS values", () => {
-    const previous = process.env.OPENCLAW_FALLBACK_SKIP_TTL_MS;
-    const malformedValues = ["-1", "0x10", "1e2", "999999999999999999999"];
-    try {
-      for (const value of malformedValues) {
-        resetFallbackSkipCacheForTest();
-        process.env.OPENCLAW_FALLBACK_SKIP_TTL_MS = value;
-        markFallbackCandidateSkipped({
-          sessionId: "s1",
-          provider: "anthropic",
-          model: "claude-opus-4-7",
-          reason: "auth",
-          now: 1_000,
-        });
-        expect(
-          isFallbackCandidateSkipped({
-            sessionId: "s1",
-            provider: "anthropic",
-            model: "claude-opus-4-7",
-            now: 1_000,
-          }),
-        ).toBe(false);
-      }
-    } finally {
-      if (previous === undefined) {
-        delete process.env.OPENCLAW_FALLBACK_SKIP_TTL_MS;
-      } else {
-        process.env.OPENCLAW_FALLBACK_SKIP_TTL_MS = previous;
-      }
-    }
+      }),
+    ).toBe(false);
   });
 
   it("uses OPENCLAW_FALLBACK_SKIP_TTL_MS as an opt-in default TTL", () => {
-    const previous = process.env.OPENCLAW_FALLBACK_SKIP_TTL_MS;
-    process.env.OPENCLAW_FALLBACK_SKIP_TTL_MS = "60000";
-    try {
-      markFallbackCandidateSkipped({
+    vi.stubEnv("OPENCLAW_FALLBACK_SKIP_TTL_MS", "60000");
+    markFallbackCandidateSkipped({
+      sessionId: "s1",
+      provider: "anthropic",
+      model: "claude-opus-4-7",
+      reason: "auth",
+      now: 1_000,
+    });
+    expect(
+      isFallbackCandidateSkipped({
         sessionId: "s1",
         provider: "anthropic",
         model: "claude-opus-4-7",
-        reason: "auth",
-        now: 1_000,
-      });
-      expect(
-        isFallbackCandidateSkipped({
-          sessionId: "s1",
-          provider: "anthropic",
-          model: "claude-opus-4-7",
-          now: 60_000,
-        }),
-      ).toBe(true);
-      expect(
-        isFallbackCandidateSkipped({
-          sessionId: "s1",
-          provider: "anthropic",
-          model: "claude-opus-4-7",
-          now: 61_001,
-        }),
-      ).toBe(false);
-    } finally {
-      if (previous === undefined) {
-        delete process.env.OPENCLAW_FALLBACK_SKIP_TTL_MS;
-      } else {
-        process.env.OPENCLAW_FALLBACK_SKIP_TTL_MS = previous;
-      }
-    }
+        now: 60_000,
+      }),
+    ).toBe(true);
+    expect(
+      isFallbackCandidateSkipped({
+        sessionId: "s1",
+        provider: "anthropic",
+        model: "claude-opus-4-7",
+        now: 61_001,
+      }),
+    ).toBe(false);
   });
 });

--- a/src/agents/fallback-skip-cache.test.ts
+++ b/src/agents/fallback-skip-cache.test.ts
@@ -262,6 +262,66 @@ describe("fallback-skip-cache", () => {
     ).toBe(false);
   });
 
+  it("rejects partial OPENCLAW_FALLBACK_SKIP_TTL_MS values with non-digit suffixes", () => {
+    const previous = process.env.OPENCLAW_FALLBACK_SKIP_TTL_MS;
+    process.env.OPENCLAW_FALLBACK_SKIP_TTL_MS = "1000ms";
+    try {
+      markFallbackCandidateSkipped({
+        sessionId: "s1",
+        provider: "anthropic",
+        model: "claude-opus-4-7",
+        reason: "auth",
+        now: 1_000,
+      });
+      expect(
+        isFallbackCandidateSkipped({
+          sessionId: "s1",
+          provider: "anthropic",
+          model: "claude-opus-4-7",
+          now: 1_000,
+        }),
+      ).toBe(false);
+    } finally {
+      if (previous === undefined) {
+        delete process.env.OPENCLAW_FALLBACK_SKIP_TTL_MS;
+      } else {
+        process.env.OPENCLAW_FALLBACK_SKIP_TTL_MS = previous;
+      }
+    }
+  });
+
+  it("rejects malformed OPENCLAW_FALLBACK_SKIP_TTL_MS values", () => {
+    const previous = process.env.OPENCLAW_FALLBACK_SKIP_TTL_MS;
+    const malformedValues = ["-1", "0x10", "1e2", "999999999999999999999"];
+    try {
+      for (const value of malformedValues) {
+        resetFallbackSkipCacheForTest();
+        process.env.OPENCLAW_FALLBACK_SKIP_TTL_MS = value;
+        markFallbackCandidateSkipped({
+          sessionId: "s1",
+          provider: "anthropic",
+          model: "claude-opus-4-7",
+          reason: "auth",
+          now: 1_000,
+        });
+        expect(
+          isFallbackCandidateSkipped({
+            sessionId: "s1",
+            provider: "anthropic",
+            model: "claude-opus-4-7",
+            now: 1_000,
+          }),
+        ).toBe(false);
+      }
+    } finally {
+      if (previous === undefined) {
+        delete process.env.OPENCLAW_FALLBACK_SKIP_TTL_MS;
+      } else {
+        process.env.OPENCLAW_FALLBACK_SKIP_TTL_MS = previous;
+      }
+    }
+  });
+
   it("uses OPENCLAW_FALLBACK_SKIP_TTL_MS as an opt-in default TTL", () => {
     const previous = process.env.OPENCLAW_FALLBACK_SKIP_TTL_MS;
     process.env.OPENCLAW_FALLBACK_SKIP_TTL_MS = "60000";

--- a/src/agents/fallback-skip-cache.ts
+++ b/src/agents/fallback-skip-cache.ts
@@ -15,7 +15,7 @@
  * `resetFallbackSkipCacheForTest()`.
  */
 
-import { parseStrictNonNegativeInteger } from "../infra/parse-finite-number.js";
+import { parseStrictNonNegativeInteger } from "@openclaw/normalization-core/number-coercion";
 import { modelKey } from "./model-selection-normalize.js";
 
 /**

--- a/src/agents/fallback-skip-cache.ts
+++ b/src/agents/fallback-skip-cache.ts
@@ -15,6 +15,7 @@
  * `resetFallbackSkipCacheForTest()`.
  */
 
+import { parseStrictNonNegativeInteger } from "../infra/parse-finite-number.js";
 import { modelKey } from "./model-selection-normalize.js";
 
 /**
@@ -36,8 +37,8 @@ function resolveConfiguredSkipTtlMs(env: NodeJS.ProcessEnv = process.env): numbe
   if (!trimmed) {
     return DEFAULT_FALLBACK_SKIP_TTL_MS;
   }
-  const parsed = Number.parseInt(trimmed, 10);
-  if (!Number.isFinite(parsed) || parsed < 0) {
+  const parsed = parseStrictNonNegativeInteger(trimmed);
+  if (parsed === undefined) {
     return DEFAULT_FALLBACK_SKIP_TTL_MS;
   }
   if (parsed === 0) {


### PR DESCRIPTION
## What Problem This Solves

`OPENCLAW_FALLBACK_SKIP_TTL_MS=1000ms` was silently accepted as `1000` because the fallback skip cache used prefix parsing. A mistyped value could therefore enable the auth-failure skip cache and change which fallback model runs on later turns.

## Why This Change Was Made

The cache now uses the shared strict non-negative integer parser. Only complete integer tokens are accepted; malformed values keep the cache disabled. Explicit `ttlMs` call paths and the documented 1-second to 10-minute clamp remain unchanged.

The regression test exercises the reported suffixed value directly. Existing valid-TTL and expiry coverage remains, with Vitest-owned environment restoration to avoid leaking process state between tests.

AI-assisted maintainer cleanup.

## User Impact

Mistyped fallback-skip TTL values no longer create an unintended skip window. Valid integer millisecond values such as `60000`, plus `0` or unset for disabled behavior, continue to work.

## Evidence

### Before

On current `main`, setting `OPENCLAW_FALLBACK_SKIP_TTL_MS=1000ms` and marking an auth-failed fallback creates a live skip marker because `Number.parseInt` consumes the numeric prefix.

### After

The same cache path rejects `1000ms`, while `60000` still creates a marker that expires at the configured TTL.

### Validation

- Testbox-through-Crabbox `tbx_01kxgmbf13v4wfkv9w58qr3qkv`, Actions run 29346074939
- `pnpm test src/agents/fallback-skip-cache.test.ts`: 11 tests passed
- `pnpm check:changed`: passed
- Exact-head autoreview: no accepted or actionable findings
- `git diff --check`: passed

### Not verified live

No live provider-auth failure was required. The behavior is isolated to environment parsing and the in-memory skip-cache entry path, both covered directly.
