### PR TITLE
fix(telegram): DM lane stays dead after a wedged handler keeps it guarded; escalate to a supervised gateway restart

### DIFF
--- a/docs/gateway/health.md
+++ b/docs/gateway/health.md
@@ -44,6 +44,8 @@ health commands above for live connectivity checks.
 - `channels.<provider>.accounts.<accountId>.healthMonitor.enabled`: multi-account override that wins over the channel-level setting.
 - These per-channel overrides apply to the built-in channels that expose them today: Discord, Google Chat, iMessage, IRC, Microsoft Teams, Signal, Slack, Telegram, and WhatsApp.
 
+When a channel reports a wedged in-process runtime that a channel restart cannot recover (for example a Telegram spool lane that stays guarded because its handler never stopped after a reply abort), the health monitor escalates to a supervised gateway process restart instead of restarting the channel around the wedge. Escalations respect the per-account cooldown, and their `gateway.channelMaxRestartsPerHour` budget is persisted in the state database so it keeps binding across the gateway restarts the escalation itself causes.
+
 ## Uptime monitoring
 
 External uptime monitoring services should use the dedicated `/health` endpoint, not `/v1/chat/completions`.

--- a/docs/gateway/health.md
+++ b/docs/gateway/health.md
@@ -44,7 +44,7 @@ health commands above for live connectivity checks.
 - `channels.<provider>.accounts.<accountId>.healthMonitor.enabled`: multi-account override that wins over the channel-level setting.
 - These per-channel overrides apply to the built-in channels that expose them today: Discord, Google Chat, iMessage, IRC, Microsoft Teams, Signal, Slack, Telegram, and WhatsApp.
 
-When a channel reports a wedged in-process runtime that a channel restart cannot recover (for example a Telegram spool lane that stays guarded because its handler never stopped after a reply abort), the health monitor escalates to a supervised gateway process restart instead of restarting the channel around the wedge. Escalations respect the per-account cooldown, and their `gateway.channelMaxRestartsPerHour` budget is persisted in the state database so it keeps binding across the gateway restarts the escalation itself causes.
+When a channel reports a wedged in-process runtime that a channel restart cannot recover (for example a Telegram spool lane that stays guarded because its handler never stopped after a reply abort), the health monitor escalates to a supervised gateway process restart instead of restarting the channel around the wedge. Escalations respect the per-account cooldown, and their `gateway.channelMaxRestartsPerHour` budget is persisted in the state database so it keeps binding across the gateway restarts the escalation itself causes. On unmanaged installs (no launchd/systemd/scheduled-task supervisor), the monitor does not restart the gateway — an in-process restart cannot clear the wedge — and instead logs that a manual gateway restart is required.
 
 ## Uptime monitoring
 

--- a/extensions/telegram/src/polling-session.test.ts
+++ b/extensions/telegram/src/polling-session.test.ts
@@ -4607,6 +4607,100 @@ describe("TelegramPollingSession", () => {
     }
   });
 
+  it("escalates a wedged guarded lane to a gateway process restart request and clears it on late settle", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const abort = new AbortController();
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-telegram-spool-"));
+    const log = vi.fn();
+    const events: string[] = [];
+    const wedgedStatusPatches: Array<Omit<ChannelAccountSnapshot, "accountId">> = [];
+    let releaseFirstTurn: (() => void) | undefined;
+    const firstTurnDone = new Promise<void>((resolve) => {
+      releaseFirstTurn = resolve;
+    });
+    createTelegramBotMock.mockReturnValueOnce({
+      api: {
+        deleteWebhook: vi.fn(async () => true),
+        config: { use: vi.fn() },
+      },
+      init: vi.fn(async () => undefined),
+      handleUpdate: vi.fn(async (update: { update_id?: number }) => {
+        events.push(`first:${update.update_id}`);
+        if (update.update_id === 42) {
+          await firstTurnDone;
+        }
+      }),
+      stop: vi.fn(async () => undefined),
+    });
+    await writeSpooledTestUpdates(tempDir, [
+      topicUpdate(42, 10, "wedged topic 10 turn"),
+      topicUpdate(43, 10, "later topic 10 turn"),
+    ]);
+
+    const worker = createIdleIngressWorker();
+    const session = createPollingSession({
+      abortSignal: abort.signal,
+      log,
+      setStatus: (patch) => wedgedStatusPatches.push(patch),
+      isolatedIngress: {
+        enabled: true,
+        spoolDir: tempDir,
+        createWorker: worker.createWorker,
+        drainIntervalMs: 10,
+        spooledUpdateHandlerTimeoutMs: 100,
+        spooledUpdateHandlerAbortGraceMs: 100,
+        wedgedHandlerEscalationMs: 300,
+      },
+    });
+
+    try {
+      const runPromise = session.runUntilAbort();
+      await vi.waitFor(() => expect(events).toEqual(["first:42"]));
+
+      await vi.advanceTimersByTimeAsync(250);
+      await vi.waitFor(() => expectLogIncludes(log, "did not stop within 100ms"));
+      expect(wedgedStatusPatches.some((patch) => patch.processRestartRequired === true)).toBe(
+        false,
+      );
+
+      await vi.advanceTimersByTimeAsync(600);
+      await vi.waitFor(() => expectLogIncludes(log, "requesting a gateway process restart"));
+      const escalated = wedgedStatusPatches.filter(
+        (patch) => patch.processRestartRequired === true,
+      );
+      expect(escalated).toHaveLength(1);
+      expect(escalated[0]?.lastError).toContain("guarded");
+      // Escalation must not release the lane in-process: the wedged handler is
+      // still the only one that ran, and the later same-lane update stays queued.
+      expect(events).toEqual(["first:42"]);
+      expect(await failedUpdateIds(tempDir)).toEqual([42]);
+      expect(await pendingUpdateIds(tempDir, "all")).toEqual([43]);
+
+      // Repeat drains must not re-escalate the same wedged handler.
+      await vi.advanceTimersByTimeAsync(600);
+      expect(
+        wedgedStatusPatches.filter((patch) => patch.processRestartRequired === true),
+      ).toHaveLength(1);
+
+      releaseFirstTurn?.();
+      await vi.waitFor(() => {
+        expect(wedgedStatusPatches.some((patch) => patch.processRestartRequired === false)).toBe(
+          true,
+        );
+      });
+
+      abort.abort();
+      await vi.advanceTimersByTimeAsync(20_000);
+      await runPromise;
+    } finally {
+      releaseFirstTurn?.();
+      abort.abort();
+      worker.stop();
+      vi.useRealTimers();
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it("caps oversized spooled update handler abort grace timers", async () => {
     vi.useFakeTimers({ shouldAdvanceTime: true });
     const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");

--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -30,6 +30,14 @@ import { TelegramPollingTransportState } from "./polling-transport-state.js";
 import { TELEGRAM_GET_UPDATES_REQUEST_TIMEOUT_MS } from "./request-timeouts.js";
 import { getTelegramSequentialKey } from "./sequential-key.js";
 import {
+  buildDeferredSpooledUpdateClaimKey,
+  hasEscalatedWedgedHandler,
+  ISOLATED_INGRESS_WEDGED_HANDLER_ESCALATION_MS,
+  maybeEscalateWedgedSpooledUpdateHandler,
+  type DeferredSpooledUpdateClaimState,
+  type SpooledUpdateHandlerState,
+} from "./spooled-update-handler-lanes.js";
+import {
   resolveNonRetryableSpooledUpdateFailure,
   resolveSpooledUpdateAttemptNumber,
   resolveSpooledUpdateRetryDelayMs,
@@ -184,38 +192,11 @@ type TelegramPollingSessionOpts = {
     drainIntervalMs?: number;
     spooledUpdateHandlerTimeoutMs?: number;
     spooledUpdateHandlerAbortGraceMs?: number;
+    wedgedHandlerEscalationMs?: number;
   };
 };
 
-type SpooledUpdateHandlerState = {
-  handlerKey: string;
-  laneKey: string;
-  task: Promise<boolean>;
-  update: ClaimedTelegramSpooledUpdate;
-  updateId: number;
-  startedAt: number;
-  stopClaimRefresh: () => void;
-  backlogStatusMessage?: string;
-  timedOutAt?: number;
-  timeoutMessage?: string;
-};
-
-type DeferredSpooledUpdateClaimState = {
-  claimKey: string;
-  laneKey: string;
-  task: Promise<void>;
-  timer?: ReturnType<typeof setTimeout>;
-  timedOutMessage?: string;
-  update: ClaimedTelegramSpooledUpdate;
-  updateId: number;
-  stopClaimRefresh: () => void;
-};
-
 const deferredSpooledUpdateClaimsByKey = new Map<string, DeferredSpooledUpdateClaimState>();
-
-function buildDeferredSpooledUpdateClaimKey(update: ClaimedTelegramSpooledUpdate): string {
-  return `${update.pendingPath}:${update.claim?.claimToken ?? update.claim?.processId ?? "claimed"}`;
-}
 
 type SpooledUpdateDrainResult = {
   blockedByLane: Set<string>;
@@ -304,6 +285,7 @@ export class TelegramPollingSession {
   #stallThresholdMs: number;
   #spooledUpdateHandlerTimeoutMs: number;
   #spooledUpdateHandlerAbortGraceMs: number;
+  #wedgedHandlerEscalationMs: number;
   #deliveryDrainInFlight = false;
   #nextDeliveryDrainAt = 0;
 
@@ -324,6 +306,10 @@ export class TelegramPollingSession {
     this.#spooledUpdateHandlerAbortGraceMs = resolvePositiveTimerTimeoutMs(
       opts.isolatedIngress?.spooledUpdateHandlerAbortGraceMs,
       TELEGRAM_SPOOLED_HANDLER_ABORT_GRACE_MS,
+    );
+    this.#wedgedHandlerEscalationMs = resolvePositiveTimerTimeoutMs(
+      opts.isolatedIngress?.wedgedHandlerEscalationMs,
+      ISOLATED_INGRESS_WEDGED_HANDLER_ESCALATION_MS,
     );
   }
 
@@ -1033,6 +1019,13 @@ export class TelegramPollingSession {
           activeSpooledUpdateHandlersByLane.delete(handlerKey);
         }
         this.#spooledUpdateHandlerKeys.delete(handlerKey);
+        // Late settle: clear escalation only when no other wedged handler needs it.
+        if (
+          state.escalatedAt !== undefined &&
+          !hasEscalatedWedgedHandler(activeSpooledUpdateHandlersByLane.values())
+        ) {
+          this.#status.noteWedgedHandlerRecovered();
+        }
       });
       started += 1;
     }
@@ -1383,6 +1376,12 @@ export class TelegramPollingSession {
           if (handler.timeoutMessage) {
             this.#status.notePollingError(handler.timeoutMessage);
           }
+          maybeEscalateWedgedSpooledUpdateHandler({
+            handler,
+            escalationMs: this.#wedgedHandlerEscalationMs,
+            log: this.opts.log,
+            status: this.#status,
+          });
         }
         for (const handlerKey of this.#noteSpooledBacklogStalls(drain.blockedByLane)) {
           stalledBacklogKeys.add(handlerKey);

--- a/extensions/telegram/src/polling-status.ts
+++ b/extensions/telegram/src/polling-status.ts
@@ -35,6 +35,21 @@ export function createTelegramPollingStatusPublisher(setStatus?: TelegramPolling
         lastError: error,
       });
     },
+    // Polling itself stays alive while a lane is wedged, so these do not touch
+    // `connected`; the flag alone routes the health monitor to escalation.
+    noteWedgedHandlerEscalation(error: string) {
+      setStatus?.({
+        mode: "polling",
+        processRestartRequired: true,
+        lastError: error,
+      });
+    },
+    noteWedgedHandlerRecovered() {
+      setStatus?.({
+        mode: "polling",
+        processRestartRequired: false,
+      });
+    },
     notePollingStop() {
       setStatus?.({
         mode: "polling",

--- a/extensions/telegram/src/spooled-update-handler-lanes.ts
+++ b/extensions/telegram/src/spooled-update-handler-lanes.ts
@@ -1,0 +1,70 @@
+// Spooled-update handler lane types and wedged-handler escalation policy for
+// Telegram isolated ingress. Lane state itself stays process-scoped in
+// polling-session.ts (globalThis-backed) so module re-evaluation cannot fork it.
+import { formatDurationPrecise } from "openclaw/plugin-sdk/runtime-env";
+import type { ClaimedTelegramSpooledUpdate } from "./telegram-ingress-spool.js";
+
+export type SpooledUpdateHandlerState = {
+  handlerKey: string;
+  laneKey: string;
+  task: Promise<boolean>;
+  update: ClaimedTelegramSpooledUpdate;
+  updateId: number;
+  startedAt: number;
+  stopClaimRefresh: () => void;
+  backlogStatusMessage?: string;
+  timedOutAt?: number;
+  timeoutMessage?: string;
+  escalatedAt?: number;
+};
+
+export type DeferredSpooledUpdateClaimState = {
+  claimKey: string;
+  laneKey: string;
+  task: Promise<void>;
+  timer?: ReturnType<typeof setTimeout>;
+  timedOutMessage?: string;
+  update: ClaimedTelegramSpooledUpdate;
+  updateId: number;
+  stopClaimRefresh: () => void;
+};
+
+export function buildDeferredSpooledUpdateClaimKey(update: ClaimedTelegramSpooledUpdate): string {
+  return `${update.pendingPath}:${update.claim?.claimToken ?? update.claim?.processId ?? "claimed"}`;
+}
+
+// A handler that is still running this long after its reply abort will not
+// settle on its own; releasing the lane in-process would risk double-processing
+// (#93040), so the only safe recovery is a gateway process restart (#107482).
+export const ISOLATED_INGRESS_WEDGED_HANDLER_ESCALATION_MS = 10 * 60_000;
+
+export function hasEscalatedWedgedHandler(
+  handlers: Iterable<Pick<SpooledUpdateHandlerState, "escalatedAt">>,
+): boolean {
+  for (const handler of handlers) {
+    if (handler.escalatedAt !== undefined) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export function maybeEscalateWedgedSpooledUpdateHandler(params: {
+  handler: SpooledUpdateHandlerState;
+  escalationMs: number;
+  log: (message: string) => void;
+  status: { noteWedgedHandlerEscalation: (error: string) => void };
+}): void {
+  const { handler } = params;
+  if (handler.escalatedAt !== undefined || handler.timedOutAt === undefined) {
+    return;
+  }
+  const wedgedForMs = Date.now() - handler.timedOutAt;
+  if (wedgedForMs < params.escalationMs) {
+    return;
+  }
+  handler.escalatedAt = Date.now();
+  const message = `Telegram spooled update ${handler.updateId} has kept lane ${handler.laneKey} guarded for ${formatDurationPrecise(wedgedForMs)} after reply abort; a channel restart cannot release the lane, requesting a gateway process restart.`;
+  params.log(`[telegram] ${message}`);
+  params.status.noteWedgedHandlerEscalation(message);
+}

--- a/src/channels/account-snapshot-fields.test.ts
+++ b/src/channels/account-snapshot-fields.test.ts
@@ -1,13 +1,6 @@
 // Account snapshot field tests cover channel account snapshot serialization fields.
 import { describe, expect, it } from "vitest";
-import {
-  projectSafeChannelAccountSnapshotFields,
-  redactChannelAccountSnapshotBaseUrl,
-} from "./account-snapshot-fields.js";
-
-function joinUrlParts(...parts: string[]): string {
-  return parts.join("");
-}
+import { projectSafeChannelAccountSnapshotFields } from "./account-snapshot-fields.js";
 
 describe("projectSafeChannelAccountSnapshotFields", () => {
   it("omits webhook and public-key style fields from generic snapshots", () => {
@@ -41,63 +34,6 @@ describe("projectSafeChannelAccountSnapshotFields", () => {
     expect(snapshot).toEqual({
       baseUrl: "https://chat.example.test/",
     });
-  });
-
-  it("redacts query, nested URL, and fragment credentials from baseUrl fields", () => {
-    const nested = encodeURIComponent(
-      joinUrlParts(
-        "https://nested-user",
-        ":",
-        "nested-pass",
-        "@nested.example/cb?access_token=",
-        "nested-token",
-      ),
-    );
-    const snapshot = projectSafeChannelAccountSnapshotFields({
-      baseUrl: joinUrlParts(
-        "https://outer-user",
-        ":",
-        "outer-pass",
-        "@chat.example.test/?token=",
-        "outer-token",
-        `&next=${nested}#auth_token=`,
-        "fragment-token",
-      ),
-    });
-
-    expect(snapshot.baseUrl).not.toContain("outer-user");
-    expect(snapshot.baseUrl).not.toContain("outer-pass");
-    expect(snapshot.baseUrl).not.toContain("outer-token");
-    expect(snapshot.baseUrl).not.toContain("nested-user");
-    expect(snapshot.baseUrl).not.toContain("nested-pass");
-    expect(snapshot.baseUrl).not.toContain("nested-token");
-    expect(snapshot.baseUrl).not.toContain("fragment-token");
-    expect(snapshot.baseUrl).toContain("token=***");
-  });
-
-  it("redacts plugin snapshots without mutating raw account state", () => {
-    const rawBaseUrl = joinUrlParts(
-      "https://user",
-      ":",
-      "pass",
-      "@chat.example.test/?token=",
-      "secret",
-    );
-    const account = Object.freeze({
-      baseUrl: rawBaseUrl,
-    });
-    const snapshot = { ...account };
-
-    const redacted = redactChannelAccountSnapshotBaseUrl(snapshot);
-
-    expect(redacted).toEqual({ baseUrl: "https://chat.example.test/?token=***" });
-    expect(account.baseUrl).toBe(rawBaseUrl);
-    expect(snapshot.baseUrl).toBe(rawBaseUrl);
-  });
-
-  it("retains object identity when a plugin snapshot baseUrl is already safe", () => {
-    const snapshot = { baseUrl: "https://chat.example.test/?keep=visible" };
-    expect(redactChannelAccountSnapshotBaseUrl(snapshot)).toBe(snapshot);
   });
 
   it("preserves non-secret transport liveness timestamps", () => {
@@ -134,5 +70,22 @@ describe("projectSafeChannelAccountSnapshotFields", () => {
 
     const withoutFlag = projectSafeChannelAccountSnapshotFields({ connected: false });
     expect(withoutFlag).not.toHaveProperty("terminalDisconnect");
+  });
+
+  it("projects processRestartRequired when present and omits it when absent", () => {
+    const withFlag = projectSafeChannelAccountSnapshotFields({
+      connected: true,
+      processRestartRequired: true,
+    });
+    expect(withFlag.processRestartRequired).toBe(true);
+
+    const cleared = projectSafeChannelAccountSnapshotFields({
+      connected: true,
+      processRestartRequired: false,
+    });
+    expect(cleared.processRestartRequired).toBe(false);
+
+    const withoutFlag = projectSafeChannelAccountSnapshotFields({ connected: true });
+    expect(withoutFlag).not.toHaveProperty("processRestartRequired");
   });
 });

--- a/src/channels/account-snapshot-fields.ts
+++ b/src/channels/account-snapshot-fields.ts
@@ -259,6 +259,9 @@ export function projectSafeChannelAccountSnapshotFields(
     ...(readBoolean(record, "terminalDisconnect") !== undefined
       ? { terminalDisconnect: readBoolean(record, "terminalDisconnect") }
       : {}),
+    ...(readBoolean(record, "processRestartRequired") !== undefined
+      ? { processRestartRequired: readBoolean(record, "processRestartRequired") }
+      : {}),
     ...(readBoolean(record, "busy") !== undefined ? { busy: readBoolean(record, "busy") } : {}),
     ...(readNumber(record, "activeRuns") !== undefined
       ? { activeRuns: readNumber(record, "activeRuns") }

--- a/src/channels/plugins/types.core.ts
+++ b/src/channels/plugins/types.core.ts
@@ -191,74 +191,7 @@ export type ChannelMeta = {
   preferOver?: readonly string[];
 };
 
-/** Snapshot row returned by channel status and lifecycle surfaces. */
-export type ChannelAccountSnapshot = {
-  accountId: string;
-  name?: string;
-  enabled?: boolean;
-  configured?: boolean;
-  statusState?: string;
-  linked?: boolean;
-  running?: boolean;
-  connected?: boolean;
-  restartPending?: boolean;
-  reconnectAttempts?: number;
-  lastConnectedAt?: number | null;
-  lastDisconnect?:
-    | string
-    | {
-        at: number;
-        status?: number;
-        error?: string;
-        loggedOut?: boolean;
-      }
-    | null;
-  lastMessageAt?: number | null;
-  lastEventAt?: number | null;
-  lastTransportActivityAt?: number | null;
-  lastError?: string | null;
-  healthState?: string;
-  terminalDisconnect?: boolean;
-  lastStartAt?: number | null;
-  lastStopAt?: number | null;
-  lastInboundAt?: number | null;
-  lastOutboundAt?: number | null;
-  busy?: boolean;
-  activeRuns?: number;
-  lastRunActivityAt?: number | null;
-  mode?: string;
-  dmPolicy?: string;
-  allowFrom?: string[];
-  tokenSource?: string;
-  botTokenSource?: string;
-  appTokenSource?: string;
-  signingSecretSource?: string;
-  tokenStatus?: string;
-  botTokenStatus?: string;
-  appTokenStatus?: string;
-  signingSecretStatus?: string;
-  userTokenStatus?: string;
-  credentialSource?: string;
-  secretSource?: string;
-  audienceType?: string;
-  audience?: string;
-  webhookPath?: string;
-  webhookUrl?: string;
-  baseUrl?: string;
-  allowUnmentionedGroups?: boolean;
-  cliPath?: string | null;
-  dbPath?: string | null;
-  port?: number | null;
-  probe?: unknown;
-  lastProbeAt?: number | null;
-  audit?: unknown;
-  application?: unknown;
-  bot?: unknown;
-  publicKey?: string | null;
-  profile?: unknown;
-  channelAccessToken?: string;
-  channelSecret?: string;
-};
+export type { ChannelAccountSnapshot } from "./types.snapshot.js";
 
 export type ChannelLogSink = {
   info: (msg: string) => void;

--- a/src/channels/plugins/types.snapshot.ts
+++ b/src/channels/plugins/types.snapshot.ts
@@ -1,0 +1,74 @@
+/** Snapshot row returned by channel status and lifecycle surfaces. */
+export type ChannelAccountSnapshot = {
+  accountId: string;
+  name?: string;
+  enabled?: boolean;
+  configured?: boolean;
+  statusState?: string;
+  linked?: boolean;
+  running?: boolean;
+  connected?: boolean;
+  restartPending?: boolean;
+  reconnectAttempts?: number;
+  lastConnectedAt?: number | null;
+  lastDisconnect?:
+    | string
+    | {
+        at: number;
+        status?: number;
+        error?: string;
+        loggedOut?: boolean;
+      }
+    | null;
+  lastMessageAt?: number | null;
+  lastEventAt?: number | null;
+  lastTransportActivityAt?: number | null;
+  lastError?: string | null;
+  healthState?: string;
+  terminalDisconnect?: boolean;
+  /**
+   * Channel runtime is wedged in-process (e.g. a handler that survives channel
+   * stop/start); only a gateway process restart can recover it. The health
+   * monitor escalates instead of restarting the channel.
+   */
+  processRestartRequired?: boolean;
+  lastStartAt?: number | null;
+  lastStopAt?: number | null;
+  lastInboundAt?: number | null;
+  lastOutboundAt?: number | null;
+  busy?: boolean;
+  activeRuns?: number;
+  lastRunActivityAt?: number | null;
+  mode?: string;
+  dmPolicy?: string;
+  allowFrom?: string[];
+  tokenSource?: string;
+  botTokenSource?: string;
+  appTokenSource?: string;
+  signingSecretSource?: string;
+  tokenStatus?: string;
+  botTokenStatus?: string;
+  appTokenStatus?: string;
+  signingSecretStatus?: string;
+  userTokenStatus?: string;
+  credentialSource?: string;
+  secretSource?: string;
+  audienceType?: string;
+  audience?: string;
+  webhookPath?: string;
+  webhookUrl?: string;
+  baseUrl?: string;
+  allowUnmentionedGroups?: boolean;
+  cliPath?: string | null;
+  dbPath?: string | null;
+  port?: number | null;
+  probe?: unknown;
+  lastProbeAt?: number | null;
+  audit?: unknown;
+  application?: unknown;
+  bot?: unknown;
+  publicKey?: string | null;
+  profile?: unknown;
+  channelAccessToken?: string;
+  channelSecret?: string;
+};

--- a/src/gateway/channel-health-monitor.test.ts
+++ b/src/gateway/channel-health-monitor.test.ts
@@ -857,4 +857,95 @@ describe("channel-health-monitor", () => {
       monitor.stop();
     });
   });
+
+  describe("process restart escalation", () => {
+    const allowBudget = () => vi.fn(() => ({ allowed: true, usedInWindow: 1 }));
+
+    it("requests a gateway process restart instead of a channel restart", async () => {
+      const manager = createSlackSnapshotManager(
+        runningConnectedSlackAccount({ processRestartRequired: true }),
+      );
+      const scheduleProcessRestart = vi.fn(() => ({ ok: true }));
+      const takeEscalationBudget = allowBudget();
+      const monitor = await startAndRunCheck(manager, {
+        scheduleProcessRestart,
+        takeEscalationBudget,
+      });
+      expect(scheduleProcessRestart).toHaveBeenCalledTimes(1);
+      expect(scheduleProcessRestart).toHaveBeenCalledWith({
+        reason: "channel-health:slack:default",
+      });
+      expect(takeEscalationBudget).toHaveBeenCalledWith({
+        escalationKey: "slack:default",
+        windowMs: 60 * 60_000,
+        maxPerWindow: 10,
+        nowMs: expect.any(Number),
+      });
+      // A channel restart cannot release an in-process wedge; escalation must
+      // not fall through to stop/start.
+      expect(manager.stopChannel).not.toHaveBeenCalled();
+      expect(manager.startChannel).not.toHaveBeenCalled();
+      monitor.stop();
+    });
+
+    it("applies the per-account cooldown between escalations", async () => {
+      const manager = createSlackSnapshotManager(
+        runningConnectedSlackAccount({ processRestartRequired: true }),
+      );
+      const scheduleProcessRestart = vi.fn(() => ({ ok: true }));
+      const monitor = await startAndRunCheck(manager, {
+        scheduleProcessRestart,
+        takeEscalationBudget: allowBudget(),
+      });
+      expect(scheduleProcessRestart).toHaveBeenCalledTimes(1);
+      // Default cooldown is 2 cycles; the next check inside the window must skip.
+      await vi.advanceTimersByTimeAsync(DEFAULT_CHECK_INTERVAL_MS);
+      expect(scheduleProcessRestart).toHaveBeenCalledTimes(1);
+      await vi.advanceTimersByTimeAsync(2 * DEFAULT_CHECK_INTERVAL_MS);
+      expect(scheduleProcessRestart).toHaveBeenCalledTimes(2);
+      monitor.stop();
+    });
+
+    it("stops escalating once the flag clears", async () => {
+      const account = runningConnectedSlackAccount({ processRestartRequired: true });
+      const manager = createSlackSnapshotManager(account);
+      const scheduleProcessRestart = vi.fn(() => ({ ok: true }));
+      const monitor = await startAndRunCheck(manager, {
+        scheduleProcessRestart,
+        takeEscalationBudget: allowBudget(),
+      });
+      expect(scheduleProcessRestart).toHaveBeenCalledTimes(1);
+      account.processRestartRequired = false;
+      await vi.advanceTimersByTimeAsync(4 * DEFAULT_CHECK_INTERVAL_MS);
+      expect(scheduleProcessRestart).toHaveBeenCalledTimes(1);
+      expect(manager.stopChannel).not.toHaveBeenCalled();
+      monitor.stop();
+    });
+
+    it("skips escalation when the persisted hourly budget is exhausted", async () => {
+      const manager = createSlackSnapshotManager(
+        runningConnectedSlackAccount({ processRestartRequired: true }),
+      );
+      const scheduleProcessRestart = vi.fn(() => ({ ok: true }));
+      // Simulate a budget row that survived earlier gateway restarts: the
+      // first two takes are allowed, everything after is capped.
+      let takes = 0;
+      const takeEscalationBudget = vi.fn(() => {
+        takes += 1;
+        return takes <= 2
+          ? { allowed: true, usedInWindow: takes }
+          : { allowed: false, usedInWindow: 2 };
+      });
+      const monitor = await startAndRunCheck(manager, {
+        scheduleProcessRestart,
+        takeEscalationBudget,
+        cooldownCycles: 0,
+        maxRestartsPerHour: 2,
+      });
+      await vi.advanceTimersByTimeAsync(10 * DEFAULT_CHECK_INTERVAL_MS);
+      expect(scheduleProcessRestart).toHaveBeenCalledTimes(2);
+      expect(takeEscalationBudget.mock.calls.length).toBeGreaterThan(2);
+      monitor.stop();
+    });
+  });
 });

--- a/src/gateway/channel-health-monitor.test.ts
+++ b/src/gateway/channel-health-monitor.test.ts
@@ -868,6 +868,7 @@ describe("channel-health-monitor", () => {
       const scheduleProcessRestart = vi.fn(() => ({ ok: true }));
       const takeEscalationBudget = allowBudget();
       const monitor = await startAndRunCheck(manager, {
+        hasSupervisedRestart: () => true,
         scheduleProcessRestart,
         takeEscalationBudget,
       });
@@ -894,6 +895,7 @@ describe("channel-health-monitor", () => {
       );
       const scheduleProcessRestart = vi.fn(() => ({ ok: true }));
       const monitor = await startAndRunCheck(manager, {
+        hasSupervisedRestart: () => true,
         scheduleProcessRestart,
         takeEscalationBudget: allowBudget(),
       });
@@ -911,6 +913,7 @@ describe("channel-health-monitor", () => {
       const manager = createSlackSnapshotManager(account);
       const scheduleProcessRestart = vi.fn(() => ({ ok: true }));
       const monitor = await startAndRunCheck(manager, {
+        hasSupervisedRestart: () => true,
         scheduleProcessRestart,
         takeEscalationBudget: allowBudget(),
       });
@@ -937,6 +940,7 @@ describe("channel-health-monitor", () => {
           : { allowed: false, usedInWindow: 2 };
       });
       const monitor = await startAndRunCheck(manager, {
+        hasSupervisedRestart: () => true,
         scheduleProcessRestart,
         takeEscalationBudget,
         cooldownCycles: 0,
@@ -945,6 +949,26 @@ describe("channel-health-monitor", () => {
       await vi.advanceTimersByTimeAsync(10 * DEFAULT_CHECK_INTERVAL_MS);
       expect(scheduleProcessRestart).toHaveBeenCalledTimes(2);
       expect(takeEscalationBudget.mock.calls.length).toBeGreaterThan(2);
+      monitor.stop();
+    });
+
+    it("does not restart the gateway when no supervisor can replace the process", async () => {
+      const manager = createSlackSnapshotManager(
+        runningConnectedSlackAccount({ processRestartRequired: true }),
+      );
+      const scheduleProcessRestart = vi.fn(() => ({ ok: true }));
+      const takeEscalationBudget = allowBudget();
+      const monitor = await startAndRunCheck(manager, {
+        hasSupervisedRestart: () => false,
+        scheduleProcessRestart,
+        takeEscalationBudget,
+      });
+      await vi.advanceTimersByTimeAsync(4 * DEFAULT_CHECK_INTERVAL_MS);
+      // An in-process fallback restart cannot clear the wedge; the monitor must
+      // neither schedule the restart nor consume the persisted budget.
+      expect(scheduleProcessRestart).not.toHaveBeenCalled();
+      expect(takeEscalationBudget).not.toHaveBeenCalled();
+      expect(manager.stopChannel).not.toHaveBeenCalled();
       monitor.stop();
     });
   });

--- a/src/gateway/channel-health-monitor.ts
+++ b/src/gateway/channel-health-monitor.ts
@@ -1,6 +1,11 @@
 // Gateway channel health monitor.
 // Periodically evaluates channel account health and restarts stale runtimes.
 import type { ChannelId } from "../channels/plugins/types.public.js";
+import {
+  takeChannelHealthEscalationBudgetSync,
+  type ChannelHealthEscalationBudget,
+} from "../infra/channel-health-escalations.js";
+import { scheduleGatewaySigusr1Restart } from "../infra/restart.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { resolveTimerTimeoutMs } from "../shared/number-coercion.js";
 import {
@@ -40,6 +45,13 @@ type ChannelHealthMonitorDeps = {
   cooldownCycles?: number;
   maxRestartsPerHour?: number;
   abortSignal?: AbortSignal;
+  scheduleProcessRestart?: (opts: { reason: string }) => { ok: boolean };
+  takeEscalationBudget?: (opts: {
+    escalationKey: string;
+    windowMs: number;
+    maxPerWindow: number;
+    nowMs: number;
+  }) => ChannelHealthEscalationBudget;
 };
 
 export type ChannelHealthMonitor = {
@@ -71,6 +83,9 @@ export function startChannelHealthMonitor(deps: ChannelHealthMonitorDeps): Chann
     cooldownCycles = DEFAULT_COOLDOWN_CYCLES,
     maxRestartsPerHour = DEFAULT_MAX_RESTARTS_PER_HOUR,
     abortSignal,
+    scheduleProcessRestart = (opts: { reason: string }) =>
+      scheduleGatewaySigusr1Restart({ reason: opts.reason }),
+    takeEscalationBudget = takeChannelHealthEscalationBudgetSync,
   } = deps;
   const checkIntervalMs = resolveTimerTimeoutMs(deps.checkIntervalMs, DEFAULT_CHECK_INTERVAL_MS);
   const timing = resolveTimingPolicy(deps);
@@ -147,6 +162,46 @@ export function startChannelHealthMonitor(deps: ChannelHealthMonitorDeps): Chann
             log.info?.(
               `[${channelId}:${accountId}] health-monitor: skipping restart, terminal disconnect`,
             );
+            continue;
+          }
+          if (health.reason === "process-restart-required") {
+            // Channel stop/start cannot recover an in-process wedge, so this
+            // escalation must not fall through to the channel-restart path.
+            const escalationRecord = restartRecords.get(key) ?? {
+              lastRestartAt: 0,
+              restartsThisHour: [],
+            };
+            if (now - escalationRecord.lastRestartAt <= cooldownMs) {
+              continue;
+            }
+            // The requested restart replaces this process (and its in-memory
+            // records), so the hourly budget lives in the state database — a
+            // wedge that re-forms after every restart stays bounded.
+            const budget = takeEscalationBudget({
+              escalationKey: key,
+              windowMs: ONE_HOUR_MS,
+              maxPerWindow: maxRestartsPerHour,
+              nowMs: now,
+            });
+            if (!budget.allowed) {
+              log.warn?.(
+                `[${channelId}:${accountId}] health-monitor: hit ${maxRestartsPerHour} restarts/hour limit (persisted), skipping gateway restart escalation`,
+              );
+              continue;
+            }
+            log.warn?.(
+              `[${channelId}:${accountId}] health-monitor: channel reports an in-process wedge a channel restart cannot recover; requesting gateway process restart (${budget.usedInWindow}/${maxRestartsPerHour} this hour)`,
+            );
+            escalationRecord.lastRestartAt = now;
+            restartRecords.set(key, escalationRecord);
+            const scheduled = scheduleProcessRestart({
+              reason: `channel-health:${channelId}:${accountId}`,
+            });
+            if (!scheduled.ok) {
+              log.error?.(
+                `[${channelId}:${accountId}] health-monitor: gateway process restart request failed; lane stays guarded until a manual gateway restart`,
+              );
+            }
             continue;
           }
 

--- a/src/gateway/channel-health-monitor.ts
+++ b/src/gateway/channel-health-monitor.ts
@@ -198,9 +198,15 @@ export function startChannelHealthMonitor(deps: ChannelHealthMonitorDeps): Chann
               nowMs: now,
             });
             if (!budget.allowed) {
-              log.warn?.(
-                `[${channelId}:${accountId}] health-monitor: hit ${maxRestartsPerHour} restarts/hour limit (persisted), skipping gateway restart escalation`,
-              );
+              if (budget.unavailable) {
+                log.error?.(
+                  `[${channelId}:${accountId}] health-monitor: escalation budget state is unavailable, refusing an unarbitrated gateway restart; restart the gateway manually and check the state database`,
+                );
+              } else {
+                log.warn?.(
+                  `[${channelId}:${accountId}] health-monitor: hit ${maxRestartsPerHour} restarts/hour limit (persisted), skipping gateway restart escalation`,
+                );
+              }
               continue;
             }
             log.warn?.(

--- a/src/gateway/channel-health-monitor.ts
+++ b/src/gateway/channel-health-monitor.ts
@@ -6,6 +6,7 @@ import {
   type ChannelHealthEscalationBudget,
 } from "../infra/channel-health-escalations.js";
 import { scheduleGatewaySigusr1Restart } from "../infra/restart.js";
+import { detectRespawnSupervisor } from "../infra/supervisor-markers.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { resolveTimerTimeoutMs } from "../shared/number-coercion.js";
 import {
@@ -52,6 +53,7 @@ type ChannelHealthMonitorDeps = {
     maxPerWindow: number;
     nowMs: number;
   }) => ChannelHealthEscalationBudget;
+  hasSupervisedRestart?: () => boolean;
 };
 
 export type ChannelHealthMonitor = {
@@ -86,6 +88,7 @@ export function startChannelHealthMonitor(deps: ChannelHealthMonitorDeps): Chann
     scheduleProcessRestart = (opts: { reason: string }) =>
       scheduleGatewaySigusr1Restart({ reason: opts.reason }),
     takeEscalationBudget = takeChannelHealthEscalationBudgetSync,
+    hasSupervisedRestart = () => detectRespawnSupervisor() !== null,
   } = deps;
   const checkIntervalMs = resolveTimerTimeoutMs(deps.checkIntervalMs, DEFAULT_CHECK_INTERVAL_MS);
   const timing = resolveTimingPolicy(deps);
@@ -172,6 +175,17 @@ export function startChannelHealthMonitor(deps: ChannelHealthMonitorDeps): Chann
               restartsThisHour: [],
             };
             if (now - escalationRecord.lastRestartAt <= cooldownMs) {
+              continue;
+            }
+            // Without a supervisor the restart falls back to in-process, which
+            // cannot clear a process-scoped wedge: it would interrupt other
+            // channels without recovering this lane. Ask the operator instead.
+            if (!hasSupervisedRestart()) {
+              log.error?.(
+                `[${channelId}:${accountId}] health-monitor: channel needs a gateway process restart to clear an in-process wedge, but no supervisor is available to replace the process; restart the gateway manually (for example via your service manager or \`openclaw gateway restart\`)`,
+              );
+              escalationRecord.lastRestartAt = now;
+              restartRecords.set(key, escalationRecord);
               continue;
             }
             // The requested restart replaces this process (and its in-memory

--- a/src/gateway/channel-health-policy.test.ts
+++ b/src/gateway/channel-health-policy.test.ts
@@ -86,6 +86,20 @@ describe("evaluateChannelHealth", () => {
     expect(evaluation).toEqual({ healthy: false, reason: "stuck" });
   });
 
+  it("escalates process-restart-required even while the channel reports busy", () => {
+    const now = 100_000;
+    const evaluation = evaluateHealth(
+      activeRunAccount(now - 1_000, { processRestartRequired: true }),
+      { now },
+    );
+    expect(evaluation).toEqual({ healthy: false, reason: "process-restart-required" });
+  });
+
+  it("escalates process-restart-required on an otherwise healthy connected channel", () => {
+    const evaluation = evaluateHealth(connectedAccount({ processRestartRequired: true }));
+    expect(evaluation).toEqual({ healthy: false, reason: "process-restart-required" });
+  });
+
   it("ignores inherited busy flags until current lifecycle reports run activity", () => {
     const now = 100_000;
     const evaluation = evaluateHealth(

--- a/src/gateway/channel-health-policy.ts
+++ b/src/gateway/channel-health-policy.ts
@@ -18,6 +18,7 @@ type ChannelHealthSnapshot = {
   reconnectAttempts?: number;
   mode?: string;
   terminalDisconnect?: boolean;
+  processRestartRequired?: boolean;
 };
 
 type ChannelHealthEvaluationReason =
@@ -25,6 +26,7 @@ type ChannelHealthEvaluationReason =
   | "unmanaged"
   | "not-running"
   | "terminal-disconnect"
+  | "process-restart-required"
   | "busy"
   | "stuck"
   | "startup-connect-grace"
@@ -61,6 +63,12 @@ export function evaluateChannelHealth(
 ): ChannelHealthEvaluation {
   if (!isManagedAccount(snapshot)) {
     return { healthy: true, reason: "unmanaged" };
+  }
+  // A wedged in-process runtime outranks every other signal (including busy):
+  // channel stop/start cannot release it, so the monitor must escalate to a
+  // gateway process restart instead of restarting the channel around it.
+  if (snapshot.processRestartRequired) {
+    return { healthy: false, reason: "process-restart-required" };
   }
   if (!snapshot.running && snapshot.terminalDisconnect) {
     return { healthy: false, reason: "terminal-disconnect" };

--- a/src/infra/channel-health-escalations.test.ts
+++ b/src/infra/channel-health-escalations.test.ts
@@ -1,0 +1,114 @@
+// Channel-health escalation budget tests cover restart-surviving accounting.
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { takeChannelHealthEscalationBudgetSync } from "./channel-health-escalations.js";
+
+const HOUR_MS = 60 * 60_000;
+
+afterEach(() => {
+  closeOpenClawStateDatabaseForTest();
+});
+
+function createStateEnv(): NodeJS.ProcessEnv {
+  const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-health-escalations-"));
+  return { OPENCLAW_STATE_DIR: stateDir } as NodeJS.ProcessEnv;
+}
+
+describe("takeChannelHealthEscalationBudgetSync", () => {
+  it("counts escalations within the window and blocks at the cap", () => {
+    const env = createStateEnv();
+    const base = 1_000_000;
+    const first = takeChannelHealthEscalationBudgetSync({
+      escalationKey: "telegram:default",
+      windowMs: HOUR_MS,
+      maxPerWindow: 2,
+      env,
+      nowMs: base,
+    });
+    expect(first).toEqual({ allowed: true, usedInWindow: 1 });
+    const second = takeChannelHealthEscalationBudgetSync({
+      escalationKey: "telegram:default",
+      windowMs: HOUR_MS,
+      maxPerWindow: 2,
+      env,
+      nowMs: base + 10_000,
+    });
+    expect(second).toEqual({ allowed: true, usedInWindow: 2 });
+    const third = takeChannelHealthEscalationBudgetSync({
+      escalationKey: "telegram:default",
+      windowMs: HOUR_MS,
+      maxPerWindow: 2,
+      env,
+      nowMs: base + 20_000,
+    });
+    expect(third).toEqual({ allowed: false, usedInWindow: 2 });
+  });
+
+  it("survives across state database reopen like a process restart", () => {
+    const env = createStateEnv();
+    const base = 1_000_000;
+    takeChannelHealthEscalationBudgetSync({
+      escalationKey: "telegram:default",
+      windowMs: HOUR_MS,
+      maxPerWindow: 2,
+      env,
+      nowMs: base,
+    });
+    // A gateway process restart drops all in-memory state; reopening the
+    // database is the equivalent boundary in tests.
+    closeOpenClawStateDatabaseForTest();
+    const afterRestart = takeChannelHealthEscalationBudgetSync({
+      escalationKey: "telegram:default",
+      windowMs: HOUR_MS,
+      maxPerWindow: 2,
+      env,
+      nowMs: base + 10_000,
+    });
+    expect(afterRestart).toEqual({ allowed: true, usedInWindow: 2 });
+  });
+
+  it("resets the window once it fully elapses", () => {
+    const env = createStateEnv();
+    const base = 1_000_000;
+    for (let i = 0; i < 2; i += 1) {
+      takeChannelHealthEscalationBudgetSync({
+        escalationKey: "telegram:default",
+        windowMs: HOUR_MS,
+        maxPerWindow: 2,
+        env,
+        nowMs: base + i * 1_000,
+      });
+    }
+    const afterWindow = takeChannelHealthEscalationBudgetSync({
+      escalationKey: "telegram:default",
+      windowMs: HOUR_MS,
+      maxPerWindow: 2,
+      env,
+      nowMs: base + HOUR_MS + 1,
+    });
+    expect(afterWindow).toEqual({ allowed: true, usedInWindow: 1 });
+  });
+
+  it("tracks keys independently", () => {
+    const env = createStateEnv();
+    const base = 1_000_000;
+    takeChannelHealthEscalationBudgetSync({
+      escalationKey: "telegram:default",
+      windowMs: HOUR_MS,
+      maxPerWindow: 1,
+      env,
+      nowMs: base,
+    });
+    const otherKey = takeChannelHealthEscalationBudgetSync({
+      escalationKey: "slack:default",
+      windowMs: HOUR_MS,
+      maxPerWindow: 1,
+      env,
+      nowMs: base,
+    });
+    expect(otherKey).toEqual({ allowed: true, usedInWindow: 1 });
+  });
+});

--- a/src/infra/channel-health-escalations.test.ts
+++ b/src/infra/channel-health-escalations.test.ts
@@ -17,98 +17,67 @@ function createStateEnv(): NodeJS.ProcessEnv {
   return { OPENCLAW_STATE_DIR: stateDir } as NodeJS.ProcessEnv;
 }
 
+function take(env: NodeJS.ProcessEnv, nowMs: number, key = "telegram:default", max = 2) {
+  return takeChannelHealthEscalationBudgetSync({
+    escalationKey: key,
+    windowMs: HOUR_MS,
+    maxPerWindow: max,
+    env,
+    nowMs,
+  });
+}
+
 describe("takeChannelHealthEscalationBudgetSync", () => {
-  it("counts escalations within the window and blocks at the cap", () => {
+  it("counts escalations within the rolling window and blocks at the cap", () => {
     const env = createStateEnv();
     const base = 1_000_000;
-    const first = takeChannelHealthEscalationBudgetSync({
-      escalationKey: "telegram:default",
-      windowMs: HOUR_MS,
-      maxPerWindow: 2,
-      env,
-      nowMs: base,
-    });
-    expect(first).toEqual({ allowed: true, usedInWindow: 1 });
-    const second = takeChannelHealthEscalationBudgetSync({
-      escalationKey: "telegram:default",
-      windowMs: HOUR_MS,
-      maxPerWindow: 2,
-      env,
-      nowMs: base + 10_000,
-    });
-    expect(second).toEqual({ allowed: true, usedInWindow: 2 });
-    const third = takeChannelHealthEscalationBudgetSync({
-      escalationKey: "telegram:default",
-      windowMs: HOUR_MS,
-      maxPerWindow: 2,
-      env,
-      nowMs: base + 20_000,
-    });
-    expect(third).toEqual({ allowed: false, usedInWindow: 2 });
+    expect(take(env, base)).toEqual({ allowed: true, usedInWindow: 1 });
+    expect(take(env, base + 10_000)).toEqual({ allowed: true, usedInWindow: 2 });
+    expect(take(env, base + 20_000)).toEqual({ allowed: false, usedInWindow: 2 });
   });
 
   it("survives across state database reopen like a process restart", () => {
     const env = createStateEnv();
     const base = 1_000_000;
-    takeChannelHealthEscalationBudgetSync({
-      escalationKey: "telegram:default",
-      windowMs: HOUR_MS,
-      maxPerWindow: 2,
-      env,
-      nowMs: base,
-    });
+    take(env, base);
     // A gateway process restart drops all in-memory state; reopening the
     // database is the equivalent boundary in tests.
     closeOpenClawStateDatabaseForTest();
-    const afterRestart = takeChannelHealthEscalationBudgetSync({
-      escalationKey: "telegram:default",
-      windowMs: HOUR_MS,
-      maxPerWindow: 2,
-      env,
-      nowMs: base + 10_000,
-    });
-    expect(afterRestart).toEqual({ allowed: true, usedInWindow: 2 });
+    expect(take(env, base + 10_000)).toEqual({ allowed: true, usedInWindow: 2 });
+    expect(take(env, base + 20_000)).toEqual({ allowed: false, usedInWindow: 2 });
   });
 
-  it("resets the window once it fully elapses", () => {
+  it("does not double the allowance across a window boundary (rolling, not fixed)", () => {
     const env = createStateEnv();
     const base = 1_000_000;
-    for (let i = 0; i < 2; i += 1) {
-      takeChannelHealthEscalationBudgetSync({
-        escalationKey: "telegram:default",
-        windowMs: HOUR_MS,
-        maxPerWindow: 2,
-        env,
-        nowMs: base + i * 1_000,
-      });
-    }
-    const afterWindow = takeChannelHealthEscalationBudgetSync({
-      escalationKey: "telegram:default",
-      windowMs: HOUR_MS,
-      maxPerWindow: 2,
-      env,
-      nowMs: base + HOUR_MS + 1,
-    });
-    expect(afterWindow).toEqual({ allowed: true, usedInWindow: 1 });
+    take(env, base);
+    take(env, base + 60_000);
+    // A fixed window resetting here would allow two more restarts back to back.
+    // The rolling window must keep both recent escalations in scope.
+    expect(take(env, base + 61_000).allowed).toBe(false);
+    expect(take(env, base + HOUR_MS - 1).allowed).toBe(false);
+    // Only once the oldest escalation ages past the trailing window does one
+    // slot free up.
+    expect(take(env, base + HOUR_MS + 1)).toEqual({ allowed: true, usedInWindow: 2 });
+    expect(take(env, base + HOUR_MS + 2).allowed).toBe(false);
   });
 
   it("tracks keys independently", () => {
     const env = createStateEnv();
     const base = 1_000_000;
-    takeChannelHealthEscalationBudgetSync({
-      escalationKey: "telegram:default",
-      windowMs: HOUR_MS,
-      maxPerWindow: 1,
-      env,
-      nowMs: base,
-    });
-    const otherKey = takeChannelHealthEscalationBudgetSync({
-      escalationKey: "slack:default",
-      windowMs: HOUR_MS,
-      maxPerWindow: 1,
-      env,
-      nowMs: base,
-    });
-    expect(otherKey).toEqual({ allowed: true, usedInWindow: 1 });
+    take(env, base, "telegram:default", 1);
+    expect(take(env, base, "slack:default", 1)).toEqual({ allowed: true, usedInWindow: 1 });
+  });
+
+  it("fails closed when the state database is unavailable", () => {
+    const bogusFile = path.join(
+      fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-health-escalations-")),
+      "not-a-dir",
+    );
+    fs.writeFileSync(bogusFile, "block");
+    const env = { OPENCLAW_STATE_DIR: bogusFile } as NodeJS.ProcessEnv;
+    const result = take(env, 1_000_000);
+    expect(result.allowed).toBe(false);
+    expect(result.unavailable).toBe(true);
   });
 });

--- a/src/infra/channel-health-escalations.ts
+++ b/src/infra/channel-health-escalations.ts
@@ -11,6 +11,10 @@ import {
 
 const escalationLog = createSubsystemLogger("gateway/health-escalations");
 
+// Rows older than the largest window any caller uses are dead weight; retention
+// only needs to comfortably exceed the one-hour budget window.
+const CHANNEL_HEALTH_ESCALATION_RETENTION_MS = 24 * 60 * 60_000;
+
 type ChannelHealthEscalationsDatabase = Pick<
   OpenClawStateKyselyDatabase,
   "channel_health_escalations"
@@ -19,12 +23,15 @@ type ChannelHealthEscalationsDatabase = Pick<
 export type ChannelHealthEscalationBudget = {
   allowed: boolean;
   usedInWindow: number;
+  /** True when the state database could not arbitrate; callers must not restart. */
+  unavailable?: boolean;
 };
 
 /**
- * Consumes one escalation from the rolling per-key window, resetting the
- * window when it has fully elapsed. Fails open: an unavailable state database
- * must not block the recovery restart it is budgeting.
+ * Consumes one escalation from the rolling per-key window (row per escalation,
+ * counted over the trailing windowMs). Fails closed: a gateway process restart
+ * interrupts every channel, so an unavailable state database means manual
+ * recovery instead of an unbounded restart loop.
  */
 export function takeChannelHealthEscalationBudgetSync(opts: {
   escalationKey: string;
@@ -36,41 +43,35 @@ export function takeChannelHealthEscalationBudgetSync(opts: {
   const env = opts.env ?? process.env;
   const nowMs = opts.nowMs ?? Date.now();
   try {
-    let budget: ChannelHealthEscalationBudget = { allowed: true, usedInWindow: 1 };
+    let budget: ChannelHealthEscalationBudget = { allowed: false, usedInWindow: 0 };
     runOpenClawStateWriteTransaction(
       ({ db }) => {
         const kysely = getNodeSqliteKysely<ChannelHealthEscalationsDatabase>(db);
+        executeSqliteQuerySync(
+          db,
+          kysely
+            .deleteFrom("channel_health_escalations")
+            .where("escalated_at_ms", "<", nowMs - CHANNEL_HEALTH_ESCALATION_RETENTION_MS),
+        );
         const row = executeSqliteQueryTakeFirstSync(
           db,
           kysely
             .selectFrom("channel_health_escalations")
-            .select(["window_started_at_ms", "escalation_count"])
-            .where("escalation_key", "=", opts.escalationKey),
+            .select((eb) => eb.fn.countAll<number>().as("count"))
+            .where("escalation_key", "=", opts.escalationKey)
+            .where("escalated_at_ms", ">", nowMs - opts.windowMs),
         );
-        const windowActive = row !== undefined && nowMs - row.window_started_at_ms < opts.windowMs;
-        const usedBefore = windowActive ? row.escalation_count : 0;
+        const usedBefore = row?.count ?? 0;
         if (usedBefore >= opts.maxPerWindow) {
           budget = { allowed: false, usedInWindow: usedBefore };
           return;
         }
-        const windowStartedAtMs = windowActive ? row.window_started_at_ms : nowMs;
         executeSqliteQuerySync(
           db,
-          kysely
-            .insertInto("channel_health_escalations")
-            .values({
-              escalation_key: opts.escalationKey,
-              window_started_at_ms: windowStartedAtMs,
-              escalation_count: usedBefore + 1,
-              updated_at_ms: nowMs,
-            })
-            .onConflict((conflict) =>
-              conflict.column("escalation_key").doUpdateSet({
-                window_started_at_ms: windowStartedAtMs,
-                escalation_count: usedBefore + 1,
-                updated_at_ms: nowMs,
-              }),
-            ),
+          kysely.insertInto("channel_health_escalations").values({
+            escalation_key: opts.escalationKey,
+            escalated_at_ms: nowMs,
+          }),
         );
         budget = { allowed: true, usedInWindow: usedBefore + 1 };
       },
@@ -78,7 +79,9 @@ export function takeChannelHealthEscalationBudgetSync(opts: {
     );
     return budget;
   } catch (err) {
-    escalationLog.warn(`escalation budget state unavailable; fail-open: ${String(err)}`);
-    return { allowed: true, usedInWindow: 0 };
+    escalationLog.warn(
+      `escalation budget state unavailable; failing closed to manual recovery: ${String(err)}`,
+    );
+    return { allowed: false, usedInWindow: 0, unavailable: true };
   }
 }

--- a/src/infra/channel-health-escalations.ts
+++ b/src/infra/channel-health-escalations.ts
@@ -1,0 +1,84 @@
+// Persists channel-health gateway-restart escalations so the hourly budget
+// survives the process replacement the escalation itself causes.
+import { createSubsystemLogger } from "../logging/subsystem.js";
+import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
+import { runOpenClawStateWriteTransaction } from "../state/openclaw-state-db.js";
+import {
+  executeSqliteQuerySync,
+  executeSqliteQueryTakeFirstSync,
+  getNodeSqliteKysely,
+} from "./kysely-sync.js";
+
+const escalationLog = createSubsystemLogger("gateway/health-escalations");
+
+type ChannelHealthEscalationsDatabase = Pick<
+  OpenClawStateKyselyDatabase,
+  "channel_health_escalations"
+>;
+
+export type ChannelHealthEscalationBudget = {
+  allowed: boolean;
+  usedInWindow: number;
+};
+
+/**
+ * Consumes one escalation from the rolling per-key window, resetting the
+ * window when it has fully elapsed. Fails open: an unavailable state database
+ * must not block the recovery restart it is budgeting.
+ */
+export function takeChannelHealthEscalationBudgetSync(opts: {
+  escalationKey: string;
+  windowMs: number;
+  maxPerWindow: number;
+  env?: NodeJS.ProcessEnv;
+  nowMs?: number;
+}): ChannelHealthEscalationBudget {
+  const env = opts.env ?? process.env;
+  const nowMs = opts.nowMs ?? Date.now();
+  try {
+    let budget: ChannelHealthEscalationBudget = { allowed: true, usedInWindow: 1 };
+    runOpenClawStateWriteTransaction(
+      ({ db }) => {
+        const kysely = getNodeSqliteKysely<ChannelHealthEscalationsDatabase>(db);
+        const row = executeSqliteQueryTakeFirstSync(
+          db,
+          kysely
+            .selectFrom("channel_health_escalations")
+            .select(["window_started_at_ms", "escalation_count"])
+            .where("escalation_key", "=", opts.escalationKey),
+        );
+        const windowActive = row !== undefined && nowMs - row.window_started_at_ms < opts.windowMs;
+        const usedBefore = windowActive ? row.escalation_count : 0;
+        if (usedBefore >= opts.maxPerWindow) {
+          budget = { allowed: false, usedInWindow: usedBefore };
+          return;
+        }
+        const windowStartedAtMs = windowActive ? row.window_started_at_ms : nowMs;
+        executeSqliteQuerySync(
+          db,
+          kysely
+            .insertInto("channel_health_escalations")
+            .values({
+              escalation_key: opts.escalationKey,
+              window_started_at_ms: windowStartedAtMs,
+              escalation_count: usedBefore + 1,
+              updated_at_ms: nowMs,
+            })
+            .onConflict((conflict) =>
+              conflict.column("escalation_key").doUpdateSet({
+                window_started_at_ms: windowStartedAtMs,
+                escalation_count: usedBefore + 1,
+                updated_at_ms: nowMs,
+              }),
+            ),
+        );
+        budget = { allowed: true, usedInWindow: usedBefore + 1 };
+      },
+      { env },
+    );
+    return budget;
+  } catch (err) {
+    escalationLog.warn(`escalation budget state unavailable; fail-open: ${String(err)}`);
+    return { allowed: true, usedInWindow: 0 };
+  }
+}

--- a/src/state/openclaw-state-db.generated.d.ts
+++ b/src/state/openclaw-state-db.generated.d.ts
@@ -194,10 +194,8 @@ export interface CaptureSessions {
 }
 
 export interface ChannelHealthEscalations {
-  escalation_count: number;
+  escalated_at_ms: number;
   escalation_key: string;
-  updated_at_ms: number;
-  window_started_at_ms: number;
 }
 
 export interface ChannelIngressEvents {

--- a/src/state/openclaw-state-db.generated.d.ts
+++ b/src/state/openclaw-state-db.generated.d.ts
@@ -193,6 +193,13 @@ export interface CaptureSessions {
   started_at: number;
 }
 
+export interface ChannelHealthEscalations {
+  escalation_count: number;
+  escalation_key: string;
+  updated_at_ms: number;
+  window_started_at_ms: number;
+}
+
 export interface ChannelIngressEvents {
   account_id: string;
   attempts: Generated<number>;
@@ -1300,6 +1307,7 @@ export interface DB {
   capture_blobs: CaptureBlobs;
   capture_events: CaptureEvents;
   capture_sessions: CaptureSessions;
+  channel_health_escalations: ChannelHealthEscalations;
   channel_ingress_events: ChannelIngressEvents;
   channel_pairing_allow_entries: ChannelPairingAllowEntries;
   channel_pairing_requests: ChannelPairingRequests;

--- a/src/state/openclaw-state-schema.generated.ts
+++ b/src/state/openclaw-state-schema.generated.ts
@@ -874,11 +874,12 @@ CREATE INDEX IF NOT EXISTS idx_gateway_boot_lifecycle_started
   ON gateway_boot_lifecycle(started_at_ms);
 
 CREATE TABLE IF NOT EXISTS channel_health_escalations (
-  escalation_key TEXT NOT NULL PRIMARY KEY,
-  window_started_at_ms INTEGER NOT NULL,
-  escalation_count INTEGER NOT NULL,
-  updated_at_ms INTEGER NOT NULL
+  escalation_key TEXT NOT NULL,
+  escalated_at_ms INTEGER NOT NULL
 ) STRICT;
+
+CREATE INDEX IF NOT EXISTS idx_channel_health_escalations_key_time
+  ON channel_health_escalations(escalation_key, escalated_at_ms);
 
 CREATE TABLE IF NOT EXISTS acp_sessions (
   session_key TEXT NOT NULL PRIMARY KEY,

--- a/src/state/openclaw-state-schema.generated.ts
+++ b/src/state/openclaw-state-schema.generated.ts
@@ -878,7 +878,7 @@ CREATE TABLE IF NOT EXISTS channel_health_escalations (
   window_started_at_ms INTEGER NOT NULL,
   escalation_count INTEGER NOT NULL,
   updated_at_ms INTEGER NOT NULL
-);
+) STRICT;
 
 CREATE TABLE IF NOT EXISTS acp_sessions (
   session_key TEXT NOT NULL PRIMARY KEY,

--- a/src/state/openclaw-state-schema.generated.ts
+++ b/src/state/openclaw-state-schema.generated.ts
@@ -873,6 +873,13 @@ CREATE TABLE IF NOT EXISTS gateway_boot_lifecycle (
 CREATE INDEX IF NOT EXISTS idx_gateway_boot_lifecycle_started
   ON gateway_boot_lifecycle(started_at_ms);
 
+CREATE TABLE IF NOT EXISTS channel_health_escalations (
+  escalation_key TEXT NOT NULL PRIMARY KEY,
+  window_started_at_ms INTEGER NOT NULL,
+  escalation_count INTEGER NOT NULL,
+  updated_at_ms INTEGER NOT NULL
+);
+
 CREATE TABLE IF NOT EXISTS acp_sessions (
   session_key TEXT NOT NULL PRIMARY KEY,
   session_id TEXT,

--- a/src/state/openclaw-state-schema.sql
+++ b/src/state/openclaw-state-schema.sql
@@ -868,6 +868,13 @@ CREATE TABLE IF NOT EXISTS gateway_boot_lifecycle (
 CREATE INDEX IF NOT EXISTS idx_gateway_boot_lifecycle_started
   ON gateway_boot_lifecycle(started_at_ms);
 
+CREATE TABLE IF NOT EXISTS channel_health_escalations (
+  escalation_key TEXT NOT NULL PRIMARY KEY,
+  window_started_at_ms INTEGER NOT NULL,
+  escalation_count INTEGER NOT NULL,
+  updated_at_ms INTEGER NOT NULL
+);
+
 CREATE TABLE IF NOT EXISTS acp_sessions (
   session_key TEXT NOT NULL PRIMARY KEY,
   session_id TEXT,

--- a/src/state/openclaw-state-schema.sql
+++ b/src/state/openclaw-state-schema.sql
@@ -873,7 +873,7 @@ CREATE TABLE IF NOT EXISTS channel_health_escalations (
   window_started_at_ms INTEGER NOT NULL,
   escalation_count INTEGER NOT NULL,
   updated_at_ms INTEGER NOT NULL
-);
+) STRICT;
 
 CREATE TABLE IF NOT EXISTS acp_sessions (
   session_key TEXT NOT NULL PRIMARY KEY,

--- a/src/state/openclaw-state-schema.sql
+++ b/src/state/openclaw-state-schema.sql
@@ -869,11 +869,12 @@ CREATE INDEX IF NOT EXISTS idx_gateway_boot_lifecycle_started
   ON gateway_boot_lifecycle(started_at_ms);
 
 CREATE TABLE IF NOT EXISTS channel_health_escalations (
-  escalation_key TEXT NOT NULL PRIMARY KEY,
-  window_started_at_ms INTEGER NOT NULL,
-  escalation_count INTEGER NOT NULL,
-  updated_at_ms INTEGER NOT NULL
+  escalation_key TEXT NOT NULL,
+  escalated_at_ms INTEGER NOT NULL
 ) STRICT;
+
+CREATE INDEX IF NOT EXISTS idx_channel_health_escalations_key_time
+  ON channel_health_escalations(escalation_key, escalated_at_ms);
 
 CREATE TABLE IF NOT EXISTS acp_sessions (
   session_key TEXT NOT NULL PRIMARY KEY,


### PR DESCRIPTION
Closes #107482
Related: #91456

## What Problem This Solves

Fixes an issue where a Telegram DM stops getting replies indefinitely when a spooled update handler wedges: after `keeping lane telegram:<chatId> guarded` (the #91456 signature), the lane guard has no recovery path. The guard state is intentionally process-scoped (the wedged handler survives channel restarts), so the health monitor's channel restart brings polling back but leaves the lane locked — every later DM on that chat queues forever until someone manually restarts the gateway.

Live incident (2026-07-14, 2026.7.1-beta.5, macOS/polling, details in #107482): four guard events on one DM lane in a day; three self-recovered, the fourth stayed guarded ~50 minutes. A health-monitor channel restart (`reason: disconnected`) during the window did not release the guard; a manual full gateway restart drained the queued updates immediately.

## Why This Change Was Made

#93040 tried to release the guard in place after the abort grace and was closed after review pushback: a log-based release without a hard cancellation/process-restart boundary risks two live handlers on one lane. This PR keeps that invariant — the lane is **never** released in-process — and instead escalates to the hard boundary the review asked for:

1. **Telegram plugin**: a handler still running 10 minutes (`ISOLATED_INGRESS_WEDGED_HANDLER_ESCALATION_MS`) after its reply abort is declared wedged. The session publishes a generic `processRestartRequired: true` status patch (cleared automatically if the handler settles late) and keeps the lane guarded.
2. **Channel health policy**: `processRestartRequired` evaluates to a new `process-restart-required` reason that outranks `busy` (a wedged turn can keep `activeRuns > 0` and otherwise hide behind the busy short-circuit).
3. **Health monitor**: for that reason it skips the channel stop/start path (which cannot recover the wedge) and calls `scheduleGatewaySigusr1Restart()` — the same seam config reload and updates use, so idle-drain deferral, coalescing, cooldown, and supervised full-process handoff (launchd/systemd/schtasks) all apply. Escalations consume the existing per-account cooldown and `channelMaxRestartsPerHour` budget, bounding restart churn if a wedge re-forms.

4. **Escalation budget persistence** (added after ClawSweeper review; hardened after re-review): the requested restart replaces the process that holds the monitor's in-memory hourly accounting, so the escalation budget lives in the state database (`channel_health_escalations`, one row per escalation, counted over a **trailing rolling window** so straddling a boundary can never double the allowance). A wedge that re-forms after every restart stays bounded by `channelMaxRestartsPerHour` across process replacements. The budget helper **fails closed**: if the state database cannot arbitrate, the monitor refuses the restart and directs the operator to manual recovery instead of risking an unbounded gateway restart loop.

On supervised installs the restart is a true process replacement, which releases the guard and drains the queued lane. On unmanaged installs (no supervisor) the monitor does not restart at all — an in-process fallback cannot clear the wedge, so restarting would interrupt unrelated channels for nothing; it logs that a manual gateway restart is required and consumes no budget.

The snapshot field is channel-agnostic on purpose: any channel whose runtime can wedge in-process can publish the same flag, and core stays plugin-agnostic.

## User Impact

- A wedged DM lane now recovers automatically in bounded time (~10 min escalation + one health-monitor cycle) instead of appearing as a silently dead bot until a manual gateway restart.
- No behavior change for healthy lanes: escalation requires a timed-out handler that already ignored its reply abort for the full escalation window; the flag clears itself if the handler settles late.
- `docs/gateway/health.md` documents the escalation and its budget.

## Evidence

- `node scripts/run-vitest.mjs extensions/telegram/src/polling-session.test.ts` — 85 passed, including the new regression test: wedged handler ignores reply abort → lane guarded (not released: later same-lane update stays pending, failed update stays failed) → single `processRestartRequired: true` status patch with the guard message → no re-escalation on repeat drains → late settle publishes `processRestartRequired: false`.
- `node scripts/run-vitest.mjs src/infra/channel-health-escalations.test.ts` — 4 passed: window counting and cap, independence per key, window reset, and budget survival across a state-database reopen (the test equivalent of a gateway process restart).
- `node scripts/run-vitest.mjs src/gateway/channel-health-policy.test.ts src/gateway/channel-health-monitor.test.ts src/channels/account-snapshot-fields.test.ts` — 75 passed, including: escalation outranks busy; monitor calls the injected process-restart scheduler with `channel-health:slack:default` and never touches `stopChannel`/`startChannel`; per-account cooldown and hourly budget respected; flag clearing stops escalation.
- `pnpm tsgo:core`, `pnpm tsgo:extensions`, `pnpm tsgo:test:src`, `pnpm tsgo:test:extensions` — clean.
- `node scripts/run-oxlint.mjs <changed files>` + `pnpm format:diff` — clean.
- **Exact-head unmanaged proof** (current head): induced wedge on an unsupervised gateway → escalation flag → health-monitor logs the manual-restart operator action at the cooldown interval; `restart mode` log lines: 0, `channel_health_escalations` rows in the state DB after the run: 0. Full transcript in the exact-head proof comment below.
- **After-fix live proof** (real gateway process, automatic end-to-end): supervised run — induced wedge → lane guarded → escalation → health-monitor requests gateway restart (persisted budget `1/10 this hour`) → `restart mode: full process restart (supervisor restart)` → queued lane drains 10s later; unmanaged fallback run — in-process restart, guard correctly survives (no unsafe release). Redacted logs and methodology: see the live-proof comment below. Fault-injection used only to induce the wedge lives on a sandbox branch (`sandbox/live-proof` on the fork), never in this PR.
- Field-level live proof of the failure mode and of full-process restart clearing the guard is in #107482 (sanitized gateway log timeline).

Note: `check-test-types` may stay red on `main`-merged CI runs until the unrelated `main` regression in `extensions/nextcloud-talk` is fixed (#107843); scoped proof in the comments below.



