### PR TITLE
fix(qqbot): add C2C fallback approval denial recovery guidance

### DIFF
--- a/extensions/qqbot/src/engine/gateway/interaction-handler.test.ts
+++ b/extensions/qqbot/src/engine/gateway/interaction-handler.test.ts
@@ -1,0 +1,524 @@
+// Qqbot tests cover interaction handler plugin behavior.
+import type { ApprovalResolveResult } from "openclaw/plugin-sdk/approval-gateway-runtime";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createSdkAccessAdapter } from "../../bridge/sdk-adapter.js";
+import { registerPlatformAdapter, type PlatformAdapter } from "../adapter/index.js";
+import type { InteractionEvent } from "../types.js";
+import { createInteractionHandler } from "./interaction-handler.js";
+import type { GatewayAccount, GatewayPluginRuntime } from "./types.js";
+
+const acknowledgeInteractionMock = vi.hoisted(() => vi.fn(async () => undefined));
+const sendTextMock = vi.hoisted(() => vi.fn(async () => ({ id: "message-1", timestamp: 1 })));
+
+function waitForQqInteraction(assertion: () => void) {
+  return vi.waitFor(assertion, { interval: 1 });
+}
+
+vi.mock("../messaging/sender.js", () => ({
+  accountToCreds: (account: GatewayAccount) => ({
+    appId: account.appId,
+    clientSecret: account.clientSecret,
+  }),
+  acknowledgeInteraction: acknowledgeInteractionMock,
+  sendText: sendTextMock,
+}));
+
+const appliedApprovalResult = {
+  applied: true,
+  approval: {
+    id: "exec:abc12345",
+    urlPath: "/approve/exec%3Aabc12345",
+    createdAtMs: 1,
+    expiresAtMs: 10_000,
+    presentation: {
+      kind: "exec",
+      commandText: "echo approved",
+      allowedDecisions: ["allow-once", "deny"],
+    },
+    status: "allowed",
+    decision: "allow-once",
+    resolvedAtMs: 2,
+    reason: "user",
+  },
+} satisfies ApprovalResolveResult;
+
+const resolveApprovalMock = vi.fn(
+  async (): Promise<ApprovalResolveResult> => appliedApprovalResult,
+);
+const expectedApprovalResolve = {
+  approvalId: "exec:abc12345",
+  approvalKind: "exec",
+  decision: "allow-once",
+} as const;
+
+function makeAccount(config: GatewayAccount["config"] = {}): GatewayAccount {
+  return {
+    accountId: "default",
+    appId: "app",
+    clientSecret: "secret",
+    markdownSupport: false,
+    config,
+  };
+}
+
+const account = makeAccount();
+
+const runtime = {} as GatewayPluginRuntime;
+
+function makeRestrictedCfg(approvers: string[]): OpenClawConfig {
+  return {
+    channels: {
+      qqbot: {
+        appId: "app",
+        clientSecret: "secret",
+        execApprovals: {
+          enabled: true,
+          approvers,
+        },
+      },
+    },
+  } as OpenClawConfig;
+}
+
+function makeCommandAuthorizedFallbackCfg(): OpenClawConfig {
+  return {
+    channels: {
+      qqbot: {
+        appId: "app",
+        clientSecret: "secret",
+        allowFrom: ["ATTACKER_OPENID"],
+      },
+    },
+  } as OpenClawConfig;
+}
+
+function makeApprovalEvent(overrides: Partial<InteractionEvent> = {}): InteractionEvent {
+  return {
+    id: "interaction-1",
+    type: 11,
+    chat_type: 1,
+    group_openid: "group-1",
+    group_member_openid: "ATTACKER_OPENID",
+    version: 1,
+    data: {
+      type: 11,
+      resolved: {
+        button_data: "approve:v2:exec:exec%3Aabc12345:allow-once",
+        user_id: "ATTACKER_USER_ID",
+      },
+    },
+    ...overrides,
+  };
+}
+
+function installPlatformAdapter(): void {
+  registerPlatformAdapter({
+    validateRemoteUrl: vi.fn(async () => undefined),
+    resolveSecret: vi.fn(async (value: unknown) => (typeof value === "string" ? value : undefined)),
+    downloadFile: vi.fn(async () => "/tmp/file"),
+    fetchMedia: vi.fn(async () => {
+      throw new Error("unused");
+    }),
+    getTempDir: () => "/tmp",
+    hasConfiguredSecret: (value: unknown) => typeof value === "string" && value.length > 0,
+    normalizeSecretInputString: (value: unknown) => (typeof value === "string" ? value : undefined),
+    resolveSecretInputString: ({ value }: { value: unknown }) =>
+      typeof value === "string" ? value : undefined,
+    resolveApproval: resolveApprovalMock,
+  } as PlatformAdapter);
+}
+
+describe("createInteractionHandler approval buttons", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resolveApprovalMock.mockResolvedValue(appliedApprovalResult);
+    installPlatformAdapter();
+  });
+
+  it("rejects approval button clicks from users outside the configured approvers", async () => {
+    const handler = createInteractionHandler(account, runtime, undefined, {
+      getActiveCfg: () => makeRestrictedCfg(["OWNER_OPENID"]),
+    });
+
+    handler(makeApprovalEvent());
+
+    await waitForQqInteraction(() => expect(acknowledgeInteractionMock).toHaveBeenCalled());
+
+    expect(acknowledgeInteractionMock).toHaveBeenCalledWith(
+      { appId: "app", clientSecret: "secret" },
+      "interaction-1",
+      0,
+      { content: "You are not authorized to approve this request." },
+    );
+    expect(resolveApprovalMock).not.toHaveBeenCalled();
+  });
+
+  it("does not authorize from resolved user id when the actor openid is not approved", async () => {
+    const handler = createInteractionHandler(account, runtime, undefined, {
+      getActiveCfg: () => makeRestrictedCfg(["OWNER_OPENID"]),
+    });
+
+    handler(
+      makeApprovalEvent({
+        data: {
+          type: 11,
+          resolved: {
+            button_data: "approve:v2:exec:exec%3Aabc12345:allow-once",
+            user_id: "OWNER_OPENID",
+          },
+        },
+      }),
+    );
+
+    await waitForQqInteraction(() => expect(acknowledgeInteractionMock).toHaveBeenCalled());
+
+    expect(acknowledgeInteractionMock).toHaveBeenCalledWith(
+      { appId: "app", clientSecret: "secret" },
+      "interaction-1",
+      0,
+      { content: "You are not authorized to approve this request." },
+    );
+    expect(resolveApprovalMock).not.toHaveBeenCalled();
+  });
+
+  it("resolves approval button clicks from configured approvers", async () => {
+    const handler = createInteractionHandler(account, runtime, undefined, {
+      getActiveCfg: () => makeRestrictedCfg(["OWNER_OPENID"]),
+    });
+
+    handler(makeApprovalEvent({ group_member_openid: "OWNER_OPENID" }));
+
+    await waitForQqInteraction(() =>
+      expect(resolveApprovalMock).toHaveBeenCalledWith(expectedApprovalResolve),
+    );
+  });
+
+  it("preserves plugin ownership through configured-approver authorization", async () => {
+    const handler = createInteractionHandler(account, runtime, undefined, {
+      getActiveCfg: () => makeRestrictedCfg(["OWNER_OPENID"]),
+    });
+
+    handler(
+      makeApprovalEvent({
+        group_member_openid: "OWNER_OPENID",
+        data: {
+          type: 11,
+          resolved: {
+            button_data: "approve:v2:plugin:exec%3Alooks-like-exec%2F1:deny",
+            user_id: "ATTACKER_USER_ID",
+          },
+        },
+      }),
+    );
+
+    await waitForQqInteraction(() =>
+      expect(resolveApprovalMock).toHaveBeenCalledWith({
+        approvalId: "exec:looks-like-exec/1",
+        approvalKind: "plugin",
+        decision: "deny",
+      }),
+    );
+  });
+
+  it("rejects plugin approval buttons from users outside the configured approvers", async () => {
+    const handler = createInteractionHandler(account, runtime, undefined, {
+      getActiveCfg: () => makeRestrictedCfg(["OWNER_OPENID"]),
+    });
+
+    handler(
+      makeApprovalEvent({
+        data: {
+          type: 11,
+          resolved: {
+            button_data: "approve:v2:plugin:exec%3Alooks-like-exec%2F1:deny",
+            user_id: "ATTACKER_USER_ID",
+          },
+        },
+      }),
+    );
+
+    await waitForQqInteraction(() => expect(acknowledgeInteractionMock).toHaveBeenCalled());
+
+    expect(acknowledgeInteractionMock).toHaveBeenCalledWith(
+      { appId: "app", clientSecret: "secret" },
+      "interaction-1",
+      0,
+      { content: "You are not authorized to approve this request." },
+    );
+    expect(resolveApprovalMock).not.toHaveBeenCalled();
+  });
+
+  it("logs the canonical winner when another surface already resolved", async () => {
+    resolveApprovalMock.mockResolvedValueOnce({
+      applied: false,
+      approval: {
+        id: "exec:abc12345",
+        urlPath: "/approve/exec%3Aabc12345",
+        createdAtMs: 1,
+        expiresAtMs: 10_000,
+        presentation: {
+          kind: "exec",
+          commandText: "echo approved",
+          allowedDecisions: ["allow-once", "deny"],
+        },
+        status: "denied",
+        decision: "deny",
+        resolvedAtMs: 2,
+        reason: "user",
+      },
+    });
+    const log = { info: vi.fn(), error: vi.fn() };
+    const handler = createInteractionHandler(account, runtime, log, {
+      getActiveCfg: () => makeRestrictedCfg(["OWNER_OPENID"]),
+    });
+
+    handler(makeApprovalEvent({ group_member_openid: "OWNER_OPENID" }));
+
+    await waitForQqInteraction(() =>
+      expect(log.info).toHaveBeenCalledWith(
+        "Approval already resolved: id=exec:abc12345, status=denied, decision=deny",
+      ),
+    );
+    expect(acknowledgeInteractionMock).toHaveBeenCalledWith(
+      { appId: "app", clientSecret: "secret" },
+      "interaction-1",
+      0,
+      { content: "Approval response received." },
+    );
+    expect(sendTextMock).toHaveBeenCalledWith(
+      { type: "group", id: "group-1" },
+      "This approval was already resolved: Denied.",
+      { appId: "app", clientSecret: "secret" },
+      { msgId: undefined },
+    );
+    expect(log.info).not.toHaveBeenCalledWith(expect.stringContaining("decision=allow-once"));
+    expect(log.error).not.toHaveBeenCalled();
+  });
+
+  it("acknowledges before a slow canonical resolution completes", async () => {
+    let releaseResolution!: (result: ApprovalResolveResult) => void;
+    resolveApprovalMock.mockImplementationOnce(
+      async () =>
+        await new Promise<ApprovalResolveResult>((resolve) => {
+          releaseResolution = resolve;
+        }),
+    );
+    const handler = createInteractionHandler(account, runtime, undefined, {
+      getActiveCfg: () => makeRestrictedCfg(["OWNER_OPENID"]),
+    });
+
+    handler(makeApprovalEvent({ group_member_openid: "OWNER_OPENID" }));
+
+    await waitForQqInteraction(() =>
+      expect(acknowledgeInteractionMock).toHaveBeenCalledWith(
+        { appId: "app", clientSecret: "secret" },
+        "interaction-1",
+        0,
+        { content: "Approval response received." },
+      ),
+    );
+    await waitForQqInteraction(() => expect(resolveApprovalMock).toHaveBeenCalled());
+    expect(sendTextMock).not.toHaveBeenCalled();
+
+    releaseResolution(appliedApprovalResult);
+    await waitForQqInteraction(() => expect(sendTextMock).toHaveBeenCalled());
+  });
+
+  it("uses the direct user openid when a group member openid is unavailable", async () => {
+    const handler = createInteractionHandler(account, runtime, undefined, {
+      getActiveCfg: () => makeRestrictedCfg(["OWNER_OPENID"]),
+    });
+
+    handler(
+      makeApprovalEvent({
+        chat_type: 2,
+        group_openid: undefined,
+        group_member_openid: undefined,
+        user_openid: "OWNER_OPENID",
+      }),
+    );
+
+    await waitForQqInteraction(() =>
+      expect(resolveApprovalMock).toHaveBeenCalledWith(expectedApprovalResolve),
+    );
+  });
+
+  it("resolves fallback approval buttons from explicit command-authorized senders", async () => {
+    const handler = createInteractionHandler(account, runtime, undefined, {
+      getActiveCfg: () => makeCommandAuthorizedFallbackCfg(),
+    });
+
+    handler(makeApprovalEvent());
+
+    await waitForQqInteraction(() =>
+      expect(resolveApprovalMock).toHaveBeenCalledWith(expectedApprovalResolve),
+    );
+  });
+
+  it("delegates fallback approval button auth to the gateway command resolver", async () => {
+    const access = createSdkAccessAdapter();
+    const handler = createInteractionHandler(account, runtime, undefined, {
+      getActiveCfg: () =>
+        ({
+          accessGroups: {
+            operators: {
+              type: "message.senders",
+              members: {
+                qqbot: ["ATTACKER_OPENID"],
+              },
+            },
+          },
+          channels: {
+            qqbot: {
+              appId: "app",
+              clientSecret: "secret",
+              allowFrom: ["accessGroup:operators"],
+            },
+          },
+        }) as OpenClawConfig,
+      resolveCommandAuthorized: (params) => access.resolveSlashCommandAuthorization(params),
+    });
+
+    handler(makeApprovalEvent());
+
+    await waitForQqInteraction(() =>
+      expect(resolveApprovalMock).toHaveBeenCalledWith(expectedApprovalResolve),
+    );
+  });
+
+  it("uses merged account config for fallback button command auth", async () => {
+    const handler = createInteractionHandler(account, runtime, undefined, {
+      getActiveCfg: () =>
+        ({
+          channels: {
+            qqbot: {
+              appId: "app",
+              clientSecret: "secret",
+              accounts: {
+                default: {
+                  allowFrom: ["ATTACKER_OPENID"],
+                },
+              },
+            },
+          },
+        }) as OpenClawConfig,
+    });
+
+    handler(makeApprovalEvent());
+
+    await waitForQqInteraction(() =>
+      expect(resolveApprovalMock).toHaveBeenCalledWith(expectedApprovalResolve),
+    );
+  });
+
+  it("rejects fallback approval buttons from senders without explicit command auth", async () => {
+    const handler = createInteractionHandler(account, runtime, undefined, {
+      getActiveCfg: () =>
+        ({
+          channels: {
+            qqbot: {
+              appId: "app",
+              clientSecret: "secret",
+              allowFrom: ["OWNER_OPENID"],
+            },
+          },
+        }) as OpenClawConfig,
+    });
+
+    handler(makeApprovalEvent());
+
+    await waitForQqInteraction(() => expect(acknowledgeInteractionMock).toHaveBeenCalled());
+
+    expect(acknowledgeInteractionMock).toHaveBeenCalledWith(
+      { appId: "app", clientSecret: "secret" },
+      "interaction-1",
+      0,
+      { content: "You are not authorized to approve this request." },
+    );
+    expect(resolveApprovalMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [
+      "no allowlist",
+      {
+        channels: {
+          qqbot: {
+            appId: "app",
+            clientSecret: "secret",
+          },
+        },
+      },
+    ],
+    [
+      "wildcard allowlist",
+      {
+        channels: {
+          qqbot: {
+            appId: "app",
+            clientSecret: "secret",
+            allowFrom: ["*"],
+          },
+        },
+      },
+    ],
+  ] satisfies Array<[string, OpenClawConfig]>)(
+    "rejects fallback approval buttons when %s does not grant command auth",
+    async (_name, cfg) => {
+      const handler = createInteractionHandler(account, runtime, undefined, {
+        getActiveCfg: () => cfg,
+      });
+
+      handler(makeApprovalEvent());
+
+      await waitForQqInteraction(() => expect(acknowledgeInteractionMock).toHaveBeenCalled());
+
+      expect(acknowledgeInteractionMock).toHaveBeenCalledWith(
+        { appId: "app", clientSecret: "secret" },
+        "interaction-1",
+        0,
+        { content: "You are not authorized to approve this request." },
+      );
+      expect(resolveApprovalMock).not.toHaveBeenCalled();
+    },
+  );
+
+  it("rejects fallback approval buttons without a trusted actor id", async () => {
+    const handler = createInteractionHandler(account, runtime, undefined, {
+      getActiveCfg: () => makeCommandAuthorizedFallbackCfg(),
+    });
+
+    handler(makeApprovalEvent({ group_member_openid: undefined, user_openid: undefined }));
+
+    await waitForQqInteraction(() => expect(acknowledgeInteractionMock).toHaveBeenCalled());
+
+    expect(acknowledgeInteractionMock).toHaveBeenCalledWith(
+      { appId: "app", clientSecret: "secret" },
+      "interaction-1",
+      0,
+      { content: "You are not authorized to approve this request." },
+    );
+    expect(resolveApprovalMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects approval button clicks when active config cannot be loaded", async () => {
+    const handler = createInteractionHandler(account, runtime, undefined, {
+      getActiveCfg: () => {
+        throw new Error("config unavailable");
+      },
+    });
+
+    handler(makeApprovalEvent());
+
+    await waitForQqInteraction(() => expect(acknowledgeInteractionMock).toHaveBeenCalled());
+
+    expect(acknowledgeInteractionMock).toHaveBeenCalledWith(
+      { appId: "app", clientSecret: "secret" },
+      "interaction-1",
+      0,
+      { content: "Approval is unavailable." },
+    );
+    expect(resolveApprovalMock).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/qqbot/src/engine/gateway/interaction-handler.test.ts
+++ b/extensions/qqbot/src/engine/gateway/interaction-handler.test.ts
@@ -129,6 +129,18 @@ function installPlatformAdapter(): void {
   } as PlatformAdapter);
 }
 
+function formatC2CApprovalDenialReason(senderId: string): string {
+  return (
+    `You are not authorized to approve this request.\n\n` +
+    `Your OpenID: ${senderId}\n\n` +
+    `To authorize approvals from this conversation, add this OpenID to ` +
+    `channels.qqbot.allowFrom or channels.qqbot.execApprovals.approvers ` +
+    `in your OpenClaw config. Use /bot-me to see your identity.`
+  );
+}
+
+const genericDenial = "You are not authorized to approve this request.";
+
 describe("createInteractionHandler approval buttons", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -149,7 +161,7 @@ describe("createInteractionHandler approval buttons", () => {
       { appId: "app", clientSecret: "secret" },
       "interaction-1",
       0,
-      { content: "You are not authorized to approve this request." },
+      { content: genericDenial },
     );
     expect(resolveApprovalMock).not.toHaveBeenCalled();
   });
@@ -177,7 +189,7 @@ describe("createInteractionHandler approval buttons", () => {
       { appId: "app", clientSecret: "secret" },
       "interaction-1",
       0,
-      { content: "You are not authorized to approve this request." },
+      { content: genericDenial },
     );
     expect(resolveApprovalMock).not.toHaveBeenCalled();
   });
@@ -244,7 +256,7 @@ describe("createInteractionHandler approval buttons", () => {
       { appId: "app", clientSecret: "secret" },
       "interaction-1",
       0,
-      { content: "You are not authorized to approve this request." },
+      { content: genericDenial },
     );
     expect(resolveApprovalMock).not.toHaveBeenCalled();
   });
@@ -434,7 +446,7 @@ describe("createInteractionHandler approval buttons", () => {
       { appId: "app", clientSecret: "secret" },
       "interaction-1",
       0,
-      { content: "You are not authorized to approve this request." },
+      { content: genericDenial },
     );
     expect(resolveApprovalMock).not.toHaveBeenCalled();
   });
@@ -478,11 +490,125 @@ describe("createInteractionHandler approval buttons", () => {
         { appId: "app", clientSecret: "secret" },
         "interaction-1",
         0,
-        { content: "You are not authorized to approve this request." },
+        { content: genericDenial },
       );
       expect(resolveApprovalMock).not.toHaveBeenCalled();
     },
   );
+
+  it.each([
+    [
+      "no allowlist",
+      {
+        channels: {
+          qqbot: {
+            appId: "app",
+            clientSecret: "secret",
+          },
+        },
+      },
+    ],
+    [
+      "wildcard allowlist",
+      {
+        channels: {
+          qqbot: {
+            appId: "app",
+            clientSecret: "secret",
+            allowFrom: ["*"],
+          },
+        },
+      },
+    ],
+  ] satisfies Array<[string, OpenClawConfig]>)(
+    "rejects fallback approval buttons in direct (C2C) conversations when %s does not grant command auth",
+    async (_name, cfg) => {
+      const handler = createInteractionHandler(account, runtime, undefined, {
+        getActiveCfg: () => cfg,
+      });
+
+      handler(
+        makeApprovalEvent({
+          chat_type: 2,
+          group_openid: undefined,
+          group_member_openid: undefined,
+          user_openid: "C2CUSER_OPENID",
+        }),
+      );
+
+      await vi.waitFor(() => expect(acknowledgeInteractionMock).toHaveBeenCalled());
+
+      expect(acknowledgeInteractionMock).toHaveBeenCalledWith(
+        { appId: "app", clientSecret: "secret" },
+        "interaction-1",
+        0,
+        { content: formatC2CApprovalDenialReason("C2CUSER_OPENID") },
+      );
+      expect(resolveApprovalMock).not.toHaveBeenCalled();
+    },
+  );
+
+  it("resolves fallback approval buttons in direct (C2C) conversations when the sender has explicit command auth", async () => {
+    const handler = createInteractionHandler(account, runtime, undefined, {
+      getActiveCfg: () =>
+        ({
+          channels: {
+            qqbot: {
+              appId: "app",
+              clientSecret: "secret",
+              allowFrom: ["C2CUSER_OPENID"],
+            },
+          },
+        }) as OpenClawConfig,
+    });
+
+    handler(
+      makeApprovalEvent({
+        chat_type: 2,
+        group_openid: undefined,
+        group_member_openid: undefined,
+        user_openid: "C2CUSER_OPENID",
+      }),
+    );
+
+    await vi.waitFor(() =>
+      expect(resolveApprovalMock).toHaveBeenCalledWith(expectedApprovalResolve),
+    );
+  });
+
+  it("rejects fallback approval buttons in direct (C2C) conversations when the sender lacks explicit command auth", async () => {
+    const handler = createInteractionHandler(account, runtime, undefined, {
+      getActiveCfg: () =>
+        ({
+          channels: {
+            qqbot: {
+              appId: "app",
+              clientSecret: "secret",
+              allowFrom: ["OWNER_OPENID"],
+            },
+          },
+        }) as OpenClawConfig,
+    });
+
+    handler(
+      makeApprovalEvent({
+        chat_type: 2,
+        group_openid: undefined,
+        group_member_openid: undefined,
+        user_openid: "UNAUTHORIZED_C2CUSER",
+      }),
+    );
+
+    await vi.waitFor(() => expect(acknowledgeInteractionMock).toHaveBeenCalled());
+
+    expect(acknowledgeInteractionMock).toHaveBeenCalledWith(
+      { appId: "app", clientSecret: "secret" },
+      "interaction-1",
+      0,
+      { content: formatC2CApprovalDenialReason("UNAUTHORIZED_C2CUSER") },
+    );
+    expect(resolveApprovalMock).not.toHaveBeenCalled();
+  });
 
   it("rejects fallback approval buttons without a trusted actor id", async () => {
     const handler = createInteractionHandler(account, runtime, undefined, {
@@ -497,7 +623,7 @@ describe("createInteractionHandler approval buttons", () => {
       { appId: "app", clientSecret: "secret" },
       "interaction-1",
       0,
-      { content: "You are not authorized to approve this request." },
+      { content: genericDenial },
     );
     expect(resolveApprovalMock).not.toHaveBeenCalled();
   });

--- a/extensions/qqbot/src/engine/gateway/interaction-handler.ts
+++ b/extensions/qqbot/src/engine/gateway/interaction-handler.ts
@@ -1,0 +1,496 @@
+/**
+ * INTERACTION_CREATE event handler.
+ *
+ * Handles three interaction branches:
+ *
+ * 1. **Config query**  (type=2001) — reads config, ACKs with `claw_cfg`.
+ * 2. **Config update** (type=2002) — writes config, ACKs with updated snapshot.
+ * 3. **Approval button** (other)   — ACKs, resolves authorized approval actions.
+ *
+ * Config query/update require `runtime.config`. When unavailable, those
+ * branches fall through to a bare ACK (backward-compatible).
+ */
+
+import { isImplicitSameChatApprovalAuthorization } from "openclaw/plugin-sdk/approval-auth-runtime";
+import type { ApprovalResolveResult } from "openclaw/plugin-sdk/approval-gateway-runtime";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { uniqueStrings } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { authorizeQQBotApprovalAction } from "../../exec-approvals.js";
+import { resolveQQBotEffectivePolicies } from "../access/resolve-policy.js";
+import { getPlatformAdapter } from "../adapter/index.js";
+import { parseApprovalButtonData } from "../approval/index.js";
+import {
+  resolveQQBotCommandsAllowFrom,
+  resolveSlashCommandAuth,
+} from "../commands/slash-command-auth.js";
+import { getPluginVersion, getFrameworkVersion } from "../commands/slash-commands-impl.js";
+import { resolveGroupConfig, resolveMentionPatterns } from "../config/group.js";
+import { resolveAccountBase } from "../config/resolve.js";
+import type { GroupActivationMode } from "../group/activation.js";
+import { accountToCreds, acknowledgeInteraction, sendText } from "../messaging/sender.js";
+import type { InteractionEvent, QQBotAccountConfigView } from "../types.js";
+import { InteractionType } from "./constants.js";
+import type { GatewayAccount, GatewayPluginRuntime, EngineLogger } from "./types.js";
+
+type QQBotCommandAuthorizationResolver = (params: {
+  cfg: OpenClawConfig;
+  accountId: string;
+  isGroup: boolean;
+  senderId: string;
+  conversationId: string;
+  allowFrom?: Array<string | number>;
+  groupAllowFrom?: Array<string | number>;
+  commandsAllowFrom?: Array<string | number>;
+}) => boolean | Promise<boolean>;
+
+// ============ claw_cfg snapshot ============
+
+/**
+ * Build the canonical `claw_cfg` snapshot returned in interaction ACKs.
+ *
+ * Pure function — all resolution helpers live in engine/config/.
+ */
+function buildClawCfgSnapshot(
+  cfg: Record<string, unknown>,
+  accountId: string,
+  groupOpenid: string,
+  runtime: GatewayPluginRuntime,
+): Record<string, unknown> {
+  const groupCfg = groupOpenid ? resolveGroupConfig(cfg, groupOpenid, accountId) : null;
+  const accountBase = resolveAccountBase(cfg, accountId);
+  const acctCfg = accountBase.config as QQBotAccountConfigView;
+  const policies = resolveQQBotEffectivePolicies({
+    allowFrom: acctCfg.allowFrom,
+    groupAllowFrom: acctCfg.groupAllowFrom,
+    dmPolicy: acctCfg.dmPolicy,
+    groupPolicy: acctCfg.groupPolicy,
+  });
+
+  const requireMentionMode: GroupActivationMode =
+    (groupCfg?.requireMention ?? true) ? "mention" : "always";
+
+  const interactionAgentId = groupOpenid
+    ? (
+        runtime.channel.routing.resolveAgentRoute({
+          cfg,
+          channel: "qqbot",
+          accountId,
+          peer: { kind: "group", id: groupOpenid },
+        }) as { agentId?: string } | undefined
+      )?.agentId
+    : undefined;
+
+  return {
+    channel_type: "qqbot",
+    channel_ver: getPluginVersion(),
+    claw_type: "openclaw",
+    claw_ver: getFrameworkVersion(),
+    require_mention: requireMentionMode,
+    group_policy: policies.groupPolicy,
+    mention_patterns: resolveMentionPatterns(cfg, interactionAgentId).join(","),
+    online_state: "online",
+  };
+}
+
+// ============ Config update ============
+
+/** Apply a config-update interaction and return the updated claw_cfg. */
+async function applyConfigUpdate(
+  event: InteractionEvent,
+  accountId: string,
+  runtime: GatewayPluginRuntime,
+  log?: EngineLogger,
+): Promise<Record<string, unknown>> {
+  const configApi = runtime.config;
+  if (!configApi) {
+    throw new Error("runtime.config not available");
+  }
+
+  const resolved = event.data?.resolved as Record<string, unknown> | undefined;
+  const clawCfgUpdate = resolved?.claw_cfg as Record<string, unknown> | undefined;
+  const groupOpenid = event.group_openid ?? "";
+
+  const currentCfg = structuredClone(configApi.current());
+  let changed = false;
+
+  if (clawCfgUpdate?.require_mention !== undefined && groupOpenid) {
+    applyRequireMentionUpdate(currentCfg, accountId, groupOpenid, clawCfgUpdate);
+    changed = true;
+  }
+
+  if (changed) {
+    await configApi.replaceConfigFile({ nextConfig: currentCfg, afterWrite: { mode: "auto" } });
+    log?.info(
+      `Config updated via interaction ${event.id}: require_mention=${String(clawCfgUpdate?.require_mention)}, group=${groupOpenid}`,
+    );
+  }
+
+  const latestCfg = changed ? configApi.current() : currentCfg;
+  return buildClawCfgSnapshot(latestCfg, accountId, groupOpenid, runtime);
+}
+
+/** Mutate `cfg` in place to apply a require_mention update for a group. */
+function applyRequireMentionUpdate(
+  cfg: Record<string, unknown>,
+  accountId: string,
+  groupOpenid: string,
+  update: Record<string, unknown>,
+): void {
+  const requireMentionBool = update.require_mention === "mention";
+  const channels = (cfg.channels ?? {}) as Record<string, unknown>;
+  const qqbot = (channels.qqbot ?? {}) as Record<string, unknown>;
+
+  const isNamedAccount =
+    accountId !== "default" &&
+    Boolean((qqbot.accounts as Record<string, Record<string, unknown>> | undefined)?.[accountId]);
+
+  if (isNamedAccount) {
+    const accounts = (qqbot.accounts ?? {}) as Record<string, Record<string, unknown>>;
+    const acct = accounts[accountId] ?? {};
+    const groups = (acct.groups ?? {}) as Record<string, Record<string, unknown>>;
+    groups[groupOpenid] = { ...groups[groupOpenid], requireMention: requireMentionBool };
+    acct.groups = groups;
+    accounts[accountId] = acct;
+    qqbot.accounts = accounts;
+  } else {
+    const groups = (qqbot.groups ?? {}) as Record<string, Record<string, unknown>>;
+    groups[groupOpenid] = { ...groups[groupOpenid], requireMention: requireMentionBool };
+    qqbot.groups = groups;
+  }
+}
+
+// ============ Public factory ============
+
+/**
+ * Create the INTERACTION_CREATE event handler.
+ *
+ * Returns a fire-and-forget callback that `GatewayConnection` calls
+ * on every `action: "interaction"` dispatch result.
+ */
+export function createInteractionHandler(
+  account: GatewayAccount,
+  runtime: GatewayPluginRuntime,
+  log?: EngineLogger,
+  options?: {
+    getActiveCfg?: () => OpenClawConfig;
+    resolveCommandAuthorized?: QQBotCommandAuthorizationResolver;
+  },
+): (event: InteractionEvent) => void {
+  return (event) => {
+    const creds = accountToCreds(account);
+    const type = event.data?.type;
+
+    // ---- Config query (type=2001) ----
+    if (type === InteractionType.CONFIG_QUERY && runtime.config) {
+      void handleWithAck(creds, event, log, "CONFIG_QUERY", () => {
+        const cfg = runtime.config!.current();
+        return buildClawCfgSnapshot(cfg, account.accountId, event.group_openid ?? "", runtime);
+      });
+      return;
+    }
+
+    // ---- Config update (type=2002) ----
+    if (type === InteractionType.CONFIG_UPDATE && runtime.config) {
+      void handleWithAck(creds, event, log, "CONFIG_UPDATE", () =>
+        applyConfigUpdate(event, account.accountId, runtime, log),
+      );
+      return;
+    }
+
+    // ---- Approval button / other ----
+    const parsed = parseApprovalButtonData(event.data?.resolved?.button_data ?? "");
+    if (!parsed) {
+      void acknowledgeInteraction(creds, event.id).catch((err: unknown) => {
+        log?.error(`Interaction ACK failed: ${err instanceof Error ? err.message : String(err)}`);
+      });
+      return;
+    }
+
+    void handleApprovalButtonInteraction({
+      account,
+      creds,
+      event,
+      getActiveCfg: options?.getActiveCfg ?? runtime.config?.current,
+      log,
+      parsed,
+      resolveCommandAuthorized: options?.resolveCommandAuthorized,
+    });
+  };
+}
+
+// ============ Helpers ============
+
+async function handleApprovalButtonInteraction(params: {
+  account: GatewayAccount;
+  creds: { appId: string; clientSecret: string };
+  event: InteractionEvent;
+  getActiveCfg?: () => OpenClawConfig | Record<string, unknown>;
+  log?: EngineLogger;
+  parsed: {
+    approvalId: string;
+    approvalKind: "exec" | "plugin";
+    decision: "allow-once" | "allow-always" | "deny";
+  };
+  resolveCommandAuthorized?: QQBotCommandAuthorizationResolver;
+}): Promise<void> {
+  if (!params.getActiveCfg) {
+    await acknowledgeApprovalInteraction(params.creds, params.event, params.log, {
+      content: "Approval is unavailable.",
+    });
+    params.log?.error("Approval button rejected: active config is unavailable");
+    return;
+  }
+
+  let cfg: OpenClawConfig;
+  try {
+    cfg = params.getActiveCfg() as OpenClawConfig;
+  } catch (err) {
+    await acknowledgeApprovalInteraction(params.creds, params.event, params.log, {
+      content: "Approval is unavailable.",
+    });
+    params.log?.error(
+      `Approval button rejected: active config failed to load: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+    return;
+  }
+
+  const authorization = await authorizeApprovalButtonActor({
+    cfg,
+    account: params.account,
+    event: params.event,
+    approvalKind: params.parsed.approvalKind,
+    resolveCommandAuthorized: params.resolveCommandAuthorized,
+  });
+  if (!authorization.authorized) {
+    await acknowledgeApprovalInteraction(params.creds, params.event, params.log, {
+      content: authorization.reason ?? "You are not authorized to approve this request.",
+    });
+    params.log?.info(`Approval button rejected: id=${params.parsed.approvalId}`);
+    return;
+  }
+
+  // QQ applies the clicked button's visited state as soon as the interaction is ACKed. Keep that
+  // state neutral, ACK promptly, then post the durable canonical outcome once Gateway resolves.
+  await acknowledgeApprovalInteraction(params.creds, params.event, params.log, {
+    content: "Approval response received.",
+  });
+
+  const adapter = getPlatformAdapter();
+  if (!adapter.resolveApproval) {
+    await reportApprovalInteractionOutcome({
+      creds: params.creds,
+      event: params.event,
+      log: params.log,
+      content: "Approval is unavailable.",
+    });
+    params.log?.error("resolveApproval not available on PlatformAdapter");
+    return;
+  }
+
+  try {
+    const result = await adapter.resolveApproval(params.parsed);
+    const canonicalDecision =
+      "decision" in result.approval ? `, decision=${result.approval.decision}` : "";
+    const canonicalOutcome = formatCanonicalApprovalOutcome(result.approval);
+    await reportApprovalInteractionOutcome({
+      creds: params.creds,
+      event: params.event,
+      log: params.log,
+      content: result.applied
+        ? `Approval resolved: ${canonicalOutcome}.`
+        : `This approval was already resolved: ${canonicalOutcome}.`,
+    });
+    params.log?.info(
+      result.applied
+        ? `Approval resolved: id=${result.approval.id}, status=${result.approval.status}${canonicalDecision}`
+        : `Approval already resolved: id=${result.approval.id}, status=${result.approval.status}${canonicalDecision}`,
+    );
+  } catch (err) {
+    await reportApprovalInteractionOutcome({
+      creds: params.creds,
+      event: params.event,
+      log: params.log,
+      content: "Approval could not be resolved.",
+    });
+    params.log?.error(
+      `Approval resolve failed: id=${params.parsed.approvalId}: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+  }
+}
+
+async function reportApprovalInteractionOutcome(params: {
+  creds: { appId: string; clientSecret: string };
+  event: InteractionEvent;
+  log?: EngineLogger;
+  content: string;
+}): Promise<void> {
+  const target = params.event.group_openid
+    ? { type: "group" as const, id: params.event.group_openid }
+    : params.event.user_openid
+      ? { type: "c2c" as const, id: params.event.user_openid }
+      : params.event.channel_id
+        ? { type: "channel" as const, id: params.event.channel_id }
+        : null;
+  if (!target) {
+    params.log?.info(`Approval interaction outcome: ${params.content}`);
+    return;
+  }
+  try {
+    await sendText(target, params.content, params.creds, {
+      msgId: params.event.data.resolved.message_id,
+    });
+  } catch (err) {
+    params.log?.error(
+      `Approval outcome delivery failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}
+
+function formatCanonicalApprovalOutcome(approval: ApprovalResolveResult["approval"]): string {
+  if (approval.status === "allowed") {
+    return approval.decision === "allow-always" ? "Allowed always" : "Allowed once";
+  }
+  if (approval.status === "denied") {
+    return "Denied";
+  }
+  return approval.status === "expired" ? "Expired" : "Cancelled";
+}
+
+async function acknowledgeApprovalInteraction(
+  creds: { appId: string; clientSecret: string },
+  event: InteractionEvent,
+  log: EngineLogger | undefined,
+  data?: Record<string, unknown>,
+): Promise<void> {
+  try {
+    await acknowledgeInteraction(creds, event.id, 0, data);
+  } catch (err) {
+    log?.error(`Interaction ACK failed: ${err instanceof Error ? err.message : String(err)}`);
+  }
+}
+
+async function authorizeApprovalButtonActor(params: {
+  cfg: OpenClawConfig;
+  account: GatewayAccount;
+  event: InteractionEvent;
+  approvalKind: "exec" | "plugin";
+  resolveCommandAuthorized?: QQBotCommandAuthorizationResolver;
+}): Promise<{ authorized: boolean; reason?: string }> {
+  const senderIds = resolveApprovalActorSenderIds(params.event);
+  if (senderIds.length === 0) {
+    const result = authorizeQQBotApprovalAction({
+      cfg: params.cfg,
+      accountId: params.account.accountId,
+      senderId: null,
+      approvalKind: params.approvalKind,
+    });
+    return result.authorized && isImplicitSameChatApprovalAuthorization(result)
+      ? { authorized: false, reason: "You are not authorized to approve this request." }
+      : result;
+  }
+
+  let denial: { authorized: boolean; reason?: string } | undefined;
+  for (const senderId of senderIds) {
+    const result = authorizeQQBotApprovalAction({
+      cfg: params.cfg,
+      accountId: params.account.accountId,
+      senderId,
+      approvalKind: params.approvalKind,
+    });
+    if (result.authorized) {
+      if (
+        !isImplicitSameChatApprovalAuthorization(result) ||
+        (await isImplicitApprovalButtonActorAuthorized({
+          cfg: params.cfg,
+          account: params.account,
+          event: params.event,
+          senderId,
+          resolveCommandAuthorized: params.resolveCommandAuthorized,
+        }))
+      ) {
+        return result;
+      }
+      denial ??= {
+        authorized: false,
+        reason: "You are not authorized to approve this request.",
+      };
+      continue;
+    }
+    denial ??= result;
+  }
+  return denial ?? { authorized: false, reason: "You are not authorized to approve this request." };
+}
+
+async function isImplicitApprovalButtonActorAuthorized(params: {
+  cfg: OpenClawConfig;
+  account: GatewayAccount;
+  event: InteractionEvent;
+  senderId: string;
+  resolveCommandAuthorized?: QQBotCommandAuthorizationResolver;
+}): Promise<boolean> {
+  const accountConfig = resolveApprovalButtonAccountConfig(params.cfg, params.account.accountId);
+  const authInput = {
+    cfg: params.cfg,
+    accountId: params.account.accountId,
+    senderId: params.senderId,
+    isGroup: Boolean(params.event.group_openid),
+    conversationId: params.event.group_openid ?? params.event.user_openid ?? params.senderId,
+    allowFrom: accountConfig.allowFrom,
+    groupAllowFrom: accountConfig.groupAllowFrom,
+    commandsAllowFrom: resolveQQBotCommandsAllowFrom(params.cfg),
+  };
+  return params.resolveCommandAuthorized
+    ? await params.resolveCommandAuthorized(authInput)
+    : resolveSlashCommandAuth(authInput);
+}
+
+function resolveApprovalButtonAccountConfig(
+  cfg: OpenClawConfig,
+  accountId: string,
+): QQBotAccountConfigView {
+  const qqbot = readRecord(readRecord(cfg.channels)?.qqbot);
+  const accounts = readRecord(qqbot?.accounts);
+  if (accountId === "default") {
+    return {
+      ...qqbot,
+      ...readRecord(accounts?.default),
+    } as QQBotAccountConfigView;
+  }
+  return (readRecord(accounts?.[accountId]) ?? {}) as QQBotAccountConfigView;
+}
+
+function readRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function resolveApprovalActorSenderIds(event: InteractionEvent): string[] {
+  const ids = [event.group_member_openid, event.user_openid].flatMap((value) => {
+    const normalized = typeof value === "string" ? value.trim() : "";
+    return normalized ? [normalized] : [];
+  });
+  return uniqueStrings(ids);
+}
+
+/** Execute an async handler, ACK with the result, and handle errors. */
+async function handleWithAck(
+  creds: { appId: string; clientSecret: string },
+  event: InteractionEvent,
+  log: EngineLogger | undefined,
+  label: string,
+  handler: () => Record<string, unknown> | Promise<Record<string, unknown>>,
+): Promise<void> {
+  try {
+    const clawCfg = await handler();
+    await acknowledgeInteraction(creds, event.id, 0, { claw_cfg: clawCfg });
+    log?.info(`Interaction ACK (${label}) sent: ${event.id}`);
+  } catch (err) {
+    log?.error(`${label} interaction failed: ${err instanceof Error ? err.message : String(err)}`);
+    void acknowledgeInteraction(creds, event.id).catch(() => {});
+  }
+}

--- a/extensions/qqbot/src/engine/gateway/interaction-handler.ts
+++ b/extensions/qqbot/src/engine/gateway/interaction-handler.ts
@@ -414,15 +414,28 @@ async function authorizeApprovalButtonActor(params: {
       ) {
         return result;
       }
+      const isGroup = Boolean(params.event.group_openid);
       denial ??= {
         authorized: false,
-        reason: "You are not authorized to approve this request.",
+        reason: isGroup
+          ? "You are not authorized to approve this request."
+          : formatC2CApprovalDenialReason(senderId),
       };
       continue;
     }
     denial ??= result;
   }
   return denial ?? { authorized: false, reason: "You are not authorized to approve this request." };
+}
+
+function formatC2CApprovalDenialReason(senderId: string): string {
+  return (
+    `You are not authorized to approve this request.\n\n` +
+    `Your OpenID: ${senderId}\n\n` +
+    `To authorize approvals from this conversation, add this OpenID to ` +
+    `channels.qqbot.allowFrom or channels.qqbot.execApprovals.approvers ` +
+    `in your OpenClaw config. Use /bot-me to see your identity.`
+  );
 }
 
 async function isImplicitApprovalButtonActorAuthorized(params: {
@@ -432,12 +445,13 @@ async function isImplicitApprovalButtonActorAuthorized(params: {
   senderId: string;
   resolveCommandAuthorized?: QQBotCommandAuthorizationResolver;
 }): Promise<boolean> {
+  const isGroup = Boolean(params.event.group_openid);
   const accountConfig = resolveApprovalButtonAccountConfig(params.cfg, params.account.accountId);
   const authInput = {
     cfg: params.cfg,
     accountId: params.account.accountId,
     senderId: params.senderId,
-    isGroup: Boolean(params.event.group_openid),
+    isGroup,
     conversationId: params.event.group_openid ?? params.event.user_openid ?? params.senderId,
     allowFrom: accountConfig.allowFrom,
     groupAllowFrom: accountConfig.groupAllowFrom,


### PR DESCRIPTION
## What This Fixes

Direct (C2C) approval button rejections now surface the sender's OpenID with setup guidance so users can self-serve authorization instead of hitting opaque timeouts.

## Root Cause

When a C2C sender without explicit command authorization clicks an approval button, `authorizeApprovalButtonActor` returns a generic "You are not authorized to approve this request." message with no path to recovery. The user has no idea which OpenID to add to the allowlist.

## Fix

- Added `formatC2CApprovalDenialReason(senderId)` that includes the sender's OpenID and instructions for self-authorization
- In `authorizeApprovalButtonActor`, the implicit same-chat authorization denial path now detects C2C vs group and uses:
  - **C2C**: OpenID guidance message (includes sender's OpenID + instructions to add it to `channels.qqbot.allowFrom` or `channels.qqbot.execApprovals.approvers` + `/bot-me` pointer)
  - **Group**: Generic "not authorized" message (unchanged)

## Security

- Authorization boundary is **NOT** weakened — C2C senders must still be explicitly authorized
- Only the denial **message** changes (adds recovery guidance), not the authorization logic

## Changes

- `extensions/qqbot/src/engine/gateway/interaction-handler.ts`: `formatC2CApprovalDenialReason` helper + C2C detection in denial path
- `extensions/qqbot/src/engine/gateway/interaction-handler.test.ts`: 4 new C2C-specific tests covering no-allowlist, wildcard, matching, and non-matching allowlist scenarios