### PR TITLE
refactor(llm): parse retry units with ms

### DIFF
--- a/src/llm/utils/rate-limit-window.ts
+++ b/src/llm/utils/rate-limit-window.ts
@@ -1,4 +1,5 @@
 import { parseRetryAfterHttpDateMs } from "@openclaw/ai/internal/retry-after";
+import milliseconds from "ms";
 import { extractLeadingHttpStatus } from "../../shared/assistant-error-format.js";
 
 type RateLimitWindow =
@@ -32,24 +33,9 @@ function parseRetryAfterSeconds(valueText: string, nowMs: number): number | unde
     ) {
       return undefined;
     }
-    if (unit === "d" || unit?.startsWith("day")) {
-      return value * 86_400;
-    }
-    if (unit === "h" || unit?.startsWith("hr") || unit?.startsWith("hour")) {
-      return value * 3_600;
-    }
-    if (
-      unit?.startsWith("m") &&
-      unit !== "ms" &&
-      !unit.startsWith("msec") &&
-      !unit.startsWith("millisecond")
-    ) {
-      return value * 60;
-    }
-    if (unit === "ms" || unit?.startsWith("msec") || unit?.startsWith("millisecond")) {
-      return value / 1000;
-    }
-    return value;
+    const unitMilliseconds = milliseconds(`1${unit ?? "s"}` as Parameters<typeof milliseconds>[0]);
+    // Preserve division for millisecond inputs; multiplying by 0.001 can change IEEE-754 rounding.
+    return unitMilliseconds === 1 ? value / 1000 : value * (unitMilliseconds / 1000);
   }
   const retryAtMs = parseRetryAfterHttpDateMs(valueText, nowMs);
   return retryAtMs === undefined ? undefined : Math.max(0, (retryAtMs - nowMs) / 1000);


### PR DESCRIPTION
## What Problem This Solves

Rate-limit Retry-After parsing manually reimplements the duration multipliers already owned by the root `ms` dependency.

## Why This Change Was Made

- Keep the existing allowlist so weeks and years remain rejected.
- Use `ms@2.1.3` to map every admitted unit alias to its canonical multiplier.
- Preserve the explicit division path for millisecond values, avoiding IEEE-754 rounding drift.

## User Impact

No classification or delay change. The parser keeps bit-identical results with 14 fewer lines of manual unit handling.

## Evidence

- Differential probe: 240,000 conversions across every admitted alias were bit-identical.
- `node scripts/run-vitest.mjs src/llm/utils/retry.test.ts src/agents/embedded-agent-runner/run/assistant-failover.test.ts` — 53 tests passed across 2 shards.
- `git diff --check origin/main...HEAD`
- Exact-head autoreview: clean, no accepted or actionable findings.
