### PR TITLE
test(sessions): stabilize extended-stable reply-init proof

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ Docs: https://docs.openclaw.ai
 
 ### Complete contribution record
 
-This audited record covers the complete v2026.6.11..544fe1e9cb46e8fbb7aed4fee8b74cd7e18ead5e history: 164 merged PRs. The generation manifest also supplies direct commits as editorial input; the grouped notes above prioritize user impact.
+This audited record covers the complete v2026.6.11..0cfce81a3c1f7d3d5e453d9788443e6e2097cc4d history: 165 merged PRs. The generation manifest also supplies direct commits as editorial input; the grouped notes above prioritize user impact.
 
 #### Pull requests
 
@@ -194,6 +194,8 @@ This audited record covers the complete v2026.6.11..544fe1e9cb46e8fbb7aed4fee8b7
 - **PR #105746** Thanks @vincentkoc.
 - **PR #99266** Thanks @RomneyDa.
 - **PR #100448** Thanks @kevinslin.
+- **PR #99212**
+
 ## 2026.6.11
 
 ### Highlights

--- a/src/config/sessions/session-accessor.reply-init-concurrency.test.ts
+++ b/src/config/sessions/session-accessor.reply-init-concurrency.test.ts
@@ -84,7 +84,10 @@ async function waitForFile(filePath) {
 }
 
 async function writeJsonFile(filePath, value) {
-  await fs.writeFile(filePath, \`\${JSON.stringify(value, null, 2)}\\n\`, "utf8");
+  // The parent treats file existence as the readiness signal, so publish atomically.
+  const tempPath = filePath + "." + process.pid + ".tmp";
+  await fs.writeFile(tempPath, \`\${JSON.stringify(value, null, 2)}\\n\`, "utf8");
+  await fs.rename(tempPath, filePath);
 }
 
 const storePath = process.env.REPLY_INIT_STORE_PATH;
@@ -192,7 +195,6 @@ describe("reply session initialization concurrency", () => {
           stdio: ["ignore", "pipe", "pipe"],
         },
       );
-
       await waitForFile(readyPath);
       const snapshot = await readJsonFile<{ currentEntry?: unknown; revision: string }>(readyPath);
       expect(snapshot.revision).toBe(JSON.stringify({ sessionId: "existing-session" }));


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the 2026.6.33 release candidate's reply-session process-concurrency proof could observe its readiness marker while the child process was still writing JSON, causing a nondeterministic `Unexpected end of JSON input` failure in exact-SHA CI.

## Why This Change Was Made

Cherry-picks upstream a004e18b4bbd30b784239741e07fdcaf569968f2 so the child publishes marker JSON with write-then-rename atomicity, then refreshes the generated 2026.6.33 contribution record to include PR #99212. This PR intentionally contains no runtime, SQLite, package, workflow, version, or publication-scope changes.

## User Impact

No runtime behavior changes. This makes the required extended-stable validation deterministic and establishes merge-backed canonical-branch provenance for the trusted Telegram release check.

## Evidence

- Before: Full Release Validation 29374207890; CI child 29374220898 failed `session-accessor.reply-init-concurrency.test.ts` with `Unexpected end of JSON input`.
- After: Blacksmith Testbox 29375132291, lease `tbx_01kxhe3zk1d0yt79hb56yc9nst`: exact focused regression passed 20/20 repetitions.
- Changelog verifier: clean, 165 merged PRs; PR #99212 classified non-editorial.
- Fresh whole-branch autoreview: zero findings, `patch is correct`, confidence 0.99.
- `git diff --check`: passed.

AI-assisted: yes. The complete release ledger remains untracked as required.
