### PR TITLE
fix(memory): reject hex/exponent dreaming integer config strings

### DIFF
--- a/src/memory-host-sdk/dreaming.test.ts
+++ b/src/memory-host-sdk/dreaming.test.ts
@@ -57,6 +57,45 @@ describe("memory dreaming host helpers", () => {
     expect(resolved.phases.deep.maxAgeDays).toBe(30);
   });
 
+  it("rejects hex and exponent integer strings for dreaming phase counts", () => {
+    const resolved = resolveMemoryDreamingConfig({
+      pluginConfig: {
+        dreaming: {
+          phases: {
+            deep: {
+              limit: "0x10",
+              minRecallCount: "1e3",
+              minUniqueQueries: "2.5",
+              recencyHalfLifeDays: "1.5",
+              maxAgeDays: "0x20",
+              maxPromotedSnippetTokens: "1e2",
+              execution: {
+                maxOutputTokens: "0x40",
+                timeoutMs: "1e4",
+              },
+            },
+            light: {
+              lookbackDays: "0x0a",
+              limit: "1e2",
+            },
+          },
+        },
+      },
+    });
+
+    // Non-decimal forms fall back to shipped defaults / omit optional fields.
+    expect(resolved.phases.deep.limit).toBe(10);
+    expect(resolved.phases.deep.minRecallCount).toBe(3);
+    expect(resolved.phases.deep.minUniqueQueries).toBe(3);
+    expect(resolved.phases.deep.recencyHalfLifeDays).toBe(14);
+    expect(resolved.phases.deep.maxAgeDays).toBe(30);
+    expect(resolved.phases.deep.maxPromotedSnippetTokens).toBe(160);
+    expect(resolved.phases.deep.execution.maxOutputTokens).toBeUndefined();
+    expect(resolved.phases.deep.execution.timeoutMs).toBeUndefined();
+    expect(resolved.phases.light.lookbackDays).toBe(2);
+    expect(resolved.phases.light.limit).toBe(100);
+  });
+
   it("parses true/false strings while keeping invalid-value defaults local", () => {
     const resolved = resolveMemoryDreamingConfig({
       pluginConfig: {

--- a/src/memory-host-sdk/dreaming.ts
+++ b/src/memory-host-sdk/dreaming.ts
@@ -1,6 +1,10 @@
 // Memory host dreaming helpers record and load memory dreaming artifacts.
 import path from "node:path";
 import { parseBoolean } from "@openclaw/normalization-core/boolean-coercion";
+import {
+  parseStrictNonNegativeInteger,
+  parseStrictPositiveInteger,
+} from "@openclaw/normalization-core/number-coercion";
 import { asNullableRecord } from "@openclaw/normalization-core/record-coerce";
 import {
   lowercasePreservingWhitespace,
@@ -179,38 +183,16 @@ function normalizeTrimmedString(value: unknown): string | undefined {
 }
 
 function normalizeNonNegativeInt(value: unknown, fallback: number): number {
-  const normalized = normalizeStringifiedOptionalString(value);
-  if (typeof value === "string" && !normalized) {
-    return fallback;
-  }
-  const num = typeof value === "string" ? Number(normalized) : Number(value);
-  if (!Number.isFinite(num)) {
-    return fallback;
-  }
-  const floored = Math.floor(num);
-  if (floored < 0) {
-    return fallback;
-  }
-  return floored;
+  // Config integers are decimal-only; Number() would accept hex/exponent forms.
+  return parseStrictNonNegativeInteger(value) ?? fallback;
 }
 
 function normalizeOptionalPositiveInt(value: unknown): number | undefined {
   if (value === undefined || value === null) {
     return undefined;
   }
-  const normalized = normalizeStringifiedOptionalString(value);
-  if (typeof value === "string" && !normalized) {
-    return undefined;
-  }
-  const num = typeof value === "string" ? Number(normalized) : Number(value);
-  if (!Number.isFinite(num)) {
-    return undefined;
-  }
-  const floored = Math.floor(num);
-  if (floored <= 0) {
-    return undefined;
-  }
-  return floored;
+  // Same strict decimal contract as normalizeNonNegativeInt for optional fields.
+  return parseStrictPositiveInteger(value);
 }
 
 function normalizeBoolean(value: unknown, fallback: boolean): boolean {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where dreaming phase integer config fields silently accepted JavaScript-specific string forms (`0x10`, `1e3`, `2.5`) via `Number()` coercion. A user who wrote `"0x10"` for `phases.deep.limit` got a promotion limit of 16 instead of the shipped default 10.

The fix targets the `pluginValidation: "skip"` path used by `openclaw configure`, `openclaw doctor` migration, and config mutation flows. In these paths, AJV JSON Schema validation is intentionally skipped, so malformed integer strings bypass the manifest's `"type": "integer"` guard and reach the resolver directly. The normal config-loading path (AJV `"full"`) already rejects these strings — this fix closes the gap for skip-validation callers.

## Why This Change Was Made

Reuse the shared `parseStrictNonNegativeInteger` / `parseStrictPositiveInteger` helpers from `@openclaw/normalization-core/number-coercion`, which enforce `/^[+-]?\d+$/` — rejecting hex prefixes, exponent notation, and fractional dots at the contract level. Ordinary decimal strings (`"5"`) and numeric literals (`5`) keep working; malformed strings fall back to shipped defaults or omit optional fields.

Key design decisions:
- Delete the local `Number()`-based `normalizeNonNegativeInt` / `normalizeOptionalPositiveInt` entirely — no compat shims, no dual path
- `normalizeScore` (float scores 0–1) intentionally retains `Number()` — scores are not integers, and `Number("0.9")` is the correct parse
- The fix is a 2-line change per function (replace implementation body with shared helper call); the bulk of the diff is deleting the old 12-line bodies

Collision check: searched open PRs for `path:src/memory-host-sdk/dreaming.ts` — **0** competing PRs.

## User Impact

Malformed hex/exponent/fraction dreaming integer strings no longer silently change lookback windows, promotion limits, or token/timeout budgets. Valid decimal config is unchanged.

| Config field | Input | Before (`Number()`) | After (strict) | Default |
|---|---|---|---|---|
| `deep.limit` | `"0x10"` | 16 | **10** (fallback) | 10 |
| `deep.minRecallCount` | `"1e3"` | 1000 | **3** (fallback) | 3 |
| `deep.recencyHalfLifeDays` | `"1.5"` | 1 (floored) | **14** (fallback) | 14 |
| `deep.maxAgeDays` | `"0x20"` | 32 | **30** (fallback) | 30 |
| `deep.maxPromotedSnippetTokens` | `"1e2"` | 100 | **160** (fallback) | 160 |
| `deep.execution.maxOutputTokens` | `"0x40"` | 64 | **undefined** (omitted) | - |
| `deep.execution.timeoutMs` | `"1e4"` | 10000 | **undefined** (omitted) | - |
| `light.lookbackDays` | `"0x0a"` | 10 | **2** (fallback) | 2 |

## Verification

- Exact head: `2b875a655abc276462e7ad68630d15cf0256bd50`
- `oxfmt --check src/memory-host-sdk/dreaming.ts src/memory-host-sdk/dreaming.test.ts` — passed.
- `oxlint src/memory-host-sdk/dreaming.ts src/memory-host-sdk/dreaming.test.ts` — passed; exit 0.
- `git diff --check` — passed; exit 0.
- Focused tests:

```bash
node scripts/run-vitest.mjs src/memory-host-sdk/dreaming.test.ts -- --run
```

```
 Test Files  1 passed (1)
      Tests  16 passed (16)
```

- Mutation check: `git checkout origin/main -- src/memory-host-sdk/dreaming.ts` → 11 proof assertions fail (hex/exponent silently coerced) → restore fix → 31/31 pass.

## Real behavior proof

### Behavior addressed

Two layers:
1. **Normal config-loading path (`pluginValidation: "full"`):** AJV JSON Schema validation with `"type": "integer"` already rejects string values — config load fails with `"must be integer"` errors. The fix here is defense-in-depth.
2. **Skip-validation path (`pluginValidation: "skip"`):** Used by `openclaw configure`, doctor migration, and config mutation flows. AJV is intentionally bypassed, so malformed strings like `"0x10"` survive validation and reach `resolveMemoryDreamingConfig` as raw strings. The old `Number()` path silently coerced these into wrong values; the fix rejects them and falls back to defaults.

The proof exercises both the `"full"` and `"skip"` validation paths via the real `validateConfigObjectWithPlugins` function, then feeds the skip-validated plugin config through the real `resolveMemoryDreamingConfig` resolver.

### Real env tested

- Linux x86_64, Node v22.22.0
- head: 2b875a655abc276462e7ad68630d15cf0256bd50

### Exact commands run

```bash
node --import tsx proof-dreaming-strict-int.mts
```

### Observed output after fix

```
node=v22.22.0
head=2b875a655abc276462e7ad68630d15cf0256bd50

[case 1] negative control - Number() accepts hex/exponent/fraction
  ok: Number("0x10") = 16 for deep.limit
  ok: Number("1e3") = 1000 for deep.minRecallCount
  ok: Number("2.5") = 2.5 for deep.minUniqueQueries
  ok: Number("1.5") = 1.5 for deep.recencyHalfLifeDays
  ok: Number("0x20") = 32 for deep.maxAgeDays
  ok: Number("1e2") = 100 for deep.maxPromotedSnippetTokens
  ok: Number("0x0a") = 10 for light.lookbackDays
  ok: Number("1e2") = 100 for light.limit
  ok: Number("0x40") = 64 for deep.execution.maxOutputTokens
  ok: Number("1e4") = 10000 for deep.execution.timeoutMs

[case 2] supported-path - pluginValidation skip lets strings bypass AJV to resolver
  ok: full validation rejects malformed strings (AJV catches type mismatch)
  ok: full validation: deep.limit error is 'must be integer'
  info: full validation had 8 issues (AJV blocks malformed strings)
  ok: skip validation passes malformed strings through (AJV bypassed)
  ok: skip-validated: deep.limit = '0x10' (string survives to reach resolver)
  ok: skip-validated: deep.minRecallCount = '1e3' (string survives)
  info: skip-validated deep.limit=0x10 (raw string, NOT a number)
  info: skip-validated deep.minRecallCount=1e3 (raw string, NOT a number)

[case 3] positive control - strict parser rejects malformed, falls back to defaults
  ok: deep.limit: malformed "0x10" → 10 (not 16)
  ok: deep.minRecallCount: malformed "1e3" → 3 (not 1000)
  ok: deep.minUniqueQueries: malformed "2.5" → 3 (not 2)
  ok: deep.recencyHalfLifeDays: malformed "1.5" → 14 (not 1)
  ok: deep.maxAgeDays: malformed "0x20" → 30 (not 32)
  ok: deep.maxPromotedSnippetTokens: malformed "1e2" → 160 (not 100)
  ok: deep.execution.maxOutputTokens: malformed '0x40' omitted (undefined)
  ok: deep.execution.timeoutMs: malformed '1e4' omitted (undefined)
  ok: light.lookbackDays: malformed "0x0a" → 2 (not 10)
  ok: light.limit: malformed "1e2" → 100 (not 100)

[case 4] valid response - decimal strings and numeric literals work
  ok: deep.limit: decimal string "5" parses to 5
  ok: deep.minRecallCount: numeric literal 7 passes through
  ok: light.limit: decimal string "50" parses to 50
  ok: light.lookbackDays: numeric literal 14 passes through

[case 5] end-to-end skip-validation -> resolver chain (doctor/mutate/configure path)
  ok: E2E skip path: deep.limit '0x10' → defaults to 10 (fix applied)
  ok: E2E skip path: deep.minRecallCount '1e3' → defaults to 3 (fix applied)

=== Summary ===
ALL PROOF ASSERTIONS: 31 passed, 0 failed
```

### Mutation check — revert to old `Number()` path

```
FAIL: deep.limit: malformed "0x10" → 10 (not 16)
FAIL: deep.minRecallCount: malformed "1e3" → 3 (not 1000)
FAIL: deep.minUniqueQueries: malformed "2.5" → 3 (not 2)
FAIL: deep.recencyHalfLifeDays: malformed "1.5" → 14 (not 1)
FAIL: deep.maxAgeDays: malformed "0x20" → 30 (not 32)
FAIL: deep.maxPromotedSnippetTokens: malformed "1e2" → 160 (not 100)
FAIL: deep.execution.maxOutputTokens: malformed '0x40' omitted (undefined)
FAIL: deep.execution.timeoutMs: malformed '1e4' omitted (undefined)
FAIL: light.lookbackDays: malformed "0x0a" → 2 (not 10)
FAIL: E2E skip path: deep.limit '0x10' → defaults to 10 (fix applied)
FAIL: E2E skip path: deep.minRecallCount '1e3' → defaults to 3 (fix applied)
ALL PROOF ASSERTIONS: 20 passed, 11 failed
```

### Evidence:

- **Old code silently coerces 10/10 fields:** `Number("0x10")` → 16, `Number("1e3")` → 1000, `Number("2.5")` → 2.5, etc.
- **Supported-path proof (case 2):** `pluginValidation: "full"` rejects malformed strings with `"must be integer"` (8 issues); `pluginValidation: "skip"` lets `"0x10"` pass through as a raw string — this is the path used by doctor/mutate/configure flows
- **Fix rejects all malformed inputs:** all 10 fields fall back to shipped defaults or omit optional fields
- **E2E skip-validation chain (case 5):** Raw strings from skip-validated config → resolver → defaults applied correctly
- **Valid decimal strings still work (case 4):** `"5"`, `"50"` parse correctly; numeric literals `7`, `14` pass through
- **Mutation check:** 11 proof assertions fail with old `Number()` path, confirming the fix catches real behavioral changes

### What was not tested

- Live memory-core dreaming cron / narrative runs (this is config normalization only; cron behavior depends on resolved config shape which is unchanged for valid inputs)
- End-to-end agent dreaming promotion cycles

## Risk / Compatibility

Medium (compatibility). Rejects previously accepted JS-coercion forms (`0x10`, `1e3`, `2.5`). Values that were silently reinterpreted now fall back to shipped defaults.

Why acceptable:
- Documented/intended values are decimal integers — hex/exponent/fraction were never documented as valid
- Sibling OpenClaw parsers (`parseStrictNonNegativeInteger` / `parseStrictPositiveInteger`) are already used in 20+ call sites
- `normalizeScore` float path intentionally retains `Number()` — scope is precise
- For the normal config-loading path, AJV already rejects these strings before they reach the resolver; the fix closes the gap for `pluginValidation: "skip"` callers (doctor, configure, mutate)
- Fallbacks preserve shipped defaults; no new config keys
