### PR TITLE
fix(ws): keep nodebuffer decoding lint-clean

### DIFF
--- a/packages/gateway-client/src/client.ts
+++ b/packages/gateway-client/src/client.ts
@@ -614,7 +614,7 @@ export class GatewayClient {
       }
       this.transportValidated = true;
     });
-    ws.on("message", (data) => handlers.message(data.toString()));
+    ws.on("message", (data) => handlers.message((data as Buffer).toString("utf8")));
     ws.on("close", (code, reason) => {
       const reasonText = reason.toString();
       if (this.ws === ws) {

--- a/packages/sdk/src/index.e2e.test.ts
+++ b/packages/sdk/src/index.e2e.test.ts
@@ -61,7 +61,7 @@ async function createFakeGateway(port = 0): Promise<FakeGateway> {
     });
 
     socket.on("message", (raw) => {
-      const frame = JSON.parse(raw.toString()) as FakeGatewayRequest;
+      const frame = JSON.parse((raw as Buffer).toString("utf8")) as FakeGatewayRequest;
       requests.push(frame);
       const reply = (payload: JsonObject): void => {
         sendJson(socket, { type: "res", id: frame.id, ok: true, payload });

--- a/scripts/lib/gateway-ws-client.ts
+++ b/scripts/lib/gateway-ws-client.ts
@@ -128,7 +128,7 @@ export function createGatewayWsClient(params: {
     });
 
   ws.on("message", (data) => {
-    const text = data.toString();
+    const text = (data as Buffer).toString("utf8");
     let frame: GatewayFrame | null;
     try {
       frame = JSON.parse(text) as GatewayFrame;


### PR DESCRIPTION
Related: #107443

## What Problem This Solves

Restores the lint gate after the nodebuffer WebSocket refactor. The runtime contract is Buffer-backed, while the published `ws` listener type intentionally remains the broader `RawData` union, so direct default stringification fails `no-base-to-string`.

## Why This Change Was Made

Keep the explicit `binaryType = "nodebuffer"` contract and narrow message payloads to `Buffer` only at the three affected consumption sites before UTF-8 decoding. No fallback or duplicate normalization path is reintroduced.

## User Impact

No runtime behavior change. Main and dependent PRs regain a green lint gate.

## Evidence

- `node scripts/run-vitest.mjs packages/gateway-client/src/client.watchdog.test.ts test/scripts/gateway-ws-client.test.ts src/realtime-transcription/websocket-session.test.ts packages/sdk/src/index.e2e.test.ts` — 41 passed, 1 skipped
- Targeted `oxlint --deny-warnings` and `oxfmt --check` — clean
- `git diff --check` — clean
- Fresh autoreview — no accepted/actionable findings
- Inspected `ws` receiver/runtime and published types: `nodebuffer` emits Buffer data while the listener signature remains `RawData`
