### PR TITLE
fix(status): trust live multi-account channel state

### DIFF
--- a/src/commands/status-all/channels-token-summary.ts
+++ b/src/commands/status-all/channels-token-summary.ts
@@ -2,7 +2,6 @@
 // The display path is intentionally secret-safe unless the caller explicitly requests disclosure.
 
 import { asRecord } from "@openclaw/normalization-core/record-coerce";
-import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { hasConfiguredUnavailableCredentialStatus } from "../../channels/account-snapshot-fields.js";
 import type { ChannelAccountSnapshot } from "../../channels/plugins/types.public.js";
 import { sha256HexPrefix } from "../../logging/redact-identifier.js";
@@ -149,16 +148,15 @@ export function summarizeTokenConfig(params: {
     const unavailable = enabled.filter((a) => hasConfiguredUnavailableCredentialStatus(a.account));
     const ready = enabled.filter((a) => {
       const rec = asRecord(a.account);
-      const bot = normalizeOptionalString(rec.botToken) ?? "";
-      const app = normalizeOptionalString(rec.appToken) ?? "";
-      return Boolean(bot) && Boolean(app);
+      return (
+        hasCredentialAvailable(rec, "botToken", "botTokenStatus") &&
+        hasCredentialAvailable(rec, "appToken", "appTokenStatus")
+      );
     });
     const partial = enabled.filter((a) => {
       const rec = asRecord(a.account);
-      const bot = normalizeOptionalString(rec.botToken) ?? "";
-      const app = normalizeOptionalString(rec.appToken) ?? "";
-      const hasBot = Boolean(bot);
-      const hasApp = Boolean(app);
+      const hasBot = hasCredentialAvailable(rec, "botToken", "botTokenStatus");
+      const hasApp = hasCredentialAvailable(rec, "appToken", "appTokenStatus");
       return (hasBot && !hasApp) || (!hasBot && hasApp);
     });
 
@@ -204,8 +202,7 @@ export function summarizeTokenConfig(params: {
     const unavailable = enabled.filter((a) => hasConfiguredUnavailableCredentialStatus(a.account));
     const ready = enabled.filter((a) => {
       const rec = asRecord(a.account);
-      const bot = normalizeOptionalString(rec.botToken) ?? "";
-      return Boolean(bot);
+      return hasCredentialAvailable(rec, "botToken", "botTokenStatus");
     });
 
     if (unavailable.length > 0) {
@@ -235,7 +232,7 @@ export function summarizeTokenConfig(params: {
   const unavailable = enabled.filter((a) => hasConfiguredUnavailableCredentialStatus(a.account));
   const ready = enabled.filter((a) => {
     const rec = asRecord(a.account);
-    return Boolean(normalizeOptionalString(rec.token));
+    return hasCredentialAvailable(rec, "token", "tokenStatus");
   });
   if (unavailable.length > 0) {
     return {

--- a/src/commands/status-all/channels.test.ts
+++ b/src/commands/status-all/channels.test.ts
@@ -148,6 +148,40 @@ describe("buildChannelsTable", () => {
     expect(table.details[0]?.rows.map((row) => row.Status)).toStrictEqual(["OK", "OK"]);
   });
 
+  it("uses live account state and credential status for token-backed summaries", async () => {
+    mocks.resolveInspectedChannelAccount.mockResolvedValue({
+      account: { botToken: "", botTokenStatus: "missing" },
+      enabled: false,
+      configured: false,
+    });
+
+    const table = await buildChannelsTable(
+      { channels: { discord: { enabled: true } } },
+      {
+        liveChannelStatus: {
+          channelAccounts: {
+            discord: [
+              {
+                accountId: "default",
+                enabled: true,
+                configured: true,
+                running: true,
+                connected: true,
+                botTokenStatus: "available",
+              },
+            ],
+          },
+        },
+      },
+    );
+
+    expect(table.rows.find((entry) => entry.id === "discord")).toMatchObject({
+      enabled: true,
+      state: "ok",
+      detail: "bot token config · accounts 1/1",
+    });
+  });
+
   it("warns when a configured token is unavailable and there is no live account proof", async () => {
     const table = await buildChannelsTable({ channels: { discord: { enabled: true } } });
 

--- a/src/commands/status-all/channels.test.ts
+++ b/src/commands/status-all/channels.test.ts
@@ -175,11 +175,13 @@ describe("buildChannelsTable", () => {
       },
     );
 
-    expect(table.rows.find((entry) => entry.id === "discord")).toMatchObject({
+    const row = table.rows.find((entry) => entry.id === "discord");
+    expect(row).toMatchObject({
       enabled: true,
       state: "ok",
       detail: "bot token config · accounts 1/1",
     });
+    expect(row?.detail).not.toContain("sha256:");
   });
 
   it("warns when a configured token is unavailable and there is no live account proof", async () => {

--- a/src/commands/status-all/channels.test.ts
+++ b/src/commands/status-all/channels.test.ts
@@ -100,6 +100,54 @@ describe("buildChannelsTable", () => {
     expect(detailRow?.Notes).toContain("credential available in gateway runtime");
   });
 
+  it("uses live multi-account state when local inspection reports accounts unconfigured", async () => {
+    mocks.listReadOnlyChannelPluginsForConfig.mockReturnValue([
+      {
+        ...discordPlugin,
+        config: { listAccountIds: () => ["primary"] },
+      },
+    ]);
+    mocks.resolveInspectedChannelAccount.mockImplementation(async ({ accountId }) => ({
+      account: { accountId },
+      enabled: false,
+      configured: false,
+    }));
+
+    const table = await buildChannelsTable(
+      { channels: { discord: { enabled: true } } },
+      {
+        liveChannelStatus: {
+          channelAccounts: {
+            discord: [
+              {
+                accountId: "primary",
+                enabled: true,
+                configured: true,
+                running: true,
+                connected: true,
+              },
+              {
+                accountId: "ops",
+                enabled: true,
+                configured: true,
+                running: true,
+                connected: true,
+              },
+            ],
+          },
+        },
+      },
+    );
+
+    expect(table.rows.find((entry) => entry.id === "discord")).toMatchObject({
+      enabled: true,
+      state: "ok",
+      detail: "configured · accounts 2/2",
+    });
+    expect(table.details[0]?.rows).toHaveLength(2);
+    expect(table.details[0]?.rows.map((row) => row.Status)).toStrictEqual(["OK", "OK"]);
+  });
+
   it("warns when a configured token is unavailable and there is no live account proof", async () => {
     const table = await buildChannelsTable({ channels: { discord: { enabled: true } } });
 

--- a/src/commands/status-all/channels.ts
+++ b/src/commands/status-all/channels.ts
@@ -262,7 +262,16 @@ export async function buildChannelsTable(
       cfg,
       accountIds,
     });
-    const resolvedAccountIds = accountIds.length > 0 ? accountIds : [defaultAccountId];
+    const liveAccounts = getRuntimeChannelAccounts({
+      payload: opts?.liveChannelStatus,
+      channelId: plugin.id,
+    });
+    const liveAccountIds = liveAccounts
+      .map((account) => normalizeOptionalString(account.accountId))
+      .filter((accountId): accountId is string => Boolean(accountId));
+    const resolvedAccountIds = [
+      ...new Set([...(accountIds.length > 0 ? accountIds : [defaultAccountId]), ...liveAccountIds]),
+    ];
 
     const accounts: ChannelAccountRow[] = [];
     for (const accountId of resolvedAccountIds) {
@@ -275,14 +284,36 @@ export async function buildChannelsTable(
         }),
       );
     }
-    const liveAccounts = getRuntimeChannelAccounts({
-      payload: opts?.liveChannelStatus,
-      channelId: plugin.id,
+    const liveAccountsById = new Map(
+      liveAccounts
+        .map((account) => [normalizeOptionalString(account.accountId), account] as const)
+        .filter((entry): entry is [string, (typeof liveAccounts)[number]] => Boolean(entry[0])),
+    );
+    const effectiveAccountStates = accounts.map((account) => {
+      const live = liveAccountsById.get(account.accountId);
+      const liveActive = live?.running === true || live?.connected === true;
+      const enabled =
+        typeof live?.enabled === "boolean" ? live.enabled : liveActive || account.enabled;
+      const configured =
+        typeof live?.configured === "boolean" ? live.configured : liveActive || account.configured;
+      return {
+        account: {
+          ...account,
+          enabled,
+          configured,
+          snapshot: { ...account.snapshot, enabled, configured },
+        },
+        enabled,
+        configured,
+      };
     });
-
-    const anyEnabled = accounts.some((a) => a.enabled);
-    const enabledAccounts = accounts.filter((a) => a.enabled);
-    const configuredAccounts = enabledAccounts.filter((a) => a.configured);
+    const anyEnabled = effectiveAccountStates.some((entry) => entry.enabled);
+    const enabledAccounts = effectiveAccountStates
+      .filter((entry) => entry.enabled)
+      .map((entry) => entry.account);
+    const configuredAccounts = effectiveAccountStates
+      .filter((entry) => entry.enabled && entry.configured)
+      .map((entry) => entry.account);
     const unavailableConfiguredAccounts = enabledAccounts.filter(
       (a) =>
         hasConfiguredUnavailableCredentialStatus(a.account) &&

--- a/src/commands/status-all/channels.ts
+++ b/src/commands/status-all/channels.ts
@@ -53,6 +53,27 @@ type ResolvedChannelAccountRowParams = {
   accountId: string;
 };
 
+const RUNTIME_CREDENTIAL_STATUS_KEYS = [
+  "tokenStatus",
+  "botTokenStatus",
+  "appTokenStatus",
+  "signingSecretStatus",
+  "userTokenStatus",
+] as const;
+
+function applyRuntimeCredentialStatuses(account: unknown, live: unknown): unknown {
+  const liveRecord = asRecord(live);
+  const statuses = Object.fromEntries(
+    RUNTIME_CREDENTIAL_STATUS_KEYS.flatMap((key) => {
+      const value = liveRecord[key];
+      return value === "available" || value === "configured_unavailable" || value === "missing"
+        ? [[key, value]]
+        : [];
+    }),
+  );
+  return Object.keys(statuses).length > 0 ? { ...asRecord(account), ...statuses } : account;
+}
+
 function existsSyncMaybe(p: string | undefined): boolean | null {
   const path = normalizeOptionalString(p) ?? "";
   if (!path) {
@@ -299,6 +320,7 @@ export async function buildChannelsTable(
       return {
         account: {
           ...account,
+          account: applyRuntimeCredentialStatuses(account.account, live),
           enabled,
           configured,
           snapshot: { ...account.snapshot, enabled, configured },
@@ -320,17 +342,20 @@ export async function buildChannelsTable(
         !credentialResolutionSkipped &&
         !hasRuntimeCredentialAvailable({ liveAccounts, accountId: a.accountId }),
     );
-    const accountsForTokenSummary = accounts.map((entry) =>
-      hasConfiguredUnavailableCredentialStatus(entry.account) &&
-      (credentialResolutionSkipped ||
-        hasRuntimeCredentialAvailable({ liveAccounts, accountId: entry.accountId }))
-        ? {
-            ...entry,
-            // Fast-mode scans may not resolve local secrets; runtime evidence can still prove availability.
-            account: markConfiguredUnavailableCredentialStatusesAvailable(entry.account),
-          }
-        : entry,
-    );
+    const accountsForTokenSummary: ChannelAccountRow[] = [];
+    for (const { account: entry } of effectiveAccountStates) {
+      accountsForTokenSummary.push(
+        hasConfiguredUnavailableCredentialStatus(entry.account) &&
+          (credentialResolutionSkipped ||
+            hasRuntimeCredentialAvailable({ liveAccounts, accountId: entry.accountId }))
+          ? {
+              ...entry,
+              // Fast-mode scans may not resolve local secrets; runtime evidence can still prove availability.
+              account: markConfiguredUnavailableCredentialStatusesAvailable(entry.account),
+            }
+          : entry,
+      );
+    }
     const defaultEntry = accounts.find((a) => a.accountId === defaultAccountId) ?? accounts[0];
 
     const summary = plugin.status?.buildChannelSummary


### PR DESCRIPTION
## Summary

- merge configured and gateway-reported account IDs in the `status --all` channel projection
- prefer live `enabled` / `configured` state, with running or connected state as the compatibility fallback
- keep local account metadata while rendering runtime-only multi-account rows
- add a focused regression for a healthy two-account gateway snapshot whose local inspection reports unconfigured accounts

## Issue / Motivation

Fixes #107742.

`openclaw status --deep` already fetches gateway channel status, but its summary was still derived from local account inspection. For Matrix multi-account setups this can report `OFF / not configured` even while the gateway reports healthy configured providers.

## Changes

- include account IDs present only in `channelAccounts`
- overlay live account availability onto summary and detail calculations
- preserve explicit live `enabled: false` / `configured: false` values
- cover aggregate state, account count, and per-account `OK` rendering

## Testing

- `node scripts/run-vitest.mjs src/commands/status-all/channels.test.ts` — passed: 1 file, 10 tests
- `pnpm exec oxfmt --check src/commands/status-all/channels.ts src/commands/status-all/channels.test.ts` — passed
- `pnpm exec oxlint --tsconfig config/tsconfig/oxlint.core.json src/commands/status-all/channels.ts src/commands/status-all/channels.test.ts` — passed: 0 warnings, 0 errors
- `git diff --check` — passed
- added-line secret scan — clean

## What Problem This Solves

It prevents the top-level status summary from contradicting the gateway's healthy multi-account channel state when local read-only inspection cannot reconstruct those configured accounts.

## Evidence

The regression supplies one locally discovered account and two live gateway accounts, with local inspection returning `enabled: false` and `configured: false`. The fixed projection reports the channel as enabled/`ok`, renders `configured · accounts 2/2`, includes the runtime-only account, and marks both detail rows `OK`.
