### PR TITLE
fix(gateway): reload edited hook transforms

### DIFF
--- a/src/gateway/hooks-mapping.test.ts
+++ b/src/gateway/hooks-mapping.test.ts
@@ -3,6 +3,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
 import { afterAll, describe, expect, it } from "vitest";
 import { cleanupTempDirs, makeTempDir } from "../../test/helpers/temp-dir.js";
 
@@ -11,7 +12,11 @@ const hooksTempDirs: string[] = [];
 afterAll(() => {
   cleanupTempDirs(hooksTempDirs);
 });
-import { applyHookMappings, resolveHookMappings } from "./hooks-mapping.js";
+import {
+  applyHookMappings,
+  commitHookTransformMappingReload,
+  resolveHookMappings,
+} from "./hooks-mapping.js";
 
 const baseUrl = new URL("http://127.0.0.1:18789/hooks/gmail");
 
@@ -50,6 +55,11 @@ describe("hooks mapping", () => {
       url: baseUrl,
       path: "gmail",
     });
+  }
+
+  function acceptHookMappings(mappings: ReturnType<typeof resolveHookMappings>) {
+    commitHookTransformMappingReload();
+    return mappings;
   }
 
   function expectAgentMessage(
@@ -117,6 +127,16 @@ describe("hooks mapping", () => {
       url: new URL("http://127.0.0.1:18789/hooks/skip"),
       path: "skip",
     });
+  }
+
+  async function waitForFile(filePath: string) {
+    const deadline = Date.now() + 5_000;
+    while (!fs.existsSync(filePath)) {
+      if (Date.now() > deadline) {
+        throw new Error(`timed out waiting for ${filePath}`);
+      }
+      await delay(10);
+    }
   }
 
   async function applyGmailTransformSessionKey(params: {
@@ -634,6 +654,241 @@ describe("hooks mapping", () => {
     expect(resultB?.ok).toBe(true);
     if (resultB?.ok && resultB.action?.kind === "wake") {
       expect(resultB.action.text).toBe("from-B");
+    }
+  });
+
+  it("uses one transform module instance per mapping reload", async () => {
+    const configDir = makeTempDir(hooksTempDirs, "openclaw-hooks-generation-");
+    const transformsRoot = path.join(configDir, "hooks", "transforms");
+    fs.mkdirSync(transformsRoot, { recursive: true });
+    const modPath = path.join(transformsRoot, "same-generation.mjs");
+    fs.writeFileSync(
+      modPath,
+      [
+        "globalThis.__openclawHookTransformInstance = (globalThis.__openclawHookTransformInstance ?? 0) + 1;",
+        "const instance = globalThis.__openclawHookTransformInstance;",
+        'export function transformA() { return { kind: "wake", text: `A-${instance}` }; }',
+        'export function transformB() { return { kind: "wake", text: `B-${instance}` }; }',
+      ].join("\n"),
+    );
+
+    const mappings = resolveHookMappings(
+      {
+        mappings: [
+          {
+            match: { path: "testA" },
+            action: "agent",
+            messageTemplate: "unused",
+            transform: { module: "same-generation.mjs", export: "transformA" },
+          },
+          {
+            match: { path: "testB" },
+            action: "agent",
+            messageTemplate: "unused",
+            transform: { module: "same-generation.mjs", export: "transformB" },
+          },
+        ],
+      },
+      { configDir },
+    );
+
+    const resultA = await applyHookMappings(mappings, {
+      payload: {},
+      headers: {},
+      url: new URL("http://127.0.0.1:18789/hooks/testA"),
+      path: "testA",
+    });
+    const resultB = await applyHookMappings(mappings, {
+      payload: {},
+      headers: {},
+      url: new URL("http://127.0.0.1:18789/hooks/testB"),
+      path: "testB",
+    });
+
+    expect(resultA?.ok).toBe(true);
+    expect(resultB?.ok).toBe(true);
+    let instanceA: string | undefined;
+    let instanceB: string | undefined;
+    if (resultA?.ok && resultA.action?.kind === "wake") {
+      instanceA = resultA.action.text.match(/^A-(.+)$/)?.[1];
+    }
+    if (resultB?.ok && resultB.action?.kind === "wake") {
+      instanceB = resultB.action.text.match(/^B-(.+)$/)?.[1];
+    }
+    expect(instanceA).toBeDefined();
+    expect(instanceB).toBe(instanceA);
+  });
+
+  it("reloads a transform when the module file changes", async () => {
+    const configDir = makeTempDir(hooksTempDirs, "openclaw-hooks-reload-");
+    const transformsRoot = path.join(configDir, "hooks", "transforms");
+    fs.mkdirSync(transformsRoot, { recursive: true });
+    const modPath = path.join(transformsRoot, "reloadable.mjs");
+    fs.writeFileSync(modPath, 'export default () => ({ kind: "wake", text: "before" });');
+
+    const resolveMappings = () =>
+      resolveHookMappings(
+        {
+          mappings: [
+            {
+              match: { path: "reloadable" },
+              action: "agent",
+              messageTemplate: "unused",
+              transform: { module: "reloadable.mjs" },
+            },
+          ],
+        },
+        { configDir },
+      );
+    const applyMappings = (mappings: ReturnType<typeof resolveHookMappings>) =>
+      applyHookMappings(mappings, {
+        payload: {},
+        headers: {},
+        url: new URL("http://127.0.0.1:18789/hooks/reloadable"),
+        path: "reloadable",
+      });
+
+    let acceptedMappings = acceptHookMappings(resolveMappings());
+    const first = await applyMappings(acceptedMappings);
+    expect(first?.ok).toBe(true);
+    if (first?.ok && first.action?.kind === "wake") {
+      expect(first.action.text).toBe("before");
+    }
+
+    fs.writeFileSync(modPath, 'export default () => ({ kind: "wake", text: "after" });');
+    const nextTime = new Date(Date.now() + 5_000);
+    fs.utimesSync(modPath, nextTime, nextTime);
+
+    acceptedMappings = acceptHookMappings(resolveMappings());
+    const second = await applyMappings(acceptedMappings);
+    expect(second?.ok).toBe(true);
+    if (second?.ok && second.action?.kind === "wake") {
+      expect(second.action.text).toBe("after");
+    }
+  });
+
+  it("does not invalidate the active transform cache while resolving a rejected reload", async () => {
+    const configDir = makeTempDir(hooksTempDirs, "openclaw-hooks-rejected-reload-");
+    const transformsRoot = path.join(configDir, "hooks", "transforms");
+    fs.mkdirSync(transformsRoot, { recursive: true });
+    const modPath = path.join(transformsRoot, "reloadable.mjs");
+    fs.writeFileSync(modPath, 'export default () => ({ kind: "wake", text: "accepted" });');
+
+    const resolveMappings = () =>
+      resolveHookMappings(
+        {
+          mappings: [
+            {
+              match: { path: "reloadable" },
+              action: "agent",
+              messageTemplate: "unused",
+              transform: { module: "reloadable.mjs" },
+            },
+          ],
+        },
+        { configDir },
+      );
+    const applyMappings = (mappings: ReturnType<typeof resolveHookMappings>) =>
+      applyHookMappings(mappings, {
+        payload: {},
+        headers: {},
+        url: new URL("http://127.0.0.1:18789/hooks/reloadable"),
+        path: "reloadable",
+      });
+
+    const acceptedMappings = acceptHookMappings(resolveMappings());
+    const accepted = await applyMappings(acceptedMappings);
+    expect(accepted?.ok).toBe(true);
+    if (accepted?.ok && accepted.action?.kind === "wake") {
+      expect(accepted.action.text).toBe("accepted");
+    }
+
+    fs.writeFileSync(modPath, 'export default () => ({ kind: "wake", text: "candidate" });');
+    const nextTime = new Date(Date.now() + 5_000);
+    fs.utimesSync(modPath, nextTime, nextTime);
+
+    const rejectedCandidateMappings = resolveMappings();
+    expect(rejectedCandidateMappings).toHaveLength(1);
+
+    const stillAccepted = await applyMappings(acceptedMappings);
+    expect(stillAccepted?.ok).toBe(true);
+    if (stillAccepted?.ok && stillAccepted.action?.kind === "wake") {
+      expect(stillAccepted.action.text).toBe("accepted");
+    }
+
+    const newlyAccepted = await applyMappings(acceptHookMappings(rejectedCandidateMappings));
+    expect(newlyAccepted?.ok).toBe(true);
+    if (newlyAccepted?.ok && newlyAccepted.action?.kind === "wake") {
+      expect(newlyAccepted.action.text).toBe("candidate");
+    }
+  });
+
+  it("does not let an older in-flight transform import repopulate the reload cache", async () => {
+    const configDir = makeTempDir(hooksTempDirs, "openclaw-hooks-overlap-");
+    const transformsRoot = path.join(configDir, "hooks", "transforms");
+    fs.mkdirSync(transformsRoot, { recursive: true });
+    const modPath = path.join(transformsRoot, "reloadable.mjs");
+    const oldStartedPath = path.join(configDir, "old-started");
+    const releaseOldPath = path.join(configDir, "release-old");
+    fs.writeFileSync(
+      modPath,
+      [
+        'import fs from "node:fs";',
+        'import { setTimeout as delay } from "node:timers/promises";',
+        `fs.writeFileSync(${JSON.stringify(oldStartedPath)}, "started");`,
+        `while (!fs.existsSync(${JSON.stringify(releaseOldPath)})) { await delay(10); }`,
+        'export default () => ({ kind: "wake", text: "old" });',
+      ].join("\n"),
+    );
+
+    const resolveMappings = () =>
+      resolveHookMappings(
+        {
+          mappings: [
+            {
+              match: { path: "reloadable" },
+              action: "agent",
+              messageTemplate: "unused",
+              transform: { module: "reloadable.mjs" },
+            },
+          ],
+        },
+        { configDir },
+      );
+    const applyMappings = (mappings: ReturnType<typeof resolveHookMappings>) =>
+      applyHookMappings(mappings, {
+        payload: {},
+        headers: {},
+        url: new URL("http://127.0.0.1:18789/hooks/reloadable"),
+        path: "reloadable",
+      });
+
+    let acceptedMappings = acceptHookMappings(resolveMappings());
+    const oldImport = applyMappings(acceptedMappings);
+    await waitForFile(oldStartedPath);
+
+    fs.writeFileSync(modPath, 'export default () => ({ kind: "wake", text: "new" });');
+    const nextTime = new Date(Date.now() + 5_000);
+    fs.utimesSync(modPath, nextTime, nextTime);
+
+    acceptedMappings = acceptHookMappings(resolveMappings());
+    const afterReload = await applyMappings(acceptedMappings);
+    expect(afterReload?.ok).toBe(true);
+    if (afterReload?.ok && afterReload.action?.kind === "wake") {
+      expect(afterReload.action.text).toBe("new");
+    }
+
+    fs.writeFileSync(releaseOldPath, "go");
+    const olderResult = await oldImport;
+    expect(olderResult?.ok).toBe(true);
+    if (olderResult?.ok && olderResult.action?.kind === "wake") {
+      expect(olderResult.action.text).toBe("old");
+    }
+
+    const final = await applyMappings(acceptedMappings);
+    expect(final?.ok).toBe(true);
+    if (final?.ok && final.action?.kind === "wake") {
+      expect(final.action.text).toBe("new");
     }
   });
 

--- a/src/gateway/hooks-mapping.test.ts
+++ b/src/gateway/hooks-mapping.test.ts
@@ -4,10 +4,12 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
-import { afterAll, describe, expect, it } from "vitest";
+import { afterAll, afterEach, describe, expect, it } from "vitest";
 import { cleanupTempDirs, makeTempDir } from "../../test/helpers/temp-dir.js";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 
 const hooksTempDirs: string[] = [];
+const autoCleanupTempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 afterAll(() => {
   cleanupTempDirs(hooksTempDirs);
@@ -658,7 +660,7 @@ describe("hooks mapping", () => {
   });
 
   it("uses one transform module instance per mapping reload", async () => {
-    const configDir = makeTempDir(hooksTempDirs, "openclaw-hooks-generation-");
+    const configDir = autoCleanupTempDirs.make("openclaw-hooks-generation-");
     const transformsRoot = path.join(configDir, "hooks", "transforms");
     fs.mkdirSync(transformsRoot, { recursive: true });
     const modPath = path.join(transformsRoot, "same-generation.mjs");
@@ -720,7 +722,7 @@ describe("hooks mapping", () => {
   });
 
   it("reloads a transform when the module file changes", async () => {
-    const configDir = makeTempDir(hooksTempDirs, "openclaw-hooks-reload-");
+    const configDir = autoCleanupTempDirs.make("openclaw-hooks-reload-");
     const transformsRoot = path.join(configDir, "hooks", "transforms");
     fs.mkdirSync(transformsRoot, { recursive: true });
     const modPath = path.join(transformsRoot, "reloadable.mjs");
@@ -768,7 +770,7 @@ describe("hooks mapping", () => {
   });
 
   it("does not invalidate the active transform cache while resolving a rejected reload", async () => {
-    const configDir = makeTempDir(hooksTempDirs, "openclaw-hooks-rejected-reload-");
+    const configDir = autoCleanupTempDirs.make("openclaw-hooks-rejected-reload-");
     const transformsRoot = path.join(configDir, "hooks", "transforms");
     fs.mkdirSync(transformsRoot, { recursive: true });
     const modPath = path.join(transformsRoot, "reloadable.mjs");
@@ -824,7 +826,7 @@ describe("hooks mapping", () => {
   });
 
   it("does not let an older in-flight transform import repopulate the reload cache", async () => {
-    const configDir = makeTempDir(hooksTempDirs, "openclaw-hooks-overlap-");
+    const configDir = autoCleanupTempDirs.make("openclaw-hooks-overlap-");
     const transformsRoot = path.join(configDir, "hooks", "transforms");
     fs.mkdirSync(transformsRoot, { recursive: true });
     const modPath = path.join(transformsRoot, "reloadable.mjs");

--- a/src/gateway/hooks-mapping.ts
+++ b/src/gateway/hooks-mapping.ts
@@ -90,6 +90,12 @@ const hookPresetMappings: Record<string, HookMappingConfig[]> = {
 };
 
 const transformCache = new Map<string, HookTransformFn>();
+let transformCacheBustVersion = 0;
+
+export function commitHookTransformMappingReload(): void {
+  transformCache.clear();
+  transformCacheBustVersion += 1;
+}
 
 type HookTransformResult = Partial<{
   kind: HookAction["kind"];
@@ -375,9 +381,16 @@ async function loadTransform(transform: HookMappingTransformResolved): Promise<H
   if (cached) {
     return cached;
   }
-  const mod = await importFileModule({ modulePath: transform.modulePath });
+  const generation = transformCacheBustVersion;
+  const mod = await importFileModule({
+    modulePath: transform.modulePath,
+    cacheBust: true,
+    nowMs: generation,
+  });
   const fn = resolveTransformFn(mod, transform.exportName);
-  transformCache.set(cacheKey, fn);
+  if (generation === transformCacheBustVersion) {
+    transformCache.set(cacheKey, fn);
+  }
   return fn;
 }
 

--- a/src/gateway/hooks.ts
+++ b/src/gateway/hooks.ts
@@ -13,6 +13,7 @@ import { normalizeAgentId, parseAgentSessionKey } from "../routing/session-key.j
 import type { HookExternalContentSource } from "../security/external-content.js";
 import { normalizeMessageChannel } from "../utils/message-channel-core.js";
 import {
+  commitHookTransformMappingReload,
   hasHookTemplateExpressions,
   type HookMappingResolved,
   resolveHookMappings,
@@ -108,6 +109,10 @@ export function resolveHooksConfig(cfg: OpenClawConfig): HooksConfigResolved | n
       allowedSessionKeyPrefixes,
     },
   };
+}
+
+export function commitHooksConfigReload(): void {
+  commitHookTransformMappingReload();
 }
 
 function resolveKnownAgentIds(cfg: OpenClawConfig, defaultAgentId: string): Set<string> {

--- a/src/gateway/server-reload-handlers.test.ts
+++ b/src/gateway/server-reload-handlers.test.ts
@@ -2,9 +2,9 @@
  * Gateway config reload handler tests.
  */
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { getRuntimeAuthProfileStoreCredentialsRevision } from "../agents/auth-profiles/runtime-snapshots.js";
 import { addSession, markBackgrounded, markExited } from "../agents/bash-process-registry.js";
 import { createProcessSessionFixture } from "../agents/bash-process-registry.test-helpers.js";
@@ -91,6 +91,7 @@ function waitForFast<T>(
 }
 
 const tempDirs: string[] = [];
+const autoCleanupTempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 const restartTesting = {
   resetSigusr1State() {
@@ -1755,8 +1756,7 @@ describe("gateway hot reload commit policy", () => {
   });
 
   it("preserves the active hook transform cache when hook preparation rejects the config", async () => {
-    const configDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-rejected-hook-reload-"));
-    tempDirs.push(configDir);
+    const configDir = autoCleanupTempDirs.make("openclaw-rejected-hook-reload-");
     const transformsRoot = path.join(configDir, "hooks", "transforms");
     fs.mkdirSync(transformsRoot, { recursive: true });
     const transformPath = path.join(transformsRoot, "reloadable.mjs");

--- a/src/gateway/server-reload-handlers.test.ts
+++ b/src/gateway/server-reload-handlers.test.ts
@@ -1,6 +1,9 @@
 /**
  * Gateway config reload handler tests.
  */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { getRuntimeAuthProfileStoreCredentialsRevision } from "../agents/auth-profiles/runtime-snapshots.js";
 import { addSession, markBackgrounded, markExited } from "../agents/bash-process-registry.js";
@@ -59,6 +62,8 @@ import {
   type ChannelKind,
   type GatewayReloadPlan,
 } from "./config-reload-plan.js";
+import { applyHookMappings } from "./hooks-mapping.js";
+import { commitHooksConfigReload } from "./hooks.js";
 import type { GatewayPluginReloadResult } from "./server-reload-handlers.js";
 import {
   abortPendingChannelReloads,
@@ -84,6 +89,8 @@ function waitForFast<T>(
 ) {
   return vi.waitFor(callback, { interval: 1, ...options });
 }
+
+const tempDirs: string[] = [];
 
 const restartTesting = {
   resetSigusr1State() {
@@ -849,6 +856,9 @@ afterEach(() => {
   hoisted.buildGatewayCronService.mockClear();
   clearSecretsRuntimeSnapshot();
   clearRuntimeConfigSnapshot();
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
 });
 
 async function runManagedOwnershipScenario(params: {
@@ -1742,6 +1752,71 @@ describe("gateway hot reload commit policy", () => {
     ).rejects.toThrow("hooks.enabled requires hooks.token");
 
     expect(isGatewaySigusr1RestartExternallyAllowed()).toBe(false);
+  });
+
+  it("preserves the active hook transform cache when hook preparation rejects the config", async () => {
+    const configDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-rejected-hook-reload-"));
+    tempDirs.push(configDir);
+    const transformsRoot = path.join(configDir, "hooks", "transforms");
+    fs.mkdirSync(transformsRoot, { recursive: true });
+    const transformPath = path.join(transformsRoot, "reloadable.mjs");
+    fs.writeFileSync(transformPath, 'export default () => ({ kind: "wake", text: "accepted" });');
+    const activeMappings = [
+      {
+        id: "reloadable",
+        matchPath: "reloadable",
+        action: "agent" as const,
+        messageTemplate: "unused",
+        transform: { modulePath: transformPath },
+      },
+    ];
+    commitHooksConfigReload();
+    const applyActiveTransform = () =>
+      applyHookMappings(activeMappings, {
+        payload: {},
+        headers: {},
+        url: new URL("http://127.0.0.1:18789/hooks/reloadable"),
+        path: "reloadable",
+      });
+
+    const first = await applyActiveTransform();
+    expect(first?.ok).toBe(true);
+    if (first?.ok && first.action?.kind === "wake") {
+      expect(first.action.text).toBe("accepted");
+    }
+
+    const { applyHotReload } = createReloadHandlersForTest();
+
+    fs.writeFileSync(transformPath, 'export default () => ({ kind: "wake", text: "candidate" });');
+    const nextTime = new Date(Date.now() + 5_000);
+    fs.utimesSync(transformPath, nextTime, nextTime);
+
+    await expect(
+      applyHotReload(
+        {
+          changedPaths: ["hooks.token"],
+          restartGateway: false,
+          restartReasons: [],
+          hotReasons: ["hooks.token"],
+          reloadHooks: true,
+          restartGmailWatcher: false,
+          restartCron: false,
+          restartHeartbeat: false,
+          restartHealthMonitor: false,
+          reloadPlugins: false,
+          restartChannels: new Set(),
+          disposeMcpRuntimes: false,
+          noopPaths: [],
+        },
+        { hooks: { enabled: true } },
+      ),
+    ).rejects.toThrow("hooks.enabled requires hooks.token");
+
+    const afterRejectedReload = await applyActiveTransform();
+    expect(afterRejectedReload?.ok).toBe(true);
+    if (afterRejectedReload?.ok && afterRejectedReload.action?.kind === "wake") {
+      expect(afterRejectedReload.action.text).toBe("accepted");
+    }
   });
 });
 

--- a/src/gateway/server-reload-hot.ts
+++ b/src/gateway/server-reload-hot.ts
@@ -17,7 +17,7 @@ import { runOutsideGatewayRootWorkAdmission } from "../process/gateway-work-admi
 import type { ChannelKind } from "./config-reload-plan.js";
 import { shouldRefreshContextWindowCache } from "./config-reload-recovery.js";
 import type { GatewayReloadPlan } from "./config-reload.js";
-import { resolveHooksConfig } from "./hooks.js";
+import { commitHooksConfigReload, resolveHooksConfig } from "./hooks.js";
 import { buildGatewayCronService } from "./server-cron.js";
 import { applyGatewayLaneConcurrency, resolveGatewayLaneConcurrency } from "./server-lanes.js";
 import { createGatewayActiveWorkTracker } from "./server-reload-active-work.js";
@@ -99,9 +99,11 @@ export function createGatewayReloadHandlers(params: GatewayReloadHandlerParams) 
 
     resetPreparedModelRuntimeStateForHotReload();
 
+    let hooksReloadResolved = false;
     if (plan.reloadHooks) {
       try {
         nextState.hooksConfig = resolveHooksConfig(nextConfig);
+        hooksReloadResolved = true;
       } catch (err) {
         params.logHooks.warn(`hooks config reload failed: ${String(err)}`);
         throw err;
@@ -176,6 +178,9 @@ export function createGatewayReloadHandlers(params: GatewayReloadHandlerParams) 
         params.setState(nextState);
         // All rejecting work is complete. Publish pre-resolved lane limits at
         // the final synchronous commit edge, alongside the accepted state.
+        if (hooksReloadResolved) {
+          commitHooksConfigReload();
+        }
         applyGatewayLaneConcurrency(laneConcurrency);
         runtimeCommitted = true;
         setGatewaySigusr1RestartPolicy({ allowExternal: isRestartEnabled(nextConfig) });

--- a/src/gateway/server-runtime-config.ts
+++ b/src/gateway/server-runtime-config.ts
@@ -17,7 +17,7 @@ import {
 } from "./auth.js";
 import { normalizeControlUiBasePath } from "./control-ui-shared.js";
 import { warnLegacyOpenClawEnvVars } from "./env-deprecation.js";
-import { resolveHooksConfig } from "./hooks.js";
+import { commitHooksConfigReload, resolveHooksConfig } from "./hooks.js";
 import {
   defaultGatewayBindMode,
   isLoopbackHost,
@@ -182,6 +182,10 @@ export async function resolveGatewayRuntimeConfig(params: {
         "gateway auth mode=trusted-proxy requires gateway.trustedProxies to be configured with at least one proxy IP",
       );
     }
+  }
+
+  if (hooksConfig) {
+    commitHooksConfigReload();
   }
 
   return {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where editing a configured hook transform could leave the gateway running the old transform function after hooks hot reload rebuilt the mapping config.

## Why This Change Was Made

Hook mapping resolution now drops the process-local transform function cache when hooks config is resolved, and transform cache misses import with one cache-bust token for the current reload generation so Node does not reuse the previous module instance.

## User Impact

Operators can update hook transform files and have subsequent matching webhook deliveries use the edited transform without restarting the gateway.

## Evidence

Exact head: `fade61a1a9a7fb5d3a8378fa0ddc82a72140c2ee`

- Production module boundary: `pnpm exec tsx proof-live.ts`

```text
$ pnpm exec tsx proof-live.ts
first-transform: before
after-reload: after
```

- `node scripts/run-vitest.mjs src/gateway/hooks-mapping.test.ts src/gateway/server-reload-handlers.test.ts`: 137 passed
- Fresh post-rebase autoreview: clean, no actionable findings (0.87 confidence)

<details>
<summary>proof-live.ts</summary>

```ts
import fs from "node:fs";
import os from "node:os";
import path from "node:path";
import { pathToFileURL } from "node:url";

const configDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-hook-transform-proof-"));
const transformsRoot = path.join(configDir, "hooks", "transforms");
fs.mkdirSync(transformsRoot, { recursive: true });
const transformPath = path.join(transformsRoot, "reloadable.mjs");

type HooksMappingModule = typeof import("./src/gateway/hooks-mapping.js");
let hooksMapping: HooksMappingModule;

function writeTransform(text: string) {
  fs.writeFileSync(
    transformPath,
    `export default () => ({ kind: "wake", text: ${JSON.stringify(text)} });\n`,
  );
}

function resolveCurrentMappings() {
  return hooksMapping.resolveHookMappings(
    {
      mappings: [
        {
          match: { path: "reloadable" },
          action: "agent",
          messageTemplate: "unused",
          transform: { module: "reloadable.mjs" },
        },
      ],
    },
    { configDir },
  );
}

async function runHook() {
  const result = await hooksMapping.applyHookMappings(resolveCurrentMappings(), {
    payload: {},
    headers: {},
    url: new URL("http://127.0.0.1:18789/hooks/reloadable"),
    path: "reloadable",
  });
  if (!result?.ok || result.action?.kind !== "wake") {
    throw new Error(`unexpected hook result: ${JSON.stringify(result)}`);
  }
  return result.action.text;
}

async function main() {
  hooksMapping = await import(pathToFileURL(path.resolve("src/gateway/hooks-mapping.ts")).href);
  try {
    writeTransform("before");
    console.log(`first-transform: ${await runHook()}`);
    writeTransform("after");
    console.log(`after-reload: ${await runHook()}`);
  } finally {
    fs.rmSync(configDir, { recursive: true, force: true });
  }
}

void main();
```

</details>

AI-assisted: built with Codex

