### PR TITLE
refactor(fs-safe): use native JSON readers

### DIFF
--- a/src/infra/json-files.test.ts
+++ b/src/infra/json-files.test.ts
@@ -7,9 +7,7 @@ import {
   JsonFileReadError,
   createAsyncLock,
   readDurableJsonFile,
-  readJson,
   readJsonFile,
-  tryReadJson,
   writeJsonAtomic,
   writeTextAtomic,
 } from "./json-files.js";
@@ -210,88 +208,5 @@ describe("json file helpers", () => {
     await expect(first).rejects.toThrow(expectedFirstError);
     await expect(second).resolves.toBe("ok");
     expect(events).toEqual(expectedEvents);
-  });
-
-  describe("retry behaviors on 'File changed during read'", () => {
-    function skipRetryDelays(): void {
-      vi.spyOn(globalThis, "setTimeout").mockImplementation((callback) => {
-        queueMicrotask(() => callback());
-        return 0 as unknown as ReturnType<typeof setTimeout>;
-      });
-    }
-
-    /**
-     * Helper: spy on fsPromises.lstat for our target file path.
-     * Returns a real Stats object with a modified ino to trigger
-     * verifyStableReadTarget in @openclaw/fs-safe.
-     * Object.assign + Object.create preserves the Stats prototype.
-     */
-    function setupLstatSpy(targetPath: string, targetCallCount: number): () => number {
-      const origLstat = fsPromises.lstat.bind(fsPromises);
-      let callCount = 0;
-
-      vi.spyOn(fsPromises, "lstat").mockImplementation(async (p, ...args) => {
-        const stat = await origLstat(p, ...args);
-        const pathStr = typeof p === "string" ? p : String(p);
-        if (pathStr === targetPath) {
-          callCount++;
-          if (callCount <= targetCallCount) {
-            // Modify ino: for BigInt ino add 100n, for number ino add 100
-            const modifiedIno = typeof stat.ino === "bigint" ? stat.ino + 100n : stat.ino + 100;
-
-            // Clone stat preserving prototype, override ino
-            return Object.assign(Object.create(Object.getPrototypeOf(stat)), stat, {
-              ino: modifiedIno,
-            });
-          }
-        }
-        return stat;
-      });
-
-      return () => callCount;
-    }
-
-    it("retries on transient File changed during read and succeeds", async () => {
-      await withTempDir({ prefix: "openclaw-json-files-retry-" }, async (base) => {
-        const filePath = path.join(base, "config.json");
-        await fsPromises.writeFile(filePath, '{"ok":true}', "utf8");
-        skipRetryDelays();
-
-        // Only fail lstat once (first call) — retry should succeed on 2nd attempt
-        const getCalls = setupLstatSpy(filePath, 1);
-
-        const result = await readJson<{ ok: boolean }>(filePath);
-        expect(result).toEqual({ ok: true });
-        // Should have at least 2 lstat calls: one failed, one successful
-        expect(getCalls()).toBeGreaterThanOrEqual(2);
-      });
-    });
-
-    it("throws JsonFileReadError after exhausting retries on persistent race", async () => {
-      await withTempDir({ prefix: "openclaw-json-files-exhaust-" }, async (base) => {
-        const filePath = path.join(base, "config.json");
-        await fsPromises.writeFile(filePath, '{"ok":true}', "utf8");
-        skipRetryDelays();
-
-        // Always fail lstat — every retry attempt should exhaust.
-        setupLstatSpy(filePath, Infinity);
-
-        await expect(readJson(filePath)).rejects.toThrow(JsonFileReadError);
-      });
-    });
-
-    it("tryReadJson returns null after exhausting retries", async () => {
-      await withTempDir({ prefix: "openclaw-json-files-try-" }, async (base) => {
-        const filePath = path.join(base, "config.json");
-        await fsPromises.writeFile(filePath, '{"ok":true}', "utf8");
-        skipRetryDelays();
-
-        // Always fail lstat — tryReadJson catches and returns null
-        setupLstatSpy(filePath, Infinity);
-
-        const result = await tryReadJson(filePath);
-        expect(result).toBeNull();
-      });
-    });
   });
 });

--- a/src/infra/json-files.ts
+++ b/src/infra/json-files.ts
@@ -1,10 +1,5 @@
 // Wraps fs-safe JSON reads and atomic writes with OpenClaw defaults.
 import "./fs-safe-defaults.js";
-import {
-  JsonFileReadError,
-  readJson as readJsonImpl,
-  readJsonIfExists as readJsonIfExistsImpl,
-} from "@openclaw/fs-safe/json";
 import { replaceFileAtomic } from "./replace-file.js";
 
 type WriteTextAtomicBeforeRename = (params: {
@@ -14,66 +9,22 @@ type WriteTextAtomicBeforeRename = (params: {
 
 export {
   JsonFileReadError,
+  readJson,
+  readJson as readJsonFileStrict,
+  readJsonIfExists,
+  readJsonIfExists as readDurableJsonFile,
   readJsonSync,
   readRootJsonObjectSync,
   readRootJsonSync,
   readRootStructuredFileSync,
+  tryReadJson,
+  tryReadJson as readJsonFile,
   tryReadJsonSync,
   tryReadJsonSync as readJsonFileSync,
   writeJson,
   writeJson as writeJsonAtomic,
   writeJsonSync,
 } from "@openclaw/fs-safe/json";
-
-/** Reads and parses JSON, wrapping unexpected read failures in JsonFileReadError. */
-export async function readJson<T>(filePath: string): Promise<T> {
-  try {
-    return await readJsonImpl<T>(filePath);
-  } catch (err) {
-    throw err instanceof JsonFileReadError ? err : new JsonFileReadError(filePath, "read", err);
-  }
-}
-
-/** Strict JSON read alias for callers that must fail on missing or invalid files. */
-export async function readJsonFileStrict<T>(filePath: string): Promise<T> {
-  return readJson<T>(filePath);
-}
-
-/** Reads JSON when the file exists, returning null only for a missing path. */
-export async function readJsonIfExists<T>(filePath: string): Promise<T | null> {
-  try {
-    return await readJsonIfExistsImpl<T>(filePath);
-  } catch (err) {
-    if (err instanceof JsonFileReadError) {
-      throw err;
-    }
-    throw new JsonFileReadError(filePath, "read", err);
-  }
-}
-
-/** Durable JSON read alias that keeps parse/read errors visible to callers. */
-export async function readDurableJsonFile<T>(filePath: string): Promise<T | null> {
-  return readJsonIfExists<T>(filePath);
-}
-
-/**
- * tryReadJson delegates to readJsonIfExists instead of the internal
- * tryReadJsonImpl from @openclaw/fs-safe. The fs-safe implementation retries
- * race conditions before propagating errors; this wrapper keeps the historical
- * null-on-error contract for callers that intentionally treat reads as optional.
- */
-export async function tryReadJson<T>(filePath: string): Promise<T | null> {
-  try {
-    return await readJsonIfExists<T>(filePath);
-  } catch {
-    return null;
-  }
-}
-
-/** Optional JSON read that returns null for missing, invalid, or racing files. */
-export async function readJsonFile<T>(filePath: string): Promise<T | null> {
-  return tryReadJson<T>(filePath);
-}
 
 export { createAsyncLock } from "@openclaw/fs-safe/advanced";
 


### PR DESCRIPTION
## What Problem This Solves

OpenClaw wrapped three JSON readers and duplicated retry tests even though pinned `@openclaw/fs-safe` now owns the same strict, missing-only, lenient, and race-retry contracts.

## Why This Change Was Made

Re-export the dependency's typed readers directly under the existing OpenClaw names. Keep OpenClaw's fs-safe defaults initialization and alias-contract tests; remove wrappers and tests of dependency internals.

## User Impact

No behavior change. Removes 134 lines while preserving all existing import names and failure shapes.

## Evidence

- `node scripts/run-vitest.mjs src/infra/json-files.test.ts src/infra/archive-helpers.test.ts src/infra/npm-managed-root.test.ts` — 55 passed
- `git diff --check`
- Fresh local and exact-branch autoreview: clean
- Direct inspection of `@openclaw/fs-safe@0.4.1` source, declarations, and JSON-reader documentation

Hosted CI intentionally not awaited per maintainer direction.
