### PR TITLE
fix(ui): keep compact macOS brand clear of window controls

### DIFF
--- a/ui/src/e2e/native-nav-sidebar-toggle.e2e.test.ts
+++ b/ui/src/e2e/native-nav-sidebar-toggle.e2e.test.ts
@@ -286,11 +286,18 @@ describeControlUiE2e("Control UI native-nav sidebar toggle E2E", () => {
   });
 
   it("keeps the drawer hamburger at narrow widths in web titlebar chrome", async () => {
-    const page = await openPage({ webChrome: true, width: 900 });
+    const page = await openPage({ webChrome: true, width: 700 });
     // The web toolbar hides below the drawer breakpoint, so the hamburger is
     // the only remaining sidebar toggle there.
     await expect.poll(() => page.locator(".macos-titlebar-controls").isVisible()).toBe(false);
     await expect.poll(() => page.locator(".topbar-nav-toggle").isVisible()).toBe(true);
+    // The native traffic-light cluster ends around x=78. Keep the brand aligned
+    // with the desktop titlebar controls' 92px inset so the groups stay distinct.
+    await expect
+      .poll(() =>
+        page.locator(".topbar-brand").evaluate((element) => element.getBoundingClientRect().x),
+      )
+      .toBe(92);
   });
 
   it("hides the drawer hamburger at narrow widths when the native toggle is present", async () => {

--- a/ui/src/styles/layout.mobile.css
+++ b/ui/src/styles/layout.mobile.css
@@ -230,15 +230,16 @@
    window): fold the titlebar clearance into one 58px row instead of stacking
    it. body-qualified + !important outranks the Mac-app-injected topbar rules
    (DashboardWindowController), so shipped apps get the compact row too. The
-   brand moves first and stays non-interactive under the AppKit drag region
-   (x 78-254, y < 46); the drawer toggle and search sit to its right. */
+   brand moves first, clears the traffic lights, and stays non-interactive
+   under the AppKit drag region (x 78-254, y < 46); the drawer toggle and
+   search sit to its right. */
 @media (max-width: 1100px) {
   html.openclaw-native-macos body .shell {
     --shell-topbar-height: 58px;
   }
 
   html.openclaw-native-macos body .topbar {
-    padding: 0 12px 0 78px !important;
+    padding: 0 12px 0 92px !important;
   }
 
   html.openclaw-native-macos body .topnav-shell {


### PR DESCRIPTION
Related: #103561

## What Problem This Solves

Fixes an issue where Mac app users with the sidebar collapsed at compact window widths would see the OpenClaw brand crowded against the macOS traffic-light buttons.

## Why This Change Was Made

The native compact header now uses the same 92px traffic-light clearance as the hosted desktop titlebar controls. The existing compact row and drawer-toggle behavior remain unchanged.

## User Impact

The crab brand and OpenClaw name remain visually separate from the macOS window controls when the sidebar is collapsed.

Release-note context: Fixed compact Mac app titlebar spacing when the sidebar is collapsed.

## Evidence

- Before: the user-supplied 702px-wide screenshot shows the crab brand nearly touching the green traffic-light button.
- After: the focused rendered Control UI E2E runs at 700px, asserts the brand begins at x=92, and confirms the drawer toggle stays visible. All 8 focused tests passed.
- Remote Blacksmith Testbox compound proof passed the focused E2E, changed-surface checks, and UI production build.
- Fresh uncommitted autoreview: clean, no accepted or actionable findings.

## AI Assistance

AI-assisted implementation and review. The change and evidence were inspected before submission.
