### PR TITLE
fix(discord): reject invalid auto-archive durations before REST

### DIFF
--- a/extensions/discord/src/actions/handle-action.test.ts
+++ b/extensions/discord/src/actions/handle-action.test.ts
@@ -99,6 +99,23 @@ describe("handleDiscordMessageAction", () => {
     expect(handleDiscordActionMock).not.toHaveBeenCalled();
   });
 
+  it("rejects invalid autoArchiveMin before Discord thread-create runtime", async () => {
+    const cfg = discordConfig({ threads: true });
+    await expect(
+      handleDiscordMessageAction({
+        action: "thread-create",
+        params: {
+          channelId: "channel-1",
+          threadName: "proof-thread",
+          autoArchiveMin: 999,
+        },
+        cfg,
+        toolContext: { currentChannelProvider: "discord" },
+      }),
+    ).rejects.toThrow("autoArchiveMin must be one of 60, 1440, 4320, or 10080 minutes");
+    expect(handleDiscordActionMock).not.toHaveBeenCalled();
+  });
+
   it("uses Discord requesterSenderId for guild admin actions and ignores params senderUserId", async () => {
     const cfg = discordConfig({ channels: true });
     await handleDiscordMessageAction({

--- a/extensions/discord/src/actions/handle-action.ts
+++ b/extensions/discord/src/actions/handle-action.ts
@@ -28,6 +28,7 @@ import {
 import { resolveDiscordChannelId } from "../targets.js";
 import { tryHandleDiscordMessageActionGuildAdmin } from "./handle-action.guild-admin.js";
 import type { DiscordMessagingActionOptions } from "./runtime.messaging.shared.js";
+import { readDiscordAutoArchiveDurationParam } from "./runtime.shared.js";
 
 const providerId = "discord";
 
@@ -385,7 +386,7 @@ export async function handleDiscordMessageAction(
     const name = readStringParam(params, "threadName", { required: true });
     const messageId = readStringParam(params, "messageId");
     const content = readStringParam(params, "message");
-    const autoArchiveMinutes = readPositiveIntegerParam(params, "autoArchiveMin");
+    const autoArchiveMinutes = readDiscordAutoArchiveDurationParam(params, "autoArchiveMin");
     const appliedTags = readStringArrayParam(params, "appliedTags");
     const result = await handleDiscordAction(
       {

--- a/extensions/discord/src/actions/runtime.messaging.send.ts
+++ b/extensions/discord/src/actions/runtime.messaging.send.ts
@@ -15,6 +15,7 @@ import { isThreadChannelType } from "../send.permissions.js";
 import type { DiscordSendComponents, DiscordSendEmbeds } from "../send.shared.js";
 import { discordMessagingActionRuntime } from "./runtime.messaging.runtime.js";
 import type { DiscordMessagingActionContext } from "./runtime.messaging.shared.js";
+import { readDiscordAutoArchiveDurationParam } from "./runtime.shared.js";
 
 function hasDiscordComponentObjectKeys(value: unknown): value is Record<string, unknown> {
   return Boolean(
@@ -326,7 +327,10 @@ export async function handleDiscordMessageSendAction(ctx: DiscordMessagingAction
       const name = readStringParam(ctx.params, "name", { required: true });
       const messageId = readStringParam(ctx.params, "messageId");
       const content = readStringParam(ctx.params, "content");
-      const autoArchiveMinutes = readPositiveIntegerParam(ctx.params, "autoArchiveMinutes");
+      const autoArchiveMinutes = readDiscordAutoArchiveDurationParam(
+        ctx.params,
+        "autoArchiveMinutes",
+      );
       const appliedTags = readStringArrayParam(ctx.params, "appliedTags");
       const payload = {
         name,

--- a/extensions/discord/src/actions/runtime.shared.auto-archive.test.ts
+++ b/extensions/discord/src/actions/runtime.shared.auto-archive.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { readDiscordAutoArchiveDurationParam } from "./runtime.shared.js";
+
+describe("readDiscordAutoArchiveDurationParam", () => {
+  it("accepts Discord REST auto-archive durations", () => {
+    for (const minutes of [60, 1440, 4320, 10080]) {
+      expect(
+        readDiscordAutoArchiveDurationParam({ autoArchiveMinutes: minutes }, "autoArchiveMinutes"),
+      ).toBe(minutes);
+    }
+  });
+
+  it("omits missing values", () => {
+    expect(readDiscordAutoArchiveDurationParam({}, "autoArchiveMinutes")).toBeUndefined();
+  });
+
+  it("rejects positive integers Discord will not accept before REST", () => {
+    expect(() =>
+      readDiscordAutoArchiveDurationParam({ autoArchiveMinutes: 999 }, "autoArchiveMinutes"),
+    ).toThrow("autoArchiveMinutes must be one of 60, 1440, 4320, or 10080 minutes");
+  });
+});

--- a/extensions/discord/src/actions/runtime.shared.ts
+++ b/extensions/discord/src/actions/runtime.shared.ts
@@ -12,6 +12,9 @@ import type {
   DiscordChannelMove,
 } from "../send.types.js";
 
+/** Discord REST auto_archive_duration allowlist (minutes). */
+const DISCORD_AUTO_ARCHIVE_MINUTES = new Set([60, 1440, 4320, 10080]);
+
 export function readDiscordParentIdParam(
   params: Record<string, unknown>,
 ): string | null | undefined {
@@ -22,6 +25,24 @@ export function readDiscordParentIdParam(
     return null;
   }
   return readStringParam(params, "parentId");
+}
+
+/**
+ * Reads Discord auto-archive duration minutes and rejects values Discord will
+ * not accept, so thread/channel edits fail closed before the REST call.
+ */
+export function readDiscordAutoArchiveDurationParam(
+  params: Record<string, unknown>,
+  key: string,
+): number | undefined {
+  const value = readPositiveIntegerParam(params, key);
+  if (value === undefined) {
+    return undefined;
+  }
+  if (!DISCORD_AUTO_ARCHIVE_MINUTES.has(value)) {
+    throw new Error(`${key} must be one of 60, 1440, 4320, or 10080 minutes`);
+  }
+  return value;
 }
 
 function readDiscordBooleanParam(
@@ -75,7 +96,7 @@ export function readDiscordChannelEditParams(params: Record<string, unknown>): D
     rateLimitPerUser: readNonNegativeIntegerParam(params, "rateLimitPerUser") ?? undefined,
     archived: readDiscordBooleanParam(params, "archived"),
     locked: readDiscordBooleanParam(params, "locked"),
-    autoArchiveDuration: readPositiveIntegerParam(params, "autoArchiveDuration") ?? undefined,
+    autoArchiveDuration: readDiscordAutoArchiveDurationParam(params, "autoArchiveDuration"),
     availableTags: parseAvailableTags(params.availableTags),
   };
 }

--- a/extensions/discord/src/actions/runtime.test.ts
+++ b/extensions/discord/src/actions/runtime.test.ts
@@ -2402,6 +2402,22 @@ describe("handleDiscordMessagingAction", () => {
     );
   });
 
+  it("rejects invalid autoArchiveMinutes before Discord thread create", async () => {
+    createThreadDiscord.mockClear();
+    await expect(
+      handleMessagingAction(
+        "threadCreate",
+        {
+          channelId: "C1",
+          name: "thread",
+          autoArchiveMinutes: 999,
+        },
+        enableAllActions,
+      ),
+    ).rejects.toThrow("autoArchiveMinutes must be one of 60, 1440, 4320, or 10080 minutes");
+    expect(createThreadDiscord).not.toHaveBeenCalled();
+  });
+
   it("returns partial success when Discord creates the thread but initial message send fails", async () => {
     const thread = { id: "T1", name: "thread", type: 11 };
     createThreadDiscord.mockRejectedValueOnce(


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Discord thread/channel actions accepting arbitrary positive `autoArchiveMinutes` / `autoArchiveDuration` / `autoArchiveMin` values (for example `999`) would reach Discord REST and fail with an Invalid Form Body error instead of failing closed locally.

## Why This Change Was Made

Thread-create and channel-edit paths now validate auto-archive durations against Discord's allowlist (`60`, `1440`, `4320`, `10080`) via one shared reader before calling create/edit APIs. No new config or env surface.

## User Impact

**Before:** Invalid auto-archive durations were accepted locally and failed at Discord REST.

**After:** Invalid durations get a clear local error and no Discord REST call is made. Valid allowlisted durations are unchanged.

## Evidence

- Shared reader: `extensions/discord/src/actions/runtime.shared.ts` (`readDiscordAutoArchiveDurationParam`)
- Callers: `runtime.messaging.send.ts` (`threadCreate`), `handle-action.ts` (`thread-create`), `readDiscordChannelEditParams` (`channelEdit`)
- Regression tests: `runtime.shared.auto-archive.test.ts`, `runtime.test.ts`, `handle-action.test.ts`

Supplemental unit run:

```text
 ✓ |extension-discord| ../../extensions/discord/src/actions/runtime.test.ts > handleDiscordMessagingAction > rejects invalid autoArchiveMinutes before Discord thread create 85ms
 ✓ |extension-discord| ../../extensions/discord/src/actions/handle-action.test.ts > handleDiscordMessageAction > rejects invalid autoArchiveMin before Discord thread-create runtime 1ms
 ✓ |extension-discord| ../../extensions/discord/src/actions/runtime.shared.auto-archive.test.ts > readDiscordAutoArchiveDurationParam > accepts Discord REST auto-archive durations 0ms
 Test Files  3 passed (3)
      Tests  3 passed | 176 skipped (179)
```

## Real behavior proof

- **Behavior or issue addressed:** Unsupported auto-archive duration `999` is rejected locally before Discord REST on thread-create / channel-edit action paths.
- **Canonical reachability path:** Message-tool `handleDiscordMessageAction({ action: "thread-create", autoArchiveMin: 999 })` → `readDiscordAutoArchiveDurationParam` (throw) before `handleDiscordAction` / `createThreadDiscord`; messaging `handleDiscordMessagingAction("threadCreate", { autoArchiveMinutes: 999 })` → same reader before `discordMessagingActionRuntime.createThreadDiscord`; `handleDiscordAction({ action: "channelEdit", autoArchiveDuration: 999 })` → `readDiscordChannelEditParams` before `editChannelDiscord`.
- **Boundary crossed:** local-runtime; Discord action runtime with instrumented REST helpers and `fetch` (no live Discord API / bot token).
- **Shared helper / provider constraint check:** Discord REST allowlist is `60|1440|4320|10080` minutes; reused `readPositiveIntegerParam` then allowlist-checked. Provider HTTP not reached.
- **Real environment tested:** Darwin arm64, Node `v22.22.0`, tsx loading production Discord action modules, stubbed `createThreadDiscord` / `editChannelDiscord` / `fetch`.
- **Exact steps or command run after this patch:**

```text
$ tsx discord-auto-archive-proof.mts
# invokes production handleDiscordMessageAction / handleDiscordMessagingAction / handleDiscordAction
# with autoArchive*=999 and counts REST helper + fetch calls
```

- **Evidence after fix:**

```text
# Real Discord action proof: reject invalid auto-archive before REST
# runtime: node v22.22.0 darwin arm64
# time: 2026-07-15T13:32:59.050Z
# note: no Discord network; REST helpers + fetch instrumented
[message-tool thread-create autoArchiveMin=999] autoArchiveMin must be one of 60, 1440, 4320, or 10080 minutes
[messaging threadCreate autoArchiveMinutes=999] autoArchiveMinutes must be one of 60, 1440, 4320, or 10080 minutes
[channelEdit autoArchiveDuration=999] autoArchiveDuration must be one of 60, 1440, 4320, or 10080 minutes
[handleDiscordAction channelEdit autoArchiveDuration=999] autoArchiveDuration must be one of 60, 1440, 4320, or 10080 minutes
createThreadDiscord calls: 0
editChannelDiscord calls: 0
fetch calls: 0
```

- **Observed result after fix:** All four invalid-`999` attempts fail with the allowlist error. `createThreadDiscord`, `editChannelDiscord`, and `fetch` each remain at 0 calls.
- **What was not tested:** Live Discord bot token / real guild thread create against Discord API.
- **Fix classification:** Root cause fix

- [x] AI-assisted (Cursor)
- [x] I understand what the code does
- [x] Change is focused and does not mix unrelated concerns
