### PR TITLE
docs: refresh generated docs map

### DIFF
--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -8401,6 +8401,7 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
   - H2: GLM models
   - H2: Getting started
   - H3: Endpoints
+  - H2: Rate limits and overloads
   - H2: Config example
   - H2: Built-in catalog
   - H2: Thinking levels


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the repository docs check fails because the generated documentation map does not include the new z.ai overload section.

## Why This Change Was Made

Regenerates the canonical docs map from the current source headings. No authored documentation or runtime behavior changes.

## User Impact

No user-visible behavior change. Maintainer CI can validate documentation changes again.

## Evidence

- Before: `node scripts/generate-docs-map.mjs --check` reported `docs/docs_map.md is out of date`.
- After: `node scripts/generate-docs-map.mjs --check` reports the map is up to date.
- `git diff --check`
