### PR TITLE
fix(i18n): refresh Korean native glossary hash

### DIFF
--- a/apps/.i18n/native/ko.json
+++ b/apps/.i18n/native/ko.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "locale": "ko",
-  "glossaryHash": "47cf80de6cebb6ba1ac7a0bfd60e96de12a8611785bae9ca4f82c14912db9bd1",
+  "glossaryHash": "31510f6398458d1da1b082b45b39b144b16b17a091cc64c02124e9563fd035be",
   "entries": [
     {
       "id": "native.android.85cc8de945e3929c",


### PR DESCRIPTION
## What Problem This Solves

Full Release Validation child CI run https://github.com/openclaw/openclaw/actions/runs/29342640615 failed `native-i18n` because the Korean native translation artifact still recorded the glossary hash from before the Korean UI glossary update.

## Why This Change Was Made

Refresh the artifact metadata to the exact current glossary hash. The newly added glossary entry is `Discard`; the native inventory contains no `Discard` source, so no native translation entry needs regeneration.

## User Impact

Native localization validation passes again. Runtime strings and product behavior are unchanged.

## Evidence

- Exact failing Full Release Validation child: https://github.com/openclaw/openclaw/actions/runs/29342640615
- Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/29343215827
  - `pnpm native:i18n:check`: passed
  - 21 locale artifacts validated; 4,525 inventory entries unchanged
- Verified no native source entry contains `Discard`
- `git diff --check`

No agent transcript is included.
