### PR TITLE
fix(ci): keep deprecated facade guard fixture current

### DIFF
--- a/test/scripts/check-deprecated-api-usage.test.ts
+++ b/test/scripts/check-deprecated-api-usage.test.ts
@@ -114,7 +114,7 @@ describe("scripts/check-deprecated-api-usage", () => {
 
   it("keeps the compat re-export chain and test files off the facade import rule", () => {
     const result = runFacadeImportRule({
-      "src/plugin-sdk/channel-message-runtime.ts": 'export * from "./channel-message.js";',
+      "src/plugin-sdk/channel-message-runtime.ts": 'export * from "./channel-outbound.js";',
       "src/plugin-sdk/channel-inbound.ts":
         'export { runChannelInboundEvent } from "../channels/message/inbound-reply-dispatch.js";',
       "src/plugin-sdk/channel-message.test.ts":


### PR DESCRIPTION
## What Problem This Solves

Restores the deprecated Plugin SDK usage test after `channel-message-runtime` was redirected from the removed `channel-message` facade to the canonical `channel-outbound` entrypoint. The stale fixture made the tooling shard reject the intended compatibility path.

## Why This Change Was Made

Updates the synthetic compatibility fixture to match the current shipped re-export. The guard itself stays strict: internal callers still cannot import deprecated facades.

## User Impact

No runtime behavior change. Main CI can validate deprecated Plugin SDK usage again.

## Evidence

- Testbox `tbx_01kxhwh02c5ns2yxscw36wyhs5`: all 7 focused guard tests passed.
- Same Testbox: full repository lint passed.
- Fresh Codex autoreview: no accepted/actionable findings, confidence 0.96.

AI-assisted. I reviewed the fixture against the current compatibility entrypoint and guard table.