### PR TITLE
refactor(schemas): use TypeBox native enums

### DIFF
--- a/extensions/feishu/src/chat-schema.ts
+++ b/extensions/feishu/src/chat-schema.ts
@@ -6,9 +6,8 @@ const CHAT_ACTION_VALUES = ["members", "info", "member_info"] as const;
 const MEMBER_ID_TYPE_VALUES = ["open_id", "user_id", "union_id"] as const;
 
 export const FeishuChatSchema = Type.Object({
-  action: Type.Unsafe<(typeof CHAT_ACTION_VALUES)[number]>({
+  action: Type.Enum(CHAT_ACTION_VALUES, {
     type: "string",
-    enum: [...CHAT_ACTION_VALUES],
     description: "Action to run: members | info | member_info",
   }),
   chat_id: Type.Optional(Type.String({ description: "Chat ID (from URL or event payload)" })),
@@ -19,9 +18,8 @@ export const FeishuChatSchema = Type.Object({
   }),
   page_token: Type.Optional(Type.String({ description: "Pagination token" })),
   member_id_type: Type.Optional(
-    Type.Unsafe<(typeof MEMBER_ID_TYPE_VALUES)[number]>({
+    Type.Enum(MEMBER_ID_TYPE_VALUES, {
       type: "string",
-      enum: [...MEMBER_ID_TYPE_VALUES],
       description: "Member ID type (default: open_id)",
     }),
   ),

--- a/extensions/lobster/src/lobster-tool.ts
+++ b/extensions/lobster/src/lobster-tool.ts
@@ -238,8 +238,7 @@ export function createLobsterTool(api: OpenClawPluginApi, options?: LobsterToolO
     description:
       "Run Lobster pipelines as a local-first workflow runtime (typed JSON envelope + resumable approvals).",
     parameters: Type.Object({
-      // NOTE: Prefer string enums in tool schemas; some providers reject unions/anyOf.
-      action: Type.Unsafe<"run" | "resume">({ type: "string", enum: ["run", "resume"] }),
+      action: Type.Enum(["run", "resume"], { type: "string" }),
       pipeline: Type.Optional(Type.String()),
       argsJson: Type.Optional(Type.String()),
       token: Type.Optional(Type.String()),

--- a/extensions/memory-lancedb/index.ts
+++ b/extensions/memory-lancedb/index.ts
@@ -1600,12 +1600,7 @@ export default definePluginEntry({
             minimum: 0,
             maximum: 1,
           }),
-          category: Type.Optional(
-            Type.Unsafe<MemoryCategory>({
-              type: "string",
-              enum: [...MEMORY_CATEGORIES],
-            }),
-          ),
+          category: Type.Optional(Type.Enum(MEMORY_CATEGORIES, { type: "string" })),
         }),
         async execute(_toolCallId, params) {
           const { text, category = "other" } = params as {

--- a/extensions/whatsapp/src/agent-tools-login.ts
+++ b/extensions/whatsapp/src/agent-tools-login.ts
@@ -18,13 +18,8 @@ export function createWhatsAppLoginTool(): ChannelAgentTool {
     label: "WhatsApp Login",
     name: "whatsapp_login",
     description: "Generate a WhatsApp QR code for linking, or wait for the scan to complete.",
-    // NOTE: Using Type.Unsafe for action enum instead of Type.Union([Type.Literal(...)]
-    // because Claude API on Vertex AI rejects nested anyOf schemas as invalid JSON Schema.
     parameters: Type.Object({
-      action: Type.Unsafe<"start" | "wait">({
-        type: "string",
-        enum: ["start", "wait"],
-      }),
+      action: Type.Enum(["start", "wait"], { type: "string" }),
       timeoutMs: optionalPositiveIntegerSchema(),
       force: Type.Optional(Type.Boolean()),
       accountId: Type.Optional(Type.String()),

--- a/packages/llm-core/src/validation.ts
+++ b/packages/llm-core/src/validation.ts
@@ -1,11 +1,9 @@
 // LLM Core module implements validation behavior.
 import { Compile } from "typebox/compile";
 import type { TLocalizedValidationError } from "typebox/error";
-import { Value } from "typebox/value";
 import type { Tool, ToolCall } from "./types.js";
 
 const validatorCache = new WeakMap<object, ReturnType<typeof Compile>>();
-const TYPEBOX_KIND = Symbol.for("TypeBox.Kind");
 
 /** Maximum string length accepted for schema-gated JSON coercion. */
 const MAX_JSON_COERCE_LENGTH = 64 * 1024;
@@ -26,10 +24,6 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function isJsonSchemaObject(value: unknown): value is JsonSchemaObject {
   return isRecord(value);
-}
-
-function hasTypeBoxMetadata(schema: unknown): boolean {
-  return isRecord(schema) && Object.getOwnPropertySymbols(schema).includes(TYPEBOX_KIND);
 }
 
 function getSchemaTypes(schema: JsonSchemaObject): string[] {
@@ -346,11 +340,11 @@ export function validateToolCall(tools: Tool[], toolCall: ToolCall): unknown {
 /** Validates tool arguments against TypeBox or plain JSON-schema parameters. */
 export function validateToolArguments(tool: Tool, toolCall: ToolCall): unknown {
   const args = structuredClone(toolCall.arguments);
-  Value.Convert(tool.parameters, args);
-
   const validator = getValidator(tool.parameters);
-  if (!hasTypeBoxMetadata(tool.parameters) && isJsonSchemaObject(tool.parameters)) {
-    // TypeBox Value.Convert is intentionally conservative for plain JSON schemas;
+  validator.Convert(args);
+
+  if (isJsonSchemaObject(tool.parameters)) {
+    // TypeBox conversion is intentionally conservative for plain JSON schemas;
     // mirror the provider-facing coercions so model-emitted string numbers validate.
     const coerced = coerceWithJsonSchema(args, tool.parameters);
     if (coerced !== args) {

--- a/src/agents/schema/string-enum.ts
+++ b/src/agents/schema/string-enum.ts
@@ -16,9 +16,14 @@ export function stringEnum<T extends readonly string[]>(
   values: T,
   options: StringEnumOptions<T> = {},
 ) {
-  return values.length === 0
+  const enumValues = Array.isArray(values)
+    ? values
+    : values && typeof values === "object"
+      ? Object.values(values).filter((value): value is T[number] => typeof value === "string")
+      : [];
+  return enumValues.length === 0
     ? Type.Unsafe<T[number]>({ type: "string", ...options })
-    : Type.Enum(values, { type: "string", ...options });
+    : Type.Enum(enumValues, { type: "string", ...options });
 }
 
 export function optionalStringEnum<T extends readonly string[]>(

--- a/src/agents/schema/string-enum.ts
+++ b/src/agents/schema/string-enum.ts
@@ -12,22 +12,13 @@ type StringEnumOptions<T extends readonly string[]> = {
   deprecated?: boolean;
 };
 
-// Avoid Type.Union([Type.Literal(...)]) which compiles to anyOf.
-// Some providers reject anyOf in tool schemas; a flat string enum is safer.
 export function stringEnum<T extends readonly string[]>(
   values: T,
   options: StringEnumOptions<T> = {},
 ) {
-  const enumValues = Array.isArray(values)
-    ? values
-    : values && typeof values === "object"
-      ? Object.values(values).filter((value): value is T[number] => typeof value === "string")
-      : [];
-  return Type.Unsafe<T[number]>({
-    type: "string",
-    ...(enumValues.length > 0 ? { enum: [...enumValues] } : {}),
-    ...options,
-  });
+  return values.length === 0
+    ? Type.Unsafe<T[number]>({ type: "string", ...options })
+    : Type.Enum(values, { type: "string", ...options });
 }
 
 export function optionalStringEnum<T extends readonly string[]>(


### PR DESCRIPTION
## What Problem This Solves

Tool schemas hand-built flat string enums with `Type.Unsafe`, while argument conversion bypassed the already cached TypeBox validator and used a metadata predicate for an obsolete symbol.

## Why This Change Was Made

Use TypeBox 1.3.3's native flat `Type.Enum` builder for every non-empty string enum and the compiled validator's context-aware `Convert`. Preserve the shared helper's legacy empty and object-input fallbacks.

## User Impact

No intended behavior change. Provider-facing schemas remain flat string enums, tool argument coercion stays equivalent, and 23 lines of duplicate schema/validation plumbing disappear.

## Evidence

- Eight focused validator/schema/plugin test files — 286 passed
- Post-fix focused rerun — 50 passed
- TypeBox schema/conversion equivalence probe — passed
- Empty and numeric-key record fallback probes — passed
- `git diff --check`
- Fresh post-rebase branch autoreview — clean, 0.96 confidence
