### PR TITLE
improve(gateway): tunable control-plane write rate limit, default unchanged

### DIFF
--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-739fe620027bad069221aef1e6ec68bef0448c31a1573f70802a461b212c3d7d  plugin-sdk-api-baseline.json
-08eb0ae2bd2c3b32e04661cde03260aa97462ba64a4944307a0bdf98f4f98a75  plugin-sdk-api-baseline.jsonl
+57e4a27d924f724b0df46310be27e3713d4a602decd38ae0693c61b0972ed756  plugin-sdk-api-baseline.json
+5f6d86ab7e35cb2a6649e318dc604f395403dc9b1ea4a952996219fbb2f9d210  plugin-sdk-api-baseline.jsonl

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -653,6 +653,7 @@ See [Inferred commitments](/concepts/commitments).
 - `gateway.channelHealthCheckMinutes`: channel health-monitor interval in minutes. Set `0` to disable health-monitor restarts globally. Default: `5`.
 - `gateway.channelStaleEventThresholdMinutes`: stale-socket threshold in minutes. Keep this greater than or equal to `gateway.channelHealthCheckMinutes`. Default: `30`.
 - `gateway.channelMaxRestartsPerHour`: maximum health-monitor restarts per channel/account in a rolling hour. Default: `10`.
+- `gateway.controlPlaneWritesPerMinute`: maximum control-plane write RPCs (`config.patch`, `update.run`, …) per minute for each client identity (device id + IP). Raise it for trusted automation that performs bursts of writes, such as a provisioner applying many config patches in one roll. Range: `1`-`600`. Default: `3`.
 - `channels.<provider>.healthMonitor.enabled`: per-channel opt-out for health-monitor restarts while keeping the global monitor enabled.
 - `channels.<provider>.accounts.<accountId>.healthMonitor.enabled`: per-account override for multi-account channels. When set, it takes precedence over the channel-level override.
 - Local gateway call paths can use `gateway.remote.*` as fallback only when `gateway.auth.*` is unset.

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -653,7 +653,7 @@ See [Inferred commitments](/concepts/commitments).
 - `gateway.channelHealthCheckMinutes`: channel health-monitor interval in minutes. Set `0` to disable health-monitor restarts globally. Default: `5`.
 - `gateway.channelStaleEventThresholdMinutes`: stale-socket threshold in minutes. Keep this greater than or equal to `gateway.channelHealthCheckMinutes`. Default: `30`.
 - `gateway.channelMaxRestartsPerHour`: maximum health-monitor restarts per channel/account in a rolling hour. Default: `10`.
-- `gateway.controlPlaneWritesPerMinute`: maximum control-plane write RPCs (`config.patch`, `update.run`, …) per minute for each client identity (device id + IP). Raise it for trusted automation that performs bursts of writes, such as a provisioner applying many config patches in one roll. Range: `1`-`600`. Default: `3`.
+- `gateway.controlPlaneWritesPerMinute`: maximum control-plane write RPCs (`config.patch`, `update.run`, …) per minute for each client identity (device id + IP). This setting is gateway-global, not an exemption for one identity. Prefer one `config.patch` for one atomic change; raise the limit only for trusted automation whose operations need independent hash checks, retries, readiness, or rollback. Range: `1`-`600`. Default: `3`.
 - `channels.<provider>.healthMonitor.enabled`: per-channel opt-out for health-monitor restarts while keeping the global monitor enabled.
 - `channels.<provider>.accounts.<accountId>.healthMonitor.enabled`: per-account override for multi-account channels. When set, it takes precedence over the channel-level override.
 - Local gateway call paths can use `gateway.remote.*` as fallback only when `gateway.auth.*` is unset.

--- a/docs/gateway/configuration.md
+++ b/docs/gateway/configuration.md
@@ -612,10 +612,13 @@ subsystem references.
 <Note>
 Control-plane writes (`config.apply`, `config.patch`, `update.run`) are
 rate-limited per `deviceId+clientIp` — 3 requests per 60 seconds by default,
-tunable via `gateway.controlPlaneWritesPerMinute` (range 1-600; raising it applies to every
-identity on the gateway, so keep the default unless trusted automation needs
-write bursts). Restart
-requests coalesce and then enforce a 30-second cooldown between restart cycles.
+tunable via `gateway.controlPlaneWritesPerMinute` (range 1-600). Raising it
+applies to every identity on the gateway, so keep the default unless trusted
+automation needs write bursts. Prefer one `config.patch` when the writes form
+one atomic config change. Raise the limit only when operations need independent
+hash checks, retries, readiness, or rollback; batching those operations couples
+their failure boundaries. Restart requests coalesce and then enforce a
+30-second cooldown between restart cycles.
 `update.status` is read-only but admin-scoped because the restart sentinel can
 include update step summaries and command output tails.
 </Note>

--- a/docs/gateway/configuration.md
+++ b/docs/gateway/configuration.md
@@ -611,7 +611,10 @@ subsystem references.
 
 <Note>
 Control-plane writes (`config.apply`, `config.patch`, `update.run`) are
-rate-limited to 3 requests per 60 seconds per `deviceId+clientIp`. Restart
+rate-limited per `deviceId+clientIp` — 3 requests per 60 seconds by default,
+tunable via `gateway.controlPlaneWritesPerMinute` (range 1-600; raising it applies to every
+identity on the gateway, so keep the default unless trusted automation needs
+write bursts). Restart
 requests coalesce and then enforce a 30-second cooldown between restart cycles.
 `update.status` is read-only but admin-scoped because the restart sentinel can
 include update step summaries and command output tails.

--- a/src/config/config-misc.test.ts
+++ b/src/config/config-misc.test.ts
@@ -966,6 +966,53 @@ describe("gateway.tools config", () => {
   });
 });
 
+describe("gateway.controlPlaneWritesPerMinute", () => {
+  it("accepts a raised control-plane write budget", () => {
+    const res = validateConfigObject({
+      gateway: {
+        controlPlaneWritesPerMinute: 60,
+      },
+    });
+    expect(res.ok).toBe(true);
+  });
+
+  it("rejects a zero control-plane write budget", () => {
+    const res = validateConfigObject({
+      gateway: {
+        controlPlaneWritesPerMinute: 0,
+      },
+    });
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.issues[0]?.path).toBe("gateway.controlPlaneWritesPerMinute");
+    }
+  });
+
+  it("rejects fractional control-plane write budgets", () => {
+    const res = validateConfigObject({
+      gateway: {
+        controlPlaneWritesPerMinute: 1.5,
+      },
+    });
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.issues[0]?.path).toBe("gateway.controlPlaneWritesPerMinute");
+    }
+  });
+
+  it("rejects control-plane write budgets above the 600 per minute ceiling", () => {
+    const res = validateConfigObject({
+      gateway: {
+        controlPlaneWritesPerMinute: 601,
+      },
+    });
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.issues[0]?.path).toBe("gateway.controlPlaneWritesPerMinute");
+    }
+  });
+});
+
 describe("gateway.channelHealthCheckMinutes", () => {
   it("accepts preauth handshake timeout tuning", () => {
     const res = validateConfigObject({

--- a/src/config/config-misc.test.ts
+++ b/src/config/config-misc.test.ts
@@ -967,10 +967,10 @@ describe("gateway.tools config", () => {
 });
 
 describe("gateway.controlPlaneWritesPerMinute", () => {
-  it("accepts a raised control-plane write budget", () => {
+  it.each([1, 600])("accepts the bounded control-plane write budget %i", (value) => {
     const res = validateConfigObject({
       gateway: {
-        controlPlaneWritesPerMinute: 60,
+        controlPlaneWritesPerMinute: value,
       },
     });
     expect(res.ok).toBe(true);

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -171,6 +171,8 @@ export const FIELD_HELP: Record<string, string> = {
     "How many minutes a connected channel can go without provider-proven transport activity before the health monitor treats it as a stale socket and triggers a restart. Default: 30.",
   "gateway.channelMaxRestartsPerHour":
     "Maximum number of health-monitor-initiated channel restarts allowed within a rolling one-hour window. Once hit, further restarts are skipped until the window expires. Default: 10.",
+  "gateway.controlPlaneWritesPerMinute":
+    "Maximum control-plane write RPCs per minute for each client identity (device id + IP). Raising it weakens the write rate limit for every identity on this gateway — including config, update, and plugin operations — so keep the default unless trusted automation needs write bursts. Range: 1-600. Default: 3.",
   "gateway.tailscale":
     "Tailscale integration settings for Serve/Funnel exposure and lifecycle handling on gateway start/exit. Keep off unless your deployment intentionally relies on Tailscale ingress.",
   "gateway.tailscale.mode":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -161,6 +161,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "gateway.channelHealthCheckMinutes": "Gateway Channel Health Check Interval (min)",
   "gateway.channelStaleEventThresholdMinutes": "Gateway Channel Stale Event Threshold (min)",
   "gateway.channelMaxRestartsPerHour": "Gateway Channel Max Restarts Per Hour",
+  "gateway.controlPlaneWritesPerMinute": "Gateway Control-Plane Writes Per Minute",
   "gateway.tailscale": "Gateway Tailscale",
   "gateway.tailscale.mode": "Gateway Tailscale Mode",
   "gateway.tailscale.resetOnExit": "Gateway Tailscale Reset on Exit",

--- a/src/config/types.gateway.ts
+++ b/src/config/types.gateway.ts
@@ -601,10 +601,10 @@ export type GatewayConfig = {
   channelMaxRestartsPerHour?: number;
   /**
    * Maximum control-plane write RPCs (config.patch, update.run, …) allowed
-   * per minute for each client identity (device id + IP). Raise this for
-   * trusted automation that performs bursts of writes (e.g. a provisioner
-   * applying many config patches during a fleet roll). Range: 1-600.
-   * Default: 3.
+   * per minute for each client identity (device id + IP). This is a
+   * gateway-global policy, not a per-identity exemption. Raise it only for
+   * trusted automation whose writes need independent lifecycle boundaries.
+   * Range: 1-600. Default: 3.
    */
   controlPlaneWritesPerMinute?: number;
 };

--- a/src/config/types.gateway.ts
+++ b/src/config/types.gateway.ts
@@ -599,4 +599,12 @@ export type GatewayConfig = {
    * the rolling window expires. Default: 10.
    */
   channelMaxRestartsPerHour?: number;
+  /**
+   * Maximum control-plane write RPCs (config.patch, update.run, …) allowed
+   * per minute for each client identity (device id + IP). Raise this for
+   * trusted automation that performs bursts of writes (e.g. a provisioner
+   * applying many config patches during a fleet roll). Range: 1-600.
+   * Default: 3.
+   */
+  controlPlaneWritesPerMinute?: number;
 };

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -1211,6 +1211,7 @@ export const OpenClawSchema = z
         channelHealthCheckMinutes: z.number().int().min(0).optional(),
         channelStaleEventThresholdMinutes: z.number().int().min(1).optional(),
         channelMaxRestartsPerHour: z.number().int().min(1).optional(),
+        controlPlaneWritesPerMinute: z.number().int().min(1).max(600).optional(),
         tailscale: z
           .strictObject({
             mode: z.union([z.literal("off"), z.literal("serve"), z.literal("funnel")]).optional(),

--- a/src/gateway/config-reload-plan.ts
+++ b/src/gateway/config-reload-plan.ts
@@ -61,6 +61,9 @@ const BASE_RELOAD_RULES: ReloadRule[] = [
   // permissions) and the bootstrap availability flag, both fixed at document
   // load, plus live PTYs — none can hot-update a connected client, so a change
   // must restart the gateway (clients reconnect with a fresh page and CSP).
+  // The write budget is read per request from the live runtime config, so a
+  // change takes effect on the next control-plane write without any reload.
+  { prefix: "gateway.controlPlaneWritesPerMinute", kind: "none" },
   {
     prefix: "gateway.channelHealthCheckMinutes",
     kind: "hot",

--- a/src/gateway/config-reload-plan.ts
+++ b/src/gateway/config-reload-plan.ts
@@ -61,9 +61,9 @@ const BASE_RELOAD_RULES: ReloadRule[] = [
   // permissions) and the bootstrap availability flag, both fixed at document
   // load, plus live PTYs — none can hot-update a connected client, so a change
   // must restart the gateway (clients reconnect with a fresh page and CSP).
-  // The write budget is read per request from the live runtime config, so a
-  // change takes effect on the next control-plane write without any reload.
-  { prefix: "gateway.controlPlaneWritesPerMinute", kind: "none" },
+  // Per-request reads still require runtime snapshot publication; hot mode
+  // also requests a restart when config reload is disabled.
+  { prefix: "gateway.controlPlaneWritesPerMinute", kind: "hot" },
   {
     prefix: "gateway.channelHealthCheckMinutes",
     kind: "hot",

--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -330,6 +330,7 @@ describe("buildGatewayReloadPlan", () => {
     "tui.footer.showRemoteHost",
     "diagnostics.stuckSessionWarnMs",
     "diagnostics.stuckSessionAbortMs",
+    "gateway.controlPlaneWritesPerMinute",
   ])("keeps runtime-irrelevant path as a no-op: %s", (path) => {
     const plan = buildGatewayReloadPlan([path]);
 

--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -330,7 +330,6 @@ describe("buildGatewayReloadPlan", () => {
     "tui.footer.showRemoteHost",
     "diagnostics.stuckSessionWarnMs",
     "diagnostics.stuckSessionAbortMs",
-    "gateway.controlPlaneWritesPerMinute",
   ])("keeps runtime-irrelevant path as a no-op: %s", (path) => {
     const plan = buildGatewayReloadPlan([path]);
 
@@ -338,6 +337,15 @@ describe("buildGatewayReloadPlan", () => {
     expect(plan.restartReasons).toStrictEqual([]);
     expect(plan.hotReasons).toStrictEqual([]);
     expect(plan.noopPaths).toEqual([path]);
+  });
+
+  it("hot reloads the control-plane write budget", () => {
+    const path = "gateway.controlPlaneWritesPerMinute";
+    const plan = buildGatewayReloadPlan([path]);
+
+    expect(plan.restartGateway).toBe(false);
+    expect(plan.hotReasons).toEqual([path]);
+    expect(plan.noopPaths).toEqual([]);
   });
 
   it("treats plugin install timestamp-only changes as no-ops", () => {

--- a/src/gateway/control-plane-rate-limit.test.ts
+++ b/src/gateway/control-plane-rate-limit.test.ts
@@ -4,6 +4,7 @@ import { afterEach, describe, expect, test } from "vitest";
 import {
   consumeControlPlaneWriteBudget,
   pruneStaleControlPlaneBuckets,
+  resolveControlPlaneWriteBudgetMaxRequests,
 } from "./control-plane-rate-limit.js";
 
 describe("control-plane-rate-limit", () => {
@@ -62,5 +63,47 @@ describe("control-plane-rate-limit", () => {
     // A fresh budget proves the oldest bucket was evicted, without exposing
     // the internal map solely for tests.
     expect(consume("oldest")).toMatchObject({ allowed: true, remaining: 2 });
+  });
+
+  test("consumeControlPlaneWriteBudget honors a configured maxRequests", () => {
+    const baseMs = 3_000_000;
+    const consume = () =>
+      consumeControlPlaneWriteBudget({
+        client: { connect: { device: { id: "dev-dial" } }, clientIp: "9.9.9.9" } as never,
+        nowMs: baseMs,
+        maxRequests: 5,
+      });
+
+    for (let attempt = 0; attempt < 5; attempt += 1) {
+      expect(consume()).toMatchObject({ allowed: true, maxRequests: 5 });
+    }
+    const blocked = consume();
+    expect(blocked.allowed).toBe(false);
+    expect(blocked.maxRequests).toBe(5);
+    expect(blocked.retryAfterMs).toBeGreaterThan(0);
+  });
+
+  test("consumeControlPlaneWriteBudget keeps the 3-per-window default", () => {
+    const baseMs = 4_000_000;
+    const consume = () =>
+      consumeControlPlaneWriteBudget({
+        client: { connect: { device: { id: "dev-default" } }, clientIp: "8.8.8.8" } as never,
+        nowMs: baseMs,
+      });
+
+    expect(consume()).toMatchObject({ allowed: true, maxRequests: 3, remaining: 2 });
+    consume();
+    consume();
+    expect(consume().allowed).toBe(false);
+  });
+
+  test("resolveControlPlaneWriteBudgetMaxRequests reads gateway config with a default of 3", () => {
+    expect(resolveControlPlaneWriteBudgetMaxRequests(undefined)).toBe(3);
+    expect(resolveControlPlaneWriteBudgetMaxRequests({})).toBe(3);
+    expect(
+      resolveControlPlaneWriteBudgetMaxRequests({
+        gateway: { controlPlaneWritesPerMinute: 60 },
+      }),
+    ).toBe(60);
   });
 });

--- a/src/gateway/control-plane-rate-limit.ts
+++ b/src/gateway/control-plane-rate-limit.ts
@@ -1,9 +1,10 @@
 // Control-plane rate limiting bounds write-side RPC attempts per device/IP and
 // caps bucket growth against unique-key memory pressure.
+import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { normalizeControlPlaneIdentityPart } from "./control-plane-identity.js";
 import type { GatewayClient } from "./server-methods/types.js";
 
-const CONTROL_PLANE_RATE_LIMIT_MAX_REQUESTS = 3;
+const CONTROL_PLANE_RATE_LIMIT_DEFAULT_MAX_REQUESTS = 3;
 const CONTROL_PLANE_RATE_LIMIT_WINDOW_MS = 60_000;
 const CONTROL_PLANE_BUCKET_MAX_STALE_MS = 5 * 60_000;
 /** Hard cap to prevent memory DoS from rapid unique-key injection (CWE-400). */
@@ -31,17 +32,30 @@ function resolveControlPlaneRateLimitKey(client: GatewayClient | null): string {
   return `${deviceId}|${clientIp}`;
 }
 
+/**
+ * Resolves the per-identity write budget from `gateway.controlPlaneWritesPerMinute`,
+ * falling back to the built-in default of 3.
+ */
+export function resolveControlPlaneWriteBudgetMaxRequests(
+  cfg: Pick<OpenClawConfig, "gateway"> | undefined,
+): number {
+  return cfg?.gateway?.controlPlaneWritesPerMinute ?? CONTROL_PLANE_RATE_LIMIT_DEFAULT_MAX_REQUESTS;
+}
+
 /** Consumes one write budget unit and reports retry state for gateway error responses. */
 export function consumeControlPlaneWriteBudget(params: {
   client: GatewayClient | null;
   nowMs?: number;
+  maxRequests?: number;
 }): {
   allowed: boolean;
   retryAfterMs: number;
   remaining: number;
   key: string;
+  maxRequests: number;
 } {
   const nowMs = params.nowMs ?? Date.now();
+  const maxRequests = params.maxRequests ?? CONTROL_PLANE_RATE_LIMIT_DEFAULT_MAX_REQUESTS;
   const key = resolveControlPlaneRateLimitKey(params.client);
   const bucket = controlPlaneBuckets.get(key);
 
@@ -64,12 +78,13 @@ export function consumeControlPlaneWriteBudget(params: {
     return {
       allowed: true,
       retryAfterMs: 0,
-      remaining: CONTROL_PLANE_RATE_LIMIT_MAX_REQUESTS - 1,
+      remaining: maxRequests - 1,
       key,
+      maxRequests,
     };
   }
 
-  if (bucket.count >= CONTROL_PLANE_RATE_LIMIT_MAX_REQUESTS) {
+  if (bucket.count >= maxRequests) {
     const retryAfterMs = Math.max(
       0,
       bucket.windowStartMs + CONTROL_PLANE_RATE_LIMIT_WINDOW_MS - nowMs,
@@ -79,6 +94,7 @@ export function consumeControlPlaneWriteBudget(params: {
       retryAfterMs,
       remaining: 0,
       key,
+      maxRequests,
     };
   }
 
@@ -86,8 +102,9 @@ export function consumeControlPlaneWriteBudget(params: {
   return {
     allowed: true,
     retryAfterMs: 0,
-    remaining: Math.max(0, CONTROL_PLANE_RATE_LIMIT_MAX_REQUESTS - bucket.count),
+    remaining: Math.max(0, maxRequests - bucket.count),
     key,
+    maxRequests,
   };
 }
 

--- a/src/gateway/server-methods.control-plane-rate-limit.test.ts
+++ b/src/gateway/server-methods.control-plane-rate-limit.test.ts
@@ -27,11 +27,12 @@ describe("gateway control-plane write rate limit", () => {
     resetGatewayWorkAdmission();
   });
 
-  function buildContext(logWarn = vi.fn()) {
+  function buildContext(logWarn = vi.fn(), runtimeConfig: object = {}) {
     return {
       logGateway: {
         warn: logWarn,
       },
+      getRuntimeConfig: () => runtimeConfig,
     } as unknown as Parameters<typeof handleGatewayRequest>[0]["context"];
   }
 
@@ -119,6 +120,85 @@ describe("gateway control-plane write rate limit", () => {
     expect(error?.code).toBe("UNAVAILABLE");
     expect(error?.retryable).toBe(true);
     expect(logWarn).toHaveBeenCalledTimes(1);
+  });
+
+  it("honors gateway.controlPlaneWritesPerMinute from the runtime config", async () => {
+    const handlerCalls = vi.fn();
+    const handler: GatewayRequestHandler = (opts) => {
+      handlerCalls(opts);
+      opts.respond(true, undefined, undefined);
+    };
+    const logWarn = vi.fn();
+    const context = {
+      logGateway: { warn: logWarn },
+      getRuntimeConfig: () => ({ gateway: { controlPlaneWritesPerMinute: 5 } }),
+    } as unknown as Parameters<typeof handleGatewayRequest>[0]["context"];
+    const client = buildClient();
+
+    for (let attempt = 0; attempt < 5; attempt += 1) {
+      await runRequest({ method: "config.patch", context, client, handler });
+    }
+    const blocked = await runRequest({ method: "config.patch", context, client, handler });
+
+    expect(handlerCalls).toHaveBeenCalledTimes(5);
+    const blockedCall = respondCall(blocked);
+    expect(blockedCall[0]).toBe(false);
+    expect(blockedCall[2]?.code).toBe("UNAVAILABLE");
+    expect((blockedCall[2]?.details as { limit?: string })?.limit).toBe("5 per 60s");
+  });
+
+  it("applies a raised budget to every client identity, each bounded separately", async () => {
+    const handler: GatewayRequestHandler = (opts) => {
+      opts.respond(true, undefined, undefined);
+    };
+    const context = buildContext(vi.fn(), { gateway: { controlPlaneWritesPerMinute: 4 } });
+    const clientA = buildClient();
+    clientSequence += 1;
+    const clientB = buildClient();
+
+    for (let attempt = 0; attempt < 4; attempt += 1) {
+      await runRequest({ method: "config.patch", context, client: clientA, handler });
+    }
+    const blockedA = await runRequest({
+      method: "config.patch",
+      context,
+      client: clientA,
+      handler,
+    });
+    expect(respondCall(blockedA)[0]).toBe(false);
+
+    // The raised value is gateway-global: the other identity gets the same
+    // budget, counted in its own bucket.
+    for (let attempt = 0; attempt < 4; attempt += 1) {
+      const ok = await runRequest({ method: "config.patch", context, client: clientB, handler });
+      expect(ok).toHaveBeenCalledWith(true, undefined, undefined);
+    }
+    const blockedB = await runRequest({
+      method: "config.patch",
+      context,
+      client: clientB,
+      handler,
+    });
+    expect(respondCall(blockedB)[0]).toBe(false);
+  });
+
+  it("adopts a changed budget on the next write without any reload", async () => {
+    const handler: GatewayRequestHandler = (opts) => {
+      opts.respond(true, undefined, undefined);
+    };
+    const runtimeConfig = { gateway: { controlPlaneWritesPerMinute: 3 } };
+    const context = buildContext(vi.fn(), runtimeConfig);
+    const client = buildClient();
+
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      await runRequest({ method: "config.patch", context, client, handler });
+    }
+    const blocked = await runRequest({ method: "config.patch", context, client, handler });
+    expect(respondCall(blocked)[0]).toBe(false);
+
+    runtimeConfig.gateway.controlPlaneWritesPerMinute = 10;
+    const allowed = await runRequest({ method: "config.patch", context, client, handler });
+    expect(allowed).toHaveBeenCalledWith(true, undefined, undefined);
   });
 
   it("allows the OpenClaw inference ladder to probe more than 3 candidates", async () => {

--- a/src/gateway/server-methods.ts
+++ b/src/gateway/server-methods.ts
@@ -844,9 +844,7 @@ export async function handleGatewayRequest(
     }
     const budget = consumeControlPlaneWriteBudget({
       client,
-      // Degrade to the built-in default when runtime config is unavailable
-      // rather than throwing from the rate-limit path.
-      maxRequests: resolveControlPlaneWriteBudgetMaxRequests(context.getRuntimeConfig?.()),
+      maxRequests: resolveControlPlaneWriteBudgetMaxRequests(context.getRuntimeConfig()),
     });
     if (budget.allowed) {
       return false;

--- a/src/gateway/server-methods.ts
+++ b/src/gateway/server-methods.ts
@@ -11,7 +11,10 @@ import {
   tryBeginGatewayRootWorkAdmission,
 } from "../process/gateway-work-admission.js";
 import { formatControlPlaneActor, resolveControlPlaneActor } from "./control-plane-audit.js";
-import { consumeControlPlaneWriteBudget } from "./control-plane-rate-limit.js";
+import {
+  consumeControlPlaneWriteBudget,
+  resolveControlPlaneWriteBudgetMaxRequests,
+} from "./control-plane-rate-limit.js";
 import {
   ADMIN_SCOPE,
   authorizeOperatorScopesForMethod,
@@ -839,7 +842,12 @@ export async function handleGatewayRequest(
     if (!methodRegistry.isControlPlaneWrite(req.method)) {
       return false;
     }
-    const budget = consumeControlPlaneWriteBudget({ client });
+    const budget = consumeControlPlaneWriteBudget({
+      client,
+      // Degrade to the built-in default when runtime config is unavailable
+      // rather than throwing from the rate-limit path.
+      maxRequests: resolveControlPlaneWriteBudgetMaxRequests(context.getRuntimeConfig?.()),
+    });
     if (budget.allowed) {
       return false;
     }
@@ -858,7 +866,7 @@ export async function handleGatewayRequest(
           retryAfterMs: budget.retryAfterMs,
           details: {
             method: req.method,
-            limit: "3 per 60s",
+            limit: `${budget.maxRequests} per 60s`,
           },
         },
       ),

--- a/src/gateway/server-methods/config.shared-auth.test.ts
+++ b/src/gateway/server-methods/config.shared-auth.test.ts
@@ -439,6 +439,21 @@ describe("config shared auth disconnects", () => {
     expect(payload?.stats?.requiresRestart).toBe(false);
   });
 
+  it("schedules a direct restart for write-budget changes when reload is off", async () => {
+    mockPreviousConfig({
+      gateway: {
+        reload: { mode: "off" },
+        controlPlaneWritesPerMinute: 3,
+      },
+    });
+
+    await runConfigPatch({ gateway: { controlPlaneWritesPerMinute: 60 } });
+
+    expect(scheduleGatewaySigusr1RestartMock).toHaveBeenCalledTimes(1);
+    const payload = restartSentinelMocks.writeRestartSentinel.mock.calls.at(-1)?.[0];
+    expect(payload?.stats?.requiresRestart).toBe(true);
+  });
+
   it("does not schedule a direct restart for hot-mode browser profile config.patch writes", async () => {
     installBrowserReloadRegistry();
     mockPreviousConfig({

--- a/src/gateway/server/plugins-http.suspension-admission.test.ts
+++ b/src/gateway/server/plugins-http.suspension-admission.test.ts
@@ -247,6 +247,7 @@ describe("plugin HTTP suspension admission", () => {
     };
     const context = {
       cron,
+      getRuntimeConfig: () => ({}),
       logGateway: { warn: vi.fn() },
       chatAbortControllers: new Map(),
       chatQueuedTurns: new Map(),


### PR DESCRIPTION
Closes #107980

### What Problem This Solves
The per-identity control-plane write budget is hardcoded at 3 requests per 60s
(`src/gateway/control-plane-rate-limit.ts`). That default is right for interactive
clients, but trusted automation legitimately bursts past it: a fleet provisioner
applying one `config.patch` per customer during a rollout is throttled to one write
every ~48 seconds, serializing the whole operation.

### Why This Change Was Made
Adds `gateway.controlPlaneWritesPerMinute` (integer, range 1–600, default 3 — existing
behavior unchanged). The 60s window and per device|IP bucket keying are untouched,
so every caller stays individually bounded. The value is read from the required live
runtime-config accessor on each request. Its reload rule is `hot`: reload-enabled
gateways publish the updated runtime snapshot, while reload-disabled gateways report
and schedule the required restart instead of persisting a value that cannot become
active. The rate-limit error reports the effective configured limit. Help text and both
doc pages state explicitly that raising the value applies to every identity on the
gateway.

### User Impact
Operators running trusted write-bursting automation (provisioners, fleet controllers)
can tune the budget; everyone else sees identical behavior and an unchanged default.

### Evidence
- *Production validation:* we operate a multi-tenant OpenClaw fleet where a
  provisioner applies one `config.patch` per customer during blue/green rollouts.
  Under the stock 3/60s budget those writes throttle to ~1 per 48s, serializing
  rollouts at ~48s per customer; with a raised per-identity budget (carried as a
  fork patch since June, this dial's ancestor) full rollouts complete with zero
  rate-limit rejections and no observed write-storm side effects.
- Unit: configured max is honored, default stays 3/60s, and the resolver reads
  `gateway.controlPlaneWritesPerMinute`
- Dispatch: config-driven limit end to end, dynamic `"5 per 60s"` error detail, and
  separate bounded budgets for two client identities
- Reload policy: hot classification publishes the new runtime snapshot; reload-off
  `config.patch` coverage proves a direct restart is required and scheduled
- Contract: all request contexts exercised by control-plane writes provide the required
  runtime-config accessor, including plugin-HTTP suspension dispatch
- Config: schema accepts both bounds (1 and 600) and rejects 0, 1.5, and 601; label and FIELD_HELP entries
- 293 exact-head focused tests green across rate limiting, config validation/reload, config-write
  restart policy, and suspension dispatch
- Fresh automated review found no remaining actionable regression after the reload-mode
  and required-context fixes


### Exact-head verification (July 16, 2026)
- Rebased onto current `main` and pushed as `749cb144bacfe3b09fdab992f939bf740d174318`
- Canonical plugin SDK API baseline regenerated and checked
- GitHub CI is green on the exact head
- Fresh full-branch automated review: clean (0.93 confidence)

🤖 Generated with [Claude Code](https://claude.com/claude-code)