### PR TITLE
fix(policy): reject nondecimal watch interval

### DIFF
--- a/extensions/policy/src/cli.test.ts
+++ b/extensions/policy/src/cli.test.ts
@@ -378,6 +378,16 @@ describe("policy commands", () => {
     expect(output.join("\n")).toContain("--interval-ms must be an integer >= 250.");
   });
 
+  it("rejects noncanonical plus-prefixed and leading-zero policy watch intervals before evaluating policy", async () => {
+    for (const value of ["+500", "+250", "0500", "000500"]) {
+      const { exitCode, output } = await runPolicyWatchJson({ intervalMs: value });
+      expect(exitCode, `interval=${value}`).toBe(2);
+      expect(output.join("\n"), `interval=${value}`).toContain(
+        "--interval-ms must be an integer >= 250.",
+      );
+    }
+  });
+
   it("reports findings instead of stale when policy watch has no attestation to compare", async () => {
     await fs.writeFile(join(workspaceDir, "policy.jsonc"), "{ channels: ", "utf-8");
 

--- a/extensions/policy/src/cli.ts
+++ b/extensions/policy/src/cli.ts
@@ -12,6 +12,7 @@ import {
   type HealthCheckContext,
   type HealthFinding,
 } from "openclaw/plugin-sdk/health";
+import { parseStrictNonNegativeInteger } from "openclaw/plugin-sdk/number-runtime";
 import { POLICY_FIX_METADATA_BY_CHECK_ID } from "./doctor/fix-metadata.js";
 import { POLICY_CHECK_IDS, evaluatePolicy } from "./doctor/register.js";
 import {
@@ -405,13 +406,25 @@ function normalizeWatchIntervalMs(value: string | number | undefined): number {
   if (value === undefined) {
     return 2000;
   }
-  const raw =
-    typeof value === "number"
-      ? value
-      : /^\+?\d+$/.test(value.trim())
-        ? Number(value.trim())
-        : Number.NaN;
-  if (!Number.isSafeInteger(raw) || raw < 250) {
+  // `parseStrictNonNegativeInteger` already rejects hex/exponent/decimal/
+  // fractional/whitespace/empty/non-numeric input. It still accepts JS
+  // coercion forms (leading `+`, leading-zero padding) because the shared
+  // helper is intentionally permissive for opaque numeric cursors.
+  // `--interval-ms` is documented as a decimal non-negative integer, so we
+  // also gate on the trimmed input matching the canonical `String(raw)`
+  // representation to reject `+500`, `0500`, and `000500` at the CLI
+  // boundary before the polling loop runs. Mirrors the canonical sibling
+  // `extensions/google-meet/src/cli.ts` (`--since` via
+  // `parseStrictNonNegativeInteger`) and the Wave 1 strict-parser cohort
+  // (#106384, #106926, #105557), and adds a decimal-only envelope because
+  // `--interval-ms` is a documented decimal rather than an opaque cursor.
+  const raw = typeof value === "number" ? value : parseStrictNonNegativeInteger(value.trim());
+  if (
+    raw === undefined ||
+    !Number.isSafeInteger(raw) ||
+    raw < 250 ||
+    (typeof value === "string" && String(raw) !== value.trim())
+  ) {
     throw new Error("--interval-ms must be an integer >= 250.");
   }
   return raw;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where `policy watch --interval-ms` accepted JavaScript-specific coercion forms — leading plus (`+500`), leading zeros (`0500`), or longer zero-padded spellings (`000500`) — silently normalizing them to a different but valid integer before reaching the polling loop. Operators resuming from a documented decimal `intervalMs` could therefore request an unintended cadence through a non-canonical alias the parser still accepted.

## Why This Change Was Made

The watch-interval parser now uses the shared `parseStrictNonNegativeInteger` helper from `openclaw/plugin-sdk/number-runtime` and additionally enforces a decimal-only envelope (trimmed input must equal `String(raw)`) so JS coercion forms are rejected at the CLI boundary. Canonical decimal values, the default of `2000`, and the documented lower bound of `250` continue to route unchanged.

This mirrors the canonical sibling `extensions/google-meet/src/cli.ts` (which uses `parseStrictNonNegativeInteger` for `--since`) and the broader Wave 1 strict-parser cohort (#106384, #106926, #105557), and adds the decimal-only envelope because `--interval-ms` is documented as a decimal rather than an opaque cursor.

## User Impact

`policy watch --interval-ms` now only accepts canonical decimal non-negative integers. Plus-prefixed, leading-zero-padded, and non-decimal spellings fail fast with the existing `--interval-ms must be an integer >= 250.` message instead of reaching the polling loop as a different cadence. The default `2000`, the boundary `250`, and every previously accepted documented decimal interval are unchanged.

## Evidence

### Before fix (FAIL on pinned main `7b16b35cb3`)

```text
 FAIL  |extensions| extensions/policy/src/cli.test.ts > policy commands > rejects noncanonical plus-prefixed and leading-zero policy watch intervals before evaluating policy
AssertionError: interval=+500: expected 1 to be 2 // Object.is equality

- Expected: 2
+ Received: 1

  at extensions/policy/src/cli.test.ts:384:45

 Test Files  1 failed (1)
      Tests  1 failed | 33 passed (34)
```

### After fix (PASS on patched head)

```text
 Test Files  1 passed (1)
      Tests  34 passed (34)
   Duration  9.86s
```

### Focused regression

- `node scripts/run-vitest.mjs extensions/policy/src/cli.test.ts` — 34/34 passed (33 existing + 1 new `rejects noncanonical plus-prefixed and leading-zero policy watch intervals` covering `+500`, `+250`, `0500`, `000500`).
- `git diff --check` — clean.

### Local CLI smoke deferral

Local Node 22.22.0 is below the required 22.22.3 floor, so the `pnpm openclaw policy watch …` launcher refuses to spawn. The vitest `runPolicyWatchJson({ intervalMs: "+500" })` path exercises the canonical `registerPolicyCli(program)` + `program.parseAsync(["policy", "watch", "--interval-ms", "+500", "--once", "--json"])` end-to-end — same code path the launcher invokes on a supported Node. Hosted Testbox will run the full CLI smoke.

### What was NOT changed

- `openclaw/plugin-sdk/number-runtime` shared helper — left as-is so opaque numeric cursors in other extensions (google-meet `--since`, etc.) keep their permissive `+`/leading-zero coercion.
- Default `2000` and lower bound `250` for `--interval-ms`.
- Existing error message string.
- Config, schema, protocol, plugin SDK, plugin manifest, or runtime hooks.
- Any other `--interval-ms` consumer outside `extensions/policy/src/cli.ts`.

## Risk / Compatibility

🚨 compatibility: `+500`, `0500`, and `000500` were silently accepted as `500` by the old parser; they are now rejected at the CLI boundary. No documented decimal interval (`2000`, `250`, `500`, etc.) is affected. Canonical decimal values continue to route unchanged.

## Follows

- #106384 — `fix(google-meet): reject nondecimal transcript cursors`
- #106926 — `fix(onepassword): validate audit limit strictly`
- #105557 — `fix(cli): reject noncanonical trajectory export requests`