### PR TITLE
docs: explain z.ai overload responses

### DIFF
--- a/docs/providers/zai.md
+++ b/docs/providers/zai.md
@@ -94,6 +94,38 @@ then `zai-cn`) before Coding Plan endpoints (`zai-coding-global`, then
 Use an explicit `--auth-choice` to force a Coding Plan endpoint if your key
 works on both.
 
+## Rate limits and overloads
+
+Z.AI documents the Coding Plan and general-purpose agent tools as capacity
+managed services. In Z.AI's own docs:
+
+- [General-purpose agent tools](https://docs.z.ai/devpack/tool/others),
+  including OpenClaw, are served on a best-effort basis. During high inference
+  load, typically around 2-6 PM Singapore time, some requests may face temporary
+  rate limits.
+- [Coding Plan rate and concurrency limits](https://docs.z.ai/devpack/usage-policy)
+  are tied to the plan tier and can be adjusted dynamically based on resource
+  availability. Off-peak hours may have higher concurrency.
+- [API error code `1302`](https://docs.z.ai/api-reference/api-code) means "Rate
+  limit reached for requests". API error code `1305` means "The service may be
+  temporarily overloaded, please try again later".
+
+If you see a temporary `429` or `1305` response during a busy period, wait and
+retry the request. If failures are repeatable outside peak periods, or only
+occur for one endpoint, model, or request shape, check the configured endpoint
+and model first:
+
+```bash
+openclaw models list --all --provider zai
+openclaw config get models.providers.zai.baseUrl
+```
+
+Coding Plan keys should use a Coding Plan endpoint such as
+`https://api.z.ai/api/coding/paas/v4`; general API keys should use a general API
+endpoint such as `https://api.z.ai/api/paas/v4`. Persistent failures with the
+same key and endpoint can indicate a provider-side rejection or plan limitation,
+not ordinary peak-load throttling.
+
 ## Config example
 
 <Tip>


### PR DESCRIPTION
Related: #103529

## What Problem This Solves

Resolves a docs gap where Z.AI users who see `429`, `1302`, or `1305` responses do not have provider-page guidance explaining Z.AI's documented capacity behavior, Coding Plan endpoint expectations, or first checks for persistent failures.

## Why This Change Was Made

This adds a focused `Rate limits and overloads` section to the Z.AI provider docs. It links to Z.AI's own tool, usage-policy, and API error-code docs, then gives users a short diagnostic path for checking their configured endpoint and model.

Non-goal: this does not change provider runtime behavior or claim that every `1305` is ordinary load; persistent repeatable failures are called out as a separate provider-side rejection or plan-limitation signal.

## User Impact

Z.AI users can distinguish ordinary peak-load throttling from persistent setup or provider-side rejection symptoms, and can verify whether their Coding Plan key is pointed at a Coding Plan endpoint.

## Evidence

- `git diff --check`
- `pnpm docs:list`

AI-assisted with human direction and review.
