### PR TITLE
fix(ui): show New Session failures in a centered alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Control UI New Session errors:** center creation and cloud-start failures in a themed alert card with an accessible status icon and readable wrapping.
 - **Mattermost progress command details:** accept the documented `streaming.preview.commandText` and `streaming.progress.commandText` modes in channel config validation and bundled metadata. Thanks @shakkernerd.
 - **1Password authorization handoff:** persist nonce-bound pending approvals in shared plugin state so hook and tool execution across broker instances remain single-use and fail closed.
 - **Control UI chat transcripts:** preserve loaded history across session and pane returns, bound automatic backscroll loading, virtualize long transcripts, retain hidden native run boundaries, and keep prepends, streaming, and responsive layouts from flickering or jumping. Thanks @shakkernerd.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Control UI New Session errors:** center creation and cloud-start failures in a themed alert card with an accessible status icon and readable wrapping.
 - **Mattermost progress command details:** accept the documented `streaming.preview.commandText` and `streaming.progress.commandText` modes in channel config validation and bundled metadata. Thanks @shakkernerd.
 - **1Password authorization handoff:** persist nonce-bound pending approvals in shared plugin state so hook and tool execution across broker instances remain single-use and fail closed.
 - **Control UI chat transcripts:** preserve loaded history across session and pane returns, bound automatic backscroll loading, virtualize long transcripts, retain hidden native run boundaries, and keep prepends, streaming, and responsive layouts from flickering or jumping. Thanks @shakkernerd.

--- a/ui/src/e2e/new-session-page.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.e2e.test.ts
@@ -798,6 +798,22 @@ describeControlUiE2e("Control UI new-session page mocked Gateway E2E", () => {
       await expect
         .poll(() => page.locator(".new-session-page__error").textContent())
         .toContain("cloud worker placement could not be verified");
+      const alert = page.locator(".new-session-page__alert");
+      await expect.poll(() => alert.getAttribute("role")).toBe("alert");
+      await expect.poll(() => alert.locator("svg").count()).toBe(1);
+      const [alertBox, composerBox] = await Promise.all([
+        alert.boundingBox(),
+        page.locator(".new-session-page__composer").boundingBox(),
+      ]);
+      expect(alertBox).not.toBeNull();
+      expect(composerBox).not.toBeNull();
+      expect(
+        Math.abs(
+          (alertBox?.x ?? 0) +
+            (alertBox?.width ?? 0) / 2 -
+            ((composerBox?.x ?? 0) + (composerBox?.width ?? 0) / 2),
+        ),
+      ).toBeLessThanOrEqual(1);
       await expect.poll(() => startButton.isDisabled()).toBe(false);
       await page.getByRole("button", { name: "Start session" }).click();
       await expect

--- a/ui/src/pages/new-session/new-session-page.ts
+++ b/ui/src/pages/new-session/new-session-page.ts
@@ -6,6 +6,7 @@ import { applicationContext, type ApplicationContext } from "../../app/context.t
 import { beginNativeWindowDragFromTopInset } from "../../app/native-window-drag.ts";
 import { hasOperatorAdminAccess } from "../../app/operator-access.ts";
 import { loadSettings } from "../../app/settings.ts";
+import { icons } from "../../components/icons.ts";
 import "../../components/tooltip.ts";
 import "../../components/web-awesome-popover.ts";
 import "../../components/web-awesome-select.ts";
@@ -41,6 +42,15 @@ import { retainRejectedInitialTurn } from "./rejected-initial-turn.ts";
 import { renderAgentSelect, renderFolderSelect, renderWhereSelect } from "./target-controls.ts";
 
 const CATALOG_RETRY_DELAYS_MS = [0, 1_000, 3_000] as const;
+
+function renderDraftError(message: string) {
+  return html`
+    <div class="callout danger new-session-page__error new-session-page__alert" role="alert">
+      <span class="new-session-page__alert-icon" aria-hidden="true">${icons.alertTriangle}</span>
+      <span class="callout__content new-session-page__alert-message">${message}</span>
+    </div>
+  `;
+}
 
 class NewSessionPage extends OpenClawLightDomElement {
   @property({ attribute: false }) data: NewSessionRouteData | undefined;
@@ -1215,12 +1225,10 @@ class NewSessionPage extends OpenClawLightDomElement {
     return html`
       <div class="new-session-page__draft" aria-busy=${String(this.submitting)}>
         ${this.renderTargetBar()}
-        ${worktreeNameInvalid
-          ? html`<div class="new-session-page__error">${t("newSession.worktreeNameInvalid")}</div>`
-          : nothing}
-        ${this.error ? html`<div class="new-session-page__error">${this.error}</div>` : nothing}
+        ${worktreeNameInvalid ? renderDraftError(t("newSession.worktreeNameInvalid")) : nothing}
+        ${this.error ? renderDraftError(this.error) : nothing}
         ${this.submissionOutcomeUnknown
-          ? html`<div class="new-session-page__error">${t("newSession.createOutcomeUnknown")}</div>`
+          ? renderDraftError(t("newSession.createOutcomeUnknown"))
           : nothing}
         ${renderNewSessionDraftComposer({
           agentDefaultModel: this.selectedAgent()?.model?.primary,

--- a/ui/src/styles/new-session.css
+++ b/ui/src/styles/new-session.css
@@ -361,9 +361,52 @@ wa-popover.new-session-page__select--folder::part(body) {
   border-top: 1px solid var(--border);
 }
 
-.new-session-page__error {
+.new-session-page__browser > .new-session-page__error {
+  padding: 8px 10px 0;
   font-size: 12px;
   color: var(--danger);
+}
+
+.new-session-page__alert {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  width: fit-content;
+  max-width: min(48rem, calc(100% - 36px));
+  margin: 4px auto 2px;
+  padding: 10px 12px;
+  box-sizing: border-box;
+  text-align: left;
+  box-shadow: 0 8px 24px color-mix(in srgb, var(--danger) 8%, transparent);
+}
+
+.new-session-page__alert-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  background: color-mix(in srgb, var(--danger) 14%, transparent);
+  color: var(--danger);
+}
+
+.new-session-page__alert-icon svg {
+  width: 15px;
+  height: 15px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.8;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.new-session-page__alert-message {
+  min-width: 0;
+  padding-top: 3px;
+  line-height: 1.45;
+  overflow-wrap: anywhere;
 }
 
 .new-session-page__browser-use {


### PR DESCRIPTION
Closes #107992

## What Problem This Solves

Fixes an issue where users whose New Session creation or cloud startup failed would see a plain red sentence stretched across the page, visually detached from the centered workflow.

## Why This Change Was Made

Draft failures now use the existing danger-callout design with a dedicated status icon, alert semantics, centered bounded layout, and safe wrapping for long backend messages. Folder-browser errors remain compact and inline instead of inheriting the page-level presentation.

## User Impact

New Session failures are easier to notice and scan, stay centered with the composer, and remain readable on narrow screens. Retry behavior and backend error text are unchanged.

## Evidence

- Before: live Chrome observation showed the failure as an uncontained, left-aligned red line across `/new`.
- After: an existing-profile Chrome design check using the exact branch markup and CSS showed one alert with a status icon and a 0 px centerline offset from the composer.
- Focused Blacksmith Testbox UI E2E: `corepack pnpm test:ui:e2e -- ui/src/e2e/new-session-page.e2e.test.ts` — 28/28 passed. The cloud-failure test asserts `role="alert"`, icon presence, centered geometry, and successful retry. Run: https://github.com/openclaw/openclaw/actions/runs/29388489969
- Final exact-head hosted CI: all checks passed on `e7fe07166589eb5add270da16bc95ac365668dbc`. Run: https://github.com/openclaw/openclaw/actions/runs/29388945137
- Fresh exact-head branch autoreview: clean, no accepted or actionable findings.
- `git diff --check`: clean.

AI-assisted implementation; reviewed and validated against the affected UI flow.
