### PR TITLE
refactor(ui): privatize config autosave delay

### DIFF
--- a/ui/src/lib/config/index.test.ts
+++ b/ui/src/lib/config/index.test.ts
@@ -2,11 +2,9 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { ConfigSchemaResponse, ConfigSnapshot } from "../../api/types.ts";
-import {
-  CONFIG_FORM_AUTO_SAVE_DEBOUNCE_MS,
-  createRuntimeConfigCapability,
-  findAgentConfigEntryIndex,
-} from "./index.ts";
+import { createRuntimeConfigCapability, findAgentConfigEntryIndex } from "./index.ts";
+
+const CONFIG_FORM_AUTO_SAVE_DEBOUNCE_MS = 800;
 
 function deferred<T>() {
   let resolve!: (value: T) => void;

--- a/ui/src/lib/config/index.ts
+++ b/ui/src/lib/config/index.ts
@@ -17,7 +17,7 @@ import {
 export type ConfigAutoSaveStatus = "idle" | "saving" | "saved" | "error" | "conflict";
 
 /** Debounce window between the last form edit and its automatic config.set. */
-export const CONFIG_FORM_AUTO_SAVE_DEBOUNCE_MS = 800;
+const CONFIG_FORM_AUTO_SAVE_DEBOUNCE_MS = 800;
 
 /**
  * localStorage key recording the config hash of the last successful


### PR DESCRIPTION
## What Problem This Solves

Current main exposes `CONFIG_FORM_AUTO_SAVE_DEBOUNCE_MS` only for direct tests, so production Knip reports a new unused export outside the shrink-only baseline.

## Why This Change Was Made

Keep the runtime debounce constant module-private. Tests retain the 800 ms contract as a local literal while exercising the public runtime config capability.

## User Impact

None. Autosave timing and behavior are unchanged. The dead-export baseline stays byte-stable at 714 entries.

## Evidence

- Production dead-export check: exact 714 entries, no baseline change.
- Blacksmith Testbox `tbx_01kxgax3hs2h81hrjnr4m5xfka`: `ui/src/lib/config/index.test.ts` 59/59 and UI types green.
- Formatting green. Type-aware lint preparation was capped after 60 seconds with no output; the focused UI typecheck passed.
- Fresh autoreview: clean, confidence 0.98.
