### PR TITLE
test: repair UI global isolation and Mattermost lint

### DIFF
--- a/extensions/mattermost/src/mattermost/interactions.test.ts
+++ b/extensions/mattermost/src/mattermost/interactions.test.ts
@@ -37,7 +37,7 @@ type ButtonPropsInput = {
 };
 
 function buildButtonAttachmentsForTest(params: ButtonPropsInput): ButtonAttachments {
-  const signedChannelId = params.buttons[0]?.context?.__openclaw_channel_id;
+  const signedChannelId = params.buttons[0]?.context?.["__openclaw_channel_id"];
   const props = buildButtonProps({
     ...params,
     channelId: typeof signedChannelId === "string" ? signedChannelId : "test-channel",

--- a/ui/src/pages/chat/chat-pane.test.ts
+++ b/ui/src/pages/chat/chat-pane.test.ts
@@ -1,7 +1,7 @@
 /* @vitest-environment jsdom */
 
 import { render, type TemplateResult } from "lit";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type {
   SessionCatalogSession,
   SessionCatalogTranscriptItem,
@@ -22,6 +22,10 @@ import { createBackgroundTasksProps } from "./components/chat-background-tasks.t
 import { createSessionWorkspaceProps } from "./components/chat-session-workspace.ts";
 import type { SidebarContent } from "./components/chat-sidebar.ts";
 import { cacheChatSessionSnapshot, type ChatMessageCache } from "./session-message-cache.ts";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
 
 type TestChatPane = HTMLElement & {
   catalogMessages: unknown[];


### PR DESCRIPTION
## What Problem This Solves

Two test-only defects break CI: a Mattermost fixture trips `no-underscore-dangle`, and a Control UI test leaves the global `TouchEvent` stubbed because the UI suite runs with isolation disabled.

## Why This Change Was Made

Use bracket notation for the signed Mattermost context key and restore all Vitest global stubs after each chat-pane test. Production behavior is unchanged.

## User Impact

None. CI becomes portable and deterministic across the full non-isolated UI suite.

## Evidence

- Blacksmith Testbox `tbx_01kxhss5kn5ykd8vbc0wc4163y`
- `pnpm test extensions/mattermost/src/mattermost/interactions.test.ts`: 47/47 passed
- `pnpm --dir ui test`: 268 files, 3979/3979 tests passed
- `check:changed` format and both core/extension test typechecks passed; the broad core lint phase encountered 12 unrelated pre-existing `src/agents/**` findings on the base revision
- Fresh autoreview: clean, confidence 0.99
