### PR TITLE
feat: sync ClickClack command menus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- **ClickClack command menus:** publish each bot's native OpenClaw commands to ClickClack composer autocomplete at gateway startup, with per-account opt-out and nonfatal compatibility handling for older tokens and servers. Thanks @shakkernerd.
 - **Skill Workshop approvals:** run agent-initiated apply, reject, and quarantine actions without an additional approval prompt by default while preserving `skills.workshop.approvalPolicy: "pending"` as an opt-in approval gate. Thanks @shakkernerd.
 - **TUI fuzzy selectors:** delegate list matching to pi-tui, adding slash-token and alpha-number matching while removing the local matcher fork.
 - **macOS paired-node terminals:** advertise duplex Codex and Claude terminal resume commands from the embedded node host and forward interactive input and cancellation through the native app bridge. (#107335)

--- a/docs/channels/clickclack.md
+++ b/docs/channels/clickclack.md
@@ -64,6 +64,7 @@ An account counts as configured only when `baseUrl`, `token`, and `workspace` ar
 | `agentId`               | route default       | Pin this account's inbound messages to one agent.                                       |
 | `toolsAllow`            | none                | Tool allowlist for agent replies from this account.                                     |
 | `model`, `systemPrompt` | none                | Used by `replyMode: "model"` completions.                                               |
+| `commandMenu`           | `true`              | Publish native commands to ClickClack composer autocomplete.                            |
 | `reconnectMs`           | `1500`              | Realtime reconnect delay (100 to 60000).                                                |
 
 If `plugins.allow` is a non-empty restrictive list, explicitly selecting
@@ -129,6 +130,46 @@ bit:
 
 Keep the trust bit off if you only use the default `agent` reply mode; it is
 not needed there.
+
+## Command menu
+
+At gateway startup, each configured account publishes OpenClaw's native
+commands to ClickClack. They appear in composer autocomplete labeled with the
+bot's handle. The published set is replaced wholesale on each startup,
+including clearing a stale menu when the native command catalog is empty.
+
+Command-menu sync is enabled by default. Set `commandMenu: false` on an account
+to opt out:
+
+```json5
+{
+  channels: {
+    clickclack: {
+      enabled: true,
+      token: { source: "env", provider: "default", id: "CLICKCLACK_BOT_TOKEN" },
+      workspace: "default",
+      commandMenu: false,
+    },
+  },
+}
+```
+
+The token needs `commands:write`. Current ClickClack `bot:write` and
+`bot:admin` bundles include that scope, and it can also be granted
+individually. Tokens created before command menus were introduced may need the
+scope added or a replacement token.
+
+Sync is best effort and runs once per gateway start. A missing scope or network
+failure logs a warning; an older ClickClack server without the endpoint logs at
+debug level. None of these failures block realtime startup. Menus remain
+available while the agent is offline and are removed when the bot leaves the
+workspace.
+
+This release publishes native command specs only. Aliases and
+skill-, plugin-, or custom-command catalogs are not added to the menu. If a
+name is also registered as an HTTP slash command, ClickClack dispatches that
+registration first; other menu commands continue through normal message
+delivery.
 
 Use `agent` mode for cross-service correlation evidence. For an authoritative
 ClickClack message id in its canonical `msg_<ulid>` shape, the channel derives
@@ -220,11 +261,12 @@ openclaw message send --channel clickclack --target thread:msg_123 --message "fo
 ClickClack token scopes are enforced by the ClickClack API.
 
 - `bot:read`: read workspace/channel/message/thread/DM/realtime/profile data.
-- `bot:write`: `bot:read` plus channel messages, thread replies, DMs, and uploads.
+- `bot:write`: `bot:read` plus channel messages, thread replies, DMs, uploads, and command-menu publishing.
 - `bot:admin`: `bot:write` plus channel creation.
+- `commands:write`: publish the bot's command menu. Included in current `bot:write` and `bot:admin` bundles and grantable individually.
 - `agent_activity:write`: durable agent activity rows (`agent_commentary` / `agent_tool`). Not inherited by `bot:write` or `bot:admin`; required only when `agentActivity: true` is set.
 
-OpenClaw only needs `bot:write` for normal agent chat. Add `agent_activity:write` when enabling [agent activity rows](#agent-activity-rows).
+OpenClaw only needs current `bot:write` for normal agent chat and command-menu sync. Add `agent_activity:write` when enabling [agent activity rows](#agent-activity-rows).
 
 ## Troubleshooting
 
@@ -232,3 +274,4 @@ OpenClaw only needs `bot:write` for normal agent chat. Add `agent_activity:write
 - `ClickClack workspace not found: <value>`: set `workspace` to the workspace id, slug, or name returned by ClickClack.
 - No inbound replies: confirm the token has realtime read access and note that the bot ignores its own messages and messages from other bots.
 - Channel sends fail: verify the bot is a member of the workspace and has `bot:write`.
+- No command menu: confirm `commandMenu` is not `false`, the ClickClack server supports `PUT /api/bots/self/commands`, and the token has `commands:write`.

--- a/extensions/clickclack/README.md
+++ b/extensions/clickclack/README.md
@@ -8,6 +8,17 @@ Official OpenClaw channel plugin for ClickClack.
 openclaw plugins install @openclaw/clickclack
 ```
 
+## Command menus
+
+ClickClack command menus are enabled by default. At gateway startup, the
+extension publishes OpenClaw's native commands for composer autocomplete,
+labeled with the bot's handle. The bot token must include `commands:write`;
+current `bot:write` and `bot:admin` bundles include it.
+
+Set `commandMenu: false` on an account to disable menu sync. Sync failures do
+not prevent the gateway from starting, so older tokens and ClickClack servers
+continue to work without a menu.
+
 ## Docs
 
 See `docs/channels/clickclack.md` in the OpenClaw repository, or the published docs at `https://docs.openclaw.ai/channels/clickclack`.

--- a/extensions/clickclack/src/accounts.test.ts
+++ b/extensions/clickclack/src/accounts.test.ts
@@ -107,6 +107,7 @@ describe("ClickClack account resolution", () => {
       defaultTo: "channel:general",
       enabled: true,
       agentActivity: false,
+      commandMenu: true,
       model: undefined,
       name: undefined,
       reconnectMs: 1_500,
@@ -160,6 +161,7 @@ describe("ClickClack account resolution", () => {
       defaultTo: "channel:general",
       enabled: true,
       agentActivity: false,
+      commandMenu: true,
       model: "openai/gpt-5.4-mini",
       name: undefined,
       reconnectMs: 1_500,
@@ -192,6 +194,31 @@ describe("ClickClack account resolution", () => {
 
     expect(resolveClickClackAccount({ cfg }).agentActivity).toBe(false);
     expect(resolveClickClackAccount({ cfg, accountId: "bridge" }).agentActivity).toBe(true);
+  });
+
+  it("enables command menus unless the resolved account explicitly disables them", () => {
+    const cfg = {
+      channels: {
+        clickclack: {
+          enabled: true,
+          baseUrl: "https://app.clickclack.chat",
+          workspace: "wsp_1",
+          token: "test-token-placeholder",
+          accounts: {
+            disabled: {
+              commandMenu: false,
+            },
+            enabled: {
+              commandMenu: true,
+            },
+          },
+        },
+      },
+    } satisfies CoreConfig;
+
+    expect(resolveClickClackAccount({ cfg }).commandMenu).toBe(true);
+    expect(resolveClickClackAccount({ cfg, accountId: "disabled" }).commandMenu).toBe(false);
+    expect(resolveClickClackAccount({ cfg, accountId: "enabled" }).commandMenu).toBe(true);
   });
 
   it("normalizes reconnect intervals to the public config bounds", () => {

--- a/extensions/clickclack/src/accounts.ts
+++ b/extensions/clickclack/src/accounts.ts
@@ -147,6 +147,9 @@ export function resolveClickClackAccount(params: {
     // the ClickClack side, so this stays a per-account opt-in (default off),
     // matching the streaming-progress commentary opt-in precedent.
     agentActivity: merged.agentActivity === true,
+    // Command-menu sync is best effort and current bot:write tokens include
+    // commands:write, so resolved accounts default on unless explicitly disabled.
+    commandMenu: merged.commandMenu !== false,
     config: {
       ...merged,
       allowFrom: merged.allowFrom ?? ["*"],

--- a/extensions/clickclack/src/command-menu.test.ts
+++ b/extensions/clickclack/src/command-menu.test.ts
@@ -1,0 +1,128 @@
+import type { NativeCommandSpec } from "openclaw/plugin-sdk/native-command-registry";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  listNativeCommandSpecsForConfig: vi.fn(),
+}));
+
+vi.mock("openclaw/plugin-sdk/native-command-registry", () => ({
+  listNativeCommandSpecsForConfig: mocks.listNativeCommandSpecsForConfig,
+}));
+
+import {
+  mapNativeCommandSpecsToClickClackMenu,
+  syncClickClackCommandMenu,
+} from "./command-menu.js";
+import type { createClickClackClient } from "./http-client.js";
+import type { CoreConfig } from "./types.js";
+
+function nativeCommand(
+  name: string,
+  options: Partial<Omit<NativeCommandSpec, "name">> = {},
+): NativeCommandSpec {
+  return {
+    name,
+    description: options.description ?? `Run ${name}`,
+    acceptsArgs: options.acceptsArgs ?? false,
+    ...options,
+  };
+}
+
+describe("ClickClack command menu", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("maps native commands to the bounded ClickClack menu contract", () => {
+    const warn = vi.fn();
+    const longDescription = "\u{1F642}".repeat(101);
+    const commands = mapNativeCommandSpecsToClickClackMenu(
+      [
+        nativeCommand("Deploy-Now", {
+          description: `  ${longDescription}  `,
+          acceptsArgs: true,
+          args: [
+            { name: "target", description: "Target", type: "string", required: true },
+            { name: "message", description: "Message", type: "string" },
+          ],
+        }),
+        nativeCommand("deploy-now", { description: "Duplicate loses" }),
+        nativeCommand("shortcut", { isAlias: true }),
+        nativeCommand("bad name"),
+        nativeCommand("also/bad"),
+        nativeCommand("status", { description: "   ", acceptsArgs: true }),
+        nativeCommand("noargs"),
+        nativeCommand("long-hint", {
+          args: Array.from({ length: 20 }, (_, index) => ({
+            name: `argument${index}`,
+            description: "Argument",
+            type: "string" as const,
+            required: index === 0,
+          })),
+        }),
+      ],
+      { warn },
+    );
+
+    expect(commands).toHaveLength(4);
+    expect(commands[0]).toEqual({
+      command: "deploy-now",
+      description: expect.any(String),
+      args_hint: "<target> [message]",
+    });
+    expect(Array.from(commands[0]?.description ?? "")).toHaveLength(100);
+    expect(commands[1]).toEqual({
+      command: "status",
+      description: "status",
+      args_hint: "[args]",
+    });
+    expect(commands[2]).toEqual({
+      command: "noargs",
+      description: "Run noargs",
+      args_hint: "",
+    });
+    expect(Array.from(commands[3]?.args_hint ?? "")).toHaveLength(100);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledWith(
+      'ClickClack command menu skipped invalid native command names: "bad name", "also/bad"',
+    );
+  });
+
+  it("keeps the first 100 unique normalized commands", () => {
+    const specs = Array.from({ length: 101 }, (_, index) => nativeCommand(`command${index}`));
+
+    const commands = mapNativeCommandSpecsToClickClackMenu(specs);
+
+    expect(commands).toHaveLength(100);
+    expect(commands[0]?.command).toBe("command0");
+    expect(commands[99]?.command).toBe("command99");
+  });
+
+  it("returns an empty overwrite for an empty native catalog", () => {
+    expect(mapNativeCommandSpecsToClickClackMenu([])).toEqual([]);
+  });
+
+  it("sources the catalog from the ClickClack native command registry", async () => {
+    const cfg = {} as CoreConfig;
+    const setBotCommands = vi.fn().mockResolvedValue([]);
+    mocks.listNativeCommandSpecsForConfig.mockReturnValue([
+      nativeCommand("status", { acceptsArgs: true }),
+    ]);
+
+    await syncClickClackCommandMenu({
+      cfg,
+      client: { setBotCommands } as unknown as ReturnType<typeof createClickClackClient>,
+    });
+
+    expect(mocks.listNativeCommandSpecsForConfig).toHaveBeenCalledWith(cfg, {
+      provider: "clickclack",
+    });
+    expect(setBotCommands).toHaveBeenCalledWith([
+      {
+        command: "status",
+        description: "Run status",
+        args_hint: "[args]",
+      },
+    ]);
+  });
+});

--- a/extensions/clickclack/src/command-menu.ts
+++ b/extensions/clickclack/src/command-menu.ts
@@ -1,0 +1,113 @@
+import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import {
+  listNativeCommandSpecsForConfig,
+  type NativeCommandSpec,
+} from "openclaw/plugin-sdk/native-command-registry";
+import type { createClickClackClient } from "./http-client.js";
+import type { CoreConfig } from "./types.js";
+
+const CLICKCLACK_COMMAND_PATTERN = /^[a-z0-9_-]{1,32}$/u;
+const CLICKCLACK_MAX_COMMANDS = 100;
+const CLICKCLACK_MAX_DESCRIPTION_LENGTH = 100;
+const CLICKCLACK_MAX_ARGS_HINT_LENGTH = 100;
+
+type ClickClackCommandMenuEntry = {
+  command: string;
+  description: string;
+  args_hint: string;
+};
+
+type ClickClackCommandMenuLogger = {
+  debug?: (message: string) => void;
+  warn?: (message: string) => void;
+};
+
+function truncateCodePoints(value: string, maxLength: number): string {
+  return Array.from(value).slice(0, maxLength).join("");
+}
+
+function commandArgsHint(spec: NativeCommandSpec): string {
+  if (spec.args?.length) {
+    return truncateCodePoints(
+      spec.args.map((arg) => (arg.required ? `<${arg.name}>` : `[${arg.name}]`)).join(" "),
+      CLICKCLACK_MAX_ARGS_HINT_LENGTH,
+    );
+  }
+  return spec.acceptsArgs ? "[args]" : "";
+}
+
+function errorStatus(error: unknown): number | undefined {
+  if (!error || typeof error !== "object" || !("status" in error)) {
+    return undefined;
+  }
+  const status = (error as { status?: unknown }).status;
+  return typeof status === "number" ? status : undefined;
+}
+
+export function mapNativeCommandSpecsToClickClackMenu(
+  specs: NativeCommandSpec[],
+  log?: ClickClackCommandMenuLogger,
+): ClickClackCommandMenuEntry[] {
+  const commands: ClickClackCommandMenuEntry[] = [];
+  const seen = new Set<string>();
+  const invalidNames = new Set<string>();
+
+  for (const spec of specs) {
+    if (spec.isAlias) {
+      continue;
+    }
+    const command = spec.name.trim().toLowerCase();
+    if (!CLICKCLACK_COMMAND_PATTERN.test(command)) {
+      invalidNames.add(spec.name.trim() || "<empty>");
+      continue;
+    }
+    if (seen.has(command)) {
+      continue;
+    }
+    seen.add(command);
+
+    const description = spec.description.trim() || command;
+    commands.push({
+      command,
+      description: truncateCodePoints(description, CLICKCLACK_MAX_DESCRIPTION_LENGTH),
+      args_hint: commandArgsHint(spec),
+    });
+  }
+
+  if (invalidNames.size > 0) {
+    log?.warn?.(
+      `ClickClack command menu skipped invalid native command names: ${[...invalidNames]
+        .map((name) => JSON.stringify(name))
+        .join(", ")}`,
+    );
+  }
+
+  return commands.slice(0, CLICKCLACK_MAX_COMMANDS);
+}
+
+export async function syncClickClackCommandMenu(params: {
+  cfg: CoreConfig;
+  client: ReturnType<typeof createClickClackClient>;
+  log?: ClickClackCommandMenuLogger;
+}): Promise<void> {
+  try {
+    // Native specs are the Phase 7c scope. Skill, plugin, and custom command
+    // catalogs can be added later when their ClickClack semantics are defined.
+    const specs = listNativeCommandSpecsForConfig(params.cfg, { provider: "clickclack" });
+    const commands = mapNativeCommandSpecsToClickClackMenu(specs, params.log);
+    await params.client.setBotCommands(commands);
+  } catch (error) {
+    const status = errorStatus(error);
+    if (status === 403) {
+      params.log?.warn?.("ClickClack command menu sync skipped: bot token lacks commands:write");
+      return;
+    }
+    if (status === 404) {
+      params.log?.debug?.(
+        "ClickClack command menu sync skipped: server does not support /api/bots/self/commands",
+      );
+      return;
+    }
+    params.log?.warn?.(`ClickClack command menu sync failed: ${formatErrorMessage(error)}`);
+  }
+}

--- a/extensions/clickclack/src/config-schema.ts
+++ b/extensions/clickclack/src/config-schema.ts
@@ -23,6 +23,7 @@ const ClickClackAccountConfigSchema = z
     allowFrom: z.array(z.string()).optional(),
     reconnectMs: z.number().int().min(100).max(60_000).optional(),
     agentActivity: z.boolean().optional(),
+    commandMenu: z.boolean().optional(),
   })
   .strict();
 

--- a/extensions/clickclack/src/gateway.test.ts
+++ b/extensions/clickclack/src/gateway.test.ts
@@ -25,6 +25,7 @@ const mocks = vi.hoisted(() => ({
     channelMessages: vi.fn(),
     directMessages: vi.fn(),
     thread: vi.fn(),
+    setBotCommands: vi.fn(),
   },
   handleClickClackInbound: vi.fn(),
   resolveClickClackInboundAccess: vi.fn(),
@@ -45,6 +46,10 @@ vi.mock("./inbound.js", () => ({
   handleClickClackInbound: mocks.handleClickClackInbound,
 }));
 
+vi.mock("openclaw/plugin-sdk/native-command-registry", () => ({
+  listNativeCommandSpecsForConfig: () => [],
+}));
+
 vi.mock("./resolve.js", () => ({
   resolveWorkspaceId: mocks.resolveWorkspaceId,
 }));
@@ -53,6 +58,9 @@ import { startClickClackGatewayAccount } from "./gateway.js";
 
 function createGatewayContext(
   abortSignal: AbortSignal,
+  options: {
+    commandMenu?: boolean;
+  } = {},
 ): ChannelGatewayContext<ResolvedClickClackAccount> {
   const setStatus = vi.fn();
   const log = { warn: vi.fn(), info: vi.fn(), error: vi.fn(), debug: vi.fn() };
@@ -64,6 +72,7 @@ function createGatewayContext(
           token: "test-token",
           workspace: "main",
           reconnectMs: 1,
+          ...(options.commandMenu === undefined ? {} : { commandMenu: options.commandMenu }),
         },
       },
     } as ChannelGatewayContext<ResolvedClickClackAccount>["cfg"],
@@ -105,6 +114,7 @@ describe("ClickClack gateway", () => {
       created_at: "2026-01-01T00:00:00.000Z",
     });
     mocks.client.eventPage.mockResolvedValue({ events: [] });
+    mocks.client.setBotCommands.mockResolvedValue([]);
     mocks.resolveClickClackInboundAccess.mockResolvedValue({
       shouldDispatch: true,
       commandAuthorized: true,
@@ -130,6 +140,91 @@ describe("ClickClack gateway", () => {
         },
       },
     ]);
+  });
+
+  it.each([
+    { label: "unset", commandMenu: undefined },
+    { label: "enabled", commandMenu: true },
+  ])("syncs the native command menu before startup when $label", async ({ commandMenu }) => {
+    const socket = new FakeSocket();
+    mocks.client.websocket.mockReturnValue(socket);
+    const abort = new AbortController();
+    const ctx = createGatewayContext(abort.signal, { commandMenu });
+    const run = startClickClackGatewayAccount(ctx);
+
+    await vi.waitFor(() => expect(mocks.client.websocket).toHaveBeenCalledTimes(1));
+
+    expect(mocks.client.setBotCommands).toHaveBeenCalledTimes(1);
+    expect(mocks.client.me.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.client.setBotCommands.mock.invocationCallOrder[0] ?? 0,
+    );
+    expect(mocks.client.setBotCommands.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.client.eventPage.mock.invocationCallOrder[0] ?? 0,
+    );
+    expect(mocks.client.setBotCommands.mock.invocationCallOrder[0]).toBeLessThan(
+      vi.mocked(ctx.setStatus).mock.invocationCallOrder[0] ?? 0,
+    );
+
+    abort.abort();
+    await run;
+  });
+
+  it("skips command menu sync when explicitly disabled", async () => {
+    const socket = new FakeSocket();
+    mocks.client.websocket.mockReturnValue(socket);
+    const abort = new AbortController();
+    const ctx = createGatewayContext(abort.signal, { commandMenu: false });
+    const run = startClickClackGatewayAccount(ctx);
+
+    await vi.waitFor(() => expect(mocks.client.websocket).toHaveBeenCalledTimes(1));
+
+    expect(mocks.client.setBotCommands).not.toHaveBeenCalled();
+
+    abort.abort();
+    await run;
+  });
+
+  it.each([
+    {
+      label: "missing command scope",
+      error: { status: 403 },
+      level: "warn" as const,
+      message: "ClickClack command menu sync skipped: bot token lacks commands:write",
+    },
+    {
+      label: "older server",
+      error: { status: 404 },
+      level: "debug" as const,
+      message:
+        "ClickClack command menu sync skipped: server does not support /api/bots/self/commands",
+    },
+    {
+      label: "network failure",
+      error: new Error("network unavailable"),
+      level: "warn" as const,
+      message: "ClickClack command menu sync failed: network unavailable",
+    },
+  ])("continues startup after $label", async ({ error, level, message }) => {
+    mocks.client.setBotCommands.mockRejectedValueOnce(error);
+    const socket = new FakeSocket();
+    mocks.client.websocket.mockReturnValue(socket);
+    const abort = new AbortController();
+    const ctx = createGatewayContext(abort.signal);
+    const run = startClickClackGatewayAccount(ctx);
+
+    await vi.waitFor(() => expect(mocks.client.websocket).toHaveBeenCalledTimes(1));
+
+    expect(ctx.log?.[level]).toHaveBeenCalledWith(message);
+    expect(ctx.setStatus).toHaveBeenCalledWith({
+      accountId: "default",
+      running: true,
+      configured: true,
+      enabled: true,
+      baseUrl: "https://clickclack.example",
+    });
+
+    abort.abort();
+    await run;
   });
 
   it("opens realtime from the server startup tail without dispatching the returned page", async () => {

--- a/extensions/clickclack/src/gateway.ts
+++ b/extensions/clickclack/src/gateway.ts
@@ -7,6 +7,7 @@ import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import type { RawData } from "ws";
 import { resolveClickClackInboundAccess } from "./access.js";
 import { resolveClickClackAccount } from "./accounts.js";
+import { syncClickClackCommandMenu } from "./command-menu.js";
 import { createClickClackClient, normalizeClickClackCorrelationId } from "./http-client.js";
 import { handleClickClackInbound } from "./inbound.js";
 import { resolveWorkspaceId } from "./resolve.js";
@@ -186,6 +187,9 @@ export async function startClickClackGatewayAccount(
     workspace: workspaceId,
     botUserId: configuredAccount.botUserId ?? me.id,
   };
+  if (account.commandMenu !== false) {
+    await syncClickClackCommandMenu({ cfg: ctx.cfg, client, log: ctx.log });
+  }
   ctx.setStatus({
     accountId: account.accountId,
     running: true,

--- a/extensions/clickclack/src/gateway.ts
+++ b/extensions/clickclack/src/gateway.ts
@@ -187,7 +187,7 @@ export async function startClickClackGatewayAccount(
     workspace: workspaceId,
     botUserId: configuredAccount.botUserId ?? me.id,
   };
-  if (account.commandMenu !== false) {
+  if (account.commandMenu) {
     await syncClickClackCommandMenu({ cfg: ctx.cfg, client, log: ctx.log });
   }
   ctx.setStatus({

--- a/extensions/clickclack/src/http-client.test.ts
+++ b/extensions/clickclack/src/http-client.test.ts
@@ -136,11 +136,13 @@ describe("ClickClack HTTP client", () => {
       created_at: "2026-07-15T00:00:00.000Z",
       updated_at: "2026-07-15T00:00:00.000Z",
     };
-    const fetchMock = vi.fn(async () => Response.json({ bot_commands: [botCommand] }));
+    const fetchMock = vi.fn(async (_input: string | URL | Request, _init?: RequestInit) =>
+      Response.json({ bot_commands: [botCommand] }),
+    );
     const client = createClickClackClient({
       baseUrl: "https://clickclack.example",
       token: "fake",
-      fetch: fetchMock,
+      fetch: fetchMock as unknown as typeof fetch,
     });
 
     const result = await client.setBotCommands([

--- a/extensions/clickclack/src/http-client.test.ts
+++ b/extensions/clickclack/src/http-client.test.ts
@@ -125,6 +125,52 @@ function streamedErrorResponse(body: string, limit: number) {
 }
 
 describe("ClickClack HTTP client", () => {
+  it("replaces the authenticated bot command menu", async () => {
+    const botCommand = {
+      id: "botcmd_1",
+      workspace_id: "wsp_1",
+      bot_user_id: "usr_bot",
+      command: "/status",
+      description: "Show agent status",
+      args_hint: "",
+      created_at: "2026-07-15T00:00:00.000Z",
+      updated_at: "2026-07-15T00:00:00.000Z",
+    };
+    const fetchMock = vi.fn(async () => Response.json({ bot_commands: [botCommand] }));
+    const client = createClickClackClient({
+      baseUrl: "https://clickclack.example",
+      token: "fake",
+      fetch: fetchMock,
+    });
+
+    const result = await client.setBotCommands([
+      {
+        command: "status",
+        description: "Show agent status",
+        args_hint: "",
+      },
+    ]);
+
+    expect(result).toEqual([botCommand]);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://clickclack.example/api/bots/self/commands",
+      expect.objectContaining({ method: "PUT" }),
+    );
+    const init = fetchMock.mock.calls[0]?.[1];
+    expect(requestBodyJson(init)).toEqual({
+      commands: [
+        {
+          command: "status",
+          description: "Show agent status",
+          args_hint: "",
+        },
+      ],
+    });
+    const headers = new Headers(init?.headers);
+    expect(headers.get("Authorization")).toBe("Bearer fake");
+    expect(headers.get("Content-Type")).toBe("application/json");
+  });
+
   it("adds paged tail queries without changing the legacy events result", async () => {
     const fetchMock = vi.fn(async () => Response.json({ events: [], tail_cursor: "cursor-900" }));
     const client = createClickClackClient({

--- a/extensions/clickclack/src/http-client.ts
+++ b/extensions/clickclack/src/http-client.ts
@@ -8,6 +8,7 @@ import {
 } from "openclaw/plugin-sdk/provider-http";
 import { WebSocket } from "ws";
 import type {
+  ClickClackBotCommand,
   ClickClackChannel,
   ClickClackEvent,
   ClickClackMessage,
@@ -155,6 +156,18 @@ export function createClickClackClient(options: ClientOptions) {
     me: async (): Promise<ClickClackUser> => {
       const data = await request<{ user: ClickClackUser }>("/api/me");
       return data.user;
+    },
+    setBotCommands: async (
+      commands: { command: string; description: string; args_hint?: string }[],
+    ): Promise<ClickClackBotCommand[]> => {
+      const data = await request<{ bot_commands: ClickClackBotCommand[] }>(
+        "/api/bots/self/commands",
+        {
+          method: "PUT",
+          body: JSON.stringify({ commands }),
+        },
+      );
+      return data.bot_commands;
     },
     workspaces: async (): Promise<ClickClackWorkspace[]> => {
       const data = await request<{ workspaces: ClickClackWorkspace[] }>("/api/workspaces");

--- a/extensions/clickclack/src/inbound.test.ts
+++ b/extensions/clickclack/src/inbound.test.ts
@@ -78,6 +78,7 @@ function createAgentAccount(
     allowFrom: ["*"],
     reconnectMs: 1_500,
     agentActivity: false,
+    commandMenu: true,
     config: {
       allowFrom: ["*"],
     },
@@ -145,6 +146,7 @@ describe("handleClickClackInbound", () => {
       allowFrom: ["*"],
       reconnectMs: 1_500,
       agentActivity: false,
+      commandMenu: true,
       config: {},
     } satisfies ResolvedClickClackAccount;
 

--- a/extensions/clickclack/src/types.ts
+++ b/extensions/clickclack/src/types.ts
@@ -74,6 +74,18 @@ export type ClickClackUser = {
   created_at: string;
 };
 
+/** Bot command row returned by the ClickClack command-menu API. */
+export type ClickClackBotCommand = {
+  id: string;
+  workspace_id: string;
+  bot_user_id: string;
+  command: string;
+  description: string;
+  args_hint: string;
+  created_at: string;
+  updated_at: string;
+};
+
 /** Workspace object returned by the ClickClack API. */
 export type ClickClackWorkspace = {
   id: string;

--- a/extensions/clickclack/src/types.ts
+++ b/extensions/clickclack/src/types.ts
@@ -22,6 +22,8 @@ export type ClickClackAccountConfig = {
   reconnectMs?: number;
   /** Opt-in: publish durable agent activity (commentary + tool) rows. */
   agentActivity?: boolean;
+  /** Publish the native command catalog to ClickClack composer autocomplete. */
+  commandMenu?: boolean;
 };
 
 /** Root ClickClack channel config with optional named accounts. */
@@ -57,6 +59,7 @@ export type ResolvedClickClackAccount = {
   allowFrom: string[];
   reconnectMs: number;
   agentActivity: boolean;
+  commandMenu: boolean;
   config: ClickClackAccountConfig;
 };
 


### PR DESCRIPTION
## Summary

- publish native OpenClaw commands to ClickClack composer autocomplete at gateway startup
- add default-on `commandMenu` configuration with per-account opt-out
- handle missing scopes, older servers, and network failures without blocking startup
- document the `commands:write` requirement and command precedence behavior

## Testing

- `pnpm check:changed` via Blacksmith Testbox
- 61 focused ClickClack tests via Blacksmith Testbox
- real native-command catalog mapping smoke test