### PR TITLE
test(raft): restore extension type validation

### DIFF
--- a/extensions/raft/src/accounts.test.ts
+++ b/extensions/raft/src/accounts.test.ts
@@ -75,9 +75,14 @@ describe("Raft account resolution", () => {
   });
 
   it("accepts the supported single and multi-account fields only", () => {
-    expect(raftChannelConfigSchema.runtime.safeParse({ profile: "default" }).success).toBe(true);
+    const runtimeSchema = raftChannelConfigSchema.runtime;
+    if (!runtimeSchema) {
+      throw new Error("Raft channel config schema must expose runtime validation");
+    }
+
+    expect(runtimeSchema.safeParse({ profile: "default" }).success).toBe(true);
     expect(
-      raftChannelConfigSchema.runtime.safeParse({
+      runtimeSchema.safeParse({
         accounts: {
           support: {
             profile: "support",
@@ -85,6 +90,6 @@ describe("Raft account resolution", () => {
         },
       }).success,
     ).toBe(true);
-    expect(raftChannelConfigSchema.runtime.safeParse({ bridgePort: 3000 }).success).toBe(false);
+    expect(runtimeSchema.safeParse({ bridgePort: 3000 }).success).toBe(false);
   });
 });


### PR DESCRIPTION
## What Problem This Solves

Current `main` fails `check-test-types` because `raftChannelConfigSchema.runtime` is optional in the public channel schema type, while the Raft account test dereferences it directly.

## Why This Change Was Made

The test now asserts that the runtime validator exists, then reuses the narrowed value for its supported/unsupported config checks. This preserves the intended production validation-path proof and makes a missing runtime validator fail explicitly.

## User Impact

None. Test-only type repair; Raft runtime behavior and accepted configuration remain unchanged.

## Evidence

- Current-main failure: CI run 29337247697, `extensions/raft/src/accounts.test.ts` TS18048 errors.
- Blacksmith Testbox `tbx_01kxge6qecksf1gyn06cfa2whc`, Actions run 29338086420: Raft account tests passed 4/4 and `pnpm tsgo:extensions:test` passed.
- `git diff --check` passed.
- Fresh autoreview passed with no accepted/actionable findings, 0.99 confidence.
