### PR TITLE
test: speed up media-only reply coverage

### DIFF
--- a/src/auto-reply/reply/get-reply-run.media-only.test.ts
+++ b/src/auto-reply/reply/get-reply-run.media-only.test.ts
@@ -27,6 +27,10 @@ vi.mock("../../agents/embedded-agent.runtime.js", () => ({
   waitForEmbeddedAgentRunEnd: vi.fn().mockResolvedValue(true),
 }));
 
+vi.mock("../../agents/harness/hook-helpers.js", () => ({
+  runAgentHarnessBeforeMessageWriteHook: vi.fn((params: { message: unknown }) => params.message),
+}));
+
 vi.mock("../../config/sessions/group.js", () => ({
   resolveGroupSessionKey: vi.fn().mockReturnValue(undefined),
 }));
@@ -40,13 +44,12 @@ const loadSessionEntryMock = vi.hoisted(() => vi.fn());
 const updateAmbientTranscriptWatermarkMock = vi.hoisted(() => vi.fn().mockResolvedValue(null));
 const consumeSessionSkillSuggestionMock = vi.hoisted(() => vi.fn());
 
-vi.mock(import("../../config/sessions/session-accessor.js"), async (importOriginal) => {
-  const actual = await importOriginal<typeof import("../../config/sessions/session-accessor.js")>();
-  return {
-    ...actual,
-    loadSessionEntry: loadSessionEntryMock,
-  };
-});
+vi.mock("../../config/sessions/session-accessor.js", () => ({
+  listSessionEntries: vi.fn().mockReturnValue([]),
+  loadSessionEntry: loadSessionEntryMock,
+  patchSessionEntry: vi.fn(),
+  persistSessionTranscriptTurn: vi.fn(),
+}));
 
 vi.mock("../../config/sessions/ambient-transcript-watermark.js", () => ({
   updateAmbientTranscriptWatermark: updateAmbientTranscriptWatermarkMock,
@@ -136,6 +139,15 @@ vi.mock("./session-updates.runtime.js", () => ({
 
 vi.mock("./session-system-events.js", () => ({
   drainFormattedSystemEvents: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("./session-reset-prompt.js", () => ({
+  resolveBareResetBootstrapFileAccess: vi.fn().mockReturnValue(false),
+  resolveBareSessionResetPromptState: vi.fn().mockResolvedValue({
+    bootstrapMode: "none",
+    prompt: "A new session was started via /new or /reset.",
+    shouldPrependStartupContext: true,
+  }),
 }));
 
 vi.mock("./typing-mode.js", () => ({


### PR DESCRIPTION
## What Problem This Solves

`get-reply-run.media-only.test.ts` evaluated unrelated session storage, bootstrap tooling, and harness-hook dependency graphs before exercising its reply fixture. On a cold Testbox run, its 98 tests spent 18.7 seconds in the test phase.

## Why This Change Was Made

Replace those unrelated transitive dependencies with narrow deterministic test doubles. The fixture keeps its existing reset-prompt shape, session reload control, and transcript-hook identity behavior while dedicated owner tests continue covering the real implementations.

## User Impact

No runtime behavior change. The isolated cold test phase drops from 18.7 seconds to 10.0 seconds; a warm paired run dropped from 4.5-4.6 seconds to 3.1 seconds.

## Evidence

- `pnpm test src/auto-reply/reply/get-reply-run.media-only.test.ts` — 98 passed on exact current main; cold test phase 9.97s ([Testbox run](https://github.com/openclaw/openclaw/actions/runs/29334343382))
- `pnpm test src/auto-reply/reply/get-reply-run.media-only.test.ts src/auto-reply/reply/session-reset-prompt.test.ts src/sessions/user-turn-transcript.test.ts` — 144 passed
- `pnpm check:changed -- src/auto-reply/reply/get-reply-run.media-only.test.ts` — passed
- Autoreview — clean, no accepted/actionable findings
