### PR TITLE
fix(codex): identify Codex-backed runs in transcripts

### DIFF
--- a/extensions/codex/src/app-server/transcript-mirror.test.ts
+++ b/extensions/codex/src/app-server/transcript-mirror.test.ts
@@ -703,6 +703,46 @@ describe("mirrorCodexAppServerTranscript", () => {
     ).toHaveLength(1);
   });
 
+  it("persists explicit Codex harness provenance on mirrored messages", async () => {
+    const target = await createSqliteMirrorTarget("openclaw-codex-mirror-harness-");
+    const messages = [
+      attachCodexMirrorIdentity(
+        makeAgentUserMessage({
+          content: [{ type: "text", text: "prompt" }],
+          timestamp: Date.now(),
+        }),
+        "turn-1:prompt",
+      ),
+      attachCodexMirrorIdentity(
+        makeAgentAssistantMessage({
+          content: [{ type: "text", text: "reply" }],
+          timestamp: Date.now() + 1,
+        }),
+        "turn-1:assistant",
+      ),
+    ];
+
+    await mirrorCodexAppServerTranscript({
+      ...target,
+      messages,
+      idempotencyScope: "codex-app-server:thread-1",
+    });
+
+    const events = (await readMirrorEvents(target)) as Array<{
+      type?: string;
+      message?: AgentMessage & {
+        __openclaw?: { harness?: string; mirrorIdentity?: string };
+      };
+    }>;
+    const persistedMessages = events
+      .filter((event) => event.type === "message")
+      .map((event) => event.message);
+    expect(persistedMessages).toMatchObject([
+      { __openclaw: { harness: "codex", mirrorIdentity: "turn-1:prompt" } },
+      { __openclaw: { harness: "codex", mirrorIdentity: "turn-1:assistant" } },
+    ]);
+  });
+
   it("emits message-bearing updates for newly appended mirrored messages only", async () => {
     const target = await createSqliteMirrorTarget("openclaw-codex-mirror-live-updates-");
     const userMessage = attachCodexMirrorIdentity(

--- a/extensions/codex/src/app-server/upstream-prompt-provenance.ts
+++ b/extensions/codex/src/app-server/upstream-prompt-provenance.ts
@@ -2,6 +2,8 @@ import type { AgentMessage } from "openclaw/plugin-sdk/agent-harness-runtime";
 
 const UPSTREAM_USER_TEXT_META_KEY = "upstreamUserText" as const;
 const MIRROR_IDENTITY_META_KEY = "mirrorIdentity" as const;
+const HARNESS_META_KEY = "harness" as const;
+const CODEX_HARNESS_ID = "codex" as const;
 
 export function attachCodexMirrorIdentity<T extends AgentMessage>(message: T, identity: string): T {
   const record = message as unknown as Record<string, unknown>;
@@ -12,7 +14,11 @@ export function attachCodexMirrorIdentity<T extends AgentMessage>(message: T, id
       : {};
   return {
     ...record,
-    __openclaw: { ...baseMeta, [MIRROR_IDENTITY_META_KEY]: identity },
+    __openclaw: {
+      ...baseMeta,
+      [MIRROR_IDENTITY_META_KEY]: identity,
+      [HARNESS_META_KEY]: CODEX_HARNESS_ID,
+    },
   } as unknown as T;
 }
 


### PR DESCRIPTION
Closes #95875

## What Problem This Solves

Fixes an issue where operators inspecting a Codex-backed cron or interactive run could mistake it for a plain canonical OpenAI run because mirrored transcript messages only showed `provider=openai` / `api=openai-chatgpt-responses` and did not identify the execution harness.

The earlier candidate, #96010, was closed unmerged by its author after an added repro script failed lint. This PR keeps the accepted owner-boundary fix, targets the current refactored helper, and omits that unrelated script.

## Why This Change Was Made

Codex-owned transcript messages now carry additive `__openclaw.harness = "codex"` provenance beside their existing stable mirror identity. The stamp is applied at the shared Codex mirror-identity helper, so prompt, assistant, reasoning, plan, tool, and imported-history mirror records receive the same provenance without changing provider identity, routing, compatibility behavior, or the Codex protocol.

## User Impact

Operators can identify Codex-backed execution directly from persisted transcript metadata instead of inferring it from `codex-app-server` idempotency details. Existing transcripts remain readable, non-Codex messages are unchanged, and no migration is required for this additive field.

## Evidence

- Exact head: `d1a8e3a7dfb39ce1cf5ca73e25e493e2259f87aa`, rebased onto `origin/main` `167a8ef20a2a60594cd3fae1e96e3e95ffad9e4c`.
- Real persistence boundary: the regression runs the production mirror path against the SQLite transcript store and verifies both user and assistant events persist `harness: "codex"` with distinct `mirrorIdentity` values.
- Before: the new persistence assertions fail because `attachCodexMirrorIdentity` writes only `mirrorIdentity`.
- After: 305/305 focused Codex tests pass across transcript mirroring, event projection, and run-attempt behavior.
- Static proof: targeted `oxfmt` and `oxlint` pass; `git diff --check` passes.
- Dependency contract: inspected upstream Codex commit `aeac226d16523875a3fc77f61d6edcd2943155fc`. `codex-rs/app-server/README.md:77-80` and `codex-rs/app-server-protocol/src/protocol/common.rs:1495-1516` define thread/turn/item lifecycle data, not OpenClaw's persisted `__openclaw` metadata; the additive marker therefore belongs at the OpenClaw mirror boundary.
- Best-fix review: the shared helper is the single owner boundary used by prompt, assistant, reasoning, plan, tool, and imported-history records; no sibling path needs a separate stamp.

Commands:

```text
node scripts/run-vitest.mjs extensions/codex/src/app-server/transcript-mirror.test.ts extensions/codex/src/app-server/event-projector.test.ts extensions/codex/src/app-server/run-attempt.test.ts -- --reporter=dot
# 3 files passed, 305 tests passed

node_modules/.bin/oxfmt --check extensions/codex/src/app-server/upstream-prompt-provenance.ts extensions/codex/src/app-server/transcript-mirror.test.ts
node scripts/run-oxlint.mjs extensions/codex/src/app-server/upstream-prompt-provenance.ts extensions/codex/src/app-server/transcript-mirror.test.ts
git diff --check
```

Fresh external autoreview was attempted after the rebase, but the configured Codex reviewer was unavailable due a local optional-binary mismatch and the configured Claude reviewer was rejected by its domain allowlist. I therefore do not claim a fresh two-model pass; the exhaustive local evidence map above found no actionable issue.

What remains unproved locally: an isolated credentialed Codex app-server turn was attempted with the source CLI, but it did not complete or persist a transcript within the explicit timeout. This PR therefore relies on the production SQLite regression for persisted-field proof while exact-head CI and repository-native real-behavior review run.

AI-assisted investigation and implementation. I reviewed and understand the change and its additive persisted-metadata impact.
