### PR TITLE
fix(voice-call): reject malformed Telnyx timestamps

### DIFF
--- a/extensions/voice-call/src/webhook-security.test.ts
+++ b/extensions/voice-call/src/webhook-security.test.ts
@@ -149,10 +149,10 @@ function verifyTwilioSignedRequest(params: {
   );
 }
 
-function createSignedTelnyxWebhookRequest() {
+function createSignedTelnyxWebhookRequest(options?: { timestamp?: string }) {
   const { publicKey, privateKey } = crypto.generateKeyPairSync("ed25519");
   const pemPublicKey = publicKey.export({ format: "pem", type: "spki" });
-  const timestamp = String(Math.floor(Date.now() / 1000));
+  const timestamp = options?.timestamp ?? String(Math.floor(Date.now() / 1000));
   const rawBody = JSON.stringify({
     data: { event_type: "call.initiated", payload: { call_control_id: "call-1" } },
     nonce: crypto.randomUUID(),
@@ -639,6 +639,17 @@ describe("verifyPlivoWebhook", () => {
 });
 
 describe("verifyTelnyxWebhook", () => {
+  it("rejects signed timestamps with trailing characters", () => {
+    const request = createSignedTelnyxWebhookRequest({
+      timestamp: `${Math.floor(Date.now() / 1000)}abc`,
+    });
+
+    expect(verifyTelnyxWebhook(request.makeCtx(), request.pemPublicKey)).toEqual({
+      ok: false,
+      reason: "Invalid timestamp header",
+    });
+  });
+
   it("treats Base64 and Base64URL signatures as the same replayed request", () => {
     const request = createSignedTelnyxWebhookRequest();
     const urlSafeSignature = request.signature

--- a/extensions/voice-call/src/webhook-security.ts
+++ b/extensions/voice-call/src/webhook-security.ts
@@ -491,8 +491,8 @@ export function verifyTelnyxWebhook(
     return { ok: false, reason: "Missing signature or timestamp header" };
   }
 
-  const eventTimeSec = Number.parseInt(timestamp, 10);
-  if (!Number.isFinite(eventTimeSec)) {
+  const eventTimeSec = /^(?:0|[1-9]\d*)$/.test(timestamp) ? Number(timestamp) : undefined;
+  if (eventTimeSec === undefined || !Number.isSafeInteger(eventTimeSec)) {
     return { ok: false, reason: "Invalid timestamp header" };
   }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Telnyx voice webhook verification could accept a signed `telnyx-timestamp` header with trailing non-numeric characters. A header such as `<current-unix-seconds>abc` is still part of the signed `timestamp|payload` string, but the previous verifier truncated it with `Number.parseInt(...)` before applying the replay-window check.

## Why This Change Was Made

Telnyx webhook signing treats the timestamp header as the signed timestamp string, and the OpenClaw verifier documents that header as Unix seconds. This change keeps signature verification over the original header value, but only converts it to an event time when the entire header is an unsigned base-10 Unix-seconds token.

## User Impact

Voice-call users with Telnyx webhooks now get stricter timestamp validation. Valid Telnyx webhooks continue to verify, while malformed signed timestamp headers are rejected before replay-window evaluation.

## Evidence

Current `main` real-path proof, using the production `verifyTelnyxWebhook()` function with a real Ed25519 keypair and signature over `timestamp|payload`:

```console
$ ./node_modules/.bin/tsx --eval 'import crypto from "node:crypto"; import { verifyTelnyxWebhook } from "./extensions/voice-call/src/webhook-security.ts"; const { publicKey, privateKey } = crypto.generateKeyPairSync("ed25519"); const publicPem = publicKey.export({ format: "pem", type: "spki" }).toString(); const now = String(Math.floor(Date.now() / 1000)); const timestamp = `${now}abc`; const rawBody = JSON.stringify({ data: { event_type: "call.initiated", payload: { call_control_id: "call-1" } }, nonce: crypto.randomUUID() }); const signature = crypto.sign(null, Buffer.from(`${timestamp}|${rawBody}`), privateKey).toString("base64"); const result = verifyTelnyxWebhook({ headers: { "telnyx-signature-ed25519": signature, "telnyx-timestamp": timestamp }, rawBody, url: "https://example.com/voice/webhook", method: "POST" }, publicPem); console.log(`[telnyx-proof-before] timestamp=${timestamp.replace(/^[0-9]+/, "<now>")}`); console.log(`[telnyx-proof-before] result=${JSON.stringify({ ok: result.ok, reason: result.reason, hasKey: Boolean(result.verifiedRequestKey) })}`);'
[telnyx-proof-before] timestamp=<now>abc
[telnyx-proof-before] result={"ok":true,"hasKey":true}
```

After this patch, the same real verifier path rejects the malformed timestamp before creating a verified request key. Rebased exact head: `8860a88589198fc03c416aa87cd4104b6767cf6a` on `origin/main` `91a18c05f1e3d818db5ec0c7b66f6232c732eda9`:

```console
$ ./node_modules/.bin/tsx --eval '
import { generateKeyPairSync, sign } from "node:crypto";
import { verifyTelnyxWebhook } from "./extensions/voice-call/src/webhook-security.ts";
const { publicKey, privateKey } = generateKeyPairSync("ed25519");
const rawBody = JSON.stringify({ data: { event_type: "call.initiated", payload: { call_control_id: "call-1" } } });
const timestamp = `${Math.floor(Date.now() / 1000)}abc`;
const signature = sign(null, Buffer.from(`${timestamp}|${rawBody}`), privateKey).toString("base64");
const pem = publicKey.export({ type: "spki", format: "pem" }).toString();
const result = verifyTelnyxWebhook({ headers: { "telnyx-timestamp": timestamp, "telnyx-signature-ed25519": signature }, rawBody, url: "https://example.com/voice/webhook", method: "POST" }, pem);
console.log(`[telnyx-proof-after-rebase7] timestamp=${timestamp}`);
console.log(`[telnyx-proof-after-rebase7] result=${JSON.stringify(result)}`);
'
[telnyx-proof-after-rebase7] timestamp=1784081425abc
[telnyx-proof-after-rebase7] result={"ok":false,"reason":"Invalid timestamp header"}
```

Focused regression test on the same rebased head:

```console
$ node scripts/run-vitest.mjs extensions/voice-call/src/webhook-security.test.ts
[test] starting test/vitest/vitest.extension-voice-call.config.ts

 RUN  v4.1.9 /home/0668000995/10288592/git-hub/codex/openclaw


 Test Files  1 passed (1)
      Tests  30 passed (30)
   Start at  10:10:30
   Duration  3.58s (transform 1.77s, setup 680ms, import 2.39s, tests 141ms, environment 0ms)

[test] passed 1 Vitest shard in 10.24s
```

Static checks on the same rebased head:

```console
$ git rev-parse HEAD && git diff --numstat origin/main && git diff --check origin/main
8860a88589198fc03c416aa87cd4104b6767cf6a
13	2	extensions/voice-call/src/webhook-security.test.ts
2	2	extensions/voice-call/src/webhook-security.ts
```

Duplicate search before opening found no matching OpenClaw PRs/issues for `Telnyx timestamp parseInt webhook`, `telnyx-timestamp`, `voice-call Telnyx timestamp`, or `Telnyx signature timestamp suffix`.

Autoreview note: `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` was rerun on head `8860a88589198fc03c416aa87cd4104b6767cf6a`, but the Codex review engine failed before returning a usable review verdict:

```console
autoreview target: branch
branch: fix/voice-call-telnyx-timestamp-parse
engine: codex
ref: origin/main
bundle: 2515 bytes; review passes: 1
codex engine failed (1)
```

## Maintainer refresh (July 30, 2026)

The contributor branch is rebased onto current `main` at head
`ddd0879c820987bdf0bbb45aef1d2e4e795f20b6`.

Contract and focused proof:

- Telnyx documents `telnyx-timestamp` as an integer Unix timestamp in seconds.
- the signature still covers the original `timestamp|payload` bytes
- the regression uses a real Ed25519 keypair and signs the malformed timestamp before verifying that the whole-token parser rejects it

```text
node scripts/run-vitest.mjs extensions/voice-call/src/webhook-security.test.ts
Test Files  1 passed (1)
Tests  41 passed (41)

oxfmt: clean
git diff --check: clean
autoreview: clean, no accepted/actionable findings
```
