### PR TITLE
test(gateway): type hidden compaction metadata assertion

### DIFF
--- a/src/gateway/session-history-state.test.ts
+++ b/src/gateway/session-history-state.test.ts
@@ -616,7 +616,10 @@ describe("SessionHistorySseState", () => {
       },
       messageSeq: 4,
     });
-    expect(compaction?.message["__openclaw"]?.turnBoundary).toBeUndefined();
+    expect(
+      (compaction?.message as { __openclaw?: { turnBoundary?: boolean } } | undefined)?.__openclaw
+        ?.turnBoundary,
+    ).toBeUndefined();
 
     const appended = appendAssistantText(state, "Disk usage crossed 95 percent.", 5);
     expect(appended?.message).toMatchObject({


### PR DESCRIPTION
## What Problem This Solves

`check-test-types` is red on current `main` after #107965. The new assertion indexes `compaction.message` even though the public append result intentionally exposes `message` as `unknown`.

## Why This Change Was Made

Narrow only the test assertion to the metadata shape it inspects. Runtime code, behavior, and public types remain unchanged.

## User Impact

No runtime impact. Restores the test-type gate so unrelated PRs can reach green CI.

## Evidence

- Blacksmith Testbox `tbx_01kxhzh0r8py8mfbjpbnsxr0rg`: formatting passed.
- Focused `src/gateway/session-history-state.test.ts`: 21/21 tests passed.
- `check:test-types`, `tsgo:scripts`, and `tsgo:test:root`: passed.
- Fresh autoreview: no accepted/actionable findings, correctness confidence 0.99.

## AI Assistance

AI-assisted implementation and review.
