### PR TITLE
improve: speed doctor host compatibility tests

### DIFF
--- a/src/commands/doctor/shared/context-engine-host-compat.test.ts
+++ b/src/commands/doctor/shared/context-engine-host-compat.test.ts
@@ -1,5 +1,5 @@
 // Context engine host compatibility tests cover doctor warnings for host/context mismatches.
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import {
   getContextEngineFactory,
@@ -12,6 +12,36 @@ import {
   collectContextEngineHostCompatibilityWarnings,
   maybeRepairContextEngineHostCompatibility,
 } from "./context-engine-host-compat.js";
+
+vi.mock("../../../agents/agent-scope-config.js", () => ({
+  resolveDefaultAgentDir: vi.fn(() => "/tmp/openclaw-doctor-host-compat"),
+}));
+
+vi.mock("../../../agents/cli-backends.js", () => ({
+  resolveCliBackendConfig: vi.fn((runtimeId: string) => ({ id: runtimeId })),
+}));
+
+vi.mock("../../../agents/harness/policy.js", () => ({
+  resolveAgentHarnessPolicy: vi.fn(
+    (params: { config: OpenClawConfig; modelId: string; provider: string }) => ({
+      runtime:
+        params.config.agents?.defaults?.models?.[`${params.provider}/${params.modelId}`]
+          ?.agentRuntime?.id ?? "openclaw",
+    }),
+  ),
+}));
+
+vi.mock("../../../agents/harness/registry.js", () => ({
+  getRegisteredAgentHarness: vi.fn(() => undefined),
+}));
+
+vi.mock("../../../context-engine/init.js", () => ({
+  ensureContextEnginesInitialized: vi.fn(),
+}));
+
+vi.mock("../../../plugins/runtime/runtime-registry-loader.js", () => ({
+  ensurePluginRegistryLoaded: vi.fn(),
+}));
 
 let engineCounter = 0;
 


### PR DESCRIPTION
## What Problem This Solves

The six doctor host-compatibility tests spent 4.80 seconds in their test bodies because they initialized real runtime, backend, harness, context-engine, and plugin-registry dependencies outside the unit's decision boundary.

## Why This Change Was Made

The suite now mocks those dependency seams with deterministic host-policy answers while keeping the real context-engine registry and doctor compatibility logic under test. Production code and behavior are unchanged.

## User Impact

No user-visible behavior change. Developers and CI get substantially faster doctor test feedback.

## Evidence

- 6/6 focused tests passing before and after.
- Test-body time: 4.80s -> 146ms (97.0% faster).
- Whole Vitest file: 8.74s -> 1.17s (86.6% faster).
- The two slow assertions fell from 1.073s and 3.719s to 28ms and 1ms.
- Baseline Testbox: https://github.com/openclaw/openclaw/actions/runs/29388943575
- Optimized Testbox: https://github.com/openclaw/openclaw/actions/runs/29389050144
- `check:changed` reached an inherited stale `extensions/discord/src/actions/runtime.guild.ts` max-lines baseline entry already present on `origin/main`; no failure involved the changed test file.
- Fresh autoreview: clean, confidence 0.94.
