### PR TITLE
fix(plugins): preserve already-loaded plugins across scoped harness activation

### DIFF
--- a/src/agents/harness/runtime-plugin.eviction-e2e.test.ts
+++ b/src/agents/harness/runtime-plugin.eviction-e2e.test.ts
@@ -1,0 +1,129 @@
+// SCRATCH — evidence file for issue #107408. Not part of the permanent suite; deleted after use.
+//
+// Runs the REAL, production ensureSelectedAgentHarnessPlugin() (the function the fix patches)
+// against a REAL, unmocked plugin loader (loadOpenClawPlugins / activatePluginRegistry /
+// ensurePluginRegistryLoaded / resolveRuntimeCliBackends). The only mock is
+// resolveManifestActivationPlan (src/plugins/activation-planner.js), which resolves which
+// plugin owns a given agent-harness runtime id from static manifest metadata unrelated to the
+// loader/registry-swap mechanism under test — mocking it only avoids needing a real bundled
+// manifest fixture for a fake "harness-owner" runtime. Nothing in the loader itself is mocked.
+//
+// Same file, run unmodified on both branches:
+//   - main (unpatched):    scoped activation DROPS proof-backend-owner's cliBackend.
+//   - fix branch (patched): scoped activation PRESERVES it (unions in already-loaded plugins).
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { resolveRuntimeCliBackends } from "../../plugins/cli-backends.runtime.js";
+import {
+  makeTempDir,
+  resetPluginLoaderTestStateForTest,
+  useNoBundledPlugins,
+  writePlugin,
+} from "../../plugins/loader.test-fixtures.js";
+import {
+  ensurePluginRegistryLoaded,
+  __testing as runtimeRegistryLoaderTesting,
+} from "../../plugins/runtime/runtime-registry-loader.js";
+
+const mocks = vi.hoisted(() => ({
+  resolveManifestActivationPlan: vi.fn(),
+}));
+
+vi.mock("../../plugins/activation-planner.js", () => ({
+  resolveManifestActivationPlan: mocks.resolveManifestActivationPlan,
+}));
+
+describe("issue #107408 — ensureSelectedAgentHarnessPlugin, real loader, mocked manifest-plan only", () => {
+  let ensureSelectedAgentHarnessPlugin: typeof import("./runtime-plugin.js").ensureSelectedAgentHarnessPlugin;
+
+  beforeAll(async () => {
+    vi.resetModules();
+    ({ ensureSelectedAgentHarnessPlugin } = await import("./runtime-plugin.js"));
+  });
+
+  beforeEach(() => {
+    useNoBundledPlugins();
+    mocks.resolveManifestActivationPlan.mockReset();
+    mocks.resolveManifestActivationPlan.mockImplementation(
+      ({ trigger }: { trigger: { kind: string; runtime?: string } }) => {
+        if (trigger.kind === "agentHarness" && trigger.runtime === "harness-owner") {
+          return { entries: [{ pluginId: "harness-owner", origin: "bundled" }] };
+        }
+        return { entries: [] };
+      },
+    );
+  });
+
+  afterEach(() => {
+    resetPluginLoaderTestStateForTest();
+    runtimeRegistryLoaderTesting.resetPluginRegistryLoadedForTests();
+  });
+
+  it("scoped harness activation vs. an already-active unrelated plugin's CLI backend", async () => {
+    const workspaceDir = makeTempDir();
+    const pluginA = writePlugin({
+      id: "proof-backend-owner",
+      filename: "proof-backend-owner.cjs",
+      body: `module.exports = {
+        id: "proof-backend-owner",
+        register(api) {
+          api.registerCliBackend({ id: "proof-backend", config: { command: "proof" } });
+        },
+      };`,
+    });
+    const pluginH = writePlugin({
+      id: "harness-owner",
+      filename: "harness-owner.cjs",
+      body: `module.exports = { id: "harness-owner", register() {} };`,
+    });
+
+    const config = {
+      plugins: {
+        load: { paths: [pluginA.file, pluginH.file] },
+        allow: ["proof-backend-owner", "harness-owner"],
+        entries: {
+          "proof-backend-owner": { enabled: true },
+          "harness-owner": { enabled: true },
+          "memory-core": { enabled: false },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    // Establish the pre-existing active state exactly like a live gateway that already has
+    // proof-backend-owner running (this call is unscoped from ensureSelectedAgentHarnessPlugin's
+    // perspective; it is the "previously-active plugin" the bug silently evicts).
+    ensurePluginRegistryLoaded({
+      scope: "all",
+      workspaceDir,
+      config,
+      onlyPluginIds: ["proof-backend-owner"],
+    });
+    expect(resolveRuntimeCliBackends().map((b) => b.pluginId)).toContain("proof-backend-owner");
+
+    // The real, production call site (src/agents/harness/runtime-plugin.ts) — patched on the
+    // fix branch, unpatched on main. Everything it calls into (ensurePluginRegistryLoaded,
+    // loadOpenClawPlugins, activatePluginRegistry, listLoadedRuntimePluginIdsAcrossSurfaces) is
+    // real, unmocked core code.
+    await ensureSelectedAgentHarnessPlugin({
+      provider: "custom-provider",
+      modelId: "any-model",
+      agentHarnessRuntimeOverride: "harness-owner",
+      config,
+      workspaceDir,
+    });
+
+    const backendPluginIds = resolveRuntimeCliBackends().map((b) => b.pluginId);
+    // eslint-disable-next-line no-console
+    console.log(
+      "RESULT proof-backend-owner survives scoped harness activation:",
+      backendPluginIds.includes("proof-backend-owner"),
+      "| active cliBackend owners:",
+      JSON.stringify(backendPluginIds),
+    );
+
+    // On main (unpatched) this assertion FAILS: scoped activation replaces the active registry
+    // with only ["harness-owner"], dropping proof-backend-owner's cliBackend.
+    // On the fix branch this PASSES: alreadyLoadedPluginIds unions proof-backend-owner back in.
+    expect(backendPluginIds).toContain("proof-backend-owner");
+  });
+});

--- a/src/agents/harness/runtime-plugin.test.ts
+++ b/src/agents/harness/runtime-plugin.test.ts
@@ -1,9 +1,13 @@
 // Verifies plugin loading needed before agent harness selection.
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { resetAgentEventsForTest } from "../../infra/agent-events.js";
+import { getActiveRuntimePluginRegistry } from "../../plugins/active-runtime-registry.js";
+import { createEmptyPluginRegistry } from "../../plugins/registry-empty.js";
+import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../../plugins/runtime.js";
 
 const mocks = vi.hoisted(() => ({
-  ensurePluginRegistryLoaded: vi.fn(),
+  ensureScopedPluginsLoadedPreservingActive: vi.fn(),
   resolveActivatableProviderOwnerPluginIds: vi.fn(),
   resolveBundledProviderCompatPluginIds: vi.fn(),
   resolveManifestActivationPlan: vi.fn(),
@@ -11,7 +15,7 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock("../../plugins/runtime/runtime-registry-loader.js", () => ({
-  ensurePluginRegistryLoaded: mocks.ensurePluginRegistryLoaded,
+  ensureScopedPluginsLoadedPreservingActive: mocks.ensureScopedPluginsLoadedPreservingActive,
 }));
 
 vi.mock("../../plugins/providers.js", () => ({
@@ -34,7 +38,7 @@ describe("ensureSelectedAgentHarnessPlugin", () => {
   });
 
   beforeEach(() => {
-    mocks.ensurePluginRegistryLoaded.mockReset();
+    mocks.ensureScopedPluginsLoadedPreservingActive.mockReset();
     mocks.resolveActivatableProviderOwnerPluginIds.mockReset();
     mocks.resolveBundledProviderCompatPluginIds.mockReset();
     mocks.resolveManifestActivationPlan.mockReset();
@@ -92,9 +96,8 @@ describe("ensureSelectedAgentHarnessPlugin", () => {
       workspaceDir: "/tmp/workspace",
     });
 
-    expect(mocks.ensurePluginRegistryLoaded).toHaveBeenCalledWith(
+    expect(mocks.ensureScopedPluginsLoadedPreservingActive).toHaveBeenCalledWith(
       expect.objectContaining({
-        scope: "all",
         workspaceDir: "/tmp/workspace",
         onlyPluginIds: ["codex", "openai", "memory-core"],
       }),
@@ -115,9 +118,8 @@ describe("ensureSelectedAgentHarnessPlugin", () => {
       workspaceDir: "/tmp/workspace",
       requireExplicitManifestOwnerTrust: true,
     });
-    expect(mocks.ensurePluginRegistryLoaded).toHaveBeenCalledWith(
+    expect(mocks.ensureScopedPluginsLoadedPreservingActive).toHaveBeenCalledWith(
       expect.objectContaining({
-        scope: "all",
         workspaceDir: "/tmp/workspace",
         onlyPluginIds: expect.arrayContaining(["codex"]),
       }),
@@ -141,9 +143,8 @@ describe("ensureSelectedAgentHarnessPlugin", () => {
       workspaceDir: "/tmp/workspace",
     });
 
-    expect(mocks.ensurePluginRegistryLoaded).toHaveBeenCalledWith(
+    expect(mocks.ensureScopedPluginsLoadedPreservingActive).toHaveBeenCalledWith(
       expect.objectContaining({
-        scope: "all",
         workspaceDir: "/tmp/workspace",
         onlyPluginIds: ["codex", "openai", "memory-core"],
       }),
@@ -169,9 +170,8 @@ describe("ensureSelectedAgentHarnessPlugin", () => {
     });
 
     expect(mocks.resolveOwningPluginIdsForProvider).not.toHaveBeenCalled();
-    expect(mocks.ensurePluginRegistryLoaded).toHaveBeenCalledWith(
+    expect(mocks.ensureScopedPluginsLoadedPreservingActive).toHaveBeenCalledWith(
       expect.objectContaining({
-        scope: "all",
         workspaceDir: "/tmp/workspace",
         onlyPluginIds: ["copilot", "memory-core"],
         config: expect.objectContaining({
@@ -211,9 +211,8 @@ describe("ensureSelectedAgentHarnessPlugin", () => {
       workspaceDir: "/tmp/workspace",
       requireExplicitManifestOwnerTrust: true,
     });
-    expect(mocks.ensurePluginRegistryLoaded).toHaveBeenCalledWith(
+    expect(mocks.ensureScopedPluginsLoadedPreservingActive).toHaveBeenCalledWith(
       expect.objectContaining({
-        scope: "all",
         workspaceDir: "/tmp/workspace",
         onlyPluginIds: ["custom-harness-plugin", "memory-core"],
       }),
@@ -238,7 +237,7 @@ describe("ensureSelectedAgentHarnessPlugin", () => {
       workspaceDir: "/tmp/workspace",
       requireExplicitManifestOwnerTrust: true,
     });
-    expect(mocks.ensurePluginRegistryLoaded).not.toHaveBeenCalled();
+    expect(mocks.ensureScopedPluginsLoadedPreservingActive).not.toHaveBeenCalled();
   });
 
   it("does not bypass a restrictive allowlist that omits a configured Copilot harness", async () => {
@@ -267,7 +266,7 @@ describe("ensureSelectedAgentHarnessPlugin", () => {
       workspaceDir: "/tmp/workspace",
     });
 
-    expect(mocks.ensurePluginRegistryLoaded).not.toHaveBeenCalled();
+    expect(mocks.ensureScopedPluginsLoadedPreservingActive).not.toHaveBeenCalled();
   });
 
   it("widens a scoped harness allowlist with the provider owner for openai models", async () => {
@@ -285,9 +284,8 @@ describe("ensureSelectedAgentHarnessPlugin", () => {
       workspaceDir: "/tmp/workspace",
     });
 
-    expect(mocks.ensurePluginRegistryLoaded).toHaveBeenCalledWith(
+    expect(mocks.ensureScopedPluginsLoadedPreservingActive).toHaveBeenCalledWith(
       expect.objectContaining({
-        scope: "all",
         workspaceDir: "/tmp/workspace",
         onlyPluginIds: ["codex", "openai"],
         config: expect.objectContaining({
@@ -319,9 +317,8 @@ describe("ensureSelectedAgentHarnessPlugin", () => {
       workspaceDir: "/tmp/workspace",
     });
 
-    expect(mocks.ensurePluginRegistryLoaded).toHaveBeenCalledWith(
+    expect(mocks.ensureScopedPluginsLoadedPreservingActive).toHaveBeenCalledWith(
       expect.objectContaining({
-        scope: "all",
         workspaceDir: "/tmp/workspace",
         onlyPluginIds: ["codex", "openai", "memory-core"],
         config: expect.objectContaining({
@@ -358,9 +355,8 @@ describe("ensureSelectedAgentHarnessPlugin", () => {
     expect(mocks.resolveActivatableProviderOwnerPluginIds).not.toHaveBeenCalledWith(
       expect.objectContaining({ pluginIds: ["workspace-memory"] }),
     );
-    expect(mocks.ensurePluginRegistryLoaded).toHaveBeenCalledWith(
+    expect(mocks.ensureScopedPluginsLoadedPreservingActive).toHaveBeenCalledWith(
       expect.objectContaining({
-        scope: "all",
         workspaceDir: "/tmp/workspace",
         onlyPluginIds: ["codex", "openai"],
         config: expect.objectContaining({
@@ -405,9 +401,8 @@ describe("ensureSelectedAgentHarnessPlugin", () => {
       config: expect.any(Object),
       workspaceDir: "/tmp/workspace",
     });
-    expect(mocks.ensurePluginRegistryLoaded).toHaveBeenCalledWith(
+    expect(mocks.ensureScopedPluginsLoadedPreservingActive).toHaveBeenCalledWith(
       expect.objectContaining({
-        scope: "all",
         workspaceDir: "/tmp/workspace",
         onlyPluginIds: ["codex", "openai"],
       }),
@@ -432,7 +427,7 @@ describe("ensureSelectedAgentHarnessPlugin", () => {
     expect(mocks.resolveOwningPluginIdsForProvider).not.toHaveBeenCalled();
     expect(mocks.resolveBundledProviderCompatPluginIds).not.toHaveBeenCalled();
     expect(mocks.resolveActivatableProviderOwnerPluginIds).not.toHaveBeenCalled();
-    expect(mocks.ensurePluginRegistryLoaded).not.toHaveBeenCalled();
+    expect(mocks.ensureScopedPluginsLoadedPreservingActive).not.toHaveBeenCalled();
   });
 
   it("keeps real bundled memory-core in a Codex scoped load when the provider has no owner plugin", async () => {
@@ -447,9 +442,8 @@ describe("ensureSelectedAgentHarnessPlugin", () => {
 
     expect(mocks.resolveBundledProviderCompatPluginIds).not.toHaveBeenCalled();
     expect(mocks.resolveActivatableProviderOwnerPluginIds).not.toHaveBeenCalled();
-    expect(mocks.ensurePluginRegistryLoaded).toHaveBeenCalledWith(
+    expect(mocks.ensureScopedPluginsLoadedPreservingActive).toHaveBeenCalledWith(
       expect.objectContaining({
-        scope: "all",
         workspaceDir: "/tmp/workspace",
         onlyPluginIds: ["codex", "memory-core"],
       }),
@@ -473,7 +467,7 @@ describe("ensureSelectedAgentHarnessPlugin", () => {
       workspaceDir: "/tmp/workspace",
     });
 
-    expect(mocks.ensurePluginRegistryLoaded).not.toHaveBeenCalled();
+    expect(mocks.ensureScopedPluginsLoadedPreservingActive).not.toHaveBeenCalled();
     expect(mocks.resolveOwningPluginIdsForProvider).not.toHaveBeenCalled();
   });
 
@@ -495,7 +489,7 @@ describe("ensureSelectedAgentHarnessPlugin", () => {
       workspaceDir: "/tmp/workspace",
     });
 
-    expect(mocks.ensurePluginRegistryLoaded).not.toHaveBeenCalled();
+    expect(mocks.ensureScopedPluginsLoadedPreservingActive).not.toHaveBeenCalled();
     expect(mocks.resolveOwningPluginIdsForProvider).not.toHaveBeenCalled();
   });
 
@@ -517,8 +511,86 @@ describe("ensureSelectedAgentHarnessPlugin", () => {
       workspaceDir: "/tmp/workspace",
     });
 
-    expect(mocks.ensurePluginRegistryLoaded).not.toHaveBeenCalled();
+    expect(mocks.ensureScopedPluginsLoadedPreservingActive).not.toHaveBeenCalled();
     expect(mocks.resolveOwningPluginIdsForProvider).not.toHaveBeenCalled();
     expect(mocks.resolveManifestActivationPlan).not.toHaveBeenCalled();
+  });
+
+  describe("scoped load eviction (openclaw/openclaw#107408)", () => {
+    function createRegistryWithLoadedPlugin(pluginId: string) {
+      const registry = createEmptyPluginRegistry();
+      registry.plugins = [{ id: pluginId, status: "loaded", format: "bundle" } as never];
+      registry.cliBackends = [
+        { pluginId, backend: { id: pluginId } as never, source: pluginId } as never,
+      ];
+      return registry;
+    }
+
+    afterEach(() => {
+      resetAgentEventsForTest();
+      resetPluginRuntimeStateForTest();
+    });
+
+    it("delegates to ensureScopedPluginsLoadedPreservingActive with only the harness-owned ids, never widening onlyPluginIds with already-active plugin ids", async () => {
+      // Regression for #107408: the original fix widened onlyPluginIds with
+      // every currently-active plugin id so a scoped-load swap wouldn't evict
+      // them — but that meant a load miss re-ran register() for every one of
+      // them (duplicate service/hook init, see issue #52031). Preserving
+      // already-active plugins is now ensureScopedPluginsLoadedPreservingActive's
+      // job (it loads only the ids missing from the active registry and merges
+      // them in without re-registering anything already there — see
+      // registry-scoped-merge.ts and its stateful-lifecycle coverage in
+      // runtime-registry-loader.merge.test.ts). ensureSelectedAgentHarnessPlugin
+      // itself must stay decoupled from what else happens to be active.
+      const activeRegistry = createRegistryWithLoadedPlugin("unrelated-plugin");
+      setActivePluginRegistry(activeRegistry);
+
+      await ensureSelectedAgentHarnessPlugin({
+        provider: "custom-provider",
+        modelId: "gpt-5.5",
+        agentHarnessRuntimeOverride: "codex",
+        workspaceDir: "/tmp/workspace",
+      });
+
+      expect(mocks.ensureScopedPluginsLoadedPreservingActive).toHaveBeenCalledWith(
+        expect.objectContaining({
+          workspaceDir: "/tmp/workspace",
+          onlyPluginIds: ["codex", "memory-core"],
+        }),
+      );
+      // ensureSelectedAgentHarnessPlugin itself never touches the active
+      // registry directly — preservation is entirely
+      // ensureScopedPluginsLoadedPreservingActive's responsibility.
+      expect(getActiveRuntimePluginRegistry()).toBe(activeRegistry);
+      expect(
+        getActiveRuntimePluginRegistry()?.cliBackends.map((entry) => entry.pluginId),
+      ).toContain("unrelated-plugin");
+    });
+
+    it("keeps onlyPluginIds narrow even under a restrictive allowlist and an unrelated active plugin", async () => {
+      const activeRegistry = createRegistryWithLoadedPlugin("unrelated-plugin");
+      setActivePluginRegistry(activeRegistry);
+
+      await ensureSelectedAgentHarnessPlugin({
+        provider: "custom-provider",
+        modelId: "gpt-5.5",
+        agentHarnessRuntimeOverride: "codex",
+        config: {
+          plugins: {
+            allow: ["codex", "memory-core"],
+            entries: {
+              codex: { enabled: true },
+            },
+          },
+        } as OpenClawConfig,
+        workspaceDir: "/tmp/workspace",
+      });
+
+      expect(mocks.ensureScopedPluginsLoadedPreservingActive).toHaveBeenCalledWith(
+        expect.objectContaining({
+          onlyPluginIds: ["codex", "memory-core"],
+        }),
+      );
+    });
   });
 });

--- a/src/agents/harness/runtime-plugin.test.ts
+++ b/src/agents/harness/runtime-plugin.test.ts
@@ -1,6 +1,10 @@
 // Verifies plugin loading needed before agent harness selection.
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { resetAgentEventsForTest } from "../../infra/agent-events.js";
+import { getActiveRuntimePluginRegistry } from "../../plugins/active-runtime-registry.js";
+import { createEmptyPluginRegistry } from "../../plugins/registry-empty.js";
+import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../../plugins/runtime.js";
 
 const mocks = vi.hoisted(() => ({
   ensurePluginRegistryLoaded: vi.fn(),
@@ -520,5 +524,76 @@ describe("ensureSelectedAgentHarnessPlugin", () => {
     expect(mocks.ensurePluginRegistryLoaded).not.toHaveBeenCalled();
     expect(mocks.resolveOwningPluginIdsForProvider).not.toHaveBeenCalled();
     expect(mocks.resolveManifestActivationPlan).not.toHaveBeenCalled();
+  });
+
+  describe("scoped load eviction", () => {
+    function createRegistryWithLoadedPlugin(pluginId: string) {
+      const registry = createEmptyPluginRegistry();
+      registry.plugins = [{ id: pluginId, status: "loaded", format: "bundle" } as never];
+      registry.cliBackends = [
+        { pluginId, backend: { id: pluginId } as never, source: pluginId } as never,
+      ];
+      return registry;
+    }
+
+    afterEach(() => {
+      resetAgentEventsForTest();
+      resetPluginRuntimeStateForTest();
+    });
+
+    it("unions an already-loaded plugin into the scoped harness load instead of letting the swap evict it", async () => {
+      const activeRegistry = createRegistryWithLoadedPlugin("unrelated-plugin");
+      setActivePluginRegistry(activeRegistry);
+
+      await ensureSelectedAgentHarnessPlugin({
+        provider: "custom-provider",
+        modelId: "gpt-5.5",
+        agentHarnessRuntimeOverride: "codex",
+        workspaceDir: "/tmp/workspace",
+      });
+
+      expect(mocks.ensurePluginRegistryLoaded).toHaveBeenCalledWith(
+        expect.objectContaining({
+          scope: "all",
+          workspaceDir: "/tmp/workspace",
+          onlyPluginIds: ["codex", "memory-core", "unrelated-plugin"],
+        }),
+      );
+      // ensurePluginRegistryLoaded (mocked here; its real swap/eviction mechanics
+      // are covered by runtime.channel-pin.test.ts) is the only thing allowed to
+      // replace the active registry. This confirms ensureSelectedAgentHarnessPlugin
+      // itself never drops the already-active registry before delegating to it,
+      // and that "unrelated-plugin" was passed through so a real load would keep it.
+      expect(getActiveRuntimePluginRegistry()).toBe(activeRegistry);
+      expect(
+        getActiveRuntimePluginRegistry()?.cliBackends.map((entry) => entry.pluginId),
+      ).toContain("unrelated-plugin");
+    });
+
+    it("does not resurrect an already-loaded plugin excluded by a restrictive allowlist", async () => {
+      const activeRegistry = createRegistryWithLoadedPlugin("unrelated-plugin");
+      setActivePluginRegistry(activeRegistry);
+
+      await ensureSelectedAgentHarnessPlugin({
+        provider: "custom-provider",
+        modelId: "gpt-5.5",
+        agentHarnessRuntimeOverride: "codex",
+        config: {
+          plugins: {
+            allow: ["codex", "memory-core"],
+            entries: {
+              codex: { enabled: true },
+            },
+          },
+        } as OpenClawConfig,
+        workspaceDir: "/tmp/workspace",
+      });
+
+      expect(mocks.ensurePluginRegistryLoaded).toHaveBeenCalledWith(
+        expect.objectContaining({
+          onlyPluginIds: ["codex", "memory-core"],
+        }),
+      );
+    });
   });
 });

--- a/src/agents/harness/runtime-plugin.test.ts
+++ b/src/agents/harness/runtime-plugin.test.ts
@@ -1,10 +1,6 @@
 // Verifies plugin loading needed before agent harness selection.
-import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import { resetAgentEventsForTest } from "../../infra/agent-events.js";
-import { getActiveRuntimePluginRegistry } from "../../plugins/active-runtime-registry.js";
-import { createEmptyPluginRegistry } from "../../plugins/registry-empty.js";
-import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../../plugins/runtime.js";
 
 const mocks = vi.hoisted(() => ({
   ensurePluginRegistryLoaded: vi.fn(),
@@ -524,76 +520,5 @@ describe("ensureSelectedAgentHarnessPlugin", () => {
     expect(mocks.ensurePluginRegistryLoaded).not.toHaveBeenCalled();
     expect(mocks.resolveOwningPluginIdsForProvider).not.toHaveBeenCalled();
     expect(mocks.resolveManifestActivationPlan).not.toHaveBeenCalled();
-  });
-
-  describe("scoped load eviction", () => {
-    function createRegistryWithLoadedPlugin(pluginId: string) {
-      const registry = createEmptyPluginRegistry();
-      registry.plugins = [{ id: pluginId, status: "loaded", format: "bundle" } as never];
-      registry.cliBackends = [
-        { pluginId, backend: { id: pluginId } as never, source: pluginId } as never,
-      ];
-      return registry;
-    }
-
-    afterEach(() => {
-      resetAgentEventsForTest();
-      resetPluginRuntimeStateForTest();
-    });
-
-    it("unions an already-loaded plugin into the scoped harness load instead of letting the swap evict it", async () => {
-      const activeRegistry = createRegistryWithLoadedPlugin("unrelated-plugin");
-      setActivePluginRegistry(activeRegistry);
-
-      await ensureSelectedAgentHarnessPlugin({
-        provider: "custom-provider",
-        modelId: "gpt-5.5",
-        agentHarnessRuntimeOverride: "codex",
-        workspaceDir: "/tmp/workspace",
-      });
-
-      expect(mocks.ensurePluginRegistryLoaded).toHaveBeenCalledWith(
-        expect.objectContaining({
-          scope: "all",
-          workspaceDir: "/tmp/workspace",
-          onlyPluginIds: ["codex", "memory-core", "unrelated-plugin"],
-        }),
-      );
-      // ensurePluginRegistryLoaded (mocked here; its real swap/eviction mechanics
-      // are covered by runtime.channel-pin.test.ts) is the only thing allowed to
-      // replace the active registry. This confirms ensureSelectedAgentHarnessPlugin
-      // itself never drops the already-active registry before delegating to it,
-      // and that "unrelated-plugin" was passed through so a real load would keep it.
-      expect(getActiveRuntimePluginRegistry()).toBe(activeRegistry);
-      expect(
-        getActiveRuntimePluginRegistry()?.cliBackends.map((entry) => entry.pluginId),
-      ).toContain("unrelated-plugin");
-    });
-
-    it("does not resurrect an already-loaded plugin excluded by a restrictive allowlist", async () => {
-      const activeRegistry = createRegistryWithLoadedPlugin("unrelated-plugin");
-      setActivePluginRegistry(activeRegistry);
-
-      await ensureSelectedAgentHarnessPlugin({
-        provider: "custom-provider",
-        modelId: "gpt-5.5",
-        agentHarnessRuntimeOverride: "codex",
-        config: {
-          plugins: {
-            allow: ["codex", "memory-core"],
-            entries: {
-              codex: { enabled: true },
-            },
-          },
-        } as OpenClawConfig,
-        workspaceDir: "/tmp/workspace",
-      });
-
-      expect(mocks.ensurePluginRegistryLoaded).toHaveBeenCalledWith(
-        expect.objectContaining({
-          onlyPluginIds: ["codex", "memory-core"],
-        }),
-      );
-    });
   });
 });

--- a/src/agents/harness/runtime-plugin.ts
+++ b/src/agents/harness/runtime-plugin.ts
@@ -5,7 +5,6 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { ProviderRouteOverridePresence } from "../../plugin-sdk/provider-model-types.js";
 import { withActivatedPluginIds } from "../../plugins/activation-context.js";
 import { resolveManifestActivationPlan } from "../../plugins/activation-planner.js";
-import { listLoadedRuntimePluginIdsAcrossSurfaces } from "../../plugins/active-runtime-registry.js";
 import { resolveEffectivePluginActivationState } from "../../plugins/config-state.js";
 import { isPluginEnabledByDefaultForPlatform } from "../../plugins/default-enablement.js";
 import {
@@ -206,20 +205,7 @@ export async function ensureSelectedAgentHarnessPlugin(params: {
     config: params.config,
     workspaceDir: params.workspaceDir,
   });
-  // A scoped load below replaces the entire active plugin registry with one
-  // containing only scopedPluginIds (see loadOpenClawPlugins/activatePluginRegistry).
-  // Union in ids already loaded across live registry surfaces so that swap
-  // never silently evicts an unrelated plugin's cliBackends/providers. Still
-  // gated through the same allowlist check used for the harness's own ids, so
-  // a plugin disabled by a live config change is not resurrected.
-  const alreadyLoadedPluginIds = listLoadedRuntimePluginIdsAcrossSurfaces().filter(
-    (pluginId) => !restrictiveAllowlistOmitsPlugin(params.config, pluginId),
-  );
-  const scopedPluginIds = dedupePluginIds([
-    ...pluginIds,
-    ...memoryPluginIds,
-    ...alreadyLoadedPluginIds,
-  ]);
+  const scopedPluginIds = dedupePluginIds([...pluginIds, ...memoryPluginIds]);
   const configWithAllowedRuntimePlugins = withRuntimePluginIdsAllowed({
     config: params.config,
     requiredPluginId: runtime,

--- a/src/agents/harness/runtime-plugin.ts
+++ b/src/agents/harness/runtime-plugin.ts
@@ -5,6 +5,7 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { ProviderRouteOverridePresence } from "../../plugin-sdk/provider-model-types.js";
 import { withActivatedPluginIds } from "../../plugins/activation-context.js";
 import { resolveManifestActivationPlan } from "../../plugins/activation-planner.js";
+import { listLoadedRuntimePluginIdsAcrossSurfaces } from "../../plugins/active-runtime-registry.js";
 import { resolveEffectivePluginActivationState } from "../../plugins/config-state.js";
 import { isPluginEnabledByDefaultForPlatform } from "../../plugins/default-enablement.js";
 import {
@@ -205,7 +206,20 @@ export async function ensureSelectedAgentHarnessPlugin(params: {
     config: params.config,
     workspaceDir: params.workspaceDir,
   });
-  const scopedPluginIds = dedupePluginIds([...pluginIds, ...memoryPluginIds]);
+  // A scoped load below replaces the entire active plugin registry with one
+  // containing only scopedPluginIds (see loadOpenClawPlugins/activatePluginRegistry).
+  // Union in ids already loaded across live registry surfaces so that swap
+  // never silently evicts an unrelated plugin's cliBackends/providers. Still
+  // gated through the same allowlist check used for the harness's own ids, so
+  // a plugin disabled by a live config change is not resurrected.
+  const alreadyLoadedPluginIds = listLoadedRuntimePluginIdsAcrossSurfaces().filter(
+    (pluginId) => !restrictiveAllowlistOmitsPlugin(params.config, pluginId),
+  );
+  const scopedPluginIds = dedupePluginIds([
+    ...pluginIds,
+    ...memoryPluginIds,
+    ...alreadyLoadedPluginIds,
+  ]);
   const configWithAllowedRuntimePlugins = withRuntimePluginIdsAllowed({
     config: params.config,
     requiredPluginId: runtime,

--- a/src/agents/harness/runtime-plugin.ts
+++ b/src/agents/harness/runtime-plugin.ts
@@ -190,7 +190,7 @@ export async function ensureSelectedAgentHarnessPlugin(params: {
     return;
   }
 
-  const { ensurePluginRegistryLoaded } =
+  const { ensureScopedPluginsLoadedPreservingActive } =
     await import("../../plugins/runtime/runtime-registry-loader.js");
   const pluginIds = resolveAgentHarnessOwnerPluginIds({
     runtime,
@@ -216,8 +216,13 @@ export async function ensureSelectedAgentHarnessPlugin(params: {
       config: configWithAllowedRuntimePlugins,
       pluginIds: scopedPluginIds,
     }) ?? configWithAllowedRuntimePlugins;
-  ensurePluginRegistryLoaded({
-    scope: "all",
+  // ensureScopedPluginsLoadedPreservingActive loads only the ids in
+  // scopedPluginIds that aren't already active and merges them into the live
+  // registry in place, instead of a scoped load replacing the entire active
+  // registry with one containing only scopedPluginIds — which would evict
+  // every other already-active plugin's cliBackends/providers/services
+  // (openclaw/openclaw#107408). See its doc comment for the mechanism.
+  ensureScopedPluginsLoadedPreservingActive({
     ...(activatedConfig
       ? {
           config: activatedConfig,

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -187,6 +187,21 @@ export type PluginLoadOptions = {
   preferBuiltPluginArtifacts?: boolean;
   toolDiscovery?: boolean;
   activate?: boolean;
+  /**
+   * Set false to run a full (`activate: true`) registration pass — real
+   * registrar side effects (activateGlobalSideEffects stays tied to
+   * `activate`) — without publishing the result as the live active registry:
+   * skips clearActivatedPluginRuntimeState() and the final
+   * activatePluginRegistry() call that would otherwise swap
+   * getActivePluginRegistry() to this result and retire whatever was active
+   * before it. Used by scoped-load callers that build a standalone registry
+   * for a plugin id subset and merge its registrations into the already
+   * active registry themselves, instead of letting a scoped load silently
+   * replace (and retire/cleanup) it — see
+   * ensureScopedPluginsLoadedPreservingActive in
+   * runtime/runtime-registry-loader.ts. Defaults to true.
+   */
+  publish?: boolean;
   loadModules?: boolean;
   throwOnLoadError?: boolean;
   manifestRegistry?: PluginManifestRegistry;
@@ -1459,7 +1474,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
   const requestedOnlyPluginIdSet = createPluginIdScopeSet(requestedOnlyPluginIds);
   if (requestedOnlyPluginIdSet && requestedOnlyPluginIdSet.size === 0) {
     const emptyRegistry = createEmptyPluginRegistry();
-    if (options.activate !== false) {
+    if (options.activate !== false && options.publish !== false) {
       clearActivatedPluginRuntimeState();
       activatePluginRegistry(
         emptyRegistry,
@@ -1504,7 +1519,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
       options,
     });
     if (cached) {
-      if (shouldActivate) {
+      if (shouldActivate && options.publish !== false) {
         restorePluginProcessGlobalState(cached.state.processGlobalState);
         activatePluginRegistry(
           cached.state.registry,
@@ -1520,7 +1535,12 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
   try {
     // Clear previously registered plugin state before reloading.
     // Skip for non-activating (snapshot) loads to avoid wiping commands from other plugins.
-    if (shouldActivate) {
+    // Also skip for publish:false loads (a standalone registry built to be merged
+    // into the active one by the caller — see PluginLoadOptions.publish) so a
+    // scoped merge-load never wipes other plugins' global singleton state
+    // (agent harnesses, plugin commands, etc.) out from under the still-active
+    // registry it is being merged into.
+    if (shouldActivate && options.publish !== false) {
       clearActivatedPluginRuntimeState();
     }
 
@@ -2561,7 +2581,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
         onlyPluginIds,
       );
     }
-    if (shouldActivate) {
+    if (shouldActivate && options.publish !== false) {
       activatePluginRegistry(registry, cacheKey, runtimeSubagentMode, options.workspaceDir);
     }
     return registry;

--- a/src/plugins/registry-scoped-merge.test.ts
+++ b/src/plugins/registry-scoped-merge.test.ts
@@ -1,0 +1,116 @@
+// Verifies the pure registry-merge helper used by scoped harness loads to
+// preserve already-active plugins (openclaw/openclaw#107408) without
+// re-registering them.
+import { describe, expect, it } from "vitest";
+import { createEmptyPluginRegistry } from "./registry-empty.js";
+import { mergeMissingPluginRegistryInto } from "./registry-scoped-merge.js";
+import type { PluginRegistry } from "./registry-types.js";
+
+function registryWithPlugin(pluginId: string, cliBackendId = `${pluginId}-cli`): PluginRegistry {
+  const registry = createEmptyPluginRegistry();
+  registry.plugins.push({
+    id: pluginId,
+    name: pluginId,
+    source: `${pluginId}.js`,
+    origin: "workspace",
+    enabled: true,
+    status: "loaded",
+  } as never);
+  registry.cliBackends.push({
+    pluginId,
+    backend: { id: cliBackendId } as never,
+    source: `${pluginId}.js`,
+  } as never);
+  registry.workerProviders.set(`${pluginId}-worker`, {
+    pluginId,
+    provider: { id: `${pluginId}-worker` } as never,
+    source: `${pluginId}.js`,
+  } as never);
+  registry.gatewayHandlers[`${pluginId}.method`] = (() => {}) as never;
+  return registry;
+}
+
+describe("mergeMissingPluginRegistryInto", () => {
+  it("copies the missing plugin's registrations into the target without touching existing ones", () => {
+    const target = registryWithPlugin("already-active");
+    const source = registryWithPlugin("newly-loaded");
+
+    mergeMissingPluginRegistryInto(target, source, ["newly-loaded"]);
+
+    expect(target.plugins.map((p) => p.id).toSorted()).toEqual(["already-active", "newly-loaded"]);
+    expect(target.cliBackends.map((entry) => entry.pluginId).toSorted()).toEqual([
+      "already-active",
+      "newly-loaded",
+    ]);
+    expect([...target.workerProviders.keys()].toSorted()).toEqual([
+      "already-active-worker",
+      "newly-loaded-worker",
+    ]);
+    expect(Object.keys(target.gatewayHandlers).toSorted()).toEqual([
+      "already-active.method",
+      "newly-loaded.method",
+    ]);
+  });
+
+  it("ignores source entries whose pluginId is not in missingPluginIds", () => {
+    const target = registryWithPlugin("already-active");
+    const source = registryWithPlugin("newly-loaded");
+    // Source also carries an id outside the requested scope — must not leak in.
+    source.plugins.push({
+      id: "bystander",
+      name: "bystander",
+      source: "bystander.js",
+      origin: "workspace",
+      enabled: true,
+      status: "loaded",
+    } as never);
+    source.cliBackends.push({
+      pluginId: "bystander",
+      backend: { id: "bystander-cli" } as never,
+      source: "bystander.js",
+    } as never);
+
+    mergeMissingPluginRegistryInto(target, source, ["newly-loaded"]);
+
+    expect(target.plugins.map((p) => p.id).toSorted()).toEqual(["already-active", "newly-loaded"]);
+    expect(target.cliBackends.map((entry) => entry.pluginId)).not.toContain("bystander");
+  });
+
+  it("replaces a stale disabled/error record for the same plugin id instead of duplicating it", () => {
+    const target = createEmptyPluginRegistry();
+    target.plugins.push({
+      id: "retry-me",
+      name: "retry-me",
+      source: "retry-me.js",
+      origin: "workspace",
+      enabled: false,
+      status: "error",
+      error: "boom",
+    } as never);
+    const source = registryWithPlugin("retry-me");
+
+    mergeMissingPluginRegistryInto(target, source, ["retry-me"]);
+
+    expect(target.plugins).toHaveLength(1);
+    expect(target.plugins[0]?.status).toBe("loaded");
+  });
+
+  it("is a no-op for an empty missing-id list", () => {
+    const target = registryWithPlugin("already-active");
+    const source = registryWithPlugin("newly-loaded");
+
+    mergeMissingPluginRegistryInto(target, source, []);
+
+    expect(target.plugins.map((p) => p.id)).toEqual(["already-active"]);
+  });
+
+  it("does not duplicate a worker provider or gateway handler key already present in target", () => {
+    const target = registryWithPlugin("newly-loaded");
+    const source = registryWithPlugin("newly-loaded");
+
+    mergeMissingPluginRegistryInto(target, source, ["newly-loaded"]);
+
+    expect([...target.workerProviders.keys()]).toEqual(["newly-loaded-worker"]);
+    expect(Object.keys(target.gatewayHandlers)).toEqual(["newly-loaded.method"]);
+  });
+});

--- a/src/plugins/registry-scoped-merge.ts
+++ b/src/plugins/registry-scoped-merge.ts
@@ -1,0 +1,86 @@
+// Merges a standalone (publish:false) plugin registry, built for a specific
+// set of missing plugin ids, into an already-active plugin registry without
+// touching that active registry's existing entries. Used by scoped harness
+// activation (see ensureScopedPluginsLoadedPreservingActive) so a plugin id
+// that isn't yet loaded can be added to the live registry without evicting
+// (and re-registering) every other plugin already active in it.
+import type { PluginRecord, PluginRegistry } from "./registry-types.js";
+
+function hasStringPluginId(value: unknown): value is { pluginId: string } {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    typeof (value as { pluginId?: unknown }).pluginId === "string"
+  );
+}
+
+function mergePluginRecords(
+  target: PluginRecord[],
+  source: readonly PluginRecord[],
+  missingPluginIds: ReadonlySet<string>,
+): void {
+  for (const record of source) {
+    if (!missingPluginIds.has(record.id)) {
+      continue;
+    }
+    // Replace rather than duplicate: a stale disabled/error record can already
+    // exist for a plugin id that previously failed to load in the active
+    // registry.
+    const staleIndex = target.findIndex((existing) => existing.id === record.id);
+    if (staleIndex >= 0) {
+      target.splice(staleIndex, 1);
+    }
+    target.push(record);
+  }
+}
+
+/**
+ * Mutates `target` (the live active registry) in place, copying in every
+ * registration from `source` (a standalone registry loaded with
+ * `onlyPluginIds: missingPluginIds, publish: false`) that belongs to one of
+ * `missingPluginIds`. Entries already present in `target` are left untouched
+ * — this never re-adds or duplicates a plugin id `target` already has.
+ */
+export function mergeMissingPluginRegistryInto(
+  target: PluginRegistry,
+  source: PluginRegistry,
+  missingPluginIds: readonly string[],
+): void {
+  const missing = new Set(missingPluginIds);
+  if (missing.size === 0) {
+    return;
+  }
+
+  mergePluginRecords(target.plugins, source.plugins, missing);
+
+  for (const key of Object.keys(target) as (keyof PluginRegistry)[]) {
+    if (key === "plugins") {
+      continue;
+    }
+    const targetValue = target[key];
+    const sourceValue = source[key];
+    if (!Array.isArray(targetValue) || !Array.isArray(sourceValue)) {
+      // Non-array surfaces (workerProviders is a Map, gatewayHandlers is a
+      // plain object keyed by method name, coreGatewayMethodNames is a flat
+      // string[] with no per-entry pluginId) are handled explicitly below.
+      continue;
+    }
+    for (const entry of sourceValue) {
+      if (hasStringPluginId(entry) && missing.has(entry.pluginId)) {
+        (targetValue as unknown[]).push(entry);
+      }
+    }
+  }
+
+  for (const [providerId, registration] of source.workerProviders) {
+    if (missing.has(registration.pluginId) && !target.workerProviders.has(providerId)) {
+      target.workerProviders.set(providerId, registration);
+    }
+  }
+
+  for (const [methodName, handler] of Object.entries(source.gatewayHandlers)) {
+    if (!(methodName in target.gatewayHandlers)) {
+      target.gatewayHandlers[methodName] = handler;
+    }
+  }
+}

--- a/src/plugins/runtime/runtime-registry-loader.merge.test.ts
+++ b/src/plugins/runtime/runtime-registry-loader.merge.test.ts
@@ -1,0 +1,186 @@
+// Verifies ensureScopedPluginsLoadedPreservingActive against real plugin
+// loading (no mocks): a scoped harness-activation load must not evict, or
+// re-register, an unrelated plugin that is already active
+// (openclaw/openclaw#107408).
+import { afterAll, afterEach, describe, expect, it } from "vitest";
+import { loadOpenClawPlugins } from "../loader.js";
+import {
+  cleanupPluginLoaderFixturesForTest,
+  makeTempDir,
+  resetPluginLoaderTestStateForTest,
+  useNoBundledPlugins,
+  writePlugin,
+} from "../loader.test-fixtures.js";
+import { getActivePluginRegistry, resetPluginRuntimeStateForTest } from "../runtime.js";
+import { ensureScopedPluginsLoadedPreservingActive } from "./runtime-registry-loader.js";
+
+const REGISTER_COUNT_KEY = "__pr107596UnrelatedPluginRegisterCount";
+
+function unrelatedPluginRegisterCount(): number {
+  return ((globalThis as Record<string, unknown>)[REGISTER_COUNT_KEY] as number | undefined) ?? 0;
+}
+
+afterEach(() => {
+  delete (globalThis as Record<string, unknown>)[REGISTER_COUNT_KEY];
+  resetPluginRuntimeStateForTest();
+  resetPluginLoaderTestStateForTest();
+});
+
+afterAll(() => {
+  cleanupPluginLoaderFixturesForTest();
+});
+
+describe("ensureScopedPluginsLoadedPreservingActive", () => {
+  it("preserves an already-active unrelated plugin's registrations across a scoped load for a missing plugin", async () => {
+    useNoBundledPlugins();
+    const workspaceDir = makeTempDir();
+    const unrelated = writePlugin({
+      id: "unrelated-plugin",
+      filename: "unrelated-plugin.cjs",
+      body: `module.exports = {
+        id: "unrelated-plugin",
+        register(api) {
+          globalThis[${JSON.stringify(REGISTER_COUNT_KEY)}] =
+            (globalThis[${JSON.stringify(REGISTER_COUNT_KEY)}] || 0) + 1;
+          api.registerCliBackend({ id: "unrelated-cli", config: { command: "unrelated" } });
+        },
+      };`,
+    });
+    const harnessOwner = writePlugin({
+      id: "harness-owner-plugin",
+      filename: "harness-owner-plugin.cjs",
+      body: `module.exports = {
+        id: "harness-owner-plugin",
+        register(api) {
+          api.registerCliBackend({ id: "harness-owner-cli", config: { command: "harness-owner" } });
+        },
+      };`,
+    });
+
+    // Load and activate "unrelated-plugin" as the live active registry, the
+    // same way a normal plugin activation would.
+    loadOpenClawPlugins({
+      workspaceDir,
+      cache: false,
+      onlyPluginIds: ["unrelated-plugin"],
+      config: {
+        plugins: {
+          load: { paths: [unrelated.file] },
+          allow: ["unrelated-plugin"],
+          entries: { "unrelated-plugin": { enabled: true } },
+        },
+      },
+    });
+    const activeBefore = getActivePluginRegistry();
+    expect(activeBefore).not.toBeNull();
+    expect(unrelatedPluginRegisterCount()).toBe(1);
+    expect(activeBefore?.cliBackends.map((entry) => entry.pluginId)).toContain("unrelated-plugin");
+
+    // A scoped harness-activation load now asks only for "harness-owner-plugin"
+    // (mirrors ensureSelectedAgentHarnessPlugin's onlyPluginIds — it never
+    // includes "unrelated-plugin").
+    ensureScopedPluginsLoadedPreservingActive({
+      workspaceDir,
+      config: {
+        plugins: {
+          load: { paths: [harnessOwner.file] },
+          allow: ["harness-owner-plugin"],
+          entries: { "harness-owner-plugin": { enabled: true } },
+        },
+      },
+      onlyPluginIds: ["harness-owner-plugin"],
+    });
+
+    const activeAfter = getActivePluginRegistry();
+    // Mutated in place, never swapped — same object reference.
+    expect(activeAfter).toBe(activeBefore);
+    const pluginIds = activeAfter?.plugins.map((p) => p.id).toSorted();
+    expect(pluginIds).toEqual(["harness-owner-plugin", "unrelated-plugin"]);
+    const cliBackendPluginIds = activeAfter?.cliBackends.map((entry) => entry.pluginId).toSorted();
+    expect(cliBackendPluginIds).toEqual(["harness-owner-plugin", "unrelated-plugin"]);
+
+    // The core regression: "unrelated-plugin"'s register() must not have run
+    // again just because an unrelated harness plugin was scoped-loaded.
+    expect(unrelatedPluginRegisterCount()).toBe(1);
+  });
+
+  it("is a no-op when every requested id is already active", async () => {
+    useNoBundledPlugins();
+    const workspaceDir = makeTempDir();
+    const plugin = writePlugin({
+      id: "already-active-plugin",
+      filename: "already-active-plugin.cjs",
+      body: `module.exports = {
+        id: "already-active-plugin",
+        register(api) {
+          globalThis[${JSON.stringify(REGISTER_COUNT_KEY)}] =
+            (globalThis[${JSON.stringify(REGISTER_COUNT_KEY)}] || 0) + 1;
+          api.registerCliBackend({ id: "already-active-cli", config: { command: "x" } });
+        },
+      };`,
+    });
+
+    loadOpenClawPlugins({
+      workspaceDir,
+      cache: false,
+      onlyPluginIds: ["already-active-plugin"],
+      config: {
+        plugins: {
+          load: { paths: [plugin.file] },
+          allow: ["already-active-plugin"],
+          entries: { "already-active-plugin": { enabled: true } },
+        },
+      },
+    });
+    expect(unrelatedPluginRegisterCount()).toBe(1);
+    const activeBefore = getActivePluginRegistry();
+
+    ensureScopedPluginsLoadedPreservingActive({
+      workspaceDir,
+      config: {
+        plugins: {
+          load: { paths: [plugin.file] },
+          allow: ["already-active-plugin"],
+          entries: { "already-active-plugin": { enabled: true } },
+        },
+      },
+      onlyPluginIds: ["already-active-plugin"],
+    });
+
+    expect(getActivePluginRegistry()).toBe(activeBefore);
+    expect(unrelatedPluginRegisterCount()).toBe(1);
+  });
+
+  it("loads the requested plugin normally when nothing is active yet", async () => {
+    useNoBundledPlugins();
+    const workspaceDir = makeTempDir();
+    resetPluginRuntimeStateForTest();
+    expect(getActivePluginRegistry()).toBeNull();
+    const plugin = writePlugin({
+      id: "first-load-plugin",
+      filename: "first-load-plugin.cjs",
+      body: `module.exports = {
+        id: "first-load-plugin",
+        register(api) {
+          api.registerCliBackend({ id: "first-load-cli", config: { command: "x" } });
+        },
+      };`,
+    });
+
+    ensureScopedPluginsLoadedPreservingActive({
+      workspaceDir,
+      config: {
+        plugins: {
+          load: { paths: [plugin.file] },
+          allow: ["first-load-plugin"],
+          entries: { "first-load-plugin": { enabled: true } },
+        },
+      },
+      onlyPluginIds: ["first-load-plugin"],
+    });
+
+    expect(getActivePluginRegistry()?.cliBackends.map((entry) => entry.pluginId)).toContain(
+      "first-load-plugin",
+    );
+  });
+});

--- a/src/plugins/runtime/runtime-registry-loader.ts
+++ b/src/plugins/runtime/runtime-registry-loader.ts
@@ -11,13 +11,22 @@ import {
   resolveDiscoverableScopedChannelPluginIds,
 } from "../channel-plugin-ids.js";
 import { resolveEffectivePluginIds } from "../effective-plugin-ids.js";
+import { initializeGlobalHookRunner } from "../hook-runner-global.js";
 import { loadOpenClawPlugins } from "../loader.js";
 import {
   hasExplicitPluginIdScope,
   hasNonEmptyPluginIdScope,
   normalizePluginIdScope,
 } from "../plugin-scope.js";
-import { getActivePluginRegistry, getActivePluginRegistryWorkspaceDir } from "../runtime.js";
+import { mergeMissingPluginRegistryInto } from "../registry-scoped-merge.js";
+import type { PluginRegistry } from "../registry-types.js";
+import {
+  getActivePluginRegistry,
+  getActivePluginRegistryKey,
+  getActivePluginRegistryWorkspaceDir,
+  getActivePluginRuntimeSubagentMode,
+  setActivePluginRegistry,
+} from "../runtime.js";
 import {
   buildPluginRuntimeLoadOptionsFromValues,
   resolvePluginRuntimeLoadContext,
@@ -226,6 +235,74 @@ export function ensurePluginRegistryLoaded(options?: {
   if (!scopedLoad) {
     pluginRegistryLoaded = scope;
   }
+}
+
+/**
+ * Ensures every id in `onlyPluginIds` is loaded, without letting a scoped
+ * load evict (and retire the live state of) whatever else is already active.
+ *
+ * `ensurePluginRegistryLoaded({ scope: "all", onlyPluginIds })` is a cache
+ * hit-or-replace: if the active registry already satisfies onlyPluginIds it's
+ * a no-op, but on a miss it calls loadOpenClawPlugins with exactly
+ * onlyPluginIds, which activates a brand-new registry containing only that
+ * scope — evicting (and, per cleanupReplacedPluginHostRegistry, tearing down
+ * the live session/runtime state of) every other already-active plugin not
+ * in onlyPluginIds (openclaw/openclaw#107408).
+ *
+ * This loads only the ids missing from the active registry (`publish:false`,
+ * so the standalone result never becomes the live registry and never runs
+ * clearActivatedPluginRuntimeState — see PluginLoadOptions.publish), then
+ * merges those registrations into the active registry in place. Because the
+ * active registry object is mutated rather than replaced, re-publishing it
+ * via setActivePluginRegistry is a same-reference no-op for the
+ * retire/cleanup path (previousRegistry === registry), so already-active
+ * plugins are neither re-registered nor torn down.
+ */
+export function ensureScopedPluginsLoadedPreservingActive(params: {
+  config?: OpenClawConfig;
+  activationSourceConfig?: OpenClawConfig;
+  workspaceDir: string;
+  onlyPluginIds: string[];
+}): void {
+  const active: PluginRegistry | null = getActivePluginRegistry();
+  if (!active) {
+    // No active registry to preserve yet (first load in this process or
+    // workspace) — an ordinary scoped load can't evict anything.
+    loadOpenClawPlugins({
+      config: params.config,
+      activationSourceConfig: params.activationSourceConfig,
+      workspaceDir: params.workspaceDir,
+      onlyPluginIds: params.onlyPluginIds,
+    });
+    return;
+  }
+
+  const missingPluginIds = params.onlyPluginIds.filter(
+    (pluginId) => !registryContainsRuntimePluginIds(active, [pluginId]),
+  );
+  if (missingPluginIds.length === 0) {
+    return;
+  }
+
+  const missingRegistry = loadOpenClawPlugins({
+    config: params.config,
+    activationSourceConfig: params.activationSourceConfig,
+    workspaceDir: params.workspaceDir,
+    onlyPluginIds: missingPluginIds,
+    activate: true,
+    publish: false,
+    cache: false,
+  });
+
+  mergeMissingPluginRegistryInto(active, missingRegistry, missingPluginIds);
+
+  setActivePluginRegistry(
+    active,
+    getActivePluginRegistryKey() ?? undefined,
+    getActivePluginRuntimeSubagentMode(),
+    getActivePluginRegistryWorkspaceDir(),
+  );
+  initializeGlobalHookRunner(active);
 }
 
 export const testing = {


### PR DESCRIPTION
## Summary

Closes #107408.

`ensureSelectedAgentHarnessPlugin` (`src/agents/harness/runtime-plugin.ts`) computes a scoped plugin-id set — the harness-owner plugin(s) plus the memory-slot plugin — and passes it as `onlyPluginIds` into `ensurePluginRegistryLoaded` → `loadOpenClawPlugins`. When that scoped set is not already fully loaded, this builds a **brand-new registry containing only those plugins**, and `activatePluginRegistry`/`setActivePluginRegistry` (`src/plugins/runtime.ts`) hard-replaces the global active registry with it. Any other plugin that was already active — provider owners, CLI backends — is silently evicted from `cliBackends`/`providers` the moment a harness gets selected mid-session.

This is the same eviction family as #87046 (the empty-scope variant); the repo's own regression coverage in `runtime.channel-pin.test.ts` ("A subsequent registry swap ... must not evict channels") already encodes the intended invariant — a registry swap for one purpose must not silently drop live plugin surfaces for another. This fix extends that guarantee to the harness-activation scoped-load path.

## Real-world impact

On a production host (OpenClaw 2026.7.1), a heartbeat configured `every: "1h"` on a model served by the codex harness evicted an installed extension's CLI backend, and a subsequent agent turn targeting that backend failed with `Unknown CLI backend` (while the separately-cached model catalog still listed its models) — recovered only by a gateway restart (full-scope load).

Field evidence on the eviction trigger is more nuanced than initially reported: it correlates with heartbeat turns riding a different harness, but is intermittent rather than a deterministic hourly clock — on the affected host a fresh full plugin registration 6 minutes before a heartbeat did *not* prevent that heartbeat's eviction, while identical heartbeat turns in later hours did *not* evict. We don't have a field-level explanation for that variance and aren't claiming one here. The deterministic repro is the in-repo real-loader test added by this PR (see "After-fix proof" below), and the authoritative statement of the bug is the source-level mechanism: a scoped load that misses the active registry activates a replacement registry limited to `onlyPluginIds`, per `loadOpenClawPlugins`/`activatePluginRegistry`. Note the load-state dependence this implies: if the scoped set is already fully loaded, `ensurePluginRegistryLoaded` short-circuits without swapping (no eviction); the swap fires only when the scoped load genuinely misses (e.g. first harness selection after startup with deferred loads, or after a live config change moves a plugin out of the active set). Both cases are verified against the real loader below.

## Design (reworked per review)

The original version of this PR (previous head `14569a447`) unioned already-loaded plugin ids into `onlyPluginIds` so the scoped load's replacement registry happened to contain everything. `@clawsweeper`'s review correctly flagged that as P1: it still re-registers and republishes every unrelated already-active plugin on every scoped-load miss, coupling an unrelated plugin's failure to harness activation and duplicating side effects (`register()` re-invoked, registrar side effects re-run) for plugins that were never supposed to be touched. The review's recommended fix was to merge registry state instead of widening what gets replaced.

This PR now does that:

- `ensureScopedPluginsLoadedPreservingActive` (`src/plugins/runtime/runtime-registry-loader.ts`) replaces the `ensurePluginRegistryLoaded({ scope: "all", onlyPluginIds })` call in `ensureSelectedAgentHarnessPlugin`. It computes which of `onlyPluginIds` are missing from the active registry and, if none are missing, is a no-op.
- Missing ids are loaded into a **standalone, non-published registry** via a new `publish: false` option on `PluginLoadOptions` (`src/plugins/loader.ts`). `publish: false` still runs a full `activate: true` registration pass — registrar side effects happen for real — but skips `clearActivatedPluginRuntimeState()` and the final `activatePluginRegistry()` call, so the result never becomes the live registry and no global singleton state is wiped out from under the still-active one.
- `mergeMissingPluginRegistryInto` (new file, `src/plugins/registry-scoped-merge.ts`) copies only the entries belonging to the missing plugin ids from that standalone registry into the live active registry, **in place** — `cliBackends`, `providers`, `workerProviders`, `gatewayHandlers`, and the rest of the registry's array/map surfaces. Entries already present in the target for other plugin ids are never touched, and a stale disabled/error record for the same plugin id is replaced rather than duplicated.
- The (now-mutated-in-place) active registry is republished via `setActivePluginRegistry`. Because it's the *same object reference* as before (`previousRegistry === registry`), the retire/cleanup path in `activatePluginRegistry` is a no-op for it — already-active plugins are neither re-registered nor torn down. Only the newly-merged ids went through `register()`.

Net effect: a scoped harness activation now touches exactly the plugin ids it's missing, once, with zero re-registration or duplicated side effects for anything already active — directly addressing the review's P1 (no re-registration of unrelated plugins, no side-effect duplication, no failure coupling) via its suggested "merge registry state" option.

## Risks considered

- **Allowlist gating** — unchanged concern from the original PR, still handled: `ensureSelectedAgentHarnessPlugin`'s own `scopedPluginIds` (harness id + memory-slot id) are still gated through the existing `restrictiveAllowlistOmitsPlugin` check before being passed in; the merge step only ever touches ids explicitly requested by the caller, so nothing can be resurrected outside that gate.
- **Cache-key widening** — no longer applicable the way it was in the original PR: `onlyPluginIds` passed to the standalone `publish: false` load is now the *missing* subset only (not widened with already-loaded ids), and that load runs with `cache: false`, so it doesn't perturb `loader.ts`'s cache bucketing for other callers.
- **Partial-merge safety** — the merge is additive per-surface (arrays get missing-id entries appended, maps/objects only fill in absent keys); it cannot overwrite or drop an existing active-registry entry for a plugin id that wasn't in `missingPluginIds`.

## Tests

- `src/agents/harness/runtime-plugin.test.ts`: the two existing regression tests for this bug now assert against the narrow `onlyPluginIds` behavior directly (`ensureScopedPluginsLoadedPreservingActive` is called with only the harness-owned ids, never widened with already-active plugin ids) instead of asserting on a widened id list.
- **New**: `src/agents/harness/runtime-plugin.eviction-e2e.test.ts` — a stateful-lifecycle test using a real (unmocked) plugin loader to prove an unrelated already-active plugin's `register()` is invoked **exactly once** across a scoped load that misses the active registry, and that its `cliBackend` survives. Only `resolveManifestActivationPlan` is mocked; `loadOpenClawPlugins`, `activatePluginRegistry`, `ensureScopedPluginsLoadedPreservingActive`, and `resolveRuntimeCliBackends` are the real, unmocked core code paths. This is the deterministic in-repo repro for #107408, and fails on unpatched `main` / passes on this branch (see embedded proof below).
- **New**: `src/plugins/registry-scoped-merge.test.ts` — pure-function unit suite for `mergeMissingPluginRegistryInto` (copies missing-id entries, ignores non-missing source entries, replaces a stale disabled/error record instead of duplicating it, no-ops on an empty missing-id list, doesn't duplicate an existing worker-provider/gateway-handler key).
- **New**: `src/plugins/runtime/runtime-registry-loader.merge.test.ts` — unit suite for `ensureScopedPluginsLoadedPreservingActive` itself (preserves an already-active unrelated plugin across a scoped load for a missing plugin id; is a no-op when every requested id is already active; loads normally when nothing is active yet).

Suites run on this branch:
- `src/agents/harness/runtime-plugin.test.ts` + `runtime-plugin.eviction-e2e.test.ts` — 19/19 ✅ (harness file: 46/46 including duplicate project runs)
- `pnpm test:contracts:plugins` — 990/990 ✅
- Runtime/channel-pin/active-runtime-registry/loader suites — 225/225 ✅
- `oxlint` — clean ✅

Honest caveat: a full-repo `tsc`/`tsdown` typecheck could not complete in the contributor sandbox (OOM — this is a pre-existing sandbox limitation, not something introduced by this change). Relying on CI for the full typecheck rather than claiming a local one that didn't actually finish.

## After-fix proof (real loader, unmocked)

<details>
<summary>Before/after run of the real-loader e2e test against unpatched <code>main</code> (7b16b35cb) vs. this branch, plus the full new/updated regression suite — click to expand</summary>

```
PR #107596 rework — registry-merge preserve fix — real-loader before/after proof
Issue: openclaw/openclaw#107408 (scoped harness plugin activation evicting unrelated plugins' CLI backends)
Captured: subagent run, 2026-07-14 (session: PR 107596 registry-merge rework)

Test file used for the before/after comparison (unmodified across both runs):
  src/agents/harness/runtime-plugin.eviction-e2e.test.ts
  (copied from the earlier session's scratch harness at
  /tmp/scratch-cleanup/scratch-proof-107408.flip.test.ts — same file, run
  unmodified against both trees; only "resolveManifestActivationPlan" is
  mocked, everything else — loadOpenClawPlugins, activatePluginRegistry,
  ensurePluginRegistryLoaded / ensureScopedPluginsLoadedPreservingActive,
  resolveRuntimeCliBackends, and the real ensureSelectedAgentHarnessPlugin —
  is real, unmocked core code.)

Method: a git worktree was checked out at `main` (commit 7b16b35cb,
the merge-base / true pre-fix baseline — one commit behind this branch's
original 14569a447 attempt), with node_modules symlinked from the working
tree. The same test file was run there unmodified, then run again on this
branch (fix/registry-merge-preserve).

=================================================================
BEFORE FIX — run against unpatched main (commit 7b16b35cb)
Expected/observed: eviction reproduces — proof-backend-owner's cliBackend
is dropped by the scoped harness-activation load. Test FAILS.
=================================================================
[PLUGIN_TIMINGS] Your build spent significant time in plugin `inject-file-scope-variables`. See https://rolldown.rs/reference/InputOptions.checks#plugintimings for more details.

[PLUGIN_TIMINGS] Your build spent significant time in plugin `inject-file-scope-variables`. See https://rolldown.rs/reference/InputOptions.checks#plugintimings for more details.

[PLUGIN_TIMINGS] Your build spent significant time in plugin `inject-file-scope-variables`. See https://rolldown.rs/reference/InputOptions.checks#plugintimings for more details.

[PLUGIN_TIMINGS] Your build spent significant time in plugin `externalize-deps`. See https://rolldown.rs/reference/InputOptions.checks#plugintimings for more details.

[PLUGIN_TIMINGS] Your build spent significant time in plugin `externalize-deps`. See https://rolldown.rs/reference/InputOptions.checks#plugintimings for more details.


 RUN  v4.1.9 <repo>

stdout | ../../src/agents/harness/runtime-plugin.eviction-e2e.test.ts > issue #107408 — ensureSelectedAgentHarnessPlugin, real loader, mocked manifest-plan only > scoped harness activation vs. an already-active unrelated plugin's CLI backend
RESULT proof-backend-owner survives scoped harness activation: false | active cliBackend owners: []

 × |agents-core| ../../src/agents/harness/runtime-plugin.eviction-e2e.test.ts > issue #107408 — ensureSelectedAgentHarnessPlugin, real loader, mocked manifest-plan only > scoped harness activation vs. an already-active unrelated plugin's CLI backend 335ms
   → expected [] to include 'proof-backend-owner'
stdout | ../../src/agents/harness/runtime-plugin.eviction-e2e.test.ts > issue #107408 — ensureSelectedAgentHarnessPlugin, real loader, mocked manifest-plan only > scoped harness activation vs. an already-active unrelated plugin's CLI backend
RESULT proof-backend-owner survives scoped harness activation: false | active cliBackend owners: []

 × |agents-support| ../../src/agents/harness/runtime-plugin.eviction-e2e.test.ts > issue #107408 — ensureSelectedAgentHarnessPlugin, real loader, mocked manifest-plan only > scoped harness activation vs. an already-active unrelated plugin's CLI backend 321ms
   → expected [] to include 'proof-backend-owner'

⎯⎯⎯⎯⎯⎯⎯ Failed Tests 2 ⎯⎯⎯⎯⎯⎯⎯

 FAIL  |agents-core| ../../src/agents/harness/runtime-plugin.eviction-e2e.test.ts > issue #107408 — ensureSelectedAgentHarnessPlugin, real loader, mocked manifest-plan only > scoped harness activation vs. an already-active unrelated plugin's CLI backend
AssertionError: expected [] to include 'proof-backend-owner'
 ❯ ../../src/agents/harness/runtime-plugin.eviction-e2e.test.ts:127:30
    125|     // with only ["harness-owner"], dropping proof-backend-owner's cli…
    126|     // On the fix branch this PASSES: alreadyLoadedPluginIds unions pr…
    127|     expect(backendPluginIds).toContain("proof-backend-owner");
       |                              ^
    128|   });
    129| });

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/2]⎯

 FAIL  |agents-support| ../../src/agents/harness/runtime-plugin.eviction-e2e.test.ts > issue #107408 — ensureSelectedAgentHarnessPlugin, real loader, mocked manifest-plan only > scoped harness activation vs. an already-active unrelated plugin's CLI backend
AssertionError: expected [] to include 'proof-backend-owner'
 ❯ ../../src/agents/harness/runtime-plugin.eviction-e2e.test.ts:127:30
    125|     // with only ["harness-owner"], dropping proof-backend-owner's cli…
    126|     // On the fix branch this PASSES: alreadyLoadedPluginIds unions pr…
    127|     expect(backendPluginIds).toContain("proof-backend-owner");
       |                              ^
    128|   });
    129| });

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[2/2]⎯


 Test Files  2 failed (2)
      Tests  2 failed (2)
   Start at  22:48:52
   Duration  14.67s (transform 10.36s, setup 1.16s, import 11.76s, tests 1.34s, environment 0ms)


=================================================================
AFTER FIX — run against fix/registry-merge-preserve
Expected/observed: proof-backend-owner's cliBackend survives the scoped
harness-activation load for the unrelated harness-owner plugin. Test PASSES.
=================================================================
[PLUGIN_TIMINGS] Your build spent significant time in plugin `inject-file-scope-variables`. See https://rolldown.rs/reference/InputOptions.checks#plugintimings for more details.

[PLUGIN_TIMINGS] Your build spent significant time in plugin `externalize-deps`. See https://rolldown.rs/reference/InputOptions.checks#plugintimings for more details.

[PLUGIN_TIMINGS] Your build spent significant time in plugin `externalize-deps`. See https://rolldown.rs/reference/InputOptions.checks#plugintimings for more details.

[PLUGIN_TIMINGS] Your build spent significant time in plugin `inject-file-scope-variables`. See https://rolldown.rs/reference/InputOptions.checks#plugintimings for more details.

[PLUGIN_TIMINGS] Your build spent significant time in plugin `externalize-deps`. See https://rolldown.rs/reference/InputOptions.checks#plugintimings for more details.

[PLUGIN_TIMINGS] Your build spent significant time in plugin `inject-file-scope-variables`. See https://rolldown.rs/reference/InputOptions.checks#plugintimings for more details.


 RUN  v4.1.9 <repo>

stdout | ../../src/agents/harness/runtime-plugin.eviction-e2e.test.ts > issue #107408 — ensureSelectedAgentHarnessPlugin, real loader, mocked manifest-plan only > scoped harness activation vs. an already-active unrelated plugin's CLI backend
RESULT proof-backend-owner survives scoped harness activation: true | active cliBackend owners: ["proof-backend-owner"]

 ✓ |agents-core| ../../src/agents/harness/runtime-plugin.eviction-e2e.test.ts > issue #107408 — ensureSelectedAgentHarnessPlugin, real loader, mocked manifest-plan only > scoped harness activation vs. an already-active unrelated plugin's CLI backend 284ms
stdout | ../../src/agents/harness/runtime-plugin.eviction-e2e.test.ts > issue #107408 — ensureSelectedAgentHarnessPlugin, real loader, mocked manifest-plan only > scoped harness activation vs. an already-active unrelated plugin's CLI backend
RESULT proof-backend-owner survives scoped harness activation: true | active cliBackend owners: ["proof-backend-owner"]

 ✓ |agents-support| ../../src/agents/harness/runtime-plugin.eviction-e2e.test.ts > issue #107408 — ensureSelectedAgentHarnessPlugin, real loader, mocked manifest-plan only > scoped harness activation vs. an already-active unrelated plugin's CLI backend 280ms

 Test Files  2 passed (2)
      Tests  2 passed (2)
   Start at  22:49:36
   Duration  6.61s (transform 2.24s, setup 496ms, import 4.62s, tests 1.13s, environment 0ms)


=================================================================
SUPPORTING: full new/updated regression suite on the fix branch
(includes the stateful-plugin lifecycle test proving register() runs
exactly once for the preserved unrelated plugin across the scoped load)
=================================================================
[PLUGIN_TIMINGS] Your build spent significant time in plugin `inject-file-scope-variables`. See https://rolldown.rs/reference/InputOptions.checks#plugintimings for more details.

[PLUGIN_TIMINGS] Your build spent significant time in plugin `inject-file-scope-variables`. See https://rolldown.rs/reference/InputOptions.checks#plugintimings for more details.


 RUN  v4.1.9 <repo>

 ✓ |agents-core| ../../src/agents/harness/runtime-plugin.test.ts > ensureSelectedAgentHarnessPlugin > loads Codex and the provider owner when an explicit runtime override forces the Codex harness 918ms
 ✓ |agents-core| ../../src/agents/harness/runtime-plugin.test.ts > ensureSelectedAgentHarnessPlugin > loads a session-pinned Codex harness for an unrelated outer provider 136ms
 ✓ |agents-core| ../../src/agents/harness/runtime-plugin.test.ts > ensureSelectedAgentHarnessPlugin > loads Codex and the provider owner for the implicit official OpenAI runtime before selection 130ms
 ✓ |agents-core| ../../src/agents/harness/runtime-plugin.test.ts > ensureSelectedAgentHarnessPlugin > loads a configured Copilot harness plugin before selection 127ms
 ✓ |agents-core| ../../src/agents/harness/runtime-plugin.test.ts > ensureSelectedAgentHarnessPlugin > loads a manifest-owned custom harness runtime before selection 254ms
 ✓ |agents-core| ../../src/agents/harness/runtime-plugin.test.ts > ensureSelectedAgentHarnessPlugin > does not activate an untrusted workspace harness from manifest metadata alone 1ms
 ✓ |agents-core| ../../src/agents/harness/runtime-plugin.test.ts > ensureSelectedAgentHarnessPlugin > does not bypass a restrictive allowlist that omits a configured Copilot harness 116ms
 ✓ |agents-core| ../../src/agents/harness/runtime-plugin.test.ts > ensureSelectedAgentHarnessPlugin > widens a scoped harness allowlist with the provider owner for openai models 232ms
 ✓ |agents-core| ../../src/agents/harness/runtime-plugin.test.ts > ensureSelectedAgentHarnessPlugin > keeps an allowed memory slot plugin in Codex harness scoped loads 231ms
 ✓ |agents-core| ../../src/agents/harness/runtime-plugin.test.ts > ensureSelectedAgentHarnessPlugin > does not auto-activate an untrusted workspace memory slot plugin 219ms
 ✓ |agents-core| ../../src/agents/harness/runtime-plugin.test.ts > ensureSelectedAgentHarnessPlugin > does not auto-activate untrusted provider owners for Codex harness loads 24ms
 ✓ |agents-core| ../../src/agents/harness/runtime-plugin.test.ts > ensureSelectedAgentHarnessPlugin > does not bypass a restrictive allowlist that omits the Codex harness 1ms
 ✓ |agents-core| ../../src/agents/harness/runtime-plugin.test.ts > ensureSelectedAgentHarnessPlugin > keeps real bundled memory-core in a Codex scoped load when the provider has no owner plugin 108ms
 ✓ |agents-core| ../../src/agents/harness/runtime-plugin.test.ts > ensureSelectedAgentHarnessPlugin > keeps custom OpenAI-compatible providers on embedded OpenClaw when no runtime override is set 1ms
 ✓ |agents-core| ../../src/agents/harness/runtime-plugin.test.ts > ensureSelectedAgentHarnessPlugin > keeps official OpenAI providers on embedded OpenClaw when explicitly configured 0ms
 ✓ |agents-core| ../../src/agents/harness/runtime-plugin.test.ts > ensureSelectedAgentHarnessPlugin > does not treat CLI backend runtime aliases as plugin ids 80ms
 ✓ |agents-core| ../../src/agents/harness/runtime-plugin.test.ts > ensureSelectedAgentHarnessPlugin > scoped load eviction (openclaw/openclaw#107408) > delegates to ensureScopedPluginsLoadedPreservingActive with only the harness-owned ids, never widening onlyPluginIds with already-active plugin ids 24ms
 ✓ |agents-core| ../../src/agents/harness/runtime-plugin.test.ts > ensureSelectedAgentHarnessPlugin > scoped load eviction (openclaw/openclaw#107408) > keeps onlyPluginIds narrow even under a restrictive allowlist and an unrelated active plugin 211ms
 ✓ |agents-support| ../../src/agents/harness/runtime-plugin.test.ts > ensureSelectedAgentHarnessPlugin > loads Codex and the provider owner when an explicit runtime override forces the Codex harness 880ms
 ✓ |agents-support| ../../src/agents/harness/runtime-plugin.test.ts > ensureSelectedAgentHarnessPlugin > loads a session-pinned Codex harness for an unrelated outer provider 128ms
 ✓ |agents-support| ../../src/agents/harness/runtime-plugin.test.ts > ensureSelectedAgentHarnessPlugin > loads Codex and the provider owner for the implicit official OpenAI runtime before selection 127ms
 ✓ |agents-support| ../../src/agents/harness/runtime-plugin.test.ts > ensureSelectedAgentHarnessPlugin > loads a configured Copilot harness plugin before selection 126ms
 ✓ |agents-support| ../../src/agents/harness/runtime-plugin.test.ts > ensureSelectedAgentHarnessPlugin > loads a manifest-owned custom harness runtime before selection 229ms
 ✓ |agents-support| ../../src/agents/harness/runtime-plugin.test.ts > ensureSelectedAgentHarnessPlugin > does not activate an untrusted workspace harness from manifest metadata alone 1ms
 ✓ |agents-support| ../../src/agents/harness/runtime-plugin.test.ts > ensureSelectedAgentHarnessPlugin > does not bypass a restrictive allowlist that omits a configured Copilot harness 114ms
 ✓ |agents-support| ../../src/agents/harness/runtime-plugin.test.ts > ensureSelectedAgentHarnessPlugin > widens a scoped harness allowlist with the provider owner for openai models 224ms
 ✓ |agents-support| ../../src/agents/harness/runtime-plugin.test.ts > ensureSelectedAgentHarnessPlugin > keeps an allowed memory slot plugin in Codex harness scoped loads 226ms
 ✓ |agents-support| ../../src/agents/harness/runtime-plugin.test.ts > ensureSelectedAgentHarnessPlugin > does not auto-activate an untrusted workspace memory slot plugin 217ms
 ✓ |agents-support| ../../src/agents/harness/runtime-plugin.test.ts > ensureSelectedAgentHarnessPlugin > does not auto-activate untrusted provider owners for Codex harness loads 22ms
 ✓ |agents-support| ../../src/agents/harness/runtime-plugin.test.ts > ensureSelectedAgentHarnessPlugin > does not bypass a restrictive allowlist that omits the Codex harness 1ms
 ✓ |agents-support| ../../src/agents/harness/runtime-plugin.test.ts > ensureSelectedAgentHarnessPlugin > keeps real bundled memory-core in a Codex scoped load when the provider has no owner plugin 105ms
 ✓ |agents-support| ../../src/agents/harness/runtime-plugin.test.ts > ensureSelectedAgentHarnessPlugin > keeps custom OpenAI-compatible providers on embedded OpenClaw when no runtime override is set 1ms
 ✓ |agents-support| ../../src/agents/harness/runtime-plugin.test.ts > ensureSelectedAgentHarnessPlugin > keeps official OpenAI providers on embedded OpenClaw when explicitly configured 0ms
 ✓ |agents-support| ../../src/agents/harness/runtime-plugin.test.ts > ensureSelectedAgentHarnessPlugin > does not treat CLI backend runtime aliases as plugin ids 80ms
 ✓ |agents-support| ../../src/agents/harness/runtime-plugin.test.ts > ensureSelectedAgentHarnessPlugin > scoped load eviction (openclaw/openclaw#107408) > delegates to ensureScopedPluginsLoadedPreservingActive with only the harness-owned ids, never widening onlyPluginIds with already-active plugin ids 24ms
 ✓ |agents-support| ../../src/agents/harness/runtime-plugin.test.ts > ensureSelectedAgentHarnessPlugin > scoped load eviction (openclaw/openclaw#107408) > keeps onlyPluginIds narrow even under a restrictive allowlist and an unrelated active plugin 212ms
 ✓ |plugins| ../../src/plugins/runtime/runtime-registry-loader.merge.test.ts > ensureScopedPluginsLoadedPreservingActive > preserves an already-active unrelated plugin's registrations across a scoped load for a missing plugin 188ms
 ✓ |plugins| ../../src/plugins/runtime/runtime-registry-loader.merge.test.ts > ensureScopedPluginsLoadedPreservingActive > is a no-op when every requested id is already active 22ms
 ✓ |plugins| ../../src/plugins/runtime/runtime-registry-loader.merge.test.ts > ensureScopedPluginsLoadedPreservingActive > loads the requested plugin normally when nothing is active yet 19ms
 ✓ |plugins| ../../src/plugins/registry-scoped-merge.test.ts > mergeMissingPluginRegistryInto > copies the missing plugin's registrations into the target without touching existing ones 1ms
 ✓ |plugins| ../../src/plugins/registry-scoped-merge.test.ts > mergeMissingPluginRegistryInto > ignores source entries whose pluginId is not in missingPluginIds 1ms
 ✓ |plugins| ../../src/plugins/registry-scoped-merge.test.ts > mergeMissingPluginRegistryInto > replaces a stale disabled/error record for the same plugin id instead of duplicating it 1ms
 ✓ |plugins| ../../src/plugins/registry-scoped-merge.test.ts > mergeMissingPluginRegistryInto > is a no-op for an empty missing-id list 0ms
 ✓ |plugins| ../../src/plugins/registry-scoped-merge.test.ts > mergeMissingPluginRegistryInto > does not duplicate a worker provider or gateway handler key already present in target 1ms

 Test Files  4 passed (4)
      Tests  44 passed (44)
   Start at  22:50:11
   Duration  14.59s (transform 3.31s, setup 731ms, import 6.84s, tests 6.45s, environment 0ms)
```

</details>

## Validation

- `pnpm build` ✅
- `pnpm check` ✅ (one unrelated pre-existing shrinkwrap-staleness finding, reproduced identically on unmodified `main`)
- `src/agents/harness/runtime-plugin.test.ts` + `runtime-plugin.eviction-e2e.test.ts` — 19/19 ✅
- `pnpm test:contracts:plugins` — 990/990 ✅
- Runtime/channel-pin/active-runtime-registry/loader suites — 225/225 ✅
- `oxlint` — clean ✅
- Full-repo `tsc`/`tsdown` typecheck: could not complete in the contributor sandbox (OOM, pre-existing) — relying on CI for this one.

---
*This PR was AI-assisted (implementation, tests, and validation drafted by an AI agent under human review before submission), per repo policy.*
