### PR TITLE
fix(qa-lab): prevent Telegram desktop API hangs

### DIFF
--- a/extensions/qa-lab/src/mantis/telegram-desktop-builder.runtime.test.ts
+++ b/extensions/qa-lab/src/mantis/telegram-desktop-builder.runtime.test.ts
@@ -119,6 +119,13 @@ describe("mantis Telegram desktop builder runtime", () => {
     expect(remoteScript).toContain("openclaw gateway run");
     expect(remoteScript).toContain("telegram-ready-message.json");
     expect(remoteScript).toContain("telegram-desktop-builder.mp4");
+    expect(remoteScript).toContain(
+      "const response = await fetch(`https://api.telegram.org/bot${token}/getMe`, {\n  signal: AbortSignal.timeout(15_000),\n});",
+    );
+    expect(remoteScript).toContain(
+      'const response = await fetch(`https://api.telegram.org/bot${token}/sendMessage`, {\n  method: "POST",\n  headers: { "content-type": "application/json" },\n  body: JSON.stringify({ chat_id: chatId, text, disable_notification: true }),\n  signal: AbortSignal.timeout(15_000),\n});',
+    );
+    expect(remoteScript?.match(/signal: AbortSignal\.timeout\(15_000\)/gu)?.length).toBe(2);
     expect(
       commands.some((entry) => entry.command === "/tmp/crabbox" && entry.args[0] === "stop"),
     ).toBe(false);

--- a/extensions/qa-lab/src/mantis/telegram-desktop-builder.runtime.ts
+++ b/extensions/qa-lab/src/mantis/telegram-desktop-builder.runtime.ts
@@ -397,7 +397,9 @@ qa_status=0
     fi
     driver_user_id="$(node --input-type=module >"$out/telegram-driver-getme.json" 2>"$out/telegram-driver-getme.err" <<'MANTIS_TELEGRAM_GETME'
 const token = process.env.OPENCLAW_MANTIS_TELEGRAM_DRIVER_BOT_TOKEN;
-const response = await fetch(\`https://api.telegram.org/bot\${token}/getMe\`);
+const response = await fetch(\`https://api.telegram.org/bot\${token}/getMe\`, {
+  signal: AbortSignal.timeout(15_000),
+});
 const body = await response.json();
 process.stdout.write(JSON.stringify({ ok: body.ok, id: body.result?.id, username: body.result?.username }));
 if (!body.ok || !body.result?.id) process.exit(1);
@@ -438,6 +440,7 @@ const response = await fetch(\`https://api.telegram.org/bot\${token}/sendMessage
   method: "POST",
   headers: { "content-type": "application/json" },
   body: JSON.stringify({ chat_id: chatId, text, disable_notification: true }),
+  signal: AbortSignal.timeout(15_000),
 });
 const body = await response.json();
 process.stdout.write(JSON.stringify({ ok: body.ok, message_id: body.result?.message_id }));


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where QA Lab Telegram desktop proofs could wait indefinitely when the Bot API stopped responding during driver identity or readiness-message checks.

## Why This Change Was Made

The generated remote script now gives `getMe` and `sendMessage` separate 15-second `AbortSignal.timeout` deadlines. Existing response artifacts, stderr capture, and nonzero failure behavior stay unchanged.

## User Impact

QA operators now get a bounded failure instead of a proof run hanging on either Telegram Bot API call.

## Evidence

Exact head: `955cc80c7c92a116ee81d162d04d94bc5d5c8f76`, replayed without behavior changes onto known-green main `7651ef5fca04f8263dd7f2d558d7c1425d60391e`.

- `node scripts/run-vitest.mjs extensions/qa-lab/src/mantis/telegram-desktop-builder.runtime.test.ts --run` - 2 tests passed.
- Secretless live probe to the documented Bot API route returned the expected `401 Unauthorized: invalid token specified`, confirming the current endpoint contract without exposing credentials. [Telegram Bot API](https://core.telegram.org/bots/api)
- Controlled no-response proof with the production deadline:

```json
{"elapsedMs":15005,"errorName":"TimeoutError","outcome":"aborted"}
```

- `oxfmt --check` and `git diff --check` passed.
- Fresh Claude Sonnet autoreview judged the patch correct; no accepted/actionable findings remain.
- Current exact-head GitHub rollup: 69 successful, 34 path-skipped, 0 failed, 0 pending.
- AI-assisted: implemented with Codex and reviewed with Claude. I inspected and understand the generated-script behavior.

Local proof used Node v22.22.0, slightly below the repository's v22.22.3 floor; GitHub CI is authoritative. Remote Testbox/Crabbox proof was unavailable because this checkout has no usable provider binary.
