### PR TITLE
fix(daemon): distinguish shared and embedded SQLite in system Node warning

### DIFF
--- a/src/daemon/runtime-paths.test.ts
+++ b/src/daemon/runtime-paths.test.ts
@@ -45,9 +45,13 @@ function mockNodePathPresent(...nodePaths: string[]) {
   });
 }
 
-function nodeRuntime(nodeVersion: string, sqliteVersion: string | null = "3.51.3") {
+function nodeRuntime(
+  nodeVersion: string,
+  sqliteVersion: string | null = "3.51.3",
+  nodeSharedSqlite = false,
+) {
   return {
-    stdout: `${JSON.stringify({ nodeVersion, sqliteVersion })}\n`,
+    stdout: `${JSON.stringify({ nodeVersion, sqliteVersion, nodeSharedSqlite })}\n`,
     stderr: "",
   };
 }
@@ -402,6 +406,7 @@ describe("resolveSystemNodeInfo", () => {
       path: darwinNode,
       sqliteVersion: "3.51.3",
       version: "22.22.3",
+      nodeSharedSqlite: false,
       supported: true,
     });
   });
@@ -432,6 +437,7 @@ describe("resolveSystemNodeInfo", () => {
       path: homebrewOptNode,
       sqliteVersion: "3.51.3",
       version: "22.22.3",
+      nodeSharedSqlite: false,
       supported: true,
     });
   });
@@ -456,6 +462,7 @@ describe("resolveSystemNodeInfo", () => {
       path: homebrewOptNode,
       sqliteVersion: "3.51.3",
       version: "24.15.0",
+      nodeSharedSqlite: false,
       supported: true,
     });
     expect(execFile).toHaveBeenCalledTimes(1);
@@ -490,6 +497,7 @@ describe("resolveSystemNodeInfo", () => {
         path: darwinNode,
         sqliteVersion: null,
         version: "18.19.0",
+        nodeSharedSqlite: false,
         supported: false,
       },
       "/Users/me/.fnm/node-22/bin/node",
@@ -504,11 +512,28 @@ describe("resolveSystemNodeInfo", () => {
       path: darwinNode,
       sqliteVersion: "3.51.2",
       version: "24.17.0",
+      nodeSharedSqlite: false,
       supported: false,
     });
 
     expect(warning).toContain("uses SQLite 3.51.2");
     expect(warning).toContain("not WAL-reset-safe");
+    expect(warning).toContain("Install Node 24.15+");
+  });
+
+  it("renders a shared-system-SQLite remediation when Node is supported but the system library is unsafe", () => {
+    const warning = renderSystemNodeWarning({
+      path: "/usr/bin/node",
+      sqliteVersion: "3.51.2",
+      version: "24.17.0",
+      nodeSharedSqlite: true,
+      supported: false,
+    });
+
+    expect(warning).toContain("uses shared system SQLite 3.51.2");
+    expect(warning).toContain("not WAL-reset-safe");
+    expect(warning).toContain("Upgrade the system SQLite library");
+    expect(warning).not.toContain("Install Node 24.15+");
   });
 
   it("uses validated custom Program Files roots on Windows", async () => {

--- a/src/daemon/runtime-paths.ts
+++ b/src/daemon/runtime-paths.ts
@@ -92,12 +92,15 @@ try {
     db.close();
   }
 } catch {}
-process.stdout.write(JSON.stringify({ nodeVersion: process.versions.node, sqliteVersion }));
+const variables = (process.config && process.config.variables) || {};
+const nodeSharedSqlite = variables.node_shared_sqlite === true || variables.node_shared_sqlite === "true";
+process.stdout.write(JSON.stringify({ nodeVersion: process.versions.node, sqliteVersion, nodeSharedSqlite }));
 `;
 
 type NodeRuntimeInfo = {
   nodeVersion: string | null;
   sqliteVersion: string | null;
+  nodeSharedSqlite: boolean;
   supported: boolean;
 };
 
@@ -112,19 +115,22 @@ async function resolveNodeRuntimeInfo(
     const parsed = JSON.parse(stdout) as {
       nodeVersion?: unknown;
       sqliteVersion?: unknown;
+      nodeSharedSqlite?: unknown;
     };
     const nodeVersion = typeof parsed.nodeVersion === "string" ? parsed.nodeVersion : null;
     const sqliteVersion = typeof parsed.sqliteVersion === "string" ? parsed.sqliteVersion : null;
+    const nodeSharedSqlite = parsed.nodeSharedSqlite === true || parsed.nodeSharedSqlite === "true";
     return {
       nodeVersion,
       sqliteVersion,
+      nodeSharedSqlite,
       supported:
         isSupportedNodeVersion(nodeVersion) &&
         sqliteVersion !== null &&
         isSqliteWalResetSafeVersion(sqliteVersion),
     };
   } catch {
-    return { nodeVersion: null, sqliteVersion: null, supported: false };
+    return { nodeVersion: null, sqliteVersion: null, nodeSharedSqlite: false, supported: false };
   }
 }
 
@@ -132,6 +138,7 @@ type SystemNodeInfo = {
   path: string;
   sqliteVersion: string | null;
   version: string | null;
+  nodeSharedSqlite: boolean;
   supported: boolean;
 };
 
@@ -211,6 +218,7 @@ export async function resolveSystemNodeInfo(params: {
       path: systemNode,
       sqliteVersion: runtime.sqliteVersion,
       version: runtime.nodeVersion,
+      nodeSharedSqlite: runtime.nodeSharedSqlite,
       supported: runtime.supported,
     };
     if (info.supported) {
@@ -233,6 +241,12 @@ export function renderSystemNodeWarning(
   const selectedLabel = selectedNodePath ? ` Using ${selectedNodePath} for the daemon.` : "";
   if (isSupportedNodeVersion(systemNode.version)) {
     const sqliteLabel = systemNode.sqliteVersion ?? "unknown";
+    if (systemNode.nodeSharedSqlite) {
+      return (
+        `System Node ${versionLabel} at ${systemNode.path} uses shared system SQLite ${sqliteLabel}, which is not WAL-reset-safe.${selectedLabel} ` +
+        "Upgrade the system SQLite library to 3.51.3+ (or patched 3.50.7+/3.44.6+), or install a Node build that embeds a safe version."
+      );
+    }
     return `System Node ${versionLabel} at ${systemNode.path} uses SQLite ${sqliteLabel}, which is not WAL-reset-safe.${selectedLabel} Install Node 24.15+ (recommended) or Node 22.22.3+ from nodejs.org or Homebrew.`;
   }
   return `System Node ${versionLabel} at ${systemNode.path} is outside the supported range.${selectedLabel} Install Node 24.15+ (recommended) or Node 22.22.3+ from nodejs.org or Homebrew.`;


### PR DESCRIPTION
## What Problem This Solves

#107771 fixed the runtime error message when Node is built with `node_shared_sqlite=true`. The same misleading wording exists in the daemon-install / doctor gateway-services warning path: when a system Node uses a shared SQLite library that is not WAL-reset-safe, `renderSystemNodeWarning` still tells the user to "Install Node 24.15+...", which will not upgrade the system library.

## Why This Change Was Made

- `NODE_RUNTIME_PROBE` now detects `process.config.variables.node_shared_sqlite` (handling GYP string values) and reports it alongside `nodeVersion` and `sqliteVersion`.
- `NodeRuntimeInfo` / `SystemNodeInfo` carry the new `nodeSharedSqlite` field.
- `renderSystemNodeWarning` branches the remediation:
  - **Shared system SQLite** → "uses shared system SQLite ... Upgrade the system SQLite library ..."
  - **Embedded SQLite** → existing "Install Node 24.15+ ..." guidance.

This keeps the daemon install warning consistent with the runtime error fix in #107771.

## User Impact

Users on distro-packaged Node builds (Kali, Debian, Ubuntu, Homebrew with shared SQLite, etc.) who see the daemon-install or `doctor gateway-services` warning will now get actionable remediation instead of being told to reinstall Node.

## Evidence

- Head `2be0a026c18` rebased onto `upstream/main` `29475988dac` (2026-07-16); `node scripts/run-vitest.mjs src/daemon/runtime-paths.test.ts --run` passes 31/31 after the rebase.
- `CI=true pnpm test src/commands/daemon-install-runtime-warning.test.ts src/commands/doctor-gateway-services.test.ts src/commands/daemon-install-helpers.test.ts src/commands/node-daemon-install-helpers.test.ts --run` passes (100/100).
- `pnpm exec oxlint --config .oxlintrc.json src/daemon/runtime-paths.ts src/daemon/runtime-paths.test.ts` clean.
- Live before/after proof through the real `openclaw daemon install --runtime node` workflow on a host whose system libsqlite3 is WAL-reset-unsafe (3.26.0): a real Node 24.15.0 binary probed as the system candidate with its two build-flag-derived facts (`node_shared_sqlite`, `sqlite_version()`) simulated via a `NODE_OPTIONS` preload, because no `--shared-sqlite` Node ≥ 22.22.3 can run on this glibc 2.28 box (details and raw probe outputs in the proof comment below).
  - Before (`upstream/main`): `System Node 24.15.0 at /usr/local/bin/node uses SQLite 3.26.0, which is not WAL-reset-safe. ... Install Node 24.15+ (recommended) or Node 22.22.3+ from nodejs.org or Homebrew.`
  - After (this PR): `System Node 24.15.0 at /usr/local/bin/node uses shared system SQLite 3.26.0, which is not WAL-reset-safe. ... Upgrade the system SQLite library to 3.51.3+ (or patched 3.50.7+/3.44.6+), or install a Node build that embeds a safe version.`
  - Control (PR build, unmodified real binary): no `System Node` warning; service installs cleanly.

Fixes no open issue; this is a follow-up to #107771.
