### PR TITLE
fix(markdown): narrow fallback lookup

### DIFF
--- a/packages/markdown-core/src/frontmatter.ts
+++ b/packages/markdown-core/src/frontmatter.ts
@@ -106,9 +106,10 @@ function parseYamlFrontmatter(block: string): ParsedFrontmatter {
       if (!coerced) {
         continue;
       }
+      const fallbackValue = Object.hasOwn(fallback, key) ? fallback[key] : undefined;
       result[key] =
-        coerced.kind === "structured" && inlineColonKeys.has(key) && Object.hasOwn(fallback, key)
-          ? fallback[key]
+        coerced.kind === "structured" && inlineColonKeys.has(key) && fallbackValue !== undefined
+          ? fallbackValue
           : coerced.value;
     }
 


### PR DESCRIPTION
## What Problem This Solves

Current `main` fails the core-test TypeScript gate because `fallback[key]` remains `string | undefined` under indexed-access checking, even after the existing own-property guard.

## Why This Change Was Made

Read the own fallback value into a narrowed local while preserving the `Object.hasOwn` guard. This fixes the type error without changing the inline-colon fallback behavior or weakening protection for prototype-named keys.

## User Impact

Restores CI validation for current `main`. Runtime frontmatter behavior is unchanged. Internal fix; no changelog entry.

## Evidence

- `corepack pnpm test packages/markdown-core/src/frontmatter.test.ts` — 15/15 passed.
- `corepack pnpm check:changed -- packages/markdown-core/src/frontmatter.ts` — passed, including core and core-test typechecks.
- Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/29364308414
- Fresh autoreview: clean after preserving the own-property guard.
