### PR TITLE
fix(models): reject oversized piped auth secrets

### DIFF
--- a/src/commands/models/auth.test.ts
+++ b/src/commands/models/auth.test.ts
@@ -300,7 +300,7 @@ function withInteractiveStdin() {
   };
 }
 
-function withPipedStdin(input: string) {
+function withPipedStdinChunks(chunks: readonly string[]) {
   const stdin = process.stdin as NodeJS.ReadStream & { isTTY?: boolean };
   const restoreInteractive = withInteractiveStdin();
   const previousAsyncIteratorDescriptor = Object.getOwnPropertyDescriptor(
@@ -315,7 +315,7 @@ function withPipedStdin(input: string) {
   Object.defineProperty(stdin, Symbol.asyncIterator, {
     configurable: true,
     async *value() {
-      yield input;
+      yield* chunks;
     },
   });
   return () => {
@@ -326,6 +326,10 @@ function withPipedStdin(input: string) {
     }
     restoreInteractive();
   };
+}
+
+function withPipedStdin(input: string) {
+  return withPipedStdinChunks([input]);
 }
 
 function createProvider(params: {
@@ -1471,6 +1475,37 @@ describe("modelsAuthLoginCommand", () => {
     expect(mocks.clackPassword).not.toHaveBeenCalled();
     expect(mocks.upsertAuthProfileWithLock).not.toHaveBeenCalled();
     expect(mocks.updateConfig).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["paste-token", modelsAuthPasteTokenCommand],
+    ["paste-api-key", modelsAuthPasteApiKeyCommand],
+  ])("rejects oversized piped secrets before %s persistence", async (_name, command) => {
+    const runtime = createRuntime();
+    restoreStdin?.();
+    restoreStdin = withPipedStdinChunks(["x".repeat(1024 * 1024), "y"]);
+
+    await expect(command({ provider: "dummy" }, runtime)).rejects.toThrow(
+      "Piped secret input exceeds 1048576 bytes.",
+    );
+
+    expect(mocks.upsertAuthProfileWithLock).not.toHaveBeenCalled();
+    expect(mocks.updateConfig).not.toHaveBeenCalled();
+  });
+
+  it("preserves multibyte piped secrets below the byte limit", async () => {
+    const runtime = createRuntime();
+    const token = "é".repeat(512 * 1024 - 1);
+    restoreStdin?.();
+    restoreStdin = withPipedStdinChunks([token.slice(0, 200_000), token.slice(200_000)]);
+
+    await modelsAuthPasteTokenCommand({ provider: "dummy" }, runtime);
+
+    expect(mocks.upsertAuthProfileWithLock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        credential: expect.objectContaining({ token }),
+      }),
+    );
   });
 
   it("writes pasted API keys to the requested agent store", async () => {

--- a/src/commands/models/auth.ts
+++ b/src/commands/models/auth.ts
@@ -137,12 +137,12 @@ async function readPipedStdin(): Promise<string> {
   const chunks: string[] = [];
   let bytes = 0;
   for await (const chunk of process.stdin) {
-    const text = String(chunk);
-    bytes += Buffer.byteLength(text, "utf8");
+    const chunkText = String(chunk);
+    bytes += Buffer.byteLength(chunkText, "utf8");
     if (bytes > PIPED_SECRET_MAX_BYTES) {
       throw new Error(`Piped secret input exceeds ${PIPED_SECRET_MAX_BYTES} bytes.`);
     }
-    chunks.push(text);
+    chunks.push(chunkText);
   }
   return chunks.join("");
 }

--- a/src/commands/models/auth.ts
+++ b/src/commands/models/auth.ts
@@ -72,6 +72,8 @@ import { loadValidConfigOrThrow, resolveKnownAgentId, updateConfig } from "./sha
 
 type UpsertAuthProfileParams = Parameters<typeof upsertAuthProfileWithLock>[0];
 
+const PIPED_SECRET_MAX_BYTES = 1024 * 1024;
+
 // CLI auth writes occur outside the gateway process, which may retain an older runtime snapshot.
 async function refreshRunningGatewayAuthState(): Promise<void> {
   try {
@@ -132,11 +134,17 @@ const select = async <T>(params: Parameters<typeof clackSelect<T>>[0]) =>
 
 async function readPipedStdin(): Promise<string> {
   process.stdin.setEncoding("utf8");
-  let input = "";
+  const chunks: string[] = [];
+  let bytes = 0;
   for await (const chunk of process.stdin) {
-    input += String(chunk);
+    const text = String(chunk);
+    bytes += Buffer.byteLength(text, "utf8");
+    if (bytes > PIPED_SECRET_MAX_BYTES) {
+      throw new Error(`Piped secret input exceeds ${PIPED_SECRET_MAX_BYTES} bytes.`);
+    }
+    chunks.push(text);
   }
-  return input;
+  return chunks.join("");
 }
 
 async function readPastedSecret(params: {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users piping credentials into `models auth paste-token` or `models auth paste-api-key` could make the CLI retain arbitrarily large input before validation and persistence.

## Why This Change Was Made

Piped model-auth secrets now use the repository's established 1 MiB streaming input limit and fail before any credential or config write when that limit is exceeded. Interactive TTY prompts and valid piped secrets are unchanged. AI-assisted.

## User Impact

Automation can continue piping normal tokens and API keys, while accidental or hostile oversized input is rejected with a clear error instead of growing memory and reaching credential persistence.

## Evidence

Environment: Linux x86_64, Node.js `v24.18.0`.

**Before — real CLI on then-current main `1fd4009e41c1`:**

```bash
node -e 'const chunk="x".repeat(512*1024); process.stdout.write(chunk); process.stdout.write(chunk+"y")' |
  HOME="$tmp/home" OPENCLAW_HOME="$tmp/home" OPENCLAW_STATE_DIR="$tmp/state" \
  node --import tsx src/entry.ts models auth paste-token --provider dummy
```

The two writes total 1 MiB + 1 byte. The command exited `0` and continued into persistence:

```text
Updated config: <temp>/state/openclaw.json
Auth profile: dummy:manual (dummy/token)
```

Current main advanced to `fc56b554d88f`; this check confirms that the production owner, CLI caller, and adjacent test did not change between the observed main and the PR base:

```bash
git diff --exit-code 1fd4009e41c1..fc56b554d88f -- \
  src/commands/models/auth.ts src/commands/models/auth.test.ts src/cli/models-cli.ts
# exit 0
```

**Premise:** both `paste-token` and `paste-api-key` registrations call the same `readPastedSecret` path. Before this patch, its non-TTY branch appended every decoded stdin chunk without a byte check. Existing native-hook, config-patch, and exec-approvals CLI readers already establish a 1 MiB owner-local stdin limit; no Commander, provider, or Codex layer bounds OpenClaw's input before this helper. I also inspected Codex's direct stdin login path in `codex-rs/cli/src/login.rs`; it is a separate CLI path and does not mediate these OpenClaw commands.

**After — real CLI on PR head `a321e0460a36`:** the same isolated command exited `1`:

```text
Error: Piped secret input exceeds 1048576 bytes.
```

The isolated state directory contained no `openclaw.json` or legacy `auth-profiles.json` after rejection. The focused regression below separately asserts that neither the auth-profile upsert nor config update seam is called for both public commands.

**Negative control — real CLI on the same PR head:**

```bash
printf 'tökën-value\n' |
  HOME="$tmp/home" OPENCLAW_HOME="$tmp/home" OPENCLAW_STATE_DIR="$tmp/state" \
  node --import tsx src/entry.ts models auth paste-token --provider dummy
```

This exited `0` and logged the expected config/profile writes. The focused regression also verifies exact preservation of a multibyte secret just below the byte limit.

**Focused validation:**

```text
node scripts/run-vitest.mjs src/commands/models/auth.test.ts
Test Files  1 passed (1)
Tests       42 passed (42)

node scripts/run-oxlint.mjs src/commands/models/auth.ts src/commands/models/auth.test.ts
passed

git diff --check upstream/main...HEAD
passed

.agents/skills/autoreview/scripts/autoreview --mode uncommitted
autoreview clean: no accepted/actionable findings reported
```

Not exercised: interactive TTY prompts and live provider network calls. The limit is only on the non-TTY branch, and these paste commands persist locally without calling a provider API.

