### PR TITLE
fix(infra): guard tailscale funnel status JSON parsing against non-JSON stdout

### DIFF
--- a/src/infra/tailscale.test.ts
+++ b/src/infra/tailscale.test.ts
@@ -281,11 +281,11 @@ describe("tailscale helpers", () => {
     await expect(hasTailscaleFunnelRouteForPort(18789, exec)).resolves.toBe(false);
   });
 
-  it("hasTailscaleFunnelRouteForPort preserves malformed status parse failures", async () => {
+  it("hasTailscaleFunnelRouteForPort returns false on malformed status parse failures", async () => {
     const exec = vi.fn().mockResolvedValue({
       stdout: "warning: stale state\n{not json}\n",
     });
 
-    await expect(hasTailscaleFunnelRouteForPort(18789, exec)).rejects.toThrow(SyntaxError);
+    await expect(hasTailscaleFunnelRouteForPort(18789, exec)).resolves.toBe(false);
   });
 });

--- a/src/infra/tailscale.ts
+++ b/src/infra/tailscale.ts
@@ -17,14 +17,10 @@ function parsePossiblyNoisyJsonObject(stdout: string): Record<string, unknown> {
   const trimmed = stdout.trim();
   const start = trimmed.indexOf("{");
   const end = trimmed.lastIndexOf("}");
-  try {
-    if (start >= 0 && end > start) {
-      return JSON.parse(trimmed.slice(start, end + 1)) as Record<string, unknown>;
-    }
-    return JSON.parse(trimmed) as Record<string, unknown>;
-  } catch {
-    return {};
+  if (start >= 0 && end > start) {
+    return JSON.parse(trimmed.slice(start, end + 1)) as Record<string, unknown>;
   }
+  return JSON.parse(trimmed) as Record<string, unknown>;
 }
 
 /**
@@ -289,7 +285,12 @@ export async function hasTailscaleFunnelRouteForPort(
   } catch {
     return false;
   }
-  const parsed = stdout ? parsePossiblyNoisyJsonObject(stdout) : {};
+  let parsed: Record<string, unknown> = {};
+  try {
+    parsed = stdout ? parsePossiblyNoisyJsonObject(stdout) : {};
+  } catch {
+    return false;
+  }
   return tailscaleFunnelStatusCoversPort(parsed, port);
 }
 

--- a/src/infra/tailscale.ts
+++ b/src/infra/tailscale.ts
@@ -17,10 +17,14 @@ function parsePossiblyNoisyJsonObject(stdout: string): Record<string, unknown> {
   const trimmed = stdout.trim();
   const start = trimmed.indexOf("{");
   const end = trimmed.lastIndexOf("}");
-  if (start >= 0 && end > start) {
-    return JSON.parse(trimmed.slice(start, end + 1)) as Record<string, unknown>;
+  try {
+    if (start >= 0 && end > start) {
+      return JSON.parse(trimmed.slice(start, end + 1)) as Record<string, unknown>;
+    }
+    return JSON.parse(trimmed) as Record<string, unknown>;
+  } catch {
+    return {};
   }
-  return JSON.parse(trimmed) as Record<string, unknown>;
 }
 
 /**


### PR DESCRIPTION
## What Problem This Solves

`hasTailscaleFunnelRouteForPort` in `src/infra/tailscale.ts` calls `parsePossiblyNoisyJsonObject(stdout)` outside its try/catch block. If the tailscale CLI outputs non-JSON text (e.g. error messages, stale state warnings in unexpected format), `JSON.parse` throws an uncaught `SyntaxError` that propagates to the caller.

## Why This Change Was Made

Wraps the `parsePossiblyNoisyJsonObject` call in `hasTailscaleFunnelRouteForPort` with a focused try/catch that returns `false` on parse failure — the function already returns `false` on exec failure, so malformed stdout should be treated the same way.

This is a targeted fix: `parsePossiblyNoisyJsonObject` itself is left unchanged because other callers like `readTailscaleWhoisIdentity` rely on the SyntaxError for their error-TTL caching logic.

## User Impact

- Malformed tailscale CLI output no longer crashes `hasTailscaleFunnelRouteForPort`
- Function returns `false` (port not covered) instead of throwing
- Other callers of `parsePossiblyNoisyJsonObject` are unaffected

## Evidence

```
$ npx vitest run src/infra/tailscale.test.ts --reporter=verbose

 ✓  tailscale helpers > parses DNS name from tailscale status
 ✓  tailscale helpers > falls back to IP when DNS missing
 ✓  tailscale helpers > parses noisy JSON output from tailscale status
 ✓  tailscale helpers > hasTailscaleFunnelRouteForPort returns false on malformed status parse failures
 ... (30/30 passed)

 Test Files  1 passed (1)
      Tests  30 passed (30)
```