### PR TITLE
ci(perf): pin calibrated Kova revision

### DIFF
--- a/.github/workflows/openclaw-performance.yml
+++ b/.github/workflows/openclaw-performance.yml
@@ -50,7 +50,7 @@ on:
       kova_ref:
         description: openclaw/Kova Git ref to install
         required: false
-        default: 8fc3ad27ae684f52eae758a913a0009f0d6dca22
+        default: f3d037b5b8aacd6adf8ef1dd2ea4c1d778ec7c6c
         type: string
       dispatch_id:
         description: Optional parent workflow dispatch identifier
@@ -153,7 +153,7 @@ jobs:
             include_filters: "scenario:agent-cold-warm-message"
             expected_release_entries: "agent-cold-warm-message:mock-openai-provider"
     env:
-      KOVA_REF: ${{ inputs.kova_ref || '8fc3ad27ae684f52eae758a913a0009f0d6dca22' }}
+      KOVA_REF: ${{ inputs.kova_ref || 'f3d037b5b8aacd6adf8ef1dd2ea4c1d778ec7c6c' }}
       KOVA_HOME: ${{ github.workspace }}/.artifacts/kova/home/${{ matrix.lane }}
       PERFORMANCE_HELPER_DIR: ${{ github.workspace }}/.artifacts/performance-workflow
       REPORT_DIR: ${{ github.workspace }}/.artifacts/kova/reports/${{ matrix.lane }}

--- a/test/scripts/openclaw-performance-workflow.test.ts
+++ b/test/scripts/openclaw-performance-workflow.test.ts
@@ -83,7 +83,7 @@ describe("OpenClaw performance workflow", () => {
 
   it("pins the Kova evaluator with release validation contracts", () => {
     const workflow = readFileSync(WORKFLOW, "utf8");
-    const kovaRef = "8fc3ad27ae684f52eae758a913a0009f0d6dca22";
+    const kovaRef = "f3d037b5b8aacd6adf8ef1dd2ea4c1d778ec7c6c";
     const install = findStep("Install OCM and Kova");
     const installRun = install.run ?? "";
 


### PR DESCRIPTION
## What Problem This Solves

Full release validation still installed Kova at `8fc3ad27ae684f52eae758a913a0009f0d6dca22`, so it did not consume the calibrated fresh-install status RSS ceiling landed in openclaw/Kova#75. That left the release lane exposed to a known single-sample 852.5 MB false regression against the old 850 MB ceiling.

## Why This Change Was Made

Pin both the workflow input default and its expression fallback to the exact landed Kova commit `f3d037b5b8aacd6adf8ef1dd2ea4c1d778ec7c6c`. Update the workflow contract test to require the same immutable revision.

## User Impact

No product behavior change. Release performance validation keeps its existing scenarios and regression policy while using the calibrated 900 MB status CLI ceiling already reviewed and landed upstream.

## Evidence

- Focused workflow contract: 29/29 passing in Blacksmith Testbox `tbx_01kxhkms9cceqz7qap6077wfc4`
- Testbox run: https://github.com/openclaw/openclaw/actions/runs/29379804884
- Kova calibration PR: https://github.com/openclaw/Kova/pull/75
- Kova exact-head CI: https://github.com/openclaw/Kova/actions/runs/29379412368
- Fresh autoreview: clean, 0.99
- `git diff --check`

No changelog entry: CI-only evaluator pin.
