### PR TITLE
fix(shared): block prototype-polluting keys in JSON schema default hydration

### DIFF
--- a/src/shared/json-schema-defaults.test.ts
+++ b/src/shared/json-schema-defaults.test.ts
@@ -1,5 +1,9 @@
-import { describe, expect, it } from "vitest";
-import { findJsonSchemaShapeError, normalizeJsonSchemaForTypeBox } from "./json-schema-defaults.js";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  applyJsonSchemaDefaults,
+  findJsonSchemaShapeError,
+  normalizeJsonSchemaForTypeBox,
+} from "./json-schema-defaults.js";
 
 describe("normalizeJsonSchemaForTypeBox", () => {
   it("combines pattern properties that collide after unicode repair", () => {
@@ -45,5 +49,47 @@ describe("normalizeJsonSchemaForTypeBox", () => {
         items: { $ref: "#/prefixItems/100001" },
       }),
     ).toBeUndefined();
+  });
+});
+
+describe("applyJsonSchemaDefaults prototype safety", () => {
+  const readPollution = () => (Object.prototype as Record<string, unknown>).polluted;
+
+  afterEach(() => {
+    delete (Object.prototype as Record<string, unknown>).polluted;
+  });
+
+  it("does not pollute Object.prototype through a __proto__ property schema", () => {
+    const schema = JSON.parse(
+      '{"type":"object","properties":{"__proto__":{"type":"object","properties":{"polluted":{"default":"yes"}}}}}',
+    );
+
+    const result = applyJsonSchemaDefaults(schema, {});
+
+    expect(readPollution()).toBeUndefined();
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+    expect(Object.hasOwn(result, "polluted")).toBe(false);
+  });
+
+  it("does not pollute Object.prototype through a __proto__ pattern property schema", () => {
+    const schema = JSON.parse(
+      '{"type":"object","patternProperties":{".*":{"type":"object","properties":{"polluted":{"default":"yes"}}}}}',
+    );
+    const value = JSON.parse('{"__proto__":{}}');
+
+    applyJsonSchemaDefaults(schema, value);
+
+    expect(readPollution()).toBeUndefined();
+  });
+
+  it("does not pollute Object.prototype through a __proto__ additional property schema", () => {
+    const schema = JSON.parse(
+      '{"type":"object","additionalProperties":{"type":"object","properties":{"polluted":{"default":"yes"}}}}',
+    );
+    const value = JSON.parse('{"__proto__":{}}');
+
+    applyJsonSchemaDefaults(schema, value);
+
+    expect(readPollution()).toBeUndefined();
   });
 });

--- a/src/shared/json-schema-defaults.ts
+++ b/src/shared/json-schema-defaults.ts
@@ -1,6 +1,7 @@
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 // JSON schema default helpers fill object values from TypeBox schema defaults.
 import { Compile } from "typebox/compile";
+import { isBlockedObjectKey } from "../infra/prototype-keys.js";
 import type { JsonSchemaObject } from "./json-schema.types.js";
 
 type JsonSchemaValue = JsonSchemaObject | boolean;
@@ -926,6 +927,9 @@ function applyObjectPropertyDefaults(
 ): Record<string, unknown> {
   const properties = isRecord(schema.properties) ? schema.properties : {};
   for (const [key, propertySchema] of Object.entries(properties)) {
+    if (isBlockedObjectKey(key)) {
+      continue;
+    }
     const currentValue = value[key];
     const defaultedValue = applySchemaDefaults(
       propertySchema as JsonSchemaValue,
@@ -951,7 +955,7 @@ function applyObjectPropertyDefaults(
         continue;
       }
       for (const key of Object.keys(value)) {
-        if (!regex.test(key)) {
+        if (isBlockedObjectKey(key) || !regex.test(key)) {
           continue;
         }
         patternMatchedKeys.add(key);
@@ -969,7 +973,11 @@ function applyObjectPropertyDefaults(
   if (isRecord(schema.additionalProperties)) {
     const additionalSchema = schema.additionalProperties as JsonSchemaValue;
     for (const key of Object.keys(value)) {
-      if (Object.hasOwn(properties, key) || patternMatchedKeys.has(key)) {
+      if (
+        isBlockedObjectKey(key) ||
+        Object.hasOwn(properties, key) ||
+        patternMatchedKeys.has(key)
+      ) {
         continue;
       }
       value[key] = applySchemaDefaults(


### PR DESCRIPTION
## Summary
A plugin whose manifest `configSchema` declares a `__proto__` property can pollute `Object.prototype` process-wide the moment its config is validated. Plugin config validation hydrates JSON Schema defaults automatically for every discovered plugin, so no operator action beyond loading the plugin is required. After the malicious plugin loads, every plain object in the process carries the attacker-supplied property.

## Root cause
`src/shared/json-schema-defaults.ts`, `applyObjectPropertyDefaults`. The property-defaults loop iterates schema-controlled keys and dereferences the matching value slot with no blocked-key guard, unlike the codebase's centralized `isBlockedObjectKey` used at other untrusted object-write boundaries.

Plugin manifests arrive as parsed JSON, so a `__proto__` entry in `properties` is an own key that `Object.entries` yields. For a config value with no own `__proto__`, `value["__proto__"]` reads the inherited `Object.prototype`, and the nested default hydration then writes defaults straight onto it.

before:
```ts
for (const [key, propertySchema] of Object.entries(properties)) {
  const currentValue = value[key];
  const defaultedValue = applySchemaDefaults(
    propertySchema as JsonSchemaValue,
    currentValue,
    ...
  );
  if (defaultedValue !== currentValue || currentValue === undefined) {
    if (defaultedValue !== undefined) {
      value[key] = defaultedValue;
    }
  }
}
```

## Fix
Skip blocked keys (`__proto__`, `prototype`, `constructor`) at each write site in `applyObjectPropertyDefaults`, reusing the existing `isBlockedObjectKey` helper from `src/infra/prototype-keys.ts`.

after:
```ts
for (const [key, propertySchema] of Object.entries(properties)) {
  if (isBlockedObjectKey(key)) {
    continue;
  }
  const currentValue = value[key];
  ...
}
```

## Why this is the right boundary
`applyObjectPropertyDefaults` is the single function that writes default values into a caller-supplied object using schema-derived and value-derived keys, and it routes every plugin/SDK default-hydration call (`applyJsonSchemaDefaults` -> `applySchemaDefaults`). Guarding its three write loops here fixes the vector for every caller rather than at one call site. The `properties` loop is the live global-pollution path (the added regression test fails on pristine `main`); the `patternProperties` and `additionalProperties` loops key off own value keys so they do not globally pollute today, but guarding all three keeps the whole function consistent with `isBlockedObjectKey` usage elsewhere and prevents the vector from reappearing under refactoring. Legitimate config keys named `__proto__`/`constructor`/`prototype` are unrepresentable through a prototype chain anyway, so skipping their default hydration changes no valid behavior.

## Verification
- `node scripts/run-vitest.mjs run src/shared/json-schema-defaults.test.ts src/plugins/config-schema.test.ts src/infra/prototype-keys.test.ts` passes (17 tests).
- New `applyJsonSchemaDefaults prototype safety` case fails on pristine `main` (`expected 'yes' to be undefined`) and passes with the patch.
- `./node_modules/.bin/oxlint src/shared/json-schema-defaults.ts src/shared/json-schema-defaults.test.ts` clean; `./node_modules/.bin/oxfmt --check` clean.
- `tsgo` on the changed files reports no new diagnostics (unrelated pre-existing module-resolution errors from broken workspace symlinks in the local checkout are not touched by this diff).

## Real behavior proof
Behavior addressed: a plugin manifest `configSchema` with a `__proto__` property pollutes `Object.prototype` for the whole process during ordinary plugin config validation.
Real environment tested: drove the real plugin config validation builder `buildJsonPluginConfigSchema(...).safeParse({})` from `src/plugins/config-schema.ts` (the same call the plugin loader makes on a discovered plugin), on pristine `origin/main` abfdfd65 and on the patched tree with an identical manifest configSchema; the real default-hydration path, the real TypeBox validation, and the real `Object.prototype` stayed live, nothing mocked.
Exact steps or command run after this patch: `./node_modules/.bin/tsx` on a driver that builds the plugin config schema from the manifest JSON and calls `safeParse({})`, then reads a freshly created object.
Evidence after fix:
```
# BEFORE (pristine origin/main abfdfd65)
safeParse.success: true
Object.prototype.polluted: pwned
freshObject.polluted: pwned
verdict: PROTOTYPE POLLUTED process-wide
# AFTER (this patch, identical inputs)
safeParse.success: true
Object.prototype.polluted: undefined
freshObject.polluted: undefined
verdict: prototype clean
```
Observed result after fix: validating the same plugin manifest leaves `Object.prototype` and newly created objects free of the attacker property, while config validation still succeeds.
What was not tested: no live end-to-end plugin discovery from disk was exercised (the real config-schema builder was driven directly with the manifest JSON); full repo build was not run.
