### PR TITLE
refactor(plugins): match Jiti callable contract

### DIFF
--- a/src/plugins/plugin-module-loader-cache.test.ts
+++ b/src/plugins/plugin-module-loader-cache.test.ts
@@ -780,33 +780,4 @@ describe("getCachedPluginModuleLoader", () => {
       "file:///C:/Users/alice/openclaw/extensions/feishu/api.ts",
     );
   });
-
-  it("forwards extra loader arguments through to the source-transform fallback", async () => {
-    const fromSourceTransformer = vi.fn(() => ({ fromSourceTransform: true }));
-    const createJiti = vi.fn(() => fromSourceTransformer);
-    vi.doMock("./native-module-require.js", () => ({
-      isJavaScriptModulePath: () => true,
-      tryNativeRequireJavaScriptModule: () => ({ ok: false }),
-    }));
-    const { getCachedPluginModuleLoader } = await importFreshModule<
-      typeof import("./plugin-module-loader-cache.js")
-    >(import.meta.url, "./plugin-module-loader-cache.js?scope=native-require-rest-args");
-
-    const cache = new Map();
-    const loader = getCachedPluginModuleLoader({
-      cache,
-      modulePath: "/repo/dist/extensions/demo/api.js",
-      importerUrl: "file:///repo/src/plugins/public-surface-loader.ts",
-      loaderFilename: "file:///repo/src/plugins/public-surface-loader.ts",
-      createLoader: asPluginModuleLoaderFactory(createJiti),
-    });
-
-    const loose = loader as unknown as (t: string, ...a: unknown[]) => unknown;
-    loose("/repo/dist/extensions/demo/api.js", { hint: "x" }, 42);
-    expect(fromSourceTransformer).toHaveBeenCalledWith(
-      "/repo/dist/extensions/demo/api.js",
-      { hint: "x" },
-      42,
-    );
-  });
 });

--- a/src/plugins/plugin-module-loader-cache.ts
+++ b/src/plugins/plugin-module-loader-cache.ts
@@ -15,7 +15,7 @@ import {
 } from "./sdk-alias.js";
 
 /** Jiti-based module loader used for plugin source/runtime imports. */
-type PluginModuleLoader = ReturnType<typeof createJiti>;
+type PluginModuleLoader = (target: string) => unknown;
 export type PluginModuleLoaderFactory = typeof createJiti;
 export type PluginModuleLoaderCache = Pick<
   PluginLruCache<PluginModuleLoader>,
@@ -205,18 +205,7 @@ function createLazySourceTransformLoader(params: {
         tryNative: false,
       },
     );
-    loadWithSourceTransform = new Proxy(jitiLoader, {
-      apply(target, thisArg, argArray) {
-        const [first, ...rest] = argArray as [unknown, ...unknown[]];
-        if (typeof first === "string") {
-          return Reflect.apply(target, thisArg, [
-            toSourceTransformImportPath(first),
-            ...rest,
-          ] as never) as never;
-        }
-        return Reflect.apply(target, thisArg, argArray as never) as never;
-      },
-    });
+    loadWithSourceTransform = (target) => jitiLoader(toSourceTransformImportPath(target));
     return loadWithSourceTransform;
   };
 }
@@ -234,10 +223,7 @@ function createPluginModuleLoader(params: {
     ...params,
   });
   const loadedTargetExports = new Map<string, unknown>();
-  const loadCachedTarget = (target: string, rest: unknown[], load: () => unknown): unknown => {
-    if (rest.length > 0) {
-      return load();
-    }
+  const loadCachedTarget = (target: string, load: () => unknown): unknown => {
     if (loadedTargetExports.has(target)) {
       return loadedTargetExports.get(target);
     }
@@ -250,17 +236,13 @@ function createPluginModuleLoader(params: {
   // jiti's alias rewriting to surface a narrow SDK slice), route every
   // target through jiti so those alias rewrites still apply.
   if (!params.tryNative) {
-    return ((target: string, ...rest: unknown[]) => {
-      return loadCachedTarget(target, rest, () => {
+    return (target) =>
+      loadCachedTarget(target, () => {
         pluginModuleLoaderStats.calls += 1;
         pluginModuleLoaderStats.sourceTransformForced += 1;
         recordSourceTransformTarget(target);
-        return (getLoadWithSourceTransform() as (t: string, ...a: unknown[]) => unknown)(
-          target,
-          ...rest,
-        );
+        return getLoadWithSourceTransform()(target);
       });
-    }) as PluginModuleLoader;
   }
   // Otherwise prefer native require() for already-compiled JS artifacts
   // (the bundled plugin public surfaces shipped in dist/). jiti's transform
@@ -269,8 +251,8 @@ function createPluginModuleLoader(params: {
   // for TS / TSX sources and for the small set of require(esm) /
   // async-module fallbacks `tryNativeRequireJavaScriptModule` declines to
   // handle.
-  return ((target: string, ...rest: unknown[]) => {
-    return loadCachedTarget(target, rest, () => {
+  return (target) =>
+    loadCachedTarget(target, () => {
       pluginModuleLoaderStats.calls += 1;
       const native = tryNativeRequireJavaScriptModule(target, {
         allowWindows: true,
@@ -285,12 +267,8 @@ function createPluginModuleLoader(params: {
       pluginModuleLoaderStats.nativeMisses += 1;
       pluginModuleLoaderStats.sourceTransformFallbacks += 1;
       recordSourceTransformTarget(target);
-      return (getLoadWithSourceTransform() as (t: string, ...a: unknown[]) => unknown)(
-        target,
-        ...rest,
-      );
+      return getLoadWithSourceTransform()(target);
     });
-  }) as PluginModuleLoader;
 }
 
 export function getCachedPluginModuleLoader(


### PR DESCRIPTION
## What Problem This Solves

The cached plugin loader preserved a fictional variadic call contract around Jiti, including a Proxy, extra-argument forwarding, and cache bypasses. Jiti's callable API accepts one module id, and all production callers already use that contract.

## Why This Change Was Made

Narrowing the internal loader to `(target: string) => unknown` lets the source-transform and native-fallback paths call Jiti directly. This removes unsupported compatibility code while retaining lazy construction, Windows path normalization, module caching, loader statistics, and native fallback behavior.

## User Impact

No behavior change for supported plugin loading. Source and built plugin modules continue to load through the same native/Jiti selection and cache paths.

## Evidence

- `node scripts/run-vitest.mjs src/plugins/plugin-module-loader-cache.test.ts src/channels/plugins/module-loader.test.ts src/plugin-sdk/facade-loader.test.ts src/plugins/public-surface-loader.test.ts` — 4 files, 36 tests passed
- Testbox `tbx_01kxg20vc8p6thd5yta55q4r5p`: `corepack pnpm build` passed ([run](https://github.com/openclaw/openclaw/actions/runs/29324734720))
- `git diff --check`
- Fresh local autoreview: no actionable findings, 0.93 confidence
- Net reduction: 51 lines
