### PR TITLE
fix(nextcloud-talk): restore test typecheck

### DIFF
--- a/extensions/nextcloud-talk/src/monitor.replay.test.ts
+++ b/extensions/nextcloud-talk/src/monitor.replay.test.ts
@@ -42,7 +42,7 @@ async function invokeWebhookServerRequest(params: {
     let status = 0;
     const res = {
       headersSent: false,
-      writeHead(code: number) {
+      writeHead(this: { headersSent: boolean }, code: number) {
         status = code;
         this.headersSent = true;
         return this;


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the repository's extension test typecheck fails on the Nextcloud Talk replay response mock after the extension-surface refactor in #107796.

## Why This Change Was Made

The mock now declares the receiver shape used by its `writeHead` method. Runtime test behavior is unchanged; TypeScript can verify the existing `headersSent` mutation.

## User Impact

No user-visible behavior change. The exact-head CI typecheck can complete again.

## Evidence

- Reproduced on the current `main` snapshot with `pnpm check:test-types`: `TS2339` at `monitor.replay.test.ts:47`.
- Testbox `tbx_01kxhbbdc1w75qvgjvv1stkdt2`: Nextcloud Talk replay tests 10/10 and `pnpm tsgo:extensions:test` pass.
- Actions proof: https://github.com/openclaw/openclaw/actions/runs/29372548814
- Fresh autoreview: no actionable findings.
