### PR TITLE
fix(tlon): keep S3 endpoint regression test lint-clean

### DIFF
--- a/extensions/tlon/src/tlon-api.test.ts
+++ b/extensions/tlon/src/tlon-api.test.ts
@@ -496,7 +496,11 @@ describe("uploadFile custom S3 upload hardening", () => {
     });
 
     expect(result.url.startsWith("https://files.example.com/")).toBe(true);
-    expect((await mockGetSignedUrl.mock.calls[0]?.[0].config.endpoint()).protocol).toBe("https:");
+    const signedUrlCall = mockGetSignedUrl.mock.calls[0];
+    if (!signedUrlCall) {
+      throw new Error("expected S3 signed URL call");
+    }
+    expect((await signedUrlCall[0].config.endpoint()).protocol).toBe("https:");
     expect(mockGuardedFetch).toHaveBeenCalledTimes(1);
     const uploadCall = guardedFetchCall(0);
     expect(uploadCall?.url).toBe("https://s3.example.com/uploads/file?sig=abc");


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the Tlon S3 endpoint regression test fails the repository lint gate because its mock-call assertion uses unsafe optional chaining.

## Why This Change Was Made

The test now asserts that the expected presigner call exists before inspecting the resolved endpoint protocol. This preserves the regression coverage while producing a clear failure if the call is absent.

## User Impact

No runtime behavior changes. Main and downstream pull requests can pass the lint gate again.

## Evidence

- Testbox: 15/15 focused Tlon tests passed.
- Testbox: changed-file type, lint, format, and contract checks passed.
- Auto-review: clean, no actionable findings.
- Blacksmith run: https://github.com/openclaw/openclaw/actions/runs/29339058736
