### PR TITLE
test: speed up CLI supervisor capture suite

### DIFF
--- a/src/agents/cli-runner/execute.supervisor-capture.test.ts
+++ b/src/agents/cli-runner/execute.supervisor-capture.test.ts
@@ -22,6 +22,24 @@ import { executePreparedCliRun } from "./execute.js";
 import { createManagedRun, supervisorSpawnMock } from "./execute.test-support.js";
 import type { PreparedCliRunContext } from "./types.js";
 
+// Gateway unit coverage owns quiet-admission timing. These integration cases only
+// need to drain calls already in flight, so skip the repeated 250 ms quiet window.
+vi.mock("../../gateway/mcp-http.loopback-runtime.js", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../../gateway/mcp-http.loopback-runtime.js")>();
+  return {
+    ...actual,
+    waitForMcpLoopbackToolCallCaptureIdle: (
+      captureKey: string,
+      options: Parameters<typeof actual.waitForMcpLoopbackToolCallCaptureIdle>[1],
+    ) =>
+      actual.waitForMcpLoopbackToolCallCaptureIdle(captureKey, {
+        ...options,
+        admissionGraceMs: 0,
+      }),
+  };
+});
+
 type ProcessSupervisor = ReturnType<typeof getProcessSupervisor>;
 type SupervisorSpawnInput = Parameters<ProcessSupervisor["spawn"]>[0];
 


### PR DESCRIPTION
## What Problem This Solves

The CLI supervisor capture suite paid the production 250 ms MCP request-admission grace after many already-synchronous mocked runs. The gateway runtime has dedicated coverage for quiet admission, so the repeated real-time wait made this integration suite much slower without adding distinct behavior proof.

## Why This Change Was Made

Partially mock the loopback runtime in this test file and delegate to the real idle-drain implementation with only the quiet-admission grace set to zero. Calls already in flight still drain through the real implementation, including the test whose loopback result settles after process exit.

## User Impact

No runtime behavior change. Faster agent test feedback and CI execution.

## Evidence

- Blacksmith Testbox `tbx_01kxhs9zcrwrsrn7bqvdjxppjp`: 48/48 tests passed twice.
- Baseline: 7.39 s test body, 12.46 s Vitest duration, 14.56 s wall, 1,112,944 KiB peak RSS.
- Optimized cold run: 0.126 s test body, 5.87 s Vitest duration, 8.10 s wall, 1,016,620 KiB peak RSS.
- Optimized warm run: 0.113 s test body, 2.09 s Vitest duration, 4.26 s wall, 803,012 KiB peak RSS.
- Remote `check:changed` passed format, core test typecheck, and lint.
- `src/gateway/mcp-http.test.ts` retains dedicated quiet-admission timing coverage.
- Fresh autoreview: no accepted or actionable findings, confidence 0.94.
