### PR TITLE
refactor(media): trim internal exports

### DIFF
--- a/scripts/deadcode-exports.baseline.mjs
+++ b/scripts/deadcode-exports.baseline.mjs
@@ -380,8 +380,6 @@ export const KNIP_UNUSED_EXPORT_BASELINE = [
   "src/mcp/openclaw-tools-serve-config.ts: resolveOpenClawToolsMcpSystemAgentApproval",
   "src/mcp/openclaw-tools-serve-config.ts: resolveOpenClawToolsMcpSystemAgentSurface",
   "src/mcp/openclaw-tools-serve-config.ts: resolveOpenClawToolsMcpToolSelection",
-  "src/media/input-files.ts: fetchWithGuard",
-  "src/media/parse.ts: SplitMediaFromOutputOptions",
   "src/music-generation/capabilities.ts: resolveMusicGenerationMode",
   "src/music-generation/runtime.ts: MusicGenerationRuntimeDeps",
   "src/node-host/invoke.ts: testing",

--- a/src/media/input-files.fetch-guard.test.ts
+++ b/src/media/input-files.fetch-guard.test.ts
@@ -28,12 +28,11 @@ async function waitForMicrotaskTurn(): Promise<void> {
   });
 }
 
-let fetchWithGuard: typeof import("./input-files.js").fetchWithGuard;
 let extractImageContentFromSource: typeof import("./input-files.js").extractImageContentFromSource;
 let extractFileContentFromSource: typeof import("./input-files.js").extractFileContentFromSource;
 
 beforeAll(async () => {
-  ({ fetchWithGuard, extractImageContentFromSource, extractFileContentFromSource } =
+  ({ extractImageContentFromSource, extractFileContentFromSource } =
     await import("./input-files.js"));
 });
 
@@ -241,7 +240,7 @@ describe("HEIC input image normalization", () => {
   });
 });
 
-describe("fetchWithGuard", () => {
+describe("guarded input file URL fetches", () => {
   it("cancels ignored HTTP error bodies", async () => {
     let canceled = false;
     const stream = new ReadableStream<Uint8Array>({
@@ -263,11 +262,12 @@ describe("fetchWithGuard", () => {
     });
 
     await expect(
-      fetchWithGuard({
-        url: "https://example.com/file.bin",
-        maxBytes: 1024,
-        timeoutMs: 1000,
-        maxRedirects: 0,
+      extractFileContentFromSource({
+        source: { type: "url", url: "https://example.com/file.bin" },
+        limits: {
+          ...createFileSourceLimits(["application/octet-stream"], true),
+          maxBytes: 1024,
+        },
       }),
     ).rejects.toThrow("Failed to fetch: 503 Service Unavailable");
 
@@ -296,11 +296,12 @@ describe("fetchWithGuard", () => {
     });
 
     await expect(
-      fetchWithGuard({
-        url: "https://example.com/file.bin",
-        maxBytes: 1024,
-        timeoutMs: 1000,
-        maxRedirects: 0,
+      extractFileContentFromSource({
+        source: { type: "url", url: "https://example.com/file.bin" },
+        limits: {
+          ...createFileSourceLimits(["application/octet-stream"], true),
+          maxBytes: 1024,
+        },
       }),
     ).rejects.toThrow("Content too large: 2048 bytes");
 
@@ -329,11 +330,12 @@ describe("fetchWithGuard", () => {
     });
 
     await expect(
-      fetchWithGuard({
-        url: "https://example.com/file.bin",
-        maxBytes: 1024,
-        timeoutMs: 1000,
-        maxRedirects: 0,
+      extractFileContentFromSource({
+        source: { type: "url", url: "https://example.com/file.bin" },
+        limits: {
+          ...createFileSourceLimits(["application/octet-stream"], true),
+          maxBytes: 1024,
+        },
       }),
     ).rejects.toThrow("invalid content-length header: 1e9");
 
@@ -371,11 +373,12 @@ describe("fetchWithGuard", () => {
     });
 
     await expect(
-      fetchWithGuard({
-        url: "https://example.com/file.bin",
-        maxBytes: 6,
-        timeoutMs: 1000,
-        maxRedirects: 0,
+      extractFileContentFromSource({
+        source: { type: "url", url: "https://example.com/file.bin" },
+        limits: {
+          ...createFileSourceLimits(["application/octet-stream"], true),
+          maxBytes: 6,
+        },
       }),
     ).rejects.toThrow("Content too large");
 

--- a/src/media/input-files.ts
+++ b/src/media/input-files.ts
@@ -201,7 +201,7 @@ export function resolveInputFileLimits(config?: InputFileLimitsConfig): InputFil
 }
 
 /** Fetches an input source URL through SSRF, redirect, timeout, and byte-limit guards. */
-export async function fetchWithGuard(params: {
+async function fetchWithGuard(params: {
   url: string;
   maxBytes: number;
   timeoutMs: number;

--- a/src/media/parse.test.ts
+++ b/src/media/parse.test.ts
@@ -1,6 +1,8 @@
 // Media parse tests cover media reference parsing from text and payloads.
 import { describe, expect, it } from "vitest";
-import { splitMediaFromOutput, type SplitMediaFromOutputOptions } from "./parse.js";
+import { splitMediaFromOutput } from "./parse.js";
+
+type SplitMediaFromOutputOptions = NonNullable<Parameters<typeof splitMediaFromOutput>[1]>;
 
 describe("splitMediaFromOutput", () => {
   function expectParsedMediaOutputCase(

--- a/src/media/parse.ts
+++ b/src/media/parse.ts
@@ -29,7 +29,7 @@ type ParsedMediaOutputSegment =
     };
 
 /** Controls which non-MEDIA syntaxes may be lifted into media attachments. */
-export type SplitMediaFromOutputOptions = {
+type SplitMediaFromOutputOptions = {
   extractMarkdownImages?: boolean;
   extractMediaDirectives?: boolean;
 };


### PR DESCRIPTION
## What Problem This Solves

The dead-export ratchet still grandfathered two internal media implementation types/helpers used externally only by tests.

## Why This Change Was Made

The guarded URL-fetch tests now exercise the retained `extractFileContentFromSource` production boundary, and parse tests derive their options type from `splitMediaFromOutput`. The internal declarations are private and their baseline rows are removed.

## User Impact

No user-visible behavior change. `src/media/**` now has zero unused-export entries.

## Evidence

- Production Knip: deletion-only baseline 431 -> 429, +0/-2.
- Final fresh Testbox regeneration byte-stable; exact deadcode matched 429.
- Focused media proof: 78 tests green.
- Targeted formatting, type-aware lint, and core types green.
- Fresh whole-diff autoreview clean, 0.97 confidence.
