### PR TITLE
fix(plugins): restore nested registry state on failed registration rollback

### DIFF
--- a/src/plugins/loader.registration.test-utils.ts
+++ b/src/plugins/loader.registration.test-utils.ts
@@ -260,6 +260,163 @@ describe("loadOpenClawPlugins", () => {
     clearPluginInteractiveHandlers();
   });
 
+  it("restores nested registry metadata after failed load and accepts clean retry", () => {
+    useNoBundledPlugins();
+    const existing = writePlugin({
+      id: "existing-stable",
+      filename: "existing-stable.cjs",
+      body: `module.exports = {
+          id: "existing-stable",
+          register(api) {
+            api.registerAgentToolResultMiddleware(async (event) => ({ result: event.result }), {
+              runtimes: ["openclaw"],
+            });
+          },
+        };`,
+    });
+    updatePluginManifest(existing, {
+      contracts: { agentToolResultMiddleware: ["openclaw"] },
+    });
+
+    const failing = writePlugin({
+      id: "retry-target",
+      filename: "retry-target.cjs",
+      body: `module.exports = {
+          id: "retry-target",
+          register(api) {
+            const handler = async (event) => ({ result: event.result });
+            // First registration inserts middleware; second mutates nested runtimes in place.
+            api.registerAgentToolResultMiddleware(handler, { runtimes: ["openclaw"] });
+            api.registerAgentToolResultMiddleware(handler, { runtimes: ["codex"] });
+            api.registerTool({
+              name: "retry_target_tool",
+              description: "Retry target",
+              parameters: {},
+              execute: async () => ({ content: [{ type: "text", text: "ok" }] }),
+            });
+            throw new Error("deliberate registration failure");
+          },
+        };`,
+    });
+    updatePluginManifest(failing, {
+      contracts: {
+        tools: ["retry_target_tool"],
+        agentToolResultMiddleware: ["openclaw", "codex"],
+      },
+    });
+
+    const loadConfig = {
+      plugins: {
+        load: { paths: [existing.file, failing.file] },
+        allow: ["existing-stable", "retry-target"],
+        entries: {
+          "existing-stable": { enabled: true },
+          "retry-target": { enabled: true },
+        },
+      },
+    };
+
+    const failedLoad = loadOpenClawPlugins({
+      cache: false,
+      workspaceDir: existing.dir,
+      onlyPluginIds: ["existing-stable", "retry-target"],
+      config: loadConfig,
+    });
+    const failedRecord = failedLoad.plugins.find((entry) => entry.id === "retry-target");
+    const existingMiddleware = failedLoad.agentToolResultMiddlewares.filter(
+      (entry) => entry.pluginId === "existing-stable",
+    );
+    const failedMiddleware = failedLoad.agentToolResultMiddlewares.filter(
+      (entry) => entry.pluginId === "retry-target",
+    );
+
+    // Real product-path proof dump for PR Evidence / re-review.
+    console.log(
+      "[proof] after failed registration",
+      JSON.stringify({
+        failedStatus: failedRecord?.status,
+        failedError: failedRecord?.error,
+        failedToolNames: failedRecord?.toolNames,
+        tools: failedLoad.tools.flatMap((entry) => entry.names),
+        middleware: failedLoad.agentToolResultMiddlewares.map((entry) => ({
+          pluginId: entry.pluginId,
+          runtimes: entry.runtimes,
+        })),
+      }),
+    );
+
+    expect(failedRecord?.status).toBe("error");
+    expect(failedRecord?.error).toContain("deliberate registration failure");
+    expect(failedRecord?.toolNames).toEqual([]);
+    expect(failedLoad.tools.flatMap((entry) => entry.names)).not.toContain("retry_target_tool");
+    expect(failedMiddleware).toEqual([]);
+    expect(existingMiddleware).toHaveLength(1);
+    expect(existingMiddleware[0]?.runtimes).toEqual(["openclaw"]);
+
+    // Clean retry uses a new entry path so module load is not sticky to the
+    // broken body (same product sequence as reinstalling/fixing a package).
+    const clean = writePlugin({
+      id: "retry-target",
+      filename: "retry-target-clean.cjs",
+      body: `module.exports = {
+          id: "retry-target",
+          register(api) {
+            api.registerTool({
+              name: "retry_target_tool",
+              description: "Retry target",
+              parameters: {},
+              execute: async () => ({ content: [{ type: "text", text: "ok" }] }),
+            });
+          },
+        };`,
+    });
+    updatePluginManifest(clean, { contracts: { tools: ["retry_target_tool"] } });
+
+    const cleanLoad = loadOpenClawPlugins({
+      cache: false,
+      workspaceDir: existing.dir,
+      onlyPluginIds: ["existing-stable", "retry-target"],
+      config: {
+        plugins: {
+          load: { paths: [existing.file, clean.file] },
+          allow: ["existing-stable", "retry-target"],
+          entries: {
+            "existing-stable": { enabled: true },
+            "retry-target": { enabled: true },
+          },
+        },
+      },
+    });
+    const cleanRecord = cleanLoad.plugins.find((entry) => entry.id === "retry-target");
+
+    console.log(
+      "[proof] after clean retry",
+      JSON.stringify({
+        cleanStatus: cleanRecord?.status,
+        cleanError: cleanRecord?.error,
+        cleanFailurePhase: cleanRecord?.failurePhase,
+        cleanToolNames: cleanRecord?.toolNames,
+        diagnostics: cleanLoad.diagnostics
+          .filter((entry) => entry.pluginId === "retry-target")
+          .map((entry) => ({ level: entry.level, message: entry.message })),
+        tools: cleanLoad.tools.flatMap((entry) => entry.names),
+        middleware: cleanLoad.agentToolResultMiddlewares.map((entry) => ({
+          pluginId: entry.pluginId,
+          runtimes: entry.runtimes,
+        })),
+      }),
+    );
+
+    expect(cleanRecord?.status).toBe("loaded");
+    expect(cleanRecord?.error).toBeUndefined();
+    expect(cleanRecord?.toolNames).toEqual(["retry_target_tool"]);
+    expect(cleanLoad.tools.flatMap((entry) => entry.names)).toContain("retry_target_tool");
+    expect(
+      cleanLoad.agentToolResultMiddlewares.find((entry) => entry.pluginId === "existing-stable")
+        ?.runtimes,
+    ).toEqual(["openclaw"]);
+  });
+
   it("fails plugin registration when a hook is missing its required name", () => {
     useNoBundledPlugins();
     const plugin = writePlugin({

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -2327,7 +2327,10 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
           if (registrationMode === "setup-runtime") {
             const registerSetupRuntime = mergedSetupRegistration.registerSetupRuntime;
             if (registerSetupRuntime) {
-              const transaction = createPluginRegistrationTransaction({ registry });
+              const transaction = createPluginRegistrationTransaction({
+                registry,
+                currentRecord: record,
+              });
               try {
                 runPluginRegisterSync(
                   (registrationApi) => registerSetupRuntime(registrationApi),
@@ -2474,6 +2477,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
       });
       const transaction = createPluginRegistrationTransaction({
         registry,
+        currentRecord: record,
         rollbackGlobalSideEffects: () => rollbackPluginGlobalSideEffects(record.id),
       });
 
@@ -2950,7 +2954,7 @@ export async function loadOpenClawPluginCliRegistry(
       },
     });
 
-    const transaction = createPluginRegistrationTransaction({ registry });
+    const transaction = createPluginRegistrationTransaction({ registry, currentRecord: record });
     try {
       withProfile({ pluginId: record.id, source: record.source }, "cli-metadata:register", () =>
         runPluginRegisterSync(register, api),

--- a/src/plugins/plugin-registration-transaction.test.ts
+++ b/src/plugins/plugin-registration-transaction.test.ts
@@ -10,6 +10,7 @@ import {
   snapshotPluginProcessGlobalState,
 } from "./plugin-registration-transaction.js";
 import { createEmptyPluginRegistry } from "./registry-empty.js";
+import { createPluginRecord } from "./status.test-helpers.js";
 
 describe("plugin registration transaction", () => {
   let initialProcessGlobalState: PluginProcessGlobalState;
@@ -50,6 +51,55 @@ describe("plugin registration transaction", () => {
       pluginId: "active-memory",
       capability: { promptBuilder: activePromptBuilder },
     });
+  });
+
+  it("restores the current record after a failed registration", () => {
+    const registry = createEmptyPluginRegistry();
+    const record = createPluginRecord({ id: "failed-plugin" });
+    const toolNames = record.toolNames;
+
+    const transaction = createPluginRegistrationTransaction({ registry, currentRecord: record });
+    record.httpRoutes += 1;
+    record.hookCount += 1;
+    record.toolNames.push("failed-tool");
+    record.contextEngineIds = ["failed-engine"];
+    record.error = "failed registration";
+
+    transaction.rollback();
+
+    expect(registry.plugins).toEqual([]);
+    expect(record.httpRoutes).toBe(0);
+    expect(record.hookCount).toBe(0);
+    expect(record.toolNames).toEqual([]);
+    expect(record.toolNames).not.toBe(toolNames);
+    expect(record.contextEngineIds).toEqual([]);
+    expect(record).not.toHaveProperty("error");
+  });
+
+  it("restores in-place mutations to existing registry entries", () => {
+    const registry = createEmptyPluginRegistry();
+    const rawHandler = async () => undefined;
+    registry.agentToolResultMiddlewares.push({
+      pluginId: "existing-plugin",
+      handler: rawHandler,
+      rawHandler,
+      runtimes: ["openclaw"],
+      // source is required on real registrations; keep fixtures contract-shaped.
+      source: "existing-plugin",
+    });
+    const originalEntry = registry.agentToolResultMiddlewares[0];
+
+    const transaction = createPluginRegistrationTransaction({ registry });
+    originalEntry.runtimes.push("codex");
+
+    transaction.rollback();
+
+    expect(registry.agentToolResultMiddlewares).toHaveLength(1);
+    expect(registry.agentToolResultMiddlewares[0]).not.toBe(originalEntry);
+    expect(registry.agentToolResultMiddlewares[0]?.rawHandler).toBe(rawHandler);
+    expect(registry.agentToolResultMiddlewares[0]?.handler).toBe(rawHandler);
+    expect(registry.agentToolResultMiddlewares[0]?.runtimes).toEqual(["openclaw"]);
+    expect(registry.agentToolResultMiddlewares[0]?.source).toBe("existing-plugin");
   });
 
   it("keeps snapshot registry writes while restoring globals for non-activating commits", () => {

--- a/src/plugins/plugin-registration-transaction.ts
+++ b/src/plugins/plugin-registration-transaction.ts
@@ -30,7 +30,7 @@ import {
   listMemoryPromptSupplements,
   restoreMemoryPluginState,
 } from "./memory-state.js";
-import type { PluginRegistry } from "./registry-types.js";
+import type { PluginRecord, PluginRegistry } from "./registry-types.js";
 
 export type PluginProcessGlobalState = {
   agentHarnesses: ReturnType<typeof listRegisteredAgentHarnesses>;
@@ -75,25 +75,108 @@ export function restorePluginProcessGlobalState(state: PluginProcessGlobalState)
   });
 }
 
-function snapshotPluginRegistry(registry: PluginRegistry): PluginRegistry {
-  return Object.fromEntries(
-    Object.entries(registry).map(([key, value]) => {
-      if (Array.isArray(value)) {
-        return [key, [...value]];
-      }
-      if (value instanceof Map) {
-        return [key, new Map(value)];
-      }
-      if (value && typeof value === "object") {
-        return [key, { ...value }];
-      }
-      return [key, value];
-    }),
-  ) as PluginRegistry;
+// Transaction-owned mutable fields are cloned by value; handlers and other
+// non-cloneable registry entries stay by reference so rollback cannot break
+// function-bearing registrations via structuredClone.
+type ObjectStateSnapshot = Map<PropertyKey, PropertyDescriptor>;
+
+type PluginRecordSnapshot = {
+  record: PluginRecord;
+  state: ObjectStateSnapshot;
+};
+
+type PluginRegistrySnapshot = {
+  registry: PluginRegistry;
+  pluginRecords: PluginRecordSnapshot[];
+};
+
+function cloneMutablePropertyValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return [...value];
+  }
+  if (value instanceof Date) {
+    return new Date(value);
+  }
+  return value;
 }
 
-function restorePluginRegistry(registry: PluginRegistry, snapshot: PluginRegistry): void {
-  Object.assign(registry, snapshot);
+function snapshotObjectState(value: object): ObjectStateSnapshot {
+  return new Map(
+    Reflect.ownKeys(value).map((key) => {
+      const descriptor = Object.getOwnPropertyDescriptor(value, key);
+      if (!descriptor) {
+        throw new Error(`missing property descriptor for ${String(key)}`);
+      }
+      return [
+        key,
+        "value" in descriptor
+          ? { ...descriptor, value: cloneMutablePropertyValue(descriptor.value) }
+          : descriptor,
+      ];
+    }),
+  );
+}
+
+function restoreObjectState(value: object, snapshot: ObjectStateSnapshot): void {
+  for (const key of Reflect.ownKeys(value)) {
+    if (!snapshot.has(key)) {
+      Reflect.deleteProperty(value, key);
+    }
+  }
+  for (const [key, descriptor] of snapshot) {
+    Object.defineProperty(
+      value,
+      key,
+      "value" in descriptor
+        ? { ...descriptor, value: cloneMutablePropertyValue(descriptor.value) }
+        : descriptor,
+    );
+  }
+}
+
+function cloneRegistryArrayEntry<T>(entry: T): T {
+  if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+    return entry;
+  }
+  const clone = Object.create(Object.getPrototypeOf(entry));
+  restoreObjectState(clone, snapshotObjectState(entry));
+  return clone as T;
+}
+
+function snapshotPluginRegistry(
+  registry: PluginRegistry,
+  currentRecord?: PluginRecord,
+): PluginRegistrySnapshot {
+  // Include currentRecord even when not yet pushed to registry.plugins so a
+  // failed registration that mutates the live PluginRecord still rolls back.
+  const records = currentRecord ? [...registry.plugins, currentRecord] : registry.plugins;
+  return {
+    registry: Object.fromEntries(
+      Object.entries(registry).map(([key, value]) => {
+        if (Array.isArray(value)) {
+          return [key, value.map((entry) => cloneRegistryArrayEntry(entry))];
+        }
+        if (value instanceof Map) {
+          return [key, new Map(value)];
+        }
+        if (value && typeof value === "object") {
+          return [key, cloneRegistryArrayEntry(value)];
+        }
+        return [key, value];
+      }),
+    ) as PluginRegistry,
+    pluginRecords: [...new Set(records)].map((record) => ({
+      record,
+      state: snapshotObjectState(record),
+    })),
+  };
+}
+
+function restorePluginRegistry(registry: PluginRegistry, snapshot: PluginRegistrySnapshot): void {
+  for (const { record, state } of snapshot.pluginRecords) {
+    restoreObjectState(record, state);
+  }
+  Object.assign(registry, snapshot.registry);
 }
 
 type PluginRegistrationTransaction = {
@@ -103,9 +186,11 @@ type PluginRegistrationTransaction = {
 
 export function createPluginRegistrationTransaction(params: {
   registry: PluginRegistry;
+  /** Live record being registered; may not be in registry.plugins yet. */
+  currentRecord?: PluginRecord;
   rollbackGlobalSideEffects?: () => void;
 }): PluginRegistrationTransaction {
-  const registrySnapshot = snapshotPluginRegistry(params.registry);
+  const registrySnapshot = snapshotPluginRegistry(params.registry, params.currentRecord);
   const processGlobalState = snapshotPluginProcessGlobalState();
   let settled = false;
 


### PR DESCRIPTION
Fixes #106647

## What Problem This Solves

Fixes an issue where a failed plugin registration could leave nested registry state partially applied. OpenClaw snapshots the plugin registry for transactional rollback, but the snapshot only copied top-level arrays and maps while keeping references to nested `PluginRecord` objects and existing capability entries. During registration, the loader mutates those objects in place (for example appending `toolNames` or extending middleware `runtimes`). On rollback, the array structure was restored while the mutated nested fields remained, so a failed plugin load could poison later retries and leave inconsistent registry metadata.

## Why This Change Was Made

Registration rollback now isolates transaction-owned mutable state without cloning the entire registry with `structuredClone` (which would break function-bearing handlers). Array and record entries get property-level snapshots that clone mutable arrays/values while keeping handlers by reference. The live `PluginRecord` being registered is included even before it is pushed onto `registry.plugins`, and all loader registration transactions pass that record through. This keeps one canonical rollback path, preserves executable handlers, and restores counters/lists after failure.

Fix quality: compatibility — no config/API change, runtime-only isolation; performance — snapshot cost only at registration boundaries, not request hot paths; usability — failed loads no longer leave sticky partial metadata; security — no trust-boundary change, fail closed still rolls back side effects.

## User Impact

Operators and developers who hit a plugin registration failure during load, setup-runtime registration, or CLI metadata registration get a clean rollback of plugin records and nested capability entries. A retry after a failed registration starts from the pre-failure registry state instead of carrying over tool names, route counters, errors, or middleware runtime lists from the failed attempt.

## Evidence

Verification host: local macOS 15 (Node 24.17.0)

Transaction-boundary unit coverage:

```text
$ node scripts/run-vitest.mjs src/plugins/plugin-registration-transaction.test.ts
 ✓ |plugins| src/plugins/plugin-registration-transaction.test.ts (4 tests)
 Test Files  1 passed (1)
      Tests  4 passed (4)
```

Product-path load/retry coverage (deliberately broken plugin registration + clean retry via `loadOpenClawPlugins`):

```text
$ node scripts/run-vitest.mjs src/plugins/loader.test.ts -t "restores nested registry metadata after failed load"
[proof] after failed registration {"failedStatus":"error","failedError":"Error: deliberate registration failure","failedToolNames":[],"tools":[],"middleware":[{"pluginId":"existing-stable","runtimes":["openclaw"]}]}
[proof] after clean retry {"cleanStatus":"loaded","cleanToolNames":["retry_target_tool"],"diagnostics":[],"tools":["retry_target_tool"],"middleware":[{"pluginId":"existing-stable","runtimes":["openclaw"]}]}
 ✓ |bundled| src/plugins/loader.test.ts (1 test)
 Test Files  1 passed (1)
      Tests  1 passed | 168 skipped (169)
```

Regression coverage:

1. Restoring the live current `PluginRecord` after failed registration (`toolNames`, `httpRoutes`, `hookCount`, `contextEngineIds`, `error`).
2. Restoring in-place mutations on existing middleware registrations (`runtimes`) while preserving handler function identity and required `source` metadata.
3. Product loader path: a deliberately broken plugin mutates nested middleware `runtimes` and `toolNames`, fails registration, leaves no sticky tools/middleware, preserves a sibling plugin's middleware `runtimes: ["openclaw"]`, then a fixed entry path for the same plugin id loads cleanly with `retry_target_tool`.

## Real behavior proof

- Behavior addressed: Failed plugin registration through the real `loadOpenClawPlugins` path no longer leaves sticky nested registry metadata; a subsequent clean load of the same plugin id succeeds without carrying failed-attempt tools or middleware runtimes.
- Environment: local macOS 15, OpenClaw checkout at this PR head, Node 24.17.0 via repo Vitest plugins/bundled config.
- Current-main contrast: On main, shallow registry snapshots keep nested object identity, so in-transaction mutations of `PluginRecord.toolNames` or middleware `runtimes` can survive rollback. This PR property-level isolates mutable values for the current record and registry entries.
- Exact steps or command run after this patch:
  ```bash
  node scripts/run-vitest.mjs src/plugins/loader.test.ts -t "restores nested registry metadata after failed load"
  ```
- Setup used:
  1. Load sibling plugin `existing-stable` with agent tool-result middleware `runtimes: ["openclaw"]`.
  2. Load deliberately broken plugin `retry-target` that registers middleware (then mutates nested `runtimes` with a second registration), registers tool `retry_target_tool`, then throws `deliberate registration failure`.
  3. Inspect registry after failure.
  4. Retry with a fixed entry path for the same plugin id that only registers the tool successfully.
- Evidence after fix (redacted runtime dumps from the command above):
  - After failed registration: `failedStatus=error`, `failedToolNames=[]`, `tools=[]`, middleware only `existing-stable` with `runtimes:["openclaw"]` (no sticky `retry-target` middleware / no `codex` runtime leak).
  - After clean retry: `cleanStatus=loaded`, `cleanToolNames=["retry_target_tool"]`, `tools=["retry_target_tool"]`, sibling middleware still `runtimes:["openclaw"]`.
- Control check: transaction unit file still passes 4/4; handler identity preservation remains covered there.
- Observed result after fix: product-path failed registration rolls back nested mutable state; clean retry for the same plugin id succeeds without leftover metadata from the failed attempt.
- What was not tested: long-lived multi-plugin gateway process with a third-party npm package install/uninstall cycle outside the loader harness. The harness exercises the same `loadOpenClawPlugins` + `createPluginRegistrationTransaction` registration path used by gateway/CLI loads.

## AI disclosure

This PR was authored with AI assistance (Grok).
