### PR TITLE
fix(ci): restore Discord architecture and max-lines gates

### DIFF
--- a/config/max-lines-baseline.txt
+++ b/config/max-lines-baseline.txt
@@ -89,7 +89,6 @@ extensions/device-pair/index.test.ts
 extensions/device-pair/index.ts
 extensions/diagnostics-otel/src/service.test.ts
 extensions/diagnostics-prometheus/src/service.ts
-extensions/discord/src/actions/runtime.guild.ts
 extensions/discord/src/actions/runtime.test.ts
 extensions/discord/src/channel.ts
 extensions/discord/src/monitor.test.ts

--- a/extensions/discord/src/monitor/message-channel-info-state.ts
+++ b/extensions/discord/src/monitor/message-channel-info-state.ts
@@ -1,4 +1,12 @@
-import type { DiscordChannelInfo } from "./message-channel-info.js";
+import type { ChannelType } from "../internal/discord.js";
+
+export type DiscordChannelInfo = {
+  type: ChannelType;
+  name?: string;
+  topic?: string;
+  parentId?: string;
+  ownerId?: string;
+};
 
 export const discordChannelInfoCacheState = {
   entries: new Map<string, { value: DiscordChannelInfo | null; expiresAt: number }>(),

--- a/extensions/discord/src/monitor/message-channel-info.ts
+++ b/extensions/discord/src/monitor/message-channel-info.ts
@@ -8,15 +8,12 @@ import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { normalizeOptionalStringifiedId } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { ChannelType, Message } from "../internal/discord.js";
 import { resolveDiscordChannelInfoSafe } from "./channel-access.js";
-import { discordChannelInfoCacheState } from "./message-channel-info-state.js";
+import {
+  discordChannelInfoCacheState,
+  type DiscordChannelInfo,
+} from "./message-channel-info-state.js";
 
-export type DiscordChannelInfo = {
-  type: ChannelType;
-  name?: string;
-  topic?: string;
-  parentId?: string;
-  ownerId?: string;
-};
+export type { DiscordChannelInfo } from "./message-channel-info-state.js";
 export type DiscordChannelInfoClient = {
   fetchChannel(channelId: string): Promise<unknown>;
 };


### PR DESCRIPTION
## What Problem This Solves

#108003 left two current-main CI regressions that block unrelated PRs:

- a circular dependency between `message-channel-info-state.ts` and `message-channel-info.ts` fails `check-additional-runtime-topology-architecture`; and
- `extensions/discord/src/actions/runtime.guild.ts` no longer has a max-lines suppression, but its stale baseline entry fails `checks-fast-max-lines-ratchet`.

## Why This Change Was Made

The cache-state module now owns the cache value type. The behavior module consumes that leaf type and re-exports it from the existing path, preserving callers while removing the reverse dependency. The stale max-lines entry is deleted so the ratchet shrinks to current source truth.

## User Impact

No runtime behavior change. Restores both CI gates and keeps the Discord channel-info cache ownership acyclic.

## Evidence

- Blacksmith Testbox `tbx_01kxj0z5ra1ktr0rxhdcjxexp4`, Actions `29389367751`.
- Formatting passed.
- 53 focused Discord tests passed.
- Full `check:architecture` passed, including zero Madge cycles.
- `node scripts/check-max-lines-ratchet.mjs --base origin/main` passed with 1,218 grandfathered suppressions.
- Exact rebased head `6a7bfe08d253f95adec9dbff66f3f01b24487d52` passed 53 focused tests and `git diff --check`.
- Fresh combined autoreview produced one rejected false positive: `ChannelType` remains used by `rawChannel.type` normalization in `message-channel-info.ts`.

## AI Assistance

AI-assisted implementation and review.
