### PR TITLE
fix(cron): anchor regex patterns with ^...$ for llama.cpp JSON Schema compatibility

### DIFF
--- a/packages/gateway-protocol/src/schema/cron.ts
+++ b/packages/gateway-protocol/src/schema/cron.ts
@@ -55,7 +55,7 @@ const CronSessionTargetSchema = Type.Union([
   Type.Literal("main"),
   Type.Literal("isolated"),
   Type.Literal("current"),
-  Type.String({ pattern: "^session:.+" }),
+  Type.String({ pattern: "^session:.+$" }),
 ]);
 /** Whether a cron job waits for heartbeat processing or wakes immediately. */
 const CronWakeModeSchema = Type.Union([Type.Literal("next-heartbeat"), Type.Literal("now")]);
@@ -112,9 +112,21 @@ const CronDeliveryStatusSchema = Type.Union([
   Type.Literal("unknown"),
   Type.Literal("not-requested"),
 ]);
-const NonBlankString = Type.String({ minLength: 1, pattern: "\\S" });
-const CronDeclarationKeySchema = Type.String({ minLength: 1, maxLength: 200, pattern: "\\S" });
-const CronDisplayNameSchema = Type.String({ minLength: 1, maxLength: 200, pattern: "\\S" });
+// Fully-anchored llama.cpp-compatible nonblank pattern: the whole string must
+// contain at least one non-whitespace character (same acceptance set as the
+// prior unanchored `\S`), including leading/trailing whitespace and newlines.
+const NONBLANK_STRING_PATTERN = "^[\\s\\S]*\\S[\\s\\S]*$";
+const NonBlankString = Type.String({ minLength: 1, pattern: NONBLANK_STRING_PATTERN });
+const CronDeclarationKeySchema = Type.String({
+  minLength: 1,
+  maxLength: 200,
+  pattern: NONBLANK_STRING_PATTERN,
+});
+const CronDisplayNameSchema = Type.String({
+  minLength: 1,
+  maxLength: 200,
+  pattern: NONBLANK_STRING_PATTERN,
+});
 const CronOwnerSchema = closedObject({
   agentId: Type.Optional(NonEmptyString),
   sessionKey: Type.Optional(NonEmptyString),

--- a/src/agents/tools/cron-tool.schema.test.ts
+++ b/src/agents/tools/cron-tool.schema.test.ts
@@ -306,4 +306,67 @@ describe("createCronToolSchema", () => {
     // The "not" composition keyword is not supported by OpenAPI 3.0.
     expect(json).not.toMatch(/"not"\s*:\s*\{/);
   });
+
+  it("anchors every regex pattern for llama.cpp schema conversion", () => {
+    // llama.cpp JSON-schema-to-grammar requires patterns to start with '^'
+    // and end with '$'; unanchored cron patterns cause a hard 400 before
+    // inference when the cron tool is advertised.
+    const patterns = collectPatterns(schemaRecord);
+    expect(patterns.length).toBeGreaterThan(0);
+    for (const pattern of patterns) {
+      expect(pattern.startsWith("^") && pattern.endsWith("$"), pattern).toBe(true);
+    }
+  });
+
+  it("accepts nonblank declarationKey and rejects whitespace-only keys", () => {
+    const schema = createCronTool().parametersJsonSchema;
+    if (!schema || typeof schema !== "object") {
+      throw new Error("expected cron tool parametersJsonSchema");
+    }
+    expect(
+      Value.Check(schema, {
+        action: "add",
+        job: { declarationKey: "daily-report" },
+      }),
+    ).toBe(true);
+    expect(
+      Value.Check(schema, {
+        action: "add",
+        job: { declarationKey: " daily-report " },
+      }),
+    ).toBe(true);
+    expect(
+      Value.Check(schema, {
+        action: "add",
+        job: { declarationKey: "line one\nline two" },
+      }),
+    ).toBe(true);
+    expect(
+      Value.Check(schema, {
+        action: "add",
+        job: { declarationKey: "   " },
+      }),
+    ).toBe(false);
+  });
 });
+
+/** Recursively collect JSON Schema `pattern` strings from a TypeBox schema tree. */
+function collectPatterns(value: unknown, out: string[] = []): string[] {
+  if (!value || typeof value !== "object") {
+    return out;
+  }
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      collectPatterns(item, out);
+    }
+    return out;
+  }
+  const record = value as Record<string, unknown>;
+  if (typeof record.pattern === "string") {
+    out.push(record.pattern);
+  }
+  for (const child of Object.values(record)) {
+    collectPatterns(child, out);
+  }
+  return out;
+}

--- a/src/agents/tools/cron-tool.ts
+++ b/src/agents/tools/cron-tool.ts
@@ -279,7 +279,8 @@ function createCronJobObjectSchema(): TSchema {
             description: "Idempotent declaration key.",
             minLength: 1,
             maxLength: 200,
-            pattern: "\\S",
+            // Fully-anchored llama.cpp-compatible nonblank pattern.
+            pattern: "^[\\s\\S]*\\S[\\s\\S]*$",
           }),
         ),
         displayName: Type.Optional(

--- a/src/cron/cron-protocol-schema.test.ts
+++ b/src/cron/cron-protocol-schema.test.ts
@@ -1,10 +1,18 @@
 // Cron protocol schema tests cover runtime validation for cron protocol payloads.
+import { Value } from "typebox/value";
 import { describe, expect, it } from "vitest";
-import { CronJobStateSchema } from "../../packages/gateway-protocol/src/schema.js";
+import {
+  CronAddParamsSchema,
+  CronDeliverySchema,
+  CronJobPatchSchema,
+  CronJobStateSchema,
+} from "../../packages/gateway-protocol/src/schema.js";
 
 type SchemaLike = {
   properties?: Record<string, unknown>;
   deprecated?: boolean;
+  pattern?: string;
+  anyOf?: SchemaLike[];
 };
 
 describe("cron protocol schema", () => {
@@ -23,4 +31,107 @@ describe("cron protocol schema", () => {
     expect(properties.lastFailureNotificationDeliveryStatus).toBeDefined();
     expect(properties.lastFailureNotificationDeliveryError).toBeDefined();
   });
+
+  it("anchors every cron regex pattern for llama.cpp schema conversion", () => {
+    // llama.cpp rejects unanchored JSON Schema patterns during grammar
+    // conversion; keep cron schemas fully ^...$ so provider routes do not 400.
+    const schemas = [CronAddParamsSchema, CronJobPatchSchema, CronDeliverySchema];
+    const patterns = schemas.flatMap((schema) => collectPatterns(schema));
+    expect(patterns.length).toBeGreaterThan(0);
+    for (const pattern of patterns) {
+      expect(pattern.startsWith("^") && pattern.endsWith("$"), pattern).toBe(true);
+    }
+  });
+
+  it("accepts nonblank declaration keys and session targets while rejecting blanks", () => {
+    const baseAdd = {
+      name: "daily-report",
+      schedule: { kind: "at" as const, at: "2026-07-16T12:00:00.000Z" },
+      sessionTarget: "main" as const,
+      wakeMode: "now" as const,
+      payload: { kind: "systemEvent" as const, text: "ping" },
+    };
+
+    expect(
+      Value.Check(CronAddParamsSchema, {
+        ...baseAdd,
+        declarationKey: "daily-report",
+        displayName: "Daily report",
+        sessionTarget: "session:agent:ops:main",
+        delivery: { mode: "webhook", to: "https://example.invalid/hook" },
+      }),
+    ).toBe(true);
+
+    // Whitespace-only values are rejected.
+    expect(
+      Value.Check(CronAddParamsSchema, {
+        ...baseAdd,
+        declarationKey: "   ",
+      }),
+    ).toBe(false);
+    expect(
+      Value.Check(CronAddParamsSchema, {
+        ...baseAdd,
+        displayName: "   ",
+      }),
+    ).toBe(false);
+
+    // Padded values are accepted.
+    expect(
+      Value.Check(CronAddParamsSchema, {
+        ...baseAdd,
+        declarationKey: " daily-report ",
+      }),
+    ).toBe(true);
+    expect(
+      Value.Check(CronAddParamsSchema, {
+        ...baseAdd,
+        displayName: " Daily report ",
+      }),
+    ).toBe(true);
+
+    // Multiline nonblank values are accepted.
+    expect(
+      Value.Check(CronAddParamsSchema, {
+        ...baseAdd,
+        displayName: "line one\nline two",
+      }),
+    ).toBe(true);
+
+    // Trailing-colon-only session targets are rejected.
+    expect(
+      Value.Check(CronAddParamsSchema, {
+        ...baseAdd,
+        sessionTarget: "session:",
+      }),
+    ).toBe(false);
+
+    // Patch rejects whitespace-only displayName.
+    expect(
+      Value.Check(CronJobPatchSchema, {
+        displayName: "   ",
+      }),
+    ).toBe(false);
+  });
 });
+
+/** Recursively collect JSON Schema `pattern` strings from a TypeBox schema tree. */
+function collectPatterns(value: unknown, out: string[] = []): string[] {
+  if (!value || typeof value !== "object") {
+    return out;
+  }
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      collectPatterns(item, out);
+    }
+    return out;
+  }
+  const record = value as Record<string, unknown>;
+  if (typeof record.pattern === "string") {
+    out.push(record.pattern);
+  }
+  for (const child of Object.values(record)) {
+    collectPatterns(child, out);
+  }
+  return out;
+}

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.discord-group.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.discord-group.json
@@ -474,7 +474,7 @@
                   "description": "Idempotent declaration key.",
                   "maxLength": 200,
                   "minLength": 1,
-                  "pattern": "\\S",
+                  "pattern": "^[\\\\s\\\\S]*\\\\S[\\\\s\\\\S]*$",
                   "type": "string"
                 },
                 "deleteAfterRun": {

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.heartbeat-turn.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.heartbeat-turn.json
@@ -470,7 +470,7 @@
                   "description": "Idempotent declaration key.",
                   "maxLength": 200,
                   "minLength": 1,
-                  "pattern": "\\S",
+                  "pattern": "^[\\\\s\\\\S]*\\\\S[\\\\s\\\\S]*$",
                   "type": "string"
                 },
                 "deleteAfterRun": {

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
@@ -470,7 +470,7 @@
                   "description": "Idempotent declaration key.",
                   "maxLength": 200,
                   "minLength": 1,
-                  "pattern": "\\S",
+                  "pattern": "^[\\\\s\\\\S]*\\\\S[\\\\s\\\\S]*$",
                   "type": "string"
                 },
                 "deleteAfterRun": {

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
@@ -208,8 +208,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 52583,
-    "roughTokens": 13146
+    "chars": 52603,
+    "roughTokens": 13151
   },
   "openClawDeveloperInstructions": {
     "chars": 3559,
@@ -220,8 +220,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 7021
   },
   "totalWithDynamicToolsJson": {
-    "chars": 80669,
-    "roughTokens": 20168
+    "chars": 80689,
+    "roughTokens": 20173
   },
   "userInputText": {
     "chars": 1442,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
@@ -208,8 +208,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 52310,
-    "roughTokens": 13078
+    "chars": 52330,
+    "roughTokens": 13083
   },
   "openClawDeveloperInstructions": {
     "chars": 2450,
@@ -220,8 +220,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6642
   },
   "totalWithDynamicToolsJson": {
-    "chars": 78878,
-    "roughTokens": 19720
+    "chars": 78898,
+    "roughTokens": 19725
   },
   "userInputText": {
     "chars": 1033,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
@@ -209,8 +209,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 53600,
-    "roughTokens": 13400
+    "chars": 53620,
+    "roughTokens": 13405
   },
   "openClawDeveloperInstructions": {
     "chars": 2469,
@@ -221,8 +221,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6777
   },
   "totalWithDynamicToolsJson": {
-    "chars": 80707,
-    "roughTokens": 20177
+    "chars": 80727,
+    "roughTokens": 20182
   },
   "userInputText": {
     "chars": 1271,


### PR DESCRIPTION
## What Problem This Solves

llama.cpp's JSON-schema-to-grammar converter rejects unanchored regex
`pattern` values with a hard 400 error. The cron tool and gateway protocol
schemas use unanchored `\S` patterns that cause every agent turn to fail
when the cron tool is enabled and the model runs on llama.cpp.

Closes #107449.

## Why This Change Was Made

Replace 5 unanchored nonblank patterns with **fully-anchored** equivalents
using `[\s\S]` (not `.`) so multiline nonblank values are preserved:

| Schema | Before | After |
|--------|--------|-------|
| NonBlankString | `\S` | `^[\s\S]*\S[\s\S]*$` |
| CronDeclarationKeySchema | `\S` | `^[\s\S]*\S[\s\S]*$` |
| CronDisplayNameSchema | `\S` | `^[\s\S]*\S[\s\S]*$` |
| cron-tool declarationKey | `\S` | `^[\s\S]*\S[\s\S]*$` |
| CronSessionTargetSchema | `^session:.+` | `^session:.+$` |

Key design decisions:
- **Use `[\s\S]` not `.`**: Under JSON Schema regex semantics (without
  dotall), `.` excludes CR and LF. `[\s\S]` matches all characters
  including newlines, preserving the original "contains at least one
  non-whitespace character" contract for multiline values.
- **Full anchors on all patterns**: Every cron-facing regex now has both
  `^` and `$` so llama.cpp's parser accepts them.

## Verification

- `cron-tool.schema.test.ts`: anchor verification across all patterns,
  Value.Check nonblank + multiline + whitespace rejection
- `cron-protocol-schema.test.ts`: anchor verification for CronAddParams,
  CronJobPatch, CronDelivery schemas; Value.Check for nonblank
  declarationKey/displayName/sessionTarget; multiline + padded + blank
  scenarios
- Snapshot fixtures updated for the longer pattern string

## Risk / Compatibility

Low. The `[\s\S]` pattern accepts the same set of strings as the prior
unanchored `\S` (contains at least one non-whitespace character), plus
it now correctly preserves multiline nonblank values. Only llama.cpp
rejects unanchored patterns — other providers already accept these.