### PR TITLE
refactor(json): share JSON5 fallback parsing

### DIFF
--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -34,6 +34,7 @@ import {
   type PluginMetadataSnapshot,
 } from "../plugins/plugin-metadata-snapshot.js";
 import { isRecord } from "../utils.js";
+import { parseJsonWithJson5Fallback } from "../utils/parse-json-compat.js";
 import { VERSION } from "../version.js";
 import { DuplicateAgentDirError, findDuplicateAgentDirs } from "./agent-dirs.js";
 import { maintainConfigBackups } from "./backup-rotation.js";
@@ -1090,13 +1091,7 @@ export function parseConfigJson5(
   json5: { parse: (value: string) => unknown } = JSON5,
 ): ParseConfigJson5Result {
   try {
-    return { ok: true, parsed: JSON.parse(raw) };
-  } catch {
-    // Keep JSON5 compatibility for authored config, but avoid the slower parser
-    // on the JSON files OpenClaw writes itself.
-  }
-  try {
-    return { ok: true, parsed: json5.parse(raw) };
+    return { ok: true, parsed: parseJsonWithJson5Fallback(raw, json5) };
   } catch (err) {
     return { ok: false, error: String(err) };
   }

--- a/src/infra/state-migrations.fs.ts
+++ b/src/infra/state-migrations.fs.ts
@@ -1,6 +1,6 @@
 // Filesystem primitives used by legacy state migration code.
 import fs from "node:fs";
-import JSON5 from "json5";
+import { parseJsonWithJson5Fallback } from "../utils/parse-json-compat.js";
 
 /** Minimal session-store entry shape needed by state migration ordering and repair logic. */
 export type SessionEntryLike = {
@@ -60,15 +60,7 @@ export function parseSessionStoreJson5(raw: string): {
   ok: boolean;
 } {
   try {
-    const parsed = JSON.parse(raw);
-    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
-      return { store: parsed as Record<string, SessionEntryLike>, ok: true };
-    }
-  } catch {
-    // Fall through to JSON5 for legacy/operator-edited stores.
-  }
-  try {
-    const parsed = JSON5.parse(raw);
+    const parsed = parseJsonWithJson5Fallback(raw);
     if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
       return { store: parsed as Record<string, SessionEntryLike>, ok: true };
     }

--- a/src/plugin-sdk/facade-activation-check.runtime.ts
+++ b/src/plugin-sdk/facade-activation-check.runtime.ts
@@ -3,7 +3,6 @@
  */
 import fs from "node:fs";
 import path from "node:path";
-import JSON5 from "json5";
 import { resolveConfigPath } from "../config/paths.js";
 import { applyPluginAutoEnable } from "../config/plugin-auto-enable.js";
 import { configMayNeedPluginAutoEnable } from "../config/plugin-auto-enable.shared.js";
@@ -59,7 +58,7 @@ function readFacadeBoundaryConfigSafely(): {
       return { rawConfig: EMPTY_FACADE_BOUNDARY_CONFIG };
     }
     const raw = fs.readFileSync(configPath, "utf8");
-    const parsed = JSON5.parse(raw);
+    const parsed = parseJsonWithJson5Fallback(raw);
     const rawConfig =
       parsed && typeof parsed === "object"
         ? (parsed as OpenClawConfig)

--- a/src/utils/parse-json-compat.ts
+++ b/src/utils/parse-json-compat.ts
@@ -5,10 +5,13 @@
 import JSON5 from "json5";
 
 /** Parses strict JSON first, then accepts JSON5 syntax such as comments and trailing commas. */
-export function parseJsonWithJson5Fallback(raw: string): unknown {
+export function parseJsonWithJson5Fallback(
+  raw: string,
+  json5: { parse: (value: string) => unknown } = JSON5,
+): unknown {
   try {
     return JSON.parse(raw);
   } catch {
-    return JSON5.parse(raw);
+    return json5.parse(raw);
   }
 }


### PR DESCRIPTION
## What Problem This Solves

OpenClaw maintained three copies of the same strict-JSON-first, JSON5-fallback parsing sequence across config, state migration, and plugin facade activation paths.

## Why This Change Was Made

Route all three call sites through the existing `parseJsonWithJson5Fallback` helper. The helper now accepts the injectable parser required by config tests. The packaged Memory Core `json5` dependency remains intact because generated plugin runtime chunks still load the helper's JSON5 import.

## User Impact

No behavior change. Authored JSON5 config and legacy/operator-edited session stores remain supported. The refactor removes 11 net lines and one duplicated parsing policy.

## Evidence

- `node scripts/run-vitest.mjs src/config/io.parse.test.ts src/infra/state-migrations.fs.test.ts src/infra/infra-store.test.ts src/plugin-sdk/facade-runtime.test.ts src/plugins/contracts/extension-runtime-dependencies.contract.test.ts` (474 tests passed across 4 shards)
- `git diff --check origin/main...HEAD`
- Fresh exact-head autoreview: clean, no accepted/actionable findings
