### PR TITLE
fix(ci): keep LSP tests stable in non-isolated shards

### DIFF
--- a/src/agents/agent-bundle-lsp-dependencies.ts
+++ b/src/agents/agent-bundle-lsp-dependencies.ts
@@ -1,0 +1,29 @@
+/** Owns the replaceable process/config dependencies used by bundled LSP runtime tests. */
+import type { ChildProcess } from "node:child_process";
+import { killProcessTree } from "../process/kill-tree.js";
+import { spawnLspServerProcess } from "./agent-bundle-lsp-process.js";
+import { loadEmbeddedAgentLspConfig } from "./embedded-agent-lsp.js";
+import type { StdioMcpServerLaunchConfig } from "./mcp-stdio.js";
+
+export type BundleLspRuntimeDependencies = {
+  loadConfig: typeof loadEmbeddedAgentLspConfig;
+  spawnServerProcess: (config: StdioMcpServerLaunchConfig) => ChildProcess;
+  killProcessTree: typeof killProcessTree;
+};
+
+const defaultDependencies: BundleLspRuntimeDependencies = {
+  loadConfig: loadEmbeddedAgentLspConfig,
+  spawnServerProcess: spawnLspServerProcess,
+  killProcessTree,
+};
+let testDependencies: BundleLspRuntimeDependencies | undefined;
+
+export function getBundleLspRuntimeDependencies(): BundleLspRuntimeDependencies {
+  return testDependencies ?? defaultDependencies;
+}
+
+export function setBundleLspRuntimeDependenciesForTest(
+  dependencies?: BundleLspRuntimeDependencies,
+): void {
+  testDependencies = dependencies;
+}

--- a/src/agents/agent-bundle-lsp-dependencies.ts
+++ b/src/agents/agent-bundle-lsp-dependencies.ts
@@ -6,13 +6,13 @@ import { loadEmbeddedAgentLspConfig } from "./embedded-agent-lsp.js";
 import type { StdioMcpServerLaunchConfig } from "./mcp-stdio.js";
 
 export type BundleLspRuntimeDependencies = {
-  loadConfig: typeof loadEmbeddedAgentLspConfig;
+  loadLspConfig: typeof loadEmbeddedAgentLspConfig;
   spawnServerProcess: (config: StdioMcpServerLaunchConfig) => ChildProcess;
   killProcessTree: typeof killProcessTree;
 };
 
 const defaultDependencies: BundleLspRuntimeDependencies = {
-  loadConfig: loadEmbeddedAgentLspConfig,
+  loadLspConfig: loadEmbeddedAgentLspConfig,
   spawnServerProcess: spawnLspServerProcess,
   killProcessTree,
 };

--- a/src/agents/agent-bundle-lsp-dependencies.ts
+++ b/src/agents/agent-bundle-lsp-dependencies.ts
@@ -1,4 +1,4 @@
-/** Owns the replaceable process/config dependencies used by bundled LSP runtime tests. */
+/** Owns the process/config dependencies used by the bundled LSP runtime. */
 import type { ChildProcess } from "node:child_process";
 import { killProcessTree } from "../process/kill-tree.js";
 import { spawnLspServerProcess } from "./agent-bundle-lsp-process.js";
@@ -11,19 +11,8 @@ export type BundleLspRuntimeDependencies = {
   killProcessTree: typeof killProcessTree;
 };
 
-const defaultDependencies: BundleLspRuntimeDependencies = {
+export const defaultBundleLspRuntimeDependencies: BundleLspRuntimeDependencies = {
   loadLspConfig: loadEmbeddedAgentLspConfig,
   spawnServerProcess: spawnLspServerProcess,
   killProcessTree,
 };
-let testDependencies: BundleLspRuntimeDependencies | undefined;
-
-export function getBundleLspRuntimeDependencies(): BundleLspRuntimeDependencies {
-  return testDependencies ?? defaultDependencies;
-}
-
-export function setBundleLspRuntimeDependenciesForTest(
-  dependencies?: BundleLspRuntimeDependencies,
-): void {
-  testDependencies = dependencies;
-}

--- a/src/agents/agent-bundle-lsp-process.ts
+++ b/src/agents/agent-bundle-lsp-process.ts
@@ -1,0 +1,46 @@
+/** Spawns bundled LSP server processes with sanitized environment and platform handling. */
+import { spawn, type ChildProcess } from "node:child_process";
+import { sanitizeHostExecEnv } from "../infra/host-env-security.js";
+import {
+  materializeWindowsSpawnProgram,
+  resolveWindowsSpawnProgram,
+} from "../plugin-sdk/windows-spawn.js";
+import type { StdioMcpServerLaunchConfig } from "./mcp-stdio.js";
+
+type LspSpawnDependencies = {
+  spawn: typeof spawn;
+  sanitizeHostExecEnv: typeof sanitizeHostExecEnv;
+  resolveWindowsSpawnProgram: typeof resolveWindowsSpawnProgram;
+  materializeWindowsSpawnProgram: typeof materializeWindowsSpawnProgram;
+};
+
+const defaultLspSpawnDependencies: LspSpawnDependencies = {
+  spawn,
+  sanitizeHostExecEnv,
+  resolveWindowsSpawnProgram,
+  materializeWindowsSpawnProgram,
+};
+
+export function spawnLspServerProcess(
+  config: StdioMcpServerLaunchConfig,
+  dependencies: LspSpawnDependencies = defaultLspSpawnDependencies,
+): ChildProcess {
+  const mergedEnv = dependencies.sanitizeHostExecEnv({
+    baseEnv: process.env,
+    overrides: config.env ?? null,
+  });
+  const program = dependencies.resolveWindowsSpawnProgram({
+    command: config.command,
+    env: mergedEnv,
+    allowShellFallback: true,
+  });
+  const invocation = dependencies.materializeWindowsSpawnProgram(program, config.args ?? []);
+  return dependencies.spawn(invocation.command, invocation.argv, {
+    stdio: ["pipe", "pipe", "pipe"],
+    env: mergedEnv,
+    cwd: config.cwd,
+    detached: process.platform !== "win32",
+    windowsHide: invocation.windowsHide ?? process.platform === "win32",
+    shell: invocation.shell,
+  });
+}

--- a/src/agents/agent-bundle-lsp-runtime.test.ts
+++ b/src/agents/agent-bundle-lsp-runtime.test.ts
@@ -2,28 +2,20 @@
 import { EventEmitter } from "node:events";
 import { PassThrough, Writable } from "node:stream";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { disposeAllBundleLspRuntimes, testing } from "./agent-bundle-lsp-runtime.js";
 
-const spawnMock = vi.hoisted(() => vi.fn());
-const killProcessTreeMock = vi.hoisted(() => vi.fn());
-const loadEmbeddedAgentLspConfigMock = vi.hoisted(() => vi.fn());
+const spawnMock = vi.fn();
+const killProcessTreeMock = vi.fn();
+const loadEmbeddedAgentLspConfigMock = vi.fn();
 
-vi.mock("node:child_process", async () => ({
-  ...(await vi.importActual<typeof import("node:child_process")>("node:child_process")),
-  spawn: spawnMock,
-}));
-
-vi.mock("../process/kill-tree.js", () => ({
-  killProcessTree: killProcessTreeMock,
-}));
-
-vi.mock("./embedded-agent-lsp.js", () => ({
-  loadEmbeddedAgentLspConfig: loadEmbeddedAgentLspConfigMock,
-}));
-
-vi.mock("../logger.js", () => ({
-  logDebug: vi.fn(),
-  logWarn: vi.fn(),
-}));
+const createBundleLspToolRuntime = (
+  params: Parameters<typeof testing.createBundleLspToolRuntime>[0],
+) =>
+  testing.createBundleLspToolRuntime(params, {
+    loadConfig: loadEmbeddedAgentLspConfigMock,
+    spawnServerProcess: spawnMock,
+    killProcessTree: killProcessTreeMock,
+  });
 
 function encodeLspMessage(body: unknown): string {
   const json = JSON.stringify(body);
@@ -121,7 +113,6 @@ function configureSingleLspServer(): void {
 
 describe("bundle LSP runtime", () => {
   afterEach(async () => {
-    const { disposeAllBundleLspRuntimes } = await import("./agent-bundle-lsp-runtime.js");
     await disposeAllBundleLspRuntimes();
     spawnMock.mockReset();
     killProcessTreeMock.mockReset();
@@ -131,7 +122,6 @@ describe("bundle LSP runtime", () => {
   it("reuses the prepared plugin manifest registry for bundle discovery", async () => {
     loadEmbeddedAgentLspConfigMock.mockReturnValue({ lspServers: {}, diagnostics: [] });
     const manifestRegistry = { plugins: [] };
-    const { createBundleLspToolRuntime } = await import("./agent-bundle-lsp-runtime.js");
 
     await createBundleLspToolRuntime({
       workspaceDir: "/tmp/workspace",
@@ -145,21 +135,20 @@ describe("bundle LSP runtime", () => {
     });
   });
 
-  it("starts LSP servers in a disposable process group", async () => {
+  it("starts configured LSP servers and exposes their tools", async () => {
     configureSingleLspServer();
     const child = new MockChildProcess();
     spawnMock.mockReturnValue(child);
-    const { createBundleLspToolRuntime } = await import("./agent-bundle-lsp-runtime.js");
 
     const runtime = await createBundleLspToolRuntime({ workspaceDir: "/tmp/workspace" });
 
     expect(spawnMock).toHaveBeenCalledTimes(1);
-    const [command, args, options] = spawnMock.mock.calls.at(0) ?? [];
-    expect(command).toBe("typescript-language-server");
-    expect(args).toEqual(["--stdio"]);
-    expect(options?.detached).toBe(process.platform !== "win32");
-    expect(options?.stdio).toEqual(["pipe", "pipe", "pipe"]);
-    expect(options?.windowsHide).toBe(process.platform === "win32");
+    expect(spawnMock).toHaveBeenCalledWith({
+      command: "typescript-language-server",
+      args: ["--stdio"],
+      cwd: undefined,
+      env: undefined,
+    });
     expect(runtime.tools.map((tool) => tool.name)).toContain("lsp_hover_typescript");
 
     await runtime.dispose();
@@ -174,7 +163,6 @@ describe("bundle LSP runtime", () => {
       queueMicrotask(() => child.emit("error", new Error("spawn ENOENT")));
       return child;
     });
-    const { createBundleLspToolRuntime } = await import("./agent-bundle-lsp-runtime.js");
 
     const runtime = await createBundleLspToolRuntime({ workspaceDir: "/tmp/workspace" });
 
@@ -198,7 +186,6 @@ describe("bundle LSP runtime", () => {
     configureSingleLspServer();
     const child = new MockChildProcess("", new Set(["initialize"]));
     spawnMock.mockReturnValue(child);
-    const { createBundleLspToolRuntime } = await import("./agent-bundle-lsp-runtime.js");
 
     const runtime = await createBundleLspToolRuntime({ workspaceDir: "/tmp/workspace" });
     const hoverTool = runtime.tools.find((tool) => tool.name === "lsp_hover_typescript");
@@ -224,7 +211,6 @@ describe("bundle LSP runtime", () => {
     configureSingleLspServer();
     const child = new MockChildProcess("", new Set(["initialize"]));
     spawnMock.mockReturnValue(child);
-    const { createBundleLspToolRuntime } = await import("./agent-bundle-lsp-runtime.js");
 
     const runtime = await createBundleLspToolRuntime({ workspaceDir: "/tmp/workspace" });
     const hoverTool = runtime.tools.find((tool) => tool.name === "lsp_hover_typescript");
@@ -258,7 +244,6 @@ describe("bundle LSP runtime", () => {
     configureSingleLspServer();
     const child = new MockChildProcess("", new Set(["initialize"]));
     spawnMock.mockReturnValue(child);
-    const { createBundleLspToolRuntime } = await import("./agent-bundle-lsp-runtime.js");
 
     const runtime = await createBundleLspToolRuntime({ workspaceDir: "/tmp/workspace" });
     const hoverTool = runtime.tools.find((tool) => tool.name === "lsp_hover_typescript");
@@ -287,7 +272,6 @@ describe("bundle LSP runtime", () => {
     configureSingleLspServer();
     const child = new MockChildProcess("", new Set(["initialize"]));
     spawnMock.mockReturnValue(child);
-    const { createBundleLspToolRuntime } = await import("./agent-bundle-lsp-runtime.js");
 
     const runtime = await createBundleLspToolRuntime({ workspaceDir: "/tmp/workspace" });
     const tool = runtime.tools.find((candidate) => candidate.name === toolName);
@@ -338,7 +322,6 @@ describe("bundle LSP runtime", () => {
     });
     const child = new MockChildProcess(prefix);
     spawnMock.mockReturnValue(child);
-    const { createBundleLspToolRuntime } = await import("./agent-bundle-lsp-runtime.js");
 
     const runtime = await createBundleLspToolRuntime({ workspaceDir: "/tmp/workspace" });
 
@@ -353,7 +336,6 @@ describe("bundle LSP runtime", () => {
       return `Content-Type: application/vscode-jsonrpc; charset=utf-8\r\nContent-Length: ${Buffer.byteLength(json, "utf-8")}\r\n\r\n${json}`;
     });
     spawnMock.mockReturnValue(child);
-    const { createBundleLspToolRuntime } = await import("./agent-bundle-lsp-runtime.js");
 
     const runtime = await createBundleLspToolRuntime({ workspaceDir: "/tmp/workspace" });
 
@@ -371,7 +353,6 @@ describe("bundle LSP runtime", () => {
       return [frame.slice(0, header.length + 1), frame.slice(header.length + 1)];
     });
     spawnMock.mockReturnValue(child);
-    const { createBundleLspToolRuntime } = await import("./agent-bundle-lsp-runtime.js");
 
     const runtime = await createBundleLspToolRuntime({ workspaceDir: "/tmp/workspace" });
 
@@ -419,7 +400,6 @@ describe("bundle LSP runtime", () => {
       (body, method) => (method === "initialize" ? encodeLspMessage(body) : frame(body)),
     );
     spawnMock.mockReturnValue(child);
-    const { createBundleLspToolRuntime } = await import("./agent-bundle-lsp-runtime.js");
 
     const runtime = await createBundleLspToolRuntime({ workspaceDir: "/tmp/workspace" });
     const hoverTool = runtime.tools.find((tool) => tool.name === "lsp_hover_typescript");
@@ -452,8 +432,6 @@ describe("bundle LSP runtime", () => {
     configureSingleLspServer();
     const child = new MockChildProcess();
     spawnMock.mockReturnValue(child);
-    const { createBundleLspToolRuntime, disposeAllBundleLspRuntimes } =
-      await import("./agent-bundle-lsp-runtime.js");
 
     const runtime = await createBundleLspToolRuntime({ workspaceDir: "/tmp/workspace" });
 

--- a/src/agents/agent-bundle-lsp-runtime.test.ts
+++ b/src/agents/agent-bundle-lsp-runtime.test.ts
@@ -1,21 +1,16 @@
 /** Tests embedded LSP runtime JSON-RPC, tool behavior, and cleanup. */
 import { EventEmitter } from "node:events";
 import { PassThrough, Writable } from "node:stream";
-import { afterEach, describe, expect, it, vi } from "vitest";
-import { disposeAllBundleLspRuntimes, testing } from "./agent-bundle-lsp-runtime.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { setBundleLspRuntimeDependenciesForTest } from "./agent-bundle-lsp-dependencies.js";
+import {
+  createBundleLspToolRuntime,
+  disposeAllBundleLspRuntimes,
+} from "./agent-bundle-lsp-runtime.js";
 
 const spawnMock = vi.fn();
 const killProcessTreeMock = vi.fn();
 const loadEmbeddedAgentLspConfigMock = vi.fn();
-
-const createBundleLspToolRuntime = (
-  params: Parameters<typeof testing.createBundleLspToolRuntime>[0],
-) =>
-  testing.createBundleLspToolRuntime(params, {
-    loadConfig: loadEmbeddedAgentLspConfigMock,
-    spawnServerProcess: spawnMock,
-    killProcessTree: killProcessTreeMock,
-  });
 
 function encodeLspMessage(body: unknown): string {
   const json = JSON.stringify(body);
@@ -112,8 +107,17 @@ function configureSingleLspServer(): void {
 }
 
 describe("bundle LSP runtime", () => {
+  beforeEach(() => {
+    setBundleLspRuntimeDependenciesForTest({
+      loadConfig: loadEmbeddedAgentLspConfigMock,
+      spawnServerProcess: spawnMock,
+      killProcessTree: killProcessTreeMock,
+    });
+  });
+
   afterEach(async () => {
     await disposeAllBundleLspRuntimes();
+    setBundleLspRuntimeDependenciesForTest();
     spawnMock.mockReset();
     killProcessTreeMock.mockReset();
     loadEmbeddedAgentLspConfigMock.mockReset();

--- a/src/agents/agent-bundle-lsp-runtime.test.ts
+++ b/src/agents/agent-bundle-lsp-runtime.test.ts
@@ -109,7 +109,7 @@ function configureSingleLspServer(): void {
 describe("bundle LSP runtime", () => {
   beforeEach(() => {
     setBundleLspRuntimeDependenciesForTest({
-      loadConfig: loadEmbeddedAgentLspConfigMock,
+      loadLspConfig: loadEmbeddedAgentLspConfigMock,
       spawnServerProcess: spawnMock,
       killProcessTree: killProcessTreeMock,
     });

--- a/src/agents/agent-bundle-lsp-runtime.test.ts
+++ b/src/agents/agent-bundle-lsp-runtime.test.ts
@@ -1,16 +1,28 @@
 /** Tests embedded LSP runtime JSON-RPC, tool behavior, and cleanup. */
 import { EventEmitter } from "node:events";
 import { PassThrough, Writable } from "node:stream";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { setBundleLspRuntimeDependenciesForTest } from "./agent-bundle-lsp-dependencies.js";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
-  createBundleLspToolRuntime,
+  createBundleLspToolRuntime as createProductionBundleLspToolRuntime,
   disposeAllBundleLspRuntimes,
 } from "./agent-bundle-lsp-runtime.js";
 
 const spawnMock = vi.fn();
 const killProcessTreeMock = vi.fn();
 const loadEmbeddedAgentLspConfigMock = vi.fn();
+
+function createBundleLspToolRuntime(
+  params: Parameters<typeof createProductionBundleLspToolRuntime>[0],
+) {
+  return createProductionBundleLspToolRuntime({
+    ...params,
+    dependencies: {
+      loadLspConfig: loadEmbeddedAgentLspConfigMock,
+      spawnServerProcess: spawnMock,
+      killProcessTree: killProcessTreeMock,
+    },
+  });
+}
 
 function encodeLspMessage(body: unknown): string {
   const json = JSON.stringify(body);
@@ -107,17 +119,8 @@ function configureSingleLspServer(): void {
 }
 
 describe("bundle LSP runtime", () => {
-  beforeEach(() => {
-    setBundleLspRuntimeDependenciesForTest({
-      loadLspConfig: loadEmbeddedAgentLspConfigMock,
-      spawnServerProcess: spawnMock,
-      killProcessTree: killProcessTreeMock,
-    });
-  });
-
   afterEach(async () => {
     await disposeAllBundleLspRuntimes();
-    setBundleLspRuntimeDependenciesForTest();
     spawnMock.mockReset();
     killProcessTreeMock.mockReset();
     loadEmbeddedAgentLspConfigMock.mockReset();

--- a/src/agents/agent-bundle-lsp-runtime.ts
+++ b/src/agents/agent-bundle-lsp-runtime.ts
@@ -543,7 +543,7 @@ export async function createBundleLspToolRuntime(params: {
   manifestRegistry?: Pick<PluginManifestRegistry, "plugins">;
 }): Promise<BundleLspToolRuntime> {
   const dependencies = getBundleLspRuntimeDependencies();
-  const loaded = dependencies.loadConfig({
+  const loaded = dependencies.loadLspConfig({
     workspaceDir: params.workspaceDir,
     cfg: params.cfg,
     manifestRegistry: params.manifestRegistry,

--- a/src/agents/agent-bundle-lsp-runtime.ts
+++ b/src/agents/agent-bundle-lsp-runtime.ts
@@ -1,22 +1,18 @@
 /** Session-scoped embedded LSP runtime and tool materialization for agent bundles. */
-import { spawn, type ChildProcess } from "node:child_process";
+import type { ChildProcess } from "node:child_process";
 import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { createAbortError } from "../infra/abort-signal.js";
-import { sanitizeHostExecEnv } from "../infra/host-env-security.js";
 import { logDebug, logWarn } from "../logger.js";
-import {
-  materializeWindowsSpawnProgram,
-  resolveWindowsSpawnProgram,
-} from "../plugin-sdk/windows-spawn.js";
 import type { PluginManifestRegistry } from "../plugins/manifest-registry.js";
 import { setPluginToolMeta } from "../plugins/tools.js";
-import { killProcessTree } from "../process/kill-tree.js";
-import { loadEmbeddedAgentLspConfig } from "./embedded-agent-lsp.js";
+import {
+  getBundleLspRuntimeDependencies,
+  type BundleLspRuntimeDependencies,
+} from "./agent-bundle-lsp-dependencies.js";
 import {
   resolveStdioMcpServerLaunchConfig,
   describeStdioMcpServerLaunchConfig,
-  type StdioMcpServerLaunchConfig,
 } from "./mcp-stdio.js";
 import type { AgentToolResult } from "./runtime/index.js";
 import type { AnyAgentTool } from "./tools/common.js";
@@ -33,23 +29,10 @@ type LspSession = {
   capabilities: LspServerCapabilities;
   disposed: boolean;
   // Cleanup must use the same process owner that spawned this session.
-  killProcessTree: typeof killProcessTree;
+  killProcessTree: BundleLspRuntimeDependencies["killProcessTree"];
   // Preserve a terminal process/transport failure so later requests reject immediately
   // instead of waiting for the per-request timeout.
   failure?: Error;
-};
-
-type LspSpawnDependencies = {
-  spawn: typeof spawn;
-  sanitizeHostExecEnv: typeof sanitizeHostExecEnv;
-  resolveWindowsSpawnProgram: typeof resolveWindowsSpawnProgram;
-  materializeWindowsSpawnProgram: typeof materializeWindowsSpawnProgram;
-};
-
-type BundleLspRuntimeDependencies = {
-  loadConfig: typeof loadEmbeddedAgentLspConfig;
-  spawnServerProcess: (config: StdioMcpServerLaunchConfig) => ChildProcess;
-  killProcessTree: typeof killProcessTree;
 };
 
 type PendingLspRequest = {
@@ -92,42 +75,10 @@ function delay(ms: number): Promise<void> {
   });
 }
 
-const defaultLspSpawnDependencies: LspSpawnDependencies = {
-  spawn,
-  sanitizeHostExecEnv,
-  resolveWindowsSpawnProgram,
-  materializeWindowsSpawnProgram,
-};
-
-/** Spawns one LSP server process using sanitized host env and Windows shim handling. */
-function spawnLspServerProcess(
-  config: StdioMcpServerLaunchConfig,
-  dependencies: LspSpawnDependencies = defaultLspSpawnDependencies,
-): ChildProcess {
-  const mergedEnv = dependencies.sanitizeHostExecEnv({
-    baseEnv: process.env,
-    overrides: config.env ?? null,
-  });
-  const program = dependencies.resolveWindowsSpawnProgram({
-    command: config.command,
-    env: mergedEnv,
-    allowShellFallback: true,
-  });
-  const invocation = dependencies.materializeWindowsSpawnProgram(program, config.args ?? []);
-  return dependencies.spawn(invocation.command, invocation.argv, {
-    stdio: ["pipe", "pipe", "pipe"],
-    env: mergedEnv,
-    cwd: config.cwd,
-    detached: process.platform !== "win32",
-    windowsHide: invocation.windowsHide ?? process.platform === "win32",
-    shell: invocation.shell,
-  });
-}
-
 function createLspSession(
   serverName: string,
   child: ChildProcess,
-  killProcessTreeFn: typeof killProcessTree,
+  killProcessTree: BundleLspRuntimeDependencies["killProcessTree"],
 ): LspSession {
   return {
     serverName,
@@ -138,7 +89,7 @@ function createLspSession(
     initialized: false,
     capabilities: {},
     disposed: false,
-    killProcessTree: killProcessTreeFn,
+    killProcessTree,
   };
 }
 
@@ -585,23 +536,13 @@ function formatLspResult(
   };
 }
 
-type CreateBundleLspToolRuntimeParams = {
+export async function createBundleLspToolRuntime(params: {
   workspaceDir: string;
   cfg?: OpenClawConfig;
   reservedToolNames?: Iterable<string>;
   manifestRegistry?: Pick<PluginManifestRegistry, "plugins">;
-};
-
-const defaultBundleLspRuntimeDependencies: BundleLspRuntimeDependencies = {
-  loadConfig: loadEmbeddedAgentLspConfig,
-  spawnServerProcess: spawnLspServerProcess,
-  killProcessTree,
-};
-
-async function createBundleLspToolRuntimeWithDependencies(
-  params: CreateBundleLspToolRuntimeParams,
-  dependencies: BundleLspRuntimeDependencies,
-): Promise<BundleLspToolRuntime> {
+}): Promise<BundleLspToolRuntime> {
+  const dependencies = getBundleLspRuntimeDependencies();
   const loaded = dependencies.loadConfig({
     workspaceDir: params.workspaceDir,
     cfg: params.cfg,
@@ -695,20 +636,6 @@ async function createBundleLspToolRuntimeWithDependencies(
   }
 }
 
-export async function createBundleLspToolRuntime(
-  params: CreateBundleLspToolRuntimeParams,
-): Promise<BundleLspToolRuntime> {
-  return createBundleLspToolRuntimeWithDependencies(params, defaultBundleLspRuntimeDependencies);
-}
-
 export async function disposeAllBundleLspRuntimes(): Promise<void> {
   await disposeSessions(activeBundleLspSessions);
 }
-
-export const testing = {
-  createBundleLspToolRuntime: (
-    params: CreateBundleLspToolRuntimeParams,
-    dependencies: BundleLspRuntimeDependencies,
-  ) => createBundleLspToolRuntimeWithDependencies(params, dependencies),
-  spawnLspServerProcess,
-};

--- a/src/agents/agent-bundle-lsp-runtime.ts
+++ b/src/agents/agent-bundle-lsp-runtime.ts
@@ -32,9 +32,24 @@ type LspSession = {
   initialized: boolean;
   capabilities: LspServerCapabilities;
   disposed: boolean;
+  // Cleanup must use the same process owner that spawned this session.
+  killProcessTree: typeof killProcessTree;
   // Preserve a terminal process/transport failure so later requests reject immediately
   // instead of waiting for the per-request timeout.
   failure?: Error;
+};
+
+type LspSpawnDependencies = {
+  spawn: typeof spawn;
+  sanitizeHostExecEnv: typeof sanitizeHostExecEnv;
+  resolveWindowsSpawnProgram: typeof resolveWindowsSpawnProgram;
+  materializeWindowsSpawnProgram: typeof materializeWindowsSpawnProgram;
+};
+
+type BundleLspRuntimeDependencies = {
+  loadConfig: typeof loadEmbeddedAgentLspConfig;
+  spawnServerProcess: (config: StdioMcpServerLaunchConfig) => ChildProcess;
+  killProcessTree: typeof killProcessTree;
 };
 
 type PendingLspRequest = {
@@ -77,16 +92,29 @@ function delay(ms: number): Promise<void> {
   });
 }
 
+const defaultLspSpawnDependencies: LspSpawnDependencies = {
+  spawn,
+  sanitizeHostExecEnv,
+  resolveWindowsSpawnProgram,
+  materializeWindowsSpawnProgram,
+};
+
 /** Spawns one LSP server process using sanitized host env and Windows shim handling. */
-function spawnLspServerProcess(config: StdioMcpServerLaunchConfig): ChildProcess {
-  const mergedEnv = sanitizeHostExecEnv({ baseEnv: process.env, overrides: config.env ?? null });
-  const program = resolveWindowsSpawnProgram({
+function spawnLspServerProcess(
+  config: StdioMcpServerLaunchConfig,
+  dependencies: LspSpawnDependencies = defaultLspSpawnDependencies,
+): ChildProcess {
+  const mergedEnv = dependencies.sanitizeHostExecEnv({
+    baseEnv: process.env,
+    overrides: config.env ?? null,
+  });
+  const program = dependencies.resolveWindowsSpawnProgram({
     command: config.command,
     env: mergedEnv,
     allowShellFallback: true,
   });
-  const invocation = materializeWindowsSpawnProgram(program, config.args ?? []);
-  return spawn(invocation.command, invocation.argv, {
+  const invocation = dependencies.materializeWindowsSpawnProgram(program, config.args ?? []);
+  return dependencies.spawn(invocation.command, invocation.argv, {
     stdio: ["pipe", "pipe", "pipe"],
     env: mergedEnv,
     cwd: config.cwd,
@@ -96,7 +124,11 @@ function spawnLspServerProcess(config: StdioMcpServerLaunchConfig): ChildProcess
   });
 }
 
-function createLspSession(serverName: string, child: ChildProcess): LspSession {
+function createLspSession(
+  serverName: string,
+  child: ChildProcess,
+  killProcessTreeFn: typeof killProcessTree,
+): LspSession {
   return {
     serverName,
     process: child,
@@ -106,6 +138,7 @@ function createLspSession(serverName: string, child: ChildProcess): LspSession {
     initialized: false,
     capabilities: {},
     disposed: false,
+    killProcessTree: killProcessTreeFn,
   };
 }
 
@@ -389,7 +422,7 @@ function hasLspProcessExited(child: ChildProcess): boolean {
 function terminateLspProcessTree(session: LspSession): void {
   const pid = session.process.pid;
   if (pid && !hasLspProcessExited(session.process)) {
-    killProcessTree(pid, { graceMs: LSP_PROCESS_TREE_KILL_GRACE_MS });
+    session.killProcessTree(pid, { graceMs: LSP_PROCESS_TREE_KILL_GRACE_MS });
     return;
   }
   if (!hasLspProcessExited(session.process)) {
@@ -552,13 +585,24 @@ function formatLspResult(
   };
 }
 
-export async function createBundleLspToolRuntime(params: {
+type CreateBundleLspToolRuntimeParams = {
   workspaceDir: string;
   cfg?: OpenClawConfig;
   reservedToolNames?: Iterable<string>;
   manifestRegistry?: Pick<PluginManifestRegistry, "plugins">;
-}): Promise<BundleLspToolRuntime> {
-  const loaded = loadEmbeddedAgentLspConfig({
+};
+
+const defaultBundleLspRuntimeDependencies: BundleLspRuntimeDependencies = {
+  loadConfig: loadEmbeddedAgentLspConfig,
+  spawnServerProcess: spawnLspServerProcess,
+  killProcessTree,
+};
+
+async function createBundleLspToolRuntimeWithDependencies(
+  params: CreateBundleLspToolRuntimeParams,
+  dependencies: BundleLspRuntimeDependencies,
+): Promise<BundleLspToolRuntime> {
+  const loaded = dependencies.loadConfig({
     workspaceDir: params.workspaceDir,
     cfg: params.cfg,
     manifestRegistry: params.manifestRegistry,
@@ -590,7 +634,11 @@ export async function createBundleLspToolRuntime(params: {
       let session: LspSession | undefined;
 
       try {
-        session = createLspSession(serverName, spawnLspServerProcess(launchConfig));
+        session = createLspSession(
+          serverName,
+          dependencies.spawnServerProcess(launchConfig),
+          dependencies.killProcessTree,
+        );
         registerActiveLspSession(session);
         attachLspProcessHandlers(session);
 
@@ -647,6 +695,20 @@ export async function createBundleLspToolRuntime(params: {
   }
 }
 
+export async function createBundleLspToolRuntime(
+  params: CreateBundleLspToolRuntimeParams,
+): Promise<BundleLspToolRuntime> {
+  return createBundleLspToolRuntimeWithDependencies(params, defaultBundleLspRuntimeDependencies);
+}
+
 export async function disposeAllBundleLspRuntimes(): Promise<void> {
   await disposeSessions(activeBundleLspSessions);
 }
+
+export const testing = {
+  createBundleLspToolRuntime: (
+    params: CreateBundleLspToolRuntimeParams,
+    dependencies: BundleLspRuntimeDependencies,
+  ) => createBundleLspToolRuntimeWithDependencies(params, dependencies),
+  spawnLspServerProcess,
+};

--- a/src/agents/agent-bundle-lsp-runtime.ts
+++ b/src/agents/agent-bundle-lsp-runtime.ts
@@ -7,7 +7,7 @@ import { logDebug, logWarn } from "../logger.js";
 import type { PluginManifestRegistry } from "../plugins/manifest-registry.js";
 import { setPluginToolMeta } from "../plugins/tools.js";
 import {
-  getBundleLspRuntimeDependencies,
+  defaultBundleLspRuntimeDependencies,
   type BundleLspRuntimeDependencies,
 } from "./agent-bundle-lsp-dependencies.js";
 import {
@@ -541,8 +541,9 @@ export async function createBundleLspToolRuntime(params: {
   cfg?: OpenClawConfig;
   reservedToolNames?: Iterable<string>;
   manifestRegistry?: Pick<PluginManifestRegistry, "plugins">;
+  dependencies?: BundleLspRuntimeDependencies;
 }): Promise<BundleLspToolRuntime> {
-  const dependencies = getBundleLspRuntimeDependencies();
+  const dependencies = params.dependencies ?? defaultBundleLspRuntimeDependencies;
   const loaded = dependencies.loadLspConfig({
     workspaceDir: params.workspaceDir,
     cfg: params.cfg,

--- a/src/agents/agent-bundle-lsp-runtime.windows-spawn.test.ts
+++ b/src/agents/agent-bundle-lsp-runtime.windows-spawn.test.ts
@@ -1,41 +1,12 @@
 /** Tests LSP server spawning with Windows shim and sanitized env handling. */
 import { describe, expect, it, vi, beforeEach } from "vitest";
-import { createBundleLspToolRuntime } from "./agent-bundle-lsp-runtime.js";
+import { testing } from "./agent-bundle-lsp-runtime.js";
 import type { StdioMcpServerLaunchConfig } from "./mcp-stdio.js";
 
-const resolveWindowsSpawnProgramMock = vi.hoisted(() => vi.fn());
-const materializeWindowsSpawnProgramMock = vi.hoisted(() => vi.fn());
-const sanitizeHostExecEnvMock = vi.hoisted(() => vi.fn());
-const spawnMock = vi.hoisted(() => vi.fn());
-const loadEmbeddedAgentLspConfigMock = vi.hoisted(() => vi.fn());
-
-vi.mock("../plugin-sdk/windows-spawn.js", () => ({
-  resolveWindowsSpawnProgram: resolveWindowsSpawnProgramMock,
-  materializeWindowsSpawnProgram: materializeWindowsSpawnProgramMock,
-}));
-
-vi.mock("../infra/host-env-security.js", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("../infra/host-env-security.js")>()),
-  sanitizeHostExecEnv: sanitizeHostExecEnvMock,
-}));
-
-vi.mock("node:child_process", async () => ({
-  ...(await vi.importActual<typeof import("node:child_process")>("node:child_process")),
-  spawn: spawnMock,
-}));
-
-vi.mock("../logger.js", () => ({
-  logDebug: vi.fn(),
-  logWarn: vi.fn(),
-}));
-
-vi.mock("../process/kill-tree.js", () => ({
-  killProcessTree: vi.fn(),
-}));
-
-vi.mock("./embedded-agent-lsp.js", () => ({
-  loadEmbeddedAgentLspConfig: loadEmbeddedAgentLspConfigMock,
-}));
+const resolveWindowsSpawnProgramMock = vi.fn();
+const materializeWindowsSpawnProgramMock = vi.fn();
+const sanitizeHostExecEnvMock = vi.fn();
+const spawnMock = vi.fn();
 
 function firstMockCall(mock: { mock: { calls: unknown[][] } }, label: string): unknown[] {
   const call = mock.mock.calls[0];
@@ -45,12 +16,17 @@ function firstMockCall(mock: { mock: { calls: unknown[][] } }, label: string): u
   return call;
 }
 
-async function createRuntimeWithServer(config: StdioMcpServerLaunchConfig): Promise<void> {
-  loadEmbeddedAgentLspConfigMock.mockReturnValue({
-    lspServers: { typescript: config },
-    diagnostics: [],
-  });
-  await createBundleLspToolRuntime({ workspaceDir: "/workspace" });
+function spawnServer(config: StdioMcpServerLaunchConfig): void {
+  try {
+    testing.spawnLspServerProcess(config, {
+      resolveWindowsSpawnProgram: resolveWindowsSpawnProgramMock,
+      materializeWindowsSpawnProgram: materializeWindowsSpawnProgramMock,
+      sanitizeHostExecEnv: sanitizeHostExecEnvMock,
+      spawn: spawnMock,
+    });
+  } catch {
+    // The injected spawn deliberately stops after argument capture.
+  }
 }
 
 describe("spawnLspServerProcess Windows .cmd shim handling", () => {
@@ -74,7 +50,7 @@ describe("spawnLspServerProcess Windows .cmd shim handling", () => {
       windowsHide: true,
     });
 
-    await createRuntimeWithServer({
+    spawnServer({
       command: "typescript-language-server",
       args: ["--stdio"],
       env: configEnv,
@@ -100,7 +76,7 @@ describe("spawnLspServerProcess Windows .cmd shim handling", () => {
       windowsHide: true,
     });
 
-    await createRuntimeWithServer({ command: "typescript-language-server", args: ["--stdio"] });
+    spawnServer({ command: "typescript-language-server", args: ["--stdio"] });
 
     const resolveParams = firstMockCall(
       resolveWindowsSpawnProgramMock,
@@ -122,15 +98,23 @@ describe("spawnLspServerProcess Windows .cmd shim handling", () => {
       windowsHide: true,
     });
 
-    await createRuntimeWithServer({ command: "typescript-language-server", args: ["--stdio"] });
+    spawnServer({ command: "typescript-language-server", args: ["--stdio"] });
 
     const spawnCall = firstMockCall(spawnMock, "child process spawn");
     expect(spawnCall?.[0]).toBe("cmd.exe");
     expect(spawnCall?.[1]).toEqual(["/c", "typescript-language-server.cmd", "--stdio"]);
     const spawnOptions = spawnCall?.[2] as
-      | { env?: Record<string, string>; shell?: boolean; windowsHide?: boolean }
+      | {
+          env?: Record<string, string>;
+          stdio?: string[];
+          detached?: boolean;
+          shell?: boolean;
+          windowsHide?: boolean;
+        }
       | undefined;
     expect(spawnOptions?.env).toBe(sanitizedEnv);
+    expect(spawnOptions?.stdio).toEqual(["pipe", "pipe", "pipe"]);
+    expect(spawnOptions?.detached).toBe(process.platform !== "win32");
     expect(spawnOptions?.shell).toBe(true);
     expect(spawnOptions?.windowsHide).toBe(true);
   });

--- a/src/agents/agent-bundle-lsp-runtime.windows-spawn.test.ts
+++ b/src/agents/agent-bundle-lsp-runtime.windows-spawn.test.ts
@@ -1,6 +1,6 @@
 /** Tests LSP server spawning with Windows shim and sanitized env handling. */
 import { describe, expect, it, vi, beforeEach } from "vitest";
-import { testing } from "./agent-bundle-lsp-runtime.js";
+import { spawnLspServerProcess } from "./agent-bundle-lsp-process.js";
 import type { StdioMcpServerLaunchConfig } from "./mcp-stdio.js";
 
 const resolveWindowsSpawnProgramMock = vi.fn();
@@ -18,7 +18,7 @@ function firstMockCall(mock: { mock: { calls: unknown[][] } }, label: string): u
 
 function spawnServer(config: StdioMcpServerLaunchConfig): void {
   try {
-    testing.spawnLspServerProcess(config, {
+    spawnLspServerProcess(config, {
       resolveWindowsSpawnProgram: resolveWindowsSpawnProgramMock,
       materializeWindowsSpawnProgram: materializeWindowsSpawnProgramMock,
       sanitizeHostExecEnv: sanitizeHostExecEnvMock,


### PR DESCRIPTION
Closes #107624

## What Problem This Solves

Fixes an issue where full release validation could fail all bundled LSP runtime tests when the shared non-isolated agents worker imported the runtime before the test file installed module mocks.

## Why This Change Was Made

The runtime now reads its config, process-spawn, and process-tree cleanup owners through a small internal dependency seam. Process spawning lives in its focused owner module; tests replace and reset only those dependencies, eliminating import-order coupling without global module resets or the cost of isolating the entire agents shard. Production defaults and cleanup behavior remain unchanged.

Best-fix verdict: explicit internal dependencies are the best fix. Global worker isolation adds broad cost; module resets preserve brittle hidden state; test ordering only moves the failure.

## User Impact

No user-visible runtime behavior changes. Maintainers get deterministic bundled LSP coverage and release validation no longer fails because of shared-worker import order.

## Evidence

- Before: exact full release CI failed 19 bundled LSP tests after the config loader mock recorded zero calls: https://github.com/openclaw/openclaw/actions/runs/29344565293/job/87124886088
- After: AWS Crabbox `cbx_eb3404d29141`, run `run_629fed0d89cd`, passed 22/22 focused LSP tests, targeted oxlint, the TypeScript LOC ratchet, and full test-typecheck.
- Earlier Blacksmith Testbox proof also passed 22/22 focused tests, targeted oxlint, and full test-typecheck: https://github.com/openclaw/openclaw/actions/runs/29345930095
- Latest structured autoreview: clean, no accepted/actionable findings; correctness 0.96.
- `git diff --check`

AI-assisted maintainer repair. No agent transcript attached by request.
