### PR TITLE
fix(tokenjuice): avoid retaining raw compacted output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Tokenjuice exec compaction:** avoid retaining raw command output inside compacted middleware metadata, preventing large successful compactions from failing the middleware details-size guard.
 - **Agent git package identities:** strip refs before hosted-repository parsing and reject traversal segments so GitLab branch refs resolve to the canonical managed install path.
 - **Tlon custom S3 uploads:** pass storage endpoints through the AWS SDK's native parser so custom S3-compatible uploads no longer fail before presigning.
 - **Signal active-run controls:** keep authorized stop, status, approval, and queue-read controls responsive during active turns while preserving ordinary and stateful turns in canonical session admission, and cancel every pending group sender lane on stop. (#107422) Thanks @arduano.

--- a/extensions/tokenjuice/index.test.ts
+++ b/extensions/tokenjuice/index.test.ts
@@ -1,5 +1,6 @@
 // Tokenjuice tests cover index plugin behavior.
 import fs from "node:fs";
+import { createAgentToolResultMiddlewareRunner } from "openclaw/plugin-sdk/agent-harness";
 import { createTestPluginApi } from "openclaw/plugin-sdk/plugin-test-api";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -55,7 +56,7 @@ describe("tokenjuice plugin", () => {
     expect(registration?.[1]).toEqual({ runtimes: ["openclaw", "codex"] });
   });
 
-  it("synthesises exec fields when bash provides metadata-only details (no status)", async () => {
+  it("synthesises exec status when bash provides metadata-only details", async () => {
     let received:
       | {
           details: unknown;
@@ -89,14 +90,14 @@ describe("tokenjuice plugin", () => {
 
     expect(received?.details).toMatchObject({
       status: "completed",
-      aggregated: "file contents\n",
       exitCode: 0,
       truncation: { reason: "max_bytes" },
       fullOutputPath: "/tmp/out.txt",
     });
+    expect(received?.details).not.toHaveProperty("aggregated");
   });
 
-  it("passes through bash details that already have a status field unchanged", async () => {
+  it("passes through status metadata without duplicate aggregated output", async () => {
     let received:
       | {
           details: unknown;
@@ -132,7 +133,43 @@ describe("tokenjuice plugin", () => {
       { runtime: "openclaw" },
     );
 
-    expect(received?.details).toBe(existingDetails);
+    expect(received?.details).toEqual({
+      status: "completed",
+      exitCode: 0,
+      cwd: "/existing/cwd",
+    });
+    expect(received?.details).not.toBe(existingDetails);
+  });
+
+  it("keeps compacted exec results below the middleware details limit", async () => {
+    tokenjuiceFactory.mockImplementationOnce(
+      (api: { on: (event: string, handler: unknown) => void }) => {
+        api.on("tool_result", async (event: { details: Record<string, unknown> }) => ({
+          content: [{ type: "text", text: "compacted" }],
+          details: { ...event.details, tokenjuice: { compacted: true } },
+        }));
+      },
+    );
+
+    const runner = createAgentToolResultMiddlewareRunner({ runtime: "openclaw" }, [
+      createTokenjuiceAgentToolResultMiddleware(),
+    ]);
+    const result = await runner.applyToolResultMiddleware({
+      toolCallId: "tool-call-tokenjuice-large",
+      toolName: "exec",
+      args: { command: "seq 1 30000" },
+      result: {
+        content: [{ type: "text", text: "x".repeat(120_000) }],
+        details: undefined,
+      },
+    });
+
+    expect(result.content).toEqual([{ type: "text", text: "compacted" }]);
+    expect(result.details).toEqual({
+      status: "completed",
+      exitCode: 0,
+      tokenjuice: { compacted: true },
+    });
   });
 
   it.each([
@@ -216,10 +253,10 @@ describe("tokenjuice plugin", () => {
     expect(received?.toolName).toBe("bash");
     expect(received?.details).toMatchObject({
       status: "completed",
-      aggregated: "hello\n",
       exitCode: 0,
     });
     expect(received?.details).not.toHaveProperty("cwd");
+    expect(received?.details).not.toHaveProperty("aggregated");
     expect(result?.result.content).toEqual([{ type: "text", text: "compacted" }]);
   });
 });

--- a/extensions/tokenjuice/tool-result-middleware.ts
+++ b/extensions/tokenjuice/tool-result-middleware.ts
@@ -23,6 +23,13 @@ function normalizeDetails(
   event: AgentToolResultMiddlewareEvent,
   current: OpenClawAgentToolResult,
 ): unknown {
+  if (
+    (event.toolName !== "exec" && event.toolName !== "bash") ||
+    typeof event.args.command !== "string" ||
+    !event.args.command
+  ) {
+    return current.details;
+  }
   const metadata = isRecord(current.details) ? { ...current.details } : {};
   // Tokenjuice reads text content when `aggregated` is absent, then merges details
   // into its response. Drop the duplicate raw copy or compaction can exceed host limits.
@@ -61,6 +68,12 @@ export function createTokenjuiceAgentToolResultMiddleware(): AgentToolResultMidd
 
   return async (event) => {
     let current = event.result;
+    const workdir = event.args.workdir;
+    const cwd = event.cwd?.trim()
+      ? event.cwd
+      : typeof workdir === "string" && workdir.trim()
+        ? workdir
+        : process.cwd();
     for (const handler of handlers) {
       const next = await handler(
         {
@@ -70,7 +83,7 @@ export function createTokenjuiceAgentToolResultMiddleware(): AgentToolResultMidd
           details: normalizeDetails(event, current),
           isError: event.isError,
         },
-        { cwd: event.cwd?.trim() ? event.cwd : process.cwd() },
+        { cwd },
       );
       if (next) {
         current = Object.assign({}, current, {

--- a/extensions/tokenjuice/tool-result-middleware.ts
+++ b/extensions/tokenjuice/tool-result-middleware.ts
@@ -19,103 +19,33 @@ type TokenjuiceToolResultHandler = (
   ctx: { cwd: string },
 ) => Promise<Partial<OpenClawAgentToolResult> | void> | Partial<OpenClawAgentToolResult> | void;
 
-function readCwd(event: AgentToolResultMiddlewareEvent): string {
-  if (event.cwd?.trim()) {
-    return event.cwd;
-  }
-  const workdir = event.args.workdir;
-  if (typeof workdir === "string" && workdir.trim()) {
-    return workdir;
-  }
-  return process.cwd();
-}
-
-function readTextContent(content: OpenClawAgentToolResult["content"]): string {
-  if (typeof content === "string") {
-    return content;
-  }
-  if (!Array.isArray(content)) {
-    return "";
-  }
-  return content
-    .map((item) => {
-      if (typeof item === "string") {
-        return item;
-      }
-      if (item && typeof item === "object" && "text" in item && typeof item.text === "string") {
-        return item.text;
-      }
-      return "";
-    })
-    .filter(Boolean)
-    .join("\n");
-}
-
-function readCommand(args: Record<string, unknown>): string {
-  const command = args.command;
-  return typeof command === "string" ? command : "";
-}
-
-function hasStatus(details: Record<string, unknown>): boolean {
-  const status = details.status;
-  return typeof status === "string" && status.trim() !== "";
-}
-
-function hasFailureState(
-  event: AgentToolResultMiddlewareEvent,
-  details: Record<string, unknown> | undefined,
-): boolean {
-  const exitCode = details?.exitCode;
-  return (
-    event.isError === true ||
-    details?.ok === false ||
-    details?.success === false ||
-    details?.timedOut === true ||
-    Boolean(details?.error) ||
-    (typeof exitCode === "number" && Number.isFinite(exitCode) && exitCode !== 0)
-  );
-}
-
 function normalizeDetails(
   event: AgentToolResultMiddlewareEvent,
   current: OpenClawAgentToolResult,
 ): unknown {
-  const isExecLike = event.toolName === "exec" || event.toolName === "bash";
-  const details = isRecord(current.details) ? current.details : undefined;
-
-  if (!isExecLike || !readCommand(event.args)) {
-    return current.details;
-  }
+  const metadata = isRecord(current.details) ? { ...current.details } : {};
+  // Tokenjuice reads text content when `aggregated` is absent, then merges details
+  // into its response. Drop the duplicate raw copy or compaction can exceed host limits.
+  delete metadata.aggregated;
   // A concrete status is already canonical. Other terminal hints are preserved below
   // while supplying only the completed/failed status Tokenjuice requires.
-  if (details && hasStatus(details)) {
-    return current.details;
+  if (typeof metadata.status === "string" && metadata.status.trim()) {
+    return metadata;
   }
-  const aggregated = readTextContent(current.content);
-  if (!aggregated.trim()) {
-    return current.details;
-  }
-  const failed = hasFailureState(event, details);
-  const existingExitCode = details?.exitCode;
+  const rawExitCode = metadata.exitCode;
+  const failed =
+    event.isError === true ||
+    metadata.ok === false ||
+    metadata.success === false ||
+    metadata.timedOut === true ||
+    Boolean(metadata.error) ||
+    (typeof rawExitCode === "number" && Number.isFinite(rawExitCode) && rawExitCode !== 0);
   const exitCode =
-    typeof existingExitCode === "number" && Number.isFinite(existingExitCode)
-      ? existingExitCode
-      : failed
-        ? 1
-        : 0;
-  const synthesized = {
-    status: failed ? "failed" : "completed",
-    aggregated,
-    exitCode,
-  };
-  if (!details) {
-    return synthesized;
-  }
+    typeof rawExitCode === "number" && Number.isFinite(rawExitCode) ? rawExitCode : failed ? 1 : 0;
   return {
-    ...synthesized,
-    ...details,
-    status: synthesized.status,
-    exitCode: synthesized.exitCode,
+    ...metadata,
+    status: failed ? "failed" : "completed",
+    exitCode,
   };
 }
 
@@ -140,7 +70,7 @@ export function createTokenjuiceAgentToolResultMiddleware(): AgentToolResultMidd
           details: normalizeDetails(event, current),
           isError: event.isError,
         },
-        { cwd: readCwd(event) },
+        { cwd: event.cwd?.trim() ? event.cwd : process.cwd() },
       );
       if (next) {
         current = Object.assign({}, current, {


### PR DESCRIPTION
## What Problem This Solves

Tokenjuice compacted large exec output in `content`, but the OpenClaw adapter also copied the original output into `details.aggregated`. Tokenjuice merges supplied details into its compacted result, so sufficiently large successful compactions exceeded the host's 100 KB middleware-details limit and failed closed.

## Why This Change Was Made

Use Tokenjuice 0.8.1's native content extraction and cwd resolution instead of duplicating command, content, and cwd parsing in the adapter. The adapter now removes only the redundant `aggregated` copy before invoking Tokenjuice, preserves other metadata, and keeps the small status/exit-code normalization required for results without canonical exec details.

This removes 57 production lines and 19 lines overall.

## User Impact

Large exec and bash results can compact successfully without the raw output being retained in middleware metadata or converted into a generic post-processing failure.

## Evidence

- `node scripts/run-vitest.mjs extensions/tokenjuice/index.test.ts src/agents/harness/tool-result-middleware.test.ts` — 38 tests passed across 2 shards after the final rebase.
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json extensions/tokenjuice/tool-result-middleware.ts extensions/tokenjuice/index.test.ts` — passed.
- Direct Tokenjuice 0.8.1 probe: 13,892 raw characters compacted to 118 characters; removing only `aggregated` produced identical reducer/statistics while preserving status, exit code, cwd, and custom metadata.
- Tokenjuice contract checked at [v0.8.1: content fallback, workdir resolution, and detail merging](https://github.com/vincentkoc/tokenjuice/blob/v0.8.1/src/hosts/openclaw/extension.ts#L43-L140).
- Codex contract checked at `2f7d89b1419bf7064346855b0acde23514b1ebc5`: [exec aggregate shape](https://github.com/openai/codex/blob/2f7d89b1419bf7064346855b0acde23514b1ebc5/codex-rs/protocol/src/exec_output.rs#L39-L47), [authoritative function-output content items](https://github.com/openai/codex/blob/2f7d89b1419bf7064346855b0acde23514b1ebc5/codex-rs/protocol/src/models.rs#L1830-L1879), and [tool-result response construction](https://github.com/openai/codex/blob/2f7d89b1419bf7064346855b0acde23514b1ebc5/codex-rs/core/src/tools/context.rs#L95-L146).
- Fresh branch-wide autoreview: no accepted or actionable findings.
- Hosted CI intentionally not awaited per maintainer direction.
