### PR TITLE
test(ci): harden scheduled release probes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -156,7 +156,7 @@ Skills own workflows; root owns hard policy and routing.
 - QA CLI `--output-dir` must be repo-relative.
 - Full suites, changed gates, builds, typechecks, lint fan-out, Docker/package/E2E/live/cross-OS proof, or anything computationally intensive: Crabbox/Testbox.
 - Testbox owns Chromium; never pass Crabbox `--browser` to `provider=blacksmith-testbox`.
-- Testbox job env uses Bash `declare`; compound commands use `bash -lc`, never `sh -lc`.
+- Testbox warmup must print a lease id; silent success is unusable. Verify before reuse; fall back to one-shot `run`.
 - If local proof fans out or becomes expensive, stop it and lazily acquire the remote box.
 - Before handoff/push: prove touched surface. Before landing to `main`: proof matches actual risk. Bounded behavior-neutral refactor: focused tests/checks enough; no issue proof or full/broad suite by default.
 - Release-branch full validation: freeze the product-complete **Code SHA**, then use `node scripts/full-release-validation-at-sha.mjs --sha <code-sha> --target-ref release/YYYY.M.PATCH`; no raw dispatch without `target_context_ref`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -155,6 +155,8 @@ Skills own workflows; root owns hard policy and routing.
 - Testbox status: `blacksmith testbox status --id <tbx_id>`; no `--json` flag.
 - QA CLI `--output-dir` must be repo-relative.
 - Full suites, changed gates, builds, typechecks, lint fan-out, Docker/package/E2E/live/cross-OS proof, or anything computationally intensive: Crabbox/Testbox.
+- Testbox owns Chromium; never pass Crabbox `--browser` to `provider=blacksmith-testbox`.
+- Testbox job env uses Bash `declare`; compound commands use `bash -lc`, never `sh -lc`.
 - If local proof fans out or becomes expensive, stop it and lazily acquire the remote box.
 - Before handoff/push: prove touched surface. Before landing to `main`: proof matches actual risk. Bounded behavior-neutral refactor: focused tests/checks enough; no issue proof or full/broad suite by default.
 - Release-branch full validation: freeze the product-complete **Code SHA**, then use `node scripts/full-release-validation-at-sha.mjs --sha <code-sha> --target-ref release/YYYY.M.PATCH`; no raw dispatch without `target_context_ref`.

--- a/src/gateway/gateway-cli-backend.live.test.ts
+++ b/src/gateway/gateway-cli-backend.live.test.ts
@@ -9,6 +9,7 @@ import {
   resolveCliBackendConfig,
   resolveCliBackendLiveTest,
 } from "../agents/cli-backends.js";
+import { getClaudeLiveSessionGenerationForOwner } from "../agents/cli-runner/claude-live-session.js";
 import { isLiveTestEnabled } from "../agents/live-test-helpers.js";
 import { shouldSkipLiveProviderDrift } from "../agents/live-test-provider-drift.js";
 import { parseModelRef } from "../agents/model-selection.js";
@@ -91,35 +92,6 @@ const CLI_BACKEND_LIVE_TIMEOUT_MS = Math.max(
   CLI_BACKEND_CODEX_TIMEOUT_RETRY_SEQUENCE_MS * CLI_BACKEND_RETRY_WRAPPED_AGENT_REQUESTS +
     2 * 60_000,
 );
-
-async function findClaudeCliSessionFile(cliSessionId: string): Promise<string | undefined> {
-  const sessionId = cliSessionId.trim();
-  if (!sessionId || sessionId.includes("/") || sessionId.includes("\\")) {
-    return undefined;
-  }
-  const configDir = process.env.CLAUDE_CONFIG_DIR?.trim() || path.join(os.homedir(), ".claude");
-  const projectsDir = path.join(configDir, "projects");
-  let entries: import("node:fs").Dirent[];
-  try {
-    entries = await fs.readdir(projectsDir, { withFileTypes: true });
-  } catch {
-    return undefined;
-  }
-  for (const entry of entries) {
-    if (!entry.isDirectory()) {
-      continue;
-    }
-    const filePath = path.join(projectsDir, entry.name, `${sessionId}.jsonl`);
-    try {
-      if ((await fs.stat(filePath)).isFile()) {
-        return filePath;
-      }
-    } catch {
-      // Try the next Claude project directory.
-    }
-  }
-  return undefined;
-}
 
 function parsePositiveIntegerEnv(name: string, fallback: number): number {
   const raw = process.env[name]?.trim();
@@ -706,29 +678,31 @@ describeLive("gateway live (cli backend)", () => {
           ).toBe(true);
         } else if (CLI_RESUME) {
           logCliBackendLiveStep("agent-resume:start", { sessionKey, resumeNonce });
+          let continuityOwner:
+            | Parameters<typeof getClaudeLiveSessionGenerationForOwner>[0]
+            | undefined;
+          let expectedLiveSessionGeneration: string | undefined;
           if (resumeContinuityProbe) {
-            const nativeHistory = await activeClient.request<{ messages?: unknown[] }>(
-              "chat.history",
-              { sessionKey },
-            );
+            const nativeHistory = await activeClient.request<{
+              messages?: unknown[];
+              sessionId?: string;
+            }>("chat.history", { sessionKey });
             const cliSessionId = resolveImportedClaudeCliSessionId(nativeHistory.messages ?? []);
             expect(JSON.stringify(nativeHistory.messages ?? [])).toContain(memoryToken);
             expect(cliSessionId).toBeTruthy();
-            const cliSessionFile = cliSessionId
-              ? await findClaudeCliSessionFile(cliSessionId)
-              : undefined;
-            expect(cliSessionFile).toBeTruthy();
-            if (!cliSessionFile) {
-              throw new Error("Claude CLI continuity probe could not locate its native transcript");
+            const continuitySessionId = nativeHistory.sessionId;
+            expect(continuitySessionId).toBeTruthy();
+            if (!continuitySessionId) {
+              throw new Error("Claude CLI continuity probe could not resolve its OpenClaw session");
             }
-            // The warm child keeps this turn in memory. Remove Claude's native transcript so
-            // --resume and raw-history reseed cannot recover the hidden note if that child is lost.
-            await fs.rm(cliSessionFile, { force: true });
-            const rawHistory = await activeClient.request<{ messages?: unknown[] }>(
-              "chat.history",
-              { sessionKey },
-            );
-            expect(JSON.stringify(rawHistory.messages ?? [])).not.toContain(memoryToken);
+            continuityOwner = {
+              backendId: providerId,
+              agentId: "dev",
+              sessionId: continuitySessionId,
+              sessionKey,
+            };
+            expectedLiveSessionGeneration = getClaudeLiveSessionGenerationForOwner(continuityOwner);
+            expect(expectedLiveSessionGeneration).toBeTruthy();
           }
           const resumePayload = await requestWithCodexTimeoutRetry(
             providerId,
@@ -765,6 +739,12 @@ describeLive("gateway live (cli backend)", () => {
             expect(
               matchesCliBackendReply(resumeText, resumeContinuityProbe.expectedResumeReply),
             ).toBe(true);
+            if (!continuityOwner || !expectedLiveSessionGeneration) {
+              throw new Error("Claude CLI continuity probe lost its live-session generation");
+            }
+            expect(getClaudeLiveSessionGenerationForOwner(continuityOwner)).toBe(
+              expectedLiveSessionGeneration,
+            );
           } else {
             expect(
               matchesCliBackendReply(resumeText, `CLI backend RESUME OK ${resumeNonce}.`),

--- a/src/wizard/clack-prompter.test.ts
+++ b/src/wizard/clack-prompter.test.ts
@@ -208,7 +208,9 @@ describe("createClackPrompter", () => {
 
   it("rejects navigation after Clack resolves an aborted prompt", async () => {
     navigationPromptMocks.textWithNavigationFooter.mockImplementation(async ({ signal }) => {
-      await new Promise((resolve) => signal.addEventListener("abort", resolve, { once: true }));
+      await new Promise((resolve) => {
+        signal.addEventListener("abort", resolve, { once: true });
+      });
       return Symbol("clack:cancel");
     });
     const prompter = createClackPrompter();

--- a/ui/src/e2e/browser-talk-start-stop.e2e.test.ts
+++ b/ui/src/e2e/browser-talk-start-stop.e2e.test.ts
@@ -61,6 +61,10 @@ async function installTalkBrowserFixtures(page: Page) {
         return { connect() {}, disconnect() {} };
       }
 
+      createGain() {
+        return { connect() {}, disconnect() {}, gain: { value: 1 } };
+      }
+
       createScriptProcessor() {
         const processor = { connect() {}, disconnect() {}, onaudioprocess: null };
         state.inputProcessor = processor;
@@ -178,7 +182,16 @@ describeControlUiE2e("Control UI browser Talk", () => {
               ).openclawTalkE2eState?.constraints,
           ),
         )
-        .toEqual([{ audio: { deviceId: { exact: "usb" } } }]);
+        .toEqual([
+          {
+            audio: {
+              autoGainControl: true,
+              deviceId: { exact: "usb" },
+              echoCancellation: true,
+              noiseSuppression: true,
+            },
+          },
+        ]);
       await expect
         .poll(async () =>
           (await gateway.getSocketUrls()).filter((url) => url.includes("BidiGenerateContent")),
@@ -446,7 +459,24 @@ describeControlUiE2e("Control UI browser Talk", () => {
       await page.setViewportSize({ width: 1366, height: 900 });
       await page.getByRole("button", { name: "Start voice input" }).click();
       await gateway.waitForRequest("talk.client.create");
+      // The request is recorded before its mock response is delivered. Wait for
+      // microphone setup before probing relay readiness below.
+      await expect
+        .poll(() =>
+          page.evaluate(
+            () =>
+              (
+                window as Window & {
+                  openclawTalkE2eState?: { constraints: unknown[] };
+                }
+              ).openclawTalkE2eState?.constraints.length,
+          ),
+        )
+        .toBe(1);
       await gateway.emitGatewayEvent("talk.event", { relaySessionId, type: "ready" });
+      await expect
+        .poll(() => page.locator('.agent-chat__voice-activity[data-status="listening"]').count())
+        .toBe(1);
       await gateway.emitGatewayEvent("talk.event", {
         relaySessionId,
         type: "transcript",
@@ -454,6 +484,11 @@ describeControlUiE2e("Control UI browser Talk", () => {
         text: "Hey, what model are you using?",
         final: true,
       });
+      await expect
+        .poll(() =>
+          page.locator(".agent-chat__voice-turn--user .agent-chat__voice-turn-text").textContent(),
+        )
+        .toBe("Hey, what model are you using?");
       // Assistant audio transcripts stream as verbatim fragments that can split
       // words ("I","'m"," Chat","G","PT"); regression coverage for #102556 where
       // the merge injected spaces mid-word and the turn collapsed while streaming.

--- a/ui/src/e2e/session-transcript-search.e2e.test.ts
+++ b/ui/src/e2e/session-transcript-search.e2e.test.ts
@@ -127,8 +127,10 @@ describeControlUiE2e("Control UI session transcript search", () => {
     await result.waitFor({ state: "visible", timeout: 10_000 });
     await expect.poll(async () => gateway.getRequests("sessions.search")).toHaveLength(1);
     expect((await gateway.getRequests("sessions.search"))[0]?.params).toEqual({
+      agentId: "main",
       limit: 25,
       query: "nebula launch",
+      sessionKeys: ["agent:main:launch"],
     });
     await expect.poll(() => result.textContent()).toContain("Launch planning");
     await expect.poll(() => result.textContent()).toContain("Assistant");
@@ -165,10 +167,19 @@ describeControlUiE2e("Control UI session transcript search", () => {
       featureMethods: ["chat.metadata", "chat.startup", "sessions.search"],
       methodResponses: {
         "sessions.list": {
-          count: 0,
+          count: 1,
           defaults: { contextTokens: null, model: null, modelProvider: null },
           path: "",
-          sessions: [],
+          sessions: [
+            {
+              key: "agent:main:stale",
+              kind: "direct",
+              label: "Stale search fixture",
+              status: "done",
+              totalTokens: 0,
+              updatedAt: timestamp,
+            },
+          ],
           ts: timestamp,
         },
         "sessions.search": { indexing: true, results: [] },

--- a/ui/src/e2e/usage-cost-analysis.e2e.test.ts
+++ b/ui/src/e2e/usage-cost-analysis.e2e.test.ts
@@ -298,10 +298,15 @@ describeControlUiE2e("Control UI usage cost analysis mocked Gateway E2E", () => 
     try {
       await page.goto(`${server.baseUrl}usage`);
       await page.locator(".daily-chart-compact").waitFor({ state: "visible", timeout: 10_000 });
+      await page.locator(".agent-scope-control__select").selectOption("");
+      await expect
+        .poll(async () => (await gateway.getRequests("usage.cost")).at(-1)?.params)
+        .toMatchObject({ agentScope: "all" });
+      const costRequestsBeforeRangeChange = (await gateway.getRequests("usage.cost")).length;
       await page.getByRole("button", { name: "90d", exact: true }).click();
       await expect
         .poll(async () => (await gateway.getRequests("usage.cost")).length)
-        .toBeGreaterThan(1);
+        .toBeGreaterThan(costRequestsBeforeRangeChange);
       await page.getByRole("button", { name: "Cost", exact: true }).click();
 
       const windowCards = page.locator(".cost-window-card");


### PR DESCRIPTION
## What Problem This Solves

Scheduled release validation drifted from current runtime contracts: Claude warm-stdio continuity was incorrectly proven through a native transcript file that the warm process does not write, three Control UI E2E fixtures still assumed older Talk, transcript-search, and usage-scope behavior, and current main carried an oxlint-invalid Promise executor in the Clack navigation regression test.

## Why This Change Was Made

- Prove Claude resume continuity through the same live-session generation that owns the warm in-memory process.
- Keep the imported Claude session marker and remembered-token assertions without requiring or deleting a native transcript.
- Model current browser audio constraints and meter APIs in the Talk fixture.
- Assert agent-scoped transcript search parameters and an explicit all-agent usage scope.
- Make the Clack abort-wait Promise executor block-bodied so it cannot return the listener registration expression.
- Record Testbox invocation guards discovered during the repair.

## User Impact

No product behavior change. Scheduled release validation now checks the runtime contract it actually depends on and avoids deterministic fixture failures.

## Evidence

- Exact head: `1b816ee40b1811ee17084bde949fa6db6dedaf45`.
- Testbox `tbx_01kxfvk4er4m5nm95h3fp9fvtr`: 11 CLI helper tests, 8 Control UI E2E tests, and `pnpm check:changed` passed after rebasing onto current main; run https://github.com/openclaw/openclaw/actions/runs/29317861674.
- Testbox `tbx_01kxfqnfa5zgmdsfzd96sk1vj2`: Docker Claude CLI backend live test passed, 1/1.
- Testbox `tbx_01kxfw1xtpafqa0sw1eq45fvv0`: Clack prompter 11/11 and targeted core oxlint passed; run https://github.com/openclaw/openclaw/actions/runs/29318351702.
- Fresh branch autoreview: clean, no accepted/actionable findings.
- `git diff --check` passed.

No changelog entry: test and maintainer-instruction changes only.
