### PR TITLE
fix: synchronous sessions_send self-targets time out

### DIFF
--- a/src/agents/tool-description-presets.ts
+++ b/src/agents/tool-description-presets.ts
@@ -43,6 +43,7 @@ export function describeSessionsSendTool(): string {
   return [
     "Message visible session by sessionKey/label, or configured agent by agentId; sessionKey wins redundant label.",
     "Thread chats rejected: target parent channel. Missing configured-agent main created. Waits for reply when available.",
+    "Do not synchronously target current session; return the reply directly. timeoutSeconds=0 allows fire-and-forget self-delivery.",
     "watch:true: notice arrives when others later change target session.",
   ].join(" ");
 }

--- a/src/agents/tools/sessions-send-helpers.test.ts
+++ b/src/agents/tools/sessions-send-helpers.test.ts
@@ -8,7 +8,65 @@ import {
   buildAgentToAgentReplyContext,
   resolveAnnounceTargetFromKey,
   resolvePingPongTurns,
+  resolveSessionsSendTargetContext,
+  resolveSessionsSendTimeouts,
 } from "./sessions-send-helpers.js";
+
+describe("sessions_send target context", () => {
+  const base = {
+    requesterSessionKey: "agent:main:main",
+    resolvedKey: "main",
+    displayKey: "agent:main:main",
+    unresolvedDisplayKey: "main",
+    mainKey: "main",
+  };
+
+  it("rejects a synchronous alias resolving to the requester session", () => {
+    const result = resolveSessionsSendTargetContext({ ...base, timeoutSeconds: 30 });
+
+    expect(result.requesterSessionKey).toBe("agent:main:main");
+    expect(result.sameSessionA2A).toBe(true);
+    expect(result.errorResult).toMatchObject({
+      status: "error",
+      sessionKey: "agent:main:main",
+      error: expect.stringContaining("cannot synchronously target the current session"),
+    });
+  });
+
+  it("preserves fire-and-forget delivery to the requester session", () => {
+    expect(resolveSessionsSendTargetContext({ ...base, timeoutSeconds: 0 })).toEqual({
+      requesterSessionKey: "agent:main:main",
+      sameSessionA2A: true,
+    });
+  });
+
+  it("rejects thread targets before dispatch", () => {
+    const result = resolveSessionsSendTargetContext({
+      ...base,
+      resolvedKey: "agent:main:slack:channel:C123:thread:1710000000.000100",
+      displayKey: "agent:main:slack:channel:C123:thread:1710000000.000100",
+      unresolvedDisplayKey: "topic-session",
+      timeoutSeconds: 0,
+    });
+
+    expect(result.errorResult).toMatchObject({
+      status: "error",
+      sessionKey: "topic-session",
+      error: expect.stringContaining("cannot target a thread session"),
+    });
+  });
+
+  it("resolves run and announcement timeout budgets", () => {
+    expect(resolveSessionsSendTimeouts(5)).toEqual({
+      timeoutMs: 5_000,
+      announceTimeoutMs: 5_000,
+    });
+    expect(resolveSessionsSendTimeouts(0)).toEqual({
+      timeoutMs: 0,
+      announceTimeoutMs: 30_000,
+    });
+  });
+});
 
 describe("resolveAnnounceTargetFromKey", () => {
   beforeEach(() => {

--- a/src/agents/tools/sessions-send-helpers.ts
+++ b/src/agents/tools/sessions-send-helpers.ts
@@ -3,13 +3,17 @@
  *
  * Resolves announcement targets, channel/session routing metadata, and ping-pong guard prompt text.
  */
+import { randomUUID } from "node:crypto";
+import { finiteSecondsToTimerSafeMilliseconds } from "@openclaw/normalization-core/number-coercion";
 import {
   getChannelPlugin,
   normalizeChannelId as normalizeAnyChannelId,
 } from "../../channels/plugins/index.js";
 import { resolveSessionConversationRef } from "../../channels/plugins/session-conversation.js";
 import { normalizeChannelId as normalizeChatChannelId } from "../../channels/registry.js";
+import { parseSessionThreadInfo } from "../../config/sessions/thread-info.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { resolveAgentIdFromSessionKey, toAgentStoreSessionKey } from "../../routing/session-key.js";
 import { ANNOUNCE_SKIP_TOKEN, REPLY_SKIP_TOKEN } from "./sessions-send-tokens.js";
 export {
   isAnnounceSkip,
@@ -26,6 +30,74 @@ export type AnnounceTarget = {
   accountId?: string;
   threadId?: string; // Forum topic/thread ID
 };
+
+type SessionsSendTargetError = {
+  runId: string;
+  status: "error";
+  error: string;
+  sessionKey: string;
+};
+
+/** Converts the public timeout into bounded run and announcement budgets. */
+export function resolveSessionsSendTimeouts(timeoutSeconds: number): {
+  timeoutMs: number;
+  announceTimeoutMs: number;
+} {
+  const timeoutMs =
+    finiteSecondsToTimerSafeMilliseconds(timeoutSeconds, { floorSeconds: true }) ?? 0;
+  return { timeoutMs, announceTimeoutMs: timeoutSeconds === 0 ? 30_000 : timeoutMs };
+}
+
+/** Resolves canonical self-target state and target errors shared by send orchestration. */
+export function resolveSessionsSendTargetContext(params: {
+  requesterSessionKey?: string;
+  resolvedKey: string;
+  displayKey: string;
+  unresolvedDisplayKey: string;
+  mainKey: string;
+  timeoutSeconds: number;
+}): {
+  requesterSessionKey?: string;
+  sameSessionA2A: boolean;
+  errorResult?: SessionsSendTargetError;
+} {
+  const canonicalTargetKey = params.requesterSessionKey
+    ? toAgentStoreSessionKey({
+        agentId: resolveAgentIdFromSessionKey(params.requesterSessionKey),
+        requestKey: params.resolvedKey,
+        mainKey: params.mainKey,
+      })
+    : params.resolvedKey;
+  const base = {
+    ...(params.requesterSessionKey ? { requesterSessionKey: params.requesterSessionKey } : {}),
+    sameSessionA2A: params.requesterSessionKey === canonicalTargetKey,
+  };
+  if (parseSessionThreadInfo(params.resolvedKey).threadId) {
+    return {
+      ...base,
+      errorResult: {
+        runId: randomUUID(),
+        status: "error",
+        error:
+          "sessions_send cannot target a thread session for inter-agent coordination. Use the parent channel session key instead.",
+        sessionKey: params.unresolvedDisplayKey,
+      },
+    };
+  }
+  if (params.timeoutSeconds > 0 && base.sameSessionA2A) {
+    return {
+      ...base,
+      errorResult: {
+        runId: randomUUID(),
+        status: "error",
+        error:
+          "sessions_send cannot synchronously target the current session. Return the reply directly, or use timeoutSeconds=0 for fire-and-forget delivery.",
+        sessionKey: params.displayKey,
+      },
+    };
+  }
+  return base;
+}
 
 /** Resolves a session key into the channel target used for source-reply announcements. */
 export function resolveAnnounceTargetFromKey(sessionKey: string): AnnounceTarget | null {

--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -5,11 +5,9 @@
  */
 import crypto from "node:crypto";
 import { isRequesterParentOfBackgroundAcpSession } from "@openclaw/acp-core/session-interaction-mode";
-import { finiteSecondsToTimerSafeMilliseconds } from "@openclaw/normalization-core/number-coercion";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { Type } from "typebox";
 import { readAcpSessionMeta } from "../../acp/runtime/session-meta.js";
-import { parseSessionThreadInfo } from "../../config/sessions/thread-info.js";
 import type { SessionEntry } from "../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { callGateway } from "../../gateway/call.js";
@@ -58,7 +56,12 @@ import {
   resolveSessionToolContext,
   resolveVisibleSessionReference,
 } from "./sessions-helpers.js";
-import { buildAgentToAgentMessageContext, resolvePingPongTurns } from "./sessions-send-helpers.js";
+import {
+  buildAgentToAgentMessageContext,
+  resolvePingPongTurns,
+  resolveSessionsSendTargetContext,
+  resolveSessionsSendTimeouts,
+} from "./sessions-send-helpers.js";
 import { runSessionsSendA2AFlow } from "./sessions-send-tool.a2a.js";
 
 const SessionsSendToolSchema = Type.Object({
@@ -510,38 +513,19 @@ export function createSessionsSendTool(opts?: {
       // Normalize sessionKey/sessionId input into a canonical session key.
       const resolvedKey = visibleSession.key;
       const displayKey = visibleSession.displayKey;
-      const timeoutMs =
-        finiteSecondsToTimerSafeMilliseconds(timeoutSeconds, {
-          floorSeconds: true,
-        }) ?? 0;
-      const announceTimeoutMs = timeoutSeconds === 0 ? 30_000 : timeoutMs;
+      const { timeoutMs, announceTimeoutMs } = resolveSessionsSendTimeouts(timeoutSeconds);
       const idempotencyKey = crypto.randomUUID();
       let runId: string = idempotencyKey;
-      const requesterSessionKey = opts?.agentSessionKey ? effectiveRequesterKey : undefined;
-      const requesterCanonicalTargetKey = requesterSessionKey
-        ? toAgentStoreSessionKey({
-            agentId: resolveAgentIdFromSessionKey(requesterSessionKey),
-            requestKey: resolvedKey,
-            mainKey,
-          })
-        : resolvedKey;
-      if (parseSessionThreadInfo(resolvedKey).threadId) {
-        return jsonResult({
-          runId: crypto.randomUUID(),
-          status: "error",
-          error:
-            "sessions_send cannot target a thread session for inter-agent coordination. Use the parent channel session key instead.",
-          sessionKey: unresolvedDisplayKey,
-        });
-      }
-      if (timeoutSeconds > 0 && requesterSessionKey === requesterCanonicalTargetKey) {
-        return jsonResult({
-          runId: crypto.randomUUID(),
-          status: "error",
-          error:
-            "sessions_send cannot synchronously target the current session. Return the reply directly, or use timeoutSeconds=0 for fire-and-forget delivery.",
-          sessionKey: displayKey,
-        });
+      const targetContext = resolveSessionsSendTargetContext({
+        requesterSessionKey: opts?.agentSessionKey ? effectiveRequesterKey : undefined,
+        resolvedKey,
+        displayKey,
+        unresolvedDisplayKey,
+        mainKey,
+        timeoutSeconds,
+      });
+      if (targetContext.errorResult) {
+        return jsonResult(targetContext.errorResult);
       }
       const visibilityGuard = await createSessionVisibilityGuard({
         action: "send",
@@ -575,7 +559,7 @@ export function createSessionsSendTool(opts?: {
       }
 
       const requesterChannel = opts?.agentChannel;
-      const sameSessionA2A = requesterSessionKey === requesterCanonicalTargetKey;
+      const { requesterSessionKey, sameSessionA2A } = targetContext;
       const isIsolatedCronRequester = isCronRunSessionKey(requesterSessionKey);
       // Watch registration follows successful dispatch: a failed send must not leave
       // a hidden watch, and cron run-scoped sends can fall back to the durable parent

--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -517,6 +517,14 @@ export function createSessionsSendTool(opts?: {
       const announceTimeoutMs = timeoutSeconds === 0 ? 30_000 : timeoutMs;
       const idempotencyKey = crypto.randomUUID();
       let runId: string = idempotencyKey;
+      const requesterSessionKey = opts?.agentSessionKey ? effectiveRequesterKey : undefined;
+      const requesterCanonicalTargetKey = requesterSessionKey
+        ? toAgentStoreSessionKey({
+            agentId: resolveAgentIdFromSessionKey(requesterSessionKey),
+            requestKey: resolvedKey,
+            mainKey,
+          })
+        : resolvedKey;
       if (parseSessionThreadInfo(resolvedKey).threadId) {
         return jsonResult({
           runId: crypto.randomUUID(),
@@ -524,6 +532,15 @@ export function createSessionsSendTool(opts?: {
           error:
             "sessions_send cannot target a thread session for inter-agent coordination. Use the parent channel session key instead.",
           sessionKey: unresolvedDisplayKey,
+        });
+      }
+      if (timeoutSeconds > 0 && requesterSessionKey === requesterCanonicalTargetKey) {
+        return jsonResult({
+          runId: crypto.randomUUID(),
+          status: "error",
+          error:
+            "sessions_send cannot synchronously target the current session. Return the reply directly, or use timeoutSeconds=0 for fire-and-forget delivery.",
+          sessionKey: displayKey,
         });
       }
       const visibilityGuard = await createSessionVisibilityGuard({
@@ -557,7 +574,6 @@ export function createSessionsSendTool(opts?: {
         });
       }
 
-      const requesterSessionKey = opts?.agentSessionKey ? effectiveRequesterKey : undefined;
       const requesterChannel = opts?.agentChannel;
       const sameSessionA2A = requesterSessionKey === resolvedKey;
       const isIsolatedCronRequester = isCronRunSessionKey(requesterSessionKey);

--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -575,7 +575,7 @@ export function createSessionsSendTool(opts?: {
       }
 
       const requesterChannel = opts?.agentChannel;
-      const sameSessionA2A = requesterSessionKey === resolvedKey;
+      const sameSessionA2A = requesterSessionKey === requesterCanonicalTargetKey;
       const isIsolatedCronRequester = isCronRunSessionKey(requesterSessionKey);
       // Watch registration follows successful dispatch: a failed send must not leave
       // a hidden watch, and cron run-scoped sends can fall back to the durable parent

--- a/src/agents/tools/sessions.test.ts
+++ b/src/agents/tools/sessions.test.ts
@@ -1116,7 +1116,76 @@ describe("sessions_send gating", () => {
     expect(requireGatewayRequest().method).toBe("sessions.resolve");
   });
 
+  it("rejects a synchronous send to the current session before dispatching an agent run", async () => {
+    const tool = createMainSessionsSendTool();
+
+    const result = await tool.execute("call-synchronous-self-send", {
+      sessionKey: MAIN_AGENT_SESSION_KEY,
+      message: "ping",
+      timeoutSeconds: 5,
+    });
+
+    const details = requireDetails(result);
+    expect(details).toMatchObject({
+      status: "error",
+      sessionKey: MAIN_AGENT_SESSION_KEY,
+    });
+    expect(details.error).toContain("cannot synchronously target the current session");
+    expect(callGatewayMock.mock.calls).not.toContainEqual([
+      expect.objectContaining({ method: "agent" }),
+    ]);
+    expect(callGatewayMock.mock.calls).not.toContainEqual([
+      expect.objectContaining({ method: "agent.wait" }),
+    ]);
+  });
+
+  it("rejects a synchronous main alias that resolves to the current session", async () => {
+    const tool = createMainSessionsSendTool();
+
+    const result = await tool.execute("call-synchronous-self-main-alias", {
+      sessionKey: "main",
+      message: "ping",
+      timeoutSeconds: 5,
+    });
+
+    const details = requireDetails(result);
+    expect(details).toMatchObject({
+      status: "error",
+      sessionKey: "main",
+    });
+    expect(details.error).toContain("cannot synchronously target the current session");
+    expect(callGatewayMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects a synchronous label target that resolves to the current session", async () => {
+    callGatewayMock.mockResolvedValueOnce({ key: MAIN_AGENT_SESSION_KEY });
+    const tool = createMainSessionsSendTool();
+
+    const result = await tool.execute("call-synchronous-self-label", {
+      label: "current conversation",
+      message: "ping",
+      timeoutSeconds: 5,
+    });
+
+    const details = requireDetails(result);
+    expect(details).toMatchObject({
+      status: "error",
+      sessionKey: MAIN_AGENT_SESSION_KEY,
+    });
+    expect(details.error).toContain("cannot synchronously target the current session");
+    expect(callGatewayMock).toHaveBeenCalledTimes(1);
+    expect(requireGatewayRequest().method).toBe("sessions.resolve");
+  });
+
   it("does not reuse a stale assistant reply when no new reply appears", async () => {
+    const targetSessionKey = "agent:main:discord:group:ops";
+    loadConfigMock.mockReturnValue({
+      session: { scope: "per-sender", mainKey: "main" },
+      tools: {
+        agentToAgent: { enabled: false },
+        sessions: { visibility: "all" },
+      },
+    });
     const tool = createMainSessionsSendTool();
     let historyCalls = 0;
     const staleAssistantMessage = {
@@ -1130,7 +1199,7 @@ describe("sessions_send gating", () => {
       if (request.method === "sessions.list") {
         return {
           path: "/tmp/sessions.json",
-          sessions: [{ key: MAIN_AGENT_SESSION_KEY, kind: "direct" }],
+          sessions: [{ key: targetSessionKey, kind: "group" }],
         };
       }
       if (request.method === "agent") {
@@ -1147,7 +1216,7 @@ describe("sessions_send gating", () => {
     });
 
     const result = await tool.execute("call-stale-send", {
-      sessionKey: MAIN_AGENT_SESSION_KEY,
+      sessionKey: targetSessionKey,
       message: "ping",
       timeoutSeconds: 1,
     });
@@ -1156,7 +1225,7 @@ describe("sessions_send gating", () => {
     const details = requireDetails(result);
     expect(details.status).toBe("ok");
     expect(details.reply).toBeUndefined();
-    expect(details.sessionKey).toBe(MAIN_AGENT_SESSION_KEY);
+    expect(details.sessionKey).toBe(targetSessionKey);
   });
 
   it("passes a baseline into fire-and-forget same-session A2A delivery", async () => {
@@ -1312,6 +1381,14 @@ describe("sessions_send gating", () => {
   );
 
   it("caps oversized timeoutSeconds before waiting for the target run", async () => {
+    const targetSessionKey = "agent:main:discord:group:ops";
+    loadConfigMock.mockReturnValue({
+      session: { scope: "per-sender", mainKey: "main" },
+      tools: {
+        agentToAgent: { enabled: false },
+        sessions: { visibility: "all" },
+      },
+    });
     const tool = createMainSessionsSendTool();
     const waitTimeouts: unknown[] = [];
 
@@ -1320,7 +1397,7 @@ describe("sessions_send gating", () => {
       if (request.method === "sessions.list") {
         return {
           path: "/tmp/sessions.json",
-          sessions: [{ key: MAIN_AGENT_SESSION_KEY, kind: "direct" }],
+          sessions: [{ key: targetSessionKey, kind: "group" }],
         };
       }
       if (request.method === "agent") {
@@ -1337,7 +1414,7 @@ describe("sessions_send gating", () => {
     });
 
     const result = await tool.execute("call-huge-timeout", {
-      sessionKey: MAIN_AGENT_SESSION_KEY,
+      sessionKey: targetSessionKey,
       message: "ping",
       timeoutSeconds: Number.MAX_SAFE_INTEGER,
     });

--- a/src/agents/tools/sessions.test.ts
+++ b/src/agents/tools/sessions.test.ts
@@ -1269,6 +1269,46 @@ describe("sessions_send gating", () => {
     expect(flowParams?.baseline?.text).toBe("older reply from a previous run");
   });
 
+  it("canonicalizes a main alias target for fire-and-forget same-session delivery", async () => {
+    const { runSessionsSendA2AFlow } = await import("./sessions-send-tool.a2a.js");
+    vi.mocked(runSessionsSendA2AFlow).mockClear();
+    const tool = createMainSessionsSendTool();
+    const staleAssistantMessage = {
+      role: "assistant",
+      content: [{ type: "text", text: "older reply from a previous run" }],
+      timestamp: 20,
+    };
+
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string };
+      if (request.method === "sessions.list") {
+        return {
+          path: "/tmp/sessions.json",
+          sessions: [{ key: "main", kind: "direct" }],
+        };
+      }
+      if (request.method === "chat.history") {
+        return { messages: [staleAssistantMessage] };
+      }
+      if (request.method === "agent") {
+        return { runId: "run-main-alias-fire-and-forget", acceptedAt: 123 };
+      }
+      return {};
+    });
+
+    const result = await tool.execute("call-main-alias-fire-and-forget", {
+      sessionKey: "main",
+      message: "ping",
+      timeoutSeconds: 0,
+    });
+
+    const details = requireDetails(result);
+    expect(details.status).toBe("accepted");
+    expect(details.sessionKey).toBe("main");
+    const flowParams = vi.mocked(runSessionsSendA2AFlow).mock.calls[0]?.[0];
+    expect(flowParams?.baseline?.text).toBe("older reply from a previous run");
+  });
+
   it("canonicalizes aliased requester keys for same-session A2A delivery", async () => {
     const { runSessionsSendA2AFlow } = await import("./sessions-send-tool.a2a.js");
     vi.mocked(runSessionsSendA2AFlow).mockClear();

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.discord-group.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.discord-group.json
@@ -1286,7 +1286,7 @@
       },
       {
         "deferLoading": true,
-        "description": "Message visible session by sessionKey/label, or configured agent by agentId; sessionKey wins redundant label. Thread chats rejected: target parent channel. Missing configured-agent main created. Waits for reply when available. watch:true: notice arrives when others later change target session.",
+        "description": "Message visible session by sessionKey/label, or configured agent by agentId; sessionKey wins redundant label. Thread chats rejected: target parent channel. Missing configured-agent main created. Waits for reply when available. Do not synchronously target current session; return the reply directly. timeoutSeconds=0 allows fire-and-forget self-delivery. watch:true: notice arrives when others later change target session.",
         "inputSchema": {
           "properties": {
             "agentId": {

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.heartbeat-turn.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.heartbeat-turn.json
@@ -1318,7 +1318,7 @@
       },
       {
         "deferLoading": true,
-        "description": "Message visible session by sessionKey/label, or configured agent by agentId; sessionKey wins redundant label. Thread chats rejected: target parent channel. Missing configured-agent main created. Waits for reply when available. watch:true: notice arrives when others later change target session.",
+        "description": "Message visible session by sessionKey/label, or configured agent by agentId; sessionKey wins redundant label. Thread chats rejected: target parent channel. Missing configured-agent main created. Waits for reply when available. Do not synchronously target current session; return the reply directly. timeoutSeconds=0 allows fire-and-forget self-delivery. watch:true: notice arrives when others later change target session.",
         "inputSchema": {
           "properties": {
             "agentId": {

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
@@ -1282,7 +1282,7 @@
       },
       {
         "deferLoading": true,
-        "description": "Message visible session by sessionKey/label, or configured agent by agentId; sessionKey wins redundant label. Thread chats rejected: target parent channel. Missing configured-agent main created. Waits for reply when available. watch:true: notice arrives when others later change target session.",
+        "description": "Message visible session by sessionKey/label, or configured agent by agentId; sessionKey wins redundant label. Thread chats rejected: target parent channel. Missing configured-agent main created. Waits for reply when available. Do not synchronously target current session; return the reply directly. timeoutSeconds=0 allows fire-and-forget self-delivery. watch:true: notice arrives when others later change target session.",
         "inputSchema": {
           "properties": {
             "agentId": {


### PR DESCRIPTION
Related: #107172

## What Problem This Solves

Fixes an issue where an agent synchronously sending a message to its own originating session with `sessions_send` could wait behind the turn that initiated it and eventually time out.

## Why This Change Was Made

Reject synchronous self-target sends after session resolution, including direct keys and aliases or labels that resolve to the originating session. Fire-and-forget self-target sends with `timeoutSeconds: 0` remain supported.

## Scope

This is a focused safeguard for one failure mode reported in #107172: a synchronous `sessions_send` resolving back to the currently active originating session. It prevents the self-wait/session-lane dependency, but it does not change the separate Codex terminal message delivery path or fully resolve the Feishu finalization and native-hook lifecycle symptoms from that issue.

For that reason, this PR intentionally uses `Related: #107172` rather than `Closes #107172`.

The broader integration work should follow in a separate TDD change covering:

- terminal message delivery from Codex through parent reply accounting;
- Feishu finalization without an additional `Done.` fallback after a visible tool-delivered reply;
- native-hook relay grace after terminal dynamic-tool turn release; and
- a regression test proving a late turn-related hook is handled without `native hook relay not found`.

Keeping that work separate avoids coupling the core session-send guard to Codex harness and Feishu channel lifecycle changes, and keeps this PR small and reviewable.

## User Impact

Agents now receive an immediate actionable error instead of entering a predictable synchronous wait when `sessions_send` resolves back to the current session. Existing asynchronous self-send workflows continue to work.

## Evidence

### TDD proof

- Initial red: the new synchronous self-target cases failed before the guard was implemented.
- Green: direct keys, aliases, and labels resolving to the originating session are rejected for synchronous sends.
- Compatibility proof: fire-and-forget self-target sends with `timeoutSeconds: 0` remain supported.
- Existing thread-target rejection and timeout conversion behavior remain covered.

### Current-head local validation

- 39/39 helper and A2A tests passed.
- 3/3 focused synchronous self-target regressions passed (46 unrelated cases skipped by the test filter).
- 10/10 unit-fast inventory tests passed after integrating current `main`.
- TypeScript LOC ratchet passed for all 3 changed production files.
- Prompt snapshot generation check passed against the current merged tree; no fixture drift remained.
- Oxfmt passed for every PR-owned TypeScript source and test file.
- `git diff --check` passed.
- The bundled Codex `$autoreview` completed cleanly on the final branch diff with no accepted/actionable findings (overall confidence 0.96).

### Prior broader regression proof

- 49/49 focused sessions cases passed.
- 138/138 unique adjacent tests passed across sessions, sessions tool, A2A, resolution, and send-helper suites (276 configured Vitest project executions).
- Those broader focused tests ran in a disposable Docker Node 24.16 environment with test-time networking disabled.

### CI remediation

- The LOC failure was fixed by extracting target-context and timeout resolution into the existing sessions-send helper boundary, restoring `sessions-send-tool.ts` to its ratcheted line budget.
- The branch was merged with current upstream `main`; the prompt snapshot checker now reports no drift.
- The stale unit-fast inventory failure was upstream state and passes after the current-main integration.
- A fresh full secretless fork CI matrix is running on head `1712bed35e1`.

AI-assisted: yes. Codex was used for issue investigation, test-first implementation, focused validation, structured autoreview, CI triage, and PR preparation. The change and evidence were reviewed before submission.
