### PR TITLE
fix(slack): keep draft previews with custom identity

### DIFF
--- a/extensions/slack/src/delivery-trace.test.ts
+++ b/extensions/slack/src/delivery-trace.test.ts
@@ -248,12 +248,8 @@ const slackTraceScenarios: Record<SlackTraceScenarioName, readonly DeliveryTrace
     { kind: "cancel" },
     { kind: "idle" },
   ],
-  // Edit-preview tier: native transport ineligible → draft post + throttled
-  // chat.update, and the final promotes the draft in place. The custom-identity
-  // flavor of this tier is structurally unreachable: dispatch.ts disables the
-  // draft stream whenever a custom identity is set because chat.update cannot
-  // preserve custom authorship (identity turns instead deliver one final
-  // chat.postMessage), so no golden exists for it.
+  // Edit-preview tier: native transport ineligible → identity-aware draft
+  // post + throttled chat.update, and the final promotes the draft in place.
   "preview-edit-fallback": [
     { kind: "reply-start" },
     { kind: "partial", text: PREVIEW_PARTIAL_ONE },

--- a/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
@@ -1230,17 +1230,57 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
     expectDeliverReplyCall(0, FINAL_REPLY_TEXT);
   });
 
-  it("uses portable draft previews with the resolved Slack identity", async () => {
+  it("uses a disposable portable preview before custom-identity final delivery", async () => {
     const relayIdentity = { username: "Nik Team Claw" };
-    finalizeSlackPreviewEditMock.mockResolvedValueOnce(undefined);
+    const draftStream = {
+      ...createDraftStreamStub(),
+      clear: vi.fn(noopAsync),
+      discardPending: vi.fn(noopAsync),
+    };
+    createSlackDraftStreamMock.mockReturnValueOnce(draftStream);
 
     await dispatchPreparedSlackMessage(createPreparedSlackMessage({ relayIdentity }));
 
     expect(createSlackDraftStreamMock).toHaveBeenCalledWith(
-      expect.objectContaining({ identity: relayIdentity }),
+      expect.not.objectContaining({ identity: expect.anything() }),
     );
-    expect(finalizeSlackPreviewEditMock).toHaveBeenCalledTimes(1);
-    expect(deliverRepliesMock).not.toHaveBeenCalled();
+    expect(finalizeSlackPreviewEditMock).not.toHaveBeenCalled();
+    expect(draftStream.discardPending).toHaveBeenCalled();
+    expect(draftStream.clear).toHaveBeenCalledTimes(1);
+    expect(deliverRepliesMock).toHaveBeenCalledTimes(1);
+    expectDeliverReplyCall(0, FINAL_REPLY_TEXT, { identity: relayIdentity });
+  });
+
+  it("clears a disposable preview before custom-identity media delivery", async () => {
+    const relayIdentity = { username: "Nik Team Claw" };
+    const draftStream = {
+      ...createDraftStreamStub(),
+      clear: vi.fn(noopAsync),
+      discardPending: vi.fn(noopAsync),
+    };
+    createSlackDraftStreamMock.mockReturnValueOnce(draftStream);
+    mockedDispatchSequence = [
+      {
+        kind: "final",
+        payload: { text: "Photo", mediaUrl: "https://example.com/a.png" },
+      },
+    ];
+
+    await dispatchPreparedSlackMessage(createPreparedSlackMessage({ relayIdentity }));
+
+    expect(createSlackDraftStreamMock).toHaveBeenCalledWith(
+      expect.not.objectContaining({ identity: expect.anything() }),
+    );
+    expect(draftStream.discardPending).toHaveBeenCalled();
+    expect(draftStream.clear).toHaveBeenCalledTimes(1);
+    expect(finalizeSlackPreviewEditMock).not.toHaveBeenCalled();
+    expect(deliverRepliesMock).toHaveBeenCalledTimes(1);
+    const params = requireRecord(
+      requireMockCall(deliverRepliesMock, 0, "deliver replies")[0],
+      "deliver replies params",
+    );
+    expectRecordFields(params, { replyThreadTs: THREAD_TS, identity: relayIdentity });
+    expect(params.replies).toEqual([{ text: "Photo", mediaUrl: "https://example.com/a.png" }]);
   });
 
   it("uses supported native Slack streaming authorship when a custom identity is active", async () => {

--- a/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
@@ -1230,15 +1230,17 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
     expectDeliverReplyCall(0, FINAL_REPLY_TEXT);
   });
 
-  it("uses the relay identity when the agent has no explicit Slack identity", async () => {
+  it("uses portable draft previews with the resolved Slack identity", async () => {
     const relayIdentity = { username: "Nik Team Claw" };
+    finalizeSlackPreviewEditMock.mockResolvedValueOnce(undefined);
 
     await dispatchPreparedSlackMessage(createPreparedSlackMessage({ relayIdentity }));
 
-    expect(createSlackDraftStreamMock).not.toHaveBeenCalled();
-    expect(finalizeSlackPreviewEditMock).not.toHaveBeenCalled();
-    expect(deliverRepliesMock).toHaveBeenCalledTimes(1);
-    expectDeliverReplyCall(0, FINAL_REPLY_TEXT, { identity: relayIdentity });
+    expect(createSlackDraftStreamMock).toHaveBeenCalledWith(
+      expect.objectContaining({ identity: relayIdentity }),
+    );
+    expect(finalizeSlackPreviewEditMock).toHaveBeenCalledTimes(1);
+    expect(deliverRepliesMock).not.toHaveBeenCalled();
   });
 
   it("uses supported native Slack streaming authorship when a custom identity is active", async () => {

--- a/extensions/slack/src/monitor/message-handler/dispatch.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.ts
@@ -608,6 +608,9 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
     shouldEnableSlackPreviewStreaming({
       mode: slackStreaming.mode,
     });
+  const hasSlackCustomIdentity = Boolean(
+    slackIdentity?.username || slackIdentity?.iconUrl || slackIdentity?.iconEmoji,
+  );
   const streamingEnabled =
     !sourceRepliesAreToolOnly &&
     isSlackStreamingEnabled({
@@ -1285,6 +1288,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
       info.kind === "final" &&
       ttsSupplement &&
       draftStream &&
+      !hasSlackCustomIdentity &&
       !draftPreviewCommitted &&
       !observedFinalReplyDelivery &&
       previewStreamingEnabled &&
@@ -1370,6 +1374,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
             : undefined,
         buildFinalEdit: () => {
           if (
+            hasSlackCustomIdentity ||
             !previewStreamingEnabled ||
             (reply.hasMedia && !ttsSupplement) ||
             payload.isError ||
@@ -1471,7 +1476,9 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
         token: ctx.botToken,
         accountId: account.accountId,
         ...(prepared.eventScope ? { eventScope: prepared.eventScope } : {}),
-        identity: slackIdentity,
+        // Customized Slack messages cannot be deleted. Keep the temporary
+        // preview disposable and apply custom identity to the final delivery.
+        ...(!hasSlackCustomIdentity && slackIdentity ? { identity: slackIdentity } : {}),
         ...(slackMessageMetadata ? { metadata: slackMessageMetadata } : {}),
         maxChars: Math.min(ctx.textLimit, SLACK_TEXT_LIMIT),
         resolveThreadTs: () => {

--- a/extensions/slack/src/monitor/message-handler/dispatch.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.ts
@@ -608,9 +608,6 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
     shouldEnableSlackPreviewStreaming({
       mode: slackStreaming.mode,
     });
-  const hasSlackCustomIdentity = Boolean(
-    slackIdentity?.username || slackIdentity?.iconUrl || slackIdentity?.iconEmoji,
-  );
   const streamingEnabled =
     !sourceRepliesAreToolOnly &&
     isSlackStreamingEnabled({
@@ -622,14 +619,10 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
     streamingEnabled,
     threadTs: streamThreadHint,
   });
-  // chat.update cannot preserve custom authorship. Use native streaming when
-  // possible; otherwise keep identity intact with one final postMessage.
-  const shouldUseDraftStream =
-    !hasSlackCustomIdentity &&
-    shouldInitializeSlackDraftStream({
-      previewStreamingEnabled,
-      useStreaming,
-    });
+  const shouldUseDraftStream = shouldInitializeSlackDraftStream({
+    previewStreamingEnabled,
+    useStreaming,
+  });
   const blockStreamingEnabled = resolveChannelStreamingBlockEnabled(account.config);
   const disableBlockStreaming = sourceRepliesAreToolOnly
     ? true


### PR DESCRIPTION
Closes #107861

Disclosure: AI was used to understand the codebase and review the fix.

## What Problem This Solves

Fixes an issue where Slack users with a custom outbound username or icon would lose portable draft-preview streaming when native streaming transport was disabled. Long-running top-level DM requests showed lifecycle reactions but no live preview, even though final replies still arrived.

## Why This Change Was Made

Portable draft selection now follows the configured streaming mode regardless of custom identity, but the temporary draft preview stays disposable by using the app identity. The final delivery path applies the configured custom Slack identity, so cleanup does not depend on deleting a custom-identity message.

## User Impact

Slack users can keep custom agent names and avatars while receiving live draft and tool-progress previews in configurations that use portable streaming. No configuration or migration changes are required.

## Evidence

- Added dispatch regressions covering disposable portable draft previews followed by custom-identity final delivery for text and media replies.
- Verified the custom-identity path does not use final preview edit/finalize behavior, clears the disposable draft preview, and sends the final reply with the resolved custom identity.
- Existing real Slack video proof remains attached on the PR and was accepted by ClawSweeper as `proof: sufficient` / `proof: video`.
- Follow-up reviewer concern addressed: custom-identity Slack messages are no longer used as the disposable draft preview message.
- `node scripts/run-vitest.mjs extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts extensions/slack/src/draft-stream.test.ts extensions/slack/src/delivery-trace.test.ts`: 136 passed.
- `node node_modules/.bin/oxlint extensions/slack/src/monitor/message-handler/dispatch.ts extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts`: passed.
- `node node_modules/.bin/oxfmt --check extensions/slack/src/monitor/message-handler/dispatch.ts extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts`: passed.
- `git diff --check`: passed.
- `rg -n "^(<<<<<<<|=======|>>>>>>>)" extensions/slack/src/monitor/message-handler/dispatch.ts extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts`: no matches.

## Notes

- `scripts/check-changed.mjs` could not complete locally because its delegated pnpm/Corepack path selected an incompatible Node runtime before running the changed-file checks. The focused equivalent checks for this touched Slack surface passed under a repository-compatible Node runtime.
