### PR TITLE
refactor(workspaces): privatize broadcast test seam

### DIFF
--- a/extensions/workspaces/src/broadcast.ts
+++ b/extensions/workspaces/src/broadcast.ts
@@ -25,8 +25,3 @@ export function rememberWorkspaceBroadcast(broadcast: WorkspaceBroadcast): void 
 export function workspaceBroadcast(): WorkspaceBroadcast | undefined {
   return handle;
 }
-
-/** Test-only: clear the remembered handle between cases. */
-export function resetWorkspaceBroadcastForTest(): void {
-  handle = undefined;
-}

--- a/extensions/workspaces/src/gateway.test.ts
+++ b/extensions/workspaces/src/gateway.test.ts
@@ -3,7 +3,6 @@ import os from "node:os";
 import path from "node:path";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
 import { describe, expect, it, vi } from "vitest";
-import { workspaceBroadcast, resetWorkspaceBroadcastForTest } from "./broadcast.js";
 import { registerWorkspaceGatewayMethods } from "./gateway.js";
 import { WorkspaceStore } from "./store.js";
 
@@ -279,12 +278,17 @@ describe("workspace gateway methods", () => {
 
 describe("workspace broadcast handle", () => {
   it("remembers the server broadcast so agent tools can announce changes off-request", async () => {
-    resetWorkspaceBroadcastForTest();
+    // Isolate the singleton broadcast module so this assertion is not coupled
+    // to state left behind by earlier test files.
+    vi.resetModules();
+    const { workspaceBroadcast } = await import("./broadcast.js");
     expect(workspaceBroadcast()).toBeUndefined();
 
+    const { registerWorkspaceGatewayMethods: registerWorkspaceGatewayMethodsForTest } =
+      await import("./gateway.js");
     await withTempStateDir(async (stateDir) => {
       const { api, methods } = createApi();
-      registerWorkspaceGatewayMethods({ api, store: new WorkspaceStore({ stateDir }) });
+      registerWorkspaceGatewayMethodsForTest({ api, store: new WorkspaceStore({ stateDir }) });
       const broadcast = vi.fn();
 
       // A read populates the slot; agent turns started from a channel or cron have

--- a/scripts/deadcode-exports.baseline.mjs
+++ b/scripts/deadcode-exports.baseline.mjs
@@ -48,7 +48,6 @@ export const KNIP_UNUSED_EXPORT_BASELINE = [
   "extensions/telegram/src/topic-name-cache.ts: resetTopicNameCacheForTest",
   "extensions/telegram/src/topic-name-cache.ts: setTelegramTopicNameStoreFactoryForTest",
   "extensions/telegram/src/update-offset-store.ts: setTelegramUpdateOffsetStoreForTest",
-  "extensions/workspaces/src/broadcast.ts: resetWorkspaceBroadcastForTest",
   "src/acp/control-plane/active-turns.ts: resetAcpActiveTurnsForTests",
   "src/acp/runtime/registry.ts: AcpRuntimeBackend",
   "src/agents/agent-hooks/compaction-safeguard.ts: testing",


### PR DESCRIPTION
## What Problem This Solves

The workspace broadcast module exported `resetWorkspaceBroadcastForTest()` only so one test could assert the singleton started empty. That is an internal test seam exposed on the public module surface, and it is listed in the dead-code export baseline.

## Why This Change Was Made

Following the recent channel/plugin test-seam cleanups (e.g., #107951, #107949), this removes the test-only export and isolates the broadcast module in the test via `vi.resetModules()` and a dynamic import instead.

## User Impact

None. This only removes an internal test-only export.

## Evidence

- `CI=true pnpm test extensions/workspaces/src/gateway.test.ts --run` passes (5/5).
- `pnpm exec oxlint --config .oxlintrc.json ...` clean.
- `pnpm deadcode:exports` baseline still matches.

Fixes no open issue; this is a standalone hygiene refactor.