### PR TITLE
refactor(ai): use native Mistral request options

### DIFF
--- a/packages/ai/src/providers/mistral.ts
+++ b/packages/ai/src/providers/mistral.ts
@@ -162,7 +162,16 @@ export const streamMistral: StreamFunction<"mistral-conversations", MistralOptio
       if (nextPayload !== undefined) {
         payload = nextPayload as ChatCompletionStreamRequest;
       }
-      const mistralStream = await mistral.chat.stream(payload, buildRequestOptions(model, options));
+      const headers = { ...model.headers, ...options?.headers };
+      // Mistral infrastructure uses `x-affinity` for KV-cache reuse (prefix caching).
+      // Respect explicit caller-provided header values.
+      if (options?.sessionId) {
+        headers["x-affinity"] ||= options.sessionId;
+      }
+      const mistralStream = await mistral.chat.stream(payload, {
+        headers,
+        signal: options?.signal,
+      });
       stream.push({ type: "start", partial: output });
       await consumeChatStream(model, output, stream, mistralStream);
 
@@ -309,39 +318,6 @@ function safeJsonStringify(value: unknown): string {
   } catch {
     return String(value);
   }
-}
-
-function buildRequestOptions(model: Model<"mistral-conversations">, options?: MistralOptions) {
-  const requestOptions: {
-    signal?: AbortSignal;
-    retries: { strategy: "none" };
-    headers?: Record<string, string>;
-  } = {
-    retries: { strategy: "none" },
-  };
-  if (options?.signal) {
-    requestOptions.signal = options.signal;
-  }
-
-  const headers: Record<string, string> = {};
-  if (model.headers) {
-    Object.assign(headers, model.headers);
-  }
-  if (options?.headers) {
-    Object.assign(headers, options.headers);
-  }
-
-  // Mistral infrastructure uses `x-affinity` for KV-cache reuse (prefix caching).
-  // Respect explicit caller-provided header values.
-  if (options?.sessionId && !headers["x-affinity"]) {
-    headers["x-affinity"] = options.sessionId;
-  }
-
-  if (Object.keys(headers).length > 0) {
-    requestOptions.headers = headers;
-  }
-
-  return requestOptions;
 }
 
 function buildChatPayload(


### PR DESCRIPTION
## What Problem This Solves

Mistral request setup duplicated the SDK's native request-option defaults and built a one-use options wrapper.

## Why This Change Was Made

Mistral SDK 2.4.0 already accepts flattened fetch headers and abort signals, and its chat stream operation defaults to a single attempt. Inline the header precedence and affinity rule at the call site, then rely on those dependency contracts.

## User Impact

No intended behavior change. Model headers, caller headers, session affinity, cancellation, and the existing no-retry behavior remain intact with 24 fewer production lines.

## Evidence

- `node scripts/run-vitest.mjs packages/ai/src/providers/mistral.test.ts packages/ai/src/providers/mistral.bounded-stream.test.ts` (21 passed)
- Mistral SDK request-options runtime probe: caller headers and abort signal reached the Request; a 503 made exactly one attempt
- Isolated tsgo probe against the exported Mistral 2.4.0 declarations accepted flattened `headers` and `signal`
- `git diff --check`
