### PR TITLE
refactor(pairing): model runtime type consumers

### DIFF
--- a/scripts/deadcode-exports.baseline.mjs
+++ b/scripts/deadcode-exports.baseline.mjs
@@ -381,8 +381,6 @@ export const KNIP_UNUSED_EXPORT_BASELINE = [
   "src/music-generation/capabilities.ts: resolveMusicGenerationMode",
   "src/music-generation/runtime.ts: MusicGenerationRuntimeDeps",
   "src/node-host/invoke.ts: testing",
-  "src/pairing/pairing-store.types.ts: ReadChannelAllowFromStoreForAccount",
-  "src/pairing/pairing-store.types.ts: UpsertChannelPairingRequestForAccount",
   "src/plugin-state/plugin-state-store.sqlite.ts: probePluginStateStore",
   "src/plugin-state/plugin-state-store.sqlite.ts: seedPluginStateDatabaseEntriesForTests",
   "src/plugin-state/plugin-state-store.sqlite.ts: setMaxPluginStateEntriesPerPluginForTests",

--- a/src/plugins/runtime/types-channel.ts
+++ b/src/plugins/runtime/types-channel.ts
@@ -24,13 +24,13 @@ import type {
   RecordSessionMetaFromInbound,
   UpdateLastRoute,
 } from "../../config/sessions/runtime-types.js";
+import type {
+  ReadChannelAllowFromStoreForAccount,
+  UpsertChannelPairingRequestForAccount,
+} from "../../pairing/pairing-store.types.js";
 
 type DispatchReplyWithBufferedBlockDispatcher =
   import("../../auto-reply/reply/provider-dispatcher.types.js").DispatchReplyWithBufferedBlockDispatcher;
-type ReadChannelAllowFromStoreForAccount =
-  import("../../pairing/pairing-store.types.js").ReadChannelAllowFromStoreForAccount;
-type UpsertChannelPairingRequestForAccount =
-  import("../../pairing/pairing-store.types.js").UpsertChannelPairingRequestForAccount;
 type RecordInboundSession = import("../../channels/session.types.js").RecordInboundSession;
 
 type RuntimeThreadBindingLifecycleRecord =


### PR DESCRIPTION
## What Problem This Solves

The dead-export ratchet treated two live pairing runtime types as unused because their consumers used inline type queries.

## Why This Change Was Made

Use explicit type-only imports in the plugin runtime channel contract so Knip models the real consumers. Runtime loading and the pairing contract remain unchanged.

## User Impact

No user-visible behavior change. The unused-export baseline shrinks from 427 to 425 without deleting a live contract.

## Evidence

- Production dead-export regeneration: byte-stable at 425 entries; zero `src/pairing/**` baseline rows.
- Exact `pnpm deadcode:exports`: green.
- Targeted formatting and type-aware lint: green.
- `pnpm tsgo:core`: green.
- Fresh autoreview: clean, 0.99.
- Final exact proof: https://github.com/openclaw/openclaw/actions/runs/29367325900
