### PR TITLE
fix(ci): avoid unbound agent failover callbacks

### DIFF
--- a/src/agents/embedded-agent-runner/run-loop.ts
+++ b/src/agents/embedded-agent-runner/run-loop.ts
@@ -465,7 +465,8 @@ export async function runPreparedEmbeddedLoop(
         authProfileStore: attemptAuthProfileStore,
         runtimeAuthRetry,
         maybeRefreshRuntimeAuthForAuthError,
-        resolveAuthProfileFailureReason: failoverRetryController.resolveAuthProfileFailureReason,
+        resolveAuthProfileFailureReason: (...args) =>
+          failoverRetryController.resolveAuthProfileFailureReason(...args),
         emptyErrorRetries,
         overloadProfileRotations,
         overloadProfileRotationLimit: failoverRetryController.overloadProfileRotationLimit,
@@ -473,12 +474,14 @@ export async function runPreparedEmbeddedLoop(
         rateLimitProfileRotationLimit: failoverRetryController.rateLimitProfileRotationLimit,
         sameModelIdleTimeoutRetries,
         previousRetryFailoverReason: lastRetryFailoverReason,
-        maybeMarkAuthProfileFailure: failoverRetryController.maybeMarkAuthProfileFailure,
-        maybeEscalateRateLimitProfileFallback:
-          failoverRetryController.maybeEscalateRateLimitProfileFallback,
-        maybeRetrySameModelRateLimit: failoverRetryController.maybeRetrySameModelRateLimit,
-        maybeBackoffBeforeOverloadFailover:
-          failoverRetryController.maybeBackoffBeforeOverloadFailover,
+        maybeMarkAuthProfileFailure: (...args) =>
+          failoverRetryController.maybeMarkAuthProfileFailure(...args),
+        maybeEscalateRateLimitProfileFallback: (...args) =>
+          failoverRetryController.maybeEscalateRateLimitProfileFallback(...args),
+        maybeRetrySameModelRateLimit: (...args) =>
+          failoverRetryController.maybeRetrySameModelRateLimit(...args),
+        maybeBackoffBeforeOverloadFailover: (...args) =>
+          failoverRetryController.maybeBackoffBeforeOverloadFailover(...args),
         advanceAttemptAuthProfile,
         traceAttempts,
         suspendForFailure,
@@ -596,7 +599,8 @@ export async function runPreparedEmbeddedLoop(
         readTerminalToolPresentation: readAttemptTerminalToolPresentation,
         resolveReplayInvalid: resolveReplayInvalidForAttempt,
         setTerminalLifecycleMeta,
-        maybeMarkAuthProfileFailure: failoverRetryController.maybeMarkAuthProfileFailure,
+        maybeMarkAuthProfileFailure: (...args) =>
+          failoverRetryController.maybeMarkAuthProfileFailure(...args),
         assistantProfileFailureReason,
         startedAtMs: started,
         provider,

--- a/src/agents/embedded-agent-runner/run/attempt-dispatch-preparation.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-dispatch-preparation.ts
@@ -220,7 +220,9 @@ export async function prepareAndDispatchEmbeddedRunAttempt(input: {
       noteLaneTaskProgress,
       onToolOutcome: input.observeToolOutcome,
       allocateToolOutcomeOrdinal: input.allocateToolOutcomeOrdinal,
-      onToolStreamBoundary: maybeAnnounceFastModeAutoOff,
+      onToolStreamBoundary: () => {
+        void maybeAnnounceFastModeAutoOff();
+      },
       onRunProgress: notifyRunProgress,
       onToolResult: notifyToolResult,
       onAgentEvent: notifyAgentEvent,

--- a/src/agents/embedded-agent-runner/run/attempt-recovery.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-recovery.ts
@@ -193,7 +193,7 @@ export async function recoverEmbeddedRunAttempt(input: {
     assistantErrorText,
     attemptCompactionCount,
     prepareCurrentTranscriptRetry: sessionPromptState.continueFromCurrentTranscript,
-    prepareCompactedTranscriptRetry: sessionPromptState.prepareCompactedTranscriptRetry,
+    prepareCompactedTranscriptRetry: () => sessionPromptState.prepareCompactedTranscriptRetry(),
   });
   if (overflowRecovery.action === "retry") {
     return retry();
@@ -324,13 +324,15 @@ export async function recoverEmbeddedRunAttempt(input: {
       externalAbort,
       pluginHarnessOwnsTransport: runtime.pluginHarnessOwnsTransport,
       timedOutByRunBudget,
-      resolveAuthProfileFailureReason: failoverRetryController.resolveAuthProfileFailureReason,
-      maybeEscalateRateLimitProfileFallback:
-        failoverRetryController.maybeEscalateRateLimitProfileFallback,
+      resolveAuthProfileFailureReason: (...args) =>
+        failoverRetryController.resolveAuthProfileFailureReason(...args),
+      maybeEscalateRateLimitProfileFallback: (...args) =>
+        failoverRetryController.maybeEscalateRateLimitProfileFallback(...args),
       advanceAttemptAuthProfile: preparedRuntime.advanceAttemptAuthProfile,
-      maybeMarkAuthProfileFailure: failoverRetryController.maybeMarkAuthProfileFailure,
-      maybeBackoffBeforeOverloadFailover:
-        failoverRetryController.maybeBackoffBeforeOverloadFailover,
+      maybeMarkAuthProfileFailure: (...args) =>
+        failoverRetryController.maybeMarkAuthProfileFailure(...args),
+      maybeBackoffBeforeOverloadFailover: (...args) =>
+        failoverRetryController.maybeBackoffBeforeOverloadFailover(...args),
       attemptedThinking: preparedRuntime.attemptedThinking,
       thinkLevel: runtime.thinkLevel,
       getThinkLevel: () => preparedRuntime.snapshot().thinkLevel,


### PR DESCRIPTION
## What Problem This Solves

Restores `check-lint` on current main by avoiding unbound method references in embedded-agent runner recovery/failover wiring. The prior implementation passed methods from `failoverRetryController` directly into callback bags, which oxlint now flags as potentially losing `this` context.

The patch keeps behavior unchanged by wrapping those calls in closures and keeping async stream-boundary handling explicitly fire-and-forget.

## Evidence

Validated at head `0c6ae1cb6ddf39b9e8506b68e49ed70a608f6fb7` after rebasing onto upstream/main `cbded6808bc`:

```
PATH="/Users/xjch/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" pnpm lint --threads=8
PATH="/Users/xjch/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" pnpm deadcode:dependencies
PATH="/Users/xjch/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" pnpm deadcode:unused-files
PATH="/Users/xjch/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" pnpm deadcode:exports
PATH="/Users/xjch/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" pnpm check:architecture
PATH="/Users/xjch/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" pnpm check:bundled-channel-config-metadata
PATH="/Users/xjch/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" pnpm check:max-lines-ratchet --base upstream/main
git diff --check
```

Results: all passed locally.

@clawsweeper re-review