### PR TITLE
refactor(talk): remove consult test dependency seam

### DIFF
--- a/scripts/deadcode-exports.baseline.mjs
+++ b/scripts/deadcode-exports.baseline.mjs
@@ -717,7 +717,6 @@ export const KNIP_UNUSED_EXPORT_BASELINE = [
   "src/skills/lifecycle/upload-store.ts: MAX_ACTIVE_SKILL_UPLOADS",
   "src/skills/runtime/refresh.ts: resetSkillsRefreshForTest",
   "src/skills/runtime/remote-skills.ts: resetRemoteNodeSkillsForTests",
-  "src/talk/agent-consult-runtime.ts: setRealtimeVoiceAgentConsultDepsForTest",
   "src/tasks/detached-task-runtime.ts: resetDetachedTaskLifecycleRuntimeForTests",
   "src/tasks/detached-task-runtime.ts: setDetachedTaskLifecycleRuntime",
   "src/tasks/generated-media-task-activity.ts: resetGeneratedMediaTaskActivityForTests",

--- a/src/talk/agent-consult-runtime.test.ts
+++ b/src/talk/agent-consult-runtime.test.ts
@@ -3,10 +3,7 @@ import type { RunEmbeddedAgentParams } from "../agents/embedded-agent-runner/run
 import type { SessionEntry } from "../config/sessions/types.js";
 import { MODEL_SELECTION_LOCKED_MESSAGE } from "../sessions/model-overrides.js";
 import { runExclusiveSessionLifecycleMutation } from "../sessions/session-lifecycle-admission.js";
-import {
-  setRealtimeVoiceAgentConsultDepsForTest,
-  consultRealtimeVoiceAgent,
-} from "./agent-consult-runtime.js";
+import { consultRealtimeVoiceAgent } from "./agent-consult-runtime.js";
 import { REALTIME_VOICE_AGENT_CONSULT_TOOL } from "./agent-consult-tool.js";
 import {
   resolveRealtimeVoiceAgentConsultTools,
@@ -17,6 +14,21 @@ type ForkSessionEntryFromParent =
   typeof import("../auto-reply/reply/session-fork.js").forkSessionEntryFromParent;
 type ForkSessionEntryFromParentParams = Parameters<ForkSessionEntryFromParent>[0];
 type ForkSessionEntryFromParentResult = Awaited<ReturnType<ForkSessionEntryFromParent>>;
+
+const sessionForkMocks = vi.hoisted(() => ({
+  defaultForkSessionEntryFromParent: undefined as ForkSessionEntryFromParent | undefined,
+  forkSessionEntryFromParent: vi.fn(),
+}));
+
+vi.mock("../auto-reply/reply/session-fork.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../auto-reply/reply/session-fork.js")>();
+  sessionForkMocks.defaultForkSessionEntryFromParent = actual.forkSessionEntryFromParent;
+  sessionForkMocks.forkSessionEntryFromParent.mockImplementation(actual.forkSessionEntryFromParent);
+  return {
+    ...actual,
+    forkSessionEntryFromParent: sessionForkMocks.forkSessionEntryFromParent,
+  };
+});
 
 function createAgentRuntime(payloads: unknown[] = [{ text: "Speak this." }]) {
   const sessionStore: Record<
@@ -144,7 +156,14 @@ function createDeferred() {
 
 describe("realtime voice agent consult runtime", () => {
   afterEach(() => {
-    setRealtimeVoiceAgentConsultDepsForTest(null);
+    sessionForkMocks.forkSessionEntryFromParent.mockReset();
+    const defaultForkSessionEntryFromParent = sessionForkMocks.defaultForkSessionEntryFromParent;
+    if (!defaultForkSessionEntryFromParent) {
+      throw new Error("Expected the realtime voice session fork implementation");
+    }
+    sessionForkMocks.forkSessionEntryFromParent.mockImplementation(
+      defaultForkSessionEntryFromParent,
+    );
   });
 
   it("exposes the shared consult tool based on policy", () => {
@@ -292,8 +311,7 @@ describe("realtime voice agent consult runtime", () => {
       agentHarnessId: "codex",
       modelSelectionLocked: true,
     };
-    const forkSessionEntryFromParent = vi.fn();
-    setRealtimeVoiceAgentConsultDepsForTest({ forkSessionEntryFromParent });
+    const forkSessionEntryFromParent = sessionForkMocks.forkSessionEntryFromParent;
 
     await expect(
       consultRealtimeVoiceAgent({
@@ -429,7 +447,8 @@ describe("realtime voice agent consult runtime", () => {
       maxTokens: 100_000,
       parentTokens: 100,
     }));
-    const forkSessionEntryFromParent = vi.fn(
+    const forkSessionEntryFromParent = sessionForkMocks.forkSessionEntryFromParent;
+    forkSessionEntryFromParent.mockImplementation(
       async (
         params: ForkSessionEntryFromParentParams,
       ): Promise<ForkSessionEntryFromParentResult> => {
@@ -468,9 +487,6 @@ describe("realtime voice agent consult runtime", () => {
         };
       },
     );
-    setRealtimeVoiceAgentConsultDepsForTest({
-      forkSessionEntryFromParent,
-    });
 
     await consultRealtimeVoiceAgent({
       cfg: {} as never,
@@ -526,7 +542,8 @@ describe("realtime voice agent consult runtime", () => {
   it("falls back to a fresh isolated consult session when requester context is too large", async () => {
     const { runtime, runEmbeddedAgent } = createAgentRuntime();
     const warn = vi.fn();
-    const forkSessionEntryFromParent = vi.fn(
+    const forkSessionEntryFromParent = sessionForkMocks.forkSessionEntryFromParent;
+    forkSessionEntryFromParent.mockImplementation(
       async (
         params: ForkSessionEntryFromParentParams,
       ): Promise<ForkSessionEntryFromParentResult> => ({
@@ -547,10 +564,6 @@ describe("realtime voice agent consult runtime", () => {
         },
       }),
     );
-    setRealtimeVoiceAgentConsultDepsForTest({
-      forkSessionEntryFromParent,
-      randomUUID: () => "00000000-0000-4000-8000-000000000000",
-    });
 
     await consultRealtimeVoiceAgent({
       cfg: {} as never,
@@ -574,11 +587,11 @@ describe("realtime voice agent consult runtime", () => {
     );
     expect(runtime.session.patchSessionEntry).toHaveBeenCalled();
     const call = requireEmbeddedAgentCall(runEmbeddedAgent);
-    expect(call.sessionId).toBe("00000000-0000-4000-8000-000000000000");
+    expectNonEmptyString(call.sessionId);
     expect(call.sessionFile).toBeUndefined();
     expect(call.sessionTarget).toMatchObject({
       agentId: "main",
-      sessionId: "00000000-0000-4000-8000-000000000000",
+      sessionId: call.sessionId,
       sessionKey: "agent:main:subagent:google-meet:meet-1",
       storePath: "/tmp/sessions.json",
     });

--- a/src/talk/agent-consult-runtime.ts
+++ b/src/talk/agent-consult-runtime.ts
@@ -36,18 +36,6 @@ export type RealtimeVoiceAgentConsultResult = { text: string };
  */
 type RealtimeVoiceAgentConsultContextMode = "isolated" | "fork";
 
-type RealtimeVoiceAgentConsultDeps = {
-  randomUUID: typeof randomUUID;
-  forkSessionEntryFromParent: typeof forkSessionEntryFromParent;
-};
-
-const defaultRealtimeVoiceAgentConsultDeps: RealtimeVoiceAgentConsultDeps = {
-  randomUUID,
-  forkSessionEntryFromParent,
-};
-
-let realtimeVoiceAgentConsultDeps = defaultRealtimeVoiceAgentConsultDeps;
-
 /**
  * Fails closed when a realtime consult would cross a model-selection lock.
  */
@@ -96,17 +84,6 @@ export function assertRealtimeVoiceAgentConsultModelSelectionUnlocked(params: {
       throw new ModelSelectionLockedError();
     }
   }
-}
-
-/**
- * Overrides consult runtime dependencies for deterministic tests.
- */
-export function setRealtimeVoiceAgentConsultDepsForTest(
-  deps: Partial<RealtimeVoiceAgentConsultDeps> | null,
-): void {
-  realtimeVoiceAgentConsultDeps = deps
-    ? { ...defaultRealtimeVoiceAgentConsultDeps, ...deps }
-    : defaultRealtimeVoiceAgentConsultDeps;
 }
 
 function resolveRealtimeVoiceAgentSandboxSessionKey(agentId: string, sessionKey: string): string {
@@ -196,7 +173,7 @@ async function resolveRealtimeVoiceAgentConsultSessionEntry(params: {
 
   let patched: SessionEntry | null = null;
   if (shouldFork) {
-    const forked = await realtimeVoiceAgentConsultDeps.forkSessionEntryFromParent({
+    const forked = await forkSessionEntryFromParent({
       storePath: params.storePath,
       parentSessionKey: requesterSessionKey,
       agentId: params.agentId,
@@ -237,7 +214,7 @@ async function resolveRealtimeVoiceAgentConsultSessionEntry(params: {
       }
       return {
         ...deliveryFields,
-        sessionId: realtimeVoiceAgentConsultDeps.randomUUID(),
+        sessionId: randomUUID(),
         ...(requesterSessionKey ? { spawnedBy: requesterSessionKey } : {}),
         updatedAt: now,
       };


### PR DESCRIPTION
## What Problem This Solves

The production dead-export ratchet still carried the test-only `setRealtimeVoiceAgentConsultDepsForTest` export in `src/talk`. The setter also kept mutable test dependency state in the runtime module.

## Why This Change Was Made

Remove the production test seam and call the canonical UUID and session-fork dependencies directly. The consult tests now partial-mock the canonical session-fork module and restore its real implementation after each test. The isolated-session assertion verifies the generated session identity without depending on a fixed UUID.

## User Impact

No user-facing or plugin-SDK behavior change. `src/talk` dead-export entries move from 1 to 0. The global baseline moves from 736 to 735. Production source changes are +2/-25 lines; tests are +31/-18 lines.

## Evidence

- Blacksmith Testbox `tbx_01kxg6y2harmgxspn95fe69dq9`: production dead-export regeneration and exact check at 735, formatting, type-aware lint, 12 focused tests, and core types all passed.
- Fresh autoreview: clean, 0.96 confidence.
- Rebased once onto current `origin/main`; intervening release-ledger and web-readability changes are disjoint. The regenerated baseline remained exact at 735.
