### PR TITLE
fix(memory-core): use surrogate-safe UTF-16 slicing in short-term promotion

### DIFF
--- a/extensions/memory-core/src/short-term-promotion.test.ts
+++ b/extensions/memory-core/src/short-term-promotion.test.ts
@@ -3670,6 +3670,78 @@ describe("short-term promotion", () => {
         expect(memoryText).not.toContain("🚀");
       });
     });
+
+    it("does not throw when the dreaming narrative lead window contains an astral character", async () => {
+      await withTempWorkspace(async (workspaceDir) => {
+        // 199 prefix chars force the 200th code unit to be the high surrogate of 🚀,
+        // exercising the surrogate-safe lead-window boundary.
+        const prefix = "x".repeat(199);
+        const snippet = `${prefix}🚀Candidate: confidence: 1 evidence: memory/ status: staged recalls: 1`;
+        await recordShortTermRecalls({
+          workspaceDir,
+          query: "boundary test",
+          results: [
+            {
+              path: "memory/2026-04-03.md",
+              source: "memory",
+              startLine: 1,
+              endLine: 1,
+              score: 0.9,
+              snippet,
+            },
+          ],
+        });
+
+        // Ranking exercises the 200-code-unit dreaming narrative lead check.
+        // The Candidate marker starts after the lead window, so ranking returns one candidate.
+        const ranked = await rankShortTermPromotionCandidates({
+          workspaceDir,
+          minScore: 0,
+          minRecallCount: 0,
+          minUniqueQueries: 0,
+        });
+        expect(ranked).toHaveLength(1);
+      });
+    });
+
+    it("does not throw when heading context contains an astral character", async () => {
+      await withTempWorkspace(async (workspaceDir) => {
+        await writeDailyMemoryNote(workspaceDir, "2026-05-28", [
+          "# 2026-05-28",
+          "",
+          "## 🚀模型切换 (16:23)",
+          "- **需求**: 用户想使用小米 Mimo 模型作为默认",
+        ]);
+        await recordShortTermRecalls({
+          workspaceDir,
+          query: "__dreaming_daily__:2026-05-28",
+          signalType: "daily",
+          dedupeByQueryPerDay: true,
+          dayBucket: "2026-05-28",
+          results: [
+            {
+              path: "memory/2026-05-28.md",
+              startLine: 4,
+              endLine: 4,
+              score: 0.91,
+              snippet: "🚀模型切换 (16:23): **需求**: 用户想使用小米 Mimo 模型作为默认",
+              source: "memory",
+            },
+          ],
+        });
+
+        // Ranking exercises targetSnippetHasHeadingContext with an emoji in the heading.
+        const ranked = await rankShortTermPromotionCandidates({
+          workspaceDir,
+          minScore: 0,
+          minRecallCount: 0,
+          minUniqueQueries: 0,
+          nowMs: Date.parse("2026-05-31T00:00:00.000Z"),
+        });
+        expect(ranked).toHaveLength(1);
+        expect(ranked[0]?.key).toBe("memory:memory/2026-05-28.md:4:4");
+      });
+    });
   });
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/extensions/memory-core/src/short-term-promotion.ts
+++ b/extensions/memory-core/src/short-term-promotion.ts
@@ -18,7 +18,7 @@ import {
   normalizeStringEntries,
   uniqueStrings,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
-import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
+import { sliceUtf16Safe, truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import pLimit from "p-limit";
 import {
   deriveConceptTags,
@@ -415,7 +415,7 @@ function hasDreamingNarrativeLead(snippet: string): boolean {
   // The composite detector below still requires the full signal combination, so widening
   // the lead check to anywhere in the first 200 chars closes the leak without creating
   // false positives for ordinary durable notes that merely mention the word in prose.
-  const head = withoutPrefix.slice(0, 200);
+  const head = truncateUtf16Safe(withoutPrefix, 200);
   return /\b(?:Candidate|Reflections?):/i.test(head);
 }
 
@@ -2106,7 +2106,7 @@ function targetSnippetHasHeadingContext(targetSnippet: string, bodySnippet: stri
   if (bodyIndex <= 0) {
     return false;
   }
-  return targetSnippet.slice(0, bodyIndex).trimEnd().endsWith(":");
+  return sliceUtf16Safe(targetSnippet, 0, bodyIndex).trimEnd().endsWith(":");
 }
 
 function extractTargetHeadingBodySnippet(


### PR DESCRIPTION
Fixes #107876.

## What Problem This Solves

`extensions/memory-core/src/short-term-promotion.ts` sliced strings at fixed UTF-16 code-unit boundaries without regard to surrogate pairs.

1. Line 417 used `withoutPrefix.slice(0, 200)`; if the 200th code unit was the high surrogate of an astral character (e.g., emoji), the resulting `head` ended with a lone surrogate.
2. Line 2108 used `targetSnippet.slice(0, bodyIndex)`; if `bodyIndex` landed inside a surrogate pair, the slice contained a dangling surrogate half.

## Why This Change Was Made

The file already imports and uses `truncateUtf16Safe` correctly elsewhere (`truncateShortTermSnippet` and `truncatePromotedSnippet`). Using the existing surrogate-safe helpers at the two remaining sites makes the behavior consistent and prevents malformed Unicode strings from reaching downstream regex tests, JSON serialization, SQLite storage, or logging.

## User Impact

Short-term promotion snippets that contain astral characters (emoji, CJK extension characters, math symbols, etc.) near the 200-code-unit lead boundary are now handled without producing lone surrogates.

## Evidence

### Regression coverage

Added two focused tests to the existing `UTF-16 snippet bounds` block in `extensions/memory-core/src/short-term-promotion.test.ts`. Both exercise the modified paths through public functions without exporting internal helpers, and both assert concrete outcomes:

- `does not throw when the dreaming narrative lead window contains an astral character` — records a recall whose snippet has 199 ASCII chars plus 🚀, forcing the 200th code unit to land inside the emoji (the exact surrogate boundary). Ranking exercises the `truncateUtf16Safe(withoutPrefix, 200)` path and returns one candidate because the `Candidate:` marker starts after the lead window.
- `does not throw when heading context contains an astral character` — records a daily recall whose heading and snippet contain 🚀, then asserts `rankShortTermPromotionCandidates` returns one candidate with key `memory:memory/2026-05-28.md:4:4`.

### Exact-boundary runtime proof

Ran a standalone script against the real production module that shows the split surrogate produced by the old raw slice and the well-formed output produced by the patched code, then exercises both real memory-core ranking paths.

Command used:

```bash
export PATH=/home/0668001525/.config/nvm/versions/node/v22.22.3/bin:$PATH
export OPENCLAW_STATE_DIR=$(mktemp -d)
node_modules/.bin/tsx utf16-exact-boundary-proof.mjs
```

Output:

```text
=== Exact boundary 1: dreaming narrative lead window ===
Input length (code units): 269
Input ends with emoji at boundary: yes

Old raw slice (would produce split surrogate):
  rawHead1 length: 200
  rawHead1 last code unit: d83d
  rawHead1 lone surrogate: YES

Patched safe slice (well-formed):
  safeHead1 length: 199
  safeHead1 last code unit: 78
  safeHead1 lone surrogate: no

Real production path after fix:
  rankShortTermPromotionCandidates returned 1 candidate(s)

=== Exact boundary 2: heading context slice ===
targetSnippet: "abc🚀:"
bodySnippet: "\ude80:"
bodyIndex: 4

Old raw slice (would produce split surrogate):
  rawSlice2 length: 4
  rawSlice2 last code unit: d83d
  rawSlice2 lone surrogate: YES

Patched safe slice (well-formed):
  safeSlice2 length: 3
  safeSlice2 last code unit: 63
  safeSlice2 lone surrogate: no

Real production path after fix:
  rankShortTermPromotionCandidates returned 1 candidate(s)
  first candidate key: memory:memory/2026-05-28.md:4:4

All exact-boundary assertions passed.
```

The script demonstrates both the pre-patch split surrogate (`d83d`) and the post-patch well-formed boundary, then confirms the real ranking paths complete successfully.

### Static checks

```bash
node_modules/.bin/oxlint extensions/memory-core/src/short-term-promotion.ts extensions/memory-core/src/short-term-promotion.test.ts
# Found 0 warnings and 0 errors.

node_modules/.bin/oxfmt --check extensions/memory-core/src/short-term-promotion.ts extensions/memory-core/src/short-term-promotion.test.ts
# All matched files use the correct format.
```

The existing `test/scripts/check-deprecated-api-usage.test.ts` failure is pre-existing on `origin/main` and unrelated to this change.

---

Maintainers: please comment `@clawsweeper re-review` to refresh the ClawSweeper review.