### PR TITLE
fix(ui): use plugin lifecycle toggles

### DIFF
--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -1836,6 +1836,7 @@ export const en: TranslationMap = {
     verifiedSource: "Verified source",
     enableAction: "Enable",
     disableAction: "Disable",
+    enableNamed: "Enable {name}",
     working: "Working…",
     detailClose: "Close",
     detailOrigin: "Source",

--- a/ui/src/pages/plugins/plugins.e2e.test.ts
+++ b/ui/src/pages/plugins/plugins.e2e.test.ts
@@ -90,7 +90,8 @@ const calendarPlugin = {
 const initialInventory = inventory([workboardDisabled, lobsterPlugin]);
 const installedInventory = inventory([workboardDisabled, lobsterPlugin, calendarPlugin]);
 const finalInventory = inventory([workboardEnabled, lobsterPlugin, calendarPlugin]);
-const uninstalledInventory = inventory([workboardEnabled, lobsterPlugin]);
+const disabledInventory = inventory([workboardDisabled, lobsterPlugin, calendarPlugin]);
+const uninstalledInventory = inventory([workboardDisabled, lobsterPlugin]);
 
 const calendarSearchResponse = {
   results: [
@@ -127,6 +128,12 @@ const installResult = {
 const enableWorkboardResult = {
   ok: true,
   plugin: workboardEnabled,
+  restartRequired: false,
+} satisfies PluginMutationResult;
+
+const disableWorkboardResult = {
+  ok: true,
+  plugin: workboardDisabled,
   restartRequired: false,
 } satisfies PluginMutationResult;
 
@@ -216,6 +223,10 @@ async function clickRowAction(page: Page, rowSelector: string, buttonName: strin
   await page.locator(rowSelector).getByRole("button", { name: buttonName, exact: true }).click();
 }
 
+async function togglePlugin(page: Page, selector: string): Promise<void> {
+  await page.locator(selector).locator("wa-switch.settings-toggle").click();
+}
+
 async function captureScreenshot(page: Page, name: string): Promise<void> {
   if (!updateScreenshots) {
     return;
@@ -269,6 +280,10 @@ function pluginMethodResponses() {
           match: { pluginId: "workboard", enabled: true },
           response: enableWorkboardResult,
         },
+        {
+          match: { pluginId: "workboard", enabled: false },
+          response: disableWorkboardResult,
+        },
       ],
     },
     "plugins.uninstall": {
@@ -302,7 +317,7 @@ describeControlUiE2e("Control UI Plugins mocked Gateway E2E", () => {
     await server?.close();
   });
 
-  it("browses the catalog, installs from ClawHub, enables Workboard, and refreshes authoritative state", async () => {
+  it("browses the catalog, installs from ClawHub, and toggles Workboard on and off", async () => {
     const context = await newContext();
     const page = await context.newPage();
     const gateway = await installMockGateway(page, {
@@ -319,14 +334,28 @@ describeControlUiE2e("Control UI Plugins mocked Gateway E2E", () => {
       const workboardCard = page.locator('[data-plugin-id="workboard"]');
       await page.getByRole("heading", { name: /^Tools/u }).waitFor();
       await page.getByRole("heading", { name: /^MCP servers/u }).waitFor();
-      await workboardCard.getByRole("button", { name: "Enable", exact: true }).waitFor();
+      await workboardCard.getByRole("switch", { name: "Enable Workboard", exact: true }).waitFor();
+      await expect
+        .poll(() =>
+          workboardCard
+            .getByRole("switch", { name: "Enable Workboard" })
+            .evaluate((element) => Reflect.get(element, "checked")),
+        )
+        .toBe(false);
       await captureScreenshot(page, "01-installed-desktop.png");
 
-      // Rows open a detail overlay; close it before continuing.
+      // Rows open a detail overlay with the same lifecycle toggle.
       await workboardCard.click();
       const detail = page.locator(".plugins-detail");
       await detail.waitFor({ state: "visible" });
       expect(await detail.textContent()).toContain("Workboard");
+      await expect
+        .poll(() =>
+          detail
+            .getByRole("switch", { name: "Enable Workboard" })
+            .evaluate((element) => Reflect.get(element, "checked")),
+        )
+        .toBe(false);
       await captureScreenshot(page, "02-detail-desktop.png");
       await detail.getByRole("button", { name: "Close" }).click();
       await detail.waitFor({ state: "detached" });
@@ -430,7 +459,7 @@ describeControlUiE2e("Control UI Plugins mocked Gateway E2E", () => {
       const enableCountBefore = (await gateway.getRequests("plugins.setEnabled")).length;
       await gateway.deferNext("plugins.list");
       await gateway.deferNext("config.get");
-      await clickRowAction(page, '[data-plugin-id="workboard"]', "Enable");
+      await togglePlugin(page, '[data-plugin-id="workboard"]');
 
       const enableRequest = await waitForNextRequest(
         gateway,
@@ -459,7 +488,49 @@ describeControlUiE2e("Control UI Plugins mocked Gateway E2E", () => {
         .waitFor({ state: "attached" });
       const calendarRow = page.locator('[data-plugin-id="calendar-plus"]');
       await calendarRow.waitFor({ state: "visible" });
+      await expect
+        .poll(() =>
+          workboardCard
+            .getByRole("switch", { name: "Enable Workboard" })
+            .evaluate((element) => Reflect.get(element, "checked")),
+        )
+        .toBe(true);
       await captureScreenshot(page, "05-enabled-installed-desktop.png");
+
+      // Detail uses the same switch and can turn the plugin back off.
+      await workboardCard.click();
+      await detail.waitFor({ state: "visible" });
+      const listCountBeforeDisable = (await gateway.getRequests("plugins.list")).length;
+      const configCountBeforeDisable = (await gateway.getRequests("config.get")).length;
+      const disableCountBefore = (await gateway.getRequests("plugins.setEnabled")).length;
+      await gateway.deferNext("plugins.list");
+      await gateway.deferNext("config.get");
+      await togglePlugin(page, ".plugins-detail");
+
+      const disableRequest = await waitForNextRequest(
+        gateway,
+        "plugins.setEnabled",
+        disableCountBefore,
+      );
+      expect(requestParams(disableRequest)).toEqual({ pluginId: "workboard", enabled: false });
+      await waitForNextRequest(gateway, "plugins.list", listCountBeforeDisable);
+      await waitForNextRequest(gateway, "config.get", configCountBeforeDisable);
+      await gateway.resolveDeferred("plugins.list", disabledInventory);
+      await gateway.resolveDeferred("config.get", configSnapshot(false));
+      await expect.poll(() => workboardCard.getAttribute("aria-busy")).toBe("false");
+      await expect
+        .poll(() =>
+          detail
+            .getByRole("switch", { name: "Enable Workboard" })
+            .evaluate((element) => Reflect.get(element, "checked")),
+        )
+        .toBe(false);
+      await page
+        .locator('[data-plugin-id="workboard"][data-plugin-status="disabled"]')
+        .waitFor({ state: "attached" });
+      await captureScreenshot(page, "06-disabled-detail-desktop.png");
+      await detail.getByRole("button", { name: "Close" }).click();
+      await detail.waitFor({ state: "detached" });
 
       // Removable installs expose a confirm-guarded uninstall behind the trash button.
       await clickRowAction(page, '[data-plugin-id="calendar-plus"]', "Remove Calendar Plus");
@@ -467,8 +538,6 @@ describeControlUiE2e("Control UI Plugins mocked Gateway E2E", () => {
       const listCountBeforeRemove = (await gateway.getRequests("plugins.list")).length;
       const configCountBeforeRemove = (await gateway.getRequests("config.get")).length;
       await gateway.deferNext("plugins.list");
-      // Keep the authoritative config refresh on the workboard-enabled snapshot
-      // so the conditional sidebar route assertion below stays meaningful.
       await gateway.deferNext("config.get");
       await calendarRow.getByRole("button", { name: "Remove", exact: true }).click();
       const uninstallRequest = await waitForNextRequest(
@@ -480,7 +549,7 @@ describeControlUiE2e("Control UI Plugins mocked Gateway E2E", () => {
       await waitForNextRequest(gateway, "plugins.list", listCountBeforeRemove);
       await waitForNextRequest(gateway, "config.get", configCountBeforeRemove);
       await gateway.resolveDeferred("plugins.list", uninstalledInventory);
-      await gateway.resolveDeferred("config.get", configSnapshot(true));
+      await gateway.resolveDeferred("config.get", configSnapshot(false));
       await calendarRow.waitFor({ state: "detached" });
       expect(await page.locator(".plugins-page-notice").textContent()).toContain(
         "Removed calendar-plus",
@@ -502,7 +571,7 @@ describeControlUiE2e("Control UI Plugins mocked Gateway E2E", () => {
         )
         .toBeLessThanOrEqual(0);
       await workboardCard.waitFor({ state: "visible" });
-      await captureScreenshot(page, "06-installed-mobile.png");
+      await captureScreenshot(page, "07-installed-mobile.png");
 
       await page.setViewportSize(desktopViewport);
       const settingsSidebar = page.locator(".settings-sidebar");
@@ -518,8 +587,7 @@ describeControlUiE2e("Control UI Plugins mocked Gateway E2E", () => {
       const workboardMenuItem = sidebar
         .locator("wa-dropdown.sidebar-more-menu")
         .locator('wa-dropdown-item[value="workboard"] a');
-      await workboardMenuItem.waitFor({ state: "visible" });
-      expect(await workboardMenuItem.getAttribute("href")).toBe("/workboard");
+      expect(await workboardMenuItem.count()).toBe(0);
     } finally {
       await context.close();
     }
@@ -542,7 +610,7 @@ describeControlUiE2e("Control UI Plugins mocked Gateway E2E", () => {
       await workboardCard.waitFor({ state: "visible" });
       expect(await page.getByRole("note").textContent()).toContain("operator.admin");
       expect(
-        await workboardCard.getByRole("button", { name: "Enable", exact: true }).isDisabled(),
+        await workboardCard.getByRole("switch", { name: "Enable Workboard" }).isDisabled(),
       ).toBe(true);
 
       await page.getByRole("tab", { name: /^Discover/u }).click();

--- a/ui/src/pages/plugins/view.test.ts
+++ b/ui/src/pages/plugins/view.test.ts
@@ -95,6 +95,17 @@ function actionButton(container: Element, label: string): HTMLButtonElement | nu
   );
 }
 
+function pluginToggle(container: Element): HTMLElement & { checked: boolean } {
+  return expectDefined(
+    container.querySelector<HTMLElement & { checked: boolean }>("wa-switch.settings-toggle"),
+  );
+}
+
+function setPluginToggle(toggle: HTMLElement & { checked: boolean }, checked: boolean): void {
+  toggle.checked = checked;
+  toggle.dispatchEvent(new Event("change", { bubbles: true }));
+}
+
 function clawHubKey(packageName: string): string {
   return `clawhub:${packageName}`;
 }
@@ -168,7 +179,7 @@ describe("renderPlugins", () => {
     expect(onFilterChange).toHaveBeenCalledWith("issues");
   });
 
-  it("offers enable and remove through direct row actions", () => {
+  it("offers an enable toggle and remove through direct row actions", () => {
     const onSetEnabled = vi.fn();
     const onRequestUninstall = vi.fn();
     const removableKey = pluginRowKey("community-thing");
@@ -186,15 +197,15 @@ describe("renderPlugins", () => {
       createProps({ result: createResult(plugins), onSetEnabled, onRequestUninstall }),
     );
     const row = container.querySelector<HTMLElement>('[data-plugin-id="community-thing"]')!;
-    actionButton(row, "Enable")?.click();
+    setPluginToggle(pluginToggle(row), true);
     expect(onSetEnabled).toHaveBeenCalledWith("community-thing", true, removableKey);
     actionButton(row, "Remove Community Thing")?.click();
     expect(onRequestUninstall).toHaveBeenCalledWith(removableKey);
 
-    // Bundled plugins cannot be removed; the row still offers enable/disable.
+    // Bundled plugins cannot be removed; the row still offers an enable toggle.
     const bundledRow = container.querySelector<HTMLElement>('[data-plugin-id="workboard"]')!;
     expect(actionButton(bundledRow, "Remove")).toBeNull();
-    expect(actionButton(bundledRow, "Enable")).not.toBeNull();
+    expect(pluginToggle(bundledRow).checked).toBe(false);
   });
 
   it("confirms removal before uninstalling", () => {
@@ -245,7 +256,7 @@ describe("renderPlugins", () => {
     expect(detail.closest("openclaw-modal-dialog")?.getAttribute("label")).toBe("Workboard");
     expect(normalizedText(detail.querySelector(".plugins-detail__title"))).toContain("Workboard");
     expect(normalizedText(detail.querySelector(".plugins-detail__meta"))).toContain("workboard");
-    detail.querySelectorAll<HTMLButtonElement>(".plugins-detail__actions button")[0]?.click();
+    setPluginToggle(pluginToggle(detail), true);
     expect(onSetEnabled).toHaveBeenCalledWith("workboard", true, pluginRowKey("workboard"));
     detail.querySelector<HTMLButtonElement>(".plugins-detail__close")?.click();
     expect(onShowDetails).toHaveBeenCalledWith(null);
@@ -444,9 +455,9 @@ describe("renderPlugins", () => {
       container.querySelector<HTMLButtonElement>('[aria-label="Install Lobster"]')?.disabled,
     ).toBe(true);
     const workboardRow = container.querySelector<HTMLElement>('[data-plugin-id="workboard"]')!;
-    const enableItem = actionButton(workboardRow, "Enable");
-    expect(enableItem?.disabled).toBe(true);
-    enableItem?.click();
+    const enableToggle = pluginToggle(workboardRow);
+    expect(enableToggle.hasAttribute("disabled")).toBe(true);
+    setPluginToggle(enableToggle, true);
     expect(onInstall).not.toHaveBeenCalled();
     expect(onSetEnabled).not.toHaveBeenCalled();
   });
@@ -533,7 +544,7 @@ describe("renderPlugins", () => {
     const row = container.querySelector<HTMLElement>(`[data-package-name="${packageName}"]`)!;
     expect(normalizedText(row.querySelector(".settings-row__title"))).toBe("Calendar Plus");
     expect(row.querySelector(".plugins-install")).toBeNull();
-    actionButton(row, "Disable")?.click();
+    setPluginToggle(pluginToggle(row), false);
     expect(onSetEnabled).toHaveBeenCalledWith("calendar-runtime", false, clawHubKey(packageName));
   });
 

--- a/ui/src/pages/plugins/view.ts
+++ b/ui/src/pages/plugins/view.ts
@@ -14,6 +14,7 @@ import {
   renderSettingsSection,
   renderSettingsSegmented,
   renderSettingsStatus,
+  renderSettingsToggle,
 } from "../../components/settings-ui.ts";
 import { t } from "../../i18n/index.ts";
 import { EXTERNAL_LINK_TARGET, buildExternalLinkRel } from "../../lib/external-link.ts";
@@ -301,6 +302,10 @@ function stateStatus(plugin: PluginCatalogItem) {
   return renderSettingsStatus({ kind, label: stateLabel(plugin) });
 }
 
+function pluginStatus(plugin: PluginCatalogItem) {
+  return plugin.state === "error" ? stateStatus(plugin) : nothing;
+}
+
 function originLabel(origin: string): string {
   switch (origin) {
     case "bundled":
@@ -398,6 +403,32 @@ function renderToggleButton(
           ? t("pluginsPage.enableAction")
           : t("pluginsPage.disableAction")}
     </button>
+  `;
+}
+
+function renderPluginEnableToggle(
+  plugin: PluginCatalogItem,
+  props: PluginsViewProps,
+  busy: boolean,
+  rowKey: string,
+) {
+  return html`
+    <span
+      title=${props.mutationBlockedReason ?? ""}
+      @click=${(event: Event) => event.stopPropagation()}
+    >
+      ${renderSettingsToggle({
+        checked: plugin.enabled,
+        disabled: !props.canMutate || busy,
+        ariaLabel: t("pluginsPage.enableNamed", { name: plugin.name }),
+        onChange: (enabled) => {
+          if (!props.canMutate || busy) {
+            return;
+          }
+          props.onSetEnabled(plugin.id, enabled, rowKey);
+        },
+      })}
+    </span>
   `;
 }
 
@@ -503,10 +534,7 @@ function renderCatalogActions(
       : html`<span class="plugins-action-note">${t("pluginsPage.unavailable")}</span>`;
   }
   return html`
-    ${renderToggleButton(props, busy, {
-      enabled: plugin.enabled,
-      onToggle: (enabled) => props.onSetEnabled(plugin.id, enabled, rowKey),
-    })}
+    ${renderPluginEnableToggle(plugin, props, busy, rowKey)}
     ${plugin.removable
       ? renderRemoveButton(props, busy, plugin.name, () => props.onRequestUninstall(rowKey))
       : nothing}
@@ -572,7 +600,7 @@ function renderInstalledRow(plugin: PluginCatalogItem, props: PluginsViewProps):
         ])}
       </div>
       <div class="settings-row__control">
-        ${stateStatus(plugin)} ${renderCatalogActions(plugin, props, busy, key)}
+        ${pluginStatus(plugin)} ${renderCatalogActions(plugin, props, busy, key)}
       </div>
       ${plugin.error
         ? html`<div class="plugins-row-message plugins-row-message--error" role="alert">
@@ -779,7 +807,7 @@ function renderCatalogRow(plugin: PluginCatalogItem, props: PluginsViewProps): T
         ${renderMetaLine([plugin.origin ? originLabel(plugin.origin) : nothing])}
       </div>
       <div class="settings-row__control">
-        ${plugin.installed ? stateStatus(plugin) : nothing}
+        ${plugin.installed ? pluginStatus(plugin) : nothing}
         ${renderCatalogActions(plugin, props, busy, key)}
       </div>
       ${plugin.error
@@ -924,7 +952,7 @@ function renderClawHubResult(item: PluginSearchResult, props: PluginsViewProps):
       </div>
       <div class="settings-row__control">
         ${installed
-          ? html`${stateStatus(installed)}${renderCatalogActions(installed, props, busy, key)}`
+          ? html`${pluginStatus(installed)}${renderCatalogActions(installed, props, busy, key)}`
           : renderInstallButton(props, busy, key, pkg.displayName, {
               source: "clawhub",
               packageName: pkg.name,
@@ -1072,7 +1100,7 @@ function renderDetailOverlay(props: PluginsViewProps) {
             ${plugin.version
               ? html`<span class="plugins-version">v${plugin.version}</span>`
               : nothing}
-            ${stateStatus(plugin)}
+            ${pluginStatus(plugin)}
           </div>
           <p class="plugins-detail__description">
             ${plugin.description || t("pluginsPage.optionalCapability")}
@@ -1082,21 +1110,7 @@ function renderDetailOverlay(props: PluginsViewProps) {
               ? renderRemoveConfirm(plugin, props, busy, key)
               : html`
                   ${plugin.installed
-                    ? html`
-                        <button
-                          type="button"
-                          class="btn ${plugin.enabled ? "" : "primary"}"
-                          title=${props.mutationBlockedReason ?? ""}
-                          ?disabled=${!props.canMutate || busy}
-                          @click=${() => props.onSetEnabled(plugin.id, !plugin.enabled, key)}
-                        >
-                          ${busy
-                            ? t("pluginsPage.working")
-                            : plugin.enabled
-                              ? t("pluginsPage.disableAction")
-                              : t("pluginsPage.enableAction")}
-                        </button>
-                      `
+                    ? renderPluginEnableToggle(plugin, props, busy, key)
                     : plugin.install
                       ? renderInstallButton(props, busy, key, plugin.name, plugin.install)
                       : nothing}


### PR DESCRIPTION
## What Problem This Solves
Plugin rows and the plugin detail overlay showed a separate lifecycle status plus an Enable or Disable button. That duplicated the same state and made the primary action heavier than necessary.

## Why This Change Was Made
Use the existing settings switch in both places, preserve error status visibility, and keep row clicks opening the detail overlay without toggling accidentally.

## User Impact
Operators can enable or disable an installed plugin directly from its row or detail overlay through a single familiar control. Read-only and busy states remain protected.

## Evidence
- Blacksmith Testbox / Crabbox: `tbx_01kxgn144ts4cc1rbjbqmz94wa` (3 plugin E2E tests and 15 view tests passed).
- Local screenshot capture: `OPENCLAW_UPDATE_E2E_SCREENSHOTS=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/pages/plugins/plugins.e2e.test.ts`.
- [Visual proof: enabled row, disabled detail modal, and mobile state](https://pagedrop.ai/g/Patrick-Erichsen/7989d6345554b50e726c963db3e4c5bc)
- `pnpm exec oxfmt --check` passed for the four changed files.
- `autoreview --mode local` reported no accepted/actionable findings.