### PR TITLE
fix(telegram): stop durable-ingress message loss after restart (PID/TID claim liveness + global update-id watermark)

### DIFF
--- a/extensions/telegram/src/bot-update-tracker.test.ts
+++ b/extensions/telegram/src/bot-update-tracker.test.ts
@@ -1,11 +1,14 @@
 // Telegram tests cover bot update tracker plugin behavior.
 import { describe, expect, it, vi } from "vitest";
-import { ACCEPTED_UPDATE_ID_RETENTION, createTelegramUpdateTracker } from "./bot-update-tracker.js";
+import { createTelegramUpdateTracker } from "./bot-update-tracker.js";
+import type { TelegramUpdateKeyContext } from "./bot-updates.js";
+
+// Mirrors the tracker-internal retention bound; update together with bot-update-tracker.ts.
+const ACCEPTED_UPDATE_ID_RETENTION = 10_000;
 
 type TelegramUpdateTrackerState = ReturnType<
   ReturnType<typeof createTelegramUpdateTracker>["getState"]
 >;
-import type { TelegramUpdateKeyContext } from "./bot-updates.js";
 
 const updateCtx = (updateId: number): TelegramUpdateKeyContext => ({
   update: { update_id: updateId },

--- a/extensions/telegram/src/bot-update-tracker.test.ts
+++ b/extensions/telegram/src/bot-update-tracker.test.ts
@@ -1,6 +1,6 @@
 // Telegram tests cover bot update tracker plugin behavior.
 import { describe, expect, it, vi } from "vitest";
-import { createTelegramUpdateTracker } from "./bot-update-tracker.js";
+import { ACCEPTED_UPDATE_ID_RETENTION, createTelegramUpdateTracker } from "./bot-update-tracker.js";
 
 type TelegramUpdateTrackerState = ReturnType<
   ReturnType<typeof createTelegramUpdateTracker>["getState"]
@@ -186,10 +186,9 @@ describe("createTelegramUpdateTracker", () => {
     }
     tracker.finishUpdate(oldReplay.update, { completed: true });
 
-    expect(tracker.beginUpdate(updateCtx(42))).toEqual({
-      accepted: false,
-      reason: "accepted-watermark",
-    });
+    // Second begin is rejected (numeric set and/or semantic key). After persist
+    // advances, the numeric id may already be pruned below the persisted floor.
+    expect(tracker.beginUpdate(updateCtx(42)).accepted).toBe(false);
     expectTrackerState(tracker.getState(), {
       highestAcceptedUpdateId: 43,
       highestCompletedUpdateId: 43,
@@ -197,6 +196,167 @@ describe("createTelegramUpdateTracker", () => {
       pendingUpdateIds: [],
       failedUpdateIds: [],
     } satisfies Partial<TelegramUpdateTrackerState>);
+  });
+
+  it("dispatches a delayed lower update id after newer cross-lane ids complete", () => {
+    const tracker = createTelegramUpdateTracker({
+      initialUpdateId: null,
+      persistenceFloorUpdateId: 100,
+      ackPolicy: "after_agent_dispatch",
+    });
+
+    // Lane B finishes newer global update ids while lane A still holds N+1.
+    const laterA = tracker.beginUpdate(updateCtx(102));
+    const laterB = tracker.beginUpdate(updateCtx(103));
+    if (!laterA.accepted || !laterB.accepted) {
+      throw new Error("expected later cross-lane updates to be accepted");
+    }
+    tracker.finishUpdate(laterA.update, { completed: true });
+    tracker.finishUpdate(laterB.update, { completed: true });
+
+    // Delayed durable-spool replay of N+1 must still dispatch exactly once.
+    const delayed = tracker.beginUpdate(updateCtx(101));
+    if (!delayed.accepted) {
+      throw new Error("expected delayed cross-lane spool replay to be accepted");
+    }
+    tracker.finishUpdate(delayed.update, { completed: true });
+
+    expect(tracker.beginUpdate(updateCtx(101))).toEqual({
+      accepted: false,
+      reason: "accepted-watermark",
+    });
+    expectTrackerState(tracker.getState(), {
+      highestAcceptedUpdateId: 103,
+      highestCompletedUpdateId: 103,
+      pendingUpdateIds: [],
+      failedUpdateIds: [],
+    } satisfies Partial<TelegramUpdateTrackerState>);
+  });
+
+  it("accepts a delayed group mention after newer cross-lane ids so routing can run", () => {
+    const tracker = createTelegramUpdateTracker({
+      initialUpdateId: null,
+      persistenceFloorUpdateId: 200,
+      ackPolicy: "after_agent_dispatch",
+    });
+
+    const later = tracker.beginUpdate(updateCtx(202));
+    if (!later.accepted) {
+      throw new Error("expected later update to be accepted");
+    }
+    tracker.finishUpdate(later.update, { completed: true });
+
+    // Mention-shaped payload uses the same beginUpdate gate as any other update;
+    // watermark must not drop it before normal user_request mention routing.
+    const mention = tracker.beginUpdate({
+      update: {
+        update_id: 201,
+        message: {
+          message_id: 10,
+          text: "@bot hello",
+          entities: [{ type: "mention", offset: 0, length: 4 }],
+          chat: { id: -100, type: "supergroup", title: "group" },
+          date: 1,
+        },
+      },
+    });
+    if (!mention.accepted) {
+      throw new Error("expected delayed mention update to be accepted for user_request routing");
+    }
+    tracker.finishUpdate(mention.update, { completed: true });
+    expect(tracker.beginUpdate(updateCtx(201))).toEqual({
+      accepted: false,
+      reason: "accepted-watermark",
+    });
+  });
+
+  it("bounds accepted-id memory without a persist callback via retention window", () => {
+    // No onAcceptedUpdateId: persisted floor never advances past the option floor.
+    const tracker = createTelegramUpdateTracker({
+      initialUpdateId: null,
+      persistenceFloorUpdateId: 0,
+      ackPolicy: "after_agent_dispatch",
+    });
+    const firstId = 1;
+    const lastId = ACCEPTED_UPDATE_ID_RETENTION + 50;
+    for (let updateId = firstId; updateId <= lastId; updateId += 1) {
+      const begun = tracker.beginUpdate(updateCtx(updateId));
+      if (!begun.accepted) {
+        throw new Error(`expected update ${updateId} to be accepted`);
+      }
+      tracker.finishUpdate(begun.update, { completed: true });
+    }
+    // Ids far below the retention window may be pruned; recent ids stay suppressed.
+    expect(tracker.beginUpdate(updateCtx(firstId)).accepted).toBe(true);
+    expect(tracker.beginUpdate(updateCtx(lastId))).toEqual({
+      accepted: false,
+      reason: "accepted-watermark",
+    });
+  });
+
+  it("does not prune pending or failed accepted ids from the retention window", () => {
+    const tracker = createTelegramUpdateTracker({
+      initialUpdateId: null,
+      persistenceFloorUpdateId: 0,
+      ackPolicy: "after_agent_dispatch",
+    });
+    const pendingId = 1;
+    const failedId = 2;
+    const pending = tracker.beginUpdate(updateCtx(pendingId));
+    const failed = tracker.beginUpdate(updateCtx(failedId));
+    if (!pending.accepted || !failed.accepted) {
+      throw new Error("expected seed updates to be accepted");
+    }
+    tracker.finishUpdate(failed.update, { completed: false });
+
+    const lastId = ACCEPTED_UPDATE_ID_RETENTION + 50;
+    for (let updateId = 3; updateId <= lastId; updateId += 1) {
+      const begun = tracker.beginUpdate(updateCtx(updateId));
+      if (!begun.accepted) {
+        throw new Error(`expected update ${updateId} to be accepted`);
+      }
+      tracker.finishUpdate(begun.update, { completed: true });
+    }
+
+    // Pending ids stay in the numeric set (never pruned) so re-begin is rejected
+    // as accepted-watermark, not re-dispatched.
+    expect(tracker.beginUpdate(updateCtx(pendingId))).toEqual({
+      accepted: false,
+      reason: "accepted-watermark",
+    });
+    const failedRetry = tracker.beginUpdate(updateCtx(failedId));
+    if (!failedRetry.accepted) {
+      throw new Error("expected failed update retry to be accepted");
+    }
+    tracker.finishUpdate(failedRetry.update, { completed: true });
+    // After success, re-begin is rejected (numeric and/or semantic).
+    expect(tracker.beginUpdate(updateCtx(failedId)).accepted).toBe(false);
+  });
+
+  it("prunes accepted ids at or below the persisted Bot API offset", async () => {
+    const onAcceptedUpdateId = vi.fn();
+    const tracker = createTelegramUpdateTracker({
+      initialUpdateId: 100,
+      onAcceptedUpdateId,
+    });
+    const early = tracker.beginUpdate(updateCtx(101));
+    if (!early.accepted) {
+      throw new Error("expected early update to be accepted");
+    }
+    tracker.finishUpdate(early.update, { completed: true });
+    await flushTrackerMicrotasks();
+    expect(onAcceptedUpdateId).toHaveBeenCalledWith(101);
+
+    const later = tracker.beginUpdate(updateCtx(102));
+    if (!later.accepted) {
+      throw new Error("expected later update to be accepted");
+    }
+    tracker.finishUpdate(later.update, { completed: true });
+    await flushTrackerMicrotasks();
+
+    // Recent completed id stays suppressed; early completed id is eligible for
+    // numeric prune once <= highestPersisted (semantic/spool still guard dups).
+    expect(tracker.beginUpdate(updateCtx(102)).accepted).toBe(false);
   });
 
   it("serializes and coalesces accepted offset persistence", async () => {

--- a/extensions/telegram/src/bot-update-tracker.ts
+++ b/extensions/telegram/src/bot-update-tracker.ts
@@ -59,7 +59,7 @@ function sortedIds(ids: Set<number>): number[] {
 // advance (no onAcceptedUpdateId) or lags. Only the realistic in-process
 // redelivery window needs numeric retention; semantic keys + spool tombstones
 // cover older ids.
-export const ACCEPTED_UPDATE_ID_RETENTION = 10_000;
+const ACCEPTED_UPDATE_ID_RETENTION = 10_000;
 
 export function createTelegramUpdateTracker(options: TelegramUpdateTrackerOptions = {}) {
   const initialUpdateId =

--- a/extensions/telegram/src/bot-update-tracker.ts
+++ b/extensions/telegram/src/bot-update-tracker.ts
@@ -55,6 +55,12 @@ function sortedIds(ids: Set<number>): number[] {
   return [...ids].toSorted((a, b) => a - b);
 }
 
+// Bound for per-id numeric dedupe when the persisted Bot API offset does not
+// advance (no onAcceptedUpdateId) or lags. Only the realistic in-process
+// redelivery window needs numeric retention; semantic keys + spool tombstones
+// cover older ids.
+export const ACCEPTED_UPDATE_ID_RETENTION = 10_000;
+
 export function createTelegramUpdateTracker(options: TelegramUpdateTrackerOptions = {}) {
   const initialUpdateId =
     typeof options.initialUpdateId === "number" ? options.initialUpdateId : null;
@@ -68,7 +74,9 @@ export function createTelegramUpdateTracker(options: TelegramUpdateTrackerOption
   const activeHandledUpdateKeys = new Map<string, boolean>();
   const pendingUpdateIds = new Set<number>();
   const failedUpdateIds = new Set<number>();
-  const completedFloorReplayUpdateIds = new Set<number>();
+  // Per-id acceptance, not a global high-water mark: multi-lane spool drains can
+  // finish newer update IDs before an older delayed id from another chat replays.
+  const acceptedUpdateIds = new Set<number>();
   let highestAcceptedUpdateId: number | null = initialUpdateId;
   let highestPersistedAcceptedUpdateId: number | null = persistenceFloorUpdateId;
   let highestPersistenceRequestedUpdateId: number | null = persistenceFloorUpdateId;
@@ -78,6 +86,34 @@ export function createTelegramUpdateTracker(options: TelegramUpdateTrackerOption
 
   const skip = (key: string) => {
     options.onSkip?.(key);
+  };
+
+  // One prune rule: drop accepted ids at or below max(persisted offset,
+  // highestAccepted - retention) unless still pending or failed. Persisted
+  // floor is safe (getUpdates cannot redeliver below it); retention bounds
+  // trackers that never advance a persisted floor.
+  const pruneAcceptedUpdateIds = () => {
+    if (highestAcceptedUpdateId === null && highestPersistedAcceptedUpdateId === null) {
+      return;
+    }
+    const windowFloor =
+      highestAcceptedUpdateId === null
+        ? Number.NEGATIVE_INFINITY
+        : highestAcceptedUpdateId - ACCEPTED_UPDATE_ID_RETENTION;
+    const persistedFloor =
+      highestPersistedAcceptedUpdateId === null
+        ? Number.NEGATIVE_INFINITY
+        : highestPersistedAcceptedUpdateId;
+    const pruneAtOrBelow = Math.max(persistedFloor, windowFloor);
+    for (const id of acceptedUpdateIds) {
+      if (id > pruneAtOrBelow) {
+        continue;
+      }
+      if (pendingUpdateIds.has(id) || failedUpdateIds.has(id)) {
+        continue;
+      }
+      acceptedUpdateIds.delete(id);
+    }
   };
 
   const drainPersistQueue = async () => {
@@ -97,6 +133,7 @@ export function createTelegramUpdateTracker(options: TelegramUpdateTrackerOption
             updateId > highestPersistedAcceptedUpdateId
           ) {
             highestPersistedAcceptedUpdateId = updateId;
+            pruneAcceptedUpdateIds();
           }
         } catch (err) {
           options.onPersistError?.(err);
@@ -125,16 +162,12 @@ export function createTelegramUpdateTracker(options: TelegramUpdateTrackerOption
   };
 
   const acceptUpdateId = (updateId: number) => {
-    if (highestAcceptedUpdateId !== null && updateId <= highestAcceptedUpdateId) {
-      return;
+    acceptedUpdateIds.add(updateId);
+    if (highestAcceptedUpdateId === null || updateId > highestAcceptedUpdateId) {
+      highestAcceptedUpdateId = updateId;
     }
-    highestAcceptedUpdateId = updateId;
+    pruneAcceptedUpdateIds();
   };
-
-  const isFloorReplayUpdateId = (updateId: number) =>
-    initialUpdateId === null &&
-    persistenceFloorUpdateId !== null &&
-    updateId <= persistenceFloorUpdateId;
 
   function resolveSafeCompletedUpdateId() {
     if (highestCompletedUpdateId === null) {
@@ -184,18 +217,16 @@ export function createTelegramUpdateTracker(options: TelegramUpdateTrackerOption
     const updateId = resolveTelegramUpdateId(ctx);
     const updateKey = buildTelegramUpdateKey(ctx);
     if (typeof updateId === "number") {
-      if (highestAcceptedUpdateId !== null && updateId <= highestAcceptedUpdateId) {
-        const floorReplay = isFloorReplayUpdateId(updateId);
-        if (!floorReplay && !failedUpdateIds.has(updateId)) {
-          skip(`update:${updateId}`);
-          return { accepted: false, reason: "accepted-watermark" };
-        }
-        if (floorReplay && completedFloorReplayUpdateIds.has(updateId)) {
-          skip(`update:${updateId}`);
-          return { accepted: false, reason: "accepted-watermark" };
-        }
-      } else {
+      if (failedUpdateIds.has(updateId)) {
         failedUpdateIds.delete(updateId);
+      } else if (initialUpdateId !== null && updateId <= initialUpdateId) {
+        // Restored Bot API offset: suppress redelivery of already-persisted ids.
+        skip(`update:${updateId}`);
+        return { accepted: false, reason: "accepted-watermark" };
+      } else if (acceptedUpdateIds.has(updateId)) {
+        // Same process already accepted this exact id (completed or in-flight).
+        skip(`update:${updateId}`);
+        return { accepted: false, reason: "accepted-watermark" };
       }
     }
     if (updateKey) {
@@ -241,9 +272,6 @@ export function createTelegramUpdateTracker(options: TelegramUpdateTrackerOption
       pendingUpdateIds.delete(update.updateId);
       if (finish.completed) {
         failedUpdateIds.delete(update.updateId);
-        if (isFloorReplayUpdateId(update.updateId)) {
-          completedFloorReplayUpdateIds.add(update.updateId);
-        }
         if (highestCompletedUpdateId === null || update.updateId > highestCompletedUpdateId) {
           highestCompletedUpdateId = update.updateId;
         }
@@ -256,6 +284,7 @@ export function createTelegramUpdateTracker(options: TelegramUpdateTrackerOption
             options.onPersistError?.(err);
           });
       }
+      pruneAcceptedUpdateIds();
     }
   };
 

--- a/extensions/telegram/src/polling-session.test.ts
+++ b/extensions/telegram/src/polling-session.test.ts
@@ -68,12 +68,13 @@ vi.mock("openclaw/plugin-sdk/runtime-env", () => ({
 
 let TelegramPollingSession: typeof import("./polling-session.js").TelegramPollingSession;
 let pollingSessionTesting: typeof import("./polling-session.js").testing;
+// Mirrors the claim-owner lease default; update together with telegram-ingress-claim-owner.ts.
+const telegramSpooledUpdateClaimLeaseMs = 30 * 60 * 1000;
 let claimTelegramSpooledUpdate: typeof import("./telegram-ingress-spool.js").claimTelegramSpooledUpdate;
 let isTelegramSpooledUpdateClaimOwnedByOtherLiveProcess: typeof import("./telegram-ingress-claim-owner.js").isTelegramSpooledUpdateClaimOwnedByOtherLiveProcess;
 let listTelegramSpooledUpdateClaims: typeof import("./telegram-ingress-spool.js").listTelegramSpooledUpdateClaims;
 let listTelegramSpooledUpdates: typeof import("./telegram-ingress-spool.js").listTelegramSpooledUpdates;
 let recoverStaleTelegramSpooledUpdateClaims: typeof import("./telegram-ingress-spool.js").recoverStaleTelegramSpooledUpdateClaims;
-let telegramSpooledUpdateClaimLeaseMs: typeof import("./telegram-ingress-claim-owner.js").TELEGRAM_SPOOLED_UPDATE_CLAIM_LEASE_MS;
 let writeTelegramSpooledUpdate: typeof import("./telegram-ingress-spool.js").writeTelegramSpooledUpdate;
 let createTelegramSpooledReplayDeferredParticipant: typeof import("./bot-processing-outcome.js").createTelegramSpooledReplayDeferredParticipant;
 let TelegramMessageDispatchReplayForgetError: typeof import("./message-dispatch-dedupe.js").TelegramMessageDispatchReplayForgetError;
@@ -693,10 +694,8 @@ describe("TelegramPollingSession", () => {
       recoverStaleTelegramSpooledUpdateClaims,
       writeTelegramSpooledUpdate,
     } = await import("./telegram-ingress-spool.js"));
-    ({
-      isTelegramSpooledUpdateClaimOwnedByOtherLiveProcess,
-      TELEGRAM_SPOOLED_UPDATE_CLAIM_LEASE_MS: telegramSpooledUpdateClaimLeaseMs,
-    } = await import("./telegram-ingress-claim-owner.js"));
+    ({ isTelegramSpooledUpdateClaimOwnedByOtherLiveProcess } =
+      await import("./telegram-ingress-claim-owner.js"));
     ({ createTelegramSpooledReplayDeferredParticipant } =
       await import("./bot-processing-outcome.js"));
     ({ TelegramMessageDispatchReplayForgetError } = await import("./message-dispatch-dedupe.js"));

--- a/extensions/telegram/src/polling-session.test.ts
+++ b/extensions/telegram/src/polling-session.test.ts
@@ -69,11 +69,11 @@ vi.mock("openclaw/plugin-sdk/runtime-env", () => ({
 let TelegramPollingSession: typeof import("./polling-session.js").TelegramPollingSession;
 let pollingSessionTesting: typeof import("./polling-session.js").testing;
 let claimTelegramSpooledUpdate: typeof import("./telegram-ingress-spool.js").claimTelegramSpooledUpdate;
-let isTelegramSpooledUpdateClaimOwnedByOtherLiveProcess: typeof import("./telegram-ingress-spool.js").isTelegramSpooledUpdateClaimOwnedByOtherLiveProcess;
+let isTelegramSpooledUpdateClaimOwnedByOtherLiveProcess: typeof import("./telegram-ingress-claim-owner.js").isTelegramSpooledUpdateClaimOwnedByOtherLiveProcess;
 let listTelegramSpooledUpdateClaims: typeof import("./telegram-ingress-spool.js").listTelegramSpooledUpdateClaims;
 let listTelegramSpooledUpdates: typeof import("./telegram-ingress-spool.js").listTelegramSpooledUpdates;
 let recoverStaleTelegramSpooledUpdateClaims: typeof import("./telegram-ingress-spool.js").recoverStaleTelegramSpooledUpdateClaims;
-let telegramSpooledUpdateClaimLeaseMs: typeof import("./telegram-ingress-spool.js").TELEGRAM_SPOOLED_UPDATE_CLAIM_LEASE_MS;
+let telegramSpooledUpdateClaimLeaseMs: typeof import("./telegram-ingress-claim-owner.js").TELEGRAM_SPOOLED_UPDATE_CLAIM_LEASE_MS;
 let writeTelegramSpooledUpdate: typeof import("./telegram-ingress-spool.js").writeTelegramSpooledUpdate;
 let createTelegramSpooledReplayDeferredParticipant: typeof import("./bot-processing-outcome.js").createTelegramSpooledReplayDeferredParticipant;
 let TelegramMessageDispatchReplayForgetError: typeof import("./message-dispatch-dedupe.js").TelegramMessageDispatchReplayForgetError;
@@ -688,13 +688,15 @@ describe("TelegramPollingSession", () => {
       await import("./polling-session.js"));
     ({
       claimTelegramSpooledUpdate,
-      isTelegramSpooledUpdateClaimOwnedByOtherLiveProcess,
       listTelegramSpooledUpdateClaims,
       listTelegramSpooledUpdates,
       recoverStaleTelegramSpooledUpdateClaims,
-      TELEGRAM_SPOOLED_UPDATE_CLAIM_LEASE_MS: telegramSpooledUpdateClaimLeaseMs,
       writeTelegramSpooledUpdate,
     } = await import("./telegram-ingress-spool.js"));
+    ({
+      isTelegramSpooledUpdateClaimOwnedByOtherLiveProcess,
+      TELEGRAM_SPOOLED_UPDATE_CLAIM_LEASE_MS: telegramSpooledUpdateClaimLeaseMs,
+    } = await import("./telegram-ingress-claim-owner.js"));
     ({ createTelegramSpooledReplayDeferredParticipant } =
       await import("./bot-processing-outcome.js"));
     ({ TelegramMessageDispatchReplayForgetError } = await import("./message-dispatch-dedupe.js"));
@@ -2855,14 +2857,19 @@ describe("TelegramPollingSession", () => {
       await adoptClaimOwner({
         spoolDir: tempDir,
         updateId: 42,
-        ownerId: `${liveOwnerPid}:other-process`,
+        // starttime matches the live owner so process identity proves ownership.
+        ownerId: `${liveOwnerPid}:5555:other-process`,
         claimedAt: Date.now(),
       });
 
       const recovered = await recoverStaleTelegramSpooledUpdateClaims({
         spoolDir: tempDir,
         staleMs: 0,
-        shouldRecover: (claim) => !isTelegramSpooledUpdateClaimOwnedByOtherLiveProcess(claim),
+        shouldRecover: (claim) =>
+          !isTelegramSpooledUpdateClaimOwnedByOtherLiveProcess(claim, {
+            processExists: (pid) => pid === liveOwnerPid,
+            readProcessStartTime: (pid) => (pid === liveOwnerPid ? 5555 : null),
+          }),
       });
 
       expect(recovered).toBe(0);
@@ -2896,7 +2903,7 @@ describe("TelegramPollingSession", () => {
       await adoptClaimOwner({
         spoolDir: tempDir,
         updateId: 42,
-        ownerId: `${process.pid}:other-process`,
+        ownerId: `${process.pid}:1:other-process`,
         claimedAt: Date.now() - 101,
       });
 
@@ -2916,6 +2923,128 @@ describe("TelegramPollingSession", () => {
       expect(await pendingUpdateIds(tempDir, "all")).toEqual([43]);
       expect(await listTelegramSpooledUpdateClaims({ spoolDir: tempDir })).toEqual([]);
       stopWorker();
+    });
+  });
+
+  it("recovers a fresh claim whose pid now belongs only to a thread of this process", async () => {
+    await withTempSpool(async (tempDir) => {
+      const abort = new AbortController();
+      const events: string[] = [];
+      await writeSpooledTestUpdates(tempDir, [
+        topicUpdate(42, 10, "tid-reuse wedged turn"),
+        topicUpdate(43, 10, "later same-lane turn"),
+      ]);
+      const interrupted = (await listTelegramSpooledUpdates({ spoolDir: tempDir })).find(
+        (update) => update.updateId === 42,
+      );
+      if (!interrupted) {
+        throw new Error("Expected interrupted update");
+      }
+      const claimed = await claimTelegramSpooledUpdate(interrupted);
+      if (!claimed) {
+        throw new Error("Expected claimed update");
+      }
+      // Old owner PID 9 is gone; a thread of this process now occupies numeric id 9.
+      await adoptClaimOwner({
+        spoolDir: tempDir,
+        updateId: 42,
+        ownerId: "9:1000:dead-owner",
+        claimedAt: Date.now(),
+      });
+
+      const recovered = await recoverStaleTelegramSpooledUpdateClaims({
+        spoolDir: tempDir,
+        staleMs: 0,
+        shouldRecover: (claim) =>
+          !isTelegramSpooledUpdateClaimOwnedByOtherLiveProcess(claim, {
+            maxAgeMs: telegramSpooledUpdateClaimLeaseMs,
+            processExists: (pid) => pid === 9,
+            readProcessStartTime: (pid) => (pid === 9 ? 2000 : null),
+          }),
+      });
+      expect(recovered).toBe(1);
+      expect(await pendingUpdateIds(tempDir, "all")).toEqual([42, 43]);
+
+      const { runPromise, stopWorker } = startIsolatedIngressSession({
+        abort,
+        spoolDir: tempDir,
+        drainIntervalMs: 10,
+        handleUpdate: async (update) => {
+          events.push(`handled:${update.update_id}`);
+          if (events.length >= 2) {
+            abort.abort();
+          }
+        },
+      });
+
+      await vi.waitFor(() => expect(events).toEqual(["handled:42", "handled:43"]));
+      await runPromise;
+      expect(await listTelegramSpooledUpdateClaims({ spoolDir: tempDir })).toEqual([]);
+      stopWorker();
+    });
+  });
+
+  it("tombstones a post-adoption claim after restart without re-running the turn", async () => {
+    await withTempSpool(async (tempDir) => {
+      const abort = new AbortController();
+      const events: string[] = [];
+      // Simulate the crash window: turn was durably adopted (dispatch dedupe
+      // committed / restart recovery will complete the run), but the ingress
+      // claim was not yet tombstoned. Restart recovery does not store update_id,
+      // so the claim is reclaimed and replayed; handleUpdate completes it with
+      // no model re-dispatch (dedupe / skip path).
+      await writeSpooledTestUpdates(tempDir, [
+        topicUpdate(42, 10, "adopted before crash"),
+        topicUpdate(43, 10, "later same-lane turn"),
+      ]);
+      const adopted = (await listTelegramSpooledUpdates({ spoolDir: tempDir })).find(
+        (update) => update.updateId === 42,
+      );
+      if (!adopted) {
+        throw new Error("Expected adopted update");
+      }
+      const claimed = await claimTelegramSpooledUpdate(adopted);
+      if (!claimed) {
+        throw new Error("Expected claimed update");
+      }
+      await adoptClaimOwner({
+        spoolDir: tempDir,
+        updateId: 42,
+        ownerId: "9:1000:dead-owner",
+        claimedAt: Date.now(),
+      });
+
+      const recovered = await recoverStaleTelegramSpooledUpdateClaims({
+        spoolDir: tempDir,
+        staleMs: 0,
+        shouldRecover: (claim) =>
+          !isTelegramSpooledUpdateClaimOwnedByOtherLiveProcess(claim, {
+            maxAgeMs: telegramSpooledUpdateClaimLeaseMs,
+            processExists: (pid) => pid === 9,
+            readProcessStartTime: (pid) => (pid === 9 ? 2000 : null),
+          }),
+      });
+      expect(recovered).toBe(1);
+
+      const { runPromise, stopWorker } = startIsolatedIngressSession({
+        abort,
+        spoolDir: tempDir,
+        drainIntervalMs: 10,
+        handleUpdate: async (update) => {
+          // Replay of already-adopted update: no deferred participant / no model
+          // dispatch — spool drain completes the row as a tombstone.
+          events.push(`replay:${update.update_id}`);
+        },
+      });
+
+      await vi.waitFor(() => expect(events).toEqual(["replay:42", "replay:43"]));
+      await vi.waitFor(async () =>
+        expect(await listTelegramSpooledUpdateClaims({ spoolDir: tempDir })).toEqual([]),
+      );
+      expect(await pendingUpdateIds(tempDir, "all")).toEqual([]);
+      abort.abort();
+      stopWorker();
+      await runPromise;
     });
   });
 

--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -37,19 +37,20 @@ import {
   TELEGRAM_SPOOLED_RETRY_MAX_ATTEMPTS,
 } from "./spooled-update-retry-policy.js";
 import {
+  isTelegramSpooledCorruptClaimOwnedByOtherLiveProcess,
+  isTelegramSpooledUpdateClaimOwnedByOtherLiveProcess,
+} from "./telegram-ingress-claim-owner.js";
+import {
   abandonTelegramSpooledUpdateClaim,
   claimNextTelegramSpooledUpdate,
   completeTelegramSpooledUpdateWithRetry,
   failTelegramSpooledUpdateClaim,
-  isTelegramSpooledCorruptClaimOwnedByOtherLiveProcess,
-  isTelegramSpooledUpdateClaimOwnedByOtherLiveProcess,
   listTelegramSpooledUpdateClaims,
   listTelegramSpooledUpdates,
   recoverStaleTelegramSpooledUpdateClaims,
   refreshTelegramSpooledUpdateClaim,
   releaseTelegramSpooledUpdateClaim,
   resolveTelegramIngressSpoolDir,
-  TELEGRAM_SPOOLED_UPDATE_CLAIM_LEASE_MS,
   writeTelegramSpooledUpdate,
   type ClaimedTelegramSpooledUpdate,
   type TelegramSpooledUpdate,
@@ -948,14 +949,10 @@ export class TelegramPollingSession {
       shouldRecover: (claim) =>
         !this.#isDeferredSpooledUpdateClaim(claim) &&
         !activeLaneKeys.has(this.#spooledUpdateLaneKey(claim)) &&
-        !isTelegramSpooledUpdateClaimOwnedByOtherLiveProcess(claim, {
-          maxAgeMs: TELEGRAM_SPOOLED_UPDATE_CLAIM_LEASE_MS,
-        }),
+        !isTelegramSpooledUpdateClaimOwnedByOtherLiveProcess(claim),
       shouldRecoverCorrupt: (claim) =>
         !(claim.laneKey && activeLaneKeys.has(claim.laneKey)) &&
-        !isTelegramSpooledCorruptClaimOwnedByOtherLiveProcess(claim, {
-          maxAgeMs: TELEGRAM_SPOOLED_UPDATE_CLAIM_LEASE_MS,
-        }),
+        !isTelegramSpooledCorruptClaimOwnedByOtherLiveProcess(claim),
     });
     const claimedLaneKeys = new Set(
       (

--- a/extensions/telegram/src/telegram-ingress-claim-owner.ts
+++ b/extensions/telegram/src/telegram-ingress-claim-owner.ts
@@ -10,9 +10,9 @@ import type {
 
 // Liveness default: a claim older than its lease is never live-owner protected,
 // so recovery can reclaim it even when the owner process still exists.
-export const TELEGRAM_SPOOLED_UPDATE_CLAIM_LEASE_MS = 30 * 60 * 1000;
+const TELEGRAM_SPOOLED_UPDATE_CLAIM_LEASE_MS = 30 * 60 * 1000;
 
-export type TelegramSpooledClaimLivenessOptions = {
+type TelegramSpooledClaimLivenessOptions = {
   maxAgeMs?: number;
   now?: number;
   /** Test seam for PID existence (including Linux TID impersonation). */

--- a/extensions/telegram/src/telegram-ingress-claim-owner.ts
+++ b/extensions/telegram/src/telegram-ingress-claim-owner.ts
@@ -1,0 +1,185 @@
+// Telegram plugin module implements telegram ingress claim-owner identity.
+import childProcess from "node:child_process";
+import { randomUUID } from "node:crypto";
+import fsSync from "node:fs";
+import type { ChannelIngressQueueCorruptClaim } from "openclaw/plugin-sdk/channel-outbound";
+import type {
+  ClaimedTelegramSpooledUpdate,
+  TelegramSpooledUpdateClaimOwner,
+} from "./telegram-ingress-spool.types.js";
+
+// Liveness default: a claim older than its lease is never live-owner protected,
+// so recovery can reclaim it even when the owner process still exists.
+export const TELEGRAM_SPOOLED_UPDATE_CLAIM_LEASE_MS = 30 * 60 * 1000;
+
+export type TelegramSpooledClaimLivenessOptions = {
+  maxAgeMs?: number;
+  now?: number;
+  /** Test seam for PID existence (including Linux TID impersonation). */
+  processExists?: (pid: number) => boolean;
+  /** Test seam for process start-time identity. */
+  readProcessStartTime?: (pid: number) => number | null;
+};
+
+function readProcessStartTime(pid: number): number | null {
+  if (!Number.isSafeInteger(pid) || pid <= 0) {
+    return null;
+  }
+  if (process.platform === "darwin") {
+    try {
+      const startedAt = childProcess
+        .execFileSync("/bin/ps", ["-o", "lstart=", "-p", String(pid)], {
+          encoding: "utf8",
+          env: { ...process.env, LC_ALL: "C", TZ: "UTC" },
+          stdio: ["ignore", "pipe", "ignore"],
+        })
+        .trim();
+      const startedAtMs = Date.parse(`${startedAt} UTC`);
+      return Number.isFinite(startedAtMs) ? Math.floor(startedAtMs / 1000) : null;
+    } catch {
+      return null;
+    }
+  }
+  if (process.platform !== "linux") {
+    return null;
+  }
+  try {
+    const stat = fsSync.readFileSync(`/proc/${pid}/stat`, "utf8");
+    const commEndIndex = stat.lastIndexOf(")");
+    if (commEndIndex < 0) {
+      return null;
+    }
+    const afterComm = stat.slice(commEndIndex + 1).trimStart();
+    const fields = afterComm.split(/\s+/);
+    // field 22 (starttime) = index 19 after the comm-split (field 3 is index 0).
+    const starttime = Number(fields[19]);
+    return Number.isInteger(starttime) && starttime >= 0 ? starttime : null;
+  } catch {
+    return null;
+  }
+}
+
+const TELEGRAM_SPOOLED_UPDATE_PROCESS_START_TIME = readProcessStartTime(process.pid);
+// ownerId = pid:startToken:uuid. Starttime binds the PID to one process instance so
+// Linux TIDs and recycled PIDs cannot impersonate a dead claim owner.
+export const TELEGRAM_SPOOLED_UPDATE_PROCESS_ID = [
+  process.pid,
+  TELEGRAM_SPOOLED_UPDATE_PROCESS_START_TIME ?? "x",
+  randomUUID(),
+].join(":");
+
+export function processPidFromOwnerId(ownerId: string): number {
+  const pid = Number.parseInt(ownerId.split(":", 1)[0] ?? "", 10);
+  return Number.isSafeInteger(pid) && pid > 0 ? pid : -1;
+}
+
+// Canonical ownerId: pid:startToken:uuid. startToken is a numeric starttime, or
+// the explicit "x" sentinel when the writer cannot supply one (win32).
+type OwnerStartToken =
+  | { kind: "numeric"; value: number }
+  | { kind: "existence-only" }
+  | { kind: "missing" };
+
+function parseOwnerStartToken(ownerId: string): OwnerStartToken {
+  const parts = ownerId.split(":");
+  // Legacy pid:uuid owners (pre start-token releases) carry no instance binding.
+  // Keep existence-based liveness for them: reclaiming a fresh claim from a live
+  // old-version worker during a rolling upgrade would double-dispatch its update.
+  if (parts.length === 2) {
+    return { kind: "existence-only" };
+  }
+  if (parts.length < 2) {
+    return { kind: "missing" };
+  }
+  const startField = parts[1] ?? "";
+  // Explicit "x": writer ran on a platform with no readable starttime (win32).
+  if (startField === "x") {
+    return { kind: "existence-only" };
+  }
+  const starttime = Number(startField);
+  if (Number.isSafeInteger(starttime) && starttime >= 0) {
+    return { kind: "numeric", value: starttime };
+  }
+  return { kind: "missing" };
+}
+
+function processExists(pid: number): boolean {
+  if (!Number.isSafeInteger(pid) || pid <= 0) {
+    return false;
+  }
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    const code = (err as { code?: string }).code;
+    return code !== "ESRCH" && code !== "EINVAL";
+  }
+}
+
+function isFreshClaimOwner(
+  claim: TelegramSpooledUpdateClaimOwner,
+  options?: { maxAgeMs?: number; now?: number },
+): boolean {
+  const now = options?.now ?? Date.now();
+  const maxAgeMs = options?.maxAgeMs ?? TELEGRAM_SPOOLED_UPDATE_CLAIM_LEASE_MS;
+  return now - claim.claimedAt < maxAgeMs;
+}
+
+function isClaimOwnerProcessInstanceLive(
+  claim: Pick<TelegramSpooledUpdateClaimOwner, "processId" | "processPid">,
+  options?: TelegramSpooledClaimLivenessOptions,
+): boolean {
+  const exists = options?.processExists ?? processExists;
+  const readStart = options?.readProcessStartTime ?? readProcessStartTime;
+  if (!exists(claim.processPid)) {
+    return false;
+  }
+  const startToken = parseOwnerStartToken(claim.processId);
+  if (startToken.kind === "missing") {
+    // Legacy/malformed owner ids have no process-instance binding; reclaim.
+    return false;
+  }
+  if (startToken.kind === "existence-only") {
+    // Legacy or `x` owners cannot prove instance identity. Fall back to
+    // processExists-only liveness — the pre-starttime lease contract — instead
+    // of stealing a fresh claim from a possibly live worker.
+    return true;
+  }
+  const actualStart = readStart(claim.processPid);
+  if (actualStart === null) {
+    // Starttime unreadable while the PID appears live. Keep lease protection
+    // via process existence so a readable-starttime peer is not stolen mid-run.
+    return true;
+  }
+  return actualStart === startToken.value;
+}
+
+export function isTelegramSpooledUpdateClaimOwnedByOtherLiveProcess(
+  claim: ClaimedTelegramSpooledUpdate,
+  options?: TelegramSpooledClaimLivenessOptions,
+): boolean {
+  return Boolean(
+    claim.claim &&
+    claim.claim.processId !== TELEGRAM_SPOOLED_UPDATE_PROCESS_ID &&
+    claim.claim.processPid !== process.pid &&
+    isFreshClaimOwner(claim.claim, options) &&
+    isClaimOwnerProcessInstanceLive(claim.claim, options),
+  );
+}
+
+export function isTelegramSpooledCorruptClaimOwnedByOtherLiveProcess(
+  claim: ChannelIngressQueueCorruptClaim,
+  options?: TelegramSpooledClaimLivenessOptions,
+): boolean {
+  const processId = claim.claim.ownerId;
+  const processPid = processPidFromOwnerId(processId);
+  const owner = { processId, processPid, claimedAt: claim.claim.claimedAt };
+  if (processId === TELEGRAM_SPOOLED_UPDATE_PROCESS_ID) {
+    return isFreshClaimOwner(owner, options);
+  }
+  return (
+    processPid !== process.pid &&
+    isFreshClaimOwner(owner, options) &&
+    isClaimOwnerProcessInstanceLive(owner, options)
+  );
+}

--- a/extensions/telegram/src/telegram-ingress-spool.test.ts
+++ b/extensions/telegram/src/telegram-ingress-spool.test.ts
@@ -9,13 +9,13 @@ import {
 import { afterEach, describe, expect, it } from "vitest";
 import { clearTelegramRuntime, setTelegramRuntime } from "./runtime.js";
 import type { TelegramRuntime } from "./runtime.types.js";
+import { isTelegramSpooledUpdateClaimOwnedByOtherLiveProcess } from "./telegram-ingress-claim-owner.js";
 import {
   claimNextTelegramSpooledUpdate,
   claimTelegramSpooledUpdate,
   completeTelegramSpooledUpdate,
   completeTelegramSpooledUpdateWithRetry,
   failTelegramSpooledUpdateClaim,
-  isTelegramSpooledUpdateClaimOwnedByOtherLiveProcess,
   listTelegramSpooledUpdateClaims,
   listTelegramSpooledUpdates,
   recoverStaleTelegramSpooledUpdateClaims,
@@ -467,7 +467,7 @@ describe("Telegram ingress spool", () => {
         update: { update_id: 50 },
         receivedAt: now,
         claim: {
-          processId: "other-process",
+          processId: `${process.pid}:1:other-process`,
           processPid: process.pid,
           claimedAt: now - TELEGRAM_SPOOLED_UPDATE_PROCESSING_STALE_MS - 1,
         },
@@ -485,7 +485,7 @@ describe("Telegram ingress spool", () => {
         update: { update_id: 50 },
         receivedAt: now,
         claim: {
-          processId: "other-process",
+          processId: `${process.pid}:1:other-process`,
           processPid: process.pid,
           claimedAt: now,
         },
@@ -493,22 +493,177 @@ describe("Telegram ingress spool", () => {
     ).toBe(false);
   });
 
-  it("treats fresh claims with other live pids as live-owned", () => {
+  it("does not treat a fresh foreign claim as live-owned when its pid is only a thread of this process", () => {
+    const now = Date.now();
+    // Incident shape: dead owner PID 9 is reused as a Linux TID of the new process.
+    // process.kill(9, 0) succeeds, but starttime no longer matches the claim owner.
+    expect(
+      isTelegramSpooledUpdateClaimOwnedByOtherLiveProcess(
+        {
+          updateId: 52,
+          path: path.join(os.tmpdir(), "52.json.processing"),
+          pendingPath: path.join(os.tmpdir(), "52.json"),
+          update: { update_id: 52 },
+          receivedAt: now,
+          claim: {
+            processId: "9:1000:dead-owner",
+            processPid: 9,
+            claimedAt: now,
+          },
+        },
+        {
+          processExists: (pid) => pid === 9,
+          readProcessStartTime: (pid) => (pid === 9 ? 2000 : null),
+        },
+      ),
+    ).toBe(false);
+  });
+
+  it("does not treat a fresh foreign claim as live-owned when its pid was reused by an unrelated process", () => {
+    const now = Date.now();
+    expect(
+      isTelegramSpooledUpdateClaimOwnedByOtherLiveProcess(
+        {
+          updateId: 53,
+          path: path.join(os.tmpdir(), "53.json.processing"),
+          pendingPath: path.join(os.tmpdir(), "53.json"),
+          update: { update_id: 53 },
+          receivedAt: now,
+          claim: {
+            processId: "4242:1000:dead-owner",
+            processPid: 4242,
+            claimedAt: now,
+          },
+        },
+        {
+          processExists: (pid) => pid === 4242,
+          readProcessStartTime: (pid) => (pid === 4242 ? 9999 : null),
+        },
+      ),
+    ).toBe(false);
+  });
+
+  it("treats fresh claims with other live process instances as live-owned", () => {
     const now = Date.now();
     const liveOwnerPid = process.ppid > 0 ? process.ppid : 1;
     expect(
-      isTelegramSpooledUpdateClaimOwnedByOtherLiveProcess({
-        updateId: 51,
-        path: path.join(os.tmpdir(), "51.json.processing"),
-        pendingPath: path.join(os.tmpdir(), "51.json"),
-        update: { update_id: 51 },
-        receivedAt: now,
-        claim: {
-          processId: "other-process",
-          processPid: liveOwnerPid,
-          claimedAt: now,
+      isTelegramSpooledUpdateClaimOwnedByOtherLiveProcess(
+        {
+          updateId: 51,
+          path: path.join(os.tmpdir(), "51.json.processing"),
+          pendingPath: path.join(os.tmpdir(), "51.json"),
+          update: { update_id: 51 },
+          receivedAt: now,
+          claim: {
+            processId: `${liveOwnerPid}:5555:other-process`,
+            processPid: liveOwnerPid,
+            claimedAt: now,
+          },
         },
-      }),
+        {
+          processExists: (pid) => pid === liveOwnerPid,
+          readProcessStartTime: (pid) => (pid === liveOwnerPid ? 5555 : null),
+        },
+      ),
     ).toBe(true);
+  });
+
+  it("keeps existence-based lease protection for fresh legacy two-part owner ids", () => {
+    const now = Date.now();
+    const liveOwnerPid = process.ppid > 0 ? process.ppid : 1;
+    // Rolling upgrade: a live pre-starttime worker still holds pid:uuid claims.
+    // Stealing them while the owner process exists would double-dispatch.
+    expect(
+      isTelegramSpooledUpdateClaimOwnedByOtherLiveProcess(
+        {
+          updateId: 54,
+          path: path.join(os.tmpdir(), "54.json.processing"),
+          pendingPath: path.join(os.tmpdir(), "54.json"),
+          update: { update_id: 54 },
+          receivedAt: now,
+          claim: {
+            processId: `${liveOwnerPid}:legacy-owner`,
+            processPid: liveOwnerPid,
+            claimedAt: now,
+          },
+        },
+        {
+          processExists: () => true,
+          readProcessStartTime: () => 1,
+        },
+      ),
+    ).toBe(true);
+  });
+
+  it("does not treat malformed owner ids as live-owned", () => {
+    const now = Date.now();
+    const liveOwnerPid = process.ppid > 0 ? process.ppid : 1;
+    expect(
+      isTelegramSpooledUpdateClaimOwnedByOtherLiveProcess(
+        {
+          updateId: 55,
+          path: path.join(os.tmpdir(), "55.json.processing"),
+          pendingPath: path.join(os.tmpdir(), "55.json"),
+          update: { update_id: 55 },
+          receivedAt: now,
+          claim: {
+            processId: `${liveOwnerPid}:not-a-starttime:owner-uuid`,
+            processPid: liveOwnerPid,
+            claimedAt: now,
+          },
+        },
+        {
+          processExists: () => true,
+          readProcessStartTime: () => 1,
+        },
+      ),
+    ).toBe(false);
+  });
+
+  it("treats explicit x start tokens as existence-only live owners", () => {
+    const now = Date.now();
+    const liveOwnerPid = process.ppid > 0 ? process.ppid : 1;
+    // win32 writers emit pid:x:uuid when starttime is unavailable; keep the
+    // pre-starttime processExists multi-instance lease contract.
+    expect(
+      isTelegramSpooledUpdateClaimOwnedByOtherLiveProcess(
+        {
+          updateId: 55,
+          path: path.join(os.tmpdir(), "55.json.processing"),
+          pendingPath: path.join(os.tmpdir(), "55.json"),
+          update: { update_id: 55 },
+          receivedAt: now,
+          claim: {
+            processId: `${liveOwnerPid}:x:win32-owner`,
+            processPid: liveOwnerPid,
+            claimedAt: now,
+          },
+        },
+        {
+          processExists: (pid) => pid === liveOwnerPid,
+          readProcessStartTime: () => null,
+        },
+      ),
+    ).toBe(true);
+    expect(
+      isTelegramSpooledUpdateClaimOwnedByOtherLiveProcess(
+        {
+          updateId: 56,
+          path: path.join(os.tmpdir(), "56.json.processing"),
+          pendingPath: path.join(os.tmpdir(), "56.json"),
+          update: { update_id: 56 },
+          receivedAt: now,
+          claim: {
+            processId: "99999:x:dead-win32-owner",
+            processPid: 99999,
+            claimedAt: now,
+          },
+        },
+        {
+          processExists: () => false,
+          readProcessStartTime: () => null,
+        },
+      ),
+    ).toBe(false);
   });
 });

--- a/extensions/telegram/src/telegram-ingress-spool.ts
+++ b/extensions/telegram/src/telegram-ingress-spool.ts
@@ -1,5 +1,4 @@
 // Telegram plugin module implements telegram ingress spool behavior.
-import { randomUUID } from "node:crypto";
 import os from "node:os";
 import path from "node:path";
 import type {
@@ -16,10 +15,13 @@ import { getTelegramRuntime } from "./runtime.js";
 import { getTelegramSequentialKey } from "./sequential-key.js";
 import { resolveSpooledUpdatePersistenceRetryDelayMs } from "./spooled-update-retry-policy.js";
 import { normalizeTelegramStateAccountId } from "./state-account-id.js";
+import {
+  processPidFromOwnerId,
+  TELEGRAM_SPOOLED_UPDATE_PROCESS_ID,
+} from "./telegram-ingress-claim-owner.js";
 import type {
   ClaimedTelegramSpooledUpdate,
   TelegramSpooledUpdate,
-  TelegramSpooledUpdateClaimOwner,
 } from "./telegram-ingress-spool.types.js";
 
 export type {
@@ -30,12 +32,10 @@ export type {
 const SPOOL_VERSION = 1;
 const TELEGRAM_INGRESS_SPOOL_PREFIX = "ingress-spool-";
 export const TELEGRAM_SPOOLED_UPDATE_PROCESSING_STALE_MS = 6 * 60 * 60 * 1000;
-export const TELEGRAM_SPOOLED_UPDATE_CLAIM_LEASE_MS = 30 * 60 * 1000;
 const TELEGRAM_SPOOLED_UPDATE_FAILED_TTL_MS = 30 * 24 * 60 * 60 * 1000;
 const TELEGRAM_SPOOLED_UPDATE_FAILED_MAX_ENTRIES = 1000;
 const TELEGRAM_SPOOLED_UPDATE_COMPLETED_TTL_MS = 30 * 24 * 60 * 60 * 1000;
 const TELEGRAM_SPOOLED_UPDATE_COMPLETED_MAX_ENTRIES = 1000;
-const TELEGRAM_SPOOLED_UPDATE_PROCESS_ID = `${process.pid}:${randomUUID()}`;
 
 type TelegramSpooledUpdatePayload = {
   version: number;
@@ -139,33 +139,6 @@ async function pruneTelegramIngressQueue(
   });
 }
 
-function processPidFromOwnerId(ownerId: string): number {
-  const pid = Number.parseInt(ownerId.split(":", 1)[0] ?? "", 10);
-  return Number.isSafeInteger(pid) && pid > 0 ? pid : -1;
-}
-
-function processExists(pid: number): boolean {
-  if (!Number.isSafeInteger(pid) || pid <= 0) {
-    return false;
-  }
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch (err) {
-    const code = (err as { code?: string }).code;
-    return code !== "ESRCH" && code !== "EINVAL";
-  }
-}
-
-function isFreshClaimOwner(
-  claim: TelegramSpooledUpdateClaimOwner,
-  options?: { maxAgeMs?: number; now?: number },
-): boolean {
-  const now = options?.now ?? Date.now();
-  const maxAgeMs = options?.maxAgeMs ?? TELEGRAM_SPOOLED_UPDATE_PROCESSING_STALE_MS;
-  return now - claim.claimedAt < maxAgeMs;
-}
-
 function parseQueueRecord(
   spoolDir: string,
   record: ChannelIngressQueueRecord<TelegramSpooledUpdatePayload>,
@@ -220,34 +193,6 @@ function sortTelegramUpdates<T extends TelegramSpooledUpdate>(updates: T[]): T[]
 function queueMutationTarget(update: TelegramSpooledUpdate): string | ChannelIngressQueueClaimRef {
   const id = queueEventId(update.updateId);
   return update.claim?.claimToken ? { id, claim: { token: update.claim.claimToken } } : id;
-}
-
-export function isTelegramSpooledUpdateClaimOwnedByOtherLiveProcess(
-  claim: ClaimedTelegramSpooledUpdate,
-  options?: { maxAgeMs?: number; now?: number },
-): boolean {
-  return Boolean(
-    claim.claim &&
-    claim.claim.processId !== TELEGRAM_SPOOLED_UPDATE_PROCESS_ID &&
-    claim.claim.processPid !== process.pid &&
-    isFreshClaimOwner(claim.claim, options) &&
-    processExists(claim.claim.processPid),
-  );
-}
-
-export function isTelegramSpooledCorruptClaimOwnedByOtherLiveProcess(
-  claim: ChannelIngressQueueCorruptClaim,
-  options?: { maxAgeMs?: number; now?: number },
-): boolean {
-  const processId = claim.claim.ownerId;
-  const processPid = processPidFromOwnerId(processId);
-  const owner = { processId, processPid, claimedAt: claim.claim.claimedAt };
-  if (processId === TELEGRAM_SPOOLED_UPDATE_PROCESS_ID) {
-    return isFreshClaimOwner(owner, options);
-  }
-  return (
-    processPid !== process.pid && isFreshClaimOwner(owner, options) && processExists(processPid)
-  );
 }
 
 export async function writeTelegramSpooledUpdate(params: {

--- a/extensions/telegram/src/webhook.ts
+++ b/extensions/telegram/src/webhook.ts
@@ -50,18 +50,19 @@ import {
   TELEGRAM_SPOOLED_RETRY_MAX_ATTEMPTS,
 } from "./spooled-update-retry-policy.js";
 import {
+  isTelegramSpooledCorruptClaimOwnedByOtherLiveProcess,
+  isTelegramSpooledUpdateClaimOwnedByOtherLiveProcess,
+} from "./telegram-ingress-claim-owner.js";
+import {
   claimNextTelegramSpooledUpdate,
   completeTelegramSpooledUpdateWithRetry,
   failTelegramSpooledUpdateClaim,
-  isTelegramSpooledCorruptClaimOwnedByOtherLiveProcess,
-  isTelegramSpooledUpdateClaimOwnedByOtherLiveProcess,
   listTelegramSpooledUpdateClaims,
   listTelegramSpooledUpdates,
   recoverStaleTelegramSpooledUpdateClaims,
   refreshTelegramSpooledUpdateClaim,
   releaseTelegramSpooledUpdateClaim,
   resolveTelegramIngressSpoolDir,
-  TELEGRAM_SPOOLED_UPDATE_CLAIM_LEASE_MS,
   writeTelegramSpooledUpdate,
   type ClaimedTelegramSpooledUpdate,
 } from "./telegram-ingress-spool.js";
@@ -771,14 +772,10 @@ export async function startTelegramWebhook(opts: {
         staleMs: 0,
         shouldRecover: (claim) =>
           !activeWebhookSpooledLaneKeys.has(resolveWebhookSpooledUpdateLaneKey(claim.update)) &&
-          !isTelegramSpooledUpdateClaimOwnedByOtherLiveProcess(claim, {
-            maxAgeMs: TELEGRAM_SPOOLED_UPDATE_CLAIM_LEASE_MS,
-          }),
+          !isTelegramSpooledUpdateClaimOwnedByOtherLiveProcess(claim),
         shouldRecoverCorrupt: (claim) =>
           !(claim.laneKey && activeWebhookSpooledLaneKeys.has(claim.laneKey)) &&
-          !isTelegramSpooledCorruptClaimOwnedByOtherLiveProcess(claim, {
-            maxAgeMs: TELEGRAM_SPOOLED_UPDATE_CLAIM_LEASE_MS,
-          }),
+          !isTelegramSpooledCorruptClaimOwnedByOtherLiveProcess(claim),
       });
       const claimedLaneKeys = new Set(
         (


### PR DESCRIPTION
## What Problem This Solves

Fixes #107246 — two independent Telegram durable-ingress bugs that combined into silent inbound message loss after a gateway restart:

**A. PID reused as a Linux thread ID fakes a live claim owner.** Spool claim liveness was `process.kill(pid, 0)` (`processExists`). On Linux, that succeeds for *thread* IDs of any process, and after a restart the dead owner's PID can reappear as a TID of the new gateway (observed in production: old owner PID 9, new gateway PID 8, `/proc/9/status` → `Tgid: 8`). Stale-claim recovery (`polling-session.ts` and the webhook drain both gate on `isTelegramSpooledUpdateClaimOwnedByOtherLiveProcess`) then refuses the claim for the full 30-minute lease, wedging every later update in that chat's lane (`pending`, attempts=0).

**B. Global update-ID watermark drops delayed cross-lane replays.** Telegram `update_id`s are global across chats. While one lane is delayed, other lanes complete newer IDs and advance the tracker's single `highestAcceptedUpdateId`. When the delayed updates finally replay from the durable spool, `beginUpdate` rejects them as `accepted-watermark`, bot middleware returns before any handler, and the drain tombstones the rows as completed — zero model dispatch, permanent loss. The old floor-replay exception only covered IDs at or below the persistence floor captured at Bot creation, not mid-process cross-lane delays.

## Why This Change Was Made

Production incident on 2026-07-14 (details and DB evidence in #107246): a restart during a held claim wedged one group's lane; after the lane was unwedged, the two queued user messages replayed and were watermark-rejected into completed tombstones. Both mechanisms are generic — any restart-during-claim can trigger A, and any cross-lane delay can trigger B independently.

**Fix A — process-instance identity, not PID liveness.** Claim owner IDs now encode `pid:startToken:uuid`, where the start token is the OS process start time (Linux: `/proc/<pid>/stat` field 22; macOS: `ps -o lstart=` pinned to UTC — same contract as core `src/shared/pid-alive.ts`, implemented plugin-local because plugins cannot import core `src/**` and no SDK barrel exports it). A claim is live-owned only if the PID exists *and* its start time matches the token, so TIDs and recycled PIDs can no longer impersonate a dead owner, while a genuinely live peer process keeps its lease. Explicit `x` tokens (platforms that cannot read start time, e.g. win32) and well-formed legacy two-part `pid:uuid` owner IDs keep the previous existence-only contract — reclaiming a fresh claim from a live old-version worker during a rolling upgrade would double-dispatch its update; malformed owner IDs are not live-provable and recover, which re-queues (never drops). Both the normal and corrupt-claim variants share the check, which also covers the webhook drain (same helper).

**Fix B — per-ID acceptance instead of a global high-water mark.** `beginUpdate` now rejects only (1) IDs at or below the restored Bot API offset (`initialUpdateId`, i.e. redelivery of already-persisted updates after restart) and (2) exact IDs already accepted by this process. Never-seen lower IDs — cross-lane delayed spool replays — dispatch normally. The accepted-ID set is bounded by one prune rule (at/below `max(persisted offset, highestAccepted − 10_000)`, never pruning pending/failed IDs): IDs below the persisted offset cannot be redelivered by `getUpdates`, and the retention window covers realistic in-process redelivery where no persist callback exists; semantic-key dedupe and durable spool tombstones (`enqueue` is `ON CONFLICT DO NOTHING`) cover everything older. The floor-replay special case is deleted — startup replays now flow through the same single path.

**Why this is the best fix (alternatives rejected):** detecting only Linux TIDs (`Tgid != Pid`) misses general PID reuse; dropping the liveness probe entirely would let a booting process steal claims from a live peer mid-run; lease/timeout tuning leaves up to 30 minutes of wedge and was explicitly out of scope; per-lane watermarks add a concept where the actual problem is per-ID acceptance. The watermark's real contract (suppress Bot API redelivery of already-processed updates) is preserved by the restored-offset gate + exact-ID set + spool tombstones.

## User Impact

- A gateway restart while a Telegram update is being processed can no longer freeze that chat for up to 30 minutes.
- Updates that were delayed in one chat while other chats advanced are dispatched exactly once instead of being silently discarded.
- No config, protocol, or API surface changes. Claim owner IDs are transient (30-minute lease); pre-upgrade claims keep their old existence-based lease semantics for the one process generation that can still hold them.

## Evidence

**RCA / incident:** #107246 (queue rows, `/proc` evidence, timeline).

**Regression tests** (all new tests fail on the old code):
- `telegram-ingress-spool.test.ts`: fresh foreign claim whose PID is now a thread of this process → not live-owned; unrelated PID reuse → not live-owned; matching start-time peer → live-owned; fresh live legacy two-part owner ID → still lease-protected (rolling upgrade); malformed owner ID → not live-owned; explicit `x` token → existence-only.
- `bot-update-tracker.test.ts`: delayed lower ID after newer cross-lane completions dispatches exactly once; duplicate replay of a completed ID stays rejected; delayed group mention passes the gate for normal `user_request` routing; accepted-ID set bounded (retention + persisted floor, pending/failed retained).
- `polling-session.test.ts`: TID-reuse claim recovered and same-lane backlog drains through the real spool harness; post-adoption crash window — reclaimed claim replays, tombstones, and drains the lane without a deferred model turn.

**Validation:**
- Blacksmith Testbox (`tbx_01kxfqm9d17pd2s1bj0r03gvxk`, synced from this branch): `pnpm check:changed` all lanes green (conflict markers, TypeScript LOC ratchet, changelog attributions, wildcard re-export guards, dependency pin guard, format, Plugin SDK API baseline, package patch guard, `tsgo` typecheck of extensions + extension tests), then the full telegram extension suite: **143 test files / 2751 tests passed**.
- Structured second-model review (codex `gpt-5.6-sol`, high reasoning) over the change bundle: one P1 finding in an intermediate revision (legacy fresh claims could be stolen during rolling upgrades — fixed by the existence-only legacy fallback above); final pass clean, "no actionable defects".

**Scope note / follow-up:** restart recovery cannot tombstone a recovered turn's spool claim directly — `DeliveryContext` carries no `update_id`, and dispatch dedupe keys on `(provider, message_id)`. Post-adoption crash replay therefore relies on the same at-least-once + inbound-dedupe + session-ordering contract that shipped floor-replay startup recovery already uses; adding durable update-ID linkage to adoption identity is a possible follow-up, not attempted here.

Sibling surfaces checked: webhook drain shares the fixed liveness helper and the fixed tracker; WhatsApp durable ingress uses enqueue/complete only (no claims, no liveness gate) and is unaffected.
