### PR TITLE
fix(session-catalog): long tool argument previews corrupt boundary emoji

### DIFF
--- a/extensions/acpx/src/pi-session-catalog.test.ts
+++ b/extensions/acpx/src/pi-session-catalog.test.ts
@@ -47,9 +47,32 @@ const originalHome = process.env.HOME;
 const originalUserProfile = process.env.USERPROFILE;
 const originalPath = process.env.PATH;
 
+function boundaryToolArguments(): { payload: string } {
+  const marker = "🦞";
+  const markerIndex = JSON.stringify({ payload: marker }).indexOf(marker);
+  return { payload: `${"x".repeat(19_999 - markerIndex)}${marker}tail` };
+}
+
+function hasUnpairedSurrogate(value: string): boolean {
+  for (let index = 0; index < value.length; index += 1) {
+    const current = value.charCodeAt(index);
+    if (current >= 0xd800 && current <= 0xdbff) {
+      const next = value.charCodeAt(index + 1);
+      if (!(next >= 0xdc00 && next <= 0xdfff)) {
+        return true;
+      }
+      index += 1;
+    } else if (current >= 0xdc00 && current <= 0xdfff) {
+      return true;
+    }
+  }
+  return false;
+}
+
 async function createPiStore(
   assistantText = "hi",
   sessionName = "Pi catalog session",
+  toolArguments: unknown = { command: "pwd" },
 ): Promise<string> {
   const directory = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-pi-catalog-"));
   temporaryDirectories.push(directory);
@@ -82,7 +105,7 @@ async function createPiStore(
         content: [
           { type: "thinking", thinking: "thinking" },
           { type: "text", text: assistantText },
-          { type: "toolCall", id: "call-1", name: "bash", arguments: { command: "pwd" } },
+          { type: "toolCall", id: "call-1", name: "bash", arguments: toolArguments },
         ],
       },
     },
@@ -291,6 +314,15 @@ describe("Pi session catalog", () => {
     const answer = transcript.items.find((item) => item.type === "agentMessage");
     expect(answer?.text?.endsWith("…")).toBe(true);
     expect(Buffer.byteLength(JSON.stringify(transcript), "utf8")).toBeLessThan(20 * 1024 * 1024);
+  });
+
+  it("keeps long tool argument previews UTF-16 safe", async () => {
+    await createPiStore("hi", "Pi catalog session", boundaryToolArguments());
+    const transcript = await readLocalPiTranscriptPage({ threadId: "pi-session", limit: 20 });
+    const toolCall = transcript.items.find((item) => item.type === "toolCall");
+
+    expect(toolCall?.text?.endsWith("…")).toBe(true);
+    expect(hasUnpairedSurrogate(toolCall?.text ?? "")).toBe(false);
   });
 
   it("reads legacy linear sessions and visible extended messages", async () => {

--- a/extensions/acpx/src/pi-session-catalog.ts
+++ b/extensions/acpx/src/pi-session-catalog.ts
@@ -5,6 +5,7 @@ import type {
   SessionsCatalogReadResult,
 } from "openclaw/plugin-sdk/session-catalog";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { listPiSummaryPage, readPiSessionById } from "./pi-session-store.js";
 
 const LOCAL_HOST_ID = "gateway";
@@ -225,7 +226,7 @@ function isoTimestamp(
 function jsonText(value: unknown, maxLength = 20_000): string | undefined {
   try {
     const text = JSON.stringify(value);
-    return text.length > maxLength ? `${text.slice(0, maxLength)}…` : text;
+    return text.length > maxLength ? `${truncateUtf16Safe(text, maxLength)}…` : text;
   } catch {
     return undefined;
   }

--- a/extensions/opencode/session-catalog.test.ts
+++ b/extensions/opencode/session-catalog.test.ts
@@ -83,9 +83,32 @@ function captureOpenCodeSessionRegistrations(pluginConfig: unknown = {}) {
   return { catalogs, commands, policies };
 }
 
+function boundaryToolArguments(): { payload: string } {
+  const marker = "🦞";
+  const markerIndex = JSON.stringify({ payload: marker }).indexOf(marker);
+  return { payload: `${"x".repeat(19_999 - markerIndex)}${marker}tail` };
+}
+
+function hasUnpairedSurrogate(value: string): boolean {
+  for (let index = 0; index < value.length; index += 1) {
+    const current = value.charCodeAt(index);
+    if (current >= 0xd800 && current <= 0xdbff) {
+      const next = value.charCodeAt(index + 1);
+      if (!(next >= 0xdc00 && next <= 0xdfff)) {
+        return true;
+      }
+      index += 1;
+    } else if (current >= 0xdc00 && current <= 0xdfff) {
+      return true;
+    }
+  }
+  return false;
+}
+
 async function installFakeOpenCode(
   assistantText = "hi",
   sessionTitle = "Catalog session",
+  toolInput: unknown = { command: "pwd" },
 ): Promise<string> {
   const directory = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-opencode-catalog-"));
   temporaryDirectories.push(directory);
@@ -125,7 +148,7 @@ async function installFakeOpenCode(
             id: "prt_tool",
             type: "tool",
             tool: "bash",
-            state: { status: "completed", input: { command: "pwd" }, output: "/workspace" },
+            state: { status: "completed", input: toolInput, output: "/workspace" },
           },
         ],
       },
@@ -296,6 +319,21 @@ describe("OpenCode session catalog", () => {
       const answer = transcript.items.find((item) => item.type === "agentMessage");
       expect(answer?.text?.endsWith("…")).toBe(true);
       expect(Buffer.byteLength(JSON.stringify(transcript), "utf8")).toBeLessThan(20 * 1024 * 1024);
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "keeps long tool argument previews UTF-16 safe",
+    async () => {
+      await installFakeOpenCode("hi", "Catalog session", boundaryToolArguments());
+      const transcript = await readLocalOpenCodeTranscriptPage({
+        threadId: "ses_test",
+        limit: 20,
+      });
+      const toolCall = transcript.items.find((item) => item.type === "toolCall");
+
+      expect(toolCall?.text?.endsWith("…")).toBe(true);
+      expect(hasUnpairedSurrogate(toolCall?.text ?? "")).toBe(false);
     },
   );
 

--- a/extensions/opencode/session-catalog.ts
+++ b/extensions/opencode/session-catalog.ts
@@ -6,6 +6,7 @@ import type {
   SessionsCatalogReadResult,
 } from "openclaw/plugin-sdk/session-catalog";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import {
   materializeWindowsSpawnProgram,
   resolveWindowsSpawnProgram,
@@ -352,7 +353,7 @@ export async function listLocalOpenCodeSessionPage(value?: unknown): Promise<Ope
 function jsonText(value: unknown, maxLength = 20_000): string | undefined {
   try {
     const text = JSON.stringify(value);
-    return text.length > maxLength ? `${text.slice(0, maxLength)}…` : text;
+    return text.length > maxLength ? `${truncateUtf16Safe(text, maxLength)}…` : text;
   } catch {
     return undefined;
   }


### PR DESCRIPTION
<!--
Optional linked context:
Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
below this comment.

Required PR title:
type: user-facing description
Use a parenthesized scope only when it adds clarity:
fix(auth): login redirect loops when session cookie is expired

Types: feat, fix, improve, refactor, docs, chore.
For fixes, describe the user-visible symptom and trigger:
fix: task list fails to load when user has no environments
Avoid implementation details such as:
fix: add null check to task query
-->

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

<!--
Describe the concrete user, product, or operational problem.
For fixes, begin with:
"Fixes an issue where users <do X> would <experience Y> when <condition>."
or:
"Resolves a problem where..."

Name the affected UI surface or workflow. Do not describe the code-level cause here.
-->

Fixes an issue where users opening a native OpenCode or Pi session transcript through `sessions.catalog.read` could see a corrupted replacement character when a long tool argument placed an emoji across the 20,000-code-unit preview boundary.

## Why This Change Was Made

<!--
In one or two sentences, explain the complete shipped solution, key design
decisions, and relevant boundaries or non-goals. Include implementation detail
only when it helps reviewers understand user-visible behavior or risk.
Avoid file-by-file narration.
-->

The OpenCode and Pi session-catalog adapters now use the repository's UTF-16-safe truncation helper when bounding serialized tool arguments. The existing limit and ellipsis are preserved; schemas, RPC fields, ordering, provider transcript formats, persistence, and model input are unchanged.

## User Impact

<!--
State what users, operators, or developers can now do or expect. Lead with the
concrete benefit and use user-facing language. If there is no user-visible
impact, say so plainly.
-->

Long native-session tool-call previews remain readable and valid when they contain emoji at the truncation boundary, so the gateway and Control UI no longer receive a split surrogate from these adapters.

## Evidence

<!--
Show the most useful proof that this change works. Screenshots, screencasts,
terminal output, focused tests, CI results, live observations, redacted logs,
and artifact links are all useful. Include before/after evidence for visual
changes when it clarifies the result.

Reviewers will inspect the code, tests, and CI. Use this section to make the
validation easy to understand, not to restate the diff.
-->

- Real gateway path: started OpenClaw, called `sessions.catalog.read` for the bundled OpenCode catalog, and observed a tool-call preview with `valid_utf16=true`, `replacement_character_present=false`, and `truncated=true`.

  ```text
  {"execution_ok":true,"gateway_rpc":"sessions.catalog.read","catalog_id":"opencode","tool_call_present":true,"valid_utf16":true,"replacement_character_present":false,"truncated":true,"ok":true}
  ```

- Production adapter path: exercised both the OpenCode process-boundary export adapter and the Pi JSONL session adapter with the same boundary input; both returned a present, truncated tool call with valid UTF-16 and no replacement character.

  ```text
  opencode: tool_call_present=true valid_utf16=true replacement_character_present=false truncated=true
  pi:       tool_call_present=true valid_utf16=true replacement_character_present=false truncated=true
  ```

- Regression suites: OpenCode session catalog `10 passed`; Pi session catalog `18 passed`.
- Focused `oxfmt --check` and `oxlint` passed on all four changed source/test files.
- Current-main port: replayed the contributor commit onto `243beca126d09b9c375c050a1efc71a886d205eb`, preserved the four-file scope and contributor attribution, and passed conflict-marker, ancestry, source-contract, and `git diff --check` validation. The gateway and adapter observations above were collected on hosted head `48cd9f96fe70f4f3d3da4d4e642dade7d14de084`; the port keeps the same production truncation changes while retaining current-main test-fixture parameters. Exact-head fork CI remains the execution environment for the ported commit.
