### PR TITLE
fix(scripts): type gateway WebSocket payload

### DIFF
--- a/scripts/lib/gateway-ws-client.ts
+++ b/scripts/lib/gateway-ws-client.ts
@@ -128,7 +128,8 @@ export function createGatewayWsClient(params: {
     });
 
   ws.on("message", (data) => {
-    const text = data.toString();
+    // `ws` emits Buffer here under nodebuffer mode, though its listener type remains RawData.
+    const text = (data as Buffer).toString("utf8");
     let frame: GatewayFrame | null;
     try {
       frame = JSON.parse(text) as GatewayFrame;


### PR DESCRIPTION
## What Problem This Solves

The tooling lint lane fails on current `main` because `ws` exposes message data as the broad `RawData` union, so direct stringification trips `no-base-to-string`.

## Why This Change Was Made

Make the existing `binaryType = "nodebuffer"` contract explicit at the listener. Upstream `ws` source emits a `Buffer` for text and binary messages in nodebuffer mode; its TypeScript listener signature does not narrow with that setting.

## User Impact

No behavior change. Repository gateway scripts keep decoding inbound frames as UTF-8, and the tooling gate is green again.

## Evidence

- Linux Testbox: `pnpm test test/scripts/gateway-ws-client.test.ts test/scripts/verify-release-notes.test.ts` — 34 tests passed
- Linux Testbox: targeted script lint and root test typecheck — passed
- Linux Testbox: `pnpm check:changed` — passed
- Fresh autoreview — clean, no actionable findings (0.96 confidence)
