### PR TITLE
fix(ai): safely serialize non-Error stream failures to avoid circular crashes

### DIFF
--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -36,6 +36,7 @@ import { AssistantMessageEventStream } from "../utils/event-stream.js";
 import { headersToRecord } from "../utils/headers.js";
 import { parseJsonWithRepair, parseStreamingJson } from "../utils/json-parse.js";
 import { notifyLlmRequestActivity } from "../utils/llm-request-activity.js";
+import { safeJsonStringify } from "../utils/safe-json-stringify.js";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
 import {
   splitSystemPromptCacheBoundary,
@@ -784,7 +785,7 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicOpti
         output.content = [];
       }
       output.stopReason = requestOptions?.signal?.aborted ? "aborted" : "error";
-      output.errorMessage = error instanceof Error ? error.message : JSON.stringify(error);
+      output.errorMessage = error instanceof Error ? error.message : safeJsonStringify(error);
       stream.push({ type: "error", reason: output.stopReason, error: output });
       stream.end();
     }

--- a/packages/ai/src/providers/google-shared.ts
+++ b/packages/ai/src/providers/google-shared.ts
@@ -30,6 +30,7 @@ import type {
   StreamOptions,
 } from "../types.js";
 import type { AssistantMessageEventStream } from "../utils/event-stream.js";
+import { safeJsonStringify } from "../utils/safe-json-stringify.js";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
 import { stripSystemPromptCacheBoundary } from "../utils/system-prompt-cache-boundary.js";
 import {
@@ -469,7 +470,7 @@ export async function runGoogleGenerateContentLifecycle<T extends GoogleApiType>
       }
     }
     output.stopReason = options?.signal?.aborted ? "aborted" : "error";
-    output.errorMessage = error instanceof Error ? error.message : JSON.stringify(error);
+    output.errorMessage = error instanceof Error ? error.message : safeJsonStringify(error);
     stream.push({ type: "error", reason: output.stopReason, error: output });
     stream.end();
   }

--- a/packages/ai/src/providers/mistral.ts
+++ b/packages/ai/src/providers/mistral.ts
@@ -29,6 +29,7 @@ import type {
 import { AssistantMessageEventStream } from "../utils/event-stream.js";
 import { shortHash } from "../utils/hash.js";
 import { parseStreamingJson } from "../utils/json-parse.js";
+import { safeJsonStringify } from "../utils/safe-json-stringify.js";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
 import { createSseByteGuard } from "../utils/streaming-byte-guard.js";
 import { stripSystemPromptCacheBoundary } from "../utils/system-prompt-cache-boundary.js";
@@ -315,13 +316,37 @@ function truncateErrorText(text: string, maxChars: number): string {
   return `${truncated}... [truncated ${text.length - truncated.length} chars]`;
 }
 
-function safeJsonStringify(value: unknown): string {
-  try {
-    const serialized = JSON.stringify(value);
-    return serialized === undefined ? String(value) : serialized;
-  } catch {
-    return String(value);
+function buildRequestOptions(model: Model<"mistral-conversations">, options?: MistralOptions) {
+  const requestOptions: {
+    signal?: AbortSignal;
+    retries: { strategy: "none" };
+    headers?: Record<string, string>;
+  } = {
+    retries: { strategy: "none" },
+  };
+  if (options?.signal) {
+    requestOptions.signal = options.signal;
   }
+
+  const headers: Record<string, string> = {};
+  if (model.headers) {
+    Object.assign(headers, model.headers);
+  }
+  if (options?.headers) {
+    Object.assign(headers, options.headers);
+  }
+
+  // Mistral infrastructure uses `x-affinity` for KV-cache reuse (prefix caching).
+  // Respect explicit caller-provided header values.
+  if (options?.sessionId && !headers["x-affinity"]) {
+    headers["x-affinity"] = options.sessionId;
+  }
+
+  if (Object.keys(headers).length > 0) {
+    requestOptions.headers = headers;
+  }
+
+  return requestOptions;
 }
 
 function buildChatPayload(

--- a/packages/ai/src/providers/mistral.ts
+++ b/packages/ai/src/providers/mistral.ts
@@ -316,39 +316,6 @@ function truncateErrorText(text: string, maxChars: number): string {
   return `${truncated}... [truncated ${text.length - truncated.length} chars]`;
 }
 
-function buildRequestOptions(model: Model<"mistral-conversations">, options?: MistralOptions) {
-  const requestOptions: {
-    signal?: AbortSignal;
-    retries: { strategy: "none" };
-    headers?: Record<string, string>;
-  } = {
-    retries: { strategy: "none" },
-  };
-  if (options?.signal) {
-    requestOptions.signal = options.signal;
-  }
-
-  const headers: Record<string, string> = {};
-  if (model.headers) {
-    Object.assign(headers, model.headers);
-  }
-  if (options?.headers) {
-    Object.assign(headers, options.headers);
-  }
-
-  // Mistral infrastructure uses `x-affinity` for KV-cache reuse (prefix caching).
-  // Respect explicit caller-provided header values.
-  if (options?.sessionId && !headers["x-affinity"]) {
-    headers["x-affinity"] = options.sessionId;
-  }
-
-  if (Object.keys(headers).length > 0) {
-    requestOptions.headers = headers;
-  }
-
-  return requestOptions;
-}
-
 function buildChatPayload(
   model: Model<"mistral-conversations">,
   context: Context,

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -37,6 +37,7 @@ import { AssistantMessageEventStream } from "../utils/event-stream.js";
 import { headersToRecord } from "../utils/headers.js";
 import { parseStreamingJson } from "../utils/json-parse.js";
 import { createReasoningTagTextPartitioner } from "../utils/reasoning-tag-text-partitioner.js";
+import { safeJsonStringify } from "../utils/safe-json-stringify.js";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
 import {
   createFirstStreamEventAbortController,
@@ -561,7 +562,7 @@ export const streamOpenAICompletions: StreamFunction<
         delete (block as { streamIndex?: number }).streamIndex;
       }
       output.stopReason = options?.signal?.aborted ? "aborted" : "error";
-      output.errorMessage = error instanceof Error ? error.message : JSON.stringify(error);
+      output.errorMessage = error instanceof Error ? error.message : safeJsonStringify(error);
       // Some providers via OpenRouter give additional information in this field.
       const rawMetadata = (error as { error?: { metadata?: { raw?: string } } })?.error?.metadata
         ?.raw;

--- a/packages/ai/src/utils/safe-json-stringify.test.ts
+++ b/packages/ai/src/utils/safe-json-stringify.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { safeJsonStringify } from "./safe-json-stringify.js";
+
+describe("safeJsonStringify", () => {
+  it("serializes plain objects the same as JSON.stringify", () => {
+    expect(safeJsonStringify({ a: 1, b: "x" })).toBe('{"a":1,"b":"x"}');
+    expect(safeJsonStringify([1, 2, 3])).toBe("[1,2,3]");
+  });
+
+  it("serializes primitives", () => {
+    expect(safeJsonStringify("hello")).toBe('"hello"');
+    expect(safeJsonStringify(42)).toBe("42");
+    expect(safeJsonStringify(true)).toBe("true");
+    expect(safeJsonStringify(null)).toBe("null");
+  });
+
+  it("does not throw on circular structures and falls back to String (#106570)", () => {
+    const circular: Record<string, unknown> = { name: "socket" };
+    circular.self = circular;
+    // JSON.stringify would throw "Converting circular structure to JSON" here.
+    expect(() => JSON.stringify(circular)).toThrow(TypeError);
+    expect(safeJsonStringify(circular)).toBe(String(circular));
+    expect(safeJsonStringify(circular)).toBe("[object Object]");
+  });
+
+  it("does not throw on a non-Error network error carrying circular socket refs", () => {
+    const socket: Record<string, unknown> = {};
+    const err: Record<string, unknown> = { code: "ECONNRESET", socket };
+    socket.parent = err; // circular
+    expect(() => JSON.stringify(err)).toThrow(TypeError);
+    expect(safeJsonStringify(err)).toBe(String(err));
+  });
+
+  it("falls back to String for values JSON.stringify drops to undefined", () => {
+    expect(safeJsonStringify(undefined)).toBe("undefined");
+    const fn = () => 1;
+    expect(safeJsonStringify(fn)).toBe(String(fn));
+  });
+
+  it("does not throw on BigInt", () => {
+    expect(() => JSON.stringify(10n)).toThrow(TypeError);
+    expect(safeJsonStringify(10n)).toBe("10");
+  });
+});

--- a/packages/ai/src/utils/safe-json-stringify.test.ts
+++ b/packages/ai/src/utils/safe-json-stringify.test.ts
@@ -40,4 +40,40 @@ describe("safeJsonStringify", () => {
     expect(() => JSON.stringify(10n)).toThrow(TypeError);
     expect(safeJsonStringify(10n)).toBe("10");
   });
+
+  it("does not throw when String() itself would throw (null-prototype object)", () => {
+    // Object.create(null) has no toString/valueOf; String() throws TypeError.
+    const bare = Object.create(null);
+    bare.circular = bare;
+    expect(() => JSON.stringify(bare)).toThrow(TypeError);
+    // First JSON.stringify fails, then String() also fails → sentinel.
+    expect(safeJsonStringify(bare)).toBe("<unserializable error>");
+  });
+
+  it("does not throw on a circular object whose Symbol.toPrimitive also throws", () => {
+    // Circular so JSON.stringify throws; then String() also throws because
+    // Symbol.toPrimitive is invoked during primitive conversion.
+    const hostile: Record<string, unknown> = {
+      [Symbol.toPrimitive](): string {
+        throw new TypeError("toPrimitive boom");
+      },
+    };
+    hostile.self = hostile;
+    expect(() => JSON.stringify(hostile)).toThrow(TypeError);
+    expect(() => String(hostile)).toThrow(TypeError);
+    expect(safeJsonStringify(hostile)).toBe("<unserializable error>");
+  });
+
+  it("does not throw when JSON.stringify-undefined value's toString throws", () => {
+    // JSON.stringify returns undefined for functions. If the function's custom
+    // toString throws, the String(…) fallback itself must be guarded.
+    const fn = Object.defineProperty(() => {}, "toString", {
+      value() {
+        throw new TypeError("toString boom");
+      },
+    });
+    expect(JSON.stringify(fn)).toBeUndefined();
+    expect(() => String(fn)).toThrow(TypeError);
+    expect(safeJsonStringify(fn)).toBe("<unserializable error>");
+  });
 });

--- a/packages/ai/src/utils/safe-json-stringify.test.ts
+++ b/packages/ai/src/utils/safe-json-stringify.test.ts
@@ -19,7 +19,6 @@ describe("safeJsonStringify", () => {
     circular.self = circular;
     // JSON.stringify would throw "Converting circular structure to JSON" here.
     expect(() => JSON.stringify(circular)).toThrow(TypeError);
-    expect(safeJsonStringify(circular)).toBe(String(circular));
     expect(safeJsonStringify(circular)).toBe("[object Object]");
   });
 
@@ -28,7 +27,7 @@ describe("safeJsonStringify", () => {
     const err: Record<string, unknown> = { code: "ECONNRESET", socket };
     socket.parent = err; // circular
     expect(() => JSON.stringify(err)).toThrow(TypeError);
-    expect(safeJsonStringify(err)).toBe(String(err));
+    expect(safeJsonStringify(err)).toBe("[object Object]");
   });
 
   it("falls back to String for values JSON.stringify drops to undefined", () => {

--- a/packages/ai/src/utils/safe-json-stringify.ts
+++ b/packages/ai/src/utils/safe-json-stringify.ts
@@ -6,12 +6,29 @@
  * paths must never throw a second exception, so this helper falls back to the
  * value's string representation instead. Values that `JSON.stringify` serializes
  * to `undefined` (e.g. `undefined`, functions) also fall back to `String`.
+ *
+ * The `String()` fallback is itself guarded: values with a null prototype or
+ * a throwing `Symbol.toPrimitive` / `toString` can make `String()` throw, so
+ * the deepest fallback is a fixed sentinel string.
  */
 export function safeJsonStringify(value: unknown): string {
   try {
     const serialized = JSON.stringify(value);
-    return serialized === undefined ? String(value) : serialized;
+    return serialized === undefined ? guardedString(value) : serialized;
   } catch {
+    return guardedString(value);
+  }
+}
+
+/**
+ * Non-throwing wrapper around `String()`.  Returns the string representation
+ * of `value` when possible, or a fixed sentinel when the primitive conversion
+ * itself throws (e.g. null-prototype objects or a throwing `Symbol.toPrimitive`).
+ */
+function guardedString(value: unknown): string {
+  try {
     return String(value);
+  } catch {
+    return "<unserializable error>";
   }
 }

--- a/packages/ai/src/utils/safe-json-stringify.ts
+++ b/packages/ai/src/utils/safe-json-stringify.ts
@@ -1,0 +1,17 @@
+/**
+ * Serialize an arbitrary value to a string without ever throwing.
+ *
+ * `JSON.stringify` throws a `TypeError` on values with circular references
+ * (common in Node network/socket errors) and on BigInt/Symbol. Error-handling
+ * paths must never throw a second exception, so this helper falls back to the
+ * value's string representation instead. Values that `JSON.stringify` serializes
+ * to `undefined` (e.g. `undefined`, functions) also fall back to `String`.
+ */
+export function safeJsonStringify(value: unknown): string {
+  try {
+    const serialized = JSON.stringify(value);
+    return serialized === undefined ? String(value) : serialized;
+  } catch {
+    return String(value);
+  }
+}


### PR DESCRIPTION
## Summary

**Problem**: the OpenAI Completions, Google, and Anthropic provider stream error handlers formatted a non-Error exception with a bare `JSON.stringify(error)`. `JSON.stringify` throws a `TypeError` on values containing circular references (network errors commonly carry circular socket refs) and on BigInt, so the error handler itself throws a second exception mid-failure, crashing the handler and preventing the stream from closing — unhandled rejections, fd leaks, and hung downstream stream consumers (issue #106570, and the identical Google case #106568).

**Solution**: add a shared `safeJsonStringify` helper (`try JSON.stringify` → fall back to `String(value)`, with a doubly-guarded `String(…)` fallback resistant to null-prototype objects and throwing `Symbol.toPrimitive`/`toString`) and use it in all three stream error handlers, so a non-serializable error degrades to a readable string instead of crashing. Mistral already had a private copy of this helper; it now consumes the shared one.

**What changed**: new `packages/ai/src/utils/safe-json-stringify.ts` (+ test); `JSON.stringify(error)` -> `safeJsonStringify(error)` in `openai-completions.ts`, `google-shared.ts`, `anthropic.ts`; `mistral.ts` imports the shared helper and drops its local duplicate. The `String(…)` fallback inside `safeJsonStringify` is itself wrapped in a try/catch to handle values whose primitive conversion throws (null-prototype objects, throwing `Symbol.toPrimitive`/`toString`).

**What did NOT change**: the `error instanceof Error ? error.message : ...` branch, all normal serialization output (plain objects/arrays/primitives serialize identically), the providers' success/abort paths, and any public API/config/CLI surface.

Fixes #106570
Fixes #106568

---

## Root Cause

**Trigger condition**: a provider stream fails with a non-Error value (e.g. a Node network error) whose object graph contains a circular reference.

**Root cause analysis**: `JSON.stringify` is a throwing operation used on the error-handling path, which must never throw again. On circular or BigInt values it throws `TypeError: Converting circular structure to JSON`, so the `catch` block that was supposed to record `errorMessage` crashes instead, leaving the stream un-closed. Root: unguarded serialization of untrusted error values.

**Affected scope**: the OpenAI Completions (#106570), Google (#106568), and Anthropic stream error handlers — the same one-line pattern in three providers. Anthropic had no filed issue but the identical bug and crash-loop, so it is fixed for consistency (preventive). `azure-openai-responses.ts` and `openai-responses.ts` already wrap `JSON.stringify` in try/catch and are not affected.

---

## Real behavior proof

**Behavior addressed**: a non-Error stream failure with circular references no longer crashes the provider error handler; it degrades to a readable string and the stream closes normally — `stream.push(error-event)` and `stream.end()` execute instead of the handler crashing mid-flight.

**Real environment tested**: Linux x86_64, Node v24.13.1.

**Exact steps or command run after this patch**: `node evidence/pr-107441/provider-lifecycle-repro.mjs && node evidence/pr-107441/repro.mjs`

**After-fix evidence**: Two layers of proof:

**Layer 1 — Provider stream lifecycle**. Shows the exact provider error-handler pattern: before the fix the handler crashes and `stream.push`/`stream.end` never run; after the fix the handler completes and the stream emits its error event and closes.
```
=== BEFORE FIX ===
Input: circular non-Error (ECONNRESET)
  💥 CRASH in handler: TypeError: Converting circular structure to JSON
  ❌ stream.push() NEVER called — stream left open
  ❌ stream.end()  NEVER called — downstream consumer hangs

=== AFTER FIX ===
  ✅ stream.push(error) — event emitted
  ✅ stream.end() — stream closed
✅ PASS: Before fix crashes before push/end. After fix completes lifecycle.
```

**Layer 2 — Helper hostile-value coverage**. Five categories that `JSON.stringify` crashes on, all handled.
```
--- 1. Circular non-Error ---
[BEFORE] TypeError crash       [AFTER]  [object Object]
--- 2. BigInt ---
[BEFORE] TypeError crash       [AFTER]  1234567890
--- 3. Null-prototype circular ---
[BEFORE] TypeError + String() throw  [AFTER]  <unserializable error>
--- 4. Throwing Symbol.toPrimitive ---
[BEFORE] TypeError + String() throw  [AFTER]  <unserializable error>
--- 5. Throwing toString ---
[BEFORE] String() crash        [AFTER]  <unserializable error>
```

**Observed result after the fix**: Every crash scenario — provider lifecycle and five hostile-value categories — completes without throwing after the fix. The provider error-handler path now guarantees `stream.push(terminal-error)` and `stream.end()` execute instead of crashing mid-handler.

**What was not tested**: a full live provider HTTP interaction against a real AI service endpoint. The lifecycle reproduction uses the exact catch-block pattern from the providers with a mock stream, exercising the same code path.

## Tests and validation

### Unit tests
```
$ node node_modules/.bin/vitest run packages/ai/src/utils/safe-json-stringify.test.ts --no-coverage
 Test Files  1 passed (1)
      Tests  9 passed (9)      # circular, network-error-circular, undefined/function, BigInt,
                               # plain objects, primitives, null-prototype circular,
                               # throwing Symbol.toPrimitive, throwing toString

$ node node_modules/.bin/vitest run packages/ai/src/providers/openai-completions.test.ts packages/ai/src/providers/anthropic.test.ts
 Test Files  2 passed (2)
      Tests  111 passed (111)  # provider regression

$ node node_modules/.bin/vitest run packages/ai/src/providers/mistral.test.ts packages/ai/src/utils/safe-json-stringify.test.ts
 Test Files  2 passed (2)
      Tests  27 passed (27)    # mistral consolidation regression (24 previous + 3 new)

$ node node_modules/.bin/vitest run packages/ai/src/providers/google-shared.test.ts
 Test Files  1 passed (1)
      Tests  8 passed (8)      # google regression
```

### Branch state
- Rebased on `upstream/main` (0 behind, 3 ahead)
- Merge conflict resolved

## Risk checklist

merge-risk: Low

- [x] This change is backwards compatible
- [x] This change has been tested with existing configurations
- [x] I have updated relevant documentation (N/A - internal error-serialization helper, no public API/config/CLI/doc surface)
- [x] Breaking changes (if any) are documented in Summary (none)

Mitigation: `safeJsonStringify` returns output identical to `JSON.stringify` for all normally-serializable values; it only diverges where `JSON.stringify` would throw (circular/BigInt) or return `undefined` (undefined/functions), turning a crash into a readable string. The mistral change is an equivalent swap to the shared helper.

## Current review state

- [x] Self-review completed
- [ ] At least one maintainer review
- [ ] All CI checks passed

---

> AI-assisted: root-cause analysis, implementation, and tests were prepared with AI assistance and human-reviewed.

