### PR TITLE
fix(mac): enable terminal actions for paired-node sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- **macOS paired-node terminals:** advertise duplex Codex and Claude terminal resume commands from the embedded node host and forward interactive input and cancellation through the native app bridge. (#107335)
 - **Control UI catalog terminals:** open eligible Codex and Claude Code sessions in the native CLI on their Gateway or paired-node host, with viewer-versus-terminal preferences, validated resume commands, and an interactive PTY relay. (#107086)
 - **Skill Workshop history review:** add a manual, newest-first session scan that progressively searches older substantial work for conservative skill ideas, stores only SQLite cursor metadata, and leaves up to three results as pending proposals even when autonomous self-learning is disabled. (#106182)
 - **SQLite snapshots:** add `openclaw backup sqlite create|list|verify|restore` for compact, verified global and per-agent database artifacts with fresh-target-only restore. (#94805) Thanks @giodl73-repo.

--- a/apps/macos/Sources/OpenClaw/NodeMode/MacNodeHostWorker.swift
+++ b/apps/macos/Sources/OpenClaw/NodeMode/MacNodeHostWorker.swift
@@ -18,6 +18,8 @@ protocol MacNodeHostWorking: Sendable {
     func start(command: [String]) async throws -> MacNodeHostManifest
     func supports(_ command: String) async -> Bool
     func invoke(_ request: BridgeInvokeRequest) async -> BridgeInvokeResponse
+    func handleInput(invokeId: String, seq: Int, payloadJSON: String) async
+    func cancel(invokeId: String) async
     func setRoute(_ route: GatewayNodeSessionRoute?, authorityGeneration: UInt64) async -> Bool
     func publishInventory(ifCurrentRoute route: GatewayNodeSessionRoute) async
     func stop() async
@@ -28,6 +30,13 @@ protocol MacNodeHostWorking: Sendable {
 /// and keeps TCC-sensitive execution behind the native exec-host socket.
 final class MacNodeHostWorker: MacNodeHostWorking, @unchecked Sendable {
     nonisolated static let defaultStartupTimeout: TimeInterval = 300
+    private static let maxPendingInvokeControlIDs = 32
+    private static let maxPendingInvokeControlsPerID = 64
+
+    private enum PendingInvokeControl {
+        case input(seq: Int, payloadJSON: String)
+        case cancel
+    }
 
     enum WorkerError: LocalizedError {
         case unavailable(String)
@@ -60,6 +69,8 @@ final class MacNodeHostWorker: MacNodeHostWorking, @unchecked Sendable {
     private var routeAuthorityGeneration: UInt64 = 0
     private var startContinuation: CheckedContinuation<MacNodeHostManifest, Error>?
     private var invokeContinuations: [String: CheckedContinuation<BridgeInvokeResponse, Never>] = [:]
+    private var pendingInvokeControls: [String: [PendingInvokeControl]] = [:]
+    private var pendingInvokeControlOrder: [String] = []
     private var startTimer: DispatchSourceTimer?
     private var eventDeliveryTask: Task<Void, Never>?
     private var inventoryPublicationTask: Task<Void, Never>?
@@ -131,11 +142,91 @@ final class MacNodeHostWorker: MacNodeHostWorking, @unchecked Sendable {
                         "type": "invoke",
                         "request": workerRequest,
                     ])
+                    for control in self.takePendingInvokeControlsLocked(invokeId: request.id) {
+                        try self.enqueueInvokeControlLocked(control, invokeId: request.id)
+                    }
                 } catch {
                     self.invokeContinuations.removeValue(forKey: request.id)?.resume(returning:
                         Self.unavailableResponse(request.id, "UNAVAILABLE: node-host worker write failed"))
                 }
             }
+        }
+    }
+
+    func handleInput(invokeId: String, seq: Int, payloadJSON: String) async {
+        await withCheckedContinuation { continuation in
+            self.queue.async {
+                let control = PendingInvokeControl.input(seq: seq, payloadJSON: payloadJSON)
+                if self.invokeContinuations[invokeId] != nil {
+                    try? self.enqueueInvokeControlLocked(control, invokeId: invokeId)
+                } else if self.process?.isRunning == true, self.manifest != nil {
+                    self.bufferInvokeControlLocked(control, invokeId: invokeId)
+                }
+                continuation.resume()
+            }
+        }
+    }
+
+    func cancel(invokeId: String) async {
+        await withCheckedContinuation { continuation in
+            self.queue.async {
+                let control = PendingInvokeControl.cancel
+                if self.invokeContinuations[invokeId] != nil {
+                    try? self.enqueueInvokeControlLocked(control, invokeId: invokeId)
+                } else if self.process?.isRunning == true, self.manifest != nil {
+                    self.bufferInvokeControlLocked(control, invokeId: invokeId)
+                }
+                continuation.resume()
+            }
+        }
+    }
+
+    private func bufferInvokeControlLocked(_ control: PendingInvokeControl, invokeId: String) {
+        // Gateway control events can overtake detached invoke dispatch. Keep the
+        // short race window bounded, then flush controls after the invoke frame.
+        if self.pendingInvokeControls[invokeId] == nil {
+            if self.pendingInvokeControlOrder.count >= Self.maxPendingInvokeControlIDs,
+               let oldest = self.pendingInvokeControlOrder.first
+            {
+                self.pendingInvokeControlOrder.removeFirst()
+                self.pendingInvokeControls.removeValue(forKey: oldest)
+            }
+            self.pendingInvokeControlOrder.append(invokeId)
+            self.pendingInvokeControls[invokeId] = []
+        }
+        var controls = self.pendingInvokeControls[invokeId] ?? []
+        if controls.contains(where: {
+            if case .cancel = $0 { return true }
+            return false
+        }) {
+            return
+        }
+        if controls.count >= Self.maxPendingInvokeControlsPerID {
+            controls.removeFirst()
+        }
+        controls.append(control)
+        self.pendingInvokeControls[invokeId] = controls
+    }
+
+    private func takePendingInvokeControlsLocked(invokeId: String) -> [PendingInvokeControl] {
+        self.pendingInvokeControlOrder.removeAll { $0 == invokeId }
+        return self.pendingInvokeControls.removeValue(forKey: invokeId) ?? []
+    }
+
+    private func enqueueInvokeControlLocked(_ control: PendingInvokeControl, invokeId: String) throws {
+        switch control {
+        case let .input(seq, payloadJSON):
+            try self.enqueueWriteLocked([
+                "type": "invoke-input",
+                "invokeId": invokeId,
+                "seq": seq,
+                "payloadJSON": payloadJSON,
+            ])
+        case .cancel:
+            try self.enqueueWriteLocked([
+                "type": "invoke-cancel",
+                "invokeId": invokeId,
+            ])
         }
     }
 
@@ -561,6 +652,8 @@ final class MacNodeHostWorker: MacNodeHostWorking, @unchecked Sendable {
         }
         let pending = self.invokeContinuations
         self.invokeContinuations.removeAll()
+        self.pendingInvokeControls.removeAll()
+        self.pendingInvokeControlOrder.removeAll()
         for (id, continuation) in pending {
             continuation.resume(returning: Self.unavailableResponse(id, "UNAVAILABLE: node-host worker stopped"))
         }

--- a/apps/macos/Sources/OpenClaw/NodeMode/MacNodeModeCoordinator.swift
+++ b/apps/macos/Sources/OpenClaw/NodeMode/MacNodeModeCoordinator.swift
@@ -683,6 +683,21 @@ final class MacNodeModeCoordinator: NSObject {
                 }
                 return await self.runtime.handleInvoke(req)
             },
+            onInvokeInput: { [weak self] input in
+                guard let self,
+                      await self.routeAuthorityAllowsInvoke(attempt.routeAuthorityGeneration)
+                else { return }
+                await self.nodeHostWorker?.handleInput(
+                    invokeId: input.id,
+                    seq: input.seq,
+                    payloadJSON: input.payloadjson)
+            },
+            onInvokeCancel: { [weak self] invokeId in
+                guard let self,
+                      await self.routeAuthorityAllowsInvoke(attempt.routeAuthorityGeneration)
+                else { return }
+                await self.nodeHostWorker?.cancel(invokeId: invokeId)
+            },
             onRouteInvalidated: { [weak self] in
                 await self?.invalidateRuntimeRoute(authorityGeneration: attempt.routeAuthorityGeneration)
             })

--- a/apps/macos/Tests/OpenClawIPCTests/MacNodeHostWorkerTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/MacNodeHostWorkerTests.swift
@@ -21,6 +21,9 @@ private actor StubMacNodeHostWorker: MacNodeHostWorking {
         return BridgeInvokeResponse(id: request.id, ok: true, payloadJSON: #"{"owner":"cli"}"#)
     }
 
+    func handleInput(invokeId _: String, seq _: Int, payloadJSON _: String) async {}
+    func cancel(invokeId _: String) async {}
+
     func setRoute(_: GatewayNodeSessionRoute?, authorityGeneration _: UInt64) async -> Bool { true }
     func publishInventory(ifCurrentRoute _: GatewayNodeSessionRoute) async {}
     func stop() async {}
@@ -95,6 +98,34 @@ struct MacNodeHostWorkerTests {
             paramsJSON: #"{"command":["/usr/bin/true"]}"#))
         #expect(response.ok)
         #expect(response.payload != nil)
+        await worker.stop()
+    }
+
+    @Test func `worker forwards terminal input and cancellation frames`() async throws {
+        let worker = MacNodeHostWorker(session: GatewayNodeSession())
+        let script = """
+        printf '%s\\n' '{"type":"ready","version":"test","manifest":{"caps":["terminal"],"commands":["codex.terminal.resume.v1"],"pathEnv":"/usr/bin:/bin"},"inventory":{"skills":null,"pluginTools":[]}}'
+        IFS= read -r invoke
+        IFS= read -r input
+        IFS= read -r cancel
+        printf '%s' "$invoke" | grep -q '"id":"terminal-1"' || exit 40
+        printf '%s' "$input" | grep -q '"type":"invoke-input"' || exit 41
+        printf '%s' "$input" | grep -q '"invokeId":"terminal-1"' || exit 42
+        printf '%s' "$input" | grep -q '"seq":7' || exit 43
+        printf '%s' "$cancel" | grep -q '"type":"invoke-cancel"' || exit 44
+        printf '%s' "$cancel" | grep -q '"invokeId":"terminal-1"' || exit 45
+        printf '%s\\n' '{"type":"invoke-result","result":{"id":"terminal-1","ok":true}}'
+        while IFS= read -r line; do :; done
+        """
+
+        _ = try await worker.start(command: ["/bin/sh", "-c", script])
+        await worker.handleInput(invokeId: "terminal-1", seq: 7, payloadJSON: #"{"data":"x"}"#)
+        await worker.cancel(invokeId: "terminal-1")
+        let response = await worker.invoke(BridgeInvokeRequest(
+            id: "terminal-1",
+            command: "codex.terminal.resume.v1"))
+
+        #expect(response.ok)
         await worker.stop()
     }
 

--- a/apps/macos/Tests/OpenClawIPCTests/MacNodeModeCoordinatorTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/MacNodeModeCoordinatorTests.swift
@@ -111,6 +111,9 @@ private actor CoordinatorNodeHostWorkerProbe: MacNodeHostWorking {
         BridgeInvokeResponse(id: request.id, ok: false)
     }
 
+    func handleInput(invokeId _: String, seq _: Int, payloadJSON _: String) async {}
+    func cancel(invokeId _: String) async {}
+
     func setRoute(_: GatewayNodeSessionRoute?, authorityGeneration _: UInt64) async -> Bool { true }
     func publishInventory(ifCurrentRoute _: GatewayNodeSessionRoute) async {}
     func stop() async { self.stopCount += 1 }

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayNodeSession.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayNodeSession.swift
@@ -12,6 +12,10 @@ private struct NodeInvokeRequestPayload: Codable {
     var idempotencyKey: String?
 }
 
+private struct NodeInvokeCancelPayload: Codable {
+    var invokeId: String
+}
+
 func canonicalizeCanvasHostUrl(raw: String?, activeURL: URL?) -> String? {
     let trimmed = raw?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
     guard !trimmed.isEmpty else { return nil }
@@ -165,6 +169,8 @@ public actor GatewayNodeSession {
     private var onConnected: (@Sendable () async -> Void)?
     private var onDisconnected: (@Sendable (String) async -> Void)?
     private var onInvoke: (@Sendable (BridgeInvokeRequest) async -> BridgeInvokeResponse)?
+    private var onInvokeInput: (@Sendable (NodeInvokeInputEvent) async -> Void)?
+    private var onInvokeCancel: (@Sendable (String) async -> Void)?
     private var onRouteInvalidated: (@Sendable () async -> Void)?
     private var hasEverConnected = false
     private var hasNotifiedConnected = false
@@ -335,6 +341,8 @@ public actor GatewayNodeSession {
         onConnected: @escaping @Sendable () async -> Void,
         onDisconnected: @escaping @Sendable (String) async -> Void,
         onInvoke: @escaping @Sendable (BridgeInvokeRequest) async -> BridgeInvokeResponse,
+        onInvokeInput: (@Sendable (NodeInvokeInputEvent) async -> Void)? = nil,
+        onInvokeCancel: (@Sendable (String) async -> Void)? = nil,
         onRouteInvalidated: (@Sendable () async -> Void)? = nil) async throws
     {
         let nextOptionsKey = self.connectOptionsKey(connectOptions)
@@ -404,6 +412,8 @@ public actor GatewayNodeSession {
             self.onConnected = onConnected
             self.onDisconnected = onDisconnected
             self.onInvoke = onInvoke
+            self.onInvokeInput = onInvokeInput
+            self.onInvokeCancel = onInvokeCancel
             self.onRouteInvalidated = onRouteInvalidated
             self.activeURL = url
             self.activeCredentials = credentials
@@ -415,6 +425,8 @@ public actor GatewayNodeSession {
             self.onConnected = onConnected
             self.onDisconnected = onDisconnected
             self.onInvoke = onInvoke
+            self.onInvokeInput = onInvokeInput
+            self.onInvokeCancel = onInvokeCancel
             self.onRouteInvalidated = onRouteInvalidated
         }
 
@@ -458,6 +470,8 @@ public actor GatewayNodeSession {
         onConnected: @escaping @Sendable () async -> Void,
         onDisconnected: @escaping @Sendable (String) async -> Void,
         onInvoke: @escaping @Sendable (BridgeInvokeRequest) async -> BridgeInvokeResponse,
+        onInvokeInput: (@Sendable (NodeInvokeInputEvent) async -> Void)? = nil,
+        onInvokeCancel: (@Sendable (String) async -> Void)? = nil,
         onRouteInvalidated: (@Sendable () async -> Void)? = nil) async throws
     {
         try await self.connect(
@@ -472,6 +486,8 @@ public actor GatewayNodeSession {
             onConnected: onConnected,
             onDisconnected: onDisconnected,
             onInvoke: onInvoke,
+            onInvokeInput: onInvokeInput,
+            onInvokeCancel: onInvokeCancel,
             onRouteInvalidated: onRouteInvalidated)
     }
 
@@ -507,6 +523,8 @@ public actor GatewayNodeSession {
         self.onConnected = nil
         self.onDisconnected = nil
         self.onInvoke = nil
+        self.onInvokeInput = nil
+        self.onInvokeCancel = nil
         self.onRouteInvalidated = nil
         self.activeSocketGeneration = nil
         self.lastRetiredSocketGeneration = nil
@@ -992,6 +1010,26 @@ extension GatewayNodeSession {
         socketGeneration: UInt64) async
     {
         self.broadcastServerEvent(evt)
+        if evt.event == "node.invoke.input" {
+            guard let payload = evt.payload, let onInvokeInput else { return }
+            do {
+                let input: NodeInvokeInputEvent = try self.decodeEventPayload(from: payload)
+                await onInvokeInput(input)
+            } catch {
+                self.logger.error("node invoke input decode failed: \(error.localizedDescription, privacy: .public)")
+            }
+            return
+        }
+        if evt.event == "node.invoke.cancel" {
+            guard let payload = evt.payload, let onInvokeCancel else { return }
+            do {
+                let cancel: NodeInvokeCancelPayload = try self.decodeEventPayload(from: payload)
+                await onInvokeCancel(cancel.invokeId)
+            } catch {
+                self.logger.error("node invoke cancel decode failed: \(error.localizedDescription, privacy: .public)")
+            }
+            return
+        }
         guard evt.event == "node.invoke.request" else { return }
         self.logger.info("node invoke request received")
         guard let payload = evt.payload else { return }
@@ -1442,12 +1480,16 @@ extension GatewayNodeSession {
     }
 
     private func decodeInvokeRequest(from payload: OpenClawProtocol.AnyCodable) throws -> NodeInvokeRequestPayload {
+        try self.decodeEventPayload(from: payload)
+    }
+
+    private func decodeEventPayload<T: Decodable>(from payload: OpenClawProtocol.AnyCodable) throws -> T {
         do {
             let data = try encoder.encode(payload)
-            return try self.decoder.decode(NodeInvokeRequestPayload.self, from: data)
+            return try self.decoder.decode(T.self, from: data)
         } catch {
             if let raw = payload.value as? String, let data = raw.data(using: .utf8) {
-                return try self.decoder.decode(NodeInvokeRequestPayload.self, from: data)
+                return try self.decoder.decode(T.self, from: data)
             }
             throw error
         }

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayNodeSessionTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayNodeSessionTests.swift
@@ -571,6 +571,23 @@ private actor ComputerInvokeProbe {
     }
 }
 
+private actor NodeInvokeControlProbe {
+    private var inputs: [NodeInvokeInputEvent] = []
+    private var cancellations: [String] = []
+
+    func recordInput(_ input: NodeInvokeInputEvent) {
+        self.inputs.append(input)
+    }
+
+    func recordCancellation(_ invokeId: String) {
+        self.cancellations.append(invokeId)
+    }
+
+    func values() -> ([String], [String]) {
+        (self.inputs.map { "\($0.id):\($0.seq):\($0.payloadjson)" }, self.cancellations)
+    }
+}
+
 private func nodeInvokePush(id: String, command: String) -> GatewayPush {
     .event(EventFrame(
         type: "event",
@@ -587,6 +604,59 @@ private func nodeInvokePush(id: String, command: String) -> GatewayPush {
 
 @Suite(.serialized)
 struct GatewayNodeSessionTests {
+    @Test func `node invoke input and cancellation reach route callbacks`() async throws {
+        let session = FakeGatewayWebSocketSession()
+        let gateway = GatewayNodeSession()
+        let probe = NodeInvokeControlProbe()
+        let options = GatewayConnectOptions(
+            role: "node",
+            scopes: [],
+            caps: ["terminal"],
+            commands: ["codex.terminal.resume.v1"],
+            permissions: [:],
+            clientId: "openclaw-macos",
+            clientMode: "node",
+            clientDisplayName: "macOS Test",
+            includeDeviceIdentity: false)
+
+        try await gateway.connect(
+            url: #require(URL(string: "ws://gateway.example.invalid")),
+            connectOptions: options,
+            sessionBox: WebSocketSessionBox(session: session),
+            onConnected: {},
+            onDisconnected: { _ in },
+            onInvoke: { request in BridgeInvokeResponse(id: request.id, ok: true) },
+            onInvokeInput: { input in await probe.recordInput(input) },
+            onInvokeCancel: { invokeId in await probe.recordCancellation(invokeId) })
+
+        await gateway._test_handlePush(
+            .event(EventFrame(
+                type: "event",
+                event: "node.invoke.input",
+                payload: AnyCodable([
+                    "id": AnyCodable("terminal-1"),
+                    "nodeId": AnyCodable("test-node"),
+                    "seq": AnyCodable(3),
+                    "payloadJSON": AnyCodable(#"{"data":"hello"}"#),
+                ]),
+                seq: nil,
+                stateversion: nil)),
+            socketGeneration: 1)
+        await gateway._test_handlePush(
+            .event(EventFrame(
+                type: "event",
+                event: "node.invoke.cancel",
+                payload: AnyCodable(["invokeId": AnyCodable("terminal-1")]),
+                seq: nil,
+                stateversion: nil)),
+            socketGeneration: 1)
+
+        let values = await probe.values()
+        #expect(values.0 == [#"terminal-1:3:{"data":"hello"}"#])
+        #expect(values.1 == ["terminal-1"])
+        await gateway.disconnect()
+    }
+
     @Test func `node connections use the node protocol floor`() {
         #expect(
             GatewayChannelActor.minimumProtocolVersion(role: "node", clientMode: "node") ==

--- a/scripts/protocol-event-coverage.allowlist.json
+++ b/scripts/protocol-event-coverage.allowlist.json
@@ -20,9 +20,7 @@
     "terminal.data": "Embedded terminal is a web/desktop surface; iOS has no terminal client.",
     "terminal.exit": "Embedded terminal is a web/desktop surface; iOS has no terminal client.",
     "update.available": "Gateway self-update notices do not apply to iOS; app updates ship via the App Store.",
-    "session.approval": "Native approval review uses exec.approval push/nudge delivery; the session-scoped approval stream is a Control UI chat surface.",
-    "node.invoke.cancel": "Cancel targets streaming agent.cli.claude.run.v1 invokes; app nodes never advertise agent runs, so no cancel can address them.",
-    "node.invoke.input": "Carries terminal keystrokes/resize to a node PTY relay invoke; the relay runs on gateway/CLI node hosts and app nodes never host it, so iOS has no consumer."
+    "session.approval": "Native approval review uses exec.approval push/nudge delivery; the session-scoped approval stream is a Control UI chat surface."
   },
   "android": {
     "session.operation": "Chat UI derives run state from chat/agent events; no session.operation consumer yet.",

--- a/src/node-host/runtime.test.ts
+++ b/src/node-host/runtime.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawPluginNodeHostCommandIo } from "../plugins/types.js";
 import type { NodeHostClient } from "./client.js";
+import { listRegisteredNodeHostCapsAndCommands } from "./plugin-node-host.js";
 import { prepareNodeHostRuntime } from "./runtime.js";
 
 const mocks = vi.hoisted(() => ({
@@ -148,5 +149,20 @@ describe("node-host invoke input dispatch", () => {
     held.release();
     await invoking;
     await runtime.close();
+  });
+});
+
+describe("node-host duplex capability selection", () => {
+  it("advertises duplex plugin commands without enabling native agent runs", async () => {
+    await prepareNodeHostRuntime({
+      config: { nodeHost: { skills: { enabled: false } } },
+      env: { PATH: "/usr/bin" },
+      enableDuplexPluginCommands: true,
+    });
+
+    expect(listRegisteredNodeHostCapsAndCommands).toHaveBeenLastCalledWith(
+      expect.anything(),
+      { includeDuplex: true },
+    );
   });
 });

--- a/src/node-host/runtime.ts
+++ b/src/node-host/runtime.ts
@@ -221,13 +221,16 @@ export async function prepareNodeHostRuntime(params?: {
   env?: NodeJS.ProcessEnv;
   /** The embedded app worker never advertises native agent runs. */
   enableAgentRuns?: boolean;
+  /** Embedded workers may still host long-lived plugin commands over the app-owned socket. */
+  enableDuplexPluginCommands?: boolean;
 }): Promise<PreparedNodeHostRuntime> {
   const config = params?.config ?? getRuntimeConfig();
   const env = params?.env ?? process.env;
   await ensureNodeHostPluginRegistry({ config, env });
   const pathEnv = ensureNodePathEnv();
   env.PATH = pathEnv;
-  const duplexEnabled = params?.enableAgentRuns === true;
+  const duplexEnabled =
+    params?.enableAgentRuns === true || params?.enableDuplexPluginCommands === true;
   const pluginNodeHost = listRegisteredNodeHostCapsAndCommands(
     { config, env },
     { includeDuplex: duplexEnabled },

--- a/src/node-host/worker-support.ts
+++ b/src/node-host/worker-support.ts
@@ -1,9 +1,71 @@
 import type { GatewayClientRequestOptions } from "../gateway/client.js";
 import type { NodeHostClient } from "./client.js";
+import type { NodeInvokeRequestPayload } from "./invoke.js";
 
-export type NodeHostWorkerGatewayResponse =
+type NodeHostWorkerGatewayResponse =
   | { type: "gateway-response"; id: string; ok: true; result: unknown }
   | { type: "gateway-response"; id: string; ok: false; error: string };
+
+type NodeHostWorkerInput =
+  | { type: "invoke"; request: NodeInvokeRequestPayload }
+  | { type: "invoke-input"; invokeId: string; seq: number; payloadJSON: string }
+  | { type: "invoke-cancel"; invokeId: string }
+  | NodeHostWorkerGatewayResponse
+  | { type: "stop" };
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+export function parseNodeHostWorkerInput(line: string): NodeHostWorkerInput | null {
+  try {
+    const parsed = asRecord(JSON.parse(line));
+    const type = typeof parsed?.type === "string" ? parsed.type : "";
+    if (type === "invoke") {
+      const request = asRecord(parsed?.request);
+      if (
+        request &&
+        typeof request.id === "string" &&
+        typeof request.nodeId === "string" &&
+        typeof request.command === "string"
+      ) {
+        return { type, request: request as NodeInvokeRequestPayload };
+      }
+      return null;
+    }
+    if (type === "gateway-response") {
+      const id = typeof parsed?.id === "string" ? parsed.id : "";
+      if (!id) {
+        return null;
+      }
+      return parsed?.ok === true
+        ? { type, id, ok: true, result: parsed.result }
+        : {
+            type,
+            id,
+            ok: false,
+            error: typeof parsed?.error === "string" ? parsed.error : "Gateway request failed",
+          };
+    }
+    if (type === "invoke-input") {
+      const invokeId = typeof parsed?.invokeId === "string" ? parsed.invokeId : "";
+      const seq = typeof parsed?.seq === "number" ? parsed.seq : -1;
+      const payloadJSON = typeof parsed?.payloadJSON === "string" ? parsed.payloadJSON : null;
+      return invokeId && Number.isInteger(seq) && seq >= 0 && payloadJSON !== null
+        ? { type, invokeId, seq, payloadJSON }
+        : null;
+    }
+    if (type === "invoke-cancel") {
+      const invokeId = typeof parsed?.invokeId === "string" ? parsed.invokeId : "";
+      return invokeId ? { type, invokeId } : null;
+    }
+    return type === "stop" ? { type } : null;
+  } catch {
+    return null;
+  }
+}
 
 type PendingGatewayRequest = {
   resolve: (value: unknown) => void;

--- a/src/node-host/worker.test.ts
+++ b/src/node-host/worker.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { NodeHostWorkerBridgeClient, stopNodeHostWorkerFromSignal } from "./worker-support.js";
-import { parseNodeHostWorkerInput } from "./worker.js";
+import {
+  NodeHostWorkerBridgeClient,
+  parseNodeHostWorkerInput,
+  stopNodeHostWorkerFromSignal,
+} from "./worker-support.js";
 
 describe("parseNodeHostWorkerInput", () => {
   it("accepts ordered input and cancel control frames", () => {

--- a/src/node-host/worker.test.ts
+++ b/src/node-host/worker.test.ts
@@ -1,5 +1,28 @@
 import { describe, expect, it } from "vitest";
 import { NodeHostWorkerBridgeClient, stopNodeHostWorkerFromSignal } from "./worker-support.js";
+import { parseNodeHostWorkerInput } from "./worker.js";
+
+describe("parseNodeHostWorkerInput", () => {
+  it("accepts ordered input and cancel control frames", () => {
+    expect(
+      parseNodeHostWorkerInput(
+        JSON.stringify({ type: "invoke-input", invokeId: "invoke-1", seq: 2, payloadJSON: "x" }),
+      ),
+    ).toEqual({ type: "invoke-input", invokeId: "invoke-1", seq: 2, payloadJSON: "x" });
+    expect(
+      parseNodeHostWorkerInput(JSON.stringify({ type: "invoke-cancel", invokeId: "invoke-1" })),
+    ).toEqual({ type: "invoke-cancel", invokeId: "invoke-1" });
+  });
+
+  it("rejects malformed duplex control frames", () => {
+    expect(
+      parseNodeHostWorkerInput(
+        JSON.stringify({ type: "invoke-input", invokeId: "invoke-1", seq: -1, payloadJSON: "x" }),
+      ),
+    ).toBeNull();
+    expect(parseNodeHostWorkerInput(JSON.stringify({ type: "invoke-cancel", invokeId: "" }))).toBeNull();
+  });
+});
 
 describe("NodeHostWorkerBridgeClient", () => {
   it("forwards invoke results and events without creating gateway request waits", async () => {

--- a/src/node-host/worker.ts
+++ b/src/node-host/worker.ts
@@ -11,6 +11,8 @@ import {
 
 type WorkerInput =
   | { type: "invoke"; request: NodeInvokeRequestPayload }
+  | { type: "invoke-input"; invokeId: string; seq: number; payloadJSON: string }
+  | { type: "invoke-cancel"; invokeId: string }
   | NodeHostWorkerGatewayResponse
   | { type: "stop" };
 
@@ -24,7 +26,7 @@ function writeMessage(message: unknown): void {
   process.stdout.write(`${JSON.stringify(message)}\n`);
 }
 
-function parseInput(line: string): WorkerInput | null {
+export function parseNodeHostWorkerInput(line: string): WorkerInput | null {
   try {
     const parsed = asRecord(JSON.parse(line));
     const type = typeof parsed?.type === "string" ? parsed.type : "";
@@ -54,6 +56,18 @@ function parseInput(line: string): WorkerInput | null {
             error: typeof parsed?.error === "string" ? parsed.error : "Gateway request failed",
           };
     }
+    if (type === "invoke-input") {
+      const invokeId = typeof parsed?.invokeId === "string" ? parsed.invokeId : "";
+      const seq = typeof parsed?.seq === "number" ? parsed.seq : -1;
+      const payloadJSON = typeof parsed?.payloadJSON === "string" ? parsed.payloadJSON : null;
+      return invokeId && Number.isInteger(seq) && seq >= 0 && payloadJSON !== null
+        ? { type, invokeId, seq, payloadJSON }
+        : null;
+    }
+    if (type === "invoke-cancel") {
+      const invokeId = typeof parsed?.invokeId === "string" ? parsed.invokeId : "";
+      return invokeId ? { type, invokeId } : null;
+    }
     return type === "stop" ? { type } : null;
   } catch {
     return null;
@@ -65,7 +79,7 @@ function emitInventory(inventory: NodeHostInventory): void {
 }
 
 export async function runNodeHostWorker(): Promise<void> {
-  const prepared = await prepareNodeHostRuntime();
+  const prepared = await prepareNodeHostRuntime({ enableDuplexPluginCommands: true });
   const client = new NodeHostWorkerBridgeClient(writeMessage);
   let stopping = false;
   let resolveStopped: (() => void) | undefined;
@@ -97,7 +111,7 @@ export async function runNodeHostWorker(): Promise<void> {
 
   const input = createInterface({ input: process.stdin, crlfDelay: Infinity });
   input.on("line", (line) => {
-    const message = parseInput(line);
+    const message = parseNodeHostWorkerInput(line);
     if (!message) {
       writeMessage({ type: "protocol-error", error: "invalid worker request" });
       return;
@@ -109,6 +123,14 @@ export async function runNodeHostWorker(): Promise<void> {
     if (message.type === "stop") {
       input.close();
       void stop(0);
+      return;
+    }
+    if (message.type === "invoke-input") {
+      runtime.handleInput(message.invokeId, message.seq, message.payloadJSON);
+      return;
+    }
+    if (message.type === "invoke-cancel") {
+      runtime.cancel(message.invokeId);
       return;
     }
     void runtime.invoke(message.request);

--- a/src/node-host/worker.ts
+++ b/src/node-host/worker.ts
@@ -1,77 +1,15 @@
 /** Private JSONL worker exposing the CLI node-host runtime to the macOS app. */
 import { createInterface } from "node:readline";
 import { VERSION } from "../version.js";
-import type { NodeInvokeRequestPayload } from "./invoke.js";
 import { prepareNodeHostRuntime, type NodeHostInventory } from "./runtime.js";
 import {
   NodeHostWorkerBridgeClient,
-  type NodeHostWorkerGatewayResponse,
+  parseNodeHostWorkerInput,
   stopNodeHostWorkerFromSignal,
 } from "./worker-support.js";
 
-type WorkerInput =
-  | { type: "invoke"; request: NodeInvokeRequestPayload }
-  | { type: "invoke-input"; invokeId: string; seq: number; payloadJSON: string }
-  | { type: "invoke-cancel"; invokeId: string }
-  | NodeHostWorkerGatewayResponse
-  | { type: "stop" };
-
-function asRecord(value: unknown): Record<string, unknown> | null {
-  return value && typeof value === "object" && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : null;
-}
-
 function writeMessage(message: unknown): void {
   process.stdout.write(`${JSON.stringify(message)}\n`);
-}
-
-export function parseNodeHostWorkerInput(line: string): WorkerInput | null {
-  try {
-    const parsed = asRecord(JSON.parse(line));
-    const type = typeof parsed?.type === "string" ? parsed.type : "";
-    if (type === "invoke") {
-      const request = asRecord(parsed?.request);
-      if (
-        request &&
-        typeof request.id === "string" &&
-        typeof request.nodeId === "string" &&
-        typeof request.command === "string"
-      ) {
-        return { type, request: request as NodeInvokeRequestPayload };
-      }
-      return null;
-    }
-    if (type === "gateway-response") {
-      const id = typeof parsed?.id === "string" ? parsed.id : "";
-      if (!id) {
-        return null;
-      }
-      return parsed?.ok === true
-        ? { type, id, ok: true, result: parsed.result }
-        : {
-            type,
-            id,
-            ok: false,
-            error: typeof parsed?.error === "string" ? parsed.error : "Gateway request failed",
-          };
-    }
-    if (type === "invoke-input") {
-      const invokeId = typeof parsed?.invokeId === "string" ? parsed.invokeId : "";
-      const seq = typeof parsed?.seq === "number" ? parsed.seq : -1;
-      const payloadJSON = typeof parsed?.payloadJSON === "string" ? parsed.payloadJSON : null;
-      return invokeId && Number.isInteger(seq) && seq >= 0 && payloadJSON !== null
-        ? { type, invokeId, seq, payloadJSON }
-        : null;
-    }
-    if (type === "invoke-cancel") {
-      const invokeId = typeof parsed?.invokeId === "string" ? parsed.invokeId : "";
-      return invokeId ? { type, invokeId } : null;
-    }
-    return type === "stop" ? { type } : null;
-  } catch {
-    return null;
-  }
 }
 
 function emitInventory(inventory: NodeHostInventory): void {


### PR DESCRIPTION
Closes #107335

## What Problem This Solves

Fixes an issue where users viewing a Codex or Claude session owned by a paired macOS node would see **Open in terminal** disabled even though the owning Mac could resume the session.

## Why This Change Was Made

The embedded macOS node worker now advertises duplex plugin commands independently from native agent runs. Gateway input and cancellation events cross the native bridge, with bounded pre-invoke buffering that preserves invoke-before-control ordering.

## User Impact

Codex and Claude sessions connected through a paired Mac node can be opened and controlled in the native terminal from the Control UI.

## Evidence

- `pnpm test src/node-host/runtime.test.ts src/node-host/worker.test.ts` on Blacksmith Testbox `tbx_01kxfzfavhr6x01yg1632r3mxt`: 10 tests passed.
- `swift test --package-path apps/shared/OpenClawKit --filter 'node invoke input and cancellation reach route callbacks'`: passed.
- `swift test --package-path apps/macos --filter MacNodeHostWorkerTests`: 9 tests passed.
- Structured Codex autoreview: clean after fixing invoke/control ordering.

AI-assisted. I reviewed the implementation and understand the bridge and ordering behavior.
