### PR TITLE
fix(release): refresh LTS WhatsApp shrinkwrap

### DIFF
--- a/extensions/whatsapp/npm-shrinkwrap.json
+++ b/extensions/whatsapp/npm-shrinkwrap.json
@@ -339,6 +339,7 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/audio-decode/-/audio-decode-2.2.3.tgz",
       "integrity": "sha512-Z0lHvMayR/Pad9+O9ddzaBJE0DrhZkQlStrC1RwcAHF3AhQAsdwKHeLGK8fYKyp2DDU6xHxzGb4CLMui12yVrg==",
+      "deprecated": "Renamed to @audio/decode — same API; this name remains a thin alias. npm i @audio/decode",
       "license": "MIT",
       "dependencies": {
         "@wasm-audio-decoders/flac": "^0.2.4",


### PR DESCRIPTION
## What Problem This Solves

Exact-head LTS CI for `release/2026.6.11` fails `check-shrinkwrap` because npm now emits a deprecation metadata field for the already locked `audio-decode@2.2.3` package in the WhatsApp package shrinkwrap.

Failure: https://github.com/openclaw/openclaw/actions/runs/29377906154/job/87235132926

## Why This Change Was Made

Regenerate only `extensions/whatsapp/npm-shrinkwrap.json` with the release branch's canonical generator. The resolved tarball, integrity, version, and dependency graph remain unchanged; only registry deprecation metadata is recorded.

## User Impact

No runtime behavior change. Restores deterministic LTS shrinkwrap validation.

## Evidence

- Testbox generation: https://github.com/openclaw/openclaw/actions/runs/29379470110
- Exact focused Testbox check: `tbx_01kxhkajn170ntwgcrazjy52ec`, https://github.com/openclaw/openclaw/actions/runs/29379555390
- `git diff --check`: green
- Fresh autoreview: clean, correctness 0.99, no accepted/actionable findings
