### PR TITLE
fix(ui): align new-session composer controls

### DIFF
--- a/ui/src/e2e/new-session-page.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.e2e.test.ts
@@ -426,9 +426,34 @@ describeControlUiE2e("Control UI new-session page mocked Gateway E2E", () => {
       await page.goto(`${server.baseUrl}new`);
       const modelSelect = page.locator('[data-chat-model-select="true"]');
       await modelSelect.waitFor();
+      expect(
+        await page.locator('.new-session-page__composer [data-chat-model-select="true"]').count(),
+      ).toBe(1);
+      expect(
+        await page.locator('.new-session-page__triggers [data-chat-model-select="true"]').count(),
+      ).toBe(0);
       await modelSelect.click();
+      const modelTriggerBox = await modelSelect.boundingBox();
+      const modelMenuBox = await page
+        .locator(".chat-controls__inline-select-menu--combined")
+        .boundingBox();
+      expect(modelTriggerBox).not.toBeNull();
+      expect(modelMenuBox).not.toBeNull();
+      expect(modelMenuBox?.x ?? 0).toBeLessThan(modelTriggerBox?.x ?? 0);
+      expect((modelMenuBox?.x ?? 0) + (modelMenuBox?.width ?? 0)).toBeCloseTo(
+        (modelTriggerBox?.x ?? 0) + (modelTriggerBox?.width ?? 0),
+        0,
+      );
       await page.locator('[data-chat-model-provider="anthropic"]').click();
       await page.locator('[data-chat-model-option="anthropic/claude-sonnet-4-6"]').click();
+      await modelSelect.click();
+      await expect
+        .poll(() =>
+          modelSelect.evaluate(
+            (element) => element.closest("details")?.hasAttribute("open") ?? false,
+          ),
+        )
+        .toBe(false);
       await page.locator(".new-session-page__message").fill("use this model");
       await page.getByRole("button", { name: "Start session" }).click();
 
@@ -513,15 +538,45 @@ describeControlUiE2e("Control UI new-session page mocked Gateway E2E", () => {
       const heroBox = await page.locator(".agent-chat__welcome h2").boundingBox();
       const triggersBox = await page.locator(".new-session-page__triggers").boundingBox();
       const composerBox = await page.locator(".new-session-page__composer").boundingBox();
+      const modelBox = await page.locator('[data-chat-model-select="true"]').boundingBox();
+      const modelWrapperBox = await page
+        .locator(".new-session-page__composer .chat-composer-model-control")
+        .boundingBox();
+      const footerBox = await page
+        .locator(".new-session-page__composer .agent-chat__composer-footer")
+        .boundingBox();
       expect(heroBox).not.toBeNull();
       expect(triggersBox).not.toBeNull();
       expect(composerBox).not.toBeNull();
+      expect(modelBox).not.toBeNull();
+      expect(modelWrapperBox).not.toBeNull();
+      expect(footerBox).not.toBeNull();
       expect((heroBox?.y ?? 0) + (heroBox?.height ?? 0)).toBeLessThanOrEqual(
         (triggersBox?.y ?? 0) + 1,
       );
       expect((triggersBox?.y ?? 0) + (triggersBox?.height ?? 0)).toBeLessThanOrEqual(
         (composerBox?.y ?? 0) + 1,
       );
+      expect(
+        await page.locator(".new-session-page__composer .agent-chat__composer-footer").count(),
+      ).toBe(1);
+      expect(
+        await page
+          .locator('[data-chat-model-select="true"]')
+          .evaluate((element) => element.closest(".agent-chat__composer-footer") != null),
+      ).toBe(true);
+      expect(modelWrapperBox?.x ?? 0).toBeGreaterThan(
+        (footerBox?.x ?? 0) + (footerBox?.width ?? 0) / 2,
+      );
+      expect(
+        (footerBox?.x ?? 0) +
+          (footerBox?.width ?? 0) -
+          ((modelWrapperBox?.x ?? 0) + (modelWrapperBox?.width ?? 0)),
+      ).toBeLessThanOrEqual(12);
+      expect(triggersBox?.x).toBeCloseTo(composerBox?.x ?? 0, 0);
+      expect(triggersBox?.width).toBeCloseTo(composerBox?.width ?? 0, 0);
+      expect(composerBox?.width).toBeCloseTo(48 * 16, 0);
+      expect(await page.locator(".new-session-page__message").getAttribute("rows")).toBe("1");
 
       // The folder trigger labels the workspace and opens the browser menu.
       const folderSelect = page.locator(".new-session-page__select--folder");
@@ -1492,6 +1547,7 @@ describeControlUiE2e("Control UI new-session page mocked Gateway E2E", () => {
       await expect.poll(() => runtime.textContent()).toContain("Claude Code");
       expect(await runtime.getAttribute("title")).toBe(model);
       expect(await page.locator('.new-session-page__trigger[title="Agent"]').count()).toBe(0);
+      expect(await page.locator('[data-chat-model-select="true"]').count()).toBe(0);
 
       await page.locator(".new-session-page__message").fill("use Claude Code");
       await page.getByRole("button", { name: "Start session" }).click();

--- a/ui/src/pages/new-session/composer.ts
+++ b/ui/src/pages/new-session/composer.ts
@@ -68,7 +68,7 @@ function renderNewSessionComposer(options: NewSessionComposerOptions) {
           <div class="agent-chat__composer-combobox">
             <textarea
               class="new-session-page__message"
-              rows="3"
+              rows="1"
               ?disabled=${options.submitting || options.messageLocked}
               placeholder=${t("newSession.messagePlaceholder")}
               .value=${options.message}
@@ -98,7 +98,9 @@ function renderNewSessionComposer(options: NewSessionComposerOptions) {
         </div>
         ${options.modelControl && options.modelControl !== nothing
           ? html`<div class="agent-chat__composer-footer">
-              <div class="agent-chat__composer-controls">${options.modelControl}</div>
+              <div class="agent-chat__composer-controls">
+                <div class="chat-composer-model-control">${options.modelControl}</div>
+              </div>
             </div>`
           : nothing}
         ${options.pendingAttachmentReads > 0

--- a/ui/src/styles/new-session.css
+++ b/ui/src/styles/new-session.css
@@ -36,7 +36,10 @@ openclaw-new-session-page {
    here; its margin: auto still centers whenever there is spare room. */
 .new-session-page .agent-chat__welcome {
   flex: 0 0 auto;
+  width: 100%;
+  max-width: none;
   min-height: auto;
+  box-sizing: border-box;
 }
 
 /* Draft block inside the centered welcome column; the welcome centers text,
@@ -50,20 +53,18 @@ openclaw-new-session-page {
   text-align: left;
 }
 
-/* The welcome column starts beside the sidebar. Open the shared model menu
-   into that column instead of letting its default right edge cover navigation. */
-.new-session-page__composer .chat-controls__inline-select-menu--combined {
-  right: auto;
-  left: 0;
-}
-
 /* Cursor-style quiet trigger row. Web Awesome owns popup/listbox behavior. */
 .new-session-page__triggers {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
+  justify-content: flex-start;
   gap: 4px 16px;
-  padding: 0 2px;
+  width: calc(100% - 36px);
+  max-width: 48rem;
+  margin: 0 auto;
+  padding: 0;
+  box-sizing: border-box;
 }
 
 .new-session-page__select {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users opening a new session saw a composer that differed from chat: the message field was taller, the model picker sat on the wrong side, its menu expanded in the wrong direction, and the options row did not align with the composer.

## Why This Change Was Made

The new-session composer now uses the same model-control wrapper and one-row input shape as chat. The page-specific layout aligns the existing target options to the shared 48rem composer width and removes the stale menu override so the picker inherits chat's right-edge anchoring.

## User Impact

New-session composition now matches chat: the model picker is in the bottom-right, its menu expands leftward, and the options above align with the composer box.

## Evidence

- Production Control UI build passed, including precompressed asset and performance checks.
- Focused mocked-Gateway browser tests cover model placement, right alignment, menu direction, option-row geometry, one-row input sizing, session creation, and catalog-target behavior.
- Autoreview reported no accepted or actionable findings.

Behavior addressed: New-session composer layout and model-picker parity with chat.

Real environment tested: macOS on Wilfred using installed Google Chrome against the mocked Control UI Gateway.

Exact steps or command run after this patch: `pnpm ui:build`; three isolated `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/new-session-page.e2e.test.ts -t '<focused test>'` runs for plain model selection, browsed-folder session creation, and catalog-target creation.

Evidence after fix: All three focused browser tests passed and the production build completed within Control UI performance limits.

Observed result after fix: The picker renders in the composer footer on the right, its menu's right edge stays attached to the trigger while expanding left, and the options row shares the composer's width and left edge.

What was not tested: The complete Control UI E2E shard and unrelated application surfaces.
