### PR TITLE
fix(update): reject npm redacted global root paths

### DIFF
--- a/src/infra/update-global.test.ts
+++ b/src/infra/update-global.test.ts
@@ -411,6 +411,46 @@ describe("update global helpers", () => {
     });
   });
 
+  it("falls back to the running package root when npm redacts UUID-like path segments", async () => {
+    await withMockedPlatform("darwin", async () => {
+      await withTempDir({ prefix: "openclaw-update-redacted-probe-" }, async (base) => {
+        const globalRoot = path.join(base, "usr", "local", "lib", "node_modules");
+        const pkgRoot = path.join(globalRoot, "openclaw");
+        const redactedRoot = path.join(
+          base,
+          "tmp",
+          "ci-agent",
+          "***",
+          "workspace",
+          "sbx-***",
+          "nvm",
+          "versions",
+          "node",
+          "v24.14.0",
+          "lib",
+          "node_modules",
+        );
+        await fs.mkdir(pkgRoot, { recursive: true });
+
+        const runCommand = createNpmRootRunner({ defaultNpmRoot: redactedRoot });
+
+        await expect(
+          resolveGlobalInstallTarget({
+            manager: "npm",
+            runCommand,
+            timeoutMs: 1000,
+            pkgRoot,
+          }),
+        ).resolves.toEqual({
+          manager: "npm",
+          command: "npm",
+          globalRoot,
+          packageRoot: pkgRoot,
+        });
+      });
+    });
+  });
+
   it("does not infer npm ownership from path shape alone when the owning npm binary is absent", async () => {
     await withTempDir({ prefix: "openclaw-update-npm-missing-bin-" }, async (base) => {
       const brewRoot = path.join(base, "opt", "homebrew", "lib", "node_modules");

--- a/src/infra/update-global.ts
+++ b/src/infra/update-global.ts
@@ -754,7 +754,13 @@ async function resolveGlobalRoot(
     return null;
   }
   const root = res.stdout.trim();
-  return root || null;
+  if (!root || root.includes("***")) {
+    // npm >= 11 redacts UUID-like path segments in stdout to literal "***".
+    // Trusting a poisoned path creates a literal "***" directory tree and leaves
+    // the live install stale, so treat it as an unresolved probe and fall back.
+    return null;
+  }
+  return root;
 }
 
 /**


### PR DESCRIPTION
npm >= 11 redacts UUID-like path segments in stdout to literal "***". Trusting a poisoned path from "npm root -g" causes the updater to materialize a literal "***" directory tree and leaves the live install stale.

This change treats any "npm root -g" / "npm prefix -g" output that contains the redaction marker as an unresolved probe, so the existing package-root fallback is used instead.

- Added a regression test in src/infra/update-global.test.ts that verifies the fallback when npm returns a redacted path.

Fixes #107239

Co-authored-by: factory-droid[bot] <138933559+factory-droid[bot]@users.noreply.github.com>