### PR TITLE
refactor(clickclack): privatize command menu mapping

### DIFF
--- a/extensions/clickclack/src/command-menu.test.ts
+++ b/extensions/clickclack/src/command-menu.test.ts
@@ -9,10 +9,7 @@ vi.mock("openclaw/plugin-sdk/native-command-registry", () => ({
   listNativeCommandSpecsForConfig: mocks.listNativeCommandSpecsForConfig,
 }));
 
-import {
-  mapNativeCommandSpecsToClickClackMenu,
-  syncClickClackCommandMenu,
-} from "./command-menu.js";
+import { syncClickClackCommandMenu } from "./command-menu.js";
 import type { createClickClackClient } from "./http-client.js";
 import type { CoreConfig } from "./types.js";
 
@@ -28,15 +25,38 @@ function nativeCommand(
   };
 }
 
+type CommandMenuEntry = {
+  command: string;
+  description: string;
+  args_hint: string;
+};
+
+async function syncNativeCommands(
+  specs: NativeCommandSpec[],
+  log?: NonNullable<Parameters<typeof syncClickClackCommandMenu>[0]["log"]>,
+): Promise<CommandMenuEntry[]> {
+  const setBotCommands = vi.fn().mockResolvedValue([]);
+  mocks.listNativeCommandSpecsForConfig.mockReturnValue(specs);
+
+  await syncClickClackCommandMenu({
+    cfg: {} as CoreConfig,
+    client: { setBotCommands } as unknown as ReturnType<typeof createClickClackClient>,
+    log,
+  });
+
+  expect(setBotCommands).toHaveBeenCalledTimes(1);
+  return setBotCommands.mock.calls[0]?.[0] as CommandMenuEntry[];
+}
+
 describe("ClickClack command menu", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it("maps native commands to the bounded ClickClack menu contract", () => {
+  it("maps native commands to the bounded ClickClack menu contract", async () => {
     const warn = vi.fn();
     const longDescription = "\u{1F642}".repeat(101);
-    const commands = mapNativeCommandSpecsToClickClackMenu(
+    const commands = await syncNativeCommands(
       [
         nativeCommand("Deploy-Now", {
           description: `  ${longDescription}  `,
@@ -88,18 +108,18 @@ describe("ClickClack command menu", () => {
     );
   });
 
-  it("keeps the first 100 unique normalized commands", () => {
+  it("keeps the first 100 unique normalized commands", async () => {
     const specs = Array.from({ length: 101 }, (_, index) => nativeCommand(`command${index}`));
 
-    const commands = mapNativeCommandSpecsToClickClackMenu(specs);
+    const commands = await syncNativeCommands(specs);
 
     expect(commands).toHaveLength(100);
     expect(commands[0]?.command).toBe("command0");
     expect(commands[99]?.command).toBe("command99");
   });
 
-  it("returns an empty overwrite for an empty native catalog", () => {
-    expect(mapNativeCommandSpecsToClickClackMenu([])).toEqual([]);
+  it("returns an empty overwrite for an empty native catalog", async () => {
+    await expect(syncNativeCommands([])).resolves.toEqual([]);
   });
 
   it("sources the catalog from the ClickClack native command registry", async () => {

--- a/extensions/clickclack/src/command-menu.ts
+++ b/extensions/clickclack/src/command-menu.ts
@@ -44,7 +44,7 @@ function errorStatus(error: unknown): number | undefined {
   return typeof status === "number" ? status : undefined;
 }
 
-export function mapNativeCommandSpecsToClickClackMenu(
+function mapNativeCommandSpecsToClickClackMenu(
   specs: NativeCommandSpec[],
   log?: ClickClackCommandMenuLogger,
 ): ClickClackCommandMenuEntry[] {


### PR DESCRIPTION
## Summary

- privatize the ClickClack native command mapping helper
- preserve normalization, bounds, empty-catalog, and warning coverage through the production sync boundary
- leave the dead-export baseline unchanged

## Validation

- focused ClickClack tests: 4 passed
- type-aware lint: passed
- dead-export baseline: byte-stable at 359
- extension type fan-out was capped after no diagnostics
- autoreview: clean, 0.97