### PR TITLE
refactor(media): use qrcode buffer renderer

### DIFF
--- a/src/media/qr-image.test.ts
+++ b/src/media/qr-image.test.ts
@@ -4,19 +4,18 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const { MOCK_PNG_BASE64, MOCK_PNG_DATA_URL, toDataURL } = vi.hoisted(() => {
-  const MOCK_PNG_BASE64Local = "ZmFrZXBuZw==";
-  const MOCK_PNG_DATA_URLLocal = `data:image/png;base64,${MOCK_PNG_BASE64Local}`;
+const { MOCK_PNG_BASE64, MOCK_PNG_BUFFER, toBuffer } = vi.hoisted(() => {
+  const MOCK_PNG_BUFFERLocal = Buffer.from("fakepng");
   return {
-    MOCK_PNG_BASE64: MOCK_PNG_BASE64Local,
-    MOCK_PNG_DATA_URL: MOCK_PNG_DATA_URLLocal,
-    toDataURL: vi.fn(async () => MOCK_PNG_DATA_URLLocal),
+    MOCK_PNG_BASE64: MOCK_PNG_BUFFERLocal.toString("base64"),
+    MOCK_PNG_BUFFER: MOCK_PNG_BUFFERLocal,
+    toBuffer: vi.fn(async () => MOCK_PNG_BUFFERLocal),
   };
 });
 
 vi.mock("qrcode", () => ({
   default: {
-    toDataURL,
+    toBuffer,
   },
 }));
 
@@ -31,8 +30,8 @@ describe("renderQrPngBase64", () => {
   const tmpRoot = path.join(os.tmpdir(), "openclaw-qr-image-tests");
 
   beforeEach(() => {
-    toDataURL.mockClear();
-    toDataURL.mockResolvedValue(MOCK_PNG_DATA_URL);
+    toBuffer.mockClear();
+    toBuffer.mockResolvedValue(MOCK_PNG_BUFFER);
   });
 
   afterEach(async () => {
@@ -43,28 +42,25 @@ describe("renderQrPngBase64", () => {
     await expect(renderQrPngBase64("openclaw", { scale: 8, marginModules: 2 })).resolves.toBe(
       MOCK_PNG_BASE64,
     );
-    expect(toDataURL).toHaveBeenCalledWith("openclaw", {
+    expect(toBuffer).toHaveBeenCalledWith("openclaw", {
       margin: 2,
       scale: 8,
-      type: "image/png",
     });
   });
 
   it("uses the default PNG rendering options", async () => {
     await renderQrPngBase64("openclaw");
-    expect(toDataURL).toHaveBeenCalledWith("openclaw", {
+    expect(toBuffer).toHaveBeenCalledWith("openclaw", {
       margin: 4,
       scale: 6,
-      type: "image/png",
     });
   });
 
   it("floors finite PNG rendering options before delegating", async () => {
     await renderQrPngBase64("openclaw", { scale: 8.9, marginModules: 2.9 });
-    expect(toDataURL).toHaveBeenCalledWith("openclaw", {
+    expect(toBuffer).toHaveBeenCalledWith("openclaw", {
       margin: 2,
       scale: 8,
-      type: "image/png",
     });
   });
 
@@ -77,14 +73,7 @@ describe("renderQrPngBase64", () => {
     ["marginModules", 6, Number.POSITIVE_INFINITY, "marginModules must be a finite number."],
   ])("rejects invalid %s values", async (_name, scale, marginModules, message) => {
     await expect(renderQrPngBase64("openclaw", { scale, marginModules })).rejects.toThrow(message);
-    expect(toDataURL).not.toHaveBeenCalled();
-  });
-
-  it("rejects non-PNG qrcode data URLs", async () => {
-    toDataURL.mockResolvedValue("data:image/svg+xml;base64,PHN2Zz4=");
-    await expect(renderQrPngBase64("openclaw")).rejects.toThrow(
-      "Expected qrcode to return a PNG data URL.",
-    );
+    expect(toBuffer).not.toHaveBeenCalled();
   });
 
   it("formats QR PNG data URLs", async () => {
@@ -120,6 +109,6 @@ describe("renderQrPngBase64", () => {
         fileName: opts.fileName,
       }),
     ).rejects.toThrow(`${name} must be a non-empty filename segment.`);
-    expect(toDataURL).not.toHaveBeenCalled();
+    expect(toBuffer).not.toHaveBeenCalled();
   });
 });

--- a/src/media/qr-image.ts
+++ b/src/media/qr-image.ts
@@ -1,7 +1,7 @@
 // QR image helpers generate QR code image files for media delivery.
 import path from "node:path";
 import { tempWorkspace } from "../infra/private-temp-workspace.js";
-import { loadQrCodeRuntime, normalizeQrText } from "./qr-runtime.ts";
+import { loadQrCodeRuntime } from "./qr-runtime.ts";
 
 const DEFAULT_QR_PNG_SCALE = 6;
 const DEFAULT_QR_PNG_MARGIN_MODULES = 4;
@@ -76,15 +76,11 @@ export async function renderQrPngBase64(
     max: MAX_QR_PNG_MARGIN_MODULES,
   });
   const qrCode = await loadQrCodeRuntime();
-  const dataUrl = await qrCode.toDataURL(normalizeQrText(input), {
+  const png = await qrCode.toBuffer(input, {
     margin: marginModules,
     scale,
-    type: "image/png",
   });
-  if (!dataUrl.startsWith(QR_PNG_DATA_URL_PREFIX)) {
-    throw new Error("Expected qrcode to return a PNG data URL.");
-  }
-  return dataUrl.slice(QR_PNG_DATA_URL_PREFIX.length);
+  return png.toString("base64");
 }
 
 /** Wraps PNG base64 in the exact data URL prefix expected by chat/media callers. */

--- a/src/media/qr-runtime.ts
+++ b/src/media/qr-runtime.ts
@@ -1,4 +1,4 @@
-// QR runtime helpers lazily load QR code generation and normalize QR text.
+// QR runtime helpers lazily load QR code generation.
 import type QRCode from "qrcode";
 import { createLazyImportLoader } from "../shared/lazy-promise.js";
 
@@ -11,15 +11,4 @@ const qrCodeRuntimeLoader = createLazyImportLoader<QrCodeRuntime>(() =>
 /** Loads the qrcode package lazily so QR support does not affect media startup paths. */
 export async function loadQrCodeRuntime(): Promise<QrCodeRuntime> {
   return await qrCodeRuntimeLoader.load();
-}
-
-/** Validates QR text before passing it to the renderer runtime. */
-export function normalizeQrText(text: string): string {
-  if (typeof text !== "string") {
-    throw new TypeError("QR text must be a string.");
-  }
-  if (text.length === 0) {
-    throw new Error("QR text must not be empty.");
-  }
-  return text;
 }

--- a/src/media/qr-terminal.render.test.ts
+++ b/src/media/qr-terminal.render.test.ts
@@ -54,6 +54,10 @@ function decodeCompactQr(output: string, size: number): boolean[] {
 }
 
 describe("renderQrTerminal (real qrcode runtime)", () => {
+  it("rejects empty input through qrcode", async () => {
+    await expect(renderQrTerminal("")).rejects.toThrow("No input text");
+  });
+
   it("keeps per-row ANSI sequence counts in line with typical rows", async () => {
     const sample = "https://wa.me/login/2@SAMPLE-TOKEN-1234567890ABCDEF";
     const rendered = await renderQrTerminal(sample);

--- a/src/media/qr-terminal.test.ts
+++ b/src/media/qr-terminal.test.ts
@@ -40,9 +40,4 @@ describe("renderQrTerminal", () => {
     expect(create).toHaveBeenCalledWith("openclaw");
     expect(toString).not.toHaveBeenCalled();
   });
-
-  it("rejects empty QR text", async () => {
-    await expect(renderQrTerminal("")).rejects.toThrow("QR text must not be empty.");
-    expect(toString).not.toHaveBeenCalled();
-  });
 });

--- a/src/media/qr-terminal.ts
+++ b/src/media/qr-terminal.ts
@@ -1,5 +1,5 @@
 // QR terminal helpers render QR codes for terminal output.
-import { loadQrCodeRuntime, normalizeQrText } from "./qr-runtime.ts";
+import { loadQrCodeRuntime } from "./qr-runtime.ts";
 
 type QrTerminalModules = {
   data: ArrayLike<boolean | number>;
@@ -50,13 +50,12 @@ export async function renderQrTerminal(
   input: string,
   opts: { small?: boolean } = {},
 ): Promise<string> {
-  const text = normalizeQrText(input);
   const qrCode = await loadQrCodeRuntime();
   if (opts.small === true) {
     // Avoid qrcode's small terminal mode so we control quiet-zone size and ANSI reset placement.
-    return renderCompactTerminalQr(qrCode.create(text).modules);
+    return renderCompactTerminalQr(qrCode.create(input).modules);
   }
-  return await qrCode.toString(text, {
+  return await qrCode.toString(input, {
     small: false,
     type: "terminal",
   });

--- a/src/types/qrcode.d.ts
+++ b/src/types/qrcode.d.ts
@@ -42,19 +42,15 @@ declare module "qrcode" {
   export function toString(text: string, options?: QrCodeRenderOptions): Promise<string>;
   /** Render a QR code to a data URL. */
   export function toDataURL(text: string, options?: QrCodeRenderOptions): Promise<string>;
-  /** Render a QR code to a file. */
-  export function toFile(
-    filePath: string,
-    text: string,
-    options?: QrCodeRenderOptions,
-  ): Promise<void>;
+  /** Render a QR code to a PNG buffer. */
+  export function toBuffer(text: string, options?: QrCodeRenderOptions): Promise<Buffer>;
 
   /** Default qrcode export with the functions OpenClaw uses. */
   const qrcode: {
     create: typeof create;
     toString: typeof toString;
     toDataURL: typeof toDataURL;
-    toFile: typeof toFile;
+    toBuffer: typeof toBuffer;
   };
 
   export default qrcode;


### PR DESCRIPTION
## What Problem This Solves

QR PNG rendering asked `qrcode` for a data URL, checked and sliced the prefix, then decoded that base64 again when writing a temporary file. OpenClaw also duplicated input validation already enforced by `qrcode`.

## Why This Change Was Made

Use `qrcode.toBuffer()` directly and base64-encode its PNG buffer only at the public base64 boundary. Rely on the dependency's native input validation and remove the unused `toFile` ambient declaration. The custom compact terminal renderer remains unchanged because upstream `small: true` has a known scanning regression.

## User Impact

No valid-input behavior change. PNG bytes are identical; invalid QR input now reports the native `qrcode` diagnostic. The refactor removes 32 net lines and avoids a data-URL round trip.

## Evidence

- `node scripts/run-vitest.mjs src/media/qr-image.test.ts src/media/qr-terminal.test.ts src/media/qr-terminal.render.test.ts` (3 files, 18 tests passed)
- Native `toDataURL()` versus `toBuffer()` byte comparison passed for default options, custom sizing, and Unicode input
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local` (clean, 0.96)
