### PR TITLE
fix: block unresolved Telegram reply targets

### DIFF
--- a/src/auto-reply/reply/get-reply-run.reply-target-preflight.test.ts
+++ b/src/auto-reply/reply/get-reply-run.reply-target-preflight.test.ts
@@ -1,0 +1,64 @@
+// Tests preflight handling for Telegram replies whose target context was not recovered.
+import { describe, expect, it } from "vitest";
+import type { TemplateContext } from "../templating.js";
+import { shouldBlockUnresolvedTelegramReplyTarget } from "./get-reply-run.js";
+
+describe("shouldBlockUnresolvedTelegramReplyTarget", () => {
+  it("blocks Telegram replies when only the unsupported rich-message placeholder was recovered", () => {
+    expect(
+      shouldBlockUnresolvedTelegramReplyTarget({
+        OriginatingChannel: "telegram",
+        Provider: "telegram",
+        Surface: "telegram",
+        ReplyToId: "14112",
+        ReplyToBody: "[unsupported Telegram rich_message received]",
+      } as TemplateContext),
+    ).toBe(true);
+  });
+
+  it("allows Telegram replies when the replied-to body is usable", () => {
+    expect(
+      shouldBlockUnresolvedTelegramReplyTarget({
+        OriginatingChannel: "telegram",
+        ReplyToId: "14112",
+        ReplyToBody: "FLOW: Daily UK visa policy change watch",
+      } as TemplateContext),
+    ).toBe(false);
+  });
+
+  it("allows Telegram replies when the selected chat window contains the reply target", () => {
+    expect(
+      shouldBlockUnresolvedTelegramReplyTarget({
+        OriginatingChannel: "telegram",
+        ReplyToId: "14112",
+        UntrustedStructuredContext: [
+          {
+            label: "Nearby reply target window",
+            source: "telegram",
+            type: "chat_window",
+            payload: {
+              relation: "selected_for_current_message",
+              messages: [
+                {
+                  message_id: "14112",
+                  body: "FLOW: Daily UK visa policy change watch",
+                  is_reply_target: true,
+                },
+              ],
+            },
+          },
+        ],
+      } as TemplateContext),
+    ).toBe(false);
+  });
+
+  it("does not block non-Telegram reply targets", () => {
+    expect(
+      shouldBlockUnresolvedTelegramReplyTarget({
+        OriginatingChannel: "discord",
+        ReplyToId: "msg-1",
+        ReplyToBody: "[unsupported Telegram rich_message received]",
+      } as TemplateContext),
+    ).toBe(false);
+  });
+});

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -433,6 +433,82 @@ function hasReplyTargetContext(ctx: MsgContext | TemplateContext): boolean {
   return Array.isArray(replyChain) && replyChain.length > 0;
 }
 
+const TELEGRAM_UNSUPPORTED_RICH_MESSAGE_PLACEHOLDER =
+  "[unsupported Telegram rich_message received]";
+
+function isUsableReplyTargetText(value: unknown): boolean {
+  const text = normalizeOptionalString(typeof value === "string" ? value : undefined);
+  return Boolean(text && text !== TELEGRAM_UNSUPPORTED_RICH_MESSAGE_PLACEHOLDER);
+}
+
+function hasUsableReplyTargetContext(ctx: MsgContext | TemplateContext): boolean {
+  if (isUsableReplyTargetText(ctx.ReplyToBody)) {
+    return true;
+  }
+  const replyChain = (ctx as { ReplyChain?: unknown }).ReplyChain;
+  if (
+    Array.isArray(replyChain) &&
+    replyChain.some((entry) => {
+      if (!entry || typeof entry !== "object") {
+        return false;
+      }
+      return isUsableReplyTargetText((entry as { body?: unknown }).body);
+    })
+  ) {
+    return true;
+  }
+  const structuredContext = (ctx as { UntrustedStructuredContext?: unknown })
+    .UntrustedStructuredContext;
+  if (!Array.isArray(structuredContext)) {
+    return false;
+  }
+  return structuredContext.some((entry) => {
+    if (!entry || typeof entry !== "object") {
+      return false;
+    }
+    const payload = (entry as { payload?: unknown; type?: unknown }).payload;
+    if (
+      (entry as { type?: unknown }).type !== "chat_window" ||
+      !payload ||
+      typeof payload !== "object"
+    ) {
+      return false;
+    }
+    const messages = (payload as { messages?: unknown }).messages;
+    return (
+      Array.isArray(messages) &&
+      messages.some((message) => {
+        if (!message || typeof message !== "object") {
+          return false;
+        }
+        return (
+          (message as { is_reply_target?: unknown }).is_reply_target === true &&
+          isUsableReplyTargetText((message as { body?: unknown }).body)
+        );
+      })
+    );
+  });
+}
+
+export function shouldBlockUnresolvedTelegramReplyTarget(
+  ctx: MsgContext | TemplateContext,
+): boolean {
+  const channel = normalizeOptionalString(ctx.OriginatingChannel);
+  const provider = normalizeOptionalString(ctx.Provider);
+  const surface = normalizeOptionalString(ctx.Surface);
+  const isTelegram = channel === "telegram" || provider === "telegram" || surface === "telegram";
+  return Boolean(
+    isTelegram && normalizeOptionalString(ctx.ReplyToId) && !hasUsableReplyTargetContext(ctx),
+  );
+}
+
+function buildUnresolvedTelegramReplyTargetResponse(ctx: MsgContext | TemplateContext): string {
+  const replyToId = normalizeOptionalString(ctx.ReplyToId);
+  return replyToId
+    ? `I can’t recover the replied-to Telegram message (${replyToId}), so I’m not going to guess from nearby chat context. Please resend the message or quote the relevant context.`
+    : "I can’t recover the replied-to Telegram message, so I’m not going to guess from nearby chat context. Please resend the message or quote the relevant context.";
+}
+
 type RunPreparedReplyParams = {
   ctx: MsgContext;
   sessionCtx: TemplateContext;
@@ -712,6 +788,17 @@ export async function runPreparedReply(
   const effectiveResetTriggered = resetTriggered || softResetTriggered;
   const hasCurrentReplyTargetContext =
     hasReplyTargetContext(ctx) || hasReplyTargetContext(sessionCtx);
+  if (
+    shouldBlockUnresolvedTelegramReplyTarget(ctx) ||
+    shouldBlockUnresolvedTelegramReplyTarget(sessionCtx)
+  ) {
+    typing.cleanup();
+    return {
+      text: buildUnresolvedTelegramReplyTargetResponse(
+        shouldBlockUnresolvedTelegramReplyTarget(ctx) ? ctx : sessionCtx,
+      ),
+    };
+  }
   const isWholeMessageCommand =
     normalizedCommandBody === rawBodyTrimmed ||
     normalizedCommandBody === rawBodyTrimmed.toLowerCase();


### PR DESCRIPTION
## Summary

Adds a Telegram reply-target preflight so OpenClaw does not start an agent turn when Telegram reports a reply target but the assembled context did not recover usable replied-to content.

The guard treats `[unsupported Telegram rich_message received]` as unresolved context rather than as a usable reply body. In that case, the runner returns a clarification instead of letting the model infer intent from nearby conversation history.

## What Problem This Solves

A user can reply to an older bot/flow message, but if the replied-to message is represented only as an unsupported rich-message placeholder, the agent may answer using nearby context from a different message. This is especially risky for short replies like “what changed?”, “do it”, “1”, or “3”.

Expected behavior: if `ReplyToId` exists for a Telegram turn, OpenClaw should either provide usable replied-to context to the agent or block and ask for the missing context. It should not guess from nearby messages.

## Behavior

- Blocks Telegram turns with `ReplyToId` when the only reply body is `[unsupported Telegram rich_message received]`.
- Allows Telegram turns when `ReplyToBody` has usable text.
- Allows Telegram turns when a selected chat-window structured context includes the reply target with usable text.
- Does not affect non-Telegram channels.

## Evidence

Focused regression coverage was added in `src/auto-reply/reply/get-reply-run.reply-target-preflight.test.ts` for the unresolved Telegram rich-message placeholder shape and the allowed cases where reply context is usable.

Local verification:

```text
node scripts/run-vitest.mjs src/auto-reply/reply/get-reply-run.reply-target-preflight.test.ts

Test Files  1 passed (1)
Tests       4 passed (4)
```

Additional local checks:

```text
CI=true pnpm install --frozen-lockfile
pnpm format src/auto-reply/reply/get-reply-run.ts src/auto-reply/reply/get-reply-run.reply-target-preflight.test.ts
git diff --check
node scripts/run-oxlint.mjs src/auto-reply/reply/get-reply-run.ts src/auto-reply/reply/get-reply-run.reply-target-preflight.test.ts
```

All passed locally. `pnpm install` and `pnpm format` printed the local Node engine warning because this machine is on `node v25.6.1` while the repo declares a narrower supported range.

## Related

This complements #90745, which carries reply metadata through runtime context. This PR adds a concrete preflight for the unresolved-target case where metadata exists but the target body/window is not usable enough to answer safely.
