### PR TITLE
refactor(web-readability): use native lazy module loading

### DIFF
--- a/extensions/web-readability/web-content-extractor.ts
+++ b/extensions/web-readability/web-content-extractor.ts
@@ -1,15 +1,12 @@
 // Web Readability plugin module implements web content extractor behavior.
-import { createLazyRuntimeSurface } from "openclaw/plugin-sdk/lazy-runtime";
-import type {
-  WebContentExtractionRequest,
-  WebContentExtractionResult,
-  WebContentExtractorPlugin,
-} from "openclaw/plugin-sdk/web-content-extractor";
+import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import {
   htmlToMarkdown,
   normalizeWhitespace,
   sanitizeHtml,
   stripInvisibleUnicode,
+  type WebContentExtractionRequest,
+  type WebContentExtractorPlugin,
 } from "openclaw/plugin-sdk/web-content-extractor";
 
 const READABILITY_MAX_HTML_CHARS = 1_000_000;
@@ -34,16 +31,11 @@ const HTML_VOID_TAGS = new Set([
 const READABILITY_MODULE = "@mozilla/readability";
 const LINKEDOM_MODULE = "linkedom";
 
-const loadReadabilityDeps = createLazyRuntimeSurface(
-  () =>
-    Promise.all([
-      import(READABILITY_MODULE) as Promise<typeof import("@mozilla/readability")>,
-      import(LINKEDOM_MODULE) as Promise<typeof import("linkedom")>,
-    ]),
-  ([readability, linkedom]) => ({
-    Readability: readability.Readability,
-    parseHTML: linkedom.parseHTML,
-  }),
+const loadReadabilityDeps = createLazyRuntimeModule(() =>
+  Promise.all([
+    import(READABILITY_MODULE) as Promise<typeof import("@mozilla/readability")>,
+    import(LINKEDOM_MODULE) as Promise<typeof import("linkedom")>,
+  ]),
 );
 
 function exceedsEstimatedHtmlNestingDepth(html: string, maxDepth: number): boolean {
@@ -119,9 +111,7 @@ function exceedsEstimatedHtmlNestingDepth(html: string, maxDepth: number): boole
   return false;
 }
 
-async function extractWithReadability(
-  request: WebContentExtractionRequest,
-): Promise<WebContentExtractionResult | null> {
+async function extractWithReadability(request: WebContentExtractionRequest) {
   const cleanHtml = await sanitizeHtml(request.html);
   if (
     cleanHtml.length > READABILITY_MAX_HTML_CHARS ||
@@ -130,19 +120,18 @@ async function extractWithReadability(
     return null;
   }
   try {
-    const { Readability, parseHTML } = await loadReadabilityDeps();
+    const [{ Readability }, { parseHTML }] = await loadReadabilityDeps();
     const { document } = parseHTML(cleanHtml, { location: { href: request.url } });
-    const reader = new Readability(document, { charThreshold: 0 });
+    const reader = new Readability(document);
     const parsed = reader.parse();
     if (!parsed?.content) {
       return null;
     }
     const title = parsed.title || undefined;
-    if (request.extractMode === "text") {
-      const text = stripInvisibleUnicode(normalizeWhitespace(parsed.textContent ?? ""));
-      return text ? { text, title } : null;
-    }
-    const rendered = htmlToMarkdown(parsed.content);
+    const rendered =
+      request.extractMode === "text"
+        ? { text: normalizeWhitespace(parsed.textContent ?? ""), title }
+        : htmlToMarkdown(parsed.content);
     const text = stripInvisibleUnicode(rendered.text);
     return text ? { text, title: title ?? rendered.title } : null;
   } catch {


### PR DESCRIPTION
## What Problem This Solves

The Web Readability plugin carried a custom lazy selector, split imports, duplicated text/Markdown result plumbing, and a `charThreshold: 0` option that Readability 0.6.0 ignores.

## Why This Change Was Made

Use the Plugin SDK's native lazy-module helper, destructure the loaded dependency modules at the use site, infer the extractor result, and share the final rendering path.

## User Impact

No behavior change. Readability extraction, title fallback, normalization, and lazy-load caching stay identical while 11 production lines disappear.

## Evidence

- `node scripts/run-vitest.mjs extensions/web-readability/web-content-extractor.test.ts` (3 tests passed)
- `git diff --check`
- fresh dependency sub-agent review: no findings, no direct live PR collision
- local and rebased branch autoreview: clean
- exact Readability 0.6.0 source: numeric zero is replaced by the same 500-character default used after this patch
