### PR TITLE
fix: cloud draft remains stuck after worker teardown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Control UI cloud draft cleanup:** allow failed cloud drafts to delete after authoritative worker teardown, clearing stuck recovery state without weakening live-worker ownership fences. Fixes #107755.
 - **Nested resource ignores:** honor slash-free patterns and escaped literal exclamation marks in nested ignore files during skill and resource discovery. Thanks @moguangyu5-design.
 - **Proxy bypass precedence:** honor blank lower-case `no_proxy` values shadowing upper-case `NO_PROXY` consistently with Undici, and reuse the canonical matcher for Telegram fallback selection.
 - **Tokenjuice exec compaction:** avoid retaining raw command output inside compacted middleware metadata, preventing large successful compactions from failing the middleware details-size guard.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Control UI cloud draft cleanup:** allow failed cloud drafts to delete after authoritative worker teardown, clearing stuck recovery state without weakening live-worker ownership fences. Fixes #107755.
 - **Nested resource ignores:** honor slash-free patterns and escaped literal exclamation marks in nested ignore files during skill and resource discovery. Thanks @moguangyu5-design.
 - **Proxy bypass precedence:** honor blank lower-case `no_proxy` values shadowing upper-case `NO_PROXY` consistently with Undici, and reuse the canonical matcher for Telegram fallback selection.
 - **Tokenjuice exec compaction:** avoid retaining raw command output inside compacted middleware metadata, preventing large successful compactions from failing the middleware details-size guard.

--- a/src/gateway/server-methods/sessions-shared.ts
+++ b/src/gateway/server-methods/sessions-shared.ts
@@ -50,10 +50,18 @@ export function resolveSessionWorkerPlacementMutationError(params: {
   const placement = params.context.workerSessionPlacementService
     ?.getMany([params.sessionId])
     .get(params.sessionId);
+  // Failed placement normally keeps destructive mutation fenced. Missing worker identity or an
+  // authoritative destroyed environment proves cleanup cannot orphan a live worker.
+  const failedPlacementCanDelete =
+    params.action === "delete" &&
+    placement?.state === "failed" &&
+    (placement.environmentId === null ||
+      params.context.workerEnvironmentService?.get(placement.environmentId)?.state === "destroyed");
   if (
     !placement ||
     placement.state === "local" ||
-    (params.action === "delete" && placement.state === "reclaimed")
+    (params.action === "delete" && placement.state === "reclaimed") ||
+    failedPlacementCanDelete
   ) {
     return undefined;
   }

--- a/src/gateway/server.sessions.worker-placement-lifecycle.test.ts
+++ b/src/gateway/server.sessions.worker-placement-lifecycle.test.ts
@@ -172,7 +172,13 @@ test("sessions.delete rejects failed placement with unresolved worker ownership"
     "sessions.delete",
     { key: sessionKey },
     {
-      context: { workerSessionPlacementService: placementReader },
+      context: {
+        workerEnvironmentService: {
+          get: () => ({ state: "attached" }),
+          resolveInferenceSessionForRunId: () => undefined,
+        } as never,
+        workerSessionPlacementService: placementReader,
+      },
     },
   );
 
@@ -180,6 +186,60 @@ test("sessions.delete rejects failed placement with unresolved worker ownership"
   expect(deleted.error?.message).toContain("cloud worker placement is failed");
   expect(loadSessionEntry(sessionKey).entry?.sessionId).toBe(sessionId);
   expect(embeddedRunMock.abortCalls).toEqual([]);
+});
+
+test("sessions.delete allows failed placement after its worker is destroyed", async () => {
+  await createSessionStoreDir();
+  const sessionKey = "discord:group:destroyed-failed-worker-session";
+  const sessionId = "sess-destroyed-failed-worker-delete";
+  await writeSessionStore({ entries: { [sessionKey]: sessionStoreEntry(sessionId) } });
+  const placementReader = sequencedPlacementReader([terminalPlacementRecord(sessionId, "failed")]);
+
+  const deleted = await directSessionReq(
+    "sessions.delete",
+    { key: sessionKey },
+    {
+      context: {
+        workerEnvironmentService: {
+          get: (environmentId: string) => {
+            expect(environmentId).toBe("worker-environment");
+            return { state: "destroyed" };
+          },
+          hasInferenceForSession: () => false,
+          resolveInferenceSessionForRunId: () => undefined,
+        } as never,
+        workerSessionPlacementService: placementReader,
+      },
+    },
+  );
+
+  expect(deleted.ok).toBe(true);
+  expect(deleted.payload).toMatchObject({ ok: true, deleted: true });
+  expect(loadSessionEntry(sessionKey).entry).toBeUndefined();
+});
+
+test("sessions.delete allows failed placement that never acquired a worker", async () => {
+  await createSessionStoreDir();
+  const sessionKey = "discord:group:unallocated-failed-worker-session";
+  const sessionId = "sess-unallocated-failed-worker-delete";
+  await writeSessionStore({ entries: { [sessionKey]: sessionStoreEntry(sessionId) } });
+  const placement = terminalPlacementRecord(sessionId, "failed");
+  if (placement.state !== "failed") {
+    throw new Error("expected failed placement fixture");
+  }
+  placement.environmentId = null;
+
+  const deleted = await directSessionReq(
+    "sessions.delete",
+    { key: sessionKey },
+    {
+      context: { workerSessionPlacementService: sequencedPlacementReader([placement]) },
+    },
+  );
+
+  expect(deleted.ok).toBe(true);
+  expect(deleted.payload).toMatchObject({ ok: true, deleted: true });
+  expect(loadSessionEntry(sessionKey).entry).toBeUndefined();
 });
 
 test("sessions.delete allows reclaimed placement with no live worker owner", async () => {


### PR DESCRIPTION
Closes #107755

## What Problem This Solves

Fixes an issue where users retrying a failed Control UI cloud draft would remain stuck on New Session after its worker had already been destroyed.

## Why This Change Was Made

Deletion remains fenced for failed placements with live or unresolved worker ownership. It is allowed only when no worker environment was acquired or the authoritative environment record is terminally `destroyed`.

## User Impact

Failed cloud drafts now clean themselves up after worker teardown, so users can retry from New Session without manual state repair.

## Evidence

- Live reproduction on ClawMac: failed placement plus destroyed AWS environment left `/new` disabled because `sessions.delete` rejected cleanup.
- Focused hosted test: `pnpm test src/gateway/server.sessions.worker-placement-lifecycle.test.ts` — 7/7 passed.
- Hosted `pnpm check:changed` — format, SDK/package guards, core and core-test typechecks, lint, database-first/import/security guards passed.
- Structured autoreview: clean, no actionable findings; 0.94 correctness confidence.
- Post-land live recovery and fresh AWS cloud-worker proof will be attached before closeout.
