### PR TITLE
fix(macos): prevent clipped and stalled onboarding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,8 +41,6 @@ Docs: https://docs.openclaw.ai
 - **Signal active-run controls:** keep authorized stop, status, approval, and queue-read controls responsive during active turns while preserving ordinary and stateful turns in canonical session admission, and cancel every pending group sender lane on stop. (#107422) Thanks @arduano.
 - **Agent auth storage locks:** surface normal release failures while avoiding redundant release attempts after `proper-lockfile` reports a compromised lock.
 - **Paired-node session catalogs:** authorize bundled Anthropic and Codex catalog requests to invoke their read-only node commands from Control UI read flows, restoring remote Claude/Codex rows and terminal resume availability. Fixes #107406.
-- **macOS onboarding window sizing:** fit setup to the visible screen so its navigation remains reachable above the Dock on shorter displays.
-- **Gateway installer restarts:** avoid restarting a freshly force-installed service a second time so startup migrations can finish without a stale lock.
 - **Sandbox recreate confirmation:** treat Clack cancellation as a decline so Ctrl-C cannot proceed with container removal.
 - **Microsoft Teams HTML text:** decode HTML5 entities consistently in quoted and Graph-fetched messages while preserving literal escaped entity text.
 - **ClawHub plugin API ranges:** delegate each supported comparator to `semver` so tilde, partial-wildcard, and prerelease caret bounds are correct while preserving OpenClaw version normalization and the existing restricted range grammar. (#106877)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ Docs: https://docs.openclaw.ai
 - **Signal active-run controls:** keep authorized stop, status, approval, and queue-read controls responsive during active turns while preserving ordinary and stateful turns in canonical session admission, and cancel every pending group sender lane on stop. (#107422) Thanks @arduano.
 - **Agent auth storage locks:** surface normal release failures while avoiding redundant release attempts after `proper-lockfile` reports a compromised lock.
 - **Paired-node session catalogs:** authorize bundled Anthropic and Codex catalog requests to invoke their read-only node commands from Control UI read flows, restoring remote Claude/Codex rows and terminal resume availability. Fixes #107406.
+- **macOS onboarding window sizing:** fit setup to the visible screen so its navigation remains reachable above the Dock on shorter displays.
+- **Gateway installer restarts:** avoid restarting a freshly force-installed service a second time so startup migrations can finish without a stale lock.
 - **Sandbox recreate confirmation:** treat Clack cancellation as a decline so Ctrl-C cannot proceed with container removal.
 - **Microsoft Teams HTML text:** decode HTML5 entities consistently in quoted and Graph-fetched messages while preserving literal escaped entity text.
 - **ClawHub plugin API ranges:** delegate each supported comparator to `semver` so tilde, partial-wildcard, and prerelease caret bounds are correct while preserving OpenClaw version normalization and the existing restricted range grammar. (#106877)

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -31195,7 +31195,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 688,
+      "line": 704,
       "path": "apps/macos/Sources/OpenClaw/Onboarding.swift",
       "source": "Finish",
       "surface": "apple",
@@ -31203,7 +31203,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 688,
+      "line": 704,
       "path": "apps/macos/Sources/OpenClaw/Onboarding.swift",
       "source": "Next",
       "surface": "apple",

--- a/apps/macos/Sources/OpenClaw/Onboarding.swift
+++ b/apps/macos/Sources/OpenClaw/Onboarding.swift
@@ -514,20 +514,36 @@ final class OnboardingController: NSObject, NSWindowDelegate {
         let hosting = NSHostingController(rootView: OnboardingView())
         let window = NSWindow(contentViewController: hosting)
         window.title = UIStrings.welcomeTitle
-        window.setContentSize(NSSize(width: OnboardingView.windowWidth, height: OnboardingView.windowHeight))
         window.styleMask = Self.windowStyleMask
+        window.setContentSize(NSSize(width: OnboardingView.windowWidth, height: OnboardingView.windowHeight))
+        if let visibleFrame = (NSScreen.main ?? NSScreen.screens.first)?.visibleFrame {
+            // Constrain the full window frame, not only its content. Otherwise the
+            // navigation bar can land below the Dock on shorter displays.
+            window.setFrame(Self.initialWindowFrame(visibleFrame: visibleFrame), display: false)
+        } else {
+            window.center()
+        }
         // Keep the focused dialog width while letting taller displays give setup more breathing room.
-        window.contentMinSize = NSSize(width: OnboardingView.windowWidth, height: OnboardingView.windowHeight)
+        window.contentMinSize = NSSize(
+            width: OnboardingView.windowWidth,
+            height: OnboardingView.minimumWindowHeight)
         window.contentMaxSize = NSSize(width: OnboardingView.windowWidth, height: .greatestFiniteMagnitude)
         window.titlebarAppearsTransparent = true
         window.titleVisibility = .hidden
         window.isMovableByWindowBackground = true
         window.delegate = self
-        window.center()
         DockIconManager.shared.temporarilyShowDock()
         window.makeKeyAndOrderFront(nil)
         NSApp.activate(ignoringOtherApps: true)
         self.window = window
+    }
+
+    static func initialWindowFrame(visibleFrame: NSRect) -> NSRect {
+        let contentRect = NSRect(
+            origin: .zero,
+            size: NSSize(width: OnboardingView.windowWidth, height: OnboardingView.windowHeight))
+        let preferredFrame = NSWindow.frameRect(forContentRect: contentRect, styleMask: self.windowStyleMask)
+        return WindowPlacement.centeredFrame(size: preferredFrame.size, in: visibleFrame)
     }
 
     func close() {
@@ -607,6 +623,7 @@ struct OnboardingView: View {
 
     static let windowWidth: CGFloat = 630
     static let windowHeight: CGFloat = 752 // ~+10% to fit full onboarding content
+    static let minimumWindowHeight: CGFloat = 520
 
     let pageWidth: CGFloat = Self.windowWidth
     let connectionPageIndex = 1
@@ -625,16 +642,15 @@ struct OnboardingView: View {
         130
     }
 
-    /// The baseline fits every setup control. Taller windows donate all extra room
-    /// to the active page instead of leaving the content pinned to a fixed canvas.
+    /// The active page is scrollable on short screens. Taller windows donate all
+    /// extra room instead of leaving the content pinned to a fixed canvas.
     func contentHeight(for windowHeight: CGFloat) -> CGFloat {
         Self.contentHeight(for: windowHeight, usesCompactHero: self.usesCompactHero)
     }
 
     static func contentHeight(for windowHeight: CGFloat, usesCompactHero: Bool) -> CGFloat {
-        let availableHeight = max(Self.windowHeight, windowHeight)
         let heroHeight: CGFloat = usesCompactHero ? 78 : 145
-        return availableHeight - heroHeight - 72
+        return max(0, windowHeight - heroHeight - 72)
     }
 
     static func pageOrder(

--- a/apps/macos/Sources/OpenClaw/OnboardingView+Layout.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingView+Layout.swift
@@ -42,7 +42,7 @@ extension OnboardingView {
         .frame(
             minWidth: pageWidth,
             maxWidth: pageWidth,
-            minHeight: Self.windowHeight,
+            minHeight: Self.minimumWindowHeight,
             maxHeight: .infinity)
         .background(Color(NSColor.windowBackgroundColor))
         .onAppear {

--- a/apps/macos/Tests/OpenClawIPCTests/OnboardingViewSmokeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/OnboardingViewSmokeTests.swift
@@ -54,6 +54,25 @@ struct OnboardingViewSmokeTests {
         #expect(taller - baseline == 200)
     }
 
+    @Test func `onboarding window fits within a short visible screen`() {
+        let visibleFrame = NSRect(x: 0, y: 78, width: 1600, height: 626)
+        let frame = OnboardingController.initialWindowFrame(visibleFrame: visibleFrame)
+
+        #expect(frame.height == visibleFrame.height)
+        #expect(frame.minY == visibleFrame.minY)
+        #expect(frame.maxY == visibleFrame.maxY)
+    }
+
+    @Test func `short onboarding window keeps a usable scrollable page`() {
+        let short = OnboardingView.contentHeight(for: 626, usesCompactHero: false)
+        let preferred = OnboardingView.contentHeight(
+            for: OnboardingView.windowHeight,
+            usesCompactHero: false)
+
+        #expect(short == 409)
+        #expect(short < preferred)
+    }
+
     @Test func `page order delegates setup after inference to Crestodian`() {
         let order = OnboardingView.pageOrder(
             for: .local,

--- a/docs/install/installer.md
+++ b/docs/install/installer.md
@@ -211,8 +211,8 @@ by default, plus git-checkout installs under the same prefix flow.
   </Step>
   <Step title="Refresh loaded gateway service">
     If a gateway service is already loaded from that same prefix, the script runs
-    `openclaw gateway install --force`, then `openclaw gateway restart`, and
-    probes gateway health best-effort.
+    `openclaw gateway install --force`, which activates the replacement service,
+    and then probes gateway health best-effort.
   </Step>
 </Steps>
 

--- a/scripts/install-cli.sh
+++ b/scripts/install-cli.sh
@@ -1274,12 +1274,8 @@ refresh_gateway_service_if_loaded() {
     return 0
   fi
 
-  if ! "$claw" gateway restart >/dev/null 2>&1; then
-    emit_json '{"event":"step","name":"gateway-service","status":"warn","reason":"restart-failed"}'
-    log "Warning: gateway service restart failed; continuing. Run: openclaw gateway restart"
-    return 0
-  fi
-
+  # `gateway install --force` activates the replacement service. A second
+  # restart can kill startup migrations and strand their lock until expiry.
   "$claw" gateway status --probe --json >/dev/null 2>&1 || true
   emit_json '{"event":"step","name":"gateway-service","status":"ok"}'
 }

--- a/test/scripts/install-cli.test.ts
+++ b/test/scripts/install-cli.test.ts
@@ -164,6 +164,39 @@ describe("install-cli.sh", () => {
     expect(result.stdout + result.stderr).not.toContain("unbound variable");
   });
 
+  it("does not restart a gateway again after force-install activates it", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "openclaw-install-cli-gateway-refresh-"));
+    const prefix = join(tmp, "prefix");
+    const bin = join(prefix, "bin");
+    const commandLog = join(tmp, "commands.log");
+    const openclaw = join(bin, "openclaw");
+    mkdirSync(bin, { recursive: true });
+    writeFileSync(openclaw, '#!/bin/bash\nprintf "%s\\n" "$*" >> "$COMMAND_LOG"\n');
+    chmodSync(openclaw, 0o755);
+
+    try {
+      const result = runInstallCliShell(
+        [
+          "set -euo pipefail",
+          `cd ${JSON.stringify(process.cwd())}`,
+          `source ${JSON.stringify(SCRIPT_PATH)}`,
+          `PREFIX=${JSON.stringify(prefix)}`,
+          "is_gateway_daemon_loaded() { return 0; }",
+          "refresh_gateway_service_if_loaded",
+        ].join("\n"),
+        { COMMAND_LOG: commandLog },
+      );
+
+      expect(result.status).toBe(0);
+      expect(readFileSync(commandLog, "utf8").trim().split("\n")).toEqual([
+        "gateway install --force",
+        "gateway status --probe --json",
+      ]);
+    } finally {
+      rmSync(tmp, { force: true, recursive: true });
+    }
+  });
+
   it("keeps HOME for default prefix while OPENCLAW_HOME controls git checkout paths", () => {
     const tmp = mkdtempSync(join(tmpdir(), "openclaw-install-cli-home-"));
     const osHome = join(tmp, "os-home");


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where macOS users could lose the onboarding navigation controls when the visible screen height was shorter than the app's preferred content height. It also fixes an onboarding update failure where replacing an already-loaded Gateway could immediately stop the new service a second time and strand slow startup migrations behind their lock.

## Why This Change Was Made

The app now constrains the complete onboarding window frame to the screen's visible frame while keeping dense page content scrollable. The bundled CLI installer now treats a successful forced service install as the activation boundary and probes status without issuing a redundant restart.

## User Impact

Onboarding remains navigable on short displays and virtual machines. Existing local Gateway installs can update through the Mac app without a second service interruption during startup.

## Evidence

- Reproduced the clipped navigation on macOS Tahoe in Parallels with a 1600x734 display and a 1600x626 visible frame. The fixed signed app opened at 630x626 with navigation above the Dock on three fresh launches. A taller 1826x971 display retained the preferred 630x752 window.
- Verified the dense AI provider page scrolls inside the short window while the navigation remains fixed.
- Reproduced the service race by onboarding over a loaded Gateway 2026.6.11. Before the fix, the newly installed Gateway was restarted again during startup migrations, hit the migration lock, and failed the onboarding readiness check.
- Repeated the same original-snapshot path with the fixed Developer ID-signed app. The update completed from Gateway 2026.6.11 / Node 22 to Gateway 2026.7.2 / Node 24. Launchd reported one run, the replacement PID remained alive for 26 minutes, `gateway status --deep --require-rpc --json` reported `rpc.ok: true`, and the post-cutover log contained no migration-lock collision.
- `node scripts/run-vitest.mjs test/scripts/install-cli.test.ts`: 30 passed.
- `OnboardingViewSmokeTests`: 23 passed on Xcode 26.6.
- SwiftFormat 0.62.1: 0 changes. SwiftLint 0.65.0: 0 violations.
- Changed-file gate: [Blacksmith Testbox run](https://github.com/openclaw/openclaw/actions/runs/29329352161), green.
- Fresh branch autoreview after the final rebase: no findings; patch correct, confidence 0.91.
- AI-assisted. I understand the window sizing and service lifecycle changes and validated both through the real Mac-app onboarding path.
