### PR TITLE
fix(doctor): preserve allowlist entries for version-bound runtime plugins during stale config scan

### DIFF
--- a/scripts/e2e/lib/upgrade-survivor/assertions.mjs
+++ b/scripts/e2e/lib/upgrade-survivor/assertions.mjs
@@ -11,6 +11,7 @@ const SCENARIOS = new Set([
   "feishu-channel",
   "bootstrap-persona",
   "channel-post-core-restore",
+  "codex-allowlist-survival",
   "plugin-deps-cleanup",
   "configured-plugin-installs",
   "stale-source-plugin-shadow",
@@ -307,6 +308,9 @@ function assertConfigSurvived() {
       assert(pluginAllow.includes("matrix"), "matrix plugin allow entry missing");
     } else {
       assert(pluginAllow.includes("whatsapp"), "whatsapp plugin allow entry missing");
+    }
+    if (getScenario() === "codex-allowlist-survival") {
+      assert(pluginAllow.includes("codex"), "Codex plugin allow entry missing");
     }
     if (hasCoverage(coverage) && acceptsIntent(coverage, "feishu-channel")) {
       assert(pluginAllow.includes("feishu"), "feishu plugin allow entry missing");

--- a/scripts/e2e/lib/upgrade-survivor/config-recipe.d.mts
+++ b/scripts/e2e/lib/upgrade-survivor/config-recipe.d.mts
@@ -1,5 +1,10 @@
 #!/usr/bin/env node
 export function isReleaseBefore(version: unknown, minimum: unknown): boolean;
+export function resolveScenarioConfigSteps(scenario: string): Array<{
+  id: string;
+  intent: string;
+  argv: string[];
+}>;
 export function resolveUpgradeSurvivorOpenClawCommand(
   argv: unknown,
   params?: Record<string, unknown>,

--- a/scripts/e2e/lib/upgrade-survivor/config-recipe.mjs
+++ b/scripts/e2e/lib/upgrade-survivor/config-recipe.mjs
@@ -163,7 +163,27 @@ const scenarioConfigSteps = new Map([
       ),
     ],
   ],
+  [
+    "codex-allowlist-survival",
+    [
+      {
+        id: "plugins-codex-allowlist",
+        intent: "codex-allowlist-survival",
+        argv: [
+          "config",
+          "set",
+          "plugins.allow",
+          JSON.stringify(["discord", "memory", "telegram", "whatsapp", "codex"]),
+          "--strict-json",
+        ],
+      },
+    ],
+  ],
 ]);
+
+export function resolveScenarioConfigSteps(scenario) {
+  return scenarioConfigSteps.get(scenario) ?? [];
+}
 
 const recipe = [
   {
@@ -289,7 +309,7 @@ function applyRecipe() {
   const summaryPath = option("--summary");
   const baselineVersion = option("--baseline-version", null);
   const scenario = selectedScenario();
-  const scenarioSteps = scenarioConfigSteps.get(scenario) ?? [];
+  const scenarioSteps = resolveScenarioConfigSteps(scenario);
   const summary = {
     source: "baseline-cli-command-recipe",
     recipe: "upgrade-survivor-v1",

--- a/src/commands/doctor-config-flow.test.ts
+++ b/src/commands/doctor-config-flow.test.ts
@@ -691,7 +691,10 @@ vi.mock("./doctor/shared/context-engine-host-compat.js", () => ({
   })),
 }));
 
-vi.mock("./doctor/shared/missing-configured-plugin-install.js", () => ({
+vi.mock("./doctor/shared/missing-configured-plugin-install.js", async (importOriginal) => ({
+  ...(await importOriginal<
+    typeof import("./doctor/shared/missing-configured-plugin-install.js")
+  >()),
   repairMissingConfiguredPluginInstalls: vi.fn(async ({ cfg }) => ({
     config: cfg,
     changes: [],

--- a/src/commands/doctor-config-flow.test.ts
+++ b/src/commands/doctor-config-flow.test.ts
@@ -691,10 +691,7 @@ vi.mock("./doctor/shared/context-engine-host-compat.js", () => ({
   })),
 }));
 
-vi.mock("./doctor/shared/missing-configured-plugin-install.js", async (importOriginal) => ({
-  ...(await importOriginal<
-    typeof import("./doctor/shared/missing-configured-plugin-install.js")
-  >()),
+vi.mock("./doctor/shared/missing-configured-plugin-install.js", () => ({
   repairMissingConfiguredPluginInstalls: vi.fn(async ({ cfg }) => ({
     config: cfg,
     changes: [],

--- a/src/commands/doctor/repair-sequencing.test.ts
+++ b/src/commands/doctor/repair-sequencing.test.ts
@@ -49,8 +49,7 @@ vi.mock("../doctor-auth-flat-profiles.js", () => ({
   maybeRepairOpenAICodexAuthProfileStores: mocks.maybeRepairOpenAICodexAuthProfileStores,
 }));
 
-vi.mock("./shared/missing-configured-plugin-install.js", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("./shared/missing-configured-plugin-install.js")>()),
+vi.mock("./shared/missing-configured-plugin-install.js", () => ({
   repairMissingConfiguredPluginInstalls: mocks.repairMissingConfiguredPluginInstalls,
 }));
 

--- a/src/commands/doctor/repair-sequencing.test.ts
+++ b/src/commands/doctor/repair-sequencing.test.ts
@@ -983,10 +983,17 @@ describe("doctor repair sequencing", () => {
       (
         cfg: OpenClawConfig,
         _env: NodeJS.ProcessEnv | undefined,
-        params: { preservePluginIds?: string[]; surfacePreservePluginIds?: { allow?: string[] } },
+        params: {
+          preservePluginIds?: string[];
+          surfacePreservePluginIds?: { allow?: string[]; deny?: string[]; entries?: string[] };
+        },
       ) => {
         expect(params.preservePluginIds).toEqual(["brave"]);
-        expect(params.surfacePreservePluginIds).toEqual({ allow: new Set(["codex"]) });
+        expect(params.surfacePreservePluginIds).toEqual({
+          allow: new Set(["codex"]),
+          deny: new Set(["codex"]),
+          entries: new Set(["codex"]),
+        });
         return {
           config: {
             ...cfg,
@@ -1079,10 +1086,17 @@ describe("doctor repair sequencing", () => {
       (
         cfg: OpenClawConfig,
         _env: NodeJS.ProcessEnv | undefined,
-        params: { preservePluginIds?: string[]; surfacePreservePluginIds?: { allow?: string[] } },
+        params: {
+          preservePluginIds?: string[];
+          surfacePreservePluginIds?: { allow?: string[]; deny?: string[]; entries?: string[] };
+        },
       ) => {
         expect(params.preservePluginIds).toEqual(["whatsapp"]);
-        expect(params.surfacePreservePluginIds).toEqual({ allow: new Set(["codex"]) });
+        expect(params.surfacePreservePluginIds).toEqual({
+          allow: new Set(["codex"]),
+          deny: new Set(["codex"]),
+          entries: new Set(["codex"]),
+        });
         return {
           config: cfg,
           changes: [],

--- a/src/commands/doctor/repair-sequencing.test.ts
+++ b/src/commands/doctor/repair-sequencing.test.ts
@@ -49,7 +49,8 @@ vi.mock("../doctor-auth-flat-profiles.js", () => ({
   maybeRepairOpenAICodexAuthProfileStores: mocks.maybeRepairOpenAICodexAuthProfileStores,
 }));
 
-vi.mock("./shared/missing-configured-plugin-install.js", () => ({
+vi.mock("./shared/missing-configured-plugin-install.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./shared/missing-configured-plugin-install.js")>()),
   repairMissingConfiguredPluginInstalls: mocks.repairMissingConfiguredPluginInstalls,
 }));
 
@@ -985,7 +986,7 @@ describe("doctor repair sequencing", () => {
         _env: NodeJS.ProcessEnv | undefined,
         params: { preservePluginIds?: string[] },
       ) => {
-        expect(params.preservePluginIds).toEqual(["brave"]);
+        expect(params.preservePluginIds).toEqual(["brave", "codex"]);
         return {
           config: {
             ...cfg,
@@ -1080,7 +1081,7 @@ describe("doctor repair sequencing", () => {
         _env: NodeJS.ProcessEnv | undefined,
         params: { preservePluginIds?: string[] },
       ) => {
-        expect(params.preservePluginIds).toEqual(["whatsapp"]);
+        expect(params.preservePluginIds).toEqual(["whatsapp", "codex"]);
         return {
           config: cfg,
           changes: [],

--- a/src/commands/doctor/repair-sequencing.test.ts
+++ b/src/commands/doctor/repair-sequencing.test.ts
@@ -984,9 +984,10 @@ describe("doctor repair sequencing", () => {
       (
         cfg: OpenClawConfig,
         _env: NodeJS.ProcessEnv | undefined,
-        params: { preservePluginIds?: string[] },
+        params: { preservePluginIds?: string[]; surfacePreservePluginIds?: { allow?: string[] } },
       ) => {
-        expect(params.preservePluginIds).toEqual(["brave", "codex"]);
+        expect(params.preservePluginIds).toEqual(["brave"]);
+        expect(params.surfacePreservePluginIds).toEqual({ allow: new Set(["codex"]) });
         return {
           config: {
             ...cfg,
@@ -1079,9 +1080,10 @@ describe("doctor repair sequencing", () => {
       (
         cfg: OpenClawConfig,
         _env: NodeJS.ProcessEnv | undefined,
-        params: { preservePluginIds?: string[] },
+        params: { preservePluginIds?: string[]; surfacePreservePluginIds?: { allow?: string[] } },
       ) => {
-        expect(params.preservePluginIds).toEqual(["whatsapp", "codex"]);
+        expect(params.preservePluginIds).toEqual(["whatsapp"]);
+        expect(params.surfacePreservePluginIds).toEqual({ allow: new Set(["codex"]) });
         return {
           config: cfg,
           changes: [],

--- a/src/commands/doctor/repair-sequencing.ts
+++ b/src/commands/doctor/repair-sequencing.ts
@@ -28,15 +28,13 @@ import {
   applyDoctorConfigMutation,
   type DoctorConfigMutationState,
 } from "./shared/config-mutation-state.js";
+import { VERSION_BOUND_RUNTIME_PLUGIN_IDS } from "./shared/configured-runtime-plugin-installs.js";
 import { maybeRepairContextEngineHostCompatibility } from "./shared/context-engine-host-compat.js";
 import { scanEmptyAllowlistPolicyWarnings } from "./shared/empty-allowlist-scan.js";
 import { maybeRepairExecSafeBinProfiles } from "./shared/exec-safe-bins.js";
 import { maybeRepairInvalidPluginConfig } from "./shared/invalid-plugin-config.js";
 import { maybeRepairLegacyToolsBySenderKeys } from "./shared/legacy-tools-by-sender.js";
-import {
-  repairMissingConfiguredPluginInstalls,
-  VERSION_BOUND_RUNTIME_PLUGIN_IDS,
-} from "./shared/missing-configured-plugin-install.js";
+import { repairMissingConfiguredPluginInstalls } from "./shared/missing-configured-plugin-install.js";
 import { maybeRepairOpenPolicyAllowFrom } from "./shared/open-policy-allowfrom.js";
 import { cleanupLegacyPluginDependencyState } from "./shared/plugin-dependency-cleanup.js";
 import { maybeRepairStaleConfiguredAuthOrders } from "./shared/stale-auth-order.js";
@@ -158,6 +156,8 @@ export async function runDoctorRepairSequence(params: {
     applyMutation(
       maybeRepairStalePluginConfig(state.candidate, env, {
         preservePluginIds: failedPluginIds,
+        // A host-version-bound runtime can be absent between core swap and package
+        // convergence. Preserve only allowlist intent; other stale surfaces still clean up.
         surfacePreservePluginIds: { allow: VERSION_BOUND_RUNTIME_PLUGIN_IDS },
       }),
     );

--- a/src/commands/doctor/repair-sequencing.ts
+++ b/src/commands/doctor/repair-sequencing.ts
@@ -33,7 +33,10 @@ import { scanEmptyAllowlistPolicyWarnings } from "./shared/empty-allowlist-scan.
 import { maybeRepairExecSafeBinProfiles } from "./shared/exec-safe-bins.js";
 import { maybeRepairInvalidPluginConfig } from "./shared/invalid-plugin-config.js";
 import { maybeRepairLegacyToolsBySenderKeys } from "./shared/legacy-tools-by-sender.js";
-import { repairMissingConfiguredPluginInstalls } from "./shared/missing-configured-plugin-install.js";
+import {
+  repairMissingConfiguredPluginInstalls,
+  VERSION_BOUND_RUNTIME_PLUGIN_IDS,
+} from "./shared/missing-configured-plugin-install.js";
 import { maybeRepairOpenPolicyAllowFrom } from "./shared/open-policy-allowfrom.js";
 import { cleanupLegacyPluginDependencyState } from "./shared/plugin-dependency-cleanup.js";
 import { maybeRepairStaleConfiguredAuthOrders } from "./shared/stale-auth-order.js";
@@ -154,7 +157,7 @@ export async function runDoctorRepairSequence(params: {
   if (!isUpdatePackageSwapInProgress(env) && !hasUnscopedInstallRepairWarnings) {
     applyMutation(
       maybeRepairStalePluginConfig(state.candidate, env, {
-        preservePluginIds: failedPluginIds,
+        preservePluginIds: [...failedPluginIds, ...VERSION_BOUND_RUNTIME_PLUGIN_IDS],
       }),
     );
   }

--- a/src/commands/doctor/repair-sequencing.ts
+++ b/src/commands/doctor/repair-sequencing.ts
@@ -28,7 +28,7 @@ import {
   applyDoctorConfigMutation,
   type DoctorConfigMutationState,
 } from "./shared/config-mutation-state.js";
-import { VERSION_BOUND_RUNTIME_PLUGIN_IDS } from "./shared/configured-runtime-plugin-installs.js";
+import { VERSION_BOUND_RUNTIME_PLUGIN_POLICY_IDS_BY_SURFACE } from "./shared/configured-runtime-plugin-installs.js";
 import { maybeRepairContextEngineHostCompatibility } from "./shared/context-engine-host-compat.js";
 import { scanEmptyAllowlistPolicyWarnings } from "./shared/empty-allowlist-scan.js";
 import { maybeRepairExecSafeBinProfiles } from "./shared/exec-safe-bins.js";
@@ -158,11 +158,7 @@ export async function runDoctorRepairSequence(params: {
         preservePluginIds: failedPluginIds,
         // A host-version-bound runtime can be absent between core swap and package
         // convergence. Preserve its allow, deny, and explicit enable/disable policy.
-        surfacePreservePluginIds: {
-          allow: VERSION_BOUND_RUNTIME_PLUGIN_IDS,
-          deny: VERSION_BOUND_RUNTIME_PLUGIN_IDS,
-          entries: VERSION_BOUND_RUNTIME_PLUGIN_IDS,
-        },
+        surfacePreservePluginIds: VERSION_BOUND_RUNTIME_PLUGIN_POLICY_IDS_BY_SURFACE,
       }),
     );
   }

--- a/src/commands/doctor/repair-sequencing.ts
+++ b/src/commands/doctor/repair-sequencing.ts
@@ -157,8 +157,12 @@ export async function runDoctorRepairSequence(params: {
       maybeRepairStalePluginConfig(state.candidate, env, {
         preservePluginIds: failedPluginIds,
         // A host-version-bound runtime can be absent between core swap and package
-        // convergence. Preserve only allowlist intent; other stale surfaces still clean up.
-        surfacePreservePluginIds: { allow: VERSION_BOUND_RUNTIME_PLUGIN_IDS },
+        // convergence. Preserve its allow, deny, and explicit enable/disable policy.
+        surfacePreservePluginIds: {
+          allow: VERSION_BOUND_RUNTIME_PLUGIN_IDS,
+          deny: VERSION_BOUND_RUNTIME_PLUGIN_IDS,
+          entries: VERSION_BOUND_RUNTIME_PLUGIN_IDS,
+        },
       }),
     );
   }

--- a/src/commands/doctor/repair-sequencing.ts
+++ b/src/commands/doctor/repair-sequencing.ts
@@ -157,7 +157,8 @@ export async function runDoctorRepairSequence(params: {
   if (!isUpdatePackageSwapInProgress(env) && !hasUnscopedInstallRepairWarnings) {
     applyMutation(
       maybeRepairStalePluginConfig(state.candidate, env, {
-        preservePluginIds: [...failedPluginIds, ...VERSION_BOUND_RUNTIME_PLUGIN_IDS],
+        preservePluginIds: failedPluginIds,
+        surfacePreservePluginIds: { allow: VERSION_BOUND_RUNTIME_PLUGIN_IDS },
       }),
     );
   }

--- a/src/commands/doctor/shared/configured-runtime-plugin-installs.ts
+++ b/src/commands/doctor/shared/configured-runtime-plugin-installs.ts
@@ -20,6 +20,8 @@ type ConfiguredRuntimePluginInstallCandidate = {
   trustedSourceLinkedOfficialInstall?: boolean;
   /** Default installer choice when multiple official sources are available. */
   defaultChoice?: PluginPackageInstall["defaultChoice"];
+  /** Keep this official runtime package on the same release cohort as OpenClaw. */
+  versionBoundToOpenClaw?: boolean;
 };
 
 export const CONFIGURED_RUNTIME_PLUGIN_INSTALL_CANDIDATES: readonly ConfiguredRuntimePluginInstallCandidate[] =
@@ -36,8 +38,15 @@ export const CONFIGURED_RUNTIME_PLUGIN_INSTALL_CANDIDATES: readonly ConfiguredRu
       label: "Codex",
       npmSpec: "@openclaw/codex",
       trustedSourceLinkedOfficialInstall: true,
+      versionBoundToOpenClaw: true,
     },
   ];
+
+export const VERSION_BOUND_RUNTIME_PLUGIN_IDS: ReadonlySet<string> = new Set(
+  CONFIGURED_RUNTIME_PLUGIN_INSTALL_CANDIDATES.filter(
+    (candidate) => candidate.versionBoundToOpenClaw,
+  ).map((candidate) => candidate.pluginId),
+);
 
 /** Resolve the official install candidate for a configured runtime id. */
 export function resolveConfiguredRuntimePluginInstallCandidate(

--- a/src/commands/doctor/shared/configured-runtime-plugin-installs.ts
+++ b/src/commands/doctor/shared/configured-runtime-plugin-installs.ts
@@ -48,6 +48,12 @@ export const VERSION_BOUND_RUNTIME_PLUGIN_IDS: ReadonlySet<string> = new Set(
   ).map((candidate) => candidate.pluginId),
 );
 
+export const VERSION_BOUND_RUNTIME_PLUGIN_POLICY_IDS_BY_SURFACE = {
+  allow: VERSION_BOUND_RUNTIME_PLUGIN_IDS,
+  deny: VERSION_BOUND_RUNTIME_PLUGIN_IDS,
+  entries: VERSION_BOUND_RUNTIME_PLUGIN_IDS,
+} as const;
+
 /** Resolve the official install candidate for a configured runtime id. */
 export function resolveConfiguredRuntimePluginInstallCandidate(
   runtimeId: string,

--- a/src/commands/doctor/shared/missing-configured-plugin-install.ts
+++ b/src/commands/doctor/shared/missing-configured-plugin-install.ts
@@ -78,6 +78,7 @@ import { collectConfiguredProviderPluginIds } from "./configured-provider-plugin
 import {
   collectConfiguredRuntimePluginIds,
   CONFIGURED_RUNTIME_PLUGIN_INSTALL_CANDIDATES,
+  VERSION_BOUND_RUNTIME_PLUGIN_IDS,
 } from "./configured-runtime-plugin-installs.js";
 import { asObjectRecord } from "./object.js";
 import {
@@ -108,7 +109,6 @@ const REPAIRABLE_PACKAGE_ENTRY_DIAGNOSTIC_MARKERS = [
   "extension entry unreadable",
   "requires compiled runtime output",
 ] as const;
-export const VERSION_BOUND_RUNTIME_PLUGIN_IDS = new Set(["codex"]);
 const OPENCLAW_BETA_COMPANION_VERSION_RE = /^(\d{4}\.[1-9]\d?\.[1-9]\d?)-beta\.[1-9]\d*$/;
 const OPENCLAW_STABLE_OR_BETA_COMPANION_VERSION_RE =
   /^(\d{4}\.[1-9]\d?\.[1-9]\d?)(?:-beta\.[1-9]\d*)?$/;

--- a/src/commands/doctor/shared/missing-configured-plugin-install.ts
+++ b/src/commands/doctor/shared/missing-configured-plugin-install.ts
@@ -108,7 +108,7 @@ const REPAIRABLE_PACKAGE_ENTRY_DIAGNOSTIC_MARKERS = [
   "extension entry unreadable",
   "requires compiled runtime output",
 ] as const;
-const VERSION_BOUND_RUNTIME_PLUGIN_IDS = new Set(["codex"]);
+export const VERSION_BOUND_RUNTIME_PLUGIN_IDS = new Set(["codex"]);
 const OPENCLAW_BETA_COMPANION_VERSION_RE = /^(\d{4}\.[1-9]\d?\.[1-9]\d?)-beta\.[1-9]\d*$/;
 const OPENCLAW_STABLE_OR_BETA_COMPANION_VERSION_RE =
   /^(\d{4}\.[1-9]\d?\.[1-9]\d?)(?:-beta\.[1-9]\d*)?$/;

--- a/src/commands/doctor/shared/preview-warnings.test.ts
+++ b/src/commands/doctor/shared/preview-warnings.test.ts
@@ -235,14 +235,18 @@ vi.mock("./stale-plugin-config.js", () => ({
     channels?: Record<string, unknown>;
   }) => {
     const knownIds = new Set(manifestState.plugins.map((plugin) => plugin.id));
-    const hits = [...(cfg.plugins?.allow ?? []), ...Object.keys(cfg.plugins?.entries ?? {})]
-      .filter((id) => !knownIds.has(id))
-      .map((id) => ({ id, surface: "plugin" }));
+    const hits = [
+      ...(cfg.plugins?.allow ?? []).map((id) => ({ id, surface: "allow" })),
+      ...Object.keys(cfg.plugins?.entries ?? {}).map((id) => ({ id, surface: "entries" })),
+    ].filter((hit) => !knownIds.has(hit.id));
     if (cfg.channels?.["openclaw-weixin"]) {
       hits.push({ id: "openclaw-weixin", surface: "channel" });
     }
     return hits.filter(
-      (hit, index) => hits.findIndex((candidate) => candidate.id === hit.id) === index,
+      (hit, index) =>
+        hits.findIndex(
+          (candidate) => candidate.id === hit.id && candidate.surface === hit.surface,
+        ) === index,
     );
   },
   isStalePluginAutoRepairBlocked: () =>
@@ -251,12 +255,20 @@ vi.mock("./stale-plugin-config.js", () => ({
     autoRepairBlocked,
     doctorFixCommand,
     hits,
+    surfacePreservePluginIds,
   }: {
     autoRepairBlocked: boolean;
     doctorFixCommand: string;
     hits: Array<{ id: string; surface: string }>;
+    surfacePreservePluginIds?: Record<string, ReadonlySet<string>>;
   }) => {
-    const pluginIds = hits
+    const actionableHits = hits.filter(
+      (hit) => !surfacePreservePluginIds?.[hit.surface]?.has(hit.id),
+    );
+    if (actionableHits.length === 0) {
+      return [];
+    }
+    const pluginIds = actionableHits
       .filter((hit) => hit.surface !== "channel")
       .map((hit) => hit.id)
       .toSorted();
@@ -264,7 +276,7 @@ vi.mock("./stale-plugin-config.js", () => ({
       pluginIds.length > 0
         ? `Stale plugin references (plugins.allow/deny/entries): ${pluginIds.join(", ")}.`
         : null,
-      ...hits
+      ...actionableHits
         .filter((hit) => hit.surface === "channel")
         .map((hit) => `channels.${hit.id}: dangling channel config.`),
       autoRepairBlocked
@@ -578,6 +590,19 @@ describe("doctor preview warnings", () => {
     );
     expect(warning).toContain('Run "openclaw doctor --fix"');
     expect(warning).not.toContain("Auto-removal is paused");
+  });
+
+  it("omits stale cleanup warnings for version-bound Codex policy", async () => {
+    const warnings = await collectDoctorPreviewWarnings({
+      cfg: {
+        plugins: {
+          allow: ["codex"],
+        },
+      },
+      doctorFixCommand: "openclaw doctor --fix",
+    });
+
+    expect(warnings.join("\n")).not.toContain("Stale plugin references");
   });
 
   it("includes stale channel config warnings without plugin config", async () => {

--- a/src/commands/doctor/shared/preview-warnings.ts
+++ b/src/commands/doctor/shared/preview-warnings.ts
@@ -20,6 +20,7 @@ import type {
 } from "../../../config/types.tools.js";
 import { collectChannelRouteTargets } from "../../../routing/channel-route-targets.js";
 import { createLazyImportLoader } from "../../../shared/lazy-promise.js";
+import { VERSION_BOUND_RUNTIME_PLUGIN_POLICY_IDS_BY_SURFACE } from "./configured-runtime-plugin-installs.js";
 import { resolveDoctorPrimaryModelRef } from "./primary-model-ref.js";
 
 type ChannelDoctorModule = typeof import("./channel-doctor.js");
@@ -777,13 +778,15 @@ export async function collectDoctorPreviewNotes(params: {
     } = await import("./stale-plugin-config.js");
     const stalePluginHits = scanStalePluginConfig(params.cfg, env);
     if (stalePluginHits.length > 0) {
-      warnings.push(
-        collectStalePluginConfigWarnings({
-          hits: stalePluginHits,
-          doctorFixCommand: params.doctorFixCommand,
-          autoRepairBlocked: isStalePluginAutoRepairBlocked(params.cfg, env),
-        }).join("\n"),
-      );
+      const stalePluginWarnings = collectStalePluginConfigWarnings({
+        hits: stalePluginHits,
+        doctorFixCommand: params.doctorFixCommand,
+        autoRepairBlocked: isStalePluginAutoRepairBlocked(params.cfg, env),
+        surfacePreservePluginIds: VERSION_BOUND_RUNTIME_PLUGIN_POLICY_IDS_BY_SURFACE,
+      });
+      if (stalePluginWarnings.length > 0) {
+        warnings.push(stalePluginWarnings.join("\n"));
+      }
     }
   }
 

--- a/src/commands/doctor/shared/stale-plugin-config.test.ts
+++ b/src/commands/doctor/shared/stale-plugin-config.test.ts
@@ -157,6 +157,43 @@ describe("doctor stale plugin config helpers", () => {
     expect(result.config.plugins?.allow).toEqual([]);
   });
 
+  it("preserves codex in allowlist when surfacePreservePluginIds.allow includes codex", () => {
+    const result = maybeRepairStalePluginConfig(
+      {
+        plugins: {
+          allow: ["codex", "discord"],
+          deny: ["codex"],
+        },
+      } as OpenClawConfig,
+      undefined,
+      { surfacePreservePluginIds: { allow: ["codex"] } },
+    );
+
+    // codex is preserved in allow (discord stays as known manifest plugin),
+    // but still removed from deny
+    expect(result.config.plugins?.allow).toEqual(["codex", "discord"]);
+    expect(result.changes).toEqual(["- plugins.deny: removed 1 stale plugin id (codex)"]);
+  });
+
+  it("does not preserve codex in non-allow surfaces when surfacePreservePluginIds.allow includes codex", () => {
+    const result = maybeRepairStalePluginConfig(
+      {
+        plugins: {
+          allow: ["codex"],
+          entries: {
+            codex: { enabled: true },
+          },
+        },
+      } as OpenClawConfig,
+      undefined,
+      { surfacePreservePluginIds: { allow: ["codex"] } },
+    );
+
+    expect(result.config.plugins?.allow).toEqual(["codex"]);
+    expect(result.config.plugins?.entries?.codex).toBeUndefined();
+    expect(result.changes).toEqual(["- plugins.entries: removed 1 stale plugin entry (codex)"]);
+  });
+
   it("does not report slot defaults or none as stale plugin refs", () => {
     expect(
       scanStalePluginConfig({

--- a/src/commands/doctor/shared/stale-plugin-config.test.ts
+++ b/src/commands/doctor/shared/stale-plugin-config.test.ts
@@ -157,41 +157,62 @@ describe("doctor stale plugin config helpers", () => {
     expect(result.config.plugins?.allow).toEqual([]);
   });
 
-  it("preserves codex in allowlist when surfacePreservePluginIds.allow includes codex", () => {
+  it("preserves codex in policy surfaces while the version-bound plugin is absent", () => {
     const result = maybeRepairStalePluginConfig(
       {
         plugins: {
           allow: ["codex", "discord"],
           deny: ["codex"],
+          entries: {
+            codex: { enabled: false },
+          },
         },
       } as OpenClawConfig,
       undefined,
-      { surfacePreservePluginIds: { allow: ["codex"] } },
+      {
+        surfacePreservePluginIds: {
+          allow: ["codex"],
+          deny: ["codex"],
+          entries: ["codex"],
+        },
+      },
     );
 
-    // codex is preserved in allow (discord stays as known manifest plugin),
-    // but still removed from deny
     expect(result.config.plugins?.allow).toEqual(["codex", "discord"]);
-    expect(result.changes).toEqual(["- plugins.deny: removed 1 stale plugin id (codex)"]);
+    expect(result.config.plugins?.deny).toEqual(["codex"]);
+    expect(result.config.plugins?.entries?.codex?.enabled).toBe(false);
+    expect(result.changes).toEqual([]);
   });
 
-  it("does not preserve codex in non-allow surfaces when surfacePreservePluginIds.allow includes codex", () => {
+  it("does not preserve codex outside policy surfaces", () => {
     const result = maybeRepairStalePluginConfig(
       {
         plugins: {
           allow: ["codex"],
           entries: {
-            codex: { enabled: true },
+            codex: { enabled: false },
+          },
+          slots: {
+            memory: "codex",
           },
         },
       } as OpenClawConfig,
       undefined,
-      { surfacePreservePluginIds: { allow: ["codex"] } },
+      {
+        surfacePreservePluginIds: {
+          allow: ["codex"],
+          deny: ["codex"],
+          entries: ["codex"],
+        },
+      },
     );
 
     expect(result.config.plugins?.allow).toEqual(["codex"]);
-    expect(result.config.plugins?.entries?.codex).toBeUndefined();
-    expect(result.changes).toEqual(["- plugins.entries: removed 1 stale plugin entry (codex)"]);
+    expect(result.config.plugins?.entries?.codex?.enabled).toBe(false);
+    expect(result.config.plugins?.slots?.memory).toBe("memory-core");
+    expect(result.changes).toEqual([
+      "- plugins.slots: reset 1 stale plugin slot (memory: codex -> memory-core)",
+    ]);
   });
 
   it("does not report slot defaults or none as stale plugin refs", () => {

--- a/src/commands/doctor/shared/stale-plugin-config.test.ts
+++ b/src/commands/doctor/shared/stale-plugin-config.test.ts
@@ -4,6 +4,7 @@ import type { OpenClawConfig } from "../../../config/config.js";
 import type { PluginInstallRecord } from "../../../config/types.plugins.js";
 import type { PluginManifestRecord } from "../../../plugins/manifest-registry.js";
 import * as manifestRegistry from "../../../plugins/manifest-registry.js";
+import { VERSION_BOUND_RUNTIME_PLUGIN_POLICY_IDS_BY_SURFACE } from "./configured-runtime-plugin-installs.js";
 import {
   collectStalePluginConfigWarnings,
   maybeRepairStalePluginConfig,
@@ -469,7 +470,7 @@ describe("doctor stale plugin config helpers", () => {
     expect(warnings.at(-1)).toContain("Auto-removal is paused");
   });
 
-  it("keeps an intentionally unavailable Codex plugin entry out of stale diagnostics", () => {
+  it("filters version-bound Codex policy from actionable stale warnings", () => {
     const cfg = {
       models: {
         providers: {
@@ -489,10 +490,8 @@ describe("doctor stale plugin config helpers", () => {
       },
     } as OpenClawConfig;
 
-    // scanStalePluginConfig flags codex in plugins.allow because it is not in
-    // knownIds. Protection happens at the repair-sequencing caller via
-    // preservePluginIds, not in the scanner.
-    expect(scanStalePluginConfig(cfg)).toEqual([
+    const hits = scanStalePluginConfig(cfg);
+    expect(hits).toEqual([
       {
         pluginId: "codex",
         pathLabel: "plugins.allow",
@@ -508,6 +507,16 @@ describe("doctor stale plugin config helpers", () => {
         pathLabel: "plugins.entries.acpx",
         surface: "entries",
       },
+    ]);
+    expect(
+      collectStalePluginConfigWarnings({
+        hits,
+        doctorFixCommand: "openclaw doctor --fix",
+        surfacePreservePluginIds: VERSION_BOUND_RUNTIME_PLUGIN_POLICY_IDS_BY_SURFACE,
+      }),
+    ).toEqual([
+      "- Stale plugin references (plugins.allow/deny/entries): acpx.",
+      '- Run "openclaw doctor --fix" to remove stale plugin ids and dangling channel references.',
     ]);
   });
 

--- a/src/commands/doctor/shared/stale-plugin-config.test.ts
+++ b/src/commands/doctor/shared/stale-plugin-config.test.ts
@@ -143,6 +143,20 @@ describe("doctor stale plugin config helpers", () => {
     });
   });
 
+  it("stale-plugin-config removes codex from allowlist when called without preservePluginIds (repair-sequencing passes preservePluginIds)", () => {
+    const result = maybeRepairStalePluginConfig({
+      plugins: {
+        allow: ["codex"],
+      },
+    } as OpenClawConfig);
+
+    // maybeRepairStalePluginConfig alone removes codex because it is not in
+    // knownIds. The preservation of version-bound runtime plugins happens at
+    // the caller (repair-sequencing.ts) via preservePluginIds.
+    expect(result.changes).toEqual(["- plugins.allow: removed 1 stale plugin id (codex)"]);
+    expect(result.config.plugins?.allow).toEqual([]);
+  });
+
   it("does not report slot defaults or none as stale plugin refs", () => {
     expect(
       scanStalePluginConfig({
@@ -417,12 +431,9 @@ describe("doctor stale plugin config helpers", () => {
       },
     } as OpenClawConfig;
 
+    // codex is a version-bound runtime plugin — its allowlist entry is not
+    // flagged as stale so the release backfill install step can install it.
     expect(scanStalePluginConfig(cfg)).toEqual([
-      {
-        pluginId: "codex",
-        pathLabel: "plugins.allow",
-        surface: "allow",
-      },
       {
         pluginId: "acpx",
         pathLabel: "plugins.allow",

--- a/src/commands/doctor/shared/stale-plugin-config.test.ts
+++ b/src/commands/doctor/shared/stale-plugin-config.test.ts
@@ -431,9 +431,15 @@ describe("doctor stale plugin config helpers", () => {
       },
     } as OpenClawConfig;
 
-    // codex is a version-bound runtime plugin — its allowlist entry is not
-    // flagged as stale so the release backfill install step can install it.
+    // scanStalePluginConfig flags codex in plugins.allow because it is not in
+    // knownIds. Protection happens at the repair-sequencing caller via
+    // preservePluginIds, not in the scanner.
     expect(scanStalePluginConfig(cfg)).toEqual([
+      {
+        pluginId: "codex",
+        pathLabel: "plugins.allow",
+        surface: "allow",
+      },
       {
         pluginId: "acpx",
         pathLabel: "plugins.allow",

--- a/src/commands/doctor/shared/stale-plugin-config.ts
+++ b/src/commands/doctor/shared/stale-plugin-config.ts
@@ -302,14 +302,16 @@ export function collectStalePluginConfigWarnings(params: {
   hits: StalePluginConfigHit[];
   doctorFixCommand: string;
   autoRepairBlocked?: boolean;
+  surfacePreservePluginIds?: Partial<Record<StalePluginSurface, Iterable<string>>>;
 }): string[] {
-  if (params.hits.length === 0) {
+  const hits = filterRepairableStalePluginHits(params);
+  if (hits.length === 0) {
     return [];
   }
   const policyPluginIds = [
-    ...new Set(params.hits.filter(isPolicySurfaceHit).map((hit) => hit.pluginId)),
+    ...new Set(hits.filter(isPolicySurfaceHit).map((hit) => hit.pluginId)),
   ].toSorted((a, b) => a.localeCompare(b));
-  const lines = params.hits
+  const lines = hits
     .map((hit) => formatStalePluginHitWarning(hit))
     .filter((line): line is string => line !== null);
   if (policyPluginIds.length > 0) {

--- a/src/commands/doctor/shared/stale-plugin-config.ts
+++ b/src/commands/doctor/shared/stale-plugin-config.ts
@@ -9,17 +9,12 @@ import { loadInstalledPluginIndexInstallRecordsSync } from "../../../plugins/ins
 import { loadManifestMetadataSnapshot } from "../../../plugins/manifest-contract-eligibility.js";
 import { defaultSlotIdForKey, type PluginSlotKey } from "../../../plugins/slots.js";
 import { asObjectRecord } from "./object.js";
+import {
+  filterRepairableStalePluginHits,
+  type StalePluginSurface,
+} from "./stale-plugin-repair-preservation.js";
 
 const CHANNEL_CONFIG_META_KEYS = new Set(["defaults", "modelByChannel"]);
-
-type StalePluginSurface =
-  | "allow"
-  | "deny"
-  | "entries"
-  | "slot"
-  | "channel"
-  | "heartbeat"
-  | "modelByChannel";
 
 type StalePluginConfigHit = {
   pluginId: string;
@@ -355,26 +350,10 @@ export function maybeRepairStalePluginConfig(
     return { config: cfg, changes: [] };
   }
 
-  const preservePluginIds = new Set(
-    [...(params?.preservePluginIds ?? [])]
-      .map((pluginId) => normalizePluginId(pluginId))
-      .filter((pluginId): pluginId is string => Boolean(pluginId)),
-  );
-  const surfacePreservePluginIds: Partial<Record<StalePluginSurface, Set<string>>> = {};
-  for (const [surface, ids] of Object.entries(params?.surfacePreservePluginIds ?? {})) {
-    const normalized = new Set(
-      [...ids].map((id) => normalizePluginId(id)).filter((id): id is string => Boolean(id)),
-    );
-    if (normalized.size > 0) {
-      surfacePreservePluginIds[surface as StalePluginSurface] = normalized;
-    }
-  }
-  const hits = scanStalePluginConfigWithState(cfg, registryState, environment).filter((hit) => {
-    const id = normalizePluginId(hit.pluginId);
-    if (preservePluginIds.has(id)) return false;
-    const surfaceIds = surfacePreservePluginIds[hit.surface];
-    if (surfaceIds?.has(id)) return false;
-    return true;
+  const hits = filterRepairableStalePluginHits({
+    hits: scanStalePluginConfigWithState(cfg, registryState, environment),
+    preservePluginIds: params?.preservePluginIds,
+    surfacePreservePluginIds: params?.surfacePreservePluginIds,
   });
   if (hits.length === 0) {
     return { config: cfg, changes: [] };

--- a/src/commands/doctor/shared/stale-plugin-config.ts
+++ b/src/commands/doctor/shared/stale-plugin-config.ts
@@ -338,7 +338,10 @@ export function collectStalePluginConfigWarnings(params: {
 export function maybeRepairStalePluginConfig(
   cfg: OpenClawConfig,
   env?: NodeJS.ProcessEnv,
-  params?: { preservePluginIds?: Iterable<string> },
+  params?: {
+    preservePluginIds?: Iterable<string>;
+    surfacePreservePluginIds?: Partial<Record<StalePluginSurface, Iterable<string>>>;
+  },
 ): {
   config: OpenClawConfig;
   changes: string[];
@@ -357,9 +360,22 @@ export function maybeRepairStalePluginConfig(
       .map((pluginId) => normalizePluginId(pluginId))
       .filter((pluginId): pluginId is string => Boolean(pluginId)),
   );
-  const hits = scanStalePluginConfigWithState(cfg, registryState, environment).filter(
-    (hit) => !preservePluginIds.has(normalizePluginId(hit.pluginId)),
-  );
+  const surfacePreservePluginIds: Partial<Record<StalePluginSurface, Set<string>>> = {};
+  for (const [surface, ids] of Object.entries(params?.surfacePreservePluginIds ?? {})) {
+    const normalized = new Set(
+      [...ids].map((id) => normalizePluginId(id)).filter((id): id is string => Boolean(id)),
+    );
+    if (normalized.size > 0) {
+      surfacePreservePluginIds[surface as StalePluginSurface] = normalized;
+    }
+  }
+  const hits = scanStalePluginConfigWithState(cfg, registryState, environment).filter((hit) => {
+    const id = normalizePluginId(hit.pluginId);
+    if (preservePluginIds.has(id)) return false;
+    const surfaceIds = surfacePreservePluginIds[hit.surface];
+    if (surfaceIds?.has(id)) return false;
+    return true;
+  });
   if (hits.length === 0) {
     return { config: cfg, changes: [] };
   }

--- a/src/commands/doctor/shared/stale-plugin-repair-preservation.ts
+++ b/src/commands/doctor/shared/stale-plugin-repair-preservation.ts
@@ -1,0 +1,39 @@
+import { normalizePluginId } from "../../../plugins/config-state.js";
+
+export type StalePluginSurface =
+  | "allow"
+  | "deny"
+  | "entries"
+  | "slot"
+  | "channel"
+  | "heartbeat"
+  | "modelByChannel";
+
+type StalePluginHit = {
+  pluginId: string;
+  surface: StalePluginSurface;
+};
+
+function normalizeIds(ids: Iterable<string> | undefined): Set<string> {
+  return new Set(
+    [...(ids ?? [])].map((id) => normalizePluginId(id)).filter((id): id is string => Boolean(id)),
+  );
+}
+
+export function filterRepairableStalePluginHits<T extends StalePluginHit>(params: {
+  hits: readonly T[];
+  preservePluginIds?: Iterable<string>;
+  surfacePreservePluginIds?: Partial<Record<StalePluginSurface, Iterable<string>>>;
+}): T[] {
+  const preserveIds = normalizeIds(params.preservePluginIds);
+  const surfacePreserveIds = Object.fromEntries(
+    Object.entries(params.surfacePreservePluginIds ?? {}).map(([surface, ids]) => [
+      surface,
+      normalizeIds(ids),
+    ]),
+  ) as Partial<Record<StalePluginSurface, Set<string>>>;
+  return params.hits.filter((hit) => {
+    const id = normalizePluginId(hit.pluginId);
+    return !preserveIds.has(id) && !surfacePreserveIds[hit.surface]?.has(id);
+  });
+}

--- a/test/scripts/upgrade-survivor-config-recipe.test.ts
+++ b/test/scripts/upgrade-survivor-config-recipe.test.ts
@@ -8,6 +8,7 @@ import {
   CONFIG_COMMAND_MAX_BUFFER_BYTES,
   CONFIG_COMMAND_TIMEOUT_MS,
   isReleaseBefore,
+  resolveScenarioConfigSteps,
   resolveUpgradeSurvivorOpenClawCommand,
   runUpgradeSurvivorOpenClawStep,
 } from "../../scripts/e2e/lib/upgrade-survivor/config-recipe.mjs";
@@ -59,6 +60,22 @@ describe("upgrade survivor config recipe command resolution", () => {
       commandLabel: "openclaw config validate",
       shell: false,
     });
+  });
+
+  it("adds the Codex allowlist survival scenario", () => {
+    expect(resolveScenarioConfigSteps("codex-allowlist-survival")).toEqual([
+      {
+        argv: [
+          "config",
+          "set",
+          "plugins.allow",
+          JSON.stringify(["discord", "memory", "telegram", "whatsapp", "codex"]),
+          "--strict-json",
+        ],
+        id: "plugins-codex-allowlist",
+        intent: "codex-allowlist-survival",
+      },
+    ]);
   });
 
   it("bounds baseline config commands and reports spawn errors", () => {


### PR DESCRIPTION
Related: #107226

## What Problem This Solves

Fixes an issue where `openclaw doctor --fix` could remove the `codex` plugin policy during the first update after Codex moved from the core package to the version-bound `@openclaw/codex` plugin. That removal left existing Codex-backed agents unable to register their harness.

## Why This Change Was Made

The canonical configured-runtime install catalog now marks host-version-bound plugins. During the transient gap between the core package swap and companion-plugin convergence, doctor preserves those plugins on policy-bearing `plugins.allow`, `plugins.deny`, and `plugins.entries` surfaces. Preview diagnostics use the same policy classification, while unrelated stale slots, channels, and dependent config still repair normally.

Gateway readiness semantics are intentionally unchanged; issue #107226 remains open for that separate product decision.

## User Impact

Existing Codex policy survives routine updates and doctor repair. Users do not need to reconstruct the allowlist manually, and explicit deny/disabled policy is not lost while the external package is temporarily absent.

## Evidence

- Focused doctor and upgrade-harness tests: 171 passed across six files on Testbox-through-Crabbox.
- Current-tree doctor, preview-warning, and repair-sequencing tests: 81 passed.
- Policy-surface regression tests: 36 passed, covering allow, deny, disabled entries, and continued stale-slot cleanup ([Actions run](https://github.com/openclaw/openclaw/actions/runs/29388653343)).
- Packaged upgrade E2E: exact published `openclaw@2026.6.11` baseline upgraded to the candidate tarball; `doctor --fix` completed; the Codex allow entry survived; gateway `/healthz`, `/readyz`, and status probes passed on Testbox-through-Crabbox `tbx_01kxj087x58p2wbsesy0gmyv38` ([Actions run](https://github.com/openclaw/openclaw/actions/runs/29388867718)).
- Build/package integrity completed inside the packaged upgrade lane.
- Exact-head CI passed ([Actions run](https://github.com/openclaw/openclaw/actions/runs/29390461217)).
- Fresh full-branch autoreview on the final patch: no accepted/actionable findings.

Exact PR head: `d94d20c2d45671b423332b972f729c32d7b7f141`.
