### PR TITLE
refactor(core): declare outbound target grammar on the messaging adapter (batch 2)

### DIFF
--- a/extensions/discord/src/channel.ts
+++ b/extensions/discord/src/channel.ts
@@ -330,6 +330,8 @@ export const discordPlugin: ChannelPlugin<ResolvedDiscordAccount, DiscordProbe> 
       },
       messaging: {
         targetPrefixes: ["discord"],
+        directTargetStyle: "user-prefixed",
+        targetIdComparison: "lowercase",
         normalizeTarget: normalizeDiscordMessagingTarget,
         resolveInboundConversation: ({
           from,

--- a/extensions/googlechat/src/channel.ts
+++ b/extensions/googlechat/src/channel.ts
@@ -86,6 +86,7 @@ export const googlechatPlugin = createChatChannelPlugin({
     groups: googlechatGroupsAdapter,
     messaging: {
       targetPrefixes: ["googlechat", "google-chat", "gchat"],
+      targetIdComparison: "case-sensitive",
       normalizeTarget: normalizeGoogleChatTarget,
       resolveOutboundSessionRoute: (params) => resolveGoogleChatOutboundSessionRoute(params),
       targetResolver: {

--- a/extensions/matrix/src/channel.ts
+++ b/extensions/matrix/src/channel.ts
@@ -473,6 +473,7 @@ export const matrixPlugin: ChannelPlugin<ResolvedMatrixAccount, MatrixProbe> =
       messaging: {
         defaultMarkdownTableMode: "bullets",
         targetPrefixes: ["matrix"],
+        targetIdComparison: "case-sensitive",
         normalizeTarget: normalizeMatrixMessagingTarget,
         resolveInboundConversation: ({ to, conversationId, threadId }) =>
           resolveMatrixInboundConversation({ to, conversationId, threadId }),

--- a/extensions/mattermost/src/channel.ts
+++ b/extensions/mattermost/src/channel.ts
@@ -811,6 +811,8 @@ export const mattermostPlugin: ChannelPlugin<ResolvedMattermostAccount> = create
     }),
     messaging: {
       targetPrefixes: ["mattermost"],
+      directTargetStyle: "user-prefixed",
+      targetIdComparison: "case-sensitive",
       defaultMarkdownTableMode: "off",
       normalizeTarget: normalizeMattermostMessagingTarget,
       resolveDeliveryTarget: ({ conversationId, parentConversationId }) => {

--- a/extensions/msteams/src/channel.ts
+++ b/extensions/msteams/src/channel.ts
@@ -573,6 +573,7 @@ export const msteamsPlugin: ChannelPlugin<ResolvedMSTeamsAccount, ProbeMSTeamsRe
       setup: msteamsSetupAdapter,
       messaging: {
         targetPrefixes: ["msteams", "teams"],
+        directTargetStyle: "user-prefixed",
         normalizeTarget: normalizeMSTeamsMessagingTarget,
         resolveOutboundSessionRoute: (params) => resolveMSTeamsOutboundSessionRoute(params),
         targetResolver: {

--- a/extensions/slack/src/channel.ts
+++ b/extensions/slack/src/channel.ts
@@ -659,6 +659,8 @@ export const slackPlugin: ChannelPlugin<ResolvedSlackAccount, SlackProbe> = crea
     },
     messaging: {
       targetPrefixes: ["slack"],
+      directTargetStyle: "user-prefixed",
+      targetIdComparison: "lowercase",
       normalizeTarget: normalizeSlackMessagingTarget,
       // Session and delivery identities stay folded; Slack API boundaries restore ID casing.
       resolveDeliveryTarget: ({ conversationId, parentConversationId }) => {

--- a/extensions/telegram/src/channel.ts
+++ b/extensions/telegram/src/channel.ts
@@ -833,6 +833,7 @@ export const telegramPlugin = createChatChannelPlugin({
     messaging: {
       defaultMarkdownTableMode: "block",
       targetPrefixes: ["telegram", "tg"],
+      numericTopicShorthand: true,
       normalizeTarget: normalizeTelegramMessagingTarget,
       resolveInboundConversation: ({ to, conversationId, threadId }) =>
         resolveTelegramInboundConversation({ to, conversationId, threadId }),

--- a/src/agents/tools/message-tool.test.ts
+++ b/src/agents/tools/message-tool.test.ts
@@ -417,6 +417,24 @@ function createChannelPlugin(params: {
   };
 }
 
+function registerMessagingPlugin(id: string, messaging: NonNullable<ChannelPlugin["messaging"]>) {
+  setActivePluginRegistry(
+    createTestRegistry([
+      {
+        pluginId: id,
+        source: "test",
+        plugin: createChannelPlugin({
+          id,
+          label: id,
+          docsPath: `/channels/${id}`,
+          blurb: "Test channel",
+          messaging,
+        }),
+      },
+    ]),
+  );
+}
+
 async function executeSend(params: {
   action: Record<string, unknown>;
   toolOptions?: Partial<Parameters<typeof createMessageTool>[0]>;
@@ -1140,35 +1158,64 @@ describe("message tool secret scoping", () => {
     expect(input?.toolContext?.currentChannelId).toBeUndefined();
   });
 
-  it("preserves direct session keys as explicit user targets when ambient channel drifted to webchat", async () => {
-    mockSendResult({ channel: "discord", to: "user:123456789" });
+  it.each([
+    {
+      name: "declared user-prefixed",
+      channel: "discord",
+      declareUserPrefix: true,
+      sessionKey: "agent:main:discord:direct:123456789",
+      expectedTarget: "user:123456789",
+      secretField: "token",
+      secretId: "DISCORD_TOKEN",
+    },
+    {
+      name: "undeclared provider-native",
+      channel: "telegram",
+      declareUserPrefix: false,
+      sessionKey: "agent:main:telegram:direct:123456789",
+      expectedTarget: "123456789",
+      secretField: "botToken",
+      secretId: "TELEGRAM_BOT_TOKEN",
+    },
+  ])(
+    "uses $name DM target metadata when ambient channel drifted to webchat",
+    async ({ channel, declareUserPrefix, sessionKey, expectedTarget, secretField, secretId }) => {
+      registerMessagingPlugin(
+        channel,
+        declareUserPrefix ? { directTargetStyle: "user-prefixed" } : {},
+      );
+      mockSendResult({ channel, to: expectedTarget });
 
-    const input = await executeSend({
-      action: { message: "hi" },
-      toolOptions: {
-        config: {
-          channels: {
-            discord: {
-              token: { source: "env", provider: "default", id: "DISCORD_TOKEN" },
+      const input = await executeSend({
+        action: { message: "hi" },
+        toolOptions: {
+          config: {
+            channels: {
+              [channel]: {
+                [secretField]: { source: "env", provider: "default", id: secretId },
+              },
             },
-          },
-        } as never,
-        sourceReplyDeliveryMode: "message_tool_only",
-        currentChannelProvider: "webchat",
-        agentSessionKey: "agent:main:discord:direct:123456789",
-      },
-    });
+          } as never,
+          sourceReplyDeliveryMode: "message_tool_only",
+          currentChannelProvider: "webchat",
+          agentSessionKey: sessionKey,
+        },
+      });
 
-    expect(input?.sourceReplyDeliveryMode).toBe("message_tool_only");
-    expect(input?.toolContext?.currentChannelProvider).toBe("discord");
-    expect(input?.toolContext?.currentChannelId).toBe("user:123456789");
-    expect(input?.params).toEqual({ action: "send", message: "hi" });
+      expect(input?.sourceReplyDeliveryMode).toBe("message_tool_only");
+      expect(input?.toolContext?.currentChannelProvider).toBe(channel);
+      expect(input?.toolContext?.currentChannelId).toBe(expectedTarget);
+      expect(input?.params).toEqual({ action: "send", message: "hi" });
 
-    const secretResolveCall = latestSecretResolveCall();
-    expect(Array.from(secretResolveCall.targetIds ?? [])).toEqual(["channels.discord.token"]);
-  });
+      const secretResolveCall = latestSecretResolveCall();
+      expect(Array.from(secretResolveCall.targetIds ?? [])).toEqual([
+        `channels.${channel}.${secretField}`,
+      ]);
+    },
+  );
 
   it("preserves MS Teams DM session keys as explicit user targets when ambient channel drifted to webchat", async () => {
+    registerMessagingPlugin("msteams", { directTargetStyle: "user-prefixed" });
     mockSendResult({ channel: "msteams", to: "user:user-1" });
 
     const input = await executeSend({
@@ -1197,35 +1244,8 @@ describe("message tool secret scoping", () => {
     expect(Array.from(secretResolveCall.targetIds ?? [])).toEqual(["channels.msteams.appPassword"]);
   });
 
-  it("keeps provider-native direct session targets when ambient channel drifted to webchat", async () => {
-    mockSendResult({ channel: "telegram", to: "123456789" });
-
-    const input = await executeSend({
-      action: { message: "hi" },
-      toolOptions: {
-        config: {
-          channels: {
-            telegram: {
-              botToken: { source: "env", provider: "default", id: "TELEGRAM_BOT_TOKEN" },
-            },
-          },
-        } as never,
-        sourceReplyDeliveryMode: "message_tool_only",
-        currentChannelProvider: "webchat",
-        agentSessionKey: "agent:main:telegram:direct:123456789",
-      },
-    });
-
-    expect(input?.sourceReplyDeliveryMode).toBe("message_tool_only");
-    expect(input?.toolContext?.currentChannelProvider).toBe("telegram");
-    expect(input?.toolContext?.currentChannelId).toBe("123456789");
-    expect(input?.params).toEqual({ action: "send", message: "hi" });
-
-    const secretResolveCall = latestSecretResolveCall();
-    expect(Array.from(secretResolveCall.targetIds ?? [])).toEqual(["channels.telegram.botToken"]);
-  });
-
   it("uses account-scoped session keys for secret and account fallback when ambient channel drifted to webchat", async () => {
+    registerMessagingPlugin("discord", { directTargetStyle: "user-prefixed" });
     mockSendResult({ channel: "discord", to: "user:123456789" });
 
     const input = await executeSend({
@@ -1260,6 +1280,7 @@ describe("message tool secret scoping", () => {
   });
 
   it("keeps account-scoped direct keys when account id matches a peer marker", async () => {
+    registerMessagingPlugin("discord", { directTargetStyle: "user-prefixed" });
     mockSendResult({ channel: "discord", to: "user:123456789" });
 
     const input = await executeSend({
@@ -1296,6 +1317,7 @@ describe("message tool secret scoping", () => {
   });
 
   it("handles legacy dm markers when ambient channel drifted to webchat", async () => {
+    registerMessagingPlugin("slack", { directTargetStyle: "user-prefixed" });
     mockSendResult({ channel: "slack", to: "user:u123" });
 
     const input = await executeSend({

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -1075,11 +1075,9 @@ type InferredSessionDelivery = {
   to: string;
 };
 
-const USER_PREFIXED_DIRECT_TARGET_CHANNELS = new Set(["discord", "mattermost", "msteams", "slack"]);
-
 function formatSessionDeliveryTarget(channel: string, peerKind: string, to: string): string {
   return (peerKind === "direct" || peerKind === "dm") &&
-    USER_PREFIXED_DIRECT_TARGET_CHANNELS.has(channel)
+    getChannelPlugin(channel)?.messaging?.directTargetStyle === "user-prefixed"
     ? `user:${to}`
     : to;
 }

--- a/src/auto-reply/reply/group-id.test.ts
+++ b/src/auto-reply/reply/group-id.test.ts
@@ -55,28 +55,70 @@ describe("extractSimpleExplicitGroupId", () => {
 });
 
 describe("extractExplicitGroupId", () => {
-  it("strips Telegram numeric topic shorthand after target normalization", () => {
-    setActivePluginRegistry(
-      createTestRegistry([
-        {
-          pluginId: "telegram",
-          source: "test",
-          plugin: {
-            ...createChannelTestPluginBase({
-              id: "telegram",
-              capabilities: { chatTypes: ["group"] },
-            }),
-            messaging: {
-              normalizeTarget: () => "telegram:-100200300:77",
-              inferTargetChatType: () => "group",
+  it.each([
+    {
+      name: "declared inferred shorthand",
+      channel: "telegram",
+      declaresNumericShorthand: true,
+      path: "inferred" as const,
+      expected: "-100200300",
+    },
+    {
+      name: "undeclared inferred shorthand",
+      channel: "plainchat",
+      declaresNumericShorthand: false,
+      path: "inferred" as const,
+      expected: "-100200300:77",
+    },
+    {
+      name: "declared parser shorthand",
+      channel: "telegram",
+      declaresNumericShorthand: true,
+      path: "parser" as const,
+      expected: "-100200300",
+    },
+    {
+      name: "undeclared parser shorthand",
+      channel: "plainchat",
+      declaresNumericShorthand: false,
+      path: "parser" as const,
+      expected: "-100200300:77",
+    },
+  ])(
+    "uses $name metadata after target normalization",
+    ({ channel, declaresNumericShorthand, path, expected }) => {
+      setActivePluginRegistry(
+        createTestRegistry([
+          {
+            pluginId: channel,
+            source: "test",
+            plugin: {
+              ...createChannelTestPluginBase({
+                id: channel,
+                capabilities: { chatTypes: ["group"] },
+              }),
+              messaging: {
+                ...(declaresNumericShorthand ? { numericTopicShorthand: true as const } : {}),
+                ...(path === "inferred"
+                  ? {
+                      normalizeTarget: () => `${channel}:-100200300:77`,
+                      inferTargetChatType: () => "group" as const,
+                    }
+                  : {
+                      parseExplicitTarget: () => ({
+                        to: "group:-100200300:77",
+                        chatType: "group" as const,
+                      }),
+                    }),
+              },
             },
           },
-        },
-      ]),
-    );
+        ]),
+      );
 
-    expect(extractExplicitGroupId("telegram:-100200300:77")).toBe("-100200300");
-  });
+      expect(extractExplicitGroupId(`${channel}:-100200300:77`)).toBe(expected);
+    },
+  );
 
   it("keeps legacy parser-only group target extraction quarantined", () => {
     setActivePluginRegistry(

--- a/src/auto-reply/reply/group-id.ts
+++ b/src/auto-reply/reply/group-id.ts
@@ -36,7 +36,7 @@ function extractInferredGroupTargetId(params: {
         "room",
         "thread",
       ]),
-      { allowNumericShorthand: params.channelId === "telegram" },
+      { allowNumericShorthand: params.messaging?.numericTopicShorthand === true },
     );
     if (target) {
       return target;
@@ -62,7 +62,7 @@ function extractLegacyParsedGroupTargetId(params: {
       "room",
       "thread",
     ]),
-    { allowNumericShorthand: params.channelId === "telegram" },
+    { allowNumericShorthand: params.messaging?.numericTopicShorthand === true },
   );
   return target || undefined;
 }

--- a/src/channels/conversation-resolution.test.ts
+++ b/src/channels/conversation-resolution.test.ts
@@ -230,27 +230,60 @@ describe("conversation resolution", () => {
     });
   });
 
-  it("strips Telegram numeric topic shorthand in fallback resolution", () => {
-    registerChannelPlugin({
-      ...createChannelTestPluginBase({ id: "telegram", label: "Telegram" }),
-      messaging: {
-        normalizeTarget: () => "telegram:-1001234567890:77",
-      },
-    });
-
-    expect(
-      resolveCommandConversationResolution({
-        cfg: testConfig,
-        channel: "telegram",
-        accountId: "default",
-        originatingTo: "-1001234567890:77",
-      })?.canonical,
-    ).toEqual({
+  it.each([
+    {
+      name: "declared raw shorthand",
       channel: "telegram",
-      accountId: "default",
-      conversationId: "-1001234567890",
-    });
-  });
+      declaresNumericShorthand: true,
+      originatingTo: "-1001234567890:77",
+      expectedConversationId: "-1001234567890",
+    },
+    {
+      name: "undeclared raw shorthand",
+      channel: "plainchat",
+      declaresNumericShorthand: false,
+      originatingTo: "-1001234567890:77",
+      expectedConversationId: "-1001234567890:77",
+    },
+    {
+      name: "declared normalized shorthand",
+      channel: "telegram",
+      declaresNumericShorthand: true,
+      originatingTo: "topic-alias",
+      expectedConversationId: "-1001234567890",
+    },
+    {
+      name: "undeclared normalized shorthand",
+      channel: "plainchat",
+      declaresNumericShorthand: false,
+      originatingTo: "topic-alias",
+      expectedConversationId: "-1001234567890:77",
+    },
+  ])(
+    "uses $name metadata in fallback resolution",
+    ({ channel, declaresNumericShorthand, originatingTo, expectedConversationId }) => {
+      registerChannelPlugin({
+        ...createChannelTestPluginBase({ id: channel, label: channel }),
+        messaging: {
+          ...(declaresNumericShorthand ? { numericTopicShorthand: true as const } : {}),
+          normalizeTarget: () => `${channel}:-1001234567890:77`,
+        },
+      });
+
+      expect(
+        resolveCommandConversationResolution({
+          cfg: testConfig,
+          channel,
+          accountId: "default",
+          originatingTo,
+        })?.canonical,
+      ).toEqual({
+        channel,
+        accountId: "default",
+        conversationId: expectedConversationId,
+      });
+    },
+  );
 
   it("keeps parser-only fallback conversation targets during the migration window", () => {
     registerChannelPlugin({

--- a/src/channels/conversation-resolution.ts
+++ b/src/channels/conversation-resolution.ts
@@ -216,6 +216,7 @@ function resolveChannelTargetId(params: {
   if (!target) {
     return undefined;
   }
+  const messaging = resolveRuntimeChannelPlugin(params.channel)?.messaging;
 
   const lower = normalizeLowercaseStringOrEmpty(target);
   const channelPrefix = `${params.channel}:`;
@@ -234,7 +235,7 @@ function resolveChannelTargetId(params: {
   if (!prefixedChannel || prefixedChannel !== params.channel) {
     const explicitConversationId = resolveFallbackConversationTargetId({
       rawTarget: target,
-      allowNumericTopicShorthand: params.channel === "telegram",
+      allowNumericTopicShorthand: messaging?.numericTopicShorthand === true,
       preserveExplicitTopicSuffix: params.preserveExplicitTopicSuffix,
     });
     if (explicitConversationId) {
@@ -242,14 +243,12 @@ function resolveChannelTargetId(params: {
     }
   }
 
-  const normalizedTarget = normalizeOptionalString(
-    resolveRuntimeChannelPlugin(params.channel)?.messaging?.normalizeTarget?.(target),
-  );
+  const normalizedTarget = normalizeOptionalString(messaging?.normalizeTarget?.(target));
   if (normalizedTarget) {
     const withoutProvider = stripTargetProviderPrefix(normalizedTarget, params.channel);
     const conversationId = resolveFallbackConversationTargetId({
       rawTarget: withoutProvider,
-      allowNumericTopicShorthand: params.channel === "telegram",
+      allowNumericTopicShorthand: messaging?.numericTopicShorthand === true,
       preserveExplicitTopicSuffix: params.preserveExplicitTopicSuffix,
     });
     return conversationId || withoutProvider || normalizedTarget;

--- a/src/channels/plugins/types.core.ts
+++ b/src/channels/plugins/types.core.ts
@@ -503,6 +503,12 @@ export type ChannelMessagingAdapter = {
    * targets before plugin-specific normalization.
    */
   targetPrefixes?: readonly string[];
+  /** DM targets rebuilt from session keys require an explicit `user:` kind prefix. */
+  directTargetStyle?: "user-prefixed";
+  /** Equality rule for ids carried by prefixed outbound targets. */
+  targetIdComparison?: "case-sensitive" | "lowercase";
+  /** Bare numeric conversation/topic shorthand is valid for this channel. */
+  numericTopicShorthand?: true;
   normalizeTarget?: (raw: string) => string | undefined;
   defaultMarkdownTableMode?: MarkdownTableMode;
   normalizeExplicitSessionKey?: (params: {

--- a/src/infra/outbound/source-delivery-plan.test.ts
+++ b/src/infra/outbound/source-delivery-plan.test.ts
@@ -1,6 +1,11 @@
 // Covers source-delivery target matching, message-tool ownership plans, and
 // fallback satisfaction outcomes.
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { setActivePluginRegistry } from "../../plugins/runtime.js";
+import {
+  createChannelTestPluginBase,
+  createTestRegistry,
+} from "../../test-utils/channel-plugins.js";
 
 vi.mock("./target-normalization.js", () => ({
   normalizeTargetForProvider: (_provider: string, raw?: string) => raw?.trim(),
@@ -10,6 +15,10 @@ import {
   resolveSourceDeliveryOutcome,
   sourceDeliveryTargetsMatch,
 } from "./source-delivery-plan.js";
+
+afterEach(() => {
+  setActivePluginRegistry(createTestRegistry());
+});
 
 describe("source delivery plan", () => {
   it("projects message-tool-owned delivery to existing source reply and message tool fields", () => {
@@ -221,32 +230,57 @@ describe("source delivery plan", () => {
     ).toBe(false);
   });
 
-  it("matches same-kind delivery target prefixes without normalizing provider-owned IDs", () => {
-    expect(
-      sourceDeliveryTargetsMatch(
-        { provider: "slack", to: "Channel: C1" },
-        { channel: "slack", to: "channel:C1" },
-      ),
-    ).toBe(true);
-    expect(
-      sourceDeliveryTargetsMatch(
-        { provider: "slack", to: "channel:C2" },
-        { channel: "slack", to: "channel:C1" },
-      ),
-    ).toBe(false);
-    expect(
-      sourceDeliveryTargetsMatch(
-        { provider: "slack", to: "channel:c1" },
-        { channel: "slack", to: "channel:C1" },
-      ),
-    ).toBe(true);
-    expect(
-      sourceDeliveryTargetsMatch(
-        { provider: "mattermost", to: "channel: abc" },
-        { channel: "mattermost", to: "channel:ABC" },
-      ),
-    ).toBe(false);
-  });
+  it.each([
+    {
+      name: "case-sensitive metadata",
+      channel: "exact-chat",
+      comparison: "case-sensitive" as const,
+      targetTo: "channel:abc",
+      deliveryTo: "channel:ABC",
+      expected: false,
+    },
+    {
+      name: "lowercase metadata",
+      channel: "folded-chat",
+      comparison: "lowercase" as const,
+      targetTo: "Channel: c1",
+      deliveryTo: "channel:C1",
+      expected: true,
+    },
+    {
+      name: "undeclared generic normalization",
+      channel: "generic-chat",
+      comparison: undefined,
+      targetTo: "channel:abc",
+      deliveryTo: "channel:ABC",
+      expected: false,
+    },
+  ])(
+    "uses $name for prefixed target ids",
+    ({ channel, comparison, targetTo, deliveryTo, expected }) => {
+      setActivePluginRegistry(
+        createTestRegistry([
+          {
+            pluginId: channel,
+            source: "test",
+            plugin: {
+              ...createChannelTestPluginBase({ id: channel, label: channel }),
+              messaging: {
+                ...(comparison ? { targetIdComparison: comparison } : {}),
+              },
+            },
+          },
+        ]),
+      );
+
+      expect(
+        sourceDeliveryTargetsMatch(
+          { provider: channel, to: targetTo },
+          { channel, to: deliveryTo },
+        ),
+      ).toBe(expected);
+    },
+  );
 
   it("matches threaded delivery only with explicit or supported implicit thread evidence", () => {
     expect(

--- a/src/infra/outbound/source-delivery-plan.test.ts
+++ b/src/infra/outbound/source-delivery-plan.test.ts
@@ -265,9 +265,7 @@ describe("source delivery plan", () => {
             source: "test",
             plugin: {
               ...createChannelTestPluginBase({ id: channel, label: channel }),
-              messaging: {
-                ...(comparison ? { targetIdComparison: comparison } : {}),
-              },
+              messaging: comparison ? { targetIdComparison: comparison } : {},
             },
           },
         ]),

--- a/src/infra/outbound/source-delivery-plan.ts
+++ b/src/infra/outbound/source-delivery-plan.ts
@@ -1,6 +1,7 @@
 // Source-delivery plans decide whether final output is visible through the
 // message tool, direct fallback delivery, both, or neither.
 import type { SourceReplyDeliveryMode } from "../../auto-reply/get-reply-options.types.js";
+import { getChannelPlugin } from "../../channels/plugins/index.js";
 import { stringifyRouteThreadId } from "../../plugin-sdk/channel-route.js";
 import { normalizeTargetForProvider } from "./target-normalization.js";
 
@@ -91,9 +92,6 @@ function normalizeDeliveryTarget(channel: string, to: string): string {
   return normalizeTargetForProvider(channel, toTrimmed) ?? toTrimmed;
 }
 
-const caseSensitivePrefixedTargetProviders = new Set(["googlechat", "mattermost", "matrix"]);
-const lowercaseNormalizedPrefixedTargetProviders = new Set(["discord", "slack"]);
-
 function deliveryTargetsMatch(channel: string, targetTo: string, deliveryTo: string): boolean {
   const targetToTrimmed = targetTo.trim();
   const deliveryToTrimmed = deliveryTo.trim();
@@ -109,14 +107,14 @@ function deliveryTargetsMatch(channel: string, targetTo: string, deliveryTo: str
     targetKind === deliveryKind &&
     ["channel", "conversation", "group", "user"].includes(targetKind)
   ) {
-    // Some provider-owned ids are case-sensitive while Slack/Discord ids are
-    // compared case-insensitively; decide that before generic target normalization.
+    // Provider-owned ID comparison can bypass generic target normalization.
     const targetId = targetPrefixed?.[2]?.trim();
     const deliveryId = deliveryPrefixed?.[2]?.trim();
-    if (caseSensitivePrefixedTargetProviders.has(channel)) {
+    const comparison = getChannelPlugin(channel)?.messaging?.targetIdComparison;
+    if (comparison === "case-sensitive") {
       return targetId === deliveryId;
     }
-    if (lowercaseNormalizedPrefixedTargetProviders.has(channel)) {
+    if (comparison === "lowercase") {
       return targetId?.toLowerCase() === deliveryId?.toLowerCase();
     }
   }


### PR DESCRIPTION
## What Problem This Solves

Batch 2 of the core→channel-literal purge: core hardcoded three families of outbound target grammar per channel — which channels need `user:`-prefixed DM targets, how prefixed target ids compare (case-sensitive vs lowercase), and telegram's bare-numeric topic shorthand. These become declarative fields on the channel `messaging` adapter, read generically by core.

## Why This Change Was Made

New fields `directTargetStyle`, `targetIdComparison`, and `numericTopicShorthand` on the messaging adapter (type fields only — SDK export counts unchanged, verified). Core swaps: `USER_PREFIXED_DIRECT_TARGET_CHANNELS` in `message-tool.ts`, both comparison sets in `source-delivery-plan.ts` (undeclared channels fall through to generic target normalization exactly as before), and the four `=== "telegram"` shorthand branches in `conversation-resolution.ts`/`group-id.ts`. Declarers: discord/mattermost/msteams/slack (user-prefixed), googlechat/mattermost/matrix (case-sensitive), discord/slack (lowercase), telegram (numeric shorthand). Core runtime LOC net zero; the literal sets are gone.

## User Impact

None — table-driven pins prove declared channels behave as the old sets did and undeclared channels keep today's generic handling.

## Evidence

- Blacksmith Testbox: full `tsgo` typecheck green; message-tool, source-delivery-plan (+ outbound suite), conversation-resolution, group-id tests green; all `check:changed` lanes green except `lint core`, which fails on two files this PR does not touch (`src/agents/embedded-agent-runner/run/attempt-dispatch-preparation.ts`, `attempt-recovery.ts`) — landed an hour ago by #107900 in the agents stream.
- Autoreview (codex gpt-5.6-sol, xhigh): clean, "patch is correct (0.95)" — confirms every previously hardcoded case has a corresponding declaration and undeclared plugins retain generic handling.
