### PR TITLE
fix(slack): keep health probes within their timeout

### DIFF
--- a/extensions/slack/src/probe.test.ts
+++ b/extensions/slack/src/probe.test.ts
@@ -39,7 +39,11 @@ describe("probeSlack", () => {
       bot: { id: "U123", name: "openclaw-bot" },
       team: { id: "T123", name: "OpenClaw" },
     });
-    expect(createSlackReadClientMock).toHaveBeenCalledWith("xoxb-test", { timeout: 2500 });
+    expect(createSlackReadClientMock).toHaveBeenCalledWith("xoxb-test", {
+      rejectRateLimitedCalls: true,
+      retryConfig: { retries: 0 },
+      timeout: 2500,
+    });
   });
 
   it("warns when auth.test looks like a user token in the bot token slot", async () => {
@@ -111,5 +115,36 @@ describe("probeSlack", () => {
     expect(result.elapsedMs).toBe(35);
     expect(result.bot).toStrictEqual({ id: undefined, name: undefined });
     expect(result.team).toStrictEqual({ id: undefined, name: undefined });
+    expect(createSlackReadClientMock).toHaveBeenCalledWith("xoxb-test", {
+      rejectRateLimitedCalls: true,
+      retryConfig: { retries: 0 },
+      timeout: 2500,
+    });
+  });
+
+  it("passes a custom probe deadline to Slack's abortable read transport", async () => {
+    authTestMock.mockResolvedValue({ ok: true });
+
+    await expect(probeSlack("xoxb-test", 175)).resolves.toMatchObject({ ok: true });
+
+    expect(createSlackReadClientMock).toHaveBeenCalledWith("xoxb-test", {
+      rejectRateLimitedCalls: true,
+      retryConfig: { retries: 0 },
+      timeout: 175,
+    });
+  });
+
+  it("keeps the normal health result when the Slack read transport aborts", async () => {
+    authTestMock.mockRejectedValue(
+      Object.assign(new Error("The operation was aborted due to timeout"), {
+        name: "TimeoutError",
+      }),
+    );
+
+    await expect(probeSlack("xoxb-test", 175)).resolves.toMatchObject({
+      ok: false,
+      status: null,
+      error: expect.any(String),
+    });
   });
 });

--- a/extensions/slack/src/probe.transport.test.ts
+++ b/extensions/slack/src/probe.transport.test.ts
@@ -1,0 +1,191 @@
+// Prove Slack probe deadlines against the real SDK and loopback HTTP transport.
+import { createServer, type RequestListener } from "node:http";
+import type { Socket } from "node:net";
+import { afterEach, describe, expect, it } from "vitest";
+import { probeSlack } from "./probe.js";
+
+const TEST_ENV_KEYS = [
+  "SLACK_API_URL",
+  "HTTPS_PROXY",
+  "HTTP_PROXY",
+  "ALL_PROXY",
+  "https_proxy",
+  "http_proxy",
+  "all_proxy",
+  "NO_PROXY",
+  "no_proxy",
+  "OPENCLAW_PROXY_ACTIVE",
+  "OPENCLAW_PROXY_CA_FILE",
+] as const;
+
+const originalEnv = Object.fromEntries(
+  TEST_ENV_KEYS.map((key) => [key, process.env[key]]),
+) as Record<(typeof TEST_ENV_KEYS)[number], string | undefined>;
+
+type TestServer = {
+  apiUrl: string;
+  sockets: Set<Socket>;
+  close(): Promise<void>;
+};
+
+function clearSlackTransportEnv(): void {
+  for (const key of TEST_ENV_KEYS) {
+    delete process.env[key];
+  }
+}
+
+function restoreSlackTransportEnv(): void {
+  for (const key of TEST_ENV_KEYS) {
+    const original = originalEnv[key];
+    if (original === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = original;
+    }
+  }
+}
+
+async function startSlackTransportServer(handler: RequestListener): Promise<TestServer> {
+  const server = createServer(handler);
+  const sockets = new Set<Socket>();
+  server.on("connection", (socket) => {
+    sockets.add(socket);
+    socket.once("close", () => sockets.delete(socket));
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    server.close();
+    throw new Error("Slack probe test server did not bind a TCP address");
+  }
+  return {
+    apiUrl: `http://127.0.0.1:${address.port}/api/`,
+    sockets,
+    close: async () => {
+      for (const socket of sockets) {
+        socket.destroy();
+      }
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) {
+            reject(error);
+          } else {
+            resolve();
+          }
+        });
+      });
+    },
+  };
+}
+
+afterEach(() => {
+  restoreSlackTransportEnv();
+});
+
+describe("probeSlack real network deadlines", () => {
+  it("aborts a stalled Slack request and closes its only socket", async () => {
+    clearSlackTransportEnv();
+    let requests = 0;
+    const server = await startSlackTransportServer((request) => {
+      requests += 1;
+      request.resume();
+    });
+    try {
+      process.env.SLACK_API_URL = server.apiUrl;
+
+      await expect(probeSlack("probe-fixture", 100)).resolves.toMatchObject({ ok: false });
+
+      expect(requests).toBe(1);
+      await expect.poll(() => server.sockets.size, { timeout: 400 }).toBe(0);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("does not retry a dropped request after the probe has already returned", async () => {
+    clearSlackTransportEnv();
+    let requests = 0;
+    const server = await startSlackTransportServer((request, response) => {
+      requests += 1;
+      request.resume();
+      response.destroy();
+    });
+    try {
+      process.env.SLACK_API_URL = server.apiUrl;
+
+      await expect(probeSlack("probe-fixture", 100)).resolves.toMatchObject({ ok: false });
+
+      // The default Slack read retry is randomized between 500 and 1,000 ms.
+      // Keep the endpoint alive long enough to catch work after the probe ends.
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 1_200);
+      });
+      expect(requests).toBe(1);
+      await expect.poll(() => server.sockets.size, { timeout: 400 }).toBe(0);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("rejects a rate limit without waiting or retrying", async () => {
+    clearSlackTransportEnv();
+    let requests = 0;
+    const server = await startSlackTransportServer((request, response) => {
+      requests += 1;
+      request.resume();
+      response.writeHead(429, {
+        "content-type": "application/json",
+        "retry-after": "2",
+      });
+      response.end(`${JSON.stringify({ ok: false, error: "ratelimited" })}\n`);
+    });
+    try {
+      process.env.SLACK_API_URL = server.apiUrl;
+      const startedAt = performance.now();
+
+      await expect(probeSlack("probe-fixture", 1_000)).resolves.toMatchObject({ ok: false });
+
+      expect(performance.now() - startedAt).toBeLessThan(500);
+      expect(requests).toBe(1);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("aborts response-body trickling at the absolute probe deadline", async () => {
+    clearSlackTransportEnv();
+    let requests = 0;
+    const server = await startSlackTransportServer((request, response) => {
+      requests += 1;
+      request.resume();
+      response.writeHead(200, { "content-type": "application/json" });
+      const trickle = setInterval(() => response.write(" "), 25);
+      const finish = setTimeout(() => {
+        clearInterval(trickle);
+        response.end(`${JSON.stringify({ ok: true })}\n`);
+      }, 750);
+      response.once("close", () => {
+        clearInterval(trickle);
+        clearTimeout(finish);
+      });
+    });
+    try {
+      process.env.SLACK_API_URL = server.apiUrl;
+      const startedAt = performance.now();
+
+      await expect(probeSlack("probe-fixture", 100)).resolves.toMatchObject({ ok: false });
+
+      expect(performance.now() - startedAt).toBeLessThan(500);
+      expect(requests).toBe(1);
+      await expect.poll(() => server.sockets.size, { timeout: 400 }).toBe(0);
+    } finally {
+      await server.close();
+    }
+  });
+});

--- a/extensions/slack/src/probe.ts
+++ b/extensions/slack/src/probe.ts
@@ -19,7 +19,13 @@ export async function probeSlack(
   timeoutMs = 2500,
   opts?: { accountId?: string | null; identity?: "bot" | "user" },
 ): Promise<SlackProbe> {
-  const client = createSlackReadClient(token, { timeout: timeoutMs });
+  // The probe owns a single absolute deadline: abort its fetch and never let
+  // retries or Slack's 429 queue outlive the shared health-check result.
+  const client = createSlackReadClient(token, {
+    rejectRateLimitedCalls: true,
+    retryConfig: { retries: 0 },
+    timeout: timeoutMs,
+  });
   return await runChannelProbe(
     timeoutMs,
     async () => {


### PR DESCRIPTION
Closes #106565.

Related exact duplicate: #107413. Thanks to @harjothkhara and @zhangqueping for independently identifying and developing the fix; both remain credited as commit co-authors.

## What Problem This Solves

Fixes an issue where a completed Slack health check could still start background HTTP requests after its deadline. A dropped request retried after the probe had already reported failure, and an HTTP 429 waited through `Retry-After` instead of failing promptly.

This three-file fix is rebuilt on current `main` after #115018 and #115056. Stalled and trickling sockets are already correctly aborted by the dedicated Slack read client; the remaining bug is its default two retries and rate-limit wait, which allow probe work to survive the shared deadline.

## Why This Change Was Made

Keep `createSlackReadClient`, the current Slack Web API v8 native `AbortSignal.timeout`, and `runChannelProbe`. Configure only the health-probe call with zero retries and immediate HTTP 429 rejection. Bot/user identity, normal reads, mutations, channel routing, proxy behavior, TLS, authentication, configuration, and the newly merged channel tests remain untouched.

## User Impact

Slack status and diagnostics return within the actual probe deadline, never start a second background request after returning, reject rate limits promptly, and continue to release stalled and trickling sockets.

## Evidence

Real current-main baseline using the actual pinned Slack SDK against a loopback HTTP server:

```text
stalled socket: already closes at the deadline (passes on current main)
trickling response: already aborts at the deadline (passes on current main)
dropped connection: 2 requests; the second starts after the 100 ms probe returned (FAIL)
HTTP 429 Retry-After: waits 1003 ms instead of returning in under 500 ms (FAIL)
```

After the fix, all four committed real-transport scenarios pass. The complete affected Slack surface was verified on a trusted Blacksmith Testbox:

```text
pnpm test \
  extensions/slack/src/probe.transport.test.ts \
  extensions/slack/src/probe.test.ts \
  extensions/slack/src/client.web-api.test.ts \
  extensions/slack/src/client.test.ts \
  extensions/slack/src/channel.test.ts \
  extensions/slack/src/channel-type.test.ts \
  extensions/slack/src/scopes.test.ts \
  extensions/slack/src/send.reconcile.test.ts

Test Files  8 passed (8)
Tests       148 passed (148)
```

The full final three-file repository gate also passed:

```text
pnpm check:changed -- \
  extensions/slack/src/probe.ts \
  extensions/slack/src/probe.test.ts \
  extensions/slack/src/probe.transport.test.ts

format: passed
extension production and test typecheck: passed
changed-file lint: passed
plugin boundary and SDK contract guards: passed
dependency, database, sidecar, and runtime import-cycle guards: passed
exit code: 0
```

Fresh independent Codex autoreview: clean; no accepted or actionable findings. Secret scan: clean. Exact-head GitHub CI must independently pass before landing.

AI-assisted: implementation, real-server regression proof, and independent review were prepared with AI assistance under human-directed scope.
