### PR TITLE
refactor(compat): trim internal naming exports

### DIFF
--- a/scripts/deadcode-exports.baseline.mjs
+++ b/scripts/deadcode-exports.baseline.mjs
@@ -330,8 +330,6 @@ export const KNIP_UNUSED_EXPORT_BASELINE = [
   "src/commitments/runtime.ts: resetCommitmentExtractionRuntimeForTests",
   "src/commitments/store.ts: loadCommitmentStore",
   "src/commitments/store.ts: saveCommitmentStore",
-  "src/compat/legacy-names.ts: MACOS_APP_SOURCES_DIR",
-  "src/compat/legacy-names.ts: PROJECT_NAME",
   "src/context-engine/registry.ts: clearContextEngineRuntimeQuarantine",
   "src/context-engine/registry.ts: ContextEngineRegistrationResult",
   "src/context-engine/registry.ts: getContextEngineFactory",

--- a/src/compat/legacy-names.test.ts
+++ b/src/compat/legacy-names.test.ts
@@ -1,10 +1,9 @@
 // Verifies legacy public names still map to current exports where supported.
 import { describe, expect, it } from "vitest";
-import { LEGACY_MANIFEST_KEYS, MANIFEST_KEY, PROJECT_NAME } from "./legacy-names.js";
+import { LEGACY_MANIFEST_KEYS, MANIFEST_KEY } from "./legacy-names.js";
 
 describe("compat/legacy-names", () => {
   it("keeps the current manifest key primary while exposing legacy fallbacks", () => {
-    expect(PROJECT_NAME).toBe("openclaw");
     expect(MANIFEST_KEY).toBe("openclaw");
     expect(LEGACY_MANIFEST_KEYS).toEqual(["clawdbot"]);
   });

--- a/src/compat/legacy-names.ts
+++ b/src/compat/legacy-names.ts
@@ -1,6 +1,6 @@
 // Product/package naming constants that bridge current OpenClaw manifests with
 // legacy Clawdbot keys still seen in older configs and packages.
-export const PROJECT_NAME = "openclaw" as const;
+const PROJECT_NAME = "openclaw" as const;
 
 const LEGACY_PROJECT_NAMES = ["clawdbot"] as const;
 
@@ -8,5 +8,3 @@ export const MANIFEST_KEY = PROJECT_NAME;
 
 /** Manifest keys accepted only for legacy compatibility. */
 export const LEGACY_MANIFEST_KEYS = LEGACY_PROJECT_NAMES;
-
-export const MACOS_APP_SOURCES_DIR = "apps/macos/Sources/OpenClaw" as const;

--- a/src/cron/cron-protocol-conformance.test.ts
+++ b/src/cron/cron-protocol-conformance.test.ts
@@ -8,7 +8,6 @@ import {
   CronJobStateSchema,
   CronRunLogEntrySchema,
 } from "../../packages/gateway-protocol/src/schema.js";
-import { MACOS_APP_SOURCES_DIR } from "../compat/legacy-names.js";
 
 type SchemaLike = {
   anyOf?: Array<SchemaLike>;
@@ -43,6 +42,7 @@ function extractConstUnionValues(schema: SchemaLike): string[] {
 
 const UI_FILES = ["ui/src/api/types.ts", "ui/src/lib/cron/index.ts", "ui/src/pages/cron/view.ts"];
 
+const MACOS_APP_SOURCES_DIR = "apps/macos/Sources/OpenClaw";
 const SWIFT_MODEL_CANDIDATES = [`${MACOS_APP_SOURCES_DIR}/CronModels.swift`];
 const SWIFT_STATUS_CANDIDATES = [`${MACOS_APP_SOURCES_DIR}/GatewayConnection.swift`];
 


### PR DESCRIPTION
## What Problem This Solves

The dead-export ratchet still grandfathered two legacy naming constants with no production consumer outside their owning module.

## Why This Change Was Made

`PROJECT_NAME` remains the private source of the retained manifest key. The macOS source path now lives as a test-local conformance fixture path. Both unused exports and baseline rows are removed.

## User Impact

No user-visible behavior change. `src/compat/**` now has zero unused-export entries.

## Evidence

- Production Knip: deletion-only baseline 429 -> 427, +0/-2.
- Final fresh Testbox regeneration byte-stable; exact deadcode matched 427.
- Compatibility and cron conformance: 4 tests green.
- Targeted formatting, type-aware lint, and core types green.
- Fresh whole-diff autoreview clean, 0.97 confidence.
