### PR TITLE
fix(macos): keep Connect Your AI choices in CLI order

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -31363,15 +31363,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 405,
-      "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
-      "source": "Connect with an API key or token instead…",
-      "surface": "apple",
-      "id": "native.apple.f179b0447a18bbf4"
-    },
-    {
-      "kind": "ui-call",
-      "line": 419,
+      "line": 404,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Sign in with a provider",
       "surface": "apple",
@@ -31379,7 +31371,7 @@
     },
     {
       "kind": "ui-call-concatenated",
-      "line": 421,
+      "line": 406,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Use an existing subscription or provider account. OpenClaw opens the provider’s own sign-in flow, then verifies it with a real reply.",
       "surface": "apple",
@@ -31387,15 +31379,23 @@
     },
     {
       "kind": "ui-call",
-      "line": 433,
+      "line": 421,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "More sign-in options",
       "surface": "apple",
       "id": "native.apple.14b23c357d7a9eff"
     },
     {
+      "kind": "ui-call",
+      "line": 451,
+      "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
+      "source": "API Keys",
+      "surface": "apple",
+      "id": "native.apple.634c5b2f1e8ec40f"
+    },
+    {
       "kind": "conditional-branch",
-      "line": 473,
+      "line": 489,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Pair",
       "surface": "apple",
@@ -31403,7 +31403,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 473,
+      "line": 489,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Sign in",
       "surface": "apple",
@@ -31411,7 +31411,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 489,
+      "line": 505,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Credentials stay on this Gateway and are saved only after the live test succeeds.",
       "surface": "apple",
@@ -31419,7 +31419,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 518,
+      "line": 534,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Open sign-in page…",
       "surface": "apple",
@@ -31427,7 +31427,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 525,
+      "line": 541,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Starting secure sign-in…",
       "surface": "apple",
@@ -31435,7 +31435,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 531,
+      "line": 547,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Sign-in didn’t complete",
       "surface": "apple",
@@ -31443,7 +31443,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 541,
+      "line": 557,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Cancel",
       "surface": "apple",
@@ -31451,7 +31451,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 564,
+      "line": 580,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Finish in your browser",
       "surface": "apple",
@@ -31459,7 +31459,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 580,
+      "line": 596,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Copy",
       "surface": "apple",
@@ -31467,7 +31467,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 591,
+      "line": 607,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Expires in \\(minutes) minutes",
       "surface": "apple",
@@ -31475,7 +31475,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 598,
+      "line": 614,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Open sign-in page",
       "surface": "apple",
@@ -31483,7 +31483,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 626,
+      "line": 642,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Option",
       "surface": "apple",
@@ -31491,7 +31491,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 632,
+      "line": 648,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Confirm",
       "surface": "apple",
@@ -31499,7 +31499,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 641,
+      "line": 657,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "I've signed in",
       "surface": "apple",
@@ -31507,7 +31507,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 643,
+      "line": 659,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Continue",
       "surface": "apple",
@@ -31515,7 +31515,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 643,
+      "line": 659,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Submit",
       "surface": "apple",
@@ -31523,7 +31523,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 648,
+      "line": 664,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Connect with an API key or token",
       "surface": "apple",
@@ -31531,7 +31531,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 651,
+      "line": 667,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Provider",
       "surface": "apple",
@@ -31539,7 +31539,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 659,
+      "line": 675,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "API key or token",
       "surface": "apple",
@@ -31547,7 +31547,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 671,
+      "line": 687,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Connect",
       "surface": "apple",
@@ -31555,7 +31555,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 684,
+      "line": 700,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "That key didn’t work",
       "surface": "apple",
@@ -31563,7 +31563,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 710,
+      "line": 726,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "OpenClaw — setup helper",
       "surface": "apple",
@@ -31571,7 +31571,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 713,
+      "line": 729,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Done",
       "surface": "apple",
@@ -31579,7 +31579,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 774,
+      "line": 790,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Open help…",
       "surface": "apple",
@@ -31587,7 +31587,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 813,
+      "line": 829,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Hide details",
       "surface": "apple",
@@ -31595,7 +31595,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 813,
+      "line": 829,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Show details",
       "surface": "apple",
@@ -31603,7 +31603,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 836,
+      "line": 852,
       "path": "apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift",
       "source": "Copy error",
       "surface": "apple",

--- a/apps/.i18n/native/ar.json
+++ b/apps/.i18n/native/ar.json
@@ -19604,11 +19604,6 @@
       "translated": "تحقق مرة أخرى"
     },
     {
-      "id": "native.apple.f179b0447a18bbf4",
-      "source": "Connect with an API key or token instead…",
-      "translated": "الاتصال باستخدام مفتاح API أو رمز مميز بدلاً من ذلك…"
-    },
-    {
       "id": "native.apple.7fc409b6aaa6d3b9",
       "source": "Sign in with a provider",
       "translated": "تسجيل الدخول باستخدام مزوّد"
@@ -19622,6 +19617,11 @@
       "id": "native.apple.14b23c357d7a9eff",
       "source": "More sign-in options",
       "translated": "المزيد من خيارات تسجيل الدخول"
+    },
+    {
+      "id": "native.apple.634c5b2f1e8ec40f",
+      "source": "API Keys",
+      "translated": "API Keys"
     },
     {
       "id": "native.apple.10971b41012d4f36",

--- a/apps/.i18n/native/de.json
+++ b/apps/.i18n/native/de.json
@@ -19604,11 +19604,6 @@
       "translated": "Erneut prüfen"
     },
     {
-      "id": "native.apple.f179b0447a18bbf4",
-      "source": "Connect with an API key or token instead…",
-      "translated": "Stattdessen mit einem API-Schlüssel oder Token verbinden…"
-    },
-    {
       "id": "native.apple.7fc409b6aaa6d3b9",
       "source": "Sign in with a provider",
       "translated": "Mit einem Anbieter anmelden"
@@ -19622,6 +19617,11 @@
       "id": "native.apple.14b23c357d7a9eff",
       "source": "More sign-in options",
       "translated": "Weitere Anmeldeoptionen"
+    },
+    {
+      "id": "native.apple.634c5b2f1e8ec40f",
+      "source": "API Keys",
+      "translated": "API Keys"
     },
     {
       "id": "native.apple.10971b41012d4f36",

--- a/apps/.i18n/native/es.json
+++ b/apps/.i18n/native/es.json
@@ -19604,11 +19604,6 @@
       "translated": "Comprobar de nuevo"
     },
     {
-      "id": "native.apple.f179b0447a18bbf4",
-      "source": "Connect with an API key or token instead…",
-      "translated": "Conectar con una clave de API o token en su lugar…"
-    },
-    {
       "id": "native.apple.7fc409b6aaa6d3b9",
       "source": "Sign in with a provider",
       "translated": "Iniciar sesión con un proveedor"
@@ -19622,6 +19617,11 @@
       "id": "native.apple.14b23c357d7a9eff",
       "source": "More sign-in options",
       "translated": "Más opciones de inicio de sesión"
+    },
+    {
+      "id": "native.apple.634c5b2f1e8ec40f",
+      "source": "API Keys",
+      "translated": "API Keys"
     },
     {
       "id": "native.apple.10971b41012d4f36",

--- a/apps/.i18n/native/fa.json
+++ b/apps/.i18n/native/fa.json
@@ -19604,11 +19604,6 @@
       "translated": "بررسی دوباره"
     },
     {
-      "id": "native.apple.f179b0447a18bbf4",
-      "source": "Connect with an API key or token instead…",
-      "translated": "در عوض با کلید API یا توکن متصل شوید…"
-    },
-    {
       "id": "native.apple.7fc409b6aaa6d3b9",
       "source": "Sign in with a provider",
       "translated": "ورود با یک ارائه‌دهنده"
@@ -19622,6 +19617,11 @@
       "id": "native.apple.14b23c357d7a9eff",
       "source": "More sign-in options",
       "translated": "گزینه‌های بیشتر ورود"
+    },
+    {
+      "id": "native.apple.634c5b2f1e8ec40f",
+      "source": "API Keys",
+      "translated": "API Keys"
     },
     {
       "id": "native.apple.10971b41012d4f36",

--- a/apps/.i18n/native/fr.json
+++ b/apps/.i18n/native/fr.json
@@ -19604,11 +19604,6 @@
       "translated": "Vérifier à nouveau"
     },
     {
-      "id": "native.apple.f179b0447a18bbf4",
-      "source": "Connect with an API key or token instead…",
-      "translated": "Se connecter plutôt avec une clé API ou un jeton…"
-    },
-    {
       "id": "native.apple.7fc409b6aaa6d3b9",
       "source": "Sign in with a provider",
       "translated": "Se connecter avec un fournisseur"
@@ -19622,6 +19617,11 @@
       "id": "native.apple.14b23c357d7a9eff",
       "source": "More sign-in options",
       "translated": "Plus d’options de connexion"
+    },
+    {
+      "id": "native.apple.634c5b2f1e8ec40f",
+      "source": "API Keys",
+      "translated": "API Keys"
     },
     {
       "id": "native.apple.10971b41012d4f36",

--- a/apps/.i18n/native/hi.json
+++ b/apps/.i18n/native/hi.json
@@ -19604,11 +19604,6 @@
       "translated": "फिर से जाँचें"
     },
     {
-      "id": "native.apple.f179b0447a18bbf4",
-      "source": "Connect with an API key or token instead…",
-      "translated": "इसके बजाय API key या token से कनेक्ट करें…"
-    },
-    {
       "id": "native.apple.7fc409b6aaa6d3b9",
       "source": "Sign in with a provider",
       "translated": "किसी प्रदाता से साइन इन करें"
@@ -19622,6 +19617,11 @@
       "id": "native.apple.14b23c357d7a9eff",
       "source": "More sign-in options",
       "translated": "अधिक साइन-इन विकल्प"
+    },
+    {
+      "id": "native.apple.634c5b2f1e8ec40f",
+      "source": "API Keys",
+      "translated": "API Keys"
     },
     {
       "id": "native.apple.10971b41012d4f36",

--- a/apps/.i18n/native/id.json
+++ b/apps/.i18n/native/id.json
@@ -19604,11 +19604,6 @@
       "translated": "Periksa lagi"
     },
     {
-      "id": "native.apple.f179b0447a18bbf4",
-      "source": "Connect with an API key or token instead…",
-      "translated": "Hubungkan dengan kunci API atau token saja…"
-    },
-    {
       "id": "native.apple.7fc409b6aaa6d3b9",
       "source": "Sign in with a provider",
       "translated": "Masuk dengan penyedia"
@@ -19622,6 +19617,11 @@
       "id": "native.apple.14b23c357d7a9eff",
       "source": "More sign-in options",
       "translated": "Opsi masuk lainnya"
+    },
+    {
+      "id": "native.apple.634c5b2f1e8ec40f",
+      "source": "API Keys",
+      "translated": "API Keys"
     },
     {
       "id": "native.apple.10971b41012d4f36",

--- a/apps/.i18n/native/it.json
+++ b/apps/.i18n/native/it.json
@@ -19604,11 +19604,6 @@
       "translated": "Controlla di nuovo"
     },
     {
-      "id": "native.apple.f179b0447a18bbf4",
-      "source": "Connect with an API key or token instead…",
-      "translated": "Connetti invece con una chiave API o un token…"
-    },
-    {
       "id": "native.apple.7fc409b6aaa6d3b9",
       "source": "Sign in with a provider",
       "translated": "Accedi con un provider"
@@ -19622,6 +19617,11 @@
       "id": "native.apple.14b23c357d7a9eff",
       "source": "More sign-in options",
       "translated": "Altre opzioni di accesso"
+    },
+    {
+      "id": "native.apple.634c5b2f1e8ec40f",
+      "source": "API Keys",
+      "translated": "API Keys"
     },
     {
       "id": "native.apple.10971b41012d4f36",

--- a/apps/.i18n/native/ja-JP.json
+++ b/apps/.i18n/native/ja-JP.json
@@ -19604,11 +19604,6 @@
       "translated": "再確認"
     },
     {
-      "id": "native.apple.f179b0447a18bbf4",
-      "source": "Connect with an API key or token instead…",
-      "translated": "代わりに API キーまたはトークンで接続…"
-    },
-    {
       "id": "native.apple.7fc409b6aaa6d3b9",
       "source": "Sign in with a provider",
       "translated": "プロバイダーでサインイン"
@@ -19622,6 +19617,11 @@
       "id": "native.apple.14b23c357d7a9eff",
       "source": "More sign-in options",
       "translated": "その他のサインインオプション"
+    },
+    {
+      "id": "native.apple.634c5b2f1e8ec40f",
+      "source": "API Keys",
+      "translated": "API Keys"
     },
     {
       "id": "native.apple.10971b41012d4f36",

--- a/apps/.i18n/native/ko.json
+++ b/apps/.i18n/native/ko.json
@@ -19604,11 +19604,6 @@
       "translated": "다시 확인"
     },
     {
-      "id": "native.apple.f179b0447a18bbf4",
-      "source": "Connect with an API key or token instead…",
-      "translated": "대신 API 키 또는 토큰으로 연결…"
-    },
-    {
       "id": "native.apple.7fc409b6aaa6d3b9",
       "source": "Sign in with a provider",
       "translated": "공급자로 로그인"
@@ -19622,6 +19617,11 @@
       "id": "native.apple.14b23c357d7a9eff",
       "source": "More sign-in options",
       "translated": "추가 로그인 옵션"
+    },
+    {
+      "id": "native.apple.634c5b2f1e8ec40f",
+      "source": "API Keys",
+      "translated": "API Keys"
     },
     {
       "id": "native.apple.10971b41012d4f36",

--- a/apps/.i18n/native/nl.json
+++ b/apps/.i18n/native/nl.json
@@ -19604,11 +19604,6 @@
       "translated": "Opnieuw controleren"
     },
     {
-      "id": "native.apple.f179b0447a18bbf4",
-      "source": "Connect with an API key or token instead…",
-      "translated": "In plaats daarvan verbinden met een API-sleutel of token…"
-    },
-    {
       "id": "native.apple.7fc409b6aaa6d3b9",
       "source": "Sign in with a provider",
       "translated": "Aanmelden met een provider"
@@ -19622,6 +19617,11 @@
       "id": "native.apple.14b23c357d7a9eff",
       "source": "More sign-in options",
       "translated": "Meer aanmeldopties"
+    },
+    {
+      "id": "native.apple.634c5b2f1e8ec40f",
+      "source": "API Keys",
+      "translated": "API Keys"
     },
     {
       "id": "native.apple.10971b41012d4f36",

--- a/apps/.i18n/native/pl.json
+++ b/apps/.i18n/native/pl.json
@@ -19604,11 +19604,6 @@
       "translated": "Sprawdź ponownie"
     },
     {
-      "id": "native.apple.f179b0447a18bbf4",
-      "source": "Connect with an API key or token instead…",
-      "translated": "Połącz zamiast tego za pomocą klucza API lub tokena…"
-    },
-    {
       "id": "native.apple.7fc409b6aaa6d3b9",
       "source": "Sign in with a provider",
       "translated": "Zaloguj się u dostawcy"
@@ -19622,6 +19617,11 @@
       "id": "native.apple.14b23c357d7a9eff",
       "source": "More sign-in options",
       "translated": "Więcej opcji logowania"
+    },
+    {
+      "id": "native.apple.634c5b2f1e8ec40f",
+      "source": "API Keys",
+      "translated": "API Keys"
     },
     {
       "id": "native.apple.10971b41012d4f36",

--- a/apps/.i18n/native/pt-BR.json
+++ b/apps/.i18n/native/pt-BR.json
@@ -19604,11 +19604,6 @@
       "translated": "Verificar novamente"
     },
     {
-      "id": "native.apple.f179b0447a18bbf4",
-      "source": "Connect with an API key or token instead…",
-      "translated": "Conectar com uma chave de API ou token…"
-    },
-    {
       "id": "native.apple.7fc409b6aaa6d3b9",
       "source": "Sign in with a provider",
       "translated": "Entrar com um provedor"
@@ -19622,6 +19617,11 @@
       "id": "native.apple.14b23c357d7a9eff",
       "source": "More sign-in options",
       "translated": "Mais opções de login"
+    },
+    {
+      "id": "native.apple.634c5b2f1e8ec40f",
+      "source": "API Keys",
+      "translated": "API Keys"
     },
     {
       "id": "native.apple.10971b41012d4f36",

--- a/apps/.i18n/native/ru.json
+++ b/apps/.i18n/native/ru.json
@@ -19604,11 +19604,6 @@
       "translated": "Проверить снова"
     },
     {
-      "id": "native.apple.f179b0447a18bbf4",
-      "source": "Connect with an API key or token instead…",
-      "translated": "Подключиться с помощью API-ключа или токена…"
-    },
-    {
       "id": "native.apple.7fc409b6aaa6d3b9",
       "source": "Sign in with a provider",
       "translated": "Войти через провайдера"
@@ -19622,6 +19617,11 @@
       "id": "native.apple.14b23c357d7a9eff",
       "source": "More sign-in options",
       "translated": "Больше вариантов входа"
+    },
+    {
+      "id": "native.apple.634c5b2f1e8ec40f",
+      "source": "API Keys",
+      "translated": "API Keys"
     },
     {
       "id": "native.apple.10971b41012d4f36",

--- a/apps/.i18n/native/sv.json
+++ b/apps/.i18n/native/sv.json
@@ -19604,11 +19604,6 @@
       "translated": "Kontrollera igen"
     },
     {
-      "id": "native.apple.f179b0447a18bbf4",
-      "source": "Connect with an API key or token instead…",
-      "translated": "Anslut med en API-nyckel eller token istället…"
-    },
-    {
       "id": "native.apple.7fc409b6aaa6d3b9",
       "source": "Sign in with a provider",
       "translated": "Logga in med en leverantör"
@@ -19622,6 +19617,11 @@
       "id": "native.apple.14b23c357d7a9eff",
       "source": "More sign-in options",
       "translated": "Fler inloggningsalternativ"
+    },
+    {
+      "id": "native.apple.634c5b2f1e8ec40f",
+      "source": "API Keys",
+      "translated": "API Keys"
     },
     {
       "id": "native.apple.10971b41012d4f36",

--- a/apps/.i18n/native/th.json
+++ b/apps/.i18n/native/th.json
@@ -19604,11 +19604,6 @@
       "translated": "ตรวจสอบอีกครั้ง"
     },
     {
-      "id": "native.apple.f179b0447a18bbf4",
-      "source": "Connect with an API key or token instead…",
-      "translated": "เชื่อมต่อด้วย API key หรือโทเค็นแทน…"
-    },
-    {
       "id": "native.apple.7fc409b6aaa6d3b9",
       "source": "Sign in with a provider",
       "translated": "ลงชื่อเข้าใช้ด้วยผู้ให้บริการ"
@@ -19622,6 +19617,11 @@
       "id": "native.apple.14b23c357d7a9eff",
       "source": "More sign-in options",
       "translated": "ตัวเลือกการลงชื่อเข้าใช้เพิ่มเติม"
+    },
+    {
+      "id": "native.apple.634c5b2f1e8ec40f",
+      "source": "API Keys",
+      "translated": "API Keys"
     },
     {
       "id": "native.apple.10971b41012d4f36",

--- a/apps/.i18n/native/tr.json
+++ b/apps/.i18n/native/tr.json
@@ -19604,11 +19604,6 @@
       "translated": "Tekrar kontrol et"
     },
     {
-      "id": "native.apple.f179b0447a18bbf4",
-      "source": "Connect with an API key or token instead…",
-      "translated": "Bunun yerine bir API anahtarı veya token ile bağlan…"
-    },
-    {
       "id": "native.apple.7fc409b6aaa6d3b9",
       "source": "Sign in with a provider",
       "translated": "Bir sağlayıcıyla oturum aç"
@@ -19622,6 +19617,11 @@
       "id": "native.apple.14b23c357d7a9eff",
       "source": "More sign-in options",
       "translated": "Daha fazla oturum açma seçeneği"
+    },
+    {
+      "id": "native.apple.634c5b2f1e8ec40f",
+      "source": "API Keys",
+      "translated": "API Keys"
     },
     {
       "id": "native.apple.10971b41012d4f36",

--- a/apps/.i18n/native/uk.json
+++ b/apps/.i18n/native/uk.json
@@ -19604,11 +19604,6 @@
       "translated": "Перевірити ще раз"
     },
     {
-      "id": "native.apple.f179b0447a18bbf4",
-      "source": "Connect with an API key or token instead…",
-      "translated": "Підключитися за допомогою ключа API чи токена натомість…"
-    },
-    {
       "id": "native.apple.7fc409b6aaa6d3b9",
       "source": "Sign in with a provider",
       "translated": "Увійти через провайдера"
@@ -19622,6 +19617,11 @@
       "id": "native.apple.14b23c357d7a9eff",
       "source": "More sign-in options",
       "translated": "Більше варіантів входу"
+    },
+    {
+      "id": "native.apple.634c5b2f1e8ec40f",
+      "source": "API Keys",
+      "translated": "API Keys"
     },
     {
       "id": "native.apple.10971b41012d4f36",

--- a/apps/.i18n/native/vi.json
+++ b/apps/.i18n/native/vi.json
@@ -19604,11 +19604,6 @@
       "translated": "Kiểm tra lại"
     },
     {
-      "id": "native.apple.f179b0447a18bbf4",
-      "source": "Connect with an API key or token instead…",
-      "translated": "Kết nối bằng khóa API hoặc token…"
-    },
-    {
       "id": "native.apple.7fc409b6aaa6d3b9",
       "source": "Sign in with a provider",
       "translated": "Đăng nhập với một nhà cung cấp"
@@ -19622,6 +19617,11 @@
       "id": "native.apple.14b23c357d7a9eff",
       "source": "More sign-in options",
       "translated": "Thêm tùy chọn đăng nhập"
+    },
+    {
+      "id": "native.apple.634c5b2f1e8ec40f",
+      "source": "API Keys",
+      "translated": "API Keys"
     },
     {
       "id": "native.apple.10971b41012d4f36",

--- a/apps/.i18n/native/zh-CN.json
+++ b/apps/.i18n/native/zh-CN.json
@@ -19604,11 +19604,6 @@
       "translated": "再次检查"
     },
     {
-      "id": "native.apple.f179b0447a18bbf4",
-      "source": "Connect with an API key or token instead…",
-      "translated": "改用 API 密钥或令牌连接…"
-    },
-    {
       "id": "native.apple.7fc409b6aaa6d3b9",
       "source": "Sign in with a provider",
       "translated": "使用提供商登录"
@@ -19622,6 +19617,11 @@
       "id": "native.apple.14b23c357d7a9eff",
       "source": "More sign-in options",
       "translated": "更多登录选项"
+    },
+    {
+      "id": "native.apple.634c5b2f1e8ec40f",
+      "source": "API Keys",
+      "translated": "API Keys"
     },
     {
       "id": "native.apple.10971b41012d4f36",

--- a/apps/.i18n/native/zh-TW.json
+++ b/apps/.i18n/native/zh-TW.json
@@ -19604,11 +19604,6 @@
       "translated": "再次檢查"
     },
     {
-      "id": "native.apple.f179b0447a18bbf4",
-      "source": "Connect with an API key or token instead…",
-      "translated": "改用 API 金鑰或權杖連接…"
-    },
-    {
       "id": "native.apple.7fc409b6aaa6d3b9",
       "source": "Sign in with a provider",
       "translated": "使用供應商登入"
@@ -19622,6 +19617,11 @@
       "id": "native.apple.14b23c357d7a9eff",
       "source": "More sign-in options",
       "translated": "更多登入選項"
+    },
+    {
+      "id": "native.apple.634c5b2f1e8ec40f",
+      "source": "API Keys",
+      "translated": "API Keys"
     },
     {
       "id": "native.apple.10971b41012d4f36",

--- a/apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift
@@ -392,29 +392,14 @@ struct OnboardingAISetupView: View {
                     self.model.retryFromScratch()
                 }
             }
-        } else {
-            VStack(alignment: .leading, spacing: 10) {
-                if self.model.candidates.isEmpty || self.model.showManualEntry {
-                    self.manualForm
-                } else {
-                    Button {
-                        withAnimation(.spring(response: 0.25, dampingFraction: 0.9)) {
-                            self.model.showManualEntry = true
-                        }
-                    } label: {
-                        Label("Connect with an API key or token instead…", systemImage: "key")
-                            .font(.callout)
-                    }
-                    .buttonStyle(.link)
-                    .disabled(self.model.isBusy)
-                }
-            }
+        } else if self.model.candidates.isEmpty || self.model.showManualEntry {
+            self.manualForm
         }
     }
 
     @ViewBuilder
     private var providerAuthSection: some View {
-        if !self.model.authOptions.isEmpty {
+        if !self.model.authOptions.isEmpty || !self.model.manualProviders.isEmpty {
             VStack(alignment: .leading, spacing: 8) {
                 Text("Sign in with a provider")
                     .font(.headline)
@@ -428,6 +413,9 @@ struct OnboardingAISetupView: View {
                 let more = self.model.authOptions.filter { !$0.featured }
                 ForEach(featured) { option in
                     self.providerAuthRow(option)
+                }
+                if !self.model.manualProviders.isEmpty {
+                    self.apiKeysRow
                 }
                 if !more.isEmpty {
                     DisclosureGroup("More sign-in options") {
@@ -447,6 +435,34 @@ struct OnboardingAISetupView: View {
                 RoundedRectangle(cornerRadius: 12, style: .continuous)
                     .fill(Color(NSColor.controlBackgroundColor)))
         }
+    }
+
+    private var apiKeysRow: some View {
+        Button {
+            withAnimation(.spring(response: 0.25, dampingFraction: 0.9)) {
+                self.model.showManualEntry = true
+            }
+        } label: {
+            HStack(spacing: 10) {
+                Image(systemName: "key.fill")
+                    .font(.title3)
+                    .frame(width: 24)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("API Keys")
+                        .font(.callout.weight(.semibold))
+                    Text("Connect with an API key or token")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer(minLength: 0)
+                Text("Connect")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(Color.accentColor)
+            }
+        }
+        .buttonStyle(.plain)
+        .disabled(self.model.isBusy)
+        .openClawSelectableRowChrome(selected: self.model.showManualEntry)
     }
 
     private func providerAuthRow(_ option: OnboardingAISetupModel.AuthOption) -> some View {

--- a/src/commands/auth-choice-options.test.ts
+++ b/src/commands/auth-choice-options.test.ts
@@ -545,10 +545,10 @@ describe("buildAuthChoiceOptions", () => {
 
     expect(groups.map((group) => group.label)).toEqual([
       "OpenAI",
-      "Anthropic",
+      "OpenRouter",
       "xAI (Grok)",
       "Google",
-      "OpenRouter",
+      "Anthropic",
       "BytePlus",
       "Custom Provider",
       "LiteLLM",
@@ -556,10 +556,10 @@ describe("buildAuthChoiceOptions", () => {
     ]);
     expect(groups.filter(isFeaturedAuthChoiceGroup).map((group) => group.label)).toEqual([
       "OpenAI",
-      "Anthropic",
+      "OpenRouter",
       "xAI (Grok)",
       "Google",
-      "OpenRouter",
+      "Anthropic",
     ]);
   });
 

--- a/src/commands/auth-choice-options.ts
+++ b/src/commands/auth-choice-options.ts
@@ -4,6 +4,10 @@ import type { AuthProfileStore } from "../agents/auth-profiles/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolveProviderSetupFlowContributions } from "../flows/provider-flow.js";
 import {
+  compareProviderAuthChoiceGroups,
+  isFeaturedProviderAuthChoiceGroup,
+} from "../plugins/provider-auth-choice-order.js";
+import {
   CORE_AUTH_CHOICE_OPTIONS,
   type AuthChoiceGroup,
   type AuthChoiceOption,
@@ -15,17 +19,9 @@ function compareOptionLabels(a: AuthChoiceOption, b: AuthChoiceOption): number {
   return a.label.localeCompare(b.label);
 }
 
-const FEATURED_AUTH_GROUP_ORDER = new Map<string, number>([
-  ["openai", 0],
-  ["anthropic", 1],
-  ["xai", 2],
-  ["google", 3],
-  ["openrouter", 4],
-]);
-
 /** Keep the first-tier provider list stable; every other group belongs under More. */
 export function isFeaturedAuthChoiceGroup(group: AuthChoiceGroup): boolean {
-  return FEATURED_AUTH_GROUP_ORDER.has(group.value);
+  return isFeaturedProviderAuthChoiceGroup(group.value);
 }
 
 function compareAssistantOptions(a: AuthChoiceOption, b: AuthChoiceOption): number {
@@ -34,18 +30,11 @@ function compareAssistantOptions(a: AuthChoiceOption, b: AuthChoiceOption): numb
   return priorityA - priorityB || compareOptionLabels(a, b);
 }
 
-function compareLabelsCaseInsensitive(a: string, b: string): number {
-  return a.localeCompare(b, undefined, { sensitivity: "base" });
-}
-
 /** Sort auth-choice groups with featured providers first, then stable labels. */
 export function compareAuthChoiceGroups(a: AuthChoiceGroup, b: AuthChoiceGroup): number {
-  const priorityA = FEATURED_AUTH_GROUP_ORDER.get(a.value) ?? Number.POSITIVE_INFINITY;
-  const priorityB = FEATURED_AUTH_GROUP_ORDER.get(b.value) ?? Number.POSITIVE_INFINITY;
-  return (
-    priorityA - priorityB ||
-    compareLabelsCaseInsensitive(a.label, b.label) ||
-    compareLabelsCaseInsensitive(a.value, b.value)
+  return compareProviderAuthChoiceGroups(
+    { id: a.value, label: a.label },
+    { id: b.value, label: b.label },
   );
 }
 

--- a/src/commands/auth-choice-prompt.test.ts
+++ b/src/commands/auth-choice-prompt.test.ts
@@ -207,10 +207,10 @@ describe("promptAuthChoiceGrouped", () => {
   it("filters guided choices while keeping featured providers and grouped methods", async () => {
     const featuredOrder = new Map([
       ["openai", 0],
-      ["anthropic", 1],
+      ["openrouter", 1],
       ["xai", 2],
       ["google", 3],
-      ["openrouter", 4],
+      ["anthropic", 4],
     ]);
     compareAuthChoiceGroups.mockImplementation((a, b) => {
       const priorityA = featuredOrder.get(a.value) ?? Number.POSITIVE_INFINITY;
@@ -292,10 +292,10 @@ describe("promptAuthChoiceGrouped", () => {
 
     expect(providerOptions.map((option) => option.value)).toEqual([
       "openai",
-      "anthropic",
+      "openrouter",
       "xai",
       "google",
-      "openrouter",
+      "anthropic",
       "__more",
       "skip",
     ]);

--- a/src/plugins/provider-auth-choice-order.ts
+++ b/src/plugins/provider-auth-choice-order.ts
@@ -1,0 +1,25 @@
+const FEATURED_PROVIDER_AUTH_GROUP_ORDER = new Map<string, number>([
+  ["openai", 0],
+  ["openrouter", 1],
+  ["xai", 2],
+  ["google", 3],
+  ["anthropic", 4],
+]);
+
+/** Keep native and CLI onboarding on one first-tier provider order. */
+export function isFeaturedProviderAuthChoiceGroup(groupId: string): boolean {
+  return FEATURED_PROVIDER_AUTH_GROUP_ORDER.has(groupId);
+}
+
+export function compareProviderAuthChoiceGroups(
+  a: { id: string; label: string },
+  b: { id: string; label: string },
+): number {
+  const priorityA = FEATURED_PROVIDER_AUTH_GROUP_ORDER.get(a.id) ?? Number.POSITIVE_INFINITY;
+  const priorityB = FEATURED_PROVIDER_AUTH_GROUP_ORDER.get(b.id) ?? Number.POSITIVE_INFINITY;
+  return (
+    priorityA - priorityB ||
+    a.label.localeCompare(b.label, undefined, { sensitivity: "base" }) ||
+    a.id.localeCompare(b.id, undefined, { sensitivity: "base" })
+  );
+}

--- a/src/system-agent/setup-inference-auth-options.ts
+++ b/src/system-agent/setup-inference-auth-options.ts
@@ -1,0 +1,100 @@
+import { compareProviderAuthChoiceGroups } from "../plugins/provider-auth-choice-order.js";
+import type { ProviderAuthChoiceMetadata } from "../plugins/provider-auth-choices.js";
+
+export type SetupInferenceManualProvider = {
+  /** Provider-auth choice id sent back to `openclaw.setup.activate`. */
+  id: string;
+  label: string;
+  hint?: string;
+};
+
+export type SetupInferenceAuthOption = {
+  /** Provider-auth choice id sent to `openclaw.setup.auth.start`. */
+  id: string;
+  label: string;
+  hint?: string;
+  groupLabel?: string;
+  kind: "oauth" | "device-code";
+  featured: boolean;
+};
+
+export function supportsSetupTextInference(
+  scopes?: ProviderAuthChoiceMetadata["onboardingScopes"],
+): boolean {
+  return !scopes || scopes.includes("text-inference");
+}
+
+export function supportsSetupManualSecret(choice: ProviderAuthChoiceMetadata): boolean {
+  return supportsSetupTextInference(choice.onboardingScopes) && choice.appGuidedSecret === true;
+}
+
+export function listSetupInferenceManualProviders(
+  authChoices: readonly ProviderAuthChoiceMetadata[],
+): SetupInferenceManualProvider[] {
+  const choices = new Map<string, SetupInferenceManualProvider>();
+  for (const choice of authChoices) {
+    const id = choice.choiceId.trim();
+    if (!id || choices.has(id) || !supportsSetupManualSecret(choice)) {
+      continue;
+    }
+    choices.set(id, {
+      id,
+      label: choice.choiceLabel,
+      ...(choice.choiceHint?.trim() ? { hint: choice.choiceHint.trim() } : {}),
+    });
+  }
+  return [...choices.values()].toSorted(
+    (a, b) => a.label.localeCompare(b.label, "en") || a.id.localeCompare(b.id, "en"),
+  );
+}
+
+export function listSetupInferenceAuthOptions(
+  authChoices: readonly ProviderAuthChoiceMetadata[],
+): SetupInferenceAuthOption[] {
+  const choices = new Map<
+    string,
+    { metadata: ProviderAuthChoiceMetadata; option: SetupInferenceAuthOption }
+  >();
+  for (const choice of authChoices) {
+    const id = choice.choiceId.trim();
+    if (
+      !id ||
+      choices.has(id) ||
+      !supportsSetupTextInference(choice.onboardingScopes) ||
+      choice.assistantVisibility === "manual-only" ||
+      !choice.appGuidedAuth
+    ) {
+      continue;
+    }
+    choices.set(id, {
+      metadata: choice,
+      option: {
+        id,
+        label: choice.choiceLabel,
+        ...(choice.choiceHint?.trim() ? { hint: choice.choiceHint.trim() } : {}),
+        ...(choice.groupLabel?.trim() ? { groupLabel: choice.groupLabel.trim() } : {}),
+        kind: choice.appGuidedAuth,
+        featured: choice.onboardingFeatured === true,
+      },
+    });
+  }
+  return [...choices.values()]
+    .toSorted(
+      (a, b) =>
+        Number(b.option.featured) - Number(a.option.featured) ||
+        compareProviderAuthChoiceGroups(
+          {
+            id: a.metadata.groupId ?? a.metadata.providerId,
+            label: a.metadata.groupLabel ?? a.metadata.choiceLabel,
+          },
+          {
+            id: b.metadata.groupId ?? b.metadata.providerId,
+            label: b.metadata.groupLabel ?? b.metadata.choiceLabel,
+          },
+        ) ||
+        (a.metadata.assistantPriority ?? 0) - (b.metadata.assistantPriority ?? 0) ||
+        a.option.label.localeCompare(b.option.label, "en") ||
+        a.option.id.localeCompare(b.option.id, "en"),
+    )
+    .map(({ option }) => option);
+}

--- a/src/system-agent/setup-inference.test.ts
+++ b/src/system-agent/setup-inference.test.ts
@@ -395,8 +395,30 @@ describe("detectSetupInference", () => {
     ]);
   });
 
-  it("lists provider-owned OAuth and device-code methods without compatibility aliases", () => {
+  it("lists provider-owned sign-ins in CLI order without compatibility aliases", () => {
     const choices: ProviderAuthChoiceMetadata[] = [
+      {
+        pluginId: "google",
+        providerId: "google-gemini-cli",
+        methodId: "oauth",
+        choiceId: "google-gemini-cli",
+        choiceLabel: "Gemini CLI OAuth",
+        groupId: "google",
+        groupLabel: "Google",
+        onboardingFeatured: true,
+        appGuidedAuth: "oauth",
+      },
+      {
+        pluginId: "openrouter",
+        providerId: "openrouter",
+        methodId: "oauth",
+        choiceId: "openrouter-oauth",
+        choiceLabel: "OpenRouter OAuth",
+        groupId: "openrouter",
+        groupLabel: "OpenRouter",
+        onboardingFeatured: true,
+        appGuidedAuth: "oauth",
+      },
       {
         pluginId: "openai",
         providerId: "openai",
@@ -407,6 +429,17 @@ describe("detectSetupInference", () => {
         groupLabel: "OpenAI",
         onboardingFeatured: true,
         appGuidedAuth: "oauth",
+      },
+      {
+        pluginId: "xai",
+        providerId: "xai",
+        methodId: "oauth",
+        choiceId: "xai-oauth",
+        choiceLabel: "xAI OAuth",
+        groupId: "xai",
+        groupLabel: "xAI (Grok)",
+        onboardingFeatured: true,
+        appGuidedAuth: "device-code",
       },
       {
         pluginId: "github-copilot",
@@ -433,6 +466,27 @@ describe("detectSetupInference", () => {
         label: "ChatGPT Login",
         hint: "Browser sign-in",
         groupLabel: "OpenAI",
+        kind: "oauth",
+        featured: true,
+      },
+      {
+        id: "openrouter-oauth",
+        label: "OpenRouter OAuth",
+        groupLabel: "OpenRouter",
+        kind: "oauth",
+        featured: true,
+      },
+      {
+        id: "xai-oauth",
+        label: "xAI OAuth",
+        groupLabel: "xAI (Grok)",
+        kind: "device-code",
+        featured: true,
+      },
+      {
+        id: "google-gemini-cli",
+        label: "Gemini CLI OAuth",
+        groupLabel: "Google",
         kind: "oauth",
         featured: true,
       },

--- a/src/system-agent/setup-inference.ts
+++ b/src/system-agent/setup-inference.ts
@@ -46,7 +46,6 @@ import { formatErrorMessage } from "../infra/errors.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { normalizePluginTargetConfig } from "../plugins/config-state.js";
 import { enablePluginInConfig } from "../plugins/enable.js";
-import { compareProviderAuthChoiceGroups } from "../plugins/provider-auth-choice-order.js";
 import {
   applyProviderPluginAuthMethodResultConfig,
   runProviderPluginAuthMethodUnpersisted,
@@ -75,6 +74,14 @@ import {
   createSystemAgentModelSelectionUpdater,
   createQuickstartNotePrompter,
 } from "./setup-apply.js";
+import {
+  listSetupInferenceAuthOptions,
+  listSetupInferenceManualProviders,
+  supportsSetupManualSecret,
+  supportsSetupTextInference,
+  type SetupInferenceAuthOption,
+  type SetupInferenceManualProvider,
+} from "./setup-inference-auth-options.js";
 import { resolveSetupInferenceProbeStreamParams } from "./setup-inference-probe.js";
 import {
   captureSystemAgentOwnerPluginArtifacts,
@@ -108,22 +115,14 @@ export type SetupInferenceCandidate = {
   credentials?: boolean;
 };
 
-export type SetupInferenceManualProvider = {
-  /** Provider-auth choice id sent back to `openclaw.setup.activate`. */
-  id: string;
-  label: string;
-  hint?: string;
-};
-
-export type SetupInferenceAuthOption = {
-  /** Provider-auth choice id sent to `openclaw.setup.auth.start`. */
-  id: string;
-  label: string;
-  hint?: string;
-  groupLabel?: string;
-  kind: "oauth" | "device-code";
-  featured: boolean;
-};
+export {
+  listSetupInferenceAuthOptions,
+  listSetupInferenceManualProviders,
+} from "./setup-inference-auth-options.js";
+export type {
+  SetupInferenceAuthOption,
+  SetupInferenceManualProvider,
+} from "./setup-inference-auth-options.js";
 
 export type SetupInferenceDetection = {
   candidates: SetupInferenceCandidate[];
@@ -303,85 +302,6 @@ async function resolveSetupInferenceWorkspace(params: {
     ),
     hasAuthoredSetup,
   };
-}
-
-function supportsTextInference(scopes?: ProviderAuthChoiceMetadata["onboardingScopes"]): boolean {
-  return !scopes || scopes.includes("text-inference");
-}
-
-function supportsManualSecret(choice: ProviderAuthChoiceMetadata): boolean {
-  return supportsTextInference(choice.onboardingScopes) && choice.appGuidedSecret === true;
-}
-
-export function listSetupInferenceManualProviders(
-  authChoices: readonly ProviderAuthChoiceMetadata[],
-): SetupInferenceManualProvider[] {
-  const choices = new Map<string, SetupInferenceManualProvider>();
-  for (const choice of authChoices) {
-    const id = choice.choiceId.trim();
-    if (!id || choices.has(id) || !supportsManualSecret(choice)) {
-      continue;
-    }
-    choices.set(id, {
-      id,
-      label: choice.choiceLabel,
-      ...(choice.choiceHint?.trim() ? { hint: choice.choiceHint.trim() } : {}),
-    });
-  }
-  return [...choices.values()].toSorted(
-    (a, b) => a.label.localeCompare(b.label, "en") || a.id.localeCompare(b.id, "en"),
-  );
-}
-
-export function listSetupInferenceAuthOptions(
-  authChoices: readonly ProviderAuthChoiceMetadata[],
-): SetupInferenceAuthOption[] {
-  const choices = new Map<
-    string,
-    { metadata: ProviderAuthChoiceMetadata; option: SetupInferenceAuthOption }
-  >();
-  for (const choice of authChoices) {
-    const id = choice.choiceId.trim();
-    if (
-      !id ||
-      choices.has(id) ||
-      !supportsTextInference(choice.onboardingScopes) ||
-      choice.assistantVisibility === "manual-only" ||
-      !choice.appGuidedAuth
-    ) {
-      continue;
-    }
-    choices.set(id, {
-      metadata: choice,
-      option: {
-        id,
-        label: choice.choiceLabel,
-        ...(choice.choiceHint?.trim() ? { hint: choice.choiceHint.trim() } : {}),
-        ...(choice.groupLabel?.trim() ? { groupLabel: choice.groupLabel.trim() } : {}),
-        kind: choice.appGuidedAuth,
-        featured: choice.onboardingFeatured === true,
-      },
-    });
-  }
-  return [...choices.values()]
-    .toSorted(
-      (a, b) =>
-        Number(b.option.featured) - Number(a.option.featured) ||
-        compareProviderAuthChoiceGroups(
-          {
-            id: a.metadata.groupId ?? a.metadata.providerId,
-            label: a.metadata.groupLabel ?? a.metadata.choiceLabel,
-          },
-          {
-            id: b.metadata.groupId ?? b.metadata.providerId,
-            label: b.metadata.groupLabel ?? b.metadata.choiceLabel,
-          },
-        ) ||
-        (a.metadata.assistantPriority ?? 0) - (b.metadata.assistantPriority ?? 0) ||
-        a.option.label.localeCompare(b.option.label, "en") ||
-        a.option.id.localeCompare(b.option.id, "en"),
-    )
-    .map(({ option }) => option);
 }
 
 export async function detectSetupInference(
@@ -1030,8 +950,8 @@ async function buildTestPlan(params: {
         : undefined;
       if (
         !choice ||
-        !supportsTextInference(choice.onboardingScopes) ||
-        (!interactive && !supportsManualSecret(choice)) ||
+        !supportsSetupTextInference(choice.onboardingScopes) ||
+        (!interactive && !supportsSetupManualSecret(choice)) ||
         (interactive && (choice.assistantVisibility === "manual-only" || !choice.appGuidedAuth))
       ) {
         return {
@@ -1065,7 +985,7 @@ async function buildTestPlan(params: {
       const resolved = provider && method ? { provider, method } : null;
       if (
         !resolved ||
-        !supportsTextInference(resolved.method.wizard?.onboardingScopes) ||
+        !supportsSetupTextInference(resolved.method.wizard?.onboardingScopes) ||
         (interactive && resolved.method.kind !== "oauth" && resolved.method.kind !== "device_code")
       ) {
         return {

--- a/src/system-agent/setup-inference.ts
+++ b/src/system-agent/setup-inference.ts
@@ -46,6 +46,7 @@ import { formatErrorMessage } from "../infra/errors.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { normalizePluginTargetConfig } from "../plugins/config-state.js";
 import { enablePluginInConfig } from "../plugins/enable.js";
+import { compareProviderAuthChoiceGroups } from "../plugins/provider-auth-choice-order.js";
 import {
   applyProviderPluginAuthMethodResultConfig,
   runProviderPluginAuthMethodUnpersisted,
@@ -335,7 +336,10 @@ export function listSetupInferenceManualProviders(
 export function listSetupInferenceAuthOptions(
   authChoices: readonly ProviderAuthChoiceMetadata[],
 ): SetupInferenceAuthOption[] {
-  const choices = new Map<string, SetupInferenceAuthOption>();
+  const choices = new Map<
+    string,
+    { metadata: ProviderAuthChoiceMetadata; option: SetupInferenceAuthOption }
+  >();
   for (const choice of authChoices) {
     const id = choice.choiceId.trim();
     if (
@@ -348,21 +352,36 @@ export function listSetupInferenceAuthOptions(
       continue;
     }
     choices.set(id, {
-      id,
-      label: choice.choiceLabel,
-      ...(choice.choiceHint?.trim() ? { hint: choice.choiceHint.trim() } : {}),
-      ...(choice.groupLabel?.trim() ? { groupLabel: choice.groupLabel.trim() } : {}),
-      kind: choice.appGuidedAuth,
-      featured: choice.onboardingFeatured === true,
+      metadata: choice,
+      option: {
+        id,
+        label: choice.choiceLabel,
+        ...(choice.choiceHint?.trim() ? { hint: choice.choiceHint.trim() } : {}),
+        ...(choice.groupLabel?.trim() ? { groupLabel: choice.groupLabel.trim() } : {}),
+        kind: choice.appGuidedAuth,
+        featured: choice.onboardingFeatured === true,
+      },
     });
   }
-  return [...choices.values()].toSorted(
-    (a, b) =>
-      Number(b.featured) - Number(a.featured) ||
-      (a.groupLabel ?? a.label).localeCompare(b.groupLabel ?? b.label, "en") ||
-      a.label.localeCompare(b.label, "en") ||
-      a.id.localeCompare(b.id, "en"),
-  );
+  return [...choices.values()]
+    .toSorted(
+      (a, b) =>
+        Number(b.option.featured) - Number(a.option.featured) ||
+        compareProviderAuthChoiceGroups(
+          {
+            id: a.metadata.groupId ?? a.metadata.providerId,
+            label: a.metadata.groupLabel ?? a.metadata.choiceLabel,
+          },
+          {
+            id: b.metadata.groupId ?? b.metadata.providerId,
+            label: b.metadata.groupLabel ?? b.metadata.choiceLabel,
+          },
+        ) ||
+        (a.metadata.assistantPriority ?? 0) - (b.metadata.assistantPriority ?? 0) ||
+        a.option.label.localeCompare(b.option.label, "en") ||
+        a.option.id.localeCompare(b.option.id, "en"),
+    )
+    .map(({ option }) => option);
 }
 
 export async function detectSetupInference(


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where macOS users opening Connect Your AI saw provider sign-ins in a different order from CLI onboarding, while API-key setup appeared as a separate secondary link.

## Why This Change Was Made

CLI and native onboarding now share one canonical provider order: ChatGPT OAuth, OpenRouter, xAI, and Gemini. macOS presents API Keys as the final first-tier choice, with additional provider sign-ins kept under More sign-in options.

## User Impact

Connect Your AI now presents the common connection choices together and in the same stable order as CLI onboarding. Choosing API Keys reveals the existing provider and credential form.

## Evidence

- 120 focused auth-choice and setup-inference tests pass.
- Native localization inventory and all 21 locale artifacts pass validation.
- TypeScript formatting and diff checks pass.
- Fresh autoreview reports no accepted or actionable findings.

