### PR TITLE
fix(doctor): accept memory provider none without api key

### DIFF
--- a/src/commands/doctor-memory-search.test.ts
+++ b/src/commands/doctor-memory-search.test.ts
@@ -280,6 +280,24 @@ describe("noteMemorySearchHealth", () => {
     expect(resolveApiKeyForProvider).not.toHaveBeenCalled();
   });
 
+  it("still reports a missing memory backend in intentional FTS-only mode", async () => {
+    resolveMemorySearchConfig.mockReturnValue({
+      provider: "none",
+      fallback: "none",
+      local: {},
+      remote: {},
+    });
+    resolveActiveMemoryBackendConfig.mockReturnValue(null);
+
+    await noteMemorySearchHealth(cfg, {});
+
+    expect(note).toHaveBeenCalledWith(
+      "No active memory plugin is registered for the current config.",
+      "Memory search",
+    );
+    expect(resolveApiKeyForProvider).not.toHaveBeenCalled();
+  });
+
   it("reports last-known llama.cpp runtime facts from the gateway", async () => {
     resolveMemorySearchConfig.mockReturnValue({
       provider: "local",

--- a/src/commands/doctor-memory-search.test.ts
+++ b/src/commands/doctor-memory-search.test.ts
@@ -266,6 +266,20 @@ describe("noteMemorySearchHealth", () => {
     expect(note).not.toHaveBeenCalled();
   });
 
+  it("does not warn or request NONE_API_KEY for intentional FTS-only mode", async () => {
+    resolveMemorySearchConfig.mockReturnValue({
+      provider: "none",
+      fallback: "none",
+      local: {},
+      remote: {},
+    });
+
+    await noteMemorySearchHealth(cfg, {});
+
+    expect(note).not.toHaveBeenCalled();
+    expect(resolveApiKeyForProvider).not.toHaveBeenCalled();
+  });
+
   it("reports last-known llama.cpp runtime facts from the gateway", async () => {
     resolveMemorySearchConfig.mockReturnValue({
       provider: "local",

--- a/src/commands/doctor-memory-search.ts
+++ b/src/commands/doctor-memory-search.ts
@@ -548,6 +548,10 @@ export async function noteMemorySearchHealth(
     return;
   }
 
+  if (provider === "none") {
+    return;
+  }
+
   if (provider === "local") {
     const suggestedRemoteProvider = resolveSuggestedRemoteMemoryProvider();
     const runtimeFacts = opts?.gatewayMemoryProbe?.runtimeFacts;


### PR DESCRIPTION
Fixes #107736.

## What Problem This Solves

`openclaw doctor` treats `agents.defaults.memorySearch.provider: "none"` as a remote embedding provider and falls through to the generic API-key warning. That produces the bogus `NONE_API_KEY` remediation even though `provider: "none"` is the documented intentional FTS-only mode.

## Summary

- Keep existing diagnostics for missing active memory backend.
- After confirming an active non-QMD backend exists, return early for `provider === "none"`.
- Add a focused regression proving intentional FTS-only mode emits no doctor warning and does not request provider auth.
- Preserve existing remote-provider missing-key behavior.

## Evidence

Exact-head validation on `619b6656f0e1af0234fe071c411cbee4714fb1e8`:

- `node scripts/run-vitest.mjs src/commands/doctor-memory-search.test.ts` -> passed; 67 tests.
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.non-agents.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test-non-agents.tsbuildinfo` -> passed.
- `./node_modules/.bin/oxfmt --check --threads=1 src/commands/doctor-memory-search.ts src/commands/doctor-memory-search.test.ts` -> passed.
- `./node_modules/.bin/oxlint src/commands/doctor-memory-search.ts src/commands/doctor-memory-search.test.ts` -> passed.
- `node scripts/check-max-lines-ratchet.mjs --base upstream/main` -> passed.
- `git diff --check` -> passed.

Failing-first proof with the production guard temporarily removed:

```text
FAIL src/commands/doctor-memory-search.test.ts > noteMemorySearchHealth > does not warn or request NONE_API_KEY for intentional FTS-only mode
AssertionError: expected "vi.fn()" to not be called at all, but actually been called 1 times

1st vi.fn() call:
Memory search provider is set to "none" but no API key was found.
Semantic recall will not work without a valid API key.

Fix (pick one):
- Set NONE_API_KEY in your environment
- Configure credentials: openclaw configure --section model
- To disable: openclaw config set agents.defaults.memorySearch.enabled false
```

Passing proof after restoring the fix:

```text
Test Files  1 passed (1)
Tests       67 passed (67)
```

## Behavior After This Patch

- `provider: "none"` remains valid intentional FTS-only mode.
- Doctor no longer suggests `NONE_API_KEY`.
- Doctor no longer suggests disabling memory search when FTS-only search is intentionally configured.
- Real remote providers still require their normal API-key checks.