### PR TITLE
refactor(ui): share native context test provider

### DIFF
--- a/ui/src/app/context.test.ts
+++ b/ui/src/app/context.test.ts
@@ -1,30 +1,17 @@
-import { consume, ContextProvider } from "@lit/context";
+import { consume } from "@lit/context";
 import { LitElement } from "lit";
 import { afterEach, describe, expect, it } from "vitest";
 import type { RouteId } from "../app-route-paths.ts";
+import { createApplicationContextProvider } from "../test-helpers/application-context.ts";
 import { applicationContext, type ApplicationContext } from "./context.ts";
 
-const PROVIDER_ELEMENT_NAME = "test-application-context-provider";
 const CONSUMER_ELEMENT_NAME = "test-application-context-consumer";
-
-class TestApplicationContextProvider extends LitElement {
-  private readonly contextProvider = new ContextProvider(this, {
-    context: applicationContext,
-  });
-
-  setContext(context: ApplicationContext<RouteId>) {
-    this.contextProvider.setValue(context);
-  }
-}
 
 class TestApplicationContextConsumer extends LitElement {
   @consume({ context: applicationContext, subscribe: true })
   context?: ApplicationContext<RouteId>;
 }
 
-if (!customElements.get(PROVIDER_ELEMENT_NAME)) {
-  customElements.define(PROVIDER_ELEMENT_NAME, TestApplicationContextProvider);
-}
 if (!customElements.get(CONSUMER_ELEMENT_NAME)) {
   customElements.define(CONSUMER_ELEMENT_NAME, TestApplicationContextConsumer);
 }
@@ -37,15 +24,12 @@ describe("application context consumption", () => {
   it("rebinds a retained consumer after its provider value changes while disconnected", async () => {
     const initialContext = { basePath: "/initial" } as ApplicationContext<RouteId>;
     const replacementContext = { basePath: "/replacement" } as ApplicationContext<RouteId>;
-    const provider = document.createElement(
-      PROVIDER_ELEMENT_NAME,
-    ) as TestApplicationContextProvider;
+    const provider = createApplicationContextProvider(initialContext);
     const consumer = document.createElement(
       CONSUMER_ELEMENT_NAME,
     ) as TestApplicationContextConsumer;
 
     document.body.append(provider);
-    provider.setContext(initialContext);
     provider.append(consumer);
     await consumer.updateComplete;
     expect(consumer.context).toBe(initialContext);

--- a/ui/src/components/app-sidebar.test.ts
+++ b/ui/src/components/app-sidebar.test.ts
@@ -1,7 +1,5 @@
 /* @vitest-environment jsdom */
 
-import { ContextProvider } from "@lit/context";
-import { LitElement } from "lit";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type {
   SessionCatalog,
@@ -10,14 +8,14 @@ import type {
 import { GatewayRequestError, type GatewayBrowserClient } from "../api/gateway.ts";
 import type { AgentsListResult, SessionsListResult } from "../api/types.ts";
 import type { RouteId } from "../app-route-paths.ts";
-import {
-  applicationContext,
-  type ApplicationContext,
-  type ApplicationGateway,
-  type ApplicationGatewaySnapshot,
+import type {
+  ApplicationContext,
+  ApplicationGateway,
+  ApplicationGatewaySnapshot,
 } from "../app/context.ts";
 import { CATALOG_SESSION_CONTINUED_EVENT } from "../lib/sessions/catalog-key.ts";
 import type { SessionCapability } from "../lib/sessions/index.ts";
+import { createApplicationContextProvider } from "../test-helpers/application-context.ts";
 import { createStorageMock } from "../test-helpers/storage.ts";
 import {
   LOBSTER_LOGO_VISIT_EVENT,
@@ -35,22 +33,6 @@ type SessionState = SessionCapability["state"];
 // models.authStatus) on connect, which would interleave with the nth-call
 // assertions on the shared mocked client below. It has its own test file.
 vi.mock("./sidebar-attention.ts", () => ({}));
-
-const PROVIDER_ELEMENT_NAME = "test-app-sidebar-context-provider";
-
-class AppSidebarContextProvider extends LitElement {
-  private readonly contextProvider = new ContextProvider(this, {
-    context: applicationContext,
-  });
-
-  setContext(context: ApplicationContext<RouteId>) {
-    this.contextProvider.setValue(context);
-  }
-}
-
-if (!customElements.get(PROVIDER_ELEMENT_NAME)) {
-  customElements.define(PROVIDER_ELEMENT_NAME, AppSidebarContextProvider);
-}
 
 type SidebarLifecycleState = HTMLElement & {
   connected: boolean;
@@ -275,13 +257,12 @@ async function mountSidebar(
   variant: SidebarLifecycleState["variant"] = "panel",
   agentsList: AgentsListResult | null = null,
 ) {
-  const provider = document.createElement(PROVIDER_ELEMENT_NAME) as AppSidebarContextProvider;
+  const context = createContext(gateway, sessions, agentsList);
+  const provider = createApplicationContextProvider(context);
   const sidebar = document.createElement(
     "openclaw-app-sidebar",
   ) as unknown as SidebarLifecycleState;
   sidebar.variant = variant;
-  const context = createContext(gateway, sessions, agentsList);
-  provider.setContext(context);
   provider.append(sidebar);
   document.body.append(provider);
   await sidebar.updateComplete;

--- a/ui/src/components/command-palette.test.ts
+++ b/ui/src/components/command-palette.test.ts
@@ -1,35 +1,17 @@
 /* @vitest-environment jsdom */
 
-import { ContextProvider } from "@lit/context";
-import { LitElement } from "lit";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { GatewayBrowserClient } from "../api/gateway.ts";
 import type { SessionsListResult } from "../api/types.ts";
 import type { RouteId } from "../app-route-paths.ts";
-import {
-  applicationContext,
-  type ApplicationContext,
-  type ApplicationGateway,
-  type ApplicationGatewaySnapshot,
+import type {
+  ApplicationContext,
+  ApplicationGateway,
+  ApplicationGatewaySnapshot,
 } from "../app/context.ts";
+import { createApplicationContextProvider } from "../test-helpers/application-context.ts";
 import { installDialogPolyfill } from "../test-helpers/modal-dialog.ts";
 import { CommandPalette } from "./command-palette.ts";
-
-const PROVIDER_ELEMENT_NAME = "test-command-palette-context-provider";
-
-class CommandPaletteContextProvider extends LitElement {
-  private readonly contextProvider = new ContextProvider(this, {
-    context: applicationContext,
-  });
-
-  setContext(context: ApplicationContext<RouteId>) {
-    this.contextProvider.setValue(context);
-  }
-}
-
-if (!customElements.get(PROVIDER_ELEMENT_NAME)) {
-  customElements.define(PROVIDER_ELEMENT_NAME, CommandPaletteContextProvider);
-}
 
 type GatewayHarness = {
   gateway: ApplicationGateway;
@@ -112,11 +94,10 @@ function createDeferred<T>() {
 }
 
 async function mountPalette(context: ApplicationContext<RouteId>) {
-  const provider = document.createElement(PROVIDER_ELEMENT_NAME) as CommandPaletteContextProvider;
+  const provider = createApplicationContextProvider(context);
   const palette = document.createElement("openclaw-command-palette") as CommandPalette;
   palette.onNavigate = vi.fn();
   palette.onSelectSession = vi.fn();
-  provider.setContext(context);
   provider.append(palette);
   document.body.append(provider);
   await palette.updateComplete;

--- a/ui/src/pages/approval/approval-page.test.ts
+++ b/ui/src/pages/approval/approval-page.test.ts
@@ -1,7 +1,5 @@
 /* @vitest-environment jsdom */
 
-import { ContextProvider } from "@lit/context";
-import { LitElement } from "lit";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type {
   AllowedApprovalSnapshot,
@@ -12,27 +10,15 @@ import type {
 } from "../../../../packages/gateway-protocol/src/index.js";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { ApplicationContext, ApplicationGatewaySnapshot } from "../../app/context.ts";
-import { applicationContext } from "../../app/context.ts";
 import { i18n } from "../../i18n/index.ts";
+import { createApplicationContextProvider } from "../../test-helpers/application-context.ts";
 import { ApprovalPage } from "./approval-page.ts";
 
 const TEST_ELEMENT_SUFFIX = crypto.randomUUID();
-const PROVIDER_ELEMENT_NAME = `test-approval-page-context-provider-${TEST_ELEMENT_SUFFIX}`;
 const APPROVAL_PAGE_ELEMENT_NAME = `test-openclaw-approval-page-${TEST_ELEMENT_SUFFIX}`;
 
-class ApprovalPageContextProvider extends LitElement {
-  private readonly contextProvider = new ContextProvider(this, {
-    context: applicationContext,
-  });
-
-  setContext(context: ApplicationContext) {
-    this.contextProvider.setValue(context);
-  }
-}
-
 // The non-isolated UI runner resets modules but not customElements. Register
-// the current provider and page graphs so context and locale state stay paired.
-customElements.define(PROVIDER_ELEMENT_NAME, ApprovalPageContextProvider);
+// the current page graph so context and locale state stay paired.
 customElements.define(APPROVAL_PAGE_ELEMENT_NAME, class extends ApprovalPage {});
 
 type TestApprovalPage = HTMLElement & {
@@ -124,9 +110,8 @@ function createPage(params: {
   withBootFallback?: boolean;
 }) {
   const source = createGateway(params.client, params.connected);
-  const provider = document.createElement(PROVIDER_ELEMENT_NAME) as ApprovalPageContextProvider;
   const page = document.createElement(APPROVAL_PAGE_ELEMENT_NAME) as TestApprovalPage;
-  provider.setContext({
+  const provider = createApplicationContextProvider({
     basePath: "",
     gateway: source.gateway,
   } as unknown as ApplicationContext);

--- a/ui/src/pages/memory-import/memory-import-page.test.ts
+++ b/ui/src/pages/memory-import/memory-import-page.test.ts
@@ -1,29 +1,10 @@
 /* @vitest-environment jsdom */
 
-import { ContextProvider } from "@lit/context";
-import { LitElement } from "lit";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
-import {
-  applicationContext,
-  type ApplicationContext,
-  type ApplicationGatewaySnapshot,
-} from "../../app/context.ts";
+import { type ApplicationContext, type ApplicationGatewaySnapshot } from "../../app/context.ts";
+import { createApplicationContextProvider } from "../../test-helpers/application-context.ts";
 import "./memory-import-page.ts";
-
-const PROVIDER_TAG = "test-memory-import-context-provider";
-
-class MemoryImportContextProvider extends LitElement {
-  private readonly provider = new ContextProvider(this, { context: applicationContext });
-
-  setContext(context: ApplicationContext) {
-    this.provider.setValue(context);
-  }
-}
-
-if (!customElements.get(PROVIDER_TAG)) {
-  customElements.define(PROVIDER_TAG, MemoryImportContextProvider);
-}
 
 type MemoryImportPageElement = HTMLElement & {
   updateComplete: Promise<boolean>;
@@ -109,9 +90,8 @@ function createContext(request: ReturnType<typeof vi.fn>): ApplicationContext {
 }
 
 async function mountPage(context: ApplicationContext): Promise<MemoryImportPageElement> {
-  const provider = document.createElement(PROVIDER_TAG) as MemoryImportContextProvider;
+  const provider = createApplicationContextProvider(context);
   const page = document.createElement("openclaw-memory-import-page") as MemoryImportPageElement;
-  provider.setContext(context);
   provider.append(page);
   document.body.append(provider);
   await page.updateComplete;

--- a/ui/src/pages/plugins/plugins-page.test.ts
+++ b/ui/src/pages/plugins/plugins-page.test.ts
@@ -1,34 +1,21 @@
 /* @vitest-environment jsdom */
 
-import { ContextProvider } from "@lit/context";
 import { expectDefined } from "@openclaw/normalization-core";
-import { LitElement } from "lit";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
-import {
-  applicationContext,
-  type ApplicationContext,
-  type ApplicationGateway,
-  type ApplicationGatewaySnapshot,
+import type {
+  ApplicationContext,
+  ApplicationGateway,
+  ApplicationGatewaySnapshot,
 } from "../../app/context.ts";
 import { i18n } from "../../i18n/index.ts";
 import type { PluginCatalogItem, PluginListResult } from "../../lib/plugins/index.ts";
+import {
+  createApplicationContextProvider,
+  type ApplicationContextProvider,
+} from "../../test-helpers/application-context.ts";
 import type { PluginsRouteData } from "./plugins-page.ts";
 import "./plugins-page.ts";
-
-const PROVIDER_TAG = "test-plugins-page-context-provider";
-
-class PluginsPageContextProvider extends LitElement {
-  private readonly provider = new ContextProvider(this, { context: applicationContext });
-
-  setContext(context: ApplicationContext) {
-    this.provider.setValue(context);
-  }
-}
-
-if (!customElements.get(PROVIDER_TAG)) {
-  customElements.define(PROVIDER_TAG, PluginsPageContextProvider);
-}
 
 type RequestHandler = (method: string, params: unknown) => Promise<unknown>;
 
@@ -191,11 +178,10 @@ function createContext(
 async function mountPage(
   context: ApplicationContext,
   routeData?: PluginsRouteData,
-): Promise<{ page: TestPluginsPage; provider: PluginsPageContextProvider }> {
-  const provider = document.createElement(PROVIDER_TAG) as PluginsPageContextProvider;
+): Promise<{ page: TestPluginsPage; provider: ApplicationContextProvider }> {
+  const provider = createApplicationContextProvider(context);
   const page = document.createElement("openclaw-plugins-page") as unknown as TestPluginsPage;
   page.routeData = routeData;
-  provider.setContext(context);
   provider.append(page);
   document.body.append(provider);
   await page.updateComplete;

--- a/ui/src/pages/profile/profile-page.test.ts
+++ b/ui/src/pages/profile/profile-page.test.ts
@@ -1,33 +1,13 @@
 /* @vitest-environment jsdom */
 
-import { ContextProvider } from "@lit/context";
-import { LitElement } from "lit";
 import { afterEach, beforeEach, expect, it } from "vitest";
 import type { RouteId } from "../../app-route-paths.ts";
-import {
-  applicationContext,
-  type ApplicationContext,
-  type ApplicationGatewaySnapshot,
-} from "../../app/context.ts";
+import { type ApplicationContext, type ApplicationGatewaySnapshot } from "../../app/context.ts";
 import { i18n, t } from "../../i18n/index.ts";
+import { createApplicationContextProvider } from "../../test-helpers/application-context.ts";
 import { ProfilePage } from "./profile-page.ts";
 
-const PROVIDER_ELEMENT_NAME = "test-profile-page-context-provider";
 const PROFILE_PAGE_TEST_TAG = "test-openclaw-profile-page";
-
-class ProfilePageContextProvider extends LitElement {
-  private readonly contextProvider = new ContextProvider(this, {
-    context: applicationContext,
-  });
-
-  setContext(context: ApplicationContext<RouteId>) {
-    this.contextProvider.setValue(context);
-  }
-}
-
-if (!customElements.get(PROVIDER_ELEMENT_NAME)) {
-  customElements.define(PROVIDER_ELEMENT_NAME, ProfilePageContextProvider);
-}
 // Keep the element class on the same post-reset i18n module as this test.
 if (!customElements.get(PROFILE_PAGE_TEST_TAG)) {
   customElements.define(PROFILE_PAGE_TEST_TAG, class extends ProfilePage {});
@@ -66,9 +46,8 @@ afterEach(async () => {
 });
 
 it("refreshes translated copy when the locale changes while mounted", async () => {
-  const provider = document.createElement(PROVIDER_ELEMENT_NAME) as ProfilePageContextProvider;
+  const provider = createApplicationContextProvider(createContext());
   const page = document.createElement(PROFILE_PAGE_TEST_TAG) as ProfilePageElement;
-  provider.setContext(createContext());
   provider.append(page);
   document.body.append(provider);
   await page.updateComplete;

--- a/ui/src/test-helpers/application-context.ts
+++ b/ui/src/test-helpers/application-context.ts
@@ -1,0 +1,16 @@
+import { ContextProvider } from "@lit/context";
+import type { RouteId } from "../app-route-paths.ts";
+import { applicationContext, type ApplicationContext } from "../app/context.ts";
+
+export function createApplicationContextProvider(context: ApplicationContext<RouteId>) {
+  const host = document.createElement("div");
+  const provider = new ContextProvider(host, {
+    context: applicationContext,
+    initialValue: context,
+  });
+  return Object.assign(host, {
+    setContext: (value: ApplicationContext<RouteId>) => provider.setValue(value),
+  });
+}
+
+export type ApplicationContextProvider = ReturnType<typeof createApplicationContextProvider>;


### PR DESCRIPTION
## What Problem This Solves

Seven Control UI test suites each declared and registered a bespoke Lit custom element solely to host the same application context provider.

## Why This Change Was Made

Use the plain-HTMLElement host supported by `@lit/context` in one shared test helper. Each suite now creates that provider directly, preserving initial values and context updates while deleting custom-element registration boilerplate.

## User Impact

No runtime behavior change. Test code is 108 lines smaller and avoids seven global custom-element registrations.

## Evidence

- `node scripts/run-vitest.mjs ui/src/app/context.test.ts ui/src/pages/profile/profile-page.test.ts ui/src/pages/approval/approval-page.test.ts ui/src/pages/memory-import/memory-import-page.test.ts ui/src/components/command-palette.test.ts ui/src/components/app-sidebar.test.ts ui/src/pages/plugins/plugins-page.test.ts` — 116 tests passed
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.test.ui.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/test-ui.tsbuildinfo` — passed
- Targeted `oxfmt` and `git diff --check` — passed
- Fresh branch autoreview against `origin/main` — clean after verifying the exact `@lit/context` plain-element contract

Hosted CI intentionally not awaited per maintainer direction.
