### PR TITLE
refactor(plugin-sdk): isolate core session state from plugin mutations

### DIFF
--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-739fe620027bad069221aef1e6ec68bef0448c31a1573f70802a461b212c3d7d  plugin-sdk-api-baseline.json
-08eb0ae2bd2c3b32e04661cde03260aa97462ba64a4944307a0bdf98f4f98a75  plugin-sdk-api-baseline.jsonl
+ec7c6c1e32c7efc54ec78bf1f156721427e31cd6c2dcc5a9826b9512bb5a049e  plugin-sdk-api-baseline.json
+1a03ccf7c1ba1ddff18941b8e8c06af172d460644629a6ae946cbf1bf44cd46d  plugin-sdk-api-baseline.jsonl

--- a/docs/plugins/sdk-subpaths.md
+++ b/docs/plugins/sdk-subpaths.md
@@ -53,6 +53,11 @@ barrels `plugin-sdk/agent-runtime`, `plugin-sdk/channel-lifecycle`,
 `plugin-sdk/security-runtime` are likewise deprecated in favor of focused
 subpaths.
 
+Plugin-visible session rows use the `SessionEntry` public projection. Core-owned restart recovery
+coordination (`mainRestartRecovery` and the `restartRecovery*` namespace) is excluded from reads,
+callback inputs, and replacement/upsert types, and is preserved internally only while the effective
+session identity remains unchanged.
+
 OpenClaw's Vitest-backed test-helper subpaths are repo-local only and are no
 longer package exports: `agent-runtime-test-contracts`,
 `channel-contract-testing`, `channel-target-testing`, `channel-test-helpers`,
@@ -273,7 +278,7 @@ usage endpoint failed or returned no usable usage data.
     | `plugin-sdk/reply-history` | Shared short-window reply-history helpers. New message-turn code should use `createChannelHistoryWindow`; lower-level map helpers remain deprecated compatibility exports only |
     | `plugin-sdk/reply-reference` | `createReplyReferencePlanner` |
     | `plugin-sdk/reply-chunking` | Narrow text/markdown chunking helpers |
-    | `plugin-sdk/session-store-runtime` | Session workflow helpers (`getSessionEntry`, `listSessionEntries`, `patchSessionEntry`, `upsertSessionEntry`), repair/lifecycle helpers (`deleteSessionEntry`, `cleanupSessionLifecycleArtifacts`, `resolveSessionStoreBackupPaths`), marker helpers for transitional `sessionFile` values, bounded recent user/assistant transcript text reads by session identity, session store path/session-key helpers, and updated-at reads, without broad config writes/maintenance imports |
+    | `plugin-sdk/session-store-runtime` | Session workflow helpers (`getSessionEntry`, `listSessionEntries`, `patchSessionEntry`, `upsertSessionEntry`) over the public `SessionEntry` projection, repair/lifecycle helpers (`deleteSessionEntry`, `cleanupSessionLifecycleArtifacts`, `resolveSessionStoreBackupPaths`), marker helpers for transitional `sessionFile` values, bounded recent user/assistant transcript text reads by session identity, session store path/session-key helpers, and updated-at reads, without broad config writes/maintenance imports or core restart-recovery coordination fields |
     | `plugin-sdk/session-transcript-runtime` | Transcript identity, scoped target/read/write helpers, visible message-entry projection, update publishing, write locks, and transcript memory hit keys |
     | `plugin-sdk/sqlite-runtime` | Focused SQLite agent-schema, path, and transaction helpers for first-party runtime, without database lifecycle controls |
     | `plugin-sdk/cron-store-runtime` | Cron store path/load/save helpers |

--- a/docs/plugins/sdk-subpaths.md
+++ b/docs/plugins/sdk-subpaths.md
@@ -299,7 +299,7 @@ usage endpoint failed or returned no usable usage data.
     | `plugin-sdk/json-unsafe-integers` | JSON parsing helpers that preserve unsafe integer literals as strings |
     | `plugin-sdk/file-lock` | Re-entrant file-lock helpers |
     | `plugin-sdk/persistent-dedupe` | Disk-backed dedupe cache helpers |
-    | `plugin-sdk/acp-runtime` | ACP runtime/session and reply-dispatch helpers |
+    | `plugin-sdk/acp-runtime` | ACP runtime/session and reply-dispatch helpers. `getAcpSessionManager()` returns a stable frozen `AcpSessionManagerFacade`, not the internal manager class instance. |
     | `plugin-sdk/acp-runtime-backend` | Lightweight ACP backend registration and reply-dispatch helpers for startup-loaded plugins |
     | `plugin-sdk/acp-binding-resolve-runtime` | Read-only ACP binding resolution without lifecycle startup imports |
     | `plugin-sdk/agent-config-primitives` | Deprecated agent runtime config-schema primitives; import schema primitives from a maintained plugin-owned surface |

--- a/scripts/plugin-sdk-surface-report.mjs
+++ b/scripts/plugin-sdk-surface-report.mjs
@@ -244,7 +244,8 @@ export function readPluginSdkSurfaceBudgets(env = process.env) {
       // +2: shared channel replay-guard factory and claim handle.
       // Harvest: retired AudioConfig type -1.
       // +6: shared progress receipt tracker + compositor snapshot across channel barrels.
-      7991,
+      // +1: AcpSessionManagerFacade names the restricted public manager contract.
+      7992,
       env,
     ),
     publicFunctionExports: readPluginSdkSurfaceBudgetEnv(

--- a/src/config/sessions/main-session-recovery.types.ts
+++ b/src/config/sessions/main-session-recovery.types.ts
@@ -1,6 +1,6 @@
 import type { SessionEntry } from "./types.js";
 
-export type MainRestartRecoveryState = {
+type MainRestartRecoveryState = {
   /** Stable identity for one interrupted episode; prevents clear-and-rewedge ABA matches. */
   cycleId: string;
   /** Monotonic identity for observations within the current recovery cycle. */

--- a/src/config/sessions/main-session-recovery.types.ts
+++ b/src/config/sessions/main-session-recovery.types.ts
@@ -1,0 +1,24 @@
+import type { SessionEntry } from "./types.js";
+
+export type MainRestartRecoveryState = {
+  /** Stable identity for one interrupted episode; prevents clear-and-rewedge ABA matches. */
+  cycleId: string;
+  /** Monotonic identity for observations within the current recovery cycle. */
+  revision: number;
+  /** Attempts charged when their reservation is persisted, before dispatch. */
+  chargedAttempts: number;
+  reservation?: {
+    runId: string;
+    attempt: number;
+    lifecycleGeneration: string;
+  };
+  foregroundClaims?: {
+    lifecycleGeneration: string;
+    tokens: string[];
+  };
+  tombstone?: { reason: string };
+};
+
+export type InternalSessionEntry = SessionEntry & {
+  mainRestartRecovery?: MainRestartRecoveryState;
+};

--- a/src/config/sessions/restart-recovery-private-keys.ts
+++ b/src/config/sessions/restart-recovery-private-keys.ts
@@ -1,0 +1,13 @@
+import type { InternalSessionEntry } from "./main-session-recovery.types.js";
+
+export type CoreRestartRecoverySessionEntryKey = Extract<
+  keyof InternalSessionEntry,
+  "mainRestartRecovery" | `restartRecovery${string}`
+>;
+
+/** Core owns this namespace; plugin-visible session rows must never expose or accept it. */
+export function isCoreRestartRecoverySessionEntryKey(key: PropertyKey): boolean {
+  return (
+    key === "mainRestartRecovery" || (typeof key === "string" && key.startsWith("restartRecovery"))
+  );
+}

--- a/src/plugin-sdk/acp-runtime.api-contract.test.ts
+++ b/src/plugin-sdk/acp-runtime.api-contract.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { renderPluginSdkApiBaseline } from "./api-baseline.js";
+
+describe("acp-runtime public API contract", () => {
+  it("declares the manager getter as an explicit facade", async () => {
+    const rendered = await renderPluginSdkApiBaseline({ entrypoints: ["acp-runtime"] });
+    const moduleSurface = rendered.baseline.modules.find(
+      (candidate) => candidate.entrypoint === "acp-runtime",
+    );
+
+    expect(moduleSurface?.exports).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          exportName: "AcpSessionManagerFacade",
+          kind: "interface",
+        }),
+        expect.objectContaining({
+          declaration: expect.stringContaining("AcpSessionManagerFacade"),
+          exportName: "getAcpSessionManager",
+          kind: "function",
+        }),
+      ]),
+    );
+  });
+});

--- a/src/plugin-sdk/acp-runtime.session-isolation.test.ts
+++ b/src/plugin-sdk/acp-runtime.session-isolation.test.ts
@@ -1,0 +1,90 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { upsertAcpSessionMeta } from "../acp/runtime/session-meta.js";
+import type { InternalSessionEntry } from "../config/sessions/main-session-recovery.types.js";
+import {
+  loadSessionEntry as loadInternalSessionEntry,
+  replaceSessionEntry as replaceInternalSessionEntry,
+} from "../config/sessions/session-accessor.js";
+import { getAcpSessionManager, readAcpSessionEntry, testing } from "./acp-runtime.js";
+
+describe("acp-runtime session isolation", () => {
+  let previousStateDir: string | undefined;
+  let storePath: string;
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sdk-acp-runtime-"));
+    storePath = path.join(tempDir, "sessions.json");
+    previousStateDir = process.env.OPENCLAW_STATE_DIR;
+    process.env.OPENCLAW_STATE_DIR = tempDir;
+    testing.resetAcpSessionManagerForTests();
+  });
+
+  afterEach(() => {
+    testing.resetAcpSessionManagerForTests();
+    if (previousStateDir === undefined) {
+      delete process.env.OPENCLAW_STATE_DIR;
+    } else {
+      process.env.OPENCLAW_STATE_DIR = previousStateDir;
+    }
+    fs.rmSync(tempDir, { force: true, recursive: true });
+  });
+
+  it("hides core recovery state through ACP SDK entrypoints", async () => {
+    const sessionKey = "agent:main:main";
+    const cfg = {
+      session: { store: storePath },
+    } as NonNullable<Parameters<typeof readAcpSessionEntry>[0]["cfg"]>;
+    const mainRestartRecovery = {
+      chargedAttempts: 1,
+      cycleId: "acp-cycle",
+      reservation: {
+        attempt: 1,
+        lifecycleGeneration: "acp-generation",
+        runId: "acp-run",
+      },
+      revision: 1,
+    };
+    await replaceInternalSessionEntry({ sessionKey, storePath }, {
+      mainRestartRecovery,
+      sessionId: "acp-session",
+      updatedAt: 10,
+    } as InternalSessionEntry);
+    await upsertAcpSessionMeta({
+      cfg,
+      sessionKey,
+      now: () => 20,
+      mutate: () => ({
+        agent: "acp-agent",
+        backend: "acp-backend",
+        lastActivityAt: 20,
+        mode: "persistent",
+        runtimeSessionName: "acp-runtime-session",
+        state: "idle",
+      }),
+    });
+
+    const direct = readAcpSessionEntry({ cfg, sessionKey });
+    const manager = getAcpSessionManager();
+    const resolved = manager.resolveSession({ cfg, sessionKey });
+
+    expect({
+      directReadExposedPrivateState: Object.hasOwn(direct?.entry ?? {}, "mainRestartRecovery"),
+      managerResolutionExposedPrivateState:
+        resolved.kind === "ready" && Object.hasOwn(resolved.entry ?? {}, "mainRestartRecovery"),
+      managerFacadeIsStable: getAcpSessionManager() === manager,
+      boundManagerMethodWorks: manager.getObservabilitySnapshot(cfg).turns.active === 0,
+    }).toEqual({
+      directReadExposedPrivateState: false,
+      managerResolutionExposedPrivateState: false,
+      managerFacadeIsStable: true,
+      boundManagerMethodWorks: true,
+    });
+    expect(loadInternalSessionEntry({ sessionKey, storePath })?.mainRestartRecovery).toEqual(
+      mainRestartRecovery,
+    );
+  });
+});

--- a/src/plugin-sdk/acp-runtime.session-isolation.test.ts
+++ b/src/plugin-sdk/acp-runtime.session-isolation.test.ts
@@ -14,11 +14,28 @@ import {
   readAcpSessionEntry,
   testing,
   type AcpSessionManagerFacade,
+  type AcpSessionStoreEntry,
 } from "./acp-runtime.js";
 
 type AcpSdkReturnClaimsInternalClass =
   ReturnType<typeof getAcpSessionManager> extends AcpSessionManager ? true : false;
 const acpSdkReturnClaimsInternalClass: AcpSdkReturnClaimsInternalClass = false;
+type AcpStoreEntryExposesCurrentRecovery =
+  "restartRecoveryDeliveryReceiptState" extends keyof NonNullable<AcpSessionStoreEntry["entry"]>
+    ? true
+    : false;
+type AcpReadyResolution = Extract<
+  ReturnType<AcpSessionManagerFacade["resolveSession"]>,
+  { kind: "ready" }
+>;
+type AcpResolutionExposesCurrentRecovery =
+  "restartRecoveryDeliveryReceiptState" extends keyof NonNullable<AcpReadyResolution["entry"]>
+    ? true
+    : false;
+const acpStoreEntryExposesCurrentRecovery: AcpStoreEntryExposesCurrentRecovery = false;
+const acpResolutionExposesCurrentRecovery: AcpResolutionExposesCurrentRecovery = false;
+void acpStoreEntryExposesCurrentRecovery;
+void acpResolutionExposesCurrentRecovery;
 
 describe("acp-runtime session isolation", () => {
   let previousStateDir: string | undefined;
@@ -60,6 +77,9 @@ describe("acp-runtime session isolation", () => {
     };
     await replaceInternalSessionEntry({ sessionKey, storePath }, {
       mainRestartRecovery,
+      restartRecoveryDeliveryReceiptState: "terminal-pending",
+      restartRecoveryDeliveryToolCallId: "acp-message-call",
+      restartRecoveryRequesterAccountId: "acp-account",
       sessionId: "acp-session",
       updatedAt: 10,
     } as InternalSessionEntry);
@@ -84,8 +104,15 @@ describe("acp-runtime session isolation", () => {
 
     expect({
       directReadExposedPrivateState: Object.hasOwn(direct?.entry ?? {}, "mainRestartRecovery"),
+      directReadExposedCurrentRecoveryState: Object.hasOwn(
+        direct?.entry ?? {},
+        "restartRecoveryDeliveryReceiptState",
+      ),
       managerResolutionExposedPrivateState:
         resolved.kind === "ready" && Object.hasOwn(resolved.entry ?? {}, "mainRestartRecovery"),
+      managerResolutionExposedCurrentRecoveryState:
+        resolved.kind === "ready" &&
+        Object.hasOwn(resolved.entry ?? {}, "restartRecoveryDeliveryReceiptState"),
       managerFacadeIsStable: getAcpSessionManager() === manager,
       managerFacadeHidesConstructor: Reflect.get(manager, "constructor") === undefined,
       managerFacadeHidesDeps: Reflect.get(manager, "deps") === undefined,
@@ -94,7 +121,9 @@ describe("acp-runtime session isolation", () => {
       returnTypeClaimsInternalClass: acpSdkReturnClaimsInternalClass,
     }).toEqual({
       directReadExposedPrivateState: false,
+      directReadExposedCurrentRecoveryState: false,
       managerResolutionExposedPrivateState: false,
+      managerResolutionExposedCurrentRecoveryState: false,
       managerFacadeIsStable: true,
       managerFacadeHidesConstructor: true,
       managerFacadeHidesDeps: true,
@@ -106,5 +135,10 @@ describe("acp-runtime session isolation", () => {
       | InternalSessionEntry
       | undefined;
     expect(internalEntry?.mainRestartRecovery).toEqual(mainRestartRecovery);
+    expect(internalEntry).toMatchObject({
+      restartRecoveryDeliveryReceiptState: "terminal-pending",
+      restartRecoveryDeliveryToolCallId: "acp-message-call",
+      restartRecoveryRequesterAccountId: "acp-account",
+    });
   });
 });

--- a/src/plugin-sdk/acp-runtime.session-isolation.test.ts
+++ b/src/plugin-sdk/acp-runtime.session-isolation.test.ts
@@ -83,8 +83,9 @@ describe("acp-runtime session isolation", () => {
       managerFacadeIsStable: true,
       boundManagerMethodWorks: true,
     });
-    expect(loadInternalSessionEntry({ sessionKey, storePath })?.mainRestartRecovery).toEqual(
-      mainRestartRecovery,
-    );
+    const internalEntry = loadInternalSessionEntry({ sessionKey, storePath }) as
+      | InternalSessionEntry
+      | undefined;
+    expect(internalEntry?.mainRestartRecovery).toEqual(mainRestartRecovery);
   });
 });

--- a/src/plugin-sdk/acp-runtime.session-isolation.test.ts
+++ b/src/plugin-sdk/acp-runtime.session-isolation.test.ts
@@ -2,13 +2,23 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { AcpSessionManager } from "../acp/control-plane/manager.js";
 import { upsertAcpSessionMeta } from "../acp/runtime/session-meta.js";
 import type { InternalSessionEntry } from "../config/sessions/main-session-recovery.types.js";
 import {
   loadSessionEntry as loadInternalSessionEntry,
   replaceSessionEntry as replaceInternalSessionEntry,
 } from "../config/sessions/session-accessor.js";
-import { getAcpSessionManager, readAcpSessionEntry, testing } from "./acp-runtime.js";
+import {
+  getAcpSessionManager,
+  readAcpSessionEntry,
+  testing,
+  type AcpSessionManagerFacade,
+} from "./acp-runtime.js";
+
+type AcpSdkReturnClaimsInternalClass =
+  ReturnType<typeof getAcpSessionManager> extends AcpSessionManager ? true : false;
+const acpSdkReturnClaimsInternalClass: AcpSdkReturnClaimsInternalClass = false;
 
 describe("acp-runtime session isolation", () => {
   let previousStateDir: string | undefined;
@@ -69,6 +79,7 @@ describe("acp-runtime session isolation", () => {
 
     const direct = readAcpSessionEntry({ cfg, sessionKey });
     const manager = getAcpSessionManager();
+    const publicManager: AcpSessionManagerFacade = manager;
     const resolved = manager.resolveSession({ cfg, sessionKey });
 
     expect({
@@ -79,7 +90,8 @@ describe("acp-runtime session isolation", () => {
       managerFacadeHidesConstructor: Reflect.get(manager, "constructor") === undefined,
       managerFacadeHidesDeps: Reflect.get(manager, "deps") === undefined,
       managerFacadeHasNullPrototype: Object.getPrototypeOf(manager) === null,
-      boundManagerMethodWorks: manager.getObservabilitySnapshot(cfg).turns.active === 0,
+      boundManagerMethodWorks: publicManager.getObservabilitySnapshot(cfg).turns.active === 0,
+      returnTypeClaimsInternalClass: acpSdkReturnClaimsInternalClass,
     }).toEqual({
       directReadExposedPrivateState: false,
       managerResolutionExposedPrivateState: false,
@@ -88,6 +100,7 @@ describe("acp-runtime session isolation", () => {
       managerFacadeHidesDeps: true,
       managerFacadeHasNullPrototype: true,
       boundManagerMethodWorks: true,
+      returnTypeClaimsInternalClass: false,
     });
     const internalEntry = loadInternalSessionEntry({ sessionKey, storePath }) as
       | InternalSessionEntry

--- a/src/plugin-sdk/acp-runtime.session-isolation.test.ts
+++ b/src/plugin-sdk/acp-runtime.session-isolation.test.ts
@@ -76,11 +76,17 @@ describe("acp-runtime session isolation", () => {
       managerResolutionExposedPrivateState:
         resolved.kind === "ready" && Object.hasOwn(resolved.entry ?? {}, "mainRestartRecovery"),
       managerFacadeIsStable: getAcpSessionManager() === manager,
+      managerFacadeHidesConstructor: Reflect.get(manager, "constructor") === undefined,
+      managerFacadeHidesDeps: Reflect.get(manager, "deps") === undefined,
+      managerFacadeHasNullPrototype: Object.getPrototypeOf(manager) === null,
       boundManagerMethodWorks: manager.getObservabilitySnapshot(cfg).turns.active === 0,
     }).toEqual({
       directReadExposedPrivateState: false,
       managerResolutionExposedPrivateState: false,
       managerFacadeIsStable: true,
+      managerFacadeHidesConstructor: true,
+      managerFacadeHidesDeps: true,
+      managerFacadeHasNullPrototype: true,
       boundManagerMethodWorks: true,
     });
     const internalEntry = loadInternalSessionEntry({ sessionKey, storePath }) as

--- a/src/plugin-sdk/acp-runtime.ts
+++ b/src/plugin-sdk/acp-runtime.ts
@@ -14,7 +14,9 @@ import type { InternalSessionEntry } from "../config/sessions/main-session-recov
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { projectPluginSessionEntry } from "../plugins/runtime/session-store-facade.js";
 
-const pluginAcpManagerFacades = new WeakMap<AcpSessionManager, AcpSessionManager>();
+type PluginAcpSessionManagerFacade = Pick<AcpSessionManager, keyof AcpSessionManager>;
+
+const pluginAcpManagerFacades = new WeakMap<AcpSessionManager, PluginAcpSessionManagerFacade>();
 
 function projectAcpSessionStoreEntry(
   storeEntry: AcpSessionStoreEntry | null,
@@ -44,9 +46,8 @@ export function getAcpSessionManager(): AcpSessionManager {
   const manager = getInternalAcpSessionManager();
   const existing = pluginAcpManagerFacades.get(manager);
   if (existing) {
-    return existing;
+    return existing as AcpSessionManager;
   }
-  const boundMethods = new Map<PropertyKey, unknown>();
   const resolveSession = ((params: Parameters<AcpSessionManager["resolveSession"]>[0]) => {
     const resolved = manager.resolveSession(params);
     if (resolved.kind !== "ready" || !resolved.entry) {
@@ -57,26 +58,24 @@ export function getAcpSessionManager(): AcpSessionManager {
       entry: projectPluginSessionEntry(resolved.entry as InternalSessionEntry),
     };
   }) as AcpSessionManager["resolveSession"];
-  const facade = new Proxy(manager, {
-    get(target, property) {
-      if (property === "resolveSession") {
-        return resolveSession;
-      }
-      const value = Reflect.get(target, property, target);
-      if (typeof value !== "function") {
-        return value;
-      }
-      const cached = boundMethods.get(property);
-      if (cached) {
-        return cached;
-      }
-      const bound = value.bind(target);
-      boundMethods.set(property, bound);
-      return bound;
-    },
-  });
+  const facade = {
+    resolveSession,
+    getObservabilitySnapshot: manager.getObservabilitySnapshot.bind(manager),
+    reconcilePendingSessionIdentities: manager.reconcilePendingSessionIdentities.bind(manager),
+    initializeSession: manager.initializeSession.bind(manager),
+    getSessionStatus: manager.getSessionStatus.bind(manager),
+    setSessionRuntimeMode: manager.setSessionRuntimeMode.bind(manager),
+    setSessionConfigOption: manager.setSessionConfigOption.bind(manager),
+    updateSessionRuntimeOptions: manager.updateSessionRuntimeOptions.bind(manager),
+    resetSessionRuntimeOptions: manager.resetSessionRuntimeOptions.bind(manager),
+    runTurn: manager.runTurn.bind(manager),
+    cancelSession: manager.cancelSession.bind(manager),
+    closeSession: manager.closeSession.bind(manager),
+  } satisfies PluginAcpSessionManagerFacade;
+  Object.setPrototypeOf(facade, null);
+  Object.freeze(facade);
   pluginAcpManagerFacades.set(manager, facade);
-  return facade;
+  return facade as AcpSessionManager;
 }
 
 export { AcpRuntimeError, isAcpRuntimeError } from "../acp/runtime/errors.js";

--- a/src/plugin-sdk/acp-runtime.ts
+++ b/src/plugin-sdk/acp-runtime.ts
@@ -10,7 +10,7 @@ import {
   type AcpManagerObservabilitySnapshot,
   type AcpRunTurnInput,
   type AcpSessionManager as InternalAcpSessionManager,
-  type AcpSessionResolution,
+  type AcpSessionResolution as InternalAcpSessionResolution,
   type AcpSessionRuntimeOptions,
   type AcpSessionStatus,
   type AcpStartupIdentityReconcileResult,
@@ -18,12 +18,25 @@ import {
 import { testing as registryTesting } from "../acp/runtime/registry.js";
 import {
   readAcpSessionEntry as readInternalAcpSessionEntry,
-  type AcpSessionStoreEntry,
+  type AcpSessionStoreEntry as InternalAcpSessionStoreEntry,
 } from "../acp/runtime/session-meta.js";
 import type { InternalSessionEntry } from "../config/sessions/main-session-recovery.types.js";
 import type { SessionAcpMeta } from "../config/sessions/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { projectPluginSessionEntry } from "../plugins/runtime/session-store-facade.js";
+import {
+  projectPluginSessionEntry,
+  type PluginSessionEntry,
+} from "../plugins/runtime/session-store-facade.js";
+
+type AcpSessionResolution =
+  | Exclude<InternalAcpSessionResolution, { kind: "ready" }>
+  | (Omit<Extract<InternalAcpSessionResolution, { kind: "ready" }>, "entry"> & {
+      entry?: PluginSessionEntry;
+    });
+
+export type AcpSessionStoreEntry = Omit<InternalAcpSessionStoreEntry, "entry"> & {
+  entry?: PluginSessionEntry;
+};
 
 /** Public ACP manager methods exposed without the internal class instance or dependencies. */
 export interface AcpSessionManagerFacade {
@@ -74,7 +87,7 @@ export interface AcpSessionManagerFacade {
 const pluginAcpManagerFacades = new WeakMap<InternalAcpSessionManager, AcpSessionManagerFacade>();
 
 function projectAcpSessionStoreEntry(
-  storeEntry: AcpSessionStoreEntry | null,
+  storeEntry: InternalAcpSessionStoreEntry | null,
 ): AcpSessionStoreEntry | null {
   if (!storeEntry?.entry) {
     return storeEntry;
@@ -161,7 +174,6 @@ export type {
   AcpRuntimeTurnResultError,
   AcpSessionUpdateTag,
 } from "@openclaw/acp-core/runtime/types";
-export type { AcpSessionStoreEntry } from "../acp/runtime/session-meta.js";
 export { tryDispatchAcpReplyHook } from "./acp-runtime-backend.js";
 
 // Keep test helpers off the hot init path. Eagerly merging them here can

--- a/src/plugin-sdk/acp-runtime.ts
+++ b/src/plugin-sdk/acp-runtime.ts
@@ -1,9 +1,84 @@
 // Public ACP runtime helpers for plugins that integrate with ACP control/session state.
 
-import { testing as managerTesting, getAcpSessionManager } from "../acp/control-plane/manager.js";
+import {
+  testing as managerTesting,
+  getAcpSessionManager as getInternalAcpSessionManager,
+  type AcpSessionManager,
+} from "../acp/control-plane/manager.js";
 import { testing as registryTesting } from "../acp/runtime/registry.js";
+import {
+  readAcpSessionEntry as readInternalAcpSessionEntry,
+  type AcpSessionStoreEntry,
+} from "../acp/runtime/session-meta.js";
+import type { InternalSessionEntry } from "../config/sessions/main-session-recovery.types.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { projectPluginSessionEntry } from "../plugins/runtime/session-store-facade.js";
 
-export { getAcpSessionManager };
+const pluginAcpManagerFacades = new WeakMap<AcpSessionManager, AcpSessionManager>();
+
+function projectAcpSessionStoreEntry(
+  storeEntry: AcpSessionStoreEntry | null,
+): AcpSessionStoreEntry | null {
+  if (!storeEntry?.entry) {
+    return storeEntry;
+  }
+  return {
+    ...storeEntry,
+    entry: projectPluginSessionEntry(storeEntry.entry as InternalSessionEntry),
+  };
+}
+
+/** Reads ACP metadata while keeping core-only session coordination private. */
+export function readAcpSessionEntry(params: {
+  sessionKey: string;
+  cfg?: OpenClawConfig;
+  clone?: boolean;
+  env?: NodeJS.ProcessEnv;
+  databasePath?: string;
+}): AcpSessionStoreEntry | null {
+  return projectAcpSessionStoreEntry(readInternalAcpSessionEntry(params));
+}
+
+/** Returns the ACP manager through the same plugin-facing session projection boundary. */
+export function getAcpSessionManager(): AcpSessionManager {
+  const manager = getInternalAcpSessionManager();
+  const existing = pluginAcpManagerFacades.get(manager);
+  if (existing) {
+    return existing;
+  }
+  const boundMethods = new Map<PropertyKey, unknown>();
+  const resolveSession = ((params: Parameters<AcpSessionManager["resolveSession"]>[0]) => {
+    const resolved = manager.resolveSession(params);
+    if (resolved.kind !== "ready" || !resolved.entry) {
+      return resolved;
+    }
+    return {
+      ...resolved,
+      entry: projectPluginSessionEntry(resolved.entry as InternalSessionEntry),
+    };
+  }) as AcpSessionManager["resolveSession"];
+  const facade = new Proxy(manager, {
+    get(target, property) {
+      if (property === "resolveSession") {
+        return resolveSession;
+      }
+      const value = Reflect.get(target, property, target);
+      if (typeof value !== "function") {
+        return value;
+      }
+      const cached = boundMethods.get(property);
+      if (cached) {
+        return cached;
+      }
+      const bound = value.bind(target);
+      boundMethods.set(property, bound);
+      return bound;
+    },
+  });
+  pluginAcpManagerFacades.set(manager, facade);
+  return facade;
+}
+
 export { AcpRuntimeError, isAcpRuntimeError } from "../acp/runtime/errors.js";
 export type { AcpRuntimeErrorCode } from "../acp/runtime/errors.js";
 export {
@@ -27,7 +102,6 @@ export type {
   AcpRuntimeTurnResultError,
   AcpSessionUpdateTag,
 } from "@openclaw/acp-core/runtime/types";
-export { readAcpSessionEntry } from "../acp/runtime/session-meta.js";
 export type { AcpSessionStoreEntry } from "../acp/runtime/session-meta.js";
 export { tryDispatchAcpReplyHook } from "./acp-runtime-backend.js";
 

--- a/src/plugin-sdk/acp-runtime.ts
+++ b/src/plugin-sdk/acp-runtime.ts
@@ -1,9 +1,19 @@
 // Public ACP runtime helpers for plugins that integrate with ACP control/session state.
 
+import type { AcpRuntime, AcpRuntimeHandle } from "@openclaw/acp-core/runtime/types";
 import {
   testing as managerTesting,
   getAcpSessionManager as getInternalAcpSessionManager,
-  type AcpSessionManager,
+  type AcpCloseSessionInput,
+  type AcpCloseSessionResult,
+  type AcpInitializeSessionInput,
+  type AcpManagerObservabilitySnapshot,
+  type AcpRunTurnInput,
+  type AcpSessionManager as InternalAcpSessionManager,
+  type AcpSessionResolution,
+  type AcpSessionRuntimeOptions,
+  type AcpSessionStatus,
+  type AcpStartupIdentityReconcileResult,
 } from "../acp/control-plane/manager.js";
 import { testing as registryTesting } from "../acp/runtime/registry.js";
 import {
@@ -11,12 +21,57 @@ import {
   type AcpSessionStoreEntry,
 } from "../acp/runtime/session-meta.js";
 import type { InternalSessionEntry } from "../config/sessions/main-session-recovery.types.js";
+import type { SessionAcpMeta } from "../config/sessions/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { projectPluginSessionEntry } from "../plugins/runtime/session-store-facade.js";
 
-type PluginAcpSessionManagerFacade = Pick<AcpSessionManager, keyof AcpSessionManager>;
+/** Public ACP manager methods exposed without the internal class instance or dependencies. */
+export interface AcpSessionManagerFacade {
+  resolveSession(params: { cfg: OpenClawConfig; sessionKey: string }): AcpSessionResolution;
+  getObservabilitySnapshot(cfg: OpenClawConfig): AcpManagerObservabilitySnapshot;
+  reconcilePendingSessionIdentities(params: {
+    cfg: OpenClawConfig;
+  }): Promise<AcpStartupIdentityReconcileResult>;
+  initializeSession(input: AcpInitializeSessionInput): Promise<{
+    runtime: AcpRuntime;
+    handle: AcpRuntimeHandle;
+    meta: SessionAcpMeta;
+  }>;
+  getSessionStatus(params: {
+    cfg: OpenClawConfig;
+    sessionKey: string;
+    signal?: AbortSignal;
+  }): Promise<AcpSessionStatus>;
+  setSessionRuntimeMode(params: {
+    cfg: OpenClawConfig;
+    sessionKey: string;
+    runtimeMode: string;
+  }): Promise<AcpSessionRuntimeOptions>;
+  setSessionConfigOption(params: {
+    cfg: OpenClawConfig;
+    sessionKey: string;
+    key: string;
+    value: string;
+  }): Promise<AcpSessionRuntimeOptions>;
+  updateSessionRuntimeOptions(params: {
+    cfg: OpenClawConfig;
+    sessionKey: string;
+    patch: Partial<AcpSessionRuntimeOptions>;
+  }): Promise<AcpSessionRuntimeOptions>;
+  resetSessionRuntimeOptions(params: {
+    cfg: OpenClawConfig;
+    sessionKey: string;
+  }): Promise<AcpSessionRuntimeOptions>;
+  runTurn(input: AcpRunTurnInput): Promise<void>;
+  cancelSession(params: {
+    cfg: OpenClawConfig;
+    sessionKey: string;
+    reason?: string;
+  }): Promise<void>;
+  closeSession(input: AcpCloseSessionInput): Promise<AcpCloseSessionResult>;
+}
 
-const pluginAcpManagerFacades = new WeakMap<AcpSessionManager, PluginAcpSessionManagerFacade>();
+const pluginAcpManagerFacades = new WeakMap<InternalAcpSessionManager, AcpSessionManagerFacade>();
 
 function projectAcpSessionStoreEntry(
   storeEntry: AcpSessionStoreEntry | null,
@@ -41,14 +96,19 @@ export function readAcpSessionEntry(params: {
   return projectAcpSessionStoreEntry(readInternalAcpSessionEntry(params));
 }
 
-/** Returns the ACP manager through the same plugin-facing session projection boundary. */
-export function getAcpSessionManager(): AcpSessionManager {
+/**
+ * Returns a stable, frozen facade over the ACP manager.
+ *
+ * The facade deliberately has no internal class identity or prototype so plugins cannot bypass
+ * the session projection boundary through the manager constructor.
+ */
+export function getAcpSessionManager(): AcpSessionManagerFacade {
   const manager = getInternalAcpSessionManager();
   const existing = pluginAcpManagerFacades.get(manager);
   if (existing) {
-    return existing as AcpSessionManager;
+    return existing;
   }
-  const resolveSession = ((params: Parameters<AcpSessionManager["resolveSession"]>[0]) => {
+  const resolveSession: AcpSessionManagerFacade["resolveSession"] = (params) => {
     const resolved = manager.resolveSession(params);
     if (resolved.kind !== "ready" || !resolved.entry) {
       return resolved;
@@ -57,7 +117,7 @@ export function getAcpSessionManager(): AcpSessionManager {
       ...resolved,
       entry: projectPluginSessionEntry(resolved.entry as InternalSessionEntry),
     };
-  }) as AcpSessionManager["resolveSession"];
+  };
   const facade = {
     resolveSession,
     getObservabilitySnapshot: manager.getObservabilitySnapshot.bind(manager),
@@ -71,11 +131,11 @@ export function getAcpSessionManager(): AcpSessionManager {
     runTurn: manager.runTurn.bind(manager),
     cancelSession: manager.cancelSession.bind(manager),
     closeSession: manager.closeSession.bind(manager),
-  } satisfies PluginAcpSessionManagerFacade;
+  } satisfies AcpSessionManagerFacade;
   Object.setPrototypeOf(facade, null);
   Object.freeze(facade);
   pluginAcpManagerFacades.set(manager, facade);
-  return facade as AcpSessionManager;
+  return facade;
 }
 
 export { AcpRuntimeError, isAcpRuntimeError } from "../acp/runtime/errors.js";

--- a/src/plugin-sdk/config-runtime.ts
+++ b/src/plugin-sdk/config-runtime.ts
@@ -9,6 +9,8 @@ export {
   listSessionEntries,
   patchSessionEntry,
   readSessionUpdatedAt,
+  recordSessionMetaFromInbound,
+  updateLastRoute,
   updateSessionStoreEntry,
   upsertSessionEntry,
 } from "./session-store-runtime.js";
@@ -140,12 +142,6 @@ export type {
   TtsProvider,
 } from "../config/types.js";
 export { clearSessionStoreCacheForTest } from "../config/sessions/store.js";
-// SDK-facing names are a shipped plugin contract; internals route through the
-// session accessor so the storage backend can change beneath them.
-export {
-  recordInboundSessionMeta as recordSessionMetaFromInbound,
-  updateSessionLastRoute as updateLastRoute,
-} from "../config/sessions/session-accessor.js";
 export { resolveSessionKey } from "../config/sessions/session-key.js";
 export { resolveStorePath } from "../config/sessions/paths.js";
 export type { SessionResetMode } from "../config/sessions/reset.js";

--- a/src/plugin-sdk/config-types.ts
+++ b/src/plugin-sdk/config-types.ts
@@ -7,4 +7,5 @@ export type * from "../config/types.js";
 export type { ConfigWriteAfterWrite } from "../config/runtime-snapshot.js";
 export type { ChannelGroupPolicy } from "../config/group-policy.js";
 export type { SessionResetMode } from "../config/sessions/reset.js";
-export type { SessionEntry, SessionScope } from "../config/sessions/types.js";
+export type { PluginSessionEntry as SessionEntry } from "../plugins/runtime/session-store-facade.js";
+export type { SessionScope } from "../config/sessions/types.js";

--- a/src/plugin-sdk/session-store-runtime.current-recovery-isolation.test.ts
+++ b/src/plugin-sdk/session-store-runtime.current-recovery-isolation.test.ts
@@ -1,0 +1,92 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { expect, it } from "vitest";
+import {
+  loadSessionEntry as loadInternalSessionEntry,
+  replaceSessionEntry as replaceInternalSessionEntry,
+} from "../config/sessions/session-accessor.js";
+import type { SessionEntry as ConfigSessionEntry } from "./config-types.js";
+import {
+  getSessionEntry,
+  listSessionEntries,
+  patchSessionEntry,
+  updateSessionStore,
+  type SessionEntry,
+} from "./session-store-runtime.js";
+
+const sessionEntryKeepsCurrentRecoveryPrivate: "restartRecoveryDeliveryReceiptState" extends keyof SessionEntry
+  ? false
+  : true = true;
+const configSessionEntryKeepsCurrentRecoveryPrivate: "restartRecoveryDeliveryReceiptState" extends keyof ConfigSessionEntry
+  ? false
+  : true = true;
+void sessionEntryKeepsCurrentRecoveryPrivate;
+void configSessionEntryKeepsCurrentRecoveryPrivate;
+
+it("hides and preserves the shipped restart recovery coordination fields", async () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sdk-current-recovery-"));
+  const storePath = path.join(tempDir, "sessions.json");
+  const sessionKey = "agent:main:recovery-coordination";
+  const recoveryState = {
+    restartRecoveryBeforeAgentReplyState: "continue" as const,
+    restartRecoveryDeliveryReceiptState: "terminal-pending" as const,
+    restartRecoveryDeliveryToolCallId: "message-call-1",
+    restartRecoveryForceSafeTools: true as const,
+    restartRecoveryRequesterAccountId: "account-1",
+    restartRecoveryRuns: [{ lifecycleGeneration: "generation-1", runId: "run-1" }],
+    restartRecoverySourceIngress: "channel" as const,
+  };
+
+  try {
+    await replaceInternalSessionEntry(
+      { sessionKey, storePath },
+      {
+        ...recoveryState,
+        model: "gpt-5.5",
+        sessionId: "session-recovery-coordination",
+        updatedAt: 10,
+      },
+    );
+
+    const direct = getSessionEntry({ sessionKey, storePath });
+    const listed = listSessionEntries({ storePath })[0]?.entry;
+    for (const field of Object.keys(recoveryState)) {
+      expect(direct).not.toHaveProperty(field);
+      expect(listed).not.toHaveProperty(field);
+    }
+
+    await patchSessionEntry({
+      sessionKey,
+      storePath,
+      update: (entry) => {
+        expect(entry).not.toHaveProperty("restartRecoveryDeliveryReceiptState");
+        return {
+          model: "gpt-5.6",
+          restartRecoveryDeliveryReceiptState: "delivered-terminal",
+          restartRecoveryRequesterAccountId: "plugin-account",
+        } as unknown as Partial<SessionEntry>;
+      },
+    });
+
+    expect(loadInternalSessionEntry({ sessionKey, storePath })).toMatchObject({
+      ...recoveryState,
+      model: "gpt-5.6",
+    });
+
+    await updateSessionStore(
+      storePath,
+      (store) => {
+        expect(store[sessionKey]).not.toHaveProperty("restartRecoveryDeliveryReceiptState");
+        Object.assign(store[sessionKey]!, {
+          restartRecoveryDeliveryReceiptState: "delivered-terminal",
+          restartRecoveryRequesterAccountId: "whole-store-plugin-account",
+        });
+      },
+      { skipMaintenance: true },
+    );
+    expect(loadInternalSessionEntry({ sessionKey, storePath })).toMatchObject(recoveryState);
+  } finally {
+    fs.rmSync(tempDir, { force: true, recursive: true });
+  }
+});

--- a/src/plugin-sdk/session-store-runtime.key-move.test.ts
+++ b/src/plugin-sdk/session-store-runtime.key-move.test.ts
@@ -1,0 +1,123 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { InternalSessionEntry } from "../config/sessions/main-session-recovery.types.js";
+import {
+  loadSessionEntry as loadInternalSessionEntry,
+  replaceSessionEntry as replaceInternalSessionEntry,
+} from "../config/sessions/session-accessor.js";
+import { reconcilePluginSessionStore } from "../plugins/runtime/session-store-facade.js";
+import { updateSessionStore } from "./session-store-runtime.js";
+
+describe("session-store-runtime whole-store key moves", () => {
+  let tempDir: string;
+  let storePath: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sdk-session-key-move-"));
+    storePath = path.join(tempDir, "sessions.json");
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { force: true, recursive: true });
+  });
+
+  it("preserves recovery when a unique session identity moves keys", async () => {
+    const oldKey = "agent:main:telegram:direct:old";
+    const newKey = "agent:main:telegram:direct:new";
+    const mainRestartRecovery = {
+      chargedAttempts: 2,
+      cycleId: "key-move-cycle",
+      revision: 4,
+    };
+    await replaceInternalSessionEntry({ agentId: "main", sessionKey: oldKey, storePath }, {
+      mainRestartRecovery,
+      sessionId: "key-move-session",
+      updatedAt: 10,
+    } as InternalSessionEntry);
+
+    await updateSessionStore(
+      storePath,
+      (store) => {
+        store[newKey] = store[oldKey]!;
+        delete store[oldKey];
+      },
+      { skipMaintenance: true },
+    );
+
+    expect(
+      loadInternalSessionEntry({ agentId: "main", sessionKey: oldKey, storePath }),
+    ).toBeUndefined();
+    expect(
+      loadInternalSessionEntry({ agentId: "main", sessionKey: newKey, storePath }),
+    ).toMatchObject({
+      mainRestartRecovery,
+      sessionId: "key-move-session",
+    });
+  });
+
+  it("does not duplicate recovery across ambiguous move destinations", async () => {
+    const oldKey = "agent:main:telegram:direct:old";
+    const firstNewKey = "agent:main:telegram:direct:new-a";
+    const secondNewKey = "agent:main:telegram:direct:new-b";
+    await replaceInternalSessionEntry({ agentId: "main", sessionKey: oldKey, storePath }, {
+      mainRestartRecovery: {
+        chargedAttempts: 2,
+        cycleId: "ambiguous-key-move-cycle",
+        revision: 4,
+      },
+      sessionId: "ambiguous-key-move-session",
+      updatedAt: 10,
+    } as InternalSessionEntry);
+
+    await updateSessionStore(
+      storePath,
+      (store) => {
+        store[firstNewKey] = { ...store[oldKey]! };
+        store[secondNewKey] = { ...store[oldKey]! };
+        delete store[oldKey];
+      },
+      { skipMaintenance: true },
+    );
+
+    expect(
+      loadInternalSessionEntry({ agentId: "main", sessionKey: firstNewKey, storePath }),
+    ).not.toHaveProperty("mainRestartRecovery");
+    expect(
+      loadInternalSessionEntry({ agentId: "main", sessionKey: secondNewKey, storePath }),
+    ).not.toHaveProperty("mainRestartRecovery");
+  });
+
+  it("does not guess recovery across ambiguous source identities", () => {
+    const firstOldKey = "agent:main:telegram:direct:old-a";
+    const secondOldKey = "agent:main:telegram:direct:old-b";
+    const newKey = "agent:main:telegram:direct:new";
+    const sessionId = "ambiguous-source-session";
+    const internalStore: Record<string, InternalSessionEntry> = {
+      [firstOldKey]: {
+        mainRestartRecovery: {
+          chargedAttempts: 2,
+          cycleId: "ambiguous-source-cycle",
+          revision: 4,
+        },
+        sessionId,
+        updatedAt: 10,
+      },
+      [secondOldKey]: {
+        sessionId,
+        updatedAt: 20,
+      },
+    };
+    const publicStore = {
+      [newKey]: {
+        sessionId,
+        updatedAt: 10,
+      },
+    };
+
+    reconcilePluginSessionStore({ internalStore, publicStore });
+
+    expect(internalStore[newKey]).not.toHaveProperty("mainRestartRecovery");
+  });
+});

--- a/src/plugin-sdk/session-store-runtime.key-move.test.ts
+++ b/src/plugin-sdk/session-store-runtime.key-move.test.ts
@@ -31,8 +31,15 @@ describe("session-store-runtime whole-store key moves", () => {
       cycleId: "key-move-cycle",
       revision: 4,
     };
+    const restartRecoveryState = {
+      restartRecoveryDeliveryReceiptState: "terminal-pending" as const,
+      restartRecoveryDeliveryToolCallId: "message-call-key-move",
+      restartRecoveryRequesterAccountId: "account-key-move",
+      restartRecoverySourceIngress: "channel" as const,
+    };
     await replaceInternalSessionEntry({ agentId: "main", sessionKey: oldKey, storePath }, {
       mainRestartRecovery,
+      ...restartRecoveryState,
       sessionId: "key-move-session",
       updatedAt: 10,
     } as InternalSessionEntry);
@@ -53,6 +60,7 @@ describe("session-store-runtime whole-store key moves", () => {
       loadInternalSessionEntry({ agentId: "main", sessionKey: newKey, storePath }),
     ).toMatchObject({
       mainRestartRecovery,
+      ...restartRecoveryState,
       sessionId: "key-move-session",
     });
   });
@@ -67,6 +75,7 @@ describe("session-store-runtime whole-store key moves", () => {
         cycleId: "ambiguous-key-move-cycle",
         revision: 4,
       },
+      restartRecoveryDeliveryReceiptState: "terminal-pending",
       sessionId: "ambiguous-key-move-session",
       updatedAt: 10,
     } as InternalSessionEntry);
@@ -87,6 +96,12 @@ describe("session-store-runtime whole-store key moves", () => {
     expect(
       loadInternalSessionEntry({ agentId: "main", sessionKey: secondNewKey, storePath }),
     ).not.toHaveProperty("mainRestartRecovery");
+    expect(
+      loadInternalSessionEntry({ agentId: "main", sessionKey: firstNewKey, storePath }),
+    ).not.toHaveProperty("restartRecoveryDeliveryReceiptState");
+    expect(
+      loadInternalSessionEntry({ agentId: "main", sessionKey: secondNewKey, storePath }),
+    ).not.toHaveProperty("restartRecoveryDeliveryReceiptState");
   });
 
   it("does not guess recovery across ambiguous source identities", () => {
@@ -101,6 +116,7 @@ describe("session-store-runtime whole-store key moves", () => {
           cycleId: "ambiguous-source-cycle",
           revision: 4,
         },
+        restartRecoveryDeliveryReceiptState: "terminal-pending",
         sessionId,
         updatedAt: 10,
       },
@@ -119,5 +135,6 @@ describe("session-store-runtime whole-store key moves", () => {
     reconcilePluginSessionStore({ internalStore, publicStore });
 
     expect(internalStore[newKey]).not.toHaveProperty("mainRestartRecovery");
+    expect(internalStore[newKey]).not.toHaveProperty("restartRecoveryDeliveryReceiptState");
   });
 });

--- a/src/plugin-sdk/session-store-runtime.test.ts
+++ b/src/plugin-sdk/session-store-runtime.test.ts
@@ -2,10 +2,15 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { InternalSessionEntry } from "../config/sessions/main-session-recovery.types.js";
 import {
   appendTranscriptEvent,
   appendTranscriptMessage,
+  loadSessionEntry as loadInternalSessionEntry,
+  patchSessionEntry as patchInternalSessionEntry,
+  replaceSessionEntry as replaceInternalSessionEntry,
 } from "../config/sessions/session-accessor.js";
+import type { SessionEntry as ConfigSessionEntry } from "./config-types.js";
 import {
   cleanupSessionLifecycleArtifacts,
   deleteSessionEntry,
@@ -14,18 +19,28 @@ import {
   loadSessionStore,
   patchSessionEntry,
   readSessionUpdatedAt,
+  recordSessionMetaFromInbound,
   resolveSessionFilePath,
   resolveSessionStoreEntry,
   resolveSessionStoreBackupPaths,
   resolveStorePath,
   updateSessionStore,
   updateSessionStoreEntry,
+  updateLastRoute,
   upsertSessionEntry,
   type SessionEntry,
 } from "./session-store-runtime.js";
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 const LEGACY_TRANSCRIPT_INSPECTION_MAX_BYTES = 16 * 1024 * 1024;
+const sessionEntryKeepsRecoveryPrivate: "mainRestartRecovery" extends keyof SessionEntry
+  ? false
+  : true = true;
+const configSessionEntryKeepsRecoveryPrivate: "mainRestartRecovery" extends keyof ConfigSessionEntry
+  ? false
+  : true = true;
+void sessionEntryKeepsRecoveryPrivate;
+void configSessionEntryKeepsRecoveryPrivate;
 
 describe("session-store-runtime compatibility surface", () => {
   let tempDir: string;
@@ -99,6 +114,271 @@ describe("session-store-runtime compatibility surface", () => {
       },
     });
     expect(getSessionEntry({ sessionKey, storePath })?.model).toBeUndefined();
+  });
+
+  it("hides core recovery state and preserves it across public mutations", async () => {
+    const sessionKey = "agent:main:recovery-owned";
+    const mainRestartRecovery = {
+      chargedAttempts: 1,
+      cycleId: "cycle-1",
+      reservation: {
+        attempt: 1,
+        lifecycleGeneration: "generation-1",
+        runId: "run-1",
+      },
+      revision: 1,
+    };
+    await replaceInternalSessionEntry({ sessionKey, storePath }, {
+      mainRestartRecovery,
+      model: "gpt-5.5",
+      sessionId: "session-recovery",
+      updatedAt: 10,
+    } as InternalSessionEntry);
+
+    expect(getSessionEntry({ sessionKey, storePath })).not.toHaveProperty("mainRestartRecovery");
+    expect(listSessionEntries({ storePath })[0]?.entry).not.toHaveProperty("mainRestartRecovery");
+
+    const recorded = await recordSessionMetaFromInbound({
+      createIfMissing: false,
+      ctx: {
+        From: "user:1",
+        OriginatingChannel: "telegram",
+        To: "bot:1",
+      },
+      sessionKey,
+      storePath,
+    });
+    expect(recorded).not.toHaveProperty("mainRestartRecovery");
+    const routed = await updateLastRoute({
+      channel: "telegram",
+      sessionKey,
+      storePath,
+      to: "user:1",
+    });
+    expect(routed).not.toHaveProperty("mainRestartRecovery");
+    expect(loadInternalSessionEntry({ sessionKey, storePath })).toMatchObject({
+      mainRestartRecovery,
+      lastChannel: "telegram",
+      lastTo: "user:1",
+    });
+
+    await patchSessionEntry({
+      sessionKey,
+      storePath,
+      update: () =>
+        ({ model: "gpt-5.6", mainRestartRecovery: undefined }) as unknown as Partial<SessionEntry>,
+    });
+
+    expect(loadInternalSessionEntry({ sessionKey, storePath })).toMatchObject({
+      mainRestartRecovery,
+      model: "gpt-5.6",
+    });
+
+    await upsertSessionEntry({
+      sessionKey,
+      storePath,
+      entry: {
+        sessionId: "session-recovery",
+        updatedAt: 20,
+      },
+    });
+    expect(loadInternalSessionEntry({ sessionKey, storePath })).toMatchObject({
+      mainRestartRecovery,
+      sessionId: "session-recovery",
+      updatedAt: 20,
+    });
+    expect(loadInternalSessionEntry({ sessionKey, storePath })?.model).toBeUndefined();
+  });
+
+  it("clears core recovery state when public replacements change session identity", async () => {
+    const patchKey = "agent:main:telegram:direct:patch-rotation";
+    const upsertKey = "agent:main:telegram:direct:upsert-rotation";
+    const upsertStorePath = path.join(tempDir, "upsert-sessions.json");
+    const mainRestartRecovery = {
+      chargedAttempts: 1,
+      cycleId: "rotation-cycle",
+      revision: 1,
+    };
+    await seedSessionEntry(patchKey, { sessionId: "patch-before", updatedAt: 10 });
+    await patchInternalSessionEntry(
+      { agentId: "main", sessionKey: patchKey, storePath },
+      () => ({ mainRestartRecovery }) as Partial<InternalSessionEntry>,
+    );
+    await upsertSessionEntry({
+      agentId: "main",
+      entry: { sessionId: "upsert-before", updatedAt: 10 },
+      sessionKey: upsertKey,
+      storePath: upsertStorePath,
+    });
+    await patchInternalSessionEntry(
+      { agentId: "main", sessionKey: upsertKey, storePath: upsertStorePath },
+      () => ({ mainRestartRecovery }) as Partial<InternalSessionEntry>,
+    );
+
+    await patchSessionEntry({
+      replaceEntry: true,
+      sessionKey: patchKey,
+      storePath,
+      update: () => ({ sessionId: "patch-after", updatedAt: 20 }),
+    });
+    await upsertSessionEntry({
+      entry: { sessionId: "upsert-after", updatedAt: 20 },
+      sessionKey: upsertKey,
+      storePath: upsertStorePath,
+    });
+
+    expect(loadInternalSessionEntry({ sessionKey: patchKey, storePath })).toMatchObject({
+      sessionId: "patch-after",
+    });
+    expect(loadInternalSessionEntry({ sessionKey: patchKey, storePath })).not.toHaveProperty(
+      "mainRestartRecovery",
+    );
+    expect(
+      loadInternalSessionEntry({ sessionKey: upsertKey, storePath: upsertStorePath }),
+    ).toMatchObject({ sessionId: "upsert-after" });
+    expect(
+      loadInternalSessionEntry({ sessionKey: upsertKey, storePath: upsertStorePath }),
+    ).not.toHaveProperty("mainRestartRecovery");
+  });
+
+  it("clears core recovery state when public patches change session identity", async () => {
+    const patchKey = "agent:main:telegram:direct:patch-rotation";
+    const updateKey = "agent:main:telegram:direct:update-rotation";
+    const updateStorePath = path.join(tempDir, "update-patch-sessions.json");
+    const mainRestartRecovery = {
+      chargedAttempts: 1,
+      cycleId: "rotation-cycle",
+      revision: 1,
+    };
+    await seedSessionEntry(patchKey, { sessionId: "patch-before", updatedAt: 10 });
+    await upsertSessionEntry({
+      agentId: "main",
+      entry: { sessionId: "update-before", updatedAt: 10 },
+      sessionKey: updateKey,
+      storePath: updateStorePath,
+    });
+    await patchInternalSessionEntry(
+      { agentId: "main", sessionKey: patchKey, storePath },
+      () => ({ mainRestartRecovery }) as Partial<InternalSessionEntry>,
+    );
+    await patchInternalSessionEntry(
+      { agentId: "main", sessionKey: updateKey, storePath: updateStorePath },
+      () => ({ mainRestartRecovery }) as Partial<InternalSessionEntry>,
+    );
+
+    await patchSessionEntry({
+      sessionKey: patchKey,
+      skipMaintenance: true,
+      storePath,
+      update: () => ({ sessionId: "patch-after", updatedAt: 20 }),
+    });
+    await updateSessionStoreEntry({
+      sessionKey: updateKey,
+      skipMaintenance: true,
+      storePath: updateStorePath,
+      update: () => ({ sessionId: "update-after", updatedAt: 20 }),
+    });
+
+    expect(loadInternalSessionEntry({ sessionKey: patchKey, storePath })).toMatchObject({
+      sessionId: "patch-after",
+    });
+    expect(loadInternalSessionEntry({ sessionKey: patchKey, storePath })).not.toHaveProperty(
+      "mainRestartRecovery",
+    );
+    expect(
+      loadInternalSessionEntry({ sessionKey: updateKey, storePath: updateStorePath }),
+    ).toMatchObject({ sessionId: "update-after" });
+    expect(
+      loadInternalSessionEntry({ sessionKey: updateKey, storePath: updateStorePath }),
+    ).not.toHaveProperty("mainRestartRecovery");
+  });
+
+  it("preserves core recovery state when merge patches leave session identity undefined", async () => {
+    const patchKey = "agent:main:telegram:direct:patch-nullish-identity";
+    const updateKey = "agent:main:telegram:direct:update-nullish-identity";
+    const updateStorePath = path.join(tempDir, "update-nullish-sessions.json");
+    const mainRestartRecovery = {
+      chargedAttempts: 1,
+      cycleId: "nullish-identity-cycle",
+      revision: 1,
+    };
+    await seedSessionEntry(patchKey, { sessionId: "patch-stable", updatedAt: 10 });
+    await upsertSessionEntry({
+      agentId: "main",
+      entry: { sessionId: "update-stable", updatedAt: 10 },
+      sessionKey: updateKey,
+      storePath: updateStorePath,
+    });
+    await patchInternalSessionEntry(
+      { agentId: "main", sessionKey: patchKey, storePath },
+      () => ({ mainRestartRecovery }) as Partial<InternalSessionEntry>,
+    );
+    await patchInternalSessionEntry(
+      { agentId: "main", sessionKey: updateKey, storePath: updateStorePath },
+      () => ({ mainRestartRecovery }) as Partial<InternalSessionEntry>,
+    );
+
+    await patchSessionEntry({
+      sessionKey: patchKey,
+      skipMaintenance: true,
+      storePath,
+      update: () => ({ model: "gpt-5.6", sessionId: undefined }),
+    });
+    await updateSessionStoreEntry({
+      sessionKey: updateKey,
+      skipMaintenance: true,
+      storePath: updateStorePath,
+      update: () => ({ model: "gpt-5.7", sessionId: undefined }),
+    });
+
+    expect(loadInternalSessionEntry({ sessionKey: patchKey, storePath })).toMatchObject({
+      mainRestartRecovery,
+      model: "gpt-5.6",
+      sessionId: "patch-stable",
+    });
+    expect(
+      loadInternalSessionEntry({ sessionKey: updateKey, storePath: updateStorePath }),
+    ).toMatchObject({
+      mainRestartRecovery,
+      model: "gpt-5.7",
+      sessionId: "update-stable",
+    });
+  });
+
+  it("rejects core recovery state from runtime-escaped creation inputs", async () => {
+    const mainRestartRecovery = {
+      chargedAttempts: 1,
+      cycleId: "cycle-injected",
+      revision: 1,
+    };
+    const patchSessionKey = "agent:main:patch-created";
+    await patchSessionEntry({
+      fallbackEntry: {
+        mainRestartRecovery,
+        sessionId: "patch-created",
+        updatedAt: 10,
+      } as unknown as SessionEntry,
+      sessionKey: patchSessionKey,
+      storePath,
+      update: () => ({ updatedAt: 20 }),
+    });
+    expect(loadInternalSessionEntry({ sessionKey: patchSessionKey, storePath })).not.toHaveProperty(
+      "mainRestartRecovery",
+    );
+
+    const upsertSessionKey = "agent:main:upsert-created";
+    await upsertSessionEntry({
+      entry: {
+        mainRestartRecovery,
+        sessionId: "upsert-created",
+        updatedAt: 10,
+      } as unknown as SessionEntry,
+      sessionKey: upsertSessionKey,
+      storePath,
+    });
+    expect(
+      loadInternalSessionEntry({ sessionKey: upsertSessionKey, storePath }),
+    ).not.toHaveProperty("mainRestartRecovery");
   });
 
   it("keeps the beta.5 official plugin import set linkable", () => {
@@ -318,6 +598,95 @@ describe("session-store-runtime compatibility surface", () => {
     expect(getSessionEntry({ sessionKey: "agent:main:remove", storePath })).toBeUndefined();
     expect(getSessionEntry({ sessionKey: "agent:main:update", storePath })?.model).toBe("gpt-5.6");
     expect(fs.existsSync(storePath)).toBe(false);
+  });
+
+  it("keeps recovery state private across deprecated whole-store mutations", async () => {
+    const keptKey = "agent:main:telegram:direct:compat-recovery";
+    const removedKey = "agent:main:telegram:direct:compat-removed";
+    const mainRestartRecovery = {
+      chargedAttempts: 2,
+      cycleId: "compat-cycle",
+      revision: 4,
+    };
+    await seedSessionEntry(keptKey, {
+      model: "gpt-5.5",
+      sessionId: "compat-recovery-session",
+      updatedAt: 10,
+    });
+    await patchInternalSessionEntry(
+      { agentId: "main", sessionKey: keptKey, storePath },
+      () => ({ mainRestartRecovery }) as Partial<InternalSessionEntry>,
+    );
+    await seedSessionEntry(removedKey, {
+      sessionId: "compat-removed-session",
+      updatedAt: 10,
+    });
+
+    const compatibilityStore = loadSessionStore(storePath);
+    expect(Object.keys(compatibilityStore)).toContain(keptKey);
+    expect(compatibilityStore[keptKey]).not.toHaveProperty("mainRestartRecovery");
+    await updateSessionStore(
+      storePath,
+      (store) => {
+        expect(store[keptKey]).not.toHaveProperty("mainRestartRecovery");
+        const escapedStore = store as unknown as Record<string, InternalSessionEntry>;
+        escapedStore[keptKey] = {
+          ...escapedStore[keptKey]!,
+          mainRestartRecovery: {
+            chargedAttempts: 99,
+            cycleId: "injected-cycle",
+            revision: 99,
+          },
+          model: "gpt-5.6",
+        };
+        delete escapedStore[removedKey];
+        escapedStore["agent:main:telegram:direct:compat-created"] = {
+          mainRestartRecovery: {
+            chargedAttempts: 1,
+            cycleId: "created-injection",
+            revision: 1,
+          },
+          sessionId: "compat-created-session",
+          updatedAt: 20,
+        };
+      },
+      { skipMaintenance: true },
+    );
+
+    expect(loadInternalSessionEntry({ sessionKey: keptKey, storePath })).toMatchObject({
+      mainRestartRecovery,
+      model: "gpt-5.6",
+    });
+    expect(loadInternalSessionEntry({ sessionKey: removedKey, storePath })).toBeUndefined();
+    expect(
+      loadInternalSessionEntry({
+        sessionKey: "agent:main:telegram:direct:compat-created",
+        storePath,
+      }),
+    ).not.toHaveProperty("mainRestartRecovery");
+
+    await updateSessionStore(
+      storePath,
+      (store) => {
+        const escapedStore = store as unknown as Record<string, InternalSessionEntry>;
+        escapedStore[keptKey] = {
+          ...escapedStore[keptKey]!,
+          mainRestartRecovery: {
+            chargedAttempts: 99,
+            cycleId: "replacement-injection",
+            revision: 99,
+          },
+          sessionId: "compat-replacement-session",
+        };
+      },
+      { skipMaintenance: true },
+    );
+    expect(loadInternalSessionEntry({ sessionKey: keptKey, storePath })).toMatchObject({
+      sessionId: "compat-replacement-session",
+    });
+    expect(loadInternalSessionEntry({ sessionKey: keptKey, storePath })).not.toHaveProperty(
+      "mainRestartRecovery",
+    );
   });
 
   it("serializes compatibility callbacks with concurrent row writes", async () => {

--- a/src/plugin-sdk/session-store-runtime.ts
+++ b/src/plugin-sdk/session-store-runtime.ts
@@ -8,6 +8,7 @@ import {
   updateAmbientTranscriptWatermark,
   type AmbientTranscriptWatermarkScope,
 } from "../config/sessions/ambient-transcript-watermark.js";
+import type { InternalSessionEntry } from "../config/sessions/main-session-recovery.types.js";
 import { resolveStorePath as resolveSessionStorePath } from "../config/sessions/paths.js";
 import { resolveSessionFilePath as resolveLegacySessionFilePath } from "../config/sessions/paths.js";
 import {
@@ -16,14 +17,9 @@ import {
   deleteSessionEntryLifecycle as deleteAccessorSessionEntryLifecycle,
   loadTranscriptEventsSync as loadAccessorTranscriptEventsSync,
   listSessionEntries as listAccessorSessionEntries,
-  loadSessionEntry,
-  patchSessionEntry as patchAccessorSessionEntry,
   readSessionUpdatedAt as readAccessorSessionUpdatedAt,
   readTranscriptStatsSync as readAccessorTranscriptStatsSync,
-  replaceSessionEntry,
   resolveTranscriptSessionKeyBySessionId as resolveAccessorTranscriptSessionKeyBySessionId,
-  type SessionAccessScope,
-  updateSessionEntry,
 } from "../config/sessions/session-accessor.js";
 import { resolveSqliteTargetFromSessionStorePath } from "../config/sessions/session-sqlite-target.js";
 import {
@@ -31,10 +27,23 @@ import {
   parseSqliteSessionFileMarker,
 } from "../config/sessions/sqlite-marker.js";
 import { resolveSessionStoreEntry as resolveSessionStoreEntryFromStore } from "../config/sessions/store-entry.js";
-import { normalizeResolvedMaintenanceConfigInput } from "../config/sessions/store-maintenance.js";
 import type { ResolvedSessionMaintenanceConfigInput } from "../config/sessions/store.js";
 import type { AmbientTranscriptWatermark, SessionEntry } from "../config/sessions/types.js";
 import { replaceFileAtomicSync } from "../infra/replace-file.js";
+import {
+  getPluginSessionEntry,
+  listPluginSessionEntries,
+  patchPluginSessionEntry,
+  projectPluginSessionEntry,
+  projectPluginSessionStore,
+  reconcilePluginSessionStore,
+  recordPluginSessionMetaFromInbound,
+  type SessionStoreReadParams,
+  toPluginSessionAccessScope,
+  updatePluginSessionLastRoute,
+  updatePluginSessionStoreEntry,
+  upsertPluginSessionEntry,
+} from "../plugins/runtime/session-store-facade.js";
 import { resolveAgentIdFromSessionKey } from "../routing/session-key.js";
 import type { SessionTranscriptEvent } from "./session-transcript-runtime.js";
 
@@ -44,15 +53,6 @@ const LEGACY_TRANSCRIPT_INSPECTION_MAX_BYTES = 16 * 1024 * 1024;
 // by path before load/update. Last selection therefore matches every shipped
 // caller. This map is not a general replacement for target-aware SDK methods.
 const legacyStoreAgentIds = new Map<string, string>();
-
-type SessionStoreReadParams = {
-  agentId?: string;
-  env?: NodeJS.ProcessEnv;
-  hydrateSkillPromptRefs?: boolean;
-  readConsistency?: "latest";
-  sessionKey: string;
-  storePath?: string;
-};
 
 type SessionStoreListParams = Partial<Omit<SessionStoreReadParams, "sessionKey">>;
 
@@ -130,21 +130,6 @@ type SessionLifecycleArtifactsCleanupResult = {
   archivedTranscriptArtifacts: number;
   removedEntries: number;
 };
-
-function toSessionAccessScope(params: SessionStoreReadParams): SessionAccessScope {
-  // Maintainer note: keep this adapter narrow so plugin callers retain the
-  // object-parameter API while internal accessor-only options stay private.
-  return {
-    sessionKey: params.sessionKey,
-    ...(params.agentId !== undefined ? { agentId: params.agentId } : {}),
-    ...(params.env !== undefined ? { env: params.env } : {}),
-    ...(params.hydrateSkillPromptRefs !== undefined
-      ? { hydrateSkillPromptRefs: params.hydrateSkillPromptRefs }
-      : {}),
-    ...(params.readConsistency !== undefined ? { readConsistency: params.readConsistency } : {}),
-    ...(params.storePath !== undefined ? { storePath: params.storePath } : {}),
-  };
-}
 
 function resolveLegacySessionStoreTarget(storePath: string): {
   agentId?: string;
@@ -244,13 +229,14 @@ export function loadSessionStore(
       hydrateSkillPromptRefs: options.hydrateSkillPromptRefs,
     }).map(({ sessionKey, entry }) => {
       const sessionId = entry.sessionId?.trim();
-      if (entry.sessionFile || !sessionId) {
-        return [sessionKey, entry];
+      const projectedEntry = projectPluginSessionEntry(entry as InternalSessionEntry);
+      if (projectedEntry.sessionFile || !sessionId) {
+        return [sessionKey, projectedEntry];
       }
       return [
         sessionKey,
         {
-          ...entry,
+          ...projectedEntry,
           // SQLite does not persist sessionFile. Beta.5 needs a locator only in
           // this detached projection so its file-based doctor reaches the bridge.
           sessionFile: formatSqliteSessionFileMarker({
@@ -285,9 +271,17 @@ export async function updateSessionStore<T>(
     storePath: target.storePath,
     skipMaintenance: options.skipMaintenance,
     update: async (store) => {
-      const result = await mutator(store);
+      const internalStore = store as Record<string, InternalSessionEntry>;
+      const publicStore = projectPluginSessionStore(internalStore);
+      const result = await mutator(publicStore);
+      const persist = !options.skipSaveWhenResult?.(result);
+      if (persist) {
+        // The deprecated callback owns public row changes and deletions, but
+        // core recovery coordination remains invisible and non-overwritable.
+        reconcilePluginSessionStore({ internalStore, publicStore });
+      }
       return {
-        persist: !options.skipSaveWhenResult?.(result),
+        persist,
         result,
       };
     },
@@ -346,21 +340,14 @@ export function resolveSessionStoreEntry(params: {
 
 /** Loads one session entry by agent/session identity. */
 export function getSessionEntry(params: SessionStoreReadParams): SessionEntry | undefined {
-  return loadSessionEntry(toSessionAccessScope(params));
+  return getPluginSessionEntry(params);
 }
 
 /** Lists session entries for one agent. */
 export function listSessionEntries(
   params: SessionStoreListParams = {},
 ): SessionStoreEntrySummary[] {
-  return listAccessorSessionEntries({
-    ...(params.agentId !== undefined ? { agentId: params.agentId } : {}),
-    ...(params.env !== undefined ? { env: params.env } : {}),
-    ...(params.hydrateSkillPromptRefs !== undefined
-      ? { hydrateSkillPromptRefs: params.hydrateSkillPromptRefs }
-      : {}),
-    ...(params.storePath !== undefined ? { storePath: params.storePath } : {}),
-  });
+  return listPluginSessionEntries(params);
 }
 
 /** Reads transcript events for a live SQLite-backed session identity. */
@@ -399,22 +386,12 @@ export function resolveTranscriptSessionKeyBySessionId(params: {
 export async function patchSessionEntry(
   params: PatchSessionEntryParams,
 ): Promise<SessionEntry | null> {
-  return await patchAccessorSessionEntry(toSessionAccessScope(params), params.update, {
-    fallbackEntry: params.fallbackEntry,
-    maintenanceConfig:
-      params.maintenanceConfig !== undefined
-        ? normalizeResolvedMaintenanceConfigInput(params.maintenanceConfig)
-        : undefined,
-    preserveActivity: params.preserveActivity,
-    requireWriteSuccess: params.requireWriteSuccess,
-    replaceEntry: params.replaceEntry,
-    skipMaintenance: params.skipMaintenance,
-  });
+  return await patchPluginSessionEntry(params);
 }
 
 /** Reads the last activity timestamp for one session entry. */
 export function readSessionUpdatedAt(params: SessionStoreReadParams): number | undefined {
-  return readAccessorSessionUpdatedAt(toSessionAccessScope(params));
+  return readAccessorSessionUpdatedAt(toPluginSessionAccessScope(params));
 }
 
 export { resolveAmbientTranscriptWatermarkKey, updateAmbientTranscriptWatermark };
@@ -430,23 +407,12 @@ export function readAmbientTranscriptWatermark(
 export async function updateSessionStoreEntry(
   params: UpdateSessionStoreEntryParams,
 ): Promise<SessionEntry | null> {
-  return await updateSessionEntry(
-    {
-      sessionKey: params.sessionKey,
-      storePath: params.storePath,
-    },
-    params.update,
-    {
-      skipMaintenance: params.skipMaintenance,
-      takeCacheOwnership: params.takeCacheOwnership,
-      requireWriteSuccess: params.requireWriteSuccess,
-    },
-  );
+  return await updatePluginSessionStoreEntry(params);
 }
 
 /** Replaces or creates one session entry by agent/session identity. */
 export async function upsertSessionEntry(params: UpsertSessionEntryParams): Promise<void> {
-  await replaceSessionEntry(toSessionAccessScope(params), params.entry);
+  await upsertPluginSessionEntry(params);
 }
 
 /** Deletes one session entry by agent/session identity. */
@@ -528,9 +494,9 @@ export { isValidAgentHarnessSessionStoreEntry } from "../sessions/agent-harness-
 // SDK-facing names are a shipped plugin contract; internals route through the
 // session accessor so the storage backend can change beneath them.
 export {
-  recordInboundSessionMeta as recordSessionMetaFromInbound,
-  updateSessionLastRoute as updateLastRoute,
-} from "../config/sessions/session-accessor.js";
+  recordPluginSessionMetaFromInbound as recordSessionMetaFromInbound,
+  updatePluginSessionLastRoute as updateLastRoute,
+};
 export {
   evaluateSessionFreshness,
   resolveChannelResetConfig,

--- a/src/plugin-sdk/session-store-runtime.ts
+++ b/src/plugin-sdk/session-store-runtime.ts
@@ -28,7 +28,7 @@ import {
 } from "../config/sessions/sqlite-marker.js";
 import { resolveSessionStoreEntry as resolveSessionStoreEntryFromStore } from "../config/sessions/store-entry.js";
 import type { ResolvedSessionMaintenanceConfigInput } from "../config/sessions/store.js";
-import type { AmbientTranscriptWatermark, SessionEntry } from "../config/sessions/types.js";
+import type { AmbientTranscriptWatermark } from "../config/sessions/types.js";
 import { replaceFileAtomicSync } from "../infra/replace-file.js";
 import {
   getPluginSessionEntry,
@@ -38,11 +38,14 @@ import {
   projectPluginSessionStore,
   reconcilePluginSessionStore,
   recordPluginSessionMetaFromInbound,
-  type SessionStoreReadParams,
   toPluginSessionAccessScope,
   updatePluginSessionLastRoute,
   updatePluginSessionStoreEntry,
   upsertPluginSessionEntry,
+} from "../plugins/runtime/session-store-facade.js";
+import type {
+  PluginSessionEntry as SessionEntry,
+  SessionStoreReadParams,
 } from "../plugins/runtime/session-store-facade.js";
 import { resolveAgentIdFromSessionKey } from "../routing/session-key.js";
 import type { SessionTranscriptEvent } from "./session-transcript-runtime.js";
@@ -505,4 +508,5 @@ export {
   resolveThreadFlag,
 } from "../config/sessions/reset.js";
 export { resolveSendPolicy } from "../sessions/send-policy.js";
-export type { SessionEntry, SessionScope } from "../config/sessions/types.js";
+export type { PluginSessionEntry as SessionEntry } from "../plugins/runtime/session-store-facade.js";
+export type { SessionScope } from "../config/sessions/types.js";

--- a/src/plugin-sdk/session-transcript-hit.test.ts
+++ b/src/plugin-sdk/session-transcript-hit.test.ts
@@ -28,6 +28,8 @@ describe("loadCombinedSessionStoreForGateway", () => {
           cycleId: "transcript-hit-cycle",
           revision: 1,
         },
+        restartRecoveryDeliveryReceiptState: "terminal-pending",
+        restartRecoveryRequesterAccountId: "transcript-account",
         sessionId: "transcript-isolation-session",
         updatedAt: 10,
       } as InternalSessionEntry);
@@ -39,6 +41,8 @@ describe("loadCombinedSessionStoreForGateway", () => {
         updatedAt: 10,
       });
       expect(store[sessionKey]).not.toHaveProperty("mainRestartRecovery");
+      expect(store[sessionKey]).not.toHaveProperty("restartRecoveryDeliveryReceiptState");
+      expect(store[sessionKey]).not.toHaveProperty("restartRecoveryRequesterAccountId");
     } finally {
       fs.rmSync(tempDir, { force: true, recursive: true });
     }

--- a/src/plugin-sdk/session-transcript-hit.test.ts
+++ b/src/plugin-sdk/session-transcript-hit.test.ts
@@ -30,7 +30,7 @@ describe("loadCombinedSessionStoreForGateway", () => {
         },
         sessionId: "transcript-isolation-session",
         updatedAt: 10,
-      } satisfies InternalSessionEntry);
+      } as InternalSessionEntry);
 
       const { store } = loadCombinedSessionStoreForGateway({ session: { store: storePath } });
 

--- a/src/plugin-sdk/session-transcript-hit.test.ts
+++ b/src/plugin-sdk/session-transcript-hit.test.ts
@@ -1,15 +1,49 @@
 // Session transcript hit tests cover transcript match formatting and path resolution.
 import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { describe, expect, it } from "vitest";
+import type { InternalSessionEntry } from "../config/sessions/main-session-recovery.types.js";
+import { replaceSessionEntry as replaceInternalSessionEntry } from "../config/sessions/session-accessor.js";
 import type { SessionEntry } from "../config/sessions/types.js";
 import {
   extractTranscriptIdentityFromSessionsMemoryHit,
   extractTranscriptStemFromSessionsMemoryHit,
   formatSessionTranscriptMemoryHitKey,
+  loadCombinedSessionStoreForGateway,
   parseSessionTranscriptMemoryHitKey,
   resolveSessionTranscriptMemoryHitKeyToSessionKeys,
   resolveTranscriptStemToSessionKeys,
 } from "./session-transcript-hit.js";
+
+describe("loadCombinedSessionStoreForGateway", () => {
+  it("hides core recovery state from combined session store reads", async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-transcript-hit-sdk-"));
+    const storePath = path.join(tempDir, "sessions.json");
+    const sessionKey = "agent:main:transcript-isolation";
+    try {
+      await replaceInternalSessionEntry({ agentId: "main", sessionKey, storePath }, {
+        mainRestartRecovery: {
+          chargedAttempts: 1,
+          cycleId: "transcript-hit-cycle",
+          revision: 1,
+        },
+        sessionId: "transcript-isolation-session",
+        updatedAt: 10,
+      } satisfies InternalSessionEntry);
+
+      const { store } = loadCombinedSessionStoreForGateway({ session: { store: storePath } });
+
+      expect(store[sessionKey]).toMatchObject({
+        sessionId: "transcript-isolation-session",
+        updatedAt: 10,
+      });
+      expect(store[sessionKey]).not.toHaveProperty("mainRestartRecovery");
+    } finally {
+      fs.rmSync(tempDir, { force: true, recursive: true });
+    }
+  });
+});
 
 describe("extractTranscriptStemFromSessionsMemoryHit", () => {
   it("strips sessions/ and .jsonl for builtin paths", () => {

--- a/src/plugin-sdk/session-transcript-hit.ts
+++ b/src/plugin-sdk/session-transcript-hit.ts
@@ -5,9 +5,11 @@ import { normalizeOptionalString } from "../../packages/normalization-core/src/s
 import { uniqueStrings } from "../../packages/normalization-core/src/string-normalization.js";
 import { parseUsageCountedSessionIdFromFileName } from "../config/sessions/artifacts.js";
 import { loadCombinedSessionStoreForGateway as loadInternalCombinedSessionStoreForGateway } from "../config/sessions/combined-store-gateway.js";
-import type { SessionEntry } from "../config/sessions/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { projectPluginSessionStore } from "../plugins/runtime/session-store-facade.js";
+import {
+  projectPluginSessionStore,
+  type PluginSessionEntry as SessionEntry,
+} from "../plugins/runtime/session-store-facade.js";
 import { normalizeAgentId } from "../routing/session-key.js";
 export {
   formatSessionTranscriptMemoryHitKey,

--- a/src/plugin-sdk/session-transcript-hit.ts
+++ b/src/plugin-sdk/session-transcript-hit.ts
@@ -4,7 +4,10 @@ import { expectDefined } from "@openclaw/normalization-core";
 import { normalizeOptionalString } from "../../packages/normalization-core/src/string-coerce.js";
 import { uniqueStrings } from "../../packages/normalization-core/src/string-normalization.js";
 import { parseUsageCountedSessionIdFromFileName } from "../config/sessions/artifacts.js";
+import { loadCombinedSessionStoreForGateway as loadInternalCombinedSessionStoreForGateway } from "../config/sessions/combined-store-gateway.js";
 import type { SessionEntry } from "../config/sessions/types.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { projectPluginSessionStore } from "../plugins/runtime/session-store-facade.js";
 import { normalizeAgentId } from "../routing/session-key.js";
 export {
   formatSessionTranscriptMemoryHitKey,
@@ -20,7 +23,16 @@ export type {
   SessionTranscriptReadParams,
 } from "./session-transcript-memory-hit.js";
 
-export { loadCombinedSessionStoreForGateway } from "../config/sessions/combined-store-gateway.js";
+export function loadCombinedSessionStoreForGateway(
+  cfg: OpenClawConfig,
+  opts: { agentId?: string; configuredAgentsOnly?: boolean } = {},
+): {
+  storePath: string;
+  store: Record<string, SessionEntry>;
+} {
+  const { storePath, store } = loadInternalCombinedSessionStoreForGateway(cfg, opts);
+  return { storePath, store: projectPluginSessionStore(store) };
+}
 
 const QMD_ARCHIVE_STEM_RE = /^(.+)-jsonl-(reset|deleted)-(.+)$/;
 const QMD_ARCHIVE_TIMESTAMP_RE =

--- a/src/plugin-sdk/session-transcript-memory-hit.ts
+++ b/src/plugin-sdk/session-transcript-memory-hit.ts
@@ -1,6 +1,6 @@
 import { normalizeOptionalString } from "../../packages/normalization-core/src/string-coerce.js";
 import { uniqueStrings } from "../../packages/normalization-core/src/string-normalization.js";
-import type { SessionEntry } from "../config/sessions/types.js";
+import type { PluginSessionEntry as SessionEntry } from "../plugins/runtime/session-store-facade.js";
 import { normalizeAgentId, resolveAgentIdFromSessionKey } from "../routing/session-key.js";
 
 const SESSION_TRANSCRIPT_MEMORY_HIT_PREFIX = "transcript";

--- a/src/plugins/contracts/session-entry-projection.contract.test.ts
+++ b/src/plugins/contracts/session-entry-projection.contract.test.ts
@@ -290,6 +290,11 @@ describe("plugin session extension SessionEntry projection", () => {
           sessionEntrySlotKey: "updatedAt",
         });
         api.registerSessionExtension({
+          namespace: "main-recovery",
+          description: "bad main recovery slot",
+          sessionEntrySlotKey: "mainRestartRecovery",
+        });
+        api.registerSessionExtension({
           namespace: "recovery",
           description: "bad fresh-main slot",
           sessionEntrySlotKey: "subagentRecovery",
@@ -304,6 +309,10 @@ describe("plugin session extension SessionEntry projection", () => {
       {
         pluginId: "slot-collision",
         message: "sessionEntrySlotKey is reserved by SessionEntry: updatedAt",
+      },
+      {
+        pluginId: "slot-collision",
+        message: "sessionEntrySlotKey is reserved by SessionEntry: mainRestartRecovery",
       },
       {
         pluginId: "slot-collision",

--- a/src/plugins/contracts/session-entry-projection.contract.test.ts
+++ b/src/plugins/contracts/session-entry-projection.contract.test.ts
@@ -299,6 +299,11 @@ describe("plugin session extension SessionEntry projection", () => {
           description: "bad fresh-main slot",
           sessionEntrySlotKey: "subagentRecovery",
         });
+        api.registerSessionExtension({
+          namespace: "future-recovery",
+          description: "bad future core recovery slot",
+          sessionEntrySlotKey: "restartRecoveryPluginOverride",
+        });
       },
     });
 
@@ -317,6 +322,11 @@ describe("plugin session extension SessionEntry projection", () => {
       {
         pluginId: "slot-collision",
         message: "sessionEntrySlotKey is reserved by SessionEntry: subagentRecovery",
+      },
+      {
+        pluginId: "slot-collision",
+        message:
+          "sessionEntrySlotKey is reserved by core restart recovery: restartRecoveryPluginOverride",
       },
     ]);
   });

--- a/src/plugins/runtime/runtime-agent.session-isolation.test.ts
+++ b/src/plugins/runtime/runtime-agent.session-isolation.test.ts
@@ -1,0 +1,99 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import type { InternalSessionEntry } from "../../config/sessions/main-session-recovery.types.js";
+import {
+  loadSessionEntry as loadInternalSessionEntry,
+  replaceSessionEntry as replaceInternalSessionEntry,
+} from "../../config/sessions/session-accessor.js";
+import type { SessionEntry } from "../../config/sessions/types.js";
+import { createRuntimeAgent } from "./runtime-agent.js";
+
+describe("plugin runtime session isolation", () => {
+  it("hides, preserves, and clears core recovery state through the injected facade", async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-plugin-session-isolation-"));
+    const storePath = path.join(tempDir, "sessions.json");
+    const sessionKey = "agent:main:plugin-runtime-isolation";
+    const mainRestartRecovery = {
+      chargedAttempts: 1,
+      cycleId: "runtime-cycle",
+      reservation: {
+        attempt: 1,
+        lifecycleGeneration: "runtime-generation",
+        runId: "runtime-run",
+      },
+      revision: 1,
+    };
+
+    try {
+      await replaceInternalSessionEntry({ sessionKey, storePath }, {
+        mainRestartRecovery,
+        model: "gpt-5.5",
+        sessionId: "runtime-session-before",
+        updatedAt: 10,
+      } as InternalSessionEntry);
+      const runtime = createRuntimeAgent();
+
+      expect(runtime.session.getSessionEntry({ sessionKey, storePath })).not.toHaveProperty(
+        "mainRestartRecovery",
+      );
+      expect(runtime.session.listSessionEntries({ storePath })[0]?.entry).not.toHaveProperty(
+        "mainRestartRecovery",
+      );
+
+      let callbackSawPrivateState = false;
+      await runtime.session.patchSessionEntry({
+        sessionKey,
+        storePath,
+        update: (entry) => {
+          callbackSawPrivateState = Object.hasOwn(entry, "mainRestartRecovery");
+          return {
+            mainRestartRecovery: {
+              chargedAttempts: 99,
+              cycleId: "runtime-injection",
+              revision: 99,
+            },
+            model: "gpt-5.6",
+          } as unknown as Partial<SessionEntry>;
+        },
+      });
+      expect(callbackSawPrivateState).toBe(false);
+      expect(loadInternalSessionEntry({ sessionKey, storePath })).toMatchObject({
+        mainRestartRecovery,
+        model: "gpt-5.6",
+      });
+
+      await runtime.session.upsertSessionEntry({
+        entry: {
+          sessionId: "runtime-session-before",
+          updatedAt: 20,
+        },
+        sessionKey,
+        storePath,
+      });
+      expect(loadInternalSessionEntry({ sessionKey, storePath })).toMatchObject({
+        mainRestartRecovery,
+        sessionId: "runtime-session-before",
+      });
+
+      await runtime.session.updateSessionStoreEntry({
+        sessionKey,
+        skipMaintenance: true,
+        storePath,
+        update: () => ({
+          sessionId: "runtime-session-after",
+          updatedAt: 30,
+        }),
+      });
+      expect(loadInternalSessionEntry({ sessionKey, storePath })).toMatchObject({
+        sessionId: "runtime-session-after",
+      });
+      expect(loadInternalSessionEntry({ sessionKey, storePath })).not.toHaveProperty(
+        "mainRestartRecovery",
+      );
+    } finally {
+      fs.rmSync(tempDir, { force: true, recursive: true });
+    }
+  });
+});

--- a/src/plugins/runtime/runtime-agent.session-isolation.test.ts
+++ b/src/plugins/runtime/runtime-agent.session-isolation.test.ts
@@ -25,10 +25,17 @@ describe("plugin runtime session isolation", () => {
       },
       revision: 1,
     };
+    const restartRecoveryState = {
+      restartRecoveryDeliveryReceiptState: "terminal-pending" as const,
+      restartRecoveryDeliveryToolCallId: "runtime-message-call",
+      restartRecoveryRequesterAccountId: "runtime-account",
+      restartRecoverySourceIngress: "channel" as const,
+    };
 
     try {
       await replaceInternalSessionEntry({ sessionKey, storePath }, {
         mainRestartRecovery,
+        ...restartRecoveryState,
         model: "gpt-5.5",
         sessionId: "runtime-session-before",
         updatedAt: 10,
@@ -40,6 +47,9 @@ describe("plugin runtime session isolation", () => {
       );
       expect(runtime.session.listSessionEntries({ storePath })[0]?.entry).not.toHaveProperty(
         "mainRestartRecovery",
+      );
+      expect(runtime.session.getSessionEntry({ sessionKey, storePath })).not.toHaveProperty(
+        "restartRecoveryDeliveryReceiptState",
       );
 
       let callbackSawPrivateState = false;
@@ -55,12 +65,14 @@ describe("plugin runtime session isolation", () => {
               revision: 99,
             },
             model: "gpt-5.6",
+            restartRecoveryDeliveryReceiptState: "delivered-terminal",
           } as unknown as Partial<SessionEntry>;
         },
       });
       expect(callbackSawPrivateState).toBe(false);
       expect(loadInternalSessionEntry({ sessionKey, storePath })).toMatchObject({
         mainRestartRecovery,
+        ...restartRecoveryState,
         model: "gpt-5.6",
       });
 
@@ -74,6 +86,7 @@ describe("plugin runtime session isolation", () => {
       });
       expect(loadInternalSessionEntry({ sessionKey, storePath })).toMatchObject({
         mainRestartRecovery,
+        ...restartRecoveryState,
         sessionId: "runtime-session-before",
       });
 
@@ -92,6 +105,9 @@ describe("plugin runtime session isolation", () => {
       expect(loadInternalSessionEntry({ sessionKey, storePath })).not.toHaveProperty(
         "mainRestartRecovery",
       );
+      for (const field of Object.keys(restartRecoveryState)) {
+        expect(loadInternalSessionEntry({ sessionKey, storePath })).not.toHaveProperty(field);
+      }
     } finally {
       fs.rmSync(tempDir, { force: true, recursive: true });
     }

--- a/src/plugins/runtime/runtime-agent.test.ts
+++ b/src/plugins/runtime/runtime-agent.test.ts
@@ -8,7 +8,6 @@ import {
   loadTranscriptEvents,
   replaceSessionEntry as replaceInternalSessionEntry,
 } from "../../config/sessions/session-accessor.js";
-import type { SessionEntry } from "../../config/sessions/types.js";
 import { createGatewaySession } from "../../gateway/session-create-service.js";
 import {
   interruptSessionWorkAdmissions,
@@ -883,94 +882,6 @@ describe("plugin runtime session creation", () => {
         ).toMatchObject({ sessionId: key, updatedAt, groupActivation: "always" });
       },
     );
-  });
-});
-
-describe("plugin runtime session isolation", () => {
-  it("hides, preserves, and clears core recovery state through the injected facade", async () => {
-    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-plugin-session-isolation-"));
-    const storePath = path.join(tempDir, "sessions.json");
-    const sessionKey = "agent:main:plugin-runtime-isolation";
-    const mainRestartRecovery = {
-      chargedAttempts: 1,
-      cycleId: "runtime-cycle",
-      reservation: {
-        attempt: 1,
-        lifecycleGeneration: "runtime-generation",
-        runId: "runtime-run",
-      },
-      revision: 1,
-    };
-
-    try {
-      await replaceInternalSessionEntry({ sessionKey, storePath }, {
-        mainRestartRecovery,
-        model: "gpt-5.5",
-        sessionId: "runtime-session-before",
-        updatedAt: 10,
-      } as InternalSessionEntry);
-      const runtime = createRuntimeAgent();
-
-      expect(runtime.session.getSessionEntry({ sessionKey, storePath })).not.toHaveProperty(
-        "mainRestartRecovery",
-      );
-      expect(runtime.session.listSessionEntries({ storePath })[0]?.entry).not.toHaveProperty(
-        "mainRestartRecovery",
-      );
-
-      let callbackSawPrivateState = false;
-      await runtime.session.patchSessionEntry({
-        sessionKey,
-        storePath,
-        update: (entry) => {
-          callbackSawPrivateState = Object.hasOwn(entry, "mainRestartRecovery");
-          return {
-            mainRestartRecovery: {
-              chargedAttempts: 99,
-              cycleId: "runtime-injection",
-              revision: 99,
-            },
-            model: "gpt-5.6",
-          } as unknown as Partial<SessionEntry>;
-        },
-      });
-      expect(callbackSawPrivateState).toBe(false);
-      expect(loadInternalSessionEntry({ sessionKey, storePath })).toMatchObject({
-        mainRestartRecovery,
-        model: "gpt-5.6",
-      });
-
-      await runtime.session.upsertSessionEntry({
-        entry: {
-          sessionId: "runtime-session-before",
-          updatedAt: 20,
-        },
-        sessionKey,
-        storePath,
-      });
-      expect(loadInternalSessionEntry({ sessionKey, storePath })).toMatchObject({
-        mainRestartRecovery,
-        sessionId: "runtime-session-before",
-      });
-
-      await runtime.session.updateSessionStoreEntry({
-        sessionKey,
-        skipMaintenance: true,
-        storePath,
-        update: () => ({
-          sessionId: "runtime-session-after",
-          updatedAt: 30,
-        }),
-      });
-      expect(loadInternalSessionEntry({ sessionKey, storePath })).toMatchObject({
-        sessionId: "runtime-session-after",
-      });
-      expect(loadInternalSessionEntry({ sessionKey, storePath })).not.toHaveProperty(
-        "mainRestartRecovery",
-      );
-    } finally {
-      fs.rmSync(tempDir, { force: true, recursive: true });
-    }
   });
 });
 

--- a/src/plugins/runtime/runtime-agent.test.ts
+++ b/src/plugins/runtime/runtime-agent.test.ts
@@ -2,7 +2,13 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, expectTypeOf, it } from "vitest";
-import { loadTranscriptEvents } from "../../config/sessions/session-accessor.js";
+import type { InternalSessionEntry } from "../../config/sessions/main-session-recovery.types.js";
+import {
+  loadSessionEntry as loadInternalSessionEntry,
+  loadTranscriptEvents,
+  replaceSessionEntry as replaceInternalSessionEntry,
+} from "../../config/sessions/session-accessor.js";
+import type { SessionEntry } from "../../config/sessions/types.js";
 import { createGatewaySession } from "../../gateway/session-create-service.js";
 import {
   interruptSessionWorkAdmissions,
@@ -543,6 +549,11 @@ describe("plugin runtime session creation", () => {
         const persistedPluginExtensions = {
           codex: { supervision: { initializing: true, sourceThreadId: "source-1" } },
         };
+        const mainRestartRecovery = {
+          chargedAttempts: 1,
+          cycleId: "create-recovery-cycle",
+          revision: 1,
+        };
         fs.mkdirSync(path.dirname(sessionFile), { recursive: true });
         fs.writeFileSync(
           sessionFile,
@@ -562,6 +573,10 @@ describe("plugin runtime session creation", () => {
             spawnedCwd: "/workspace/project",
           },
         });
+        await replaceInternalSessionEntry({ sessionKey: key, storePath }, {
+          ...loadInternalSessionEntry({ sessionKey: key, storePath })!,
+          mainRestartRecovery,
+        } as InternalSessionEntry);
 
         const recovered = await runtime.session.createSessionEntry({
           cfg: {},
@@ -576,6 +591,7 @@ describe("plugin runtime session creation", () => {
           afterCreate: async (created) => {
             expect(created.sessionId).toBe(sessionId);
             expect(created.entry.initializationPending).toBe(true);
+            expect(created.entry).not.toHaveProperty("mainRestartRecovery");
             return {
               pluginExtensions: {
                 codex: { supervision: { sourceThreadId: "source-1", modelLocked: true } },
@@ -586,12 +602,16 @@ describe("plugin runtime session creation", () => {
 
         expect(recovered.sessionId).toBe(sessionId);
         expect(recovered.entry.initializationPending).toBeUndefined();
+        expect(recovered.entry).not.toHaveProperty("mainRestartRecovery");
         expect(recovered.entry.pluginExtensions).toEqual({
           codex: { supervision: { sourceThreadId: "source-1", modelLocked: true } },
         });
         expect(
           runtime.session.getSessionEntry({ sessionKey: key, readConsistency: "latest" }),
         ).toEqual(recovered.entry);
+        expect(loadInternalSessionEntry({ sessionKey: key, storePath })).toMatchObject({
+          mainRestartRecovery,
+        });
       },
     );
   });
@@ -863,6 +883,94 @@ describe("plugin runtime session creation", () => {
         ).toMatchObject({ sessionId: key, updatedAt, groupActivation: "always" });
       },
     );
+  });
+});
+
+describe("plugin runtime session isolation", () => {
+  it("hides, preserves, and clears core recovery state through the injected facade", async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-plugin-session-isolation-"));
+    const storePath = path.join(tempDir, "sessions.json");
+    const sessionKey = "agent:main:plugin-runtime-isolation";
+    const mainRestartRecovery = {
+      chargedAttempts: 1,
+      cycleId: "runtime-cycle",
+      reservation: {
+        attempt: 1,
+        lifecycleGeneration: "runtime-generation",
+        runId: "runtime-run",
+      },
+      revision: 1,
+    };
+
+    try {
+      await replaceInternalSessionEntry({ sessionKey, storePath }, {
+        mainRestartRecovery,
+        model: "gpt-5.5",
+        sessionId: "runtime-session-before",
+        updatedAt: 10,
+      } as InternalSessionEntry);
+      const runtime = createRuntimeAgent();
+
+      expect(runtime.session.getSessionEntry({ sessionKey, storePath })).not.toHaveProperty(
+        "mainRestartRecovery",
+      );
+      expect(runtime.session.listSessionEntries({ storePath })[0]?.entry).not.toHaveProperty(
+        "mainRestartRecovery",
+      );
+
+      let callbackSawPrivateState = false;
+      await runtime.session.patchSessionEntry({
+        sessionKey,
+        storePath,
+        update: (entry) => {
+          callbackSawPrivateState = Object.hasOwn(entry, "mainRestartRecovery");
+          return {
+            mainRestartRecovery: {
+              chargedAttempts: 99,
+              cycleId: "runtime-injection",
+              revision: 99,
+            },
+            model: "gpt-5.6",
+          } as unknown as Partial<SessionEntry>;
+        },
+      });
+      expect(callbackSawPrivateState).toBe(false);
+      expect(loadInternalSessionEntry({ sessionKey, storePath })).toMatchObject({
+        mainRestartRecovery,
+        model: "gpt-5.6",
+      });
+
+      await runtime.session.upsertSessionEntry({
+        entry: {
+          sessionId: "runtime-session-before",
+          updatedAt: 20,
+        },
+        sessionKey,
+        storePath,
+      });
+      expect(loadInternalSessionEntry({ sessionKey, storePath })).toMatchObject({
+        mainRestartRecovery,
+        sessionId: "runtime-session-before",
+      });
+
+      await runtime.session.updateSessionStoreEntry({
+        sessionKey,
+        skipMaintenance: true,
+        storePath,
+        update: () => ({
+          sessionId: "runtime-session-after",
+          updatedAt: 30,
+        }),
+      });
+      expect(loadInternalSessionEntry({ sessionKey, storePath })).toMatchObject({
+        sessionId: "runtime-session-after",
+      });
+      expect(loadInternalSessionEntry({ sessionKey, storePath })).not.toHaveProperty(
+        "mainRestartRecovery",
+      );
+    } finally {
+      fs.rmSync(tempDir, { force: true, recursive: true });
+    }
   });
 });
 

--- a/src/plugins/runtime/runtime-agent.ts
+++ b/src/plugins/runtime/runtime-agent.ts
@@ -17,19 +17,15 @@ import { ensureAgentWorkspace } from "../../agents/workspace.js";
 import { normalizeThinkLevel, resolveThinkingProfile } from "../../auto-reply/thinking.js";
 import { getRuntimeConfig } from "../../config/config.js";
 import { resolveSessionWorkStartError } from "../../config/sessions/lifecycle.js";
+import type { InternalSessionEntry } from "../../config/sessions/main-session-recovery.types.js";
 import { resolveStorePath } from "../../config/sessions/paths.js";
 import {
   deleteSessionEntryLifecycle,
-  listSessionEntries as listAccessorSessionEntries,
   loadSessionEntry,
   patchSessionEntry as patchAccessorSessionEntry,
-  replaceSessionEntry,
   rollbackAgentHarnessSessionEntryLifecycle,
   rollbackPluginOwnedSessionEntryLifecycle,
-  type SessionAccessScope,
-  updateSessionEntry,
 } from "../../config/sessions/session-accessor.js";
-import { normalizeResolvedMaintenanceConfigInput } from "../../config/sessions/store-maintenance.js";
 import type { ResolvedSessionMaintenanceConfigInput } from "../../config/sessions/store.js";
 import type { SessionEntry } from "../../config/sessions/types.js";
 import {
@@ -40,6 +36,14 @@ import {
 import { createLazyRuntimeMethod, createLazyRuntimeModule } from "../../shared/lazy-runtime.js";
 import { resolveRuntimeThinkingCatalog } from "./runtime-agent-thinking.js";
 import { defineCachedValue } from "./runtime-cache.js";
+import {
+  getPluginSessionEntry,
+  listPluginSessionEntries,
+  patchPluginSessionEntry,
+  projectPluginSessionEntry,
+  updatePluginSessionStoreEntry,
+  upsertPluginSessionEntry,
+} from "./session-store-facade.js";
 import type { PluginRuntime } from "./types.js";
 
 type RuntimeSessionStoreReadParams = {
@@ -88,75 +92,30 @@ const loadEmbeddedAgentRuntime = createLazyRuntimeModule(
   () => import("./runtime-embedded-agent.runtime.js"),
 );
 
-function toSessionAccessScope(params: RuntimeSessionStoreReadParams): SessionAccessScope {
-  // Keep plugin runtime parameters aligned with the public SDK wrapper while
-  // avoiding direct exposure of internal accessor-only options.
-  return {
-    sessionKey: params.sessionKey,
-    ...(params.agentId !== undefined ? { agentId: params.agentId } : {}),
-    ...(params.env !== undefined ? { env: params.env } : {}),
-    ...(params.hydrateSkillPromptRefs !== undefined
-      ? { hydrateSkillPromptRefs: params.hydrateSkillPromptRefs }
-      : {}),
-    ...(params.readConsistency !== undefined ? { readConsistency: params.readConsistency } : {}),
-    ...(params.storePath !== undefined ? { storePath: params.storePath } : {}),
-  };
-}
-
 function getSessionEntry(params: RuntimeSessionStoreReadParams): SessionEntry | undefined {
-  return loadSessionEntry(toSessionAccessScope(params));
+  return getPluginSessionEntry(params);
 }
 
 function listSessionEntries(
   params: RuntimeSessionStoreListParams = {},
 ): RuntimeSessionStoreEntrySummary[] {
-  return listAccessorSessionEntries({
-    ...(params.agentId !== undefined ? { agentId: params.agentId } : {}),
-    ...(params.env !== undefined ? { env: params.env } : {}),
-    ...(params.hydrateSkillPromptRefs !== undefined
-      ? { hydrateSkillPromptRefs: params.hydrateSkillPromptRefs }
-      : {}),
-    ...(params.storePath !== undefined ? { storePath: params.storePath } : {}),
-  });
+  return listPluginSessionEntries(params);
 }
 
 async function patchSessionEntry(
   params: RuntimeSessionStoreEntryPatchParams,
 ): Promise<SessionEntry | null> {
-  return await patchAccessorSessionEntry(toSessionAccessScope(params), params.update, {
-    fallbackEntry: params.fallbackEntry,
-    maintenanceConfig:
-      params.maintenanceConfig !== undefined
-        ? normalizeResolvedMaintenanceConfigInput(params.maintenanceConfig)
-        : undefined,
-    preserveActivity: params.preserveActivity,
-    replaceEntry: params.replaceEntry,
-  });
+  return await patchPluginSessionEntry(params);
 }
 
 async function updateSessionStoreEntry(
   params: RuntimeSessionStoreEntryUpdateParams,
 ): Promise<SessionEntry | null> {
-  // Maintainer note: keep the legacy object-parameter API here, but route
-  // mutations through the session accessor boundary.
-  return await updateSessionEntry(
-    {
-      sessionKey: params.sessionKey,
-      storePath: params.storePath,
-    },
-    params.update,
-    {
-      skipMaintenance: params.skipMaintenance,
-      takeCacheOwnership: params.takeCacheOwnership,
-      requireWriteSuccess: params.requireWriteSuccess,
-    },
-  );
+  return await updatePluginSessionStoreEntry(params);
 }
 
 async function upsertSessionEntry(params: RuntimeUpsertSessionEntryParams): Promise<void> {
-  // Maintainer note: this compatibility helper has full-entry replacement
-  // semantics, so removed fields must not survive as merge leftovers.
-  await replaceSessionEntry(toSessionAccessScope(params), params.entry);
+  await upsertPluginSessionEntry(params);
 }
 
 async function createSessionEntry(
@@ -193,18 +152,19 @@ async function createSessionEntry(
       const afterCreate = params.afterCreate;
       let callbackContext: CreatedContext | undefined;
       let finalEntryPatch: { pluginExtensions: SessionEntry["pluginExtensions"] } | undefined;
-      let rollbackExpectedEntry: SessionEntry | undefined;
+      let rollbackExpectedEntry: InternalSessionEntry | undefined;
       const runAfterCreate = async (context: CreatedContext): Promise<void> => {
         callbackContext = context;
         rollbackExpectedEntry = structuredClone(context.entry);
         if (!afterCreate) {
           return;
         }
+        const publicEntry = projectPluginSessionEntry(context.entry);
         const finalPatch = await afterCreate({
           key: context.key,
           agentId: context.agentId,
-          sessionId: context.entry.sessionId,
-          entry: structuredClone(context.entry),
+          sessionId: publicEntry.sessionId,
+          entry: structuredClone(publicEntry),
         });
         if (finalPatch === undefined) {
           return;
@@ -220,14 +180,14 @@ async function createSessionEntry(
       try {
         const matchingEntry =
           params.recoverMatchingInitialEntry === true
-            ? getSessionEntry({
+            ? loadSessionEntry({
                 sessionKey: target.canonicalKey,
                 storePath: target.storePath,
                 readConsistency: "latest",
               })
             : undefined;
         let recovered = false;
-        let created: { key: string; agentId: string; entry: SessionEntry };
+        let created: { key: string; agentId: string; entry: InternalSessionEntry };
         if (matchingEntry) {
           const expectedSpawnedCwd = params.spawnedCwd?.trim() || undefined;
           const expectedExecNode = params.execNode?.trim() || undefined;
@@ -351,7 +311,7 @@ async function createSessionEntry(
           key: created.key,
           agentId: created.agentId,
           sessionId: finalEntry.sessionId,
-          entry: finalEntry,
+          entry: projectPluginSessionEntry(finalEntry),
         };
       } catch (error) {
         if (!callbackContext) {

--- a/src/plugins/runtime/runtime-agent.ts
+++ b/src/plugins/runtime/runtime-agent.ts
@@ -27,7 +27,6 @@ import {
   rollbackPluginOwnedSessionEntryLifecycle,
 } from "../../config/sessions/session-accessor.js";
 import type { ResolvedSessionMaintenanceConfigInput } from "../../config/sessions/store.js";
-import type { SessionEntry } from "../../config/sessions/types.js";
 import {
   beginSessionWorkAdmission,
   isSessionWorkAdmissionActive,
@@ -43,6 +42,7 @@ import {
   projectPluginSessionEntry,
   updatePluginSessionStoreEntry,
   upsertPluginSessionEntry,
+  type PluginSessionEntry as SessionEntry,
 } from "./session-store-facade.js";
 import type { PluginRuntime } from "./types.js";
 

--- a/src/plugins/runtime/runtime-channel.test.ts
+++ b/src/plugins/runtime/runtime-channel.test.ts
@@ -28,10 +28,16 @@ describe("session runtime", () => {
       cycleId: "channel-cycle",
       revision: 1,
     };
+    const restartRecoveryState = {
+      restartRecoveryBeforeAgentReplyState: "continue" as const,
+      restartRecoveryRequesterAccountId: "channel-account",
+      restartRecoverySourceIngress: "channel" as const,
+    };
 
     try {
       await replaceInternalSessionEntry({ sessionKey, storePath }, {
         mainRestartRecovery,
+        ...restartRecoveryState,
         sessionId: "channel-session",
         updatedAt: 10,
       } as InternalSessionEntry);
@@ -47,8 +53,10 @@ describe("session runtime", () => {
         storePath,
       });
       expect(recorded).not.toHaveProperty("mainRestartRecovery");
+      expect(recorded).not.toHaveProperty("restartRecoveryBeforeAgentReplyState");
       expect(loadInternalSessionEntry({ sessionKey, storePath })).toMatchObject({
         mainRestartRecovery,
+        ...restartRecoveryState,
         origin: expect.objectContaining({ provider: "telegram" }),
       });
 
@@ -59,10 +67,12 @@ describe("session runtime", () => {
         to: "user:1",
       });
       expect(routed).not.toHaveProperty("mainRestartRecovery");
+      expect(routed).not.toHaveProperty("restartRecoveryBeforeAgentReplyState");
       expect(loadInternalSessionEntry({ sessionKey, storePath })).toMatchObject({
         lastChannel: "telegram",
         lastTo: "user:1",
         mainRestartRecovery,
+        ...restartRecoveryState,
       });
     } finally {
       fs.rmSync(tempDir, { force: true, recursive: true });

--- a/src/plugins/runtime/runtime-channel.test.ts
+++ b/src/plugins/runtime/runtime-channel.test.ts
@@ -1,5 +1,13 @@
 // Runtime channel tests cover channel plugin runtime send, reply, and capability behavior.
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
+import type { InternalSessionEntry } from "../../config/sessions/main-session-recovery.types.js";
+import {
+  loadSessionEntry as loadInternalSessionEntry,
+  replaceSessionEntry as replaceInternalSessionEntry,
+} from "../../config/sessions/session-accessor.js";
 import { createRuntimeChannel } from "./runtime-channel.js";
 
 function requireWatcherEvent(mock: ReturnType<typeof vi.fn>, index: number) {
@@ -9,6 +17,58 @@ function requireWatcherEvent(mock: ReturnType<typeof vi.fn>, index: number) {
   }
   return event;
 }
+
+describe("session runtime", () => {
+  it("keeps core recovery state private in channel metadata helper results", async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-channel-session-isolation-"));
+    const storePath = path.join(tempDir, "sessions.json");
+    const sessionKey = "agent:main:telegram:direct:runtime-isolation";
+    const mainRestartRecovery = {
+      chargedAttempts: 1,
+      cycleId: "channel-cycle",
+      revision: 1,
+    };
+
+    try {
+      await replaceInternalSessionEntry({ sessionKey, storePath }, {
+        mainRestartRecovery,
+        sessionId: "channel-session",
+        updatedAt: 10,
+      } as InternalSessionEntry);
+      const channel = createRuntimeChannel();
+      const recorded = await channel.session.recordSessionMetaFromInbound({
+        createIfMissing: false,
+        ctx: {
+          From: "user:1",
+          OriginatingChannel: "telegram",
+          To: "bot:1",
+        },
+        sessionKey,
+        storePath,
+      });
+      expect(recorded).not.toHaveProperty("mainRestartRecovery");
+      expect(loadInternalSessionEntry({ sessionKey, storePath })).toMatchObject({
+        mainRestartRecovery,
+        origin: expect.objectContaining({ provider: "telegram" }),
+      });
+
+      const routed = await channel.session.updateLastRoute({
+        channel: "telegram",
+        sessionKey,
+        storePath,
+        to: "user:1",
+      });
+      expect(routed).not.toHaveProperty("mainRestartRecovery");
+      expect(loadInternalSessionEntry({ sessionKey, storePath })).toMatchObject({
+        lastChannel: "telegram",
+        lastTo: "user:1",
+        mainRestartRecovery,
+      });
+    } finally {
+      fs.rmSync(tempDir, { force: true, recursive: true });
+    }
+  });
+});
 
 describe("runtimeContexts", () => {
   it("registers, resolves, watches, and unregisters contexts", () => {

--- a/src/plugins/runtime/runtime-channel.ts
+++ b/src/plugins/runtime/runtime-channel.ts
@@ -65,11 +65,7 @@ import {
 import { resolveMarkdownTableMode } from "../../config/markdown-tables.js";
 import { resolveStorePath } from "../../config/sessions.js";
 import { resolveSessionEntryResetFreshness } from "../../config/sessions/entry-freshness.js";
-import {
-  readSessionUpdatedAt,
-  recordInboundSessionMeta,
-  updateSessionLastRoute,
-} from "../../config/sessions/session-accessor.js";
+import { readSessionUpdatedAt } from "../../config/sessions/session-accessor.js";
 import { getChannelActivity, recordChannelActivity } from "../../infra/channel-activity.js";
 import {
   fetchRemoteMedia,
@@ -86,6 +82,10 @@ import {
 } from "../../pairing/pairing-store.js";
 import { buildAgentSessionKey, resolveAgentRoute } from "../../routing/resolve-route.js";
 import { createChannelRuntimeContextRegistry } from "./channel-runtime-contexts.js";
+import {
+  recordPluginSessionMetaFromInbound,
+  updatePluginSessionLastRoute,
+} from "./session-store-facade.js";
 import type { PluginRuntime } from "./types.js";
 
 export function createRuntimeChannel(): PluginRuntime["channel"] {
@@ -94,9 +94,9 @@ export function createRuntimeChannel(): PluginRuntime["channel"] {
     readSessionUpdatedAt,
     // Plugin runtime property names are a shipped contract; the implementations
     // route through the session accessor boundary.
-    recordSessionMetaFromInbound: recordInboundSessionMeta,
+    recordSessionMetaFromInbound: recordPluginSessionMetaFromInbound,
     recordInboundSession,
-    updateLastRoute: updateSessionLastRoute,
+    updateLastRoute: updatePluginSessionLastRoute,
     resolveEntryResetFreshness: resolveSessionEntryResetFreshness,
   };
   const channelRuntime = {

--- a/src/plugins/runtime/session-store-facade.ts
+++ b/src/plugins/runtime/session-store-facade.ts
@@ -1,5 +1,9 @@
 import type { InternalSessionEntry } from "../../config/sessions/main-session-recovery.types.js";
 import {
+  isCoreRestartRecoverySessionEntryKey,
+  type CoreRestartRecoverySessionEntryKey,
+} from "../../config/sessions/restart-recovery-private-keys.js";
+import {
   listSessionEntries as listAccessorSessionEntries,
   loadSessionEntry,
   patchSessionEntry as patchAccessorSessionEntry,
@@ -12,7 +16,12 @@ import {
 } from "../../config/sessions/session-accessor.js";
 import { normalizeResolvedMaintenanceConfigInput } from "../../config/sessions/store-maintenance.js";
 import type { ResolvedSessionMaintenanceConfigInput } from "../../config/sessions/store.js";
-import type { SessionEntry } from "../../config/sessions/types.js";
+
+export type PluginSessionEntry = Omit<InternalSessionEntry, CoreRestartRecoverySessionEntryKey>;
+
+type CoreRestartRecoveryState = Partial<
+  Pick<InternalSessionEntry, CoreRestartRecoverySessionEntryKey>
+>;
 
 export type SessionStoreReadParams = {
   agentId?: string;
@@ -27,20 +36,20 @@ type SessionStoreListParams = Partial<Omit<SessionStoreReadParams, "sessionKey">
 
 type SessionStoreEntrySummary = {
   sessionKey: string;
-  entry: SessionEntry;
+  entry: PluginSessionEntry;
 };
 
 type SessionStoreEntryUpdate = (
-  entry: SessionEntry,
-) => Promise<Partial<SessionEntry> | null> | Partial<SessionEntry> | null;
+  entry: PluginSessionEntry,
+) => Promise<Partial<PluginSessionEntry> | null> | Partial<PluginSessionEntry> | null;
 
 type SessionStoreEntryPatch = (
-  entry: SessionEntry,
-  context: { existingEntry?: SessionEntry },
-) => Promise<Partial<SessionEntry> | null> | Partial<SessionEntry> | null;
+  entry: PluginSessionEntry,
+  context: { existingEntry?: PluginSessionEntry },
+) => Promise<Partial<PluginSessionEntry> | null> | Partial<PluginSessionEntry> | null;
 
 type PatchSessionEntryParams = SessionStoreReadParams & {
-  fallbackEntry?: SessionEntry;
+  fallbackEntry?: PluginSessionEntry;
   maintenanceConfig?: ResolvedSessionMaintenanceConfigInput;
   preserveActivity?: boolean;
   requireWriteSuccess?: boolean;
@@ -58,7 +67,7 @@ type UpdateSessionStoreEntryParams = {
   requireWriteSuccess?: boolean;
 };
 
-type UpsertSessionEntryParams = SessionStoreReadParams & { entry: SessionEntry };
+type UpsertSessionEntryParams = SessionStoreReadParams & { entry: PluginSessionEntry };
 
 export function toPluginSessionAccessScope(params: SessionStoreReadParams): SessionAccessScope {
   return {
@@ -73,21 +82,31 @@ export function toPluginSessionAccessScope(params: SessionStoreReadParams): Sess
   };
 }
 
-export function projectPluginSessionEntry(entry: InternalSessionEntry): SessionEntry {
-  const { mainRestartRecovery: _mainRestartRecovery, ...publicEntry } = entry;
-  return publicEntry;
+export function projectPluginSessionEntry(entry: InternalSessionEntry): PluginSessionEntry {
+  const publicEntry = { ...entry } as Record<string, unknown>;
+  for (const key of Object.keys(publicEntry)) {
+    if (isCoreRestartRecoverySessionEntryKey(key)) {
+      delete publicEntry[key];
+    }
+  }
+  return publicEntry as PluginSessionEntry;
 }
 
 function projectPluginSessionEntryPatch(
   patch: Partial<InternalSessionEntry>,
-): Partial<SessionEntry> {
-  const { mainRestartRecovery: _mainRestartRecovery, ...publicPatch } = patch;
-  return publicPatch;
+): Partial<PluginSessionEntry> {
+  const publicPatch = { ...patch } as Record<string, unknown>;
+  for (const key of Object.keys(publicPatch)) {
+    if (isCoreRestartRecoverySessionEntryKey(key)) {
+      delete publicPatch[key];
+    }
+  }
+  return publicPatch as Partial<PluginSessionEntry>;
 }
 
 export function projectPluginSessionStore(
   store: Record<string, InternalSessionEntry>,
-): Record<string, SessionEntry> {
+): Record<string, PluginSessionEntry> {
   return Object.fromEntries(
     Object.entries(store).map(([sessionKey, entry]) => [
       sessionKey,
@@ -96,17 +115,31 @@ export function projectPluginSessionStore(
   );
 }
 
+function readCoreRestartRecoveryState(
+  entry: InternalSessionEntry,
+): CoreRestartRecoveryState | undefined {
+  const recoveryState = {} as Record<string, unknown>;
+  for (const [key, value] of Object.entries(entry)) {
+    if (isCoreRestartRecoverySessionEntryKey(key)) {
+      recoveryState[key] = value;
+    }
+  }
+  return Object.keys(recoveryState).length > 0
+    ? (recoveryState as CoreRestartRecoveryState)
+    : undefined;
+}
+
 function recoveryStateForSameSession(
   existingEntry: InternalSessionEntry | undefined,
   nextSessionId: string | undefined,
-): InternalSessionEntry["mainRestartRecovery"] {
+): CoreRestartRecoveryState | undefined {
   return existingEntry && existingEntry.sessionId === nextSessionId
-    ? existingEntry.mainRestartRecovery
+    ? readCoreRestartRecoveryState(existingEntry)
     : undefined;
 }
 
 function indexSessionKeysBySessionId(
-  store: Record<string, Pick<SessionEntry, "sessionId">>,
+  store: Record<string, Pick<PluginSessionEntry, "sessionId">>,
 ): Map<string, string[]> {
   const keysBySessionId = new Map<string, string[]>();
   for (const [sessionKey, entry] of Object.entries(store)) {
@@ -125,17 +158,24 @@ function indexSessionKeysBySessionId(
 
 function clearRecoveryStateForRotatedMergePatch(
   existingEntry: InternalSessionEntry,
-  publicPatch: Partial<SessionEntry>,
+  publicPatch: Partial<PluginSessionEntry>,
 ): Partial<InternalSessionEntry> {
   const nextSessionId = publicPatch.sessionId ?? existingEntry.sessionId;
-  return nextSessionId !== existingEntry.sessionId
-    ? { ...publicPatch, mainRestartRecovery: undefined }
-    : publicPatch;
+  if (nextSessionId === existingEntry.sessionId) {
+    return publicPatch;
+  }
+  const rotatedPatch = { ...publicPatch } as Record<string, unknown>;
+  for (const key of Object.keys(existingEntry)) {
+    if (isCoreRestartRecoverySessionEntryKey(key)) {
+      rotatedPatch[key] = undefined;
+    }
+  }
+  return rotatedPatch as Partial<InternalSessionEntry>;
 }
 
 export function reconcilePluginSessionStore(params: {
   internalStore: Record<string, InternalSessionEntry>;
-  publicStore: Record<string, SessionEntry>;
+  publicStore: Record<string, PluginSessionEntry>;
 }): void {
   const originalStore = { ...params.internalStore };
   const originalKeysBySessionId = indexSessionKeysBySessionId(originalStore);
@@ -155,16 +195,19 @@ export function reconcilePluginSessionStore(params: {
       const originalKeys = originalKeysBySessionId.get(projectedEntry.sessionId);
       const publicKeys = publicKeysBySessionId.get(projectedEntry.sessionId);
       if (originalKeys?.length === 1 && publicKeys?.length === 1) {
-        existingRecovery = originalStore[originalKeys[0]!]?.mainRestartRecovery;
+        const originalEntry = originalStore[originalKeys[0]!];
+        existingRecovery = originalEntry ? readCoreRestartRecoveryState(originalEntry) : undefined;
       }
     }
     params.internalStore[sessionKey] = existingRecovery
-      ? { ...projectedEntry, mainRestartRecovery: existingRecovery }
+      ? { ...projectedEntry, ...existingRecovery }
       : projectedEntry;
   }
 }
 
-export function getPluginSessionEntry(params: SessionStoreReadParams): SessionEntry | undefined {
+export function getPluginSessionEntry(
+  params: SessionStoreReadParams,
+): PluginSessionEntry | undefined {
   const entry = loadSessionEntry(toPluginSessionAccessScope(params));
   return entry ? projectPluginSessionEntry(entry) : undefined;
 }
@@ -187,7 +230,7 @@ export function listPluginSessionEntries(
 
 export async function patchPluginSessionEntry(
   params: PatchSessionEntryParams,
-): Promise<SessionEntry | null> {
+): Promise<PluginSessionEntry | null> {
   const entry = await patchAccessorSessionEntry(
     toPluginSessionAccessScope(params),
     async (internalEntry, context) => {
@@ -205,7 +248,7 @@ export async function patchPluginSessionEntry(
       return params.replaceEntry
         ? {
             ...publicPatch,
-            ...(existingRecovery ? { mainRestartRecovery: existingRecovery } : {}),
+            ...existingRecovery,
           }
         : clearRecoveryStateForRotatedMergePatch(persistedEntry, publicPatch);
     },
@@ -228,7 +271,7 @@ export async function patchPluginSessionEntry(
 
 export async function updatePluginSessionStoreEntry(
   params: UpdateSessionStoreEntryParams,
-): Promise<SessionEntry | null> {
+): Promise<PluginSessionEntry | null> {
   const entry = await updateSessionEntry(
     { sessionKey: params.sessionKey, storePath: params.storePath },
     async (internalEntry) => {
@@ -260,7 +303,7 @@ export async function upsertPluginSessionEntry(params: UpsertSessionEntryParams)
       );
       return {
         ...publicEntry,
-        ...(existingRecovery ? { mainRestartRecovery: existingRecovery } : {}),
+        ...existingRecovery,
       };
     },
     { fallbackEntry: publicEntry, replaceEntry: true },
@@ -269,14 +312,14 @@ export async function upsertPluginSessionEntry(params: UpsertSessionEntryParams)
 
 export async function recordPluginSessionMetaFromInbound(
   params: RecordInboundSessionMetaParams,
-): Promise<SessionEntry | null> {
+): Promise<PluginSessionEntry | null> {
   const entry = await recordAccessorInboundSessionMeta(params);
   return entry ? projectPluginSessionEntry(entry) : null;
 }
 
 export async function updatePluginSessionLastRoute(
   params: UpdateSessionLastRouteParams,
-): Promise<SessionEntry | null> {
+): Promise<PluginSessionEntry | null> {
   const entry = await updateAccessorSessionLastRoute(params);
   return entry ? projectPluginSessionEntry(entry) : null;
 }

--- a/src/plugins/runtime/session-store-facade.ts
+++ b/src/plugins/runtime/session-store-facade.ts
@@ -105,6 +105,24 @@ function recoveryStateForSameSession(
     : undefined;
 }
 
+function indexSessionKeysBySessionId(
+  store: Record<string, Pick<SessionEntry, "sessionId">>,
+): Map<string, string[]> {
+  const keysBySessionId = new Map<string, string[]>();
+  for (const [sessionKey, entry] of Object.entries(store)) {
+    if (!entry.sessionId) {
+      continue;
+    }
+    const existing = keysBySessionId.get(entry.sessionId);
+    if (existing) {
+      existing.push(sessionKey);
+    } else {
+      keysBySessionId.set(entry.sessionId, [sessionKey]);
+    }
+  }
+  return keysBySessionId;
+}
+
 function clearRecoveryStateForRotatedMergePatch(
   existingEntry: InternalSessionEntry,
   publicPatch: Partial<SessionEntry>,
@@ -119,6 +137,9 @@ export function reconcilePluginSessionStore(params: {
   internalStore: Record<string, InternalSessionEntry>;
   publicStore: Record<string, SessionEntry>;
 }): void {
+  const originalStore = { ...params.internalStore };
+  const originalKeysBySessionId = indexSessionKeysBySessionId(originalStore);
+  const publicKeysBySessionId = indexSessionKeysBySessionId(params.publicStore);
   for (const sessionKey of Object.keys(params.internalStore)) {
     if (!Object.hasOwn(params.publicStore, sessionKey)) {
       delete params.internalStore[sessionKey];
@@ -126,10 +147,17 @@ export function reconcilePluginSessionStore(params: {
   }
   for (const [sessionKey, publicEntry] of Object.entries(params.publicStore)) {
     const projectedEntry = projectPluginSessionEntry(publicEntry as InternalSessionEntry);
-    const existingRecovery = recoveryStateForSameSession(
-      params.internalStore[sessionKey],
+    let existingRecovery = recoveryStateForSameSession(
+      originalStore[sessionKey],
       projectedEntry.sessionId,
     );
+    if (existingRecovery === undefined && projectedEntry.sessionId) {
+      const originalKeys = originalKeysBySessionId.get(projectedEntry.sessionId);
+      const publicKeys = publicKeysBySessionId.get(projectedEntry.sessionId);
+      if (originalKeys?.length === 1 && publicKeys?.length === 1) {
+        existingRecovery = originalStore[originalKeys[0]!]?.mainRestartRecovery;
+      }
+    }
     params.internalStore[sessionKey] = existingRecovery
       ? { ...projectedEntry, mainRestartRecovery: existingRecovery }
       : projectedEntry;

--- a/src/plugins/runtime/session-store-facade.ts
+++ b/src/plugins/runtime/session-store-facade.ts
@@ -1,0 +1,254 @@
+import type { InternalSessionEntry } from "../../config/sessions/main-session-recovery.types.js";
+import {
+  listSessionEntries as listAccessorSessionEntries,
+  loadSessionEntry,
+  patchSessionEntry as patchAccessorSessionEntry,
+  recordInboundSessionMeta as recordAccessorInboundSessionMeta,
+  updateSessionEntry,
+  updateSessionLastRoute as updateAccessorSessionLastRoute,
+  type RecordInboundSessionMetaParams,
+  type SessionAccessScope,
+  type UpdateSessionLastRouteParams,
+} from "../../config/sessions/session-accessor.js";
+import { normalizeResolvedMaintenanceConfigInput } from "../../config/sessions/store-maintenance.js";
+import type { ResolvedSessionMaintenanceConfigInput } from "../../config/sessions/store.js";
+import type { SessionEntry } from "../../config/sessions/types.js";
+
+export type SessionStoreReadParams = {
+  agentId?: string;
+  env?: NodeJS.ProcessEnv;
+  hydrateSkillPromptRefs?: boolean;
+  readConsistency?: "latest";
+  sessionKey: string;
+  storePath?: string;
+};
+
+type SessionStoreListParams = Partial<Omit<SessionStoreReadParams, "sessionKey">>;
+
+type SessionStoreEntrySummary = {
+  sessionKey: string;
+  entry: SessionEntry;
+};
+
+type SessionStoreEntryUpdate = (
+  entry: SessionEntry,
+) => Promise<Partial<SessionEntry> | null> | Partial<SessionEntry> | null;
+
+type SessionStoreEntryPatch = (
+  entry: SessionEntry,
+  context: { existingEntry?: SessionEntry },
+) => Promise<Partial<SessionEntry> | null> | Partial<SessionEntry> | null;
+
+type PatchSessionEntryParams = SessionStoreReadParams & {
+  fallbackEntry?: SessionEntry;
+  maintenanceConfig?: ResolvedSessionMaintenanceConfigInput;
+  preserveActivity?: boolean;
+  requireWriteSuccess?: boolean;
+  replaceEntry?: boolean;
+  skipMaintenance?: boolean;
+  update: SessionStoreEntryPatch;
+};
+
+type UpdateSessionStoreEntryParams = {
+  storePath: string;
+  sessionKey: string;
+  update: SessionStoreEntryUpdate;
+  skipMaintenance?: boolean;
+  takeCacheOwnership?: boolean;
+  requireWriteSuccess?: boolean;
+};
+
+type UpsertSessionEntryParams = SessionStoreReadParams & { entry: SessionEntry };
+
+export function toPluginSessionAccessScope(params: SessionStoreReadParams): SessionAccessScope {
+  return {
+    sessionKey: params.sessionKey,
+    ...(params.agentId !== undefined ? { agentId: params.agentId } : {}),
+    ...(params.env !== undefined ? { env: params.env } : {}),
+    ...(params.hydrateSkillPromptRefs !== undefined
+      ? { hydrateSkillPromptRefs: params.hydrateSkillPromptRefs }
+      : {}),
+    ...(params.readConsistency !== undefined ? { readConsistency: params.readConsistency } : {}),
+    ...(params.storePath !== undefined ? { storePath: params.storePath } : {}),
+  };
+}
+
+export function projectPluginSessionEntry(entry: InternalSessionEntry): SessionEntry {
+  const { mainRestartRecovery: _mainRestartRecovery, ...publicEntry } = entry;
+  return publicEntry;
+}
+
+function projectPluginSessionEntryPatch(
+  patch: Partial<InternalSessionEntry>,
+): Partial<SessionEntry> {
+  const { mainRestartRecovery: _mainRestartRecovery, ...publicPatch } = patch;
+  return publicPatch;
+}
+
+export function projectPluginSessionStore(
+  store: Record<string, InternalSessionEntry>,
+): Record<string, SessionEntry> {
+  return Object.fromEntries(
+    Object.entries(store).map(([sessionKey, entry]) => [
+      sessionKey,
+      projectPluginSessionEntry(entry),
+    ]),
+  );
+}
+
+function recoveryStateForSameSession(
+  existingEntry: InternalSessionEntry | undefined,
+  nextSessionId: string | undefined,
+): InternalSessionEntry["mainRestartRecovery"] {
+  return existingEntry && existingEntry.sessionId === nextSessionId
+    ? existingEntry.mainRestartRecovery
+    : undefined;
+}
+
+function clearRecoveryStateForRotatedMergePatch(
+  existingEntry: InternalSessionEntry,
+  publicPatch: Partial<SessionEntry>,
+): Partial<InternalSessionEntry> {
+  const nextSessionId = publicPatch.sessionId ?? existingEntry.sessionId;
+  return nextSessionId !== existingEntry.sessionId
+    ? { ...publicPatch, mainRestartRecovery: undefined }
+    : publicPatch;
+}
+
+export function reconcilePluginSessionStore(params: {
+  internalStore: Record<string, InternalSessionEntry>;
+  publicStore: Record<string, SessionEntry>;
+}): void {
+  for (const sessionKey of Object.keys(params.internalStore)) {
+    if (!Object.hasOwn(params.publicStore, sessionKey)) {
+      delete params.internalStore[sessionKey];
+    }
+  }
+  for (const [sessionKey, publicEntry] of Object.entries(params.publicStore)) {
+    const projectedEntry = projectPluginSessionEntry(publicEntry as InternalSessionEntry);
+    const existingRecovery = recoveryStateForSameSession(
+      params.internalStore[sessionKey],
+      projectedEntry.sessionId,
+    );
+    params.internalStore[sessionKey] = existingRecovery
+      ? { ...projectedEntry, mainRestartRecovery: existingRecovery }
+      : projectedEntry;
+  }
+}
+
+export function getPluginSessionEntry(params: SessionStoreReadParams): SessionEntry | undefined {
+  const entry = loadSessionEntry(toPluginSessionAccessScope(params));
+  return entry ? projectPluginSessionEntry(entry) : undefined;
+}
+
+export function listPluginSessionEntries(
+  params: SessionStoreListParams = {},
+): SessionStoreEntrySummary[] {
+  return listAccessorSessionEntries({
+    ...(params.agentId !== undefined ? { agentId: params.agentId } : {}),
+    ...(params.env !== undefined ? { env: params.env } : {}),
+    ...(params.hydrateSkillPromptRefs !== undefined
+      ? { hydrateSkillPromptRefs: params.hydrateSkillPromptRefs }
+      : {}),
+    ...(params.storePath !== undefined ? { storePath: params.storePath } : {}),
+  }).map(({ sessionKey, entry }) => ({
+    sessionKey,
+    entry: projectPluginSessionEntry(entry),
+  }));
+}
+
+export async function patchPluginSessionEntry(
+  params: PatchSessionEntryParams,
+): Promise<SessionEntry | null> {
+  const entry = await patchAccessorSessionEntry(
+    toPluginSessionAccessScope(params),
+    async (internalEntry, context) => {
+      const persistedEntry = internalEntry as InternalSessionEntry;
+      const patch = await params.update(projectPluginSessionEntry(internalEntry), {
+        existingEntry: context.existingEntry
+          ? projectPluginSessionEntry(context.existingEntry)
+          : undefined,
+      });
+      if (!patch) {
+        return null;
+      }
+      const publicPatch = projectPluginSessionEntryPatch(patch);
+      const existingRecovery = recoveryStateForSameSession(persistedEntry, publicPatch.sessionId);
+      return params.replaceEntry
+        ? {
+            ...publicPatch,
+            ...(existingRecovery ? { mainRestartRecovery: existingRecovery } : {}),
+          }
+        : clearRecoveryStateForRotatedMergePatch(persistedEntry, publicPatch);
+    },
+    {
+      fallbackEntry: params.fallbackEntry
+        ? projectPluginSessionEntry(params.fallbackEntry)
+        : undefined,
+      maintenanceConfig:
+        params.maintenanceConfig !== undefined
+          ? normalizeResolvedMaintenanceConfigInput(params.maintenanceConfig)
+          : undefined,
+      preserveActivity: params.preserveActivity,
+      requireWriteSuccess: params.requireWriteSuccess,
+      replaceEntry: params.replaceEntry,
+      skipMaintenance: params.skipMaintenance,
+    },
+  );
+  return entry ? projectPluginSessionEntry(entry) : null;
+}
+
+export async function updatePluginSessionStoreEntry(
+  params: UpdateSessionStoreEntryParams,
+): Promise<SessionEntry | null> {
+  const entry = await updateSessionEntry(
+    { sessionKey: params.sessionKey, storePath: params.storePath },
+    async (internalEntry) => {
+      const patch = await params.update(projectPluginSessionEntry(internalEntry));
+      return patch
+        ? clearRecoveryStateForRotatedMergePatch(
+            internalEntry as InternalSessionEntry,
+            projectPluginSessionEntryPatch(patch),
+          )
+        : null;
+    },
+    {
+      skipMaintenance: params.skipMaintenance,
+      takeCacheOwnership: params.takeCacheOwnership,
+      requireWriteSuccess: params.requireWriteSuccess,
+    },
+  );
+  return entry ? projectPluginSessionEntry(entry) : null;
+}
+
+export async function upsertPluginSessionEntry(params: UpsertSessionEntryParams): Promise<void> {
+  const publicEntry = projectPluginSessionEntry(params.entry);
+  await patchAccessorSessionEntry(
+    toPluginSessionAccessScope(params),
+    (internalEntry) => {
+      const existingRecovery = recoveryStateForSameSession(
+        internalEntry as InternalSessionEntry,
+        publicEntry.sessionId,
+      );
+      return {
+        ...publicEntry,
+        ...(existingRecovery ? { mainRestartRecovery: existingRecovery } : {}),
+      };
+    },
+    { fallbackEntry: publicEntry, replaceEntry: true },
+  );
+}
+
+export async function recordPluginSessionMetaFromInbound(
+  params: RecordInboundSessionMetaParams,
+): Promise<SessionEntry | null> {
+  const entry = await recordAccessorInboundSessionMeta(params);
+  return entry ? projectPluginSessionEntry(entry) : null;
+}
+
+export async function updatePluginSessionLastRoute(
+  params: UpdateSessionLastRouteParams,
+): Promise<SessionEntry | null> {
+  const entry = await updateAccessorSessionLastRoute(params);
+  return entry ? projectPluginSessionEntry(entry) : null;
+}

--- a/src/plugins/runtime/types-channel.ts
+++ b/src/plugins/runtime/types-channel.ts
@@ -33,6 +33,13 @@ import type {
 type DispatchReplyWithBufferedBlockDispatcher =
   import("../../auto-reply/reply/provider-dispatcher.types.js").DispatchReplyWithBufferedBlockDispatcher;
 type RecordInboundSession = import("../../channels/session.types.js").RecordInboundSession;
+type RuntimeSessionEntry = import("./session-store-facade.js").PluginSessionEntry;
+type PluginRecordSessionMetaFromInbound = (
+  params: Parameters<RecordSessionMetaFromInbound>[0],
+) => Promise<RuntimeSessionEntry | null>;
+type PluginUpdateLastRoute = (
+  params: Parameters<UpdateLastRoute>[0],
+) => Promise<RuntimeSessionEntry | null>;
 
 type RuntimeThreadBindingLifecycleRecord =
   | import("../../infra/outbound/session-binding.types.js").SessionBindingRecord
@@ -149,10 +156,10 @@ export type PluginRuntimeChannel = {
     /** @deprecated Prefer channel turn helpers that record inbound sessions as part of dispatch. */
     resolveStorePath: typeof import("../../config/sessions/paths.js").resolveStorePath;
     readSessionUpdatedAt: ReadSessionUpdatedAt;
-    recordSessionMetaFromInbound: RecordSessionMetaFromInbound;
+    recordSessionMetaFromInbound: PluginRecordSessionMetaFromInbound;
     /** @deprecated Prefer channel turn helpers that record inbound sessions as part of dispatch. */
     recordInboundSession: RecordInboundSession;
-    updateLastRoute: UpdateLastRoute;
+    updateLastRoute: PluginUpdateLastRoute;
   };
   mentions: {
     buildMentionRegexes: BuildMentionRegexes;

--- a/src/plugins/runtime/types-core.ts
+++ b/src/plugins/runtime/types-core.ts
@@ -59,7 +59,7 @@ type RuntimeReplaceConfigFileParams = {
   afterWrite: RuntimeConfigAfterWrite;
   writeOptions?: RuntimeWriteConfigOptions;
 };
-type RuntimeSessionEntry = import("../../config/sessions/types.js").SessionEntry;
+type RuntimeSessionEntry = import("./session-store-facade.js").PluginSessionEntry;
 type RuntimeSessionPluginExtensions =
   | Record<string, Record<string, SessionPluginJsonValue>>
   | undefined;

--- a/src/plugins/session-entry-slot-keys.ts
+++ b/src/plugins/session-entry-slot-keys.ts
@@ -1,5 +1,5 @@
 /** Reserves session-entry keys so plugin extension slots cannot collide with core session state. */
-import type { SessionEntry } from "../config/sessions/types.js";
+import type { InternalSessionEntry as SessionEntry } from "../config/sessions/main-session-recovery.types.js";
 
 const SESSION_ENTRY_RESERVED_SLOT_KEY_LIST = [
   "__proto__",
@@ -33,6 +33,7 @@ const SESSION_ENTRY_RESERVED_SLOT_KEY_LIST = [
   "subagentControlScope",
   "inheritedToolDeny",
   "inheritedToolAllow",
+  "mainRestartRecovery",
   "subagentRecovery",
   "pluginOwnerId",
   "systemSent",

--- a/src/plugins/session-entry-slot-keys.ts
+++ b/src/plugins/session-entry-slot-keys.ts
@@ -1,5 +1,6 @@
 /** Reserves session-entry keys so plugin extension slots cannot collide with core session state. */
 import type { InternalSessionEntry as SessionEntry } from "../config/sessions/main-session-recovery.types.js";
+import { isCoreRestartRecoverySessionEntryKey } from "../config/sessions/restart-recovery-private-keys.js";
 
 const SESSION_ENTRY_RESERVED_SLOT_KEY_LIST = [
   "__proto__",
@@ -204,6 +205,12 @@ export function normalizeSessionEntrySlotKey(
     return {
       ok: false,
       error: `sessionEntrySlotKey is reserved by SessionEntry: ${key}`,
+    };
+  }
+  if (isCoreRestartRecoverySessionEntryKey(key)) {
+    return {
+      ok: false,
+      error: `sessionEntrySlotKey is reserved by core restart recovery: ${key}`,
     };
   }
   if (OBJECT_PROTOTYPE_RESERVED_SLOT_KEYS.has(key)) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an isolation gap where core-owned restart-recovery coordination could be exposed, overwritten, or lost through Plugin SDK session APIs.

Upstream now persists channel-turn recovery fields under the `restartRecovery*` namespace. This PR keeps those shipped fields, as well as the later split series' `mainRestartRecovery` aggregate, out of plugin reads, callback inputs, replacements, ACP resolution, and injected runtime surfaces.

The repair also addresses two earlier review findings: an identity-preserving whole-store key move could silently drop private recovery state, and the ACP SDK declared that it returned the internal `AcpSessionManager` class even though the runtime object was already a restricted facade.

## Why This Change Was Made

Plugin-visible session rows now pass through one projection/reconciliation owner. The public `SessionEntry` type omits `mainRestartRecovery` and the complete `restartRecovery*` namespace, matching runtime behavior.

Private recovery state is retained for same-key updates and for a unique one-to-one `sessionId` key move. It is not copied when the source or destination mapping is ambiguous, and it is cleared when the effective session identity changes. Future `restartRecovery*` plugin extension slots are reserved before a new core field can collide with them.

The ACP getter returns an explicit `AcpSessionManagerFacade` interface. The runtime object remains stable, frozen, null-prototype, and limited to bound public methods, so plugins cannot reach the internal manager constructor or bypass session projection.

Compatibility note: released `v2026.7.1-beta.5` / `v2026.7.1` and the frozen PR #96230 returned the real manager class. This PR intentionally does not preserve `instanceof`, prototype, or constructor identity because exposing the internal constructor would reopen the private-session-state escape path. The SDK catalog documents that contract for maintainer review.

## User Impact

Plugin authors continue to use the same session and ACP methods, while current and future core restart-recovery coordination remains private and survives valid session-key moves.

Plugins that relied on `getAcpSessionManager()` being an actual internal class instance must migrate to the structural `AcpSessionManagerFacade` contract. No session schema, storage format, ACP method behavior, retry budget, or production `mainRestartRecovery` writer is added by this PR.

## Evidence

- Recovery isolation matrix: 9 files, 82/82 tests passed across direct Plugin SDK APIs, modern and deprecated whole-store mutation, unique and ambiguous key moves, ACP, agent runtime, channel runtime, combined transcript-store reads, injection rejection, and session identity rotation.
- Plugin SDK surface budget tests: 10/10 passed.
- Public API contract: generated declarations expose the projected `SessionEntry` and `AcpSessionManagerFacade`; no `mainRestartRecovery` or `restartRecovery*` declaration remains in the generated SDK baseline.
- Plugin SDK API baseline, public export budget, formatting, lint, max-lines ratchet, and diff-check passed after syncing to exact base `ff1687e04f11df6c35002c4531cdafba6a845f8f`.
- Upstream's current public Plugin SDK export baseline is 7,991; this PR's reviewed `AcpSessionManagerFacade` is the sole additional export, for a passing budget of 7,992.
- Source audit found no remaining critical, major, minor, security, performance, persistence, or public-contract issue.
- Frozen PR comparison at `edc24088387a8d573798233979a71f3b40a24ac9` confirms that its whole-store implementation lacked cross-key recovery transfer and its ACP SDK returned the internal class directly.
- The branch contains zero production `mainRestartRecovery` producers. Existing upstream `restartRecovery*` writers remain unchanged and now sit behind the Plugin SDK projection boundary.
- Range-diff against the prior reviewed PR2 head found the five functional commits patch-equivalent; the resync changed only upstream surface-budget context and the generated API hash.

Protected local TypeScript validation could not be recorded because this machine cannot attest the required cgroup limits; the guard stopped before execution and was not bypassed. GitHub CI remains the authoritative protected typecheck/build lane.

Per maintainer-requested workflow for this split, the final audit is a complete code-diff/source review rather than a separate automated final-review pass.
