### PR TITLE
fix: include plugin LLM calls in usage diagnostics

### DIFF
--- a/docs/gateway/opentelemetry.md
+++ b/docs/gateway/opentelemetry.md
@@ -494,9 +494,14 @@ Liveness warnings also emit:
 
 - `openclaw.model.usage`
   - `openclaw.channel`, `openclaw.provider`, `openclaw.model`
+  - Optional host-derived `openclaw.plugin` only for trusted plugin runtime completions
   - `openclaw.tokens.*` (input/output/cache_read/cache_write/total)
   - `gen_ai.system` by default, or `gen_ai.provider.name` when the latest GenAI semantic conventions are opted in
   - `gen_ai.request.model`, `gen_ai.operation.name`, `gen_ai.usage.*`
+
+Plugin attribution is span-only. It does not add a plugin dimension to shared
+OpenTelemetry metrics or change Prometheus metric labels.
+
 - `openclaw.run`
   - `openclaw.outcome`, `openclaw.channel`, `openclaw.provider`, `openclaw.model`, `openclaw.errorCategory`
 - `openclaw.model.call`

--- a/extensions/diagnostics-otel/src/service-events.ts
+++ b/extensions/diagnostics-otel/src/service-events.ts
@@ -17,6 +17,10 @@ type DiagnosticsEventRecorders = ReturnType<typeof createHarnessRecorders> &
   ReturnType<typeof createOperationsRecorders> &
   ReturnType<typeof createToolAndSystemRecorders> &
   ReturnType<typeof createUsageRecorders>;
+type OtelDiagnosticEventPrivateData = DiagnosticEventPrivateData &
+  Readonly<{
+    hostPluginId?: string;
+  }>;
 
 export function createDiagnosticsEventHandler(params: {
   logger: OtelLogger;
@@ -76,12 +80,12 @@ export function createDiagnosticsEventHandler(params: {
   return (
     evt: DiagnosticEventPayload,
     metadata: DiagnosticEventMetadata,
-    privateData: DiagnosticEventPrivateData,
+    privateData: OtelDiagnosticEventPrivateData,
   ) => {
     try {
       switch (evt.type) {
         case "model.usage":
-          recordModelUsage(evt, metadata);
+          recordModelUsage(evt, metadata, privateData.hostPluginId);
           return;
         case "webhook.received":
           recordWebhookReceived(evt);

--- a/extensions/diagnostics-otel/src/service-recorders-usage.ts
+++ b/extensions/diagnostics-otel/src/service-recorders-usage.ts
@@ -51,6 +51,7 @@ export function createUsageRecorders(runtime: DiagnosticsRecorderRuntime) {
   const recordModelUsage = (
     evt: Extract<DiagnosticEventPayload, { type: "model.usage" }>,
     metadata: DiagnosticEventMetadata,
+    hostPluginId?: string,
   ) => {
     const attrs = {
       "openclaw.channel": evt.channel ?? "unknown",
@@ -124,6 +125,9 @@ export function createUsageRecorders(runtime: DiagnosticsRecorderRuntime) {
       "openclaw.tokens.cache_write": usage.cacheWrite ?? 0,
       "openclaw.tokens.total": usage.total ?? 0,
     };
+    if (metadata.trusted && metadata.internal && hostPluginId) {
+      spanAttrs["openclaw.plugin"] = normalizeDiagnosticValue(hostPluginId);
+    }
     assignGenAiSpanIdentityAttrs(spanAttrs, evt);
     assignPositiveNumberAttr(spanAttrs, "gen_ai.usage.input_tokens", genAiInputTokens);
     assignPositiveNumberAttr(spanAttrs, "gen_ai.usage.output_tokens", usage.output);

--- a/extensions/diagnostics-otel/src/service.plugin-usage-attribution.test.ts
+++ b/extensions/diagnostics-otel/src/service.plugin-usage-attribution.test.ts
@@ -1,0 +1,111 @@
+import { trace } from "@opentelemetry/api";
+import {
+  BasicTracerProvider,
+  InMemorySpanExporter,
+  SimpleSpanProcessor,
+} from "@opentelemetry/sdk-trace-base";
+import {
+  emitTrustedDiagnosticEvent,
+  emitTrustedDiagnosticEventWithPrivateData,
+  resetDiagnosticEventsForTest,
+  waitForDiagnosticEventsDrained,
+} from "openclaw/plugin-sdk/diagnostic-runtime";
+import { afterEach, beforeEach, expect, test } from "vitest";
+import { startOtelServiceWithHostUsage, stopStartedOtelServices } from "./service.test-helpers.js";
+
+const PRELOAD_ENV = "OPENCLAW_OTEL_PRELOADED";
+const OTEL_GLOBAL_API_KEY = Symbol.for("opentelemetry.js.api.1");
+
+type OtelGlobalRegistrations = {
+  trace?: Parameters<typeof trace.setGlobalTracerProvider>[0];
+};
+
+let exporter: InMemorySpanExporter;
+let provider: BasicTracerProvider;
+let originalPreloaded: string | undefined;
+let originalTraceProvider: OtelGlobalRegistrations["trace"];
+
+function registeredOtelGlobals(): OtelGlobalRegistrations | undefined {
+  return (globalThis as unknown as Record<symbol, OtelGlobalRegistrations | undefined>)[
+    OTEL_GLOBAL_API_KEY
+  ];
+}
+
+beforeEach(() => {
+  originalPreloaded = process.env[PRELOAD_ENV];
+  originalTraceProvider = registeredOtelGlobals()?.trace;
+  if (originalTraceProvider) {
+    trace.disable();
+  }
+  process.env[PRELOAD_ENV] = "1";
+  exporter = new InMemorySpanExporter();
+  provider = new BasicTracerProvider({ spanProcessors: [new SimpleSpanProcessor(exporter)] });
+  trace.setGlobalTracerProvider(provider);
+});
+
+afterEach(async () => {
+  await stopStartedOtelServices();
+  await provider.shutdown();
+  trace.disable();
+  if (originalTraceProvider) {
+    trace.setGlobalTracerProvider(originalTraceProvider);
+  }
+  if (originalPreloaded === undefined) {
+    delete process.env[PRELOAD_ENV];
+  } else {
+    process.env[PRELOAD_ENV] = originalPreloaded;
+  }
+  resetDiagnosticEventsForTest();
+});
+
+test("adds plugin attribution only from trusted exporter-private provenance", async () => {
+  const started = await startOtelServiceWithHostUsage();
+  const { service, ctx } = started;
+
+  started.emitHostPluginUsage(
+    {
+      type: "model.usage",
+      provider: "openai",
+      model: "gpt-5.5",
+      usage: { input: 10, output: 4, total: 14 },
+    },
+    "llm-task",
+  );
+  emitTrustedDiagnosticEvent({
+    type: "model.usage",
+    provider: "openai",
+    model: "gpt-5.5",
+    usage: { input: 2 },
+    pluginId: "public-emitter-spoof",
+  } as Parameters<typeof emitTrustedDiagnosticEvent>[0] & { pluginId: string });
+  emitTrustedDiagnosticEvent({
+    type: "model.usage",
+    provider: "openai",
+    model: "gpt-5.5",
+    usage: { input: 3 },
+  });
+  emitTrustedDiagnosticEventWithPrivateData(
+    {
+      type: "model.usage",
+      provider: "openai",
+      model: "gpt-5.5",
+      usage: { input: 5 },
+    },
+    { hostPluginId: "private-data-spoof" } as Parameters<
+      typeof emitTrustedDiagnosticEventWithPrivateData
+    >[1] & { hostPluginId: string },
+  );
+  await waitForDiagnosticEventsDrained();
+  await service.stop?.(ctx);
+
+  const usageSpans = exporter
+    .getFinishedSpans()
+    .filter((span) => span.name === "openclaw.model.usage");
+  expect(usageSpans).toHaveLength(4);
+  expect(usageSpans.map((span) => span.attributes["openclaw.plugin"])).toEqual([
+    "llm-task",
+    undefined,
+    undefined,
+    undefined,
+  ]);
+});

--- a/extensions/diagnostics-otel/src/service.test-helpers.ts
+++ b/extensions/diagnostics-otel/src/service.test-helpers.ts
@@ -1,5 +1,6 @@
 import {
   emitTrustedDiagnosticEventWithPrivateData,
+  type DiagnosticEventPayload,
   type DiagnosticTraceContext,
 } from "openclaw/plugin-sdk/diagnostic-runtime";
 import {
@@ -38,6 +39,13 @@ type StartOtelServiceOptions = OtelContextFlags & {
   endpoint?: string;
   configure?: (ctx: OpenClawPluginServiceContext) => void;
 };
+type InternalDiagnosticListener = Parameters<
+  NonNullable<OpenClawPluginServiceContext["internalDiagnostics"]>["onEvent"]
+>[0];
+type ModelUsageEventInput = Omit<
+  Extract<DiagnosticEventPayload, { type: "model.usage" }>,
+  "seq" | "ts"
+>;
 
 type StartedService = {
   service: ReturnType<typeof createDiagnosticsOtelService>;
@@ -100,6 +108,41 @@ export async function startOtelService({
   const started = { service, ctx };
   startedServices.add(started);
   return started;
+}
+
+export async function startOtelServiceWithHostUsage() {
+  let listener: InternalDiagnosticListener | undefined;
+  const started = await startOtelService({
+    traces: true,
+    configure: (ctx) => {
+      const internalDiagnostics = ctx.internalDiagnostics;
+      if (!internalDiagnostics) {
+        throw new Error("expected internal diagnostics for trusted OTel service");
+      }
+      const onEvent = internalDiagnostics.onEvent;
+      ctx.internalDiagnostics = {
+        ...internalDiagnostics,
+        onEvent: (registeredListener) => {
+          listener = registeredListener;
+          return onEvent(registeredListener);
+        },
+      };
+    },
+  });
+  if (!listener) {
+    throw new Error("expected OTel service to register a diagnostics listener");
+  }
+  const registeredListener = listener;
+  return {
+    ...started,
+    emitHostPluginUsage(event: ModelUsageEventInput, hostPluginId: string) {
+      registeredListener({ ...event, seq: 1, ts: Date.now() }, { trusted: true, internal: true }, {
+        hostPluginId,
+      } as Parameters<InternalDiagnosticListener>[2] & {
+        hostPluginId: string;
+      });
+    },
+  };
 }
 
 export async function stopStartedOtelServices() {

--- a/extensions/diagnostics-prometheus/src/service.test.ts
+++ b/extensions/diagnostics-prometheus/src/service.test.ts
@@ -435,6 +435,36 @@ describe("diagnostics-prometheus service", () => {
     expect(rendered).not.toContain("Agent:qa:otel-trace-smoke");
   });
 
+  it("aggregates plugin usage without adding a plugin label", () => {
+    const metrics = createMetricsHarness();
+    const record = (input: number) =>
+      metrics.record(
+        {
+          ...baseEvent(),
+          type: "model.usage",
+          agentId: "main",
+          provider: "openai",
+          model: "gpt-5.4",
+          usage: { input, total: input },
+        },
+        Object.freeze({ trusted: true, internal: true }),
+      );
+
+    record(12);
+    record(8);
+    const rendered = metrics.render();
+
+    expect(rendered).toContain(
+      'openclaw_model_tokens_total{agent="main",channel="unknown",model="gpt-5.4",provider="openai",token_type="input"} 20',
+    );
+    expect(rendered).toContain(
+      'openclaw_model_tokens_total{agent="main",channel="unknown",model="gpt-5.4",provider="openai",token_type="total"} 20',
+    );
+    expect(rendered).not.toContain("plugin=");
+    expect(rendered).not.toContain("llm-task");
+    expect(rendered).not.toContain("another-plugin");
+  });
+
   it("drops session-shaped queue lane labels", () => {
     const metrics = createMetricsHarness();
 

--- a/extensions/qa-lab/src/providers/mock-openai/mock-openai-tooling.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/mock-openai-tooling.ts
@@ -334,6 +334,17 @@ export function buildQaToolSearchArgs(
       timeoutSeconds: 60,
     };
   }
+  if (targetTool === "llm-task") {
+    return {
+      prompt: 'Remember this fact and reply exactly `{"status":"ok"}`.',
+      input: { secret: "qa-plugin-usage-secret-sentinel" },
+      schema: {
+        type: "object",
+        required: ["status"],
+        properties: { status: { const: "ok" } },
+      },
+    };
+  }
   if (targetTool === "session_status") {
     return { sessionKey: "current" };
   }

--- a/src/agents/isolated-completion.test.ts
+++ b/src/agents/isolated-completion.test.ts
@@ -277,11 +277,60 @@ describe("runIsolatedCompletion", () => {
     });
   });
 
+  it.each(["error", "aborted"] as const)(
+    "rejects %s harness output before usage reaches the runtime finalizer",
+    async (stopReason) => {
+      mocks.getRegisteredAgentHarness.mockReturnValue({
+        harness: {
+          id: "codex",
+          label: "Codex",
+          supports: () => ({ supported: true }),
+          runAttempt: vi.fn(),
+          runIsolatedCompletion: vi.fn(async () => ({
+            assistant: assistant([{ type: "text", text: "partial" }], stopReason),
+          })),
+        } satisfies AgentHarness,
+      });
+
+      await expect(runIsolatedCompletion(request())).rejects.toMatchObject({
+        code: "output-rejected",
+        message: expect.stringContaining(`stop reason ${stopReason}`),
+      });
+    },
+  );
+
+  it("rejects thinking-only harness output before usage reaches the runtime finalizer", async () => {
+    mocks.getRegisteredAgentHarness.mockReturnValue({
+      harness: {
+        id: "codex",
+        label: "Codex",
+        supports: () => ({ supported: true }),
+        runAttempt: vi.fn(),
+        runIsolatedCompletion: vi.fn(async () => ({
+          assistant: assistant([{ type: "thinking", thinking: "hidden" }]),
+        })),
+      } satisfies AgentHarness,
+    });
+
+    await expect(runIsolatedCompletion(request())).rejects.toMatchObject({
+      code: "output-rejected",
+      message: expect.stringContaining("empty output"),
+    });
+  });
+
   it("routes CLI owners through one exact empty-tool run without direct preparation", async () => {
     mocks.isCliRuntimeAliasForProvider.mockReturnValue(true);
     mocks.runCliAgent.mockResolvedValue({
       payloads: [{ text: '{"cli":true}' }],
-      meta: { durationMs: 1 },
+      meta: {
+        durationMs: 1,
+        agentMeta: {
+          sessionId: "cli-session",
+          provider: "claude-cli",
+          model: "claude-test",
+          usage: { input: 8, output: 3, cacheRead: 2, total: 13 },
+        },
+      },
     });
 
     await expect(
@@ -296,6 +345,7 @@ describe("runIsolatedCompletion", () => {
       provider: "anthropic",
       model: "claude-test",
       owner: { kind: "cli", id: "claude-cli" },
+      usage: { input: 8, output: 3, cacheRead: 2, total: 13 },
     });
     expect(mocks.prepareSimpleCompletionModel).not.toHaveBeenCalled();
     expect(mocks.runCliAgent).toHaveBeenCalledWith(
@@ -309,6 +359,30 @@ describe("runIsolatedCompletion", () => {
         cliToolAvailability: { native: [], openClaw: [] },
       }),
     );
+  });
+
+  it("keeps unavailable CLI usage absent", async () => {
+    mocks.isCliRuntimeAliasForProvider.mockReturnValue(true);
+    mocks.runCliAgent.mockResolvedValue({
+      payloads: [{ text: "done" }],
+      meta: {
+        durationMs: 1,
+        agentMeta: {
+          sessionId: "cli-session",
+          provider: "claude-cli",
+          model: "claude-test",
+        },
+      },
+    });
+
+    const result = await runIsolatedCompletion({
+      ...request(),
+      provider: "anthropic",
+      model: "claude-test",
+      agentHarnessRuntimeOverride: "claude-cli",
+    });
+
+    expect(result).not.toHaveProperty("usage");
   });
 
   it("forwards one explicit auth profile unchanged to a CLI owner", async () => {

--- a/src/agents/isolated-completion.ts
+++ b/src/agents/isolated-completion.ts
@@ -30,6 +30,7 @@ import {
 } from "./provider-secret-egress.js";
 import { prepareSimpleCompletionModel } from "./simple-completion-runtime.js";
 import { resolveEffectiveAgentRuntime } from "./thinking-runtime.js";
+import type { UsageLike } from "./usage.js";
 
 type RunIsolatedCompletionParams = {
   config?: OpenClawConfig;
@@ -58,7 +59,7 @@ export type IsolatedCompletionResult = {
   model: string;
   owner: { kind: "cli" | "harness"; id: string };
   /** CLI runtimes may not report token usage; absence must not be projected as zero. */
-  usage?: AssistantMessage["usage"];
+  usage?: UsageLike;
 };
 
 type IsolatedCompletionErrorCode =
@@ -141,7 +142,7 @@ async function runCliIsolatedCompletion(params: {
   agentId: string;
   agentDir: string;
   workspaceDir: string;
-}): Promise<{ model: string; text: string }> {
+}): Promise<{ model: string; text: string; usage?: UsageLike }> {
   return await withTempWorkspace(
     { rootDir: resolvePreferredOpenClawTmpDir(), prefix: "openclaw-isolated-completion-" },
     async ({ dir }) => {
@@ -219,7 +220,12 @@ async function runCliIsolatedCompletion(params: {
           `CLI backend ${params.provider} became unavailable after execution.`,
         );
       }
-      return { text, model: normalizeCliModel(params.request.model, backend.config) };
+      const usage = result.meta?.agentMeta?.usage;
+      return {
+        text,
+        model: normalizeCliModel(params.request.model, backend.config),
+        ...(usage ? { usage } : {}),
+      };
     },
   );
 }
@@ -373,6 +379,7 @@ export async function runIsolatedCompletion(
           provider,
           model: completion.model,
           owner: { kind: "cli", id: cliOwner },
+          ...(completion.usage ? { usage: completion.usage } : {}),
         };
       }
 

--- a/src/infra/diagnostic-events.plugin-usage.test.ts
+++ b/src/infra/diagnostic-events.plugin-usage.test.ts
@@ -1,0 +1,181 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  emitTrustedDiagnosticEvent,
+  emitTrustedDiagnosticEventWithPrivateData,
+  onInternalDiagnosticEvent,
+  onTrustedInternalDiagnosticEvent,
+  resetDiagnosticEventsForTest,
+} from "./diagnostic-events.js";
+import { markTrustedOtelDiagnosticListener } from "./diagnostic-otel-listener-provenance.js";
+import { markHostPluginUsageDiagnosticEvent } from "./diagnostic-plugin-usage-provenance.js";
+
+describe("diagnostic event plugin usage attribution", () => {
+  beforeEach(() => {
+    resetDiagnosticEventsForTest();
+  });
+
+  it("keeps host plugin attribution private and unforgeable", () => {
+    const publicEvents: Array<{
+      eventPluginId?: unknown;
+      hostPluginId?: string;
+      internal?: boolean;
+      trusted: boolean;
+    }> = [];
+    const trustedEvents: Array<{
+      eventPluginId?: unknown;
+      privateHostPluginId?: unknown;
+      internal?: boolean;
+      trusted: boolean;
+    }> = [];
+    const otelEvents: Array<{
+      eventPluginId?: unknown;
+      hostPluginId?: string;
+      internal?: boolean;
+      trusted: boolean;
+    }> = [];
+    onInternalDiagnosticEvent((event, metadata) => {
+      if (event.type === "model.usage") {
+        publicEvents.push({
+          eventPluginId: (event as typeof event & { pluginId?: unknown }).pluginId,
+          hostPluginId: (metadata as typeof metadata & { hostPluginId?: string }).hostPluginId,
+          internal: metadata.internal,
+          trusted: metadata.trusted,
+        });
+      }
+    });
+    onTrustedInternalDiagnosticEvent((event, metadata, privateData) => {
+      if (event.type === "model.usage") {
+        trustedEvents.push({
+          eventPluginId: (event as typeof event & { pluginId?: unknown }).pluginId,
+          privateHostPluginId: (privateData as { hostPluginId?: unknown }).hostPluginId,
+          internal: metadata.internal,
+          trusted: metadata.trusted,
+        });
+      }
+    });
+    onTrustedInternalDiagnosticEvent(
+      markTrustedOtelDiagnosticListener((event, metadata, privateData) => {
+        if (event.type === "model.usage") {
+          otelEvents.push({
+            eventPluginId: (event as typeof event & { pluginId?: unknown }).pluginId,
+            hostPluginId: (privateData as { hostPluginId?: string }).hostPluginId,
+            internal: metadata.internal,
+            trusted: metadata.trusted,
+          });
+        }
+      }),
+    );
+
+    emitTrustedDiagnosticEvent({
+      type: "model.usage",
+      usage: { input: 1 },
+      pluginId: "public-emitter-spoof",
+    } as Parameters<typeof emitTrustedDiagnosticEvent>[0] & { pluginId: string });
+    emitTrustedDiagnosticEventWithPrivateData(
+      {
+        type: "model.usage",
+        usage: { input: 2 },
+      },
+      { hostPluginId: "private-data-spoof" } as Parameters<
+        typeof emitTrustedDiagnosticEventWithPrivateData
+      >[1] & { hostPluginId: string },
+    );
+    emitTrustedDiagnosticEvent(
+      markHostPluginUsageDiagnosticEvent(
+        {
+          type: "model.usage",
+          usage: { input: 3 },
+        },
+        "llm-task",
+      ),
+    );
+
+    expect(publicEvents).toEqual([
+      {
+        eventPluginId: "public-emitter-spoof",
+        hostPluginId: undefined,
+        internal: undefined,
+        trusted: true,
+      },
+      {
+        eventPluginId: undefined,
+        hostPluginId: undefined,
+        internal: undefined,
+        trusted: true,
+      },
+      {
+        eventPluginId: undefined,
+        hostPluginId: undefined,
+        internal: true,
+        trusted: true,
+      },
+    ]);
+    expect(trustedEvents).toEqual([
+      {
+        eventPluginId: "public-emitter-spoof",
+        privateHostPluginId: undefined,
+        internal: undefined,
+        trusted: true,
+      },
+      {
+        eventPluginId: undefined,
+        privateHostPluginId: undefined,
+        internal: undefined,
+        trusted: true,
+      },
+      {
+        eventPluginId: undefined,
+        privateHostPluginId: undefined,
+        internal: true,
+        trusted: true,
+      },
+    ]);
+    expect(otelEvents).toEqual([
+      {
+        eventPluginId: "public-emitter-spoof",
+        hostPluginId: undefined,
+        internal: undefined,
+        trusted: true,
+      },
+      {
+        eventPluginId: undefined,
+        hostPluginId: undefined,
+        internal: undefined,
+        trusted: true,
+      },
+      {
+        eventPluginId: undefined,
+        hostPluginId: "llm-task",
+        internal: true,
+        trusted: true,
+      },
+    ]);
+  });
+
+  it("scopes OTel attribution to one listener registration", () => {
+    const observedHostPluginIds: Array<string | undefined> = [];
+    const sharedListener = (
+      event: Parameters<Parameters<typeof onTrustedInternalDiagnosticEvent>[0]>[0],
+      _metadata: Parameters<Parameters<typeof onTrustedInternalDiagnosticEvent>[0]>[1],
+      privateData: Parameters<Parameters<typeof onTrustedInternalDiagnosticEvent>[0]>[2],
+    ) => {
+      if (event.type === "model.usage") {
+        observedHostPluginIds.push((privateData as { hostPluginId?: string }).hostPluginId);
+      }
+    };
+    onTrustedInternalDiagnosticEvent(sharedListener);
+    onTrustedInternalDiagnosticEvent(markTrustedOtelDiagnosticListener(sharedListener));
+
+    emitTrustedDiagnosticEvent(
+      markHostPluginUsageDiagnosticEvent(
+        {
+          type: "model.usage",
+          usage: { input: 1 },
+        },
+        "llm-task",
+      ),
+    );
+
+    expect(observedHostPluginIds).toEqual([undefined, "llm-task"]);
+  });
+});

--- a/src/infra/diagnostic-events.ts
+++ b/src/infra/diagnostic-events.ts
@@ -4,6 +4,8 @@ import type { EmbeddedAgentExecutionPhase } from "../agents/embedded-agent-runne
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { TalkBrain, TalkEventType, TalkMode, TalkTransport } from "../talk/talk-events.js";
 import { setInternalDiagnosticEventListenerCounts } from "./diagnostic-event-listener-presence.js";
+import { isTrustedOtelDiagnosticListener } from "./diagnostic-otel-listener-provenance.js";
+import { consumeHostPluginUsageDiagnosticEvent } from "./diagnostic-plugin-usage-provenance.js";
 import {
   getActiveDiagnosticTraceContext,
   type DiagnosticTraceContext,
@@ -894,6 +896,11 @@ type TrustedDiagnosticEventListener = (
   privateData: DiagnosticEventPrivateData,
 ) => void;
 
+type TrustedOtelDiagnosticEventPrivateData = DiagnosticEventPrivateData &
+  Readonly<{
+    hostPluginId?: string;
+  }>;
+
 export type TrustedToolExecutionEvent = Extract<
   DiagnosticEventPayload,
   {
@@ -911,6 +918,7 @@ type QueuedDiagnosticEvent = {
   event: DiagnosticEventPayload;
   metadata: DiagnosticEventMetadata;
   privateData?: DiagnosticEventPrivateData;
+  hostPluginId?: string;
   trustedListenersOnly?: boolean;
 };
 
@@ -1050,7 +1058,7 @@ function dispatchDiagnosticEvent(
   enriched: DiagnosticEventPayload,
   metadata: DiagnosticEventMetadata,
   privateData?: DiagnosticEventPrivateData,
-  options: { trustedListenersOnly?: boolean } = {},
+  options: { hostPluginId?: string; trustedListenersOnly?: boolean } = {},
 ): void {
   if (state.dispatchDepth > 100) {
     console.error(
@@ -1084,11 +1092,21 @@ function dispatchDiagnosticEvent(
     }
     for (const listener of state.trustedListeners) {
       try {
-        listener(
-          cloneDiagnosticEventForListener(enriched),
-          createDiagnosticMetadataForListener(metadata),
-          cloneDiagnosticPrivateDataForListener(privateData),
-        );
+        const eventForListener = cloneDiagnosticEventForListener(enriched);
+        const metadataForListener = createDiagnosticMetadataForListener(metadata);
+        if (isTrustedOtelDiagnosticListener(listener)) {
+          listener(
+            eventForListener,
+            metadataForListener,
+            cloneDiagnosticPrivateDataForOtelListener(privateData, options.hostPluginId),
+          );
+        } else {
+          listener(
+            eventForListener,
+            metadataForListener,
+            cloneDiagnosticPrivateDataForListener(privateData),
+          );
+        }
       } catch (err) {
         const errorMessage =
           err instanceof Error
@@ -1128,6 +1146,20 @@ function cloneDiagnosticPrivateDataForListener(
     return Object.freeze({});
   }
   return deepFreezeDiagnosticValue(structuredClone(privateData)) as DiagnosticEventPrivateData;
+}
+
+function cloneDiagnosticPrivateDataForOtelListener(
+  privateData: DiagnosticEventPrivateData | undefined,
+  hostPluginId: string | undefined,
+): TrustedOtelDiagnosticEventPrivateData {
+  // Keep the third-argument transport for independently updated official OTel installs.
+  // Only the marked OTel listener receives this host-owned field.
+  const cloned = structuredClone(privateData ?? {}) as Record<string, unknown>;
+  delete cloned.hostPluginId;
+  if (hostPluginId) {
+    cloned.hostPluginId = hostPluginId;
+  }
+  return deepFreezeDiagnosticValue(cloned) as TrustedOtelDiagnosticEventPrivateData;
 }
 
 function isPriorityAsyncDiagnosticEvent(entry: QueuedDiagnosticEvent): boolean {
@@ -1191,6 +1223,7 @@ function scheduleAsyncDiagnosticDrain(state: DiagnosticEventsGlobalState): void 
     const batch = state.asyncQueue.splice(0, MAX_ASYNC_DIAGNOSTIC_EVENTS_PER_TURN);
     for (const entry of batch) {
       dispatchDiagnosticEvent(state, entry.event, entry.metadata, entry.privateData, {
+        hostPluginId: entry.hostPluginId,
         trustedListenersOnly: entry.trustedListenersOnly,
       });
     }
@@ -1266,6 +1299,7 @@ function createInternalDiagnosticMetadata(trusted: boolean): DiagnosticEventMeta
 
 type EmitDiagnosticEventOptions = {
   allowSecurityEvent?: boolean;
+  hostPluginId?: string;
   internal?: boolean;
   privateData?: DiagnosticEventPrivateData;
   trustedTraceContext?: boolean;
@@ -1288,7 +1322,7 @@ function emitDiagnosticEventWithTrust(
   }
 
   const enriched = enrichDiagnosticEvent(state, event);
-  const { internal = false, privateData } = options;
+  const { hostPluginId, internal = false, privateData } = options;
   const trustedTraceContext = options.trustedTraceContext === true;
   const metadata = {
     ...(internal ? createInternalDiagnosticMetadata(trusted) : { trusted }),
@@ -1299,7 +1333,7 @@ function emitDiagnosticEventWithTrust(
   if (ASYNC_DIAGNOSTIC_EVENT_TYPES.has(enriched.type)) {
     if (state.asyncQueue.length >= MAX_ASYNC_DIAGNOSTIC_EVENTS) {
       if (!trusted || !PRIORITY_ASYNC_DIAGNOSTIC_EVENT_TYPES.has(enriched.type)) {
-        noteAsyncDiagnosticDrop(state, { event: enriched, metadata, privateData });
+        noteAsyncDiagnosticDrop(state, { event: enriched, metadata, privateData, hostPluginId });
         return;
       }
       const droppedEntry = makeRoomForPriorityAsyncDiagnosticEvent(state);
@@ -1307,7 +1341,7 @@ function emitDiagnosticEventWithTrust(
         noteAsyncDiagnosticDrop(state, droppedEntry);
       }
     }
-    state.asyncQueue.push({ event: enriched, metadata, privateData });
+    state.asyncQueue.push({ event: enriched, metadata, privateData, hostPluginId });
     if (prepareTracePropagation) {
       prepareDiagnosticTracePropagation(
         cloneDiagnosticEventForListener(enriched),
@@ -1324,7 +1358,7 @@ function emitDiagnosticEventWithTrust(
       createDiagnosticMetadataForListener(metadata),
     );
   }
-  dispatchDiagnosticEvent(state, enriched, metadata, privateData);
+  dispatchDiagnosticEvent(state, enriched, metadata, privateData, { hostPluginId });
 }
 
 function isToolExecutionEventInput(
@@ -1387,7 +1421,8 @@ export function getInternalDiagnosticEventSequence(): number {
 
 /** Emits a trusted diagnostic event from core/runtime-owned instrumentation. */
 export function emitTrustedDiagnosticEvent(event: DiagnosticEventInput) {
-  emitDiagnosticEventWithTrust(event, true);
+  const hostPluginId = consumeHostPluginUsageDiagnosticEvent(event);
+  emitDiagnosticEventWithTrust(event, true, hostPluginId ? { hostPluginId, internal: true } : {});
 }
 
 /** Keeps trusted internal skill accounting alive when optional diagnostics are disabled. */
@@ -1419,7 +1454,19 @@ export function emitTrustedDiagnosticEventWithPrivateData(
   event: DiagnosticEventInput,
   privateData?: DiagnosticEventPrivateData,
 ) {
-  emitDiagnosticEventWithTrust(event, true, { privateData });
+  if (!privateData || !Object.hasOwn(privateData, "hostPluginId")) {
+    emitDiagnosticEventWithTrust(event, true, { privateData });
+    return;
+  }
+  // Plugin-facing emitters may provide trusted private content, but host attribution
+  // is reserved for the object-identity provenance consumed above.
+  const sanitized = {
+    ...(privateData as DiagnosticEventPrivateData & { hostPluginId?: unknown }),
+  } as Record<string, unknown>;
+  delete sanitized.hostPluginId;
+  emitDiagnosticEventWithTrust(event, true, {
+    privateData: sanitized as DiagnosticEventPrivateData,
+  });
 }
 
 /** Emits a trusted canonical security event from core-owned enforcement boundaries. */

--- a/src/infra/diagnostic-otel-listener-provenance.ts
+++ b/src/infra/diagnostic-otel-listener-provenance.ts
@@ -1,0 +1,13 @@
+const trustedOtelDiagnosticListeners = new WeakSet<object>();
+
+export function markTrustedOtelDiagnosticListener<TArgs extends unknown[], TResult>(
+  listener: (...args: TArgs) => TResult,
+): (...args: TArgs) => TResult {
+  const registeredListener = (...args: TArgs) => listener(...args);
+  trustedOtelDiagnosticListeners.add(registeredListener);
+  return registeredListener;
+}
+
+export function isTrustedOtelDiagnosticListener(listener: object): boolean {
+  return trustedOtelDiagnosticListeners.has(listener);
+}

--- a/src/infra/diagnostic-plugin-usage-provenance.ts
+++ b/src/infra/diagnostic-plugin-usage-provenance.ts
@@ -1,0 +1,21 @@
+type HostPluginUsageEvent = { type: "model.usage" };
+
+// Object identity is the host-only channel; public payload fields and clones cannot forge it.
+const hostPluginUsageIds = new WeakMap<object, string>();
+
+export function markHostPluginUsageDiagnosticEvent<T extends HostPluginUsageEvent>(
+  event: T,
+  hostPluginId?: string,
+): T {
+  const normalizedHostPluginId = hostPluginId?.trim();
+  if (normalizedHostPluginId) {
+    hostPluginUsageIds.set(event, normalizedHostPluginId);
+  }
+  return event;
+}
+
+export function consumeHostPluginUsageDiagnosticEvent(event: object): string | undefined {
+  const hostPluginId = hostPluginUsageIds.get(event);
+  hostPluginUsageIds.delete(event);
+  return hostPluginId;
+}

--- a/src/plugin-sdk/plugin-service-context.test.ts
+++ b/src/plugin-sdk/plugin-service-context.test.ts
@@ -1,0 +1,31 @@
+import { describe, expectTypeOf, it } from "vitest";
+import type { OpenClawPluginServiceContext as CoreServiceContext } from "./core.js";
+import type { DiagnosticEventPrivateData } from "./diagnostic-runtime.js";
+import type { OpenClawPluginServiceContext as PluginEntryServiceContext } from "./plugin-entry.js";
+
+type ListenerArgs<T extends { internalDiagnostics?: unknown }> =
+  NonNullable<T["internalDiagnostics"]> extends { onEvent: infer TOnEvent }
+    ? TOnEvent extends (listener: infer TListener) => unknown
+      ? TListener extends (...args: infer TArgs) => unknown
+        ? TArgs
+        : never
+      : never
+    : never;
+
+type ListenerPrivateData<T extends { internalDiagnostics?: unknown }> = ListenerArgs<T>[2];
+
+describe("plugin service diagnostics contract", () => {
+  it("keeps host attribution out of public SDK listener declarations", () => {
+    expectTypeOf<
+      ListenerPrivateData<PluginEntryServiceContext>
+    >().toEqualTypeOf<DiagnosticEventPrivateData>();
+    expectTypeOf<
+      ListenerPrivateData<CoreServiceContext>
+    >().toEqualTypeOf<DiagnosticEventPrivateData>();
+    expectTypeOf<ListenerArgs<PluginEntryServiceContext>["length"]>().toEqualTypeOf<3>();
+    expectTypeOf<ListenerArgs<CoreServiceContext>["length"]>().toEqualTypeOf<3>();
+    expectTypeOf<
+      "hostPluginId" extends keyof ListenerPrivateData<PluginEntryServiceContext> ? true : false
+    >().toEqualTypeOf<false>();
+  });
+});

--- a/src/plugins/runtime/runtime-llm-diagnostics.runtime.test.ts
+++ b/src/plugins/runtime/runtime-llm-diagnostics.runtime.test.ts
@@ -1,0 +1,271 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import {
+  onTrustedInternalDiagnosticEvent,
+  resetDiagnosticEventsForTest,
+  type DiagnosticEventPayload,
+} from "../../infra/diagnostic-events.js";
+import { markTrustedOtelDiagnosticListener } from "../../infra/diagnostic-otel-listener-provenance.js";
+import { createRuntimeLlm } from "./runtime-llm.runtime.js";
+
+const hoisted = vi.hoisted(() => ({
+  prepareSimpleCompletionModelForAgent: vi.fn(),
+  completeWithPreparedSimpleCompletionModel: vi.fn(),
+  resolveSimpleCompletionSelectionForAgent: vi.fn(),
+}));
+
+vi.mock("../../agents/simple-completion-runtime.js", () => ({
+  prepareSimpleCompletionModelForAgent: hoisted.prepareSimpleCompletionModelForAgent,
+  completeWithPreparedSimpleCompletionModel: hoisted.completeWithPreparedSimpleCompletionModel,
+  resolveSimpleCompletionSelectionForAgent: hoisted.resolveSimpleCompletionSelectionForAgent,
+}));
+
+const cfg = {
+  agents: {
+    defaults: {
+      model: "openai/gpt-5.5",
+    },
+  },
+} satisfies OpenClawConfig;
+
+const preparedModel = {
+  selection: {
+    provider: "openai",
+    modelId: "gpt-5.5",
+    agentDir: "/tmp/openclaw-agent",
+  },
+  model: {
+    provider: "openai",
+    id: "gpt-5.5",
+    name: "gpt-5.5",
+    api: "openai",
+    input: ["text"],
+    reasoning: false,
+    contextWindow: 128_000,
+    maxTokens: 4096,
+    cost: { input: 1, output: 2, cacheRead: 0.1, cacheWrite: 0.2 },
+  },
+  auth: {
+    apiKey: "test-api-key",
+    source: "test",
+    mode: "api-key",
+  },
+};
+
+function captureUsageEvents() {
+  const events: Array<{
+    event: Extract<DiagnosticEventPayload, { type: "model.usage" }>;
+    hostPluginId?: string;
+    internal?: boolean;
+    trusted: boolean;
+  }> = [];
+  const stop = onTrustedInternalDiagnosticEvent(
+    markTrustedOtelDiagnosticListener((event, metadata, privateData) => {
+      if (event.type === "model.usage") {
+        events.push({
+          event,
+          hostPluginId: (privateData as { hostPluginId?: string }).hostPluginId,
+          internal: metadata.internal,
+          trusted: metadata.trusted,
+        });
+      }
+    }),
+  );
+  return { events, stop };
+}
+
+describe("runtime.llm.complete diagnostics", () => {
+  beforeEach(() => {
+    resetDiagnosticEventsForTest();
+    hoisted.prepareSimpleCompletionModelForAgent.mockReset();
+    hoisted.completeWithPreparedSimpleCompletionModel.mockReset();
+    hoisted.resolveSimpleCompletionSelectionForAgent.mockReset();
+    hoisted.prepareSimpleCompletionModelForAgent.mockResolvedValue(preparedModel);
+    hoisted.resolveSimpleCompletionSelectionForAgent.mockReturnValue(preparedModel.selection);
+    hoisted.completeWithPreparedSimpleCompletionModel.mockResolvedValue({
+      content: [{ type: "text", text: "done" }],
+      usage: {
+        input: 11,
+        output: 7,
+        cacheRead: 5,
+        cacheWrite: 2,
+        total: 25,
+        cost: { total: 0.0042 },
+      },
+      stopReason: "stop",
+    });
+  });
+
+  it("emits one trusted usage event using only host-owned plugin identity", async () => {
+    const usageEvents = captureUsageEvents();
+    const llm = createRuntimeLlm({
+      getConfig: () => cfg,
+      authority: {
+        caller: { kind: "host", id: "runtime-test" },
+        pluginIdForPolicy: "trusted-plugin",
+        allowComplete: true,
+      },
+    });
+
+    const result = await llm.complete({
+      messages: [{ role: "user", content: "Ping" }],
+      purpose: "test-purpose",
+      caller: { kind: "plugin", id: "spoofed-plugin" },
+      pluginId: "spoofed-plugin",
+      telemetry: { pluginId: "nested-spoofed-plugin" },
+    } as Parameters<typeof llm.complete>[0] & {
+      caller: unknown;
+      pluginId: string;
+      telemetry: { pluginId: string };
+    });
+    usageEvents.stop();
+
+    expect(result.execution).toEqual({
+      mode: "direct-provider",
+      owner: { kind: "provider", id: "openai" },
+    });
+    expect(result.audit).toEqual({
+      caller: { kind: "host", id: "runtime-test" },
+      purpose: "test-purpose",
+    });
+    expect(usageEvents.events).toEqual([
+      {
+        trusted: true,
+        hostPluginId: "trusted-plugin",
+        internal: true,
+        event: expect.objectContaining({
+          type: "model.usage",
+          agentId: "main",
+          provider: "openai",
+          model: "gpt-5.5",
+          usage: {
+            input: 11,
+            output: 7,
+            cacheRead: 5,
+            cacheWrite: 2,
+            promptTokens: 18,
+            total: 25,
+          },
+          costUsd: 0.0042,
+        }),
+      },
+    ]);
+  });
+
+  it.each([
+    ["absent", undefined, true, undefined, undefined],
+    [
+      "all-zero",
+      { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+      true,
+      undefined,
+      undefined,
+    ],
+    ["reasoning-only", { reasoningTokens: 7 }, true, undefined, undefined],
+    [
+      "unavailable context usage",
+      { contextUsage: { state: "unavailable" } },
+      true,
+      undefined,
+      undefined,
+    ],
+    [
+      "input-only",
+      { input: 4 },
+      true,
+      { input: 4, output: 0, cacheRead: 0, cacheWrite: 0, promptTokens: 4, total: 4 },
+      undefined,
+    ],
+    [
+      "cache-only",
+      { cacheRead: 9 },
+      true,
+      { input: 0, output: 0, cacheRead: 9, cacheWrite: 0, promptTokens: 9, total: 9 },
+      undefined,
+    ],
+    [
+      "positive explicit cost-only",
+      { cost: { total: 0.0042 } },
+      true,
+      { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, promptTokens: 0, total: 0 },
+      0.0042,
+    ],
+    ["zero explicit cost-only", { cost: { total: 0 } }, true, undefined, undefined],
+    ["disabled", { input: 1 }, false, undefined, undefined],
+  ] as const)(
+    "emits usage only for positive enabled tokens or cost: %s",
+    async (_name, rawUsage, enabled, expectedEventUsage, expectedCostUsd) => {
+      hoisted.completeWithPreparedSimpleCompletionModel.mockResolvedValueOnce({
+        content: [{ type: "text", text: "done" }],
+        usage: rawUsage,
+        stopReason: "stop",
+      });
+      const usageEvents = captureUsageEvents();
+      const llm = createRuntimeLlm({
+        getConfig: () => (enabled ? cfg : { ...cfg, diagnostics: { enabled: false } }),
+        authority: { allowComplete: true, pluginIdForPolicy: "trusted-plugin" },
+      });
+
+      await llm.complete({ messages: [{ role: "user", content: "Ping" }] });
+      usageEvents.stop();
+
+      if (expectedEventUsage) {
+        expect(usageEvents.events).toEqual([
+          {
+            trusted: true,
+            hostPluginId: "trusted-plugin",
+            internal: true,
+            event: expect.objectContaining({
+              usage: expectedEventUsage,
+              ...(expectedCostUsd !== undefined ? { costUsd: expectedCostUsd } : {}),
+            }),
+          },
+        ]);
+      } else {
+        expect(usageEvents.events).toHaveLength(0);
+      }
+    },
+  );
+
+  it.each([
+    ["resolved provider error", "error", [{ type: "text", text: "partial" }], "partial"],
+    ["resolved provider abort", "aborted", [{ type: "text", text: "partial" }], "partial"],
+    ["thinking-only completion", "stop", [{ type: "thinking", thinking: "hidden" }], ""],
+  ] as const)("keeps %s usage silent", async (_name, stopReason, content, expectedText) => {
+    hoisted.completeWithPreparedSimpleCompletionModel.mockResolvedValueOnce({
+      content,
+      stopReason,
+      usage: { input: 11, output: 7, totalTokens: 18 },
+    });
+    const usageEvents = captureUsageEvents();
+    const llm = createRuntimeLlm({
+      getConfig: () => cfg,
+      authority: { allowComplete: true, pluginIdForPolicy: "trusted-plugin" },
+    });
+
+    await expect(
+      llm.complete({ messages: [{ role: "user", content: "Ping" }] }),
+    ).resolves.toMatchObject({ text: expectedText });
+    usageEvents.stop();
+
+    expect(usageEvents.events).toEqual([]);
+  });
+
+  it("emits no usage when the provider fails", async () => {
+    const usageEvents = captureUsageEvents();
+    hoisted.completeWithPreparedSimpleCompletionModel.mockRejectedValueOnce(
+      new Error("provider failed"),
+    );
+    const llm = createRuntimeLlm({
+      getConfig: () => cfg,
+      authority: { allowComplete: true },
+    });
+
+    await expect(llm.complete({ messages: [{ role: "user", content: "Ping" }] })).rejects.toThrow(
+      "provider failed",
+    );
+    usageEvents.stop();
+
+    expect(usageEvents.events).toHaveLength(0);
+  });
+});

--- a/src/plugins/runtime/runtime-llm-isolated.runtime.test.ts
+++ b/src/plugins/runtime/runtime-llm-isolated.runtime.test.ts
@@ -1,6 +1,11 @@
 // Isolated runtime.llm.complete tests cover zero-tool dispatch and policy enforcement.
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import {
+  onTrustedInternalDiagnosticEvent,
+  resetDiagnosticEventsForTest,
+} from "../../infra/diagnostic-events.js";
+import { markTrustedOtelDiagnosticListener } from "../../infra/diagnostic-otel-listener-provenance.js";
 import { withPluginRuntimePluginIdScope } from "./gateway-request-scope.js";
 import { createRuntimeLlm } from "./runtime-llm.runtime.js";
 
@@ -62,6 +67,7 @@ function expectSingleCallFirstArg(mock: { mock: { calls: unknown[][] } }, expect
 
 describe("runtime.llm.complete isolated agent runtime", () => {
   beforeEach(() => {
+    resetDiagnosticEventsForTest();
     hoisted.prepareSimpleCompletionModelForAgent.mockReset();
     hoisted.completeWithPreparedSimpleCompletionModel.mockReset();
     hoisted.resolveSimpleCompletionSelectionForAgent.mockReset();
@@ -70,6 +76,24 @@ describe("runtime.llm.complete isolated agent runtime", () => {
   });
 
   it("routes authorized isolated completion through the configured agent runtime", async () => {
+    const usageEvents: Array<{
+      hostPluginId?: string;
+      internal?: boolean;
+      trusted: boolean;
+      usage: unknown;
+    }> = [];
+    const stop = onTrustedInternalDiagnosticEvent(
+      markTrustedOtelDiagnosticListener((event, metadata, privateData) => {
+        if (event.type === "model.usage") {
+          usageEvents.push({
+            hostPluginId: (privateData as { hostPluginId?: string }).hostPluginId,
+            internal: metadata.internal,
+            trusted: metadata.trusted,
+            usage: event.usage,
+          });
+        }
+      }),
+    );
     hoisted.resolveSimpleCompletionSelectionForAgent.mockReturnValueOnce({
       provider: "openai",
       modelId: "gpt-5.5",
@@ -104,6 +128,7 @@ describe("runtime.llm.complete isolated agent runtime", () => {
         },
       }),
     );
+    stop();
 
     expectSingleCallFirstArg(hoisted.runIsolatedCompletion, {
       config: expect.any(Object),
@@ -124,8 +149,49 @@ describe("runtime.llm.complete isolated agent runtime", () => {
         owner: { kind: "harness", id: "openclaw" },
       },
       usage: { inputTokens: 3, outputTokens: 2, totalTokens: 5 },
+      audit: { caller: { kind: "plugin", id: "llm-task" } },
     });
+    expect(usageEvents).toEqual([
+      {
+        hostPluginId: "llm-task",
+        internal: true,
+        trusted: true,
+        usage: {
+          input: 3,
+          output: 2,
+          cacheRead: 0,
+          cacheWrite: 0,
+          promptTokens: 3,
+          total: 5,
+        },
+      },
+    ]);
     expect(hoisted.completeWithPreparedSimpleCompletionModel).not.toHaveBeenCalled();
+  });
+
+  it("keeps usage-free isolated completions silent", async () => {
+    hoisted.runIsolatedCompletion.mockResolvedValueOnce({
+      text: "isolated",
+      provider: "openai",
+      model: "gpt-5.5",
+      owner: { kind: "cli", id: "claude-cli" },
+    });
+    const usageEvents: unknown[] = [];
+    const stop = onTrustedInternalDiagnosticEvent((event) => {
+      if (event.type === "model.usage") {
+        usageEvents.push(event);
+      }
+    });
+    const llm = createRuntimeLlm({ getConfig: () => cfg, authority: { allowComplete: true } });
+
+    const result = await llm.complete({
+      messages: [{ role: "user", content: "Return JSON" }],
+      execution: { mode: "isolated-agent-runtime" },
+    });
+    stop();
+
+    expect(result.usage).toEqual({});
+    expect(usageEvents).toEqual([]);
   });
 
   it("uses the authority-bound profile before the agent-configured profile", async () => {
@@ -408,6 +474,12 @@ describe("runtime.llm.complete isolated agent runtime", () => {
     ["input-rejected", "LLM_ISOLATED_INPUT_REJECTED"],
     ["output-rejected", "LLM_COMPLETION_OUTPUT_REJECTED"],
   ] as const)("maps %s adapter failures to %s", async (adapterCode, publicCode) => {
+    const usageEvents: unknown[] = [];
+    const stop = onTrustedInternalDiagnosticEvent((event) => {
+      if (event.type === "model.usage") {
+        usageEvents.push(event);
+      }
+    });
     hoisted.runIsolatedCompletion.mockRejectedValueOnce(
       Object.assign(new Error(`adapter ${adapterCode}`), { code: adapterCode }),
     );
@@ -419,5 +491,7 @@ describe("runtime.llm.complete isolated agent runtime", () => {
         execution: { mode: "isolated-agent-runtime" },
       }),
     ).rejects.toMatchObject({ code: publicCode });
+    stop();
+    expect(usageEvents).toEqual([]);
   });
 });

--- a/src/plugins/runtime/runtime-llm.runtime.ts
+++ b/src/plugins/runtime/runtime-llm.runtime.ts
@@ -11,6 +11,8 @@ import { normalizeModelRef } from "../../agents/model-ref-shared.js";
 import type { NormalizedUsage, UsageLike } from "../../agents/usage.js";
 import { normalizeUsage } from "../../agents/usage.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { emitTrustedDiagnosticEvent, isDiagnosticsEnabled } from "../../infra/diagnostic-events.js";
+import { markHostPluginUsageDiagnosticEvent } from "../../infra/diagnostic-plugin-usage-provenance.js";
 import type { Api, Message } from "../../llm/types.js";
 import { getChildLogger } from "../../logging.js";
 import { normalizeAgentId } from "../../routing/session-key.js";
@@ -257,6 +259,68 @@ function buildUsage(params: {
     ...(params.normalized?.total !== undefined ? { totalTokens: params.normalized.total } : {}),
     ...(costUsd !== undefined ? { costUsd } : {}),
   };
+}
+
+function finalizeCompletion(params: {
+  cfg: OpenClawConfig;
+  hostPluginId?: string;
+  suppressUsage?: boolean;
+  rawUsage: unknown;
+  logger: RuntimeLogger;
+  result: Omit<LlmCompleteResult, "usage">;
+}): LlmCompleteResult {
+  const normalized = normalizeUsage(params.rawUsage as UsageLike | undefined);
+  const usage = buildUsage({
+    rawUsage: params.rawUsage,
+    normalized,
+    cfg: params.cfg,
+    provider: params.result.provider,
+    model: params.result.model,
+  });
+  params.logger.info("plugin llm completion", {
+    caller: params.result.audit.caller,
+    purpose: params.result.audit.purpose,
+    sessionKey: params.result.audit.sessionKey,
+    agentId: params.result.agentId,
+    provider: params.result.provider,
+    model: params.result.model,
+    executionMode: params.result.execution.mode,
+    executionOwner: params.result.execution.owner,
+    usage,
+  });
+  const input = normalized?.input ?? 0;
+  const output = normalized?.output ?? 0;
+  const cacheRead = normalized?.cacheRead ?? 0;
+  const cacheWrite = normalized?.cacheWrite ?? 0;
+  const promptTokens = input + cacheRead + cacheWrite;
+  const total = normalized?.total ?? promptTokens + output;
+  const hasPositiveUsage = [input, output, cacheRead, cacheWrite, total, usage.costUsd].some(
+    (value) => typeof value === "number" && Number.isFinite(value) && value > 0,
+  );
+  if (params.suppressUsage !== true && isDiagnosticsEnabled(params.cfg) && hasPositiveUsage) {
+    emitTrustedDiagnosticEvent(
+      markHostPluginUsageDiagnosticEvent(
+        {
+          type: "model.usage",
+          ...(params.result.audit.sessionKey ? { sessionKey: params.result.audit.sessionKey } : {}),
+          agentId: params.result.agentId,
+          provider: params.result.provider,
+          model: params.result.model,
+          usage: {
+            input,
+            output,
+            cacheRead,
+            cacheWrite,
+            promptTokens,
+            total,
+          },
+          ...(usage.costUsd !== undefined ? { costUsd: usage.costUsd } : {}),
+        },
+        params.hostPluginId,
+      ),
+    );
+  }
+  return { ...params.result, usage };
 }
 
 function finiteOption(value: number | undefined): number | undefined {
@@ -531,6 +595,11 @@ export function createRuntimeLlm(
       const pluginPolicy = resolvePluginLlmPolicy(cfg, pluginPolicyId);
       const authorityPolicy = resolveAuthorityModelPolicy(options.authority);
       const preferredProfile = normalizeOptionalString(options.authority?.preferredProfile);
+      const audit = {
+        caller,
+        ...(params.purpose ? { purpose: params.purpose } : {}),
+        ...(options.authority?.sessionKey ? { sessionKey: options.authority.sessionKey } : {}),
+      };
       const agentId = await resolveAgentId({
         request: params,
         cfg,
@@ -601,38 +670,20 @@ export function createRuntimeLlm(
           authProfileId:
             executionProfile ?? requestedModelProfile ?? preferredProfile ?? modelProfile,
         });
-        const normalizedUsage = normalizeUsage(result.usage as UsageLike | undefined);
-        const usage = buildUsage({
-          rawUsage: result.usage,
-          normalized: normalizedUsage,
+        return finalizeCompletion({
           cfg,
-          provider: result.provider,
-          model: result.model,
-        });
-        logger.info("plugin llm completion", {
-          caller,
-          purpose: params.purpose,
-          sessionKey: options.authority?.sessionKey,
-          agentId,
-          provider: result.provider,
-          model: result.model,
-          executionMode: params.execution.mode,
-          executionOwner: result.owner,
-          usage,
-        });
-        return {
-          text: result.text,
-          provider: result.provider,
-          model: result.model,
-          agentId,
-          usage,
-          execution: { mode: params.execution.mode, owner: result.owner },
-          audit: {
-            caller,
-            ...(params.purpose ? { purpose: params.purpose } : {}),
-            ...(options.authority?.sessionKey ? { sessionKey: options.authority.sessionKey } : {}),
+          hostPluginId: pluginPolicyId,
+          rawUsage: result.usage,
+          logger,
+          result: {
+            text: result.text,
+            provider: result.provider,
+            model: result.model,
+            agentId,
+            execution: { mode: params.execution.mode, owner: result.owner },
+            audit,
           },
-        };
+        });
       }
 
       const prepared = await prepareSimpleCompletionModelForAgent({
@@ -676,43 +727,25 @@ export function createRuntimeLlm(
         .filter((c): c is { type: "text"; text: string } => c.type === "text")
         .map((c) => c.text)
         .join("");
-      const normalizedUsage = normalizeUsage(result.usage as UsageLike | undefined);
-      const usage = buildUsage({
-        rawUsage: result.usage,
-        normalized: normalizedUsage,
+      return finalizeCompletion({
         cfg,
-        provider: prepared.selection.provider,
-        model: prepared.selection.modelId,
-      });
-
-      logger.info("plugin llm completion", {
-        caller,
-        purpose: params.purpose,
-        sessionKey: options.authority?.sessionKey,
-        agentId,
-        provider: prepared.selection.provider,
-        model: prepared.selection.modelId,
-        executionMode: "direct-provider",
-        executionOwner: { kind: "provider", id: prepared.selection.provider },
-        usage,
-      });
-
-      return {
-        text,
-        provider: prepared.selection.provider,
-        model: prepared.selection.modelId,
-        agentId,
-        usage,
-        execution: {
-          mode: "direct-provider",
-          owner: { kind: "provider", id: prepared.selection.provider },
+        hostPluginId: pluginPolicyId,
+        // Provider failures resolve as messages; only visible successful output owns usage.
+        suppressUsage: !text.trim() || !["stop", "length", "toolUse"].includes(result.stopReason),
+        rawUsage: result.usage,
+        logger,
+        result: {
+          text,
+          provider: prepared.selection.provider,
+          model: prepared.selection.modelId,
+          agentId,
+          execution: {
+            mode: "direct-provider",
+            owner: { kind: "provider", id: prepared.selection.provider },
+          },
+          audit,
         },
-        audit: {
-          caller,
-          ...(params.purpose ? { purpose: params.purpose } : {}),
-          ...(options.authority?.sessionKey ? { sessionKey: options.authority.sessionKey } : {}),
-        },
-      };
+      });
     },
   };
 }

--- a/src/plugins/services.test.ts
+++ b/src/plugins/services.test.ts
@@ -22,6 +22,7 @@ import {
   resetDiagnosticEventsForTest,
   waitForDiagnosticEventsDrained,
 } from "../infra/diagnostic-events.js";
+import { markHostPluginUsageDiagnosticEvent } from "../infra/diagnostic-plugin-usage-provenance.js";
 import { queuePluginSessionsChanged, subscribePluginSessionsChanged } from "./gateway-events.js";
 import { registerPluginHttpRoute } from "./http-registry.js";
 import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "./runtime.js";
@@ -860,5 +861,57 @@ describe("startPluginServices", () => {
     });
 
     expect(spoofedContexts[0]?.internalDiagnostics).toBeUndefined();
+  });
+
+  it("delivers host plugin attribution only to the trusted OTel listener lane", async () => {
+    const observed: Array<{
+      exporter: string;
+      hostPluginId?: string;
+      privateHostPluginId?: unknown;
+    }> = [];
+    const createDiagnosticsService = (id: "diagnostics-otel" | "diagnostics-prometheus") => ({
+      id,
+      start(ctx: OpenClawPluginServiceContext) {
+        ctx.internalDiagnostics?.onEvent((event, _metadata, privateData) => {
+          if (event.type === "model.usage") {
+            observed.push({
+              exporter: id,
+              hostPluginId: (privateData as { hostPluginId?: string }).hostPluginId,
+              privateHostPluginId: (privateData as { hostPluginId?: unknown }).hostPluginId,
+            });
+          }
+        });
+      },
+    });
+    const registry = createRegistry(
+      [createDiagnosticsService("diagnostics-otel")],
+      "diagnostics-otel",
+      "bundled",
+    );
+    registry.services.push(
+      ...createRegistry(
+        [createDiagnosticsService("diagnostics-prometheus")],
+        "diagnostics-prometheus",
+        "bundled",
+      ).services,
+    );
+    await startPluginServices({ registry, config: createServiceConfig() });
+
+    emitTrustedDiagnosticEvent(
+      markHostPluginUsageDiagnosticEvent({ type: "model.usage", usage: { input: 1 } }, "llm-task"),
+    );
+
+    expect(observed).toEqual([
+      {
+        exporter: "diagnostics-otel",
+        hostPluginId: "llm-task",
+        privateHostPluginId: "llm-task",
+      },
+      {
+        exporter: "diagnostics-prometheus",
+        hostPluginId: undefined,
+        privateHostPluginId: undefined,
+      },
+    ]);
   });
 });

--- a/src/plugins/services.ts
+++ b/src/plugins/services.ts
@@ -7,6 +7,7 @@ import {
   onTrustedInternalDiagnosticEvent,
   waitForDiagnosticEventsDrained,
 } from "../infra/diagnostic-events.js";
+import { markTrustedOtelDiagnosticListener } from "../infra/diagnostic-otel-listener-provenance.js";
 import { registerDiagnosticTracePropagationBridge } from "../infra/diagnostic-trace-propagation.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { subscribePluginSessionsChanged } from "./gateway-events.js";
@@ -38,6 +39,7 @@ function createServiceContext(params: {
     params.service?.pluginId === params.service?.service.id &&
     (params.service?.service.id === "diagnostics-otel" ||
       params.service?.service.id === "diagnostics-prometheus");
+  const isOtelExporter = isDiagnosticsExporter && params.service.service.id === "diagnostics-otel";
   const grantsInternalDiagnostics =
     isDiagnosticsExporter &&
     (params.service?.origin === "bundled" || params.service?.trustedOfficialInstall === true);
@@ -60,7 +62,10 @@ function createServiceContext(params: {
       ? {
           internalDiagnostics: {
             emit: emitTrustedDiagnosticEventWithPrivateData,
-            onEvent: onTrustedInternalDiagnosticEvent,
+            onEvent: isOtelExporter
+              ? (listener) =>
+                  onTrustedInternalDiagnosticEvent(markTrustedOtelDiagnosticListener(listener))
+              : onTrustedInternalDiagnosticEvent,
             registerTracePropagationBridge: registerDiagnosticTracePropagationBridge,
           },
         }

--- a/test/e2e/qa-lab/runtime/otel-gateway-runtime.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/otel-gateway-runtime.e2e.test.ts
@@ -9,8 +9,8 @@ import {
 } from "../../../../extensions/qa-lab/api.js";
 import { type CapturedSpan, startLocalOtlpReceiver } from "./otel-test-support.js";
 
-async function startOtlpReceiver() {
-  const receiver = startLocalOtlpReceiver();
+async function startOtlpReceiver(disallowedBodyNeedles: string[] = []) {
+  const receiver = startLocalOtlpReceiver(disallowedBodyNeedles);
   const port = await receiver.listen();
   return { ...receiver, baseUrl: `http://127.0.0.1:${port}` };
 }
@@ -93,7 +93,7 @@ describe("diagnostics-otel gateway runtime", () => {
 
     try {
       bus = await startQaBusServer({ state });
-      const activeReceiver = await startOtlpReceiver();
+      const activeReceiver = await startOtlpReceiver(["qa-plugin-usage-secret-sentinel"]);
       receiver = activeReceiver;
       mock = await startQaMockOpenAiServer();
       gateway = await startQaGatewayChild({
@@ -103,12 +103,17 @@ describe("diagnostics-otel gateway runtime", () => {
         providerMode: "mock-openai",
         transport,
         transportBaseUrl: bus.baseUrl,
-        enabledPluginIds: ["diagnostics-otel"],
+        enabledPluginIds: ["diagnostics-otel", "llm-task"],
         controlUiEnabled: false,
         mutateConfig: (cfg) => ({
           ...cfg,
+          session: {
+            ...cfg.session,
+            dmScope: "per-peer",
+          },
           tools: {
             ...cfg.tools,
+            alsoAllow: [...(cfg.tools?.alsoAllow ?? []), "llm-task"],
             codeMode: {
               ...(typeof cfg.tools?.codeMode === "object" ? cfg.tools.codeMode : {}),
               enabled: true,
@@ -131,10 +136,14 @@ describe("diagnostics-otel gateway runtime", () => {
         }),
       });
       const conversation = { id: "qa-operator", kind: "direct" as const };
-      const send = async (text: string) => {
+      const send = async (
+        text: string,
+        expectedText: string,
+        targetConversation = conversation,
+      ) => {
         const cursor = state.getSnapshot().messages.length;
         state.addInboundMessage({
-          conversation,
+          conversation: targetConversation,
           senderId: "qa-user",
           senderName: "QA User",
           text,
@@ -145,13 +154,16 @@ describe("diagnostics-otel gateway runtime", () => {
             .messages.slice(cursor)
             .find(
               (message) =>
-                message.direction === "outbound" && message.conversation.id === conversation.id,
+                message.direction === "outbound" &&
+                message.conversation.id === targetConversation.id &&
+                message.text.includes(expectedText),
             ),
         );
       };
 
       const successful = await send(
         "Tool progress QA check: use the read tool exactly once on `QA_KICKOFF_TASK.md` before answering. After that read completes, reply with only this exact marker and no other text: `OTEL-GATEWAY-SUCCESS-OK`.",
+        "OTEL-GATEWAY-SUCCESS-OK",
       );
       expect(successful.direction).toBe("outbound");
       expect(successful.text).toContain("OTEL-GATEWAY-SUCCESS-OK");
@@ -161,6 +173,7 @@ describe("diagnostics-otel gateway runtime", () => {
       )) as { cursor: number };
       const recovered = await send(
         "Failed tool terminal recovery QA check: read the missing workspace file, then respond with exact marker: `QA-FAILED-TOOL-FINALIZED-OK`.",
+        "QA-FAILED-TOOL-FINALIZED-OK",
       );
       expect(recovered.direction).toBe("outbound");
       expect(recovered.text).toContain("The requested file could not be read: ENOENT.");
@@ -300,6 +313,85 @@ describe("diagnostics-otel gateway runtime", () => {
         expect(expectResolvedParent(modelCall, successSpansById).name).toBe("openclaw.run");
       }
       expect(expectResolvedParent(successEvidence!, successSpansById).name).toBe("openclaw.run");
+
+      const llmTaskConversation = { id: "qa-plugin-usage", kind: "direct" as const };
+      const llmTaskSpanCursor = activeReceiver.capturedSpans.length;
+      const llmTaskCursor = (await fetch(`${mock.baseUrl}/debug/request-cursor`).then((response) =>
+        response.json(),
+      )) as { cursor: number };
+      const llmTaskReply = await send(
+        "tool search qa check target=llm-task. Call exactly that tool once, then reply with only this exact marker: `OTEL-PLUGIN-USAGE-OK`.",
+        "OTEL-PLUGIN-USAGE-OK",
+        llmTaskConversation,
+      );
+      expect(llmTaskReply.text).toContain("OTEL-PLUGIN-USAGE-OK");
+
+      const llmTaskRequests = (await fetch(
+        `${mock.baseUrl}/debug/requests?after=${llmTaskCursor.cursor}`,
+      ).then((response) => response.json())) as Array<{
+        allInputText?: string;
+        plannedToolName?: string;
+      }>;
+      expect(
+        llmTaskRequests.filter((request) => request.plannedToolName === "llm-task"),
+      ).toHaveLength(1);
+      expect(
+        llmTaskRequests.some((request) =>
+          String(request.allInputText).includes("You are a JSON-only function."),
+        ),
+      ).toBe(true);
+
+      const llmTaskUsage = await waitFor(
+        () =>
+          activeReceiver.capturedSpans.find(
+            (span) =>
+              span.name === "openclaw.model.usage" &&
+              span.attributes["openclaw.plugin"] === "llm-task",
+          ),
+        45_000,
+        () => activeReceiver.capturedSpans,
+      );
+      expect(llmTaskUsage.attributes).toMatchObject({
+        "openclaw.tokens.input": 64,
+        "openclaw.tokens.output": 24,
+        "openclaw.tokens.total": 88,
+      });
+      expect(
+        activeReceiver.capturedSpans
+          .slice(llmTaskSpanCursor)
+          .filter(
+            (span) =>
+              span.name === "openclaw.model.usage" &&
+              span.attributes["openclaw.channel"] === "unknown" &&
+              span.attributes["openclaw.tokens.input"] === 64 &&
+              span.attributes["openclaw.tokens.output"] === 24 &&
+              span.attributes["openclaw.tokens.total"] === 88,
+          )
+          .map((span) => span.attributes["openclaw.plugin"]),
+      ).toEqual(["llm-task"]);
+      const attributedUsageSpans = activeReceiver.capturedSpans.filter(
+        (span) => span.attributes["openclaw.plugin"] !== undefined,
+      );
+      expect(
+        attributedUsageSpans.map((span) => ({
+          name: span.name,
+          pluginId: span.attributes["openclaw.plugin"],
+        })),
+      ).toEqual([{ name: "openclaw.model.usage", pluginId: "llm-task" }]);
+
+      const exportedBodies = Object.values(activeReceiver.capturedBodyText).flat().join("\n");
+      expect(exportedBodies).not.toContain("qa-plugin-usage-secret-sentinel");
+      console.info(
+        `[otel-gateway-runtime] plugin usage proof ${JSON.stringify({
+          spanName: llmTaskUsage.name,
+          pluginId: llmTaskUsage.attributes["openclaw.plugin"],
+          inputTokens: llmTaskUsage.attributes["openclaw.tokens.input"],
+          outputTokens: llmTaskUsage.attributes["openclaw.tokens.output"],
+          totalTokens: llmTaskUsage.attributes["openclaw.tokens.total"],
+          attributedUsageSpanCount: attributedUsageSpans.length,
+          requestContentPresent: exportedBodies.includes("qa-plugin-usage-secret-sentinel"),
+        })}`,
+      );
     } finally {
       await settleCleanup(
         async () => {


### PR DESCRIPTION
## What Problem This Solves

Plugin calls through `runtime.llm.complete` now contribute trusted token and cost diagnostics at the host-owned completion boundary.

## Root Cause

Direct and isolated plugin LLM completions returned normalized usage, but the shared completion owner did not emit that usage to diagnostics.

Three sibling defects remained:

- `runCliAgent` exposed CLI-isolated usage in `meta.agentMeta.usage`, but `runCliIsolatedCompletion` dropped it before the shared finalizer.
- Direct provider completion resolves both successful and error terminal events as assistant messages. The owner discarded `stopReason` and output validity, so resolved errors, aborts, and reasoning-only messages could emit usage.
- Earlier attribution repairs exposed host plugin identity through public diagnostic event or Plugin SDK listener shapes, allowing observation or forgery outside the OTel exporter boundary.

## Fix

- Finalize direct, harness-isolated, and CLI-isolated completions through one shared host path.
- Thread CLI-reported usage through the isolated adapter; do not add a CLI-specific emitter.
- Emit exactly one trusted `model.usage` event only for a successful visible completion with positive token or cost usage.
- Keep missing, zero, reasoning-only, unavailable-context, diagnostics-disabled, resolved-error, aborted, and rejected isolated completions silent.
- Derive plugin identity only from trusted host policy and one-shot event provenance.
- Keep `OpenClawPluginServiceContext.internalDiagnostics.onEvent`, `DiagnosticEventPrivateData`, public metadata, and SDK export counts unchanged.
- Scope hidden host identity to a fresh OTel listener registration. Ordinary public/trusted listeners and Prometheus never receive it.
- Preserve independently updated official OTel package compatibility through the existing three-argument listener transport without exposing `hostPluginId` in the public type.
- Add `openclaw.plugin` only to the trusted OTel usage span. Existing OTel metric labels and Prometheus labels remain unchanged.
- Strip caller-supplied attribution at the public trusted emitter and again at the OTel-private clone boundary.

## User Impact

Operators can attribute plugin-initiated LLM spend in traces without changing existing metric series, dashboards, or recording rules. Non-exporter plugins cannot observe or claim another plugin's trace identity.

## Evidence

- Published head: `8d55032feba093179c690cab4080c40ea9d59bbb`, one contributor-preserving commit.
- Focused sibling matrix: **385 tests passed** across direct runtime, harness/CLI isolated adapters, diagnostic dispatch, service capability, Plugin SDK declaration, OTel, Prometheus, and `llm-task` suites.
- Regression coverage includes:
  - resolved provider error, aborted, and thinking-only direct silence;
  - harness error, aborted, and thinking-only rejection;
  - CLI-isolated usage propagation and missing-usage silence;
  - public listener/type non-observation;
  - caller-supplied attribution rejection;
  - OTel registration-scoped provenance when one callback is reused in generic and OTel lanes;
  - old/new core and official OTel package listener compatibility.
- Final P0-P2 autoreview: no actionable findings; patch correct at confidence `0.90`.
- `oxfmt --check`, focused `oxlint`, `git diff --check`, max-lines, extension boundary, deprecated-API, dead-export, Plugin SDK API/export, and Plugin SDK surface checks passed.
- Plugin SDK surface remains count-neutral: `4831` public exports, `2908` callable exports, `0` forbidden package subpaths.

### Exporter capability boundary

- `src/plugins/registry-registrars-operations.ts:300` captures `pluginId`, `origin`, and `trustedOfficialInstall` from the host-owned plugin record when a service is registered; the plugin supplies only the service implementation.
- `src/plugins/services.ts:38` grants `internalDiagnostics` only when the host record owner matches the exact `diagnostics-otel` or `diagnostics-prometheus` service id and the record is bundled or a verified official install.
- `src/plugins/manifest-registry.ts:835` derives official-install trust from a matching install path, install record, official catalog package/id, and registry or trusted official ClawHub source. Workspace/path/npm-pack/custom-source/unrecorded lookalikes cannot obtain the capability from manifest claims.
- `src/infra/diagnostic-events.ts:1093` gives the one-shot host identity only to the listener wrapper marked by the OTel service context. Public listeners, generic trusted listeners, and Prometheus receive cloned private data without `hostPluginId`; `src/plugins/services.test.ts:781` covers the grant and spoof-denial matrix.
- `hostPluginId` is absent from the public listener declaration, and the internal test-runtime listener API is not shipped as a package export. OpenClaw native plugins are trusted in-process code; the supported plugin model does not claim process isolation from deliberate runtime tampering.

### Exact-head real Gateway + OTLP proof

- Provider: `aws`
- Lease: `cbx_4b929dbe9648`
- Run: `run_2758a6c4fd2e`
- URL: https://crabbox.openclaw.ai/portal/runs/run_2758a6c4fd2e
- Result: 1 real Gateway + mock provider + `llm-task` + OTLP receiver E2E passed, exit `0`, `runStatus=succeeded`; lease released.

Redacted receiver/span output:

```json
{"spanName":"openclaw.model.usage","pluginId":"llm-task","inputTokens":64,"outputTokens":24,"totalTokens":88,"attributedUsageSpanCount":1,"requestContentPresent":false}
```

The E2E fails if the completion emits a second matching usage span, if attribution is missing or forged, or if request content reaches OTLP.

Production runtime delta is `+217/-83` (net `+134`), justified by the shared completion owner, CLI adapter propagation, and exporter-private security/version-skew boundary. Tests and QA are net `+971`; docs are net `+5`.

No changelog entry is included for this contributor repair.

Fixes #98968
