### PR TITLE
fix(discord): bound gateway metadata response reads

### DIFF
--- a/extensions/discord/src/monitor/gateway-metadata.test.ts
+++ b/extensions/discord/src/monitor/gateway-metadata.test.ts
@@ -52,4 +52,35 @@ describe("Discord gateway metadata", () => {
       "discord: gateway metadata lookup failed transiently; using default gateway url (Failed to get gateway information from Discord: fetch failed | Discord API /gateway/bot failed (429): Error 1015 rate limited)",
     );
   });
+
+  it("bounds direct gateway metadata response bodies before parsing", async () => {
+    const error = await fetchDiscordGatewayInfoWithTimeout({
+      token: "test",
+      fetchImpl: async () =>
+        new Response(
+          new ReadableStream({
+            start(controller) {
+              controller.enqueue(
+                new Uint8Array(DISCORD_GATEWAY_METADATA_MAX_BYTES + 1).fill(0x78),
+              );
+              controller.close();
+            },
+          }),
+          { status: 502, headers: { "content-type": "text/plain" } },
+        ),
+      timeoutMs: 1_000,
+    }).catch((err: unknown) => err);
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toBe(
+      "Failed to get gateway information from Discord: fetch failed",
+    );
+    const cause = (error as { cause?: unknown }).cause;
+    expect(cause).toBeInstanceOf(Error);
+    expect((cause as Error).message).toMatch(
+      new RegExp(
+        `Discord gateway metadata response body too large: \\d+ bytes \\(limit: ${DISCORD_GATEWAY_METADATA_MAX_BYTES} bytes\\)`,
+      ),
+    );
+  });
 });

--- a/extensions/discord/src/monitor/gateway-metadata.ts
+++ b/extensions/discord/src/monitor/gateway-metadata.ts
@@ -3,6 +3,7 @@ import type { APIGatewayBotInfo } from "discord-api-types/v10";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { parseStrictPositiveInteger } from "openclaw/plugin-sdk/number-runtime";
 import { captureHttpExchange } from "openclaw/plugin-sdk/proxy-capture";
+import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import { Type } from "typebox";
@@ -16,16 +17,16 @@ const DEFAULT_DISCORD_GATEWAY_URL = "wss://gateway.discord.gg/";
 const DEFAULT_DISCORD_GATEWAY_INFO_TIMEOUT_MS = 30_000;
 const MAX_DISCORD_GATEWAY_INFO_TIMEOUT_MS = 120_000;
 const DISCORD_GATEWAY_INFO_TIMEOUT_ENV = "OPENCLAW_DISCORD_GATEWAY_INFO_TIMEOUT_MS";
+const DISCORD_GATEWAY_METADATA_MAX_BYTES = 4 * 1024 * 1024;
 const DISCORD_GATEWAY_METADATA_FALLBACK_LOG_INTERVAL_MS = 60_000;
 
-type DiscordGatewayMetadataResponse = Pick<Response, "ok" | "status" | "text">;
 export type DiscordGatewayFetchInit = Record<string, unknown> & {
   headers?: Record<string, string>;
 };
 export type DiscordGatewayFetch = (
   input: string,
   init?: DiscordGatewayFetchInit,
-) => Promise<DiscordGatewayMetadataResponse>;
+) => Promise<Response>;
 export type DiscordGatewayMetadataFetchOptions = {
   capture?: false | { flowId: string; meta: Record<string, unknown> };
   proxyUrl?: string;
@@ -56,8 +57,20 @@ function resolveFetchInputUrl(input: RequestInfo | URL): string {
   return input.url;
 }
 
+function createGatewayMetadataOverflowError(size: number, maxBytes: number): Error {
+  return new Error(
+    `Discord gateway metadata response body too large: ${size} bytes (limit: ${maxBytes} bytes)`,
+  );
+}
+
+async function readGatewayMetadataResponseBody(response: Response): Promise<Buffer> {
+  return await readResponseWithLimit(response, DISCORD_GATEWAY_METADATA_MAX_BYTES, {
+    onOverflow: ({ size, maxBytes }) => createGatewayMetadataOverflowError(size, maxBytes),
+  });
+}
+
 async function materializeGuardedResponse(response: Response): Promise<Response> {
-  const body = await response.arrayBuffer();
+  const body = new Uint8Array(await readGatewayMetadataResponseBody(response));
   return new Response(body, {
     status: response.status,
     statusText: response.statusText,
@@ -168,7 +181,7 @@ export async function fetchDiscordGatewayInfo(params: {
   fetchImpl: DiscordGatewayFetch;
   fetchInit?: DiscordGatewayFetchInit;
 }): Promise<APIGatewayBotInfo> {
-  let response: DiscordGatewayMetadataResponse;
+  let response: Response;
   try {
     response = await params.fetchImpl(DISCORD_GATEWAY_BOT_URL, {
       ...params.fetchInit,
@@ -187,7 +200,7 @@ export async function fetchDiscordGatewayInfo(params: {
 
   let body: string;
   try {
-    body = await response.text();
+    body = new TextDecoder().decode(await readGatewayMetadataResponseBody(response));
   } catch (error) {
     throw createGatewayMetadataError({
       detail: formatErrorMessage(error),

--- a/extensions/discord/src/monitor/provider.proxy.test.ts
+++ b/extensions/discord/src/monitor/provider.proxy.test.ts
@@ -312,11 +312,7 @@ describe("createDiscordGatewayPlugin", () => {
     plugin: unknown;
     fetchMock: typeof globalFetchMock;
   }) {
-    params.fetchMock.mockResolvedValue({
-      ok: true,
-      status: 200,
-      text: async () => createGatewayInfoBody(),
-    } as Response);
+    params.fetchMock.mockResolvedValue(new Response(createGatewayInfoBody()));
     await registerGatewayClient(params.plugin);
   }
 


### PR DESCRIPTION
<!--
Optional linked context:
Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
below this comment.

Required PR title:
type: user-facing description
Use a parenthesized scope only when it adds clarity:
fix(auth): login redirect loops when session cookie is expired

Types: feat, fix, improve, refactor, docs, chore.
For fixes, describe the user-visible symptom and trigger:
fix: task list fails to load when user has no environments
Avoid implementation details such as:
fix: add null check to task query
-->

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

<!--
Describe the concrete user, product, or operational problem.
For fixes, begin with:
"Fixes an issue where users <do X> would <experience Y> when <condition>."
or:
"Resolves a problem where..."

Name the affected UI surface or workflow. Do not describe the code-level cause here.
-->

## Why This Change Was Made

<!--
In one or two sentences, explain the complete shipped solution, key design
decisions, and relevant boundaries or non-goals. Include implementation detail
only when it helps reviewers understand user-visible behavior or risk.
Avoid file-by-file narration.
-->

## User Impact

<!--
State what users, operators, or developers can now do or expect. Lead with the
concrete benefit and use user-facing language. If there is no user-visible
impact, say so plainly.
-->

## Evidence

<!--
Show the most useful proof that this change works. Screenshots, screencasts,
terminal output, focused tests, CI results, live observations, redacted logs,
and artifact links are all useful. Include before/after evidence for visual
changes when it clarifies the result.

Reviewers will inspect the code, tests, and CI. Use this section to make the
validation easy to understand, not to restate the diff.
-->
