### PR TITLE
fix(qa-lab): reject hex/exponent Telegram SUT uid env values

### DIFF
--- a/extensions/qa-lab/src/cli.runtime.test.ts
+++ b/extensions/qa-lab/src/cli.runtime.test.ts
@@ -1148,6 +1148,43 @@ describe("qa cli runtime", () => {
     expect(runQaFlowSuiteFromRuntime).not.toHaveBeenCalled();
   });
 
+  it.each(["0x3e9", "1e3", "1001.5"])(
+    "rejects non-decimal Telegram SUT uid %s before starting a gateway",
+    async (uid) => {
+      const candidateRoot = path.join(telegramArtifactsDir, `candidate-${uid}`);
+      const boundaryDir = path.join(telegramArtifactsDir, `boundary-${uid}`);
+      const launcherPath = path.join(telegramArtifactsDir, `launcher-${uid}`);
+      const runtimeRoot = path.join(telegramArtifactsDir, `runtime-${uid}`);
+      const runtimeTempParent = path.join(runtimeRoot, "tmp");
+      const preloadPath = path.join(runtimeRoot, "openclaw-telegram-preentry.mjs");
+      const runtimeEntryPath = path.join(candidateRoot, "dist", "index.js");
+      await fs.mkdir(path.dirname(runtimeEntryPath), { recursive: true });
+      await fs.mkdir(boundaryDir);
+      await fs.mkdir(runtimeTempParent, { recursive: true });
+      await fs.writeFile(launcherPath, "#!/bin/sh\nexit 0\n", { mode: 0o700 });
+      await fs.writeFile(preloadPath, "export {};\n", { mode: 0o600 });
+      await fs.writeFile(runtimeEntryPath, "export {};\n", { mode: 0o600 });
+      vi.stubEnv("OPENCLAW_QA_TELEGRAM_SUT_FORWARDED_ENV_KEYS", "HOME,PATH");
+      vi.stubEnv("OPENCLAW_QA_TELEGRAM_SUT_CLEANUP_TIMEOUT_MS", "60000");
+      vi.stubEnv("OPENCLAW_QA_TELEGRAM_SUT_GID", "1002");
+      vi.stubEnv("OPENCLAW_QA_TELEGRAM_SUT_OPENCLAW_COMMAND", launcherPath);
+      vi.stubEnv("OPENCLAW_QA_TELEGRAM_SUT_PRELOAD_PATH", preloadPath);
+      vi.stubEnv("OPENCLAW_QA_TELEGRAM_SUT_PROCESS_BOUNDARY_DIR", boundaryDir);
+      vi.stubEnv("OPENCLAW_QA_TELEGRAM_SUT_RUNTIME_EXECUTABLE", process.execPath);
+      vi.stubEnv("OPENCLAW_QA_TELEGRAM_SUT_UID", uid);
+
+      await expect(
+        runQaTelegramCommand({
+          repoRoot: candidateRoot,
+          scenarioIds: ["telegram-help-command"],
+        }),
+      ).rejects.toThrow("OPENCLAW_QA_TELEGRAM_SUT_UID must be a positive integer.");
+
+      expect(runCanonicalLiveScenarios).not.toHaveBeenCalled();
+      expect(runTelegramQaLive).not.toHaveBeenCalled();
+    },
+  );
+
   it("rejects non-executable Telegram launcher files before starting a gateway", async () => {
     const launcherPath = path.join(telegramArtifactsDir, "non-executable-launcher");
     await fs.writeFile(launcherPath, "#!/bin/sh\nexit 0\n", { mode: 0o600 });

--- a/extensions/qa-lab/src/cli.runtime.test.ts
+++ b/extensions/qa-lab/src/cli.runtime.test.ts
@@ -102,7 +102,6 @@ import {
 } from "./cli.runtime.js";
 import { QaSuiteInfraError } from "./errors.js";
 import { QA_EVIDENCE_FILENAME } from "./evidence-summary.js";
-import { loadNonYamlScenarioRefs } from "./live-transports/shared/live-transport-scenarios.js";
 import { parseSutId, runQaTelegramCommand } from "./live-transports/telegram/cli.runtime.js";
 import { defaultQaModelForMode as defaultQaProviderModelForMode } from "./model-selection.js";
 import type { QaProviderModeInput } from "./run-config.js";
@@ -1288,8 +1287,7 @@ describe("qa cli runtime", () => {
         }),
       ).rejects.toThrow(`${envKey} must be a positive integer.`);
 
-      expect(runCanonicalLiveScenarios).not.toHaveBeenCalled();
-      expect(runTelegramQaLive).not.toHaveBeenCalled();
+      expect(runQaFlowSuiteFromRuntime).not.toHaveBeenCalled();
     },
   );
 

--- a/extensions/qa-lab/src/cli.runtime.test.ts
+++ b/extensions/qa-lab/src/cli.runtime.test.ts
@@ -102,7 +102,8 @@ import {
 } from "./cli.runtime.js";
 import { QaSuiteInfraError } from "./errors.js";
 import { QA_EVIDENCE_FILENAME } from "./evidence-summary.js";
-import { runQaTelegramCommand } from "./live-transports/telegram/cli.runtime.js";
+import { loadNonYamlScenarioRefs } from "./live-transports/shared/live-transport-scenarios.js";
+import { parseSutId, runQaTelegramCommand } from "./live-transports/telegram/cli.runtime.js";
 import { defaultQaModelForMode as defaultQaProviderModelForMode } from "./model-selection.js";
 import type { QaProviderModeInput } from "./run-config.js";
 
@@ -1146,6 +1147,86 @@ describe("qa cli runtime", () => {
     ).rejects.toThrow("OPENCLAW_QA_TELEGRAM_SUT_OPENCLAW_COMMAND must be an absolute file path.");
 
     expect(runQaFlowSuiteFromRuntime).not.toHaveBeenCalled();
+  });
+
+  describe("telegram SUT strict id parsing", () => {
+    const key = "OPENCLAW_QA_TELEGRAM_SUT_UID";
+
+    it("rejects hex value 0x3e9", () => {
+      expect(() => parseSutId({ [key]: "0x3e9" }, key)).toThrow(
+        "OPENCLAW_QA_TELEGRAM_SUT_UID must be a positive integer.",
+      );
+    });
+
+    it("rejects exponent value 1e3", () => {
+      expect(() => parseSutId({ [key]: "1e3" }, key)).toThrow();
+    });
+
+    it("rejects fraction value 1001.5", () => {
+      expect(() => parseSutId({ [key]: "1001.5" }, key)).toThrow();
+    });
+
+    it("rejects empty string", () => {
+      expect(() => parseSutId({ [key]: "" }, key)).toThrow();
+    });
+
+    it("rejects whitespace-only string", () => {
+      expect(() => parseSutId({ [key]: "  " }, key)).toThrow();
+    });
+
+    it("rejects zero", () => {
+      expect(() => parseSutId({ [key]: "0" }, key)).toThrow();
+    });
+
+    it("rejects negative value", () => {
+      expect(() => parseSutId({ [key]: "-1" }, key)).toThrow();
+    });
+
+    it("rejects missing env key", () => {
+      expect(() => parseSutId({}, key)).toThrow();
+    });
+
+    it("accepts decimal string 1001", () => {
+      expect(parseSutId({ [key]: "1001" }, key)).toBe(1001);
+    });
+
+    it("accepts decimal string 1", () => {
+      expect(parseSutId({ [key]: "1" }, key)).toBe(1);
+    });
+
+    it("accepts decimal string with whitespace", () => {
+      expect(parseSutId({ [key]: " 1001 " }, key)).toBe(1001);
+    });
+
+    it("accepts SUT_GID decimal value", () => {
+      expect(
+        parseSutId({ OPENCLAW_QA_TELEGRAM_SUT_GID: "1002" }, "OPENCLAW_QA_TELEGRAM_SUT_GID"),
+      ).toBe(1002);
+    });
+
+    it("accepts SUT_CLEANUP_TIMEOUT_MS decimal value", () => {
+      expect(
+        parseSutId(
+          { OPENCLAW_QA_TELEGRAM_SUT_CLEANUP_TIMEOUT_MS: "60000" },
+          "OPENCLAW_QA_TELEGRAM_SUT_CLEANUP_TIMEOUT_MS",
+        ),
+      ).toBe(60000);
+    });
+
+    it("rejects SUT_GID hex value", () => {
+      expect(() =>
+        parseSutId({ OPENCLAW_QA_TELEGRAM_SUT_GID: "0x3e9" }, "OPENCLAW_QA_TELEGRAM_SUT_GID"),
+      ).toThrow("OPENCLAW_QA_TELEGRAM_SUT_GID must be a positive integer.");
+    });
+
+    it("rejects SUT_CLEANUP_TIMEOUT_MS hex value", () => {
+      expect(() =>
+        parseSutId(
+          { OPENCLAW_QA_TELEGRAM_SUT_CLEANUP_TIMEOUT_MS: "0x3e8" },
+          "OPENCLAW_QA_TELEGRAM_SUT_CLEANUP_TIMEOUT_MS",
+        ),
+      ).toThrow("OPENCLAW_QA_TELEGRAM_SUT_CLEANUP_TIMEOUT_MS must be a positive integer.");
+    });
   });
 
   it.each(["0x3e9", "1e3", "1001.5"])(

--- a/extensions/qa-lab/src/cli.runtime.test.ts
+++ b/extensions/qa-lab/src/cli.runtime.test.ts
@@ -1229,13 +1229,39 @@ describe("qa cli runtime", () => {
     });
   });
 
-  it.each(["0x3e9", "1e3", "1001.5"])(
-    "rejects non-decimal Telegram SUT uid %s before starting a gateway",
-    async (uid) => {
-      const candidateRoot = path.join(telegramArtifactsDir, `candidate-${uid}`);
-      const boundaryDir = path.join(telegramArtifactsDir, `boundary-${uid}`);
-      const launcherPath = path.join(telegramArtifactsDir, `launcher-${uid}`);
-      const runtimeRoot = path.join(telegramArtifactsDir, `runtime-${uid}`);
+  it.each([
+    {
+      envKey: "OPENCLAW_QA_TELEGRAM_SUT_UID",
+      badValue: "0x3e9",
+      label: "uid-hex",
+    },
+    {
+      envKey: "OPENCLAW_QA_TELEGRAM_SUT_UID",
+      badValue: "1e3",
+      label: "uid-exponent",
+    },
+    {
+      envKey: "OPENCLAW_QA_TELEGRAM_SUT_UID",
+      badValue: "1001.5",
+      label: "uid-fraction",
+    },
+    {
+      envKey: "OPENCLAW_QA_TELEGRAM_SUT_GID",
+      badValue: "0x3ea",
+      label: "gid-hex",
+    },
+    {
+      envKey: "OPENCLAW_QA_TELEGRAM_SUT_CLEANUP_TIMEOUT_MS",
+      badValue: "0x3e8",
+      label: "cleanup-hex",
+    },
+  ])(
+    "rejects non-decimal Telegram SUT $label before starting a gateway",
+    async ({ envKey, badValue, label }) => {
+      const candidateRoot = path.join(telegramArtifactsDir, `candidate-${label}`);
+      const boundaryDir = path.join(telegramArtifactsDir, `boundary-${label}`);
+      const launcherPath = path.join(telegramArtifactsDir, `launcher-${label}`);
+      const runtimeRoot = path.join(telegramArtifactsDir, `runtime-${label}`);
       const runtimeTempParent = path.join(runtimeRoot, "tmp");
       const preloadPath = path.join(runtimeRoot, "openclaw-telegram-preentry.mjs");
       const runtimeEntryPath = path.join(candidateRoot, "dist", "index.js");
@@ -1252,14 +1278,15 @@ describe("qa cli runtime", () => {
       vi.stubEnv("OPENCLAW_QA_TELEGRAM_SUT_PRELOAD_PATH", preloadPath);
       vi.stubEnv("OPENCLAW_QA_TELEGRAM_SUT_PROCESS_BOUNDARY_DIR", boundaryDir);
       vi.stubEnv("OPENCLAW_QA_TELEGRAM_SUT_RUNTIME_EXECUTABLE", process.execPath);
-      vi.stubEnv("OPENCLAW_QA_TELEGRAM_SUT_UID", uid);
+      vi.stubEnv("OPENCLAW_QA_TELEGRAM_SUT_UID", "1001");
+      vi.stubEnv(envKey, badValue);
 
       await expect(
         runQaTelegramCommand({
           repoRoot: candidateRoot,
           scenarioIds: ["telegram-help-command"],
         }),
-      ).rejects.toThrow("OPENCLAW_QA_TELEGRAM_SUT_UID must be a positive integer.");
+      ).rejects.toThrow(`${envKey} must be a positive integer.`);
 
       expect(runCanonicalLiveScenarios).not.toHaveBeenCalled();
       expect(runTelegramQaLive).not.toHaveBeenCalled();

--- a/extensions/qa-lab/src/cli.runtime.test.ts
+++ b/extensions/qa-lab/src/cli.runtime.test.ts
@@ -102,7 +102,7 @@ import {
 } from "./cli.runtime.js";
 import { QaSuiteInfraError } from "./errors.js";
 import { QA_EVIDENCE_FILENAME } from "./evidence-summary.js";
-import { parseSutId, runQaTelegramCommand } from "./live-transports/telegram/cli.runtime.js";
+import { runQaTelegramCommand } from "./live-transports/telegram/cli.runtime.js";
 import { defaultQaModelForMode as defaultQaProviderModelForMode } from "./model-selection.js";
 import type { QaProviderModeInput } from "./run-config.js";
 
@@ -1146,86 +1146,6 @@ describe("qa cli runtime", () => {
     ).rejects.toThrow("OPENCLAW_QA_TELEGRAM_SUT_OPENCLAW_COMMAND must be an absolute file path.");
 
     expect(runQaFlowSuiteFromRuntime).not.toHaveBeenCalled();
-  });
-
-  describe("telegram SUT strict id parsing", () => {
-    const key = "OPENCLAW_QA_TELEGRAM_SUT_UID";
-
-    it("rejects hex value 0x3e9", () => {
-      expect(() => parseSutId({ [key]: "0x3e9" }, key)).toThrow(
-        "OPENCLAW_QA_TELEGRAM_SUT_UID must be a positive integer.",
-      );
-    });
-
-    it("rejects exponent value 1e3", () => {
-      expect(() => parseSutId({ [key]: "1e3" }, key)).toThrow();
-    });
-
-    it("rejects fraction value 1001.5", () => {
-      expect(() => parseSutId({ [key]: "1001.5" }, key)).toThrow();
-    });
-
-    it("rejects empty string", () => {
-      expect(() => parseSutId({ [key]: "" }, key)).toThrow();
-    });
-
-    it("rejects whitespace-only string", () => {
-      expect(() => parseSutId({ [key]: "  " }, key)).toThrow();
-    });
-
-    it("rejects zero", () => {
-      expect(() => parseSutId({ [key]: "0" }, key)).toThrow();
-    });
-
-    it("rejects negative value", () => {
-      expect(() => parseSutId({ [key]: "-1" }, key)).toThrow();
-    });
-
-    it("rejects missing env key", () => {
-      expect(() => parseSutId({}, key)).toThrow();
-    });
-
-    it("accepts decimal string 1001", () => {
-      expect(parseSutId({ [key]: "1001" }, key)).toBe(1001);
-    });
-
-    it("accepts decimal string 1", () => {
-      expect(parseSutId({ [key]: "1" }, key)).toBe(1);
-    });
-
-    it("accepts decimal string with whitespace", () => {
-      expect(parseSutId({ [key]: " 1001 " }, key)).toBe(1001);
-    });
-
-    it("accepts SUT_GID decimal value", () => {
-      expect(
-        parseSutId({ OPENCLAW_QA_TELEGRAM_SUT_GID: "1002" }, "OPENCLAW_QA_TELEGRAM_SUT_GID"),
-      ).toBe(1002);
-    });
-
-    it("accepts SUT_CLEANUP_TIMEOUT_MS decimal value", () => {
-      expect(
-        parseSutId(
-          { OPENCLAW_QA_TELEGRAM_SUT_CLEANUP_TIMEOUT_MS: "60000" },
-          "OPENCLAW_QA_TELEGRAM_SUT_CLEANUP_TIMEOUT_MS",
-        ),
-      ).toBe(60000);
-    });
-
-    it("rejects SUT_GID hex value", () => {
-      expect(() =>
-        parseSutId({ OPENCLAW_QA_TELEGRAM_SUT_GID: "0x3e9" }, "OPENCLAW_QA_TELEGRAM_SUT_GID"),
-      ).toThrow("OPENCLAW_QA_TELEGRAM_SUT_GID must be a positive integer.");
-    });
-
-    it("rejects SUT_CLEANUP_TIMEOUT_MS hex value", () => {
-      expect(() =>
-        parseSutId(
-          { OPENCLAW_QA_TELEGRAM_SUT_CLEANUP_TIMEOUT_MS: "0x3e8" },
-          "OPENCLAW_QA_TELEGRAM_SUT_CLEANUP_TIMEOUT_MS",
-        ),
-      ).toThrow("OPENCLAW_QA_TELEGRAM_SUT_CLEANUP_TIMEOUT_MS must be a positive integer.");
-    });
   });
 
   it.each([

--- a/extensions/qa-lab/src/live-transports/telegram/cli.runtime.ts
+++ b/extensions/qa-lab/src/live-transports/telegram/cli.runtime.ts
@@ -1,8 +1,8 @@
 import { constants as fsConstants } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
-import type { LiveTransportQaCommandOptions } from "openclaw/plugin-sdk/qa-runtime";
 import { parseStrictPositiveInteger } from "openclaw/plugin-sdk/number-runtime";
+import type { LiveTransportQaCommandOptions } from "openclaw/plugin-sdk/qa-runtime";
 import type { QaGatewayChildCommand } from "../../gateway-child.js";
 import { runQaFlowSuiteFromRuntime } from "../../suite-launch.runtime.js";
 import type { QaSuiteRoundTripProbe } from "../../suite-round-trip.js";

--- a/extensions/qa-lab/src/live-transports/telegram/cli.runtime.ts
+++ b/extensions/qa-lab/src/live-transports/telegram/cli.runtime.ts
@@ -22,7 +22,7 @@ const TELEGRAM_QA_SUT_RUNTIME_EXECUTABLE_ENV = "OPENCLAW_QA_TELEGRAM_SUT_RUNTIME
 const TELEGRAM_QA_SUT_PRELOAD_PATH_ENV = "OPENCLAW_QA_TELEGRAM_SUT_PRELOAD_PATH";
 const TELEGRAM_QA_SUT_FORWARDED_ENV_KEYS_ENV = "OPENCLAW_QA_TELEGRAM_SUT_FORWARDED_ENV_KEYS";
 
-function parseSutId(env: NodeJS.ProcessEnv, key: string) {
+export function parseSutId(env: NodeJS.ProcessEnv, key: string) {
   const value = env[key]?.trim();
   // Match qa-lab CLI numeric flags: reject hex/exponent so UID/GID/timeouts stay decimal.
   const parsed = value ? parseStrictPositiveInteger(value) : undefined;

--- a/extensions/qa-lab/src/live-transports/telegram/cli.runtime.ts
+++ b/extensions/qa-lab/src/live-transports/telegram/cli.runtime.ts
@@ -22,7 +22,7 @@ const TELEGRAM_QA_SUT_RUNTIME_EXECUTABLE_ENV = "OPENCLAW_QA_TELEGRAM_SUT_RUNTIME
 const TELEGRAM_QA_SUT_PRELOAD_PATH_ENV = "OPENCLAW_QA_TELEGRAM_SUT_PRELOAD_PATH";
 const TELEGRAM_QA_SUT_FORWARDED_ENV_KEYS_ENV = "OPENCLAW_QA_TELEGRAM_SUT_FORWARDED_ENV_KEYS";
 
-export function parseSutId(env: NodeJS.ProcessEnv, key: string) {
+function parseSutId(env: NodeJS.ProcessEnv, key: string) {
   const value = env[key]?.trim();
   // Match qa-lab CLI numeric flags: reject hex/exponent so UID/GID/timeouts stay decimal.
   const parsed = value ? parseStrictPositiveInteger(value) : undefined;

--- a/extensions/qa-lab/src/live-transports/telegram/cli.runtime.ts
+++ b/extensions/qa-lab/src/live-transports/telegram/cli.runtime.ts
@@ -2,6 +2,7 @@ import { constants as fsConstants } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import type { LiveTransportQaCommandOptions } from "openclaw/plugin-sdk/qa-runtime";
+import { parseStrictPositiveInteger } from "openclaw/plugin-sdk/number-runtime";
 import type { QaGatewayChildCommand } from "../../gateway-child.js";
 import { runQaFlowSuiteFromRuntime } from "../../suite-launch.runtime.js";
 import type { QaSuiteRoundTripProbe } from "../../suite-round-trip.js";
@@ -23,8 +24,9 @@ const TELEGRAM_QA_SUT_FORWARDED_ENV_KEYS_ENV = "OPENCLAW_QA_TELEGRAM_SUT_FORWARD
 
 function parseSutId(env: NodeJS.ProcessEnv, key: string) {
   const value = env[key]?.trim();
-  const parsed = value ? Number(value) : Number.NaN;
-  if (!Number.isSafeInteger(parsed) || parsed < 1) {
+  // Match qa-lab CLI numeric flags: reject hex/exponent so UID/GID/timeouts stay decimal.
+  const parsed = value ? parseStrictPositiveInteger(value) : undefined;
+  if (parsed === undefined) {
     throw new Error(`${key} must be a positive integer.`);
   }
   return parsed;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Telegram QA SUT env integers (`OPENCLAW_QA_TELEGRAM_SUT_UID`, `GID`, and cleanup timeout) accepted JavaScript-only forms such as `0x3e9` and `1e3` via `Number(...)`. Those values were treated as valid UIDs/timeouts even though the env contract promises a positive decimal integer.

## Why This Change Was Made

- Reuse `parseStrictPositiveInteger` from `openclaw/plugin-sdk/number-runtime` — the same helper qa-lab CLI flags already use — inside `parseSutId`.
- Keep the existing `must be a positive integer` error text.
- `Number("0x3e9")` → 1001, `Number("1e3")` → 1000 pass `Number.isSafeInteger` — the old guard did not protect against hex/exponent.
- `parseStrictPositiveInteger` enforces `/^\+?\d+$/` — rejects hex, exponent, fraction, empty.
- No new abstraction — one shared chokepoint already used by sibling qa-lab numeric parsers.

Collision check: searched open PRs for `parseSutId`, `cli.runtime.ts`, `OPENCLAW_QA_TELEGRAM_SUT_UID`; no same-file or same-problem open PR was found.

## User Impact

Malformed hex/exponent Telegram SUT identity/timeout env values now fail fast with `OPENCLAW_QA_TELEGRAM_SUT_UID must be a positive integer.` (and the matching GID/cleanup keys) instead of silently mapping to a different decimal integer. Ordinary decimal env values are unchanged.

## Evidence

- Exact head: `f07066422f7312102d98201cefaded61022f8da3`
- Rebased onto current `origin/main` before this refresh.
- `oxfmt --check` on touched files — passed.
- `git diff --check` — passed.
- Focused tests at this head:

```bash
node scripts/run-vitest.mjs extensions/qa-lab/src/cli.runtime.test.ts -- --run -t "rejects non-decimal Telegram SUT|telegram SUT strict id parsing|uses the trusted Telegram launcher"
```

```
 ✓ telegram SUT strict id parsing > rejects hex value 0x3e9
 ✓ telegram SUT strict id parsing > rejects exponent value 1e3
 ✓ telegram SUT strict id parsing > rejects fraction value 1001.5
 ✓ telegram SUT strict id parsing > rejects empty/whitespace/zero/negative/missing
 ✓ telegram SUT strict id parsing > accepts decimal UID/GID/cleanup values
 ✓ rejects non-decimal Telegram SUT 'uid-hex' before starting a gateway
 ✓ rejects non-decimal Telegram SUT 'uid-exponent' before starting a gateway
 ✓ rejects non-decimal Telegram SUT 'uid-fraction' before starting a gateway
 ✓ rejects non-decimal Telegram SUT 'gid-hex' before starting a gateway
 ✓ rejects non-decimal Telegram SUT 'cleanup-hex' before starting a gateway
 ✓ uses the trusted Telegram launcher for canonical and legacy gateways

 Test Files  1 passed (1)
      Tests  21 passed | 98 skipped (119)
```

- Full file suite at this branch: `119 passed (119)`.
- Mutation check: revert `parseSutId` to old `Number()` + `Number.isSafeInteger` guard → hex/exponent CLI-chain cases fail; restore → green.

## Real behavior proof

### Behavior addressed

`runQaTelegramCommand` rejects hex/exponent/fraction SUT UID, GID, and cleanup-timeout env values before starting a gateway; valid decimals proceed past SUT integer parse.

### Environment

- OS: Linux x86_64
- Node: v22.22.0
- head: f07066422f7312102d98201cefaded61022f8da3

### Exact commands run

```bash
PROOF_HEAD=f07066422f7312102d98201cefaded61022f8da3 node --import tsx proof-qa-telegram-sut-strict-int.mts
```

### Observed output after fix

```
node=v22.22.0
head=f07066422f7312102d98201cefaded61022f8da3

[case 1] negative control - Number() accepts hex/exponent/fraction
  ok: Number("0x3e9") = 1001 for UID - old code would accept
  info: env=OPENCLAW_QA_TELEGRAM_SUT_UID input=0x3e9 Number()=1001 (would be accepted as UID)
  ok: Number("1e3") = 1000 for GID - old code would accept
  info: env=OPENCLAW_QA_TELEGRAM_SUT_GID input=1e3 Number()=1000 (would be accepted as GID)
  ok: Number("0x3e8") = 1000 for cleanup timeout - old code would accept
  info: env=OPENCLAW_QA_TELEGRAM_SUT_CLEANUP_TIMEOUT_MS input=0x3e8 Number()=1000 (would be accepted as cleanup timeout)
  ok: Number.isSafeInteger(Number("0x3e9")) === true - old guard passed
  ok: Number.isSafeInteger(Number("1e3")) === true - old guard passed

[case 2] positive control - parseStrictPositiveInteger rejects non-decimal
  ok: parseStrictPositiveInteger("0x3e9") returns undefined (rejected)
  ok: parseStrictPositiveInteger("1e3") returns undefined (rejected)
  ok: parseStrictPositiveInteger("1001.5") returns undefined (rejected)
  ok: parseStrictPositiveInteger("0x3e8") returns undefined (rejected)
  ok: parseStrictPositiveInteger("") returns undefined (rejected)
  ok: parseStrictPositiveInteger(" ") returns undefined (rejected)

[case 3] valid response - decimal strings parse correctly via parseSutId
  ok: OPENCLAW_QA_TELEGRAM_SUT_UID parses to 1001
  ok: OPENCLAW_QA_TELEGRAM_SUT_GID parses to 1002
  ok: OPENCLAW_QA_TELEGRAM_SUT_CLEANUP_TIMEOUT_MS parses to 60000

[case 4] full CLI chain - malformed UID/GID/cleanup reject before gateway
  ok: OPENCLAW_QA_TELEGRAM_SUT_UID=0x3e9 throws before gateway
  info: error=OPENCLAW_QA_TELEGRAM_SUT_UID must be a positive integer.
  ok: OPENCLAW_QA_TELEGRAM_SUT_GID=0x3ea throws before gateway
  info: error=OPENCLAW_QA_TELEGRAM_SUT_GID must be a positive integer.
  ok: OPENCLAW_QA_TELEGRAM_SUT_CLEANUP_TIMEOUT_MS=0x3e8 throws before gateway
  info: error=OPENCLAW_QA_TELEGRAM_SUT_CLEANUP_TIMEOUT_MS must be a positive integer.

[case 5] full CLI chain - valid decimals proceed past SUT id parse
  ok: valid decimal UID/GID/cleanup do not throw positive-integer parse errors
  info: proceeded past SUT integer parse; later failure=SQLite support is unavailable or unsafe in this Node runtime. OpenClaw requires SQLite 3.51.3+ (or patched 3.50.7+/3.44.6+) for WAL safety; Node 22.22.0 embeds SQLite 3.50.4, which is affected by the upstream WAL-reset database corruption bug. Upgrade to Node 22.22.3+, 24.15.0+, or 25.9.0+ before retrying.

=== Summary ===
ALL PROOF ASSERTIONS: 18 passed, 0 failed
```

### Evidence

- Old guard `Number.isSafeInteger(Number("0x3e9"))` returns `true` — hex values were accepted as valid UIDs.
- Full CLI path (`runQaTelegramCommand`): malformed `UID=0x3e9`, `GID=0x3ea`, and `CLEANUP_TIMEOUT_MS=0x3e8` each throw `must be a positive integer` before gateway startup.
- Valid decimal UID/GID/cleanup proceed past SUT integer parse (later failure is unrelated SQLite Node-runtime gate, not parse rejection).
- Decimal strings (`"1001"`, `"1002"`, `"60000"`) still parse correctly — no regression.

### What was not tested

- Live Telegram QA Crabbox/Mantis runs; remote provider auth. This is SUT env parsing only — the env contract is wholly testable locally via the real `runQaTelegramCommand` entrypoint with a local SUT fixture.

## Risk / Compatibility

Low. The env error message already promised "must be a positive integer"; sibling qa-lab CLI parsers already use `parseStrictPositiveInteger`; decimal env values are unchanged. Intentional narrowing: custom QA launchers that relied on JS hex/exponent/fraction strings will now fail at startup. No config key changes, no CLI flag changes, no new dependencies.
