### PR TITLE
test(agents): skip unrelated message tool setup

### DIFF
--- a/src/agents/openclaw-tools.client-caps.test.ts
+++ b/src/agents/openclaw-tools.client-caps.test.ts
@@ -39,6 +39,7 @@ describe("gateway client capability tool filtering", () => {
   it("does not let tools.allow resurrect a gated tool for a channel run", () => {
     const tools = createOpenClawCodingTools({
       messageProvider: "telegram",
+      disableMessageTool: true,
       config: { tools: { allow: ["show_widget"] } },
       toolConstructionPlan: {
         includeBaseCodingTools: false,


### PR DESCRIPTION
## What Problem This Solves

`openclaw-tools.client-caps.test.ts` spent 13-20 seconds constructing the message tool for a capability-gating assertion that never uses it. On a focused Testbox run, the file reached 1.80 GB RSS and 23.60 seconds wall time.

## Why This Change Was Made

The test now uses the existing `disableMessageTool` construction option. It still exercises the real coding-tool assembly, plugin resolution, client-capability filter, and `tools.allow` policy pipeline; only the unrelated message-tool surface is omitted.

## User Impact

No runtime behavior change. Faster and lower-memory CI.

## Evidence

- Blacksmith Testbox `tbx_01kxgjw3nd48r1t1hypejz38t7`
- Before: 5 tests passed; 13.238s test phase, 21.41s Vitest duration, 23.60s wall, 1,797,496 KB max RSS
- After run 1: 5 tests passed; 0.252s test phase, 3.03s Vitest duration, 5.18s wall, 874,880 KB max RSS
- After run 2: 5 tests passed; 0.287s test phase, 3.09s Vitest duration, 5.38s wall, 882,016 KB max RSS
- `pnpm check:changed -- src/agents/openclaw-tools.client-caps.test.ts`
- Fresh autoreview: clean, confidence 0.95
