### PR TITLE
fix(maint): honor recent green PR cohorts

### DIFF
--- a/scripts/verify-pr-hosted-gates.d.mts
+++ b/scripts/verify-pr-hosted-gates.d.mts
@@ -16,6 +16,9 @@ export function collectHostedGateEvidence({
   sha,
   pr,
   recentSha,
+  pullRequestCommitShas,
+  pullRequestHeadBranch,
+  pullRequestHeadRepository,
   workflowRuns,
   changelogOnly,
   nowMs,
@@ -23,6 +26,9 @@ export function collectHostedGateEvidence({
   sha: string;
   pr?: number;
   recentSha?: string;
+  pullRequestCommitShas?: string[];
+  pullRequestHeadBranch?: string;
+  pullRequestHeadRepository?: string;
   workflowRuns: Array<Record<string, unknown>>;
   changelogOnly?: boolean | undefined;
   nowMs?: number | undefined;
@@ -47,6 +53,7 @@ export function collectHostedGateEvidence({
     reason: string;
   }[];
 };
+export function compareCommitPageCount(totalCommits: number): number;
 export function workflowRunQueryPaths(
   repo: string,
   {

--- a/scripts/verify-pr-hosted-gates.mjs
+++ b/scripts/verify-pr-hosted-gates.mjs
@@ -19,6 +19,7 @@ const ARTIFACT_FALLBACK_REQUIRED_WORKFLOWS = [
 ];
 const WORKFLOW_RUNS_PAGE_SIZE = 100;
 const MAX_WORKFLOW_RUN_SEARCH_RESULTS = 1_000;
+const COMPARE_COMMITS_PAGE_SIZE = 100;
 export const HOSTED_GATE_MAX_AGE_HOURS = 24;
 const HOSTED_GATE_MAX_AGE_MS = HOSTED_GATE_MAX_AGE_HOURS * 60 * 60 * 1_000;
 const HOSTED_GATE_CLOCK_SKEW_MS = 5 * 60 * 1_000;
@@ -187,6 +188,29 @@ function hasSuccessfulRecentReleaseGate(workflowRuns, sha, nowMs) {
   return isSuccessfulRecentRun(releaseGate, nowMs);
 }
 
+function runBelongsToPullRequest(
+  run,
+  pr,
+  pullRequestCommitShas,
+  pullRequestHeadBranch,
+  pullRequestHeadRepository,
+) {
+  if (run?.pull_requests?.some((pullRequest) => pullRequest?.number === pr)) {
+    return true;
+  }
+  if (Array.isArray(run?.pull_requests) && run.pull_requests.length > 0) {
+    return false;
+  }
+  // Fork pull_request runs currently arrive with pull_requests: []. Require
+  // the immutable commit plus its PR head identity; branch identity alone is
+  // mutable, while ancestry alone can include commits from merged branches.
+  return (
+    pullRequestCommitShas.has(run?.head_sha) &&
+    run?.head_branch === pullRequestHeadBranch &&
+    run?.head_repository?.full_name?.toLowerCase() === pullRequestHeadRepository.toLowerCase()
+  );
+}
+
 function canCoverQueuedBuildArtifacts(workflowRuns, sha, nowMs) {
   if (!hasSuccessfulRecentReleaseGate(workflowRuns, sha, nowMs)) {
     return false;
@@ -239,6 +263,9 @@ export function collectHostedGateEvidence({
   sha,
   pr,
   recentSha,
+  pullRequestCommitShas = [],
+  pullRequestHeadBranch = "",
+  pullRequestHeadRepository = "",
   workflowRuns,
   changelogOnly = false,
   nowMs = Date.now(),
@@ -246,6 +273,7 @@ export function collectHostedGateEvidence({
   if (!Array.isArray(workflowRuns)) {
     throw new Error("workflowRuns must be an array.");
   }
+  const pullRequestCommitShaSet = new Set(pullRequestCommitShas);
 
   const collectForSha = (evidenceSha, { allowManual, requiredScheduledWorkflows = new Set() }) => {
     const workflows = [];
@@ -295,27 +323,9 @@ export function collectHostedGateEvidence({
   try {
     selected = collectForSha(sha, { allowManual: true });
   } catch (exactError) {
-    const currentWorkflowNames = ["CI", ...SCHEDULED_HOSTED_WORKFLOWS];
-    const currentHeadHasTerminalNonSuccess = currentWorkflowNames.some((workflowName) => {
-      const latestScheduled = latestRun(
-        matchingAuthoritativeRuns(workflowRuns, workflowName, sha, false).filter(
-          (run) => run?.status === "completed",
-        ),
-      );
-      if (latestScheduled && latestScheduled.conclusion !== "success") {
-        return true;
-      }
-      if (workflowName !== "CI") {
-        return false;
-      }
-      const latestManual = latestRun(
-        workflowRuns.filter((run) => isReleaseGateCiRun(run, sha) && run?.status === "completed"),
-      );
-      return latestManual && latestManual.conclusion !== "success";
-    });
-    if (currentHeadHasTerminalNonSuccess) {
-      throw exactError;
-    }
+    // Hosted CI proves the PR cohort, not ancestry freshness. A newer head's
+    // failure must not discard a complete same-PR green cohort from the last
+    // 24 hours; review and focused gates own the newer delta.
     const targetScheduledWorkflows = new Set(
       SCHEDULED_HOSTED_WORKFLOWS.filter(
         (workflowName) =>
@@ -329,7 +339,13 @@ export function collectHostedGateEvidence({
           (run) =>
             run?.event === "pull_request" &&
             run?.head_sha !== sha &&
-            run?.pull_requests?.some((pullRequest) => pullRequest?.number === pr) &&
+            runBelongsToPullRequest(
+              run,
+              pr,
+              pullRequestCommitShaSet,
+              pullRequestHeadBranch,
+              pullRequestHeadRepository,
+            ) &&
             isRecentRun(run, nowMs),
         )
         .toSorted((left, right) =>
@@ -420,19 +436,74 @@ function loadWorkflowRuns(repo, sha, recentSha, headBranch) {
   return [...new Map(workflowRuns.map((run) => [run.id, run])).values()];
 }
 
+export function compareCommitPageCount(totalCommits) {
+  if (!Number.isSafeInteger(totalCommits) || totalCommits < 0) {
+    throw new Error("Expected comparison total_commits to be a non-negative integer.");
+  }
+  return Math.max(1, Math.ceil(totalCommits / COMPARE_COMMITS_PAGE_SIZE));
+}
+
+function loadPullRequestCommitShas(repo, { baseSha, headSha }) {
+  const loadPage = (page) =>
+    JSON.parse(
+      execPlainGh(
+        [
+          "api",
+          `repos/${repo}/compare/${baseSha}...${headSha}?per_page=${COMPARE_COMMITS_PAGE_SIZE}&page=${page}`,
+        ],
+        {
+          encoding: "utf8",
+          stdio: ["ignore", "pipe", "pipe"],
+        },
+      ),
+    );
+
+  // The PR commits endpoint stops at 250. GitHub's paginated comparison is
+  // equivalent to git log BASE..HEAD and keeps the membership proof complete.
+  const firstPage = loadPage(1);
+  const pages = [firstPage];
+  for (let page = 2; page <= compareCommitPageCount(firstPage?.total_commits); page += 1) {
+    pages.push(loadPage(page));
+  }
+  const shas = pages.flatMap((comparison, index) => {
+    if (!Array.isArray(comparison?.commits)) {
+      throw new Error(`Expected comparison commit page ${index + 1} to be an array.`);
+    }
+    return comparison.commits.map((commit) => commit?.sha).filter(Boolean);
+  });
+  if (shas.length !== firstPage.total_commits) {
+    throw new Error(
+      `Expected ${firstPage.total_commits} comparison commits, received ${shas.length}.`,
+    );
+  }
+  return shas;
+}
+
 export function main(argv = process.argv.slice(2)) {
   const args = parseArgs(argv);
-  const headBranch = execPlainGh(
-    ["api", `repos/${args.repo}/pulls/${args.pr}`, "--jq", ".head.ref"],
-    {
+  const pullRequest = JSON.parse(
+    execPlainGh(["api", `repos/${args.repo}/pulls/${args.pr}`], {
       encoding: "utf8",
       stdio: ["ignore", "pipe", "pipe"],
-    },
-  ).trim();
+    }),
+  );
+  const headBranch = pullRequest?.head?.ref;
+  const headRepository = pullRequest?.head?.repo?.full_name;
+  const baseSha = pullRequest?.base?.sha;
+  const headSha = pullRequest?.head?.sha;
+  if (!headBranch || !headRepository || !baseSha || !headSha) {
+    throw new Error(`PR #${args.pr} is missing head or base metadata.`);
+  }
+  if (headSha !== args.sha) {
+    throw new Error(`PR #${args.pr} head changed from ${args.sha} to ${headSha}.`);
+  }
   const evidence = collectHostedGateEvidence({
     sha: args.sha,
     pr: args.pr,
     recentSha: args.recentSha,
+    pullRequestCommitShas: loadPullRequestCommitShas(args.repo, { baseSha, headSha }),
+    pullRequestHeadBranch: headBranch,
+    pullRequestHeadRepository: headRepository,
     workflowRuns: loadWorkflowRuns(args.repo, args.sha, args.recentSha, headBranch),
     changelogOnly: args.changelogOnly,
   });

--- a/test/scripts/verify-pr-hosted-gates.test.ts
+++ b/test/scripts/verify-pr-hosted-gates.test.ts
@@ -2,6 +2,7 @@ import { expectDefined } from "@openclaw/normalization-core";
 import { describe, expect, it } from "vitest";
 import {
   collectHostedGateEvidence as collectHostedGateEvidenceRaw,
+  compareCommitPageCount,
   HOSTED_GATE_MAX_AGE_HOURS,
   parseArgs,
   parseWorkflowRunPage,
@@ -176,6 +177,92 @@ describe("verify-pr-hosted-gates", () => {
     });
   });
 
+  it("accepts a recent green fork head when GitHub omits pull request links", () => {
+    const headBranch = "fix/token-listener";
+    const headRepository = "contributor/openclaw";
+    const evidence = collectHostedGateEvidence({
+      sha,
+      pullRequestCommitShas: [previousSha, sha],
+      pullRequestHeadBranch: headBranch,
+      pullRequestHeadRepository: headRepository,
+      workflowRuns: [
+        {
+          ...successfulRun("CI", 1, "2026-06-17T10:50:00Z"),
+          head_sha: previousSha,
+          head_branch: headBranch,
+          head_repository: { full_name: headRepository },
+          pull_requests: [],
+        },
+        {
+          ...successfulRun("CI", 2, "2026-06-17T10:54:00Z"),
+          head_branch: headBranch,
+          head_repository: { full_name: headRepository },
+          pull_requests: [],
+          conclusion: "failure",
+        },
+      ],
+    });
+
+    expect(evidence).toEqual({
+      headSha: sha,
+      evidenceHeadSha: previousSha,
+      workflows: [expect.objectContaining({ name: "CI", id: 1, headSha: previousSha })],
+    });
+  });
+
+  it("rejects an unlinked fork run whose head is absent from the PR commit list", () => {
+    expect(() =>
+      collectHostedGateEvidence({
+        sha,
+        pullRequestCommitShas: [sha],
+        pullRequestHeadBranch: "fix/token-listener",
+        pullRequestHeadRepository: "other/openclaw",
+        workflowRuns: [
+          {
+            ...successfulRun("CI", 1, "2026-06-17T10:50:00Z"),
+            head_sha: previousSha,
+            head_branch: "fix/token-listener",
+            head_repository: { full_name: "other/openclaw" },
+            pull_requests: [],
+          },
+          {
+            ...successfulRun("CI", 2, "2026-06-17T10:54:00Z"),
+            conclusion: "failure",
+          },
+        ],
+      }),
+    ).toThrow(`Missing successful recent CI workflow for ${sha}`);
+  });
+
+  it("rejects a commit-list run explicitly linked to another PR", () => {
+    expect(() =>
+      collectHostedGateEvidence({
+        sha,
+        pullRequestCommitShas: [previousSha, sha],
+        pullRequestHeadBranch: "fix/token-listener",
+        pullRequestHeadRepository: "contributor/openclaw",
+        workflowRuns: [
+          {
+            ...successfulRun("CI", 1, "2026-06-17T10:50:00Z"),
+            head_sha: previousSha,
+            pull_requests: [{ number: pr + 1 }],
+          },
+          {
+            ...successfulRun("CI", 2, "2026-06-17T10:54:00Z"),
+            conclusion: "failure",
+          },
+        ],
+      }),
+    ).toThrow(`Missing successful recent CI workflow for ${sha}`);
+  });
+
+  it("paginates comparisons beyond the pull-request endpoint's 250-commit cap", () => {
+    expect(compareCommitPageCount(0)).toBe(1);
+    expect(compareCommitPageCount(250)).toBe(3);
+    expect(compareCommitPageCount(251)).toBe(3);
+    expect(compareCommitPageCount(301)).toBe(4);
+  });
+
   it("requires recent evidence for scheduled gates observed on the target head", () => {
     const targetArmRun = {
       ...successfulRun("Blacksmith ARM Testbox", 3, "2026-06-17T10:54:00Z"),
@@ -217,24 +304,28 @@ describe("verify-pr-hosted-gates", () => {
   });
 
   it.each(["failure", "cancelled", "skipped"])(
-    "does not reuse older green evidence after a current-head %s run",
+    "reuses recent same-PR green evidence after a current-head %s run",
     (conclusion) => {
-      expect(() =>
-        collectHostedGateEvidence({
-          sha,
-          recentSha: previousSha,
-          workflowRuns: [
-            {
-              ...successfulRun("CI", 1, "2026-06-17T10:50:00Z"),
-              head_sha: previousSha,
-            },
-            {
-              ...successfulRun("CI", 2, "2026-06-17T10:54:00Z"),
-              conclusion,
-            },
-          ],
-        }),
-      ).toThrow(`Missing successful recent CI workflow for ${sha}`);
+      const evidence = collectHostedGateEvidence({
+        sha,
+        recentSha: previousSha,
+        workflowRuns: [
+          {
+            ...successfulRun("CI", 1, "2026-06-17T10:50:00Z"),
+            head_sha: previousSha,
+          },
+          {
+            ...successfulRun("CI", 2, "2026-06-17T10:54:00Z"),
+            conclusion,
+          },
+        ],
+      });
+
+      expect(evidence).toEqual({
+        headSha: sha,
+        evidenceHeadSha: previousSha,
+        workflows: [expect.objectContaining({ name: "CI", id: 1, headSha: previousSha })],
+      });
     },
   );
 
@@ -307,30 +398,34 @@ describe("verify-pr-hosted-gates", () => {
     ).toThrow(`Missing successful recent Blacksmith ARM Testbox workflow for ${previousSha}`);
   });
 
-  it("does not reuse pre-rebase green evidence after a failed current-head manual gate", () => {
-    expect(() =>
-      collectHostedGateEvidence({
-        sha,
-        recentSha: previousSha,
-        workflowRuns: [
-          {
-            ...successfulRun("CI", 1, "2026-06-17T10:50:00Z"),
-            head_sha: previousSha,
-          },
-          {
-            ...successfulRun("CI", 2, "2026-06-17T10:53:00Z"),
-            status: "in_progress",
-            conclusion: null,
-          },
-          {
-            ...successfulRun(`CI release gate ${sha}`, 3, "2026-06-17T10:54:00Z"),
-            event: "workflow_dispatch",
-            display_title: `CI release gate ${sha}`,
-            conclusion: "failure",
-          },
-        ],
-      }),
-    ).toThrow(`Missing successful recent CI workflow for ${sha}`);
+  it("reuses pre-rebase green evidence after a failed current-head manual gate", () => {
+    const evidence = collectHostedGateEvidence({
+      sha,
+      recentSha: previousSha,
+      workflowRuns: [
+        {
+          ...successfulRun("CI", 1, "2026-06-17T10:50:00Z"),
+          head_sha: previousSha,
+        },
+        {
+          ...successfulRun("CI", 2, "2026-06-17T10:53:00Z"),
+          status: "in_progress",
+          conclusion: null,
+        },
+        {
+          ...successfulRun(`CI release gate ${sha}`, 3, "2026-06-17T10:54:00Z"),
+          event: "workflow_dispatch",
+          display_title: `CI release gate ${sha}`,
+          conclusion: "failure",
+        },
+      ],
+    });
+
+    expect(evidence).toEqual({
+      headSha: sha,
+      evidenceHeadSha: previousSha,
+      workflows: [expect.objectContaining({ name: "CI", id: 1, headSha: previousSha })],
+    });
   });
 
   it("rejects stale or unrecorded fallback heads", () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where maintainers could not land a reviewed PR using its complete green CI cohort from the last 24 hours when a newer head had a terminal failure, cancellation, or skip. Fork PR runs were also missed when GitHub returned an empty pull-request association list.

## Why This Change Was Made

Recent same-PR green cohorts remain valid for 24 hours even when a newer head has a terminal result. Unlinked fork runs are accepted only when their SHA is in the complete paginated `BASE..HEAD` comparison and their repository and branch match the PR head; explicitly linked runs from another PR remain rejected.

## User Impact

Maintainers can land reviewed incremental fixups without repeatedly rebasing solely because `main` advanced or an unrelated current-head lane failed. The coordinator still requires a complete, recent cohort from the same PR.

## Evidence

- Blacksmith Testbox `tbx_01kxg4718y2hna0dfpmncvvma7`: 44/44 focused verifier tests passed.
- `pnpm check:changed -- scripts/verify-pr-hosted-gates.mjs scripts/verify-pr-hosted-gates.d.mts test/scripts/verify-pr-hosted-gates.test.ts` passed remotely, including formatting, script/test type checks, lint, and repository guards.
- Live proof against fork PR #105886 at `87dbb640b7968105e73ba747b04bb7d10c700fc7` selected the complete green cohort at `22b2d4969b6a346545791426d5c3ff2c3c5c91ca`: CI run 29307460692 and Workflow Sanity run 29307460667.
- Fresh structured autoreview: clean, no accepted/actionable findings.
