### PR TITLE
fix(agents): normalize git package identities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Agent git package identities:** strip refs before hosted-repository parsing and reject traversal segments so GitLab branch refs resolve to the canonical managed install path.
 - **Tlon custom S3 uploads:** pass storage endpoints through the AWS SDK's native parser so custom S3-compatible uploads no longer fail before presigning.
 - **Signal active-run controls:** keep authorized stop, status, approval, and queue-read controls responsive during active turns while preserving ordinary and stateful turns in canonical session admission, and cancel every pending group sender lane on stop. (#107422) Thanks @arduano.
 - **Agent auth storage locks:** surface normal release failures while avoiding redundant release attempts after `proper-lockfile` reports a compromised lock.

--- a/src/agents/utils/git.test.ts
+++ b/src/agents/utils/git.test.ts
@@ -1,4 +1,4 @@
-// Git utility tests cover plugin git source parsing, ref extraction, and path
+// Git utility tests cover plugin git source parsing, ref normalization, and path
 // traversal rejection before managed checkouts are created.
 import { describe, expect, it } from "vitest";
 import { parseGitUrl } from "./git.js";
@@ -9,34 +9,21 @@ describe("parseGitUrl", () => {
       type: "git",
       host: "github.com",
       path: "openclaw/example-plugin",
-      repo: "https://github.com/openclaw/example-plugin",
+    });
+    expect(parseGitUrl("git:https://example.com/@team/example-plugin")).toMatchObject({
+      host: "example.com",
+      path: "@team/example-plugin",
     });
   });
 
-  it("parses refs from hosted, scp-style, and generic shorthand sources", () => {
-    expect(parseGitUrl("git:https://github.com/openclaw/example-plugin.git@v1.2.3")).toMatchObject({
-      host: "github.com",
-      path: "openclaw/example-plugin",
-      repo: "https://github.com/openclaw/example-plugin.git",
-      ref: "v1.2.3",
-      pinned: true,
-    });
-    expect(parseGitUrl("git:git@github.com:openclaw/example-plugin.git@feature/foo")).toMatchObject(
-      {
-        host: "github.com",
-        path: "openclaw/example-plugin",
-        repo: "git@github.com:openclaw/example-plugin.git",
-        ref: "feature/foo",
-        pinned: true,
-      },
-    );
-    expect(parseGitUrl("git:example.com/openclaw/example-plugin@main")).toMatchObject({
-      host: "example.com",
-      path: "openclaw/example-plugin",
-      repo: "https://example.com/openclaw/example-plugin",
-      ref: "main",
-      pinned: true,
-    });
+  it.each([
+    ["git:https://github.com/openclaw/example-plugin.git@v1.2.3", "github.com"],
+    ["git:git@github.com:openclaw/example-plugin.git@feature/foo", "github.com"],
+    ["git:example.com/openclaw/example-plugin@main", "example.com"],
+    ["git:gitlab.com/openclaw/example-plugin@feature/foo", "gitlab.com"],
+    ["git:https://example.com/@team/example-plugin@main", "example.com", "@team/example-plugin"],
+  ])("ignores refs in the identity for %s", (source, host, path = "openclaw/example-plugin") => {
+    expect(parseGitUrl(source)).toMatchObject({ host, path });
   });
 
   it("rejects repository paths that could escape managed checkout roots", () => {
@@ -45,5 +32,8 @@ describe("parseGitUrl", () => {
     expect(parseGitUrl("git:https://example.com/openclaw/../outside")).toBeNull();
     expect(parseGitUrl("git:git@example.com:openclaw/../outside")).toBeNull();
     expect(parseGitUrl("git:example.com/openclaw/./outside")).toBeNull();
+    expect(parseGitUrl("git:https://github.com/openclaw/../outside@feature/foo")).toBeNull();
+    expect(parseGitUrl("git:https://github.com/openclaw/%2e%2e/outside")).toBeNull();
+    expect(parseGitUrl("git:https://github.com/openclaw/repo\\..\\outside")).toBeNull();
   });
 });

--- a/src/agents/utils/git.ts
+++ b/src/agents/utils/git.ts
@@ -1,7 +1,7 @@
 /**
  * Git source parsing helpers.
  *
- * Normalizes git-style package references into clone URL, host/path, and optional ref metadata.
+ * Normalizes git-style package references into host/path identity.
  */
 import hostedGitInfo from "hosted-git-info";
 
@@ -9,110 +9,66 @@ import hostedGitInfo from "hosted-git-info";
 export type GitSource = {
   /** Always "git" for git sources */
   type: "git";
-  /** Clone URL (always valid for git clone, without ref suffix) */
-  repo: string;
   /** Git host domain (e.g., "github.com") */
   host: string;
   /** Repository path (e.g., "user/repo") */
   path: string;
-  /** Git ref (branch, tag, commit) if specified */
-  ref?: string;
-  /** True if ref was specified (package won't be auto-updated) */
-  pinned: boolean;
 };
 
-function splitPathRef(params: {
-  originalRepo: string;
-  pathWithMaybeRef: string;
-  buildRepo: (repoPath: string) => string;
-}): { repo: string; ref?: string } {
-  const refSeparator = params.pathWithMaybeRef.indexOf("@");
-  if (refSeparator < 0) {
-    return { repo: params.originalRepo };
+function stripRef(url: string): string {
+  const protocolIndex = url.indexOf("://");
+  // Package refs use @ only after the repository path starts; credential @ signs stay intact.
+  const pathStart = url.startsWith("git@")
+    ? url.indexOf(":") + 1
+    : url.indexOf("/", protocolIndex < 0 ? 0 : protocolIndex + 3) + 1;
+  if (pathStart <= 0) {
+    return url;
   }
-  const repoPath = params.pathWithMaybeRef.slice(0, refSeparator);
-  const ref = params.pathWithMaybeRef.slice(refSeparator + 1);
-  if (!repoPath || !ref) {
-    return { repo: params.originalRepo };
+  const suffixOffset = url.slice(pathStart).search(/[?#]/);
+  const pathEnd = suffixOffset < 0 ? url.length : pathStart + suffixOffset;
+  let refSeparator = url.indexOf("@", pathStart);
+  if (refSeparator === pathStart) {
+    refSeparator = url.indexOf("@", pathStart + 1);
   }
-  return {
-    repo: params.buildRepo(repoPath),
-    ref,
-  };
+  if (refSeparator <= pathStart || refSeparator === pathEnd - 1 || refSeparator >= pathEnd) {
+    return url;
+  }
+  return protocolIndex < 0
+    ? url.slice(0, refSeparator)
+    : url.slice(0, refSeparator) + url.slice(pathEnd);
 }
 
-function splitRef(url: string): { repo: string; ref?: string } {
-  const scpLikeMatch = url.match(/^git@([^:]+):(.+)$/);
-  if (scpLikeMatch) {
-    return splitPathRef({
-      originalRepo: url,
-      pathWithMaybeRef: scpLikeMatch[2] ?? "",
-      buildRepo: (repoPath) => `git@${scpLikeMatch[1] ?? ""}:${repoPath}`,
-    });
-  }
-
-  if (url.includes("://")) {
-    try {
-      const parsed = new URL(url);
-      return splitPathRef({
-        originalRepo: url,
-        pathWithMaybeRef: parsed.pathname.replace(/^\/+/, ""),
-        buildRepo: (repoPath) => {
-          parsed.pathname = `/${repoPath}`;
-          return parsed.toString().replace(/\/$/, "");
-        },
-      });
-    } catch {
-      return { repo: url };
-    }
-  }
-
-  const slashIndex = url.indexOf("/");
-  if (slashIndex < 0) {
-    return { repo: url };
-  }
-  const host = url.slice(0, slashIndex);
-  return splitPathRef({
-    originalRepo: url,
-    pathWithMaybeRef: url.slice(slashIndex + 1),
-    buildRepo: (repoPath) => `${host}/${repoPath}`,
-  });
+function hasUnsafePathSegments(url: string): boolean {
+  const path = url.split(/[?#]/, 1)[0] ?? "";
+  return path.includes("\\") || /(?:^|\/)(?:\.|%2e){1,2}(?:\/|$)/i.test(path);
 }
 
 function parseGenericGitUrl(url: string): GitSource | null {
-  const { repo: repoWithoutRef, ref } = splitRef(url);
-  let repo = repoWithoutRef;
   let host;
   let path;
 
-  const scpLikeMatch = repoWithoutRef.match(/^git@([^:]+):(.+)$/);
+  const scpLikeMatch = url.match(/^git@([^:]+):(.+)$/);
   if (scpLikeMatch) {
     host = scpLikeMatch[1] ?? "";
     path = scpLikeMatch[2] ?? "";
-  } else if (
-    repoWithoutRef.startsWith("https://") ||
-    repoWithoutRef.startsWith("http://") ||
-    repoWithoutRef.startsWith("ssh://") ||
-    repoWithoutRef.startsWith("git://")
-  ) {
+  } else if (/^(?:https?|ssh|git):\/\//.test(url)) {
     try {
-      const parsed = new URL(repoWithoutRef);
+      const parsed = new URL(url);
       host = parsed.hostname;
       path = parsed.pathname.replace(/^\/+/, "");
     } catch {
       return null;
     }
   } else {
-    const slashIndex = repoWithoutRef.indexOf("/");
+    const slashIndex = url.indexOf("/");
     if (slashIndex < 0) {
       return null;
     }
-    host = repoWithoutRef.slice(0, slashIndex);
-    path = repoWithoutRef.slice(slashIndex + 1);
+    host = url.slice(0, slashIndex);
+    path = url.slice(slashIndex + 1);
     if (!host.includes(".") && host !== "localhost") {
       return null;
     }
-    repo = `https://${repoWithoutRef}`;
   }
 
   const normalizedPath = normalizeGitPath(path);
@@ -122,11 +78,8 @@ function parseGenericGitUrl(url: string): GitSource | null {
 
   return {
     type: "git",
-    repo,
     host,
     path: normalizedPath,
-    ref,
-    pinned: Boolean(ref),
   };
 }
 
@@ -152,31 +105,24 @@ function normalizeGitPath(path: string): string | null {
   return segments.join("/");
 }
 
-function resolveHostedGitSource(params: {
-  candidate: string;
-  split: { repo: string; ref?: string };
-  repo: string;
-}): GitSource | null {
-  const info = hostedGitInfo.fromUrl(params.candidate);
-  if (!info) {
-    return null;
+function parseHostedGitUrl(url: string): GitSource | null {
+  const candidates = [url];
+  if (!url.includes("://") && !url.startsWith("git@")) {
+    candidates.push(`https://${url}`);
   }
-  if (params.split.ref && info.project?.includes("@")) {
-    return null;
+
+  for (const candidate of candidates) {
+    const info = hostedGitInfo.fromUrl(candidate);
+    if (!info) {
+      continue;
+    }
+    const host = info.domain || "";
+    const path = normalizeGitPath(`${info.user}/${info.project}`);
+    if (isSafeGitHost(host) && path) {
+      return { type: "git", host, path };
+    }
   }
-  const host = info.domain || "";
-  const path = normalizeGitPath(`${info.user}/${info.project}`);
-  if (!isSafeGitHost(host) || !path) {
-    return null;
-  }
-  return {
-    type: "git",
-    repo: params.repo,
-    host,
-    path,
-    ref: info.committish || params.split.ref || undefined,
-    pinned: Boolean(info.committish || params.split.ref),
-  };
+  return null;
 }
 
 /**
@@ -195,42 +141,9 @@ export function parseGitUrl(source: string): GitSource | null {
     return null;
   }
 
-  const split = splitRef(url);
-
-  const hostedCandidates = [split.ref ? `${split.repo}#${split.ref}` : undefined, url].filter(
-    (value): value is string => Boolean(value),
-  );
-  for (const candidate of hostedCandidates) {
-    const useHttpsPrefix =
-      !split.repo.startsWith("http://") &&
-      !split.repo.startsWith("https://") &&
-      !split.repo.startsWith("ssh://") &&
-      !split.repo.startsWith("git://") &&
-      !split.repo.startsWith("git@");
-    const parsed = resolveHostedGitSource({
-      candidate,
-      split,
-      repo: useHttpsPrefix ? `https://${split.repo}` : split.repo,
-    });
-    if (parsed) {
-      return parsed;
-    }
+  const urlWithoutRef = stripRef(url);
+  if (hasUnsafePathSegments(urlWithoutRef)) {
+    return null;
   }
-
-  const httpsCandidates = [
-    split.ref ? `https://${split.repo}#${split.ref}` : undefined,
-    `https://${url}`,
-  ].filter((value): value is string => Boolean(value));
-  for (const candidate of httpsCandidates) {
-    const parsed = resolveHostedGitSource({
-      candidate,
-      split,
-      repo: `https://${split.repo}`,
-    });
-    if (parsed) {
-      return parsed;
-    }
-  }
-
-  return parseGenericGitUrl(url);
+  return parseHostedGitUrl(urlWithoutRef) ?? parseGenericGitUrl(urlWithoutRef);
 }


### PR DESCRIPTION
## What Problem This Solves

Agent package identity parsing returned clone URL and ref metadata that no caller used. It also let slash-containing GitLab refs contaminate the managed install path and allowed hosted URL parsing to normalize traversal segments before validation.

## Why This Change Was Made

Reduce `GitSource` to the host/path identity its only consumer needs, strip package refs before delegating hosted repositories to `hosted-git-info`, keep the generic-host fallback, and reject traversal syntax before URL normalization.

## User Impact

GitLab branch refs now resolve to one canonical managed package path, unsafe traversal forms are rejected consistently, and the parser is 96 repository lines smaller.

## Evidence

- `node scripts/run-vitest.mjs src/agents/utils/git.test.ts src/agents/sessions/package-manager.test.ts` — 13 tests passed locally and on Blacksmith Testbox.
- `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo`
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.agents.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/test-core-agents.tsbuildinfo`
- 6,048-form old/new differential probe; drift was limited to canonical GitLab slash refs and traversal rejection.
- `git diff origin/main...HEAD --check`
- Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/29346958198

Hosted CI not awaited per maintainer direction.
