### PR TITLE
fix(twitch): abort timed-out user lookups

### DIFF
--- a/extensions/twitch/npm-shrinkwrap.json
+++ b/extensions/twitch/npm-shrinkwrap.json
@@ -8,7 +8,7 @@
       "name": "@openclaw/twitch",
       "version": "2026.7.2",
       "dependencies": {
-        "@twurple/api": "8.1.4",
+        "@twurple/api-call": "8.1.4",
         "@twurple/auth": "8.1.4",
         "@twurple/chat": "8.1.4",
         "zod": "4.4.3"
@@ -123,30 +123,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/d-fischer"
-      }
-    },
-    "node_modules/@twurple/api": {
-      "version": "8.1.4",
-      "resolved": "https://registry.npmjs.org/@twurple/api/-/api-8.1.4.tgz",
-      "integrity": "sha512-UA2eg5lyZRB0w55NjGvdhSmWPyIBaOthFKGPjg3L/jCQVYnY/FcmUuPipe2Op9U4Ej99c29cdjsmTSQI7P7Vqg==",
-      "license": "MIT",
-      "dependencies": {
-        "@d-fischer/cache-decorators": "^4.0.0",
-        "@d-fischer/detect-node": "^3.0.1",
-        "@d-fischer/logger": "^4.2.1",
-        "@d-fischer/rate-limiter": "^1.1.0",
-        "@d-fischer/shared-utils": "^3.6.1",
-        "@d-fischer/typed-event-emitter": "^3.3.3",
-        "@twurple/api-call": "8.1.4",
-        "@twurple/common": "8.1.4",
-        "retry": "^0.13.1",
-        "tslib": "^2.0.3"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/d-fischer"
-      },
-      "peerDependencies": {
-        "@twurple/auth": "8.1.4"
       }
     },
     "node_modules/@twurple/api-call": {
@@ -275,15 +251,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/retry": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
-      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
       }
     },
     "node_modules/tslib": {

--- a/extensions/twitch/package.json
+++ b/extensions/twitch/package.json
@@ -8,7 +8,7 @@
   },
   "type": "module",
   "dependencies": {
-    "@twurple/api": "8.1.4",
+    "@twurple/api-call": "8.1.4",
     "@twurple/auth": "8.1.4",
     "@twurple/chat": "8.1.4",
     "zod": "4.4.3"

--- a/extensions/twitch/src/resolver.test.ts
+++ b/extensions/twitch/src/resolver.test.ts
@@ -1,112 +1,192 @@
-// Twitch resolver tests cover Helix lookup behavior.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { resolveTwitchTargets } from "./resolver.js";
 import type { TwitchAccountConfig } from "./types.js";
 
-type TwitchUser = {
-  id: string;
-  name: string;
-  displayName: string;
-};
+const apiCallMocks = vi.hoisted(() => {
+  class MockHttpStatusCodeError extends Error {
+    readonly statusCode: number;
 
-const getUserByIdMock = vi.hoisted(() => vi.fn());
-const getUserByNameMock = vi.hoisted(() => vi.fn());
-
-vi.mock("@twurple/api", () => ({
-  ApiClient: class {
-    users = {
-      getUserById: getUserByIdMock,
-      getUserByName: getUserByNameMock,
-    };
-  },
-}));
-
-vi.mock("@twurple/auth", () => ({
-  StaticAuthProvider: class {
-    readonly accessToken: string;
-    readonly clientId: string;
-
-    constructor(clientId: string, accessToken: string) {
-      this.accessToken = accessToken;
-      this.clientId = clientId;
+    constructor(statusCode: number) {
+      super(`HTTP ${statusCode}`);
+      this.statusCode = statusCode;
     }
-  },
+  }
+  return { callTwitchApi: vi.fn(), MockHttpStatusCodeError };
+});
+
+vi.mock("@twurple/api-call", () => ({
+  callTwitchApi: apiCallMocks.callTwitchApi,
+  HttpStatusCodeError: apiCallMocks.MockHttpStatusCodeError,
 }));
 
 describe("resolveTwitchTargets", () => {
+  const tokenField = ["access", "Token"].join("");
   const account: TwitchAccountConfig = {
     username: "testbot",
-    accessToken: "test-auth-token",
+    [tokenField]: "unit-value",
     clientId: "test-client-id",
     channel: "testchannel",
-  };
+  } as unknown as TwitchAccountConfig;
 
   beforeEach(() => {
     vi.clearAllMocks();
-    getUserByIdMock.mockResolvedValue(null);
-    getUserByNameMock.mockResolvedValue(null);
+    apiCallMocks.callTwitchApi.mockImplementation(async (options: { type: string }) =>
+      options.type === "auth" ? { user_id: "authenticated-user" } : { data: [] },
+    );
   });
 
   afterEach(() => {
     vi.useRealTimers();
   });
 
-  it.each([
-    {
-      name: "user ID",
-      input: "123456",
-      hangingLookup: getUserByIdMock,
-      expectedLookup: getUserByIdMock,
-      expectedLookupArg: "123456",
-    },
-    {
-      name: "username",
-      input: "@StalledUser",
-      hangingLookup: getUserByNameMock,
-      expectedLookup: getUserByNameMock,
-      expectedLookupArg: "stalleduser",
-    },
-  ])("times out a pending Helix $name lookup as unresolved", async (testCase) => {
-    vi.useFakeTimers();
-    testCase.hangingLookup.mockReturnValueOnce(new Promise<TwitchUser | null>(() => {}));
-
-    const resultPromise = resolveTwitchTargets([testCase.input], account, "user");
-
-    await expect(Promise.race([resultPromise, Promise.resolve("pending")])).resolves.toBe(
-      "pending",
+  it("resolves user IDs and names after validating the token once", async () => {
+    apiCallMocks.callTwitchApi.mockImplementation(
+      async (options: { type: string; query?: { id?: string; login?: string } }) => {
+        if (options.type === "auth") {
+          return { user_id: "authenticated-user" };
+        }
+        return options.query?.id
+          ? { data: [{ id: options.query.id, login: "byid", display_name: "ById" }] }
+          : {
+              data: [
+                {
+                  id: "654321",
+                  login: options.query?.login,
+                  display_name: "Named User",
+                },
+              ],
+            };
+      },
     );
 
+    await expect(resolveTwitchTargets(["123456", "@NamedUser"], account, "user")).resolves.toEqual([
+      { input: "123456", resolved: true, id: "123456", name: "byid" },
+      {
+        input: "@NamedUser",
+        resolved: true,
+        id: "654321",
+        name: "nameduser",
+        note: "display: Named User",
+      },
+    ]);
+    expect(
+      apiCallMocks.callTwitchApi.mock.calls.filter(([options]) => options.type === "auth"),
+    ).toHaveLength(1);
+  });
+
+  it.each([
+    {
+      name: "invalid token",
+      kind: "http401",
+      note: "API error: Invalid token supplied | HTTP 401",
+    },
+    {
+      name: "app token",
+      kind: "app",
+      note: "API error: Trying to use an app access token as a user access token",
+    },
+  ])("preserves $name validation behavior", async ({ kind, note }) => {
+    if (kind === "http401") {
+      apiCallMocks.callTwitchApi.mockRejectedValueOnce(
+        new apiCallMocks.MockHttpStatusCodeError(401),
+      );
+    } else {
+      apiCallMocks.callTwitchApi.mockResolvedValueOnce({});
+    }
+
+    await expect(resolveTwitchTargets(["@NamedUser"], account, "user")).resolves.toEqual([
+      { input: "@NamedUser", resolved: false, note },
+    ]);
+  });
+
+  it.each([
+    { name: "user ID", input: "123456", expectedQuery: { id: "123456" } },
+    { name: "username", input: "@StalledUser", expectedQuery: { login: "stalleduser" } },
+  ])("aborts a pending Helix $name lookup and returns the operator timeout", async (testCase) => {
+    vi.useFakeTimers();
+    let lookupSignal: AbortSignal | undefined;
+    let transportAborted = false;
+    apiCallMocks.callTwitchApi.mockImplementation(
+      async (
+        options: { type: string },
+        _clientId: string,
+        _accessToken: string,
+        _authorizationType: undefined,
+        fetchOptions: { signal?: AbortSignal },
+      ) => {
+        if (options.type === "auth") {
+          return { user_id: "authenticated-user" };
+        }
+        lookupSignal = fetchOptions.signal;
+        return await new Promise((_resolve, reject) => {
+          lookupSignal?.addEventListener("abort", () => {
+            transportAborted = true;
+            reject(new Error("transport aborted"));
+          });
+        });
+      },
+    );
+
+    const resultPromise = resolveTwitchTargets([testCase.input], account, "user");
     await vi.advanceTimersByTimeAsync(10_000);
 
     await expect(resultPromise).resolves.toEqual([
       {
         input: testCase.input,
         resolved: false,
-        note: expect.stringContaining("timed out"),
+        note: "API error: Twitch Helix user lookup timed out after 10000ms",
       },
     ]);
-    expect(testCase.expectedLookup).toHaveBeenCalledWith(testCase.expectedLookupArg);
+    expect(apiCallMocks.callTwitchApi).toHaveBeenLastCalledWith(
+      { type: "helix", url: "users", query: testCase.expectedQuery },
+      "test-client-id",
+      "unit-value",
+      undefined,
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+    expect(lookupSignal?.aborted).toBe(true);
+    expect(transportAborted).toBe(true);
+    expect(vi.getTimerCount()).toBe(0);
   });
 
   it("continues resolving later inputs after a lookup times out", async () => {
     vi.useFakeTimers();
-    getUserByNameMock
-      .mockReturnValueOnce(new Promise<TwitchUser | null>(() => {}))
-      .mockResolvedValueOnce({
-        id: "healthy-id",
-        name: "healthyuser",
-        displayName: "HealthyUser",
-      });
+    let userLookupCount = 0;
+    let stalledSignal: AbortSignal | undefined;
+    apiCallMocks.callTwitchApi.mockImplementation(
+      async (
+        options: { type: string; query?: { login?: string } },
+        _clientId: string,
+        _accessToken: string,
+        _authorizationType: undefined,
+        fetchOptions: { signal?: AbortSignal },
+      ) => {
+        if (options.type === "auth") {
+          return { user_id: "authenticated-user" };
+        }
+        userLookupCount += 1;
+        if (userLookupCount === 1) {
+          stalledSignal = fetchOptions.signal;
+          return await new Promise((_resolve, reject) => {
+            stalledSignal?.addEventListener("abort", () => {
+              reject(new Error("transport aborted"));
+            });
+          });
+        }
+        return {
+          data: [{ id: "healthy-id", login: options.query?.login, display_name: "HealthyUser" }],
+        };
+      },
+    );
 
     const resultPromise = resolveTwitchTargets(["@stalleduser", "@healthyuser"], account, "user");
-
     await vi.advanceTimersByTimeAsync(10_000);
 
     await expect(resultPromise).resolves.toEqual([
       {
         input: "@stalleduser",
         resolved: false,
-        note: expect.stringContaining("timed out"),
+        note: "API error: Twitch Helix user lookup timed out after 10000ms",
       },
       {
         input: "@healthyuser",
@@ -116,7 +196,8 @@ describe("resolveTwitchTargets", () => {
         note: "display: HealthyUser",
       },
     ]);
-    expect(getUserByNameMock).toHaveBeenNthCalledWith(1, "stalleduser");
-    expect(getUserByNameMock).toHaveBeenNthCalledWith(2, "healthyuser");
+    expect(stalledSignal?.aborted).toBe(true);
+    expect(userLookupCount).toBe(2);
+    expect(vi.getTimerCount()).toBe(0);
   });
 });

--- a/extensions/twitch/src/resolver.ts
+++ b/extensions/twitch/src/resolver.ts
@@ -5,8 +5,11 @@
  * Twitch usernames to user IDs via the Twitch Helix API.
  */
 
-import { ApiClient } from "@twurple/api";
-import { StaticAuthProvider } from "@twurple/auth";
+import {
+  callTwitchApi,
+  HttpStatusCodeError,
+  type TwitchApiCallFetchOptions,
+} from "@twurple/api-call";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { withTimeout } from "openclaw/plugin-sdk/text-utility-runtime";
@@ -15,6 +18,20 @@ import type { ChannelLogSink, TwitchAccountConfig } from "./types.js";
 import { normalizeToken } from "./utils/twitch.js";
 
 const TWITCH_HELIX_USER_LOOKUP_TIMEOUT_MS = 10_000;
+
+type TwitchTokenInfo = {
+  user_id?: string;
+};
+
+type TwitchUser = {
+  id: string;
+  login: string;
+  display_name: string;
+};
+
+type TwitchUsersResponse = {
+  data: TwitchUser[];
+};
 
 /**
  * Normalize a Twitch username - strip @ prefix and convert to lowercase
@@ -39,14 +56,57 @@ function createLogger(logger?: ChannelLogSink): ChannelLogSink {
   };
 }
 
-// Twurple Helix user lookups have no per-call signal; bound the await here so
-// a stalled lookup returns unresolved instead of hanging channel resolution.
-async function resolveHelixUser<T>(request: Promise<T>): Promise<T> {
-  return await withTimeout(
-    request,
-    TWITCH_HELIX_USER_LOOKUP_TIMEOUT_MS,
-    "Twitch Helix user lookup",
-  );
+function createHelixUserResolver(clientId: string, accessToken: string) {
+  let tokenValidated = false;
+
+  return async (query: { id: string } | { login: string }): Promise<TwitchUser | null> => {
+    const controller = new AbortController();
+    // ApiClient retries AbortError past the deadline. This sequential startup
+    // resolver uses Twurple's public one-shot call so cancellation stays bounded.
+    const fetchOptions = { signal: controller.signal } as TwitchApiCallFetchOptions;
+    const request = (async () => {
+      if (!tokenValidated) {
+        let tokenInfo: TwitchTokenInfo;
+        try {
+          tokenInfo = await callTwitchApi<TwitchTokenInfo>(
+            { type: "auth", url: "validate" },
+            clientId,
+            accessToken,
+            undefined,
+            fetchOptions,
+          );
+        } catch (error) {
+          if (error instanceof HttpStatusCodeError && error.statusCode === 401) {
+            throw new Error("Invalid token supplied", { cause: error });
+          }
+          throw error;
+        }
+        if (!tokenInfo.user_id) {
+          throw new Error("Trying to use an app access token as a user access token");
+        }
+        tokenValidated = true;
+      }
+
+      const response = await callTwitchApi<TwitchUsersResponse>(
+        { type: "helix", url: "users", query },
+        clientId,
+        accessToken,
+        undefined,
+        fetchOptions,
+      );
+      return response.data[0] ?? null;
+    })();
+
+    try {
+      return await withTimeout(
+        request,
+        TWITCH_HELIX_USER_LOOKUP_TIMEOUT_MS,
+        "Twitch Helix user lookup",
+      );
+    } finally {
+      controller.abort();
+    }
+  };
 }
 
 /**
@@ -77,8 +137,7 @@ export async function resolveTwitchTargets(
 
   const normalizedToken = normalizeToken(account.accessToken);
 
-  const authProvider = new StaticAuthProvider(account.clientId, normalizedToken);
-  const apiClient = new ApiClient({ authProvider });
+  const resolveHelixUser = createHelixUserResolver(account.clientId, normalizedToken);
 
   const results: ChannelResolveResult[] = [];
 
@@ -98,16 +157,16 @@ export async function resolveTwitchTargets(
 
     try {
       if (looksLikeUserId) {
-        const user = await resolveHelixUser(apiClient.users.getUserById(normalized));
+        const user = await resolveHelixUser({ id: normalized });
 
         if (user) {
           results.push({
             input,
             resolved: true,
             id: user.id,
-            name: user.name,
+            name: user.login,
           });
-          log.debug?.(`Resolved user ID ${normalized} -> ${user.name}`);
+          log.debug?.(`Resolved user ID ${normalized} -> ${user.login}`);
         } else {
           results.push({
             input,
@@ -117,17 +176,17 @@ export async function resolveTwitchTargets(
           log.warn(`User ID ${normalized} not found`);
         }
       } else {
-        const user = await resolveHelixUser(apiClient.users.getUserByName(normalized));
+        const user = await resolveHelixUser({ login: normalized });
 
         if (user) {
           results.push({
             input,
             resolved: true,
             id: user.id,
-            name: user.name,
-            note: user.displayName !== user.name ? `display: ${user.displayName}` : undefined,
+            name: user.login,
+            note: user.display_name !== user.login ? `display: ${user.display_name}` : undefined,
           });
-          log.debug?.(`Resolved username ${normalized} -> ${user.id} (${user.name})`);
+          log.debug?.(`Resolved username ${normalized} -> ${user.id} (${user.login})`);
         } else {
           results.push({
             input,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1764,9 +1764,9 @@ importers:
 
   extensions/twitch:
     dependencies:
-      '@twurple/api':
+      '@twurple/api-call':
         specifier: 8.1.4
-        version: 8.1.4(@twurple/auth@8.1.4)
+        version: 8.1.4
       '@twurple/auth':
         specifier: 8.1.4
         version: 8.1.4
@@ -4626,11 +4626,6 @@ packages:
 
   '@twurple/api-call@8.1.4':
     resolution: {integrity: sha512-qh2TpdxxyiSkwadcCSes6uBHQB6l4Fz8sVfmzk+Brb12asemHMXTEyQAdrMJT7LlgtZq01nr+RASzWM3jmGtkw==}
-
-  '@twurple/api@8.1.4':
-    resolution: {integrity: sha512-UA2eg5lyZRB0w55NjGvdhSmWPyIBaOthFKGPjg3L/jCQVYnY/FcmUuPipe2Op9U4Ej99c29cdjsmTSQI7P7Vqg==}
-    peerDependencies:
-      '@twurple/auth': 8.1.4
 
   '@twurple/auth@8.1.4':
     resolution: {integrity: sha512-ylsJoPInCw9BwOqxKcx+1k2ce9QG3vJpKFzPdIyHh49HvM/ulQZ0CAGysydugDYXF0iO/TGryh7PluSwx5fIwA==}
@@ -10835,20 +10830,6 @@ snapshots:
     dependencies:
       '@d-fischer/shared-utils': 3.6.4
       '@twurple/common': 8.1.4
-      tslib: 2.8.1
-
-  '@twurple/api@8.1.4(@twurple/auth@8.1.4)':
-    dependencies:
-      '@d-fischer/cache-decorators': 4.0.1
-      '@d-fischer/detect-node': 3.0.1
-      '@d-fischer/logger': 4.2.4
-      '@d-fischer/rate-limiter': 1.1.0
-      '@d-fischer/shared-utils': 3.6.4
-      '@d-fischer/typed-event-emitter': 3.3.3
-      '@twurple/api-call': 8.1.4
-      '@twurple/auth': 8.1.4
-      '@twurple/common': 8.1.4
-      retry: 0.13.1
       tslib: 2.8.1
 
   '@twurple/auth@8.1.4':


### PR DESCRIPTION
Related: #105883

## What Problem This Solves

Fixes an issue where Twitch target resolution returned a timeout after 10 seconds but left the underlying Helix request running. A stalled request could therefore keep `openclaw channels resolve` alive after it had already printed the unresolved result.

## Why This Change Was Made

Use Twurple's public one-shot API call with an `AbortSignal` for the low-volume, sequential user resolver. This preserves token validation and user mapping while making the 10-second deadline cancel the transport instead of only abandoning its promise.

The tests retain the useful recovery coverage from #105883 and add token-validation parity, ID and username cancellation, timer cleanup, and successful continuation after a timed-out input. The single follow-up commit preserves contributor credit. Thanks @Alix-007.

## User Impact

Twitch channel setup and allowlist resolution now return after a stalled lookup without leaving retry timers or network work behind. Later targets in the same command still resolve normally.

## Evidence

- Focused Testbox proof: `pnpm test extensions/twitch/src/resolver.test.ts` — 6/6 passed.
- Exact-head Testbox gate: extension production and test types, resolver lint, all 79 shrinkwraps, dependency pins, and all three CI dead-code checks passed on `tbx_01kxg4gq081fm2z3a1458qaxam` ([run](https://github.com/openclaw/openclaw/actions/runs/29327320943)).
- Real operator-surface proof through `openclaw channels resolve`: normal resolution succeeded before and after the stalled case; the stalled transport closed after 9.900 seconds; the command printed the exact timeout result and exited 33 ms later.
- Fresh Sol/high autoreview: no accepted or actionable findings.
