### PR TITLE
refactor(ui): privatize chat test helpers

### DIFF
--- a/ui/src/pages/chat/chat-page.test.ts
+++ b/ui/src/pages/chat/chat-page.test.ts
@@ -15,7 +15,7 @@ import { createStorageMock } from "../../test-helpers/storage.ts";
 import { ChatPage } from "./chat-page.ts";
 import type { ChatMessageCache } from "./session-message-cache.ts";
 import type { SplitDropZone } from "./split-drop-zone.ts";
-import { createSplitLayout, type ChatSplitLayout } from "./split-layout.ts";
+import { insertPane, type ChatSplitLayout } from "./split-layout.ts";
 
 type RenderedPane = HTMLElement & {
   paneId: string;
@@ -30,6 +30,15 @@ type RenderedPane = HTMLElement & {
 };
 
 type RenderedDivider = HTMLElement & { orientation: "horizontal" | "vertical" };
+
+function createSplitLayout(sessionKey: string): ChatSplitLayout {
+  const singlePane: ChatSplitLayout = {
+    columns: [{ id: "c1", panes: [{ id: "p1", sessionKey }], paneWeights: [1] }],
+    columnWeights: [1],
+    activePaneId: "p1",
+  };
+  return insertPane(singlePane, "p1", sessionKey, "right");
+}
 
 function itemAt<T>(items: ArrayLike<T>, index: number, label: string): T {
   return expectDefined(items[index], `${label} ${index}`);

--- a/ui/src/pages/chat/chat-send.test.ts
+++ b/ui/src/pages/chat/chat-send.test.ts
@@ -33,7 +33,7 @@ import {
 import { handleChatInputHistoryKey } from "./input-history.ts";
 import type { RenderLifecycle } from "./render-lifecycle.ts";
 import {
-  cacheChatMessages,
+  cacheChatSessionSnapshot,
   readChatMessagesFromCache,
   type ChatMessageCache,
 } from "./session-message-cache.ts";
@@ -59,6 +59,19 @@ function requireChatMessageCache(host: ChatHost): ChatMessageCache {
     throw new Error("Expected chat message cache");
   }
   return host.chatMessagesBySession;
+}
+
+function cacheChatMessages(
+  cache: ChatMessageCache,
+  host: Parameters<typeof cacheChatSessionSnapshot>[1],
+  target: Parameters<typeof cacheChatSessionSnapshot>[2],
+  messages: unknown[],
+): void {
+  cacheChatSessionSnapshot(cache, host, target, {
+    messages,
+    pagination: { hasMore: false },
+    sessionId: null,
+  });
 }
 
 const executeSlashCommandMock = vi.hoisted(() => vi.fn());

--- a/ui/src/pages/chat/session-message-cache.test.ts
+++ b/ui/src/pages/chat/session-message-cache.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   appendChatMessageToCache,
-  cacheChatMessages,
   cacheChatSessionSnapshot,
   readChatMessagesFromCache,
   readChatSessionSnapshot,
@@ -13,6 +12,19 @@ function createHost() {
     assistantAgentId: "ops",
     agentsList: { defaultId: "ops", mainKey: "home" },
   };
+}
+
+function cacheChatMessages(
+  cache: ChatMessageCache,
+  host: Parameters<typeof cacheChatSessionSnapshot>[1],
+  target: Parameters<typeof cacheChatSessionSnapshot>[2],
+  messages: unknown[],
+): void {
+  cacheChatSessionSnapshot(cache, host, target, {
+    messages,
+    pagination: { hasMore: false },
+    sessionId: null,
+  });
 }
 
 describe("session message cache", () => {

--- a/ui/src/pages/chat/session-message-cache.ts
+++ b/ui/src/pages/chat/session-message-cache.ts
@@ -82,21 +82,6 @@ function resolveChatMessageCacheKey(
   return `agent:${agentId}:${sessionKey}`;
 }
 
-export function cacheChatMessages(
-  cache: ChatMessageCache,
-  host: ChatMessageCacheHost,
-  target: ChatMessageCacheTarget,
-  messages: unknown[],
-): void {
-  const cacheKey = resolveChatMessageCacheKey(host, target);
-  const existing = getSessionCacheValue(cache, cacheKey)?.snapshot;
-  cacheChatSessionSnapshot(cache, host, target, {
-    messages,
-    pagination: existing?.pagination ?? { hasMore: false },
-    sessionId: existing?.sessionId ?? null,
-  });
-}
-
 export function appendChatMessageToCache(
   cache: ChatMessageCache,
   host: ChatMessageCacheHost,

--- a/ui/src/pages/chat/split-layout.test.ts
+++ b/ui/src/pages/chat/split-layout.test.ts
@@ -1,8 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
   closePane,
-  createSinglePaneLayout,
-  createSplitLayout,
   findPane,
   insertPane,
   normalizeChatSplitLayout,
@@ -13,6 +11,18 @@ import {
   setPaneSession,
   type ChatSplitLayout,
 } from "./split-layout.ts";
+
+function createSinglePaneLayout(sessionKey: string): ChatSplitLayout {
+  return {
+    columns: [{ id: "c1", panes: [{ id: "p1", sessionKey }], paneWeights: [1] }],
+    columnWeights: [1],
+    activePaneId: "p1",
+  };
+}
+
+function createSplitLayout(sessionKey: string): ChatSplitLayout {
+  return insertPane(createSinglePaneLayout(sessionKey), "p1", sessionKey, "right");
+}
 
 function threePaneLayout(): ChatSplitLayout {
   return insertPane(createSplitLayout("main"), "p2", "agent:main:second", "down");

--- a/ui/src/pages/chat/split-layout.ts
+++ b/ui/src/pages/chat/split-layout.ts
@@ -53,18 +53,6 @@ function nextPaneId(layout: ChatSplitLayout): string {
   return `p${max + 1}`;
 }
 
-export function createSinglePaneLayout(sessionKey: string): ChatSplitLayout {
-  return {
-    columns: [{ id: "c1", panes: [{ id: "p1", sessionKey }], paneWeights: [1] }],
-    columnWeights: [1],
-    activePaneId: "p1",
-  };
-}
-
-export function createSplitLayout(sessionKey: string): ChatSplitLayout {
-  return insertPane(createSinglePaneLayout(sessionKey), "p1", sessionKey, "right");
-}
-
 export function findPane(
   layout: ChatSplitLayout,
   paneId: string,


### PR DESCRIPTION
## Summary

- remove three production exports used only by chat tests
- retain coverage through cache snapshot and layout insertion production boundaries
- leave the dead-export baseline unchanged

## Validation

- focused UI tests: 242 passed
- UI production and test types: passed
- type-aware lint: passed
- dead-export baseline: byte-stable at 359
- autoreview: clean, 0.96