### PR TITLE
chore(ci): repair Discord refactor gates

### DIFF
--- a/config/max-lines-baseline.txt
+++ b/config/max-lines-baseline.txt
@@ -89,7 +89,6 @@ extensions/device-pair/index.test.ts
 extensions/device-pair/index.ts
 extensions/diagnostics-otel/src/service.test.ts
 extensions/diagnostics-prometheus/src/service.ts
-extensions/discord/src/actions/runtime.guild.ts
 extensions/discord/src/actions/runtime.test.ts
 extensions/discord/src/channel.ts
 extensions/discord/src/monitor.test.ts

--- a/extensions/discord/src/monitor/message-channel-info-state.ts
+++ b/extensions/discord/src/monitor/message-channel-info-state.ts
@@ -1,4 +1,4 @@
-import type { DiscordChannelInfo } from "./message-channel-info.js";
+import type { DiscordChannelInfo } from "./message-channel-info-types.js";
 
 export const discordChannelInfoCacheState = {
   entries: new Map<string, { value: DiscordChannelInfo | null; expiresAt: number }>(),

--- a/extensions/discord/src/monitor/message-channel-info-types.ts
+++ b/extensions/discord/src/monitor/message-channel-info-types.ts
@@ -1,0 +1,13 @@
+import type { ChannelType } from "../internal/discord.js";
+
+export type DiscordChannelInfo = {
+  type: ChannelType;
+  name?: string;
+  topic?: string;
+  parentId?: string;
+  ownerId?: string;
+};
+
+export type DiscordChannelInfoClient = {
+  fetchChannel(channelId: string): Promise<unknown>;
+};

--- a/extensions/discord/src/monitor/message-channel-info.ts
+++ b/extensions/discord/src/monitor/message-channel-info.ts
@@ -9,17 +9,9 @@ import { normalizeOptionalStringifiedId } from "openclaw/plugin-sdk/string-coerc
 import type { ChannelType, Message } from "../internal/discord.js";
 import { resolveDiscordChannelInfoSafe } from "./channel-access.js";
 import { discordChannelInfoCacheState } from "./message-channel-info-state.js";
+import type { DiscordChannelInfo, DiscordChannelInfoClient } from "./message-channel-info-types.js";
 
-export type DiscordChannelInfo = {
-  type: ChannelType;
-  name?: string;
-  topic?: string;
-  parentId?: string;
-  ownerId?: string;
-};
-export type DiscordChannelInfoClient = {
-  fetchChannel(channelId: string): Promise<unknown>;
-};
+export type { DiscordChannelInfo, DiscordChannelInfoClient } from "./message-channel-info-types.js";
 
 type DiscordMessageWithChannelId = Message & {
   channel_id?: unknown;


### PR DESCRIPTION
## What Problem This Solves

Current `main` fails two CI gates after #108003:

- `checks-fast-max-lines-ratchet` sees the removed `runtime.guild.ts` suppression as a stale baseline entry.
- `check-additional-runtime-topology-architecture` sees a Madge cycle between `message-channel-info-state.ts` and `message-channel-info.ts`.

## Why This Change Was Made

Remove the one stale max-lines baseline entry. Extract the shared Discord channel-info types into a leaf module so the cache state no longer type-imports its runtime owner.

## User Impact

No runtime behavior change. Restores both CI gates so unrelated PRs can land.

## Evidence

- Exact failing main-derived PR run: https://github.com/openclaw/openclaw/actions/runs/29389029137
- Blacksmith changed-surface gate: https://github.com/openclaw/openclaw/actions/runs/29389505796 — passed; max-lines ratchet, format, extension production/test types, lint, dependency guards, and runtime import-cycle check.
- `node --import tsx scripts/check-madge-import-cycles.ts`: passed, 0 cycles.
- `node scripts/run-vitest.mjs extensions/discord/src/monitor/message-utils.test.ts extensions/discord/src/monitor/threading.parent-info.test.ts`: 53 tests passed.
- `git diff --check`: passed.
- Fresh autoreview: clean, no accepted/actionable findings; 0.98 correctness confidence.

AI-assisted: yes.
