### PR TITLE
fix(anthropic): restore session catalog test types

### DIFF
--- a/extensions/anthropic/session-catalog.test.ts
+++ b/extensions/anthropic/session-catalog.test.ts
@@ -513,7 +513,7 @@ describe("Claude session catalog", () => {
         invocableCommands: commands.filter((command) => authorizedCommands.has(command)),
       },
     ];
-    const invoke = vi.fn(async ({ command }: { command: string }) => {
+    const invoke = vi.fn(async ({ command }: Parameters<PluginRuntime["nodes"]["invoke"]>[0]) => {
       if (command === CLAUDE_SESSIONS_LIST_COMMAND) {
         return {
           payloadJSON: JSON.stringify({


### PR DESCRIPTION
Related: #107410

## What Problem This Solves

Fixes an issue where the extensions test-types CI lane failed after the paired-node authorization test began inspecting the requested scopes.

## Why This Change Was Made

The node invoke mock now derives its request parameter from the canonical `PluginRuntime.nodes.invoke` signature instead of a narrower hand-written `{ command: string }` shape.

## User Impact

No runtime behavior change. New pull requests can complete the test-types gate again.

## Evidence

- Reproduced in CI run 29328623251: `extensions/anthropic/session-catalog.test.ts(610,59): error TS2339: Property 'scopes' does not exist on type '{ command: string; }'.`
- Blacksmith Testbox `tbx_01kxg66nv2jpaps2yxbfbe249z`: `pnpm tsgo:extensions:test` passed.
- Same Testbox: all 20 Anthropic session-catalog tests passed.
- Same Testbox: touched `check:changed` passed formatting, extension test typecheck, lint, and repository guards.
