### PR TITLE
fix(ui): center terminal tab close button

### DIFF
--- a/ui/src/components/terminal/terminal-panel-styles.ts
+++ b/ui/src/components/terminal/terminal-panel-styles.ts
@@ -124,20 +124,23 @@ export const terminalPanelStyles = css`
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    width: 16px;
-    height: 16px;
+    align-self: center;
+    flex: 0 0 26px;
+    width: 26px;
+    height: 26px;
     opacity: 0;
     border: none;
     background: transparent;
-    color: inherit;
-    border-radius: 4px;
+    color: var(--muted, #8a919e);
+    border-radius: 6px;
     padding: 0;
   }
-  .tp-tab:hover + .tp-tab__close,
-  .tp-tab[active] + .tp-tab__close,
+  :where(.tp-tab:hover, .tp-tab[active]) + .tp-tab__close {
+    opacity: 0.7;
+  }
   .tp-tab__close:hover,
   .tp-tab__close:focus-visible {
-    opacity: 0.7;
+    opacity: 1;
   }
   .tp-new,
   .tp-icon {

--- a/ui/src/components/terminal/terminal-panel-tabs.ts
+++ b/ui/src/components/terminal/terminal-panel-tabs.ts
@@ -14,7 +14,7 @@ export type TerminalPanelTab = {
 };
 
 const TERMINAL_GLYPH = svg`<svg viewBox="0 0 16 16" width="13" height="13" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"><path d="M3 4l3 3-3 3M8 11h5" /></svg>`;
-const CLOSE_GLYPH = svg`<svg viewBox="0 0 16 16" width="12" height="12" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"><path d="M4 4l8 8M12 4l-8 8" /></svg>`;
+const CLOSE_GLYPH = svg`<svg viewBox="0 0 16 16" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"><path d="M4 4l8 8M12 4l-8 8" /></svg>`;
 const PLUS_GLYPH = svg`<svg viewBox="0 0 16 16" width="13" height="13" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"><path d="M8 3v10M3 8h10" /></svg>`;
 
 function terminalTabLabel(tab: TerminalPanelTab): string {

--- a/ui/src/e2e/terminal-embedded.e2e.test.ts
+++ b/ui/src/e2e/terminal-embedded.e2e.test.ts
@@ -32,7 +32,7 @@ describeControlUiE2e("embedded terminal document", () => {
     await server?.close();
   });
 
-  it("renders only the terminal while native authentication connects", async () => {
+  it("renders only the terminal with a centered close control while native auth connects", async () => {
     const context = await browser.newContext({ serviceWorkers: "block" });
     const page = await context.newPage();
     await page.addInitScript(() => {
@@ -81,6 +81,34 @@ describeControlUiE2e("embedded terminal document", () => {
       });
       expect(await page.locator("openclaw-login-gate").count()).toBe(0);
       expect(await page.locator("openclaw-terminal-panel").count()).toBe(1);
+      const closeControlMetrics = await page
+        .locator("openclaw-terminal-panel")
+        .locator(".tp-tab__close")
+        .evaluate((close) => {
+          const header = close.closest<HTMLElement>(".tp-header");
+          if (!header) {
+            throw new Error("Terminal close control must stay inside the tab header");
+          }
+          const headerBounds = header.getBoundingClientRect();
+          const closeBounds = close.getBoundingClientRect();
+          return {
+            centerOffset: Math.abs(
+              closeBounds.top +
+                closeBounds.height / 2 -
+                (headerBounds.top + headerBounds.height / 2),
+            ),
+            height: closeBounds.height,
+            width: closeBounds.width,
+          };
+        });
+      expect(closeControlMetrics.width).toBe(26);
+      expect(closeControlMetrics.height).toBe(26);
+      expect(closeControlMetrics.centerOffset).toBeLessThanOrEqual(0.5);
+      const closeControl = page.locator("openclaw-terminal-panel").locator(".tp-tab__close");
+      expect(await closeControl.getAttribute("aria-label")).toBe("Close terminal session: bash");
+      await closeControl.click();
+      const terminalClose = await gateway.waitForRequest("terminal.close");
+      expect(terminalClose.params).toEqual({ sessionId: "terminal-e2e" });
     } finally {
       await context.close();
     }


### PR DESCRIPTION
Closes #107769

## What Problem This Solves

Fixes an issue where users opening terminal tabs saw a small close control aligned to the top of the tab header, making the affordance look detached and harder to target.

## Why This Change Was Made

The terminal tab close control now shares the neighboring header controls' 26px geometry, centers itself in the tab strip, and uses a slightly larger glyph. Active, hover, and keyboard-focus visibility remain distinct without changing terminal lifecycle behavior.

## User Impact

Terminal tabs now have a visually centered, easier-to-target close button with clearer hover and focus feedback.

## Evidence

- Blacksmith Testbox through Crabbox: tbx_01kxh7y2qdq8psgw101m41ajdk
- Hosted run: https://github.com/openclaw/openclaw/actions/runs/29369055541
- Chromium E2E: terminal close control is 26x26 CSS pixels, centered within 0.5 CSS pixel, exposes the expected accessible label, and sends the terminal.close request.
- Changed gate: format, Control UI i18n, test typecheck, UI typecheck, and changed-file lint all passed.
- Autoreview: clean after accepting and fixing one CSS-specificity finding.
