### PR TITLE
chore: speed up agent runner tests

### DIFF
--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -471,7 +471,6 @@ function createFollowupRun(): FollowupRun {
       skillsSnapshot: {},
       provider: "anthropic",
       model: "claude",
-      thinkLevel: "low",
       verboseLevel: "off",
       elevatedLevel: "off",
       bashElevated: {
@@ -1407,6 +1406,7 @@ describe("runAgentTurnWithFallback", () => {
   afterEach(() => {
     // Fake-timer tests in this describe must not leak into --isolate=false peers.
     vi.useRealTimers();
+    cliBackendsTesting.resetDepsForTest();
     vi.clearAllMocks();
   });
 
@@ -1446,6 +1446,7 @@ describe("runAgentTurnWithFallback", () => {
         defaults: {
           models: {
             "openai/gpt-5.6-sol": { agentRuntime: { id: "openclaw" } },
+            "demo/basic": { agentRuntime: { id: "openclaw" } },
           },
         },
       },
@@ -4028,6 +4029,21 @@ describe("runAgentTurnWithFallback", () => {
   });
 
   it("does not pass CLI runtime overrides as embedded harness ids for fallback providers", async () => {
+    cliBackendsTesting.setDepsForTest({
+      resolveRuntimeCliBackends: () => [],
+      resolvePluginSetupCliBackend: ({ backend, config }) =>
+        backend === "claude-cli" && config
+          ? {
+              pluginId: "anthropic",
+              backend: {
+                id: "claude-cli",
+                modelProvider: "anthropic",
+                config: { command: "claude" },
+                bundleMcp: false,
+              },
+            }
+          : undefined,
+    });
     state.isCliProviderMock.mockImplementation((provider: unknown) => provider === "claude-cli");
     state.runWithModelFallbackMock.mockImplementationOnce(async (params: FallbackRunnerParams) => ({
       result: await params.run("openai", "gpt-5.4"),


### PR DESCRIPTION
## What Problem This Solves

The agent-runner unit suite spent most of its time discovering installed plugin runtime metadata even though the affected tests only exercise fallback orchestration. One abort-path case took 11.3 seconds, making focused development and CI feedback unnecessarily slow.

## Why This Change Was Made

Keep the common follow-up fixture free of an unused thinking override, pin concrete runtime policy only in the thinking-specific test, and inject the canonical Anthropic CLI backend through the existing test seam where that binding is the assertion prerequisite. Production behavior is unchanged.

## User Impact

No user-visible behavior change. Maintainers and CI get faster agent-runner test feedback.

## Evidence

- Baseline Testbox run 29321540791: abort-path test 11.299s; file 17.30s.
- Focused Testbox run 29322793783: abort-path test 149ms; thinking revalidation 727ms; 2 tests passed.
- Final exact-head Testbox run 29323618168: 254 tests passed; test phase 1.44s; file 5.25s.
- Changed-surface Testbox run 29323299083: `check:changed` passed, including formatting, core-test typecheck, and lint.
- Autoreview: no accepted/actionable findings; confidence 0.94.

AI-assisted: yes. The change and timing evidence were inspected and validated by the maintainer.
