### PR TITLE
fix(qa): restore WhatsApp live scenario contracts

### DIFF
--- a/extensions/qa-lab/src/live-transports/whatsapp/whatsapp-live.gateway.ts
+++ b/extensions/qa-lab/src/live-transports/whatsapp/whatsapp-live.gateway.ts
@@ -145,6 +145,7 @@ export async function callWhatsAppGatewayMessageAction(
       accountId: context.sutAccountId,
       action: params.action,
       channel: "whatsapp",
+      conversationReadOrigin: "direct-operator",
       idempotencyKey: buildWhatsAppQaIdempotencyKey(context.scenarioId, params.label),
       params: {
         ...params.params,

--- a/extensions/qa-lab/src/live-transports/whatsapp/whatsapp-live.runtime.test.ts
+++ b/extensions/qa-lab/src/live-transports/whatsapp/whatsapp-live.runtime.test.ts
@@ -1394,6 +1394,9 @@ describe("WhatsApp QA live runtime", () => {
       messageId: "driver-message-1",
       to: "+15550000001",
     });
+    expect(calls[2]?.payload).toMatchObject({
+      conversationReadOrigin: "direct-operator",
+    });
   });
 
   it("formats redacted wait diagnostics for unmatched WhatsApp observations", () => {

--- a/extensions/qa-lab/src/live-transports/whatsapp/whatsapp-live.scenarios.conversation.ts
+++ b/extensions/qa-lab/src/live-transports/whatsapp/whatsapp-live.scenarios.conversation.ts
@@ -103,8 +103,8 @@ export const WHATSAPP_QA_CONVERSATION_SCENARIOS: WhatsAppQaScenarioDefinition[] 
         expectedSutMessageCount: 1,
         input:
           `openclawqa pending history context check ${triggerMarker}. ` +
-          `Reply with only ${okMarker} only if the previous quiet group message containing ` +
-          `${quietMarker} is present in prior group context with its context-only sentinel. ` +
+          `Reply with only ${okMarker} only if the previous quiet group message is present ` +
+          `in prior group context with its context-only sentinel. ` +
           "Do not use current-message text as proof.",
         matchText: okMarker,
         quietInput: `quiet context marker ${quietMarker} ${contextSentinel}`,

--- a/extensions/qa-lab/src/providers/mock-openai/mock-openai-contracts.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/mock-openai-contracts.ts
@@ -188,8 +188,6 @@ export const QA_WHATSAPP_AGENT_MESSAGE_ACTION_UPLOAD_PROMPT_RE =
   /upload-file action to send a PNG with caption\s+((?:WHATSAPP_QA_AGENT_UPLOAD|WHATSAPP_QA_GROUP_AGENT_UPLOAD)_[A-Z0-9]+)/i;
 export const QA_WHATSAPP_PENDING_HISTORY_TRIGGER_MARKER_RE =
   /\bWHATSAPP_QA_PENDING_HISTORY_TRIGGER_([A-Z0-9]+)\b/u;
-export const QA_WHATSAPP_PENDING_HISTORY_STRUCTURED_LABEL =
-  "Chat history since last reply (untrusted, for context):";
 export const QA_WHATSAPP_BROADCAST_PROMPT_RE =
   /\bopenclawqa broadcast fanout check\s+([A-Z0-9_]+)\b/i;
 export const QA_WHATSAPP_RUNTIME_AGENT_RE = /\bRuntime:\s*[^\n]*\bagent=([A-Za-z0-9_-]+)/i;

--- a/extensions/qa-lab/src/providers/mock-openai/mock-openai-directives.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/mock-openai-directives.ts
@@ -78,16 +78,42 @@ export function extractWhatsAppStickerMarkerDirective(text: string) {
   return extractLastCapture(text, /WhatsApp sticker marker:\s*([^\s`.,;:!?]+(?:-[^\s`.,;:!?]+)*)/i);
 }
 
+const QA_TIMESTAMPED_MESSAGE_PREFIX_RE =
+  /^\[[A-Z][a-z]{2} \d{4}-\d{2}-\d{2} \d{2}:\d{2}(?::\d{2})?(?: [^\]\r\n]+)?\]\s*/u;
+const QA_WHATSAPP_ENVELOPE_PREFIX_RE = /^\[WhatsApp(?: [^\]\r\n]+)?\]\s*/iu;
+const QA_WHATSAPP_SENDER_PREFIX_RE = /^(?:\(self\)|[^:\r\n]+):\s*/u;
+
+function hasWhatsAppStructuredMessageBody(prompt: string, bodyPattern: RegExp) {
+  return prompt.split(/\r?\n/u).some((rawLine) => {
+    const line = rawLine.trim();
+    if (!line) {
+      return false;
+    }
+
+    const timestampedBody = line.replace(QA_TIMESTAMPED_MESSAGE_PREFIX_RE, "");
+    const envelopeBody = timestampedBody.replace(QA_WHATSAPP_ENVELOPE_PREFIX_RE, "");
+    if (bodyPattern.test(envelopeBody)) {
+      return true;
+    }
+    // Sender attribution is structural only inside a WhatsApp envelope. Treating every colon as
+    // attribution would misclassify ordinary timestamped prose such as "Contact note: <contact>".
+    if (envelopeBody === timestampedBody) {
+      return false;
+    }
+    return bodyPattern.test(envelopeBody.replace(QA_WHATSAPP_SENDER_PREFIX_RE, ""));
+  });
+}
+
 export function shouldUseWhatsAppLocationMarker(prompt: string) {
-  return /(?:^|[\n:]\s*)📍\s*37\.774900,\s*-122\.419400\b/u.test(prompt.trim());
+  return hasWhatsAppStructuredMessageBody(prompt, /^📍\s*37\.774900,\s*-122\.419400\b/u);
 }
 
 export function shouldUseWhatsAppContactMarker(prompt: string) {
-  return /(?:^|[\n:]\s*)<contacts?(?::|>)/iu.test(prompt.trim());
+  return hasWhatsAppStructuredMessageBody(prompt, /^<contacts?(?::|>)/iu);
 }
 
 export function shouldUseWhatsAppStickerMarker(prompt: string) {
-  return /(?:^|[\n:]\s*)<media:sticker>(?:\s|$)/iu.test(prompt.trim());
+  return hasWhatsAppStructuredMessageBody(prompt, /^<media:sticker>(?:\s|$)/iu);
 }
 
 function extractLabeledMarkerDirective(text: string, label: string) {

--- a/extensions/qa-lab/src/providers/mock-openai/mock-openai-input.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/mock-openai-input.ts
@@ -1,11 +1,9 @@
 // QA Lab mock provider input and tool-output extraction.
-import { escapeRegExp } from "openclaw/plugin-sdk/text-utility-runtime";
 import {
   type ResponsesInputItem,
   INTERNAL_RUNTIME_CONTEXT_BEGIN,
   INTERNAL_RUNTIME_CONTEXT_END,
   QA_WHATSAPP_PENDING_HISTORY_TRIGGER_MARKER_RE,
-  QA_WHATSAPP_PENDING_HISTORY_STRUCTURED_LABEL,
   QA_WHATSAPP_BROADCAST_PROMPT_RE,
   QA_WHATSAPP_RUNTIME_AGENT_RE,
   QA_WHATSAPP_ACTIVATION_ALWAYS_MARKER_RE,
@@ -329,14 +327,15 @@ export function extractAllRequestTexts(input: ResponsesInputItem[], body: Record
   return texts.join("\n");
 }
 
-export function buildWhatsAppPendingHistoryReply(allInputText: string) {
-  const triggerMatch = QA_WHATSAPP_PENDING_HISTORY_TRIGGER_MARKER_RE.exec(allInputText);
+export function buildWhatsAppPendingHistoryReply(prompt: string, input: ResponsesInputItem[]) {
+  const triggerMatch = QA_WHATSAPP_PENDING_HISTORY_TRIGGER_MARKER_RE.exec(prompt);
   if (!triggerMatch?.[1]) {
     return undefined;
   }
   const suffix = triggerMatch[1];
-  const beforeTrigger = allInputText.slice(0, triggerMatch.index);
-  const priorGroupContext = extractStructuredWhatsAppPendingHistoryContext(beforeTrigger);
+  // Pending history is injected as an internal runtime carrier, separate from the current prompt.
+  // Restricting proof to those carriers prevents current-message marker text from satisfying QA.
+  const priorGroupContext = extractWhatsAppPendingHistoryRuntimeContext(input);
   const quietMarkerPattern = new RegExp(`\\bWHATSAPP_QA_PENDING_HISTORY_QUIET_${suffix}\\b`, "u");
   const contextSentinelPattern = new RegExp(
     `\\bWHATSAPP_QA_PENDING_HISTORY_CONTEXT_ONLY_${suffix}\\b`,
@@ -351,12 +350,13 @@ export function buildWhatsAppPendingHistoryReply(allInputText: string) {
   return `WHATSAPP_QA_PENDING_HISTORY_OK_${suffix}`;
 }
 
-function extractStructuredWhatsAppPendingHistoryContext(beforeTrigger: string) {
-  const blockRe = new RegExp(
-    `${escapeRegExp(QA_WHATSAPP_PENDING_HISTORY_STRUCTURED_LABEL)}\\n((?:(?!\\n\\n)[\\s\\S])+)\\n\\n`,
-    "gu",
-  );
-  return Array.from(beforeTrigger.matchAll(blockRe), (match) => match[1]?.trim())
+function extractWhatsAppPendingHistoryRuntimeContext(input: ResponsesInputItem[]) {
+  return input
+    .filter((item) => item.role === "user" && Array.isArray(item.content))
+    .map((item) => {
+      const text = extractInputText(item.content as unknown[]);
+      return isInternalRuntimeContextCarrierText(text) ? text : undefined;
+    })
     .filter((block): block is string => Boolean(block))
     .join("\n");
 }

--- a/extensions/qa-lab/src/providers/mock-openai/server.test.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.test.ts
@@ -154,8 +154,10 @@ function buildWhatsAppPendingHistoryContextFixture(
   history: Array<{ body: string; sender: string; timestamp: number }>,
 ) {
   return [
-    "Chat history since last reply (untrusted, for context):",
+    "[Chat messages since your last reply - for context]",
     ...history.map((entry, index) => `#history-${index + 1} ${entry.sender}: ${entry.body}`),
+    "",
+    "[Current message - respond to this]",
   ].join("\n");
 }
 
@@ -1596,6 +1598,11 @@ describe("qa mock openai server", () => {
 
   it("answers WhatsApp pending-history prompts only with injected prior group context", async () => {
     const server = await startMockServer();
+    const currentTriggerPrompt = [
+      "openclawqa pending history context check",
+      WHATSAPP_PENDING_HISTORY_TRIGGER_MARKER,
+      `Return ${WHATSAPP_PENDING_HISTORY_OK_MARKER} only if prior group context contains the context-only sentinel.`,
+    ].join(" ");
 
     const historyContext = buildWhatsAppPendingHistoryContextFixture([
       {
@@ -1608,72 +1615,57 @@ describe("qa mock openai server", () => {
       stream: false,
       model: "gpt-5.6-luna",
       input: [
-        makeUserInput([historyContext, WHATSAPP_PENDING_HISTORY_TRIGGER_PROMPT].join("\n\n")),
+        makeUserInput(currentTriggerPrompt),
+        makeUserInput(TEST_RUNTIME_CONTEXT_CARRIER.replace("runtime metadata", historyContext)),
       ],
     });
 
     expect(outputText(withStructuredHistory)).toBe(WHATSAPP_PENDING_HISTORY_OK_MARKER);
 
-    const triggerTextOnly = await expectResponsesJson(server, {
+    const withoutHistory = await expectResponsesJson(server, {
+      stream: false,
+      model: "gpt-5.6-luna",
+      input: [makeUserInput(currentTriggerPrompt)],
+    });
+
+    expect(outputText(withoutHistory)).not.toBe(WHATSAPP_PENDING_HISTORY_OK_MARKER);
+
+    const currentMessageOnlyMarkers = await expectResponsesJson(server, {
       stream: false,
       model: "gpt-5.6-luna",
       input: [
+        makeDeveloperInput(
+          buildWhatsAppPendingHistoryContextFixture([
+            {
+              sender: "Alice",
+              timestamp: 1_786_000_000_000,
+              body: "unrelated prior context",
+            },
+          ]),
+        ),
         makeUserInput(
           [
             WHATSAPP_PENDING_HISTORY_TRIGGER_PROMPT,
-            `The current trigger text mentions ${WHATSAPP_PENDING_HISTORY_QUIET_MARKER}.`,
-            `It also mentions ${WHATSAPP_PENDING_HISTORY_CONTEXT_SENTINEL}.`,
-          ].join(" "),
+            `Current request: ${WHATSAPP_PENDING_HISTORY_QUIET_MARKER}`,
+          ].join("\n"),
         ),
       ],
     });
 
-    expect(outputText(triggerTextOnly)).not.toBe(WHATSAPP_PENDING_HISTORY_OK_MARKER);
+    expect(outputText(currentMessageOnlyMarkers)).not.toBe(WHATSAPP_PENDING_HISTORY_OK_MARKER);
 
-    const currentMessageOnlySentinel = await expectResponsesJson(server, {
+    const ordinaryEarlierUserMarkers = await expectResponsesJson(server, {
       stream: false,
       model: "gpt-5.6-luna",
       input: [
         makeUserInput(
-          [
-            buildWhatsAppPendingHistoryContextFixture([
-              {
-                sender: "Alice",
-                timestamp: 1_786_000_000_000,
-                body: "unrelated prior context",
-              },
-            ]),
-            WHATSAPP_PENDING_HISTORY_TRIGGER_PROMPT,
-            `The current trigger text mentions ${WHATSAPP_PENDING_HISTORY_QUIET_MARKER}.`,
-            `It also mentions ${WHATSAPP_PENDING_HISTORY_CONTEXT_SENTINEL}.`,
-          ].join("\n\n"),
+          `${WHATSAPP_PENDING_HISTORY_QUIET_MARKER} ${WHATSAPP_PENDING_HISTORY_CONTEXT_SENTINEL}`,
         ),
+        makeUserInput(currentTriggerPrompt),
       ],
     });
 
-    expect(outputText(currentMessageOnlySentinel)).not.toBe(WHATSAPP_PENDING_HISTORY_OK_MARKER);
-
-    const currentPromptBeforeTrigger = await expectResponsesJson(server, {
-      stream: false,
-      model: "gpt-5.6-luna",
-      input: [
-        makeUserInput(
-          [
-            buildWhatsAppPendingHistoryContextFixture([
-              {
-                sender: "Alice",
-                timestamp: 1_786_000_000_000,
-                body: "unrelated prior context",
-              },
-            ]),
-            `Current request: ${WHATSAPP_PENDING_HISTORY_QUIET_MARKER} ${WHATSAPP_PENDING_HISTORY_CONTEXT_SENTINEL}`,
-            WHATSAPP_PENDING_HISTORY_TRIGGER_PROMPT,
-          ].join("\n\n"),
-        ),
-      ],
-    });
-
-    expect(outputText(currentPromptBeforeTrigger)).not.toBe(WHATSAPP_PENDING_HISTORY_OK_MARKER);
+    expect(outputText(ordinaryEarlierUserMarkers)).not.toBe(WHATSAPP_PENDING_HISTORY_OK_MARKER);
 
     const contextWithoutCurrentTrigger = await expectResponsesJson(server, {
       stream: false,
@@ -3966,7 +3958,7 @@ describe("qa mock openai server", () => {
 
     const response = await postResponses(server, {
       stream: false,
-      input: [setupInput, makeUserInput("📍 37.774900, -122.419400")],
+      input: [setupInput, makeUserInput("  📍 37.774900, -122.419400")],
     });
 
     expect(setupResponse.status).toBe(200);
@@ -3991,11 +3983,11 @@ describe("qa mock openai server", () => {
     });
     const contactResponse = await postResponses(server, {
       stream: false,
-      input: [setupInput, makeUserInput("<contact>")],
+      input: [setupInput, makeUserInput("  <contact>")],
     });
     const stickerResponse = await postResponses(server, {
       stream: false,
-      input: [setupInput, makeUserInput("<media:sticker>")],
+      input: [setupInput, makeUserInput("  <media:sticker>")],
     });
 
     expect(setupResponse.status).toBe(200);
@@ -4006,7 +3998,7 @@ describe("qa mock openai server", () => {
     expect(outputText(await stickerResponse.json())).toBe("QA_WHATSAPP_STICKER_OK");
   });
 
-  it("uses WhatsApp structured markers for channel-prefixed message bodies", async () => {
+  it("uses WhatsApp structured markers for metadata-prefixed message bodies", async () => {
     const server = await startMockServer();
     const setupInput = makeUserInput(
       "When a later WhatsApp location message shows 37.774900, -122.419400, " +
@@ -4074,6 +4066,175 @@ describe("qa mock openai server", () => {
     expect(outputText(await contactResponse.json())).toBe("QA_WHATSAPP_CONTACT_OK");
     expect(stickerResponse.status).toBe(200);
     expect(outputText(await stickerResponse.json())).toBe("QA_WHATSAPP_STICKER_OK");
+  });
+
+  it("detects each WhatsApp structured body after a channel envelope", async () => {
+    const server = await startMockServer();
+    const setupInput = makeUserInput(
+      "When a later WhatsApp location message shows 37.774900, -122.419400, " +
+        "reply with only this WhatsApp location marker: QA_WHATSAPP_LOCATION_OK. " +
+        "When a later WhatsApp contact message appears, " +
+        "reply with only this WhatsApp contact marker: QA_WHATSAPP_CONTACT_OK. " +
+        "When a later WhatsApp sticker message appears, " +
+        "reply with only this WhatsApp sticker marker: QA_WHATSAPP_STICKER_OK. " +
+        "Reply with only this exact marker: QA_STRUCTURED_INITIAL_OK",
+    );
+
+    const cases = [
+      {
+        body: "📍 37.774900, -122.419400",
+        expected: "QA_WHATSAPP_LOCATION_OK",
+      },
+      { body: "<contact>", expected: "QA_WHATSAPP_CONTACT_OK" },
+      { body: "<media:sticker>", expected: "QA_WHATSAPP_STICKER_OK" },
+    ];
+    for (const structuredCase of cases) {
+      const response = await postResponses(server, {
+        stream: false,
+        input: [
+          setupInput,
+          makeUserInput("Reply with only this previous document marker: QA_WHATSAPP_DOCUMENT_OK"),
+          makeUserInput(`[WhatsApp +15555550123] +15555550123: ${structuredCase.body}`),
+        ],
+      });
+
+      expect(response.status).toBe(200);
+      expect(outputText(await response.json())).toBe(structuredCase.expected);
+    }
+  });
+
+  it("detects each WhatsApp structured body after combined timestamp and channel prefixes", async () => {
+    const server = await startMockServer();
+    const setupInput = makeUserInput(
+      "When a later WhatsApp location message shows 37.774900, -122.419400, " +
+        "reply with only this WhatsApp location marker: QA_WHATSAPP_LOCATION_OK. " +
+        "When a later WhatsApp contact message appears, " +
+        "reply with only this WhatsApp contact marker: QA_WHATSAPP_CONTACT_OK. " +
+        "When a later WhatsApp sticker message appears, " +
+        "reply with only this WhatsApp sticker marker: QA_WHATSAPP_STICKER_OK. " +
+        "Reply with only this exact marker: QA_STRUCTURED_INITIAL_OK",
+    );
+    const cases = [
+      {
+        body: "📍 37.774900, -122.419400",
+        expected: "QA_WHATSAPP_LOCATION_OK",
+      },
+      { body: "<contact>", expected: "QA_WHATSAPP_CONTACT_OK" },
+      { body: "<media:sticker>", expected: "QA_WHATSAPP_STICKER_OK" },
+    ];
+
+    for (const structuredCase of cases) {
+      const response = await postResponses(server, {
+        stream: false,
+        input: [
+          setupInput,
+          makeUserInput(
+            `[Tue 2026-07-14 18:17 GMT+5:30] [WhatsApp +15555550123] +15555550123: ${structuredCase.body}`,
+          ),
+        ],
+      });
+
+      expect(response.status).toBe(200);
+      expect(outputText(await response.json())).toBe(structuredCase.expected);
+    }
+  });
+
+  it("detects each WhatsApp structured body after canonical timestamp prefixes", async () => {
+    const server = await startMockServer();
+    const setupInput = makeUserInput(
+      "When a later WhatsApp location message shows 37.774900, -122.419400, " +
+        "reply with only this WhatsApp location marker: QA_WHATSAPP_LOCATION_OK. " +
+        "When a later WhatsApp contact message appears, " +
+        "reply with only this WhatsApp contact marker: QA_WHATSAPP_CONTACT_OK. " +
+        "When a later WhatsApp sticker message appears, " +
+        "reply with only this WhatsApp sticker marker: QA_WHATSAPP_STICKER_OK. " +
+        "Reply with only this exact marker: QA_STRUCTURED_INITIAL_OK",
+    );
+    const timestampPrefixes = [
+      "[Tue 2026-07-14 12:47 UTC]",
+      "[Tue 2026-07-14 07:47 EST]",
+      "[Tue 2026-07-14 09:47 GMT-3]",
+      "[Tue 2026-07-14 14:47 GMT+2]",
+      "[Tue 2026-07-14 09:17 GMT-3:30]",
+      "[Tue 2026-07-14 18:17 GMT+5:30]",
+    ];
+    const cases = [
+      {
+        body: "📍 37.774900, -122.419400",
+        expected: "QA_WHATSAPP_LOCATION_OK",
+      },
+      { body: "<contact>", expected: "QA_WHATSAPP_CONTACT_OK" },
+      { body: "<media:sticker>", expected: "QA_WHATSAPP_STICKER_OK" },
+    ];
+
+    for (const prefix of timestampPrefixes) {
+      for (const structuredCase of cases) {
+        const response = await postResponses(server, {
+          stream: false,
+          input: [setupInput, makeUserInput(`${prefix} ${structuredCase.body}`)],
+        });
+
+        expect(response.status).toBe(200);
+        expect(outputText(await response.json())).toBe(structuredCase.expected);
+      }
+    }
+  });
+
+  it("uses the latest WhatsApp structured body when history contains another kind", async () => {
+    const server = await startMockServer();
+    const setupInput = makeUserInput(
+      "When a later WhatsApp location message shows 37.774900, -122.419400, " +
+        "reply with only this WhatsApp location marker: QA_WHATSAPP_LOCATION_OK. " +
+        "When a later WhatsApp contact message appears, " +
+        "reply with only this WhatsApp contact marker: QA_WHATSAPP_CONTACT_OK. " +
+        "Reply with only this exact marker: QA_STRUCTURED_INITIAL_OK",
+    );
+    const response = await postResponses(server, {
+      stream: false,
+      input: [
+        setupInput,
+        makeUserInput("[WhatsApp +15555550123] +15555550123: 📍 37.774900, -122.419400"),
+        makeUserInput("[WhatsApp +15555550123] +15555550123: <contact>"),
+      ],
+    });
+
+    expect(response.status).toBe(200);
+    expect(outputText(await response.json())).toBe("QA_WHATSAPP_CONTACT_OK");
+  });
+
+  it("does not treat structured WhatsApp tokens in ordinary prose as message bodies", async () => {
+    const server = await startMockServer();
+    const setupInput = makeUserInput(
+      "When a later WhatsApp location message shows 37.774900, -122.419400, " +
+        "reply with only this WhatsApp location marker: QA_WHATSAPP_LOCATION_OK. " +
+        "When a later WhatsApp contact message appears, " +
+        "reply with only this WhatsApp contact marker: QA_WHATSAPP_CONTACT_OK. " +
+        "When a later WhatsApp sticker message appears, " +
+        "reply with only this WhatsApp sticker marker: QA_WHATSAPP_STICKER_OK. " +
+        "Reply with only this exact marker: QA_STRUCTURED_INITIAL_OK",
+    );
+    const proseInputs = [
+      "Please compare [Tue 2026-07-14 12:47 UTC] 📍 37.774900, -122.419400 and explain [that] <contact> and <media:sticker> text",
+      "[Tue 2026-07-14 12:47 UTC] Contact note: <contact> is descriptive prose",
+      [
+        "Coordinate note: 📍 37.774900, -122.419400",
+        "Contact note: <contact>",
+        "Sticker note: <media:sticker>",
+      ].join("\n"),
+    ];
+
+    for (const proseInput of proseInputs) {
+      const response = await postResponses(server, {
+        stream: false,
+        input: [setupInput, makeUserInput(proseInput)],
+      });
+
+      expect(response.status).toBe(200);
+      const text = outputText(await response.json());
+      expect(text).not.toBe("QA_WHATSAPP_LOCATION_OK");
+      expect(text).not.toBe("QA_WHATSAPP_CONTACT_OK");
+      expect(text).not.toBe("QA_WHATSAPP_STICKER_OK");
+    }
   });
 
   it("streams WhatsApp location markers for the matching coordinate body", async () => {

--- a/extensions/qa-lab/src/providers/mock-openai/server.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.ts
@@ -471,7 +471,7 @@ async function buildResponsesPayload(
       },
     ]);
   }
-  const whatsAppPendingHistoryReply = buildWhatsAppPendingHistoryReply(allInputText);
+  const whatsAppPendingHistoryReply = buildWhatsAppPendingHistoryReply(prompt, input);
   if (whatsAppPendingHistoryReply) {
     return buildAssistantEvents(whatsAppPendingHistoryReply);
   }


### PR DESCRIPTION
Related: #95622

## What Problem This Solves

Resolves a problem where three WhatsApp QA scenarios failed on current `main` even though the underlying WhatsApp behavior was working. The pending-history scenario inspected an obsolete request shape, direct QA Gateway actions omitted the now-required read-origin field, and the structured-message oracle could select a prior message type instead of the current timestamp-prefixed WhatsApp body.

## Why This Change Was Made

The QA lane now follows the current runtime contracts: pending-history evidence is read only from the internal runtime context carrier and matched with per-run markers, direct `message.action` calls identify their operator read origin, and structured location/contact/sticker replies are selected from bounded current-message forms, including channel and timestamp prefixes. Regression tests cover the supported forms, current-message precedence, and ordinary-prose false positives.

## User Impact

There is no production WhatsApp behavior change. Maintainers can run the full local WhatsApp QA lane without these three harness-level false failures, while the scenarios continue to reject evidence from ordinary user text.

## Evidence

- `node scripts/run-vitest.mjs extensions/qa-lab/src/providers/mock-openai/server.test.ts extensions/qa-lab/src/live-transports/whatsapp/whatsapp-live.runtime.test.ts extensions/whatsapp/src/qa-driver.runtime.test.ts extensions/whatsapp/src/inbound/send-api.test.ts` - 4 files and 259 tests passed.
- Full local linked-account WhatsApp QA lane - 38/38 scenarios passed (`.artifacts/qa-e2e/whatsapp-full-current-069616f33b6-20260714-040006`).
- Post-hardening pending-history scenario passed (`.artifacts/qa-e2e/whatsapp-full-current-069616f33b6-20260714-124416`).
- Post-hardening structured-message scenario passed (`.artifacts/qa-e2e/whatsapp-full-current-069616f33b6-20260714-131619`).
- External Codex autoreview reported no accepted or actionable findings.
- `git diff --check` passed.
- Blacksmith Testbox/Crabbox was unavailable in this environment, so the focused proof used the repository's narrow local Vitest fallback.

AI-assisted: Codex. The implementation and validation results were reviewed before submission.
