### PR TITLE
fix(ui): reject non-decimal input in toNumber() to prevent hex/scientific notation bypass

### DIFF
--- a/ui/src/lib/format.test.ts
+++ b/ui/src/lib/format.test.ts
@@ -12,6 +12,7 @@ import {
   formatUnknownText,
   parseSessionKeyParts,
   setUiTimeFormatPreference,
+  toNumber,
   truncateText,
 } from "./format.ts";
 import { stripThinkingTags } from "./strip-thinking-tags.ts";
@@ -299,5 +300,73 @@ describe("text truncation", () => {
   it("preserves ordinary truncation behavior", () => {
     expect(clampText("abc", 2)).toBe("a…");
     expect(truncateText("abc", 2)).toEqual({ text: "ab", truncated: true, total: 3 });
+  });
+});
+
+describe("toNumber", () => {
+  it("parses positive integer strings", () => {
+    expect(toNumber("10", 0)).toBe(10);
+    expect(toNumber("1", 0)).toBe(1);
+    expect(toNumber("999", 0)).toBe(999);
+  });
+
+  it("parses negative integer strings", () => {
+    expect(toNumber("-10", 0)).toBe(-10);
+    expect(toNumber("-1", 0)).toBe(-1);
+  });
+
+  it("parses negative decimal strings", () => {
+    expect(toNumber("-3.5", 0)).toBe(-3.5);
+    expect(toNumber("-0.25", 0)).toBe(-0.25);
+  });
+
+  it("parses zero", () => {
+    expect(toNumber("0", -1)).toBe(0);
+    expect(toNumber("-0", -1)).toBe(0);
+  });
+
+  it("parses decimal strings", () => {
+    expect(toNumber("3.5", 0)).toBe(3.5);
+    expect(toNumber(".5", 0)).toBe(0.5);
+    expect(toNumber("0.25", 0)).toBe(0.25);
+  });
+
+  it("rejects hex notation", () => {
+    expect(toNumber("0x10", 0)).toBe(0);
+    expect(toNumber("0xFF", 0)).toBe(0);
+  });
+
+  it("rejects scientific notation", () => {
+    expect(toNumber("1e3", 0)).toBe(0);
+    expect(toNumber("1.5e2", 0)).toBe(0);
+  });
+
+  it("rejects leading-plus notation", () => {
+    expect(toNumber("+1", 0)).toBe(0);
+    expect(toNumber("+10", 0)).toBe(0);
+  });
+
+  it("rejects empty and whitespace-only strings", () => {
+    expect(toNumber("", 0)).toBe(0);
+    expect(toNumber("   ", 0)).toBe(0);
+  });
+
+  it("rejects non-numeric strings", () => {
+    expect(toNumber("abc", 0)).toBe(0);
+    expect(toNumber("70junk", 0)).toBe(0);
+    expect(toNumber("12.5.3", 0)).toBe(0);
+  });
+
+  it("returns fallback for all rejected inputs", () => {
+    expect(toNumber("0x10", 42)).toBe(42);
+    expect(toNumber("1e3", -1)).toBe(-1);
+    expect(toNumber("+1", 99)).toBe(99);
+    expect(toNumber("junk", 5)).toBe(5);
+  });
+
+  it("handles leading/trailing whitespace", () => {
+    expect(toNumber("  10  ", 0)).toBe(10);
+    expect(toNumber("  -5  ", 0)).toBe(-5);
+    expect(toNumber("  0x10  ", 0)).toBe(0);
   });
 });

--- a/ui/src/lib/format.ts
+++ b/ui/src/lib/format.ts
@@ -139,8 +139,17 @@ export function truncateText(
   };
 }
 
+const STRICT_DECIMAL_RE = /^-?(?:\d+(?:\.\d*)?|\.\d+)$/;
+
 export function toNumber(value: string, fallback: number): number {
-  const n = Number(value);
+  const trimmed = value.trim();
+  // Reject hex (0x10), scientific (1e3), and leading-plus (+1) notation
+  // so that form fields do not silently accept non-decimal input.
+  // Preserve an optional leading minus sign for negative plain decimals.
+  if (!STRICT_DECIMAL_RE.test(trimmed)) {
+    return fallback;
+  }
+  const n = Number(trimmed);
   return Number.isFinite(n) ? n : fallback;
 }
 


### PR DESCRIPTION
## What Problem This Solves

The shared `toNumber()` helper uses JavaScript `Number()` conversion, which
accepts hex (0x10), scientific (1e3), and leading-plus (+1) notation. This
allows non-decimal input to silently pass form-field validation in the
Control UI.

## Why This Change Was Made

- Add a strict decimal regex (`/^-?(?:\d+(?:\.\d*)?|\.\d+)$/`) that only
  accepts plain decimal strings
- **Preserve** the optional leading minus sign so that negative plain
  decimals (-1, -3.5, -0.25) continue to work for all callers
- Reject hex, scientific, and leading-plus notation at the parser level
- Add focused test coverage for accepted and rejected syntax

## User Impact

- Before: `0x10` and `1e3` were silently accepted as cron intervals
- After: non-decimal input returns the fallback; negative decimals still work

## Verification

- Focused suite: `ui/src/lib/format.test.ts` — `toNumber` test block
  covering positive/negative integers, negative decimals, zero, hex
  rejection, scientific rejection, leading-plus rejection, whitespace,
  and non-numeric strings

## Risk / Compatibility

Low. The strict regex preserves both positive and negative plain decimals.
Only hex, scientific, and leading-plus inputs change behavior — these were
never valid form-field inputs.