### PR TITLE
fix(markdown): restore main frontmatter type checks

### DIFF
--- a/packages/markdown-core/src/frontmatter.ts
+++ b/packages/markdown-core/src/frontmatter.ts
@@ -106,9 +106,10 @@ function parseYamlFrontmatter(block: string): ParsedFrontmatter {
       if (!coerced) {
         continue;
       }
+      const fallbackValue = Object.hasOwn(fallback, key) ? fallback[key] : undefined;
       result[key] =
-        coerced.kind === "structured" && inlineColonKeys.has(key) && Object.hasOwn(fallback, key)
-          ? fallback[key]
+        coerced.kind === "structured" && inlineColonKeys.has(key) && fallbackValue !== undefined
+          ? fallbackValue
           : coerced.value;
     }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where current `main` failed production type checking and extension package boundary compilation after the YAML frontmatter refactor.

## Why This Change Was Made

The fallback lookup now narrows the indexed value explicitly while retaining the own-property guard that protects prototype-named frontmatter keys. No runtime behavior or public contract changes.

## User Impact

No user-visible behavior change. Maintainers regain green main CI and release validation for markdown frontmatter consumers.

## Evidence

- AI-assisted; fresh autoreview clean at 0.97.
- Blacksmith Testbox through Crabbox: `tbx_01kxh3qhbjawme0nb2r88znb81`.
- Testbox workflow: https://github.com/openclaw/openclaw/actions/runs/29364330238
- `pnpm test packages/markdown-core/src/frontmatter.test.ts`: 15 passed.
- `pnpm tsgo:prod`: passed.
- Extension package boundary compile: 121 plugins passed.
- Extension package boundary canary: 2 plugins passed.
- Targeted oxfmt, type-aware oxlint, and `git diff --check`: passed.
