### PR TITLE
fix(nextcloud-talk): replay test this-typing breaks tsgo:test on macOS checkouts

### DIFF
--- a/extensions/nextcloud-talk/src/monitor.replay.test.ts
+++ b/extensions/nextcloud-talk/src/monitor.replay.test.ts
@@ -40,11 +40,14 @@ async function invokeWebhookServerRequest(params: {
 
   return await new Promise<{ body: string; status: number }>((resolve) => {
     let status = 0;
+    let headersSent = false;
     const res = {
-      headersSent: false,
+      get headersSent() {
+        return headersSent;
+      },
       writeHead(code: number) {
         status = code;
-        this.headersSent = true;
+        headersSent = true;
         return this;
       },
       end(body?: string) {


### PR DESCRIPTION
## What Problem This Solves

Correction after more data: this does **not** reproduce on Linux CI (`check-test-types` is green on current `main`-based runs, e.g. #107547's run). It reproduces consistently on a fresh **macOS** checkout (Node 24.18, clean `pnpm install`):

```text
$ pnpm tsgo:extensions:test   # on plain origin/main (21ec1546e5), macOS
extensions/nextcloud-talk/src/monitor.replay.test.ts(47,14): error TS2339: Property 'headersSent' does not exist on type '{}'.
```

So the impact is the local macOS dev loop (focused typecheck lanes fail on an untouched tree), not CI. Downgrading severity accordingly — happy to close instead if maintainers consider platform-local typecheck drift not worth patching.

## Why This Change Was Made

The mock `ServerResponse` literal mutated `this.headersSent` inside a shorthand method, relying on `this` being contextually typed to the literal — typing that evidently resolves differently across platforms/resolution of `@types/node`. Replacing the mutation with a closure boolean exposed through a getter keeps the mock's observable behavior identical without depending on literal `this` typing, and is portable across both environments.

## User Impact

None at runtime — test-only change. Restores a clean `tsgo:extensions:test` on macOS checkouts.

## Evidence

- Plain `origin/main` (21ec1546e5), macOS/Node 24.18: `pnpm tsgo:extensions:test` fails with the error above (reproduced twice on independent runs).
- With this change: `pnpm tsgo:extensions:test` clean on macOS; `node scripts/run-vitest.mjs extensions/nextcloud-talk/src/monitor.replay.test.ts` — 10 passed; Linux CI on this PR green.
