### PR TITLE
test: isolate provider ownership fixture

### DIFF
--- a/src/agents/harness/selection.test.ts
+++ b/src/agents/harness/selection.test.ts
@@ -69,16 +69,13 @@ vi.mock("./builtin-openclaw.js", () => ({
     runAttempt: agentRunAttempt,
   }),
 }));
-// Auth planning has dedicated coverage; keep this harness suite on closed, deterministic inputs.
-vi.mock("../model-auth.js", () => ({
+vi.mock("../model-auth.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../model-auth.js")>()),
   applySecretRefHeaderSentinels: (model: unknown) => model,
   ensureAuthProfileStore: compactAuthMocks.ensureAuthProfileStore,
   ensureAuthProfileStoreWithoutExternalProfiles:
     compactAuthMocks.ensureAuthProfileStoreWithoutExternalProfiles,
   getApiKeyForModel: compactAuthMocks.getApiKeyForModel,
-  hasUsableCustomProviderApiKey: () => false,
-  resolveProviderEntryApiKeyProfileReference: () => ({ kind: "none" }),
-  shouldPreferExplicitConfigApiKeyAuth: () => false,
 }));
 vi.mock("../embedded-agent-runner/model.js", () => ({
   resolveModelAsync: compactAuthMocks.resolveModelAsync,
@@ -1076,13 +1073,13 @@ describe("selectAgentHarness", () => {
   it("passes manifest provider owners into plugin support checks", () => {
     providerOwnerMocks.resolveProviderRefOwnership.mockReturnValue({
       status: "owned",
-      pluginIds: ["anthropic"],
+      pluginIds: ["fixture-owner"],
     });
     const supports = vi.fn(() => ({
       supported: false as const,
       reason: "provider is owned by a native plugin",
     }));
-    const config = providerRuntimeConfig("anthropic", "copilot");
+    const config = providerRuntimeConfig("fixture-provider", "copilot");
     registerAgentHarness({
       id: "copilot",
       label: "Copilot",
@@ -1092,24 +1089,24 @@ describe("selectAgentHarness", () => {
 
     expect(() =>
       selectAgentHarness({
-        provider: "anthropic",
-        modelId: "claude-sonnet-4.6",
+        provider: "fixture-provider",
+        modelId: "fixture-model",
         config,
         agentHarnessRuntimeOverride: "copilot",
       }),
     ).toThrow("provider is owned by a native plugin");
 
     expect(providerOwnerMocks.resolveProviderRefOwnership).toHaveBeenCalledWith({
-      provider: "anthropic",
+      provider: "fixture-provider",
       config,
     });
     expect(supports).toHaveBeenCalledWith(
       expect.objectContaining({
-        provider: "anthropic",
-        modelId: "claude-sonnet-4.6",
+        provider: "fixture-provider",
+        modelId: "fixture-model",
         requestedRuntime: "copilot",
         providerOwnerStatus: "owned",
-        providerOwnerPluginIds: ["anthropic"],
+        providerOwnerPluginIds: ["fixture-owner"],
       }),
     );
   });

--- a/src/agents/harness/selection.test.ts
+++ b/src/agents/harness/selection.test.ts
@@ -69,13 +69,16 @@ vi.mock("./builtin-openclaw.js", () => ({
     runAttempt: agentRunAttempt,
   }),
 }));
-vi.mock("../model-auth.js", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("../model-auth.js")>()),
+// Auth planning has dedicated coverage; keep this harness suite on closed, deterministic inputs.
+vi.mock("../model-auth.js", () => ({
   applySecretRefHeaderSentinels: (model: unknown) => model,
   ensureAuthProfileStore: compactAuthMocks.ensureAuthProfileStore,
   ensureAuthProfileStoreWithoutExternalProfiles:
     compactAuthMocks.ensureAuthProfileStoreWithoutExternalProfiles,
   getApiKeyForModel: compactAuthMocks.getApiKeyForModel,
+  hasUsableCustomProviderApiKey: () => false,
+  resolveProviderEntryApiKeyProfileReference: () => ({ kind: "none" }),
+  shouldPreferExplicitConfigApiKeyAuth: () => false,
 }));
 vi.mock("../embedded-agent-runner/model.js", () => ({
   resolveModelAsync: compactAuthMocks.resolveModelAsync,


### PR DESCRIPTION
## What Problem This Solves

An ownership pass-through test used the real Anthropic provider, plugin, and model identifiers. Before it could assert the mocked ownership facts, harness support projection synchronously loaded and evaluated the bundled Anthropic provider-policy artifact. That unrelated work consumed 9.69s in the paired cold baseline and 3.42s in the warm baseline.

## Why This Change Was Made

Use fixture-only provider, plugin, and model identifiers for this ownership unit test. Its mocked ownership result, selection path, thrown reason, provider-owner call assertion, and support-context assertion stay intact; dedicated provider-policy surface, route-adapter, and Anthropic provider-policy tests retain the real artifact coverage.

## User Impact

Faster agent CI. Runtime behavior and all 98 harness tests are unchanged. Test-only change; no changelog entry.

## Evidence

- Same-Testbox paired run with the filesystem module cache disabled: 98/98 passed in every sample.
- Cold baseline/candidate: 20.52s -> 9.34s overall (54.5% faster); test execution 11.71s -> 1.22s.
- Warm candidate/baseline: 9.95s vs 12.66s overall (21.4% faster); test execution 1.50s vs 4.68s.
- Paired Testbox: https://github.com/openclaw/openclaw/actions/runs/29370570361
- Exact rebased head: 98/98 passed in 8.95s; `pnpm check:changed` passed.
- Exact-head Testbox: https://github.com/openclaw/openclaw/actions/runs/29370857751
- Fresh rebased-head autoreview: clean, no accepted/actionable findings (0.99 confidence).
