### PR TITLE
refactor(net-policy): use ipaddr transition ranges

### DIFF
--- a/packages/net-policy/src/ip.ts
+++ b/packages/net-policy/src/ip.ts
@@ -93,49 +93,6 @@ export type Ipv6SpecialUseBlockOptions = {
   allowUniqueLocalRange?: boolean;
 };
 
-const EMBEDDED_IPV4_SENTINEL_RULES: Array<{
-  matches: (parts: Ipv6Hextets) => boolean;
-  toHextets: (parts: Ipv6Hextets) => [high: number, low: number];
-}> = [
-  {
-    // IPv4-compatible form ::w.x.y.z (deprecated, but still seen in parser edge-cases).
-    matches: (parts) =>
-      parts[0] === 0 &&
-      parts[1] === 0 &&
-      parts[2] === 0 &&
-      parts[3] === 0 &&
-      parts[4] === 0 &&
-      parts[5] === 0,
-    toHextets: (parts) => [parts[6], parts[7]],
-  },
-  {
-    // NAT64 local-use prefix: 64:ff9b:1::/48.
-    matches: (parts) =>
-      parts[0] === 0x0064 &&
-      parts[1] === 0xff9b &&
-      parts[2] === 0x0001 &&
-      parts[3] === 0 &&
-      parts[4] === 0 &&
-      parts[5] === 0,
-    toHextets: (parts) => [parts[6], parts[7]],
-  },
-  {
-    // 6to4 prefix: 2002::/16 (IPv4 lives in hextets 1..2).
-    matches: (parts) => parts[0] === 0x2002,
-    toHextets: (parts) => [parts[1], parts[2]],
-  },
-  {
-    // Teredo prefix: 2001:0000::/32 (client IPv4 XOR 0xffff in hextets 6..7).
-    matches: (parts) => parts[0] === 0x2001 && parts[1] === 0x0000,
-    toHextets: (parts) => [parts[6] ^ 0xffff, parts[7] ^ 0xffff],
-  },
-  {
-    // ISATAP IID marker: ....:0000:5efe:w.x.y.z with u/g bits allowed in hextet 4.
-    matches: (parts) => (parts[4] & 0xfcff) === 0 && parts[5] === 0x5efe,
-    toHextets: (parts) => [parts[6], parts[7]],
-  },
-];
-
 function stripIpv6Brackets(value: string): string {
   if (value.startsWith("[") && value.endsWith("]")) {
     return value.slice(1, -1);
@@ -349,22 +306,32 @@ function decodeIpv4FromHextets(high: number, low: number): ipaddr.IPv4 {
 
 /** Extracts embedded IPv4 addresses from mapped and transition IPv6 prefixes. */
 export function extractEmbeddedIpv4FromIpv6(address: ipaddr.IPv6): ipaddr.IPv4 | undefined {
-  if (address.isIPv4MappedAddress()) {
-    return address.toIPv4Address();
-  }
   const parts = expectIpv6Hextets(address.parts);
-  if (address.range() === "rfc6145") {
-    return decodeIpv4FromHextets(parts[6], parts[7]);
+  switch (address.range()) {
+    case "ipv4Mapped":
+      return address.toIPv4Address();
+    case "rfc6145":
+    case "rfc6052":
+      return decodeIpv4FromHextets(parts[6], parts[7]);
+    case "6to4":
+      return decodeIpv4FromHextets(parts[1], parts[2]);
+    case "teredo":
+      return decodeIpv4FromHextets(parts[6] ^ 0xffff, parts[7] ^ 0xffff);
+    default:
+      break;
   }
-  if (address.range() === "rfc6052") {
+
+  // ipaddr.js classifies transition prefixes, but not compatible or ISATAP forms.
+  const isIpv4Compatible =
+    parts[0] === 0 &&
+    parts[1] === 0 &&
+    parts[2] === 0 &&
+    parts[3] === 0 &&
+    parts[4] === 0 &&
+    parts[5] === 0;
+  const isIsatap = (parts[4] & 0xfcff) === 0 && parts[5] === 0x5efe;
+  if (isIpv4Compatible || isIsatap) {
     return decodeIpv4FromHextets(parts[6], parts[7]);
-  }
-  for (const rule of EMBEDDED_IPV4_SENTINEL_RULES) {
-    if (!rule.matches(parts)) {
-      continue;
-    }
-    const [high, low] = rule.toHextets(parts);
-    return decodeIpv4FromHextets(high, low);
   }
   return undefined;
 }


### PR DESCRIPTION
## What Problem This Solves

The net-policy package duplicated IPv6 transition-prefix classification already provided by its exact-pinned `ipaddr.js` dependency. That left five local rule objects and repeated range lookups to maintain in an SSRF-sensitive path.

## Why This Change Was Made

Use `IPv6.range()` once for IPv4-mapped, RFC 6145, RFC 6052, 6to4, and Teredo addresses. Keep the two forms the dependency does not classify—IPv4-compatible and ISATAP—as small explicit checks.

This removes 33 production lines without changing the exported API or intended behavior.

## User Impact

No intended behavior change. Embedded IPv4 addresses continue to be detected across mapped and transition IPv6 forms before SSRF policy evaluation.

## Evidence

- `node scripts/run-vitest.mjs packages/net-policy/src/ip.test.ts src/infra/net/ssrf.test.ts` — 64 tests passed.
- Type-aware Oxc lint, Oxfmt check, and `git diff --check` passed.
- Deterministic differential probe: previous and new algorithms matched for 10 transition fixtures plus 50,000 generated IPv6 addresses.
- Exact `ipaddr.js@2.4.0` source and types inspected for all used range names and prefix tables.
- Local and branch `$autoreview` passes reported no accepted/actionable findings.
- Hosted CI intentionally not awaited per maintainer direction.
