### PR TITLE
fix(wizard): reject invalid plugin number inputs

### DIFF
--- a/src/wizard/setup.plugin-config.test.ts
+++ b/src/wizard/setup.plugin-config.test.ts
@@ -394,19 +394,35 @@ describe("setupPluginConfig", () => {
     expect(({} as Record<string, unknown>)[pollutionProbe]).toBeUndefined();
   });
 
-  it("coerces integer schema fields from text input", async () => {
+  it("coerces only JSON-compatible numeric inputs", async () => {
     loadPluginManifestRegistry.mockReturnValue({
       plugins: [
         makeManifestPlugin(
-          "retry-plugin",
+          "numeric-plugin",
           {
+            decimal: { label: "Decimal" },
+            scientific: { label: "Scientific" },
             retries: { label: "Retries" },
+            hexadecimal: { label: "Hexadecimal" },
+            fractionalRetries: { label: "Fractional retries" },
           },
           {
             type: "object",
             additionalProperties: false,
             properties: {
+              decimal: {
+                type: "number",
+              },
+              scientific: {
+                type: "number",
+              },
               retries: {
+                type: "integer",
+              },
+              hexadecimal: {
+                type: "number",
+              },
+              fractionalRetries: {
                 type: "integer",
               },
             },
@@ -415,11 +431,13 @@ describe("setupPluginConfig", () => {
       ],
     });
 
+    const answers = ["1.5", "1e2", "3", "0x10", "1.5"];
+
     const result = await setupPluginConfig({
       config: {
         plugins: {
           entries: {
-            "retry-plugin": {
+            "numeric-plugin": {
               enabled: true,
             },
           },
@@ -431,15 +449,17 @@ describe("setupPluginConfig", () => {
         note: vi.fn(async () => {}),
         select: vi.fn(async () => "") as unknown as WizardPrompter["select"],
         multiselect: vi.fn(async () => [
-          "retry-plugin",
+          "numeric-plugin",
         ]) as unknown as WizardPrompter["multiselect"],
-        text: vi.fn(async () => "3") as unknown as WizardPrompter["text"],
+        text: vi.fn(async () => answers.shift() ?? "") as unknown as WizardPrompter["text"],
         confirm: vi.fn(async () => true),
         progress: vi.fn(() => ({ update: vi.fn(), stop: vi.fn() })),
       },
     });
 
-    expect(result.plugins?.entries?.["retry-plugin"]?.config).toEqual({
+    expect(result.plugins?.entries?.["numeric-plugin"]?.config).toEqual({
+      decimal: 1.5,
+      scientific: 100,
       retries: 3,
     });
   });

--- a/src/wizard/setup.plugin-config.ts
+++ b/src/wizard/setup.plugin-config.ts
@@ -79,6 +79,15 @@ function formatCurrentValue(value: unknown): string {
   return JSON.stringify(value);
 }
 
+function parseJsonNumberInput(value: string): number | undefined {
+  try {
+    const parsed: unknown = JSON.parse(value);
+    return typeof parsed === "number" && Number.isFinite(parsed) ? parsed : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 /**
  * Discover plugins that have non-advanced uiHints fields.
  * Returns only plugins that have at least one promptable field.
@@ -274,8 +283,8 @@ async function promptPluginFields(params: {
           setPathCreateStrict(updatedConfig, pathSegments, undefined);
           changed = true;
         } else {
-          const parsed = Number(trimmed);
-          if (Number.isFinite(parsed)) {
+          const parsed = parseJsonNumberInput(trimmed);
+          if (parsed !== undefined && (schemaProp.type === "number" || Number.isInteger(parsed))) {
             setPathCreateStrict(updatedConfig, pathSegments, parsed);
             changed = true;
           }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users configuring plugin numeric fields could enter non-JSON tokens such as `0x10` and have the wizard silently save a different value (`16`). Integer fields also accepted fractional values even though their plugin schema declared them as integers.

## Why This Change Was Made

The wizard now parses numeric prompt answers with JSON's number grammar before the original spelling is lost, and only writes integer fields when the parsed value is an integer. The compatibility risk is limited to previously accepted non-JSON or fractional-integer answers; the live proof below covers both rejection and retained decimal/scientific inputs.

## User Impact

Plugin configuration no longer silently converts invalid numeric spellings into valid-but-unintended settings. Valid JSON decimal, scientific-notation, and integer answers continue to work.

## Evidence

On the local Linux checkout with Node 24, I drove the real exported `configurePluginConfig` function through the real bundled Logbook manifest and its visible `captureIntervalSeconds` number field.

Before the fix at `88e5dc121934b3573470242ff2aecff67a40c0bd`, the production path silently converted the hexadecimal answer:

```text
$ node --import tsx --input-type=module -e '<harness importing configurePluginConfig; select Logbook; answer 0x10 for Capture Interval>'
{"captureIntervalSeconds":16,"captureEnabled":false}
```

After the fix, the same production path leaves the invalid answer unwritten while retaining valid decimal and scientific-notation controls:

```text
$ node --import tsx --input-type=module -e '<same configurePluginConfig + real Logbook manifest harness; run 0x10, 1.5, and 1e2>'
{"input":"0x10","config":{"captureEnabled":false}}
{"input":"1.5","config":{"captureEnabled":false,"captureIntervalSeconds":1.5}}
{"input":"1e2","config":{"captureEnabled":false,"captureIntervalSeconds":100}}
```

Focused regression and changed-surface checks:

```text
$ node scripts/run-vitest.mjs src/wizard/setup.plugin-config.test.ts
Test Files  1 passed (1)
Tests  14 passed (14)
[test] passed 1 Vitest shard

$ OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 pnpm check:changed --base upstream/main
[check:changed] lanes=core, coreTests
exited 0 after conflict-marker, LOC, attribution, boundary, dependency, format, SDK baseline, and core type checks
```

Full repository validation is left to the fork PR's GitHub Actions because this contributor checkout is not suitable for the full local suite.

AI-assisted: Codex helped implement and review this change; the production-path proof and checks above were run in the contributor checkout.
