### PR TITLE
improve: speed up run-lease tests

### DIFF
--- a/src/agents/worktrees/run-lease.test.ts
+++ b/src/agents/worktrees/run-lease.test.ts
@@ -3,7 +3,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
 import { lockState, unlockWorktree } from "./git-lock.js";
 import {
@@ -41,15 +41,30 @@ async function initializeRepository(root: string): Promise<string> {
 }
 
 describe("worktree run lease", () => {
+  let templateRoot: string;
+  let templateRepo: string;
   let root: string;
   let repo: string;
   let env: NodeJS.ProcessEnv;
   let service: ManagedWorktreeService;
 
+  beforeAll(async () => {
+    const tempRoot = await fs.realpath(os.tmpdir());
+    templateRoot = await fs.mkdtemp(path.join(tempRoot, "openclaw-run-lease-template-"));
+    templateRepo = await initializeRepository(templateRoot);
+  });
+
+  afterAll(async () => {
+    await fs.rm(templateRoot, { recursive: true, force: true });
+  });
+
   beforeEach(async () => {
     const tempRoot = await fs.realpath(os.tmpdir());
     root = await fs.mkdtemp(path.join(tempRoot, "openclaw-run-lease-"));
-    repo = await initializeRepository(root);
+    repo = path.join(root, "repo");
+    // Each case keeps a private .git directory; only repository construction is shared.
+    await fs.cp(templateRepo, repo, { recursive: true });
+    repo = await fs.realpath(repo);
     env = { ...process.env, OPENCLAW_STATE_DIR: path.join(root, "openclaw-state") };
     service = new ManagedWorktreeService({ env });
   });

--- a/src/agents/worktrees/run-lease.test.ts
+++ b/src/agents/worktrees/run-lease.test.ts
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
 import { lockState, unlockWorktree } from "./git-lock.js";
 import {
@@ -41,7 +42,14 @@ async function initializeRepository(root: string): Promise<string> {
 }
 
 describe("worktree run lease", () => {
-  let templateRoot: string;
+  const templateTempDirs = useAutoCleanupTempDirTracker(afterAll);
+  const caseTempDirs = useAutoCleanupTempDirTracker((cleanup) => {
+    afterEach(() => {
+      runLeaseTesting.resetForTest();
+      closeOpenClawStateDatabaseForTest();
+      cleanup();
+    });
+  });
   let templateRepo: string;
   let root: string;
   let repo: string;
@@ -50,29 +58,19 @@ describe("worktree run lease", () => {
 
   beforeAll(async () => {
     const tempRoot = await fs.realpath(os.tmpdir());
-    templateRoot = await fs.mkdtemp(path.join(tempRoot, "openclaw-run-lease-template-"));
+    const templateRoot = templateTempDirs.make("openclaw-run-lease-template-", tempRoot);
     templateRepo = await initializeRepository(templateRoot);
-  });
-
-  afterAll(async () => {
-    await fs.rm(templateRoot, { recursive: true, force: true });
   });
 
   beforeEach(async () => {
     const tempRoot = await fs.realpath(os.tmpdir());
-    root = await fs.mkdtemp(path.join(tempRoot, "openclaw-run-lease-"));
+    root = caseTempDirs.make("openclaw-run-lease-", tempRoot);
     repo = path.join(root, "repo");
     // Each case keeps a private .git directory; only repository construction is shared.
     await fs.cp(templateRepo, repo, { recursive: true });
     repo = await fs.realpath(repo);
     env = { ...process.env, OPENCLAW_STATE_DIR: path.join(root, "openclaw-state") };
     service = new ManagedWorktreeService({ env });
-  });
-
-  afterEach(async () => {
-    runLeaseTesting.resetForTest();
-    closeOpenClawStateDatabaseForTest();
-    await fs.rm(root, { recursive: true, force: true });
   });
 
   async function createSessionWorktree(): Promise<{ id: string; path: string }> {


### PR DESCRIPTION
## What Problem This Solves

The run-lease test suite rebuilt and committed the same Git repository separately for all 15 cases, spending CI time on repeated subprocess setup that did not vary between tests.

## Why This Change Was Made

Build one repository template for the suite, then copy it into a fresh case directory. Each test still receives private Git metadata, OpenClaw state, and cleanup; tracked temp-directory helpers own both suite and case lifecycles.

## User Impact

No runtime behavior change. Maintainer and CI feedback for the managed-worktree run-lease tests is faster.

## Evidence

- Same-Testbox paired samples: mean focused-suite wall time 2.29s -> 1.63s (28.9% faster); mean test time 1.81s -> 1.26s (30.2% faster). All four samples passed 15/15 tests.
- Exact rebased head: `pnpm test src/agents/worktrees` passed 63/63 tests in one shard (Vitest duration 5.02s; shard 7.08s): https://github.com/openclaw/openclaw/actions/runs/29375617329
- Exact rebased head: `pnpm check:changed` passed, including formatting, core-test typecheck, lint, and no temp-directory warnings.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`: clean, no accepted/actionable findings (0.91 confidence).
- Changelog omitted: test-only optimization.
