### PR TITLE
refactor(zalouser): use native typing API

### DIFF
--- a/extensions/zalouser/src/zalo-js.ts
+++ b/extensions/zalouser/src/zalo-js.ts
@@ -98,13 +98,6 @@ const groupContextCache = new Map<string, { value: ZaloGroupContext; expiresAt: 
 
 type AccountInfoResponse = Awaited<ReturnType<API["fetchAccountInfo"]>>;
 
-type ApiTypingCapability = {
-  sendTypingEvent: (
-    threadId: string,
-    type?: (typeof ThreadType)[keyof typeof ThreadType],
-  ) => Promise<unknown>;
-};
-
 type StoredZaloCredentials = {
   imei: string;
   cookie: Credentials["cookie"];
@@ -1388,11 +1381,7 @@ export async function sendZaloTypingEvent(
   }
   await withZaloApi(profile, async (api) => {
     const type = options.isGroup ? ThreadType.Group : ThreadType.User;
-    if ("sendTypingEvent" in api && typeof api.sendTypingEvent === "function") {
-      await (api as API & ApiTypingCapability).sendTypingEvent(trimmedThreadId, type);
-      return;
-    }
-    throw new Error("Zalo typing indicator is not supported by current API session");
+    await api.sendTypingEvent(trimmedThreadId, type);
   });
 }
 


### PR DESCRIPTION
## What Problem This Solves

The Zalouser typing path kept a local capability type, runtime method probe, assertion, and fallback error for a method guaranteed by the pinned dependency.

## Why This Change Was Made

Use the native [`zca-js@2.1.2`](https://github.com/RFS-ADRENO/zca-js/tree/v2.1.2) `API.sendTypingEvent` contract directly. Both login paths construct `API`; its type requires the method and its constructor always installs the factory.

This removes 11 production lines without changing arguments or error propagation.

## User Impact

None expected. Valid Zalo sessions follow the same typing request path; impossible compatibility scaffolding is gone.

## Evidence

- Direct dependency inspection: `dist/apis.d.ts` requires `sendTypingEvent`, `dist/apis.js` assigns it in the constructor, and the factory signature matches the existing call.
- `node scripts/run-vitest.mjs extensions/zalouser/src/zalo-js.credentials.test.ts extensions/zalouser/src/send.test.ts extensions/zalouser/src/zca-client.test.ts extensions/zalouser/src/monitor.group-gating.test.ts` — 53 tests passed.
- Package-boundary TypeScript contract probe — zero diagnostics.
- Scoped oxlint, oxfmt, and `git diff --check` — passed.
- Fresh local and branch autoreview — no accepted or actionable findings.
- No live Zalo session proof; this is a behavior-neutral dependency-contract cleanup.
- Hosted CI intentionally not awaited per maintainer direction.
