### PR TITLE
fix(ui): restore lint for context test imports

### DIFF
--- a/ui/src/pages/memory-import/memory-import-page.test.ts
+++ b/ui/src/pages/memory-import/memory-import-page.test.ts
@@ -2,7 +2,7 @@
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
-import { type ApplicationContext, type ApplicationGatewaySnapshot } from "../../app/context.ts";
+import type { ApplicationContext, ApplicationGatewaySnapshot } from "../../app/context.ts";
 import { createApplicationContextProvider } from "../../test-helpers/application-context.ts";
 import "./memory-import-page.ts";
 

--- a/ui/src/pages/profile/profile-page.test.ts
+++ b/ui/src/pages/profile/profile-page.test.ts
@@ -2,7 +2,7 @@
 
 import { afterEach, beforeEach, expect, it } from "vitest";
 import type { RouteId } from "../../app-route-paths.ts";
-import { type ApplicationContext, type ApplicationGatewaySnapshot } from "../../app/context.ts";
+import type { ApplicationContext, ApplicationGatewaySnapshot } from "../../app/context.ts";
 import { i18n, t } from "../../i18n/index.ts";
 import { createApplicationContextProvider } from "../../test-helpers/application-context.ts";
 import { ProfilePage } from "./profile-page.ts";


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the main CI lint shard fails on two Control UI tests after their context imports were rewritten with inline type specifiers.

## Why This Change Was Made

Uses declaration-level type-only imports so TypeScript erases the full import instead of leaving a runtime side-effect import. No runtime or test behavior changes.

## User Impact

No user-visible behavior change. Main and dependent PR CI can pass the lint shard again.

## Evidence

- Reproduced in CI run 29344330108, job 87124263692: `typescript(no-import-type-side-effects)` on both touched files.
- `node scripts/run-oxlint.mjs ui/src/pages/memory-import/memory-import-page.test.ts ui/src/pages/profile/profile-page.test.ts`
- `git diff --check`
- Autoreview: clean, zero accepted/actionable findings.

AI-assisted. I reviewed and understand the change.
