### PR TITLE
fix(agents): skip error classification for clean non-zero exits

### DIFF
--- a/src/agents/embedded-agent-subscribe.tools.test.ts
+++ b/src/agents/embedded-agent-subscribe.tools.test.ts
@@ -195,8 +195,11 @@ describe("isToolResultError", () => {
     expect(isToolResultError({ details: { status: "blocked" } })).toBe(true);
     expect(isToolResultError({ details: { status: "approval-unavailable" } })).toBe(true);
     expect(isToolResultError({ details: { status: "completed", timedOut: true } })).toBe(true);
-    expect(isToolResultError({ details: { status: "completed", exitCode: 1 } })).toBe(true);
+    // Non-zero exit with "completed" status is a clean exit, not an error.
+    expect(isToolResultError({ details: { status: "completed", exitCode: 1 } })).toBe(false);
     expect(isToolResultError({ details: { status: "completed", exitCode: 0 } })).toBe(false);
+    // Non-zero exit without a completed status is still an error.
+    expect(isToolResultError({ details: { exitCode: 1 } })).toBe(true);
     expect(isToolResultError({ details: { ok: true, status: "cancelled" } })).toBe(false);
     expect(isToolResultError({ details: { success: true, status: "canceled" } })).toBe(false);
     expect(isToolResultError({ details: { ok: false, status: "completed" } })).toBe(true);

--- a/src/agents/tool-result-error.ts
+++ b/src/agents/tool-result-error.ts
@@ -109,7 +109,15 @@ export function isToolResultError(result: unknown): boolean {
     return true;
   }
   const exitCode = details ? readToolErrorField(details, "exitCode") : undefined;
-  return typeof exitCode === "number" && Number.isFinite(exitCode) && exitCode !== 0;
+  if (typeof exitCode !== "number" || !Number.isFinite(exitCode) || exitCode === 0) {
+    return false;
+  }
+  // The exec runtime already classifies clean non-zero exits as completed.
+  // Defer to that classification instead of treating every non-zero exit as an error.
+  if (readToolResultStatus(result) === "completed") {
+    return false;
+  }
+  return true;
 }
 
 export type ToolResultFailureKind = "blocked" | "cancelled" | "failed" | "timed_out";


### PR DESCRIPTION
## What Problem This Solves

Tools executing commands that exit with code 1 for non-failure reasons (e.g. `grep` finding no matches, `git rebase` conflict) trigger spurious `⚠️ Exec failed` notifications in Discord/Telegram channels. The exec runtime already correctly classifies these as `status: "completed"`, but `isToolResultError()` ignores the runtime's classification and treats every non-zero exitCode as an error.

Fixes #107278.

## Evidence

```bash
$ npx vitest run src/agents/tool-result-error.test.ts src/agents/embedded-agent-subscribe.tools.test.ts --no-coverage

 Test Files  3 passed (3)
      Tests  82 passed (82)
```

Test coverage for `isToolResultError` exitCode behavior:

| Input | Before | After | Rationale |
|---|---|---|---|
| `{ status: "completed", exitCode: 1 }` | `true` (error) | `false` | Clean exit, not an error |
| `{ status: "completed", exitCode: 0 }` | `false` | `false` | Zero exit, unchanged |
| `{ exitCode: 1 }` | `true` | `true` | Non-zero without completed status still an error |
| `{ ok: false, status: "completed" }` | `true` | `true` | Explicit `ok: false` still an error |

## Why This Change Was Made

The exec runtime in `bash-tools.exec-runtime.ts` already distinguishes clean non-zero exits (`status: "completed"`, `reason: "exit"`) from real failures (`status: "failed"`). `isToolResultError()` was overriding this classification by checking exitCode alone. The fix defers to the runtime's own status classification when a non-zero exit is cleanly completed.

## Merge Risk

Low. This is a guard fix that narrows the error classification scope, not expands it. The only behavior change is that clean non-zero exits no longer trigger spurious error notifications. Real failures (`status: "failed"`, `ok: false`, `timedOut: true`, etc.) are completely unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)