### PR TITLE
fix: OpenAI OAuth models fail on cloud workers

### DIFF
--- a/src/gateway/worker-environments/inference-runtime.test.ts
+++ b/src/gateway/worker-environments/inference-runtime.test.ts
@@ -19,6 +19,7 @@ import type { loadManifestMetadataSnapshot } from "../../plugins/manifest-contra
 import type { WorkerConnectionIdentity } from "./connection-identity.js";
 import {
   createWorkerInferenceExecutor,
+  projectWorkerInferenceModelRouteConfig,
   type WorkerInferenceExecutionParams,
 } from "./inference-runtime.js";
 import { createWorkerToolCallStream } from "./inference-tool-call-stream.js";
@@ -28,6 +29,7 @@ type Deps = {
   loadCatalog: typeof loadModelCatalog;
   loadManifestSnapshot: typeof loadManifestMetadataSnapshot;
   prepareModel: typeof prepareSimpleCompletionModel;
+  resolveAuthProfileMode: () => string | undefined;
   resolveModel: typeof resolveModelAsync;
   resolveProviderStream: typeof registerProviderStreamForModel;
   resolveStream: typeof resolveEmbeddedAgentStreamFn;
@@ -35,7 +37,7 @@ type Deps = {
 type Execution = WorkerInferenceExecutionParams;
 
 const PROVIDER = "openai";
-const MODEL = "approved-model";
+const MODEL = "gpt-5.6-sol";
 const ALIAS = "fast";
 const BASE_URL = "https://chatgpt.com/backend-api";
 const ENDPOINT = `${BASE_URL}/codex`;
@@ -193,6 +195,7 @@ function setup(entry: SessionEntry = sessionEntry) {
       },
     };
   });
+  const resolveAuthProfileMode = vi.fn<Deps["resolveAuthProfileMode"]>(() => undefined);
   const stream = vi.fn<StreamFn>(() => providerStream());
   const fallbackStream = vi.fn<StreamFn>(() => providerStream());
   const loadManifestSnapshot = vi.fn(
@@ -231,6 +234,7 @@ function setup(entry: SessionEntry = sessionEntry) {
     resolveSessionAuthProfile: vi.fn(async () => entry.authProfileOverride),
     resolveModel,
     prepareModel,
+    resolveAuthProfileMode,
     resolveProviderStream,
     resolveStream,
     applyStreamPolicy,
@@ -242,6 +246,7 @@ function setup(entry: SessionEntry = sessionEntry) {
     applyStreamPolicy,
     executor: createWorkerInferenceExecutor(dependencies),
     prepareModel,
+    resolveAuthProfileMode,
     scope,
     stream,
   };
@@ -269,6 +274,47 @@ const MODEL_ERROR = {
 };
 
 describe("worker inference provider runtime", () => {
+  it("projects the gateway-owned auth profile onto the provider route", () => {
+    const oauth = projectWorkerInferenceModelRouteConfig({
+      config: {},
+      provider: "openai",
+      modelId: "gpt-5.6-sol",
+      authMode: "oauth",
+    });
+    const apiKey = projectWorkerInferenceModelRouteConfig({
+      config: {},
+      provider: "openai",
+      modelId: "gpt-5.6-sol",
+      authMode: "api_key",
+    });
+
+    expect(oauth.models?.providers?.openai).toMatchObject({
+      auth: "oauth",
+      api: "openai-chatgpt-responses",
+      baseUrl: "https://chatgpt.com/backend-api/codex",
+    });
+    expect(apiKey.models?.providers?.openai).toMatchObject({
+      auth: "api-key",
+      api: "openai-responses",
+      baseUrl: "https://api.openai.com/v1",
+    });
+  });
+
+  it("prepares the selected model against its gateway-owned OAuth route", async () => {
+    const runtime = setup();
+    runtime.resolveAuthProfileMode.mockReturnValue("oauth");
+
+    await expect(runtime.executor(params(request(), vi.fn()))).resolves.toMatchObject({
+      type: "done",
+    });
+
+    expect(runtime.prepareModel.mock.calls[0]?.[0].cfg?.models?.providers?.openai).toMatchObject({
+      auth: "oauth",
+      api: "openai-chatgpt-responses",
+      baseUrl: "https://chatgpt.com/backend-api/codex",
+    });
+  });
+
   it("keeps approved alias routing, endpoint, headers, and auth gateway-owned", async () => {
     const runtime = setup();
     const emitted: Parameters<Execution["emit"]>[0][] = [];

--- a/src/gateway/worker-environments/inference-runtime.test.ts
+++ b/src/gateway/worker-environments/inference-runtime.test.ts
@@ -315,6 +315,27 @@ describe("worker inference provider runtime", () => {
     });
   });
 
+  it("pins an automatic profile to the route projected from that profile", async () => {
+    const runtime = setup({
+      ...sessionEntry,
+      authProfileOverrideSource: "auto",
+      authProfileOverrideCompactionCount: 1,
+    });
+    runtime.resolveAuthProfileMode.mockReturnValue("oauth");
+
+    await expect(runtime.executor(params(request(), vi.fn()))).resolves.toMatchObject({
+      type: "done",
+    });
+
+    expect(runtime.prepareModel).toHaveBeenCalledWith(
+      expect.objectContaining({
+        profileId: PROFILE,
+        preferredProfile: PROFILE,
+        bindAuthOwner: true,
+      }),
+    );
+  });
+
   it("keeps approved alias routing, endpoint, headers, and auth gateway-owned", async () => {
     const runtime = setup();
     const emitted: Parameters<Execution["emit"]>[0][] = [];

--- a/src/gateway/worker-environments/inference-runtime.ts
+++ b/src/gateway/worker-environments/inference-runtime.ts
@@ -565,14 +565,16 @@ async function resolveApprovedModel(params: {
       }),
     workspaceDir,
   );
+  // Route projection and credential selection are one decision. Pin even an
+  // automatic profile so generic auth fallback cannot cross to another route.
   const prepared = await dependencies.prepareModel({
     cfg: modelConfig,
     provider: resolved.ref.provider,
     modelId: resolved.ref.model,
     agentDir,
-    ...(selectedProfile?.source === "user" ? { profileId: selectedProfile.id } : {}),
+    ...(selectedProfile ? { profileId: selectedProfile.id } : {}),
     ...(selectedProfile ? { preferredProfile: selectedProfile.id } : {}),
-    ...(selectedProfile?.source === "user" ? { bindAuthOwner: true } : {}),
+    ...(selectedProfile ? { bindAuthOwner: true } : {}),
     allowMissingApiKeyModes: ["aws-sdk"],
     useAsyncModelResolution: true,
     modelResolver,

--- a/src/gateway/worker-environments/inference-runtime.ts
+++ b/src/gateway/worker-environments/inference-runtime.ts
@@ -13,6 +13,7 @@ import {
   resolveDefaultAgentId,
 } from "../../agents/agent-scope.js";
 import { resolveSessionAuthProfileOverride } from "../../agents/auth-profiles/session-override.js";
+import { ensureAuthProfileStore } from "../../agents/auth-profiles/store.js";
 import { applyExtraParamsToAgent } from "../../agents/embedded-agent-runner/extra-params.js";
 import { resolveModelAsync } from "../../agents/embedded-agent-runner/model.js";
 import { wrapStreamFnWithDiagnosticModelCallEvents } from "../../agents/embedded-agent-runner/run/attempt.model-diagnostic-events.js";
@@ -34,6 +35,8 @@ import {
   RUNTIME_MODEL_VISIBILITY_NORMALIZATION,
 } from "../../agents/model-visibility-policy.js";
 import { listOpenAIAuthProfileProvidersForAgentRuntime } from "../../agents/openai-routing.js";
+import { resolveProviderModelRouteAuthRequirement } from "../../agents/provider-model-route-auth.js";
+import { projectProviderModelRouteConfig } from "../../agents/provider-model-route.js";
 import { registerProviderStreamForModel } from "../../agents/provider-stream.js";
 import {
   prepareSimpleCompletionModel,
@@ -63,6 +66,7 @@ import type {
   Usage,
 } from "../../llm/types.js";
 import { loadManifestMetadataSnapshot } from "../../plugins/manifest-contract-eligibility.js";
+import { resolveProviderModelRoutes } from "../../plugins/provider-model-routes.js";
 import { estimateUsageCost, resolveModelCostConfig } from "../../utils/usage-format.js";
 import {
   projectWorkerInferenceTerminalMessage,
@@ -100,6 +104,7 @@ type WorkerInferenceRuntimeDependencies = {
   loadCatalog: typeof loadModelCatalog;
   resolveDefaultModel: typeof resolveDefaultModelForAgent;
   resolveSessionAuthProfile: typeof resolveSessionAuthProfileOverride;
+  resolveAuthProfileMode: typeof resolveWorkerInferenceAuthProfileMode;
   resolveModel: typeof resolveModelAsync;
   prepareModel: typeof prepareSimpleCompletionModel;
   resolveProviderStream: typeof registerProviderStreamForModel;
@@ -110,6 +115,56 @@ type WorkerInferenceRuntimeDependencies = {
   createTrace: typeof createDiagnosticTraceContextFromActiveScope;
   recordUsage: (params: WorkerInferenceUsageParams) => void;
 };
+
+function resolveWorkerInferenceAuthProfileMode(params: {
+  config: OpenClawConfig;
+  agentDir: string;
+  profileId: string;
+}): string | undefined {
+  const configuredMode = params.config.auth?.profiles?.[params.profileId]?.mode;
+  if (configuredMode) {
+    return configuredMode;
+  }
+  return ensureAuthProfileStore(params.agentDir, {
+    readOnly: true,
+    allowKeychainPrompt: false,
+    config: params.config,
+  }).profiles[params.profileId]?.type;
+}
+
+export function projectWorkerInferenceModelRouteConfig(params: {
+  config: OpenClawConfig;
+  provider: string;
+  modelId: string;
+  authMode?: string;
+}): OpenClawConfig {
+  const authRequirement = resolveProviderModelRouteAuthRequirement(params.authMode);
+  if (!authRequirement) {
+    return params.config;
+  }
+  const resolution = resolveProviderModelRoutes({
+    provider: params.provider,
+    modelId: params.modelId,
+    config: params.config,
+  });
+  if (resolution?.kind !== "routes") {
+    return params.config;
+  }
+  const route = resolution.routes.find(
+    (candidate) => candidate.authRequirement === authRequirement,
+  );
+  if (!route) {
+    return params.config;
+  }
+  // Worker placement owns the agent harness, while the gateway-owned profile
+  // owns the provider route. Keep those decisions separate or OAuth can be
+  // materialized as a public API-key endpoint and fail before the first token.
+  return projectProviderModelRouteConfig({
+    provider: params.provider,
+    config: params.config,
+    route,
+  });
+}
 
 const ERROR_MESSAGES = {
   "model-not-approved": "Model is not approved for this agent.",
@@ -330,6 +385,7 @@ const DEFAULT_DEPENDENCIES: WorkerInferenceRuntimeDependencies = {
   loadCatalog: loadModelCatalog,
   resolveDefaultModel: resolveDefaultModelForAgent,
   resolveSessionAuthProfile: resolveSessionAuthProfileOverride,
+  resolveAuthProfileMode: resolveWorkerInferenceAuthProfileMode,
   resolveModel: resolveModelAsync,
   prepareModel: prepareSimpleCompletionModel,
   resolveProviderStream: registerProviderStreamForModel,
@@ -488,6 +544,18 @@ async function resolveApprovedModel(params: {
         : sessionProfileId
           ? { id: sessionProfileId, source: sessionProfileSource }
           : undefined;
+  const modelConfig = projectWorkerInferenceModelRouteConfig({
+    config,
+    provider: resolved.ref.provider,
+    modelId: resolved.ref.model,
+    authMode: selectedProfile
+      ? dependencies.resolveAuthProfileMode({
+          config,
+          agentDir,
+          profileId: selectedProfile.id,
+        })
+      : undefined,
+  });
   const modelResolver = bindSimpleCompletionModelResolverWorkspace(
     (provider, modelId, resolvedAgentDir, cfg, options) =>
       dependencies.resolveModel(provider, modelId, resolvedAgentDir, cfg, {
@@ -498,7 +566,7 @@ async function resolveApprovedModel(params: {
     workspaceDir,
   );
   const prepared = await dependencies.prepareModel({
-    cfg: config,
+    cfg: modelConfig,
     provider: resolved.ref.provider,
     modelId: resolved.ref.model,
     agentDir,


### PR DESCRIPTION
Closes #107782

## What Problem This Solves

Fixes an issue where users running an OpenAI ChatGPT/Codex OAuth model on a cloud worker would see the turn fail before producing a reply, even though the same model worked locally.

## Why This Change Was Made

Cloud workers keep the OpenClaw harness on the remote machine while inference and credentials stay on the gateway. The gateway now projects the selected auth profile onto the provider-owned physical model route before materializing the model, keeping harness placement separate from OAuth/API-key endpoint selection.

## User Impact

Cloud worker sessions can use gateway-owned OpenAI OAuth models such as GPT-5.6 Sol without exporting credentials to the worker. OpenAI API-key profiles continue to use the public Responses route.

## Evidence

- Reproduced on ClawMac: local GPT-5.6 Sol succeeded; the same model on an attached AWS worker failed before first token; switching that same worker to ClawRouter succeeded.
- Live route probe on ClawMac: unprojected OpenClaw preparation rejected the OAuth profile against the public Responses route; projected preparation resolved `openai-chatgpt-responses` at `chatgpt.com` with the same profile.
- `node scripts/run-vitest.mjs src/gateway/worker-environments/inference-runtime.test.ts` — 20 passed on Testbox `tbx_01kxh9zxfy6a812qcncxmtpgsk` ([run](https://github.com/openclaw/openclaw/actions/runs/29371201329)).
- `pnpm check:changed` — passed core and core-test typecheck, lint, format, import-cycle, SDK baseline, and repository guards on Testbox `tbx_01kxh9nfherb8ex4gqt1cpj9c6` ([run](https://github.com/openclaw/openclaw/actions/runs/29370865661)).
- Fresh branch autoreview: no accepted/actionable findings.
