### PR TITLE
fix(ui): show <1m for sub-minute quota reset windows instead of 0m

### DIFF
--- a/ui/src/lib/provider-quota-summary.test.ts
+++ b/ui/src/lib/provider-quota-summary.test.ts
@@ -18,8 +18,9 @@ describe("formatQuotaReset", () => {
   it("returns <1m for sub-minute reset windows instead of 0m", () => {
     vi.spyOn(Date, "now").mockReturnValue(Date.parse("2026-05-30T12:00:00.000Z"));
 
-    expect(formatQuotaReset(Date.now() + 30_000)).toBe("<1m");
+    expect(formatQuotaReset(Date.now() + 1)).toBe("<1m");
     expect(formatQuotaReset(Date.now() + 59_999)).toBe("<1m");
+    expect(formatQuotaReset(Date.now() + 60_000)).toBe("1m");
   });
 
   it("ignores Date-invalid reset timestamps", () => {

--- a/ui/src/lib/provider-quota-summary.test.ts
+++ b/ui/src/lib/provider-quota-summary.test.ts
@@ -15,6 +15,13 @@ describe("formatQuotaReset", () => {
     expect(formatQuotaReset(Date.now() + 2 * 60 * 60_000 + 15 * 60_000)).toBe("2h 15m");
   });
 
+  it("returns <1m for sub-minute reset windows instead of 0m", () => {
+    vi.spyOn(Date, "now").mockReturnValue(Date.parse("2026-05-30T12:00:00.000Z"));
+
+    expect(formatQuotaReset(Date.now() + 30_000)).toBe("<1m");
+    expect(formatQuotaReset(Date.now() + 59_999)).toBe("<1m");
+  });
+
   it("ignores Date-invalid reset timestamps", () => {
     expect(formatQuotaReset(8_640_000_000_000_001)).toBeNull();
     expect(formatQuotaReset(Number.POSITIVE_INFINITY)).toBeNull();

--- a/ui/src/lib/provider-quota-summary.test.ts
+++ b/ui/src/lib/provider-quota-summary.test.ts
@@ -18,6 +18,8 @@ describe("formatQuotaReset", () => {
   it("returns <1m for sub-minute reset windows instead of 0m", () => {
     vi.spyOn(Date, "now").mockReturnValue(Date.parse("2026-05-30T12:00:00.000Z"));
 
+    expect(formatQuotaReset(Date.now() - 1)).toBe("now");
+    expect(formatQuotaReset(Date.now())).toBe("now");
     expect(formatQuotaReset(Date.now() + 1)).toBe("<1m");
     expect(formatQuotaReset(Date.now() + 59_999)).toBe("<1m");
     expect(formatQuotaReset(Date.now() + 60_000)).toBe("1m");

--- a/ui/src/lib/provider-quota-summary.ts
+++ b/ui/src/lib/provider-quota-summary.ts
@@ -12,6 +12,9 @@ export function formatQuotaReset(resetAt?: number): string | null {
     return "now";
   }
   const minutes = Math.floor(diffMs / 60_000);
+  if (minutes < 1) {
+    return "<1m";
+  }
   if (minutes < 60) {
     return `${minutes}m`;
   }


### PR DESCRIPTION
## What Problem This Solves

`formatQuotaReset` (`ui/src/lib/provider-quota-summary.ts`) renders the compact reset label for each provider quota window in the chat context-usage popover. Positive reset windows below one minute were floored to zero, so the Control UI displayed **`Resets 0m`** even though the reset was still in the future.

## Why This Change Was Made

- **Root cause:** the minute branch used `Math.floor(diffMs / 60_000)` without handling the positive sub-minute interval.
- **Fix:** return `<1m` for `1..59,999ms`, matching the established `formatRelativeTimestamp` convention while preserving `now` for elapsed windows and `1m` at exactly 60 seconds.
- **Boundary coverage:** the regression test fixes time and covers past, exactly now, `+1ms`, `+59,999ms`, and exactly `+60,000ms`, plus the existing invalid-timestamp cases.

This is the UI formatter's owner boundary. Provider timestamps, Gateway payloads, and normalization contracts are unchanged.

## User Impact

The quota popover now shows `Resets <1m` instead of `Resets 0m` during the final minute before reset. Minute-or-longer windows render exactly as before.

## Linked context

N/A (no existing issue).

## Evidence

**Terminal capture from a GitHub-hosted Node 24 + Playwright Chromium run using the real Control UI `/chat` route and deterministic mocked Gateway data:**

```text
BEFORE: .context-usage__limit-reset = "Resets 0m"
AFTER:  .context-usage__limit-reset = "Resets <1m"
Playwright assertion: passed
```

### UI before/after screenshots

- Proof run: https://github.com/miorbnli/openclaw/actions/runs/29400428645
- Screenshot artifact: https://github.com/miorbnli/openclaw/actions/runs/29400428645/artifacts/8336903133
- Files: `quota/before-quota-reset.png`, `quota/after-quota-reset.png`
- Artifact manifest binds this proof to exact PR head `9bf81514c76ae565745fa3fdce2f7da63542b3d8`; SHA-256 checksums are included.

| # | Field | Value |
|---|---|---|
| 1 | Behavior or issue addressed | A future reset below 60 seconds rendered as `Resets 0m`. |
| 2 | Real environment tested | GitHub-hosted Ubuntu 24.04, Node 24, Playwright Chromium, exact head `9bf81514c76ae565745fa3fdce2f7da63542b3d8`. |
| 3 | Exact steps or command run | Started the real Control UI E2E server, installed the mocked Gateway before navigation, opened `/chat`, expanded the context-usage popover, and asserted/screenshot `.context-usage__limit-reset` before and after the production formatter change. |
| 4 | Evidence after fix | Terminal output and screenshot artifact above show `Resets <1m`. |
| 5 | Observed result after fix | The visible quota row distinguishes a still-future sub-minute reset from an elapsed reset. |
| 6 | What was not tested | Live provider credentials/API data; deterministic Gateway data exercises the actual browser rendering path without secrets or timing drift. |

## Tests and validation

- Exact-head hosted CI: https://github.com/openclaw/openclaw/actions/runs/29398476148
  - `openclaw/ci-gate`: success
  - `checks-ui`: success
  - `check-lint`: success
  - `checks-fast-max-lines-ratchet`: success
- Real behavior proof check: https://github.com/openclaw/openclaw/actions/runs/29398474718
- Focused regression: `ui/src/lib/provider-quota-summary.test.ts` covers the complete elapsed/sub-minute/exact-minute boundary.
- Visual proof: real Control UI + mocked Gateway Playwright assertions and screenshots passed in the run linked above.

## Risk checklist

- [x] One concern, one PR: only quota reset presentation.
- [x] No config/env/default surface change.
- [x] No SDK/protocol/auth/provider behavior change.
- [x] Backward compatible: durations at or above one minute are unchanged.
- [x] No new dependencies.
- [x] No CHANGELOG edit (release generation owns it).
- [x] Regression and browser proof included.
- [x] Allow edits by maintainers.
