### PR TITLE
refactor(markdown): use yaml document nodes

### DIFF
--- a/packages/markdown-core/src/frontmatter.test.ts
+++ b/packages/markdown-core/src/frontmatter.test.ts
@@ -115,11 +115,14 @@ Body text`;
   });
 
   it("ignores non-delimiter closing prefixes", () => {
-    const content = `---
+    for (const closing of ["---not", "---\u2028Body text"]) {
+      const content = `---
 name: nope
----not
+${closing}
 Body text`;
-    expect(parseFrontmatterBlock(content)).toStrictEqual({});
+      expect(parseFrontmatterBlock(content)).toStrictEqual({});
+      expect(stripFrontmatterBlock(content)).toBe(content);
+    }
   });
 
   it("accepts delimiter lines with trailing whitespace", () => {

--- a/packages/markdown-core/src/frontmatter.ts
+++ b/packages/markdown-core/src/frontmatter.ts
@@ -1,13 +1,7 @@
 // Markdown Core module implements frontmatter behavior.
-import YAML from "yaml";
+import { isMap, isNode, parseDocument } from "yaml";
 
 type ParsedFrontmatter = Record<string, string>;
-
-type ParsedFrontmatterLineEntry = {
-  value: string;
-  kind: "inline" | "multiline";
-  rawInline: string;
-};
 
 type ParsedYamlValue = {
   value: string;
@@ -15,13 +9,8 @@ type ParsedYamlValue = {
 };
 
 function stripQuotes(value: string): string {
-  if (
-    (value.startsWith('"') && value.endsWith('"')) ||
-    (value.startsWith("'") && value.endsWith("'"))
-  ) {
-    return value.slice(1, -1);
-  }
-  return value;
+  const quote = value.at(0);
+  return (quote === '"' || quote === "'") && value.at(-1) === quote ? value.slice(1, -1) : value;
 }
 
 function coerceYamlFrontmatterValue(value: unknown): ParsedYamlValue | undefined {
@@ -29,23 +18,14 @@ function coerceYamlFrontmatterValue(value: unknown): ParsedYamlValue | undefined
     return undefined;
   }
   if (typeof value === "string") {
-    return {
-      value: value.trim(),
-      kind: "scalar",
-    };
+    return { value: value.trim(), kind: "scalar" };
   }
   if (typeof value === "number" || typeof value === "boolean") {
-    return {
-      value: String(value),
-      kind: "scalar",
-    };
+    return { value: String(value), kind: "scalar" };
   }
   if (typeof value === "object") {
     try {
-      return {
-        value: JSON.stringify(value),
-        kind: "structured",
-      };
+      return { value: JSON.stringify(value), kind: "structured" };
     } catch {
       return undefined;
     }
@@ -53,138 +33,94 @@ function coerceYamlFrontmatterValue(value: unknown): ParsedYamlValue | undefined
   return undefined;
 }
 
-function parseYamlFrontmatter(block: string): Record<string, ParsedYamlValue> | null {
-  try {
-    const parsed = YAML.parse(block, { schema: "core" }) as unknown;
-    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-      return null;
+function parseLineFrontmatter(block: string): ParsedFrontmatter {
+  const result: ParsedFrontmatter = {};
+  const lines = block.split("\n");
+
+  for (let i = 0; i < lines.length; i += 1) {
+    const match = lines.at(i)?.match(/^([\w-]+):\s*(.*)$/);
+    const key = match?.[1];
+    const rawValue = match?.[2];
+    if (!key || rawValue === undefined) {
+      continue;
     }
-    const result: Record<string, ParsedYamlValue> = {};
-    for (const [rawKey, value] of Object.entries(parsed as Record<string, unknown>)) {
-      const key = rawKey.trim();
-      if (!key) {
+
+    let value = rawValue.trim();
+    if (!value && /^[ \t]/.test(lines.at(i + 1) ?? "")) {
+      const valueLines: string[] = [];
+      while (i + 1 < lines.length) {
+        const line = lines.at(i + 1);
+        if (line === undefined || (line && !/^[ \t]/.test(line))) {
+          break;
+        }
+        valueLines.push(line);
+        i += 1;
+      }
+      value = valueLines.join("\n").trim();
+    } else {
+      value = stripQuotes(value);
+    }
+
+    if (value) {
+      result[key] = value;
+    }
+  }
+
+  return result;
+}
+
+function parseYamlFrontmatter(block: string): ParsedFrontmatter {
+  const fallback = parseLineFrontmatter(block);
+  try {
+    const doc = parseDocument(block, { schema: "core", prettyErrors: false });
+    if (doc.errors.length > 0 || !isMap(doc.contents)) {
+      return fallback;
+    }
+
+    const parsed = doc.toJS() as unknown;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return fallback;
+    }
+
+    const inlineColonKeys = new Set<string>();
+    for (const pair of doc.contents.items) {
+      if (!isNode(pair.key)) {
         continue;
       }
-      const coerced = coerceYamlFrontmatterValue(value);
+      const start = pair.key.range?.[0];
+      if (start === undefined) {
+        continue;
+      }
+      const lineEnd = block.indexOf("\n", start);
+      const line = block.slice(start, lineEnd === -1 ? block.length : lineEnd);
+      const match = line.match(/^([\w-]+):\s*(.*)$/);
+      if (match?.[1] && match[2]?.includes(":")) {
+        inlineColonKeys.add(match[1]);
+      }
+    }
+
+    const result: ParsedFrontmatter = {};
+    for (const [rawKey, value] of Object.entries(parsed as Record<string, unknown>)) {
+      const key = rawKey.trim();
+      const coerced = key ? coerceYamlFrontmatterValue(value) : undefined;
       if (!coerced) {
         continue;
       }
-      result[key] = coerced;
+      result[key] =
+        coerced.kind === "structured" && inlineColonKeys.has(key) && Object.hasOwn(fallback, key)
+          ? fallback[key]
+          : coerced.value;
+    }
+
+    for (const [key, value] of Object.entries(fallback)) {
+      if (!Object.hasOwn(result, key)) {
+        result[key] = value;
+      }
     }
     return result;
   } catch {
-    return null;
+    return fallback;
   }
-}
-
-function extractMultiLineValue(
-  lines: string[],
-  startIndex: number,
-): {
-  value: string;
-  linesConsumed: number;
-} {
-  const valueLines: string[] = [];
-  let i = startIndex + 1;
-
-  while (i < lines.length) {
-    const line = lines.at(i);
-    if (line === undefined) {
-      break;
-    }
-    if (line.length > 0 && !line.startsWith(" ") && !line.startsWith("\t")) {
-      break;
-    }
-    valueLines.push(line);
-    i += 1;
-  }
-
-  const combined = valueLines.join("\n").trim();
-  return { value: combined, linesConsumed: i - startIndex };
-}
-
-function parseLineFrontmatter(block: string): Record<string, ParsedFrontmatterLineEntry> {
-  const result: Record<string, ParsedFrontmatterLineEntry> = {};
-  const lines = block.split("\n");
-  let i = 0;
-
-  while (i < lines.length) {
-    const line = lines.at(i);
-    if (line === undefined) {
-      break;
-    }
-    const match = line.match(/^([\w-]+):\s*(.*)$/);
-    if (!match) {
-      i += 1;
-      continue;
-    }
-
-    const [, key, rawInlineValue] = match;
-    if (!key || rawInlineValue === undefined) {
-      i += 1;
-      continue;
-    }
-    const inlineValue = rawInlineValue.trim();
-
-    if (!inlineValue && i + 1 < lines.length) {
-      const nextLine = lines.at(i + 1);
-      if (nextLine?.startsWith(" ") || nextLine?.startsWith("\t")) {
-        const { value, linesConsumed } = extractMultiLineValue(lines, i);
-        if (value) {
-          result[key] = {
-            value,
-            kind: "multiline",
-            rawInline: inlineValue,
-          };
-        }
-        i += linesConsumed;
-        continue;
-      }
-    }
-
-    const value = stripQuotes(inlineValue);
-    if (value) {
-      result[key] = {
-        value,
-        kind: "inline",
-        rawInline: inlineValue,
-      };
-    }
-    i += 1;
-  }
-
-  return result;
-}
-
-function lineFrontmatterToPlain(
-  parsed: Record<string, ParsedFrontmatterLineEntry>,
-): ParsedFrontmatter {
-  const result: ParsedFrontmatter = {};
-  for (const [key, entry] of Object.entries(parsed)) {
-    result[key] = entry.value;
-  }
-  return result;
-}
-
-function isYamlBlockScalarIndicator(value: string): boolean {
-  return /^[|>][+-]?(\d+)?[+-]?$/.test(value);
-}
-
-function shouldPreferInlineLineValue(params: {
-  lineEntry: ParsedFrontmatterLineEntry;
-  yamlValue: ParsedYamlValue;
-}): boolean {
-  const { lineEntry, yamlValue } = params;
-  if (yamlValue.kind !== "structured") {
-    return false;
-  }
-  if (lineEntry.kind !== "inline") {
-    return false;
-  }
-  if (isYamlBlockScalarIndicator(lineEntry.rawInline)) {
-    return false;
-  }
-  return lineEntry.value.includes(":");
 }
 
 export type ExtractedFrontmatterBlock = {
@@ -199,43 +135,25 @@ function normalizeFrontmatterContent(content: string): string {
     .replace(/\r/g, "\n");
 }
 
-function isFrontmatterDelimiterLine(line: string): boolean {
-  return line.trimEnd() === "---";
-}
+const FRONTMATTER_CLOSING_DELIMITER = /(?:^|\n)---[^\S\n]*(?:\n|(?![\s\S]))/;
 
 function extractFrontmatterBlockFromNormalized(
   normalized: string,
 ): ExtractedFrontmatterBlock | undefined {
-  const firstLineEnd = normalized.indexOf("\n");
-  const firstLine = firstLineEnd === -1 ? normalized : normalized.slice(0, firstLineEnd);
-  if (!isFrontmatterDelimiterLine(firstLine)) {
+  const opening = /^---[^\S\n]*\n/.exec(normalized);
+  if (!opening) {
     return undefined;
   }
-  if (firstLineEnd === -1) {
+  const blockStart = opening[0].length;
+  const tail = normalized.slice(blockStart);
+  const closing = FRONTMATTER_CLOSING_DELIMITER.exec(tail);
+  if (!closing) {
     return undefined;
   }
-
-  const blockStart = firstLineEnd + 1;
-  let lineStart = blockStart;
-  while (lineStart <= normalized.length) {
-    const lineEnd = normalized.indexOf("\n", lineStart);
-    const currentLineEnd = lineEnd === -1 ? normalized.length : lineEnd;
-    const line = normalized.slice(lineStart, currentLineEnd);
-    if (isFrontmatterDelimiterLine(line)) {
-      const blockEnd = lineStart > blockStart ? lineStart - 1 : lineStart;
-      const bodyStart = lineEnd === -1 ? normalized.length : lineEnd + 1;
-      return {
-        block: normalized.slice(blockStart, blockEnd),
-        body: normalized.slice(bodyStart),
-      };
-    }
-    if (lineEnd === -1) {
-      break;
-    }
-    lineStart = lineEnd + 1;
-  }
-
-  return undefined;
+  return {
+    block: tail.slice(0, closing.index),
+    body: tail.slice(closing.index + closing[0].length),
+  };
 }
 
 /** Splits a complete leading YAML frontmatter block from its Markdown body. */
@@ -253,33 +171,5 @@ export function stripFrontmatterBlock(content: string): string {
 /** Parses leading YAML frontmatter into string values used by skill and metadata loaders. */
 export function parseFrontmatterBlock(content: string): ParsedFrontmatter {
   const block = extractFrontmatterBlock(content)?.block;
-  if (!block) {
-    return {};
-  }
-
-  const lineParsed = parseLineFrontmatter(block);
-  const yamlParsed = parseYamlFrontmatter(block);
-  if (yamlParsed === null) {
-    return lineFrontmatterToPlain(lineParsed);
-  }
-
-  const merged: ParsedFrontmatter = {};
-  for (const [key, yamlValue] of Object.entries(yamlParsed)) {
-    merged[key] = yamlValue.value;
-    const lineEntry = lineParsed[key];
-    if (!lineEntry) {
-      continue;
-    }
-    if (shouldPreferInlineLineValue({ lineEntry, yamlValue })) {
-      merged[key] = lineEntry.value;
-    }
-  }
-
-  for (const [key, lineEntry] of Object.entries(lineParsed)) {
-    if (!Object.hasOwn(merged, key)) {
-      merged[key] = lineEntry.value;
-    }
-  }
-
-  return merged;
+  return block ? parseYamlFrontmatter(block) : {};
 }


### PR DESCRIPTION
## What Problem This Solves

The shared Markdown frontmatter helper manually duplicated parsing, coercion, multiline extraction, and delimiter scanning that the pinned `yaml` package already exposes through its document and node APIs. That left a large internal parser surface to maintain.

## Why This Change Was Made

Parse valid frontmatter once with `parseDocument`, preserve the dependency's whole-document alias guard via `toJS`, and use map-key source ranges only for the existing lenient inline-colon fallback. Keep the compact line parser solely for malformed-but-tolerated metadata. Replace the delimiter loop with an explicit LF-boundary matcher.

The implementation was checked directly against `yaml@2.9.0` source, types, and runtime node-range behavior. It removes 107 net lines without changing the exported API.

## User Impact

No intended behavior change. Skill, hook, plugin-command, and shared metadata loaders retain valid YAML parsing plus the existing lenient fallback. Complete delimiter lines remain required, including around Unicode line separators.

## Evidence

- 58 focused tests across Markdown core and all direct frontmatter consumers.
- Type-aware Oxc lint, formatting, and `git diff --check` pass on the exact rebased head.
- Differential corpus: 1,000 repository Markdown files / 3,000 API comparisons, zero differences.
- Generated corpus: 6,000 frontmatter cases / 18,000 API comparisons, zero differences.
- Fresh local and exact-branch autoreviews report no accepted/actionable findings.
- Hosted CI intentionally not awaited per maintainer direction.
