### PR TITLE
refactor(net): share Undici fetch normalization

### DIFF
--- a/src/infra/net/proxy-fetch.ts
+++ b/src/infra/net/proxy-fetch.ts
@@ -2,13 +2,12 @@
 // options and runtime FormData normalization.
 import { logWarn } from "../../logger.js";
 import { formatErrorMessage } from "../errors.js";
-import { normalizeHeadersInitForFetch } from "../fetch-headers.js";
-import { isFormDataLike } from "./form-data.js";
 import {
   addActiveManagedProxyTlsOptions,
   resolveManagedEnvHttpProxyAgentOptions,
 } from "./proxy/managed-proxy-undici.js";
-import { loadUndiciRuntimeDeps, type UndiciRuntimeDeps } from "./undici-runtime.js";
+import { fetchWithPreparedRuntimeDispatcher } from "./runtime-fetch.js";
+import { loadUndiciRuntimeDeps } from "./undici-runtime.js";
 
 /** Non-enumerable marker used to recover the explicit proxy URL from proxy fetch wrappers. */
 export const PROXY_FETCH_PROXY_URL = Symbol.for("openclaw.proxyFetch.proxyUrl");
@@ -16,78 +15,25 @@ type ProxyFetchWithMetadata = typeof fetch & {
   [PROXY_FETCH_PROXY_URL]?: string;
 };
 
-type UndiciFormDataCtor = NonNullable<UndiciRuntimeDeps["FormData"]>;
-type UndiciFormDataInstance = InstanceType<UndiciFormDataCtor>;
-
-function appendFormDataEntry(
-  target: UndiciFormDataInstance,
-  key: string,
-  value: FormDataEntryValue,
-): void {
-  if (typeof value === "string") {
-    target.append(key, value);
-    return;
-  }
-  const fileName = typeof value.name === "string" && value.name.trim() ? value.name : undefined;
-  if (fileName) {
-    target.append(key, value, fileName);
-    return;
-  }
-  target.append(key, value);
-}
-
-function normalizeInitForUndici(
-  init: RequestInit | undefined,
-  UndiciFormData: UndiciFormDataCtor,
-): RequestInit | undefined {
-  // Proxy fetch also uses undici runtime FormData; rebuild global FormData and
-  // drop caller-supplied multipart headers so undici owns the boundary.
-  if (!init) {
-    return init;
-  }
-  const normalizedHeaders = normalizeHeadersInitForFetch(init.headers);
-  const initWithNormalizedHeaders =
-    normalizedHeaders === init.headers ? init : { ...init, headers: normalizedHeaders };
-  const body = init.body;
-  if (!isFormDataLike(body) || body instanceof UndiciFormData) {
-    return initWithNormalizedHeaders;
-  }
-  const form = new UndiciFormData();
-  for (const [key, value] of body.entries()) {
-    appendFormDataEntry(form, key, value);
-  }
-  // Undici must generate the multipart boundary for its own FormData instance;
-  // forwarding caller-supplied multipart headers can send a stale boundary.
-  const headers = new Headers(normalizedHeaders);
-  headers.delete("content-length");
-  headers.delete("content-type");
-  return { ...initWithNormalizedHeaders, headers, body: form as unknown as BodyInit };
-}
-
 /**
  * Create a fetch function that routes requests through the given HTTP proxy.
  * Uses undici's ProxyAgent under the hood.
  */
 export function makeProxyFetch(proxyUrl: string): typeof fetch {
-  const {
-    ProxyAgent,
-    FormData: UndiciFormData = globalThis.FormData as unknown as UndiciFormDataCtor,
-    fetch: undiciFetch,
-  } = loadUndiciRuntimeDeps();
-  let agent: InstanceType<UndiciRuntimeDeps["ProxyAgent"]> | null = null;
-  const resolveAgent = (): InstanceType<UndiciRuntimeDeps["ProxyAgent"]> => {
+  const runtimeDeps = loadUndiciRuntimeDeps();
+  const { ProxyAgent } = runtimeDeps;
+  let agent: InstanceType<typeof ProxyAgent> | null = null;
+  const resolveAgent = (): InstanceType<typeof ProxyAgent> => {
     if (!agent) {
       agent = new ProxyAgent(addActiveManagedProxyTlsOptions({ uri: proxyUrl }));
     }
     return agent;
   };
-  // undici's fetch is runtime-compatible with global fetch but the types diverge
-  // on stream/body internals. Single cast at the boundary keeps the rest type-safe.
   const proxyFetch = ((input: RequestInfo | URL, init?: RequestInit) =>
-    undiciFetch(input as string | URL, {
-      ...(normalizeInitForUndici(init, UndiciFormData) as Record<string, unknown>),
+    fetchWithPreparedRuntimeDispatcher(runtimeDeps, input, {
+      ...init,
       dispatcher: resolveAgent(),
-    }) as unknown as Promise<Response>) as ProxyFetchWithMetadata;
+    })) as ProxyFetchWithMetadata;
   Object.defineProperty(proxyFetch, PROXY_FETCH_PROXY_URL, {
     value: proxyUrl,
     enumerable: false,
@@ -121,17 +67,14 @@ export function resolveProxyFetchFromEnv(
     return undefined;
   }
   try {
-    const {
-      EnvHttpProxyAgent,
-      FormData: UndiciFormData = globalThis.FormData as unknown as UndiciFormDataCtor,
-      fetch: undiciFetch,
-    } = loadUndiciRuntimeDeps();
+    const runtimeDeps = loadUndiciRuntimeDeps();
+    const { EnvHttpProxyAgent } = runtimeDeps;
     const agent = new EnvHttpProxyAgent(proxyOptions);
     return ((input: RequestInfo | URL, init?: RequestInit) =>
-      undiciFetch(input as string | URL, {
-        ...(normalizeInitForUndici(init, UndiciFormData) as Record<string, unknown>),
+      fetchWithPreparedRuntimeDispatcher(runtimeDeps, input, {
+        ...init,
         dispatcher: agent,
-      }) as unknown as Promise<Response>) as typeof fetch;
+      })) as typeof fetch;
   } catch (err) {
     logWarn(
       `Proxy env var set but agent creation failed — falling back to direct fetch: ${formatErrorMessage(err)}`,

--- a/src/infra/net/runtime-fetch.ts
+++ b/src/infra/net/runtime-fetch.ts
@@ -89,15 +89,20 @@ export async function fetchWithRuntimeDispatcher(
   input: RequestInfo | URL,
   init?: DispatcherAwareRequestInit,
 ): Promise<Response> {
-  const runtimeDeps = loadUndiciRuntimeDeps();
+  return await fetchWithPreparedRuntimeDispatcher(loadUndiciRuntimeDeps(), input, init);
+}
+
+/** Uses one prepared Undici snapshot so reusable fetch wrappers stay stable. */
+export function fetchWithPreparedRuntimeDispatcher(
+  runtimeDeps: UndiciRuntimeDeps,
+  input: RequestInfo | URL,
+  init?: DispatcherAwareRequestInit,
+): Promise<Response> {
   const runtimeFetch = runtimeDeps.fetch as unknown as (
     input: RequestInfo | URL,
     init?: DispatcherAwareRequestInit,
-  ) => Promise<unknown>;
-  return (await runtimeFetch(
-    input,
-    normalizeRuntimeRequestInit(init, runtimeDeps.FormData),
-  )) as Response;
+  ) => Promise<Response>;
+  return runtimeFetch(input, normalizeRuntimeRequestInit(init, runtimeDeps.FormData));
 }
 
 /**


### PR DESCRIPTION
## What Problem This Solves

Proxy fetch wrappers duplicated the shared Undici adapter's header cleanup, foreign FormData conversion, filename preservation, and multipart boundary handling.

## Why This Change Was Made

Route proxy requests through the canonical runtime fetch adapter. A prepared-dependency entry point lets each reusable wrapper keep one stable Undici fetch/FormData/agent snapshot instead of rediscovering it per request.

## User Impact

No behavior change. Explicit and environment proxy dispatchers, lazy agent reuse, proxy metadata, headers, FormData filenames, and multipart boundaries retain their existing contracts. Net reduction: 52 lines.

## Evidence

- Focused runtime, provider, Telegram, and Discord tests — 7 files, 93 tests passed
- `git diff --check origin/main...HEAD`
- Fresh branch autoreview: no accepted/actionable findings
