### PR TITLE
refactor(tasks): use Kysely update objects

### DIFF
--- a/src/tasks/task-registry.store.sqlite.ts
+++ b/src/tasks/task-registry.store.sqlite.ts
@@ -274,44 +274,13 @@ function selectTaskDeliveryStateRows(db: DatabaseSync): TaskDeliveryStateRow[] {
 }
 
 function upsertTaskRow(db: DatabaseSync, row: Insertable<TaskRunsTable>): void {
+  const updates = { ...row, task_id: undefined };
   executeSqliteQuerySync(
     db,
     getTaskRegistryKysely(db)
       .insertInto("task_runs")
       .values(row)
-      .onConflict((conflict) =>
-        conflict.column("task_id").doUpdateSet({
-          runtime: (eb) => eb.ref("excluded.runtime"),
-          task_kind: (eb) => eb.ref("excluded.task_kind"),
-          source_id: (eb) => eb.ref("excluded.source_id"),
-          requester_session_key: (eb) => eb.ref("excluded.requester_session_key"),
-          owner_key: (eb) => eb.ref("excluded.owner_key"),
-          scope_kind: (eb) => eb.ref("excluded.scope_kind"),
-          child_session_key: (eb) => eb.ref("excluded.child_session_key"),
-          parent_flow_id: (eb) => eb.ref("excluded.parent_flow_id"),
-          parent_task_id: (eb) => eb.ref("excluded.parent_task_id"),
-          agent_id: (eb) => eb.ref("excluded.agent_id"),
-          requester_agent_id: (eb) => eb.ref("excluded.requester_agent_id"),
-          run_id: (eb) => eb.ref("excluded.run_id"),
-          label: (eb) => eb.ref("excluded.label"),
-          task: (eb) => eb.ref("excluded.task"),
-          status: (eb) => eb.ref("excluded.status"),
-          delivery_status: (eb) => eb.ref("excluded.delivery_status"),
-          notify_policy: (eb) => eb.ref("excluded.notify_policy"),
-          created_at: (eb) => eb.ref("excluded.created_at"),
-          started_at: (eb) => eb.ref("excluded.started_at"),
-          ended_at: (eb) => eb.ref("excluded.ended_at"),
-          last_event_at: (eb) => eb.ref("excluded.last_event_at"),
-          cleanup_after: (eb) => eb.ref("excluded.cleanup_after"),
-          tool_use_count: (eb) => eb.ref("excluded.tool_use_count"),
-          last_tool_name: (eb) => eb.ref("excluded.last_tool_name"),
-          error: (eb) => eb.ref("excluded.error"),
-          progress_summary: (eb) => eb.ref("excluded.progress_summary"),
-          terminal_summary: (eb) => eb.ref("excluded.terminal_summary"),
-          terminal_outcome: (eb) => eb.ref("excluded.terminal_outcome"),
-          detail_json: (eb) => eb.ref("excluded.detail_json"),
-        }),
-      ),
+      .onConflict((conflict) => conflict.column("task_id").doUpdateSet(updates)),
   );
 }
 


### PR DESCRIPTION
## What Problem This Solves

The task registry upsert repeats every mutable `task_runs` column as an `excluded.*` reference, duplicating the complete row that the caller already binds.

## Why This Change Was Made

Kysely accepts row-shaped update objects and omits properties whose value is `undefined`. Reuse the fully bound task row while setting the conflict key to `undefined`, replacing 33 production lines with 2 without changing the stored values.

## User Impact

No behavior change. Task creation, updates, delivery state, and restore semantics stay the same.

## Evidence

- `node scripts/run-vitest.mjs src/tasks/task-registry.store.test.ts` — 36 passed
- `node_modules/.bin/oxlint --type-aware src/tasks/task-registry.store.sqlite.ts`
- `node_modules/.bin/oxfmt --check src/tasks/task-registry.store.sqlite.ts`
- `git diff --check origin/main...HEAD`
- Local and branch autoreview: no accepted/actionable findings
