### PR TITLE
fix(tlon): use native S3 endpoint parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Tlon custom S3 uploads:** pass storage endpoints through the AWS SDK's native parser so custom S3-compatible uploads no longer fail before presigning.
 - **Agent auth storage locks:** surface normal release failures while avoiding redundant release attempts after `proper-lockfile` reports a compromised lock.
 - **Paired-node session catalogs:** authorize bundled Anthropic and Codex catalog requests to invoke their read-only node commands from Control UI read flows, restoring remote Claude/Codex rows and terminal resume availability. Fixes #107406.
 - **Sandbox recreate confirmation:** treat Clack cancellation as a decline so Ctrl-C cannot proceed with container removal.

--- a/extensions/tlon/src/tlon-api.test.ts
+++ b/extensions/tlon/src/tlon-api.test.ts
@@ -496,6 +496,7 @@ describe("uploadFile custom S3 upload hardening", () => {
     });
 
     expect(result.url.startsWith("https://files.example.com/")).toBe(true);
+    expect((await mockGetSignedUrl.mock.calls[0]?.[0].config.endpoint()).protocol).toBe("https:");
     expect(mockGuardedFetch).toHaveBeenCalledTimes(1);
     const uploadCall = guardedFetchCall(0);
     expect(uploadCall?.url).toBe("https://s3.example.com/uploads/file?sig=abc");

--- a/extensions/tlon/src/tlon-api.ts
+++ b/extensions/tlon/src/tlon-api.ts
@@ -335,13 +335,8 @@ export async function uploadFile(params: UploadFileParams): Promise<UploadResult
     throw new Error("No storage credentials configured");
   }
 
-  const endpoint = new URL(prefixEndpoint(credentials.endpoint));
   const client = new S3Client({
-    endpoint: {
-      protocol: endpoint.protocol.slice(0, -1) as "http" | "https",
-      hostname: endpoint.host,
-      path: endpoint.pathname || "/",
-    },
+    endpoint: prefixEndpoint(credentials.endpoint),
     region: storageConfig.region || "us-east-1",
     credentials: {
       accessKeyId: credentials.accessKeyId,
@@ -366,7 +361,6 @@ export async function uploadFile(params: UploadFileParams): Promise<UploadResult
 
   const signedUrl = await getSignedUrl(client, command, {
     expiresIn: 3600,
-    signableHeaders: new Set(Object.keys(headers)),
   });
 
   let release: (() => Promise<void>) | undefined;


### PR DESCRIPTION
## What Problem This Solves

Tlon's custom S3 upload path stripped the colon from an endpoint protocol before passing it to the AWS SDK. The pinned SDK then rejected endpoints such as `https://s3.example.com` before presigning.

## Why This Change Was Made

Pass the normalized endpoint string directly to `S3Client`, which already owns URL, port, and path parsing. Remove the custom endpoint adapter and a `signableHeaders` option that has no effect with the current header casing and S3 presigner hoisting rules.

## User Impact

Tlon users can presign uploads to custom S3-compatible endpoints instead of failing before the upload request begins.

## Evidence

- `node scripts/run-vitest.mjs extensions/tlon/src/tlon-api.test.ts extensions/tlon/src/urbit/upload.test.ts` — 23 passed
- Exact pinned-SDK probe: old endpoint object rejected with `EndpointError`; native endpoint string produced a signed URL
- `git diff --check`
- Fresh autoreview: no findings
