### PR TITLE
feat(ui): pick a repo folder and a cloud worker together in the new-session composer

### DIFF
--- a/ui/src/e2e/new-session-page.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.e2e.test.ts
@@ -743,16 +743,22 @@ describeControlUiE2e("Control UI new-session page mocked Gateway E2E", () => {
       await expect.poll(() => trigger.getAttribute("data-worktree")).toBe("true");
       await expect.poll(() => page.getByLabel("Base branch").inputValue()).toBe("main");
 
+      // Picking a Gateway repo keeps the cloud selection: that folder is what
+      // the managed worktree checks out and dispatch syncs to the worker.
       await page.locator("#new-session-folder-trigger").click();
       await page
         .locator(".new-session-page__browser-list")
         .getByRole("button", { name: "Gateway" })
         .click();
+      await page.locator("input.new-session-page__browser-path").fill(TARGET_REPO);
       await page.getByRole("button", { name: "Use this folder" }).click();
-      await expect.poll(() => trigger.getAttribute("data-cloud-profile")).toBeNull();
-      await page.locator("#new-session-where-trigger").click();
-      await where.getByRole("button", { name: "Cloud · aws" }).click();
       await expect.poll(() => trigger.getAttribute("data-cloud-profile")).toBe("aws");
+      await expect.poll(() => trigger.getAttribute("data-worktree")).toBe("true");
+      await page.locator("#new-session-where-trigger").click();
+      await expect
+        .poll(() => where.locator(".new-session-page__menu-note").textContent())
+        .toContain("Syncs target-repo to the cloud worker");
+      await page.keyboard.press("Escape");
 
       const message = "fix the cloud-only failure";
       const composer = page.locator(".new-session-page__message");
@@ -788,6 +794,7 @@ describeControlUiE2e("Control UI new-session page mocked Gateway E2E", () => {
         message: "",
         worktree: true,
         worktreeBaseRef: "main",
+        cwd: TARGET_REPO,
       });
       expect(create.params).not.toHaveProperty("attachments");
       await gateway.waitForRequest("sessions.dispatch");
@@ -940,9 +947,11 @@ describeControlUiE2e("Control UI new-session page mocked Gateway E2E", () => {
         .toBe(true);
       await page.keyboard.press("Escape");
 
-      const agentSelect = page.locator("wa-select.new-session-page__agent-select");
-      await agentSelect.click();
-      await agentSelect.getByRole("option", { name: "Local" }).click();
+      await page.locator("#new-session-agent-trigger").click();
+      await page
+        .locator("wa-popover.new-session-page__agent-popover")
+        .getByRole("button", { name: "Local" })
+        .click();
       await page.getByRole("heading", { name: "Local" }).waitFor();
       await expect.poll(() => trigger.getAttribute("data-cloud-profile")).toBeNull();
       await expect.poll(() => trigger.getAttribute("data-worktree")).toBe("false");
@@ -1811,9 +1820,11 @@ describeControlUiE2e("Control UI new-session page mocked Gateway E2E", () => {
       await page.goto(`${server.baseUrl}new`);
       await page.getByRole("heading", { name: "Main" }).waitFor();
       await gateway.waitForRequest("worktrees.branches");
-      const agentSelect = page.locator("wa-select.new-session-page__agent-select");
-      await agentSelect.click();
-      await agentSelect.getByRole("option", { name: "Research" }).click();
+      await page.locator("#new-session-agent-trigger").click();
+      await page
+        .locator("wa-popover.new-session-page__agent-popover")
+        .getByRole("button", { name: "Research" })
+        .click();
       await page.getByRole("heading", { name: "Research" }).waitFor();
 
       const message = page.locator(".new-session-page__message");

--- a/ui/src/i18n/.i18n/catalog-fallbacks.json
+++ b/ui/src/i18n/.i18n/catalog-fallbacks.json
@@ -1,5 +1,28 @@
 {
-  "fallbacks": {},
-  "sourceHash": "dc6d0f7bdb69960a5b9d54c5743445b89b0689913b3f962829f8490dede56d2c",
+  "fallbacks": {
+    "newSession.cloudSyncsFolder": [
+      "ar",
+      "de",
+      "es",
+      "fa",
+      "fr",
+      "hi",
+      "id",
+      "it",
+      "ja-JP",
+      "ko",
+      "nl",
+      "pl",
+      "pt-BR",
+      "ru",
+      "th",
+      "tr",
+      "uk",
+      "vi",
+      "zh-CN",
+      "zh-TW"
+    ]
+  },
+  "sourceHash": "bd7720cbb311b6d966553d28ed5a01d4badd6edf08980b1c7824328f1533b8fd",
   "version": 1
 }

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -475,6 +475,7 @@ export const en: TranslationMap = {
     cloudSecureContextRequired:
       "Cloud workers need a secure browser context so recovery can protect your task.",
     cloudStartFailed: "The session was created locally, but cloud startup failed: {error}",
+    cloudSyncsFolder: "Syncs {folder} to the cloud worker",
     folder: "Folder",
     folderPlaceholder: "Agent workspace",
     browse: "Browse folders",

--- a/ui/src/pages/new-session/new-session-page.ts
+++ b/ui/src/pages/new-session/new-session-page.ts
@@ -9,7 +9,6 @@ import { loadSettings } from "../../app/settings.ts";
 import { icons } from "../../components/icons.ts";
 import "../../components/tooltip.ts";
 import "../../components/web-awesome-popover.ts";
-import "../../components/web-awesome-select.ts";
 import { t } from "../../i18n/index.ts";
 import { searchForSession } from "../../lib/sessions/index.ts";
 import { buildAgentMainSessionKey, normalizeAgentId } from "../../lib/sessions/session-key.ts";
@@ -82,6 +81,8 @@ class NewSessionPage extends OpenClawLightDomElement {
   @state() private browserTarget: BrowserTarget | null = null;
   @state() private wherePopoverOpen = false;
   @state() private wherePopoverHiding = false;
+  @state() private agentPopoverOpen = false;
+  @state() private agentPopoverHiding = false;
   @state() private folderPopoverHiding = false;
   // Live head input; absolute paths stay applicable even without fs.listDir.
   @state() private browserPathDraft = "";
@@ -394,8 +395,9 @@ class NewSessionPage extends OpenClawLightDomElement {
       this.agentSelectedByUser = false;
     }
     const keepSelectedFolder = options.preserveSelectedFolder && this.folderSelectedByUser;
-    // A node cwd belongs to node discovery, not agent workspace refresh.
-    if (!this.execNode && !keepSelectedFolder) {
+    // A node cwd belongs to node discovery, and a locked cloud-recovery draft
+    // shows its staged repo; neither may be replaced by a workspace refresh.
+    if (!this.execNode && !keepSelectedFolder && !this.pendingCloud.sessionKey) {
       this.folder = this.workspacePath();
       this.folderSelectedByUser = false;
     }
@@ -427,6 +429,8 @@ class NewSessionPage extends OpenClawLightDomElement {
       this.agentId = this.pendingCloud.agentId;
       this.cloudProfileId = this.pendingCloud.profileId;
       this.worktree = true;
+      // Show the staged repo (not the agent workspace) while the draft is locked.
+      this.folder = this.pendingCloud.createParams?.cwd ?? "";
       this.pendingCloud.restored = false;
       this.message = this.pendingCloud.message;
       this.attachmentDraft.replace(restoreChatApiAttachments(this.pendingCloud.attachments));
@@ -436,8 +440,10 @@ class NewSessionPage extends OpenClawLightDomElement {
     }
     this.error = null;
     this.wherePopoverHiding = false;
+    this.agentPopoverHiding = false;
     this.folderPopoverHiding = false;
     this.closeWherePopover();
+    this.closeAgentPopover();
     this.closeBrowser();
     this.adoptAgentDefaults();
     void this.updateComplete.then(() => {
@@ -477,6 +483,8 @@ class NewSessionPage extends OpenClawLightDomElement {
     this.agentId = recovery.agentId;
     this.cloudProfileId = recovery.profileId;
     this.worktree = true;
+    // Show the staged repo (not the agent workspace) while the draft is locked.
+    this.folder = recovery.createParams?.cwd ?? "";
     this.message = recovery.message;
     this.attachmentDraft.replace(restoreChatApiAttachments(recovery.attachments));
   }
@@ -679,6 +687,7 @@ class NewSessionPage extends OpenClawLightDomElement {
     this.error = null;
     // Retire hidden pickers before their late requests can mutate this submitted draft.
     this.closeWherePopover();
+    this.closeAgentPopover();
     this.closeBrowser();
     for (const dropdown of this.querySelectorAll<HTMLElement & { open: boolean }>(
       "wa-dropdown[open]",
@@ -887,19 +896,35 @@ class NewSessionPage extends OpenClawLightDomElement {
     this.maybeLoadBranches();
   }
 
+  /**
+   * Loaded branch data already covers the effective Gateway repo selection.
+   * Branch data is always Gateway-owned: maybeLoadBranches clears and never
+   * requests while a node is selected, so a path match cannot cross hosts.
+   */
+  private branchesMatchCurrentRepo(): boolean {
+    if (this.execNode) {
+      return false;
+    }
+    const repoRoot = this.folder.trim() || this.workspacePath();
+    return this.branches?.repoRoot === repoRoot;
+  }
+
   private applyFolder(folder: string, execNode = this.execNode) {
     if (this.submitting || this.pendingCloud.sessionKey) {
       return;
     }
     this.execNode = execNode;
-    this.cloudProfileId = "";
+    if (execNode) {
+      // Node sessions run on that device; a cloud worker cannot sync a node path.
+      this.cloudProfileId = "";
+    }
     this.error = null;
     this.folder = folder.trim();
     this.folderSelectedByUser = true;
     if (this.execNode) {
       this.worktree = false;
-    } else if (this.usesCustomFolder()) {
-      // Explicit host paths only materialize through a managed worktree.
+    } else if (this.usesCustomFolder() || this.cloudProfileId) {
+      // Explicit host paths and cloud dispatch only materialize through a managed worktree.
       this.worktree = true;
     }
     this.maybeLoadBranches();
@@ -912,14 +937,21 @@ class NewSessionPage extends OpenClawLightDomElement {
     if (execNode === this.execNode && !this.cloudProfileId) {
       return;
     }
+    // Turning a cloud selection back into a plain Gateway session keeps the
+    // picked repo; only a host change retires the folder path.
+    const keepGatewayFolder = !execNode && !this.execNode;
     this.execNode = execNode;
     this.cloudProfileId = "";
-    // Folder paths belong to one host; never carry a Gateway or node path to another host.
-    this.folder = execNode ? "" : this.workspacePath();
-    this.folderSelectedByUser = false;
-    this.worktree = false;
+    if (!keepGatewayFolder) {
+      // Folder paths belong to one host; never carry a Gateway or node path to another host.
+      this.folder = execNode ? "" : this.workspacePath();
+      this.folderSelectedByUser = false;
+    }
+    this.worktree = keepGatewayFolder && this.usesCustomFolder();
     this.closeBrowser();
-    this.maybeLoadBranches();
+    if (!this.branchesMatchCurrentRepo()) {
+      this.maybeLoadBranches();
+    }
   }
 
   private selectCloudProfile(profileId: string) {
@@ -931,14 +963,17 @@ class NewSessionPage extends OpenClawLightDomElement {
     ) {
       return;
     }
+    // worktreeAvailable() is false for node targets, so this transition always
+    // starts from a Gateway selection and the folder is a Gateway path. It
+    // stays selected: its repo is what the managed worktree checks out and the
+    // dispatch tunnel syncs to the cloud worker.
     this.cloudProfileId = profileId;
     this.error = null;
-    this.execNode = "";
-    this.folder = this.workspacePath();
-    this.folderSelectedByUser = false;
     this.worktree = true;
     this.closeBrowser();
-    this.maybeLoadBranches();
+    if (!this.branchesMatchCurrentRepo()) {
+      this.maybeLoadBranches();
+    }
   }
 
   private browseAvailable(): boolean {
@@ -975,6 +1010,16 @@ class NewSessionPage extends OpenClawLightDomElement {
     this.wherePopoverOpen = false;
     const popover = this.querySelector<HTMLElement & { open: boolean }>(
       ".new-session-page__where-popover",
+    );
+    if (popover) {
+      popover.open = false;
+    }
+  }
+
+  private closeAgentPopover() {
+    this.agentPopoverOpen = false;
+    const popover = this.querySelector<HTMLElement & { open: boolean }>(
+      ".new-session-page__agent-popover",
     );
     if (popover) {
       popover.open = false;
@@ -1113,6 +1158,17 @@ class NewSessionPage extends OpenClawLightDomElement {
       agents,
       agentId: this.agentId,
       disabled: this.submitting || Boolean(this.pendingCloud.sessionKey),
+      popoverOpen: this.agentPopoverOpen,
+      popoverHiding: this.agentPopoverHiding,
+      onGuardTransition: (event) => this.guardPopoverTransition(event, this.agentPopoverHiding),
+      onPopoverOpenChange: (open) => {
+        this.agentPopoverOpen = open;
+      },
+      onPopoverHidingChange: (hiding) => {
+        this.agentPopoverHiding = hiding;
+      },
+      onRestoreTrigger: () =>
+        this.restorePopoverTrigger("new-session-agent-trigger", ".new-session-page__agent-popover"),
       onSelect: (agentId) => this.selectAgentId(agentId),
     });
   }
@@ -1126,6 +1182,7 @@ class NewSessionPage extends OpenClawLightDomElement {
       cloudProfiles: this.isAdmin() ? cloudProfiles : [],
       cloudProfileId: this.cloudProfileId,
       execNode: this.execNode,
+      syncFolder: this.folder.trim() || this.workspacePath(),
       worktree: this.worktree,
       worktreeAvailable: this.worktreeAvailable(),
       customFolder: this.usesCustomFolder(),

--- a/ui/src/pages/new-session/target-controls.ts
+++ b/ui/src/pages/new-session/target-controls.ts
@@ -12,39 +12,75 @@ type DraftAgent = {
   identity?: { name?: string };
 };
 
+function agentDisplayName(agent: DraftAgent): string {
+  return agent.identity?.name ?? agent.name ?? agent.id;
+}
+
 export function renderAgentSelect(params: {
   agents: DraftAgent[];
   agentId: string;
   disabled: boolean;
+  popoverOpen: boolean;
+  popoverHiding: boolean;
+  onGuardTransition: (event: MouseEvent) => void;
+  onPopoverOpenChange: (open: boolean) => void;
+  onPopoverHidingChange: (hiding: boolean) => void;
+  onRestoreTrigger: () => void;
   onSelect: (agentId: string) => void;
 }) {
+  const selectedId = normalizeAgentId(params.agentId);
+  const active = params.agents.find((agent) => normalizeAgentId(agent.id) === selectedId);
+  const activeLabel = active ? agentDisplayName(active) : params.agentId;
   return html`
-    <wa-select
-      class="new-session-page__select new-session-page__agent-select"
-      label=${t("newSession.agent")}
-      .value=${params.agentId}
-      ?disabled=${params.disabled}
-      @change=${(event: Event) => {
-        const value = (event.currentTarget as HTMLElement & { value?: string }).value;
-        if (value) {
-          params.onSelect(value);
-        }
+    <span class="new-session-page__select">
+      <button
+        id="new-session-agent-trigger"
+        type="button"
+        class="new-session-page__trigger ${params.popoverHiding
+          ? "new-session-page__trigger--hiding"
+          : ""}"
+        title=${t("newSession.agent")}
+        aria-label="${t("newSession.agent")}: ${activeLabel}"
+        aria-haspopup="dialog"
+        aria-expanded=${String(params.popoverOpen)}
+        ?disabled=${params.disabled}
+        @click=${params.onGuardTransition}
+      >
+        <span class="new-session-page__target-icon" aria-hidden="true">${icons.bot}</span>
+        <span class="new-session-page__trigger-label">${activeLabel}</span>
+        <span class="new-session-page__trigger-chevron" aria-hidden="true"
+          >${icons.chevronDown}</span
+        >
+      </button>
+    </span>
+    <wa-popover
+      class="new-session-page__select new-session-page__agent-popover"
+      for="new-session-agent-trigger"
+      placement="bottom-start"
+      without-arrow
+      @wa-show=${() => params.onPopoverOpenChange(true)}
+      @wa-hide=${() => {
+        params.onPopoverOpenChange(false);
+        params.onPopoverHidingChange(true);
+      }}
+      @wa-after-hide=${() => {
+        params.onPopoverHidingChange(false);
+        params.onRestoreTrigger();
       }}
     >
-      <span slot="start" class="new-session-page__target-icon" aria-hidden="true"
-        >${icons.bot}</span
-      >
-      ${params.agents.map(
-        (option) => html`
-          <wa-option
-            value=${normalizeAgentId(option.id)}
-            .label=${option.identity?.name ?? option.name ?? option.id}
-          >
-            ${option.identity?.name ?? option.name ?? option.id}
-          </wa-option>
-        `,
+      <div class="new-session-page__menu-title">${t("newSession.agent")}</div>
+      ${params.agents.map((option) =>
+        renderSessionMenuItem(
+          {
+            value: normalizeAgentId(option.id),
+            label: agentDisplayName(option),
+            checked: normalizeAgentId(option.id) === selectedId,
+            onSelect: () => params.onSelect(normalizeAgentId(option.id)),
+          },
+          params.disabled,
+        ),
       )}
-    </wa-select>
+    </wa-popover>
   `;
 }
 
@@ -53,6 +89,7 @@ export function renderWhereSelect(params: {
   cloudProfiles: DraftCloudProfile[];
   cloudProfileId: string;
   execNode: string;
+  syncFolder: string;
   worktree: boolean;
   worktreeAvailable: boolean;
   customFolder: boolean;
@@ -93,6 +130,7 @@ export function renderWhereSelect(params: {
           ? "new-session-page__trigger--hiding"
           : ""}"
         title=${t("newSession.where")}
+        aria-label="${t("newSession.where")}: ${whereLabel}"
         data-worktree=${String(params.worktree)}
         data-cloud-profile=${params.cloudProfileId || nothing}
         aria-haspopup="dialog"
@@ -171,6 +209,13 @@ export function renderWhereSelect(params: {
                   },
                   params.submitting,
                 )
+              : nothing}
+            ${params.cloudProfileId && params.syncFolder
+              ? html`<div class="new-session-page__menu-note">
+                  ${t("newSession.cloudSyncsFolder", {
+                    folder: folderDisplayName(params.syncFolder),
+                  })}
+                </div>`
               : nothing}
           `
         : nothing}
@@ -273,6 +318,7 @@ export function renderFolderSelect(params: {
         title=${params.browseAvailable
           ? t("newSession.browse")
           : t("newSession.browseRequiresAdmin")}
+        aria-label="${t("newSession.folder")}: ${label}"
         aria-haspopup="dialog"
         aria-expanded=${String(params.browserOpen)}
         ?disabled=${params.submitting || params.pendingCloud || !params.browseAvailable}

--- a/ui/src/styles/new-session.css
+++ b/ui/src/styles/new-session.css
@@ -53,13 +53,15 @@ openclaw-new-session-page {
   text-align: left;
 }
 
-/* Cursor-style quiet trigger row. Web Awesome owns popup/listbox behavior. */
+/* Quiet chip row directly above the composer: every picker (agent, folder,
+   where) shares one trigger treatment so the row reads as a single control
+   strip. Web Awesome owns popup/listbox behavior. */
 .new-session-page__triggers {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
   justify-content: flex-start;
-  gap: 4px 16px;
+  gap: 4px 2px;
   width: calc(100% - 36px);
   max-width: 48rem;
   margin: 0 auto;
@@ -74,14 +76,16 @@ openclaw-new-session-page {
 .new-session-page__trigger {
   display: inline-flex;
   align-items: center;
-  gap: 5px;
-  padding: 2px 0;
+  gap: 6px;
+  height: 26px;
+  padding: 0 10px;
   font-size: 12px;
   color: var(--muted);
   list-style: none;
   cursor: pointer;
   user-select: none;
   border: 0;
+  border-radius: 999px;
   background: transparent;
   font-family: inherit;
 }
@@ -90,9 +94,15 @@ openclaw-new-session-page {
   display: none;
 }
 
-.new-session-page__trigger:hover,
+.new-session-page__trigger:hover:not(:disabled),
 .new-session-page__trigger[aria-expanded="true"] {
   color: var(--text);
+  background: color-mix(in srgb, var(--bg-hover) 84%, transparent);
+}
+
+.new-session-page__trigger:disabled {
+  cursor: default;
+  opacity: 0.6;
 }
 
 .new-session-page__trigger--disabled {
@@ -102,6 +112,7 @@ openclaw-new-session-page {
 
 .new-session-page__trigger--disabled:hover {
   color: var(--muted);
+  background: transparent;
 }
 
 /* Keep the anchor focusable while Web Awesome finishes its hide animation. */
@@ -112,6 +123,10 @@ openclaw-new-session-page {
 .new-session-page__runtime {
   color: var(--text);
   cursor: default;
+}
+
+.new-session-page__runtime:hover {
+  background: transparent;
 }
 
 .new-session-page__catalog-unavailable {
@@ -208,6 +223,14 @@ wa-popover.new-session-page__select::part(body) {
   border-color: color-mix(in srgb, var(--accent) 40%, var(--border));
 }
 
+/* Context line inside a picker menu, e.g. which repo syncs to a cloud worker. */
+.new-session-page__menu-note {
+  padding: 4px 8px 6px;
+  font-size: 11px;
+  line-height: 1.4;
+  color: var(--muted);
+}
+
 /* The folder menu hosts the directory browser; wider than the list menus. */
 wa-popover.new-session-page__select--folder::part(body) {
   width: min(420px, calc(100vw - 24px));
@@ -220,30 +243,9 @@ wa-popover.new-session-page__select--folder::part(body) {
   width: 100%;
 }
 
-.new-session-page__agent-select::part(form-control-label) {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border: 0;
-}
-
-.new-session-page__agent-select::part(combobox) {
-  min-height: 0;
-  padding: 2px 0;
-  border: 0;
-  background: transparent;
-  color: var(--muted);
-  box-shadow: none;
-}
-
-.new-session-page__agent-select::part(display-input) {
-  font-size: 12px;
-  color: inherit;
+/* The chip row already spaces itself; keep the composer snug beneath it. */
+.new-session-page__composer.agent-chat__composer-shell {
+  margin-top: 0;
 }
 
 .new-session-page__target-icon {
@@ -436,7 +438,7 @@ wa-popover.new-session-page__select--folder::part(body) {
 
   .new-session-page__triggers {
     position: relative;
-    gap: 4px 12px;
+    gap: 4px 2px;
   }
 
   .new-session-page__select {


### PR DESCRIPTION
## What Problem This Solves

Resolves two problems on the new-session screen (`/new`) in the Control UI.

First, users could not send a specific repository to a cloud worker. Selecting a folder silently cleared the cloud worker selection, and selecting a cloud worker silently reset the folder back to the agent workspace. The two choices were mutually exclusive, so the only repo a cloud worker could ever run against was the agent's own workspace — there was no way to say "take *this* checkout and run it in the cloud."

Second, the picker row above the composer read as three unrelated controls. The agent picker was a full `wa-select` combobox — visually much heavier and wider than the quiet text triggers next to it — so it sat off-center against the folder and where pickers and against the composer below.

## Why This Change Was Made

Folder and cloud worker are now independent choices. Picking a folder only clears the cloud profile when the target is an execution node (a node path cannot be synced by a cloud worker); picking a cloud worker keeps whatever Gateway folder is already selected. No backend change was needed: `sessions.dispatch` already requires a session-owned managed worktree and its tunnel syncs that worktree to the worker, so the selected repo flows through as `sessions.create` `cwd` → managed worktree → `syncWorkspace`. Selecting a cloud worker therefore forces the managed worktree on, as it already did.

The agent picker is converted to the same quiet trigger + `wa-popover` menu the folder and where pickers already use, and all three now render as one uniform chip system. The where menu states which repo will sync so the beam-to-cloud action is explicit rather than implied. Non-goals: no gateway protocol, dispatch, or sync-path changes; no new config surface.

## User Impact

You can now pick any local git repo and a cloud worker together, and that repo is what gets synced and worked on in the cloud: **folder chip → choose repo → where chip → Cloud**. The where menu confirms it ("Syncs *blockdigest* to the cloud worker"). Switching back to Gateway keeps your chosen repo instead of snapping back to the agent workspace, and a cloud draft recovered after a reload now shows the repo it actually staged. The three pickers read as one aligned control strip above the composer, and each now exposes a proper accessible name ("Agent: Clawd", "Folder: blockdigest", "Where: Cloud · aws") — the old `wa-select` label was otherwise lost in the conversion.

## Evidence

Before/after, captured against a mocked Gateway with the repo's own Control UI e2e harness (light theme shown; dark verified too):

| | Before | After |
| --- | --- | --- |
| **Picker row** | [agent select sprawls, off-center](https://artifacts.openclaw.ai/pr-new-session-cloud-folder-477c8365ebdbd/before-1-default.png) | [uniform chips, aligned to composer](https://artifacts.openclaw.ai/pr-new-session-cloud-folder-477c8365ebdbd/after-1-default.png) |
| **Repo + cloud** | [picking `blockdigest` reverts Cloud · aws → Gateway · local](https://artifacts.openclaw.ai/pr-new-session-cloud-folder-477c8365ebdbd/before-2-folder-drops-cloud.png) | [`blockdigest` + `Cloud · aws` hold together](https://artifacts.openclaw.ai/pr-new-session-cloud-folder-477c8365ebdbd/after-2-folder-plus-cloud.png) |

Also: [where menu sync note](https://artifacts.openclaw.ai/pr-new-session-cloud-folder-477c8365ebdbd/after-3-cloud-sync-note.png) · [agent menu](https://artifacts.openclaw.ai/pr-new-session-cloud-folder-477c8365ebdbd/after-4-agent-menu.png) · [dark theme](https://artifacts.openclaw.ai/pr-new-session-cloud-folder-477c8365ebdbd/after-5-dark-folder-plus-cloud.png) · [artifact manifest](https://artifacts.openclaw.ai/pr-new-session-cloud-folder-477c8365ebdbd/artifact-manifest.json)

The cloud e2e test previously asserted the old behavior (folder-pick clears the cloud profile); it now asserts the two hold together and that `sessions.create` carries the picked repo as `cwd`:

```
node scripts/run-vitest.mjs ui/src/e2e/new-session-page.e2e.test.ts   # 28 passed
node scripts/run-vitest.mjs ui/src/pages/new-session                  # 62 passed
node scripts/run-tsgo.mjs -p tsconfig.ui.json                         # clean
node scripts/run-oxlint.mjs ui/src/pages/new-session                  # clean
pnpm ui:i18n:verify                                                   # clean (new key baselined)
```

Reviewed with `autoreview --mode uncommitted` (Codex `gpt-5.6-sol`, xhigh) until clean. It caught two real defects that are fixed here: the agent trigger lost its accessible name in the select→button conversion, and the agent-defaults refresh could overwrite a restored cloud draft's staged repo. Two further findings were rejected as unreachable and the invariants documented inline instead — a node→cloud transition is already blocked by `worktreeAvailable()`, and branch data is Gateway-only because `maybeLoadBranches` never requests while a node is selected.
