### PR TITLE
fix(macos): restore app builds on current Swift

### DIFF
--- a/apps/macos/Package.resolved
+++ b/apps/macos/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "1ef8c3159f08d9e5b942aecae21c4a350abc8b3f799fa1ea8cbcaf50ad1792f6",
+  "originHash" : "36b4eed5f0ab5307178cd25e14c3a22f00a5227b5dd462f297531ed701cfa7ef",
   "pins" : [
     {
       "identity" : "axorcist",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/steipete/AXorcist.git",
       "state" : {
-        "revision" : "289d403c53ce26cdd2fcb2bfb8672cd43adc2b43",
-        "version" : "0.1.2"
+        "revision" : "20d360e9f7a77b45a6ed3a25622e03029159e96c",
+        "version" : "0.1.4"
       }
     },
     {
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/steipete/Commander.git",
       "state" : {
-        "revision" : "ae2ce746b386ff94b26648cfe5625cfa8d02639b",
-        "version" : "0.2.2"
+        "revision" : "b9fb00564aa3229deeb48090801fec2c185951f4",
+        "version" : "0.2.3"
       }
     },
     {
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/steipete/Peekaboo.git",
       "state" : {
-        "revision" : "e3a2b3793fe4c4a6b4ccbc3069ccd9816516edb7",
-        "version" : "3.9.0"
+        "revision" : "3cfd612adbcb1b43e8431a7a1f3b02ec45d01269",
+        "version" : "3.9.3"
       }
     },
     {

--- a/apps/macos/Package.swift
+++ b/apps/macos/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
         .package(url: "https://github.com/swiftlang/swift-subprocess.git", from: "0.4.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.12.0"),
         .package(url: "https://github.com/sparkle-project/Sparkle", from: "2.9.0"),
-        .package(url: "https://github.com/steipete/Peekaboo.git", exact: "3.9.0"),
+        .package(url: "https://github.com/steipete/Peekaboo.git", exact: "3.9.3"),
         .package(url: "https://github.com/pointfreeco/swift-concurrency-extras", from: "1.3.1"),
         .package(path: "../shared/OpenClawKit"),
         .package(path: "../shared/OpenClawMLXTTSProtocol"),

--- a/apps/swabble/Package.swift
+++ b/apps/swabble/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
         .executable(name: "swabble", targets: ["SwabbleCLI"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/steipete/Commander.git", exact: "0.2.2"),
+        .package(url: "https://github.com/steipete/Commander.git", exact: "0.2.3"),
         .package(url: "https://github.com/apple/swift-testing", from: "6.3.1"),
     ],
     targets: [


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where building the macOS app with current Swift 6 toolchains failed inside Peekaboo 3.9.0 because its AXorcist dependency exposed actor-isolated error descriptions.

## Why This Change Was Made

Updates Peekaboo to 3.9.3, which carries the AXorcist 0.1.4 compatibility fix, and aligns Swabble on Commander 0.2.3 so SwiftPM resolves one consistent dependency graph.

## User Impact

Developers and live-update automation can build the macOS app again. No runtime behavior changes.

## Evidence

- `swift package resolve` succeeds with Peekaboo 3.9.3, AXorcist 0.1.4, and Commander 0.2.3.
- Exact arm64 OpenClaw Swift product build succeeds under Xcode 27 beta; the former `ActionInputDriver.swift` actor-isolation error is gone.
- Autoreview clean: no accepted or actionable findings.
