### PR TITLE
fix(qa-lab): prevent Slack desktop auth hangs

### DIFF
--- a/extensions/qa-lab/src/mantis/slack-desktop-smoke.runtime.test.ts
+++ b/extensions/qa-lab/src/mantis/slack-desktop-smoke.runtime.test.ts
@@ -242,6 +242,12 @@ describe("mantis Slack desktop smoke runtime", () => {
     expect(remoteScript).toContain("Slack desktop screenshot is missing or empty");
     expect(remoteScript).not.toContain('test -s "$out/slack-desktop-smoke.png"');
     expect(remoteScript).toContain("OPENCLAW_MANTIS_SLACK_BROWSER_PROFILE_DIR");
+    expect(remoteScript)
+      .toContain(`const response = await fetch("https://slack.com/api/auth.test", {
+  method: "POST",
+  headers: { authorization: \`Bearer \${token}\` },
+  signal: AbortSignal.timeout(15_000),
+});`);
     const rsyncArgs = commands
       .filter((entry) => entry.command === "rsync")
       .flatMap((entry) => entry.args);

--- a/extensions/qa-lab/src/mantis/slack-desktop-smoke.runtime.ts
+++ b/extensions/qa-lab/src/mantis/slack-desktop-smoke.runtime.ts
@@ -622,6 +622,7 @@ const token = process.env.OPENCLAW_QA_SLACK_SUT_BOT_TOKEN || process.env.OPENCLA
 const response = await fetch("https://slack.com/api/auth.test", {
   method: "POST",
   headers: { authorization: \`Bearer \${token}\` },
+  signal: AbortSignal.timeout(15_000),
 });
 const body = await response.json();
 process.stdout.write(JSON.stringify({ ok: body.ok, team_id: body.team_id, user_id: body.user_id }));


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the QA Lab Slack desktop smoke could hang indefinitely while checking workspace authentication.

## Why This Change Was Made

The generated `auth.test` request now carries a 15-second `AbortSignal.timeout`. Its existing request method, authorization header, response parsing, and failure behavior are unchanged.

## User Impact

QA operators now get a bounded auth-check failure instead of a stalled desktop-smoke run.

## Evidence

- `node scripts/run-vitest.mjs extensions/qa-lab/src/mantis/slack-desktop-smoke.runtime.test.ts --run` - 18 tests passed after rebasing onto current `main`.
- Secretless live `POST https://slack.com/api/auth.test` returned `200 {"ok":false,"error":"not_authed"}`, confirming the current endpoint contract without exposing credentials. [Slack `auth.test`](https://api.slack.com/methods/auth.test)
- Controlled no-response proof with the production deadline:

```json
{"timeoutMs":15000,"elapsedMs":15004,"errorName":"TimeoutError","outcome":"aborted"}
```

- `oxfmt --check` and `git diff --check` passed.
- Fresh Claude Sonnet autoreview: patch correct, confidence 0.97, no findings.
- AI-assisted: implemented with Codex and reviewed with Claude. I inspected and understand the generated-script behavior.

Local proof used Node v22.22.0, slightly below the repository's v22.22.3 floor; CI remains authoritative. Remote Testbox/Crabbox proof was unavailable because the checkout has no installed Crabbox binary.
