### PR TITLE
fix(reply): preserve finals while successor waits

### DIFF
--- a/src/auto-reply/dispatch.freshness.test.ts
+++ b/src/auto-reply/dispatch.freshness.test.ts
@@ -331,11 +331,11 @@ describe("foreground reply freshness", () => {
         if (params.ctx.MessageSid === "new-message") {
           newerStarted.resolve();
           // Same-session follow-up admission waits for the owning final delivery.
-          params.replyOptions?.onFollowupAdmissionWaitChange?.(true);
+          params.replyOptions?.onReplyAdmissionWaitChange?.(true);
           try {
             await olderDelivered.promise;
           } finally {
-            params.replyOptions?.onFollowupAdmissionWaitChange?.(false);
+            params.replyOptions?.onReplyAdmissionWaitChange?.(false);
           }
           return {
             queuedFinal: false,

--- a/src/auto-reply/dispatch.ts
+++ b/src/auto-reply/dispatch.ts
@@ -660,9 +660,9 @@ export async function dispatchInboundMessageWithBufferedDispatcher(params: {
       replyOptions: {
         ...params.replyOptions,
         ...replyOptions,
-        onFollowupAdmissionWaitChange: (waiting) => {
-          // An admission wait depends on the older owner finishing delivery.
-          // Suspending only that generation breaks the cycle without weakening newer-turn fencing.
+        onReplyAdmissionWaitChange: (waiting) => {
+          // A turn waiting to own the lane cannot make the current owner's reply stale.
+          // Suspend only that generation so independent newer turns still fence old replies.
           setForegroundReplyFenceAdmissionWaiting(foregroundReplyFence, waiting);
         },
       },

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -109,6 +109,7 @@ import {
 import { resolveEffectiveReplyRoute } from "./effective-reply-route.js";
 import { createFollowupRunner } from "./followup-runner.js";
 import { REPLY_RUN_STILL_SHUTTING_DOWN_TEXT } from "./get-reply-run-queue.js";
+import type { InternalGetReplyOptions } from "./get-reply.types.js";
 import { normalizeReplyPayload } from "./normalize-reply.js";
 import { resolveOriginMessageProvider, resolveOriginMessageTo } from "./origin-routing.js";
 import {
@@ -1147,7 +1148,7 @@ export async function runReplyAgent(params: {
   isActive: boolean;
   isRunActive?: () => boolean;
   isStreaming: boolean;
-  opts?: GetReplyOptions;
+  opts?: InternalGetReplyOptions;
   typing: TypingController;
   sessionEntry?: SessionEntry;
   sessionStore?: Record<string, SessionEntry>;
@@ -1206,7 +1207,6 @@ export async function runReplyAgent(params: {
     replyThreadingOverride,
     replyOperation: providedReplyOperation,
   } = params;
-
   let activeSessionEntry = sessionEntry;
   const activeSessionStore = sessionStore;
   let activeIsNewSession = isNewSession;
@@ -1457,7 +1457,6 @@ export async function runReplyAgent(params: {
           buffer: createAudioAsVoiceBuffer({ isAudioPayload }),
         })
       : null;
-
   const replySessionKey = sessionKey ?? followupRun.run.sessionKey;
   const replyRouteThreadId = resolveRoutedDeliveryThreadId({
     ctx: sessionCtx,
@@ -1480,6 +1479,7 @@ export async function runReplyAgent(params: {
       resetTriggered: effectiveResetTriggered,
       routeThreadId: replyRouteThreadId,
       upstreamAbortSignal: opts?.abortSignal,
+      onReplyAdmissionWaitChange: opts?.onReplyAdmissionWaitChange,
     });
     if (replyOperationRunState) {
       replyOperationRunState.admission =

--- a/src/auto-reply/reply/dispatch-from-config.lifecycle.ts
+++ b/src/auto-reply/reply/dispatch-from-config.lifecycle.ts
@@ -193,6 +193,7 @@ export function createDispatchReplyOperationCoordinator(params: {
       waitForActive: !allowActivePreDispatch && !allowSlackRoutedThreadBypass,
       retainLifecycleAdmissionOnActive: allowActivePreDispatch || allowSlackRoutedThreadBypass,
       onLifecycleInterrupt,
+      onReplyAdmissionWaitChange: params.replyOptions?.onReplyAdmissionWaitChange,
     });
     if (
       admission.status === "skipped" &&
@@ -239,6 +240,7 @@ export function createDispatchReplyOperationCoordinator(params: {
           waitForActive: !allowActivePreDispatch && !allowSlackRoutedThreadBypass,
           retainLifecycleAdmissionOnActive: allowActivePreDispatch || allowSlackRoutedThreadBypass,
           onLifecycleInterrupt,
+          onReplyAdmissionWaitChange: params.replyOptions?.onReplyAdmissionWaitChange,
         });
       }
     }

--- a/src/auto-reply/reply/dispatch-from-config.stale-recovery.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.stale-recovery.test.ts
@@ -79,8 +79,14 @@ describe("dispatchReplyFromConfig stale visible admission recovery", () => {
       resetTriggered: false,
     });
     activeOperation.setPhase("running");
+    const waitChanges: boolean[] = [];
     const replyResolver = vi.fn(async () => ({ text: "telegram reply" }) satisfies ReplyPayload);
-    const dispatchParams = createVisibleDispatchParams(replyResolver);
+    const dispatchParams = {
+      ...createVisibleDispatchParams(replyResolver),
+      replyOptions: {
+        onReplyAdmissionWaitChange: (waiting: boolean) => waitChanges.push(waiting),
+      },
+    };
     let settled = false;
 
     const resultPromise = dispatchReplyFromConfig(dispatchParams).then((result) => {
@@ -91,6 +97,7 @@ describe("dispatchReplyFromConfig stale visible admission recovery", () => {
     await vi.advanceTimersByTimeAsync(1_000);
 
     expect(settled).toBe(false);
+    expect(waitChanges).toEqual([true]);
     expect(replyResolver).not.toHaveBeenCalled();
     expect(diagnosticMocks.requestStuckDiagnosticSessionRecovery).not.toHaveBeenCalled();
 
@@ -103,6 +110,7 @@ describe("dispatchReplyFromConfig stale visible admission recovery", () => {
     });
     expect(replyResolver).toHaveBeenCalledTimes(1);
     expect(dispatchParams.dispatcher.sendFinalReply).toHaveBeenCalledTimes(1);
+    expect(waitChanges).toEqual([true, false]);
   });
 
   it("reclaims stale visible reply work through admission and dispatches the turn", async () => {

--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -1077,7 +1077,7 @@ describe("createFollowupRunner reply-lane admission", () => {
 
     const pending = runner(
       createQueuedRun({
-        onFollowupAdmissionWaitChange: (waiting) => waitChanges.push(waiting),
+        onReplyAdmissionWaitChange: (waiting) => waitChanges.push(waiting),
         run: {
           sessionId: "queued-session",
           sessionKey: "main",

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -696,7 +696,7 @@ export function createFollowupRunner(params: {
         resetTriggered: false,
         routeThreadId: queued.originatingThreadId,
         upstreamAbortSignal: resolveFollowupAbortSignal(queued),
-        onFollowupAdmissionWaitChange: effectiveQueued.onFollowupAdmissionWaitChange,
+        onReplyAdmissionWaitChange: effectiveQueued.onReplyAdmissionWaitChange,
       });
       if (admission.status === "skipped") {
         if (admission.reason === "active-run") {

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -1516,7 +1516,7 @@ export async function runPreparedReply(
     ...(queuedFollowupAbortSignal ? { abortSignal: queuedFollowupAbortSignal } : {}),
     deliveryCorrelations: opts?.queuedDeliveryCorrelations,
     queuedLifecycle: opts?.queuedFollowupLifecycle,
-    onFollowupAdmissionWaitChange: opts?.onFollowupAdmissionWaitChange,
+    onReplyAdmissionWaitChange: opts?.onReplyAdmissionWaitChange,
     messageId: sessionCtx.MessageSidFull ?? sessionCtx.MessageSid,
     summaryLine: baseBodyTrimmedRaw,
     enqueuedAt: Date.now(),

--- a/src/auto-reply/reply/get-reply.types.ts
+++ b/src/auto-reply/reply/get-reply.types.ts
@@ -19,8 +19,8 @@ type InternalReplySessionOptions = {
   requestedSessionId?: string;
   resumeRequestedSession?: boolean;
   sessionPromptSourceReplyDeliveryMode?: GetReplyOptions["sourceReplyDeliveryMode"];
-  /** Marks queued follow-up admission waits on an older owner's delivery barrier. */
-  onFollowupAdmissionWaitChange?: (waiting: boolean) => void;
+  /** Marks when this reply is waiting to own its session's reply lane. */
+  onReplyAdmissionWaitChange?: (waiting: boolean) => void;
 };
 
 export type InternalGetReplyOptions = GetReplyOptions &

--- a/src/auto-reply/reply/queue/drain.identity-guard.test.ts
+++ b/src/auto-reply/reply/queue/drain.identity-guard.test.ts
@@ -126,9 +126,9 @@ describe("drain finally identity guard — late D1 must not orphan Q2", () => {
     const firstEntered = createDeferred<void>();
     const firstCallback = () => {};
     const secondCallback = () => {};
-    const callbacks: Array<FollowupRun["onFollowupAdmissionWaitChange"]> = [];
+    const callbacks: Array<FollowupRun["onReplyAdmissionWaitChange"]> = [];
     const firstRunner = async (run: FollowupRun) => {
-      callbacks.push(run.onFollowupAdmissionWaitChange);
+      callbacks.push(run.onReplyAdmissionWaitChange);
       if (callbacks.length === 1) {
         firstEntered.resolve();
         await gate.promise;
@@ -140,7 +140,7 @@ describe("drain finally identity guard — late D1 must not orphan Q2", () => {
 
     enqueueFollowupRun(
       key,
-      { ...createRun({ prompt: "msg1" }), onFollowupAdmissionWaitChange: firstCallback },
+      { ...createRun({ prompt: "msg1" }), onReplyAdmissionWaitChange: firstCallback },
       settings,
       "message-id",
       firstRunner,
@@ -150,7 +150,7 @@ describe("drain finally identity guard — late D1 must not orphan Q2", () => {
 
     enqueueFollowupRun(
       key,
-      { ...createRun({ prompt: "msg2" }), onFollowupAdmissionWaitChange: secondCallback },
+      { ...createRun({ prompt: "msg2" }), onReplyAdmissionWaitChange: secondCallback },
       settings,
       "message-id",
       secondRunner,

--- a/src/auto-reply/reply/queue/drain.ts
+++ b/src/auto-reply/reply/queue/drain.ts
@@ -298,7 +298,7 @@ type FollowupRuntimeMetadata = Pick<
   | "queueAbortSignal"
   | "deliveryCorrelations"
   | "queuedLifecycle"
-  | "onFollowupAdmissionWaitChange"
+  | "onReplyAdmissionWaitChange"
 >;
 
 function hasCurrentTurnRuntimeMetadata(item: FollowupRun): boolean {
@@ -532,7 +532,7 @@ function collectRuntimeMetadata(
   const deliveryCorrelations = items.flatMap((item) => item.deliveryCorrelations ?? []);
   const admissionWaitCallbacks = new Set(
     items.flatMap((item) =>
-      item.onFollowupAdmissionWaitChange ? [item.onFollowupAdmissionWaitChange] : [],
+      item.onReplyAdmissionWaitChange ? [item.onReplyAdmissionWaitChange] : [],
     ),
   );
   return {
@@ -543,7 +543,7 @@ function collectRuntimeMetadata(
     queueAbortSignal: items.find((item) => item.queueAbortSignal)?.queueAbortSignal,
     deliveryCorrelations: deliveryCorrelations.length > 0 ? deliveryCorrelations : undefined,
     queuedLifecycle: items.length === 1 ? items[0]?.queuedLifecycle : undefined,
-    onFollowupAdmissionWaitChange:
+    onReplyAdmissionWaitChange:
       admissionWaitCallbacks.size > 0
         ? (waiting) => {
             for (const callback of admissionWaitCallbacks) {
@@ -885,7 +885,7 @@ export function createOverflowSummaryRetrySource(source: FollowupRun): FollowupR
     originatingChatType: source.originatingChatType,
     abortSignal: source.abortSignal,
     queuedLifecycle: source.queuedLifecycle,
-    onFollowupAdmissionWaitChange: source.onFollowupAdmissionWaitChange,
+    onReplyAdmissionWaitChange: source.onReplyAdmissionWaitChange,
     ...(source.currentInboundEventKind === "room_event"
       ? { currentInboundEventKind: "room_event" }
       : {}),
@@ -945,8 +945,7 @@ async function runSyntheticOverflowSummary(params: {
     run: params.source.run,
     enqueuedAt: Date.now(),
     abortSignal: params.abortSignal,
-    onFollowupAdmissionWaitChange: collectRuntimeMetadata(params.sources)
-      .onFollowupAdmissionWaitChange,
+    onReplyAdmissionWaitChange: collectRuntimeMetadata(params.sources).onReplyAdmissionWaitChange,
     ...(params.onAdmitted
       ? {
           queuedLifecycle: {

--- a/src/auto-reply/reply/queue/types.ts
+++ b/src/auto-reply/reply/queue/types.ts
@@ -74,7 +74,7 @@ export type FollowupRun = {
   deliveryCorrelations?: QueuedReplyDeliveryCorrelation[];
   queuedLifecycle?: QueuedReplyLifecycle;
   /** Dispatch-scoped freshness owner for a queued delivery-barrier wait. */
-  onFollowupAdmissionWaitChange?: (waiting: boolean) => void;
+  onReplyAdmissionWaitChange?: (waiting: boolean) => void;
   /** Provider message ID, when available (for deduplication). */
   messageId?: string;
   summaryLine?: string;

--- a/src/auto-reply/reply/reply-turn-admission.test.ts
+++ b/src/auto-reply/reply/reply-turn-admission.test.ts
@@ -458,7 +458,7 @@ describe("reply turn admission", () => {
       sessionId: "new-session",
       kind: "visible",
       resetTriggered: false,
-      onFollowupAdmissionWaitChange: (waiting) => waitChanges.push(waiting),
+      onReplyAdmissionWaitChange: (waiting) => waitChanges.push(waiting),
     });
 
     let settled = false;
@@ -469,11 +469,11 @@ describe("reply turn admission", () => {
       setImmediate(resolve);
     });
     expect(settled).toBe(false);
-    expect(waitChanges).toEqual([]);
+    expect(waitChanges).toEqual([true]);
 
     active.complete();
     const result = await admitted;
-    expect(waitChanges).toEqual([]);
+    expect(waitChanges).toEqual([true, false]);
 
     expect(result.status).toBe("owned");
     if (result.status === "owned") {
@@ -566,7 +566,7 @@ describe("reply turn admission", () => {
       sessionId: "queued-session",
       kind: "queued_followup",
       resetTriggered: false,
-      onFollowupAdmissionWaitChange: (waiting) => waitChanges.push(waiting),
+      onReplyAdmissionWaitChange: (waiting) => waitChanges.push(waiting),
     });
     let settled = false;
     void admitted.then(() => {
@@ -978,6 +978,7 @@ describe("reply turn admission", () => {
       active.setPhase("running");
       active.recordActivity();
       const abortController = new AbortController();
+      const waitChanges: boolean[] = [];
       let settled = false;
       const result = admitReplyTurn({
         sessionKey: "agent:main:telegram:topic:fresh-visible",
@@ -985,6 +986,7 @@ describe("reply turn admission", () => {
         kind: "visible",
         resetTriggered: false,
         upstreamAbortSignal: abortController.signal,
+        onReplyAdmissionWaitChange: (waiting) => waitChanges.push(waiting),
       }).then((admission) => {
         settled = true;
         return admission;
@@ -992,6 +994,7 @@ describe("reply turn admission", () => {
 
       await vi.advanceTimersByTimeAsync(REPLY_RUN_IDLE_SETTLE_TIMEOUT_MS);
       expect(settled).toBe(false);
+      expect(waitChanges).toEqual([true]);
       expect(replyRunRegistry.get("agent:main:telegram:topic:fresh-visible")).toBe(active);
 
       abortController.abort();
@@ -1000,6 +1003,7 @@ describe("reply turn admission", () => {
         reason: "aborted",
         activeOperation: active,
       });
+      expect(waitChanges).toEqual([true, false]);
     } finally {
       await vi.runOnlyPendingTimersAsync();
       vi.useRealTimers();

--- a/src/auto-reply/reply/reply-turn-admission.ts
+++ b/src/auto-reply/reply/reply-turn-admission.ts
@@ -91,8 +91,7 @@ function resolveVisibleActiveWaitMs(operation: ReplyOperation | undefined): numb
   return Math.min(REPLY_RUN_IDLE_SETTLE_TIMEOUT_MS, Math.max(1, remainingMs));
 }
 
-/** Waits for or claims the per-session reply run slot. */
-export async function admitReplyTurn(params: {
+type ReplyTurnAdmissionParams = {
   sessionKey: string;
   sessionId: string;
   expectedSessionId?: string;
@@ -112,21 +111,42 @@ export async function admitReplyTurn(params: {
   waitForActive?: boolean;
   retainLifecycleAdmissionOnActive?: boolean;
   onLifecycleInterrupt?: () => void;
-  onFollowupAdmissionWaitChange?: (waiting: boolean) => void;
-}): Promise<ReplyTurnAdmission> {
+  /** Reports one interval while blocked behind an older lane owner or its delivery barrier. */
+  onReplyAdmissionWaitChange?: (waiting: boolean) => void;
+};
+
+type WaitForReplyAdmission = <T>(wait: () => Promise<T>) => Promise<T>;
+
+/** Waits for or claims the per-session reply run slot. */
+export async function admitReplyTurn(
+  params: ReplyTurnAdmissionParams,
+): Promise<ReplyTurnAdmission> {
+  let admissionWaitReported = false;
+  const waitForAdmission = async <T>(wait: () => Promise<T>): Promise<T> => {
+    if (!admissionWaitReported) {
+      admissionWaitReported = true;
+      params.onReplyAdmissionWaitChange?.(true);
+    }
+    return await wait();
+  };
+  try {
+    return await admitReplyTurnWithWaitSignal(params, waitForAdmission);
+  } finally {
+    if (admissionWaitReported) {
+      params.onReplyAdmissionWaitChange?.(false);
+    }
+  }
+}
+
+async function admitReplyTurnWithWaitSignal(
+  params: ReplyTurnAdmissionParams,
+  waitForAdmission: WaitForReplyAdmission,
+): Promise<ReplyTurnAdmission> {
   let sessionId = params.sessionId;
   let expectedSessionId = params.expectedSessionId;
   const waitTimeoutMs =
     params.waitTimeoutMs ??
     (params.kind === "queued_followup" ? REPLY_RUN_IDLE_SETTLE_TIMEOUT_MS : undefined);
-  const waitForFollowupAdmission = async <T>(wait: () => Promise<T>): Promise<T> => {
-    params.onFollowupAdmissionWaitChange?.(true);
-    try {
-      return await wait();
-    } finally {
-      params.onFollowupAdmissionWaitChange?.(false);
-    }
-  };
   while (true) {
     if (isAbortSignalAborted(params.upstreamAbortSignal)) {
       return { status: "skipped", reason: "aborted" };
@@ -280,7 +300,7 @@ export async function admitReplyTurn(params: {
         if (params.kind === "heartbeat") {
           return { status: "skipped", reason: "active-run" };
         }
-        const followupAdmission = await waitForFollowupAdmission(() =>
+        const followupAdmission = await waitForAdmission(() =>
           waitForReplyRunFollowupAdmission(
             params.sessionKey,
             waitTimeoutMs ?? REPLY_RUN_IDLE_SETTLE_TIMEOUT_MS,
@@ -315,9 +335,11 @@ export async function admitReplyTurn(params: {
       }
       const activeWaitTimeoutMs =
         params.kind === "visible" ? resolveVisibleActiveWaitMs(activeOperation) : waitTimeoutMs;
-      const ended = await replyRunRegistry.waitForIdle(params.sessionKey, activeWaitTimeoutMs, {
-        signal: params.upstreamAbortSignal,
-      });
+      const ended = await waitForAdmission(() =>
+        replyRunRegistry.waitForIdle(params.sessionKey, activeWaitTimeoutMs, {
+          signal: params.upstreamAbortSignal,
+        }),
+      );
       if (!ended) {
         if (params.kind === "visible" && !isAbortSignalAborted(params.upstreamAbortSignal)) {
           // Visible turns block on active work like before, but in bounded wait

--- a/src/auto-reply/reply/stranded-reply-recovery.test.ts
+++ b/src/auto-reply/reply/stranded-reply-recovery.test.ts
@@ -14,7 +14,7 @@ describe("buildStrandedReplyRetryFollowupRun lifecycle ownership", () => {
       transcriptPrompt: "user question",
       queuedLifecycle: { onComplete, onEnqueued },
       admissionSessionId: "sess-rotated",
-      onFollowupAdmissionWaitChange: vi.fn(),
+      onReplyAdmissionWaitChange: vi.fn(),
     });
 
     const retry = buildStrandedReplyRetryFollowupRun(parent, {
@@ -27,7 +27,7 @@ describe("buildStrandedReplyRetryFollowupRun lifecycle ownership", () => {
     expect(retry.summaryLine).toBe(STRANDED_REPLY_RETRY_MARKER);
     // Session routing stays; only the client-turn lifecycle identity is detached.
     expect(retry.admissionSessionId).toBe("sess-rotated");
-    expect(retry.onFollowupAdmissionWaitChange).toBe(parent.onFollowupAdmissionWaitChange);
+    expect(retry.onReplyAdmissionWaitChange).toBe(parent.onReplyAdmissionWaitChange);
     expect(retry.run.sessionKey).toBe(parent.run.sessionKey);
 
     // mark/complete no-op when lifecycle is absent (drop-policy onDrop path too).


### PR DESCRIPTION
Fixes #106594

AI-assisted: implemented and validated with Codex. The author reviewed and understands the change.

## What Problem This Solves

Fixes an issue where a completed assistant final could be silently suppressed when a newer same-session message arrived while the current reply was waiting for an older reply-lane owner or delivery barrier. The final remained in the transcript, but channel delivery was never invoked.

## Why This Change Was Made

Reply freshness now treats every wait behind an older reply admission owner as one balanced admission-wait interval, rather than marking only queued follow-up waits. The signal is carried through visible replies, follow-up drains, queue metadata, and lifecycle recovery, with cleanup in `finally` for success, abort, and error paths.

This keeps freshness ownership aligned with the actual reply-admission boundary without adding channel-specific behavior, retry semantics, configuration, or a new delivery contract.

## User Impact

Users can send a follow-up while an earlier response is finishing without causing that already-generated final to disappear before channel dispatch. Existing steer behavior and exactly-once delivery remain unchanged.

## Evidence

- Exact tested head: `77d8e5c2659fa7762e5d680038cfd2f53a84c235`.
- Focused auto-reply regression suite on Blacksmith Testbox `tbx_01kxh480885dz1cxzh6vc011sm`: 204 tests passed, exit 0. The associated keepalive Actions run is [29364920124](https://github.com/openclaw/openclaw/actions/runs/29364920124); its final `cancelled` conclusion is the expected external lease-stop cleanup after the SSH command completed successfully.
- Live Slack native delivery and forced `followup` regression proof on AWS Crabbox `cbx_8897a9daa9e7`, run `run_15fc7d0464f1`: three-turn post-tool race passed in both native and forced-final-post paths; every marker was delivered exactly once. Native round trip: 21.9s; forced-final-post: 17.9s.
- Live Feishu OAuth-user ingress → WebSocket plugin → live `openai/gpt-5.4` → chunked raw final on AWS Crabbox `cbx_9179fce6e19f`, run `run_da5bf4a9f515`: injected the successor during the second model fetch (post-tool final generation), preserved all four first-final chunks, and delivered all five marker identities exactly once under `queueMode=followup`.
- Regression coverage exercises visible admission waits, follow-up admission waits, stale recovery, stranded-reply recovery, queue-drain identity guards, and balanced wait cleanup.
- Fresh structured autoreview on the committed patch: clean, no accepted/actionable findings; overall correctness 0.93.
- PR CI: 66 checks passed and 42 were correctly skipped. `check-test-types` is red only because the synthetic merge inherited `extensions/nextcloud-talk/src/monitor.replay.test.ts:47` from base commit `21ec1546e5a`; current `main` run [29372109256](https://github.com/openclaw/openclaw/actions/runs/29372109256) independently fails with the identical `TS2339: Property 'headersSent' does not exist on type '{}'` error. No changed file in this PR overlaps that plugin.
