### PR TITLE
fix(logbook): reject malformed 12-hour AM/PM times from model output [AI-assisted]

### DIFF
--- a/extensions/logbook/src/analyze.test.ts
+++ b/extensions/logbook/src/analyze.test.ts
@@ -35,6 +35,21 @@ describe("clockToMs", () => {
     expect(clockToMs("not-a-day", "10:00:00")).toBeNull();
   });
 
+  it("rejects invalid 12-hour meridiem hours from model output", () => {
+    // A meridiem clock must use hours 1-12; the model can emit malformed clocks
+    // like "13:05 pm" or "00:05 am" that would otherwise be accepted as the wrong 24h time.
+    expect(clockToMs(DAY, "13:05 pm")).toBeNull();
+    expect(clockToMs(DAY, "00:05 am")).toBeNull();
+    expect(clockToMs(DAY, "00:30 pm")).toBeNull();
+    expect(clockToMs(DAY, "15:00 am")).toBeNull();
+    // Valid 12-hour edges stay accepted.
+    expect(clockToMs(DAY, "12:00 am")).toBe(dayMs("00:00:00"));
+    expect(clockToMs(DAY, "12:00 pm")).toBe(dayMs("12:00:00"));
+    expect(clockToMs(DAY, "1:05 pm")).toBe(dayMs("13:05:00"));
+    // 24-hour clocks without a meridiem are unaffected.
+    expect(clockToMs(DAY, "13:05:00")).toBe(dayMs("13:05:00"));
+  });
+
   it("preserves local wall-clock time across a DST transition", () => {
     const moduleUrl = new URL("./analyze.ts", import.meta.url).href;
     const output = execFileSync(

--- a/extensions/logbook/src/analyze.ts
+++ b/extensions/logbook/src/analyze.ts
@@ -24,6 +24,13 @@ export function clockToMs(day: string, clock: string): number | null {
   const minutes = Number(match[2]);
   const seconds = Number(match[3] ?? "0");
   const meridiem = match[4]?.toLowerCase();
+  // A 12-hour meridiem clock must use hours 1-12. The model sometimes emits
+  // malformed clocks like "13:05 pm" or "00:05 am"; without this guard they
+  // fall through to the 24-hour branch and are silently accepted as the wrong
+  // time (e.g. "00:30 pm" becomes 12:30 noon) instead of being rejected.
+  if (meridiem !== undefined && (hours < 1 || hours > 12)) {
+    return null;
+  }
   if (meridiem === "pm" && hours < 12) {
     hours += 12;
   }


### PR DESCRIPTION
> [AI-assisted] This PR was generated using Claude Code.

## What Problem This Solves

Fixes an issue where Logbook analysis would silently accept invalid 12-hour
meridiem clocks emitted by the vision model — e.g. `13:05 pm`, `00:05 am`,
`00:30 pm`, `15:00 am` — and turn them into misleading timeline timestamps.

`clockToMs` (the shared parser behind observation segments, timeline cards, and
distraction ranges) applied AM/PM conversion and then only checked
`hours > 23`. So a meridiem hour outside the valid 1–12 range fell through to
the 24-hour branch and was accepted as the wrong time. The worst case is
`00:30 pm`: hour `0` triggers `hours += 12`, so it silently becomes `12:30`
(noon) instead of being rejected.

## Why This Change Was Made

When a meridiem (`am`/`pm`) is present, the hour must be in the 1–12 range.
The parser now rejects meridiem-formatted hours outside 1–12 **before** the
AM/PM conversion. The change stays entirely inside the Logbook analysis parsing
boundary: 24-hour clocks without a meridiem (e.g. `13:05:00`) are unchanged,
and the valid 12-hour edges (`12:00 am` → midnight, `12:00 pm` → noon,
`1:05 pm` → 13:05) behave exactly as before.

## User Impact

Logbook analysis no longer turns malformed model output into wrong timeline
timestamps. Invalid 12-hour clock ranges are rejected through the same parser
used by observation segments, timeline cards, and distraction ranges, so a
misread meridiem hour no longer produces a silently-shifted event on the
timeline.

## Evidence

Real behavior proof captured by running the **production** `clockToMs` function
(imported from `extensions/logbook/src/analyze.ts`) via
`tsx scripts/proof/logbook-meridiem-clock.mjs` on the unpatched head and again
after the patch. Day `2026-07-03`, local TZ `Asia/Shanghai`.

**Before (unpatched `upstream/main`)** — malformed meridiem clocks are silently
accepted as the wrong 24h time:

```
Bug cases (invalid 12-hour meridiem clocks — MUST be rejected):
  clockToMs("13:05 pm"  ) = 13:05:00           ❌ ACCEPTED (bug)
  clockToMs("00:05 am"  ) = 00:05:00           ❌ ACCEPTED (bug)
  clockToMs("00:30 pm"  ) = 12:30:00           ❌ ACCEPTED (bug)
  clockToMs("15:00 am"  ) = 15:00:00           ❌ ACCEPTED (bug)

Valid controls (MUST remain unchanged):
  clockToMs("1:05 pm"   ) = 13:05:00   expect 13:05:00  [valid 12h pm] ✅
  clockToMs("12:00 am"  ) = 00:00:00   expect 00:00:00  [midnight] ✅
  clockToMs("12:00 pm"  ) = 12:00:00   expect 12:00:00  [noon] ✅
  clockToMs("10:00:00"  ) = 10:00:00   expect 10:00:00  [24h no meridiem] ✅
  clockToMs("13:05:00"  ) = 13:05:00   expect 13:05:00  [24h no meridiem (still valid)] ✅

Verdict: BUG PRESENT | valid controls all preserved
```

**After (this patch)** — malformed meridiem clocks are now rejected, valid
clocks unchanged:

```
Bug cases (invalid 12-hour meridiem clocks — MUST be rejected):
  clockToMs("13:05 pm"  ) = null (rejected)    ✅ rejected
  clockToMs("00:05 am"  ) = null (rejected)    ✅ rejected
  clockToMs("00:30 pm"  ) = null (rejected)    ✅ rejected
  clockToMs("15:00 am"  ) = null (rejected)    ✅ rejected

Valid controls (MUST remain unchanged):
  clockToMs("1:05 pm"   ) = 13:05:00   expect 13:05:00  [valid 12h pm] ✅
  clockToMs("12:00 am"  ) = 00:00:00   expect 00:00:00  [midnight] ✅
  clockToMs("12:00 pm"  ) = 12:00:00   expect 12:00:00  [noon] ✅
  clockToMs("10:00:00"  ) = 10:00:00   expect 10:00:00  [24h no meridiem] ✅
  clockToMs("13:05:00"  ) = 13:05:00   expect 13:05:00  [24h no meridiem (still valid)] ✅

Verdict: bug fixed | valid controls all preserved
```

Regression coverage added in `extensions/logbook/src/analyze.test.ts`
(`rejects invalid 12-hour meridiem hours from model output`): the four malformed
cases assert `null`, and the valid 12-hour edges plus a 24-hour clock assert the
expected times. Full file run:

```
node scripts/run-vitest.mjs extensions/logbook/src/analyze.test.ts
 Test Files  1 passed (1)
      Tests  25 passed (25)
```

The local proof script (`scripts/proof/logbook-meridiem-clock.mjs`) is kept
untracked — it is not part of the shipped change. The production code path it
exercises (`clockToMs`) is the exact function the Logbook analysis pipeline
calls for every observation segment, timeline card, and distraction range.
