### PR TITLE
fix(session-catalog): authorize paired-node reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Paired-node session catalogs:** authorize bundled Anthropic and Codex catalog requests to invoke their read-only node commands from Control UI read flows, restoring remote Claude/Codex rows and terminal resume availability. Fixes #107406.
 - **Sandbox recreate confirmation:** treat Clack cancellation as a decline so Ctrl-C cannot proceed with container removal.
 - **Microsoft Teams HTML text:** decode HTML5 entities consistently in quoted and Graph-fetched messages while preserving literal escaped entity text.
 - **ClawHub plugin API ranges:** delegate each supported comparator to `semver` so tilde, partial-wildcard, and prerelease caret bounds are correct while preserving OpenClaw version normalization and the existing restricted range grammar. (#106877)

--- a/extensions/anthropic/session-catalog.test.ts
+++ b/extensions/anthropic/session-catalog.test.ts
@@ -602,7 +602,13 @@ describe("Claude session catalog", () => {
       }),
     );
     expect(invoke).toHaveBeenCalledWith(
-      expect.objectContaining({ command: CLAUDE_SESSION_READ_COMMAND }),
+      expect.objectContaining({
+        command: CLAUDE_SESSION_READ_COMMAND,
+        scopes: ["operator.write"],
+      }),
+    );
+    expect(invoke.mock.calls.every(([request]) => request.scopes?.includes("operator.write"))).toBe(
+      true,
     );
 
     nodes[0]!.invocableCommands = [

--- a/extensions/anthropic/session-catalog.ts
+++ b/extensions/anthropic/session-catalog.ts
@@ -953,6 +953,7 @@ export async function listClaudeSessionCatalog(params: {
             ...(query.cursors?.[hostId] ? { cursor: query.cursors[hostId] } : {}),
           },
           timeoutMs: NODE_INVOKE_TIMEOUT_MS,
+          scopes: ["operator.write"],
         });
         return Object.assign(common, parseCatalogPage(unwrapNodePayload(raw)));
       } catch {
@@ -1009,6 +1010,7 @@ async function readClaudeSessionTranscript(params: {
       ...(params.cursor ? { cursor: params.cursor } : {}),
     },
     timeoutMs: NODE_INVOKE_TIMEOUT_MS,
+    scopes: ["operator.write"],
   });
   const page = unwrapNodePayload(raw);
   if (
@@ -1080,6 +1082,7 @@ export async function resolveNodeClaudeRecord(params: {
         ...(cursor ? { cursor } : {}),
       },
       timeoutMs: NODE_INVOKE_TIMEOUT_MS,
+      scopes: ["operator.write"],
     });
     const page = parseCatalogPage(unwrapNodePayload(raw));
     const record = page.sessions.find((candidate) => candidate.threadId === params.threadId);

--- a/extensions/codex/src/node-cli-sessions.test.ts
+++ b/extensions/codex/src/node-cli-sessions.test.ts
@@ -156,6 +156,10 @@ describe("codex cli node sessions", () => {
   });
 
   it("reports malformed node session payloadJSON with an owned error", async () => {
+    const invoke = vi.fn(async () => ({
+      ok: true,
+      payloadJSON: "{not json",
+    }));
     const runtime = {
       nodes: {
         list: vi.fn(async () => ({
@@ -167,10 +171,7 @@ describe("codex cli node sessions", () => {
             },
           ],
         })),
-        invoke: vi.fn(async () => ({
-          ok: true,
-          payloadJSON: "{not json",
-        })),
+        invoke,
       },
     } as unknown as PluginRuntime;
 
@@ -180,6 +181,7 @@ describe("codex cli node sessions", () => {
         requestedNode: "node-1",
       }),
     ).rejects.toThrow("Codex CLI node command returned malformed payloadJSON.");
+    expect(invoke).toHaveBeenCalledWith(expect.objectContaining({ scopes: ["operator.write"] }));
   });
 
   it("keeps Codex history session previews on UTF-16 code point boundaries", async () => {

--- a/extensions/codex/src/node-cli-sessions.ts
+++ b/extensions/codex/src/node-cli-sessions.ts
@@ -119,6 +119,7 @@ export async function listCodexCliSessionsOnNode(params: {
       filter: params.filter,
     },
     timeoutMs: 15_000,
+    scopes: ["operator.write"],
   });
   return { node, result: parseCodexCliSessionsListResult(raw) };
 }
@@ -163,6 +164,7 @@ export async function resumeCodexCliSessionOnNode(params: {
       timeoutMs: params.timeoutMs,
     },
     timeoutMs: (params.timeoutMs ?? DEFAULT_RESUME_TIMEOUT_MS) + 5_000,
+    scopes: ["operator.write"],
   });
   const payload = unwrapNodeInvokePayload(raw);
   if (!isRecord(payload) || payload.ok !== true || typeof payload.text !== "string") {

--- a/extensions/codex/src/session-catalog-node-continue.ts
+++ b/extensions/codex/src/session-catalog-node-continue.ts
@@ -105,6 +105,7 @@ export async function listPairedNode(params: {
         searchTerm: params.query.search,
       },
       timeoutMs: NODE_INVOKE_TIMEOUT_MS,
+      scopes: ["operator.write"],
     });
     const page = filterCatalogPageByTitle(
       parseCatalogPage(unwrapNodeInvokePayload(raw)),
@@ -162,6 +163,7 @@ async function resolveNodeCodexRecord(params: {
         ...(cursor ? { cursor } : {}),
       },
       timeoutMs: NODE_INVOKE_TIMEOUT_MS,
+      scopes: ["operator.write"],
     });
     const page = parseCatalogPage(unwrapNodeInvokePayload(raw));
     const record = page.sessions.find((candidate) => candidate.threadId === params.threadId);
@@ -216,6 +218,7 @@ async function readNodeCodexHistory(params: {
       limit: MAX_TRANSCRIPT_PAGE_LIMIT,
     },
     timeoutMs: NODE_INVOKE_TIMEOUT_MS,
+    scopes: ["operator.write"],
   });
   const page = parseTranscriptPage(unwrapNodeInvokePayload(raw));
   const thread: CodexThread = {

--- a/extensions/codex/src/session-catalog-terminal.ts
+++ b/extensions/codex/src/session-catalog-terminal.ts
@@ -141,6 +141,7 @@ async function resolveNodeCatalogEligibleThread(params: {
         ...(cursor ? { cursor } : {}),
       },
       timeoutMs: NODE_INVOKE_TIMEOUT_MS,
+      scopes: ["operator.write"],
     });
     const page = params.parseCatalogPage(unwrapNodeInvokePayload(raw));
     const record = page.sessions.find((candidate) => candidate.threadId === params.threadId);

--- a/extensions/codex/src/session-catalog.test.ts
+++ b/extensions/codex/src/session-catalog.test.ts
@@ -777,6 +777,7 @@ describe("Codex supervision catalog", () => {
         command: CODEX_APP_SERVER_THREADS_LIST_COMMAND,
         params: expect.not.objectContaining({ archived: expect.anything() }),
         timeoutMs: 65_000,
+        scopes: ["operator.write"],
       }),
     );
     expect(JSON.stringify(result)).not.toContain("private");
@@ -926,12 +927,14 @@ describe("Codex supervision catalog", () => {
       expect.objectContaining({
         nodeId: "healthy",
         params: { cursor: "healthy-page-2", limit: 7, searchTerm: "match" },
+        scopes: ["operator.write"],
       }),
     );
     expect(invoke).toHaveBeenCalledWith(
       expect.objectContaining({
         nodeId: "broken",
         params: { cursor: "broken-page-2", limit: 7, searchTerm: "match" },
+        scopes: ["operator.write"],
       }),
     );
     expect(result.hosts).toEqual([
@@ -3422,6 +3425,7 @@ describe("Codex supervision actions", () => {
       command: CODEX_APP_SERVER_THREAD_TURNS_LIST_COMMAND,
       params: { threadId: "thread-remote", cursor: "remote-turns-1", limit: 25 },
       timeoutMs: 65_000,
+      scopes: ["operator.write"],
     });
   });
 });

--- a/extensions/codex/src/session-catalog.ts
+++ b/extensions/codex/src/session-catalog.ts
@@ -594,6 +594,7 @@ async function readCodexSessionTranscript(params: {
       ...(params.cursor ? { cursor: params.cursor } : {}),
     },
     timeoutMs: NODE_INVOKE_TIMEOUT_MS,
+    scopes: ["operator.write"],
   });
   const page = parseTranscriptPage(unwrapNodeInvokePayload(raw));
   return {


### PR DESCRIPTION
## Summary

- request `operator.write` for bundled Anthropic and Codex paired-node catalog invocations
- keep catalog list, transcript read, record validation, terminal eligibility, and Codex CLI node operations on the same trusted scope path
- add regression assertions for the effective invocation scope

Fixes #107406.

## Validation

- `node scripts/run-vitest.mjs extensions/codex/src/session-catalog.test.ts extensions/codex/src/node-cli-sessions.test.ts extensions/anthropic/session-catalog.test.ts` (110 tests passed)
- Blacksmith Testbox-through-Crabbox `tbx_01kxg5dkpp6q5eytkexh93sqmb`, Actions run 29328260212 (110 tests passed)
- `oxfmt --check` on all touched files
- `git diff --check`
- autoreview clean, no actionable findings

## Live proof

Before: direct `node.invoke` succeeded but `sessions.catalog.list` returned `NODE_INVOKE_FAILED` for the same paired node.

After deployment: verify the paired-node catalog row and active **Open in terminal** menu item against the landed SHA.
