### PR TITLE
fix(ai): normalize non-conforming tool-call ids reaching Anthropic/Google targets (#95623)

### DIFF
--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -1331,7 +1331,7 @@ async function convertMessages(
   const cacheBreakpointOptOutParamIndexes = new Set<number>();
 
   // Transform messages for cross-provider compatibility
-  const transformedMessages = transformMessages(messages, model, normalizeToolCallId);
+  const transformedMessages = transformMessages(messages, model, normalizeToolCallId, true);
   const activeToolTurnAssistantIndex = replayThinkingEnabled
     ? -1
     : findActiveAnthropicToolTurnAssistantIndex(transformedMessages);

--- a/packages/ai/src/providers/google-shared.ts
+++ b/packages/ai/src/providers/google-shared.ts
@@ -170,7 +170,7 @@ export function convertMessages<T extends GoogleApiType>(
     return id.replace(/[^a-zA-Z0-9_-]/g, "_").slice(0, 64);
   };
 
-  const transformedMessages = transformMessages(context.messages, model, normalizeToolCallId);
+  const transformedMessages = transformMessages(context.messages, model, normalizeToolCallId, true);
 
   // Parallel calls need one immediate function-response turn. Gemini < 3 images cannot
   // live inside functionResponse, so hold them until the consecutive result run ends.

--- a/packages/ai/src/providers/transform-messages.test.ts
+++ b/packages/ai/src/providers/transform-messages.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from "vitest";
-import type { Message, Model } from "../types.js";
+import { describe, expect, it, vi } from "vitest";
+import type { AssistantMessage, Message, Model, ToolResultMessage } from "../types.js";
 import { transformMessages } from "./transform-messages.js";
 
 const model: Model<"openai-completions"> = {
@@ -49,5 +49,160 @@ describe("transformMessages", () => {
 
     expect(transformed).toHaveLength(3);
     expect(transformed.map((message) => message.content)).toEqual([[], [], []]);
+  });
+});
+
+// Covers tool-call-id normalization invariants for cross-provider replay (#95623).
+const anthropicModel: Model<"anthropic-messages"> = {
+  id: "claude-sonnet-5",
+  name: "Claude Sonnet 5",
+  api: "anthropic-messages",
+  provider: "anthropic",
+  baseUrl: "",
+  reasoning: true,
+  input: ["text", "image"],
+  cost: { input: 1, output: 2, cacheRead: 0.25, cacheWrite: 0 },
+  contextWindow: 200_000,
+  maxTokens: 8_192,
+};
+
+// Mirrors anthropic.ts / google-shared.ts normalizeToolCallId (charset scrub).
+const anthropicNormalize = (id: string): string => id.replace(/[^a-zA-Z0-9_-]/g, "_").slice(0, 64);
+
+// OpenAI-responses composite id — the `|` 400s the Anthropic API.
+const compositeId = "call_AbCd0123|fc_beef01";
+const scrubbedId = "call_AbCd0123_fc_beef01";
+
+function toolIds(out: Message[]): string[] {
+  const ids: string[] = [];
+  for (const m of out) {
+    if (m.role === "toolResult") {
+      ids.push(`result:${m.toolCallId}`);
+    }
+    if (m.role === "assistant" && Array.isArray(m.content)) {
+      for (const block of m.content) {
+        if (block.type === "toolCall") {
+          ids.push(`call:${block.id}`);
+        }
+      }
+    }
+  }
+  return ids;
+}
+
+function orphanToolResult(): Message {
+  return {
+    role: "toolResult",
+    toolCallId: compositeId,
+    toolName: "x",
+    content: [{ type: "text", text: "ok" }],
+  } as unknown as ToolResultMessage;
+}
+
+function sameModelCallAndResult(): Message[] {
+  return [
+    {
+      role: "assistant",
+      provider: "anthropic",
+      api: "anthropic-messages",
+      model: "claude-sonnet-5",
+      content: [{ type: "toolCall", id: compositeId, name: "x", arguments: {} }],
+    },
+    {
+      role: "toolResult",
+      toolCallId: compositeId,
+      toolName: "x",
+      content: [{ type: "text", text: "ok" }],
+    },
+  ] as unknown as Message[];
+}
+
+describe("transformMessages tool-call-id normalization (#95623)", () => {
+  it("S1: target-safe mode scrubs an orphaned non-conforming toolResult id", () => {
+    const out = transformMessages([orphanToolResult()], anthropicModel, anthropicNormalize, true);
+    const result = out.find((m) => m.role === "toolResult") as ToolResultMessage;
+    expect(result.toolCallId).toBe(scrubbedId);
+  });
+
+  it("S3: target-safe mode scrubs a same-model-tagged toolCall and keeps its result paired", () => {
+    const out = transformMessages(
+      sameModelCallAndResult(),
+      anthropicModel,
+      anthropicNormalize,
+      true,
+    );
+    expect(toolIds(out)).toEqual([`call:${scrubbedId}`, `result:${scrubbedId}`]);
+  });
+
+  it("regression: default mode leaves a same-model composite id untouched", () => {
+    const out = transformMessages(sameModelCallAndResult(), anthropicModel, anthropicNormalize);
+    expect(toolIds(out)).toEqual([`call:${compositeId}`, `result:${compositeId}`]);
+  });
+
+  it("regression: cross-provider pair still normalizes both ids via the map", () => {
+    const msgs = [
+      {
+        role: "assistant",
+        provider: "openai",
+        api: "openai-responses",
+        model: "gpt-5",
+        content: [{ type: "toolCall", id: compositeId, name: "x", arguments: {} }],
+      },
+      {
+        role: "toolResult",
+        toolCallId: compositeId,
+        toolName: "x",
+        content: [{ type: "text", text: "ok" }],
+      },
+    ] as unknown as Message[];
+    const out = transformMessages(msgs, anthropicModel, anthropicNormalize);
+    expect(toolIds(out)).toEqual([`call:${scrubbedId}`, `result:${scrubbedId}`]);
+  });
+
+  it("regression: default mode never invokes a source-requiring normalizer on a map-miss result", () => {
+    const normalizer = vi.fn(
+      (id: string, _model: Model<"anthropic-messages">, source?: AssistantMessage) => {
+        // openai-responses reads source.provider; a source-less call would break it.
+        void source?.provider;
+        return id.replace(/[^a-zA-Z0-9_-]/g, "_");
+      },
+    );
+    const out = transformMessages([orphanToolResult()], anthropicModel, normalizer);
+    const result = out.find((m) => m.role === "toolResult") as ToolResultMessage;
+    expect(result.toolCallId).toBe(compositeId);
+    expect(normalizer).not.toHaveBeenCalled();
+  });
+
+  it("SDK compat: default mode still accepts the existing required-`source` plugin normalizer (#95623)", () => {
+    // `plugin-sdk/llm` re-exports transformMessages; existing provider plugins pass a
+    // normalizer whose `source` is required. Widening it back to optional makes this
+    // explicitly-typed callback un-assignable under strict function checks, so this call
+    // is a compile-time guard for the public SDK callback contract (the default overload).
+    const requiredSourceNormalizer: (
+      id: string,
+      model: Model<"anthropic-messages">,
+      source: AssistantMessage,
+    ) => string = (id, _model, source) =>
+      source.provider === anthropicModel.provider ? id : id.replace(/[^a-zA-Z0-9_-]/g, "_");
+    const out = transformMessages(
+      [
+        {
+          role: "assistant",
+          provider: "openai",
+          api: "openai-responses",
+          model: "gpt-5",
+          content: [{ type: "toolCall", id: compositeId, name: "x", arguments: {} }],
+        },
+        {
+          role: "toolResult",
+          toolCallId: compositeId,
+          toolName: "x",
+          content: [{ type: "text", text: "ok" }],
+        },
+      ] as unknown as Message[],
+      anthropicModel,
+      requiredSourceNormalizer,
+    );
+    expect(toolIds(out)).toEqual([`call:${scrubbedId}`, `result:${scrubbedId}`]);
   });
 });

--- a/packages/ai/src/providers/transform-messages.ts
+++ b/packages/ai/src/providers/transform-messages.ts
@@ -72,11 +72,19 @@ function downgradeUnsupportedImages<TApi extends Api>(
  * Normalize tool call ID for cross-provider compatibility.
  * OpenAI Responses API generates IDs that are 450+ chars with special characters like `|`.
  * Anthropic APIs require IDs matching ^[a-zA-Z0-9_-]+$ (max 64 chars).
+ *
+ * `plugin-sdk/llm` re-exports this helper, so `normalizeToolCallId` keeps its required-`source`
+ * contract that existing provider plugins already implement. `targetSafeToolCallIds` is an
+ * additive opt-in (default off): when the normalizer is a charset scrub idempotent on the
+ * target's own native ids (Anthropic/Google), it is applied to every tool id reaching the
+ * target — same-model-tagged calls and orphaned results included — so other providers'
+ * non-idempotent/source-aware normalizers never rewrite valid native same-model ids (#95623).
  */
 export function transformMessages<TApi extends Api>(
   messages: Message[],
   model: Model<TApi>,
   normalizeToolCallId?: (id: string, model: Model<TApi>, source: AssistantMessage) => string,
+  targetSafeToolCallIds = false,
 ): Message[] {
   // Build a map of original tool call IDs to normalized IDs
   const toolCallIdMap = new Map<string, string>();
@@ -92,9 +100,19 @@ export function transformMessages<TApi extends Api>(
       return msg;
     }
 
-    // Handle toolResult messages - normalize toolCallId if we have a mapping
+    // Handle toolResult messages - normalize toolCallId from the map, or
+    // (target-safe) scrub directly when the paired call is absent (orphan result).
     if (msg.role === "toolResult") {
-      const normalizedId = toolCallIdMap.get(msg.toolCallId);
+      const mappedId = toolCallIdMap.get(msg.toolCallId);
+      // Target-safe normalizers (Anthropic/Google) are source-independent charset scrubs, so an
+      // orphaned result with no paired assistant call is normalized without a `source`. Cast to
+      // the source-less shape rather than widen the public `source`-required callback contract.
+      const scrubOrphanId = normalizeToolCallId as
+        | ((id: string, model: Model<TApi>) => string)
+        | undefined;
+      const normalizedId =
+        mappedId ??
+        (targetSafeToolCallIds && scrubOrphanId ? scrubOrphanId(msg.toolCallId, model) : undefined);
       if (normalizedId && normalizedId !== msg.toolCallId) {
         return Object.assign({}, msg, { toolCallId: normalizedId });
       }
@@ -179,7 +197,7 @@ export function transformMessages<TApi extends Api>(
             delete (normalizedToolCall as { thoughtSignature?: string }).thoughtSignature;
           }
 
-          if (!isSameModel && normalizeToolCallId) {
+          if ((targetSafeToolCallIds || !isSameModel) && normalizeToolCallId) {
             const normalizedId = normalizeToolCallId(toolCall.id, model, assistantMsg);
             if (normalizedId !== toolCall.id) {
               toolCallIdMap.set(toolCall.id, normalizedId);


### PR DESCRIPTION
Fixes #95623

## What Problem This Solves

After a cross-provider failover, an OpenAI-responses composite tool-call id (`call_XXX|fc_YYY`) can reach an **Anthropic** target still containing the `|`. Anthropic requires tool ids matching `^[a-zA-Z0-9_-]+$`, so it hard-400s the whole replay and the session is bricked for its own primary provider — no new turns without a reset.

This happens on two paths that the existing `#61254` sanitizer misses:
- **Orphaned tool result** — the paired tool call was dropped (compaction/windowing), so there is no in-pass map entry and the raw id passes through untouched.
- **Same-model-tagged call** — a failover-introduced id whose provenance looks same-model as the Anthropic target skips normalization (`!isSameModel` guard), so both the call and its result keep the `|`.

## Why This Change Was Made

`packages/ai/src/providers/transform-messages.ts` owns cross-provider tool-call-id normalization but only normalized `toolCall` ids when `!isSameModel`, and `toolResult` ids only via an in-pass `toolCallIdMap`. Non-conforming ids leaked through both gaps.

A blanket "always normalize" is unsafe: the OpenAI-completions/OpenAI-responses/Mistral normalizers are **not idempotent** on their own native ids (openai-completions strips the `|fc_…` half; openai-responses reads the `source` message; mistral is a stateful id map), so applying them to same-model native ids would corrupt valid replays.

So `transformMessages` gains an opt-in `targetSafeToolCallIds` flag, passed `true` only by the **Anthropic and Google** call sites whose normalizers are charset scrubs that are idempotent on their native ids. In target-safe mode every tool id reaching the target is normalized — the same-model call and the map-miss result included — and because the scrub is deterministic, a call and its result stay paired. Every other provider keeps the default (`false`), so their behavior is byte-for-byte unchanged.

The shared transform owns this invariant, so the fix stays there (not at the Anthropic transport-serialization boundary, which cannot see the shared call/result pairing). Non-goals: no change to any provider's normalizer semantics, no change to cross-provider behavior, and no id-collision hashing.

## User Impact

Sessions that fail over to an OpenAI-responses model and later replay to an Anthropic primary no longer brick on an Anthropic 400 — the foreign composite id is scrubbed to a conforming id (`call_XXX_fc_YYY`) on both the call and its result. Google targets get the same protection. OpenAI/Mistral users are unaffected.

## Evidence

Real behavior via the actual `transformMessages` (Anthropic target, composite id `call_AbCd0123|fc_beef01`), head `e7e315d6c5a3`:

~~~text
AFTER S1-safe orphan (targetSafe=true):          ["result:call_AbCd0123_fc_beef01"]                                | PIPE-SURVIVES=false
AFTER S3-safe same-model-mistag (targetSafe=true): ["call:call_AbCd0123_fc_beef01","result:call_AbCd0123_fc_beef01"] | PIPE-SURVIVES=false
REGRESSION default (targetSafe=false) same-model:  ["call:call_AbCd0123|fc_beef01","result:call_AbCd0123|fc_beef01"] | PIPE-SURVIVES=true
~~~

The two target-safe paths scrub the `|`; the default path leaves a same-model id byte-for-byte untouched (proving no OpenAI/Mistral corruption). On current `main` (target-safe absent) both S1 and S3 leak — `PIPE-SURVIVES=true`.

- `vitest run packages/ai/src/providers/transform-messages.test.ts` — 5 passed (2 red-first #95623 guards for S1/S3 + 3 regressions: default-mode composite untouched, cross-provider pair still mapped, source-requiring normalizer never invoked on a map-miss result).
- Negative control: with the source fix stashed, the S1 & S3 guard tests fail (`expected 'call_AbCd0123|fc_beef01' to be 'call_AbCd0123_fc_beef01'`) — confirms the tests guard the bug.
- Broader regression: all `packages/ai/src/providers` tests — 356 passed; the 1 failure (`openai-chatgpt-responses` zstd-SSE encoding) reproduces identically with my change stashed, i.e. pre-existing/unrelated (a zstd env issue on this host).
- `tsgo -p tsconfig.core.json` / `-p test/tsconfig/tsconfig.core.test.json` — no errors; `oxfmt --check` — clean; `check:loc` — passes (all growth in the sub-500-line transform; the three oversized provider files stay net-zero).

## Notes

- Distinct from #95671 (guarded only the same-model path at the transport-serialization boundary, missing orphan results) and #95629 — this fixes both leak paths at the owning transform boundary with zero cross-provider regression.
- AI-assisted (Claude Code); I have reviewed and understand every line.
