### PR TITLE
fix(ci): fetch exact PR base before history

### DIFF
--- a/.github/actions/ensure-base-commit/action.yml
+++ b/.github/actions/ensure-base-commit/action.yml
@@ -44,6 +44,15 @@ runs:
             fetch "$@"
         }
 
+        echo "Base commit missing; fetching exact SHA before branch history."
+        if ! fetch_base_ref --no-tags --depth=1 origin "$BASE_SHA"; then
+          echo "::warning title=ensure-base-commit exact fetch failed::Failed to fetch exact base SHA $BASE_SHA"
+        fi
+        if git rev-parse --verify "$BASE_SHA^{commit}" >/dev/null 2>&1; then
+          echo "Resolved base commit after exact fetch: $BASE_SHA"
+          exit 0
+        fi
+
         for deepen_by in 25 100 300; do
           echo "Base commit missing; deepening $FETCH_REF by $deepen_by."
           if ! fetch_base_ref --no-tags --deepen="$deepen_by" origin -- "$FETCH_REF"; then
@@ -64,4 +73,5 @@ runs:
           exit 0
         fi
 
-        echo "Base commit still unavailable after fetch attempts: $BASE_SHA"
+        echo "::error title=ensure-base-commit missing base::Base commit still unavailable after fetch attempts: $BASE_SHA"
+        exit 1

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -1619,11 +1619,16 @@ describe("ci workflow guards", () => {
 
   it("bounds shared base commit fetches", () => {
     const action = readFileSync(".github/actions/ensure-base-commit/action.yml", "utf8");
+    const exactFetch = action.indexOf('fetch_base_ref --no-tags --depth=1 origin "$BASE_SHA"');
+    const branchDeepening = action.indexOf("for deepen_by in 25 100 300");
 
     expect(action).toContain("fetch_base_ref()");
     expect(action).toContain("timeout --signal=TERM --kill-after=10s 30s git");
     expect(action).toContain("-c protocol.version=2");
     expect(action).not.toContain("if ! git fetch --no-tags");
+    expect(exactFetch).toBeGreaterThan(-1);
+    expect(branchDeepening).toBeGreaterThan(exactFetch);
+    expect(action).toContain("::error title=ensure-base-commit missing base::");
   });
 
   it("bounds early unauthenticated checkout fetches", () => {


### PR DESCRIPTION
## What Problem This Solves

Closes #107669.

The iOS, macOS, and shared OpenClawKit Periphery scope detectors start from a depth-1 synthetic merge checkout. When the concrete PR base commit is absent, the shared action deepens the full base branch three times and then fetches full history. On PR #107625, all four fetches hit their 30-second bounds in all three workflows across two attempts, and the subsequent path diff failed with exit code 128.

## Why This Change Was Made

Fetch the already-known base SHA directly at depth 1 before expanding branch history. Preserve the bounded branch-deepening sequence as a fallback for remotes that reject direct SHA fetches. If neither path materializes the required commit, fail inside the shared action with a precise error instead of letting downstream consumers fail ambiguously.

The workflow guard now locks the exact-fetch-before-deepening order and the fail-closed terminal state.

## User Impact

No product behavior changes. Native scope detectors avoid about two minutes of doomed branch-history fetches when an exact base fetch succeeds, and missing-base failures point to the actual owner.

## Evidence

- Repeated failure: https://github.com/openclaw/openclaw/actions/runs/29350487219/attempts/2
- Matching iOS failure: https://github.com/openclaw/openclaw/actions/runs/29350487202
- Matching macOS failure: https://github.com/openclaw/openclaw/actions/runs/29350487292
- Blacksmith Testbox `tbx_01kxgs26vqmj49c40s6fa6vasc`: `pnpm test test/scripts/ci-workflow-guards.test.ts` — 58/58 passed: https://github.com/openclaw/openclaw/actions/runs/29351855372
- `git diff --check`
- Fresh autoreview: clean, no actionable findings.

No agent transcript attached per maintainer direction.
