### PR TITLE
refactor(ws): normalize raw message payloads

### DIFF
--- a/packages/gateway-client/src/client.ts
+++ b/packages/gateway-client/src/client.ts
@@ -1,4 +1,3 @@
-// Gateway Client module implements client behavior.
 import { randomUUID } from "node:crypto";
 import {
   GATEWAY_CLIENT_MODES,
@@ -44,6 +43,7 @@ import {
 } from "./protocol-client.js";
 import { shouldPauseGatewayReconnect } from "./reconnect-policy.js";
 import { resolveConnectChallengeTimeoutMs, resolveSafeTimeoutDelayMs } from "./timeouts.js";
+import { rawDataToString } from "./websocket-data.js";
 
 export type DeviceIdentity = {
   deviceId: string;
@@ -614,7 +614,7 @@ export class GatewayClient {
       }
       this.transportValidated = true;
     });
-    ws.on("message", (data) => handlers.message((data as Buffer).toString()));
+    ws.on("message", (data) => handlers.message(rawDataToString(data)));
     ws.on("close", (code, reason) => {
       const reasonText = reason.toString();
       if (this.ws === ws) {

--- a/packages/gateway-client/src/client.watchdog.test.ts
+++ b/packages/gateway-client/src/client.watchdog.test.ts
@@ -6,6 +6,7 @@ import { WebSocket, WebSocketServer } from "ws";
 import { GatewayClient } from "./client.js";
 import type { GatewayProtocolSocket } from "./protocol-client.js";
 import { MAX_SAFE_TIMEOUT_DELAY_MS } from "./timeouts.js";
+import { rawDataToString } from "./websocket-data.js";
 
 async function getFreePort(): Promise<number> {
   return await new Promise((resolve, reject) => {
@@ -15,22 +16,6 @@ async function getFreePort(): Promise<number> {
       server.close((err) => (err ? reject(err) : resolve(port)));
     });
   });
-}
-
-function rawDataToString(data: unknown): string {
-  if (typeof data === "string") {
-    return data;
-  }
-  if (Buffer.isBuffer(data)) {
-    return data.toString("utf8");
-  }
-  if (data instanceof ArrayBuffer) {
-    return Buffer.from(data).toString("utf8");
-  }
-  if (Array.isArray(data)) {
-    return Buffer.concat(data.map((entry) => Buffer.from(entry))).toString("utf8");
-  }
-  return String(data);
 }
 
 function createOpenGatewayClient(requestTimeoutMs: number): {
@@ -48,6 +33,12 @@ function createOpenGatewayClient(requestTimeoutMs: number): {
 function getPendingCount(client: GatewayClient): number {
   return protocolHarness(client).pending.size;
 }
+
+test("decodes every ws raw-data shape", () => {
+  expect(rawDataToString(Buffer.from("buffer"))).toBe("buffer");
+  expect(rawDataToString(Uint8Array.from(Buffer.from("array-buffer")).buffer)).toBe("array-buffer");
+  expect(rawDataToString([Buffer.from("frag"), Buffer.from("ments")])).toBe("fragments");
+});
 
 type ProtocolHarness = {
   socket: GatewayProtocolSocket | null;

--- a/packages/gateway-client/src/websocket-data.ts
+++ b/packages/gateway-client/src/websocket-data.ts
@@ -1,0 +1,10 @@
+// Gateway Client WebSocket helpers normalize transport payloads without a core dependency.
+import { Buffer } from "node:buffer";
+import type { RawData } from "ws";
+
+export function rawDataToString(data: RawData): string {
+  if (Array.isArray(data)) {
+    return Buffer.concat(data).toString("utf8");
+  }
+  return data instanceof ArrayBuffer ? Buffer.from(data).toString("utf8") : data.toString("utf8");
+}

--- a/packages/sdk/src/index.e2e.test.ts
+++ b/packages/sdk/src/index.e2e.test.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { WebSocketServer, type WebSocket } from "ws";
 import { installGatewayTestHooks, startServer } from "../../../src/gateway/test-helpers.js";
 import { emitAgentEvent, registerAgentRunContext } from "../../../src/infra/agent-events.js";
+import { rawDataToString } from "../../../src/infra/ws.js";
 import { withTimeout } from "../../../src/utils/with-timeout.js";
 import { GatewayClientTransport, OpenClaw } from "./index.js";
 
@@ -61,7 +62,7 @@ async function createFakeGateway(port = 0): Promise<FakeGateway> {
     });
 
     socket.on("message", (raw) => {
-      const frame = JSON.parse((raw as Buffer).toString()) as FakeGatewayRequest;
+      const frame = JSON.parse(rawDataToString(raw)) as FakeGatewayRequest;
       requests.push(frame);
       const reply = (payload: JsonObject): void => {
         sendJson(socket, { type: "res", id: frame.id, ok: true, payload });

--- a/scripts/lib/gateway-ws-client.ts
+++ b/scripts/lib/gateway-ws-client.ts
@@ -1,6 +1,7 @@
 // Gateway Ws Client script supports OpenClaw repository automation.
 import { randomUUID } from "node:crypto";
 import WebSocket from "ws";
+import { rawDataToString } from "../../src/infra/ws.js";
 
 type GatewayReqFrame = { type: "req"; id: string; method: string; params?: unknown };
 type GatewayResFrame = {
@@ -128,7 +129,7 @@ export function createGatewayWsClient(params: {
     });
 
   ws.on("message", (data) => {
-    const text = (data as Buffer).toString();
+    const text = rawDataToString(data);
     let frame: GatewayFrame | null;
     try {
       frame = JSON.parse(text) as GatewayFrame;


### PR DESCRIPTION
## What Problem This Solves

The lint hotfix on current `main` casts three WebSocket message payloads to `Buffer`. That satisfies lint because every socket currently sets `binaryType = "nodebuffer"`, but it encodes the invariant only as an unchecked cast and leaves the package test's duplicate decoder in place.

## Why This Change Was Made

Normalize every `RawData` variant explicitly. Core-owning test/script callers reuse `src/infra/ws.ts`; the standalone gateway-client package gets one internal helper instead of depending on core. Its watchdog test now reuses that helper rather than keeping a duplicate decoder. This supersedes the cast-only hotfix from `7abb20fe33b`.

## User Impact

Gateway and SDK WebSocket messages decode consistently for Buffer, ArrayBuffer, and fragmented Buffer payloads without unchecked casts.

## Evidence

- Blacksmith Testbox `tbx_01kxg8v1b0yvp2h0yhn8fk55kd`, run 29331806186: touched format, LOC ratchet, tsgo, core/script lint, boundaries, and repository guards passed.
- Same Testbox: gateway-client 18/18, gateway script 6/6, SDK E2E 4 passed / 1 intentionally skipped.
- Added direct coverage for all three `ws` `RawData` variants.
- `git diff --check` passed.
- Fresh autoreview: no accepted/actionable findings.
