### PR TITLE
fix(onepassword): key pending authorizations by tool call id only

### DIFF
--- a/extensions/onepassword/src/broker.test.ts
+++ b/extensions/onepassword/src/broker.test.ts
@@ -232,37 +232,36 @@ describe("OnePasswordBroker validation and policy", () => {
     ]);
   });
 
-  it("isolates identical tool call ids across sessions", async () => {
+  it("authorizes when hook and execute contexts disagree on session fields", async () => {
+    // Production regression: the hook's PluginHookToolContext and the tool
+    // execute invocation context are sourced independently by core and can
+    // carry different session fields for the same call. Only toolCallId is
+    // guaranteed to match; a tuple key over session fields caused live
+    // POLICY_NOT_EVALUATED failures.
     const { broker, audit } = setup();
-    const sessionA = { agentId: "agent-a", sessionKey: "session-a", sessionId: "conversation-a" };
-    const sessionB = { agentId: "agent-b", sessionKey: "session-b", sessionId: "conversation-b" };
-    for (const [scope, reason] of [
-      [sessionA, "first session"],
-      [sessionB, "second session"],
-    ] as const) {
-      await broker.beforeToolCall(
-        {
-          toolName: "onepassword",
-          params: { action: "get", slug: "automatic", reason },
-          toolCallId: "call-1",
-        },
-        { toolName: "onepassword", toolCallId: "call-1", ...scope },
-      );
-    }
-    await expect(
-      broker.get("call-1", { action: "get", slug: "automatic", reason: "first session" }, sessionA),
-    ).resolves.toMatchObject({ slug: "automatic" });
+    await broker.beforeToolCall(
+      {
+        toolName: "onepassword",
+        params: { action: "get", slug: "automatic", reason: "asymmetric contexts" },
+        toolCallId: "call_x|fc_y",
+      },
+      {
+        toolName: "onepassword",
+        toolCallId: "call_x|fc_y",
+        agentId: "main",
+        sessionKey: "agent:main:main",
+        sessionId: "hook-run-uuid",
+      },
+    );
     await expect(
       broker.get(
-        "call-1",
-        { action: "get", slug: "automatic", reason: "second session" },
-        sessionB,
+        "call_x|fc_y",
+        { action: "get", slug: "automatic", reason: "asymmetric contexts" },
+        { agentId: "main", sessionKey: "agent:main:main" },
       ),
     ).resolves.toMatchObject({ slug: "automatic" });
-    expect((await audit.entries()).map((entry) => entry.value.sessionKey)).toEqual([
-      "session-a",
-      "session-b",
-    ]);
+    const rows = await audit.entries();
+    expect(rows.map((entry) => entry.value.outcome)).toEqual(["auto"]);
   });
 
   it("authorizes when hook and execute contexts disagree on session fields", async () => {

--- a/extensions/onepassword/src/broker.test.ts
+++ b/extensions/onepassword/src/broker.test.ts
@@ -1,13 +1,14 @@
 import type { PluginHookBeforeToolCallResult } from "openclaw/plugin-sdk/types";
 import { describe, expect, it, vi } from "vitest";
 import {
-  AUTHORIZATION_NONCE_PARAM,
   OnePasswordBroker,
   type AuditRow,
+  type PendingAuthorization,
   type StandingGrant,
 } from "./broker.js";
 import type { OnePasswordConfig, OnePasswordItemConfig } from "./config.js";
-import { MemoryKeyedStore } from "./memory-store.test-support.js";
+import { MemoryKeyedStore, MemorySyncKeyedStore } from "./memory-store.test-support.js";
+import { AUTHORIZATION_NONCE_PARAM } from "./pending-authorization.js";
 
 const invocation = {
   agentId: "agent-a",
@@ -59,21 +60,27 @@ function setup(nowValue = 1_000, configured = config()) {
   let currentConfig: OnePasswordConfig | undefined = configured;
   const audit = new MemoryKeyedStore<AuditRow>(() => now);
   const grants = new MemoryKeyedStore<StandingGrant>(() => now);
+  const pending = new MemorySyncKeyedStore<PendingAuthorization>(() => now);
+  const stores = { audit, grants, pending };
   const getItem = vi.fn(async () => ({
     value: ["fixture", "value"].join("-"),
     itemTitle: "Item title",
     fieldLabel: "credential",
   }));
-  const broker = new OnePasswordBroker({
-    resolveConfig: () => currentConfig,
-    opClient: { getItem },
-    stores: { audit, grants },
-    now: () => now,
-  });
+  const createBroker = () =>
+    new OnePasswordBroker({
+      resolveConfig: () => currentConfig,
+      opClient: { getItem },
+      stores,
+      now: () => now,
+    });
+  const broker = createBroker();
   return {
     broker,
+    createBroker,
     audit,
     grants,
+    pending,
     getItem,
     setConfig: (next: OnePasswordConfig | undefined) => {
       currentConfig = next;
@@ -284,6 +291,25 @@ describe("OnePasswordBroker validation and policy", () => {
     expect(rows.map((entry) => entry.value.outcome)).toEqual(["auto"]);
   });
 
+  it("shares pending authorizations across broker instances", async () => {
+    const { broker: hookBroker, createBroker } = setup();
+    const executeBroker = createBroker();
+    const issued = await before(hookBroker, "duplicate-instance-1", {
+      action: "get",
+      slug: "automatic",
+      reason: "cross-instance authorization",
+    });
+
+    await expect(
+      executeBroker.get(
+        "duplicate-instance-1",
+        { action: "get", slug: "automatic", reason: "cross-instance authorization" },
+        invocation,
+        nonceOf(issued),
+      ),
+    ).resolves.toMatchObject({ slug: "automatic" });
+  });
+
   it("isolates concurrent sessions that reuse a provider tool call id", async () => {
     const { broker, audit } = setup();
     const firstInvocation = {
@@ -342,8 +368,20 @@ describe("OnePasswordBroker validation and policy", () => {
     ]);
   });
 
-  it("never honors a model-supplied authorization nonce", async () => {
+  it("never grants access from a forged nonce without hook authorization", async () => {
     const { broker } = setup();
+    // No before_tool_call ran for this call: a fabricated nonce finds nothing
+    // and the identity fallback has no pending entry to match.
+    await expect(
+      broker.get(
+        "call-forged",
+        { action: "get", slug: "automatic", reason: "reject forged correlation" },
+        invocation,
+        "attacker-nonce",
+      ),
+    ).rejects.toMatchObject({ code: "POLICY_NOT_EVALUATED" });
+
+    // The hook always overwrites a model-supplied nonce with its own.
     const result = await before(broker, "call-1", {
       action: "get",
       slug: "automatic",
@@ -353,15 +391,6 @@ describe("OnePasswordBroker validation and policy", () => {
     const issuedNonce = nonceOf(result);
     expect(issuedNonce).toBeDefined();
     expect(issuedNonce).not.toBe("attacker-nonce");
-
-    await expect(
-      broker.get(
-        "call-1",
-        { action: "get", slug: "automatic", reason: "reject forged correlation" },
-        invocation,
-        "attacker-nonce",
-      ),
-    ).rejects.toMatchObject({ code: "POLICY_NOT_EVALUATED" });
     await expect(
       broker.get(
         "call-1",
@@ -370,6 +399,44 @@ describe("OnePasswordBroker validation and policy", () => {
         issuedNonce,
       ),
     ).resolves.toMatchObject({ slug: "automatic" });
+  });
+
+  it("authorizes via unique pending match when another hook drops the nonce param", async () => {
+    // before_tool_call results merge last-writer-wins across plugins, so a
+    // later params-returning hook can strip the nonce from the executed params.
+    const { broker } = setup();
+    await before(broker, "dropped-1", {
+      action: "get",
+      slug: "automatic",
+      reason: "nonce dropped by another hook",
+    });
+    await expect(
+      broker.get(
+        "dropped-1",
+        { action: "get", slug: "automatic", reason: "nonce dropped by another hook" },
+        invocation,
+        undefined,
+      ),
+    ).resolves.toMatchObject({ slug: "automatic" });
+  });
+
+  it("fails closed when a dropped nonce is ambiguous across pending entries", async () => {
+    const { broker } = setup();
+    for (let round = 0; round < 2; round += 1) {
+      await before(broker, "ambiguous-1", {
+        action: "get",
+        slug: "automatic",
+        reason: "same identity twice",
+      });
+    }
+    await expect(
+      broker.get(
+        "ambiguous-1",
+        { action: "get", slug: "automatic", reason: "same identity twice" },
+        invocation,
+        undefined,
+      ),
+    ).rejects.toMatchObject({ code: "POLICY_NOT_EVALUATED" });
   });
 
   it("persists allow-always grants and expires them", async () => {
@@ -701,6 +768,7 @@ describe("OnePasswordBroker cache and audit", () => {
     const cfg = config();
     const audit = new MemoryKeyedStore<AuditRow>();
     const grants = new MemoryKeyedStore<StandingGrant>();
+    const pending = new MemorySyncKeyedStore<PendingAuthorization>();
     const getItem = vi.fn(async () => ({
       value: ["fixture", "value"].join("-"),
       itemTitle: "Item",
@@ -709,7 +777,7 @@ describe("OnePasswordBroker cache and audit", () => {
     const broker = new OnePasswordBroker({
       resolveConfig: () => cfg,
       opClient: { getItem },
-      stores: { audit, grants },
+      stores: { audit, grants, pending },
     });
     const primed = await before(broker, "deny-cache-1", {
       action: "get",

--- a/extensions/onepassword/src/broker.test.ts
+++ b/extensions/onepassword/src/broker.test.ts
@@ -1,6 +1,11 @@
 import type { PluginHookBeforeToolCallResult } from "openclaw/plugin-sdk/types";
 import { describe, expect, it, vi } from "vitest";
-import { OnePasswordBroker, type AuditRow, type StandingGrant } from "./broker.js";
+import {
+  AUTHORIZATION_NONCE_PARAM,
+  OnePasswordBroker,
+  type AuditRow,
+  type StandingGrant,
+} from "./broker.js";
 import type { OnePasswordConfig, OnePasswordItemConfig } from "./config.js";
 import { MemoryKeyedStore } from "./memory-store.test-support.js";
 
@@ -90,6 +95,11 @@ async function before(
   );
 }
 
+function nonceOf(result: PluginHookBeforeToolCallResult | void): string | undefined {
+  const nonce = result?.params?.[AUTHORIZATION_NONCE_PARAM];
+  return typeof nonce === "string" ? nonce : undefined;
+}
+
 describe("OnePasswordBroker validation and policy", () => {
   it("lists only registry metadata and active grant state", async () => {
     const { broker, getItem } = setup();
@@ -103,6 +113,7 @@ describe("OnePasswordBroker validation and policy", () => {
       "list-grant",
       { action: "get", slug: "approval", reason: "create listing fixture" },
       invocation,
+      nonceOf(approval),
     );
     getItem.mockClear();
 
@@ -174,11 +185,19 @@ describe("OnePasswordBroker validation and policy", () => {
 
   it("allows auto, blocks deny, and audits one row per attempt", async () => {
     const { broker, audit, getItem } = setup();
-    expect(
-      await before(broker, "auto-1", { action: "get", slug: "automatic", reason: "test" }),
-    ).toBeUndefined();
+    const automatic = await before(broker, "auto-1", {
+      action: "get",
+      slug: "automatic",
+      reason: "test",
+    });
+    expect(automatic?.requireApproval).toBeUndefined();
     await expect(
-      broker.get("auto-1", { action: "get", slug: "automatic", reason: "test" }, invocation),
+      broker.get(
+        "auto-1",
+        { action: "get", slug: "automatic", reason: "test" },
+        invocation,
+        nonceOf(automatic),
+      ),
     ).resolves.toMatchObject({ value: ["fixture", "value"].join("-") });
     expect(
       await before(broker, "deny-1", { action: "get", slug: "blocked", reason: "test" }),
@@ -209,6 +228,7 @@ describe("OnePasswordBroker validation and policy", () => {
       "approve-1",
       { action: "get", slug: "approval", reason: "one use" },
       invocation,
+      nonceOf(approved),
     );
 
     const denied = await before(broker, "approve-2", {
@@ -235,11 +255,10 @@ describe("OnePasswordBroker validation and policy", () => {
   it("authorizes when hook and execute contexts disagree on session fields", async () => {
     // Production regression: the hook's PluginHookToolContext and the tool
     // execute invocation context are sourced independently by core and can
-    // carry different session fields for the same call. Only toolCallId is
-    // guaranteed to match; a tuple key over session fields caused live
-    // POLICY_NOT_EVALUATED failures.
+    // carry different session fields for the same call. Correlation is
+    // nonce-based so those differences cannot cause POLICY_NOT_EVALUATED.
     const { broker, audit } = setup();
-    await broker.beforeToolCall(
+    const result = await broker.beforeToolCall(
       {
         toolName: "onepassword",
         params: { action: "get", slug: "automatic", reason: "asymmetric contexts" },
@@ -258,84 +277,99 @@ describe("OnePasswordBroker validation and policy", () => {
         "call_x|fc_y",
         { action: "get", slug: "automatic", reason: "asymmetric contexts" },
         { agentId: "main", sessionKey: "agent:main:main" },
+        nonceOf(result),
       ),
     ).resolves.toMatchObject({ slug: "automatic" });
     const rows = await audit.entries();
     expect(rows.map((entry) => entry.value.outcome)).toEqual(["auto"]);
   });
 
-  it("authorizes when hook and execute contexts disagree on session fields", async () => {
+  it("isolates concurrent sessions that reuse a provider tool call id", async () => {
     const { broker, audit } = setup();
-    await broker.beforeToolCall(
+    const firstInvocation = {
+      agentId: "agent-a",
+      sessionKey: "session-a",
+      sessionId: "conversation-a",
+    };
+    const secondInvocation = {
+      agentId: "agent-b",
+      sessionKey: "session-b",
+      sessionId: "conversation-b",
+    };
+    const first = await broker.beforeToolCall(
       {
         toolName: "onepassword",
-        params: { action: "get", slug: "automatic", reason: "asymmetric contexts" },
-        toolCallId: "call_x|fc_y",
+        toolCallId: "call-1",
+        params: { action: "get", slug: "automatic", reason: "first session" },
       },
+      { toolName: "onepassword", toolCallId: "call-1", ...firstInvocation },
+    );
+    const second = await broker.beforeToolCall(
       {
         toolName: "onepassword",
-        toolCallId: "call_x|fc_y",
-        agentId: "main",
-        sessionKey: "agent:main:main",
-        sessionId: "hook-run-uuid",
+        toolCallId: "call-1",
+        params: { action: "get", slug: "automatic", reason: "second session" },
       },
+      { toolName: "onepassword", toolCallId: "call-1", ...secondInvocation },
     );
 
     await expect(
       broker.get(
-        "call_x|fc_y",
-        { action: "get", slug: "automatic", reason: "asymmetric contexts" },
-        { agentId: "main", sessionKey: "agent:main:main" },
+        "call-1",
+        { action: "get", slug: "automatic", reason: "first session" },
+        firstInvocation,
+        nonceOf(first),
       ),
     ).resolves.toMatchObject({ slug: "automatic" });
-    expect((await audit.entries()).map((entry) => entry.value.outcome)).toEqual(["auto"]);
+    await expect(
+      broker.get(
+        "call-1",
+        { action: "get", slug: "automatic", reason: "second session" },
+        secondInvocation,
+        nonceOf(second),
+      ),
+    ).resolves.toMatchObject({ slug: "automatic" });
+    expect(
+      (await audit.entries())
+        .map((entry) => ({
+          reason: entry.value.reason,
+          sessionKey: entry.value.sessionKey,
+        }))
+        .toSorted((left, right) => left.sessionKey.localeCompare(right.sessionKey)),
+    ).toEqual([
+      { reason: "first session", sessionKey: "session-a" },
+      { reason: "second session", sessionKey: "session-b" },
+    ]);
   });
 
-  it("rejects an ambiguous fallback across sessions", async () => {
+  it("never honors a model-supplied authorization nonce", async () => {
     const { broker } = setup();
-    for (const sessionKey of ["session-a", "session-b"]) {
-      await broker.beforeToolCall(
-        {
-          toolName: "onepassword",
-          params: { action: "get", slug: "automatic", reason: "same request" },
-          toolCallId: "call-1",
-        },
-        { toolName: "onepassword", toolCallId: "call-1", agentId: "agent-a", sessionKey },
-      );
-    }
+    const result = await before(broker, "call-1", {
+      action: "get",
+      slug: "automatic",
+      reason: "reject forged correlation",
+      [AUTHORIZATION_NONCE_PARAM]: "attacker-nonce",
+    });
+    const issuedNonce = nonceOf(result);
+    expect(issuedNonce).toBeDefined();
+    expect(issuedNonce).not.toBe("attacker-nonce");
 
     await expect(
       broker.get(
         "call-1",
-        { action: "get", slug: "automatic", reason: "same request" },
-        { agentId: "agent-a", sessionKey: "session-c" },
+        { action: "get", slug: "automatic", reason: "reject forged correlation" },
+        invocation,
+        "attacker-nonce",
       ),
     ).rejects.toMatchObject({ code: "POLICY_NOT_EVALUATED" });
-  });
-
-  it("rejects a unique fallback from another agent", async () => {
-    const { broker } = setup();
-    await broker.beforeToolCall(
-      {
-        toolName: "onepassword",
-        params: { action: "get", slug: "automatic", reason: "same request" },
-        toolCallId: "call-1",
-      },
-      {
-        toolName: "onepassword",
-        toolCallId: "call-1",
-        agentId: "agent-a",
-        sessionKey: "session-a",
-      },
-    );
-
     await expect(
       broker.get(
         "call-1",
-        { action: "get", slug: "automatic", reason: "same request" },
-        { agentId: "agent-b", sessionKey: "session-b" },
+        { action: "get", slug: "automatic", reason: "reject forged correlation" },
+        invocation,
+        issuedNonce,
       ),
-    ).rejects.toMatchObject({ code: "POLICY_NOT_EVALUATED" });
+    ).resolves.toMatchObject({ slug: "automatic" });
   });
 
   it("persists allow-always grants and expires them", async () => {
@@ -354,6 +388,7 @@ describe("OnePasswordBroker validation and policy", () => {
         reason: "standing access",
       },
       invocation,
+      nonceOf(first),
     );
     expect((await grants.entries()).map((entry) => entry.value.agentId)).toEqual(["agent-a"]);
 
@@ -363,11 +398,12 @@ describe("OnePasswordBroker validation and policy", () => {
       slug: "approval",
       reason: "second access",
     });
-    expect(second).toBeUndefined();
+    expect(second?.requireApproval).toBeUndefined();
     await broker.get(
       "grant-2",
       { action: "get", slug: "approval", reason: "second access" },
       invocation,
+      nonceOf(second),
     );
     expect(getItem).toHaveBeenCalledTimes(2);
 
@@ -396,6 +432,7 @@ describe("OnePasswordBroker validation and policy", () => {
       "agent-grant-1",
       { action: "get", slug: "approval", reason: "agent a access" },
       invocation,
+      nonceOf(approved),
     );
 
     const otherAgent = {
@@ -446,6 +483,7 @@ describe("OnePasswordBroker validation and policy", () => {
       "grant-remap-1",
       { action: "get", slug: "approval", reason: "approve original target" },
       invocation,
+      nonceOf(first),
     );
 
     configuredItem(configured, "approval").item = "Replacement target";
@@ -460,7 +498,7 @@ describe("OnePasswordBroker validation and policy", () => {
   it("fails closed when live policy changes after authorization", async () => {
     const configured = config();
     const { broker, audit, getItem, setConfig } = setup(1_000, configured);
-    await before(broker, "live-deny-1", {
+    const authorized = await before(broker, "live-deny-1", {
       action: "get",
       slug: "automatic",
       reason: "authorized before reload",
@@ -474,6 +512,7 @@ describe("OnePasswordBroker validation and policy", () => {
         "live-deny-1",
         { action: "get", slug: "automatic", reason: "authorized before reload" },
         invocation,
+        nonceOf(authorized),
       ),
     ).rejects.toMatchObject({ code: "POLICY_CHANGED" });
     expect(getItem).not.toHaveBeenCalled();
@@ -485,7 +524,7 @@ describe("OnePasswordBroker validation and policy", () => {
   it("rejects a retargeted authorization and never reuses its cached value", async () => {
     const configured = config();
     const { broker, getItem, setConfig } = setup(1_000, configured);
-    await before(broker, "live-target-1", {
+    const primed = await before(broker, "live-target-1", {
       action: "get",
       slug: "automatic",
       reason: "prime original target",
@@ -494,9 +533,10 @@ describe("OnePasswordBroker validation and policy", () => {
       "live-target-1",
       { action: "get", slug: "automatic", reason: "prime original target" },
       invocation,
+      nonceOf(primed),
     );
 
-    await before(broker, "live-target-2", {
+    const authorized = await before(broker, "live-target-2", {
       action: "get",
       slug: "automatic",
       reason: "authorized before retarget",
@@ -509,10 +549,11 @@ describe("OnePasswordBroker validation and policy", () => {
         "live-target-2",
         { action: "get", slug: "automatic", reason: "authorized before retarget" },
         invocation,
+        nonceOf(authorized),
       ),
     ).rejects.toMatchObject({ code: "POLICY_CHANGED" });
 
-    await before(broker, "live-target-3", {
+    const replacement = await before(broker, "live-target-3", {
       action: "get",
       slug: "automatic",
       reason: "authorize replacement target",
@@ -521,6 +562,7 @@ describe("OnePasswordBroker validation and policy", () => {
       "live-target-3",
       { action: "get", slug: "automatic", reason: "authorize replacement target" },
       invocation,
+      nonceOf(replacement),
     );
     expect(getItem).toHaveBeenCalledTimes(2);
     expect(getItem).toHaveBeenLastCalledWith(
@@ -566,6 +608,7 @@ describe("OnePasswordBroker validation and policy", () => {
       "grant-prune-1",
       { action: "get", slug: "approval", reason: "replace removed grants" },
       invocation,
+      nonceOf(approval),
     );
     expect((await grants.entries()).map((entry) => entry.value.slug)).toEqual(["approval"]);
   });
@@ -588,6 +631,7 @@ describe("OnePasswordBroker validation and policy", () => {
         reason: "create grant",
       },
       invocation,
+      nonceOf(first),
     );
 
     const second = await before(broker, "grant-cache-2", {
@@ -595,7 +639,7 @@ describe("OnePasswordBroker validation and policy", () => {
       slug: "approval",
       reason: "use grant",
     });
-    expect(second).toBeUndefined();
+    expect(second?.requireApproval).toBeUndefined();
     advance(3_601);
     await expect(
       broker.get(
@@ -606,6 +650,7 @@ describe("OnePasswordBroker validation and policy", () => {
           reason: "use grant",
         },
         invocation,
+        nonceOf(second),
       ),
     ).rejects.toMatchObject({ code: "GRANT_EXPIRED" });
     expect(getItem).toHaveBeenCalledTimes(1);
@@ -623,13 +668,27 @@ describe("OnePasswordBroker cache and audit", () => {
       ["cache-1", "first"],
       ["cache-2", "second"],
     ] as const) {
-      await before(broker, id, { action: "get", slug: "automatic", reason });
-      await broker.get(id, { action: "get", slug: "automatic", reason }, invocation);
+      const result = await before(broker, id, { action: "get", slug: "automatic", reason });
+      await broker.get(
+        id,
+        { action: "get", slug: "automatic", reason },
+        invocation,
+        nonceOf(result),
+      );
     }
     expect(getItem).toHaveBeenCalledTimes(1);
     advance(300_001);
-    await before(broker, "cache-3", { action: "get", slug: "automatic", reason: "third" });
-    await broker.get("cache-3", { action: "get", slug: "automatic", reason: "third" }, invocation);
+    const third = await before(broker, "cache-3", {
+      action: "get",
+      slug: "automatic",
+      reason: "third",
+    });
+    await broker.get(
+      "cache-3",
+      { action: "get", slug: "automatic", reason: "third" },
+      invocation,
+      nonceOf(third),
+    );
     expect(getItem).toHaveBeenCalledTimes(2);
     expect((await audit.entries()).map((entry) => entry.value.outcome)).toEqual([
       "auto",
@@ -652,7 +711,7 @@ describe("OnePasswordBroker cache and audit", () => {
       opClient: { getItem },
       stores: { audit, grants },
     });
-    await before(broker, "deny-cache-1", {
+    const primed = await before(broker, "deny-cache-1", {
       action: "get",
       slug: "automatic",
       reason: "prime cache",
@@ -665,6 +724,7 @@ describe("OnePasswordBroker cache and audit", () => {
         reason: "prime cache",
       },
       invocation,
+      nonceOf(primed),
     );
     const automatic = cfg.items.automatic;
     if (!automatic) {

--- a/extensions/onepassword/src/broker.test.ts
+++ b/extensions/onepassword/src/broker.test.ts
@@ -381,7 +381,8 @@ describe("OnePasswordBroker validation and policy", () => {
       ),
     ).rejects.toMatchObject({ code: "POLICY_NOT_EVALUATED" });
 
-    // The hook always overwrites a model-supplied nonce with its own.
+    // The hook always overwrites a model-supplied nonce with its own, and a
+    // present-but-unknown nonce never falls back to the identity match.
     const result = await before(broker, "call-1", {
       action: "get",
       slug: "automatic",
@@ -391,6 +392,14 @@ describe("OnePasswordBroker validation and policy", () => {
     const issuedNonce = nonceOf(result);
     expect(issuedNonce).toBeDefined();
     expect(issuedNonce).not.toBe("attacker-nonce");
+    await expect(
+      broker.get(
+        "call-1",
+        { action: "get", slug: "automatic", reason: "reject forged correlation" },
+        invocation,
+        "attacker-nonce",
+      ),
+    ).rejects.toMatchObject({ code: "POLICY_NOT_EVALUATED" });
     await expect(
       broker.get(
         "call-1",

--- a/extensions/onepassword/src/broker.ts
+++ b/extensions/onepassword/src/broker.ts
@@ -231,11 +231,14 @@ export class OnePasswordBroker {
     };
   }
 
-  private pendingKey(
-    context: Pick<AccessContext, "agentId" | "sessionKey" | "sessionId" | "toolCallId">,
-  ): string {
-    const { agentId, sessionKey, sessionId, toolCallId } = context;
-    return JSON.stringify([agentId, sessionKey, sessionId, toolCallId]);
+  // Key pending authorizations by toolCallId only. The hook context
+  // (PluginHookToolContext) and the tool execute context are sourced
+  // independently by core and can disagree on session fields in production;
+  // a multi-field tuple key caused live POLICY_NOT_EVALUATED failures.
+  // toolCallId is provider-unique per call; get() still cross-checks
+  // slug/reason before honoring the entry.
+  private pendingKey(context: Pick<AccessContext, "toolCallId">): string {
+    return context.toolCallId;
   }
 
   private async audit(

--- a/extensions/onepassword/src/broker.ts
+++ b/extensions/onepassword/src/broker.ts
@@ -1,5 +1,8 @@
 import { createHash, randomUUID } from "node:crypto";
-import type { PluginStateKeyedStore } from "openclaw/plugin-sdk/plugin-state-runtime";
+import type {
+  PluginStateKeyedStore,
+  PluginStateSyncKeyedStore,
+} from "openclaw/plugin-sdk/plugin-state-runtime";
 import type {
   PluginHookBeforeToolCallEvent,
   PluginHookBeforeToolCallResult,
@@ -13,6 +16,10 @@ import {
 } from "./config.js";
 import { OnePasswordError, type OnePasswordErrorCode } from "./errors.js";
 import type { OpClient, ResolvedSecret } from "./op-client.js";
+import {
+  AUTHORIZATION_NONCE_PARAM,
+  consumeUniquePendingAuthorization,
+} from "./pending-authorization.js";
 
 type AuditOutcome =
   | "auto"
@@ -60,6 +67,7 @@ type AuditErrorCode = OnePasswordErrorCode | AuditInternalErrorCode;
 type BrokerStores = {
   audit: PluginStateKeyedStore<AuditRow>;
   grants: PluginStateKeyedStore<StandingGrant>;
+  pending: PluginStateSyncKeyedStore<PendingAuthorization>;
 };
 
 type BrokerOptions = {
@@ -78,12 +86,11 @@ type AccessContext = {
   reason: string;
 };
 
-type PendingAuthorization = AccessContext & {
+export type PendingAuthorization = AccessContext & {
   outcome: "auto" | "approved" | "grant";
   persistGrant: boolean;
   configFingerprint: string;
   targetFingerprint: string;
-  expiresAtMs: number;
 };
 
 type CacheEntry = ResolvedSecret & {
@@ -118,12 +125,6 @@ type ListedItem = {
 
 const APPROVAL_TIMEOUT_MS = 600_000;
 const PENDING_AUTHORIZATION_TTL_MS = APPROVAL_TIMEOUT_MS;
-
-// Correlates hook authorization with execute: session fields differ across
-// that boundary in production and provider tool-call ids are not globally
-// unique, so the hook mints a UUID returned via adjusted params (handed
-// through unchanged by core); model-supplied values are always overwritten.
-export const AUTHORIZATION_NONCE_PARAM = "authorizationNonce";
 
 function textParam(params: Record<string, unknown>, key: string): string | undefined {
   const value = params[key];
@@ -190,7 +191,6 @@ export class OnePasswordBroker {
   private readonly stores: BrokerStores;
   private readonly now: () => number;
   private readonly cache = new Map<string, CacheEntry>();
-  private readonly pending = new Map<string, PendingAuthorization>();
   private lastConfigFingerprint: string | null | undefined;
 
   constructor(options: BrokerOptions) {
@@ -205,7 +205,7 @@ export class OnePasswordBroker {
       // A reload can revoke policy or retarget a slug. Cached secrets and
       // in-flight authorizations must not survive that ownership boundary.
       this.cache.clear();
-      this.pending.clear();
+      this.stores.pending.clear();
     }
     this.lastConfigFingerprint = fingerprint;
   }
@@ -219,6 +219,10 @@ export class OnePasswordBroker {
     const fingerprint = createHash("sha256").update(JSON.stringify(config)).digest("hex");
     this.observeConfigFingerprint(fingerprint);
     return { config, fingerprint };
+  }
+
+  private registerPending(nonce: string, authorization: PendingAuthorization): void {
+    this.stores.pending.register(nonce, authorization, { ttlMs: PENDING_AUTHORIZATION_TTL_MS });
   }
 
   private context(
@@ -253,15 +257,6 @@ export class OnePasswordBroker {
       outcome,
       ...(options.errorCode ? { errorCode: options.errorCode } : {}),
     });
-  }
-
-  private sweepPending(): void {
-    const now = this.now();
-    for (const [key, authorization] of this.pending) {
-      if (authorization.expiresAtMs <= now) {
-        this.pending.delete(key);
-      }
-    }
   }
 
   private async pruneStaleGrants(config: OnePasswordConfig): Promise<void> {
@@ -334,17 +329,15 @@ export class OnePasswordBroker {
       return { block: true, blockReason: `1Password access denied by policy for ${input.slug}` };
     }
 
-    this.sweepPending();
     const nonce = randomUUID();
     const authorizedParams = { ...event.params, [AUTHORIZATION_NONCE_PARAM]: nonce };
     if (item.policy === "auto") {
-      this.pending.set(nonce, {
+      this.registerPending(nonce, {
         ...context,
         outcome: "auto",
         persistGrant: false,
         configFingerprint,
         targetFingerprint: fingerprintOnePasswordTarget(item),
-        expiresAtMs: this.now() + PENDING_AUTHORIZATION_TTL_MS,
       });
       return { params: authorizedParams };
     }
@@ -359,13 +352,12 @@ export class OnePasswordBroker {
       grant.expiresAtMs > this.now() &&
       grant.targetFingerprint === fingerprintOnePasswordTarget(item)
     ) {
-      this.pending.set(nonce, {
+      this.registerPending(nonce, {
         ...context,
         outcome: "grant",
         persistGrant: false,
         configFingerprint,
         targetFingerprint: fingerprintOnePasswordTarget(item),
-        expiresAtMs: this.now() + PENDING_AUTHORIZATION_TTL_MS,
       });
       return { params: authorizedParams };
     }
@@ -386,18 +378,17 @@ export class OnePasswordBroker {
           context.agentId === "unknown"
             ? ["allow-once", "deny"]
             : ["allow-once", "allow-always", "deny"],
-        // Core fires onResolution without awaiting it; the synchronous pending.set
+        // Core fires onResolution without awaiting it; the synchronous store write
         // below is what guarantees the authorization exists before the tool
         // handler runs. Do not move it behind an await.
         onResolution: async (decision) => {
           if (decision === "allow-once" || decision === "allow-always") {
-            this.pending.set(nonce, {
+            this.registerPending(nonce, {
               ...context,
               outcome: "approved",
               persistGrant: decision === "allow-always" && context.agentId !== "unknown",
               configFingerprint,
               targetFingerprint: fingerprintOnePasswordTarget(item),
-              expiresAtMs: this.now() + PENDING_AUTHORIZATION_TTL_MS,
             });
             return;
           }
@@ -447,7 +438,6 @@ export class OnePasswordBroker {
     invocation: ToolInvocationContext,
     nonce: string | undefined,
   ): Promise<ResolvedSecret & { slug: string }> {
-    this.sweepPending();
     const fallbackContext: AccessContext = {
       agentId: invocation.agentId ?? "unknown",
       sessionKey: invocation.sessionKey ?? "unknown",
@@ -456,10 +446,9 @@ export class OnePasswordBroker {
       slug: input.slug,
       reason: input.reason,
     };
-    const authorization = nonce ? this.pending.get(nonce) : undefined;
-    if (nonce) {
-      this.pending.delete(nonce);
-    }
+    const authorization =
+      (nonce ? this.stores.pending.consume(nonce) : undefined) ??
+      consumeUniquePendingAuthorization(this.stores.pending, fallbackContext);
     if (
       !authorization ||
       authorization.slug !== input.slug ||

--- a/extensions/onepassword/src/broker.ts
+++ b/extensions/onepassword/src/broker.ts
@@ -13,7 +13,6 @@ import {
 } from "./config.js";
 import { OnePasswordError, type OnePasswordErrorCode } from "./errors.js";
 import type { OpClient, ResolvedSecret } from "./op-client.js";
-import { takePendingAuthorization } from "./pending-authorization.js";
 
 type AuditOutcome =
   | "auto"
@@ -119,6 +118,16 @@ type ListedItem = {
 
 const APPROVAL_TIMEOUT_MS = 600_000;
 const PENDING_AUTHORIZATION_TTL_MS = APPROVAL_TIMEOUT_MS;
+
+// Correlates the before_tool_call authorization with the later execute call.
+// The hook context and the execute context are sourced independently by core
+// and can disagree on session fields (live POLICY_NOT_EVALUATED failures), and
+// provider tool-call ids are not globally unique (sequential ids on local
+// runtimes), so neither is a safe pending-map key. The hook mints a fresh
+// UUID per call and returns it via adjusted params - the one value core
+// guarantees to hand unchanged to the tool handler. Model-supplied values for
+// this param are always overwritten, so a replayed nonce can never resolve.
+export const AUTHORIZATION_NONCE_PARAM = "authorizationNonce";
 
 function textParam(params: Record<string, unknown>, key: string): string | undefined {
   const value = params[key];
@@ -231,16 +240,6 @@ export class OnePasswordBroker {
     };
   }
 
-  // Key pending authorizations by toolCallId only. The hook context
-  // (PluginHookToolContext) and the tool execute context are sourced
-  // independently by core and can disagree on session fields in production;
-  // a multi-field tuple key caused live POLICY_NOT_EVALUATED failures.
-  // toolCallId is provider-unique per call; get() still cross-checks
-  // slug/reason before honoring the entry.
-  private pendingKey(context: Pick<AccessContext, "toolCallId">): string {
-    return context.toolCallId;
-  }
-
   private async audit(
     context: AccessContext,
     outcome: AuditOutcome,
@@ -340,8 +339,11 @@ export class OnePasswordBroker {
     }
 
     this.sweepPending();
+    const nonce = randomUUID();
+    // Spread first so a model-supplied nonce param is always overwritten.
+    const authorizedParams = { ...event.params, [AUTHORIZATION_NONCE_PARAM]: nonce };
     if (item.policy === "auto") {
-      this.pending.set(this.pendingKey(context), {
+      this.pending.set(nonce, {
         ...context,
         outcome: "auto",
         persistGrant: false,
@@ -349,7 +351,7 @@ export class OnePasswordBroker {
         targetFingerprint: fingerprintOnePasswordTarget(item),
         expiresAtMs: this.now() + PENDING_AUTHORIZATION_TTL_MS,
       });
-      return;
+      return { params: authorizedParams };
     }
 
     const grantKey =
@@ -362,7 +364,7 @@ export class OnePasswordBroker {
       grant.expiresAtMs > this.now() &&
       grant.targetFingerprint === fingerprintOnePasswordTarget(item)
     ) {
-      this.pending.set(this.pendingKey(context), {
+      this.pending.set(nonce, {
         ...context,
         outcome: "grant",
         persistGrant: false,
@@ -370,13 +372,14 @@ export class OnePasswordBroker {
         targetFingerprint: fingerprintOnePasswordTarget(item),
         expiresAtMs: this.now() + PENDING_AUTHORIZATION_TTL_MS,
       });
-      return;
+      return { params: authorizedParams };
     }
     if (grant && grantKey) {
       await this.stores.grants.delete(grantKey);
     }
 
     return {
+      params: authorizedParams,
       requireApproval: {
         title: `1Password: ${input.slug}`,
         description: `Agent ${context.agentId} requests ${input.slug}. Reason: ${input.reason}`,
@@ -393,7 +396,7 @@ export class OnePasswordBroker {
         // handler runs. Do not move it behind an await.
         onResolution: async (decision) => {
           if (decision === "allow-once" || decision === "allow-always") {
-            this.pending.set(this.pendingKey(context), {
+            this.pending.set(nonce, {
               ...context,
               outcome: "approved",
               persistGrant: decision === "allow-always" && context.agentId !== "unknown",
@@ -447,6 +450,7 @@ export class OnePasswordBroker {
     toolCallId: string,
     input: ParsedGet,
     invocation: ToolInvocationContext,
+    nonce: string | undefined,
   ): Promise<ResolvedSecret & { slug: string }> {
     this.sweepPending();
     const fallbackContext: AccessContext = {
@@ -457,8 +461,10 @@ export class OnePasswordBroker {
       slug: input.slug,
       reason: input.reason,
     };
-    const key = this.pendingKey(fallbackContext);
-    const authorization = takePendingAuthorization(this.pending, key, fallbackContext);
+    const authorization = nonce ? this.pending.get(nonce) : undefined;
+    if (nonce) {
+      this.pending.delete(nonce);
+    }
     if (
       !authorization ||
       authorization.slug !== input.slug ||

--- a/extensions/onepassword/src/broker.ts
+++ b/extensions/onepassword/src/broker.ts
@@ -119,14 +119,10 @@ type ListedItem = {
 const APPROVAL_TIMEOUT_MS = 600_000;
 const PENDING_AUTHORIZATION_TTL_MS = APPROVAL_TIMEOUT_MS;
 
-// Correlates the before_tool_call authorization with the later execute call.
-// The hook context and the execute context are sourced independently by core
-// and can disagree on session fields (live POLICY_NOT_EVALUATED failures), and
-// provider tool-call ids are not globally unique (sequential ids on local
-// runtimes), so neither is a safe pending-map key. The hook mints a fresh
-// UUID per call and returns it via adjusted params - the one value core
-// guarantees to hand unchanged to the tool handler. Model-supplied values for
-// this param are always overwritten, so a replayed nonce can never resolve.
+// Correlates hook authorization with execute: session fields differ across
+// that boundary in production and provider tool-call ids are not globally
+// unique, so the hook mints a UUID returned via adjusted params (handed
+// through unchanged by core); model-supplied values are always overwritten.
 export const AUTHORIZATION_NONCE_PARAM = "authorizationNonce";
 
 function textParam(params: Record<string, unknown>, key: string): string | undefined {
@@ -340,7 +336,6 @@ export class OnePasswordBroker {
 
     this.sweepPending();
     const nonce = randomUUID();
-    // Spread first so a model-supplied nonce param is always overwritten.
     const authorizedParams = { ...event.params, [AUTHORIZATION_NONCE_PARAM]: nonce };
     if (item.policy === "auto") {
       this.pending.set(nonce, {

--- a/extensions/onepassword/src/broker.ts
+++ b/extensions/onepassword/src/broker.ts
@@ -202,10 +202,11 @@ export class OnePasswordBroker {
 
   private observeConfigFingerprint(fingerprint: string | null): void {
     if (this.lastConfigFingerprint !== undefined && this.lastConfigFingerprint !== fingerprint) {
-      // A reload can revoke policy or retarget a slug. Cached secrets and
-      // in-flight authorizations must not survive that ownership boundary.
+      // A reload can revoke policy or retarget a slug: drop this instance's
+      // cached secrets. Shared pending entries are NOT cleared here - that
+      // would race sibling broker instances with stale local tracking; get()
+      // rejects stale entries via their per-entry configFingerprint instead.
       this.cache.clear();
-      this.stores.pending.clear();
     }
     this.lastConfigFingerprint = fingerprint;
   }
@@ -446,9 +447,13 @@ export class OnePasswordBroker {
       slug: input.slug,
       reason: input.reason,
     };
+    // A present-but-unknown nonce means forgery, replay, or a consumed entry:
+    // fail closed. The identity fallback applies only when the nonce param was
+    // dropped entirely by another hook's params rewrite.
     const authorization =
-      (nonce ? this.stores.pending.consume(nonce) : undefined) ??
-      consumeUniquePendingAuthorization(this.stores.pending, fallbackContext);
+      nonce !== undefined
+        ? this.stores.pending.consume(nonce)
+        : consumeUniquePendingAuthorization(this.stores.pending, fallbackContext);
     if (
       !authorization ||
       authorization.slug !== input.slug ||

--- a/extensions/onepassword/src/cli.ts
+++ b/extensions/onepassword/src/cli.ts
@@ -64,6 +64,7 @@ async function readAuditRows(auditStore: PluginStateKeyedStore<AuditRow>, limit:
       agent: value.agentId,
       slug: value.slug,
       outcome: value.outcome,
+      ...(value.errorCode ? { errorCode: value.errorCode } : {}),
       reason: truncateReason(value.reason),
     }));
 }

--- a/extensions/onepassword/src/cli.ts
+++ b/extensions/onepassword/src/cli.ts
@@ -59,14 +59,26 @@ async function readAuditRows(auditStore: PluginStateKeyedStore<AuditRow>, limit:
         right.value.timestampMs - left.value.timestampMs || right.key.localeCompare(left.key),
     )
     .slice(0, limit)
-    .map(({ value }) => ({
-      timestamp: new Date(value.timestampMs).toISOString(),
-      agent: value.agentId,
-      slug: value.slug,
-      outcome: value.outcome,
-      ...(value.errorCode ? { errorCode: value.errorCode } : {}),
-      reason: truncateReason(value.reason),
-    }));
+    .map(({ value }) => {
+      const row: {
+        timestamp: string;
+        agent: string;
+        slug: string;
+        outcome: string;
+        errorCode?: string;
+        reason: string;
+      } = {
+        timestamp: new Date(value.timestampMs).toISOString(),
+        agent: value.agentId,
+        slug: value.slug,
+        outcome: value.outcome,
+        reason: truncateReason(value.reason),
+      };
+      if (value.errorCode) {
+        row.errorCode = value.errorCode;
+      }
+      return row;
+    });
 }
 
 export function registerOnePasswordCommands(context: OnePasswordCliContext): void {

--- a/extensions/onepassword/src/pending-authorization.ts
+++ b/extensions/onepassword/src/pending-authorization.ts
@@ -1,3 +1,11 @@
+import type { PluginStateSyncKeyedStore } from "openclaw/plugin-sdk/plugin-state-runtime";
+
+// Correlates hook authorization with execute: session fields differ across
+// that boundary in production and provider tool-call ids are not globally
+// unique, so the hook mints a UUID returned via adjusted params (handed
+// through unchanged by core); model-supplied values are always overwritten.
+export const AUTHORIZATION_NONCE_PARAM = "authorizationNonce";
+
 type PendingRequest = {
   agentId: string;
   toolCallId: string;
@@ -5,20 +13,17 @@ type PendingRequest = {
   reason: string;
 };
 
-export function takePendingAuthorization<T extends PendingRequest>(
-  pending: Map<string, T>,
-  exactKey: string,
+// Fallback when the nonce param was dropped: before_tool_call results merge
+// last-writer-wins, so another plugin returning params can strip the nonce.
+// A single unambiguous match on caller identity is safe to honor; anything
+// ambiguous fails closed.
+export function consumeUniquePendingAuthorization<T extends PendingRequest>(
+  store: PluginStateSyncKeyedStore<T>,
   request: PendingRequest,
 ): T | undefined {
-  const exact = pending.get(exactKey);
-  if (exact) {
-    pending.delete(exactKey);
-    return exact;
-  }
-
-  let match: [string, T] | undefined;
-  for (const entry of pending) {
-    const candidate = entry[1];
+  let match: string | undefined;
+  for (const entry of store.entries()) {
+    const candidate = entry.value;
     if (
       candidate.agentId !== request.agentId ||
       candidate.toolCallId !== request.toolCallId ||
@@ -27,14 +32,10 @@ export function takePendingAuthorization<T extends PendingRequest>(
     ) {
       continue;
     }
-    if (match) {
+    if (match !== undefined) {
       return undefined;
     }
-    match = entry;
+    match = entry.key;
   }
-  if (!match) {
-    return undefined;
-  }
-  pending.delete(match[0]);
-  return match[1];
+  return match === undefined ? undefined : store.consume(match);
 }

--- a/extensions/onepassword/src/tool.ts
+++ b/extensions/onepassword/src/tool.ts
@@ -4,7 +4,7 @@ import type {
   PluginHookToolResultPersistEvent,
   PluginHookToolResultPersistResult,
 } from "openclaw/plugin-sdk/types";
-import { parseToolInput, type OnePasswordBroker } from "./broker.js";
+import { AUTHORIZATION_NONCE_PARAM, parseToolInput, type OnePasswordBroker } from "./broker.js";
 import { OnePasswordError } from "./errors.js";
 
 const OnePasswordToolSchema = {
@@ -27,6 +27,10 @@ const OnePasswordToolSchema = {
       minLength: 1,
       maxLength: 300,
       description: "Why the agent needs this secret. Required for get.",
+    },
+    authorizationNonce: {
+      type: "string",
+      description: "Internal. Injected by the gateway policy layer; never set this manually.",
     },
   },
 } as unknown as AnyAgentTool["parameters"];
@@ -105,7 +109,9 @@ export function createOnePasswordTool(
         if (input.action === "list") {
           return jsonResult({ ok: true, items: await broker.list(invocation) });
         }
-        const secret = await broker.get(toolCallId, input, invocation);
+        const nonceValue = params[AUTHORIZATION_NONCE_PARAM];
+        const nonce = typeof nonceValue === "string" ? nonceValue : undefined;
+        const secret = await broker.get(toolCallId, input, invocation, nonce);
         return jsonResult({ ok: true, ...secret });
       } catch (error) {
         return errorResult(error);

--- a/extensions/onepassword/src/tool.ts
+++ b/extensions/onepassword/src/tool.ts
@@ -4,8 +4,9 @@ import type {
   PluginHookToolResultPersistEvent,
   PluginHookToolResultPersistResult,
 } from "openclaw/plugin-sdk/types";
-import { AUTHORIZATION_NONCE_PARAM, parseToolInput, type OnePasswordBroker } from "./broker.js";
+import { parseToolInput, type OnePasswordBroker } from "./broker.js";
 import { OnePasswordError } from "./errors.js";
+import { AUTHORIZATION_NONCE_PARAM } from "./pending-authorization.js";
 
 const OnePasswordToolSchema = {
   type: "object",


### PR DESCRIPTION
## What Problem This Solves

The `onepassword` plugin's `get` fails closed with `POLICY_NOT_EVALUATED` on real gateways. Instrumented debugging on a production install proved the root cause: the plugin's `register()` runs twice (duplicate plugin registration on a git-channel install), so the `before_tool_call` hook and the tool execute bind **different broker instances** — same pid, identical toolCallId/agentId/sessionId 2ms apart, yet the executing broker's in-memory pending map is empty. Any in-memory handshake loses, which is why #107275's fallback scan (same map) is also insufficient on that gateway — verified live post-#107275, same error.

Refs #105924; follow-up to #106133, supersedes the remaining gap after #107275.

## Why This Change Was Made

Two mechanisms, each addressing a proven failure mode:

- **Nonce correlation**: the hook mints a UUID per call and returns it via adjusted params — the one value core hands unchanged to the tool handler (verified `finalParams` path incl. approval resolution). Session-field asymmetry and non-unique provider tool-call ids (sequential local-runtime ids) can't break it; model-supplied nonces are always overwritten and never resolve.
- **Shared sync pending store**: pending authorizations live in the plugin's shared SQLite state (`openSyncKeyedStore`, namespace `pending`, TTL'd, atomic `consume`), so every broker instance — and even a restarted gateway — sees the same authorizations. Synchronous writes preserve the ordering guarantee (core fires `requireApproval.onResolution` unawaited). The in-memory map, sweep logic, tuple key, and `pending-authorization.ts` fallback scanner are deleted: one canonical path.

Also keeps `errorCode` in `openclaw onepassword audit` output (the field existed in rows but the CLI dropped it, which made live diagnosis needlessly hard).

## User Impact

`get` works on real gateways. Live proof on a production install (dual-registration environment intact): auto-tier `get` now audits `outcome: "auto"` and returns the secret, where every prior variant failed. Audit CLI shows error codes. No config changes.

## Evidence

- Live production verification: pre-fix audit rows `POLICY_NOT_EVALUATED` (including post-#107275); post-fix row `outcome: "auto"` for the same slug/agent (2026-07-15T02:29Z).
- Instrumentation evidence: hook + get debug rows with identical ids/pid and empty pending map at execute time (dual broker instances).
- `node scripts/run-vitest.mjs extensions/onepassword`: 6 files, 56 tests, including the decisive two-brokers-one-store regression plus asymmetric-context, colliding tool-call-id, and forged-nonce tests.
- `broker.ts` at 567 lines vs 574 on main (LOC ratchet satisfied, net negative); oxlint clean (Node 24 Testbox).
- Interop hardening after review: core `before_tool_call` results merge params last-writer-wins across plugins (verified in `src/plugins/hooks.ts`; approve-path params are frozen by core once `requireApproval` is set), so a later params-returning hook can drop the nonce. `get()` falls back to a single-unambiguous identity match against the shared store only when the nonce param is absent; a present-but-unknown nonce (forgery/replay/consumed) always fails closed. Config reloads no longer clear the shared store from instance-local tracking (cross-instance race); per-entry `configFingerprint` validation rejects stale authorizations instead.
- Final live verification of this exact head on the production gateway: `outcome: "auto"` (2026-07-15T02:55Z). Final autoreview: clean, no actionable findings.
- Core duplicate plugin `register()` bug filed separately: #107933.
