### PR TITLE
fix(agents): propagate auth lock release failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Agent auth storage locks:** surface normal release failures while avoiding redundant release attempts after `proper-lockfile` reports a compromised lock.
 - **Paired-node session catalogs:** authorize bundled Anthropic and Codex catalog requests to invoke their read-only node commands from Control UI read flows, restoring remote Claude/Codex rows and terminal resume availability. Fixes #107406.
 - **Sandbox recreate confirmation:** treat Clack cancellation as a decline so Ctrl-C cannot proceed with container removal.
 - **Microsoft Teams HTML text:** decode HTML5 entities consistently in quoted and Graph-fetched messages while preserving literal escaped entity text.

--- a/src/agents/sessions/auth-storage.test.ts
+++ b/src/agents/sessions/auth-storage.test.ts
@@ -2,6 +2,7 @@
 // contracts for agent model authentication.
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import lockfile from "proper-lockfile";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 // auth-storage.ts persists via the named import `writeFileSync` from node:fs,
@@ -35,12 +36,13 @@ vi.mock("node:fs", async (importOriginal) => {
 });
 
 const fs = await import("node:fs");
-const { AuthStorage } = await import("./auth-storage.js");
+const { AuthStorage, FileAuthStorageBackend } = await import("./auth-storage.js");
 
-describe("auth-storage survives an interrupted write during persist (atomic write)", () => {
+describe("file auth storage", () => {
   let tmpDir: string | undefined;
 
   afterEach(() => {
+    vi.restoreAllMocks();
     writeFailHook.fn = undefined;
     if (tmpDir) {
       fs.rmSync(tmpDir, { recursive: true, force: true });
@@ -115,5 +117,14 @@ describe("auth-storage survives an interrupted write during persist (atomic writ
 
     expect(fs.statSync(tmpDir).mode & 0o777).toBe(0o755);
     expect(fs.statSync(authPath).mode & 0o777).toBe(0o600);
+  });
+
+  it("propagates async lock release failures", async () => {
+    tmpDir = fs.mkdtempSync(join(tmpdir(), "auth-releasefail-"));
+    const error = new Error("simulated lock release failure");
+    vi.spyOn(lockfile, "lock").mockResolvedValueOnce(() => Promise.reject(error));
+    const storage = new FileAuthStorageBackend(join(tmpDir, "auth.json"));
+
+    await expect(storage.withLockAsync(async () => ({ result: undefined }))).rejects.toBe(error);
   });
 });

--- a/src/agents/sessions/auth-storage.ts
+++ b/src/agents/sessions/auth-storage.ts
@@ -98,9 +98,8 @@ export class FileAuthStorageBackend implements AuthStorageBackend {
     this.ensureParentDir();
     this.ensureFileExists();
 
-    let release: (() => void) | undefined;
+    const release = acquireLockSyncWithRetry(this.authPath);
     try {
-      release = acquireLockSyncWithRetry(this.authPath);
       const current = existsSync(this.authPath) ? readFileSync(this.authPath, "utf-8") : undefined;
       const { result, next } = fn(current);
       if (next !== undefined) {
@@ -108,9 +107,7 @@ export class FileAuthStorageBackend implements AuthStorageBackend {
       }
       return result;
     } finally {
-      if (release) {
-        release();
-      }
+      release();
     }
   }
 
@@ -118,47 +115,31 @@ export class FileAuthStorageBackend implements AuthStorageBackend {
     this.ensureParentDir();
     this.ensureFileExists();
 
-    let release: (() => Promise<void>) | undefined;
-    let lockCompromised = false;
     let lockCompromisedError: Error | undefined;
-    const throwIfCompromised = () => {
-      if (lockCompromised) {
-        throw lockCompromisedError ?? new Error("Auth storage lock was compromised");
-      }
-    };
-
+    const release = await lockfile.lock(this.authPath, {
+      retries: {
+        minTimeout: 100,
+        maxTimeout: 10000,
+        randomize: true,
+      },
+      stale: 30000,
+      onCompromised: (err) => {
+        lockCompromisedError = err;
+      },
+    });
     try {
-      release = await lockfile.lock(this.authPath, {
-        retries: {
-          retries: 10,
-          factor: 2,
-          minTimeout: 100,
-          maxTimeout: 10000,
-          randomize: true,
-        },
-        stale: 30000,
-        onCompromised: (err) => {
-          lockCompromised = true;
-          lockCompromisedError = err;
-        },
-      });
-
-      throwIfCompromised();
       const current = existsSync(this.authPath) ? readFileSync(this.authPath, "utf-8") : undefined;
       const { result, next } = await fn(current);
-      throwIfCompromised();
+      if (lockCompromisedError) {
+        throw lockCompromisedError;
+      }
       if (next !== undefined) {
         this.replaceAuthFileAtomic(next);
       }
-      throwIfCompromised();
       return result;
     } finally {
-      if (release) {
-        try {
-          await release();
-        } catch {
-          // Ignore unlock errors when lock is compromised.
-        }
+      if (!lockCompromisedError) {
+        await release();
       }
     }
   }


### PR DESCRIPTION
## What Problem This Solves

The async auth-storage lock path swallowed every `proper-lockfile` release failure. A normal unlock failure could therefore leave the lock directory behind while the credential update appeared successful.

## Why This Change Was Made

Follow `proper-lockfile`'s release contract directly: propagate normal release failures, but skip release after the dependency has already marked the lock compromised. The dependency's native retry count and factor defaults replace duplicate configuration.

## User Impact

Credential refreshes now report failed lock cleanup instead of silently leaving stale lock state. Compromised-lock behavior remains unchanged. The production path is 19 lines smaller; the regression test and changelog leave a net 7-line reduction.

## Evidence

- `node scripts/run-vitest.mjs src/agents/sessions/auth-storage.test.ts` (3 tests passed)
- `git diff --check`
- local and rebased branch autoreview: clean
- direct dependency inspection: compromise marks the release handle released; normal remove errors reject through the promise adapter
