### PR TITLE
refactor(msteams): use Express listen errors

### DIFF
--- a/extensions/msteams/src/monitor.lifecycle.test.ts
+++ b/extensions/msteams/src/monitor.lifecycle.test.ts
@@ -92,7 +92,7 @@ vi.mock("express", () => {
     const app = vi.fn() as MockExpressApp;
     app.use = vi.fn();
     app.post = vi.fn();
-    app.listen = vi.fn((_port: number) => {
+    app.listen = vi.fn((_port: number, callback?: (error?: Error) => void) => {
       const server = new EventEmitter() as FakeServer;
       server.setTimeout = vi.fn((_msecs: number) => server);
       server.requestTimeout = 0;
@@ -105,10 +105,10 @@ vi.mock("express", () => {
       };
       queueMicrotask(() => {
         if (expressControl.mode.value === "error") {
-          server.emit("error", new Error("listen EADDRINUSE"));
+          callback?.(new Error("listen EADDRINUSE"));
           return;
         }
-        server.emit("listening");
+        callback?.();
       });
       return server;
     });

--- a/extensions/msteams/src/monitor.ts
+++ b/extensions/msteams/src/monitor.ts
@@ -1,4 +1,5 @@
 // Msteams plugin module implements monitor behavior.
+import type { Server } from "node:http";
 import type { Request, Response } from "express";
 import {
   DEFAULT_WEBHOOK_MAX_BODY_BYTES,
@@ -537,21 +538,13 @@ export async function monitorMSTeamsProvider(
   await app.initialize();
 
   // Start listening and fail fast if bind/listen fails.
-  const httpServer = expressApp.listen(port);
-  await new Promise<void>((resolve, reject) => {
-    const onListening = () => {
-      httpServer.off("error", onError);
-      log.info(`msteams provider started on port ${port}`);
-      resolve();
-    };
-    const onError = (err: unknown) => {
-      httpServer.off("listening", onListening);
-      log.error("msteams server error", { error: formatUnknownError(err) });
-      reject(toLintErrorObject(err, "MSTeams server failed"));
-    };
-    httpServer.once("listening", onListening);
-    httpServer.once("error", onError);
+  const httpServer = await new Promise<Server>((resolve, reject) => {
+    const server = expressApp.listen(port, (err) => (err ? reject(err) : resolve(server)));
+  }).catch((err: unknown) => {
+    log.error("msteams server error", { error: formatUnknownError(err) });
+    throw err;
   });
+  log.info(`msteams provider started on port ${port}`);
   applyMSTeamsWebhookTimeouts(httpServer);
 
   httpServer.on("error", (err) => {
@@ -578,20 +571,6 @@ export async function monitorMSTeamsProvider(
   });
 
   return { app: expressApp, shutdown };
-}
-
-function toLintErrorObject(value: unknown, fallbackMessage: string): Error {
-  if (value instanceof Error) {
-    return value;
-  }
-  if (typeof value === "string") {
-    return new Error(value);
-  }
-  const error = new Error(fallbackMessage, { cause: value });
-  if ((typeof value === "object" && value !== null) || typeof value === "function") {
-    Object.assign(error, value);
-  }
-  return error;
 }
 
 /**


### PR DESCRIPTION
## What Problem This Solves

The Microsoft Teams monitor manually coordinated Express server `listening` and `error` events, then normalized error values that Express 5 already guarantees are `Error` objects.

## Why This Change Was Made

Express 5.2.1 natively forwards bind failures to the `app.listen` callback. Using that contract removes duplicate listener cleanup and the now-dead error normalizer.

## User Impact

No behavior change. Microsoft Teams startup still resolves after a successful bind and rejects immediately on failures such as `EADDRINUSE`.

## Evidence

- `node scripts/run-vitest.mjs extensions/msteams/src/monitor.lifecycle.test.ts extensions/msteams/src/monitor.test.ts extensions/msteams/src/sdk.test.ts` — 3 files, 38 tests passed
- `git diff --check`
- Fresh local autoreview: no actionable findings
- Net reduction: 21 lines
