### PR TITLE
fix(agents): preserve native runtime controls on Codex routes

### DIFF
--- a/src/agents/harness/selection.test.ts
+++ b/src/agents/harness/selection.test.ts
@@ -1503,6 +1503,35 @@ describe("selectAgentHarness", () => {
     },
   );
 
+  it("keeps native model run controls compatible with Codex", () => {
+    expect(
+      buildAgentHarnessSupportContext({
+        provider: "openai",
+        modelId: "gpt-5.6-sol",
+        modelProvider: {
+          api: "openai-responses",
+          baseUrl: "https://api.openai.com/v1",
+          requestTransportOverrides: "none",
+        },
+        requestedRuntime: "codex",
+        config: {
+          agents: {
+            defaults: {
+              models: {
+                "openai/gpt-5.6-sol": {
+                  params: { thinking: "xhigh", fastMode: true, fastAutoOnSeconds: 30 },
+                },
+              },
+            },
+          },
+        } as OpenClawConfig,
+      }).modelProvider,
+    ).toMatchObject({
+      requestTransportOverrides: "none",
+      runtimePolicy: { compatibleIds: ["openclaw", "codex"] },
+    });
+  });
+
   it("rejects explicit Codex when agent request params cannot be reproduced", () => {
     const supports = vi.fn((ctx: Parameters<AgentHarness["supports"]>[0]) =>
       ctx.modelProvider?.requestTransportOverrides === "present"

--- a/src/agents/model-extra-params.ts
+++ b/src/agents/model-extra-params.ts
@@ -1,3 +1,5 @@
+import { normalizeFastMode } from "@openclaw/normalization-core/string-coerce";
+import { normalizeThinkLevel } from "../auto-reply/thinking.shared.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { modelKey } from "../shared/model-key.js";
 import { resolveAgentConfig } from "./agent-scope-config.js";
@@ -8,17 +10,35 @@ type ModelExtraParamSources = {
   agentParams?: Record<string, unknown>;
 };
 
-// These model-scoped values are promoted into the agent run contract before harness selection.
-// Native harnesses receive them as typed run controls rather than raw provider request fields.
-const AGENT_RUNTIME_MODEL_PARAM_KEYS = new Set([
+const FAST_MODE_MODEL_PARAM_KEYS = new Set(["fastMode", "fast_mode"]);
+const FAST_MODE_CUTOFF_MODEL_PARAM_KEYS = new Set([
   "fastAutoOnSeconds",
-  "fastMode",
   "fastSeconds",
   "fast_auto_on_seconds",
-  "fast_mode",
   "fast_seconds",
-  "thinking",
 ]);
+
+// Native harnesses receive recognized values as typed run controls. Other value
+// shapes with the same keys remain authored provider request parameters.
+function isAgentRuntimeModelParam(key: string, value: unknown): boolean {
+  if (key === "thinking") {
+    return (
+      value === false ||
+      value === "disabled" ||
+      value === "none" ||
+      (typeof value === "string" && normalizeThinkLevel(value) !== undefined)
+    );
+  }
+  if (FAST_MODE_MODEL_PARAM_KEYS.has(key)) {
+    return normalizeFastMode(value) !== undefined;
+  }
+  return (
+    FAST_MODE_CUTOFF_MODEL_PARAM_KEYS.has(key) &&
+    typeof value === "number" &&
+    Number.isInteger(value) &&
+    value > 0
+  );
+}
 
 function legacyModelKey(provider: string, modelId: string): string | undefined {
   const rawKey = `${provider.trim()}/${modelId.trim()}`;
@@ -60,7 +80,7 @@ export function hasModelExtraParams(
   ) {
     return true;
   }
-  return Object.keys(sources.modelParams ?? {}).some(
-    (key) => !AGENT_RUNTIME_MODEL_PARAM_KEYS.has(key),
+  return Object.entries(sources.modelParams ?? {}).some(
+    ([key, value]) => !isAgentRuntimeModelParam(key, value),
   );
 }

--- a/src/agents/model-extra-params.ts
+++ b/src/agents/model-extra-params.ts
@@ -13,8 +13,10 @@ type ModelExtraParamSources = {
 const AGENT_RUNTIME_MODEL_PARAM_KEYS = new Set([
   "fastAutoOnSeconds",
   "fastMode",
+  "fastSeconds",
   "fast_auto_on_seconds",
   "fast_mode",
+  "fast_seconds",
   "thinking",
 ]);
 

--- a/src/agents/model-extra-params.ts
+++ b/src/agents/model-extra-params.ts
@@ -10,7 +10,6 @@ type ModelExtraParamSources = {
   agentParams?: Record<string, unknown>;
 };
 
-const FAST_MODE_MODEL_PARAM_KEYS = new Set(["fastMode", "fast_mode"]);
 const FAST_MODE_CUTOFF_MODEL_PARAM_KEYS = new Set([
   "fastAutoOnSeconds",
   "fastSeconds",
@@ -29,7 +28,7 @@ function isAgentRuntimeModelParam(key: string, value: unknown): boolean {
       (typeof value === "string" && normalizeThinkLevel(value) !== undefined)
     );
   }
-  if (FAST_MODE_MODEL_PARAM_KEYS.has(key)) {
+  if (key === "fastMode" || key === "fast_mode") {
     return normalizeFastMode(value) !== undefined;
   }
   return (

--- a/src/agents/model-extra-params.ts
+++ b/src/agents/model-extra-params.ts
@@ -8,6 +8,16 @@ type ModelExtraParamSources = {
   agentParams?: Record<string, unknown>;
 };
 
+// These model-scoped values are promoted into the agent run contract before harness selection.
+// Native harnesses receive them as typed run controls rather than raw provider request fields.
+const AGENT_RUNTIME_MODEL_PARAM_KEYS = new Set([
+  "fastAutoOnSeconds",
+  "fastMode",
+  "fast_auto_on_seconds",
+  "fast_mode",
+  "thinking",
+]);
+
 function legacyModelKey(provider: string, modelId: string): string | undefined {
   const rawKey = `${provider.trim()}/${modelId.trim()}`;
   const canonicalKey = modelKey(provider, modelId);
@@ -36,12 +46,19 @@ export function resolveModelExtraParamSources(params: {
   return { defaultParams, modelParams, agentParams };
 }
 
-/** Returns whether embedded OpenClaw would apply authored request parameters. */
+/** Returns whether embedded OpenClaw would apply authored provider request parameters. */
 export function hasModelExtraParams(
   params: Parameters<typeof resolveModelExtraParamSources>[0],
 ): boolean {
   const sources = resolveModelExtraParamSources(params);
-  return [sources.defaultParams, sources.modelParams, sources.agentParams].some(
-    (source) => source !== undefined && Object.keys(source).length > 0,
+  if (
+    [sources.defaultParams, sources.agentParams].some(
+      (source) => source !== undefined && Object.keys(source).length > 0,
+    )
+  ) {
+    return true;
+  }
+  return Object.keys(sources.modelParams ?? {}).some(
+    (key) => !AGENT_RUNTIME_MODEL_PARAM_KEYS.has(key),
   );
 }

--- a/src/agents/openai-routing.test.ts
+++ b/src/agents/openai-routing.test.ts
@@ -36,6 +36,29 @@ describe("OpenAI runtime routing policy", () => {
     ).toBe(true);
   });
 
+  it("keeps Codex for model-scoped thinking and fast-mode controls", () => {
+    const config = {
+      agents: {
+        defaults: {
+          models: {
+            "openai/gpt-5.6-sol": {
+              params: { thinking: "xhigh", fastMode: true, fastAutoOnSeconds: 30 },
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(
+      resolveOpenAIImplicitAgentRuntime({
+        provider: "openai",
+        modelId: "gpt-5.6-sol",
+        config,
+        env: {},
+      }),
+    ).toBe("codex");
+  });
+
   it("maps provider route facts onto a closed implicit runtime", () => {
     expect(
       resolveOpenAIImplicitAgentRuntime({ provider: "openai", modelId: "gpt-5.6", env: {} }),

--- a/src/agents/openai-routing.test.ts
+++ b/src/agents/openai-routing.test.ts
@@ -36,13 +36,21 @@ describe("OpenAI runtime routing policy", () => {
     ).toBe(true);
   });
 
-  it("keeps Codex for model-scoped thinking and fast-mode controls", () => {
+  it.each([
+    ["thinking", { thinking: "xhigh" }],
+    ["fastMode", { fastMode: true }],
+    ["fast_mode", { fast_mode: true }],
+    ["fastAutoOnSeconds", { fastMode: "auto", fastAutoOnSeconds: 30 }],
+    ["fast_auto_on_seconds", { fastMode: "auto", fast_auto_on_seconds: 30 }],
+    ["fastSeconds", { fastMode: "auto", fastSeconds: 30 }],
+    ["fast_seconds", { fastMode: "auto", fast_seconds: 30 }],
+  ])("keeps Codex for model-scoped %s controls", (_label, params) => {
     const config = {
       agents: {
         defaults: {
           models: {
             "openai/gpt-5.6-sol": {
-              params: { thinking: "xhigh", fastMode: true, fastAutoOnSeconds: 30 },
+              params,
             },
           },
         },

--- a/src/agents/openai-routing.test.ts
+++ b/src/agents/openai-routing.test.ts
@@ -67,6 +67,31 @@ describe("OpenAI runtime routing policy", () => {
     ).toBe("codex");
   });
 
+  it.each([
+    ["provider-native thinking", { thinking: { type: "enabled", budget_tokens: 2_048 } }],
+    ["invalid fast mode", { fastMode: { enabled: true } }],
+    ["invalid fast cutoff", { fastAutoOnSeconds: "30" }],
+  ])("keeps %s values on the OpenClaw runtime", (_label, params) => {
+    const config = {
+      agents: {
+        defaults: {
+          models: {
+            "openai/gpt-5.6-sol": { params },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(
+      resolveOpenAIImplicitAgentRuntime({
+        provider: "openai",
+        modelId: "gpt-5.6-sol",
+        config,
+        env: {},
+      }),
+    ).toBe("openclaw");
+  });
+
   it("maps provider route facts onto a closed implicit runtime", () => {
     expect(
       resolveOpenAIImplicitAgentRuntime({ provider: "openai", modelId: "gpt-5.6", env: {} }),


### PR DESCRIPTION
<!-- AI-assisted: Codex helped diagnose, implement, test, and review this fix. I reviewed the diff and understand the behavior it changes. -->

## Summary

OpenClaw was mistaking its own model-level thinking and fast controls for arbitrary provider request overrides. That made valid OpenAI models incompatible with the Codex harness. This change keeps Codex routing for values that OpenClaw recognizes as typed runtime controls while unknown keys, provider-native objects, invalid values, default params, and agent params remain fail-closed.

The existing OpenClaw model-control spellings covered here are:

- `thinking`
- `fastMode` / `fast_mode`
- `fastAutoOnSeconds` / `fast_auto_on_seconds`
- `fastSeconds` / `fast_seconds`

## What Problem This Solves

A model entry with an OpenClaw-native thinking or fast control produced `requestTransportOverrides: "present"`. Implicit routing then fell back from Codex, and explicit Codex selection could reject the route, even though the resolved controls are represented natively by Codex effort and service-tier fields.

## Root Cause

PR #104685 added a fail-closed transport-compatibility gate. `hasModelExtraParams` classified every model-scoped parameter as a raw provider request override, including values already owned by the typed agent-run contract.

## Why This Change Was Made

The transport-override detector now recognizes only valid host-owned control values:

- thinking values accepted by the canonical thinking normalizer;
- fast-mode values accepted by the canonical fast-mode normalizer;
- positive integer cutoff values for the four shipped cutoff spellings.

The value-shape check matters because names such as `thinking` can also carry provider-native objects. Those objects, invalid same-name values, every unknown model key, and every default-level or agent-level parameter still count as request transport overrides.

## User Impact

Existing OpenAI model configurations that use OpenClaw thinking or fast-mode controls can retain the Codex harness instead of silently falling back or being rejected. Provider-specific request parameters remain on the embedded OpenClaw route.

## Evidence

Current head: `58ebf756f6f77b7b82f2f2b012bfb95e2f6c03bc`, rebased onto `46f4018ff9143639f8aedcb660e5d6477ad2142a`.

### Exact-head real behavior proof

Blacksmith Testbox `tbx_01kygj6gxgthvj1fb1qnzn8ktp` synced the exact branch and ran the repository's real Docker Gateway/Codex harness path. Actions run: https://github.com/openclaw/openclaw/actions/runs/30229346898

Environment shape:

```text
OPENCLAW_LIVE_CODEX_HARNESS_AUTH=api-key
OPENCLAW_LIVE_CODEX_HARNESS_MODEL=openai/gpt-5.6-sol
OPENCLAW_LIVE_CODEX_HARNESS_THINKING=high
OPENCLAW_LIVE_CODEX_HARNESS_EXPECTED_EFFORT=high
```

Observed result:

```text
codex-cli 0.145.0
Model: openai/gpt-5.6-sol
Thinking: high
Expected native effort: high
Harness fallback: none
gateway-codex-harness.live.test.ts: 1 passed, 1 skipped
runs gateway agent turns through the plugin-owned Codex app-server harness: passed
```

The live assertion requires an actual `codex_app_server.lifecycle` `turn_starting` event, verifies the selected model, checks `effort === "high"`, and checks collaboration effort matches the native turn effort.

The exact-head request-capture regression for fast mode also passed:

```text
node scripts/run-vitest.mjs extensions/codex/src/app-server/run-attempt.test.ts -t 'maps .* to app-server resume and turn service tier'
1 file passed; 3 passed, 114 skipped
```

Those three cases assert fast-on and active auto mode send `serviceTier: "priority"` to both `thread/resume` and `turn/start`, while fast-off clears a configured tier with `null`.

### Routing and safety proof

```text
node scripts/run-vitest.mjs src/agents/openai-routing.test.ts src/agents/harness/selection.test.ts
2 files passed; 134 tests passed
```

This covers all seven spellings, combined native controls, unknown model parameters, provider-native `thinking` objects, invalid fast values, and the default/agent fail-closed paths.

`OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 node scripts/check-changed.mjs --timed` passed every core/coreTests lane, including format, core and core-test tsgo, targeted lint, plugin boundaries, import cycles, and storage/runtime guards. Final branch autoreview reported no accepted/actionable findings.

Hosted exact-head CI run `30227815460` passed after rerunning one unrelated wall-clock-sensitive gateway test shard; attempt 2 completed successfully on the unchanged head.

### Direct Codex contract inspection

The local `openai/codex` checkout was refreshed to `18f50c9e628af083a52d9240de09fc2db24d79ce`. The exact package tag used here, `rust-v0.145.0` (`25af12f7e61572b0bc18ddb1008be543b91519b0`), has the same contract:

- `codex-rs/app-server-protocol/src/protocol/v2/thread.rs:56-73,235-250` accepts nullable `service_tier` and subsequent-turn `effort`.
- `codex-rs/app-server-protocol/src/protocol/v2/turn.rs:122-136` accepts per-turn `service_tier` and `effort`.
- `codex-rs/app-server/src/request_processors/turn_processor.rs:682-821` validates and applies both settings.
- `codex-rs/core/src/client.rs:824-908` builds the Responses request with native reasoning and service tier.

## What Was Not Tested

- Telegram/UI delivery is not involved; the exact-head proof used an isolated Gateway turn with delivery disabled.
- A deliberately provider-native `thinking` object was not sent to OpenAI. Routing regressions prove it remains incompatible with Codex before provider execution.
- The live turn verified native effort; service-tier mapping was verified by the exact request-capture regression on the same head.
