### PR TITLE
fix(codex): remove duplicate provider setup choice

### DIFF
--- a/docs/plugins/plugin-inventory.md
+++ b/docs/plugins/plugin-inventory.md
@@ -213,7 +213,7 @@ Each entry lists the package, distribution route, and description.
 
 - **[cloudflare-ai-gateway](/plugins/reference/cloudflare-ai-gateway)** (`@openclaw/cloudflare-ai-gateway-provider`) - npm; ClawHub: `clawhub:@openclaw/cloudflare-ai-gateway-provider`. Adds Cloudflare AI Gateway model provider support to OpenClaw.
 
-- **[codex](/plugins/reference/codex)** (`@openclaw/codex`) - npm; ClawHub. Codex app-server harness, model provider, and native session catalog.
+- **[codex](/plugins/reference/codex)** (`@openclaw/codex`) - npm; ClawHub. Codex app-server harness and native session catalog.
 
 - **[copilot](/plugins/reference/copilot)** (`@openclaw/copilot`) - npm; ClawHub: `clawhub:@openclaw/copilot`. Registers the GitHub Copilot agent runtime.
 

--- a/docs/plugins/reference/codex.md
+++ b/docs/plugins/reference/codex.md
@@ -1,5 +1,5 @@
 ---
-summary: "Codex app-server harness, model provider, and native session catalog."
+summary: "Codex app-server harness and native session catalog."
 read_when:
   - You are installing, configuring, or auditing the codex plugin
 title: "Codex plugin"
@@ -7,7 +7,7 @@ title: "Codex plugin"
 
 # Codex plugin
 
-Codex app-server harness, model provider, and native session catalog.
+Codex app-server harness and native session catalog.
 
 ## Distribution
 
@@ -16,7 +16,7 @@ Codex app-server harness, model provider, and native session catalog.
 
 ## Surface
 
-providers: `codex`; contracts: `mediaUnderstandingProviders`, `migrationProviders`, `tools`, `webSearchProviders`
+contracts: `mediaUnderstandingProviders`, `migrationProviders`, `tools`, `webSearchProviders`
 
 ## Related docs
 

--- a/docs/plugins/reference/discord.md
+++ b/docs/plugins/reference/discord.md
@@ -16,7 +16,7 @@ OpenClaw Discord channel plugin for channels, DMs, commands, and app events.
 
 ## Surface
 
-channels: `discord`; contracts: `transcriptSourceProviders`; skills
+channels: `discord`; contracts: `tools`, `transcriptSourceProviders`; skills
 
 ## Related docs
 

--- a/extensions/codex/package.json
+++ b/extensions/codex/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openclaw/codex",
   "version": "2026.7.2",
-  "description": "OpenClaw Codex app-server harness, model provider, and native session supervision plugin.",
+  "description": "OpenClaw Codex app-server harness and native session supervision plugin.",
   "repository": {
     "type": "git",
     "url": "https://github.com/openclaw/openclaw"

--- a/scripts/lib/official-external-plugin-catalog.json
+++ b/scripts/lib/official-external-plugin-catalog.json
@@ -56,6 +56,26 @@
       }
     },
     {
+      "name": "@openclaw/codex",
+      "description": "OpenClaw Codex app-server harness and native session catalog",
+      "source": "official",
+      "kind": "plugin",
+      "openclaw": {
+        "plugin": {
+          "id": "codex",
+          "label": "Codex"
+        },
+        "contracts": {
+          "migrationProviders": ["codex"]
+        },
+        "install": {
+          "npmSpec": "@openclaw/codex",
+          "defaultChoice": "npm",
+          "minHostVersion": ">=2026.5.1-beta.1"
+        }
+      }
+    },
+    {
       "name": "@openclaw/copilot",
       "description": "OpenClaw GitHub Copilot agent runtime plugin",
       "source": "official",

--- a/scripts/lib/official-external-provider-catalog.json
+++ b/scripts/lib/official-external-provider-catalog.json
@@ -366,47 +366,6 @@
       }
     },
     {
-      "name": "@openclaw/codex",
-      "description": "OpenClaw Codex harness and model provider plugin",
-      "source": "official",
-      "kind": "provider",
-      "openclaw": {
-        "plugin": {
-          "id": "codex",
-          "label": "Codex"
-        },
-        "contracts": {
-          "migrationProviders": ["codex"]
-        },
-        "providers": [
-          {
-            "id": "codex",
-            "name": "Codex",
-            "docs": "/providers/models",
-            "categories": ["cloud", "llm"],
-            "authChoices": [
-              {
-                "method": "app-server",
-                "choiceId": "codex",
-                "choiceLabel": "Codex app-server",
-                "choiceHint": "Keep using your Codex CLI or ChatGPT app sign-in via the Codex app-server runtime.",
-                "assistantPriority": -40,
-                "groupId": "codex",
-                "groupLabel": "Codex",
-                "groupHint": "Codex app-server model provider",
-                "onboardingScopes": ["text-inference"]
-              }
-            ]
-          }
-        ],
-        "install": {
-          "npmSpec": "@openclaw/codex",
-          "defaultChoice": "npm",
-          "minHostVersion": ">=2026.5.1-beta.1"
-        }
-      }
-    },
-    {
       "name": "@openclaw/deepinfra-provider",
       "description": "OpenClaw DeepInfra provider plugin.",
       "source": "official",

--- a/src/plugins/official-external-plugin-catalog.test.ts
+++ b/src/plugins/official-external-plugin-catalog.test.ts
@@ -180,6 +180,18 @@ describe("official external plugin catalog", () => {
     expect(officialExternalPluginCatalog.entries.length).toBeGreaterThan(0);
   });
 
+  it("keeps Codex installable as a harness without declaring a model provider", () => {
+    const entry = expectCatalogEntry("codex");
+    const manifest = getOfficialExternalPluginCatalogManifest(entry);
+
+    expect(entry.kind).toBe("plugin");
+    expect(manifest?.providers).toBeUndefined();
+    expect(resolveOfficialExternalPluginInstall(entry)).toMatchObject({
+      npmSpec: "@openclaw/codex",
+      defaultChoice: "npm",
+    });
+  });
+
   it("curates featured external plugins with ClawHub install alternatives", () => {
     const featured = [
       ["diffs", "@openclaw/diffs", 40],

--- a/src/wizard/setup.official-plugins.ts
+++ b/src/wizard/setup.official-plugins.ts
@@ -37,7 +37,9 @@ function isGenericOfficialPluginEntry(entry: { source?: string; kind?: string })
     Boolean(manifest?.plugin?.id) &&
     !manifest?.channel &&
     (manifest?.providers?.length ?? 0) === 0 &&
-    (manifest?.webSearchProviders?.length ?? 0) === 0
+    (manifest?.webSearchProviders?.length ?? 0) === 0 &&
+    // Migration owners have their own setup flow; listing them here duplicates install prompts.
+    (manifest?.contracts?.migrationProviders?.length ?? 0) === 0
   );
 }
 


### PR DESCRIPTION
Related: #105561

## What Problem This Solves

Fixes an issue where users browsing provider setup could still see Codex as a separate model provider after Codex model selection moved to the canonical `openai/*` namespace.

## Why This Change Was Made

Codex remains an installable app-server harness and migration owner, but no longer advertises a text-provider choice. The official catalog entry moves from the provider catalog to the general plugin catalog while preserving its npm install metadata and migration contract. Migration-owner plugins stay out of the generic optional-plugin prompt because they have a dedicated setup flow.

## User Impact

Users no longer see a duplicate, retired Codex provider setup choice or an extra optional-plugin prompt for the same harness. The Codex harness remains installable, and existing app-server, session, migration, and configuration behavior is unchanged.

## Evidence

- `node scripts/run-vitest.mjs src/plugins/official-external-plugin-catalog.test.ts` — 36 tests passed.
- `node scripts/run-vitest.mjs src/wizard/setup.official-plugins.test.ts` — 3 tests passed.
- `node scripts/run-vitest.mjs test/release-check.test.ts` — 59 tests passed.
- `node scripts/generate-plugin-inventory-doc.mjs --check`, formatting, and `git diff --check` passed.
- Exact-head hosted CI passed all 67 jobs, including bundled protocol, type, lint, package-boundary, security, contract, build-artifact, and test shards: https://github.com/openclaw/openclaw/actions/runs/29489963051
- Fresh branch AutoReview against `origin/main` at `ac71a1d6ee8` completed clean with no accepted or actionable findings.

AI-assisted: yes.

<!-- agent-transcript:start -->
## Agent Transcript

<details>
<summary>Redacted Codex session excerpt</summary>

````text
source: [LOCAL_SESSION]
redaction: local paths, emails, phone-shaped strings, token-shaped strings, auth headers, auth query params
omitted: raw tool outputs, system/developer prompts, local paths, secrets, browser/session/auth details, unrelated lane operations

[user]
fix improve land then do your work improve land

[assistant]
GO understood: repair/improve/land overlapping PR first. Then fresh follow-up refactor, improve, publish, land. Same lane. No release. Rechecking skill rules, git state, live PR.

Current `main` already contains the core provider fold, so the old PR is mostly superseded. The remaining user-visible defect is narrower: Codex still advertises a retired text-provider choice. Reading the complete catalog, onboarding, migration, tests, docs, and upstream Codex model-list contracts before rewriting.

Best-fix rewrite: move Codex from provider metadata into the general plugin catalog while preserving install and migration ownership. Upstream `model/list` supplies model metadata, not an OpenClaw provider identity.

Hosted CI exposed one same-invariant issue: the general catalog made Codex appear in the generic optional-plugin prompt. Fixing at the owner boundary: plugins with a declared migration-provider contract use their dedicated setup flow and stay out of generic optional onboarding.

Focused proof green: catalog 36/36, wizard 3/3, release checks 59/59, generated inventory exact. Changed checks, hosted CI, formatting, diff check, and fresh AutoReview all clean. Contributor credit retained.
````

</details>
<!-- agent-transcript:end -->
