### PR TITLE
fix(ui): show live quick settings channel status

### DIFF
--- a/ui/src/pages/config/config-page.test.ts
+++ b/ui/src/pages/config/config-page.test.ts
@@ -9,7 +9,12 @@ import type {
   ApplicationGateway,
   ApplicationGatewaySnapshot,
 } from "../../app/context.ts";
-import { ConfigPage, configSelectionFromSearch, supportsSystemInfo } from "./config-page.ts";
+import {
+  ConfigPage,
+  configSelectionFromSearch,
+  quickChannels,
+  supportsSystemInfo,
+} from "./config-page.ts";
 import type { ConfigViewState } from "./view.ts";
 
 function deferred<T>() {
@@ -53,6 +58,46 @@ describe("supportsSystemInfo", () => {
     expect(supportsSystemInfo(hello)).toBe(true);
     expect(supportsSystemInfo(unsupportedHello)).toBe(false);
     expect(supportsSystemInfo(null)).toBe(false);
+  });
+});
+
+describe("quickChannels", () => {
+  it("does not count configured channels as connected without a live connection", () => {
+    expect(
+      quickChannels(
+        { channels: { slack: { token: "x" }, discord: { token: "y" } } },
+        {
+          ts: Date.now(),
+          channelOrder: ["discord", "slack"],
+          channelLabels: { discord: "Discord", slack: "Slack" },
+          channelDetailLabels: { discord: "Connected", slack: "Disconnected" },
+          channels: {
+            discord: { configured: true, connected: true },
+            slack: { configured: true, connected: false },
+          },
+          channelAccounts: {
+            discord: [{ accountId: "default", configured: true, connected: true }],
+            slack: [{ accountId: "default", configured: true, connected: false }],
+          },
+          channelDefaultAccountId: { discord: "default", slack: "default" },
+        },
+      ),
+    ).toEqual([
+      {
+        id: "discord",
+        label: "Discord",
+        connected: true,
+        configured: true,
+        detail: "Connected",
+      },
+      {
+        id: "slack",
+        label: "Slack",
+        connected: false,
+        configured: true,
+        detail: "Configured",
+      },
+    ]);
   });
 });
 

--- a/ui/src/pages/config/config-page.ts
+++ b/ui/src/pages/config/config-page.ts
@@ -4,7 +4,7 @@ import { html, nothing, type PropertyValues } from "lit";
 import { property, state } from "lit/decorators.js";
 import type { SystemInfoResult } from "../../../../packages/gateway-protocol/src/index.js";
 import { GatewayRequestError, type GatewayBrowserClient } from "../../api/gateway.ts";
-import type { FastMode } from "../../api/types.ts";
+import type { ChannelsStatusSnapshot, FastMode } from "../../api/types.ts";
 import { pathForRoute, type RouteId } from "../../app-route-paths.ts";
 import {
   applicationContext,
@@ -154,26 +154,60 @@ function mcpServerCount(config: unknown): number {
     : 0;
 }
 
-function quickChannels(config: unknown): QuickSettingsChannel[] {
+export function quickChannels(
+  config: unknown,
+  snapshot: ChannelsStatusSnapshot | null | undefined,
+): QuickSettingsChannel[] {
   const configured = asConfigRecord(asConfigRecord(config)?.channels) ?? {};
   const configuredIds = Object.keys(configured).filter((id) => id.trim().length > 0);
-  const channelIds =
-    configuredIds.length > 0
-      ? configuredIds.toSorted((left, right) => left.localeCompare(right))
+  const liveIds = new Set<string>([
+    ...(snapshot?.channelOrder ?? []),
+    ...Object.keys(snapshot?.channels ?? {}),
+    ...Object.keys(snapshot?.channelAccounts ?? {}),
+    ...Object.keys(snapshot?.channelLabels ?? {}),
+  ]);
+  const channelIds = Array.from(new Set([...configuredIds, ...liveIds])).filter(
+    (id) => id.trim().length > 0,
+  );
+  const sortedIds =
+    channelIds.length > 0
+      ? channelIds.toSorted((left, right) => left.localeCompare(right))
       : KNOWN_CHANNELS.map(({ id }) => id);
   const labels = new Map<string, string>(
     KNOWN_CHANNELS.map(({ id, labelKey }) => [id, t(labelKey)]),
   );
-  return channelIds.map((id) => {
+  return sortedIds.map((id) => {
     const value = configured[id];
-    const connected = Boolean(value && typeof value === "object" && Object.keys(value).length);
+    const hasConfig = Boolean(value && typeof value === "object" && Object.keys(value).length);
+    const status = (snapshot?.channels?.[id] ?? null) as Record<string, unknown> | null;
+    const accounts = snapshot?.channelAccounts?.[id] ?? [];
+    const defaultAccountId = snapshot?.channelDefaultAccountId?.[id];
+    const defaultAccount =
+      (defaultAccountId
+        ? accounts.find((account) => account.accountId === defaultAccountId)
+        : undefined) ?? accounts[0] ?? null;
+    const connected =
+      status?.connected === true ||
+      defaultAccount?.connected === true ||
+      accounts.some((account) => account.connected === true);
+    const isConfigured =
+      hasConfig ||
+      status?.configured === true ||
+      defaultAccount?.configured === true ||
+      accounts.some((account) => account.configured === true || account.running === true);
     return {
       id,
       label:
+        snapshot?.channelLabels?.[id] ??
         labels.get(id) ??
         id.replace(/[-_]+/g, " ").replace(/\b\w/g, (character) => character.toUpperCase()),
       connected,
-      detail: connected ? t("common.configured") : undefined,
+      configured: isConfigured,
+      detail: connected
+        ? snapshot?.channelDetailLabels?.[id] ?? t("common.connected")
+        : isConfigured
+          ? t("common.configured")
+          : undefined,
     };
   });
 }
@@ -840,7 +874,7 @@ export class ConfigPage extends OpenClawLightDomElement {
       currentModel: model,
       thinkingLevel,
       fastMode: fastMode === "auto" || typeof fastMode === "boolean" ? fastMode : false,
-      channels: quickChannels(configObject),
+      channels: quickChannels(configObject, this.context.channels.state.channelsSnapshot),
       automation: {
         cronJobCount: 0,
         skillCount: 0,

--- a/ui/src/pages/config/quick.test.ts
+++ b/ui/src/pages/config/quick.test.ts
@@ -198,7 +198,8 @@ describe("renderQuickSettings", () => {
       renderQuickSettings(
         createProps({
           channels: [
-            { id: "discord", label: "Discord", connected: true, detail: "Configured" },
+            { id: "discord", label: "Discord", connected: true, configured: true, detail: "Connected" },
+            { id: "slack", label: "Slack", connected: false, configured: true, detail: "Configured" },
             { id: "telegram", label: "Telegram", connected: false },
           ],
           onChannelConfigure,
@@ -208,7 +209,10 @@ describe("renderQuickSettings", () => {
     );
 
     const discordRow = expectRowByTitle(container, "Discord");
-    expect(discordRow.querySelector(".settings-status")?.textContent?.trim()).toBe("Configured");
+    expect(discordRow.querySelector(".settings-status")?.textContent?.trim()).toBe("Connected");
+    const slackRow = expectRowByTitle(container, "Slack");
+    expect(slackRow.querySelector("button")).toBeNull();
+    expect(slackRow.querySelector(".settings-status")?.textContent?.trim()).toBe("Configured");
     const telegramRow = expectRowByTitle(container, "Telegram");
     const connectButton = telegramRow.querySelector("button");
     expect(connectButton?.textContent?.trim()).toBe("Connect →");

--- a/ui/src/pages/config/quick.ts
+++ b/ui/src/pages/config/quick.ts
@@ -54,6 +54,7 @@ export type QuickSettingsChannel = {
   id: string;
   label: string;
   connected: boolean;
+  configured?: boolean;
   detail?: string;
 };
 
@@ -439,11 +440,16 @@ function renderChannelsSection(props: QuickSettingsProps) {
             title: ch.label,
             control: ch.connected
               ? renderSettingsStatus({ kind: "ok", label: ch.detail ?? t("common.connected") })
-              : html`
-                  <button class="btn" @click=${() => props.onChannelConfigure?.(ch.id)}>
-                    ${t("quickSettings.channels.connect")}
-                  </button>
-                `,
+              : ch.configured
+                ? renderSettingsStatus({
+                    kind: "muted",
+                    label: ch.detail ?? t("common.configured"),
+                  })
+                : html`
+                    <button class="btn" @click=${() => props.onChannelConfigure?.(ch.id)}>
+                      ${t("quickSettings.channels.connect")}
+                    </button>
+                  `,
           }),
         );
   return renderTargetSection(


### PR DESCRIPTION
## Summary
- derive Quick Settings channel rows from the live channels snapshot instead of config presence alone
- keep configured-but-disconnected channels labeled as Configured instead of counting them as connected
- add regression coverage for both extraction and rendering

Closes #107855

## Testing
- CI=true ./node_modules/.bin/vitest run ui/src/ui/app-render.assistant-avatar.test.ts ui/src/ui/views/config-quick.test.ts