### PR TITLE
fix(agents): guard null response body in proxy stream reader

### DIFF
--- a/src/agents/runtime/proxy.test.ts
+++ b/src/agents/runtime/proxy.test.ts
@@ -598,4 +598,33 @@ describe("streamProxy", () => {
       errorMessage: "Proxy stream ended before terminal event",
     });
   });
+
+  it("emits a business-level error when the proxy returns a null response body", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          ({
+            ok: true,
+            status: 200,
+            body: null,
+          }) as Response,
+      ),
+    );
+
+    const stream = streamProxy(model, context, {
+      authToken: "token",
+      proxyUrl: "https://proxy.example",
+    });
+    const events = [];
+    for await (const event of stream) {
+      events.push(event);
+    }
+
+    expect(events.at(-1)?.type).toBe("error");
+    await expect(stream.result()).resolves.toMatchObject({
+      stopReason: "error",
+      errorMessage: "Proxy returned an empty response body",
+    });
+  });
 });

--- a/src/agents/runtime/proxy.ts
+++ b/src/agents/runtime/proxy.ts
@@ -340,7 +340,11 @@ export function streamProxy(
         throw new Error(errorMessage);
       }
 
-      reader = response.body!.getReader();
+      if (!response.body) {
+        throw new Error("Proxy returned an empty response body");
+      }
+
+      reader = response.body.getReader();
       const sseReader = createSseByteGuard(reader, {
         maxBytes: PROXY_SSE_STREAM_MAX_BYTES,
         onOverflow: ({ maxBytes }) => new Error(`Proxy SSE stream exceeded ${maxBytes} bytes`),


### PR DESCRIPTION
## What Problem This Solves

`streamProxy()` in `src/agents/runtime/proxy.ts` accesses `response.body!` with a non-null assertion after checking `response.ok`, but `response.ok === true` does not guarantee `response.body !== null`. A real HTTP 204 response (or a misconfigured reverse proxy that returns an empty 200 envelope) produces `ok=true, body=null` through the real `node:http` → `undici` fetch stack.

When triggered, the caller receives `"Cannot read properties of null (reading 'getReader')"` — a JavaScript TypeError that describes an implementation detail (null reference on `getReader`) rather than the actual problem (the upstream proxy returned no body). A developer seeing this would debug proxy.ts internals rather than the proxy server configuration.

Sibling transports in this repository already guard this case:

| File | Guard |
|------|-------|
| `provider-transport-fetch.ts:148` | `if (!response.body) return response;` |
| `provider-transport-fetch.ts:385` | `if (!params.response.ok \|\| !params.response.body)` |
| `provider-transport-fetch.ts:541` | `if (!response.body)` |
| `anthropic-transport-stream.ts:847` | `if (!response.body)` |
| `openai-completions-transport.ts:272` | `if (!response.body \|\| !response.ok)` |
| `mcp-http-fetch.ts:60` | `if (response.body != null)` |
| `mcp-http-fetch.ts:76` | `if (!response.body)` |

Three merged PRs applied this same pattern to transports that previously lacked it:
- **#98143** `fix(agents): bound body-less MCP HTTP text responses` — added `!response.body` guard to `mcp-http-fetch.ts`
- **#97851** `fix(mattermost): bound null-body error response reads` — removed unbounded `!res.body` fallback in mattermost client
- **#99340** `fix(infra): enforce maxBytes in body-less HTTP error snippet path` — same body=null guard pattern

`proxy.ts:343` was the last remaining transport without this guard.

## Why This Change Was Made

A 4-line null guard is added before `getReader()` so the caller receives a business-level error (`"Proxy returned an empty response body"`) instead of a JS internal TypeError. The existing try-catch in `streamProxy` already converts thrown errors to stream error events — no new error propagation path is introduced.

`streamProxy` is a public SDK API: `src/agents/runtime/proxy.ts` → `src/plugin-sdk/agent-core.ts` (re-export) → `packages/plugin-sdk/dist/` (compiled type declarations). A public API should not leak implementation-level error messages.

A committed regression test (`proxy.test.ts`) ensures the business-level error is preserved through refactoring.

## User Impact

Operators debugging proxy connection failures see `"Proxy returned an empty response body"` — a message that identifies the upstream proxy as the problem. Previously they saw `"Cannot read properties of null (reading 'getReader')"` — a message that suggests a code bug. Normal streaming paths are unaffected.

## Evidence

### Real HTTP server proof — `ok=true, body=null` through real fetch

A real `node:http` server returns `204 No Content` and the response is fetched through the real network stack (no stub, no mock):

```
$ node --import tsx /tmp/proxy-proof-server.mts

[proof] server at http://127.0.0.1:36747/api/stream
[proof] ok=true status=204 body=NULL
[proof] CONFIRMED: real HTTP response ok=true, body=null
[proof] WITHOUT the guard, calling response.body!.getReader() throws:
[proof]   → TypeError: Cannot read properties of null (reading 'getReader')
[proof] WITH the guard, streamProxy throws:
[proof]   → "Proxy returned an empty response body"
```

This proves that a real HTTP exchange through the full Node.js fetch → undici → TCP stack produces the `ok=true, body=null` shape. The guard replaces an internal TypeError with a business-level diagnostic.

### Negative control — upstream main source + new regression test

The new test applied to `upstream/main` source (before the fix):

```
$ node scripts/run-vitest.mjs src/agents/runtime/proxy.test.ts --run -t "null response body"

 FAIL  streamProxy > emits a business-level error when the proxy returns a null response body
AssertionError: expected … to match object …

- Expected  |  + Received
  "errorMessage": "Proxy returned an empty response body",
  "errorMessage": "Cannot read properties of null (reading 'getReader')",
```

Upstream main leaks the JS runtime TypeError — the caller sees `"Cannot read properties of null"` instead of identifying the upstream proxy as the cause.

### After fix — full test suite

```
$ node scripts/run-vitest.mjs src/agents/runtime/proxy.test.ts --run
 Test Files  1 passed (1)
      Tests  14 passed (14)
```

The new test (`"emits a business-level error when the proxy returns a null response body"`) is included in the 14. The existing 13 tests pass unchanged.

### Lint

```
$ node scripts/run-oxlint.mjs src/agents/runtime/proxy.ts
exit 0

$ node scripts/run-oxlint.mjs src/agents/runtime/proxy.test.ts
exit 0
```

### Delta

```
$ git diff --stat upstream/main..
 src/agents/runtime/proxy.test.ts | 29 +++++++++++++++++++++++++++++
 src/agents/runtime/proxy.ts      |  6 +++++-
 2 files changed, 34 insertions(+), 1 deletion(-)
```

Source: +4 lines (guard). Test: +29 lines (regression test).

**Observed result after fix**: Null-body proxy responses produce `"Proxy returned an empty response body"`. Normal streaming paths are unchanged. The regression test locks the business-level error message.

**What was not tested**: A live misconfigured proxy server in production returning empty 200 envelopes. The 204 No Content response from a real `node:http` server proves the exact `ok=true, body=null` shape through the real fetch/undici/TCP stack — the same code path that `streamProxy`'s `fetch()` call exercises.

## Regression Test Plan

```
$ node scripts/run-vitest.mjs src/agents/runtime/proxy.test.ts --run
 Test Files  1 passed (1)
      Tests  14 passed (14)

$ node scripts/run-oxlint.mjs src/agents/runtime/proxy.ts
exit 0

$ node scripts/run-oxlint.mjs src/agents/runtime/proxy.test.ts
exit 0
```

## Root Cause

In `streamProxy()`, `response.ok` is checked (line 328) before entering the SSE read loop. When `ok` is true, the code calls `response.body!.getReader()` (line 343) with a non-null assertion, assuming a 2xx response always carries a readable stream body. The Fetch Standard does not guarantee this — `response.body` is null for 204 No Content, 304 Not Modified, responses with an empty payload, and responses from reverse proxies that return header-only status envelopes.

The 9 other `response.body` access sites across the repository's transport layer all perform an explicit null check. PRs #98143, #97851, and #99340 applied this pattern to files that previously lacked it. `proxy.ts:343` inherits the identical risk but was not updated in those rounds.

## AI Assistance

Implementation, test, real-server proof, and PR body were drafted with agent assistance. All commands were run locally.