### PR TITLE
fix(codex): skip runtime setup during CLI metadata registration

### DIFF
--- a/extensions/codex/index.test.ts
+++ b/extensions/codex/index.test.ts
@@ -86,7 +86,6 @@ describe("codex plugin", () => {
     const registerAgentHarness = vi.fn();
     const registerNodeHostCommand = vi.fn();
     const registerSessionCatalog = vi.fn();
-
     expect(() =>
       plugin.register(
         createTestPluginApi({
@@ -112,6 +111,122 @@ describe("codex plugin", () => {
         "codex.terminal.resume.v1",
       ]),
     );
+  });
+
+  const METADATA_ONLY_REGISTRATION_MODES = [
+    "discovery",
+    "setup-only",
+    "setup-runtime",
+    "cli-metadata",
+  ] as const;
+
+  const codexCliDescriptor = {
+    descriptors: [
+      {
+        name: "codex",
+        description: "Inspect and branch from Codex sessions through the Gateway",
+        hasSubcommands: true,
+      },
+    ],
+  };
+
+  it.each(METADATA_ONLY_REGISTRATION_MODES)(
+    "registers only CLI metadata in %s mode without runtime wiring",
+    (registrationMode) => {
+      const registerCli = vi.fn();
+      const registerAgentHarness = vi.fn();
+      const registerCommand = vi.fn();
+      const registerTool = vi.fn();
+      const registerService = vi.fn();
+      const on = vi.fn();
+
+      expect(() =>
+        plugin.register(
+          createTestPluginApi({
+            id: "codex",
+            name: "Codex",
+            source: "test",
+            config: {},
+            pluginConfig: {
+              appServer: {
+                transport: "websocket",
+                url: "ws://127.0.0.1:39175",
+              },
+            },
+            registrationMode,
+            runtime: {} as never,
+            registerCli,
+            registerAgentHarness,
+            registerCommand,
+            registerTool,
+            registerService,
+            on,
+          }),
+        ),
+      ).not.toThrow();
+
+      expect(registerCli).toHaveBeenCalledWith(expect.any(Function), codexCliDescriptor);
+      expect(registerAgentHarness).not.toHaveBeenCalled();
+      expect(registerCommand).not.toHaveBeenCalled();
+      expect(registerTool).not.toHaveBeenCalled();
+      expect(registerService).not.toHaveBeenCalled();
+      expect(on).not.toHaveBeenCalled();
+    },
+  );
+
+  it("registers tools and providers in tool-discovery mode without harness or hooks", () => {
+    const registerCli = vi.fn();
+    const registerAgentHarness = vi.fn();
+    const registerCommand = vi.fn();
+    const registerMediaUnderstandingProvider = vi.fn();
+    const registerWebSearchProvider = vi.fn();
+    const registerTool = vi.fn();
+    const registerToolMetadata = vi.fn();
+    const registerMigrationProvider = vi.fn();
+    const registerService = vi.fn();
+    const on = vi.fn();
+
+    expect(() =>
+      plugin.register(
+        createTestPluginApi({
+          id: "codex",
+          name: "Codex",
+          source: "test",
+          config: {},
+          pluginConfig: {
+            appServer: {
+              transport: "websocket",
+              url: "ws://127.0.0.1:39175",
+            },
+          },
+          registrationMode: "tool-discovery",
+          runtime: createCodexTestRuntime(),
+          registerCli,
+          registerAgentHarness,
+          registerCommand,
+          registerMediaUnderstandingProvider,
+          registerWebSearchProvider,
+          registerTool,
+          registerToolMetadata,
+          registerMigrationProvider,
+          registerService,
+          on,
+        }),
+      ),
+    ).not.toThrow();
+
+    expect(registerCli).toHaveBeenCalledWith(expect.any(Function), codexCliDescriptor);
+    expect(registerMediaUnderstandingProvider).toHaveBeenCalledOnce();
+    expect(registerWebSearchProvider).toHaveBeenCalledOnce();
+    expect(registerTool).toHaveBeenCalledWith(expect.any(Function), { name: "codex_threads" });
+    expect(registerToolMetadata).toHaveBeenCalledWith(
+      expect.objectContaining({ toolName: "codex_threads", risk: "high" }),
+    );
+    expect(registerAgentHarness).not.toHaveBeenCalled();
+    expect(registerCommand).not.toHaveBeenCalled();
+    expect(registerMigrationProvider).not.toHaveBeenCalled();
+    expect(registerService).not.toHaveBeenCalled();
+    expect(on).not.toHaveBeenCalled();
   });
 
   it("proactively monitors an explicitly configured remote websocket app-server", () => {

--- a/extensions/codex/index.ts
+++ b/extensions/codex/index.ts
@@ -67,6 +67,22 @@ export default definePluginEntry({
     // Bundled modules may execute from a shared dist chunk, so import.meta.url
     // cannot identify the owning plugin package or its pinned dependencies.
     setManagedCodexPluginRoot(api.rootDir);
+
+    // Dedicated cli-metadata entry is preferred for unknown-command discovery.
+    // Still register descriptors first here so any host that loads the full
+    // entry under a partial registrationMode stays side-effect free (#107219).
+    registerCodexCliMetadata(api);
+
+    const mode = api.registrationMode;
+    // Metadata/setup loads are non-activating: CLI descriptors only.
+    if (
+      mode === "cli-metadata" ||
+      mode === "discovery" ||
+      mode === "setup-only" ||
+      mode === "setup-runtime"
+    ) {
+      return;
+    }
     const resolveCurrentConfig = () =>
       api.runtime.config?.current ? (api.runtime.config.current() as OpenClawConfig) : undefined;
     const resolvePluginConfig = (resolveConfig: () => OpenClawConfig | undefined) => {
@@ -99,15 +115,6 @@ export default definePluginEntry({
       return livePluginConfig;
     };
     const resolveCurrentPluginConfig = () => resolvePluginConfig(resolveCurrentConfig);
-    const appServerConfig = readCodexPluginConfig(resolveCurrentPluginConfig()).appServer;
-    if (appServerConfig?.transport === "websocket") {
-      api.registerService(
-        createCodexAppServerConnectionHealthService({
-          getPluginConfig: resolveCurrentPluginConfig,
-          getRuntimeConfig: resolveCurrentConfig,
-        }),
-      );
-    }
     let bindingStateStore: PluginStateSyncKeyedStore<StoredCodexAppServerBinding> | undefined;
     const openBindingStateStore = () =>
       (bindingStateStore ??= api.runtime.state.openSyncKeyedStore<StoredCodexAppServerBinding>({
@@ -129,35 +136,8 @@ export default definePluginEntry({
       },
     };
     const bindingStore = createLazyCodexAppServerBindingStore(lazyBindingStateStore);
-    registerCodexCliMetadata(api);
-    const sessionCatalogControlFactory = createCodexSessionCatalogControl({
-      config: api.config as OpenClawConfig,
-      getPluginConfig: resolveCurrentPluginConfig,
-      getRuntimeConfig: resolveCurrentConfig,
-    });
-    const sessionCatalogEnabled =
-      readCodexPluginConfig(resolveCurrentPluginConfig()).sessionCatalog?.enabled !== false;
-    if (sessionCatalogEnabled) {
-      codexSessionCatalogRuntime.register({
-        api,
-        bindingStore,
-        control: sessionCatalogControlFactory,
-        getPluginConfig: resolveCurrentPluginConfig,
-        getRuntimeConfig: resolveCurrentConfig,
-      });
-      for (const command of createCodexSessionCatalogNodeHostCommands(
-        sessionCatalogControlFactory,
-        {
-          getPluginConfig: resolveCurrentPluginConfig,
-          getRuntimeConfig: () => resolveCurrentConfig() ?? (api.config as OpenClawConfig),
-        },
-      )) {
-        api.registerNodeHostCommand(command);
-      }
-    }
-    for (const policy of createCodexSessionCatalogNodeInvokePolicies()) {
-      api.registerNodeInvokePolicy(policy);
-    }
+
+    // Capability surfaces shared by tool-discovery and full.
     if (readCodexPluginConfig(resolveCurrentPluginConfig()).supervision?.enabled === true) {
       api.registerTool(
         (context) => {
@@ -178,23 +158,12 @@ export default definePluginEntry({
         { names: [...CODEX_SUPERVISION_COMPAT_TOOL_NAMES] },
       );
     }
-    const agentHarnessOptions = {
-      bindingStore,
-      sessionCatalogControlFactory,
-      resolveConfig: resolveCurrentConfig,
-      resolvePluginConfig: resolveCurrentPluginConfig,
-      runtime: api.runtime,
-    };
-    api.registerAgentHarness(createCodexAppServerAgentHarness(agentHarnessOptions), {
-      nativeCompaction: createCodexAppServerNativeCompaction(agentHarnessOptions),
-    });
     api.registerMediaUnderstandingProvider(
       buildCodexMediaUnderstandingProvider({ pluginConfig: api.pluginConfig }),
     );
     api.registerWebSearchProvider(
       createCodexWebSearchProvider({ resolvePluginConfig: resolveCurrentPluginConfig }),
     );
-    api.registerMigrationProvider(buildCodexMigrationProvider({ runtime: api.runtime }));
     api.registerTool(
       (context) =>
         createCodexThreadsTool({
@@ -228,6 +197,61 @@ export default definePluginEntry({
       risk: "low",
       tags: ["codex", "plugins", "discovery"],
     });
+
+    // tool-discovery is capability-only: tools/providers, no harness/hooks/services.
+    if (mode === "tool-discovery") {
+      return;
+    }
+
+    // full: durable runtime wiring.
+    const appServerConfig = readCodexPluginConfig(resolveCurrentPluginConfig()).appServer;
+    if (appServerConfig?.transport === "websocket") {
+      api.registerService(
+        createCodexAppServerConnectionHealthService({
+          getPluginConfig: resolveCurrentPluginConfig,
+          getRuntimeConfig: resolveCurrentConfig,
+        }),
+      );
+    }
+    const sessionCatalogControlFactory = createCodexSessionCatalogControl({
+      config: api.config as OpenClawConfig,
+      getPluginConfig: resolveCurrentPluginConfig,
+      getRuntimeConfig: resolveCurrentConfig,
+    });
+    const sessionCatalogEnabled =
+      readCodexPluginConfig(resolveCurrentPluginConfig()).sessionCatalog?.enabled !== false;
+    if (sessionCatalogEnabled) {
+      codexSessionCatalogRuntime.register({
+        api,
+        bindingStore,
+        control: sessionCatalogControlFactory,
+        getPluginConfig: resolveCurrentPluginConfig,
+        getRuntimeConfig: resolveCurrentConfig,
+      });
+      for (const command of createCodexSessionCatalogNodeHostCommands(
+        sessionCatalogControlFactory,
+        {
+          getPluginConfig: resolveCurrentPluginConfig,
+          getRuntimeConfig: () => resolveCurrentConfig() ?? (api.config as OpenClawConfig),
+        },
+      )) {
+        api.registerNodeHostCommand(command);
+      }
+    }
+    for (const policy of createCodexSessionCatalogNodeInvokePolicies()) {
+      api.registerNodeInvokePolicy(policy);
+    }
+    const agentHarnessOptions = {
+      bindingStore,
+      sessionCatalogControlFactory,
+      resolveConfig: resolveCurrentConfig,
+      resolvePluginConfig: resolveCurrentPluginConfig,
+      runtime: api.runtime,
+    };
+    api.registerAgentHarness(createCodexAppServerAgentHarness(agentHarnessOptions), {
+      nativeCompaction: createCodexAppServerNativeCompaction(agentHarnessOptions),
+    });
+    api.registerMigrationProvider(buildCodexMigrationProvider({ runtime: api.runtime }));
     for (const command of createCodexCliSessionNodeHostCommands()) {
       api.registerNodeHostCommand(command);
     }


### PR DESCRIPTION
## What Problem This Solves

Codex plugin registration has two related concerns:

1. **Unknown-command / CLI metadata discovery** must not crash when `runtime.state` is unavailable.
2. **Partial host loads of the full entry** (`discovery`, `setup-*`, `tool-discovery`) must not silently run full durable runtime wiring (harness, hooks, session catalog, websocket health services).

Main already improved (1) by preferring the dedicated `cli-metadata` entry for CLI descriptor capture, plus lazy binding-store open-on-first-use in the full entry.

**This PR still adds value for (2):** when a host loads the **full** Codex entry under a non-`full` `registrationMode`, the entry now follows the SDK lifecycle contract instead of registering everything.

## What this is *not*

- Not a replacement for the dedicated `cli-metadata.ts` entry (that remains the preferred unknown-command path).
- Not a broader “non-full means CLI-only” gate that drops tool-discovery capabilities.

## Summary

| Mode | Behavior |
|---|---|
| `cli-metadata` / `discovery` / `setup-only` / `setup-runtime` | CLI descriptors only, then return |
| `tool-discovery` | tools (`codex_threads`) + media/web-search (+ metadata); **no** harness/hooks/services/migration |
| `full` | durable runtime (session catalog, harness, migration, websocket health service, commands, hooks) |

Preserves main’s lazy `openSyncKeyedStore` (first binding use only).

## Why still useful after main’s cli-metadata entry

```text
CLI unknown-command path  →  loader prefers cli-metadata entry  (main)
Partial full-entry loads  →  registrationMode partition         (this PR)
Full gateway activation   →  full mode + lazy state             (main + this PR)
```

Without this partition, any caller that still loads `index.ts` with `registrationMode !== "full"` continues to attach harness, hooks, catalog, and services — which is broader than the SDK mode table and is the compatibility surface ClawSweeper previously flagged.

## Evidence

### Focused tests

Mode coverage added for metadata-only and tool-discovery (including that websocket health service is not registered outside full). On rebased head 49674c5f, local validation passed: 35 focused tests, oxfmt --check, tsgo:extensions, and lint:extensions. CI will run the full suite on this head.

### Prior live proof
- Unknown command clean (no `openSyncKeyedStore` crash)
- `openclaw codex --help` OK
- `plugins inspect codex --runtime`: loaded/activated; contracts include `codex_threads` + codex providers
- `gateway run`: HTTP listen + plugin load without registration TypeError

Fresh-head rebase validation completed on commit 49674c5f; the validated main snapshot was 64776a0489.

### Rebase

Recreated on main snapshot 64776a0489. Final GitHub commit: 49674c5f (the repository base may advance independently between validation and merge).

## Mode × capability matrix

| Surface | metadata/setup | tool-discovery | full |
|---|---|---|---|
| CLI descriptors | yes | yes | yes |
| tools / media / web-search | no | yes | yes |
| harness / hooks / commands / catalog / ws health service | no | no | yes |

## Test plan

- [x] Mode-partition unit coverage (metadata-only + tool-discovery + full regression)
- [ ] CI green on `49674c5f`
- [ ] Maintainer review of lifecycle split vs dedicated cli-metadata entry