### PR TITLE
refactor(time): trust pretty-ms defaults

### DIFF
--- a/extensions/google-meet/src/cli.ts
+++ b/extensions/google-meet/src/cli.ts
@@ -346,8 +346,6 @@ function formatDuration(value: number | undefined): string {
     return "n/a";
   }
   return prettyMilliseconds(Math.max(0, Math.round(value / 1000) * 1000), {
-    millisecondsDecimalDigits: 0,
-    secondsDecimalDigits: 0,
     unitCount: 2,
   });
 }

--- a/extensions/phone-control/index.ts
+++ b/extensions/phone-control/index.ts
@@ -108,7 +108,6 @@ function formatDuration(ms: number): string {
   return prettyMilliseconds(Math.max(0, roundedMs), {
     compact: true,
     hideYear: true,
-    secondsDecimalDigits: 0,
   });
 }
 

--- a/extensions/qa-lab/src/character-eval.ts
+++ b/extensions/qa-lab/src/character-eval.ts
@@ -243,8 +243,6 @@ function formatDuration(ms: number) {
   }
   const roundedMs = ms < 1000 ? Math.round(ms) : Math.round(ms / 1000) * 1000;
   return prettyMilliseconds(roundedMs, {
-    millisecondsDecimalDigits: 0,
-    secondsDecimalDigits: 0,
     unitCount: 2,
   });
 }

--- a/extensions/qa-lab/web/src/ui-render-utils.ts
+++ b/extensions/qa-lab/web/src/ui-render-utils.ts
@@ -24,8 +24,6 @@ export function formatIso(iso?: string) {
 export function formatDuration(ms: number): string {
   const roundedMs = ms < 1000 ? Math.round(ms) : Math.round(ms / 1000) * 1000;
   return prettyMilliseconds(Math.max(0, roundedMs), {
-    millisecondsDecimalDigits: 0,
-    secondsDecimalDigits: 0,
     unitCount: 2,
   });
 }

--- a/extensions/qa-matrix/src/runners/contract/runtime.ts
+++ b/extensions/qa-matrix/src/runners/contract/runtime.ts
@@ -193,8 +193,6 @@ function shouldWriteMatrixQaProgress() {
 function formatMatrixQaDurationMs(durationMs: number) {
   const roundedMs = durationMs < 1000 ? Math.round(durationMs) : Math.round(durationMs / 100) * 100;
   return prettyMilliseconds(Math.max(0, roundedMs), {
-    millisecondsDecimalDigits: 0,
-    secondsDecimalDigits: 1,
     unitCount: 1,
   });
 }

--- a/extensions/qqbot/src/engine/utils/format.ts
+++ b/extensions/qqbot/src/engine/utils/format.ts
@@ -65,8 +65,6 @@ export function formatDuration(durationMs: number): string {
   const roundedMs =
     durationMs < 1000 ? Math.round(durationMs) : Math.round(durationMs / 1000) * 1000;
   return prettyMilliseconds(roundedMs, {
-    millisecondsDecimalDigits: 0,
-    secondsDecimalDigits: 0,
     unitCount: 2,
   });
 }

--- a/scripts/build-all.mjs
+++ b/scripts/build-all.mjs
@@ -594,7 +594,6 @@ export function formatBuildAllDuration(durationMs) {
         ? Math.round(clampedMs / 10) * 10
         : Math.round(clampedMs / 100) * 100;
   return prettyMilliseconds(roundedMs, {
-    millisecondsDecimalDigits: 0,
     secondsDecimalDigits: clampedMs < 10_000 ? 2 : 1,
   });
 }

--- a/scripts/run-additional-boundary-checks.mjs
+++ b/scripts/run-additional-boundary-checks.mjs
@@ -449,8 +449,6 @@ function formatDuration(ms) {
   }
   const roundedMs = ms < 1000 ? Math.round(ms) : Math.round(ms / 100) * 100;
   return prettyMilliseconds(Math.max(0, roundedMs), {
-    millisecondsDecimalDigits: 0,
-    secondsDecimalDigits: 1,
     unitCount: 1,
   });
 }

--- a/src/infra/format-time/format-duration.ts
+++ b/src/infra/format-time/format-duration.ts
@@ -38,7 +38,7 @@ export function formatDurationPrecise(
   }
   const roundedMs = Math.max(0, Math.round(ms));
   if (roundedMs < 1000) {
-    return prettyMilliseconds(roundedMs, { millisecondsDecimalDigits: 0 });
+    return prettyMilliseconds(roundedMs);
   }
   return formatDurationSeconds(ms, {
     decimals: options.decimals ?? 2,
@@ -61,11 +61,10 @@ export function formatDurationCompact(
   }
   const roundedMs = Math.round(ms);
   if (roundedMs < 1000) {
-    return prettyMilliseconds(roundedMs, { millisecondsDecimalDigits: 0 });
+    return prettyMilliseconds(roundedMs);
   }
   const formatted = prettyMilliseconds(Math.round(ms / 1000) * 1000, {
     hideYear: true,
-    secondsDecimalDigits: 0,
     unitCount: 2,
   });
   return options?.spaced ? formatted : formatted.replaceAll(" ", "");


### PR DESCRIPTION
## What Problem This Solves

Nine duration-formatting call sites repeat `pretty-ms` options that are already the library defaults or are forced by `compact` mode. The extra precision settings obscure the meaningful rounding and unit-count choices.

## Why This Change Was Made

- Trust `pretty-ms@9.3.0` defaults for zero millisecond digits and one second digit.
- Drop zero-second precision only where callers already round to whole seconds.
- Keep dynamic precision, unit-count, year-hiding, and compact behavior explicit.

## User Impact

No output change. Duration formatting keeps the same rounding and units with 15 fewer lines of configuration noise.

## Evidence

- Differential probe: 30,000 old/new formatted outputs were identical across all changed option shapes.
- `node scripts/run-vitest.mjs src/infra/format-time/format-time.test.ts extensions/qa-matrix/src/runners/contract/runtime.test.ts extensions/qqbot/src/engine/utils/format.test.ts test/scripts/build-all.test.ts` — 142 tests passed across 4 shards.
- `git diff --check origin/main...HEAD`
- Exact-head autoreview: clean, no accepted or actionable findings.
