### PR TITLE
refactor(nostr): simplify profile relay subscriptions

### DIFF
--- a/extensions/nostr/src/nostr-profile-import.test.ts
+++ b/extensions/nostr/src/nostr-profile-import.test.ts
@@ -2,87 +2,121 @@
  * Tests for Nostr Profile Import
  */
 
-import { MAX_TIMER_TIMEOUT_MS } from "openclaw/plugin-sdk/number-runtime";
+import type { Event, SimplePool } from "nostr-tools";
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import type { NostrProfile } from "./config-schema.js";
 import { importProfileFromRelays, mergeProfiles } from "./nostr-profile-import.js";
 
+type ProfileSubscriptionParams = Parameters<SimplePool["subscribeMany"]>[2];
+
 const mockState = vi.hoisted(() => ({
-  subscribeMany: vi.fn(),
+  close: vi.fn(),
+  closeSubscription: vi.fn(),
+  subscribeMany:
+    vi.fn<(relays: string[], filter: unknown, params: ProfileSubscriptionParams) => void>(),
 }));
 
 vi.mock("nostr-tools", () => {
   class MockSimplePool {
-    subscribeMany(
-      relays: string[],
-      filters: unknown,
-      handlers: {
-        onevent: (event: Record<string, unknown>) => void;
-        oneose?: () => void;
-        onclose?: () => void;
-      },
-    ) {
-      mockState.subscribeMany(relays, filters, handlers);
-      queueMicrotask(() => handlers.oneose?.());
-      return {
-        close: vi.fn(),
-      };
+    subscribeMany(relays: string[], filter: unknown, params: ProfileSubscriptionParams) {
+      mockState.subscribeMany(relays, filter, params);
+      return { close: mockState.closeSubscription };
     }
 
-    close = vi.fn();
+    close(relays: string[]) {
+      mockState.close(relays);
+    }
   }
 
   return {
     SimplePool: MockSimplePool,
-    verifyEvent: vi.fn(() => true),
   };
 });
 
-// Mock SimplePool so importProfileFromRelays can assert the relay subscription shape.
+function createProfileEvent(overrides: Partial<Event> = {}): Event {
+  return {
+    id: "1".repeat(64),
+    pubkey: "a".repeat(64),
+    created_at: 1,
+    kind: 0,
+    tags: [],
+    content: JSON.stringify({ name: "profile" }),
+    sig: "b".repeat(128),
+    ...overrides,
+  };
+}
 
 describe("nostr-profile-import", () => {
   beforeEach(() => {
-    mockState.subscribeMany.mockClear();
+    mockState.close.mockReset();
+    mockState.closeSubscription.mockReset();
+    mockState.subscribeMany.mockReset();
   });
 
   describe("importProfileFromRelays", () => {
-    it("subscribes to profiles with a single Nostr filter object", async () => {
+    it("queries relays independently and uses the newest profile", async () => {
       const pubkey = "a".repeat(64);
+      const relays = ["wss://old.example", "wss://new.example"];
+      const relayEvents = [
+        createProfileEvent({ id: "1".repeat(64), created_at: 10 }),
+        createProfileEvent({
+          id: "2".repeat(64),
+          created_at: 20,
+          content: JSON.stringify({ name: "newest" }),
+        }),
+      ];
+      mockState.subscribeMany.mockImplementation((_relays, _filter, params) => {
+        params.onevent?.(relayEvents.shift()!);
+        params.oneose?.();
+      });
 
-      await importProfileFromRelays({
+      const result = await importProfileFromRelays({
         pubkey,
-        relays: ["wss://relay.example"],
-        timeoutMs: 1,
+        relays,
       });
 
-      expect(mockState.subscribeMany).toHaveBeenCalledTimes(1);
-      const filters = mockState.subscribeMany.mock.calls[0]?.[1];
-      expect(Array.isArray(filters)).toBe(false);
-      expect(filters).toMatchObject({
-        kinds: [0],
-        authors: [pubkey],
-        limit: 1,
+      expect(result).toMatchObject({
+        ok: true,
+        profile: { name: "newest" },
+        event: { id: "2".repeat(64), created_at: 20 },
+        relaysQueried: relays,
+        sourceRelay: relays[1],
       });
+      expect(mockState.subscribeMany).toHaveBeenCalledTimes(2);
+      for (const [index, relay] of relays.entries()) {
+        expect(mockState.subscribeMany).toHaveBeenNthCalledWith(
+          index + 1,
+          [relay],
+          { kinds: [0], authors: [pubkey], limit: 1 },
+          expect.objectContaining({
+            onevent: expect.any(Function),
+            oneose: expect.any(Function),
+            onclose: expect.any(Function),
+          }),
+        );
+      }
+      expect(mockState.close).toHaveBeenCalledWith(relays);
     });
 
-    it("caps oversized relay timeouts and clears pending timeout handles", async () => {
+    it("bounds the whole query while the native relay subscription is pending", async () => {
       vi.useFakeTimers();
       try {
-        const timeoutSpy = vi.spyOn(globalThis, "setTimeout");
-        const clearSpy = vi.spyOn(globalThis, "clearTimeout");
-
-        await importProfileFromRelays({
+        const resultPromise = importProfileFromRelays({
           pubkey: "a".repeat(64),
-          relays: ["wss://relay.example"],
-          timeoutMs: Number.MAX_SAFE_INTEGER,
+          relays: ["wss://slow.example"],
+          timeoutMs: 25,
         });
 
-        expect(timeoutSpy).toHaveBeenCalledWith(expect.any(Function), MAX_TIMER_TIMEOUT_MS);
-        expect(timeoutSpy).toHaveBeenCalledTimes(2);
-        expect(clearSpy).toHaveBeenCalledTimes(2);
+        await vi.advanceTimersByTimeAsync(25);
+
+        await expect(resultPromise).resolves.toMatchObject({
+          ok: false,
+          error: "No profile found on any relay",
+        });
+        expect(mockState.closeSubscription).toHaveBeenCalledOnce();
+        expect(mockState.close).toHaveBeenCalledWith(["wss://slow.example"]);
       } finally {
         vi.useRealTimers();
-        vi.restoreAllMocks();
       }
     });
   });

--- a/extensions/nostr/src/nostr-profile-import.ts
+++ b/extensions/nostr/src/nostr-profile-import.ts
@@ -5,7 +5,7 @@
  * Used to import existing profiles before editing.
  */
 
-import { SimplePool, verifyEvent, type Event } from "nostr-tools";
+import { SimplePool, type Event } from "nostr-tools";
 import { resolveTimerTimeoutMs } from "openclaw/plugin-sdk/number-runtime";
 import type { NostrProfile } from "./config-schema.js";
 import { contentToProfile, type ProfileContent } from "./nostr-profile-core.js";
@@ -106,67 +106,43 @@ export async function importProfileFromRelays(
   }
 
   const pool = new SimplePool();
-  const relaysQueried: string[] = [];
-  const timers: Array<ReturnType<typeof setTimeout>> = [];
-  const scheduleTimeout = (callback: () => void) => {
-    const timer = setTimeout(callback, timeoutMs);
-    timer.unref?.();
-    timers.push(timer);
-    return timer;
-  };
+  const relaysQueried = [...relays];
+  let deadlineTimer: ReturnType<typeof setTimeout> | undefined;
+  const deadline = new Promise<void>((resolve) => {
+    deadlineTimer = setTimeout(resolve, timeoutMs);
+    deadlineTimer.unref?.();
+  });
+  const subscriptions: Array<ReturnType<typeof pool.subscribeMany>> = [];
 
   try {
-    // Query all relays for kind:0 events from this pubkey
+    // Keep subscriptions separate: pool-wide ID dedupe runs before signature verification.
     const events: Array<{ event: Event; relay: string }> = [];
-
-    // Create timeout promise
-    const timeoutPromise = new Promise<void>((resolve) => {
-      scheduleTimeout(resolve);
-    });
-
-    // Create subscription promise
-    const subscriptionPromise = new Promise<void>((resolve) => {
-      let completed = 0;
-
-      for (const relay of relays) {
-        relaysQueried.push(relay);
-
-        const profileFilter = {
-          kinds: [0],
-          authors: [pubkey],
-          limit: 1,
-        } satisfies Parameters<typeof pool.subscribeMany>[1];
-
-        const sub = pool.subscribeMany([relay], profileFilter, {
-          onevent(event) {
-            events.push({ event, relay });
-          },
-          oneose() {
-            completed++;
-            if (completed >= relays.length) {
-              resolve();
-            }
-          },
-          onclose() {
-            completed++;
-            if (completed >= relays.length) {
-              resolve();
-            }
-          },
-        });
-
-        // Clean up subscription after timeout
-        scheduleTimeout(() => {
-          sub.close();
-        });
-      }
-    });
-
-    // Wait for either all relays to respond or timeout
-    await Promise.race([subscriptionPromise, timeoutPromise]);
-    for (const timer of timers.splice(0)) {
-      clearTimeout(timer);
-    }
+    await Promise.race([
+      Promise.all(
+        relays.map(
+          (relay) =>
+            new Promise<void>((resolve) => {
+              const subscription = pool.subscribeMany(
+                [relay],
+                { kinds: [0], authors: [pubkey], limit: 1 },
+                {
+                  onevent(event) {
+                    events.push({ event, relay });
+                  },
+                  oneose() {
+                    resolve();
+                  },
+                  onclose() {
+                    resolve();
+                  },
+                },
+              );
+              subscriptions.push(subscription);
+            }),
+        ),
+      ),
+      deadline,
+    ]);
 
     // No events found
     if (events.length === 0) {
@@ -178,31 +154,9 @@ export async function importProfileFromRelays(
     }
 
     // Find the event with the highest created_at (newest wins for replaceable events)
-    let bestEvent: { event: Event; relay: string } | null = null;
-    for (const item of events) {
-      if (!bestEvent || item.event.created_at > bestEvent.event.created_at) {
-        bestEvent = item;
-      }
-    }
-
-    if (!bestEvent) {
-      return {
-        ok: false,
-        error: "No valid profile event found",
-        relaysQueried,
-      };
-    }
-
-    // Verify the event signature
-    const isValid = verifyEvent(bestEvent.event);
-    if (!isValid) {
-      return {
-        ok: false,
-        error: "Profile event has invalid signature",
-        relaysQueried,
-        sourceRelay: bestEvent.relay,
-      };
-    }
+    const bestEvent = events.reduce((current, candidate) =>
+      candidate.event.created_at > current.event.created_at ? candidate : current,
+    );
 
     // Parse the profile content
     let content: ProfileContent;
@@ -235,8 +189,12 @@ export async function importProfileFromRelays(
       sourceRelay: bestEvent.relay,
     };
   } finally {
-    for (const timer of timers) {
-      clearTimeout(timer);
+    if (deadlineTimer) {
+      clearTimeout(deadlineTimer);
+    }
+    // Individual closers catch relay connections that finish after the deadline.
+    for (const subscription of subscriptions) {
+      subscription.close();
     }
     pool.close(relays);
   }


### PR DESCRIPTION
## What Problem This Solves

Nostr profile import duplicated relay lifecycle work already owned by the exact-pinned `nostr-tools` pool: per-relay timeout handles, completion counting, and a second signature check after the pool had already verified each event.

## Why This Change Was Made

Keep one native `SimplePool.subscribeMany` call per relay, resolve each relay on EOSE or close, and retain one unref'ed overall deadline. Per-relay subscriptions remain intentionally isolated because the dependency deduplicates event IDs before signature verification. Returned subscription closers are retained so connections completing after the deadline still tear down.

This removes 42 production lines and 8 lines overall while adding focused lifecycle coverage.

## User Impact

No intended behavior change. Profile imports still query relays in parallel, accept only dependency-verified events, honor the overall timeout, select the newest profile, and clean up late relay connections.

## Evidence

- `node scripts/run-vitest.mjs extensions/nostr/src/nostr-profile-import.test.ts extensions/nostr/src/nostr-profile-http.test.ts` — 33 tests passed.
- Type-aware Oxc lint, Oxfmt check, and `git diff --check` passed.
- Live `wss://nos.lol` probe returned a verified kind-0 event through the final `subscribeMany` path.
- Exact `nostr-tools@2.23.9` source and types inspected for verification order, EOSE timeout behavior, connection setup, and subscription cleanup.
- Fresh local and branch `$autoreview` passes reported no accepted/actionable findings after lifecycle fixes.
- Hosted CI intentionally not awaited per maintainer direction.
