### PR TITLE
refactor(flows): trim internal export surface

### DIFF
--- a/scripts/deadcode-exports.baseline.mjs
+++ b/scripts/deadcode-exports.baseline.mjs
@@ -644,8 +644,6 @@ export const KNIP_UNUSED_EXPORT_BASELINE = [
   "src/fleet/service.runtime.ts: FleetServiceOptions",
   "src/flows/doctor-health-contributions.ts: createDoctorHealthContribution",
   "src/flows/doctor-health-contributions.ts: resolveDoctorHealthContributions",
-  "src/flows/doctor-health-contributions.ts: shouldSkipLegacyUpdateDoctorConfigWrite",
-  "src/flows/health-check-adapter.ts: defineSplitHealthCheck",
   "src/gateway/cli-session-history.claude.ts: ClaudeCliPromptTextCandidate",
   "src/gateway/terminal/launch.ts: shellQuote",
   "src/hooks/gmail-setup-utils.ts: resetGmailSetupUtilsCachesForTest",

--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -11,7 +11,6 @@ import {
   createDoctorHealthContribution,
   resolveDoctorContributionHealthChecks,
   resolveDoctorHealthContributions,
-  shouldSkipLegacyUpdateDoctorConfigWrite,
 } from "./doctor-health-contributions.js";
 import { runDoctorLintChecks } from "./doctor-lint-flow.js";
 import type { HealthCheck, HealthFinding } from "./health-checks.js";
@@ -2951,43 +2950,6 @@ describe("doctor health contributions", () => {
     },
   );
 
-  it("skips doctor config writes under legacy update parents", () => {
-    expect(
-      shouldSkipLegacyUpdateDoctorConfigWrite({
-        env: { OPENCLAW_UPDATE_IN_PROGRESS: "1" },
-      }),
-    ).toBe(true);
-  });
-
-  it("keeps doctor writes outside legacy update writable", () => {
-    expect(
-      shouldSkipLegacyUpdateDoctorConfigWrite({
-        env: {},
-      }),
-    ).toBe(false);
-  });
-
-  it("keeps current update parents writable", () => {
-    expect(
-      shouldSkipLegacyUpdateDoctorConfigWrite({
-        env: {
-          OPENCLAW_UPDATE_IN_PROGRESS: "1",
-          OPENCLAW_UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE: "1",
-        },
-      }),
-    ).toBe(false);
-  });
-
-  it("treats falsey update env values as normal writes", () => {
-    expect(
-      shouldSkipLegacyUpdateDoctorConfigWrite({
-        env: {
-          OPENCLAW_UPDATE_IN_PROGRESS: "0",
-        },
-      }),
-    ).toBe(false);
-  });
-
   describe("write-config lint findings", () => {
     const writeConfigContribution = requireDoctorContribution("doctor:write-config");
     const check = writeConfigContribution.healthChecks[0] as HealthCheck & {
@@ -3345,6 +3307,41 @@ describe("doctor health contributions", () => {
     const writeConfigContribution = resolveDoctorHealthContributions().find(
       (entry) => entry.id === "doctor:write-config",
     )!;
+
+    it.each([
+      {
+        name: "legacy update parents",
+        env: { OPENCLAW_UPDATE_IN_PROGRESS: "1" },
+        shouldWrite: false,
+      },
+      { name: "ordinary doctor runs", env: {}, shouldWrite: true },
+      {
+        name: "current update parents",
+        env: {
+          OPENCLAW_UPDATE_IN_PROGRESS: "1",
+          OPENCLAW_UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE: "1",
+        },
+        shouldWrite: true,
+      },
+      {
+        name: "falsey update env values",
+        env: { OPENCLAW_UPDATE_IN_PROGRESS: "0" },
+        shouldWrite: true,
+      },
+    ])("handles config writes for $name", async ({ env, shouldWrite }) => {
+      const ctx = buildWriteConfigCtx(env);
+
+      await writeConfigContribution.run(ctx);
+
+      if (shouldWrite) {
+        expect(mocks.replaceConfigFile).toHaveBeenCalled();
+      } else {
+        expect(mocks.replaceConfigFile).not.toHaveBeenCalled();
+        expect(ctx.runtime.log).toHaveBeenCalledWith(
+          "Skipping doctor config write during legacy update handoff.",
+        );
+      }
+    });
 
     it("allows config size drops when OPENCLAW_UPDATE_IN_PROGRESS=1", async () => {
       const ctx = buildWriteConfigCtx({

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -103,9 +103,7 @@ function isTruthyEnvValue(value: string | undefined): boolean {
   return normalized !== "" && normalized !== "0" && normalized !== "false" && normalized !== "no";
 }
 
-export function shouldSkipLegacyUpdateDoctorConfigWrite(params: {
-  env: NodeJS.ProcessEnv;
-}): boolean {
+function shouldSkipLegacyUpdateDoctorConfigWrite(params: { env: NodeJS.ProcessEnv }): boolean {
   if (!isTruthyEnvValue(params.env.OPENCLAW_UPDATE_IN_PROGRESS)) {
     return false;
   }

--- a/src/flows/doctor-repair-flow.test.ts
+++ b/src/flows/doctor-repair-flow.test.ts
@@ -2,7 +2,7 @@
 import { describe, expect, expectTypeOf, it } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { runDoctorHealthRepairs } from "./doctor-repair-flow.js";
-import { defineSplitHealthCheck, normalizeHealthCheck } from "./health-check-adapter.js";
+import { normalizeHealthCheck } from "./health-check-adapter.js";
 import type { RunnableHealthCheck, SplitHealthCheckInput } from "./health-check-runner-types.js";
 import type { HealthCheck, HealthRepairContext } from "./health-checks.js";
 
@@ -68,7 +68,7 @@ describe("runDoctorHealthRepairs", () => {
   it("repairs modern checks and threads updated config", async () => {
     const scopes: unknown[] = [];
     const checks: HealthCheck[] = [
-      defineSplitHealthCheck({
+      normalizeHealthCheck({
         id: "test/repairable",
         kind: "core",
         description: "repairable",
@@ -116,7 +116,7 @@ describe("runDoctorHealthRepairs", () => {
 
   it("leaves non-repairable checks for legacy doctor behavior", async () => {
     const checks: HealthCheck[] = [
-      defineSplitHealthCheck({
+      normalizeHealthCheck({
         id: "test/legacy-only",
         kind: "core",
         description: "legacy only",
@@ -144,7 +144,7 @@ describe("runDoctorHealthRepairs", () => {
 
   it("keeps split check findings when repair throws", async () => {
     const checks: HealthCheck[] = [
-      defineSplitHealthCheck({
+      normalizeHealthCheck({
         id: "test/repair-throws",
         kind: "core",
         description: "repair throws",
@@ -179,7 +179,7 @@ describe("runDoctorHealthRepairs", () => {
 
   it("reports repair validation findings that remain after repair", async () => {
     const checks: HealthCheck[] = [
-      defineSplitHealthCheck({
+      normalizeHealthCheck({
         id: "test/not-fixed",
         kind: "core",
         description: "not fixed",
@@ -217,7 +217,7 @@ describe("runDoctorHealthRepairs", () => {
   it("validates successful repairs by default", async () => {
     let detectCalls = 0;
     const checks: HealthCheck[] = [
-      defineSplitHealthCheck({
+      normalizeHealthCheck({
         id: "test/no-default-validation",
         kind: "core",
         description: "no default validation",
@@ -256,7 +256,7 @@ describe("runDoctorHealthRepairs", () => {
   it("does not validate skipped or failed repair results", async () => {
     let validationCalls = 0;
     const checks: HealthCheck[] = [
-      defineSplitHealthCheck({
+      normalizeHealthCheck({
         id: "test/skipped",
         kind: "core",
         description: "skipped",
@@ -294,7 +294,7 @@ describe("runDoctorHealthRepairs", () => {
     const repairContexts: HealthRepairContext[] = [];
     let detectCalls = 0;
     const checks: HealthCheck[] = [
-      defineSplitHealthCheck({
+      normalizeHealthCheck({
         id: "test/dry-run",
         kind: "core",
         description: "dry run",
@@ -356,7 +356,7 @@ describe("runDoctorHealthRepairs", () => {
   it("passes diff false and true through the repair API", async () => {
     const repairContexts: HealthRepairContext[] = [];
     const checks: HealthCheck[] = [
-      defineSplitHealthCheck({
+      normalizeHealthCheck({
         id: "test/diff-preview",
         kind: "core",
         description: "diff preview",

--- a/src/flows/health-check-adapter.ts
+++ b/src/flows/health-check-adapter.ts
@@ -9,7 +9,7 @@ import type { HealthRepairContext } from "./health-checks.js";
 
 // Adapts legacy split detect/repair checks and newer runnable checks to one runner contract.
 /** Wraps a detect/repair health check in the runnable health-check contract. */
-export function defineSplitHealthCheck(check: SplitHealthCheckInput): RegisteredHealthCheck {
+function defineSplitHealthCheck(check: SplitHealthCheckInput): RegisteredHealthCheck {
   return {
     id: check.id,
     kind: check.kind,


### PR DESCRIPTION
## What Problem This Solves

The dead-export ratchet still grandfathered four symbols under `src/flows`. Two were internal adapters exposed only for direct tests; two contribution catalog/build helpers remain active test seams.

## Why This Change Was Made

- Make the legacy update write-skip predicate private and cover it through the real write-config contribution.
- Make the split health-check adapter private and exercise it through `normalizeHealthCheck`.
- Retain the contribution builder and catalog resolver because focused doctor tests still require custom contributions and ordered catalog inspection.
- Shrink the generated baseline by exactly two entries, with no additions; `src/flows` moves from 4 to 2.

## User Impact

No doctor behavior, config migration, CLI, or plugin contract changes. Tests now follow retained production entry points where practical.

## Evidence

- Blacksmith Testbox `tbx_01kxg5w8jb4ycza3rxmmrbssq8`: exact production Knip 737, format, type-aware lint, 101 focused tests, core types, and core test types green.
- Latest-main regeneration byte-stable at 737 entries (`+0/-2`).
- Fresh branch autoreview clean, confidence 0.97.
