### PR TITLE
fix(cli): adopt native Clack prompt contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Sandbox recreate confirmation:** treat Clack cancellation as a decline so Ctrl-C cannot proceed with container removal.
 - **Microsoft Teams HTML text:** decode HTML5 entities consistently in quoted and Graph-fetched messages while preserving literal escaped entity text.
 - **ClawHub plugin API ranges:** delegate each supported comparator to `semver` so tilde, partial-wildcard, and prerelease caret bounds are correct while preserving OpenClaw version normalization and the existing restricted range grammar. (#106877)
 - **Web Readability relative links:** seed parsed documents with the request URL so article links resolve correctly while removing the plugin's duplicate lazy-loader facade. (#106860)

--- a/packages/terminal-core/src/note.ts
+++ b/packages/terminal-core/src/note.ts
@@ -230,7 +230,6 @@ export function note(message: unknown, title?: string) {
   const wrappedMessage = wrapNoteMessage(message, { columns });
   clackNote(wrappedMessage, stylePromptTitle(title), {
     output: createNoteOutput(resolveNoteOutputColumns(wrappedMessage, columns)),
-    format: (line) => line,
   });
 }
 

--- a/packages/terminal-core/src/table.test.ts
+++ b/packages/terminal-core/src/table.test.ts
@@ -720,7 +720,7 @@ describe("wrapNoteMessage", () => {
       },
     } as unknown as NodeJS.WriteStream;
 
-    clackNote(wrapped, "Session locks", { output, format: (line) => line });
+    clackNote(wrapped, "Session locks", { output });
 
     const rendered = writes.join("");
     expect(rendered).toContain(".jsonl.lock");

--- a/src/commands/sandbox.test.ts
+++ b/src/commands/sandbox.test.ts
@@ -287,7 +287,7 @@ describe("sandboxRecreateCommand", () => {
     });
 
     it("should cancel on clack cancel symbol", async () => {
-      await runCancelledConfirmation(Symbol.for("clack:cancel"));
+      await runCancelledConfirmation(Symbol("clack:cancel"));
 
       expect(runtime.log).toHaveBeenCalledWith("Cancelled.");
       expect(mocks.removeSandboxContainer).not.toHaveBeenCalled();

--- a/src/commands/sandbox.ts
+++ b/src/commands/sandbox.ts
@@ -153,7 +153,7 @@ async function confirmRecreate(): Promise<boolean> {
     initialValue: false,
   });
 
-  return result !== false && result !== Symbol.for("clack:cancel");
+  return result === true;
 }
 
 async function removeContainers(

--- a/src/wizard/clack-prompter.test.ts
+++ b/src/wizard/clack-prompter.test.ts
@@ -111,8 +111,8 @@ describe("createClackPrompter", () => {
     expect(write).toHaveBeenCalledWith('{"ok":true}\n');
   });
 
-  it("renders vertical confirms as stacked yes/no select choices", async () => {
-    clackMocks.select.mockResolvedValue(true);
+  it("renders vertical confirms with Clack's native layout", async () => {
+    clackMocks.confirm.mockResolvedValue(true);
     const prompter = createClackPrompter();
 
     await expect(
@@ -122,14 +122,11 @@ describe("createClackPrompter", () => {
       }),
     ).resolves.toBe(true);
 
-    expect(clackMocks.confirm).not.toHaveBeenCalled();
-    expect(clackMocks.select).toHaveBeenCalledWith(
+    expect(clackMocks.select).not.toHaveBeenCalled();
+    expect(clackMocks.confirm).toHaveBeenCalledWith(
       expect.objectContaining({
-        options: [
-          { value: true, label: "Yes" },
-          { value: false, label: "No" },
-        ],
-        initialValue: true,
+        initialValue: undefined,
+        vertical: true,
       }),
     );
   });
@@ -209,10 +206,11 @@ describe("createClackPrompter", () => {
     );
   });
 
-  it("rejects navigation immediately when a prompt does not resolve after abort", async () => {
-    navigationPromptMocks.textWithNavigationFooter.mockImplementation(
-      async () => await new Promise<string>(() => {}),
-    );
+  it("rejects navigation after Clack resolves an aborted prompt", async () => {
+    navigationPromptMocks.textWithNavigationFooter.mockImplementation(async ({ signal }) => {
+      await new Promise((resolve) => signal.addEventListener("abort", resolve, { once: true }));
+      return Symbol("clack:cancel");
+    });
     const prompter = createClackPrompter();
 
     const result = prompter.text({

--- a/src/wizard/clack-prompter.ts
+++ b/src/wizard/clack-prompter.ts
@@ -96,36 +96,30 @@ async function runPromptWithNavigation<T>(
   navigation: WizardPromptNavigation | undefined,
   work: (signal: AbortSignal | undefined) => Promise<T | symbol>,
 ): Promise<T> {
-  const controller =
-    navigation?.canGoBack || navigation?.canGoForward ? new AbortController() : undefined;
-  let rejectNavigation: ((error: Error) => void) | undefined;
+  if (!hasPromptNavigation(navigation)) {
+    return guardCancel(await work(undefined));
+  }
+
+  const controller = new AbortController();
+  let navigationDirection: "back" | "forward" | undefined;
   const onKeypress = (_input: string | undefined, key: KeypressInfo | undefined) => {
     const nextDirection = resolveNavigationDirection(navigation, key);
     if (!nextDirection) {
       return;
     }
-    rejectNavigation?.(new WizardNavigationError(nextDirection));
-    controller?.abort();
+    navigationDirection ??= nextDirection;
+    controller.abort();
   };
 
   try {
-    if (!controller) {
-      return guardCancel(await work(undefined));
-    }
-
-    const navigationPromise = new Promise<T | symbol>((_, reject) => {
-      rejectNavigation = reject;
-    });
     process.stdin.on("keypress", onKeypress);
-    const promptPromise = work(controller.signal);
-    promptPromise.catch(() => {
-      // Navigation may settle first while Clack is still unwinding its prompt.
-    });
-    return guardCancel(await Promise.race([promptPromise, navigationPromise]));
-  } finally {
-    if (controller) {
-      process.stdin.off("keypress", onKeypress);
+    const value = await work(controller.signal);
+    if (navigationDirection) {
+      throw new WizardNavigationError(navigationDirection);
     }
+    return guardCancel(value);
+  } finally {
+    process.stdin.off("keypress", onKeypress);
   }
 }
 
@@ -172,12 +166,12 @@ export function createClackPrompter(): WizardPrompter {
       const { message, options: styledOptions } = styleSelectParams(params);
       const options = styledOptions as Option<(typeof params.options)[number]["value"]>[];
 
-      if (params.searchable) {
-        return await withHorizontalCursorActionsDisabled(
-          hasPromptNavigation(params.navigation),
-          async () =>
-            await runPromptWithNavigation(params.navigation, async (signal) =>
-              params.navigation
+      return await withHorizontalCursorActionsDisabled(
+        hasPromptNavigation(params.navigation),
+        async () =>
+          await runPromptWithNavigation(params.navigation, async (signal) => {
+            if (params.searchable) {
+              return params.navigation
                 ? await autocompleteWithNavigationFooter({
                     message,
                     options,
@@ -192,16 +186,9 @@ export function createClackPrompter(): WizardPrompter {
                     initialValue: params.initialValue,
                     filter: tokenizedOptionFilter,
                     signal,
-                  }),
-            ),
-        );
-      }
-
-      return await withHorizontalCursorActionsDisabled(
-        hasPromptNavigation(params.navigation),
-        async () =>
-          await runPromptWithNavigation(params.navigation, async (signal) =>
-            params.navigation
+                  });
+            }
+            return params.navigation
               ? await selectWithNavigationFooter({
                   message,
                   options,
@@ -214,20 +201,20 @@ export function createClackPrompter(): WizardPrompter {
                   options,
                   initialValue: params.initialValue,
                   signal,
-                }),
-          ),
+                });
+          }),
       );
     },
     multiselect: async (params) => {
       const { message, options: styledOptions } = styleSelectParams(params);
       const options = styledOptions as Option<(typeof params.options)[number]["value"]>[];
 
-      if (params.searchable) {
-        return await withHorizontalCursorActionsDisabled(
-          hasPromptNavigation(params.navigation),
-          async () =>
-            await runPromptWithNavigation(params.navigation, async (signal) =>
-              params.navigation
+      return await withHorizontalCursorActionsDisabled(
+        hasPromptNavigation(params.navigation),
+        async () =>
+          await runPromptWithNavigation(params.navigation, async (signal) => {
+            if (params.searchable) {
+              return params.navigation
                 ? await autocompleteMultiselectWithNavigationFooter({
                     message,
                     options,
@@ -242,16 +229,9 @@ export function createClackPrompter(): WizardPrompter {
                     initialValues: params.initialValues,
                     filter: tokenizedOptionFilter,
                     signal,
-                  }),
-            ),
-        );
-      }
-
-      return await withHorizontalCursorActionsDisabled(
-        hasPromptNavigation(params.navigation),
-        async () =>
-          await runPromptWithNavigation(params.navigation, async (signal) =>
-            params.navigation
+                  });
+            }
+            return params.navigation
               ? await multiselectWithNavigationFooter({
                   message,
                   options,
@@ -264,53 +244,47 @@ export function createClackPrompter(): WizardPrompter {
                   options,
                   initialValues: params.initialValues,
                   signal,
-                }),
-          ),
+                });
+          }),
       );
     },
     text: async (params) => {
       const validate = params.validate;
-      if (params.sensitive) {
-        return await withHorizontalCursorActionsDisabled(
-          hasPromptNavigation(params.navigation),
-          async () =>
-            await runPromptWithNavigation(params.navigation, async (signal) =>
-              params.navigation
-                ? await passwordWithNavigationFooter({
-                    message: stylePromptMessage(params.message),
-                    validate: validate ? (value) => validate(value ?? "") : undefined,
-                    navigation: params.navigation,
-                    signal,
-                  })
-                : await password({
-                    message: stylePromptMessage(params.message),
-                    validate: validate ? (value) => validate(value ?? "") : undefined,
-                    signal,
-                  }),
-            ),
-        );
-      }
       return await withHorizontalCursorActionsDisabled(
         hasPromptNavigation(params.navigation),
         async () =>
-          await runPromptWithNavigation(params.navigation, async (signal) =>
-            params.navigation
+          await runPromptWithNavigation(params.navigation, async (signal) => {
+            const message = stylePromptMessage(params.message);
+            const validateInput = validate
+              ? (value: string | undefined) => validate(value ?? "")
+              : undefined;
+            if (params.sensitive) {
+              return params.navigation
+                ? await passwordWithNavigationFooter({
+                    message,
+                    validate: validateInput,
+                    navigation: params.navigation,
+                    signal,
+                  })
+                : await password({ message, validate: validateInput, signal });
+            }
+            return params.navigation
               ? await textWithNavigationFooter({
-                  message: stylePromptMessage(params.message),
+                  message,
                   initialValue: params.initialValue,
                   placeholder: params.placeholder,
-                  validate: validate ? (value) => validate(value ?? "") : undefined,
+                  validate: validateInput,
                   navigation: params.navigation,
                   signal,
                 })
               : await text({
-                  message: stylePromptMessage(params.message),
+                  message,
                   initialValue: params.initialValue,
                   placeholder: params.placeholder,
-                  validate: validate ? (value) => validate(value ?? "") : undefined,
+                  validate: validateInput,
                   signal,
-                }),
-          ),
+                });
+          }),
       );
     },
     confirm: async (params) =>
@@ -328,20 +302,10 @@ export function createClackPrompter(): WizardPrompter {
                 signal,
               });
             }
-            if (params.layout === "vertical") {
-              return await select({
-                message,
-                options: [
-                  { value: true, label: "Yes" },
-                  { value: false, label: "No" },
-                ],
-                initialValue: params.initialValue ?? true,
-                signal,
-              });
-            }
             return await confirm({
               message,
               initialValue: params.initialValue,
+              vertical: params.layout === "vertical",
               signal,
             });
           }),


### PR DESCRIPTION
## What Problem This Solves

OpenClaw's Clack adapter duplicated prompt-selection scaffolding, emulated Clack's native vertical confirmation layout, and overrode Clack's identity note formatter. Sandbox recreation also compared cancellation against a global symbol that Clack never returns, so Ctrl-C could be treated as approval.

## Why This Change Was Made

- Use Clack's native `vertical` confirm option instead of a two-option select.
- Share one navigation wrapper across searchable, multiselect, text, and password branches.
- Rely on Clack's AbortSignal teardown contract before raising wizard navigation.
- Remove identity note formatters now covered by Clack 1.6 defaults.
- Require an explicit `true` confirmation before destructive sandbox recreation.

This removes 38 lines overall while keeping custom navigation renderers only where Clack has no footer-composition hook.

## User Impact

Vertical confirmations use Clack's native keyboard behavior, including direct y/n input. Cancelling sandbox recreation now reliably stops before container removal.

## Evidence

- `node scripts/run-vitest.mjs src/wizard/clack-prompter.test.ts packages/terminal-core/src/table.test.ts src/commands/sandbox.test.ts` — 77 tests passed across 3 shards.
- `git diff --check origin/main...HEAD`
- Exact-head autoreview: clean, no accepted or actionable findings.
