### PR TITLE
refactor(cron): trust Croner run results

### DIFF
--- a/src/cron/schedule.ts
+++ b/src/cron/schedule.ts
@@ -87,12 +87,8 @@ export function computeNextRunAtMs(schedule: CronSchedule, nowMs: number): numbe
   if (!cron) {
     return undefined;
   }
-  const next = cron.nextRun(new Date(nowMs));
-  if (!next) {
-    return undefined;
-  }
-  const nextMs = next.getTime();
-  if (!Number.isFinite(nextMs)) {
+  const nextMs = cron.nextRun(new Date(nowMs))?.getTime();
+  if (nextMs === undefined) {
     return undefined;
   }
 
@@ -102,21 +98,15 @@ export function computeNextRunAtMs(schedule: CronSchedule, nowMs: number): numbe
   // future.
   if (nextMs <= nowMs) {
     const nextSecondMs = Math.floor(nowMs / 1000) * 1000 + 1000;
-    const retry = cron.nextRun(new Date(nextSecondMs));
-    if (retry) {
-      const retryMs = retry.getTime();
-      if (Number.isFinite(retryMs) && retryMs > nowMs) {
-        return retryMs;
-      }
+    const retryMs = cron.nextRun(new Date(nextSecondMs))?.getTime();
+    if (retryMs !== undefined && retryMs > nowMs) {
+      return retryMs;
     }
     // Still in the past — try from start of tomorrow (UTC) as a broader reset.
     const tomorrowMs = new Date(nowMs).setUTCHours(24, 0, 0, 0);
-    const retry2 = cron.nextRun(new Date(tomorrowMs));
-    if (retry2) {
-      const retry2Ms = retry2.getTime();
-      if (Number.isFinite(retry2Ms) && retry2Ms > nowMs) {
-        return retry2Ms;
-      }
+    const retry2Ms = cron.nextRun(new Date(tomorrowMs))?.getTime();
+    if (retry2Ms !== undefined && retry2Ms > nowMs) {
+      return retry2Ms;
     }
     return undefined;
   }
@@ -133,16 +123,8 @@ export function computePreviousRunAtMs(schedule: CronSchedule, nowMs: number): n
   if (!cron) {
     return undefined;
   }
-  const previousRuns = cron.previousRuns(1, new Date(nowMs));
-  const previous = previousRuns[0];
-  if (!previous) {
-    return undefined;
-  }
-  const previousMs = previous.getTime();
-  if (!Number.isFinite(previousMs)) {
-    return undefined;
-  }
-  if (previousMs >= nowMs) {
+  const previousMs = cron.previousRuns(1, new Date(nowMs))[0]?.getTime();
+  if (previousMs === undefined || previousMs >= nowMs) {
     return undefined;
   }
   return previousMs;


### PR DESCRIPTION
## What Problem This Solves

Cron scheduling wrapped Croner results with temporary variables and finite-number guards even though Croner 10.0.1 already guarantees valid `Date` values, `null`, or an empty result array.

## Why This Change Was Made

Use the dependency's typed `nextRun()` and `previousRuns()` contracts directly with optional chaining. Keep the existing future/past guards and both DST rollback retry probes unchanged.

## User Impact

No scheduling behavior changes. The cron scheduling path is 18 lines smaller while retaining the existing timezone rollback protections.

## Evidence

- Inspected the installed `croner@10.0.1` implementation and declarations for `nextRun`, `previousRuns`, `CronDate`, and `getDate`.
- 111 focused cron tests passed across schedule calculations, prior-run handling, top-of-hour staggering, and unresolved-next-run behavior.
- `git diff --check` passed.
- Fresh autoreview: clean, no accepted/actionable findings.
- Blacksmith Testbox: `tbx_01kxfqwq3f44h3jrzbzm72g9j9` (`crimson-shrimp-f3d3`), workflow run https://github.com/openclaw/openclaw/actions/runs/29314151274.

Known gap: `check:changed` reached core typecheck, then failed on pre-existing unused `mergeChildEnv` in unchanged `src/process/exec.ts`; this branch changes only `src/cron/schedule.ts`. Hosted CI was not awaited per maintainer direction.
