### PR TITLE
fix: classify Codex tool results through shared failure contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Codex dynamic tool outcomes:** use the shared tool-result failure contract for arbitrary lifecycle metadata, preventing successful Skill Workshop results from being displayed and persisted as failed calls. Fixes #107684. Thanks @shakkernerd.
 - **Nested resource ignores:** honor slash-free patterns and escaped literal exclamation marks in nested ignore files during skill and resource discovery. Thanks @moguangyu5-design.
 - **Proxy bypass precedence:** honor blank lower-case `no_proxy` values shadowing upper-case `NO_PROXY` consistently with Undici, and reuse the canonical matcher for Telegram fallback selection.
 - **Tokenjuice exec compaction:** avoid retaining raw command output inside compacted middleware metadata, preventing large successful compactions from failing the middleware details-size guard.

--- a/extensions/codex/src/app-server/dynamic-tools.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tools.test.ts
@@ -349,9 +349,9 @@ describe("createCodexDynamicToolBridge", () => {
     // An accepted sessions_spawn launch carries details.status "accepted" with a
     // runId + childSessionKey. The launch succeeded (the child session was
     // accepted), so Codex must see a successful tool call, not an error.
-    // Regression for #96833: "accepted" was missing from the non-error status
-    // allowlist, so the launch was classified as an error and persisted with
-    // isError: true (and reported to Codex as success: false).
+    // Regression for #96833: the former Codex-only success allowlist omitted
+    // "accepted", so the launch was persisted with isError: true and reported
+    // to Codex as success: false.
     const onAgentToolResult = vi.fn();
     const bridge = createBridgeWithToolResult(
       "sessions_spawn",
@@ -407,8 +407,8 @@ describe("createCodexDynamicToolBridge", () => {
   });
 
   it("treats accepted goal tool statuses (created / updated) as successful dynamic tool calls", async () => {
-    // Same classifier-completeness class as the accepted spawn fix: create_goal /
-    // update_goal return details.status "created" / "updated", reach codex agents
+    // Same runtime-parity class as the accepted spawn fix: create_goal /
+    // update_goal return details.status "created" / "updated", reach Codex agents
     // through the dynamic-tool bridge, and must not be classified as errors (#96833).
     const createdBridge = createBridgeWithToolResult(
       "create_goal",
@@ -484,6 +484,52 @@ describe("createCodexDynamicToolBridge", () => {
     expect(onMissingResult).toHaveBeenCalledWith(
       expect.objectContaining({ toolName: "get_goal", isError: false }),
     );
+  });
+
+  it.each(["pending", "applied", "rejected", "quarantined", "stale"] as const)(
+    "treats Skill Workshop lifecycle status %s as a successful dynamic tool call",
+    async (status) => {
+      const onAgentToolResult = vi.fn();
+      const bridge = createBridgeWithToolResult(
+        "skill_workshop",
+        textToolResult(`Proposal is ${status}.`, { status }),
+      );
+
+      const result = await bridge.handleToolCall(
+        {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          callId: `call-${status}`,
+          namespace: null,
+          tool: "skill_workshop",
+          arguments: { action: "inspect" },
+        },
+        { onAgentToolResult },
+      );
+
+      expect(result.success).toBe(true);
+      expect(onAgentToolResult).toHaveBeenCalledWith(
+        expect.objectContaining({ toolName: "skill_workshop", isError: false }),
+      );
+    },
+  );
+
+  it("treats arbitrary plugin-owned status metadata as successful by default", async () => {
+    const bridge = createBridgeWithToolResult(
+      "plugin_tool",
+      textToolResult("Plugin action completed.", { status: "plugin-defined-outcome" }),
+    );
+
+    const result = await bridge.handleToolCall({
+      threadId: "thread-1",
+      turnId: "turn-1",
+      callId: "call-plugin-defined-outcome",
+      namespace: null,
+      tool: "plugin_tool",
+      arguments: {},
+    });
+
+    expect(result.success).toBe(true);
   });
 
   it("keeps available and registered schemas paired with their tools", () => {
@@ -2381,7 +2427,7 @@ describe("createCodexDynamicToolBridge", () => {
     expectContextFields(callArg(handler, 0, 1, "middleware context"), { runtime: "codex" });
   });
 
-  it("keeps unrecognized non-success statuses fail-closed", async () => {
+  it("keeps shared failure statuses fail-closed", async () => {
     const onAgentToolResult = vi.fn();
     const bridge = createCodexDynamicToolBridge({
       tools: [

--- a/extensions/codex/src/app-server/dynamic-tools.ts
+++ b/extensions/codex/src/app-server/dynamic-tools.ts
@@ -560,7 +560,7 @@ export function createCodexDynamicToolBridge(params: {
           toolResultHookContext.runId,
         );
         const telemetryRawResult = sanitizeToolResult(rawResult);
-        const rawIsError = isCodexToolResultError(rawResult);
+        const rawIsError = isToolResultError(rawResult);
         const rawResultFailureKind = resolveToolResultFailureKind(rawResult);
         const middlewareResult = await middlewareRunner.applyToolResultMiddleware({
           threadId: call.threadId,
@@ -579,7 +579,7 @@ export function createCodexDynamicToolBridge(params: {
           args: structuredClone(executedArgs),
           result: middlewareResult,
         });
-        const resultIsError = rawIsError || isCodexToolResultError(result);
+        const resultIsError = rawIsError || isToolResultError(result);
         const finalResultFailureKind = resolveToolResultFailureKind(result);
         const resultFailureKind = rawResultFailureKind ?? finalResultFailureKind;
         const observerResult =
@@ -1254,45 +1254,6 @@ function extractInternalSourceReplyPayload(
   return text || mediaUrls.length > 0 || payload.presentation || payload.interactive
     ? payload
     : undefined;
-}
-function isCodexToolResultError(result: AgentToolResult<unknown>): boolean {
-  if (isToolResultError(result)) {
-    return true;
-  }
-  const details = result.details;
-  if (!isRecord(details)) {
-    return false;
-  }
-  if (details.ok === true || details.success === true) {
-    return false;
-  }
-  if (details.timedOut === true) {
-    return true;
-  }
-  if (typeof details.exitCode === "number" && details.exitCode !== 0) {
-    return true;
-  }
-  if (typeof details.status !== "string") {
-    return false;
-  }
-  const status = details.status.trim().toLowerCase();
-  return (
-    status !== "" &&
-    status !== "0" &&
-    status !== "ok" &&
-    status !== "success" &&
-    status !== "completed" &&
-    status !== "recorded" &&
-    status !== "created" &&
-    status !== "updated" &&
-    status !== "accepted" &&
-    status !== "found" &&
-    status !== "missing" &&
-    status !== "pending" &&
-    status !== "started" &&
-    status !== "running" &&
-    status !== "yielded"
-  );
 }
 function isToolResultYield(result: AgentToolResult<unknown>): boolean {
   const details = result.details;


### PR DESCRIPTION
## What Problem This Solves

Fixes #107684.

The Codex dynamic-tool bridge treated every non-empty `details.status` outside a hardcoded success allowlist as a failure.

This caused successful tool calls to be reported and persisted as failed. Skill Workshop exposed the issue because successful lifecycle results such as `applied`, `rejected`, `quarantined`, and `stale` were absent from that allowlist.

## Solution

Remove the Codex-specific status allowlist and use the shared `isToolResultError` contract for both raw and middleware-adjusted tool results.

The shared classifier reports failures only for explicit failure signals, including:

- `ok: false` or `success: false`
- recognized failure statuses
- structured errors or timeouts
- nonzero exit codes

Tool-specific lifecycle statuses remain metadata and no longer require recurring Codex allowlist updates.

## User Impact

Successful Skill Workshop actions are no longer displayed or persisted as failed Codex tool calls.

The fix also covers built-in tools, bundled and external plugin tools, middleware-adjusted results, and future tools with new domain-specific statuses.

## Evidence

### Focused and changed-surface validation

Blacksmith Testbox through Crabbox:

- Testbox: `tbx_01kxh9p0jbgfk5gm6qwgdwjm9h`
- Codex dynamic-tool tests: 105 passed
- `pnpm check:changed`: passed
- Extension production and test typechecks: passed
- Formatting, lint, SDK baseline, dependency, boundary, and import-cycle guards: passed

### Real Codex runtime proof

Tested with a disposable clone of the existing CodexClaw environment using:

- OpenClaw `2026.7.2`
- OpenAI Codex runtime
- `openai/gpt-5.5`
- This branch at `ac8c3d81f77`

A real agent turn called `skill_workshop` to apply a pending proposal.

Observed result:

```text
tool.result skill_workshop ok
model.completed openai/gpt-5.5 done
session.ended success
```

The proposal manifest recorded `status: applied`, the resulting `SKILL.md` was created, and the agent reported zero tool failures.

The disposable environment and test artifacts were removed afterward.

## Regression Coverage

Added coverage for:

- all Skill Workshop proposal lifecycle statuses
- arbitrary plugin-owned status metadata
- existing explicit failure statuses
- raw and middleware-adjusted result classification

## Security And Compatibility

No protocol, configuration, permission, authentication, migration, dependency, or persisted-data shape changes.

Explicit failure signals remain failures. The change aligns Codex with the shared classifier already used by the embedded and Copilot runtimes.
