### PR TITLE
fix(ci): restore session history types and max-lines gate

### DIFF
--- a/config/max-lines-baseline.txt
+++ b/config/max-lines-baseline.txt
@@ -275,7 +275,6 @@ extensions/qa-matrix/src/runners/contract/scenario-runtime-approval.ts
 extensions/qa-matrix/src/runners/contract/scenario-runtime-e2ee-destructive.ts
 extensions/qa-matrix/src/runners/contract/scenario-runtime-room.ts
 extensions/qa-matrix/src/runners/contract/scenarios.test.ts
-extensions/qa-matrix/src/substrate/client.ts
 extensions/qqbot/src/engine/gateway/outbound-dispatch.test.ts
 extensions/qqbot/src/engine/gateway/outbound-dispatch.ts
 extensions/qqbot/src/engine/messaging/outbound-deliver.ts

--- a/src/gateway/session-history-state.test.ts
+++ b/src/gateway/session-history-state.test.ts
@@ -616,7 +616,7 @@ describe("SessionHistorySseState", () => {
       },
       messageSeq: 4,
     });
-    expect(compaction?.message["__openclaw"]?.turnBoundary).toBeUndefined();
+    expect(compaction?.message?.["__openclaw"]?.turnBoundary).toBeUndefined();
 
     const appended = appendAssistantText(state, "Disk usage crossed 95 percent.", 5);
     expect(appended?.message).toMatchObject({

--- a/src/gateway/session-history-state.ts
+++ b/src/gateway/session-history-state.ts
@@ -19,6 +19,7 @@ import {
 type SessionHistoryTranscriptMeta = {
   idempotencyKey?: string;
   seq?: number;
+  turnBoundary?: boolean;
 };
 
 type SessionHistoryMessage = Record<string, unknown> & {
@@ -39,7 +40,7 @@ type SessionHistorySnapshot = {
 };
 
 type InlineSessionHistoryAppend = {
-  message?: unknown;
+  message?: SessionHistoryMessage;
   messageSeq?: number;
   shouldRefresh?: boolean;
 };


### PR DESCRIPTION
## What Problem This Solves

Restores two deterministic CI gates on `main` that currently block otherwise healthy contributor PRs: test-type compilation for the hidden-turn-boundary session-history regression, and the max-lines ratchet after QA Matrix's client split.

## Why This Change Was Made

The inline history append path already normalizes emitted messages to `SessionHistoryMessage`. Its return type now reflects that invariant, includes the boundary metadata the state machine writes, and the regression assertion safely handles refresh-only results that contain no message. The obsolete QA Matrix baseline entry is removed now that the split source is below the limit.

## User Impact

No runtime behavior change. Maintainers regain green test-types and max-lines gates without weakening session-history coverage or the source-size ratchet.

## Evidence

- Blacksmith Testbox `tbx_01kxhygp2je6tdd6wspkqns6q3`, Actions run `29387618063`
- `pnpm test src/gateway/session-history-state.test.ts`: 21/21 passed
- `pnpm tsgo:test`: passed all core, plugin, and root test-type projects
- Exact hosted CI exposed the stale QA Matrix ratchet entry; the follow-up patch removes only that obsolete entry
- Fresh structured autoreview after the follow-up: clean, no accepted/actionable findings
