### PR TITLE
fix: session deletion works immediately after cloud worker teardown

### DIFF
--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-f444dbb08b59604a60784437a4c303038918aa486380cfb09eb09e8f2f3d9c7a  plugin-sdk-api-baseline.json
-edbcf681f3566ffc03f877e3d813445fbcc88f39c2108628fa2a3135a11d488b  plugin-sdk-api-baseline.jsonl
+9b6fe207d1ed9bbd141de92ecc23b97e75d9e59755be5779655a4d4174652a62  plugin-sdk-api-baseline.json
+ebdc7e79bde53559aac7d9f3b39a20944598edd2a2f6559ec1917b060ace3bf3  plugin-sdk-api-baseline.jsonl

--- a/src/gateway/server-methods/environments.test.ts
+++ b/src/gateway/server-methods/environments.test.ts
@@ -28,8 +28,14 @@ type TestWorkerService = {
   destroy: (environmentId: string) => Promise<TestWorkerRecord>;
 };
 
-function mockContext(workerEnvironmentService?: TestWorkerService) {
+function mockContext(
+  workerEnvironmentService?: TestWorkerService,
+  reconcileActive: (environmentId?: string) => Promise<void> = vi.fn(async () => {}),
+) {
   return {
+    logGateway: {
+      warn: vi.fn(),
+    },
     nodeRegistry: {
       listConnected: () => [
         {
@@ -46,7 +52,7 @@ function mockContext(workerEnvironmentService?: TestWorkerService) {
     workerEnvironmentService,
     ...(workerEnvironmentService
       ? {
-          workerPlacementDispatchService: { dispatch: vi.fn() },
+          workerPlacementDispatchService: { dispatch: vi.fn(), reconcileActive },
           getRuntimeConfig: () => ({
             cloudWorkers: {
               profiles: {
@@ -104,13 +110,16 @@ async function callEnvironmentMethod(
     | "environments.create"
     | "environments.destroy",
   params: unknown,
-  options: { service?: TestWorkerService } = {},
+  options: {
+    service?: TestWorkerService;
+    reconcileActive?: (environmentId?: string) => Promise<void>;
+  } = {},
 ) {
   const respond = vi.fn();
   await environmentsHandlers[method]?.({
     params: params as Record<string, unknown>,
     respond,
-    context: mockContext(options.service),
+    context: mockContext(options.service, options.reconcileActive),
   } as never);
   const call = respond.mock.calls.at(0);
   if (call === undefined) {
@@ -415,6 +424,39 @@ describe("environment gateway methods", () => {
       worker: { state: "destroyed" },
     });
     expect(destroy).toHaveBeenCalledTimes(2);
+  });
+
+  it("reconciles active placements before returning destroyed worker state", async () => {
+    const service = workerService();
+    const reconcileActive = vi.fn(async () => {});
+
+    const [ok, payload] = await callEnvironmentMethod(
+      "environments.destroy",
+      { environmentId: "worker-1" },
+      { service, reconcileActive },
+    );
+
+    expect(ok).toBe(true);
+    expect(payload).toMatchObject({ worker: { state: "destroyed" } });
+    expect(reconcileActive).toHaveBeenCalledExactlyOnceWith("worker-1");
+    expect(service.destroy).toHaveBeenCalledBefore(reconcileActive);
+  });
+
+  it("preserves destroyed worker success when placement reconciliation fails", async () => {
+    const service = workerService();
+    const reconcileActive = vi.fn(async () => {
+      throw new Error("temporary reconciliation failure");
+    });
+
+    const [ok, payload] = await callEnvironmentMethod(
+      "environments.destroy",
+      { environmentId: "worker-1" },
+      { service, reconcileActive },
+    );
+
+    expect(ok).toBe(true);
+    expect(payload).toMatchObject({ worker: { state: "destroyed" } });
+    expect(reconcileActive).toHaveBeenCalledExactlyOnceWith("worker-1");
   });
 
   it("rejects an unknown worker environment on destroy", async () => {

--- a/src/gateway/server-methods/environments.ts
+++ b/src/gateway/server-methods/environments.ts
@@ -14,6 +14,7 @@ import type { NodeListNode } from "../../shared/node-list-types.js";
 import { createKnownNodeCatalog, listKnownNodes } from "../node-catalog.js";
 import type { WorkerEnvironmentServiceRecord } from "../worker-environments/service-contract.js";
 import type { WorkerEnvironmentState } from "../worker-environments/state.js";
+import { formatForLog } from "../ws-log.js";
 import { respondInvalidParams, respondUnavailableOnThrow } from "./nodes.helpers.js";
 import type { GatewayRequestContext, GatewayRequestHandlers, RespondFn } from "./types.js";
 
@@ -206,7 +207,21 @@ export const environmentsHandlers: GatewayRequestHandlers = {
     }
     await respondWorkerMutation(
       respond,
-      () => service.destroy(params.environmentId),
+      async () => {
+        const destroyed = await service.destroy(params.environmentId);
+        // Destruction is authoritative. Project the dead worker into its owning
+        // placement before returning, or immediate session deletion stays fenced.
+        try {
+          await context.workerPlacementDispatchService?.reconcileActive?.(params.environmentId);
+        } catch (error) {
+          // The provider mutation has committed. Keep its success authoritative;
+          // the periodic recovery sweep will retry this projection.
+          context.logGateway.warn(
+            `worker placement reconciliation after destroy failed: ${formatForLog(error)}`,
+          );
+        }
+        return destroyed;
+      },
       ["environment_not_found", "invalid_state"],
       "worker environment destruction failed",
     );

--- a/src/gateway/worker-environments/placement-dispatch-recovery.ts
+++ b/src/gateway/worker-environments/placement-dispatch-recovery.ts
@@ -198,9 +198,12 @@ export function createPlacementRecoveryActions(deps: {
 
   // Runtime sweeps must not classify a live dispatch preparation as a crash. They only repair
   // durable active ownership and retry teardown already fenced by a previous failure.
-  const reconcileActive = async (): Promise<void> => {
+  const reconcileActive = async (environmentId?: string): Promise<void> => {
     await environments.reconcileOnce();
     for (const placement of placements.listForReconcile()) {
+      if (environmentId !== undefined && placement.environmentId !== environmentId) {
+        continue;
+      }
       if (isFailedPlacement(placement)) {
         await failure.retryFailedTeardown(placement);
         continue;

--- a/src/gateway/worker-environments/placement-dispatch.test.ts
+++ b/src/gateway/worker-environments/placement-dispatch.test.ts
@@ -653,6 +653,35 @@ describe("worker placement dispatch", () => {
     expect(harness.environments.destroy).not.toHaveBeenCalled();
   });
 
+  it("limits requested runtime reconciliation to one environment", async () => {
+    const harness = createHarness(placementStore);
+    harness.placements.seedActive(harness.attached.ownerEpoch);
+    harness.markEnvironmentDestroyed();
+    harness.log.length = 0;
+
+    await harness.service.reconcileActive("worker-other");
+
+    expect(harness.placements.current()).toMatchObject({ state: "active" });
+    expect(harness.log).toEqual(["environment:reconcile"]);
+
+    await harness.service.reconcileActive(harness.ready.environmentId);
+
+    expect(harness.placements.current()).toMatchObject({ state: "reclaimed" });
+  });
+
+  it("does not retry unrelated failed teardown during requested reconciliation", async () => {
+    const harness = createHarness(placementStore, { failAt: "sync", destroyFails: true });
+    await expect(harness.service.dispatch(REQUEST)).rejects.toThrow("sync failed");
+    harness.log.length = 0;
+    vi.mocked(harness.environments.destroy).mockClear();
+
+    await harness.service.reconcileActive("worker-other");
+
+    expect(harness.placements.current()).toMatchObject({ state: "failed" });
+    expect(harness.log).toEqual(["environment:reconcile"]);
+    expect(harness.environments.destroy).not.toHaveBeenCalled();
+  });
+
   it("fences a turn admitted immediately before runtime drain", async () => {
     const harness = createHarness(placementStore, { claimOnDrain: true });
     harness.placements.seedActive(harness.attached.ownerEpoch);

--- a/src/gateway/worker-environments/service-contract.ts
+++ b/src/gateway/worker-environments/service-contract.ts
@@ -42,4 +42,5 @@ export type WorkerPlacementDispatchContract = {
   dispatch(
     request: WorkerPlacementDispatchRequest,
   ): Promise<Extract<WorkerSessionPlacementRecord, { state: "active" }>>;
+  reconcileActive?(environmentId?: string): Promise<void>;
 };


### PR DESCRIPTION
Closes #107840

## What Problem This Solves

Fixes an issue where users tearing down a cloud worker could not immediately delete its session because the session remained fenced as actively placed until the next periodic recovery sweep.

## Why This Change Was Made

The destroy gateway method now projects the authoritative destroyed environment into only its owning placement before returning. Targeted reconciliation also avoids touching unrelated failed teardowns, and a transient projection failure cannot turn an already-committed provider destruction into a misleading API failure; the periodic sweep remains the retry owner.

## User Impact

After a cloud worker is destroyed, its session can be deleted immediately. Live, unresolved, and unrelated worker placements remain protected.

## Evidence

- `pnpm test src/gateway/server-methods/environments.test.ts src/gateway/worker-environments/placement-dispatch.test.ts` — 45/45 passed on Testbox `tbx_01kxhg6eb8068ksmgs20b3902b`
- `pnpm check:changed` — passed on the same Testbox
- Blacksmith proof: https://github.com/openclaw/openclaw/actions/runs/29376948467
- Fresh maintainer autoreview: no actionable findings
- Live trigger documented in #107840: provider destruction succeeded while immediate session deletion remained fenced until periodic reconciliation
