### PR TITLE
refactor(net): consolidate Undici runtime loading

### DIFF
--- a/src/infra/net/undici-runtime.ts
+++ b/src/infra/net/undici-runtime.ts
@@ -7,6 +7,7 @@ import { addActiveManagedProxyTlsOptions } from "./proxy/managed-proxy-undici.js
 import { resolveUndiciAutoSelectFamilyConnectOptions } from "./undici-family-policy.js";
 
 const TEST_UNDICI_RUNTIME_DEPS_KEY = "__OPENCLAW_TEST_UNDICI_RUNTIME_DEPS__";
+const requireUndici = createRequire(import.meta.url);
 
 /** Runtime-loaded undici constructors/functions used where static imports would affect globals. */
 export type UndiciRuntimeDeps = {
@@ -50,40 +51,17 @@ function applyMissingConnectOptions(
   }
 }
 
-function isUndiciRuntimeDeps(value: unknown): value is UndiciRuntimeDeps {
-  return (
-    typeof value === "object" &&
-    value !== null &&
-    typeof (value as UndiciRuntimeDeps).Agent === "function" &&
-    typeof (value as UndiciRuntimeDeps).EnvHttpProxyAgent === "function" &&
-    typeof (value as UndiciRuntimeDeps).ProxyAgent === "function" &&
-    typeof (value as UndiciRuntimeDeps).fetch === "function"
-  );
-}
-
-function isUndiciGlobalDispatcherDeps(value: unknown): value is UndiciGlobalDispatcherDeps {
-  return (
-    typeof value === "object" &&
-    value !== null &&
-    typeof (value as UndiciGlobalDispatcherDeps).Agent === "function" &&
-    typeof (value as UndiciGlobalDispatcherDeps).EnvHttpProxyAgent === "function" &&
-    typeof (value as UndiciGlobalDispatcherDeps).getGlobalDispatcher === "function" &&
-    typeof (value as UndiciGlobalDispatcherDeps).setGlobalDispatcher === "function"
-  );
-}
-
-function loadUndiciProxyPoolCtor(): typeof import("undici").Pool {
+function loadUndiciModule(
+  requiredExports: ReadonlyArray<keyof typeof import("undici")>,
+): typeof import("undici") {
   const override = (globalThis as Record<string, unknown>)[TEST_UNDICI_RUNTIME_DEPS_KEY];
   if (
-    typeof override === "object" &&
-    override !== null &&
-    typeof (override as { Pool?: unknown }).Pool === "function"
+    isObjectRecord(override) &&
+    requiredExports.every((key) => typeof override[key] === "function")
   ) {
-    return (override as { Pool: typeof import("undici").Pool }).Pool;
+    return override as typeof import("undici");
   }
-
-  const require = createRequire(import.meta.url);
-  return (require("undici") as typeof import("undici")).Pool;
+  return requireUndici("undici") as typeof import("undici");
 }
 
 function stripIpServernameFromConnectOptions(options: unknown): unknown {
@@ -111,7 +89,7 @@ function stripIpServernameFromConnect(connect: unknown): unknown {
 
 function createIpSafeProxyClientFactory(): UndiciProxyClientFactory {
   return (origin, options) => {
-    const Pool = loadUndiciProxyPoolCtor();
+    const { Pool } = loadUndiciModule(["Pool"]);
     // HTTPS proxies addressed by IP can arrive with an IP servername. Strip it
     // before TLS connect because OpenSSL rejects IP literals as SNI values.
     const clientOptions = isObjectRecord(options)
@@ -138,37 +116,17 @@ function addIpSafeProxyClientFactory<TOptions extends object>(options: TOptions)
 
 /** Loads undici lazily, allowing tests to inject constructors without global side effects. */
 export function loadUndiciRuntimeDeps(): UndiciRuntimeDeps {
-  const override = (globalThis as Record<string, unknown>)[TEST_UNDICI_RUNTIME_DEPS_KEY];
-  if (isUndiciRuntimeDeps(override)) {
-    return override;
-  }
-
-  const require = createRequire(import.meta.url);
-  const undici = require("undici") as typeof import("undici");
-  return {
-    Agent: undici.Agent,
-    EnvHttpProxyAgent: undici.EnvHttpProxyAgent,
-    FormData: undici.FormData,
-    ProxyAgent: undici.ProxyAgent,
-    fetch: undici.fetch,
-  };
+  return loadUndiciModule(["Agent", "EnvHttpProxyAgent", "ProxyAgent", "fetch"]);
 }
 
 /** Loads only the undici global-dispatcher API used by startup proxy setup. */
 export function loadUndiciGlobalDispatcherDeps(): UndiciGlobalDispatcherDeps {
-  const override = (globalThis as Record<string, unknown>)[TEST_UNDICI_RUNTIME_DEPS_KEY];
-  if (isUndiciGlobalDispatcherDeps(override)) {
-    return override;
-  }
-
-  const require = createRequire(import.meta.url);
-  const undici = require("undici") as typeof import("undici");
-  return {
-    Agent: undici.Agent,
-    EnvHttpProxyAgent: undici.EnvHttpProxyAgent,
-    getGlobalDispatcher: undici.getGlobalDispatcher,
-    setGlobalDispatcher: undici.setGlobalDispatcher,
-  };
+  return loadUndiciModule([
+    "Agent",
+    "EnvHttpProxyAgent",
+    "getGlobalDispatcher",
+    "setGlobalDispatcher",
+  ]);
 }
 
 function withHttp1OnlyDispatcherOptions<T extends object | undefined>(


### PR DESCRIPTION
## What Problem This Solves

The lazy Undici seam separately reimplemented export validation and reconstructed two overlapping subsets of Undici's root module.

## Why This Change Was Made

Use one typed loader for Undici 8.5.0's native root exports. Callers declare the exports their private test override must provide; missing or malformed override groups retain the existing fallback to the real module.

## User Impact

No runtime behavior change. Lazy loading, test injection, proxy `Pool` fallback, and global-dispatcher setup keep their existing contracts. Net reduction: 42 lines.

## Evidence

- `node scripts/run-vitest.mjs src/infra/net/undici-runtime.test.ts src/infra/net/runtime-fetch.test.ts src/infra/net/proxy-fetch.test.ts src/infra/net/ssrf.dispatcher.test.ts src/infra/net/undici-global-dispatcher.test.ts` — 5 files, 73 tests passed
- `git diff --check origin/main...HEAD`
- Fresh branch autoreview: no accepted/actionable findings
