### PR TITLE
fix(ai): safely format circular provider stream errors

### DIFF
--- a/packages/ai/src/providers/anthropic.test.ts
+++ b/packages/ai/src/providers/anthropic.test.ts
@@ -1799,11 +1799,13 @@ describe("Anthropic provider", () => {
       { messages: [{ role: "user", content: "hello", timestamp: 0 }] },
       { apiKey: "sk-ant-provider", client: client as never },
     );
-    for await (const _event of stream) {
-      // drain
+    const eventTypes: string[] = [];
+    for await (const event of stream) {
+      eventTypes.push(event.type);
     }
     const result = await stream.result();
 
+    expect(eventTypes).toEqual(["error"]);
     expect(result.errorMessage).toBe("Overloaded");
   });
 

--- a/packages/ai/src/providers/anthropic.test.ts
+++ b/packages/ai/src/providers/anthropic.test.ts
@@ -1750,6 +1750,34 @@ describe("Anthropic provider", () => {
     expect(result.errorMessage).toContain("ended before message_stop");
   });
 
+  it("terminates the stream when the thrown error is a circular structure", async () => {
+    // Socket/HTTP layers raise self-referential error objects; a bare
+    // JSON.stringify in stream teardown throws and strands the run (#106568).
+    const circular: Record<string, unknown> = { code: "ECONNRESET" };
+    circular.self = circular;
+    const client = {
+      messages: {
+        create: vi.fn(() => ({
+          asResponse: () => Promise.reject(circular),
+        })),
+      },
+    };
+    const stream = streamAnthropic(
+      makeAnthropicModel({ id: "claude-fable-5", name: "Claude Fable 5" }),
+      { messages: [{ role: "user", content: "hello", timestamp: 0 }] },
+      { apiKey: "sk-ant-provider", client: client as never },
+    );
+    const eventTypes: string[] = [];
+    for await (const event of stream) {
+      eventTypes.push(event.type);
+    }
+    const result = await stream.result();
+
+    expect(eventTypes).toEqual(["error"]);
+    expect(result.stopReason).toBe("error");
+    expect(typeof result.errorMessage).toBe("string");
+  });
+
   it("strips Fable thinking when replay targets Anthropic Vertex", async () => {
     let capturedPayload: unknown;
     const stream = streamAnthropic(

--- a/packages/ai/src/providers/anthropic.test.ts
+++ b/packages/ai/src/providers/anthropic.test.ts
@@ -1776,7 +1776,35 @@ describe("Anthropic provider", () => {
 
     expect(eventTypes).toEqual(["error"]);
     expect(result.stopReason).toBe("error");
-    expect(typeof result.errorMessage).toBe("string");
+    // Must be a usable diagnostic, not just "a string" — an empty message would
+    // still leave the operator with nothing to act on.
+    expect(result.errorMessage).toBeTruthy();
+    expect(result.errorMessage).toBe("[object Object]");
+  });
+
+  it("keeps the message for Anthropic errors that carry no HTTP body", async () => {
+    // formatProviderError only substitutes status+body when a body is present, so
+    // ordinary Error rejections must still surface error.message — retry
+    // classification in src/llm/utils/retry.ts parses this string.
+    const asResponse = vi
+      .fn()
+      .mockRejectedValue(Object.assign(new Error("Overloaded"), { status: 529 }));
+    const client = {
+      messages: {
+        create: vi.fn(() => ({ asResponse })),
+      },
+    };
+    const stream = streamAnthropic(
+      makeAnthropicModel({ id: "claude-fable-5", name: "Claude Fable 5" }),
+      { messages: [{ role: "user", content: "hello", timestamp: 0 }] },
+      { apiKey: "sk-ant-provider", client: client as never },
+    );
+    for await (const _event of stream) {
+      // drain
+    }
+    const result = await stream.result();
+
+    expect(result.errorMessage).toBe("Overloaded");
   });
 
   it("strips Fable thinking when replay targets Anthropic Vertex", async () => {

--- a/packages/ai/src/providers/anthropic.test.ts
+++ b/packages/ai/src/providers/anthropic.test.ts
@@ -1755,11 +1755,12 @@ describe("Anthropic provider", () => {
     // JSON.stringify in stream teardown throws and strands the run (#106568).
     const circular: Record<string, unknown> = { code: "ECONNRESET" };
     circular.self = circular;
+    // Transport layers reject with plain objects, not Error instances, which is
+    // what sends the formatter down the JSON.stringify branch.
+    const asResponse = vi.fn().mockRejectedValue(circular);
     const client = {
       messages: {
-        create: vi.fn(() => ({
-          asResponse: () => Promise.reject(circular),
-        })),
+        create: vi.fn(() => ({ asResponse })),
       },
     };
     const stream = streamAnthropic(

--- a/packages/ai/src/providers/anthropic.test.ts
+++ b/packages/ai/src/providers/anthropic.test.ts
@@ -1776,10 +1776,10 @@ describe("Anthropic provider", () => {
 
     expect(eventTypes).toEqual(["error"]);
     expect(result.stopReason).toBe("error");
-    // Must be a usable diagnostic, not just "a string" — an empty message would
-    // still leave the operator with nothing to act on.
+    // Keep salient transport fields while replacing the cycle, so the terminal
+    // diagnostic remains actionable without stranding the stream.
     expect(result.errorMessage).toBeTruthy();
-    expect(result.errorMessage).toBe("[object Object]");
+    expect(result.errorMessage).toBe('{"code":"ECONNRESET","self":"[Circular]"}');
   });
 
   it("keeps the message for Anthropic errors that carry no HTTP body", async () => {

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -43,6 +43,7 @@ import { AssistantMessageEventStream } from "../utils/event-stream.js";
 import { headersToRecord } from "../utils/headers.js";
 import { parseJsonWithRepair, parseStreamingJson } from "../utils/json-parse.js";
 import { notifyLlmRequestActivity } from "../utils/llm-request-activity.js";
+import { formatProviderError } from "../utils/provider-error.js";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
 import {
   splitSystemPromptCacheBoundary,
@@ -826,7 +827,10 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicOpti
         output.content = [];
       }
       output.stopReason = requestOptions?.signal?.aborted ? "aborted" : "error";
-      output.errorMessage = error instanceof Error ? error.message : JSON.stringify(error);
+      // Stream teardown must never throw: a bare JSON.stringify here dies on the
+      // circular error objects HTTP/socket layers raise, stranding the run with no
+      // terminal error event. formatProviderError is the shared total formatter.
+      output.errorMessage = formatProviderError(error);
       stream.push({ type: "error", reason: output.stopReason, error: output });
       stream.end();
     }

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -827,9 +827,10 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicOpti
         output.content = [];
       }
       output.stopReason = requestOptions?.signal?.aborted ? "aborted" : "error";
-      // Stream teardown must never throw: a bare JSON.stringify here dies on the
-      // circular error objects HTTP/socket layers raise, stranding the run with no
-      // terminal error event. formatProviderError is the shared total formatter.
+      // A bare JSON.stringify here dies on the circular error objects HTTP/socket
+      // layers raise, and the throw escapes this catch so stream.end() never runs
+      // and the consumer hangs. formatProviderError guards that conversion, matching
+      // the other provider terminal paths.
       output.errorMessage = formatProviderError(error);
       stream.push({ type: "error", reason: output.stopReason, error: output });
       stream.end();

--- a/packages/ai/src/utils/provider-error.test.ts
+++ b/packages/ai/src/utils/provider-error.test.ts
@@ -35,6 +35,13 @@ describe("formatProviderError", () => {
     expect(formatProviderError(error)).toBe(body);
   });
 
+  it("preserves diagnostic fields when serializing a circular error object", () => {
+    const error: Record<string, unknown> = { code: "ECONNRESET" };
+    error.self = error;
+
+    expect(formatProviderError(error)).toBe('{"code":"ECONNRESET","self":"[Circular]"}');
+  });
+
   it("does not split surrogate pairs when truncating response bodies", () => {
     const body = `${"x".repeat(3999)}😀tail`;
     const error = Object.assign(new Error("502 status code (no body)"), { status: 502, body });

--- a/packages/ai/src/utils/provider-error.ts
+++ b/packages/ai/src/utils/provider-error.ts
@@ -16,8 +16,20 @@ type HttpErrorShape = Error & {
 };
 
 function stringify(value: unknown): string {
+  const seen = new WeakSet<object>();
   try {
-    return JSON.stringify(value) ?? String(value);
+    return (
+      JSON.stringify(value, (_key, candidate: unknown) => {
+        if (typeof candidate !== "object" || candidate === null) {
+          return candidate;
+        }
+        if (seen.has(candidate)) {
+          return "[Circular]";
+        }
+        seen.add(candidate);
+        return candidate;
+      }) ?? String(value)
+    );
   } catch {
     return String(value);
   }


### PR DESCRIPTION
## What Problem This Solves

Closes #106568.

Provider stream teardown must still emit a terminal error event when a transport rejects with a self-referential value. Anthropic retained an inline `JSON.stringify(error)` after Google and OpenAI Completions moved to the shared `formatProviderError`; a circular plain object therefore threw from inside the catch block and stranded the stream.

## Changed

- Route the remaining Anthropic terminal-error path through the canonical shared provider formatter.
- Make that formatter cycle-safe while retaining useful fields, so `{ code: "ECONNRESET", self: <cycle> }` becomes `{"code":"ECONNRESET","self":"[Circular]"}` instead of the unhelpful `[object Object]` fallback.
- Cover both the shared formatter contract and the real `streamAnthropic` terminal-event contract.
- Preserve ordinary `Error.message` behavior when an Anthropic error has no HTTP body.

The branch is rebased onto current `main` at `9e5849a0e894`; the hosted head is `15fbb5f2c0e`. GitHub reports the PR as mergeable.

## Review aids

```mermaid
flowchart LR
  A[Anthropic request] --> B[Transport rejection]
  B --> C[Cycle-safe shared formatter]
  C --> D[Terminal error event]
  D --> E[Stream completion]
```

Before, the circular rejection threw `TypeError: Converting circular structure to JSON` before `stream.end()`. After, the stream emits exactly one `error` event, resolves with `stopReason: "error"`, and retains `ECONNRESET` in the diagnostic.

## Evidence

Cloudflare Containers, hash-pinned to the final four changed files plus the live test file:

- `cbx_3ecae9b76001`: frozen-lockfile install and supply-chain lock policy passed; `provider-error.test.ts` passed 6/6; focused circular Anthropic regression passed 1/1; real Anthropic context-overflow probe passed 1/1 using only the scoped `ANTHROPIC_API_KEY` secret.
- `cbx_efcdcfa08075`: `oxfmt --check` passed on all four changed files; `oxlint` reported 0 warnings and 0 errors.
- Bundled Codex autoreview after the formatter improvement: clean, no accepted/actionable findings (`patch is correct`, confidence 0.94).
- `git diff --check` clean; rebase range-diff shows all five commits replayed unchanged.
- Previous exact-head hosted checks failed only in the unrelated `src/cli/help-exit.process.test.ts > exits promptly after root --help` 30-second timeout. Current `main` increases that shared-runner timeout to 45 seconds, and fresh exact-head CI for `15fbb5f2c0e` is running: https://github.com/openclaw/openclaw/actions/runs/30268817900.

Redacted provider-backed transcript:

```text
provider=cloudflare lease=cbx_3ecae9b76001
ANTHROPIC_API_KEY=set secret=true
packages/ai/src/providers/anthropic.live.test.ts
  ✓ classifies the provider's current context-overflow error
Test Files  1 passed (1)
Tests       1 passed | 4 skipped (5)
```

The broad `pnpm check` attempt on that Cloudflare lease reached repository guards that call `git ls-files`; Cloudflare's synced workspace intentionally omits `.git`, so those guards failed for transport reasons. No green claim is made for that command. Hosted CI supplied the git-dependent breadth, with the unrelated CLI timeout above as the sole failing test.

AI-assisted implementation and review; maintainer verification and provider-backed proof were performed before the branch update.


