### PR TITLE
fix(imessage): preserve split Full Disk Access errors

### DIFF
--- a/extensions/imessage/src/client.test.ts
+++ b/extensions/imessage/src/client.test.ts
@@ -112,4 +112,89 @@ describe("IMessageRpcClient child stream error handling", () => {
       await client.stop();
     }
   });
+
+  it("promotes a complete Full Disk Access diagnostic", async () => {
+    const { IMessageRpcClient } = await import("./client.js");
+    const runtimeError = vi.fn();
+    const client = new IMessageRpcClient({
+      cliPath: "imsg",
+      runtime: { error: runtimeError, exit: vi.fn(), log: vi.fn() },
+    });
+    await client.start();
+
+    const pending = client.request("ping", {}, { timeoutMs: 0 });
+    pending.catch(() => {});
+    child.stderr.emit("data", Buffer.from("notice Full Disk Access denied for chat.db\n"));
+    child.emit("close", 1, null);
+
+    await expect(pending).rejects.toThrow(
+      "imsg cannot access ~/Library/Messages/chat.db. Grant Full Disk Access to the Gateway/launcher process and restart Gateway.",
+    );
+    expect(runtimeError).toHaveBeenCalledOnce();
+    expect(runtimeError.mock.calls[0]?.[0]).not.toContain("�");
+  });
+
+  it("preserves a split UTF-8 Full Disk Access diagnostic from a real child", async () => {
+    const childProcess =
+      await vi.importActual<typeof import("node:child_process")>("node:child_process");
+    const script = `
+      const prefix = Buffer.from("notice 猫 Full Disk Acc", "utf8");
+      setTimeout(() => {
+        process.stderr.write(prefix.subarray(0, 8));
+        setTimeout(() => {
+          process.stderr.write(prefix.subarray(8));
+          setTimeout(() => {
+            process.stderr.write("ess denied for chat.db");
+            setTimeout(() => process.exit(1), 10);
+          }, 10);
+        }, 10);
+      }, 50);
+    `;
+    const realChild = childProcess.spawn(process.execPath, ["-e", script], {
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    spawnMock.mockReturnValueOnce(realChild);
+    const { IMessageRpcClient } = await import("./client.js");
+    const runtimeError = vi.fn();
+    const client = new IMessageRpcClient({
+      cliPath: "imsg",
+      runtime: { error: runtimeError, exit: vi.fn(), log: vi.fn() },
+    });
+    await client.start();
+
+    try {
+      const pending = client.request("ping", {}, { timeoutMs: 0 });
+      pending.catch(() => {});
+
+      await expect(pending).rejects.toThrow(
+        "imsg cannot access ~/Library/Messages/chat.db. Grant Full Disk Access to the Gateway/launcher process and restart Gateway.",
+      );
+      expect(runtimeError).toHaveBeenCalledWith(
+        "imsg rpc: notice 猫 Full Disk Access denied for chat.db",
+      );
+    } finally {
+      if (!realChild.killed) {
+        realChild.kill("SIGTERM");
+      }
+      await client.stop();
+    }
+  });
+
+  it("keeps unrelated unterminated stderr on the generic close error path", async () => {
+    const { IMessageRpcClient } = await import("./client.js");
+    const runtimeError = vi.fn();
+    const client = new IMessageRpcClient({
+      cliPath: "imsg",
+      runtime: { error: runtimeError, exit: vi.fn(), log: vi.fn() },
+    });
+    await client.start();
+
+    const pending = client.request("ping", {}, { timeoutMs: 0 });
+    pending.catch(() => {});
+    child.stderr.emit("data", Buffer.from("unrelated warning"));
+    child.emit("close", 1, null);
+
+    await expect(pending).rejects.toThrow("imsg rpc exited (code 1)");
+    expect(runtimeError).toHaveBeenCalledWith("imsg rpc: unrelated warning");
+  });
 });

--- a/extensions/imessage/src/client.ts
+++ b/extensions/imessage/src/client.ts
@@ -70,6 +70,8 @@ export class IMessageRpcClient {
   private child: ChildProcessWithoutNullStreams | null = null;
   private stdoutBuffer = "";
   private readonly stdoutDecoder = new StringDecoder("utf8");
+  private stderrBuffer = "";
+  private readonly stderrDecoder = new StringDecoder("utf8");
   private nextId = 1;
   private publicProcessError: string | null = null;
 
@@ -107,15 +109,10 @@ export class IMessageRpcClient {
     });
 
     child.stderr?.on("data", (chunk) => {
-      const lines = chunk.toString().split(/\r?\n/);
-      for (const line of lines) {
-        if (!line.trim()) {
-          continue;
-        }
-        const trimmed = line.trim();
-        this.recordProcessDiagnostic(trimmed);
-        this.runtime?.error?.(`imsg rpc: ${trimmed}`);
+      if (this.child !== child) {
+        return;
       }
+      this.handleStderrChunk(chunk);
     });
 
     // Every process/stdio error is terminal for this RPC transport. Settle the
@@ -138,7 +135,10 @@ export class IMessageRpcClient {
 
     child.on("close", (code, signal) => {
       if (this.child === child) {
+        // Complete both byte streams before selecting the terminal error so a
+        // final split diagnostic can still provide its public recovery guidance.
         this.flushStdoutBuffer();
+        this.flushStderrBuffer();
       }
       this.finish(this.buildCloseError(code, signal));
     });
@@ -150,6 +150,8 @@ export class IMessageRpcClient {
     }
     this.stdoutBuffer = "";
     this.stdoutDecoder.end();
+    this.stderrBuffer = "";
+    this.stderrDecoder.end();
     this.child.stdin?.end();
     const child = this.child;
     this.child = null;
@@ -255,6 +257,38 @@ export class IMessageRpcClient {
       return;
     }
     this.handleLine(trimmed);
+  }
+
+  private handleStderrChunk(chunk: Buffer | string) {
+    const text = typeof chunk === "string" ? chunk : this.stderrDecoder.write(chunk);
+    this.stderrBuffer += text;
+
+    let newlineIndex = this.stderrBuffer.indexOf("\n");
+    while (newlineIndex !== -1) {
+      const line = this.stderrBuffer.slice(0, newlineIndex);
+      this.stderrBuffer = this.stderrBuffer.slice(newlineIndex + 1);
+      this.handleStderrLine(line);
+      newlineIndex = this.stderrBuffer.indexOf("\n");
+    }
+  }
+
+  private flushStderrBuffer() {
+    this.stderrBuffer += this.stderrDecoder.end();
+    if (!this.stderrBuffer) {
+      return;
+    }
+    const line = this.stderrBuffer;
+    this.stderrBuffer = "";
+    this.handleStderrLine(line);
+  }
+
+  private handleStderrLine(line: string) {
+    const trimmed = line.trim();
+    if (!trimmed) {
+      return;
+    }
+    this.recordProcessDiagnostic(trimmed);
+    this.runtime?.error?.(`imsg rpc: ${trimmed}`);
   }
 
   private handleLine(line: string) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where iMessage users whose `imsg rpc` process reports a Full Disk Access failure could receive only `imsg rpc exited (code 1)` when the diagnostic was split across stderr chunks. The generic error hides the actionable permission recovery guidance.

## Why This Change Was Made

The iMessage RPC client now decodes stderr as a byte stream, classifies complete lines, and flushes the final unterminated line before constructing the terminal error. The change is limited to iMessage child-process diagnostics; RPC payloads, delivery behavior, configuration, and permission policy are unchanged.

## User Impact

iMessage users now receive the existing Full Disk Access recovery message even when the helper or operating-system pipe splits the diagnostic or a UTF-8 character across chunks.

## Evidence

AI-assisted.

- Base: current `upstream/main` at `319a796079191a33b74103b3808b4e89fe6cb260`; neither target file changed between the initial investigation and this base.
- Real process path: an actual Node child process was spawned through the production `IMessageRpcClient`. It made three timed stderr writes, splitting both the UTF-8 bytes for `猫` and `Full Disk Access` (`Full Disk Acc` / `ess denied for chat.db`), then exited with code 1. The committed regression test uses this same real child-process pipe.
- Before, on the base above, `node --no-compilation-cache --import tsx .tmp-imessage-stderr-proof.ts` returned:

  ```text
  {"error":"Error: imsg rpc exited (code 1)","diagnostics":["imsg rpc: notice �","imsg rpc: �� Full Disk Acc","imsg rpc: ess denied for chat.db"]}
  ```

- Premise: Node's [`StringDecoder`](https://nodejs.org/api/string_decoder.html) contract retains incomplete multibyte input until the next `write()` or `end()`. Local `@types/node` declarations were also checked for the same `write`/`end` contract.
- After, on commit `0cfb8d784d3d0d948e842efb47ccd91b26631bf5`, the identical command and child fixture returned:

  ```text
  {"error":"Error: imsg cannot access ~/Library/Messages/chat.db. Grant Full Disk Access to the Gateway/launcher process and restart Gateway.","diagnostics":["imsg rpc: notice 猫 Full Disk Access denied for chat.db"]}
  ```

- Negative controls: a complete one-chunk Full Disk Access line still promotes the public error; unrelated unterminated stderr still returns `imsg rpc exited (code 1)`.
- Focused tests:
  - `node scripts/run-vitest.mjs extensions/imessage/src/client.test.ts` — 1 file, 7 tests passed, including the real child-process split-byte case.
  - `node scripts/run-vitest.mjs extensions/imessage/src/status.test.ts` — 1 file, 29 tests passed.
- Static checks:
  - `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json extensions/imessage/src/client.ts extensions/imessage/src/client.test.ts` — passed.
  - `pnpm format:check extensions/imessage/src/client.ts extensions/imessage/src/client.test.ts` — passed.
  - `git diff --check` — passed.
- Review: `.agents/skills/autoreview/scripts/autoreview --mode local --stream-engine-output` — clean, no accepted/actionable findings; final correctness confidence 0.94.
- Not exercised: a signed-in macOS Messages database and real TCC denial were not used. The failure being fixed occurs at the child-process stderr framing boundary before Messages data access; the real-process proof exercises that production boundary. The full `check:changed` wrapper attempted restricted Blacksmith delegation in this contributor checkout and failed its wrapper sanity check before running; fork CI remains pending.
