### PR TITLE
refactor(ws): use native socket contracts

### DIFF
--- a/extensions/browser/src/browser/cdp.helpers.internal.test.ts
+++ b/extensions/browser/src/browser/cdp.helpers.internal.test.ts
@@ -440,29 +440,6 @@ describe("cdp.helpers internal", () => {
         }),
       ).rejects.toThrow(/callback boom/);
     });
-
-    it("tolerates a ws.close() that throws in the cleanup finally", async () => {
-      // Force ws.close() to throw by wrapping withCdpSocket against a live
-      // server but monkey-patching the ws prototype momentarily. We do this
-      // via a callback that pre-empts close by calling terminate() first.
-      const server = await startWsServer();
-      wss = server.wss;
-      server.wss.on("connection", (socket) => {
-        socket.on("message", (raw) => {
-          const msg = JSON.parse(rawDataToString(raw)) as { id?: number };
-          socket.send(JSON.stringify({ id: msg.id, result: {} }));
-        });
-      });
-      // The fn throws AFTER sending so both the catch (closeWithError) and
-      // the finally ws.close() run. ws.close() on an already-closed socket
-      // is a no-op but exercises the try/catch in the finally.
-      await expect(
-        withCdpSocket(server.url, async (send) => {
-          await send("Test.ok");
-          throw new Error("fn post-send boom");
-        }),
-      ).rejects.toThrow(/fn post-send boom/);
-    });
   });
 
   describe("createCdpSender error/close event forwarding", () => {

--- a/extensions/browser/src/browser/cdp.helpers.ts
+++ b/extensions/browser/src/browser/cdp.helpers.ts
@@ -16,6 +16,7 @@ import {
   type SsrFPolicy,
   resolvePinnedHostnameWithPolicy,
 } from "../infra/net/ssrf.js";
+import { rawDataToString } from "../infra/ws.js";
 import { redactToolPayloadText } from "../logging/redact.js";
 import {
   getDirectAgentForCdp,
@@ -174,22 +175,6 @@ function decodeUrlUserInfo(value: string): string {
   }
 }
 
-function rawCdpMessageToString(data: WebSocket.RawData): string {
-  if (typeof data === "string") {
-    return data;
-  }
-  if (Buffer.isBuffer(data)) {
-    return data.toString("utf8");
-  }
-  if (Array.isArray(data)) {
-    return Buffer.concat(data).toString("utf8");
-  }
-  if (ArrayBuffer.isView(data)) {
-    return Buffer.from(data.buffer, data.byteOffset, data.byteLength).toString("utf8");
-  }
-  return Buffer.from(data).toString("utf8");
-}
-
 /** Merge URL basic-auth credentials into headers without overriding explicit auth. */
 export function getHeadersWithAuth(url: string, headers: Record<string, string> = {}) {
   const mergedHeaders = { ...headers };
@@ -322,11 +307,7 @@ function createCdpSender(ws: WebSocket, opts?: { commandTimeoutMs?: number }) {
       p.reject(err);
     }
     pending.clear();
-    try {
-      ws.close();
-    } catch {
-      // ignore
-    }
+    ws.close();
   };
 
   ws.on("error", (err) => {
@@ -340,7 +321,7 @@ function createCdpSender(ws: WebSocket, opts?: { commandTimeoutMs?: number }) {
 
   ws.on("message", (data) => {
     try {
-      const parsed = JSON.parse(rawCdpMessageToString(data)) as CdpResponse;
+      const parsed = JSON.parse(rawDataToString(data)) as CdpResponse;
       if (typeof parsed.id !== "number") {
         return;
       }
@@ -563,11 +544,6 @@ export async function withCdpSocket<T>(
       // non-Error wrap is defensive and structurally unreachable.
       /* c8 ignore next */
       closeWithError(err instanceof Error ? err : new Error(String(err)));
-      try {
-        ws.close();
-      } catch {
-        // ignore
-      }
       if (attempt >= maxHandshakeRetries || !shouldRetryCdpHandshakeError(err)) {
         throw err;
       }
@@ -583,11 +559,7 @@ export async function withCdpSocket<T>(
       closeWithError(err instanceof Error ? err : new Error(String(err)));
       throw err;
     } finally {
-      try {
-        ws.close();
-      } catch {
-        // ignore
-      }
+      ws.close();
     }
   }
 

--- a/extensions/browser/src/browser/chrome.diagnostics.ts
+++ b/extensions/browser/src/browser/chrome.diagnostics.ts
@@ -229,20 +229,12 @@ async function diagnoseCdpHealthCommand(
       settled = true;
       clearTimeout(timer);
       ws.off("message", onMessage);
-      try {
-        ws.close();
-      } catch {
-        // ignore
-      }
+      ws.close();
       resolve(value);
     };
     const timer = setTimeout(
       () => {
-        try {
-          ws.terminate();
-        } catch {
-          // ignore
-        }
+        ws.terminate();
         finish({
           ok: false,
           code: opened ? "websocket_health_command_timeout" : "websocket_handshake_failed",

--- a/extensions/browser/src/browser/chrome.ts
+++ b/extensions/browser/src/browser/chrome.ts
@@ -854,24 +854,12 @@ function buildOpenClawChromeLaunchArgs(params: {
 async function canOpenWebSocket(url: string, timeoutMs: number): Promise<boolean> {
   return new Promise<boolean>((resolve) => {
     const ws = openCdpWebSocket(url, { handshakeTimeoutMs: timeoutMs });
-    let settled = false;
-    const finish = (value: boolean) => {
-      if (settled) {
-        return;
-      }
-      settled = true;
-      resolve(value);
-    };
     ws.once("open", () => {
-      try {
-        ws.close();
-      } catch {
-        // ignore
-      }
-      finish(true);
+      ws.close();
+      resolve(true);
     });
-    ws.once("error", () => finish(false));
-    ws.once("close", () => finish(false));
+    ws.once("error", () => resolve(false));
+    ws.once("close", () => resolve(false));
   });
 }
 

--- a/extensions/browser/src/browser/extension-relay/relay-server.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-server.ts
@@ -15,6 +15,7 @@ import type { Duplex } from "node:stream";
 import { safeEqualSecret } from "openclaw/plugin-sdk/security-runtime";
 import { WebSocketServer, type WebSocket } from "ws";
 import { isLoopbackHost } from "../../gateway/net.js";
+import { rawDataToString } from "../../infra/ws.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { ExtensionRelayBridge } from "./relay-bridge.js";
 
@@ -30,7 +31,7 @@ export const EXTENSION_RELAY_MAX_PAYLOAD_BYTES = 64 * 1024 * 1024;
 
 /** Wire an accepted extension WebSocket to a bridge (shared by loopback + gateway paths). */
 export function attachExtensionWebSocket(bridge: ExtensionRelayBridge, ws: WebSocket): void {
-  bindSocket(ws, bridge.attachExtensionSocket(toBridgeSocket(ws)));
+  bindSocket(ws, bridge.attachExtensionSocket(ws));
 }
 
 /** Running relay server handle owned by the profile runtime state. */
@@ -191,7 +192,7 @@ export async function startExtensionRelayServer(params: {
     }
     if (path === "/cdp") {
       wss.handleUpgrade(req, socket, head, (ws) => {
-        bindSocket(ws, bridge.attachCdpClientSocket(toBridgeSocket(ws)));
+        bindSocket(ws, bridge.attachCdpClientSocket(ws));
       });
       return;
     }
@@ -222,40 +223,12 @@ export async function startExtensionRelayServer(params: {
   };
 }
 
-function toBridgeSocket(ws: WebSocket) {
-  return {
-    send: (data: string) => {
-      if (ws.readyState === ws.OPEN) {
-        ws.send(data);
-      }
-    },
-    close: (code?: number, reason?: string) => {
-      try {
-        ws.close(code, reason);
-      } catch {
-        // already closing
-      }
-    },
-  };
-}
-
-/** Decode a ws frame (string | Buffer | Buffer[] | ArrayBuffer) to text. */
-function decodeWsData(data: import("ws").RawData | string): string {
-  if (typeof data === "string") {
-    return data;
-  }
-  if (Array.isArray(data)) {
-    return Buffer.concat(data).toString("utf8");
-  }
-  return Buffer.from(data as ArrayBuffer).toString("utf8");
-}
-
 function bindSocket(
   ws: WebSocket,
   handlers: { onMessage: (raw: string) => void; onClose: () => void },
 ): void {
   ws.on("message", (data) => {
-    handlers.onMessage(decodeWsData(data));
+    handlers.onMessage(rawDataToString(data));
   });
   ws.on("close", handlers.onClose);
   ws.on("error", (err) => {

--- a/extensions/canvas/src/host/server.ts
+++ b/extensions/canvas/src/host/server.ts
@@ -299,13 +299,7 @@ export async function createCanvasHostHandler(
     if (!wss) {
       return;
     }
-    for (const ws of wss.clients) {
-      try {
-        ws.send("reload");
-      } catch {
-        // ignore
-      }
-    }
+    wss.clients.forEach((ws) => ws.send("reload"));
   };
   const scheduleReload = () => {
     if (debounce) {
@@ -459,13 +453,7 @@ export async function createCanvasHostHandler(
       }
       watcherClosed = true;
       await watcher?.close().catch(() => {});
-      for (const ws of wss?.clients ?? []) {
-        try {
-          ws.terminate();
-        } catch {
-          // ignore
-        }
-      }
+      wss?.clients.forEach((ws) => ws.terminate());
       if (wss) {
         await new Promise<void>((resolve) => {
           wss.close(() => resolve());

--- a/extensions/voice-call/src/media-stream.ts
+++ b/extensions/voice-call/src/media-stream.ts
@@ -581,11 +581,7 @@ export class MediaStreamHandler {
       };
     }
     if (bufferedBeforeBytes > MAX_WS_BUFFERED_BYTES) {
-      try {
-        session.ws.close(1013, "Backpressure: send buffer exceeded");
-      } catch {
-        // Best-effort close; caller still receives sent:false.
-      }
+      session.ws.close(1013, "Backpressure: send buffer exceeded");
       return {
         sent: false,
         readyState,
@@ -598,11 +594,7 @@ export class MediaStreamHandler {
       session.ws.send(JSON.stringify(message));
       const bufferedAfterBytes = session.ws.bufferedAmount;
       if (bufferedAfterBytes > MAX_WS_BUFFERED_BYTES) {
-        try {
-          session.ws.close(1013, "Backpressure: send buffer exceeded");
-        } catch {
-          // Best-effort close; caller still receives sent:false.
-        }
+        session.ws.close(1013, "Backpressure: send buffer exceeded");
         return {
           sent: false,
           readyState,


### PR DESCRIPTION
## What Problem This Solves

Browser, Canvas, and Voice Call code wrapped `ws` lifecycle methods with duplicate state guards, adapters, decoders, and exception swallowing. Those layers duplicated behavior already guaranteed by the pinned `ws` contract and added 118 net lines.

## Why This Change Was Made

- Reuse the shared Browser `RawData` decoder instead of two local decoders.
- Pass accepted `WebSocket` instances directly through the relay's structural socket seam.
- Rely on native idempotent `close()` and `terminate()` behavior and accepted-socket `OPEN` state.
- Use Promise resolution idempotence in the reachability probe.
- Delete a test that claimed to force `close()` to throw but only exercised the documented no-op path.

The installed `ws@8.21.0` source and `@types/ws@8.18.1` declarations were inspected directly. All fixed close codes and reasons satisfy the dependency's validation contract.

## User Impact

No user-visible behavior change. WebSocket paths keep Buffer, Buffer array, ArrayBuffer, and typed-array decoding through the shared helper.

## Evidence

- Browser focused suite: 7 files, 168 tests passed.
- Voice Call focused suite: 22 tests passed.
- Canvas WebSocket lifecycle/reload tests: 3 passed; Canvas state-dir test: 1 passed.
- Structural `WebSocket` to relay-socket `tsgo` probe: passed.
- Scoped extension oxlint: passed.
- `git diff --check origin/main...HEAD`: passed.
- Fresh local and branch autoreview: clean.

The full Canvas test file has one unrelated existing hidden-watch-path assertion failure in untouched code that is byte-identical to `origin/main`; all three changed WebSocket scenarios pass. Hosted CI intentionally not awaited per maintainer direction.
