### PR TITLE
fix(tui): type searchable item metadata

### DIFF
--- a/src/tui/components/searchable-select-list.ts
+++ b/src/tui/components/searchable-select-list.ts
@@ -22,12 +22,17 @@ export interface SearchableSelectListTheme extends SelectListTheme {
   matchHighlight: (text: string) => string;
 }
 
+export interface SearchableSelectItem extends SelectItem {
+  /** Additional searchable fields beyond label and description. */
+  searchText?: string;
+}
+
 /**
  * A select list with a search input at the top for fuzzy filtering.
  */
 export class SearchableSelectList implements Component {
-  private items: SelectItem[];
-  private filteredItems: SelectItem[];
+  private items: SearchableSelectItem[];
+  private filteredItems: SearchableSelectItem[];
   private selectedIndex = 0;
   private maxVisible: number;
   private theme: SearchableSelectListTheme;
@@ -44,7 +49,7 @@ export class SearchableSelectList implements Component {
   // Keep a small right margin so we don't risk wrapping due to styling/terminal quirks.
   private static readonly RIGHT_MARGIN_WIDTH = 2;
 
-  constructor(items: SelectItem[], maxVisible: number, theme: SearchableSelectListTheme) {
+  constructor(items: SearchableSelectItem[], maxVisible: number, theme: SearchableSelectListTheme) {
     this.items = items;
     this.filteredItems = items;
     this.maxVisible = maxVisible;
@@ -81,10 +86,10 @@ export class SearchableSelectList implements Component {
    * 2. Exact substring in description
    * 3. Fuzzy match (lowest priority)
    */
-  private smartFilter(query: string): SelectItem[] {
+  private smartFilter(query: string): SearchableSelectItem[] {
     const q = normalizeLowercaseStringOrEmpty(query);
-    type ScoredItem = { item: SelectItem; tier: number; score: number };
-    type FuzzyCandidate = { item: SelectItem; searchText: string };
+    type ScoredItem = { item: SearchableSelectItem; tier: number; score: number };
+    type FuzzyCandidate = { item: SearchableSelectItem; searchText: string };
     const scoredItems: ScoredItem[] = [];
     const fuzzyCandidates: FuzzyCandidate[] = [];
 
@@ -107,7 +112,7 @@ export class SearchableSelectList implements Component {
         continue;
       }
       // Tier 3: Fuzzy match
-      const searchText = (item as { searchText?: string }).searchText ?? "";
+      const searchText = item.searchText ?? "";
       fuzzyCandidates.push({
         item,
         searchText: normalizeLowercaseStringOrEmpty(

--- a/src/tui/components/searchable-select-list.ts
+++ b/src/tui/components/searchable-select-list.ts
@@ -22,7 +22,7 @@ export interface SearchableSelectListTheme extends SelectListTheme {
   matchHighlight: (text: string) => string;
 }
 
-export interface SearchableSelectItem extends SelectItem {
+interface SearchableSelectItem extends SelectItem {
   /** Additional searchable fields beyond label and description. */
   searchText?: string;
 }


### PR DESCRIPTION
## What Problem This Solves

`check-test-types` fails because `SearchableSelectList` already reads optional `searchText` metadata at runtime, while its constructor only accepts the upstream `SelectItem` type that does not declare that field.

## Why This Change Was Made

Model the existing contract as `SearchableSelectItem extends SelectItem`, propagate that type through the filter internals, and remove the local cast. This matches the established `FilterableSelectItem` pattern.

## User Impact

No runtime behavior change. Main CI type checks pass again, and callers can type the searchable metadata the component already supports.

## Evidence

- Blacksmith Testbox `tbx_01kxgg8gs04z602apx9cm6jk6z`: `pnpm test src/tui/components/searchable-select-list.test.ts` — 22 passed.
- Same Testbox: `pnpm check:test-types` — passed.
- Autoreview: clean at 0.99, no accepted/actionable findings.
