### PR TITLE
test(memory): model qmd child stream encoding

### DIFF
--- a/extensions/memory-core/src/memory/qmd-manager.slugified-paths.test.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.slugified-paths.test.ts
@@ -13,16 +13,18 @@ const { logWarnMock, logDebugMock, logInfoMock } = vi.hoisted(() => ({
   logInfoMock: vi.fn(),
 }));
 
+type MockStream = EventEmitter & { setEncoding: ReturnType<typeof vi.fn> };
+
 interface MockChild extends EventEmitter {
-  stdout: EventEmitter;
-  stderr: EventEmitter;
+  stdout: MockStream;
+  stderr: MockStream;
   kill: (signal?: NodeJS.Signals) => void;
   closeWith: (code?: number | null) => void;
 }
 
 function createMockChild(params?: { autoClose?: boolean }): MockChild {
-  const stdout = new EventEmitter();
-  const stderr = new EventEmitter();
+  const stdout = Object.assign(new EventEmitter(), { setEncoding: vi.fn() });
+  const stderr = Object.assign(new EventEmitter(), { setEncoding: vi.fn() });
   const child = new EventEmitter() as unknown as MockChild;
   child.stdout = stdout;
   child.stderr = stderr;


### PR DESCRIPTION
## What Problem This Solves

Restores the Plugin Prerelease extension shard after the UTF-8-safe qmd process change began calling `setEncoding` on child stdout and stderr streams.

The slugified-path tests still modeled those streams as bare event emitters, so all three tests failed before exercising path resolution.

## Why This Change Was Made

The production process contract is correct: real child-process pipes expose `setEncoding`, which preserves split UTF-8 sequences. The test double now models that same Readable-stream method, matching the sibling memory-manager test helper instead of weakening production behavior.

## User Impact

No runtime behavior change. Plugin prerelease and full release validation can exercise the intended memory-core slugified-path behavior again.

## Evidence

- Failing exact-head job: https://github.com/openclaw/openclaw/actions/runs/29373996452/job/87223463242
- Focused Testbox proof: https://github.com/openclaw/openclaw/actions/runs/29374734708 — 1 file, 3 tests passed
- Full memory-core Testbox proof: https://github.com/openclaw/openclaw/actions/runs/29374859021 — 65 files, 991 tests passed
- Exact-head hosted CI: https://github.com/openclaw/openclaw/actions/runs/29374894613 — passed
- `pnpm exec oxfmt --check extensions/memory-core/src/memory/qmd-manager.slugified-paths.test.ts`
- `git diff --check`
- Fresh structured autoreview: clean, confidence 0.98
