### PR TITLE
fix(system-agent): reject untrusted plugin specs before proposing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1399,7 +1399,7 @@ jobs:
             // isolate each scenario so one invocation cannot pin a profile part.
             const compatibilityScenarioIds = new Set([
               "control-ui-chat-flow-playwright",
-              "crestodian-ring-zero-setup",
+              "system-agent-ring-zero-setup",
               "dreaming-shadow-trial-report",
               "gateway-smoke",
               "group-visible-reply-tool",

--- a/src/system-agent/assistant.ts
+++ b/src/system-agent/assistant.ts
@@ -169,7 +169,7 @@ async function requireVerifiedPlannerRoute(
 }
 
 async function createTempPlannerDir(): Promise<string> {
-  return await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-openclaw-planner-"));
+  return await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-planner-"));
 }
 
 async function removeTempPlannerDir(dir: string): Promise<void> {

--- a/src/system-agent/operations-execution-helpers.ts
+++ b/src/system-agent/operations-execution-helpers.ts
@@ -607,11 +607,12 @@ export async function executePluginInstall(
   runtime: RuntimeEnv,
   opts: ExecuteOptions,
 ): Promise<SystemAgentOperationResult> {
-  if (opts.approved) {
-    const validationError = validateSystemAgentPluginInstallSpec(operation.spec);
-    if (validationError) {
-      throw new Error(validationError);
-    }
+  // Reject an untrusted plugin source before proposing or installing it, not
+  // only on the approved apply — a formatted "plan" must never surface an
+  // arbitrary npm/url/file spec that bypassed the ClawHub trust boundary.
+  const validationError = validateSystemAgentPluginInstallSpec(operation.spec);
+  if (validationError) {
+    throw new Error(validationError);
   }
   const result = await applyPersistentOperation({
     auditOperation: "plugin.install",

--- a/src/system-agent/operations.test.ts
+++ b/src/system-agent/operations.test.ts
@@ -908,6 +908,22 @@ describe("parseSystemAgentOperation", () => {
     expect(mockConfig.readConfigFileSnapshot).not.toHaveBeenCalled();
   });
 
+  it("rejects arbitrary plugin sources before proposing or installing them", async () => {
+    const { runtime } = createSystemAgentTestRuntime();
+    const runPluginInstall = vi.fn();
+
+    // Untrusted spec must be rejected on the unapproved path too, so a
+    // formatted "plan" never surfaces an arbitrary source for approval.
+    await expect(
+      executeSystemAgentOperation(
+        { kind: "plugin-install", spec: "npm:@example/plugin" },
+        runtime,
+        { deps: { runPluginInstall } },
+      ),
+    ).rejects.toThrow("trusted shell");
+    expect(runPluginInstall).not.toHaveBeenCalled();
+  });
+
   it("refuses plugin uninstall because it cannot prove inference survives", async () => {
     const { runtime, lines } = createSystemAgentTestRuntime();
     const runPluginUninstall = vi.fn();


### PR DESCRIPTION
## What Problem This Solves

The Crestodian→OpenClaw rename ([#107320](https://github.com/openclaw/openclaw/pull/107320)) reconciled with [#102197](https://github.com/openclaw/openclaw/pull/102197) (ClawHub plugin-install trust check) under time pressure and accidentally restored a pre-#102197 `if (opts.approved)` wrapper around the **execute-time** validation in `executePluginInstall`. #102197 had deliberately removed that wrapper so an untrusted spec is rejected "before proposing or installing," and its regression test was dropped in the port.

## Why This Change Was Made

- Restore unconditional validation in `src/system-agent/operations-execution-helpers.ts`: an unapproved `plugin-install` op with an arbitrary npm/url/file spec must reject rather than produce a formatted "plan" proposing the untrusted source. Latent today (both op constructors — the parser and the ring-zero tool — validate first), so this is defense-in-depth + coverage, not a live exploit; but the innermost guardrail #102197 added should not silently regress.
- Re-add #102197's dropped test asserting the unapproved-path rejection (`operations.test.ts`).
- Two mechanical-rename residues: a stale `crestodian-ring-zero-setup` id in the CI smoke compat list (scenario renamed to `system-agent-ring-zero-setup`), and a doubled `openclaw-openclaw-planner-` tmpdir prefix in `assistant.ts`.

## User Impact

None user-visible. Restores a security-hardening invariant (ClawHub/bundled/official-only plugin installs) and its test.

## Evidence

- `operations.test.ts` passes (56, incl. the re-added `rejects arbitrary plugin sources before proposing or installing them`).
- Type-aware oxlint clean on touched files.
