### PR TITLE
fix: prevent uninstallable source packages when AI runtime is unpublished

### DIFF
--- a/scripts/openclaw-prepack.ts
+++ b/scripts/openclaw-prepack.ts
@@ -2,7 +2,7 @@
 // Openclaw Prepack script supports OpenClaw repository automation.
 
 import { spawnSync, type SpawnSyncOptions } from "node:child_process";
-import { existsSync, readdirSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 import { formatErrorMessage } from "../src/infra/errors.ts";
 import { writePackageDistInventory } from "./lib/package-dist-inventory.ts";
@@ -17,14 +17,50 @@ const requiredControlUiAssetPrefix = "dist/control-ui/assets/";
 const requiredControlUiCompressionSuffixes = [".br", ".gz"] as const;
 const DEFAULT_PREPACK_COMMAND_TIMEOUT_MS = 30 * 60 * 1000;
 const ALLOW_UNRELEASED_CHANGELOG_ENV = "OPENCLAW_PREPACK_ALLOW_UNRELEASED_CHANGELOG";
+const PREPARED_RELEASE_ENV = "OPENCLAW_PREPACK_PREPARED";
+const SELF_CONTAINED_SOURCE_PACK_COMMAND =
+  "node scripts/package-openclaw-for-docker.mjs --allow-unreleased-changelog";
 
 type PreparedFileReader = {
   existsSync: typeof existsSync;
   readdirSync: typeof readdirSync;
 };
 
+type PackageManifest = {
+  dependencies?: Record<string, unknown>;
+};
+
 function normalizeFiles(files: Iterable<string>): Set<string> {
   return new Set(Array.from(files, (file) => file.replace(/\\/g, "/")));
+}
+
+export function collectSourcePackWorkspaceDependencyErrors(
+  packageJson: PackageManifest,
+  env: NodeJS.ProcessEnv = process.env,
+): string[] {
+  if (env[PREPARED_RELEASE_ENV]?.trim() === "1") {
+    return [];
+  }
+  const aiDependency = packageJson.dependencies?.["@openclaw/ai"];
+  if (typeof aiDependency !== "string" || !aiDependency.trim().startsWith("workspace:")) {
+    return [];
+  }
+  return [
+    `plain root packing cannot safely resolve @openclaw/ai from ${aiDependency}: pnpm rewrites the workspace dependency to an exact version without bundling the package`,
+    `use \`${SELF_CONTAINED_SOURCE_PACK_COMMAND}\` for a self-contained source package; official npm release automation prepares and publishes @openclaw/ai separately`,
+  ];
+}
+
+function ensureSupportedSourcePack(env: NodeJS.ProcessEnv = process.env): void {
+  const packageJson = JSON.parse(readFileSync("package.json", "utf8")) as PackageManifest;
+  const errors = collectSourcePackWorkspaceDependencyErrors(packageJson, env);
+  if (errors.length === 0) {
+    return;
+  }
+  for (const error of errors) {
+    console.error(`prepack: ${error}`);
+  }
+  process.exit(1);
 }
 
 export function collectPreparedPrepackErrors(
@@ -234,6 +270,7 @@ export async function preparePrepackArtifacts(env: NodeJS.ProcessEnv = process.e
 }
 
 async function main(): Promise<void> {
+  ensureSupportedSourcePack();
   const buildEnv = resolvePrepackBuildEnvironment();
   runPnpm(["build"], buildEnv);
   runPnpm(["ui:build"], buildEnv);

--- a/test/openclaw-prepack.test.ts
+++ b/test/openclaw-prepack.test.ts
@@ -1,13 +1,99 @@
 // OpenClaw prepack tests validate package prepack output.
-import { describe, expect, it } from "vitest";
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import * as tar from "tar";
+import { afterEach, describe, expect, it } from "vitest";
 import {
   collectPreparedPrepackErrors,
+  collectSourcePackWorkspaceDependencyErrors,
   resolvePrepackAllowUnreleasedChangelog,
   resolvePrepackBuildEnvironment,
   resolvePrepackCommandStdio,
   resolvePrepackCommandTimeoutMs,
   runPrepackCommand,
 } from "../scripts/openclaw-prepack.ts";
+import { useAutoCleanupTempDirTracker } from "./helpers/temp-dir.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+describe("collectSourcePackWorkspaceDependencyErrors", () => {
+  it("rejects the plain source pack that pnpm rewrites without bundling @openclaw/ai", () => {
+    const rootDir = tempDirs.make("openclaw-source-pack-workspace-");
+    const aiDir = path.join(rootDir, "packages", "ai");
+    const packDir = path.join(rootDir, "pack");
+    const extractDir = path.join(rootDir, "extract");
+    const version = "2099.1.2-test.0";
+    const rootPackageJson = {
+      dependencies: { "@openclaw/ai": "workspace:*" },
+      name: "openclaw-source-pack-regression",
+      version,
+    };
+    mkdirSync(aiDir, { recursive: true });
+    mkdirSync(packDir);
+    mkdirSync(extractDir);
+    writeFileSync(
+      path.join(rootDir, "package.json"),
+      `${JSON.stringify(rootPackageJson, null, 2)}\n`,
+    );
+    writeFileSync(path.join(rootDir, "pnpm-workspace.yaml"), 'packages:\n  - "packages/*"\n');
+    writeFileSync(
+      path.join(aiDir, "package.json"),
+      `${JSON.stringify({ name: "@openclaw/ai", version }, null, 2)}\n`,
+    );
+
+    const install = spawnSync(
+      "pnpm",
+      ["install", "--ignore-scripts", "--lockfile=false", "--reporter=silent"],
+      {
+        cwd: rootDir,
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    );
+    expect(install.status, install.stderr).toBe(0);
+    const packed = spawnSync(
+      "pnpm",
+      ["pack", "--config.ignore-scripts=true", "--json", "--pack-destination", packDir],
+      {
+        cwd: rootDir,
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    );
+    expect(packed.status, packed.stderr).toBe(0);
+    const packResult = JSON.parse(packed.stdout) as
+      | { filename: string }
+      | Array<{
+          filename: string;
+        }>;
+    const filename = Array.isArray(packResult) ? packResult[0]?.filename : packResult.filename;
+    expect(filename).toBeTruthy();
+    const tarballPath = path.resolve(packDir, path.basename(filename ?? ""));
+    tar.x({ cwd: extractDir, file: tarballPath, sync: true });
+
+    const packedPackageJson = JSON.parse(
+      readFileSync(path.join(extractDir, "package", "package.json"), "utf8"),
+    ) as {
+      bundleDependencies?: string[];
+      dependencies?: Record<string, string>;
+    };
+    expect(packedPackageJson.dependencies?.["@openclaw/ai"]).toBe(version);
+    expect(packedPackageJson.bundleDependencies).toBeUndefined();
+    expect(existsSync(path.join(extractDir, "package", "node_modules", "@openclaw", "ai"))).toBe(
+      false,
+    );
+    expect(collectSourcePackWorkspaceDependencyErrors(rootPackageJson, {})).toEqual([
+      "plain root packing cannot safely resolve @openclaw/ai from workspace:*: pnpm rewrites the workspace dependency to an exact version without bundling the package",
+      "use `node scripts/package-openclaw-for-docker.mjs --allow-unreleased-changelog` for a self-contained source package; official npm release automation prepares and publishes @openclaw/ai separately",
+    ]);
+    expect(
+      collectSourcePackWorkspaceDependencyErrors(rootPackageJson, {
+        OPENCLAW_PREPACK_PREPARED: "1",
+      }),
+    ).toEqual([]);
+  });
+});
 
 describe("resolvePrepackAllowUnreleasedChangelog", () => {
   it("requires an explicit non-publish opt-in", () => {


### PR DESCRIPTION
Related: #103941

## What Problem This Solves

Fixes an issue where developers packing the root source checkout could produce an OpenClaw tarball that fails to install with npm `ETARGET` when the matching `@openclaw/ai` version has not been published yet.

## Why This Change Was Made

### Contract and cause

The root manifest declares `@openclaw/ai` as `workspace:*`. pnpm rewrites that dependency to an exact version in a packed manifest, but a plain root pack does not include the workspace package. The resulting source candidate therefore asks npm for an exact registry version that may not exist.

OpenClaw already has two valid packaging contracts:

- the official npm release workflow packs and verifies `@openclaw/ai`, then publishes it before `openclaw`;
- `scripts/package-openclaw-for-docker.mjs` owns self-contained source candidates by staging and bundling the AI runtime before packing.

The root prepack lifecycle now rejects unsupported plain source packing before starting a build and points developers to the existing self-contained pack command. The established `OPENCLAW_PREPACK_PREPARED=1` release signal preserves official release packaging after its sibling AI artifact has been prepared.

### Best-fix rationale

This keeps the fix at the existing packaging boundary and prevents an invalid candidate at the earliest normal lifecycle hook.

- A new shared packer or package alias was rejected because `scripts/package-openclaw-for-docker.mjs` already owns the build, inventory, bundled-workspace, pack, and integrity-check sequence.
- A global tarball-checker requirement was rejected because official npm tarballs intentionally depend on the separately published exact AI package rather than bundling it.
- Broader release changes were rejected because the release workflow and the merged local release-check fix in #103941 already prepare and validate the exact sibling AI artifact.

### Provenance and duplicate audit

The workspace split and packaging contract were introduced in #99059 (`062f88e3e3aff6e96c8fcb8ec3acc173fbbbf24f`) by `@steipete`, who also merged it on July 5, 2026.

Gitcrawl was searched first, followed by live GitHub search. No exact open issue or PR covers unsafe plain root source packing. Related items are distinct: #103941 fixes local release checks, #103552 covered malformed bundled AI contents, #106351/#107073 cover missing AI build output, and #70844 covered plugin runtime workspace-protocol installation.

## User Impact

Developers now get an immediate actionable error instead of spending time building and then discovering an uninstallable tarball. The error directs them to the canonical self-contained source pack command. Official npm release behavior and shipped runtime behavior are unchanged.

Release-note context: source packaging now fails early rather than producing an artifact whose unpublished AI dependency cannot be installed.

## Evidence

### Before

- `pnpm pack --config.ignore-scripts=true --json --pack-destination <dir>` produced a root tarball with `dependencies["@openclaw/ai"] = "2026.7.2"`, no `bundleDependencies`, and no `package/node_modules/@openclaw/ai` payload.
- `npm view @openclaw/ai@2026.7.2 version` returned no published match.
- Installing that tarball in a clean prefix failed with `npm error code ETARGET` and `No matching version found for @openclaw/ai@2026.7.2`.

### After

- `node scripts/run-vitest.mjs test/openclaw-prepack.test.ts` - 12 tests passed, including a real temporary pnpm workspace that proves the exact-version rewrite, missing bundled workspace, normal rejection, and prepared-release bypass.
- `pnpm pack --json --pack-destination <dir>` - fails before build with the self-contained packaging guidance.
- `node scripts/package-openclaw-for-docker.mjs --allow-unreleased-changelog --output-dir <dir> --output-name openclaw-current.tgz` - full build, inventory, pack, and strict tarball integrity check passed; the tarball declares and contains bundled `@openclaw/ai`.
- `pnpm tsgo:scripts` - passed.
- `pnpm tsgo:test:root` - passed.
- `node scripts/run-oxlint.mjs scripts/openclaw-prepack.ts test/openclaw-prepack.test.ts` - passed.
- `pnpm exec oxfmt --check scripts/openclaw-prepack.ts test/openclaw-prepack.test.ts` - passed.
- `git diff --check` - passed.
- Autoreview - clean, no actionable findings.

Behavior addressed: plain root source packs silently producing an artifact that requires an unpublished exact `@openclaw/ai` version.

Real environment tested: clean macOS worktree, Node 24.16.0, pnpm 11.2.2, npm registry availability check, isolated npm install prefix, and the repository's canonical self-contained package builder.

Exact steps or command run after this patch: focused Vitest regression; normal `pnpm pack`; full `scripts/package-openclaw-for-docker.mjs` build/pack/check; targeted formatter, lint, and tsgo lanes.

Evidence after fix: normal packing stops before build with the canonical command, while the canonical self-contained artifact passes strict integrity checks and includes `package/node_modules/@openclaw/ai`.

Observed result after fix: invalid plain source candidates are rejected early; supported release and self-contained package paths remain valid.

What was not tested: no package was published, no dist-tag was changed, and no live OpenClaw installation was modified or restarted. A supplementary local run of the package-helper E2E had 26/27 tests pass; its unchanged copied-script fixture hits the existing macOS `/tmp` versus `/private/tmp` main-module path behavior, while the real package-helper command above passed end to end.
