### PR TITLE
fix(irc): disconnect on oversized inbound lines

### DIFF
--- a/extensions/irc/src/client.test.ts
+++ b/extensions/irc/src/client.test.ts
@@ -6,6 +6,8 @@ import { connectIrcClient } from "./client.js";
 type LoopbackIrcServer = {
   port: number;
   lines: string[];
+  openSocketCount(): number;
+  writeToClients(data: string): void;
   close(): Promise<void>;
 };
 
@@ -51,6 +53,9 @@ async function startLoopbackIrcServer(options?: {
     socket.on("close", () => {
       sockets.delete(socket);
     });
+    socket.on("error", () => {
+      // The client intentionally resets the socket when a protocol limit is exceeded.
+    });
   });
   await new Promise<void>((resolve) => {
     server.listen(0, "127.0.0.1", resolve);
@@ -62,6 +67,12 @@ async function startLoopbackIrcServer(options?: {
   return {
     port: address.port,
     lines,
+    openSocketCount: () => sockets.size,
+    writeToClients: (data) => {
+      for (const socket of sockets) {
+        socket.write(data);
+      }
+    },
     close: async () => {
       for (const socket of sockets) {
         socket.destroy();
@@ -262,6 +273,98 @@ describe("irc client readiness timeout", () => {
         () => server.closedCount >= 1 && server.openSocketCount() === 0,
         `expected timed-out IRC connect socket to close; accepted=${server.acceptedCount} closed=${server.closedCount} open=${server.openSocketCount()}`,
       );
+    } finally {
+      await server.close();
+    }
+  });
+});
+
+describe("irc client inbound line byte limit", () => {
+  it("reports an error and closes on an oversized unterminated line", async () => {
+    const server = await startLoopbackIrcServer();
+    const errors: Error[] = [];
+    try {
+      const client = await connectIrcClient({
+        host: "127.0.0.1",
+        port: server.port,
+        tls: false,
+        nick: "bot",
+        username: "bot",
+        realname: "OpenClaw Bot",
+        connectTimeoutMs: 5000,
+        onError: (error) => errors.push(error),
+      });
+
+      server.writeToClients("x".repeat(1024 * 1024));
+
+      await waitForIrcCondition(
+        () => errors.length > 0 && server.openSocketCount() === 0,
+        "expected oversized IRC input to close the client socket",
+      );
+      expect(errors.map((error) => error.message)).toEqual([
+        "IRC inbound line exceeds the 512-byte limit",
+      ]);
+      expect(client.isReady()).toBe(false);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("accepts a legal 510-byte line split across socket writes", async () => {
+    const server = await startLoopbackIrcServer();
+    const receivedLines: string[] = [];
+    try {
+      const client = await connectIrcClient({
+        host: "127.0.0.1",
+        port: server.port,
+        tls: false,
+        nick: "bot",
+        username: "bot",
+        realname: "OpenClaw Bot",
+        connectTimeoutMs: 5000,
+        onLine: (line) => receivedLines.push(line),
+      });
+      const line = `PING :${"x".repeat(504)}`;
+
+      server.writeToClients(line.slice(0, 300));
+      server.writeToClients(`${line.slice(300)}\r\n`);
+
+      await waitForIrcCondition(
+        () =>
+          receivedLines.includes(line) && server.lines.some((entry) => entry.startsWith("PONG :")),
+        "expected split legal IRC line to be processed",
+      );
+      expect(Buffer.byteLength(`${line}\r\n`, "utf8")).toBe(512);
+      expect(client.isReady()).toBe(true);
+      client.close();
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("applies the inbound limit to UTF-8 bytes", async () => {
+    const server = await startLoopbackIrcServer();
+    const errors: Error[] = [];
+    try {
+      await connectIrcClient({
+        host: "127.0.0.1",
+        port: server.port,
+        tls: false,
+        nick: "bot",
+        username: "bot",
+        realname: "OpenClaw Bot",
+        connectTimeoutMs: 5000,
+        onError: (error) => errors.push(error),
+      });
+
+      server.writeToClients(`NOTICE bot :${"猫".repeat(167)}\r\n`);
+
+      await waitForIrcCondition(
+        () => errors.length > 0 && server.openSocketCount() === 0,
+        "expected multibyte oversized IRC line to close the client socket",
+      );
+      expect(errors).toHaveLength(1);
+      expect(errors[0]?.message).toContain("512-byte limit");
     } finally {
       await server.close();
     }

--- a/extensions/irc/src/client.ts
+++ b/extensions/irc/src/client.ts
@@ -13,6 +13,7 @@ import {
 const IRC_ERROR_CODES = new Set(["432", "464", "465"]);
 const IRC_NICK_COLLISION_CODES = new Set(["433", "436"]);
 const IRC_MAX_LINE_BYTES = 512;
+const IRC_MAX_LINE_PAYLOAD_BYTES = IRC_MAX_LINE_BYTES - Buffer.byteLength("\r\n", "utf8");
 
 function takeIrcPrivmsgChunk(text: string, maxChars: number, maxBytes: number): string {
   let end = 0;
@@ -292,6 +293,11 @@ export async function connectIrcClient(options: IrcClientOptions): Promise<IrcCl
       buffer = buffer.slice(idx + 1);
       idx = buffer.indexOf("\n");
 
+      if (Buffer.byteLength(rawLine, "utf8") > IRC_MAX_LINE_PAYLOAD_BYTES) {
+        failAndClose(new Error(`IRC inbound line exceeds the ${IRC_MAX_LINE_BYTES}-byte limit`));
+        return;
+      }
+
       if (!rawLine) {
         continue;
       }
@@ -408,6 +414,13 @@ export async function connectIrcClient(options: IrcClientOptions): Promise<IrcCl
           });
         }
       }
+    }
+
+    // Reserve the terminating CRLF while the final record is still pending.
+    // Otherwise a peer can grow this retained buffer without bound.
+    const pendingLine = buffer.endsWith("\r") ? buffer.slice(0, -1) : buffer;
+    if (Buffer.byteLength(pendingLine, "utf8") > IRC_MAX_LINE_PAYLOAD_BYTES) {
+      failAndClose(new Error(`IRC inbound line exceeds the ${IRC_MAX_LINE_BYTES}-byte limit`));
     }
   });
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a broken or hostile IRC server could keep sending an unterminated line and make OpenClaw retain the growing input indefinitely while the channel remained connected.

## Why This Change Was Made

The IRC client now applies the protocol's existing 512-byte wire limit to both complete inbound lines and the pending unterminated record. The check reserves the terminating CRLF and measures UTF-8 bytes, then reports the protocol error and closes the socket before parsing oversized input.

## User Impact

IRC connections no longer grow memory without bound on oversized inbound records. Legal 512-byte lines, split socket writes, PING/PONG handling, and multibyte UTF-8 input within the limit continue to work.

## Evidence

- Real Linux TCP loopback server/client regression: a post-registration 1 MiB fragment without CRLF produced exactly `IRC inbound line exceeds the 512-byte limit`, closed the socket, and made the client not ready.
- Real TCP boundary control: a legal 510-byte PING payload split across two socket writes (512 bytes including CRLF) was delivered and received a PONG while the client remained ready.
- UTF-8 control: an oversized multibyte line was rejected by byte length rather than JavaScript character count.
- `node scripts/run-vitest.mjs extensions/irc/src/client.test.ts` — 19 passed.
- `node scripts/run-vitest.mjs extensions/irc/src/client.surrogate.test.ts` — 5 passed.
- `.agents/skills/autoreview/scripts/autoreview --mode local` — clean, no accepted/actionable findings.
- `git diff --check` — passed.

Remote Testbox evidence was not available in the authoring environment because neither Crabbox nor Blacksmith was installed; the socket evidence above uses real kernel TCP sockets rather than mocked transports.

AI-assisted: implemented and reviewed with Codex; I reviewed the resulting code and validation evidence.
