### PR TITLE
improve: speed CLI capture tests

### DIFF
--- a/src/agents/cli-runner.reliability.test.ts
+++ b/src/agents/cli-runner.reliability.test.ts
@@ -63,6 +63,23 @@ import { MAX_AGENT_HOOK_HISTORY_MESSAGES } from "./harness/hook-history.js";
 
 const MAX_CLI_SESSION_HISTORY_MESSAGES = MAX_AGENT_HOOK_HISTORY_MESSAGES;
 
+// Gateway unit coverage owns quiet-admission timing. These reliability cases only
+// need to drain calls already in flight, so skip the repeated 250 ms quiet window.
+vi.mock("../gateway/mcp-http.loopback-runtime.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../gateway/mcp-http.loopback-runtime.js")>();
+  return {
+    ...actual,
+    waitForMcpLoopbackToolCallCaptureIdle: (
+      captureKey: string,
+      options: Parameters<typeof actual.waitForMcpLoopbackToolCallCaptureIdle>[1],
+    ) =>
+      actual.waitForMcpLoopbackToolCallCaptureIdle(captureKey, {
+        ...options,
+        admissionGraceMs: 0,
+      }),
+  };
+});
+
 vi.mock("../plugins/hook-runner-global.js", () => ({
   getGlobalHookRunner: vi.fn(() => null),
 }));

--- a/src/agents/cli-runner.spawn.test.ts
+++ b/src/agents/cli-runner.spawn.test.ts
@@ -65,6 +65,23 @@ import { setCliRunnerPrepareTestDeps } from "./cli-runner/prepare.js";
 import type { PreparedCliRunContext } from "./cli-runner/types.js";
 import { createClaudeApiErrorFixture } from "./test-helpers/claude-api-error-fixture.js";
 
+// Gateway unit coverage owns quiet-admission timing. These spawn cases only
+// need to drain calls already in flight, so skip the repeated 250 ms quiet window.
+vi.mock("../gateway/mcp-http.loopback-runtime.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../gateway/mcp-http.loopback-runtime.js")>();
+  return {
+    ...actual,
+    waitForMcpLoopbackToolCallCaptureIdle: (
+      captureKey: string,
+      options: Parameters<typeof actual.waitForMcpLoopbackToolCallCaptureIdle>[1],
+    ) =>
+      actual.waitForMcpLoopbackToolCallCaptureIdle(captureKey, {
+        ...options,
+        admissionGraceMs: 0,
+      }),
+  };
+});
+
 vi.mock("../plugin-sdk/anthropic-cli.js", () => ({
   CLAUDE_CLI_BACKEND_ID: "claude-cli",
   isClaudeCliProvider: (providerId: string) => providerId === "claude-cli",


### PR DESCRIPTION
## What Problem This Solves

Two CLI runner test suites spent most of their test-body time waiting for the MCP loopback late-admission grace period, despite testing CLI capture behavior rather than the grace period itself.

## Why This Change Was Made

The suites now partially mock the MCP loopback runtime and force only the test-local admission grace to zero. Production behavior stays unchanged, and the real late-admission timing contract remains covered in `src/gateway/mcp-http.test.ts`.

## User Impact

No user-visible behavior change. Developers and CI get faster focused CLI runner feedback.

## Evidence

- `src/agents/cli-runner.reliability.test.ts`: 2.984s -> 0.818s test-body time (72.6% faster), 79/79 passing.
- `src/agents/cli-runner.spawn.test.ts`: 2.355s -> 1.295s test-body time (45.0% faster), 89/89 passing.
- Combined test-body time: 5.339s -> 2.113s (60.4% faster).
- Exact Testbox run: https://github.com/openclaw/openclaw/actions/runs/29387848457
- `check:changed` reached an inherited stale `extensions/qa-matrix/src/substrate/client.ts` max-lines baseline entry already present on `origin/main`; no failure involved either changed test file.
- Fresh autoreview: clean, confidence 0.95.
