### PR TITLE
test(zalo): narrow message adapter fixture

### DIFF
--- a/extensions/zalo/src/outbound-payload.contract.test.ts
+++ b/extensions/zalo/src/outbound-payload.contract.test.ts
@@ -28,10 +28,16 @@ vi.mock("./channel.runtime.js", () => ({
 
 type ZaloOutbound = NonNullable<typeof zaloPlugin.outbound>;
 type ZaloSendPayload = NonNullable<ZaloOutbound["sendPayload"]>;
-const zaloMessageAdapter = zaloPlugin.message;
-if (!zaloMessageAdapter) {
-  throw new Error("Expected Zalo message adapter");
+
+function requireZaloMessageAdapter(): NonNullable<typeof zaloPlugin.message> {
+  const adapter = zaloPlugin.message;
+  if (!adapter) {
+    throw new Error("Expected Zalo message adapter");
+  }
+  return adapter;
 }
+
+const zaloMessageAdapter = requireZaloMessageAdapter();
 type ZaloMessageSender = NonNullable<typeof zaloMessageAdapter.send>;
 
 function requireZaloSendPayload(): ZaloSendPayload {


### PR DESCRIPTION
## What Problem This Solves

The Zalo outbound payload contract fixture narrowed an optional message adapter only at top level. TypeScript did not preserve that narrowing inside the later helper closures, breaking the extension test-type lane on current main.

## Why This Change Was Made

A small requirement helper now returns the adapter with an explicit non-null type. The existing fail-fast assertion and one-time adapter resolution remain unchanged.

## User Impact

No runtime, CLI, plugin, or dead-export baseline change. This repairs test typing only.

## Evidence

- Blacksmith Testbox `tbx_01kxfxy89dqd9306enh319ysgv`: exact dead-export baseline 799, type-aware lint, focused 9/9 test, and full extension test types green.
- Targeted formatting green.
- Fresh autoreview clean at 0.99 confidence.

Hosted CI intentionally not awaited under the requested focused direct-land workflow.
