### PR TITLE
fix(plugins): rebuild unverifiable managed npm installs

### DIFF
--- a/src/plugins/install.npm-spec.test.ts
+++ b/src/plugins/install.npm-spec.test.ts
@@ -1288,6 +1288,79 @@ describe("installPluginFromNpmSpec", () => {
     expect(fs.existsSync(resolveTestPluginPackageDir(npmRoot, "missing-lock-plugin"))).toBe(false);
   });
 
+  it("quarantines a stale managed package whose lock entry omits integrity", async () => {
+    const npmRoot = path.join(suiteTempRootTracker.makeTempDir(), "npm");
+    const packageName = "@openclaw/codex";
+    const npmProjectRoot = resolveTestPluginGenerationProjectDir({
+      npmRoot,
+      packageName,
+      version: "1.0.0",
+    });
+    const warnings: string[] = [];
+    const stalePackageDir = writeInstalledNpmPlugin({
+      npmRoot: npmProjectRoot,
+      packageName,
+      version: "1.0.0",
+      pluginId: "codex",
+      indexJs: "module.exports = { stale: true };\n",
+    });
+    fs.writeFileSync(
+      path.join(npmProjectRoot, "package-lock.json"),
+      `${JSON.stringify(
+        {
+          lockfileVersion: 3,
+          packages: {
+            "": { dependencies: { [packageName]: "1.0.0" } },
+            [`node_modules/${packageName}`]: { version: "1.0.0" },
+          },
+        },
+        null,
+        2,
+      )}\n`,
+      "utf8",
+    );
+    mockNpmViewAndInstall({
+      spec: `${packageName}@1.0.0`,
+      packageName,
+      version: "1.0.0",
+      pluginId: "codex",
+      npmRoot,
+      expectedDependencySpec: "1.0.0",
+    });
+
+    const result = await installPluginFromNpmSpec({
+      spec: `${packageName}@1.0.0`,
+      npmDir: npmRoot,
+      mode: "update",
+      logger: { info: () => {}, warn: (message) => warnings.push(message) },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(
+      warnings.some(
+        (warning) => warning.includes("cannot be verified") && warning.includes("integrity"),
+      ),
+    ).toBe(true);
+    const quarantineParent = path.join(
+      npmProjectRoot,
+      "_openclaw-quarantined-npm-projects",
+    );
+    const quarantines = fs.readdirSync(quarantineParent);
+    expect(quarantines).toHaveLength(1);
+    expect(
+      fs.readFileSync(
+        path.join(
+          quarantineParent,
+          quarantines[0] ?? "",
+          path.relative(npmProjectRoot, stalePackageDir),
+          "dist",
+          "index.js",
+        ),
+        "utf8",
+      ),
+    ).toContain("stale: true");
+  });
+
   it("repairs omitted current-platform packages with a fresh npm cache", async () => {
     const stateDir = suiteTempRootTracker.makeTempDir();
     const npmRoot = path.join(stateDir, "npm");

--- a/src/plugins/install.npm-spec.test.ts
+++ b/src/plugins/install.npm-spec.test.ts
@@ -1341,10 +1341,7 @@ describe("installPluginFromNpmSpec", () => {
         (warning) => warning.includes("cannot be verified") && warning.includes("integrity"),
       ),
     ).toBe(true);
-    const quarantineParent = path.join(
-      npmProjectRoot,
-      "_openclaw-quarantined-npm-projects",
-    );
+    const quarantineParent = path.join(npmProjectRoot, "_openclaw-quarantined-npm-projects");
     const quarantines = fs.readdirSync(quarantineParent);
     expect(quarantines).toHaveLength(1);
     expect(

--- a/src/plugins/install.npm-spec.test.ts
+++ b/src/plugins/install.npm-spec.test.ts
@@ -1341,6 +1341,12 @@ describe("installPluginFromNpmSpec", () => {
         (warning) => warning.includes("cannot be verified") && warning.includes("integrity"),
       ),
     ).toBe(true);
+    const rebuiltLock = JSON.parse(
+      fs.readFileSync(path.join(npmProjectRoot, "package-lock.json"), "utf8"),
+    ) as { packages?: Record<string, { integrity?: string }> };
+    expect(rebuiltLock.packages?.[`node_modules/${packageName}`]?.integrity).toBe(
+      "sha512-plugin-test",
+    );
     const quarantineParent = path.join(npmProjectRoot, "_openclaw-quarantined-npm-projects");
     const quarantines = fs.readdirSync(quarantineParent);
     expect(quarantines).toHaveLength(1);

--- a/src/plugins/install.ts
+++ b/src/plugins/install.ts
@@ -1027,6 +1027,47 @@ async function quarantineManagedNpmProjectRebuildArtifacts(params: {
   return { quarantineDir, movedArtifactNames };
 }
 
+async function quarantineUnverifiableManagedNpmProjectBeforeInstall(params: {
+  expectedIntegrity?: string;
+  installRoot: string;
+  npmRoot: string;
+  packageName: string;
+}): Promise<(ManagedNpmProjectQuarantine & { reason: string }) | null> {
+  if (!params.expectedIntegrity) {
+    return null;
+  }
+  try {
+    await fs.lstat(params.installRoot);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return null;
+    }
+    throw error;
+  }
+
+  let installedDependency: ManagedNpmRootInstalledDependency | null;
+  let reason: string;
+  try {
+    installedDependency = await readManagedNpmRootInstalledDependency({
+      npmRoot: params.npmRoot,
+      packageName: params.packageName,
+    });
+    if (installedDependency?.integrity) {
+      return null;
+    }
+    reason = installedDependency
+      ? "its package-lock entry does not include integrity metadata"
+      : "its package-lock entry is missing";
+  } catch (error) {
+    reason = `its package-lock metadata is unreadable: ${String(error)}`;
+  }
+
+  return {
+    ...(await quarantineManagedNpmProjectRebuildArtifacts({ npmRoot: params.npmRoot })),
+    reason,
+  };
+}
+
 function resolveInstalledNpmResolutionMismatch(params: {
   packageName: string;
   expected: NpmSpecResolution;
@@ -1401,6 +1442,25 @@ async function installPluginFromManagedNpmRoot(
       extensions: [],
       npmResolution: params.npmResolution,
       ...(params.integrityDrift ? { integrityDrift: params.integrityDrift } : {}),
+    };
+  }
+
+  try {
+    const quarantine = await quarantineUnverifiableManagedNpmProjectBeforeInstall({
+      expectedIntegrity: params.npmResolution.integrity,
+      installRoot,
+      npmRoot,
+      packageName: params.packageName,
+    });
+    if (quarantine) {
+      logger.warn?.(
+        `Found an existing managed npm install for ${params.packageName} that cannot be verified because ${quarantine.reason}; quarantined ${formatManagedNpmProjectQuarantineArtifacts(quarantine.movedArtifactNames)} at ${quarantine.quarantineDir} and rebuilding before install.`,
+      );
+    }
+  } catch (error) {
+    return {
+      ok: false,
+      error: `Failed to quarantine unverifiable managed npm state before installing ${params.packageName}: ${String(error)}`,
     };
   }
 

--- a/src/plugins/install.ts
+++ b/src/plugins/install.ts
@@ -1446,6 +1446,9 @@ async function installPluginFromManagedNpmRoot(
   }
 
   try {
+    // Managed project roots are package-specific. Keep an unverifiable tree quarantined
+    // instead of snapshotting it for rollback: restoring it would reactivate the same
+    // integrity-unknown install on the next reconciliation attempt.
     const quarantine = await quarantineUnverifiableManagedNpmProjectBeforeInstall({
       expectedIntegrity: params.npmResolution.integrity,
       installRoot,


### PR DESCRIPTION
## Summary

- quarantine an existing package-specific managed npm project when registry integrity is available but its lock entry is missing, unreadable, or omits integrity
- rebuild from a clean managed root before taking the rollback snapshot, while preserving the unverifiable tree for inspection
- keep the existing post-install registry-integrity comparison strict
- cover the stale `@openclaw/codex` lock-entry shape and assert that the rebuilt lock records the expected integrity

## What Problem This Solves

The failure is not a checksum comparison against the hook-packed/repacked tarball. A stale managed npm project can contain the installed `@openclaw/codex` tree while its top-level `package-lock.json` entry has `version` and `resolved` but no `integrity`. Re-running npm against that satisfied tree can preserve the incomplete lock metadata, so OpenClaw's strict post-install verifier reads `integrity unknown` while registry resolution expects the published `sha512` value.

The managed project root is package-specific (and generation-specific where applicable). The fix quarantines only that root's rebuild artifacts, then lets the normal npm path produce fresh registry-backed lock metadata. It does not bypass or synthesize integrity.

## Behavior and safety

- healthy installs whose lock entry already has integrity are unchanged
- fresh installs and non-registry resolutions are unchanged
- quarantine failures stop the install fail-closed
- the old tree remains available under the package-specific quarantine directory instead of being reactivated on rollback
- for this stale-state path, rebuilding before the rollback snapshot also avoids copying the multi-platform Codex hook-pack tree that produced the observed rollback `chmod`/`ENOENT`; no platform filtering is added because the hook pack intentionally contains multiple platform packages

## Evidence

- `vitest --config test/vitest/vitest.plugins.config.ts src/plugins/install.npm-spec.test.ts`: 57 passed
- `oxfmt --check` on both changed files: passed
- type-aware `oxlint` on both changed files: passed
- `git diff --check`: passed
- repository `autoreview`: clean, no actionable findings
- Claude Opus iterative review: `建议合入`, no P0/P1/P2 findings after two rounds

Live macOS arm64 validation with OpenClaw 2026.7.1 and `@openclaw/codex@2026.7.1`:

- clean managed install completed and recorded the registry `sha512-OCEV...` integrity
- gateway reached ready with Codex enabled and no integrity/migration/rollback errors
- default, `main`, and `hr` were restored to `openai/gpt-5.6-terra`
- direct `main` and `hr` Codex harness smoke tests returned `MAIN_CODEX_OK` and `HR_CODEX_OK` with no fallback

No OpenClaw or `@openclaw/codex` version bump is required for the code fix itself.
