### PR TITLE
test: isolate command harness selection

### DIFF
--- a/src/agents/agent-command.live-model-switch.test.ts
+++ b/src/agents/agent-command.live-model-switch.test.ts
@@ -202,6 +202,11 @@ vi.mock("./harness/runtime-plugin.js", () => ({
   ensureSelectedAgentHarnessPlugin: vi.fn(async () => undefined),
 }));
 
+// Harness selection has dedicated coverage; this command suite registers no auto harnesses.
+vi.mock("./harness/support.js", () => ({
+  resolveAutoAgentHarnessId: () => undefined,
+}));
+
 vi.mock("../acp/policy.js", () => ({
   isAcpEnabledByPolicy: () => true,
   resolveAcpAgentPolicyError: (...args: unknown[]) => state.resolveAcpAgentPolicyErrorMock(...args),


### PR DESCRIPTION
## What Problem This Solves

The 98-test live model-switch command suite registers no automatic agent harnesses, but its real thinking-runtime path still called `resolveAutoAgentHarnessId`. That resolver built provider support context before discovering the empty registry, synchronously evaluating bundled provider-policy artifacts unrelated to command retry behavior. In the cold baseline, two tests spent 8.78s and 4.17s on this work.

## Why This Change Was Made

Close the already-mocked harness boundary by returning the real empty-registry outcome (`undefined`) from `resolveAutoAgentHarnessId`. Command retry, configured-runtime, explicit-session-runtime, and thinking-level assertions remain unchanged. Dedicated `thinking-runtime.test.ts` and harness selection/support suites retain automatic harness and provider-route coverage.

## User Impact

Faster agent CI. Runtime behavior and all 98 tests are unchanged. Test-only change; no changelog entry.

## Evidence

- Same-Testbox paired run with the filesystem module cache disabled: 98/98 passed in every sample.
- Candidate samples: 9.20s and 7.21s overall; baseline samples: 13.16s and 11.77s overall. Mean wall time improved 12.47s -> 8.21s (34.2%).
- Cold baseline/candidate: 21.17s -> 9.28s overall; the 8.78s and 4.17s provider-artifact outliers disappeared.
- Paired Testbox: https://github.com/openclaw/openclaw/actions/runs/29371367397
- Exact rebased head: 98/98 passed in 10.57s; scoped `pnpm check:changed` passed.
- Exact-head Testbox: https://github.com/openclaw/openclaw/actions/runs/29371753303
- Fresh rebased-head autoreview: clean, no accepted/actionable findings (0.98 confidence).
