### PR TITLE
test(live): classify xAI degraded availability

### DIFF
--- a/src/agents/live-test-provider-drift.test.ts
+++ b/src/agents/live-test-provider-drift.test.ts
@@ -49,6 +49,11 @@ describe("live test provider drift", () => {
         "Service temporarily unavailable. The model is at capacity and currently cannot serve this request.",
       ),
     ).toBe(true);
+    expect(
+      isLiveProviderUnavailableDrift(
+        "Error Code unknown: Service temporarily unavailable. The model's availability is currently degraded.",
+      ),
+    ).toBe(true);
   });
 
   it("returns explicit skip labels only for enabled drift classes", () => {
@@ -66,5 +71,12 @@ describe("live test provider drift", () => {
         allowBilling: true,
       }),
     ).toBeUndefined();
+    expect(
+      shouldSkipLiveProviderDrift({
+        error:
+          "Error Code unknown: Service temporarily unavailable. The model's availability is currently degraded.",
+        allowProviderUnavailable: true,
+      }),
+    ).toEqual({ reason: "provider-unavailable", label: "provider unavailable" });
   });
 });

--- a/src/agents/live-test-provider-drift.ts
+++ b/src/agents/live-test-provider-drift.ts
@@ -9,7 +9,9 @@ import { isCloudflareOrHtmlErrorPage } from "../shared/assistant-error-format.js
 import {
   isAuthErrorMessage,
   isBillingErrorMessage,
+  isOverloadedErrorMessage,
   isRateLimitErrorMessage,
+  isServerErrorMessage,
   isTimeoutErrorMessage,
 } from "./embedded-agent-helpers/failover-matches.js";
 import { isAnthropicBillingError, isApiKeyRateLimitError } from "./live-auth-keys.js";
@@ -84,6 +86,8 @@ export function isLiveProviderUnavailableDrift(error: unknown): boolean {
   const htmlCandidate = raw.trim().replace(/^error:\s*/i, "");
   const msg = normalizeLowercaseStringOrEmpty(raw);
   return (
+    isOverloadedErrorMessage(raw) ||
+    isServerErrorMessage(raw) ||
     isRawHtmlProviderErrorPage(htmlCandidate) ||
     isCloudflareOrHtmlErrorPage(raw) ||
     isCloudflareOrHtmlErrorPage(htmlCandidate) ||

--- a/src/agents/xai.live.test.ts
+++ b/src/agents/xai.live.test.ts
@@ -3,16 +3,13 @@
 import { completeSimple, type Model } from "openclaw/plugin-sdk/llm";
 import { Type } from "typebox";
 import { describe, expect, it } from "vitest";
-import {
-  isBillingErrorMessage,
-  isOverloadedErrorMessage,
-} from "./embedded-agent-helpers/failover-matches.js";
 import { applyExtraParamsToAgent } from "./embedded-agent-runner/extra-params.js";
 import {
   createSingleUserPromptMessage,
   extractNonEmptyAssistantText,
   isLiveTestEnabled,
 } from "./live-test-helpers.js";
+import { shouldSkipLiveProviderDrift } from "./live-test-provider-drift.js";
 import { createOpenAIResponsesTransportStreamFn } from "./openai-transport-stream.js";
 import { createWebSearchTool } from "./tools/web-search.js";
 
@@ -86,12 +83,13 @@ async function runXaiLiveCase(label: string, run: () => Promise<void>): Promise<
     await run();
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    if (isBillingErrorMessage(message)) {
-      console.warn(`[xai:live] skip ${label}: billing drift: ${message}`);
-      return;
-    }
-    if (isOverloadedErrorMessage(message)) {
-      console.warn(`[xai:live] skip ${label}: temporary provider capacity: ${message}`);
+    const drift = shouldSkipLiveProviderDrift({
+      error,
+      allowBilling: true,
+      allowProviderUnavailable: true,
+    });
+    if (drift) {
+      console.warn(`[xai:live] skip ${label}: ${drift.label}: ${message}`);
       return;
     }
     if (/\b403\b/.test(message) && /model .+ is not available in your region/i.test(message)) {
@@ -258,8 +256,13 @@ describeLive("xai live", () => {
         details.error && details.message
           ? `${details.error} ${details.message}`
           : details.error || details.message || "";
-      if (isBillingErrorMessage(errorMessage)) {
-        console.warn(`[xai:live] skip web-search: billing drift: ${errorMessage}`);
+      const drift = shouldSkipLiveProviderDrift({
+        error: errorMessage,
+        allowBilling: true,
+        allowProviderUnavailable: true,
+      });
+      if (drift) {
+        console.warn(`[xai:live] skip web-search: ${drift.label}: ${errorMessage}`);
         return;
       }
 


### PR DESCRIPTION
## What Problem This Solves

Full Release Validation failed the native xAI agent lane when Grok returned `Service temporarily unavailable. The model's availability is currently degraded.` One live tool-call assertion failed while 74 sibling native live tests passed; fail-fast then cancelled unrelated Docker, package, QA, and cross-OS work.

Failure: https://github.com/openclaw/openclaw/actions/runs/29379189220/job/87239480734

## Why This Change Was Made

Route xAI live-test drift through the existing canonical live-provider classifier. Extend that classifier to consume the already-established overload and server-error matchers, including the exact observed xAI degradation response. Use the same classifier for returned web-search errors, not only thrown completion errors.

This does not relax tool payload, assistant text, citation, or provider assertions. Only recognized billing/upstream availability failures are skipped. xAI's official debugging guidance distinguishes service errors from request errors and directs ongoing disruptions to its status service: https://docs.x.ai/developers/debugging

## User Impact

No runtime behavior change. Live release validation no longer treats a recognized temporary provider outage as an OpenClaw contract regression; deterministic response and payload regressions still fail.

## Evidence

- Exact failure: 1 failed, 74 passed, 25 skipped; xAI reported degraded model availability
- Focused classifier test: 4/4 passing in Blacksmith Testbox `tbx_01kxhmp3faved74m07bxgtrtmh`
- Testbox run: https://github.com/openclaw/openclaw/actions/runs/29380596024
- Targeted formatter check passed
- `git diff --check` passed
- Fresh autoreview clean, 0.90

After PR CI, rerun `native-live-src-agents` on this exact head, then rerun Full Release Validation on the landed main SHA.

No changelog entry: test/release-harness robustness only.
