### PR TITLE
fix(macos): update Peekaboo for Swift 6.2

### DIFF
--- a/apps/macos/Package.resolved
+++ b/apps/macos/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "1ef8c3159f08d9e5b942aecae21c4a350abc8b3f799fa1ea8cbcaf50ad1792f6",
+  "originHash" : "36b4eed5f0ab5307178cd25e14c3a22f00a5227b5dd462f297531ed701cfa7ef",
   "pins" : [
     {
       "identity" : "axorcist",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/steipete/AXorcist.git",
       "state" : {
-        "revision" : "289d403c53ce26cdd2fcb2bfb8672cd43adc2b43",
-        "version" : "0.1.2"
+        "revision" : "20d360e9f7a77b45a6ed3a25622e03029159e96c",
+        "version" : "0.1.4"
       }
     },
     {
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/steipete/Commander.git",
       "state" : {
-        "revision" : "ae2ce746b386ff94b26648cfe5625cfa8d02639b",
-        "version" : "0.2.2"
+        "revision" : "b9fb00564aa3229deeb48090801fec2c185951f4",
+        "version" : "0.2.3"
       }
     },
     {
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/steipete/Peekaboo.git",
       "state" : {
-        "revision" : "e3a2b3793fe4c4a6b4ccbc3069ccd9816516edb7",
-        "version" : "3.9.0"
+        "revision" : "3cfd612adbcb1b43e8431a7a1f3b02ec45d01269",
+        "version" : "3.9.3"
       }
     },
     {

--- a/apps/macos/Package.swift
+++ b/apps/macos/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
         .package(url: "https://github.com/swiftlang/swift-subprocess.git", from: "0.4.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.12.0"),
         .package(url: "https://github.com/sparkle-project/Sparkle", from: "2.9.0"),
-        .package(url: "https://github.com/steipete/Peekaboo.git", exact: "3.9.0"),
+        .package(url: "https://github.com/steipete/Peekaboo.git", exact: "3.9.3"),
         .package(url: "https://github.com/pointfreeco/swift-concurrency-extras", from: "1.3.1"),
         .package(path: "../shared/OpenClawKit"),
         .package(path: "../shared/OpenClawMLXTTSProtocol"),

--- a/apps/swabble/Package.swift
+++ b/apps/swabble/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
         .executable(name: "swabble", targets: ["SwabbleCLI"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/steipete/Commander.git", exact: "0.2.2"),
+        .package(url: "https://github.com/steipete/Commander.git", exact: "0.2.3"),
         .package(url: "https://github.com/apple/swift-testing", from: "6.3.1"),
     ],
     targets: [


### PR DESCRIPTION
Fixes https://github.com/openclaw/openclaw/issues/107850

## Summary

- update the macOS app to Peekaboo 3.9.3 / AXorcist 0.1.4
- align the direct Swabble Commander dependency with Peekaboo on 0.2.3
- regenerate the SwiftPM lockfile from the published release tags

## Verification

- ClawMac, Xcode beta / current Swift: `swift package resolve` and full `swift build`
- ClawMac: `swift test` in `apps/swabble` (7 passed)
- Blacksmith Testbox `tbx_01kxhrvvy63zn1fgjmwq60fhhw`: `pnpm check:changed` (178 passed, 37 skipped across selected shards)
- Testbox run: https://github.com/openclaw/openclaw/actions/runs/29383611868
- Peekaboo release: https://github.com/openclaw/Peekaboo/releases/tag/v3.9.3
- AXorcist release: https://github.com/openclaw/AXorcist/releases/tag/v0.1.4

## Security and configuration

No secret, protocol, or configuration changes.
