### PR TITLE
refactor(agents): repair runner export drift

### DIFF
--- a/src/agents/embedded-agent-runner/run-orchestrator.ts
+++ b/src/agents/embedded-agent-runner/run-orchestrator.ts
@@ -41,10 +41,6 @@ import type {
   RunEmbeddedAgentParamsWithSessionFile,
 } from "./run/internal-params.js";
 import { createEmbeddedRunLaneController } from "./run/lane-controller.js";
-import {
-  EMBEDDED_RUN_LANE_TIMEOUT_GRACE_MS,
-  resolveEmbeddedRunLaneTimeoutMs,
-} from "./run/lane-runtime.js";
 import type { RunEmbeddedAgentParams } from "./run/params.js";
 import { createEmbeddedRunProgressController } from "./run/progress-controller.js";
 import { resolveInitialEmbeddedRunModel } from "./run/runtime-resolution.js";
@@ -212,7 +208,7 @@ async function runEmbeddedAgentInternal(
       startupStages.mark("runtime-plugins");
       notifyExecutionPhase("runtime_plugins");
 
-      let { provider, modelId } = resolveInitialEmbeddedRunModel({
+      const { provider, modelId } = resolveInitialEmbeddedRunModel({
         config: params.config,
         agentId: workspaceResolution.agentId,
         provider: params.provider,
@@ -292,8 +288,3 @@ async function runEmbeddedAgentInternal(
     });
   });
 }
-
-export const testing = {
-  EMBEDDED_RUN_LANE_TIMEOUT_GRACE_MS,
-  resolveEmbeddedRunLaneTimeoutMs,
-};

--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -1,4 +1,14 @@
 /**
  * Public embedded-agent run entrypoint.
  */
-export { runEmbeddedAgent, testing } from "./run-orchestrator.js";
+import {
+  EMBEDDED_RUN_LANE_TIMEOUT_GRACE_MS,
+  resolveEmbeddedRunLaneTimeoutMs,
+} from "./run/lane-runtime.js";
+
+export { runEmbeddedAgent } from "./run-orchestrator.js";
+
+export const testing = {
+  EMBEDDED_RUN_LANE_TIMEOUT_GRACE_MS,
+  resolveEmbeddedRunLaneTimeoutMs,
+};

--- a/src/agents/embedded-agent-runner/run/assistant-failure.ts
+++ b/src/agents/embedded-agent-runner/run/assistant-failure.ts
@@ -29,7 +29,7 @@ import type { EmbeddedRunAttemptResult } from "./types.js";
 const MAX_EMPTY_ERROR_RETRIES = 3;
 const MAX_SAME_MODEL_IDLE_TIMEOUT_RETRIES = 1;
 
-export type EmbeddedRunAssistantFailureOutcome = {
+type EmbeddedRunAssistantFailureOutcome = {
   action: "retry" | "proceed";
   thinkLevel: ThinkLevel;
   authRetryPending: boolean;

--- a/src/agents/embedded-agent-runner/run/overflow-context-recovery.ts
+++ b/src/agents/embedded-agent-runner/run/overflow-context-recovery.ts
@@ -42,7 +42,7 @@ type ActiveSession = {
   target?: ContextEngineSessionTarget;
 };
 
-export type EmbeddedRunOverflowRecoveryOutcome =
+type EmbeddedRunOverflowRecoveryOutcome =
   | { action: "none" }
   | { action: "retry" }
   | {


### PR DESCRIPTION
## Summary

- keep the existing embedded-runner testing contract owned by its public run entrypoint
- privatize two split-created outcome types
- fix the split-created const lint regression
- leave the dead-export baseline unchanged

## Validation

- embedded runner lane-timeout tests: 2 passed
- core types: passed
- type-aware lint: passed
- production Knip: all three agent-runner drift findings removed; the remaining three findings belong to the separately prepared UI prerequisite
- autoreview: clean, 0.94