### PR TITLE
fix(ui): restore user avatar wiring in quick settings [AI-assisted]

### DIFF
--- a/ui/src/app/settings.test.ts
+++ b/ui/src/app/settings.test.ts
@@ -1,0 +1,41 @@
+// Settings persistence tests cover local user identity read/write.
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { loadLocalUserIdentity, saveLocalUserIdentity } from "./settings.js";
+
+describe("local user identity persistence", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("saveLocalUserIdentity writes and reads back the avatar", () => {
+    const store = new Map<string, string>();
+    vi.stubGlobal("localStorage", {
+      getItem: (key: string) => store.get(key) ?? null,
+      setItem: (key: string, value: string) => void store.set(key, value),
+      removeItem: (key: string) => void store.delete(key),
+    });
+
+    expect(loadLocalUserIdentity().avatar).toBeNull();
+
+    saveLocalUserIdentity({ avatar: "data:image/png;base64,abc" });
+    expect(loadLocalUserIdentity().avatar).toBe("data:image/png;base64,abc");
+
+    saveLocalUserIdentity({ avatar: null });
+    expect(loadLocalUserIdentity().avatar).toBeNull();
+  });
+
+  it("saveLocalUserIdentity merges with existing identity fields", () => {
+    const store = new Map<string, string>();
+    vi.stubGlobal("localStorage", {
+      getItem: (key: string) => store.get(key) ?? null,
+      setItem: (key: string, value: string) => void store.set(key, value),
+      removeItem: (key: string) => void store.delete(key),
+    });
+
+    saveLocalUserIdentity({ name: "tester" });
+    saveLocalUserIdentity({ avatar: "😀" });
+    const identity = loadLocalUserIdentity();
+    expect(identity.name).toBe("tester");
+    expect(identity.avatar).toBe("😀");
+  });
+});

--- a/ui/src/app/settings.ts
+++ b/ui/src/app/settings.ts
@@ -450,6 +450,17 @@ export function loadLocalUserIdentity(): LocalUserIdentity {
   }
 }
 
+export function saveLocalUserIdentity(next: Partial<LocalUserIdentity>): LocalUserIdentity {
+  const merged = normalizeLocalUserIdentity({ ...loadLocalUserIdentity(), ...next });
+  const storage = getSafeLocalStorage();
+  try {
+    storage?.setItem(LOCAL_USER_IDENTITY_KEY, JSON.stringify(merged));
+  } catch {
+    // best-effort: browser storage may be unavailable (private mode, quota)
+  }
+  return merged;
+}
+
 function persistSettings(next: UiSettings, options: { selectGateway?: boolean } = {}) {
   persistSessionToken(next.gatewayUrl, next.token);
   const storage = getSafeLocalStorage();

--- a/ui/src/pages/config/config-page.ts
+++ b/ui/src/pages/config/config-page.ts
@@ -14,11 +14,13 @@ import {
 import { importCustomThemeFromUrl } from "../../app/custom-theme.ts";
 import { hasOperatorAdminAccess } from "../../app/operator-access.ts";
 import {
+  loadLocalUserIdentity,
   loadSettings,
   normalizeCatalogOpenTarget,
   normalizeTextScale,
   normalizeChatSendShortcut,
   patchSettings,
+  saveLocalUserIdentity,
   type UiSettings,
 } from "../../app/settings.ts";
 import { startThemeTransition } from "../../app/theme-transition.ts";
@@ -879,6 +881,11 @@ export class ConfigPage extends OpenClawLightDomElement {
           appearance: { activeSection: "__appearance__", activeSubsection: null },
         };
         this.openCustomThemeImport();
+      },
+      userAvatar: loadLocalUserIdentity().avatar ?? null,
+      onUserAvatarChange: (avatar) => {
+        saveLocalUserIdentity({ avatar });
+        this.requestUpdate();
       },
       connected: runtimeConfig.state.connected,
       gatewayUrl: this.context.gateway.connection.gatewayUrl,


### PR DESCRIPTION
> [AI-assisted] This PR was generated using Claude Code.

## What Problem This Solves

Fixes a regression where selecting, clearing, or changing the User avatar in Settings -> Simple silently does nothing. The avatar does not update and is not persisted to browser-local storage. This worked in 2026.6.11 but broke in 2026.7.1 after the Control UI refactor (#106865).

## Why This Change Was Made

`renderQuickConfig()` in `ui/src/pages/config/config-page.ts` calls `renderQuickSettings({...})` but stopped passing `userAvatar` and `onUserAvatarChange` to the avatar editor (the 2026.6.11 wiring had `userAvatar: e.userAvatar ?? null, onUserAvatarChange: t => e.applyLocalUserIdentity?.({avatar: t})`). Without these props, the avatar editor's change handler is `undefined`, so `quick.ts:317 if (!file || !onUserAvatarChange)` skips the write - a silent no-op.

The 2026.7.1 refactor also removed `applyLocalUserIdentity` (the write function). `loadLocalUserIdentity()` (read) still exists in `settings.ts`, but there was no corresponding write function - `LOCAL_USER_IDENTITY_KEY` had `getItem` but no `setItem` anywhere in the codebase.

The fix restores the wiring in two parts:
1. `settings.ts`: add `saveLocalUserIdentity(next: Partial<LocalUserIdentity>)` - the write counterpart to `loadLocalUserIdentity()` (merges + `setItem(LOCAL_USER_IDENTITY_KEY, ...)`). Same pattern as the 2026.6.11 `applyLocalUserIdentity`.
2. `config-page.ts renderQuickConfig()`: pass `userAvatar: loadLocalUserIdentity().avatar ?? null` + `onUserAvatarChange: (avatar) => { saveLocalUserIdentity({ avatar }); this.requestUpdate(); }` to `renderQuickSettings()`. Same wiring as 2026.6.11.

## User Impact

Selecting, clearing, or entering an emoji/text User avatar in Settings -> Simple now updates immediately and persists across reloads, as documented in `docs/web/control-ui.md`. Restores the 2026.6.11 behavior.

## Evidence

Real behavior captured by driving the real `saveLocalUserIdentity` + `loadLocalUserIdentity` functions against a mocked `localStorage`:

**Before fix (current `main`)**: No `saveLocalUserIdentity` function exists. `LOCAL_USER_IDENTITY_KEY` has `getItem` but no `setItem` anywhere. `renderQuickConfig()` does not pass `userAvatar` or `onUserAvatarChange` to `renderQuickSettings()` -> avatar editor's `onUserAvatarChange` is `undefined` -> `quick.ts:317 if (!file || !onUserAvatarChange)` skips -> silent no-op.

**After fix**: `saveLocalUserIdentity` writes + `loadLocalUserIdentity` reads back:

```
before_avatar: null
after_avatar: "data:image/png;base64,proof"
cleared_avatar: null
storage_has_key: true
```

Regression test in `ui/src/app/settings.test.ts` (`saveLocalUserIdentity writes and reads back the avatar` + `merges with existing identity fields`): mocks `localStorage`, calls `saveLocalUserIdentity({ avatar: "data:..." })`, then `loadLocalUserIdentity()` and asserts the avatar is persisted and read back. Also verifies merge semantics.

Local verification:

- `node scripts/run-vitest.mjs ui/src/app/settings.test.ts` - 2/2 pass.
- `oxlint` + `oxfmt --check` on changed files - pass.

Not tested: live Control UI browser interaction (the proof drives the real `saveLocalUserIdentity`/`loadLocalUserIdentity` against a mocked `localStorage`, exercising the exact read/write path the avatar editor uses; the existing `quick.test.ts` component tests cover the avatar editor UI behavior when `onUserAvatarChange` is supplied).
