### PR TITLE
refactor(raft): privatize config schema

### DIFF
--- a/extensions/raft/src/accounts.test.ts
+++ b/extensions/raft/src/accounts.test.ts
@@ -1,7 +1,7 @@
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { afterEach, describe, expect, it } from "vitest";
 import { listRaftAccountIds, resolveRaftAccount } from "./accounts.js";
-import { RaftConfigSchema } from "./config-schema.js";
+import { raftChannelConfigSchema } from "./config-schema.js";
 import { raftSetupPlugin } from "./setup.js";
 
 const originalProfile = process.env.RAFT_PROFILE;
@@ -75,9 +75,9 @@ describe("Raft account resolution", () => {
   });
 
   it("accepts the supported single and multi-account fields only", () => {
-    expect(RaftConfigSchema.safeParse({ profile: "default" }).success).toBe(true);
+    expect(raftChannelConfigSchema.runtime.safeParse({ profile: "default" }).success).toBe(true);
     expect(
-      RaftConfigSchema.safeParse({
+      raftChannelConfigSchema.runtime.safeParse({
         accounts: {
           support: {
             profile: "support",
@@ -85,6 +85,6 @@ describe("Raft account resolution", () => {
         },
       }).success,
     ).toBe(true);
-    expect(RaftConfigSchema.safeParse({ bridgePort: 3000 }).success).toBe(false);
+    expect(raftChannelConfigSchema.runtime.safeParse({ bridgePort: 3000 }).success).toBe(false);
   });
 });

--- a/extensions/raft/src/config-schema.ts
+++ b/extensions/raft/src/config-schema.ts
@@ -10,7 +10,7 @@ const RaftAccountSchema = z
   })
   .strict();
 
-export const RaftConfigSchema = z
+const RaftConfigSchema = z
   .object({
     name: z.string().optional(),
     enabled: z.boolean().optional(),

--- a/scripts/deadcode-exports.baseline.mjs
+++ b/scripts/deadcode-exports.baseline.mjs
@@ -167,7 +167,6 @@ export const KNIP_UNUSED_EXPORT_BASELINE = [
   "extensions/qa-matrix/src/substrate/client.ts: testing",
   "extensions/qa-matrix/src/substrate/e2ee-client.ts: testing",
   "extensions/qa-matrix/src/substrate/harness.runtime.ts: testing",
-  "extensions/raft/src/config-schema.ts: RaftConfigSchema",
   "extensions/signal/src/reply-authors.ts: clearSignalReplyAuthorsForTest",
   "extensions/sms/src/channel.ts: resolveSmsTextChunkLimit",
   "extensions/sms/src/config-schema.ts: SmsConfigSchema",


### PR DESCRIPTION
## What Problem This Solves

The enforced Knip dead-export ratchet still grandfathered Raft's internal `RaftConfigSchema` symbol.

## Why This Change Was Made

The schema is only needed inside `config-schema.ts` to build the retained channel config contract. This makes it module-private and moves the direct schema assertions onto `raftChannelConfigSchema.runtime.safeParse`, the production validation path.

## User Impact

None. Raft configuration validation and accepted fields are unchanged. Baseline delta: +0/-1 entry; production source line count unchanged.

## Evidence

- Testbox `tbx_01kxgd1zrcwavnenjq5nzx1vcg`: exact dead-export check at 702 entries, formatting, type-aware lint, 11/11 Raft tests, and extension types all green.
- Fresh post-rebase Testbox `tbx_01kxgdc6mp1szej4gkqt0zvjsy`: baseline regeneration byte-stable at 702 and exact dead-export check green.
- Fresh autoreview: clean, 0.98 confidence.
