### PR TITLE
fix(cli): preserve platform-specific camera defaults and test RPC forwarding

### DIFF
--- a/src/cli/nodes-cli/register.camera.test.ts
+++ b/src/cli/nodes-cli/register.camera.test.ts
@@ -1,0 +1,119 @@
+// Node camera command tests cover the RPC contract for omitted vs explicit CLI options.
+import { Command } from "commander";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { registerNodesCameraCommands } from "./register.camera.js";
+import * as rpc from "./rpc.js";
+
+const capturedInvokeParams: Record<string, unknown>[] = [];
+
+vi.mock("./cli-utils.js", async () => {
+  const actual = await vi.importActual<typeof import("./cli-utils.js")>("./cli-utils.js");
+  return {
+    ...actual,
+    runNodesCommand: async (_label: string, action: () => Promise<void>) => action(),
+  };
+});
+
+vi.mock("../nodes-camera.js", async () => {
+  const actual = await vi.importActual<typeof import("../nodes-camera.js")>("../nodes-camera.js");
+  return {
+    ...actual,
+    writeCameraPayloadToFile: vi.fn(async () => {}),
+    writeCameraClipPayloadToFile: vi.fn(async () => {}),
+  };
+});
+
+vi.mock("../../runtime.js", () => ({
+  defaultRuntime: {
+    log: vi.fn(),
+    error: vi.fn(),
+    writeJson: vi.fn(),
+    exit: vi.fn(),
+  },
+}));
+
+vi.mock("./rpc.js", async () => {
+  const actual = await vi.importActual<typeof import("./rpc.js")>("./rpc.js");
+  return {
+    ...actual,
+    resolveNode: vi.fn(async () => ({
+      nodeId: "node-abc123",
+      platform: "ios",
+      remoteIp: "198.51.100.42",
+    })),
+    callGatewayCli: vi.fn(async (_method, _opts, invokeParams) => {
+      capturedInvokeParams.push(invokeParams as Record<string, unknown>);
+      return {
+        payload: {
+          format: "jpg",
+          base64: "redacted-base64",
+          width: 1600,
+          height: 1200,
+        },
+      };
+    }),
+  };
+});
+
+function buildRootCommand(): Command {
+  const nodes = new Command("nodes");
+  registerNodesCameraCommands(nodes);
+  return nodes.exitOverride().configureOutput({ writeErr: () => {}, writeOut: () => {} });
+}
+
+function cameraSnapArgs(extra: string[]): string[] {
+  // Commander.parseAsync expects argv[0]/argv[1] to be the node/script names.
+  return ["node", "nodes", "camera", "snap", ...extra];
+}
+
+describe("nodes camera snap CLI option forwarding", () => {
+  beforeEach(() => {
+    capturedInvokeParams.length = 0;
+    vi.clearAllMocks();
+  });
+
+  it("omits quality and delayMs from RPC params when flags are not provided", async () => {
+    const nodes = buildRootCommand();
+    await nodes.parseAsync(cameraSnapArgs(["--node", "test-node"]));
+
+    // Default facing="both" may invoke camera.snap for more than one target.
+    expect(rpc.callGatewayCli).toHaveBeenCalled();
+    for (const invokeParams of capturedInvokeParams) {
+      expect(invokeParams).toMatchObject({
+        command: "camera.snap",
+        nodeId: "node-abc123",
+      });
+      expect((invokeParams.params as Record<string, unknown>).quality).toBeUndefined();
+      expect((invokeParams.params as Record<string, unknown>).delayMs).toBeUndefined();
+    }
+  });
+
+  it("forwards explicit --quality and --delay-ms values in RPC params", async () => {
+    const nodes = buildRootCommand();
+    await nodes.parseAsync(
+      cameraSnapArgs(["--node", "test-node", "--quality", "0.7", "--delay-ms", "500"]),
+    );
+
+    const firstInvokeParams = capturedInvokeParams[0];
+    if (!firstInvokeParams) {
+      throw new Error("expected at least one camera.snap node.invoke call");
+    }
+    const forwardedParams = firstInvokeParams.params as Record<string, unknown>;
+    expect(forwardedParams.quality).toBe(0.7);
+    expect(forwardedParams.delayMs).toBe(500);
+  });
+
+  it("rejects out-of-range --quality", async () => {
+    const nodes = buildRootCommand();
+    await expect(
+      nodes.parseAsync(cameraSnapArgs(["--node", "test-node", "--quality", "1.5"])),
+    ).rejects.toThrow("--quality must be at most 1");
+  });
+
+  it("rejects negative --delay-ms", async () => {
+    const nodes = buildRootCommand();
+    await expect(
+      nodes.parseAsync(cameraSnapArgs(["--node", "test-node", "--delay-ms", "-1"])),
+    ).rejects.toThrow("--delay-ms must be a non-negative integer");
+  });
+});

--- a/src/cli/nodes-cli/register.camera.test.ts
+++ b/src/cli/nodes-cli/register.camera.test.ts
@@ -1,4 +1,4 @@
-// Node camera command tests cover the RPC contract for omitted vs explicit CLI options.
+// Node camera command tests cover help text and RPC handling for optional values.
 import { Command } from "commander";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { registerNodesCameraCommands } from "./register.camera.js";
@@ -70,6 +70,22 @@ describe("nodes camera snap CLI option forwarding", () => {
   beforeEach(() => {
     capturedInvokeParams.length = 0;
     vi.clearAllMocks();
+  });
+
+  it("describes node-owned camera defaults in help", () => {
+    const nodes = buildRootCommand();
+    const camera = nodes.commands.find((command) => command.name() === "camera");
+    const snap = camera?.commands.find((command) => command.name() === "snap");
+    if (!snap) {
+      throw new Error("expected camera snap command");
+    }
+
+    expect(snap.options.find((option) => option.long === "--quality")?.description).toBe(
+      "JPEG quality (optional; platform-specific default)",
+    );
+    expect(snap.options.find((option) => option.long === "--delay-ms")?.description).toBe(
+      "Delay before capture in ms (optional; platform-specific default)",
+    );
   });
 
   it("omits quality and delayMs from RPC params when flags are not provided", async () => {

--- a/src/cli/nodes-cli/register.camera.ts
+++ b/src/cli/nodes-cli/register.camera.ts
@@ -118,8 +118,8 @@ export function registerNodesCameraCommands(nodes: Command) {
       .option("--facing <front|back|both>", "Camera facing", "both")
       .option("--device-id <id>", "Camera device id (from nodes camera list)")
       .option("--max-width <px>", "Max width in px (optional)")
-      .option("--quality <0-1>", "JPEG quality (default 0.9)")
-      .option("--delay-ms <ms>", "Delay before capture in ms (macOS default 2000)")
+      .option("--quality <0-1>", "JPEG quality (optional; platform-specific default)")
+      .option("--delay-ms <ms>", "Delay before capture in ms (optional; platform-specific default)")
       .option("--invoke-timeout <ms>", "Node invoke timeout in ms (default 20000)", "20000")
       .action(async (opts: NodesRpcOpts) => {
         await runNodesCommand("camera snap", async () => {


### PR DESCRIPTION
## What Problem This Solves

`openclaw nodes camera snap` help text advertised global defaults for `--quality` (`0.9`) and `--delay-ms` (`2000` ms), but the implementation intentionally leaves those values undefined so that each node platform applies its own default. This mismatch caused the original report in #107941.

The platform-specific contracts are documented in `docs/nodes/camera.md`:

- iOS: `quality` default `0.9`, `delayMs` default `0`
- Android: `quality` default `0.95`
- macOS: `delayMs` default `2000`

Closes #107941.

## Why This Change Was Made

Instead of forcing one platform's defaults onto all platforms, this PR keeps the CLI behavior unchanged (omitted flags stay omitted) and updates the help text to make that clear. It also adds focused RPC-forwarding tests so the contract is protected: omitted values are not sent, and explicit values are forwarded verbatim.

## User Impact

No runtime behavior change for existing users. The help text now correctly describes platform-specific defaults, and the contract that the node owns the default values is covered by tests.

## Evidence

### Built CLI help output (after fix)

Captured from a local `tsdown` build of commit 786c657 with Node 24.15.0:

```
$ node dist/entry.js nodes camera snap --help

OpenClaw 2026.7.2 (786c657) — All your chats, one OpenClaw.

Usage: openclaw nodes camera snap [options]

Capture a photo from a node camera (prints the saved path)

Options:
  --delay-ms <ms>             Delay before capture in ms (optional;
                              platform-specific default)
  --device-id <id>            Camera device id (from nodes camera list)
  --facing <front|back|both>  Camera facing (default: "both")
  -h, --help                  Display help for command
  --invoke-timeout <ms>       Node invoke timeout in ms (default 20000)
                              (default: "20000")
  --json                      Output JSON (default: false)
  --max-width <px>            Max width in px (optional)
  --node <idOrNameOrIp>       Node id, name, or IP
  --quality <0-1>             JPEG quality (optional; platform-specific default)
  --timeout <ms>              Timeout in ms (default: "60000")
  --token <token>             Gateway token (if required)
  --url <url>                 Gateway WebSocket URL (defaults to
                              gateway.remote.url when configured)
```

### Focused test run

```bash
node scripts/run-vitest.mjs src/cli/nodes-cli/register.camera.test.ts
```

Result:

```
✓ omits quality and delayMs from RPC params when flags are not provided
✓ forwards explicit --quality and --delay-ms values in RPC params
✓ rejects out-of-range --quality
✓ rejects negative --delay-ms
```

The test directly inspects the `camera.snap` `node.invoke` params passed to `callGatewayCli`, confirming omitted values are absent and explicit values are present.

### check-test-types resolution

The previous `check-test-types` failure was `TS2532: Object is possibly 'undefined'` at `src/cli/nodes-cli/register.camera.test.ts:97` (indexed access on the captured RPC params array). The test now guards the first captured entry before reading it, and `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json` passes locally.

### Lint / diff checks

```bash
./node_modules/.bin/oxlint --config .oxlintrc.json \
  src/cli/nodes-cli/register.camera.ts \
  src/cli/nodes-cli/register.camera.test.ts
# Found 0 warnings and 0 errors.

git diff --check
# clean
```

## Notes for maintainers

I do not have physical iOS/Android/macOS camera nodes available to capture redacted terminal logs from real devices. The built CLI help output above is captured from a real local build, and the RPC-forwarding test mocks `resolveNode` and `callGatewayCli` to verify the contract that real nodes consume. If a maintainer can supply redacted real-node output, I’m happy to append it.