### PR TITLE
fix(discord): keep voice participant labels UTF-16 safe [AI-assisted]

### DIFF
--- a/extensions/discord/src/voice/participant-context.test.ts
+++ b/extensions/discord/src/voice/participant-context.test.ts
@@ -1,0 +1,42 @@
+// Discord voice participant context tests cover label normalization safety.
+import { describe, expect, it } from "vitest";
+import { formatDiscordVoiceParticipantStateLine } from "./participant-context.js";
+
+function participantWithNick(nick: string): { userId: string; state: unknown } {
+  return {
+    userId: "u1",
+    state: { member: { nick } } as unknown,
+  };
+}
+
+describe("formatDiscordVoiceParticipantStateLine", () => {
+  it("keeps participant labels UTF-16 safe when an emoji lands on the truncate boundary", () => {
+    // "m" * 99 + "😀" is 101 UTF-16 code units. A naive slice(0, 100) splits the
+    // "😀" surrogate pair, leaving a dangling high surrogate that corrupts the
+    // rendered label and downstream JSON/logs. The truncated label must stay
+    // within 100 code units AND carry no dangling surrogate.
+    const nick = "m".repeat(99) + "😀";
+    const line = formatDiscordVoiceParticipantStateLine(participantWithNick(nick) as never);
+
+    expect(line).toContain("display_name=");
+    // Confirm the nick was actually used (not fallback userId "u1").
+    expect(line).toContain("mm");
+    // No dangling surrogate halves in the truncated label (check the parsed
+    // label, not the JSON-escaped line).
+    const match = line.match(/display_name=(".*")$/);
+    expect(match).toBeDefined();
+    const label = JSON.parse(match![1] as string) as string;
+    expect(label).not.toMatch(/[\uD800-\uDFFF]/u);
+    expect(label.length).toBeLessThanOrEqual(100);
+  });
+
+  it("preserves an exact-boundary label with no emoji intact", () => {
+    const nick = "m".repeat(100);
+    const line = formatDiscordVoiceParticipantStateLine(participantWithNick(nick) as never);
+    const match = line.match(/display_name=(".*")$/);
+    expect(match).toBeDefined();
+    const label = JSON.parse(match![1] as string) as string;
+    expect(label).toBe("m".repeat(100));
+    expect(label).toHaveLength(100);
+  });
+});

--- a/extensions/discord/src/voice/participant-context.ts
+++ b/extensions/discord/src/voice/participant-context.ts
@@ -1,4 +1,5 @@
 import type { DiscordAccountConfig, OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import type { APIVoiceState, Client } from "../internal/discord.js";
 import type { GatewayPlugin } from "../internal/gateway.js";
 import { type DiscordVoiceIngressContext, resolveDiscordVoiceIngressContext } from "./ingress.js";
@@ -23,7 +24,7 @@ function normalizeLabel(value: unknown): string | undefined {
     return undefined;
   }
   const normalized = value.replace(/\s+/g, " ").trim();
-  return normalized ? normalized.slice(0, 100) : undefined;
+  return normalized ? truncateUtf16Safe(normalized, 100) : undefined;
 }
 
 function memberLabel(state: APIVoiceState): string | undefined {


### PR DESCRIPTION
> [AI-assisted] This PR was generated using Claude Code.

## What Problem This Solves

Fixes an issue where Discord voice participant labels (nick / global name / username) could end up with a dangling UTF-16 surrogate half when the label is longer than 100 code units and an emoji lands on the truncation boundary.

`normalizeLabel` in `extensions/discord/src/voice/participant-context.ts` (introduced in #107004) truncated with a plain `normalized.slice(0, 100)`. Discord nicks and global names regularly contain emoji. When an emoji's surrogate pair straddles the 100-code-unit boundary, `slice(0, 100)` keeps the high surrogate and drops the low one, leaving a dangling `\uD83D`-style half that renders as `�` and can corrupt downstream JSON serialization / logs that consume the formatted participant line.

## Why This Change Was Made

The fix swaps the bare `slice(0, 100)` for the shared `truncateUtf16Safe` helper (from `@openclaw/plugin-sdk/text-utility-runtime`), which is already used across the Discord extension (`error-body.ts`, `monitor/gateway-plugin.ts`, `monitor/message-handler.context.ts`, etc.) and across ~300 call sites repo-wide for exactly this class of truncation. Same pattern as #102246 (mushuiyu886, merged) and dozens of zhangguiping-xydt / mushuiyu886 UTF-16 safe truncation PRs.

The change is one import + one call-site replacement in `participant-context.ts`; no behavior change for labels that fit or that don't land an emoji on the boundary.

## User Impact

Voice participant lines (`- user_id=... display_name=...`) rendered to the agent / logs no longer carry a `�` or a dangling surrogate when a long Discord nick/global name is truncated mid-emoji. Labels <= 100 code units are unchanged.

## Evidence

Real behavior captured by driving the real exported `formatDiscordVoiceParticipantStateLine` with a participant whose nick is `"m".repeat(99) + "😀"` (101 UTF-16 code units - the emoji's surrogate pair straddles the 100 boundary).

**Before fix (current `main`)** - `slice(0, 100)` splits the `😀` surrogate pair, leaving a dangling high surrogate:

```
nick_length: 101
label_length: 100
has_dangling_surrogate: true
label_preview: "mmmm\ud83d"
```

**After fix** - `truncateUtf16Safe` backs the boundary off the surrogate pair:

```
nick_length: 101
label_length: 99
has_dangling_surrogate: false
label_preview: "mmmmm"
```

Regression test in `extensions/discord/src/voice/participant-context.test.ts` (`keeps participant labels UTF-16 safe when an emoji lands on the truncate boundary`): failing-first, asserts the parsed `display_name` label has no dangling surrogate and stays within 100 code units.

Local verification:

- `node scripts/run-vitest.mjs extensions/discord/src/voice/participant-context.test.ts` - 2/2 pass (failing-first on `main`).
- `oxlint` + `oxfmt --check` on changed files - pass.

Not tested: live Discord voice state events (the proof drives the real `formatDiscordVoiceParticipantStateLine` formatter directly with a participant state shaped like a real `APIVoiceState.member.nick`).
