### PR TITLE
fix(imessage): keep message actions within the current conversation

### DIFF
--- a/docs/channels/imessage.md
+++ b/docs/channels/imessage.md
@@ -584,7 +584,7 @@ All actions are enabled by default; use `channels.imessage.actions` to turn indi
   </Accordion>
 
   <Accordion title="Message IDs">
-    Inbound iMessage context includes both short `MessageSid` values and full message GUIDs (`MessageSidFull`) when available. Short IDs are scoped to the recent SQLite-backed reply cache and are checked against the current chat before use. If a short ID has expired or belongs to another chat, retry with the full `MessageSidFull`.
+    Inbound iMessage context includes both short `MessageSid` values and full message GUIDs (`MessageSidFull`) when available. Short IDs are scoped to the recent SQLite-backed reply cache and are checked against the current chat before use. If a short ID expires, retry with its `MessageSidFull` while targeting the conversation that supplied it. Full IDs do not bypass conversation or account binding, so replace an ID from another chat with one from the current target. Remote delegated calls can reject stale full IDs when current-conversation evidence is unavailable.
 
   </Accordion>
 

--- a/extensions/imessage/src/accounts.test.ts
+++ b/extensions/imessage/src/accounts.test.ts
@@ -1,7 +1,11 @@
 // Imessage tests cover accounts plugin behavior.
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   collectIMessageDuplicateAccountSourceWarnings,
+  hasExclusiveIMessageLocalDatabase,
   listEnabledIMessageAccounts,
   listIMessageAccountIds,
   resolveDefaultIMessageAccountId,
@@ -180,5 +184,133 @@ describe("iMessage duplicate-source watcher ownership", () => {
     } as never;
 
     expect(collectIMessageDuplicateAccountSourceWarnings({ cfg })).toEqual([]);
+  });
+});
+
+describe("iMessage local database account ownership", () => {
+  function createLocalFixture() {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-imessage-account-db-"));
+    const cliPath = path.join(root, "imsg");
+    const firstDbPath = path.join(root, "first.db");
+    const secondDbPath = path.join(root, "second.db");
+    fs.writeFileSync(cliPath, Buffer.from("cafebabe", "hex"));
+    fs.writeFileSync(firstDbPath, "");
+    fs.writeFileSync(secondDbPath, "");
+    return { root, cliPath, firstDbPath, secondDbPath };
+  }
+
+  it("rejects a database shared by two enabled accounts", () => {
+    const fixture = createLocalFixture();
+    try {
+      const cfg = {
+        channels: {
+          imessage: {
+            accounts: {
+              work: { cliPath: fixture.cliPath, dbPath: fixture.firstDbPath },
+              home: { cliPath: fixture.cliPath, dbPath: fixture.firstDbPath },
+            },
+          },
+        },
+      } as never;
+      const account = resolveIMessageAccount({ cfg, accountId: "work" });
+
+      expect(
+        hasExclusiveIMessageLocalDatabase({
+          cfg,
+          account,
+          cliPath: fixture.cliPath,
+          dbPath: fixture.firstDbPath,
+        }),
+      ).toBe(false);
+    } finally {
+      fs.rmSync(fixture.root, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects hard-linked paths to the same database", () => {
+    const fixture = createLocalFixture();
+    const linkedDbPath = path.join(fixture.root, "linked.db");
+    fs.linkSync(fixture.firstDbPath, linkedDbPath);
+    try {
+      const cfg = {
+        channels: {
+          imessage: {
+            accounts: {
+              work: { cliPath: fixture.cliPath, dbPath: fixture.firstDbPath },
+              home: { cliPath: fixture.cliPath, dbPath: linkedDbPath },
+            },
+          },
+        },
+      } as never;
+      const account = resolveIMessageAccount({ cfg, accountId: "work" });
+
+      expect(
+        hasExclusiveIMessageLocalDatabase({
+          cfg,
+          account,
+          cliPath: fixture.cliPath,
+          dbPath: fixture.firstDbPath,
+        }),
+      ).toBe(false);
+    } finally {
+      fs.rmSync(fixture.root, { recursive: true, force: true });
+    }
+  });
+
+  it("accepts distinct proven local databases and ignores explicit remote accounts", () => {
+    const fixture = createLocalFixture();
+    try {
+      const cfg = {
+        channels: {
+          imessage: {
+            accounts: {
+              work: { cliPath: fixture.cliPath, dbPath: fixture.firstDbPath },
+              home: { cliPath: fixture.cliPath, dbPath: fixture.secondDbPath },
+              remote: { cliPath: "/usr/local/bin/remote-imsg", remoteHost: "qa@example.invalid" },
+            },
+          },
+        },
+      } as never;
+      const account = resolveIMessageAccount({ cfg, accountId: "work" });
+
+      expect(
+        hasExclusiveIMessageLocalDatabase({
+          cfg,
+          account,
+          cliPath: fixture.cliPath,
+          dbPath: fixture.firstDbPath,
+        }),
+      ).toBe(true);
+    } finally {
+      fs.rmSync(fixture.root, { recursive: true, force: true });
+    }
+  });
+
+  it("fails closed when another local account source cannot be attested", () => {
+    const fixture = createLocalFixture();
+    try {
+      const cfg = {
+        channels: {
+          imessage: {
+            accounts: {
+              work: { cliPath: fixture.cliPath, dbPath: fixture.firstDbPath },
+              unknown: { cliPath: path.join(fixture.root, "unknown-imsg") },
+            },
+          },
+        },
+      } as never;
+      const account = resolveIMessageAccount({ cfg, accountId: "work" });
+
+      expect(
+        hasExclusiveIMessageLocalDatabase({
+          cfg,
+          account,
+          cliPath: fixture.cliPath,
+          dbPath: fixture.firstDbPath,
+        }),
+      ).toBe(false);
+    } finally {
+      fs.rmSync(fixture.root, { recursive: true, force: true });
+    }
   });
 });

--- a/extensions/imessage/src/accounts.ts
+++ b/extensions/imessage/src/accounts.ts
@@ -1,3 +1,4 @@
+import { statSync } from "node:fs";
 import { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk/account-id";
 import {
   createAccountListHelpers,
@@ -10,6 +11,7 @@ import { expectDefined } from "openclaw/plugin-sdk/expect-runtime";
 import { resolveAccountEntry } from "openclaw/plugin-sdk/routing";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { IMessageAccountConfig } from "./account-types.js";
+import { resolveLocalIMessageChatDbPath } from "./cli-path.js";
 
 export type ResolvedIMessageAccount = {
   accountId: string;
@@ -170,6 +172,15 @@ function resolveIMessageAccountSourceOwner(params: {
   return defaultOwner;
 }
 
+function resolveIMessageDatabaseFileIdentity(dbPath: string): string | undefined {
+  try {
+    const stats = statSync(dbPath);
+    return stats.isFile() ? `${stats.dev}:${stats.ino}` : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 /**
  * Returns the owner account id when `account` is an enabled duplicate of
  * another enabled account that targets the same local Messages source. Used
@@ -196,6 +207,52 @@ export function listEnabledIMessageAccounts(cfg: OpenClawConfig): ResolvedIMessa
   return listIMessageAccountIds(cfg)
     .map((accountId) => resolveIMessageAccount({ cfg, accountId }))
     .filter((account) => account.enabled);
+}
+
+export function hasExclusiveIMessageLocalDatabase(params: {
+  cfg: OpenClawConfig;
+  account: ResolvedIMessageAccount;
+  cliPath: string;
+  dbPath?: string;
+}): boolean {
+  const otherAccounts = listEnabledIMessageAccounts(params.cfg).filter(
+    (candidate) => candidate.accountId !== params.account.accountId,
+  );
+  if (otherAccounts.length === 0) {
+    return true;
+  }
+
+  const selectedDbPath = resolveLocalIMessageChatDbPath({
+    cliPath: params.cliPath,
+    dbPath: params.dbPath,
+    remoteHost: params.account.config.remoteHost,
+  });
+  if (!selectedDbPath) {
+    return false;
+  }
+
+  const selectedDbIdentity = resolveIMessageDatabaseFileIdentity(selectedDbPath);
+  if (!selectedDbIdentity) {
+    return false;
+  }
+
+  for (const candidate of otherAccounts) {
+    if (candidate.config.remoteHost?.trim()) {
+      continue;
+    }
+    const candidateDbPath = resolveLocalIMessageChatDbPath({
+      cliPath: candidate.config.cliPath?.trim() || "imsg",
+      dbPath: candidate.config.dbPath?.trim() || undefined,
+    });
+    if (!candidateDbPath) {
+      return false;
+    }
+    const candidateDbIdentity = resolveIMessageDatabaseFileIdentity(candidateDbPath);
+    if (!candidateDbIdentity || candidateDbIdentity === selectedDbIdentity) {
+      return false;
+    }
+  }
+  return true;
 }
 
 export function collectIMessageDuplicateAccountSourceWarnings(params: {

--- a/extensions/imessage/src/actions.runtime.test.ts
+++ b/extensions/imessage/src/actions.runtime.test.ts
@@ -255,6 +255,9 @@ describe("normalizeDirectChatIdentifier", () => {
   });
   it("leaves group identifiers (iMessage;+;chat...) unchanged", () => {
     expect(normalizeDirectChatIdentifierForTest("iMessage;+;chat0000")).toBe("iMessage;+;chat0000");
+    expect(normalizeDirectChatIdentifierForTest("iMessage;+;Some@example.com")).toBe(
+      "iMessage;+;Some@example.com",
+    );
   });
   it("leaves bare values unchanged", () => {
     expect(normalizeDirectChatIdentifierForTest("+12069106512")).toBe("+12069106512");

--- a/extensions/imessage/src/actions.runtime.ts
+++ b/extensions/imessage/src/actions.runtime.ts
@@ -7,12 +7,14 @@ import {
   resolveExpiresAtMsFromDurationMs,
 } from "openclaw/plugin-sdk/number-runtime";
 import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/temp-path";
+import { normalizeDirectChatIdentifier } from "./chat-context.js";
 import { runIMessageCliJsonCommand } from "./cli-output.js";
 import { createIMessageRpcClient } from "./client.js";
 import { extractMarkdownFormatRuns } from "./markdown-format.js";
+import { authorizeIMessageResourceReference } from "./message-resource.js";
 import {
-  normalizeDirectChatIdentifier,
   resolveIMessageMessageId as resolveIMessageMessageIdImpl,
+  type IMessageChatContext,
 } from "./monitor-reply-cache.js";
 import type { IMessageTarget } from "./targets.js";
 
@@ -198,6 +200,19 @@ async function withTempFile<T>(input: TempFileInput, fn: (path: string) => Promi
 
 export const imessageActionsRuntime = {
   resolveIMessageMessageId: resolveIMessageMessageIdImpl,
+
+  authorizeMessageReference(params: {
+    accountId: string;
+    chatContext: IMessageChatContext;
+    cliPath: string;
+    dbPath?: string;
+    hasExclusiveLocalDatabase: boolean;
+    remoteHost?: string;
+    messageId: string;
+    conversationReadOrigin?: string;
+  }): void {
+    authorizeIMessageResourceReference(params);
+  },
 
   async resolveChatGuidForTarget(params: {
     target: Extract<IMessageTarget, { kind: "chat_id" | "chat_identifier" }>;

--- a/extensions/imessage/src/actions.test.ts
+++ b/extensions/imessage/src/actions.test.ts
@@ -9,9 +9,12 @@ const probeMock = vi.hoisted(() => ({
 
 const runtimeMock = vi.hoisted(() => ({
   resolveIMessageMessageId: vi.fn((id: string) => id),
+  authorizeMessageReference: vi.fn(),
   resolveChatGuidForTarget: vi.fn(),
   sendReaction: vi.fn(),
   sendRichMessage: vi.fn(),
+  editMessage: vi.fn(),
+  unsendMessage: vi.fn(),
   sendAttachment: vi.fn(),
   renameGroup: vi.fn(),
   setGroupIcon: vi.fn(),
@@ -90,6 +93,7 @@ function imsgOptions(chatGuid = "") {
   return {
     cliPath: "imsg",
     dbPath: "/tmp/messages.db",
+    remoteHost: undefined,
     timeoutMs: undefined,
     chatGuid,
   };
@@ -99,9 +103,12 @@ describe("imessage message actions", () => {
   beforeEach(() => {
     runtimeMock.resolveIMessageMessageId.mockClear();
     runtimeMock.resolveIMessageMessageId.mockImplementation((id: string) => id);
+    runtimeMock.authorizeMessageReference.mockReset();
     runtimeMock.resolveChatGuidForTarget.mockReset();
     runtimeMock.sendReaction.mockReset();
     runtimeMock.sendRichMessage.mockReset();
+    runtimeMock.editMessage.mockReset();
+    runtimeMock.unsendMessage.mockReset();
     runtimeMock.sendAttachment.mockReset();
     runtimeMock.renameGroup.mockReset();
     runtimeMock.setGroupIcon.mockReset();
@@ -378,6 +385,7 @@ describe("imessage message actions", () => {
     const result = await imessageMessageActions.handleAction?.({
       action: "poll-vote",
       cfg: cfg(),
+      conversationReadOrigin: "delegated",
       params: {
         chatGuid: "iMessage;+;chat0000",
         pollId: "3",
@@ -397,6 +405,13 @@ describe("imessage message actions", () => {
         },
       ],
     ]);
+    expect(runtimeMock.authorizeMessageReference).toHaveBeenCalledWith(
+      expect.objectContaining({
+        accountId: "default",
+        messageId: "poll-full-guid",
+        conversationReadOrigin: "delegated",
+      }),
+    );
     expect(result).toMatchObject({
       details: { ok: true, messageId: "vote-guid", pollVotedOption: "Blue" },
     });
@@ -734,6 +749,7 @@ describe("imessage message actions", () => {
     await imessageMessageActions.handleAction?.({
       action: "react",
       cfg: cfg(),
+      conversationReadOrigin: "delegated",
       params: {
         chatGuid: "iMessage;+;chat0000",
         messageId: "message-guid",
@@ -753,7 +769,196 @@ describe("imessage message actions", () => {
         },
       ],
     ]);
+    expect(runtimeMock.authorizeMessageReference).toHaveBeenCalledWith({
+      accountId: "default",
+      chatContext: {
+        chatGuid: "iMessage;+;chat0000",
+      },
+      cliPath: "imsg",
+      dbPath: "/tmp/messages.db",
+      hasExclusiveLocalDatabase: true,
+      remoteHost: undefined,
+      messageId: "message-guid",
+      conversationReadOrigin: "delegated",
+    });
   });
+
+  it("rejects an unbound message before invoking the bridge", async () => {
+    probeMock.getCachedIMessagePrivateApiStatus.mockReturnValue({
+      available: true,
+      v2Ready: true,
+      selectors: {},
+    });
+    runtimeMock.authorizeMessageReference.mockImplementationOnce(() => {
+      throw new Error("iMessage message reference does not belong to the selected conversation.");
+    });
+
+    await expect(
+      imessageMessageActions.handleAction?.({
+        action: "react",
+        cfg: cfg(),
+        conversationReadOrigin: "delegated",
+        params: {
+          chatGuid: "iMessage;+;chat0000",
+          messageId: "foreign-guid",
+          emoji: "👍",
+        },
+      } as never),
+    ).rejects.toThrow("does not belong to the selected conversation");
+
+    expect(runtimeMock.sendReaction).not.toHaveBeenCalled();
+  });
+
+  it("rejects before resolving provider metadata for an unbound target alias", async () => {
+    probeMock.getCachedIMessagePrivateApiStatus.mockReturnValue({
+      available: true,
+      v2Ready: true,
+      selectors: {},
+    });
+    runtimeMock.authorizeMessageReference.mockImplementationOnce(() => {
+      throw new Error("iMessage message reference belongs to a different conversation.");
+    });
+
+    await expect(
+      imessageMessageActions.handleAction?.({
+        action: "react",
+        cfg: cfg(),
+        conversationReadOrigin: "delegated",
+        params: {
+          chatIdentifier: "foreign-chat",
+          messageId: "foreign-guid",
+          emoji: "👍",
+        },
+      } as never),
+    ).rejects.toThrow("different conversation");
+
+    expect(runtimeMock.resolveChatGuidForTarget).not.toHaveBeenCalled();
+    expect(runtimeMock.sendReaction).not.toHaveBeenCalled();
+  });
+
+  it("authorizes a provider-resolved GUID independently of its input alias", async () => {
+    probeMock.getCachedIMessagePrivateApiStatus.mockReturnValue({
+      available: true,
+      v2Ready: true,
+      selectors: {},
+    });
+    runtimeMock.resolveChatGuidForTarget.mockResolvedValue("iMessage;+;foreign");
+    runtimeMock.authorizeMessageReference.mockImplementation(({ chatContext }) => {
+      if (chatContext.chatGuid) {
+        throw new Error("iMessage message reference belongs to a different conversation.");
+      }
+    });
+
+    await expect(
+      imessageMessageActions.handleAction?.({
+        action: "react",
+        cfg: cfg(),
+        conversationReadOrigin: "delegated",
+        params: {
+          chatIdentifier: "trusted-alias",
+          messageId: "message-guid",
+          emoji: "👍",
+        },
+      } as never),
+    ).rejects.toThrow("different conversation");
+
+    expect(runtimeMock.authorizeMessageReference.mock.calls).toEqual([
+      [expect.objectContaining({ chatContext: { chatIdentifier: "trusted-alias" } })],
+      [expect.objectContaining({ chatContext: { chatGuid: "iMessage;+;foreign" } })],
+    ]);
+    expect(runtimeMock.sendReaction).not.toHaveBeenCalled();
+  });
+
+  it("uses one canonical selector when explicit and fallback targets disagree", async () => {
+    probeMock.getCachedIMessagePrivateApiStatus.mockReturnValue({
+      available: true,
+      v2Ready: true,
+      selectors: {},
+    });
+    runtimeMock.sendReaction.mockResolvedValue(undefined);
+
+    await imessageMessageActions.handleAction?.({
+      action: "react",
+      cfg: cfg(),
+      params: {
+        chatGuid: "iMessage;+;selected",
+        target: "chat_identifier:ignored",
+        messageId: "message-guid",
+        emoji: "👍",
+      },
+    } as never);
+
+    expect(runtimeMock.resolveChatGuidForTarget).not.toHaveBeenCalled();
+    expect(runtimeMock.authorizeMessageReference).toHaveBeenCalledTimes(2);
+    for (const [authorization] of runtimeMock.authorizeMessageReference.mock.calls) {
+      expect(authorization.chatContext).toStrictEqual({ chatGuid: "iMessage;+;selected" });
+    }
+  });
+
+  it("rejects conflicting explicit chat aliases before provider reads", async () => {
+    probeMock.getCachedIMessagePrivateApiStatus.mockReturnValue({
+      available: true,
+      v2Ready: true,
+      selectors: {},
+    });
+
+    await expect(
+      imessageMessageActions.handleAction?.({
+        action: "react",
+        cfg: cfg(),
+        params: {
+          chatGuid: "iMessage;+;one",
+          chatIdentifier: "two",
+          messageId: "message-guid",
+          emoji: "👍",
+        },
+      } as never),
+    ).rejects.toThrow("conflicting delivery target aliases");
+
+    expect(runtimeMock.resolveChatGuidForTarget).not.toHaveBeenCalled();
+    expect(runtimeMock.authorizeMessageReference).not.toHaveBeenCalled();
+    expect(runtimeMock.sendReaction).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["edit", { messageId: "message-guid", text: "updated" }, runtimeMock.editMessage],
+    ["unsend", { messageId: "message-guid" }, runtimeMock.unsendMessage],
+  ] as const)(
+    "authorizes %s references before native mutation",
+    async (action, params, mutation) => {
+      probeMock.getCachedIMessagePrivateApiStatus.mockReturnValue({
+        available: true,
+        v2Ready: true,
+        selectors: { editMessage: true, retractMessagePart: true },
+      });
+      mutation.mockResolvedValue(undefined);
+
+      await imessageMessageActions.handleAction?.({
+        action,
+        cfg: cfg(),
+        conversationReadOrigin: "direct-operator",
+        params: { chatGuid: "iMessage;+;chat0000", ...params },
+      } as never);
+
+      expect(runtimeMock.resolveIMessageMessageId.mock.calls).toHaveLength(2);
+      expect(runtimeMock.resolveIMessageMessageId.mock.calls[0]).toEqual([
+        "message-guid",
+        expect.objectContaining({ requireFromMe: true }),
+      ]);
+      expect(runtimeMock.resolveIMessageMessageId.mock.calls[1]).toEqual([
+        "message-guid",
+        expect.not.objectContaining({ requireFromMe: expect.anything() }),
+      ]);
+      expect(runtimeMock.authorizeMessageReference).toHaveBeenCalledWith(
+        expect.objectContaining({
+          accountId: "default",
+          messageId: "message-guid",
+          conversationReadOrigin: "direct-operator",
+        }),
+      );
+      expect(mutation).toHaveBeenCalledTimes(1);
+    },
+  );
 
   it("resolves chat_id targets before invoking bridge actions", async () => {
     probeMock.getCachedIMessagePrivateApiStatus.mockReturnValue({
@@ -865,8 +1070,6 @@ describe("imessage message actions", () => {
       requireKnownShortId: true,
       chatContext: {
         chatGuid: "iMessage;+;chat0000",
-        chatIdentifier: undefined,
-        chatId: undefined,
       },
     });
     expect(runtimeMock.sendReaction.mock.calls).toStrictEqual([
@@ -895,6 +1098,7 @@ describe("imessage message actions", () => {
     await imessageMessageActions.handleAction?.({
       action: "reply",
       cfg: cfg(),
+      conversationReadOrigin: "delegated",
       params: {
         chatIdentifier: "team-thread",
         messageId: "message-guid",
@@ -922,6 +1126,13 @@ describe("imessage message actions", () => {
         },
       ],
     ]);
+    expect(runtimeMock.authorizeMessageReference).toHaveBeenCalledWith(
+      expect.objectContaining({
+        accountId: "default",
+        messageId: "message-guid",
+        conversationReadOrigin: "delegated",
+      }),
+    );
     expect(rememberIMessageReplyCacheMock).toHaveBeenCalledWith({
       accountId: "default",
       messageId: "reply-guid",
@@ -953,6 +1164,35 @@ describe("imessage message actions", () => {
         | undefined;
       return call?.attachment;
     }
+
+    it("rejects an unbound reference before processing attachment params", async () => {
+      probeMock.getCachedIMessagePrivateApiStatus.mockReturnValue({
+        available: true,
+        v2Ready: true,
+        selectors: {},
+        cliCapabilities: { sendRichSupportsAttachment: true },
+      });
+      runtimeMock.authorizeMessageReference.mockImplementationOnce(() => {
+        throw new Error("iMessage message reference belongs to a different conversation.");
+      });
+
+      await expect(
+        imessageMessageActions.handleAction?.({
+          action: "reply",
+          cfg: cfg(),
+          conversationReadOrigin: "delegated",
+          params: {
+            chatIdentifier: "foreign-chat",
+            messageId: "foreign-guid",
+            text: "reply",
+            filePath: stringPath,
+          },
+        } as never),
+      ).rejects.toThrow("different conversation");
+
+      expect(runtimeMock.resolveChatGuidForTarget).not.toHaveBeenCalled();
+      expect(runtimeMock.sendRichMessage).not.toHaveBeenCalled();
+    });
 
     it("threads a hydrated buffer attachment through to sendRichMessage when imsg supports send-rich --file", async () => {
       probeMock.getCachedIMessagePrivateApiStatus.mockReturnValue({
@@ -1079,7 +1319,7 @@ describe("imessage message actions", () => {
   });
 
   describe("phone-number target end-to-end (regressions caught the hard way)", () => {
-    it("synthesizes iMessage;-;<phone> chat_identifier from a handle target and sends through to sendReaction", async () => {
+    it("lets a direct operator resolve an auto handle before sending a reaction", async () => {
       // Scenario from prod: agent calls react with `target:"+12069106512"` and a
       // known-cached short messageId. resolveChatGuid synthesizes
       // `iMessage;-;+12069106512` and asks the runtime to look it up. The
@@ -1097,6 +1337,7 @@ describe("imessage message actions", () => {
       await imessageMessageActions.handleAction?.({
         action: "react",
         cfg: cfg(),
+        conversationReadOrigin: "direct-operator",
         params: {
           target: "+12069106512",
           messageId: "5",
@@ -1117,14 +1358,16 @@ describe("imessage message actions", () => {
           },
         ],
       ]);
-      // The cache lookup uses the synthesized chat_identifier as scope so
-      // cross-chat checks have something to match against.
-      expect(runtimeMock.resolveIMessageMessageId).toHaveBeenCalledWith("5", {
+      expect(runtimeMock.resolveIMessageMessageId).toHaveBeenNthCalledWith(1, "5", {
+        requireKnownShortId: true,
+        chatContext: {},
+      });
+      // The second phase rechecks the resolved id against the canonical GUID
+      // before mutation, so provider alias resolution cannot change authority.
+      expect(runtimeMock.resolveIMessageMessageId).toHaveBeenLastCalledWith("full-guid", {
         requireKnownShortId: true,
         chatContext: {
-          chatGuid: undefined,
-          chatIdentifier: "iMessage;-;+12069106512",
-          chatId: undefined,
+          chatGuid: "any;-;+12069106512",
         },
       });
       // sendReaction lands on the real registered chat guid, not the

--- a/extensions/imessage/src/actions.ts
+++ b/extensions/imessage/src/actions.ts
@@ -18,9 +18,11 @@ import { normalizePollInput } from "openclaw/plugin-sdk/poll-runtime";
 import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
 import { normalizeOptionalLowercaseString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { extractToolSend } from "openclaw/plugin-sdk/tool-send";
-import { resolveIMessageAccount } from "./accounts.js";
+import { hasExclusiveIMessageLocalDatabase, resolveIMessageAccount } from "./accounts.js";
 import { IMESSAGE_ACTION_NAMES, IMESSAGE_ACTIONS } from "./actions-contract.js";
+import { chatContextFromIMessageTarget } from "./chat-context.js";
 import { DEFAULT_IMESSAGE_PROBE_TIMEOUT_MS } from "./constants.js";
+import { resolveAuthorizedIMessageActionReference } from "./message-action-reference.js";
 import { describeIMessageMessageTool } from "./message-tool-api.js";
 import {
   findLatestIMessageEntryForChat,
@@ -30,7 +32,7 @@ import {
 } from "./monitor-reply-cache.js";
 import { imessageRpcSupportsMethod } from "./private-api-status.js";
 import { getCachedIMessagePrivateApiStatus, probeIMessagePrivateApi } from "./probe.js";
-import { parseIMessageTarget, type IMessageTarget } from "./targets.js";
+import { parseIMessageTarget, type IMessageService, type IMessageTarget } from "./targets.js";
 
 const loadIMessageActionsRuntime = createLazyRuntimeNamedExport(
   () => import("./actions.runtime.js"),
@@ -70,6 +72,18 @@ function resolveIMessageDeliveryTarget(args: Record<string, unknown>): string | 
     throw new Error("iMessage action received conflicting delivery target aliases.");
   }
   return targets[0];
+}
+
+function resolveIMessageActionTarget(params: {
+  actionParams: Record<string, unknown>;
+  currentChannelId?: string;
+}): IMessageTarget | null {
+  const rawTarget =
+    resolveIMessageDeliveryTarget(params.actionParams) ??
+    readStringParam(params.actionParams, "to") ??
+    readStringParam(params.actionParams, "target") ??
+    (params.currentChannelId?.trim() || undefined);
+  return rawTarget ? parseIMessageTarget(rawTarget) : null;
 }
 
 const IMESSAGE_DELIVERY_TARGET_ALIASES = ["chatGuid", "chatIdentifier", "chatId"];
@@ -162,40 +176,8 @@ async function resolveChatGuid(params: {
     timeoutMs?: number;
   };
 }): Promise<string> {
-  const explicitChatGuid = readStringParam(params.actionParams, "chatGuid");
-  if (explicitChatGuid) {
-    return explicitChatGuid;
-  }
-  const explicitChatId = readPositiveIntegerParam(params.actionParams, "chatId");
-  if (typeof explicitChatId === "number") {
-    const resolved = await params.runtime.resolveChatGuidForTarget({
-      target: { kind: "chat_id", chatId: explicitChatId },
-      options: params.options,
-    });
-    if (resolved) {
-      return resolved;
-    }
-    throw new Error(`iMessage ${params.action} failed: chatGuid not found for chat_id:<redacted>.`);
-  }
-  const explicitChatIdentifier = readStringParam(params.actionParams, "chatIdentifier");
-  if (explicitChatIdentifier) {
-    const resolved = await params.runtime.resolveChatGuidForTarget({
-      target: { kind: "chat_identifier", chatIdentifier: explicitChatIdentifier },
-      options: params.options,
-    });
-    if (resolved) {
-      return resolved;
-    }
-    throw new Error(
-      `iMessage ${params.action} failed: chatGuid not found for chat_identifier:<redacted>.`,
-    );
-  }
-  const rawTarget =
-    readStringParam(params.actionParams, "to") ??
-    readStringParam(params.actionParams, "target") ??
-    (params.currentChannelId?.trim() || undefined);
-  if (rawTarget) {
-    const target = parseIMessageTarget(rawTarget);
+  const target = resolveIMessageActionTarget(params);
+  if (target) {
     if (target.kind === "chat_guid") {
       return target.chatGuid;
     }
@@ -258,40 +240,10 @@ function formatUnresolvedTarget(
 function buildChatContextFromActionParams(params: {
   actionParams: Record<string, unknown>;
   currentChannelId?: string;
+  service?: IMessageService;
 }): IMessageChatContext {
-  const explicitChatGuid = readStringParam(params.actionParams, "chatGuid")?.trim();
-  const explicitChatIdentifier = readStringParam(params.actionParams, "chatIdentifier")?.trim();
-  const explicitChatId = readPositiveIntegerParam(params.actionParams, "chatId");
-  // Trim before the truthy check so a whitespace-only currentChannelId can't
-  // reach parseIMessageTarget (which throws on empty/whitespace input and
-  // would abort the whole action with a confusing "target is required").
-  const rawTarget =
-    readStringParam(params.actionParams, "to") ??
-    readStringParam(params.actionParams, "target") ??
-    (params.currentChannelId?.trim() || undefined);
-  const target = rawTarget ? parseIMessageTarget(rawTarget) : null;
-  // A "handle" target (raw phone or email — what the agent uses most of the
-  // time) is still a usable chat scope: Messages addresses DMs as
-  // `iMessage;-;+15551234567` / `SMS;-;+15551234567`. Synthesizing the
-  // chat-identifier here lets resolveIMessageMessageId succeed without
-  // forcing every action plumbing site to also surface chatGuid/chatId.
-  const handleChatIdentifier =
-    target?.kind === "handle"
-      ? `${target.service === "sms" ? "SMS" : "iMessage"};-;${target.to}`
-      : undefined;
-  return {
-    chatGuid: explicitChatGuid || (target?.kind === "chat_guid" ? target.chatGuid : undefined),
-    chatIdentifier:
-      explicitChatIdentifier ||
-      (target?.kind === "chat_identifier" ? target.chatIdentifier : undefined) ||
-      handleChatIdentifier,
-    chatId:
-      typeof explicitChatId === "number"
-        ? explicitChatId
-        : target?.kind === "chat_id"
-          ? target.chatId
-          : undefined,
-  };
+  const target = resolveIMessageActionTarget(params);
+  return target ? chatContextFromIMessageTarget(target, params.service) : {};
 }
 
 function mapTapbackReaction(emoji?: string): string | undefined {
@@ -477,6 +429,7 @@ export const imessageMessageActions: ChannelMessageActionAdapter = {
     toolContext,
     senderIsOwner,
     gatewayClientScopes,
+    conversationReadOrigin,
   }) => {
     // Group administration mutates the host's Messages identity, so model-driven
     // actions need owner provenance or an admin-scoped Gateway caller.
@@ -534,6 +487,7 @@ export const imessageMessageActions: ChannelMessageActionAdapter = {
     const opts = {
       cliPath: account.config.cliPath?.trim() || "imsg",
       dbPath: account.config.dbPath?.trim() || undefined,
+      remoteHost: account.config.remoteHost?.trim() || undefined,
       timeoutMs: account.config.probeTimeoutMs,
       chatGuid: "",
     };
@@ -545,20 +499,35 @@ export const imessageMessageActions: ChannelMessageActionAdapter = {
         runtime,
         options: opts,
       });
-    const messageId = (resolveOpts?: { requireFromMe?: boolean }) => {
-      const chatContext = buildChatContextFromActionParams({
+    const messageReference = async (input?: { messageId?: string; requireFromMe?: boolean }) => {
+      const inputChatContext = buildChatContextFromActionParams({
         actionParams: params,
         currentChannelId: toolContext?.currentChannelId,
+        service: account.config.service,
       });
-      const fallbackContext = { ...chatContext, accountId: account.accountId };
-      return runtime.resolveIMessageMessageId(
-        readMessageIdWithChatFallback(params, fallbackContext),
-        {
-          requireKnownShortId: true,
-          chatContext,
-          ...(resolveOpts?.requireFromMe ? { requireFromMe: true } : {}),
+      return await resolveAuthorizedIMessageActionReference({
+        messageId: input?.messageId,
+        inputChatContext,
+        requireFromMe: input?.requireFromMe,
+        resolveFallbackMessageId: (chatContext) =>
+          readMessageIdWithChatFallback(params, { ...chatContext, accountId: account.accountId }),
+        resolveMessageId: runtime.resolveIMessageMessageId,
+        resolveChatGuid: chatGuid,
+        authorize: (authorization) => runtime.authorizeMessageReference(authorization),
+        authorization: {
+          accountId: account.accountId,
+          cliPath: opts.cliPath,
+          dbPath: opts.dbPath,
+          hasExclusiveLocalDatabase: hasExclusiveIMessageLocalDatabase({
+            cfg,
+            account,
+            cliPath: opts.cliPath,
+            dbPath: opts.dbPath,
+          }),
+          remoteHost: opts.remoteHost,
+          conversationReadOrigin,
         },
-      );
+      });
     };
 
     if (action === "react") {
@@ -579,18 +548,17 @@ export const imessageMessageActions: ChannelMessageActionAdapter = {
           "iMessage react supports love, like, dislike, laugh, emphasize, and question tapbacks.",
         );
       }
-      const resolvedMessageId = messageId();
       const partIndex = readNonNegativeIntegerParam(params, "partIndex");
-      const resolvedChatGuid = await chatGuid();
+      const reference = await messageReference();
       const reactionsToSend = remove && !reaction ? [...TAPBACK_KINDS] : reaction ? [reaction] : [];
       for (const kind of reactionsToSend) {
         await runtime.sendReaction({
-          chatGuid: resolvedChatGuid,
-          messageId: resolvedMessageId,
+          chatGuid: reference.chatGuid,
+          messageId: reference.messageId,
           reaction: kind,
           remove: remove || undefined,
           partIndex: typeof partIndex === "number" ? partIndex : undefined,
-          options: { ...opts, chatGuid: resolvedChatGuid },
+          options: { ...opts, chatGuid: reference.chatGuid },
         });
       }
       return jsonResult({ ok: true, ...(remove ? { removed: true } : { added: reaction }) });
@@ -598,7 +566,6 @@ export const imessageMessageActions: ChannelMessageActionAdapter = {
 
     if (action === "edit") {
       await assertPrivateApiEnabled();
-      const resolvedMessageId = messageId({ requireFromMe: true });
       const text =
         readStringParam(params, "text") ??
         readStringParam(params, "newText") ??
@@ -608,39 +575,38 @@ export const imessageMessageActions: ChannelMessageActionAdapter = {
       }
       const partIndex = readNonNegativeIntegerParam(params, "partIndex");
       const backwardsCompatMessage = readStringParam(params, "backwardsCompatMessage");
-      const resolvedChatGuid = await chatGuid();
+      const reference = await messageReference({ requireFromMe: true });
       await runtime.editMessage({
-        chatGuid: resolvedChatGuid,
-        messageId: resolvedMessageId,
+        chatGuid: reference.chatGuid,
+        messageId: reference.messageId,
         text,
         backwardsCompatMessage: backwardsCompatMessage ?? undefined,
         partIndex: typeof partIndex === "number" ? partIndex : undefined,
-        options: { ...opts, chatGuid: resolvedChatGuid },
+        options: { ...opts, chatGuid: reference.chatGuid },
       });
-      return jsonResult({ ok: true, edited: resolvedMessageId });
+      return jsonResult({ ok: true, edited: reference.messageId });
     }
 
     if (action === "unsend") {
       await assertPrivateApiEnabled();
-      const resolvedMessageId = messageId({ requireFromMe: true });
       const partIndex = readNonNegativeIntegerParam(params, "partIndex");
-      const resolvedChatGuid = await chatGuid();
+      const reference = await messageReference({ requireFromMe: true });
       await runtime.unsendMessage({
-        chatGuid: resolvedChatGuid,
-        messageId: resolvedMessageId,
+        chatGuid: reference.chatGuid,
+        messageId: reference.messageId,
         partIndex: typeof partIndex === "number" ? partIndex : undefined,
-        options: { ...opts, chatGuid: resolvedChatGuid },
+        options: { ...opts, chatGuid: reference.chatGuid },
       });
-      return jsonResult({ ok: true, unsent: resolvedMessageId });
+      return jsonResult({ ok: true, unsent: reference.messageId });
     }
 
     if (action === "reply") {
       await assertPrivateApiEnabled();
-      const resolvedMessageId = messageId();
       const text = readMessageText(params);
       if (!text) {
         throw new Error("iMessage reply requires text or message.");
       }
+      const reference = await messageReference();
       const attachment = extractReplyAttachment(params);
       if (attachment) {
         if (attachment.spec === null) {
@@ -664,21 +630,20 @@ export const imessageMessageActions: ChannelMessageActionAdapter = {
         }
       }
       const partIndex = readNonNegativeIntegerParam(params, "partIndex");
-      const resolvedChatGuid = await chatGuid();
       const result = await runtime.sendRichMessage({
-        chatGuid: resolvedChatGuid,
+        chatGuid: reference.chatGuid,
         text,
-        replyToMessageId: resolvedMessageId,
+        replyToMessageId: reference.messageId,
         partIndex: typeof partIndex === "number" ? partIndex : undefined,
         attachment: attachment?.spec ?? undefined,
-        options: { ...opts, chatGuid: resolvedChatGuid },
+        options: { ...opts, chatGuid: reference.chatGuid },
       });
       rememberOutboundBridgeMessage({
         accountId: account.accountId,
         messageId: result.messageId,
-        chatGuid: resolvedChatGuid,
+        chatGuid: reference.chatGuid,
       });
-      return jsonResult({ ok: true, messageId: result.messageId, repliedTo: resolvedMessageId });
+      return jsonResult({ ok: true, messageId: result.messageId, repliedTo: reference.messageId });
     }
 
     if (action === "sendWithEffect") {
@@ -854,14 +819,6 @@ export const imessageMessageActions: ChannelMessageActionAdapter = {
       if (!pollRef) {
         throw new Error("iMessage poll-vote requires the poll message id (pollId or messageId).");
       }
-      const chatContext = buildChatContextFromActionParams({
-        actionParams: params,
-        currentChannelId: toolContext?.currentChannelId,
-      });
-      const pollGuid = runtime.resolveIMessageMessageId(pollRef, {
-        requireKnownShortId: true,
-        chatContext,
-      });
       // Option selection: 1-based index, explicit UUID, or option text — imsg
       // resolves index/text to the stable optionIdentifier from the decoded poll.
       // Require exactly one selector so a conflicting pair can't silently vote
@@ -884,19 +841,19 @@ export const imessageMessageActions: ChannelMessageActionAdapter = {
           "iMessage poll-vote requires exactly one of pollOptionIndex, pollOptionId, or pollOptionText.",
         );
       }
-      const resolvedChatGuid = await chatGuid();
+      const pollReference = await messageReference({ messageId: pollRef });
       const result = await runtime.sendPollVote({
-        chatGuid: resolvedChatGuid,
-        pollGuid,
+        chatGuid: pollReference.chatGuid,
+        pollGuid: pollReference.messageId,
         optionIndex,
         optionId: optionId ?? undefined,
         optionText: optionText ?? undefined,
-        options: { ...opts, chatGuid: resolvedChatGuid },
+        options: { ...opts, chatGuid: pollReference.chatGuid },
       });
       rememberOutboundBridgeMessage({
         accountId: account.accountId,
         messageId: result.messageId,
-        chatGuid: resolvedChatGuid,
+        chatGuid: pollReference.chatGuid,
       });
       return jsonResult({
         ok: true,

--- a/extensions/imessage/src/channel.runtime.test.ts
+++ b/extensions/imessage/src/channel.runtime.test.ts
@@ -127,6 +127,7 @@ describe("sendIMessageOutbound approval identity", () => {
         cfg: {} as never,
         to: "+15551230000",
         text: "approval text",
+        conversationReadOrigin: "delegated",
         deps: { imessage: send },
       }),
     ).resolves.toEqual(
@@ -137,6 +138,11 @@ describe("sendIMessageOutbound approval identity", () => {
           imessageVisibleText: "delivered approval text",
         },
       }),
+    );
+    expect(send).toHaveBeenCalledWith(
+      "+15551230000",
+      "approval text",
+      expect.objectContaining({ conversationReadOrigin: "delegated" }),
     );
   });
 });

--- a/extensions/imessage/src/channel.runtime.ts
+++ b/extensions/imessage/src/channel.runtime.ts
@@ -21,6 +21,7 @@ export async function sendIMessageOutbound(params: {
   accountId?: string;
   deps?: { [channelId: string]: unknown };
   replyToId?: string;
+  conversationReadOrigin?: "delegated" | "direct-operator";
 }) {
   const send =
     resolveOutboundSendDep<IMessageSendFn>(params.deps, "imessage", {
@@ -41,6 +42,7 @@ export async function sendIMessageOutbound(params: {
     maxBytes,
     accountId: params.accountId ?? undefined,
     replyToId: params.replyToId ?? undefined,
+    conversationReadOrigin: params.conversationReadOrigin,
   });
   const meta = {
     ...(result as typeof result & { meta?: Record<string, unknown> }).meta,

--- a/extensions/imessage/src/channel.ts
+++ b/extensions/imessage/src/channel.ts
@@ -61,6 +61,7 @@ const loadIMessageChannelRuntime = createLazyRuntimeModule(() => import("./chann
 
 type IMessageMessageContextExtras = {
   deps?: { [channelId: string]: unknown };
+  conversationReadOrigin?: "delegated" | "direct-operator";
 };
 
 function toIMessageMessageSendResult(
@@ -140,6 +141,8 @@ const imessageMessageAdapter = defineChannelMessageAdapter({
         accountId: ctx.accountId ?? undefined,
         deps: (ctx as typeof ctx & IMessageMessageContextExtras).deps,
         replyToId: ctx.replyToId ?? undefined,
+        conversationReadOrigin: (ctx as typeof ctx & IMessageMessageContextExtras)
+          .conversationReadOrigin,
       });
       return toIMessageMessageSendResult(result, "text", ctx.replyToId);
     },
@@ -156,6 +159,8 @@ const imessageMessageAdapter = defineChannelMessageAdapter({
         accountId: ctx.accountId ?? undefined,
         deps: (ctx as typeof ctx & IMessageMessageContextExtras).deps,
         replyToId: ctx.replyToId ?? undefined,
+        conversationReadOrigin: (ctx as typeof ctx & IMessageMessageContextExtras)
+          .conversationReadOrigin,
       });
       return toIMessageMessageSendResult(
         result,

--- a/extensions/imessage/src/chat-context.ts
+++ b/extensions/imessage/src/chat-context.ts
@@ -14,6 +14,8 @@ type IMessageDirectChatIdentity = {
   identifier: string;
 };
 
+const EMAIL_HANDLE_PATTERN = /^[^\s@]+@[^\s@]+$/u;
+
 function parseDirectChatIdentity(raw: string): IMessageDirectChatIdentity | undefined {
   const trimmed = raw.trim();
   const parts = trimmed.split(";");
@@ -23,14 +25,22 @@ function parseDirectChatIdentity(raw: string): IMessageDirectChatIdentity | unde
       const identifier = parts[2];
       return {
         service,
-        identifier: /^[^\s@]+@[^\s@]+$/u.test(identifier) ? identifier.toLowerCase() : identifier,
+        identifier: EMAIL_HANDLE_PATTERN.test(identifier) ? identifier.toLowerCase() : identifier,
       };
     }
   }
-  if (trimmed.startsWith("+") || /^[^\s@]+@[^\s@]+$/u.test(trimmed)) {
+  if (parts.length !== 1) {
+    return undefined;
+  }
+  if (trimmed.startsWith("+") || EMAIL_HANDLE_PATTERN.test(trimmed)) {
     return { identifier: trimmed.toLowerCase() };
   }
   return undefined;
+}
+
+export function isIMessageEmailChatIdentifier(raw: string): boolean {
+  const identity = parseDirectChatIdentity(raw);
+  return Boolean(identity && EMAIL_HANDLE_PATTERN.test(identity.identifier));
 }
 
 /**

--- a/extensions/imessage/src/chat-context.ts
+++ b/extensions/imessage/src/chat-context.ts
@@ -1,0 +1,137 @@
+// Imessage plugin module normalizes equivalent provider conversation identifiers.
+import { normalizeE164 } from "openclaw/plugin-sdk/account-resolution";
+import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
+import type { IMessageService, IMessageTarget } from "./targets.js";
+
+export type IMessageChatContext = {
+  chatGuid?: string;
+  chatIdentifier?: string;
+  chatId?: number;
+};
+
+type IMessageDirectChatIdentity = {
+  service?: "imessage" | "sms" | "any";
+  identifier: string;
+};
+
+function parseDirectChatIdentity(raw: string): IMessageDirectChatIdentity | undefined {
+  const trimmed = raw.trim();
+  const parts = trimmed.split(";");
+  if (parts.length === 3 && parts[1] === "-" && parts[2]) {
+    const service = parts[0]?.toLowerCase();
+    if (service === "imessage" || service === "sms" || service === "any") {
+      const identifier = parts[2];
+      return {
+        service,
+        identifier: /^[^\s@]+@[^\s@]+$/u.test(identifier) ? identifier.toLowerCase() : identifier,
+      };
+    }
+  }
+  if (trimmed.startsWith("+") || /^[^\s@]+@[^\s@]+$/u.test(trimmed)) {
+    return { identifier: trimmed.toLowerCase() };
+  }
+  return undefined;
+}
+
+/**
+ * Strip the `iMessage;-;` / `SMS;-;` / `any;-;` service prefix that Messages
+ * uses for direct chats. Different layers report direct DMs in different
+ * forms, so raw comparison would falsely treat one DM as different chats.
+ */
+export function normalizeDirectChatIdentifier(raw: string): string {
+  const trimmed = raw.trim();
+  return parseDirectChatIdentity(trimmed)?.identifier ?? trimmed;
+}
+
+export function chatContextFromIMessageTarget(
+  target: IMessageTarget,
+  effectiveService?: IMessageService,
+): IMessageChatContext {
+  if (target.kind === "chat_id") {
+    return { chatId: target.chatId };
+  }
+  if (target.kind === "chat_guid") {
+    return { chatGuid: target.chatGuid };
+  }
+  if (target.kind === "chat_identifier") {
+    return { chatIdentifier: target.chatIdentifier };
+  }
+  const trimmedHandle = target.to.trim();
+  const canonicalHandle = trimmedHandle.startsWith("+")
+    ? normalizeE164(trimmedHandle)
+    : /^[^\s@]+@[^\s@]+$/u.test(trimmedHandle)
+      ? trimmedHandle.toLowerCase()
+      : undefined;
+  if (!canonicalHandle) {
+    return {};
+  }
+  const service = target.service === "auto" ? effectiveService : target.service;
+  if (service !== "imessage" && service !== "sms") {
+    return {};
+  }
+  return {
+    chatIdentifier: `${service === "sms" ? "SMS" : "iMessage"};-;${canonicalHandle}`,
+  };
+}
+
+function compareOptional<T>(left: T | undefined, right: T | undefined): boolean | undefined {
+  return left === undefined || right === undefined ? undefined : left === right;
+}
+
+function compareChatSelector(
+  cachedRaw: string | undefined,
+  currentRaw: string | undefined,
+  crossKind = false,
+): boolean | undefined {
+  const cached = normalizeOptionalString(cachedRaw);
+  const current = normalizeOptionalString(currentRaw);
+  if (!cached || !current) {
+    return undefined;
+  }
+  if (cached === current) {
+    return true;
+  }
+  const cachedDirect = parseDirectChatIdentity(cached);
+  const currentDirect = parseDirectChatIdentity(current);
+  if (!cachedDirect || !currentDirect) {
+    return crossKind ? undefined : false;
+  }
+  if (cachedDirect.identifier !== currentDirect.identifier) {
+    return false;
+  }
+  if (cachedDirect.service === "any") {
+    return true;
+  }
+  if (!cachedDirect.service || !currentDirect.service) {
+    return undefined;
+  }
+  return cachedDirect.service === currentDirect.service;
+}
+
+export function resolveIMessageChatMatch(
+  cached: IMessageChatContext,
+  current: IMessageChatContext,
+): "match" | "mismatch" | "unknown" {
+  const cachedChatGuid = normalizeOptionalString(cached.chatGuid);
+  const currentChatGuid = normalizeOptionalString(current.chatGuid);
+  const cachedChatIdentifier = normalizeOptionalString(cached.chatIdentifier);
+  const currentChatIdentifier = normalizeOptionalString(current.chatIdentifier);
+  const comparisons = [
+    compareChatSelector(cachedChatGuid, currentChatGuid),
+    compareChatSelector(cachedChatIdentifier, currentChatIdentifier),
+    compareOptional(cached.chatId, current.chatId),
+    compareChatSelector(cachedChatGuid, currentChatIdentifier, true),
+    compareChatSelector(cachedChatIdentifier, currentChatGuid, true),
+  ].filter((comparison): comparison is boolean => comparison !== undefined);
+  if (comparisons.length === 0) {
+    return "unknown";
+  }
+  return comparisons.every(Boolean) ? "match" : "mismatch";
+}
+
+export function isPositiveIMessageChatMatch(
+  cached: IMessageChatContext,
+  current: IMessageChatContext,
+): boolean {
+  return resolveIMessageChatMatch(cached, current) === "match";
+}

--- a/extensions/imessage/src/cli-path.ts
+++ b/extensions/imessage/src/cli-path.ts
@@ -27,7 +27,7 @@ function safeHomeDir(): string | undefined {
   }
 }
 
-export function expandIMessageUserPath(value: string): string {
+function expandIMessageUserPath(value: string): string {
   if (!value.startsWith("~")) {
     return value;
   }

--- a/extensions/imessage/src/cli-path.ts
+++ b/extensions/imessage/src/cli-path.ts
@@ -1,0 +1,145 @@
+// Imessage plugin module classifies CLI and Messages database locality.
+import { constants, accessSync, readFileSync, realpathSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const localCliPathCache = new Map<string, boolean>();
+const MACH_O_MAGICS = new Set([
+  "feedface",
+  "feedfacf",
+  "cefaedfe",
+  "cffaedfe",
+  "cafebabe",
+  "cafebabf",
+  "bebafeca",
+  "bfbafeca",
+]);
+
+function safeHomeDir(): string | undefined {
+  const home = process.env.HOME?.trim();
+  if (home) {
+    return home;
+  }
+  try {
+    return os.homedir().trim() || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export function expandIMessageUserPath(value: string): string {
+  if (!value.startsWith("~")) {
+    return value;
+  }
+  const home = safeHomeDir();
+  return home ? value.replace(/^~(?=$|[\\/])/, home) : value;
+}
+
+function resolveIMessageExecutable(cliPath: string): string | undefined {
+  const expanded = expandIMessageUserPath(cliPath);
+  if (expanded.includes(path.sep)) {
+    return expanded;
+  }
+  for (const directory of (process.env.PATH ?? "").split(path.delimiter)) {
+    if (!directory) {
+      continue;
+    }
+    const candidate = path.join(directory, expanded);
+    try {
+      accessSync(candidate, constants.X_OK);
+      return candidate;
+    } catch {
+      // Continue through PATH until an executable candidate is found.
+    }
+  }
+  return undefined;
+}
+
+function isMachOExecutable(filePath: string): boolean {
+  try {
+    return MACH_O_MAGICS.has(readFileSync(realpathSync(filePath)).subarray(0, 4).toString("hex"));
+  } catch {
+    return false;
+  }
+}
+
+function isProvenLocalIMessageCliPath(params: { cliPath: string; remoteHost?: string }): boolean {
+  if (params.remoteHost?.trim()) {
+    return false;
+  }
+  const cliPath = params.cliPath.trim();
+  const cacheKey = `${cliPath}\0${process.env.PATH ?? ""}`;
+  const cached = localCliPathCache.get(cacheKey);
+  if (cached !== undefined) {
+    return cached;
+  }
+  const executable = resolveIMessageExecutable(cliPath);
+  let local = executable ? isMachOExecutable(executable) : false;
+  if (executable && !local) {
+    try {
+      const wrapper = readFileSync(realpathSync(executable), "utf8");
+      const match = wrapper.match(
+        /^#![^\r\n]+\r?\n\s*exec\s+(?:"([^"]+)"|'([^']+)'|(\S+))\s+"\$@"\s*$/u,
+      );
+      const target = match?.[1] ?? match?.[2] ?? match?.[3];
+      local = Boolean(target && path.isAbsolute(target) && isMachOExecutable(target));
+    } catch {
+      local = false;
+    }
+  }
+  // CLI installation is process-stable channel metadata; avoid repeated file reads.
+  localCliPathCache.set(cacheKey, local);
+  return local;
+}
+
+function isLikelyLocalIMessageCliPath(params: { cliPath: string; remoteHost?: string }): boolean {
+  if (params.remoteHost?.trim()) {
+    return false;
+  }
+  const cliPath = params.cliPath.trim();
+  if (cliPath === "imsg") {
+    return true;
+  }
+  if (path.basename(cliPath) !== "imsg") {
+    return false;
+  }
+  try {
+    return !/\bssh\b[\s\S]*\bimsg\b/u.test(readFileSync(expandIMessageUserPath(cliPath), "utf8"));
+  } catch {
+    return true;
+  }
+}
+
+function defaultMessagesDbPath(): string | undefined {
+  const home = safeHomeDir();
+  return home ? path.join(home, "Library", "Messages", "chat.db") : undefined;
+}
+
+export function resolveIMessageChatDbLookupPath(params: {
+  cliPath: string;
+  dbPath?: string;
+  remoteHost?: string;
+}): string | undefined {
+  const configured = params.dbPath?.trim();
+  if (configured) {
+    return configured;
+  }
+  // Receipt recovery is best effort and preserves the shipped wrapper heuristic.
+  if (!isLikelyLocalIMessageCliPath({ cliPath: params.cliPath, remoteHost: params.remoteHost })) {
+    return undefined;
+  }
+  return defaultMessagesDbPath();
+}
+
+export function resolveLocalIMessageChatDbPath(params: {
+  cliPath: string;
+  dbPath?: string;
+  remoteHost?: string;
+}): string | undefined {
+  // Authorization may use chat.db only after positively attesting a local imsg executable.
+  if (!isProvenLocalIMessageCliPath({ cliPath: params.cliPath, remoteHost: params.remoteHost })) {
+    return undefined;
+  }
+  const configured = params.dbPath?.trim();
+  return configured ? expandIMessageUserPath(configured) : defaultMessagesDbPath();
+}

--- a/extensions/imessage/src/message-action-reference.ts
+++ b/extensions/imessage/src/message-action-reference.ts
@@ -1,0 +1,58 @@
+// Imessage plugin module resolves and authorizes action message references.
+import type { IMessageChatContext } from "./chat-context.js";
+
+type ResolveMessageId = (
+  messageId: string,
+  options: {
+    requireKnownShortId: boolean;
+    chatContext: IMessageChatContext;
+    requireFromMe?: boolean;
+  },
+) => string;
+
+type AuthorizeMessageReference = (params: {
+  accountId: string;
+  chatContext: IMessageChatContext;
+  cliPath: string;
+  dbPath?: string;
+  hasExclusiveLocalDatabase: boolean;
+  remoteHost?: string;
+  messageId: string;
+  conversationReadOrigin?: string;
+}) => void;
+
+export async function resolveAuthorizedIMessageActionReference(params: {
+  messageId?: string;
+  inputChatContext: IMessageChatContext;
+  requireFromMe?: boolean;
+  resolveFallbackMessageId: (chatContext: IMessageChatContext) => string;
+  resolveMessageId: ResolveMessageId;
+  authorize: AuthorizeMessageReference;
+  authorization: Omit<Parameters<AuthorizeMessageReference>[0], "chatContext" | "messageId">;
+  resolveChatGuid: () => Promise<string>;
+}): Promise<{ messageId: string; chatGuid: string }> {
+  const options = {
+    requireKnownShortId: true,
+    chatContext: params.inputChatContext,
+    ...(params.requireFromMe ? { requireFromMe: true } : {}),
+  };
+  const rawMessageId = params.messageId ?? params.resolveFallbackMessageId(params.inputChatContext);
+  const messageId = params.resolveMessageId(rawMessageId, options);
+  const authorize = (authorizedMessageId: string, chatContext: IMessageChatContext) =>
+    params.authorize({ ...params.authorization, messageId: authorizedMessageId, chatContext });
+  // Alias resolution may call `chats.list`; reject known foreign references
+  // before that provider read, then bind again to its canonical result.
+  authorize(messageId, params.inputChatContext);
+  const chatGuid = await params.resolveChatGuid();
+  // The mutation uses this GUID, so authorize it independently. Keeping the
+  // original alias here would let an alias-only cache match mask a foreign GUID.
+  const chatContext = { chatGuid };
+  // Sender ownership was proven against the original selector above. Repeating
+  // it here would reject cache entries whose canonical GUID was learned later.
+  const resolvedMessageId = params.resolveMessageId(messageId, {
+    requireKnownShortId: true,
+    chatContext,
+  });
+  authorize(resolvedMessageId, chatContext);
+  return { messageId: resolvedMessageId, chatGuid };
+}

--- a/extensions/imessage/src/message-resource-db.ts
+++ b/extensions/imessage/src/message-resource-db.ts
@@ -1,11 +1,16 @@
 // Imessage plugin module verifies provider message ownership in the local Messages database.
 import { createRequire } from "node:module";
+import { isIMessageEmailChatIdentifier, type IMessageChatContext } from "./chat-context.js";
 import { resolveLocalIMessageChatDbPath } from "./cli-path.js";
-import type { IMessageChatContext } from "./monitor-reply-cache.js";
 
 const require = createRequire(import.meta.url);
 
 type IMessageResourceBinding = "match" | "mismatch" | "unavailable";
+type IMessageChatRow = {
+  chatGuid: unknown;
+  chatId: unknown;
+  chatIdentifier: unknown;
+};
 
 export function normalizeIMessageMessageGuidForLookup(messageId: string): string {
   const trimmed = messageId.trim();
@@ -58,6 +63,24 @@ function isKnownChatGuid(raw: string | undefined): raw is string {
   return service === "imessage" || service === "sms" || service === "any";
 }
 
+function matchesChatCandidate(stored: string, candidate: string): boolean {
+  if (stored === candidate) {
+    return true;
+  }
+  return (
+    isIMessageEmailChatIdentifier(stored) &&
+    isIMessageEmailChatIdentifier(candidate) &&
+    stored.toLowerCase() === candidate.toLowerCase()
+  );
+}
+
+function matchesAnyChatCandidate(stored: unknown, candidates: string[]): boolean {
+  if (typeof stored !== "string") {
+    return false;
+  }
+  return candidates.some((candidate) => matchesChatCandidate(stored, candidate));
+}
+
 function loadNodeSqlite(): typeof import("node:sqlite") | null {
   try {
     return require("node:sqlite") as typeof import("node:sqlite");
@@ -88,42 +111,41 @@ export function checkIMessageResourceBinding(params: {
     ? chatGuidCandidates(params.chatContext.chatIdentifier)
     : [];
   const chatId = params.chatContext.chatId;
-  const chatClauses: string[] = [];
-  const bindings: Array<string | number> = [messageGuid];
-  if (typeof chatId === "number" && Number.isSafeInteger(chatId) && chatId > 0) {
-    chatClauses.push("cmj.chat_id = ?");
-    bindings.push(chatId);
-  }
-  if (expectedChatGuids.length > 0) {
-    chatClauses.push(`c.guid IN (${expectedChatGuids.map(() => "?").join(", ")})`);
-    bindings.push(...expectedChatGuids);
-  }
-  if (expectedChatIdentifiers.length > 0) {
-    chatClauses.push(`c.chat_identifier IN (${expectedChatIdentifiers.map(() => "?").join(", ")})`);
-    bindings.push(...expectedChatIdentifiers);
-  }
-  if (identifierChatGuids.length > 0) {
-    chatClauses.push(`c.guid IN (${identifierChatGuids.map(() => "?").join(", ")})`);
-    bindings.push(...identifierChatGuids);
-  }
-  if (chatClauses.length === 0) {
+  const hasChatId = typeof chatId === "number" && Number.isSafeInteger(chatId) && chatId > 0;
+  if (
+    !hasChatId &&
+    expectedChatGuids.length === 0 &&
+    expectedChatIdentifiers.length === 0 &&
+    identifierChatGuids.length === 0
+  ) {
     return "unavailable";
   }
 
   let db: import("node:sqlite").DatabaseSync | undefined;
   try {
     db = new sqlite.DatabaseSync(dbPath, { readOnly: true });
-    const row = db
+    const rows = db
       .prepare(
-        `SELECT 1 AS found
+        `SELECT cmj.chat_id AS chatId,
+                c.guid AS chatGuid,
+                c.chat_identifier AS chatIdentifier
          FROM message m
          JOIN chat_message_join cmj ON cmj.message_id = m.ROWID
          JOIN chat c ON c.ROWID = cmj.chat_id
-         WHERE m.guid = ? AND (${chatClauses.join(" AND ")})
-         LIMIT 1`,
+         WHERE m.guid = ?`,
       )
-      .get(...bindings);
-    return row ? "match" : "mismatch";
+      .all(messageGuid) as unknown as IMessageChatRow[];
+    const matched = rows.some(
+      (row) =>
+        (!hasChatId || row.chatId === chatId) &&
+        (expectedChatGuids.length === 0 ||
+          matchesAnyChatCandidate(row.chatGuid, expectedChatGuids)) &&
+        (expectedChatIdentifiers.length === 0 ||
+          matchesAnyChatCandidate(row.chatIdentifier, expectedChatIdentifiers)) &&
+        (identifierChatGuids.length === 0 ||
+          matchesAnyChatCandidate(row.chatGuid, identifierChatGuids)),
+    );
+    return matched ? "match" : "mismatch";
   } catch {
     return "unavailable";
   } finally {

--- a/extensions/imessage/src/message-resource-db.ts
+++ b/extensions/imessage/src/message-resource-db.ts
@@ -1,0 +1,136 @@
+// Imessage plugin module verifies provider message ownership in the local Messages database.
+import { createRequire } from "node:module";
+import { resolveLocalIMessageChatDbPath } from "./cli-path.js";
+import type { IMessageChatContext } from "./monitor-reply-cache.js";
+
+const require = createRequire(import.meta.url);
+
+type IMessageResourceBinding = "match" | "mismatch" | "unavailable";
+
+export function normalizeIMessageMessageGuidForLookup(messageId: string): string {
+  const trimmed = messageId.trim();
+  const slash = trimmed.lastIndexOf("/");
+  return slash >= 0 && slash + 1 < trimmed.length ? trimmed.slice(slash + 1) : trimmed;
+}
+
+function chatGuidCandidates(raw: string | undefined): string[] {
+  const trimmed = raw?.trim();
+  if (!trimmed) {
+    return [];
+  }
+  const ordered = [trimmed];
+  const parts = trimmed.split(";");
+  const service = parts[0]?.toLowerCase();
+  const kind = parts[1];
+  const identifier = parts[2];
+  if (parts.length === 3 && (kind === "+" || kind === "-") && identifier) {
+    if (service === "any") {
+      ordered.push(`iMessage;${kind};${identifier}`, `SMS;${kind};${identifier}`);
+    } else if (service === "imessage") {
+      ordered.push(`iMessage;${kind};${identifier}`, `any;${kind};${identifier}`);
+    } else if (service === "sms") {
+      ordered.push(`SMS;${kind};${identifier}`, `any;${kind};${identifier}`);
+    }
+  }
+  return [...new Set(ordered)];
+}
+
+function chatIdentifierCandidates(raw: string | undefined): string[] {
+  const trimmed = raw?.trim();
+  if (!trimmed) {
+    return [];
+  }
+  const parts = trimmed.split(";");
+  const service = parts[0]?.toLowerCase();
+  const hasKnownPrefix = service === "imessage" || service === "sms" || service === "any";
+  const hasKnownKind = parts[1] === "+" || parts[1] === "-";
+  const bareIdentifier =
+    parts.length === 3 && hasKnownPrefix && hasKnownKind ? parts[2] : undefined;
+  return [...new Set([trimmed, ...(bareIdentifier ? [bareIdentifier] : [])])];
+}
+
+function isKnownChatGuid(raw: string | undefined): raw is string {
+  const parts = raw?.trim().split(";");
+  if (!parts || parts.length !== 3 || (parts[1] !== "+" && parts[1] !== "-") || !parts[2]) {
+    return false;
+  }
+  const service = parts[0]?.toLowerCase();
+  return service === "imessage" || service === "sms" || service === "any";
+}
+
+function loadNodeSqlite(): typeof import("node:sqlite") | null {
+  try {
+    return require("node:sqlite") as typeof import("node:sqlite");
+  } catch {
+    return null;
+  }
+}
+
+export function checkIMessageResourceBinding(params: {
+  chatContext: IMessageChatContext;
+  cliPath: string;
+  dbPath?: string;
+  messageId: string;
+  remoteHost?: string;
+}): IMessageResourceBinding {
+  const dbPath = resolveLocalIMessageChatDbPath(params);
+  const sqlite = loadNodeSqlite();
+  if (!dbPath || !sqlite) {
+    return "unavailable";
+  }
+  const messageGuid = normalizeIMessageMessageGuidForLookup(params.messageId);
+  if (!messageGuid) {
+    return "mismatch";
+  }
+  const expectedChatGuids = chatGuidCandidates(params.chatContext.chatGuid);
+  const expectedChatIdentifiers = chatIdentifierCandidates(params.chatContext.chatIdentifier);
+  const identifierChatGuids = isKnownChatGuid(params.chatContext.chatIdentifier)
+    ? chatGuidCandidates(params.chatContext.chatIdentifier)
+    : [];
+  const chatId = params.chatContext.chatId;
+  const chatClauses: string[] = [];
+  const bindings: Array<string | number> = [messageGuid];
+  if (typeof chatId === "number" && Number.isSafeInteger(chatId) && chatId > 0) {
+    chatClauses.push("cmj.chat_id = ?");
+    bindings.push(chatId);
+  }
+  if (expectedChatGuids.length > 0) {
+    chatClauses.push(`c.guid IN (${expectedChatGuids.map(() => "?").join(", ")})`);
+    bindings.push(...expectedChatGuids);
+  }
+  if (expectedChatIdentifiers.length > 0) {
+    chatClauses.push(`c.chat_identifier IN (${expectedChatIdentifiers.map(() => "?").join(", ")})`);
+    bindings.push(...expectedChatIdentifiers);
+  }
+  if (identifierChatGuids.length > 0) {
+    chatClauses.push(`c.guid IN (${identifierChatGuids.map(() => "?").join(", ")})`);
+    bindings.push(...identifierChatGuids);
+  }
+  if (chatClauses.length === 0) {
+    return "unavailable";
+  }
+
+  let db: import("node:sqlite").DatabaseSync | undefined;
+  try {
+    db = new sqlite.DatabaseSync(dbPath, { readOnly: true });
+    const row = db
+      .prepare(
+        `SELECT 1 AS found
+         FROM message m
+         JOIN chat_message_join cmj ON cmj.message_id = m.ROWID
+         JOIN chat c ON c.ROWID = cmj.chat_id
+         WHERE m.guid = ? AND (${chatClauses.join(" AND ")})
+         LIMIT 1`,
+      )
+      .get(...bindings);
+    return row ? "match" : "mismatch";
+  } catch {
+    return "unavailable";
+  } finally {
+    try {
+      db?.close();
+    } catch {
+      // Best-effort cleanup after a read-only authorization query.
+    }
+  }
+}

--- a/extensions/imessage/src/message-resource.test.ts
+++ b/extensions/imessage/src/message-resource.test.ts
@@ -1,0 +1,480 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { chatContextFromIMessageTarget } from "./chat-context.js";
+import {
+  authorizeIMessageResourceReference,
+  checkIMessageResourceBinding,
+  resolveIMessageCachedResourceBinding,
+} from "./message-resource.js";
+import { rememberIMessageReplyCache, resetIMessageShortIdState } from "./monitor-reply-cache.js";
+import { installIMessageStateRuntimeForTest } from "./test-support/runtime.js";
+
+let tempDir = "";
+let dbPath = "";
+let cliPath = "";
+
+beforeEach(() => {
+  installIMessageStateRuntimeForTest();
+  resetIMessageShortIdState();
+  tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-imessage-resource-"));
+  dbPath = path.join(tempDir, "chat.db");
+  const binDir = path.join(tempDir, "bin");
+  const libexecDir = path.join(tempDir, "libexec");
+  const binaryPath = path.join(libexecDir, "imsg");
+  cliPath = path.join(binDir, "imsg");
+  fs.mkdirSync(binDir);
+  fs.mkdirSync(libexecDir);
+  fs.writeFileSync(binaryPath, Buffer.from("cafebabe", "hex"));
+  fs.writeFileSync(cliPath, `#!/bin/bash\nexec "${binaryPath}" "$@"\n`);
+  const db = new DatabaseSync(dbPath);
+  db.exec(`
+    CREATE TABLE chat (ROWID INTEGER PRIMARY KEY, chat_identifier TEXT, guid TEXT);
+    CREATE TABLE message (ROWID INTEGER PRIMARY KEY, guid TEXT);
+    CREATE TABLE chat_message_join (chat_id INTEGER, message_id INTEGER);
+    INSERT INTO chat(ROWID, chat_identifier, guid) VALUES
+      (1, '+15550001111', 'iMessage;-;+15550001111'),
+      (2, 'other', 'iMessage;+;other'),
+      (3, '+15550002222', 'SMS;-;+15550002222');
+    INSERT INTO message(ROWID, guid) VALUES
+      (10, 'message-guid'),
+      (11, 'sms-message-guid');
+    INSERT INTO chat_message_join(chat_id, message_id) VALUES
+      (1, 10),
+      (3, 11);
+  `);
+  db.close();
+});
+
+afterEach(() => {
+  resetIMessageShortIdState();
+  vi.unstubAllEnvs();
+  fs.rmSync(tempDir, { recursive: true, force: true });
+});
+
+describe("iMessage provider resource binding", () => {
+  it("only treats canonical handles as authoritative chat identifiers", () => {
+    expect(
+      chatContextFromIMessageTarget({ kind: "handle", to: "Jane Appleseed", service: "auto" }),
+    ).toEqual({});
+    expect(
+      chatContextFromIMessageTarget({ kind: "handle", to: "206 555 0100", service: "auto" }),
+    ).toEqual({});
+    expect(
+      chatContextFromIMessageTarget({ kind: "handle", to: "+1 (206) 555-0100", service: "auto" }),
+    ).toEqual({});
+    expect(
+      chatContextFromIMessageTarget(
+        { kind: "handle", to: "+1 (206) 555-0100", service: "auto" },
+        "sms",
+      ),
+    ).toEqual({ chatIdentifier: "SMS;-;+12065550100" });
+    expect(
+      chatContextFromIMessageTarget(
+        { kind: "handle", to: "+1 (206) 555-0100", service: "imessage" },
+        "sms",
+      ),
+    ).toEqual({ chatIdentifier: "iMessage;-;+12065550100" });
+    expect(
+      chatContextFromIMessageTarget({ kind: "handle", to: "User@Example.com", service: "sms" }),
+    ).toEqual({ chatIdentifier: "SMS;-;user@example.com" });
+  });
+
+  it("requires a current positive account and chat cache match", () => {
+    rememberIMessageReplyCache({
+      accountId: "work",
+      messageId: "bound-guid",
+      chatGuid: "any;-;+15550001111",
+      chatIdentifier: "+15550001111",
+      chatId: 1,
+      timestamp: Date.now(),
+    });
+    expect(
+      resolveIMessageCachedResourceBinding("bound-guid", {
+        accountId: "work",
+        chatIdentifier: "iMessage;-;+15550001111",
+      }),
+    ).toBe("match");
+
+    rememberIMessageReplyCache({
+      accountId: "work",
+      messageId: "mixed-case-email-guid",
+      chatGuid: "any;-;User@Example.com",
+      timestamp: Date.now(),
+    });
+    expect(
+      resolveIMessageCachedResourceBinding("mixed-case-email-guid", {
+        accountId: "work",
+        chatIdentifier: "iMessage;-;user@example.com",
+      }),
+    ).toBe("match");
+    expect(
+      resolveIMessageCachedResourceBinding("bound-guid", {
+        accountId: "personal",
+        chatIdentifier: "iMessage;-;+15550001111",
+      }),
+    ).toBe("mismatch");
+
+    rememberIMessageReplyCache({
+      accountId: "work",
+      messageId: "guid-only",
+      chatGuid: "any;-;+15550001111",
+      timestamp: Date.now(),
+    });
+    expect(
+      resolveIMessageCachedResourceBinding("guid-only", {
+        accountId: "work",
+        chatId: 1,
+      }),
+    ).toBe("unknown");
+    expect(
+      resolveIMessageCachedResourceBinding("bound-guid", {
+        accountId: "work",
+        chatId: 99,
+      }),
+    ).toBe("mismatch");
+    expect(
+      resolveIMessageCachedResourceBinding("bound-guid", {
+        accountId: "work",
+        chatGuid: "iMessage;+;other",
+        chatIdentifier: "iMessage;-;+15550001111",
+      }),
+    ).toBe("mismatch");
+
+    rememberIMessageReplyCache({
+      accountId: "default",
+      messageId: "stale-guid",
+      chatId: 42,
+      timestamp: Date.now() - 7 * 60 * 60 * 1000,
+    });
+    expect(
+      resolveIMessageCachedResourceBinding("stale-guid", {
+        accountId: "default",
+        chatId: 42,
+      }),
+    ).toBe("unknown");
+  });
+
+  it("matches part-prefixed message ids only in their database chat", () => {
+    expect(
+      checkIMessageResourceBinding({
+        chatContext: { chatId: 1 },
+        cliPath,
+        dbPath,
+        messageId: "p:0/message-guid",
+      }),
+    ).toBe("match");
+    expect(
+      checkIMessageResourceBinding({
+        chatContext: { chatGuid: "imessage;-;+15550001111" },
+        cliPath,
+        dbPath,
+        messageId: "message-guid",
+      }),
+    ).toBe("match");
+    expect(
+      checkIMessageResourceBinding({
+        chatContext: { chatGuid: "sms;-;+15550002222" },
+        cliPath,
+        dbPath,
+        messageId: "sms-message-guid",
+      }),
+    ).toBe("match");
+    expect(
+      checkIMessageResourceBinding({
+        chatContext: { chatId: 2 },
+        cliPath,
+        dbPath,
+        messageId: "message-guid",
+      }),
+    ).toBe("mismatch");
+    expect(
+      checkIMessageResourceBinding({
+        chatContext: { chatGuid: "iMessage;+;+15550001111" },
+        cliPath,
+        dbPath,
+        messageId: "message-guid",
+      }),
+    ).toBe("mismatch");
+    expect(
+      checkIMessageResourceBinding({
+        chatContext: { chatIdentifier: "SMS;-;+15550001111" },
+        cliPath,
+        dbPath,
+        messageId: "message-guid",
+      }),
+    ).toBe("mismatch");
+    expect(
+      checkIMessageResourceBinding({
+        chatContext: {
+          chatId: 1,
+          chatGuid: "any;-;+15550001111",
+          chatIdentifier: "iMessage;-;+15550001111",
+        },
+        cliPath,
+        dbPath,
+        messageId: "message-guid",
+      }),
+    ).toBe("match");
+    expect(
+      checkIMessageResourceBinding({
+        chatContext: {
+          chatGuid: "iMessage;+;other",
+          chatIdentifier: "iMessage;-;+15550001111",
+        },
+        cliPath,
+        dbPath,
+        messageId: "message-guid",
+      }),
+    ).toBe("mismatch");
+    expect(
+      checkIMessageResourceBinding({
+        chatContext: { chatId: 1, chatGuid: "iMessage;+;other" },
+        cliPath,
+        dbPath,
+        messageId: "message-guid",
+      }),
+    ).toBe("mismatch");
+    expect(
+      checkIMessageResourceBinding({
+        chatContext: { chatIdentifier: "unknown;-;+15550001111" },
+        cliPath,
+        dbPath,
+        messageId: "message-guid",
+      }),
+    ).toBe("mismatch");
+  });
+
+  it("accepts an uncached delegated reference only after a local database match", () => {
+    expect(() =>
+      authorizeIMessageResourceReference({
+        accountId: "default",
+        chatContext: { chatIdentifier: "iMessage;-;+15550001111" },
+        cliPath,
+        dbPath,
+        hasExclusiveLocalDatabase: true,
+        messageId: "message-guid",
+        conversationReadOrigin: "delegated",
+      }),
+    ).not.toThrow();
+    expect(() =>
+      authorizeIMessageResourceReference({
+        accountId: "default",
+        chatContext: { chatGuid: "iMessage;+;other" },
+        cliPath,
+        dbPath,
+        hasExclusiveLocalDatabase: true,
+        messageId: "message-guid",
+        conversationReadOrigin: "delegated",
+      }),
+    ).toThrow("does not belong to the selected conversation");
+    expect(() =>
+      authorizeIMessageResourceReference({
+        accountId: "default",
+        chatContext: { chatGuid: "iMessage;+;other" },
+        cliPath,
+        dbPath,
+        hasExclusiveLocalDatabase: true,
+        messageId: "message-guid",
+        conversationReadOrigin: "direct-operator",
+      }),
+    ).toThrow("does not belong to the selected conversation");
+  });
+
+  it("uses the local database when cached chat keys are not comparable", () => {
+    rememberIMessageReplyCache({
+      accountId: "default",
+      messageId: "message-guid",
+      chatGuid: "any;-;+15550001111",
+      timestamp: Date.now(),
+    });
+
+    expect(() =>
+      authorizeIMessageResourceReference({
+        accountId: "default",
+        chatContext: { chatId: 1 },
+        cliPath,
+        dbPath,
+        hasExclusiveLocalDatabase: true,
+        messageId: "message-guid",
+        conversationReadOrigin: "delegated",
+      }),
+    ).not.toThrow();
+  });
+
+  it("uses positive cache attestation for remote delegated calls", () => {
+    rememberIMessageReplyCache({
+      accountId: "work",
+      messageId: "remote-guid",
+      chatGuid: "any;-;+15550001111",
+      timestamp: Date.now(),
+    });
+
+    expect(() =>
+      authorizeIMessageResourceReference({
+        accountId: "work",
+        chatContext: { chatIdentifier: "iMessage;-;+15550001111" },
+        cliPath: "/tmp/remote-imsg-wrapper",
+        hasExclusiveLocalDatabase: false,
+        remoteHost: "qa@example.invalid",
+        messageId: "remote-guid",
+        conversationReadOrigin: "delegated",
+      }),
+    ).not.toThrow();
+    expect(() =>
+      authorizeIMessageResourceReference({
+        accountId: "work",
+        chatContext: { chatIdentifier: "iMessage;-;+15550001111" },
+        cliPath: "/tmp/remote-imsg-wrapper",
+        hasExclusiveLocalDatabase: false,
+        remoteHost: "qa@example.invalid",
+        messageId: "p:0/remote-guid",
+        conversationReadOrigin: "delegated",
+      }),
+    ).not.toThrow();
+    expect(() =>
+      authorizeIMessageResourceReference({
+        accountId: "personal",
+        chatContext: { chatIdentifier: "iMessage;-;+15550001111" },
+        cliPath: "/tmp/remote-imsg-wrapper",
+        hasExclusiveLocalDatabase: false,
+        remoteHost: "qa@example.invalid",
+        messageId: "remote-guid",
+        conversationReadOrigin: "delegated",
+      }),
+    ).toThrow("different account or conversation");
+  });
+
+  it.each([undefined, "delegated", "unknown-origin"])(
+    "fails unknown remote references closed for origin %s",
+    (conversationReadOrigin) => {
+      expect(() =>
+        authorizeIMessageResourceReference({
+          accountId: "default",
+          chatContext: { chatId: 1 },
+          cliPath: "/tmp/remote-imsg-wrapper",
+          hasExclusiveLocalDatabase: false,
+          remoteHost: "qa@example.invalid",
+          messageId: "unknown-guid",
+          conversationReadOrigin,
+        }),
+      ).toThrow("require a current same-account conversation binding");
+    },
+  );
+
+  it("preserves direct operators when remote binding evidence is unavailable", () => {
+    const params = {
+      accountId: "default",
+      chatContext: { chatId: 1 },
+      cliPath: "/tmp/remote-imsg-wrapper",
+      hasExclusiveLocalDatabase: false,
+      remoteHost: "qa@example.invalid",
+      messageId: "unknown-guid",
+    };
+
+    expect(() =>
+      authorizeIMessageResourceReference({
+        ...params,
+        conversationReadOrigin: "direct-operator",
+      }),
+    ).not.toThrow();
+  });
+
+  it("does not use an account-ambiguous local database for delegated authorization", () => {
+    expect(() =>
+      authorizeIMessageResourceReference({
+        accountId: "work",
+        chatContext: { chatIdentifier: "iMessage;-;+15550001111" },
+        cliPath,
+        dbPath,
+        hasExclusiveLocalDatabase: false,
+        messageId: "message-guid",
+        conversationReadOrigin: "delegated",
+      }),
+    ).toThrow("require a current same-account conversation binding");
+
+    expect(() =>
+      authorizeIMessageResourceReference({
+        accountId: "work",
+        chatContext: { chatIdentifier: "iMessage;-;+15550001111" },
+        cliPath,
+        dbPath,
+        hasExclusiveLocalDatabase: false,
+        messageId: "message-guid",
+        conversationReadOrigin: "direct-operator",
+      }),
+    ).not.toThrow();
+  });
+
+  it("treats provider-resolved handle aliases as unavailable binding evidence", () => {
+    expect(
+      checkIMessageResourceBinding({
+        chatContext: {},
+        cliPath,
+        dbPath,
+        messageId: "message-guid",
+      }),
+    ).toBe("unavailable");
+    expect(() =>
+      authorizeIMessageResourceReference({
+        accountId: "default",
+        chatContext: {},
+        cliPath,
+        dbPath,
+        hasExclusiveLocalDatabase: true,
+        messageId: "message-guid",
+        conversationReadOrigin: "direct-operator",
+      }),
+    ).not.toThrow();
+    expect(() =>
+      authorizeIMessageResourceReference({
+        accountId: "default",
+        chatContext: {},
+        cliPath,
+        dbPath,
+        hasExclusiveLocalDatabase: true,
+        messageId: "message-guid",
+        conversationReadOrigin: "delegated",
+      }),
+    ).toThrow("require a current same-account conversation binding");
+  });
+
+  it("does not treat a configured database as local for an SSH imsg wrapper", () => {
+    const wrapperDir = path.join(tempDir, "wrapper");
+    const wrapperPath = path.join(wrapperDir, "imsg");
+    fs.mkdirSync(wrapperDir);
+    fs.writeFileSync(wrapperPath, '#!/bin/sh\nexec ssh qa.example.invalid imsg "$@"\n');
+
+    expect(
+      checkIMessageResourceBinding({
+        chatContext: { chatId: 1 },
+        cliPath: wrapperPath,
+        dbPath,
+        messageId: "message-guid",
+      }),
+    ).toBe("unavailable");
+  });
+
+  it("does not trust a PATH wrapper whose remote command is hidden behind variables", () => {
+    const wrapperDir = path.join(tempDir, "path-wrapper");
+    const wrapperPath = path.join(wrapperDir, "imsg");
+    fs.mkdirSync(wrapperDir);
+    fs.writeFileSync(
+      wrapperPath,
+      '#!/bin/sh\nhost=qa.example.invalid\nexec ssh "$host" imsg "$@"\n',
+      { mode: 0o755 },
+    );
+    vi.stubEnv("PATH", wrapperDir);
+
+    expect(
+      checkIMessageResourceBinding({
+        chatContext: { chatId: 1 },
+        cliPath: "imsg",
+        dbPath,
+        messageId: "message-guid",
+      }),
+    ).toBe("unavailable");
+  });
+});

--- a/extensions/imessage/src/message-resource.test.ts
+++ b/extensions/imessage/src/message-resource.test.ts
@@ -38,14 +38,19 @@ beforeEach(async () => {
     CREATE TABLE chat_message_join (chat_id INTEGER, message_id INTEGER);
     INSERT INTO chat(ROWID, chat_identifier, guid) VALUES
       (1, '+15550001111', 'iMessage;-;+15550001111'),
-      (2, 'other', 'iMessage;+;other'),
-      (3, '+15550002222', 'SMS;-;+15550002222');
+      (2, 'other', 'iMessage;+;Some@example.com'),
+      (3, '+15550002222', 'SMS;-;+15550002222'),
+      (4, 'Üser@Example.com', 'iMessage;-;Üser@Example.com');
     INSERT INTO message(ROWID, guid) VALUES
       (10, 'message-guid'),
-      (11, 'sms-message-guid');
+      (11, 'sms-message-guid'),
+      (12, 'email-message-guid'),
+      (13, 'other-message-guid');
     INSERT INTO chat_message_join(chat_id, message_id) VALUES
       (1, 10),
-      (3, 11);
+      (3, 11),
+      (4, 12),
+      (2, 13);
   `);
   db.close();
 });
@@ -185,6 +190,30 @@ describe("iMessage provider resource binding", () => {
     ).toBe("match");
     expect(
       checkIMessageResourceBinding({
+        chatContext: { chatIdentifier: "iMessage;-;üser@example.com" },
+        cliPath,
+        dbPath,
+        messageId: "email-message-guid",
+      }),
+    ).toBe("match");
+    expect(
+      checkIMessageResourceBinding({
+        chatContext: { chatGuid: "iMessage;-;üser@example.com" },
+        cliPath,
+        dbPath,
+        messageId: "email-message-guid",
+      }),
+    ).toBe("match");
+    expect(
+      checkIMessageResourceBinding({
+        chatContext: { chatIdentifier: "iMessage;-;other@example.com" },
+        cliPath,
+        dbPath,
+        messageId: "email-message-guid",
+      }),
+    ).toBe("mismatch");
+    expect(
+      checkIMessageResourceBinding({
         chatContext: { chatId: 2 },
         cliPath,
         dbPath,
@@ -197,6 +226,22 @@ describe("iMessage provider resource binding", () => {
         cliPath,
         dbPath,
         messageId: "message-guid",
+      }),
+    ).toBe("mismatch");
+    expect(
+      checkIMessageResourceBinding({
+        chatContext: { chatGuid: "iMessage;+;Some@example.com" },
+        cliPath,
+        dbPath,
+        messageId: "other-message-guid",
+      }),
+    ).toBe("match");
+    expect(
+      checkIMessageResourceBinding({
+        chatContext: { chatGuid: "iMessage;+;some@example.com" },
+        cliPath,
+        dbPath,
+        messageId: "other-message-guid",
       }),
     ).toBe("mismatch");
     expect(

--- a/extensions/imessage/src/message-resource.test.ts
+++ b/extensions/imessage/src/message-resource.test.ts
@@ -4,12 +4,13 @@ import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { chatContextFromIMessageTarget } from "./chat-context.js";
+import { checkIMessageResourceBinding } from "./message-resource-db.js";
+import { authorizeIMessageResourceReference } from "./message-resource.js";
 import {
-  authorizeIMessageResourceReference,
-  checkIMessageResourceBinding,
+  rememberIMessageReplyCache,
+  resetIMessageShortIdState,
   resolveIMessageCachedResourceBinding,
-} from "./message-resource.js";
-import { rememberIMessageReplyCache, resetIMessageShortIdState } from "./monitor-reply-cache.js";
+} from "./monitor-reply-cache.js";
 import { installIMessageStateRuntimeForTest } from "./test-support/runtime.js";
 
 let tempDir = "";

--- a/extensions/imessage/src/message-resource.test.ts
+++ b/extensions/imessage/src/message-resource.test.ts
@@ -5,21 +5,22 @@ import { DatabaseSync } from "node:sqlite";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { chatContextFromIMessageTarget } from "./chat-context.js";
 import { checkIMessageResourceBinding } from "./message-resource-db.js";
-import { authorizeIMessageResourceReference } from "./message-resource.js";
-import {
-  rememberIMessageReplyCache,
-  resetIMessageShortIdState,
-  resolveIMessageCachedResourceBinding,
-} from "./monitor-reply-cache.js";
-import { installIMessageStateRuntimeForTest } from "./test-support/runtime.js";
+import { loadFreshIMessageReplyCacheForTest } from "./test-support/runtime.js";
+
+type MessageResourceModule = typeof import("./message-resource.js");
+type ReplyCacheModule = typeof import("./monitor-reply-cache.js");
+let authorizeIMessageResourceReference: MessageResourceModule["authorizeIMessageResourceReference"];
+let rememberIMessageReplyCache: ReplyCacheModule["rememberIMessageReplyCache"];
+let resolveIMessageCachedResourceBinding: ReplyCacheModule["resolveIMessageCachedResourceBinding"];
 
 let tempDir = "";
 let dbPath = "";
 let cliPath = "";
 
-beforeEach(() => {
-  installIMessageStateRuntimeForTest();
-  resetIMessageShortIdState();
+beforeEach(async () => {
+  ({ rememberIMessageReplyCache, resolveIMessageCachedResourceBinding } =
+    await loadFreshIMessageReplyCacheForTest());
+  ({ authorizeIMessageResourceReference } = await import("./message-resource.js"));
   tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-imessage-resource-"));
   dbPath = path.join(tempDir, "chat.db");
   const binDir = path.join(tempDir, "bin");
@@ -50,7 +51,6 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  resetIMessageShortIdState();
   vi.unstubAllEnvs();
   fs.rmSync(tempDir, { recursive: true, force: true });
 });

--- a/extensions/imessage/src/message-resource.ts
+++ b/extensions/imessage/src/message-resource.ts
@@ -1,9 +1,11 @@
 // Imessage plugin module binds provider message ids to one authorized chat.
-import { createRequire } from "node:module";
 import { createActionGate } from "openclaw/plugin-sdk/channel-actions";
 import type { ResolvedIMessageAccount } from "./accounts.js";
 import { chatContextFromIMessageTarget } from "./chat-context.js";
-import { resolveLocalIMessageChatDbPath } from "./cli-path.js";
+import {
+  checkIMessageResourceBinding,
+  normalizeIMessageMessageGuidForLookup,
+} from "./message-resource-db.js";
 import {
   resolveIMessageCachedResourceBinding,
   resolveIMessageMessageId,
@@ -11,11 +13,7 @@ import {
 } from "./monitor-reply-cache.js";
 import type { IMessageService, IMessageTarget } from "./targets.js";
 
-const require = createRequire(import.meta.url);
 const MAX_REPLY_TO_ID_LENGTH = 256;
-
-export type IMessageResourceBinding = "match" | "mismatch" | "unavailable";
-export { resolveIMessageCachedResourceBinding };
 
 type IMessageResourceAuthorizationParams = {
   accountId: string;
@@ -79,133 +77,6 @@ export function resolveAuthorizedIMessageReplyReference(params: {
   return messageId;
 }
 
-function normalizeMessageGuidForLookup(messageId: string): string {
-  const trimmed = messageId.trim();
-  const slash = trimmed.lastIndexOf("/");
-  return slash >= 0 && slash + 1 < trimmed.length ? trimmed.slice(slash + 1) : trimmed;
-}
-
-function chatGuidCandidates(raw: string | undefined): string[] {
-  const trimmed = raw?.trim();
-  if (!trimmed) {
-    return [];
-  }
-  const ordered = [trimmed];
-  const parts = trimmed.split(";");
-  const service = parts[0]?.toLowerCase();
-  const kind = parts[1];
-  const identifier = parts[2];
-  if (parts.length === 3 && (kind === "+" || kind === "-") && identifier) {
-    if (service === "any") {
-      ordered.push(`iMessage;${kind};${identifier}`, `SMS;${kind};${identifier}`);
-    } else if (service === "imessage") {
-      ordered.push(`iMessage;${kind};${identifier}`, `any;${kind};${identifier}`);
-    } else if (service === "sms") {
-      ordered.push(`SMS;${kind};${identifier}`, `any;${kind};${identifier}`);
-    }
-  }
-  return [...new Set(ordered)];
-}
-
-function chatIdentifierCandidates(raw: string | undefined): string[] {
-  const trimmed = raw?.trim();
-  if (!trimmed) {
-    return [];
-  }
-  const parts = trimmed.split(";");
-  const service = parts[0]?.toLowerCase();
-  const hasKnownPrefix = service === "imessage" || service === "sms" || service === "any";
-  const hasKnownKind = parts[1] === "+" || parts[1] === "-";
-  const bareIdentifier =
-    parts.length === 3 && hasKnownPrefix && hasKnownKind ? parts[2] : undefined;
-  return [...new Set([trimmed, ...(bareIdentifier ? [bareIdentifier] : [])])];
-}
-
-function isKnownChatGuid(raw: string | undefined): raw is string {
-  const parts = raw?.trim().split(";");
-  if (!parts || parts.length !== 3 || (parts[1] !== "+" && parts[1] !== "-") || !parts[2]) {
-    return false;
-  }
-  const service = parts[0]?.toLowerCase();
-  return service === "imessage" || service === "sms" || service === "any";
-}
-
-function loadNodeSqlite(): typeof import("node:sqlite") | null {
-  try {
-    return require("node:sqlite") as typeof import("node:sqlite");
-  } catch {
-    return null;
-  }
-}
-
-export function checkIMessageResourceBinding(
-  params: Omit<
-    IMessageResourceAuthorizationParams,
-    "accountId" | "conversationReadOrigin" | "hasExclusiveLocalDatabase"
-  >,
-): IMessageResourceBinding {
-  const dbPath = resolveLocalIMessageChatDbPath(params);
-  const sqlite = loadNodeSqlite();
-  if (!dbPath || !sqlite) {
-    return "unavailable";
-  }
-  const messageGuid = normalizeMessageGuidForLookup(params.messageId);
-  if (!messageGuid) {
-    return "mismatch";
-  }
-  const expectedChatGuids = chatGuidCandidates(params.chatContext.chatGuid);
-  const expectedChatIdentifiers = chatIdentifierCandidates(params.chatContext.chatIdentifier);
-  const identifierChatGuids = isKnownChatGuid(params.chatContext.chatIdentifier)
-    ? chatGuidCandidates(params.chatContext.chatIdentifier)
-    : [];
-  const chatId = params.chatContext.chatId;
-  const chatClauses: string[] = [];
-  const bindings: Array<string | number> = [messageGuid];
-  if (typeof chatId === "number" && Number.isSafeInteger(chatId) && chatId > 0) {
-    chatClauses.push("cmj.chat_id = ?");
-    bindings.push(chatId);
-  }
-  if (expectedChatGuids.length > 0) {
-    chatClauses.push(`c.guid IN (${expectedChatGuids.map(() => "?").join(", ")})`);
-    bindings.push(...expectedChatGuids);
-  }
-  if (expectedChatIdentifiers.length > 0) {
-    chatClauses.push(`c.chat_identifier IN (${expectedChatIdentifiers.map(() => "?").join(", ")})`);
-    bindings.push(...expectedChatIdentifiers);
-  }
-  if (identifierChatGuids.length > 0) {
-    chatClauses.push(`c.guid IN (${identifierChatGuids.map(() => "?").join(", ")})`);
-    bindings.push(...identifierChatGuids);
-  }
-  if (chatClauses.length === 0) {
-    return "unavailable";
-  }
-
-  let db: import("node:sqlite").DatabaseSync | undefined;
-  try {
-    db = new sqlite.DatabaseSync(dbPath, { readOnly: true });
-    const row = db
-      .prepare(
-        `SELECT 1 AS found
-         FROM message m
-         JOIN chat_message_join cmj ON cmj.message_id = m.ROWID
-         JOIN chat c ON c.ROWID = cmj.chat_id
-         WHERE m.guid = ? AND (${chatClauses.join(" AND ")})
-         LIMIT 1`,
-      )
-      .get(...bindings);
-    return row ? "match" : "mismatch";
-  } catch {
-    return "unavailable";
-  } finally {
-    try {
-      db?.close();
-    } catch {
-      // Best-effort cleanup after a read-only authorization query.
-    }
-  }
-}
-
 export function authorizeIMessageResourceReference(
   params: IMessageResourceAuthorizationParams,
 ): void {
@@ -214,7 +85,7 @@ export function authorizeIMessageResourceReference(
     accountId: params.accountId,
   };
   let cacheBinding = resolveIMessageCachedResourceBinding(params.messageId, cacheContext);
-  const normalizedMessageId = normalizeMessageGuidForLookup(params.messageId);
+  const normalizedMessageId = normalizeIMessageMessageGuidForLookup(params.messageId);
   if (cacheBinding === "unknown" && normalizedMessageId !== params.messageId.trim()) {
     cacheBinding = resolveIMessageCachedResourceBinding(normalizedMessageId, cacheContext);
   }

--- a/extensions/imessage/src/message-resource.ts
+++ b/extensions/imessage/src/message-resource.ts
@@ -1,0 +1,243 @@
+// Imessage plugin module binds provider message ids to one authorized chat.
+import { createRequire } from "node:module";
+import { createActionGate } from "openclaw/plugin-sdk/channel-actions";
+import type { ResolvedIMessageAccount } from "./accounts.js";
+import { chatContextFromIMessageTarget } from "./chat-context.js";
+import { resolveLocalIMessageChatDbPath } from "./cli-path.js";
+import {
+  resolveIMessageCachedResourceBinding,
+  resolveIMessageMessageId,
+  type IMessageChatContext,
+} from "./monitor-reply-cache.js";
+import type { IMessageService, IMessageTarget } from "./targets.js";
+
+const require = createRequire(import.meta.url);
+const MAX_REPLY_TO_ID_LENGTH = 256;
+
+export type IMessageResourceBinding = "match" | "mismatch" | "unavailable";
+export { resolveIMessageCachedResourceBinding };
+
+type IMessageResourceAuthorizationParams = {
+  accountId: string;
+  chatContext: IMessageChatContext;
+  cliPath: string;
+  dbPath?: string;
+  hasExclusiveLocalDatabase: boolean;
+  remoteHost?: string;
+  messageId: string;
+  conversationReadOrigin?: string;
+};
+
+function sanitizeReplyToId(rawReplyToId?: string): string | undefined {
+  const trimmed = rawReplyToId?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  let sanitized = "";
+  for (const ch of trimmed) {
+    const code = ch.charCodeAt(0);
+    if ((code >= 0 && code <= 31) || code === 127 || ch === "[" || ch === "]") {
+      continue;
+    }
+    sanitized += ch;
+  }
+  return sanitized.trim().slice(0, MAX_REPLY_TO_ID_LENGTH) || undefined;
+}
+
+export function resolveAuthorizedIMessageReplyReference(params: {
+  account: ResolvedIMessageAccount;
+  target: IMessageTarget;
+  cliPath: string;
+  dbPath?: string;
+  hasExclusiveLocalDatabase: boolean;
+  service?: IMessageService;
+  replyToId?: string;
+  conversationReadOrigin?: string;
+}): string | undefined {
+  if (!createActionGate(params.account.config.actions)("reply")) {
+    return undefined;
+  }
+  const rawReplyToId = sanitizeReplyToId(params.replyToId);
+  if (!rawReplyToId) {
+    return undefined;
+  }
+  const chatContext = chatContextFromIMessageTarget(params.target, params.service);
+  const messageId = resolveIMessageMessageId(rawReplyToId, {
+    requireKnownShortId: true,
+    chatContext,
+  });
+  authorizeIMessageResourceReference({
+    accountId: params.account.accountId,
+    chatContext,
+    cliPath: params.cliPath,
+    dbPath: params.dbPath,
+    hasExclusiveLocalDatabase: params.hasExclusiveLocalDatabase,
+    remoteHost: params.account.config.remoteHost,
+    messageId,
+    conversationReadOrigin: params.conversationReadOrigin,
+  });
+  return messageId;
+}
+
+function normalizeMessageGuidForLookup(messageId: string): string {
+  const trimmed = messageId.trim();
+  const slash = trimmed.lastIndexOf("/");
+  return slash >= 0 && slash + 1 < trimmed.length ? trimmed.slice(slash + 1) : trimmed;
+}
+
+function chatGuidCandidates(raw: string | undefined): string[] {
+  const trimmed = raw?.trim();
+  if (!trimmed) {
+    return [];
+  }
+  const ordered = [trimmed];
+  const parts = trimmed.split(";");
+  const service = parts[0]?.toLowerCase();
+  const kind = parts[1];
+  const identifier = parts[2];
+  if (parts.length === 3 && (kind === "+" || kind === "-") && identifier) {
+    if (service === "any") {
+      ordered.push(`iMessage;${kind};${identifier}`, `SMS;${kind};${identifier}`);
+    } else if (service === "imessage") {
+      ordered.push(`iMessage;${kind};${identifier}`, `any;${kind};${identifier}`);
+    } else if (service === "sms") {
+      ordered.push(`SMS;${kind};${identifier}`, `any;${kind};${identifier}`);
+    }
+  }
+  return [...new Set(ordered)];
+}
+
+function chatIdentifierCandidates(raw: string | undefined): string[] {
+  const trimmed = raw?.trim();
+  if (!trimmed) {
+    return [];
+  }
+  const parts = trimmed.split(";");
+  const service = parts[0]?.toLowerCase();
+  const hasKnownPrefix = service === "imessage" || service === "sms" || service === "any";
+  const hasKnownKind = parts[1] === "+" || parts[1] === "-";
+  const bareIdentifier =
+    parts.length === 3 && hasKnownPrefix && hasKnownKind ? parts[2] : undefined;
+  return [...new Set([trimmed, ...(bareIdentifier ? [bareIdentifier] : [])])];
+}
+
+function isKnownChatGuid(raw: string | undefined): raw is string {
+  const parts = raw?.trim().split(";");
+  if (!parts || parts.length !== 3 || (parts[1] !== "+" && parts[1] !== "-") || !parts[2]) {
+    return false;
+  }
+  const service = parts[0]?.toLowerCase();
+  return service === "imessage" || service === "sms" || service === "any";
+}
+
+function loadNodeSqlite(): typeof import("node:sqlite") | null {
+  try {
+    return require("node:sqlite") as typeof import("node:sqlite");
+  } catch {
+    return null;
+  }
+}
+
+export function checkIMessageResourceBinding(
+  params: Omit<
+    IMessageResourceAuthorizationParams,
+    "accountId" | "conversationReadOrigin" | "hasExclusiveLocalDatabase"
+  >,
+): IMessageResourceBinding {
+  const dbPath = resolveLocalIMessageChatDbPath(params);
+  const sqlite = loadNodeSqlite();
+  if (!dbPath || !sqlite) {
+    return "unavailable";
+  }
+  const messageGuid = normalizeMessageGuidForLookup(params.messageId);
+  if (!messageGuid) {
+    return "mismatch";
+  }
+  const expectedChatGuids = chatGuidCandidates(params.chatContext.chatGuid);
+  const expectedChatIdentifiers = chatIdentifierCandidates(params.chatContext.chatIdentifier);
+  const identifierChatGuids = isKnownChatGuid(params.chatContext.chatIdentifier)
+    ? chatGuidCandidates(params.chatContext.chatIdentifier)
+    : [];
+  const chatId = params.chatContext.chatId;
+  const chatClauses: string[] = [];
+  const bindings: Array<string | number> = [messageGuid];
+  if (typeof chatId === "number" && Number.isSafeInteger(chatId) && chatId > 0) {
+    chatClauses.push("cmj.chat_id = ?");
+    bindings.push(chatId);
+  }
+  if (expectedChatGuids.length > 0) {
+    chatClauses.push(`c.guid IN (${expectedChatGuids.map(() => "?").join(", ")})`);
+    bindings.push(...expectedChatGuids);
+  }
+  if (expectedChatIdentifiers.length > 0) {
+    chatClauses.push(`c.chat_identifier IN (${expectedChatIdentifiers.map(() => "?").join(", ")})`);
+    bindings.push(...expectedChatIdentifiers);
+  }
+  if (identifierChatGuids.length > 0) {
+    chatClauses.push(`c.guid IN (${identifierChatGuids.map(() => "?").join(", ")})`);
+    bindings.push(...identifierChatGuids);
+  }
+  if (chatClauses.length === 0) {
+    return "unavailable";
+  }
+
+  let db: import("node:sqlite").DatabaseSync | undefined;
+  try {
+    db = new sqlite.DatabaseSync(dbPath, { readOnly: true });
+    const row = db
+      .prepare(
+        `SELECT 1 AS found
+         FROM message m
+         JOIN chat_message_join cmj ON cmj.message_id = m.ROWID
+         JOIN chat c ON c.ROWID = cmj.chat_id
+         WHERE m.guid = ? AND (${chatClauses.join(" AND ")})
+         LIMIT 1`,
+      )
+      .get(...bindings);
+    return row ? "match" : "mismatch";
+  } catch {
+    return "unavailable";
+  } finally {
+    try {
+      db?.close();
+    } catch {
+      // Best-effort cleanup after a read-only authorization query.
+    }
+  }
+}
+
+export function authorizeIMessageResourceReference(
+  params: IMessageResourceAuthorizationParams,
+): void {
+  const cacheContext = {
+    ...params.chatContext,
+    accountId: params.accountId,
+  };
+  let cacheBinding = resolveIMessageCachedResourceBinding(params.messageId, cacheContext);
+  const normalizedMessageId = normalizeMessageGuidForLookup(params.messageId);
+  if (cacheBinding === "unknown" && normalizedMessageId !== params.messageId.trim()) {
+    cacheBinding = resolveIMessageCachedResourceBinding(normalizedMessageId, cacheContext);
+  }
+  if (cacheBinding === "match") {
+    return;
+  }
+  if (cacheBinding === "mismatch") {
+    throw new Error("iMessage message reference belongs to a different account or conversation.");
+  }
+
+  const providerBinding = params.hasExclusiveLocalDatabase
+    ? checkIMessageResourceBinding(params)
+    : "unavailable";
+  if (providerBinding === "match") {
+    return;
+  }
+  if (providerBinding === "mismatch") {
+    throw new Error("iMessage message reference does not belong to the selected conversation.");
+  }
+  if (params.conversationReadOrigin === "direct-operator") {
+    return;
+  }
+  throw new Error(
+    "Delegated iMessage message references require a current same-account conversation binding when the Messages database is unavailable.",
+  );
+}

--- a/extensions/imessage/src/monitor-reply-cache.test.ts
+++ b/extensions/imessage/src/monitor-reply-cache.test.ts
@@ -7,6 +7,7 @@ let findLatestIMessageEntryForChat: ReplyCacheModule["findLatestIMessageEntryFor
 let isIMessageCurrentMessageInChat: ReplyCacheModule["isIMessageCurrentMessageInChat"];
 let isKnownFromMeIMessageMessageId: ReplyCacheModule["isKnownFromMeIMessageMessageId"];
 let rememberIMessageReplyCache: ReplyCacheModule["rememberIMessageReplyCache"];
+let resolveIMessageCachedResourceBinding: ReplyCacheModule["resolveIMessageCachedResourceBinding"];
 let resolveIMessageMessageId: ReplyCacheModule["resolveIMessageMessageId"];
 
 async function loadReplyCache(options?: { preservePersistentState?: boolean }): Promise<void> {
@@ -15,6 +16,7 @@ async function loadReplyCache(options?: { preservePersistentState?: boolean }): 
     isIMessageCurrentMessageInChat,
     isKnownFromMeIMessageMessageId,
     rememberIMessageReplyCache,
+    resolveIMessageCachedResourceBinding,
     resolveIMessageMessageId,
   } = await loadFreshIMessageReplyCacheForTest(options));
 }
@@ -393,6 +395,55 @@ describe("hydrate-on-resolve (post-restart short-id persistence)", () => {
 });
 
 describe("current-message chat binding", () => {
+  it("preserves concrete service identity while allowing trusted any aliases", () => {
+    rememberIMessageReplyCache({
+      accountId: "work",
+      messageId: "sms-guid",
+      chatGuid: "SMS;-;+12069106512",
+      chatIdentifier: "+12069106512",
+      timestamp: Date.now(),
+    });
+    rememberIMessageReplyCache({
+      accountId: "work",
+      messageId: "any-guid",
+      chatGuid: "any;-;+12069106512",
+      chatIdentifier: "+12069106512",
+      timestamp: Date.now(),
+    });
+
+    expect(
+      resolveIMessageCachedResourceBinding("sms-guid", {
+        accountId: "work",
+        chatIdentifier: "iMessage;-;+12069106512",
+      }),
+    ).toBe("mismatch");
+    expect(
+      resolveIMessageCachedResourceBinding("any-guid", {
+        accountId: "work",
+        chatIdentifier: "iMessage;-;+12069106512",
+      }),
+    ).toBe("match");
+  });
+
+  it("treats expired entries as unknown before account or chat mismatches", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-08T00:00:00Z"));
+    rememberIMessageReplyCache({
+      accountId: "work",
+      messageId: "expired-guid",
+      chatId: 42,
+      timestamp: Date.now(),
+    });
+    vi.setSystemTime(new Date("2026-05-08T07:00:00Z"));
+
+    expect(
+      resolveIMessageCachedResourceBinding("expired-guid", {
+        accountId: "other",
+        chatId: 99,
+      }),
+    ).toBe("unknown");
+  });
+
   it.each([{ chatGuid: "any;-;+12069106512" }, { chatIdentifier: "+12069106512" }, { chatId: 42 }])(
     "matches a trusted current message through $chatGuid$chatIdentifier$chatId",
     (chatContext) => {

--- a/extensions/imessage/src/monitor-reply-cache.test.ts
+++ b/extensions/imessage/src/monitor-reply-cache.test.ts
@@ -80,7 +80,16 @@ describe("imessage short message id resolution", () => {
         requireKnownShortId: true,
         chatContext: { chatGuid: "iMessage;+;other" },
       }),
-    ).toThrow("belongs to a different chat");
+    ).toThrow("MessageSidFull from another chat is rejected");
+  });
+
+  it("recommends the full id when a short id has expired in the current chat", () => {
+    expect(() =>
+      resolveIMessageMessageId("9999", {
+        requireKnownShortId: true,
+        chatContext: { chatGuid: "iMessage;+;chat0000" },
+      }),
+    ).toThrow("is no longer available. Use MessageSidFull");
   });
 
   it("guards full guid reuse across chats when cached", () => {

--- a/extensions/imessage/src/monitor-reply-cache.ts
+++ b/extensions/imessage/src/monitor-reply-cache.ts
@@ -3,7 +3,14 @@ import { createHash } from "node:crypto";
 import type { PluginStateSyncKeyedStore } from "openclaw/plugin-sdk/plugin-state-runtime";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
+import {
+  isPositiveIMessageChatMatch,
+  resolveIMessageChatMatch,
+  type IMessageChatContext,
+} from "./chat-context.js";
 import { getIMessageRuntime } from "./runtime.js";
+
+export type { IMessageChatContext } from "./chat-context.js";
 
 export const IMESSAGE_REPLY_CACHE_NAMESPACE = "imessage.reply-cache";
 export const IMESSAGE_REPLY_CACHE_MAX_ENTRIES = 2000;
@@ -21,12 +28,6 @@ function reportPersistenceFailure(scope: string, err: unknown): void {
   persistenceFailureLogged = true;
   logVerbose(`imessage reply-cache: ${scope} disabled after first failure: ${String(err)}`);
 }
-
-export type IMessageChatContext = {
-  chatGuid?: string;
-  chatIdentifier?: string;
-  chatId?: number;
-};
 
 type IMessageReplyCacheEntry = IMessageChatContext & {
   accountId: string;
@@ -248,69 +249,8 @@ function hasChatScope(ctx?: IMessageChatContext): boolean {
   );
 }
 
-/**
- * Strip the `iMessage;-;` / `SMS;-;` / `any;-;` service prefix that Messages
- * uses for direct chats. Different layers report direct DMs in different
- * forms — imsg's watch emits the bare handle plus an `any;-;…` chat_guid,
- * the action surface synthesizes `iMessage;-;…` from a phone-number target —
- * so comparing the raw strings would falsely flag the same chat as a
- * cross-chat target. Normalize both sides to the bare suffix.
- */
-export function normalizeDirectChatIdentifier(raw: string): string {
-  const trimmed = raw.trim();
-  const lowered = trimmed.toLowerCase();
-  for (const prefix of ["imessage;-;", "sms;-;", "any;-;"]) {
-    if (lowered.startsWith(prefix)) {
-      return trimmed.slice(prefix.length);
-    }
-  }
-  return trimmed;
-}
-
 function isCrossChatMismatch(cached: IMessageReplyCacheEntry, ctx: IMessageChatContext): boolean {
-  const cachedChatGuid = normalizeOptionalString(cached.chatGuid);
-  const ctxChatGuid = normalizeOptionalString(ctx.chatGuid);
-  if (cachedChatGuid && ctxChatGuid) {
-    if (
-      normalizeDirectChatIdentifier(cachedChatGuid) === normalizeDirectChatIdentifier(ctxChatGuid)
-    ) {
-      return false;
-    }
-    return cachedChatGuid !== ctxChatGuid;
-  }
-  const cachedChatIdentifier = normalizeOptionalString(cached.chatIdentifier);
-  const ctxChatIdentifier = normalizeOptionalString(ctx.chatIdentifier);
-  if (cachedChatIdentifier && ctxChatIdentifier) {
-    if (
-      normalizeDirectChatIdentifier(cachedChatIdentifier) ===
-      normalizeDirectChatIdentifier(ctxChatIdentifier)
-    ) {
-      return false;
-    }
-    return cachedChatIdentifier !== ctxChatIdentifier;
-  }
-  const cachedChatId = typeof cached.chatId === "number" ? cached.chatId : undefined;
-  const ctxChatId = typeof ctx.chatId === "number" ? ctx.chatId : undefined;
-  if (cachedChatId !== undefined && ctxChatId !== undefined) {
-    return cachedChatId !== ctxChatId;
-  }
-  // Cross-format pairing: caller supplied chatIdentifier=iMessage;-;<phone>
-  // and the cache stored chatGuid=any;-;<phone> (or vice versa). Compare via
-  // the direct-DM normalization so we recognize them as the same chat.
-  const cachedFingerprint = cachedChatGuid
-    ? normalizeDirectChatIdentifier(cachedChatGuid)
-    : cachedChatIdentifier
-      ? normalizeDirectChatIdentifier(cachedChatIdentifier)
-      : undefined;
-  const ctxFingerprint = ctxChatGuid
-    ? normalizeDirectChatIdentifier(ctxChatGuid)
-    : ctxChatIdentifier
-      ? normalizeDirectChatIdentifier(ctxChatIdentifier)
-      : undefined;
-  if (cachedFingerprint && ctxFingerprint) {
-    return cachedFingerprint !== ctxFingerprint;
-  }
-  return false;
+  return resolveIMessageChatMatch(cached, ctx) === "mismatch";
 }
 
 function describeChatForError(values: IMessageChatContext): string {
@@ -440,7 +380,7 @@ export function isKnownFromMeIMessageMessageId(
   if (!cached || cached.isFromMe !== true || cached.accountId !== ctx.accountId) {
     return false;
   }
-  return isPositiveChatMatch(cached, ctx);
+  return isPositiveIMessageChatMatch(cached, ctx);
 }
 
 function buildFromMeError(inputId: string, inputKind: "short" | "uuid"): Error {
@@ -487,7 +427,7 @@ export function findLatestIMessageEntryForChat(
     if (entry.timestamp < cutoff) {
       continue;
     }
-    if (!isPositiveChatMatch(entry, ctx)) {
+    if (!isPositiveIMessageChatMatch(entry, ctx)) {
       continue;
     }
     if (!best || entry.timestamp > best.timestamp) {
@@ -497,45 +437,26 @@ export function findLatestIMessageEntryForChat(
   return best;
 }
 
-/**
- * Return true when the cached entry positively matches the caller's chat
- * context on at least one identifier kind. Unlike `isCrossChatMismatch`,
- * which returns false for "no overlap," this requires concrete agreement.
- */
-function isPositiveChatMatch(entry: IMessageReplyCacheEntry, ctx: IMessageChatContext): boolean {
-  const cachedChatGuid = normalizeOptionalString(entry.chatGuid);
-  const ctxChatGuid = normalizeOptionalString(ctx.chatGuid);
-  if (cachedChatGuid && ctxChatGuid && cachedChatGuid === ctxChatGuid) {
-    return true;
+export function resolveIMessageCachedResourceBinding(
+  messageId: string,
+  ctx: IMessageChatContext & { accountId: string },
+): "match" | "mismatch" | "unknown" {
+  hydrateFromStoreOnce();
+  const entry = imessageReplyCacheByMessageId.get(messageId.trim());
+  if (!entry) {
+    return "unknown";
   }
-  const cachedChatIdentifier = normalizeOptionalString(entry.chatIdentifier);
-  const ctxChatIdentifier = normalizeOptionalString(ctx.chatIdentifier);
-  if (cachedChatIdentifier && ctxChatIdentifier && cachedChatIdentifier === ctxChatIdentifier) {
-    return true;
+  if (Date.now() - entry.timestamp > REPLY_CACHE_TTL_MS) {
+    return "unknown";
   }
-  if (
-    typeof entry.chatId === "number" &&
-    typeof ctx.chatId === "number" &&
-    entry.chatId === ctx.chatId
-  ) {
-    return true;
+  if (entry.accountId !== ctx.accountId) {
+    return "mismatch";
   }
-  // Cross-format: cached chatGuid vs ctx chatIdentifier, etc. Compare via
-  // the direct-DM normalization that strips iMessage;-;/SMS;-;/any;-; .
-  const cachedFingerprint = cachedChatGuid
-    ? normalizeDirectChatIdentifier(cachedChatGuid)
-    : cachedChatIdentifier
-      ? normalizeDirectChatIdentifier(cachedChatIdentifier)
-      : undefined;
-  const ctxFingerprint = ctxChatGuid
-    ? normalizeDirectChatIdentifier(ctxChatGuid)
-    : ctxChatIdentifier
-      ? normalizeDirectChatIdentifier(ctxChatIdentifier)
-      : undefined;
-  if (cachedFingerprint && ctxFingerprint && cachedFingerprint === ctxFingerprint) {
-    return true;
+  const chatMatch = resolveIMessageChatMatch(entry, ctx);
+  if (chatMatch !== "match") {
+    return chatMatch;
   }
-  return false;
+  return "match";
 }
 
 export function isIMessageCurrentMessageInChat(params: {
@@ -557,11 +478,10 @@ export function isIMessageCurrentMessageInChat(params: {
   if (!fullMessageId) {
     return false;
   }
-  const entry = imessageReplyCacheByMessageId.get(fullMessageId);
-  return Boolean(
-    entry &&
-    entry.accountId === params.accountId &&
-    Date.now() - entry.timestamp <= REPLY_CACHE_TTL_MS &&
-    isPositiveChatMatch(entry, params.chatContext),
+  return (
+    resolveIMessageCachedResourceBinding(fullMessageId, {
+      ...params.chatContext,
+      accountId: params.accountId,
+    }) === "match"
   );
 }

--- a/extensions/imessage/src/monitor-reply-cache.ts
+++ b/extensions/imessage/src/monitor-reply-cache.ts
@@ -282,7 +282,7 @@ function buildCrossChatError(
 ): Error {
   const remediation =
     inputKind === "short"
-      ? "Retry with MessageSidFull to avoid cross-chat reactions/replies landing in the wrong conversation."
+      ? "Use a message ID from the current chat target; MessageSidFull from another chat is rejected."
       : "Retry with the correct chat target.";
   return new Error(
     `iMessage message id ${describeMessageIdForError(inputId, inputKind)} belongs to a different chat ` +

--- a/extensions/imessage/src/send.test.ts
+++ b/extensions/imessage/src/send.test.ts
@@ -14,10 +14,12 @@ let clearIMessageApprovalReactionTargetsForTest: ApprovalReactionsModule["clearI
 let resolveIMessageApprovalReactionTargetWithPersistence: ApprovalReactionsModule["resolveIMessageApprovalReactionTargetWithPersistence"];
 let hasPersistedIMessageEcho: PersistedEchoCacheModule["hasPersistedIMessageEcho"];
 let findLatestIMessageEntryForChat: ReplyCacheModule["findLatestIMessageEntryForChat"];
+let rememberIMessageReplyCache: ReplyCacheModule["rememberIMessageReplyCache"];
 let sendMessageIMessage: SendModule["sendMessageIMessage"];
 
 async function loadFreshSendModule(): Promise<void> {
-  ({ findLatestIMessageEntryForChat } = await loadFreshIMessageReplyCacheForTest());
+  ({ findLatestIMessageEntryForChat, rememberIMessageReplyCache } =
+    await loadFreshIMessageReplyCacheForTest());
   ({
     clearIMessageApprovalReactionTargetsForTest,
     resolveIMessageApprovalReactionTargetWithPersistence,
@@ -90,6 +92,7 @@ describe("sendMessageIMessage receipts", () => {
     const result = await sendMessageIMessage("chat_id:42", "hello", {
       config: IMESSAGE_TEST_CFG,
       client,
+      conversationReadOrigin: "direct-operator",
       replyToId: "reply-1",
     });
 
@@ -148,6 +151,190 @@ describe("sendMessageIMessage receipts", () => {
     expect(result.receipt.parts[0]?.replyToId).toBeUndefined();
   });
 
+  it("rejects an unbound delegated reply before media or provider access", async () => {
+    const client = createClient({ guid: "should-not-send" });
+    const resolveAttachment = vi.fn(async () => ({
+      path: "/tmp/image.png",
+      contentType: "image/png",
+    }));
+
+    await expect(
+      sendMessageIMessage("chat_id:42", "caption", {
+        config: {
+          channels: {
+            imessage: {
+              remoteHost: "qa@example.invalid",
+              accounts: { default: {} },
+            },
+          },
+        },
+        client,
+        conversationReadOrigin: "delegated",
+        mediaUrl: "/tmp/image.png",
+        replyToId: "unbound-reply-guid",
+        resolveAttachmentImpl: resolveAttachment,
+      }),
+    ).rejects.toThrow("require a current same-account conversation binding");
+
+    expect(resolveAttachment).not.toHaveBeenCalled();
+    expect(getClientMocks(client).request).not.toHaveBeenCalled();
+  });
+
+  it("allows a delegated reply with a current same-account cache binding", async () => {
+    const client = createClient({ guid: "p:0/imsg-bound" });
+    rememberIMessageReplyCache({
+      accountId: "default",
+      messageId: "bound-reply-guid",
+      chatId: 42,
+      timestamp: Date.now(),
+    });
+
+    await expect(
+      sendMessageIMessage("chat_id:42", "hello", {
+        config: {
+          channels: {
+            imessage: {
+              remoteHost: "qa@example.invalid",
+              accounts: { default: {} },
+            },
+          },
+        },
+        client,
+        conversationReadOrigin: "delegated",
+        replyToId: "bound-reply-guid",
+      }),
+    ).resolves.toMatchObject({ messageId: "p:0/imsg-bound" });
+
+    expect(getClientMocks(client).request).toHaveBeenCalledWith(
+      "send",
+      expect.objectContaining({ chat_id: 42, reply_to: "bound-reply-guid" }),
+      expect.any(Object),
+    );
+  });
+
+  it("uses the effective SMS service for a delegated raw-handle reply", async () => {
+    const client = createClient({ guid: "p:0/imsg-sms-bound" });
+    rememberIMessageReplyCache({
+      accountId: "default",
+      messageId: "sms-reply-guid",
+      chatGuid: "SMS;-;+15550004567",
+      chatIdentifier: "+15550004567",
+      timestamp: Date.now(),
+    });
+
+    await expect(
+      sendMessageIMessage("+15550004567", "hello", {
+        config: {
+          channels: {
+            imessage: {
+              remoteHost: "qa@example.invalid",
+              accounts: { default: {} },
+            },
+          },
+        },
+        client,
+        service: "sms",
+        conversationReadOrigin: "delegated",
+        replyToId: "sms-reply-guid",
+      }),
+    ).resolves.toMatchObject({ messageId: "p:0/imsg-sms-bound" });
+
+    expect(getClientMocks(client).request).toHaveBeenCalledWith(
+      "send",
+      expect.objectContaining({
+        to: "+15550004567",
+        service: "sms",
+        reply_to: "sms-reply-guid",
+      }),
+      expect.any(Object),
+    );
+  });
+
+  it("rejects a delegated reply when an auto handle has no concrete service", async () => {
+    const client = createClient({ guid: "should-not-send" });
+    rememberIMessageReplyCache({
+      accountId: "default",
+      messageId: "ambiguous-service-guid",
+      chatGuid: "SMS;-;+15550004567",
+      chatIdentifier: "+15550004567",
+      timestamp: Date.now(),
+    });
+
+    await expect(
+      sendMessageIMessage("+15550004567", "hello", {
+        config: {
+          channels: {
+            imessage: {
+              remoteHost: "qa@example.invalid",
+              accounts: { default: {} },
+            },
+          },
+        },
+        client,
+        conversationReadOrigin: "delegated",
+        replyToId: "ambiguous-service-guid",
+      }),
+    ).rejects.toThrow("require a current same-account conversation binding");
+
+    expect(getClientMocks(client).request).not.toHaveBeenCalled();
+  });
+
+  it("caches provider-resolved chat IDs with the canonical effective service", async () => {
+    const client = createClient({
+      guid: "p:0/imsg-canonical",
+      chat_guid: "SMS;-;+15550004567",
+      service: "SMS",
+    });
+
+    await sendMessageIMessage("+1 (555) 000-4567", "hello", {
+      config: IMESSAGE_TEST_CFG,
+      client,
+    });
+
+    expect(
+      findLatestIMessageEntryForChat({
+        accountId: "default",
+        chatGuid: "SMS;-;+15550004567",
+        chatIdentifier: "SMS;-;+15550004567",
+      }),
+    ).toEqual(
+      expect.objectContaining({
+        messageId: "p:0/imsg-canonical",
+        chatGuid: "SMS;-;+15550004567",
+        chatIdentifier: "SMS;-;+15550004567",
+        isFromMe: true,
+      }),
+    );
+  });
+
+  it("caches the provider-resolved GUID alongside an outbound chat ID", async () => {
+    const client = createClient({
+      guid: "p:0/imsg-chat-id",
+      chat_guid: "iMessage;+;group-guid",
+      service: "iMessage",
+    });
+
+    await sendMessageIMessage("chat_id:42", "hello", {
+      config: IMESSAGE_TEST_CFG,
+      client,
+    });
+
+    expect(
+      findLatestIMessageEntryForChat({
+        accountId: "default",
+        chatId: 42,
+        chatGuid: "iMessage;+;group-guid",
+      }),
+    ).toEqual(
+      expect.objectContaining({
+        messageId: "p:0/imsg-chat-id",
+        chatId: 42,
+        chatGuid: "iMessage;+;group-guid",
+        isFromMe: true,
+      }),
+    );
+  });
+
   it("resends unthreaded when the transport cannot deliver a threaded reply (#99638)", async () => {
     const sendParams: Array<Record<string, unknown>> = [];
     const client = {
@@ -166,6 +353,7 @@ describe("sendMessageIMessage receipts", () => {
     const result = await sendMessageIMessage("chat_id:42", "hello", {
       config: IMESSAGE_TEST_CFG,
       client,
+      conversationReadOrigin: "direct-operator",
       replyToId: "reply-1",
     });
 
@@ -200,6 +388,7 @@ describe("sendMessageIMessage receipts", () => {
     const result = await sendMessageIMessage("chat_id:42", "caption", {
       config: IMESSAGE_TEST_CFG,
       client,
+      conversationReadOrigin: "direct-operator",
       replyToId: "reply-1",
       mediaUrl: "/tmp/image.png",
       resolveAttachmentImpl: async () => ({ path: "/tmp/image.png", contentType: "image/png" }),
@@ -363,6 +552,7 @@ describe("sendMessageIMessage receipts", () => {
     const result = await sendMessageIMessage("chat_guid:chat-1", "", {
       config: IMESSAGE_TEST_CFG,
       client,
+      conversationReadOrigin: "direct-operator",
       mediaUrl: "/tmp/voice.caf",
       audioAsVoice: true,
       replyToId: "p:0/reply-guid",

--- a/extensions/imessage/src/send.ts
+++ b/extensions/imessage/src/send.ts
@@ -1,9 +1,6 @@
 // Imessage plugin module implements send behavior.
-import { constants, accessSync, readFileSync } from "node:fs";
+import { constants, accessSync } from "node:fs";
 import { createRequire } from "node:module";
-import os from "node:os";
-import path from "node:path";
-import { createActionGate } from "openclaw/plugin-sdk/channel-actions";
 import {
   createMessageReceiptFromOutboundResults,
   type MessageReceipt,
@@ -17,17 +14,24 @@ import { requireRuntimeConfig } from "openclaw/plugin-sdk/plugin-config-runtime"
 import { sleep as delay } from "openclaw/plugin-sdk/runtime-env";
 import { convertMarkdownTables } from "openclaw/plugin-sdk/text-chunking";
 import { stripInlineDirectiveTagsForDelivery } from "openclaw/plugin-sdk/text-chunking";
-import { resolveIMessageAccount, type ResolvedIMessageAccount } from "./accounts.js";
+import {
+  hasExclusiveIMessageLocalDatabase,
+  resolveIMessageAccount,
+  type ResolvedIMessageAccount,
+} from "./accounts.js";
 import {
   appendIMessageApprovalReactionHintForOutboundMessage,
   extractIMessageApprovalPromptBinding,
   type IMessageApprovalConversationKey,
   registerIMessageApprovalReactionTargetForOutboundMessage,
 } from "./approval-reactions.js";
+import { chatContextFromIMessageTarget } from "./chat-context.js";
 import { runIMessageCliJsonCommand } from "./cli-output.js";
+import { resolveIMessageChatDbLookupPath } from "./cli-path.js";
 import { createIMessageRpcClient, type IMessageRpcClient } from "./client.js";
 import { DEFAULT_IMESSAGE_SEND_TIMEOUT_MS } from "./constants.js";
 import { extractMarkdownFormatRuns } from "./markdown-format.js";
+import { resolveAuthorizedIMessageReplyReference } from "./message-resource.js";
 import { rememberIMessageReplyCache } from "./monitor-reply-cache.js";
 import {
   forgetPersistedIMessageEchoKey,
@@ -52,6 +56,7 @@ type IMessageSendOpts = {
   service?: IMessageService;
   region?: string;
   accountId?: string;
+  conversationReadOrigin?: "delegated" | "direct-operator";
   replyToId?: string;
   mediaUrl?: string;
   mediaLocalRoots?: readonly string[];
@@ -106,101 +111,6 @@ type IMessageSendResult = {
   echoText?: string;
   receipt: MessageReceipt;
 };
-
-const MAX_REPLY_TO_ID_LENGTH = 256;
-const sshWrapperCliPathCache = new Map<string, boolean>();
-
-function safeHomeDir(): string | undefined {
-  const home = process.env.HOME?.trim();
-  if (home) {
-    return home;
-  }
-  try {
-    return os.homedir().trim() || undefined;
-  } catch {
-    return undefined;
-  }
-}
-
-function expandCliPathForInspection(cliPath: string): string {
-  if (!cliPath.startsWith("~")) {
-    return cliPath;
-  }
-  const home = safeHomeDir();
-  return home ? cliPath.replace(/^~(?=$|[\\/])/, home) : cliPath;
-}
-
-function isSshIMessageCliWrapper(cliPath: string): boolean {
-  if (cliPath === "imsg") {
-    return false;
-  }
-  const cached = sshWrapperCliPathCache.get(cliPath);
-  if (cached !== undefined) {
-    return cached;
-  }
-  let detected;
-  try {
-    const content = readFileSync(expandCliPathForInspection(cliPath), "utf8");
-    detected = /\bssh\b[\s\S]*\bimsg\b/u.test(content);
-  } catch {
-    detected = false;
-  }
-  // cliPath scripts are process-stable channel metadata; cache inspection so
-  // repeated sends do not poll wrapper files on the hot path.
-  sshWrapperCliPathCache.set(cliPath, detected);
-  return detected;
-}
-
-function isLocalIMessageCliPath(params: { cliPath: string; remoteHost?: string }): boolean {
-  const cliPath = params.cliPath.trim();
-  if (params.remoteHost?.trim() || isSshIMessageCliWrapper(cliPath)) {
-    return false;
-  }
-  return cliPath === "imsg" || path.basename(cliPath) === "imsg";
-}
-
-function resolveChatDbLookupPath(params: {
-  cliPath: string;
-  dbPath?: string;
-  remoteHost?: string;
-}): string | undefined {
-  const configured = params.dbPath?.trim();
-  if (configured) {
-    return configured;
-  }
-  if (!isLocalIMessageCliPath({ cliPath: params.cliPath, remoteHost: params.remoteHost })) {
-    return undefined;
-  }
-  const home = safeHomeDir();
-  return home ? path.join(home, "Library", "Messages", "chat.db") : undefined;
-}
-
-function stripUnsafeReplyTagChars(value: string): string {
-  let next = "";
-  for (const ch of value) {
-    const code = ch.charCodeAt(0);
-    if ((code >= 0 && code <= 31) || code === 127 || ch === "[" || ch === "]") {
-      continue;
-    }
-    next += ch;
-  }
-  return next;
-}
-
-function sanitizeReplyToId(rawReplyToId?: string): string | undefined {
-  const trimmed = rawReplyToId?.trim();
-  if (!trimmed) {
-    return undefined;
-  }
-  const sanitized = stripUnsafeReplyTagChars(trimmed).trim();
-  if (!sanitized) {
-    return undefined;
-  }
-  if (sanitized.length > MAX_REPLY_TO_ID_LENGTH) {
-    return sanitized.slice(0, MAX_REPLY_TO_ID_LENGTH);
-  }
-  return sanitized;
-}
 
 function resolveMessageId(result: Record<string, unknown> | null | undefined): string | null {
   if (!result) {
@@ -585,6 +495,11 @@ function stringValue(value: unknown): string | undefined {
   return typeof value === "string" && value.trim() ? value.trim() : undefined;
 }
 
+function resultService(value: unknown): IMessageService | undefined {
+  const normalized = stringValue(value)?.toLowerCase();
+  return normalized === "imessage" || normalized === "sms" ? normalized : undefined;
+}
+
 function resolvePendingPersistedEchoTtlMs(timeoutMs: number): number {
   return Math.max(
     MIN_PENDING_PERSISTED_ECHO_TTL_MS,
@@ -776,7 +691,7 @@ export async function sendMessageIMessage(
     });
   const cliPath = opts.cliPath?.trim() || account.config.cliPath?.trim() || "imsg";
   const dbPath = opts.dbPath?.trim() || account.config.dbPath?.trim();
-  const chatDbLookupPath = resolveChatDbLookupPath({
+  const chatDbLookupPath = resolveIMessageChatDbLookupPath({
     cliPath,
     dbPath,
     remoteHost: account.config.remoteHost,
@@ -787,6 +702,21 @@ export async function sendMessageIMessage(
     resolveTargetService(target) ??
     (account.config.service as IMessageService | undefined);
   const sendTransport = (account.config.sendTransport ?? "auto") as IMessageSendTransport;
+  const resolvedReplyToId = resolveAuthorizedIMessageReplyReference({
+    account,
+    target,
+    cliPath,
+    dbPath,
+    hasExclusiveLocalDatabase: hasExclusiveIMessageLocalDatabase({
+      cfg,
+      account,
+      cliPath,
+      dbPath,
+    }),
+    service,
+    replyToId: opts.replyToId,
+    conversationReadOrigin: opts.conversationReadOrigin,
+  });
   // Sends use a dedicated longer default (not the 10s probe timeout) so macOS 26
   // bridge stalls aren't aborted mid-send. Explicit opts/probeTimeoutMs still win
   // for callers that tuned them. See DEFAULT_IMESSAGE_SEND_TIMEOUT_MS.
@@ -842,8 +772,6 @@ export async function sendMessageIMessage(
     throw new Error("iMessage send requires text or media");
   }
   const echoText = resolveOutboundEchoText(message, filePath ? mediaContentType : undefined);
-  const replyActionsEnabled = createActionGate(account.config.actions)("reply");
-  const resolvedReplyToId = replyActionsEnabled ? sanitizeReplyToId(opts.replyToId) : undefined;
   // The reply id actually delivered. The threaded-reply fallback below clears it
   // so the receipt and approval binding report the unthreaded send it became,
   // not the threaded reply the transport rejected (#99638).
@@ -1038,17 +966,16 @@ export async function sendMessageIMessage(
     // before dispatching. Inbound recording (in monitor/inbound-processing)
     // sets isFromMe=false, so the cache distinguishes own-sent from received.
     if (resolvedId) {
+      const chatContext = chatContextFromIMessageTarget(
+        target,
+        resultService(result.service) ?? service,
+      );
+      const providerChatGuid = stringValue(result.chat_guid) ?? stringValue(result.chatGuid);
       rememberIMessageReplyCache({
         accountId: account.accountId,
         messageId: resolvedId,
-        chatGuid: target.kind === "chat_guid" ? target.chatGuid : undefined,
-        chatIdentifier:
-          target.kind === "chat_identifier"
-            ? target.chatIdentifier
-            : target.kind === "handle"
-              ? `${target.service === "sms" ? "SMS" : "iMessage"};-;${target.to}`
-              : undefined,
-        chatId: target.kind === "chat_id" ? target.chatId : undefined,
+        ...chatContext,
+        ...(providerChatGuid ? { chatGuid: providerChatGuid } : {}),
         timestamp: Date.now(),
         isFromMe: true,
       });

--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -64,7 +64,7 @@ const internalHookMocks = vi.hoisted(() => ({
   triggerInternalHook: vi.fn(async () => {}),
 }));
 const queueMocks = vi.hoisted(() => ({
-  enqueueDelivery: vi.fn(async () => "mock-queue-id"),
+  enqueueDelivery: vi.fn(async (_params: unknown) => "mock-queue-id"),
   ackDelivery: vi.fn(async () => {}),
   failDelivery: vi.fn(async () => {}),
   failDeliveryAfterPlatformSend: vi.fn(async () => {}),
@@ -135,6 +135,7 @@ vi.mock("../../logging/subsystem.js", () => ({
 type DeliverModule = typeof import("./deliver.js");
 
 let deliverOutboundPayloads: DeliverModule["deliverOutboundPayloads"];
+let deliverOutboundPayloadsInternal: DeliverModule["deliverOutboundPayloadsInternal"];
 let resolveOutboundDurableFinalDeliverySupport: DeliverModule["resolveOutboundDurableFinalDeliverySupport"];
 
 const matrixChunkConfig: OpenClawConfig = {
@@ -305,8 +306,11 @@ async function runBestEffortPartialFailureDelivery(params?: { onError?: boolean 
 
 describe("deliverOutboundPayloads", () => {
   beforeAll(async () => {
-    ({ deliverOutboundPayloads, resolveOutboundDurableFinalDeliverySupport } =
-      await import("./deliver.js"));
+    ({
+      deliverOutboundPayloads,
+      deliverOutboundPayloadsInternal,
+      resolveOutboundDurableFinalDeliverySupport,
+    } = await import("./deliver.js"));
   });
 
   beforeEach(() => {
@@ -3908,18 +3912,27 @@ describe("deliverOutboundPayloads", () => {
       ]),
     );
 
-    await deliverOutboundPayloads({
+    await deliverOutboundPayloadsInternal({
       cfg: { channels: { matrix: { textChunkLimit: 4000 } } } as OpenClawConfig,
       channel: "matrix",
       to: "!room",
       payloads: [{ text: "line one\nline two" }],
       replyToId: "reply-1",
       replyToMode: "first",
+      conversationReadOrigin: "direct-operator",
       formatting: { maxLinesPerMessage: 1 },
     });
 
     expect(sendText.mock.calls.map((call) => call[0]?.text)).toEqual(["line one", "line two"]);
     expect(sendText.mock.calls.map((call) => call[0]?.replyToId)).toEqual(["reply-1", undefined]);
+    expect(
+      sendText.mock.calls.map(
+        (call) => (call[0] as { conversationReadOrigin?: string })?.conversationReadOrigin,
+      ),
+    ).toEqual(["direct-operator", "direct-operator"]);
+    expect(queueMocks.enqueueDelivery.mock.calls[0]?.[0]).not.toHaveProperty(
+      "conversationReadOrigin",
+    );
   });
 
   it("drops text payloads after adapter sanitization removes all content", async () => {

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -19,7 +19,6 @@ import { loadChannelOutboundAdapter } from "../../channels/plugins/outbound/load
 import type {
   ChannelDeliveryCapabilities,
   ChannelOutboundAdapter,
-  ChannelOutboundContext,
   ChannelOutboundPayloadContext,
   ChannelOutboundTargetRef,
 } from "../../channels/plugins/types.adapters.js";
@@ -199,7 +198,6 @@ type ChannelHandler = {
   ) => Promise<OutboundDeliveryResult>;
 };
 
-type ChannelMessageLifecycleContext = ChannelMessageSendAttemptContext;
 type PlatformSendRoute = {
   replyToId?: string | null;
   threadId?: string | number | null;
@@ -221,6 +219,7 @@ type ChannelHandlerParams = {
   silent?: boolean;
   mediaAccess?: OutboundMediaAccess;
   gatewayClientScopes?: readonly string[];
+  conversationReadOrigin?: "delegated" | "direct-operator";
   deliveryQueueId?: string;
   requiredUnknownSendReconciliation?: boolean;
   onPlatformSendStart?: (route: PlatformSendRoute) => Promise<void>;
@@ -269,7 +268,7 @@ async function runChannelMessageSendWithLifecycle<
   TResult extends ChannelMessageSendResult,
 >(params: {
   lifecycle?: ChannelMessageSendLifecycleAdapter;
-  ctx: ChannelMessageLifecycleContext;
+  ctx: ChannelMessageSendAttemptContext;
   send: () => Promise<TResult>;
 }): Promise<{ result: TResult; afterCommit?: OutboundDeliveryCommitHook }> {
   if (!params.lifecycle) {
@@ -407,9 +406,7 @@ function createPluginHandler(
         await params.onDeliveryResult?.(normalizeChannelMessageSendResult(params.channel, result));
       }
     : undefined;
-  const resolveCtx = (
-    overrides?: OutboundMessageSendOverrides,
-  ): Omit<ChannelOutboundContext, "text" | "mediaUrl"> => ({
+  const resolveCtx = (overrides?: OutboundMessageSendOverrides) => ({
     ...baseCtx,
     replyToId: overrides && "replyToId" in overrides ? overrides.replyToId : baseCtx.replyToId,
     replyToIdSource:
@@ -630,31 +627,29 @@ function normalizeChannelMessageSendResult(
   };
 }
 
-function createChannelOutboundContextBase(
-  params: ChannelHandlerParams,
-): Omit<ChannelOutboundContext, "text" | "mediaUrl"> {
-  return {
-    cfg: params.cfg,
-    to: params.to,
-    accountId: params.accountId,
-    replyToId: params.replyToId,
-    replyToMode: params.replyToMode,
-    formatting: params.formatting,
-    threadId: params.threadId,
-    identity: params.identity,
-    gifPlayback: params.gifPlayback,
-    forceDocument: params.forceDocument,
-    deps: params.deps,
-    silent: params.silent,
-    mediaAccess: params.mediaAccess,
-    mediaLocalRoots: params.mediaAccess?.localRoots,
-    mediaReadFile: params.mediaAccess?.readFile,
-    gatewayClientScopes: params.gatewayClientScopes,
-    deliveryQueueId: params.deliveryQueueId,
-    onPlatformSendDispatch: params.onPlatformSendDispatch,
-    onDeliveryResult: params.onDeliveryResult,
-  };
-}
+const createChannelOutboundContextBase = (params: ChannelHandlerParams) => ({
+  cfg: params.cfg,
+  to: params.to,
+  accountId: params.accountId,
+  replyToId: params.replyToId,
+  replyToIdSource: undefined,
+  replyToMode: params.replyToMode,
+  formatting: params.formatting,
+  threadId: params.threadId,
+  identity: params.identity,
+  gifPlayback: params.gifPlayback,
+  forceDocument: params.forceDocument,
+  deps: params.deps,
+  silent: params.silent,
+  mediaAccess: params.mediaAccess,
+  mediaLocalRoots: params.mediaAccess?.localRoots,
+  mediaReadFile: params.mediaAccess?.readFile,
+  gatewayClientScopes: params.gatewayClientScopes,
+  conversationReadOrigin: params.conversationReadOrigin,
+  deliveryQueueId: params.deliveryQueueId,
+  onPlatformSendDispatch: params.onPlatformSendDispatch,
+  onDeliveryResult: params.onDeliveryResult,
+});
 
 const isAbortError = (err: unknown): boolean => err instanceof Error && err.name === "AbortError";
 
@@ -756,6 +751,7 @@ type DeliverOutboundPayloadsCoreParams = {
   mirror?: DeliveryMirror;
   silent?: boolean;
   gatewayClientScopes?: readonly string[];
+  conversationReadOrigin?: "delegated" | "direct-operator";
 };
 
 /**
@@ -1387,6 +1383,7 @@ export async function deliverOutboundPayloadsInternal(
     ? createRenderedMessageBatchPlan(queuePayloads)
     : renderedBatchPlan;
 
+  // Invocation authority is not queued; recovery must re-enter delegated after restart.
   // Write-ahead delivery queue: persist before sending, remove after success.
   const queueId = params.skipQueue
     ? null
@@ -1982,6 +1979,7 @@ async function deliverOutboundPayloadsCore(
       silent: params.silent,
       mediaAccess: resolveMediaAccess(mediaSources),
       gatewayClientScopes: params.gatewayClientScopes,
+      conversationReadOrigin: params.conversationReadOrigin,
       deliveryQueueId: params.deliveryQueueId,
       requiredUnknownSendReconciliation: params.requiredUnknownSendReconciliation,
       onPlatformSendStart: params.onPlatformSendStart,

--- a/src/infra/outbound/message.ts
+++ b/src/infra/outbound/message.ts
@@ -48,8 +48,6 @@ const loadMessageGatewayRuntime = createLazyRuntimeModule(
   () => import("./message.gateway.runtime.js"),
 );
 
-type MessageGatewayOptions = OutboundMessageGatewayOptionsInput;
-
 type MessageSendParams = {
   to: string;
   content: string;
@@ -79,6 +77,7 @@ type MessageSendParams = {
   accountId?: string;
   /** Known destination conversation kind prepared by the caller. */
   conversationType?: ChatType;
+  conversationReadOrigin?: "delegated" | "direct-operator";
   replyToId?: string;
   threadId?: string | number;
   dryRun?: boolean;
@@ -88,7 +87,7 @@ type MessageSendParams = {
   mediaAccess?: OutboundMediaAccess;
   deps?: OutboundSendDeps;
   cfg?: OpenClawConfig;
-  gateway?: MessageGatewayOptions;
+  gateway?: OutboundMessageGatewayOptionsInput;
   idempotencyKey?: string;
   mirror?: OutboundMirror;
   abortSignal?: AbortSignal;
@@ -125,7 +124,7 @@ type MessagePollParams = {
   isAnonymous?: boolean;
   dryRun?: boolean;
   cfg?: OpenClawConfig;
-  gateway?: MessageGatewayOptions;
+  gateway?: OutboundMessageGatewayOptionsInput;
   idempotencyKey?: string;
 };
 
@@ -196,12 +195,11 @@ async function resolveRequiredChannel(params: {
   cfg: OpenClawConfig;
   channel?: string;
 }): Promise<string> {
-  return (
-    await resolveMessageChannelSelection({
-      cfg: params.cfg,
-      channel: params.channel,
-    })
-  ).channel;
+  const selection = await resolveMessageChannelSelection({
+    cfg: params.cfg,
+    channel: params.channel,
+  });
+  return selection.channel;
 }
 
 function resolveRequiredPlugin(channel: string, cfg: OpenClawConfig) {
@@ -285,12 +283,12 @@ async function assertRequiredMessageSendDurability(params: {
   );
 }
 
-function resolveGatewayOptions(opts?: MessageGatewayOptions) {
+function resolveGatewayOptions(opts?: OutboundMessageGatewayOptionsInput) {
   return resolveOutboundMessageGatewayOptions(opts);
 }
 
 async function callMessageGateway<T>(params: {
-  gateway?: MessageGatewayOptions;
+  gateway?: OutboundMessageGatewayOptionsInput;
   method: string;
   params: Record<string, unknown>;
 }): Promise<T> {
@@ -409,6 +407,7 @@ export async function sendMessage(params: MessageSendParams): Promise<MessageSen
       to: resolvedTarget.to,
       session: outboundSession,
       accountId: params.accountId,
+      conversationReadOrigin: params.conversationReadOrigin,
       payloads: normalizedPayloads,
       replyToId: params.replyToId,
       threadId: params.threadId,

--- a/src/infra/outbound/outbound-send-service.test.ts
+++ b/src/infra/outbound/outbound-send-service.test.ts
@@ -996,6 +996,7 @@ describe("executeSendAction", () => {
         dryRun: false,
         sessionKey: "discord-session",
         inboundEventKind: "room_event",
+        conversationReadOrigin: "delegated",
       },
       to: "channel:123",
       message: "hello",
@@ -1020,6 +1021,7 @@ describe("executeSendAction", () => {
       queuePolicy: "best_effort",
       replyToId: "reply-1",
       threadId: "thread-1",
+      conversationReadOrigin: "delegated",
     });
     const [payload] = requireArray(sendArgs.payloads, "send payloads");
     expectFields(requireRecord(payload, "prepared payload"), {

--- a/src/infra/outbound/outbound-send-service.ts
+++ b/src/infra/outbound/outbound-send-service.ts
@@ -138,6 +138,7 @@ async function sendCoreMessage(params: {
     channel: params.ctx.channel || undefined,
     accountId: params.ctx.accountId ?? undefined,
     conversationType: params.ctx.conversationType,
+    conversationReadOrigin: params.ctx.conversationReadOrigin,
     replyToId: params.replyToId,
     threadId: params.threadId,
     gifPlayback: params.gifPlayback,


### PR DESCRIPTION
Closes #107770

AI-assisted with Codex. I reviewed the implementation and validation results.

## What Problem This Solves

Fixes an issue where delegated iMessage reactions, replies, poll votes, retractions, and threaded sends could resolve a referenced resource without consistently proving that it belongs to the selected current conversation and account.

Equivalent valid target forms and direct operator workflows must continue to work, while stale, ambiguous, wrong-account, and cross-conversation references must fail before mutation.

## Why This Change Was Made

This change gives iMessage one canonical, account-aware conversation context and applies it consistently to cached message references, provider-backed resource checks, message actions, and outbound replies. Authorization remains operation-local: delegated calls require a positive current-conversation binding, while direct operators retain their existing behavior.

The implementation also keeps provider lookup and mutation ordering fail closed, preserves target-kind distinctions, and avoids carrying delegated authority through durable delivery state.

## User Impact

Agents can continue using message actions in their current iMessage conversation across supported aliases and identifier forms. References from another conversation, another account, stale context, or an ambiguous target are rejected instead of affecting an unrelated resource.

## Evidence

Current and live behavior candidate: `8d8db3bfd78`

- Exact-HEAD Testbox run: 365 focused tests passed (180 iMessage action, send, cache, and resource-binding tests; 185 shared outbound-delivery tests).
- Knip unused-export/dead-code and changed-surface checks passed, including formatting, type, lint, policy, and import-cycle gates.
- The exact candidate source build completed and its isolated Gateway started successfully on Node 24.15.
- Live two-host provider matrix passed for valid reactions, replies, poll votes, and threaded sends, with provider-side verification.
- Live negative controls passed for auto-service ambiguity and cross-conversation reaction, reply, poll-vote, retraction, and threaded-send references.
- Live model-selected delegated current-conversation action passed; the model-selected cross-conversation action was rejected.
- Fresh full-branch `$autoreview` completed with no remaining actionable findings.
