### PR TITLE
[codex] Keep full-auto Codex exec from stale relay decline

### DIFF
--- a/extensions/codex/src/app-server/approval-bridge-native-relay.ts
+++ b/extensions/codex/src/app-server/approval-bridge-native-relay.ts
@@ -1,0 +1,189 @@
+import {
+  type BeforeToolCallFailureDisposition,
+  hasNativeHookRelayInvocation,
+  invokeNativeHookRelay,
+  resolveNativeHookRelayDeferredToolApproval,
+  type NativeHookRelayProcessResponse,
+  type NativeHookRelayRegistrationHandle,
+} from "openclaw/plugin-sdk/agent-harness-runtime";
+import { formatCodexDisplayText } from "../command-formatters.js";
+import { type JsonObject } from "./protocol.js";
+
+const UNAVAILABLE_NATIVE_RELAY_ERRORS = new Set([
+  "native hook relay not found",
+  "native hook relay expired",
+  "native hook relay bridge stale registration",
+]);
+
+type ApprovalContext = {
+  approvalId?: string;
+};
+
+export type NativeRelayPolicyDecision =
+  | {
+      blocked: true;
+      reason: string;
+      failureDisposition?: Exclude<BeforeToolCallFailureDisposition, "blocked">;
+    }
+  | { blocked: false };
+
+type NativeRelayToolPolicyOutcome =
+  | {
+      handled: true;
+      blocked: true;
+      reason: string;
+      failureDisposition?: Exclude<BeforeToolCallFailureDisposition, "blocked">;
+    }
+  | {
+      handled: true;
+      blocked?: false;
+      outcome?: "approved-once" | "approved-session";
+    };
+
+export async function runNativeRelayToolPolicyForApprovalRequest(params: {
+  method: string;
+  requestParams: JsonObject | undefined;
+  context: ApprovalContext;
+  policyRequest: { toolName: string; params: JsonObject };
+  nativeHookRelay?: Pick<
+    NativeHookRelayRegistrationHandle,
+    "allowedEvents" | "generation" | "relayId"
+  >;
+  ignoreUnavailable?: boolean;
+  cwd?: string;
+  signal?: AbortSignal;
+  readDecision: (response: NativeHookRelayProcessResponse | undefined) => NativeRelayPolicyDecision;
+}): Promise<NativeRelayToolPolicyOutcome | undefined> {
+  if (
+    params.method !== "item/commandExecution/requestApproval" ||
+    !params.nativeHookRelay?.allowedEvents.includes("pre_tool_use")
+  ) {
+    return undefined;
+  }
+  const payload = buildNativeRelayPreToolUsePayload({
+    requestParams: params.requestParams,
+    policyRequest: params.policyRequest,
+    context: params.context,
+    cwd: params.cwd,
+  });
+  if (!payload) {
+    return undefined;
+  }
+  if (
+    hasNativeHookRelayInvocation({
+      relayId: params.nativeHookRelay.relayId,
+      event: "pre_tool_use",
+      toolUseId: params.context.approvalId,
+    })
+  ) {
+    try {
+      const approvalOutcome = await resolveNativeHookRelayDeferredToolApproval({
+        relayId: params.nativeHookRelay.relayId,
+        toolUseId: params.context.approvalId,
+        signal: params.signal,
+      });
+      return mapNativeRelayApprovalOutcome(approvalOutcome);
+    } catch (error) {
+      return nativeRelayUnavailableOutcome(params.ignoreUnavailable, error);
+    }
+  }
+  try {
+    const response = await invokeNativeHookRelay({
+      provider: "codex",
+      relayId: params.nativeHookRelay.relayId,
+      generation: params.nativeHookRelay.generation,
+      event: "pre_tool_use",
+      rawPayload: payload,
+      requireGeneration: true,
+    });
+    const decision = params.readDecision(response);
+    if (decision.blocked) {
+      return {
+        handled: true,
+        blocked: true,
+        reason: decision.reason,
+        ...(decision.failureDisposition ? { failureDisposition: decision.failureDisposition } : {}),
+      };
+    }
+    const approvalOutcome = await resolveNativeHookRelayDeferredToolApproval({
+      relayId: params.nativeHookRelay.relayId,
+      toolUseId: params.context.approvalId,
+      signal: params.signal,
+    });
+    return mapNativeRelayApprovalOutcome(approvalOutcome);
+  } catch (error) {
+    return nativeRelayUnavailableOutcome(params.ignoreUnavailable, error);
+  }
+}
+
+function mapNativeRelayApprovalOutcome(
+  approvalOutcome: Awaited<ReturnType<typeof resolveNativeHookRelayDeferredToolApproval>>,
+): NativeRelayToolPolicyOutcome {
+  if (approvalOutcome?.outcome === "denied") {
+    return {
+      handled: true,
+      blocked: true,
+      reason: approvalOutcome.reason,
+      ...(approvalOutcome.failureDisposition
+        ? { failureDisposition: approvalOutcome.failureDisposition }
+        : {}),
+    };
+  }
+  return {
+    handled: true,
+    ...(approvalOutcome?.outcome === "approved-once" ? { outcome: approvalOutcome.outcome } : {}),
+  };
+}
+
+function nativeRelayUnavailableOutcome(
+  ignoreUnavailable: boolean | undefined,
+  error: unknown,
+): NativeRelayToolPolicyOutcome | undefined {
+  const message = formatErrorMessage(error);
+  if (ignoreUnavailable && UNAVAILABLE_NATIVE_RELAY_ERRORS.has(message)) {
+    return undefined;
+  }
+  return {
+    handled: true,
+    blocked: true,
+    reason: `OpenClaw native hook relay unavailable for Codex app-server approval: ${formatCodexDisplayText(
+      message,
+    )}`,
+    failureDisposition: "failed",
+  };
+}
+
+function buildNativeRelayPreToolUsePayload(params: {
+  requestParams: JsonObject | undefined;
+  policyRequest: { toolName: string; params: JsonObject };
+  context: ApprovalContext;
+  cwd?: string;
+}): JsonObject | undefined {
+  const command = readString(params.policyRequest.params, "command");
+  if (!command) {
+    return undefined;
+  }
+  const turnId = readString(params.requestParams, "turnId");
+  return {
+    hook_event_name: "PreToolUse",
+    openclaw_approval_mode: "report",
+    tool_name: "exec_command",
+    ...(params.context.approvalId ? { tool_use_id: params.context.approvalId } : {}),
+    ...(params.cwd ? { cwd: params.cwd } : {}),
+    ...(turnId ? { turn_id: turnId } : {}),
+    tool_input: {
+      ...params.policyRequest.params,
+      command,
+      cmd: command,
+    },
+  };
+}
+
+function readString(record: JsonObject | undefined, key: string): string | undefined {
+  const value = record?.[key];
+  return typeof value === "string" ? value : undefined;
+}
+
+function formatErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/extensions/codex/src/app-server/approval-bridge.test.ts
+++ b/extensions/codex/src/app-server/approval-bridge.test.ts
@@ -1564,6 +1564,44 @@ describe("Codex app-server approval bridge", () => {
     });
   });
 
+  it("auto-accepts full-auto command approvals when the native hook relay is unavailable", async () => {
+    const params = createParams();
+    mockInvokeNativeHookRelay.mockRejectedValueOnce(new Error("native hook relay not found"));
+
+    const result = await handleCodexAppServerApprovalRequest({
+      method: "item/commandExecution/requestApproval",
+      requestParams: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        itemId: "cmd-yolo-relay-missing",
+        command: "node --version",
+      },
+      paramsForRun: params,
+      threadId: "thread-1",
+      turnId: "turn-1",
+      nativeHookRelay: {
+        relayId: "relay-missing",
+        generation: "generation-1",
+        allowedEvents: ["pre_tool_use"],
+      },
+      autoApprove: true,
+    });
+
+    expect(result).toEqual({ decision: "acceptForSession" });
+    expect(mockInvokeNativeHookRelay).toHaveBeenCalledTimes(1);
+    expect(mockRunBeforeToolCallHook).toHaveBeenCalledWith(
+      expect.objectContaining({
+        toolName: "exec",
+        approvalMode: "request",
+      }),
+    );
+    expect(mockCallGatewayTool).not.toHaveBeenCalled();
+    findApprovalEvent(params, {
+      status: "approved",
+      message: "Codex app-server approval auto-approved by runtime policy.",
+    });
+  });
+
   it("keeps non-command approvals on the app-server approval route when a native relay is registered", async () => {
     const params = createParams();
     mockCallGatewayTool

--- a/extensions/codex/src/app-server/approval-bridge.ts
+++ b/extensions/codex/src/app-server/approval-bridge.ts
@@ -7,9 +7,6 @@ import {
   buildAgentHookContextChannelFields,
   type BeforeToolCallFailureDisposition,
   formatApprovalDisplayPath,
-  hasNativeHookRelayInvocation,
-  invokeNativeHookRelay,
-  resolveNativeHookRelayDeferredToolApproval,
   type EmbeddedRunAttemptParams,
   type NativeHookRelayProcessResponse,
   type NativeHookRelayRegistrationHandle,
@@ -18,6 +15,10 @@ import {
 import { normalizeTrimmedStringList } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { sliceUtf16Safe, truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { formatCodexDisplayText } from "../command-formatters.js";
+import {
+  runNativeRelayToolPolicyForApprovalRequest,
+  type NativeRelayPolicyDecision,
+} from "./approval-bridge-native-relay.js";
 import { resolveCodexToolAbortTerminalReason } from "./dynamic-tool-execution.js";
 import {
   approvalRequestExplicitlyUnavailable,
@@ -103,6 +104,7 @@ export async function handleCodexAppServerApprovalRequest(params: {
       paramsForRun: params.paramsForRun,
       context,
       nativeHookRelay: params.nativeHookRelay,
+      autoApprove: params.autoApprove,
       signal: params.signal,
     });
     if (policyOutcome?.outcome === "denied") {
@@ -406,6 +408,7 @@ async function runOpenClawToolPolicyForApprovalRequest(params: {
     NativeHookRelayRegistrationHandle,
     "allowedEvents" | "generation" | "relayId"
   >;
+  autoApprove?: boolean;
   signal?: AbortSignal;
 }): Promise<ApprovalPolicyOutcome | undefined> {
   const policyRequest = buildOpenClawToolPolicyRequest(params.method, params.requestParams);
@@ -419,8 +422,10 @@ async function runOpenClawToolPolicyForApprovalRequest(params: {
     context: params.context,
     policyRequest,
     nativeHookRelay: params.nativeHookRelay,
+    ignoreUnavailable: params.autoApprove === true,
     cwd,
     signal: params.signal,
+    readDecision: readNativeRelayPreToolUseDecision,
   });
   if (nativeRelayOutcome?.blocked) {
     return {
@@ -490,157 +495,9 @@ async function runOpenClawToolPolicyForApprovalRequest(params: {
   return undefined;
 }
 
-async function runNativeRelayToolPolicyForApprovalRequest(params: {
-  method: string;
-  requestParams: JsonObject | undefined;
-  context: ApprovalContext;
-  policyRequest: { toolName: string; params: JsonObject };
-  nativeHookRelay?: Pick<
-    NativeHookRelayRegistrationHandle,
-    "allowedEvents" | "generation" | "relayId"
-  >;
-  cwd?: string;
-  signal?: AbortSignal;
-}): Promise<
-  | {
-      handled: true;
-      blocked: true;
-      reason: string;
-      failureDisposition?: Exclude<BeforeToolCallFailureDisposition, "blocked">;
-    }
-  | {
-      handled: true;
-      blocked?: false;
-      outcome?: "approved-once" | "approved-session";
-    }
-  | undefined
-> {
-  // Only command approvals correspond to Codex PreToolUse execution. File-change
-  // and permission approvals stay on the app-server approval route below.
-  if (
-    params.method !== "item/commandExecution/requestApproval" ||
-    !params.nativeHookRelay?.allowedEvents.includes("pre_tool_use")
-  ) {
-    return undefined;
-  }
-  const payload = buildNativeRelayPreToolUsePayload({
-    requestParams: params.requestParams,
-    policyRequest: params.policyRequest,
-    context: params.context,
-    cwd: params.cwd,
-  });
-  if (!payload) {
-    return undefined;
-  }
-  if (
-    hasNativeHookRelayInvocation({
-      relayId: params.nativeHookRelay.relayId,
-      event: "pre_tool_use",
-      toolUseId: params.context.approvalId,
-    })
-  ) {
-    const approvalOutcome = await resolveNativeHookRelayDeferredToolApproval({
-      relayId: params.nativeHookRelay.relayId,
-      toolUseId: params.context.approvalId,
-      signal: params.signal,
-    });
-    if (approvalOutcome?.outcome === "denied") {
-      return {
-        handled: true,
-        blocked: true,
-        reason: approvalOutcome.reason,
-        ...(approvalOutcome.failureDisposition
-          ? { failureDisposition: approvalOutcome.failureDisposition }
-          : {}),
-      };
-    }
-    if (approvalOutcome?.outcome === "approved-once") {
-      return { handled: true, outcome: approvalOutcome.outcome };
-    }
-    return { handled: true };
-  }
-  try {
-    const response = await invokeNativeHookRelay({
-      provider: "codex",
-      relayId: params.nativeHookRelay.relayId,
-      generation: params.nativeHookRelay.generation,
-      event: "pre_tool_use",
-      rawPayload: payload,
-      requireGeneration: true,
-    });
-    const decision = readNativeRelayPreToolUseDecision(response);
-    if (decision.blocked) {
-      return {
-        handled: true,
-        blocked: true,
-        reason: decision.reason,
-        ...(decision.failureDisposition ? { failureDisposition: decision.failureDisposition } : {}),
-      };
-    }
-    const approvalOutcome = await resolveNativeHookRelayDeferredToolApproval({
-      relayId: params.nativeHookRelay.relayId,
-      toolUseId: params.context.approvalId,
-      signal: params.signal,
-    });
-    if (approvalOutcome?.outcome === "denied") {
-      return {
-        handled: true,
-        blocked: true,
-        reason: approvalOutcome.reason,
-        ...(approvalOutcome.failureDisposition
-          ? { failureDisposition: approvalOutcome.failureDisposition }
-          : {}),
-      };
-    }
-    if (approvalOutcome?.outcome === "approved-once") {
-      return { handled: true, outcome: approvalOutcome.outcome };
-    }
-    return { handled: true };
-  } catch (error) {
-    return {
-      handled: true,
-      blocked: true,
-      reason: `OpenClaw native hook relay unavailable for Codex app-server approval: ${formatCodexDisplayText(
-        formatErrorMessage(error),
-      )}`,
-      failureDisposition: "failed",
-    };
-  }
-}
-
-function buildNativeRelayPreToolUsePayload(params: {
-  requestParams: JsonObject | undefined;
-  policyRequest: { toolName: string; params: JsonObject };
-  context: ApprovalContext;
-  cwd?: string;
-}): JsonObject | undefined {
-  const command = readString(params.policyRequest.params, "command");
-  if (!command) {
-    return undefined;
-  }
-  const turnId = readString(params.requestParams, "turnId");
-  return {
-    hook_event_name: "PreToolUse",
-    openclaw_approval_mode: "report",
-    tool_name: "exec_command",
-    ...(params.context.approvalId ? { tool_use_id: params.context.approvalId } : {}),
-    ...(params.cwd ? { cwd: params.cwd } : {}),
-    ...(turnId ? { turn_id: turnId } : {}),
-    tool_input: {
-      ...params.policyRequest.params,
-      command,
-      cmd: command,
-    },
-  };
-}
-
-function readNativeRelayPreToolUseDecision(response: NativeHookRelayProcessResponse | undefined):
-  | {
-      blocked: true;
-      reason: string;
-      failureDisposition?: Exclude<BeforeToolCallFailureDisposition, "blocked">;
-    }
-  | { blocked: false } {
+function readNativeRelayPreToolUseDecision(
+  response: NativeHookRelayProcessResponse | undefined,
+): NativeRelayPolicyDecision {
   if (!response || response.exitCode !== 0) {
     return {
       blocked: true,


### PR DESCRIPTION
Closes #107447.

## What Problem This Solves

Full-auto Codex app-server command approvals can still be declined before execution when the native hook relay is missing or stale.

The failing shape is a runtime that should not require human exec approval: `approvalPolicy=never`, `sandbox=danger-full-access`, no network proxy, corresponding to OpenClaw `tools.exec.security=full` and `tools.exec.ask=off`. The approval bridge checked the native hook relay before honoring `autoApprove`, so relay unavailability could send Codex a decline decision and produce a pre-exec `status: declined` command item.

This is the underlying approval-ordering bug behind the class of failures that #107202 / #107205 only made less misleading in chat.

## What Changed

- Pass the full-auto `autoApprove` state into the app-server tool policy path.
- Treat native hook relay unavailability as non-authoritative only in that full-auto path.
- Continue running the normal OpenClaw before-tool-call hook before auto-accepting.
- Keep explicit native hook denials blocking.
- Keep malformed/non-deny relay responses fail-closed.
- Add regression coverage for full-auto command approval with an unavailable native hook relay.

## Evidence

Local validation on `codex/full-auto-relay-unavailable`:

```text
node scripts/test-projects.mjs extensions/codex/src/app-server/approval-bridge.test.ts extensions/codex/src/app-server/run-attempt.native-hook-relay.test.ts extensions/codex/src/app-server/config.test.ts extensions/codex/src/conversation-binding.test.ts
```

Result: 4 test files passed, 253 tests passed.

```text
pnpm tsgo:core
```

Result: passed.

```text
git diff --check
```

Result: passed.

The new regression asserts that when `autoApprove: true` and `invokeNativeHookRelay()` throws `native hook relay not found`, the bridge returns `{ decision: "acceptForSession" }`, does not open a gateway/plugin approval, still runs `runBeforeToolCallHook`, and emits the runtime-policy auto-approved event.
