### PR TITLE
fix(signal): keep active-run controls responsive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - **Tlon custom S3 uploads:** pass storage endpoints through the AWS SDK's native parser so custom S3-compatible uploads no longer fail before presigning.
+- **Signal active-run controls:** keep authorized stop, status, approval, and queue-read controls responsive during active turns while preserving ordinary and stateful turns in canonical session admission, and cancel every pending group sender lane on stop. (#107422) Thanks @arduano.
 - **Agent auth storage locks:** surface normal release failures while avoiding redundant release attempts after `proper-lockfile` reports a compromised lock.
 - **Paired-node session catalogs:** authorize bundled Anthropic and Codex catalog requests to invoke their read-only node commands from Control UI read flows, restoring remote Claude/Codex rows and terminal resume availability. Fixes #107406.
 - **Sandbox recreate confirmation:** treat Clack cancellation as a decline so Ctrl-C cannot proceed with container removal.

--- a/extensions/signal/src/monitor/event-handler.control-lane.test.ts
+++ b/extensions/signal/src/monitor/event-handler.control-lane.test.ts
@@ -49,7 +49,7 @@ const [
   { createBaseSignalEventHandlerDeps, createSignalReceiveEvent },
   { createSignalEventHandler },
   {
-    cancelPendingSignalInboundOnAbort,
+    createSignalPendingInboundRegistry,
     resolveSignalControlLaneKey,
     resolveSignalInboundDebounceKey,
   },
@@ -86,6 +86,19 @@ function signalText(message: string, timestamp: number) {
   return createSignalReceiveEvent({
     timestamp,
     dataMessage: { message, attachments: [] },
+  });
+}
+
+function signalGroupText(message: string, timestamp: number, sourceNumber: string) {
+  return createSignalReceiveEvent({
+    sourceNumber,
+    sourceName: sourceNumber,
+    timestamp,
+    dataMessage: {
+      message,
+      attachments: [],
+      groupInfo: { groupId: "group-1", groupName: "Test Group" },
+    },
   });
 }
 
@@ -196,12 +209,14 @@ describe("Signal active-run control lane", () => {
       commandAuthorized: false,
     };
     const cancelKey = vi.fn(() => true);
+    const pendingInboundRegistry = createSignalPendingInboundRegistry("default");
 
     expect(resolveSignalInboundDebounceKey("default", entry)).toBe(
       "signal:default:+15550001111:+15550001111",
     );
     expect(resolveSignalControlLaneKey("default", entry)).toBeNull();
-    cancelPendingSignalInboundOnAbort("default", entry, cancelKey);
+    pendingInboundRegistry.track(entry);
+    pendingInboundRegistry.cancelPendingOnAbort(entry, cancelKey);
     expect(cancelKey).not.toHaveBeenCalled();
   });
 
@@ -260,6 +275,18 @@ describe("Signal active-run control lane", () => {
 
     await handler(signalText("queued work", 1));
     await handler(signalText("stop", 2));
+    expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1);
+    expect(dispatchedCommandBody(0)).toBe("stop");
+
+    await delay(75);
+    expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancels pending normal work from every sender in a group conversation", async () => {
+    const handler = createHandler(50);
+
+    await handler(signalGroupText("queued work", 1, "+15550001111"));
+    await handler(signalGroupText("stop", 2, "+15550002222"));
     expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1);
     expect(dispatchedCommandBody(0)).toBe("stop");
 

--- a/extensions/signal/src/monitor/event-handler.control-lane.test.ts
+++ b/extensions/signal/src/monitor/event-handler.control-lane.test.ts
@@ -112,30 +112,34 @@ describe("Signal active-run control lane", () => {
     sendTypingMock.mockReset().mockResolvedValue(true);
   });
 
-  it.each(["stop", "/status", "/queue", "/QUEUE", "/steer keep going"])(
-    "dispatches active-run-safe control %s while normal work is active",
-    async (controlText) => {
-      let releaseActive!: () => void;
-      const activeGate = new Promise<void>((resolve) => {
-        releaseActive = resolve;
-      });
-      dispatchInboundMessageMock.mockImplementationOnce(async () => {
-        await activeGate;
-        return dispatchResult;
-      });
-      const handler = createHandler(5);
+  it.each([
+    "stop",
+    "/approve abc12345 allow-once",
+    "/status",
+    "/queue",
+    "/QUEUE",
+    "/steer keep going",
+  ])("dispatches active-run-safe control %s while normal work is active", async (controlText) => {
+    let releaseActive!: () => void;
+    const activeGate = new Promise<void>((resolve) => {
+      releaseActive = resolve;
+    });
+    dispatchInboundMessageMock.mockImplementationOnce(async () => {
+      await activeGate;
+      return dispatchResult;
+    });
+    const handler = createHandler(5);
 
-      await handler(signalText("start a long task", 1));
-      await vi.waitFor(() => expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1));
+    await handler(signalText("start a long task", 1));
+    await vi.waitFor(() => expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1));
 
-      const controlHandled = handler(signalText(controlText, 2));
-      await vi.waitFor(() => expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(2));
-      expect(dispatchedCommandBody(1)).toBe(controlText);
+    const controlHandled = handler(signalText(controlText, 2));
+    await vi.waitFor(() => expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(2));
+    expect(dispatchedCommandBody(1)).toBe(controlText);
 
-      releaseActive();
-      await controlHandled;
-    },
-  );
+    releaseActive();
+    await controlHandled;
+  });
 
   it("serializes repeated aborts on the control lane", async () => {
     let releaseFirstAbort!: () => void;

--- a/extensions/signal/src/monitor/event-handler.control-lane.test.ts
+++ b/extensions/signal/src/monitor/event-handler.control-lane.test.ts
@@ -203,8 +203,12 @@ describe("Signal active-run control lane", () => {
 
   it("does not promote or cancel an unauthorized abort", () => {
     const entry = {
+      senderName: "Alice",
+      senderDisplay: "+15550001111",
+      senderRecipient: "+15550001111",
       senderPeerId: "+15550001111",
       isGroup: false,
+      bodyText: "stop",
       commandBody: "stop",
       commandAuthorized: false,
     };
@@ -222,9 +226,13 @@ describe("Signal active-run control lane", () => {
 
   it("shares one group control lane without merging normal sender batches", () => {
     const entry = {
+      senderName: "Alice",
+      senderDisplay: "+15550001111",
+      senderRecipient: "+15550001111",
       senderPeerId: "+15550001111",
       groupId: "group-1",
       isGroup: true,
+      bodyText: "stop",
       commandBody: "stop",
       commandAuthorized: true,
     };

--- a/extensions/signal/src/monitor/event-handler.control-lane.test.ts
+++ b/extensions/signal/src/monitor/event-handler.control-lane.test.ts
@@ -108,7 +108,7 @@ describe("Signal active-run control lane", () => {
     sendTypingMock.mockReset().mockResolvedValue(true);
   });
 
-  it.each(["stop", "/status", "/queue status", "/steer keep going"])(
+  it.each(["stop", "/status", "/queue", "/QUEUE", "/steer keep going"])(
     "dispatches active-run-safe control %s while normal work is active",
     async (controlText) => {
       let releaseActive!: () => void;
@@ -172,7 +172,16 @@ describe("Signal active-run control lane", () => {
     expect(cancelKey).not.toHaveBeenCalled();
   });
 
-  it("keeps stateful commands behind active conversation work", async () => {
+  it.each([
+    "/reset",
+    "/queue status",
+    "/queue collect",
+    "/queue interrupt",
+    "/queue reset",
+    "/queue debounce:2s",
+    "/queue cap:5",
+    "/queue drop:summarize",
+  ])("keeps stateful command %s behind active conversation work", async (commandText) => {
     let releaseActive!: () => void;
     const activeGate = new Promise<void>((resolve) => {
       releaseActive = resolve;
@@ -185,14 +194,14 @@ describe("Signal active-run control lane", () => {
 
     const active = handler(signalText("start a long task", 1));
     await vi.waitFor(() => expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1));
-    const reset = handler(signalText("/reset", 2));
+    const statefulCommand = handler(signalText(commandText, 2));
     await delay(20);
     expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1);
 
     releaseActive();
-    await Promise.all([active, reset]);
+    await Promise.all([active, statefulCommand]);
     expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(2);
-    expect(dispatchedCommandBody(1)).toBe("/reset");
+    expect(dispatchedCommandBody(1)).toBe(commandText);
   });
 
   it("cancels ordinary text still waiting in the debounce window", async () => {

--- a/extensions/signal/src/monitor/event-handler.control-lane.test.ts
+++ b/extensions/signal/src/monitor/event-handler.control-lane.test.ts
@@ -262,4 +262,29 @@ describe("Signal active-run control lane", () => {
     await delay(75);
     expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1);
   });
+
+  it("cancels ordinary text released from debounce but still waiting on active work", async () => {
+    let releaseActive!: () => void;
+    const activeGate = new Promise<void>((resolve) => {
+      releaseActive = resolve;
+    });
+    dispatchInboundMessageMock.mockImplementationOnce(async () => {
+      await activeGate;
+      return dispatchResult;
+    });
+    const handler = createHandler(5);
+
+    await handler(signalText("start a long task", 1));
+    await vi.waitFor(() => expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1));
+    await handler(signalText("queued followup", 2));
+    await delay(20);
+
+    await handler(signalText("stop", 3));
+    expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(2);
+    expect(dispatchedCommandBody(1)).toBe("stop");
+
+    releaseActive();
+    await delay(20);
+    expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(2);
+  });
 });

--- a/extensions/signal/src/monitor/event-handler.control-lane.test.ts
+++ b/extensions/signal/src/monitor/event-handler.control-lane.test.ts
@@ -1,0 +1,203 @@
+// Signal tests cover ordered control delivery around active inbound work.
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import type { MsgContext } from "openclaw/plugin-sdk/reply-runtime";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  dispatchInboundMessageMock,
+  recordInboundSessionMock,
+  sendReadReceiptMock,
+  sendTypingMock,
+} = vi.hoisted(() => ({
+  dispatchInboundMessageMock: vi.fn(),
+  recordInboundSessionMock: vi.fn(),
+  sendReadReceiptMock: vi.fn(),
+  sendTypingMock: vi.fn(),
+}));
+
+vi.mock("../send.js", () => ({
+  sendMessageSignal: vi.fn(),
+  sendTypingSignal: sendTypingMock,
+  sendReadReceiptSignal: sendReadReceiptMock,
+}));
+
+vi.mock("openclaw/plugin-sdk/reply-runtime", async () => {
+  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/reply-runtime")>(
+    "openclaw/plugin-sdk/reply-runtime",
+  );
+  return {
+    ...actual,
+    dispatchInboundMessage: dispatchInboundMessageMock,
+    dispatchInboundMessageWithDispatcher: dispatchInboundMessageMock,
+    dispatchInboundMessageWithBufferedDispatcher: dispatchInboundMessageMock,
+  };
+});
+
+vi.mock("openclaw/plugin-sdk/conversation-runtime", async () => {
+  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/conversation-runtime")>(
+    "openclaw/plugin-sdk/conversation-runtime",
+  );
+  return {
+    ...actual,
+    recordInboundSession: recordInboundSessionMock,
+    readChannelAllowFromStore: vi.fn().mockResolvedValue([]),
+    upsertChannelPairingRequest: vi.fn(),
+  };
+});
+
+const [
+  { createBaseSignalEventHandlerDeps, createSignalReceiveEvent },
+  { createSignalEventHandler },
+  { cancelPendingSignalInboundOnAbort, resolveSignalInboundDebounceKey },
+] = await Promise.all([
+  import("./event-handler.test-harness.js"),
+  import("./event-handler.js"),
+  import("./event-handler.control-lane.js"),
+]);
+
+type DispatchParams = { ctx: MsgContext };
+
+const dispatchResult = {
+  queuedFinal: false,
+  counts: { tool: 0, block: 0, final: 1 },
+};
+
+function createHandler(debounceMs: number) {
+  const dmPolicy = "allowlist";
+  const allowFrom = ["+15550001111"];
+  return createSignalEventHandler(
+    createBaseSignalEventHandlerDeps({
+      cfg: {
+        messages: { inbound: { debounceMs } },
+        channels: { signal: { dmPolicy, allowFrom } },
+      } as OpenClawConfig,
+      dmPolicy,
+      allowFrom,
+      historyLimit: 0,
+    }),
+  );
+}
+
+function signalText(message: string, timestamp: number) {
+  return createSignalReceiveEvent({
+    timestamp,
+    dataMessage: { message, attachments: [] },
+  });
+}
+
+describe("Signal active-run control lane", () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+    dispatchInboundMessageMock.mockReset().mockResolvedValue(dispatchResult);
+    recordInboundSessionMock.mockReset().mockResolvedValue(undefined);
+    sendReadReceiptMock.mockReset().mockResolvedValue(true);
+    sendTypingMock.mockReset().mockResolvedValue(true);
+  });
+
+  it.each(["stop", "/status", "/queue status", "/steer keep going"])(
+    "dispatches active-run-safe control %s while normal work is active",
+    async (controlText) => {
+      let releaseActive!: () => void;
+      const activeGate = new Promise<void>((resolve) => {
+        releaseActive = resolve;
+      });
+      dispatchInboundMessageMock.mockImplementationOnce(async () => {
+        await activeGate;
+        return dispatchResult;
+      });
+      const handler = createHandler(5);
+
+      await handler(signalText("start a long task", 1));
+      await vi.waitFor(() => expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1));
+
+      const controlHandled = handler(signalText(controlText, 2));
+      await vi.waitFor(() => expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(2));
+      expect(
+        (dispatchInboundMessageMock.mock.calls[1]?.[0] as DispatchParams).ctx.CommandBody,
+      ).toBe(controlText);
+
+      releaseActive();
+      await controlHandled;
+    },
+  );
+
+  it("serializes repeated aborts on the control lane", async () => {
+    let releaseFirstAbort!: () => void;
+    const firstAbortGate = new Promise<void>((resolve) => {
+      releaseFirstAbort = resolve;
+    });
+    dispatchInboundMessageMock.mockImplementationOnce(async () => {
+      await firstAbortGate;
+      return dispatchResult;
+    });
+    const handler = createHandler(0);
+
+    const first = handler(signalText("stop", 1));
+    await vi.waitFor(() => expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1));
+    const second = handler(signalText("halt", 2));
+    await new Promise<void>((resolve) => setTimeout(resolve, 20));
+    expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1);
+
+    releaseFirstAbort();
+    await Promise.all([first, second]);
+    expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(2);
+    expect((dispatchInboundMessageMock.mock.calls[1]?.[0] as DispatchParams).ctx.CommandBody).toBe(
+      "halt",
+    );
+  });
+
+  it("does not promote or cancel an unauthorized abort", () => {
+    const entry = {
+      senderPeerId: "+15550001111",
+      isGroup: false,
+      commandBody: "stop",
+      commandAuthorized: false,
+    };
+    const cancelKey = vi.fn(() => true);
+
+    expect(resolveSignalInboundDebounceKey("default", entry)).toBe(
+      "signal:default:+15550001111:+15550001111",
+    );
+    cancelPendingSignalInboundOnAbort("default", entry, cancelKey);
+    expect(cancelKey).not.toHaveBeenCalled();
+  });
+
+  it("keeps stateful commands behind active conversation work", async () => {
+    let releaseActive!: () => void;
+    const activeGate = new Promise<void>((resolve) => {
+      releaseActive = resolve;
+    });
+    dispatchInboundMessageMock.mockImplementationOnce(async () => {
+      await activeGate;
+      return dispatchResult;
+    });
+    const handler = createHandler(0);
+
+    const active = handler(signalText("start a long task", 1));
+    await vi.waitFor(() => expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1));
+    const reset = handler(signalText("/reset", 2));
+    await new Promise<void>((resolve) => setTimeout(resolve, 20));
+    expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1);
+
+    releaseActive();
+    await Promise.all([active, reset]);
+    expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(2);
+    expect((dispatchInboundMessageMock.mock.calls[1]?.[0] as DispatchParams).ctx.CommandBody).toBe(
+      "/reset",
+    );
+  });
+
+  it("cancels ordinary text still waiting in the debounce window", async () => {
+    const handler = createHandler(50);
+
+    await handler(signalText("queued work", 1));
+    await handler(signalText("stop", 2));
+    expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1);
+    expect((dispatchInboundMessageMock.mock.calls[0]?.[0] as DispatchParams).ctx.CommandBody).toBe(
+      "stop",
+    );
+
+    await new Promise<void>((resolve) => setTimeout(resolve, 75));
+    expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/extensions/signal/src/monitor/event-handler.control-lane.test.ts
+++ b/extensions/signal/src/monitor/event-handler.control-lane.test.ts
@@ -85,6 +85,20 @@ function signalText(message: string, timestamp: number) {
   });
 }
 
+function dispatchedCommandBody(index: number): string | undefined {
+  const call = dispatchInboundMessageMock.mock.calls[index];
+  if (!call) {
+    throw new Error(`missing dispatch call ${index}`);
+  }
+  return (call[0] as DispatchParams).ctx.CommandBody;
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
 describe("Signal active-run control lane", () => {
   beforeEach(() => {
     vi.useRealTimers();
@@ -112,9 +126,7 @@ describe("Signal active-run control lane", () => {
 
       const controlHandled = handler(signalText(controlText, 2));
       await vi.waitFor(() => expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(2));
-      expect(
-        (dispatchInboundMessageMock.mock.calls[1]?.[0] as DispatchParams).ctx.CommandBody,
-      ).toBe(controlText);
+      expect(dispatchedCommandBody(1)).toBe(controlText);
 
       releaseActive();
       await controlHandled;
@@ -135,15 +147,13 @@ describe("Signal active-run control lane", () => {
     const first = handler(signalText("stop", 1));
     await vi.waitFor(() => expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1));
     const second = handler(signalText("halt", 2));
-    await new Promise<void>((resolve) => setTimeout(resolve, 20));
+    await delay(20);
     expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1);
 
     releaseFirstAbort();
     await Promise.all([first, second]);
     expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(2);
-    expect((dispatchInboundMessageMock.mock.calls[1]?.[0] as DispatchParams).ctx.CommandBody).toBe(
-      "halt",
-    );
+    expect(dispatchedCommandBody(1)).toBe("halt");
   });
 
   it("does not promote or cancel an unauthorized abort", () => {
@@ -176,15 +186,13 @@ describe("Signal active-run control lane", () => {
     const active = handler(signalText("start a long task", 1));
     await vi.waitFor(() => expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1));
     const reset = handler(signalText("/reset", 2));
-    await new Promise<void>((resolve) => setTimeout(resolve, 20));
+    await delay(20);
     expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1);
 
     releaseActive();
     await Promise.all([active, reset]);
     expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(2);
-    expect((dispatchInboundMessageMock.mock.calls[1]?.[0] as DispatchParams).ctx.CommandBody).toBe(
-      "/reset",
-    );
+    expect(dispatchedCommandBody(1)).toBe("/reset");
   });
 
   it("cancels ordinary text still waiting in the debounce window", async () => {
@@ -193,11 +201,9 @@ describe("Signal active-run control lane", () => {
     await handler(signalText("queued work", 1));
     await handler(signalText("stop", 2));
     expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1);
-    expect((dispatchInboundMessageMock.mock.calls[0]?.[0] as DispatchParams).ctx.CommandBody).toBe(
-      "stop",
-    );
+    expect(dispatchedCommandBody(0)).toBe("stop");
 
-    await new Promise<void>((resolve) => setTimeout(resolve, 75));
+    await delay(75);
     expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/extensions/signal/src/monitor/event-handler.control-lane.test.ts
+++ b/extensions/signal/src/monitor/event-handler.control-lane.test.ts
@@ -48,7 +48,11 @@ vi.mock("openclaw/plugin-sdk/conversation-runtime", async () => {
 const [
   { createBaseSignalEventHandlerDeps, createSignalReceiveEvent },
   { createSignalEventHandler },
-  { cancelPendingSignalInboundOnAbort, resolveSignalInboundDebounceKey },
+  {
+    cancelPendingSignalInboundOnAbort,
+    resolveSignalControlLaneKey,
+    resolveSignalInboundDebounceKey,
+  },
 ] = await Promise.all([
   import("./event-handler.test-harness.js"),
   import("./event-handler.js"),
@@ -156,6 +160,30 @@ describe("Signal active-run control lane", () => {
     expect(dispatchedCommandBody(1)).toBe("halt");
   });
 
+  it.each(["one more detail", "/reset"])(
+    "leaves zero-debounce turn %s to core session admission",
+    async (followupText) => {
+      let releaseActive!: () => void;
+      const activeGate = new Promise<void>((resolve) => {
+        releaseActive = resolve;
+      });
+      dispatchInboundMessageMock.mockImplementationOnce(async () => {
+        await activeGate;
+        return dispatchResult;
+      });
+      const handler = createHandler(0);
+
+      const active = handler(signalText("start a long task", 1));
+      await vi.waitFor(() => expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1));
+      const followup = handler(signalText(followupText, 2));
+      await vi.waitFor(() => expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(2));
+      expect(dispatchedCommandBody(1)).toBe(followupText);
+
+      releaseActive();
+      await Promise.all([active, followup]);
+    },
+  );
+
   it("does not promote or cancel an unauthorized abort", () => {
     const entry = {
       senderPeerId: "+15550001111",
@@ -168,8 +196,27 @@ describe("Signal active-run control lane", () => {
     expect(resolveSignalInboundDebounceKey("default", entry)).toBe(
       "signal:default:+15550001111:+15550001111",
     );
+    expect(resolveSignalControlLaneKey("default", entry)).toBeNull();
     cancelPendingSignalInboundOnAbort("default", entry, cancelKey);
     expect(cancelKey).not.toHaveBeenCalled();
+  });
+
+  it("shares one group control lane without merging normal sender batches", () => {
+    const entry = {
+      senderPeerId: "+15550001111",
+      groupId: "group-1",
+      isGroup: true,
+      commandBody: "stop",
+      commandAuthorized: true,
+    };
+    const otherSender = { ...entry, senderPeerId: "+15550002222" };
+
+    expect(resolveSignalControlLaneKey("default", entry)).toBe(
+      resolveSignalControlLaneKey("default", otherSender),
+    );
+    expect(resolveSignalInboundDebounceKey("default", entry)).not.toBe(
+      resolveSignalInboundDebounceKey("default", otherSender),
+    );
   });
 
   it.each([
@@ -190,7 +237,7 @@ describe("Signal active-run control lane", () => {
       await activeGate;
       return dispatchResult;
     });
-    const handler = createHandler(0);
+    const handler = createHandler(5);
 
     const active = handler(signalText("start a long task", 1));
     await vi.waitFor(() => expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1));

--- a/extensions/signal/src/monitor/event-handler.control-lane.ts
+++ b/extensions/signal/src/monitor/event-handler.control-lane.ts
@@ -14,6 +14,11 @@ type SignalInboundControlEntry = {
   commandAuthorized: boolean;
 };
 
+type TrackedSignalInboundLane = {
+  conversationKey: string;
+  inboundKey: string;
+};
+
 const SIGNAL_ACTIVE_RUN_CONTROL_COMMAND_KEYS = new Set([
   "approve",
   "commands",
@@ -40,6 +45,14 @@ export function resolveSignalInboundDebounceKey(
     return null;
   }
   return `signal:${accountId}:${conversationId}:${entry.senderPeerId}`;
+}
+
+function resolveSignalInboundConversationKey(
+  accountId: string,
+  entry: SignalInboundControlEntry,
+): string | null {
+  const conversationId = resolveSignalConversationId(entry);
+  return conversationId ? `signal:${accountId}:${conversationId}` : null;
 }
 
 function isSignalActiveRunControlText(text: string): boolean {
@@ -72,17 +85,62 @@ export function resolveSignalControlLaneKey(
   return conversationId ? `signal:${accountId}:${conversationId}:control` : null;
 }
 
-export function cancelPendingSignalInboundOnAbort(
-  accountId: string,
-  entry: SignalInboundControlEntry,
-  cancelKey: (key: string) => boolean,
-): void {
-  if (!entry.commandAuthorized || !isAbortRequestText(entry.commandBody)) {
-    return;
-  }
-  const conversationKey = resolveSignalInboundDebounceKey(accountId, entry);
-  if (conversationKey) {
-    // Active work is interrupted later by the reply layer; only undispatched text is removed here.
-    cancelKey(conversationKey);
-  }
+export function createSignalPendingInboundRegistry(accountId: string) {
+  const trackedEntries = new WeakMap<SignalInboundControlEntry, TrackedSignalInboundLane>();
+  const countsByConversation = new Map<string, Map<string, number>>();
+
+  const track = (entry: SignalInboundControlEntry) => {
+    if (trackedEntries.has(entry)) {
+      return;
+    }
+    const conversationKey = resolveSignalInboundConversationKey(accountId, entry);
+    const inboundKey = resolveSignalInboundDebounceKey(accountId, entry);
+    if (!conversationKey || !inboundKey) {
+      return;
+    }
+    const counts = countsByConversation.get(conversationKey) ?? new Map<string, number>();
+    counts.set(inboundKey, (counts.get(inboundKey) ?? 0) + 1);
+    countsByConversation.set(conversationKey, counts);
+    trackedEntries.set(entry, { conversationKey, inboundKey });
+  };
+
+  const complete = (entries: SignalInboundControlEntry[]) => {
+    for (const entry of entries) {
+      const tracked = trackedEntries.get(entry);
+      if (!tracked) {
+        continue;
+      }
+      trackedEntries.delete(entry);
+      const counts = countsByConversation.get(tracked.conversationKey);
+      const nextCount = (counts?.get(tracked.inboundKey) ?? 0) - 1;
+      if (nextCount > 0) {
+        counts?.set(tracked.inboundKey, nextCount);
+        continue;
+      }
+      counts?.delete(tracked.inboundKey);
+      if (counts?.size === 0) {
+        countsByConversation.delete(tracked.conversationKey);
+      }
+    }
+  };
+
+  const cancelPendingOnAbort = (
+    entry: SignalInboundControlEntry,
+    cancelKey: (key: string) => boolean,
+  ) => {
+    if (!entry.commandAuthorized || !isAbortRequestText(entry.commandBody)) {
+      return;
+    }
+    const conversationKey = resolveSignalInboundConversationKey(accountId, entry);
+    if (!conversationKey) {
+      return;
+    }
+    // Group members have distinct normal debounce keys, but stop applies to the shared session.
+    // Cancel every still-tracked sender lane before core interrupts the active run.
+    for (const inboundKey of countsByConversation.get(conversationKey)?.keys() ?? []) {
+      cancelKey(inboundKey);
+    }
+  };
+
+  return { track, complete, cancelPendingOnAbort };
 }

--- a/extensions/signal/src/monitor/event-handler.control-lane.ts
+++ b/extensions/signal/src/monitor/event-handler.control-lane.ts
@@ -25,11 +25,16 @@ const SIGNAL_ACTIVE_RUN_CONTROL_COMMAND_KEYS = new Set([
   "whoami",
 ]);
 
-function resolveSignalConversationDebounceKey(
+function resolveSignalConversationId(entry: SignalInboundControlEntry): string | null {
+  const conversationId = entry.isGroup ? entry.groupId : entry.senderPeerId;
+  return conversationId?.trim() || null;
+}
+
+export function resolveSignalInboundDebounceKey(
   accountId: string,
   entry: SignalInboundControlEntry,
 ): string | null {
-  const conversationId = entry.isGroup ? (entry.groupId ?? "unknown") : entry.senderPeerId;
+  const conversationId = resolveSignalConversationId(entry);
   if (!conversationId || !entry.senderPeerId) {
     return null;
   }
@@ -55,18 +60,15 @@ function isSignalActiveRunControlText(text: string): boolean {
   return command ? SIGNAL_ACTIVE_RUN_CONTROL_COMMAND_KEYS.has(command.key) : false;
 }
 
-export function resolveSignalInboundDebounceKey(
+export function resolveSignalControlLaneKey(
   accountId: string,
   entry: SignalInboundControlEntry,
 ): string | null {
-  const conversationKey = resolveSignalConversationDebounceKey(accountId, entry);
-  // Active-run-safe controls overtake the conversation run, but remain ordered with each other.
-  // Stateful commands keep the normal key so they cannot race session mutations against a run.
-  return conversationKey &&
-    entry.commandAuthorized &&
-    isSignalActiveRunControlText(entry.commandBody)
-    ? `${conversationKey}:control`
-    : conversationKey;
+  if (!entry.commandAuthorized || !isSignalActiveRunControlText(entry.commandBody)) {
+    return null;
+  }
+  const conversationId = resolveSignalConversationId(entry);
+  return conversationId ? `signal:${accountId}:${conversationId}:control` : null;
 }
 
 export function cancelPendingSignalInboundOnAbort(
@@ -77,7 +79,7 @@ export function cancelPendingSignalInboundOnAbort(
   if (!entry.commandAuthorized || !isAbortRequestText(entry.commandBody)) {
     return;
   }
-  const conversationKey = resolveSignalConversationDebounceKey(accountId, entry);
+  const conversationKey = resolveSignalInboundDebounceKey(accountId, entry);
   if (conversationKey) {
     // Active work is interrupted later by the reply layer; only undispatched text is removed here.
     cancelKey(conversationKey);

--- a/extensions/signal/src/monitor/event-handler.control-lane.ts
+++ b/extensions/signal/src/monitor/event-handler.control-lane.ts
@@ -18,7 +18,6 @@ const SIGNAL_ACTIVE_RUN_CONTROL_COMMAND_KEYS = new Set([
   "commands",
   "context",
   "help",
-  "queue",
   "status",
   "steer",
   "tasks",
@@ -41,13 +40,18 @@ function isSignalActiveRunControlText(text: string): boolean {
   if (isAbortRequestText(text)) {
     return true;
   }
-  const alias = maybeResolveTextAlias(normalizeCommandBody(text.trim()));
+  const normalizedBody = normalizeCommandBody(text.trim());
+  const alias = maybeResolveTextAlias(normalizedBody);
   if (!alias) {
     return false;
   }
   const command = listChatCommands().find((entry) =>
     entry.textAliases.some((candidate) => candidate.trim().toLowerCase() === alias),
   );
+  if (command?.key === "queue") {
+    // Bare `/queue` only reads current settings. Every argument form can mutate them.
+    return normalizedBody.slice(alias.length).trim() === "";
+  }
   return command ? SIGNAL_ACTIVE_RUN_CONTROL_COMMAND_KEYS.has(command.key) : false;
 }
 

--- a/extensions/signal/src/monitor/event-handler.control-lane.ts
+++ b/extensions/signal/src/monitor/event-handler.control-lane.ts
@@ -1,0 +1,81 @@
+// Signal plugin helpers isolate active-run control scheduling from the inbound handler.
+import {
+  listChatCommands,
+  maybeResolveTextAlias,
+  normalizeCommandBody,
+} from "openclaw/plugin-sdk/command-auth-native";
+import { isAbortRequestText } from "openclaw/plugin-sdk/command-primitives-runtime";
+
+type SignalInboundControlEntry = {
+  senderPeerId: string;
+  groupId?: string;
+  isGroup: boolean;
+  commandBody: string;
+  commandAuthorized: boolean;
+};
+
+const SIGNAL_ACTIVE_RUN_CONTROL_COMMAND_KEYS = new Set([
+  "commands",
+  "context",
+  "help",
+  "queue",
+  "status",
+  "steer",
+  "tasks",
+  "tools",
+  "whoami",
+]);
+
+function resolveSignalConversationDebounceKey(
+  accountId: string,
+  entry: SignalInboundControlEntry,
+): string | null {
+  const conversationId = entry.isGroup ? (entry.groupId ?? "unknown") : entry.senderPeerId;
+  if (!conversationId || !entry.senderPeerId) {
+    return null;
+  }
+  return `signal:${accountId}:${conversationId}:${entry.senderPeerId}`;
+}
+
+function isSignalActiveRunControlText(text: string): boolean {
+  if (isAbortRequestText(text)) {
+    return true;
+  }
+  const alias = maybeResolveTextAlias(normalizeCommandBody(text.trim()));
+  if (!alias) {
+    return false;
+  }
+  const command = listChatCommands().find((entry) =>
+    entry.textAliases.some((candidate) => candidate.trim().toLowerCase() === alias),
+  );
+  return command ? SIGNAL_ACTIVE_RUN_CONTROL_COMMAND_KEYS.has(command.key) : false;
+}
+
+export function resolveSignalInboundDebounceKey(
+  accountId: string,
+  entry: SignalInboundControlEntry,
+): string | null {
+  const conversationKey = resolveSignalConversationDebounceKey(accountId, entry);
+  // Active-run-safe controls overtake the conversation run, but remain ordered with each other.
+  // Stateful commands keep the normal key so they cannot race session mutations against a run.
+  return conversationKey &&
+    entry.commandAuthorized &&
+    isSignalActiveRunControlText(entry.commandBody)
+    ? `${conversationKey}:control`
+    : conversationKey;
+}
+
+export function cancelPendingSignalInboundOnAbort(
+  accountId: string,
+  entry: SignalInboundControlEntry,
+  cancelKey: (key: string) => boolean,
+): void {
+  if (!entry.commandAuthorized || !isAbortRequestText(entry.commandBody)) {
+    return;
+  }
+  const conversationKey = resolveSignalConversationDebounceKey(accountId, entry);
+  if (conversationKey) {
+    // Active work is interrupted later by the reply layer; only undispatched text is removed here.
+    cancelKey(conversationKey);
+  }
+}

--- a/extensions/signal/src/monitor/event-handler.control-lane.ts
+++ b/extensions/signal/src/monitor/event-handler.control-lane.ts
@@ -15,6 +15,7 @@ type SignalInboundControlEntry = {
 };
 
 const SIGNAL_ACTIVE_RUN_CONTROL_COMMAND_KEYS = new Set([
+  "approve",
   "commands",
   "context",
   "help",

--- a/extensions/signal/src/monitor/event-handler.control-lane.ts
+++ b/extensions/signal/src/monitor/event-handler.control-lane.ts
@@ -6,12 +6,32 @@ import {
 } from "openclaw/plugin-sdk/command-auth-native";
 import { isAbortRequestText } from "openclaw/plugin-sdk/command-primitives-runtime";
 
-type SignalInboundControlEntry = {
+export type SignalInboundEntry = {
+  senderName: string;
+  senderDisplay: string;
+  senderRecipient: string;
   senderPeerId: string;
   groupId?: string;
+  groupName?: string;
   isGroup: boolean;
+  bodyText: string;
+  nativeReplyBody?: string;
   commandBody: string;
+  timestamp?: number;
+  messageId?: string;
+  replyToId?: string;
+  isBatched?: boolean;
+  mediaPath?: string;
+  mediaType?: string;
+  mediaPaths?: string[];
+  mediaTypes?: string[];
   commandAuthorized: boolean;
+  canDetectMention?: boolean;
+  requireMention?: boolean;
+  wasMentioned?: boolean;
+  replyToBody?: string;
+  replyToSender?: string;
+  replyToIsQuote?: boolean;
 };
 
 type TrackedSignalInboundLane = {
@@ -31,14 +51,14 @@ const SIGNAL_ACTIVE_RUN_CONTROL_COMMAND_KEYS = new Set([
   "whoami",
 ]);
 
-function resolveSignalConversationId(entry: SignalInboundControlEntry): string | null {
+function resolveSignalConversationId(entry: SignalInboundEntry): string | null {
   const conversationId = entry.isGroup ? entry.groupId : entry.senderPeerId;
   return conversationId?.trim() || null;
 }
 
 export function resolveSignalInboundDebounceKey(
   accountId: string,
-  entry: SignalInboundControlEntry,
+  entry: SignalInboundEntry,
 ): string | null {
   const conversationId = resolveSignalConversationId(entry);
   if (!conversationId || !entry.senderPeerId) {
@@ -49,7 +69,7 @@ export function resolveSignalInboundDebounceKey(
 
 function resolveSignalInboundConversationKey(
   accountId: string,
-  entry: SignalInboundControlEntry,
+  entry: SignalInboundEntry,
 ): string | null {
   const conversationId = resolveSignalConversationId(entry);
   return conversationId ? `signal:${accountId}:${conversationId}` : null;
@@ -76,7 +96,7 @@ function isSignalActiveRunControlText(text: string): boolean {
 
 export function resolveSignalControlLaneKey(
   accountId: string,
-  entry: SignalInboundControlEntry,
+  entry: SignalInboundEntry,
 ): string | null {
   if (!entry.commandAuthorized || !isSignalActiveRunControlText(entry.commandBody)) {
     return null;
@@ -86,10 +106,10 @@ export function resolveSignalControlLaneKey(
 }
 
 export function createSignalPendingInboundRegistry(accountId: string) {
-  const trackedEntries = new WeakMap<SignalInboundControlEntry, TrackedSignalInboundLane>();
+  const trackedEntries = new WeakMap<SignalInboundEntry, TrackedSignalInboundLane>();
   const countsByConversation = new Map<string, Map<string, number>>();
 
-  const track = (entry: SignalInboundControlEntry) => {
+  const track = (entry: SignalInboundEntry) => {
     if (trackedEntries.has(entry)) {
       return;
     }
@@ -104,7 +124,7 @@ export function createSignalPendingInboundRegistry(accountId: string) {
     trackedEntries.set(entry, { conversationKey, inboundKey });
   };
 
-  const complete = (entries: SignalInboundControlEntry[]) => {
+  const complete = (entries: SignalInboundEntry[]) => {
     for (const entry of entries) {
       const tracked = trackedEntries.get(entry);
       if (!tracked) {
@@ -124,10 +144,7 @@ export function createSignalPendingInboundRegistry(accountId: string) {
     }
   };
 
-  const cancelPendingOnAbort = (
-    entry: SignalInboundControlEntry,
-    cancelKey: (key: string) => boolean,
-  ) => {
+  const cancelPendingOnAbort = (entry: SignalInboundEntry, cancelKey: (key: string) => boolean) => {
     if (!entry.commandAuthorized || !isAbortRequestText(entry.commandBody)) {
       return;
     }
@@ -142,5 +159,15 @@ export function createSignalPendingInboundRegistry(accountId: string) {
     }
   };
 
-  return { track, complete, cancelPendingOnAbort };
+  const completeAfter =
+    (flush: (entries: SignalInboundEntry[]) => Promise<void>) =>
+    async (entries: SignalInboundEntry[]) => {
+      try {
+        await flush(entries);
+      } finally {
+        complete(entries);
+      }
+    };
+
+  return { track, complete, completeAfter, cancelPendingOnAbort };
 }

--- a/extensions/signal/src/monitor/event-handler.ts
+++ b/extensions/signal/src/monitor/event-handler.ts
@@ -32,7 +32,7 @@ import {
   resolveChannelGroupPolicy,
   resolveChannelGroupRequireMention,
 } from "openclaw/plugin-sdk/channel-policy";
-import { hasControlCommand } from "openclaw/plugin-sdk/command-auth-native";
+import { isControlCommandMessage } from "openclaw/plugin-sdk/command-detection";
 import { recordInboundSession } from "openclaw/plugin-sdk/conversation-runtime";
 import { collectErrorGraphCandidates, formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import {
@@ -84,6 +84,10 @@ import {
 } from "../send-reactions.js";
 import { sendMessageSignal, sendReadReceiptSignal, sendTypingSignal } from "../send.js";
 import { handleSignalDirectMessageAccess, resolveSignalAccessState } from "./access-policy.js";
+import {
+  cancelPendingSignalInboundOnAbort,
+  resolveSignalInboundDebounceKey,
+} from "./event-handler.control-lane.js";
 import type {
   SignalEnvelope,
   SignalEventHandlerDeps,
@@ -744,13 +748,8 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
   const { debouncer } = createChannelInboundDebouncer<SignalInboundEntry>({
     cfg: deps.cfg,
     channel: "signal",
-    buildKey: (entry) => {
-      const conversationId = entry.isGroup ? (entry.groupId ?? "unknown") : entry.senderPeerId;
-      if (!conversationId || !entry.senderPeerId) {
-        return null;
-      }
-      return `signal:${deps.accountId}:${conversationId}:${entry.senderPeerId}`;
-    },
+    serializeImmediate: true,
+    buildKey: (entry) => resolveSignalInboundDebounceKey(deps.accountId, entry),
     shouldDebounce: (entry) => {
       return shouldDebounceTextInbound({
         text: entry.commandBody,
@@ -940,7 +939,7 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
     const messageText = normalizedMessage.trim();
     const groupId = dataMessage?.groupInfo?.groupId ?? reaction?.groupInfo?.groupId ?? undefined;
     const isGroup = Boolean(groupId);
-    const hasControlCommandInMessage = hasControlCommand(messageText, deps.cfg);
+    const hasControlCommandInMessage = isControlCommandMessage(messageText, deps.cfg);
 
     const senderDisplay = formatSignalSenderDisplay(sender);
     const { senderAccess, commandAccess } = await resolveSignalAccessState({
@@ -1310,6 +1309,7 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       replyToSender: visibleQuoteSender,
       replyToIsQuote: visibleQuoteText ? true : undefined,
     };
+    cancelPendingSignalInboundOnAbort(deps.accountId, entry, debouncer.cancelKey);
     activeEnqueueEntries.add(entry);
     try {
       await debouncer.enqueue(entry);

--- a/extensions/signal/src/monitor/event-handler.ts
+++ b/extensions/signal/src/monitor/event-handler.ts
@@ -85,7 +85,7 @@ import {
 import { sendMessageSignal, sendReadReceiptSignal, sendTypingSignal } from "../send.js";
 import { handleSignalDirectMessageAccess, resolveSignalAccessState } from "./access-policy.js";
 import {
-  cancelPendingSignalInboundOnAbort,
+  createSignalPendingInboundRegistry,
   resolveSignalControlLaneKey,
   resolveSignalInboundDebounceKey,
 } from "./event-handler.control-lane.js";
@@ -772,6 +772,14 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
   const reportSignalInboundFlushError = (err: unknown) => {
     deps.runtime.error?.(`signal debounce flush failed: ${String(err)}`);
   };
+  const pendingInboundRegistry = createSignalPendingInboundRegistry(deps.accountId);
+  const flushNormalSignalInboundEntries = async (entries: SignalInboundEntry[]) => {
+    try {
+      await flushDebouncedSignalInboundEntries(entries);
+    } finally {
+      pendingInboundRegistry.complete(entries);
+    }
+  };
 
   const { debouncer } = createChannelInboundDebouncer<SignalInboundEntry>({
     cfg: deps.cfg,
@@ -784,8 +792,9 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
         hasMedia: Boolean(entry.mediaPath || entry.mediaType || entry.mediaPaths?.length),
       });
     },
-    onFlush: flushDebouncedSignalInboundEntries,
+    onFlush: flushNormalSignalInboundEntries,
     onError: reportSignalInboundFlushError,
+    onCancel: pendingInboundRegistry.complete,
   });
   const { debouncer: controlDebouncer } = createChannelInboundDebouncer<SignalInboundEntry>({
     cfg: deps.cfg,
@@ -1322,12 +1331,15 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       replyToSender: visibleQuoteSender,
       replyToIsQuote: visibleQuoteText ? true : undefined,
     };
-    cancelPendingSignalInboundOnAbort(deps.accountId, entry, debouncer.cancelKey);
+    pendingInboundRegistry.cancelPendingOnAbort(entry, debouncer.cancelKey);
     // Normal and stateful turns stay on the existing ingress path so core session admission owns
     // queueing and lifecycle mutations; only the narrow safe set uses channel-level serialization.
     const inboundLane = resolveSignalControlLaneKey(deps.accountId, entry)
       ? controlDebouncer
       : debouncer;
+    if (inboundLane === debouncer) {
+      pendingInboundRegistry.track(entry);
+    }
     activeEnqueueEntries.add(entry);
     try {
       await inboundLane.enqueue(entry);

--- a/extensions/signal/src/monitor/event-handler.ts
+++ b/extensions/signal/src/monitor/event-handler.ts
@@ -88,6 +88,7 @@ import {
   createSignalPendingInboundRegistry,
   resolveSignalControlLaneKey,
   resolveSignalInboundDebounceKey,
+  type SignalInboundEntry,
 } from "./event-handler.control-lane.js";
 import type {
   SignalEnvelope,
@@ -213,33 +214,6 @@ async function finalizeSignalStatusReaction(params: {
 }
 
 export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
-  type SignalInboundEntry = {
-    senderName: string;
-    senderDisplay: string;
-    senderRecipient: string;
-    senderPeerId: string;
-    groupId?: string;
-    groupName?: string;
-    isGroup: boolean;
-    bodyText: string;
-    nativeReplyBody?: string;
-    commandBody: string;
-    timestamp?: number;
-    messageId?: string;
-    replyToId?: string;
-    isBatched?: boolean;
-    mediaPath?: string;
-    mediaType?: string;
-    mediaPaths?: string[];
-    mediaTypes?: string[];
-    commandAuthorized: boolean;
-    canDetectMention?: boolean;
-    requireMention?: boolean;
-    wasMentioned?: boolean;
-    replyToBody?: string;
-    replyToSender?: string;
-    replyToIsQuote?: boolean;
-  };
   const activeEnqueueEntries = new WeakSet<SignalInboundEntry>();
 
   async function handleSignalInboundMessage(entry: SignalInboundEntry) {
@@ -773,13 +747,9 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
     deps.runtime.error?.(`signal debounce flush failed: ${String(err)}`);
   };
   const pendingInboundRegistry = createSignalPendingInboundRegistry(deps.accountId);
-  const flushNormalSignalInboundEntries = async (entries: SignalInboundEntry[]) => {
-    try {
-      await flushDebouncedSignalInboundEntries(entries);
-    } finally {
-      pendingInboundRegistry.complete(entries);
-    }
-  };
+  const flushNormalSignalInboundEntries = pendingInboundRegistry.completeAfter(
+    flushDebouncedSignalInboundEntries,
+  );
 
   const { debouncer } = createChannelInboundDebouncer<SignalInboundEntry>({
     cfg: deps.cfg,

--- a/extensions/signal/src/monitor/event-handler.ts
+++ b/extensions/signal/src/monitor/event-handler.ts
@@ -86,6 +86,7 @@ import { sendMessageSignal, sendReadReceiptSignal, sendTypingSignal } from "../s
 import { handleSignalDirectMessageAccess, resolveSignalAccessState } from "./access-policy.js";
 import {
   cancelPendingSignalInboundOnAbort,
+  resolveSignalControlLaneKey,
   resolveSignalInboundDebounceKey,
 } from "./event-handler.control-lane.js";
 import type {
@@ -745,10 +746,36 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
     throw lastError;
   }
 
+  const flushDebouncedSignalInboundEntries = async (entries: SignalInboundEntry[]) => {
+    // enqueue() awaits inline and overflow flushes, but not timer-backed work.
+    // Drain tracked inline work on shutdown; stop delayed work with no owner.
+    const hasActiveEnqueue = entries.some((entry) => activeEnqueueEntries.has(entry));
+    if (!hasActiveEnqueue && deps.abortSignal?.aborted) {
+      return;
+    }
+    try {
+      await flushSignalInboundEntries(entries);
+    } catch (err) {
+      if (!isSignalReplySessionInitConflictError(err)) {
+        throw err;
+      }
+      if (deps.abortSignal?.aborted) {
+        return;
+      }
+      // Keep the current keyed debounce task reserved through backoff so a
+      // newer same-conversation flush cannot overtake this failed batch.
+      const retryTask = retrySignalInboundFlush(entries, err);
+      deps.runTrackedTask?.(() => retryTask.catch(() => undefined));
+      await retryTask;
+    }
+  };
+  const reportSignalInboundFlushError = (err: unknown) => {
+    deps.runtime.error?.(`signal debounce flush failed: ${String(err)}`);
+  };
+
   const { debouncer } = createChannelInboundDebouncer<SignalInboundEntry>({
     cfg: deps.cfg,
     channel: "signal",
-    serializeImmediate: true,
     buildKey: (entry) => resolveSignalInboundDebounceKey(deps.accountId, entry),
     shouldDebounce: (entry) => {
       return shouldDebounceTextInbound({
@@ -757,32 +784,18 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
         hasMedia: Boolean(entry.mediaPath || entry.mediaType || entry.mediaPaths?.length),
       });
     },
-    onFlush: async (entries) => {
-      // enqueue() awaits inline and overflow flushes, but not timer-backed work.
-      // Drain tracked inline work on shutdown; stop delayed work with no owner.
-      const hasActiveEnqueue = entries.some((entry) => activeEnqueueEntries.has(entry));
-      if (!hasActiveEnqueue && deps.abortSignal?.aborted) {
-        return;
-      }
-      try {
-        await flushSignalInboundEntries(entries);
-      } catch (err) {
-        if (!isSignalReplySessionInitConflictError(err)) {
-          throw err;
-        }
-        if (deps.abortSignal?.aborted) {
-          return;
-        }
-        // Keep the current keyed debounce task reserved through backoff so a
-        // newer same-conversation flush cannot overtake this failed batch.
-        const retryTask = retrySignalInboundFlush(entries, err);
-        deps.runTrackedTask?.(() => retryTask.catch(() => undefined));
-        await retryTask;
-      }
-    },
-    onError: (err) => {
-      deps.runtime.error?.(`signal debounce flush failed: ${String(err)}`);
-    },
+    onFlush: flushDebouncedSignalInboundEntries,
+    onError: reportSignalInboundFlushError,
+  });
+  const { debouncer: controlDebouncer } = createChannelInboundDebouncer<SignalInboundEntry>({
+    cfg: deps.cfg,
+    channel: "signal",
+    // Controls bypass normal batching but retain FIFO ordering with each other.
+    serializeImmediate: true,
+    buildKey: (entry) => resolveSignalControlLaneKey(deps.accountId, entry),
+    shouldDebounce: () => false,
+    onFlush: flushDebouncedSignalInboundEntries,
+    onError: reportSignalInboundFlushError,
   });
 
   async function handleReactionOnlyInbound(params: {
@@ -1310,9 +1323,14 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       replyToIsQuote: visibleQuoteText ? true : undefined,
     };
     cancelPendingSignalInboundOnAbort(deps.accountId, entry, debouncer.cancelKey);
+    // Normal and stateful turns stay on the existing ingress path so core session admission owns
+    // queueing and lifecycle mutations; only the narrow safe set uses channel-level serialization.
+    const inboundLane = resolveSignalControlLaneKey(deps.accountId, entry)
+      ? controlDebouncer
+      : debouncer;
     activeEnqueueEntries.add(entry);
     try {
-      await debouncer.enqueue(entry);
+      await inboundLane.enqueue(entry);
     } finally {
       activeEnqueueEntries.delete(entry);
     }

--- a/src/auto-reply/inbound-debounce.ts
+++ b/src/auto-reply/inbound-debounce.ts
@@ -63,6 +63,7 @@ export type InboundDebounceCreateParams<T> = {
 export function createInboundDebouncer<T>(params: InboundDebounceCreateParams<T>) {
   const buffers = new Map<string, DebounceBuffer<T>>();
   const keyChains = new Map<string, Promise<void>>();
+  const keyGenerations = new Map<string, number>();
   const defaultDebounceMs = resolveNonNegativeIntegerOption(params.debounceMs, 0);
   const maxTrackedKeys = Math.max(1, Math.trunc(params.maxTrackedKeys ?? DEFAULT_MAX_TRACKED_KEYS));
 
@@ -84,6 +85,25 @@ export function createInboundDebouncer<T>(params: InboundDebounceCreateParams<T>
     }
   };
 
+  const cancelItems = (items: T[]) => {
+    try {
+      params.onCancel?.(items);
+    } catch {
+      // Cancellation observers release caller-owned resources; debounce state
+      // must still drain even if an observer fails.
+    }
+  };
+
+  const resolveKeyGeneration = (key: string) => keyGenerations.get(key) ?? 0;
+
+  const runQueuedFlush = async (key: string, generation: number, items: T[]) => {
+    if (resolveKeyGeneration(key) !== generation) {
+      cancelItems(items);
+      return;
+    }
+    await runFlush(items);
+  };
+
   const enqueueKeyTask = (key: string, task: () => Promise<void>) => {
     const previous = keyChains.get(key) ?? Promise.resolve();
     const next = previous.catch(() => undefined).then(task);
@@ -92,6 +112,9 @@ export function createInboundDebouncer<T>(params: InboundDebounceCreateParams<T>
     const cleanup = () => {
       if (keyChains.get(key) === settled) {
         keyChains.delete(key);
+        if (!buffers.has(key)) {
+          keyGenerations.delete(key);
+        }
       }
     };
     settled.then(cleanup, cleanup);
@@ -108,6 +131,9 @@ export function createInboundDebouncer<T>(params: InboundDebounceCreateParams<T>
       resolveSettled();
       if (keyChains.get(key) === settled) {
         keyChains.delete(key);
+        if (!buffers.has(key)) {
+          keyGenerations.delete(key);
+        }
       }
     };
     let next: Promise<void>;
@@ -174,8 +200,14 @@ export function createInboundDebouncer<T>(params: InboundDebounceCreateParams<T>
 
   const cancelKey = (key: string): boolean => {
     const buffer = buffers.get(key);
-    if (!buffer) {
+    if (!buffer && !keyChains.has(key)) {
       return false;
+    }
+    // Invalidate released tasks still waiting behind an active same-key flush.
+    // The active task has already crossed this check and remains caller-owned.
+    keyGenerations.set(key, resolveKeyGeneration(key) + 1);
+    if (!buffer) {
+      return true;
     }
     if (buffers.get(key) === buffer) {
       buffers.delete(key);
@@ -186,12 +218,7 @@ export function createInboundDebouncer<T>(params: InboundDebounceCreateParams<T>
     }
     const canceledItems = buffer.items;
     buffer.items = [];
-    try {
-      params.onCancel?.(canceledItems);
-    } catch {
-      // Cancellation observers release caller-owned resources; debounce state
-      // must still drain even if an observer fails.
-    }
+    cancelItems(canceledItems);
     releaseBuffer(buffer);
     return true;
   };
@@ -223,8 +250,9 @@ export function createInboundDebouncer<T>(params: InboundDebounceCreateParams<T>
         if (buffers.has(key)) {
           // Reserve the keyed immediate slot before forcing the pending buffer
           // to flush so fire-and-forget callers cannot be overtaken.
+          const generation = resolveKeyGeneration(key);
           const reservedTask = enqueueReservedKeyTask(key, async () => {
-            await runFlush([item]);
+            await runQueuedFlush(key, generation, [item]);
           });
           try {
             await flushKey(key);
@@ -235,8 +263,9 @@ export function createInboundDebouncer<T>(params: InboundDebounceCreateParams<T>
           return;
         }
         if (keyChains.has(key)) {
+          const generation = resolveKeyGeneration(key);
           await enqueueKeyTask(key, async () => {
-            await runFlush([item]);
+            await runQueuedFlush(key, generation, [item]);
           });
           return;
         }
@@ -263,16 +292,22 @@ export function createInboundDebouncer<T>(params: InboundDebounceCreateParams<T>
     if (!canTrackKey(key)) {
       // When the debounce map is saturated, fall back to immediate keyed work
       // instead of buffering, but still preserve same-key ordering.
+      const generation = resolveKeyGeneration(key);
       await enqueueKeyTask(key, async () => {
-        await runFlush([item]);
+        await runQueuedFlush(key, generation, [item]);
       });
       return;
     }
+    const generation = resolveKeyGeneration(key);
     const reservedTask = enqueueReservedKeyTask(key, async () => {
       if (buffer.items.length === 0) {
         return;
       }
-      await runFlush(buffer.items);
+      const items = buffer.items;
+      if (resolveKeyGeneration(key) !== generation) {
+        buffer.items = [];
+      }
+      await runQueuedFlush(key, generation, items);
     });
     const buffer: DebounceBuffer<T> = {
       items: [item],

--- a/src/auto-reply/inbound.test.ts
+++ b/src/auto-reply/inbound.test.ts
@@ -534,6 +534,45 @@ describe("createInboundDebouncer", () => {
     vi.useRealTimers();
   });
 
+  it("cancels a released flush still waiting behind active same-key work", async () => {
+    const calls: Array<string[]> = [];
+    const canceled: Array<string[]> = [];
+    let releaseFirst!: () => void;
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    const debouncer = createInboundDebouncer<{ key: string; id: string }>({
+      debounceMs: 50,
+      buildKey: (item) => item.key,
+      onFlush: async (items) => {
+        const ids = items.map((entry) => entry.id);
+        calls.push(ids);
+        if (ids[0] === "1") {
+          await firstGate;
+        }
+      },
+      onCancel: (items) => {
+        canceled.push(items.map((entry) => entry.id));
+      },
+    });
+
+    await debouncer.enqueue({ key: "a", id: "1" });
+    const firstFlush = debouncer.flushKey("a");
+    await vi.waitFor(() => expect(calls).toEqual([["1"]]));
+
+    await debouncer.enqueue({ key: "a", id: "2" });
+    const secondFlush = debouncer.flushKey("a");
+    expect(debouncer.cancelKey("a")).toBe(true);
+
+    await debouncer.enqueue({ key: "a", id: "3" });
+    const thirdFlush = debouncer.flushKey("a");
+    releaseFirst();
+    await Promise.all([firstFlush, secondFlush, thirdFlush]);
+
+    expect(canceled).toEqual([["2"]]);
+    expect(calls).toEqual([["1"], ["3"]]);
+  });
+
   it("flushes buffered items before non-debounced item", async () => {
     vi.useFakeTimers();
     const calls: Array<string[]> = [];


### PR DESCRIPTION
Closes #103309
Supersedes #103308

## What Problem This Solves

Authorized Signal controls could wait behind active conversation work. A stop, approval response, status query, or steering command could therefore arrive only after the work it was meant to control had completed.

## Why This Change Was Made

Signal now routes only a narrow, already-authorized active-run-safe set onto a dedicated conversation-scoped FIFO lane: aborts, approval responses, status/help/context/tools/tasks/whoami/commands, steer, and bare read-only `/queue`.

Ordinary text and stateful commands such as `/reset`, `/new`, `/model`, and argument-bearing `/queue` remain on the existing ingress path, so canonical core session admission still owns batching, lifecycle mutations, and queue behavior. No Signal-specific memory or session concept is added.

Authorized aborts also cancel every pending normal sender lane for the shared Signal conversation. The generic inbound debouncer now invalidates work released from its timer but not yet started, without canceling the active task or later messages.

This replaces the broad concurrent SDK bypass proposed in #103308. It adds no Plugin SDK API.

## User Impact

Signal users can stop, approve, inspect, or steer active work promptly. Repeated controls remain ordered. Ordinary messages retain per-sender batching and core session behavior, and a group stop cannot be followed by another member's previously buffered turn.

## Evidence

- `node scripts/run-vitest.mjs extensions/signal/src/monitor/event-handler.control-lane.test.ts extensions/signal/src/monitor/event-handler.reply-session-conflict.test.ts extensions/signal/src/monitor/event-handler.inbound-context.test.ts` — 3 files, 75 tests passed.
- `node scripts/run-vitest.mjs src/auto-reply/inbound.test.ts` — 62 tests passed.
- Cross-sender group-stop regression, approval-unblock, control FIFO, stateful-command admission, unauthorized-abort, and released-queue cancellation coverage.
- Blacksmith changed-file gate: conflict, LOC, attribution, SDK, dependency, formatting, baseline, package, core typecheck, core-test typecheck, and extension production typecheck gates passed; the previously blocked main gates were repaired separately.
- Targeted Oxfmt, Oxlint, and `git diff --check` passed.
- Fresh whole-branch autoreview: clean after fixing group-wide abort cancellation; fresh refactor autoreview also clean.

Contributor credit from #103308 is preserved in commit co-authorship and the changelog.
