### PR TITLE
fix(sqlite): compaction works with memory path search enabled

### DIFF
--- a/packages/memory-host-sdk/src/host/memory-schema.ts
+++ b/packages/memory-host-sdk/src/host/memory-schema.ts
@@ -13,10 +13,43 @@ export const MEMORY_INDEX_FTS_TABLE = "memory_index_chunks_fts";
 export const MEMORY_INDEX_PATHS_FTS_TABLE = "memory_index_paths_fts";
 export const MEMORY_INDEX_VECTOR_TABLE = "memory_index_chunks_vec";
 
-const MEMORY_PATH_FTS_TRIGGER_NAMES = [
-  "memory_index_paths_fts_after_insert",
-  "memory_index_paths_fts_after_update",
-  "memory_index_paths_fts_after_delete",
+/** Optional canonical triggers owned by the derived path FTS index. */
+export const MEMORY_PATH_FTS_TRIGGER_DEFINITIONS = [
+  {
+    name: "memory_index_paths_fts_after_insert",
+    sql: `
+      CREATE TRIGGER IF NOT EXISTS main.memory_index_paths_fts_after_insert
+      AFTER INSERT ON ${MEMORY_INDEX_SOURCES_TABLE}
+      BEGIN
+        INSERT INTO ${MEMORY_INDEX_PATHS_FTS_TABLE} (rowid, path, source)
+        VALUES (NEW.id, NEW.path, NEW.source);
+      END;
+    `,
+  },
+  {
+    name: "memory_index_paths_fts_after_update",
+    sql: `
+      CREATE TRIGGER IF NOT EXISTS main.memory_index_paths_fts_after_update
+      AFTER UPDATE OF id, path, source ON ${MEMORY_INDEX_SOURCES_TABLE}
+      BEGIN
+        DELETE FROM ${MEMORY_INDEX_PATHS_FTS_TABLE}
+        WHERE rowid = OLD.id;
+        INSERT INTO ${MEMORY_INDEX_PATHS_FTS_TABLE} (rowid, path, source)
+        VALUES (NEW.id, NEW.path, NEW.source);
+      END;
+    `,
+  },
+  {
+    name: "memory_index_paths_fts_after_delete",
+    sql: `
+      CREATE TRIGGER IF NOT EXISTS main.memory_index_paths_fts_after_delete
+      AFTER DELETE ON ${MEMORY_INDEX_SOURCES_TABLE}
+      BEGIN
+        DELETE FROM ${MEMORY_INDEX_PATHS_FTS_TABLE}
+        WHERE rowid = OLD.id;
+      END;
+    `,
+  },
 ] as const;
 
 const LEGACY_MEMORY_INDEX_TRIGGERS = [
@@ -454,37 +487,18 @@ function migrateLegacyMemoryIndexTables(
 
 /** Drop the canonical source-to-path-FTS maintenance triggers. */
 export function dropMemoryPathFtsTriggers(db: DatabaseSync): void {
-  for (const triggerName of MEMORY_PATH_FTS_TRIGGER_NAMES) {
-    db.exec(`DROP TRIGGER IF EXISTS main.${triggerName}`);
+  for (const trigger of MEMORY_PATH_FTS_TRIGGER_DEFINITIONS) {
+    db.exec(`DROP TRIGGER IF EXISTS main.${trigger.name}`);
   }
 }
 
 /** Install the canonical source-to-path-FTS maintenance triggers. */
 export function ensureMemoryPathFtsTriggers(db: DatabaseSync): void {
-  db.exec(`
-    -- The named integer source identity survives VACUUM and gives every
-    -- FTS update/delete a direct rowid lookup instead of a virtual-table scan.
-    CREATE TRIGGER IF NOT EXISTS main.memory_index_paths_fts_after_insert
-    AFTER INSERT ON ${MEMORY_INDEX_SOURCES_TABLE}
-    BEGIN
-      INSERT INTO ${MEMORY_INDEX_PATHS_FTS_TABLE} (rowid, path, source)
-      VALUES (NEW.id, NEW.path, NEW.source);
-    END;
-    CREATE TRIGGER IF NOT EXISTS main.memory_index_paths_fts_after_update
-    AFTER UPDATE OF id, path, source ON ${MEMORY_INDEX_SOURCES_TABLE}
-    BEGIN
-      DELETE FROM ${MEMORY_INDEX_PATHS_FTS_TABLE}
-      WHERE rowid = OLD.id;
-      INSERT INTO ${MEMORY_INDEX_PATHS_FTS_TABLE} (rowid, path, source)
-      VALUES (NEW.id, NEW.path, NEW.source);
-    END;
-    CREATE TRIGGER IF NOT EXISTS main.memory_index_paths_fts_after_delete
-    AFTER DELETE ON ${MEMORY_INDEX_SOURCES_TABLE}
-    BEGIN
-      DELETE FROM ${MEMORY_INDEX_PATHS_FTS_TABLE}
-      WHERE rowid = OLD.id;
-    END;
-  `);
+  // The named integer source identity survives VACUUM and gives every
+  // FTS update/delete a direct rowid lookup instead of a virtual-table scan.
+  for (const trigger of MEMORY_PATH_FTS_TRIGGER_DEFINITIONS) {
+    db.exec(trigger.sql);
+  }
 }
 
 function ensureMemoryPathFtsSchema(params: { db: DatabaseSync; tokenizeClause: string }): void {

--- a/src/infra/sqlite-schema-contract.ts
+++ b/src/infra/sqlite-schema-contract.ts
@@ -63,6 +63,17 @@ export type SqliteSchemaCompatibility = {
    * requires a temporary default that the clean schema does not retain.
    */
   allowedColumnDefinitions?: Readonly<Record<string, readonly string[]>>;
+  /**
+   * Exact owner-defined trigger groups that may be absent when their derived
+   * schema is disabled, but must be complete and canonical when present.
+   */
+  optionalCanonicalTriggerGroups?: readonly {
+    tableName: string;
+    triggers: readonly {
+      name: string;
+      sql: string;
+    }[];
+  }[];
 };
 
 const schemaContractCache = new Map<string, SqliteSchemaContract>();
@@ -119,9 +130,34 @@ export function assertSqliteSchemaContains(
         mismatches.push(`missing or drifted trigger ${expectedTrigger.name}`);
       }
     }
+    const optionalCanonicalTriggerGroups = collectOptionalCanonicalTriggerGroups(
+      compatibility,
+      tableName,
+    );
+    for (const triggerGroup of optionalCanonicalTriggerGroups) {
+      const isPresent = actualTable.triggers.some((actualTrigger) =>
+        triggerGroup.some((canonicalTrigger) => actualTrigger.name === canonicalTrigger.name),
+      );
+      if (!isPresent) {
+        continue;
+      }
+      for (const canonicalTrigger of triggerGroup) {
+        if (
+          !actualTable.triggers.some((actualTrigger) => isEqual(actualTrigger, canonicalTrigger))
+        ) {
+          mismatches.push(`missing or drifted trigger ${canonicalTrigger.name}`);
+        }
+      }
+    }
+    const optionalCanonicalTriggers = optionalCanonicalTriggerGroups.flat();
     for (const actualTrigger of actualTable.triggers) {
       if (
-        !expectedTable.triggers.some((expectedTrigger) => isEqual(actualTrigger, expectedTrigger))
+        !expectedTable.triggers.some((expectedTrigger) =>
+          isEqual(actualTrigger, expectedTrigger),
+        ) &&
+        !optionalCanonicalTriggers.some((canonicalTrigger) =>
+          isEqual(actualTrigger, canonicalTrigger),
+        )
       ) {
         mismatches.push(`unexpected trigger ${actualTrigger.name}`);
       }
@@ -146,6 +182,25 @@ export function assertSqliteSchemaContains(
       `SQLite schema is incomplete or noncanonical for ${databaseLabel}: ${shown.join("; ")}`,
     );
   }
+}
+
+function collectOptionalCanonicalTriggerGroups(
+  compatibility: SqliteSchemaCompatibility,
+  tableName: string,
+): Array<Array<{ name: string; sql: string | null }>> {
+  return (compatibility.optionalCanonicalTriggerGroups ?? [])
+    .filter((group) => group.tableName === tableName)
+    .map((group) =>
+      group.triggers.map((trigger) => ({
+        name: trigger.name,
+        sql: normalizeOptionalCanonicalTriggerSql(trigger.sql),
+      })),
+    );
+}
+
+function normalizeOptionalCanonicalTriggerSql(sql: string): string | null {
+  // sqlite_schema stores main-schema trigger names without the schema qualifier.
+  return normalizeSchemaSql(sql)?.replace(/^(CREATE TRIGGER) main\./iu, "$1 ") ?? null;
 }
 
 function buildSqliteSchemaContract(schemaSql: string): SqliteSchemaContract {

--- a/src/state/openclaw-agent-db.ts
+++ b/src/state/openclaw-agent-db.ts
@@ -2,7 +2,11 @@
 import { chmodSync, existsSync, lstatSync, mkdirSync, statSync } from "node:fs";
 import path from "node:path";
 import type { DatabaseSync } from "node:sqlite";
-import { migrateMemoryIndexSourcesIdentity } from "../../packages/memory-host-sdk/src/host/memory-schema.js";
+import {
+  MEMORY_INDEX_SOURCES_TABLE,
+  MEMORY_PATH_FTS_TRIGGER_DEFINITIONS,
+  migrateMemoryIndexSourcesIdentity,
+} from "../../packages/memory-host-sdk/src/host/memory-schema.js";
 import {
   clearNodeSqliteKyselyCacheForDatabase,
   executeSqliteQuerySync,
@@ -15,7 +19,10 @@ import {
   type CanonicalSqliteUniqueIndex,
 } from "../infra/sqlite-index-schema.js";
 import { assertSqliteIntegrity } from "../infra/sqlite-integrity.js";
-import { assertSqliteSchemaContains } from "../infra/sqlite-schema-contract.js";
+import {
+  assertSqliteSchemaContains,
+  type SqliteSchemaCompatibility,
+} from "../infra/sqlite-schema-contract.js";
 import {
   runSqliteImmediateTransactionSync,
   type SqliteTransactionOptions,
@@ -101,6 +108,14 @@ const OPENCLAW_AGENT_CANONICAL_UNIQUE_INDEXES = [
     `,
   },
 ] as const satisfies readonly CanonicalSqliteUniqueIndex[];
+const OPENCLAW_AGENT_MAINTENANCE_SCHEMA_COMPATIBILITY = {
+  optionalCanonicalTriggerGroups: [
+    {
+      tableName: MEMORY_INDEX_SOURCES_TABLE,
+      triggers: MEMORY_PATH_FTS_TRIGGER_DEFINITIONS,
+    },
+  ],
+} satisfies SqliteSchemaCompatibility;
 const agentDbLog = createSubsystemLogger("state/agent-db");
 
 /** Open per-agent SQLite database handle plus lifecycle maintenance. */
@@ -607,7 +622,12 @@ export function assertOpenClawAgentDatabaseForMaintenance(
       `OpenClaw agent database ${options.pathname} metadata schema version ${metadata.schemaVersion ?? "invalid"} does not match ${OPENCLAW_AGENT_SCHEMA_VERSION}; run openclaw doctor --fix before compacting it.`,
     );
   }
-  assertSqliteSchemaContains(database, options.pathname, OPENCLAW_AGENT_SCHEMA_SQL);
+  assertSqliteSchemaContains(
+    database,
+    options.pathname,
+    OPENCLAW_AGENT_SCHEMA_SQL,
+    OPENCLAW_AGENT_MAINTENANCE_SCHEMA_COMPATIBILITY,
+  );
 }
 
 function ensureAgentSchema(db: DatabaseSync, agentId: string, pathname: string): void {

--- a/src/state/openclaw-database-maintenance.test.ts
+++ b/src/state/openclaw-database-maintenance.test.ts
@@ -213,6 +213,35 @@ describe("OpenClaw database maintenance schema validation", () => {
     }
   });
 
+  it("rejects a drifted canonical memory path FTS trigger", () => {
+    const database = createAgentDatabase();
+    try {
+      ensureMemoryIndexSchema({
+        db: database,
+        cacheEnabled: true,
+        ftsEnabled: true,
+      });
+      database.exec(`
+        DROP TRIGGER memory_index_paths_fts_after_insert;
+        CREATE TRIGGER memory_index_paths_fts_after_insert
+        AFTER INSERT ON memory_index_sources
+        BEGIN
+          INSERT INTO memory_index_paths_fts (rowid, path, source)
+          VALUES (NEW.id, NEW.path || '-drifted', NEW.source);
+        END;
+      `);
+
+      expect(() =>
+        assertOpenClawAgentDatabaseForMaintenance(database, {
+          agentId: "worker-1",
+          pathname: "agent.sqlite",
+        }),
+      ).toThrow("missing or drifted trigger memory_index_paths_fts_after_insert");
+    } finally {
+      database.close();
+    }
+  });
+
   it("rejects a current agent database with a drifted canonical trigger", () => {
     const database = createAgentDatabase();
     try {

--- a/src/state/openclaw-database-maintenance.test.ts
+++ b/src/state/openclaw-database-maintenance.test.ts
@@ -1,5 +1,6 @@
 import { DatabaseSync } from "node:sqlite";
 import { describe, expect, it } from "vitest";
+import { ensureMemoryIndexSchema } from "../../packages/memory-host-sdk/src/host/memory-schema.js";
 import {
   assertOpenClawAgentDatabaseForMaintenance,
   OPENCLAW_AGENT_SCHEMA_VERSION,
@@ -164,14 +165,40 @@ describe("OpenClaw database maintenance schema validation", () => {
     }
   });
 
-  it("rejects a current agent database with an unexpected trigger", () => {
+  it("accepts only canonical memory path FTS triggers", () => {
     const database = createAgentDatabase();
     try {
+      ensureMemoryIndexSchema({
+        db: database,
+        cacheEnabled: true,
+        ftsEnabled: true,
+      });
+
+      expect(() =>
+        assertOpenClawAgentDatabaseForMaintenance(database, {
+          agentId: "worker-1",
+          pathname: "agent.sqlite",
+        }),
+      ).not.toThrow();
+
+      database.exec("DROP TRIGGER memory_index_paths_fts_after_delete;");
+      expect(() =>
+        assertOpenClawAgentDatabaseForMaintenance(database, {
+          agentId: "worker-1",
+          pathname: "agent.sqlite",
+        }),
+      ).toThrow("missing or drifted trigger memory_index_paths_fts_after_delete");
+      ensureMemoryIndexSchema({
+        db: database,
+        cacheEnabled: true,
+        ftsEnabled: true,
+      });
+
       database.exec(`
-        CREATE TRIGGER sessions_unexpected_delete_after_insert
-        AFTER INSERT ON sessions
+        CREATE TRIGGER memory_index_sources_unexpected_after_insert
+        AFTER INSERT ON memory_index_sources
         BEGIN
-          DELETE FROM sessions WHERE session_key = NEW.session_key;
+          UPDATE memory_index_state SET revision = revision + 100 WHERE id = 1;
         END;
       `);
 
@@ -180,7 +207,7 @@ describe("OpenClaw database maintenance schema validation", () => {
           agentId: "worker-1",
           pathname: "agent.sqlite",
         }),
-      ).toThrow("unexpected trigger sessions_unexpected_delete_after_insert");
+      ).toThrow("unexpected trigger memory_index_sources_unexpected_after_insert");
     } finally {
       database.close();
     }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where startup or `openclaw doctor` session SQLite compaction could fail when memory filename/path search was enabled. The strict agent database validator treated the three path-FTS maintenance triggers created by OpenClaw itself as unexpected schema objects.

## Why This Change Was Made

The memory host now exports the exact canonical path-FTS trigger definitions, and agent database maintenance recognizes them as one optional, all-or-none owner-defined group. A database without path FTS remains valid; if any canonical path-FTS trigger is present, the complete trio must match exactly. Unknown, partial, or drifted triggers still fail closed.

This is the narrowest durable ownership invariant because the trigger SQL remains defined by the memory schema owner while the generic SQLite validator only receives exact compatibility metadata. It does not introduce a broad trigger allowlist.

Old-schema migration ordering is intentionally out of scope and remains a separate task.

### Alternatives considered

- A broad trigger-name allowlist was rejected because it would weaken strict schema validation.
- Dropping and restoring triggers around maintenance was rejected because the same validation path is used by read-only snapshot and reliability workflows, and mutating derived schema adds interruption risk.
- Adding the optional path-FTS objects to the static agent schema was rejected because that would make a derived, feature-dependent memory index look mandatory.

### Provenance

- #104449 (`e9b7a9a91277`) introduced memory filename/path FTS and its three triggers.
- #105583 (`f11b17d937cc`) introduced full agent schema validation for maintenance.
- #105767 (`4be088ec02fd`) made unexpected triggers fail strict validation, exposing the ownership mismatch.
- Gitcrawl archive search followed by live GitHub issue/PR search found no duplicate open work for this conflict.

## User Impact

Agents with memory filename/path search enabled can complete startup and doctor-owned SQLite compaction without disabling that search index. Schema validation remains strict for unknown or modified triggers.

Release-note context: fixes agent session SQLite compaction when memory filename/path search is enabled; noncanonical triggers continue to be rejected.

## Evidence

- Focused regression after rebasing onto canonical `main`: 3 files, 2 Vitest shards, 52 assertions passed.
- Regression coverage proves the exact canonical trio passes, a partial trio fails, and an unknown trigger on the same table fails.
- File-backed compaction proof: `{"skipped":false,"triggerCount":3,"pathAfter":"memory/after.md","issues":0}`.
- Changed gate: `pnpm check:changed` passed on Blacksmith Testbox `tbx_01kxhb1q1bfb427fyyzhxgbg9j` ([Actions run 29372254935](https://github.com/openclaw/openclaw/actions/runs/29372254935)).
- Autoreview: clean, with no accepted or actionable findings.
- Canonical base at final ancestry check: `origin/main` `75354578cff2c3686ee29a13b432eb87291b60b0`; branch commit `7ed7fd08206339d794c9164d2ff2bf68eb6015cb`.

## Real behavior proof

Behavior or issue addressed: Strict agent SQLite maintenance rejected OpenClaw-owned memory path-FTS triggers and blocked compaction.

Behavior addressed: Canonical path-FTS triggers are accepted as an exact all-or-none group while unknown, partial, and drifted triggers remain rejected.

Real environment tested: Temporary file-backed OpenClaw agent SQLite database on Node 24, plus the repository changed gate on Blacksmith Testbox.

Exact steps or command run after this patch: Created a current agent database, enabled memory path FTS through the owner schema API, inserted a source row, ran `compactDoctorSessionSqliteTarget`, reopened the database, updated the source path, and read the path-FTS row.

Evidence after fix: Compaction completed, all three canonical triggers remained installed, the path-FTS row followed the source rename, and `PRAGMA integrity_check` reported no issues.

Observed result after fix: `{"skipped":false,"triggerCount":3,"pathAfter":"memory/after.md","issues":0}`.

What was not tested: The live installation was not modified or restarted. Version-1 memory schema migration ordering was not tested because it is a separate scoped task.
