### PR TITLE
fix(agents): avoid stale session label timestamps after replacement

### DIFF
--- a/src/agents/embedded-agent-runner/session-manager-init.test.ts
+++ b/src/agents/embedded-agent-runner/session-manager-init.test.ts
@@ -44,6 +44,7 @@ describe("prepareSessionManagerForRun", () => {
       ],
       byId: new Map([["old", {}]]),
       labelsById: new Map([["old", {}]]),
+      labelTimestampsById: new Map([["old", "2026-05-27T00:00:01.000Z"]]),
       leafId: "old",
     };
     const readFileSpy = vi.spyOn(fs, "readFile");
@@ -67,6 +68,7 @@ describe("prepareSessionManagerForRun", () => {
     ]);
     expect(sessionManager.byId.size).toBe(0);
     expect(sessionManager.labelsById.size).toBe(0);
+    expect(sessionManager.labelTimestampsById.size).toBe(0);
     expect(sessionManager.leafId).toBeNull();
     expect(sessionManager.flushed).toBe(false);
     expect(readFileSpy).not.toHaveBeenCalled();

--- a/src/agents/embedded-agent-runner/session-manager-init.ts
+++ b/src/agents/embedded-agent-runner/session-manager-init.ts
@@ -113,6 +113,7 @@ export async function prepareSessionManagerForRun(params: {
     fileEntries: Array<SessionHeaderEntry | SessionMessageEntry | { type: string }>;
     byId?: Map<string, unknown>;
     labelsById?: Map<string, unknown>;
+    labelTimestampsById?: Map<string, unknown>;
     leafId?: string | null;
     wasRecoveredFromCorruptHeader?: () => boolean;
     clearPreservedOpaqueFileEntries?: () => void;
@@ -166,7 +167,9 @@ export async function prepareSessionManagerForRun(params: {
     sm.fileEntries = [header];
     sm.clearPreservedOpaqueFileEntries?.();
     sm.byId?.clear?.();
+    // Labels and timestamps form one index; neither half may survive this reset.
     sm.labelsById?.clear?.();
+    sm.labelTimestampsById?.clear?.();
     sm.leafId = null;
     sm.flushed = false;
     return;

--- a/src/agents/sessions/session-manager-core.ts
+++ b/src/agents/sessions/session-manager-core.ts
@@ -210,6 +210,7 @@ export class SessionManagerCore {
     this.logicalParentsById.clear();
     this.invalidLeafControlIds.clear();
     this.labelsById.clear();
+    this.labelTimestampsById.clear();
     this.leafId = null;
     this.appendParentId = null;
     this.promptReleasedSideBranchParentId = undefined;

--- a/src/agents/sessions/session-manager.test.ts
+++ b/src/agents/sessions/session-manager.test.ts
@@ -2847,6 +2847,22 @@ describe("SessionManager.open", () => {
     expect(records.find((entry) => entry.id === "side-delivery")?.parentId).toBe(metadata.id);
   });
 
+  it("clears label timestamps when starting a replacement session", async () => {
+    const dir = await makeTempDir();
+    const sessionManager = SessionManager.create(dir, dir);
+    const answerId = sessionManager.appendMessage(buildAssistantMessage("answer"));
+    sessionManager.appendLabelChange(answerId, "saved");
+    const state = sessionManager as unknown as {
+      labelTimestampsById: Map<string, string>;
+    };
+
+    expect(state.labelTimestampsById.size).toBe(1);
+
+    sessionManager.newSession();
+
+    expect(state.labelTimestampsById.size).toBe(0);
+  });
+
   it("removes leaf controls that target regenerated labels when branching", async () => {
     const dir = await makeTempDir();
     const sessionFile = path.join(dir, "session.jsonl");


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users replacing sessions in a long-lived agent runtime could leave old session label timestamps retained in memory after starting the new session.

## Why This Change Was Made

Starting a replacement session already clears the session label map, so it now clears the paired label timestamp map at the same lifecycle boundary. The regression test covers the replacement-session cleanup path directly.

## User Impact

Long-lived session runtimes no longer retain stale label timestamp entries across session replacement.

## Evidence

- Runtime proof: `node --import tsx/esm proof-live.mts` imports the real `SessionManager` production class, labels an assistant entry, replaces the session, and shows the old label timestamp is no longer retained.
- `node scripts/run-vitest.mjs src/agents/sessions/session-manager.test.ts`: passed, 67 tests.
- `git diff --check 57d926b4fd821088bddcd51b516215b409b5a2b4...HEAD`: passed.

```text
$ node --import tsx/esm proof-live.mts
OpenClaw session replacement runtime proof
head=c759612c69c8a9258dd663ec860a10d7361097a5
sessionDir=<tmp>/openclaw-session-runtime-proof-Z3lCAB
answerId=ac7d1b09
labelEntryId=2e45df00
before: timestampPresent=true labelTimestampCount=1
after: timestampPresent=false labelTimestampCount=0
beforeNewSession.timestampPresent=true
beforeNewSession.labelTimestampCount=1
replacementSessionFile=<tmp>/openclaw-session-runtime-proof-Z3lCAB/2026-07-15T02-26-03-044Z_019f6398-72a4-7bd2-8a74-85272a686957.jsonl
afterNewSession.timestampPresent=false
afterNewSession.labelTimestampCount=0
result: PASS

$ node scripts/run-vitest.mjs src/agents/sessions/session-manager.test.ts
Test Files  1 passed (1)
Tests  67 passed (67)

$ git diff --check 57d926b4fd821088bddcd51b516215b409b5a2b4...HEAD
<no output>
```

<details>
<summary>proof-live.mts</summary>

```ts
import fs from "node:fs";
import os from "node:os";
import path from "node:path";
import { execFileSync } from "node:child_process";
import { SessionManager } from "./src/agents/sessions/session-manager.ts";

function buildAssistantMessage(text: string) {
  return {
    role: "assistant" as const,
    content: [{ type: "text" as const, text }],
    api: "messages" as const,
    provider: "anthropic" as const,
    model: "sonnet-4.6" as const,
    usage: {
      input: 0,
      output: 0,
      cacheRead: 0,
      cacheWrite: 0,
      totalTokens: 0,
      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
    },
    stopReason: "stop" as const,
    timestamp: Date.now(),
  };
}

const head = execFileSync("git", ["rev-parse", "HEAD"], { encoding: "utf8" }).trim();
const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-session-runtime-proof-"));

try {
  const sessionManager = SessionManager.create(tempDir, tempDir);
  const answerId = sessionManager.appendMessage(buildAssistantMessage("runtime answer"));
  const labelEntryId = sessionManager.appendLabelChange(answerId, "saved for runtime proof");
  const state = sessionManager as unknown as {
    labelTimestampsById: Map<string, string>;
  };
  const beforeTimestamp = state.labelTimestampsById.get(answerId);
  const beforeTimestampCount = state.labelTimestampsById.size;
  const replacementFile = sessionManager.newSession();
  const afterTimestamp = state.labelTimestampsById.get(answerId);

  console.log("OpenClaw session replacement runtime proof");
  console.log(`head=${head}`);
  console.log(`sessionDir=${tempDir}`);
  console.log(`answerId=${answerId}`);
  console.log(`labelEntryId=${labelEntryId}`);
  console.log(
    `before: timestampPresent=${String(beforeTimestamp !== undefined)} labelTimestampCount=${beforeTimestampCount}`,
  );
  console.log(
    `after: timestampPresent=${String(afterTimestamp !== undefined)} labelTimestampCount=${state.labelTimestampsById.size}`,
  );
  console.log(`beforeNewSession.timestampPresent=${String(beforeTimestamp !== undefined)}`);
  console.log(`beforeNewSession.labelTimestampCount=${beforeTimestampCount}`);
  console.log(`replacementSessionFile=${replacementFile}`);
  console.log(`afterNewSession.timestampPresent=${String(afterTimestamp !== undefined)}`);
  console.log(`afterNewSession.labelTimestampCount=${state.labelTimestampsById.size}`);
  console.log(
    `result: ${afterTimestamp === undefined && state.labelTimestampsById.size === 0 ? "PASS" : "FAIL"}`,
  );
} finally {
  fs.rmSync(tempDir, { recursive: true, force: true });
}
```

</details>

AI-assisted: built with Codex
