### PR TITLE
refactor(backup): use tar read-entry APIs

### DIFF
--- a/src/commands/backup-verify.ts
+++ b/src/commands/backup-verify.ts
@@ -207,14 +207,13 @@ async function listArchiveEntries(archivePath: string): Promise<ArchiveEntry[]> 
   await tar.t({
     file: archivePath,
     gzip: true,
-    onentry: (entry) => {
+    onReadEntry: (entry) => {
       entries.push({
         path: entry.path,
         ...(entry.linkpath ? { linkpath: entry.linkpath } : {}),
         ...(Number.isSafeInteger(entry.size) && entry.size >= 0 ? { size: entry.size } : {}),
         ...(entry.type ? { type: entry.type } : {}),
       });
-      entry.resume();
     },
   });
   return entries;
@@ -224,67 +223,32 @@ async function extractManifest(params: {
   archivePath: string;
   manifestEntryPath: string;
 }): Promise<string> {
-  let manifestContentPromise: Promise<{ content?: string; error?: Error }> | undefined;
+  const limitError = new Error(`Backup manifest exceeds ${MAX_MANIFEST_BYTES} byte limit.`);
+  let manifestContentPromise: Promise<Buffer | Error> | undefined;
   await tar.t({
     file: params.archivePath,
     gzip: true,
-    onentry: (entry) => {
-      if (entry.path !== params.manifestEntryPath) {
-        entry.resume();
-        return;
-      }
-
-      manifestContentPromise = new Promise<{ content?: string; error?: Error }>((resolve) => {
-        const chunks: Buffer[] = [];
-        let totalBytes = 0;
-        let exceededLimit = false;
-        let settled = false;
-        const settle = (result: { content?: string; error?: Error }) => {
-          if (settled) {
-            return;
-          }
-          settled = true;
-          resolve(result);
-        };
-        entry.on("data", (chunk: Buffer | string) => {
-          if (exceededLimit) {
-            return;
-          }
-          const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
-          totalBytes += buffer.byteLength;
-          if (totalBytes > MAX_MANIFEST_BYTES) {
-            exceededLimit = true;
-            chunks.length = 0;
-            return;
-          }
-          chunks.push(buffer);
-        });
-        entry.on("error", (error) => {
-          settle({
-            error: error instanceof Error ? error : new Error(String(error)),
-          });
-        });
-        entry.on("end", () => {
-          if (exceededLimit) {
-            settle({
-              error: new Error(`Backup manifest exceeds ${MAX_MANIFEST_BYTES} byte limit.`),
-            });
-            return;
-          }
-          settle({ content: Buffer.concat(chunks, totalBytes).toString("utf8") });
-        });
-      });
+    filter: (entryPath) => entryPath === params.manifestEntryPath,
+    onReadEntry: (entry) => {
+      manifestContentPromise =
+        entry.size > MAX_MANIFEST_BYTES
+          ? Promise.resolve(limitError)
+          : entry
+              .concat()
+              .catch((error: unknown) =>
+                error instanceof Error ? error : new Error(String(error)),
+              );
     },
   });
 
   if (!manifestContentPromise) {
     throw new Error(`Archive is missing manifest entry: ${params.manifestEntryPath}`);
   }
-  const result = await manifestContentPromise;
-  if (result.error) {
-    throw result.error;
+  const content = await manifestContentPromise;
+  if (content instanceof Error) {
+    throw content;
   }
-  return result.content ?? "";
+  return content.toString("utf8");
 }
 
 function isRootManifestEntry(entryPath: string): boolean {
@@ -692,7 +656,6 @@ async function verifySqliteSnapshots(params: {
       cwd: tempDir,
       strict: true,
       preserveOwner: false,
-      noChmod: true,
       filter: (entryPath, archiveEntry) => {
         const expected = sqliteEntriesByRawPath.get(entryPath);
         if (!expected) {

--- a/src/fleet/backup.runtime.ts
+++ b/src/fleet/backup.runtime.ts
@@ -538,9 +538,6 @@ export async function restoreFleetCell(params: {
       preservePaths: false,
       preserveOwner: false,
       strict: true,
-      onwarn: () => {
-        invalidArchive = true;
-      },
       filter: (entryPath, entry) => {
         if (exceeded || tooManyEntries) {
           return false;


### PR DESCRIPTION
## What Problem This Solves

Backup verification manually reimplemented tar entry buffering, stream settlement, entry filtering, and resume behavior. Restore code also carried options that tar 7 ignores or makes unreachable under strict mode.

## Why This Change Was Made

Use tar 7's native `onReadEntry`, `filter`, and inherited `ReadEntry.concat()` contracts. Preserve the manifest size limit before allocation and attach stream rejection handling immediately. Remove redundant resume, ignored chmod, and unreachable warning plumbing.

## User Impact

No intended behavior change. Backup verification and fleet restore keep the same validation and safety limits with 40 fewer lines of local stream machinery.

## Evidence

- `node scripts/run-vitest.mjs src/commands/backup-verify.test.ts` — 28 passed
- `node scripts/run-vitest.mjs src/fleet/backup.runtime.test.ts` — 22 passed
- `git diff --check`
- Fresh branch autoreview: clean, 0.90 confidence
