### PR TITLE
fix(workspaces): array bindings can select the wrong item for malformed pointers

### DIFF
--- a/extensions/workspaces/src/data-read.test.ts
+++ b/extensions/workspaces/src/data-read.test.ts
@@ -64,6 +64,32 @@ describe("workspace data binding resolver", () => {
     });
   });
 
+  it("rejects noncanonical array indices in JSON pointers", async () => {
+    await withTempStateDir(async (stateDir) => {
+      await fs.mkdir(path.join(stateDir, "workspaces", "data"), { recursive: true });
+      await fs.writeFile(
+        path.join(stateDir, "workspaces", "data", "items.json"),
+        JSON.stringify({ items: ["zero", "one"], lookup: { "01": "object-key" } }),
+      );
+
+      await expect(
+        resolveBinding({ source: "file", path: "items.json", pointer: "/items/1" }, { stateDir }),
+      ).resolves.toBe("one");
+      await expect(
+        resolveBinding({ source: "file", path: "items.json", pointer: "/lookup/01" }, { stateDir }),
+      ).resolves.toBe("object-key");
+
+      for (const segment of ["", " ", "01", "+1", "-0", "1.0", "1e0", "0x1"]) {
+        await expect(
+          resolveBinding(
+            { source: "file", path: "items.json", pointer: `/items/${segment}` },
+            { stateDir },
+          ),
+        ).rejects.toMatchObject({ code: "binding_not_found" });
+      }
+    });
+  });
+
   it("rejects file traversal and oversized files with typed errors", async () => {
     await withTempStateDir(async (stateDir) => {
       await expect(

--- a/extensions/workspaces/src/data-read.test.ts
+++ b/extensions/workspaces/src/data-read.test.ts
@@ -73,13 +73,26 @@ describe("workspace data binding resolver", () => {
       );
 
       await expect(
+        resolveBinding({ source: "file", path: "items.json", pointer: "/items/0" }, { stateDir }),
+      ).resolves.toBe("zero");
+      await expect(
         resolveBinding({ source: "file", path: "items.json", pointer: "/items/1" }, { stateDir }),
       ).resolves.toBe("one");
       await expect(
         resolveBinding({ source: "file", path: "items.json", pointer: "/lookup/01" }, { stateDir }),
       ).resolves.toBe("object-key");
 
-      for (const segment of ["", " ", "01", "+1", "-0", "1.0", "1e0", "0x1"]) {
+      for (const segment of [
+        "",
+        " ",
+        "01",
+        "+1",
+        "-0",
+        "1.0",
+        "1e0",
+        "0x1",
+        "9007199254740993",
+      ]) {
         await expect(
           resolveBinding(
             { source: "file", path: "items.json", pointer: `/items/${segment}` },

--- a/extensions/workspaces/src/data-read.test.ts
+++ b/extensions/workspaces/src/data-read.test.ts
@@ -85,6 +85,7 @@ describe("workspace data binding resolver", () => {
       for (const segment of [
         "",
         " ",
+        "00",
         "01",
         "+1",
         "-0",

--- a/extensions/workspaces/src/data-read.ts
+++ b/extensions/workspaces/src/data-read.ts
@@ -14,6 +14,7 @@ export type ResolveBindingOptions = {
 };
 
 const MAX_FILE_BYTES = 1024 * 1024;
+const JSON_POINTER_ARRAY_INDEX_SEGMENT = /^(?:0|[1-9]\d*)$/u;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -59,6 +60,14 @@ function decodePointerSegment(value: string): string {
   return value.replaceAll("~1", "/").replaceAll("~0", "~");
 }
 
+function parseJsonPointerArrayIndex(segment: string): number | undefined {
+  if (!JSON_POINTER_ARRAY_INDEX_SEGMENT.test(segment)) {
+    return undefined;
+  }
+  const index = Number(segment);
+  return Number.isSafeInteger(index) ? index : undefined;
+}
+
 function applyJsonPointer(value: unknown, pointer: string | undefined): unknown {
   if (pointer === undefined || pointer === "") {
     return value;
@@ -70,8 +79,8 @@ function applyJsonPointer(value: unknown, pointer: string | undefined): unknown 
   for (const rawSegment of pointer.slice(1).split("/")) {
     const segment = decodePointerSegment(rawSegment);
     if (Array.isArray(current)) {
-      const index = Number(segment);
-      if (!Number.isInteger(index) || index < 0 || index >= current.length) {
+      const index = parseJsonPointerArrayIndex(segment);
+      if (index === undefined || index >= current.length) {
         throw new WorkspaceBindingResolutionError("binding_not_found", "JSON pointer not found");
       }
       current = current[index];

--- a/extensions/workspaces/src/data-read.ts
+++ b/extensions/workspaces/src/data-read.ts
@@ -61,6 +61,7 @@ function decodePointerSegment(value: string): string {
 }
 
 function parseJsonPointerArrayIndex(segment: string): number | undefined {
+  // RFC 6901 array tokens are canonical decimal indices; object tokens remain opaque keys.
   if (!JSON_POINTER_ARRAY_INDEX_SEGMENT.test(segment)) {
     return undefined;
   }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Workspaces file bindings could select an unintended array item when their JSON Pointer contained a malformed array token. Inputs such as `/items/`, `/items/01`, `/items/1.0`, `/items/1e0`, and `/items/0x1` were coerced to numeric indices instead of being rejected.

## Why This Change Was Made

The root cause was array traversal converting every pointer token with `Number(segment)`. Array tokens now have to match the canonical JSON Pointer array-index grammar and produce a safe integer before traversal.

Object property tokens are unchanged, so an object key such as `"01"` remains valid. Invalid array tokens continue to use the existing `binding_not_found` / `JSON pointer not found` error contract. This does not change configuration, schema, storage, migration, defaults, or wire formats.

## User Impact

Malformed Workspaces file-binding pointers now fail clearly instead of silently reading the wrong workspace data. Canonical array indices such as `/items/1` and object keys such as `/lookup/01` keep their existing behavior.

This intentionally narrows acceptance only for noncanonical array-index aliases.

## Evidence

- Focused TDD reproduction failed before the fix because `/items/` resolved the first array item instead of rejecting the token.
- The complete Workspaces data-read test file passes: 1 file, 8 tests.
- The Control UI client to real gateway-handler seam passes: 1 file, 2 tests.
- A runtime harness using the real Workspaces store, gateway handler, file resolver, and UI resolver observed:

  ```text
  /items/1     -> "one"
  /lookup/01   -> "object-key"
  /items/{empty,space,01,+1,-0,1.0,1e0,0x1}
                -> "JSON pointer not found"
  ```

- A real isolated OpenClaw gateway with the Workspaces plugin loaded was exercised over WebSocket RPC via `workspaces.data.read`:

  ```text
  canonical /items/1       -> exit 0, data "one"
  object key /lookup/01    -> exit 0, data "object-key"
  8 malformed array tokens -> exit 1, binding_not_found
  ```

- Formatter check passed for both changed files.
- Local protected typecheck was not started because this host uses cgroup v1 and cannot attest the required `memory.high` resource envelope. CI remains authoritative for repository typechecking.
