### PR TITLE
fix(sqlite): prevent startup failure on dormant older session databases

### DIFF
--- a/src/commands/doctor-session-sqlite-compact.ts
+++ b/src/commands/doctor-session-sqlite-compact.ts
@@ -5,6 +5,7 @@ import {
   assertOpenClawAgentDatabaseForMaintenance,
   ensureOpenClawAgentDatabasePermissions,
   isOpenClawAgentDatabaseOpen,
+  migrateOpenClawAgentDatabaseForMaintenance,
 } from "../state/openclaw-agent-db.js";
 import { resolveTargetSqlitePath } from "./doctor-session-sqlite-readers.js";
 import type { DoctorSessionSqliteCompactReport } from "./doctor-session-sqlite-types.js";
@@ -13,6 +14,7 @@ import { compactDoctorSqliteFile } from "./doctor-sqlite-compact.js";
 /** Reclaim free pages from one agent session SQLite database. */
 export function compactDoctorSessionSqliteTarget(
   target: SessionStoreTarget,
+  options: { migrateOlderSchema?: boolean } = {},
 ): DoctorSessionSqliteCompactReport {
   const sqlitePath = resolveTargetSqlitePath(target);
   const beforeFileSizes = readSqliteFileSizes(sqlitePath);
@@ -37,6 +39,12 @@ export function compactDoctorSessionSqliteTarget(
     throw new Error(
       `OpenClaw agent database ${sqlitePath} is already open in this process. Stop OpenClaw and retry.`,
     );
+  }
+  if (options.migrateOlderSchema) {
+    migrateOpenClawAgentDatabaseForMaintenance({
+      agentId: target.agentId,
+      pathname: sqlitePath,
+    });
   }
 
   const compact = compactDoctorSqliteFile({

--- a/src/commands/doctor-session-sqlite.test.ts
+++ b/src/commands/doctor-session-sqlite.test.ts
@@ -19,6 +19,7 @@ import {
   closeOpenClawAgentDatabasesForTest,
   openOpenClawAgentDatabase,
   OPENCLAW_AGENT_SCHEMA_VERSION,
+  resolveOpenClawAgentSqlitePath,
 } from "../state/openclaw-agent-db.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import {
@@ -141,30 +142,21 @@ describe("runDoctorSessionSqlite", () => {
     }
   });
 
-  it("migrates dormant older agent databases before all-agent import compaction", async () => {
+  it("migrates a dormant historical agent database before all-agent import compaction", async () => {
     const tempDir = autoCleanupTempDirs.make("openclaw-doctor-session-sqlite-");
     const stateDir = path.join(tempDir, "state");
     const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
     const agentIds = ["dormant", "current"] as const;
-    const sqlitePaths = new Map<string, string>();
     for (const agentId of agentIds) {
       const sessionsDir = path.join(stateDir, "agents", agentId, "sessions");
       fs.mkdirSync(sessionsDir, { recursive: true });
       fs.writeFileSync(path.join(sessionsDir, "sessions.json"), "{}\n", { mode: 0o600 });
-      sqlitePaths.set(agentId, openOpenClawAgentDatabase({ agentId, env }).path);
     }
+    const dormantPath = createHistoricalV1AgentDatabase({ agentId: "dormant", env });
+    const currentPath = openOpenClawAgentDatabase({ agentId: "current", env }).path;
     closeOpenClawAgentDatabasesForTest();
 
     const sqlite = nodeSqlite.requireNodeSqlite();
-    const dormantPath = expectDefined(sqlitePaths.get("dormant"), "dormant SQLite path");
-    const dormant = new sqlite.DatabaseSync(dormantPath);
-    try {
-      dormant.exec("PRAGMA user_version = 1;");
-      dormant.prepare("UPDATE schema_meta SET schema_version = 1 WHERE meta_key = 'primary'").run();
-    } finally {
-      dormant.close();
-    }
-    const currentPath = expectDefined(sqlitePaths.get("current"), "current SQLite path");
     const currentBefore = new sqlite.DatabaseSync(currentPath);
     const currentUpdatedAt = expectDefined(
       currentBefore
@@ -186,6 +178,9 @@ describe("runDoctorSessionSqlite", () => {
       issues: 0,
       targets: 2,
     });
+    expect(report.targets.find((target) => target.agentId === "dormant")?.compact).toMatchObject({
+      skipped: false,
+    });
     const dormantAfter = new sqlite.DatabaseSync(dormantPath);
     const currentAfter = new sqlite.DatabaseSync(currentPath);
     try {
@@ -197,6 +192,22 @@ describe("runDoctorSessionSqlite", () => {
           .prepare("SELECT schema_version FROM schema_meta WHERE meta_key = 'primary'")
           .get(),
       ).toEqual({ schema_version: OPENCLAW_AGENT_SCHEMA_VERSION });
+      expect(
+        dormantAfter
+          .prepare("PRAGMA table_info(sessions)")
+          .all()
+          .map((column) => (column as { name?: unknown }).name),
+      ).toContain("session_scope");
+      expect(
+        dormantAfter
+          .prepare("PRAGMA table_info(memory_index_sources)")
+          .all()
+          .map((column) => (column as { name?: unknown }).name),
+      ).toEqual(["id", "path", "source", "hash", "mtime", "size"]);
+      expect(dormantAfter.prepare("PRAGMA integrity_check").get()).toEqual({
+        integrity_check: "ok",
+      });
+      expect(dormantAfter.prepare("PRAGMA foreign_key_check").all()).toEqual([]);
       expect(
         currentAfter
           .prepare("SELECT schema_version, updated_at FROM schema_meta WHERE meta_key = 'primary'")
@@ -2391,6 +2402,92 @@ async function createImportedStoreForCompaction(): Promise<{
   }
   closeOpenClawAgentDatabasesForTest();
   return { sqlitePath, store };
+}
+
+// Build the physical v1 layout directly so the doctor path, not the runtime
+// opener, owns the upgrade. Empty session tables preserve the dormant-agent
+// reproduction: import has no rows to open before its compact step.
+function createHistoricalV1AgentDatabase(params: {
+  agentId: string;
+  env: NodeJS.ProcessEnv;
+}): string {
+  const sqlitePath = resolveOpenClawAgentSqlitePath(params);
+  fs.mkdirSync(path.dirname(sqlitePath), { recursive: true });
+  const sqlite = nodeSqlite.requireNodeSqlite();
+  const database = new sqlite.DatabaseSync(sqlitePath);
+  try {
+    database.exec(`
+      CREATE TABLE schema_meta (
+        meta_key TEXT NOT NULL PRIMARY KEY,
+        role TEXT NOT NULL,
+        schema_version INTEGER NOT NULL,
+        agent_id TEXT,
+        app_version TEXT,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL
+      );
+      CREATE TABLE sessions (
+        session_id TEXT NOT NULL PRIMARY KEY,
+        session_key TEXT NOT NULL,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL
+      );
+      CREATE TABLE session_entries (
+        session_key TEXT NOT NULL PRIMARY KEY,
+        session_id TEXT NOT NULL,
+        entry_json TEXT NOT NULL,
+        updated_at INTEGER NOT NULL,
+        FOREIGN KEY (session_id) REFERENCES sessions(session_id) ON DELETE CASCADE
+      );
+      CREATE TABLE memory_index_state (
+        id INTEGER PRIMARY KEY CHECK (id = 1),
+        revision INTEGER NOT NULL
+      );
+      INSERT INTO memory_index_state (id, revision) VALUES (1, 1);
+      CREATE TABLE memory_index_sources (
+        source_kind TEXT NOT NULL DEFAULT 'memory',
+        source_key TEXT NOT NULL,
+        path TEXT,
+        session_id TEXT,
+        hash TEXT NOT NULL,
+        mtime INTEGER NOT NULL,
+        size INTEGER NOT NULL,
+        PRIMARY KEY (source_kind, source_key),
+        FOREIGN KEY (session_id) REFERENCES sessions(session_id) ON DELETE CASCADE
+      );
+      CREATE TABLE memory_index_chunks (
+        id TEXT PRIMARY KEY,
+        source_kind TEXT NOT NULL DEFAULT 'memory',
+        source_key TEXT NOT NULL,
+        path TEXT NOT NULL,
+        session_id TEXT,
+        start_line INTEGER NOT NULL,
+        end_line INTEGER NOT NULL,
+        hash TEXT NOT NULL,
+        model TEXT NOT NULL,
+        text TEXT NOT NULL,
+        embedding BLOB NOT NULL,
+        embedding_dims INTEGER,
+        updated_at INTEGER NOT NULL,
+        FOREIGN KEY (source_kind, source_key)
+          REFERENCES memory_index_sources(source_kind, source_key) ON DELETE CASCADE,
+        FOREIGN KEY (session_id) REFERENCES sessions(session_id) ON DELETE CASCADE
+      );
+      PRAGMA user_version = 1;
+    `);
+    database
+      .prepare(
+        `
+          INSERT INTO schema_meta
+            (meta_key, role, schema_version, agent_id, app_version, created_at, updated_at)
+          VALUES ('primary', 'agent', 1, ?, NULL, 1, 1)
+        `,
+      )
+      .run(params.agentId);
+  } finally {
+    database.close();
+  }
+  return sqlitePath;
 }
 
 function createUnsafeIndexDrift(sqlitePath: string): void {

--- a/src/commands/doctor-session-sqlite.test.ts
+++ b/src/commands/doctor-session-sqlite.test.ts
@@ -141,6 +141,121 @@ describe("runDoctorSessionSqlite", () => {
     }
   });
 
+  it("migrates dormant older agent databases before all-agent import compaction", async () => {
+    const tempDir = autoCleanupTempDirs.make("openclaw-doctor-session-sqlite-");
+    const stateDir = path.join(tempDir, "state");
+    const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
+    const agentIds = ["dormant", "current"] as const;
+    const sqlitePaths = new Map<string, string>();
+    for (const agentId of agentIds) {
+      const sessionsDir = path.join(stateDir, "agents", agentId, "sessions");
+      fs.mkdirSync(sessionsDir, { recursive: true });
+      fs.writeFileSync(path.join(sessionsDir, "sessions.json"), "{}\n", { mode: 0o600 });
+      sqlitePaths.set(agentId, openOpenClawAgentDatabase({ agentId, env }).path);
+    }
+    closeOpenClawAgentDatabasesForTest();
+
+    const sqlite = nodeSqlite.requireNodeSqlite();
+    const dormantPath = expectDefined(sqlitePaths.get("dormant"), "dormant SQLite path");
+    const dormant = new sqlite.DatabaseSync(dormantPath);
+    try {
+      dormant.exec("PRAGMA user_version = 1;");
+      dormant.prepare("UPDATE schema_meta SET schema_version = 1 WHERE meta_key = 'primary'").run();
+    } finally {
+      dormant.close();
+    }
+    const currentPath = expectDefined(sqlitePaths.get("current"), "current SQLite path");
+    const currentBefore = new sqlite.DatabaseSync(currentPath);
+    const currentUpdatedAt = expectDefined(
+      currentBefore
+        .prepare("SELECT updated_at FROM schema_meta WHERE meta_key = 'primary'")
+        .get() as { updated_at?: number } | undefined,
+      "current schema metadata",
+    ).updated_at;
+    currentBefore.close();
+
+    const report = await runDoctorSessionSqlite({
+      allAgents: true,
+      cfg: { agents: { list: agentIds.map((id) => ({ id })) } },
+      env,
+      mode: "import",
+    });
+
+    expect(report.totals).toMatchObject({
+      importedEntries: 0,
+      issues: 0,
+      targets: 2,
+    });
+    const dormantAfter = new sqlite.DatabaseSync(dormantPath);
+    const currentAfter = new sqlite.DatabaseSync(currentPath);
+    try {
+      expect(dormantAfter.prepare("PRAGMA user_version").get()).toEqual({
+        user_version: OPENCLAW_AGENT_SCHEMA_VERSION,
+      });
+      expect(
+        dormantAfter
+          .prepare("SELECT schema_version FROM schema_meta WHERE meta_key = 'primary'")
+          .get(),
+      ).toEqual({ schema_version: OPENCLAW_AGENT_SCHEMA_VERSION });
+      expect(
+        currentAfter
+          .prepare("SELECT schema_version, updated_at FROM schema_meta WHERE meta_key = 'primary'")
+          .get(),
+      ).toEqual({
+        schema_version: OPENCLAW_AGENT_SCHEMA_VERSION,
+        updated_at: currentUpdatedAt,
+      });
+    } finally {
+      dormantAfter.close();
+      currentAfter.close();
+    }
+  });
+
+  it("keeps mismatched older agent schema versions blocking during all-agent import", async () => {
+    const tempDir = autoCleanupTempDirs.make("openclaw-doctor-session-sqlite-");
+    const stateDir = path.join(tempDir, "state");
+    const sessionsDir = path.join(stateDir, "agents", "drifted", "sessions");
+    const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
+    fs.mkdirSync(sessionsDir, { recursive: true });
+    fs.writeFileSync(path.join(sessionsDir, "sessions.json"), "{}\n", { mode: 0o600 });
+    const sqlitePath = openOpenClawAgentDatabase({ agentId: "drifted", env }).path;
+    closeOpenClawAgentDatabasesForTest();
+
+    const sqlite = nodeSqlite.requireNodeSqlite();
+    const database = new sqlite.DatabaseSync(sqlitePath);
+    try {
+      database.exec("PRAGMA user_version = 1;");
+      database
+        .prepare("UPDATE schema_meta SET schema_version = 2 WHERE meta_key = 'primary'")
+        .run();
+    } finally {
+      database.close();
+    }
+
+    const report = await runDoctorSessionSqlite({
+      allAgents: true,
+      cfg: { agents: { list: [{ id: "drifted" }] } },
+      env,
+      mode: "import",
+    });
+
+    expect(report.targets[0]?.issues).toEqual([
+      expect.objectContaining({
+        code: "sqlite_compact_failed",
+        message: expect.stringMatching(/uses schema version 1/iu),
+      }),
+    ]);
+    const after = new sqlite.DatabaseSync(sqlitePath);
+    try {
+      expect(after.prepare("PRAGMA user_version").get()).toEqual({ user_version: 1 });
+      expect(
+        after.prepare("SELECT schema_version FROM schema_meta WHERE meta_key = 'primary'").get(),
+      ).toEqual({ schema_version: 2 });
+    } finally {
+      after.close();
+    }
+  });
+
   it("repairs legacy message and route shapes at the import boundary", async () => {
     const store = createLegacyStore({
       entryOverrides: {

--- a/src/commands/doctor-session-sqlite.ts
+++ b/src/commands/doctor-session-sqlite.ts
@@ -297,7 +297,10 @@ async function inspectOrMigrateTarget(params: {
     if (validationPassed) {
       // Post-import compact retrofits auto_vacuum=INCREMENTAL onto pre-flip
       // databases and returns the pages the import churn freed.
-      compactSqliteDatabase(params.target, report, { closeImportedHandle: true });
+      compactSqliteDatabase(params.target, report, {
+        closeImportedHandle: true,
+        migrateOlderSchema: true,
+      });
     }
   }
   report.unreferencedJsonlFiles = listUnreferencedJsonlFiles(params.target.storePath, [
@@ -985,13 +988,15 @@ function appendSqliteDbStats(
 function compactSqliteDatabase(
   target: SessionStoreTarget,
   report: DoctorSessionSqliteTargetReport,
-  options: { closeImportedHandle?: boolean } = {},
+  options: { closeImportedHandle?: boolean; migrateOlderSchema?: boolean } = {},
 ): void {
   try {
     if (options.closeImportedHandle) {
       closeOpenClawAgentDatabaseByPath(resolveTargetSqlitePath(target));
     }
-    report.compact = compactDoctorSessionSqliteTarget(target);
+    report.compact = options.migrateOlderSchema
+      ? compactDoctorSessionSqliteTarget(target, { migrateOlderSchema: true })
+      : compactDoctorSessionSqliteTarget(target);
   } catch (err) {
     report.issues.push({
       code: "sqlite_compact_failed",

--- a/src/state/openclaw-agent-db.ts
+++ b/src/state/openclaw-agent-db.ts
@@ -610,6 +610,44 @@ export function assertOpenClawAgentDatabaseForMaintenance(
   assertSqliteSchemaContains(database, options.pathname, OPENCLAW_AGENT_SCHEMA_SQL);
 }
 
+/** Upgrade a supported older owned schema before strict offline maintenance. */
+export function migrateOpenClawAgentDatabaseForMaintenance(options: {
+  agentId: string;
+  pathname: string;
+}): void {
+  const agentId = normalizeAgentId(options.agentId);
+  const sqlite = requireNodeSqlite();
+  const database = new sqlite.DatabaseSync(options.pathname);
+  try {
+    database.exec(`PRAGMA busy_timeout = ${OPENCLAW_SQLITE_BUSY_TIMEOUT_MS};`);
+    const metadata = readExistingSchemaMeta(database);
+    if (!metadata) {
+      return;
+    }
+    assertExistingSchemaOwner(metadata, agentId, options.pathname);
+    assertSupportedAgentSchemaVersion(database, options.pathname);
+    const userVersion = readSqliteUserVersion(database);
+    const metadataVersion = metadata.schemaVersion;
+    const hasSupportedOlderVersion =
+      userVersion >= 1 &&
+      userVersion < OPENCLAW_AGENT_SCHEMA_VERSION &&
+      metadataVersion !== null &&
+      metadataVersion === userVersion &&
+      metadataVersion >= 1 &&
+      metadataVersion < OPENCLAW_AGENT_SCHEMA_VERSION;
+    if (!hasSupportedOlderVersion) {
+      return;
+    }
+    ensureOpenClawAgentDatabaseSchema(database, {
+      agentId,
+      path: options.pathname,
+    });
+  } finally {
+    clearNodeSqliteKyselyCacheForDatabase(database);
+    database.close();
+  }
+}
+
 function ensureAgentSchema(db: DatabaseSync, agentId: string, pathname: string): void {
   // FK enforcement must be off before BEGIN: PRAGMA foreign_keys is a silent
   // no-op inside a transaction, and the v1 sessions rebuild would otherwise


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where gateway startup's all-agent session SQLite import could fail when a configured or discovered agent had a dormant database created by an older supported OpenClaw schema. The import reached strict post-import compaction before that database had been opened and upgraded, so operators were told to run `doctor --fix` even though startup owns this supported upgrade path.

## Why This Change Was Made

The import path now asks the agent-database owner to transactionally migrate a coherently versioned, supported older schema before post-import compaction performs strict maintenance validation. Direct `doctor --session-sqlite compact` remains strict, and databases with missing metadata, mismatched versions, future versions, wrong ownership, malformed schemas, or corruption are still rejected.

Invariant: every owner-valid supported older agent database selected by startup import reaches the canonical schema transactionally before strict maintenance; current schemas are a no-op, while unsupported or drifted states remain blocking.

Non-goal: this does not change memory path-FTS trigger ownership validation. Unexpected path-FTS triggers remain a separate strict startup blocker.

## User Impact

Upgrades no longer strand gateway startup on dormant older agent databases that have no legacy rows to import. Current-schema agents are left unchanged, and strict validation continues to protect unsupported or inconsistent databases.

## Evidence

Before the patch, the new mixed-fleet regression failed on fresh `main`: the dormant version-1 database produced one `sqlite_compact_failed` issue while the adjacent current-schema database was valid.

After the patch:

- `node scripts/run-vitest.mjs src/commands/doctor-session-sqlite.test.ts -- --reporter=verbose -t "migrates dormant older agent databases before all-agent import compaction"` — 1 passed after rebasing onto `origin/main` at `21ec1546e5a83975e5ffb3535bc8bc8b0cf2365b`.
- `node scripts/run-vitest.mjs src/commands/doctor-session-sqlite.test.ts` — 66 passed.
- `node scripts/run-vitest.mjs src/state/openclaw-agent-db.test.ts` — 35 passed, 1 skipped.
- `node scripts/run-vitest.mjs src/gateway/server-startup-session-migration.test.ts` — 11 passed.
- `pnpm format:check` and `git diff --check` — passed.
- Blacksmith Testbox `tbx_01kxhaeg3y5bah9qbf9adj5f7d` ran `pnpm check:changed` on Linux — passed.
- Autoreview — clean after adding a negative regression for mismatched older schema markers.

Behavior addressed: Gateway startup all-agent session SQLite import rejects dormant databases on a supported older schema before compaction.

Real environment tested: macOS Node source checkout with real temporary SQLite files, plus the Linux Blacksmith Testbox changed gate; no live installation was touched.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/commands/doctor-session-sqlite.test.ts -- --reporter=verbose -t "migrates dormant older agent databases before all-agent import compaction"`

Evidence after fix: The post-rebase focused regression passed, the complete adjacent doctor/session SQLite and agent database suites passed, and Linux changed checks passed in Testbox `tbx_01kxhaeg3y5bah9qbf9adj5f7d`.

Observed result after fix: The dormant version-1 database migrated to the current schema before compaction, the adjacent current-schema database remained unchanged, and a database with mismatched version markers remained blocked and unmodified.

What was not tested: A live installed gateway startup was intentionally not run; the separate memory path-FTS trigger ownership failure was not changed or exercised as part of this patch.

## Provenance

The ordering defect became visible when #105370 added strict offline maintenance validation on July 12, 2026, on top of #98236's post-import compaction path from July 11, 2026. Gitcrawl was searched first, then live GitHub issue and PR search; no open duplicate was found as of July 14, 2026.

## Release Note Context

Gateway startup now upgrades supported dormant session SQLite databases before post-import compaction, preventing upgrade-time startup failures while preserving strict rejection of inconsistent databases.
