### PR TITLE
fix(ui): terminal artifacts after hide and show

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Control UI terminal repaint:** force a full terminal canvas render after panel hide/show and same-size tab switches so stale visual artifacts do not survive reattachment. Fixes #107952.
 - **Mattermost progress command details:** accept the documented `streaming.preview.commandText` and `streaming.progress.commandText` modes in channel config validation and bundled metadata. Thanks @shakkernerd.
 - **1Password authorization handoff:** persist nonce-bound pending approvals in shared plugin state so hook and tool execution across broker instances remain single-use and fail closed.
 - **Control UI chat transcripts:** preserve loaded history across session and pane returns, bound automatic backscroll loading, virtualize long transcripts, retain hidden native run boundaries, and keep prepends, streaming, and responsive layouts from flickering or jumping. Thanks @shakkernerd.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Control UI terminal repaint:** force a full terminal canvas render after panel hide/show and same-size tab switches so stale visual artifacts do not survive reattachment. Fixes #107952.
 - **Mattermost progress command details:** accept the documented `streaming.preview.commandText` and `streaming.progress.commandText` modes in channel config validation and bundled metadata. Thanks @shakkernerd.
 - **1Password authorization handoff:** persist nonce-bound pending approvals in shared plugin state so hook and tool execution across broker instances remain single-use and fail closed.
 - **Control UI chat transcripts:** preserve loaded history across session and pane returns, bound automatic backscroll loading, virtualize long transcripts, retain hidden native run boundaries, and keep prepends, streaming, and responsive layouts from flickering or jumping. Thanks @shakkernerd.

--- a/ui/src/components/terminal/terminal-panel.test.ts
+++ b/ui/src/components/terminal/terminal-panel.test.ts
@@ -239,6 +239,7 @@ describe("OpenClawTerminalPanel", () => {
       true,
       0,
       controller.terminal,
+      0,
     );
   });
 

--- a/ui/src/components/terminal/terminal-panel.test.ts
+++ b/ui/src/components/terminal/terminal-panel.test.ts
@@ -20,12 +20,19 @@ type TerminalFactory = typeof import("./terminal-runtime.ts").createIsolatedGhos
 const createGhosttyTerminalMock: CreateGhosttyTerminalMock = vi.fn();
 
 function createTerminalController(dispose: () => void = vi.fn()) {
+  const wasmTerm = {};
+  const renderer = {
+    setTheme: vi.fn(),
+    render: vi.fn(),
+  };
   return {
     readOnly: false,
     terminal: {
       cols: 100,
       rows: 30,
       viewportY: 0,
+      wasmTerm,
+      renderer,
       write: vi.fn(),
       focus: vi.fn(),
       reset: vi.fn(),
@@ -193,6 +200,46 @@ describe("OpenClawTerminalPanel", () => {
         params: { sessionId: "session-1", cols: 120, rows: 40 },
       });
     });
+  });
+
+  it("forces a full render after hiding and showing the panel", async () => {
+    const controller = createTerminalController();
+    let createOptions: CreateOptions | undefined;
+    createGhosttyTerminalMock.mockImplementation(async (options: CreateOptions) => {
+      createOptions = options;
+      return controller;
+    });
+    const client: TerminalGatewayClient = {
+      forceReconnect: () => {},
+      request: async <T>(method: string) =>
+        (method === "terminal.open" ? terminalOpenResult("session-1") : {}) as T,
+      addEventListener: () => () => {},
+    };
+    const panel = document.createElement(TERMINAL_PANEL_ELEMENT_NAME) as OpenClawTerminalPanel;
+    panel.client = client;
+    panel.available = true;
+    document.body.append(panel);
+    panel.toggle();
+
+    await vi.waitFor(() => expect(createOptions?.parent.isConnected).toBe(true));
+    controller.fit.mockClear();
+    controller.terminal.renderer.render.mockClear();
+
+    panel.toggle();
+    await panel.updateComplete;
+    expect(createOptions?.parent.isConnected).toBe(false);
+
+    panel.toggle();
+    await panel.updateComplete;
+
+    expect(createOptions?.parent.isConnected).toBe(true);
+    expect(controller.fit).toHaveBeenCalled();
+    expect(controller.terminal.renderer.render).toHaveBeenCalledWith(
+      controller.terminal.wasmTerm,
+      true,
+      0,
+      controller.terminal,
+    );
   });
 
   it("flushes keystrokes entered while open is in flight after resize resync", async () => {

--- a/ui/src/components/terminal/terminal-panel.ts
+++ b/ui/src/components/terminal/terminal-panel.ts
@@ -80,6 +80,13 @@ const TERMINAL_FONT_FAMILY =
 const TERMINAL_OUTPUT_ENCODER = new TextEncoder();
 const CATALOG_TERMINAL_READY_TIMEOUT_MS = 30_000;
 
+function forceTerminalRender(controller: GhosttyTerminalController): void {
+  const term = controller.terminal;
+  if (term.renderer && term.wasmTerm) {
+    term.renderer.render(term.wasmTerm, true, term.viewportY, term);
+  }
+}
+
 /** `<openclaw-terminal-panel>` — the dockable Control UI shell surface. */
 export class OpenClawTerminalPanel extends OpenClawLitElement {
   /** Gateway client used for terminal.* RPCs; null until connected. */
@@ -212,7 +219,7 @@ export class OpenClawTerminalPanel extends OpenClawLitElement {
         const term = tab.controller.terminal;
         if (term.renderer && term.wasmTerm) {
           term.renderer.setTheme(theme);
-          term.renderer.render(term.wasmTerm, true, term.viewportY, term);
+          forceTerminalRender(tab.controller);
         }
       }
     }
@@ -227,7 +234,13 @@ export class OpenClawTerminalPanel extends OpenClawLitElement {
             viewport.append(tab.host);
           }
         }
-        this.tabs.find((tab) => tab.id === this.activeId)?.controller.fit();
+        const activeTab = this.tabs.find((tab) => tab.id === this.activeId);
+        if (activeTab) {
+          activeTab.controller.fit();
+          // FitAddon skips unchanged dimensions; force dirty-row rendering to
+          // repair a canvas that was detached while the panel was hidden.
+          forceTerminalRender(activeTab.controller);
+        }
       }
     }
     this.syncLayoutReservation();
@@ -773,10 +786,14 @@ export class OpenClawTerminalPanel extends OpenClawLitElement {
   private switchTo(tabId: string): void {
     this.activeId = tabId;
     const tab = this.tabs.find((entry) => entry.id === tabId);
-    // Refit after the container becomes visible so cols/rows match the viewport.
+    // Refit and repaint after the container becomes visible. A same-size tab
+    // switch otherwise leaves the newly shown canvas without dirty rows.
     void this.updateComplete.then(() => {
-      tab?.controller.fit();
-      tab?.controller.terminal.focus();
+      if (tab) {
+        tab.controller.fit();
+        forceTerminalRender(tab.controller);
+        tab.controller.terminal.focus();
+      }
     });
   }
 

--- a/ui/src/components/terminal/terminal-panel.ts
+++ b/ui/src/components/terminal/terminal-panel.ts
@@ -83,7 +83,8 @@ const CATALOG_TERMINAL_READY_TIMEOUT_MS = 30_000;
 function forceTerminalRender(controller: GhosttyTerminalController): void {
   const term = controller.terminal;
   if (term.renderer && term.wasmTerm) {
-    term.renderer.render(term.wasmTerm, true, term.viewportY, term);
+    // An omitted opacity defaults to 1; repaint without inventing a visible scrollbar.
+    term.renderer.render(term.wasmTerm, true, term.viewportY, term, 0);
   }
 }
 

--- a/ui/src/e2e/terminal-repaint.e2e.test.ts
+++ b/ui/src/e2e/terminal-repaint.e2e.test.ts
@@ -1,6 +1,7 @@
+import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
-import { chromium, type Browser } from "playwright";
+import { chromium, type Browser, type Locator } from "playwright";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import {
   canRunPlaywrightChromium,
@@ -18,6 +19,11 @@ const screenshotPath = process.env.OPENCLAW_TERMINAL_REPAINT_SCREENSHOT?.trim();
 
 let browser: Browser;
 let server: ControlUiE2eServer;
+
+async function terminalCanvasDigest(canvas: Locator): Promise<string> {
+  const png = await canvas.screenshot({ animations: "disabled", caret: "hide" });
+  return createHash("sha256").update(png).digest("hex");
+}
 
 describeControlUiE2e("Control UI terminal repaint", () => {
   beforeAll(async () => {
@@ -71,21 +77,25 @@ describeControlUiE2e("Control UI terminal repaint", () => {
       await gateway.waitForRequest("connect");
       await page.keyboard.press("Control+Backquote");
       await gateway.waitForRequest("terminal.open");
-      await gateway.emitGatewayEvent("terminal.data", {
-        sessionId: "terminal-repaint-e2e",
-        seq: 0,
-        data: "terminal repaint sentinel\r\n$ ",
-      });
 
       const hideTerminal = page.getByRole("button", { name: "Hide terminal" });
       const terminalCanvas = page.locator(".tp-host canvas");
       await terminalCanvas.waitFor({ state: "visible" });
+      const blankCanvasDigest = await terminalCanvasDigest(terminalCanvas);
+      await gateway.emitGatewayEvent("terminal.data", {
+        sessionId: "terminal-repaint-e2e",
+        seq: 0,
+        data: "\u001b[?25lterminal repaint sentinel\r\n$ ",
+      });
+      await expect.poll(() => terminalCanvasDigest(terminalCanvas)).not.toBe(blankCanvasDigest);
+      const renderedCanvasDigest = await terminalCanvasDigest(terminalCanvas);
 
       for (let cycle = 0; cycle < 3; cycle += 1) {
         await hideTerminal.click();
         await expect.poll(() => terminalCanvas.count()).toBe(0);
         await page.keyboard.press("Control+Backquote");
         await terminalCanvas.waitFor({ state: "visible" });
+        await expect.poll(() => terminalCanvasDigest(terminalCanvas)).toBe(renderedCanvasDigest);
       }
 
       await terminalCanvas.click();

--- a/ui/src/e2e/terminal-repaint.e2e.test.ts
+++ b/ui/src/e2e/terminal-repaint.e2e.test.ts
@@ -1,0 +1,106 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { chromium, type Browser } from "playwright";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  canRunPlaywrightChromium,
+  installMockGateway,
+  resolvePlaywrightChromiumExecutablePath,
+  startControlUiE2eServer,
+  type ControlUiE2eServer,
+} from "../test-helpers/control-ui-e2e.ts";
+
+const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
+const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
+const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
+const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+const screenshotPath = process.env.OPENCLAW_TERMINAL_REPAINT_SCREENSHOT?.trim();
+
+let browser: Browser;
+let server: ControlUiE2eServer;
+
+describeControlUiE2e("Control UI terminal repaint", () => {
+  beforeAll(async () => {
+    if (!chromiumAvailable) {
+      throw new Error(
+        `Playwright Chromium is not installed or cannot start at ${chromiumExecutablePath}. Run \`pnpm --dir ui exec playwright install --with-deps chromium\`.`,
+      );
+    }
+    server = await startControlUiE2eServer();
+    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
+  });
+
+  afterAll(async () => {
+    await browser?.close();
+    await server?.close();
+  });
+
+  it("keeps one interactive terminal clean across repeated hide and show cycles", async () => {
+    const context = await browser.newContext({
+      serviceWorkers: "block",
+      viewport: { width: 1180, height: 520 },
+    });
+    const page = await context.newPage();
+    await page.addInitScript(() => {
+      (
+        window as Window & {
+          ["__OPENCLAW_NATIVE_CONTROL_AUTH__"]?: { gatewayUrl: string; token: string };
+        }
+      )["__OPENCLAW_NATIVE_CONTROL_AUTH__"] = {
+        gatewayUrl: "ws://gateway.example.test",
+        token: "test",
+      };
+    });
+    const gateway = await installMockGateway(page, {
+      featureMethods: ["terminal.open"],
+      methodResponses: {
+        "terminal.list": { sessions: [] },
+        "terminal.open": {
+          agentId: "main",
+          confined: false,
+          cwd: "/workspace",
+          sessionId: "terminal-repaint-e2e",
+          shell: "/bin/zsh",
+        },
+      },
+      terminalEnabled: true,
+    });
+
+    try {
+      await page.goto(server.baseUrl);
+      await gateway.waitForRequest("connect");
+      await page.keyboard.press("Control+Backquote");
+      await gateway.waitForRequest("terminal.open");
+      await gateway.emitGatewayEvent("terminal.data", {
+        sessionId: "terminal-repaint-e2e",
+        seq: 0,
+        data: "terminal repaint sentinel\r\n$ ",
+      });
+
+      const hideTerminal = page.getByRole("button", { name: "Hide terminal" });
+      const terminalCanvas = page.locator(".tp-host canvas");
+      await terminalCanvas.waitFor({ state: "visible" });
+
+      for (let cycle = 0; cycle < 3; cycle += 1) {
+        await hideTerminal.click();
+        await expect.poll(() => terminalCanvas.count()).toBe(0);
+        await page.keyboard.press("Control+Backquote");
+        await terminalCanvas.waitFor({ state: "visible" });
+      }
+
+      await terminalCanvas.click();
+      await page.keyboard.type("echo repaint");
+      await expect
+        .poll(async () => (await gateway.getRequests("terminal.input")).length)
+        .toBeGreaterThan(0);
+      expect(await gateway.getRequests("terminal.open")).toHaveLength(1);
+
+      if (screenshotPath) {
+        await fs.mkdir(path.dirname(screenshotPath), { recursive: true });
+        await page.screenshot({ path: screenshotPath });
+      }
+    } finally {
+      await context.close();
+    }
+  });
+});


### PR DESCRIPTION
Fixes #107952

## What Problem This Solves

Fixes an issue where Control UI terminal users could see stale black rectangles or square glyph artifacts after hiding and reopening the terminal panel.

## Why This Change Was Made

The terminal now performs a full canvas render after a hidden host is reattached and after a same-size tab becomes visible. This complements fitting because the terminal fit addon intentionally skips work when rows and columns are unchanged. The repaint supplies zero synthetic scrollbar opacity because the renderer defaults an omitted value to fully visible.

## User Impact

Terminal contents repaint cleanly after panel hide/show and tab switches while the existing PTY session remains connected and interactive.

## Evidence

- Before: reproduced stale compositor rectangles after hiding and reopening the terminal on current main.
- Focused unit proof: `terminal-panel.test.ts`, 18 tests passed.
- Chromium E2E: a rendered-terminal canvas digest was captured, then required to return exactly after each of three hide/show cycles; the same terminal session accepted input after the final show. 1 test passed on Blacksmith Testbox run https://github.com/openclaw/openclaw/actions/runs/29390499278.
- Changed-file gate: formatting, UI and core-test type checks, i18n verification, dependency guards, and changed-file lint passed on Blacksmith Testbox.
- Fresh follow-up autoreview after the pixel assertion: clean, no accepted/actionable findings.

The original screenshot contains user terminal contents and was intentionally not uploaded.
