### PR TITLE
fix exec env undefined removals

### DIFF
--- a/src/process/exec-spawn.ts
+++ b/src/process/exec-spawn.ts
@@ -12,9 +12,6 @@ function assignChildEnvValue(params: {
   platform: NodeJS.Platform;
   value: string | undefined;
 }): void {
-  if (params.value === undefined) {
-    return;
-  }
   if (params.platform === "win32") {
     const normalizedKey = params.key.toLowerCase();
     for (const existingKey of Object.keys(params.env)) {
@@ -22,6 +19,10 @@ function assignChildEnvValue(params: {
         delete params.env[existingKey];
       }
     }
+  }
+  if (params.value === undefined) {
+    delete params.env[params.key];
+    return;
   }
   params.env[params.key] = params.value;
 }


### PR DESCRIPTION
## Summary

Fix `resolveCommandEnv` so child env entries set to `undefined` remove inherited/base values instead of being ignored.

## Root cause

The active env merge implementation in `src/process/exec-spawn.ts` returned early for `undefined` values. That left inherited values in place, including case-insensitive Windows duplicates such as `Path` when `PATH` was set to `undefined`.

## Validation

- `pnpm exec vitest run src/process/exec.test.ts`