### PR TITLE
refactor(browser): trust Playwright tab focus

### DIFF
--- a/extensions/browser/src/browser/pw-session.ts
+++ b/extensions/browser/src/browser/pw-session.ts
@@ -55,7 +55,7 @@ import {
   type BrowserDownloadCaptureOptions,
   type PlaywrightDownload,
 } from "./pw-download-capture.js";
-import { BROWSER_REF_MARKER_ATTRIBUTE, withPageScopedCdpClient } from "./pw-session.page-cdp.js";
+import { BROWSER_REF_MARKER_ATTRIBUTE } from "./pw-session.page-cdp.js";
 
 const { chromium } = playwrightCore;
 
@@ -2429,22 +2429,7 @@ export async function focusPageByTargetIdViaPlaywright(opts: {
   ssrfPolicy?: SsrFPolicy;
 }): Promise<void> {
   const page = await getPageForTargetId(opts);
-  try {
-    await page.bringToFront();
-  } catch (err) {
-    try {
-      await withPageScopedCdpClient({
-        cdpUrl: opts.cdpUrl,
-        page,
-        targetId: opts.targetId,
-        fn: async (send) => {
-          await send("Page.bringToFront");
-        },
-      });
-    } catch {
-      throw err;
-    }
-  }
+  await page.bringToFront();
 }
 
 function toLintErrorObject(value: unknown, fallbackMessage: string): Error {


### PR DESCRIPTION
## What Problem This Solves

Remote-profile tab focus retried a failed Playwright focus by recreating the same CDP operation through a second session.

## Why This Change Was Made

Playwright Core 1.61.1 already implements Chromium `page.bringToFront()` with `Page.bringToFront` on the page's main frame session. Remove the duplicate lower-level fallback and let the dependency own tab activation.

## User Impact

No intended behavior change. Exact-target tab focus keeps using the persistent Playwright page, with 15 fewer production lines and the original Playwright error preserved directly.

## Evidence

- `node scripts/run-vitest.mjs extensions/browser/src/browser/pw-session.get-page-for-targetid.test.ts extensions/browser/src/browser/server-context.remote-profile-tab-ops.playwright.test.ts` (22 passed)
- Playwright Core 1.61.1 source inspection confirmed Chromium `bringToFront()` sends `Page.bringToFront`
- Fresh autoreview: clean
- `git diff origin/main --check`
