### PR TITLE
fix(cron): one-shot jobs are permanently disabled after a session lifecycle claim race

### DIFF
--- a/src/cron/retry-hint.test.ts
+++ b/src/cron/retry-hint.test.ts
@@ -83,4 +83,22 @@ describe("resolveCronExecutionRetryHint", () => {
       });
     }
   });
+
+  it("classifies session lifecycle claim conflicts as transient regardless of retryOn (#106875)", () => {
+    for (const message of [
+      'CronSessionLifecycleClaimError: Session "agent:main:cron:job-1" changed while starting work. Retry.',
+      'Error: Session "agent:main:cron:job-1" changed while starting work. Retry.',
+      'Error: Session "agent:main:cron:job-1" was deleted while starting work. Retry.',
+    ]) {
+      expect(resolveCronExecutionRetryHint(message, ["network"])).toEqual({ retryable: true });
+    }
+  });
+
+  it("does not classify archived-session work-start errors as transient", () => {
+    expect(
+      resolveCronExecutionRetryHint(
+        'Error: Session "agent:main:main" is archived. Restore it before starting new work.',
+      ),
+    ).toEqual({ retryable: false });
+  });
 });

--- a/src/cron/retry-hint.ts
+++ b/src/cron/retry-hint.ts
@@ -18,6 +18,11 @@ type CronRetryHint = {
 const SERVER_ERROR_PATTERN =
   /\b(?:https?|status(?:[ _]code)?|response(?:[ _]code)?|http(?:[ _]status)?)\b[\s:=#"']{0,4}5\d{2}\b|\b5\d{2}\b[\s:)\].,-]*(?:internal server error|server error|bad gateway|service unavailable|gateway time-?out)\b|\binternal server error\b|\bbad gateway\b|\bservice unavailable\b|\bgateway time-?out\b|\b5xx\b|^\s*5\d{2}\s*$/i;
 
+// Lifecycle claims can lose a race before provider execution. Retry the run;
+// treating the conflict as permanent disables one-shot jobs without running them.
+const SESSION_LIFECYCLE_CLAIM_ERROR_PATTERN =
+  /^(?:(?:CronSessionLifecycleClaimError|Error): )?Session "[^"\n]+" (?:changed|was deleted) while starting work\. Retry\.$/;
+
 const TRANSIENT_PATTERNS: Record<CronRetryOn, RegExp> = {
   rate_limit:
     /(rate[_ ]limit|too many requests|429|resource has been exhausted|cloudflare|tokens per day)/i,
@@ -37,6 +42,9 @@ export function resolveCronExecutionRetryHint(
 ): CronRetryHint {
   if (!error || typeof error !== "string") {
     return { retryable: false };
+  }
+  if (SESSION_LIFECYCLE_CLAIM_ERROR_PATTERN.test(error)) {
+    return { retryable: true };
   }
   const keys = retryOn?.length ? retryOn : (Object.keys(TRANSIENT_PATTERNS) as CronRetryOn[]);
   const classified = classifiedReason ?? undefined;

--- a/src/cron/service.runs-one-shot-main-job-disables-it.test.ts
+++ b/src/cron/service.runs-one-shot-main-job-disables-it.test.ts
@@ -644,6 +644,30 @@ describe("CronService", () => {
     await stopCronAndCleanup(cron, store);
   });
 
+  it("retries one-shot lifecycle claim conflicts instead of disabling the job (#106875)", async () => {
+    const runIsolatedAgentJob = vi.fn(async () => ({
+      status: "error" as const,
+      error:
+        'CronSessionLifecycleClaimError: Session "agent:main:cron:job-1" changed while starting work. Retry.',
+    }));
+    const { store, cron, events } = await createIsolatedAnnounceHarness(runIsolatedAgentJob);
+    const job = await runIsolatedAnnounceJobAndWait({
+      cron,
+      events,
+      name: "one-shot lifecycle claim retry",
+      status: "error",
+    });
+
+    const updated = (await cron.list({ includeDisabled: true })).find(
+      (entry) => entry.id === job.id,
+    );
+    expect(updated?.enabled).toBe(true);
+    expect(updated?.state.consecutiveErrors).toBe(1);
+    expect(updated?.state.nextRunAtMs).toBeTypeOf("number");
+
+    await stopCronAndCleanup(cron, store);
+  });
+
   it("does not post fallback main summary for isolated delivery-target errors", async () => {
     const runIsolatedAgentJob = vi.fn(async () => ({
       status: "error" as const,


### PR DESCRIPTION
Related: #106875

## What Problem This Solves

Fixes an issue where one-shot cron jobs could be permanently disabled when a session changed during work-start admission. The scheduler reported that internal race as a permanent failure even though its canonical error explicitly requests a retry.

## Why This Change Was Made

The cron retry policy now recognizes only the canonical serialized lifecycle-claim conflict messages and schedules the existing bounded backoff. Provider retry configuration remains unchanged, archived-session errors remain permanent, and the normal maximum-attempt limit still applies.

This maintainer rewrite keeps the fix at the retry-policy owner boundary. It avoids new cross-module error plumbing while preserving the original contribution and authorship.

## User Impact

Affected one-shot jobs remain enabled and receive a bounded retry instead of silently dying after a session-claim race.

## Evidence

- Before fix: two new regressions failed; the lifecycle error was non-retryable and the one-shot job became disabled.
- After fix: focused cron proof passed, 23 tests across 2 files.
- [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/29319378723): passed.
- Mandatory local autoreview: clean, no actionable findings.

AI-assisted maintainer rewrite. Contributor credit retained for @SL4N.
