### PR TITLE
refactor(core): read channel metadata instead of hardcoded channel literals (batch 1)

### DIFF
--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-9b6fe207d1ed9bbd141de92ecc23b97e75d9e59755be5779655a4d4174652a62  plugin-sdk-api-baseline.json
-ebdc7e79bde53559aac7d9f3b39a20944598edd2a2f6559ec1917b060ace3bf3  plugin-sdk-api-baseline.jsonl
+202ccd0c71f23d8448f37dfc7b10ee2e8b2e12a90b9498740da5b757fb90513f  plugin-sdk-api-baseline.json
+265925043de4f1e2beed2660c5fcdc9c7b79b570e94afbe1dd3074bc304cea98  plugin-sdk-api-baseline.jsonl

--- a/docs/channels/groups.md
+++ b/docs/channels/groups.md
@@ -559,7 +559,7 @@ Group inbound payloads set:
 - `WasMentioned` (mention gating result)
 - Telegram forum topics also include `MessageThreadId` and `IsForum`.
 
-The agent system prompt includes a group intro on the first turn of a new group session (and after `/activation` changes). It reminds the model to respond like a human, minimize empty lines and follow normal chat spacing, and avoid typing literal `\n` sequences. Non-Telegram groups also discourage Markdown tables; Telegram rich-text guidance comes from the Telegram channel prompt. Channel-sourced group names and participant labels are rendered as fenced untrusted metadata, not inline system instructions.
+The agent system prompt includes a group intro on the first turn of a new group session (and after `/activation` changes). It reminds the model to respond like a human, minimize empty lines and follow normal chat spacing, and avoid typing literal `\n` sequences. Channels whose declared table mode does not preserve native or raw tables also discourage Markdown tables. Channel-sourced group names and participant labels are rendered as fenced untrusted metadata, not inline system instructions.
 
 ## iMessage specifics
 

--- a/extensions/discord/src/group-policy.ts
+++ b/extensions/discord/src/group-policy.ts
@@ -3,6 +3,7 @@ import type { ChannelGroupContext } from "openclaw/plugin-sdk/channel-contract";
 import {
   resolveScopeRequireMention,
   resolveScopeToolsPolicy,
+  scopeKey,
   type GroupToolPolicyConfig,
   type ScopeTree,
 } from "openclaw/plugin-sdk/channel-policy";
@@ -14,12 +15,10 @@ function normalizeDiscordSlug(value?: string | null) {
   return normalizeAtHashSlug(value);
 }
 
-const encodeScopeSegment = (value: string) => `${value.length}:${value}`;
-
 // Length-prefixed segments keep arbitrary config keys, including slashes, collision-free.
-const guildScopeKey = (guildKey: string) => `guild:${encodeScopeSegment(guildKey)}`;
+const guildScopeKey = (guildKey: string) => scopeKey(["guild", guildKey]);
 const channelScopeKey = (guildKey: string, channelKey: string) =>
-  `${guildScopeKey(guildKey)}/channel:${encodeScopeSegment(channelKey)}`;
+  scopeKey(["guild", guildKey], ["channel", channelKey]);
 
 function resolveDiscordGuildKey(
   guilds: DiscordConfig["guilds"],

--- a/extensions/googlechat/src/group-policy.ts
+++ b/extensions/googlechat/src/group-policy.ts
@@ -1,17 +1,28 @@
 import {
   buildChannelGroupsScopeTree,
   resolveScopeRequireMention,
+  type ScopeTree,
 } from "openclaw/plugin-sdk/channel-policy";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/core";
 
 type GroupContext = { cfg: OpenClawConfig; accountId?: string | null; groupId?: string | null };
-function resolveScopePath(params: GroupContext) {
-  return params.groupId ? [params.groupId] : [];
+
+export function buildGoogleChatGroupPolicyScope(params: {
+  tree: ScopeTree;
+  groupId?: string | null;
+}) {
+  const matchKey =
+    params.groupId && Object.hasOwn(params.tree.scopes, params.groupId)
+      ? params.groupId
+      : undefined;
+  return { tree: params.tree, path: matchKey ? [matchKey] : [], matchKey };
 }
 
 export function resolveGoogleChatGroupRequireMention(params: GroupContext): boolean {
-  return resolveScopeRequireMention({
-    tree: buildChannelGroupsScopeTree(params.cfg, "googlechat", params.accountId),
-    path: resolveScopePath(params),
-  });
+  return resolveScopeRequireMention(
+    buildGoogleChatGroupPolicyScope({
+      tree: buildChannelGroupsScopeTree(params.cfg, "googlechat", params.accountId),
+      groupId: params.groupId,
+    }),
+  );
 }

--- a/extensions/googlechat/src/monitor-access.ts
+++ b/extensions/googlechat/src/monitor-access.ts
@@ -21,6 +21,7 @@ import {
 } from "../runtime-api.js";
 import type { ResolvedGoogleChatAccount } from "./accounts.js";
 import { sendGoogleChatMessage } from "./api.js";
+import { buildGoogleChatGroupPolicyScope } from "./group-policy.js";
 import type { GoogleChatCoreRuntime } from "./monitor-types.js";
 import type { GoogleChatAnnotation, GoogleChatMessage, GoogleChatSpace } from "./types.js";
 
@@ -100,8 +101,15 @@ function resolveGoogleChatGroupConfig(params: {
   if (keys.length === 0) {
     return { entry: undefined, allowlistConfigured: false, deprecatedNameMatch: false };
   }
-  const entry = entries[groupId];
+  const { "*": fallback, ...scopes } = entries;
+  const scope = buildGoogleChatGroupPolicyScope({
+    tree: { defaults: fallback, scopes },
+    groupId,
+  });
+  const entry = scope.matchKey ? entries[scope.matchKey] : undefined;
   const normalizedGroupName = normalizeLowercaseStringOrEmpty(groupName ?? "");
+  // Mutable display-name keys deliberately block wildcard selection when no stable id matches.
+  // The canonical scope owns exact/wildcard lookup; this monitor-only guard owns deprecation.
   const deprecatedNameMatch =
     !entry &&
     Boolean(
@@ -116,7 +124,6 @@ function resolveGoogleChatGroupConfig(params: {
         );
       }),
     );
-  const fallback = entries["*"];
   return {
     entry: deprecatedNameMatch ? undefined : (entry ?? fallback),
     allowlistConfigured: true,

--- a/extensions/imessage/src/monitor/inbound-processing.systemPrompt.test.ts
+++ b/extensions/imessage/src/monitor/inbound-processing.systemPrompt.test.ts
@@ -141,6 +141,7 @@ describe("resolveIMessageInboundDecision per-group systemPrompt", () => {
           "*": { systemPrompt: "Wildcard." },
           "7": { requireMention: true },
         }),
+        opts: { requireMention: false },
       }),
     );
     expect(decision.kind).toBe("dispatch");
@@ -148,6 +149,7 @@ describe("resolveIMessageInboundDecision per-group systemPrompt", () => {
       return;
     }
     expect(decision.groupSystemPrompt).toBe("Wildcard.");
+    expect(decision.groupRequireMention).toBe(false);
   });
 
   it("does not set groupSystemPrompt on true DM decisions", async () => {

--- a/extensions/imessage/src/monitor/inbound-processing.ts
+++ b/extensions/imessage/src/monitor/inbound-processing.ts
@@ -18,8 +18,9 @@ import {
   type ChannelIngressIdentityDescriptor,
 } from "openclaw/plugin-sdk/channel-ingress-runtime";
 import {
+  buildChannelGroupsScopeTree,
   resolveChannelGroupPolicy,
-  resolveChannelGroupRequireMention,
+  resolveScopeRequireMention,
 } from "openclaw/plugin-sdk/channel-policy";
 import { hasControlCommand } from "openclaw/plugin-sdk/command-auth-native";
 import type { DmPolicy, GroupPolicy, OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
@@ -777,11 +778,9 @@ export async function resolveIMessageInboundDecision(params: {
     : undefined;
 
   const mentioned = isGroup ? matchesMentionPatterns(messageText, mentionRegexes) : true;
-  const requireMention = resolveChannelGroupRequireMention({
-    cfg: params.cfg,
-    channel: "imessage",
-    accountId: params.accountId,
-    groupId,
+  const requireMention = resolveScopeRequireMention({
+    tree: buildChannelGroupsScopeTree(params.cfg, "imessage", params.accountId),
+    path: groupId ? [groupId] : [],
     requireMentionOverride: params.opts?.requireMention,
     overrideOrder: "before-config",
   });

--- a/extensions/msteams/src/policy.ts
+++ b/extensions/msteams/src/policy.ts
@@ -1,5 +1,9 @@
 // Msteams plugin module implements policy behavior.
-import { resolveScopeToolsPolicy, type ScopeTree } from "openclaw/plugin-sdk/channel-policy";
+import {
+  resolveScopeToolsPolicy,
+  scopeKey,
+  type ScopeTree,
+} from "openclaw/plugin-sdk/channel-policy";
 import type {
   AllowlistMatch,
   ChannelGroupContext,
@@ -28,12 +32,10 @@ type MSTeamsResolvedRouteConfig = {
   channelMatchSource?: "direct" | "wildcard";
 };
 
-const encodeScopeSegment = (value: string) => `${value.length}:${value}`;
-
 // Length-prefixed segments keep arbitrary config keys, including slashes, collision-free.
-const teamScopeKey = (teamKey: string) => `team:${encodeScopeSegment(teamKey)}`;
+const teamScopeKey = (teamKey: string) => scopeKey(["team", teamKey]);
 const channelScopeKey = (teamKey: string, channelKey: string) =>
-  `${teamScopeKey(teamKey)}/channel:${encodeScopeSegment(channelKey)}`;
+  scopeKey(["team", teamKey], ["channel", channelKey]);
 
 function buildMSTeamsToolPolicyTree(teams: MSTeamsConfig["teams"]): ScopeTree {
   const scopes: ScopeTree["scopes"] = {};

--- a/extensions/qqbot/src/engine/config/group.ts
+++ b/extensions/qqbot/src/engine/config/group.ts
@@ -1,4 +1,5 @@
 // Qqbot plugin module implements group behavior.
+import { resolveScopeRequireMention, type ScopeTree } from "openclaw/plugin-sdk/channel-policy";
 import { asBoolean } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { asOptionalObjectRecord as asRecord } from "../utils/string-normalize.js";
 import { resolveAccountBase } from "./resolve.js";
@@ -81,18 +82,32 @@ export function resolveGroupConfig(
 ): GroupConfig {
   const account = resolveAccountBase(cfg, accountId);
   const groups = readGroupsMap(cfg, accountId);
-  const wildcard = groups["*"] ?? {};
+  const { "*": wildcard = {}, ...scopes } = groups;
   const specific = groupOpenid ? (groups[groupOpenid] ?? {}) : {};
 
   // 账户级默认值：defaultRequireMention 配置 > 默认 true
-  const accountDefaultRequireMention =
-    asBoolean(account.config.defaultRequireMention) ?? DEFAULT_GROUP_CONFIG.requireMention;
+  const accountDefaultRequireMention = asBoolean(account.config.defaultRequireMention);
+  const mentionTree: ScopeTree = {
+    defaults: { requireMention: readBoolean(wildcard, "requireMention") },
+    scopes: Object.fromEntries(
+      Object.entries(scopes).map(([key, entry]) => [
+        key,
+        { requireMention: readBoolean(entry, "requireMention") },
+      ]),
+    ),
+  };
+  // Engine mention matching stays exact and case-sensitive. QQBot's tool-policy
+  // adapter is intentionally case-insensitive, so these paths remain asymmetric.
+  const mentionPath =
+    groupOpenid && Object.hasOwn(mentionTree.scopes, groupOpenid) ? [groupOpenid] : [];
 
   return {
-    requireMention:
-      readBoolean(specific, "requireMention") ??
-      readBoolean(wildcard, "requireMention") ??
-      accountDefaultRequireMention,
+    requireMention: resolveScopeRequireMention({
+      tree: mentionTree,
+      path: mentionPath,
+      requireMentionOverride: accountDefaultRequireMention,
+      overrideOrder: "after-config",
+    }),
     ignoreOtherMentions:
       readBoolean(specific, "ignoreOtherMentions") ??
       readBoolean(wildcard, "ignoreOtherMentions") ??

--- a/extensions/slack/src/group-policy.ts
+++ b/extensions/slack/src/group-policy.ts
@@ -6,6 +6,7 @@ import {
   resolveScopeToolsPolicy,
   type GroupToolPolicyBySenderConfig,
   type GroupToolPolicyConfig,
+  type ScopeNode,
   type ScopeTree,
 } from "openclaw/plugin-sdk/channel-policy";
 import { normalizeHyphenSlug } from "openclaw/plugin-sdk/string-normalization-runtime";
@@ -17,16 +18,37 @@ type SlackChannelPolicyEntry = {
   toolsBySender?: GroupToolPolicyBySenderConfig;
 };
 
-function resolveSlackChannelPolicyScope(params: ChannelGroupContext) {
+export function buildSlackChannelPolicyScope<T extends ScopeNode>(params: {
+  channels?: Record<string, T>;
+  candidates: readonly string[];
+}) {
+  // Whole-entry selection: an exact channel hides every wildcard field.
+  // The wildcard is a normal scope selected only after all candidates miss.
+  const channels: Record<string, T> = params.channels ?? {};
+  const tree: ScopeTree = { scopes: channels };
+  const matchKey =
+    params.candidates.find(
+      (candidate) => candidate !== "*" && Object.hasOwn(tree.scopes, candidate),
+    ) ?? (Object.hasOwn(tree.scopes, "*") ? "*" : undefined);
+  const matchSource: "direct" | "wildcard" | undefined =
+    matchKey === undefined ? undefined : matchKey === "*" ? "wildcard" : "direct";
+  return {
+    tree,
+    path: matchKey ? [matchKey] : [],
+    entry: matchKey ? channels[matchKey] : undefined,
+    wildcardEntry: channels["*"],
+    matchKey,
+    matchSource,
+  };
+}
+
+function resolveSlackGroupPolicyScope(params: ChannelGroupContext) {
   const accountId = normalizeAccountId(
     params.accountId ?? resolveDefaultSlackAccountId(params.cfg),
   );
   const channels = mergeSlackAccountConfig(params.cfg, accountId).channels as
     | Record<string, SlackChannelPolicyEntry>
     | undefined;
-  // Whole-entry selection: an exact channel hides every wildcard field.
-  // The wildcard is a normal scope selected only after all candidates miss.
-  const tree: ScopeTree = { scopes: channels ?? {} };
   const channelId = params.groupId?.trim();
   const channelName = params.groupChannel?.replace(/^#/, "");
   const candidates = [
@@ -35,21 +57,18 @@ function resolveSlackChannelPolicyScope(params: ChannelGroupContext) {
     channelName,
     normalizeHyphenSlug(channelName),
   ].filter((candidate): candidate is string => Boolean(candidate));
-  const key =
-    candidates.find((candidate) => Object.hasOwn(tree.scopes, candidate)) ??
-    (Object.hasOwn(tree.scopes, "*") ? "*" : undefined);
-  return { tree, path: key ? [key] : [] };
+  return buildSlackChannelPolicyScope({ channels, candidates });
 }
 
 export function resolveSlackGroupRequireMention(params: ChannelGroupContext): boolean {
   // The adapter intentionally ignores root requireMention; the monitor resolves that default.
-  return resolveScopeRequireMention(resolveSlackChannelPolicyScope(params));
+  return resolveScopeRequireMention(resolveSlackGroupPolicyScope(params));
 }
 
 export function resolveSlackGroupToolPolicy(
   params: ChannelGroupContext,
 ): GroupToolPolicyConfig | undefined {
-  const scope = resolveSlackChannelPolicyScope(params);
+  const scope = resolveSlackGroupPolicyScope(params);
   // No messageProvider: this path historically never matched channel-prefixed sender keys.
   return resolveScopeToolsPolicy({
     ...scope,

--- a/extensions/slack/src/monitor/channel-config.ts
+++ b/extensions/slack/src/monitor/channel-config.ts
@@ -2,7 +2,6 @@
 import {
   applyChannelMatchMeta,
   buildChannelKeyCandidates,
-  resolveChannelEntryMatchWithFallback,
   type ChannelMatchSource,
 } from "openclaw/plugin-sdk/channel-targets";
 import type {
@@ -11,6 +10,7 @@ import type {
 } from "openclaw/plugin-sdk/config-contracts";
 import { mergePairLoopGuardConfig } from "openclaw/plugin-sdk/pair-loop-guard-runtime";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { buildSlackChannelPolicyScope } from "../group-policy.js";
 import { normalizeSlackSlug } from "./allow-list.js";
 
 export type SlackChannelConfigResolved = {
@@ -100,13 +100,10 @@ export function resolveSlackChannelConfig(params: {
     allowNameMatching ? directName : undefined,
     allowNameMatching ? normalizedName : undefined,
   );
-  const match = resolveChannelEntryMatchWithFallback({
-    entries,
-    keys: candidates,
-    wildcardKey: "*",
-  });
+  const match = buildSlackChannelPolicyScope({ channels: entries, candidates });
   const { entry: matched, wildcardEntry: fallback } = match;
 
+  // The monitor honors root channels.slack.requireMention; the adapter deliberately ignores it.
   const requireMentionDefault = defaultRequireMention ?? true;
   if (keys.length === 0) {
     return { allowed: true, requireMention: requireMentionDefault };

--- a/extensions/telegram/src/bot-core.ts
+++ b/extensions/telegram/src/bot-core.ts
@@ -1,7 +1,8 @@
 // Telegram plugin module implements bot core behavior.
 import {
+  buildChannelGroupsScopeTree,
   resolveChannelGroupPolicy,
-  resolveChannelGroupRequireMention,
+  resolveScopeRequireMention,
 } from "openclaw/plugin-sdk/channel-policy";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import {
@@ -329,11 +330,9 @@ export function createTelegramBotCore(
     return undefined;
   };
   const resolveGroupRequireMention = (chatId: string | number, turnCfg: OpenClawConfig) =>
-    resolveChannelGroupRequireMention({
-      cfg: turnCfg,
-      channel: "telegram",
-      accountId: account.accountId,
-      groupId: String(chatId),
+    resolveScopeRequireMention({
+      tree: buildChannelGroupsScopeTree(turnCfg, "telegram", account.accountId),
+      path: [String(chatId)],
       requireMentionOverride: opts.requireMention,
       overrideOrder: "after-config",
     });

--- a/extensions/telegram/src/bot-message-context.ts
+++ b/extensions/telegram/src/bot-message-context.ts
@@ -425,6 +425,8 @@ export const buildTelegramMessageContext = async ({
     cfg,
   });
   const baseRequireMention = resolveGroupRequireMention(chatId, cfg);
+  // Persisted session activation intentionally interleaves topic and group config.
+  // ScopeTree resolves config only, so this precedence remains session-owned here.
   const groupRequireMention = firstDefined(
     topicConfig?.requireMention,
     activationOverride,

--- a/extensions/telegram/src/bot.create-telegram-bot.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test.ts
@@ -3979,12 +3979,13 @@ describe("createTelegramBot", () => {
           telegram: {
             groupPolicy: "open",
             groups: {
-              "*": { requireMention: true },
-              "123": { requireMention: false },
+              "*": { requireMention: false },
+              "123": {},
             },
           },
         },
       },
+      botRequireMention: true,
       message: {
         chat: { id: 123, type: "group", title: "Dev Chat" },
         text: "hello",
@@ -4000,6 +4001,7 @@ describe("createTelegramBot", () => {
           },
         },
       },
+      botRequireMention: undefined,
       message: {
         chat: { id: 456, type: "group", title: "Ops" },
         text: "hello",
@@ -4015,6 +4017,7 @@ describe("createTelegramBot", () => {
           },
         },
       },
+      botRequireMention: undefined,
       message: {
         chat: { id: 789, type: "group", title: "No Me" },
         text: "hello",
@@ -4028,6 +4031,7 @@ describe("createTelegramBot", () => {
     await dispatchMessage({
       message: testCase.message,
       me: testCase.me,
+      botRequireMention: testCase.botRequireMention,
     });
     expect(replySpy).toHaveBeenCalledTimes(1);
   });
@@ -4265,15 +4269,19 @@ describe("createTelegramBot", () => {
     setMessageReactionSpy.mockClear();
     setMyCommandsSpy.mockClear();
   }
-  function getMessageHandler() {
-    createTelegramBot({ token: "tok" });
+  function getMessageHandler(botRequireMention?: boolean) {
+    createTelegramBot({
+      token: "tok",
+      ...(typeof botRequireMention === "boolean" ? { requireMention: botRequireMention } : {}),
+    });
     return getOnHandler("message") as (ctx: Record<string, unknown>) => Promise<void>;
   }
   async function dispatchMessage(params: {
     message: Record<string, unknown>;
     me?: Record<string, unknown>;
+    botRequireMention?: boolean;
   }) {
-    const handler = getMessageHandler();
+    const handler = getMessageHandler(params.botRequireMention);
     await handler({
       message: params.message,
       me: params.me ?? { username: "openclaw_bot" },

--- a/extensions/telegram/src/group-config-helpers.ts
+++ b/extensions/telegram/src/group-config-helpers.ts
@@ -1,3 +1,4 @@
+import type { ScopeTree } from "openclaw/plugin-sdk/channel-policy";
 // Telegram helper module supports group config helpers behavior.
 import type {
   TelegramAccountConfig,
@@ -27,7 +28,16 @@ export function resolveTelegramScopedGroupConfig(
   };
   const chatIdStr = String(chatId);
   const scopedConfigs = chatIdStr.startsWith("-") ? telegramCfg.groups : telegramCfg.direct;
-  const groupConfig = scopedConfigs?.[chatIdStr] ?? scopedConfigs?.["*"];
+  // Whole-entry selection: an exact chat hides every wildcard field.
+  const tree = { scopes: scopedConfigs ?? {} } as ScopeTree;
+  const groupKey = Object.hasOwn(tree.scopes, chatIdStr)
+    ? chatIdStr
+    : Object.hasOwn(tree.scopes, "*")
+      ? "*"
+      : undefined;
+  const path = groupKey ? [groupKey] : [];
+  const matchKey = path[0];
+  const groupConfig = matchKey ? scopedConfigs?.[matchKey] : undefined;
   const topicConfig = resolveTopicConfig(groupConfig);
   return { groupConfig, topicConfig };
 }

--- a/extensions/telegram/src/group-policy.ts
+++ b/extensions/telegram/src/group-policy.ts
@@ -4,6 +4,7 @@ import {
   resolveChannelGroupRequireMention,
   resolveScopeRequireMention,
   resolveScopeToolsPolicy,
+  scopeKey,
   type GroupToolPolicyConfig,
   type ScopeTree,
 } from "openclaw/plugin-sdk/channel-policy";
@@ -47,10 +48,9 @@ function parseTelegramGroupId(value?: string | null) {
   return { chatId: raw, topicId: undefined };
 }
 
-const encodeScopeSegment = (value: string) => `${value.length}:${value}`;
-const groupScopeKey = (groupKey: string) => `group:${encodeScopeSegment(groupKey)}`;
+const groupScopeKey = (groupKey: string) => scopeKey(["group", groupKey]);
 const topicScopeKey = (groupKey: string, topicKey: string) =>
-  `${groupScopeKey(groupKey)}/topic:${encodeScopeSegment(topicKey)}`;
+  scopeKey(["group", groupKey], ["topic", topicKey]);
 
 function resolveTelegramRequireMention(params: {
   cfg: ChannelGroupContext["cfg"];

--- a/extensions/zalouser/src/group-policy.ts
+++ b/extensions/zalouser/src/group-policy.ts
@@ -65,8 +65,8 @@ export function resolveZalouserGroupScope(
   candidates: string[],
 ) {
   // Whole-entry selection: an exact candidate hides every wildcard field.
-  // Callers opt into the wildcard by including "*" in candidates
-  // (buildZalouserGroupCandidates honors includeWildcard: false).
+  // Candidate construction owns aliases, names, and wildcard opt-in; the monitor
+  // requests group:<id>, groupName, and "*" through buildZalouserGroupCandidates.
   const tree: ScopeTree = { scopes: groups ?? {} };
   const key =
     candidates.find((candidate) => candidate !== "*" && Object.hasOwn(tree.scopes, candidate)) ??

--- a/scripts/plugin-sdk-surface-report.mjs
+++ b/scripts/plugin-sdk-surface-report.mjs
@@ -135,7 +135,8 @@ const defaultPublicDeprecatedExportsByEntrypointBudget = Object.freeze({
   types: 6,
   "agent-config-primitives": 2,
   "command-auth": 81,
-  compat: 160,
+  // +2: group scope encoder/key builder mirrored by deprecated compat.
+  compat: 162,
   "direct-dm": 9,
   "direct-dm-access": 5,
   discord: 48,
@@ -205,6 +206,7 @@ export function readPluginSdkSurfaceBudgets(env = process.env) {
     // ScopeTree adds six channel-policy exports, mirrored by compat, including three functions.
     // Its flat channel-groups builder adds one function, also mirrored by compat.
     // Its case-insensitive scope-key resolver adds one function, also mirrored by compat.
+    // Its length-prefixed segment encoder and scope-key builder add two functions, also mirrored.
     // The focused HTML entity runtime and quote-aware HTML tokenizer add one public function each.
     // Plugin service Gateway event scope and emitter types add four facade exports.
     publicExports: readPluginSdkSurfaceBudgetEnv(
@@ -212,18 +214,21 @@ export function readPluginSdkSurfaceBudgets(env = process.env) {
       // +4: registerMcpServerConnectionResolver context/result/resolver/registration types (#106229).
       // +2: materializeRequesterScopedMcpToolsForHarnessRun (agent-harness-runtime + compat mirror).
       // +1: matchesNoProxy exposes canonical Undici-compatible bypass selection to plugins.
-      10695,
+      // +4: group scope encoder/key builder (channel-policy + compat mirror).
+      10699,
       env,
     ),
     publicFunctionExports: readPluginSdkSurfaceBudgetEnv(
       "OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_FUNCTION_EXPORTS",
       // +2: materializeRequesterScopedMcpToolsForHarnessRun (agent-harness-runtime + compat mirror).
-      5382,
+      // +4: group scope encoder/key builder (channel-policy + compat mirror).
+      5386,
       env,
     ),
     publicDeprecatedExports: readPluginSdkSurfaceBudgetEnv(
       "OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_DEPRECATED_EXPORTS",
-      3292,
+      // +2: group scope encoder/key builder mirrored by deprecated compat.
+      3294,
       env,
     ),
     publicWildcardReexports: readPluginSdkSurfaceBudgetEnv(

--- a/src/agents/subagent-announce-delivery.ts
+++ b/src/agents/subagent-announce-delivery.ts
@@ -173,21 +173,6 @@ function resolveBoundConversationOrigin(params: {
   const parentConversationId = conversation.parentConversationId?.trim() ?? "";
   const requesterConversationId = params.requesterConversation?.conversationId?.trim() ?? "";
   const requesterTo = params.requesterOrigin?.to?.trim();
-  if (
-    conversation.channel === "matrix" &&
-    parentConversationId &&
-    requesterConversationId &&
-    parentConversationId === requesterConversationId &&
-    requesterTo
-  ) {
-    return {
-      channel: conversation.channel,
-      accountId: conversation.accountId,
-      to: requesterTo,
-      ...(conversationId ? { threadId: conversationId } : {}),
-    };
-  }
-
   const boundTarget = routeToDeliveryFields(routeFromConversationRef(conversation));
   const inferredThreadId =
     boundTarget.threadId ??

--- a/src/agents/subagent-announce.format.e2e.test.ts
+++ b/src/agents/subagent-announce.format.e2e.test.ts
@@ -247,7 +247,18 @@ const announceFormatChannelPlugins = [
   },
   {
     pluginId: "matrix",
-    plugin: createChannelTestPluginBase({ id: "matrix", label: "Matrix" }),
+    plugin: {
+      ...createChannelTestPluginBase({ id: "matrix", label: "Matrix" }),
+      messaging: {
+        resolveDeliveryTarget: (params: {
+          conversationId: string;
+          parentConversationId?: string;
+        }) => ({
+          to: `room:${params.parentConversationId ?? params.conversationId}`,
+          ...(params.parentConversationId ? { threadId: params.conversationId } : {}),
+        }),
+      },
+    },
     source: "test",
   },
   {

--- a/src/auto-reply/reply/commands-private-route.test.ts
+++ b/src/auto-reply/reply/commands-private-route.test.ts
@@ -65,6 +65,7 @@ function createOwnerDerivedApprovalChannelPlugin(params: {
       id: params.id,
       label: params.id,
     }),
+    messaging: { targetPrefixes: params.ownerPrefixes },
     approvalCapability: {
       native: {
         describeDeliveryCapabilities: vi.fn(({ cfg }) => {
@@ -267,7 +268,7 @@ describe("resolvePrivateCommandRouteTargets", () => {
     ]);
   });
 
-  it("routes a Discord group command to the Telegram owner without Telegram exec approvers", async () => {
+  it("routes a Discord group command through Telegram's declared tg owner prefix", async () => {
     registerApprovalChannelPlugins([
       createApprovalChannelPlugin({
         id: "discord",
@@ -282,7 +283,7 @@ describe("resolvePrivateCommandRouteTargets", () => {
     const targets = await resolvePrivateCommandRouteTargets({
       commandParams: buildCommandParams({
         commands: {
-          ownerAllowFrom: ["telegram:849985193"],
+          ownerAllowFrom: ["tg:849985193"],
         },
         channels: {
           telegram: {

--- a/src/auto-reply/reply/commands-private-route.ts
+++ b/src/auto-reply/reply/commands-private-route.ts
@@ -200,8 +200,11 @@ function buildPrivateCommandRouteOwnerKeys(target: PrivateCommandRouteTarget): S
   }
   if (channel && to) {
     keys.add(`${channel}:${to}`);
-    if (channel === "telegram") {
-      keys.add(`tg:${to}`);
+    for (const prefix of getLoadedChannelPlugin(channel)?.messaging?.targetPrefixes ?? []) {
+      const normalizedPrefix = normalizeLowercaseStringOrEmpty(prefix);
+      if (normalizedPrefix) {
+        keys.add(`${normalizedPrefix}:${to}`);
+      }
     }
   }
   return keys;

--- a/src/auto-reply/reply/dispatch-from-config.context.ts
+++ b/src/auto-reply/reply/dispatch-from-config.context.ts
@@ -11,6 +11,7 @@ import type { FinalizedMsgContext } from "../templating.js";
 import { resolveConversationBindingContextFromMessage } from "./conversation-binding-input.js";
 import { loadSessionStoreEntry, resolveStorePath } from "./dispatch-from-config.runtime.js";
 import type { ReplyOperation } from "./reply-run-registry.js";
+import { isSlackDirectRoutedThreadTurn } from "./routed-delivery-thread.js";
 
 function routeThreadIdsDiffer(
   left: string | number | undefined,
@@ -20,28 +21,6 @@ function routeThreadIdsDiffer(
     return false;
   }
   return String(left) !== String(right);
-}
-
-function isSlackDirectRoutedThreadTurn(
-  ctx: Pick<
-    FinalizedMsgContext,
-    | "ChatType"
-    | "MessageThreadId"
-    | "OriginatingChannel"
-    | "Provider"
-    | "Surface"
-    | "TransportThreadId"
-  >,
-): boolean {
-  if (normalizeChatType(ctx.ChatType) !== "direct") {
-    return false;
-  }
-  if (ctx.MessageThreadId == null && ctx.TransportThreadId == null) {
-    return false;
-  }
-  return [ctx.Provider, ctx.Surface, ctx.OriginatingChannel].some(
-    (value) => normalizeOptionalString(value)?.toLowerCase() === "slack",
-  );
 }
 
 export function shouldLetSlackRoutedThreadBypassBusyReplyOperation(params: {

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -118,7 +118,10 @@ import {
 } from "./reply-run-registry.js";
 import { resolveReplyToMode } from "./reply-threading.js";
 import { admitReplyTurn } from "./reply-turn-admission.js";
-import { resolveRoutedDeliveryThreadId } from "./routed-delivery-thread.js";
+import {
+  isSlackDirectRoutedThreadTurn,
+  resolveRoutedDeliveryThreadId,
+} from "./routed-delivery-thread.js";
 import { resolveRuntimePolicySessionKey } from "./runtime-policy-session-key.js";
 import type { ReplySessionEntryHandle } from "./session-entry-handle.js";
 import { resolveBareSessionResetPromptState } from "./session-reset-prompt.js";
@@ -226,18 +229,6 @@ async function updateRoomEventAmbientTranscriptWatermark(params: {
     timestampMs: params.sessionCtx.AmbientTranscriptTimestampMs,
     expectedSessionId: params.expectedSessionId,
   });
-}
-
-function isSlackDirectRoutedThreadTurn(ctx: MsgContext): boolean {
-  if (normalizeChatType(ctx.ChatType) !== "direct") {
-    return false;
-  }
-  if (ctx.MessageThreadId == null && ctx.TransportThreadId == null) {
-    return false;
-  }
-  return [ctx.Provider, ctx.Surface, ctx.OriginatingChannel].some(
-    (value) => normalizeOptionalString(value)?.toLowerCase() === "slack",
-  );
 }
 
 function resolvePromptSilentReplyConversationType(params: {

--- a/src/auto-reply/reply/groups.test.ts
+++ b/src/auto-reply/reply/groups.test.ts
@@ -1,7 +1,11 @@
 // Tests group prompt helpers and lazy runtime loading for group metadata.
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
-import { resetPluginRuntimeStateForTest } from "../../plugins/runtime.js";
+import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../../plugins/runtime.js";
+import {
+  createChannelTestPluginBase,
+  createTestRegistry,
+} from "../../test-utils/channel-plugins.js";
 import * as groups from "./groups.js";
 
 describe("group runtime loading", () => {
@@ -75,13 +79,6 @@ describe("group runtime loading", () => {
     expect(channelToolOnlyContext).toContain("posted to this channel");
     expect(channelToolOnlyContext).not.toContain("visible group response");
     expect(channelToolOnlyContext).not.toContain("posted to the group");
-    const telegramContext = isolatedGroups.buildGroupChatContext({
-      sessionCtx: { ChatType: "group", Provider: "telegram" },
-      silentReplyPolicy: "allow",
-      silentToken: "NO_REPLY",
-    });
-    expect(telegramContext).toContain("Write like a human. Minimize empty lines");
-    expect(telegramContext).not.toContain("Avoid Markdown tables");
     expect(
       isolatedGroups.buildGroupIntro({
         defaultActivation: "mention",
@@ -119,6 +116,39 @@ describe("group runtime loading", () => {
     expect(toolOnlyContext).toContain("do not call message(action=send)");
     expect(toolOnlyContext).not.toContain("NO_REPLY");
     expect(toolOnlyContext).not.toContain("Your replies are automatically sent");
+  });
+
+  it("reads markdown table guidance from channel metadata", () => {
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "table-chat",
+          source: "test",
+          plugin: {
+            ...createChannelTestPluginBase({ id: "table-chat" }),
+            messaging: { defaultMarkdownTableMode: "off" },
+          },
+        },
+        {
+          pluginId: "telegram",
+          source: "test",
+          plugin: {
+            ...createChannelTestPluginBase({ id: "telegram" }),
+            messaging: { defaultMarkdownTableMode: "block" },
+          },
+        },
+      ]),
+    );
+
+    expect(groups.buildGroupChatContext({ sessionCtx: { Provider: "table-chat" } })).not.toContain(
+      "Avoid Markdown tables",
+    );
+    expect(groups.buildGroupChatContext({ sessionCtx: { Provider: "telegram" } })).not.toContain(
+      "Avoid Markdown tables",
+    );
+    expect(groups.buildGroupChatContext({ sessionCtx: { Provider: "plain-chat" } })).toContain(
+      "Avoid Markdown tables",
+    );
   });
 
   it("gates group silent-token instructions on the resolved silent reply policy", () => {
@@ -218,7 +248,7 @@ describe("group runtime loading", () => {
     ).toBe(false);
   });
 
-  it("resolves requireMention through runtime and Discord fallback paths", async () => {
+  it("resolves requireMention through runtime and generic fallback paths", async () => {
     vi.resetModules();
     const groupsRuntimeLoads = vi.fn();
     vi.doMock("./groups.runtime.js", () => {
@@ -250,72 +280,6 @@ describe("group runtime loading", () => {
           key: "slack:group:C123",
           channel: "slack",
           id: "C123",
-          chatType: "group",
-        },
-      }),
-    ).resolves.toBe(false);
-    expect(groupsRuntimeLoads).toHaveBeenCalledTimes(1);
-
-    await expect(
-      isolatedGroups.resolveGroupRequireMention({
-        cfg: {
-          channels: {
-            discord: {
-              guilds: {
-                G1: {
-                  requireMention: true,
-                  channels: {
-                    C1: { requireMention: false },
-                  },
-                },
-              },
-            },
-          },
-        } as unknown as OpenClawConfig,
-        ctx: {
-          Provider: "discord",
-          From: "discord:channel:C1",
-          GroupSpace: "G1",
-          GroupChannel: "general",
-        },
-        groupResolution: {
-          key: "discord:channel:C1",
-          channel: "discord",
-          id: "C1",
-          chatType: "group",
-        },
-      }),
-    ).resolves.toBe(false);
-
-    await expect(
-      isolatedGroups.resolveGroupRequireMention({
-        cfg: {
-          channels: {
-            discord: {
-              guilds: {
-                G1: { requireMention: true },
-              },
-              accounts: {
-                work: {
-                  guilds: {
-                    G1: { requireMention: false },
-                  },
-                },
-              },
-            },
-          },
-        } as unknown as OpenClawConfig,
-        ctx: {
-          Provider: "discord",
-          From: "discord:channel:C1",
-          GroupSpace: "G1",
-          GroupChannel: "general",
-          AccountId: "work",
-        },
-        groupResolution: {
-          key: "discord:channel:C1",
-          channel: "discord",
-          id: "C1",
           chatType: "group",
         },
       }),

--- a/src/auto-reply/reply/groups.ts
+++ b/src/auto-reply/reply/groups.ts
@@ -3,6 +3,8 @@ import {
   normalizeOptionalLowercaseString,
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
+import { getLoadedChannelPluginForRead } from "../../channels/plugins/registry-loaded.js";
+import { findChatChannelMeta, normalizeChatChannelId } from "../../channels/registry.js";
 import { resolveChannelGroupRequireMention } from "../../config/group-policy.js";
 import type { GroupKeyResolution, SessionEntry } from "../../config/sessions.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -15,17 +17,6 @@ import type { TemplateContext } from "../templating.js";
 import { extractExplicitGroupId } from "./group-id.js";
 
 const groupsRuntimeLoader = createLazyImportLoader(() => import("./groups.runtime.js"));
-
-type DiscordGroupConfig = {
-  requireMention?: boolean;
-  slug?: string;
-  channels?: Record<string, DiscordGroupConfig>;
-};
-
-type DiscordConfigWithGuilds = {
-  accounts?: Record<string, { guilds?: Record<string, DiscordGroupConfig> }>;
-  guilds?: Record<string, DiscordGroupConfig>;
-};
 
 function loadGroupsRuntime() {
   return groupsRuntimeLoader.load();
@@ -49,99 +40,6 @@ async function resolveRuntimeChannelId(raw?: string | null): Promise<string | nu
   } catch {
     return normalized;
   }
-}
-
-function normalizeDiscordSlug(value?: string | null) {
-  const normalized = normalizeOptionalLowercaseString(value);
-  if (!normalized) {
-    return "";
-  }
-  return normalized
-    .replace(/^#/, "")
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "");
-}
-
-function resolveDiscordGuilds(
-  cfg: OpenClawConfig,
-  accountId?: string | null,
-): Record<string, DiscordGroupConfig> | undefined {
-  const discord = cfg.channels?.discord as DiscordConfigWithGuilds | undefined;
-  if (!discord) {
-    return undefined;
-  }
-  const normalizedAccountId = normalizeOptionalString(accountId);
-  const accountGuilds = normalizedAccountId
-    ? discord.accounts?.[normalizedAccountId]?.guilds
-    : undefined;
-  return accountGuilds ?? discord.guilds;
-}
-
-function resolveDiscordGuildEntry(
-  guilds: Record<string, DiscordGroupConfig> | undefined,
-  groupSpace?: string | null,
-): DiscordGroupConfig | undefined {
-  if (!guilds || Object.keys(guilds).length === 0) {
-    return undefined;
-  }
-  const space = normalizeOptionalString(groupSpace) ?? "";
-  if (space && guilds[space]) {
-    return guilds[space];
-  }
-  const slug = normalizeDiscordSlug(space);
-  if (slug && guilds[slug]) {
-    return guilds[slug];
-  }
-  if (slug) {
-    const match = Object.values(guilds).find((entry) => normalizeDiscordSlug(entry?.slug) === slug);
-    if (match) {
-      return match;
-    }
-  }
-  return guilds["*"];
-}
-
-function resolveDiscordChannelEntry(
-  channels: Record<string, DiscordGroupConfig> | undefined,
-  params: { groupId?: string | null; groupChannel?: string | null },
-): DiscordGroupConfig | undefined {
-  if (!channels || Object.keys(channels).length === 0) {
-    return undefined;
-  }
-  const groupId = normalizeOptionalString(params.groupId);
-  const groupChannel = normalizeOptionalString(params.groupChannel);
-  const channelSlug = normalizeDiscordSlug(groupChannel);
-  return (
-    (groupId ? channels[groupId] : undefined) ??
-    (channelSlug ? (channels[channelSlug] ?? channels[`#${channelSlug}`]) : undefined) ??
-    (groupChannel ? channels[groupChannel] : undefined) ??
-    channels["*"]
-  );
-}
-
-function resolveDiscordRequireMentionFallback(params: {
-  cfg: OpenClawConfig;
-  channel: string;
-  groupId?: string | null;
-  groupChannel?: string | null;
-  groupSpace?: string | null;
-  accountId?: string | null;
-}): boolean | undefined {
-  if (params.channel !== "discord") {
-    return undefined;
-  }
-  const guildEntry = resolveDiscordGuildEntry(
-    resolveDiscordGuilds(params.cfg, params.accountId),
-    params.groupSpace,
-  );
-  const channelEntry = resolveDiscordChannelEntry(guildEntry?.channels, params);
-  if (typeof channelEntry?.requireMention === "boolean") {
-    return channelEntry.requireMention;
-  }
-  if (typeof guildEntry?.requireMention === "boolean") {
-    return guildEntry.requireMention;
-  }
-  return undefined;
 }
 
 /** Resolves whether a group/channel turn requires an explicit mention. */
@@ -178,17 +76,6 @@ export async function resolveGroupRequireMention(params: {
   if (typeof requireMention === "boolean") {
     return requireMention;
   }
-  const discordRequireMention = resolveDiscordRequireMentionFallback({
-    cfg,
-    channel,
-    groupId,
-    groupChannel,
-    groupSpace,
-    accountId: ctx.AccountId,
-  });
-  if (typeof discordRequireMention === "boolean") {
-    return discordRequireMention;
-  }
   return resolveChannelGroupRequireMention({
     cfg,
     channel,
@@ -210,11 +97,8 @@ function resolveProviderLabel(rawProvider: string | undefined): string {
   if (isInternalMessageChannel(providerKey)) {
     return "WebChat";
   }
-  const labels: Record<string, string> = {
-    imessage: "iMessage",
-    whatsapp: "WhatsApp",
-  };
-  const label = labels[providerKey];
+  const channelId = normalizeChatChannelId(providerKey);
+  const label = channelId ? findChatChannelMeta(channelId)?.label : undefined;
   if (label) {
     return label;
   }
@@ -258,7 +142,10 @@ export function buildGroupChatContext(params: {
   lines.push(
     "Be a good group participant: mostly lurk and follow the conversation; reply only when directly addressed or you can add clear value. Emoji reactions are welcome when available.",
   );
-  const tableGuidance = provider === "telegram" ? "" : " Avoid Markdown tables.";
+  const channelId = normalizeChatChannelId(provider) ?? provider ?? "";
+  const tableMode = getLoadedChannelPluginForRead(channelId)?.messaging?.defaultMarkdownTableMode;
+  const tableGuidance =
+    tableMode === "block" || tableMode === "off" ? "" : " Avoid Markdown tables.";
   lines.push(
     `Write like a human.${tableGuidance} Minimize empty lines and use normal chat conventions, not document-style spacing. Don't type literal \\n sequences; use real line breaks sparingly.`,
   );

--- a/src/auto-reply/reply/routed-delivery-thread.ts
+++ b/src/auto-reply/reply/routed-delivery-thread.ts
@@ -1,6 +1,30 @@
-/** Resolves the thread id used when replies are routed through channel delivery helpers. */
+/** Routed delivery thread classification and id resolution helpers. */
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { normalizeChatType } from "../../channels/chat-type.js";
 import { parseSessionThreadInfoFast } from "../../config/sessions/thread-info.js";
 import type { MsgContext } from "../templating.js";
+
+export function isSlackDirectRoutedThreadTurn(
+  ctx: Pick<
+    MsgContext,
+    | "ChatType"
+    | "MessageThreadId"
+    | "OriginatingChannel"
+    | "Provider"
+    | "Surface"
+    | "TransportThreadId"
+  >,
+): boolean {
+  if (normalizeChatType(ctx.ChatType) !== "direct") {
+    return false;
+  }
+  if (ctx.MessageThreadId == null && ctx.TransportThreadId == null) {
+    return false;
+  }
+  return [ctx.Provider, ctx.Surface, ctx.OriginatingChannel].some(
+    (value) => normalizeOptionalString(value)?.toLowerCase() === "slack",
+  );
+}
 
 /** Prefers current inbound thread ids, falling back to persisted session thread metadata. */
 export function resolveRoutedDeliveryThreadId(params: {

--- a/src/config/group-scope-tree.ts
+++ b/src/config/group-scope-tree.ts
@@ -22,6 +22,12 @@ export type ScopeTree = {
 
 export type ScopePath = string[];
 
+export const encodeScopeSegment = (value: string) => `${value.length}:${value}`;
+
+export function scopeKey(...segments: Array<readonly [prefix: string, value: string]>): string {
+  return segments.map(([prefix, value]) => `${prefix}:${encodeScopeSegment(value)}`).join("/");
+}
+
 type ScopeToolPolicySender = Omit<Parameters<typeof resolveToolsBySender>[0], "toolsBySender">;
 
 export function buildChannelGroupsScopeTree(

--- a/src/config/group-scope-tree.ts
+++ b/src/config/group-scope-tree.ts
@@ -57,7 +57,7 @@ export function resolveScopeKeyCaseInsensitive(
   }
   const target = normalizeLowercaseStringOrEmpty(key);
   return Object.keys(tree.scopes).find(
-    (scopeKey) => normalizeLowercaseStringOrEmpty(scopeKey) === target,
+    (candidate) => normalizeLowercaseStringOrEmpty(candidate) === target,
   );
 }
 

--- a/src/plugin-sdk/channel-policy.ts
+++ b/src/plugin-sdk/channel-policy.ts
@@ -50,10 +50,12 @@ export {
 } from "../config/group-policy.js";
 export {
   buildChannelGroupsScopeTree,
+  encodeScopeSegment,
   resolveScopeIntroHint,
   resolveScopeKeyCaseInsensitive,
   resolveScopeRequireMention,
   resolveScopeToolsPolicy,
+  scopeKey,
   type ScopeNode,
   type ScopePath,
   type ScopeTree,


### PR DESCRIPTION
## What Problem This Solves

Core hardcoded channel-id literals for facts the channel plugins already declare — violations of "core stays plugin-agnostic." This is batch 1 of the purge: every site here reads existing metadata or deletes a branch made redundant by it. Net −154 lines.

## Why This Change Was Made

Verified against a fresh audit of the Phase-3 hit list (26 sites confirmed + 5 new). This batch: core's duplicated Discord guild/channel requireMention fallback deleted (`src/auto-reply/reply/groups.ts` — the plugin adapter is consulted first and resolves via the canonical ScopeTree; the sole production caller sits inside inbound processing where the transport is loaded, and the bundled-registry fallback covers the rest — this addresses the objection that blocked the same deletion earlier); the telegram Markdown-table prompt hint reads `messaging.defaultMarkdownTableMode`; channel display labels read `ChannelMeta.label`; the `tg:` alias iterates `messaging.targetPrefixes`; the matrix thread-under-parent rewrite in `subagent-announce-delivery.ts` routes through matrix's own `messaging.resolveDeliveryTarget` (e2e fixture now registers the resolver, proving the adapter path covers the deleted branch); the two identical `isSlackDirectRoutedThreadTurn` copies collapse into one.

## User Impact

None — metadata-driven behavior matches the literals, pinned by new tests (metadata table-mode both directions, `tg:` prefix key, matrix delivery e2e).

## Evidence

- Blacksmith Testbox: groups, commands-private-route, subagent-announce e2e, message-tool, group-scope-tree suites green; `check:changed` all lanes green (including `lint core` with the scopeKey shadow fix underneath).
- Review note: codex autoreview refuses this diff — the deleted legacy test block contains `silentToken: "NO_REPLY"` and the reviewer's secret scanner hits deleted lines (known limitation, same as the telegram fixture case). The deleted assertions are re-pinned generically by the new metadata-driven tests; the diff received a line-by-line manual review instead (all six sites, callers enumerated for the Discord fallback deletion, adapter-path fixture verified).
