### PR TITLE
improve: accelerate directive behavior tests

### DIFF
--- a/src/auto-reply/reply.directive.directive-behavior.e2e-mocks.ts
+++ b/src/auto-reply/reply.directive.directive-behavior.e2e-mocks.ts
@@ -110,6 +110,16 @@ vi.mock("../agents/model-catalog.js", () => ({
   loadModelCatalog: loadModelCatalogMock,
 }));
 
+vi.mock("../agents/thinking-runtime.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../agents/thinking-runtime.js")>();
+  return {
+    ...actual,
+    // These tests cover directive acknowledgements and persistence, not harness selection.
+    // Keep each directive from loading unrelated provider-route metadata through auto selection.
+    resolveEffectiveAgentRuntime: () => "openclaw",
+  };
+});
+
 vi.mock("../cli/command-secret-gateway.js", () => ({
   resolveCommandSecretRefsViaGateway: (...args: unknown[]) =>
     resolveCommandSecretRefsViaGatewayMock(...args),


### PR DESCRIPTION
## What Problem This Solves

The directive behavior fixture spent almost ten seconds resolving auto-selected agent harness metadata even though these tests only exercise directive acknowledgements and persistence.

## Why This Change Was Made

Fix the test harness runtime at `openclaw` while preserving every other real thinking-runtime export. Dedicated thinking-runtime and model-directive suites continue to own runtime-selection behavior; this fixture now stays inside its intended directive boundary.

## User Impact

No production behavior change. CI and local directive-test feedback become faster and less variable.

## Evidence

- Baseline Testbox: 9 tests passed; file 9.848s; slow test 9.839s.
- Exact-base Testbox: 9 tests passed; file 14ms.
- Baseline proof: https://github.com/openclaw/openclaw/actions/runs/29328320020
- Exact-base proof: https://github.com/openclaw/openclaw/actions/runs/29329509480
- `check:changed` passed formatting, SDK baseline, core and core-test typechecks, lint, import-cycle, and repository guards: https://github.com/openclaw/openclaw/actions/runs/29329138749
- Structured autoreview: clean, no accepted or actionable findings, confidence 0.93.
