### PR TITLE
fix(raft): restore channel schema test types

### DIFF
--- a/extensions/raft/src/accounts.test.ts
+++ b/extensions/raft/src/accounts.test.ts
@@ -6,6 +6,14 @@ import { raftSetupPlugin } from "./setup.js";
 
 const originalProfile = process.env.RAFT_PROFILE;
 
+function parseRaftConfig(value: unknown) {
+  const runtime = raftChannelConfigSchema.runtime;
+  if (!runtime) {
+    throw new Error("expected Raft channel config runtime");
+  }
+  return runtime.safeParse(value);
+}
+
 afterEach(() => {
   if (originalProfile === undefined) {
     delete process.env.RAFT_PROFILE;
@@ -75,9 +83,9 @@ describe("Raft account resolution", () => {
   });
 
   it("accepts the supported single and multi-account fields only", () => {
-    expect(raftChannelConfigSchema.runtime.safeParse({ profile: "default" }).success).toBe(true);
+    expect(parseRaftConfig({ profile: "default" }).success).toBe(true);
     expect(
-      raftChannelConfigSchema.runtime.safeParse({
+      parseRaftConfig({
         accounts: {
           support: {
             profile: "support",
@@ -85,6 +93,6 @@ describe("Raft account resolution", () => {
         },
       }).success,
     ).toBe(true);
-    expect(raftChannelConfigSchema.runtime.safeParse({ bridgePort: 3000 }).success).toBe(false);
+    expect(parseRaftConfig({ bridgePort: 3000 }).success).toBe(false);
   });
 });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the Raft account schema test dereferenced an optional channel runtime contract, causing the repository test-type gate to fail on `main`.

## Why This Change Was Made

Narrows the optional runtime once through the same explicit guard used by sibling channel schema tests, then parses all Raft fixtures through that helper.

## User Impact

No runtime behavior change. The Raft schema tests remain equivalent and the repository type gate passes again.

## Evidence

- `pnpm test extensions/raft/src/accounts.test.ts` — 4/4 pass.
- `pnpm check:test-types` — pass.
- Blacksmith Testbox `tbx_01kxge9t173emvgpeej6taz6g0` / Actions run 29338208424.
- Fresh autoreview — zero actionable findings.
- `git diff --check` — pass.
