### PR TITLE
fix(update): reject npm redacted global root paths

### DIFF
--- a/src/infra/package-manager-output.ts
+++ b/src/infra/package-manager-output.ts
@@ -1,0 +1,8 @@
+export function parseGlobalRootOutput(manager: "npm" | "pnpm", stdout: string): string | null {
+  const root = stdout.trim();
+  if (!root || root.includes("\n") || root.includes("\r")) {
+    return null;
+  }
+  // npm >= 11 redacts UUID-like path segments to literal "***".
+  return manager === "npm" && root.includes("***") ? null : root;
+}

--- a/src/infra/package-update-steps.test.ts
+++ b/src/infra/package-update-steps.test.ts
@@ -13,6 +13,7 @@ import {
   UPDATE_POST_INSTALL_DOCTOR_ADVISORY_EXIT_CODE,
 } from "./update-doctor-result.js";
 import {
+  resolveGlobalInstallTarget,
   resolveNpmGlobalPrefixLayoutFromPrefix,
   type CommandRunner,
   type ResolvedGlobalInstallTarget,
@@ -156,6 +157,60 @@ describe("markPackagePostInstallDoctorAdvisory", () => {
 });
 
 describe("runGlobalPackageUpdateSteps", () => {
+  it("keeps redacted npm roots out of staged paths and install arguments", async () => {
+    await withTempDir({ prefix: "openclaw-package-update-redacted-root-" }, async (base) => {
+      const redactedRoot = path.join(
+        base,
+        "ci-agent",
+        "***",
+        "workspace",
+        "sbx-***",
+        "nvm",
+        "versions",
+        "node",
+        "v24.14.0",
+        "lib",
+        "node_modules",
+      );
+      const runCommand: CommandRunner = async (argv) => {
+        if (argv.join(" ") === "npm root -g") {
+          return { stdout: `${redactedRoot}\n`, stderr: "", code: 0 };
+        }
+        throw new Error(`unexpected command: ${argv.join(" ")}`);
+      };
+      const installTarget = await resolveGlobalInstallTarget({
+        manager: "npm",
+        runCommand,
+        timeoutMs: 1000,
+      });
+      const installArgv: string[][] = [];
+
+      const result = await runGlobalPackageUpdateSteps({
+        installTarget,
+        installSpec: "openclaw@2.0.0",
+        packageName: "openclaw",
+        runCommand,
+        runStep: async ({ name, argv, cwd }) => {
+          installArgv.push(argv);
+          return {
+            name,
+            command: argv.join(" "),
+            cwd: cwd ?? process.cwd(),
+            durationMs: 1,
+            exitCode: 1,
+          };
+        },
+        timeoutMs: 1000,
+      });
+
+      expect(result.failedStep).not.toBeNull();
+      expect(installArgv).toHaveLength(2);
+      expect(installArgv.flat()).not.toContain("--prefix");
+      expect(installArgv.flat().some((arg) => arg.includes("***"))).toBe(false);
+      await expectPathMissing(redactedRoot);
+    });
+  });
+
   it("installs npm updates into a clean staged prefix before swapping the global package", async () => {
     await withTempDir({ prefix: "openclaw-package-update-staged-" }, async (base) => {
       const prefix = path.join(base, "prefix");

--- a/src/infra/update-global.test.ts
+++ b/src/infra/update-global.test.ts
@@ -411,42 +411,84 @@ describe("update global helpers", () => {
     });
   });
 
-  it("falls back to the running package root when npm redacts UUID-like path segments", async () => {
-    await withMockedPlatform("darwin", async () => {
-      await withTempDir({ prefix: "openclaw-update-redacted-probe-" }, async (base) => {
-        const globalRoot = path.join(base, "usr", "local", "lib", "node_modules");
-        const pkgRoot = path.join(globalRoot, "openclaw");
-        const redactedRoot = path.join(
-          base,
-          "tmp",
-          "ci-agent",
-          "***",
-          "workspace",
-          "sbx-***",
-          "nvm",
-          "versions",
-          "node",
-          "v24.14.0",
-          "lib",
-          "node_modules",
-        );
-        await fs.mkdir(pkgRoot, { recursive: true });
+  it("rejects redacted npm global roots when no running-package fallback exists", async () => {
+    await withTempDir({ prefix: "openclaw-update-redacted-probe-" }, async (base) => {
+      const redactedRoot = path.join(
+        base,
+        "ci-agent",
+        "***",
+        "workspace",
+        "sbx-***",
+        "nvm",
+        "versions",
+        "node",
+        "v24.14.0",
+        "lib",
+        "node_modules",
+      );
+      const runCommand = createNpmRootRunner({ defaultNpmRoot: redactedRoot });
 
-        const runCommand = createNpmRootRunner({ defaultNpmRoot: redactedRoot });
-
-        await expect(
-          resolveGlobalInstallTarget({
-            manager: "npm",
-            runCommand,
-            timeoutMs: 1000,
-            pkgRoot,
-          }),
-        ).resolves.toEqual({
+      await expect(
+        resolveGlobalInstallTarget({
           manager: "npm",
-          command: "npm",
-          globalRoot,
-          packageRoot: pkgRoot,
-        });
+          runCommand,
+          timeoutMs: 1000,
+        }),
+      ).resolves.toEqual({
+        manager: "npm",
+        command: "npm",
+        globalRoot: null,
+        packageRoot: null,
+      });
+    });
+  });
+
+  it("preserves literal star segments reported by pnpm", async () => {
+    await withTempDir({ prefix: "openclaw-update-pnpm-stars-" }, async (base) => {
+      const globalRoot = path.join(base, "pnpm", "***", "5", "node_modules");
+      const runCommand: CommandRunner = async (argv) => {
+        if (argv[0] === "pnpm") {
+          return { stdout: `${globalRoot}\n`, stderr: "", code: 0 };
+        }
+        throw new Error(`unexpected command: ${argv.join(" ")}`);
+      };
+
+      await expect(
+        resolveGlobalInstallTarget({
+          manager: "pnpm",
+          runCommand,
+          timeoutMs: 1000,
+        }),
+      ).resolves.toEqual({
+        manager: "pnpm",
+        command: "pnpm",
+        globalRoot,
+        packageRoot: path.join(globalRoot, "openclaw"),
+      });
+    });
+  });
+
+  it("rejects multiline package-manager root output", async () => {
+    await withTempDir({ prefix: "openclaw-update-multiline-root-" }, async (base) => {
+      const firstRoot = path.join(base, "first", "lib", "node_modules");
+      const secondRoot = path.join(base, "second", "lib", "node_modules");
+      const runCommand: CommandRunner = async () => ({
+        stdout: `${firstRoot}\n${secondRoot}\n`,
+        stderr: "",
+        code: 0,
+      });
+
+      await expect(
+        resolveGlobalInstallTarget({
+          manager: "npm",
+          runCommand,
+          timeoutMs: 1000,
+        }),
+      ).resolves.toEqual({
+        manager: "npm",
+        command: "npm",
+        globalRoot: null,
+        packageRoot: null,
       });
     });
   });

--- a/src/infra/update-global.test.ts
+++ b/src/infra/update-global.test.ts
@@ -411,6 +411,46 @@ describe("update global helpers", () => {
     });
   });
 
+  it("falls back to the running package root when npm redacts UUID-like path segments", async () => {
+    await withMockedPlatform("darwin", async () => {
+      await withTempDir({ prefix: "openclaw-update-redacted-probe-" }, async (base) => {
+        const globalRoot = path.join(base, "usr", "local", "lib", "node_modules");
+        const pkgRoot = path.join(globalRoot, "openclaw");
+        const redactedRoot = path.join(
+          base,
+          "tmp",
+          "ci-agent",
+          "***",
+          "workspace",
+          "sbx-***",
+          "nvm",
+          "versions",
+          "node",
+          "v24.14.0",
+          "lib",
+          "node_modules",
+        );
+        await fs.mkdir(pkgRoot, { recursive: true });
+
+        const runCommand = createNpmRootRunner({ defaultNpmRoot: redactedRoot });
+
+        await expect(
+          resolveGlobalInstallTarget({
+            manager: "npm",
+            runCommand,
+            timeoutMs: 1000,
+            pkgRoot,
+          }),
+        ).resolves.toEqual({
+          manager: "npm",
+          command: "npm",
+          globalRoot,
+          packageRoot: pkgRoot,
+        });
+      });
+    });
+  });
+
   it("does not infer npm ownership from path shape alone when the owning npm binary is absent", async () => {
     await withTempDir({ prefix: "openclaw-update-npm-missing-bin-" }, async (base) => {
       const brewRoot = path.join(base, "opt", "homebrew", "lib", "node_modules");

--- a/src/infra/update-global.ts
+++ b/src/infra/update-global.ts
@@ -17,6 +17,7 @@ import {
   readPackageDistInventoryIfPresent,
 } from "./package-dist-inventory.js";
 import { readPackageVersion } from "./package-json.js";
+import { parseGlobalRootOutput } from "./package-manager-output.js";
 import { applyPathPrepend } from "./path-prepend.js";
 import { parseSemver } from "./runtime-guard.js";
 
@@ -753,14 +754,7 @@ async function resolveGlobalRoot(
   if (!res || res.code !== 0) {
     return null;
   }
-  const root = res.stdout.trim();
-  if (!root || root.includes("***")) {
-    // npm >= 11 redacts UUID-like path segments in stdout to literal "***".
-    // Trusting a poisoned path creates a literal "***" directory tree and leaves
-    // the live install stale, so treat it as an unresolved probe and fall back.
-    return null;
-  }
-  return root;
+  return parseGlobalRootOutput(resolved.manager, res.stdout);
 }
 
 /**
@@ -854,7 +848,7 @@ export async function detectGlobalInstallManagerForRoot(
     if (!res || res.code !== 0) {
       continue;
     }
-    const globalRoot = res.stdout.trim();
+    const globalRoot = parseGlobalRootOutput(manager, res.stdout);
     if (!globalRoot) {
       continue;
     }

--- a/src/infra/update-global.ts
+++ b/src/infra/update-global.ts
@@ -754,7 +754,13 @@ async function resolveGlobalRoot(
     return null;
   }
   const root = res.stdout.trim();
-  return root || null;
+  if (!root || root.includes("***")) {
+    // npm >= 11 redacts UUID-like path segments in stdout to literal "***".
+    // Trusting a poisoned path creates a literal "***" directory tree and leaves
+    // the live install stale, so treat it as an unresolved probe and fall back.
+    return null;
+  }
+  return root;
 }
 
 /**


### PR DESCRIPTION
## Summary

npm >= 11 can redact UUID-like global-root path segments as literal `***`. Treating that output as a real path can create a literal `***` directory tree during staged updates while leaving the live install stale.

This revision:

- rejects `***` only for npm root probes, preserving legal pnpm paths;
- rejects multiline package-manager root output;
- applies the same parser to install-target resolution and manager detection;
- verifies the composed update flow never stages into or passes a poisoned root to npm.

Fixes #107239

## Test evidence

Two-sided regression proof:

- current upstream base + new tests: 3 expected failures (redacted npm root, composed poisoned staging path, multiline output);
- previous PR head + new tests: 2 expected failures (legal pnpm `***` path rejected, multiline output accepted);
- corrected candidate: 57/57 focused tests pass.

Exact candidate proof ran in a disposable Blaxel Linux sandbox bound to parent `921154b7e3d5cebe94a47157ab97743b666970fb` and archive SHA-256 `60de94bc5eef540c92da905978e1628afc5a5c3a8795f952d76d4e4ca927e9f0`:

- `pnpm install --frozen-lockfile`
- Oxfmt check on all four changed files
- type-aware Oxlint for core production and test files: 0 warnings/errors
- core TypeScript project check
- core-test TypeScript project check
- focused Vitest: 2 files, 57 tests passed

Sandbox cleanup was verified through provider-authoritative inventory (`[]`).
