### PR TITLE
fix(tasks): key cancel button state by taskId to match the cancel action

### DIFF
--- a/ui/src/pages/tasks/tasks-page.test.ts
+++ b/ui/src/pages/tasks/tasks-page.test.ts
@@ -1,9 +1,11 @@
+import { html, render } from "lit";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { GatewayBrowserClient, GatewayEventFrame } from "../../api/gateway.ts";
 import { sessionRefFromPath } from "../../app-session-route-paths.ts";
 import type { ApplicationContext, ApplicationGatewaySnapshot } from "../../app/context.ts";
 import type { TaskStatus, TaskSummary } from "../../lib/tasks/data.ts";
 import "./tasks-page.ts";
+import { renderTasks } from "./view.ts";
 
 type TasksPageTestElement = HTMLElement & {
   context: ApplicationContext;
@@ -297,6 +299,45 @@ describe("TasksPage concurrent refresh events", () => {
     await pending;
 
     expect(refresh.page.tasks.map((task) => task.id)).toEqual(["task-after-reconnect"]);
+  });
+});
+
+describe("Tasks view cancellation rendering", () => {
+  it("renders cancellation state by taskId when the row id differs", () => {
+    const task: TaskSummary = {
+      id: "row-id",
+      taskId: "cancel-id",
+      status: "running",
+      runtime: "subagent",
+      title: "Map codebase",
+      createdAt: 1_000,
+      updatedAt: 2_000,
+    };
+    const container = document.createElement("div");
+    document.body.append(container);
+    render(
+      html`${renderTasks({
+        basePath: "",
+        agentId: "main",
+        mainKey: "main",
+        connected: true,
+        canCancel: true,
+        loading: false,
+        error: null,
+        tasks: [task],
+        cancellingTaskIds: new Set(["cancel-id"]),
+        sessionRow: () => undefined,
+        onCancel: () => {},
+        onNavigateToChat: () => {},
+      })}`,
+      container,
+    );
+
+    const cancel = container.querySelector<HTMLButtonElement>(
+      '[data-task-id="row-id"] button[aria-label="Cancel Map codebase"]',
+    );
+    expect(cancel?.disabled).toBe(true);
+    expect(cancel?.textContent?.trim()).toBe("Cancelling…");
   });
 });
 

--- a/ui/src/pages/tasks/tasks.e2e.test.ts
+++ b/ui/src/pages/tasks/tasks.e2e.test.ts
@@ -1,4 +1,4 @@
-import { copyFile, mkdir, rm } from "node:fs/promises";
+import { copyFile, mkdir, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { chromium, type Browser } from "playwright";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
@@ -32,8 +32,8 @@ const runningTask = {
 };
 
 const queuedTask = {
-  id: "task-queued",
-  taskId: "task-queued",
+  id: "task-queued-row",
+  taskId: "task-queued-cancel",
   kind: "cron",
   runtime: "cron",
   status: "queued",
@@ -102,6 +102,7 @@ describeControlUiE2e("Control UI Tasks mocked Gateway E2E", () => {
     const video = page.video();
     try {
       const gateway = await installMockGateway(page, {
+        deferredMethods: ["tasks.cancel"],
         methodResponses: {
           "tasks.list": {
             tasks: [runningTask, queuedTask, completedTask, failedTask],
@@ -119,7 +120,7 @@ describeControlUiE2e("Control UI Tasks mocked Gateway E2E", () => {
       const active = page.locator('[data-task-section="active"]');
       const recent = page.locator('[data-task-section="recent"]');
       await active.locator('[data-task-id="task-running"]').waitFor({ state: "visible" });
-      await active.locator('[data-task-id="task-queued"]').waitFor({ state: "visible" });
+      await active.locator('[data-task-id="task-queued-row"]').waitFor({ state: "visible" });
       await recent.locator('[data-task-id="task-completed"]').waitFor({ state: "visible" });
       await recent.locator('[data-task-id="task-failed"]').waitFor({ state: "visible" });
       expect(await active.textContent()).toContain("Reading subscription paths");
@@ -146,12 +147,40 @@ describeControlUiE2e("Control UI Tasks mocked Gateway E2E", () => {
         fullPage: true,
       });
 
-      await active
-        .locator('[data-task-id="task-queued"]')
-        .getByRole("button", { name: "Cancel Nightly cleanup" })
-        .click();
+      const queuedCancel = active
+        .locator('[data-task-id="task-queued-row"]')
+        .getByRole("button", { name: "Cancel Nightly cleanup" });
+      await queuedCancel.click();
       const cancelRequest = await gateway.waitForRequest("tasks.cancel");
-      expect(cancelRequest.params).toEqual({ taskId: "task-queued" });
+      expect(cancelRequest.params).toEqual({ taskId: "task-queued-cancel" });
+      await expect
+        .poll(async () => ({
+          disabled: await queuedCancel.isDisabled(),
+          text: (await queuedCancel.textContent())?.trim(),
+        }))
+        .toEqual({ disabled: true, text: "Cancelling…" });
+      await writeFile(
+        path.join(artifactDir, "03-cancelling-id-taskid-mismatch.json"),
+        `${JSON.stringify(
+          {
+            cancellationRequest: cancelRequest.params,
+            observedButton: {
+              disabled: await queuedCancel.isDisabled(),
+              text: (await queuedCancel.textContent())?.trim(),
+            },
+            rowId: queuedTask.id,
+            taskId: queuedTask.taskId,
+          },
+          null,
+          2,
+        )}\n`,
+      );
+      await page.screenshot({
+        path: path.join(artifactDir, "03-cancelling-id-taskid-mismatch.png"),
+        fullPage: true,
+      });
+      await gateway.resolveDeferred("tasks.cancel");
+      await recent.locator('[data-task-id="task-queued-row"]').waitFor({ state: "visible" });
     } finally {
       await context.close();
       if (video) {

--- a/ui/src/pages/tasks/view.ts
+++ b/ui/src/pages/tasks/view.ts
@@ -76,7 +76,7 @@ function renderTask(task: TaskSummary, props: TasksProps) {
   const timestamp = taskTimestampMs(task.updatedAt ?? task.createdAt);
   const detail = taskDetail(task);
   const title = taskTitle(task);
-  const cancelling = props.cancellingTaskIds.has(task.id);
+  const cancelling = props.cancellingTaskIds.has(task.taskId);
   return html`
     <div class="list-item" data-task-id=${task.id}>
       <div class="list-main">


### PR DESCRIPTION
## What Problem This Solves

The Tasks page uses two identifiers for one cancellation interaction:

- the Cancel action passes `task.taskId` and the in-flight set is keyed by that cancellation identifier;
- the renderer previously queried that set with the row identity, `task.id`.

The wire schema permits the fields to differ. A client receiving `{ id: "row-id", taskId: "cancel-id" }` could send the correct cancellation request while leaving its matching button enabled and labeled `Cancel` during the request.

## Why This Change Was Made

The Tasks page now queries `cancellingTaskIds` with `task.taskId`, matching the existing value passed to `onCancel`.

During the rebase, current main had already moved the chat rail to a canonical `task.id` lifecycle for action, pending state, details, and events. This PR intentionally retains that newer chat architecture and only changes the still-inconsistent Tasks page path. Row/DOM identity remains `task.id`; cancellation action identity on this page remains `task.taskId`.

## User Impact

When a protocol-valid task has distinct row and cancellation IDs, the Tasks page immediately disables the matching Cancel button and displays `Cancelling…` during the `tasks.cancel` round trip. Tasks with equal IDs behave unchanged.

## Evidence

### Exact-head browser proof

A GitHub-hosted Ubuntu 24.04 / Node 24 / Playwright Chromium run exercised the real Control UI `/tasks` route with a deterministic mocked Gateway. The visible-state proof below was captured against an earlier head; after `main` advanced, the branch was rebased onto the latest `main` (exact head now `8e294c36ff71058bd67040bdbec9b73004f77e33`), which required two compatibility fixes the rebase surfaced: `main` made `agentId`, `mainKey`, and `sessionRow` required on `TasksProps`, so the rendering regression test now supplies them. The cancellation identity fix and the divergent-id E2E assertion are unchanged.

- Proof run: https://github.com/miorbnli/openclaw/actions/runs/29684588803
- Artifact: https://github.com/miorbnli/openclaw/actions/runs/29684588803/artifacts/8441693609
- Files:
  - `03-cancelling-id-taskid-mismatch.png` — visible `Nightly cleanup` button disabled as `Cancelling…` while cancellation is pending.
  - `tasks-flow.webm` — recorded full browser interaction.
  - `03-cancelling-id-taskid-mismatch.json` — redacted diagnostics: DOM row ID `task-queued-row`; requested/in-flight cancellation ID `task-queued-cancel`; observed button `{ disabled: true, text: "Cancelling…" }`.
  - `SHA256SUMS` and `manifest.json` — hash binding and exact-head/environment metadata.

The browser test defers `tasks.cancel`, asserts its request payload is `{ taskId: "task-queued-cancel" }`, verifies the `data-task-id="task-queued-row"` button state before resolving that response, then captures the evidence. It uses no provider keys, real Gateway, or channel credentials.

### Regression and CI

- Focused rendering regression uses `id: "row-id"`, `taskId: "cancel-id"`, and an in-flight set containing `cancel-id`; it asserts that the row-id control is disabled and displays `Cancelling…`. Now also supplies the `agentId`/`mainKey`/`sessionRow` props that `main` made required on `TasksProps`.
- The committed Tasks E2E makes the divergent-ID browser proof reproducible in the normal Control UI E2E lane.
- Local focused run on the rebased head: `node scripts/run-vitest.mjs ui/src/pages/tasks/tasks-page.test.ts` → 11 passed. `tsgo:ui` and `tsgo:test:ui` clean.
- Exact-head upstream CI is running against `8e294c36` after the rebase; required check results will reflect on the PR once the lane completes.

## Risk checklist

- [x] One concern, one PR: Tasks page cancellation pending-state identity.
- [x] No config/env/default surface change.
- [x] No SDK/protocol/auth/provider behavior change.
- [x] Backward compatible when `id === taskId`.
- [x] No new dependencies or CHANGELOG edit.
- [x] Current-main chat task identity architecture remains unchanged.
- [x] Allow edits by maintainers.

