### PR TITLE
refactor(config): use dotenv buffer parsing

### DIFF
--- a/src/config/state-dir-dotenv.ts
+++ b/src/config/state-dir-dotenv.ts
@@ -1,7 +1,7 @@
 // Loads state-directory dotenv entries used by config and runtime startup.
 import fs from "node:fs";
 import path from "node:path";
-import dotenv from "dotenv";
+import { parse as parseDotEnv } from "dotenv";
 import {
   isDangerousHostEnvOverrideVarName,
   isDangerousHostEnvVarName,
@@ -59,11 +59,10 @@ type ParsedStateDirDotEnv = {
   skippedShellReferenceKeys: string[];
 };
 
-function parseStateDirDotEnvContent(content: string): ParsedStateDirDotEnv {
-  const parsed = dotenv.parse(content);
+function parseStateDirDotEnvContent(content: string | Buffer): ParsedStateDirDotEnv {
   const entries: Record<string, string> = {};
   const skippedShellReferenceKeys: string[] = [];
-  for (const [rawKey, value] of Object.entries(parsed)) {
+  for (const [rawKey, value] of Object.entries(parseDotEnv(content))) {
     if (!value?.trim()) {
       continue;
     }
@@ -97,7 +96,7 @@ function parseStateDirDotEnvContent(content: string): ParsedStateDirDotEnv {
 export function readStateDirDotEnvFromStateDir(stateDir: string): ParsedStateDirDotEnv {
   const dotEnvPath = path.join(stateDir, ".env");
   try {
-    return parseStateDirDotEnvContent(fs.readFileSync(dotEnvPath, "utf8"));
+    return parseStateDirDotEnvContent(fs.readFileSync(dotEnvPath));
   } catch {
     return { entries: {}, skippedShellReferenceKeys: [] };
   }

--- a/src/infra/dotenv-global.ts
+++ b/src/infra/dotenv-global.ts
@@ -2,7 +2,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import dotenv from "dotenv";
+import { parse as parseDotEnv } from "dotenv";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { resolveConfigDir } from "../utils.js";
 import { resolveRequiredHomeDir } from "./home-dir.js";
@@ -34,9 +34,9 @@ export function readDotEnvFile(params: {
   filePath: string;
   quiet?: boolean;
 }): LoadedDotEnvFile | null {
-  let content: string;
+  let content: Buffer;
   try {
-    content = fs.readFileSync(params.filePath, "utf8");
+    content = fs.readFileSync(params.filePath);
   } catch (error) {
     if (!params.quiet) {
       const code =
@@ -48,17 +48,8 @@ export function readDotEnvFile(params: {
     return null;
   }
 
-  let parsed: Record<string, string>;
-  try {
-    parsed = dotenv.parse(content);
-  } catch (error) {
-    if (!params.quiet) {
-      logger.warn(`Failed to parse ${params.filePath}: ${String(error)}`, { error });
-    }
-    return null;
-  }
   const entries: DotEnvEntry[] = [];
-  for (const [rawKey, value] of Object.entries(parsed)) {
+  for (const [rawKey, value] of Object.entries(parseDotEnv(content))) {
     const key = normalizeEnvVarKey(rawKey, { portable: true });
     if (key && (params.entryFilter?.(key, value) ?? true)) {
       entries.push({ key, value });


### PR DESCRIPTION
## What Problem This Solves

Two dotenv readers converted files to strings before passing them to a parser that already accepts Buffers. The global reader also kept an unreachable parse-error branch around dotenv's non-throwing parser.

## Why This Change Was Made

Use dotenv's named `parse` export with `readFileSync` Buffers directly and let the existing read-error handling own the only fallible step.

## User Impact

No behavior change. State and global dotenv filtering, precedence, and diagnostics stay the same while 10 production lines disappear.

## Evidence

- `node scripts/run-vitest.mjs src/infra/dotenv.test.ts src/config/state-dir-dotenv.test.ts src/config/config.env-vars.test.ts` (75 tests passed)
- `git diff --check`
- direct Buffer/string parse equivalence probe on representative dotenv inputs
- fresh dependency sub-agent review: no findings
- local and rebased branch autoreview: clean
- exact dotenv 17.4.2 source/types checked
