### PR TITLE
test(raft): guard optional runtime config schema

### DIFF
--- a/extensions/raft/src/accounts.test.ts
+++ b/extensions/raft/src/accounts.test.ts
@@ -5,6 +5,10 @@ import { raftChannelConfigSchema } from "./config-schema.js";
 import { raftSetupPlugin } from "./setup.js";
 
 const originalProfile = process.env.RAFT_PROFILE;
+const runtimeConfigSchema = raftChannelConfigSchema.runtime;
+if (!runtimeConfigSchema) {
+  throw new Error("expected Raft runtime config schema");
+}
 
 afterEach(() => {
   if (originalProfile === undefined) {
@@ -75,9 +79,9 @@ describe("Raft account resolution", () => {
   });
 
   it("accepts the supported single and multi-account fields only", () => {
-    expect(raftChannelConfigSchema.runtime.safeParse({ profile: "default" }).success).toBe(true);
+    expect(runtimeConfigSchema.safeParse({ profile: "default" }).success).toBe(true);
     expect(
-      raftChannelConfigSchema.runtime.safeParse({
+      runtimeConfigSchema.safeParse({
         accounts: {
           support: {
             profile: "support",
@@ -85,6 +89,6 @@ describe("Raft account resolution", () => {
         },
       }).success,
     ).toBe(true);
-    expect(raftChannelConfigSchema.runtime.safeParse({ bridgePort: 3000 }).success).toBe(false);
+    expect(runtimeConfigSchema.safeParse({ bridgePort: 3000 }).success).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

- guard the optional Raft runtime config schema before test use
- keep the existing supported-field assertions unchanged

## Proof

- `pnpm tsgo:extensions:test` on Blacksmith Testbox
- autoreview clean

Fixes exact-main CI run https://github.com/openclaw/openclaw/actions/runs/29337247697
