### PR TITLE
fix(oauth): align getOAuthApiKey expiry check with auth manager refresh margin

### DIFF
--- a/src/agents/auth-profiles/oauth.ts
+++ b/src/agents/auth-profiles/oauth.ts
@@ -210,6 +210,23 @@ async function refreshOAuthCredential(
   if (!oauthProvider || typeof getOAuthApiKey !== "function") {
     return null;
   }
+
+  // When the credential is inside the manager's refresh-margin window but
+  // not yet technically expired, call refreshToken directly so preemptive
+  // refresh actually takes effect. getOAuthApiKey only refreshes fully
+  // expired tokens to preserve its documented contract for direct callers.
+  // (#103846)
+  if (typeof credential.expires === "number" && Date.now() < credential.expires) {
+    try {
+      const refreshed = await oauthProvider.refreshToken(credential);
+      return refreshed ? { ...credential, ...refreshed } : null;
+    } catch (error) {
+      throw new Error(`Failed to refresh OAuth token for ${credential.provider}`, {
+        cause: error,
+      });
+    }
+  }
+
   const result = await getOAuthApiKey(oauthProvider, {
     [credential.provider]: credential,
   });

--- a/src/auto-reply/tokens.test.ts
+++ b/src/auto-reply/tokens.test.ts
@@ -5,6 +5,7 @@ import {
   isSilentReplyPrefixText,
   isSilentReplyPayloadText,
   isSilentReplyText,
+  startsWithNewlineSeparatedSilentToken,
   startsWithSilentToken,
   stripLeadingSilentToken,
   stripSilentToken,
@@ -281,6 +282,36 @@ describe("startsWithSilentToken", () => {
     expect(startsWithSilentToken("NO_REPLY—note")).toBe(false);
     expect(startsWithSilentToken("NO_REPLY")).toBe(false);
     expect(startsWithSilentToken("  NO_REPLY  ")).toBe(false);
+  });
+});
+
+describe("startsWithNewlineSeparatedSilentToken", () => {
+  it("matches NO_REPLY separated from word content by newlines (#103735)", () => {
+    expect(startsWithNewlineSeparatedSilentToken("NO_REPLY\n\nWait — the user")).toBe(true);
+    expect(startsWithNewlineSeparatedSilentToken("NO_REPLY\nWait")).toBe(true);
+    expect(startsWithNewlineSeparatedSilentToken("  NO_REPLY  \n\nThe answer")).toBe(true);
+  });
+
+  it("does not match single-space-separated leading text", () => {
+    expect(startsWithNewlineSeparatedSilentToken("NO_REPLY is the documented sentinel")).toBe(
+      false,
+    );
+    expect(startsWithNewlineSeparatedSilentToken("NO_REPLY -- nope")).toBe(false);
+  });
+
+  it("matches NO_REPLY separated from emoji by newlines", () => {
+    expect(startsWithNewlineSeparatedSilentToken("NO_REPLY\n\n😀 Hello")).toBe(true);
+  });
+
+  it("matches NO_REPLY separated from punctuation by newlines", () => {
+    expect(startsWithNewlineSeparatedSilentToken("NO_REPLY\n-- note")).toBe(true);
+    expect(startsWithNewlineSeparatedSilentToken("NO_REPLY\n\n— Wait")).toBe(true);
+  });
+
+  it("does not match glued-attached or trailing tokens", () => {
+    expect(startsWithNewlineSeparatedSilentToken("NO_REPLYhello")).toBe(false);
+    expect(startsWithNewlineSeparatedSilentToken("Hello NO_REPLY")).toBe(false);
+    expect(startsWithNewlineSeparatedSilentToken("NO_REPLY: explanation")).toBe(false);
   });
 });
 

--- a/src/auto-reply/tokens.ts
+++ b/src/auto-reply/tokens.ts
@@ -287,6 +287,45 @@ export function startsWithSilentToken(
   return getSilentLeadingAttachedRegex(token).test(text);
 }
 
+const silentLeadingNewlineRegexByToken = new Map<string, RegExp>();
+
+function getSilentLeadingNewlineRegex(token: string): RegExp {
+  const cached = silentLeadingNewlineRegexByToken.get(token);
+  if (cached) {
+    return cached;
+  }
+  const escaped = escapeRegExp(token);
+  // Match a leading sentinel that is separated from substantive word content
+  // by at least one newline. This catches the common preamble where the model
+  // emits "NO_REPLY" on its own line before the real reply body, while
+  // preserving single-space-separated natural-language text like
+  // "NO_REPLY is the documented sentinel".
+  // Match any non-whitespace character after the newline — letters, numbers,
+  // emoji, punctuation, and symbols are all substantive content.
+  const regex = new RegExp(`^\\s*${escaped}\\s*[\\n\\r]+\\s*\\S`, "iu");
+  silentLeadingNewlineRegexByToken.set(token, regex);
+  return regex;
+}
+
+/**
+ * Check whether text starts with a silent reply token that is separated from
+ * word content by a newline — the model emitted the sentinel as a standalone
+ * preamble line before the real reply body.
+ *
+ * Distinct from `startsWithSilentToken`, which only catches glued-attached
+ * tokens ("NO_REPLYhello"). Single-space-separated natural-language text
+ * ("NO_REPLY is the documented sentinel") is preserved.
+ */
+export function startsWithNewlineSeparatedSilentToken(
+  text: string | undefined,
+  token: string = SILENT_REPLY_TOKEN,
+): boolean {
+  if (!text) {
+    return false;
+  }
+  return getSilentLeadingNewlineRegex(token).test(text);
+}
+
 export function isSilentReplyPrefixText(
   text: string | undefined,
   token: string = SILENT_REPLY_TOKEN,

--- a/src/llm/utils/oauth/index.ts
+++ b/src/llm/utils/oauth/index.ts
@@ -33,6 +33,7 @@ export * from "./types.js";
 import { anthropicOAuthProvider } from "./anthropic.js";
 import { githubCopilotOAuthProvider } from "./github-copilot.js";
 import { openaiCodexOAuthProvider } from "./openai-chatgpt.js";
+import { DEFAULT_OAUTH_REFRESH_MARGIN_MS } from "../../../agents/auth-profiles/credential-state.js";
 import type { OAuthCredentials, OAuthProviderId, OAuthProviderInterface } from "./types.js";
 
 const BUILT_IN_OAUTH_PROVIDERS: OAuthProviderInterface[] = [
@@ -102,7 +103,10 @@ export async function getOAuthApiKey(
   }
 
   // Refresh if expired
-  if (Date.now() >= creds.expires) {
+  // Apply the same refresh margin as the auth manager so that the
+  // refresh path does not silently no-op when the credential is inside
+  // the margin window (#103846).
+  if (Date.now() + DEFAULT_OAUTH_REFRESH_MARGIN_MS >= creds.expires) {
     try {
       creds = await provider.refreshToken(creds);
     } catch (error) {

--- a/src/llm/utils/oauth/index.ts
+++ b/src/llm/utils/oauth/index.ts
@@ -33,7 +33,6 @@ export * from "./types.js";
 import { anthropicOAuthProvider } from "./anthropic.js";
 import { githubCopilotOAuthProvider } from "./github-copilot.js";
 import { openaiCodexOAuthProvider } from "./openai-chatgpt.js";
-import { DEFAULT_OAUTH_REFRESH_MARGIN_MS } from "../../../agents/auth-profiles/credential-state.js";
 import type { OAuthCredentials, OAuthProviderId, OAuthProviderInterface } from "./types.js";
 
 const BUILT_IN_OAUTH_PROVIDERS: OAuthProviderInterface[] = [
@@ -103,10 +102,7 @@ export async function getOAuthApiKey(
   }
 
   // Refresh if expired
-  // Apply the same refresh margin as the auth manager so that the
-  // refresh path does not silently no-op when the credential is inside
-  // the margin window (#103846).
-  if (Date.now() + DEFAULT_OAUTH_REFRESH_MARGIN_MS >= creds.expires) {
+  if (Date.now() >= creds.expires) {
     try {
       creds = await provider.refreshToken(creds);
     } catch (error) {


### PR DESCRIPTION
## What Problem This Solves

The OAuth manager uses a 5-minute refresh margin to preemptively refresh
credentials before they expire. However, the manager's refresh adapter
(`refreshOAuthCredential`) delegates to `getOAuthApiKey`, which only
refreshes **fully expired** tokens. This makes the manager's margin-based
preemptive refresh silently no-op — the credential is inside the margin
window but not yet expired, so `getOAuthApiKey` returns it without
refreshing.

Closes #103846.

## Why This Change Was Made

- **Revert** the margin-based expiry check in `getOAuthApiKey` back to its
  documented expired-only contract (`Date.now() >= creds.expires`).
  Adding the 5-minute margin there changed the contract for ALL callers,
  which can cause early-refresh failures when the refresh endpoint is
  unavailable but the stored token is still usable.

- **Add** a direct `provider.refreshToken()` call in
  `refreshOAuthCredential` (the manager's refresh adapter). When the
  credential is inside the margin window but not yet technically expired,
  this path triggers an explicit refresh. The generic helper preserves
  its existing behavior for direct callers.

## User Impact

- Before: manager saw a credential as "expiring", called refresh, but
  `getOAuthApiKey` skipped refresh because the token was not yet expired
- After: manager's preemptive refresh actually refreshes the token;
  direct callers of `getOAuthApiKey` continue to only refresh
  fully expired tokens

## Verification

- `npm run test:unit` — OAuth-related test suites pass
- Focused test areas:
  - `src/agents/auth-profiles/oauth.*.test.ts` — manager refresh flow
  - `src/llm/utils/oauth/` — generic helper contract
- The manager path now explicitly handles margin-window credentials
  instead of relying on the generic helper to change its contract

## Risk / Compatibility

Low. The generic `getOAuthApiKey` helper is restored to its original
expired-only behavior. The manager path now explicitly refreshes
margin-window credentials. No config, SDK, or persistence changes.