### PR TITLE
fix(channels): prevent base URL credentials in status output

### DIFF
--- a/packages/net-policy/src/redact-sensitive-url.test.ts
+++ b/packages/net-policy/src/redact-sensitive-url.test.ts
@@ -44,6 +44,9 @@ describe("redactSensitiveUrl", () => {
     expect(redactSensitiveUrl("https://example.com/mcp?safe=value")).toBe(
       "https://example.com/mcp?safe=value",
     );
+    expect(redactSensitiveUrl("https://example.test/?discount=100%25")).toBe(
+      "https://example.test/?discount=100%25",
+    );
   });
 
   it("redacts Telegram bot tokens from URL paths", () => {
@@ -57,6 +60,135 @@ describe("redactSensitiveUrl", () => {
         "https://api.telegram.org/bot123456%3AABCDEFGHIJKLMNOPQRSTUVWXYZ_abcd/getMe",
       ),
     ).toBe("https://api.telegram.org/bot***/getMe");
+  });
+
+  it("redacts credentials in literal and encoded nested URLs", () => {
+    const nested = joinUrlParts(
+      "https://nested-user",
+      ":",
+      "nested-pass",
+      "@inner.example/cb?access",
+      "_token",
+      "=",
+      "nested-token",
+    );
+    for (const value of [
+      nested,
+      encodeURIComponent(nested),
+      encodeURIComponent(encodeURIComponent(nested)),
+    ]) {
+      const redacted = redactSensitiveUrl(
+        `https://outer.example/connect?redirect=${encodeURIComponent(value)}&keep=visible`,
+      );
+      expect(redacted).not.toContain("nested-user");
+      expect(redacted).not.toContain("nested-pass");
+      expect(redacted).not.toContain("nested-token");
+      expect(new URL(redacted).searchParams.get("keep")).toBe("visible");
+    }
+  });
+
+  it("redacts sensitive query params in query and hash-router fragments", () => {
+    expect(
+      redactSensitiveUrl(
+        joinUrlParts("https://example.com/cb#access", "_token", "=", "secret", "&keep=visible"),
+      ),
+    ).toBe(joinUrlParts("https://example.com/cb#access", "_token", "=", "***", "&keep=visible"));
+    expect(
+      redactSensitiveUrl(
+        joinUrlParts("https://example.com/#/cb?to", "ken=", "secret", "&keep=visible"),
+      ),
+    ).toBe(joinUrlParts("https://example.com/#/cb?to", "ken=", "***", "&keep=visible"));
+  });
+
+  it("redacts sensitive encoded fragments without changing safe encoded fragments", () => {
+    const sensitiveFragment = encodeURIComponent(
+      joinUrlParts("access", "_token", "=", "secret", "&keep=visible"),
+    );
+    expect(redactSensitiveUrl(`https://example.com/cb#${sensitiveFragment}`)).toBe(
+      "https://example.com/cb#access_token%3D***%26keep%3Dvisible",
+    );
+
+    const safeUrl = "https://example.com/cb#keep%3Dvisible%26next%3Dsafe";
+    expect(redactSensitiveUrl(safeUrl)).toBe(safeUrl);
+  });
+
+  it("preserves safe nested URLs, fragments, and duplicate query ordering byte-for-byte", () => {
+    const safeUrl =
+      "https://outer.example/cb?next=https%3A%2F%2Finner.example%2Fpath%3Fkeep%3Dvisible&keep=one&keep=two#https%3A%2F%2Ffragment.example%2Fpath%3Fok%3D1";
+    expect(redactSensitiveUrl(safeUrl)).toBe(safeUrl);
+
+    expect(
+      redactSensitiveUrl(
+        joinUrlParts("https://example.com/?keep=one&keep=two&to", "ken=", "a", "&to", "ken=b"),
+      ),
+    ).toBe(joinUrlParts("https://example.com/?keep=one&keep=two&to", "ken=", "***"));
+  });
+
+  it("is idempotent after nested URL redaction", () => {
+    const input =
+      "https://outer.example/?next=https%3A%2F%2Fu%3Ap%40inner.example%2F%3Ftoken%3Dsecret";
+    const once = redactSensitiveUrl(input);
+    expect(redactSensitiveUrl(once)).toBe(once);
+  });
+
+  it("fails closed when nested URL encoding exceeds the recursion bound", () => {
+    let nested = joinUrlParts(
+      "https://deep-user",
+      ":",
+      "deep-pass",
+      "@inner.example/?to",
+      "ken=",
+      "deep-token",
+    );
+    for (let index = 0; index < 12; index += 1) {
+      nested = `https://level-${index}.example/?next=${encodeURIComponent(nested)}`;
+    }
+    const redacted = redactSensitiveUrl(nested);
+    expect(redacted).not.toContain("deep-user");
+    expect(redacted).not.toContain("deep-pass");
+    expect(redacted).not.toContain("deep-token");
+    expect(redacted).toContain("***");
+  });
+
+  it("fails closed when one nested URL exceeds the percent-encoding bound", () => {
+    let nested = joinUrlParts(
+      "https://encoded-user",
+      ":",
+      "encoded-pass",
+      "@inner.example/?to",
+      "ken=",
+      "encoded-token",
+    );
+    for (let index = 0; index < 20; index += 1) {
+      nested = encodeURIComponent(nested);
+    }
+    const redacted = redactSensitiveUrl(
+      `https://outer.example/?next=${encodeURIComponent(nested)}`,
+    );
+    expect(redacted).not.toContain("encoded-user");
+    expect(redacted).not.toContain("encoded-pass");
+    expect(redacted).not.toContain("encoded-token");
+    expect(redacted).toContain("***");
+  });
+
+  it("preserves redaction for valid non-hierarchical URLs", () => {
+    const value = joinUrlParts("mailto:user@example.com?to", "ken=", "secret");
+    expect(redactSensitiveUrl(value)).toBe(
+      joinUrlParts("mailto:user@example.com?to", "ken=", "***"),
+    );
+  });
+
+  it("redacts embedded credentials in opaque URLs", () => {
+    const value = joinUrlParts(
+      "data:text/plain,https://opaque-user",
+      ":",
+      "opaque-pass",
+      "@inner.example",
+    );
+    const redacted = redactSensitiveUrl(value);
+    expect(redacted).not.toContain("opaque-user");
+    expect(redacted).not.toContain("opaque-pass");
+    expect(redacted).toContain("***:***@inner.example");
   });
 });
 
@@ -153,5 +285,320 @@ describe("sensitive URL config metadata", () => {
     expect(SENSITIVE_URL_HINT_TAG).toBe("url-secret");
     expect(hasSensitiveUrlHintTag({ tags: [SENSITIVE_URL_HINT_TAG] })).toBe(true);
     expect(hasSensitiveUrlHintTag({ tags: ["security"] })).toBe(false);
+  });
+});
+
+function joinUrlParts(...parts: string[]): string {
+  return parts.join("");
+}
+
+describe("nested URL-like fallback redaction", () => {
+  it("redacts embedded credentials from query parameter names", () => {
+    const nestedKey = joinUrlParts("https://key-user", ":", "key-pass", "@inner.example/");
+    for (const value of [
+      `https://outer.example/?${nestedKey}=value`,
+      `https://outer.example/#/cb?${nestedKey}=value`,
+    ]) {
+      const redacted = redactSensitiveUrlLikeString(value);
+      expect(redacted).not.toContain("key-user");
+      expect(redacted).not.toContain("key-pass");
+      expect(redacted).toContain("***");
+    }
+  });
+
+  it("redacts encoded reserved characters inside nested userinfo", () => {
+    for (const encodedReserved of ["%2F", "%3F", "%23"]) {
+      const encodedNested = joinUrlParts(
+        "%68%74%74%70%73%3A%2F%2Fencoded-user",
+        "%3A",
+        `encoded-pass${encodedReserved}part%40inner.example%2F`,
+      );
+      const redacted = redactSensitiveUrlLikeString(`https://outer.example/proxy/${encodedNested}`);
+      expect(redacted).not.toContain("encoded-user");
+      expect(redacted).not.toContain("encoded-pass");
+      expect(redacted).toContain("***:***@inner.example/");
+    }
+  });
+
+  it("fails closed for unresolved encoded userinfo delimiters", () => {
+    for (const encodedUserInfo of [
+      "encoded-user%3Aencoded-pass%20part%40",
+      "encoded-user%2Fpart%3Aencoded-pass%40",
+      "encoded-user%2Fpart%40",
+    ]) {
+      const encodedNested = `%68%74%74%70%73%3A%2F%2F${encodedUserInfo}inner.example%2F`;
+      const redacted = redactSensitiveUrlLikeString(`https://outer.example/proxy/${encodedNested}`);
+      expect(redacted).not.toContain("encoded-user");
+      expect(redacted).not.toContain("encoded-pass");
+      expect(redacted).toContain("***");
+    }
+  });
+
+  it("fails closed for unresolved encoded protocol-relative userinfo", () => {
+    const value = joinUrlParts("//relative-user%2Fpart%3A", "relative-pass", "%40inner.example");
+    const redacted = redactSensitiveUrlLikeString(value);
+    expect(redacted).not.toContain("relative-user");
+    expect(redacted).not.toContain("relative-pass");
+    expect(redacted).toContain("***");
+  });
+
+  it("fails closed after a nested query value decodes into ambiguous userinfo", () => {
+    const nested = joinUrlParts(
+      "https%3A%2F%2Fquery-user%2Fpart%3A",
+      "query-pass",
+      "%40inner.example%2F",
+    );
+    const redacted = redactSensitiveUrlLikeString(`https://outer.example/?next=${nested}`);
+    expect(redacted).not.toContain("query-user");
+    expect(redacted).not.toContain("query-pass");
+    expect(redacted).toContain("***");
+  });
+
+  it("preserves host ports and IPv6 hosts when later path segments contain an at sign", () => {
+    for (const nested of [
+      "https://inner.example:443/path@label",
+      "https://inner.example:443?email=user@example.com",
+      "https://[2001:db8::1]/path@label",
+      "https://[2001:db8::1]#user@example.com",
+    ]) {
+      const value = `https://outer.example/proxy/${nested}`;
+      expect(redactSensitiveUrlLikeString(value)).toBe(value);
+    }
+  });
+
+  it("redacts embedded URLs when a diagnostic prefix parses as an opaque scheme", () => {
+    expect(
+      redactSensitiveUrlLikeString(
+        joinUrlParts(
+          "fatal: retry https://first",
+          ":",
+          "first-pass",
+          "@one.example then https://second",
+          ":",
+          "second-pass",
+          "@two.example",
+        ),
+      ),
+    ).toBe(
+      joinUrlParts(
+        "fatal: retry https://",
+        "***",
+        ":",
+        "***",
+        "@one.example then https://",
+        "***",
+        ":",
+        "***",
+        "@two.example",
+      ),
+    );
+  });
+
+  it("redacts a credential-bearing URL embedded in a parsed outer URL path", () => {
+    const value = joinUrlParts(
+      "https://outer.example/proxy/https://path-user",
+      ":",
+      "path-pass",
+      "@inner.example/",
+    );
+    const redacted = redactSensitiveUrlLikeString(value);
+    expect(redacted).not.toContain("path-user");
+    expect(redacted).not.toContain("path-pass");
+    expect(redacted).toContain(joinUrlParts("https://", "***", ":", "***", "@inner.example/"));
+  });
+
+  it("redacts a percent-encoded credential-bearing URL in an outer URL path", () => {
+    const nested = joinUrlParts(
+      "https://path-user",
+      ":",
+      "path-pass",
+      "@inner.example/?to",
+      "ken=",
+      "path-token",
+    );
+    for (const layers of [1, 2, 20]) {
+      let encoded = nested;
+      for (let index = 0; index < layers; index += 1) {
+        encoded = encodeURIComponent(encoded);
+      }
+      const redacted = redactSensitiveUrlLikeString(`https://outer.example/proxy/${encoded}`);
+      expect(redacted).not.toContain("path-user");
+      expect(redacted).not.toContain("path-pass");
+      expect(redacted).not.toContain("path-token");
+      expect(redacted).toContain("***");
+    }
+  });
+
+  it("redacts a nested URL in a hash-router query parameter", () => {
+    const nested = joinUrlParts("https://inner.example/?access", "_token", "=", "router-secret");
+    const value = `https://outer.example/#/cb?next=${nested}&keep=visible`;
+    const redacted = redactSensitiveUrlLikeString(value);
+    expect(redacted).not.toContain("router-secret");
+    expect(redacted).toContain("keep=visible");
+  });
+
+  it("fails closed when an encoded fragment also has a malformed escape", () => {
+    const value = joinUrlParts(
+      "https://outer.example/#access",
+      "_token%3D",
+      "malformed-secret",
+      "%ZZ",
+    );
+    const redacted = redactSensitiveUrlLikeString(value);
+    expect(redacted).not.toContain("malformed-secret");
+    expect(redacted).toBe("https://outer.example/#***");
+  });
+
+  it("redacts an encoded URL in an otherwise unparsed URL-like string", () => {
+    const nested = joinUrlParts(
+      "https://fallback-user",
+      ":",
+      "fallback-pass",
+      "@inner.example/?to",
+      "ken=",
+      "fallback-token",
+    );
+    const value = `callback=${encodeURIComponent(nested)}`;
+    const redacted = redactSensitiveUrlLikeString(value);
+    expect(redacted).not.toContain("fallback-user");
+    expect(redacted).not.toContain("fallback-pass");
+    expect(redacted).not.toContain("fallback-token");
+    expect(redacted).toContain("***");
+  });
+
+  it("redacts an encoded relative URL fragment in a nested query value", () => {
+    const relative = joinUrlParts("callback#access", "_token", "=", "relative-secret");
+    const value = `https://outer.example/?next=${encodeURIComponent(relative)}`;
+    const redacted = redactSensitiveUrlLikeString(value);
+    expect(redacted).not.toContain("relative-secret");
+    expect(redacted).toContain("***");
+  });
+
+  it("redacts an encoded backslash-form URL authority", () => {
+    const nested = joinUrlParts(
+      "https:",
+      "\\\\",
+      "backslash-user",
+      ":",
+      "backslash-pass",
+      "@inner.example/",
+    );
+    const value = `https://outer.example/?next=${encodeURIComponent(nested)}`;
+    const redacted = redactSensitiveUrlLikeString(value);
+    expect(redacted).not.toContain("backslash-user");
+    expect(redacted).not.toContain("backslash-pass");
+    expect(redacted).toContain("***");
+  });
+
+  it("redacts special-scheme URLs with omitted authority slashes", () => {
+    for (const separator of ["/", ""]) {
+      const nested = joinUrlParts(
+        "https:",
+        separator,
+        "short-user",
+        ":",
+        "short-pass",
+        "@inner.example/",
+      );
+      const value = `https://outer.example/?next=${encodeURIComponent(nested)}`;
+      const redacted = redactSensitiveUrlLikeString(value);
+      expect(redacted).not.toContain("short-user");
+      expect(redacted).not.toContain("short-pass");
+      expect(redacted).toContain("***");
+    }
+  });
+
+  it("redacts slashless special-scheme userinfo embedded in an outer path", () => {
+    const nested = joinUrlParts("https:", "path-user", ":", "path-pass", "@inner.example/");
+    const redacted = redactSensitiveUrlLikeString(`https://outer.example/proxy/${nested}`);
+    expect(redacted).not.toContain("path-user");
+    expect(redacted).not.toContain("path-pass");
+    expect(redacted).toContain("***");
+  });
+
+  it("redacts through the final userinfo delimiter in a protocol-relative URL", () => {
+    const nested = joinUrlParts("//first-user@second-user", ":", "multi-pass", "@inner.example/");
+    const redacted = redactSensitiveUrlLikeString(`https://outer.example/proxy/${nested}`);
+    expect(redacted).not.toContain("first-user");
+    expect(redacted).not.toContain("second-user");
+    expect(redacted).not.toContain("multi-pass");
+    expect(redacted).toContain("***:***@inner.example/");
+  });
+
+  it("redacts an ampersand inside embedded URL userinfo", () => {
+    const nested = joinUrlParts("https://amp-user", ":", "amp&pass", "@inner.example/");
+    const redacted = redactSensitiveUrlLikeString(`https://outer.example/proxy/${nested}`);
+    expect(redacted).not.toContain("amp-user");
+    expect(redacted).not.toContain("amp&pass");
+    expect(redacted).toContain("***:***@inner.example/");
+  });
+
+  it("redacts mixed literal and encoded credentials in one URL-like string", () => {
+    const literal = joinUrlParts("https://literal-user", ":", "literal-pass", "@one.example/");
+    const encoded = encodeURIComponent(
+      joinUrlParts("https://encoded-user", ":", "encoded-pass", "@two.example/"),
+    );
+    const value = `diagnostic ${literal} then ${encoded}`;
+    const redacted = redactSensitiveUrlLikeString(value);
+    expect(redacted).not.toContain("literal-user");
+    expect(redacted).not.toContain("literal-pass");
+    expect(redacted).not.toContain("encoded-user");
+    expect(redacted).not.toContain("encoded-pass");
+  });
+
+  it("redacts mixed literal and encoded credentials in one fragment", () => {
+    const literal = joinUrlParts("https://literal-user", ":", "literal-pass", "@one.example/");
+    const encoded = encodeURIComponent(
+      joinUrlParts("https://encoded-user", ":", "encoded-pass", "@two.example/"),
+    );
+    const redacted = redactSensitiveUrlLikeString(
+      `https://outer.example/#diagnostic ${literal} then ${encoded}`,
+    );
+    expect(redacted).not.toContain("literal-user");
+    expect(redacted).not.toContain("literal-pass");
+    expect(redacted).not.toContain("encoded-user");
+    expect(redacted).not.toContain("encoded-pass");
+  });
+
+  it("redacts an opaque URL whose pathname cannot be assigned", () => {
+    const nested = encodeURIComponent(
+      joinUrlParts("https://opaque-user", ":", "opaque-pass", "@inner.example/"),
+    );
+    const redacted = redactSensitiveUrlLikeString(`data:text/plain,${nested}`);
+    expect(redacted).not.toContain("opaque-user");
+    expect(redacted).not.toContain("opaque-pass");
+    expect(redacted).toContain("***:***@inner.example/");
+  });
+
+  it("redacts repeatedly encoded sensitive query parameter names", () => {
+    for (const layers of [0, 1, 8, 20]) {
+      let key = "%74oken";
+      for (let index = 0; index < layers; index += 1) {
+        key = encodeURIComponent(key);
+      }
+      const value = `https://example.test/?${key}=encoded-name-secret`;
+      const redacted = redactSensitiveUrlLikeString(value);
+      expect(redacted).not.toContain("encoded-name-secret");
+      expect(redacted).toContain("***");
+    }
+  });
+
+  it("redacts mixed percent-encoded URL structure with a literal sensitive value", () => {
+    const encodedScheme = "%68%74%74%70%73%3A%2F%2Finner.example%2F%3F";
+    const value = joinUrlParts(
+      "https://outer.example/proxy/",
+      encodedScheme,
+      "to",
+      "ken=",
+      "mixed-secret",
+    );
+    const redacted = redactSensitiveUrlLikeString(value);
+    expect(redacted).not.toContain("mixed-secret");
+    expect(redacted).toContain("***");
+  });
+
+  it("does not consume later query parameters while scanning embedded authorities", () => {
+    const value = "https://outer.example/?next=https://inner.example&email=user@example.com";
+    expect(redactSensitiveUrlLikeString(value)).toBe(value);
   });
 });

--- a/packages/net-policy/src/redact-sensitive-url.test.ts
+++ b/packages/net-policy/src/redact-sensitive-url.test.ts
@@ -366,6 +366,31 @@ describe("nested URL-like fallback redaction", () => {
     }
   });
 
+  it("preserves encoded safe URLs when paths, queries, or fragments contain an at sign", () => {
+    const unambiguousEmbeddedUrls = [
+      "https://inner.example:443/path@label",
+      "https://inner.example:443?email=user@example.com",
+      "https://[2001:db8::1]/path@label",
+      "https://[2001:db8::1]#user@example.com",
+    ];
+    const safeUrls = [
+      "https://inner.example/path@label",
+      "https://inner.example?email=user@example.com",
+      "https://inner.example#user@example.com",
+      ...unambiguousEmbeddedUrls,
+    ];
+    for (const nested of safeUrls) {
+      const encoded = encodeURIComponent(nested);
+      expect(redactSensitiveUrlLikeString(encoded)).toBe(encoded);
+      for (const outer of [
+        `https://outer.example/proxy/${encoded}`,
+        `https://outer.example/?next=${encoded}`,
+      ]) {
+        expect(redactSensitiveUrlLikeString(outer)).toBe(outer);
+      }
+    }
+  });
+
   it("redacts embedded URLs when a diagnostic prefix parses as an opaque scheme", () => {
     expect(
       redactSensitiveUrlLikeString(

--- a/packages/net-policy/src/redact-sensitive-url.ts
+++ b/packages/net-policy/src/redact-sensitive-url.ts
@@ -37,33 +37,87 @@ const SENSITIVE_URL_QUERY_PARAM_NAMES = new Set([
   "credential",
   "authorization",
 ]);
-// Keep in sync with FORM_BODY_KEY_SEPARATOR_RE in src/logging/redact.ts: Hangul fillers are
-// category Lo, so \p{C}\p{Z} alone would let them splice sensitive key names.
+// Align with FORM_BODY_KEY_SEPARATOR_RE: category-Lo Hangul fillers can splice sensitive names.
 const URL_QUERY_NAME_SEPARATOR_RE = /[\p{C}\p{Z}\u115F\u1160\u3164\uFFA0+]/gu;
 
-// Telegram Bot API credentials live in `/bot<token>/...` path segments rather
-// than userinfo or query params. Keep this shape aligned with logging/redact.ts.
+// Telegram bot credentials use `/bot<token>/...`; align this shape with logging/redact.ts.
 const TELEGRAM_BOT_TOKEN_PATH_RE = /\/bot\d{6,}(?::|%3[aA])[A-Za-z0-9_-]{20,}(?=\/|$)/giu;
+// Nested callbacks may be repeatedly percent-encoded. Bound recursive decoding so hostile
+// diagnostics cannot grow work without limit; unresolved URL-like values then fail closed.
+const MAX_NESTED_URL_REDACTION_DEPTH = 8;
+const URL_SCHEME_RE = /(?:^|[^a-z\d+.-])[a-z][a-z\d+.-]{0,31}:/iu;
+const SPECIAL_SCHEME_AUTHORITY_RE = /\b(?:https?|wss?|ftp):[\\/]{0,2}[^\\/?#\s]*/giu;
+const SPECIAL_SCHEME_SPILLED_USERINFO_RE = /\b(?:https?|wss?|ftp):[\\/]{0,2}[^\s]*@[^\\/?#\s]*/giu;
+const PROTOCOL_RELATIVE_AUTHORITY_RE = /[\\/]{2,}[^\\/?#\s]*/gu;
+
+type UrlRedactionResult = {
+  value: string;
+  parsedWholeUrl: boolean;
+};
 
 function redactSensitiveUrlPath(value: string): string {
   return value.replace(TELEGRAM_BOT_TOKEN_PATH_RE, "/bot***");
 }
 
-function normalizeUrlQueryParamName(name: string): string {
-  const stripped = name.replace(URL_QUERY_NAME_SEPARATOR_RE, "");
-  try {
-    return normalizeLowercaseStringOrEmpty(
-      decodeURIComponent(stripped).replace(URL_QUERY_NAME_SEPARATOR_RE, ""),
-    ).replaceAll("-", "_");
-  } catch {
-    return normalizeLowercaseStringOrEmpty(stripped).replaceAll("-", "_");
+function normalizeUrlQueryParamName(name: string): {
+  value: string;
+  unresolvedEncoding: boolean;
+} {
+  let current = name.replace(URL_QUERY_NAME_SEPARATOR_RE, "");
+  for (let depth = 0; depth <= MAX_NESTED_URL_REDACTION_DEPTH; depth += 1) {
+    let decoded: string;
+    try {
+      decoded = decodeURIComponent(current).replace(URL_QUERY_NAME_SEPARATOR_RE, "");
+    } catch {
+      return {
+        value: normalizeLowercaseStringOrEmpty(current).replaceAll("-", "_"),
+        unresolvedEncoding: current.includes("%"),
+      };
+    }
+    if (decoded === current) {
+      return {
+        value: normalizeLowercaseStringOrEmpty(current).replaceAll("-", "_"),
+        unresolvedEncoding: false,
+      };
+    }
+    current = decoded;
   }
+  return {
+    value: normalizeLowercaseStringOrEmpty(current).replaceAll("-", "_"),
+    unresolvedEncoding: current.includes("%"),
+  };
+}
+
+function looksLikeNestedUrlValue(value: string): boolean {
+  if (URL_SCHEME_RE.test(value)) {
+    return true;
+  }
+  const forwardAuthorityIndex = value.indexOf("//");
+  const backwardAuthorityIndex = value.indexOf("\\\\");
+  const authorityIndex =
+    forwardAuthorityIndex < 0
+      ? backwardAuthorityIndex
+      : backwardAuthorityIndex < 0
+        ? forwardAuthorityIndex
+        : Math.min(forwardAuthorityIndex, backwardAuthorityIndex);
+  if (authorityIndex >= 0 && value.includes("@", authorityIndex + 2)) {
+    return true;
+  }
+  const queryIndex = value.search(/[?&]/u);
+  if (queryIndex >= 0 && value.includes("=", queryIndex + 1)) {
+    return true;
+  }
+  const fragmentIndex = value.indexOf("#");
+  if (fragmentIndex >= 0 && value.includes("=", fragmentIndex + 1)) {
+    return true;
+  }
+  return /%[\da-f]{2}/iu.test(value);
 }
 
 /** True for auth-like URL query parameter names that should be redacted. */
 export function isSensitiveUrlQueryParamName(name: string): boolean {
   const normalized = normalizeUrlQueryParamName(name);
-  return SENSITIVE_URL_QUERY_PARAM_NAMES.has(normalized);
+  return normalized.unresolvedEncoding || SENSITIVE_URL_QUERY_PARAM_NAMES.has(normalized.value);
 }
 
 /** True for config paths whose URL values may contain credentials or secret query params. */
@@ -85,8 +139,7 @@ export function hasSensitiveUrlHintTag(hint: ConfigUiHintTags | undefined): bool
   return hint?.tags?.includes(SENSITIVE_URL_HINT_TAG) === true;
 }
 
-/** Redacts credentials and sensitive query params from parseable URLs. */
-export function redactSensitiveUrl(value: string): string {
+function redactDirectSensitiveUrl(value: string): string {
   try {
     const parsed = new URL(value);
     let mutated = false;
@@ -112,16 +165,335 @@ export function redactSensitiveUrl(value: string): string {
   }
 }
 
-/** Redacts sensitive URL-looking substrings even when the full value is not a valid URL. */
-export function redactSensitiveUrlLikeString(value: string): string {
-  const redactedUrl = redactSensitiveUrl(value);
-  if (redactedUrl !== value) {
+function redactQueryString(value: string, depth: number): string {
+  const params = new URLSearchParams(value);
+  const entries = Array.from(params.entries());
+  const redactedEntries: Array<[string, string]> = [];
+  const seenSensitiveKeys = new Set<string>();
+  let mutated = false;
+
+  for (const [key, entryValue] of entries) {
+    if (isSensitiveUrlQueryParamName(key)) {
+      mutated = true;
+      if (!seenSensitiveKeys.has(key)) {
+        seenSensitiveKeys.add(key);
+        redactedEntries.push([key, "***"]);
+      }
+      continue;
+    }
+
+    const redactedKey = redactNestedUrlValue(key, depth + 1);
+    const redactedValue = redactNestedUrlValue(entryValue, depth + 1);
+    if (redactedKey !== key || redactedValue !== entryValue) {
+      mutated = true;
+    }
+    redactedEntries.push([redactedKey, redactedValue]);
+  }
+
+  if (!mutated) {
+    return value;
+  }
+  const redactedParams = new URLSearchParams();
+  for (const [key, entryValue] of redactedEntries) {
+    redactedParams.append(key, entryValue);
+  }
+  return redactedParams.toString();
+}
+
+function redactUrlLikeFallback(value: string): string {
+  const redactedFallback = redactEmbeddedUrlUserInfo(value).replace(
+    /([?&])([^=&]+)=([^&]*)/g,
+    (match, prefix: string, key: string) =>
+      isSensitiveUrlQueryParamName(key) ? `${prefix}${key}=***` : match,
+  );
+  return redactSensitiveUrlPath(redactedFallback);
+}
+
+function redactAuthorityUserInfo(candidate: string, authorityStart: number): string {
+  const authority = candidate.slice(authorityStart);
+  const userInfoEnd = authority.lastIndexOf("@");
+  if (userInfoEnd < 0) {
+    return candidate;
+  }
+  return `${candidate.slice(0, authorityStart)}***:***@${authority.slice(userInfoEnd + 1)}`;
+}
+
+function redactEmbeddedUrlUserInfo(value: string): string {
+  return value
+    .replace(SPECIAL_SCHEME_AUTHORITY_RE, (candidate) => {
+      let authorityStart = candidate.indexOf(":") + 1;
+      while (
+        authorityStart < candidate.length &&
+        (candidate[authorityStart] === "/" || candidate[authorityStart] === "\\")
+      ) {
+        authorityStart += 1;
+      }
+      return redactAuthorityUserInfo(candidate, authorityStart);
+    })
+    .replace(SPECIAL_SCHEME_SPILLED_USERINFO_RE, (candidate) => {
+      let authorityStart = candidate.indexOf(":") + 1;
+      while (
+        authorityStart < candidate.length &&
+        (candidate[authorityStart] === "/" || candidate[authorityStart] === "\\")
+      ) {
+        authorityStart += 1;
+      }
+      const userInfoEnd = candidate.lastIndexOf("@");
+      const firstReservedDelimiter = candidate.slice(authorityStart).search(/[\\/?#]/u);
+      if (userInfoEnd < 0 || firstReservedDelimiter < 0) {
+        return candidate;
+      }
+      const absoluteReservedDelimiter = authorityStart + firstReservedDelimiter;
+      if (absoluteReservedDelimiter >= userInfoEnd) {
+        return candidate;
+      }
+      const credentialSeparator = candidate.indexOf(":", authorityStart);
+      if (credentialSeparator < 0 || credentialSeparator > absoluteReservedDelimiter) {
+        return candidate;
+      }
+      const authorityPrefix = candidate.slice(authorityStart, absoluteReservedDelimiter);
+      const possiblePort = candidate.slice(credentialSeparator + 1, absoluteReservedDelimiter);
+      // Decoded reserved delimiters can hide inside userinfo, but ordinary host:port and IPv6
+      // URLs must remain untouched even when a later path, query, or fragment contains `@`.
+      if (/^\d+$/u.test(possiblePort) || /^\[[^\]]+\](?::\d+)?$/u.test(authorityPrefix)) {
+        return candidate;
+      }
+      return `${candidate.slice(0, authorityStart)}***:***@${candidate.slice(userInfoEnd + 1)}`;
+    })
+    .replace(PROTOCOL_RELATIVE_AUTHORITY_RE, (candidate) => {
+      let authorityStart = 0;
+      while (
+        authorityStart < candidate.length &&
+        (candidate[authorityStart] === "/" || candidate[authorityStart] === "\\")
+      ) {
+        authorityStart += 1;
+      }
+      return redactAuthorityUserInfo(candidate, authorityStart);
+    });
+}
+
+function hasUnresolvedEmbeddedUrlUserInfo(value: string): boolean {
+  for (const match of value.matchAll(/(?:\b(?:https?|wss?|ftp):[\\/]{0,2}|[\\/]{2,})/giu)) {
+    const authorityStart = (match.index ?? 0) + match[0].length;
+    if (/(?<!\*\*\*:\*\*\*)@/u.test(value.slice(authorityStart))) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function redactRelativeUrlFragment(value: string, depth: number): string {
+  const fragmentIndex = value.indexOf("#");
+  if (fragmentIndex < 0) {
+    return value;
+  }
+  const fragment = value.slice(fragmentIndex + 1);
+  const redactedFragment = redactFragment(fragment, depth + 1);
+  return redactedFragment === fragment
+    ? value
+    : `${value.slice(0, fragmentIndex + 1)}${redactedFragment}`;
+}
+
+function redactFragment(value: string, depth: number): string {
+  if (!value) {
+    return value;
+  }
+  if (depth > MAX_NESTED_URL_REDACTION_DEPTH && looksLikeNestedUrlValue(value)) {
+    return "***";
+  }
+
+  const wholeUrl = redactSensitiveUrlAtDepth(value, depth);
+  if (wholeUrl.parsedWholeUrl) {
+    return redactUrlLikeFallback(wholeUrl.value);
+  }
+
+  const candidate = value;
+  // Query-only fragments do not have a leading `?`, so the URL-like fallback cannot see them.
+  const firstQueryDelimiter = candidate.search(/[?&]/u);
+  const firstEquals = candidate.indexOf("=");
+  if (firstEquals >= 0 && (firstQueryDelimiter < 0 || firstEquals < firstQueryDelimiter)) {
+    return redactQueryString(candidate, depth);
+  }
+
+  const hashRouterQueryIndex = candidate.indexOf("?");
+  if (hashRouterQueryIndex >= 0) {
+    const query = candidate.slice(hashRouterQueryIndex + 1);
+    const redactedQuery = redactQueryString(query, depth);
+    const prefix = candidate.slice(0, hashRouterQueryIndex + 1);
+    const redactedPrefix = redactEncodedUrlLikeString(redactUrlLikeFallback(prefix), depth + 1);
+    return `${redactedPrefix}${redactedQuery}`;
+  }
+
+  const fallback = redactUrlLikeFallback(candidate);
+  if (!looksLikeNestedUrlValue(fallback)) {
+    return fallback;
+  }
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(fallback);
+  } catch {
+    return "***";
+  }
+  if (decoded === fallback) {
+    return fallback;
+  }
+  const redactedDecoded = redactFragment(decoded, depth + 1);
+  return redactedDecoded === decoded ? fallback : encodeURIComponent(redactedDecoded);
+}
+
+function redactEncodedNestedUrlPath(value: string, depth: number): string {
+  if (!looksLikeNestedUrlValue(value)) {
+    return value;
+  }
+  if (depth > MAX_NESTED_URL_REDACTION_DEPTH) {
+    return "***";
+  }
+
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(value);
+  } catch {
+    return "***";
+  }
+  if (decoded === value) {
+    return value;
+  }
+
+  const direct = redactSensitiveUrlLikeStringAtDepth(decoded, depth);
+  if (direct.value !== decoded) {
+    // Once a secret is found, emit the sanitized decoded path instead of recreating
+    // attacker-controlled encoding layers that could hide it again.
+    return direct.value;
+  }
+  // Unresolved decoded authorities can restore credentials behind any delimiter; fail closed.
+  if (hasUnresolvedEmbeddedUrlUserInfo(decoded)) {
+    return "***";
+  }
+  if (direct.parsedWholeUrl) {
+    return value;
+  }
+
+  const nested = redactEncodedNestedUrlPath(decoded, depth + 1);
+  return nested === decoded ? value : nested;
+}
+
+function redactSensitiveUrlAtDepth(value: string, depth: number): UrlRedactionResult {
+  try {
+    const directRedaction = redactDirectSensitiveUrl(value);
+    const parsed = new URL(directRedaction);
+    if (depth > MAX_NESTED_URL_REDACTION_DEPTH) {
+      return { value: "***", parsedWholeUrl: true };
+    }
+    let mutated = directRedaction !== value;
+    const redactedNestedPath = redactEmbeddedUrlUserInfo(
+      redactEncodedNestedUrlPath(parsed.pathname, depth + 1),
+    );
+    if (redactedNestedPath !== parsed.pathname) {
+      const originalPath = parsed.pathname;
+      parsed.pathname = redactedNestedPath;
+      if (parsed.pathname === originalPath) {
+        // Opaque schemes such as `data:` and diagnostic prefixes such as `fatal:` reject
+        // pathname assignment. Let the whole-string scanner sanitize their embedded URLs.
+        return { value: directRedaction, parsedWholeUrl: false };
+      }
+      mutated = true;
+    }
+    const redactedQuery = redactQueryString(parsed.search.slice(1), depth);
+    if (redactedQuery !== parsed.search.slice(1)) {
+      parsed.search = redactedQuery;
+      mutated = true;
+    }
+
+    const fragment = parsed.hash.slice(1);
+    const redactedHash = redactFragment(fragment, depth + 1);
+    if (redactedHash !== fragment) {
+      parsed.hash = redactedHash;
+      mutated = true;
+    }
+    return { value: mutated ? parsed.toString() : value, parsedWholeUrl: true };
+  } catch {
+    return { value, parsedWholeUrl: false };
+  }
+}
+
+function redactSensitiveUrlLikeStringAtDepth(value: string, depth: number): UrlRedactionResult {
+  const redactedUrl = redactSensitiveUrlAtDepth(value, depth);
+  if (redactedUrl.parsedWholeUrl) {
     return redactedUrl;
   }
-  const redactedFallback = value
-    .replace(/\/\/([^@/?#\s]+)@/g, "//***:***@")
-    .replace(/([?&])([^=&]+)=([^&]*)/g, (match, prefix: string, key: string) =>
-      isSensitiveUrlQueryParamName(key) ? `${prefix}${key}=***` : match,
-    );
-  return redactSensitiveUrlPath(redactedFallback);
+  const redactedFallback = redactUrlLikeFallback(redactedUrl.value);
+  const redactedRelativeFragment = redactRelativeUrlFragment(redactedFallback, depth);
+  return {
+    value: redactEncodedUrlLikeString(redactedRelativeFragment, depth + 1),
+    parsedWholeUrl: false,
+  };
+}
+
+function redactEncodedUrlLikeString(value: string, depth: number): string {
+  if (!looksLikeNestedUrlValue(value)) {
+    return value;
+  }
+  if (depth > MAX_NESTED_URL_REDACTION_DEPTH) {
+    return "***";
+  }
+
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(value);
+  } catch {
+    return "***";
+  }
+  if (decoded === value) {
+    return value;
+  }
+
+  const redactedDecoded = redactSensitiveUrlLikeStringAtDepth(decoded, depth + 1);
+  if (redactedDecoded.value !== decoded) {
+    return redactedDecoded.value;
+  }
+  return hasUnresolvedEmbeddedUrlUserInfo(decoded) ? "***" : value;
+}
+
+function redactNestedUrlValue(value: string, depth: number): string {
+  if (!looksLikeNestedUrlValue(value)) {
+    return value;
+  }
+  if (depth > MAX_NESTED_URL_REDACTION_DEPTH) {
+    return "***";
+  }
+
+  const direct = redactSensitiveUrlLikeStringAtDepth(value, depth);
+  // A valid safe URL is terminal; decoding it again could reinterpret its encoded path or query.
+  if (direct.value !== value) {
+    return direct.value;
+  }
+  if (hasUnresolvedEmbeddedUrlUserInfo(value)) {
+    return "***";
+  }
+  if (direct.parsedWholeUrl) {
+    return value;
+  }
+
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(value);
+  } catch {
+    return "***";
+  }
+  if (decoded === value || !looksLikeNestedUrlValue(decoded)) {
+    return value;
+  }
+
+  const redactedDecoded = redactNestedUrlValue(decoded, depth + 1);
+  return redactedDecoded === decoded ? value : encodeURIComponent(redactedDecoded);
+}
+
+/** Redacts credentials and sensitive query params from URL values. */
+export function redactSensitiveUrl(value: string): string {
+  return redactSensitiveUrlLikeStringAtDepth(value, 0).value;
+}
+
+/** Redacts sensitive URL-looking substrings even when the full value is not a valid URL. */
+export function redactSensitiveUrlLikeString(value: string): string {
+  return redactSensitiveUrlLikeStringAtDepth(value, 0).value;
 }

--- a/packages/net-policy/src/redact-sensitive-url.ts
+++ b/packages/net-policy/src/redact-sensitive-url.ts
@@ -42,18 +42,14 @@ const URL_QUERY_NAME_SEPARATOR_RE = /[\p{C}\p{Z}\u115F\u1160\u3164\uFFA0+]/gu;
 
 // Telegram bot credentials use `/bot<token>/...`; align this shape with logging/redact.ts.
 const TELEGRAM_BOT_TOKEN_PATH_RE = /\/bot\d{6,}(?::|%3[aA])[A-Za-z0-9_-]{20,}(?=\/|$)/giu;
-// Nested callbacks may be repeatedly percent-encoded. Bound recursive decoding so hostile
-// diagnostics cannot grow work without limit; unresolved URL-like values then fail closed.
+// Bound recursive decoding so hostile nested callbacks cannot grow work without limit.
 const MAX_NESTED_URL_REDACTION_DEPTH = 8;
 const URL_SCHEME_RE = /(?:^|[^a-z\d+.-])[a-z][a-z\d+.-]{0,31}:/iu;
 const SPECIAL_SCHEME_AUTHORITY_RE = /\b(?:https?|wss?|ftp):[\\/]{0,2}[^\\/?#\s]*/giu;
 const SPECIAL_SCHEME_SPILLED_USERINFO_RE = /\b(?:https?|wss?|ftp):[\\/]{0,2}[^\s]*@[^\\/?#\s]*/giu;
 const PROTOCOL_RELATIVE_AUTHORITY_RE = /[\\/]{2,}[^\\/?#\s]*/gu;
 
-type UrlRedactionResult = {
-  value: string;
-  parsedWholeUrl: boolean;
-};
+type UrlRedactionResult = { value: string; parsedWholeUrl: boolean };
 
 function redactSensitiveUrlPath(value: string): string {
   return value.replace(TELEGRAM_BOT_TOKEN_PATH_RE, "/bot***");
@@ -253,8 +249,7 @@ function redactEmbeddedUrlUserInfo(value: string): string {
       }
       const authorityPrefix = candidate.slice(authorityStart, absoluteReservedDelimiter);
       const possiblePort = candidate.slice(credentialSeparator + 1, absoluteReservedDelimiter);
-      // Decoded reserved delimiters can hide inside userinfo, but ordinary host:port and IPv6
-      // URLs must remain untouched even when a later path, query, or fragment contains `@`.
+      // Keep unambiguous host:port and IPv6 authorities when later URL components contain `@`.
       if (/^\d+$/u.test(possiblePort) || /^\[[^\]]+\](?::\d+)?$/u.test(authorityPrefix)) {
         return candidate;
       }
@@ -274,8 +269,19 @@ function redactEmbeddedUrlUserInfo(value: string): string {
 
 function hasUnresolvedEmbeddedUrlUserInfo(value: string): boolean {
   for (const match of value.matchAll(/(?:\b(?:https?|wss?|ftp):[\\/]{0,2}|[\\/]{2,})/giu)) {
-    const authorityStart = (match.index ?? 0) + match[0].length;
-    if (/(?<!\*\*\*:\*\*\*)@/u.test(value.slice(authorityStart))) {
+    const remainder = value.slice((match.index ?? 0) + match[0].length);
+    const userInfoEnd = remainder.search(/(?<!\*\*\*:\*\*\*)@/u);
+    const authorityEnd = remainder.search(/[\\/?#]/u);
+    // After the authority, only path text shaped like spilled userinfo remains ambiguous.
+    const pathBeforeAt = remainder.slice(authorityEnd + 1, userInfoEnd);
+    if (
+      userInfoEnd >= 0 &&
+      (authorityEnd < 0 ||
+        userInfoEnd <= authorityEnd ||
+        (remainder[authorityEnd] === "/" &&
+          (pathBeforeAt.includes(":") ||
+            /^[^/?#\s]+\.[^/?#\s]+(?:[/?#]|$)/u.test(remainder.slice(userInfoEnd + 1)))))
+    ) {
       return true;
     }
   }
@@ -360,14 +366,9 @@ function redactEncodedNestedUrlPath(value: string, depth: number): string {
   }
 
   const direct = redactSensitiveUrlLikeStringAtDepth(decoded, depth);
-  if (direct.value !== decoded) {
-    // Once a secret is found, emit the sanitized decoded path instead of recreating
-    // attacker-controlled encoding layers that could hide it again.
-    return direct.value;
-  }
-  // Unresolved decoded authorities can restore credentials behind any delimiter; fail closed.
-  if (hasUnresolvedEmbeddedUrlUserInfo(decoded)) {
-    return "***";
+  // Emit sanitized decoded secrets; unresolved decoded authorities fail closed.
+  if (direct.value !== decoded || hasUnresolvedEmbeddedUrlUserInfo(decoded)) {
+    return direct.value !== decoded ? direct.value : "***";
   }
   if (direct.parsedWholeUrl) {
     return value;
@@ -392,8 +393,7 @@ function redactSensitiveUrlAtDepth(value: string, depth: number): UrlRedactionRe
       const originalPath = parsed.pathname;
       parsed.pathname = redactedNestedPath;
       if (parsed.pathname === originalPath) {
-        // Opaque schemes such as `data:` and diagnostic prefixes such as `fatal:` reject
-        // pathname assignment. Let the whole-string scanner sanitize their embedded URLs.
+        // Opaque/diagnostic schemes reject pathname assignment; use the whole-string scanner.
         return { value: directRedaction, parsedWholeUrl: false };
       }
       mutated = true;
@@ -448,8 +448,8 @@ function redactEncodedUrlLikeString(value: string, depth: number): string {
   }
 
   const redactedDecoded = redactSensitiveUrlLikeStringAtDepth(decoded, depth + 1);
-  if (redactedDecoded.value !== decoded) {
-    return redactedDecoded.value;
+  if (redactedDecoded.value !== decoded || redactedDecoded.parsedWholeUrl) {
+    return redactedDecoded.value === decoded ? value : redactedDecoded.value;
   }
   return hasUnresolvedEmbeddedUrlUserInfo(decoded) ? "***" : value;
 }

--- a/src/channels/account-snapshot-fields.test.ts
+++ b/src/channels/account-snapshot-fields.test.ts
@@ -1,6 +1,13 @@
 // Account snapshot field tests cover channel account snapshot serialization fields.
 import { describe, expect, it } from "vitest";
-import { projectSafeChannelAccountSnapshotFields } from "./account-snapshot-fields.js";
+import {
+  projectSafeChannelAccountSnapshotFields,
+  redactChannelAccountSnapshotBaseUrl,
+} from "./account-snapshot-fields.js";
+
+function joinUrlParts(...parts: string[]): string {
+  return parts.join("");
+}
 
 describe("projectSafeChannelAccountSnapshotFields", () => {
   it("omits webhook and public-key style fields from generic snapshots", () => {
@@ -34,6 +41,63 @@ describe("projectSafeChannelAccountSnapshotFields", () => {
     expect(snapshot).toEqual({
       baseUrl: "https://chat.example.test/",
     });
+  });
+
+  it("redacts query, nested URL, and fragment credentials from baseUrl fields", () => {
+    const nested = encodeURIComponent(
+      joinUrlParts(
+        "https://nested-user",
+        ":",
+        "nested-pass",
+        "@nested.example/cb?access_token=",
+        "nested-token",
+      ),
+    );
+    const snapshot = projectSafeChannelAccountSnapshotFields({
+      baseUrl: joinUrlParts(
+        "https://outer-user",
+        ":",
+        "outer-pass",
+        "@chat.example.test/?token=",
+        "outer-token",
+        `&next=${nested}#auth_token=`,
+        "fragment-token",
+      ),
+    });
+
+    expect(snapshot.baseUrl).not.toContain("outer-user");
+    expect(snapshot.baseUrl).not.toContain("outer-pass");
+    expect(snapshot.baseUrl).not.toContain("outer-token");
+    expect(snapshot.baseUrl).not.toContain("nested-user");
+    expect(snapshot.baseUrl).not.toContain("nested-pass");
+    expect(snapshot.baseUrl).not.toContain("nested-token");
+    expect(snapshot.baseUrl).not.toContain("fragment-token");
+    expect(snapshot.baseUrl).toContain("token=***");
+  });
+
+  it("redacts plugin snapshots without mutating raw account state", () => {
+    const rawBaseUrl = joinUrlParts(
+      "https://user",
+      ":",
+      "pass",
+      "@chat.example.test/?token=",
+      "secret",
+    );
+    const account = Object.freeze({
+      baseUrl: rawBaseUrl,
+    });
+    const snapshot = { ...account };
+
+    const redacted = redactChannelAccountSnapshotBaseUrl(snapshot);
+
+    expect(redacted).toEqual({ baseUrl: "https://chat.example.test/?token=***" });
+    expect(account.baseUrl).toBe(rawBaseUrl);
+    expect(snapshot.baseUrl).toBe(rawBaseUrl);
+  });
+
+  it("retains object identity when a plugin snapshot baseUrl is already safe", () => {
+    const snapshot = { baseUrl: "https://chat.example.test/?keep=visible" };
+    expect(redactChannelAccountSnapshotBaseUrl(snapshot)).toBe(snapshot);
   });
 
   it("preserves non-secret transport liveness timestamps", () => {

--- a/src/channels/account-snapshot-fields.ts
+++ b/src/channels/account-snapshot-fields.ts
@@ -2,6 +2,7 @@
  * Status-safe channel account projection helpers for CLI, status APIs, and plugin SDK callers.
  * This file is the redaction boundary between runtime account objects and public snapshots.
  */
+import { redactSensitiveUrlLikeString } from "@openclaw/net-policy/redact-sensitive-url";
 import { stripUrlUserInfo } from "@openclaw/net-policy/url-userinfo";
 import { asFiniteNumber } from "@openclaw/normalization-core/number-coercion";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
@@ -19,6 +20,19 @@ const CREDENTIAL_STATUS_KEYS = [
 ] as const;
 
 type CredentialStatusKey = (typeof CREDENTIAL_STATUS_KEYS)[number];
+
+/** Redacts a plugin-provided base URL at the public account-snapshot boundary. */
+export function redactChannelAccountSnapshotBaseUrl<T extends Partial<ChannelAccountSnapshot>>(
+  snapshot: T,
+): T {
+  if (typeof snapshot.baseUrl !== "string" || !snapshot.baseUrl) {
+    return snapshot;
+  }
+  const redactedBaseUrl = stripUrlUserInfo(redactSensitiveUrlLikeString(snapshot.baseUrl));
+  return redactedBaseUrl === snapshot.baseUrl
+    ? snapshot
+    : ({ ...snapshot, baseUrl: redactedBaseUrl } as T);
+}
 
 function readBoolean(record: Record<string, unknown>, key: string): boolean | undefined {
   return asBoolean(record[key]);
@@ -253,8 +267,8 @@ export function projectSafeChannelAccountSnapshotFields(
       ? { allowFrom: readStringArray(record, "allowFrom") }
       : {}),
     ...projectCredentialSnapshotFields(account),
-    // Base URLs are useful diagnostics, but embedded userinfo would expose credentials.
-    ...(baseUrl ? { baseUrl: stripUrlUserInfo(baseUrl) } : {}),
+    // Base URLs are useful diagnostics, but embedded credentials must not cross this boundary.
+    ...(baseUrl ? { baseUrl: stripUrlUserInfo(redactSensitiveUrlLikeString(baseUrl)) } : {}),
     ...(readBoolean(record, "allowUnmentionedGroups") !== undefined
       ? { allowUnmentionedGroups: readBoolean(record, "allowUnmentionedGroups") }
       : {}),

--- a/src/channels/account-snapshot-fields.ts
+++ b/src/channels/account-snapshot-fields.ts
@@ -21,17 +21,22 @@ const CREDENTIAL_STATUS_KEYS = [
 
 type CredentialStatusKey = (typeof CREDENTIAL_STATUS_KEYS)[number];
 
+/** Redacts a plugin-provided base URL after status hooks have produced their final record. */
+export function redactChannelStatusSummaryBaseUrl<T>(summary: T): T {
+  if (!isRecord(summary) || typeof summary.baseUrl !== "string" || !summary.baseUrl) {
+    return summary;
+  }
+  const redactedBaseUrl = stripUrlUserInfo(redactSensitiveUrlLikeString(summary.baseUrl));
+  return redactedBaseUrl === summary.baseUrl
+    ? summary
+    : ({ ...summary, baseUrl: redactedBaseUrl } as T);
+}
+
 /** Redacts a plugin-provided base URL at the public account-snapshot boundary. */
 export function redactChannelAccountSnapshotBaseUrl<T extends Partial<ChannelAccountSnapshot>>(
   snapshot: T,
 ): T {
-  if (typeof snapshot.baseUrl !== "string" || !snapshot.baseUrl) {
-    return snapshot;
-  }
-  const redactedBaseUrl = stripUrlUserInfo(redactSensitiveUrlLikeString(snapshot.baseUrl));
-  return redactedBaseUrl === snapshot.baseUrl
-    ? snapshot
-    : ({ ...snapshot, baseUrl: redactedBaseUrl } as T);
+  return redactChannelStatusSummaryBaseUrl(snapshot);
 }
 
 function readBoolean(record: Record<string, unknown>, key: string): boolean | undefined {

--- a/src/channels/account-summary.test.ts
+++ b/src/channels/account-summary.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { buildChannelAccountSnapshot } from "./account-summary.js";
+import type { ChannelPlugin } from "./plugins/types.plugin.js";
+
+describe("buildChannelAccountSnapshot", () => {
+  it("redacts a raw baseUrl returned by describeAccount without mutating the account", () => {
+    const rawBaseUrl = [
+      "https://",
+      "user",
+      ":",
+      "pass",
+      "@",
+      "chat.example.test/?token=",
+      "secret",
+    ].join("");
+    const account = Object.freeze({
+      baseUrl: "https://safe.example.test/",
+    });
+    const plugin = {
+      config: {
+        describeAccount: () => ({
+          baseUrl: rawBaseUrl,
+        }),
+      },
+    } as unknown as ChannelPlugin;
+
+    const snapshot = buildChannelAccountSnapshot({
+      plugin,
+      account,
+      cfg: {} as OpenClawConfig,
+      accountId: "default",
+      enabled: true,
+      configured: true,
+    });
+
+    expect(snapshot.baseUrl).toBe("https://chat.example.test/?token=***");
+    expect(account.baseUrl).toBe("https://safe.example.test/");
+  });
+});

--- a/src/channels/account-summary.ts
+++ b/src/channels/account-summary.ts
@@ -6,7 +6,10 @@
 import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { isRecord } from "../utils.js";
-import { projectSafeChannelAccountSnapshotFields } from "./account-snapshot-fields.js";
+import {
+  projectSafeChannelAccountSnapshotFields,
+  redactChannelAccountSnapshotBaseUrl,
+} from "./account-snapshot-fields.js";
 import type { ChannelAccountSnapshot } from "./plugins/types.core.js";
 import type { ChannelPlugin } from "./plugins/types.plugin.js";
 
@@ -22,13 +25,13 @@ export function buildChannelAccountSnapshot(params: {
   configured: boolean;
 }): ChannelAccountSnapshot {
   const described = params.plugin.config.describeAccount?.(params.account, params.cfg);
-  return {
+  return redactChannelAccountSnapshotBaseUrl({
     enabled: params.enabled,
     configured: params.configured,
     ...projectSafeChannelAccountSnapshotFields(params.account),
     ...described,
     accountId: params.accountId,
-  };
+  });
 }
 
 /**

--- a/src/channels/plugins/status.test.ts
+++ b/src/channels/plugins/status.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { buildChannelAccountSnapshotFromAccount } from "./status.js";
+import type { ChannelPlugin } from "./types.plugin.js";
+
+describe("buildChannelAccountSnapshotFromAccount", () => {
+  it("redacts a custom status snapshot baseUrl without mutating the resolved account", async () => {
+    const rawBaseUrl = [
+      "https://",
+      "user",
+      ":",
+      "pass",
+      "@",
+      "chat.example.test/?token=",
+      "secret",
+    ].join("");
+    const account = Object.freeze({
+      baseUrl: rawBaseUrl,
+    });
+    let receivedAccount: unknown;
+    const plugin = {
+      config: {},
+      status: {
+        buildAccountSnapshot: ({ account: hookAccount }: { account: unknown }) => {
+          receivedAccount = hookAccount;
+          return {
+            accountId: "custom",
+            baseUrl: (hookAccount as { baseUrl: string }).baseUrl,
+          };
+        },
+      },
+    } as unknown as ChannelPlugin<typeof account>;
+
+    const snapshot = await buildChannelAccountSnapshotFromAccount({
+      plugin,
+      cfg: {} as OpenClawConfig,
+      accountId: "default",
+      account,
+    });
+
+    expect(receivedAccount).toBe(account);
+    expect(snapshot.baseUrl).toBe("https://chat.example.test/?token=***");
+    expect(account.baseUrl).toBe(rawBaseUrl);
+  });
+});

--- a/src/channels/plugins/status.ts
+++ b/src/channels/plugins/status.ts
@@ -6,7 +6,10 @@
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { inspectChannelAccount } from "../account-inspection.js";
-import { projectSafeChannelAccountSnapshotFields } from "../account-snapshot-fields.js";
+import {
+  projectSafeChannelAccountSnapshotFields,
+  redactChannelAccountSnapshotBaseUrl,
+} from "../account-snapshot-fields.js";
 import type { ChannelPlugin } from "./types.plugin.js";
 import type { ChannelAccountSnapshot } from "./types.public.js";
 
@@ -51,13 +54,13 @@ export async function buildChannelAccountSnapshotFromAccount<ResolvedAccount>(pa
     };
   }
 
-  return {
+  return redactChannelAccountSnapshotBaseUrl({
     ...snapshot,
     accountId: normalizeOptionalString(snapshot.accountId) ? snapshot.accountId : params.accountId,
     enabled: snapshot.enabled ?? params.enabledFallback,
     configured: snapshot.configured ?? params.configuredFallback,
     ...(params.probe !== undefined && snapshot.probe === undefined ? { probe: params.probe } : {}),
-  };
+  });
 }
 
 export async function buildReadOnlySourceChannelAccountSnapshot<ResolvedAccount>(params: {

--- a/src/commands/health.snapshot.test.ts
+++ b/src/commands/health.snapshot.test.ts
@@ -755,6 +755,35 @@ describe("getHealthSnapshot", () => {
     expect(discord.accounts?.default?.tokenStatus).toBe("available");
   });
 
+  it("redacts base URL credentials returned by channel summary hooks", async () => {
+    testConfig = { channels: { discord: { token: "test" } } };
+    testStore = {};
+    const plugin = createDiscordHealthPlugin();
+    plugin.status = {
+      ...plugin.status,
+      buildChannelSummary: () => ({
+        configured: true,
+        baseUrl: [
+          "https://summary-user",
+          ":",
+          "summary-pass",
+          "@chat.example.test/?to",
+          "ken=test",
+        ].join(""),
+      }),
+    };
+    healthPluginsForTest = [plugin];
+
+    const snap = await getHealthSnapshot({ probe: false, includeSensitive: false });
+    const discord = snap.channels.discord as {
+      baseUrl?: string;
+      accounts?: Record<string, { baseUrl?: string }>;
+    };
+
+    expect(discord.baseUrl).toBe("https://chat.example.test/?token=***");
+    expect(discord.accounts?.default?.baseUrl).toBe("https://chat.example.test/?token=***");
+  });
+
   it("preserves plugin-derived configured state for unavailable SecretRef credentials", async () => {
     testConfig = {
       channels: {

--- a/src/commands/health.ts
+++ b/src/commands/health.ts
@@ -6,6 +6,7 @@ import { styleHealthChannelLine } from "../../packages/terminal-core/src/health-
 import { isRich } from "../../packages/terminal-core/src/theme.js";
 import { resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { inspectChannelAccount } from "../channels/account-inspection.js";
+import { redactChannelStatusSummaryBaseUrl } from "../channels/account-snapshot-fields.js";
 import {
   resolveChannelAccountConfigured,
   resolveChannelAccountEnabled,
@@ -667,14 +668,12 @@ export async function getHealthSnapshot(params?: {
             snapshot,
           })
         : undefined;
-      const record =
+      // Summary hooks overlay the safe snapshot, so reapply URL redaction after the final merge.
+      const record = redactChannelStatusSummaryBaseUrl(
         summary && typeof summary === "object"
           ? ({ ...snapshot, ...summary } as ChannelAccountHealthSummary)
-          : ({
-              ...snapshot,
-              accountId,
-              configured,
-            } satisfies ChannelAccountHealthSummary);
+          : ({ ...snapshot, accountId, configured } satisfies ChannelAccountHealthSummary),
+      );
       if (record.configured === undefined) {
         record.configured = configured;
       }

--- a/src/gateway/server-methods/channels.status.test.ts
+++ b/src/gateway/server-methods/channels.status.test.ts
@@ -211,6 +211,28 @@ describe("channelsHandlers channels.status", () => {
     expect(whatsapp.configured).toBe(true);
   });
 
+  it("redacts base URL credentials returned by channel summary hooks", async () => {
+    configureAutoEnabledChannels([
+      createChannelPlugin({
+        buildChannelSummary: () => ({
+          configured: true,
+          baseUrl: [
+            "https://summary-user",
+            ":",
+            "summary-pass",
+            "@chat.example.test/?to",
+            "ken=test",
+          ].join(""),
+        }),
+      }),
+    ]);
+
+    const payload = await runChannelsStatus({ probe: false, timeoutMs: 2000 });
+    const channels = requireRecord(payload.channels, "channels payload");
+    const whatsapp = requireRecord(channels.whatsapp, "whatsapp channel");
+    expect(whatsapp.baseUrl).toBe("https://chat.example.test/?token=***");
+  });
+
   it("caps probe timeout before passing it to channel plugins", async () => {
     const autoEnabledConfig = { autoEnabled: true };
     const probeAccount = vi.fn(async () => ({ ok: true }));

--- a/src/gateway/server-methods/channels.ts
+++ b/src/gateway/server-methods/channels.ts
@@ -9,6 +9,7 @@ import {
   validateChannelsLogoutParams,
   validateChannelsStatusParams,
 } from "../../../packages/gateway-protocol/src/index.js";
+import { redactChannelStatusSummaryBaseUrl } from "../../channels/account-snapshot-fields.js";
 import { buildChannelUiCatalog } from "../../channels/plugins/catalog.js";
 import { resolveChannelDefaultAccountId } from "../../channels/plugins/helpers.js";
 import {
@@ -169,16 +170,14 @@ async function runChannelStatusHook(params: {
   };
 }
 
-type ChannelStatusSummaryOutcome =
-  | { ok: true; value: unknown }
-  | { ok: false; error: string; timedOut?: boolean };
+type Summary = { ok: true; value: unknown } | { ok: false; error: string; timedOut?: boolean };
 
 async function runChannelStatusSummary(params: {
   channelId: ChannelId;
   timeoutMs: number;
   warnings: string[];
   run: () => unknown;
-}): Promise<ChannelStatusSummaryOutcome> {
+}): Promise<Summary> {
   const timeoutMs = Math.max(1, params.timeoutMs);
   const result = await raceWithTimeout({
     timeoutMs,
@@ -186,7 +185,8 @@ async function runChannelStatusSummary(params: {
   });
   const warningPrefix = `${params.channelId} summary`;
   if (result.kind === "value") {
-    return { ok: true, value: result.value };
+    // Summary hooks return the final public record, after account snapshot sanitization.
+    return { ok: true, value: redactChannelStatusSummaryBaseUrl(result.value) };
   }
   if (result.kind === "timeout") {
     const error = `summary timed out after ${timeoutMs}ms`;


### PR DESCRIPTION
Closes #98633
Closes #102932
Closes #105427

Supersedes the narrower fix in #98599. This fix is independent of #102272.

## What Problem This Solves

Fixes an issue where users sharing channel status and diagnostic output could expose credentials embedded in configured channel base URLs. The same redaction gap also allowed nested, encoded, path, query, fragment, and plugin-provided account URL fields to retain sensitive values.

## Why This Change Was Made

Channel account snapshots are now sanitized at their final public boundary, after plugin summary/status overrides, so every current consumer receives the same safe value. The shared URL redactor now recursively handles nested URL structure and fails closed for ambiguous encoded userinfo while preserving ordinary safe URLs and canonical redacted output.

## User Impact

`channels status`, `channels list`, `status --all`, health/status snapshots, and plugin-provided account summaries no longer print credentials from channel base URLs. Non-sensitive URL context remains available for diagnosis.

AI-assisted: implementation and validation were completed with Codex; I reviewed the resulting code paths, tests, and live proof.

## Evidence

- `$autoreview --mode local`: clean; no accepted/actionable findings.
- Blacksmith Testbox `tbx_01kxh2xx5wh8j61xvpv4xdd1wf`: 207 focused tests passed across net-policy, channel snapshot boundaries, status/list/health commands, MCP HTTP, config redaction, and Git install diagnostics.
- Blacksmith Testbox `tbx_01kxh2xx5wh8j61xvpv4xdd1wf`: `pnpm check:changed` passed all selected format, LOC, SDK surface, typecheck, lint, storage, runtime, cycle, webhook, and pairing guards.
- Blacksmith Testbox `tbx_01kxh2xx5wh8j61xvpv4xdd1wf`: production `pnpm build` passed for both candidate and base worktrees.
- Live CLI fix proof at `9ec1cffdb17`: 0 synthetic credential-marker hits across 7 real CLI invocations; safe URL context remained visible.
- Exact-base regression repro at `d08228eee13`: 20 credential-marker hits across `channels status`, `channels list`, and `status --all` under the identical scenario.
