### PR TITLE
fix(mcp): retry OAuth MCP connect at session bind instead of retiring the server on a refresh-in-flight

### DIFF
--- a/src/agents/agent-bundle-mcp-runtime.test.ts
+++ b/src/agents/agent-bundle-mcp-runtime.test.ts
@@ -4697,4 +4697,71 @@ process.on("SIGINT", shutdown);`,
     },
   );
 });
+
+describe("MCP connect retry at session bind", () => {
+  type FakeClient = Parameters<typeof testing.connectWithRetry>[0];
+  type FakeTransport = Parameters<typeof testing.connectWithRetry>[1];
+  const fakeTransport = {} as FakeTransport;
+
+  function makeClient(connect: () => Promise<void>): { client: FakeClient; calls: () => number } {
+    let calls = 0;
+    const client = {
+      connect: () => {
+        calls += 1;
+        return connect();
+      },
+    } as unknown as FakeClient;
+    return { client, calls: () => calls };
+  }
+
+  it("retries a transient connect failure and succeeds without retiring the server", async () => {
+    // Mirrors an OAuth transport losing a race against an in-flight token
+    // refresh at bind: the first attempt throws, the retry succeeds.
+    const { client, calls } = makeClient(() => {
+      if (calls() === 1) {
+        return Promise.reject(new Error("fetch failed: token refresh in flight"));
+      }
+      return Promise.resolve();
+    });
+
+    await expect(testing.connectWithRetry(client, fakeTransport, 1_000)).resolves.toBeUndefined();
+    expect(calls()).toBe(2);
+  });
+
+  it("gives up after exhausting the bounded retries", async () => {
+    const { client, calls } = makeClient(() => Promise.reject(new Error("connect refused")));
+
+    await expect(testing.connectWithRetry(client, fakeTransport, 1_000)).rejects.toThrow(
+      "connect refused",
+    );
+    expect(calls()).toBe(3);
+  });
+
+  it("does not retry a clearly-permanent auth error", async () => {
+    const { client, calls } = makeClient(() =>
+      Promise.reject(
+        new Error(
+          'MCP server "linear" requires OAuth authorization. Run openclaw mcp login linear.',
+        ),
+      ),
+    );
+
+    await expect(testing.connectWithRetry(client, fakeTransport, 1_000)).rejects.toThrow(
+      "Run openclaw mcp login",
+    );
+    expect(calls()).toBe(1);
+  });
+
+  it("classifies permanent vs transient connect errors", () => {
+    expect(testing.isPermanentMcpConnectError(new Error("Run openclaw mcp login linear"))).toBe(
+      true,
+    );
+    expect(testing.isPermanentMcpConnectError(new Error("HTTP 401 Unauthorized"))).toBe(true);
+    expect(testing.isPermanentMcpConnectError(new Error("invalid_grant"))).toBe(true);
+    expect(testing.isPermanentMcpConnectError(new Error("fetch failed"))).toBe(false);
+    expect(
+      testing.isPermanentMcpConnectError(new Error("MCP server connection timed out after 1000ms")),
+    ).toBe(false);
+  });
+});
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/agents/agent-bundle-mcp-runtime.ts
+++ b/src/agents/agent-bundle-mcp-runtime.ts
@@ -15,6 +15,7 @@ import { toErrorObject } from "../infra/errors.js";
 import { logWarn } from "../logger.js";
 import type { PluginManifestRegistry } from "../plugins/manifest-registry.js";
 import { runTasksWithConcurrency } from "../utils/run-with-concurrency.js";
+import { sleep } from "../utils/sleep.js";
 import { mergeMcpToolCatalogs } from "./agent-bundle-mcp-combined.js";
 import { matchesMcpToolFilterPattern } from "./agent-bundle-mcp-filter.js";
 import {
@@ -83,6 +84,12 @@ const BUNDLE_MCP_FAILURE_COOLDOWN_MS = 60_000;
 const BUNDLE_MCP_CATALOG_LIST_TIMEOUT_MS = 1_500;
 const BUNDLE_MCP_DISPOSE_TIMEOUT_MS = 5_000;
 const BUNDLE_MCP_CATALOG_CONNECT_CONCURRENCY = 6;
+// A transport bind can lose a race against an in-flight OAuth token refresh and
+// fail transiently even though the stored credentials are healthy. Retry the
+// connect a few times with short backoff before letting the server retire, so a
+// refresh-in-flight does not drop the server for the whole session.
+const BUNDLE_MCP_CONNECT_MAX_ATTEMPTS = 3;
+const BUNDLE_MCP_CONNECT_RETRY_BACKOFF_MS = [300, 600] as const;
 let bundleMcpCatalogListTimeoutMs: number | undefined;
 const BUNDLE_MCP_TEST_STATE_KEY = Symbol.for("openclaw.bundleMcpTestState");
 type BundleMcpTestState = { disposeTimeoutMs?: number };
@@ -135,6 +142,45 @@ function connectWithTimeout(
 
 function redactErrorUrls(error: unknown): string {
   return redactSensitiveUrlLikeString(String(error));
+}
+
+// A permanent connect failure means the stored credentials are unusable and no
+// amount of retrying at bind will help: the user must re-authorize. These are
+// the actionable OAuth errors surfaced by mcp-oauth.ts plus the standard OAuth
+// protocol / HTTP auth signals. Everything else (network blips, transports
+// racing an in-flight token refresh) is treated as transient and retried.
+function isPermanentMcpConnectError(error: unknown): boolean {
+  const message = String(error);
+  return (
+    /openclaw mcp login/i.test(message) ||
+    /\binvalid_grant\b/i.test(message) ||
+    /\binvalid_client\b/i.test(message) ||
+    /\b(401|403)\b/.test(message) ||
+    /\b(unauthorized|forbidden)\b/i.test(message)
+  );
+}
+
+// Bind can transiently fail when it loses a race against an in-flight OAuth
+// token refresh even though the credentials are healthy. Retry a bounded number
+// of times with short backoff instead of retiring the server for the session;
+// give up immediately on a clearly-permanent auth error, or once attempts are
+// exhausted.
+async function connectWithRetry(
+  client: Client,
+  transport: Transport,
+  timeoutMs: number,
+): Promise<void> {
+  for (let attempt = 1; ; attempt += 1) {
+    try {
+      await connectWithTimeout(client, transport, timeoutMs);
+      return;
+    } catch (error) {
+      if (attempt >= BUNDLE_MCP_CONNECT_MAX_ATTEMPTS || isPermanentMcpConnectError(error)) {
+        throw error;
+      }
+      await sleep(BUNDLE_MCP_CONNECT_RETRY_BACKOFF_MS[attempt - 1] ?? 0);
+    }
+  }
 }
 
 async function listAllTools(client: Client, timeoutMs: number) {
@@ -455,7 +501,7 @@ export function createSessionMcpRuntime(params: {
     if (session.connected) {
       return;
     }
-    session.connectPromise ??= connectWithTimeout(
+    session.connectPromise ??= connectWithRetry(
       session.client,
       session.transport,
       connectionTimeoutMs,
@@ -967,6 +1013,8 @@ export { mergeMcpToolCatalogs };
 
 export const testing = {
   buildMcpClientCapabilities,
+  connectWithRetry,
+  isPermanentMcpConnectError,
   createSessionMcpRuntimeManager,
   async resetSessionMcpRuntimeManager() {
     await disposeAllSessionMcpRuntimes();


### PR DESCRIPTION
When a session-scoped MCP server binds its transport while its OAuth token is mid-refresh, `connect()` can fail **transiently** even though the stored credentials are healthy. `ensureSessionConnected` (in `src/agents/agent-bundle-mcp-runtime.ts`) caught that failure and retired the server for the **entire session** with no retry — so an OAuth-authenticated server (e.g. Linear) intermittently drops *all* of its tools for a whole session. Which server loses the race is stochastic per session.

### Fix
Wrap the bind `connect` in a small bounded retry (`connectWithRetry`): 3 attempts with 300/600ms backoff.
- Transient failures (network blips, a transport racing an in-flight token refresh) are re-attempted, so healthy credentials recover instead of dropping the server.
- Clearly-permanent auth failures are **not** retried — `isPermanentMcpConnectError` short-circuits on needs-re-login / `invalid_grant` / `invalid_client` / `401` / `403` so a genuinely unauthorized server still fails fast.
- Existing `connectPromise` dedup semantics and the timeout behavior are unchanged; the retry simply wraps `connectWithTimeout`.

### Tests
Added unit tests in `agent-bundle-mcp-runtime.test.ts`: a transient failure retries and succeeds without retiring the server, retries are exhausted after the bound, a permanent auth error is not retried, and the permanent/transient classifier.

### Scope
Small and isolated — one helper + one call-site swap in `ensureSessionConnected`, plus tests. No behavior change for servers that connect cleanly on the first attempt.

Note: I did not run the full monorepo build locally; CI will validate typecheck + tests.