### PR TITLE
refactor(acp): use SDK protocol contracts

### DIFF
--- a/src/acp/client.ts
+++ b/src/acp/client.ts
@@ -72,10 +72,6 @@ function resolveSelfEntryPath(): string | null {
 
 function printSessionUpdate(notification: SessionNotification): void {
   const update = notification.update;
-  if (!("sessionUpdate" in update)) {
-    return;
-  }
-
   switch (update.sessionUpdate) {
     case "agent_message_chunk": {
       if (update.content?.type === "text") {

--- a/src/acp/event-mapper.ts
+++ b/src/acp/event-mapper.ts
@@ -1,7 +1,6 @@
 /** Converts ACP prompt and tool-event shapes into Gateway-friendly text, files, and metadata. */
 import type {
   ContentBlock,
-  ImageContent,
   ToolCallContent,
   ToolCallLocation,
   ToolKind,
@@ -254,11 +253,8 @@ export function extractTextFromPrompt(prompt: ContentBlock[], maxBytes?: number)
     let blockText: string | undefined;
     if (block.type === "text") {
       blockText = block.text;
-    } else if (block.type === "resource") {
-      const resource = block.resource as { text?: string } | undefined;
-      if (resource?.text) {
-        blockText = resource.text;
-      }
+    } else if (block.type === "resource" && "text" in block.resource && block.resource.text) {
+      blockText = block.resource.text;
     } else if (block.type === "resource_link") {
       const title = block.title ? ` (${escapeResourceTitle(block.title)})` : "";
       const uri = block.uri ? escapeInlineControlChars(block.uri) : "";
@@ -286,14 +282,13 @@ export function extractAttachmentsFromPrompt(prompt: ContentBlock[]): GatewayAtt
     if (block.type !== "image") {
       continue;
     }
-    const image = block as ImageContent;
-    if (!image.data || !image.mimeType) {
+    if (!block.data || !block.mimeType) {
       continue;
     }
     attachments.push({
       type: "image",
-      mimeType: image.mimeType,
-      content: image.data,
+      mimeType: block.mimeType,
+      content: block.data,
     });
   }
   return attachments;

--- a/src/acp/protocol-schema.test.ts
+++ b/src/acp/protocol-schema.test.ts
@@ -4,17 +4,7 @@ import acpProtocolSchema from "@agentclientprotocol/sdk/schema/schema.json" with
 import { describe, expect, it } from "vitest";
 import { type JsonSchemaValue, validateJsonSchemaValue } from "../plugins/schema-validator.js";
 
-type AcpSchemaName =
-  | "CloseSessionRequest"
-  | "InitializeRequest"
-  | "ListSessionsRequest"
-  | "LoadSessionRequest"
-  | "NewSessionRequest"
-  | "PromptRequest"
-  | "ResumeSessionRequest"
-  | "SessionNotification";
-
-function acpSchema(name: AcpSchemaName): JsonSchemaValue {
+function acpSchema(name: keyof typeof acpProtocolSchema.$defs): JsonSchemaValue {
   return {
     ...acpProtocolSchema.$defs[name],
     $defs: acpProtocolSchema.$defs,

--- a/src/acp/server.ts
+++ b/src/acp/server.ts
@@ -7,6 +7,7 @@ import {
   AgentSideConnection,
   PROTOCOL_VERSION,
   ndJsonStream,
+  type AnyMessage,
 } from "@agentclientprotocol/sdk";
 import type { AcpServerOptions } from "@openclaw/acp-core/types";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
@@ -31,12 +32,6 @@ import { readSecretFromFile } from "./secret-file.js";
 import { AcpGatewayAgent } from "./translator.js";
 import { normalizeAcpProvenanceMode } from "./types.js";
 
-type AcpStreamMessage =
-  ReturnType<typeof ndJsonStream> extends {
-    readable: ReadableStream<infer Message>;
-  }
-    ? Message
-    : never;
 type JsonObject = Record<string, unknown>;
 
 /** Starts the ACP Gateway bridge and serves AgentSideConnection over stdio. */
@@ -176,7 +171,7 @@ export async function serveAcpGateway(opts: AcpServerOptions = {}): Promise<void
   const output = Readable.toWeb(process.stdin) as unknown as ReadableStream<Uint8Array>;
   const stream = ndJsonStream(input, output);
   const readable = stream.readable.pipeThrough(
-    new TransformStream<AcpStreamMessage, AcpStreamMessage>({
+    new TransformStream<AnyMessage, AnyMessage>({
       transform(message, controller) {
         controller.enqueue(normalizeAcpInitializeProtocolVersion(message));
       },
@@ -214,7 +209,7 @@ export async function serveAcpGateway(opts: AcpServerOptions = {}): Promise<void
   return closed;
 }
 
-function normalizeAcpInitializeProtocolVersion(message: AcpStreamMessage): AcpStreamMessage {
+function normalizeAcpInitializeProtocolVersion(message: AnyMessage): AnyMessage {
   if (!isJsonObject(message)) {
     return message;
   }
@@ -235,7 +230,7 @@ function normalizeAcpInitializeProtocolVersion(message: AcpStreamMessage): AcpSt
       ...params,
       protocolVersion: PROTOCOL_VERSION,
     },
-  } as AcpStreamMessage;
+  } as AnyMessage;
 }
 
 function isJsonObject(value: unknown): value is JsonObject {

--- a/src/acp/translator.lifecycle.test.ts
+++ b/src/acp/translator.lifecycle.test.ts
@@ -164,28 +164,6 @@ describe("acp translator stable lifecycle handlers", () => {
     sessionStore.clearAllSessionsForTest();
   });
 
-  it("captures ACP client capabilities during initialize", async () => {
-    const agent = new AcpGatewayAgent(createAcpConnection(), createAcpGateway());
-
-    expect(agent.supportsClientReadTextFile()).toBe(false);
-    expect(agent.supportsClientWriteTextFile()).toBe(false);
-    expect(agent.supportsClientTerminal()).toBe(false);
-
-    await agent.initialize({
-      ...createInitializeRequest(),
-      clientCapabilities: {
-        fs: { readTextFile: true, writeTextFile: false },
-        terminal: true,
-      },
-      clientInfo: { name: "test-client", version: "1.2.3" },
-    } as InitializeRequest);
-
-    expect(agent.supportsClientReadTextFile()).toBe(true);
-    expect(agent.supportsClientWriteTextFile()).toBe(false);
-    expect(agent.supportsClientTerminal()).toBe(true);
-    expect(agent.getClientInfo()).toEqual({ name: "test-client", version: "1.2.3" });
-  });
-
   it("lists Gateway sessions through the stable handler with opaque cursors and cwd filtering", async () => {
     const allRows = [
       createSessionRow({ key: "agent:main:a1", cwd: "/work/a", title: "A1" }),

--- a/src/acp/translator.presentation.ts
+++ b/src/acp/translator.presentation.ts
@@ -1,9 +1,5 @@
 /** Builds ACP session presentation, metadata, usage, and config-option snapshots. */
-import type {
-  InitializeRequest,
-  SessionConfigOption,
-  SessionModeState,
-} from "@agentclientprotocol/sdk";
+import type { SessionConfigOption, SessionModeState } from "@agentclientprotocol/sdk";
 import {
   toAcpSessionLineageMeta,
   type AcpSessionLineageMeta,
@@ -26,13 +22,6 @@ export const ACP_RESPONSE_USAGE_CONFIG_ID = "response_usage";
 export const ACP_ELEVATED_LEVEL_CONFIG_ID = "elevated_level";
 export const ACP_TIMEOUT_CONFIG_ID = "timeout";
 export const ACP_TIMEOUT_SECONDS_CONFIG_ID = "timeout_seconds";
-
-/** Normalized ACP client capability flags used to choose session controls. */
-export type ClientCapabilityState = {
-  readTextFile: boolean;
-  writeTextFile: boolean;
-  terminal: boolean;
-};
 
 /** Gateway session fields needed to build ACP session presentation state. */
 export type GatewaySessionPresentationRow = Pick<
@@ -91,17 +80,6 @@ export type SessionSnapshot = SessionPresentation & {
   metadata?: SessionMetadata;
   usage?: SessionUsageSnapshot;
 };
-
-/** Normalizes optional ACP initialize capabilities into stable booleans. */
-export function normalizeClientCapabilities(
-  capabilities: InitializeRequest["clientCapabilities"] | undefined,
-): ClientCapabilityState {
-  return {
-    readTextFile: capabilities?.fs?.readTextFile === true,
-    writeTextFile: capabilities?.fs?.writeTextFile === true,
-    terminal: capabilities?.terminal === true,
-  };
-}
 
 function formatThinkingLevelName(level: string): string {
   switch (level) {

--- a/src/acp/translator.ts
+++ b/src/acp/translator.ts
@@ -85,8 +85,6 @@ import {
   buildSessionMetadata,
   buildSessionPresentation,
   buildSessionUsageSnapshot,
-  normalizeClientCapabilities,
-  type ClientCapabilityState,
   type GatewaySessionPresentationRow,
   type SessionSnapshot,
 } from "./translator.presentation.js";
@@ -134,11 +132,6 @@ const loadAcpSdkModule = createLazyRuntimeModule(() => import("@agentclientproto
 async function getAvailableCommandsForAcp() {
   const { getAvailableCommands } = await loadAcpCommandsModule();
   return getAvailableCommands();
-}
-
-async function getAcpProtocolVersion() {
-  const { PROTOCOL_VERSION } = await loadAcpSdkModule();
-  return PROTOCOL_VERSION;
 }
 
 type DisconnectContext = {
@@ -257,8 +250,6 @@ export class AcpGatewayAgent implements Agent {
   private pendingPrompts = new Map<string, PendingPrompt>();
   private settlingPromptKeys = new Set<string>();
   private approvalRelays = new Map<string, PendingApprovalRelay>();
-  private clientCapabilities: ClientCapabilityState = normalizeClientCapabilities(undefined);
-  private clientInfo: InitializeRequest["clientInfo"] = null;
   private disconnectTimer: NodeJS.Timeout | null = null;
   private activeDisconnectContext: DisconnectContext | null = null;
   private disconnectGeneration = 0;
@@ -315,22 +306,6 @@ export class AcpGatewayAgent implements Agent {
     this.clearDisconnectTimer();
   }
 
-  supportsClientReadTextFile(): boolean {
-    return this.clientCapabilities.readTextFile;
-  }
-
-  supportsClientWriteTextFile(): boolean {
-    return this.clientCapabilities.writeTextFile;
-  }
-
-  supportsClientTerminal(): boolean {
-    return this.clientCapabilities.terminal;
-  }
-
-  getClientInfo(): InitializeRequest["clientInfo"] {
-    return this.clientInfo;
-  }
-
   handleGatewayReconnect(): void {
     this.log("gateway reconnected");
     const disconnectContext = this.activeDisconnectContext;
@@ -372,11 +347,9 @@ export class AcpGatewayAgent implements Agent {
     }
   }
 
-  async initialize(params: InitializeRequest): Promise<InitializeResponse> {
-    this.clientCapabilities = normalizeClientCapabilities(params.clientCapabilities);
-    this.clientInfo = params.clientInfo ?? null;
+  async initialize(_params: InitializeRequest): Promise<InitializeResponse> {
     return {
-      protocolVersion: await getAcpProtocolVersion(),
+      protocolVersion: (await loadAcpSdkModule()).PROTOCOL_VERSION,
       agentCapabilities: {
         loadSession: true,
         promptCapabilities: {


### PR DESCRIPTION
## What Problem This Solves

The ACP bridge duplicated contracts already guaranteed by `@agentclientprotocol/sdk@1.1.0`: it inferred the SDK stream message type, rechecked discriminated protocol unions, cast discriminated content blocks, manually listed schema keys, and retained client capability/info state with no production reader.

## Why This Change Was Made

Use the SDK's public `AnyMessage`, `SessionUpdate`, `ContentBlock`, and schema definitions directly. Delete dead client metadata state, getters, normalization, and their test. Keep the runtime JSON-object guard because `ndJsonStream` parses but does not validate arbitrary JSON before this compatibility transform.

## User Impact

No behavior change. ACP initialization, protocol-version normalization, session updates, prompt text/images, and schema validation retain their existing behavior. The implementation shrinks by 95 lines.

## Evidence

- Five focused ACP suites: 99 tests passed locally on the final rebased head
- `git diff --check origin/main...HEAD`
- Fresh exact-commit autoreview: clean, no accepted/actionable findings
- Supplemental full changed gate for the same patch before the final unrelated main rebase: https://github.com/openclaw/openclaw/actions/runs/29315688883
