### PR TITLE
test: isolate live model switch suite

### DIFF
--- a/src/agents/agent-command.live-model-switch.test.ts
+++ b/src/agents/agent-command.live-model-switch.test.ts
@@ -270,6 +270,11 @@ vi.mock("../config/runtime-snapshot.js", () => ({
   setRuntimeConfigSnapshot: vi.fn(),
 }));
 
+// Model selection is mocked below, so plugin discovery cannot affect these assertions.
+vi.mock("../plugins/manifest-contract-eligibility.js", () => ({
+  loadManifestMetadataSnapshot: () => ({ plugins: [] }),
+}));
+
 vi.mock("../config/sessions.js", () => ({
   resolveAgentIdFromSessionKey: () => "default",
   mergeSessionEntry: (a: unknown, b: unknown) => ({ ...(a as object), ...(b as object) }),
@@ -467,6 +472,11 @@ vi.mock("./auth-profiles/session-override.js", () => ({
 vi.mock("./defaults.js", () => ({
   DEFAULT_MODEL: "claude",
   DEFAULT_PROVIDER: "anthropic",
+}));
+
+// Exec eligibility is outside model-switch scope; avoid loading its policy graph.
+vi.mock("./exec-defaults.js", () => ({
+  resolveNodeExecEligibility: () => ({ canExec: false }),
 }));
 
 vi.mock("./lanes.js", () => ({


### PR DESCRIPTION
## What Problem This Solves

The live model-switch orchestration suite loaded real plugin metadata and the exec-policy graph even though it already mocks model selection and never asserts exec eligibility. Those unrelated cold paths made 98 focused tests take 26.50s.

## Why This Change Was Made

Stub the two out-of-scope boundaries with the same lightweight contracts used by sibling agent-command tests: an empty plugin metadata snapshot and disabled node exec eligibility. Model-switch behavior, production code, and all 98 assertions remain unchanged.

## User Impact

Faster agent CI. Runtime behavior and coverage are unchanged. Test-only change; no changelog entry.

## Evidence

- Baseline Testbox: 98/98 passed, Vitest tests 26.50s.
- Exact-head Testbox: 98/98 passed, Vitest tests 23.73s (10.5% faster); `check:changed` passed.
- An earlier implementation run completed the same 98 tests in 19.68s (25.7% faster), showing expected runner variance while preserving the improvement.
- Baseline: https://github.com/openclaw/openclaw/actions/runs/29362260684
- Exact-head Testbox: https://github.com/openclaw/openclaw/actions/runs/29366109432
- Exact-head hosted CI: https://github.com/openclaw/openclaw/actions/runs/29366036096
- Fresh exact-head autoreview: clean, no accepted/actionable findings.
