### PR TITLE
improve: speed Telegram archive guard test

### DIFF
--- a/test/scripts/release-telegram-candidate-archive.test.ts
+++ b/test/scripts/release-telegram-candidate-archive.test.ts
@@ -205,15 +205,16 @@ with tarfile.open(sys.argv[1], "w", format=tarfile.PAX_FORMAT) as archive:
     root.type = tarfile.DIRTYPE
     archive.addfile(root)
 
-    tail = ["d" for _ in range(254)]
-    for index in range(path_count):
-        parts = ["candidate", f"{index:04d}", *tail]
-        for component_count in range(2, len(parts)):
-            directory = tarfile.TarInfo("/".join(parts[:component_count]))
-            directory.type = tarfile.DIRTYPE
-            archive.addfile(directory)
+    # One shared prefix preserves the 256-component boundary and distinct leaves
+    # without rebuilding the same deep parent chain for every sibling.
+    parts = ["candidate", *["d" for _ in range(254)]]
+    for component_count in range(2, len(parts) + 1):
+        directory = tarfile.TarInfo("/".join(parts[:component_count]))
+        directory.type = tarfile.DIRTYPE
+        archive.addfile(directory)
 
-        member = tarfile.TarInfo("/".join(parts))
+    for index in range(path_count):
+        member = tarfile.TarInfo("/".join([*parts, f"{index:04d}"]))
         member.size = 1
         archive.addfile(member, io.BytesIO(b"x"))
 `;
@@ -928,7 +929,7 @@ with tarfile.open(sys.argv[1], "w", format=tarfile.USTAR_FORMAT) as archive:
       "--max-path-bytes",
       `${8 * 1024 * 1024}`,
     ]);
-    expect(JSON.parse(result.stdout)).toMatchObject({ members: 8_162 });
+    expect(JSON.parse(result.stdout)).toMatchObject({ members: 288 });
     expect(JSON.parse(result.stdout).maxCachedMembers).toBeLessThanOrEqual(1);
   });
 


### PR DESCRIPTION
## What Problem This Solves

The Telegram release archive guard suite spent most of its runtime extracting 32 separate 254-directory parent chains just to prove that distinct 256-component paths are accepted.

## Why This Change Was Made

The fixture now gives all 32 distinct leaf members one shared 255-component prefix. Every tested leaf still reaches the 256-component limit, sibling uniqueness is still exercised, the metadata budget assertion remains active, and the separate 100,000-member memory guard is unchanged.

## User Impact

No product behavior changes. The 37-test archive guard suite runs about 49% faster.

## Evidence

- Blacksmith Testbox `tbx_01kxhhjn627eb0c773cvk337kv`
- Focused archive guard: 37/37 passed
- Suite tests: 9.361s baseline to 4.771s candidate (49.0% faster)
- Max-depth case: 5.323s baseline to 0.330s candidate (93.8% faster)
- Path-scoped `check:changed`: passed
- Fresh autoreview: clean, patch correct (0.98)
