### PR TITLE
fix(linux-node): keep tool error detail UTF-16 safe at truncation boundary [AI-assisted]

### DIFF
--- a/extensions/linux-node/src/command-utils-utf16.test.ts
+++ b/extensions/linux-node/src/command-utils-utf16.test.ts
@@ -1,0 +1,42 @@
+// Tests for command-utils formatToolError UTF-16 safety.
+import { describe, expect, it } from "vitest";
+import { formatToolError } from "./command-utils.js";
+
+describe("formatToolError", () => {
+  it("truncates error detail without splitting surrogate pairs at the boundary", () => {
+    // 299 ASCII chars + emoji (2 code units) = 301 code units; slice(0, 300)
+    // would split the surrogate pair. truncateUtf16Safe backs off to 299.
+    const detail = "e".repeat(299) + "😀";
+    const result = formatToolError({
+      code: 1,
+      stdout: detail,
+      stderr: "",
+      termination: null,
+    } as never);
+
+    expect(result).not.toMatch(/[\uD800-\uDFFF]/u);
+    expect(result.length).toBeLessThanOrEqual(300);
+    expect(result).toContain("eee");
+    expect(result).not.toContain("😀");
+  });
+
+  it("preserves short error detail unchanged", () => {
+    const result = formatToolError({
+      code: 1,
+      stdout: "something went wrong",
+      stderr: "",
+      termination: null,
+    } as never);
+    expect(result).toBe("something went wrong");
+  });
+
+  it("falls back to exit code when no output", () => {
+    const result = formatToolError({
+      code: 42,
+      stdout: "",
+      stderr: "   ",
+      termination: null,
+    } as never);
+    expect(result).toBe("exit 42");
+  });
+});

--- a/extensions/linux-node/src/command-utils.ts
+++ b/extensions/linux-node/src/command-utils.ts
@@ -1,5 +1,6 @@
 import type { OpenClawPluginNodeHostCommandAvailabilityContext } from "openclaw/plugin-sdk/plugin-entry";
 import type { CommandOptions, SpawnResult } from "openclaw/plugin-sdk/process-runtime";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import {
   resolveLinuxNodePluginConfigFromHost,
   type ResolvedLinuxNodePluginConfig,
@@ -32,7 +33,7 @@ export function clamp(value: number, minimum: number, maximum: number): number {
 export function formatToolError(result: SpawnResult): string {
   const detail = result.stderr.trim() || result.stdout.trim();
   return detail
-    ? detail.replaceAll(/\s+/gu, " ").slice(0, 300)
+    ? truncateUtf16Safe(detail.replaceAll(/\s+/gu, " "), 300)
     : `exit ${result.code ?? "unknown"}`;
 }
 


### PR DESCRIPTION
> [AI-assisted] This PR was generated using Claude Code.

## What Problem This Solves

Fixes an issue where `formatToolError` in `extensions/linux-node/src/command-utils.ts` could produce a dangling UTF-16 surrogate half when truncating command stderr/stdout output to 300 characters. Same pattern as #102246 (mushuiyu886, merged) and dozens of zhangguiping-xydt / mushuiyu886 UTF-16 safe truncation PRs.

## Why This Change Was Made

`formatToolError` truncated command output with `detail.replaceAll(/\s+/gu, " ").slice(0, 300)`. Command output (stderr/stdout from any user-run command) can contain emoji or other astral-plane characters. When a surrogate pair straddles the 300-code-unit boundary, `slice(0, 300)` keeps the high surrogate and drops the low one, leaving a dangling `\uD83D`-style half that renders as `�` and can corrupt the error message displayed to the agent.

The fix swaps the bare `slice(0, 300)` for `truncateUtf16Safe` from `@openclaw/plugin-sdk/text-utility-runtime`, which backs the boundary off the surrogate pair. One import + one call-site replacement; no behavior change for output that fits or that doesn't land an emoji on the boundary.

**Production reachability**: unlike #107268 (which was closed because Discord limits nicknames to 32 chars), `formatToolError` truncates **arbitrary command stderr/stdout** -- any user command can produce emoji-laden output of any length (e.g. `echo "🧪".repeat(200) >&2`). The 300-code-unit boundary is genuinely reachable in production.

## User Impact

Error messages from failed linux-node commands no longer carry a `�` or dangling surrogate when the output contains emoji near the 300-character truncation boundary. Output <= 300 code units is unchanged.

## Evidence

Regression test in `extensions/linux-node/src/command-utils-utf16.test.ts` (`truncates error detail without splitting surrogate pairs at the boundary`): constructs `"e".repeat(299) + "😀"` (301 code units, emoji straddling the 300 boundary), calls `formatToolError` with it as stdout, asserts the result has no dangling surrogate and stays within 300 code units.

**Before fix (current `main`)** - `slice(0, 300)` splits the `😀` surrogate pair:

```
detail = "e".repeat(299) + "😀"  // 301 UTF-16 code units
detail.slice(0, 300)             // = "e".repeat(299) + "\uD83D" (dangling high surrogate)
```

**After fix** - `truncateUtf16Safe` backs off the surrogate pair:

```
truncateUtf16Safe(detail, 300)   // = "e".repeat(299) (backs off the split pair, 299 code units, no surrogate)
```

Local verification:

- `node scripts/run-vitest.mjs extensions/linux-node/src/command-utils-utf16.test.ts` - 3/3 pass.
- `oxlint` + `oxfmt --check` on changed files - pass.

Not tested: live linux-node command execution (the proof drives the real `formatToolError` function directly with a `SpawnResult` shaped like real command output; no process spawn is involved in this string-formatting path).
