### PR TITLE
fix(zai): Coding Plan chat turns always fail with fake rate-limit when system prompt carries OpenClaw signature line

### DIFF
--- a/extensions/zai/coding-prompt-compat.test.ts
+++ b/extensions/zai/coding-prompt-compat.test.ts
@@ -1,0 +1,177 @@
+// Zai tests cover Coding Plan system-prompt compatibility behavior.
+import type { OpenClawConfig } from "openclaw/plugin-sdk/provider-onboard";
+import { describe, expect, it } from "vitest";
+import { isZaiCodingBaseUrl, transformZaiCodingSystemPrompt } from "./coding-prompt-compat.js";
+import {
+  ZAI_CN_BASE_URL,
+  ZAI_CODING_CN_BASE_URL,
+  ZAI_CODING_GLOBAL_BASE_URL,
+  ZAI_GLOBAL_BASE_URL,
+} from "./model-definitions.js";
+
+const BLOCKED_LINE = "You are a personal assistant running inside OpenClaw.";
+const REWRITTEN_LINE = "You are a personal assistant running within OpenClaw.";
+
+type ProviderEntry = {
+  baseUrl?: string;
+  models?: Array<{ id: string; baseUrl?: string }>;
+};
+
+function buildConfig(providers: Record<string, ProviderEntry>): OpenClawConfig {
+  return { models: { providers } } as unknown as OpenClawConfig;
+}
+
+function transform(params: {
+  providers: Record<string, ProviderEntry>;
+  systemPrompt?: string;
+  provider?: string;
+  modelId?: string;
+}): string | undefined {
+  return transformZaiCodingSystemPrompt({
+    config: buildConfig(params.providers),
+    provider: params.provider ?? "zai",
+    modelId: params.modelId ?? "glm-5.2",
+    systemPrompt: params.systemPrompt ?? BLOCKED_LINE,
+  });
+}
+
+describe("isZaiCodingBaseUrl", () => {
+  it("matches both official Coding Plan endpoints", () => {
+    expect(isZaiCodingBaseUrl(ZAI_CODING_GLOBAL_BASE_URL)).toBe(true);
+    expect(isZaiCodingBaseUrl(ZAI_CODING_CN_BASE_URL)).toBe(true);
+  });
+
+  it("matches reverse proxies that preserve the coding path", () => {
+    expect(isZaiCodingBaseUrl("http://127.0.0.1:9998/api/coding/paas/v4")).toBe(true);
+  });
+
+  it("rejects ordinary Z.AI endpoints and empty values", () => {
+    expect(isZaiCodingBaseUrl(ZAI_GLOBAL_BASE_URL)).toBe(false);
+    expect(isZaiCodingBaseUrl(ZAI_CN_BASE_URL)).toBe(false);
+    expect(isZaiCodingBaseUrl(undefined)).toBe(false);
+    expect(isZaiCodingBaseUrl("")).toBe(false);
+    expect(isZaiCodingBaseUrl("   ")).toBe(false);
+  });
+});
+
+describe("transformZaiCodingSystemPrompt", () => {
+  it("rewrites only the blocked identity line on Coding Plan routes", () => {
+    const prompt = `${BLOCKED_LINE}\nOpenClaw routes messages across channels.\nUse OpenClaw tools.`;
+    const transformed = transform({
+      providers: { zai: { baseUrl: ZAI_CODING_GLOBAL_BASE_URL } },
+      systemPrompt: prompt,
+    });
+    expect(transformed).toBe(
+      `${REWRITTEN_LINE}\nOpenClaw routes messages across channels.\nUse OpenClaw tools.`,
+    );
+    expect(transformed).not.toContain("running inside OpenClaw");
+  });
+
+  it("rewrites every occurrence of the blocked line", () => {
+    const prompt = `${BLOCKED_LINE}\nintermediate text\n${BLOCKED_LINE}`;
+    const transformed = transform({
+      providers: { zai: { baseUrl: ZAI_CODING_CN_BASE_URL } },
+      systemPrompt: prompt,
+    });
+    expect(transformed).toBe(`${REWRITTEN_LINE}\nintermediate text\n${REWRITTEN_LINE}`);
+  });
+
+  it("uses a per-model baseUrl override that routes to a Coding Plan endpoint", () => {
+    expect(
+      transform({
+        providers: {
+          zai: {
+            baseUrl: ZAI_GLOBAL_BASE_URL,
+            models: [{ id: "glm-5.2", baseUrl: ZAI_CODING_GLOBAL_BASE_URL }],
+          },
+        },
+      }),
+    ).toBe(REWRITTEN_LINE);
+  });
+
+  it("matches provider-scoped per-model config ids", () => {
+    expect(
+      transform({
+        providers: {
+          zai: {
+            models: [{ id: "zai/glm-5.2", baseUrl: ZAI_CODING_GLOBAL_BASE_URL }],
+          },
+        },
+      }),
+    ).toBe(REWRITTEN_LINE);
+  });
+
+  it("lets an ordinary per-model baseUrl override a coding provider baseUrl", () => {
+    expect(
+      transform({
+        providers: {
+          zai: {
+            baseUrl: ZAI_CODING_GLOBAL_BASE_URL,
+            models: [{ id: "glm-5.2", baseUrl: ZAI_GLOBAL_BASE_URL }],
+          },
+        },
+      }),
+    ).toBeUndefined();
+  });
+
+  it("ignores per-model overrides for other model ids", () => {
+    expect(
+      transform({
+        providers: {
+          zai: {
+            baseUrl: ZAI_GLOBAL_BASE_URL,
+            models: [{ id: "glm-5.1", baseUrl: ZAI_CODING_GLOBAL_BASE_URL }],
+          },
+        },
+        modelId: "glm-5.2",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("resolves provider config keys case-insensitively like core resolution", () => {
+    expect(
+      transform({
+        providers: { ZAI: { baseUrl: ZAI_CODING_GLOBAL_BASE_URL } },
+      }),
+    ).toBe(REWRITTEN_LINE);
+  });
+
+  it("resolves alias provider ids against their exact config keys", () => {
+    expect(
+      transform({
+        providers: { "z-ai": { baseUrl: ZAI_CODING_GLOBAL_BASE_URL } },
+        provider: "z-ai",
+      }),
+    ).toBe(REWRITTEN_LINE);
+  });
+
+  it("leaves ordinary Z.AI routes byte-identical", () => {
+    expect(transform({ providers: { zai: { baseUrl: ZAI_GLOBAL_BASE_URL } } })).toBeUndefined();
+    expect(transform({ providers: { zai: {} } })).toBeUndefined();
+    expect(
+      transformZaiCodingSystemPrompt({
+        provider: "zai",
+        modelId: "glm-5.2",
+        systemPrompt: BLOCKED_LINE,
+      }),
+    ).toBeUndefined();
+  });
+
+  it("leaves Coding Plan prompts without the blocked line unchanged", () => {
+    expect(
+      transform({
+        providers: { zai: { baseUrl: ZAI_CODING_GLOBAL_BASE_URL } },
+        systemPrompt: "You are a helpful assistant.",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("does not touch case variants the provider filter ignores", () => {
+    expect(
+      transform({
+        providers: { zai: { baseUrl: ZAI_CODING_GLOBAL_BASE_URL } },
+        systemPrompt: "you are a personal assistant running inside openclaw.",
+      }),
+    ).toBeUndefined();
+  });
+});

--- a/extensions/zai/coding-prompt-compat.ts
+++ b/extensions/zai/coding-prompt-compat.ts
@@ -1,0 +1,134 @@
+// Zai plugin module implements Coding Plan system-prompt compatibility behavior.
+import type { OpenClawConfig } from "openclaw/plugin-sdk/provider-onboard";
+import {
+  normalizeLowercaseStringOrEmpty,
+  normalizeOptionalString,
+} from "openclaw/plugin-sdk/string-coerce-runtime";
+
+/**
+ * Z.AI Coding Plan endpoints deterministically reject (HTTP 429, code 1305,
+ * disguised as "overloaded") any request whose system message contains this
+ * exact case-sensitive substring. The literal is a provider-contract match
+ * against z.ai's measured server-side filter, not an example string; see
+ * https://github.com/openclaw/openclaw/issues/103529 for the measurements.
+ */
+const ZAI_CODING_BLOCKED_PROMPT_SUBSTRING = "You are a personal assistant running inside OpenClaw";
+
+/**
+ * Minimal semantics-preserving rewrite. The filter is an exact substring
+ * match, so swapping "inside" for "within" is measured to pass (see the issue
+ * above) while keeping the assistant identity line intact.
+ */
+const ZAI_CODING_PROMPT_REPLACEMENT = "You are a personal assistant running within OpenClaw";
+
+/**
+ * Both official Coding Plan base URLs (api.z.ai and open.bigmodel.cn) carry
+ * this path segment, and it survives user-configured reverse proxies that
+ * preserve the upstream path.
+ */
+const ZAI_CODING_PATH_MARKER = "/api/coding/";
+
+type ConfiguredProviders = NonNullable<NonNullable<OpenClawConfig["models"]>["providers"]>;
+type ConfiguredProvider = ConfiguredProviders[string];
+
+export type ZaiCodingSystemPromptContext = {
+  config?: OpenClawConfig;
+  provider: string;
+  modelId: string;
+  systemPrompt: string;
+};
+
+/** True when the given base URL routes to a Coding Plan endpoint. */
+export function isZaiCodingBaseUrl(baseUrl: unknown): boolean {
+  const normalized = normalizeOptionalString(baseUrl);
+  if (!normalized) {
+    return false;
+  }
+  try {
+    return new URL(normalized).pathname.includes(ZAI_CODING_PATH_MARKER);
+  } catch {
+    return normalized.includes(ZAI_CODING_PATH_MARKER);
+  }
+}
+
+// Mirrors core resolveConfiguredProviderConfig: exact key first, then the
+// first key that matches after provider-id normalization, so the transform
+// sees the same provider entry the transport route was resolved from.
+function resolveConfiguredProvider(
+  cfg: OpenClawConfig | undefined,
+  provider: string,
+): ConfiguredProvider | undefined {
+  const providers = cfg?.models?.providers;
+  if (!providers) {
+    return undefined;
+  }
+  const exact = providers[provider];
+  if (exact) {
+    return exact;
+  }
+  const normalizedProvider = normalizeLowercaseStringOrEmpty(provider);
+  for (const [key, value] of Object.entries(providers)) {
+    if (normalizeLowercaseStringOrEmpty(key) === normalizedProvider) {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+// Mirrors core matchesProviderScopedModelId: config model ids may be plain
+// ("glm-5.2") or provider-scoped ("zai/glm-5.2").
+function matchesConfiguredModelId(candidateId: unknown, provider: string, modelId: string): boolean {
+  if (typeof candidateId !== "string") {
+    return false;
+  }
+  if (candidateId === modelId) {
+    return true;
+  }
+  const slashIndex = candidateId.indexOf("/");
+  if (slashIndex <= 0) {
+    return false;
+  }
+  return (
+    candidateId.slice(slashIndex + 1) === modelId &&
+    normalizeLowercaseStringOrEmpty(candidateId.slice(0, slashIndex)) ===
+      normalizeLowercaseStringOrEmpty(provider)
+  );
+}
+
+/**
+ * Resolves the base URL the transport will use for this provider/model from
+ * config, mirroring core model resolution precedence where a per-model
+ * `models[]` entry baseUrl overrides the provider-level baseUrl.
+ */
+function resolveEffectiveConfiguredBaseUrl(ctx: ZaiCodingSystemPromptContext): string | undefined {
+  const providerConfig = resolveConfiguredProvider(ctx.config, ctx.provider);
+  if (!providerConfig) {
+    return undefined;
+  }
+  const configuredModel = providerConfig.models?.find((candidate) =>
+    matchesConfiguredModelId(candidate?.id, ctx.provider, ctx.modelId),
+  );
+  return (
+    normalizeOptionalString(configuredModel?.baseUrl) ??
+    normalizeOptionalString(providerConfig.baseUrl)
+  );
+}
+
+/**
+ * Rewrites the blocked identity line for Coding Plan requests only. Returns
+ * undefined to leave the prompt byte-identical for ordinary Z.AI routes and
+ * for prompts that do not contain the blocked substring.
+ */
+export function transformZaiCodingSystemPrompt(
+  ctx: ZaiCodingSystemPromptContext,
+): string | undefined {
+  if (!isZaiCodingBaseUrl(resolveEffectiveConfiguredBaseUrl(ctx))) {
+    return undefined;
+  }
+  if (!ctx.systemPrompt.includes(ZAI_CODING_BLOCKED_PROMPT_SUBSTRING)) {
+    return undefined;
+  }
+  return ctx.systemPrompt
+    .split(ZAI_CODING_BLOCKED_PROMPT_SUBSTRING)
+    .join(ZAI_CODING_PROMPT_REPLACEMENT);
+}

--- a/extensions/zai/index.test.ts
+++ b/extensions/zai/index.test.ts
@@ -562,6 +562,39 @@ describe("zai provider plugin", () => {
     ).toBe(explicit);
   });
 
+  it("rewrites the Coding-Plan-blocked identity line through transformSystemPrompt", async () => {
+    const provider = await registerSingleProviderPlugin(plugin);
+    const blockedPrompt = "You are a personal assistant running inside OpenClaw.\nOpenClaw stays.";
+
+    expect(
+      provider.transformSystemPrompt?.({
+        provider: "zai",
+        modelId: "glm-5.2",
+        promptMode: "full",
+        config: {
+          models: {
+            providers: { zai: { baseUrl: "https://api.z.ai/api/coding/paas/v4" } },
+          },
+        },
+        systemPrompt: blockedPrompt,
+      } as never),
+    ).toBe("You are a personal assistant running within OpenClaw.\nOpenClaw stays.");
+
+    expect(
+      provider.transformSystemPrompt?.({
+        provider: "zai",
+        modelId: "glm-5.1",
+        promptMode: "full",
+        config: {
+          models: {
+            providers: { zai: { baseUrl: "https://api.z.ai/api/paas/v4" } },
+          },
+        },
+        systemPrompt: blockedPrompt,
+      } as never),
+    ).toBeUndefined();
+  });
+
   it("uses deprecated pi agent auth.json for usage auth when modern sources are empty", async () => {
     const home = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-zai-legacy-auth-"));
     try {

--- a/extensions/zai/index.ts
+++ b/extensions/zai/index.ts
@@ -32,6 +32,7 @@ import {
 } from "openclaw/plugin-sdk/provider-stream-shared";
 import { fetchZaiUsage } from "openclaw/plugin-sdk/provider-usage";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { transformZaiCodingSystemPrompt } from "./coding-prompt-compat.js";
 import { detectZaiEndpoint, type ZaiEndpointId } from "./detect.js";
 import { zaiMediaUnderstandingProvider } from "./media-understanding-provider.js";
 import { buildZaiModelDefinition, resolveZaiBaseUrl } from "./model-definitions.js";
@@ -390,6 +391,7 @@ export default definePluginEntry({
         dropReasoningFromHistory: false,
       }),
       prepareExtraParams: (ctx) => defaultToolStreamExtraParams(ctx.extraParams),
+      transformSystemPrompt: (ctx) => transformZaiCodingSystemPrompt(ctx),
       wrapStreamFn: (ctx) => wrapZaiStreamFn(ctx),
       resolveThinkingProfile,
       isModernModelRef: ({ modelId }) => {


### PR DESCRIPTION
Closes #103529

## What Problem This Solves

Fixes an issue where users who onboard a valid z.ai Coding Plan key would see every chat turn fail with `⚠️ API rate limit reached. Please try again later.` even though the key, quota, and endpoint are all healthy. As measured in #103529 (and re-confirmed live below), the z.ai Coding Plan endpoints (`api.z.ai/api/coding/paas/v4` and `open.bigmodel.cn/api/coding/paas/v4`) deterministically return HTTP 429 / code 1305 whenever the request's `system` message contains OpenClaw's exact opening identity line `You are a personal assistant running inside OpenClaw` — the match is case-sensitive, exact-substring, and system-role-only. Onboarding succeeds (the detection probe carries no system prompt), then every real turn fails, with no in-product recovery.

## Why This Change Was Made

This uses the fix shape identified in the ClawSweeper triage on #103529: the provider-owned `transformSystemPrompt` seam, which exists precisely for small transport compatibility rewrites after OpenClaw assembles the full prompt. The z.ai plugin now rewrites only the blocked line — `running inside OpenClaw` → `running within OpenClaw`, a substitution the issue's measurement matrix (and the live run below) shows passes the filter while any single-character deviation returns 200 — and only when the request routes to a Coding Plan path (`/api/coding/`, which also covers user reverse proxies that preserve the upstream path).

Route detection mirrors core model resolution (per Codex review feedback): the provider config entry is resolved like core `resolveConfiguredProviderConfig` (exact key, then normalized-key match), and a per-model `models[]` entry `baseUrl` — matched in plain or provider-scoped id form like `matchesProviderScopedModelId` — takes precedence over the provider-level `baseUrl`, matching the transport's `metadataOverrideBaseUrl ?? providerConfiguredBaseUrl` precedence. Ordinary z.ai routes and all other providers keep byte-identical canonical prompts. The blocked-string literal in the plugin is a provider-contract match against z.ai's measured server-side filter, not a cosmetic string; this is documented at the constant. Complementary to #104076, which improves the 1305 error copy but does not make Coding Plan turns succeed.

Non-goal: this does not decide whether z.ai *intends* to block OpenClaw on Coding Plan; that upstream question stays with maintainers per the issue discussion. Until it is answered, this restores a working chat path for affected users.

## User Impact

z.ai Coding Plan users (global and CN) get working chat turns immediately after onboarding, instead of a fully broken session disguised as a rate limit. No config changes, no new options, no behavior change for any other provider or z.ai route.

## Evidence

### Live validation (glm-5.2, `api.z.ai/api/coding/paas/v4`, UA `OpenAI/JS 6.39.1`)

Measurement matrix — only the `system` content varies:

```
control (no signature):      200
OpenClaw signature line:     429   {"error":{"code":"1305","message":"The service may be temporarily overloaded, please try again later"}}
PR replacement (within):     200
lowercased signature:        200
larger prompt, signature line embedded + 4 other "OpenClaw" mentions intact:   429
same larger prompt, only the opening line rewritten by the PR transform:       200
```

End-to-end through the **actual production transform** (`transformZaiCodingSystemPrompt`) — its real output POSTed to the live endpoint, for both routing configurations:

```
provider-level route rewritten:      true
per-model override route rewritten:  true   (coding baseUrl on the models[] entry, ordinary provider baseUrl)
both outputs identical:              true
live status, ORIGINAL prompt:        429 (blocked)
live status, PRODUCTION TRANSFORM:   200 (success)
```

So the shipped transform turns a deterministically-blocked Coding Plan request into a successful one, while leaving every other `OpenClaw` reference in the prompt intact.

### Automated tests / checks

- New focused tests: `extensions/zai/coding-prompt-compat.test.ts` (provider-level and per-model route scoping incl. proxy paths and provider-scoped ids, precedence of per-model overrides in both directions, normalized provider-key lookup, single/multiple occurrence rewrite, byte-identical pass-through for non-coding routes, case-sensitivity guard) and a wiring test in `extensions/zai/index.test.ts` proving the registered provider hook applies the rewrite for `/api/coding/` base URLs and returns `undefined` for the ordinary endpoint.
- `pnpm test:extension zai` — 7 files, 54 tests passed (includes `provider-runtime.contract.test.ts`, `onboard.test.ts`).
- `pnpm test src/agents/system-prompt.test.ts src/agents/embedded-agent-runner/run/attempt-system-prompt.test.ts src/agents/plugin-text-transforms.test.ts` — 4 files, 106 tests passed (prompt-seam callers unaffected).
- `pnpm check:test-types` and `pnpm lint:extensions` green locally after rebasing onto latest `main` (the earlier `check-lint` CI failure was the pre-existing `src/wizard/clack-prompter.test.ts` issue fixed on `main` by #107301; the earlier `check-test-types` failure was a test-file cast in this PR, fixed).
- `pnpm check` — all lanes green except the `npm shrinkwrap guard`, which fails identically on a clean `main` checkout (root, `extensions/llama-cpp`, `extensions/twitch` report stale) and is unrelated to this diff; `node scripts/generate-npm-shrinkwrap.mjs --changed --check` reports "No shrinkwrap-managed package changes detected".

---

AI-assisted (Claude) with human review; the transform literal and scoping decisions follow the measurements and fix shape recorded in #103529 and are confirmed by the live runs above.
