### PR TITLE
fix(process): apply undefined env removals

### DIFF
--- a/src/process/exec-spawn.ts
+++ b/src/process/exec-spawn.ts
@@ -12,9 +12,6 @@ function assignChildEnvValue(params: {
   platform: NodeJS.Platform;
   value: string | undefined;
 }): void {
-  if (params.value === undefined) {
-    return;
-  }
   if (params.platform === "win32") {
     const normalizedKey = params.key.toLowerCase();
     for (const existingKey of Object.keys(params.env)) {
@@ -22,6 +19,10 @@ function assignChildEnvValue(params: {
         delete params.env[existingKey];
       }
     }
+  }
+  if (params.value === undefined) {
+    delete params.env[params.key];
+    return;
   }
   params.env[params.key] = params.value;
 }

--- a/src/process/exec.ts
+++ b/src/process/exec.ts
@@ -17,42 +17,6 @@ export type { SpawnResult } from "./exec-result.js";
 export { resolveCommandEnv, shouldSpawnWithShell, spawnCommand } from "./exec-spawn.js";
 export type { SpawnCommandOptions } from "./exec-spawn.js";
 
-function assignChildEnvValue(params: {
-  env: NodeJS.ProcessEnv;
-  key: string;
-  platform: NodeJS.Platform;
-  value: string | undefined;
-}): void {
-  if (params.platform === "win32") {
-    const normalizedKey = params.key.toLowerCase();
-    for (const existingKey of Object.keys(params.env)) {
-      if (existingKey.toLowerCase() === normalizedKey && existingKey !== params.key) {
-        delete params.env[existingKey];
-      }
-    }
-  }
-  if (params.value === undefined) {
-    delete params.env[params.key];
-    return;
-  }
-  params.env[params.key] = params.value;
-}
-
-function mergeChildEnv(params: {
-  baseEnv: NodeJS.ProcessEnv;
-  env?: NodeJS.ProcessEnv;
-  platform: NodeJS.Platform;
-}): NodeJS.ProcessEnv {
-  const resolvedEnv: NodeJS.ProcessEnv = {};
-  for (const [key, value] of Object.entries(params.baseEnv)) {
-    assignChildEnvValue({ env: resolvedEnv, key, platform: params.platform, value });
-  }
-  for (const [key, value] of Object.entries(params.env ?? {})) {
-    assignChildEnvValue({ env: resolvedEnv, key, platform: params.platform, value });
-  }
-  return resolvedEnv;
-}
-
 const DEFAULT_EXEC_MAX_BUFFER_BYTES = 1024 * 1024;
 
 export type RunExecOptions = {


### PR DESCRIPTION
Related: #107248

## What Problem This Solves

Resolves a regression where explicit `undefined` child-environment overrides were ignored. That could preserve inherited variables instead of removing them, including case-insensitive Windows keys. The same regression also left duplicate unused helpers in `exec.ts`, breaking type and lint gates on `main`.

## Why This Change Was Made

Undefined-value deletion now lives in the canonical `exec-spawn.ts` environment merge path. The unused duplicate implementation is deleted from `exec.ts`.

## User Impact

Callers can reliably remove inherited child-process environment variables. Current `main` type, lint, and process test failures are repaired.

## Evidence

- Blacksmith Testbox `tbx_01kxfrgjna33j431bjzz0medm1`: 38 process exec tests passed, 1 skipped.
- `pnpm tsgo:core` passed.
- Focused oxlint passed for `src/process/exec.ts` and `src/process/exec-spawn.ts`.
- Fresh autoreview: clean, no actionable findings.

Recreates #107248 because its branch is not maintainer-writable. Preserves contributor credit via `Co-authored-by`.
