### PR TITLE
fix(memory): preserve UTF-8 when qmd output splits across pipe chunks

### DIFF
--- a/packages/memory-host-sdk/src/host/qmd-process.real.test.ts
+++ b/packages/memory-host-sdk/src/host/qmd-process.real.test.ts
@@ -76,6 +76,83 @@ function killProcessTree(parentPid: number): void {
   process.kill(-parentPid, "SIGTERM");
 }
 
+describe("runCliCommand real process UTF-8 framing", () => {
+  it("preserves a multibyte character split across real stdout pipe chunks", async () => {
+    const script = `
+      const { setTimeout } = require("node:timers/promises");
+      (async () => {
+        const cat = Buffer.from("猫");
+        process.stdout.write(Buffer.concat([Buffer.from('{"value":"'), cat.subarray(0, 1)]));
+        await setTimeout(50);
+        process.stdout.write(Buffer.concat([cat.subarray(1), Buffer.from('"}\\n')]));
+      })();
+    `;
+
+    await expect(
+      runCliCommand({
+        commandSummary: "real qmd utf8 stdout fixture",
+        spawnInvocation: { command: process.execPath, argv: ["-e", script] },
+        env: process.env,
+        cwd: process.cwd(),
+        timeoutMs: 5_000,
+        maxOutputChars: 10_000,
+      }),
+    ).resolves.toEqual({
+      stdout: '{"value":"猫"}\n',
+      stderr: "",
+    });
+  }, 10_000);
+
+  it("preserves a multibyte character split across real stderr pipe chunks", async () => {
+    const script = `
+      const { setTimeout } = require("node:timers/promises");
+      const { finished } = require("node:stream/promises");
+      (async () => {
+        const cat = Buffer.from("猫");
+        process.stderr.write(Buffer.concat([Buffer.from("path: "), cat.subarray(0, 1)]));
+        await setTimeout(50);
+        process.stderr.write(Buffer.concat([cat.subarray(1), Buffer.from(" denied\\n")]));
+        process.exitCode = 1;
+        process.stderr.end();
+        await finished(process.stderr);
+      })();
+    `;
+
+    await expect(
+      runCliCommand({
+        commandSummary: "real qmd utf8 stderr fixture",
+        spawnInvocation: { command: process.execPath, argv: ["-e", script] },
+        env: process.env,
+        cwd: process.cwd(),
+        timeoutMs: 5_000,
+        maxOutputChars: 10_000,
+      }),
+    ).rejects.toMatchObject({
+      code: 1,
+      stderr: "path: 猫 denied\n",
+    });
+  }, 10_000);
+
+  it("keeps one-chunk Unicode stdout intact as a control", async () => {
+    await expect(
+      runCliCommand({
+        commandSummary: "real qmd utf8 one-chunk fixture",
+        spawnInvocation: {
+          command: process.execPath,
+          argv: ["-e", `process.stdout.write(Buffer.from('{"value":"猫"}\\n'));`],
+        },
+        env: process.env,
+        cwd: process.cwd(),
+        timeoutMs: 5_000,
+        maxOutputChars: 10_000,
+      }),
+    ).resolves.toEqual({
+      stdout: '{"value":"猫"}\n',
+      stderr: "",
+    });
+  }, 10_000);
+});
+
 describe("runCliCommand real process lifecycle", () => {
   it("kills the command and its descendant when the caller aborts", async () => {
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-qmd-abort-"));

--- a/packages/memory-host-sdk/src/host/qmd-process.real.test.ts
+++ b/packages/memory-host-sdk/src/host/qmd-process.real.test.ts
@@ -77,50 +77,27 @@ function killProcessTree(parentPid: number): void {
 }
 
 describe("runCliCommand real process UTF-8 framing", () => {
-  it("preserves a multibyte character split across real stdout pipe chunks", async () => {
-    const script = `
-      const { setTimeout } = require("node:timers/promises");
-      (async () => {
-        const cat = Buffer.from("猫");
-        process.stdout.write(Buffer.concat([Buffer.from('{"value":"'), cat.subarray(0, 1)]));
-        await setTimeout(50);
-        process.stdout.write(Buffer.concat([cat.subarray(1), Buffer.from('"}\\n')]));
-      })();
-    `;
-
-    await expect(
-      runCliCommand({
-        commandSummary: "real qmd utf8 stdout fixture",
-        spawnInvocation: { command: process.execPath, argv: ["-e", script] },
-        env: process.env,
-        cwd: process.cwd(),
-        timeoutMs: 5_000,
-        maxOutputChars: 10_000,
-      }),
-    ).resolves.toEqual({
-      stdout: '{"value":"猫"}\n',
-      stderr: "",
-    });
-  }, 10_000);
-
-  it("preserves a multibyte character split across real stderr pipe chunks", async () => {
+  it("preserves a multibyte character split across real stdout and stderr pipes", async () => {
     const script = `
       const { setTimeout } = require("node:timers/promises");
       const { finished } = require("node:stream/promises");
       (async () => {
         const cat = Buffer.from("猫");
+        process.stdout.write(Buffer.concat([Buffer.from('{"value":"'), cat.subarray(0, 1)]));
         process.stderr.write(Buffer.concat([Buffer.from("path: "), cat.subarray(0, 1)]));
         await setTimeout(50);
+        process.stdout.write(Buffer.concat([cat.subarray(1), Buffer.from('"}\\n')]));
         process.stderr.write(Buffer.concat([cat.subarray(1), Buffer.from(" denied\\n")]));
         process.exitCode = 1;
+        process.stdout.end();
         process.stderr.end();
-        await finished(process.stderr);
+        await Promise.all([finished(process.stdout), finished(process.stderr)]);
       })();
     `;
 
     await expect(
       runCliCommand({
-        commandSummary: "real qmd utf8 stderr fixture",
+        commandSummary: "real qmd utf8 pipe fixture",
         spawnInvocation: { command: process.execPath, argv: ["-e", script] },
         env: process.env,
         cwd: process.cwd(),
@@ -129,26 +106,8 @@ describe("runCliCommand real process UTF-8 framing", () => {
       }),
     ).rejects.toMatchObject({
       code: 1,
-      stderr: "path: 猫 denied\n",
-    });
-  }, 10_000);
-
-  it("keeps one-chunk Unicode stdout intact as a control", async () => {
-    await expect(
-      runCliCommand({
-        commandSummary: "real qmd utf8 one-chunk fixture",
-        spawnInvocation: {
-          command: process.execPath,
-          argv: ["-e", `process.stdout.write(Buffer.from('{"value":"猫"}\\n'));`],
-        },
-        env: process.env,
-        cwd: process.cwd(),
-        timeoutMs: 5_000,
-        maxOutputChars: 10_000,
-      }),
-    ).resolves.toEqual({
       stdout: '{"value":"猫"}\n',
-      stderr: "",
+      stderr: "path: 猫 denied\n",
     });
   }, 10_000);
 });

--- a/packages/memory-host-sdk/src/host/qmd-process.test.ts
+++ b/packages/memory-host-sdk/src/host/qmd-process.test.ts
@@ -307,6 +307,59 @@ describe("checkQmdBinaryAvailability", () => {
 });
 
 describe("runCliCommand", () => {
+  it("preserves UTF-8 characters split across stdout and stderr chunks", async () => {
+    const child = createMockChild();
+    const cat = Buffer.from("猫", "utf8");
+    spawnMock.mockImplementationOnce(() => {
+      queueMicrotask(() => {
+        child.stdout.emit("data", Buffer.concat([Buffer.from('{"value":"'), cat.subarray(0, 1)]));
+        child.stdout.emit("data", Buffer.concat([cat.subarray(1), Buffer.from('"}\n')]));
+        child.stderr.emit("data", Buffer.concat([Buffer.from("path: "), cat.subarray(0, 2)]));
+        child.stderr.emit("data", Buffer.concat([cat.subarray(2), Buffer.from(" ok\n")]));
+        child.closeWith(0);
+      });
+      return child;
+    });
+
+    await expect(
+      runCliCommand({
+        commandSummary: "qmd query test",
+        spawnInvocation: { command: "qmd", argv: ["query", "test", "--json"] },
+        env: process.env,
+        cwd: tempDir,
+        maxOutputChars: 10_000,
+      }),
+    ).resolves.toEqual({
+      stdout: '{"value":"猫"}\n',
+      stderr: "path: 猫 ok\n",
+    });
+  });
+
+  it("flushes a trailing incomplete UTF-8 sequence on close", async () => {
+    const child = createMockChild();
+    spawnMock.mockImplementationOnce(() => {
+      queueMicrotask(() => {
+        // Incomplete lead byte held in the decoder until close flushes it.
+        child.stdout.emit("data", Buffer.from([0xe7]));
+        child.closeWith(0);
+      });
+      return child;
+    });
+
+    await expect(
+      runCliCommand({
+        commandSummary: "qmd query test",
+        spawnInvocation: { command: "qmd", argv: ["query", "test", "--json"] },
+        env: process.env,
+        cwd: tempDir,
+        maxOutputChars: 10_000,
+      }),
+    ).resolves.toEqual({
+      stdout: "\uFFFD",
+      stderr: "",
+    });
+  });
+
   it("keeps stdout and stderr on non-zero exits", async () => {
     const child = createMockChild();
     spawnMock.mockImplementationOnce(() => {

--- a/packages/memory-host-sdk/src/host/qmd-process.test.ts
+++ b/packages/memory-host-sdk/src/host/qmd-process.test.ts
@@ -39,14 +39,14 @@ import {
 function createMockChild(params: { pid?: number } = {}) {
   const child = new EventEmitter() as EventEmitter & {
     pid?: number;
-    stdout: EventEmitter;
-    stderr: EventEmitter;
+    stdout: EventEmitter & { setEncoding: ReturnType<typeof vi.fn> };
+    stderr: EventEmitter & { setEncoding: ReturnType<typeof vi.fn> };
     kill: ReturnType<typeof vi.fn>;
     closeWith: (code?: number | null, signal?: NodeJS.Signals | null) => void;
   };
   child.pid = params.pid;
-  child.stdout = new EventEmitter();
-  child.stderr = new EventEmitter();
+  child.stdout = Object.assign(new EventEmitter(), { setEncoding: vi.fn() });
+  child.stderr = Object.assign(new EventEmitter(), { setEncoding: vi.fn() });
   child.kill = vi.fn();
   child.closeWith = (code: number | null = 0, signal: NodeJS.Signals | null = null) => {
     child.emit("close", code, signal);
@@ -307,59 +307,6 @@ describe("checkQmdBinaryAvailability", () => {
 });
 
 describe("runCliCommand", () => {
-  it("preserves UTF-8 characters split across stdout and stderr chunks", async () => {
-    const child = createMockChild();
-    const cat = Buffer.from("猫", "utf8");
-    spawnMock.mockImplementationOnce(() => {
-      queueMicrotask(() => {
-        child.stdout.emit("data", Buffer.concat([Buffer.from('{"value":"'), cat.subarray(0, 1)]));
-        child.stdout.emit("data", Buffer.concat([cat.subarray(1), Buffer.from('"}\n')]));
-        child.stderr.emit("data", Buffer.concat([Buffer.from("path: "), cat.subarray(0, 2)]));
-        child.stderr.emit("data", Buffer.concat([cat.subarray(2), Buffer.from(" ok\n")]));
-        child.closeWith(0);
-      });
-      return child;
-    });
-
-    await expect(
-      runCliCommand({
-        commandSummary: "qmd query test",
-        spawnInvocation: { command: "qmd", argv: ["query", "test", "--json"] },
-        env: process.env,
-        cwd: tempDir,
-        maxOutputChars: 10_000,
-      }),
-    ).resolves.toEqual({
-      stdout: '{"value":"猫"}\n',
-      stderr: "path: 猫 ok\n",
-    });
-  });
-
-  it("flushes a trailing incomplete UTF-8 sequence on close", async () => {
-    const child = createMockChild();
-    spawnMock.mockImplementationOnce(() => {
-      queueMicrotask(() => {
-        // Incomplete lead byte held in the decoder until close flushes it.
-        child.stdout.emit("data", Buffer.from([0xe7]));
-        child.closeWith(0);
-      });
-      return child;
-    });
-
-    await expect(
-      runCliCommand({
-        commandSummary: "qmd query test",
-        spawnInvocation: { command: "qmd", argv: ["query", "test", "--json"] },
-        env: process.env,
-        cwd: tempDir,
-        maxOutputChars: 10_000,
-      }),
-    ).resolves.toEqual({
-      stdout: "\uFFFD",
-      stderr: "",
-    });
-  });
-
   it("keeps stdout and stderr on non-zero exits", async () => {
     const child = createMockChild();
     spawnMock.mockImplementationOnce(() => {
@@ -393,6 +340,8 @@ describe("runCliCommand", () => {
         stderr: "ggml-metal-device.m:612",
       });
       expect(err.message).toContain("qmd query test failed (code 134)");
+      expect(child.stdout.setEncoding).toHaveBeenCalledWith("utf8");
+      expect(child.stderr.setEncoding).toHaveBeenCalledWith("utf8");
     }
   });
 

--- a/packages/memory-host-sdk/src/host/qmd-process.ts
+++ b/packages/memory-host-sdk/src/host/qmd-process.ts
@@ -2,6 +2,7 @@
 import { spawn, spawnSync } from "node:child_process";
 import { statSync } from "node:fs";
 import path from "node:path";
+import { StringDecoder } from "node:string_decoder";
 import { resolveSafeTimeoutDelayMs } from "../../../gateway-client/src/timeouts.js";
 import { materializeWindowsSpawnProgram, resolveWindowsSpawnProgram } from "./windows-spawn.js";
 
@@ -206,6 +207,10 @@ export async function runCliCommand(params: {
     let stdoutTruncated = false;
     let stderrTruncated = false;
     let settled = false;
+    // Pipe chunks can split a UTF-8 sequence mid-code-point. Carry decoder
+    // state across chunks and flush on close so qmd JSON/paths/snippets stay intact.
+    const stdoutDecoder = new StringDecoder("utf8");
+    const stderrDecoder = new StringDecoder("utf8");
     const discardStdout = params.discardStdout === true;
     const timeoutMs =
       params.timeoutMs === undefined ? undefined : resolveSafeTimeoutDelayMs(params.timeoutMs);
@@ -232,17 +237,35 @@ export async function runCliCommand(params: {
       signal?.removeEventListener("abort", onAbort);
       run();
     }
+    function appendDecodedOutput(
+      current: string,
+      chunk: Buffer | string,
+      decoder: StringDecoder,
+    ): { text: string; truncated: boolean } {
+      const bytes = typeof chunk === "string" ? Buffer.from(chunk, "utf8") : chunk;
+      return appendOutputWithCap(current, decoder.write(bytes), params.maxOutputChars);
+    }
+    function flushDecodedOutput(
+      current: string,
+      decoder: StringDecoder,
+    ): { text: string; truncated: boolean } {
+      const pending = decoder.end();
+      if (!pending) {
+        return { text: current, truncated: false };
+      }
+      return appendOutputWithCap(current, pending, params.maxOutputChars);
+    }
     signal?.addEventListener("abort", onAbort, { once: true });
     child.stdout.on("data", (data) => {
       if (discardStdout) {
         return;
       }
-      const next = appendOutputWithCap(stdout, data.toString("utf8"), params.maxOutputChars);
+      const next = appendDecodedOutput(stdout, data, stdoutDecoder);
       stdout = next.text;
       stdoutTruncated = stdoutTruncated || next.truncated;
     });
     child.stderr.on("data", (data) => {
-      const next = appendOutputWithCap(stderr, data.toString("utf8"), params.maxOutputChars);
+      const next = appendDecodedOutput(stderr, data, stderrDecoder);
       stderr = next.text;
       stderrTruncated = stderrTruncated || next.truncated;
     });
@@ -276,6 +299,14 @@ export async function runCliCommand(params: {
       if (timer) {
         clearTimeout(timer);
       }
+      if (!discardStdout) {
+        const flushedStdout = flushDecodedOutput(stdout, stdoutDecoder);
+        stdout = flushedStdout.text;
+        stdoutTruncated = stdoutTruncated || flushedStdout.truncated;
+      }
+      const flushedStderr = flushDecodedOutput(stderr, stderrDecoder);
+      stderr = flushedStderr.text;
+      stderrTruncated = stderrTruncated || flushedStderr.truncated;
       settle(() => {
         if (!discardStdout && (stdoutTruncated || stderrTruncated)) {
           reject(

--- a/packages/memory-host-sdk/src/host/qmd-process.ts
+++ b/packages/memory-host-sdk/src/host/qmd-process.ts
@@ -2,7 +2,6 @@
 import { spawn, spawnSync } from "node:child_process";
 import { statSync } from "node:fs";
 import path from "node:path";
-import { StringDecoder } from "node:string_decoder";
 import { resolveSafeTimeoutDelayMs } from "../../../gateway-client/src/timeouts.js";
 import { materializeWindowsSpawnProgram, resolveWindowsSpawnProgram } from "./windows-spawn.js";
 
@@ -207,11 +206,13 @@ export async function runCliCommand(params: {
     let stdoutTruncated = false;
     let stderrTruncated = false;
     let settled = false;
-    // Pipe chunks can split a UTF-8 sequence mid-code-point. Carry decoder
-    // state across chunks and flush on close so qmd JSON/paths/snippets stay intact.
-    const stdoutDecoder = new StringDecoder("utf8");
-    const stderrDecoder = new StringDecoder("utf8");
     const discardStdout = params.discardStdout === true;
+    // Let the streams carry partial UTF-8 sequences across pipe chunks before
+    // qmd JSON, paths, or diagnostics reach the character-based output cap.
+    if (!discardStdout) {
+      child.stdout.setEncoding("utf8");
+    }
+    child.stderr.setEncoding("utf8");
     const timeoutMs =
       params.timeoutMs === undefined ? undefined : resolveSafeTimeoutDelayMs(params.timeoutMs);
     const timer = timeoutMs
@@ -237,35 +238,17 @@ export async function runCliCommand(params: {
       signal?.removeEventListener("abort", onAbort);
       run();
     }
-    function appendDecodedOutput(
-      current: string,
-      chunk: Buffer | string,
-      decoder: StringDecoder,
-    ): { text: string; truncated: boolean } {
-      const bytes = typeof chunk === "string" ? Buffer.from(chunk, "utf8") : chunk;
-      return appendOutputWithCap(current, decoder.write(bytes), params.maxOutputChars);
-    }
-    function flushDecodedOutput(
-      current: string,
-      decoder: StringDecoder,
-    ): { text: string; truncated: boolean } {
-      const pending = decoder.end();
-      if (!pending) {
-        return { text: current, truncated: false };
-      }
-      return appendOutputWithCap(current, pending, params.maxOutputChars);
-    }
     signal?.addEventListener("abort", onAbort, { once: true });
-    child.stdout.on("data", (data) => {
+    child.stdout.on("data", (data: string) => {
       if (discardStdout) {
         return;
       }
-      const next = appendDecodedOutput(stdout, data, stdoutDecoder);
+      const next = appendOutputWithCap(stdout, data, params.maxOutputChars);
       stdout = next.text;
       stdoutTruncated = stdoutTruncated || next.truncated;
     });
-    child.stderr.on("data", (data) => {
-      const next = appendDecodedOutput(stderr, data, stderrDecoder);
+    child.stderr.on("data", (data: string) => {
+      const next = appendOutputWithCap(stderr, data, params.maxOutputChars);
       stderr = next.text;
       stderrTruncated = stderrTruncated || next.truncated;
     });
@@ -299,14 +282,6 @@ export async function runCliCommand(params: {
       if (timer) {
         clearTimeout(timer);
       }
-      if (!discardStdout) {
-        const flushedStdout = flushDecodedOutput(stdout, stdoutDecoder);
-        stdout = flushedStdout.text;
-        stdoutTruncated = stdoutTruncated || flushedStdout.truncated;
-      }
-      const flushedStderr = flushDecodedOutput(stderr, stderrDecoder);
-      stderr = flushedStderr.text;
-      stderrTruncated = stderrTruncated || flushedStderr.truncated;
       settle(() => {
         if (!discardStdout && (stdoutTruncated || stderrTruncated)) {
           reject(


### PR DESCRIPTION
## What Problem This Solves

QMD and mcporter output was decoded independently for each pipe chunk. When the OS split a multibyte UTF-8 character across chunks, paths, snippets, JSON, and actionable stderr reached callers with replacement characters instead of the original text.

## Why This Change Was Made

The process owner now sets UTF-8 decoding directly on the child stdout and stderr streams before consuming data. Node's readable-stream decoder carries incomplete multibyte sequences across chunks and flushes them at EOF, keeping the existing character cap and process lifecycle unchanged without a second decoder state machine.

## User Impact

QMD memory search results and diagnostics preserve Unicode text even when child-process output is fragmented at a multibyte boundary.

## Evidence

- Current-main source repro: decoding the first byte and remaining bytes of `猫` independently with `Buffer.toString("utf8")` produces `���`.
- Real child-process regression: delayed stdout and stderr writes split the same UTF-8 character 1+2 bytes; both streams preserve `猫` after the fix.
- Testbox-through-Crabbox `tbx_01kxgmf4mxw9c815k44becjpst`, Actions run 29346220892: `pnpm test packages/memory-host-sdk/src/host/qmd-process.test.ts packages/memory-host-sdk/src/host/qmd-process.real.test.ts` — 25 passed.
- Same Testbox: `pnpm check:changed` — formatting, type checks, lint, and guards passed.
- Exact final patch autoreview: clean, no accepted/actionable findings; correctness 0.98.
- `git diff --check` — clean.

Contributor implementation and repro by @wahaha1223; maintainer cleanup preserved that credit.

*AI-assisted*
