### PR TITLE
improve: chat messages, tool outputs, and composer use configured width

### DIFF
--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -615,6 +615,78 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
     }
   });
 
+  it("applies configured chat width to tool rows and composer without changing defaults", async () => {
+    const page = await openBrowserPage(1600, 900);
+    const renderFixture = async (configured: boolean) => {
+      const style = configured
+        ? 'style="--chat-thread-max-width: 82%; --chat-message-max-width: 100%"'
+        : "";
+      await page.setContent(`<!doctype html><html><head><style>${readUiCss()}</style></head><body>
+        <section class="card chat" ${style}>
+          <div class="chat-thread chat-thread--direct" role="log">
+            <div class="chat-thread-inner">
+              <div class="chat-group tool">
+                <div class="chat-avatar tool">A</div>
+                <div class="chat-group-messages" data-tool-lane>
+                  <div class="chat-bubble chat-bubble--tool-shell" data-tool-shell>
+                    <div class="chat-tool-msg-collapse">Tool output</div>
+                  </div>
+                </div>
+              </div>
+              <div class="chat-group tool chat-group--activity">
+                <div class="chat-avatar tool">A</div>
+                <div class="chat-group-messages" data-activity-lane>
+                  <div class="chat-activity-group">Activity</div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="chat-prs" data-chat-prs>Pull requests</div>
+          <div class="agent-chat__composer-shell" data-composer>
+            <div class="agent-chat__input">Composer</div>
+          </div>
+        </section>
+      </body></html>`);
+      return await page.evaluate(() => {
+        const rect = (selector: string) => {
+          const bounds = document.querySelector<HTMLElement>(selector)!.getBoundingClientRect();
+          return { center: bounds.x + bounds.width / 2, width: bounds.width };
+        };
+        return {
+          activity: rect("[data-activity-lane]"),
+          composer: rect("[data-composer]"),
+          prs: rect("[data-chat-prs]"),
+          shell: rect("[data-tool-shell]"),
+          thread: rect(".chat-thread-inner"),
+          tool: rect("[data-tool-lane]"),
+        };
+      });
+    };
+
+    try {
+      const defaults = await renderFixture(false);
+      expect(defaults.thread.width).toBeCloseTo(768, 0);
+      expect(defaults.composer.width).toBeCloseTo(defaults.thread.width, 0);
+      expect(defaults.prs.width).toBeCloseTo(defaults.thread.width, 0);
+      expect(defaults.tool.width).toBeCloseTo(defaults.thread.width, 0);
+      expect(defaults.shell.width).toBeCloseTo(760, 0);
+      expect(defaults.activity.width).toBeCloseTo(760, 0);
+
+      const configured = await renderFixture(true);
+      for (const key of ["activity", "shell", "tool"] as const) {
+        expect(configured[key].width).toBeCloseTo(configured.thread.width, 0);
+      }
+      expect(configured.composer.width).toBeCloseTo(configured.prs.width, 0);
+      for (const rect of Object.values(configured)) {
+        expect(rect.center).toBeCloseTo(configured.thread.center, 0);
+      }
+      expect(configured.thread.width).toBeGreaterThan(defaults.thread.width);
+      expect(configured.composer.width).toBeGreaterThan(defaults.composer.width);
+    } finally {
+      await closeBrowserPage(page);
+    }
+  });
+
   it(
     "reveals, pins, and dismisses message context from the timestamp",
     FULL_APP_TEST_OPTIONS,

--- a/ui/src/styles/chat/grouped.css
+++ b/ui/src/styles/chat/grouped.css
@@ -40,7 +40,7 @@
 }
 
 .chat-group.tool .chat-group-messages {
-  max-width: min(980px, calc(100% - 46px));
+  max-width: var(--chat-message-max-width, min(980px, calc(100% - 46px)));
 }
 
 .chat-group.user .chat-group-footer {
@@ -417,7 +417,8 @@ img.chat-avatar {
    width; all bubble chrome (border/background/padding) is reset. */
 .chat-bubble--tool-shell {
   align-self: stretch;
-  width: min(100%, 760px);
+  width: 100%;
+  max-width: var(--chat-message-max-width, 760px);
   padding: 0;
   border: 0;
   background: transparent;
@@ -471,7 +472,7 @@ img.chat-avatar {
 }
 
 .chat-thread--direct .chat-group.tool .chat-group-messages {
-  max-width: min(980px, 100%);
+  max-width: var(--chat-message-max-width, min(980px, 100%));
 }
 
 .chat-duplicate-count {

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -1299,7 +1299,7 @@ openclaw-chat-page {
   align-items: end;
   gap: 6px;
   width: calc(100% - 36px);
-  max-width: 48rem;
+  max-width: var(--chat-thread-max-width, 48rem);
   margin: 8px auto 14px;
 }
 
@@ -1440,7 +1440,7 @@ openclaw-chat-page {
   /* Mirror .agent-chat__composer-shell sizing: the rows belong to the input
      stack and must not read as a full-pane banner above a narrower composer. */
   width: calc(100% - 36px);
-  max-width: 48rem;
+  max-width: var(--chat-thread-max-width, 48rem);
   margin: 0 auto;
   padding: 0 0 8px;
 }

--- a/ui/src/styles/chat/tool-cards.css
+++ b/ui/src/styles/chat/tool-cards.css
@@ -976,7 +976,7 @@
 /* Keep the activity summary, call bubbles, and flat result rows on one width.
    Include the role classes so this wins over the generic tool-group rule. */
 .chat-group.tool.chat-group--activity .chat-group-messages {
-  max-width: min(760px, 100%);
+  max-width: var(--chat-message-max-width, min(760px, 100%));
 }
 
 .chat-activity-group {


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where assistant messages, tool output blocks, and activity tool groups in the WebChat UI remained visually narrow even when the chat message width setting allowed more horizontal space.

On wide screens, this left unused blank space beside assistant responses, command/tool output blocks, and activity summaries, forcing extra vertical scrolling and making longer technical answers, logs, and command output harder to read.

## Why This Change Was Made

This change makes assistant message content, tool message lanes, activity tool groups, tool output shells, and the message composer respect the configured chat width so the visible conversation layout expands consistently.

The goal is limited to improving readability in the WebChat conversation layout without changing message rendering behavior, tool execution behavior, or model context limits.

## User Impact

Users can read longer assistant responses and tool or command output with more characters per line on wide screens.

The message composer also expands with the configured chat width, giving users more room to draft longer prompts on wide screens.

This reduces unnecessary scrolling and makes code explanations, logs, terminal output, activity summaries, and technical responses easier to scan.

## Evidence

Tested locally in the OpenClaw WebChat UI with a wide browser viewport.

Before the change, the outer assistant message area widened, but tool output blocks and activity tool groups remained narrower than the available chat width.

After the change, assistant messages, tool message lanes, activity tool groups, tool output shells, and the composer expand with the configured chat width after rebuilding the UI, restarting the gateway, and hard-refreshing the browser.

### Validation

- `pnpm test:ui`
- 255 test files passed
- 3,760 tests passed
- All 61 responsive WebChat browser tests passed

### Screenshots

<img width="3806" height="1562" alt="WebChat width before fix" src="https://github.com/user-attachments/assets/bc433eb2-dac6-4a56-bc47-0a154239425f" />

<img width="3433" height="1515" alt="WebChat width after fix" src="https://github.com/user-attachments/assets/eb6a0711-620e-4f07-a0b0-f5dcb907d885" />

<img width="3403" height="1645" alt="Tool output width after fix" src="https://github.com/user-attachments/assets/ed66e4c8-7fdb-468a-91c0-06d187e04167" />

<img width="3433" height="1772" alt="Wide technical output after fix" src="https://github.com/user-attachments/assets/32363435-2827-4866-9c38-6800552f8319" />

## AI Assistance

This PR was prepared with AI assistance. I reviewed the resulting CSS changes and confirmed that I understand their behavior and scope.
