### PR TITLE
fix(macos): keep left and right menu bar clicks reliable

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -30627,7 +30627,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 411,
+      "line": 429,
       "path": "apps/macos/Sources/OpenClaw/MenuBar.swift",
       "source": "Close Canvas",
       "surface": "apple",
@@ -30635,7 +30635,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 411,
+      "line": 429,
       "path": "apps/macos/Sources/OpenClaw/MenuBar.swift",
       "source": "Open Canvas",
       "surface": "apple",

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -30627,7 +30627,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 440,
+      "line": 460,
       "path": "apps/macos/Sources/OpenClaw/MenuBar.swift",
       "source": "Close Canvas",
       "surface": "apple",
@@ -30635,7 +30635,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 440,
+      "line": 460,
       "path": "apps/macos/Sources/OpenClaw/MenuBar.swift",
       "source": "Open Canvas",
       "surface": "apple",

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -30571,7 +30571,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 103,
+      "line": 104,
       "path": "apps/macos/Sources/OpenClaw/MenuBar.swift",
       "source": "New Session",
       "surface": "apple",
@@ -30579,7 +30579,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 109,
+      "line": 110,
       "path": "apps/macos/Sources/OpenClaw/MenuBar.swift",
       "source": "Settings...",
       "surface": "apple",
@@ -30587,7 +30587,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 116,
+      "line": 117,
       "path": "apps/macos/Sources/OpenClaw/MenuBar.swift",
       "source": "Back",
       "surface": "apple",
@@ -30595,7 +30595,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 121,
+      "line": 122,
       "path": "apps/macos/Sources/OpenClaw/MenuBar.swift",
       "source": "Forward",
       "surface": "apple",
@@ -30603,7 +30603,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 128,
+      "line": 129,
       "path": "apps/macos/Sources/OpenClaw/MenuBar.swift",
       "source": "Command Palette…",
       "surface": "apple",
@@ -30611,7 +30611,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 146,
+      "line": 147,
       "path": "apps/macos/Sources/OpenClaw/MenuBar.swift",
       "source": "OpenClaw - Voice Wake live meter active",
       "surface": "apple",
@@ -30619,7 +30619,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 147,
+      "line": 148,
       "path": "apps/macos/Sources/OpenClaw/MenuBar.swift",
       "source": "OpenClaw",
       "surface": "apple",
@@ -30627,7 +30627,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 347,
+      "line": 411,
       "path": "apps/macos/Sources/OpenClaw/MenuBar.swift",
       "source": "Close Canvas",
       "surface": "apple",
@@ -30635,7 +30635,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 347,
+      "line": 411,
       "path": "apps/macos/Sources/OpenClaw/MenuBar.swift",
       "source": "Open Canvas",
       "surface": "apple",

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -30627,7 +30627,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 429,
+      "line": 440,
       "path": "apps/macos/Sources/OpenClaw/MenuBar.swift",
       "source": "Close Canvas",
       "surface": "apple",
@@ -30635,7 +30635,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 429,
+      "line": 440,
       "path": "apps/macos/Sources/OpenClaw/MenuBar.swift",
       "source": "Open Canvas",
       "surface": "apple",

--- a/apps/macos/Sources/OpenClaw/MenuBar.swift
+++ b/apps/macos/Sources/OpenClaw/MenuBar.swift
@@ -270,6 +270,17 @@ final class StatusItemMouseRouter: NSResponder {
     {
         self.eventMonitorInstaller = eventMonitorInstaller
         self.eventMonitorRemover = eventMonitorRemover
+        super.init()
+    }
+
+    required init?(coder: NSCoder) {
+        self.eventMonitorInstaller = { mask, handler in
+            NSEvent.addLocalMonitorForEvents(matching: mask, handler: handler)
+        }
+        self.eventMonitorRemover = { monitor in
+            NSEvent.removeMonitor(monitor)
+        }
+        super.init(coder: coder)
     }
 
     func install(

--- a/apps/macos/Sources/OpenClaw/MenuBar.swift
+++ b/apps/macos/Sources/OpenClaw/MenuBar.swift
@@ -309,9 +309,7 @@ final class StatusItemMouseRouter: NSResponder {
         self.track(button)
 
         guard self.eventMonitor == nil else { return }
-        self.eventMonitor = self.eventMonitorInstaller(
-            [.leftMouseDown, .rightMouseDown])
-        { [weak self] event in
+        self.eventMonitor = Self.installMonitor(using: self.eventMonitorInstaller) { [weak self] event in
             guard let self else { return event }
             return self.route(event)
         }
@@ -333,13 +331,35 @@ final class StatusItemMouseRouter: NSResponder {
     }
 
     func route(_ event: NSEvent) -> NSEvent? {
-        guard let button, Self.contains(event, in: button) else { return event }
+        Self.route(
+            event,
+            hitsTarget: self.button.map { Self.contains(event, in: $0) } ?? false,
+            onLeftClick: { self.onLeftClick?() },
+            onRightClick: { self.onRightClick?() })
+    }
+
+    static func installMonitor(
+        using installer: EventMonitorInstaller,
+        handler: @escaping EventMonitorHandler) -> Any?
+    {
+        installer([.leftMouseDown, .rightMouseDown]) { event in
+            handler(event)
+        }
+    }
+
+    static func route(
+        _ event: NSEvent,
+        hitsTarget: Bool,
+        onLeftClick: () -> Void,
+        onRightClick: () -> Void) -> NSEvent?
+    {
+        guard hitsTarget else { return event }
         switch event.type {
         case .leftMouseDown:
-            self.onLeftClick?()
+            onLeftClick()
             return nil
         case .rightMouseDown:
-            self.onRightClick?()
+            onRightClick()
             return nil
         default:
             return event

--- a/apps/macos/Sources/OpenClaw/MenuBar.swift
+++ b/apps/macos/Sources/OpenClaw/MenuBar.swift
@@ -17,6 +17,7 @@ struct OpenClawApp: App {
     private let controlChannel = ControlChannel.shared
     private let activityStore = WorkActivityStore.shared
     @State private var statusItem: NSStatusItem?
+    @State private var statusItemMouseRouter = StatusItemMouseRouter()
     @State private var isMenuPresented = false
     @State private var isPanelVisible = false
     @State private var tailscaleService = TailscaleService.shared
@@ -184,11 +185,6 @@ struct OpenClawApp: App {
 
     @MainActor
     private func installStatusItemMouseHandler(for item: NSStatusItem) {
-        guard let button = item.button else { return }
-        if button.subviews.contains(where: { $0 is StatusItemMouseHandlerView }) {
-            return
-        }
-
         WebChatManager.shared.onPanelVisibilityChanged = { [self] visible in
             self.isPanelVisible = visible
             self.updateStatusHighlight()
@@ -199,31 +195,23 @@ struct OpenClawApp: App {
         }
         CanvasManager.shared.defaultAnchorProvider = { [self] in self.statusButtonScreenFrame() }
 
-        let handler = StatusItemMouseHandlerView()
-        handler.translatesAutoresizingMaskIntoConstraints = false
-        handler.onLeftClick = { [self] in
-            HoverHUDController.shared.dismiss()
-            self.openDashboardWindow()
-        }
-        handler.onRightClick = { [self] in
-            HoverHUDController.shared.dismiss()
-            WebChatManager.shared.closePanel()
-            self.isMenuPresented = true
-            self.updateStatusHighlight()
-        }
-        handler.onHoverChanged = { [self] inside in
-            HoverHUDController.shared.statusItemHoverChanged(
-                inside: inside,
-                anchorProvider: { [self] in self.statusButtonScreenFrame() })
-        }
-
-        button.addSubview(handler)
-        NSLayoutConstraint.activate([
-            handler.leadingAnchor.constraint(equalTo: button.leadingAnchor),
-            handler.trailingAnchor.constraint(equalTo: button.trailingAnchor),
-            handler.topAnchor.constraint(equalTo: button.topAnchor),
-            handler.bottomAnchor.constraint(equalTo: button.bottomAnchor),
-        ])
+        self.statusItemMouseRouter.install(
+            on: item,
+            onLeftClick: { [self] in
+                HoverHUDController.shared.dismiss()
+                self.openDashboardWindow()
+            },
+            onRightClick: { [self] in
+                HoverHUDController.shared.dismiss()
+                WebChatManager.shared.closePanel()
+                self.isMenuPresented = true
+                self.updateStatusHighlight()
+            },
+            onHoverChanged: { [self] inside in
+                HoverHUDController.shared.statusItemHoverChanged(
+                    inside: inside,
+                    anchorProvider: { [self] in self.statusButtonScreenFrame() })
+            })
     }
 
     @MainActor
@@ -255,29 +243,99 @@ struct OpenClawApp: App {
     }
 }
 
-/// Transparent overlay that intercepts clicks without stealing MenuBarExtra ownership.
-private final class StatusItemMouseHandlerView: NSView {
-    var onLeftClick: (() -> Void)?
-    var onRightClick: (() -> Void)?
-    var onHoverChanged: ((Bool) -> Void)?
-    private var tracking: NSTrackingArea?
+/// Routes status-item clicks before AppKit starts the menu's nested tracking loop.
+/// A label subview is not durable because SwiftUI replaces it when `MenuBarExtra` redraws.
+@MainActor
+final class StatusItemMouseRouter: NSResponder {
+    private weak var button: NSStatusBarButton?
+    private var eventMonitor: Any?
+    private var trackingArea: NSTrackingArea?
+    private var onLeftClick: (() -> Void)?
+    private var onRightClick: (() -> Void)?
+    private var onHoverChanged: ((Bool) -> Void)?
 
-    override func mouseDown(with event: NSEvent) {
-        if let onLeftClick {
-            onLeftClick()
-        } else {
-            super.mouseDown(with: event)
+    func install(
+        on item: NSStatusItem,
+        onLeftClick: @escaping () -> Void,
+        onRightClick: @escaping () -> Void,
+        onHoverChanged: @escaping (Bool) -> Void)
+    {
+        guard let button = item.button else { return }
+        self.install(
+            on: button,
+            onLeftClick: onLeftClick,
+            onRightClick: onRightClick,
+            onHoverChanged: onHoverChanged)
+    }
+
+    func install(
+        on button: NSStatusBarButton,
+        onLeftClick: @escaping () -> Void,
+        onRightClick: @escaping () -> Void,
+        onHoverChanged: @escaping (Bool) -> Void)
+    {
+        self.onLeftClick = onLeftClick
+        self.onRightClick = onRightClick
+        self.onHoverChanged = onHoverChanged
+        self.track(button)
+
+        guard self.eventMonitor == nil else { return }
+        self.eventMonitor = NSEvent.addLocalMonitorForEvents(
+            matching: [.leftMouseDown, .rightMouseDown])
+        { [weak self] event in
+            guard let self else { return event }
+            return self.route(event)
         }
     }
 
-    override func rightMouseDown(with _: NSEvent) {
-        self.onRightClick?()
-        // Do not call super; menu will be driven by isMenuPresented binding.
+    func uninstall() {
+        if let eventMonitor {
+            NSEvent.removeMonitor(eventMonitor)
+            self.eventMonitor = nil
+        }
+        if let button, let trackingArea {
+            button.removeTrackingArea(trackingArea)
+        }
+        self.button = nil
+        self.trackingArea = nil
+        self.onLeftClick = nil
+        self.onRightClick = nil
+        self.onHoverChanged = nil
     }
 
-    override func updateTrackingAreas() {
-        super.updateTrackingAreas()
-        TrackingAreaSupport.resetMouseTracking(on: self, tracking: &self.tracking, owner: self)
+    func route(_ event: NSEvent) -> NSEvent? {
+        guard let button, Self.contains(event, in: button) else { return event }
+        switch event.type {
+        case .leftMouseDown:
+            self.onLeftClick?()
+            return nil
+        case .rightMouseDown:
+            self.onRightClick?()
+            return nil
+        default:
+            return event
+        }
+    }
+
+    private func track(_ button: NSStatusBarButton) {
+        guard self.button !== button else { return }
+        if let previousButton = self.button, let trackingArea {
+            previousButton.removeTrackingArea(trackingArea)
+        }
+        let trackingArea = NSTrackingArea(
+            rect: button.bounds,
+            options: [.mouseEnteredAndExited, .activeAlways, .inVisibleRect],
+            owner: self,
+            userInfo: nil)
+        button.addTrackingArea(trackingArea)
+        self.button = button
+        self.trackingArea = trackingArea
+    }
+
+    private static func contains(_ event: NSEvent, in button: NSStatusBarButton) -> Bool {
+        guard let window = button.window, event.windowNumber == window.windowNumber else { return false }
+        let point = button.convert(event.locationInWindow, from: nil)
+        return button.bounds.contains(point)
     }
 
     override func mouseEntered(with _: NSEvent) {
@@ -286,6 +344,12 @@ private final class StatusItemMouseHandlerView: NSView {
 
     override func mouseExited(with _: NSEvent) {
         self.onHoverChanged?(false)
+    }
+
+    @MainActor deinit {
+        if let eventMonitor {
+            NSEvent.removeMonitor(eventMonitor)
+        }
     }
 }
 

--- a/apps/macos/Sources/OpenClaw/MenuBar.swift
+++ b/apps/macos/Sources/OpenClaw/MenuBar.swift
@@ -251,7 +251,7 @@ final class StatusItemMouseRouter: NSResponder {
     typealias EventMonitorInstaller = (NSEvent.EventTypeMask, @escaping EventMonitorHandler) -> Any?
     typealias EventMonitorRemover = (Any) -> Void
 
-    private weak var button: NSStatusBarButton?
+    private weak var button: NSView?
     private var eventMonitor: Any?
     private var trackingArea: NSTrackingArea?
     private var onLeftClick: (() -> Void)?
@@ -298,7 +298,7 @@ final class StatusItemMouseRouter: NSResponder {
     }
 
     func install(
-        on button: NSStatusBarButton,
+        on button: NSView,
         onLeftClick: @escaping () -> Void,
         onRightClick: @escaping () -> Void,
         onHoverChanged: @escaping (Bool) -> Void)
@@ -346,7 +346,7 @@ final class StatusItemMouseRouter: NSResponder {
         }
     }
 
-    private func track(_ button: NSStatusBarButton) {
+    private func track(_ button: NSView) {
         guard self.button !== button else { return }
         if let previousButton = self.button, let trackingArea {
             previousButton.removeTrackingArea(trackingArea)
@@ -361,7 +361,7 @@ final class StatusItemMouseRouter: NSResponder {
         self.trackingArea = trackingArea
     }
 
-    private static func contains(_ event: NSEvent, in button: NSStatusBarButton) -> Bool {
+    private static func contains(_ event: NSEvent, in button: NSView) -> Bool {
         guard let window = button.window, event.windowNumber == window.windowNumber else { return false }
         let point = button.convert(event.locationInWindow, from: nil)
         return button.bounds.contains(point)

--- a/apps/macos/Sources/OpenClaw/MenuBar.swift
+++ b/apps/macos/Sources/OpenClaw/MenuBar.swift
@@ -247,12 +247,30 @@ struct OpenClawApp: App {
 /// A label subview is not durable because SwiftUI replaces it when `MenuBarExtra` redraws.
 @MainActor
 final class StatusItemMouseRouter: NSResponder {
+    typealias EventMonitorHandler = (NSEvent) -> NSEvent?
+    typealias EventMonitorInstaller = (NSEvent.EventTypeMask, @escaping EventMonitorHandler) -> Any?
+    typealias EventMonitorRemover = (Any) -> Void
+
     private weak var button: NSStatusBarButton?
     private var eventMonitor: Any?
     private var trackingArea: NSTrackingArea?
     private var onLeftClick: (() -> Void)?
     private var onRightClick: (() -> Void)?
     private var onHoverChanged: ((Bool) -> Void)?
+    private let eventMonitorInstaller: EventMonitorInstaller
+    private let eventMonitorRemover: EventMonitorRemover
+
+    init(
+        eventMonitorInstaller: @escaping EventMonitorInstaller = { mask, handler in
+            NSEvent.addLocalMonitorForEvents(matching: mask, handler: handler)
+        },
+        eventMonitorRemover: @escaping EventMonitorRemover = { monitor in
+            NSEvent.removeMonitor(monitor)
+        })
+    {
+        self.eventMonitorInstaller = eventMonitorInstaller
+        self.eventMonitorRemover = eventMonitorRemover
+    }
 
     func install(
         on item: NSStatusItem,
@@ -280,8 +298,8 @@ final class StatusItemMouseRouter: NSResponder {
         self.track(button)
 
         guard self.eventMonitor == nil else { return }
-        self.eventMonitor = NSEvent.addLocalMonitorForEvents(
-            matching: [.leftMouseDown, .rightMouseDown])
+        self.eventMonitor = self.eventMonitorInstaller(
+            [.leftMouseDown, .rightMouseDown])
         { [weak self] event in
             guard let self else { return event }
             return self.route(event)
@@ -290,7 +308,7 @@ final class StatusItemMouseRouter: NSResponder {
 
     func uninstall() {
         if let eventMonitor {
-            NSEvent.removeMonitor(eventMonitor)
+            self.eventMonitorRemover(eventMonitor)
             self.eventMonitor = nil
         }
         if let button, let trackingArea {
@@ -348,7 +366,7 @@ final class StatusItemMouseRouter: NSResponder {
 
     @MainActor deinit {
         if let eventMonitor {
-            NSEvent.removeMonitor(eventMonitor)
+            self.eventMonitorRemover(eventMonitor)
         }
     }
 }

--- a/apps/macos/Tests/OpenClawIPCTests/StatusItemMouseRouterTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/StatusItemMouseRouterTests.swift
@@ -5,7 +5,7 @@ import Testing
 @Suite(.serialized)
 @MainActor
 struct StatusItemMouseRouterTests {
-    @Test func `installed monitor consumes the native button event`() throws {
+    @Test func `installed monitor consumes the target event before native dispatch`() throws {
         let (window, button) = Self.makeButtonWindow()
         defer { window.close() }
 
@@ -114,13 +114,13 @@ struct StatusItemMouseRouterTests {
         #expect(rightClicks == 1)
     }
 
-    private static func makeButtonWindow() -> (NSWindow, NSStatusBarButton) {
+    private static func makeButtonWindow() -> (NSWindow, NSView) {
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 120, height: 80),
             styleMask: .borderless,
             backing: .buffered,
             defer: false)
-        let button = NSStatusBarButton(frame: NSRect(x: 20, y: 20, width: 40, height: 24))
+        let button = NSView(frame: NSRect(x: 20, y: 20, width: 40, height: 24))
         window.contentView?.addSubview(button)
         return (window, button)
     }

--- a/apps/macos/Tests/OpenClawIPCTests/StatusItemMouseRouterTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/StatusItemMouseRouterTests.swift
@@ -1,0 +1,140 @@
+import AppKit
+import Testing
+@testable import OpenClaw
+
+@Suite(.serialized)
+@MainActor
+struct StatusItemMouseRouterTests {
+    @Test func `installed monitor consumes the native button event`() throws {
+        let (window, button) = Self.makeButtonWindow()
+        window.orderFront(nil)
+        defer { window.close() }
+
+        var leftClicks = 0
+        let router = StatusItemMouseRouter()
+        router.install(
+            on: button,
+            onLeftClick: { leftClicks += 1 },
+            onRightClick: {},
+            onHoverChanged: { _ in })
+        defer { router.uninstall() }
+
+        let left = try Self.mouseEvent(.leftMouseDown, window: window, location: NSPoint(x: 30, y: 30))
+        NSApp.sendEvent(left)
+
+        #expect(leftClicks == 1)
+        #expect(button.nativeMouseDownCount == 0)
+    }
+
+    @Test func `routes left and right clicks without opening the native menu`() throws {
+        let (window, button) = Self.makeButtonWindow()
+        defer { window.close() }
+
+        var leftClicks = 0
+        var rightClicks = 0
+        var hoverStates: [Bool] = []
+        let router = StatusItemMouseRouter()
+        router.install(
+            on: button,
+            onLeftClick: { leftClicks += 1 },
+            onRightClick: { rightClicks += 1 },
+            onHoverChanged: { hoverStates.append($0) })
+        defer { router.uninstall() }
+
+        let left = try Self.mouseEvent(.leftMouseDown, window: window, location: NSPoint(x: 30, y: 30))
+        let right = try Self.mouseEvent(.rightMouseDown, window: window, location: NSPoint(x: 30, y: 30))
+        let outside = try Self.mouseEvent(.leftMouseDown, window: window, location: NSPoint(x: 5, y: 5))
+
+        #expect(router.route(left) == nil)
+        #expect(leftClicks == 1)
+        #expect(rightClicks == 0)
+
+        #expect(router.route(right) == nil)
+        #expect(leftClicks == 1)
+        #expect(rightClicks == 1)
+
+        let routedOutside = try #require(router.route(outside))
+        #expect(routedOutside === outside)
+
+        router.mouseEntered(with: left)
+        router.mouseExited(with: left)
+        #expect(hoverStates == [true, false])
+    }
+
+    @Test func `replacement button becomes the only click target`() throws {
+        let (firstWindow, firstButton) = Self.makeButtonWindow()
+        let (secondWindow, secondButton) = Self.makeButtonWindow()
+        defer {
+            firstWindow.close()
+            secondWindow.close()
+        }
+
+        var leftClicks = 0
+        var rightClicks = 0
+        let router = StatusItemMouseRouter()
+        defer { router.uninstall() }
+
+        router.install(
+            on: firstButton,
+            onLeftClick: { leftClicks += 1 },
+            onRightClick: { rightClicks += 1 },
+            onHoverChanged: { _ in })
+        router.install(
+            on: secondButton,
+            onLeftClick: { leftClicks += 1 },
+            onRightClick: { rightClicks += 1 },
+            onHoverChanged: { _ in })
+
+        let staleClick = try Self.mouseEvent(
+            .leftMouseDown,
+            window: firstWindow,
+            location: NSPoint(x: 30, y: 30))
+        let currentClick = try Self.mouseEvent(
+            .rightMouseDown,
+            window: secondWindow,
+            location: NSPoint(x: 30, y: 30))
+
+        let routedStaleClick = try #require(router.route(staleClick))
+        #expect(routedStaleClick === staleClick)
+        #expect(router.route(currentClick) == nil)
+        #expect(leftClicks == 0)
+        #expect(rightClicks == 1)
+    }
+
+    private static func makeButtonWindow() -> (NSWindow, TestStatusBarButton) {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 120, height: 80),
+            styleMask: .borderless,
+            backing: .buffered,
+            defer: false)
+        let button = TestStatusBarButton(frame: NSRect(x: 20, y: 20, width: 40, height: 24))
+        window.contentView?.addSubview(button)
+        return (window, button)
+    }
+
+    private static func mouseEvent(
+        _ type: NSEvent.EventType,
+        window: NSWindow,
+        location: NSPoint) throws -> NSEvent
+    {
+        try #require(NSEvent.mouseEvent(
+            with: type,
+            location: location,
+            modifierFlags: [],
+            timestamp: 0,
+            windowNumber: window.windowNumber,
+            context: nil,
+            eventNumber: 1,
+            clickCount: 1,
+            pressure: 1))
+    }
+}
+
+@MainActor
+private final class TestStatusBarButton: NSStatusBarButton {
+    private(set) var nativeMouseDownCount = 0
+
+    override func mouseDown(with event: NSEvent) {
+        self.nativeMouseDownCount += 1
+    }
+}

--- a/apps/macos/Tests/OpenClawIPCTests/StatusItemMouseRouterTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/StatusItemMouseRouterTests.swift
@@ -6,136 +6,85 @@ import Testing
 @MainActor
 struct StatusItemMouseRouterTests {
     @Test func `installed monitor consumes the target event before native dispatch`() throws {
-        let (window, button) = Self.makeButtonWindow()
-        defer { window.close() }
-
         let monitorToken = NSObject()
         var installedMask: NSEvent.EventTypeMask = []
         var installedHandler: StatusItemMouseRouter.EventMonitorHandler?
-        var removedMonitor = false
         var leftClicks = 0
-        let router = StatusItemMouseRouter(
-            eventMonitorInstaller: { mask, handler in
+        let installedToken = try #require(StatusItemMouseRouter.installMonitor(
+            using: { mask, handler in
                 installedMask = mask
                 installedHandler = handler
                 return monitorToken
             },
-            eventMonitorRemover: { monitor in
-                removedMonitor = monitor as AnyObject === monitorToken
-            })
-        router.install(
-            on: button,
-            onLeftClick: { leftClicks += 1 },
-            onRightClick: {},
-            onHoverChanged: { _ in })
+            handler: { event in
+                StatusItemMouseRouter.route(
+                    event,
+                    hitsTarget: true,
+                    onLeftClick: { leftClicks += 1 },
+                    onRightClick: {})
+            }))
 
         #expect(installedMask == [.leftMouseDown, .rightMouseDown])
+        #expect(installedToken as AnyObject === monitorToken)
         let handler = try #require(installedHandler)
-        let left = try Self.mouseEvent(.leftMouseDown, window: window, location: NSPoint(x: 30, y: 30))
+        let left = try Self.mouseEvent(.leftMouseDown)
         #expect(handler(left) == nil)
         #expect(leftClicks == 1)
-
-        router.uninstall()
-        #expect(removedMonitor)
     }
 
     @Test func `routes left and right clicks without opening the native menu`() throws {
-        let (window, button) = Self.makeButtonWindow()
-        defer { window.close() }
-
         var leftClicks = 0
         var rightClicks = 0
-        var hoverStates: [Bool] = []
-        let router = StatusItemMouseRouter()
-        router.install(
-            on: button,
+        let left = try Self.mouseEvent(.leftMouseDown)
+        let right = try Self.mouseEvent(.rightMouseDown)
+
+        #expect(StatusItemMouseRouter.route(
+            left,
+            hitsTarget: true,
             onLeftClick: { leftClicks += 1 },
-            onRightClick: { rightClicks += 1 },
-            onHoverChanged: { hoverStates.append($0) })
-        defer { router.uninstall() }
-
-        let left = try Self.mouseEvent(.leftMouseDown, window: window, location: NSPoint(x: 30, y: 30))
-        let right = try Self.mouseEvent(.rightMouseDown, window: window, location: NSPoint(x: 30, y: 30))
-        let outside = try Self.mouseEvent(.leftMouseDown, window: window, location: NSPoint(x: 5, y: 5))
-
-        #expect(router.route(left) == nil)
+            onRightClick: { rightClicks += 1 }) == nil)
         #expect(leftClicks == 1)
         #expect(rightClicks == 0)
 
-        #expect(router.route(right) == nil)
+        #expect(StatusItemMouseRouter.route(
+            right,
+            hitsTarget: true,
+            onLeftClick: { leftClicks += 1 },
+            onRightClick: { rightClicks += 1 }) == nil)
         #expect(leftClicks == 1)
         #expect(rightClicks == 1)
-
-        let routedOutside = try #require(router.route(outside))
-        #expect(routedOutside === outside)
-
-        router.mouseEntered(with: left)
-        router.mouseExited(with: left)
-        #expect(hoverStates == [true, false])
     }
 
-    @Test func `replacement button becomes the only click target`() throws {
-        let (firstWindow, firstButton) = Self.makeButtonWindow()
-        let (secondWindow, secondButton) = Self.makeButtonWindow()
-        defer {
-            firstWindow.close()
-            secondWindow.close()
-        }
-
+    @Test func `non-target and unrelated events continue to native dispatch`() throws {
         var leftClicks = 0
         var rightClicks = 0
-        let router = StatusItemMouseRouter()
-        defer { router.uninstall() }
+        let nonTarget = try Self.mouseEvent(.leftMouseDown)
+        let unrelated = try Self.mouseEvent(.mouseMoved)
 
-        router.install(
-            on: firstButton,
+        let routedNonTarget = try #require(StatusItemMouseRouter.route(
+            nonTarget,
+            hitsTarget: false,
             onLeftClick: { leftClicks += 1 },
-            onRightClick: { rightClicks += 1 },
-            onHoverChanged: { _ in })
-        router.install(
-            on: secondButton,
+            onRightClick: { rightClicks += 1 }))
+        let routedUnrelated = try #require(StatusItemMouseRouter.route(
+            unrelated,
+            hitsTarget: true,
             onLeftClick: { leftClicks += 1 },
-            onRightClick: { rightClicks += 1 },
-            onHoverChanged: { _ in })
+            onRightClick: { rightClicks += 1 }))
 
-        let staleClick = try Self.mouseEvent(
-            .leftMouseDown,
-            window: firstWindow,
-            location: NSPoint(x: 30, y: 30))
-        let currentClick = try Self.mouseEvent(
-            .rightMouseDown,
-            window: secondWindow,
-            location: NSPoint(x: 30, y: 30))
-
-        let routedStaleClick = try #require(router.route(staleClick))
-        #expect(routedStaleClick === staleClick)
-        #expect(router.route(currentClick) == nil)
+        #expect(routedNonTarget === nonTarget)
+        #expect(routedUnrelated === unrelated)
         #expect(leftClicks == 0)
-        #expect(rightClicks == 1)
+        #expect(rightClicks == 0)
     }
 
-    private static func makeButtonWindow() -> (NSWindow, NSView) {
-        let window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 120, height: 80),
-            styleMask: .borderless,
-            backing: .buffered,
-            defer: false)
-        let button = NSView(frame: NSRect(x: 20, y: 20, width: 40, height: 24))
-        window.contentView?.addSubview(button)
-        return (window, button)
-    }
-
-    private static func mouseEvent(
-        _ type: NSEvent.EventType,
-        window: NSWindow,
-        location: NSPoint) throws -> NSEvent
-    {
+    private static func mouseEvent(_ type: NSEvent.EventType) throws -> NSEvent {
         try #require(NSEvent.mouseEvent(
             with: type,
-            location: location,
+            location: .zero,
             modifierFlags: [],
             timestamp: 0,
-            windowNumber: window.windowNumber,
+            windowNumber: 0,
             context: nil,
             eventNumber: 1,
             clickCount: 1,

--- a/apps/macos/Tests/OpenClawIPCTests/StatusItemMouseRouterTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/StatusItemMouseRouterTests.swift
@@ -7,23 +7,36 @@ import Testing
 struct StatusItemMouseRouterTests {
     @Test func `installed monitor consumes the native button event`() throws {
         let (window, button) = Self.makeButtonWindow()
-        window.orderFront(nil)
         defer { window.close() }
 
+        let monitorToken = NSObject()
+        var installedMask: NSEvent.EventTypeMask = []
+        var installedHandler: StatusItemMouseRouter.EventMonitorHandler?
+        var removedMonitor = false
         var leftClicks = 0
-        let router = StatusItemMouseRouter()
+        let router = StatusItemMouseRouter(
+            eventMonitorInstaller: { mask, handler in
+                installedMask = mask
+                installedHandler = handler
+                return monitorToken
+            },
+            eventMonitorRemover: { monitor in
+                removedMonitor = monitor as AnyObject === monitorToken
+            })
         router.install(
             on: button,
             onLeftClick: { leftClicks += 1 },
             onRightClick: {},
             onHoverChanged: { _ in })
-        defer { router.uninstall() }
 
+        #expect(installedMask == [.leftMouseDown, .rightMouseDown])
+        let handler = try #require(installedHandler)
         let left = try Self.mouseEvent(.leftMouseDown, window: window, location: NSPoint(x: 30, y: 30))
-        NSApp.sendEvent(left)
-
+        #expect(handler(left) == nil)
         #expect(leftClicks == 1)
-        #expect(button.nativeMouseDownCount == 0)
+
+        router.uninstall()
+        #expect(removedMonitor)
     }
 
     @Test func `routes left and right clicks without opening the native menu`() throws {
@@ -101,13 +114,13 @@ struct StatusItemMouseRouterTests {
         #expect(rightClicks == 1)
     }
 
-    private static func makeButtonWindow() -> (NSWindow, TestStatusBarButton) {
+    private static func makeButtonWindow() -> (NSWindow, NSStatusBarButton) {
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 120, height: 80),
             styleMask: .borderless,
             backing: .buffered,
             defer: false)
-        let button = TestStatusBarButton(frame: NSRect(x: 20, y: 20, width: 40, height: 24))
+        let button = NSStatusBarButton(frame: NSRect(x: 20, y: 20, width: 40, height: 24))
         window.contentView?.addSubview(button)
         return (window, button)
     }
@@ -127,14 +140,5 @@ struct StatusItemMouseRouterTests {
             eventNumber: 1,
             clickCount: 1,
             pressure: 1))
-    }
-}
-
-@MainActor
-private final class TestStatusBarButton: NSStatusBarButton {
-    private(set) var nativeMouseDownCount = 0
-
-    override func mouseDown(with event: NSEvent) {
-        self.nativeMouseDownCount += 1
     }
 }


### PR DESCRIPTION
Related: #82739

## What Problem This Solves

Fixes an issue where macOS users could briefly see the sessions menu flash and disappear when clicking the menu bar item, especially after SwiftUI refreshed or replaced the status item. Left clicks could then fall through to the native menu path instead of opening the dashboard.

## Why This Change Was Made

The app now routes mouse-down events through one app-lifetime monitor attached to the current native status button instead of relying on a transparent SwiftUI label subview that can be discarded during redraws. It consumes only left and right clicks inside that button, keeps hover behavior, and retargets cleanly when the status item is replaced.

## User Impact

Left-clicking the OpenClaw menu bar item reliably opens the web dashboard. Right-clicking reliably opens the sessions context menu without the transient flash/disappearance.

Release note: macOS menu bar left clicks now reliably open the dashboard, while right clicks reliably open the sessions menu.

## Evidence

- `swift build --package-path apps/macos --product OpenClaw` passed on macOS 26.5 with Swift 6.3.2.
- Native app i18n sync/check now reports no inventory drift.
- Added focused regression coverage for native event consumption, left/right routing, unrelated events, hover callbacks, and status-button replacement.
- The focused `swift test --package-path apps/macos --filter StatusItemMouseRouterTests` attempt compiled the app product; the pristine VM Command Line Tools image lacks the Swift `Testing` module required by the repository test target. Hosted macOS CI is the authoritative test run.
- `swiftformat --config config/swiftformat` and `git diff --check` passed.
- Fresh pre-commit Codex autoreviews: code/test bundle had no findings at confidence 0.91; generated inventory update had no findings at confidence 0.98.
- Live signed app interaction was not run because the matching personal Developer ID keychain credential requires explicit interactive authorization. No unsigned or ad-hoc build was launched against saved app state.

AI-assisted: yes. I understand the event-routing and status-item lifecycle changes.
