### PR TITLE
refactor(bonjour): privatize process error classification

### DIFF
--- a/extensions/bonjour/src/ciao.ts
+++ b/extensions/bonjour/src/ciao.ts
@@ -13,7 +13,7 @@ const CIAO_NETMASK_ASSERTION_MESSAGE_RE =
 const CIAO_INTERFACE_ENUMERATION_FAILURE_RE = /\bUV_INTERFACE_ADDRESSES\b/u;
 
 /** Known ciao process-level errors that OpenClaw handles specially. */
-export type CiaoProcessErrorClassification =
+type CiaoProcessErrorClassification =
   | { kind: "netmask-assertion"; formatted: string }
   | { kind: "interface-enumeration-failure"; formatted: string };
 


### PR DESCRIPTION
## Summary

- make the same-file-only Bonjour process error classification type module-private
- prevent a new production Knip finding without growing the dead-export baseline

## Testing

- Blacksmith Testbox `tbx_01kxgzw17mg7md5s4av9jbfz1p`: baseline regeneration byte-stable at 502; `pnpm deadcode:exports` exact
- fresh autoreview: clean, confidence 0.99
