### PR TITLE
fix(feishu): remove stale schema builder export

### DIFF
--- a/extensions/feishu/src/channel-runtime-api.ts
+++ b/extensions/feishu/src/channel-runtime-api.ts
@@ -8,7 +8,6 @@ export type {
 
 export { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk/account-resolution";
 export { createActionGate } from "openclaw/plugin-sdk/channel-actions";
-export { buildChannelConfigSchema } from "openclaw/plugin-sdk/channel-config-schema";
 export {
   buildProbeChannelStatusSummary,
   createDefaultChannelRuntimeState,


### PR DESCRIPTION
Follow-up to #107336.

## What Problem This Solves

Fixes an issue where the Feishu runtime API retained an unused schema-builder export after #107336 moved schema construction to the Feishu config owner, causing the latest dead-code export check to fail.

## Why This Change Was Made

Removes the stale internal re-export. The active Feishu config schema imports the shared builder directly from the public plugin SDK entrypoint.

## User Impact

No behavior change. Restores the dead-code export gate after the Form config fix landed.

## Evidence

- `pnpm deadcode:exports`: passed on Blacksmith Testbox `tbx_01kxg3qw4q9tewwvn4srj7h3mg`.
- Fresh autoreview: clean; no accepted or actionable findings.
- `git diff --check`: passed.
