### PR TITLE
refactor(docs): use native MDX defaults

### DIFF
--- a/scripts/check-docs-mdx.mjs
+++ b/scripts/check-docs-mdx.mjs
@@ -169,15 +169,11 @@ function stripFrontmatter(raw) {
 }
 
 function formatMdxError(filePath, error) {
-  const place = error?.place ?? error?.position;
-  const start = place?.start ?? place;
-  const line = typeof start?.line === "number" ? start.line : undefined;
-  const column = typeof start?.column === "number" ? start.column : undefined;
   return {
     type: "mdx",
     file: filePath,
-    line,
-    column,
+    line: error?.line,
+    column: error?.column,
     message: String(error?.reason ?? error?.message ?? error).split("\n")[0],
   };
 }
@@ -230,14 +226,7 @@ async function checkMdxFile(filePath) {
   if (structureErrors.length > 0) {
     return structureErrors;
   }
-  const value = stripFrontmatter(raw);
-  await compile(
-    { path: filePath, value },
-    {
-      development: false,
-      jsx: false,
-    },
-  );
+  await compile({ path: filePath, value: stripFrontmatter(raw) });
   return [];
 }
 


### PR DESCRIPTION
## What Problem This Solves

The docs checker repeated MDX compiler defaults and manually unpacked diagnostic positions already exposed by the dependency.

## Why This Change Was Made

MDX 3.1.1 defaults `development` and `jsx` to false. Its VFileMessage 4.0.3 diagnostics expose top-level `line` and `column`. Use those native contracts directly.

## User Impact

No intended behavior change. Docs syntax checks and error locations stay the same with 11 fewer script lines.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/check-docs-mdx.test.ts` (3 passed)
- `node scripts/check-docs-mdx.mjs docs` (729 files passed)
- Malformed MDX probe preserved the expected line 4, column 1 diagnostic
- Fresh autoreview: clean
- `git diff origin/main --check`
