### PR TITLE
improve: accelerate reply runner tests

### DIFF
--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -2,7 +2,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { testing as cliBackendsTesting } from "../../agents/cli-backends.js";
 import {
   testing as embeddedRunTesting,
@@ -53,7 +53,27 @@ function createCliBackendTestConfig() {
 }
 
 function registerCliBackendsForTest(): void {
+  const backends = [
+    {
+      id: "claude-cli",
+      modelProvider: "anthropic",
+      pluginId: "anthropic",
+      config: { command: "claude" },
+      bundleMcp: false,
+    },
+    {
+      id: "google-gemini-cli",
+      modelProvider: "google",
+      pluginId: "google",
+      config: { command: "gemini" },
+      bundleMcp: false,
+    },
+  ] as const;
   cliBackendsTesting.setDepsForTest({
+    resolvePluginSetupCliBackend: ({ backend }) => {
+      const resolved = backends.find((entry) => entry.id === backend);
+      return resolved ? { pluginId: resolved.pluginId, backend: resolved } : undefined;
+    },
     resolvePluginSetupRegistry: () => ({
       providers: [],
       cliBackends: [],
@@ -61,22 +81,7 @@ function registerCliBackendsForTest(): void {
       autoEnableProbes: [],
       diagnostics: [],
     }),
-    resolveRuntimeCliBackends: () => [
-      {
-        id: "claude-cli",
-        modelProvider: "anthropic",
-        pluginId: "anthropic",
-        config: { command: "claude" },
-        bundleMcp: false,
-      },
-      {
-        id: "google-gemini-cli",
-        modelProvider: "google",
-        pluginId: "google",
-        config: { command: "gemini" },
-        bundleMcp: false,
-      },
-    ],
+    resolveRuntimeCliBackends: () => [...backends],
   });
 }
 
@@ -145,6 +150,17 @@ vi.mock("../../agents/model-selection.js", async () => {
         Boolean(cfg?.agents?.defaults?.cliBackends?.[normalized])
       );
     },
+  };
+});
+
+vi.mock("../../agents/thinking-runtime.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../agents/thinking-runtime.js")>();
+  return {
+    ...actual,
+    resolveCandidateThinkingLevel: (
+      params: Parameters<typeof actual.resolveCandidateThinkingLevel>[0],
+    ) => params.level,
+    resolveEffectiveAgentRuntime: () => "openclaw",
   };
 });
 
@@ -370,7 +386,6 @@ describe("runReplyAgent auto-compaction token update", () => {
         skillsSnapshot: {},
         provider: "anthropic",
         model: "claude",
-        thinkLevel: "low",
         reasoningLevel: "on",
         verboseLevel: "off",
         elevatedLevel: "off",
@@ -523,17 +538,6 @@ describe("runReplyAgent auto-compaction token update", () => {
     const usageEvent = diagnostics.find((event) => event.type === "model.usage");
     return { sessionKey, stored, usageEvent };
   }
-
-  beforeAll(async () => {
-    setupAgentRunnerMocks();
-    await runBaseReplyWithAgentMeta({
-      tmpPrefix: "openclaw-usage-warm-",
-      agentMeta: {
-        usage: { input: 10, output: 5, total: 15 },
-        lastCallUsage: { input: 8, output: 2, total: 10 },
-      },
-    });
-  });
 
   it("updates totalTokens from lastCallUsage even without compaction", async () => {
     const { sessionKey, stored } = await runBaseReplyWithAgentMeta({
@@ -2780,7 +2784,6 @@ describe("runReplyAgent fallback reasoning tags", () => {
         skillsSnapshot: {},
         provider: "anthropic",
         model: "claude",
-        thinkLevel: "low",
         verboseLevel: "off",
         elevatedLevel: "off",
         bashElevated: {

--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -30,6 +30,7 @@ const runPreflightCompactionIfNeededMock = vi.fn();
 const resolveCommandSecretRefsViaGatewayMock = vi.fn();
 const resolveQueuedReplyExecutionConfigMock = vi.fn();
 const resolveProviderFollowupFallbackRouteMock = vi.fn();
+const resolveProviderThinkingProfileMock = vi.fn();
 let resolveQueuedReplyExecutionConfigActual:
   | (typeof import("./agent-runner-utils.js"))["resolveQueuedReplyExecutionConfig"]
   | undefined;
@@ -457,6 +458,16 @@ async function loadFreshFollowupRunnerModuleForTest() {
         resolveProviderFollowupFallbackRouteMock(...args),
     };
   });
+  vi.doMock("../../plugins/provider-thinking.js", async () => {
+    const actual = await vi.importActual<typeof import("../../plugins/provider-thinking.js")>(
+      "../../plugins/provider-thinking.js",
+    );
+    return {
+      ...actual,
+      resolveProviderThinkingProfile: (...args: unknown[]) =>
+        resolveProviderThinkingProfileMock(...args),
+    };
+  });
   vi.doMock("./agent-runner-utils.js", async () => {
     const actual =
       await vi.importActual<typeof import("./agent-runner-utils.js")>("./agent-runner-utils.js");
@@ -528,7 +539,21 @@ async function loadFreshFollowupRunnerModuleForTest() {
 }
 
 function setFastFollowupCliBackendDeps(): void {
+  const claudeBackend = {
+    id: "claude-cli",
+    pluginId: "anthropic",
+    modelProvider: "anthropic",
+    config: { command: "claude" },
+    bundleMcp: false,
+  };
   cliBackendsTestingForTest.setDepsForTest({
+    resolvePluginSetupCliBackend: ({ backend }) =>
+      backend === "claude-cli"
+        ? {
+            pluginId: "anthropic",
+            backend: claudeBackend,
+          }
+        : undefined,
     resolvePluginSetupRegistry: () => ({
       providers: [],
       cliBackends: [],
@@ -536,15 +561,7 @@ function setFastFollowupCliBackendDeps(): void {
       autoEnableProbes: [],
       diagnostics: [],
     }),
-    resolveRuntimeCliBackends: () => [
-      {
-        id: "claude-cli",
-        pluginId: "claude-cli",
-        modelProvider: "anthropic",
-        config: { command: "claude" },
-        bundleMcp: false,
-      },
-    ],
+    resolveRuntimeCliBackends: () => [claudeBackend],
   });
 }
 
@@ -595,6 +612,8 @@ beforeEach(() => {
   resolveQueuedReplyExecutionConfigMock.mockReset();
   resolveProviderFollowupFallbackRouteMock.mockReset();
   resolveProviderFollowupFallbackRouteMock.mockReturnValue(undefined);
+  resolveProviderThinkingProfileMock.mockReset();
+  resolveProviderThinkingProfileMock.mockReturnValue(undefined);
   const resolveQueuedReplyExecutionConfig = resolveQueuedReplyExecutionConfigActual;
   if (!resolveQueuedReplyExecutionConfig) {
     throw new Error("resolveQueuedReplyExecutionConfig mock not initialized");
@@ -2443,6 +2462,15 @@ describe("createFollowupRunner runtime config", () => {
         },
       },
     };
+    resolveProviderThinkingProfileMock.mockImplementation(({ provider }: { provider: string }) => {
+      if (provider === "openai") {
+        return { levels: [{ id: "ultra" }] };
+      }
+      if (provider === "anthropic") {
+        return { levels: [{ id: "max" }] };
+      }
+      return undefined;
+    });
     runWithModelFallbackMock.mockImplementationOnce(
       async (params: { run: (provider: string, model: string) => Promise<unknown> }) => {
         await params.run("openai", "gpt-5.6-sol");

--- a/src/auto-reply/reply/test-helpers.ts
+++ b/src/auto-reply/reply/test-helpers.ts
@@ -46,7 +46,6 @@ export function createMockFollowupRun(
       },
       provider: "anthropic",
       model: "claude",
-      thinkLevel: "low",
       verboseLevel: "off",
       elevatedLevel: "off",
       bashElevated: {


### PR DESCRIPTION
## What Problem This Solves

The auto-reply test suite spent several seconds per file discovering plugin CLI backends and provider thinking metadata unrelated to the runner behavior under test. One suite also needed a no-assertion warm-up run to hide the cold-path cost.

## Why This Change Was Made

Inject fixed CLI-backend and provider-thinking fixtures at the existing test seams, remove the redundant warm-up run, and stop the shared follow-up fixture from selecting thinking behavior by default. The Ultra-level revalidation test still supplies explicit OpenAI and Anthropic profiles, preserving its real contract coverage.

## User Impact

No production behavior change. CI and local test feedback become faster and less variable.

## Evidence

- Main baseline: `followup-runner.test.ts` 13.742s; `agent-runner.misc.runreplyagent.test.ts` 6.099s.
- Exact-base Testbox: 224 tests passed; files 2.785s and 1.639s; test phase 4.42s, total 7.36s.
- Full `src/auto-reply` Testbox: 225 files and 4,239 tests passed across both shards.
- `check:changed` passed formatting, SDK baseline, core and core-test typechecks, lint, import-cycle, and repository guards.
- Blacksmith proof: https://github.com/openclaw/openclaw/actions/runs/29327423695
- Full-suite proof: https://github.com/openclaw/openclaw/actions/runs/29326716965
- Structured autoreview: clean, no accepted or actionable findings.
