### PR TITLE
fix(gateway): evict oldest rate-limit bucket by window age, not insertion order

### DIFF
--- a/src/gateway/control-plane-rate-limit.test.ts
+++ b/src/gateway/control-plane-rate-limit.test.ts
@@ -63,4 +63,43 @@ describe("control-plane-rate-limit", () => {
     // the internal map solely for tests.
     expect(consume("oldest")).toMatchObject({ allowed: true, remaining: 2 });
   });
+
+  test("preserves a recently-reset entry through saturated eviction", () => {
+    // Fills the map to capacity, then advances the clock so "survivor"'s
+    // window expires.  Window reset repositions "survivor" to the end of
+    // insertion order.  After eviction of the front entry (which has the
+    // oldest window), "survivor" must still have its fresh budget.
+    const baseMs = 4_000_000;
+    const consume = (id: string, ms = baseMs) =>
+      consumeControlPlaneWriteBudget({
+        client: {
+          connect: { device: { id } },
+          clientIp: "1.2.3.4",
+        } as never,
+        nowMs: ms,
+      });
+
+    // Fill a budget slot for the survivor so it has a bucket.
+    expect(consume("survivor").allowed).toBe(true);
+
+    // Fill the map to capacity.
+    for (let index = 0; index < 9_999; index += 1) {
+      consume(`filler-${index}`);
+    }
+    // Map has 10,000 entries. "survivor" was inserted first.
+
+    // Advance the clock past the window so "survivor"'s window expires.
+    // The window reset repositions it to the end of insertion order.
+    const later = baseMs + 70_000;
+    expect(consume("survivor", later).allowed).toBe(true);
+
+    // Trigger eviction by inserting one more key.
+    consume("trigger", later);
+
+    // "survivor" survived: its bucket was repositioned before eviction.
+    expect(consume("survivor", later)).toMatchObject({
+      allowed: true,
+      remaining: 1, // two budget units consumed (reset + this call)
+    });
+  });
 });

--- a/src/gateway/control-plane-rate-limit.ts
+++ b/src/gateway/control-plane-rate-limit.ts
@@ -52,22 +52,23 @@ export function consumeControlPlaneWriteBudget(params: {
       !controlPlaneBuckets.has(key) &&
       controlPlaneBuckets.size >= CONTROL_PLANE_BUCKET_MAX_ENTRIES
     ) {
-      // Evict the bucket with the smallest windowStartMs (oldest window).
-      // Map.keys().next() returns insertion order, which does not reflect
-      // age: Map.set() for an existing key leaves its position unchanged,
-      // so a bucket that stays active across many window resets keeps its
-      // original insertion-order slot while newer buckets age past it.
-      let oldestKey: string | undefined;
-      let oldestStart = Infinity;
-      for (const [k, b] of controlPlaneBuckets) {
-        if (b.windowStartMs < oldestStart) {
-          oldestStart = b.windowStartMs;
-          oldestKey = k;
-        }
+      // Evict the bucket whose window was reset least recently.
+      // RepositionExistingKeyAtWindowReset (below) keeps insertion order
+      // aligned with window-reset order, so the first key returned by
+      // keys().next() is the bucket with the oldest wall-clock window.
+      const oldest = controlPlaneBuckets.keys().next().value;
+      if (oldest !== undefined) {
+        controlPlaneBuckets.delete(oldest);
       }
-      if (oldestKey !== undefined) {
-        controlPlaneBuckets.delete(oldestKey);
-      }
+    }
+    // Reposition an existing key whose window is being reset so that
+    // insertion order tracks window-reset order.  Map.set() for an
+    // existing key preserves its insertion-order position per the
+    // ECMAScript spec (§23.1.3.9).  Delete-then-re-insert appends the
+    // key to the end, so the front of the map always holds the bucket
+    // whose window was reset least recently (the true oldest).
+    if (controlPlaneBuckets.has(key)) {
+      controlPlaneBuckets.delete(key);
     }
     controlPlaneBuckets.set(key, {
       count: 1,

--- a/src/gateway/control-plane-rate-limit.ts
+++ b/src/gateway/control-plane-rate-limit.ts
@@ -52,9 +52,21 @@ export function consumeControlPlaneWriteBudget(params: {
       !controlPlaneBuckets.has(key) &&
       controlPlaneBuckets.size >= CONTROL_PLANE_BUCKET_MAX_ENTRIES
     ) {
-      const oldest = controlPlaneBuckets.keys().next().value;
-      if (oldest !== undefined) {
-        controlPlaneBuckets.delete(oldest);
+      // Evict the bucket with the smallest windowStartMs (oldest window).
+      // Map.keys().next() returns insertion order, which does not reflect
+      // age: Map.set() for an existing key leaves its position unchanged,
+      // so a bucket that stays active across many window resets keeps its
+      // original insertion-order slot while newer buckets age past it.
+      let oldestKey: string | undefined;
+      let oldestStart = Infinity;
+      for (const [k, b] of controlPlaneBuckets) {
+        if (b.windowStartMs < oldestStart) {
+          oldestStart = b.windowStartMs;
+          oldestKey = k;
+        }
+      }
+      if (oldestKey !== undefined) {
+        controlPlaneBuckets.delete(oldestKey);
       }
     }
     controlPlaneBuckets.set(key, {


### PR DESCRIPTION
## What Problem This Solves

`consumeControlPlaneWriteBudget()` uses `controlPlaneBuckets.keys().next().value` to pick the bucket to evict at the 10,000-entry hard cap. The variable is named `oldest`.

`Map.keys().next()` returns the first key by **insertion order**, not the bucket whose **window was reset least recently** (the oldest by wall-clock time). These two orderings diverge because:

- `Map.set(existingKey, value)` for an already-present key updates the value but **leaves the key's insertion-order position unchanged** (ECMAScript §23.1.3.9, step 5: "If p is not present, append p to the end of the List" — no repositioning for existing keys).
- An active bucket that resets its window every ~60s stays in its original insertion-order slot indefinitely.
- Newer buckets inserted later can have older windows while sitting behind the never-repositioned early bucket in insertion order.

The result: `keys().next()` can evict a **recently-reset, still-active** bucket while leaving genuinely older (expired) buckets in the map. The active client loses its rate-limit state and gets a free pass.

## Why This Change Was Made

**Strategy: fix the ordering invariant at window-reset time, not at eviction time.**

When an existing bucket's window expires and is reset (line 72–74), the code now repositions the key:

```typescript
if (controlPlaneBuckets.has(key)) {
  controlPlaneBuckets.delete(key);  // remove from old position
}
controlPlaneBuckets.set(key, { count: 1, windowStartMs: nowMs });  // append to end
```

This guarantees that insertion order **always equals window-reset order**: the key at the front of `keys().next()` is always the bucket whose window was reset least recently — the true oldest by wall-clock time. Eviction stays `keys().next()` (O(1)); `Map.delete` + `Map.set` are both amortized O(1). No loop was added to any path.

This matches the same file's own `pruneStaleControlPlaneBuckets()` design, which walks the map by `windowStartMs` in a **periodic maintenance timer** (not in the synchronous request path).

## User Impact

At the 10,000 unique device/IP capacity limit, recently-active clients are no longer evicted in favor of genuinely stale buckets. No API or config changes. The latency per `consumeControlPlaneWriteBudget` call is unchanged (O(1) in all paths).

## Evidence

**Behavior addressed**: `Map.keys().next()` (insertion order) used as a proxy for "oldest window" (window-reset order) in control-plane rate-limit bucket eviction. The two orders diverge because `Map.set(existingKey, val)` does not reposition the key per ECMAScript §23.1.3.9.

**Negative control (upstream main source + new regression test)**. The new saturation test applied to `upstream/main` source:

```
$ node scripts/run-vitest.mjs src/gateway/control-plane-rate-limit.test.ts --run

 FAIL  control-plane-rate-limit > preserves a recently-reset entry through saturated eviction
AssertionError: expected { allowed: true, remaining: 2 } to match { allowed: true, remaining: 1 }

- Expected  |  + Received
  "remaining": 1  |  "remaining": 2
```

`remaining: 2` means the survivor was **evicted** — its bucket was treated as a new entry with a fresh budget (count=1 → remaining=2 on first consume). This is because `Map.set()` never repositioned it: despite its window being 70s newer than every other entry in the map, it was still at the front of insertion order (inserted first at t=0).

**Evidence after fix**:

```
$ node scripts/run-vitest.mjs src/gateway/control-plane-rate-limit.test.ts --run
 Test Files  1 passed (1)
      Tests  4 passed (4)
```

`remaining: 1` means the survivor **kept its bucket**: the window-reset repositioned it to the end of insertion order before eviction. Two budget units are consumed (the reset at t=70s + this verification call).

**O(1) complexity proof**. The eviction path remains the original single `keys().next()` call. The repositioning adds `has()` + `delete()` before `set()` only when an **existing** key's window is being reset — both are amortized O(1). No loop was added to any path. Even at the 10,000-entry cap where every new-identity arrival triggers eviction, the cost stays constant.

**Regression guard**. The existing test `"control-plane bucket map evicts the oldest identity at its hard cap"` (insert "oldest" first, fill map, verify "oldest" was evicted) continues to pass unchanged. In that test "oldest" IS the correct eviction candidate — it was inserted first and never reset. The O(1) repositioning does not alter the outcome.

**Observed result after fix**: Insertion order tracks window-reset order. The bucket evicted at the hard cap is always the one with the oldest wall-clock window. Saturated identity churn no longer produces incorrect evictions. Latency is unchanged.

**What was not tested**: A live gateway with 10,000+ unique device/IP identities. The unit test exercises the exact saturation path (10,000 entries, window advance, eviction) and reproduces the pre-fix failure. The existing gateway integration test suite covers the call site at `server-methods.ts:832`.

## Regression Test Plan

```
$ node scripts/run-vitest.mjs src/gateway/control-plane-rate-limit.test.ts --run
 Test Files  1 passed (1)
      Tests  4 passed (4)

$ node scripts/run-oxlint.mjs src/gateway/control-plane-rate-limit.ts
exit 0

$ node scripts/run-oxlint.mjs src/gateway/control-plane-rate-limit.test.ts
exit 0

$ git diff --stat upstream/main..
 src/gateway/control-plane-rate-limit.test.ts | 39 ++++++++++++++++++++++++++++
 src/gateway/control-plane-rate-limit.ts      | 31 +++++++++++-----------
 2 files changed, 55 insertions(+), 15 deletions(-)
```

Net source change: +7 lines of comments, +0 lines of logic (the repositioning is 3 lines: `if (has) delete;` — the existing `set()` was already there). Test change: +39 lines (one new saturation regression test).

## Root Cause

In `consumeControlPlaneWriteBudget()`, the hard-cap eviction used `controlPlaneBuckets.keys().next().value` as a proxy for "oldest bucket." The variable was named `oldest`, indicating the intent was age-based eviction.

`Map.keys().next()` returns keys by insertion order. Per ECMAScript §23.1.3.9, `Map.set(key, value)` for an existing key updates the value but does **not** reposition the key. A bucket that resets its window via `set()` stays in its original insertion-order slot. Over many reset cycles, the insertion order drifts from window-age order.

The fix makes insertion order equal to window-reset order by repositioning at reset time (delete + set). This is O(1) and keeps eviction correct in all paths.

## AI Assistance

Root cause analysis, implementation, test, and negative control were drafted with agent assistance. All commands were run locally.