### PR TITLE
fix(codex): keep omitted-final source replies from releasing the turn

### DIFF
--- a/extensions/codex/src/app-server/dynamic-tools.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tools.test.ts
@@ -1388,7 +1388,7 @@ describe("createCodexDynamicToolBridge", () => {
     ]);
   });
 
-  it("marks delivered message-tool-only source replies as terminal when final is omitted", async () => {
+  it("keeps omitted-final delivered source replies non-terminal with a completed marker", async () => {
     const bridge = createBridgeWithToolResult(
       "message",
       textToolResult("Sent.", { messageId: "imessage-6264" }),
@@ -1401,15 +1401,14 @@ describe("createCodexDynamicToolBridge", () => {
     });
 
     expect(result).toEqual(expectInputText("Sent."));
-    expect(result.terminate).toBe(true);
+    expect(result.terminate).toBeUndefined();
     expect(bridge.telemetry.didDeliverSourceReplyViaMessageTool).toBe(true);
     expect(bridge.telemetry.messagingToolSentTargets.at(-1)).toMatchObject({
       sourceReplyFinal: true,
     });
-    expect(Object.keys(result)).not.toContain("terminate");
   });
 
-  it("requires explicit final=false to keep a delivered message-tool-only source reply non-terminal", async () => {
+  it("releases delivered message-tool-only source replies only on explicit final=true", async () => {
     const bridge = createBridgeWithToolResult(
       "message",
       textToolResult("Sent.", { messageId: "imessage-6264" }),
@@ -1474,6 +1473,7 @@ describe("createCodexDynamicToolBridge", () => {
     const result = await handleMessageToolCall(bridge, {
       action: "send",
       message: "visible reply",
+      final: true,
     });
 
     expect(result).toEqual(expectInputText("Sent."));
@@ -1525,6 +1525,7 @@ describe("createCodexDynamicToolBridge", () => {
       messageId: "853",
       message: "visible reply",
       buttons: [],
+      final: true,
     });
 
     expect(result).toEqual(expectInputText("Sent."));
@@ -1571,6 +1572,7 @@ describe("createCodexDynamicToolBridge", () => {
       target: "+1 (206) 910-6512",
       messageId: "853",
       message: "visible reply",
+      final: true,
     });
 
     expect(result).toEqual(expectInputText("Sent."));
@@ -1610,6 +1612,7 @@ describe("createCodexDynamicToolBridge", () => {
       messageId: "857",
       message: "visible reply",
       buttons: [],
+      final: true,
     });
 
     expect(result).toEqual(expectInputText("Sent."));
@@ -1646,6 +1649,7 @@ describe("createCodexDynamicToolBridge", () => {
       messageId: "861",
       message: "visible reply",
       buttons: [],
+      final: true,
     });
 
     expect(result).toEqual(expectInputText(receiptText));
@@ -1726,6 +1730,7 @@ describe("createCodexDynamicToolBridge", () => {
       messageId: "863",
       message: "visible reply",
       buttons: [],
+      final: true,
     });
 
     expect(result).toEqual(expectInputText("Sent."));
@@ -1734,7 +1739,7 @@ describe("createCodexDynamicToolBridge", () => {
     expect(Object.keys(result)).not.toContain("terminate");
   });
 
-  it("keeps message-tool-only source replies terminal when the provider is only in the current channel id", async () => {
+  it("keeps omitted-final explicit source-route replies non-terminal while recording delivery", async () => {
     const bridge = createBridgeWithToolResult("message", textToolResult("Sent.", { ok: true }), {
       sourceReplyDeliveryMode: "message_tool_only",
       currentChannelId: "imessage:any;-;+12069106512",
@@ -1750,9 +1755,11 @@ describe("createCodexDynamicToolBridge", () => {
     });
 
     expect(result).toEqual(expectInputText("Sent."));
-    expect(result.terminate).toBe(true);
+    expect(result.terminate).toBeUndefined();
     expect(bridge.telemetry.didDeliverSourceReplyViaMessageTool).toBe(true);
-    expect(Object.keys(result)).not.toContain("terminate");
+    expect(bridge.telemetry.messagingToolSentTargets.at(-1)).toMatchObject({
+      sourceReplyFinal: true,
+    });
   });
 
   it("records message-tool-owned terminal replies as delivered source replies", async () => {
@@ -1840,6 +1847,7 @@ describe("createCodexDynamicToolBridge", () => {
     const firstResult = await handleMessageToolCall(bridge, {
       action: "send",
       message: "visible reply",
+      final: true,
     });
     const secondResult = await bridge.handleToolCall({
       threadId: "thread-1",

--- a/extensions/codex/src/app-server/dynamic-tools.ts
+++ b/extensions/codex/src/app-server/dynamic-tools.ts
@@ -665,9 +665,12 @@ export function createCodexDynamicToolBridge(params: {
           isError: resultIsError,
           allowExplicitSourceRoute: !blocksSourceReplyTermination,
         });
-        const receiptConfirmedSourceReply =
+        const messageToolOnlySourceMode =
           params.hookContext?.sourceReplyDeliveryMode === "message_tool_only" &&
-          toolName === "message" &&
+          toolName === "message";
+        const toolOwnedTermination = rawResult.terminate === true || result.terminate === true;
+        const receiptConfirmedSourceReply =
+          messageToolOnlySourceMode &&
           normalizeRouteToken(
             typeof executedArgs.action === "string" ? executedArgs.action : undefined,
           ) === "reply" &&
@@ -683,17 +686,12 @@ export function createCodexDynamicToolBridge(params: {
           (replyReceiptMatchesCurrentMessage(rawResult, params.hookContext) ||
             replyReceiptMatchesCurrentMessage(result, params.hookContext));
         const toolConfirmedSourceReply =
-          params.hookContext?.sourceReplyDeliveryMode === "message_tool_only" &&
-          toolName === "message" &&
-          !resultIsError &&
-          (rawResult.terminate === true || result.terminate === true);
+          messageToolOnlySourceMode && !resultIsError && toolOwnedTermination;
         const hasExplicitFinalControl = typeof executedArgs.final === "boolean";
-        // Omitted final on a confirmed source reply must degrade to legacy
-        // terminate-on-delivery (completed marker), never progress; otherwise
-        // stranded-reply recovery re-delivers a duplicate of that reply.
+        // Omitted final still records a completed marker; downgrading it to
+        // progress would let stranded-reply recovery re-deliver the reply.
         const sourceReplyFinal =
-          params.hookContext?.sourceReplyDeliveryMode === "message_tool_only" &&
-          toolName === "message" &&
+          messageToolOnlySourceMode &&
           (toolConfirmedSourceReply || deliveredSourceReply || receiptConfirmedSourceReply)
             ? hasExplicitFinalControl
               ? executedArgs.final === true
@@ -714,15 +712,12 @@ export function createCodexDynamicToolBridge(params: {
         }
         withDynamicToolTermination(
           response,
-          ((rawResult.terminate === true || result.terminate === true) &&
-            !(
-              params.hookContext?.sourceReplyDeliveryMode === "message_tool_only" &&
-              toolName === "message" &&
-              executedArgs.final === false
-            )) ||
+          (toolOwnedTermination && !(messageToolOnlySourceMode && executedArgs.final === false)) ||
             isToolResultYield(rawResult) ||
             isToolResultYield(result) ||
-            ((deliveredSourceReply || receiptConfirmedSourceReply) && executedArgs.final !== false),
+            // Inferred source replies release only on explicit final=true so
+            // progress sends keep the turn alive until Codex turn/completed.
+            ((deliveredSourceReply || receiptConfirmedSourceReply) && executedArgs.final === true),
         );
         const asyncStarted =
           isAsyncStartedToolResult(rawResult) || isAsyncStartedToolResult(result);

--- a/extensions/codex/src/app-server/message-tool-final-control.ts
+++ b/extensions/codex/src/app-server/message-tool-final-control.ts
@@ -45,7 +45,7 @@ function addCodexMessageToolOnlyFinalParameter(parameters: unknown): unknown {
       final: {
         type: "boolean",
         description:
-          "Set true only when this message is intended to complete the reply to the current source conversation. OpenClaw stops after confirming delivery.",
+          "Set true only when this message is intended to complete the reply to the current source conversation. OpenClaw stops after confirming delivery. Omit or set false for progress updates; the turn continues.",
       },
     },
   };


### PR DESCRIPTION
Closes #106961

## What Problem This Solves

In `message_tool_only` delivery mode, the Codex app-server treated any delivered `message` source reply as terminal unless the model explicitly passed `final: false`. An agent that sent an early progress update ("on it, will report back") had its turn released immediately: the remaining tool calls and the real final reply never ran. From the user's side the agent posts one status line and then goes silent (log signal: `codex app-server turn released after terminal dynamic tool result`).

## Why This Change Was Made

The projected `final` schema control tells the model to "set true **only when** this message is intended to complete the reply" - so models naturally omit `final` on progress sends, and the runtime contradicted its own schema by terminating anyway.

This change makes inferred source-reply delivery release the turn only on explicit `final: true`, matching the generic embedded-runner contract established in #92343: intermediate delivery continues the turn, and termination follows the normal Codex `turn/completed` lifecycle.

Safety properties preserved:

- The `sourceReplyFinal` completed marker for omitted `final` is unchanged, so stranded-reply recovery still cannot re-deliver a duplicate of a delivered reply.
- Duplicate end-block suppression via `didDeliverSourceReplyViaMessageTool` is unchanged.
- Tool-owned `terminate` results and yield results still release as before.
- Mixed dynamic-tool batch semantics (`resolveTerminalDynamicToolBatchAction`) are untouched.

The `final` schema description now also tells models that omitting it keeps the turn alive, so the control is learnable instead of discipline-based.

## User Impact

Codex-backed agents on Discord/Telegram/etc. can post intermediate progress messages and keep executing until the work is done. Explicit `final: true` still stops the turn after confirmed delivery.

## Evidence

- `extensions/codex/src/app-server/dynamic-tools.test.ts`: 99/99 pass. Omitted-final delivered replies are now non-terminal with a completed marker; explicit `final: true` still releases across implicit sends, explicit source routes, receipt-confirmed replies, and middleware-redacted receipts.
- `extensions/codex/src/app-server/dynamic-tool-build.test.ts` + `dynamic-tool-execution.test.ts`: 74/74 pass.
- `pnpm tsgo:extensions` clean, `oxfmt --check` clean on changed files.
- Fork CI (full matrix, pre-rebase head): all codex/agents/auto-reply lanes green; the only failures were `checks-ui` (`chat-tool-cards.test.ts` MCP App preview test, unrelated to this change) and `checks-fast-bundled-protocol` on a base 106 commits behind main; branch has since been rebased onto current `main` (no upstream changes to the touched files).

AI-assisted: implemented and validated with an AI coding agent; I have reviewed and understand the change.
