### PR TITLE
fix(sessions-send): normalize sourceSessionKey to dmScope-resolved canonical key

### DIFF
--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -15,6 +15,7 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { callGateway } from "../../gateway/call.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import {
+  buildAgentMainSessionKey,
   isSubagentSessionKey,
   normalizeAgentId,
   resolveAgentIdFromSessionKey,
@@ -558,18 +559,43 @@ export function createSessionsSendTool(opts?: {
       }
 
       const requesterSessionKey = opts?.agentSessionKey ? effectiveRequesterKey : undefined;
+      // When dmScope is "main", DMs route to agent:{agentId}:{mainKey}.
+      // A session originally created under a per-peer / per-channel-peer /
+      // per-account-channel-peer regime stores a key like
+      //   agent:main:feishu:default:direct:ou_XXXX
+      // Embedding that stale key in inter-session provenance causes the
+      // receiving agent to reply into a ghost session the sender never
+      // monitors — permanent one-way communication failure.
+      //
+      // Only canonicalize keys whose parsed rest contains a "direct" peer-kind
+      // segment (legacy DM keys). Group, cron, hook, subagent, and other
+      // non-DM callers must preserve their exact session key for correct
+      // routing, watch registration, and A2A ping-pong bookkeeping.
+      const parsedRequester = requesterSessionKey
+        ? parseAgentSessionKey(requesterSessionKey)
+        : null;
+      const isLegacyDmRequester = parsedRequester
+        ? parsedRequester.rest.split(":").includes("direct")
+        : false;
+      const normalizedRequesterKey =
+        requesterSessionKey && (cfg.session?.dmScope ?? "main") === "main" && isLegacyDmRequester
+          ? buildAgentMainSessionKey({
+              agentId: resolveAgentIdFromSessionKey(requesterSessionKey),
+              mainKey,
+            })
+          : requesterSessionKey;
       const requesterChannel = opts?.agentChannel;
-      const sameSessionA2A = requesterSessionKey === resolvedKey;
-      const isIsolatedCronRequester = isCronRunSessionKey(requesterSessionKey);
+      const sameSessionA2A = normalizedRequesterKey === resolvedKey;
+      const isIsolatedCronRequester = isCronRunSessionKey(normalizedRequesterKey);
       // Watch registration follows successful dispatch: a failed send must not leave
       // a hidden watch, and cron run-scoped sends can fall back to the durable parent
       // session, which is the key that receives future state changes.
       const watchRequested = params.watch === true;
       const registerWatchIfRequested = (targetSessionKey: string) => {
         const watched =
-          watchRequested && requesterSessionKey && requesterSessionKey !== targetSessionKey
+          watchRequested && normalizedRequesterKey && normalizedRequesterKey !== targetSessionKey
             ? registerSessionStateWatch({
-                watcherSessionKey: requesterSessionKey,
+                watcherSessionKey: normalizedRequesterKey,
                 targetSessionKey,
               })
             : false;
@@ -613,13 +639,13 @@ export function createSessionsSendTool(opts?: {
           : undefined;
 
       const agentMessageContext = buildAgentToAgentMessageContext({
-        requesterSessionKey,
+        requesterSessionKey: normalizedRequesterKey,
         requesterChannel,
         targetSessionKey: displayKey,
       });
       const inputProvenance = {
         kind: "inter_session" as const,
-        sourceSessionKey: requesterSessionKey,
+        sourceSessionKey: normalizedRequesterKey,
         sourceChannel: requesterChannel,
         sourceTool: "sessions_send",
       };
@@ -699,7 +725,7 @@ export function createSessionsSendTool(opts?: {
           // Cron runs are isolated jobs; target replies must not become new
           // requester turns, but the target-side announce still runs.
           maxPingPongTurns: isIsolatedCronRequester ? 0 : maxPingPongTurns,
-          requesterSessionKey,
+          requesterSessionKey: normalizedRequesterKey,
           requesterChannel,
           baseline: flowBaseline,
           roundOneReply,


### PR DESCRIPTION
## What Problem This Solves

When `session.dmScope` is `"main"` (default), inter-agent messages sent via `sessions_send` embed the calling session persisted storage key as `sourceSessionKey` — even when that key was created under a previous `per-account-channel-peer` routing regime. The receiving agent replies to the stale key, creating a ghost session that the sender never monitors, causing permanent one-way communication failure between agents.

**Split path:**
1. **Inbound user DMs** → resolved via `buildAgentPeerSessionKey()` with `dmScope="main"` → lands in `agent:{id}:main` ✓
2. **Inter-session replies** → routed to `sourceSessionKey` from provenance → lands in `agent:{id}:{channel}:{account}:direct:{peer}` (stale format) ✗

Two different session keys → two different sessions → the agent in session A never sees replies delivered to session B.

## Why This Change Was Made

The `sessions_send` tool passed `opts.agentSessionKey` verbatim into `inputProvenance.sourceSessionKey`. This is the session persisted key from storage, not a dmScope-resolved key. The fix normalizes the requester key through `buildAgentMainSessionKey()` when `dmScope` is `"main"`, so all downstream provenance, watch registration, same-session detection, and A2A ping-pong routing use the same canonical key that the agent actually monitors.

## User Impact

Multi-agent setups using `dmScope="main"` (the default) with sessions that predate a routing regime change will now correctly route inter-agent replies back to the sender monitored session. No config changes required. Operators with `dmScope` set to `per-peer`, `per-channel-peer`, or `per-account-channel-peer` are unaffected — the normalization only activates when `dmScope` is `"main"`.

## Evidence

- `sessions-send-helpers.test.ts`: **10/10 passed**
- `sessions-send-tool.a2a.test.ts`: **25/25 passed**
- oxfmt and git diff --check clean

Fixes #107399
