### PR TITLE
test(nextcloud-talk): type replay response mock

### DIFF
--- a/extensions/nextcloud-talk/src/monitor.replay.test.ts
+++ b/extensions/nextcloud-talk/src/monitor.replay.test.ts
@@ -40,11 +40,14 @@ async function invokeWebhookServerRequest(params: {
 
   return await new Promise<{ body: string; status: number }>((resolve) => {
     let status = 0;
+    let headersSent = false;
     const res = {
-      headersSent: false,
+      get headersSent() {
+        return headersSent;
+      },
       writeHead(code: number) {
         status = code;
-        this.headersSent = true;
+        headersSent = true;
         return this;
       },
       end(body?: string) {


### PR DESCRIPTION
## What Problem This Solves

Current CI `check-test-types` fails in `extensions/nextcloud-talk/src/monitor.replay.test.ts` because the mock `ServerResponse.writeHead()` mutates `this.headersSent`, and strict test type checking infers `this` as `{}` for that object-literal method.

This patch keeps the same test behavior but moves `headersSent` into closure state exposed through a getter. The mock still reports headers as sent after `writeHead()`, without relying on an untyped `this` mutation.

## Evidence

Exact-head local validation on `63f29c24259db35ebf6eca1a2c38699e9a8d3d63`:
- `PATH="..." node scripts/run-vitest.mjs extensions/nextcloud-talk/src/monitor.replay.test.ts` -> passed; 1 Vitest shard, 10 tests
- `PATH="..." node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions-test.tsbuildinfo` -> passed
- `PATH="..." ./node_modules/.bin/oxfmt --check --threads=1 extensions/nextcloud-talk/src/monitor.replay.test.ts` -> passed
- `PATH="..." ./node_modules/.bin/oxlint extensions/nextcloud-talk/src/monitor.replay.test.ts` -> passed
- `git diff --check upstream/main...HEAD` -> passed

This is the same `check-test-types` error currently blocking refreshed open PRs: `Property headersSent does not exist on type {}`.
