### PR TITLE
fix(line): run post-ack webhook processing on its own admitted work root

### DIFF
--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-b4512610eb85bd1f2b1298edc93df408e1cff54b344ed9592fe69a4eda047dd1  plugin-sdk-api-baseline.json
-3d108005341642d35ba10a02e1106178e1f20f9d564295704be473006ff35ced  plugin-sdk-api-baseline.jsonl
+b8431b55f28440c269cec5afd95c3ef7cd7eb2b443c5cf713fcbaefacc5e0634  plugin-sdk-api-baseline.json
+6dc1e7d7015b7cd5451d0e716bea212f6824da0e71f311f62aad46948d039524  plugin-sdk-api-baseline.jsonl

--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -7394,6 +7394,7 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
   - H3: Capability registration
   - H3: Tools and commands
   - H3: Infrastructure
+  - H4: Post-ack webhook work
   - H4: Requester-scoped MCP connections
   - H3: Host hooks for workflow plugins
   - H3: Gateway discovery registration

--- a/docs/plugins/sdk-overview.md
+++ b/docs/plugins/sdk-overview.md
@@ -223,11 +223,12 @@ void runDetachedWebhookWork(() => processWebhookEvent(event)).catch((error) => {
 ```
 
 Call `runDetachedWebhookWork(...)` synchronously while the HTTP request is still
-admitted. The callback starts immediately on an independent root, and the
-returned promise adopts its result; callers still own rejection handling. This
-keeps post-ack queue work accepted and makes restart or suspension drains wait
-for it. Handlers that await all processing before returning do not need this
-helper.
+admitted. The helper reserves an independent root immediately, then starts the
+callback in the next microtask so the request handler can write its
+acknowledgement first. The returned promise adopts the callback result; callers
+still own rejection handling. This keeps post-ack queue work accepted and makes
+restart or suspension drains wait for it. Handlers that await all processing
+before returning do not need this helper.
 
 #### Requester-scoped MCP connections
 

--- a/docs/plugins/sdk-overview.md
+++ b/docs/plugins/sdk-overview.md
@@ -209,6 +209,26 @@ advertised node command.
 | `api.registerNodeInvokePolicy(policy)`          | Allowlist/approval policy for node-invoked commands                    |
 | `api.registerSecurityAuditCollector(collector)` | Findings collector for `openclaw security audit`                       |
 
+#### Post-ack webhook work
+
+Webhook routes that acknowledge a request before processing finishes must move
+that detached work onto its own tracked admission root:
+
+```typescript
+import { runDetachedWebhookWork } from "openclaw/plugin-sdk/webhook-request-guards";
+
+void runDetachedWebhookWork(() => processWebhookEvent(event)).catch((error) => {
+  runtime.error?.(`webhook dispatch failed: ${String(error)}`);
+});
+```
+
+Call `runDetachedWebhookWork(...)` synchronously while the HTTP request is still
+admitted. The callback starts immediately on an independent root, and the
+returned promise adopts its result; callers still own rejection handling. This
+keeps post-ack queue work accepted and makes restart or suspension drains wait
+for it. Handlers that await all processing before returning do not need this
+helper.
+
 #### Requester-scoped MCP connections
 
 Keep the MCP server **identity** static (name, tool filter) in `mcp.servers` or a

--- a/docs/plugins/sdk-subpaths.md
+++ b/docs/plugins/sdk-subpaths.md
@@ -235,7 +235,7 @@ usage endpoint failed or returned no usable usage data.
     | `plugin-sdk/ssrf-runtime` | Pinned-dispatcher, SSRF-guarded fetch, SSRF error, and SSRF policy helpers |
     | `plugin-sdk/secret-input` | Secret input parsing helpers |
     | `plugin-sdk/webhook-ingress` | Webhook request/target helpers and raw websocket/body coercion |
-    | `plugin-sdk/webhook-request-guards` | Request body size/timeout helpers |
+    | `plugin-sdk/webhook-request-guards` | Request body size/timeout helpers and `runDetachedWebhookWork` for tracked post-ack processing |
   </Accordion>
 
   <Accordion title="Runtime and storage subpaths">

--- a/extensions/googlechat/src/monitor-webhook.test.ts
+++ b/extensions/googlechat/src/monitor-webhook.test.ts
@@ -6,12 +6,14 @@ import type { WebhookTarget } from "./monitor-types.js";
 import type { GoogleChatEvent } from "./types.js";
 
 const readJsonWebhookBodyOrReject = vi.hoisted(() => vi.fn());
+const runDetachedWebhookWork = vi.hoisted(() => vi.fn((run: () => Promise<void>) => run()));
 const resolveWebhookTargetWithAuthOrReject = vi.hoisted(() => vi.fn());
 const withResolvedWebhookRequestPipeline = vi.hoisted(() => vi.fn());
 const verifyGoogleChatRequest = vi.hoisted(() => vi.fn());
 
 vi.mock("openclaw/plugin-sdk/webhook-request-guards", () => ({
   readJsonWebhookBodyOrReject,
+  runDetachedWebhookWork,
 }));
 
 vi.mock("openclaw/plugin-sdk/webhook-targets", () => ({
@@ -294,6 +296,7 @@ describe("googlechat monitor webhook", () => {
       },
       target,
     );
+    expect(runDetachedWebhookWork).toHaveBeenCalledTimes(1);
     expect(res.statusCode).toBe(200);
     expect(res.headers["Content-Type"]).toBe("application/json");
     expect(res.body).toBe("{}");

--- a/extensions/googlechat/src/monitor-webhook.ts
+++ b/extensions/googlechat/src/monitor-webhook.ts
@@ -6,8 +6,11 @@ import {
   resolveRequestClientIp,
   type FixedWindowRateLimiter,
 } from "openclaw/plugin-sdk/webhook-ingress";
-import type { WebhookInFlightLimiter } from "openclaw/plugin-sdk/webhook-request-guards";
-import { readJsonWebhookBodyOrReject } from "openclaw/plugin-sdk/webhook-request-guards";
+import {
+  readJsonWebhookBodyOrReject,
+  runDetachedWebhookWork,
+  type WebhookInFlightLimiter,
+} from "openclaw/plugin-sdk/webhook-request-guards";
 import {
   resolveWebhookTargetWithAuthOrReject,
   withResolvedWebhookRequestPipeline,
@@ -345,11 +348,15 @@ export function createGoogleChatWebhookRequestHandler(params: {
 
         const dispatchTarget = selectedTarget;
         dispatchTarget.statusSink?.({ lastInboundAt: Date.now() });
-        params.processEvent(parsedEvent, dispatchTarget).catch((err: unknown) => {
-          dispatchTarget.runtime.error?.(
-            `[${dispatchTarget.account.accountId}] Google Chat webhook failed: ${String(err)}`,
-          );
-        });
+        // Reserve the detached task before the HTTP admission is released;
+        // otherwise later queue work inherits a released admission root.
+        void runDetachedWebhookWork(() => params.processEvent(parsedEvent, dispatchTarget)).catch(
+          (err: unknown) => {
+            dispatchTarget.runtime.error?.(
+              `[${dispatchTarget.account.accountId}] Google Chat webhook failed: ${String(err)}`,
+            );
+          },
+        );
 
         res.statusCode = 200;
         res.setHeader("Content-Type", "application/json");

--- a/extensions/line/src/monitor.lifecycle.test.ts
+++ b/extensions/line/src/monitor.lifecycle.test.ts
@@ -15,6 +15,7 @@ const {
   createLineBotMock,
   createLineNodeWebhookHandlerMock,
   registerWebhookTargetWithPluginRouteMock,
+  runDetachedWebhookWorkMock,
   unregisterHttpMock,
 } = vi.hoisted(() => ({
   createLineBotMock: vi.fn(() => ({
@@ -25,6 +26,7 @@ const {
     vi.fn<LineNodeWebhookHandler>(async () => {}),
   ),
   registerWebhookTargetWithPluginRouteMock: vi.fn(),
+  runDetachedWebhookWorkMock: vi.fn(),
   unregisterHttpMock: vi.fn(),
 }));
 
@@ -100,6 +102,17 @@ vi.mock("openclaw/plugin-sdk/webhook-ingress", async () => {
   };
 });
 
+vi.mock("openclaw/plugin-sdk/webhook-request-guards", async () => {
+  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/webhook-request-guards")>(
+    "openclaw/plugin-sdk/webhook-request-guards",
+  );
+  runDetachedWebhookWorkMock.mockImplementation(actual.runDetachedWebhookWork);
+  return {
+    ...actual,
+    runDetachedWebhookWork: runDetachedWebhookWorkMock,
+  };
+});
+
 vi.mock("./webhook-node.js", async () => {
   const actual = await vi.importActual<typeof import("./webhook-node.js")>("./webhook-node.js");
   return {
@@ -148,6 +161,7 @@ describe("monitorLineProvider lifecycle", () => {
     vi.doUnmock("openclaw/plugin-sdk/reply-runtime");
     vi.doUnmock("openclaw/plugin-sdk/runtime-env");
     vi.doUnmock("openclaw/plugin-sdk/webhook-ingress");
+    vi.doUnmock("openclaw/plugin-sdk/webhook-request-guards");
     vi.doUnmock("./webhook-node.js");
     vi.doUnmock("./auto-reply-delivery.js");
     vi.doUnmock("./markdown-to-line.js");
@@ -163,6 +177,9 @@ describe("monitorLineProvider lifecycle", () => {
       account: { accountId: "default" },
       handleWebhook: vi.fn<LineHandleWebhook>(),
     }));
+    // Clear call history only; the implementation was wired to the actual
+    // helper once in the module mock factory.
+    runDetachedWebhookWorkMock.mockClear();
     innerLineWebhookHandlerMock = vi.fn<LineNodeWebhookHandler>(async () => {});
     createLineNodeWebhookHandlerMock
       .mockReset()
@@ -395,6 +412,39 @@ describe("monitorLineProvider lifecycle", () => {
       handleWebhook: ReturnType<typeof vi.fn>;
     };
     expect(res.statusCode).toBe(200);
+    expect(bot.handleWebhook).toHaveBeenCalledTimes(1);
+
+    monitor.stop();
+  });
+
+  it("runs matched event processing on a detached admitted work root", async () => {
+    const monitor = await monitorLineProvider({
+      channelAccessToken: "token",
+      channelSecret: "secret", // pragma: allowlist secret
+      accountId: "default",
+      config: {} as OpenClawConfig,
+      runtime: {} as RuntimeEnv,
+    });
+
+    const route = requireRegisteredRoute();
+    const payload = JSON.stringify({ events: [{ type: "message" }] });
+    const signature = crypto.createHmac("SHA256", "secret").update(payload).digest("base64");
+    const req = Object.assign(createMockIncomingRequest([payload]), {
+      method: "POST",
+      headers: { "x-line-signature": signature },
+    }) as unknown as IncomingMessage;
+    const res = createRouteResponse();
+
+    await route.handler(req, res);
+
+    const bot = createLineBotMock.mock.results[0]?.value as {
+      handleWebhook: ReturnType<typeof vi.fn>;
+    };
+    expect(res.statusCode).toBe(200);
+    // The request admission is released once the route handler returns, so
+    // event processing dispatched on the inherited chain would be refused as
+    // draining; the dispatch must reserve its own root.
+    expect(runDetachedWebhookWorkMock).toHaveBeenCalledTimes(1);
     expect(bot.handleWebhook).toHaveBeenCalledTimes(1);
 
     monitor.stop();

--- a/extensions/line/src/monitor.ts
+++ b/extensions/line/src/monitor.ts
@@ -20,6 +20,7 @@ import {
 import {
   beginWebhookRequestPipelineOrReject,
   createWebhookInFlightLimiter,
+  runDetachedWebhookWork,
 } from "openclaw/plugin-sdk/webhook-request-guards";
 import { resolveDefaultLineAccountId } from "./accounts.js";
 import { deliverLineAutoReply } from "./auto-reply-delivery.js";
@@ -385,13 +386,15 @@ export async function monitorLineProvider(
 
           if (body.events && body.events.length > 0) {
             logVerbose(`line: received ${body.events.length} webhook events`);
-            void Promise.resolve()
-              .then(() => match.target.bot.handleWebhook(body))
-              .catch((err: unknown) => {
+            // Detach event processing from the request admission before the ack
+            // releases it; an inherited released admission refuses queue work.
+            void runDetachedWebhookWork(() => match.target.bot.handleWebhook(body)).catch(
+              (err: unknown) => {
                 match.target.runtime.error?.(
                   danger(`line webhook dispatch failed: ${String(err)}`),
                 );
-              });
+              },
+            );
           }
         } catch (err) {
           if (isRequestBodyLimitError(err, "PAYLOAD_TOO_LARGE")) {

--- a/extensions/line/src/webhook-node.test.ts
+++ b/extensions/line/src/webhook-node.test.ts
@@ -4,9 +4,26 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import type { NextFunction, Request, Response } from "express";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { createMockIncomingRequest } from "openclaw/plugin-sdk/test-env";
-import { describe, expect, it, vi } from "vitest";
+import { afterAll, describe, expect, it, vi } from "vitest";
+
+const runDetachedWebhookWorkSpy = vi.hoisted(() => vi.fn());
+vi.mock("openclaw/plugin-sdk/webhook-request-guards", async () => {
+  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/webhook-request-guards")>(
+    "openclaw/plugin-sdk/webhook-request-guards",
+  );
+  runDetachedWebhookWorkSpy.mockImplementation(actual.runDetachedWebhookWork);
+  return {
+    ...actual,
+    runDetachedWebhookWork: runDetachedWebhookWorkSpy,
+  };
+});
+
 import { createLineNodeWebhookHandler, readLineWebhookRequestBody } from "./webhook-node.js";
 import { createLineWebhookMiddleware } from "./webhook.js";
+
+afterAll(() => {
+  vi.doUnmock("openclaw/plugin-sdk/webhook-request-guards");
+});
 
 const sign = (body: string, secret: string) =>
   crypto.createHmac("SHA256", secret).update(body).digest("base64");
@@ -396,6 +413,21 @@ describe("createLineNodeWebhookHandler", () => {
     expect(bot.handleWebhook).not.toHaveBeenCalled();
   });
 
+  it("dispatches signed POST event processing through the detached admitted work root", async () => {
+    runDetachedWebhookWorkSpy.mockClear();
+    const rawBody = JSON.stringify({ events: [{ type: "message" }] });
+    const { bot, handler, secret } = createPostWebhookTestHarness(rawBody);
+
+    const { res } = createRes();
+    await runSignedPost({ handler, rawBody, secret, res });
+
+    expect(res.statusCode).toBe(200);
+    // The request admission is released once the handler returns; the inherited
+    // chain would be refused as draining, so dispatch must reserve its own root.
+    expect(runDetachedWebhookWorkSpy).toHaveBeenCalledTimes(1);
+    expect(bot.handleWebhook).toHaveBeenCalledTimes(1);
+  });
+
   it("uses strict pre-auth limits for signed POST requests", async () => {
     const rawBody = JSON.stringify({ events: [{ type: "message" }] });
     const bot = { handleWebhook: vi.fn(async () => {}) };
@@ -526,6 +558,16 @@ describe("createLineWebhookMiddleware", () => {
     expect(onEvents).toHaveBeenCalledTimes(1);
     const payload = firstParsedPayload(onEvents, "LINE middleware payload");
     expect(payload.events).toEqual(expectedEvents);
+  });
+
+  it("dispatches middleware event processing through the detached admitted work root", async () => {
+    runDetachedWebhookWorkSpy.mockClear();
+    const { res, onEvents } = await invokeWebhook({
+      body: JSON.stringify({ events: [{ type: "message" }] }),
+    });
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(runDetachedWebhookWorkSpy).toHaveBeenCalledTimes(1);
+    expect(onEvents).toHaveBeenCalledTimes(1);
   });
 
   it("rejects invalid JSON payloads", async () => {

--- a/extensions/line/src/webhook-node.ts
+++ b/extensions/line/src/webhook-node.ts
@@ -10,6 +10,7 @@ import {
   isRequestBodyLimitError,
   readRequestBodyWithLimit,
   requestBodyErrorToText,
+  runDetachedWebhookWork,
 } from "openclaw/plugin-sdk/webhook-request-guards";
 import { parseLineWebhookBody, validateLineSignature } from "./webhook-utils.js";
 
@@ -127,9 +128,11 @@ export function createLineNodeWebhookHandler(params: {
 
       if (body.events && body.events.length > 0) {
         logVerbose(`line: received ${body.events.length} webhook events`);
-        void Promise.resolve()
-          .then(() => params.bot.handleWebhook(body))
-          .catch((err: unknown) => logLineWebhookDispatchError(params.runtime, err));
+        // Detach event processing from the request admission before the ack
+        // releases it; an inherited released admission refuses queue work.
+        void runDetachedWebhookWork(() => params.bot.handleWebhook(body)).catch((err: unknown) =>
+          logLineWebhookDispatchError(params.runtime, err),
+        );
       }
     } catch (err) {
       await receiveContext?.nack(err);

--- a/extensions/line/src/webhook.ts
+++ b/extensions/line/src/webhook.ts
@@ -6,6 +6,7 @@ import {
   type MessageReceiveContext,
 } from "openclaw/plugin-sdk/channel-outbound";
 import { danger, logVerbose, type RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
+import { runDetachedWebhookWork } from "openclaw/plugin-sdk/webhook-request-guards";
 import { parseLineWebhookBody, validateLineSignature } from "./webhook-utils.js";
 
 const LINE_WEBHOOK_MAX_RAW_BODY_BYTES = 64 * 1024;
@@ -92,9 +93,11 @@ export function createLineWebhookMiddleware(
 
       if (body.events && body.events.length > 0) {
         logVerbose(`line: received ${body.events.length} webhook events`);
-        void Promise.resolve()
-          .then(() => onEvents(body))
-          .catch((err: unknown) => logLineWebhookDispatchError(runtime, err));
+        // Detach event processing from the request admission before the ack
+        // releases it; an inherited released admission refuses queue work.
+        void runDetachedWebhookWork(() => onEvents(body)).catch((err: unknown) =>
+          logLineWebhookDispatchError(runtime, err),
+        );
       }
     } catch (err) {
       await receiveContext?.nack(err);

--- a/extensions/sms/src/webhook.test.ts
+++ b/extensions/sms/src/webhook.test.ts
@@ -8,6 +8,13 @@ import type { ResolvedSmsAccount } from "./types.js";
 import { createSmsWebhookHandler } from "./webhook.js";
 
 const dispatchSmsInboundEvent = vi.hoisted(() => vi.fn(async () => undefined));
+const runDetachedWebhookWork = vi.hoisted(() => vi.fn((run: () => Promise<void>) => run()));
+
+vi.mock("openclaw/plugin-sdk/webhook-request-guards", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("openclaw/plugin-sdk/webhook-request-guards")>();
+  return { ...actual, runDetachedWebhookWork };
+});
 
 vi.mock("./inbound.js", () => ({
   dispatchSmsInboundEvent,
@@ -136,6 +143,7 @@ function createMessageSid(index: number): string {
 describe("createSmsWebhookHandler", () => {
   beforeEach(() => {
     dispatchSmsInboundEvent.mockClear();
+    runDetachedWebhookWork.mockClear();
     activeAccountId = `test-${++testAccountSequence}`;
   });
 
@@ -164,6 +172,7 @@ describe("createSmsWebhookHandler", () => {
     expect(firstRes.statusCode).toBe(200);
     expect(replayRes.statusCode).toBe(200);
     expect(dispatchSmsInboundEvent).toHaveBeenCalledTimes(1);
+    expect(runDetachedWebhookWork).toHaveBeenCalledTimes(1);
   });
 
   it("validates the raw RCS form before canonicalizing its sender", async () => {

--- a/extensions/sms/src/webhook.ts
+++ b/extensions/sms/src/webhook.ts
@@ -5,6 +5,7 @@ import {
   createFixedWindowRateLimiter,
   resolveRequestClientIp,
 } from "openclaw/plugin-sdk/webhook-ingress";
+import { runDetachedWebhookWork } from "openclaw/plugin-sdk/webhook-request-guards";
 import { dispatchSmsInboundEvent, type SmsChannelRuntime } from "./inbound.js";
 import {
   buildTwilioInboundMessage,
@@ -175,13 +176,17 @@ export function createSmsWebhookHandler(params: SmsWebhookHandlerParams) {
       return true;
     }
 
-    void dispatchSmsInboundEvent({
-      cfg: params.cfg,
-      account: params.account,
-      msg,
-      channelRuntime: params.channelRuntime,
-      log: params.log,
-    }).catch((err: unknown) => {
+    // Reserve the detached task before the HTTP admission is released;
+    // otherwise later queue work inherits a released admission root.
+    void runDetachedWebhookWork(() =>
+      dispatchSmsInboundEvent({
+        cfg: params.cfg,
+        account: params.account,
+        msg,
+        channelRuntime: params.channelRuntime,
+        log: params.log,
+      }),
+    ).catch((err: unknown) => {
       params.log?.error?.(
         `SMS webhook dispatch failed: ${err instanceof Error ? err.message : String(err)}`,
       );

--- a/extensions/zalo/src/monitor.webhook.test.ts
+++ b/extensions/zalo/src/monitor.webhook.test.ts
@@ -19,6 +19,15 @@ import {
 } from "./monitor.webhook.js";
 import { createTextUpdate, postWebhookReplay } from "./test-support/lifecycle-test-support.js";
 import type { ResolvedZaloAccount } from "./types.js";
+
+const runDetachedWebhookWork = vi.hoisted(() => vi.fn((run: () => Promise<void>) => run()));
+
+vi.mock("openclaw/plugin-sdk/webhook-request-guards", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("openclaw/plugin-sdk/webhook-request-guards")>();
+  return { ...actual, runDetachedWebhookWork };
+});
+
 const DEFAULT_ACCOUNT: ResolvedZaloAccount = {
   accountId: "default",
   enabled: true,
@@ -210,6 +219,7 @@ describe("handleZaloWebhookRequest", () => {
   });
 
   it("deduplicates webhook replay for the same event origin", async () => {
+    runDetachedWebhookWork.mockClear();
     const sink = vi.fn();
     const unregister = registerTarget({ path: "/hook-replay", statusSink: sink });
     const payload = createTextUpdate({
@@ -232,6 +242,7 @@ describe("handleZaloWebhookRequest", () => {
         expect(first.status).toBe(200);
         expect(replay.status).toBe(200);
         expect(sink).toHaveBeenCalledTimes(1);
+        expect(runDetachedWebhookWork).toHaveBeenCalledTimes(2);
       });
     } finally {
       unregister();

--- a/extensions/zalo/src/monitor.webhook.ts
+++ b/extensions/zalo/src/monitor.webhook.ts
@@ -2,6 +2,7 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { createClaimableDedupe } from "openclaw/plugin-sdk/persistent-dedupe";
 import { safeEqualSecret } from "openclaw/plugin-sdk/security-runtime";
+import { runDetachedWebhookWork } from "openclaw/plugin-sdk/webhook-request-guards";
 import type { ResolvedZaloAccount } from "./accounts.js";
 import type { ZaloFetch, ZaloUpdate } from "./api.js";
 import type { ZaloRuntimeEnv } from "./monitor.types.js";
@@ -258,12 +259,16 @@ export async function handleZaloWebhookRequest(
         return true;
       }
 
-      void processZaloReplayGuardedUpdate({
-        target,
-        update,
-        processUpdate,
-        nowMs,
-      }).catch((err: unknown) => {
+      // Reserve the detached task before the HTTP admission is released;
+      // otherwise later queue work inherits a released admission root.
+      void runDetachedWebhookWork(() =>
+        processZaloReplayGuardedUpdate({
+          target,
+          update,
+          processUpdate,
+          nowMs,
+        }),
+      ).catch((err: unknown) => {
         target.runtime.error?.(`[${target.account.accountId}] Zalo webhook failed: ${String(err)}`);
       });
 

--- a/scripts/plugin-sdk-surface-report.mjs
+++ b/scripts/plugin-sdk-surface-report.mjs
@@ -221,6 +221,7 @@ export function readPluginSdkSurfaceBudgets(env = process.env) {
       // +2: materializeRequesterScopedMcpToolsForHarnessRun (agent-harness-runtime + compat mirror).
       // +1: matchesNoProxy exposes canonical Undici-compatible bypass selection to plugins.
       // +4: group scope encoder/key builder (channel-policy + compat mirror).
+      // +1: runDetachedWebhookWork gives post-ack work an independently tracked admission root.
       // +9: app-guided provider setup context/candidate/hook types and their public mirrors.
       // +3: atomic SQLite STRICT migration function, options, and result for plugin stores.
       // Harvest: channel-ingress -64; dead channel-message dispatch aliases -23.
@@ -233,7 +234,7 @@ export function readPluginSdkSurfaceBudgets(env = process.env) {
       // +3: widget HTML validation helpers and tool input error.
       // Used-union narrowing: 31 wildcard barrels drop to explicit used exports;
       // proxy stream API and codex marker/scaffold pins retained.
-      7948,
+      7949,
       env,
     ),
     publicFunctionExports: readPluginSdkSurfaceBudgetEnv(
@@ -241,6 +242,7 @@ export function readPluginSdkSurfaceBudgets(env = process.env) {
       // +2: materializeRequesterScopedMcpToolsForHarnessRun (agent-harness-runtime + compat mirror).
       // +4: group scope encoder/key builder (channel-policy + compat mirror).
       // +1: atomic SQLite STRICT migration for plugin stores.
+      // +1: runDetachedWebhookWork gives post-ack work an independently tracked admission root.
       // Harvest: channel-ingress -19; dead channel-message dispatch aliases -23.
       // Harvest: retired qa-live-transport-scenarios subpath -3.
       // +4: shared plan checklist formatter across channel barrels.
@@ -249,7 +251,7 @@ export function readPluginSdkSurfaceBudgets(env = process.env) {
       // +6: active plan-step helpers pinned through channel-outbound and mirrors.
       // +2: widget HTML document detection and size assertion.
       // Used-union narrowing of the 31 wildcard barrels.
-      4436,
+      4437,
       env,
     ),
     publicDeprecatedExports: readPluginSdkSurfaceBudgetEnv(

--- a/src/plugin-sdk/webhook-request-guards.test.ts
+++ b/src/plugin-sdk/webhook-request-guards.test.ts
@@ -13,6 +13,7 @@ import {
   isJsonContentType,
   readWebhookBodyOrReject,
   readJsonWebhookBodyOrReject,
+  runDetachedWebhookWork,
 } from "./webhook-request-guards.js";
 
 type MockIncomingMessage = IncomingMessage & {
@@ -297,5 +298,48 @@ describe("beginWebhookRequestPipelineOrReject", () => {
     if (third.ok) {
       third.release();
     }
+  });
+});
+
+describe("runDetachedWebhookWork", () => {
+  it("keeps post-ack processing admitted after the request admission is released", async () => {
+    const { runWithGatewayHttpWorkAdmission } =
+      await import("../gateway/server/http-work-admission.js");
+    const { enqueueCommandInLane } = await import("../process/command-queue.js");
+
+    let detached: Promise<number> | null = null;
+    await runWithGatewayHttpWorkAdmission(createMockServerResponse(), async () => {
+      // Ack-first shape: dispatch continues after the handler (and its
+      // admission) completes; the queue enqueue happens well past release.
+      detached = runDetachedWebhookWork(async () => {
+        await new Promise<void>((resolve) => {
+          setTimeout(resolve, 25);
+        });
+        return await enqueueCommandInLane("detached-webhook-work-test", async () => 42);
+      });
+      return true;
+    });
+
+    await expect(detached).resolves.toBe(42);
+  });
+
+  it("refuses the same post-ack processing when it merely inherits the request admission", async () => {
+    const { runWithGatewayHttpWorkAdmission } =
+      await import("../gateway/server/http-work-admission.js");
+    const { enqueueCommandInLane } = await import("../process/command-queue.js");
+
+    let inherited: Promise<number> | null = null;
+    await runWithGatewayHttpWorkAdmission(createMockServerResponse(), async () => {
+      inherited = (async () => {
+        await new Promise<void>((resolve) => {
+          setTimeout(resolve, 25);
+        });
+        return await enqueueCommandInLane("inherited-webhook-work-test", async () => 42);
+      })();
+      inherited.catch(() => {});
+      return true;
+    });
+
+    await expect(inherited).rejects.toThrow("Gateway is draining");
   });
 });

--- a/src/plugin-sdk/webhook-request-guards.test.ts
+++ b/src/plugin-sdk/webhook-request-guards.test.ts
@@ -306,18 +306,20 @@ describe("runDetachedWebhookWork", () => {
     const { runWithGatewayHttpWorkAdmission } =
       await import("../gateway/server/http-work-admission.js");
     const order: string[] = [];
-    let detached: Promise<void> | null = null;
+    const detached: Promise<void>[] = [];
 
     await runWithGatewayHttpWorkAdmission(createMockServerResponse(), async () => {
-      detached = runDetachedWebhookWork(async () => {
-        order.push("work");
-      });
+      detached.push(
+        runDetachedWebhookWork(async () => {
+          order.push("work");
+        }),
+      );
       order.push("ack");
       expect(order).toEqual(["ack"]);
       return true;
     });
 
-    await detached;
+    await Promise.all(detached);
     expect(order).toEqual(["ack", "work"]);
   });
 

--- a/src/plugin-sdk/webhook-request-guards.test.ts
+++ b/src/plugin-sdk/webhook-request-guards.test.ts
@@ -302,6 +302,25 @@ describe("beginWebhookRequestPipelineOrReject", () => {
 });
 
 describe("runDetachedWebhookWork", () => {
+  it("defers the callback until the request handler can acknowledge", async () => {
+    const { runWithGatewayHttpWorkAdmission } =
+      await import("../gateway/server/http-work-admission.js");
+    const order: string[] = [];
+    let detached: Promise<void> | null = null;
+
+    await runWithGatewayHttpWorkAdmission(createMockServerResponse(), async () => {
+      detached = runDetachedWebhookWork(async () => {
+        order.push("work");
+      });
+      order.push("ack");
+      expect(order).toEqual(["ack"]);
+      return true;
+    });
+
+    await detached;
+    expect(order).toEqual(["ack", "work"]);
+  });
+
   it("keeps post-ack processing admitted after the request admission is released", async () => {
     const { runWithGatewayHttpWorkAdmission } =
       await import("../gateway/server/http-work-admission.js");

--- a/src/plugin-sdk/webhook-request-guards.ts
+++ b/src/plugin-sdk/webhook-request-guards.ts
@@ -9,6 +9,7 @@ import {
   requestBodyErrorToText,
 } from "../infra/http-body.js";
 import { pruneMapToMaxSize } from "../infra/map-size.js";
+import { runWithGatewayIndependentRootWorkContinuation } from "../process/gateway-work-admission.js";
 import type { FixedWindowRateLimiter } from "./webhook-memory-guards.js";
 import { resolveWebhookIntegerOption } from "./webhook-numeric-options.js";
 
@@ -275,6 +276,20 @@ export function beginWebhookRequestPipelineOrReject(params: {
       }
     },
   };
+}
+
+/**
+ * Run post-ack webhook processing on its own admitted gateway work root.
+ *
+ * Ack-first handlers respond before processing events, so the continued work
+ * outlives the HTTP request admission it inherited; once that admission is
+ * released, queue enqueues from the inherited chain are refused as if the
+ * gateway were draining. Call this synchronously from the request handler
+ * (while the request is still admitted): it reserves an independent root that
+ * keeps the detached processing accepted and lets a restart drain wait for it.
+ */
+export function runDetachedWebhookWork<T>(run: () => Promise<T>): Promise<T> {
+  return runWithGatewayIndependentRootWorkContinuation(run);
 }
 
 /** Read a webhook request body with bounded size/time limits and translate failures into responses. */

--- a/src/plugin-sdk/webhook-request-guards.ts
+++ b/src/plugin-sdk/webhook-request-guards.ts
@@ -289,7 +289,12 @@ export function beginWebhookRequestPipelineOrReject(params: {
  * keeps the detached processing accepted and lets a restart drain wait for it.
  */
 export function runDetachedWebhookWork<T>(run: () => Promise<T>): Promise<T> {
-  return runWithGatewayIndependentRootWorkContinuation(run);
+  return runWithGatewayIndependentRootWorkContinuation(async () => {
+    // Reserve the root now, but let the request handler write its acknowledgement
+    // before any synchronous prefix in the detached callback can run.
+    await Promise.resolve();
+    return await run();
+  });
 }
 
 /** Read a webhook request body with bounded size/time limits and translate failures into responses. */


### PR DESCRIPTION
Closes #107732

## What Problem This Solves

On current `main`, every inbound LINE message — DM, group mention, or postback — fails its agent turn with `GatewayDrainingError: Gateway is draining; new tasks are not accepted`, on an idle, healthy gateway that is not restarting. Users see the bot reply *"Sorry, I encountered an error processing your message."* (or stay silent) to everything. LINE inbound is effectively dead.

## Why This Change Was Made

LINE acks the webhook and then dispatches event processing fire-and-forget on the same async chain:

```ts
res.end(JSON.stringify({ status: "ok" }));      // ack
void Promise.resolve().then(() => bot.handleWebhook(body)).catch(...);
```

Plugin HTTP routes run under `runWithGatewayHttpWorkAdmission`, which reserves a gateway root work admission for the request and releases it when the route handler returns. The detached `handleWebhook` chain inherits that admission through `AsyncLocalStorage`. By the time it reaches the command queue, the handler has returned and the inherited admission is released — and `isGatewaySubordinateWorkAdmissionClosed()` treats a released inherited admission as "closed", so `enqueueCommandInLane` rejects with `GatewayDrainingError`. (The subordinate-admission rule landed in #105585; this is distinct from the restart-fence bug fixed in #107322, which does not address it.)

The fix reserves an **independent tracked work root** for the post-ack processing, synchronously while the request is still admitted, instead of inheriting the request's soon-to-be-released admission. A new `runDetachedWebhookWork` helper on the plugin-sdk webhook-request-guards surface wraps `runWithGatewayIndependentRootWorkContinuation` — the same continuation pattern core already uses for detached follow-up work (`gateway/server/hooks.ts`, `cron/service/ops.ts`, `auto-reply/reply/session.ts`). Because the root is reserved while a live parent still exists, the detached processing stays admitted, and a genuine restart drain still waits for it via `waitForActiveGatewayRootWork` instead of stranding it mid-turn.

LINE has three ack-first ingress handlers that #65375 unified onto the same fire-and-forget dispatch shape: the gateway `monitor.ts` route handler (the live production path), and the public `createLineNodeWebhookHandler` (node) / `createLineWebhookMiddleware` (Express) building blocks that an embedder can register under the gateway HTTP boundary. All three now dispatch through `runDetachedWebhookWork`, so the fix is complete and the three stay consistent rather than leaving the same latent defect in the two that are not on the live path today. The helper lives in plugin-sdk so other ack-first HTTP webhook channels can adopt the same primitive.

## User Impact

LINE DMs, group mentions, and postbacks are processed and answered again instead of failing with a draining error on a healthy gateway. No behavior change during an actual restart drain (the detached root is still tracked and drained). No change for channels that already `await` their processing before returning.

## Evidence

### Live behavior proof (real LINE channel)

**Before (on `main`)** — every inbound message fails; the bot replies with the generic error to a `@`-mention in a group:

<img width="605" height="208" alt="LINE group before fix: bot replies Sorry I encountered an error processing your message" src="https://github.com/user-attachments/assets/e32ef99c-80c1-4621-8f14-1e75742af712" />

Gateway log for that message (ids redacted):

```
line inbound: from=line:group:C...7c6 "...@openclaw please summarize what everyone discussed recently"
line: received message from <user> (line:group:C...7c6)
[diagnostic] message processed: channel=line ... outcome=error duration=64ms
  error="GatewayDrainingError: Gateway is draining; new tasks are not accepted"
[line] auto-reply failed: GatewayDrainingError: Gateway is draining; new tasks are not accepted
```

**After (this branch, no other patches)** — the same real LINE channel, both a group mention and a DM (the two gating paths, both through the `monitor.ts` gateway dispatch). Gateway log:

```
02:47:23 line inbound: from=line:group:C...7c6 "...@openclaw hello, are you working now?"
02:48:01 [line] embedded run agent end: runId=882a... isError=false
02:48:27 line inbound: from=line:U...12a "...hello in DM"
02:48:38 [line] embedded run agent end: runId=8b48... isError=false
```

`GatewayDrainingError` count in the run: **0**. `outcome=error` count: **0**.

Group mention — agent replies normally:

<img width="596" height="213" alt="LINE group after fix: bot replies Yep still here and ready to go" src="https://github.com/user-attachments/assets/4a52e99a-19a8-45c4-b74b-244473f20c9e" />

DM — agent replies normally:

<img width="592" height="147" alt="LINE DM after fix: bot replies Hey good to see you" src="https://github.com/user-attachments/assets/bc459c58-e4d4-40ed-881d-c5e7dc4956e8" />

### Red↔green

Reverting each dispatch site (back to the inherited-admission `Promise.resolve().then(...)`) fails its coverage:

```
# revert monitor.ts:
 × monitorLineProvider lifecycle > runs matched event processing on a detached admitted work root
 × monitorLineProvider lifecycle > acknowledges shared-path POST requests before matched event processing completes

# revert webhook-node.ts + webhook.ts:
 × createLineNodeWebhookHandler > dispatches signed POST event processing through the detached admitted work root
 × createLineWebhookMiddleware > dispatches middleware event processing through the detached admitted work root
```

Restored — full LINE suite + guards suite green:

```
 Test Files  26 passed (LINE)            Tests  319 passed | 1 skipped (320)
 webhook-request-guards.test.ts          Tests  17 passed (17)
```

### Tests

```
webhook-request-guards.test.ts (plugin-sdk, process-layer proof):
 ✓ runDetachedWebhookWork > keeps post-ack processing admitted after the request admission is released
 ✓ runDetachedWebhookWork > refuses the same post-ack processing when it merely inherits the request admission

monitor.lifecycle.test.ts (line, live gateway path):
 ✓ runs matched event processing on a detached admitted work root

webhook-node.test.ts (line, node + Express building blocks):
 ✓ createLineNodeWebhookHandler > dispatches signed POST event processing through the detached admitted work root
 ✓ createLineWebhookMiddleware > dispatches middleware event processing through the detached admitted work root
```

The first guards test reserves the detached root correctly and the enqueue resolves; the second omits the helper (raw inherited chain) and reproduces the `GatewayDrainingError` rejection — the bug and the fix pinned side by side, independent of LINE.

### Static checks

```
$ pnpm tsgo:core / tsgo:extensions / tsgo:*:test  -> exit 0
$ pnpm lint:extensions + oxlint src/plugin-sdk    -> exit 0
$ oxfmt --check <touched files>                   -> All matched files use the correct format.
$ pnpm plugin-sdk:api:check                       -> OK (baseline regenerated for the new export)
$ check-max-lines-ratchet --base origin/main      -> OK
```
