### PR TITLE
fix(onepassword): preserve pending tool authorization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **1Password tool authorization:** recover uniquely matching pending authorization when hook and execution contexts omit or disagree on session fields, while failing closed for ambiguous cross-session matches.
 - **Microsoft Teams HTML text:** decode HTML5 entities consistently in quoted and Graph-fetched messages while preserving literal escaped entity text.
 - **ClawHub plugin API ranges:** delegate each supported comparator to `semver` so tilde, partial-wildcard, and prerelease caret bounds are correct while preserving OpenClaw version normalization and the existing restricted range grammar. (#106877)
 - **Web Readability relative links:** seed parsed documents with the request URL so article links resolve correctly while removing the plugin's duplicate lazy-loader facade. (#106860)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **1Password tool authorization:** recover uniquely matching pending authorization when hook and execution contexts omit or disagree on session fields, while failing closed for ambiguous cross-session matches.
 - **Microsoft Teams HTML text:** decode HTML5 entities consistently in quoted and Graph-fetched messages while preserving literal escaped entity text.
 - **ClawHub plugin API ranges:** delegate each supported comparator to `semver` so tilde, partial-wildcard, and prerelease caret bounds are correct while preserving OpenClaw version normalization and the existing restricted range grammar. (#106877)
 - **Web Readability relative links:** seed parsed documents with the request URL so article links resolve correctly while removing the plugin's duplicate lazy-loader facade. (#106860)

--- a/extensions/onepassword/src/broker.test.ts
+++ b/extensions/onepassword/src/broker.test.ts
@@ -265,6 +265,80 @@ describe("OnePasswordBroker validation and policy", () => {
     ]);
   });
 
+  it("authorizes when hook and execute contexts disagree on session fields", async () => {
+    const { broker, audit } = setup();
+    await broker.beforeToolCall(
+      {
+        toolName: "onepassword",
+        params: { action: "get", slug: "automatic", reason: "asymmetric contexts" },
+        toolCallId: "call_x|fc_y",
+      },
+      {
+        toolName: "onepassword",
+        toolCallId: "call_x|fc_y",
+        agentId: "main",
+        sessionKey: "agent:main:main",
+        sessionId: "hook-run-uuid",
+      },
+    );
+
+    await expect(
+      broker.get(
+        "call_x|fc_y",
+        { action: "get", slug: "automatic", reason: "asymmetric contexts" },
+        { agentId: "main", sessionKey: "agent:main:main" },
+      ),
+    ).resolves.toMatchObject({ slug: "automatic" });
+    expect((await audit.entries()).map((entry) => entry.value.outcome)).toEqual(["auto"]);
+  });
+
+  it("rejects an ambiguous fallback across sessions", async () => {
+    const { broker } = setup();
+    for (const sessionKey of ["session-a", "session-b"]) {
+      await broker.beforeToolCall(
+        {
+          toolName: "onepassword",
+          params: { action: "get", slug: "automatic", reason: "same request" },
+          toolCallId: "call-1",
+        },
+        { toolName: "onepassword", toolCallId: "call-1", agentId: "agent-a", sessionKey },
+      );
+    }
+
+    await expect(
+      broker.get(
+        "call-1",
+        { action: "get", slug: "automatic", reason: "same request" },
+        { agentId: "agent-a", sessionKey: "session-c" },
+      ),
+    ).rejects.toMatchObject({ code: "POLICY_NOT_EVALUATED" });
+  });
+
+  it("rejects a unique fallback from another agent", async () => {
+    const { broker } = setup();
+    await broker.beforeToolCall(
+      {
+        toolName: "onepassword",
+        params: { action: "get", slug: "automatic", reason: "same request" },
+        toolCallId: "call-1",
+      },
+      {
+        toolName: "onepassword",
+        toolCallId: "call-1",
+        agentId: "agent-a",
+        sessionKey: "session-a",
+      },
+    );
+
+    await expect(
+      broker.get(
+        "call-1",
+        { action: "get", slug: "automatic", reason: "same request" },
+        { agentId: "agent-b", sessionKey: "session-b" },
+      ),
+    ).rejects.toMatchObject({ code: "POLICY_NOT_EVALUATED" });
+  });
+
   it("persists allow-always grants and expires them", async () => {
     const { broker, audit, grants, getItem, advance } = setup();
     const first = await before(broker, "grant-1", {

--- a/extensions/onepassword/src/broker.ts
+++ b/extensions/onepassword/src/broker.ts
@@ -13,6 +13,7 @@ import {
 } from "./config.js";
 import { OnePasswordError, type OnePasswordErrorCode } from "./errors.js";
 import type { OpClient, ResolvedSecret } from "./op-client.js";
+import { findPendingAuthorization } from "./pending-authorization.js";
 
 type AuditOutcome =
   | "auto"
@@ -233,12 +234,8 @@ export class OnePasswordBroker {
   private pendingKey(
     context: Pick<AccessContext, "agentId" | "sessionKey" | "sessionId" | "toolCallId">,
   ): string {
-    return JSON.stringify([
-      context.agentId,
-      context.sessionKey,
-      context.sessionId,
-      context.toolCallId,
-    ]);
+    const { agentId, sessionKey, sessionId, toolCallId } = context;
+    return JSON.stringify([agentId, sessionKey, sessionId, toolCallId]);
   }
 
   private async audit(
@@ -458,8 +455,12 @@ export class OnePasswordBroker {
       reason: input.reason,
     };
     const key = this.pendingKey(fallbackContext);
-    const authorization = this.pending.get(key);
-    this.pending.delete(key);
+    const [authorizationKey, authorization] = findPendingAuthorization(
+      this.pending,
+      key,
+      fallbackContext,
+    );
+    this.pending.delete(authorizationKey);
     if (
       !authorization ||
       authorization.slug !== input.slug ||

--- a/extensions/onepassword/src/broker.ts
+++ b/extensions/onepassword/src/broker.ts
@@ -13,7 +13,7 @@ import {
 } from "./config.js";
 import { OnePasswordError, type OnePasswordErrorCode } from "./errors.js";
 import type { OpClient, ResolvedSecret } from "./op-client.js";
-import { findPendingAuthorization } from "./pending-authorization.js";
+import { takePendingAuthorization } from "./pending-authorization.js";
 
 type AuditOutcome =
   | "auto"
@@ -455,12 +455,7 @@ export class OnePasswordBroker {
       reason: input.reason,
     };
     const key = this.pendingKey(fallbackContext);
-    const [authorizationKey, authorization] = findPendingAuthorization(
-      this.pending,
-      key,
-      fallbackContext,
-    );
-    this.pending.delete(authorizationKey);
+    const authorization = takePendingAuthorization(this.pending, key, fallbackContext);
     if (
       !authorization ||
       authorization.slug !== input.slug ||

--- a/extensions/onepassword/src/pending-authorization.ts
+++ b/extensions/onepassword/src/pending-authorization.ts
@@ -1,0 +1,35 @@
+type PendingRequest = {
+  agentId: string;
+  toolCallId: string;
+  slug: string;
+  reason: string;
+};
+
+export function findPendingAuthorization<T extends PendingRequest>(
+  pending: ReadonlyMap<string, T>,
+  exactKey: string,
+  request: PendingRequest,
+): [key: string, authorization: T | undefined] {
+  const exact = pending.get(exactKey);
+  if (exact) {
+    return [exactKey, exact];
+  }
+
+  let match: [string, T] | undefined;
+  for (const entry of pending) {
+    const candidate = entry[1];
+    if (
+      candidate.agentId !== request.agentId ||
+      candidate.toolCallId !== request.toolCallId ||
+      candidate.slug !== request.slug ||
+      candidate.reason !== request.reason
+    ) {
+      continue;
+    }
+    if (match) {
+      return [exactKey, undefined];
+    }
+    match = entry;
+  }
+  return match ?? [exactKey, undefined];
+}

--- a/extensions/onepassword/src/pending-authorization.ts
+++ b/extensions/onepassword/src/pending-authorization.ts
@@ -5,14 +5,15 @@ type PendingRequest = {
   reason: string;
 };
 
-export function findPendingAuthorization<T extends PendingRequest>(
-  pending: ReadonlyMap<string, T>,
+export function takePendingAuthorization<T extends PendingRequest>(
+  pending: Map<string, T>,
   exactKey: string,
   request: PendingRequest,
-): [key: string, authorization: T | undefined] {
+): T | undefined {
   const exact = pending.get(exactKey);
   if (exact) {
-    return [exactKey, exact];
+    pending.delete(exactKey);
+    return exact;
   }
 
   let match: [string, T] | undefined;
@@ -27,9 +28,13 @@ export function findPendingAuthorization<T extends PendingRequest>(
       continue;
     }
     if (match) {
-      return [exactKey, undefined];
+      return undefined;
     }
     match = entry;
   }
-  return match ?? [exactKey, undefined];
+  if (!match) {
+    return undefined;
+  }
+  pending.delete(match[0]);
+  return match[1];
 }


### PR DESCRIPTION
## Summary

- recover a pending 1Password authorization when hook and execution contexts differ only in session fields
- preserve the agent boundary and fail closed for ambiguous matches
- add regression coverage for asymmetric, ambiguous, and cross-agent contexts

## Proof

- `pnpm test extensions/onepassword/src/broker.test.ts` (20 passed)
- `pnpm check:changed` via Blacksmith Testbox
- autoreview clean
