### PR TITLE
improve: speed up hooks process lifecycle tests

### DIFF
--- a/src/cli/hooks-cli.process.test.ts
+++ b/src/cli/hooks-cli.process.test.ts
@@ -187,50 +187,36 @@ async function runHooksRelay(params: { event: "post_tool_use" | "pre_tool_use"; 
 }
 
 describe("hooks CLI process lifecycle", () => {
-  it("exits after JSON output when plugin registration leaves a ref'd handle", async () => {
+  it("exits after one-shot outputs when plugins leave ref'd handles", async () => {
     const fixture = await createLingeringPluginFixture();
 
-    const result = await runHooksCli({
-      args: ["hooks", "list", "--json"],
-      env: {
-        LINGER_MARKER: fixture.markerPath,
-        OPENCLAW_CONFIG_PATH: fixture.configPath,
-        OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
-        OPENCLAW_STATE_DIR: fixture.stateDir,
-      },
-      timeoutMessage: "hooks list did not exit after emitting output",
-    });
+    // Both command families need real process coverage. Run their expensive CLI
+    // bootstraps together; unit suites cover the individual relay result shapes.
+    const [listResult, relayResult] = await Promise.all([
+      runHooksCli({
+        args: ["hooks", "list", "--json"],
+        env: {
+          LINGER_MARKER: fixture.markerPath,
+          OPENCLAW_CONFIG_PATH: fixture.configPath,
+          OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+          OPENCLAW_STATE_DIR: fixture.stateDir,
+        },
+        timeoutMessage: "hooks list did not exit after emitting output",
+      }),
+      runHooksRelay({ event: "pre_tool_use", stdin: "{}" }),
+    ]);
 
-    expect(result, result.stderr).toMatchObject({ code: 0, signal: null });
-    expect(result.stderr).not.toContain("Error:");
-    expect(JSON.parse(result.stdout)).toMatchObject({ hooks: expect.any(Array) });
+    expect(listResult, listResult.stderr).toMatchObject({ code: 0, signal: null });
+    expect(listResult.stderr).not.toContain("Error:");
+    expect(JSON.parse(listResult.stdout)).toMatchObject({ hooks: expect.any(Array) });
     await expect(fs.readFile(fixture.markerPath, "utf8")).resolves.toBe("registered\n");
-  }, 20_000);
-
-  it("exits successfully after an observational relay result with a ref'd handle", async () => {
-    const result = await runHooksRelay({ event: "post_tool_use", stdin: "{}" });
-
-    expect(result, result.stderr).toMatchObject({ code: 0, signal: null, stdout: "" });
-    expect(result.stderr).toMatch(/native hook relay (timed out|unavailable)/);
-  }, 20_000);
-
-  it("flushes fail-closed PreToolUse JSON before exiting with a ref'd handle", async () => {
-    const result = await runHooksRelay({ event: "pre_tool_use", stdin: "{}" });
-
-    expect(result, result.stderr).toMatchObject({ code: 0, signal: null });
-    expect(JSON.parse(result.stdout)).toMatchObject({
+    expect(relayResult, relayResult.stderr).toMatchObject({ code: 0, signal: null });
+    expect(JSON.parse(relayResult.stdout)).toMatchObject({
       hookSpecificOutput: {
         hookEventName: "PreToolUse",
         permissionDecision: "deny",
         permissionDecisionReason: expect.any(String),
       },
     });
-  }, 20_000);
-
-  it("preserves a malformed-input exit code with a ref'd handle", async () => {
-    const result = await runHooksRelay({ event: "post_tool_use", stdin: "{nope" });
-
-    expect(result).toMatchObject({ code: 1, signal: null, stdout: "" });
-    expect(result.stderr).toContain("failed to read native hook input");
   }, 20_000);
 });


### PR DESCRIPTION
## What Problem This Solves

The hooks process-lifecycle suite started four complete CLI subprocesses sequentially. A fresh main CI run spent 20.77 seconds in this four-test file, and a focused remote baseline spent 10.27 seconds.

## Why This Change Was Made

Keep real subprocess coverage for both distinct one-shot command families: plugin-backed hooks listing and native relay output flushing. Start those two expensive CLI bootstraps together, while the existing native relay and one-shot exit unit suites continue covering the individual result, malformed-input, and exit-code shapes.

AI-assisted change; behavior and coverage boundaries reviewed.

## User Impact

No user-visible behavior change. Contributors and CI get faster hooks lifecycle validation with the same process-exit invariants.

## Evidence

- Before, focused Testbox baseline: 4/4 tests passed; hooks process file 10.27 seconds.
- After, same Testbox: hooks process file 2.47 seconds; 25/25 related tests passed across the process, relay, and one-shot exit suites.
- Current head 3ed6222fd30: 25/25 related tests passed on Testbox tbx_01kxhw0fsjngp6xd9jt504ste9 (run 29385843907).
- Remote check:changed passed after the preceding rebase; the final rebase only incorporated unrelated main changes.
- Fresh autoreview: clean, 0.91 confidence.
