### PR TITLE
chore: restore green max-lines ratchet on main

### DIFF
--- a/config/max-lines-baseline.txt
+++ b/config/max-lines-baseline.txt
@@ -275,7 +275,6 @@ extensions/qa-matrix/src/runners/contract/scenario-runtime-approval.ts
 extensions/qa-matrix/src/runners/contract/scenario-runtime-e2ee-destructive.ts
 extensions/qa-matrix/src/runners/contract/scenario-runtime-room.ts
 extensions/qa-matrix/src/runners/contract/scenarios.test.ts
-extensions/qa-matrix/src/substrate/client.ts
 extensions/qqbot/src/engine/gateway/outbound-dispatch.test.ts
 extensions/qqbot/src/engine/gateway/outbound-dispatch.ts
 extensions/qqbot/src/engine/messaging/outbound-deliver.ts


### PR DESCRIPTION
## What Problem This Solves

`main` is red: `checks-fast-max-lines-ratchet` fails on every PR and on `main` itself, so no PR can reach a fully green run.

`#107973` (refactor: privatize QA Matrix and Workspaces internals) shrank `extensions/qa-matrix/src/substrate/client.ts` to 636 lines and removed its `max-lines` suppression, but left the file's entry in `config/max-lines-baseline.txt`. The ratchet treats a baseline entry with no corresponding suppression as stale and exits 1.

## Why This Change Was Made

This is exactly the repair the tool prescribes — its own failure message is "Remove stale max-lines baseline entries (or run with --prune)". The change is the mechanical output of `node scripts/check-max-lines-ratchet.mjs --prune`: one deleted line. The baseline only shrinks, which is the direction the ratchet enforces; no suppression is added and no file is split.

## User Impact

No user-visible or runtime impact. Restores a green `checks-fast-max-lines-ratchet` so PRs can land again.

## Evidence

Failure is reproducible on unmodified `main` (`3eb8b3a`) and on its own CI run [29387539492](https://github.com/openclaw/openclaw/actions/runs/29387539492), where `checks-fast-max-lines-ratchet` is `failure`.

Before, on clean `main`:

```
$ node scripts/check-max-lines-ratchet.mjs; echo "exit=$?"
Remove stale max-lines baseline entries (or run with --prune):
  extensions/qa-matrix/src/substrate/client.ts
exit=1
```

After this one-line prune:

```
$ node scripts/check-max-lines-ratchet.mjs; echo "exit=$?"
max-lines ratchet OK: 1219 grandfathered suppressions.
exit=0
```

The entry is genuinely stale — the file is under the budget and carries no suppression, so removing it does not weaken the gate:

```
$ wc -l < extensions/qa-matrix/src/substrate/client.ts
636
$ rg -c "max-lines" extensions/qa-matrix/src/substrate/client.ts
(no matches)
```
