### PR TITLE
test: preload provider auth parity plugins

### DIFF
--- a/test/plugins/bundled-provider-auth-literal-parity.test.ts
+++ b/test/plugins/bundled-provider-auth-literal-parity.test.ts
@@ -2,7 +2,8 @@
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { afterAll, describe, expect, it } from "vitest";
+import pLimit from "p-limit";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { listBundledPluginMetadata } from "../../src/plugins/bundled-plugin-metadata.js";
 import type { PluginManifest } from "../../src/plugins/manifest.js";
 import type {
@@ -32,12 +33,14 @@ type ParityCase = {
   setupEnvVars: readonly string[];
 };
 
+type PluginRegister = (api: ReturnType<typeof createCapturedPluginRegistration>["api"]) => void;
+
 type PluginEntryModule = {
   default?: {
     id?: string;
-    register?: (api: ReturnType<typeof createCapturedPluginRegistration>["api"]) => void;
+    register?: PluginRegister;
   };
-  register?: (api: ReturnType<typeof createCapturedPluginRegistration>["api"]) => void;
+  register?: PluginRegister;
 };
 
 function isApiKeyStyleChoice(
@@ -69,9 +72,7 @@ function listParityCases(): ParityCase[] {
   });
 }
 
-async function loadPluginRegister(
-  pluginId: string,
-): Promise<(api: ReturnType<typeof createCapturedPluginRegistration>["api"]) => void> {
+async function loadPluginRegister(pluginId: string): Promise<PluginRegister> {
   // Dynamic import keeps this file out of the unit-fast lane: loading built
   // plugin dists pulls large module graphs into the shared worker cache and
   // breaks co-resident vi.mock-based unit tests (observed with memory-host-sdk).
@@ -157,6 +158,26 @@ const parityCases = listParityCases().toSorted((left, right) => {
 });
 
 const probeAgentDir = mkdtempSync(path.join(tmpdir(), "openclaw-auth-parity-"));
+const PLUGIN_LOAD_CONCURRENCY = 5;
+const parityPluginIds = [...new Set(parityCases.map((entry) => entry.pluginId))];
+const registerResultByPluginId = new Map<string, Promise<PromiseSettledResult<PluginRegister>>>();
+
+beforeAll(() => {
+  // Bound only module loading. Auth probes stay serial because provider setup
+  // can log or inspect the shared probe directory.
+  const limitPluginLoad = pLimit(PLUGIN_LOAD_CONCURRENCY);
+  for (const pluginId of parityPluginIds) {
+    // Settle each preload independently so one hung or rejected plugin cannot
+    // suppress parity coverage for plugins that loaded successfully.
+    registerResultByPluginId.set(
+      pluginId,
+      limitPluginLoad(() => loadPluginRegister(pluginId)).then(
+        (value): PromiseFulfilledResult<PluginRegister> => ({ status: "fulfilled", value }),
+        (reason): PromiseRejectedResult => ({ status: "rejected", reason }),
+      ),
+    );
+  }
+});
 
 afterAll(() => {
   rmSync(probeAgentDir, { recursive: true, force: true });
@@ -172,7 +193,17 @@ describe("bundled provider manifest↔runtime auth literal parity", () => {
     "$pluginId $providerId/$methodId optionKey=$optionKey",
     { timeout: PARITY_TIMEOUT_MS },
     async (parityCase) => {
-      const register = await loadPluginRegister(parityCase.pluginId);
+      const registerResultPromise = registerResultByPluginId.get(parityCase.pluginId);
+      if (!registerResultPromise) {
+        throw new Error(`bundled plugin ${parityCase.pluginId} was not preloaded`);
+      }
+      const registerResult = await registerResultPromise;
+      if (registerResult.status === "rejected") {
+        throw new Error(`bundled plugin ${parityCase.pluginId} preload failed`, {
+          cause: registerResult.reason,
+        });
+      }
+      const register = registerResult.value;
       const captured = createCapturedPluginRegistration({
         id: parityCase.pluginId,
         name: parityCase.pluginId,


### PR DESCRIPTION
## What Problem This Solves

The bundled provider auth parity suite loaded the same plugin entry module once per parity case. Its 72 cases repeatedly traversed large bundled plugin module graphs, making it a tooling-shard hotspot.

## Why This Change Was Made

Preload each unique plugin register callback once with bounded concurrency, then reuse the settled result from each serial parity case. Import failures and hangs remain isolated to the affected plugin, while auth probes stay serial because provider setup can log or inspect shared probe state.

## User Impact

Faster CI for bundled provider auth parity coverage. Runtime behavior and test coverage are unchanged. Test-only change; no changelog entry.

## Evidence

- Fresh Testbox baseline: 72/72 passed, Vitest 28.30s.
- Same-box counterbalanced runs: baseline 29.46s then optimized 17.13s; optimized 16.34s then baseline 17.94s.
- Final rebased-head Testbox: 72/72 passed, Vitest 28.60s, and the changed gate passed.
- Blacksmith proof: https://github.com/openclaw/openclaw/actions/runs/29361680373
- Exact-head hosted CI: https://github.com/openclaw/openclaw/actions/runs/29361290981
- Fresh whole-branch autoreview: clean, no accepted/actionable findings.
