### PR TITLE
ci: refresh plugin SDK API baseline

### DIFF
--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-72a838530460f61e1f8bb76f454cbeb5e4824bebe2db777515fa83a8ba836bb2  plugin-sdk-api-baseline.json
-8f18c66bc06e5c310889e7a8c70b69a74433eef932b6a3d97cf26b10af6c5f3c  plugin-sdk-api-baseline.jsonl
+291c9d0687821d30cee5d8f58c48bfa09c8dad4cd9899ba2db34da305649098c  plugin-sdk-api-baseline.json
+88fb3c123a521054f8c2219b71088aebf953f48976daa8d81ed04223afecd9eb  plugin-sdk-api-baseline.jsonl


### PR DESCRIPTION
## What Problem This Solves

The Plugin SDK API baseline gate fails on current `main` because its checked-in hashes no longer match the generated baseline.

## Why This Change Was Made

Refresh the generated checksum file with the repository baseline generator. macOS and Linux Testbox generation produced the same hashes.

## User Impact

None. CI metadata only; no runtime or API behavior changes.

## Evidence

- `node --max-old-space-size=8192 --import tsx scripts/generate-plugin-sdk-api-baseline.ts --check`
- `git diff --check`
- Linux Testbox generation produced the identical checksum pair.
- Fresh autoreview: clean, no actionable findings.
