### PR TITLE
fix(agents): avoid premature compaction in tool-heavy sessions

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt-prompt-context.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-context.test.ts
@@ -189,7 +189,7 @@ describe("prepareEmbeddedAttemptPromptContext", () => {
     expect(result.llmBoundaryPromptForPrecheck).not.toContain("deployment finished");
   });
 
-  it("reports aggregate tool-result pressure for compact-then-truncate routing", () => {
+  it("reports aggregate tool-result pressure and successful prompt projection", () => {
     hoisted.truncateOversizedToolResultsInMessages.mockImplementation((inputMessages) => ({
       messages: [...inputMessages],
       truncatedCount: 2,
@@ -204,8 +204,12 @@ describe("prepareEmbeddedAttemptPromptContext", () => {
     const result = prepareEmbeddedAttemptPromptContext(fixture.input);
 
     expect(result.aggregatePressureEngaged).toBe(true);
+    expect(result.aggregateTruncatedCount).toBe(1);
     expect(hoisted.warn).toHaveBeenCalledWith(
       expect.stringContaining("aggregate tool-result pressure"),
+    );
+    expect(hoisted.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining("compaction has been requested"),
     );
   });
 

--- a/src/agents/embedded-agent-runner/run/attempt-prompt-context.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-context.ts
@@ -63,6 +63,7 @@ type CurrentUserTimestampOverride = {
 
 type EmbeddedAttemptPromptContext = {
   aggregatePressureEngaged: boolean;
+  aggregateTruncatedCount: number;
   contextTokenBudget: number;
   currentUserTimestampOverride?: CurrentUserTimestampOverride;
   effectivePrompt: string;
@@ -125,7 +126,7 @@ export function prepareEmbeddedAttemptPromptContext(input: {
     cloneToolResultPromptProjectionState(input.toolResultPromptProjectionState),
   );
   const promptHistoryChanged = promptToolResultTruncation.messages !== sessionMessages;
-  const { aggregatePressureEngaged } = promptToolResultTruncation;
+  const { aggregatePressureEngaged, aggregateTruncatedCount } = promptToolResultTruncation;
   if (promptHistoryChanged) {
     sessionMessages = promptToolResultTruncation.messages;
   }
@@ -141,7 +142,7 @@ export function prepareEmbeddedAttemptPromptContext(input: {
     if (aggregatePressureEngaged) {
       if (!toolResultWarningDedupe.promptPressure.check(sessionLogKey)) {
         log.warn(
-          `${truncationLog}; aggregate tool-result pressure detected, compaction has been requested; consider /compact or /new if pressure persists`,
+          `${truncationLog}; aggregate tool-result pressure detected; consider /compact or /new if pressure persists`,
         );
       }
     } else {
@@ -264,6 +265,7 @@ export function prepareEmbeddedAttemptPromptContext(input: {
 
   return {
     aggregatePressureEngaged,
+    aggregateTruncatedCount,
     contextTokenBudget,
     ...(currentUserTimestampOverride ? { currentUserTimestampOverride } : {}),
     effectivePrompt: input.prompt.effectivePrompt,

--- a/src/agents/embedded-agent-runner/run/attempt-prompt-phase.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-phase.test.ts
@@ -76,7 +76,10 @@ type PromptErrorCall = {
   yieldMessage: string | null;
 };
 
-function createFixture() {
+function createFixture(options?: {
+  aggregatePressureEngaged?: boolean;
+  aggregateTruncatedCount?: number;
+}) {
   const order: string[] = [];
   const state: PromptPhaseState = {
     contextBudgetStatus: undefined,
@@ -118,7 +121,8 @@ function createFixture() {
   mocks.preparePromptContext.mockImplementation(() => {
     order.push("context");
     return {
-      aggregatePressureEngaged: false,
+      aggregatePressureEngaged: options?.aggregatePressureEngaged ?? false,
+      aggregateTruncatedCount: options?.aggregateTruncatedCount ?? 0,
       contextTokenBudget: 32_000,
       currentUserTimestampOverride: { timestamp: 123, text: "hello" },
       effectivePrompt: "hello",
@@ -297,6 +301,56 @@ describe("runEmbeddedAttemptPromptPhase", () => {
       }),
     );
     expect(mocks.releasePendingSteering).not.toHaveBeenCalled();
+  });
+
+  it("continues submission after aggregate prompt projection recovers pressure", async () => {
+    const fixture = createFixture({
+      aggregatePressureEngaged: true,
+      aggregateTruncatedCount: 1,
+    });
+
+    await expect(runEmbeddedAttemptPromptPhase(fixture.input)).resolves.toEqual({
+      promptStartedAt: expect.any(Number),
+    });
+
+    expect(mocks.prepareGooglePromptCache).toHaveBeenCalledOnce();
+    expect(mocks.dispatchPrompt).toHaveBeenCalledWith(
+      expect.objectContaining({
+        state: expect.objectContaining({
+          preflightRecovery: undefined,
+          promptError: null,
+          promptErrorSource: null,
+          skipPromptSubmission: false,
+        }),
+      }),
+    );
+  });
+
+  it("keeps compact-then-truncate when aggregate pressure has no replacement", async () => {
+    const fixture = createFixture({
+      aggregatePressureEngaged: true,
+      aggregateTruncatedCount: 0,
+    });
+    mocks.dispatchPrompt.mockImplementation(async (input: DispatchCall) => {
+      fixture.order.push("dispatch");
+      return input.state;
+    });
+
+    await expect(runEmbeddedAttemptPromptPhase(fixture.input)).resolves.toEqual({
+      promptStartedAt: expect.any(Number),
+    });
+
+    expect(mocks.prepareGooglePromptCache).not.toHaveBeenCalled();
+    expect(mocks.dispatchPrompt).toHaveBeenCalledWith(
+      expect.objectContaining({
+        state: expect.objectContaining({
+          preflightRecovery: { route: "compact_then_truncate" },
+          promptError: expect.objectContaining({ message: expect.any(String) }),
+          promptErrorSource: "precheck",
+          skipPromptSubmission: true,
+        }),
+      }),
+    );
   });
 
   it("reads yield state after submission fails and publishes abort state before recovery", async () => {

--- a/src/agents/embedded-agent-runner/run/attempt-prompt-phase.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-phase.ts
@@ -182,15 +182,16 @@ export async function runEmbeddedAttemptPromptPhase(input: {
     });
     const {
       aggregatePressureEngaged,
+      aggregateTruncatedCount,
       hookMessagesForCurrentPrompt,
       promptForModel,
       systemPromptForHook,
     } = promptContext;
     input.lifecycle.setPrePromptMessageCount(promptContext.prePromptMessageCount);
     input.lifecycle.setCurrentUserTimestampOverride(promptContext.currentUserTimestampOverride);
-    if (aggregatePressureEngaged) {
-      // Compaction and aggregate truncation both target about half the window;
-      // compact-then-truncate prevents re-hitting the same cap on the next turn.
+    if (aggregatePressureEngaged && aggregateTruncatedCount === 0) {
+      // Successful aggregate replacements are already reflected in preflight messages.
+      // Compact only when prompt projection could not reduce historical tool results.
       patchState({
         preflightRecovery: { route: "compact_then_truncate" },
         promptError: new Error(PREEMPTIVE_OVERFLOW_ERROR_TEXT),


### PR DESCRIPTION
Closes #107655

## What Problem This Solves

Fixes an issue where tool-heavy sessions could trigger whole-session compaction even after prompt-only tool-result projection had successfully reduced the history.

Under aggregate tool-result pressure, OpenClaw discarded the bounded projection, skipped provider submission, and manufactured a local context-overflow recovery. This caused unnecessary compaction and persistent session rewriting before the actual context budget required it.

## Why This Change Was Made

The prompt-context stage now carries the aggregate replacement count into prompt admission. When one or more historical tool results were successfully replaced, OpenClaw continues through the existing post-projection budget checks and provider submission path.

The existing `compact_then_truncate` fallback remains unchanged when aggregate pressure produces no replacement. Genuine projected-budget overflow and provider context rejection also continue through the existing recovery paths.

This is deliberately narrow: it does not change aggregate thresholds, truncation policy, configuration, provider identity, protocol shapes, or persisted-session formats.

AI-assisted: yes. I reviewed the implementation, traced prompt projection through preflight and provider dispatch, and understand the code and regression coverage.

## User Impact

Long-lived, tool-heavy sessions can continue using their bounded prompt projection instead of compacting prematurely.

Users retain more conversational history, avoid unnecessary compaction delays, and still receive normal compaction when the projected prompt genuinely exceeds the context budget.

## Evidence

Human-run live A/B from #107655:

- Before: prompt projection reported `aggregate=1`, but OpenClaw skipped provider submission, emitted a synthetic precheck overflow, and started whole-session compaction.
- After changing only the aggregate fallback condition, projected prompts with replacement counts of 1, 2, 3, 7, 12, and 27 reached the same provider/model route and returned HTTP 200.
- The session continued to 246k/272k without aggregate-triggered compaction, then completed a normal budget-driven compaction and resumed successfully.
- @kesslerio provided separate production evidence of the same local-overflow-before-provider symptom on a custom OpenAI-compatible/vLLM route.

Regression proof:

- The two new routing cases fail against the previous unconditional branch.
- The patched branch submits when aggregate projection replaced at least one result.
- It retains `compact_then_truncate`, skips submission, and reports precheck overflow when the replacement count is zero.

```shell
node scripts/run-vitest.mjs \
  src/agents/embedded-agent-runner/run/attempt-prompt-context.test.ts \
  src/agents/embedded-agent-runner/run/attempt-prompt-phase.test.ts \
  src/agents/embedded-agent-runner/run/attempt-prompt-preflight.test.ts \
  src/agents/embedded-agent-runner/tool-result-truncation.test.ts
```

Result on current `main` base: 4 test files passed, 81 tests passed.

Additional checks:

```shell
node_modules/.bin/oxfmt --check --threads=1 \
  src/agents/embedded-agent-runner/run/attempt-prompt-context.test.ts \
  src/agents/embedded-agent-runner/run/attempt-prompt-context.ts \
  src/agents/embedded-agent-runner/run/attempt-prompt-phase.test.ts \
  src/agents/embedded-agent-runner/run/attempt-prompt-phase.ts

git diff --check
```

Both passed. The final Codex+Claude structured review panel reported no actionable findings.

Proof limitation: this exact branch was not replayed against a live provider because Testbox/Crabbox access is unavailable. The issue's human-run A/B exercised the same routing condition; the focused tests prove field propagation and both admission outcomes.

<!-- agent-transcript:start -->
## Agent Transcript

<details>
<summary>Redacted Codex session transcript</summary>

```text
Scope: investigate and fix OpenClaw #107655, prove the behavior, and prepare the contribution.

User: Requested read-only verification of whether aggregate tool-result pressure still forced compaction after successful prompt projection.

Codex: Confirmed current main discarded a successful bounded projection before normal admission. Traced the decision through prompt context, prompt phase, normal preflight, and provider-boundary projection. Recommended carrying aggregateTruncatedCount to the phase and preserving compact_then_truncate only for zero-replacement pressure.

User: Approved implementation.

Codex: Added the narrow four-file change and two routing regressions. The new cases failed before the production change and passed afterward. Final focused proof passed 81/81 tests on Node 24.16; formatting and git diff checks were clean. No config, protocol, provider identity, persistence shape, or public API changed.

User: Requested a pre-publish cross-review and PR proof draft.

Codex: Rechecked live issue and duplicate state, current main, owner boundaries, and proof. Codex autoreview reported no actionable findings. The first Claude panel attempt was blocked by expired local authentication, so publication was held pending reauthentication rather than bypassing the review gate.

User: Approved publishing a ready-for-review PR and including a sanitized transcript.

Codex: Fast-forwarded the branch to current main without conflicts and reran focused proof: 4 files and 81 tests passed, with formatter and whitespace checks clean. The final Codex+Claude panel completed with zero actionable findings.

Raw tool outputs, system/developer prompts, local paths, credentials, authentication details, and unrelated session turns were omitted.
```

</details>
<!-- agent-transcript:end -->
