### PR TITLE
test: speed up responsive browser fixtures

### DIFF
--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -1,5 +1,5 @@
 // Control UI tests cover chat responsive behavior.
-import { chromium, type Browser, type Page } from "playwright";
+import { chromium, type Browser, type BrowserContext, type Page } from "playwright";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { readStyleSheet } from "../../../../test/helpers/ui-style-fixtures.js";
 import {
@@ -30,7 +30,9 @@ const describeBrowserLayout = canRunPlaywrightChromium(chromiumExecutablePath)
   : describe.skip;
 
 let sharedBrowser: Browser | null = null;
+let sharedStaticContext: BrowserContext | null = null;
 let realChatServer: ControlUiE2eServer | null = null;
+let cachedUiCss: string | null = null;
 
 type ControlRect = {
   x: number;
@@ -76,6 +78,9 @@ function expectControlRect(rect: ControlRect | null, label: string): ControlRect
 }
 
 function readUiCss(): string {
+  if (cachedUiCss !== null) {
+    return cachedUiCss;
+  }
   const files = [
     "ui/src/styles/base.css",
     "ui/src/styles/layout.css",
@@ -87,7 +92,8 @@ function readUiCss(): string {
     "ui/src/styles/chat/tool-cards.css",
     "ui/src/styles/chat/sidebar.css",
   ];
-  return files.map((file) => readStyleSheet(file)).join("\n");
+  cachedUiCss = files.map((file) => readStyleSheet(file)).join("\n");
+  return cachedUiCss;
 }
 
 function iconSvg() {
@@ -418,7 +424,7 @@ function chatHtml(opts: ChatFixtureOptions = {}) {
 }
 
 async function openFixture(width: number, height: number, opts: ChatFixtureOptions = {}) {
-  const page = await openBrowserPage(width, height);
+  const page = await openStaticPage(width, height);
   try {
     await page.setContent(
       `<!doctype html><html><head><style>${readUiCss()}</style></head><body>${chatHtml(opts)}</body></html>`,
@@ -436,6 +442,17 @@ async function openBrowserPage(width: number, height: number): Promise<Page> {
     headless: true,
   });
   return await sharedBrowser.newPage({ viewport: { width, height } });
+}
+
+async function openStaticPage(width: number, height: number): Promise<Page> {
+  if (!sharedStaticContext) {
+    throw new Error("Expected the static fixture browser context to be ready");
+  }
+  // Static setContent fixtures carry no storage. Share their context so each
+  // concurrent case keeps an isolated DOM without paying for a new context.
+  const page = await sharedStaticContext.newPage();
+  await page.setViewportSize({ width, height });
+  return page;
 }
 
 async function closeBrowserPage(page: Page): Promise<void> {
@@ -490,7 +507,7 @@ function rectsOverlap(
 }
 
 async function openHeaderFixture(width: number, height: number, opts: { hidden?: boolean } = {}) {
-  const page = await openBrowserPage(width, height);
+  const page = await openStaticPage(width, height);
   try {
     await page.setContent(
       `<!doctype html><html><head><style>${readUiCss()}</style></head><body>${chatHeaderControlsHtml(Boolean(opts.hidden))}</body></html>`,
@@ -518,12 +535,15 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
       executablePath: chromiumExecutablePath,
       headless: true,
     });
+    sharedStaticContext = await sharedBrowser.newContext();
     realChatServer = await startControlUiE2eServer();
   });
 
   afterAll(async () => {
     await realChatServer?.close();
     realChatServer = null;
+    await sharedStaticContext?.close();
+    sharedStaticContext = null;
     await sharedBrowser?.close();
     sharedBrowser = null;
   });
@@ -561,7 +581,7 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
     [430, 720],
     [1366, 900],
   ] as const)("right-aligns activity rows with call bubbles at %sx%s", async (width, height) => {
-    const page = await openBrowserPage(width, height);
+    const page = await openStaticPage(width, height);
     try {
       await page.setContent(
         `<!doctype html><html><head><style>${readUiCss()}</style></head><body>${activityAlignmentHtml()}</body></html>`,
@@ -948,7 +968,7 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
   ] as const)(
     "keeps short assistant footer actions below the bubble at %sx%s",
     async (width, height) => {
-      const page = await openBrowserPage(width, height);
+      const page = await openStaticPage(width, height);
       try {
         await page.setContent(
           `<!doctype html><html><head><style>${readUiCss()}</style></head><body>
@@ -988,7 +1008,7 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
     [320, 568],
     [1366, 900],
   ] as const)("wraps long inline code without clipping at %sx%s", async (width, height) => {
-    const page = await openBrowserPage(width, height);
+    const page = await openStaticPage(width, height);
     try {
       await page.setContent(
         `<!doctype html><html><head><style>${readUiCss()}</style></head><body>
@@ -1108,7 +1128,7 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
   });
 
   it("aligns the reasoning default action with the reasoning heading", async () => {
-    const page = await openBrowserPage(520, 600);
+    const page = await openStaticPage(520, 600);
     try {
       await page.setContent(`
         <!doctype html>
@@ -1428,7 +1448,7 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
   );
 
   it("stacks the detail sidebar below the thread in a narrow pane", async () => {
-    const page = await openBrowserPage(900, 700);
+    const page = await openStaticPage(900, 700);
     try {
       // A 620px pane inside a wide viewport: chat-pane sets the stacked class
       // when the pane cannot fit chat + detail panel side by side.
@@ -1467,7 +1487,7 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
   });
 
   it("docks the tasks rail as a full-width bottom strip in a narrow pane", async () => {
-    const page = await openBrowserPage(1200, 700);
+    const page = await openStaticPage(1200, 700);
     try {
       // chat-pane sets --tasks-dock-bottom instead of --tasks-open when the
       // pane is too narrow for a side column; the strip spans the pane and
@@ -1530,7 +1550,7 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
   });
 
   it("keeps the bottom-docked rail path and summary rows unclipped", async () => {
-    const page = await openBrowserPage(760, 700);
+    const page = await openStaticPage(760, 700);
     try {
       await page.setContent(
         `<!doctype html><html><head><style>${readUiCss()}</style></head><body>


### PR DESCRIPTION
## What Problem This Solves

The 61-case responsive browser suite repeatedly created a fresh Playwright browser context and reread nine CSS files for every static `setContent` fixture. A recent CI shard measured the file at 19.4s under suite load; the focused Testbox baseline was 6.92s with 1.43 GB max RSS.

## Why This Change Was Made

Static layout fixtures do not navigate, use cookies, or use storage. They now share one lifecycle-owned browser context while retaining a separate page and viewport per concurrent test. Full Control UI flows keep their fresh isolated contexts. The immutable CSS bundle is read once per test module.

This follows Playwright 1.61.1's explicit `browser.newContext()` plus `context.newPage()` lifetime contract while preserving DOM isolation between cases.

## User Impact

No runtime or UI behavior change. Responsive browser tests use less time and substantially less memory, reducing CI contention.

## Evidence

- `corepack pnpm test ui/src/pages/chat/chat-responsive.browser.test.ts --reporter=verbose`
  - baseline: 61/61, Vitest 6.92s, test body 6.20s, wall 7.63s, max RSS 1,432,756 KB
  - patched: 61/61, Vitest 5.55s, test body 5.00s, wall 6.08s, max RSS 706,908 KB
- repeat patched run: 61/61, Vitest 5.17s, test body 4.66s, wall 5.68s, max RSS 667,836 KB
- `check:changed`: passed the core-tests lane on Testbox `tbx_01kxfqg961tqg6npk5d9w08w0r`
- Fresh autoreview: no actionable findings, confidence 0.97

Docs, screenshots, and changelog are not applicable for this test-only optimization.
