### PR TITLE
fix(test): declare release verifier helpers

### DIFF
--- a/test/external-script-modules.d.ts
+++ b/test/external-script-modules.d.ts
@@ -70,6 +70,11 @@ declare module "*openclaw-changelog-update/scripts/verify-release-notes.mjs" {
     shippedBaselines: unknown[],
   ): number[];
   export function standardRevertedHash(message: string): string | null;
+  export function contributionRecordTarget(section: { source: string }): string | undefined;
+  export function pullRequestTitleFromCommitSubject(
+    subject: string,
+    number: number,
+  ): string | undefined;
   export function contributionRecordFor(section: Record<string, unknown>): {
     legacyIssues: Map<number, unknown>;
     pullRequests: Map<number, ContributionRecord>;
@@ -124,6 +129,9 @@ declare module "*openclaw-changelog-update/scripts/verify-release-notes.mjs" {
     associatedPullRequests: number[],
     hasProvenanceOverride: boolean,
   ): number[];
+  export function recoverUnavailablePullRequests(
+    params: Record<string, unknown>,
+  ): Map<number, Record<string, unknown>>;
   export function validateReleaseProvenanceOverrides(
     provenanceOverrides: Map<string, number[]>,
     nodes: Map<number, unknown>,


### PR DESCRIPTION
## What Problem This Solves

The full test typecheck on current `main` fails because three release-verifier helpers added by `a2790f10af1` are exported and used by tests but absent from the ambient declaration shim.

## Why This Change Was Made

Declare the existing exports in the owning external-script module shim. This restores the test graph without changing release runtime behavior.

## User Impact

No product behavior change. Maintainer CI and release-note verifier tests typecheck again.

## Evidence

- Blacksmith Testbox `tbx_01kxg8268xrrtc6dt2w24f04q8`: `pnpm check:test-types` passed.
- Same Testbox: `pnpm test test/scripts/verify-release-notes.test.ts` passed, 28/28 tests.
- `git diff --check` passed.
- Fresh autoreview: no accepted/actionable findings.
