### PR TITLE
test(wizard): satisfy promise executor lint

### DIFF
--- a/src/wizard/clack-prompter.test.ts
+++ b/src/wizard/clack-prompter.test.ts
@@ -208,7 +208,9 @@ describe("createClackPrompter", () => {
 
   it("rejects navigation after Clack resolves an aborted prompt", async () => {
     navigationPromptMocks.textWithNavigationFooter.mockImplementation(async ({ signal }) => {
-      await new Promise((resolve) => signal.addEventListener("abort", resolve, { once: true }));
+      await new Promise((resolve) => {
+        signal.addEventListener("abort", resolve, { once: true });
+      });
       return Symbol("clack:cancel");
     });
     const prompter = createClackPrompter();


### PR DESCRIPTION
## What Problem This Solves

Main CI fails `check-lint` because a Promise executor in the Clack prompter regression test implicitly returns `addEventListener`.

## Why This Change Was Made

Use a block-bodied executor so the listener registration does not become the executor return value. Test behavior remains unchanged.

## User Impact

No product behavior change. Restores the required lint gate on `main`.

## Evidence

- Exact failing main run: https://github.com/openclaw/openclaw/actions/runs/29317865849
- Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/29318436836
- `oxlint src/wizard/clack-prompter.test.ts`: 0 warnings, 0 errors
- `pnpm test src/wizard/clack-prompter.test.ts`: 11/11 passed
- Autoreview: clean, no actionable findings
