### PR TITLE
fix(signal): prevent daemon overlap during restart

### DIFF
--- a/extensions/signal/src/daemon.test.ts
+++ b/extensions/signal/src/daemon.test.ts
@@ -35,6 +35,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  vi.useRealTimers();
   child.stdout.end();
   child.stderr.end();
   child.removeAllListeners();
@@ -118,4 +119,80 @@ describe("spawnSignalDaemon", () => {
       expect(error).toHaveBeenCalledWith(`signal-cli: ${line}`);
     },
   );
+
+  it("waits for exit after SIGTERM before resolving stop", async () => {
+    const handle = spawnSignalDaemon({
+      cliPath: "signal-cli",
+      httpHost: "127.0.0.1",
+      httpPort: 8080,
+    });
+
+    let resolved = false;
+    const stopPromise = handle.stop().then(() => {
+      resolved = true;
+    });
+    await Promise.resolve();
+
+    expect(child.kill).toHaveBeenCalledWith("SIGTERM");
+    expect(resolved).toBe(false);
+
+    child.emit("exit", 0, null);
+    await stopPromise;
+    expect(resolved).toBe(true);
+  });
+
+  it("falls back to SIGKILL when the daemon does not exit after SIGTERM", async () => {
+    vi.useFakeTimers();
+    const handle = spawnSignalDaemon({
+      cliPath: "signal-cli",
+      httpHost: "127.0.0.1",
+      httpPort: 8080,
+    });
+
+    const stopPromise = handle.stop();
+    expect(child.kill).toHaveBeenNthCalledWith(1, "SIGTERM");
+
+    await vi.runOnlyPendingTimersAsync();
+    expect(child.kill).toHaveBeenNthCalledWith(2, "SIGKILL");
+
+    child.emit("exit", null, "SIGKILL");
+    await stopPromise;
+  });
+
+  it("reuses the in-flight stop promise across repeated calls", async () => {
+    const handle = spawnSignalDaemon({
+      cliPath: "signal-cli",
+      httpHost: "127.0.0.1",
+      httpPort: 8080,
+    });
+
+    const firstStop = handle.stop();
+    const secondStop = handle.stop();
+
+    expect(firstStop).toBe(secondStop);
+    expect(child.kill).toHaveBeenCalledTimes(1);
+
+    child.emit("exit", 0, null);
+    await Promise.all([firstStop, secondStop]);
+  });
+
+  it("does not treat a post-spawn signaling error as process exit", async () => {
+    const handle = spawnSignalDaemon({
+      cliPath: "signal-cli",
+      httpHost: "127.0.0.1",
+      httpPort: 8080,
+    });
+    let resolved = false;
+    const stopPromise = handle.stop().then(() => {
+      resolved = true;
+    });
+
+    child.emit("error", new Error("kill EPERM"));
+    await Promise.resolve();
+    expect(resolved).toBe(false);
+
+    child.emit("exit", 0, null);
+    await stopPromise;
+    expect(resolved).toBe(true);
+  });
 });

--- a/extensions/signal/src/daemon.ts
+++ b/extensions/signal/src/daemon.ts
@@ -20,10 +20,12 @@ type SignalDaemonOpts = {
 
 export type SignalDaemonHandle = {
   pid?: number;
-  stop: () => void;
+  stop: () => Promise<void>;
   exited: Promise<SignalDaemonExitEvent>;
   isExited: () => boolean;
 };
+
+const SIGNAL_DAEMON_STOP_KILL_TIMEOUT_MS = 1_500;
 
 type SignalDaemonExitEvent = {
   source: "process" | "spawn-error";
@@ -130,6 +132,7 @@ export function spawnSignalDaemon(opts: SignalDaemonOpts): SignalDaemonHandle {
   const error = opts.runtime?.error ?? (() => {});
   let exited = false;
   let settledExit = false;
+  let stopPromise: Promise<void> | undefined;
   let resolveExit!: (value: SignalDaemonExitEvent) => void;
   const exitedPromise = new Promise<SignalDaemonExitEvent>((resolve) => {
     resolveExit = resolve;
@@ -163,8 +166,14 @@ export function spawnSignalDaemon(opts: SignalDaemonOpts): SignalDaemonHandle {
     });
   });
   child.on("error", (err) => {
-    error(`signal-cli spawn error: ${String(err)}`);
-    settleExit({ source: "spawn-error", code: null, signal: null });
+    // ChildProcess also emits "error" when signaling an already-spawned process fails.
+    // Only a missing pid proves there was no daemon whose exit still needs to be observed.
+    if (child.pid === undefined) {
+      error(`signal-cli spawn error: ${String(err)}`);
+      settleExit({ source: "spawn-error", code: null, signal: null });
+    } else {
+      error(`signal-cli process error: ${String(err)}`);
+    }
   });
 
   return {
@@ -172,9 +181,38 @@ export function spawnSignalDaemon(opts: SignalDaemonOpts): SignalDaemonHandle {
     exited: exitedPromise,
     isExited: () => exited,
     stop: () => {
-      if (!child.killed && !exited) {
-        child.kill("SIGTERM");
+      if (exited) {
+        return Promise.resolve();
       }
+      if (stopPromise) {
+        return stopPromise;
+      }
+      if (!child.killed) {
+        try {
+          child.kill("SIGTERM");
+        } catch (err) {
+          error(`signal-cli stop error: ${String(err)}`);
+        }
+      }
+      stopPromise = new Promise<void>((resolve) => {
+        const timeout = setTimeout(() => {
+          if (!exited) {
+            try {
+              child.kill("SIGKILL");
+            } catch (err) {
+              error(`signal-cli force-stop error: ${String(err)}`);
+            }
+          }
+        }, SIGNAL_DAEMON_STOP_KILL_TIMEOUT_MS);
+        timeout.unref?.();
+        // Do not resolve merely because SIGKILL was sent: monitor lifetime prevents the gateway
+        // from starting a replacement before the old daemon releases its port and config lock.
+        void exitedPromise.then(() => {
+          clearTimeout(timeout);
+          resolve();
+        });
+      });
+      return stopPromise;
     },
   };
 }

--- a/extensions/signal/src/monitor.tool-result.autostart.test.ts
+++ b/extensions/signal/src/monitor.tool-result.autostart.test.ts
@@ -215,7 +215,7 @@ describe("monitorSignalProvider autostart", () => {
     const exitedPromise = new Promise<SignalDaemonExitEvent>((resolve) => {
       resolveExit = resolve;
     });
-    const stop = vi.fn(() => {
+    const stop = vi.fn(async () => {
       if (exited) {
         return;
       }
@@ -224,6 +224,7 @@ describe("monitorSignalProvider autostart", () => {
         throw new Error("Expected signal daemon exit resolver to be initialized");
       }
       resolveExit({ source: "process", code: null, signal: "SIGTERM" });
+      await exitedPromise;
     });
     spawnSignalDaemonMock.mockReturnValueOnce(
       createMockSignalDaemonHandle({
@@ -244,6 +245,40 @@ describe("monitorSignalProvider autostart", () => {
         abortSignal: abortController.signal,
       }),
     ).resolves.toBeUndefined();
+  });
+
+  it("awaits daemon exit before resolving aborted monitor shutdown", async () => {
+    const runtime = createMonitorRuntime();
+    setSignalAutoStartConfig();
+    const abortController = new AbortController();
+    let resolveStop!: () => void;
+    const stopPromise = new Promise<void>((resolve) => {
+      resolveStop = resolve;
+    });
+    const stop = vi.fn(() => stopPromise);
+    spawnSignalDaemonMock.mockReturnValueOnce(createMockSignalDaemonHandle({ stop }));
+    streamMock.mockImplementationOnce(async () => {
+      abortController.abort(new Error("stop"));
+    });
+
+    let settled = false;
+    const monitorPromise = runMonitorWithMocks({
+      autoStart: true,
+      baseUrl: SIGNAL_BASE_URL,
+      runtime,
+      abortSignal: abortController.signal,
+    }).then(() => {
+      settled = true;
+    });
+
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(stop).toHaveBeenCalledTimes(1);
+    expect(settled).toBe(false);
+
+    resolveStop();
+    await monitorPromise;
+    expect(settled).toBe(true);
   });
 });
 

--- a/extensions/signal/src/monitor.tool-result.test-harness.ts
+++ b/extensions/signal/src/monitor.tool-result.test-harness.ts
@@ -88,7 +88,7 @@ export function createMockSignalDaemonHandle(
   const exited = overrides.exited ?? new Promise<SignalDaemonExitEvent>(() => {});
   const isExited = overrides.isExited ?? (() => false);
   return {
-    stop: stop as unknown as () => void,
+    stop: stop as unknown as () => Promise<void>,
     exited,
     isExited,
   };

--- a/extensions/signal/src/monitor.ts
+++ b/extensions/signal/src/monitor.ts
@@ -117,14 +117,14 @@ function createSignalDaemonLifecycle(params: { abortSignal?: AbortSignal }) {
   const abortSignal = params.abortSignal
     ? AbortSignal.any([params.abortSignal, daemonAbortController.signal])
     : daemonAbortController.signal;
-  const stop = () => {
+  const stop = (): Promise<void> => {
     daemonStopRequested = true;
     if (!daemonAbortController.signal.aborted) {
       daemonAbortController.abort(
         params.abortSignal?.reason ?? new Error("Signal monitor stopped"),
       );
     }
-    daemonHandle?.stop();
+    return daemonHandle?.stop() ?? Promise.resolve();
   };
   const attach = (handle: SignalDaemonHandle) => {
     daemonHandle = handle;
@@ -615,7 +615,7 @@ export async function monitorSignalProvider(opts: MonitorSignalOpts = {}): Promi
   }
 
   const onAbort = () => {
-    daemonLifecycle.stop();
+    void daemonLifecycle.stop();
   };
   opts.abortSignal?.addEventListener("abort", onAbort, { once: true });
 
@@ -710,10 +710,9 @@ export async function monitorSignalProvider(opts: MonitorSignalOpts = {}): Promi
     }
     throw err;
   } finally {
-    // Stop first: pending retry delays observe abort, while retries that already
-    // started remain in the task runner and drain before monitor teardown.
-    daemonLifecycle.stop();
-    await monitorTaskRunner.waitForIdle();
+    // Daemon attachment finishes before monitor tasks start. Keep teardown open until both the
+    // child has exited and already-started reply work has drained.
+    await Promise.all([daemonLifecycle.stop(), monitorTaskRunner.waitForIdle()]);
     opts.abortSignal?.removeEventListener("abort", onAbort);
   }
 }


### PR DESCRIPTION
Closes #22676

## What Problem This Solves

Fixes an issue where Signal users restarting or hot-reloading the gateway could start a replacement signal-cli daemon before the previous daemon released its HTTP port and config lock. That race caused orphaned processes, bind/lock failures, and failed message sends.

## Why This Change Was Made

Signal daemon shutdown is now asynchronous and idempotent: it sends SIGTERM, escalates to SIGKILL after a bounded grace period, and resolves only after Node observes process exit. Signal monitor teardown stays alive until both the daemon exits and already-started reply work drains. Post-spawn signaling errors no longer masquerade as spawn failures and prematurely mark a live daemon exited.

The implementation preserves the newer readline-safe signal-cli output handling on current main and carries the original #71863 contributor as co-author.

## User Impact

Signal gateway restarts no longer race the old daemon for its port or config lock. Graceful signal-cli cleanup remains preferred; stuck daemons are force-stopped before restart recovery proceeds.

## Evidence

- Focused tests: 16 passed across daemon lifecycle and monitor autostart shutdown coverage.
- Linux Blacksmith Testbox: 15 focused tests passed before the final post-spawn error regression case was added; run https://github.com/openclaw/openclaw/actions/runs/29327206638.
- Direct signal-cli v0.13.23 source inspection confirmed SIGTERM triggers its shutdown handler, closes daemon transports/managers, and exits only after cleanup completes.
- TypeScript LOC ratchet, oxfmt check, and git diff check passed.
- Fresh autoreview: clean, confidence 0.94.
