### PR TITLE
fix(raft): tsgo:test lane fails on main after config schema privatization

### DIFF
--- a/extensions/raft/src/accounts.test.ts
+++ b/extensions/raft/src/accounts.test.ts
@@ -75,9 +75,15 @@ describe("Raft account resolution", () => {
   });
 
   it("accepts the supported single and multi-account fields only", () => {
-    expect(raftChannelConfigSchema.runtime.safeParse({ profile: "default" }).success).toBe(true);
+    // ChannelConfigSchema.runtime is optional in the SDK contract, but the Zod
+    // builder always provides it; narrow once so the assertions typecheck.
+    const runtime = raftChannelConfigSchema.runtime;
+    if (!runtime) {
+      throw new Error("raft channel config schema must expose runtime validation");
+    }
+    expect(runtime.safeParse({ profile: "default" }).success).toBe(true);
     expect(
-      raftChannelConfigSchema.runtime.safeParse({
+      runtime.safeParse({
         accounts: {
           support: {
             profile: "support",
@@ -85,6 +91,6 @@ describe("Raft account resolution", () => {
         },
       }).success,
     ).toBe(true);
-    expect(raftChannelConfigSchema.runtime.safeParse({ bridgePort: 3000 }).success).toBe(false);
+    expect(runtime.safeParse({ bridgePort: 3000 }).success).toBe(false);
   });
 });


### PR DESCRIPTION
## What Problem This Solves

`main` currently fails the `tsgo:test` lane (via `tsgo:extensions:test`), which blocks CI for every open PR:

```text
extensions/raft/src/accounts.test.ts(78,12): error TS18048: 'raftChannelConfigSchema.runtime' is possibly 'undefined'.
extensions/raft/src/accounts.test.ts(80,7): error TS18048: 'raftChannelConfigSchema.runtime' is possibly 'undefined'.
extensions/raft/src/accounts.test.ts(88,12): error TS18048: 'raftChannelConfigSchema.runtime' is possibly 'undefined'.
```

Introduced by e4aa176c82 (#107554), which switched the test from the now-private `RaftConfigSchema` to `raftChannelConfigSchema.runtime`. `ChannelConfigSchema.runtime` is optional in the SDK contract, so the test no longer typechecks even though `buildChannelConfigSchema` always provides `runtime`.

## Why This Change Was Made

Narrow `runtime` once at the top of the test (throw with a clear message if it were ever missing) instead of sprinkling non-null assertions or widening the SDK contract. `runtime` stays optional in `ChannelConfigSchema` because plugins may construct schema object literals without it; the always-present guarantee belongs to the Zod builder, not the contract type.

## User Impact

None at runtime — test-only change. Restores a green `tsgo:test` lane on `main`, unblocking CI for all open PRs.

## Evidence

- On plain `origin/main` (e4aa176c82): `pnpm tsgo:extensions:test` fails with the three errors above.
- With this change: `pnpm tsgo:extensions:test` clean; `node scripts/run-vitest.mjs extensions/raft/src/accounts.test.ts` — 4 passed; oxlint/oxfmt clean.
