### PR TITLE
fix(ui): center external session conversations

### DIFF
--- a/ui/src/e2e/claude-sessions.e2e.test.ts
+++ b/ui/src/e2e/claude-sessions.e2e.test.ts
@@ -1,3 +1,5 @@
+import fs from "node:fs/promises";
+import path from "node:path";
 import { chromium, type Browser } from "playwright";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import {
@@ -162,6 +164,34 @@ suite("Claude native session catalog", () => {
     await expect
       .poll(() => page.getByText("This session is on a paired node and is view-only.").count())
       .toBe(1);
+    const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+    const expectCenteredLayout = async (screenshotName: string) => {
+      const [workbenchBox, threadBox, composerBox] = await Promise.all([
+        page.locator(".chat-workbench").boundingBox(),
+        page.locator(".chat-thread-inner").boundingBox(),
+        page.locator(".agent-chat__composer-shell").boundingBox(),
+      ]);
+      expect(workbenchBox).not.toBeNull();
+      expect(threadBox).not.toBeNull();
+      expect(composerBox).not.toBeNull();
+      const workbenchCenter = workbenchBox!.x + workbenchBox!.width / 2;
+      expect(Math.abs(threadBox!.x + threadBox!.width / 2 - workbenchCenter)).toBeLessThanOrEqual(
+        1,
+      );
+      expect(
+        Math.abs(composerBox!.x + composerBox!.width / 2 - workbenchCenter),
+      ).toBeLessThanOrEqual(1);
+      if (artifactDir) {
+        await fs.mkdir(artifactDir, { recursive: true });
+        await page.screenshot({
+          path: path.join(artifactDir, screenshotName),
+          fullPage: true,
+        });
+      }
+    };
+    await expectCenteredLayout("claude-external-session-centered-1280.png");
+    await page.setViewportSize({ width: 1600, height: 900 });
+    await expectCenteredLayout("claude-external-session-centered-1600.png");
     expect((await gateway.getRequests("sessions.catalog.read")).at(-1)?.params).toMatchObject({
       catalogId: "claude",
       cursor: "older",

--- a/ui/src/pages/chat/chat-view.ts
+++ b/ui/src/pages/chat/chat-view.ts
@@ -219,6 +219,7 @@ export function renderChat(props: ChatProps) {
   const splitRatio = props.splitRatio ?? 0.6;
   const sidebarOpen = Boolean(props.sidebarOpen && props.onCloseSidebar);
   const sidebarStacked = props.sidebarStacked === true;
+  const workspaceCollapsed = props.sessionWorkspace?.collapsed !== false;
   const workspaceDockBottom = Boolean(
     props.sessionWorkspace &&
     (props.sessionWorkspace.dock === "bottom" || props.sessionWorkspace.narrowLayout),
@@ -470,7 +471,7 @@ export function renderChat(props: ChatProps) {
         requestUpdate,
       )}
       <div
-        class="chat-workbench ${props.sessionWorkspace?.collapsed
+        class="chat-workbench ${workspaceCollapsed
           ? "chat-workbench--workspace-collapsed"
           : ""} ${workspaceDockBottom ? "chat-workbench--dock-bottom" : ""} ${tasksOpen &&
         !tasksDockBottom


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users opening a paired-node Claude external session saw the transcript and disabled composer shifted left instead of centered like ordinary agent conversations.

## Why This Change Was Made

External catalogs intentionally have no session workspace. The chat layout now treats an absent optional workspace as collapsed, so it does not reserve an empty right-side rail; explicitly expanded workspaces keep their existing split layout.

## User Impact

Paired-node external session transcripts and composers now share the centered conversation axis used by normal chats at narrow and wide desktop viewport sizes. View-only behavior and messaging remain unchanged.

## Evidence

- Focused Chromium E2E: `ui/src/e2e/claude-sessions.e2e.test.ts` — 2 passed.
- New geometry assertions prove the transcript and composer center match the workbench center within 1 px at 1280x720 and 1600x900.
- Blacksmith Testbox: `tbx_01kxh7x3vqmtww5q47r1x0eb9b` ([run](https://github.com/openclaw/openclaw/actions/runs/29369025173)).
- Source-blind behavior validation: 4/4 contract checks passed across both captured viewport sizes.
- Autoreview on the rebased diff: no findings; patch correct at 0.93 confidence.

AI-assisted: yes. The maintainer reviewed the root cause, implementation, and proof.

Release note: Control UI: center paired-node external session transcripts and composer like ordinary chats.
