### PR TITLE
fix(ui): restore chat module boundaries

### DIFF
--- a/ui/src/pages/chat/chat-history-pagination.ts
+++ b/ui/src/pages/chat/chat-history-pagination.ts
@@ -1,0 +1,3 @@
+export type ChatHistoryPagination =
+  | { hasMore: false; totalMessages?: number; completeSnapshot?: true }
+  | { hasMore: true; nextOffset: number; totalMessages?: number };

--- a/ui/src/pages/chat/chat-history.ts
+++ b/ui/src/pages/chat/chat-history.ts
@@ -43,6 +43,7 @@ import {
   resolveUiSelectedSessionAgentId,
 } from "../../lib/sessions/session-key.ts";
 import { normalizeLowercaseStringOrEmpty } from "../../lib/string-coerce.ts";
+import type { ChatHistoryPagination } from "./chat-history-pagination.ts";
 import {
   isRetryableStartupUnavailable,
   isUnknownGatewayMethodError,
@@ -376,10 +377,6 @@ export type ChatHistoryResult = {
   agentsList?: AgentsListResult;
   metadata?: ChatMetadataResult;
 };
-
-export type ChatHistoryPagination =
-  | { hasMore: false; totalMessages?: number; completeSnapshot?: true }
-  | { hasMore: true; nextOffset: number; totalMessages?: number };
 
 export function resolveChatHistoryPagination(
   result: ChatHistoryResult | undefined,

--- a/ui/src/pages/chat/chat-pane.ts
+++ b/ui/src/pages/chat/chat-pane.ts
@@ -63,6 +63,7 @@ import { OpenClawLightDomElement } from "../../lit/openclaw-element.ts";
 import { PollController } from "../../lit/poll-controller.ts";
 import { catalogMessageId } from "./catalog-message-id.ts";
 import { refreshChatAvatar } from "./chat-avatar.ts";
+import type { ChatHistoryPagination } from "./chat-history-pagination.ts";
 import {
   applyChatAgentsList,
   clearChatHistory,
@@ -70,7 +71,6 @@ import {
   loadOlderChatHistoryPage,
   resolveChatHistoryPagination,
   syncSelectedSessionMessageSubscription,
-  type ChatHistoryPagination,
 } from "./chat-history.ts";
 import { dismissChatError, resolveAssistantAttachmentAuthToken } from "./chat-pane-state.ts";
 import { markQueuedChatSendsWaitingForReconnect } from "./chat-queue.ts";

--- a/ui/src/pages/chat/session-message-cache.ts
+++ b/ui/src/pages/chat/session-message-cache.ts
@@ -10,7 +10,7 @@ import {
   type UiSessionDefaultsHost,
 } from "../../lib/sessions/session-key.ts";
 import { normalizeLowercaseStringOrEmpty } from "../../lib/string-coerce.ts";
-import type { ChatHistoryPagination } from "./chat-history.ts";
+import type { ChatHistoryPagination } from "./chat-history-pagination.ts";
 import { readTranscriptSequence } from "./history-merge.ts";
 import { getSessionCacheValue, setSessionCacheValue } from "./session-cache.ts";
 


### PR DESCRIPTION
## What Problem This Solves

Resolves a Control UI runtime-topology cycle between chat history and the session message cache. The cache imported its pagination type from a runtime module that already imported the cache.

## Why This Change Was Made

Extracts the shared pagination type into a dependency-neutral leaf module. No runtime behavior changes.

## User Impact

No user-visible change. Restores the module-boundary guard so unrelated PRs can prepare and land.

## Evidence

- Fresh exact-head Testbox `tbx_01kxhrejbn22fmjk8fdztvrcmn`: the full architecture guard passed with zero runtime and Madge cycles.
- Same Testbox: 29 affected Control UI tests passed.
- Earlier scoped `check:changed` passed formatting, i18n verification, UI/core-test typechecks, and exhaustive lint for this extraction.
- Codex autoreview on the final four-file diff: no accepted/actionable findings, confidence 0.99.

AI-assisted. I reviewed the implementation and understand the affected module boundary.
