### PR TITLE
fix(codex): decode sandbox exec PathUri inputs

### DIFF
--- a/extensions/codex/src/app-server/sandbox-exec-server.fs.test.ts
+++ b/extensions/codex/src/app-server/sandbox-exec-server.fs.test.ts
@@ -32,11 +32,11 @@ describe("OpenClaw Codex sandbox exec-server filesystem", () => {
     socket.send(JSON.stringify({ method: "initialized" }));
 
     await rpc(socket, "fs/writeFile", {
-      path: "/workspace/note.txt",
+      path: "file:///workspace/note.txt",
       dataBase64: Buffer.from("hello").toString("base64"),
     });
     await rpc(socket, "fs/writeFile", {
-      path: "/workspace/empty.txt",
+      path: "file:///workspace/%65mpty.txt",
       dataBase64: "",
     });
 
@@ -107,7 +107,7 @@ describe("OpenClaw Codex sandbox exec-server filesystem", () => {
       sandbox: codexFsSandboxContext({
         entries: [
           { path: specialPath("root"), access: "read" },
-          { path: specialPath("project_roots"), access: "write" },
+          { path: { type: "path", path: "file:///workspace" }, access: "write" },
         ],
       }),
     });
@@ -367,8 +367,8 @@ describe("OpenClaw Codex sandbox exec-server filesystem", () => {
     socket.send(JSON.stringify({ method: "initialized" }));
 
     await rpc(socket, "fs/copy", {
-      sourcePath: "/workspace/source-dir",
-      destinationPath: "/workspace/destination-dir",
+      sourcePath: "file:///workspace/source-dir",
+      destinationPath: "file:///workspace/destination-dir",
       recursive: true,
     });
 

--- a/extensions/codex/src/app-server/sandbox-exec-server.test-helpers.ts
+++ b/extensions/codex/src/app-server/sandbox-exec-server.test-helpers.ts
@@ -115,7 +115,7 @@ export function codexFsSandboxContext(params: {
       },
       network: "restricted",
     },
-    cwd: params.cwd ?? "/workspace",
+    cwd: params.cwd ?? "file:///workspace",
     windowsSandboxLevel: "disabled",
     windowsSandboxPrivateDesktop: false,
     useLegacyLandlock: false,

--- a/extensions/codex/src/app-server/sandbox-exec-server.test.ts
+++ b/extensions/codex/src/app-server/sandbox-exec-server.test.ts
@@ -144,7 +144,7 @@ describe("OpenClaw Codex sandbox exec-server", () => {
     const start = (await rpc(socket, "process/start", {
       processId: "proc-1",
       argv: ["/bin/sh", "-lc", "printf ok"],
-      cwd: "/workspace",
+      cwd: "file:///workspace",
       env: { POLICY_SET: "env-wins", TEST_FLAG: "1" },
       envPolicy: {
         inherit: "none",
@@ -177,6 +177,77 @@ describe("OpenClaw Codex sandbox exec-server", () => {
     expect(notifications.map((notification) => notification.method)).toEqual(
       expect.arrayContaining(["process/output", "process/exited", "process/closed"]),
     );
+    socket.close();
+  });
+
+  it("decodes a Codex file URI cwd before sandbox execution", async () => {
+    const buildExecSpec = vi.fn(async () => ({
+      argv: [process.execPath, "-e", ""],
+      env: testExecEnv(),
+      stdinMode: "pipe-closed" as const,
+    }));
+    const sandbox = createSandboxContext({ buildExecSpec });
+    const client = createClient();
+    await ensureCodexSandboxExecServerEnvironment({
+      client: client as never,
+      sandbox,
+    });
+    const socket = await openSocket(execServerUrlFromClient(client));
+    await rpc(socket, "initialize", { clientName: "test" });
+    socket.send(JSON.stringify({ method: "initialized" }));
+
+    await rpc(socket, "process/start", {
+      processId: "proc-uri-cwd",
+      argv: ["/usr/bin/pwd"],
+      cwd: "file:///projects/example%20repo",
+      env: {},
+      tty: false,
+      pipeStdin: false,
+      arg0: null,
+    });
+
+    expect(buildExecSpec).toHaveBeenCalledWith(
+      expect.objectContaining({ workdir: "/projects/example repo" }),
+    );
+    socket.close();
+  });
+
+  it.each([
+    ["a non-file scheme", "https://example.test/workspace"],
+    ["a remote file authority", "file://remote.example.test/workspace"],
+    ["a query", "file:///workspace?revision=1"],
+    ["a fragment", "file:///workspace#section"],
+    ["a Windows drive path", "file:///C:/workspace"],
+    ["an encoded Windows drive path", "file:///%43:/workspace"],
+    ["an encoded null byte", "file:///workspace%00"],
+  ])("rejects a process cwd with %s", async (_label, cwd) => {
+    const buildExecSpec = vi.fn(async () => ({
+      argv: [process.execPath, "-e", ""],
+      env: testExecEnv(),
+      stdinMode: "pipe-closed" as const,
+    }));
+    const sandbox = createSandboxContext({ buildExecSpec });
+    const client = createClient();
+    await ensureCodexSandboxExecServerEnvironment({
+      client: client as never,
+      sandbox,
+    });
+    const socket = await openSocket(execServerUrlFromClient(client));
+    await rpc(socket, "initialize", { clientName: "test" });
+    socket.send(JSON.stringify({ method: "initialized" }));
+
+    await expect(
+      rpc(socket, "process/start", {
+        processId: "proc-invalid-cwd",
+        argv: ["/usr/bin/pwd"],
+        cwd,
+        env: {},
+        tty: false,
+        pipeStdin: false,
+        arg0: null,
+      }),
+    ).rejects.toThrow(/process cwd/u);
+    expect(buildExecSpec).not.toHaveBeenCalled();
     socket.close();
   });
 

--- a/extensions/codex/src/app-server/sandbox-exec-server/filesystem.ts
+++ b/extensions/codex/src/app-server/sandbox-exec-server/filesystem.ts
@@ -21,6 +21,7 @@ import {
   requireObject,
   requireString,
 } from "./json-rpc.js";
+import { resolveExecServerPath } from "./path-uri.js";
 import { requireBackend, requireFsBridge } from "./runtime.js";
 import type { DirectoryEntry, OpenClawExecServer, ResolvedFsSandboxPolicy } from "./types.js";
 
@@ -32,7 +33,7 @@ export async function readFile(
   params: JsonValue | undefined,
 ): Promise<JsonObject> {
   const record = requireObject(params, "fs/readFile params");
-  const filePath = requireString(record.path, "path");
+  const filePath = resolveExecServerPath(requireString(record.path, "path"), "read path");
   assertFsSandboxAccess(execServer, record, [{ path: filePath, access: "read" }]);
   const fsBridge = requireFsBridge(execServer);
   const stat = await fsBridge.stat({ filePath });
@@ -56,7 +57,7 @@ export async function writeFile(
   params: JsonValue | undefined,
 ): Promise<void> {
   const record = requireObject(params, "fs/writeFile params");
-  const filePath = requireString(record.path, "path");
+  const filePath = resolveExecServerPath(requireString(record.path, "path"), "write path");
   assertFsSandboxAccess(execServer, record, [{ path: filePath, access: "write" }]);
   const fsBridge = requireFsBridge(execServer);
   const parent = await fsBridge.stat({ filePath: pathPosix.dirname(filePath) });
@@ -76,7 +77,10 @@ export async function createDirectory(
   params: JsonValue | undefined,
 ): Promise<void> {
   const record = requireObject(params, "fs/createDirectory params");
-  const filePath = requireString(record.path, "path");
+  const filePath = resolveExecServerPath(
+    requireString(record.path, "path"),
+    "create-directory path",
+  );
   assertFsSandboxAccess(execServer, record, [{ path: filePath, access: "write" }]);
   const fsBridge = requireFsBridge(execServer);
   if (record.recursive === false) {
@@ -97,7 +101,7 @@ export async function getMetadata(
   params: JsonValue | undefined,
 ): Promise<JsonObject> {
   const record = requireObject(params, "fs/getMetadata params");
-  const filePath = requireString(record.path, "path");
+  const filePath = resolveExecServerPath(requireString(record.path, "path"), "metadata path");
   assertFsSandboxAccess(execServer, record, [{ path: filePath, access: "read" }]);
   const fsBridge = requireFsBridge(execServer);
   const stat = await fsBridge.stat({
@@ -115,7 +119,7 @@ export async function readDirectory(
   params: JsonValue | undefined,
 ): Promise<JsonObject> {
   const record = requireObject(params, "fs/readDirectory params");
-  const filePath = requireString(record.path, "path");
+  const filePath = resolveExecServerPath(requireString(record.path, "path"), "read-directory path");
   const fsSandboxPolicy = resolveFsSandboxPolicy(execServer, record);
   return {
     entries: await listDirectoryEntries(execServer, filePath, fsSandboxPolicy),
@@ -163,7 +167,7 @@ export async function removePath(
   params: JsonValue | undefined,
 ): Promise<void> {
   const record = requireObject(params, "fs/remove params");
-  const filePath = requireString(record.path, "path");
+  const filePath = resolveExecServerPath(requireString(record.path, "path"), "remove path");
   const fsSandboxPolicy = resolveFsSandboxPolicy(execServer, record);
   assertResolvedFsSandboxAccess(fsSandboxPolicy, [{ path: filePath, access: "write" }]);
   if (record.recursive !== false) {
@@ -183,10 +187,13 @@ export async function copyPath(
   params: JsonValue | undefined,
 ): Promise<void> {
   const record = requireObject(params, "fs/copy params");
-  const sourcePath = requireString(record.sourcePath ?? record.source, "sourcePath");
-  const destinationPath = requireString(
-    record.destinationPath ?? record.destination,
-    "destinationPath",
+  const sourcePath = resolveExecServerPath(
+    requireString(record.sourcePath ?? record.source, "sourcePath"),
+    "copy source path",
+  );
+  const destinationPath = resolveExecServerPath(
+    requireString(record.destinationPath ?? record.destination, "destinationPath"),
+    "copy destination path",
   );
   const fsSandboxPolicy = resolveFsSandboxPolicy(execServer, record);
   assertResolvedFsSandboxAccess(fsSandboxPolicy, [

--- a/extensions/codex/src/app-server/sandbox-exec-server/fs-policy.ts
+++ b/extensions/codex/src/app-server/sandbox-exec-server/fs-policy.ts
@@ -5,6 +5,7 @@
 import { posix as pathPosix } from "node:path";
 import type { JsonObject } from "../protocol.js";
 import { requireObject, requireString } from "./json-rpc.js";
+import { resolveExecServerPath } from "./path-uri.js";
 import type {
   FsAccessMode,
   OpenClawExecServer,
@@ -67,7 +68,10 @@ function readFsSandboxCwd(execServer: OpenClawExecServer, sandbox: JsonObject): 
   if (sandbox.cwd === undefined || sandbox.cwd === null) {
     return normalizeSandboxAbsolutePath(execServer.sandbox.containerWorkdir, "sandbox cwd");
   }
-  return normalizeSandboxAbsolutePath(requireString(sandbox.cwd, "sandbox cwd"), "sandbox cwd");
+  return normalizeSandboxAbsolutePath(
+    resolveExecServerPath(requireString(sandbox.cwd, "sandbox cwd"), "sandbox cwd"),
+    "sandbox cwd",
+  );
 }
 
 function resolveFsSandboxEntry(entry: JsonObject, cwd: string): ResolvedFsSandboxEntry | undefined {
@@ -78,7 +82,7 @@ function resolveFsSandboxEntry(entry: JsonObject, cwd: string): ResolvedFsSandbo
     return {
       kind: "path",
       path: normalizeSandboxAbsolutePath(
-        requireString(pathSpec.path, "fs sandbox path"),
+        resolveExecServerPath(requireString(pathSpec.path, "fs sandbox path"), "fs sandbox path"),
         "fs sandbox path",
       ),
       access,

--- a/extensions/codex/src/app-server/sandbox-exec-server/path-uri.ts
+++ b/extensions/codex/src/app-server/sandbox-exec-server/path-uri.ts
@@ -1,0 +1,53 @@
+/** Converts Codex PathUri protocol values into sandbox-backend path strings. */
+import { fileURLToPath } from "node:url";
+
+const URI_SCHEME_RE = /^([A-Za-z][A-Za-z0-9+.-]*):/u;
+const WINDOWS_ABSOLUTE_PATH_RE = /^[A-Za-z]:[\\/]/u;
+const WINDOWS_DRIVE_PATH_RE = /^\/[A-Za-z]:(?:\/|$)/u;
+
+/** Resolves one Codex exec-server path while retaining legacy native absolute paths. */
+export function resolveExecServerPath(rawPath: string, label: string): string {
+  const scheme = WINDOWS_ABSOLUTE_PATH_RE.test(rawPath)
+    ? undefined
+    : URI_SCHEME_RE.exec(rawPath)?.[1]?.toLowerCase();
+  if (!scheme) {
+    // Codex versions before PathUri sent native absolute paths here.
+    return rawPath;
+  }
+  if (scheme !== "file") {
+    throw new Error(`${label} URI must use the file scheme, received ${scheme}.`);
+  }
+
+  let pathUrl: URL;
+  try {
+    pathUrl = new URL(rawPath);
+  } catch (error) {
+    throw new Error(
+      `${label} must be a valid file URI: ${error instanceof Error ? error.message : String(error)}`,
+      { cause: error },
+    );
+  }
+  if (pathUrl.search || pathUrl.hash) {
+    throw new Error(`${label} file URI must not include a query or fragment.`);
+  }
+  let resolved: string;
+  try {
+    // The URI names the sandbox target, so decode with POSIX rules even when
+    // the Gateway host is Windows. Docker and SSH backends own POSIX workdirs.
+    resolved = fileURLToPath(pathUrl, { windows: false });
+  } catch (error) {
+    throw new Error(
+      `${label} file URI is not valid for the sandbox: ${error instanceof Error ? error.message : String(error)}`,
+      { cause: error },
+    );
+  }
+  if (WINDOWS_DRIVE_PATH_RE.test(resolved)) {
+    // OpenClaw exec-server backends currently expose Docker/SSH POSIX paths.
+    // Reject foreign drive URIs instead of silently rewriting their meaning.
+    throw new Error(`${label} Windows file URI is not supported by the sandbox.`);
+  }
+  if (resolved.includes("\0")) {
+    throw new Error(`${label} file URI must not contain a null byte.`);
+  }
+  return resolved;
+}

--- a/extensions/codex/src/app-server/sandbox-exec-server/processes.ts
+++ b/extensions/codex/src/app-server/sandbox-exec-server/processes.ts
@@ -7,6 +7,7 @@ import { embeddedAgentLog } from "openclaw/plugin-sdk/agent-harness-runtime";
 import type { WebSocket } from "ws";
 import type { JsonObject, JsonValue } from "../protocol.js";
 import { requireObject, requireString, requireStringArray } from "./json-rpc.js";
+import { resolveExecServerPath } from "./path-uri.js";
 import type { ManagedProcess, OpenClawExecServer, ProcessChunk } from "./types.js";
 
 const ENV_KEY_RE = /^[A-Za-z_][A-Za-z0-9_]*$/;
@@ -26,7 +27,7 @@ export async function startProcess(
     throw new Error(`process already exists: ${processId}`);
   }
   const argv = requireStringArray(record.argv, "argv");
-  const cwd = requireString(record.cwd, "cwd");
+  const cwd = resolveExecServerPath(requireString(record.cwd, "cwd"), "process cwd");
   rejectUnsupportedArg0(record.arg0);
   const env = readProcessEnv(record);
   const tty = record.tty === true;


### PR DESCRIPTION
Closes #107579

## What Problem This Solves

Codex app-server now serializes exec-server process and filesystem paths as `PathUri` strings such as `file:///workspace`. OpenClaw's sandbox exec-server forwarded those strings directly to Docker/SSH backends and filesystem policy checks, causing native process starts to fail before launch and leaving sibling fs operations on the same incompatible protocol boundary.

## Why This Change Was Made

This adds one shared PathUri decoder at the OpenClaw exec-server boundary and applies it to `process/start`, supported `fs/*` methods, and managed filesystem policy cwd/path entries. It preserves the shipped legacy native absolute-path input, accepts only local `file:` URIs, decodes using the POSIX namespace owned by current Docker/SSH sandbox backends, and rejects remote authorities, non-file schemes, query/fragment metadata, NULs, and Windows-drive URIs that are not supported end to end.

## User Impact

Codex-harness agents using `sandboxExecServer` can run native process commands in `/workspace` and mounted project directories again when current Codex sends file URIs. File operations and sandbox policy checks receive the same normalized path semantics, while malformed or foreign path URIs fail closed before a backend is invoked.

## Evidence

- Directly verified the upstream Codex contracts in commits `0fed4497f` (#28032, process cwd PathUri) and `d23bb22f` (#27653, filesystem PathUri).
- Five focused sandbox exec-server files pass: 51 tests.
- Reverse proof without the conversion fails because `buildExecSpec` receives `file:///workspace`; restoring the conversion returns `/workspace` and passes.
- Added coverage for percent decoding, filesystem operations/policy paths, remote authorities, non-file schemes, query/fragment metadata, NULs, and literal and encoded Windows drive URIs.
- oxfmt, targeted oxlint, conflict-marker check, TypeScript LOC ratchet, and git diff check passed.
- Fresh autoreview found and drove two Windows-drive validation fixes; the final rerun reported no actionable findings.
- Full workspace tsgo/build lanes are left to PR CI because changed-file classification delegates the extension surface to remote validation.

AI-assisted contribution; the author reviewed the implementation, validated the upstream protocol source, accepted the actionable review findings, and verified the focused behavior locally.

## Real behavior proof

Validated at exact PR head `6e58c3ab480f4dfe3ef127c728e69e125b0efa73` after rebasing onto upstream `main` (`9d4610cbd1`). The runtime topology was:

`exact-head OpenClaw -> @openai/codex 0.144.4 app-server -> OpenClaw sandbox exec-server -> SSH backend -> isolated Alinux 3 workspace`

The real OpenClaw CLI turn selected `agentHarnessId: codex`, used `openai/gpt-5.4`, started the sandbox exec-server, made one native `exec_command` call, reported zero tool failures, and used no model fallback. The command requested from Codex was:

```sh
pwd; printf 'PATHURI_PROCESS_OK\n'; cat proof-input.txt; printf 'PATHURI_WRITE_OK\n' > proof-output.txt; cat proof-output.txt
```

Observed native command output:

```text
/tmp/openclaw-pr107644/openclaw-ssh-agent-main-pr107644-live-pathuri-76f40a3b/workspace
PATHURI_PROCESS_OK
PATHURI_FS_INPUT_OK
PATHURI_WRITE_OK
```

An audit-only SSH wrapper passed arguments through unchanged while recording path shape. Across the turn it observed 38 sandbox calls (`27 control`, `10 fs`, `1 exec`): all 38 contained the native remote workspace path and none contained a `file://` URI. An independent SSH read after the turn confirmed `proof-output.txt` contained `PATHURI_WRITE_OK` in that remote workspace.

The disposable SSH host did not ship `/bin/zsh`. Codex 0.144.4 currently falls back to the gateway shell while probing an exec-server method that OpenClaw does not yet implement, so the proof host temporarily exposed `/bin/zsh` as `/bin/sh` (bash). That compatibility entry affected only shell selection; it did not intercept or rewrite cwd/path arguments and was removed after the run.
