### PR TITLE
fix(agents): keep CLI runner diagnostic tails UTF-8 safe

### DIFF
--- a/src/agents/cli-runner/execute-output-buffer.test.ts
+++ b/src/agents/cli-runner/execute-output-buffer.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { appendCliOutputTail } from "./execute-output-buffer.js";
+
+const TAIL_BYTES = 64 * 1024;
+
+describe("appendCliOutputTail", () => {
+  it("keeps ascii tails bounded to the last window", () => {
+    const tail = appendCliOutputTail(Buffer.alloc(0), "a".repeat(TAIL_BYTES + 5000));
+
+    expect(tail.byteLength).toBe(TAIL_BYTES);
+    expect(tail.toString("utf8")).toBe("a".repeat(TAIL_BYTES));
+  });
+
+  it("returns the existing tail when the chunk is empty", () => {
+    const tail = appendCliOutputTail(Buffer.alloc(0), "abc");
+
+    expect(appendCliOutputTail(tail, "")).toBe(tail);
+  });
+
+  it("does not split multibyte characters when one chunk overflows the window", () => {
+    // 21846 * 3 = 65538 bytes: the byte-window cut lands inside the first character.
+    const chunk = "汉".repeat(21846);
+
+    const tail = appendCliOutputTail(Buffer.alloc(0), chunk);
+    const decoded = tail.toString("utf8");
+
+    expect(decoded).not.toContain("�");
+    expect(decoded).toBe("汉".repeat(21845));
+    expect(tail.byteLength).toBeLessThanOrEqual(TAIL_BYTES);
+  });
+
+  it("does not split multibyte characters when an appended chunk overflows the window", () => {
+    // 21845 * 3 = 65535 bytes of CJK, then 2 ascii bytes push the cut mid-character.
+    const tail = appendCliOutputTail(Buffer.alloc(0), "汉".repeat(21845));
+
+    const next = appendCliOutputTail(tail, "ab");
+    const decoded = next.toString("utf8");
+
+    expect(decoded).not.toContain("�");
+    expect(decoded).toBe(`${"汉".repeat(21844)}ab`);
+    expect(next.byteLength).toBeLessThanOrEqual(TAIL_BYTES);
+  });
+});

--- a/src/agents/cli-runner/execute-output-buffer.ts
+++ b/src/agents/cli-runner/execute-output-buffer.ts
@@ -1,16 +1,26 @@
 const CLI_RUNNER_OUTPUT_TAIL_BYTES = 64 * 1024;
 
+function truncateToUtf8TailWindow(buffer: Buffer): Buffer {
+  // Skip UTF-8 continuation bytes so the byte-window cut never splits a
+  // multibyte character into U+FFFD replacement noise in diagnostics.
+  let start = buffer.byteLength - CLI_RUNNER_OUTPUT_TAIL_BYTES;
+  while (start < buffer.byteLength && (buffer[start]! & 0b1100_0000) === 0b1000_0000) {
+    start += 1;
+  }
+  return Buffer.from(buffer.subarray(start));
+}
+
 export function appendCliOutputTail(tail: Buffer, chunk: string): Buffer {
   if (!chunk) {
     return tail;
   }
   const chunkBuffer = Buffer.from(chunk);
   if (chunkBuffer.byteLength >= CLI_RUNNER_OUTPUT_TAIL_BYTES) {
-    return Buffer.from(chunkBuffer.subarray(chunkBuffer.byteLength - CLI_RUNNER_OUTPUT_TAIL_BYTES));
+    return truncateToUtf8TailWindow(chunkBuffer);
   }
   const next = Buffer.concat([tail, chunkBuffer], tail.byteLength + chunkBuffer.byteLength);
   if (next.byteLength <= CLI_RUNNER_OUTPUT_TAIL_BYTES) {
     return next;
   }
-  return Buffer.from(next.subarray(next.byteLength - CLI_RUNNER_OUTPUT_TAIL_BYTES));
+  return truncateToUtf8TailWindow(next);
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where CLI runner failure diagnostics (`stdoutDiagnostic`/`stderrDiagnostic` in `src/agents/cli-runner/execute.ts`) start with U+FFFD replacement characters when a CLI backend emits more than 64 KiB of output containing multibyte text (CJK, emoji). The tail-window cut in `appendCliOutputTail` slices the buffer at a raw byte offset, so it can land inside a multibyte UTF-8 character and the later `toString("utf8")` decodes the orphaned continuation bytes as `��`.

## Why This Change Was Made

The 64 KiB tail truncation now skips UTF-8 continuation bytes before slicing, so the retained window always starts on a character boundary. This is the same idiom the repo already uses for bounded subprocess diagnostics in `extensions/browser/src/browser/bounded-utf8-tail.ts`, and follows the direction of the merged multibyte diagnostics fixes #104230 (discord ffmpeg stderr) and #105475 (matrix bootstrap output).

## User Impact

CLI backend failures with large non-ASCII output now surface clean diagnostic tails to the agent and logs instead of leading `��` garbage; the 64 KiB bound is unchanged.

## Evidence

- Regression test (added in this PR, fails on main): `node scripts/run-vitest.mjs run src/agents/cli-runner/execute-output-buffer.test.ts` — main: 2 failed (`expected '��汉汉…' not to contain '�'`); this branch: 4 passed.
- Live proof: real `getProcessSupervisor().spawn` child process (same wiring as `execute.ts` `consumeStderr` with `captureOutput: false`), child writes a 65,535-byte CJK stderr burst plus 2 ASCII bytes and exits 1, decoded exactly as `execute.ts` decodes `stderrDiagnostic`.

Before (main @ 91a18c05):

```text
$ node --import tsx live-proof.mjs
child exit         : code=1 reason=exit
stderr chunks      : 2
tail bytes         : 65536 (cap 65536)
diagnostic head    : "��汉汉汉汉" [U+FFFD U+FFFD U+6C49 U+6C49 U+6C49 U+6C49]
contains U+FFFD    : true
diagnostic tail end: "汉汉ab"
```

After (this branch, same script and input):

```text
$ node --import tsx live-proof.mjs
child exit         : code=1 reason=exit
stderr chunks      : 2
tail bytes         : 65534 (cap 65536)
diagnostic head    : "汉汉汉汉汉汉" [U+6C49 U+6C49 U+6C49 U+6C49 U+6C49 U+6C49]
contains U+FFFD    : false
diagnostic tail end: "汉汉ab"
```

<details>
<summary>live-proof.mjs (save in repo root, run with `node --import tsx live-proof.mjs`)</summary>

```js
// Drives the REAL process-supervisor spawn boundary and the REAL production
// appendCliOutputTail import, exactly as src/agents/cli-runner/execute.ts
// wires consumeStderr and decodes stderrDiagnostic. The external CLI backend
// is replaced at the process boundary by a local child that emits a >64KiB
// multibyte stderr tail and exits non-zero.
import path from "node:path";
import { pathToFileURL } from "node:url";

const repoRoot = process.cwd();
const load = (relative) => import(pathToFileURL(path.resolve(repoRoot, relative)).href);

const { appendCliOutputTail } = await load("src/agents/cli-runner/execute-output-buffer.ts");
const { getProcessSupervisor } = await load("src/process/supervisor/index.ts");

// Child: one 65535-byte CJK write, a flush gap, then 2 ascii bytes and exit 1.
// The second append overflows the 64KiB tail window by 1 byte, so the window
// cut lands inside the first CJK character.
const childScript = `
  const big = "\\u6c49".repeat(21845); // 65535 bytes of UTF-8
  process.stderr.write(big, () => {
    setTimeout(() => {
      process.stderr.write("ab", () => process.exit(1));
    }, 150);
  });
`;

const supervisor = getProcessSupervisor();
let stderrTail = Buffer.alloc(0);
let chunkCount = 0;
const consumeStderr = (chunk) => {
  chunkCount += 1;
  stderrTail = appendCliOutputTail(stderrTail, chunk); // same as execute.ts consumeStderr
};

const managedRun = await supervisor.spawn({
  sessionId: "live-proof-cli-runner-utf8-tail",
  backendId: "live-proof-backend",
  mode: "child",
  argv: [process.execPath, "-e", childScript],
  captureOutput: false, // same as execute.ts
  onStderr: consumeStderr,
});
const exit = await managedRun.wait();

const stderrDiagnostic = stderrTail.toString("utf8").trim(); // same as execute.ts
const headCodePoints = [...stderrDiagnostic.slice(0, 6)]
  .map((ch) => `U+${ch.codePointAt(0).toString(16).toUpperCase().padStart(4, "0")}`)
  .join(" ");

console.log(`child exit         : code=${exit.exitCode ?? exit.code ?? "?"} reason=${exit.reason ?? "?"}`);
console.log(`stderr chunks      : ${chunkCount}`);
console.log(`tail bytes         : ${stderrTail.byteLength} (cap 65536)`);
console.log(`diagnostic head    : ${JSON.stringify(stderrDiagnostic.slice(0, 6))} [${headCodePoints}]`);
console.log(`contains U+FFFD    : ${stderrDiagnostic.includes("�")}`);
console.log(`diagnostic tail end: ${JSON.stringify(stderrDiagnostic.slice(-4))}`);
process.exit(0);
```

</details>

AI-assisted: built with Codex
