### PR TITLE
fix: scale stuck-session recovery skip with abort threshold

### DIFF
--- a/src/logging/diagnostic-recovery-skip-delay.ts
+++ b/src/logging/diagnostic-recovery-skip-delay.ts
@@ -1,0 +1,24 @@
+// Heartbeat-delay gate for stuck-session recovery under event-loop observer stall.
+
+/** Diagnostics heartbeat period; recovery skip scales in multiples of this. */
+export const DIAGNOSTIC_HEARTBEAT_INTERVAL_MS = 30_000;
+
+/**
+ * Fixed multi-interval ceiling for default/high abort thresholds.
+ * Low stuckSessionAbortMs configs scale the skip down via
+ * resolveDiagnosticRecoverySkipHeartbeatDelayMs so observer-inflated ages
+ * cannot cross abort while still under this 90s historical fixed cutoff.
+ */
+export const DIAGNOSTIC_HEARTBEAT_DELAY_RECOVERY_SKIP_MS = 3 * DIAGNOSTIC_HEARTBEAT_INTERVAL_MS;
+
+/**
+ * Heartbeat delay above which stuck-session recovery must not run on this tick.
+ * Scales with the effective abort threshold so low configs stay protected; the
+ * fixed multi-interval cap preserves the multi-minute observer-stall guard.
+ */
+export function resolveDiagnosticRecoverySkipHeartbeatDelayMs(stuckSessionAbortMs: number): number {
+  if (!Number.isFinite(stuckSessionAbortMs) || stuckSessionAbortMs <= 0) {
+    return DIAGNOSTIC_HEARTBEAT_DELAY_RECOVERY_SKIP_MS;
+  }
+  return Math.min(DIAGNOSTIC_HEARTBEAT_DELAY_RECOVERY_SKIP_MS, Math.floor(stuckSessionAbortMs));
+}

--- a/src/logging/diagnostic-recovery-skip-delay.ts
+++ b/src/logging/diagnostic-recovery-skip-delay.ts
@@ -15,10 +15,19 @@ export const DIAGNOSTIC_HEARTBEAT_DELAY_RECOVERY_SKIP_MS = 3 * DIAGNOSTIC_HEARTB
  * Heartbeat delay above which stuck-session recovery must not run on this tick.
  * Scales with the effective abort threshold so low configs stay protected; the
  * fixed multi-interval cap preserves the multi-minute observer-stall guard.
+ *
+ * Floored at the heartbeat interval so ordinary 30s cadence (strict `>` at the
+ * call site) cannot continuously defer recovery when abort is at or below 30s.
  */
 export function resolveDiagnosticRecoverySkipHeartbeatDelayMs(stuckSessionAbortMs: number): number {
   if (!Number.isFinite(stuckSessionAbortMs) || stuckSessionAbortMs <= 0) {
     return DIAGNOSTIC_HEARTBEAT_DELAY_RECOVERY_SKIP_MS;
   }
-  return Math.min(DIAGNOSTIC_HEARTBEAT_DELAY_RECOVERY_SKIP_MS, Math.floor(stuckSessionAbortMs));
+  // Floor at heartbeat interval: valid sub-interval abort configs must still
+  // allow recovery on ordinary ticks. Without this floor, tickDelayMs ≈ 30s
+  // always exceeds a sub-30s threshold and recovery never runs.
+  return Math.min(
+    DIAGNOSTIC_HEARTBEAT_DELAY_RECOVERY_SKIP_MS,
+    Math.max(DIAGNOSTIC_HEARTBEAT_INTERVAL_MS, Math.floor(stuckSessionAbortMs)),
+  );
 }

--- a/src/logging/diagnostic.test.ts
+++ b/src/logging/diagnostic.test.ts
@@ -10,7 +10,11 @@ import {
   type DiagnosticEventPayload,
 } from "../infra/diagnostic-events.js";
 import { withDiagnosticPhase } from "./diagnostic-phase.js";
-import { resolveDiagnosticRecoverySkipHeartbeatDelayMs } from "./diagnostic-recovery-skip-delay.js";
+import {
+  DIAGNOSTIC_HEARTBEAT_DELAY_RECOVERY_SKIP_MS,
+  DIAGNOSTIC_HEARTBEAT_INTERVAL_MS,
+  resolveDiagnosticRecoverySkipHeartbeatDelayMs,
+} from "./diagnostic-recovery-skip-delay.js";
 import {
   getDiagnosticSessionActivitySnapshot,
   markDiagnosticEmbeddedRunEnded,
@@ -465,7 +469,7 @@ describe("stuck session diagnostics threshold", () => {
     expect(resolveDiagnosticRecoverySkipHeartbeatDelayMs(stuckSessionAbortMs)).toBe(
       stuckSessionAbortMs,
     );
-    expect(observerDelayMs).toBeLessThan(90_000);
+    expect(observerDelayMs).toBeLessThan(DIAGNOSTIC_HEARTBEAT_DELAY_RECOVERY_SKIP_MS);
     expect(observerDelayMs).toBeGreaterThan(stuckSessionAbortMs);
 
     vi.setSystemTime(0);
@@ -482,14 +486,72 @@ describe("stuck session diagnostics threshold", () => {
     logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
 
     vi.setSystemTime(observerDelayMs + 1);
-    vi.advanceTimersByTime(30_000);
+    vi.advanceTimersByTime(DIAGNOSTIC_HEARTBEAT_INTERVAL_MS);
 
     expectLoggerMessageContaining(warnSpy, "liveness heartbeat delayed");
     expect(recoverStuckSession).not.toHaveBeenCalled();
 
     // Next on-time tick may recover once ages are observed without observer drift.
-    vi.advanceTimersByTime(30_000);
+    vi.advanceTimersByTime(DIAGNOSTIC_HEARTBEAT_INTERVAL_MS);
 
+    expect(recoverStuckSession).toHaveBeenCalled();
+  });
+
+  it("still recovers on ordinary ticks when stuckSessionAbortMs is below the heartbeat interval", () => {
+    const recoverStuckSession = vi.fn();
+    const warnSpy = vi.spyOn(diagnosticLogger, "warn").mockImplementation(() => undefined);
+    // Valid config range allows sub-interval abort; ordinary cadence must not defer forever.
+    const stuckSessionWarnMs = 1_000;
+    const stuckSessionAbortMs = 5_000;
+    expect(resolveDiagnosticRecoverySkipHeartbeatDelayMs(stuckSessionAbortMs)).toBe(
+      DIAGNOSTIC_HEARTBEAT_INTERVAL_MS,
+    );
+
+    vi.setSystemTime(0);
+    startDiagnosticHeartbeat(
+      {
+        diagnostics: {
+          enabled: true,
+          stuckSessionWarnMs,
+          stuckSessionAbortMs,
+        },
+      },
+      { recoverStuckSession },
+    );
+    logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
+
+    // Two ordinary heartbeat periods (~60s wall) with no observer stall.
+    vi.advanceTimersByTime(DIAGNOSTIC_HEARTBEAT_INTERVAL_MS * 2);
+
+    expectNoLoggerMessageContaining(warnSpy, "liveness heartbeat delayed");
+    expect(recoverStuckSession).toHaveBeenCalled();
+  });
+
+  it("still recovers on ordinary ticks when stuckSessionAbortMs equals the heartbeat interval", () => {
+    const recoverStuckSession = vi.fn();
+    const warnSpy = vi.spyOn(diagnosticLogger, "warn").mockImplementation(() => undefined);
+    const stuckSessionWarnMs = 10_000;
+    const stuckSessionAbortMs = DIAGNOSTIC_HEARTBEAT_INTERVAL_MS;
+    expect(resolveDiagnosticRecoverySkipHeartbeatDelayMs(stuckSessionAbortMs)).toBe(
+      DIAGNOSTIC_HEARTBEAT_INTERVAL_MS,
+    );
+
+    vi.setSystemTime(0);
+    startDiagnosticHeartbeat(
+      {
+        diagnostics: {
+          enabled: true,
+          stuckSessionWarnMs,
+          stuckSessionAbortMs,
+        },
+      },
+      { recoverStuckSession },
+    );
+    logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
+
+    vi.advanceTimersByTime(DIAGNOSTIC_HEARTBEAT_INTERVAL_MS * 2);
+
+    expectNoLoggerMessageContaining(warnSpy, "liveness heartbeat delayed");
     expect(recoverStuckSession).toHaveBeenCalled();
   });
 

--- a/src/logging/diagnostic.test.ts
+++ b/src/logging/diagnostic.test.ts
@@ -10,6 +10,7 @@ import {
   type DiagnosticEventPayload,
 } from "../infra/diagnostic-events.js";
 import { withDiagnosticPhase } from "./diagnostic-phase.js";
+import { resolveDiagnosticRecoverySkipHeartbeatDelayMs } from "./diagnostic-recovery-skip-delay.js";
 import {
   getDiagnosticSessionActivitySnapshot,
   markDiagnosticEmbeddedRunEnded,
@@ -452,6 +453,44 @@ describe("stuck session diagnostics threshold", () => {
       { sessionId: "s1", sessionKey: "main", queueDepth: 0 },
       ["ageMs", "stateGeneration"],
     );
+  });
+
+  it("scales recovery deferral with a low stuckSessionAbortMs below the fixed 90s skip", () => {
+    const recoverStuckSession = vi.fn();
+    const warnSpy = vi.spyOn(diagnosticLogger, "warn").mockImplementation(() => undefined);
+    const stuckSessionWarnMs = 20_000;
+    const stuckSessionAbortMs = 45_000;
+    // Delay sits between the abort threshold and the historical 90s fixed skip.
+    const observerDelayMs = 60_000;
+    expect(resolveDiagnosticRecoverySkipHeartbeatDelayMs(stuckSessionAbortMs)).toBe(
+      stuckSessionAbortMs,
+    );
+    expect(observerDelayMs).toBeLessThan(90_000);
+    expect(observerDelayMs).toBeGreaterThan(stuckSessionAbortMs);
+
+    vi.setSystemTime(0);
+    startDiagnosticHeartbeat(
+      {
+        diagnostics: {
+          enabled: true,
+          stuckSessionWarnMs,
+          stuckSessionAbortMs,
+        },
+      },
+      { recoverStuckSession },
+    );
+    logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
+
+    vi.setSystemTime(observerDelayMs + 1);
+    vi.advanceTimersByTime(30_000);
+
+    expectLoggerMessageContaining(warnSpy, "liveness heartbeat delayed");
+    expect(recoverStuckSession).not.toHaveBeenCalled();
+
+    // Next on-time tick may recover once ages are observed without observer drift.
+    vi.advanceTimersByTime(30_000);
+
+    expect(recoverStuckSession).toHaveBeenCalled();
   });
 
   it("does not warn while a processing session continues reporting progress", () => {

--- a/src/logging/diagnostic.ts
+++ b/src/logging/diagnostic.ts
@@ -18,6 +18,7 @@ import {
   getRecentDiagnosticPhases,
   resetDiagnosticPhasesForTest,
 } from "./diagnostic-phase.js";
+import { resolveDiagnosticRecoverySkipHeartbeatDelayMs } from "./diagnostic-recovery-skip-delay.js";
 import {
   BLOCKED_TOOL_CALL_ABORT_FLOOR_MS,
   getDiagnosticSessionActivitySnapshot,
@@ -88,8 +89,6 @@ const DEFAULT_LIVENESS_EVENT_LOOP_DELAY_WARN_MS = 1_000;
 const DEFAULT_LIVENESS_EVENT_LOOP_UTILIZATION_WARN = 0.95;
 const DEFAULT_LIVENESS_CPU_CORE_RATIO_WARN = 0.9;
 const DEFAULT_LIVENESS_WARN_COOLDOWN_MS = 120_000;
-const DIAGNOSTIC_HEARTBEAT_INTERVAL_MS = 30_000;
-const DIAGNOSTIC_HEARTBEAT_DELAY_RECOVERY_SKIP_MS = 3 * DIAGNOSTIC_HEARTBEAT_INTERVAL_MS;
 const loadStuckSessionRecoveryRuntime = createLazyRuntimeModule(
   () => import("./diagnostic-stuck-session-recovery.runtime.js"),
 );
@@ -1240,9 +1239,9 @@ export function startDiagnosticHeartbeat(
     const tickDelayMs =
       lastDiagnosticHeartbeatTickAt === undefined ? 0 : now - lastDiagnosticHeartbeatTickAt;
     lastDiagnosticHeartbeatTickAt = now;
-    // A late interval tick means the process was stalled, not the sessions.
-    // Acting on inflated ages here can abort healthy runs; the next on-time tick decides.
-    const skipRecoveryThisTick = tickDelayMs > DIAGNOSTIC_HEARTBEAT_DELAY_RECOVERY_SKIP_MS;
+    // Late ticks inflate ages; skip when delay > min(90s cap, abort threshold).
+    const skipRecoveryThisTick =
+      tickDelayMs > resolveDiagnosticRecoverySkipHeartbeatDelayMs(stuckSessionAbortMs);
     if (skipRecoveryThisTick) {
       diag.warn(
         `liveness heartbeat delayed ${Math.round(tickDelayMs)}ms; deferring recovery decisions`,
@@ -1373,7 +1372,7 @@ export function startDiagnosticHeartbeat(
         }
       }
     }
-  }, DIAGNOSTIC_HEARTBEAT_INTERVAL_MS);
+  }, 30_000);
   heartbeatInterval.unref?.();
 }
 

--- a/src/logging/diagnostic.ts
+++ b/src/logging/diagnostic.ts
@@ -18,7 +18,10 @@ import {
   getRecentDiagnosticPhases,
   resetDiagnosticPhasesForTest,
 } from "./diagnostic-phase.js";
-import { resolveDiagnosticRecoverySkipHeartbeatDelayMs } from "./diagnostic-recovery-skip-delay.js";
+import {
+  DIAGNOSTIC_HEARTBEAT_INTERVAL_MS,
+  resolveDiagnosticRecoverySkipHeartbeatDelayMs,
+} from "./diagnostic-recovery-skip-delay.js";
 import {
   BLOCKED_TOOL_CALL_ABORT_FLOOR_MS,
   getDiagnosticSessionActivitySnapshot,
@@ -1239,7 +1242,8 @@ export function startDiagnosticHeartbeat(
     const tickDelayMs =
       lastDiagnosticHeartbeatTickAt === undefined ? 0 : now - lastDiagnosticHeartbeatTickAt;
     lastDiagnosticHeartbeatTickAt = now;
-    // Late ticks inflate ages; skip when delay > min(90s cap, abort threshold).
+    // Late ticks inflate ages; skip when delay exceeds the abort-scaled gate
+    // (floored at the heartbeat interval, capped at the historical 90s multi-interval guard).
     const skipRecoveryThisTick =
       tickDelayMs > resolveDiagnosticRecoverySkipHeartbeatDelayMs(stuckSessionAbortMs);
     if (skipRecoveryThisTick) {
@@ -1372,7 +1376,7 @@ export function startDiagnosticHeartbeat(
         }
       }
     }
-  }, 30_000);
+  }, DIAGNOSTIC_HEARTBEAT_INTERVAL_MS);
   heartbeatInterval.unref?.();
 }
 


### PR DESCRIPTION
Closes #107415

## What Problem This Solves

Fixes an issue where operators who configure a stuck-session abort threshold below the fixed 90-second diagnostics heartbeat skip window could still have healthy embedded runs aborted during moderate gateway event-loop stalls. Current main already defers recovery when a heartbeat is more than 90 seconds late, but a heartbeat delayed longer than a lower configured abort threshold (yet under 90s) can still treat observer-inflated ages as real agent stalls and call `abort_embedded_run`.

Also protects valid sub-30-second abort configs: the skip gate is floored at the diagnostics heartbeat interval so ordinary 30s cadence cannot continuously suppress recovery for low thresholds.

## Why This Change Was Made

Scale the heartbeat-delay recovery skip with the effective `diagnostics.stuckSessionAbortMs`: skip recovery for the delayed tick when `tickDelayMs` exceeds `min(fixed 90s multi-interval cap, max(heartbeat interval, abort threshold))`, then let the next on-time tick decide. Flooring at the 30s heartbeat interval keeps ordinary ticks recoverable for abort values at or below the cadence; default and high abort thresholds keep the existing 90s multi-minute observer-stall guard. No new config, no product decision, and no change to text-only warn classification.

Compatibility: additive threshold-relative gate only; defaults unchanged. Performance: O(1) on the existing heartbeat tick. Usability: fewer false aborts under low abort configs without wedging sub-interval configs. Security: no trust-boundary change.

## User Impact

Gateway operators using a lower stuck-session abort threshold no longer risk healthy cron/interactive runs being aborted solely because the diagnostics heartbeat itself was delayed between that threshold and 90 seconds. Operators with abort at or below the 30s heartbeat interval still get recovery on ordinary ticks. Multi-minute stalls under default thresholds remain deferred as before.

## Evidence

Verification host: local macOS (Crabbox not required for this unit/source surface).

```text
# Resolver contract (real Node, no fake timers)
fixed cap ms: 90000
heartbeat interval ms: 30000
abort=5000 -> 30000 (floor=interval)
abort=30000 -> 30000 (at interval)
abort=45000 -> 45000
abort=300000 -> 90000
abort=invalid -> 90000
ordinary tickDelay=30000 abort=5000 thr=30000 skip=false
ordinary tickDelay=30000 abort=30000 thr=30000 skip=false
ordinary tickDelay=30000 abort=45000 thr=45000 skip=false
delayed tickDelay=60000 abort=45000 thr=45000 skip=true

# Focused Vitest
node scripts/run-vitest.mjs src/logging/diagnostic.test.ts -t "scales recovery deferral|still recovers on ordinary|defers recovery on delayed"
✓ scales recovery deferral with a low stuckSessionAbortMs below the fixed 90s skip
✓ still recovers on ordinary ticks when stuckSessionAbortMs is below the heartbeat interval
✓ still recovers on ordinary ticks when stuckSessionAbortMs equals the heartbeat interval
✓ defers recovery on delayed heartbeat ticks and recovers on the next on-time tick
Tests  4 passed

# Broader stuck-session threshold suite
node scripts/run-vitest.mjs src/logging/diagnostic.test.ts -t "stuck session diagnostics threshold"
✓ 54 passed | 23 skipped

# Static
git diff --check  # clean
```

## Real behavior proof

- Behavior addressed:
  1. Do not abort healthy work when diagnostics heartbeat delay exceeds a low configured abort threshold but stays under the historical fixed 90s skip.
  2. Do not continuously defer recovery on ordinary 30s ticks when abort is at or below the heartbeat interval.
- Environment: local macOS, branch `fix/107415-recovery-skip-scales-with-abort` at `38f211a52`, Node focused Vitest via `node scripts/run-vitest.mjs` plus a real-Node resolver contract script (`node --import tsx`).
- Current-main contrast:
  - With `stuckSessionAbortMs=45_000`, a heartbeat delayed ~60s still allowed recovery requests (delay under 90s fixed skip). After this patch, the same delay is deferred and recovery only runs on a subsequent on-time tick.
  - With `stuckSessionAbortMs=5_000` or `30_000`, a pure abort-scaled gate would treat every ordinary 30s tick as delayed and never recover; after this patch the skip threshold is floored at 30s so ordinary cadence recovers.
- Exact steps or command run after this patch:
  1. `node --import tsx -e '…resolveDiagnosticRecoverySkipHeartbeatDelayMs…'` (resolver contract above)
  2. `node scripts/run-vitest.mjs src/logging/diagnostic.test.ts -t "scales recovery deferral|still recovers on ordinary|defers recovery on delayed"`
  3. `node scripts/run-vitest.mjs src/logging/diagnostic.test.ts -t "stuck session diagnostics threshold"`
- Evidence after fix: resolver prints floor behavior for 5s/30s abort and scaled 45s/300s paths; Vitest asserts (a) delayed 60s tick under abort=45s warns and defers then recovers on the next on-time tick, (b) ordinary ticks under abort=5s and abort=30s do not emit the delay warn and do call recovery.
- Control check: existing “defers recovery on delayed heartbeat ticks…” case still passes for default/high abort paths (fixed 90s cap preserved). Stuck-session threshold suite: 54 passed.
- Observed result after fix: low-but-above-interval abort configs defer only when observer delay exceeds the scaled gate; at-or-below-interval configs keep ordinary recovery; default multi-minute protection unchanged.
- What was not tested: full multi-minute swap-storm memory-pressure incident replay on a production multi-channel gateway; live Slack/cron DM delivery after abort. The exercised path is the same diagnostics heartbeat used by the gateway (`startDiagnosticHeartbeat` + recovery skip resolver).

## AI disclosure

This PR was authored with AI assistance (Grok).
