### PR TITLE
refactor(status): privatize channel feature rendering

### DIFF
--- a/scripts/deadcode-exports.baseline.mjs
+++ b/scripts/deadcode-exports.baseline.mjs
@@ -717,7 +717,6 @@ export const KNIP_UNUSED_EXPORT_BASELINE = [
   "src/skills/lifecycle/upload-store.ts: MAX_ACTIVE_SKILL_UPLOADS",
   "src/skills/runtime/refresh.ts: resetSkillsRefreshForTest",
   "src/skills/runtime/remote-skills.ts: resetRemoteNodeSkillsForTests",
-  "src/status/status-text.ts: resolveStatusChannelFeatureLine",
   "src/talk/agent-consult-runtime.ts: setRealtimeVoiceAgentConsultDepsForTest",
   "src/tasks/detached-task-runtime.ts: resetDetachedTaskLifecycleRuntimeForTests",
   "src/tasks/detached-task-runtime.ts: setDetachedTaskLifecycleRuntime",

--- a/src/status/status-text.test.ts
+++ b/src/status/status-text.test.ts
@@ -1,17 +1,47 @@
 import { describe, expect, it } from "vitest";
-import { resolveStatusChannelFeatureLine } from "./status-text.js";
+import { buildStatusText } from "./status-text.js";
+
+type StatusTextParams = Parameters<typeof buildStatusText>[0];
+
+async function renderTelegramStatus(params: {
+  cfg: StatusTextParams["cfg"];
+  sessionEntry: NonNullable<StatusTextParams["sessionEntry"]>;
+  statusAccountId?: string;
+}): Promise<string> {
+  return await buildStatusText({
+    cfg: params.cfg,
+    sessionEntry: params.sessionEntry,
+    sessionKey: "agent:main:main",
+    statusChannel: "telegram",
+    ...(params.statusAccountId ? { statusAccountId: params.statusAccountId } : {}),
+    provider: "openai",
+    model: "gpt-5.4-mini",
+    resolvedHarness: "pi",
+    resolvedVerboseLevel: "off",
+    resolvedReasoningLevel: "off",
+    resolveDefaultThinkingLevel: async () => undefined,
+    isGroup: false,
+    defaultGroupActivation: () => "mention",
+    pluginHealthLineOverride: "Plugins: test",
+    taskLineOverride: "",
+    skipDefaultTaskLookup: true,
+    primaryModelLabelOverride: "openai/gpt-5.4-mini",
+    modelAuthOverride: "test",
+    activeModelAuthOverride: "test",
+    includeTranscriptUsage: false,
+  });
+}
 
 describe("buildStatusText channel features", () => {
   it.each([
     { richMessages: undefined, expected: "Telegram rich messages: off" },
     { richMessages: false, expected: "Telegram rich messages: off" },
     { richMessages: true, expected: "Telegram rich messages: on" },
-  ])("shows Telegram rich message state for %s", ({ richMessages, expected }) => {
+  ])("shows Telegram rich message state for %s", async ({ richMessages, expected }) => {
     const telegram = richMessages === undefined ? {} : { richMessages };
-    const text = resolveStatusChannelFeatureLine({
+    const text = await renderTelegramStatus({
       cfg: { channels: { telegram } },
       sessionEntry: { sessionId: `telegram-rich-${String(richMessages)}`, updatedAt: 0 },
-      statusChannel: "telegram",
     });
 
     expect(text).toContain(expected);
@@ -22,8 +52,8 @@ describe("buildStatusText channel features", () => {
     }
   });
 
-  it("uses Telegram account rich message overrides", () => {
-    const text = resolveStatusChannelFeatureLine({
+  it("uses Telegram account rich message overrides", async () => {
+    const text = await renderTelegramStatus({
       cfg: {
         channels: {
           telegram: {
@@ -37,15 +67,14 @@ describe("buildStatusText channel features", () => {
         updatedAt: 0,
         lastAccountId: "work",
       },
-      statusChannel: "telegram",
     });
 
     expect(text).toContain("Telegram rich messages: off");
     expect(text).toContain("enable richMessages for this Telegram account");
   });
 
-  it("uses the current Telegram command account before the session records it", () => {
-    const text = resolveStatusChannelFeatureLine({
+  it("uses the current Telegram command account before the session records it", async () => {
+    const text = await renderTelegramStatus({
       cfg: {
         channels: {
           telegram: {
@@ -58,7 +87,6 @@ describe("buildStatusText channel features", () => {
         sessionId: "telegram-rich-command-account",
         updatedAt: 0,
       },
-      statusChannel: "telegram",
       statusAccountId: "work",
     });
 

--- a/src/status/status-text.ts
+++ b/src/status/status-text.ts
@@ -70,7 +70,7 @@ const USAGE_OAUTH_ONLY_PROVIDERS = new Set([
 ]);
 const CODEX_APP_SERVER_HOME_DIRNAME = "codex-home";
 
-export function resolveStatusChannelFeatureLine(params: {
+function resolveStatusChannelFeatureLine(params: {
   cfg: OpenClawConfig;
   statusChannel: string;
   statusAccountId?: string;


### PR DESCRIPTION
## What Problem This Solves

The dead-export ratchet still grandfathered the sole symbol under `src/status`: a Telegram feature-line helper used only inside `buildStatusText` and by direct tests.

## Why This Change Was Made

- Make channel feature-line resolution module-private.
- Preserve global, account override, and current command-account coverage through the public `buildStatusText` production path.
- Shrink the generated baseline by exactly one entry, with no additions; `src/status` moves from 1 to 0.

## User Impact

No status output, Telegram behavior, CLI, config, or plugin contract changes.

## Evidence

- Blacksmith Testbox `tbx_01kxg6e46xxgx0rq9h4wq9j3w9`: exact production Knip 736, format, type-aware lint, 5 focused tests, core types, and core test types green.
- Latest-main regeneration byte-stable at 736 entries (`+0/-1`).
- Fresh branch autoreview clean, confidence 0.98.
