### PR TITLE
fix(nextcloud-talk): restore replay test typecheck

### DIFF
--- a/extensions/nextcloud-talk/src/monitor.replay.test.ts
+++ b/extensions/nextcloud-talk/src/monitor.replay.test.ts
@@ -51,8 +51,8 @@ async function invokeWebhookServerRequest(params: {
         resolve({ body: body ?? "", status });
         return this;
       },
-    } as unknown as ServerResponse;
-    listener(req, res);
+    };
+    listener(req, res as unknown as ServerResponse);
   });
 }
 


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the full test-types CI shard fails on current `main` while type-checking the Nextcloud Talk replay response mock.

## Why This Change Was Made

The response mock was asserted as a complete `ServerResponse` at its declaration, which erased the object literal's contextual `this` type. The assertion now sits only at the listener boundary, preserving the partial mock's inferred method receiver while keeping the production listener contract unchanged.

## User Impact

No user-visible behavior change. CI can type-check the test suite again.

## Evidence

- Failure reproduced in [`check-test-types`](https://github.com/openclaw/openclaw/actions/runs/29372054162/job/87217445488): `Property 'headersSent' does not exist on type '{}'`.
- Testbox `tbx_01kxhb58jezv7et2ttkc0w9yga`: `pnpm test extensions/nextcloud-talk/src/monitor.replay.test.ts` — 10/10 passed.
- Same Testbox: `pnpm check:test-types` — passed.
- Fresh autoreview: clean, confidence 0.99.
- Test-only repair; no docs or changelog change.
