### PR TITLE
fix(memory): re-throw non-ENOENT/ENOTDIR errors in root memory file lookup

### DIFF
--- a/src/agents/workspace.test.ts
+++ b/src/agents/workspace.test.ts
@@ -1058,6 +1058,52 @@ describe("loadWorkspaceBootstrapFiles", () => {
     }
   });
 
+  it("does not mark a pending workspace complete when a lookup failure makes it unreadable", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    if (typeof process.getuid === "function" && process.getuid() === 0) {
+      return;
+    }
+    const rootDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-workspace-pending-eacces-"));
+    try {
+      const workspaceDir = path.join(rootDir, "workspace");
+      await fs.mkdir(workspaceDir, { recursive: true });
+
+      // Phase 1: real setup seeds an unchanged-template pending workspace:
+      // BOOTSTRAP.md exists, templates match, setup is not yet complete.
+      await ensureAgentWorkspace({ dir: workspaceDir, ensureBootstrapFiles: true });
+      const pendingState = await readWorkspaceState(workspaceDir);
+      expect(pendingState.setupCompletedAt).toBeUndefined();
+      await expect(
+        fs.access(path.join(workspaceDir, DEFAULT_BOOTSTRAP_FILENAME)),
+      ).resolves.toBeUndefined();
+
+      // Phase 2: the dir becomes unreadable (readdir EACCES) but known files
+      // remain writable/searchable (0300). A lookup failure must NOT be treated
+      // as positive completion evidence: pending workspaces must keep their
+      // BOOTSTRAP.md and must not acquire a durable false setupCompletedAt.
+      await fs.chmod(workspaceDir, 0o300);
+      try {
+        await expect(
+          ensureAgentWorkspace({ dir: workspaceDir, ensureBootstrapFiles: true }),
+        ).resolves.toBeDefined();
+      } finally {
+        await fs.chmod(workspaceDir, 0o700);
+      }
+
+      // Phase 3: still pending — BOOTSTRAP.md survives and no false completion.
+      await expect(
+        fs.access(path.join(workspaceDir, DEFAULT_BOOTSTRAP_FILENAME)),
+      ).resolves.toBeUndefined();
+      const after = await readWorkspaceState(workspaceDir);
+      expect(after.setupCompletedAt).toBeUndefined();
+      expect(after.bootstrapSeededAt).toMatch(/\d{4}-\d{2}-\d{2}T/);
+    } finally {
+      await fs.rm(rootDir, { recursive: true, force: true });
+    }
+  });
+
   it("treats hardlinked bootstrap aliases as unreadable", async () => {
     if (process.platform === "win32") {
       return;

--- a/src/agents/workspace.test.ts
+++ b/src/agents/workspace.test.ts
@@ -990,6 +990,34 @@ describe("loadWorkspaceBootstrapFiles", () => {
     expect(getMemoryEntries(files)).toHaveLength(0);
   });
 
+  it("does not reject the whole bootstrap load when the workspace dir is unreadable", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    // root bypasses directory permission checks, so this scenario cannot be
+    // exercised as root.
+    if (typeof process.getuid === "function" && process.getuid() === 0) {
+      return;
+    }
+    const rootDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-workspace-eacces-"));
+    try {
+      const workspaceDir = path.join(rootDir, "workspace");
+      await fs.mkdir(workspaceDir, { recursive: true });
+      await fs.writeFile(path.join(workspaceDir, "MEMORY.md"), "memory", "utf8");
+      await fs.chmod(workspaceDir, 0o000);
+      try {
+        // An unreadable workspace directory must not turn an EACCES from the
+        // exact-entry lookup into a rejected bootstrap load; the guarded read
+        // reports the unreadable entry and other context remains readable.
+        await expect(loadWorkspaceBootstrapFiles(workspaceDir)).resolves.toBeDefined();
+      } finally {
+        await fs.chmod(workspaceDir, 0o700);
+      }
+    } finally {
+      await fs.rm(rootDir, { recursive: true, force: true });
+    }
+  });
+
   it("treats hardlinked bootstrap aliases as unreadable", async () => {
     if (process.platform === "win32") {
       return;

--- a/src/agents/workspace.test.ts
+++ b/src/agents/workspace.test.ts
@@ -412,6 +412,41 @@ describe("ensureAgentWorkspace", () => {
     expect((await readWorkspaceState(tempDir)).setupCompletedAt).toMatch(/\d{4}-\d{2}-\d{2}T/);
   });
 
+  it("preserves readable custom-skill survival evidence under an unlistable root", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    if (typeof process.getuid === "function" && process.getuid() === 0) {
+      return;
+    }
+    const rootDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-workspace-skill-eacces-"));
+    try {
+      const tempDir = path.join(rootDir, "workspace");
+      await fs.mkdir(tempDir, { recursive: true });
+      await ensureAgentWorkspace({ dir: tempDir, ensureBootstrapFiles: true });
+
+      // Only a readable custom skill survives; the root becomes searchable but
+      // unlistable (0300). The exact-entry lookup on the root now raises EACCES,
+      // but the skill probe only needs search on the root and read on the skills
+      // subdirectory — it must still establish workspace survival so a recent
+      // attestation is not mistaken for a vanished workspace.
+      await fs.rm(tempDir, { recursive: true, force: true });
+      await fs.mkdir(path.join(tempDir, "skills", "local-skill"), { recursive: true });
+      await fs.writeFile(path.join(tempDir, "skills", "local-skill", "SKILL.md"), "---\n");
+      await fs.chmod(tempDir, 0o300);
+      try {
+        await expect(
+          ensureAgentWorkspace({ dir: tempDir, ensureBootstrapFiles: true }),
+        ).resolves.toMatchObject({ dir: tempDir });
+      } finally {
+        await fs.chmod(tempDir, 0o700);
+      }
+      expect((await readWorkspaceState(tempDir)).setupCompletedAt).toMatch(/\d{4}-\d{2}-\d{2}T/);
+    } finally {
+      await fs.rm(rootDir, { recursive: true, force: true });
+    }
+  });
+
   it("refuses a recently attested workspace when only non-skill skills leftovers survive", async () => {
     const tempDir = await makeTempWorkspace("openclaw-workspace-");
     await ensureAgentWorkspace({ dir: tempDir, ensureBootstrapFiles: true });

--- a/src/agents/workspace.test.ts
+++ b/src/agents/workspace.test.ts
@@ -1018,6 +1018,46 @@ describe("loadWorkspaceBootstrapFiles", () => {
     }
   });
 
+  it("does not abort setup or reseed when the workspace dir becomes unlistable", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    if (typeof process.getuid === "function" && process.getuid() === 0) {
+      return;
+    }
+    const rootDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-workspace-unlistable-"));
+    try {
+      const workspaceDir = path.join(rootDir, "workspace");
+      await fs.mkdir(workspaceDir, { recursive: true });
+      await fs.writeFile(path.join(workspaceDir, DEFAULT_MEMORY_FILENAME), "user memory", "utf8");
+
+      // Phase 1: real setup records existing state (skip-bootstrap).
+      await ensureAgentWorkspace({ dir: workspaceDir, ensureBootstrapFiles: false });
+      const before = await fs.readdir(workspaceDir);
+
+      // Phase 2: the dir becomes unlistable (readdir EACCES, but known files
+      // still open). Setup must not abort from the exact-entry/listing lookup
+      // and must not mistake the unreadable workspace for an empty one.
+      await fs.chmod(workspaceDir, 0o100);
+      try {
+        await expect(
+          ensureAgentWorkspace({ dir: workspaceDir, ensureBootstrapFiles: false }),
+        ).resolves.toBeDefined();
+      } finally {
+        await fs.chmod(workspaceDir, 0o700);
+      }
+
+      // Phase 3: existing content and setup state survived (no reseed/clear).
+      const after = await fs.readdir(workspaceDir);
+      expect(after.sort()).toEqual(before.sort());
+      expect(await fs.readFile(path.join(workspaceDir, DEFAULT_MEMORY_FILENAME), "utf8")).toBe(
+        "user memory",
+      );
+    } finally {
+      await fs.rm(rootDir, { recursive: true, force: true });
+    }
+  });
+
   it("treats hardlinked bootstrap aliases as unreadable", async () => {
     if (process.platform === "win32") {
       return;

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -416,10 +416,21 @@ async function hasWorkspaceUserContentEvidence(
       // continue
     }
   }
-  if (await exactWorkspaceEntryExists(dir, DEFAULT_MEMORY_FILENAME)) {
+  // The exact-entry lookup distinguishes an absent optional file from one that
+  // exists but cannot be listed/read. When any lookup fails operationally
+  // (EACCES/EIO on the workspace dir or a skills dir), setup must not abort and
+  // must not mistake an unreadable workspace for an empty one (which could
+  // trigger brand-new detection and reseed/clear existing setup). Treat the
+  // workspace as having user content so setup preserves existing state; the
+  // diagnostics surface separately through the bootstrap loader's guarded reads.
+  try {
+    if (await exactWorkspaceEntryExists(dir, DEFAULT_MEMORY_FILENAME)) {
+      return true;
+    }
+    return await hasWorkspaceSkillEvidence(dir);
+  } catch {
     return true;
   }
-  return await hasWorkspaceSkillEvidence(dir);
 }
 
 async function hasWorkspaceSkillEvidence(dir: string): Promise<boolean> {
@@ -462,9 +473,14 @@ async function hasSkipBootstrapWorkspaceContentEvidence(dir: string): Promise<bo
     }
   } catch (err) {
     const anyErr = err as { code?: string };
-    if (anyErr.code !== "ENOENT") {
-      throw err;
+    if (anyErr.code === "ENOENT") {
+      return false;
     }
+    // An operational listing failure (EACCES/EIO) means we cannot tell whether
+    // the workspace has content. Treat it as having content so setup preserves
+    // the workspace instead of aborting or mistaking an unreadable dir for an
+    // empty one (which could trigger brand-new detection and reseed/clear).
+    return true;
   }
   return false;
 }

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -417,20 +417,16 @@ async function hasWorkspaceUserContentEvidence(
     }
   }
   // The exact-entry lookup distinguishes an absent optional file from one that
-  // exists but cannot be listed/read. When any lookup fails operationally
-  // (EACCES/EIO on the workspace dir or a skills dir), setup must not abort and
-  // must not mistake an unreadable workspace for an empty one (which could
-  // trigger brand-new detection and reseed/clear existing setup). Treat the
-  // workspace as having user content so setup preserves existing state; the
-  // diagnostics surface separately through the bootstrap loader's guarded reads.
-  try {
-    if (await exactWorkspaceEntryExists(dir, DEFAULT_MEMORY_FILENAME)) {
-      return true;
-    }
-    return await hasWorkspaceSkillEvidence(dir);
-  } catch {
+  // exists but cannot be listed/read. An operational lookup failure (EACCES/EIO)
+  // stays an unknown outcome: it is neither absence nor positive user-content
+  // evidence. Callers decide how to treat the unknown — completion evidence must
+  // not count it as configured (that could persist false completion and remove
+  // BOOTSTRAP.md), while disappearance detection must not count it as empty
+  // (that could reseed/clear an existing workspace).
+  if (await exactWorkspaceEntryExists(dir, DEFAULT_MEMORY_FILENAME)) {
     return true;
   }
+  return await hasWorkspaceSkillEvidence(dir);
 }
 
 async function hasWorkspaceSkillEvidence(dir: string): Promise<boolean> {
@@ -494,12 +490,19 @@ async function workspaceProfileLooksConfigured(params: {
       fileContentDiffersFromTemplate(path.join(params.dir, fileName), await loadTemplate(fileName)),
     ),
   );
-  return (
-    profileFileDiffs.some(Boolean) ||
-    (await hasWorkspaceUserContentEvidence(params.dir, {
+  if (profileFileDiffs.some(Boolean)) {
+    return true;
+  }
+  try {
+    return await hasWorkspaceUserContentEvidence(params.dir, {
       includeGit: params.includeGitEvidence,
-    }))
-  );
+    });
+  } catch {
+    // An operational lookup failure is an unknown, not positive completion
+    // evidence. Treat it as not configured so a pending workspace keeps its
+    // BOOTSTRAP.md and does not acquire a durable false setupCompletedAt.
+    return false;
+  }
 }
 
 async function workspaceRequiredBootstrapLooksCustomized(
@@ -1097,7 +1100,11 @@ export async function ensureAgentWorkspace(params?: {
         }
       }),
     );
-    return existing.every((v) => !v) && !(await hasWorkspaceUserContentEvidence(dir));
+    // An operational lookup failure is an unknown; treat it as having user
+    // content so an unreadable workspace is not mistaken for an empty/brand-new
+    // one (which would reseed or clear existing setup).
+    const hasUserContent = await hasWorkspaceUserContentEvidence(dir).catch(() => true);
+    return existing.every((v) => !v) && !hasUserContent;
   })();
 
   if (isBrandNewWorkspace) {

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -1280,11 +1280,20 @@ export async function loadWorkspaceBootstrapFiles(
 
   const result: WorkspaceBootstrapFile[] = [];
   for (const entry of entries) {
-    if (
-      (entry.name === DEFAULT_MEMORY_FILENAME || entry.name === DEFAULT_USER_FILENAME) &&
-      !(await exactWorkspaceEntryExists(resolvedDir, entry.name))
-    ) {
-      continue;
+    if (entry.name === DEFAULT_MEMORY_FILENAME || entry.name === DEFAULT_USER_FILENAME) {
+      // The exact-entry check distinguishes an absent optional file (skipped)
+      // from one that exists but cannot be listed or read. When the lookup
+      // itself fails operationally (e.g. EACCES/EIO on the workspace dir), do
+      // not reject the whole bootstrap load: fall through to the guarded read,
+      // which produces the existing [UNREADABLE: ...] record and retains the
+      // remaining readable context.
+      try {
+        if (!(await exactWorkspaceEntryExists(resolvedDir, entry.name))) {
+          continue;
+        }
+      } catch {
+        // Fall through to the guarded read; it reports unreadability per entry.
+      }
     }
     const loaded = await readWorkspaceFileWithGuards({
       filePath: entry.filePath,

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -416,6 +416,14 @@ async function hasWorkspaceUserContentEvidence(
       // continue
     }
   }
+  // Readable custom skills are independent user-content evidence that survives
+  // a root-listing failure (e.g. a 0300 searchable-but-unlistable root): the
+  // probe only needs search on the root plus read on the skills subdirectory.
+  // Probe them before the exact-entry lookup so an EACCES on the root cannot
+  // hide readable skills from survival/completion decisions.
+  if (await hasWorkspaceSkillEvidence(dir)) {
+    return true;
+  }
   // The exact-entry lookup distinguishes an absent optional file from one that
   // exists but cannot be listed/read. An operational lookup failure (EACCES/EIO)
   // stays an unknown outcome: it is neither absence nor positive user-content
@@ -423,10 +431,7 @@ async function hasWorkspaceUserContentEvidence(
   // not count it as configured (that could persist false completion and remove
   // BOOTSTRAP.md), while disappearance detection must not count it as empty
   // (that could reseed/clear an existing workspace).
-  if (await exactWorkspaceEntryExists(dir, DEFAULT_MEMORY_FILENAME)) {
-    return true;
-  }
-  return await hasWorkspaceSkillEvidence(dir);
+  return await exactWorkspaceEntryExists(dir, DEFAULT_MEMORY_FILENAME);
 }
 
 async function hasWorkspaceSkillEvidence(dir: string): Promise<boolean> {

--- a/src/memory/root-memory-files.test.ts
+++ b/src/memory/root-memory-files.test.ts
@@ -1,0 +1,111 @@
+import { mkdirSync, chmodSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  CANONICAL_ROOT_MEMORY_FILENAME,
+  exactWorkspaceEntryExists,
+  resolveCanonicalRootMemoryFile,
+} from "./root-memory-files.js";
+
+const isRoot = process.getuid && process.getuid() === 0;
+const canTestEacces = process.platform !== "win32" && !isRoot;
+
+describe("resolveCanonicalRootMemoryFile", () => {
+  it("returns null for non-existent directory", async () => {
+    const result = await resolveCanonicalRootMemoryFile(
+      join(tmpdir(), `no-such-dir-${Date.now()}`),
+    );
+    expect(result).toBeNull();
+  });
+
+  it("returns null when directory has no MEMORY.md", async () => {
+    const dir = join(tmpdir(), `root-memory-test-empty-${Date.now()}`);
+    try {
+      mkdirSync(dir, { recursive: true });
+      const result = await resolveCanonicalRootMemoryFile(dir);
+      expect(result).toBeNull();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("returns path when MEMORY.md exists as a regular file", async () => {
+    const dir = join(tmpdir(), `root-memory-test-exists-${Date.now()}`);
+    try {
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(join(dir, CANONICAL_ROOT_MEMORY_FILENAME), "# Memory\n");
+      const result = await resolveCanonicalRootMemoryFile(dir);
+      expect(result).toBe(join(dir, CANONICAL_ROOT_MEMORY_FILENAME));
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("re-throws EACCES when directory is not readable", async ({ skip }) => {
+    if (!canTestEacces) return skip();
+    const dir = join(tmpdir(), `root-memory-test-eacces-${Date.now()}`);
+    try {
+      mkdirSync(dir, { recursive: true });
+      chmodSync(dir, 0o000);
+      await expect(resolveCanonicalRootMemoryFile(dir)).rejects.toThrow();
+    } finally {
+      try {
+        chmodSync(dir, 0o755);
+      } catch {
+        // already gone
+      }
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("exactWorkspaceEntryExists", () => {
+  it("returns false for non-existent directory", async () => {
+    const result = await exactWorkspaceEntryExists(
+      join(tmpdir(), `no-such-dir-${Date.now()}`),
+      "MEMORY.md",
+    );
+    expect(result).toBe(false);
+  });
+
+  it("returns true when entry exists", async () => {
+    const dir = join(tmpdir(), `exact-entry-test-exists-${Date.now()}`);
+    try {
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(join(dir, "MEMORY.md"), "");
+      const result = await exactWorkspaceEntryExists(dir, "MEMORY.md");
+      expect(result).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("returns false when entry does not exist", async () => {
+    const dir = join(tmpdir(), `exact-entry-test-missing-${Date.now()}`);
+    try {
+      mkdirSync(dir, { recursive: true });
+      const result = await exactWorkspaceEntryExists(dir, "MEMORY.md");
+      expect(result).toBe(false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("re-throws EACCES when directory is not readable", async ({ skip }) => {
+    if (!canTestEacces) return skip();
+    const dir = join(tmpdir(), `exact-entry-test-eacces-${Date.now()}`);
+    try {
+      mkdirSync(dir, { recursive: true });
+      chmodSync(dir, 0o000);
+      await expect(exactWorkspaceEntryExists(dir, "MEMORY.md")).rejects.toThrow();
+    } finally {
+      try {
+        chmodSync(dir, 0o755);
+      } catch {
+        // already gone
+      }
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/memory/root-memory-files.test.ts
+++ b/src/memory/root-memory-files.test.ts
@@ -1,0 +1,56 @@
+import { chmodSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { exactWorkspaceEntryExists } from "./root-memory-files.js";
+
+const isRoot = process.getuid && process.getuid() === 0;
+const canTestEacces = process.platform !== "win32" && !isRoot;
+
+describe("exactWorkspaceEntryExists", () => {
+  it("returns false for a non-existent directory", async () => {
+    const result = await exactWorkspaceEntryExists(
+      join(tmpdir(), `no-such-dir-${Date.now()}`),
+      "MEMORY.md",
+    );
+    expect(result).toBe(false);
+  });
+
+  it("returns true when the entry exists", async () => {
+    const dir = join(tmpdir(), `exact-entry-test-exists-${Date.now()}`);
+    try {
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(join(dir, "MEMORY.md"), "");
+      await expect(exactWorkspaceEntryExists(dir, "MEMORY.md")).resolves.toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("returns false when the entry does not exist", async () => {
+    const dir = join(tmpdir(), `exact-entry-test-missing-${Date.now()}`);
+    try {
+      mkdirSync(dir, { recursive: true });
+      await expect(exactWorkspaceEntryExists(dir, "MEMORY.md")).resolves.toBe(false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("re-throws EACCES when the directory is unreadable", async ({ skip }) => {
+    if (!canTestEacces) return skip();
+    const dir = join(tmpdir(), `exact-entry-test-eacces-${Date.now()}`);
+    try {
+      mkdirSync(dir, { recursive: true });
+      chmodSync(dir, 0o000);
+      await expect(exactWorkspaceEntryExists(dir, "MEMORY.md")).rejects.toThrow();
+    } finally {
+      try {
+        chmodSync(dir, 0o755);
+      } catch {
+        // restored or already removed
+      }
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/memory/root-memory-files.ts
+++ b/src/memory/root-memory-files.ts
@@ -27,13 +27,25 @@ function normalizeWorkspaceRelativePath(value: string): string {
   return value.trim().replace(/\\/g, "/").replace(/^\.\//, "");
 }
 
+function isErrnoCode(error: unknown, code: string): boolean {
+  return (
+    error !== null &&
+    typeof error === "object" &&
+    "code" in error &&
+    (error as { code: unknown }).code === code
+  );
+}
+
 /** Checks for an exact directory entry without case-folded path lookup. */
 export async function exactWorkspaceEntryExists(dir: string, name: string): Promise<boolean> {
   try {
     const entries = await fs.readdir(dir);
     return entries.includes(name);
-  } catch {
-    return false;
+  } catch (error: unknown) {
+    if (isErrnoCode(error, "ENOENT") || isErrnoCode(error, "ENOTDIR")) {
+      return false;
+    }
+    throw error;
   }
 }
 
@@ -50,7 +62,12 @@ export async function resolveCanonicalRootMemoryFile(workspaceDir: string): Prom
         return path.join(workspaceDir, entry.name);
       }
     }
-  } catch {}
+  } catch (error: unknown) {
+    if (isErrnoCode(error, "ENOENT") || isErrnoCode(error, "ENOTDIR")) {
+      return null;
+    }
+    throw error;
+  }
   return null;
 }
 

--- a/src/memory/root-memory-files.ts
+++ b/src/memory/root-memory-files.ts
@@ -33,8 +33,14 @@ export async function exactWorkspaceEntryExists(dir: string, name: string): Prom
   try {
     const entries = await fs.readdir(dir);
     return entries.includes(name);
-  } catch {
-    return false;
+  } catch (error) {
+    // A missing directory or non-directory component is absence; re-throw
+    // permission and I/O errors so callers do not mistake an unreadable
+    // workspace for a missing entry (e.g. and then overwrite/delete it).
+    if (isMissingPathError(error)) {
+      return false;
+    }
+    throw error;
   }
 }
 


### PR DESCRIPTION
## What Problem This Solves

`findRootMemoryFile` in `active-memory-files.ts` wraps `fs.readdir` in a try-catch that silently swallows all errors. Non-absence errors like `EACCES` (permission denied) are silently caught, masking real filesystem problems. The only legitimate reasons for the catch are `ENOENT` (file not yet created) and `ENOTDIR` (path component is not a directory) — both represent absence, not failure.

## Fix

Check `error.code` and only silently catch `ENOENT` and `ENOTDIR`. Re-throw all other errors so they surface to the caller.

## Evidence

### Before fix: all errors silently swallowed

```
=== EACCES case ===
Error code: EACCES
Before fix: catch {} silently swallows this
User never knows their memory file can't be read due to permissions
```

### After fix: only absence errors caught, others re-thrown

```
=== ENOENT case (should be silently caught) ===
Error code: ENOENT
ENOENT → acceptable: memory file not yet created

=== ENOTDIR case (should be silently caught) ===
ENOTDIR → acceptable: path component is not a directory

=== EACCES case (should be re-thrown) ===
Error code: EACCES
After fix: re-thrown because err.code is neither ENOENT nor ENOTDIR
```

## Test plan

- [x] ENOENT and ENOTDIR still silently caught (absence semantics preserved)
- [x] Other errors (EACCES, EMFILE, etc.) now re-thrown
- [x] Existing tests pass

## Real Behavior Proof (real filesystem through workspace bootstrap)

Real `node:fs` operations against real temporary directories, calling the real
production `resolveCanonicalRootMemoryFile` (workspace bootstrap loader) and
`exactWorkspaceEntryExists` (exact-entry helper) from `src/memory/root-memory-files.ts`.

Actual output:

```
1) workspace with MEMORY.md -> resolveCanonicalRootMemoryFile = /tmp/openclaw-proof-107921-*/with-memory/MEMORY.md
2) workspace without MEMORY.md -> resolveCanonicalRootMemoryFile = null
3) exactWorkspaceEntryExists(missing dir, "MEMORY.md") = false
4) exactWorkspaceEntryExists(with-memory, "MEMORY.md") = true
5) exactWorkspaceEntryExists(EACCES dir) -> EACCES

PROOF PASS: missing entries are absence (false/null); EACCES re-throws.
```

- A real workspace with `MEMORY.md` → bootstrap loader finds it.
- Without it → returns `null` (absence, not error).
- Missing dir → `false`; present entry → `true`.
- A real `chmod 000` directory → `EACCES` is re-thrown, NOT reported as absent,
  so bootstrap never mistakes an unreadable workspace for "no memory file" and
  overwrites/removes it.

### Caller fix (ClawSweeper P1: bootstrap recovery)

`loadWorkspaceBootstrapFiles` (`src/agents/workspace.ts`) awaited the exact-entry
check unguarded, so an EACCES/EIO from the lookup would reject the whole
bootstrap load. Now the caller falls through to `readWorkspaceFileWithGuards` on
a lookup error, which produces the existing `[UNREADABLE: ...]` record and
retains the remaining readable context. Covered by the new loader-level test
`does not reject the whole bootstrap load when the workspace dir is unreadable`.

**Tests all green:** `src/memory/root-memory-files.test.ts` (exact-entry
helper: present / missing dir / EACCES re-throw / missing name) and
`src/agents/workspace.test.ts` — 62/62 passed.


### Loader-level proof (real bootstrap loader, after-fix outcomes)

Real `loadWorkspaceBootstrapFiles` (`src/agents/workspace.ts`, the production
bootstrap loader) was driven against a real filesystem with `chmod 000`
unreadable entries — not just the helper. Recorded after-fix loader output:

```
[workspace] bootstrap file is unreadable: file=.../ws-file-eacces/MEMORY.md reason=EACCES: permission denied, open '.../MEMORY.md'
(a) unreadable MEMORY.md file:
    AGENTS.md: "# Agents\n\nkeep me\n"
    MEMORY.md: "[UNREADABLE: EACCES: permission denied, open '.../MEMORY.md']"
[workspace] bootstrap file is unreadable: file=.../ws-dir-eacces/AGENTS.md reason=EACCES: permission denied, lstat '.../AGENTS.md'
... (all 6 bootstrap entries report EACCES)
(b) unreadable workspace dir:
    resolved with 6 records (no rejection)
PROOF PASS: loader keeps readable context and reports unreadable entries instead of rejecting the bootstrap load.
```

This establishes the two production callers' after-fix behavior with recorded
loader diagnostics:

- **Unreadable `MEMORY.md` file** → the loader returns an `[UNREADABLE: ...]`
  record (not `missing`, not a thrown load), while the readable `AGENTS.md`
  stays loaded. The exact-entry helper (`exactWorkspaceEntryExists`) correctly
  reported the entry as present, routing it to the guarded read that produced
  the diagnostic.
- **Unreadable workspace directory** (readdir EACCES on the whole dir) → the
  exact-entry lookup error no longer rejects the whole bootstrap load; the
  loader falls through to its guarded reader and resolves with per-entry
  `[UNREADABLE]` records. This is the P1 caller-recovery fix in this head
  (`99779cd5b`).

Both are the real production loader with real filesystem errors — no mocks.
Run via the repo's tsx entrypoint; output above is verbatim.


### Setup-consumer fix (ClawSweeper P1) + real setup proof

The exact-entry helper now re-throws operational errors, and two **setup
consumers** awaited it unguarded: `hasWorkspaceUserContentEvidence` and
`hasSkipBootstrapWorkspaceContentEvidence`. A transiently unlistable workspace
dir (readdir EACCES) would abort setup — and, worse, could be mistaken for an
empty/brand-new workspace, triggering reseed/clear of existing setup.

Fix: both consumers treat an operational listing/lookup failure as **having
user content**, so setup preserves existing files and setup state instead of
aborting or reseeding. The unreadable-entry diagnostics continue to surface
separately through the bootstrap loader's guarded reads.

Real setup proof (real `ensureAgentWorkspace` + real filesystem, isolated
state DB):

```
phase1 setup done; entries: MEMORY.md
phase2 (dir unlistable, existing setup):
  resolved (no abort)
phase3 entries: MEMORY.md
  MEMORY.md preserved: true
PROOF PASS: workspace setup does not abort on exact-entry EACCES and preserves existing files + setup state.
```

The workspace dir was set execute-only (`chmod 0o100`) — listing fails with
EACCES while known files still open, the precise "workspace exists but cannot
be listed" scenario — after a real first setup pass created real SQLite setup
state. The second pass resolved without abort and the existing `MEMORY.md` and
setup state survived (no reseed/clear).

Regression: `does not abort setup or reseed when the workspace dir becomes
unlistable` (skip-bootstrap existing setup). **Tests all green:**
`src/agents/workspace.test.ts` 63/63 and `src/memory/root-memory-files.test.ts`
4/4.


### Revision 8 — lookup failures are never onboarding-completion evidence (P1)

ClawSweeper Revision 7 identified a concrete onboarding-state regression: a
pending workspace (unchanged templates, BOOTSTRAP.md, no memory indicators,
`setupCompletedAt` unset) whose directory loses read permission (mode 0300)
was treated as "configured" — `reconcileWorkspaceBootstrapCompletionState`
persisted a durable false `setupCompletedAt` and deleted BOOTSTRAP.md.

**Fix** — the exact-entry lookup keeps an *unknown* outcome distinct from
absence, and each caller decides how to treat it:

- `exactWorkspaceEntryExists` re-throws operational failures (EACCES/EIO), so
  an unreadable workspace is never mistaken for a missing entry.
- `hasWorkspaceUserContentEvidence` no longer swallows the failure into `true`.
  `workspaceProfileLooksConfigured` (completion evidence) catches it and
  returns **not configured** — a pending workspace keeps BOOTSTRAP.md and does
  not acquire a false `setupCompletedAt`.
- Brand-new detection catches it and treats the workspace as **having content**
  — an existing workspace is preserved instead of reseeded/cleared.

**Real behavior proof** (`.proof/proof-pending-eacces.ts`, safe Node 24.19.0,
`OPENCLAW_STATE_DIR`):

```
phase1 pending: setupCompletedAt=(unset)
phase1 BOOTSTRAP.md present: true
phase2 (dir unlistable, normal setup re-run):
  resolved (no abort)
phase3 BOOTSTRAP.md preserved: true
phase3 setupCompletedAt=(unset)
PROOF PASS: normal setup keeps a pending workspace pending under exact-entry
EACCES (BOOTSTRAP.md preserved, no false setupCompletedAt).
```

**Regression test** `does not mark a pending workspace complete when a lookup
failure makes it unreadable` — verified to FAIL against the previous catch→true
behavior (BOOTSTRAP.md was deleted) and passes with the fix. Full
`src/agents/workspace.test.ts`: **64/64 passed**.


### Revision 9 — readable custom-skill survival evidence under root EACCES (P1)

ClawSweeper Revision 8 found a second P1: the exact-entry lookup raised EACCES
*before* the skill probe ran, so a recently attested workspace reduced to only
a readable custom skill (root `0300`, searchable-but-unlistable) was mistaken
for vanished (`WorkspaceVanishedError`) or had its expired setup state cleared
and reseeded — even though `skills/local-skill/SKILL.md` stayed readable.

**Fix** — probe readable custom skills **first** in `hasWorkspaceUserContentEvidence`:
that check needs only search on the root plus read on the skills subdirectory,
so it survives a root-listing failure and still establishes workspace
survival/completion evidence. The exact-entry lookup now only runs when no
skills exist, retaining the pending-onboarding protection (a lookup failure
remains an unknown, never positive evidence).

**Real behavior proof** (`.proof/proof-pending-eacces.ts`, extended, safe Node
24.19.0, `OPENCLAW_STATE_DIR`):

```
phase1 pending: setupCompletedAt=(unset)
phase1 BOOTSTRAP.md present: true
phase2 (dir unlistable, normal setup re-run):
  resolved (no abort)
phase3 BOOTSTRAP.md preserved: true
phase3 setupCompletedAt=(unset)
PROOF PASS: normal setup keeps a pending workspace pending under exact-entry
EACCES (BOOTSTRAP.md preserved, no false setupCompletedAt).
phase4 (only readable skill survives, unlistable root):
  accepted (workspace survived)
PROOF PASS: readable custom-skill survival evidence survives an unlistable root
(no false WorkspaceVanishedError).
```

**Regression tests** (both verified to FAIL against the previous code and pass
with the fix):
- `does not mark a pending workspace complete when a lookup failure makes it
  unreadable` (previous code deleted BOOTSTRAP.md / persisted false completion)
- `preserves readable custom-skill survival evidence under an unlistable root`
  (previous code threw `WorkspaceVanishedError`)

Full `src/agents/workspace.test.ts`: **65/65 passed** (safe node).
