### PR TITLE
perf(agents): scope subagent registry reads

### DIFF
--- a/src/agents/subagent-registry-read.scoped.test.ts
+++ b/src/agents/subagent-registry-read.scoped.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { SubagentRunRecord } from "./subagent-registry.types.js";
+
+const mocks = vi.hoisted(() => ({
+  getSubagentRunsSnapshotForChildSession: vi.fn<
+    (
+      runs: Map<string, SubagentRunRecord>,
+      childSessionKey: string,
+    ) => Map<string, SubagentRunRecord>
+  >(() => new Map()),
+  getSubagentRunsSnapshotForController: vi.fn<
+    (
+      runs: Map<string, SubagentRunRecord>,
+      controllerSessionKey: string,
+    ) => Map<string, SubagentRunRecord>
+  >(() => new Map()),
+  getSubagentRunsSnapshotForRead: vi.fn<
+    (runs: Map<string, SubagentRunRecord>) => Map<string, SubagentRunRecord>
+  >(() => {
+    throw new Error("unexpected full registry hydration");
+  }),
+}));
+
+vi.mock("./subagent-registry-memory.js", () => ({
+  subagentRuns: new Map<string, SubagentRunRecord>(),
+}));
+
+vi.mock("./subagent-registry-state.js", () => ({
+  getSubagentRunsSnapshotForChildSession: mocks.getSubagentRunsSnapshotForChildSession,
+  getSubagentRunsSnapshotForController: mocks.getSubagentRunsSnapshotForController,
+  getSubagentRunsSnapshotForRead: mocks.getSubagentRunsSnapshotForRead,
+}));
+
+function createRun(overrides: Partial<SubagentRunRecord>): SubagentRunRecord {
+  const runId = overrides.runId ?? "run";
+  return {
+    runId,
+    childSessionKey: overrides.childSessionKey ?? `agent:main:subagent:${runId}`,
+    requesterSessionKey: "agent:main:main",
+    requesterDisplayKey: "main",
+    task: "test task",
+    cleanup: "keep",
+    createdAt: 1,
+    ...overrides,
+  };
+}
+
+describe("subagent registry scoped reads", () => {
+  let mod: typeof import("./subagent-registry-read.js");
+
+  beforeEach(async () => {
+    mocks.getSubagentRunsSnapshotForChildSession.mockReset().mockReturnValue(new Map());
+    mocks.getSubagentRunsSnapshotForController.mockReset().mockReturnValue(new Map());
+    mocks.getSubagentRunsSnapshotForRead.mockClear();
+    mod = await import("./subagent-registry-read.js");
+  });
+
+  it("uses the child snapshot for latest and display lookups without full hydration", () => {
+    const childSessionKey = "agent:main:subagent:child";
+    const older = createRun({ runId: "older", childSessionKey, generation: 1, createdAt: 200 });
+    const latest = createRun({ runId: "latest", childSessionKey, generation: 2, createdAt: 100 });
+    mocks.getSubagentRunsSnapshotForChildSession.mockReturnValue(
+      new Map([
+        [older.runId, older],
+        [latest.runId, latest],
+      ]),
+    );
+
+    expect(mod.getLatestSubagentRunByChildSessionKey(childSessionKey)).toEqual(latest);
+    expect(mod.getSessionDisplaySubagentRunByChildSessionKey(childSessionKey)).toEqual(latest);
+    expect(mocks.getSubagentRunsSnapshotForChildSession).toHaveBeenCalledTimes(2);
+    expect(mocks.getSubagentRunsSnapshotForRead).not.toHaveBeenCalled();
+  });
+
+  it("uses the controller snapshot while retaining legacy requester-owned runs", () => {
+    const controllerSessionKey = "agent:main:controller";
+    const explicit = createRun({
+      runId: "explicit",
+      controllerSessionKey,
+      requesterSessionKey: "agent:main:other",
+    });
+    const legacy = createRun({ runId: "legacy", requesterSessionKey: controllerSessionKey });
+    const other = createRun({
+      runId: "other",
+      controllerSessionKey: "agent:main:other-controller",
+      requesterSessionKey: controllerSessionKey,
+    });
+    mocks.getSubagentRunsSnapshotForController.mockReturnValue(
+      new Map([
+        [explicit.runId, explicit],
+        [legacy.runId, legacy],
+        [other.runId, other],
+      ]),
+    );
+
+    expect(mod.listSubagentRunsForController(controllerSessionKey)).toEqual([explicit, legacy]);
+    expect(mocks.getSubagentRunsSnapshotForRead).not.toHaveBeenCalled();
+  });
+});

--- a/src/agents/subagent-registry-read.ts
+++ b/src/agents/subagent-registry-read.ts
@@ -15,7 +15,11 @@ import {
   type LatestSubagentRunReadIndex,
   type SubagentRunReadIndex,
 } from "./subagent-registry-queries.js";
-import { getSubagentRunsSnapshotForRead } from "./subagent-registry-state.js";
+import {
+  getSubagentRunsSnapshotForChildSession,
+  getSubagentRunsSnapshotForController,
+  getSubagentRunsSnapshotForRead,
+} from "./subagent-registry-state.js";
 import type { SubagentRunRecord } from "./subagent-registry.types.js";
 import { compareSubagentRunGeneration } from "./subagent-run-generation.js";
 
@@ -42,7 +46,7 @@ export function buildLatestSubagentRunReadIndex(): LatestSubagentRunReadIndex {
 /** Lists runs controlled by a session key. */
 export function listSubagentRunsForController(controllerSessionKey: string): SubagentRunRecord[] {
   return listRunsForControllerFromRuns(
-    getSubagentRunsSnapshotForRead(subagentRuns),
+    getSubagentRunsSnapshotForController(subagentRuns, controllerSessionKey),
     controllerSessionKey,
   );
 }
@@ -60,14 +64,6 @@ export function listDescendantRunsForRequester(rootSessionKey: string): Subagent
   return listDescendantRunsForRequesterFromRuns(
     getSubagentRunsSnapshotForRead(subagentRuns),
     rootSessionKey,
-  );
-}
-
-/** Returns the preferred run for a child session, favoring active over ended runs. */
-function getSubagentRunByChildSessionKey(childSessionKey: string): SubagentRunRecord | null {
-  return getSubagentRunByChildSessionKeyFromRuns(
-    getSubagentRunsSnapshotForRead(subagentRuns),
-    childSessionKey,
   );
 }
 
@@ -119,7 +115,10 @@ export function getSessionDisplaySubagentRunByChildSessionKey(
     return latestInMemoryActive ?? latestInMemoryEnded;
   }
 
-  return getSubagentRunByChildSessionKey(key);
+  return getSubagentRunByChildSessionKeyFromRuns(
+    getSubagentRunsSnapshotForChildSession(subagentRuns, key),
+    key,
+  );
 }
 
 /** Returns the most recently created run for a child session from readable registry state. */
@@ -132,7 +131,7 @@ export function getLatestSubagentRunByChildSessionKey(
   }
 
   let latest: SubagentRunRecord | null = null;
-  for (const entry of getSubagentRunsSnapshotForRead(subagentRuns).values()) {
+  for (const entry of getSubagentRunsSnapshotForChildSession(subagentRuns, key).values()) {
     if (entry.childSessionKey !== key) {
       continue;
     }

--- a/src/agents/subagent-registry-state.test.ts
+++ b/src/agents/subagent-registry-state.test.ts
@@ -2,6 +2,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   clearSubagentRunsReadCacheForTest,
+  getSubagentRunsSnapshotForChildSession,
+  getSubagentRunsSnapshotForController,
   getSubagentRunsSnapshotForRead,
   onSubagentRegistryPersisted,
   persistSubagentRunsToDisk,
@@ -9,11 +11,17 @@ import {
 import type { SubagentRunRecord } from "./subagent-registry.types.js";
 
 const mocks = vi.hoisted(() => ({
+  loadSubagentRunsForChildSessionFromSqlite:
+    vi.fn<(childSessionKey: string) => SubagentRunRecord[]>(),
+  loadSubagentRunsForControllerFromSqlite:
+    vi.fn<(controllerSessionKey: string) => SubagentRunRecord[]>(),
   loadSubagentRegistryFromSqlite: vi.fn<() => Map<string, SubagentRunRecord>>(),
   saveSubagentRegistryToSqlite: vi.fn<(runs: Map<string, SubagentRunRecord>) => void>(),
 }));
 
 vi.mock("./subagent-registry.store.sqlite.js", () => ({
+  loadSubagentRunsForChildSessionFromSqlite: mocks.loadSubagentRunsForChildSessionFromSqlite,
+  loadSubagentRunsForControllerFromSqlite: mocks.loadSubagentRunsForControllerFromSqlite,
   loadSubagentRegistryFromSqlite: mocks.loadSubagentRegistryFromSqlite,
   saveSubagentRegistryToSqlite: mocks.saveSubagentRegistryToSqlite,
 }));
@@ -39,6 +47,8 @@ describe("subagent registry state read cache", () => {
     vi.setSystemTime(1_000);
     process.env.OPENCLAW_TEST_READ_SUBAGENT_RUNS_FROM_SQLITE = "1";
     clearSubagentRunsReadCacheForTest();
+    mocks.loadSubagentRunsForChildSessionFromSqlite.mockReset();
+    mocks.loadSubagentRunsForControllerFromSqlite.mockReset();
     mocks.loadSubagentRegistryFromSqlite.mockReset();
     mocks.saveSubagentRegistryToSqlite.mockReset();
   });
@@ -100,5 +110,81 @@ describe("subagent registry state read cache", () => {
     expect(listener).toHaveBeenCalledOnce();
     expect([...getSubagentRunsSnapshotForRead(new Map()).keys()]).toEqual(["updated"]);
     unsubscribe();
+  });
+
+  it("queries controller rows directly and overlays matching in-memory state", () => {
+    const persisted = createRun("shared");
+    persisted.controllerSessionKey = "agent:main:controller";
+    persisted.task = "persisted";
+    const inMemory = { ...persisted, task: "in-memory" };
+    mocks.loadSubagentRunsForControllerFromSqlite.mockReturnValue([persisted]);
+
+    const result = getSubagentRunsSnapshotForController(
+      new Map([[inMemory.runId, inMemory]]),
+      "agent:main:controller",
+    );
+
+    expect(result.get("shared")?.task).toBe("in-memory");
+    expect(mocks.loadSubagentRunsForControllerFromSqlite).toHaveBeenCalledOnce();
+    expect(getSubagentRunsSnapshotForController(new Map(), "   ")).toEqual(new Map());
+  });
+
+  it("queries one child directly and returns isolated snapshots", () => {
+    const childSessionKey = "agent:main:subagent:child";
+    const persisted = createRun("child");
+    persisted.childSessionKey = childSessionKey;
+    persisted.task = "persisted";
+    mocks.loadSubagentRunsForChildSessionFromSqlite.mockReturnValue([persisted]);
+
+    const first = getSubagentRunsSnapshotForChildSession(new Map(), childSessionKey);
+    first.get("child")!.task = "mutated";
+    const second = getSubagentRunsSnapshotForChildSession(new Map(), childSessionKey);
+
+    expect(second.get("child")?.task).toBe("persisted");
+    expect(mocks.loadSubagentRunsForChildSessionFromSqlite).toHaveBeenCalledTimes(2);
+  });
+
+  it("masks persisted scope membership when the live run moved", () => {
+    const persisted = createRun("moved");
+    persisted.controllerSessionKey = "agent:main:controller:old";
+    persisted.childSessionKey = "agent:main:subagent:old";
+    const inMemory = {
+      ...persisted,
+      controllerSessionKey: "agent:main:controller:new",
+      childSessionKey: "agent:main:subagent:new",
+    };
+    mocks.loadSubagentRunsForControllerFromSqlite.mockReturnValue([persisted]);
+    mocks.loadSubagentRunsForChildSessionFromSqlite.mockReturnValue([persisted]);
+    const live = new Map([[inMemory.runId, inMemory]]);
+
+    expect(getSubagentRunsSnapshotForController(live, "agent:main:controller:old")).toEqual(
+      new Map(),
+    );
+    expect(getSubagentRunsSnapshotForChildSession(live, "agent:main:subagent:old")).toEqual(
+      new Map(),
+    );
+  });
+
+  it("preserves the fresh authoritative write snapshot before returning to scoped SQL", () => {
+    const controllerSessionKey = "agent:main:controller";
+    const saved = createRun("saved");
+    saved.controllerSessionKey = controllerSessionKey;
+    mocks.saveSubagentRegistryToSqlite.mockImplementationOnce(() => {
+      throw new Error("disk unavailable");
+    });
+    mocks.loadSubagentRunsForControllerFromSqlite.mockReturnValue([]);
+
+    persistSubagentRunsToDisk(new Map([[saved.runId, saved]]));
+
+    expect([
+      ...getSubagentRunsSnapshotForController(new Map(), controllerSessionKey).keys(),
+    ]).toEqual(["saved"]);
+    expect(mocks.loadSubagentRunsForControllerFromSqlite).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(500);
+    expect(getSubagentRunsSnapshotForController(new Map(), controllerSessionKey)).toEqual(
+      new Map(),
+    );
+    expect(mocks.loadSubagentRunsForControllerFromSqlite).toHaveBeenCalledOnce();
   });
 });

--- a/src/agents/subagent-registry-state.ts
+++ b/src/agents/subagent-registry-state.ts
@@ -4,6 +4,8 @@
  * Merges process-local active runs with persisted SQLite state for cross-process readers.
  */
 import {
+  loadSubagentRunsForChildSessionFromSqlite,
+  loadSubagentRunsForControllerFromSqlite,
   loadSubagentRegistryFromSqlite,
   saveSubagentRegistryToSqlite,
 } from "./subagent-registry.store.sqlite.js";
@@ -53,14 +55,29 @@ function rememberPersistedSubagentRunsSnapshot(runs: Map<string, SubagentRunReco
   };
 }
 
+function shouldReadPersistedSubagentRuns(): boolean {
+  return (
+    process.env.OPENCLAW_TEST_READ_SUBAGENT_RUNS_FROM_SQLITE === "1" ||
+    !(process.env.VITEST || process.env.NODE_ENV === "test")
+  );
+}
+
+function getFreshPersistedSubagentRunsSnapshot(
+  nowMs: number,
+): Map<string, SubagentRunRecord> | null {
+  const cached = persistedSubagentRunsReadCache;
+  return cached &&
+    nowMs >= cached.loadedAtMs &&
+    nowMs - cached.loadedAtMs < SUBAGENT_RUNS_READ_CACHE_TTL_MS
+    ? cached.runs
+    : null;
+}
+
 function loadPersistedSubagentRunsForRead(): Map<string, SubagentRunRecord> {
   const nowMs = Date.now();
-  if (
-    persistedSubagentRunsReadCache &&
-    nowMs >= persistedSubagentRunsReadCache.loadedAtMs &&
-    nowMs - persistedSubagentRunsReadCache.loadedAtMs < SUBAGENT_RUNS_READ_CACHE_TTL_MS
-  ) {
-    return persistedSubagentRunsReadCache.runs;
+  const cached = getFreshPersistedSubagentRunsSnapshot(nowMs);
+  if (cached) {
+    return cached;
   }
 
   const runs = loadSubagentRegistryFromSqlite();
@@ -69,6 +86,24 @@ function loadPersistedSubagentRunsForRead(): Map<string, SubagentRunRecord> {
     runs,
   };
   return runs;
+}
+
+function loadPersistedSubagentRunsForScopedRead(params: {
+  load: () => SubagentRunRecord[];
+  matches: (entry: SubagentRunRecord) => boolean;
+}): Map<string, SubagentRunRecord> {
+  // A fresh broad snapshot represents same-process writes, including the
+  // existing best-effort persistence-failure behavior. Otherwise query the index directly.
+  const cached = getFreshPersistedSubagentRunsSnapshot(Date.now());
+  const entries = cached ? [...cached.values()].filter(params.matches) : params.load();
+  return new Map(entries.map((entry) => [entry.runId, entry]));
+}
+
+function resolvesToControllerSessionKey(
+  entry: SubagentRunRecord,
+  controllerSessionKey: string,
+): boolean {
+  return (entry.controllerSessionKey?.trim() || entry.requesterSessionKey) === controllerSessionKey;
 }
 
 export function clearSubagentRunsReadCacheForTest(): void {
@@ -119,10 +154,7 @@ export function getSubagentRunsSnapshotForRead(
   inMemoryRuns: Map<string, SubagentRunRecord>,
 ): Map<string, SubagentRunRecord> {
   const merged = new Map<string, SubagentRunRecord>();
-  const shouldReadPersisted =
-    process.env.OPENCLAW_TEST_READ_SUBAGENT_RUNS_FROM_SQLITE === "1" ||
-    !(process.env.VITEST || process.env.NODE_ENV === "test");
-  if (shouldReadPersisted) {
+  if (shouldReadPersistedSubagentRuns()) {
     try {
       // Persisted state lets other worker processes observe active runs.
       // Cache this hot cross-process snapshot briefly; writes refresh the local
@@ -136,6 +168,70 @@ export function getSubagentRunsSnapshotForRead(
   }
   for (const [runId, entry] of inMemoryRuns.entries()) {
     merged.set(runId, entry);
+  }
+  return merged;
+}
+
+export function getSubagentRunsSnapshotForController(
+  inMemoryRuns: Map<string, SubagentRunRecord>,
+  controllerSessionKey: string,
+): Map<string, SubagentRunRecord> {
+  const key = controllerSessionKey.trim();
+  const merged = new Map<string, SubagentRunRecord>();
+  if (!key) {
+    return merged;
+  }
+  if (shouldReadPersistedSubagentRuns()) {
+    try {
+      for (const [runId, entry] of loadPersistedSubagentRunsForScopedRead({
+        load: () => loadSubagentRunsForControllerFromSqlite(key),
+        matches: (candidate) => resolvesToControllerSessionKey(candidate, key),
+      })) {
+        merged.set(runId, structuredClone(entry));
+      }
+    } catch {
+      // Ignore disk read failures and fall back to local memory.
+    }
+  }
+  for (const [runId, entry] of inMemoryRuns) {
+    if (resolvesToControllerSessionKey(entry, key)) {
+      merged.set(runId, entry);
+    } else {
+      // Live memory is authoritative even when a run moved out of this persisted scope.
+      merged.delete(runId);
+    }
+  }
+  return merged;
+}
+
+export function getSubagentRunsSnapshotForChildSession(
+  inMemoryRuns: Map<string, SubagentRunRecord>,
+  childSessionKey: string,
+): Map<string, SubagentRunRecord> {
+  const key = childSessionKey.trim();
+  const merged = new Map<string, SubagentRunRecord>();
+  if (!key) {
+    return merged;
+  }
+  if (shouldReadPersistedSubagentRuns()) {
+    try {
+      for (const [runId, entry] of loadPersistedSubagentRunsForScopedRead({
+        load: () => loadSubagentRunsForChildSessionFromSqlite(key),
+        matches: (candidate) => candidate.childSessionKey === key,
+      })) {
+        merged.set(runId, structuredClone(entry));
+      }
+    } catch {
+      // Ignore disk read failures and fall back to local memory.
+    }
+  }
+  for (const [runId, entry] of inMemoryRuns) {
+    if (entry.childSessionKey === key) {
+      merged.set(runId, entry);
+    } else {
+      // Match full-snapshot overlay semantics for runs that changed child association.
+      merged.delete(runId);
+    }
   }
   return merged;
 }

--- a/src/agents/subagent-registry.store.sqlite.test.ts
+++ b/src/agents/subagent-registry.store.sqlite.test.ts
@@ -11,6 +11,8 @@ import {
 } from "../state/openclaw-state-db.js";
 import { withEnvAsync } from "../test-utils/env.js";
 import {
+  loadSubagentRunsForChildSessionFromSqlite,
+  loadSubagentRunsForControllerFromSqlite,
   loadSubagentRegistryFromSqlite,
   saveSubagentRegistryToSqlite,
 } from "./subagent-registry.store.sqlite.js";
@@ -217,6 +219,73 @@ describe("subagent registry sqlite store", () => {
       expect(
         openOpenClawStateDatabase().db.prepare("SELECT COUNT(*) AS count FROM subagent_runs").get(),
       ).toEqual({ count: 0 });
+    });
+  });
+
+  it("loads explicit controller rows and null-controller requester fallbacks", async () => {
+    await withTempStateEnv(async () => {
+      const explicit = createRun({
+        runId: "explicit",
+        controllerSessionKey: "agent:main:controller",
+        requesterSessionKey: "agent:main:other",
+      });
+      const fallback = createRun({
+        runId: "fallback",
+        controllerSessionKey: undefined,
+        requesterSessionKey: "agent:main:controller",
+      });
+      const emptyController = createRun({
+        runId: "empty-controller",
+        controllerSessionKey: "",
+        requesterSessionKey: "agent:main:controller",
+      });
+      const paddedController = createRun({
+        runId: "padded-controller",
+        controllerSessionKey: " agent:main:controller ",
+        requesterSessionKey: "agent:main:other",
+      });
+      const other = createRun({
+        runId: "other",
+        controllerSessionKey: "agent:main:other-controller",
+        requesterSessionKey: "agent:main:controller",
+      });
+      saveSubagentRegistryToSqlite(
+        new Map([
+          [explicit.runId, explicit],
+          [fallback.runId, fallback],
+          [emptyController.runId, emptyController],
+          [paddedController.runId, paddedController],
+          [other.runId, other],
+        ]),
+      );
+
+      expect(
+        loadSubagentRunsForControllerFromSqlite("agent:main:controller").map((run) => run.runId),
+      ).toEqual(["empty-controller", "explicit", "fallback", "padded-controller"]);
+      expect(
+        loadSubagentRunsForControllerFromSqlite("agent:main:controller").at(-1)
+          ?.controllerSessionKey,
+      ).toBe("agent:main:controller");
+      expect(loadSubagentRunsForControllerFromSqlite("   ")).toEqual([]);
+    });
+  });
+
+  it("loads only the requested child session in deterministic storage order", async () => {
+    await withTempStateEnv(async () => {
+      const childSessionKey = "agent:main:subagent:restarted";
+      const runs = [
+        createRun({ runId: "legacy", childSessionKey, createdAt: 300, generation: 1 }),
+        createRun({ runId: "latest", childSessionKey, createdAt: 100, generation: 2 }),
+        createRun({ runId: "same-zulu", childSessionKey, createdAt: 200, generation: 2 }),
+        createRun({ runId: "same-alpha", childSessionKey, createdAt: 200, generation: 2 }),
+        createRun({ runId: "other", childSessionKey: "agent:main:subagent:other" }),
+      ];
+      saveSubagentRegistryToSqlite(new Map(runs.map((run) => [run.runId, run])));
+
+      expect(
+        loadSubagentRunsForChildSessionFromSqlite(childSessionKey).map((run) => run.runId),
+      ).toEqual(["latest", "same-alpha", "same-zulu", "legacy"]);
+      expect(loadSubagentRunsForChildSessionFromSqlite("   ")).toEqual([]);
     });
   });
 });

--- a/src/agents/subagent-registry.store.sqlite.ts
+++ b/src/agents/subagent-registry.store.sqlite.ts
@@ -277,7 +277,7 @@ function subagentRunRecordToSqliteInsert(entry: SubagentRunRecord): SubagentRunS
   return {
     run_id: normalized.runId,
     child_session_key: normalized.childSessionKey,
-    controller_session_key: normalized.controllerSessionKey ?? null,
+    controller_session_key: normalized.controllerSessionKey?.trim() || null,
     requester_session_key: normalized.requesterSessionKey,
     requester_display_key: normalized.requesterDisplayKey,
     requester_origin_json: jsonStringify(normalized.requesterOrigin),
@@ -355,6 +355,68 @@ function readSubagentRegistryRows(): SubagentRunSqliteRow[] {
       .orderBy("created_at", "asc")
       .orderBy("run_id", "asc"),
   ).rows;
+}
+
+/** Loads runs controlled by one session, preserving the legacy requester fallback. */
+export function loadSubagentRunsForControllerFromSqlite(
+  controllerSessionKey: string,
+): SubagentRunRecord[] {
+  const key = controllerSessionKey.trim();
+  if (!key) {
+    return [];
+  }
+  const { db } = openOpenClawStateDatabase();
+  const stateDb = getNodeSqliteKysely<SubagentRegistryDatabase>(db);
+  const rows = executeSqliteQuerySync(
+    db,
+    stateDb
+      .selectFrom("subagent_runs")
+      .selectAll()
+      // The write boundary canonicalizes controller keys; null/empty retains legacy fallback.
+      .where((eb) =>
+        eb.or([
+          eb("controller_session_key", "=", key),
+          eb.and([
+            eb.or([
+              eb("controller_session_key", "is", null),
+              eb("controller_session_key", "=", ""),
+            ]),
+            eb("requester_session_key", "=", key),
+          ]),
+        ]),
+      )
+      .orderBy("created_at", "asc")
+      .orderBy("run_id", "asc"),
+  ).rows;
+  return rows.flatMap((row) => {
+    const run = rowToSubagentRunRecord(row);
+    return run ? [run] : [];
+  });
+}
+
+/** Loads all persisted generations for one child session through its existing index. */
+export function loadSubagentRunsForChildSessionFromSqlite(
+  childSessionKey: string,
+): SubagentRunRecord[] {
+  const key = childSessionKey.trim();
+  if (!key) {
+    return [];
+  }
+  const { db } = openOpenClawStateDatabase();
+  const stateDb = getNodeSqliteKysely<SubagentRegistryDatabase>(db);
+  const rows = executeSqliteQuerySync(
+    db,
+    stateDb
+      .selectFrom("subagent_runs")
+      .selectAll()
+      .where("child_session_key", "=", key)
+      .orderBy("created_at", "asc")
+      .orderBy("run_id", "asc"),
+  ).rows;
+  return rows.flatMap((row) => {
+    const run = rowToSubagentRunRecord(row);
+    return run ? [run] : [];
+  });
 }
 
 /** Loads the canonical subagent registry from shared SQLite state. */

--- a/src/agents/subagent-registry.test.ts
+++ b/src/agents/subagent-registry.test.ts
@@ -176,6 +176,12 @@ const mocks = vi.hoisted(() => ({
   getSubagentRunsSnapshotForRead: vi.fn(
     (runs: Map<string, import("./subagent-registry.types.js").SubagentRunRecord>) => new Map(runs),
   ),
+  getSubagentRunsSnapshotForChildSession: vi.fn(
+    (runs: Map<string, import("./subagent-registry.types.js").SubagentRunRecord>) => new Map(runs),
+  ),
+  getSubagentRunsSnapshotForController: vi.fn(
+    (runs: Map<string, import("./subagent-registry.types.js").SubagentRunRecord>) => new Map(runs),
+  ),
   captureSubagentCompletionReply: vi.fn(async () => "final completion reply"),
   cleanupBrowserSessionsForLifecycleEnd: vi.fn(async () => {}),
   runSubagentAnnounceFlow: vi.fn(async () => true),
@@ -243,6 +249,8 @@ vi.mock("../sessions/session-lifecycle-events.js", () => ({
 
 vi.mock("./subagent-registry-state.js", () => ({
   clearSubagentRunsReadCacheForTest: mocks.clearSubagentRunsReadCacheForTest,
+  getSubagentRunsSnapshotForChildSession: mocks.getSubagentRunsSnapshotForChildSession,
+  getSubagentRunsSnapshotForController: mocks.getSubagentRunsSnapshotForController,
   getSubagentRunsSnapshotForRead: mocks.getSubagentRunsSnapshotForRead,
   persistSubagentRunsToDisk: mocks.persistSubagentRunsToDisk,
   persistSubagentRunsToDiskOrThrow: mocks.persistSubagentRunsToDiskOrThrow,
@@ -319,6 +327,12 @@ describe("subagent registry seam flow", () => {
     mocks.scheduleOrphanRecovery.mockReset();
     mocks.resolveAgentTimeoutMs.mockReturnValue(1_000);
     mocks.restoreSubagentRunsFromDisk.mockReturnValue(0);
+    mocks.getSubagentRunsSnapshotForChildSession
+      .mockReset()
+      .mockImplementation((runs) => new Map(runs));
+    mocks.getSubagentRunsSnapshotForController
+      .mockReset()
+      .mockImplementation((runs) => new Map(runs));
     mocks.callGateway.mockImplementation(async (request: { method?: string }) => {
       if (request.method === "agent.wait") {
         return {
@@ -360,6 +374,34 @@ describe("subagent registry seam flow", () => {
     swarmSchedulerTesting.reset();
     vi.unstubAllEnvs();
     vi.useRealTimers();
+  });
+
+  it("routes controller and child lookups through scoped snapshots", () => {
+    const controllerSessionKey = "agent:main:controller";
+    const childSessionKey = "agent:main:subagent:scoped";
+    const run = {
+      runId: "run-scoped",
+      childSessionKey,
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      controllerSessionKey,
+      task: "scoped registry run",
+      cleanup: "keep" as const,
+      createdAt: Date.now(),
+    };
+    mocks.getSubagentRunsSnapshotForController.mockReturnValue(new Map([[run.runId, run]]));
+    mocks.getSubagentRunsSnapshotForChildSession.mockReturnValue(new Map([[run.runId, run]]));
+
+    expect(mod.listSubagentRunsForController(controllerSessionKey)).toEqual([run]);
+    expect(mod.getLatestSubagentRunByChildSessionKey(childSessionKey)).toEqual(run);
+    expect(mocks.getSubagentRunsSnapshotForController).toHaveBeenCalledWith(
+      expect.any(Map),
+      controllerSessionKey,
+    );
+    expect(mocks.getSubagentRunsSnapshotForChildSession).toHaveBeenCalledWith(
+      expect.any(Map),
+      childSessionKey,
+    );
   });
 
   it("keeps a sweeper archive mutation root-admitted until deletion settles", async () => {

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -89,6 +89,8 @@ import {
 } from "./subagent-registry-run-manager.js";
 import {
   clearSubagentRunsReadCacheForTest,
+  getSubagentRunsSnapshotForChildSession,
+  getSubagentRunsSnapshotForController,
   getSubagentRunsSnapshotForRead,
   persistSubagentRunsToDisk,
   persistSubagentRunsToDiskOrThrow,
@@ -142,6 +144,8 @@ type SubagentRegistryDeps = {
   getGatewayRecoveryRuntime: () => GatewayRecoveryRuntime | undefined;
   captureSubagentCompletionReply: SubagentAnnounceModule["captureSubagentCompletionReply"];
   cleanupBrowserSessionsForLifecycleEnd: typeof cleanupBrowserSessionsForLifecycleEnd;
+  getSubagentRunsSnapshotForChildSession: typeof getSubagentRunsSnapshotForChildSession;
+  getSubagentRunsSnapshotForController: typeof getSubagentRunsSnapshotForController;
   getSubagentRunsSnapshotForRead: typeof getSubagentRunsSnapshotForRead;
   getRuntimeConfig: typeof getRuntimeConfig;
   onAgentEvent: typeof onAgentEvent;
@@ -185,6 +189,8 @@ const defaultSubagentRegistryDeps: SubagentRegistryDeps = {
     (await loadSubagentAnnounceModule()).captureSubagentCompletionReply(sessionKey, options),
   cleanupBrowserSessionsForLifecycleEnd: async (params) =>
     (await loadCleanupBrowserSessionsForLifecycleEnd())(params),
+  getSubagentRunsSnapshotForChildSession,
+  getSubagentRunsSnapshotForController,
   getSubagentRunsSnapshotForRead,
   getRuntimeConfig,
   onAgentEvent,
@@ -2440,7 +2446,7 @@ export { prependAgentSteeringPrompt };
 
 export function listSubagentRunsForController(controllerSessionKey: string): SubagentRunRecord[] {
   return listRunsForControllerFromRuns(
-    subagentRegistryDeps.getSubagentRunsSnapshotForRead(subagentRuns),
+    subagentRegistryDeps.getSubagentRunsSnapshotForController(subagentRuns, controllerSessionKey),
     controllerSessionKey,
   );
 }
@@ -2597,7 +2603,9 @@ export function getLatestSubagentRunByChildSessionKey(
   }
 
   let latest: SubagentRunRecord | null = null;
-  for (const entry of subagentRegistryDeps.getSubagentRunsSnapshotForRead(subagentRuns).values()) {
+  for (const entry of subagentRegistryDeps
+    .getSubagentRunsSnapshotForChildSession(subagentRuns, key)
+    .values()) {
     if (entry.childSessionKey !== key) {
       continue;
     }


### PR DESCRIPTION
## What Problem This Solves

Fixes #105423. Controller and child-session lookups hydrated the entire persisted subagent registry before filtering, so a small indexed lookup paid the parse, allocation, and scan cost of every stored run.

## Why This Change Was Made

The rewrite adds two narrow Kysely reads over existing `controller_session_key`, `requester_session_key`, and `child_session_key` indexes. The state layer then overlays every process-local run by `runId`, including deleting stale persisted membership when a live run moved to another controller or child session.

No second scoped cache is introduced. A fresh existing broad snapshot is reused only to preserve same-process write and best-effort persistence-failure semantics; otherwise scoped reads query SQLite directly. Broad tree/index APIs still use the full snapshot path.

Controller keys are canonicalized at the write boundary. Null/empty legacy controller rows retain the existing requester-key fallback.

## User Impact

Large registries no longer require full persisted hydration for controller lists or child latest/display lookups. Result ordering, generation selection, live-memory precedence, persistence-failure behavior, and legacy controller fallback remain unchanged.

## Evidence

- `node scripts/run-vitest.mjs src/agents/subagent-registry.store.sqlite.test.ts src/agents/subagent-registry-state.test.ts src/agents/subagent-registry-read.scoped.test.ts src/agents/subagent-registry.test.ts src/agents/subagent-registry-queries.test.ts` — 5 files, 165 tests passed.
- `node scripts/check-changed.mjs -- <8 touched files>` on Blacksmith Testbox — formatting, guards, core production/test types, changed-file lint, schema/storage guards, and import-cycle checks passed.
- 4,080-row fresh-process benchmark: controller count 1,047 and child count 8 matched exact SHA-256 ID hashes. Full hydration: 44.23 ms, +2.21 MB RSS. Scoped reads: 10.09 ms, +0.59 MB RSS.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` — clean, no accepted/actionable findings after overlay and canonicalization fixes.
- `git diff --check origin/main...HEAD` — passed.

Supersedes the broader closed attempt #105489. Credit is retained with `Co-authored-by: LZY3538 <liu.zhenye@xydigit.com>`.
