### PR TITLE
fix(discord): show only agent status in progress drafts

### DIFF
--- a/docs/channels/discord.md
+++ b/docs/channels/discord.md
@@ -674,10 +674,9 @@ See [Slash commands](/tools/slash-commands) for the command catalog and behavior
       streaming: {
         mode: "progress",
         progress: {
-          label: "auto",
           maxLines: 8,
           maxLineChars: 120,
-          toolProgress: true,
+          toolProgress: false,
           commentary: false,
         },
       },
@@ -689,11 +688,11 @@ See [Slash commands](/tools/slash-commands) for the command catalog and behavior
     - `off` disables Discord preview edits.
     - `partial` edits a single preview message as tokens arrive.
     - `block` emits draft-sized chunks; tune size and breakpoints with `streaming.preview.chunk` (`minChars`, `maxChars`, `breakPreference`), clamped to `textChunkLimit`. When block streaming is explicitly enabled, OpenClaw skips the preview stream to avoid double-streaming.
-    - `progress` keeps one editable status draft and updates it with tool progress until final delivery. Raw tool progress uses the shared starter label as a rolling line; narrated status shows only the narration unless a label is explicitly configured.
+    - `progress` keeps one editable status draft until final delivery. By default it shows one line of the agent's latest preamble or narration, with no generated label, spacer, or tool rows.
     - Media, error, and explicit-reply finals cancel pending preview edits.
-    - `streaming.preview.toolProgress` (default `true`) controls whether tool/progress updates reuse the preview message.
-    - Tool/progress rows render as compact emoji + title + detail when available, for example `🛠️ Bash: run tests` or `🔎 Web Search: for "query"`.
-    - `streaming.progress.commentary` (default `false`) opts into assistant commentary/preamble text in the temporary progress draft. Commentary is cleaned before display, stays transient, and does not change final answer delivery.
+    - `streaming.preview.toolProgress` defaults to `true` in `partial`/`block` mode. Discord progress mode defaults to no tool rows; set `streaming.progress.toolProgress: true` to opt in.
+    - Set `streaming.progress.toolProgress: true` to add compact tool/progress rows such as `🛠️ Bash: run tests` or `🔎 Web Search: for "query"`. For compatibility, an existing `progress.label` or `progress.labels` configuration retains the prior tool-row default; set `toolProgress: false` for a custom label without rows.
+    - `streaming.progress.commentary` (default `false`) opts into raw assistant commentary in the temporary progress draft. The default preamble/narration status line is independent of this option. Commentary is cleaned before display, stays transient, and does not change final answer delivery.
     - `streaming.progress.maxLineChars` controls the per-line progress preview budget. Prose is shortened on word boundaries; command and path details keep useful suffixes.
     - `streaming.preview.commandText` / `streaming.progress.commandText` controls command/exec detail in compact progress lines: `raw` (default) or `status` (tool label only).
 

--- a/extensions/discord/src/monitor/message-handler.draft-preview.ts
+++ b/extensions/discord/src/monitor/message-handler.draft-preview.ts
@@ -2,6 +2,7 @@ import { EmbeddedBlockChunker } from "openclaw/plugin-sdk/agent-runtime";
 import {
   type ChannelProgressDraftLine,
   createChannelProgressDraftCompositor,
+  resolveChannelProgressDraftConfig,
   resolveChannelStreamingBlockEnabled,
   resolveChannelStreamingPreviewCommandText,
   resolveChannelStreamingPreviewToolProgress,
@@ -82,8 +83,18 @@ export function createDiscordDraftPreviewController(params: {
   let progressDraftStartedBeforeFinal = false;
   let progressDraftCollapsed = false;
   let progressNarratorLifecycle: { beginTurn: () => void; stopTurn: () => void } | undefined;
+  const progressConfig = resolveChannelProgressDraftConfig(params.discordConfig);
+  const progressHasExplicitLabel =
+    progressConfig.label !== undefined || progressConfig.labels !== undefined;
+  // Discord defaults to progress mode even when `streaming.mode` is omitted,
+  // so pass that resolved mode into the shared default through this fallback.
+  const progressToolDefault = progressConfig.toolProgress ?? progressHasExplicitLabel;
   const previewToolProgressEnabled =
-    Boolean(draftStream) && resolveChannelStreamingPreviewToolProgress(params.discordConfig);
+    Boolean(draftStream) &&
+    resolveChannelStreamingPreviewToolProgress(
+      params.discordConfig,
+      discordStreamMode === "progress" ? progressToolDefault : true,
+    );
   const narrationProgressEnabled =
     Boolean(draftStream) &&
     discordStreamMode === "progress" &&
@@ -108,7 +119,7 @@ export function createDiscordDraftPreviewController(params: {
     seed: progressSeed,
     reasoningLinePrefix: "🧠 ",
     commentaryLinePrefix: "💬 ",
-    reasoningGate: true,
+    reasoningGate: previewToolProgressEnabled,
     commentaryItalics: false,
     update: async (previewText, options) => {
       lastPartialText = previewText;

--- a/extensions/discord/src/monitor/message-handler.process.test.ts
+++ b/extensions/discord/src/monitor/message-handler.process.test.ts
@@ -2661,7 +2661,7 @@ describe("processDiscordMessage draft streaming", () => {
     await runProcessDiscordMessage(ctx);
 
     expect(getLastDispatchReplyOptions()?.sourceReplyDeliveryMode).toBe("message_tool_only");
-    expect(draftStream.update).toHaveBeenCalledWith("🛠️ Exec\n• exec done");
+    expect(draftStream.update).toHaveBeenCalledWith("Working\n\n🛠️ Exec\n• exec done");
     expect(deliverDiscordReply).not.toHaveBeenCalled();
   });
 

--- a/extensions/discord/src/monitor/message-handler.process.test.ts
+++ b/extensions/discord/src/monitor/message-handler.process.test.ts
@@ -2299,7 +2299,7 @@ describe("processDiscordMessage draft streaming", () => {
     expect(getDeliveredFinalTexts()[0]).not.toContain("\n-# ");
   });
 
-  it("streams Discord tool progress by default once the initial delay elapses", async () => {
+  it("streams Discord tool progress when explicitly enabled", async () => {
     const elapseProgressDraftStartDelay = useProgressDraftStartDelay();
     const draftStream = createMockDraftStreamForTest();
 
@@ -2312,7 +2312,13 @@ describe("processDiscordMessage draft streaming", () => {
     });
 
     const ctx = await createAutomaticSourceDeliveryContext({
-      discordConfig: { maxLinesPerMessage: 5 },
+      discordConfig: {
+        maxLinesPerMessage: 5,
+        streaming: {
+          mode: "progress",
+          progress: { label: "Working", toolProgress: true },
+        },
+      },
     });
 
     await runProcessDiscordMessage(ctx);
@@ -2635,6 +2641,14 @@ describe("processDiscordMessage draft streaming", () => {
 
     const ctx = await createBaseContext({
       cfg: {
+        channels: {
+          discord: {
+            streaming: {
+              mode: "progress",
+              progress: { toolProgress: true },
+            },
+          },
+        },
         tools: { profile: "coding" },
         messages: {
           groupChat: { visibleReplies: "message_tool" },
@@ -2647,7 +2661,7 @@ describe("processDiscordMessage draft streaming", () => {
     await runProcessDiscordMessage(ctx);
 
     expect(getLastDispatchReplyOptions()?.sourceReplyDeliveryMode).toBe("message_tool_only");
-    expect(draftStream.update).toHaveBeenCalledWith("Working\n\n🛠️ Exec\n• exec done");
+    expect(draftStream.update).toHaveBeenCalledWith("🛠️ Exec\n• exec done");
     expect(deliverDiscordReply).not.toHaveBeenCalled();
   });
 
@@ -3116,12 +3130,17 @@ describe("processDiscordMessage draft streaming", () => {
     expect(firstDispatchParams().replyOptions?.disableBlockStreaming).toBe(true);
   });
 
-  it("uses the plain default progress label when Discord tool lines are disabled", async () => {
+  it("shows only the agent status in the default Discord progress draft", async () => {
     const elapseProgressDraftStartDelay = useProgressDraftStartDelay();
     const draftStream = createMockDraftStreamForTest();
 
     dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
       await params?.replyOptions?.onReplyStart?.();
+      await params?.replyOptions?.onItemEvent?.({
+        itemId: "preamble-1",
+        kind: "preamble",
+        progressText: "Claiming my square footage. Tastefully, but with claws.",
+      });
       await params?.replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
       await params?.replyOptions?.onItemEvent?.({ progressText: "exec done" });
       await elapseProgressDraftStartDelay();
@@ -3132,9 +3151,6 @@ describe("processDiscordMessage draft streaming", () => {
       discordConfig: {
         streaming: {
           mode: "progress",
-          progress: {
-            toolProgress: false,
-          },
         },
       },
     });
@@ -3142,7 +3158,10 @@ describe("processDiscordMessage draft streaming", () => {
     await runProcessDiscordMessage(ctx);
 
     expect(draftStream.update).toHaveBeenCalledTimes(1);
-    expect(draftStream.update).toHaveBeenCalledWith("Working");
+    expect(draftStream.update).toHaveBeenCalledWith(
+      "Claiming my square footage. Tastefully, but with claws.",
+    );
+    expect(String(draftStream.update.mock.calls[0]?.[0])).not.toMatch(/Working|Exec|\n\n/);
     expect(draftStream.flush).toHaveBeenCalledTimes(1);
     expect(
       requireRecord(firstDispatchParams().replyOptions, "dispatch reply options")

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -4080,8 +4080,8 @@ describe("dispatchTelegramMessage draft streaming", () => {
 
     expect(answerDraftStream.updatePreview).toHaveBeenCalledWith(
       telegramProgressPreview(
-        "Cracking\n\n🛠️ Exec\n🛠️ git rev-parse --abbrev-ref HEAD",
-        "<b>Cracking</b>\n<b>🛠️ Exec</b>\n<b>🛠️ Exec</b> <code>git rev-parse --abbrev-ref HEAD</code>",
+        "Working\n\n🛠️ Exec\n🛠️ git rev-parse --abbrev-ref HEAD",
+        "<b>Working</b>\n<b>🛠️ Exec</b>\n<b>🛠️ Exec</b> <code>git rev-parse --abbrev-ref HEAD</code>",
       ),
     );
     expect(answerDraftStream.update).not.toHaveBeenCalledWith("Branch is up to date");
@@ -4806,7 +4806,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     });
 
     expect(answerDraftStream.updatePreview).toHaveBeenCalledWith(
-      telegramProgressPreview("Cracking\n\n🛠️ Exec", "<b>Cracking</b>\n<b>🛠️ Exec</b>"),
+      telegramProgressPreview("Working\n\n🛠️ Exec", "<b>Working</b>\n<b>🛠️ Exec</b>"),
     );
     expect(answerDraftStream.update).toHaveBeenCalledTimes(1);
     expect(answerDraftStream.update).toHaveBeenNthCalledWith(1, trailingFinalStatusText);

--- a/ui/src/e2e/chat-run-lifecycle.e2e.test.ts
+++ b/ui/src/e2e/chat-run-lifecycle.e2e.test.ts
@@ -74,7 +74,7 @@ describeControlUiE2e("Control UI chat run lifecycle", () => {
     const workingLabel = currentPage.locator(
       ".chat-working-indicator__status > .agent-chat__sr-only",
     );
-    await expect(workingLabel).toHaveText("Working…");
+    expect(await workingLabel.textContent()).toBe("Working…");
     expect(
       await currentPage
         .locator(".chat-working-indicator__status > span:not(.agent-chat__sr-only)")

--- a/ui/src/e2e/chat-run-lifecycle.e2e.test.ts
+++ b/ui/src/e2e/chat-run-lifecycle.e2e.test.ts
@@ -71,7 +71,15 @@ describeControlUiE2e("Control UI chat run lifecycle", () => {
     await expect
       .poll(() => currentPage.locator(".chat-working-indicator__elapsed").textContent())
       .toBe("2m 57s");
-    await currentPage.getByText("Working…", { exact: true }).waitFor();
+    const workingLabel = currentPage.locator(
+      ".chat-working-indicator__status > .agent-chat__sr-only",
+    );
+    await expect(workingLabel).toHaveText("Working…");
+    expect(
+      await currentPage
+        .locator(".chat-working-indicator__status > span:not(.agent-chat__sr-only)")
+        .count(),
+    ).toBe(0);
   });
 
   it("clears shared session activity when chat final arrives first", async () => {

--- a/ui/src/e2e/mantis-chat-proof.e2e.test.ts
+++ b/ui/src/e2e/mantis-chat-proof.e2e.test.ts
@@ -110,7 +110,7 @@ describeMantisWebUiChat("Mantis Control UI web chat proof", () => {
       await page.getByText("saved 875.3k tokens", { exact: true }).waitFor();
       await page.locator(".chat-working-indicator").waitFor();
       const workingLabel = page.locator(".chat-working-indicator__status > .agent-chat__sr-only");
-      await expect(workingLabel).toHaveText("Working…");
+      expect(await workingLabel.textContent()).toBe("Working…");
       expect(
         await page
           .locator(".chat-working-indicator__status > span:not(.agent-chat__sr-only)")

--- a/ui/src/e2e/mantis-chat-proof.e2e.test.ts
+++ b/ui/src/e2e/mantis-chat-proof.e2e.test.ts
@@ -109,7 +109,13 @@ describeMantisWebUiChat("Mantis Control UI web chat proof", () => {
 
       await page.getByText("saved 875.3k tokens", { exact: true }).waitFor();
       await page.locator(".chat-working-indicator").waitFor();
-      await page.getByText("Working…", { exact: true }).waitFor();
+      const workingLabel = page.locator(".chat-working-indicator__status > .agent-chat__sr-only");
+      await expect(workingLabel).toHaveText("Working…");
+      expect(
+        await page
+          .locator(".chat-working-indicator__status > span:not(.agent-chat__sr-only)")
+          .count(),
+      ).toBe(0);
       await page.clock.runFor(177_000);
       await expect
         .poll(() => page.locator(".chat-working-indicator__elapsed").textContent())

--- a/ui/src/pages/chat/components/chat-message.test.ts
+++ b/ui/src/pages/chat/components/chat-message.test.ts
@@ -1049,9 +1049,15 @@ describe("grouped chat rendering", () => {
     expect(container.querySelectorAll(".chat-avatar.assistant")).toHaveLength(0);
     expect(container.querySelector(".chat-reading-indicator")).not.toBeNull();
     expect(container.querySelector(".chat-working-indicator__elapsed")).not.toBeNull();
-    expect(container.querySelector(".chat-working-indicator__status")?.textContent).toContain(
-      "Working…",
-    );
+    expect(
+      container.querySelector(".chat-working-indicator__status > .agent-chat__sr-only")
+        ?.textContent,
+    ).toBe("Working…");
+    expect(
+      container.querySelectorAll(
+        ".chat-working-indicator__status > span:not(.agent-chat__sr-only)",
+      ),
+    ).toHaveLength(0);
     expect(container.querySelector(".chat-group-footer")).toBeNull();
   });
 
@@ -1096,20 +1102,23 @@ describe("grouped chat rendering", () => {
     }
   });
 
-  it("keeps the progress label plain across runs", () => {
-    const labelFor = (startedAt: number) => {
+  it("keeps the synthetic progress word screen-reader-only across runs", () => {
+    const statusFor = (startedAt: number) => {
       const container = document.createElement("div");
       render(
         renderStreamGroup([{ kind: "reading-indicator", key: "reading", startedAt }]),
         container,
       );
-      return container.querySelector(".chat-working-indicator__status span:last-child")
-        ?.textContent;
+      const status = container.querySelector(".chat-working-indicator__status");
+      return {
+        hidden: status?.querySelector(".agent-chat__sr-only")?.textContent,
+        visibleLabels: status?.querySelectorAll("span:not(.agent-chat__sr-only)").length,
+      };
     };
 
-    expect(labelFor(1_000)).toBe("Working…");
-    expect(labelFor(1_500)).toBe("Working…");
-    expect(labelFor(8_000)).toBe("Working…");
+    expect(statusFor(1_000)).toEqual({ hidden: "Working…", visibleLabels: 0 });
+    expect(statusFor(1_500)).toEqual({ hidden: "Working…", visibleLabels: 0 });
+    expect(statusFor(8_000)).toEqual({ hidden: "Working…", visibleLabels: 0 });
   });
 
   it("renders configured local user names", () => {

--- a/ui/src/pages/chat/components/chat-working-indicator.ts
+++ b/ui/src/pages/chat/components/chat-working-indicator.ts
@@ -41,12 +41,11 @@ export function renderChatWorkingIndicator(part: Extract<ChatItem, { kind: "read
         ${icons.claw}
       </div>
       <span class="chat-working-indicator__status">
+        <span class="agent-chat__sr-only">${t("common.working")}</span>
         <openclaw-elapsed-time
           class="chat-working-indicator__elapsed"
           .startMs=${part.startedAt}
         ></openclaw-elapsed-time>
-        <span aria-hidden="true">·</span>
-        <span>${t("common.working")}</span>
       </span>
     </div>
   `;


### PR DESCRIPTION
Related: #107260

## What Problem This Solves

Fixes an issue where Discord users watching an agent run would see a generated one-word activity label, a blank line, and the agent's own status sentence as separate progress content.

## Why This Change Was Made

Discord's default progress draft now renders only the agent's preamble or narration sentence. Explicitly configured progress labels and tool rows retain their existing behavior, and the Control UI keeps the elapsed-time indicator while removing its visible generic “Working…” label.

## User Impact

Default Discord progress is one meaningful agent-authored line instead of a synthetic label plus spacer plus narration. Operators who explicitly configured labels or tool progress keep those settings.

## Evidence

- Blacksmith Testbox `tbx_01kxfz0py7ntq7exk8c4fcj00g`: Discord monitor tests 132/132, Telegram dispatch tests 209/209, UI tests 3764/3764.
- Blacksmith Testbox `tbx_01kxfz7ppg2zvtkrrpyhyec92x`: UI browser E2E 3/3. Actions run: https://github.com/openclaw/openclaw/actions/runs/29321780186
- Fresh autoreview: no accepted or actionable findings.
- `git diff --check origin/main...HEAD`

Live Discord posting was not used; exact renderer regressions cover the Discord output shape without sending to an external channel.
