### PR TITLE
fix(slack): inbound events lost when multiple accounts share one Slack app's Socket Mode token

### DIFF
--- a/extensions/slack/src/approval-handler.context.ts
+++ b/extensions/slack/src/approval-handler.context.ts
@@ -1,0 +1,41 @@
+// Slack plugin module implements approval handler context resolution: the
+// registered-context shape approval-handler.runtime.ts stores per account,
+// and resolving both the account/context pair and the per-account Web API
+// client to use for approval messages.
+import type { App } from "@slack/bolt";
+import type { WebClient } from "@slack/web-api";
+import type { ChannelApprovalCapabilityHandlerContext } from "openclaw/plugin-sdk/approval-handler-runtime";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
+
+export type SlackExecApprovalConfig = NonNullable<
+  NonNullable<NonNullable<OpenClawConfig["channels"]>["slack"]>["execApprovals"]
+>;
+
+export type SlackApprovalHandlerContext = {
+  app: App;
+  // Per-account Web API client bound to this account's own bot token. When
+  // the Bolt App is shared across accounts (same app token installed in
+  // multiple workspaces), app.client authenticates as whichever account
+  // created the App — approval messages must go through this client instead.
+  // Optional for contexts registered before this field existed; those fall
+  // back to app.client via resolveSlackApprovalClient.
+  client?: WebClient;
+  config: SlackExecApprovalConfig;
+};
+
+export function resolveHandlerContext(params: ChannelApprovalCapabilityHandlerContext): {
+  accountId: string;
+  context: SlackApprovalHandlerContext;
+} | null {
+  const context = params.context as SlackApprovalHandlerContext | undefined;
+  const accountId = normalizeOptionalString(params.accountId) ?? "";
+  if (!context?.app || !accountId) {
+    return null;
+  }
+  return { accountId, context };
+}
+
+export function resolveSlackApprovalClient(context: SlackApprovalHandlerContext): WebClient {
+  return context.client ?? context.app.client;
+}

--- a/extensions/slack/src/approval-handler.runtime.ts
+++ b/extensions/slack/src/approval-handler.runtime.ts
@@ -1,6 +1,6 @@
 // Slack plugin module implements approval handler behavior.
 import type { App } from "@slack/bolt";
-import type { Block, KnownBlock } from "@slack/web-api";
+import type { Block, KnownBlock, WebClient } from "@slack/web-api";
 import type {
   ChannelApprovalCapabilityHandlerContext,
   ExecApprovalExpiredView,
@@ -57,6 +57,13 @@ type SlackExecApprovalConfig = NonNullable<
 
 type SlackApprovalHandlerContext = {
   app: App;
+  // Per-account Web API client bound to this account's own bot token. When
+  // the Bolt App is shared across accounts (same app token installed in
+  // multiple workspaces), app.client authenticates as whichever account
+  // created the App — approval messages must go through this client instead.
+  // Optional for contexts registered before this field existed; those fall
+  // back to app.client via resolveSlackApprovalClient.
+  client?: WebClient;
   config: SlackExecApprovalConfig;
 };
 
@@ -70,6 +77,10 @@ function resolveHandlerContext(params: ChannelApprovalCapabilityHandlerContext):
     return null;
   }
   return { accountId, context };
+}
+
+function resolveSlackApprovalClient(context: SlackApprovalHandlerContext): WebClient {
+  return context.client ?? context.app.client;
 }
 
 function truncateSlackMrkdwn(text: string, maxChars: number): string {
@@ -408,14 +419,14 @@ function buildSlackExpiredBlocks(view: ExpiredApprovalView): SlackBlock[] {
 }
 
 async function updateMessage(params: {
-  app: App;
+  client: WebClient;
   channelId: string;
   messageTs: string;
   text: string;
   blocks: SlackBlock[];
 }): Promise<void> {
   try {
-    await params.app.client.chat.update({
+    await params.client.chat.update({
       channel: params.channelId,
       ts: params.messageTs,
       text: truncateSlackText(params.text, SLACK_CHAT_UPDATE_TEXT_LIMIT),
@@ -496,7 +507,7 @@ export const slackApprovalNativeRuntime = createChannelApprovalNativeRuntimeAdap
         accountId: resolved.accountId,
         threadTs: preparedTarget.threadTs,
         blocks: pendingPayload.blocks,
-        client: resolved.context.app.client,
+        client: resolveSlackApprovalClient(resolved.context),
       });
       return {
         channelId: message.channelId,
@@ -510,7 +521,7 @@ export const slackApprovalNativeRuntime = createChannelApprovalNativeRuntimeAdap
       }
       const nextPayload = payload;
       await updateMessage({
-        app: resolved.context.app,
+        client: resolveSlackApprovalClient(resolved.context),
         channelId: entry.channelId,
         messageTs: entry.messageTs,
         text: nextPayload.text,

--- a/extensions/slack/src/approval-handler.runtime.ts
+++ b/extensions/slack/src/approval-handler.runtime.ts
@@ -1,8 +1,6 @@
 // Slack plugin module implements approval handler behavior.
-import type { App } from "@slack/bolt";
 import type { Block, KnownBlock, WebClient } from "@slack/web-api";
 import type {
-  ChannelApprovalCapabilityHandlerContext,
   ExecApprovalExpiredView,
   ExecApprovalPendingView,
   ExecApprovalResolvedView,
@@ -16,10 +14,10 @@ import type {
 import { createChannelApprovalNativeRuntimeAdapter } from "openclaw/plugin-sdk/approval-handler-runtime";
 import { buildChannelApprovalNativeTargetKey } from "openclaw/plugin-sdk/approval-native-runtime";
 import { buildApprovalPresentationFromActionDescriptors } from "openclaw/plugin-sdk/approval-reply-runtime";
-import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { logError } from "openclaw/plugin-sdk/logging-core";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
+import { resolveHandlerContext, resolveSlackApprovalClient } from "./approval-handler.context.js";
 import {
   isSlackAnyNativeApprovalClientEnabled,
   shouldHandleSlackNativeApprovalRequest,
@@ -50,38 +48,6 @@ type SlackPluginApprovalView =
 const SLACK_CONTEXT_ELEMENTS_MAX = 10;
 const SLACK_CHAT_UPDATE_TEXT_LIMIT = 4000;
 const SLACK_TEXT_OBJECT_MAX = 3000;
-
-type SlackExecApprovalConfig = NonNullable<
-  NonNullable<NonNullable<OpenClawConfig["channels"]>["slack"]>["execApprovals"]
->;
-
-type SlackApprovalHandlerContext = {
-  app: App;
-  // Per-account Web API client bound to this account's own bot token. When
-  // the Bolt App is shared across accounts (same app token installed in
-  // multiple workspaces), app.client authenticates as whichever account
-  // created the App — approval messages must go through this client instead.
-  // Optional for contexts registered before this field existed; those fall
-  // back to app.client via resolveSlackApprovalClient.
-  client?: WebClient;
-  config: SlackExecApprovalConfig;
-};
-
-function resolveHandlerContext(params: ChannelApprovalCapabilityHandlerContext): {
-  accountId: string;
-  context: SlackApprovalHandlerContext;
-} | null {
-  const context = params.context as SlackApprovalHandlerContext | undefined;
-  const accountId = normalizeOptionalString(params.accountId) ?? "";
-  if (!context?.app || !accountId) {
-    return null;
-  }
-  return { accountId, context };
-}
-
-function resolveSlackApprovalClient(context: SlackApprovalHandlerContext): WebClient {
-  return context.client ?? context.app.client;
-}
 
 function truncateSlackMrkdwn(text: string, maxChars: number): string {
   const limit = Math.max(0, Math.floor(maxChars));

--- a/extensions/slack/src/delivery-trace.test.ts
+++ b/extensions/slack/src/delivery-trace.test.ts
@@ -447,6 +447,9 @@ function createPreparedTraceMessage(scenario: SlackTraceScenarioName): PreparedS
       runtime: { log: () => {}, error: () => {} },
       botToken: "xoxb-trace",
       app: { client },
+      // Source reads ctx.client (per-account WebClient), not ctx.app.client;
+      // reuse the same recording client so all wire calls stay captured.
+      client,
       teamId: TEAM_ID,
       botUserId: "UBOT",
       botId: "BBOT",

--- a/extensions/slack/src/monitor.test-helpers.ts
+++ b/extensions/slack/src/monitor.test-helpers.ts
@@ -4,12 +4,14 @@ import { resolveGlobalDedupeCache } from "openclaw/plugin-sdk/dedupe-runtime";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { vi } from "vitest";
 import type { Mock } from "vitest";
+import { resetSlackSharedSocketGroupsForTests } from "./monitor/shared-socket-group.js";
 
 type SlackHandler = (args: unknown) => Promise<void>;
 type SlackMiddleware = (args: { next: () => Promise<void> } & Record<string, unknown>) => unknown;
 type SlackProviderMonitor = (params: {
   botToken: string;
   appToken: string;
+  accountId?: string;
   abortSignal: AbortSignal;
   config?: Record<string, unknown>;
   channelRuntime?: ChannelRuntimeSurface;
@@ -85,52 +87,110 @@ export const getSlackHandlers = () => ensureSlackTestRuntime().handlers;
 
 export const getSlackClient = () => ensureSlackTestRuntime().client;
 
+// Default bot token used by startSlackMonitor() when a test doesn't pass its
+// own. Every per-account WebClient the code under test constructs (via
+// createSlackWebClient) is keyed by the token it was constructed with, so a
+// second account started with a different botToken gets its own, independent
+// mock client — see getSlackClientForToken.
+export const DEFAULT_SLACK_TEST_BOT_TOKEN = "bot-token";
+
+// Get-or-create a mock client dedicated to `token`, for tests that need a
+// SECOND, genuinely distinct account identity (e.g. shared-app-token
+// multi-account tests). Call this to register/configure the second account's
+// client BEFORE starting its monitor. Tokens nobody explicitly registers this
+// way keep resolving to the single default client (see
+// resolveSlackClientForToken) so every pre-existing test that passes a custom
+// botToken without expecting a distinct mock keeps working unchanged.
+export const getSlackClientForToken = (token: string): SlackClient =>
+  ensureSlackClientForToken(token);
+
+function resolveSlackClientForToken(token: string): SlackClient {
+  const { clientsByToken, client } = ensureSlackTestRuntime();
+  return clientsByToken.get(token) ?? client;
+}
+
+function createMockSlackClient(): SlackClient {
+  return {
+    auth: { test: vi.fn().mockResolvedValue({ user_id: "bot-user", bot_id: "bot-id" }) },
+    conversations: {
+      info: vi.fn().mockResolvedValue({
+        channel: { name: "dm", is_im: true },
+      }),
+      replies: vi.fn().mockResolvedValue({ messages: [] }),
+      history: vi.fn().mockResolvedValue({ messages: [] }),
+    },
+    users: {
+      info: vi.fn().mockResolvedValue({
+        user: { profile: { display_name: "Ada" } },
+      }),
+    },
+    assistant: {
+      threads: {
+        setStatus: vi.fn().mockResolvedValue({ ok: true }),
+      },
+    },
+    reactions: {
+      add: (...args: unknown[]) => {
+        slackTestState.reactionAddMock(...args);
+        return slackTestState.reactMock(...args);
+      },
+      remove: (...args: unknown[]) => {
+        slackTestState.reactionRemoveMock(...args);
+        return slackTestState.reactMock(...args);
+      },
+    },
+  };
+}
+
+function ensureSlackClientForToken(token: string): SlackClient {
+  const { clientsByToken } = ensureSlackTestRuntime();
+  let client = clientsByToken.get(token);
+  if (!client) {
+    client = createMockSlackClient();
+    clientsByToken.set(token, client);
+  }
+  return client;
+}
+
 function ensureSlackTestRuntime(): {
   handlers: Map<string, SlackHandler>;
+  // Raw per-event registrations, in registration order, keyed by event name.
+  // Real Bolt invokes every listener registered for a matching event (this is
+  // exactly what makes sharing one App across accounts work); `handlers`
+  // above stores one composed function per name so getSlackHandlerOrThrow()
+  // keeps its existing single-handler contract while still invoking all of
+  // them.
+  rawEventHandlersByName: Map<string, SlackHandler[]>;
   client: SlackClient;
+  clientsByToken: Map<string, SlackClient>;
 } {
   const globalState = globalThis as {
     __slackHandlers?: Map<string, SlackHandler>;
+    __slackRawEventHandlersByName?: Map<string, SlackHandler[]>;
     __slackClient?: SlackClient;
+    __slackClientsByToken?: Map<string, SlackClient>;
   };
   if (!globalState["__slackHandlers"]) {
     globalState["__slackHandlers"] = new Map<string, SlackHandler>();
   }
+  if (!globalState["__slackRawEventHandlersByName"]) {
+    globalState["__slackRawEventHandlersByName"] = new Map<string, SlackHandler[]>();
+  }
+  if (!globalState["__slackClientsByToken"]) {
+    globalState["__slackClientsByToken"] = new Map<string, SlackClient>();
+  }
   if (!globalState["__slackClient"]) {
-    globalState["__slackClient"] = {
-      auth: { test: vi.fn().mockResolvedValue({ user_id: "bot-user", bot_id: "bot-id" }) },
-      conversations: {
-        info: vi.fn().mockResolvedValue({
-          channel: { name: "dm", is_im: true },
-        }),
-        replies: vi.fn().mockResolvedValue({ messages: [] }),
-        history: vi.fn().mockResolvedValue({ messages: [] }),
-      },
-      users: {
-        info: vi.fn().mockResolvedValue({
-          user: { profile: { display_name: "Ada" } },
-        }),
-      },
-      assistant: {
-        threads: {
-          setStatus: vi.fn().mockResolvedValue({ ok: true }),
-        },
-      },
-      reactions: {
-        add: (...args: unknown[]) => {
-          slackTestState.reactionAddMock(...args);
-          return slackTestState.reactMock(...args);
-        },
-        remove: (...args: unknown[]) => {
-          slackTestState.reactionRemoveMock(...args);
-          return slackTestState.reactMock(...args);
-        },
-      },
-    };
+    globalState["__slackClient"] = createMockSlackClient();
+    globalState["__slackClientsByToken"].set(
+      DEFAULT_SLACK_TEST_BOT_TOKEN,
+      globalState["__slackClient"],
+    );
   }
   return {
     handlers: globalState["__slackHandlers"],
+    rawEventHandlersByName: globalState["__slackRawEventHandlersByName"],
     client: globalState["__slackClient"],
+    clientsByToken: globalState["__slackClientsByToken"],
   };
 }
 
@@ -153,16 +213,19 @@ export function startSlackMonitor(
   opts?: {
     botToken?: string;
     appToken?: string;
+    accountId?: string;
+    config?: Record<string, unknown>;
     channelRuntime?: ChannelRuntimeSurface;
     runtime?: RuntimeEnv;
   },
 ) {
   const controller = new AbortController();
   const run = monitorSlackProvider({
-    botToken: opts?.botToken ?? "bot-token",
+    botToken: opts?.botToken ?? DEFAULT_SLACK_TEST_BOT_TOKEN,
     appToken: opts?.appToken ?? "app-token",
+    accountId: opts?.accountId,
     abortSignal: controller.signal,
-    config: slackTestState.config,
+    config: opts?.config ?? slackTestState.config,
     channelRuntime: opts?.channelRuntime,
     runtime: opts?.runtime,
   });
@@ -260,7 +323,15 @@ export function resetSlackTestState(config: Record<string, unknown> = defaultSla
     user: { profile: { display_name: "Ada" } },
   });
   client.assistant.threads.setStatus.mockReset().mockResolvedValue({ ok: true });
+  const { clientsByToken, rawEventHandlersByName } = ensureSlackTestRuntime();
   getSlackHandlers()?.clear();
+  rawEventHandlersByName.clear();
+  // Any per-token WebClient created by a previous test (e.g. a second
+  // account in a shared-app-token test) must not leak into the next test;
+  // only the default token's client (reset above) survives.
+  clientsByToken.clear();
+  clientsByToken.set(DEFAULT_SLACK_TEST_BOT_TOKEN, client);
+  resetSlackSharedSocketGroupsForTests();
 }
 
 vi.mock("./monitor/config.runtime.js", async () => {
@@ -328,7 +399,7 @@ vi.mock("./monitor/conversation.runtime.js", async () => {
 });
 
 vi.mock("@slack/bolt", () => {
-  const { handlers, client: slackClient } = ensureSlackTestRuntime();
+  const { handlers, rawEventHandlersByName, client: slackClient } = ensureSlackTestRuntime();
   class App {
     client = slackClient;
     receiver: unknown;
@@ -341,6 +412,14 @@ vi.mock("@slack/bolt", () => {
       this.middlewares.push(middleware);
     }
     event(name: string, handler: SlackHandler) {
+      // Real Bolt invokes every listener registered for a matching event —
+      // this is the mechanism a shared App relies on to demux multiple
+      // accounts' handlers. Track all registrations for `name` and, on
+      // dispatch, run every one of them (each account's own
+      // shouldDropMismatchedSlackEvent filter decides whether it acts).
+      const registered = rawEventHandlersByName.get(name) ?? [];
+      registered.push(handler);
+      rawEventHandlersByName.set(name, registered);
       handlers.set(name, async (args: unknown) => {
         const eventArgs =
           args && typeof args === "object" && !Array.isArray(args)
@@ -349,7 +428,9 @@ vi.mock("@slack/bolt", () => {
         const run = async (index: number): Promise<void> => {
           const middleware = this.middlewares[index];
           if (!middleware) {
-            await handler(args);
+            for (const registeredHandler of rawEventHandlersByName.get(name) ?? []) {
+              await registeredHandler(args);
+            }
             return;
           }
           await middleware({
@@ -386,4 +467,16 @@ vi.mock("@slack/bolt", () => {
     SocketModeReceiver,
     default: { App, HTTPReceiver, SocketModeReceiver },
   };
+});
+
+// createSlackWebClient()/createSlackWriteClient() construct a real
+// `new WebClient(token, options)`. Route that through the same per-token
+// mock registry as app.client so provider.ts's per-account client (used for
+// auth.test() and ctx.client) resolves to the SAME mock object tests already
+// assert against — for the default token this is literally getSlackClient().
+vi.mock("@slack/web-api", () => {
+  const WebClient = vi.fn(function WebClientMock(token: string) {
+    return resolveSlackClientForToken(token);
+  });
+  return { WebClient };
 });

--- a/extensions/slack/src/monitor/auth.test.ts
+++ b/extensions/slack/src/monitor/auth.test.ts
@@ -130,6 +130,8 @@ describe("authorizeSlackSystemEventSender", () => {
       accountId: "main",
       allowNameMatching: false,
       app: { client: { conversations: { members: conversationsMembers } } },
+      // Source reads ctx.client (per-account WebClient), not ctx.app.client.
+      client: { conversations: { members: conversationsMembers } },
       botToken: "xoxb-test",
     } as unknown as SlackMonitorContext;
 
@@ -168,6 +170,8 @@ describe("authorizeSlackSystemEventSender", () => {
       accountId: "main",
       allowNameMatching: false,
       app: { client: { conversations: { members: conversationsMembers } } },
+      // Source reads ctx.client (per-account WebClient), not ctx.app.client.
+      client: { conversations: { members: conversationsMembers } },
       botToken: "xoxb-test",
     } as unknown as SlackMonitorContext;
 
@@ -202,6 +206,8 @@ describe("authorizeSlackSystemEventSender", () => {
       accountId: "main",
       allowNameMatching: false,
       app: { client: { conversations: { members: conversationsMembers } } },
+      // Source reads ctx.client (per-account WebClient), not ctx.app.client.
+      client: { conversations: { members: conversationsMembers } },
       botToken: "xoxb-test",
     } as unknown as SlackMonitorContext;
 
@@ -243,6 +249,8 @@ describe("authorizeSlackSystemEventSender", () => {
       accountId: "main",
       allowNameMatching: false,
       app: { client: { conversations: { members: conversationsMembers } } },
+      // Source reads ctx.client (per-account WebClient), not ctx.app.client.
+      client: { conversations: { members: conversationsMembers } },
       botToken: "xoxb-test",
     } as unknown as SlackMonitorContext;
 

--- a/extensions/slack/src/monitor/auth.ts
+++ b/extensions/slack/src/monitor/auth.ts
@@ -211,7 +211,7 @@ async function fetchSlackChannelMemberIds(
   const members = new Set<string>();
   let cursor: string | undefined;
   do {
-    const response = await (eventScope?.client ?? ctx.app.client).conversations.members({
+    const response = await (eventScope?.client ?? ctx.client).conversations.members({
       token: ctx.botToken,
       channel: channelId,
       limit: 999,

--- a/extensions/slack/src/monitor/context-account-client.test.ts
+++ b/extensions/slack/src/monitor/context-account-client.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import {
+  isSelfAuthoredSlackBotMessage,
+  resolveIncomingSlackEventTeamId,
+} from "./context-account-client.js";
+
+describe("resolveIncomingSlackEventTeamId", () => {
+  it("resolves the Events API envelope team_id", () => {
+    expect(resolveIncomingSlackEventTeamId({ team_id: "T1" })).toBe("T1");
+  });
+
+  it("falls back to interaction body team.id", () => {
+    expect(resolveIncomingSlackEventTeamId({ team: { id: "T2" } })).toBe("T2");
+  });
+
+  it("prefers view.app_installed_team_id over the actor's team for view payloads", () => {
+    // Slack Connect: the actor's team (T_ACTOR) can differ from the workspace
+    // the app is installed in (T_INSTALLED). Bolt resolves the installed
+    // workspace from view.app_installed_team_id for view submissions/closures,
+    // and the installed workspace is the account demux key.
+    expect(
+      resolveIncomingSlackEventTeamId({
+        team: { id: "T_ACTOR" },
+        user: { team_id: "T_ACTOR" },
+        view: { app_installed_team_id: "T_INSTALLED", team_id: "T_ACTOR" },
+      }),
+    ).toBe("T_INSTALLED");
+  });
+
+  it("falls back to view.team_id, then user.team_id, then empty", () => {
+    expect(resolveIncomingSlackEventTeamId({ view: { team_id: "T3" } })).toBe("T3");
+    expect(resolveIncomingSlackEventTeamId({ user: { team_id: "T4" } })).toBe("T4");
+    expect(resolveIncomingSlackEventTeamId({})).toBe("");
+    expect(resolveIncomingSlackEventTeamId(undefined)).toBe("");
+  });
+});
+
+describe("isSelfAuthoredSlackBotMessage", () => {
+  it("matches by user id", () => {
+    expect(
+      isSelfAuthoredSlackBotMessage({
+        message: { user: "U_BOT" },
+        botUserId: "U_BOT",
+        botId: "B1",
+      }),
+    ).toBe(true);
+  });
+
+  it("matches by bot_id when the payload carries no user (bot_message shape)", () => {
+    expect(
+      isSelfAuthoredSlackBotMessage({
+        message: { bot_id: "B1" },
+        botUserId: "U_BOT",
+        botId: "B1",
+      }),
+    ).toBe(true);
+  });
+
+  it("does not match a different bot or an unresolved own identity", () => {
+    expect(
+      isSelfAuthoredSlackBotMessage({
+        message: { bot_id: "B_OTHER" },
+        botUserId: "U_BOT",
+        botId: "B1",
+      }),
+    ).toBe(false);
+    expect(
+      isSelfAuthoredSlackBotMessage({
+        message: { bot_id: "B1" },
+        botUserId: undefined,
+        botId: undefined,
+      }),
+    ).toBe(false);
+  });
+});

--- a/extensions/slack/src/monitor/context-account-client.ts
+++ b/extensions/slack/src/monitor/context-account-client.ts
@@ -8,7 +8,11 @@ import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 
 /**
  * Resolves the workspace (team) id carried by an inbound Slack payload,
- * covering every shape the event surfaces treat as a team source: Events API
+ * covering every shape the event surfaces treat as a team source: view
+ * payloads' installed-workspace id (`view.app_installed_team_id` — for view
+ * submissions/closures Bolt resolves the INSTALLED workspace from this field,
+ * and with Slack Connect the actor's `team.id` can legitimately differ from
+ * the workspace the app is installed in, so it must win), Events API
  * envelopes (`team_id`), interaction bodies (`team.id`), view payloads
  * (`view.team_id`), and shortcut payloads that only identify the user's home
  * workspace (`user.team_id` — see events/interactions.shortcuts.ts). Ordered
@@ -21,9 +25,12 @@ export function resolveIncomingSlackEventTeamId(body: unknown): string {
   const raw = body as {
     team_id?: unknown;
     team?: { id?: unknown };
-    view?: { team_id?: unknown };
+    view?: { team_id?: unknown; app_installed_team_id?: unknown };
     user?: { team_id?: unknown };
   };
+  if (typeof raw.view?.app_installed_team_id === "string" && raw.view.app_installed_team_id) {
+    return raw.view.app_installed_team_id;
+  }
   if (typeof raw.team_id === "string" && raw.team_id) {
     return raw.team_id;
   }
@@ -37,6 +44,28 @@ export function resolveIncomingSlackEventTeamId(body: unknown): string {
     return raw.user.team_id;
   }
   return "";
+}
+
+/**
+ * True when an inbound message was authored by THIS account's own bot
+ * identity (matched by `user` against the bot's user id, or by `bot_id`
+ * against the bot's bot id — `bot_message` payloads often carry only the
+ * latter). Solo accounts already drop self events at the Bolt App level via
+ * its per-event context, but on a shared App that context carries the group
+ * CREATOR's identity, so a non-owner account's own bot messages sail past the
+ * app-level filter and must be dropped per account before `allowBots` is
+ * honored — otherwise an account with allowBots enabled can reply to itself.
+ */
+export function isSelfAuthoredSlackBotMessage(params: {
+  message: { user?: string; bot_id?: string };
+  botUserId?: string;
+  botId?: string;
+}): boolean {
+  const { message, botUserId, botId } = params;
+  if (message.user && botUserId && message.user === botUserId) {
+    return true;
+  }
+  return Boolean(message.bot_id && botId && message.bot_id === botId);
 }
 
 /**

--- a/extensions/slack/src/monitor/context-account-client.ts
+++ b/extensions/slack/src/monitor/context-account-client.ts
@@ -1,0 +1,107 @@
+// Slack plugin module implements per-account event demultiplexing for
+// context.ts: resolving the workspace (team) id carried by an inbound Slack
+// payload, and building the shouldDropMismatchedSlackEvent filter every
+// event surface uses to drop traffic that doesn't belong to this account
+// (e.g. when its Bolt App/Socket Mode connection is shared with sibling
+// accounts on the same app token).
+import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
+
+/**
+ * Resolves the workspace (team) id carried by an inbound Slack payload,
+ * covering every shape the event surfaces treat as a team source: Events API
+ * envelopes (`team_id`), interaction bodies (`team.id`), view payloads
+ * (`view.team_id`), and shortcut payloads that only identify the user's home
+ * workspace (`user.team_id` — see events/interactions.shortcuts.ts). Ordered
+ * most-authoritative first; returns "" when no source is present.
+ */
+export function resolveIncomingSlackEventTeamId(body: unknown): string {
+  if (!body || typeof body !== "object") {
+    return "";
+  }
+  const raw = body as {
+    team_id?: unknown;
+    team?: { id?: unknown };
+    view?: { team_id?: unknown };
+    user?: { team_id?: unknown };
+  };
+  if (typeof raw.team_id === "string" && raw.team_id) {
+    return raw.team_id;
+  }
+  if (typeof raw.team?.id === "string" && raw.team.id) {
+    return raw.team.id;
+  }
+  if (typeof raw.view?.team_id === "string" && raw.view.team_id) {
+    return raw.view.team_id;
+  }
+  if (typeof raw.user?.team_id === "string" && raw.user.team_id) {
+    return raw.user.team_id;
+  }
+  return "";
+}
+
+/**
+ * Builds the per-account `shouldDropMismatchedSlackEvent` filter every Slack
+ * event surface passes inbound payloads through, to demultiplex traffic when
+ * this account's Bolt App/Socket Mode connection may be shared with sibling
+ * accounts on the same app token.
+ */
+export function createSlackShouldDropMismatchedEvent(params: {
+  accountId: string;
+  accountAbortSignal?: AbortSignal;
+  isSharedSocketGroup?: boolean;
+  teamId: string;
+  apiAppId: string;
+}): (body: unknown) => boolean {
+  return (body: unknown) => {
+    // A stopped account must not keep acting on events. Bolt offers no way to
+    // unregister listeners, so when this account was stopped while its (shared
+    // or solo) App stays connected, its handlers are still invoked — drop at
+    // the gate instead. Universally correct semantics, so no shared/solo split.
+    if (params.accountAbortSignal?.aborted) {
+      logVerbose(`slack: drop event for stopped account ${params.accountId}`);
+      return true;
+    }
+    // On a shared App an account without a resolved teamId (boot auth.test
+    // failed) has no way to demux its own workspace's traffic from its
+    // siblings'. Processing anyway would act on OTHER tenants' events, so
+    // fail closed until restart with a valid bot token. Solo accounts keep
+    // the historical lenient behavior below.
+    if (params.isSharedSocketGroup && !params.teamId) {
+      logVerbose(
+        `slack: drop event for account ${params.accountId} (teamId unresolved on shared socket group)`,
+      );
+      return true;
+    }
+    const raw =
+      body && typeof body === "object"
+        ? (body as {
+            api_app_id?: unknown;
+          })
+        : undefined;
+    const incomingApiAppId = typeof raw?.api_app_id === "string" ? raw.api_app_id : "";
+    const incomingTeamId = raw ? resolveIncomingSlackEventTeamId(raw) : "";
+
+    if (params.apiAppId && incomingApiAppId && incomingApiAppId !== params.apiAppId) {
+      logVerbose(
+        `slack: drop event with api_app_id=${incomingApiAppId} (expected ${params.apiAppId})`,
+      );
+      return true;
+    }
+    if (params.teamId && incomingTeamId && incomingTeamId !== params.teamId) {
+      logVerbose(`slack: drop event with team_id=${incomingTeamId} (expected ${params.teamId})`);
+      return true;
+    }
+    // On a shared App, api_app_id is identical for every account, so team is
+    // the ONLY demux key. A payload without any team information would sail
+    // through every sharing account's filter and be processed by all of them
+    // (cross-tenant processing) — fail closed instead. Solo accounts keep the
+    // historical lenient pass-through for team-less payloads.
+    if (params.isSharedSocketGroup && !incomingTeamId) {
+      logVerbose(
+        `slack: drop event without team info for account ${params.accountId} (shared socket group)`,
+      );
+      return true;
+    }
+    return false;
+  };
+}

--- a/extensions/slack/src/monitor/context.test.ts
+++ b/extensions/slack/src/monitor/context.test.ts
@@ -12,6 +12,9 @@ function createTestContext(params?: {
   groupDmEnabled?: boolean;
   groupDmChannels?: string[];
   appClient?: App["client"];
+  teamId?: string;
+  isSharedSocketGroup?: boolean;
+  accountAbortSignal?: AbortSignal;
 }) {
   return createSlackMonitorContext({
     cfg: {
@@ -25,9 +28,11 @@ function createTestContext(params?: {
     // reuse the same mock so existing appClient assertions keep observing it.
     client: (params?.appClient ?? {}) as WebClient,
     runtime: {} as RuntimeEnv,
+    accountAbortSignal: params?.accountAbortSignal,
+    isSharedSocketGroup: params?.isSharedSocketGroup,
     botUserId: "U_BOT",
     botId: "B_BOT",
-    teamId: "T_EXPECTED",
+    teamId: params?.teamId ?? "T_EXPECTED",
     apiAppId: "A_EXPECTED",
     historyLimit: 0,
     sessionScope: "per-sender",
@@ -90,6 +95,50 @@ describe("createSlackMonitorContext shouldDropMismatchedSlackEvent", () => {
       ctx.shouldDropMismatchedSlackEvent({
         api_app_id: "A_EXPECTED",
         team: { id: "T_EXPECTED" },
+      }),
+    ).toBe(false);
+  });
+
+  it("drops everything once the account's own abort signal fires", () => {
+    const controller = new AbortController();
+    const ctx = createTestContext({ accountAbortSignal: controller.signal });
+
+    // Fully matching payloads pass while the account is alive.
+    const matching = { api_app_id: "A_EXPECTED", team_id: "T_EXPECTED" };
+    expect(ctx.shouldDropMismatchedSlackEvent(matching)).toBe(false);
+
+    // Bolt has no listener-removal API: once the account is stopped its
+    // handlers stay registered on the (shared or solo) App, so the gate must
+    // drop even perfectly matching events — and malformed/empty bodies too.
+    controller.abort();
+    expect(ctx.shouldDropMismatchedSlackEvent(matching)).toBe(true);
+    expect(ctx.shouldDropMismatchedSlackEvent(undefined)).toBe(true);
+  });
+
+  it("fails closed on a shared socket group when teamId is unresolved", () => {
+    const ctx = createTestContext({ teamId: "", isSharedSocketGroup: true });
+
+    // Without a resolved teamId the account cannot demux its own workspace's
+    // traffic from its siblings' on the shared connection: drop everything,
+    // even events that would otherwise pass the api_app_id check.
+    expect(
+      ctx.shouldDropMismatchedSlackEvent({
+        api_app_id: "A_EXPECTED",
+        team_id: "T_ANY",
+      }),
+    ).toBe(true);
+    expect(ctx.shouldDropMismatchedSlackEvent({})).toBe(true);
+  });
+
+  it("keeps the historical lenient behavior for a solo account without teamId", () => {
+    const ctx = createTestContext({ teamId: "", isSharedSocketGroup: false });
+
+    // A solo account owns its whole connection, so an unresolved teamId only
+    // disables the team check — events still flow (pre-existing semantics).
+    expect(
+      ctx.shouldDropMismatchedSlackEvent({
+        api_app_id: "A_EXPECTED",
+        team_id: "T_ANY",
       }),
     ).toBe(false);
   });

--- a/extensions/slack/src/monitor/context.test.ts
+++ b/extensions/slack/src/monitor/context.test.ts
@@ -1,5 +1,6 @@
 // Slack tests cover context plugin behavior.
 import type { App } from "@slack/bolt";
+import type { WebClient } from "@slack/web-api";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { describe, expect, it, vi } from "vitest";
@@ -20,6 +21,9 @@ function createTestContext(params?: {
     accountId: "default",
     botToken: "xoxb-test",
     app: { client: params?.appClient ?? {} } as App,
+    // Source reads ctx.client (per-account WebClient), not ctx.app.client;
+    // reuse the same mock so existing appClient assertions keep observing it.
+    client: (params?.appClient ?? {}) as WebClient,
     runtime: {} as RuntimeEnv,
     botUserId: "U_BOT",
     botId: "B_BOT",

--- a/extensions/slack/src/monitor/context.test.ts
+++ b/extensions/slack/src/monitor/context.test.ts
@@ -115,6 +115,65 @@ describe("createSlackMonitorContext shouldDropMismatchedSlackEvent", () => {
     expect(ctx.shouldDropMismatchedSlackEvent(undefined)).toBe(true);
   });
 
+  it("drops payloads whose only team source is user.team_id when it mismatches", () => {
+    const ctx = createTestContext();
+    // Shortcut payloads may carry no top-level team_id / team.id; the user's
+    // home workspace (used as the team source by
+    // events/interactions.shortcuts.ts) must still be able to veto.
+    expect(
+      ctx.shouldDropMismatchedSlackEvent({
+        api_app_id: "A_EXPECTED",
+        user: { team_id: "T_WRONG" },
+      }),
+    ).toBe(true);
+    expect(
+      ctx.shouldDropMismatchedSlackEvent({
+        api_app_id: "A_EXPECTED",
+        user: { team_id: "T_EXPECTED" },
+      }),
+    ).toBe(false);
+  });
+
+  it("drops payloads whose only team source is view.team_id when it mismatches", () => {
+    const ctx = createTestContext();
+    expect(
+      ctx.shouldDropMismatchedSlackEvent({
+        api_app_id: "A_EXPECTED",
+        view: { team_id: "T_WRONG" },
+      }),
+    ).toBe(true);
+    expect(
+      ctx.shouldDropMismatchedSlackEvent({
+        api_app_id: "A_EXPECTED",
+        view: { team_id: "T_EXPECTED" },
+      }),
+    ).toBe(false);
+  });
+
+  it("fails closed on a shared socket group when the payload carries no team info", () => {
+    const ctx = createTestContext({ isSharedSocketGroup: true });
+    // api_app_id is identical for every account sharing an app, so a payload
+    // without any team source would pass every sibling's filter and be
+    // processed by all of them — drop it instead.
+    expect(ctx.shouldDropMismatchedSlackEvent({ api_app_id: "A_EXPECTED" })).toBe(true);
+    expect(ctx.shouldDropMismatchedSlackEvent({})).toBe(true);
+    // A payload that does carry this account's team still flows normally.
+    expect(
+      ctx.shouldDropMismatchedSlackEvent({
+        api_app_id: "A_EXPECTED",
+        team_id: "T_EXPECTED",
+      }),
+    ).toBe(false);
+  });
+
+  it("keeps passing team-less payloads through for a solo account", () => {
+    const ctx = createTestContext({ isSharedSocketGroup: false });
+    // Historical lenient behavior: a solo account owns its whole connection,
+    // so a payload without team info is not a demux hazard.
+    expect(ctx.shouldDropMismatchedSlackEvent({ api_app_id: "A_EXPECTED" })).toBe(false);
+    expect(ctx.shouldDropMismatchedSlackEvent({})).toBe(false);
+  });
+
   it("fails closed on a shared socket group when teamId is unresolved", () => {
     const ctx = createTestContext({ teamId: "", isSharedSocketGroup: true });
 

--- a/extensions/slack/src/monitor/context.ts
+++ b/extensions/slack/src/monitor/context.ts
@@ -30,6 +30,7 @@ import type { SlackChannelConfigEntries } from "./channel-config.js";
 import { resolveSlackChannelConfig } from "./channel-config.js";
 import { normalizeSlackChannelType } from "./channel-type.js";
 import { resolveSessionKey } from "./config.runtime.js";
+import { createSlackShouldDropMismatchedEvent } from "./context-account-client.js";
 import type { SlackInstallationIdentity } from "./enterprise-install.js";
 import type { SlackEventScope } from "./event-scope.js";
 import { isSlackChannelAllowedByPolicy } from "./policy.js";
@@ -229,39 +230,6 @@ export type SlackMonitorContext = {
 const SLACK_ASSISTANT_CONTEXT_TTL_MS = 24 * 60 * 60 * 1000;
 const SLACK_ASSISTANT_CONTEXT_CLEANUP_INTERVAL_MS = 10 * 60 * 1000;
 
-/**
- * Resolves the workspace (team) id carried by an inbound Slack payload,
- * covering every shape the event surfaces treat as a team source: Events API
- * envelopes (`team_id`), interaction bodies (`team.id`), view payloads
- * (`view.team_id`), and shortcut payloads that only identify the user's home
- * workspace (`user.team_id` — see events/interactions.shortcuts.ts). Ordered
- * most-authoritative first; returns "" when no source is present.
- */
-export function resolveIncomingSlackEventTeamId(body: unknown): string {
-  if (!body || typeof body !== "object") {
-    return "";
-  }
-  const raw = body as {
-    team_id?: unknown;
-    team?: { id?: unknown };
-    view?: { team_id?: unknown };
-    user?: { team_id?: unknown };
-  };
-  if (typeof raw.team_id === "string" && raw.team_id) {
-    return raw.team_id;
-  }
-  if (typeof raw.team?.id === "string" && raw.team.id) {
-    return raw.team.id;
-  }
-  if (typeof raw.view?.team_id === "string" && raw.view.team_id) {
-    return raw.view.team_id;
-  }
-  if (typeof raw.user?.team_id === "string" && raw.user.team_id) {
-    return raw.user.team_id;
-  }
-  return "";
-}
-
 export function createSlackMonitorContext(params: {
   cfg: OpenClawConfig;
   accountId: string;
@@ -272,9 +240,8 @@ export function createSlackMonitorContext(params: {
   channelRuntime?: ChannelRuntimeSurface;
   // This account's own stop signal. Bolt has no listener-removal API, so when
   // one account of a shared-App group is stopped individually its handlers
-  // stay registered on the shared App; shouldDropMismatchedSlackEvent (the
-  // gate every event surface already passes through) uses this signal to
-  // drop everything once the account has been aborted.
+  // stay registered on the shared App; shouldDropMismatchedSlackEvent uses
+  // this signal to drop everything once the account has been aborted.
   accountAbortSignal?: AbortSignal;
   // True when this account shares its Bolt App / Socket Mode connection with
   // sibling accounts on the same app token. In that mode an unknown teamId
@@ -764,58 +731,13 @@ export function createSlackMonitorContext(params: {
     return true;
   };
 
-  const shouldDropMismatchedSlackEvent = (body: unknown) => {
-    // A stopped account must not keep acting on events. Bolt offers no way to
-    // unregister listeners, so when this account was stopped while its (shared
-    // or solo) App stays connected, its handlers are still invoked — drop at
-    // the gate instead. Universally correct semantics, so no shared/solo split.
-    if (params.accountAbortSignal?.aborted) {
-      logVerbose(`slack: drop event for stopped account ${params.accountId}`);
-      return true;
-    }
-    // On a shared App an account without a resolved teamId (boot auth.test
-    // failed) has no way to demux its own workspace's traffic from its
-    // siblings'. Processing anyway would act on OTHER tenants' events, so
-    // fail closed until restart with a valid bot token. Solo accounts keep
-    // the historical lenient behavior below.
-    if (params.isSharedSocketGroup && !params.teamId) {
-      logVerbose(
-        `slack: drop event for account ${params.accountId} (teamId unresolved on shared socket group)`,
-      );
-      return true;
-    }
-    const raw =
-      body && typeof body === "object"
-        ? (body as {
-            api_app_id?: unknown;
-          })
-        : undefined;
-    const incomingApiAppId = typeof raw?.api_app_id === "string" ? raw.api_app_id : "";
-    const incomingTeamId = raw ? resolveIncomingSlackEventTeamId(raw) : "";
-
-    if (params.apiAppId && incomingApiAppId && incomingApiAppId !== params.apiAppId) {
-      logVerbose(
-        `slack: drop event with api_app_id=${incomingApiAppId} (expected ${params.apiAppId})`,
-      );
-      return true;
-    }
-    if (params.teamId && incomingTeamId && incomingTeamId !== params.teamId) {
-      logVerbose(`slack: drop event with team_id=${incomingTeamId} (expected ${params.teamId})`);
-      return true;
-    }
-    // On a shared App, api_app_id is identical for every account, so team is
-    // the ONLY demux key. A payload without any team information would sail
-    // through every sharing account's filter and be processed by all of them
-    // (cross-tenant processing) — fail closed instead. Solo accounts keep the
-    // historical lenient pass-through for team-less payloads.
-    if (params.isSharedSocketGroup && !incomingTeamId) {
-      logVerbose(
-        `slack: drop event without team info for account ${params.accountId} (shared socket group)`,
-      );
-      return true;
-    }
-    return false;
-  };
+  const shouldDropMismatchedSlackEvent = createSlackShouldDropMismatchedEvent({
+    accountId: params.accountId,
+    accountAbortSignal: params.accountAbortSignal,
+    isSharedSocketGroup: params.isSharedSocketGroup,
+    teamId: params.teamId,
+    apiAppId: params.apiAppId,
+  });
 
   return {
     cfg: params.cfg,

--- a/extensions/slack/src/monitor/context.ts
+++ b/extensions/slack/src/monitor/context.ts
@@ -237,6 +237,17 @@ export function createSlackMonitorContext(params: {
   client: WebClient;
   runtime: RuntimeEnv;
   channelRuntime?: ChannelRuntimeSurface;
+  // This account's own stop signal. Bolt has no listener-removal API, so when
+  // one account of a shared-App group is stopped individually its handlers
+  // stay registered on the shared App; shouldDropMismatchedSlackEvent (the
+  // gate every event surface already passes through) uses this signal to
+  // drop everything once the account has been aborted.
+  accountAbortSignal?: AbortSignal;
+  // True when this account shares its Bolt App / Socket Mode connection with
+  // sibling accounts on the same app token. In that mode an unknown teamId
+  // must fail closed (drop all events) instead of falling through leniently,
+  // or the account would process BOTH workspaces' traffic.
+  isSharedSocketGroup?: boolean;
 
   botUserId: string;
   botId?: string;
@@ -721,6 +732,25 @@ export function createSlackMonitorContext(params: {
   };
 
   const shouldDropMismatchedSlackEvent = (body: unknown) => {
+    // A stopped account must not keep acting on events. Bolt offers no way to
+    // unregister listeners, so when this account was stopped while its (shared
+    // or solo) App stays connected, its handlers are still invoked — drop at
+    // the gate instead. Universally correct semantics, so no shared/solo split.
+    if (params.accountAbortSignal?.aborted) {
+      logVerbose(`slack: drop event for stopped account ${params.accountId}`);
+      return true;
+    }
+    // On a shared App an account without a resolved teamId (boot auth.test
+    // failed) has no way to demux its own workspace's traffic from its
+    // siblings'. Processing anyway would act on OTHER tenants' events, so
+    // fail closed until restart with a valid bot token. Solo accounts keep
+    // the historical lenient behavior below.
+    if (params.isSharedSocketGroup && !params.teamId) {
+      logVerbose(
+        `slack: drop event for account ${params.accountId} (teamId unresolved on shared socket group)`,
+      );
+      return true;
+    }
     if (!body || typeof body !== "object") {
       return false;
     }

--- a/extensions/slack/src/monitor/context.ts
+++ b/extensions/slack/src/monitor/context.ts
@@ -229,6 +229,39 @@ export type SlackMonitorContext = {
 const SLACK_ASSISTANT_CONTEXT_TTL_MS = 24 * 60 * 60 * 1000;
 const SLACK_ASSISTANT_CONTEXT_CLEANUP_INTERVAL_MS = 10 * 60 * 1000;
 
+/**
+ * Resolves the workspace (team) id carried by an inbound Slack payload,
+ * covering every shape the event surfaces treat as a team source: Events API
+ * envelopes (`team_id`), interaction bodies (`team.id`), view payloads
+ * (`view.team_id`), and shortcut payloads that only identify the user's home
+ * workspace (`user.team_id` — see events/interactions.shortcuts.ts). Ordered
+ * most-authoritative first; returns "" when no source is present.
+ */
+export function resolveIncomingSlackEventTeamId(body: unknown): string {
+  if (!body || typeof body !== "object") {
+    return "";
+  }
+  const raw = body as {
+    team_id?: unknown;
+    team?: { id?: unknown };
+    view?: { team_id?: unknown };
+    user?: { team_id?: unknown };
+  };
+  if (typeof raw.team_id === "string" && raw.team_id) {
+    return raw.team_id;
+  }
+  if (typeof raw.team?.id === "string" && raw.team.id) {
+    return raw.team.id;
+  }
+  if (typeof raw.view?.team_id === "string" && raw.view.team_id) {
+    return raw.view.team_id;
+  }
+  if (typeof raw.user?.team_id === "string" && raw.user.team_id) {
+    return raw.user.team_id;
+  }
+  return "";
+}
+
 export function createSlackMonitorContext(params: {
   cfg: OpenClawConfig;
   accountId: string;
@@ -751,21 +784,14 @@ export function createSlackMonitorContext(params: {
       );
       return true;
     }
-    if (!body || typeof body !== "object") {
-      return false;
-    }
-    const raw = body as {
-      api_app_id?: unknown;
-      team_id?: unknown;
-      team?: { id?: unknown };
-    };
-    const incomingApiAppId = typeof raw.api_app_id === "string" ? raw.api_app_id : "";
-    const incomingTeamId =
-      typeof raw.team_id === "string"
-        ? raw.team_id
-        : typeof raw.team?.id === "string"
-          ? raw.team.id
-          : "";
+    const raw =
+      body && typeof body === "object"
+        ? (body as {
+            api_app_id?: unknown;
+          })
+        : undefined;
+    const incomingApiAppId = typeof raw?.api_app_id === "string" ? raw.api_app_id : "";
+    const incomingTeamId = raw ? resolveIncomingSlackEventTeamId(raw) : "";
 
     if (params.apiAppId && incomingApiAppId && incomingApiAppId !== params.apiAppId) {
       logVerbose(
@@ -775,6 +801,17 @@ export function createSlackMonitorContext(params: {
     }
     if (params.teamId && incomingTeamId && incomingTeamId !== params.teamId) {
       logVerbose(`slack: drop event with team_id=${incomingTeamId} (expected ${params.teamId})`);
+      return true;
+    }
+    // On a shared App, api_app_id is identical for every account, so team is
+    // the ONLY demux key. A payload without any team information would sail
+    // through every sharing account's filter and be processed by all of them
+    // (cross-tenant processing) — fail closed instead. Solo accounts keep the
+    // historical lenient pass-through for team-less payloads.
+    if (params.isSharedSocketGroup && !incomingTeamId) {
+      logVerbose(
+        `slack: drop event without team info for account ${params.accountId} (shared socket group)`,
+      );
       return true;
     }
     return false;

--- a/extensions/slack/src/monitor/context.ts
+++ b/extensions/slack/src/monitor/context.ts
@@ -1,5 +1,6 @@
 // Slack plugin module implements context behavior.
 import type { App } from "@slack/bolt";
+import type { WebClient } from "@slack/web-api";
 import { resolveDefaultAgentId } from "openclaw/plugin-sdk/agent-runtime";
 import { formatAllowlistMatchMeta } from "openclaw/plugin-sdk/allow-from";
 import type { ChannelRuntimeSurface } from "openclaw/plugin-sdk/channel-contract";
@@ -115,6 +116,14 @@ export type SlackMonitorContext = {
   accountId: string;
   botToken: string;
   app: App;
+  // Per-account Web API client bound to this account's own bot token. When a
+  // Slack app is shared across multiple accounts (same app token, multiple
+  // workspace installs on one Socket Mode connection), `app` is the shared
+  // Bolt App instance and `app.client` defaults to whichever account created
+  // it. All outbound Web API calls made on behalf of THIS account must go
+  // through `client`, never `app.client`, so they always authenticate as this
+  // account's own bot identity regardless of which account owns the app.
+  client: WebClient;
   runtime: RuntimeEnv;
   channelRuntime?: ChannelRuntimeSurface;
 
@@ -225,6 +234,7 @@ export function createSlackMonitorContext(params: {
   accountId: string;
   botToken: string;
   app: App;
+  client: WebClient;
   runtime: RuntimeEnv;
   channelRuntime?: ChannelRuntimeSurface;
 
@@ -513,7 +523,7 @@ export function createSlackMonitorContext(params: {
       return cached.info;
     }
     try {
-      const info = await (eventScope?.client ?? params.app.client).conversations.info({
+      const info = await (eventScope?.client ?? params.client).conversations.info({
         token: params.botToken,
         channel: channelId,
       });
@@ -551,7 +561,7 @@ export function createSlackMonitorContext(params: {
       return cached;
     }
     try {
-      const info = await (eventScope?.client ?? params.app.client).users.info({
+      const info = await (eventScope?.client ?? params.client).users.info({
         token: params.botToken,
         user: userId,
       });
@@ -576,7 +586,7 @@ export function createSlackMonitorContext(params: {
       return;
     }
     try {
-      await (p.eventScope?.client ?? params.app.client).assistant.threads.setStatus({
+      await (p.eventScope?.client ?? params.client).assistant.threads.setStatus({
         token: params.botToken,
         channel_id: p.channelId,
         thread_ts: p.threadTs,
@@ -605,7 +615,7 @@ export function createSlackMonitorContext(params: {
       return false;
     }
     try {
-      await params.app.client.assistant.threads.setSuggestedPrompts({
+      await params.client.assistant.threads.setSuggestedPrompts({
         token: params.botToken,
         channel_id: p.channelId,
         thread_ts: p.threadTs,
@@ -745,6 +755,7 @@ export function createSlackMonitorContext(params: {
     accountId: params.accountId,
     botToken: params.botToken,
     app: params.app,
+    client: params.client,
     runtime: params.runtime,
     channelRuntime: params.channelRuntime,
     botUserId: params.botUserId,

--- a/extensions/slack/src/monitor/events/assistant.test.ts
+++ b/extensions/slack/src/monitor/events/assistant.test.ts
@@ -29,6 +29,11 @@ function createHarness(overrides?: {
         handlers[name] = handler;
       },
     } as unknown as App,
+    // Source reads ctx.client (per-account WebClient), not ctx.app.client.
+    client: {
+      conversations: { replies },
+      chat: { update },
+    },
     runtime: { error: vi.fn() },
     botToken: "xoxb-test",
     botUserId: "B1",

--- a/extensions/slack/src/monitor/events/assistant.ts
+++ b/extensions/slack/src/monitor/events/assistant.ts
@@ -104,7 +104,7 @@ async function persistAssistantThreadMetadata(params: {
 }) {
   const { ctx, assistantThread } = params;
   try {
-    const response = (await ctx.app.client.conversations.replies({
+    const response = (await ctx.client.conversations.replies({
       token: ctx.botToken,
       channel: assistantThread.assistantChannelId,
       ts: assistantThread.threadTs,
@@ -126,7 +126,7 @@ async function persistAssistantThreadMetadata(params: {
     if (!initialMessage?.ts) {
       return;
     }
-    await ctx.app.client.chat.update({
+    await ctx.client.chat.update({
       token: ctx.botToken,
       channel: assistantThread.assistantChannelId,
       ts: initialMessage.ts,

--- a/extensions/slack/src/monitor/events/home.test.ts
+++ b/extensions/slack/src/monitor/events/home.test.ts
@@ -20,6 +20,10 @@ function createHomeContext(params?: {
   (harness.ctx.app as unknown as { client: { views: { publish: typeof publish } } }).client = {
     views: { publish },
   };
+  // Source reads ctx.client (per-account WebClient), not ctx.app.client.
+  (harness.ctx as unknown as { client: { views: { publish: typeof publish } } }).client = {
+    views: { publish },
+  };
   registerSlackHomeEvents({
     ctx: harness.ctx,
     slashCommandName: params?.slashCommandName,

--- a/extensions/slack/src/monitor/events/home.ts
+++ b/extensions/slack/src/monitor/events/home.ts
@@ -62,7 +62,7 @@ export function registerSlackHomeEvents(params: {
           return;
         }
 
-        await ctx.app.client.views.publish({
+        await ctx.client.views.publish({
           token: ctx.botToken,
           user_id: payload.user,
           view: buildSlackHomeView(slashCommandName),

--- a/extensions/slack/src/monitor/events/interactions.block-actions.ts
+++ b/extensions/slack/src/monitor/events/interactions.block-actions.ts
@@ -481,7 +481,7 @@ async function updateSlackInteractionMessage(params: {
   if (!params.channelId || !params.messageTs) {
     return;
   }
-  await params.ctx.app.client.chat.update({
+  await params.ctx.client.chat.update({
     channel: params.channelId,
     ts: params.messageTs,
     text: params.text,

--- a/extensions/slack/src/monitor/events/interactions.test.ts
+++ b/extensions/slack/src/monitor/events/interactions.test.ts
@@ -266,6 +266,11 @@ function createContext(overrides?: {
     );
   const ctx = {
     app,
+    // Source now reads ctx.client (a per-account WebClient) instead of
+    // ctx.app.client so shared-app accounts always call out with their own
+    // token; point it at the same mock so assertions on app.client.* still
+    // observe the calls the code under test makes.
+    client: app.client,
     accountId: "default",
     cfg: overrides?.cfg ?? {
       channels: {

--- a/extensions/slack/src/monitor/message-handler.app-mention-race.test.ts
+++ b/extensions/slack/src/monitor/message-handler.app-mention-race.test.ts
@@ -113,6 +113,8 @@ function createTestHandler(
       botUserId: params.botUserId ?? "U_BOT",
       channelHistories: params.channelHistories ?? new Map(),
       app: { client: {} },
+      // Source reads ctx.client (per-account WebClient), not ctx.app.client.
+      client: {},
       runtime: {},
       markMessageSeen: seenMessages["markMessageSeen"],
       rememberSlackChannelType: () => {},

--- a/extensions/slack/src/monitor/message-handler.test.ts
+++ b/extensions/slack/src/monitor/message-handler.test.ts
@@ -65,6 +65,8 @@ function createContext(overrides?: {
     app: {
       client: {},
     },
+    // Source reads ctx.client (per-account WebClient), not ctx.app.client.
+    client: {},
     runtime: {},
     markMessageSeen: (channel: string | undefined, ts: string | undefined) =>
       overrides?.markMessageSeen?.(channel, ts) ?? false,

--- a/extensions/slack/src/monitor/message-handler.ts
+++ b/extensions/slack/src/monitor/message-handler.ts
@@ -324,7 +324,7 @@ export function createSlackMessageHandler(params: {
       ctx.runtime.error?.(`slack inbound debounce flush failed: ${formatErrorMessage(err)}`);
     },
   });
-  const threadTsResolver = createSlackThreadTsResolver({ client: ctx.app.client });
+  const threadTsResolver = createSlackThreadTsResolver({ client: ctx.client });
   const pendingTopLevelDebounceKeys = new Map<string, Set<string>>();
   const appMentionRetryKeys = new Map<string, number>();
   const appMentionPreparingKeys = new Set<string>();

--- a/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
@@ -382,6 +382,8 @@ function createPreparedSlackMessage(params?: {
       runtime: {},
       botToken: "xoxb-test",
       app: { client: { chat: { postMessage: postMessageMock, update: chatUpdateMock } } },
+      // Source reads ctx.client (per-account WebClient), not ctx.app.client.
+      client: { chat: { postMessage: postMessageMock, update: chatUpdateMock } },
       teamId: "T1",
       botUserId: "U_OPENCLAW",
       botId: "B_OPENCLAW",

--- a/extensions/slack/src/monitor/message-handler/dispatch.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.ts
@@ -416,7 +416,7 @@ function shouldUseStreaming(params: {
 }
 
 async function resolveSlackStreamRecipientTeamId(params: {
-  client: Pick<PreparedSlackMessage["ctx"]["app"]["client"], "users">;
+  client: Pick<PreparedSlackMessage["ctx"]["client"], "users">;
   token: string;
   userId?: PreparedSlackMessage["message"]["user"];
   fallbackTeamId?: string;
@@ -445,7 +445,7 @@ async function resolveSlackStreamRecipientTeamId(params: {
 
 export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessage) {
   const { ctx, account, message, route } = prepared;
-  const slackClient = prepared.eventScope?.client ?? ctx.app.client;
+  const slackClient = prepared.eventScope?.client ?? ctx.client;
   const slackStreamFallbackTeamId = prepared.eventScope?.teamId ?? ctx.teamId;
   const cfg = ctx.cfg;
   const runtime = ctx.runtime;

--- a/extensions/slack/src/monitor/message-handler/prepare-dm-history.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare-dm-history.ts
@@ -50,9 +50,7 @@ export async function resolveSlackDmHistoryContext(params: {
   }
 
   try {
-    const response = (await (
-      params.eventScope?.client ?? params.ctx.app.client
-    ).conversations.history({
+    const response = (await (params.eventScope?.client ?? params.ctx.client).conversations.history({
       token: params.ctx.botToken,
       channel: params.channelId,
       ...(params.currentMessageTs ? { latest: params.currentMessageTs, inclusive: true } : {}),

--- a/extensions/slack/src/monitor/message-handler/prepare-thread-context.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare-thread-context.ts
@@ -241,7 +241,7 @@ export async function resolveSlackThreadContextData(params: {
       const { resolveSlackMedia } = await loadSlackMediaModule();
       threadStarterMedia = await resolveSlackMedia({
         files: starter.files,
-        client: params.eventScope?.client ?? params.ctx.app.client,
+        client: params.eventScope?.client ?? params.ctx.client,
         token: params.ctx.botToken,
         maxBytes: params.ctx.mediaMaxBytes,
       });
@@ -281,7 +281,7 @@ export async function resolveSlackThreadContextData(params: {
     const threadHistory = await resolveSlackThreadHistory({
       channelId: params.message.channel,
       threadTs: params.threadTs,
-      client: params.eventScope?.client ?? params.ctx.app.client,
+      client: params.eventScope?.client ?? params.ctx.client,
       currentMessageTs: params.message.ts,
       limit: threadInitialHistoryLimit,
     });

--- a/extensions/slack/src/monitor/message-handler/prepare.test-helpers.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.test-helpers.ts
@@ -28,6 +28,9 @@ export function createInboundSlackTestContext(params: {
     accountId: "default",
     botToken: "token",
     app: params.app ?? ({ client: params.appClient ?? {} } as App),
+    // Source reads ctx.client (per-account WebClient), not ctx.app.client;
+    // reuse the same mock so existing appClient assertions keep observing it.
+    client: (params.app?.client ?? params.appClient ?? {}) as App["client"],
     runtime: {} as RuntimeEnv,
     channelRuntime: params.channelRuntime ?? createPluginRuntimeMock().channel,
     botUserId: "B1",

--- a/extensions/slack/src/monitor/message-handler/prepare.test.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.test.ts
@@ -1249,6 +1249,33 @@ Second paragraph should still reach the agent after Slack's preview cutoff.`;
     expect(prepared.ctxPayload.BodyForAgent).toContain("Readiness probe failed");
   });
 
+  it("drops a bot message authored by this account's own bot id even when allowBots is true", async () => {
+    const slackCtx = createInboundSlackCtx({
+      cfg: {
+        channels: {
+          slack: { enabled: true },
+        },
+      } as OpenClawConfig,
+      defaultRequireMention: false,
+    });
+
+    const prepared = await prepareMessageWith(
+      slackCtx,
+      createSlackAccount({ allowBots: true }),
+      createSlackMessage({
+        text: "self-authored",
+        // Matches the harness ctx's own botId ("B1"). bot_message payloads
+        // often carry no `user`, and on a shared App the Bolt-level self
+        // filter only knows the group creator's identity — this per-account
+        // drop is what prevents an allowBots account from replying to itself.
+        bot_id: "B1",
+        subtype: "bot_message",
+      }),
+    );
+
+    expect(prepared).toBeNull();
+  });
+
   it("drops bot-authored room messages when allowBots is true but no owner is present (#59284)", async () => {
     const { slackCtx, members } = createOwnerScopedBotRoomCtx({ members: ["UOTHER"] });
 

--- a/extensions/slack/src/monitor/message-handler/prepare.test.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.test.ts
@@ -4286,6 +4286,8 @@ describe("prepareSlackMessage sender prefix", () => {
       accountId: "default",
       botToken: "xoxb",
       app: { client: {} },
+      // Source reads ctx.client (per-account WebClient), not ctx.app.client.
+      client: {},
       runtime: {
         log: vi.fn(),
         error: vi.fn(),

--- a/extensions/slack/src/monitor/message-handler/prepare.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.ts
@@ -183,9 +183,7 @@ async function restoreSlackAssistantThreadContextFromMetadata(params: {
     return undefined;
   }
   try {
-    const response = (await (
-      params.eventScope?.client ?? params.ctx.app.client
-    ).conversations.replies({
+    const response = (await (params.eventScope?.client ?? params.ctx.client).conversations.replies({
       channel: params.message.channel,
       ts: threadTs,
       oldest: threadTs,
@@ -323,7 +321,7 @@ async function resolveSlackHistoryMediaForPendingRecord(params: {
     isThreadReply: params.isThreadReply,
     threadStarter: params.threadStarter,
     isBotMessage: params.isBotMessage,
-    client: params.eventScope?.client ?? params.ctx.app.client,
+    client: params.eventScope?.client ?? params.ctx.client,
     botToken: params.ctx.botToken,
     mediaMaxBytes: Math.min(params.ctx.mediaMaxBytes, SLACK_HISTORY_MEDIA_MAX_BYTES),
     mediaReadIdleTimeoutMs: SLACK_HISTORY_MEDIA_IDLE_TIMEOUT_MS,
@@ -417,7 +415,7 @@ async function resolveSlackExplicitMentionState(params: {
   const explicitlyMentionedBotSubteam =
     Boolean(params.ctx.botUserId && params.hasSubteamMention) &&
     (await isSlackSubteamMentionForBot({
-      client: params.eventScope?.client ?? params.ctx.app.client,
+      client: params.eventScope?.client ?? params.ctx.client,
       text: params.messageText,
       botUserId: params.ctx.botUserId,
       teamId: params.eventScope?.teamId ?? params.ctx.teamId,
@@ -611,7 +609,7 @@ async function authorizeSlackInboundMessage(params: {
         await sendMessageSlack(message.channel, text, {
           cfg: ctx.cfg,
           token: ctx.botToken,
-          client: params.eventScope?.client ?? ctx.app.client,
+          client: params.eventScope?.client ?? ctx.client,
           accountId: account.accountId,
         });
       },
@@ -650,7 +648,7 @@ export async function prepareSlackMessage(params: {
   };
 }): Promise<PreparedSlackMessage | null> {
   const { ctx, account, message, opts } = params;
-  const slackClient = opts.eventScope?.client ?? ctx.app.client;
+  const slackClient = opts.eventScope?.client ?? ctx.client;
   const threadStarterWorkspaceScope = opts.eventScope
     ? { accountId: account.accountId, teamId: opts.eventScope.teamId }
     : undefined;

--- a/extensions/slack/src/monitor/message-handler/prepare.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.ts
@@ -58,6 +58,7 @@ import {
   resolveChannelContextVisibilityMode,
   resolveStorePath,
 } from "../config.runtime.js";
+import { isSelfAuthoredSlackBotMessage } from "../context-account-client.js";
 import {
   buildSlackAssistantThreadMetadata,
   normalizeSlackChannelType,
@@ -558,7 +559,7 @@ async function authorizeSlackInboundMessage(params: {
     conversation;
 
   if (isBotMessage) {
-    if (message.user && ctx.botUserId && message.user === ctx.botUserId) {
+    if (isSelfAuthoredSlackBotMessage({ message, botUserId: ctx.botUserId, botId: ctx.botId })) {
       return null;
     }
     if (allowBotsMode === "off") {

--- a/extensions/slack/src/monitor/monitor.test.ts
+++ b/extensions/slack/src/monitor/monitor.test.ts
@@ -1,5 +1,6 @@
 // Slack tests cover monitor plugin behavior.
 import type { App } from "@slack/bolt";
+import type { WebClient } from "@slack/web-api";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { describe, expect, it, vi } from "vitest";
@@ -194,6 +195,7 @@ const baseParams = () => ({
   accountId: "default",
   botToken: "token",
   app: { client: {} } as App,
+  client: {} as WebClient,
   runtime: {} as RuntimeEnv,
   botUserId: "B1",
   botId: "B1",

--- a/extensions/slack/src/monitor/provider-shared-socket.ts
+++ b/extensions/slack/src/monitor/provider-shared-socket.ts
@@ -1,0 +1,315 @@
+// Slack plugin module implements the provider-level policy layer on top of
+// shared-socket-group.ts's group primitives: deciding whether an account
+// should join a shared Socket Mode group, resolving its App bundle
+// accordingly, logging the boot-time warnings that decision produces, running
+// the connection with the right shared/solo semantics, and settling
+// membership on exit. Split out of provider.ts (which must stay at or under
+// its ratcheted line budget) as its own module.
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { warn, type RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
+import { listEnabledSlackAccounts } from "../accounts.js";
+import { gracefulStopSlackApp } from "./provider-support.js";
+import { formatUnknownError } from "./reconnect-policy.js";
+import {
+  forceStopSlackSharedSocketGroup,
+  joinSlackSharedSocketGroup,
+  runSlackSocketConnectionLoop,
+  type SlackSharedSocketGroupHandle,
+} from "./shared-socket-group.js";
+
+/**
+ * Counts enabled Socket Mode accounts (across the whole `channels.slack`
+ * config, not just the account currently booting) that resolve to the same
+ * app token as `appToken`. Grouping into a shared Socket Mode connection is
+ * only engaged when this is greater than 1 — a single account per app token
+ * takes the original, unmodified code path with zero behavioral change.
+ *
+ * Enterprise Grid org installs are excluded: they resolve teamId as ""
+ * (resolveSlackInstallationIdentity's "enterprise" kind never carries a
+ * teamId), so they can never pass shouldDropMismatchedSlackEvent's per-event
+ * team_id demux once inside a shared group — every inbound event would be
+ * dropped fail-closed. They always take the dedicated, non-shared connection
+ * regardless of how many siblings share their app token, so they must not
+ * count toward (or be counted as) a sharing group.
+ */
+function countEnabledSlackSocketAccountsSharingAppToken(params: {
+  cfg: OpenClawConfig;
+  appToken: string;
+}): number {
+  return listEnabledSlackAccounts(params.cfg).filter((candidate) => {
+    const mode = candidate.config.mode ?? "socket";
+    return (
+      mode === "socket" &&
+      candidate.appToken === params.appToken &&
+      candidate.config.enterpriseOrgInstall !== true
+    );
+  }).length;
+}
+
+/**
+ * Decides whether this account's Socket Mode connection should be shared
+ * with sibling accounts on the same app token.
+ *
+ * Slack Socket Mode delivers each event to exactly one open connection for an
+ * app (it load-balances, it does not fan out). If two accounts open two
+ * Socket Mode connections for the SAME app token, each drops ~half the
+ * traffic via shouldDropMismatchedSlackEvent's team_id filter. Detect that
+ * configuration up front (purely from static config, so every sibling
+ * account computes the same answer) and, only then, share a single Bolt
+ * App/connection across all of them. A single account per app token takes
+ * the untouched original code path (resolveSlackSocketAppBundle's solo
+ * branch) with no behavioral change.
+ *
+ * Enterprise Grid org installs are excluded from sharing (see
+ * countEnabledSlackSocketAccountsSharingAppToken): their teamId always
+ * resolves to "", which would make the shared group's fail-closed
+ * unresolved-teamId guard drop every inbound event for them. They keep using
+ * this dedicated, non-shared connection even if a sibling account reuses the
+ * same app token.
+ */
+export function resolveSlackSharedSocketGroupParticipation(params: {
+  cfg: OpenClawConfig;
+  enterpriseOrgInstall: boolean;
+  slackMode: string;
+  appToken?: string;
+}): {
+  isSharedSlackSocketAppToken: boolean;
+  enterpriseExcludedFromSharedSocketGroup: boolean;
+} {
+  const { cfg, enterpriseOrgInstall, slackMode, appToken } = params;
+  const isSharedSlackSocketAppToken =
+    !enterpriseOrgInstall &&
+    slackMode === "socket" &&
+    Boolean(appToken) &&
+    countEnabledSlackSocketAccountsSharingAppToken({ cfg, appToken: appToken ?? "" }) > 1;
+  // True when this enterprise account's app token IS shared by other
+  // (non-enterprise) accounts — i.e. it would have joined a shared group were
+  // it not an enterprise install. Drives a single boot-time warning so the
+  // dedicated-connection fallback above is not silent.
+  const enterpriseExcludedFromSharedSocketGroup =
+    enterpriseOrgInstall &&
+    slackMode === "socket" &&
+    Boolean(appToken) &&
+    countEnabledSlackSocketAccountsSharingAppToken({ cfg, appToken: appToken ?? "" }) > 0;
+  return { isSharedSlackSocketAppToken, enterpriseExcludedFromSharedSocketGroup };
+}
+
+/**
+ * Builds the graceful-stop callback for an account's Bolt App.
+ *
+ * Pre-sets shuttingDown on the SocketModeClient before app.stop() to prevent
+ * a race where the library's internal ping timeout fires disconnect() before
+ * shuttingDown is set, causing orphaned reconnects with leaked ping
+ * intervals. See: openclaw/openclaw#56508
+ *
+ * When `sharedGroup` is set, this is a no-op: the group-owned connection
+ * task stops the shared App; individual accounts (creator included) never
+ * stop an App siblings may be using.
+ */
+export function createSlackGracefulStop<TAppBundle>(params: {
+  app: { stop: () => unknown };
+  sharedGroup: SlackSharedSocketGroupHandle<TAppBundle> | null;
+}): () => Promise<void> {
+  return async () => {
+    if (params.sharedGroup) {
+      return;
+    }
+    await gracefulStopSlackApp(params.app);
+  };
+}
+
+/**
+ * Warns once, at boot, when this account is in a shared Socket Mode group but
+ * its teamId never resolved (auth.test failed or returned no team_id). On a
+ * shared App every event for this account will be dropped fail-closed (see
+ * shouldDropMismatchedSlackEvent) to avoid acting on sibling workspaces'
+ * traffic, so the operator needs to know to fix the bot token and restart.
+ */
+export function warnSlackSharedSocketGroupUnresolvedTeamId(params: {
+  isSharedSlackSocketAppToken: boolean;
+  teamId: string;
+  accountId: string;
+  runtime: RuntimeEnv;
+}): void {
+  if (!params.isSharedSlackSocketAppToken || params.teamId) {
+    return;
+  }
+  params.runtime.log?.(
+    warn(
+      `[${params.accountId}] slack: teamId unresolved on a shared socket group (auth.test failed or returned no team_id); ` +
+        "ALL events for this account will be dropped to avoid acting on sibling workspaces' traffic — " +
+        "fix the bot token and restart",
+    ),
+  );
+}
+
+/**
+ * Resolves the Bolt App/receiver bundle an account should use: joins the
+ * shared Socket Mode group when `isSharedSlackSocketAppToken` is set, or
+ * creates a dedicated (solo) bundle otherwise — the untouched original code
+ * path, with no behavioral change for accounts that don't share an app
+ * token.
+ */
+export async function resolveSlackSocketAppBundle<TAppBundle>(params: {
+  isSharedSlackSocketAppToken: boolean;
+  appToken?: string;
+  accountId: string;
+  createSharedAppBundle: () => Promise<TAppBundle>;
+  createSoloAppBundle: () => Promise<TAppBundle>;
+}): Promise<{
+  appBundle: TAppBundle;
+  sharedGroup: SlackSharedSocketGroupHandle<TAppBundle> | null;
+}> {
+  if (params.isSharedSlackSocketAppToken) {
+    const sharedGroup = await joinSlackSharedSocketGroup<TAppBundle>({
+      appToken: params.appToken as string,
+      accountId: params.accountId,
+      createAppBundle: params.createSharedAppBundle,
+    });
+    return { appBundle: sharedGroup.appBundle, sharedGroup };
+  }
+  return { appBundle: await params.createSoloAppBundle(), sharedGroup: null };
+}
+
+/**
+ * Logs the boot-time warnings tied to shared Socket Mode group participation:
+ * the log-once "sharing socket" message when a solo group just became
+ * shared, and the enterprise-org-excluded notice. Must be called from inside
+ * the caller's try block: runtime.log is caller-supplied and may throw, and
+ * an account that dies here must still leave the group / unwind cleanly
+ * through the caller's existing finally.
+ */
+export function logSlackSharedSocketGroupBootWarnings<TAppBundle>(params: {
+  sharedGroup: SlackSharedSocketGroupHandle<TAppBundle> | null;
+  enterpriseExcludedFromSharedSocketGroup: boolean;
+  cfg: OpenClawConfig;
+  appToken?: string;
+  expectedApiAppIdFromAppToken?: string;
+  accountId: string;
+  runtime: RuntimeEnv;
+}): void {
+  const { sharedGroup, runtime } = params;
+  if (sharedGroup?.justBecameShared) {
+    const sharedAccountCount = countEnabledSlackSocketAccountsSharingAppToken({
+      cfg: params.cfg,
+      appToken: params.appToken ?? "",
+    });
+    runtime.log?.(
+      `slack: sharing socket for ${sharedAccountCount} accounts on app ` +
+        `${params.expectedApiAppIdFromAppToken ?? "unknown"} (multi-workspace)`,
+    );
+  }
+
+  if (params.enterpriseExcludedFromSharedSocketGroup) {
+    runtime.log?.(
+      warn(
+        `slack account ${params.accountId}: enterprise org install cannot join a shared Socket Mode group; using a dedicated connection`,
+      ),
+    );
+  }
+}
+
+/**
+ * Runs (or joins) the Slack Socket Mode connection for an account, respecting
+ * shared-group semantics when `sharedGroup` is set:
+ *
+ * - The group creator starts the connection as a GROUP-owned task, decoupled
+ *   from this account's lifecycle: it keeps serving sibling accounts after
+ *   this creator account is stopped, and only ends once every member has left
+ *   (or a fatal error kills it). It intentionally keeps using the CREATOR's
+ *   runtime for logs and the creator's setStatus for connection status even
+ *   after the creator account itself stops.
+ * - Every sharing account — creator included — waits passively until its OWN
+ *   abort signal fires (per-account stop resolves this monitor promise
+ *   immediately; the shared socket lives on for siblings) or the group's
+ *   stopSignal fires (last member left, or the connection task died). Both
+ *   listeners are removed on settle so neither signal accumulates stale
+ *   callbacks.
+ * - A fatal connection-task failure (e.g. non-recoverable auth error) is
+ *   surfaced on every sharing account's monitor promise — unless this
+ *   account was stopped on purpose, in which case it exits cleanly.
+ *
+ * When `sharedGroup` is null (solo account), this degrades to a plain
+ * `runSlackSocketConnectionLoop` call with no behavioral change.
+ */
+export async function runSlackSocketModeConnectionForAccount<TAppBundle>(params: {
+  app: { start: () => unknown; stop: () => unknown };
+  sharedGroup: SlackSharedSocketGroupHandle<TAppBundle> | null;
+  abortSignal?: AbortSignal;
+  runtime: RuntimeEnv;
+  setStatus?: (next: Record<string, unknown>) => void;
+  getLastSdkLogMessage?: () => string | undefined;
+}): Promise<void> {
+  const { app, sharedGroup, abortSignal, runtime } = params;
+  if (!sharedGroup) {
+    await runSlackSocketConnectionLoop({
+      app,
+      abortSignal,
+      runtime,
+      setStatus: params.setStatus,
+      getLastSdkLogMessage: params.getLastSdkLogMessage,
+    });
+    return;
+  }
+
+  if (sharedGroup.isOwner) {
+    sharedGroup.startConnectionTask(async () => {
+      // Pre-set shuttingDown as soon as the group stops (same race guard as
+      // the caller's own stopOnAbort, but keyed to the group's lifetime).
+      const stopOnGroupStop = () => {
+        void gracefulStopSlackApp(app);
+      };
+      sharedGroup.stopSignal.addEventListener("abort", stopOnGroupStop, { once: true });
+      try {
+        await runSlackSocketConnectionLoop({
+          app,
+          abortSignal: sharedGroup.stopSignal,
+          runtime,
+          setStatus: params.setStatus,
+          getLastSdkLogMessage: params.getLastSdkLogMessage,
+        });
+      } finally {
+        sharedGroup.stopSignal.removeEventListener("abort", stopOnGroupStop);
+        await gracefulStopSlackApp(app);
+      }
+    });
+  }
+  if (!abortSignal?.aborted && !sharedGroup.stopSignal.aborted) {
+    await new Promise<void>((resolve) => {
+      const settle = () => {
+        abortSignal?.removeEventListener("abort", settle);
+        sharedGroup.stopSignal.removeEventListener("abort", settle);
+        resolve();
+      };
+      abortSignal?.addEventListener("abort", settle, { once: true });
+      sharedGroup.stopSignal.addEventListener("abort", settle, { once: true });
+    });
+  }
+  const stopError = sharedGroup.getStopError();
+  if (stopError !== undefined && !abortSignal?.aborted) {
+    throw stopError instanceof Error ? stopError : new Error(formatUnknownError(stopError));
+  }
+}
+
+/**
+ * Settles this account's shared-group membership on exit (from the caller's
+ * `finally`). If this account created the group but threw before the
+ * connection task existed, tears the group down so members are never left
+ * waiting forever on a stopSignal nobody will fire — once the task runs, its
+ * own finally performs the teardown and a plain leave() is correct even for
+ * the creator. A no-op when `sharedGroup` is null (solo account).
+ */
+export function settleSlackSharedSocketGroupMembership<TAppBundle>(params: {
+  sharedGroup: SlackSharedSocketGroupHandle<TAppBundle> | null;
+  appToken: string;
+}): void {
+  const { sharedGroup, appToken } = params;
+  if (!sharedGroup) {
+    return;
+  }
+  if (sharedGroup.isOwner && !sharedGroup.hasConnectionTask()) {
+    forceStopSlackSharedSocketGroup({ appToken });
+  } else {
+    sharedGroup.leave();
+  }
+}

--- a/extensions/slack/src/monitor/provider.shared-socket-group.test.ts
+++ b/extensions/slack/src/monitor/provider.shared-socket-group.test.ts
@@ -16,6 +16,7 @@ const { monitorSlackProvider } = await import("./provider.js");
 const SHARED_APP_TOKEN = "xapp-1-A0SHARED-sharedsecrettoken";
 const TEAM1_BOT_TOKEN = "bot-token-team1";
 const TEAM2_BOT_TOKEN = "bot-token-team2";
+const ENT_BOT_TOKEN = "bot-token-enterprise";
 
 function sharedGroupConfig(): OpenClawConfig {
   return {
@@ -26,6 +27,37 @@ function sharedGroupConfig(): OpenClawConfig {
         accounts: {
           team1: { botToken: TEAM1_BOT_TOKEN, appToken: SHARED_APP_TOKEN, mode: "socket" },
           team2: { botToken: TEAM2_BOT_TOKEN, appToken: SHARED_APP_TOKEN, mode: "socket" },
+        },
+      },
+    },
+  };
+}
+
+// Same shared app token as sharedGroupConfig(), plus a third account that is
+// an Enterprise Grid org-wide install. Enterprise installs always resolve
+// teamId as "" (see enterprise-install.ts's "enterprise" identity kind), so
+// they must never join the team1/team2 shared group: shouldDropMismatchedSlackEvent
+// fails closed on ANY shared-group member with an unresolved teamId, which
+// would silently drop every one of the enterprise account's inbound events.
+function sharedGroupConfigWithEnterprise(): OpenClawConfig {
+  return {
+    channels: {
+      slack: {
+        dm: { enabled: true, policy: "open", allowFrom: ["*"] },
+        groupPolicy: "open",
+        accounts: {
+          team1: { botToken: TEAM1_BOT_TOKEN, appToken: SHARED_APP_TOKEN, mode: "socket" },
+          team2: { botToken: TEAM2_BOT_TOKEN, appToken: SHARED_APP_TOKEN, mode: "socket" },
+          entOrg: {
+            botToken: ENT_BOT_TOKEN,
+            appToken: SHARED_APP_TOKEN,
+            mode: "socket",
+            enterpriseOrgInstall: true,
+            // Enterprise org installs must use dm.enabled=false, or dmPolicy
+            // "open" with allowFrom containing "*" (assertEnterpriseSlackDmPolicy);
+            // disabling DMs outright keeps this fixture minimal.
+            dm: { enabled: false },
+          },
         },
       },
     },
@@ -478,5 +510,131 @@ describe("monitorSlackProvider shared Socket Mode group", () => {
     // auto-removed, so forgetting the removeEventListener would leak here.
     expect(getEventListeners(harness.controller1.signal, "abort")).toHaveLength(0);
     expect(getEventListeners(harness.controller2.signal, "abort")).toHaveLength(0);
+  });
+});
+
+describe("monitorSlackProvider excludes Enterprise Grid org installs from shared Socket Mode groups", () => {
+  /** Bolt's per-event `context` and `client` args required for an Enterprise
+   * Grid org install to pass resolveSlackEventScope (see event-scope.ts):
+   * isEnterpriseInstall/enterpriseId/teamId on `context`, and any listener
+   * `client`. Without these the event would be dropped before ever reaching
+   * ctx.shouldDropMismatchedSlackEvent, regardless of this fix. */
+  function makeEnterpriseOrgEvent(params: { channel: string; ts: string; text: string }) {
+    return {
+      event: {
+        type: "message" as const,
+        user: "U_SENDER",
+        text: params.text,
+        ts: params.ts,
+        channel: params.channel,
+        channel_type: "channel" as const,
+      },
+      body: { api_app_id: "A0SHARED" },
+      context: { isEnterpriseInstall: true, enterpriseId: "E1", teamId: "T999" },
+      client: getSlackClientForToken(ENT_BOT_TOKEN),
+    };
+  }
+
+  it("keeps an enterprise org install on its own dedicated connection instead of joining siblings' shared group", async () => {
+    mockHealthyTeamAuth();
+    getSlackClientForToken(ENT_BOT_TOKEN).auth.test.mockResolvedValue({
+      enterprise_id: "E1",
+      is_enterprise_install: true,
+    });
+
+    const runtimeLogEnt = vi.fn();
+    const setStatusEnt = vi.fn();
+    const config = sharedGroupConfigWithEnterprise();
+    const harness = startBothTeamAccounts(config);
+    const controllerEnt = new AbortController();
+    const runEnt = monitorSlackProvider({
+      accountId: "entOrg",
+      config,
+      abortSignal: controllerEnt.signal,
+      setStatus: setStatusEnt,
+      runtime: { log: runtimeLogEnt, error: vi.fn(), exit: vi.fn() as never },
+    });
+
+    try {
+      const handler = await getSlackHandlerOrThrow("message");
+      await flush();
+      await flush();
+      await flush();
+
+      // Two physical sockets: one shared connection for team1+team2 (as in
+      // the tests above), and one SEPARATE dedicated connection for the
+      // enterprise org install — not three, and not one shared-by-all-three.
+      expect(getSlackTestState().appStartMock).toHaveBeenCalledTimes(2);
+
+      // The exclusion is logged once at boot so the dedicated-connection
+      // fallback is not silent.
+      // resolveSlackAccount normalizes account ids to lowercase, so the log
+      // carries "entorg" even though the config key is "entOrg".
+      expect(runtimeLogEnt).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "slack account entorg: enterprise org install cannot join a shared Socket Mode group; using a dedicated connection",
+        ),
+      );
+
+      setStatusEnt.mockClear();
+      harness.setStatus1.mockClear();
+      harness.setStatus2.mockClear();
+
+      // The enterprise account's OWN dedicated connection still delivers and
+      // processes its inbound events — this is the regression the Med-severity
+      // review finding was about: before this fix, an enterprise account
+      // sharing an app token with siblings would join their shared group with
+      // ctx.teamId permanently "" and ctx.isSharedSocketGroup=true, so
+      // shouldDropMismatchedSlackEvent's fail-closed unresolved-teamId guard
+      // would drop 100% of its inbound events.
+      await handler(makeEnterpriseOrgEvent({ channel: "C_ENT", ts: "111.222", text: "org event" }));
+
+      expect(setStatusEnt).toHaveBeenCalled();
+    } finally {
+      controllerEnt.abort();
+      await runEnt;
+      await stopBothTeamAccounts(harness);
+    }
+  });
+
+  it("still shares one connection between the two non-enterprise siblings when an enterprise account also uses their app token", async () => {
+    mockHealthyTeamAuth();
+    getSlackClientForToken(ENT_BOT_TOKEN).auth.test.mockResolvedValue({
+      enterprise_id: "E1",
+      is_enterprise_install: true,
+    });
+
+    const config = sharedGroupConfigWithEnterprise();
+    const harness = startBothTeamAccounts(config);
+    const controllerEnt = new AbortController();
+    const runEnt = monitorSlackProvider({
+      accountId: "entOrg",
+      config,
+      abortSignal: controllerEnt.signal,
+      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() as never },
+    });
+
+    try {
+      const handler = await getSlackHandlerOrThrow("message");
+      await flush();
+      await flush();
+      await flush();
+
+      harness.setStatus1.mockClear();
+      harness.setStatus2.mockClear();
+
+      // team1/team2 still demux correctly between each other on the shared
+      // connection, unaffected by the enterprise sibling's presence.
+      await handler({
+        event: makeDirectMessageEvent({ channel: "C_T1", ts: "333.444", text: "hi from team1" }),
+        body: { api_app_id: "A0SHARED", team_id: "T1" },
+      });
+      expect(harness.setStatus1).toHaveBeenCalled();
+      expect(harness.setStatus2).not.toHaveBeenCalled();
+    } finally {
+      controllerEnt.abort();
+      await runEnt;
+      await stopBothTeamAccounts(harness);
+    }
   });
 });

--- a/extensions/slack/src/monitor/provider.shared-socket-group.test.ts
+++ b/extensions/slack/src/monitor/provider.shared-socket-group.test.ts
@@ -393,6 +393,72 @@ describe("monitorSlackProvider shared Socket Mode group", () => {
     }
   });
 
+  it("leaves the group cleanly when the second account throws on the sharing log", async () => {
+    mockHealthyTeamAuth();
+
+    const config = sharedGroupConfig();
+    const controller1 = new AbortController();
+    const controller2 = new AbortController();
+    const setStatus1 = vi.fn();
+    const run1 = monitorSlackProvider({
+      accountId: "team1",
+      config,
+      abortSignal: controller1.signal,
+      setStatus: setStatus1,
+    });
+    // The second joiner is the account that emits the one-time
+    // "sharing socket" info log — the last remaining statement between
+    // joining the group and any handler registration. If runtime.log throws
+    // there, the member must still leave the group instead of lingering as a
+    // handler-less refcount entry that keeps the group alive forever.
+    const run2 = monitorSlackProvider({
+      accountId: "team2",
+      config,
+      abortSignal: controller2.signal,
+      runtime: {
+        log: (...args: unknown[]) => {
+          if (typeof args[0] === "string" && args[0].includes("sharing socket")) {
+            throw new Error("boom-sharing-log");
+          }
+        },
+        error: vi.fn(),
+        exit: vi.fn() as never,
+      },
+    });
+
+    await expect(run2).rejects.toThrow("boom-sharing-log");
+
+    // The surviving creator keeps serving its own workspace.
+    const handler = await getSlackHandlerOrThrow("message");
+    await flush();
+    await flush();
+    setStatus1.mockClear();
+    await handler({
+      event: makeDirectMessageEvent({ channel: "C_T1", ts: "999.009", text: "still fine" }),
+      body: { api_app_id: "A0SHARED", team_id: "T1" },
+    });
+    expect(setStatus1).toHaveBeenCalled();
+
+    // The failed member's refcount entry must be gone: stopping the creator
+    // (now the only member) must fully dissolve the group so a fresh pair
+    // creates a NEW group whose creator starts a second socket. A lingering
+    // ghost member would keep the old group alive, making the fresh pair
+    // join it as members and never start another App.
+    controller1.abort();
+    await run1;
+    await flush();
+
+    const fresh = startBothTeamAccounts(config);
+    try {
+      await getSlackHandlerOrThrow("message");
+      await flush();
+      await flush();
+      expect(getSlackTestState().appStartMock).toHaveBeenCalledTimes(2);
+    } finally {
+      await stopBothTeamAccounts(fresh);
+    }
+  });
+
   it("propagates a fatal socket error to every sharing account and leaves no abort listeners behind", async () => {
     mockHealthyTeamAuth();
     // First socket start dies with a non-recoverable auth error: the

--- a/extensions/slack/src/monitor/provider.shared-socket-group.test.ts
+++ b/extensions/slack/src/monitor/provider.shared-socket-group.test.ts
@@ -1,5 +1,6 @@
 // Slack tests cover the shared Socket Mode connection for multiple accounts
 // installed on the same Slack app (same app token).
+import { getEventListeners } from "node:events";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
@@ -40,6 +41,22 @@ function makeDirectMessageEvent(params: { channel: string; ts: string; text: str
     channel: params.channel,
     channel_type: "im" as const,
   };
+}
+
+/** Gives each team account its own healthy bot identity on its own client. */
+function mockHealthyTeamAuth() {
+  getSlackClientForToken(TEAM1_BOT_TOKEN).auth.test.mockResolvedValue({
+    user_id: "U_BOT1",
+    bot_id: "B_BOT1",
+    team_id: "T1",
+    api_app_id: "A0SHARED",
+  });
+  getSlackClientForToken(TEAM2_BOT_TOKEN).auth.test.mockResolvedValue({
+    user_id: "U_BOT2",
+    bot_id: "B_BOT2",
+    team_id: "T2",
+    api_app_id: "A0SHARED",
+  });
 }
 
 /** Starts both team accounts back-to-back (no await between the two calls) so
@@ -274,5 +291,126 @@ describe("monitorSlackProvider shared Socket Mode group", () => {
     } finally {
       await stopBothTeamAccounts(harness);
     }
+  });
+
+  it("resolves the creator's monitor promise on its own abort while the socket keeps serving siblings", async () => {
+    mockHealthyTeamAuth();
+
+    const harness = startBothTeamAccounts(sharedGroupConfig());
+    try {
+      const handler = await getSlackHandlerOrThrow("message");
+      await flush();
+      await flush();
+
+      // Stop ONLY the creator (team1). The connection now runs as a
+      // group-owned task, so the creator's monitor promise must resolve
+      // immediately (the gateway's per-account stop contract) instead of
+      // lingering until the whole group winds down.
+      harness.controller1.abort();
+      await harness.run1;
+
+      harness.setStatus1.mockClear();
+      harness.setStatus2.mockClear();
+
+      // The surviving sibling still processes its workspace's events on the
+      // connection the (stopped) creator originally opened...
+      await handler({
+        event: makeDirectMessageEvent({ channel: "C_T2", ts: "777.007", text: "creator gone" }),
+        body: { api_app_id: "A0SHARED", team_id: "T2" },
+      });
+      expect(harness.setStatus2).toHaveBeenCalled();
+
+      // ...while the stopped creator's own workspace traffic is dropped.
+      await handler({
+        event: makeDirectMessageEvent({ channel: "C_T1", ts: "888.008", text: "to stopped" }),
+        body: { api_app_id: "A0SHARED", team_id: "T1" },
+      });
+      expect(harness.setStatus1).not.toHaveBeenCalled();
+    } finally {
+      await stopBothTeamAccounts(harness);
+    }
+  });
+
+  it("releases members and the registry slot when the creator throws after joining but before the connection task starts", async () => {
+    // team1's boot-time auth.test fails AND its runtime.log throws: the warn
+    // emitted for the auth failure happens after the group slot was joined
+    // but before the connection task exists — exactly the window where a
+    // leaked reservation would leave members waiting forever.
+    getSlackClientForToken(TEAM1_BOT_TOKEN).auth.test.mockRejectedValue(new Error("nope"));
+    getSlackClientForToken(TEAM2_BOT_TOKEN).auth.test.mockResolvedValue({
+      user_id: "U_BOT2",
+      bot_id: "B_BOT2",
+      team_id: "T2",
+      api_app_id: "A0SHARED",
+    });
+
+    const config = sharedGroupConfig();
+    const controller1 = new AbortController();
+    const controller2 = new AbortController();
+    const run1 = monitorSlackProvider({
+      accountId: "team1",
+      config,
+      abortSignal: controller1.signal,
+      runtime: {
+        log: () => {
+          throw new Error("boom-after-join");
+        },
+        error: vi.fn(),
+        exit: vi.fn() as never,
+      },
+    });
+    const run2 = monitorSlackProvider({
+      accountId: "team2",
+      config,
+      abortSignal: controller2.signal,
+      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() as never },
+    });
+
+    // The creator's monitor rejects with the boot error...
+    await expect(run1).rejects.toThrow("boom-after-join");
+    // ...and the member resolves on its own WITHOUT anyone aborting it: the
+    // creator's cleanup force-stopped the group, releasing the passive wait.
+    // (A leaked registry reservation would hang this await until the test
+    // times out.)
+    await run2;
+
+    // No connection was ever started by the failed round.
+    expect(getSlackTestState().appStartMock).not.toHaveBeenCalled();
+
+    // The registry slot must be free again: a fresh pair forms a NEW group
+    // whose creator actually starts the socket. If the dead group's slot had
+    // leaked, both fresh accounts would join it as members and no App would
+    // ever start.
+    mockHealthyTeamAuth();
+    const fresh = startBothTeamAccounts(config);
+    try {
+      await getSlackHandlerOrThrow("message");
+      await flush();
+      await flush();
+      expect(getSlackTestState().appStartMock).toHaveBeenCalledTimes(1);
+    } finally {
+      await stopBothTeamAccounts(fresh);
+    }
+  });
+
+  it("propagates a fatal socket error to every sharing account and leaves no abort listeners behind", async () => {
+    mockHealthyTeamAuth();
+    // First socket start dies with a non-recoverable auth error: the
+    // group-owned task records it and tears the group down.
+    getSlackTestState().appStartMock.mockRejectedValue(new Error("invalid_auth"));
+
+    const harness = startBothTeamAccounts(sharedGroupConfig());
+
+    // Both accounts' monitor promises surface the fatal error (neither was
+    // stopped on purpose), symmetric between creator and member.
+    await expect(harness.run1).rejects.toThrow("invalid_auth");
+    await expect(harness.run2).rejects.toThrow("invalid_auth");
+
+    // The passive wait settled via the GROUP's stop signal, so the listener
+    // each account had registered on its OWN abort signal must have been
+    // removed on settle — a once-listener that never fires is never
+    // auto-removed, so forgetting the removeEventListener would leak here.
+    expect(getEventListeners(harness.controller1.signal, "abort")).toHaveLength(0);
+    expect(getEventListeners(harness.controller2.signal, "abort")).toHaveLength(0);
   });
 });

--- a/extensions/slack/src/monitor/provider.shared-socket-group.test.ts
+++ b/extensions/slack/src/monitor/provider.shared-socket-group.test.ts
@@ -1,0 +1,186 @@
+// Slack tests cover the shared Socket Mode connection for multiple accounts
+// installed on the same Slack app (same app token).
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  flush,
+  getSlackClientForToken,
+  getSlackHandlerOrThrow,
+  getSlackTestState,
+  resetSlackTestState,
+} from "../monitor.test-helpers.js";
+
+const { monitorSlackProvider } = await import("./provider.js");
+
+const SHARED_APP_TOKEN = "xapp-1-A0SHARED-sharedsecrettoken";
+const TEAM1_BOT_TOKEN = "bot-token-team1";
+const TEAM2_BOT_TOKEN = "bot-token-team2";
+
+function sharedGroupConfig(): OpenClawConfig {
+  return {
+    channels: {
+      slack: {
+        dm: { enabled: true, policy: "open", allowFrom: ["*"] },
+        groupPolicy: "open",
+        accounts: {
+          team1: { botToken: TEAM1_BOT_TOKEN, appToken: SHARED_APP_TOKEN, mode: "socket" },
+          team2: { botToken: TEAM2_BOT_TOKEN, appToken: SHARED_APP_TOKEN, mode: "socket" },
+        },
+      },
+    },
+  };
+}
+
+function makeDirectMessageEvent(params: { channel: string; ts: string; text: string }) {
+  return {
+    type: "message" as const,
+    user: "U_SENDER",
+    text: params.text,
+    ts: params.ts,
+    channel: params.channel,
+    channel_type: "im" as const,
+  };
+}
+
+/** Starts both team accounts back-to-back (no await between the two calls) so
+ * team1's synchronous prefix — including reserving the shared-socket-group
+ * registry slot — always runs before team2 observes it, making team1 the
+ * deterministic owner regardless of scheduling. */
+function startBothTeamAccounts(config: ReturnType<typeof sharedGroupConfig>) {
+  const controller1 = new AbortController();
+  const controller2 = new AbortController();
+  const setStatus1 = vi.fn();
+  const setStatus2 = vi.fn();
+  const run1 = monitorSlackProvider({
+    accountId: "team1",
+    config,
+    abortSignal: controller1.signal,
+    setStatus: setStatus1,
+  });
+  const run2 = monitorSlackProvider({
+    accountId: "team2",
+    config,
+    abortSignal: controller2.signal,
+    setStatus: setStatus2,
+  });
+  return { controller1, controller2, setStatus1, setStatus2, run1, run2 };
+}
+
+async function stopBothTeamAccounts(harness: ReturnType<typeof startBothTeamAccounts>) {
+  await flush();
+  harness.controller1.abort();
+  harness.controller2.abort();
+  await Promise.all([harness.run1, harness.run2]);
+}
+
+beforeEach(() => {
+  resetSlackTestState(sharedGroupConfig());
+});
+
+describe("monitorSlackProvider shared Socket Mode group", () => {
+  it("shares one App for two accounts on the same app token and demuxes by team_id", async () => {
+    const client1 = getSlackClientForToken(TEAM1_BOT_TOKEN);
+    const client2 = getSlackClientForToken(TEAM2_BOT_TOKEN);
+    client1.auth.test.mockResolvedValue({
+      user_id: "U_BOT1",
+      bot_id: "B_BOT1",
+      team_id: "T1",
+      api_app_id: "A0SHARED",
+    });
+    client2.auth.test.mockResolvedValue({
+      user_id: "U_BOT2",
+      bot_id: "B_BOT2",
+      team_id: "T2",
+      api_app_id: "A0SHARED",
+    });
+
+    const harness = startBothTeamAccounts(sharedGroupConfig());
+    try {
+      // Both accounts register their "message" listener on the SAME shared
+      // Bolt App; getSlackHandlerOrThrow returns one composed function that
+      // invokes every registered listener (mirroring real Bolt's fan-out to
+      // every matching listener on an App).
+      const handler = await getSlackHandlerOrThrow("message");
+      // Give the second (non-owner) account's registration a few more ticks
+      // to land before asserting both are present.
+      await flush();
+      await flush();
+
+      // The event-registry demux below would also "pass" if two accounts
+      // each opened their own App and both happened to register into this
+      // mock's global handler registry — that wouldn't prove real sharing.
+      // Assert only ONE physical socket was actually started: Bolt's
+      // App.start() is only called by the group owner (team1); a
+      // non-shared implementation would call it once per account (twice).
+      expect(getSlackTestState().appStartMock).toHaveBeenCalledTimes(1);
+
+      harness.setStatus1.mockClear();
+      harness.setStatus2.mockClear();
+
+      // An event carrying team1's team_id should be processed by team1's
+      // handler only; team2's shouldDropMismatchedSlackEvent filter must
+      // reject it since its own ctx.teamId ("T2") does not match.
+      await handler({
+        event: makeDirectMessageEvent({ channel: "C_T1", ts: "111.001", text: "hi from team1" }),
+        body: { api_app_id: "A0SHARED", team_id: "T1" },
+      });
+
+      expect(harness.setStatus1).toHaveBeenCalled();
+      expect(harness.setStatus2).not.toHaveBeenCalled();
+
+      harness.setStatus1.mockClear();
+      harness.setStatus2.mockClear();
+
+      // The reverse: an event carrying team2's team_id is handled only by
+      // team2; team1 drops it. This confirms Slack's "deliver to exactly one
+      // connection" behavior is fully compensated for by sharing one App and
+      // demuxing via team_id, instead of losing team2's traffic to a second,
+      // never-selected socket.
+      await handler({
+        event: makeDirectMessageEvent({ channel: "C_T2", ts: "222.002", text: "hi from team2" }),
+        body: { api_app_id: "A0SHARED", team_id: "T2" },
+      });
+
+      expect(harness.setStatus1).not.toHaveBeenCalled();
+      expect(harness.setStatus2).toHaveBeenCalled();
+    } finally {
+      await stopBothTeamAccounts(harness);
+    }
+  });
+
+  it("resolves each account's boot-time auth.test via its OWN bot token client, not the shared app's owner client", async () => {
+    const client1 = getSlackClientForToken(TEAM1_BOT_TOKEN);
+    const client2 = getSlackClientForToken(TEAM2_BOT_TOKEN);
+    client1.auth.test.mockResolvedValue({
+      user_id: "U_BOT1",
+      bot_id: "B_BOT1",
+      team_id: "T1",
+      api_app_id: "A0SHARED",
+    });
+    client2.auth.test.mockResolvedValue({
+      user_id: "U_BOT2",
+      bot_id: "B_BOT2",
+      team_id: "T2",
+      api_app_id: "A0SHARED",
+    });
+
+    const harness = startBothTeamAccounts(sharedGroupConfig());
+    try {
+      // Wait for both accounts to finish booting (handler registration
+      // happens after the boot-time auth.test() call resolves).
+      await getSlackHandlerOrThrow("message");
+      await flush();
+      await flush();
+
+      // If team2's boot path incorrectly used the shared App's default
+      // client (bound to the owner/team1's bot token) instead of a client
+      // built from its OWN bot token, client2.auth.test would never be
+      // called at all — every identity lookup would silently resolve via
+      // client1 instead, and team2 would boot up believing it is team1.
+      expect(client1.auth.test).toHaveBeenCalledTimes(1);
+      expect(client2.auth.test).toHaveBeenCalledTimes(1);
+    } finally {
+      await stopBothTeamAccounts(harness);
+    }
+  });
+});

--- a/extensions/slack/src/monitor/provider.shared-socket-group.test.ts
+++ b/extensions/slack/src/monitor/provider.shared-socket-group.test.ts
@@ -183,4 +183,96 @@ describe("monitorSlackProvider shared Socket Mode group", () => {
       await stopBothTeamAccounts(harness);
     }
   });
+
+  it("stops processing a stopped member's events while the shared socket stays up for siblings", async () => {
+    const client1 = getSlackClientForToken(TEAM1_BOT_TOKEN);
+    const client2 = getSlackClientForToken(TEAM2_BOT_TOKEN);
+    client1.auth.test.mockResolvedValue({
+      user_id: "U_BOT1",
+      bot_id: "B_BOT1",
+      team_id: "T1",
+      api_app_id: "A0SHARED",
+    });
+    client2.auth.test.mockResolvedValue({
+      user_id: "U_BOT2",
+      bot_id: "B_BOT2",
+      team_id: "T2",
+      api_app_id: "A0SHARED",
+    });
+
+    const harness = startBothTeamAccounts(sharedGroupConfig());
+    try {
+      const handler = await getSlackHandlerOrThrow("message");
+      await flush();
+      await flush();
+
+      // Stop ONLY team2 (per-account stop) while team1 keeps the shared
+      // socket alive. Bolt has no listener-removal API, so team2's handler
+      // physically stays registered on the shared App — the abort-signal
+      // gate in shouldDropMismatchedSlackEvent is what must keep the stopped
+      // account from acting like a zombie and still replying in Slack.
+      harness.controller2.abort();
+      await harness.run2;
+
+      harness.setStatus1.mockClear();
+      harness.setStatus2.mockClear();
+
+      await handler({
+        event: makeDirectMessageEvent({ channel: "C_T2", ts: "333.003", text: "after stop" }),
+        body: { api_app_id: "A0SHARED", team_id: "T2" },
+      });
+      expect(harness.setStatus2).not.toHaveBeenCalled();
+
+      // The surviving sibling still processes its own workspace's traffic.
+      await handler({
+        event: makeDirectMessageEvent({ channel: "C_T1", ts: "444.004", text: "still alive" }),
+        body: { api_app_id: "A0SHARED", team_id: "T1" },
+      });
+      expect(harness.setStatus1).toHaveBeenCalled();
+    } finally {
+      await stopBothTeamAccounts(harness);
+    }
+  });
+
+  it("fails closed for a shared-group account whose boot auth.test could not resolve a teamId", async () => {
+    const client1 = getSlackClientForToken(TEAM1_BOT_TOKEN);
+    const client2 = getSlackClientForToken(TEAM2_BOT_TOKEN);
+    client1.auth.test.mockResolvedValue({
+      user_id: "U_BOT1",
+      bot_id: "B_BOT1",
+      team_id: "T1",
+      api_app_id: "A0SHARED",
+    });
+    // team2's bot token is broken: no identity, hence no teamId to demux by.
+    client2.auth.test.mockRejectedValue(new Error("invalid_auth"));
+
+    const harness = startBothTeamAccounts(sharedGroupConfig());
+    try {
+      const handler = await getSlackHandlerOrThrow("message");
+      await flush();
+      await flush();
+
+      harness.setStatus1.mockClear();
+      harness.setStatus2.mockClear();
+
+      // With teamId unresolved, team2's mismatch filter would previously
+      // skip the team check entirely and process BOTH workspaces' events.
+      // On a shared connection that is a cross-tenant leak, so the account
+      // must drop everything instead — even its own workspace's traffic.
+      await handler({
+        event: makeDirectMessageEvent({ channel: "C_T2", ts: "555.005", text: "to broken team" }),
+        body: { api_app_id: "A0SHARED", team_id: "T2" },
+      });
+      await handler({
+        event: makeDirectMessageEvent({ channel: "C_T1", ts: "666.006", text: "to team1" }),
+        body: { api_app_id: "A0SHARED", team_id: "T1" },
+      });
+
+      expect(harness.setStatus2).not.toHaveBeenCalled();
+      // team1 (healthy) still handles its own events.
+      expect(harness.setStatus1).toHaveBeenCalled();
+    } finally {
+      await stopBothTeamAccounts(harness);
+    }
+  });
 });

--- a/extensions/slack/src/monitor/provider.ts
+++ b/extensions/slack/src/monitor/provider.ts
@@ -144,6 +144,14 @@ function parseApiAppIdFromAppToken(raw?: string) {
  * app token as `appToken`. Grouping into a shared Socket Mode connection is
  * only engaged when this is greater than 1 — a single account per app token
  * takes the original, unmodified code path with zero behavioral change.
+ *
+ * Enterprise Grid org installs are excluded: they resolve teamId as ""
+ * (resolveSlackInstallationIdentity's "enterprise" kind never carries a
+ * teamId), so they can never pass shouldDropMismatchedSlackEvent's per-event
+ * team_id demux once inside a shared group — every inbound event would be
+ * dropped fail-closed. They always take the dedicated, non-shared connection
+ * regardless of how many siblings share their app token, so they must not
+ * count toward (or be counted as) a sharing group.
  */
 function countEnabledSlackSocketAccountsSharingAppToken(params: {
   cfg: OpenClawConfig;
@@ -151,7 +159,11 @@ function countEnabledSlackSocketAccountsSharingAppToken(params: {
 }): number {
   return listEnabledSlackAccounts(params.cfg).filter((candidate) => {
     const mode = candidate.config.mode ?? "socket";
-    return mode === "socket" && candidate.appToken === params.appToken;
+    return (
+      mode === "socket" &&
+      candidate.appToken === params.appToken &&
+      candidate.config.enterpriseOrgInstall !== true
+    );
   }).length;
 }
 
@@ -328,10 +340,27 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
   // account computes the same answer) and, only then, share a single Bolt
   // App/connection across all of them. A single account per app token takes
   // the untouched original code path below with no behavioral change.
+  //
+  // Enterprise Grid org installs are excluded from sharing (see
+  // countEnabledSlackSocketAccountsSharingAppToken): their teamId always
+  // resolves to "", which would make the shared group's fail-closed
+  // unresolved-teamId guard drop every inbound event for them. They keep
+  // using this dedicated, non-shared connection even if a sibling account
+  // reuses the same app token.
   const isSharedSlackSocketAppToken =
+    !enterpriseOrgInstall &&
     slackMode === "socket" &&
     Boolean(appToken) &&
     countEnabledSlackSocketAccountsSharingAppToken({ cfg, appToken: appToken ?? "" }) > 1;
+  // True when this enterprise account's app token IS shared by other
+  // (non-enterprise) accounts — i.e. it would have joined a shared group were
+  // it not an enterprise install. Drives a single boot-time warning so the
+  // dedicated-connection fallback above is not silent.
+  const enterpriseExcludedFromSharedSocketGroup =
+    enterpriseOrgInstall &&
+    slackMode === "socket" &&
+    Boolean(appToken) &&
+    countEnabledSlackSocketAccountsSharingAppToken({ cfg, appToken: appToken ?? "" }) > 0;
 
   let app: SlackBoltAppBundle["app"];
   let receiver: SlackBoltAppBundle["receiver"];
@@ -411,6 +440,17 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
       runtime.log?.(
         `slack: sharing socket for ${sharedAccountCount} accounts on app ` +
           `${expectedApiAppIdFromAppToken ?? "unknown"} (multi-workspace)`,
+      );
+    }
+
+    if (enterpriseExcludedFromSharedSocketGroup) {
+      // Deliberately inside the try, same reasoning as above: runtime.log may
+      // throw and this account (a solo, non-shared connection) must still
+      // unwind cleanly through the existing finally below.
+      runtime.log?.(
+        warn(
+          `slack account ${account.accountId}: enterprise org install cannot join a shared Socket Mode group; using a dedicated connection`,
+        ),
       );
     }
 

--- a/extensions/slack/src/monitor/provider.ts
+++ b/extensions/slack/src/monitor/provider.ts
@@ -542,6 +542,16 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
     );
   }
 
+  if (isSharedSlackSocketAppToken && !teamId) {
+    runtime.log?.(
+      warn(
+        `[${account.accountId}] slack: teamId unresolved on a shared socket group (auth.test failed or returned no team_id); ` +
+          "ALL events for this account will be dropped to avoid acting on sibling workspaces' traffic — " +
+          "fix the bot token and restart",
+      ),
+    );
+  }
+
   const ctx = createSlackMonitorContext({
     cfg,
     accountId: account.accountId,
@@ -550,6 +560,8 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
     client: accountWebClient,
     runtime,
     channelRuntime: opts.channelRuntime,
+    accountAbortSignal: opts.abortSignal,
+    isSharedSocketGroup: isSharedSlackSocketAppToken,
     botUserId,
     botId,
     teamId,
@@ -605,7 +617,11 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
       accountId: account.accountId,
       capability: CHANNEL_APPROVAL_NATIVE_RUNTIME_CONTEXT_CAPABILITY,
       context: {
+        // The approval runtime must call the Web API as THIS account, not as
+        // whichever account owns a shared App — pass the per-account client
+        // alongside the (possibly shared) App.
         app,
+        client: accountWebClient,
         config: slackCfg.execApprovals ?? {},
       },
       abortSignal: opts.abortSignal,

--- a/extensions/slack/src/monitor/provider.ts
+++ b/extensions/slack/src/monitor/provider.ts
@@ -15,12 +15,7 @@ import { resolveTextChunkLimit } from "openclaw/plugin-sdk/reply-chunking";
 import { DEFAULT_GROUP_HISTORY_LIMIT } from "openclaw/plugin-sdk/reply-history";
 import { normalizeMainKey } from "openclaw/plugin-sdk/routing";
 import { warn } from "openclaw/plugin-sdk/runtime-env";
-import {
-  computeBackoff,
-  createNonExitingRuntime,
-  sleepWithAbort,
-  type RuntimeEnv,
-} from "openclaw/plugin-sdk/runtime-env";
+import { createNonExitingRuntime, type RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { normalizeResolvedSecretInputString } from "openclaw/plugin-sdk/secret-input";
 import {
   normalizeOptionalString,
@@ -69,23 +64,19 @@ import {
   formatSlackChannelResolved,
   formatSlackUserResolved,
   gracefulStopSlackApp,
-  publishSlackConnectedStatus,
-  publishSlackDisconnectedStatus,
   resolveSlackBoltInterop,
-  startSlackSocketAndWaitForDisconnect,
   type SlackBoltResolvedExports,
 } from "./provider-support.js";
 import {
   formatSlackSocketModeSharedConnectionWarning,
   formatUnknownError,
-  isNonRecoverableSlackAuthError,
   registerSlackSocketModeConnectionDiagnostics,
-  SLACK_SOCKET_RECONNECT_POLICY,
 } from "./reconnect-policy.js";
 import { setSlackDefaultSendIdentity } from "./send.runtime.js";
 import {
   forceStopSlackSharedSocketGroup,
   joinSlackSharedSocketGroup,
+  runSlackSocketConnectionLoop,
   type SlackSharedSocketGroupHandle,
 } from "./shared-socket-group.js";
 import { registerSlackMonitorSlashCommands } from "./slash.js";
@@ -136,30 +127,6 @@ function resolveStableSlackUserAllowlistEntries(entries: string[]): SlackUserRes
     }
   }
   return resolved;
-}
-
-function formatSlackSocketReconnectMessage(params: {
-  event: string;
-  attempt: number;
-  delayMs: number;
-  error?: unknown;
-}) {
-  const suffix = params.error ? ` (${formatUnknownError(params.error)})` : "";
-  return `slack socket disconnected (${params.event}); reconnecting in ${Math.round(params.delayMs / 1000)}s (attempt ${params.attempt}/∞)${suffix}`;
-}
-
-function formatSlackSocketStartRetryMessage(params: {
-  attempt: number;
-  delayMs: number;
-  error: unknown;
-  sdkContext?: string;
-}) {
-  const reason = formatUnknownError(
-    params.error,
-    "Slack Socket Mode start failed without error detail",
-  );
-  const sdkContext = params.sdkContext?.trim() ? `; last SDK log: ${params.sdkContext.trim()}` : "";
-  return `slack socket mode failed to start; retry ${params.attempt}/∞ in ${Math.round(params.delayMs / 1000)}s reason="${reason}${sdkContext}"`;
 }
 
 function parseApiAppIdFromAppToken(raw?: string) {
@@ -410,489 +377,443 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
     }));
   }
 
-  // Only the group owner physically owns the shared App: members must never
-  // start/stop/diagnose a connection another account created. For a solo
-  // (non-shared) account, sharedGroup is null and every one of these checks
-  // degrades to the original single-account behavior.
+  // Members of a shared group must never start/stop/diagnose a connection
+  // another account created. For a solo (non-shared) account, sharedGroup is
+  // null and every one of these checks degrades to the original
+  // single-account behavior.
   const isSharedGroupMember = sharedGroup !== null && !sharedGroup.isOwner;
-  // The owner's connect/reconnect loop keys off the GROUP's stop signal
-  // (fires only once every member has left) rather than its own individual
-  // abortSignal, so the shared socket stays open for as long as any sibling
-  // account still needs it — even if this account's own abortSignal fires
-  // first. Non-shared accounts see sharedGroup === null and keep using their
-  // own abortSignal exactly as before.
-  const socketAbortSignal =
-    sharedGroup && sharedGroup.isOwner ? sharedGroup.stopSignal : opts.abortSignal;
-  const leaveSharedGroupOnAbort = sharedGroup
-    ? () => {
-        sharedGroup?.leave();
-      }
-    : undefined;
-  if (leaveSharedGroupOnAbort) {
-    opts.abortSignal?.addEventListener("abort", leaveSharedGroupOnAbort, { once: true });
-  }
 
   // Pre-set shuttingDown on the SocketModeClient before app.stop() to prevent
   // a race where the library's internal ping timeout fires disconnect() before
   // shuttingDown is set, causing orphaned reconnects with leaked ping intervals.
   // See: openclaw/openclaw#56508
   const gracefulStop = async () => {
-    if (isSharedGroupMember) {
-      // Never stop an app this account doesn't own; the owner's own
-      // gracefulStop (driven by the group stop signal) handles it.
+    if (sharedGroup) {
+      // The group-owned connection task stops the shared App; individual
+      // accounts (creator included) never stop an App siblings may be using.
       return;
     }
     await gracefulStopSlackApp(app);
   };
-
-  const slackHttpHandler =
-    slackMode === "http" && receiver
-      ? async (req: IncomingMessage, res: ServerResponse) => {
-          const httpReceiver = receiver as {
-            requestListener: (req: IncomingMessage, res: ServerResponse) => unknown;
-          };
-          const guard = installRequestBodyLimitGuard(req, res, {
-            maxBytes: SLACK_WEBHOOK_MAX_BODY_BYTES,
-            timeoutMs: SLACK_WEBHOOK_BODY_TIMEOUT_MS,
-            responseFormat: "text",
-          });
-          if (guard.isTripped()) {
-            return;
-          }
-          try {
-            await Promise.resolve(httpReceiver.requestListener(req, res));
-          } catch (err) {
-            if (!guard.isTripped()) {
-              throw err;
-            }
-          } finally {
-            guard.dispose();
-          }
-        }
-      : null;
-  let unregisterHttpHandler: (() => void) | null = null;
-  // Only the owner (or a non-shared solo account) registers diagnostics: a
-  // shared group has exactly one physical connection, so a member
-  // registering its own listener on the same emitter would be redundant.
-  const unregisterSocketModeConnectionDiagnostics =
-    slackMode === "socket" && !isSharedGroupMember
-      ? registerSlackSocketModeConnectionDiagnostics({
-          app,
-          onSharedConnection: (activeConnections) => {
-            runtime.log?.(warn(formatSlackSocketModeSharedConnectionWarning(activeConnections)));
-          },
-        })
-      : () => {};
-
-  let botUserId = "";
-  let botId = "";
-  let authTestFailed = false;
-  let authTestError: string | undefined;
-  let authIdentityWarning: string | undefined;
-  let authTestIdentity: SlackAuthTestIdentity | undefined;
-  try {
-    // Always authenticate via this account's OWN per-account client, never
-    // app.client: when the App is shared, app.client's default identity is
-    // whichever account created it (the group owner), which would make every
-    // member account boot up believing it is the owner's team/app.
-    const auth = await accountWebClient.auth.test();
-    const authUserId = normalizeOptionalString(auth.user_id) ?? "";
-    botId = normalizeOptionalString((auth as { bot_id?: string }).bot_id) ?? "";
-    // Slack documents bot_id only for bot-token identities. Never treat the user behind a
-    // user token as the bot mention target; required-mention channels must fail closed instead.
-    botUserId = botId ? authUserId : "";
-    authTestIdentity = auth;
-    authIdentityWarning = formatSlackBotTokenIdentityWarning({
-      auth,
-      accountId: account.accountId,
-    });
-    if (!authUserId && !enterpriseOrgInstall) {
-      authTestFailed = true;
-      authTestError = "auth.test returned no user_id";
+  const stopOnAbort = () => {
+    if (opts.abortSignal?.aborted && slackMode === "socket") {
+      void gracefulStop();
     }
-  } catch (err) {
-    authTestFailed = true;
-    authTestError = err instanceof Error ? err.message : String(err);
-  }
-  const installationIdentity = resolveSlackInstallationIdentity({
-    enterpriseOrgInstall,
-    auth: authTestFailed ? undefined : authTestIdentity,
-    authError: authTestError,
-    transportApiAppId: expectedApiAppIdFromAppToken,
-  });
-  const teamId = installationIdentity.kind === "workspace" ? installationIdentity.teamId : "";
-  const apiAppId =
-    installationIdentity.kind === "degraded" ? "" : (installationIdentity.apiAppId ?? "");
-  if (authTestFailed) {
-    runtime.log?.(
-      warn(
-        `[${account.accountId}] slack auth.test failed at boot (${authTestError ?? "unknown error"}); ` +
-          "explicit bot-mention detection will be disabled until restart with a valid bot token; " +
-          "required-mention channels will fail closed without another trusted activation signal",
-      ),
-    );
-  }
-  if (authIdentityWarning) {
-    runtime.log?.(warn(authIdentityWarning));
-  }
+  };
+  opts.abortSignal?.addEventListener("abort", stopOnAbort, { once: true });
 
-  if (apiAppId && expectedApiAppIdFromAppToken && apiAppId !== expectedApiAppIdFromAppToken) {
-    runtime.error?.(
-      `slack token mismatch: bot token app_id=${apiAppId} but app token looks like app_id=${expectedApiAppIdFromAppToken}`,
-    );
-  }
+  // From here on any thrown error must release the shared group reservation
+  // (see the finally at the end of this function): a creator that throws
+  // before its connection task exists tears the whole group down so members
+  // are never left waiting on a stopSignal nobody will fire, and a member
+  // that throws simply leaves.
+  let unregisterHttpHandler: (() => void) | null = null;
+  let unregisterSocketModeConnectionDiagnostics: () => void = () => {};
+  try {
+    const slackHttpHandler =
+      slackMode === "http" && receiver
+        ? async (req: IncomingMessage, res: ServerResponse) => {
+            const httpReceiver = receiver as {
+              requestListener: (req: IncomingMessage, res: ServerResponse) => unknown;
+            };
+            const guard = installRequestBodyLimitGuard(req, res, {
+              maxBytes: SLACK_WEBHOOK_MAX_BODY_BYTES,
+              timeoutMs: SLACK_WEBHOOK_BODY_TIMEOUT_MS,
+              responseFormat: "text",
+            });
+            if (guard.isTripped()) {
+              return;
+            }
+            try {
+              await Promise.resolve(httpReceiver.requestListener(req, res));
+            } catch (err) {
+              if (!guard.isTripped()) {
+                throw err;
+              }
+            } finally {
+              guard.dispose();
+            }
+          }
+        : null;
+    // Only the group creator (or a non-shared solo account) registers
+    // diagnostics: a shared group has exactly one physical connection, so a
+    // member registering its own listener on the same emitter would be
+    // redundant.
+    unregisterSocketModeConnectionDiagnostics =
+      slackMode === "socket" && !isSharedGroupMember
+        ? registerSlackSocketModeConnectionDiagnostics({
+            app,
+            onSharedConnection: (activeConnections) => {
+              runtime.log?.(warn(formatSlackSocketModeSharedConnectionWarning(activeConnections)));
+            },
+          })
+        : () => {};
 
-  if (isSharedSlackSocketAppToken && !teamId) {
-    runtime.log?.(
-      warn(
-        `[${account.accountId}] slack: teamId unresolved on a shared socket group (auth.test failed or returned no team_id); ` +
-          "ALL events for this account will be dropped to avoid acting on sibling workspaces' traffic — " +
-          "fix the bot token and restart",
-      ),
-    );
-  }
-
-  const ctx = createSlackMonitorContext({
-    cfg,
-    accountId: account.accountId,
-    botToken,
-    app,
-    client: accountWebClient,
-    runtime,
-    channelRuntime: opts.channelRuntime,
-    accountAbortSignal: opts.abortSignal,
-    isSharedSocketGroup: isSharedSlackSocketAppToken,
-    botUserId,
-    botId,
-    teamId,
-    apiAppId,
-    installationIdentity,
-    historyLimit,
-    dmHistoryLimit,
-    sessionScope,
-    mainKey,
-    dmEnabled,
-    dmPolicy,
-    allowFrom,
-    allowNameMatching,
-    groupDmEnabled,
-    groupDmChannels,
-    defaultRequireMention: slackCfg.requireMention,
-    channelsConfig,
-    groupPolicy,
-    useAccessGroups,
-    reactionMode,
-    reactionAllowlist,
-    replyToMode,
-    threadHistoryScope,
-    threadInheritParent,
-    threadRequireExplicitMention,
-    slashCommand,
-    textLimit,
-    ackReactionScope,
-    typingReaction,
-    mediaMaxBytes,
-    removeAckAfterReply,
-  });
-
-  // Slack's socket-mode client keeps ping/pong health private and closes on
-  // missed pongs. App events are useful status activity, but not transport proof.
-  const trackEvent = opts.setStatus
-    ? () => {
-        opts.setStatus!({ lastEventAt: Date.now(), lastInboundAt: Date.now() });
+    let botUserId = "";
+    let botId = "";
+    let authTestFailed = false;
+    let authTestError: string | undefined;
+    let authIdentityWarning: string | undefined;
+    let authTestIdentity: SlackAuthTestIdentity | undefined;
+    try {
+      // Always authenticate via this account's OWN per-account client, never
+      // app.client: when the App is shared, app.client's default identity is
+      // whichever account created it (the group owner), which would make every
+      // member account boot up believing it is the owner's team/app.
+      const auth = await accountWebClient.auth.test();
+      const authUserId = normalizeOptionalString(auth.user_id) ?? "";
+      botId = normalizeOptionalString((auth as { bot_id?: string }).bot_id) ?? "";
+      // Slack documents bot_id only for bot-token identities. Never treat the user behind a
+      // user token as the bot mention target; required-mention channels must fail closed instead.
+      botUserId = botId ? authUserId : "";
+      authTestIdentity = auth;
+      authIdentityWarning = formatSlackBotTokenIdentityWarning({
+        auth,
+        accountId: account.accountId,
+      });
+      if (!authUserId && !enterpriseOrgInstall) {
+        authTestFailed = true;
+        authTestError = "auth.test returned no user_id";
       }
-    : undefined;
+    } catch (err) {
+      authTestFailed = true;
+      authTestError = err instanceof Error ? err.message : String(err);
+    }
+    const installationIdentity = resolveSlackInstallationIdentity({
+      enterpriseOrgInstall,
+      auth: authTestFailed ? undefined : authTestIdentity,
+      authError: authTestError,
+      transportApiAppId: expectedApiAppIdFromAppToken,
+    });
+    const teamId = installationIdentity.kind === "workspace" ? installationIdentity.teamId : "";
+    const apiAppId =
+      installationIdentity.kind === "degraded" ? "" : (installationIdentity.apiAppId ?? "");
+    if (authTestFailed) {
+      runtime.log?.(
+        warn(
+          `[${account.accountId}] slack auth.test failed at boot (${authTestError ?? "unknown error"}); ` +
+            "explicit bot-mention detection will be disabled until restart with a valid bot token; " +
+            "required-mention channels will fail closed without another trusted activation signal",
+        ),
+      );
+    }
+    if (authIdentityWarning) {
+      runtime.log?.(warn(authIdentityWarning));
+    }
 
-  const handleSlackMessage = createSlackMessageHandler({ ctx, account, trackEvent });
-  if (
-    installationIdentity.kind !== "enterprise" &&
-    isSlackAnyNativeApprovalClientEnabled({
+    if (apiAppId && expectedApiAppIdFromAppToken && apiAppId !== expectedApiAppIdFromAppToken) {
+      runtime.error?.(
+        `slack token mismatch: bot token app_id=${apiAppId} but app token looks like app_id=${expectedApiAppIdFromAppToken}`,
+      );
+    }
+
+    if (isSharedSlackSocketAppToken && !teamId) {
+      runtime.log?.(
+        warn(
+          `[${account.accountId}] slack: teamId unresolved on a shared socket group (auth.test failed or returned no team_id); ` +
+            "ALL events for this account will be dropped to avoid acting on sibling workspaces' traffic — " +
+            "fix the bot token and restart",
+        ),
+      );
+    }
+
+    const ctx = createSlackMonitorContext({
       cfg,
       accountId: account.accountId,
-    })
-  ) {
-    registerChannelRuntimeContext({
+      botToken,
+      app,
+      client: accountWebClient,
+      runtime,
       channelRuntime: opts.channelRuntime,
-      channelId: "slack",
-      accountId: account.accountId,
-      capability: CHANNEL_APPROVAL_NATIVE_RUNTIME_CONTEXT_CAPABILITY,
-      context: {
-        // The approval runtime must call the Web API as THIS account, not as
-        // whichever account owns a shared App — pass the per-account client
-        // alongside the (possibly shared) App.
-        app,
-        client: accountWebClient,
-        config: slackCfg.execApprovals ?? {},
-      },
-      abortSignal: opts.abortSignal,
+      accountAbortSignal: opts.abortSignal,
+      isSharedSocketGroup: isSharedSlackSocketAppToken,
+      botUserId,
+      botId,
+      teamId,
+      apiAppId,
+      installationIdentity,
+      historyLimit,
+      dmHistoryLimit,
+      sessionScope,
+      mainKey,
+      dmEnabled,
+      dmPolicy,
+      allowFrom,
+      allowNameMatching,
+      groupDmEnabled,
+      groupDmChannels,
+      defaultRequireMention: slackCfg.requireMention,
+      channelsConfig,
+      groupPolicy,
+      useAccessGroups,
+      reactionMode,
+      reactionAllowlist,
+      replyToMode,
+      threadHistoryScope,
+      threadInheritParent,
+      threadRequireExplicitMention,
+      slashCommand,
+      textLimit,
+      ackReactionScope,
+      typingReaction,
+      mediaMaxBytes,
+      removeAckAfterReply,
     });
-  }
 
-  // Resolve command registration first so App Home never advertises an inactive single command.
-  const commandRegistration =
-    installationIdentity.kind === "enterprise"
-      ? ({ mode: "disabled" } as const)
-      : await registerSlackMonitorSlashCommands({ ctx, account, trackEvent });
-  const appHomeSlashCommandName =
-    commandRegistration.mode === "single" ? commandRegistration.name : undefined;
-  registerSlackMonitorEvents({
-    ctx,
-    account,
-    handleSlackMessage,
-    appHomeSlashCommandName,
-    trackEvent,
-  });
-  if (slackMode === "http" && slackHttpHandler) {
-    unregisterHttpHandler = registerSlackHttpHandler({
-      path: slackWebhookPath,
-      handler: slackHttpHandler,
-      log: runtime.log,
-      accountId: account.accountId,
+    // Slack's socket-mode client keeps ping/pong health private and closes on
+    // missed pongs. App events are useful status activity, but not transport proof.
+    const trackEvent = opts.setStatus
+      ? () => {
+          opts.setStatus!({ lastEventAt: Date.now(), lastInboundAt: Date.now() });
+        }
+      : undefined;
+
+    const handleSlackMessage = createSlackMessageHandler({ ctx, account, trackEvent });
+    if (
+      installationIdentity.kind !== "enterprise" &&
+      isSlackAnyNativeApprovalClientEnabled({
+        cfg,
+        accountId: account.accountId,
+      })
+    ) {
+      registerChannelRuntimeContext({
+        channelRuntime: opts.channelRuntime,
+        channelId: "slack",
+        accountId: account.accountId,
+        capability: CHANNEL_APPROVAL_NATIVE_RUNTIME_CONTEXT_CAPABILITY,
+        context: {
+          // The approval runtime must call the Web API as THIS account, not as
+          // whichever account owns a shared App — pass the per-account client
+          // alongside the (possibly shared) App.
+          app,
+          client: accountWebClient,
+          config: slackCfg.execApprovals ?? {},
+        },
+        abortSignal: opts.abortSignal,
+      });
+    }
+
+    // Resolve command registration first so App Home never advertises an inactive single command.
+    const commandRegistration =
+      installationIdentity.kind === "enterprise"
+        ? ({ mode: "disabled" } as const)
+        : await registerSlackMonitorSlashCommands({ ctx, account, trackEvent });
+    const appHomeSlashCommandName =
+      commandRegistration.mode === "single" ? commandRegistration.name : undefined;
+    registerSlackMonitorEvents({
+      ctx,
+      account,
+      handleSlackMessage,
+      appHomeSlashCommandName,
+      trackEvent,
     });
-  }
+    if (slackMode === "http" && slackHttpHandler) {
+      unregisterHttpHandler = registerSlackHttpHandler({
+        path: slackWebhookPath,
+        handler: slackHttpHandler,
+        log: runtime.log,
+        accountId: account.accountId,
+      });
+    }
 
-  if (resolveToken && installationIdentity.kind !== "enterprise") {
-    void (async () => {
-      if (opts.abortSignal?.aborted) {
-        return;
-      }
-
-      if (channelsConfig && Object.keys(channelsConfig).length > 0) {
-        try {
-          const entries = Object.keys(channelsConfig).filter((key) => key !== "*");
-          if (entries.length > 0) {
-            const resolved = await resolveSlackChannelAllowlist({
-              token: resolveToken,
-              entries,
-            });
-            const nextChannels = { ...channelsConfig };
-            const mapping: string[] = [];
-            const unresolved: string[] = [];
-            for (const entry of resolved) {
-              const source = channelsConfig?.[entry.input];
-              if (!source) {
-                continue;
-              }
-              if (!entry.resolved || !entry.id) {
-                unresolved.push(entry.input);
-                continue;
-              }
-              const resolvedLabel = formatSlackChannelResolved(entry);
-              if (resolvedLabel) {
-                mapping.push(resolvedLabel);
-              }
-              const existing = nextChannels[entry.id] ?? {};
-              nextChannels[entry.id] = { ...source, ...existing };
-            }
-            channelsConfig = nextChannels;
-            ctx.channelsConfig = nextChannels;
-            summarizeMapping("slack channels", mapping, unresolved, runtime);
-          }
-        } catch (err) {
-          runtime.log?.(
-            `slack channel resolve failed; using config entries. ${formatUnknownError(err)}`,
-          );
-        }
-      }
-
-      const allowEntries = normalizeStringEntries(allowFrom).filter((entry) => entry !== "*");
-      if (allowEntries.length > 0) {
-        const stableResolvedUsers = resolveStableSlackUserAllowlistEntries(allowEntries);
-        if (stableResolvedUsers.length > 0) {
-          const { mapping, additions } = buildAllowlistResolutionSummary(stableResolvedUsers, {
-            formatResolved: formatSlackUserResolved,
-          });
-          allowFrom = mergeAllowlist({ existing: allowFrom, additions });
-          ctx.allowFrom = normalizeAllowList(allowFrom);
-          summarizeMapping("slack users", mapping, [], runtime);
+    if (resolveToken && installationIdentity.kind !== "enterprise") {
+      void (async () => {
+        if (opts.abortSignal?.aborted) {
+          return;
         }
 
-        if (allowNameMatching) {
+        if (channelsConfig && Object.keys(channelsConfig).length > 0) {
           try {
-            const resolvedUsers = await resolveSlackUserAllowlist({
-              token: resolveToken,
-              entries: allowEntries,
-            });
-            const { mapping, unresolved, additions } = buildAllowlistResolutionSummary(
-              resolvedUsers,
-              {
-                formatResolved: formatSlackUserResolved,
-              },
-            );
-            allowFrom = mergeAllowlist({ existing: allowFrom, additions });
-            ctx.allowFrom = normalizeAllowList(allowFrom);
-            summarizeMapping("slack users", mapping, unresolved, runtime);
+            const entries = Object.keys(channelsConfig).filter((key) => key !== "*");
+            if (entries.length > 0) {
+              const resolved = await resolveSlackChannelAllowlist({
+                token: resolveToken,
+                entries,
+              });
+              const nextChannels = { ...channelsConfig };
+              const mapping: string[] = [];
+              const unresolved: string[] = [];
+              for (const entry of resolved) {
+                const source = channelsConfig?.[entry.input];
+                if (!source) {
+                  continue;
+                }
+                if (!entry.resolved || !entry.id) {
+                  unresolved.push(entry.input);
+                  continue;
+                }
+                const resolvedLabel = formatSlackChannelResolved(entry);
+                if (resolvedLabel) {
+                  mapping.push(resolvedLabel);
+                }
+                const existing = nextChannels[entry.id] ?? {};
+                nextChannels[entry.id] = { ...source, ...existing };
+              }
+              channelsConfig = nextChannels;
+              ctx.channelsConfig = nextChannels;
+              summarizeMapping("slack channels", mapping, unresolved, runtime);
+            }
           } catch (err) {
             runtime.log?.(
-              `slack user resolve failed; using config entries. ${formatUnknownError(err)}`,
+              `slack channel resolve failed; using config entries. ${formatUnknownError(err)}`,
             );
           }
         }
-      }
 
-      if (channelsConfig && Object.keys(channelsConfig).length > 0) {
-        const userEntries = new Set<string>();
-        for (const channel of Object.values(channelsConfig)) {
-          addAllowlistUserEntriesFromConfigEntry(userEntries, channel);
-        }
-
-        if (userEntries.size > 0) {
-          const stableResolvedUsers = resolveStableSlackUserAllowlistEntries(
-            Array.from(userEntries),
-          );
+        const allowEntries = normalizeStringEntries(allowFrom).filter((entry) => entry !== "*");
+        if (allowEntries.length > 0) {
+          const stableResolvedUsers = resolveStableSlackUserAllowlistEntries(allowEntries);
           if (stableResolvedUsers.length > 0) {
-            const { resolvedMap, mapping } = buildAllowlistResolutionSummary(stableResolvedUsers, {
+            const { mapping, additions } = buildAllowlistResolutionSummary(stableResolvedUsers, {
               formatResolved: formatSlackUserResolved,
             });
-            const nextChannels = patchAllowlistUsersInConfigEntries({
-              entries: channelsConfig,
-              resolvedMap,
-            });
-            channelsConfig = nextChannels;
-            ctx.channelsConfig = nextChannels;
-            summarizeMapping("slack channel users", mapping, [], runtime);
+            allowFrom = mergeAllowlist({ existing: allowFrom, additions });
+            ctx.allowFrom = normalizeAllowList(allowFrom);
+            summarizeMapping("slack users", mapping, [], runtime);
           }
 
           if (allowNameMatching) {
             try {
               const resolvedUsers = await resolveSlackUserAllowlist({
                 token: resolveToken,
-                entries: Array.from(userEntries),
+                entries: allowEntries,
               });
-              const { resolvedMap, mapping, unresolved } = buildAllowlistResolutionSummary(
+              const { mapping, unresolved, additions } = buildAllowlistResolutionSummary(
                 resolvedUsers,
                 {
                   formatResolved: formatSlackUserResolved,
                 },
               );
+              allowFrom = mergeAllowlist({ existing: allowFrom, additions });
+              ctx.allowFrom = normalizeAllowList(allowFrom);
+              summarizeMapping("slack users", mapping, unresolved, runtime);
+            } catch (err) {
+              runtime.log?.(
+                `slack user resolve failed; using config entries. ${formatUnknownError(err)}`,
+              );
+            }
+          }
+        }
 
+        if (channelsConfig && Object.keys(channelsConfig).length > 0) {
+          const userEntries = new Set<string>();
+          for (const channel of Object.values(channelsConfig)) {
+            addAllowlistUserEntriesFromConfigEntry(userEntries, channel);
+          }
+
+          if (userEntries.size > 0) {
+            const stableResolvedUsers = resolveStableSlackUserAllowlistEntries(
+              Array.from(userEntries),
+            );
+            if (stableResolvedUsers.length > 0) {
+              const { resolvedMap, mapping } = buildAllowlistResolutionSummary(
+                stableResolvedUsers,
+                {
+                  formatResolved: formatSlackUserResolved,
+                },
+              );
               const nextChannels = patchAllowlistUsersInConfigEntries({
                 entries: channelsConfig,
                 resolvedMap,
               });
               channelsConfig = nextChannels;
               ctx.channelsConfig = nextChannels;
-              summarizeMapping("slack channel users", mapping, unresolved, runtime);
-            } catch (err) {
-              runtime.log?.(
-                `slack channel user resolve failed; using config entries. ${formatUnknownError(err)}`,
-              );
+              summarizeMapping("slack channel users", mapping, [], runtime);
+            }
+
+            if (allowNameMatching) {
+              try {
+                const resolvedUsers = await resolveSlackUserAllowlist({
+                  token: resolveToken,
+                  entries: Array.from(userEntries),
+                });
+                const { resolvedMap, mapping, unresolved } = buildAllowlistResolutionSummary(
+                  resolvedUsers,
+                  {
+                    formatResolved: formatSlackUserResolved,
+                  },
+                );
+
+                const nextChannels = patchAllowlistUsersInConfigEntries({
+                  entries: channelsConfig,
+                  resolvedMap,
+                });
+                channelsConfig = nextChannels;
+                ctx.channelsConfig = nextChannels;
+                summarizeMapping("slack channel users", mapping, unresolved, runtime);
+              } catch (err) {
+                runtime.log?.(
+                  `slack channel user resolve failed; using config entries. ${formatUnknownError(err)}`,
+                );
+              }
             }
           }
         }
-      }
-    })();
-  }
-
-  const stopOnAbort = () => {
-    if (socketAbortSignal?.aborted && slackMode === "socket") {
-      void gracefulStop();
+      })();
     }
-  };
-  socketAbortSignal?.addEventListener("abort", stopOnAbort, { once: true });
 
-  try {
-    if (slackMode === "socket" && isSharedGroupMember && sharedGroup) {
-      // This account joined an existing shared socket group as a member, not
-      // its owner: its event/slash handlers are already registered on the
-      // shared App above, but the group owner's coroutine is the one that
-      // actually starts/reconnects/stops the connection. Wait passively
-      // until either this account's own abortSignal fires (normal per-account
-      // stop) or the group's stopSignal fires (the owner tore the whole
-      // group down, e.g. on a fatal non-recoverable auth error), whichever
-      // comes first.
+    if (slackMode === "socket" && sharedGroup) {
       const group = sharedGroup;
-      if (!opts.abortSignal?.aborted && !group.stopSignal.aborted) {
-        await new Promise<void>((resolve) => {
-          const onOwnAbort = () => resolve();
-          const onGroupStop = () => resolve();
-          opts.abortSignal?.addEventListener("abort", onOwnAbort, { once: true });
-          group.stopSignal.addEventListener("abort", onGroupStop, { once: true });
+      if (group.isOwner) {
+        // The connection runs as a GROUP-owned task, decoupled from this
+        // account's lifecycle: it keeps serving sibling accounts after this
+        // creator account is stopped, and only ends once every member has
+        // left (or a fatal error kills it). It intentionally keeps using the
+        // CREATOR's runtime for logs and the creator's setStatus for
+        // connection status even after the creator account itself stops.
+        group.startConnectionTask(async () => {
+          // Pre-set shuttingDown as soon as the group stops (same race guard
+          // as stopOnAbort above, but keyed to the group's lifetime).
+          const stopOnGroupStop = () => {
+            void gracefulStopSlackApp(app);
+          };
+          group.stopSignal.addEventListener("abort", stopOnGroupStop, { once: true });
+          try {
+            await runSlackSocketConnectionLoop({
+              app,
+              abortSignal: group.stopSignal,
+              runtime,
+              setStatus: opts.setStatus,
+              getLastSdkLogMessage: socketModeLogger.getLastMessage,
+            });
+          } finally {
+            group.stopSignal.removeEventListener("abort", stopOnGroupStop);
+            await gracefulStopSlackApp(app);
+          }
         });
       }
-    } else if (slackMode === "socket") {
-      let reconnectAttempts = 0;
-      let hasLoggedSocketConnected = false;
-      // socketAbortSignal itself never gets reassigned, but its .aborted getter flips when
-      // abort() fires externally (this account's own signal, or the shared group's stop
-      // signal); same pattern as the original opts.abortSignal?.aborted check this loop is
-      // based on.
-      // oxlint-disable-next-line eslint/no-unmodified-loop-condition
-      while (!socketAbortSignal?.aborted) {
-        try {
-          const disconnect = await startSlackSocketAndWaitForDisconnect({
-            app,
-            abortSignal: socketAbortSignal,
-            onStarted: () => {
-              reconnectAttempts = 0;
-              publishSlackConnectedStatus(opts.setStatus);
-              if (!hasLoggedSocketConnected) {
-                hasLoggedSocketConnected = true;
-                runtime.log?.("slack socket mode connected");
-              }
-            },
-          });
-          if (!disconnect) {
-            break;
-          }
-          if (socketAbortSignal?.aborted) {
-            break;
-          }
-          publishSlackDisconnectedStatus(opts.setStatus, disconnect.error);
-
-          // Permanent account and credential failures need operator action.
-          if (disconnect.error && isNonRecoverableSlackAuthError(disconnect.error)) {
-            runtime.error?.(
-              `slack socket mode disconnected due to non-recoverable auth error — skipping channel (${formatUnknownError(disconnect.error)})`,
-            );
-            throw disconnect.error instanceof Error
-              ? disconnect.error
-              : new Error(formatUnknownError(disconnect.error));
-          }
-
-          reconnectAttempts += 1;
-          const delayMs = computeBackoff(SLACK_SOCKET_RECONNECT_POLICY, reconnectAttempts);
-          runtime.log?.(
-            warn(
-              formatSlackSocketReconnectMessage({
-                event: disconnect.event,
-                attempt: reconnectAttempts,
-                delayMs,
-                error: disconnect.error,
-              }),
-            ),
-          );
-          await gracefulStop();
-          try {
-            await sleepWithAbort(delayMs, socketAbortSignal);
-          } catch {
-            break;
-          }
-        } catch (err) {
-          if (isNonRecoverableSlackAuthError(err)) {
-            runtime.error?.(
-              `slack socket mode failed to start due to non-recoverable auth error — skipping channel (${formatUnknownError(err)})`,
-            );
-            throw err;
-          }
-          reconnectAttempts += 1;
-          const delayMs = computeBackoff(SLACK_SOCKET_RECONNECT_POLICY, reconnectAttempts);
-          runtime.error?.(
-            formatSlackSocketStartRetryMessage({
-              attempt: reconnectAttempts,
-              delayMs,
-              error: err,
-              sdkContext: socketModeLogger.getLastMessage(),
-            }),
-          );
-          try {
-            await sleepWithAbort(delayMs, socketAbortSignal);
-          } catch {
-            break;
-          }
-          continue;
-        }
+      // Every sharing account — creator included — waits passively until its
+      // OWN abort signal fires (per-account stop resolves this monitor
+      // promise immediately; the shared socket lives on for siblings) or the
+      // group's stopSignal fires (last member left, or the connection task
+      // died). Both listeners are removed on settle so neither signal
+      // accumulates stale callbacks.
+      if (!opts.abortSignal?.aborted && !group.stopSignal.aborted) {
+        await new Promise<void>((resolve) => {
+          const settle = () => {
+            opts.abortSignal?.removeEventListener("abort", settle);
+            group.stopSignal.removeEventListener("abort", settle);
+            resolve();
+          };
+          opts.abortSignal?.addEventListener("abort", settle, { once: true });
+          group.stopSignal.addEventListener("abort", settle, { once: true });
+        });
       }
+      // Surface a fatal connection-task failure (e.g. non-recoverable auth
+      // error) on every sharing account's monitor promise — unless this
+      // account was stopped on purpose, in which case it exits cleanly.
+      const stopError = group.getStopError();
+      if (stopError !== undefined && !opts.abortSignal?.aborted) {
+        throw stopError instanceof Error ? stopError : new Error(formatUnknownError(stopError));
+      }
+    } else if (slackMode === "socket") {
+      await runSlackSocketConnectionLoop({
+        app,
+        abortSignal: opts.abortSignal,
+        runtime,
+        setStatus: opts.setStatus,
+        getLastSdkLogMessage: socketModeLogger.getLastMessage,
+      });
     } else if (slackMode === "relay" && relayConfig) {
       runtime.log?.(
         `slack relay mode connecting to ${relayConfig.url} gateway_id:${relayConfig.gatewayId}`,
@@ -921,19 +842,16 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
     if (slackMode === "relay") {
       setSlackDefaultSendIdentity(account.accountId, undefined);
     }
-    socketAbortSignal?.removeEventListener("abort", stopOnAbort);
-    if (leaveSharedGroupOnAbort) {
-      opts.abortSignal?.removeEventListener("abort", leaveSharedGroupOnAbort);
-    }
+    opts.abortSignal?.removeEventListener("abort", stopOnAbort);
     unregisterSocketModeConnectionDiagnostics();
     unregisterHttpHandler?.();
     if (sharedGroup) {
-      if (sharedGroup.isOwner) {
-        // Backstop: unconditionally tear the group down regardless of
-        // remaining refcount, so a member can never be left waiting forever
-        // on a group whose owner coroutine stopped running for any reason
-        // (normal empty-group shutdown, or this account throwing a fatal
-        // error while siblings were still active).
+      if (sharedGroup.isOwner && !sharedGroup.hasConnectionTask()) {
+        // This account created the group but threw before the connection
+        // task existed: tear the group down so members are never left
+        // waiting forever on a stopSignal nobody will fire. Once the task
+        // runs, its own finally performs the teardown and a plain leave()
+        // below is correct even for the creator.
         forceStopSlackSharedSocketGroup({ appToken: appToken as string });
       } else {
         sharedGroup.leave();

--- a/extensions/slack/src/monitor/provider.ts
+++ b/extensions/slack/src/monitor/provider.ts
@@ -82,17 +82,27 @@ import {
 import { registerSlackMonitorSlashCommands } from "./slash.js";
 import type { MonitorSlackOpts } from "./types.js";
 
-let slackBoltInterop: SlackBoltResolvedExports | undefined;
+// Single-flight: cache the in-flight promise, not the resolved value, so
+// concurrent account startups (e.g. several accounts booting at once) share
+// one module resolution instead of racing the `undefined` check into several
+// parallel imports.
+let slackBoltInteropPromise: Promise<SlackBoltResolvedExports> | undefined;
 
-async function getSlackBoltInterop(): Promise<SlackBoltResolvedExports> {
-  if (!slackBoltInterop) {
-    const slackBoltModule = await import("@slack/bolt");
-    slackBoltInterop = resolveSlackBoltInterop({
-      defaultImport: slackBoltModule.default,
-      namespaceImport: slackBoltModule,
+function getSlackBoltInterop(): Promise<SlackBoltResolvedExports> {
+  slackBoltInteropPromise ??= import("@slack/bolt")
+    .then((slackBoltModule) =>
+      resolveSlackBoltInterop({
+        defaultImport: slackBoltModule.default,
+        namespaceImport: slackBoltModule,
+      }),
+    )
+    .catch((err: unknown) => {
+      // Don't cache a rejected resolution permanently — the pre-single-flight
+      // code retried the import on the next call, so keep that behavior.
+      slackBoltInteropPromise = undefined;
+      throw err;
     });
-  }
-  return slackBoltInterop;
+  return slackBoltInteropPromise;
 }
 
 type SlackBoltAppBundle = ReturnType<typeof createSlackBoltApp>;

--- a/extensions/slack/src/monitor/provider.ts
+++ b/extensions/slack/src/monitor/provider.ts
@@ -9,7 +9,7 @@ import {
 } from "openclaw/plugin-sdk/allow-from";
 import { CHANNEL_APPROVAL_NATIVE_RUNTIME_CONTEXT_CAPABILITY } from "openclaw/plugin-sdk/approval-handler-adapter-runtime";
 import { registerChannelRuntimeContext } from "openclaw/plugin-sdk/channel-runtime-context";
-import type { SessionScope } from "openclaw/plugin-sdk/config-contracts";
+import type { OpenClawConfig, SessionScope } from "openclaw/plugin-sdk/config-contracts";
 import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import { resolveTextChunkLimit } from "openclaw/plugin-sdk/reply-chunking";
 import { DEFAULT_GROUP_HISTORY_LIMIT } from "openclaw/plugin-sdk/reply-history";
@@ -28,12 +28,14 @@ import {
 } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { installRequestBodyLimitGuard } from "openclaw/plugin-sdk/webhook-request-guards";
 import {
+  listEnabledSlackAccounts,
   resolveSlackAccount,
   resolveSlackAccountAllowFrom,
   resolveSlackAccountDmPolicy,
 } from "../accounts.js";
 import { isSlackAnyNativeApprovalClientEnabled } from "../approval-native-gates.js";
 import { resolveSlackWebClientOptions } from "../client-options.js";
+import { createSlackWebClient } from "../client.js";
 import { normalizeSlackWebhookPath, registerSlackHttpHandler } from "../http/index.js";
 import { SLACK_TEXT_LIMIT } from "../limits.js";
 import { resolveSlackChannelAllowlist } from "../resolve-channels.js";
@@ -81,6 +83,11 @@ import {
   SLACK_SOCKET_RECONNECT_POLICY,
 } from "./reconnect-policy.js";
 import { setSlackDefaultSendIdentity } from "./send.runtime.js";
+import {
+  forceStopSlackSharedSocketGroup,
+  joinSlackSharedSocketGroup,
+  type SlackSharedSocketGroupHandle,
+} from "./shared-socket-group.js";
 import { registerSlackMonitorSlashCommands } from "./slash.js";
 import type { MonitorSlackOpts } from "./types.js";
 
@@ -96,6 +103,8 @@ async function getSlackBoltInterop(): Promise<SlackBoltResolvedExports> {
   }
   return slackBoltInterop;
 }
+
+type SlackBoltAppBundle = ReturnType<typeof createSlackBoltApp>;
 
 const loadSlackRelaySource = createLazyRuntimeModule(() => import("./relay-source.js"));
 
@@ -160,6 +169,23 @@ function parseApiAppIdFromAppToken(raw?: string) {
   }
   const match = /^xapp-\d-([a-z0-9]+)-/i.exec(token);
   return match?.[1]?.toUpperCase();
+}
+
+/**
+ * Counts enabled Socket Mode accounts (across the whole `channels.slack`
+ * config, not just the account currently booting) that resolve to the same
+ * app token as `appToken`. Grouping into a shared Socket Mode connection is
+ * only engaged when this is greater than 1 — a single account per app token
+ * takes the original, unmodified code path with zero behavioral change.
+ */
+function countEnabledSlackSocketAccountsSharingAppToken(params: {
+  cfg: OpenClawConfig;
+  appToken: string;
+}): number {
+  return listEnabledSlackAccounts(params.cfg).filter((candidate) => {
+    const mode = candidate.config.mode ?? "socket";
+    return mode === "socket" && candidate.appToken === params.appToken;
+  }).length;
 }
 
 function resolveSlackRelayConfig(params: { relay: unknown; accountId: string }): {
@@ -317,22 +343,105 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
   const mediaMaxBytes = (opts.mediaMaxMb ?? slackCfg.mediaMaxMb ?? 20) * 1024 * 1024;
   const removeAckAfterReply = cfg.messages?.removeAckAfterReply ?? false;
   const clientOptions = resolveSlackWebClientOptions();
-  const { app, receiver, socketModeLogger } = createSlackBoltApp({
-    interop: await getSlackBoltInterop(),
-    slackMode,
-    botToken,
-    appToken: slackMode === "socket" ? (appToken ?? undefined) : undefined,
-    signingSecret: slackMode === "http" ? (signingSecret ?? undefined) : undefined,
-    slackWebhookPath,
-    clientOptions: clientOptions as Record<string, unknown>,
-    ...(slackCfg.socketMode ? { socketMode: slackCfg.socketMode } : {}),
-  });
+  const expectedApiAppIdFromAppToken =
+    slackMode === "socket" ? parseApiAppIdFromAppToken(appToken) : undefined;
+
+  // Per-account Web API client bound to THIS account's own bot token. Used
+  // for the boot-time auth.test() call below and handed to the monitor
+  // context (ctx.client) so every inbound-side Web API call authenticates as
+  // this account, regardless of whether its Bolt App ends up shared with
+  // other accounts (see isSharedSlackSocketAppToken below).
+  const accountWebClient = createSlackWebClient(botToken, clientOptions);
+
+  // Slack Socket Mode delivers each event to exactly one open connection for
+  // an app (it load-balances, it does not fan out). If two accounts open two
+  // Socket Mode connections for the SAME app token, each drops ~half the
+  // traffic via shouldDropMismatchedSlackEvent's team_id filter. Detect that
+  // configuration up front (purely from static config, so every sibling
+  // account computes the same answer) and, only then, share a single Bolt
+  // App/connection across all of them. A single account per app token takes
+  // the untouched original code path below with no behavioral change.
+  const isSharedSlackSocketAppToken =
+    slackMode === "socket" &&
+    Boolean(appToken) &&
+    countEnabledSlackSocketAccountsSharingAppToken({ cfg, appToken: appToken ?? "" }) > 1;
+
+  let app: SlackBoltAppBundle["app"];
+  let receiver: SlackBoltAppBundle["receiver"];
+  let socketModeLogger: SlackBoltAppBundle["socketModeLogger"];
+  let sharedGroup: SlackSharedSocketGroupHandle<SlackBoltAppBundle> | null = null;
+
+  if (isSharedSlackSocketAppToken) {
+    sharedGroup = await joinSlackSharedSocketGroup<SlackBoltAppBundle>({
+      appToken: appToken as string,
+      accountId: account.accountId,
+      createAppBundle: async () =>
+        createSlackBoltApp({
+          interop: await getSlackBoltInterop(),
+          slackMode,
+          botToken,
+          appToken: appToken ?? undefined,
+          slackWebhookPath,
+          clientOptions: clientOptions as Record<string, unknown>,
+          ...(slackCfg.socketMode ? { socketMode: slackCfg.socketMode } : {}),
+        }),
+    });
+    ({ app, receiver, socketModeLogger } = sharedGroup.appBundle);
+    if (sharedGroup.justBecameShared) {
+      const sharedAccountCount = countEnabledSlackSocketAccountsSharingAppToken({
+        cfg,
+        appToken: appToken ?? "",
+      });
+      runtime.log?.(
+        `slack: sharing socket for ${sharedAccountCount} accounts on app ` +
+          `${expectedApiAppIdFromAppToken ?? "unknown"} (multi-workspace)`,
+      );
+    }
+  } else {
+    ({ app, receiver, socketModeLogger } = createSlackBoltApp({
+      interop: await getSlackBoltInterop(),
+      slackMode,
+      botToken,
+      appToken: slackMode === "socket" ? (appToken ?? undefined) : undefined,
+      signingSecret: slackMode === "http" ? (signingSecret ?? undefined) : undefined,
+      slackWebhookPath,
+      clientOptions: clientOptions as Record<string, unknown>,
+      ...(slackCfg.socketMode ? { socketMode: slackCfg.socketMode } : {}),
+    }));
+  }
+
+  // Only the group owner physically owns the shared App: members must never
+  // start/stop/diagnose a connection another account created. For a solo
+  // (non-shared) account, sharedGroup is null and every one of these checks
+  // degrades to the original single-account behavior.
+  const isSharedGroupMember = sharedGroup !== null && !sharedGroup.isOwner;
+  // The owner's connect/reconnect loop keys off the GROUP's stop signal
+  // (fires only once every member has left) rather than its own individual
+  // abortSignal, so the shared socket stays open for as long as any sibling
+  // account still needs it — even if this account's own abortSignal fires
+  // first. Non-shared accounts see sharedGroup === null and keep using their
+  // own abortSignal exactly as before.
+  const socketAbortSignal =
+    sharedGroup && sharedGroup.isOwner ? sharedGroup.stopSignal : opts.abortSignal;
+  const leaveSharedGroupOnAbort = sharedGroup
+    ? () => {
+        sharedGroup?.leave();
+      }
+    : undefined;
+  if (leaveSharedGroupOnAbort) {
+    opts.abortSignal?.addEventListener("abort", leaveSharedGroupOnAbort, { once: true });
+  }
 
   // Pre-set shuttingDown on the SocketModeClient before app.stop() to prevent
   // a race where the library's internal ping timeout fires disconnect() before
   // shuttingDown is set, causing orphaned reconnects with leaked ping intervals.
   // See: openclaw/openclaw#56508
   const gracefulStop = async () => {
+    if (isSharedGroupMember) {
+      // Never stop an app this account doesn't own; the owner's own
+      // gracefulStop (driven by the group stop signal) handles it.
+      return;
+    }
     await gracefulStopSlackApp(app);
   };
 
@@ -362,8 +471,11 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
         }
       : null;
   let unregisterHttpHandler: (() => void) | null = null;
+  // Only the owner (or a non-shared solo account) registers diagnostics: a
+  // shared group has exactly one physical connection, so a member
+  // registering its own listener on the same emitter would be redundant.
   const unregisterSocketModeConnectionDiagnostics =
-    slackMode === "socket"
+    slackMode === "socket" && !isSharedGroupMember
       ? registerSlackSocketModeConnectionDiagnostics({
           app,
           onSharedConnection: (activeConnections) => {
@@ -374,14 +486,16 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
 
   let botUserId = "";
   let botId = "";
-  const expectedApiAppIdFromAppToken =
-    slackMode === "socket" ? parseApiAppIdFromAppToken(appToken) : undefined;
   let authTestFailed = false;
   let authTestError: string | undefined;
   let authIdentityWarning: string | undefined;
   let authTestIdentity: SlackAuthTestIdentity | undefined;
   try {
-    const auth = await app.client.auth.test();
+    // Always authenticate via this account's OWN per-account client, never
+    // app.client: when the App is shared, app.client's default identity is
+    // whichever account created it (the group owner), which would make every
+    // member account boot up believing it is the owner's team/app.
+    const auth = await accountWebClient.auth.test();
     const authUserId = normalizeOptionalString(auth.user_id) ?? "";
     botId = normalizeOptionalString((auth as { bot_id?: string }).bot_id) ?? "";
     // Slack documents bot_id only for bot-token identities. Never treat the user behind a
@@ -433,6 +547,7 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
     accountId: account.accountId,
     botToken,
     app,
+    client: accountWebClient,
     runtime,
     channelRuntime: opts.channelRuntime,
     botUserId,
@@ -654,21 +769,44 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
   }
 
   const stopOnAbort = () => {
-    if (opts.abortSignal?.aborted && slackMode === "socket") {
+    if (socketAbortSignal?.aborted && slackMode === "socket") {
       void gracefulStop();
     }
   };
-  opts.abortSignal?.addEventListener("abort", stopOnAbort, { once: true });
+  socketAbortSignal?.addEventListener("abort", stopOnAbort, { once: true });
 
   try {
-    if (slackMode === "socket") {
+    if (slackMode === "socket" && isSharedGroupMember && sharedGroup) {
+      // This account joined an existing shared socket group as a member, not
+      // its owner: its event/slash handlers are already registered on the
+      // shared App above, but the group owner's coroutine is the one that
+      // actually starts/reconnects/stops the connection. Wait passively
+      // until either this account's own abortSignal fires (normal per-account
+      // stop) or the group's stopSignal fires (the owner tore the whole
+      // group down, e.g. on a fatal non-recoverable auth error), whichever
+      // comes first.
+      const group = sharedGroup;
+      if (!opts.abortSignal?.aborted && !group.stopSignal.aborted) {
+        await new Promise<void>((resolve) => {
+          const onOwnAbort = () => resolve();
+          const onGroupStop = () => resolve();
+          opts.abortSignal?.addEventListener("abort", onOwnAbort, { once: true });
+          group.stopSignal.addEventListener("abort", onGroupStop, { once: true });
+        });
+      }
+    } else if (slackMode === "socket") {
       let reconnectAttempts = 0;
       let hasLoggedSocketConnected = false;
-      while (!opts.abortSignal?.aborted) {
+      // socketAbortSignal itself never gets reassigned, but its .aborted getter flips when
+      // abort() fires externally (this account's own signal, or the shared group's stop
+      // signal); same pattern as the original opts.abortSignal?.aborted check this loop is
+      // based on.
+      // oxlint-disable-next-line eslint/no-unmodified-loop-condition
+      while (!socketAbortSignal?.aborted) {
         try {
           const disconnect = await startSlackSocketAndWaitForDisconnect({
             app,
-            abortSignal: opts.abortSignal,
+            abortSignal: socketAbortSignal,
             onStarted: () => {
               reconnectAttempts = 0;
               publishSlackConnectedStatus(opts.setStatus);
@@ -681,7 +819,7 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
           if (!disconnect) {
             break;
           }
-          if (opts.abortSignal?.aborted) {
+          if (socketAbortSignal?.aborted) {
             break;
           }
           publishSlackDisconnectedStatus(opts.setStatus, disconnect.error);
@@ -710,7 +848,7 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
           );
           await gracefulStop();
           try {
-            await sleepWithAbort(delayMs, opts.abortSignal);
+            await sleepWithAbort(delayMs, socketAbortSignal);
           } catch {
             break;
           }
@@ -732,7 +870,7 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
             }),
           );
           try {
-            await sleepWithAbort(delayMs, opts.abortSignal);
+            await sleepWithAbort(delayMs, socketAbortSignal);
           } catch {
             break;
           }
@@ -767,9 +905,24 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
     if (slackMode === "relay") {
       setSlackDefaultSendIdentity(account.accountId, undefined);
     }
-    opts.abortSignal?.removeEventListener("abort", stopOnAbort);
+    socketAbortSignal?.removeEventListener("abort", stopOnAbort);
+    if (leaveSharedGroupOnAbort) {
+      opts.abortSignal?.removeEventListener("abort", leaveSharedGroupOnAbort);
+    }
     unregisterSocketModeConnectionDiagnostics();
     unregisterHttpHandler?.();
+    if (sharedGroup) {
+      if (sharedGroup.isOwner) {
+        // Backstop: unconditionally tear the group down regardless of
+        // remaining refcount, so a member can never be left waiting forever
+        // on a group whose owner coroutine stopped running for any reason
+        // (normal empty-group shutdown, or this account throwing a fatal
+        // error while siblings were still active).
+        forceStopSlackSharedSocketGroup({ appToken: appToken as string });
+      } else {
+        sharedGroup.leave();
+      }
+    }
     await gracefulStop();
   }
 }

--- a/extensions/slack/src/monitor/provider.ts
+++ b/extensions/slack/src/monitor/provider.ts
@@ -354,16 +354,6 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
         }),
     });
     ({ app, receiver, socketModeLogger } = sharedGroup.appBundle);
-    if (sharedGroup.justBecameShared) {
-      const sharedAccountCount = countEnabledSlackSocketAccountsSharingAppToken({
-        cfg,
-        appToken: appToken ?? "",
-      });
-      runtime.log?.(
-        `slack: sharing socket for ${sharedAccountCount} accounts on app ` +
-          `${expectedApiAppIdFromAppToken ?? "unknown"} (multi-workspace)`,
-      );
-    }
   } else {
     ({ app, receiver, socketModeLogger } = createSlackBoltApp({
       interop: await getSlackBoltInterop(),
@@ -402,14 +392,28 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
   };
   opts.abortSignal?.addEventListener("abort", stopOnAbort, { once: true });
 
-  // From here on any thrown error must release the shared group reservation
-  // (see the finally at the end of this function): a creator that throws
-  // before its connection task exists tears the whole group down so members
-  // are never left waiting on a stopSignal nobody will fire, and a member
-  // that throws simply leaves.
+  // Everything between joining the shared group (above; only non-throwing
+  // statements may sit in between) and this try runs under the finally at the
+  // end of this function, so any thrown error releases the group
+  // reservation: a creator that throws before its connection task exists
+  // tears the whole group down so members are never left waiting on a
+  // stopSignal nobody will fire, and a member that throws simply leaves.
   let unregisterHttpHandler: (() => void) | null = null;
   let unregisterSocketModeConnectionDiagnostics: () => void = () => {};
   try {
+    if (sharedGroup?.justBecameShared) {
+      // Deliberately inside the try: runtime.log is caller-supplied and may
+      // throw, and a member that dies here must still leave the group.
+      const sharedAccountCount = countEnabledSlackSocketAccountsSharingAppToken({
+        cfg,
+        appToken: appToken ?? "",
+      });
+      runtime.log?.(
+        `slack: sharing socket for ${sharedAccountCount} accounts on app ` +
+          `${expectedApiAppIdFromAppToken ?? "unknown"} (multi-workspace)`,
+      );
+    }
+
     const slackHttpHandler =
       slackMode === "http" && receiver
         ? async (req: IncomingMessage, res: ServerResponse) => {

--- a/extensions/slack/src/monitor/provider.ts
+++ b/extensions/slack/src/monitor/provider.ts
@@ -9,7 +9,7 @@ import {
 } from "openclaw/plugin-sdk/allow-from";
 import { CHANNEL_APPROVAL_NATIVE_RUNTIME_CONTEXT_CAPABILITY } from "openclaw/plugin-sdk/approval-handler-adapter-runtime";
 import { registerChannelRuntimeContext } from "openclaw/plugin-sdk/channel-runtime-context";
-import type { OpenClawConfig, SessionScope } from "openclaw/plugin-sdk/config-contracts";
+import type { SessionScope } from "openclaw/plugin-sdk/config-contracts";
 import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import { resolveTextChunkLimit } from "openclaw/plugin-sdk/reply-chunking";
 import { DEFAULT_GROUP_HISTORY_LIMIT } from "openclaw/plugin-sdk/reply-history";
@@ -23,7 +23,6 @@ import {
 } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { installRequestBodyLimitGuard } from "openclaw/plugin-sdk/webhook-request-guards";
 import {
-  listEnabledSlackAccounts,
   resolveSlackAccount,
   resolveSlackAccountAllowFrom,
   resolveSlackAccountDmPolicy,
@@ -60,10 +59,18 @@ import {
 import { registerSlackMonitorEvents } from "./events.js";
 import { createSlackMessageHandler } from "./message-handler.js";
 import {
+  createSlackGracefulStop,
+  logSlackSharedSocketGroupBootWarnings,
+  resolveSlackSharedSocketGroupParticipation,
+  resolveSlackSocketAppBundle,
+  runSlackSocketModeConnectionForAccount,
+  settleSlackSharedSocketGroupMembership,
+  warnSlackSharedSocketGroupUnresolvedTeamId,
+} from "./provider-shared-socket.js";
+import {
   createSlackBoltApp,
   formatSlackChannelResolved,
   formatSlackUserResolved,
-  gracefulStopSlackApp,
   resolveSlackBoltInterop,
   type SlackBoltResolvedExports,
 } from "./provider-support.js";
@@ -73,12 +80,6 @@ import {
   registerSlackSocketModeConnectionDiagnostics,
 } from "./reconnect-policy.js";
 import { setSlackDefaultSendIdentity } from "./send.runtime.js";
-import {
-  forceStopSlackSharedSocketGroup,
-  joinSlackSharedSocketGroup,
-  runSlackSocketConnectionLoop,
-  type SlackSharedSocketGroupHandle,
-} from "./shared-socket-group.js";
 import { registerSlackMonitorSlashCommands } from "./slash.js";
 import type { MonitorSlackOpts } from "./types.js";
 
@@ -146,35 +147,6 @@ function parseApiAppIdFromAppToken(raw?: string) {
   }
   const match = /^xapp-\d-([a-z0-9]+)-/i.exec(token);
   return match?.[1]?.toUpperCase();
-}
-
-/**
- * Counts enabled Socket Mode accounts (across the whole `channels.slack`
- * config, not just the account currently booting) that resolve to the same
- * app token as `appToken`. Grouping into a shared Socket Mode connection is
- * only engaged when this is greater than 1 — a single account per app token
- * takes the original, unmodified code path with zero behavioral change.
- *
- * Enterprise Grid org installs are excluded: they resolve teamId as ""
- * (resolveSlackInstallationIdentity's "enterprise" kind never carries a
- * teamId), so they can never pass shouldDropMismatchedSlackEvent's per-event
- * team_id demux once inside a shared group — every inbound event would be
- * dropped fail-closed. They always take the dedicated, non-shared connection
- * regardless of how many siblings share their app token, so they must not
- * count toward (or be counted as) a sharing group.
- */
-function countEnabledSlackSocketAccountsSharingAppToken(params: {
-  cfg: OpenClawConfig;
-  appToken: string;
-}): number {
-  return listEnabledSlackAccounts(params.cfg).filter((candidate) => {
-    const mode = candidate.config.mode ?? "socket";
-    return (
-      mode === "socket" &&
-      candidate.appToken === params.appToken &&
-      candidate.config.enterpriseOrgInstall !== true
-    );
-  }).length;
 }
 
 function resolveSlackRelayConfig(params: { relay: unknown; accountId: string }): {
@@ -342,69 +314,42 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
   // other accounts (see isSharedSlackSocketAppToken below).
   const accountWebClient = createSlackWebClient(botToken, clientOptions);
 
-  // Slack Socket Mode delivers each event to exactly one open connection for
-  // an app (it load-balances, it does not fan out). If two accounts open two
-  // Socket Mode connections for the SAME app token, each drops ~half the
-  // traffic via shouldDropMismatchedSlackEvent's team_id filter. Detect that
-  // configuration up front (purely from static config, so every sibling
-  // account computes the same answer) and, only then, share a single Bolt
-  // App/connection across all of them. A single account per app token takes
-  // the untouched original code path below with no behavioral change.
-  //
-  // Enterprise Grid org installs are excluded from sharing (see
-  // countEnabledSlackSocketAccountsSharingAppToken): their teamId always
-  // resolves to "", which would make the shared group's fail-closed
-  // unresolved-teamId guard drop every inbound event for them. They keep
-  // using this dedicated, non-shared connection even if a sibling account
-  // reuses the same app token.
-  const isSharedSlackSocketAppToken =
-    !enterpriseOrgInstall &&
-    slackMode === "socket" &&
-    Boolean(appToken) &&
-    countEnabledSlackSocketAccountsSharingAppToken({ cfg, appToken: appToken ?? "" }) > 1;
-  // True when this enterprise account's app token IS shared by other
-  // (non-enterprise) accounts — i.e. it would have joined a shared group were
-  // it not an enterprise install. Drives a single boot-time warning so the
-  // dedicated-connection fallback above is not silent.
-  const enterpriseExcludedFromSharedSocketGroup =
-    enterpriseOrgInstall &&
-    slackMode === "socket" &&
-    Boolean(appToken) &&
-    countEnabledSlackSocketAccountsSharingAppToken({ cfg, appToken: appToken ?? "" }) > 0;
-
-  let app: SlackBoltAppBundle["app"];
-  let receiver: SlackBoltAppBundle["receiver"];
-  let socketModeLogger: SlackBoltAppBundle["socketModeLogger"];
-  let sharedGroup: SlackSharedSocketGroupHandle<SlackBoltAppBundle> | null = null;
-
-  if (isSharedSlackSocketAppToken) {
-    sharedGroup = await joinSlackSharedSocketGroup<SlackBoltAppBundle>({
-      appToken: appToken as string,
-      accountId: account.accountId,
-      createAppBundle: async () =>
-        createSlackBoltApp({
-          interop: await getSlackBoltInterop(),
-          slackMode,
-          botToken,
-          appToken: appToken ?? undefined,
-          slackWebhookPath,
-          clientOptions: clientOptions as Record<string, unknown>,
-          ...(slackCfg.socketMode ? { socketMode: slackCfg.socketMode } : {}),
-        }),
-    });
-    ({ app, receiver, socketModeLogger } = sharedGroup.appBundle);
-  } else {
-    ({ app, receiver, socketModeLogger } = createSlackBoltApp({
-      interop: await getSlackBoltInterop(),
+  // See provider-shared-socket.ts's resolveSlackSharedSocketGroupParticipation.
+  const { isSharedSlackSocketAppToken, enterpriseExcludedFromSharedSocketGroup } =
+    resolveSlackSharedSocketGroupParticipation({
+      cfg,
+      enterpriseOrgInstall,
       slackMode,
-      botToken,
-      appToken: slackMode === "socket" ? (appToken ?? undefined) : undefined,
-      signingSecret: slackMode === "http" ? (signingSecret ?? undefined) : undefined,
-      slackWebhookPath,
-      clientOptions: clientOptions as Record<string, unknown>,
-      ...(slackCfg.socketMode ? { socketMode: slackCfg.socketMode } : {}),
-    }));
-  }
+      appToken,
+    });
+
+  const { appBundle, sharedGroup } = await resolveSlackSocketAppBundle<SlackBoltAppBundle>({
+    isSharedSlackSocketAppToken,
+    appToken,
+    accountId: account.accountId,
+    createSharedAppBundle: async () =>
+      createSlackBoltApp({
+        interop: await getSlackBoltInterop(),
+        slackMode,
+        botToken,
+        appToken: appToken ?? undefined,
+        slackWebhookPath,
+        clientOptions: clientOptions as Record<string, unknown>,
+        ...(slackCfg.socketMode ? { socketMode: slackCfg.socketMode } : {}),
+      }),
+    createSoloAppBundle: async () =>
+      createSlackBoltApp({
+        interop: await getSlackBoltInterop(),
+        slackMode,
+        botToken,
+        appToken: slackMode === "socket" ? (appToken ?? undefined) : undefined,
+        signingSecret: slackMode === "http" ? (signingSecret ?? undefined) : undefined,
+        slackWebhookPath,
+        clientOptions: clientOptions as Record<string, unknown>,
+        ...(slackCfg.socketMode ? { socketMode: slackCfg.socketMode } : {}),
+      }),
+  });
+  const { app, receiver, socketModeLogger } = appBundle;
 
   // Members of a shared group must never start/stop/diagnose a connection
   // another account created. For a solo (non-shared) account, sharedGroup is
@@ -412,18 +357,8 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
   // single-account behavior.
   const isSharedGroupMember = sharedGroup !== null && !sharedGroup.isOwner;
 
-  // Pre-set shuttingDown on the SocketModeClient before app.stop() to prevent
-  // a race where the library's internal ping timeout fires disconnect() before
-  // shuttingDown is set, causing orphaned reconnects with leaked ping intervals.
-  // See: openclaw/openclaw#56508
-  const gracefulStop = async () => {
-    if (sharedGroup) {
-      // The group-owned connection task stops the shared App; individual
-      // accounts (creator included) never stop an App siblings may be using.
-      return;
-    }
-    await gracefulStopSlackApp(app);
-  };
+  // See provider-shared-socket.ts's createSlackGracefulStop (openclaw/openclaw#56508).
+  const gracefulStop = createSlackGracefulStop({ app, sharedGroup });
   const stopOnAbort = () => {
     if (opts.abortSignal?.aborted && slackMode === "socket") {
       void gracefulStop();
@@ -440,29 +375,18 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
   let unregisterHttpHandler: (() => void) | null = null;
   let unregisterSocketModeConnectionDiagnostics: () => void = () => {};
   try {
-    if (sharedGroup?.justBecameShared) {
-      // Deliberately inside the try: runtime.log is caller-supplied and may
-      // throw, and a member that dies here must still leave the group.
-      const sharedAccountCount = countEnabledSlackSocketAccountsSharingAppToken({
-        cfg,
-        appToken: appToken ?? "",
-      });
-      runtime.log?.(
-        `slack: sharing socket for ${sharedAccountCount} accounts on app ` +
-          `${expectedApiAppIdFromAppToken ?? "unknown"} (multi-workspace)`,
-      );
-    }
-
-    if (enterpriseExcludedFromSharedSocketGroup) {
-      // Deliberately inside the try, same reasoning as above: runtime.log may
-      // throw and this account (a solo, non-shared connection) must still
-      // unwind cleanly through the existing finally below.
-      runtime.log?.(
-        warn(
-          `slack account ${account.accountId}: enterprise org install cannot join a shared Socket Mode group; using a dedicated connection`,
-        ),
-      );
-    }
+    // Deliberately inside the try: runtime.log is caller-supplied and may
+    // throw, and an account that dies here must still leave the group /
+    // unwind cleanly through the existing finally below.
+    logSlackSharedSocketGroupBootWarnings({
+      sharedGroup,
+      enterpriseExcludedFromSharedSocketGroup,
+      cfg,
+      appToken,
+      expectedApiAppIdFromAppToken,
+      accountId: account.accountId,
+      runtime,
+    });
 
     const slackHttpHandler =
       slackMode === "http" && receiver
@@ -561,15 +485,12 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
       );
     }
 
-    if (isSharedSlackSocketAppToken && !teamId) {
-      runtime.log?.(
-        warn(
-          `[${account.accountId}] slack: teamId unresolved on a shared socket group (auth.test failed or returned no team_id); ` +
-            "ALL events for this account will be dropped to avoid acting on sibling workspaces' traffic — " +
-            "fix the bot token and restart",
-        ),
-      );
-    }
+    warnSlackSharedSocketGroupUnresolvedTeamId({
+      isSharedSlackSocketAppToken,
+      teamId,
+      accountId: account.accountId,
+      runtime,
+    });
 
     const ctx = createSlackMonitorContext({
       cfg,
@@ -806,63 +727,11 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
       })();
     }
 
-    if (slackMode === "socket" && sharedGroup) {
-      const group = sharedGroup;
-      if (group.isOwner) {
-        // The connection runs as a GROUP-owned task, decoupled from this
-        // account's lifecycle: it keeps serving sibling accounts after this
-        // creator account is stopped, and only ends once every member has
-        // left (or a fatal error kills it). It intentionally keeps using the
-        // CREATOR's runtime for logs and the creator's setStatus for
-        // connection status even after the creator account itself stops.
-        group.startConnectionTask(async () => {
-          // Pre-set shuttingDown as soon as the group stops (same race guard
-          // as stopOnAbort above, but keyed to the group's lifetime).
-          const stopOnGroupStop = () => {
-            void gracefulStopSlackApp(app);
-          };
-          group.stopSignal.addEventListener("abort", stopOnGroupStop, { once: true });
-          try {
-            await runSlackSocketConnectionLoop({
-              app,
-              abortSignal: group.stopSignal,
-              runtime,
-              setStatus: opts.setStatus,
-              getLastSdkLogMessage: socketModeLogger.getLastMessage,
-            });
-          } finally {
-            group.stopSignal.removeEventListener("abort", stopOnGroupStop);
-            await gracefulStopSlackApp(app);
-          }
-        });
-      }
-      // Every sharing account — creator included — waits passively until its
-      // OWN abort signal fires (per-account stop resolves this monitor
-      // promise immediately; the shared socket lives on for siblings) or the
-      // group's stopSignal fires (last member left, or the connection task
-      // died). Both listeners are removed on settle so neither signal
-      // accumulates stale callbacks.
-      if (!opts.abortSignal?.aborted && !group.stopSignal.aborted) {
-        await new Promise<void>((resolve) => {
-          const settle = () => {
-            opts.abortSignal?.removeEventListener("abort", settle);
-            group.stopSignal.removeEventListener("abort", settle);
-            resolve();
-          };
-          opts.abortSignal?.addEventListener("abort", settle, { once: true });
-          group.stopSignal.addEventListener("abort", settle, { once: true });
-        });
-      }
-      // Surface a fatal connection-task failure (e.g. non-recoverable auth
-      // error) on every sharing account's monitor promise — unless this
-      // account was stopped on purpose, in which case it exits cleanly.
-      const stopError = group.getStopError();
-      if (stopError !== undefined && !opts.abortSignal?.aborted) {
-        throw stopError instanceof Error ? stopError : new Error(formatUnknownError(stopError));
-      }
-    } else if (slackMode === "socket") {
-      await runSlackSocketConnectionLoop({
+    if (slackMode === "socket") {
+      // See provider-shared-socket.ts's runSlackSocketModeConnectionForAccount.
+      await runSlackSocketModeConnectionForAccount({
         app,
+        sharedGroup,
         abortSignal: opts.abortSignal,
         runtime,
         setStatus: opts.setStatus,
@@ -899,18 +768,8 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
     opts.abortSignal?.removeEventListener("abort", stopOnAbort);
     unregisterSocketModeConnectionDiagnostics();
     unregisterHttpHandler?.();
-    if (sharedGroup) {
-      if (sharedGroup.isOwner && !sharedGroup.hasConnectionTask()) {
-        // This account created the group but threw before the connection
-        // task existed: tear the group down so members are never left
-        // waiting forever on a stopSignal nobody will fire. Once the task
-        // runs, its own finally performs the teardown and a plain leave()
-        // below is correct even for the creator.
-        forceStopSlackSharedSocketGroup({ appToken: appToken as string });
-      } else {
-        sharedGroup.leave();
-      }
-    }
+    // See provider-shared-socket.ts's settleSlackSharedSocketGroupMembership.
+    settleSlackSharedSocketGroupMembership({ sharedGroup, appToken: appToken as string });
     await gracefulStop();
   }
 }

--- a/extensions/slack/src/monitor/reconnect-policy.ts
+++ b/extensions/slack/src/monitor/reconnect-policy.ts
@@ -159,6 +159,30 @@ export function isNonRecoverableSlackAuthError(error: unknown): boolean {
   return SLACK_AUTH_ERROR_RE.test(formatUnknownError(error, ""));
 }
 
+export function formatSlackSocketReconnectMessage(params: {
+  event: string;
+  attempt: number;
+  delayMs: number;
+  error?: unknown;
+}) {
+  const suffix = params.error ? ` (${formatUnknownError(params.error)})` : "";
+  return `slack socket disconnected (${params.event}); reconnecting in ${Math.round(params.delayMs / 1000)}s (attempt ${params.attempt}/∞)${suffix}`;
+}
+
+export function formatSlackSocketStartRetryMessage(params: {
+  attempt: number;
+  delayMs: number;
+  error: unknown;
+  sdkContext?: string;
+}) {
+  const reason = formatUnknownError(
+    params.error,
+    "Slack Socket Mode start failed without error detail",
+  );
+  const sdkContext = params.sdkContext?.trim() ? `; last SDK log: ${params.sdkContext.trim()}` : "";
+  return `slack socket mode failed to start; retry ${params.attempt}/∞ in ${Math.round(params.delayMs / 1000)}s reason="${reason}${sdkContext}"`;
+}
+
 export function formatUnknownError(error: unknown, fallback = NO_ERROR_DETAIL): string {
   return formatSlackError(error, fallback);
 }

--- a/extensions/slack/src/monitor/shared-socket-group.ts
+++ b/extensions/slack/src/monitor/shared-socket-group.ts
@@ -1,0 +1,170 @@
+// Slack plugin module implements shared Socket Mode group behavior.
+//
+// Slack delivers Socket Mode events to exactly one of the open connections for
+// a given app (it load-balances across connections, it does not fan events
+// out to all of them). When the SAME Slack app (identified by its app token)
+// is installed into multiple workspaces and configured as multiple OpenClaw
+// accounts, opening one Socket Mode connection per account means Slack picks
+// a single connection per event and roughly half the traffic lands on an
+// account whose `shouldDropMismatchedSlackEvent` team/app filter throws it
+// away — the other workspace's events are silently lost.
+//
+// The fix is to open exactly one Socket Mode connection (one Bolt App) per
+// distinct app token, and register every sharing account's event handlers on
+// that single App. Bolt invokes every registered listener for a matching
+// event, so the existing per-account `shouldDropMismatchedSlackEvent` filter
+// already demultiplexes correctly once handlers from multiple accounts sit on
+// the same App.
+//
+// This module tracks that sharing at the process level: the first account to
+// reference a given app token creates the App and becomes its "owner" for the
+// lifetime of the group; every later account with the same app token joins as
+// a member and reuses the owner's App/receiver instead of opening a second
+// socket. Membership is reference-counted so the shared App is stopped
+// exactly once, only after every member has left the group — regardless of
+// which member (owner or not) happens to leave last, and regardless of
+// whether the owner's own account is stopped independently while other
+// members are still running (each account has its own AbortController; see
+// src/gateway/server-channels.ts).
+import { createSlackTokenCacheKey } from "../client.js";
+
+const SLACK_SHARED_SOCKET_GROUPS_KEY = Symbol.for("openclaw.slack.sharedSocketGroups");
+
+type SlackSharedSocketGroupState<TAppBundle> = {
+  key: string;
+  ownerAccountId: string;
+  memberAccountIds: Set<string>;
+  appBundlePromise: Promise<TAppBundle>;
+  stopController: AbortController;
+};
+
+type SlackSharedSocketGroupRegistry = Map<string, SlackSharedSocketGroupState<unknown>>;
+
+function registryMap(): SlackSharedSocketGroupRegistry {
+  const proc = process as NodeJS.Process & {
+    [SLACK_SHARED_SOCKET_GROUPS_KEY]?: SlackSharedSocketGroupRegistry;
+  };
+  proc[SLACK_SHARED_SOCKET_GROUPS_KEY] ??= new Map();
+  return proc[SLACK_SHARED_SOCKET_GROUPS_KEY];
+}
+
+export type SlackSharedSocketGroupHandle<TAppBundle> = {
+  /** The Bolt App/receiver bundle to register listeners on and (owner only) start/stop. */
+  appBundle: TAppBundle;
+  /** True if this account created the group (and therefore owns start/stop). */
+  isOwner: boolean;
+  /** True the moment a second account joins an existing solo group (log-once signal). */
+  justBecameShared: boolean;
+  /** Total accounts currently sharing this app token. */
+  memberCount: number;
+  /**
+   * Aborts once every member account has left the group (or the owner forces
+   * a teardown). The owner's connect/reconnect loop should key off this
+   * signal instead of its own individual account abortSignal so the shared
+   * socket stays open for as long as ANY member still needs it.
+   */
+  stopSignal: AbortSignal;
+  /** Removes this account from the group; aborts stopSignal if it was last. */
+  leave: () => void;
+};
+
+/**
+ * Joins (or creates) the shared Socket Mode group for `appToken`. Concurrent
+ * joins for the same app token are race-free: the registry slot is reserved
+ * synchronously before `createAppBundle` is awaited, so a second account
+ * arriving while the first account's App is still being constructed will
+ * always see the in-flight reservation and await the same instance rather
+ * than creating a competing one.
+ */
+export async function joinSlackSharedSocketGroup<TAppBundle>(params: {
+  appToken: string;
+  accountId: string;
+  createAppBundle: () => Promise<TAppBundle>;
+}): Promise<SlackSharedSocketGroupHandle<TAppBundle>> {
+  const key = createSlackTokenCacheKey(params.appToken);
+  const reg = registryMap();
+  const existing = reg.get(key);
+
+  if (existing) {
+    existing.memberAccountIds.add(params.accountId);
+    const appBundle = (await existing.appBundlePromise) as TAppBundle;
+    const memberCount = existing.memberAccountIds.size;
+    return {
+      appBundle,
+      isOwner: false,
+      justBecameShared: memberCount === 2,
+      memberCount,
+      stopSignal: existing.stopController.signal,
+      leave: () => leaveGroup(key, params.accountId),
+    };
+  }
+
+  const memberAccountIds = new Set<string>([params.accountId]);
+  const stopController = new AbortController();
+  const appBundlePromise = params.createAppBundle();
+  const state: SlackSharedSocketGroupState<unknown> = {
+    key,
+    ownerAccountId: params.accountId,
+    memberAccountIds,
+    appBundlePromise,
+    stopController,
+  };
+  reg.set(key, state);
+
+  let appBundle: TAppBundle;
+  try {
+    appBundle = await appBundlePromise;
+  } catch (err) {
+    // Creation failed before anyone else could observe it: release the
+    // reservation so a subsequent attempt (e.g. after a config fix) can retry
+    // cleanly instead of being stuck awaiting a permanently-rejected promise.
+    if (reg.get(key) === state) {
+      reg.delete(key);
+    }
+    throw err;
+  }
+
+  return {
+    appBundle,
+    isOwner: true,
+    justBecameShared: false,
+    memberCount: memberAccountIds.size,
+    stopSignal: stopController.signal,
+    leave: () => leaveGroup(key, params.accountId),
+  };
+}
+
+function leaveGroup(key: string, accountId: string): void {
+  const reg = registryMap();
+  const existing = reg.get(key);
+  if (!existing) {
+    return;
+  }
+  existing.memberAccountIds.delete(accountId);
+  if (existing.memberAccountIds.size === 0) {
+    reg.delete(key);
+    existing.stopController.abort();
+  }
+}
+
+/**
+ * Unconditionally tears down the group for `appToken`, aborting `stopSignal`
+ * regardless of remaining membership. Intended as a backstop the owner calls
+ * on its own way out (including on a thrown/fatal error) so members can never
+ * be left waiting forever on a group whose owner coroutine has already
+ * stopped running the shared connection.
+ */
+export function forceStopSlackSharedSocketGroup(params: { appToken: string }): void {
+  const key = createSlackTokenCacheKey(params.appToken);
+  const reg = registryMap();
+  const existing = reg.get(key);
+  if (!existing) {
+    return;
+  }
+  reg.delete(key);
+  existing.stopController.abort();
+}
+
+export function resetSlackSharedSocketGroupsForTests(): void {
+  registryMap().clear();
+}

--- a/extensions/slack/src/monitor/shared-socket-group.ts
+++ b/extensions/slack/src/monitor/shared-socket-group.ts
@@ -17,16 +17,39 @@
 // the same App.
 //
 // This module tracks that sharing at the process level: the first account to
-// reference a given app token creates the App and becomes its "owner" for the
-// lifetime of the group; every later account with the same app token joins as
-// a member and reuses the owner's App/receiver instead of opening a second
-// socket. Membership is reference-counted so the shared App is stopped
-// exactly once, only after every member has left the group — regardless of
-// which member (owner or not) happens to leave last, and regardless of
-// whether the owner's own account is stopped independently while other
-// members are still running (each account has its own AbortController; see
-// src/gateway/server-channels.ts).
+// reference a given app token creates the App and becomes the group's
+// creator; every later account with the same app token joins as a member and
+// reuses that App/receiver instead of opening a second socket.
+//
+// The connection itself runs as a GROUP-OWNED task (startConnectionTask),
+// deliberately decoupled from any single account's lifecycle: every sharing
+// account — creator included — just registers handlers and then waits
+// passively on its own abort signal, so a per-account stop resolves that
+// account's monitor promise immediately (the gateway stops accounts
+// independently; see src/gateway/server-channels.ts) while the shared socket
+// keeps serving the remaining accounts. Membership is reference-counted; the
+// group, and with it the connection task, ends only after every member has
+// left — regardless of which member leaves last.
+import {
+  computeBackoff,
+  sleepWithAbort,
+  warn,
+  type RuntimeEnv,
+} from "openclaw/plugin-sdk/runtime-env";
 import { createSlackTokenCacheKey } from "../client.js";
+import {
+  gracefulStopSlackApp,
+  publishSlackConnectedStatus,
+  publishSlackDisconnectedStatus,
+  startSlackSocketAndWaitForDisconnect,
+} from "./provider-support.js";
+import {
+  formatSlackSocketReconnectMessage,
+  formatSlackSocketStartRetryMessage,
+  formatUnknownError,
+  isNonRecoverableSlackAuthError,
+  SLACK_SOCKET_RECONNECT_POLICY,
+} from "./reconnect-policy.js";
 
 const SLACK_SHARED_SOCKET_GROUPS_KEY = Symbol.for("openclaw.slack.sharedSocketGroups");
 
@@ -36,6 +59,11 @@ type SlackSharedSocketGroupState<TAppBundle> = {
   memberAccountIds: Set<string>;
   appBundlePromise: Promise<TAppBundle>;
   stopController: AbortController;
+  connectionTaskStarted: boolean;
+  // Fatal error that tore the group down (e.g. a non-recoverable auth
+  // failure in the connection task). Recorded before stopSignal fires so
+  // accounts waking from their passive wait can rethrow it.
+  stopError?: unknown;
 };
 
 type SlackSharedSocketGroupRegistry = Map<string, SlackSharedSocketGroupState<unknown>>;
@@ -49,24 +77,84 @@ function registryMap(): SlackSharedSocketGroupRegistry {
 }
 
 export type SlackSharedSocketGroupHandle<TAppBundle> = {
-  /** The Bolt App/receiver bundle to register listeners on and (owner only) start/stop. */
+  /** The Bolt App/receiver bundle to register listeners on. */
   appBundle: TAppBundle;
-  /** True if this account created the group (and therefore owns start/stop). */
+  /** True if this account created the group (and starts the connection task). */
   isOwner: boolean;
   /** True the moment a second account joins an existing solo group (log-once signal). */
   justBecameShared: boolean;
   /** Total accounts currently sharing this app token. */
   memberCount: number;
   /**
-   * Aborts once every member account has left the group (or the owner forces
-   * a teardown). The owner's connect/reconnect loop should key off this
-   * signal instead of its own individual account abortSignal so the shared
-   * socket stays open for as long as ANY member still needs it.
+   * Aborts once every member account has left the group, the connection task
+   * ended (fatally or not), or a force-stop tore the group down. Every
+   * account's passive wait keys off this signal alongside its own abort
+   * signal.
    */
   stopSignal: AbortSignal;
+  /** Fatal error that ended the group's connection task, if any. */
+  getStopError: () => unknown;
+  /**
+   * Starts the group-owned connection task (the creator calls this once,
+   * after registering its handlers). The task's lifetime belongs to the
+   * GROUP, not the calling account: it keeps running after the creator's own
+   * account is stopped, for as long as any member remains. When the task
+   * ends — fatally or because stopSignal fired — the group is torn down so
+   * every member's passive wait resolves. Idempotent; extra calls are
+   * ignored.
+   */
+  startConnectionTask: (run: () => Promise<void>) => void;
+  /** True once startConnectionTask has been called for this group. */
+  hasConnectionTask: () => boolean;
   /** Removes this account from the group; aborts stopSignal if it was last. */
   leave: () => void;
 };
+
+function teardownGroup(state: SlackSharedSocketGroupState<unknown>): void {
+  const reg = registryMap();
+  if (reg.get(state.key) === state) {
+    reg.delete(state.key);
+  }
+  state.stopController.abort();
+}
+
+function buildGroupHandle<TAppBundle>(params: {
+  state: SlackSharedSocketGroupState<unknown>;
+  appBundle: TAppBundle;
+  accountId: string;
+  isOwner: boolean;
+  justBecameShared: boolean;
+}): SlackSharedSocketGroupHandle<TAppBundle> {
+  const { state } = params;
+  return {
+    appBundle: params.appBundle,
+    isOwner: params.isOwner,
+    justBecameShared: params.justBecameShared,
+    memberCount: state.memberAccountIds.size,
+    stopSignal: state.stopController.signal,
+    getStopError: () => state.stopError,
+    startConnectionTask: (run) => {
+      if (state.connectionTaskStarted) {
+        return;
+      }
+      state.connectionTaskStarted = true;
+      void (async () => {
+        try {
+          await run();
+        } catch (err) {
+          state.stopError = err ?? new Error("Slack shared socket task failed without detail");
+        } finally {
+          // Whatever ended the task (fatal error, or stopSignal firing after
+          // the last member left), make the teardown observable: members
+          // must never keep waiting on a group whose connection is gone.
+          teardownGroup(state);
+        }
+      })();
+    },
+    hasConnectionTask: () => state.connectionTaskStarted,
+    leave: () => leaveGroup(state.key, params.accountId),
+  };
+}
 
 /**
  * Joins (or creates) the shared Socket Mode group for `appToken`. Concurrent
@@ -88,26 +176,24 @@ export async function joinSlackSharedSocketGroup<TAppBundle>(params: {
   if (existing) {
     existing.memberAccountIds.add(params.accountId);
     const appBundle = (await existing.appBundlePromise) as TAppBundle;
-    const memberCount = existing.memberAccountIds.size;
-    return {
+    return buildGroupHandle({
+      state: existing,
       appBundle,
+      accountId: params.accountId,
       isOwner: false,
-      justBecameShared: memberCount === 2,
-      memberCount,
-      stopSignal: existing.stopController.signal,
-      leave: () => leaveGroup(key, params.accountId),
-    };
+      justBecameShared: existing.memberAccountIds.size === 2,
+    });
   }
 
-  const memberAccountIds = new Set<string>([params.accountId]);
   const stopController = new AbortController();
   const appBundlePromise = params.createAppBundle();
   const state: SlackSharedSocketGroupState<unknown> = {
     key,
     ownerAccountId: params.accountId,
-    memberAccountIds,
+    memberAccountIds: new Set<string>([params.accountId]),
     appBundlePromise,
     stopController,
+    connectionTaskStarted: false,
   };
   reg.set(key, state);
 
@@ -118,20 +204,17 @@ export async function joinSlackSharedSocketGroup<TAppBundle>(params: {
     // Creation failed before anyone else could observe it: release the
     // reservation so a subsequent attempt (e.g. after a config fix) can retry
     // cleanly instead of being stuck awaiting a permanently-rejected promise.
-    if (reg.get(key) === state) {
-      reg.delete(key);
-    }
+    teardownGroup(state);
     throw err;
   }
 
-  return {
+  return buildGroupHandle({
+    state,
     appBundle,
+    accountId: params.accountId,
     isOwner: true,
     justBecameShared: false,
-    memberCount: memberAccountIds.size,
-    stopSignal: stopController.signal,
-    leave: () => leaveGroup(key, params.accountId),
-  };
+  });
 }
 
 function leaveGroup(key: string, accountId: string): void {
@@ -142,27 +225,123 @@ function leaveGroup(key: string, accountId: string): void {
   }
   existing.memberAccountIds.delete(accountId);
   if (existing.memberAccountIds.size === 0) {
-    reg.delete(key);
-    existing.stopController.abort();
+    teardownGroup(existing);
   }
 }
 
 /**
  * Unconditionally tears down the group for `appToken`, aborting `stopSignal`
- * regardless of remaining membership. Intended as a backstop the owner calls
- * on its own way out (including on a thrown/fatal error) so members can never
- * be left waiting forever on a group whose owner coroutine has already
- * stopped running the shared connection.
+ * regardless of remaining membership. Backstop for the group creator's error
+ * paths BEFORE the connection task exists (once the task runs, its own
+ * finally performs the teardown): without it, a creator that throws between
+ * joining and starting the task would leave members waiting forever on a
+ * stopSignal nobody will ever fire.
  */
 export function forceStopSlackSharedSocketGroup(params: { appToken: string }): void {
   const key = createSlackTokenCacheKey(params.appToken);
-  const reg = registryMap();
-  const existing = reg.get(key);
+  const existing = registryMap().get(key);
   if (!existing) {
     return;
   }
-  reg.delete(key);
-  existing.stopController.abort();
+  teardownGroup(existing);
+}
+
+/**
+ * Runs one Slack Socket Mode connection with the standard reconnect/backoff
+ * policy until `abortSignal` fires or a non-recoverable auth error is hit
+ * (which is rethrown to the caller). Used both by the group-owned shared
+ * connection task and by solo (non-shared) accounts; the caller owns the
+ * final `gracefulStopSlackApp` for its App.
+ */
+export async function runSlackSocketConnectionLoop(params: {
+  app: { start: () => unknown; stop: () => unknown };
+  abortSignal?: AbortSignal;
+  runtime: RuntimeEnv;
+  setStatus?: (next: Record<string, unknown>) => void;
+  getLastSdkLogMessage?: () => string | undefined;
+}): Promise<void> {
+  const { app, abortSignal, runtime } = params;
+  let reconnectAttempts = 0;
+  let hasLoggedSocketConnected = false;
+  // abortSignal itself never gets reassigned, but its .aborted getter flips
+  // when abort() fires externally (an account's own stop signal, or the
+  // shared group's stop signal).
+  // oxlint-disable-next-line eslint/no-unmodified-loop-condition
+  while (!abortSignal?.aborted) {
+    try {
+      const disconnect = await startSlackSocketAndWaitForDisconnect({
+        app,
+        abortSignal,
+        onStarted: () => {
+          reconnectAttempts = 0;
+          publishSlackConnectedStatus(params.setStatus);
+          if (!hasLoggedSocketConnected) {
+            hasLoggedSocketConnected = true;
+            runtime.log?.("slack socket mode connected");
+          }
+        },
+      });
+      if (!disconnect) {
+        break;
+      }
+      if (abortSignal?.aborted) {
+        break;
+      }
+      publishSlackDisconnectedStatus(params.setStatus, disconnect.error);
+
+      // Permanent account and credential failures need operator action.
+      if (disconnect.error && isNonRecoverableSlackAuthError(disconnect.error)) {
+        runtime.error?.(
+          `slack socket mode disconnected due to non-recoverable auth error — skipping channel (${formatUnknownError(disconnect.error)})`,
+        );
+        throw disconnect.error instanceof Error
+          ? disconnect.error
+          : new Error(formatUnknownError(disconnect.error));
+      }
+
+      reconnectAttempts += 1;
+      const delayMs = computeBackoff(SLACK_SOCKET_RECONNECT_POLICY, reconnectAttempts);
+      runtime.log?.(
+        warn(
+          formatSlackSocketReconnectMessage({
+            event: disconnect.event,
+            attempt: reconnectAttempts,
+            delayMs,
+            error: disconnect.error,
+          }),
+        ),
+      );
+      await gracefulStopSlackApp(app);
+      try {
+        await sleepWithAbort(delayMs, abortSignal);
+      } catch {
+        break;
+      }
+    } catch (err) {
+      if (isNonRecoverableSlackAuthError(err)) {
+        runtime.error?.(
+          `slack socket mode failed to start due to non-recoverable auth error — skipping channel (${formatUnknownError(err)})`,
+        );
+        throw err;
+      }
+      reconnectAttempts += 1;
+      const delayMs = computeBackoff(SLACK_SOCKET_RECONNECT_POLICY, reconnectAttempts);
+      runtime.error?.(
+        formatSlackSocketStartRetryMessage({
+          attempt: reconnectAttempts,
+          delayMs,
+          error: err,
+          sdkContext: params.getLastSdkLogMessage?.(),
+        }),
+      );
+      try {
+        await sleepWithAbort(delayMs, abortSignal);
+      } catch {
+        break;
+      }
+      continue;
+    }
+  }
 }
 
 export function resetSlackSharedSocketGroupsForTests(): void {

--- a/extensions/slack/src/monitor/slash.test.ts
+++ b/extensions/slack/src/monitor/slash.test.ts
@@ -407,6 +407,8 @@ function createArgMenusHarness(
     },
     textLimit: 4000,
     app,
+    // Source reads ctx.client (per-account WebClient), not ctx.app.client.
+    client: app.client,
     isChannelAllowed: () => true,
     resolveChannelName: async () => ({ name: "dm", type: "im" }),
     resolveUserName: async () => ({ name: "Ada" }),
@@ -1208,6 +1210,8 @@ function createPolicyHarness(overrides?: {
     },
     textLimit: 4000,
     app,
+    // Source reads ctx.client (per-account WebClient), not ctx.app.client.
+    client: app.client,
     isChannelAllowed: () => true,
     shouldDropMismatchedSlackEvent: (body: unknown) =>
       overrides?.shouldDropMismatchedSlackEvent?.(body) ?? false,

--- a/extensions/slack/src/monitor/slash.ts
+++ b/extensions/slack/src/monitor/slash.ts
@@ -1030,7 +1030,7 @@ export async function registerSlackMonitorSlashCommands(params: {
                   blocks?: (Block | KnownBlock)[];
                   mrkdwn?: boolean;
                 });
-          await ctx.app.client.chat.postEphemeral({
+          await ctx.client.chat.postEphemeral({
             token: ctx.botToken,
             channel: body.channel.id,
             user: body.user.id,


### PR DESCRIPTION
Related: #58523

<details>
<summary>Additional instructions</summary>

Allow edits from maintainers is enabled for this PR.

</details>

## What Problem This Solves

When one Slack app is installed into multiple workspaces (Slack's standard multi-workspace distribution) and each workspace is configured as its own OpenClaw Slack account, every account shares the same app-level token. Each account currently opens its own Socket Mode connection with that token, and Slack load-balances events across connections of the same app: an event for workspace B can be delivered on workspace A's connection, where it is dropped as a cross-team mismatch. Inbound messages then fail to reach OpenClaw for one of the workspaces — while outbound keeps working — which matches the symptom reported in #58523.

## Why This Change Was Made

When more than one enabled socket-mode account shares an app token, they now share a single Bolt App / Socket Mode connection owned by a shared group. Per-event `team_id` demux routes each event to the owning account; events for stopped accounts are dropped; events whose `teamId` cannot be resolved fail closed rather than leaking across teams. The shared connection's lifecycle is group-owned and leak-proof (cleanup runs inside the same try/finally that tears the group down, so a throwing logger cannot leak group membership or abort listeners). Enterprise Grid org installs are excluded from sharing — their installation identity intentionally resolves without a `teamId`, so the fail-closed demux would drop all of their events — and they keep a dedicated connection with a boot-time warning. A single account per app token takes the original, unmodified code path with zero behavioral change.

## User Impact

Operators can install one Slack app into multiple workspaces and run one OpenClaw account per workspace with reliable inbound delivery in every workspace. No configuration changes are required, and single-workspace deployments are unaffected.

A supporting fix rode along: `getSlackBoltInterop()` cached the resolved value rather than the in-flight promise, so concurrent account startups could race into parallel `@slack/bolt` imports. It now caches the promise (single-flight), preserving retry-on-failure.

## Evidence

- New focused tests: `extensions/slack/src/monitor/provider.shared-socket-group.test.ts` (10 tests) covering shared-group engagement and team_id demux, per-account boot `auth.test` on each account's own client, stopped-account drops, fail-closed unresolved teamId, creator/member lifecycle and abort-listener cleanup, fatal-error propagation, and Enterprise Grid exclusion (dedicated connection + boot warning, and siblings keep sharing); plus `context-account-client.test.ts` (team resolution incl. `view.app_installed_team_id`, self-authored detection) and a `prepare` test for the per-account self-bot drop under `allowBots`.
- `pnpm test:extension slack`: 1849 passed (1849), 120 test files, 0 failed. `pnpm check` passes (including the TS LOC ratchet).
- `codex review --base origin/main` run locally before opening this PR, per CONTRIBUTING.
- Production observation: this patch has been running in our deployment since 2026-07-09 with one Slack app installed in two workspaces (one OpenClaw account per workspace). Inbound + outbound verified working in both workspaces; before the patch, inbound from the second workspace was lost.
- The diff is confined to `extensions/slack/**` (no shared surfaces, no CHANGELOG changes).

## Known Limitations (from the pre-open local Codex review)

`codex review --base origin/main` was run before opening (twice — after the initial patch and after the ratchet refactor). Findings and how they were handled:

- **Fixed in this PR**: per-account self-authored bot-message filtering (a non-owner account with `allowBots` enabled could have replied to its own `bot_message` payloads, since the shared App's Bolt-level self filter only knows the group creator's identity), and view demux now prefers `view.app_installed_team_id` so Slack Connect modal callbacks route to the installed workspace's account.
- **Remaining, documented**: the shared Bolt App is constructed with the group creator's bot token, so if the creator account's bot token is revoked while sibling tokens stay valid, Bolt's per-event authorization degrades for the whole shared connection. A follow-up could supply a team-aware `authorize` (teamId → that account's token/identity) to remove the creator bias entirely; I kept it out of this PR to stay focused, but I'm happy to do it here or as a follow-up if maintainers prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
