### PR TITLE
fix(macos): honor attach-only launch agent marker

### DIFF
--- a/apps/macos/Sources/OpenClaw/GatewayLaunchAgentManager.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayLaunchAgentManager.swift
@@ -96,7 +96,11 @@ enum GatewayLaunchAgentManager {
     }
 
     static func kickstart() async -> String? {
-        await self.runDaemonCommand(["restart"], timeout: 20)
+        if self.isLaunchAgentWriteDisabled() {
+            self.logger.info("launchd restart skipped (disable marker set)")
+            return nil
+        }
+        return await self.runDaemonCommand(["restart"], timeout: 20)
     }
 
     static func launchdConfigSnapshot() -> LaunchAgentPlistSnapshot? {

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayLaunchAgentManagerTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayLaunchAgentManagerTests.swift
@@ -28,7 +28,7 @@ struct GatewayLaunchAgentManagerTests {
         }
     }
 
-    @Test func `attach only runtime override does not uninstall gateway launch agent`() throws {
+    @Test func `attach only runtime override blocks gateway launch agent writes`() async throws {
         let dir = FileManager().temporaryDirectory
             .appendingPathComponent("openclaw-attach-only-\(UUID().uuidString)", isDirectory: true)
         let marker = dir.appendingPathComponent("disable-launchagent")
@@ -45,8 +45,10 @@ struct GatewayLaunchAgentManagerTests {
         GatewayLaunchAgentManager.clearTestingDaemonCommandCalls()
 
         let error = GatewayLaunchAgentManager.applyAttachOnlyRuntimeOverride()
+        let kickstartError = await GatewayLaunchAgentManager.kickstart()
 
         #expect(error == nil)
+        #expect(kickstartError == nil)
         #expect(FileManager().fileExists(atPath: marker.path))
         #expect(GatewayLaunchAgentManager.testingDaemonCommandCallsSnapshot().isEmpty)
     }


### PR DESCRIPTION
## Summary

- honor the attach-only LaunchAgent disable marker in the restart path
- cover the no-write behavior in the existing manager test

## Proof

- autoreview: clean, no actionable findings
- focused Swift test reaches project compilation with Xcode beta; blocked in unchanged Peekaboo dependency by an actor-isolation compile error

