### PR TITLE
refactor(plugin-sdk): isolate HTML entity runtime

### DIFF
--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-b01a5fcd6cf5e4f6189638b28a2fe17d227d7028a15e047f3a82915ab6b96ace  plugin-sdk-api-baseline.json
-03d5d1c2a6cefe69677f44e7df2a8864873b3bda812bd18d996043eb861e5c4e  plugin-sdk-api-baseline.jsonl
+33404fe321c4413d7d0d4bdd9697fe942ea17dbc6505761a68b528fc1d978437  plugin-sdk-api-baseline.json
+c84e9d2181a2c8e2889984e180405846028def0dc347f489c333c0794f54a4c7  plugin-sdk-api-baseline.jsonl

--- a/docs/plugins/sdk-subpaths.md
+++ b/docs/plugins/sdk-subpaths.md
@@ -336,7 +336,8 @@ usage endpoint failed or returned no usable usage data.
     | `plugin-sdk/session-binding-runtime` | Current conversation binding state without configured binding routing or pairing stores |
     | `plugin-sdk/context-visibility-runtime` | Context visibility resolution and supplemental context filtering without broad config/security imports |
     | `plugin-sdk/string-coerce-runtime` | Narrow primitive record/string coercion and normalization helpers without markdown/logging imports |
-    | `plugin-sdk/text-utility-runtime` | Low-level text and path helpers, including five-entity HTML escaping and single-pass semicolon-terminated HTML5 entity decoding |
+    | `plugin-sdk/html-entity-runtime` | Single-pass semicolon-terminated HTML5 entity decoding without broad text utilities |
+    | `plugin-sdk/text-utility-runtime` | Low-level text and path helpers, including five-entity HTML escaping |
     | `plugin-sdk/host-runtime` | Hostname and SCP host normalization helpers |
     | `plugin-sdk/retry-runtime` | Retry config and retry runner helpers |
     | `plugin-sdk/agent-runtime` | Deprecated broad barrel for agent dir/identity/workspace helpers, including `resolveAgentDir`, `resolveDefaultAgentDir`, and the deprecated `resolveOpenClawAgentDir` compatibility export; prefer focused agent/runtime subpaths |

--- a/extensions/duckduckgo/src/ddg-client.ts
+++ b/extensions/duckduckgo/src/ddg-client.ts
@@ -1,5 +1,6 @@
 // Duckduckgo plugin module implements ddg client behavior.
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { decodeHtmlEntities as decodeHtmlEntity } from "openclaw/plugin-sdk/html-entity-runtime";
 import { readProviderTextResponse } from "openclaw/plugin-sdk/provider-http";
 import {
   DEFAULT_CACHE_TTL_MINUTES,
@@ -15,7 +16,6 @@ import {
   wrapWebContent,
   writeCache,
 } from "openclaw/plugin-sdk/provider-web-search";
-import { decodeHtmlEntities as decodeHtmlEntity } from "openclaw/plugin-sdk/text-utility-runtime";
 import { resolveDdgRegion, resolveDdgSafeSearch, type DdgSafeSearch } from "./config.js";
 
 const DDG_HTML_ENDPOINT = "https://html.duckduckgo.com/html";

--- a/extensions/matrix/src/matrix/monitor/mentions.ts
+++ b/extensions/matrix/src/matrix/monitor/mentions.ts
@@ -1,6 +1,7 @@
 // Matrix plugin module implements mentions behavior.
+import { decodeHtmlEntities } from "openclaw/plugin-sdk/html-entity-runtime";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
-import { decodeHtmlEntities, escapeRegExp } from "openclaw/plugin-sdk/text-utility-runtime";
+import { escapeRegExp } from "openclaw/plugin-sdk/text-utility-runtime";
 import { getMatrixRuntime } from "../../runtime.js";
 import type { RoomMessageEventContent } from "./types.js";
 

--- a/extensions/msteams/src/graph-thread.ts
+++ b/extensions/msteams/src/graph-thread.ts
@@ -1,5 +1,5 @@
 // Msteams plugin module implements graph thread behavior.
-import { decodeHtmlEntities } from "openclaw/plugin-sdk/text-utility-runtime";
+import { decodeHtmlEntities } from "openclaw/plugin-sdk/html-entity-runtime";
 import { fetchGraphJson, type GraphResponse } from "./graph.js";
 import type { MSTeamsRequestDeadline } from "./request-timeout.js";
 

--- a/extensions/msteams/src/inbound.ts
+++ b/extensions/msteams/src/inbound.ts
@@ -1,5 +1,5 @@
 // Msteams plugin module implements inbound behavior.
-import { decodeHtmlEntities } from "openclaw/plugin-sdk/text-utility-runtime";
+import { decodeHtmlEntities } from "openclaw/plugin-sdk/html-entity-runtime";
 
 type MSTeamsQuoteInfo = {
   sender: string;

--- a/package.json
+++ b/package.json
@@ -651,6 +651,10 @@
       "types": "./dist/plugin-sdk/hook-runtime.d.ts",
       "default": "./dist/plugin-sdk/hook-runtime.js"
     },
+    "./plugin-sdk/html-entity-runtime": {
+      "types": "./dist/plugin-sdk/html-entity-runtime.d.ts",
+      "default": "./dist/plugin-sdk/html-entity-runtime.js"
+    },
     "./plugin-sdk/host-runtime": {
       "types": "./dist/plugin-sdk/host-runtime.d.ts",
       "default": "./dist/plugin-sdk/host-runtime.js"

--- a/scripts/lib/plugin-sdk-entrypoints.json
+++ b/scripts/lib/plugin-sdk-entrypoints.json
@@ -117,6 +117,7 @@
   "agent-harness-runtime",
   "agent-harness-tool-runtime",
   "hook-runtime",
+  "html-entity-runtime",
   "host-runtime",
   "types",
   "process-runtime",

--- a/scripts/plugin-sdk-surface-report.mjs
+++ b/scripts/plugin-sdk-surface-report.mjs
@@ -199,13 +199,13 @@ export function readPluginSdkSurfaceBudgets(env = process.env) {
   const budgets = {
     publicEntrypoints: readPluginSdkSurfaceBudgetEnv(
       "OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_ENTRYPOINTS",
-      328,
+      329,
       env,
     ),
     // ScopeTree adds six channel-policy exports, mirrored by compat, including three functions.
     // Its flat channel-groups builder adds one function, also mirrored by compat.
     // Its case-insensitive scope-key resolver adds one function, also mirrored by compat.
-    // The focused text utility HTML decoder adds one public function.
+    // The focused HTML entity runtime adds one public function.
     publicExports: readPluginSdkSurfaceBudgetEnv(
       "OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_EXPORTS",
       10675,

--- a/src/plugin-sdk/html-entity-runtime.test.ts
+++ b/src/plugin-sdk/html-entity-runtime.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from "vitest";
+import { decodeHtmlEntities } from "./html-entity-runtime.js";
+
+describe("decodeHtmlEntities", () => {
+  it("exposes single-pass HTML5 decoding to plugins", () => {
+    expect(decodeHtmlEntities("&copy; &amp;lt; &#128512; &#xD800;")).toBe("© &lt; 😀 &#xD800;");
+  });
+});

--- a/src/plugin-sdk/html-entity-runtime.ts
+++ b/src/plugin-sdk/html-entity-runtime.ts
@@ -1,0 +1,1 @@
+export { decodeHtmlEntities } from "../shared/html-entities.js";

--- a/src/plugin-sdk/text-utility-runtime.test.ts
+++ b/src/plugin-sdk/text-utility-runtime.test.ts
@@ -1,15 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { decodeHtmlEntities, escapeHtml } from "./text-utility-runtime.js";
+import { escapeHtml } from "./text-utility-runtime.js";
 
 describe("escapeHtml", () => {
   it("escapes five HTML-sensitive characters and existing entity markers", () => {
     expect(escapeHtml(`&<>"'`)).toBe("&amp;&lt;&gt;&quot;&#39;");
     expect(escapeHtml("already &amp; escaped")).toBe("already &amp;amp; escaped");
-  });
-});
-
-describe("decodeHtmlEntities", () => {
-  it("exposes single-pass HTML5 decoding to plugins", () => {
-    expect(decodeHtmlEntities("&copy; &amp;lt; &#128512; &#xD800;")).toBe("© &lt; 😀 &#xD800;");
   });
 });

--- a/src/plugin-sdk/text-utility-runtime.ts
+++ b/src/plugin-sdk/text-utility-runtime.ts
@@ -10,8 +10,6 @@ export function escapeHtml(value: string): string {
     .replaceAll("'", "&#39;");
 }
 
-export { decodeHtmlEntities } from "../shared/html-entities.js";
-
 export {
   CONFIG_DIR,
   clamp,


### PR DESCRIPTION
## What Problem This Solves

#107235 adopted `entities` for HTML5 decoding but published the decoder from the broad `text-utility-runtime` SDK subpath. Every plugin importing common text helpers would therefore also load the HTML entity trie.

## Why This Change Was Made

Move the unshipped decoder export to a focused `html-entity-runtime` subpath, migrate the four plugin importers, and keep the package export, SDK registry, docs, surface budget, and generated API baseline aligned.

## User Impact

HTML decoding behavior stays unchanged. Plugins that only need ordinary text helpers no longer pull the entity decoder into their startup graph.

## Evidence

- 86 focused tests passed across the shared decoder, SDK entrypoints, DuckDuckGo, Matrix, and Microsoft Teams.
- `pnpm plugin-sdk:surface:check` passed: 329 public entrypoints, 10,675 exports, 5,376 callable exports.
- Full `pnpm build` passed.
- DuckDuckGo, Matrix, and Microsoft Teams extension memory profiles passed.
- Full `pnpm check:changed` passed, including typecheck, lint, generated API baseline, package exports, surface budget, and import-cycle checks.
- Blacksmith Testbox run: `tbx_01kxfq063r5xk3r7rgewt3gq1s` (`brisk-crayfish-87ab`).
- Fresh autoreview: clean, no accepted/actionable findings.
