### PR TITLE
fix(signal): reject hex/exponent text-style span offsets

### DIFF
--- a/extensions/signal/src/client-container-text-style.test.ts
+++ b/extensions/signal/src/client-container-text-style.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+import { parseContainerTextStyleEntry } from "./client-container-text-style.js";
+
+describe("parseContainerTextStyleEntry", () => {
+  it("rejects hex start token", () => {
+    expect(parseContainerTextStyleEntry("0x10:4:ITALIC")).toBeUndefined();
+  });
+
+  it("rejects hex length token", () => {
+    expect(parseContainerTextStyleEntry("0:0x4:BOLD")).toBeUndefined();
+  });
+
+  it("rejects exponent start token", () => {
+    expect(parseContainerTextStyleEntry("1e1:2:BOLD")).toBeUndefined();
+  });
+
+  it("rejects exponent length token", () => {
+    expect(parseContainerTextStyleEntry("0:1e0:BOLD")).toBeUndefined();
+  });
+
+  it("rejects fractional start token", () => {
+    expect(parseContainerTextStyleEntry("0.5:4:BOLD")).toBeUndefined();
+  });
+
+  it("rejects fractional length token", () => {
+    expect(parseContainerTextStyleEntry("0:1.5:BOLD")).toBeUndefined();
+  });
+
+  it("rejects negative start token", () => {
+    expect(parseContainerTextStyleEntry("-1:4:BOLD")).toBeUndefined();
+  });
+
+  it("rejects negative length token", () => {
+    expect(parseContainerTextStyleEntry("0:-4:BOLD")).toBeUndefined();
+  });
+
+  it("rejects empty string", () => {
+    expect(parseContainerTextStyleEntry("")).toBeUndefined();
+  });
+
+  it("rejects single token (no length or style)", () => {
+    expect(parseContainerTextStyleEntry("0")).toBeUndefined();
+  });
+
+  it("rejects two tokens (no style)", () => {
+    expect(parseContainerTextStyleEntry("0:4")).toBeUndefined();
+  });
+
+  it("rejects missing start (empty before first colon)", () => {
+    expect(parseContainerTextStyleEntry(":4:BOLD")).toBeUndefined();
+  });
+
+  it("parses valid decimal BOLD span", () => {
+    expect(parseContainerTextStyleEntry("0:4:BOLD")).toEqual({
+      start: 0,
+      length: 4,
+      style: "BOLD",
+    });
+  });
+
+  it("parses valid decimal ITALIC span", () => {
+    expect(parseContainerTextStyleEntry("5:2:ITALIC")).toEqual({
+      start: 5,
+      length: 2,
+      style: "ITALIC",
+    });
+  });
+
+  it("parses STRIKETHROUGH span", () => {
+    expect(parseContainerTextStyleEntry("10:5:STRIKETHROUGH")).toEqual({
+      start: 10,
+      length: 5,
+      style: "STRIKETHROUGH",
+    });
+  });
+
+  it("parses MONOSPACE span", () => {
+    expect(parseContainerTextStyleEntry("3:1:MONOSPACE")).toEqual({
+      start: 3,
+      length: 1,
+      style: "MONOSPACE",
+    });
+  });
+
+  it("parses zero-length span (allowed by protocol)", () => {
+    expect(parseContainerTextStyleEntry("0:0:BOLD")).toEqual({
+      start: 0,
+      length: 0,
+      style: "BOLD",
+    });
+  });
+
+  it("parses zero-start span", () => {
+    expect(parseContainerTextStyleEntry("0:4:BOLD")).toEqual({
+      start: 0,
+      length: 4,
+      style: "BOLD",
+    });
+  });
+
+  it("drops extra colon-separated parts beyond start:length:style", () => {
+    const result = parseContainerTextStyleEntry("0:4:BOLD:extra");
+    expect(result).toEqual({ start: 0, length: 4, style: "BOLD" });
+  });
+
+  it.each([
+    "0x10:4:ITALIC",
+    "1e1:2:BOLD",
+    "0x0:0x4:BOLD",
+    "1e0:4:BOLD",
+    "0:1.5:BOLD",
+    "0x10:4",
+    ":4:BOLD",
+  ])("rejects malformed input %j", (raw) => {
+    expect(parseContainerTextStyleEntry(raw)).toBeUndefined();
+  });
+
+  it.each([
+    ["0:4:BOLD", 0, 4, "BOLD"],
+    ["5:2:ITALIC", 5, 2, "ITALIC"],
+    ["10:5:STRIKETHROUGH", 10, 5, "STRIKETHROUGH"],
+    ["0:0:BOLD", 0, 0, "BOLD"],
+    ["3:1:MONOSPACE", 3, 1, "MONOSPACE"],
+    ["7:3:SPOILER", 7, 3, "SPOILER"],
+  ] as const)("parses %j → start=%d length=%d style=%s", (raw, start, length, style) => {
+    expect(parseContainerTextStyleEntry(raw)).toEqual({ start, length, style });
+  });
+});

--- a/extensions/signal/src/client-container-text-style.ts
+++ b/extensions/signal/src/client-container-text-style.ts
@@ -1,0 +1,18 @@
+// Parse Signal container text-style span entries.
+import { parseStrictNonNegativeInteger } from "openclaw/plugin-sdk/number-runtime";
+
+export function parseContainerTextStyleEntry(
+  raw: string,
+): { start: number; length: number; style: string } | undefined {
+  const [startRaw, lengthRaw, style] = raw.split(":");
+  if (startRaw === undefined || lengthRaw === undefined || style === undefined) {
+    return undefined;
+  }
+  // Match quote-timestamp: reject hex/exponent so style spans cannot silently shift.
+  const start = parseStrictNonNegativeInteger(startRaw);
+  const length = parseStrictNonNegativeInteger(lengthRaw);
+  if (start === undefined || length === undefined) {
+    return undefined;
+  }
+  return { start, length, style };
+}

--- a/extensions/signal/src/client-container-text-style.ts
+++ b/extensions/signal/src/client-container-text-style.ts
@@ -8,7 +8,7 @@ export function parseContainerTextStyleEntry(
   if (startRaw === undefined || lengthRaw === undefined || style === undefined) {
     return undefined;
   }
-  // Match quote-timestamp: reject hex/exponent so style spans cannot silently shift.
+  // Reject hex/exponent so style spans cannot silently shift to wrong positions.
   const start = parseStrictNonNegativeInteger(startRaw);
   const length = parseStrictNonNegativeInteger(lengthRaw);
   if (start === undefined || length === undefined) {

--- a/extensions/signal/src/client-container.test.ts
+++ b/extensions/signal/src/client-container.test.ts
@@ -1077,6 +1077,52 @@ describe("containerRpcRequest send", () => {
     expect(body).not.toHaveProperty("quote_author");
     expect(body).not.toHaveProperty("quote_message");
   });
+
+  it("keeps decimal text-style spans and drops hex/exponent offsets", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      ...bodyStream(JSON.stringify({ timestamp: "1700000000000" })),
+    });
+
+    await containerRpcRequest(
+      "send",
+      {
+        account: "+14259798283",
+        recipient: ["+15550001111"],
+        message: "Bold text",
+        "text-style": ["0:4:BOLD", "0x10:4:ITALIC", "1e1:2:BOLD", "0:1.5:BOLD"],
+      },
+      { baseUrl: "http://localhost:8080" },
+    );
+
+    const body = parseFetchBody();
+    expect(body.message).toBe("**Bold** text");
+    expect(body.text_mode).toBe("styled");
+  });
+
+  it("omits styled mode when every text-style span is non-decimal", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      ...bodyStream(JSON.stringify({ timestamp: "1700000000000" })),
+    });
+
+    await containerRpcRequest(
+      "send",
+      {
+        account: "+14259798283",
+        recipient: ["+15550001111"],
+        message: "Bold text",
+        "text-style": ["0x0:0x4:BOLD", "1e0:4:BOLD"],
+      },
+      { baseUrl: "http://localhost:8080" },
+    );
+
+    const body = parseFetchBody();
+    expect(body.message).toBe("Bold text");
+    expect(body).not.toHaveProperty("text_mode");
+  });
 });
 
 describe("containerSendReceipt", () => {

--- a/extensions/signal/src/client-container.ts
+++ b/extensions/signal/src/client-container.ts
@@ -19,6 +19,7 @@ import {
 } from "openclaw/plugin-sdk/response-limit-runtime";
 import { readRegularFile } from "openclaw/plugin-sdk/security-runtime";
 import WebSocket from "ws";
+import { parseContainerTextStyleEntry } from "./client-container-text-style.js";
 
 type ContainerRpcOptions = {
   baseUrl: string;
@@ -527,22 +528,6 @@ function normalizeContainerQuoteTimestamp(raw: unknown): number | undefined {
 
 function normalizeContainerQuoteText(raw: unknown): string | undefined {
   return typeof raw === "string" ? raw : undefined;
-}
-
-function parseContainerTextStyleEntry(
-  raw: string,
-): { start: number; length: number; style: string } | undefined {
-  const [startRaw, lengthRaw, style] = raw.split(":");
-  if (startRaw === undefined || lengthRaw === undefined || style === undefined) {
-    return undefined;
-  }
-  // Match quote-timestamp: reject hex/exponent so style spans cannot silently shift.
-  const start = parseStrictNonNegativeInteger(startRaw);
-  const length = parseStrictNonNegativeInteger(lengthRaw);
-  if (start === undefined || length === undefined) {
-    return undefined;
-  }
-  return { start, length, style };
 }
 
 /**

--- a/extensions/signal/src/client-container.ts
+++ b/extensions/signal/src/client-container.ts
@@ -529,6 +529,22 @@ function normalizeContainerQuoteText(raw: unknown): string | undefined {
   return typeof raw === "string" ? raw : undefined;
 }
 
+function parseContainerTextStyleEntry(
+  raw: string,
+): { start: number; length: number; style: string } | undefined {
+  const [startRaw, lengthRaw, style] = raw.split(":");
+  if (startRaw === undefined || lengthRaw === undefined || style === undefined) {
+    return undefined;
+  }
+  // Match quote-timestamp: reject hex/exponent so style spans cannot silently shift.
+  const start = parseStrictNonNegativeInteger(startRaw);
+  const length = parseStrictNonNegativeInteger(lengthRaw);
+  if (start === undefined || length === undefined) {
+    return undefined;
+  }
+  return { start, length, style };
+}
+
 /**
  * Send message via bbernhard container REST API.
  */
@@ -746,11 +762,8 @@ export async function containerRpcRequest<T = unknown>(
 
       const textStylesRaw = p["text-style"] as string[] | undefined;
       const textStyles = textStylesRaw?.flatMap((s) => {
-        const [start, length, style] = s.split(":");
-        if (start === undefined || length === undefined || style === undefined) {
-          return [];
-        }
-        return [{ start: Number(start), length: Number(length), style }];
+        const parsed = parseContainerTextStyleEntry(s);
+        return parsed ? [parsed] : [];
       });
 
       const quoteTimestamp = normalizeContainerQuoteTimestamp(


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Signal container sends could apply the wrong styled span when `text-style` start/length tokens used JavaScript-only forms such as `0x10` or `1e1`. Those tokens were coerced with `Number(...)` into different offsets, so bold/italic markers could land on the wrong characters or invent spans that the caller never intended.

## Why This Change Was Made

Parse `text-style` `start`/`length` at the canonical Signal container translation boundary (`containerRpcRequest` → `/v2/send`) with the same `parseStrictNonNegativeInteger` helper already used for container quote timestamps. The parser lives in `client-container-text-style.ts` so oversized `client-container.ts` stays LOC-neutral.

Boundaries: no config keys; no native signal-cli path; incomplete `start:length:style` entries still drop the same way.

Collision check: searched open PRs for `path:extensions/signal/src/client-container.ts` and `parseStrictNonNegativeInteger text-style` — **0** competing PRs. Open Signal PRs #101380 / #100906 do not touch `text-style` `Number()` parsing.

## User Impact

- **Before:** `0x10:4:ITALIC` silently styled offset 16; `1e1:2:BOLD` silently styled offset 10; fractional lengths like `1.5` were accepted.
- **After:** Non-decimal tokens are dropped (same drop path as incomplete entries). Ordinary decimal spans such as `0:4:BOLD` are unchanged. All-invalid lists omit `text_mode=styled` and keep the plain message.

## Evidence

Exact product head: `5904fe91e4f642e338c56a04735812cae92fd1ef`

Real-container proof run (fork Actions, product sources identical to product head; proof branch only adds the harness):  
https://github.com/Pick-cat/openclaw/actions/runs/29426993121  
Proof checkout: `83dd475df702295cbc654bcf84f6e231326f403f` = `5904fe91e4f642e338c56a04735812cae92fd1ef` + proof-only files.

Image: `bbernhard/signal-cli-rest-api:latest` (`MODE=native`, about version `0.100`)

```text
node=v22.22.3
head=83dd475df702295cbc654bcf84f6e231326f403f
real_container=http://127.0.0.1:8080

[case 0] real container /v1/about
  ok: /v1/about HTTP ok
  info: status=200
  info: body={"versions":["v1","v2"],"build":2,"mode":"native","version":"0.100","capabilities":{"v2/send":["quotes","mentions"]}}
  ok: /v1/about returns JSON
  info: keys=build,capabilities,mode,version,versions
  info: version=0.100
  info: build=2
  ok: containerCheck(ok) against real image
  info: containerCheck status=200 error=null

[case 1] current-main Number() negative
  ok: Number("0x10") path yields start=16
  info: raw=0x10:4:ITALIC Number(start)=16 Number(length)=4
  ok: Number("1e1") path yields start=10
  info: raw=1e1:2:BOLD Number(start)=10 Number(length)=2
  ok: Number("1.5") path yields length=1.5
  info: raw=0:1.5:BOLD Number(start)=0 Number(length)=1.5
  ok: strict helper rejects same hex token
  ok: strict helper rejects same exponent token
  ok: strict helper rejects same fraction token

[case 2] positive — parseContainerTextStyleEntry rejects non-decimal
  ok: parseContainerTextStyleEntry("0x10:4:ITALIC") returns undefined
  ok: parseContainerTextStyleEntry("1e1:2:BOLD") returns undefined
  ok: parseContainerTextStyleEntry("0x0:0x4:BOLD") returns undefined
  ok: parseContainerTextStyleEntry("1e0:4:BOLD") returns undefined
  ok: parseContainerTextStyleEntry("0:1.5:BOLD") returns undefined
  ok: parseContainerTextStyleEntry("0x10:4") returns undefined
  ok: parseContainerTextStyleEntry(":4:BOLD") returns undefined

[case 3] valid decimal spans still parse
  ok: 0:4:BOLD
  ok: 5:2:ITALIC

[case 4] production containerRpcRequest → real container /v2/send
  info: forwarder=http://127.0.0.1:46301 → http://127.0.0.1:8080
  ok: real container returned Signal REST error (not connection failure)
  info: container error: Signal REST 400: {"error":"User +15555550100 is not registered.\n"}
  ok: mixed send hit real /v2/send once
  ok: mixed: only decimal BOLD applied → "**Bold** text here"
  ok: mixed: text_mode="styled"
  info: wire message="**Bold** text here" text_mode="styled"
  info: dropped=3 (hex, exponent, fraction); survived=1 (0:4:BOLD)
  info: real HTTP 400: {"error":"User +15555550100 is not registered.\n"}
  ok: mixed: real container responded (non-2xx account/send failure expected)
  ok: real container returned Signal REST error (not connection failure)
  info: container error: Signal REST 400: {"error":"User +15555550100 is not registered.\n"}
  ok: all-invalid send hit real /v2/send once
  ok: all-invalid: plain message unchanged
  ok: all-invalid: text_mode omitted
  info: wire message="Bold text here" has_text_mode=false
  info: real HTTP 400: {"error":"User +15555550100 is not registered.\n"}
  ok: real container returned Signal REST error (not connection failure)
  info: container error: Signal REST 400: {"error":"User +15555550100 is not registered.\n"}
  ok: valid decimals hit real /v2/send once
  ok: valid: styled markers applied
  ok: valid: text_mode="styled"
  info: wire message="**Bold** *text* here"
  info: real HTTP 400: {"error":"User +15555550100 is not registered.\n"}

=== Summary ===
ALL PROOF ASSERTIONS: 31 passed, 0 failed
```

Container identity / GIN access log:

```text
=== docker image ===
bbernhard/signal-cli-rest-api:latest 649eebf27d13bdd516c38469bca68622f2af0c8009b87000854c2641d3f0702c
=== /v1/about ===
{"versions":["v1","v2"],"build":2,"mode":"native","version":"0.100","capabilities":{"v2/send":["quotes","mentions"]}}
=== docker logs (tail) ===
usermod: no changes
Changing ownership of /home/.local/share/signal-cli to 1000:1000
[GIN] 2026/07/15 - 15:12:53 | 200 |      82.875µs |      172.17.0.1 | GET      "/v1/about"
[GIN] 2026/07/15 - 15:12:57 | 200 |      71.474µs |      172.17.0.1 | GET      "/v1/about"
[GIN] 2026/07/15 - 15:12:57 | 200 |      33.853µs |      172.17.0.1 | GET      "/v1/about"
[GIN] 2026/07/15 - 15:12:57 | 400 |  475.073993ms |      172.17.0.1 | POST     "/v2/send"
[GIN] 2026/07/15 - 15:12:58 | 400 |  450.703105ms |      172.17.0.1 | POST     "/v2/send"
[GIN] 2026/07/15 - 15:12:58 | 400 |  435.532342ms |      172.17.0.1 | POST     "/v2/send"
[GIN] 2026/07/15 - 15:12:58 | 200 |      52.889µs |      172.17.0.1 | GET      "/v1/about"
```

## Verification

- Exact product head: `5904fe91e4f642e338c56a04735812cae92fd1ef`
- Rebased onto latest `origin/main` to clear inherited Discord madge cycle + stale max-lines baseline (`#108013`)
- Focused tests:

```bash
node scripts/run-vitest.mjs extensions/signal/src/client-container-text-style.test.ts extensions/signal/src/client-container.test.ts -- --run
```

```
Test Files  2 passed (2)
     Tests  99 passed (99)
```

- Mutation: temporarily replace `parseStrictNonNegativeInteger` with `Number()` → **17 tests fail**; restore → 99/99 pass.

## Real behavior proof

### Behavior addressed

Hex/exponent/fraction `text-style` start/length tokens were silently coerced by `Number()`, shifting style spans. After fix, `parseContainerTextStyleEntry` rejects non-decimal forms via `parseStrictNonNegativeInteger`, matching the existing quote-timestamp contract and upstream signal-cli decimal `start:length:STYLE` grammar.

### Real env tested

- Hosted runner: GitHub Actions `ubuntu-latest` (run `29426993121`)
- Node: v22.22.3
- Product head: `5904fe91e4f642e338c56a04735812cae92fd1ef`
- Container: real `bbernhard/signal-cli-rest-api:latest` (`MODE=native`, `/v1/about` → version `0.100`, build `2`)
- Path: production `containerRpcRequest` → logging forwarder → **real** container `POST /v2/send` (not a stub implementation of the send contract)

### Exact commands run

```bash
docker run -d --name signal-api -p 8080:8080 -e MODE=native bbernhard/signal-cli-rest-api:latest
SIGNAL_CONTAINER_URL=http://127.0.0.1:8080 node --import tsx scripts/proof-signal-text-style-real-container.mts
```

### Observed output after fix

- `/v1/about`: `{"versions":["v1","v2"],"build":2,"mode":"native","version":"0.100",...}`
- Mixed spans: wire `message="**Bold** text here"` + `text_mode="styled"` (hex/exponent/fraction dropped); real container `HTTP 400` `User +15555550100 is not registered.` (JSON accepted, account gate rejected — expected without a linked device)
- All-invalid: plain `message="Bold text here"`, no `text_mode`; same real `HTTP 400`
- Valid decimals: styled markers + `text_mode="styled"`; same real `HTTP 400`
- Docker GIN log shows three real `POST /v2/send` hits
- Assertions: **31 passed, 0 failed**

### What was not tested

- End-to-end delivery/rendering on a linked Signal device (no registered number in CI). Real container image + `/v2/send` acceptance path is covered; device delivery remains optional maintainer follow-up.

## Risk / Compatibility

- **Risk:** `merge-risk: compatibility` — intentionally stops accepting previously coerced hex/exponent/fraction offset strings.
- **Why acceptable:** Upstream/docs use decimal integers; sibling quote parsing is already strict; invalid tokens already had a drop path for incomplete entries; decimal spans unchanged.
- **Mitigation:** focused unit + real `bbernhard/signal-cli-rest-api` `/v2/send` wire proof + mutation.
