### PR TITLE
refactor(infra): remove dead resolveDedupeNonNegativeInteger re-export

### DIFF
--- a/src/infra/dedupe.ts
+++ b/src/infra/dedupe.ts
@@ -20,9 +20,6 @@ export type DedupeCacheOptions = {
   maxSize: number;
 };
 
-/** @deprecated Use resolveNonNegativeIntegerOption for new internal numeric option normalization. */
-export { resolveNonNegativeIntegerOption as resolveDedupeNonNegativeInteger };
-
 /** Creates a bounded in-memory dedupe cache with optional TTL expiry. */
 export function createDedupeCache(options: DedupeCacheOptions): DedupeCache {
   const ttlMs = resolveNonNegativeIntegerOption(options.ttlMs, 0);


### PR DESCRIPTION
## What Problem This Solves

Removes a dead `@deprecated` re-export alias `resolveDedupeNonNegativeInteger` from `src/infra/dedupe.ts`. This alias has zero callers anywhere in the codebase — the underlying `resolveNonNegativeIntegerOption` is imported directly from `@openclaw/normalization-core` by all consumers.

## Evidence

```
$ grep -rn "resolveDedupeNonNegativeInteger" src/
src/infra/dedupe.ts:24:export { resolveNonNegativeIntegerOption as resolveDedupeNonNegativeInteger };
```

Only the export definition itself. No imports, no re-exports, no test references.

```bash
$ npx vitest run src/infra/dedupe.test.ts --no-coverage
Test Files  1 passed (1)
     Tests  5 passed (5)
```

## Why This Change Was Made

The `@deprecated` comment on line 23 already instructs callers to use `resolveNonNegativeIntegerOption` directly. There are no remaining consumers that need the migration path — this is pure dead code.

## Merge Risk

Zero risk. This is a removal of an unused re-export with no external callers, no re-exports through plugin-sdk, and no test coverage that references it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)