### PR TITLE
fix(plugins): quarantine managed npm projects with missing integrity

### DIFF
--- a/src/plugins/install.npm-spec.test.ts
+++ b/src/plugins/install.npm-spec.test.ts
@@ -120,6 +120,17 @@ function isManagedNpmInstallCommand(argv: unknown): argv is string[] {
   return isNpmInstallCommand(argv) && !isNpmPeerPlannerInstallCommand(argv);
 }
 
+function managedNpmRootHasDependency(npmRoot: string, packageName: string): boolean {
+  const manifestPath = path.join(npmRoot, "package.json");
+  if (!fs.existsSync(manifestPath)) {
+    return false;
+  }
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8")) as {
+    dependencies?: Record<string, string>;
+  };
+  return packageName in (manifest.dependencies ?? {});
+}
+
 function expectNpmInstallIntoRoot(params: {
   calls: unknown[][];
   npmRoot: string;
@@ -1307,6 +1318,115 @@ describe("installPluginFromNpmSpec", () => {
     const quarantines = fs.readdirSync(quarantineParent);
     expect(quarantines.length).toBeGreaterThanOrEqual(1);
     expect(fs.existsSync(resolveTestPluginPackageDir(npmRoot, packageName))).toBe(true);
+  });
+
+  it("does not restore a quarantined tree when post-recovery validation fails", async () => {
+    const npmRoot = path.join(suiteTempRootTracker.makeTempDir(), "npm");
+    const packageName = "unsafe-recovered-plugin";
+    const addedPeerName = "recovery-added-peer";
+    const npmProjectRoot = resolvePluginNpmProjectDir({ npmDir: npmRoot, packageName });
+    const stalePackageDir = path.join(npmProjectRoot, "node_modules", "stale-plugin");
+    fs.mkdirSync(stalePackageDir, { recursive: true });
+    fs.writeFileSync(path.join(stalePackageDir, "stale.txt"), "poisoned tree", "utf8");
+    const fixture: MockNpmPackage & { spec: string } = {
+      spec: `${packageName}@latest`,
+      packageName,
+      version: "1.0.0",
+      pluginId: packageName,
+      integrity: "sha512-safe",
+      omitInstalledIntegrity: true,
+      npmRoot,
+      expectedDependencySpec: "1.0.0",
+      hoistedDependency: { name: "plain-crypto-js", version: "1.0.0" },
+    };
+    mockNpmViewAndInstallMany([
+      fixture,
+      {
+        packageName: addedPeerName,
+        version: "2.0.0",
+        npmRoot,
+      },
+    ]);
+    const delegate = runCommandWithTimeoutMock.getMockImplementation();
+    if (!delegate) {
+      throw new Error("expected npm mock implementation");
+    }
+    let managedInstallAttempts = 0;
+    runCommandWithTimeoutMock.mockImplementation(async (argv, options) => {
+      if (
+        isManagedNpmInstallCommand(argv) &&
+        options?.cwd === npmProjectRoot &&
+        managedNpmRootHasDependency(npmProjectRoot, packageName)
+      ) {
+        managedInstallAttempts += 1;
+        if (managedInstallAttempts === 2) {
+          fixture.omitInstalledIntegrity = false;
+        }
+      }
+      return await delegate(argv, options);
+    });
+    let mutatedPeerAfterQuarantine = false;
+    const addPeerAfterQuarantine = () => {
+      const manifestPath = path.join(npmProjectRoot, "package.json");
+      const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8")) as {
+        dependencies?: Record<string, string>;
+        openclaw?: { managedPeerDependencies?: string[] };
+      };
+      manifest.dependencies ??= {};
+      manifest.dependencies[addedPeerName] = "2.0.0";
+      manifest.openclaw ??= {};
+      manifest.openclaw.managedPeerDependencies = [addedPeerName];
+      fs.writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
+      mutatedPeerAfterQuarantine = true;
+    };
+
+    const result = await installPluginFromNpmSpec({
+      spec: fixture.spec,
+      expectedIntegrity: fixture.integrity,
+      npmDir: npmRoot,
+      logger: {
+        info: () => {},
+        warn: (message) => {
+          if (message.includes("quarantined")) {
+            addPeerAfterQuarantine();
+          }
+        },
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      return;
+    }
+    expect(result.code).toBe(PLUGIN_INSTALL_ERROR_CODE.SECURITY_SCAN_BLOCKED);
+    expect(managedInstallAttempts).toBe(2);
+    expect(mutatedPeerAfterQuarantine).toBe(true);
+    const quarantineParent = path.join(npmProjectRoot, "_openclaw-quarantined-npm-projects");
+    const quarantines = fs.readdirSync(quarantineParent);
+    expect(quarantines).toHaveLength(1);
+    expect(
+      fs.readFileSync(
+        path.join(
+          quarantineParent,
+          quarantines[0] ?? "",
+          "node_modules",
+          "stale-plugin",
+          "stale.txt",
+        ),
+        "utf8",
+      ),
+    ).toBe("poisoned tree");
+    // Poisoned tree must stay quarantined — outer rollback must not restore it.
+    expect(fs.existsSync(stalePackageDir)).toBe(false);
+    const manifest = JSON.parse(
+      fs.readFileSync(path.join(npmProjectRoot, "package.json"), "utf8"),
+    ) as {
+      dependencies?: Record<string, string>;
+      openclaw?: { managedPeerDependencies?: string[] };
+    };
+    expect(manifest.dependencies?.[addedPeerName]).toBeUndefined();
+    expect(manifest.openclaw?.managedPeerDependencies ?? []).not.toContain(addedPeerName);
+    expect(fs.existsSync(resolveTestPluginPackageDir(npmRoot, packageName))).toBe(false);
   });
 
   it("rejects npm installs when the installed version drifts from verified metadata", async () => {

--- a/src/plugins/install.npm-spec.test.ts
+++ b/src/plugins/install.npm-spec.test.ts
@@ -302,6 +302,8 @@ type MockNpmPackage = {
   versions?: string[];
   installedVersion?: string;
   installedIntegrity?: string;
+  /** When true, write lock entry without an integrity field (poisoned project repro). */
+  omitInstalledIntegrity?: boolean;
   materializesRootOpenClaw?: boolean;
   skipLockfileEntry?: boolean;
   packArchivePath?: string;
@@ -325,7 +327,11 @@ function writeNpmRootPackageLock(params: {
     }
     lockPackages[`node_modules/${pkg.packageName}`] = {
       version: pkg.installedVersion ?? pkg.version,
-      integrity: pkg.installedIntegrity ?? pkg.integrity ?? "sha512-plugin-test",
+      ...(pkg.omitInstalledIntegrity
+        ? {}
+        : {
+            integrity: pkg.installedIntegrity ?? pkg.integrity ?? "sha512-plugin-test",
+          }),
     };
     if (pkg.materializesRootOpenClaw) {
       lockPackages["node_modules/openclaw"] = {
@@ -1231,6 +1237,76 @@ describe("installPluginFromNpmSpec", () => {
     expect(result.error).toContain("integrity sha512-evil");
     expect(result.error).toContain("expected sha512-safe");
     expect(fs.existsSync(resolveTestPluginPackageDir(npmRoot, "drift-plugin"))).toBe(false);
+  });
+
+  it("quarantines and rebuilds when package-lock omits integrity instead of looping forever", async () => {
+    const stateDir = suiteTempRootTracker.makeTempDir();
+    const npmRoot = path.join(stateDir, "npm");
+    const packageName = "missing-integrity-plugin";
+    const warnings: string[] = [];
+    const npmProjectRoot = resolvePluginNpmProjectDir({ npmDir: npmRoot, packageName });
+
+    mockNpmViewAndInstall({
+      spec: `${packageName}@1.0.0`,
+      packageName,
+      version: "1.0.0",
+      pluginId: packageName,
+      integrity: "sha512-safe-integrity",
+      npmRoot,
+      expectedDependencySpec: "1.0.0",
+    });
+    const delegate = runCommandWithTimeoutMock.getMockImplementation();
+    if (!delegate) {
+      throw new Error("expected npm mock implementation");
+    }
+    let managedInstallAttempts = 0;
+    const quarantineParent = path.join(npmProjectRoot, "_openclaw-quarantined-npm-projects");
+    runCommandWithTimeoutMock.mockImplementation(
+      async (argv: string[], options?: { cwd?: string }) => {
+        const result = await delegate(argv, options);
+        if (options?.cwd === npmProjectRoot) {
+          if (isManagedNpmInstallCommand(argv)) {
+            managedInstallAttempts += 1;
+          }
+          // Before recovery quarantine, keep lock integrity absent so verification
+          // observes the poisoned package-lock-only reconstruction state.
+          if (!fs.existsSync(quarantineParent)) {
+            const lockPath = path.join(npmProjectRoot, "package-lock.json");
+            if (fs.existsSync(lockPath)) {
+              const lockfile = JSON.parse(fs.readFileSync(lockPath, "utf8")) as {
+                packages?: Record<string, Record<string, unknown>>;
+              };
+              const entry = lockfile.packages?.[`node_modules/${packageName}`];
+              if (entry && "integrity" in entry) {
+                delete entry.integrity;
+                fs.writeFileSync(lockPath, `${JSON.stringify(lockfile, null, 2)}\n`, "utf8");
+              }
+            }
+          }
+        }
+        return result;
+      },
+    );
+
+    const result = await installPluginFromNpmSpec({
+      spec: `${packageName}@1.0.0`,
+      expectedIntegrity: "sha512-safe-integrity",
+      npmDir: npmRoot,
+      logger: { info: () => {}, warn: (message) => warnings.push(message) },
+    });
+
+    if (!result.ok) {
+      throw new Error(`expected install success, got: ${result.error}`);
+    }
+    expect(managedInstallAttempts).toBeGreaterThanOrEqual(2);
+    expect(result.pluginId).toBe(packageName);
+    expect(
+      warnings.some((warning) => warning.includes("package-lock metadata without integrity")),
+    ).toBe(true);
+    expect(fs.existsSync(quarantineParent)).toBe(true);
+    const quarantines = fs.readdirSync(quarantineParent);
+    expect(quarantines.length).toBeGreaterThanOrEqual(1);
+    expect(fs.existsSync(resolveTestPluginPackageDir(npmRoot, packageName))).toBe(true);
   });
 
   it("rejects npm installs when the installed version drifts from verified metadata", async () => {

--- a/src/plugins/install.ts
+++ b/src/plugins/install.ts
@@ -1427,6 +1427,22 @@ async function installPluginFromManagedNpmRoot(
 
   let rollbackSnapshot: ManagedNpmPluginInstallRollbackSnapshot;
   let preparedDependency: ManagedNpmRootPreparedDependency | undefined;
+  // Peer + tree rollback ownership stay on this install attempt so nested recovery
+  // retries reuse the pre-quarantine peer snapshot and never re-capture post-recovery
+  // mutations as the restore baseline.
+  let rollbackPeerDependencySnapshot:
+    | Awaited<ReturnType<typeof readManagedNpmRootPeerDependencySnapshot>>
+    | undefined;
+  // Once the poisoned tree has been quarantined, restoring the pre-quarantine
+  // snapshot would recreate the crash loop that the recovery attempt is repairing.
+  // Keep recovery ownership on this install attempt so every later failure cleans
+  // the rebuilt tree without re-poisoning the managed project.
+  let recovery:
+    | {
+        cause: { kind: "npm-corruption" | "incomplete-metadata"; error: string };
+        quarantine: ManagedNpmProjectQuarantine;
+      }
+    | undefined;
   try {
     rollbackSnapshot = await createManagedNpmPluginInstallRollbackSnapshot({ npmRoot });
   } catch (error) {
@@ -1455,7 +1471,7 @@ async function installPluginFromManagedNpmRoot(
     }
     let preInstallRootPackageNames = await listManagedNpmRootPackageNames(npmRoot);
     const managedOverrides = await readOpenClawManagedNpmRootOverrides();
-    const rollbackPeerDependencySnapshot = await readManagedNpmRootPeerDependencySnapshot({
+    rollbackPeerDependencySnapshot ??= await readManagedNpmRootPeerDependencySnapshot({
       npmRoot,
     });
     const rollbackFailedManagedNpmInstall = async (
@@ -1468,25 +1484,8 @@ async function installPluginFromManagedNpmRoot(
         timeoutMs,
         logger,
         peerDependencySnapshot: rollbackPeerDependencySnapshot,
-        snapshot: rollbackSnapshot,
-      });
-      await rollbackManagedNpmRootPreparedDependency({
-        packageName: params.packageName,
-        preparedDependency: prepared,
-        logger,
-      });
-      return failure;
-    };
-    const rollbackFailedManagedNpmInstallAfterQuarantine = async (
-      failure: Extract<InstallPluginResult, { ok: false }>,
-    ): Promise<Extract<InstallPluginResult, { ok: false }>> => {
-      await rollbackManagedNpmPluginInstall({
-        npmRoot,
-        packageName: params.packageName,
-        targetDir: installRoot,
-        timeoutMs,
-        logger,
-        peerDependencySnapshot: rollbackPeerDependencySnapshot,
+        // After quarantine, do not restore the original poisoned snapshot.
+        snapshot: recovery ? undefined : rollbackSnapshot,
       });
       await rollbackManagedNpmRootPreparedDependency({
         packageName: params.packageName,
@@ -1571,11 +1570,22 @@ async function installPluginFromManagedNpmRoot(
       }
       install = await runCommandWithTimeout(npmInstallArgs, npmInstallOptions);
     }
-    if (install.code !== 0 && isManagedNpmProjectCorruptionInstallFailure(install)) {
+    if (
+      !recovery &&
+      install.code !== 0 &&
+      isManagedNpmProjectCorruptionInstallFailure(install)
+    ) {
       const originalError = formatNpmCommandFailureOutput(install);
       let quarantine: ManagedNpmProjectQuarantine;
       try {
         quarantine = await quarantineManagedNpmProjectRebuildArtifacts({ npmRoot });
+        recovery = {
+          cause: {
+            kind: "npm-corruption",
+            error: `npm install failed with a managed npm project corruption signature. Original npm error: ${originalError}`,
+          },
+          quarantine,
+        };
       } catch (error) {
         return await rollbackFailedManagedNpmInstall({
           ok: false,
@@ -1583,23 +1593,23 @@ async function installPluginFromManagedNpmRoot(
         });
       }
       logger.warn?.(
-        `npm reported a managed npm project corruption signature; quarantined ${formatManagedNpmProjectQuarantineArtifacts(quarantine.movedArtifactNames)} at ${quarantine.quarantineDir} and rebuilding once before retrying.`,
+        `npm reported a managed npm project corruption signature; quarantined ${formatManagedNpmProjectQuarantineArtifacts(recovery.quarantine.movedArtifactNames)} at ${recovery.quarantine.quarantineDir} and rebuilding once before retrying.`,
       );
       preInstallRootPackageNames = await listManagedNpmRootPackageNames(npmRoot);
       const recoveryPeerSync = await syncManagedPeerDependenciesForInstall({
         omitUnsupportedManagedOverrides,
       });
       if (!recoveryPeerSync.ok) {
-        return await rollbackFailedManagedNpmInstallAfterQuarantine({
+        return await rollbackFailedManagedNpmInstall({
           ok: false,
-          error: `managed npm project recovery failed after quarantining ${formatManagedNpmProjectQuarantineArtifacts(quarantine.movedArtifactNames)} at ${quarantine.quarantineDir}: ${recoveryPeerSync.error}. Original npm error: ${originalError}`,
+          error: `managed npm project recovery failed after quarantining ${formatManagedNpmProjectQuarantineArtifacts(recovery.quarantine.movedArtifactNames)} at ${recovery.quarantine.quarantineDir}: ${recoveryPeerSync.error}. Original npm error: ${originalError}`,
         });
       }
       install = await runCommandWithTimeout(npmInstallArgs, npmInstallOptions);
       if (install.code !== 0) {
-        return await rollbackFailedManagedNpmInstallAfterQuarantine({
+        return await rollbackFailedManagedNpmInstall({
           ok: false,
-          error: `npm install failed after managed npm project recovery (quarantine: ${quarantine.quarantineDir}): ${formatNpmCommandFailureOutput(install)}. Original npm error: ${originalError}`,
+          error: `npm install failed after managed npm project recovery (quarantine: ${recovery.quarantine.quarantineDir}): ${formatNpmCommandFailureOutput(install)}. Original npm error: ${originalError}`,
         });
       }
     }
@@ -1789,6 +1799,13 @@ async function installPluginFromManagedNpmRoot(
       let quarantine: ManagedNpmProjectQuarantine;
       try {
         quarantine = await quarantineManagedNpmProjectRebuildArtifacts({ npmRoot });
+        recovery = {
+          cause: {
+            kind: "incomplete-metadata",
+            error: originalError ?? `npm install resolved ${params.packageName} with incomplete lock metadata`,
+          },
+          quarantine,
+        };
       } catch (error) {
         return await rollbackFailedManagedNpmInstall({
           ok: false,
@@ -1796,9 +1813,10 @@ async function installPluginFromManagedNpmRoot(
         });
       }
       logger.warn?.(
-        `npm install recorded package-lock metadata without integrity for ${params.packageName}; quarantined ${formatManagedNpmProjectQuarantineArtifacts(quarantine.movedArtifactNames)} at ${quarantine.quarantineDir} and rebuilding once before retrying.`,
+        `npm install recorded package-lock metadata without integrity for ${params.packageName}; quarantined ${formatManagedNpmProjectQuarantineArtifacts(recovery.quarantine.movedArtifactNames)} at ${recovery.quarantine.quarantineDir} and rebuilding once before retrying.`,
       );
       // Restart from a clean managed project so npm records integrity metadata.
+      // recovery remains set so any later failure does not restore the poisoned snapshot.
       return await runManagedNpmInstall(prepared);
     }
     const resolutionMismatch = resolveInstalledNpmResolutionMismatch({
@@ -1809,7 +1827,14 @@ async function installPluginFromManagedNpmRoot(
     if (resolutionMismatch) {
       return await rollbackFailedManagedNpmInstall({
         ok: false,
-        error: resolutionMismatch,
+        error:
+          recovery &&
+          hasMissingInstalledIntegrity({
+            expected: params.npmResolution,
+            installed: installedDependency,
+          })
+            ? `npm install metadata remained incomplete after managed npm project recovery (quarantine: ${recovery.quarantine.quarantineDir}): ${resolutionMismatch}`
+            : resolutionMismatch,
       });
     }
 

--- a/src/plugins/install.ts
+++ b/src/plugins/install.ts
@@ -1027,6 +1027,19 @@ async function quarantineManagedNpmProjectRebuildArtifacts(params: {
   return { quarantineDir, movedArtifactNames };
 }
 
+/**
+ * True when lock metadata exists but omits integrity while the verified npm
+ * resolution required one. That state is usually a poisoned managed project
+ * (e.g. package-lock reconstructed from node_modules after .package-lock.json
+ * cleanup), not a real content mismatch — recovery should quarantine/rebuild.
+ */
+function hasMissingInstalledIntegrity(params: {
+  expected: NpmSpecResolution;
+  installed: ManagedNpmRootInstalledDependency | null;
+}): boolean {
+  return Boolean(params.expected.integrity && params.installed && !params.installed.integrity);
+}
+
 function resolveInstalledNpmResolutionMismatch(params: {
   packageName: string;
   expected: NpmSpecResolution;
@@ -1038,8 +1051,16 @@ function resolveInstalledNpmResolutionMismatch(params: {
   if (params.expected.version && params.installed.version !== params.expected.version) {
     return `npm install resolved ${params.packageName} to version ${params.installed.version ?? "unknown"}, expected ${params.expected.version}`;
   }
-  if (params.expected.integrity && params.installed.integrity !== params.expected.integrity) {
-    return `npm install resolved ${params.packageName} with integrity ${params.installed.integrity ?? "unknown"}, expected ${params.expected.integrity}`;
+  // Missing integrity is a separate recovery signal (hasMissingInstalledIntegrity).
+  // Present-but-different integrity stays fail-closed as a real resolution mismatch.
+  if (params.expected.integrity && params.installed.integrity) {
+    if (params.installed.integrity !== params.expected.integrity) {
+      return `npm install resolved ${params.packageName} with integrity ${params.installed.integrity}, expected ${params.expected.integrity}`;
+    }
+    return null;
+  }
+  if (params.expected.integrity && !params.installed.integrity) {
+    return `npm install resolved ${params.packageName} with integrity unknown, expected ${params.expected.integrity}`;
   }
   return null;
 }
@@ -1415,6 +1436,9 @@ async function installPluginFromManagedNpmRoot(
     };
   }
 
+  // One-shot recovery when package-lock records the package without integrity
+  // (poisoned managed project). A second missing-integrity result fails closed.
+  let recoveredMissingIntegrity = false;
   const runManagedNpmInstall = async (
     prepared: ManagedNpmRootPreparedDependency,
   ): Promise<InstallPluginResult> => {
@@ -1748,6 +1772,34 @@ async function installPluginFromManagedNpmRoot(
         ok: false,
         error: `Failed to verify npm install metadata for ${params.packageName}: ${String(error)}`,
       });
+    }
+    if (
+      hasMissingInstalledIntegrity({
+        expected: params.npmResolution,
+        installed: installedDependency,
+      }) &&
+      !recoveredMissingIntegrity
+    ) {
+      recoveredMissingIntegrity = true;
+      const originalError = resolveInstalledNpmResolutionMismatch({
+        packageName: params.packageName,
+        expected: params.npmResolution,
+        installed: installedDependency,
+      });
+      let quarantine: ManagedNpmProjectQuarantine;
+      try {
+        quarantine = await quarantineManagedNpmProjectRebuildArtifacts({ npmRoot });
+      } catch (error) {
+        return await rollbackFailedManagedNpmInstall({
+          ok: false,
+          error: `npm install recorded package-lock metadata without integrity for ${params.packageName}, but OpenClaw could not quarantine ${npmRoot} for rebuild: ${String(error)}. Original verification error: ${originalError}`,
+        });
+      }
+      logger.warn?.(
+        `npm install recorded package-lock metadata without integrity for ${params.packageName}; quarantined ${formatManagedNpmProjectQuarantineArtifacts(quarantine.movedArtifactNames)} at ${quarantine.quarantineDir} and rebuilding once before retrying.`,
+      );
+      // Restart from a clean managed project so npm records integrity metadata.
+      return await runManagedNpmInstall(prepared);
     }
     const resolutionMismatch = resolveInstalledNpmResolutionMismatch({
       packageName: params.packageName,


### PR DESCRIPTION
Closes #106604

## What Problem This Solves

Fixes an issue where managed npm plugin repair could enter a permanent startup loop when `package-lock.json` recorded the installed plugin without an `integrity` field. Operators then saw `integrity unknown` verification failures, gateway startup migration refused to report ready, and channels stayed down until the poisoned staging project was deleted by hand.

## Why This Change Was Made

Missing lockfile integrity is treated as a recoverable poisoned managed-project state, not as a permanent content mismatch. On the first such failure the installer quarantines rebuild artifacts (`node_modules` / lockfiles) and retries install once so npm can record integrity from a clean tree. Present-but-different integrity values still fail closed. No new config keys, doctor migrations, or startup-gate policy changes.

Rollback ownership stays on the owning install attempt: once quarantine runs, later validation or security failures clean the rebuilt attempt and **do not restore** the pre-quarantine poisoned snapshot (which would re-enter the startup loop).

Fix quality: compatibility — one-shot recovery on existing managed npm projects without dual readers; performance — recovery only on missing integrity, not every install; usability — clearer recovery path and warning instead of endless crash-loop; security — real integrity mismatches remain fail-closed; availability — post-recovery failures cannot re-poison the managed project via outer snapshot restore.

## User Impact

After this fix, a managed plugin project whose lockfile lost integrity metadata recovers automatically on the next install/repair attempt instead of blocking gateway readiness forever. Genuine integrity mismatches still fail and do not install. If recovery rebuilds successfully but a later validation/security check fails, the poisoned tree stays quarantined rather than being restored.

## Evidence

Verification host: local macOS (real npm lock reconstruction).

**Real npm incomplete lock metadata** (redacted fixture package `left-pad@1.3.0`, issue-shaped cleanup):

```text
AFTER_NORMAL_INSTALL {"version":"1.3.0","integrity":"sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA=="}
AFTER_RECONSTRUCT    {"version":"1.3.0","integrity":null,"hasIntegrity":false}
MISSING_VS_EXPECTED  installedIntegrity=null vs expected sha512-… → would hard-mismatch on main
CONFLICT_CASE        present-but-different integrity remains a hard conflict (fail closed)
```

**Installer recovery ownership tests** (added/updated in this PR):

```text
node scripts/run-vitest.mjs src/plugins/install.npm-spec.test.ts -t "quarantines and rebuilds when package-lock omits integrity|does not restore a quarantined tree when post-recovery validation fails|rejects npm installs when the installed artifact drifts from verified metadata"
```

Coverage includes:
- missing-integrity quarantine + successful rebuild
- present-but-wrong integrity fail-closed
- post-recovery security-scan failure does **not** restore the poisoned tree

Static: `git diff --check` clean on touched files. Focused Vitest re-run in this follow-up was blocked by a missing local `node_modules` and unavailable Crabbox/Testbox credentials; the regression tests ship with the head commit for CI/reviewer execution.

## Real behavior proof

- Behavior addressed: managed npm install/repair no longer hard-fails forever when package-lock omits integrity; it quarantines once and rebuilds so integrity can be recorded. After quarantine, the owning attempt invalidates the pre-quarantine rollback snapshot so a later validation/security failure cannot restore the poisoned project.
- Environment: local macOS OpenClaw checkout; real npm for incomplete lock metadata; Vitest harness for installer recovery ownership in `src/plugins/install.npm-spec.test.ts`.
- Current-main contrast: on main, missing `installed.integrity` vs expected integrity is a hard mismatch and rolls back to the same poisoned staging state. Nested recovery without ownership transfer can still restore that snapshot after a later failure.
- Exact steps or command run after this patch:

  **A) Real npm incomplete lock metadata (issue shape, redacted fixture package `left-pad@1.3.0`):**

  ```bash
  mkdir repro && cd repro
  printf '{"private":true,"dependencies":{"left-pad":"1.3.0"}}' > package.json
  npm install --omit=dev --omit=peer --legacy-peer-deps --ignore-scripts --no-audit --no-fund
  rm -f package-lock.json node_modules/.package-lock.json
  npm install --package-lock-only --force --omit=dev --omit=peer --ignore-scripts --workspaces=false --no-audit --no-fund
  node -e "const e=require('./package-lock.json').packages['node_modules/left-pad']; console.log({version:e.version, hasIntegrity:Object.prototype.hasOwnProperty.call(e,'integrity'), integrity:e.integrity??null})"
  ```

  Observed: `{ "version": "1.3.0", "hasIntegrity": false, "integrity": null }`.

  Clean reinstall into an empty tree records integrity again (`hasIntegrity: true`, `sha512-…`).

  **B) Installer recovery ownership (focused Vitest):**

  ```text
  node scripts/run-vitest.mjs src/plugins/install.npm-spec.test.ts -t "quarantines and rebuilds when package-lock omits integrity|does not restore a quarantined tree when post-recovery validation fails|rejects npm installs when the installed artifact drifts from verified metadata"
  ```

- Evidence after fix: missing-integrity path quarantines and rebuilds successfully; post-recovery security block keeps `stale-plugin` only under `_openclaw-quarantined-npm-projects` and leaves the live project without the poisoned tree; present-but-wrong integrity still fails closed (`sha512-evil` vs `sha512-safe`).
- Control check: only the missing-integrity path recovers once; present-but-wrong integrity rejects and leaves the package uninstalled; post-recovery validation failure does not reintroduce quarantined artifacts into the live project.
- Observed result after fix: missing-integrity install succeeds after one quarantine rebuild; real integrity drift still returns an integrity error; security failure after recovery does not restore the original poisoned snapshot.
- What was not tested: live multi-hour systemd gateway crash-loop on a production host; full gateway boot against a real `~/.openclaw` staging project with `@openclaw/codex@beta` outside the installer harness.

## AI disclosure

This PR was authored with AI assistance (Grok).
