### PR TITLE
fix(workspaces): reject nondecimal widget grid spellings

### DIFF
--- a/extensions/workspaces/src/cli.test.ts
+++ b/extensions/workspaces/src/cli.test.ts
@@ -350,6 +350,38 @@ describe("workspace CLI", () => {
     });
   });
 
+  it("rejects non-decimal grid spellings that Number() would silently coerce", async () => {
+    const program = createProgram();
+    // Number() would coerce each to a valid integer (0x10 -> 16, "" -> 0,
+    // 1e2 -> 100) and silently accept a different grid than the one typed.
+    const silentCoercions = [
+      "0x10,0,1,1", // hex
+      "0,0,1e2,1", // exponent
+      "1,,1,1", // empty segment coerces to 0
+      "0b1,0,1,1", // binary
+      "-1,0,1,1", // negative
+      "1.5,0,1,1", // fractional
+    ];
+    for (const grid of silentCoercions) {
+      await expect(
+        program.parseAsync(
+          [
+            "workspaces",
+            "widgets",
+            "add",
+            "--tab",
+            "ops",
+            "--kind",
+            "builtin:markdown",
+            "--grid",
+            grid,
+          ],
+          { from: "user" },
+        ),
+      ).rejects.toThrow("grid must be x,y,w,h");
+    }
+  });
+
   it("scaffolds operator widgets as pending and approves them through the approvals method", async () => {
     await withTempStateDir(async (stateDir) => {
       const store = new WorkspaceStore({ stateDir });

--- a/extensions/workspaces/src/cli.ts
+++ b/extensions/workspaces/src/cli.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import type { Command } from "commander";
 import { addGatewayClientOptions, callGatewayFromCli } from "openclaw/plugin-sdk/gateway-runtime";
+import { parseStrictNonNegativeInteger } from "openclaw/plugin-sdk/number-runtime";
 import {
   validateWorkspaceDoc,
   type WorkspaceBinding,
@@ -59,8 +60,10 @@ function parseOptionalBoolean(value: string): boolean {
 }
 
 function parseWorkspaceGrid(value: string): WorkspaceGrid {
-  const parts = value.split(",").map((entry) => Number(entry.trim()));
-  if (parts.length !== 4 || parts.some((entry) => !Number.isInteger(entry))) {
+  // Reject non-decimal spellings (0x10, 1e2, "", 0b10) that Number() would
+  // silently coerce; grid cells are non-negative per validateGrid.
+  const parts = value.split(",").map((entry) => parseStrictNonNegativeInteger(entry.trim()));
+  if (parts.length !== 4 || parts.some((entry) => entry === undefined)) {
     throw new Error("grid must be x,y,w,h");
   }
   const [x, y, w, h] = parts as [number, number, number, number];


### PR DESCRIPTION
## What Problem This Solves

`parseWorkspaceGrid` (the CLI parser for `--grid x,y,w,h` in `workspaces widgets add`/`update`/`move`) used `Number()` on each comma-separated cell, then only checked `Number.isInteger`. `Number()` silently coerces non-decimal spellings, so the CLI accepted grids that were never intended:

- `0x10,0,1,1` -> `16,0,1,1` (hex)
- `0,0,1e2,1` -> `0,0,100,1` (exponent)
- `1,,1,1` -> `1,0,1,1` (empty segment -> `0`)
- `0b1,0,1,1` -> `1,0,1,1` (binary)
- `-1,0,1,1` -> `-1,0,1,1` (negative)
- `1.5,0,1,1` -> `1,0,1,1` (fractional, floored by `isInteger`? no — `Number.isInteger(1.5)` is false so this one is already rejected; the others are not)

The user types one grid and gets a different one persisted, with no error. The hex/exponent/binary/empty/negative cases all pass the `isInteger` guard.

## Why This Change Was Made

Route the parse through the shared `parseStrictNonNegativeInteger` helper (`openclaw/plugin-sdk/number-runtime`, re-exported from `packages/normalization-core/src/number-coercion.ts`). This is the same helper `google-meet`'s `--since` transcript cursor uses (#106384) — it accepts only base-10 integer strings and rejects hex, binary, exponent, fractional, empty, and non-string inputs at the boundary. Grid cells are non-negative per `validateGrid` (schema enforces `x>=0, y>=0, w>=1, h>=1`), so a non-negative integer parse matches the schema contract exactly and rejects the negative case too.

## What Changed

- `extensions/workspaces/src/cli.ts`: `parseWorkspaceGrid` now maps each cell through `parseStrictNonNegativeInteger` and treats `undefined` (parse failure) as an invalid grid, throwing the same `grid must be x,y,w,h` error.
- `extensions/workspaces/src/cli.test.ts`: new test `rejects non-decimal grid spellings that Number() would silently coerce`, covering hex / exponent / empty / binary / negative / fractional. Existing `"bad"` rejection and valid `"0,0,4,2"` grids are unchanged.

## Evidence

```
node scripts/run-vitest.mjs extensions/workspaces/src/cli.test.ts
# new test passes; the 5 pre-existing EBUSY sqlite-cleanup failures on Windows are unrelated to this change (they reproduce on base without these edits)
node_modules/.bin/oxlint extensions/workspaces/src/cli.ts extensions/workspaces/src/cli.test.ts  # exit 0
git diff --check  # clean
```
