### PR TITLE
fix(proxy): share canonical NO_PROXY matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Proxy bypass precedence:** honor blank lower-case `no_proxy` values shadowing upper-case `NO_PROXY` consistently with Undici, and reuse the canonical matcher for Telegram fallback selection.
 - **Tokenjuice exec compaction:** avoid retaining raw command output inside compacted middleware metadata, preventing large successful compactions from failing the middleware details-size guard.
 - **Agent git package identities:** strip refs before hosted-repository parsing and reject traversal segments so GitLab branch refs resolve to the canonical managed install path.
 - **Tlon custom S3 uploads:** pass storage endpoints through the AWS SDK's native parser so custom S3-compatible uploads no longer fail before presigning.

--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-b54488723b29d94400cf65abba859bab80cd3b1e3bf9f7104956242152470c39  plugin-sdk-api-baseline.json
-d96f25f59d60b3171bc139da39eed20dd5b46d271db0875bf002a546699d2ccb  plugin-sdk-api-baseline.jsonl
+9b7fffbbff226d95b445fea145ab18fe20ab301ebaf8688f09103f060b4b2a70  plugin-sdk-api-baseline.json
+4b34fa0d32983b75fa16553088bbe851b3e76f56713db2b5de36e045117bc854  plugin-sdk-api-baseline.jsonl

--- a/extensions/telegram/src/fetch.ts
+++ b/extensions/telegram/src/fetch.ts
@@ -9,6 +9,7 @@ import {
   createHttp1ProxyAgent,
   createPinnedLookup,
   hasEnvHttpProxyAgentConfigured,
+  matchesNoProxy,
   resolveEnvHttpProxyAgentOptions,
   resolveFetch,
   type PinnedDispatcherPolicy,
@@ -206,44 +207,6 @@ function buildTelegramConnectOptions(params: {
   }
 
   return connect;
-}
-
-function shouldBypassEnvProxyForTelegramApi(env: NodeJS.ProcessEnv = process.env): boolean {
-  const noProxyValue = env.no_proxy ?? env.NO_PROXY ?? "";
-  if (!noProxyValue) {
-    return false;
-  }
-  if (noProxyValue === "*") {
-    return true;
-  }
-  const targetHostname = normalizeLowercaseStringOrEmpty(TELEGRAM_API_HOSTNAME);
-  const targetPort = 443;
-  const noProxyEntries = noProxyValue.split(/[,\s]/);
-  for (const entry of noProxyEntries) {
-    if (!entry) {
-      continue;
-    }
-    const parsed = entry.match(/^(.+):(\d+)$/);
-    const parsedHostname = parsed?.[1];
-    const parsedPort = parsed?.[2];
-    if (parsed && (parsedHostname === undefined || parsedPort === undefined)) {
-      continue;
-    }
-    const entryHostname = normalizeLowercaseStringOrEmpty(
-      (parsedHostname ?? entry).replace(/^\*?\./, ""),
-    );
-    const entryPort = parsedPort === undefined ? 0 : Number.parseInt(parsedPort, 10);
-    if (entryPort && entryPort !== targetPort) {
-      continue;
-    }
-    if (
-      targetHostname === entryHostname ||
-      targetHostname.slice(-(entryHostname.length + 1)) === `.${entryHostname}`
-    ) {
-      return true;
-    }
-  }
-  return false;
 }
 
 function hasEnvHttpProxyForTelegramApi(env: NodeJS.ProcessEnv = process.env): boolean {
@@ -643,7 +606,7 @@ export function resolveTelegramTransport(
     proxyUrl: resolvedExplicitProxyUrl,
   });
   const defaultDispatcher = createTelegramDispatcher(defaultDispatcherResolution.policy);
-  const shouldBypassEnvProxy = shouldBypassEnvProxyForTelegramApi();
+  const shouldBypassEnvProxy = matchesNoProxy(`https://${TELEGRAM_API_HOSTNAME}`);
   const hasExplicitDnsResultOrder =
     (dnsDecision.source === "config" ||
       dnsDecision.source === `env:${TELEGRAM_DNS_RESULT_ORDER_ENV}`) &&

--- a/scripts/plugin-sdk-surface-report.mjs
+++ b/scripts/plugin-sdk-surface-report.mjs
@@ -211,13 +211,14 @@ export function readPluginSdkSurfaceBudgets(env = process.env) {
       "OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_EXPORTS",
       // +4: registerMcpServerConnectionResolver context/result/resolver/registration types (#106229).
       // +2: materializeRequesterScopedMcpToolsForHarnessRun (agent-harness-runtime + compat mirror).
-      10694,
+      // +1: matchesNoProxy exposes canonical Undici-compatible bypass selection to plugins.
+      10695,
       env,
     ),
     publicFunctionExports: readPluginSdkSurfaceBudgetEnv(
       "OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_FUNCTION_EXPORTS",
       // +2: materializeRequesterScopedMcpToolsForHarnessRun (agent-harness-runtime + compat mirror).
-      5381,
+      5382,
       env,
     ),
     publicDeprecatedExports: readPluginSdkSurfaceBudgetEnv(

--- a/src/infra/net/proxy-env.test.ts
+++ b/src/infra/net/proxy-env.test.ts
@@ -164,6 +164,18 @@ describe("matchesNoProxy", () => {
       expected: false,
     },
     {
+      name: "lets blank lower-case no_proxy shadow upper-case NO_PROXY",
+      url: "https://api.openai.com",
+      env: { no_proxy: "", NO_PROXY: "*" } as NodeJS.ProcessEnv,
+      expected: false,
+    },
+    {
+      name: "does not treat a whitespace-wrapped wildcard as global bypass",
+      url: "https://api.openai.com",
+      env: { NO_PROXY: " * " } as NodeJS.ProcessEnv,
+      expected: false,
+    },
+    {
       name: "matches wildcard",
       url: "https://api.openai.com/v1/chat",
       env: { NO_PROXY: "*" } as NodeJS.ProcessEnv,

--- a/src/infra/net/proxy-env.ts
+++ b/src/infra/net/proxy-env.ts
@@ -126,6 +126,7 @@ export function shouldUseEnvHttpProxyForUrl(
  * (`undici/lib/dispatcher/env-http-proxy-agent.js`):
  * - Entries separated by commas OR whitespace (undici splits on `/[,\s]/`)
  * - Case-insensitive
+ * - Lower-case `no_proxy` shadows upper-case `NO_PROXY`, including blank values
  * - Empty or missing → no bypass
  * - Bare `*` value → bypass everything
  * - Exact hostname match
@@ -147,7 +148,7 @@ export function shouldUseEnvHttpProxyForUrl(
  * SSRF bypass.
  */
 export function matchesNoProxy(targetUrl: string, env: NodeJS.ProcessEnv = process.env): boolean {
-  const raw = normalizeProxyEnvValue(env.no_proxy) ?? normalizeProxyEnvValue(env.NO_PROXY);
+  const raw = env.no_proxy ?? env.NO_PROXY ?? "";
   if (!raw) {
     return false;
   }

--- a/src/plugin-sdk/fetch-runtime.ts
+++ b/src/plugin-sdk/fetch-runtime.ts
@@ -18,6 +18,7 @@ export {
 export {
   hasEnvHttpProxyConfigured,
   hasEnvHttpProxyAgentConfigured,
+  matchesNoProxy,
   resolveEnvHttpProxyAgentOptions,
   resolveEnvHttpProxyUrl,
   shouldUseEnvHttpProxyForUrl,


### PR DESCRIPTION
## What Problem This Solves

OpenClaw maintained two NO_PROXY matchers. Telegram's copy drifted from the shared Undici-compatible path, while the shared matcher also normalized values too early: a blank lower-case `no_proxy` could incorrectly fall through to upper-case `NO_PROXY`, and whitespace-wrapped `*` could incorrectly become a global bypass.

## Why This Change Was Made

Use the raw environment precedence implemented by [Undici 8.5.0](https://github.com/nodejs/undici/blob/v8.5.0/lib/dispatcher/env-http-proxy-agent.js): lower-case wins even when blank, and only a bare raw `*` is the global wildcard. Export that canonical matcher through the plugin SDK and delete Telegram's duplicate implementation.

This removes 36 production lines and 21 lines overall while keeping one tested contract.

## User Impact

- Blank lower-case `no_proxy` now correctly shadows upper-case `NO_PROXY`.
- Whitespace-wrapped `*` no longer bypasses every proxy target.
- Telegram fallback selection now follows the same matcher as the rest of OpenClaw.

## Evidence

- `node scripts/run-vitest.mjs src/infra/net/proxy-env.test.ts src/plugin-sdk/fetch-runtime.test.ts extensions/telegram/src/fetch.test.ts` — 102 tests passed across 3 shards.
- `node --max-old-space-size=8192 scripts/plugin-sdk-surface-report.mjs --check` — passed.
- `node --max-old-space-size=8192 --import tsx scripts/generate-plugin-sdk-api-baseline.ts --check` — passed.
- Scoped oxlint for core, Telegram, and the surface-report script — passed.
- Fresh local and branch autoreview — no accepted or actionable findings.
- Live Telegram proof unavailable: no runtime token was present, and approved secret lookup timed out before any credential was read.
- Hosted CI intentionally not awaited per maintainer direction.
