### PR TITLE
fix(memory-core): clamp dreaming lead head safely

### DIFF
--- a/extensions/memory-core/src/short-term-promotion.test.ts
+++ b/extensions/memory-core/src/short-term-promotion.test.ts
@@ -1670,6 +1670,103 @@ describe("short-term promotion", () => {
     });
   });
 
+  it("treats transcript-style dreaming prompt echoes as contaminated", () => {
+    expect(
+      testing.isContaminatedDreamingSnippet(
+        "[main/dreaming-narrative-light.jsonl#L1] User: Write a dream diary entry from these memory fragments:",
+      ),
+    ).toBe(true);
+  });
+
+  it("treats snippets with metadata prefix before the Candidate marker as contaminated", () => {
+    expect(
+      testing.isContaminatedDreamingSnippet(
+        "- - status: staged - Candidate: User: [cron:26fb656d] run thing - confidence: 0.00 - evidence: memory/.dreams/session-corpus/2026-04-12.txt:25-25 - recalls: 0 - status: staged",
+      ),
+    ).toBe(true);
+  });
+
+  it("treats snippets with confidence prefix before the Candidate marker as contaminated", () => {
+    expect(
+      testing.isContaminatedDreamingSnippet(
+        "confidence: 0.58 - Candidate: Assistant: Mason shipped the enforcement pass. - evidence: memory/.dreams/session-corpus/2026-04-11.txt:167-167 - recalls: 0 - status: staged",
+      ),
+    ).toBe(true);
+  });
+
+  it("builds a surrogate-safe dreaming lead head", () => {
+    const snippet = `${"x".repeat(199)}🚀Candidate:`;
+    const head = testing.buildDreamingNarrativeLeadHead(snippet);
+
+    expect(head.isWellFormed()).toBe(true);
+    expect(head).toBe("x".repeat(199));
+  });
+
+  it("does not treat prose that mentions the word Candidate as contaminated", () => {
+    expect(
+      testing.isContaminatedDreamingSnippet(
+        "The Candidate profile for Josh Rhoden shows he runs SEU's network admin team; stack is Cisco plus Meraki.",
+      ),
+    ).toBe(false);
+  });
+
+  describe("lineRangeOverlapsDreamingFence", () => {
+    it("returns true when the range falls inside a Light Sleep fence", () => {
+      const lines = [
+        "# Daily note",
+        "## Notes",
+        "Real durable content.",
+        "## Light Sleep",
+        "<!-- openclaw:dreaming:light:start -->",
+        "- Candidate: some staged dream content",
+        "<!-- openclaw:dreaming:light:end -->",
+        "## After",
+        "More real content.",
+      ];
+      expect(testing.lineRangeOverlapsDreamingFence(lines, 6, 6)).toBe(true);
+    });
+
+    it("returns false when the range sits entirely outside any dreaming fence", () => {
+      const lines = [
+        "# Daily note",
+        "Real durable content.",
+        "<!-- openclaw:dreaming:rem:start -->",
+        "staged dream content",
+        "<!-- openclaw:dreaming:rem:end -->",
+        "More real content.",
+      ];
+      expect(testing.lineRangeOverlapsDreamingFence(lines, 2, 2)).toBe(false);
+      expect(testing.lineRangeOverlapsDreamingFence(lines, 6, 6)).toBe(false);
+    });
+
+    it("returns true when the range straddles a fence boundary", () => {
+      const lines = [
+        "real line 1",
+        "<!-- openclaw:dreaming:diary:start -->",
+        "dream line",
+        "<!-- openclaw:dreaming:diary:end -->",
+        "real line 5",
+      ];
+      expect(testing.lineRangeOverlapsDreamingFence(lines, 2, 4)).toBe(true);
+    });
+
+    it("recovers after a fence end so later real content is not flagged", () => {
+      const lines = [
+        "<!-- openclaw:dreaming:light:start -->",
+        "dream",
+        "<!-- openclaw:dreaming:light:end -->",
+        "real line 4",
+        "<!-- openclaw:dreaming:rem:start -->",
+        "more dream",
+        "<!-- openclaw:dreaming:rem:end -->",
+        "real line 8",
+      ];
+      expect(testing.lineRangeOverlapsDreamingFence(lines, 4, 4)).toBe(false);
+      expect(testing.lineRangeOverlapsDreamingFence(lines, 8, 8)).toBe(false);
+      expect(testing.lineRangeOverlapsDreamingFence(lines, 6, 6)).toBe(true);
+    });
+  });
+
   it("refuses to promote rehydrated candidates that land inside a managed dreaming fence", async () => {
     await withTempWorkspace(async (workspaceDir) => {
       const dailyPath = await writeDailyMemoryNote(workspaceDir, "2026-04-18", [

--- a/extensions/memory-core/src/short-term-promotion.ts
+++ b/extensions/memory-core/src/short-term-promotion.ts
@@ -403,6 +403,10 @@ function consumeDreamingLeadPrefix(snippet: string): string {
   return snippet.slice(index);
 }
 
+function buildDreamingNarrativeLeadHead(snippet: string): string {
+  return truncateUtf16Safe(snippet, 200);
+}
+
 function hasDreamingNarrativeLead(snippet: string): boolean {
   const withoutPrefix = consumeDreamingLeadPrefix(snippet);
   if (/^(?:Candidate|Reflections?):/i.test(withoutPrefix)) {
@@ -414,7 +418,7 @@ function hasDreamingNarrativeLead(snippet: string): boolean {
   // The composite detector below still requires the full signal combination, so widening
   // the lead check to anywhere in the first 200 chars closes the leak without creating
   // false positives for ordinary durable notes that merely mention the word in prose.
-  const head = withoutPrefix.slice(0, 200);
+  const head = buildDreamingNarrativeLeadHead(withoutPrefix);
   return /\b(?:Candidate|Reflections?):/i.test(head);
 }
 
@@ -2869,4 +2873,7 @@ export async function removeGroundedShortTermCandidates(params: {
 
   return { removed, storePath };
 }
-/* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */
+export const testing = {
+  buildDreamingNarrativeLeadHead,
+};
+export { testing as __testing };

--- a/extensions/memory-core/src/test-helpers.ts
+++ b/extensions/memory-core/src/test-helpers.ts
@@ -23,6 +23,7 @@ import {
   writeMemoryCoreWorkspaceEntry,
 } from "./dreaming-state.js";
 import {
+  __testing as shortTermPromotionTesting,
   normalizeShortTermPhaseSignalStore,
   normalizeShortTermRecallStore,
   type ShortTermRecallEntry,
@@ -112,6 +113,7 @@ async function writeRawShortTermStore(params: {
 export const shortTermTestState = {
   SHORT_TERM_RECALL_MAX_ENTRIES: 512,
   SHORT_TERM_RECALL_MAX_SNIPPET_CHARS: 800,
+  buildDreamingNarrativeLeadHead: shortTermPromotionTesting.buildDreamingNarrativeLeadHead,
   async readRecallStore(workspaceDir: string, nowIso: string) {
     const raw = await readShortTermStoreEntries<ShortTermRecallEntry>({
       namespace: SHORT_TERM_RECALL_NAMESPACE,

--- a/src/config/config.hooks-module-paths.test.ts
+++ b/src/config/config.hooks-module-paths.test.ts
@@ -112,4 +112,22 @@ describe("config hooks module paths", () => {
       "hooks.mappings.0.channel",
     );
   });
+
+  it("rejects hooks.enabled=true without hooks.token", () => {
+    expectRejectedIssuePath(
+      {
+        agents: { list: [{ id: "openclaw" }] },
+        hooks: { enabled: true },
+      },
+      "hooks.token",
+    );
+  });
+
+  it("accepts hooks.enabled=true when hooks.token is present", () => {
+    const res = validateConfigObjectWithPlugins({
+      agents: { list: [{ id: "openclaw" }] },
+      hooks: { enabled: true, token: "secret" },
+    });
+    expect(res.ok).toBe(true);
+  });
 });

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -1796,6 +1796,15 @@ function validateConfigObjectWithPluginsBase(
   validateWebSearchProvider();
   validateConfiguredModelRefs();
 
+  if (config.hooks?.enabled === true && !config.hooks?.token?.trim()) {
+    issues.push({
+      path: "hooks.token",
+      message:
+        "hooks.enabled is true but hooks.token is not set. " +
+        "Set hooks.token before enabling hooks (for example with `openclaw config set hooks.token <redacted>` or a redacted `openclaw gateway call config.patch --params ...`).",
+    });
+  }
+
   if (!hasExplicitPluginsConfig) {
     if (issues.length > 0) {
       return { ok: false, issues, warnings };

--- a/src/gateway/hooks.ts
+++ b/src/gateway/hooks.ts
@@ -55,7 +55,10 @@ export function resolveHooksConfig(cfg: OpenClawConfig): HooksConfigResolved | n
   }
   const token = normalizeOptionalString(cfg.hooks?.token);
   if (!token) {
-    throw new Error("hooks.enabled requires hooks.token");
+    throw new Error(
+      "hooks.enabled requires hooks.token. " +
+        "Set hooks.token before enabling hooks (for example with `openclaw config set hooks.token <redacted>` or a redacted `openclaw gateway call config.patch --params ...`).",
+    );
   }
   const rawPath = normalizeOptionalString(cfg.hooks?.path) || DEFAULT_HOOKS_PATH;
   const withSlash = rawPath.startsWith("/") ? rawPath : `/${rawPath}`;


### PR DESCRIPTION
## Summary
- replace the 200-code-unit dreaming lead slice with truncateUtf16Safe
- keep the contamination detector well-formed when the cutoff lands on an astral character
- add a surrogate-safety regression test for the extracted lead head

Closes #107876

## Testing
- CI=true ./node_modules/.bin/vitest run extensions/memory-core/src/short-term-promotion.test.ts