### PR TITLE
fix(sessions): disk budget counts unremovable *.migrated sidecars and evicts live sessions instead

### DIFF
--- a/src/config/sessions/artifacts.test.ts
+++ b/src/config/sessions/artifacts.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   formatSessionArchiveTimestamp,
   isCompactionCheckpointTranscriptFileName,
+  isMigrationArchiveArtifactName,
   isPrimarySessionTranscriptFileName,
   isSessionArchiveArtifactName,
   isSessionStoreTempArtifactName,
@@ -20,6 +21,14 @@ describe("session artifact helpers", () => {
     expect(isSessionArchiveArtifactName("sessions.json.bak.1737420882")).toBe(true);
     expect(isSessionArchiveArtifactName("keep.deleted.keep.jsonl")).toBe(false);
     expect(isSessionArchiveArtifactName("abc.jsonl")).toBe(false);
+  });
+
+  it("classifies migration archive file names", () => {
+    expect(isMigrationArchiveArtifactName("abc.jsonl.migrated")).toBe(true);
+    expect(isMigrationArchiveArtifactName("sessions.json.migrated.2")).toBe(true);
+    expect(isMigrationArchiveArtifactName("abc.jsonl.migrated.tmp")).toBe(false);
+    expect(isMigrationArchiveArtifactName("abc.migrated.jsonl")).toBe(false);
+    expect(isMigrationArchiveArtifactName("abc.jsonl.MIGRATED")).toBe(false);
   });
 
   it("classifies orphaned session store atomic-write temp files", () => {

--- a/src/config/sessions/artifacts.ts
+++ b/src/config/sessions/artifacts.ts
@@ -9,6 +9,7 @@ export type SessionArchiveReason = "bak" | "reset" | "deleted";
 
 const ARCHIVE_TIMESTAMP_RE = /^\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}(?:\.\d{3})?Z$/;
 const LEGACY_STORE_BACKUP_RE = /^sessions\.json\.bak\.\d+$/;
+const MIGRATION_ARCHIVE_RE = /\.migrated(?:\.\d+)?$/u;
 const COMPACTION_CHECKPOINT_TRANSCRIPT_RE =
   /^(.+)\.checkpoint\.([0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})\.jsonl$/i;
 
@@ -35,6 +36,11 @@ export function isSessionArchiveArtifactName(fileName: string): boolean {
     hasArchiveSuffix(fileName, "reset") ||
     hasArchiveSuffix(fileName, "bak")
   );
+}
+
+/** Returns true for migration rollback archives retained beside their legacy source. */
+export function isMigrationArchiveArtifactName(fileName: string): boolean {
+  return MIGRATION_ARCHIVE_RE.test(fileName);
 }
 
 // Compiled-pattern cache keyed by store basename. A disk sweep calls the matcher

--- a/src/config/sessions/disk-budget.test.ts
+++ b/src/config/sessions/disk-budget.test.ts
@@ -54,6 +54,43 @@ function refreshPathBeforeSecondStat(targetPath: string): ReturnType<typeof vi.s
 }
 
 describe("enforceSessionDiskBudget", () => {
+  it("excludes migration archives from the session disk budget (#106875)", async () => {
+    await withTempDir({ prefix: "openclaw-disk-budget-" }, async (dir) => {
+      const storePath = path.join(dir, "sessions.json");
+      const sessionKey = "agent:main:main";
+      const sessionId = "keep";
+      const transcriptPath = path.join(dir, `${sessionId}.jsonl`);
+      const migrationArchivePath = path.join(dir, "legacy.jsonl.migrated");
+      const numberedMigrationArchivePath = path.join(dir, "legacy.jsonl.migrated.2");
+      const store: Record<string, SessionEntry> = {
+        [sessionKey]: { sessionId, updatedAt: Date.now() },
+      };
+      await fs.writeFile(storePath, JSON.stringify(store, null, 2), "utf-8");
+      await fs.writeFile(transcriptPath, "t".repeat(64), "utf-8");
+      await fs.writeFile(migrationArchivePath, "m".repeat(400), "utf-8");
+      await fs.writeFile(numberedMigrationArchivePath, "n".repeat(400), "utf-8");
+
+      const result = await enforceSessionDiskBudget({
+        store,
+        storePath,
+        maintenance: {
+          maxDiskBytes: 300,
+          highWaterBytes: 200,
+        },
+        warnOnly: false,
+      });
+
+      expectBudgetResult(result);
+      expect(result.overBudget).toBe(false);
+      expect(result.removedEntries).toBe(0);
+      expect(result.removedFiles).toBe(0);
+      expect(store).toHaveProperty(sessionKey);
+      await expectPathExists(transcriptPath);
+      await expectPathExists(migrationArchivePath);
+      await expectPathExists(numberedMigrationArchivePath);
+    });
+  });
+
   it("does not treat referenced transcripts with marker-like session IDs as archived artifacts", async () => {
     await withTempDir({ prefix: "openclaw-disk-budget-" }, async (dir) => {
       const storePath = path.join(dir, "sessions.json");

--- a/src/config/sessions/disk-budget.ts
+++ b/src/config/sessions/disk-budget.ts
@@ -12,6 +12,7 @@ import {
 import { runTasksWithConcurrency } from "../../utils/run-with-concurrency.js";
 import {
   isCompactionCheckpointTranscriptFileName,
+  isMigrationArchiveArtifactName,
   isPrimarySessionTranscriptFileName,
   isSessionArchiveArtifactName,
   isSessionStoreTempArtifactName,
@@ -227,7 +228,9 @@ async function readSessionsDirFiles(sessionsDir: string): Promise<SessionsDirFil
   // stats turn one sweep into per-file latency round trips on networked
   // filesystems.
   const tasks = dirEntries
-    .filter((dirent) => dirent.isFile())
+    // Migration rollback archives stay outside session cleanup ownership. Exclude
+    // them before stat so their retained bytes cannot evict live sessions.
+    .filter((dirent) => dirent.isFile() && !isMigrationArchiveArtifactName(dirent.name))
     .map((dirent) => async (): Promise<SessionsDirFileStat | null> => {
       const filePath = path.join(sessionsDir, dirent.name);
       const stat = await fs.promises.stat(filePath).catch(() => null);

--- a/src/config/sessions/disk-budget.ts
+++ b/src/config/sessions/disk-budget.ts
@@ -224,12 +224,8 @@ async function readSessionsDirFiles(sessionsDir: string): Promise<SessionsDirFil
   const dirEntries = await fs.promises
     .readdir(sessionsDir, { withFileTypes: true })
     .catch(() => []);
-  // Stat concurrently: the budget sweep stats every session file, and serial
-  // stats turn one sweep into per-file latency round trips on networked
-  // filesystems.
+  // Skip rollback archives before concurrent stats so retained bytes cannot evict live sessions.
   const tasks = dirEntries
-    // Migration rollback archives stay outside session cleanup ownership. Exclude
-    // them before stat so their retained bytes cannot evict live sessions.
     .filter((dirent) => dirent.isFile() && !isMigrationArchiveArtifactName(dirent.name))
     .map((dirent) => async (): Promise<SessionsDirFileStat | null> => {
       const filePath = path.join(sessionsDir, dirent.name);


### PR DESCRIPTION
Fixes #106875

## What Problem This Solves

Fixes an issue where retained legacy migration archives in a sessions directory counted toward the live session disk budget even though the budget could not remove them. Archive-only pressure could therefore evict current session entries and transcripts.

## Why This Change Was Made

The shared session-artifact classifier now recognizes the documented `.migrated` and numbered `.migrated.N` rollback archive forms. Session-directory maintenance excludes those files before stat and accounting, leaving them untouched and outside live-session cleanup ownership.

This maintainer rewrite keeps the result shape and CLI output unchanged. It removes the accounting error without adding a second reported-byte category or teaching the budget to delete migration archives.

## User Impact

Retained migration rollback files no longer create false disk pressure or cause live session eviction. Existing archive files remain available for recovery.

## Evidence

- Before fix: 2 new regressions failed; migration names had no classifier and an archive-only budget exceeded its limit.
- After fix: focused session artifact and disk-budget proof passed, 29 tests across 2 files.
- `git diff --check`: passed.
- TypeScript LOC ratchet: passed; `disk-budget.ts` shrinks to 847 lines from 848 on the base.
- Mandatory branch autoreview: clean, no actionable findings.
- [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/29320657340): passed.

AI-assisted maintainer rewrite. Contributor credit retained for @SL4N.
