### PR TITLE
fix(deadcode): remove stale UI baseline rows

### DIFF
--- a/scripts/deadcode-exports.baseline.mjs
+++ b/scripts/deadcode-exports.baseline.mjs
@@ -772,10 +772,6 @@ export const KNIP_UNUSED_EXPORT_BASELINE = [
   "src/wizard/setup.migration-recovery.ts: testing",
   "src/wizard/setup.official-plugins.ts: resolveOfficialPluginOnboardingInstallEntries",
   "src/wizard/setup.official-plugins.ts: testing",
-  "ui/src/pages/chat/components/chat-attachments.ts: ChatAttachmentControlsProps",
-  "ui/src/pages/chat/initial-turn-handoff.ts: consumeInitialTurnHandoff",
-  "ui/src/pages/chat/terminal-message-identity.ts: isLiveTerminalForRun",
-  "ui/src/pages/new-session/composer.ts: renderNewSessionComposer",
 ];
 
 // Platform-variant findings. Allowed when present; never required.


### PR DESCRIPTION
## What Problem This Solves

The dead-export baseline still required four UI symbols after #107379 made them module-private. That made the ratchet fail with stale required entries.

## Why This Change Was Made

Remove only the four stale rows. Source ownership and behavior remain unchanged.

## User Impact

None. Internal dead-code metadata cleanup only.

## Evidence

- `node scripts/check-deadcode-exports.mjs` — exact match, 770 entries
- `git diff --check` — clean
- Autoreview — clean, 0.99
- Source repair: #107379 / `276efaa48b3927151be8c78178f08fc0b1268578`
