### PR TITLE
fix(swift): clear shared kit dead-code findings

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatGatewayRequest.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatGatewayRequest.swift
@@ -149,17 +149,6 @@ public enum OpenClawChatGatewayRequests {
             timeoutMs: Double(requestTimeoutMs))
     }
 
-    public static func patchSessionModel(
-        sessionKey: String,
-        agentID: String?,
-        model: String?) -> OpenClawChatGatewayRequest
-    {
-        self.patchSessionSettings(
-            sessionKey: sessionKey,
-            agentID: agentID,
-            model: .some(model))
-    }
-
     public static func patchSessionPreferences(
         sessionKey: String,
         agentID: String?,

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessions.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessions.swift
@@ -70,7 +70,6 @@ public struct OpenClawChatModelPatchResult: Decodable, Sendable, Equatable {
     public let thinkingLevel: String?
     public let thinkingLevels: [OpenClawChatThinkingLevelOption]?
 
-    // periphery:ignore - package tests construct patch responses; app consumers decode them.
     public init(
         key: String? = nil,
         modelProvider: String?,

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayNodeSession.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayNodeSession.swift
@@ -685,13 +685,6 @@ public actor GatewayNodeSession {
         return serverMethods.contains(method)
     }
 
-    public func currentMainSessionKey(
-        ifCurrentRoute expectedRoute: GatewayNodeSessionRoute) -> String?
-    {
-        guard self.isCurrentRoute(expectedRoute), self.channel != nil else { return nil }
-        return self.mainSessionKey
-    }
-
     public func waitForCurrentMainSessionKey(
         ifCurrentRoute expectedRoute: GatewayNodeSessionRoute) async -> String?
     {

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatGatewayRequestTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatGatewayRequestTests.swift
@@ -68,11 +68,11 @@ struct ChatGatewayRequestTests {
         #expect(request.params["archived"] == nil)
     }
 
-    @Test func `model patch request encodes default model as null`() {
-        let request = OpenClawChatGatewayRequests.patchSessionModel(
+    @Test func `settings patch request encodes default model as null`() {
+        let request = OpenClawChatGatewayRequests.patchSessionSettings(
             sessionKey: "agent:main:main",
             agentID: nil,
-            model: nil)
+            model: .some(nil))
 
         #expect(request.params["model"]?.value is NSNull)
         #expect(request.params["agentId"] == nil)

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayNodeSessionTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayNodeSessionTests.swift
@@ -3167,10 +3167,10 @@ struct GatewayNodeSessionTests {
 
         let route = try #require(await gateway.currentRoute())
         #expect(await capturedMainSessionKey.get() == "agent:main:main")
-        #expect(await gateway.currentMainSessionKey(ifCurrentRoute: route) == "agent:main:main")
+        #expect(await gateway.waitForCurrentMainSessionKey(ifCurrentRoute: route) == "agent:main:main")
 
         await gateway.disconnect()
-        #expect(await gateway.currentMainSessionKey(ifCurrentRoute: route) == nil)
+        #expect(await gateway.waitForCurrentMainSessionKey(ifCurrentRoute: route) == nil)
     }
 
     @Test


### PR DESCRIPTION
Related: #106997

AI-assisted: Codex.

## What Problem This Solves

Resolves a problem where every Swift-touching pull request fails the advisory Shared OpenClawKit Periphery intersection because three pre-existing shared-kit findings remain on `main`.

## Why This Change Was Made

Removes the two unreleased declarations with no production callers and the stale Periphery suppression on a constructor that is now used by production code. The canonical session-settings request and route-aware waiting accessor remain.

## User Impact

No runtime behavior change. Swift pull requests regain a trustworthy green shared-kit dead-code signal.

## Evidence

- Existing failing dual-consumer run: https://github.com/openclaw/openclaw/actions/runs/29319291244 reports the exact three Swift USRs from both iOS and macOS scans.
- Fresh current-`main` baseline: https://github.com/openclaw/openclaw/actions/runs/29344731632 failed with the same exact three identities at SHA `3b2d2d523b1bad26923ee43c3a909268dc29c5f6`.
- Exact-head fix workflow: https://github.com/openclaw/openclaw/actions/runs/29350412755 passed both consumer scans and the shared intersection at rebased SHA `088e9d1d598019495f1f62d26437ff888219002a`.
- Exact-head CI release gate: https://github.com/openclaw/openclaw/actions/runs/29350432302 passed at SHA `088e9d1d598019495f1f62d26437ff888219002a`.
- `swift test --package-path apps/shared/OpenClawKit --filter ChatGatewayRequestTests`: 15 tests passed.
- `swift test --package-path apps/shared/OpenClawKit --filter 'main session key follows the current node snapshot route'`: 1 test passed.
- Delegated `node scripts/check-changed.mjs`: green on Blacksmith Testbox, https://github.com/openclaw/openclaw/actions/runs/29344869837.
- Structured autoreview: clean, no accepted/actionable findings.
