### PR TITLE
refactor(discord): privatize channel info test seam

### DIFF
--- a/extensions/discord/src/monitor/message-channel-info.ts
+++ b/extensions/discord/src/monitor/message-channel-info.ts
@@ -33,10 +33,6 @@ const DISCORD_CHANNEL_INFO_CACHE = new Map<
   { value: DiscordChannelInfo | null; expiresAt: number }
 >();
 
-export function resetDiscordChannelInfoCacheForTest() {
-  DISCORD_CHANNEL_INFO_CACHE.clear();
-}
-
 function resolveDiscordChannelInfoCacheExpiresAt(ttlMs: number, nowMs: number): number | undefined {
   return resolveExpiresAtMsFromDurationMs(ttlMs, { nowMs });
 }

--- a/extensions/discord/src/monitor/message-utils.test.ts
+++ b/extensions/discord/src/monitor/message-utils.test.ts
@@ -7,8 +7,6 @@ import {
 } from "discord-api-types/v10";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { ChannelType, type Client, type Message } from "../internal/discord.js";
-import { resetDiscordChannelInfoCacheForTest } from "./message-channel-info.js";
-
 const readRemoteMediaBuffer = vi.fn();
 const saveMediaBuffer = vi.fn();
 
@@ -1199,10 +1197,6 @@ describe("resolveDiscordMessageText", () => {
 });
 
 describe("resolveDiscordChannelInfo", () => {
-  beforeEach(() => {
-    resetDiscordChannelInfoCacheForTest();
-  });
-
   it("caches channel lookups between calls", async () => {
     const fetchChannel = vi.fn().mockResolvedValue({
       type: ChannelType.DM,

--- a/extensions/discord/src/monitor/threading.parent-info.test.ts
+++ b/extensions/discord/src/monitor/threading.parent-info.test.ts
@@ -1,28 +1,30 @@
 // Discord tests cover threading.parent info plugin behavior.
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { ChannelType } from "../internal/discord.js";
 import { createPartialDiscordChannelWithThrowingGetters } from "../test-support/partial-channel.js";
-import { resetDiscordChannelInfoCacheForTest } from "./message-channel-info.js";
 import { resolveDiscordThreadParentInfo } from "./threading.js";
 
-describe("resolveDiscordThreadParentInfo", () => {
-  beforeEach(() => {
-    resetDiscordChannelInfoCacheForTest();
-  });
+let idSequence = 0;
+function nextTestId(prefix: string): string {
+  return `${prefix}-${++idSequence}`;
+}
 
+describe("resolveDiscordThreadParentInfo", () => {
   it("falls back to fetched thread parentId when parentId is missing in payload", async () => {
+    const threadId = nextTestId("thread");
+    const parentId = nextTestId("parent");
     const fetchChannel = vi.fn(async (channelId: string) => {
-      if (channelId === "thread-1") {
+      if (channelId === threadId) {
         return {
-          id: "thread-1",
+          id: threadId,
           type: ChannelType.PublicThread,
           name: "thread-name",
-          parentId: "parent-1",
+          parentId,
         };
       }
-      if (channelId === "parent-1") {
+      if (channelId === parentId) {
         return {
-          id: "parent-1",
+          id: parentId,
           type: ChannelType.GuildText,
           name: "parent-name",
         };
@@ -37,34 +39,36 @@ describe("resolveDiscordThreadParentInfo", () => {
     const result = await resolveDiscordThreadParentInfo({
       client,
       threadChannel: {
-        id: "thread-1",
+        id: threadId,
         parentId: undefined,
       },
       channelInfo: null,
     });
 
-    expect(fetchChannel).toHaveBeenCalledWith("thread-1");
-    expect(fetchChannel).toHaveBeenCalledWith("parent-1");
+    expect(fetchChannel).toHaveBeenCalledWith(threadId);
+    expect(fetchChannel).toHaveBeenCalledWith(parentId);
     expect(result).toEqual({
-      id: "parent-1",
+      id: parentId,
       name: "parent-name",
       type: ChannelType.GuildText,
     });
   });
 
   it("falls back to fetched thread parentId when partial channel getters throw", async () => {
+    const threadId = nextTestId("thread");
+    const parentId = nextTestId("parent");
     const fetchChannel = vi.fn(async (channelId: string) => {
-      if (channelId === "thread-1") {
+      if (channelId === threadId) {
         return {
-          id: "thread-1",
+          id: threadId,
           type: ChannelType.PublicThread,
           name: "thread-name",
-          parentId: "parent-1",
+          parentId,
         };
       }
-      if (channelId === "parent-1") {
+      if (channelId === parentId) {
         return {
-          id: "parent-1",
+          id: parentId,
           type: ChannelType.GuildText,
           name: "parent-name",
         };
@@ -75,7 +79,7 @@ describe("resolveDiscordThreadParentInfo", () => {
     const client = { fetchChannel } as unknown as import("../internal/discord.js").Client;
     const threadChannel = createPartialDiscordChannelWithThrowingGetters(
       {
-        id: "thread-1",
+        id: threadId,
         parent: { id: "stale-parent", name: "stale-parent-name" },
       },
       ["parentId", "parent"],
@@ -87,20 +91,22 @@ describe("resolveDiscordThreadParentInfo", () => {
       channelInfo: null,
     });
 
-    expect(fetchChannel).toHaveBeenCalledWith("thread-1");
-    expect(fetchChannel).toHaveBeenCalledWith("parent-1");
+    expect(fetchChannel).toHaveBeenCalledWith(threadId);
+    expect(fetchChannel).toHaveBeenCalledWith(parentId);
     expect(result).toEqual({
-      id: "parent-1",
+      id: parentId,
       name: "parent-name",
       type: ChannelType.GuildText,
     });
   });
 
   it("does not fetch thread info when parentId is already present", async () => {
+    const threadId = nextTestId("thread");
+    const parentId = nextTestId("parent");
     const fetchChannel = vi.fn(async (channelId: string) => {
-      if (channelId === "parent-1") {
+      if (channelId === parentId) {
         return {
-          id: "parent-1",
+          id: parentId,
           type: ChannelType.GuildText,
           name: "parent-name",
         };
@@ -112,26 +118,27 @@ describe("resolveDiscordThreadParentInfo", () => {
     const result = await resolveDiscordThreadParentInfo({
       client,
       threadChannel: {
-        id: "thread-1",
-        parentId: "parent-1",
+        id: threadId,
+        parentId,
       },
       channelInfo: null,
     });
 
     expect(fetchChannel).toHaveBeenCalledTimes(1);
-    expect(fetchChannel).toHaveBeenCalledWith("parent-1");
+    expect(fetchChannel).toHaveBeenCalledWith(parentId);
     expect(result).toEqual({
-      id: "parent-1",
+      id: parentId,
       name: "parent-name",
       type: ChannelType.GuildText,
     });
   });
 
   it("returns empty parent info when fallback thread lookup has no parentId", async () => {
+    const threadId = nextTestId("thread");
     const fetchChannel = vi.fn(async (channelId: string) => {
-      if (channelId === "thread-1") {
+      if (channelId === threadId) {
         return {
-          id: "thread-1",
+          id: threadId,
           type: ChannelType.PublicThread,
           name: "thread-name",
           parentId: undefined,
@@ -144,14 +151,14 @@ describe("resolveDiscordThreadParentInfo", () => {
     const result = await resolveDiscordThreadParentInfo({
       client,
       threadChannel: {
-        id: "thread-1",
+        id: threadId,
         parentId: undefined,
       },
       channelInfo: null,
     });
 
     expect(fetchChannel).toHaveBeenCalledTimes(1);
-    expect(fetchChannel).toHaveBeenCalledWith("thread-1");
+    expect(fetchChannel).toHaveBeenCalledWith(threadId);
     expect(result).toStrictEqual({});
   });
 });

--- a/scripts/deadcode-exports.baseline.mjs
+++ b/scripts/deadcode-exports.baseline.mjs
@@ -14,7 +14,6 @@ export const KNIP_UNUSED_EXPORT_BASELINE = [
   "extensions/discord/src/directory-cache.ts: resetDiscordDirectoryCacheForTest",
   "extensions/discord/src/internal/client.ts: ComponentRegistry",
   "extensions/discord/src/internal/command-deploy.ts: testing",
-  "extensions/discord/src/monitor/message-channel-info.ts: resetDiscordChannelInfoCacheForTest",
   "extensions/discord/src/monitor/native-command.runtime.ts: testing",
   "extensions/discord/src/monitor/native-command.ts: testing",
   "extensions/discord/src/monitor/provider.ts: testing",


### PR DESCRIPTION
## What Problem This Solves

`resetDiscordChannelInfoCacheForTest()` was an exported test-only seam used by two test files to clear a module-level cache between cases. It is listed in the dead-code export baseline as an internal surface that should be privatized.

## Why This Change Was Made

Following the recent plugin test-seam cleanups (e.g., #107859, #107951), this removes the test-only export:

- `threading.parent-info.test.ts` now uses unique `thread-N` / `parent-N` IDs per test, so the process-wide cache no longer leaks between assertions.
- `message-utils.test.ts` already uses distinctive channel IDs in its cache tests, so the reset is unnecessary.

## User Impact

None. This only removes an internal test-only export and tightens test isolation.

## Evidence

- `CI=true pnpm test extensions/discord/src/monitor/message-utils.test.ts extensions/discord/src/monitor/threading.parent-info.test.ts --run` passes (53/53).
- `pnpm exec oxlint --config .oxlintrc.json ...` clean.
- `pnpm deadcode:exports` baseline still matches.

Fixes no open issue; this is a standalone hygiene refactor.