### PR TITLE
fix(agents): keep session tool stderr tails UTF-8 safe

### DIFF
--- a/src/agents/sessions/tools/find.fd.test.ts
+++ b/src/agents/sessions/tools/find.fd.test.ts
@@ -55,6 +55,24 @@ it("rejects partial fd output when fd exits with an error", async () => {
   await expect(result).rejects.toThrow("fd failed while reading subtree");
 });
 
+it("keeps multibyte stderr intact when pipe chunks split a character", async () => {
+  const child = createChild();
+  vi.mocked(spawnCommand).mockReturnValue(child as never);
+  vi.mocked(ensureTool).mockResolvedValue("fd");
+
+  const tool = createFindToolDefinition("/workspace");
+  const result = tool.execute("call-1", { pattern: "*.ts" }, undefined, undefined, {} as never);
+  await vi.waitFor(() => expect(spawnCommand).toHaveBeenCalledOnce());
+  const stderrBytes = Buffer.from("fd 失败：权限被拒绝\n");
+  child.stdout.end();
+  // Split inside the first multibyte character to mimic a pipe chunk boundary.
+  child.stderr.write(stderrBytes.subarray(0, 5));
+  child.stderr.end(stderrBytes.subarray(5));
+  child.emit("close", 2, null);
+
+  await expect(result).rejects.toThrow("fd 失败：权限被拒绝");
+});
+
 it.each(["stdout", "stderr"] as const)(
   "rejects and stops fd when %s emits an error",
   async (stream) => {

--- a/src/agents/sessions/tools/find.ts
+++ b/src/agents/sessions/tools/find.ts
@@ -305,7 +305,7 @@ export function createFindToolDefinition(
             // Decode stderr as UTF-8 at the stream so pipe chunk boundaries
             // cannot split multibyte characters into U+FFFD replacement noise.
             child.stderr?.setEncoding("utf8");
-            child.stderr?.on("data", (chunk) => {
+            child.stderr?.on("data", (chunk: string) => {
               stderr = appendBoundedTextTail(stderr, chunk);
             });
             // Readline re-emits input failures, while the stream listener also catches

--- a/src/agents/sessions/tools/find.ts
+++ b/src/agents/sessions/tools/find.ts
@@ -302,6 +302,9 @@ export function createFindToolDefinition(
               settle(() => reject(new Error(`fd ${stream} error: ${error.message}`)));
             };
 
+            // Decode stderr as UTF-8 at the stream so pipe chunk boundaries
+            // cannot split multibyte characters into U+FFFD replacement noise.
+            child.stderr?.setEncoding("utf8");
             child.stderr?.on("data", (chunk) => {
               stderr = appendBoundedTextTail(stderr, chunk);
             });

--- a/src/agents/sessions/tools/grep.stream-errors.test.ts
+++ b/src/agents/sessions/tools/grep.stream-errors.test.ts
@@ -223,4 +223,22 @@ describe("grep tool stream errors", () => {
     }).not.toThrow();
     await expect(result).rejects.toThrow("stderr first");
   });
+
+  it("keeps multibyte stderr intact when pipe chunks split a character", async () => {
+    const child = createChild();
+    vi.mocked(spawnCommand).mockReturnValue(child as never);
+    vi.mocked(ensureTool).mockResolvedValue("rg");
+
+    const tool = createGrepToolDefinition(process.cwd());
+    const result = tool.execute("call-1", { pattern: "foo" }, undefined, undefined, {} as never);
+    await vi.waitFor(() => expect(spawnCommand).toHaveBeenCalledOnce());
+    const stderrBytes = Buffer.from("rg 错误：权限被拒绝\n");
+    child.stdout.end();
+    // Split inside the first multibyte character to mimic a pipe chunk boundary.
+    child.stderr.write(stderrBytes.subarray(0, 4));
+    child.stderr.end(stderrBytes.subarray(4));
+    child.emit("close", 2);
+
+    await expect(result).rejects.toThrow("rg 错误：权限被拒绝");
+  });
 });

--- a/src/agents/sessions/tools/grep.ts
+++ b/src/agents/sessions/tools/grep.ts
@@ -279,7 +279,7 @@ export function createGrepToolDefinition(
             // Decode stderr as UTF-8 at the stream so pipe chunk boundaries
             // cannot split multibyte characters into U+FFFD replacement noise.
             spawnedChild.stderr?.setEncoding("utf8");
-            spawnedChild.stderr?.on("data", (chunk) => {
+            spawnedChild.stderr?.on("data", (chunk: string) => {
               stderr = appendBoundedTextTail(stderr, chunk);
             });
             const onStreamError = (stream: "stdout" | "stderr", error: Error) => {

--- a/src/agents/sessions/tools/grep.ts
+++ b/src/agents/sessions/tools/grep.ts
@@ -276,6 +276,9 @@ export function createGrepToolDefinition(
             let linesTruncated = false;
             const outputLines: string[] = [];
 
+            // Decode stderr as UTF-8 at the stream so pipe chunk boundaries
+            // cannot split multibyte characters into U+FFFD replacement noise.
+            spawnedChild.stderr?.setEncoding("utf8");
             spawnedChild.stderr?.on("data", (chunk) => {
               stderr = appendBoundedTextTail(stderr, chunk);
             });

--- a/src/agents/sessions/tools/limits.test.ts
+++ b/src/agents/sessions/tools/limits.test.ts
@@ -29,7 +29,7 @@ describe("session tool limits", () => {
   });
 
   it("clips oversized chunks to the configured tail bytes", () => {
-    const output = appendBoundedTextTail("ignored", Buffer.from("x".repeat(128)), 16);
+    const output = appendBoundedTextTail("ignored", "x".repeat(128), 16);
 
     expect(output).toBe("x".repeat(16));
     expect(Buffer.byteLength(output, "utf8")).toBe(16);

--- a/src/agents/sessions/tools/limits.test.ts
+++ b/src/agents/sessions/tools/limits.test.ts
@@ -50,6 +50,17 @@ describe("session tool limits", () => {
     expect(Buffer.byteLength(output, "utf8")).toBe(2);
   });
 
+  it("drops orphan continuation bytes when the byte window splits a character", () => {
+    // "aaaa😀ccccccc" is 15 bytes; a 6-byte chunk under a 16-byte cap keeps a
+    // 10-byte tail whose cut lands inside the 4-byte emoji. The orphan
+    // continuation bytes must not surface as U+FFFD at the head of the tail.
+    const output = appendBoundedTextTail("aaaa😀ccccccc", "dddddd", 16);
+
+    expect(output).toBe("cccccccdddddd");
+    expect(output).not.toContain("�");
+    expect(Buffer.byteLength(output, "utf8")).toBeLessThanOrEqual(16);
+  });
+
   it("uses the session stderr tail limit by default", () => {
     const output = appendBoundedTextTail("", "x".repeat(SESSION_TOOL_STDERR_TAIL_BYTES + 1));
 

--- a/src/agents/sessions/tools/limits.ts
+++ b/src/agents/sessions/tools/limits.ts
@@ -5,6 +5,7 @@
  * splitting multi-byte characters in display output.
  */
 import { resolveIntegerOption } from "@openclaw/normalization-core/number-coercion";
+import { truncateUtf8Suffix } from "../../../utils/utf8-truncate.js";
 
 /** Normalizes optional positive numeric limits to a finite integer. */
 export function normalizePositiveLimit(value: number | undefined, fallback: number): number {
@@ -14,53 +15,12 @@ export function normalizePositiveLimit(value: number | undefined, fallback: numb
 /** Default stderr tail retained for long-running session tools. */
 export const SESSION_TOOL_STDERR_TAIL_BYTES = 64 * 1024;
 
-function isUtf8ContinuationByte(byte: number | undefined): boolean {
-  return byte !== undefined && (byte & 0b1100_0000) === 0b1000_0000;
-}
-
-function decodeUtf8TextTail(buffer: Buffer, maxBytes: number): string {
-  const chars = Array.from(buffer.toString("utf8"));
-  const kept: string[] = [];
-  let bytes = 0;
-
-  for (let i = chars.length - 1; i >= 0; i--) {
-    const char = chars[i] ?? "";
-    const charBytes = Buffer.byteLength(char, "utf8");
-    if (bytes + charBytes > maxBytes) {
-      break;
-    }
-    kept.push(char);
-    bytes += charBytes;
-  }
-
-  return kept.toReversed().join("");
-}
-
 /** Appends a chunk while retaining only the UTF-8-safe tail within maxBytes. */
 export function appendBoundedTextTail(
   current: string,
-  chunk: Buffer | string,
+  chunk: string,
   maxBytes = SESSION_TOOL_STDERR_TAIL_BYTES,
 ): string {
   const effectiveMaxBytes = normalizePositiveLimit(maxBytes, SESSION_TOOL_STDERR_TAIL_BYTES);
-  const chunkBuffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
-  if (chunkBuffer.byteLength >= effectiveMaxBytes) {
-    return decodeUtf8TextTail(chunkBuffer, effectiveMaxBytes);
-  }
-
-  const currentBuffer = Buffer.from(current);
-  const nextBytes = currentBuffer.byteLength + chunkBuffer.byteLength;
-  if (nextBytes <= effectiveMaxBytes) {
-    return `${current}${chunkBuffer.toString("utf8")}`;
-  }
-
-  const currentTailBytes = Math.max(0, effectiveMaxBytes - chunkBuffer.byteLength);
-  // Skip UTF-8 continuation bytes so the byte-window cut never leaves orphan
-  // bytes that decode into U+FFFD noise at the head of the retained tail.
-  let tailStart = currentBuffer.byteLength - currentTailBytes;
-  while (tailStart < currentBuffer.byteLength && isUtf8ContinuationByte(currentBuffer[tailStart])) {
-    tailStart += 1;
-  }
-  const currentTail = currentBuffer.subarray(tailStart);
-  return decodeUtf8TextTail(Buffer.concat([currentTail, chunkBuffer]), effectiveMaxBytes);
+  return truncateUtf8Suffix(`${current}${chunk}`, effectiveMaxBytes);
 }

--- a/src/agents/sessions/tools/limits.ts
+++ b/src/agents/sessions/tools/limits.ts
@@ -14,6 +14,10 @@ export function normalizePositiveLimit(value: number | undefined, fallback: numb
 /** Default stderr tail retained for long-running session tools. */
 export const SESSION_TOOL_STDERR_TAIL_BYTES = 64 * 1024;
 
+function isUtf8ContinuationByte(byte: number | undefined): boolean {
+  return byte !== undefined && (byte & 0b1100_0000) === 0b1000_0000;
+}
+
 function decodeUtf8TextTail(buffer: Buffer, maxBytes: number): string {
   const chars = Array.from(buffer.toString("utf8"));
   const kept: string[] = [];
@@ -51,6 +55,12 @@ export function appendBoundedTextTail(
   }
 
   const currentTailBytes = Math.max(0, effectiveMaxBytes - chunkBuffer.byteLength);
-  const currentTail = currentBuffer.subarray(currentBuffer.byteLength - currentTailBytes);
+  // Skip UTF-8 continuation bytes so the byte-window cut never leaves orphan
+  // bytes that decode into U+FFFD noise at the head of the retained tail.
+  let tailStart = currentBuffer.byteLength - currentTailBytes;
+  while (tailStart < currentBuffer.byteLength && isUtf8ContinuationByte(currentBuffer[tailStart])) {
+    tailStart += 1;
+  }
+  const currentTail = currentBuffer.subarray(tailStart);
   return decodeUtf8TextTail(Buffer.concat([currentTail, chunkBuffer]), effectiveMaxBytes);
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the sessions `find`/`grep` tools and `tool_search_code` surface stderr with U+FFFD replacement characters (`�`) when a child process (fd/ripgrep) emits multibyte text (CJK paths, emoji filenames). Two byte-boundary cuts cause it:

- `appendBoundedTextTail` in `src/agents/sessions/tools/limits.ts` slices the retained tail at a raw byte offset, so the cut can land inside a multibyte UTF-8 character and the orphaned continuation bytes decode as `�` at the head of the tail once stderr exceeds 64 KiB.
- `find.ts`/`grep.ts` feed raw `Buffer` pipe chunks straight into the tail, so a pipe read boundary inside a multibyte character corrupts it into `��` even far below the 64 KiB cap.

## Why This Change Was Made

The tail-window cut now skips UTF-8 continuation bytes before slicing, and `find`/`grep` decode stderr with `setEncoding("utf8")` at the stream so chunk boundaries can never split a character — the same wiring `tool_search.ts` already uses for the same helper (added in #101007). This is the sibling gap of the merged multibyte tail fixes #104151 (file-transfer bounded stderr tail) and #101007 (tool_search stderr accumulation); the 64 KiB bound and the existing "never exceed maxBytes" guarantee are unchanged.

## User Impact

Agents and logs now see clean fd/ripgrep error text (permission-denied paths, missing-directory messages with non-ASCII names) instead of `�`-corrupted fragments; behavior for ASCII stderr is unchanged.

## Evidence

- Regression tests (added in this PR, fail on main): `node scripts/run-vitest.mjs src/agents/sessions/tools/limits.test.ts src/agents/sessions/tools/find.fd.test.ts src/agents/sessions/tools/grep.stream-errors.test.ts` — main: 3 failed; this branch: 13 + 6 + 9 passed.
- Live proof: real `createGrepToolDefinition` from production `grep.ts` spawning the real ripgrep binary over 3000 unreadable files with emoji-dense names (12 trials per run); rg exits 2 and the tool rejects with the bounded stderr tail an agent sees.

Before (main @ 30738a3c):

```text
$ node --import tsx live-proof.mjs
trial 11: bytes=65535 U+FFFD=1
rg binary: /usr/local/bin/rg
corrupted trials: 2/12
sample corrupted head: "�😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀😀aaa-2200.txt: Permission denied (os error 13)\nrg: /tmp/openclaw-grep-utf8-pro"
RESULT: corrupted (U+FFFD present)
```

After (this branch, same script and machine):

```text
$ node --import tsx live-proof.mjs
trial 11: bytes=65535 U+FFFD=0
rg binary: /usr/local/bin/rg
corrupted trials: 0/12
RESULT: clean multibyte stderr tails
```

<details>
<summary>live-proof.mjs (save in repo root, run with `node --import tsx live-proof.mjs`)</summary>

```js
// Drives the REAL production grep session tool (createGrepToolDefinition)
// with the REAL ripgrep binary. Thousands of unreadable files with multibyte
// (emoji-dense) names make rg emit a large multibyte stderr stream and
// exit 2, so the tool rejects with the bounded stderr tail an agent sees.
//
// Corruption depends on where pipe reads and the 64 KiB byte-window cut land
// inside a multibyte character, so the proof runs repeated trials and counts
// trials whose rejection message contains U+FFFD. Before the fix a fraction of
// trials is corrupted; after the fix every trial must be clean.
import { execFileSync } from "node:child_process";
import fs from "node:fs";
import os from "node:os";
import path from "node:path";
import { pathToFileURL } from "node:url";

const repoRoot = process.cwd();
const load = (relative) => import(pathToFileURL(path.resolve(repoRoot, relative)).href);
const { createGrepToolDefinition } = await load("src/agents/sessions/tools/grep.ts");

const rgPath = execFileSync("which", ["rg"], { encoding: "utf8" }).trim();
const trials = 12;
const fileCount = 3000;
let corrupted = 0;
let sampleHead = "";

for (let trial = 0; trial < trials; trial++) {
  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-grep-utf8-proof-"));
  for (let i = 0; i < fileCount; i++) {
    const emojiName = "😀".repeat(20 + ((i + trial) % 5)) + "a".repeat((i * 7 + trial) % 4);
    const file = path.join(tempDir, `${emojiName}-${String(i).padStart(4, "0")}.txt`);
    fs.writeFileSync(file, "needle\n");
    fs.chmodSync(file, 0o000);
  }
  const tool = createGrepToolDefinition(tempDir);
  let message = "";
  try {
    await tool.execute("proof-1", { pattern: "needle", path: tempDir }, undefined, undefined, {});
    console.log(`trial ${trial}: UNEXPECTED resolve`);
  } catch (error) {
    message = error instanceof Error ? error.message : String(error);
  } finally {
    execFileSync("chmod", ["-R", "u+rw", tempDir]);
    fs.rmSync(tempDir, { recursive: true, force: true });
  }
  const fffdCount = (message.match(/�/g) ?? []).length;
  if (fffdCount > 0) {
    corrupted += 1;
    if (!sampleHead) {
      sampleHead = message.slice(0, 120);
    }
  }
  console.log(`trial ${trial}: bytes=${Buffer.byteLength(message, "utf8")} U+FFFD=${fffdCount}`);
}

console.log(`rg binary: ${rgPath}`);
console.log(`corrupted trials: ${corrupted}/${trials}`);
if (sampleHead) {
  console.log(`sample corrupted head: ${JSON.stringify(sampleHead)}`);
}
console.log(
  corrupted === 0 ? "RESULT: clean multibyte stderr tails" : "RESULT: corrupted (U+FFFD present)",
);
```

</details>

AI-assisted: built with Codex
