### PR TITLE
improve: speed provider auth parity preloads

### DIFF
--- a/test/plugins/bundled-provider-auth-literal-parity.test.ts
+++ b/test/plugins/bundled-provider-auth-literal-parity.test.ts
@@ -1,6 +1,6 @@
 // Keeps manifest providerAuthChoices literals aligned with registered provider.auth methods.
 import { mkdtempSync, rmSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { availableParallelism, tmpdir } from "node:os";
 import path from "node:path";
 import pLimit from "p-limit";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
@@ -158,7 +158,8 @@ const parityCases = listParityCases().toSorted((left, right) => {
 });
 
 const probeAgentDir = mkdtempSync(path.join(tmpdir(), "openclaw-auth-parity-"));
-const PLUGIN_LOAD_CONCURRENCY = 5;
+// Keep at least five imports in flight, but leave CPU headroom on larger CI runners.
+const PLUGIN_LOAD_CONCURRENCY = Math.max(5, Math.min(12, availableParallelism()));
 const parityPluginIds = [...new Set(parityCases.map((entry) => entry.pluginId))];
 const registerResultByPluginId = new Map<string, Promise<PromiseSettledResult<PluginRegister>>>();
 


### PR DESCRIPTION
## What Problem This Solves

The bundled provider auth parity suite loads many independent plugin module graphs, but caps preload concurrency at five even on larger CI runners. That leaves a 72-case tooling hotspot waiting on module transforms.

## Why This Change Was Made

Scale the existing preload limit with Node's reported CPU quota. The suite keeps at least the established five imports in flight, uses additional parallelism when available, and caps at twelve to leave runner headroom. Auth probes remain serial and all existing fail-closed parity checks stay unchanged.

## User Impact

No runtime behavior change. Maintainer and CI feedback for provider-auth parity coverage is faster.

## Evidence

- Dedicated fresh Testbox baseline: 72/72 passed, Vitest 33.31s: https://github.com/openclaw/openclaw/actions/runs/29376795115
- Dedicated fresh Testbox candidate: 72/72 passed, Vitest 25.04s (24.8% faster): https://github.com/openclaw/openclaw/actions/runs/29376924191
- Exact committed head on a fresh Testbox: 72/72 passed, Vitest 22.97s (31.0% faster than baseline), and `pnpm check:changed -- test/plugins/bundled-provider-auth-literal-parity.test.ts` passed: https://github.com/openclaw/openclaw/actions/runs/29377233518
- Warm same-box comparison also improved: 11.88s -> 10.67s (10.2%).
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`: clean, no accepted/actionable findings (0.96 confidence).
- Changelog omitted: test-only optimization.
