### PR TITLE
fix(nextcloud-talk): annotate this type in mock writeHead

### DIFF
--- a/extensions/nextcloud-talk/src/monitor.replay.test.ts
+++ b/extensions/nextcloud-talk/src/monitor.replay.test.ts
@@ -42,7 +42,7 @@ async function invokeWebhookServerRequest(params: {
     let status = 0;
     const res = {
       headersSent: false,
-      writeHead(code: number) {
+      writeHead(this: { headersSent: boolean }, code: number) {
         status = code;
         this.headersSent = true;
         return this;


### PR DESCRIPTION
## What Problem This Solves

Fixes a `check-test-types` failure on current `main`:

```
extensions/nextcloud-talk/src/monitor.replay.test.ts(47,14): error TS2339: Property 'headersSent' does not exist on type '{}'.
```

The mock `writeHead` method references `this.headersSent` without a `this` type annotation, causing TypeScript to treat `this` as `{}`.

## Why This Change Was Made

Added `this: { headersSent: boolean }` parameter annotation to the mock `writeHead` method.

## User Impact

No user-visible impact. Fixes CI type-check gate.

## Evidence

Before: `check-test-types` fails on `main`. After: `pnpm check:changed` passes, CI will confirm.