### PR TITLE
fix(android): keep offline chat actions readable

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt
@@ -921,12 +921,12 @@ private fun ChatOfflineActions(
   onCopyDiagnostics: () -> Unit,
   modifier: Modifier = Modifier,
 ) {
-  Row(
+  Column(
     modifier = modifier.fillMaxWidth(),
-    horizontalArrangement = Arrangement.spacedBy(8.dp),
+    verticalArrangement = Arrangement.spacedBy(8.dp),
   ) {
-    ClawPrimaryButton(text = nativeString("Fix connection"), icon = Icons.Default.Cloud, onClick = onFixConnection, modifier = Modifier.weight(1f))
-    ClawSecondaryButton(text = nativeString("Copy diagnostics"), icon = Icons.Default.ContentCopy, onClick = onCopyDiagnostics, modifier = Modifier.weight(1f))
+    ClawPrimaryButton(text = nativeString("Fix connection"), icon = Icons.Default.Cloud, onClick = onFixConnection, modifier = Modifier.fillMaxWidth())
+    ClawSecondaryButton(text = nativeString("Copy diagnostics"), icon = Icons.Default.ContentCopy, onClick = onCopyDiagnostics, modifier = Modifier.fillMaxWidth())
   }
 }
 


### PR DESCRIPTION
[AI-assisted]
## What Problem This Solves

Fixes an issue where Android users opening Chat while the Gateway is offline could see the “Fix connection” and “Copy diagnostics” actions compressed into a narrow horizontal row.

## Why This Change Was Made

Stacks the two recovery actions vertically and gives each button the full available width. The change stays local to ChatOfflineActions; shared button behavior and connection handling remain unchanged.

## User Impact

Offline recovery actions are fully readable and easier to use on narrow Android screens.

## Evidence

> [!NOTE]
> ### Validation
>
> - [x] `git diff --check` — passed.
> - [x] `pnpm native:i18n:sync` — passed with changed=false.
> - [x] `pnpm native:i18n:check` — passed.
> - [x] `pnpm android:i18n:check` — passed.
> - [x] `pnpm apple:i18n:check` — passed.
> - [x] `pnpm android:assemble` — completed successfully for the exact Base and patched After states.
> - [x] `adb install -r` — installed the patched APK successfully with literal Success.
> - [x] `sha256sum` — confirmed that the installed APK matched the built patched APK byte-for-byte.
> - [x] `adb shell wm size + adb shell settings get system font_scale` — verified the target screen at 1080×2400 with font scale 1.0.

> [!TIP]
> ### Real Behavior Proof
>
> Android emulator behavior verified with the exact patched APK.
>
> - [x] **Environment:** Android API 36 emulators for exact Base and patched After states at 1080×2400 with font scale 1.0.
> - [x] **Precondition:** The Base and After app states were paired and online before reproducing the offline flow.
> - [x] **Before:** The exact Base app was cold-started without Gateway transport, then Chat was opened. “Fix connection” and “Copy diagnostics” appeared in one cramped horizontal row.
> - [x] **After:** The exact patched APK was cold-started through the same offline Chat flow. Both actions appeared vertically at full width with fully readable labels.
> - [x] **Result:** PASS — the offline actions remained fully readable in the patched flow.
> - [x] **Remaining proof gap:** None for the scoped Android emulator behavior.

<table>
  <tr><th>Before</th><th>After</th></tr>
  <tr>
    <td><img width="260" src="https://github.com/user-attachments/assets/cffc5685-379a-4542-b39d-f57d9c474108" alt="Before" /></td>
    <td><img width="260" src="https://github.com/user-attachments/assets/15d28fa3-ed0a-40a2-a85d-2cfb29b16aa3" alt="After" /></td>
  </tr>
</table>

Before behavior recording:

https://github.com/user-attachments/assets/271afab6-f896-4610-86ff-e34241f96637

After behavior recording:

https://github.com/user-attachments/assets/3c02acdb-91e2-49b1-890a-7e1ca79d3ceb
