### PR TITLE
fix: default skill workshop approvals to auto

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- **Skill Workshop approvals:** run agent-initiated apply, reject, and quarantine actions without an additional approval prompt by default while preserving `skills.workshop.approvalPolicy: "pending"` as an opt-in approval gate. Thanks @shakkernerd.
 - **TUI fuzzy selectors:** delegate list matching to pi-tui, adding slash-token and alpha-number matching while removing the local matcher fork.
 - **macOS paired-node terminals:** advertise duplex Codex and Claude terminal resume commands from the embedded node host and forward interactive input and cancellation through the native app bridge. (#107335)
 - **Control UI catalog terminals:** open eligible Codex and Claude Code sessions in the native CLI on their Gateway or paired-node host, with viewer-versus-terminal preferences, validated resume commands, and an interactive PTY relay. (#107086)

--- a/docs/tools/self-learning.md
+++ b/docs/tools/self-learning.md
@@ -205,13 +205,13 @@ model.
 
 ## Configuration
 
-| Setting                                    | Default     | Self-learning effect                                                                                                              |
-| ------------------------------------------ | ----------- | --------------------------------------------------------------------------------------------------------------------------------- |
-| `skills.workshop.autonomous.enabled`       | `false`     | Enables direct correction capture and delayed experience review.                                                                  |
-| `skills.workshop.approvalPolicy`           | `"pending"` | Controls approval prompts for normal agent-initiated lifecycle actions; it does not expand the background reviewer's permissions. |
-| `skills.workshop.maxPending`               | `50`        | Caps pending and quarantined proposals per workspace.                                                                             |
-| `skills.workshop.maxSkillBytes`            | `40000`     | Caps proposal body size in bytes.                                                                                                 |
-| `skills.workshop.allowSymlinkTargetWrites` | `false`     | Affects apply behavior only; self-learning itself writes proposal state, not live skill targets.                                  |
+| Setting                                    | Default  | Self-learning effect                                                                                                              |
+| ------------------------------------------ | -------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `skills.workshop.autonomous.enabled`       | `false`  | Enables direct correction capture and delayed experience review.                                                                  |
+| `skills.workshop.approvalPolicy`           | `"auto"` | Controls approval prompts for normal agent-initiated lifecycle actions; it does not expand the background reviewer's permissions. |
+| `skills.workshop.maxPending`               | `50`     | Caps pending and quarantined proposals per workspace.                                                                             |
+| `skills.workshop.maxSkillBytes`            | `40000`  | Caps proposal body size in bytes.                                                                                                 |
+| `skills.workshop.allowSymlinkTargetWrites` | `false`  | Affects apply behavior only; self-learning itself writes proposal state, not live skill targets.                                  |
 
 For the exhaustive schema, ranges, and related skill settings, see
 [Skills config](/tools/skills-config#workshop-skills-workshop).

--- a/docs/tools/skill-workshop.md
+++ b/docs/tools/skill-workshop.md
@@ -116,15 +116,15 @@ Revise it to also flag anything marked urgent.
 Apply the morning-catchup proposal.
 ```
 
-Agent-initiated `apply`, `reject`, and `quarantine` show an approval prompt by
-default. Set `skills.workshop.approvalPolicy` to `"auto"` to skip it in
-trusted environments.
+Agent-initiated `apply`, `reject`, and `quarantine` run without an additional
+approval prompt by default. Set `skills.workshop.approvalPolicy` to `"pending"`
+to require operator approval before those actions.
 
-The prompt identifies the proposal id and target skill, and shows the proposal
-description, support-file count, and body size. Approval requests are bounded
-to finish before the agent tool watchdog. If no decision arrives before the
-prompt expires, the lifecycle action does not run: the proposal stays pending
-and unchanged. Decide later in the Skill Workshop UI or run
+When approval is required, the prompt identifies the proposal id and target
+skill, and shows the proposal description, support-file count, and body size.
+Approval requests are bounded to finish before the agent tool watchdog. If no
+decision arrives before the prompt expires, the lifecycle action does not run:
+the proposal stays pending and unchanged. Decide later in the Skill Workshop UI or run
 `openclaw skills workshop apply|reject|quarantine <proposal-id>`. Agents should
 not retry an expired lifecycle action in a loop.
 
@@ -283,7 +283,7 @@ the proposal threshold, and troubleshooting.
         enabled: false,
       },
       allowSymlinkTargetWrites: false,
-      approvalPolicy: "pending",
+      approvalPolicy: "auto",
       maxPending: 50,
       maxSkillBytes: 40000,
     },
@@ -291,13 +291,13 @@ the proposal threshold, and troubleshooting.
 }
 ```
 
-| Setting                    | Default     | Effect                                                                                                                                                                 |
-| -------------------------- | ----------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `autonomous.enabled`       | `false`     | Creates pending proposals from explicit corrections and, after an idle delay, substantial completed work with reusable recovery or meaningful round-trip savings.      |
-| `allowSymlinkTargetWrites` | `false`     | Lets apply write through workspace skill symlinks whose real target is listed in `skills.load.allowSymlinkTargets`.                                                    |
-| `approvalPolicy`           | `"pending"` | `"pending"` requires an approval prompt before agent-initiated `apply`, `reject`, or `quarantine`. `"auto"` skips the prompt (the agent still has to call the action). |
-| `maxPending`               | `50`        | Caps pending and quarantined proposals per workspace (1-200).                                                                                                          |
-| `maxSkillBytes`            | `40000`     | Caps proposal body size in bytes (1024-200000).                                                                                                                        |
+| Setting                    | Default  | Effect                                                                                                                                                              |
+| -------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `autonomous.enabled`       | `false`  | Creates pending proposals from explicit corrections and, after an idle delay, substantial completed work with reusable recovery or meaningful round-trip savings.   |
+| `allowSymlinkTargetWrites` | `false`  | Lets apply write through workspace skill symlinks whose real target is listed in `skills.load.allowSymlinkTargets`.                                                 |
+| `approvalPolicy`           | `"auto"` | `"auto"` skips an additional prompt for agent-initiated `apply`, `reject`, or `quarantine` (the agent still has to call the action). `"pending"` requires approval. |
+| `maxPending`               | `50`     | Caps pending and quarantined proposals per workspace (1-200).                                                                                                       |
+| `maxSkillBytes`            | `40000`  | Caps proposal body size in bytes (1024-200000).                                                                                                                     |
 
 Autonomous capture recognizes prospective rules (for example, “from now on”) and reactive
 corrections (for example, “that’s not what I asked”). It groups new instructions by topic into up

--- a/docs/tools/skills-config.md
+++ b/docs/tools/skills-config.md
@@ -30,7 +30,7 @@ Most skills configuration lives under `skills` in
     workshop: {
       autonomous: { enabled: false },
       allowSymlinkTargetWrites: false,
-      approvalPolicy: "pending",
+      approvalPolicy: "auto",
       maxPending: 50,
       maxSkillBytes: 40000,
     },
@@ -351,9 +351,9 @@ different visible skill set per agent.
 See [Self-learning](/tools/self-learning) for eligibility, privacy, cost,
 proposal-only permissions, and troubleshooting.
 
-<ParamField path="skills.workshop.approvalPolicy" type='"pending" | "auto"' default='"pending"'>
-  `pending` requires operator approval before agent-initiated apply, reject,
-  or quarantine. `auto` allows those actions without approval.
+<ParamField path="skills.workshop.approvalPolicy" type='"pending" | "auto"' default='"auto"'>
+  `auto` allows agent-initiated apply, reject, or quarantine without an
+  additional approval prompt. `pending` requires operator approval.
 </ParamField>
 
 <ParamField path="skills.workshop.allowSymlinkTargetWrites" type="boolean" default="false">

--- a/src/agents/agent-tools.before-tool-call.embedded-mode.test.ts
+++ b/src/agents/agent-tools.before-tool-call.embedded-mode.test.ts
@@ -182,7 +182,17 @@ describe("runBeforeToolCallHook — embedded mode approvals", () => {
       toolName: "skill_workshop",
       params: { action: "apply", proposal_id: "weather" },
       toolCallId: "call-skill-local",
-      ctx: { agentId: "main", sessionKey: "agent:main:main" },
+      ctx: {
+        agentId: "main",
+        sessionKey: "agent:main:main",
+        config: {
+          skills: {
+            workshop: {
+              approvalPolicy: "pending",
+            },
+          },
+        },
+      },
     });
     await vi.waitFor(() => {
       expect(broker.listPending()).toHaveLength(1);
@@ -633,7 +643,17 @@ describe("runBeforeToolCallHook — embedded mode approvals", () => {
       toolName: "skill_workshop",
       params: { action: "apply", proposal_id: "weather-20260530-a1b2c3d4e5" },
       toolCallId: "call-skill-timeout",
-      ctx: { agentId: "main", sessionKey: "main" },
+      ctx: {
+        agentId: "main",
+        sessionKey: "main",
+        config: {
+          skills: {
+            workshop: {
+              approvalPolicy: "pending",
+            },
+          },
+        },
+      },
     });
 
     expect(result).toMatchObject({
@@ -779,21 +799,12 @@ describe("runBeforeToolCallHook — embedded mode approvals", () => {
     }
   });
 
-  it("does not require skill_workshop lifecycle approval in auto mode", async () => {
+  it("does not require skill_workshop lifecycle approval by default", async () => {
     (hookRunner.hasHooks as ReturnType<typeof vi.fn>).mockReturnValue(false);
 
     const result = await runBeforeToolCallHook({
       toolName: "skill_workshop",
       params: { action: "reject", proposal_id: "weather-20260530-a1b2c3d4e5" },
-      ctx: {
-        config: {
-          skills: {
-            workshop: {
-              approvalPolicy: "auto",
-            },
-          },
-        },
-      },
     });
 
     expect(result).toEqual({
@@ -804,14 +815,18 @@ describe("runBeforeToolCallHook — embedded mode approvals", () => {
     expect(runBeforeToolCallMock).not.toHaveBeenCalled();
   });
 
-  it("uses runtime config for skill_workshop auto mode when hook context config is absent", async () => {
+  it("uses runtime config for skill_workshop pending mode when hook context config is absent", async () => {
     (hookRunner.hasHooks as ReturnType<typeof vi.fn>).mockReturnValue(false);
     setRuntimeConfigSnapshot({
       skills: {
         workshop: {
-          approvalPolicy: "auto",
+          approvalPolicy: "pending",
         },
       },
+    });
+    mockCallGatewayTool.mockResolvedValueOnce({
+      id: "skill-workshop-runtime-approval",
+      decision: PluginApprovalResolutions.ALLOW_ONCE,
     });
 
     const result = await runBeforeToolCallHook({
@@ -823,8 +838,9 @@ describe("runBeforeToolCallHook — embedded mode approvals", () => {
     expect(result).toEqual({
       blocked: false,
       params: { action: "apply", proposal_id: "weather-20260530-a1b2c3d4e5" },
+      approvalResolution: PluginApprovalResolutions.ALLOW_ONCE,
     });
-    expect(mockCallGatewayTool).not.toHaveBeenCalled();
+    expect(mockCallGatewayTool).toHaveBeenCalledTimes(1);
     expect(runBeforeToolCallMock).not.toHaveBeenCalled();
   });
 

--- a/src/skills/workshop/config.ts
+++ b/src/skills/workshop/config.ts
@@ -18,7 +18,7 @@ const DEFAULT_CONFIG: SkillWorkshopConfig = {
     enabled: false,
   },
   allowSymlinkTargetWrites: false,
-  approvalPolicy: "pending",
+  approvalPolicy: "auto",
   maxPending: 50,
   maxSkillBytes: 40_000,
 };
@@ -34,7 +34,7 @@ function readInteger(value: unknown, fallback: number, min: number, max: number)
 }
 
 function readApprovalPolicy(value: unknown, fallback: SkillWorkshopConfig["approvalPolicy"]) {
-  return value === "auto" ? "auto" : fallback;
+  return value === "pending" || value === "auto" ? value : fallback;
 }
 
 export function resolveSkillWorkshopConfig(config?: OpenClawConfig): SkillWorkshopConfig {

--- a/src/skills/workshop/policy.test.ts
+++ b/src/skills/workshop/policy.test.ts
@@ -15,6 +15,13 @@ import { proposeCreateSkill } from "./service.js";
 
 const tempDirs = createTrackedTempDirs();
 let testState: OpenClawTestState;
+const pendingApprovalConfig = {
+  skills: {
+    workshop: {
+      approvalPolicy: "pending" as const,
+    },
+  },
+};
 
 beforeEach(async () => {
   testState = await createOpenClawTestState({
@@ -48,6 +55,7 @@ describe("resolveSkillWorkshopToolApproval", () => {
       toolName: "skill_workshop",
       toolParams: { action: "apply", proposal_id: proposal.record.id },
       workspaceDir,
+      config: pendingApprovalConfig,
     });
 
     expect(result?.requireApproval).toMatchObject({
@@ -70,6 +78,7 @@ describe("resolveSkillWorkshopToolApproval", () => {
       toolName: "skill_workshop",
       toolParams: { action: "reject", name: "weather-helper" },
       workspaceDir,
+      config: pendingApprovalConfig,
     });
     expect(resolvedByName?.requireApproval?.description).toContain(
       `Proposal ID: ${proposal.record.id}`,
@@ -105,6 +114,7 @@ describe("resolveSkillWorkshopToolApproval", () => {
       toolName: "skill_workshop",
       toolParams: { action: "apply", proposal_id: proposal.record.id },
       workspaceDir,
+      config: pendingApprovalConfig,
     });
     const approvalDescription = result?.requireApproval?.description ?? "";
 
@@ -137,6 +147,7 @@ describe("resolveSkillWorkshopToolApproval", () => {
       toolName: "skill_workshop",
       toolParams: { action: "apply", proposal_id: proposal.record.id },
       workspaceDir,
+      config: pendingApprovalConfig,
     });
     const lines = result?.requireApproval?.description.split("\n") ?? [];
 
@@ -158,6 +169,7 @@ describe("resolveSkillWorkshopToolApproval", () => {
       toolName: "skill_workshop",
       toolParams: { action: "apply", proposal_id: "missing-20260705-0000000000" },
       workspaceDir,
+      config: pendingApprovalConfig,
     });
 
     expect(result?.requireApproval?.description).toBe(
@@ -168,10 +180,20 @@ describe("resolveSkillWorkshopToolApproval", () => {
     const withoutWorkspace = await resolveSkillWorkshopToolApproval({
       toolName: "skill_workshop",
       toolParams: { action: "apply", proposal_id: "any-proposal" },
+      config: pendingApprovalConfig,
     });
     expect(withoutWorkspace?.requireApproval?.description).toBe(
       "Apply a pending workspace skill proposal into live workspace skills.",
     );
+  });
+
+  it("allows lifecycle actions without approval by default", async () => {
+    await expect(
+      resolveSkillWorkshopToolApproval({
+        toolName: "skill_workshop",
+        toolParams: { action: "apply", proposal_id: "weather-20260530-a1b2c3d4e5" },
+      }),
+    ).resolves.toBeUndefined();
   });
 
   it("uses runtime config when lifecycle hook config is absent", async () => {
@@ -191,7 +213,7 @@ describe("resolveSkillWorkshopToolApproval", () => {
     ).resolves.toBeUndefined();
   });
 
-  it("keeps approval pending when runtime config loading throws", async () => {
+  it("keeps the default auto policy when runtime config loading throws", async () => {
     const sharedAgentDir = testState.agentDir("shared");
     await testState.writeConfig({
       agents: {
@@ -205,12 +227,12 @@ describe("resolveSkillWorkshopToolApproval", () => {
 
     try {
       expect(() => getRuntimeConfig()).toThrow(/duplicate agentDir/i);
-      const result = await resolveSkillWorkshopToolApproval({
-        toolName: "skill_workshop",
-        toolParams: { action: "quarantine", proposal_id: "weather-20260530-a1b2c3d4e5" },
-      });
-
-      expect(result?.requireApproval?.title).toBe("Quarantine workspace skill proposal");
+      await expect(
+        resolveSkillWorkshopToolApproval({
+          toolName: "skill_workshop",
+          toolParams: { action: "quarantine", proposal_id: "weather-20260530-a1b2c3d4e5" },
+        }),
+      ).resolves.toBeUndefined();
     } finally {
       consoleError.mockRestore();
     }

--- a/src/skills/workshop/policy.ts
+++ b/src/skills/workshop/policy.ts
@@ -147,7 +147,7 @@ function resolveApprovalConfig(config?: OpenClawConfig): OpenClawConfig | undefi
     return config;
   }
   // Explicit hook config wins. Missing hook config may happen on agent paths;
-  // unreadable runtime config keeps the default pending approval gate.
+  // unreadable runtime config cannot supply an explicit pending override.
   try {
     return getRuntimeConfig();
   } catch {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where agent-initiated Skill Workshop `apply`, `reject`, and `quarantine` actions required an additional Gateway execution approval unless operators explicitly enabled automatic approval.

This interrupted the expected workflow where a user reviews a proposal and tells the agent to apply it directly.

## Why This Change Was Made

Skill Workshop lifecycle actions now use `auto` as the default approval policy. Operators who require an additional approval gate can explicitly set:

```json
{
  "skills": {
    "workshop": {
      "approvalPolicy": "pending"
    }
  }
}
```

The agent must still have access to the `skill_workshop` tool and must explicitly call the lifecycle action. This change does not expand tool permissions or enable autonomous proposal application.

## User Impact

Users can tell an agent to apply, reject, or quarantine a Skill Workshop proposal without receiving a redundant Gateway approval request.

Existing configurations that explicitly use `approvalPolicy: "pending"` remain approval-gated.

## Evidence

- Live CodexClaw verification confirmed that an agent-initiated apply proceeds without a Gateway approval when `approvalPolicy` is omitted.
- Regression coverage verifies automatic approval as the default.
- Coverage verifies that explicit `pending` configuration still requires approval.
- Embedded-agent coverage verifies both direct and runtime-configured policy resolution.
- Skill Workshop, self-learning, and skills configuration documentation now describe the updated default.
