### PR TITLE
refactor(channels): privatize message access internals

### DIFF
--- a/src/channels/message-access/index.ts
+++ b/src/channels/message-access/index.ts
@@ -1,6 +1,5 @@
 // Public channel ingress/message-access barrel. Keep this as the narrow import
 // point for callers that need access decisions without plugin internals.
-export { decideChannelIngress } from "./decision.js";
 export { defineStableChannelIngressIdentity } from "./runtime-identity.js";
 export {
   channelIngressRoutes,
@@ -10,7 +9,6 @@ export {
 } from "./runtime.js";
 export { readChannelIngressStoreAllowFromForDmPolicy } from "./store-allow-from.js";
 
-export { resolveChannelIngressState } from "./state.js";
 export type {
   ChannelIngressAccessGroupMembershipResolver,
   ChannelIngressCommandPresetInput,

--- a/src/channels/message-access/message-access.test.ts
+++ b/src/channels/message-access/message-access.test.ts
@@ -1,13 +1,13 @@
 // Message access tests cover channel message visibility and permission helpers.
 import { describe, expect, it } from "vitest";
-import {
-  decideChannelIngress,
-  resolveChannelIngressState,
-  type ChannelIngressPolicyInput,
-  type ChannelIngressStateInput,
-  type InternalChannelIngressAdapter,
-  type InternalChannelIngressSubject,
+import { decideChannelIngress } from "./decision.js";
+import type {
+  ChannelIngressPolicyInput,
+  ChannelIngressStateInput,
+  InternalChannelIngressAdapter,
+  InternalChannelIngressSubject,
 } from "./index.js";
+import { resolveChannelIngressState } from "./state.js";
 
 const subject = (value: string): InternalChannelIngressSubject => ({
   identifiers: [{ opaqueId: "subject-1", kind: "stable-id", value }],

--- a/src/channels/message-access/types.ts
+++ b/src/channels/message-access/types.ts
@@ -20,7 +20,7 @@ export type ChannelIngressIdentifierKind =
   | `plugin:${string}`;
 
 /** Public, redacted identifier material that can participate in allowlist matching. */
-export type MatchableIdentifier = {
+type MatchableIdentifier = {
   opaqueId: string;
   kind: ChannelIngressIdentifierKind;
   dangerous?: boolean;
@@ -38,7 +38,7 @@ export type InternalChannelIngressSubject = {
 };
 
 /** Public, redacted form of a normalized allowlist entry. */
-export type ChannelIngressNormalizedEntry = {
+type ChannelIngressNormalizedEntry = {
   opaqueEntryId: string;
   kind: ChannelIngressIdentifierKind;
   dangerous?: boolean;
@@ -70,10 +70,7 @@ type ChannelIngressNormalizeResult = {
 };
 
 /** Internal normalization result with raw comparable entry values retained. */
-export type InternalChannelIngressNormalizeResult = Omit<
-  ChannelIngressNormalizeResult,
-  "matchable"
-> & {
+type InternalChannelIngressNormalizeResult = Omit<ChannelIngressNormalizeResult, "matchable"> & {
   matchable: InternalNormalizedEntry[];
 };
 
@@ -145,18 +142,13 @@ export type RedactedIngressAllowlistFacts = {
 };
 
 /** Route lookup state projected into the ingress access graph. */
-export type RouteGateState =
-  | "not-configured"
-  | "matched"
-  | "not-matched"
-  | "disabled"
-  | "lookup-failed";
+type RouteGateState = "not-configured" | "matched" | "not-matched" | "disabled" | "lookup-failed";
 
 /** How a matched route affects sender allowlist evaluation. */
 export type RouteSenderPolicy = "inherit" | "replace" | "deny-when-empty";
 
 /** Source list used when a route sender policy contributes sender entries. */
-export type RouteSenderAllowlistSource = "effective-dm" | "effective-group";
+type RouteSenderAllowlistSource = "effective-dm" | "effective-group";
 
 /** Raw route gate facts supplied by a channel-specific router. */
 export type RouteGateFacts = {
@@ -195,7 +187,7 @@ export type ChannelIngressEventInput = {
 };
 
 /** Redacted event facts exposed in decisions and access facts. */
-export type RedactedChannelIngressEvent = Omit<ChannelIngressEventInput, "originSubject"> & {
+type RedactedChannelIngressEvent = Omit<ChannelIngressEventInput, "originSubject"> & {
   hasOriginSubject: boolean;
   originSubjectMatched: boolean;
 };
@@ -248,10 +240,10 @@ export type ChannelIngressPolicyInput = {
 };
 
 /** Ordered phase for a gate in the ingress graph. */
-export type IngressGatePhase = "route" | "sender" | "command" | "event" | "activation";
+type IngressGatePhase = "route" | "sender" | "command" | "event" | "activation";
 
 /** Gate kind used in the ingress graph and projected access facts. */
-export type IngressGateKind =
+type IngressGateKind =
   | "route"
   | "routeSender"
   | "dmSender"
@@ -264,7 +256,7 @@ export type IngressGateKind =
   | "mention";
 
 /** Effect produced by a gate when computing final ingress admission. */
-export type IngressGateEffect =
+type IngressGateEffect =
   | "allow"
   | "block-dispatch"
   | "block-command"
@@ -340,7 +332,7 @@ export type AccessGraphGate = {
 };
 
 /** Ordered graph of all evaluated ingress gates. */
-export type AccessGraph = {
+type AccessGraph = {
   gates: AccessGraphGate[];
 };
 
@@ -362,7 +354,7 @@ export type ChannelIngressState = {
 };
 
 /** Final runtime admission action for the inbound event. */
-export type ChannelIngressAdmission = "dispatch" | "observe" | "skip" | "drop" | "pairing-required";
+type ChannelIngressAdmission = "dispatch" | "observe" | "skip" | "drop" | "pairing-required";
 
 /** Final decision and graph for a resolved channel ingress event. */
 export type ChannelIngressDecision = {


### PR DESCRIPTION
## What Problem This Solves

Prevents the production dead-export ratchet from growing after the channel-ingress SDK facade cleanup exposed 13 internal message-access exports.

## Why This Change Was Made

Removes two unused core barrel aliases and makes eleven same-module implementation types private. The shipped `openclaw/plugin-sdk/channel-ingress-runtime` contract and its documented exports remain unchanged.

## User Impact

No user-visible behavior change. Internal channel ingress code now exposes only consumed surfaces.

## Evidence

- Production dead-export regeneration is byte-stable at 345 entries; zero additions.
- `src/channels/message-access/message-access.test.ts`: 8 passed.
- `src/plugin-sdk/channel-ingress-runtime.test.ts`: 2 passed.
- Scoped type-aware lint and core types passed.
- Fresh autoreview clean, confidence 0.88.
- Testbox run: https://github.com/openclaw/openclaw/actions/runs/29385167604
