### PR TITLE
improve: speed live updater tests

### DIFF
--- a/test/scripts/openclaw-live-updater.test.ts
+++ b/test/scripts/openclaw-live-updater.test.ts
@@ -1,6 +1,7 @@
 import { execFileSync, spawn, spawnSync } from "node:child_process";
 import {
   chmodSync,
+  constants as fsConstants,
   cpSync,
   existsSync,
   mkdirSync,
@@ -99,9 +100,11 @@ function initializeFixture(root: string) {
   const origin = path.join(root, "origin.git");
   const seed = path.join(root, "seed");
   const mirror = path.join(root, "mirror");
+  const gitTemplate = path.join(root, "git-template");
+  mkdirSync(gitTemplate);
   mkdirSync(seed);
-  git(root, "init", "--bare", origin);
-  git(seed, "init", "-b", "main");
+  git(root, "init", "--bare", "-b", "main", `--template=${gitTemplate}`, origin);
+  git(seed, "init", "-b", "main", `--template=${gitTemplate}`);
   git(seed, "config", "user.name", "Test");
   git(seed, "config", "user.email", "test@example.com");
   writeFileSync(path.join(seed, "README.md"), "one\n");
@@ -110,14 +113,17 @@ function initializeFixture(root: string) {
   git(seed, "commit", "-m", "initial");
   git(seed, "remote", "add", "origin", "../origin.git");
   git(seed, "push", "-u", "origin", "main");
-  git(root, "--git-dir", origin, "symbolic-ref", "HEAD", "refs/heads/main");
-  git(root, "clone", origin, mirror);
+  git(root, "clone", `--template=${gitTemplate}`, origin, mirror);
   const canonicalOrigin = "https://github.com/openclaw/openclaw.git";
   git(mirror, "remote", "set-url", "origin", canonicalOrigin);
   return { root, mirror, origin, seed };
 }
 
-function makeFixture() {
+type Fixture = ReturnType<typeof initializeFixture>;
+
+function makeFixture(): Omit<Fixture, "seed">;
+function makeFixture(options: { includeSeed: true }): Fixture;
+function makeFixture(options?: { includeSeed?: boolean }) {
   if (!fixtureTemplate) {
     throw new Error("fixture template is not initialized");
   }
@@ -127,12 +133,16 @@ function makeFixture() {
   const mirror = path.join(root, "mirror");
   // Mutable refs and configs must stay isolated; copying one initialized repo
   // set avoids rebuilding identical Git history for every test.
-  cpSync(fixtureTemplate.origin, origin, { recursive: true });
-  cpSync(fixtureTemplate.seed, seed, { recursive: true });
-  cpSync(fixtureTemplate.mirror, mirror, { recursive: true });
+  const copyOptions = { mode: fsConstants.COPYFILE_FICLONE, recursive: true };
+  cpSync(fixtureTemplate.origin, origin, copyOptions);
+  cpSync(fixtureTemplate.mirror, mirror, copyOptions);
+  if (options?.includeSeed) {
+    cpSync(fixtureTemplate.seed, seed, copyOptions);
+  }
   fixtureOrigins.set(mirror, origin);
   fixtureOrigins.set(realpathSync(mirror), origin);
-  return { root, mirror, origin, seed };
+  const fixture = { root, mirror, origin };
+  return options?.includeSeed ? { ...fixture, seed } : fixture;
 }
 
 function writeBuild(mirror: string) {
@@ -942,7 +952,7 @@ describe("openclaw live updater", () => {
   });
 
   test("fast-forwards, builds exact SHA, restarts Gateway, then proves exact Mac target", () => {
-    const { root, mirror, seed } = makeFixture();
+    const { root, mirror, seed } = makeFixture({ includeSeed: true });
     mkdirSync(path.join(seed, "apps/macos/Sources/OpenClaw"), { recursive: true });
     writeFileSync(path.join(seed, "apps/macos/Sources/OpenClaw/App.swift"), "// changed\n");
     git(seed, "add", ".");
@@ -1309,7 +1319,7 @@ describe("openclaw live updater", () => {
   });
 
   test("repoints an ancestor snapshot across the next source update", () => {
-    const { root, mirror, seed } = makeFixture();
+    const { root, mirror, seed } = makeFixture({ includeSeed: true });
     mkdirSync(path.join(mirror, "node_modules"));
     writeBuild(mirror);
     writeFileSync(path.join(seed, "README.md"), "snapshot update\n");
@@ -1777,7 +1787,7 @@ describe("openclaw live updater", () => {
   });
 
   test("retains failed exact-bundle Mac proof for the next heartbeat", () => {
-    const { root, mirror, seed } = makeFixture();
+    const { root, mirror, seed } = makeFixture({ includeSeed: true });
     mkdirSync(path.join(seed, "apps/macos/Sources/OpenClaw"), { recursive: true });
     writeFileSync(path.join(seed, "apps/macos/Sources/OpenClaw/App.swift"), "// changed\n");
     git(seed, "add", ".");
@@ -1824,7 +1834,7 @@ describe("openclaw live updater", () => {
   });
 
   test("records pending Mac work before Gateway maintenance can fail", () => {
-    const { root, mirror, seed } = makeFixture();
+    const { root, mirror, seed } = makeFixture({ includeSeed: true });
     mkdirSync(path.join(seed, "apps/macos/Sources/OpenClaw"), { recursive: true });
     writeFileSync(path.join(seed, "apps/macos/Sources/OpenClaw/App.swift"), "// changed\n");
     git(seed, "add", ".");


### PR DESCRIPTION
## What Problem This Solves

The live-updater suite copied three complete Git fixture repositories for nearly every test, including a mutable seed checkout used by only four tests. The 52-test file spent about 9.10 seconds mostly materializing identical fixtures.

## Why This Change Was Made

Fixture copies now request copy-on-write reflinks with Node's documented fallback copy behavior. The shared template repositories use an empty Git template, avoiding unused sample hooks, and the mutable seed checkout is copied only for tests that push a new commit. Origin, mirror, refs, and configs remain isolated per test.

## User Impact

No runtime behavior change. The live-updater suite falls from 9,100 ms to 4,220 ms (53.6% faster) on Blacksmith Testbox.

## Evidence

- `corepack pnpm test test/scripts/openclaw-live-updater.test.ts` — 52/52 passed; 4,220 ms
- `env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed -- test/scripts/openclaw-live-updater.test.ts` — passed
- Testbox `tbx_01kxhn54xhsnacp7fsvxs741je`
- Fresh autoreview: clean, no accepted/actionable findings
