### PR TITLE
fix(memory): recover real on-disk path for slugified QMD search results

### DIFF
--- a/extensions/memory-core/src/memory/qmd-document-resolver.ts
+++ b/extensions/memory-core/src/memory/qmd-document-resolver.ts
@@ -1,3 +1,4 @@
+import fsSync from "node:fs";
 import path from "node:path";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { expectDefined } from "openclaw/plugin-sdk/expect-runtime";
@@ -285,8 +286,23 @@ export class QmdDocumentResolver {
     if (!rootEntry) {
       return null;
     }
-    const normalizedRelative = collectionRelativePath.replace(/\\/g, "/");
-    const absPath = path.normalize(path.resolve(rootEntry.path, collectionRelativePath));
+    let normalizedRelative = collectionRelativePath.replace(/\\/g, "/");
+    let absPath = path.normalize(path.resolve(rootEntry.path, collectionRelativePath));
+    // Native QMD can persist a slugified path (e.g. `_` stored as `-`) whose active
+    // documents row diverges from the real filesystem name. If the resolved file is
+    // missing, recover the real on-disk path whose slug form matches before returning
+    // it, so memory_search never emits a citation that cannot be read (issue #106866).
+    if (!this.pathExistsOnDisk(absPath)) {
+      const recovered = this.recoverExistingCollectionRelativePath(
+        rootEntry.path,
+        normalizedRelative,
+      );
+      if (recovered === null) {
+        return null;
+      }
+      normalizedRelative = recovered;
+      absPath = path.normalize(path.resolve(rootEntry.path, recovered));
+    }
     const relativeToWorkspace = path.relative(this.workspaceDir, absPath);
     return {
       rel: this.buildSearchPath(collection, normalizedRelative, relativeToWorkspace, absPath),
@@ -325,11 +341,16 @@ export class QmdDocumentResolver {
         const match = rows.find((row) =>
           this.matchesPreferredFileHint(row.path, collectionRelativePath),
         );
-        if (
-          match &&
-          path.normalize(path.resolve(rootValue.path, match.path)) === normalizedAbsPath
-        ) {
-          return true;
+        if (match) {
+          if (path.normalize(path.resolve(rootValue.path, match.path)) === normalizedAbsPath) {
+            return true;
+          }
+          // The active row is a slugified alias (e.g. `_` stored as `-`) of a real
+          // file. Allow reading the real on-disk file the alias normalizes to
+          // (issue #106866); it is confined to the collection root and exists.
+          if (this.pathExistsOnDisk(normalizedAbsPath)) {
+            return true;
+          }
         }
       } catch (err) {
         if (isSqliteBusyError(err)) {
@@ -340,6 +361,68 @@ export class QmdDocumentResolver {
       }
     }
     return false;
+  }
+
+  /**
+   * Walks `relativePath` under `rootPath` segment by segment. When a segment does
+   * not exist verbatim, matches it against the real directory entries by their
+   * normalized slug form (normalizeQmdLookupSegment), recovering the actual
+   * on-disk name (e.g. a `-` in the stored path that is really `_` on disk).
+   * Returns the recovered relative path, or null when any segment cannot be
+   * matched to exactly one existing entry (missing or ambiguous).
+   */
+  private recoverExistingCollectionRelativePath(
+    rootPath: string,
+    relativePath: string,
+  ): string | null {
+    if (relativePath.includes("..")) {
+      return null;
+    }
+    const segments = relativePath
+      .split("/")
+      .filter((segment) => segment.length > 0 && segment !== ".");
+    if (segments.length === 0) {
+      return null;
+    }
+    let currentDir = rootPath;
+    const recovered: string[] = [];
+    for (const [index, segment] of segments.entries()) {
+      const isLast = index === segments.length - 1;
+      const direct = path.join(currentDir, segment);
+      if (this.pathExistsOnDisk(direct)) {
+        recovered.push(segment);
+        currentDir = direct;
+        continue;
+      }
+      let entries: fsSync.Dirent[];
+      try {
+        entries = fsSync.readdirSync(currentDir, { withFileTypes: true }) as fsSync.Dirent[];
+      } catch {
+        return null;
+      }
+      const target = normalizeQmdLookupSegment(segment);
+      const matches = entries.filter(
+        (entry) =>
+          (isLast ? entry.isFile() : entry.isDirectory()) &&
+          normalizeQmdLookupSegment(entry.name) === target,
+      );
+      const [match] = matches;
+      if (!match || matches.length !== 1) {
+        // 0 matches -> no real file; >1 -> ambiguous. Never guess a citation.
+        return null;
+      }
+      recovered.push(match.name);
+      currentDir = path.join(currentDir, match.name);
+    }
+    return recovered.join("/");
+  }
+
+  private pathExistsOnDisk(absPath: string): boolean {
+    try {
+      return fsSync.existsSync(absPath);
+    } catch {
+      return false;
+    }
   }
 }
 

--- a/extensions/memory-core/src/memory/qmd-manager.slugified-paths.test.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.slugified-paths.test.ts
@@ -404,4 +404,142 @@ describe("QmdMemoryManager slugified path resolution", () => {
       lines: 1,
     });
   });
+
+  it("maps a slugified underscore path back to the real on-disk filesystem path (#106866)", async () => {
+    // Native QMD can store `mundo-pathfinder.md` (a `_`->`-` slug) as the active
+    // documents row while the real file on disk is `mundo_pathfinder.md`. Search
+    // must return the real, readable path rather than the non-existent slug path.
+    const actualRelative = "rol/mundo_pathfinder.md";
+    const actualFile = path.join(workspaceDir, actualRelative);
+    await fs.mkdir(path.dirname(actualFile), { recursive: true });
+    await fs.writeFile(actualFile, "line-1\nline-2\nline-3", "utf-8");
+
+    spawnMock.mockImplementation((_cmd: string, args: string[]) => {
+      if (args[0] === "search") {
+        const child = createMockChild({ autoClose: false });
+        emitAndClose(
+          child,
+          "stdout",
+          JSON.stringify([
+            {
+              file: "qmd://workspace-main/rol/mundo-pathfinder.md",
+              score: 0.94,
+              snippet: "@@ -2,1\nline-2",
+            },
+          ]),
+        );
+        return child;
+      }
+      return createMockChild();
+    });
+
+    const { manager } = await createManager();
+    installIndexedPathStub({
+      manager,
+      collection: "workspace-main",
+      normalizedPath: "rol/mundo-pathfinder.md",
+      exactPaths: ["rol/mundo-pathfinder.md"],
+      allPaths: ["rol/mundo-pathfinder.md"],
+    });
+
+    const results = await manager.search("line-2", {
+      sessionKey: "agent:main:slack:dm:u123",
+    });
+    expect(results).toEqual([
+      {
+        path: actualRelative,
+        startLine: 2,
+        endLine: 2,
+        score: 0.94,
+        snippet: "@@ -2,1\nline-2",
+        source: "memory",
+      },
+    ]);
+
+    const result = expectDefined(results[0], "recovered underscore QMD search result");
+    await expect(manager.readFile({ relPath: result.path })).resolves.toEqual({
+      path: actualRelative,
+      text: "line-1\nline-2\nline-3",
+      from: 1,
+      lines: 3,
+    });
+  });
+
+  it("skips a search result whose slugified path has no file on disk (#106866)", async () => {
+    // The active row points at `rol/ghost-doc.md` and no real file exists on disk.
+    // Search must drop the result rather than emit an unreadable citation.
+    await fs.mkdir(path.join(workspaceDir, "rol"), { recursive: true });
+
+    spawnMock.mockImplementation((_cmd: string, args: string[]) => {
+      if (args[0] === "search") {
+        const child = createMockChild({ autoClose: false });
+        emitAndClose(
+          child,
+          "stdout",
+          JSON.stringify([
+            {
+              file: "qmd://workspace-main/rol/ghost-doc.md",
+              score: 0.5,
+              snippet: "@@ -1,1\nghost",
+            },
+          ]),
+        );
+        return child;
+      }
+      return createMockChild();
+    });
+
+    const { manager } = await createManager();
+    installIndexedPathStub({
+      manager,
+      collection: "workspace-main",
+      normalizedPath: "rol/ghost-doc.md",
+      exactPaths: ["rol/ghost-doc.md"],
+    });
+
+    const results = await manager.search("ghost", {
+      sessionKey: "agent:main:slack:dm:u123",
+    });
+    expect(results).toEqual([]);
+  });
+
+  it("does not guess when a slug matches multiple real files (#106866)", async () => {
+    // Two real files normalize to the same slug (`mundo-pathfinder.md`). Recovery
+    // must stay ambiguous-safe and skip rather than return the wrong file.
+    await fs.mkdir(path.join(workspaceDir, "rol"), { recursive: true });
+    await fs.writeFile(path.join(workspaceDir, "rol/mundo_pathfinder.md"), "underscore", "utf-8");
+    await fs.writeFile(path.join(workspaceDir, "rol/mundo pathfinder.md"), "space", "utf-8");
+
+    spawnMock.mockImplementation((_cmd: string, args: string[]) => {
+      if (args[0] === "search") {
+        const child = createMockChild({ autoClose: false });
+        emitAndClose(
+          child,
+          "stdout",
+          JSON.stringify([
+            {
+              file: "qmd://workspace-main/rol/mundo-pathfinder.md",
+              score: 0.7,
+              snippet: "@@ -1,1\nunderscore",
+            },
+          ]),
+        );
+        return child;
+      }
+      return createMockChild();
+    });
+
+    const { manager } = await createManager();
+    installIndexedPathStub({
+      manager,
+      collection: "workspace-main",
+      normalizedPath: "rol/mundo-pathfinder.md",
+      exactPaths: ["rol/mundo-pathfinder.md"],
+    });
+
+    const results = await manager.search("underscore", {
+      sessionKey: "agent:main:slack:dm:u123",
+    });
+    expect(results).toEqual([]);
+  });
 });


### PR DESCRIPTION
## Summary

**Problem**: `openclaw memory search` (QMD backend) returns citations whose paths do not exist on disk. When a file name contains `_`, native QMD persists a slugified alias (`mundo_pathfinder.md` -> `mundo-pathfinder.md`) as the active `documents` row while the real path stays inactive, so search emits `rol/mundo-pathfinder.md`, which cannot be read and makes agents lose or mis-handle memory (issue #106866).

**Solution**: `toDocLocation` now verifies the resolved path exists on disk; when it does not, it recovers the real on-disk path whose slug form matches by walking the collection directory and matching each segment via the existing `normalizeQmdLookupSegment`. `isIndexedWorkspaceReadPath` is relaxed to accept that recovered real file so the search -> read roundtrip stays intact. Unrecoverable or ambiguous paths are skipped rather than emitting an unreadable citation.

**What changed**: in `extensions/memory-core/src/memory/qmd-document-resolver.ts`, `toDocLocation` gains an existence check + new `recoverExistingCollectionRelativePath` / `pathExistsOnDisk` helpers, and `isIndexedWorkspaceReadPath` accepts a slug-aliased real file; three new slugified-path tests in `qmd-manager.slugified-paths.test.ts`.

**What did NOT change**: native QMD indexing (the slugified active row is written by the out-of-repo native binary), the existing case/space slug resolution, and any public API/config/CLI surface. Recovery engages only when the resolved path is missing, so normal paths are unaffected.

Fixes #106866

---

## Root Cause

**Trigger condition**: native QMD stores a `_`->`-` slugified path as the active `documents` row (real path inactive). The document resolver exact-matches that active slug row and passes it to `toDocLocation`.

**Root cause analysis**: `toDocLocation` trusted the store's active path and returned it without checking that the resolved file exists on disk. The store-side normalized recovery only scans active rows, which are all slug aliases in this case, so it cannot reach the real (inactive) path. Root: missing filesystem existence validation and real-path recovery in the document resolver.

**Affected scope**: any `memory_search` result or read hint whose native active row is a slugified alias of a real file. The native binary is out of repo; this is a TS-side defensive fix.

---

## Real behavior proof

**Behavior addressed**: `memory_search` no longer returns a slugified path that does not exist on disk; it recovers and returns the real, readable path (or skips when unrecoverable or ambiguous).

**Real environment tested**: Linux x86_64, Node v24.13.1, vitest v4.1.9. Real `QmdMemoryManager.search` / `readFile` execution with the native engine mocked via `child_process.spawn` and a stubbed SQLite store (the repo's existing QMD source-repro harness), running the modified source.

**Exact steps or command run after this patch**: revert the resolver to the pre-fix version and run the underscore recovery test (search returns the non-existent slug path), then restore the fix and run it (search returns the real path).
```bash
# node vitest - Before fix (revert resolver) then After fix (restore)
git checkout HEAD~1 -- extensions/memory-core/src/memory/qmd-document-resolver.ts
node node_modules/.bin/vitest run extensions/memory-core/src/memory/qmd-manager.slugified-paths.test.ts -t underscore
git checkout HEAD -- extensions/memory-core/src/memory/qmd-document-resolver.ts
node node_modules/.bin/vitest run extensions/memory-core/src/memory/qmd-manager.slugified-paths.test.ts
```

**After-fix evidence**:
```
Before fix (native slug active row trusted): search returns the non-existent slug path.
    FAIL ... maps a slugified underscore path back to the real on-disk filesystem path (#106866)
    - Expected  "path": "rol/mundo_pathfinder.md"     (real file on disk)
    + Received  "path": "rol/mundo-pathfinder.md"     (slug alias, does not exist)

After fix (real path recovered):
    Test Files  1 passed (1)
         Tests  6 passed (6)
```

**Observed result after the fix**: the identical scenario now returns the real, readable `rol/mundo_pathfinder.md` and `readFile` reads its content; before the patch it returned the non-existent slug path. Missing-file and ambiguous cases are skipped, so no unreadable citation is emitted.

**What was not tested**: a full live native QMD reindex over real underscore files (the native binary that writes the slug rows is out of repo and needs a specific FS/QMD environment). Substituted by the repo's mock-spawn + stubbed-store source-repro harness running the real manager code path.

## Tests and validation

### Unit tests
```
$ node node_modules/.bin/vitest run extensions/memory-core/src/memory/qmd-manager.slugified-paths.test.ts --no-coverage
 Test Files  1 passed (1)
      Tests  6 passed (6)      # 3 existing + 3 new (#106866): recovery+readFile, missing-file skip, ambiguous skip

$ node scripts/run-tsgo.mjs -p tsconfig.extensions.json        # no resolver type errors
$ node node_modules/.bin/oxlint <changed files>                # exit 0
```

## Risk checklist

merge-risk: Low

- [x] This change is backwards compatible
- [x] This change has been tested with existing configurations
- [x] I have updated relevant documentation (N/A - internal path-resolution fix, no public API/config/CLI/doc surface)
- [x] Breaking changes (if any) are documented in Summary (none)

Mitigation: recovery engages only when the resolved path is missing; normal paths are unaffected. Recovery is confined to the collection root (`isPathInside`), requires a normalized match to an active row, and requires the real file to exist, so no arbitrary-file read is introduced.

## Current review state

- [x] Self-review completed
- [ ] At least one maintainer review
- [ ] All CI checks passed

---

> AI-assisted: root-cause analysis, implementation, and tests were prepared with AI assistance and human-reviewed.
