### PR TITLE
refactor(duckduckgo): privatize safe-search default

### DIFF
--- a/extensions/duckduckgo/src/config.ts
+++ b/extensions/duckduckgo/src/config.ts
@@ -2,7 +2,7 @@
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
 
-export const DEFAULT_DDG_SAFE_SEARCH = "moderate";
+const DEFAULT_DDG_SAFE_SEARCH = "moderate";
 
 export type DdgSafeSearch = "strict" | "moderate" | "off";
 

--- a/extensions/duckduckgo/src/ddg-search-provider.test.ts
+++ b/extensions/duckduckgo/src/ddg-search-provider.test.ts
@@ -2,7 +2,7 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { createStreamingResponse } from "../../test-support/streaming-error-response.js";
 import { createDuckDuckGoWebSearchProvider as createDuckDuckGoWebSearchContractProvider } from "../web-search-contract-api.js";
-import { DEFAULT_DDG_SAFE_SEARCH, resolveDdgRegion, resolveDdgSafeSearch } from "./config.js";
+import { resolveDdgRegion, resolveDdgSafeSearch } from "./config.js";
 
 const { runDuckDuckGoSearch } = vi.hoisted(() => ({
   runDuckDuckGoSearch: vi.fn(async (params: Record<string, unknown>) => params),
@@ -158,7 +158,7 @@ describe("duckduckgo web search provider", () => {
   });
 
   it("defaults safeSearch to moderate and accepts strict and off", () => {
-    expect(resolveDdgSafeSearch(undefined)).toBe(DEFAULT_DDG_SAFE_SEARCH);
+    expect(resolveDdgSafeSearch(undefined)).toBe("moderate");
 
     expect(
       resolveDdgSafeSearch({

--- a/scripts/deadcode-exports.baseline.mjs
+++ b/scripts/deadcode-exports.baseline.mjs
@@ -90,7 +90,6 @@ export const KNIP_UNUSED_EXPORT_BASELINE = [
   "extensions/discord/src/runtime.ts: DiscordRuntime",
   "extensions/discord/src/voice-message.ts: VoiceMessageMetadata",
   "extensions/discord/src/voice/prompt.ts: DISCORD_VOICE_SPOKEN_OUTPUT_CONTRACT",
-  "extensions/duckduckgo/src/config.ts: DEFAULT_DDG_SAFE_SEARCH",
   "extensions/file-transfer/src/node-host/dir-fetch.ts: testing",
   "extensions/file-transfer/src/shared/node-invoke-policy.ts: testing",
   "extensions/file-transfer/src/tools/dir-fetch-tool.ts: testing",


### PR DESCRIPTION
## What Problem This Solves

DuckDuckGo exported its safe-search default only for one direct test, leaving one dead-export baseline row.

## Why This Change Was Made

Keep the default module-private and assert the retained resolver's `moderate` contract directly.

## User Impact

None. Safe-search behavior is unchanged. The dead-export baseline shrinks 704 → 703, and DuckDuckGo goes 1 → 0.

## Evidence

- Testbox `tbx_01kxgcffw3te49akep985x0601`: exact Knip 703, format, scoped type-aware lint, 11/11 DuckDuckGo tests, extension types green.
- Latest-main regeneration byte-stable; baseline +0/-1.
- Fresh whole-diff autoreview clean, confidence 0.99.
