### PR TITLE
fix(ci): repair full release validation dispatch

### DIFF
--- a/.github/workflows/full-release-validation.yml
+++ b/.github/workflows/full-release-validation.yml
@@ -779,6 +779,7 @@ jobs:
           MODE: ${{ inputs.mode }}
           RELEASE_PROFILE: ${{ inputs.release_profile }}
           RUN_RELEASE_SOAK: ${{ inputs.run_release_soak || inputs.release_profile == 'stable' || inputs.release_profile == 'full' }}
+          ALLOW_UNRELEASED_CHANGELOG: ${{ inputs.target_context_ref == '' && (inputs.allow_unreleased_changelog || inputs.ref == 'main' || inputs.ref == 'refs/heads/main') }}
           RERUN_GROUP: ${{ inputs.rerun_group }}
           LIVE_SUITE_FILTER: ${{ inputs.live_suite_filter }}
           CROSS_OS_SUITE_FILTER: ${{ inputs.cross_os_suite_filter }}

--- a/scripts/full-release-validation-at-sha.mjs
+++ b/scripts/full-release-validation-at-sha.mjs
@@ -123,8 +123,16 @@ export function parseArgs(argv) {
       continue;
     }
     if (arg === "--") {
-      for (const extra of argv.slice(i + 1)) {
-        const assignment = extra.startsWith("-f") ? extra.slice(2).trim() : extra;
+      const extras = argv.slice(i + 1);
+      for (let extraIndex = 0; extraIndex < extras.length; extraIndex += 1) {
+        const extra = extras[extraIndex];
+        let assignment;
+        if (extra === "-f") {
+          assignment = readOptionValue(extras, extraIndex, extra);
+          extraIndex += 1;
+        } else {
+          assignment = extra.startsWith("-f") ? extra.slice(2).trim() : extra;
+        }
         const [key, ...valueParts] = assignment.split("=");
         if (!key || valueParts.length === 0) {
           throw new Error(`Unsupported extra argument after --: ${extra}`);

--- a/test/scripts/full-release-validation-at-sha.test.ts
+++ b/test/scripts/full-release-validation-at-sha.test.ts
@@ -42,6 +42,17 @@ describe("full-release-validation-at-sha", () => {
     });
   });
 
+  it("accepts documented -f assignments after the option separator", () => {
+    expect(
+      parseArgs(["--", "-f", "release_profile=full", "-fmode=linux", "provider=anthropic"]).inputs,
+    ).toMatchObject({
+      mode: "linux",
+      provider: "anthropic",
+      release_profile: "full",
+    });
+    expect(() => parseArgs(["--", "-f"])).toThrow("-f requires a value");
+  });
+
   it("infers the release profile from the target package version", () => {
     const readVersion = (version: string) => () => JSON.stringify({ version });
 

--- a/test/scripts/plugin-prerelease-test-plan.test.ts
+++ b/test/scripts/plugin-prerelease-test-plan.test.ts
@@ -659,7 +659,7 @@ describe("scripts/lib/plugin-prerelease-test-plan.mjs", () => {
 
   it("allows Unreleased notes only for current-tree release checks", () => {
     const workflow = parse(readFileSync(".github/workflows/openclaw-release-checks.yml", "utf8"));
-    const fullReleaseSource = readFileSync(".github/workflows/full-release-validation.yml", "utf8");
+    const fullReleaseWorkflow = readFullReleaseValidationWorkflow();
     const resolveTarget = workflow.jobs.resolve_target;
     const captureInputs = resolveTarget.steps.find(
       (step: WorkflowStep) => step.name === "Capture selected inputs",
@@ -694,9 +694,12 @@ describe("scripts/lib/plugin-prerelease-test-plan.mjs", () => {
     expect(workflow.jobs.docker_e2e_release_checks.with.allow_unreleased_changelog).toBe(
       currentTreeAllowance,
     );
-    expect(fullReleaseSource).toContain(
-      "ALLOW_UNRELEASED_CHANGELOG: ${{ inputs.target_context_ref == '' && (inputs.allow_unreleased_changelog || inputs.ref == 'main' || inputs.ref == 'refs/heads/main') }}",
+    const fullReleaseAllowance =
+      "${{ inputs.target_context_ref == '' && (inputs.allow_unreleased_changelog || inputs.ref == 'main' || inputs.ref == 'refs/heads/main') }}";
+    const releaseChecksDispatch = fullReleaseWorkflow.jobs.release_checks.steps.find(
+      (step: WorkflowStep) => step.name === "Dispatch and monitor release checks",
     );
+    expect(releaseChecksDispatch?.env?.ALLOW_UNRELEASED_CHANGELOG).toBe(fullReleaseAllowance);
   });
 
   it("keeps runtime tool coverage blocking in release checks", () => {


### PR DESCRIPTION
## What Problem This Solves

Full Release Validation had two deterministic dispatch failures. The SHA helper documented workflow inputs as `-- -f key=value` but rejected the separated `-f` token. After dispatching with the compact form, the parent release-check job referenced `ALLOW_UNRELEASED_CHANGELOG` under `set -u` without defining that environment variable.

## Why This Change Was Made

The post-separator parser now consumes `-f` and its following assignment as one input. Compact `-fkey=value` and bare `key=value` forms remain supported.

The release-check dispatch step now receives the same current-tree-only Unreleased allowance already computed for the parent summary. Its parsed workflow test asserts the exact step environment rather than a loose source substring.

## User Impact

Maintainers can copy the documented Full Release Validation command directly, and current-main validation reaches the release/live/Docker/QA child instead of aborting before dispatch. Canonical release contexts remain strict.

## Evidence

- Before: `Unsupported extra argument after --: -f`
- Before: [Full Release Validation 29361231463](https://github.com/openclaw/openclaw/actions/runs/29361231463) — `ALLOW_UNRELEASED_CHANGELOG: unbound variable`
- Blacksmith Testbox `tbx_01kxh0wvfjjrjagd54n29hke3k`: [29361145366](https://github.com/openclaw/openclaw/actions/runs/29361145366) — 13/13 tests, formatting, exact dry-run invocation
- Blacksmith Testbox `tbx_01kxh1brjy8xyg3skmv09nr382`: [29361650470](https://github.com/openclaw/openclaw/actions/runs/29361650470) — 25/25 workflow/helper tests and formatting
- Exact-head hosted CI: [29361761539](https://github.com/openclaw/openclaw/actions/runs/29361761539) — green at `e8910f3acff2200101c8c528bf92e720f3d91b96`
- Fresh autoreview: final whole branch clean at 0.93
- `git diff --check`: passed

No agent transcript attached, per maintainer direction.
