### PR TITLE
fix(terminal): keep slow clients connected under heavy output

### DIFF
--- a/src/gateway/gateway-misc.test.ts
+++ b/src/gateway/gateway-misc.test.ts
@@ -382,6 +382,18 @@ function broadcastChatClassEvents(
 }
 
 describe("gateway broadcaster", () => {
+  it("exposes current buffered bytes for a targeted connection", () => {
+    const socket = makeRecordingSocket();
+    socket.bufferedAmount = 1234;
+    const client = makeOperatorWsClient("c-admin", socket, ["operator.admin"]);
+    const clients = new Set<GatewayWsClient>([client]);
+    const { getBufferedAmount } = createGatewayBroadcaster({ clients });
+
+    expect(getBufferedAmount("c-admin")).toBe(1234);
+    clients.delete(client);
+    expect(getBufferedAmount("c-admin")).toBeUndefined();
+  });
+
   it("keeps workers outside all generic and targeted gateway broadcasts", () => {
     const workerSocket = makeRecordingSocket();
     const worker = makeGatewayWsClient("c-worker", workerSocket, {

--- a/src/gateway/server-broadcast-types.ts
+++ b/src/gateway/server-broadcast-types.ts
@@ -25,3 +25,6 @@ export type GatewayBroadcastToConnIdsFn = (
   connIds: ReadonlySet<string>,
   opts?: GatewayBroadcastOpts,
 ) => void;
+
+/** Current queued outbound bytes for one live gateway connection. */
+export type GatewayBufferedAmountFn = (connId: string) => number | undefined;

--- a/src/gateway/server-broadcast.ts
+++ b/src/gateway/server-broadcast.ts
@@ -12,6 +12,7 @@ import type {
   GatewayBroadcastFn,
   GatewayBroadcastOpts,
   GatewayBroadcastToConnIdsFn,
+  GatewayBufferedAmountFn,
 } from "./server-broadcast-types.js";
 import { MAX_BUFFERED_BYTES } from "./server-constants.js";
 import type { GatewayWsClient } from "./server/ws-types.js";
@@ -216,5 +217,14 @@ export function createGatewayBroadcaster(params: { clients: Set<GatewayWsClient>
     broadcastInternal(event, payload, opts, connIds);
   };
 
-  return { broadcast, broadcastToConnIds };
+  const getBufferedAmount: GatewayBufferedAmountFn = (connId) => {
+    for (const client of params.clients) {
+      if (client.connId === connId) {
+        return client.socket.bufferedAmount;
+      }
+    }
+    return undefined;
+  };
+
+  return { broadcast, broadcastToConnIds, getBufferedAmount };
 }

--- a/src/gateway/server-runtime-state.ts
+++ b/src/gateway/server-runtime-state.ts
@@ -29,7 +29,11 @@ import type { HooksConfigResolved } from "./hooks.js";
 import type { AuthorizedGatewayHttpRequest } from "./http-auth-utils.js";
 import { createMcpAppSandboxHttpServer } from "./mcp-app-sandbox-http.js";
 import { isLoopbackHost, resolveGatewayListenHosts } from "./net.js";
-import type { GatewayBroadcastFn, GatewayBroadcastToConnIdsFn } from "./server-broadcast-types.js";
+import type {
+  GatewayBroadcastFn,
+  GatewayBroadcastToConnIdsFn,
+  GatewayBufferedAmountFn,
+} from "./server-broadcast-types.js";
 import { createGatewayBroadcaster } from "./server-broadcast.js";
 import {
   type ChatRunEntry,
@@ -127,6 +131,7 @@ export async function createGatewayRuntimeState(params: {
   clients: Set<GatewayWsClient>;
   broadcast: GatewayBroadcastFn;
   broadcastToConnIds: GatewayBroadcastToConnIdsFn;
+  getBufferedAmount: GatewayBufferedAmountFn;
   agentRunSeq: Map<string, number>;
   dedupe: Map<string, DedupeEntry>;
   chatRunState: ReturnType<typeof createChatRunState>;
@@ -156,7 +161,9 @@ export async function createGatewayRuntimeState(params: {
     const resolvePluginRouteRegistry = () =>
       params.getPluginRouteRegistry?.() ?? params.pluginRegistry;
     const clients = new Set<GatewayWsClient>();
-    const { broadcast, broadcastToConnIds } = createGatewayBroadcaster({ clients });
+    const { broadcast, broadcastToConnIds, getBufferedAmount } = createGatewayBroadcaster({
+      clients,
+    });
 
     let loadedHooksRequestHandler: HooksRequestHandler | null = null;
     const handleHooksRequest: HooksRequestHandler = async (req, res) => {
@@ -461,6 +468,7 @@ export async function createGatewayRuntimeState(params: {
       clients,
       broadcast,
       broadcastToConnIds,
+      getBufferedAmount,
       agentRunSeq,
       dedupe,
       chatRunState,

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -1132,6 +1132,7 @@ export async function startGatewayServer(
     clients,
     broadcast,
     broadcastToConnIds,
+    getBufferedAmount,
     agentRunSeq,
     dedupe,
     chatRunState,
@@ -1245,12 +1246,9 @@ export async function startGatewayServer(
   watchNodeRequestHandler.current = watchNodeHttpRuntime.handleRequest;
   const { TerminalSessionManager, DEFAULT_TERMINAL_DETACH_SECONDS } =
     await import("./terminal/session-manager.js");
-  // One PTY store per gateway. Emits each session's bytes only to the owning
-  // connection so terminals stay private to the operator that opened them.
-  // Startup config is enough here: gateway.terminal.* changes restart the
-  // gateway (config-reload-plan), so the grace period never drifts at runtime.
+  const { createTerminalSessionTransport } = await import("./terminal/gateway-transport.js");
   const terminalSessions = new TerminalSessionManager({
-    emit: (connId, event, payload) => broadcastToConnIds(event, payload, new Set([connId])),
+    ...createTerminalSessionTransport(broadcastToConnIds, getBufferedAmount),
     detachGraceMs:
       (cfgAtStart.gateway?.terminal?.detachedSessionTimeoutSeconds ??
         DEFAULT_TERMINAL_DETACH_SECONDS) * 1000,

--- a/src/gateway/terminal/backend.ts
+++ b/src/gateway/terminal/backend.ts
@@ -9,6 +9,8 @@ export type TerminalBackendExit = {
 export interface TerminalBackend {
   write(data: string): void;
   resize(cols: number, rows: number): void;
+  pause(): void;
+  resume(): void;
   kill(): void;
   onData(callback: (data: string) => void): void;
   onExit(callback: (exit: TerminalBackendExit) => void): void;
@@ -24,6 +26,8 @@ export async function createLocalTerminalBackend(
   return {
     write: (data) => pty.write(data),
     resize: (cols, rows) => pty.resize(cols, rows),
+    pause: () => pty.pause(),
+    resume: () => pty.resume(),
     kill: () => pty.kill(),
     onData: (callback) => pty.onData(callback),
     onExit: (callback) => pty.onExit(callback),

--- a/src/gateway/terminal/gateway-transport.ts
+++ b/src/gateway/terminal/gateway-transport.ts
@@ -1,0 +1,22 @@
+import type {
+  GatewayBroadcastToConnIdsFn,
+  GatewayBufferedAmountFn,
+} from "../server-broadcast-types.js";
+
+export const TERMINAL_EVENT_DATA = "terminal.data" as const;
+export const TERMINAL_EVENT_EXIT = "terminal.exit" as const;
+
+/** Adapts terminal ownership to targeted gateway delivery and pressure state. */
+export function createTerminalSessionTransport(
+  broadcastToConnIds: GatewayBroadcastToConnIdsFn,
+  getBufferedAmount: GatewayBufferedAmountFn,
+) {
+  return {
+    emit: (connId: string, event: string, payload: unknown) =>
+      broadcastToConnIds(event, payload, new Set([connId]), {
+        // PTY flow control is primary; dropping is the last-resort socket cap guard.
+        dropIfSlow: event === TERMINAL_EVENT_DATA,
+      }),
+    getBufferedAmount,
+  };
+}

--- a/src/gateway/terminal/node-relay.ts
+++ b/src/gateway/terminal/node-relay.ts
@@ -134,6 +134,10 @@ export async function createNodeRelayBackend(params: {
     resize(cols, rows) {
       send({ kind: "resize", cols, rows });
     },
+    // Node host pauses its PTY around each awaited progress write; this relay
+    // has no local PTY or transport-level pause operation to control.
+    pause() {},
+    resume() {},
     kill() {
       abort.abort();
     },

--- a/src/gateway/terminal/output-coalescer.ts
+++ b/src/gateway/terminal/output-coalescer.ts
@@ -1,0 +1,85 @@
+import { truncateUtf8Prefix } from "../../utils/utf8-truncate.js";
+
+export const TERMINAL_OUTPUT_COALESCE_WINDOW_MS = 4;
+export const TERMINAL_OUTPUT_FRAME_BYTES = 64 * 1024;
+
+/** Batches adjacent PTY chunks while keeping each emitted frame UTF-8 bounded. */
+export class TerminalOutputCoalescer {
+  private readonly emit: (data: string) => void;
+  private chunks: string[] = [];
+  private bufferedBytes = 0;
+  private timer: ReturnType<typeof setTimeout> | null = null;
+
+  constructor(emit: (data: string) => void) {
+    this.emit = emit;
+  }
+
+  get isEmpty(): boolean {
+    return this.chunks.length === 0;
+  }
+
+  push(data: string, opts?: { flushNow?: boolean }): void {
+    let remaining = data;
+    while (remaining) {
+      const available = TERMINAL_OUTPUT_FRAME_BYTES - this.bufferedBytes;
+      const part = truncateUtf8Prefix(remaining, available);
+      if (!part) {
+        this.flush();
+        continue;
+      }
+      this.chunks.push(part);
+      this.bufferedBytes += Buffer.byteLength(part, "utf8");
+      remaining = remaining.slice(part.length);
+      if (this.bufferedBytes >= TERMINAL_OUTPUT_FRAME_BYTES) {
+        this.flush();
+      }
+    }
+    if (opts?.flushNow) {
+      this.flush();
+    } else {
+      this.schedule();
+    }
+  }
+
+  flush(): void {
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+    if (this.chunks.length === 0) {
+      return;
+    }
+    const data = this.chunks.join("");
+    this.chunks = [];
+    this.bufferedBytes = 0;
+    this.emit(data);
+  }
+
+  clear(): void {
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+    this.chunks = [];
+    this.bufferedBytes = 0;
+  }
+
+  dispose(opts?: { flush?: boolean }): void {
+    if (opts?.flush) {
+      this.flush();
+    } else {
+      this.clear();
+    }
+  }
+
+  private schedule(): void {
+    if (this.timer || this.chunks.length === 0) {
+      return;
+    }
+    this.timer = setTimeout(() => {
+      this.timer = null;
+      this.flush();
+    }, TERMINAL_OUTPUT_COALESCE_WINDOW_MS);
+    this.timer.unref?.();
+  }
+}

--- a/src/gateway/terminal/output-coalescer.ts
+++ b/src/gateway/terminal/output-coalescer.ts
@@ -1,7 +1,7 @@
 import { truncateUtf8Prefix } from "../../utils/utf8-truncate.js";
 
-export const TERMINAL_OUTPUT_COALESCE_WINDOW_MS = 4;
-export const TERMINAL_OUTPUT_FRAME_BYTES = 64 * 1024;
+const TERMINAL_OUTPUT_COALESCE_WINDOW_MS = 4;
+const TERMINAL_OUTPUT_FRAME_BYTES = 64 * 1024;
 
 /** Batches adjacent PTY chunks while keeping each emitted frame UTF-8 bounded. */
 export class TerminalOutputCoalescer {

--- a/src/gateway/terminal/output-flow-control.ts
+++ b/src/gateway/terminal/output-flow-control.ts
@@ -1,0 +1,149 @@
+import type { TerminalBackend } from "./backend.js";
+import { TerminalOutputCoalescer } from "./output-coalescer.js";
+
+export const TERMINAL_OUTPUT_HIGH_WATER_BYTES = 4 * 1024 * 1024;
+export const TERMINAL_OUTPUT_LOW_WATER_BYTES = 512 * 1024;
+export const TERMINAL_OUTPUT_REASSERT_MS = 5_000;
+const INTERACTIVE_OUTPUT_BYTES = 1024;
+const INTERACTIVE_OUTPUT_WINDOW_MS = 100;
+
+type TerminalOutputControllerOptions = {
+  backend: Pick<TerminalBackend, "pause" | "resume">;
+  getConnId: () => string | null;
+  getBufferedAmount: (connId: string) => number | undefined;
+  record: (chunk: string) => void;
+  emit: (connId: string, data: string) => void;
+  now?: () => number;
+};
+
+/** Couples PTY output batching to the owning WebSocket's send pressure. */
+export class TerminalOutputController {
+  private readonly backend: Pick<TerminalBackend, "pause" | "resume">;
+  private readonly getConnId: () => string | null;
+  private readonly getBufferedAmount: (connId: string) => number | undefined;
+  private readonly record: (chunk: string) => void;
+  private readonly emit: (connId: string, data: string) => void;
+  private readonly now: () => number;
+  private readonly coalescer: TerminalOutputCoalescer;
+  private lastInputAtMs = Number.NEGATIVE_INFINITY;
+  private desiredPaused = false;
+  private reassertTimer: ReturnType<typeof setInterval> | null = null;
+
+  constructor(options: TerminalOutputControllerOptions) {
+    this.backend = options.backend;
+    this.getConnId = options.getConnId;
+    this.getBufferedAmount = options.getBufferedAmount;
+    this.record = options.record;
+    this.emit = options.emit;
+    this.now = options.now ?? Date.now;
+    this.coalescer = new TerminalOutputCoalescer((data) => this.emitBuffered(data));
+  }
+
+  push(chunk: string): void {
+    this.record(chunk);
+    const connId = this.getConnId();
+    if (connId === null) {
+      return;
+    }
+    if (this.coalescer.isEmpty) {
+      this.reconcile(connId);
+    }
+    const interactive =
+      Buffer.byteLength(chunk, "utf8") <= INTERACTIVE_OUTPUT_BYTES &&
+      this.now() - this.lastInputAtMs <= INTERACTIVE_OUTPUT_WINDOW_MS;
+    this.coalescer.push(chunk, { flushNow: interactive });
+  }
+
+  noteInput(): void {
+    this.lastInputAtMs = this.now();
+  }
+
+  resetOwnership(): void {
+    this.coalescer.clear();
+    this.lastInputAtMs = Number.NEGATIVE_INFINITY;
+    if (this.reassertTimer) {
+      this.desiredPaused = false;
+      this.tryResume();
+    }
+  }
+
+  dispose(opts?: { flush?: boolean }): void {
+    this.coalescer.dispose(opts);
+    if (this.reassertTimer) {
+      clearInterval(this.reassertTimer);
+      this.reassertTimer = null;
+      this.desiredPaused = false;
+      this.tryResume();
+    }
+  }
+
+  private emitBuffered(data: string): void {
+    const connId = this.getConnId();
+    if (connId === null) {
+      return;
+    }
+    this.emit(connId, data);
+    this.reconcile(connId);
+  }
+
+  private reconcile(connId: string): void {
+    const bufferedAmount = this.getBufferedAmount(connId);
+    if (bufferedAmount === undefined) {
+      return;
+    }
+    if (bufferedAmount >= TERMINAL_OUTPUT_HIGH_WATER_BYTES) {
+      this.ensureReassertTimer();
+      if (!this.desiredPaused) {
+        this.desiredPaused = true;
+        this.tryPause();
+      }
+      return;
+    }
+    if (bufferedAmount <= TERMINAL_OUTPUT_LOW_WATER_BYTES && this.desiredPaused) {
+      this.desiredPaused = false;
+      this.tryResume();
+    }
+  }
+
+  private ensureReassertTimer(): void {
+    if (this.reassertTimer) {
+      return;
+    }
+    this.reassertTimer = setInterval(() => {
+      const connId = this.getConnId();
+      const bufferedAmount = connId === null ? undefined : this.getBufferedAmount(connId);
+      if (bufferedAmount !== undefined) {
+        if (bufferedAmount >= TERMINAL_OUTPUT_HIGH_WATER_BYTES) {
+          this.desiredPaused = true;
+        } else if (bufferedAmount <= TERMINAL_OUTPUT_LOW_WATER_BYTES) {
+          this.desiredPaused = false;
+        }
+      } else {
+        this.desiredPaused = false;
+      }
+      // Reassert both states. A missed native resume must not wedge the shell.
+      if (this.desiredPaused) {
+        this.tryPause();
+      } else {
+        this.tryResume();
+      }
+    }, TERMINAL_OUTPUT_REASSERT_MS);
+    this.reassertTimer.unref?.();
+  }
+
+  private tryPause(): void {
+    try {
+      this.backend.pause();
+    } catch {
+      // The failsafe timer retries while pressure remains high.
+    }
+  }
+
+  private tryResume(): void {
+    try {
+      this.backend.resume();
+    } catch {
+      // The failsafe timer retries after a prior pause.
+    }
+  }
+}

--- a/src/gateway/terminal/output-flow-control.ts
+++ b/src/gateway/terminal/output-flow-control.ts
@@ -1,9 +1,9 @@
 import type { TerminalBackend } from "./backend.js";
 import { TerminalOutputCoalescer } from "./output-coalescer.js";
 
-export const TERMINAL_OUTPUT_HIGH_WATER_BYTES = 4 * 1024 * 1024;
-export const TERMINAL_OUTPUT_LOW_WATER_BYTES = 512 * 1024;
-export const TERMINAL_OUTPUT_REASSERT_MS = 5_000;
+const TERMINAL_OUTPUT_HIGH_WATER_BYTES = 4 * 1024 * 1024;
+const TERMINAL_OUTPUT_LOW_WATER_BYTES = 512 * 1024;
+const TERMINAL_OUTPUT_REASSERT_MS = 5_000;
 const INTERACTIVE_OUTPUT_BYTES = 1024;
 const INTERACTIVE_OUTPUT_WINDOW_MS = 100;
 

--- a/src/gateway/terminal/session-limits.ts
+++ b/src/gateway/terminal/session-limits.ts
@@ -1,0 +1,14 @@
+/** Bounds concurrent shells so a client cannot exhaust host processes. */
+export const DEFAULT_MAX_SESSIONS = 24;
+/**
+ * Rolling output retained per session for reattach replay and terminal.text,
+ * in UTF-16 code units. The session cap keeps worst-case memory bounded.
+ */
+export const DEFAULT_SCROLLBACK_CHARS = 256 * 1024;
+/**
+ * Detached-session cap; the oldest parked shell is killed to keep repeated
+ * disconnects from parking the full session cap of headless shells.
+ */
+export const DEFAULT_MAX_DETACHED_SESSIONS = 8;
+/** Default grace period before a detached session is killed (seconds). */
+export const DEFAULT_TERMINAL_DETACH_SECONDS = 300;

--- a/src/gateway/terminal/session-manager.test.ts
+++ b/src/gateway/terminal/session-manager.test.ts
@@ -2,11 +2,6 @@ import { expectDefined } from "@openclaw/normalization-core";
 import { describe, expect, it, vi } from "vitest";
 import type { TerminalPtyHandle } from "../../process/terminal-pty.js";
 import type { TerminalBackend } from "./backend.js";
-import {
-  TERMINAL_OUTPUT_HIGH_WATER_BYTES,
-  TERMINAL_OUTPUT_LOW_WATER_BYTES,
-  TERMINAL_OUTPUT_REASSERT_MS,
-} from "./output-flow-control.js";
 import { TerminalSessionManager } from "./session-manager.js";
 
 type TerminalOpenRequest = Parameters<TerminalSessionManager["open"]>[0];
@@ -233,14 +228,13 @@ describe("TerminalSessionManager", () => {
 
       const frames = emit.mock.calls.filter(([, event]) => event === TERMINAL_EVENT_DATA);
       expect(frames.length).toBeLessThan(10);
-      expect(frames.map(([, , payload]) => (payload as { seq: number }).seq)).toEqual([0, 1]);
+      expect(frames.map((call) => (call[2] as { seq: number }).seq)).toEqual([0, 1]);
       expect(
         frames.every(
-          ([, , payload]) =>
-            Buffer.byteLength((payload as { data: string }).data, "utf8") <= 64 * 1024,
+          (call) => Buffer.byteLength((call[2] as { data: string }).data, "utf8") <= 64 * 1024,
         ),
       ).toBe(true);
-      expect(frames.map(([, , payload]) => (payload as { data: string }).data).join("")).toBe(
+      expect(frames.map((call) => (call[2] as { data: string }).data).join("")).toBe(
         chunk.repeat(10_000),
       );
     } finally {
@@ -270,7 +264,7 @@ describe("TerminalSessionManager", () => {
   it("pauses local PTY reads above the socket watermark and reasserts resume below it", async () => {
     vi.useFakeTimers();
     try {
-      let bufferedAmount = TERMINAL_OUTPUT_HIGH_WATER_BYTES + 1;
+      let bufferedAmount = Number.MAX_SAFE_INTEGER;
       const fake = makeFakePty();
       const manager = new TerminalSessionManager({
         emit: vi.fn(),
@@ -289,8 +283,8 @@ describe("TerminalSessionManager", () => {
       expect(fake.deliveredChunks).toBe(1);
       expect(manager.snapshot(outcome.sessionId)).toBe("chunk");
 
-      bufferedAmount = TERMINAL_OUTPUT_LOW_WATER_BYTES - 1;
-      await vi.advanceTimersByTimeAsync(TERMINAL_OUTPUT_REASSERT_MS);
+      bufferedAmount = 0;
+      await vi.advanceTimersByTimeAsync(5_000);
       expect(fake.resumeCalls).toBeGreaterThanOrEqual(1);
       fake.emitData("resumed");
       expect(fake.deliveredChunks).toBe(2);

--- a/src/gateway/terminal/session-manager.test.ts
+++ b/src/gateway/terminal/session-manager.test.ts
@@ -2,6 +2,11 @@ import { expectDefined } from "@openclaw/normalization-core";
 import { describe, expect, it, vi } from "vitest";
 import type { TerminalPtyHandle } from "../../process/terminal-pty.js";
 import type { TerminalBackend } from "./backend.js";
+import {
+  TERMINAL_OUTPUT_HIGH_WATER_BYTES,
+  TERMINAL_OUTPUT_LOW_WATER_BYTES,
+  TERMINAL_OUTPUT_REASSERT_MS,
+} from "./output-flow-control.js";
 import { TerminalSessionManager } from "./session-manager.js";
 
 type TerminalOpenRequest = Parameters<TerminalSessionManager["open"]>[0];
@@ -16,6 +21,10 @@ function makeFakePty() {
     writes: string[];
     resizes: Array<[number, number]>;
     killed: boolean;
+    paused: boolean;
+    pauseCalls: number;
+    resumeCalls: number;
+    deliveredChunks: number;
     emitData: (chunk: string) => void;
     emitExit: (code: number, signal?: number) => void;
   } = {
@@ -23,10 +32,20 @@ function makeFakePty() {
     writes: [],
     resizes: [],
     killed: false,
+    paused: false,
+    pauseCalls: 0,
+    resumeCalls: 0,
+    deliveredChunks: 0,
     write: (data) => handle.writes.push(data),
     resize: (cols, rows) => handle.resizes.push([cols, rows]),
-    pause: () => {},
-    resume: () => {},
+    pause: () => {
+      handle.paused = true;
+      handle.pauseCalls += 1;
+    },
+    resume: () => {
+      handle.paused = false;
+      handle.resumeCalls += 1;
+    },
     onData: (listener) => {
       dataListener = listener;
     },
@@ -36,7 +55,12 @@ function makeFakePty() {
     kill: () => {
       handle.killed = true;
     },
-    emitData: (chunk) => dataListener?.(chunk),
+    emitData: (chunk) => {
+      if (!handle.paused) {
+        handle.deliveredChunks += 1;
+        dataListener?.(chunk);
+      }
+    },
     emitExit: (code, signal) => exitListener?.({ exitCode: code, signal }),
   };
   return handle;
@@ -68,6 +92,8 @@ describe("TerminalSessionManager", () => {
     const backend: TerminalBackend = {
       write,
       resize,
+      pause: vi.fn(),
+      resume: vi.fn(),
       kill,
       onData: (callback) => {
         onData = callback;
@@ -84,6 +110,7 @@ describe("TerminalSessionManager", () => {
     }
 
     onData?.("relay output");
+    await vi.waitFor(() => expect(emit).toHaveBeenCalledOnce());
     expect(emit).toHaveBeenCalledWith("conn-1", TERMINAL_EVENT_DATA, {
       sessionId: opened.sessionId,
       seq: 0,
@@ -108,6 +135,8 @@ describe("TerminalSessionManager", () => {
       resize: () => {
         throw new Error("dead PTY");
       },
+      pause: vi.fn(),
+      resume: vi.fn(),
       kill,
       onData: vi.fn(),
       onExit: vi.fn(),
@@ -137,6 +166,8 @@ describe("TerminalSessionManager", () => {
     const backend: TerminalBackend = {
       write: vi.fn(),
       resize: vi.fn(),
+      pause: vi.fn(),
+      resume: vi.fn(),
       kill: vi.fn(),
       onData: vi.fn(),
       onExit: (callback) => {
@@ -175,16 +206,97 @@ describe("TerminalSessionManager", () => {
 
     fake.emitData("hello");
     fake.emitData("world");
-    expect(emit).toHaveBeenNthCalledWith(1, "conn-1", TERMINAL_EVENT_DATA, {
+    await vi.waitFor(() => expect(emit).toHaveBeenCalledOnce());
+    expect(emit).toHaveBeenCalledWith("conn-1", TERMINAL_EVENT_DATA, {
       sessionId: outcome.sessionId,
       seq: 0,
-      data: "hello",
+      data: "helloworld",
     });
-    expect(emit).toHaveBeenNthCalledWith(2, "conn-1", TERMINAL_EVENT_DATA, {
+  });
+
+  it("coalesces thousands of PTY chunks into a bounded number of data frames", async () => {
+    vi.useFakeTimers();
+    try {
+      const emit = vi.fn();
+      const fake = makeFakePty();
+      const manager = new TerminalSessionManager({ emit, spawn: async () => fake });
+      const outcome = await manager.open(baseRequest());
+      if (!outcome.ok) {
+        throw new Error("expected open");
+      }
+
+      const chunk = "12345678";
+      for (let index = 0; index < 10_000; index += 1) {
+        fake.emitData(chunk);
+      }
+      await vi.advanceTimersByTimeAsync(4);
+
+      const frames = emit.mock.calls.filter(([, event]) => event === TERMINAL_EVENT_DATA);
+      expect(frames.length).toBeLessThan(10);
+      expect(frames.map(([, , payload]) => (payload as { seq: number }).seq)).toEqual([0, 1]);
+      expect(
+        frames.every(
+          ([, , payload]) =>
+            Buffer.byteLength((payload as { data: string }).data, "utf8") <= 64 * 1024,
+        ),
+      ).toBe(true);
+      expect(frames.map(([, , payload]) => (payload as { data: string }).data).join("")).toBe(
+        chunk.repeat(10_000),
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("flushes small output immediately after terminal input", async () => {
+    const emit = vi.fn();
+    const fake = makeFakePty();
+    const manager = new TerminalSessionManager({ emit, spawn: async () => fake });
+    const outcome = await manager.open(baseRequest());
+    if (!outcome.ok) {
+      throw new Error("expected open");
+    }
+
+    expect(manager.write("conn-1", outcome.sessionId, "x")).toBe(true);
+    fake.emitData("x");
+
+    expect(emit).toHaveBeenCalledWith("conn-1", TERMINAL_EVENT_DATA, {
       sessionId: outcome.sessionId,
-      seq: 1,
-      data: "world",
+      seq: 0,
+      data: "x",
     });
+  });
+
+  it("pauses local PTY reads above the socket watermark and reasserts resume below it", async () => {
+    vi.useFakeTimers();
+    try {
+      let bufferedAmount = TERMINAL_OUTPUT_HIGH_WATER_BYTES + 1;
+      const fake = makeFakePty();
+      const manager = new TerminalSessionManager({
+        emit: vi.fn(),
+        getBufferedAmount: () => bufferedAmount,
+        spawn: async () => fake,
+      });
+      const outcome = await manager.open(baseRequest());
+      if (!outcome.ok) {
+        throw new Error("expected open");
+      }
+
+      for (let index = 0; index < 2_000; index += 1) {
+        fake.emitData("chunk");
+      }
+      expect(fake.pauseCalls).toBe(1);
+      expect(fake.deliveredChunks).toBe(1);
+      expect(manager.snapshot(outcome.sessionId)).toBe("chunk");
+
+      bufferedAmount = TERMINAL_OUTPUT_LOW_WATER_BYTES - 1;
+      await vi.advanceTimersByTimeAsync(TERMINAL_OUTPUT_REASSERT_MS);
+      expect(fake.resumeCalls).toBeGreaterThanOrEqual(1);
+      fake.emitData("resumed");
+      expect(fake.deliveredChunks).toBe(2);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("routes input and resize to the pty for the owning connection", async () => {
@@ -512,9 +624,10 @@ describe("TerminalSessionManager detach/reattach", () => {
       expect(fake.killed).toBe(false);
 
       fake.emitData("live");
+      await vi.advanceTimersByTimeAsync(4);
       expect(emit).toHaveBeenCalledWith("conn-2", TERMINAL_EVENT_DATA, {
         sessionId,
-        seq: 1,
+        seq: 0,
         data: "live",
       });
       expect(manager.write("conn-2", sessionId, "ls\n")).toBe(true);
@@ -525,27 +638,35 @@ describe("TerminalSessionManager detach/reattach", () => {
   });
 
   it("keeps data sequence numbers monotonic across repeated detach and attach", async () => {
-    const { manager, fake, emit, sessionId } = await openDetachable();
-    fake.emitData("first");
-    manager.handleDisconnect("conn-1");
-    fake.emitData("detached");
-    manager.attach("conn-2", sessionId);
-    fake.emitData("second");
-    manager.handleDisconnect("conn-2");
-    manager.attach("conn-3", sessionId);
-    fake.emitData("third");
+    vi.useFakeTimers();
+    try {
+      const { manager, fake, emit, sessionId } = await openDetachable();
+      fake.emitData("first");
+      await vi.advanceTimersByTimeAsync(4);
+      manager.handleDisconnect("conn-1");
+      fake.emitData("detached");
+      manager.attach("conn-2", sessionId);
+      fake.emitData("second");
+      await vi.advanceTimersByTimeAsync(4);
+      manager.handleDisconnect("conn-2");
+      manager.attach("conn-3", sessionId);
+      fake.emitData("third");
+      await vi.advanceTimersByTimeAsync(4);
 
-    const dataEvents = emit.mock.calls
-      .filter(([, event]) => event === TERMINAL_EVENT_DATA)
-      .map(([connId, , payload]) => {
-        const data = payload as { sessionId: string; seq: number; data: string };
-        return { connId, sessionId: data.sessionId, seq: data.seq, data: data.data };
-      });
-    expect(dataEvents).toEqual([
-      { connId: "conn-1", sessionId, seq: 0, data: "first" },
-      { connId: "conn-2", sessionId, seq: 1, data: "second" },
-      { connId: "conn-3", sessionId, seq: 2, data: "third" },
-    ]);
+      const dataEvents = emit.mock.calls
+        .filter(([, event]) => event === TERMINAL_EVENT_DATA)
+        .map(([connId, , payload]) => {
+          const data = payload as { sessionId: string; seq: number; data: string };
+          return { connId, sessionId: data.sessionId, seq: data.seq, data: data.data };
+        });
+      expect(dataEvents).toEqual([
+        { connId: "conn-1", sessionId, seq: 0, data: "first" },
+        { connId: "conn-2", sessionId, seq: 1, data: "second" },
+        { connId: "conn-3", sessionId, seq: 2, data: "third" },
+      ]);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("attach takes over a live session and notifies the previous owner", async () => {
@@ -561,7 +682,7 @@ describe("TerminalSessionManager detach/reattach", () => {
     });
     emit.mockClear();
     fake.emitData("output");
-    expect(emit).toHaveBeenCalledTimes(1);
+    await vi.waitFor(() => expect(emit).toHaveBeenCalledTimes(1));
     expect(expectDefined(emit.mock.calls[0], "emit.mock.calls[0] test invariant")[0]).toBe(
       "conn-2",
     );

--- a/src/gateway/terminal/session-manager.ts
+++ b/src/gateway/terminal/session-manager.ts
@@ -27,7 +27,6 @@ type TerminalSession = {
   cwd: string;
   shell: string;
   backend: TerminalBackend;
-  seq: number;
   closed: boolean;
   createdAtMs: number;
   buffer: TerminalOutputRing;
@@ -165,30 +164,38 @@ export class TerminalSessionManager {
       return { ok: false, code: "closed", message: token.abortMessage };
     }
 
-    let session: TerminalSession;
+    const sessionId = randomUUID();
+    const buffer = new TerminalOutputRing(this.scrollbackChars);
+    const owner = { connId: request.connId as string | null };
+    let seq = 0;
     const output = new TerminalOutputController({
       backend,
-      getConnId: () => session.connId,
+      getConnId: () => owner.connId,
       getBufferedAmount: this.getBufferedAmount,
-      record: (chunk) => session.buffer.push(chunk),
+      record: (chunk) => buffer.push(chunk),
       emit: (connId, data) =>
         this.emit(connId, TERMINAL_EVENT_DATA, {
-          sessionId: session.id,
-          seq: session.seq++,
+          sessionId,
+          seq: seq++,
           data,
         }),
     });
-    session = {
-      id: randomUUID(),
-      connId: request.connId,
+    const session: TerminalSession = {
+      id: sessionId,
+      // One owner cell keeps lifecycle mutation and async output routing atomic.
+      get connId() {
+        return owner.connId;
+      },
+      set connId(connId) {
+        owner.connId = connId;
+      },
       agentId: request.agentId,
       cwd: request.cwd,
       shell: request.shell,
       backend,
-      seq: 0,
       closed: false,
       createdAtMs: Date.now(),
-      buffer: new TerminalOutputRing(this.scrollbackChars),
+      buffer,
       output,
       reaper: null,
       detachedAtMs: null,

--- a/src/gateway/terminal/session-manager.ts
+++ b/src/gateway/terminal/session-manager.ts
@@ -1,18 +1,21 @@
-// Owns the lifecycle of operator terminal sessions: one PTY per open, bound to
-// the connection that opened it, streamed back over the gateway event channel.
+// Owns one PTY per operator connection and its gateway event lifecycle.
 import { randomUUID } from "node:crypto";
 import {
   createLocalTerminalBackend,
   type LocalTerminalBackendSpawner,
   type TerminalBackend,
 } from "./backend.js";
+import { TERMINAL_EVENT_DATA, TERMINAL_EVENT_EXIT } from "./gateway-transport.js";
+import { TerminalOutputController } from "./output-flow-control.js";
 import { TerminalOutputRing } from "./output-ring.js";
-
+import {
+  DEFAULT_MAX_DETACHED_SESSIONS,
+  DEFAULT_MAX_SESSIONS,
+  DEFAULT_SCROLLBACK_CHARS,
+} from "./session-limits.js";
+export { DEFAULT_TERMINAL_DETACH_SECONDS } from "./session-limits.js";
 /** Emits one terminal event frame to the single owning connection. */
 type TerminalEventSink = (connId: string, event: string, payload: unknown) => void;
-
-const TERMINAL_EVENT_DATA = "terminal.data" as const;
-const TERMINAL_EVENT_EXIT = "terminal.exit" as const;
 
 type TerminalExitReason = "process_exit" | "closed" | "disconnected" | "detached" | "error";
 
@@ -28,6 +31,7 @@ type TerminalSession = {
   closed: boolean;
   createdAtMs: number;
   buffer: TerminalOutputRing;
+  output: TerminalOutputController;
   /** Kills the session when a detach outlives the grace period. */
   reaper: ReturnType<typeof setTimeout> | null;
   detachedAtMs: number | null;
@@ -43,34 +47,13 @@ type TerminalSessionSummary = {
   createdAtMs: number;
 };
 
-/** Bounds concurrent shells so a client cannot exhaust host processes. */
-const DEFAULT_MAX_SESSIONS = 24;
-/**
- * Rolling output kept per session for reattach replay and terminal.text,
- * in UTF-16 code units (≈ bytes for typical terminal output). Constant, not
- * config: ~256 KiB × session cap bounds worst-case memory at a few MiB.
- */
-const DEFAULT_SCROLLBACK_CHARS = 256 * 1024;
-/**
- * Cap on simultaneously detached sessions; the oldest detached session is
- * killed to make room. Keeps repeated disconnects from parking a full
- * session-cap worth of headless shells.
- */
-const DEFAULT_MAX_DETACHED_SESSIONS = 8;
-/** Default grace period before a detached session is killed (seconds). */
-export const DEFAULT_TERMINAL_DETACH_SECONDS = 300;
-
 type TerminalSessionManagerOptions = {
   emit: TerminalEventSink;
+  getBufferedAmount?: (connId: string) => number | undefined;
   spawn?: LocalTerminalBackendSpawner;
   maxSessions?: number;
   env?: NodeJS.ProcessEnv;
-  /**
-   * How long a session may stay detached after its connection drops before it
-   * is killed. 0 (default) preserves kill-on-disconnect; the config-facing
-   * default lives in DEFAULT_TERMINAL_DETACH_SECONDS and is applied by the
-   * gateway wiring.
-   */
+  /** Detach grace; 0 preserves kill-on-disconnect. Gateway wiring owns its default. */
   detachGraceMs?: number;
   maxDetachedSessions?: number;
   scrollbackChars?: number;
@@ -108,6 +91,7 @@ export class TerminalSessionManager {
   // orphan for a dead connection.
   private readonly pendingOpens = new Map<string, Set<OpenToken>>();
   private readonly emit: TerminalEventSink;
+  private readonly getBufferedAmount: (connId: string) => number | undefined;
   private readonly spawn?: LocalTerminalBackendSpawner;
   private readonly maxSessions: number;
   private readonly detachGraceMs: number;
@@ -119,6 +103,7 @@ export class TerminalSessionManager {
 
   constructor(options: TerminalSessionManagerOptions) {
     this.emit = options.emit;
+    this.getBufferedAmount = options.getBufferedAmount ?? (() => undefined);
     this.spawn = options.spawn;
     this.maxSessions = options.maxSessions ?? DEFAULT_MAX_SESSIONS;
     this.detachGraceMs = options.detachGraceMs ?? 0;
@@ -180,7 +165,20 @@ export class TerminalSessionManager {
       return { ok: false, code: "closed", message: token.abortMessage };
     }
 
-    const session: TerminalSession = {
+    let session: TerminalSession;
+    const output = new TerminalOutputController({
+      backend,
+      getConnId: () => session.connId,
+      getBufferedAmount: this.getBufferedAmount,
+      record: (chunk) => session.buffer.push(chunk),
+      emit: (connId, data) =>
+        this.emit(connId, TERMINAL_EVENT_DATA, {
+          sessionId: session.id,
+          seq: session.seq++,
+          data,
+        }),
+    });
+    session = {
       id: randomUUID(),
       connId: request.connId,
       agentId: request.agentId,
@@ -191,6 +189,7 @@ export class TerminalSessionManager {
       closed: false,
       createdAtMs: Date.now(),
       buffer: new TerminalOutputRing(this.scrollbackChars),
+      output,
       reaper: null,
       detachedAtMs: null,
     };
@@ -198,19 +197,9 @@ export class TerminalSessionManager {
     this.indexByConn(request.connId, session.id);
 
     backend.onData((chunk) => {
-      if (session.closed) {
-        return;
+      if (!session.closed) {
+        session.output.push(chunk);
       }
-      // Always buffer so attach can replay; stream only while a conn owns it.
-      session.buffer.push(chunk);
-      if (session.connId === null) {
-        return;
-      }
-      this.emit(session.connId, TERMINAL_EVENT_DATA, {
-        sessionId: session.id,
-        seq: session.seq++,
-        data: chunk,
-      });
     });
     backend.onExit((event) => {
       const signal = event.signal && event.signal !== 0 ? event.signal : null;
@@ -237,6 +226,7 @@ export class TerminalSessionManager {
       return false;
     }
     try {
+      session.output.noteInput();
       session.backend.write(data);
       return true;
     } catch {
@@ -292,6 +282,7 @@ export class TerminalSessionManager {
       clearTimeout(session.reaper);
       session.reaper = null;
     }
+    session.output.resetOwnership();
     session.detachedAtMs = null;
     if (session.connId !== null && session.connId !== connId) {
       this.byConn.get(session.connId)?.delete(session.id);
@@ -415,6 +406,7 @@ export class TerminalSessionManager {
 
   /** Parks a session ownerless with a reaper; PTY output keeps buffering. */
   private detach(session: TerminalSession): void {
+    session.output.resetOwnership();
     session.connId = null;
     session.detachedAtMs = Date.now();
     session.reaper = setTimeout(() => {
@@ -483,6 +475,7 @@ export class TerminalSessionManager {
     if (session.closed) {
       return;
     }
+    session.output.dispose({ flush: !opts?.silent && session.connId !== null });
     session.closed = true;
     if (session.reaper) {
       clearTimeout(session.reaper);


### PR DESCRIPTION
Related: #107214

## What Problem This Solves

Fixes an issue where operators using the embedded terminal could be disconnected as slow consumers when a shell produced sustained output, while every small PTY chunk also incurred its own WebSocket frame.

## Why This Change Was Made

Terminal output now coalesces for up to 4 ms or 64 KiB, with immediate delivery for small keystroke echoes. Local PTYs pause when the owning socket crosses a high buffered-byte watermark and resume below a lower watermark, with periodic state reassertion; node-relay terminals retain their existing node-host progress backpressure.

## User Impact

Embedded terminals remain responsive during interactive input and tolerate sustained output without eagerly closing the operator connection. Release note: fixed embedded-terminal disconnects under heavy output by batching frames and applying PTY backpressure.

## Evidence

- `node scripts/run-vitest.mjs src/gateway/terminal`: 171 tests passed on Blacksmith Testbox `tbx_01kxfysrtfdbvtmfn6msc7dq0e`.
- `node scripts/run-vitest.mjs src/gateway/gateway-misc.test.ts`: 43 tests passed on the same Testbox.
- `pnpm build`: passed on the same Testbox against the final changed content.
- `pnpm check:changed`: conflict, LOC-ratchet, attribution, dependency, formatting, and export guards passed; the Plugin SDK baseline hash mismatch reproduces unchanged from `origin/main` in an isolated archive.
- Mandatory autoreview: clean, no accepted or actionable findings.
