### PR TITLE
refactor(media): collapse MIME precedence

### DIFF
--- a/packages/media-core/src/mime.ts
+++ b/packages/media-core/src/mime.ts
@@ -163,60 +163,23 @@ export function isAudioFileName(fileName?: string | null): boolean {
 }
 
 /** Detects the best MIME type from bytes, file path, and header metadata. */
-export function detectMime(opts: {
+export async function detectMime(opts: {
   buffer?: Buffer;
   headerMime?: string | null;
   filePath?: string;
 }): Promise<string | undefined> {
-  return detectMimeImpl(opts);
-}
-
-function isGenericMime(mime?: string): boolean {
-  if (!mime) {
-    return true;
-  }
-  const m = mime.toLowerCase();
-  return m === "application/octet-stream" || m === "application/zip";
-}
-
-function isImageMime(mime?: string): boolean {
-  return mediaKindFromMime(normalizeMimeType(mime)) === "image";
-}
-
-async function detectMimeImpl(opts: {
-  buffer?: Buffer;
-  headerMime?: string | null;
-  filePath?: string;
-}): Promise<string | undefined> {
-  const ext = getFileExtension(opts.filePath);
-  const extMime = ext ? MIME_BY_EXT[ext] : undefined;
-
+  const extMime = MIME_BY_EXT[getFileExtension(opts.filePath) ?? ""];
   const headerMime = normalizeMimeType(opts.headerMime);
   const sniffed = await sniffMime(opts.buffer);
-  const sniffedGenericContainer = sniffed && isGenericMime(sniffed);
-  const trustedExtMime = sniffedGenericContainer && isImageMime(extMime) ? undefined : extMime;
-  const trustedHeaderMime =
-    sniffedGenericContainer && isImageMime(headerMime) ? undefined : headerMime;
+  const sniffedGenericContainer =
+    sniffed === "application/octet-stream" || sniffed === "application/zip";
 
   // Prefer sniffed types, but don't let generic container types override a more
   // specific extension mapping (e.g. XLSX vs ZIP).
-  if (sniffed && (!isGenericMime(sniffed) || !trustedExtMime)) {
-    return sniffed;
+  if (sniffedGenericContainer && extMime && !extMime.startsWith("image/")) {
+    return extMime;
   }
-  if (trustedExtMime) {
-    return trustedExtMime;
-  }
-  if (trustedHeaderMime && !isGenericMime(trustedHeaderMime)) {
-    return trustedHeaderMime;
-  }
-  if (sniffed) {
-    return sniffed;
-  }
-  if (trustedHeaderMime) {
-    return trustedHeaderMime;
-  }
-
-  return undefined;
+  return sniffed ?? extMime ?? headerMime;
 }
 
 /** Returns the preferred file extension for a normalized or raw MIME string. */


### PR DESCRIPTION
## What Problem This Solves

Media MIME detection expressed one precedence rule through a wrapper, two helpers, filtered copies of extension/header metadata, and six return branches.

## Why This Change Was Made

Collapse that state machine around the actual `file-type` 22.0.1 results: specific byte detection wins; generic ZIP/octet-stream detection yields only to a known non-image extension; then extension and normalized header metadata remain fallbacks.

## User Impact

No intended behavior change. MIME selection keeps the same spoof guard and metadata precedence with 37 fewer lines.

## Evidence

- `node scripts/run-vitest.mjs packages/media-core/src/mime.test.ts` — 121 passed
- `node scripts/run-vitest.mjs src/plugins/contracts/session-attachments.contract.test.ts` — 14 passed
- Exhaustive precedence probe — 343 states equivalent
- `git diff --check`
- Fresh post-rebase branch autoreview — clean, 0.96 confidence
