### PR TITLE
refactor(wizard): remove test-only exports

### DIFF
--- a/scripts/deadcode-exports.baseline.mjs
+++ b/scripts/deadcode-exports.baseline.mjs
@@ -721,14 +721,6 @@ export const KNIP_UNUSED_EXPORT_BASELINE = [
   "src/tasks/task-registry.ts: resetTaskRegistryForTests",
   "src/tasks/task-registry.ts: setTaskRegistryControlRuntimeForTests",
   "src/tasks/task-registry.ts: setTaskRegistryDeliveryRuntimeForTests",
-  "src/wizard/clack-navigation-prompts.ts: formatNavigationFooter",
-  "src/wizard/i18n/index.ts: listWizardI18nKeys",
-  "src/wizard/i18n/index.ts: resolveWizardLocale",
-  "src/wizard/i18n/index.ts: resolveWizardLocaleFromEnv",
-  "src/wizard/i18n/index.ts: WIZARD_SUPPORTED_LOCALES",
-  "src/wizard/setup.migration-recovery.ts: testing",
-  "src/wizard/setup.official-plugins.ts: resolveOfficialPluginOnboardingInstallEntries",
-  "src/wizard/setup.official-plugins.ts: testing",
 ];
 
 // Platform-variant findings. Allowed when present; never required.

--- a/src/wizard/clack-navigation-prompts.test.ts
+++ b/src/wizard/clack-navigation-prompts.test.ts
@@ -1,29 +1,88 @@
-// Navigation prompt tests cover shared onboarding footer copy.
-import { describe, expect, it } from "vitest";
+// Navigation prompt tests cover shared onboarding footer copy through the prompt renderer.
+import type { Writable } from "node:stream";
+import { describe, expect, it, vi } from "vitest";
 import { stripAnsi } from "../../packages/terminal-core/src/ansi.js";
-import { formatNavigationFooter } from "./clack-navigation-prompts.js";
 
-describe("formatNavigationFooter", () => {
-  it("omits the footer when no navigation is possible", () => {
-    expect(formatNavigationFooter({ canGoBack: false, canGoForward: false })).toBe("");
+type TestPromptOption = {
+  value: unknown;
+  label?: string;
+  hint?: string;
+  disabled?: boolean;
+};
+
+type TestSelectPrompt = {
+  state: "active";
+  cursor: number;
+  options: TestPromptOption[];
+};
+
+vi.mock("@clack/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@clack/core")>();
+  return {
+    ...actual,
+    SelectPrompt: class {
+      readonly state = "active" as const;
+      readonly cursor = 0;
+      readonly options: TestPromptOption[];
+      readonly render: () => string;
+
+      constructor(params: {
+        options: TestPromptOption[];
+        render: (this: TestSelectPrompt) => string;
+      }) {
+        this.options = params.options;
+        this.render = params.render.bind(this);
+      }
+
+      prompt(): Promise<string> {
+        return Promise.resolve(this.render());
+      }
+    },
+  };
+});
+
+import { selectWithNavigationFooter } from "./clack-navigation-prompts.js";
+import type { WizardPromptNavigation } from "./prompts.js";
+
+const output = {
+  columns: 80,
+  write: () => true,
+} as unknown as Writable;
+
+async function renderNavigationFooter(
+  navigation: WizardPromptNavigation | undefined,
+): Promise<string> {
+  return stripAnsi(
+    String(
+      await selectWithNavigationFooter({
+        message: "Pick one",
+        options: [{ value: "one", label: "One" }],
+        navigation,
+        output,
+      }),
+    ),
+  );
+}
+
+describe("navigation-aware select rendering", () => {
+  it("omits navigation copy when no move is available", async () => {
+    await expect(
+      renderNavigationFooter({ canGoBack: false, canGoForward: false }),
+    ).resolves.not.toMatch(/← back|→ next/u);
   });
 
-  it("renders compact back and forward guidance for navigable onboarding prompts", () => {
-    expect(stripAnsi(formatNavigationFooter({ canGoBack: true, canGoForward: true }))).toBe(
-      "← back  → next",
-    );
+  it("renders compact back and forward guidance", async () => {
+    await expect(
+      renderNavigationFooter({ canGoBack: true, canGoForward: true }),
+    ).resolves.toContain("← back  → next  ↑/↓ option");
   });
 
-  it("renders only the available navigation action", () => {
-    expect(stripAnsi(formatNavigationFooter({ canGoBack: true, canGoForward: false }))).toBe(
-      "← back",
-    );
-    expect(stripAnsi(formatNavigationFooter({ canGoBack: false, canGoForward: true }))).toBe(
-      "→ next",
-    );
-  });
-
-  it("omits the footer outside prompt navigation", () => {
-    expect(formatNavigationFooter(undefined)).toBe("");
+  it("renders only the available navigation action", async () => {
+    await expect(
+      renderNavigationFooter({ canGoBack: true, canGoForward: false }),
+    ).resolves.toContain("← back  ↑/↓ option");
+    await expect(
+      renderNavigationFooter({ canGoBack: false, canGoForward: true }),
+    ).resolves.toContain("→ next  ↑/↓ option");
   });
 });

--- a/src/wizard/clack-navigation-prompts.ts
+++ b/src/wizard/clack-navigation-prompts.ts
@@ -86,7 +86,7 @@ function adaptOptionFilter<Value>(
   return filter ? (search, option) => filter(search, option as never) : undefined;
 }
 
-export function formatNavigationFooter(navigation: WizardPromptNavigation | undefined): string {
+function formatNavigationFooter(navigation: WizardPromptNavigation | undefined): string {
   if (!navigation || (!navigation.canGoBack && !navigation.canGoForward)) {
     return "";
   }

--- a/src/wizard/i18n/index.test.ts
+++ b/src/wizard/i18n/index.test.ts
@@ -1,32 +1,45 @@
-// Wizard i18n tests cover locale lookup and fallback behavior.
-import { describe, expect, it } from "vitest";
-import {
-  WIZARD_SUPPORTED_LOCALES,
-  createSetupTranslator,
-  listWizardI18nKeys,
-  resolveWizardLocale,
-  resolveWizardLocaleFromEnv,
-  t,
-} from "./index.js";
+// Wizard i18n tests cover locale lookup and fallback behavior through retained translators.
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createSetupTranslator, t } from "./index.js";
+import { en } from "./locales/en.js";
+import { zh_CN } from "./locales/zh-CN.js";
+import { zh_TW } from "./locales/zh-TW.js";
+import type { WizardTranslationTree } from "./types.js";
+
+function collectLeafKeys(tree: WizardTranslationTree, prefix = "", out: string[] = []): string[] {
+  for (const [key, value] of Object.entries(tree)) {
+    const next = prefix ? `${prefix}.${key}` : key;
+    if (typeof value === "string") {
+      out.push(next);
+    } else {
+      collectLeafKeys(value, next, out);
+    }
+  }
+  return out;
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
 
 describe("wizard i18n", () => {
-  it("resolves supported CLI locales from explicit and system locale values", () => {
-    expect(resolveWizardLocale("zh_CN.UTF-8")).toBe("zh-CN");
-    expect(resolveWizardLocale("zh-Hans")).toBe("zh-CN");
-    expect(resolveWizardLocale("zh_TW.UTF-8")).toBe("zh-TW");
-    expect(resolveWizardLocale("zh-HK")).toBe("zh-TW");
-    expect(resolveWizardLocale("en_US.UTF-8")).toBe("en");
-    expect(resolveWizardLocale("de_DE.UTF-8")).toBe("en");
+  it.each([
+    ["zh_CN.UTF-8", "Gateway 端口"],
+    ["zh-Hans", "Gateway 端口"],
+    ["zh_TW.UTF-8", "Gateway 連接埠"],
+    ["zh-HK", "Gateway 連接埠"],
+    ["en_US.UTF-8", "Gateway port"],
+    ["de_DE.UTF-8", "Gateway port"],
+  ])("resolves the %s CLI locale through translated setup copy", (locale, expected) => {
+    vi.stubEnv("OPENCLAW_LOCALE", locale);
+    expect(t("wizard.gateway.port")).toBe(expected);
   });
 
   it("uses OPENCLAW_LOCALE before process locale variables", () => {
-    expect(
-      resolveWizardLocaleFromEnv({
-        OPENCLAW_LOCALE: "zh-TW",
-        LC_ALL: "zh-CN",
-        LANG: "en-US",
-      }),
-    ).toBe("zh-TW");
+    vi.stubEnv("OPENCLAW_LOCALE", "zh-TW");
+    vi.stubEnv("LC_ALL", "zh-CN");
+    vi.stubEnv("LANG", "en-US");
+    expect(t("wizard.gateway.port")).toBe("Gateway 連接埠");
   });
 
   it("falls back to English and interpolates params", () => {
@@ -53,9 +66,12 @@ describe("wizard i18n", () => {
   });
 
   it("keeps shipped locale keys aligned with English", () => {
-    const english = listWizardI18nKeys("en");
-    for (const locale of WIZARD_SUPPORTED_LOCALES) {
-      expect(listWizardI18nKeys(locale), locale).toEqual(english);
+    const english = collectLeafKeys(en).toSorted();
+    for (const [locale, translations] of [
+      ["zh-CN", zh_CN],
+      ["zh-TW", zh_TW],
+    ] as const) {
+      expect(collectLeafKeys(translations).toSorted(), locale).toEqual(english);
     }
   });
 });

--- a/src/wizard/i18n/index.ts
+++ b/src/wizard/i18n/index.ts
@@ -22,7 +22,6 @@ const LOCALES: Record<WizardLocale, WizardTranslationMap> = {
 };
 
 const WIZARD_DEFAULT_LOCALE: WizardLocale = "en";
-export const WIZARD_SUPPORTED_LOCALES: readonly WizardLocale[] = ["en", "zh-CN", "zh-TW"];
 
 function normalizeLocaleToken(raw: string | undefined): string {
   return (raw ?? "").trim().split(".")[0]?.split("@")[0]?.replaceAll("_", "-") ?? "";
@@ -30,7 +29,7 @@ function normalizeLocaleToken(raw: string | undefined): string {
 
 // Resolve shell/browser locale strings such as zh_Hant_TW.UTF-8 into supported
 // setup locales, falling back to English for unknown languages.
-export function resolveWizardLocale(value: string | undefined): WizardLocale {
+function resolveWizardLocale(value: string | undefined): WizardLocale {
   const normalized = normalizeLocaleToken(value);
   if (!normalized) {
     return WIZARD_DEFAULT_LOCALE;
@@ -49,7 +48,7 @@ export function resolveWizardLocale(value: string | undefined): WizardLocale {
   return WIZARD_DEFAULT_LOCALE;
 }
 
-export function resolveWizardLocaleFromEnv(env: NodeJS.ProcessEnv = process.env): WizardLocale {
+function resolveWizardLocaleFromEnv(env: NodeJS.ProcessEnv = process.env): WizardLocale {
   return resolveWizardLocale(env.OPENCLAW_LOCALE ?? env.LC_ALL ?? env.LC_MESSAGES ?? env.LANG);
 }
 
@@ -101,20 +100,4 @@ export function createSetupTranslator(options?: {
         : key;
     return wizardT(resolvedKey, params, { locale: options?.locale });
   };
-}
-
-function collectLeafKeys(tree: WizardTranslationTree, prefix = "", out: string[] = []): string[] {
-  for (const [key, value] of Object.entries(tree)) {
-    const next = prefix ? `${prefix}.${key}` : key;
-    if (typeof value === "string") {
-      out.push(next);
-    } else {
-      collectLeafKeys(value, next, out);
-    }
-  }
-  return out;
-}
-
-export function listWizardI18nKeys(locale: WizardLocale = WIZARD_DEFAULT_LOCALE): string[] {
-  return collectLeafKeys(LOCALES[locale]).toSorted();
 }

--- a/src/wizard/setup.migration-recovery.test.ts
+++ b/src/wizard/setup.migration-recovery.test.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { createMigrationItem, summarizeMigrationItems } from "../plugin-sdk/migration.js";
 import type { MigrationApplyResult, MigrationPlan } from "../plugins/types.js";
@@ -8,9 +8,9 @@ import {
   createSetupMigrationAttempt,
   prepareSetupMigrationRetryPlan,
   resolveSetupMigrationRecovery,
+  runSetupMigrationAttempt,
   setupMigrationAttemptMatchesSource,
   setupMigrationProviderSupportsRecovery,
-  testing,
 } from "./setup.migration-recovery.js";
 import {
   buildSetupMigrationPlanSourceSnapshot,
@@ -22,7 +22,6 @@ const BEFORE_HASH = "a".repeat(64);
 const AFTER_HASH = "b".repeat(64);
 const CHANGED_HASH = "c".repeat(64);
 const SOURCE_HASH = "d".repeat(64);
-const { writeSetupMigrationAttempt } = testing;
 
 async function makeTempRoot(): Promise<string> {
   return tempRoots.make("openclaw-setup-recovery-");
@@ -81,6 +80,55 @@ function buildFailedResult(plan: MigrationPlan): MigrationApplyResult {
   return { ...plan, items, summary: summarizeMigrationItems(items) };
 }
 
+async function persistFailedSetupMigrationAttempt(params: {
+  reportDir: string;
+  attempt: ReturnType<typeof createSetupMigrationAttempt>;
+  targetSnapshotHash: string;
+  result?: MigrationApplyResult;
+}): Promise<void> {
+  const failure = new Error("expected setup migration failure");
+  await expect(
+    runSetupMigrationAttempt({
+      reportDir: params.reportDir,
+      attempt: params.attempt,
+      apply: async () => {
+        if (!params.result) {
+          throw failure;
+        }
+        return params.result;
+      },
+      assertSucceeded: () => {
+        throw failure;
+      },
+      readTargetSnapshot: async () => params.targetSnapshotHash,
+    }),
+  ).rejects.toThrow(failure.message);
+}
+
+async function persistSucceededSetupMigrationAttempt(params: {
+  reportDir: string;
+  attempt: ReturnType<typeof createSetupMigrationAttempt>;
+  result: MigrationApplyResult;
+}): Promise<void> {
+  await runSetupMigrationAttempt({
+    reportDir: params.reportDir,
+    attempt: params.attempt,
+    apply: async () => params.result,
+    assertSucceeded: () => {},
+    readTargetSnapshot: async () => {
+      throw new Error("successful migration should not read the failure snapshot");
+    },
+  });
+}
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
 describe("setup migration recovery", () => {
   it("limits recovery to the audited Hermes provider contract", () => {
     expect(setupMigrationProviderSupportsRecovery("hermes")).toBe(true);
@@ -105,10 +153,9 @@ describe("setup migration recovery", () => {
       new Date("2026-07-13T10:00:00Z"),
     );
     const failedReportDir = path.join(stateDir, "migration", "hermes", "2026-07-13T10-00-00Z");
-    await writeSetupMigrationAttempt({
+    await persistFailedSetupMigrationAttempt({
       reportDir: failedReportDir,
       attempt: failed,
-      status: "failed",
       result: buildFailedResult(plan),
       targetSnapshotHash: AFTER_HASH,
     });
@@ -172,10 +219,9 @@ describe("setup migration recovery", () => {
       { ...prepared.items[2]!, status: "skipped" as const, reason: "not attempted" },
       { ...prepared.items[3]!, status: "migrated" as const },
     ];
-    await writeSetupMigrationAttempt({
+    await persistFailedSetupMigrationAttempt({
       reportDir: path.join(stateDir, "migration", "hermes", "2026-07-13T10-30-00Z"),
       attempt: retry,
-      status: "failed",
       result: {
         ...prepared,
         items: retryResultItems,
@@ -228,10 +274,10 @@ describe("setup migration recovery", () => {
       targetSnapshotHash: AFTER_HASH,
       previousAttempt: recovery.attempt,
     });
-    await writeSetupMigrationAttempt({
+    await persistSucceededSetupMigrationAttempt({
       reportDir: path.join(stateDir, "migration", "hermes", "2026-07-13T11-00-00Z"),
       attempt: succeeded,
-      status: "succeeded",
+      result: buildFailedResult(prepared),
     });
     await expect(
       resolveSetupMigrationRecovery({
@@ -257,17 +303,29 @@ describe("setup migration recovery", () => {
       source: path.join(stateDir, "hermes"),
       workspaceDir: path.join(stateDir, "workspace"),
     };
+    const plan = buildPlan(stateDir);
     const attempt = createSetupMigrationAttempt({
       ...identity,
-      plan: buildPlan(stateDir),
+      plan,
       sourceSnapshotHash: SOURCE_HASH,
       preparedTargetSnapshotHash: BEFORE_HASH,
       targetSnapshotHash: AFTER_HASH,
     });
-    await writeSetupMigrationAttempt({
-      reportDir: path.join(stateDir, "migration", "hermes", "2026-07-13T10-00-00Z"),
+    const applyingReportDir = path.join(stateDir, "migration", "hermes", "2026-07-13T10-00-00Z");
+    const apply = createDeferred<MigrationApplyResult>();
+    const applyingRun = runSetupMigrationAttempt({
+      reportDir: applyingReportDir,
       attempt,
-      status: "applying",
+      apply: async () => await apply.promise,
+      assertSucceeded: () => {},
+      readTargetSnapshot: async () => {
+        throw new Error("pending migration should not read the failure snapshot");
+      },
+    });
+    await vi.waitFor(async () => {
+      await expect(
+        fs.readFile(path.join(applyingReportDir, "onboarding-attempt.json"), "utf8"),
+      ).resolves.toContain('"status": "applying"');
     });
 
     await expect(
@@ -295,11 +353,13 @@ describe("setup migration recovery", () => {
       }),
     ).resolves.toEqual({ kind: "none" });
 
+    apply.resolve(buildFailedResult(plan));
+    await applyingRun;
+
     const failedReportDir = path.join(stateDir, "migration", "hermes", "2026-07-13T11-00-00Z");
-    await writeSetupMigrationAttempt({
+    await persistFailedSetupMigrationAttempt({
       reportDir: failedReportDir,
       attempt,
-      status: "failed",
       targetSnapshotHash: BEFORE_HASH,
     });
     await expect(
@@ -311,10 +371,9 @@ describe("setup migration recovery", () => {
       }),
     ).resolves.toMatchObject({ kind: "recoverable" });
 
-    await writeSetupMigrationAttempt({
+    await persistFailedSetupMigrationAttempt({
       reportDir: failedReportDir,
       attempt,
-      status: "failed",
       targetSnapshotHash: CHANGED_HASH,
     });
     await expect(

--- a/src/wizard/setup.migration-recovery.ts
+++ b/src/wizard/setup.migration-recovery.ts
@@ -398,5 +398,3 @@ export function prepareSetupMigrationRetryPlan(
   });
   return { ...plan, items, summary: summarizeMigrationItems(items) };
 }
-
-export const testing = { writeSetupMigrationAttempt };

--- a/src/wizard/setup.official-plugins.test.ts
+++ b/src/wizard/setup.official-plugins.test.ts
@@ -15,72 +15,7 @@ vi.mock("../commands/onboarding-plugin-install.js", () => ({
   ensureOnboardingPluginInstalled,
 }));
 
-import {
-  testing,
-  resolveOfficialPluginOnboardingInstallEntries,
-  setupOfficialPluginInstalls,
-} from "./setup.official-plugins.js";
-
-describe("resolveOfficialPluginOnboardingInstallEntries", () => {
-  it("lists optional generic official plugins without channel, provider, or search-owned entries", () => {
-    const entries = resolveOfficialPluginOnboardingInstallEntries({ config: {} });
-    const pluginIds = entries.map((entry) => entry.pluginId);
-
-    expect(pluginIds).toContain("diagnostics-otel");
-    expect(pluginIds).toContain("diagnostics-prometheus");
-    expect(pluginIds).toContain("acpx");
-    expect(pluginIds).toContain("tokenjuice");
-    expect(pluginIds).not.toContain("brave");
-    expect(pluginIds).not.toContain("codex");
-    expect(pluginIds).not.toContain("discord");
-  });
-
-  it("hides already configured official plugins", () => {
-    const entries = resolveOfficialPluginOnboardingInstallEntries({
-      config: {
-        plugins: {
-          entries: {
-            acpx: { enabled: true },
-          },
-          installs: {
-            "diagnostics-otel": {
-              source: "npm",
-              spec: "@openclaw/diagnostics-otel",
-              installPath: "/tmp/diagnostics-otel",
-            },
-          },
-        },
-      },
-    });
-    const pluginIds = entries.map((entry) => entry.pluginId);
-
-    expect(pluginIds).not.toContain("acpx");
-    expect(pluginIds).not.toContain("diagnostics-otel");
-    expect(pluginIds).toContain("diagnostics-prometheus");
-  });
-});
-
-describe("formatInstallHint", () => {
-  it("describes dual-source npm-default installs as npm first", () => {
-    expect(
-      testing.formatInstallHint({
-        clawhubSpec: "clawhub:@openclaw/diagnostics-otel",
-        npmSpec: "@openclaw/diagnostics-otel",
-        defaultChoice: "npm",
-      }),
-    ).toBe("npm, with ClawHub fallback");
-  });
-
-  it("keeps dual-source clawhub-default installs ClawHub first", () => {
-    expect(
-      testing.formatInstallHint({
-        clawhubSpec: "clawhub:@openclaw/diagnostics-otel",
-        npmSpec: "@openclaw/diagnostics-otel",
-        defaultChoice: "clawhub",
-      }),
-    ).toBe("ClawHub, with npm fallback");
-  });
-});
+import { setupOfficialPluginInstalls } from "./setup.official-plugins.js";
 
 describe("setupOfficialPluginInstalls", () => {
   beforeEach(() => {
@@ -117,6 +52,13 @@ describe("setupOfficialPluginInstalls", () => {
       label: "Skip for now",
       hint: "Continue without installing optional plugins",
     });
+    const pluginIds = prompt.options.slice(1).map((option) => option.value);
+    expect(pluginIds).toEqual(
+      expect.arrayContaining(["acpx", "diagnostics-otel", "diagnostics-prometheus", "tokenjuice"]),
+    );
+    expect(pluginIds).not.toContain("brave");
+    expect(pluginIds).not.toContain("codex");
+    expect(pluginIds).not.toContain("discord");
     expect(prompt.options).toEqual(
       expect.arrayContaining([
         {
@@ -160,6 +102,41 @@ describe("setupOfficialPluginInstalls", () => {
       workspaceDir: "/tmp/workspace",
       promptInstall: false,
     });
+  });
+
+  it("hides already configured official plugins from the production prompt", async () => {
+    const multiselect = vi.fn(async (_params: WizardMultiSelectParams) => ["__skip__"]);
+    const prompter = createWizardPrompter({
+      multiselect: multiselect as unknown as WizardPrompter["multiselect"],
+    });
+
+    await setupOfficialPluginInstalls({
+      config: {
+        plugins: {
+          entries: {
+            acpx: { enabled: true },
+          },
+          installs: {
+            "diagnostics-otel": {
+              source: "npm",
+              spec: "@openclaw/diagnostics-otel",
+              installPath: "/tmp/diagnostics-otel",
+            },
+          },
+        },
+      },
+      prompter,
+      runtime: createNonExitingRuntime(),
+    });
+
+    const prompt = multiselect.mock.calls[0]?.[0];
+    if (!prompt) {
+      throw new Error("expected optional plugin multiselect prompt");
+    }
+    const pluginIds = prompt.options.map((option) => option.value);
+    expect(pluginIds).not.toContain("acpx");
+    expect(pluginIds).not.toContain("diagnostics-otel");
+    expect(pluginIds).toContain("diagnostics-prometheus");
   });
 
   it("does not install when the user skips optional plugins", async () => {

--- a/src/wizard/setup.official-plugins.ts
+++ b/src/wizard/setup.official-plugins.ts
@@ -59,11 +59,7 @@ function formatInstallHint(install: PluginPackageInstall): string {
   return "install source";
 }
 
-export const testing = {
-  formatInstallHint,
-};
-
-export function resolveOfficialPluginOnboardingInstallEntries(params: {
+function resolveOfficialPluginOnboardingInstallEntries(params: {
   config: OpenClawConfig;
 }): OfficialPluginOnboardingInstallEntry[] {
   const entries: OfficialPluginOnboardingInstallEntry[] = [];


### PR DESCRIPTION
## What Problem This Solves

`src/wizard` still exposed eight internal or test-only symbols through the production dead-export baseline.

## Why This Change Was Made

- Privatize the navigation and locale helpers that are only used by their owning modules.
- Remove mutable test accessors for migration recovery and official-plugin setup.
- Preserve behavior coverage through retained production entry points and prompt rendering.
- Shrink the baseline by eight entries, from 727 to 719; `src/wizard` goes from 8 to 0.

Production source: +4/-27 lines. Tests: +242/-131 lines. Baseline: +0/-8 entries.

## User Impact

None. Wizard runtime behavior and CLI surface are unchanged; only internal TypeScript export seams are removed.

## Evidence

- Blacksmith Testbox `tbx_01kxg7t6pmftkyt1s6gxy2mb7g`
- `node scripts/check-deadcode-exports.mjs` — exact 719-entry match
- formatting and scoped type-aware lint — clean
- full `src/wizard` suite — 16 files, 168 tests passed
- core types — passed
- fresh autoreview — clean, 0.98
- broad test-types tail was capped after focused and core-type proof; hosted CI intentionally not awaited per maintainer direction
