### PR TITLE
fix(ui): keep unsupported schema guidance field-local

### DIFF
--- a/ui/src/pages/config/view.browser.test.ts
+++ b/ui/src/pages/config/view.browser.test.ts
@@ -338,7 +338,7 @@ describe("config view", () => {
     expect(onFormModeChange).toHaveBeenCalledWith("raw");
   });
 
-  it("shows the form safety warning only in form mode", () => {
+  it("keeps unsupported schema guidance field-local", () => {
     const container = document.createElement("div");
     const props = {
       ...baseProps(),
@@ -355,9 +355,11 @@ describe("config view", () => {
     };
 
     render(renderConfig({ ...props, formMode: "form" }), container);
-    expect(normalizedText(container)).toContain(
+    expect(normalizedText(container)).not.toContain(
       "Your config contains fields the form editor can't safely represent. Use Raw mode to edit those entries.",
     );
+    expect(normalizedText(container)).toContain("Unsupported schema node. Use Raw mode.");
+    expect(findButtonByText(container, "Form").hasAttribute("title")).toBe(false);
 
     render(renderConfig({ ...props, formMode: "raw" }), container);
     expect(normalizedText(container)).not.toContain(

--- a/ui/src/pages/config/view.ts
+++ b/ui/src/pages/config/view.ts
@@ -1407,7 +1407,6 @@ export function renderConfig(props: ConfigProps) {
     include,
     exclude,
   );
-  const formUnsafe = analysis.schema ? analysis.unsupportedPaths.length > 0 : false;
   const rawAvailable = props.rawAvailable ?? true;
   const formMode = showModeToggle && rawAvailable ? props.formMode : "form";
   const requestUpdate = props.onViewStateChange;
@@ -1582,7 +1581,6 @@ export function renderConfig(props: ConfigProps) {
   const configBusy = props.loading || props.saving || props.applying || props.updating;
 
   // Save/apply buttons require actual changes to be enabled.
-  // Note: formUnsafe warns about unsupported schema paths but shouldn't block saving.
   const canSaveForm = Boolean(props.formValue) && !props.loading && Boolean(analysis.schema);
   const canSave =
     props.connected && !configBusy && hasChanges && (formMode === "raw" ? true : canSaveForm);
@@ -1612,7 +1610,6 @@ export function renderConfig(props: ConfigProps) {
                     <button
                       class="config-mode-toggle__btn ${formMode === "form" ? "active" : ""}"
                       ?disabled=${props.schemaLoading || !props.schema}
-                      title=${formUnsafe ? t("configView.formUnsafeTitle") : ""}
                       @click=${() => props.onFormModeChange("form")}
                     >
                       ${t("configView.form")}
@@ -1941,13 +1938,6 @@ export function renderConfig(props: ConfigProps) {
                 : nothing
               : formMode === "form"
                 ? html`
-                    ${formUnsafe && showModeToggle && rawAvailable
-                      ? html`
-                          <div class="callout info" style="margin-bottom: 12px">
-                            ${t("configView.formUnsafe")}
-                          </div>
-                        `
-                      : nothing}
                     ${showAppearanceOnRoot ? renderAppearanceSection(props) : nothing}
                     ${props.schemaLoading
                       ? html`


### PR DESCRIPTION
## Summary

- remove the page-wide unsupported-schema warning from the Form config editor
- remove the warning tooltip from the Form mode toggle
- keep unsupported-schema guidance beside the specific affected field
- add regression coverage for the field-local behavior

## What Problem This Solves

The Form config editor showed a global warning whenever any schema path was unsupported, even though the editor already renders guidance beside the affected field. This made a field-local limitation look like the entire form was unsafe to use.

Closes #107318

## Why This Change Was Made

Unsupported paths are already handled by the field renderer. Removing the duplicate page-level signal keeps the ownership of the warning at the point where the limitation exists and avoids implying that unrelated fields are unsafe.

## User Impact

Users no longer see a misleading page-wide warning or Form-toggle tooltip for isolated unsupported schema nodes. The affected field still tells users to use Raw mode.

## Evidence

- `node scripts/run-vitest.mjs ui/src/pages/config/view.browser.test.ts` — 31 tests passed
- `pnpm ui:i18n:verify` — passed
- `pnpm format:check ui/src/pages/config/view.ts ui/src/pages/config/view.browser.test.ts` — passed
- `git diff --check` — passed
- Full build was not completed at the contributor's request; the change only removes rendered markup and updates its focused regression test.

## Screenshots

Not included. The focused browser test verifies that the page-wide warning and Form-toggle tooltip are absent while the field-local warning remains visible.
