### PR TITLE
fix(google-meet): bound attendance grace by numeric safety so late checks stay finite

### DIFF
--- a/extensions/google-meet/index.test.ts
+++ b/extensions/google-meet/index.test.ts
@@ -1564,6 +1564,54 @@ describe("google-meet plugin", () => {
     ]);
   });
 
+  it("keeps late detection finite when lateAfterMinutes would overflow", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = requestUrl(input);
+      if (url.pathname === "/v2/conferenceRecords/rec-1") {
+        return jsonResponse({
+          name: "conferenceRecords/rec-1",
+          startTime: "2026-04-25T10:00:00Z",
+          endTime: "2026-04-27T11:00:00Z",
+        });
+      }
+      if (url.pathname === "/v2/conferenceRecords/rec-1/participants") {
+        return jsonResponse({
+          participants: [
+            {
+              name: "conferenceRecords/rec-1/participants/p1",
+              signedinUser: { user: "users/alice", displayName: "Alice" },
+            },
+          ],
+        });
+      }
+      if (url.pathname === "/v2/conferenceRecords/rec-1/participants/p1/participantSessions") {
+        return jsonResponse({
+          participantSessions: [
+            {
+              name: "conferenceRecords/rec-1/participants/p1/participantSessions/s1",
+              // More than default 5-minute grace after conference start.
+              startTime: "2026-04-25T10:30:00Z",
+              endTime: "2026-04-25T11:00:00Z",
+            },
+          ],
+        });
+      }
+      return new Response(`unexpected ${url.pathname}`, { status: 404 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await fetchGoogleMeetAttendance({
+      accessToken: "token",
+      conferenceRecord: "rec-1",
+      // Overflow-class input must not disable late detection via Infinity grace.
+      lateAfterMinutes: 1e308,
+    });
+
+    expect(result.attendance).toHaveLength(1);
+    expect(result.attendance[0]?.late).toBe(true);
+    expect(result.attendance[0]?.lateByMs).toBe(30 * 60_000);
+  });
+
   it("surfaces Developer Preview acknowledgment blockers in preflight reports", () => {
     const report = buildGoogleMeetPreflightReport({
       input: "abc-defg-hij",

--- a/extensions/google-meet/index.ts
+++ b/extensions/google-meet/index.ts
@@ -17,6 +17,10 @@ import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runti
 import { jsonResult as json } from "openclaw/plugin-sdk/tool-results";
 import { Type } from "typebox";
 import {
+  optionalAttendanceGraceMinutesSchema,
+  readAttendanceGraceParam,
+} from "./src/attendance-grace.js";
+import {
   buildGoogleMeetCalendarDayWindow,
   findGoogleMeetCalendarEvent,
   listGoogleMeetCalendarEvents,
@@ -44,11 +48,8 @@ import {
 } from "./src/node-invoke-policy.js";
 import { GoogleMeetRuntime } from "./src/runtime.js";
 import { isGoogleMeetBrowserManualActionError } from "./src/transports/chrome-create.js";
-
 const loadGoogleMeetCreateModule = createLazyRuntimeModule(() => import("./src/create.js"));
-
 const loadGoogleMeetCliModule = createLazyRuntimeModule(() => import("./src/cli.js"));
-
 const googleMeetConfigSchema = {
   parse(value: unknown) {
     return resolveGoogleMeetConfig(value);
@@ -223,7 +224,6 @@ const googleMeetConfigSchema = {
     },
   },
 };
-
 const GoogleMeetToolSchema = Type.Object({
   action: Type.String({
     enum: [
@@ -338,19 +338,18 @@ const GoogleMeetToolSchema = Type.Object({
   mergeDuplicateParticipants: Type.Optional(
     Type.Boolean({ description: "For attendance, merge duplicate participant resources." }),
   ),
-  lateAfterMinutes: optionalPositiveIntegerSchema({
-    description: "For attendance, mark participants late after this many minutes.",
-  }),
-  earlyBeforeMinutes: optionalPositiveIntegerSchema({
-    description: "For attendance, mark early leavers before this many minutes.",
-  }),
+  lateAfterMinutes: optionalAttendanceGraceMinutesSchema(
+    "For attendance, mark participants late after this many minutes.",
+  ),
+  earlyBeforeMinutes: optionalAttendanceGraceMinutesSchema(
+    "For attendance, mark early leavers before this many minutes.",
+  ),
   accessToken: Type.Optional(Type.String({ description: "Access token override" })),
   refreshToken: Type.Optional(Type.String({ description: "Refresh token override" })),
   clientId: Type.Optional(Type.String({ description: "OAuth client id override" })),
   clientSecret: Type.Optional(Type.String({ description: "OAuth client secret override" })),
   expiresAt: Type.Optional(Type.Number({ description: "Cached access token expiry ms" })),
 });
-
 function asParamRecord(params: unknown): Record<string, unknown> {
   return params && typeof params === "object" && !Array.isArray(params)
     ? (params as Record<string, unknown>)
@@ -621,8 +620,8 @@ async function resolveArtifactQueryFromParams(
     includeDocumentBodies: raw.includeDocumentBodies === true,
     allConferenceRecords: raw.includeAllConferenceRecords === true,
     mergeDuplicateParticipants: raw.mergeDuplicateParticipants !== false,
-    lateAfterMinutes: readPositiveIntegerParam(raw, "lateAfterMinutes"),
-    earlyBeforeMinutes: readPositiveIntegerParam(raw, "earlyBeforeMinutes"),
+    lateAfterMinutes: readAttendanceGraceParam(raw, "lateAfterMinutes"),
+    earlyBeforeMinutes: readAttendanceGraceParam(raw, "earlyBeforeMinutes"),
   };
 }
 

--- a/extensions/google-meet/src/attendance-grace.test.ts
+++ b/extensions/google-meet/src/attendance-grace.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { resolveAttendanceGraceMinutes } from "./attendance-grace.js";
+
+describe("resolveAttendanceGraceMinutes", () => {
+  it("defaults missing or non-finite values", () => {
+    expect(resolveAttendanceGraceMinutes(undefined)).toBe(5);
+    expect(resolveAttendanceGraceMinutes(Number.NaN)).toBe(5);
+    expect(resolveAttendanceGraceMinutes(1.9)).toBe(1);
+  });
+
+  it("preserves finite windows above one day", () => {
+    expect(resolveAttendanceGraceMinutes(1_441)).toBe(1_441);
+    expect(resolveAttendanceGraceMinutes(100_000)).toBe(100_000);
+  });
+
+  it("falls back for overflow-class values that would become Infinity grace", () => {
+    expect(resolveAttendanceGraceMinutes(Number.MAX_SAFE_INTEGER)).toBe(5);
+    expect(resolveAttendanceGraceMinutes(1e308)).toBe(5);
+    expect(Number.isFinite(resolveAttendanceGraceMinutes(1e308) * 60_000)).toBe(true);
+  });
+});

--- a/extensions/google-meet/src/attendance-grace.ts
+++ b/extensions/google-meet/src/attendance-grace.ts
@@ -1,0 +1,76 @@
+import {
+  optionalPositiveIntegerSchema,
+  readPositiveIntegerParam,
+} from "openclaw/plugin-sdk/channel-actions";
+import { parseStrictPositiveInteger } from "openclaw/plugin-sdk/number-runtime";
+
+/** Default late/early grace window for attendance annotations. */
+const GOOGLE_MEET_ATTENDANCE_GRACE_DEFAULT_MINUTES = 5;
+
+/**
+ * Max minutes where minutes * 60_000 stays within Number.MAX_SAFE_INTEGER.
+ * Rejects overflow-class inputs without inventing a one-day product policy.
+ */
+const GOOGLE_MEET_ATTENDANCE_GRACE_MAX_MINUTES = Math.floor(Number.MAX_SAFE_INTEGER / 60_000);
+
+/**
+ * Resolves attendance grace minutes to a finite positive integer. Non-finite or
+ * overflow-class values fall back so late/early checks stay meaningful.
+ */
+export function resolveAttendanceGraceMinutes(
+  raw: unknown,
+  fallback = GOOGLE_MEET_ATTENDANCE_GRACE_DEFAULT_MINUTES,
+): number {
+  if (typeof raw !== "number" || !Number.isFinite(raw)) {
+    return fallback;
+  }
+  const floored = Math.floor(raw);
+  if (floored < 1 || floored > GOOGLE_MEET_ATTENDANCE_GRACE_MAX_MINUTES) {
+    return fallback;
+  }
+  return floored;
+}
+
+/** CLI parser: reject floats, zero, and numeric-overflow grace windows. */
+function parseAttendanceGraceMinutesOption(
+  value: string | undefined,
+  label: string,
+): number | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  const parsed = parseStrictPositiveInteger(value);
+  if (parsed === undefined || parsed > GOOGLE_MEET_ATTENDANCE_GRACE_MAX_MINUTES) {
+    throw new Error(
+      `${label} must be a positive integer between 1 and ${GOOGLE_MEET_ATTENDANCE_GRACE_MAX_MINUTES}`,
+    );
+  }
+  return parsed;
+}
+
+export function parseLateAfterMinutesOption(value: string | undefined): number | undefined {
+  return parseAttendanceGraceMinutesOption(value, "late-after-minutes");
+}
+
+export function parseEarlyBeforeMinutesOption(value: string | undefined): number | undefined {
+  return parseAttendanceGraceMinutesOption(value, "early-before-minutes");
+}
+
+/** Tool schema for late/early grace minutes (matches CLI/runtime max). */
+export function optionalAttendanceGraceMinutesSchema(description: string) {
+  return optionalPositiveIntegerSchema({
+    description,
+    maximum: GOOGLE_MEET_ATTENDANCE_GRACE_MAX_MINUTES,
+  });
+}
+
+/** Tool param reader for late/early grace minutes. */
+export function readAttendanceGraceParam(
+  raw: Record<string, unknown>,
+  key: string,
+): number | undefined {
+  return readPositiveIntegerParam(raw, key, {
+    max: GOOGLE_MEET_ATTENDANCE_GRACE_MAX_MINUTES,
+    message: `${key} must be a positive integer between 1 and ${GOOGLE_MEET_ATTENDANCE_GRACE_MAX_MINUTES}`,
+  });
+}

--- a/extensions/google-meet/src/cli.test.ts
+++ b/extensions/google-meet/src/cli.test.ts
@@ -528,6 +528,35 @@ describe("google-meet CLI", () => {
     },
   );
 
+  it.each([
+    ["1.5", "late-after-minutes must be a positive integer between 1 and"],
+    ["0", "late-after-minutes must be a positive integer between 1 and"],
+    [
+      String(Number.MAX_SAFE_INTEGER),
+      "late-after-minutes must be a positive integer between 1 and",
+    ],
+  ])("rejects invalid attendance grace minutes: %s", async (value, message) => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      setupCli({}).parseAsync(
+        [
+          "googlemeet",
+          "attendance",
+          "--access-token",
+          "token",
+          "--conference-record",
+          "rec-1",
+          "--late-after-minutes",
+          value,
+        ],
+        { from: "user" },
+      ),
+    ).rejects.toThrow(message);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it("prints markdown artifact and attendance output", async () => {
     stubMeetArtifactsApi();
     const tempDir = mkdtempSync(path.join(tmpdir(), "openclaw-google-meet-artifacts-"));

--- a/extensions/google-meet/src/cli.ts
+++ b/extensions/google-meet/src/cli.ts
@@ -12,6 +12,7 @@ import {
   parseStrictPositiveInteger,
 } from "openclaw/plugin-sdk/number-runtime";
 import prettyMilliseconds from "pretty-ms";
+import { parseEarlyBeforeMinutesOption, parseLateAfterMinutesOption } from "./attendance-grace.js";
 import {
   buildGoogleMeetCalendarDayWindow,
   findGoogleMeetCalendarEvent,
@@ -46,7 +47,6 @@ import {
   waitForGoogleMeetAuthCode,
 } from "./oauth.js";
 import type { GoogleMeetRuntime } from "./runtime.js";
-
 type JoinOptions = {
   transport?: GoogleMeetTransport;
   mode?: GoogleMeetModeInput;
@@ -791,8 +791,8 @@ function resolveArtifactTokenOptions(
     allConferenceRecords: Boolean(options.allConferenceRecords),
     includeDocumentBodies: Boolean(options.includeDocBodies),
     mergeDuplicateParticipants: options.mergeDuplicates !== false,
-    lateAfterMinutes: parseOptionalNumber(options.lateAfterMinutes),
-    earlyBeforeMinutes: parseOptionalNumber(options.earlyBeforeMinutes),
+    lateAfterMinutes: parseLateAfterMinutesOption(options.lateAfterMinutes),
+    earlyBeforeMinutes: parseEarlyBeforeMinutesOption(options.earlyBeforeMinutes),
   };
 }
 

--- a/extensions/google-meet/src/meet.ts
+++ b/extensions/google-meet/src/meet.ts
@@ -1,7 +1,7 @@
 import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
-// Google Meet plugin module implements meet behavior.
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import { uniqueStrings } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { resolveAttendanceGraceMinutes } from "./attendance-grace.js";
 import { exportGoogleDriveDocumentText, extractGoogleDriveDocumentId } from "./drive.js";
 import { googleApiError } from "./google-api-errors.js";
 
@@ -738,8 +738,8 @@ function decorateAttendanceRow(
   const conferenceEndMs = parseGoogleMeetTimestamp(conferenceRecord.endTime);
   const firstJoinMs = parseGoogleMeetTimestamp(firstJoinTime);
   const lastLeaveMs = parseGoogleMeetTimestamp(lastLeaveTime);
-  const lateGraceMs = (params.lateAfterMinutes ?? 5) * 60_000;
-  const earlyGraceMs = (params.earlyBeforeMinutes ?? 5) * 60_000;
+  const lateGraceMs = resolveAttendanceGraceMinutes(params.lateAfterMinutes) * 60_000;
+  const earlyGraceMs = resolveAttendanceGraceMinutes(params.earlyBeforeMinutes) * 60_000;
   const lateByMs =
     conferenceStartMs !== undefined && firstJoinMs !== undefined
       ? Math.max(firstJoinMs - conferenceStartMs, 0)


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Google Meet attendance late/early annotation would never mark a participant as `late` or `earlyLeave` when an overflow-class grace value such as `1e308` was passed. `lateAfterMinutes * 60_000` became `Infinity`, so the comparison was always false.

## Why This Change Was Made

Bound grace minutes by numeric safety (`floor(MAX_SAFE_INTEGER / 60_000)`) across CLI parsing, tool params, and runtime decoration, instead of inventing a one-day product policy. Finite windows above one day stay accepted; overflow-class values are rejected at CLI/tool boundaries and fall back to the default (5) in decoration. Tool schemas declare the matching `maximum`. Helpers live in `attendance-grace.ts` so oversized `meet.ts` / `cli.ts` / `index.ts` do not grow.

## User Impact

**Before:** Overflow-class grace input silently disabled late/early detection. Finite values above one day were accepted.

**After:** CLI/tool reject unsafe grace flags before Meet API work. Decoration falls back to 5 for overflow-class runtime values so late/early checks stay finite. Finite integers such as 1441 / 100000 remain accepted. Default 5 is unchanged.

## Evidence

- Runtime decoration: `extensions/google-meet/src/meet.ts` uses `resolveAttendanceGraceMinutes`
- CLI caller: `extensions/google-meet/src/cli.ts` → `parseLateAfterMinutesOption` / `parseEarlyBeforeMinutesOption`
- Tool schema + reader: `extensions/google-meet/index.ts` → `optionalAttendanceGraceMinutesSchema` / `readAttendanceGraceParam`
- Regression tests: `extensions/google-meet/src/attendance-grace.test.ts`, `extensions/google-meet/src/cli.test.ts`, `extensions/google-meet/index.test.ts`

Supplemental unit run:

```text
 ✓ |extensions| ../../extensions/google-meet/src/cli.test.ts > google-meet CLI > rejects invalid attendance grace minutes: 1.5 25ms
 ✓ |extensions| ../../extensions/google-meet/src/cli.test.ts > google-meet CLI > rejects invalid attendance grace minutes: 0 1ms
 ✓ |extensions| ../../extensions/google-meet/src/cli.test.ts > google-meet CLI > rejects invalid attendance grace minutes: 9007199254740991 1ms
 ✓ |extensions| ../../extensions/google-meet/index.test.ts > google-meet plugin > keeps late detection finite when lateAfterMinutes would overflow 7ms
 ✓ |extensions| ../../extensions/google-meet/src/attendance-grace.test.ts > resolveAttendanceGraceMinutes > defaults missing or non-finite values 0ms
 ✓ |extensions| ../../extensions/google-meet/src/attendance-grace.test.ts > resolveAttendanceGraceMinutes > preserves finite windows above one day 0ms
 ✓ |extensions| ../../extensions/google-meet/src/attendance-grace.test.ts > resolveAttendanceGraceMinutes > falls back for overflow-class values that would become Infinity grace 0ms
 Test Files  3 passed (3)
      Tests  7 passed | 191 skipped (198)
```

## Real behavior proof

- **Behavior or issue addressed:** Overflow-class `--late-after-minutes` no longer turns grace into `Infinity`; CLI rejects unsafe values, and finite windows above one day (1441) still pass grace validation.
- **Canonical reachability path:** `openclaw googlemeet attendance --late-after-minutes <n>` → `registerGoogleMeetCli` → `resolveArtifactTokenOptions` → `parseLateAfterMinutesOption` / `parseAttendanceGraceMinutesOption` (reject before Meet `fetch`); runtime decoration path uses `resolveAttendanceGraceMinutes` inside `fetchGoogleMeetAttendance` / `decorateAttendanceRow`.
- **Boundary crossed:** local-runtime; Commander CLI registration for the google-meet plugin, no live Meet OAuth or Conference Records API.
- **Shared helper / provider constraint check:** Reused `parseStrictPositiveInteger` and `readPositiveIntegerParam` / `optionalPositiveIntegerSchema`; provider constraints N/A (local numeric validation).
- **Real environment tested:** Darwin arm64, Node `v22.22.0`, Vitest `v4.1.9`, Commander CLI via `registerGoogleMeetCli` (tsx), stubbed `fetch` to prove rejection happens before network.
- **Exact steps or command run after this patch:**

```text
$ node --import tsx -e '<Commander registerGoogleMeetCli attendance parse for 1.5 / 0 / MAX_SAFE_INTEGER / 1441>'
# equivalent local proof script invoking:
# googlemeet attendance --access-token redacted-token --conference-record rec-1 --late-after-minutes <value>
```

- **Evidence after fix:**

```text
# Real CLI proof: googlemeet attendance --late-after-minutes
# runtime: node v22.22.0 darwin arm64
# time: 2026-07-15T13:29:43.354Z
# note: no Meet API/network; invalid grace must fail before fetch
[float] $ openclaw googlemeet attendance --late-after-minutes 1.5
  -> late-after-minutes must be a positive integer between 1 and 150119987579
[zero] $ openclaw googlemeet attendance --late-after-minutes 0
  -> late-after-minutes must be a positive integer between 1 and 150119987579
[overflow] $ openclaw googlemeet attendance --late-after-minutes 9007199254740991
  -> late-after-minutes must be a positive integer between 1 and 150119987579
[above-one-day-finite] $ openclaw googlemeet attendance --late-after-minutes 1441
  -> Missing Google Meet OAuth credentials. Configure oauth.clientId and oauth.refreshToken, or pass --client-id and --refresh-token.
```

- **Observed result after fix:** `1.5`, `0`, and `Number.MAX_SAFE_INTEGER` fail at grace parsing before Meet `fetch`. `1441` passes grace validation and only then fails on missing OAuth credentials, proving finite above-one-day windows remain accepted. Overflow runtime decoration falls back to 5 so a 30-minute-late join is still marked `late: true` (unit path).
- **What was not tested:** Live Google Meet Conference Records API with real OAuth tokens; no packaged npm binary `openclaw` install path.
- **Fix classification:** Root cause fix

- [x] AI-assisted (Cursor)
- [x] I understand what the code does
- [x] Change is focused and does not mix unrelated concerns
