### PR TITLE
fix(reef): send through the connected gateway

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Reef outbound delivery:** keep Reef outbound on the canonical channel plugin and execute sends in the Gateway process that owns the live encrypted transport, preventing connected channels from reporting `Reef channel is not running`.
 - **Sandbox recreate confirmation:** treat Clack cancellation as a decline so Ctrl-C cannot proceed with container removal.
 - **Microsoft Teams HTML text:** decode HTML5 entities consistently in quoted and Graph-fetched messages while preserving literal escaped entity text.
 - **ClawHub plugin API ranges:** delegate each supported comparator to `semver` so tilde, partial-wildcard, and prerelease caret bounds are correct while preserving OpenClaw version normalization and the existing restricted range grammar. (#106877)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Reef outbound delivery:** keep Reef outbound on the canonical channel plugin and execute sends in the Gateway process that owns the live encrypted transport, preventing connected channels from reporting `Reef channel is not running`.
 - **Sandbox recreate confirmation:** treat Clack cancellation as a decline so Ctrl-C cannot proceed with container removal.
 - **Microsoft Teams HTML text:** decode HTML5 entities consistently in quoted and Graph-fetched messages while preserving literal escaped entity text.
 - **ClawHub plugin API ranges:** delegate each supported comparator to `semver` so tilde, partial-wildcard, and prerelease caret bounds are correct while preserving OpenClaw version normalization and the existing restricted range grammar. (#106877)

--- a/extensions/reef/index.test.ts
+++ b/extensions/reef/index.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+import reefEntry from "./index.js";
+import { reefPlugin } from "./src/channel.js";
+import { reefOutboundAdapter } from "./src/outbound.js";
+
+describe("reef bundled entry", () => {
+  it("keeps outbound delivery on the canonical channel plugin", () => {
+    expect(reefEntry.loadChannelOutbound).toBeUndefined();
+    expect(reefPlugin.outbound).toBe(reefOutboundAdapter);
+  });
+});

--- a/extensions/reef/index.ts
+++ b/extensions/reef/index.ts
@@ -26,7 +26,6 @@ export default defineBundledChannelEntry({
   description: "Guarded end-to-end encrypted claw channel",
   importMetaUrl: import.meta.url,
   plugin: { specifier: "./channel-plugin-api.js", exportName: "reefPlugin" },
-  outbound: { specifier: "./api.js", exportName: "reefOutboundAdapter" },
   runtime: { specifier: "./runtime-api.js", exportName: "setReefRuntime" },
   registerCliMetadata: registerReefCliMetadata,
   registerFull: registerReefFullRuntime,

--- a/extensions/reef/src/outbound.test.ts
+++ b/extensions/reef/src/outbound.test.ts
@@ -3,6 +3,10 @@ import { reefOutboundAdapter } from "./outbound.js";
 import { setActiveReef } from "./runtime.js";
 
 describe("reefOutboundAdapter", () => {
+  it("delegates delivery to the Gateway that owns the active encrypted flow", () => {
+    expect(reefOutboundAdapter.deliveryMode).toBe("gateway");
+  });
+
   it("normalizes the SDK target and delegates only message content/context to the guarded flow", async () => {
     const send = vi.fn(async () => "01JZ0000000000000000000200");
     setActiveReef({ flow: { send }, friends: {}, reviews: {} } as never);

--- a/extensions/reef/src/outbound.ts
+++ b/extensions/reef/src/outbound.ts
@@ -27,7 +27,8 @@ async function send(
 }
 
 export const reefOutboundAdapter: ChannelOutboundAdapter = {
-  deliveryMode: "direct",
+  // The encrypted flow belongs to the Gateway account lifecycle; other processes must delegate.
+  deliveryMode: "gateway",
   textChunkLimit: 32 * 1024,
   deliveryCapabilities: { durableFinal: { text: true, replyTo: true, thread: true } },
   resolveTarget: ({ to }) => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users sending a Reef message from the CLI would get `Reef channel is not running` even while the gateway reported Reef as running and connected.

## Why This Change Was Made

Reef now keeps one canonical channel plugin and delegates outbound delivery to the gateway process that owns the live encrypted flow. The redundant bundled outbound loader is removed, while core durable-delivery and portable-presentation behavior remain intact.

## User Impact

Users can send Reef messages through the CLI and other core delivery paths whenever the configured gateway channel is connected, without starting a duplicate Reef runtime.

## Evidence

- Before: a live CLI send failed immediately with `OutboundDeliveryError: Reef channel is not running`.
- After: a fresh live message was sent through the gateway, accepted and persisted by the paired receiver, and returned a signed accepted Reef receipt.
- Full Reef extension suite: 12 files passed; 108 tests passed; 2 opt-in live guard tests skipped.
- Patch-identical changed gate: passed on Blacksmith Testbox `tbx_01kxg2e94efgpc95xwwrjnf8xj`.
- Testbox run: https://github.com/openclaw/openclaw/actions/runs/29325173171
- Exact-head CI: https://github.com/openclaw/openclaw/actions/runs/29327188015/attempts/2
- Exact-head structured Codex autoreview: clean, no accepted or actionable findings.

AI-assisted implementation and review.
