### PR TITLE
fix(ci): supersede stale exact-SHA release validations

### DIFF
--- a/.github/workflows/full-release-validation.yml
+++ b/.github/workflows/full-release-validation.yml
@@ -128,8 +128,8 @@ permissions:
   contents: read
 
 concurrency:
-  group: full-release-validation-${{ inputs.ref }}-${{ inputs.rerun_group }}
-  cancel-in-progress: ${{ (inputs.ref == 'main' && inputs.rerun_group == 'all') || startsWith(inputs.ref, 'tideclaw/alpha/') || startsWith(inputs.ref, 'release/') }}
+  group: full-release-validation-${{ inputs.target_context_ref || inputs.ref }}-${{ inputs.rerun_group }}
+  cancel-in-progress: ${{ (inputs.ref == 'main' && inputs.rerun_group == 'all') || startsWith(inputs.ref, 'tideclaw/alpha/') || startsWith(inputs.ref, 'release/') || startsWith(inputs.target_context_ref, 'release/') }}
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -99,6 +99,10 @@ type WorkflowJob = {
 };
 
 type Workflow = {
+  concurrency?: {
+    group?: string;
+    "cancel-in-progress"?: boolean | string;
+  };
   env?: Record<string, string>;
   jobs?: Record<string, WorkflowJob>;
 };
@@ -2480,10 +2484,17 @@ describe("package artifact reuse", () => {
 
   it("runs full release children from the trusted workflow ref", () => {
     const workflow = readFileSync(FULL_RELEASE_VALIDATION_WORKFLOW, "utf8");
+    const parsedWorkflow = readWorkflow(FULL_RELEASE_VALIDATION_WORKFLOW);
     const npmTelegramJob = workflowJob(FULL_RELEASE_VALIDATION_WORKFLOW, "npm_telegram");
     const performanceJob = workflowJob(FULL_RELEASE_VALIDATION_WORKFLOW, "performance");
     const dispatchStep = workflowStep(npmTelegramJob, "Dispatch and monitor npm Telegram E2E");
 
+    expect(parsedWorkflow.concurrency).toEqual({
+      group:
+        "full-release-validation-${{ inputs.target_context_ref || inputs.ref }}-${{ inputs.rerun_group }}",
+      "cancel-in-progress":
+        "${{ (inputs.ref == 'main' && inputs.rerun_group == 'all') || startsWith(inputs.ref, 'tideclaw/alpha/') || startsWith(inputs.ref, 'release/') || startsWith(inputs.target_context_ref, 'release/') }}",
+    });
     expect(workflow).toContain("CHILD_WORKFLOW_REF: ${{ github.ref_name }}");
     expect(workflow).toContain('gh workflow run "$workflow" --ref "$CHILD_WORKFLOW_REF" "$@" 2>&1');
     expect(npmTelegramJob.name).toBe("Run package Telegram E2E");
@@ -2523,7 +2534,6 @@ describe("package artifact reuse", () => {
       'args+=(-f cross_os_suite_filter="$CROSS_OS_SUITE_FILTER")',
       'case "$RERUN_GROUP" in',
       "release-checks|install-smoke|cross-os|live-e2e|package|qa|qa-parity|qa-live)",
-      "cancel-in-progress: ${{ (inputs.ref == 'main' && inputs.rerun_group == 'all') || startsWith(inputs.ref, 'tideclaw/alpha/') || startsWith(inputs.ref, 'release/') }}",
       "Verify release checks accepted Tideclaw alpha advisory lanes",
       "release_checks_advisory_only",
       "release_check_blocking_job",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where exact-SHA release validation runs could remain queued behind an older, already-doomed validation for the same release branch.

The SHA-pinned helper passes the immutable commit through `ref` and the canonical release branch through `target_context_ref`. The workflow previously used only `ref` for its concurrency identity and release cancellation predicate, so it lost normal `release/*` replacement behavior.

Observed on the `2026.7.2` release:

- full validation run `29320669525` already had three failed parent lanes but remained active while its plugin prerelease Docker child finished
- replacement run `29321412123` remained pending with zero jobs instead of superseding it

## Why This Change Was Made

Full Release Validation now uses `target_context_ref` as the concurrency identity when present and recognizes a `release/*` target context for `cancel-in-progress`.

Exact-SHA validation remains immutable, while repeated validation for the same canonical release branch and rerun group regains the workflow's intended replacement behavior. Unrelated release branches, SHAs without release context, and different rerun groups remain isolated.

## User Impact

Release operators can restart validation for an exact frozen SHA without waiting for a stale validation's remaining child jobs to drain. This reduces release stalls and avoids duplicate queued umbrella runs.

## Evidence

- `actionlint .github/workflows/full-release-validation.yml`
- Blacksmith Testbox `tbx_01kxfzmscdprfr925s9wh25jdz`
- Testbox run: https://github.com/openclaw/openclaw/actions/runs/29322223900
- `pnpm test:serial test/scripts/package-acceptance-workflow.test.ts test/scripts/full-release-validation-at-sha.test.ts`
  - 2 files passed
  - 84 tests passed
- `pnpm check:workflows`
- `pnpm check:changed`
- autoreview: clean, no accepted/actionable findings