### PR TITLE
fix(worktrees): prevent session-aware GC regressions

### DIFF
--- a/src/cli/worktrees-cli.test.ts
+++ b/src/cli/worktrees-cli.test.ts
@@ -1,0 +1,37 @@
+import { Command } from "commander";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { managedWorktrees } from "../agents/worktrees/service.js";
+import { resetConfigRuntimeState, setRuntimeConfigSnapshot } from "../config/config.js";
+import type { OpenClawConfig } from "../config/config.js";
+import { isManagedWorktreeOwnerActive } from "../gateway/worktree-owner-activity.js";
+import { defaultRuntime } from "../runtime.js";
+import { registerWorktreesCli } from "./worktrees-cli.js";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  resetConfigRuntimeState();
+});
+
+describe("worktrees cli", () => {
+  it("passes session owner activity and configured limits to gc", async () => {
+    const cfg: OpenClawConfig = {
+      worktrees: { cleanup: { maxCount: 25, maxTotalSizeGb: 50 } },
+    };
+    setRuntimeConfigSnapshot(cfg, cfg);
+    const gc = vi.spyOn(managedWorktrees, "gc").mockResolvedValue({
+      removed: [],
+      orphansDeleted: 0,
+      snapshotsPruned: 0,
+    });
+    vi.spyOn(defaultRuntime, "log").mockImplementation(() => undefined);
+    const program = new Command().name("openclaw");
+    registerWorktreesCli(program);
+
+    await program.parseAsync(["worktrees", "gc"], { from: "user" });
+
+    expect(gc).toHaveBeenCalledWith({
+      limits: { maxCount: 25, maxTotalSizeBytes: 50 * 1024 ** 3 },
+      isOwnerActive: isManagedWorktreeOwnerActive,
+    });
+  });
+});

--- a/src/gateway/server-maintenance.test.ts
+++ b/src/gateway/server-maintenance.test.ts
@@ -9,6 +9,7 @@ import type { ChatAbortControllerEntry } from "./chat-abort.js";
 import { DEDUPE_MAX, DEDUPE_TTL_MS } from "./server-constants.js";
 import { pendingChatSendDedupeKey } from "./server-shared.js";
 import { createGatewayMaintenanceStateForTest } from "./test-helpers.maintenance-state.js";
+import { isManagedWorktreeOwnerActive } from "./worktree-owner-activity.js";
 
 const cleanOldMediaMock = vi.fn(async () => {});
 
@@ -208,7 +209,7 @@ describe("startGatewayMaintenanceTimers", () => {
     const timers = startGatewayMaintenanceTimers(deps);
     await Promise.resolve();
 
-    expect(gc).toHaveBeenCalledWith({ isOwnerActive: expect.any(Function), limits: {} });
+    expect(gc).toHaveBeenCalledWith({ isOwnerActive: isManagedWorktreeOwnerActive, limits: {} });
     stopMaintenanceTimers(timers);
   });
 

--- a/src/gateway/server-methods/worktrees.test.ts
+++ b/src/gateway/server-methods/worktrees.test.ts
@@ -2,6 +2,7 @@ import { expectDefined } from "@openclaw/normalization-core";
 import { describe, expect, it, vi } from "vitest";
 import { WorktreeSnapshotError } from "../../agents/worktrees/service.js";
 import type { ManagedWorktreeRecord } from "../../agents/worktrees/types.js";
+import { isManagedWorktreeOwnerActive } from "../worktree-owner-activity.js";
 import { createWorktreesHandlers } from "./worktrees.js";
 
 const record: ManagedWorktreeRecord = {
@@ -72,7 +73,7 @@ describe("worktrees gateway methods", () => {
     ]);
     expect(service.gc).toHaveBeenCalledWith({
       limits: {},
-      isOwnerActive: expect.any(Function),
+      isOwnerActive: isManagedWorktreeOwnerActive,
     });
 
     expect(service.create).toHaveBeenCalledWith({

--- a/src/gateway/worktree-owner-activity.test.ts
+++ b/src/gateway/worktree-owner-activity.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { IDLE_GC_MS } from "../agents/worktrees/service.js";
+import { isManagedWorktreeOwnerActive } from "./worktree-owner-activity.js";
+
+const mocks = vi.hoisted(() => ({
+  loadSessionEntry: vi.fn(),
+}));
+
+vi.mock("./session-utils.js", () => ({
+  loadSessionEntry: mocks.loadSessionEntry,
+}));
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.clearAllMocks();
+});
+
+describe("isManagedWorktreeOwnerActive", () => {
+  it("recognizes only recently active session owners", () => {
+    const now = 1_800_000_000_000;
+    vi.spyOn(Date, "now").mockReturnValue(now);
+    const entries: Record<string, { lastInteractionAt?: number; updatedAt?: number }> = {
+      "agent:main:live": { lastInteractionAt: now - 1_000 },
+      "agent:main:stale": { updatedAt: now - IDLE_GC_MS - 1 },
+    };
+    mocks.loadSessionEntry.mockImplementation((ownerId: string) => ({
+      entry: entries[ownerId],
+    }));
+
+    expect(isManagedWorktreeOwnerActive("session", "agent:main:live")).toBe(true);
+    expect(isManagedWorktreeOwnerActive("session", "agent:main:stale")).toBe(false);
+    expect(isManagedWorktreeOwnerActive("manual", "agent:main:live")).toBe(false);
+    expect(isManagedWorktreeOwnerActive("session", "agent:main:missing")).toBe(false);
+  });
+
+  it("treats unreadable session state as inactive", () => {
+    mocks.loadSessionEntry.mockImplementation(() => {
+      throw new Error("unreadable session store");
+    });
+
+    expect(isManagedWorktreeOwnerActive("session", "agent:main:live")).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #104108
Supersedes #104146 because GitHub rejected maintainer writes to its fork branch.

## What Problem This Solves

Fixes an issue where manual managed-worktree cleanup could delete an idle-expired worktree while its owning session was still active. The production correction now exists on main through #106224, but the invariant was not pinned at every cleanup entry point, and the original contributor PR could no longer be updated by maintainers.

## Why This Change Was Made

This test-only replacement preserves current main's cleanup-limit implementation and adds focused regression coverage. Scheduled maintenance, the worktrees.gc RPC, and the CLI command must all pass the same Gateway-owned session activity predicate. The predicate tests cover recent, stale, unsupported-owner, missing-session, and unreadable-session state.

The commit preserves RickLin's contribution with a co-author trailer.

## User Impact

No new runtime behavior. The existing session-worktree data-loss fix now has durable coverage across every production GC caller.

## Evidence

- Blacksmith Testbox through Crabbox: tbx_01kxhxzkkpfhgda1tx0qfrky74 ([run 29387245149](https://github.com/openclaw/openclaw/actions/runs/29387245149)).
- Targeted formatting: four files clean.
- Focused tests: 35/35 passed across CLI and Gateway suites.
- check:changed: green, including core-test tsgo and changed-file lint.
- Autoreview: clean on the final patch after each main rebase; no accepted or actionable findings.
- Patch identity remained unchanged across the final rebases.

AI-assisted maintainer rewrite. The original PR, current main implementation, callers, service contract, sibling worktree protections, and tests were reviewed directly.
