### PR TITLE
fix(gateway): cap sessions.get when numeric limit is huge

### DIFF
--- a/src/gateway/server-methods/sessions-read.ts
+++ b/src/gateway/server-methods/sessions-read.ts
@@ -43,6 +43,7 @@ import {
   type SessionsPreviewEntry,
   type SessionsPreviewResult,
 } from "../session-utils.js";
+import { resolveSessionsGetMessageLimit } from "../sessions-get-limit.js";
 import { resolveSessionKeyFromResolveParams } from "../sessions-resolve.js";
 import { projectWorkerSessionPlacement } from "../worker-environments/placement-projector.js";
 import { loadOptionalServerMethodModelCatalog } from "./optional-model-catalog.js";
@@ -394,10 +395,9 @@ export const sessionReadHandlers: GatewayRequestHandlers = {
     if (!key) {
       return;
     }
-    const limit =
-      typeof p.limit === "number" && Number.isFinite(p.limit)
-        ? Math.max(1, Math.floor(p.limit))
-        : 200;
+    // Mirror chat.history / sessions-history HTTP: keep transcript reads bounded
+    // even when callers pass Number.MAX_SAFE_INTEGER-sized limits.
+    const limit = resolveSessionsGetMessageLimit(p.limit);
 
     const cfg = context.getRuntimeConfig();
     const requestedAgent = resolveRequestedGlobalAgentId(

--- a/src/gateway/server-methods/sessions.get-limit.test.ts
+++ b/src/gateway/server-methods/sessions.get-limit.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Production-path proof that sessions.get caps oversized numeric limits before
+ * transcript reads (same hard cap family as chat.history / sessions-history HTTP).
+ */
+import { expectDefined } from "@openclaw/normalization-core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { GatewayRequestContext, RespondFn } from "./types.js";
+
+const { readRecentMock } = vi.hoisted(() => ({
+  readRecentMock: vi.fn(async (_scope: unknown, _opts?: unknown) => ({
+    messages: [] as unknown[],
+    totalMessages: 0,
+  })),
+}));
+
+vi.mock("../session-transcript-readers.js", async () => {
+  const actual = await vi.importActual<typeof import("../session-transcript-readers.js")>(
+    "../session-transcript-readers.js",
+  );
+  return {
+    ...actual,
+    readRecentSessionMessagesWithStatsAsync: readRecentMock,
+  };
+});
+
+vi.mock("../session-utils.js", async () => {
+  const actual = await vi.importActual<typeof import("../session-utils.js")>("../session-utils.js");
+  return {
+    ...actual,
+    resolveGatewaySessionStoreTargetWithStore: () => ({
+      agentId: "main",
+      canonicalKey: "main",
+      storePath: "/tmp/sessions.json",
+      storeKeys: ["main"],
+      store: {
+        main: { sessionId: "sess-main", updatedAt: Date.now() },
+      },
+    }),
+  };
+});
+
+import { sessionsHandlers } from "./sessions.js";
+
+function createContext(): GatewayRequestContext {
+  return {
+    chatAbortControllers: new Map(),
+    getRuntimeConfig: () => ({ agents: { list: [{ id: "main", default: true }] } }),
+  } as unknown as GatewayRequestContext;
+}
+
+function createRespond(): RespondFn {
+  return vi.fn() as unknown as RespondFn;
+}
+
+describe("sessions.get message limit cap", () => {
+  beforeEach(() => {
+    readRecentMock.mockClear();
+  });
+
+  it("caps Number.MAX_SAFE_INTEGER before transcript reads", async () => {
+    const respond = createRespond();
+    await expectDefined(
+      sessionsHandlers["sessions.get"],
+      'sessionsHandlers["sessions.get"] test invariant',
+    )({
+      req: { id: "req-sessions-get-limit" } as never,
+      params: { key: "main", limit: Number.MAX_SAFE_INTEGER },
+      respond,
+      context: createContext(),
+      client: null,
+      isWebchatConnect: () => false,
+    });
+
+    expect(respond).toHaveBeenCalledWith(true, { messages: [] }, undefined);
+    expect(readRecentMock).toHaveBeenCalledTimes(1);
+    expect(readRecentMock.mock.calls[0]?.[1]).toEqual({
+      maxMessages: 1000,
+      maxLines: 20020,
+      allowResetArchiveFallback: true,
+    });
+  });
+});

--- a/src/gateway/server.sessions.get-limit.test.ts
+++ b/src/gateway/server.sessions.get-limit.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Live Gateway RPC proof that sessions.get caps oversized numeric limits.
+ */
+import { expect, test } from "vitest";
+import { writeSessionStore, testState } from "./test-helpers.js";
+import {
+  setupGatewaySessionsTestHarness,
+  sessionStoreEntry,
+  directSessionReq,
+  seedLinearSessionTranscript,
+} from "./test/server-sessions.test-helpers.js";
+
+const { createSessionStoreDir } = setupGatewaySessionsTestHarness();
+
+test("sessions.get caps oversized numeric limit over live Gateway RPC", async () => {
+  const { dir, storePath } = await createSessionStoreDir();
+  try {
+    const sessionId = "sess-get-limit-cap";
+    const seeded = 1005;
+    await writeSessionStore({
+      storePath,
+      entries: {
+        main: sessionStoreEntry(sessionId),
+      },
+    });
+    await seedLinearSessionTranscript({
+      contents: Array.from({ length: seeded }, (_, index) => `msg-${index}`),
+      sessionId,
+      sessionKey: "main",
+      storePath,
+    });
+
+    const result = await directSessionReq<{ messages?: unknown[] }>("sessions.get", {
+      key: "main",
+      limit: Number.MAX_SAFE_INTEGER,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.payload?.messages).toHaveLength(1000);
+    const rendered = JSON.stringify(result.payload?.messages ?? []);
+    expect(rendered).toContain("msg-1004");
+    expect(rendered).not.toContain("msg-0");
+  } finally {
+    testState.sessionStorePath = undefined;
+    void dir;
+  }
+});

--- a/src/gateway/sessions-get-limit.test.ts
+++ b/src/gateway/sessions-get-limit.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { resolveSessionsGetMessageLimit } from "./sessions-get-limit.js";
+
+describe("resolveSessionsGetMessageLimit", () => {
+  it("defaults missing or non-finite limits", () => {
+    expect(resolveSessionsGetMessageLimit(undefined)).toBe(200);
+    expect(resolveSessionsGetMessageLimit(Number.NaN)).toBe(200);
+    expect(resolveSessionsGetMessageLimit("12")).toBe(200);
+  });
+
+  it("floors and keeps positive limits under the hard cap", () => {
+    expect(resolveSessionsGetMessageLimit(1)).toBe(1);
+    expect(resolveSessionsGetMessageLimit(12.9)).toBe(12);
+    expect(resolveSessionsGetMessageLimit(1000)).toBe(1000);
+  });
+
+  it("caps oversized numeric limits before transcript reads", () => {
+    expect(resolveSessionsGetMessageLimit(1001)).toBe(1000);
+    expect(resolveSessionsGetMessageLimit(Number.MAX_SAFE_INTEGER)).toBe(1000);
+  });
+});

--- a/src/gateway/sessions-get-limit.ts
+++ b/src/gateway/sessions-get-limit.ts
@@ -1,0 +1,12 @@
+/** Default recent-message page size for `sessions.get`. */
+const SESSIONS_GET_DEFAULT_MESSAGE_LIMIT = 200;
+/** Hard cap shared with chat.history / sessions-history HTTP transcript pages. */
+const SESSIONS_GET_MAX_MESSAGE_LIMIT = 1000;
+
+/** Resolves `sessions.get` limit with a hard upper bound for oversized numeric input. */
+export function resolveSessionsGetMessageLimit(raw: unknown): number {
+  if (typeof raw !== "number" || !Number.isFinite(raw)) {
+    return SESSIONS_GET_DEFAULT_MESSAGE_LIMIT;
+  }
+  return Math.min(SESSIONS_GET_MAX_MESSAGE_LIMIT, Math.max(1, Math.floor(raw)));
+}


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Gateway `sessions.get` callers that pass an oversized numeric `limit` (for example `Number.MAX_SAFE_INTEGER`) would request unbounded transcript page sizes before the recent-message reader ran, unlike `chat.history` and sessions-history HTTP which already hard-cap at 1000.

## Why This Change Was Made

`sessions.get` now resolves `limit` through a shared helper with the same 200-default / 1000-max contract used by sibling history surfaces, so oversized numeric input is capped before `maxMessages` / `maxLines` transcript reads. No new config or env surface.

## User Impact

**Before:** Huge finite `limit` values were forwarded into transcript reads and could drive oversized scans.

**After:** Finite limits are floored, lower-bounded at 1, and hard-capped at 1000 before transcript reads. Missing / non-finite limits still default to 200.

## Evidence

- Helper: `src/gateway/sessions-get-limit.ts` (`resolveSessionsGetMessageLimit`)
- Caller: `src/gateway/server-methods/sessions-read.ts` (`sessions.get`)
- Sibling contracts: `src/gateway/server-methods/chat.ts` (`Math.min(1000, requested)`), `src/gateway/sessions-history-http.ts` (`MAX_SESSION_HISTORY_LIMIT = 1000`)
- Tests: helper unit, handler mock (caps before reader), live Gateway RPC

Focused run:

```text
 ✓ resolveSessionsGetMessageLimit > defaults missing or non-finite limits
 ✓ resolveSessionsGetMessageLimit > floors and keeps positive limits under the hard cap
 ✓ resolveSessionsGetMessageLimit > caps oversized numeric limits before transcript reads
 ✓ sessions.get message limit cap > caps Number.MAX_SAFE_INTEGER before transcript reads
 ✓ sessions.get caps oversized numeric limit over live Gateway RPC
 Test Files  3 passed (3)
      Tests  5 passed (5)
```

## Real behavior proof

- **Behavior or issue addressed:** `sessions.get` with `limit: Number.MAX_SAFE_INTEGER` returns at most 1000 recent messages over a live Gateway RPC, instead of requesting an unbounded transcript page.
- **Canonical reachability path:** Live Gateway WebSocket `sessions.get` → `sessionReadHandlers["sessions.get"]` in `sessions-read.ts` → `resolveSessionsGetMessageLimit(p.limit)` → `readRecentSessionMessagesWithStatsAsync(..., { maxMessages: 1000, maxLines: 20020 })`.
- **Boundary crossed:** live-local-gateway; real in-process Gateway server + session store + seeded transcript (1005 messages), no mocks of the limit resolver or transcript reader on this path.
- **Shared helper / provider constraint check:** Hard cap matches sibling `chat.history` / sessions-history HTTP (`1000`). Default remains `200` for missing/non-finite input.
- **Real environment tested:** Darwin 24.3.0 arm64, Node `v24.15.0` (embedded SQLite 3.51.3), Vitest gateway-server project.
- **Exact steps or command run after this patch:**

```text
$ node scripts/run-vitest.mjs src/gateway/server.sessions.get-limit.test.ts --reporter=verbose
# seeds 1005 transcript messages, calls live Gateway sessions.get with
# limit: Number.MAX_SAFE_INTEGER, asserts messages.length === 1000
```

- **Evidence after fix:**

```text
# Real Gateway sessions.get limit cap proof
# runtime: node v24.15.0 darwin arm64
# time: 2026-07-15T13:44:45Z
 ✓ |gateway-server| sessions.get caps oversized numeric limit over live Gateway RPC 1011ms
 Test Files  1 passed (1)
      Tests  1 passed (1)
# assertion: messages.length === 1000; payload contains msg-1004, not msg-0
```

- **Observed result after fix:** Live `sessions.get` with oversized numeric limit returns exactly 1000 recent messages (drops the oldest of 1005 seeded).
- **What was not tested:** Remote multi-host Gateway deployment / Control UI sessions page click-through.
- **Fix classification:** Root cause fix

- [x] AI-assisted (Cursor)
- [x] I understand what the code does
- [x] Change is focused and does not mix unrelated concerns
