### PR TITLE
fix(ui): format cron run token counts and durations consistently

### DIFF
--- a/ui/src/i18n/.i18n/raw-copy-baseline.json
+++ b/ui/src/i18n/.i18n/raw-copy-baseline.json
@@ -619,13 +619,6 @@
     },
     {
       "count": 1,
-      "kind": "html-text",
-      "name": "text",
-      "path": "ui/src/pages/cron/view-runs.ts",
-      "text": "ms"
-    },
-    {
-      "count": 1,
       "kind": "html-attribute",
       "name": "placeholder",
       "path": "ui/src/pages/cron/view.ts",

--- a/ui/src/pages/cron/view-runs.ts
+++ b/ui/src/pages/cron/view-runs.ts
@@ -12,6 +12,7 @@ import { toSanitizedMarkdownHtml } from "../../components/markdown.ts";
 import { t } from "../../i18n/index.ts";
 import {
   formatDurationCompact,
+  formatDurationHuman,
   formatRelativeTimestamp,
   formatMs,
   formatTokens,
@@ -318,7 +319,7 @@ function renderRun(
           <div class="muted">
             ${typeof entry.durationMs === "number" && Number.isFinite(entry.durationMs)
               ? (formatDurationCompact(entry.durationMs, { spaced: true }) ??
-                `${entry.durationMs}ms`)
+                formatDurationHuman(entry.durationMs))
               : t("common.na")}
           </div>
           ${typeof entry.nextRunAtMs === "number"

--- a/ui/src/pages/cron/view-runs.ts
+++ b/ui/src/pages/cron/view-runs.ts
@@ -319,7 +319,7 @@ function renderRun(
           <div class="muted">
             ${typeof entry.durationMs === "number" && Number.isFinite(entry.durationMs)
               ? (formatDurationCompact(entry.durationMs, { spaced: true }) ??
-                formatDurationHuman(entry.durationMs))
+                formatDurationHuman(entry.durationMs, t("common.na")))
               : t("common.na")}
           </div>
           ${typeof entry.nextRunAtMs === "number"

--- a/ui/src/pages/cron/view-runs.ts
+++ b/ui/src/pages/cron/view-runs.ts
@@ -10,7 +10,12 @@ import { icon } from "../../components/icons.ts";
 import "../../components/web-awesome.ts";
 import { toSanitizedMarkdownHtml } from "../../components/markdown.ts";
 import { t } from "../../i18n/index.ts";
-import { formatRelativeTimestamp, formatMs } from "../../lib/format.ts";
+import {
+  formatDurationCompact,
+  formatRelativeTimestamp,
+  formatMs,
+  formatTokens,
+} from "../../lib/format.ts";
 import { searchForSession } from "../../lib/sessions/index.ts";
 
 // Leaf contract: the slice of the cron view props this module needs. Keeping
@@ -288,9 +293,9 @@ function renderRun(
   const usage = entry.usage;
   const usageSummary =
     usage && typeof usage.total_tokens === "number"
-      ? `${usage.total_tokens} tokens`
+      ? `${formatTokens(usage.total_tokens)} ${t("usage.metrics.tokens")}`
       : usage && typeof usage.input_tokens === "number" && typeof usage.output_tokens === "number"
-        ? `${usage.input_tokens} in / ${usage.output_tokens} out`
+        ? `${formatTokens(usage.input_tokens)} in / ${formatTokens(usage.output_tokens)} out`
         : null;
   const bodySource = entry.summary || entry.error || t("cron.runEntry.noSummary");
   const showErrorInMeta = Boolean(entry.error) && Boolean(entry.summary);
@@ -310,7 +315,12 @@ function renderRun(
           ${typeof entry.runAtMs === "number"
             ? html`<div class="muted">${t("cron.runEntry.runAt")} ${formatMs(entry.runAtMs)}</div>`
             : nothing}
-          <div class="muted">${entry.durationMs ?? 0}ms</div>
+          <div class="muted">
+            ${typeof entry.durationMs === "number" && Number.isFinite(entry.durationMs)
+              ? (formatDurationCompact(entry.durationMs, { spaced: true }) ??
+                `${entry.durationMs}ms`)
+              : t("common.na")}
+          </div>
           ${typeof entry.nextRunAtMs === "number"
             ? html`<div class="muted">${formatRunNextLabel(entry.nextRunAtMs)}</div>`
             : nothing}

--- a/ui/src/pages/cron/view.test.ts
+++ b/ui/src/pages/cron/view.test.ts
@@ -457,6 +457,64 @@ describe("cron view run history", () => {
     expect(onRunsFiltersChange).toHaveBeenCalledWith({ cronRunsStatuses: [] });
   });
 
+  it("formats run token counts and durations in the rendered entry", () => {
+    const container = renderView({
+      listTab: "activity",
+      runs: [
+        {
+          ts: 4,
+          jobId: "job-total",
+          status: "ok",
+          summary: "total usage",
+          durationMs: 90_000,
+          usage: { total_tokens: 1_234_567 },
+        },
+        {
+          ts: 3,
+          jobId: "job-split",
+          status: "ok",
+          summary: "split usage",
+          durationMs: 500,
+          usage: { input_tokens: 50_000, output_tokens: 999 },
+        },
+        {
+          ts: 2,
+          jobId: "job-zero",
+          status: "ok",
+          summary: "zero duration",
+          durationMs: 0,
+        },
+        { ts: 1, jobId: "job-unknown", status: "ok", summary: "unknown duration" },
+      ],
+    });
+    const entries = Array.from(container.querySelectorAll(".cron-run-entry"));
+    const entryFor = (jobId: string) => {
+      const entry = entries.find((candidate) =>
+        candidate.querySelector(".cron-run-entry__title")?.textContent?.includes(jobId),
+      );
+      expect(entry).toBeInstanceOf(HTMLDivElement);
+      return entry;
+    };
+
+    const total = entryFor("job-total");
+    expect(total?.querySelector(".cron-run-entry__facts")?.textContent).toContain("1.2M Tokens");
+    expect(total?.querySelector(".cron-run-entry__meta")?.textContent).toContain("1m 30s");
+    expect(total?.textContent).not.toContain("1234567");
+    expect(total?.textContent).not.toContain("90000ms");
+
+    const split = entryFor("job-split");
+    expect(split?.querySelector(".cron-run-entry__facts")?.textContent).toContain(
+      "50k in / 999 out",
+    );
+    expect(split?.querySelector(".cron-run-entry__meta")?.textContent).toContain("500ms");
+    expect(entryFor("job-zero")?.querySelector(".cron-run-entry__meta")?.textContent).toContain(
+      "0ms",
+    );
+    expect(entryFor("job-unknown")?.querySelector(".cron-run-entry__meta")?.textContent).toContain(
+      "n/a",
+    );
+  });
+
   it("renders run summaries as sanitized markdown", () => {
     const container = renderView({
       listTab: "activity",

--- a/ui/src/pages/cron/view.test.ts
+++ b/ui/src/pages/cron/view.test.ts
@@ -484,6 +484,13 @@ describe("cron view run history", () => {
           summary: "zero duration",
           durationMs: 0,
         },
+        {
+          ts: 1.5,
+          jobId: "job-invalid",
+          status: "ok",
+          summary: "invalid duration",
+          durationMs: -1,
+        },
         { ts: 1, jobId: "job-unknown", status: "ok", summary: "unknown duration" },
       ],
     });
@@ -509,6 +516,9 @@ describe("cron view run history", () => {
     expect(split?.querySelector(".cron-run-entry__meta")?.textContent).toContain("500ms");
     expect(entryFor("job-zero")?.querySelector(".cron-run-entry__meta")?.textContent).toContain(
       "0ms",
+    );
+    expect(entryFor("job-invalid")?.querySelector(".cron-run-entry__meta")?.textContent).toContain(
+      "n/a",
     );
     expect(entryFor("job-unknown")?.querySelector(".cron-run-entry__meta")?.textContent).toContain(
       "n/a",


### PR DESCRIPTION
## What Problem This Solves

Cron run entries (`ui/src/pages/cron/view-runs.ts`) rendered metrics differently from the rest of the Control UI:

1. Token counts used raw integers such as `1234567 tokens` instead of compact values such as `1.2M Tokens`.
2. Durations used raw milliseconds such as `90000ms` instead of `1m 30s`.
3. A missing duration rendered as `0ms`, incorrectly implying an instantaneous run rather than unavailable metadata.

## Why This Change Was Made

- **Root cause:** the run renderer used ad hoc string interpolation instead of the existing Control UI token and duration formatters.
- **Fix:** use `formatTokens`, `formatDurationCompact(..., { spaced: true })`, and the shared `formatDurationHuman` zero-duration fallback; missing/non-finite values use `common.na`.
- **Contract preserved:** protocol-valid `durationMs: 0` still renders `0ms`; positive durations retain compact compound precision; absent duration renders `n/a`.
- **i18n baseline:** the official keyless baseline generator removed the now-stale raw `ms` entry for `view-runs.ts`; no locale key or hand-edited translation was added.

## User Impact

Cron run history now shows compact, consistent metrics:

- `1234567 tokens` → `1.2M Tokens`
- `50000 in / 999 out` → `50k in / 999 out`
- `90000ms` → `1m 30s`
- missing `durationMs` → `n/a`

## Linked context

N/A (no existing issue).

## Evidence

**Terminal capture from a GitHub-hosted Node 24 + Playwright Chromium run using the real Control UI `/cron` route and deterministic mocked Gateway data:**

```text
BEFORE: "1234567 tokens"; "90000ms"; missing duration = "0ms"
AFTER:  "1.2M Tokens"; "1m 30s"; split usage = "50k in / 999 out"; missing duration = "n/a"
Playwright assertions: passed
```

### UI before/after screenshots

- Proof run: https://github.com/miorbnli/openclaw/actions/runs/29400428645
- Screenshot artifact: https://github.com/miorbnli/openclaw/actions/runs/29400428645/artifacts/8336903133
- Files: `cron/before-cron-runs.png`, `cron/after-cron-runs.png`
- Artifact manifest binds this proof to exact PR head `1fbf0af9f4e2985dd7f438a535ee5b4899977715`; SHA-256 checksums are included.

| # | Field | Value |
|---|---|---|
| 1 | Behavior or issue addressed | Cron run history displayed raw token counts, raw millisecond durations, and misleading `0ms` for missing duration metadata. |
| 2 | Real environment tested | GitHub-hosted Ubuntu 24.04, Node 24, Playwright Chromium, exact head `1fbf0af9f4e2985dd7f438a535ee5b4899977715`. |
| 3 | Exact steps or command run | Started the real Control UI E2E server, mocked `cron.runs`, opened `/cron`, selected Run history, and asserted/screenshot the rendered `.cron-runs__list` before and after the production renderer change. |
| 4 | Evidence after fix | Terminal output and screenshot artifact above show compact totals/splits, compound duration, and `n/a` for missing duration. |
| 5 | Observed result after fix | Cron metrics match shared UI formatting while preserving legitimate zero duration. |
| 6 | What was not tested | A live scheduler/store; deterministic Gateway data exercises the actual browser rendering path and all affected display states. |

## Tests and validation

- Focused Lit regression in `ui/src/pages/cron/view.test.ts` asserts actual `.cron-run-entry` output for:
  - total and split token counts;
  - `90_000ms`, `500ms`, valid `0ms`, and missing duration;
  - absence of old raw values.
- Official generated baseline proof and `pnpm ui:i18n:verify`: success in https://github.com/miorbnli/openclaw/actions/runs/29399961206
- Final exact-head hosted CI: https://github.com/openclaw/openclaw/actions/runs/29400352911
- Visual proof: real Control UI + mocked Gateway Playwright assertions and screenshots passed in the run linked above.

## Risk checklist

- [x] One concern, one PR: cron run metric presentation.
- [x] No config/env/default surface change.
- [x] No SDK/protocol/auth/provider behavior change.
- [x] Protocol-valid zero duration remains `0ms`; missing duration is distinct.
- [x] No new dependencies.
- [x] No CHANGELOG edit (release generation owns it).
- [x] Render regression, i18n verification, and browser proof included.
- [x] Allow edits by maintainers.
