### PR TITLE
fix(workspaces): reject non-decimal --grid segments via strict parser

### DIFF
--- a/extensions/workspaces/src/cli.test.ts
+++ b/extensions/workspaces/src/cli.test.ts
@@ -342,6 +342,42 @@ describe("workspace CLI", () => {
     });
   });
 
+  it.each([
+    ["0x10,0,4,2", "hex"],
+    ["1e2,0,4,2", "exponent"],
+    ["0o10,0,4,2", "octal literal"],
+    ["0b10,0,4,2", "binary literal"],
+    ["1.5,0,4,2", "decimal"],
+    ["-1,0,4,2", "negative"],
+    [",0,4,2", "empty segment"],
+    ["1,2,3", "too few segments"],
+    ["1,2,3,4,5", "too many segments"],
+    ["1a,2,3,4", "alphanumeric"],
+  ])("rejects %s (%s) --grid input", async (grid, _label) => {
+    await withTempStateDir(async (stateDir) => {
+      const store = new WorkspaceStore({ stateDir });
+      installGatewayMock(store);
+      const program = createProgram(stateDir);
+
+      await expect(
+        program.parseAsync(
+          [
+            "workspaces",
+            "widgets",
+            "add",
+            "--tab",
+            "ops",
+            "--kind",
+            "builtin:markdown",
+            "--grid",
+            grid,
+          ],
+          { from: "user" },
+        ),
+      ).rejects.toThrow("grid must be x,y,w,h");
+    });
+  });
+
   it("scaffolds operator widgets as pending and approves them through the approvals method", async () => {
     await withTempStateDir(async (stateDir) => {
       const store = new WorkspaceStore({ stateDir });

--- a/extensions/workspaces/src/cli.test.ts
+++ b/extensions/workspaces/src/cli.test.ts
@@ -343,39 +343,31 @@ describe("workspace CLI", () => {
   });
 
   it.each([
-    ["0x10,0,4,2", "hex"],
-    ["1e2,0,4,2", "exponent"],
-    ["0o10,0,4,2", "octal literal"],
-    ["0b10,0,4,2", "binary literal"],
-    ["1.5,0,4,2", "decimal"],
-    ["-1,0,4,2", "negative"],
+    ["0x1,0,4,2", "hex"],
+    ["1e0,0,4,2", "exponent"],
+    ["0o1,0,4,2", "octal literal"],
+    ["0b1,0,4,2", "binary literal"],
     [",0,4,2", "empty segment"],
-    ["1,2,3", "too few segments"],
-    ["1,2,3,4,5", "too many segments"],
-    ["1a,2,3,4", "alphanumeric"],
   ])("rejects %s (%s) --grid input", async (grid, _label) => {
-    await withTempStateDir(async (stateDir) => {
-      const store = new WorkspaceStore({ stateDir });
-      installGatewayMock(store);
-      const program = createProgram(stateDir);
+    const program = createProgram();
 
-      await expect(
-        program.parseAsync(
-          [
-            "workspaces",
-            "widgets",
-            "add",
-            "--tab",
-            "ops",
-            "--kind",
-            "builtin:markdown",
-            "--grid",
-            grid,
-          ],
-          { from: "user" },
-        ),
-      ).rejects.toThrow("grid must be x,y,w,h");
-    });
+    await expect(
+      program.parseAsync(
+        [
+          "workspaces",
+          "widgets",
+          "add",
+          "--tab",
+          "ops",
+          "--kind",
+          "builtin:markdown",
+          "--grid",
+          grid,
+        ],
+        { from: "user" },
+      ),
+    ).rejects.toThrow("grid must be x,y,w,h");
+    expect(gatewayRuntime.callGatewayFromCli).not.toHaveBeenCalled();
   });
 
   it("scaffolds operator widgets as pending and approves them through the approvals method", async () => {

--- a/extensions/workspaces/src/cli.ts
+++ b/extensions/workspaces/src/cli.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import type { Command } from "commander";
 import { addGatewayClientOptions, callGatewayFromCli } from "openclaw/plugin-sdk/gateway-runtime";
+import { parseStrictNonNegativeInteger } from "openclaw/plugin-sdk/number-runtime";
 import {
   validateWorkspaceDoc,
   type WorkspaceBinding,
@@ -59,12 +60,13 @@ function parseOptionalBoolean(value: string): boolean {
 }
 
 function parseWorkspaceGrid(value: string): WorkspaceGrid {
-  const parts = value.split(",").map((entry) => Number(entry.trim()));
-  if (parts.length !== 4 || parts.some((entry) => !Number.isInteger(entry))) {
+  // parseStrictNonNegativeInteger rejects the JS-coercion tokens (hex, octal,
+  // exponent, negative, empty) that bare `Number()` used to let through.
+  const parts = value.split(",").map((entry) => parseStrictNonNegativeInteger(entry.trim()));
+  if (parts.length !== 4 || parts.includes(undefined)) {
     throw new Error("grid must be x,y,w,h");
   }
-  const [x, y, w, h] = parts as [number, number, number, number];
-  return { x, y, w, h };
+  return { x: parts[0]!, y: parts[1]!, w: parts[2]!, h: parts[3]! };
 }
 
 export function parseWorkspaceBindingShorthand(value: string): [string, WorkspaceBinding] {

--- a/extensions/workspaces/src/cli.ts
+++ b/extensions/workspaces/src/cli.ts
@@ -60,8 +60,7 @@ function parseOptionalBoolean(value: string): boolean {
 }
 
 function parseWorkspaceGrid(value: string): WorkspaceGrid {
-  // parseStrictNonNegativeInteger rejects the JS-coercion tokens (hex, octal,
-  // exponent, negative, empty) that bare `Number()` used to let through.
+  // Reject alternate JS numeric spellings that the CLI contract does not expose.
   const parts = value.split(",").map((entry) => parseStrictNonNegativeInteger(entry.trim()));
   if (parts.length !== 4 || parts.includes(undefined)) {
     throw new Error("grid must be x,y,w,h");


### PR DESCRIPTION
## What Problem This Solves

The Workspaces CLI accepted JavaScript-only numeric spellings in `--grid`, because its private parser used `Number()` for each segment. In-range inputs such as `0x1,0,4,2`, `1e0,0,4,2`, `0o1,0,4,2`, `0b1,0,4,2`, and an empty first segment were silently normalized to valid persisted decimal coordinates.

## Why This Change Was Made

The CLI owns string spelling before that information is lost. It now uses the existing `parseStrictNonNegativeInteger` Plugin SDK helper, while gateway/schema validation continues to own numeric range and shape checks.

The regression matrix uses only inputs that previously reached the gateway as valid grids. It does not create a store or SQLite handle because the corrected parser must reject before any gateway call.

## User Impact

Documented decimal grids remain unchanged. Undocumented hex, exponent, octal, binary, and empty-segment coercions now fail with `grid must be x,y,w,h` before the gateway call.

## Evidence

- Exact improved head: `5d3895939c0008b109d42eee3e3ed3faf81fb23f`.
- Blacksmith Testbox `tbx_01kxjche543htk4pgbnb0nm3s9`: focused Workspaces CLI suite, 11/11 passed; changed files passed `oxfmt --check`.
- Built registered CLI proof on the same Testbox: `0x1,0,4,2` stopped at `grid must be x,y,w,h`; decimal control `1,0,4,2` crossed grid validation and reached the configured gateway connection boundary.
- Exact improved-head hosted CI gate: [run 29399762934](https://github.com/openclaw/openclaw/actions/runs/29399762934), green.
- Autoreview: local correction and full improved-branch passes clean.

AI-assisted change. No contributor changelog edit.
