### PR TITLE
style(auto-reply): restore runtime-mode formatting

### DIFF
--- a/src/auto-reply/reply/reply-config-runtime-mode.ts
+++ b/src/auto-reply/reply/reply-config-runtime-mode.ts
@@ -22,6 +22,6 @@ export function usesFullReplyRuntime(config: unknown): boolean {
   return Boolean(
     config &&
     typeof config === "object" &&
-    replyConfigRuntimeModes.get(config as OpenClawConfig) === "full"
+    replyConfigRuntimeModes.get(config as OpenClawConfig) === "full",
   );
 }


### PR DESCRIPTION
## What Problem This Solves

Full formatting checks on current `main` fail on `src/auto-reply/reply/reply-config-runtime-mode.ts`, blocking unrelated pull requests in both `check-docs` and `check-lint`.

## Why This Change Was Made

Restore the trailing comma required by oxfmt. This is a formatting-only repair with no runtime behavior change.

## User Impact

None. CI can validate and land unrelated changes again.

## Evidence

- `node_modules/.bin/oxfmt --check --threads=1 src/auto-reply/reply/reply-config-runtime-mode.ts`
- `git diff --check`
- Fresh autoreview: no accepted or actionable findings
- Prior failing CI run: https://github.com/openclaw/openclaw/actions/runs/29353233059
