### PR TITLE
fix(meeting-bot): preserve spawn failure diagnostics

### DIFF
--- a/extensions/google-meet/node-host.test.ts
+++ b/extensions/google-meet/node-host.test.ts
@@ -163,6 +163,93 @@ describe("google-meet node host bridge sessions", () => {
     }
   });
 
+  it("rejects Chrome launch when the command exits by signal", async () => {
+    const originalPlatform = process.platform;
+    vi.mocked(spawnSync).mockImplementationOnce(() => ({
+      pid: 123,
+      output: [null, "", ""],
+      stdout: "",
+      stderr: "",
+      status: null,
+      signal: "SIGTERM",
+    }));
+
+    Object.defineProperty(process, "platform", { configurable: true, value: "darwin" });
+    try {
+      await expect(
+        handleGoogleMeetNodeHostCommand(
+          JSON.stringify({
+            action: "start",
+            url: "https://meet.google.com/xyz-abcd-uvw",
+            mode: "transcribe",
+          }),
+        ),
+      ).rejects.toThrow("failed to launch Chrome for Meet: terminated by SIGTERM");
+    } finally {
+      Object.defineProperty(process, "platform", { configurable: true, value: originalPlatform });
+    }
+  });
+
+  it("preserves timeout diagnostics when Chrome launch stderr is empty", async () => {
+    const originalPlatform = process.platform;
+    const error = Object.assign(new Error("spawnSync open ETIMEDOUT"), { code: "ETIMEDOUT" });
+    vi.mocked(spawnSync).mockImplementationOnce(() => ({
+      pid: 123,
+      output: [null, "", ""],
+      stdout: "",
+      stderr: "",
+      status: null,
+      signal: "SIGTERM",
+      error,
+    }));
+
+    Object.defineProperty(process, "platform", { configurable: true, value: "darwin" });
+    try {
+      await expect(
+        handleGoogleMeetNodeHostCommand(
+          JSON.stringify({
+            action: "start",
+            url: "https://meet.google.com/xyz-abcd-uvw",
+            mode: "transcribe",
+          }),
+        ),
+      ).rejects.toThrow("failed to launch Chrome for Meet: spawnSync open ETIMEDOUT");
+    } finally {
+      Object.defineProperty(process, "platform", { configurable: true, value: originalPlatform });
+    }
+  });
+
+  it("preserves timeout diagnostics when Chrome launch also writes stderr", async () => {
+    const originalPlatform = process.platform;
+    const error = Object.assign(new Error("spawnSync open ETIMEDOUT"), { code: "ETIMEDOUT" });
+    vi.mocked(spawnSync).mockImplementationOnce(() => ({
+      pid: 123,
+      output: [null, "", "child warning"],
+      stdout: "",
+      stderr: "child warning",
+      status: null,
+      signal: "SIGTERM",
+      error,
+    }));
+
+    Object.defineProperty(process, "platform", { configurable: true, value: "darwin" });
+    try {
+      await expect(
+        handleGoogleMeetNodeHostCommand(
+          JSON.stringify({
+            action: "start",
+            url: "https://meet.google.com/xyz-abcd-uvw",
+            mode: "transcribe",
+          }),
+        ),
+      ).rejects.toThrow(
+        "failed to launch Chrome for Meet: spawnSync open ETIMEDOUT: child warning",
+      );
+    } finally {
+      Object.defineProperty(process, "platform", { configurable: true, value: originalPlatform });
+    }
+  });
+
   it("clears output playback without closing the active bridge when the old output exits", async () => {
     const originalPlatform = process.platform;
     children.length = 0;

--- a/src/meeting-bot/node-host.ts
+++ b/src/meeting-bot/node-host.ts
@@ -81,10 +81,15 @@ function runCommandWithTimeout(argv: string[], timeoutMs: number) {
     throw new Error("command must not be empty");
   }
   const result = spawnSync(command, args, { encoding: "utf8", timeout: timeoutMs });
+  const errorMessage = result.error ? formatErrorMessage(result.error) : "";
+  const stderr =
+    errorMessage && result.stderr
+      ? `${errorMessage}: ${result.stderr}`
+      : errorMessage || result.stderr || (result.signal ? `terminated by ${result.signal}` : "");
   return {
-    code: typeof result.status === "number" ? result.status : result.error ? 1 : 0,
+    code: typeof result.status === "number" ? result.status : 1,
     stdout: result.stdout ?? "",
-    stderr: result.stderr ?? (result.error ? formatErrorMessage(result.error) : ""),
+    stderr,
   };
 }
 


### PR DESCRIPTION
## What Problem This Solves

The shared meeting node host could treat a `spawnSync()` process that exited only by signal as successful because Node returns `status: null` without necessarily setting `error`. Timeout failures could also lose `ETIMEDOUT` when `stderr` was empty, or report only child stderr when both were present.

## Why This Change Was Made

The audio-pull waiter leak originally addressed by this PR was fixed on `main` by #109755 in the shared meeting-bot layer. This refresh replaces the superseded, conflicting diff with a small fix at the current shared process-result owner instead of patching the Google Meet call sites independently.

The normalized result now:

- treats every non-numeric `status` as failure;
- reports the terminating signal when no stronger diagnostic exists;
- preserves `spawnSync()` errors such as `ETIMEDOUT`;
- combines the spawn error with non-empty child stderr so neither diagnostic is lost.

## User Impact

Meeting audio health checks, external audio bridge startup, and Chrome launch no longer continue after a signal-only process failure. Timeout errors retain the actual `ETIMEDOUT` cause, including when the child wrote stderr before timing out.

## Evidence

- `node scripts/run-vitest.mjs extensions/google-meet/node-host.test.ts` — 13 tests passed.
- `node scripts/run-vitest.mjs src/meeting-bot/node-host.test.ts` — 1 test passed.
- `oxfmt --check src/meeting-bot/node-host.ts extensions/google-meet/node-host.test.ts` — passed.
- Type-aware Oxlint against `tsconfig.core.json` and `test/tsconfig/tsconfig.extensions.test.json` for the two changed files — passed.
- `git diff --check` — passed.
- Node 24 signal-only probe: `status=null`, `signal=SIGTERM`, no spawn error; normalized to failure with `terminated by SIGTERM`.
- Node 24 timeout probe with empty stderr: `status=null`, `error.code=ETIMEDOUT`; normalized to failure while preserving the timeout error.
- Node 24 timeout probe with child stderr: normalized diagnostic retained both `ETIMEDOUT` and the child stderr.

Full local test typechecking was blocked by the same dependency-registry failures that left `@microsoft/mxc-sdk` unavailable after the permitted install retry; exact-head CI is the remaining typecheck evidence. This proof covers the real Node child-process contract and the production command-handler mapping, not a live Google Meet, Chrome, or BlackHole session.