### PR TITLE
refactor(bonjour): trust ciao rejection handling

### DIFF
--- a/extensions/bonjour/src/advertiser.test.ts
+++ b/extensions/bonjour/src/advertiser.test.ts
@@ -317,31 +317,6 @@ describe("gateway bonjour advertiser", () => {
     await started.stop();
   });
 
-  it("installs only the scoped ciao unhandled-rejection listener by default", async () => {
-    enableAdvertiserUnitMode();
-
-    const destroy = vi.fn().mockResolvedValue(undefined);
-    const advertise = vi.fn().mockResolvedValue(undefined);
-    mockCiaoService({ advertise, destroy });
-    const processOn = vi.spyOn(process, "on");
-
-    const started = await startGatewayBonjourAdvertiser(
-      {
-        gatewayPort: 18789,
-        sshPort: 2222,
-      },
-      { logger },
-    );
-
-    const unhandledRejectionRegistration = processOn.mock.calls.find(
-      ([event]) => event === "unhandledRejection",
-    );
-    expect(unhandledRejectionRegistration?.[1]).toBeTypeOf("function");
-    expect(processOn.mock.calls.map(([event]) => event)).not.toContain("uncaughtException");
-
-    await started.stop();
-  });
-
   it("cleans up ciao process handlers after shutdown", async () => {
     enableAdvertiserUnitMode();
 
@@ -376,7 +351,7 @@ describe("gateway bonjour advertiser", () => {
     expect(order).toEqual(["shutdown", "cleanup-exception", "cleanup-rejection"]);
   });
 
-  it("logs ciao handler classifications at the bonjour caller", async () => {
+  it("handles ciao netmask assertions at the bonjour caller", async () => {
     enableAdvertiserUnitMode();
 
     const destroy = vi.fn().mockResolvedValue(undefined);
@@ -388,19 +363,11 @@ describe("gateway bonjour advertiser", () => {
       sshPort: 2222,
     });
 
-    const handler = mockCall(registerUnhandledRejectionHandler).at(0) as
-      | ((reason: unknown) => boolean)
-      | undefined;
     const exceptionHandler = mockCall(registerUncaughtExceptionHandler).at(0) as
       | ((reason: unknown) => boolean)
       | undefined;
-    expect(handler).toBeTypeOf("function");
     expect(exceptionHandler).toBeTypeOf("function");
 
-    expect(handler?.(new Error("CIAO PROBING CANCELLED"))).toBe(true);
-    expectWarnContaining("suppressing ciao cancellation");
-
-    logger.warn.mockClear();
     expect(
       exceptionHandler?.(
         Object.assign(
@@ -412,45 +379,6 @@ describe("gateway bonjour advertiser", () => {
       ),
     ).toBe(true);
     expectWarnContaining("suppressing ciao netmask assertion");
-
-    logger.warn.mockClear();
-    expect(
-      handler?.(
-        new Error(
-          "Can't probe for a service which is announced already. Received announcing for service OpenClaw Gateway._openclaw._tcp.local.",
-        ),
-      ),
-    ).toBe(true);
-    expectWarnContaining("suppressing ciao self-probe race");
-
-    await started.stop();
-  });
-
-  it("recovers when ciao cancellation escapes the advertiser", async () => {
-    enableAdvertiserUnitMode();
-
-    const destroy = vi.fn().mockResolvedValue(undefined);
-    const advertise = vi.fn().mockResolvedValue(undefined);
-    mockCiaoService({ advertise, destroy });
-
-    const started = await startAdvertiser({
-      gatewayPort: 18789,
-      sshPort: 2222,
-    });
-
-    const handler = mockCall(registerUnhandledRejectionHandler).at(0) as
-      | ((reason: unknown) => boolean)
-      | undefined;
-    expect(handler?.(new Error("CIAO ANNOUNCEMENT CANCELLED"))).toBe(true);
-
-    await vi.waitFor(() => {
-      expect(createService).toHaveBeenCalledTimes(2);
-    });
-
-    expectWarnContaining("suppressing ciao cancellation");
-    expectWarnContaining("restarting advertiser");
-    expect(destroy).toHaveBeenCalledTimes(1);
-    expect(advertise).toHaveBeenCalledTimes(2);
 
     await started.stop();
   });

--- a/extensions/bonjour/src/advertiser.ts
+++ b/extensions/bonjour/src/advertiser.ts
@@ -35,12 +35,11 @@ type ServiceStateTracker = {
 type ConsoleLogFn = (...args: unknown[]) => void;
 type UncaughtExceptionHandler = (error: unknown) => boolean;
 type UnhandledRejectionHandler = (reason: unknown) => boolean;
-type ProcessUnhandledRejectionListener = (reason: unknown, promise: Promise<unknown>) => void;
 
 type BonjourAdvertiserDeps = {
   logger?: Pick<PluginLogger, "info" | "warn" | "debug">;
-  registerUncaughtExceptionHandler?: (handler: UncaughtExceptionHandler) => () => void;
-  registerUnhandledRejectionHandler?: (handler: UnhandledRejectionHandler) => () => void;
+  registerUncaughtExceptionHandler: (handler: UncaughtExceptionHandler) => () => void;
+  registerUnhandledRejectionHandler: (handler: UnhandledRejectionHandler) => () => void;
 };
 
 const WATCHDOG_INTERVAL_MS = 5_000;
@@ -203,29 +202,10 @@ function installCiaoConsoleNoiseFilter(): () => void {
   };
 }
 
-function installCiaoUnhandledRejectionListener(handler: UnhandledRejectionHandler): () => void {
-  const hadOtherListeners = process.listenerCount("unhandledRejection") > 0;
-  const listener: ProcessUnhandledRejectionListener = (reason) => {
-    if (handler(reason)) {
-      return;
-    }
-    if (hadOtherListeners) {
-      return;
-    }
-    queueMicrotask(() => {
-      throw reason instanceof Error ? reason : new Error(String(reason));
-    });
-  };
-  process.on("unhandledRejection", listener);
-  return () => {
-    process.off("unhandledRejection", listener);
-  };
-}
-
 /** Start Bonjour advertisements for the local gateway services. */
 export async function startGatewayBonjourAdvertiser(
   opts: GatewayBonjourAdvertiseOpts,
-  deps: BonjourAdvertiserDeps = {},
+  deps: BonjourAdvertiserDeps,
 ): Promise<GatewayBonjourAdvertiser> {
   if (isDisabledByEnv()) {
     return { stop: async () => {} };
@@ -245,7 +225,6 @@ export async function startGatewayBonjourAdvertiser(
   let restoreConsoleLog: () => void = () => {};
   let requestCiaoRecovery: ((classification: CiaoProcessErrorClassification) => void) | undefined;
   let cleanupUnhandledRejection: (() => void) | undefined;
-  let cleanupDirectUnhandledRejection: (() => void) | undefined;
   let cleanupUncaughtException: (() => void) | undefined;
   let processHandlersCleaned = false;
 
@@ -254,7 +233,6 @@ export async function startGatewayBonjourAdvertiser(
       return;
     }
     processHandlersCleaned = true;
-    cleanupDirectUnhandledRejection?.();
     cleanupUncaughtException?.();
     cleanupUnhandledRejection?.();
   }
@@ -268,10 +246,7 @@ export async function startGatewayBonjourAdvertiser(
         return false;
       }
 
-      if (classification.kind === "cancellation") {
-        logger.warn(`bonjour: suppressing ciao cancellation: ${classification.formatted}`);
-        requestCiaoRecovery?.(classification);
-      } else if (classification.kind === "interface-enumeration-failure") {
+      if (classification.kind === "interface-enumeration-failure") {
         // Restricted sandboxes can refuse os.networkInterfaces(); mDNS cannot
         // function without it, so surface a single warning and skip recovery.
         // Recovery would just re-enter the same failing syscall.
@@ -279,16 +254,13 @@ export async function startGatewayBonjourAdvertiser(
           `bonjour: disabling mDNS — networkInterfaces() unavailable in this environment: ${classification.formatted}`,
         );
       } else {
-        const label =
-          classification.kind === "netmask-assertion" ? "netmask assertion" : "self-probe race";
-        logger.warn(`bonjour: suppressing ciao ${label}: ${classification.formatted}`);
+        logger.warn(`bonjour: suppressing ciao netmask assertion: ${classification.formatted}`);
         requestCiaoRecovery?.(classification);
       }
       return true;
     };
-    cleanupDirectUnhandledRejection = installCiaoUnhandledRejectionListener(handleCiaoProcessError);
-    cleanupUnhandledRejection = deps.registerUnhandledRejectionHandler?.(handleCiaoProcessError);
-    cleanupUncaughtException = deps.registerUncaughtExceptionHandler?.(handleCiaoProcessError);
+    cleanupUnhandledRejection = deps.registerUnhandledRejectionHandler(handleCiaoProcessError);
+    cleanupUncaughtException = deps.registerUncaughtExceptionHandler(handleCiaoProcessError);
 
     const hostnameRaw =
       process.env.OPENCLAW_MDNS_HOSTNAME?.trim() || resolveSystemMdnsHostname() || "openclaw";

--- a/extensions/bonjour/src/ciao.test.ts
+++ b/extensions/bonjour/src/ciao.test.ts
@@ -4,13 +4,6 @@ import { describe, expect, it } from "vitest";
 const { classifyCiaoProcessError } = await import("./ciao.js");
 
 describe("bonjour-ciao", () => {
-  it("classifies ciao cancellation rejections separately from side effects", () => {
-    expect(classifyCiaoProcessError(new Error("CIAO PROBING CANCELLED"))).toEqual({
-      kind: "cancellation",
-      formatted: "CIAO PROBING CANCELLED",
-    });
-  });
-
   it("classifies ciao netmask assertions separately from side effects", () => {
     expect(
       classifyCiaoProcessError(
@@ -26,45 +19,6 @@ describe("bonjour-ciao", () => {
       formatted:
         "AssertionError: IP address version must match. Netmask cannot have a version different from the address!",
     });
-  });
-
-  it("classifies ciao self-probe races separately from side effects", () => {
-    expect(
-      classifyCiaoProcessError(
-        new Error(
-          "Can't probe for a service which is announced already. Received announcing for service OpenClaw Gateway._openclaw._tcp.local.",
-        ),
-      ),
-    ).toEqual({
-      kind: "self-probe",
-      formatted:
-        "Can't probe for a service which is announced already. Received announcing for service OpenClaw Gateway._openclaw._tcp.local.",
-    });
-  });
-
-  it("suppresses ciao announcement cancellation rejections", () => {
-    expect(classifyCiaoProcessError(new Error("Ciao announcement cancelled by shutdown"))).not.toBe(
-      null,
-    );
-  });
-
-  it("suppresses ciao probing cancellation rejections", () => {
-    expect(classifyCiaoProcessError(new Error("CIAO PROBING CANCELLED"))).not.toBe(null);
-  });
-
-  it("suppresses wrapped ciao cancellation rejections", () => {
-    expect(
-      classifyCiaoProcessError({
-        reason: new Error("CIAO ANNOUNCEMENT CANCELLED"),
-      }),
-    ).toEqual({
-      kind: "cancellation",
-      formatted: "CIAO ANNOUNCEMENT CANCELLED",
-    });
-  });
-
-  it("suppresses lower-case string cancellation reasons too", () => {
-    expect(classifyCiaoProcessError("ciao announcement cancelled during cleanup")).not.toBe(null);
   });
 
   it("suppresses ciao netmask assertion errors as non-fatal", () => {

--- a/extensions/bonjour/src/ciao.ts
+++ b/extensions/bonjour/src/ciao.ts
@@ -5,11 +5,8 @@
 import { collectErrorGraphCandidates } from "openclaw/plugin-sdk/error-runtime";
 import { formatBonjourError } from "./errors.js";
 
-const CIAO_CANCELLATION_MESSAGE_RE = /^CIAO (?:ANNOUNCEMENT|PROBING) CANCELLED\b/u;
 const CIAO_NETMASK_ASSERTION_MESSAGE_RE =
   /IP ADDRESS VERSION MUST MATCH\.\s+NETMASK CANNOT HAVE A VERSION DIFFERENT FROM THE ADDRESS!?/u;
-const CIAO_SELF_PROBE_MESSAGE_RE =
-  /CAN'T PROBE FOR A SERVICE WHICH IS ANNOUNCED ALREADY\.\s+RECEIVED (?:PROBING|ANNOUNCING|ANNOUNCED) FOR SERVICE\b/u;
 // Restricted sandboxes (NemoClaw, Docker-in-Docker, k3s with locked-down policy)
 // can refuse os.networkInterfaces(), which ciao calls during NetworkManager init.
 // Node surfaces this as a SystemError mentioning the libuv syscall by name.
@@ -17,9 +14,7 @@ const CIAO_INTERFACE_ENUMERATION_FAILURE_RE = /\bUV_INTERFACE_ADDRESSES\b/u;
 
 /** Known ciao process-level errors that OpenClaw handles specially. */
 export type CiaoProcessErrorClassification =
-  | { kind: "cancellation"; formatted: string }
   | { kind: "netmask-assertion"; formatted: string }
-  | { kind: "self-probe"; formatted: string }
   | { kind: "interface-enumeration-failure"; formatted: string };
 
 /** Classify a ciao error/rejection chain into a known category. */
@@ -34,14 +29,8 @@ export function classifyCiaoProcessError(reason: unknown): CiaoProcessErrorClass
   ])) {
     const formatted = formatBonjourError(candidate);
     const message = formatted.toUpperCase();
-    if (CIAO_CANCELLATION_MESSAGE_RE.test(message)) {
-      return { kind: "cancellation", formatted };
-    }
     if (CIAO_NETMASK_ASSERTION_MESSAGE_RE.test(message)) {
       return { kind: "netmask-assertion", formatted };
-    }
-    if (CIAO_SELF_PROBE_MESSAGE_RE.test(message)) {
-      return { kind: "self-probe", formatted };
     }
     if (CIAO_INTERFACE_ENUMERATION_FAILURE_RE.test(message)) {
       return { kind: "interface-enumeration-failure", formatted };


### PR DESCRIPTION
## What Problem This Solves

The Bonjour plugin still duplicated process-level handling for ciao lifecycle cancellations and self-probe retries that `@homebridge/ciao@1.3.9` now consumes internally.

## Why This Change Was Made

Trust ciao's pinned lifecycle contract, keep only OpenClaw handling for netmask and restricted-interface platform failures, and require the host process-handler registrars used by the sole production caller. This removes 157 lines of obsolete handling and tests.

## User Impact

No intended behavior change. Bonjour keeps its watchdog, console-noise filter, platform-failure handling, and host cleanup while avoiding duplicate rejection listeners and recovery paths.

## Evidence

- `node scripts/run-vitest.mjs extensions/bonjour/src/advertiser.test.ts extensions/bonjour/src/ciao.test.ts extensions/bonjour/index.test.ts src/gateway/server-discovery-runtime.test.ts` — 42 passed
- `git diff --check origin/main...HEAD`
- Live pinned-dependency probe cancellation: advertise and destroy fulfilled; zero unhandled rejections
- Live pinned-dependency announce cancellation: advertise and destroy fulfilled; zero unhandled rejections
- Fresh branch autoreview completed; one lifecycle concern was disproved by the exact ciao source and both live cancellation scenarios above
- Hosted CI intentionally not awaited per maintainer direction
