### PR TITLE
refactor(system-agent): narrow internal turn types

### DIFF
--- a/scripts/deadcode-exports.baseline.mjs
+++ b/scripts/deadcode-exports.baseline.mjs
@@ -413,8 +413,6 @@ export const KNIP_UNUSED_EXPORT_BASELINE = [
   "src/skills/runtime/refresh.ts: resetSkillsRefreshForTest",
   "src/skills/runtime/remote-skills.ts: resetRemoteNodeSkillsForTests",
   "src/system-agent/agent-turn.ts: runSystemAgentTurnWithDeps",
-  "src/system-agent/agent-turn.ts: SystemAgentTurnDeps",
-  "src/system-agent/agent-turn.ts: SystemAgentTurnDirective",
   "src/tasks/detached-task-runtime.ts: resetDetachedTaskLifecycleRuntimeForTests",
   "src/tasks/detached-task-runtime.ts: setDetachedTaskLifecycleRuntime",
   "src/tasks/generated-media-task-activity.ts: resetGeneratedMediaTaskActivityForTests",

--- a/src/system-agent/agent-turn.test.ts
+++ b/src/system-agent/agent-turn.test.ts
@@ -10,7 +10,6 @@ import {
   createSystemAgentSession,
   runSystemAgentTurnWithDeps,
   type SystemAgentSession,
-  type SystemAgentTurnDeps,
 } from "./agent-turn.js";
 import { SystemAgentInferenceUnavailableError } from "./inference-error.js";
 import { resolveSystemAgentConfiguredRouteFromConfig } from "./inference-route.js";
@@ -30,6 +29,7 @@ vi.mock("../agents/harness/runtime-plugin.js", async (importOriginal) => ({
   ),
 }));
 
+type SystemAgentTurnDeps = NonNullable<Parameters<typeof runSystemAgentTurnWithDeps>[1]>;
 type RunCliAgentParams = Parameters<NonNullable<SystemAgentTurnDeps["runCliAgent"]>>[0];
 type RunEmbeddedAgentParams = Parameters<NonNullable<SystemAgentTurnDeps["runEmbeddedAgent"]>>[0];
 

--- a/src/system-agent/agent-turn.ts
+++ b/src/system-agent/agent-turn.ts
@@ -88,7 +88,7 @@ type SystemAgentRunCliAgent = (
   },
 ) => ReturnType<typeof import("../agents/cli-runner.js").runCliAgent>;
 
-export type SystemAgentTurnDeps = SystemAgentVerifiedInferenceDeps & {
+type SystemAgentTurnDeps = SystemAgentVerifiedInferenceDeps & {
   runEmbeddedAgent?: SystemAgentRunEmbeddedAgent;
   runCliAgent?: SystemAgentRunCliAgent;
   readConfigFileSnapshot?: typeof import("../config/config.js").readConfigFileSnapshot;

--- a/src/system-agent/chat-engine.ts
+++ b/src/system-agent/chat-engine.ts
@@ -7,6 +7,7 @@ import {
   createSystemAgentSession,
   runSystemAgentTurn,
   type SystemAgentSession,
+  type SystemAgentTurnDirective,
   type SystemAgentTurnRunner,
 } from "./agent-turn.js";
 import {
@@ -655,7 +656,7 @@ export class SystemAgentChatEngine {
 
   private async applyAgentTurnReply(loopReply: {
     text: string;
-    directive?: import("./agent-turn.js").SystemAgentTurnDirective;
+    directive?: SystemAgentTurnDirective;
   }): Promise<SystemAgentChatReply> {
     // Recheck after the model turn: the route may have changed while inference
     // was running, and its stale directive must never cross that boundary.


### PR DESCRIPTION
## What Problem This Solves

The dead-export ratchet still grandfathered two system-agent types whose real use was either internal or hidden behind an inline type query.

## Why This Change Was Made

Keep the dependency shape module-private and derive it from the retained test seam. Use an explicit type-only import for the live directive contract. The injected turn runner remains exported because it owns extensive backend behavior tests.

## User Impact

No user-visible behavior change. The unused-export baseline shrinks from 425 to 423.

## Evidence

- Production dead-export regeneration: byte-stable at 423 entries.
- Exact `pnpm deadcode:exports`: green.
- System-agent owner suites: 3 files, 178 tests green.
- Targeted formatting and type-aware lint: green.
- `pnpm tsgo:core`: green.
- Fresh autoreview: clean, 0.96.
- Final exact proof: https://github.com/openclaw/openclaw/actions/runs/29367901662
