### PR TITLE
test(tui): use supported fuzzy fixture fields

### DIFF
--- a/src/tui/components/searchable-select-list.test.ts
+++ b/src/tui/components/searchable-select-list.test.ts
@@ -259,7 +259,7 @@ describe("SearchableSelectList", () => {
 
   it("treats slashes as fuzzy token separators", () => {
     const list = new SearchableSelectList(
-      [{ value: "sonnet", label: "Claude Sonnet", searchText: "anthropic" }],
+      [{ value: "sonnet", label: "Claude Sonnet", description: "anthropic" }],
       5,
       mockTheme,
     );


### PR DESCRIPTION
## What Problem This Solves

The slash-token fuzzy-search regression test passed an undeclared `searchText` property to `SearchableSelectList`, causing the test-source tsgo lane to fail on `main`.

## Why This Change Was Made

Put the same searchable fixture text in the supported `description` field. The test still exercises native slash-token matching across combined searchable fields.

## User Impact

No runtime change. Test types compile again.

## Evidence

- `node scripts/run-vitest.mjs src/tui/components/searchable-select-list.test.ts` — 22 tests passed.
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.test.src.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/test-src.tsbuildinfo` — passed.
- Targeted oxfmt and `git diff --check` — passed.
- Fresh local and branch autoreviews — no actionable findings.

Hosted CI intentionally not awaited per maintainer direction.
