### PR TITLE
fix(memory-core): preserve canonical embedding cache on migration

### DIFF
--- a/extensions/memory-core/doctor-contract-api.test.ts
+++ b/extensions/memory-core/doctor-contract-api.test.ts
@@ -232,6 +232,46 @@ async function createUnrelatedCanonicalMemoryIndex(
   }
 }
 
+async function seedCanonicalEmbeddingCacheConflict(agentPath: string): Promise<void> {
+  const db = new DatabaseSync(agentPath);
+  try {
+    db.prepare(
+      `INSERT INTO memory_embedding_cache (
+         provider, model, provider_key, hash, embedding, dims, updated_at
+       ) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    ).run("openai", "embed-model", "key", "chunk-hash", "[0,1,0]", 3, 41);
+  } finally {
+    db.close();
+  }
+}
+
+function readEmbeddingCacheRows(agentPath: string) {
+  const db = new DatabaseSync(agentPath);
+  try {
+    return db
+      .prepare(
+        `SELECT provider, model, provider_key, hash, embedding, dims, updated_at
+         FROM memory_embedding_cache
+         ORDER BY provider, model, provider_key, hash`,
+      )
+      .all();
+  } finally {
+    db.close();
+  }
+}
+
+function readDatabaseChecks(databasePath: string) {
+  const db = new DatabaseSync(databasePath, { readOnly: true });
+  try {
+    return {
+      quickCheck: db.prepare("PRAGMA quick_check").all(),
+      integrityCheck: db.prepare("PRAGMA integrity_check").all(),
+    };
+  } finally {
+    db.close();
+  }
+}
+
 async function createCanonicalLegacyMemoryRowsWithFts(agentPath: string, ftsText: string) {
   await fs.mkdir(path.dirname(agentPath), { recursive: true });
   const db = new DatabaseSync(agentPath);
@@ -1400,6 +1440,60 @@ describe("memory-core doctor dreaming migration", () => {
     const keywordRows = await searchMigratedKeywordRows(agentPath, "remember");
     expect(keywordRows.map((row) => row.id)).toEqual(["chunk-1"]);
     await expect(fs.access(`${legacyPath}.migrated`)).resolves.toBeUndefined();
+  });
+
+  it("keeps canonical embedding cache values while importing other legacy rows", async () => {
+    const stateDir = path.join(rootDir, "state");
+    const legacyPath = path.join(stateDir, "memory", "main.sqlite");
+    const archivedPath = `${legacyPath}.migrated`;
+    const agentPath = path.join(stateDir, "agents", "main", "agent", "openclaw-agent.sqlite");
+    await writeLegacyMemorySidecar(legacyPath);
+    await createUnrelatedCanonicalMemoryIndex(agentPath);
+    await seedCanonicalEmbeddingCacheConflict(agentPath);
+
+    const migration = legacyMemoryIndexMigration();
+    const result = await migration.migrateLegacyState(migrationParams());
+
+    expect(result.warnings).toEqual([]);
+    expect(result.changes).toEqual([
+      "Migrated Memory Core legacy memory index for agent main -> per-agent SQLite (1 source(s), 1 chunk(s), 1 cache row(s))",
+      expect.stringContaining("Archived Memory Core legacy memory index sidecar"),
+    ]);
+    expect(readMemoryRows(agentPath)).toEqual({
+      sources: [
+        { path: "MEMORY.md", source: "memory", hash: "file-hash" },
+        { path: "OTHER.md", source: "memory", hash: "canonical-other-file-hash" },
+      ],
+      chunks: [
+        { id: "canonical-other-chunk", text: "canonical unrelated memory" },
+        { id: "chunk-1", text: "remember this" },
+      ],
+      cache: [{ provider: "openai", hash: "chunk-hash" }],
+    });
+    expect(readEmbeddingCacheRows(agentPath)).toEqual([
+      {
+        provider: "openai",
+        model: "embed-model",
+        provider_key: "key",
+        hash: "chunk-hash",
+        embedding: "[0,1,0]",
+        dims: 3,
+        updated_at: 41,
+      },
+    ]);
+    expect(readDatabaseChecks(agentPath)).toEqual({
+      quickCheck: [{ quick_check: "ok" }],
+      integrityCheck: [{ integrity_check: "ok" }],
+    });
+    expect(readDatabaseChecks(archivedPath)).toEqual({
+      quickCheck: [{ quick_check: "ok" }],
+      integrityCheck: [{ integrity_check: "ok" }],
+    });
+
+    await expect(migration.migrateLegacyState(migrationParams())).resolves.toEqual({
+      changes: [],
+      warnings: [],
+    });
   });
 
   it("leaves legacy vector sidecars in place when vector dimensions conflict", async () => {

--- a/extensions/memory-core/doctor-contract-api.ts
+++ b/extensions/memory-core/doctor-contract-api.ts
@@ -500,6 +500,9 @@ function copyLegacyMemoryIndexRows(
       SELECT provider, model, provider_key, hash, embedding, dims, updated_at
       FROM ${schema}.embedding_cache;
     `);
+    // Cache rows are derived and keyed by their embedding inputs. If the
+    // canonical cache already has a key, keep its current value while still
+    // importing every non-conflicting legacy cache entry.
     assertLegacyRowsCopied(
       db,
       `SELECT COUNT(*) AS missing
@@ -510,9 +513,6 @@ function copyLegacyMemoryIndexRows(
            AND canonical.model = legacy.model
            AND canonical.provider_key = legacy.provider_key
            AND canonical.hash = legacy.hash
-           AND canonical.embedding IS legacy.embedding
-           AND canonical.dims IS legacy.dims
-           AND canonical.updated_at IS legacy.updated_at
        )`,
       "embedding_cache",
     );


### PR DESCRIPTION
## What Problem This Solves

Closes #107133.

Upgrading to 2026.7.1 can leave the Gateway unable to start when a legacy Memory Core sidecar and the canonical per-agent database contain the same embedding-cache key with different derived values or timestamps. The migration uses `INSERT OR IGNORE`, then incorrectly requires the ignored legacy row to match every canonical value, so Doctor reports a persistent migration warning and startup refuses readiness.

Related: #107220. That issue also covers `meta` and `chunks` conflicts; this change intentionally addresses only the derived embedding-cache case, where the existing cache key defines the identity and the canonical database is already authoritative.

## Why This Change Was Made

Embedding-cache rows are derived data keyed by `(provider, model, provider_key, hash)`. The migration now verifies that every legacy cache key exists after the import instead of requiring non-key cache values to be byte-identical. Existing canonical values win for duplicate keys, while non-conflicting legacy cache rows and unrelated legacy files/chunks still import inside the existing savepoint.

The strict conflict checks for source rows, chunks, FTS/vector rows, and metadata are unchanged.

## User Impact

Affected upgrades can converge through the normal migration path without deleting SQLite files or manually moving the legacy sidecar. The canonical embedding cache is preserved, unrelated legacy memory rows are imported, the sidecar is archived only after the transaction succeeds, and rerunning the migration is a no-op.

## Evidence

- Published `openclaw@2026.7.1` (`2d2ddc43d0dcf71f31283d780f9fe9ff4cc04fe4`, npm integrity `sha512-ge/Xss99CHAjPL/ikmH/UFoiOrjcxDB4sW3y9mhyCD+dYW3wzV7TKbAVdkrXFgAG2d2BjpJofP97zUZ+umxo8g==`) reproduced the warning with a seeded same-key/different-value cache conflict. Doctor exited 0 but left the legacy database in place and imported no legacy sources/chunks.
- Exact current-main RED at `21382b3755fafd7253339b2f3146b8667c5a7bde`: the focused regression failed with `legacy memory embedding_cache rows conflict with canonical memory index rows`.
- Focused GREEN: `extensions/memory-core/doctor-contract-api.test.ts` passed all 29 tests.
- Owner-suite GREEN: 103 test files, 1,423 tests passed.
- `pnpm check:changed` passed formatting, extension/test typechecks, lint, database-first guards, and import-cycle checks.
- Seeded candidate audit preserved the canonical cache row, imported the legacy source/chunk, archived the legacy database, returned `ok` from both `PRAGMA quick_check` and `PRAGMA integrity_check` on canonical and archived databases, and produced byte-identical verification output on a second Doctor run.
- Final base `4ed76a7ddb89604c35769e88d9d61c32e1a41d05` did not change either owner/test file from the fully tested base; their blob contents are byte-identical. The rebased candidate is `3072762c82526c0fce27804c6b3839f0002db49a`; its 29 focused tests and local `check:changed` gate passed on Node 24.15.0 / SQLite 3.51.3.

AI-assisted change. I reviewed the implementation, migration boundary, tests, and evidence.
