### PR TITLE
refactor(ui): privatize chat helpers

### DIFF
--- a/ui/src/pages/chat/components/chat-attachments.ts
+++ b/ui/src/pages/chat/components/chat-attachments.ts
@@ -23,7 +23,7 @@ const PASTED_TEXT_PREVIEW_MAX_LENGTH = 20;
 const largePastedTextAttachments = new WeakSet<ChatAttachment>();
 const pastedTextPreviews = new WeakMap<ChatAttachment, string>();
 
-export type ChatAttachmentControlsProps = {
+type ChatAttachmentControlsProps = {
   attachments?: ChatAttachment[];
   disabled?: boolean;
   getAttachments?: () => ChatAttachment[];

--- a/ui/src/pages/chat/initial-turn-handoff.ts
+++ b/ui/src/pages/chat/initial-turn-handoff.ts
@@ -37,7 +37,7 @@ export function prepareInitialTurnHandoff(sessionKey: string, item: ChatQueueIte
   pending = { item, sessionKey, timer };
 }
 
-export function consumeInitialTurnHandoff(sessionKey: string): ChatQueueItem | null {
+function consumeInitialTurnHandoff(sessionKey: string): ChatQueueItem | null {
   if (!pending || !areUiSessionKeysEquivalent(pending.sessionKey, sessionKey)) {
     return null;
   }

--- a/ui/src/pages/chat/terminal-message-identity.ts
+++ b/ui/src/pages/chat/terminal-message-identity.ts
@@ -21,7 +21,7 @@ export function rememberLiveTerminalRun(
   return message;
 }
 
-export function isLiveTerminalForRun(message: unknown, runId: string): boolean {
+function isLiveTerminalForRun(message: unknown, runId: string): boolean {
   return Boolean(
     message && typeof message === "object" && liveTerminalRunIds.get(message) === runId,
   );

--- a/ui/src/pages/new-session/composer.ts
+++ b/ui/src/pages/new-session/composer.ts
@@ -45,7 +45,7 @@ function handleComposerKeydown(event: KeyboardEvent, options: NewSessionComposer
 }
 
 /** Draft message box styled as the chat composer shell so both pickers match. */
-export function renderNewSessionComposer(options: NewSessionComposerOptions) {
+function renderNewSessionComposer(options: NewSessionComposerOptions) {
   const startLabel = options.submitting ? t("newSession.starting") : t("newSession.start");
   const attachmentProps = {
     attachments: options.attachments,


### PR DESCRIPTION
## What Problem This Solves

The new-session image/model UI change exposed four same-module declarations to production Knip, which would grow the shrink-only dead-export baseline from 770 to 774.

## Why This Change Was Made

Each declaration is used only inside its defining module. Removing the export modifier keeps the implementation unchanged while restoring the ratchet without grandfathering new rows.

## User Impact

No UI behavior or public API changes. Module visibility only.

## Evidence

- Production Knip regeneration byte-stable at 770; exact deadcode green.
- Testbox `tbx_01kxg2avkgdrpy4s4bg62km2s7`, run 29325058361: formatting, type-aware lint, 255 UI files / 3,779 tests, production UI build, sidecar verification, and performance gates green.
- Whole-tree caller audit found only same-module uses; no dynamic, string, barrel, or public consumers.
- Fresh autoreview clean before commit at 0.98 and after rebase at 0.96.
