### PR TITLE
fix(music): validate base64 input before decoding in generated music assets

### DIFF
--- a/src/music-generation/provider-assets.ts
+++ b/src/music-generation/provider-assets.ts
@@ -1,4 +1,5 @@
 // Validates and normalizes provider asset attachments for music generation.
+import { canonicalizeBase64 } from "@openclaw/media-core/base64";
 import { maxBytesForKind } from "@openclaw/media-core/constants";
 import { extensionForMime } from "@openclaw/media-core/mime";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
@@ -81,8 +82,9 @@ export function generatedMusicAssetFromBase64(params: {
   fileName?: string;
 }): GeneratedMusicAsset {
   const ext = extensionForMime(params.mimeType)?.replace(/^\./u, "") || "mp3";
+  const canonicalBase64 = canonicalizeBase64(params.base64);
   return {
-    buffer: Buffer.from(params.base64, "base64"),
+    buffer: Buffer.from(canonicalBase64, "base64"),
     mimeType: params.mimeType,
     fileName: params.fileName ?? `track-${(params.index ?? 0) + 1}.${ext}`,
   };


### PR DESCRIPTION
## What Problem This Solves

`generatedMusicAssetFromBase64` in `src/music-generation/provider-assets.ts` passes raw `params.base64` directly to `Buffer.from(data, "base64")` without validation. Node.js silently ignores invalid base64 characters, producing truncated or unpredictable binary content that downstream code treats as valid audio.

## Why This Change Was Made

Adds `canonicalizeBase64()` validation before decoding, matching the exact pattern already used by the sibling `image-generation/image-assets.ts` (line 127, 146) for the same base64-to-buffer pipeline.

## User Impact

- Invalid base64 input is now caught and rejected with a clear error instead of producing garbled audio
- Same canonicalization behavior as image generation
- No change for valid base64 input

## Evidence

- Follows the established `canonicalizeBase64` pattern from `src/image-generation/image-assets.ts` lines 127, 146
- +3/-1 line change, zero risk