### PR TITLE
fix: startup recovers from stale npm plugin generations

### DIFF
--- a/src/plugins/plugin-registry-snapshot.test.ts
+++ b/src/plugins/plugin-registry-snapshot.test.ts
@@ -512,6 +512,76 @@ describe("loadPluginRegistrySnapshotWithMetadata", () => {
     expect(loadInstalledPluginIndexInstallRecordsSync({ env, stateDir }).codex).toBeDefined();
   });
 
+  it("derives from the recorded npm generation when persisted plugin metadata points at an older generation", () => {
+    const tempRoot = makeTempDir();
+    const stateDir = path.join(tempRoot, "state");
+    const env = {
+      ...createHermeticEnv(tempRoot),
+      OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+      OPENCLAW_STATE_DIR: stateDir,
+    };
+    const config = {};
+    const oldWhatsappDir = writeManagedNpmPlugin({
+      stateDir,
+      packageName: "@openclaw/whatsapp",
+      pluginId: "whatsapp",
+      version: "2026.6.11",
+      layout: "generation",
+      generationKey: "whatsapp-2026.6.11",
+    });
+    const currentWhatsappDir = writeManagedNpmPlugin({
+      stateDir,
+      packageName: "@openclaw/whatsapp",
+      pluginId: "whatsapp",
+      version: "2026.7.1",
+      layout: "generation",
+      generationKey: "whatsapp-2026.7.1",
+    });
+    const staleIndex = loadInstalledPluginIndex({
+      config,
+      env,
+      stateDir,
+      installRecords: {
+        whatsapp: {
+          source: "npm",
+          spec: "@openclaw/whatsapp@2026.6.11",
+          installPath: oldWhatsappDir,
+          version: "2026.6.11",
+          resolvedName: "@openclaw/whatsapp",
+          resolvedVersion: "2026.6.11",
+          resolvedSpec: "@openclaw/whatsapp@2026.6.11",
+        },
+      },
+    });
+    writePersistedInstalledPluginIndexSync(
+      {
+        ...staleIndex,
+        installRecords: {
+          whatsapp: {
+            source: "npm",
+            spec: "@openclaw/whatsapp@latest",
+            installPath: currentWhatsappDir,
+            version: "2026.7.1",
+            resolvedName: "@openclaw/whatsapp",
+            resolvedVersion: "2026.7.1",
+            resolvedSpec: "@openclaw/whatsapp@2026.7.1",
+          },
+        },
+      },
+      { stateDir },
+    );
+
+    const result = loadPluginRegistrySnapshotWithMetadata({ config, env, stateDir });
+
+    expect(result.source).toBe("derived");
+    expectDiagnosticsContainCode(result.diagnostics, "persisted-registry-stale-source");
+    const whatsapp = requirePluginRecord(result.snapshot.plugins, "whatsapp");
+    expect(whatsapp.rootDir).toBe(fs.realpathSync(currentWhatsappDir));
+    expect(whatsapp.packageVersion).toBe("2026.7.1");
+    expect(result.snapshot.installRecords.whatsapp?.installPath).toBe(currentWhatsappDir);
+    expect(fs.existsSync(oldWhatsappDir)).toBe(true);
+  });
+
   it("keeps vanished recovered install records on the persisted fast path", () => {
     const tempRoot = makeTempDir();
     const stateDir = path.join(tempRoot, "state");
@@ -688,8 +758,10 @@ describe("loadPluginRegistrySnapshotWithMetadata", () => {
     };
     writePackagePlugin(firstRoot, { pluginId: "duplicate" });
     writePackagePlugin(secondRoot, { pluginId: "duplicate" });
+    const firstRealRoot = fs.realpathSync(firstRoot);
+    const secondRealRoot = fs.realpathSync(secondRoot);
     const originalIndex = loadInstalledPluginIndex({ config: originalConfig, env });
-    expect(originalIndex.plugins.map((plugin) => plugin.rootDir)).toEqual([firstRoot]);
+    expect(originalIndex.plugins.map((plugin) => plugin.rootDir)).toEqual([firstRealRoot]);
     writePersistedInstalledPluginIndexSync(originalIndex, { stateDir });
 
     const unchanged = loadPluginRegistrySnapshotWithMetadata({
@@ -706,7 +778,7 @@ describe("loadPluginRegistrySnapshotWithMetadata", () => {
     });
     expect(reordered.source).toBe("derived");
     expectDiagnosticsContainCode(reordered.diagnostics, "persisted-registry-stale-source");
-    expect(reordered.snapshot.plugins.map((plugin) => plugin.rootDir)).toEqual([secondRoot]);
+    expect(reordered.snapshot.plugins.map((plugin) => plugin.rootDir)).toEqual([secondRealRoot]);
   });
 
   it("rebuilds legacy config-path persisted registries before startup scoping", () => {

--- a/src/plugins/plugin-registry-snapshot.ts
+++ b/src/plugins/plugin-registry-snapshot.ts
@@ -413,6 +413,30 @@ function isAllowedPersistedBundledPluginRoot(
   return !fs.existsSync(path.join(bundledPluginsDir, relativePluginRoot));
 }
 
+function hasMismatchedPersistedNpmInstallRoot(
+  index: InstalledPluginIndex,
+  env: NodeJS.ProcessEnv,
+): boolean {
+  const installRecords = extractPluginInstallRecordsFromInstalledPluginIndex(index);
+  return index.plugins.some((plugin) => {
+    if (plugin.origin !== "global") {
+      return false;
+    }
+    const installRecord = installRecords[plugin.pluginId];
+    if (installRecord?.source !== "npm" || !installRecord.installPath?.trim()) {
+      return false;
+    }
+    const installPath = resolveUserPath(installRecord.installPath, env);
+    if (!fs.existsSync(installPath)) {
+      return false;
+    }
+    return (
+      !isPathInsideOrEqual(plugin.rootDir, installPath) &&
+      !isPathInsideOrEqual(installPath, plugin.rootDir)
+    );
+  });
+}
+
 function sourcePluginOptsOutOfBundledDist(pluginRootDir: string): boolean {
   const packageJson = tryReadJsonSync<PackageManifest>(path.join(pluginRootDir, "package.json"));
   return getPackageManifestMetadata(packageJson ?? undefined)?.build?.bundledDist === false;
@@ -591,6 +615,13 @@ export function loadPluginRegistrySnapshotWithMetadata(
           code: "persisted-registry-stale-source",
           message:
             "Persisted plugin registry points at a different bundled plugin tree; using derived plugin index. Run `openclaw plugins registry --refresh` to update the persisted registry.",
+        });
+      } else if (hasMismatchedPersistedNpmInstallRoot(persistedIndex, env)) {
+        diagnostics.push({
+          level: "warn",
+          code: "persisted-registry-stale-source",
+          message:
+            "Persisted plugin registry points at an older npm plugin generation; using derived plugin index. Run `openclaw plugins registry --refresh` to update the persisted registry.",
         });
       } else if (hasMismatchedPersistedConfigPathPlugins(persistedIndex, params, env)) {
         diagnostics.push({

--- a/src/plugins/test-helpers/managed-npm-plugin.ts
+++ b/src/plugins/test-helpers/managed-npm-plugin.ts
@@ -1,7 +1,10 @@
 // Managed npm plugin test helpers create package fixtures for managed plugin tests.
 import fs from "node:fs";
 import path from "node:path";
-import { resolvePluginNpmProjectDir } from "../install-paths.js";
+import {
+  resolvePluginNpmGenerationProjectDir,
+  resolvePluginNpmProjectDir,
+} from "../install-paths.js";
 
 /** Writes a managed npm plugin fixture and returns its package directory. */
 export function writeManagedNpmPlugin(params: {
@@ -11,16 +14,23 @@ export function writeManagedNpmPlugin(params: {
   version: string;
   name?: string;
   dependencySpec?: string;
-  layout?: "project" | "legacy";
+  layout?: "project" | "legacy" | "generation";
+  generationKey?: string;
 }): string {
   const npmBaseDir = path.join(params.stateDir, "npm");
   const npmRoot =
     params.layout === "legacy"
       ? npmBaseDir
-      : resolvePluginNpmProjectDir({
-          npmDir: npmBaseDir,
-          packageName: params.packageName,
-        });
+      : params.layout === "generation"
+        ? resolvePluginNpmGenerationProjectDir({
+            npmDir: npmBaseDir,
+            packageName: params.packageName,
+            generationKey: params.generationKey ?? `${params.packageName}@${params.version}`,
+          })
+        : resolvePluginNpmProjectDir({
+            npmDir: npmBaseDir,
+            packageName: params.packageName,
+          });
   const rootManifestPath = path.join(npmRoot, "package.json");
   fs.mkdirSync(npmRoot, { recursive: true });
   const rootManifest = fs.existsSync(rootManifestPath)


### PR DESCRIPTION
Closes #107841

## What Problem This Solves

Fixes an issue where users with older managed npm plugin generation directories on disk could keep hitting startup "conflicting plugin install metadata" during upgrade or restart when persisted registry metadata pointed at an older plugin generation.

## Why This Change Was Made

OpenClaw now treats recorded npm install paths as the freshness boundary for global installed plugins. If the persisted registry points outside the recorded npm generation, startup rebuilds a derived registry from the current install record instead of reusing stale plugin metadata.

This does not delete old generation directories or change npm install cleanup behavior.

## User Impact

Users can restart after managed npm plugin upgrades without manually deleting stale `npm/projects/*__openclaw-generation__*` directories. Current install records remain authoritative, and old generations can remain on disk until normal cleanup handles them.

## Evidence

- Reproduced the stale persisted-registry case with a regression test that writes old and current `@openclaw/whatsapp` managed npm generations and persists metadata rooted at the old generation.
- Before the fix, the regression failed because the snapshot source stayed `persisted` instead of rebuilding as `derived`.
- `node scripts/run-vitest.mjs src/plugins/plugin-registry-snapshot.test.ts -t "derives from the recorded npm generation"`: 1 passed.
- `node scripts/run-vitest.mjs src/plugins/plugin-registry-snapshot.test.ts`: 25 passed.
- `node scripts/run-vitest.mjs src/plugins/installed-plugin-index-records.test.ts src/plugins/installed-plugin-index-store.test.ts`: 35 passed.
- `git diff --check`
- `./node_modules/.bin/oxlint --tsconfig config/tsconfig/oxlint.core.json src/plugins/plugin-registry-snapshot.ts src/plugins/plugin-registry-snapshot.test.ts src/plugins/test-helpers/managed-npm-plugin.ts`
- `node --max-old-space-size=8192 --import tsx scripts/generate-plugin-sdk-api-baseline.ts --check`
