### PR TITLE
test(nextcloud-talk): fix response mock typecheck

### DIFF
--- a/extensions/nextcloud-talk/src/monitor.replay.test.ts
+++ b/extensions/nextcloud-talk/src/monitor.replay.test.ts
@@ -40,19 +40,24 @@ async function invokeWebhookServerRequest(params: {
 
   return await new Promise<{ body: string; status: number }>((resolve) => {
     let status = 0;
-    const res = {
+    type MutableMockResponse = {
+      headersSent: boolean;
+      writeHead(code: number): MutableMockResponse;
+      end(body?: string): MutableMockResponse;
+    };
+    const resObj: MutableMockResponse = {
       headersSent: false,
       writeHead(code: number) {
         status = code;
-        this.headersSent = true;
-        return this;
+        resObj.headersSent = true;
+        return resObj;
       },
       end(body?: string) {
         resolve({ body: body ?? "", status });
-        return this;
+        return resObj;
       },
-    } as unknown as ServerResponse;
-    listener(req, res);
+    };
+    listener(req, resObj as unknown as ServerResponse);
   });
 }
 


### PR DESCRIPTION
## What Problem This Solves

Fresh Full Release Validation at exact main SHA `75354578cff2c3686ee29a13b432eb87291b60b0` failed extension test typechecking because the Nextcloud Talk response mock mutated `this.headersSent` after the object had been cast to `ServerResponse`.

Failed job: https://github.com/openclaw/openclaw/actions/runs/29372151407/job/87217751219

## Why This Change Was Made

Keep the response mock mutable and explicitly typed locally, then cast only at the listener boundary. This preserves the mock's runtime behavior while avoiding both the readonly `ServerResponse.headersSent` contract and self-referential inference errors.

## User Impact

No runtime behavior change. Restores the extension test typecheck lane required by full release validation.

## Evidence

Blacksmith Testbox through Crabbox: `tbx_01kxhbetc1pk6cq309cw12yp7a`

- Run: https://github.com/openclaw/openclaw/actions/runs/29372649022
- focused Nextcloud replay suite: 1 file, 10 tests passed
- `pnpm tsgo:extensions:test`: passed
- `pnpm check:changed`: passed
- fresh autoreview: clean, no accepted/actionable findings

AI-assisted implementation. No agent transcript attached.
