### PR TITLE
fix(release): retry transient live provider failures

### DIFF
--- a/scripts/ci-live-command-retry.sh
+++ b/scripts/ci-live-command-retry.sh
@@ -14,8 +14,9 @@ fi
 attempts="${OPENCLAW_LIVE_COMMAND_ATTEMPTS:-2}"
 delay_seconds="${OPENCLAW_LIVE_COMMAND_RETRY_DELAY_SECONDS:-10}"
 rate_limit_delay_seconds="${OPENCLAW_LIVE_COMMAND_RATE_LIMIT_RETRY_DELAY_SECONDS:-60}"
-# MiniMax code 1000 is documented as transient; keep auth/input failures fail-fast.
-retry_pattern="${OPENCLAW_LIVE_COMMAND_RETRY_PATTERN:-ECONNRESET|ETIMEDOUT|ENOTFOUND|EAI_AGAIN|fetch failed|TLS connection|socket hang up|UND_ERR|gateway request timeout|MiniMax image generation API error \\(1000\\)|model idle timeout|did not produce a response before the model idle timeout|\\b429\\b|\\b529\\b}"
+# Live provider 5xx responses and one-off test timeouts get one retry; deterministic
+# hangs still fail the second attempt. Keep auth and input failures fail-fast.
+retry_pattern="${OPENCLAW_LIVE_COMMAND_RETRY_PATTERN:-ECONNRESET|ETIMEDOUT|ENOTFOUND|EAI_AGAIN|fetch failed|TLS connection|socket hang up|UND_ERR|gateway request timeout|HTTP 5[0-9][0-9]|Test timed out in [0-9]+ms|MiniMax image generation API error \\(1000\\)|model idle timeout|did not produce a response before the model idle timeout|\\b429\\b|\\b529\\b}"
 rate_limit_pattern="${OPENCLAW_LIVE_COMMAND_RATE_LIMIT_PATTERN:-Rate limit reached|rate.?limit|tokens per min|requests per min|\\bTPM\\b|\\bRPM\\b}"
 
 if ! [[ "$attempts" =~ ^[1-9][0-9]*$ ]]; then

--- a/test/scripts/ci-live-command-retry.test.ts
+++ b/test/scripts/ci-live-command-retry.test.ts
@@ -66,6 +66,27 @@ describe("scripts/ci-live-command-retry.sh", () => {
     );
   });
 
+  it.each([
+    ["provider HTTP 500", "xAI image edit failed (HTTP 500): Please try again later"],
+    ["live test timeout", "Error: Test timed out in 45000ms."],
+  ])("retries a transient %s", (_label, message) => {
+    const { commandPath, counterPath } = writeCommand("openclaw-ci-live-transient-", [
+      'attempts="$(cat "$OPENCLAW_RETRY_TEST_COUNTER" 2>/dev/null || printf 0)"',
+      'attempts="$((attempts + 1))"',
+      'printf "%s" "$attempts" > "$OPENCLAW_RETRY_TEST_COUNTER"',
+      'if [[ "$attempts" -eq 1 ]]; then',
+      `  echo ${JSON.stringify(message)} >&2`,
+      "  exit 42",
+      "fi",
+    ]);
+
+    const result = runRetryHelper(commandPath, counterPath);
+
+    expect(result.status).toBe(0);
+    expect(readFileSync(counterPath, "utf8")).toBe("2");
+    expect(result.stderr).toContain("retrying (1/2)");
+  });
+
   it("does not retry a MiniMax authentication failure", () => {
     const { commandPath, counterPath } = writeCommand("openclaw-ci-live-auth-failure-", [
       'attempts="$(cat "$OPENCLAW_RETRY_TEST_COUNTER" 2>/dev/null || printf 0)"',


### PR DESCRIPTION
## What Problem This Solves

Full Release Validation wraps live-provider shards with a bounded two-attempt retry helper, but the helper did not recognize two common transient failure forms: provider HTTP 5xx responses and Vitest live-test timeouts. As a result, xAI HTTP 500 in run 29381121976 and a ZAI 45-second timeout in run 29389075438 each aborted an otherwise healthy release matrix without using the available second attempt.

## Why This Change Was Made

Extend the existing retry classifier with `HTTP 5xx` and `Test timed out in <n>ms` signatures. The retry count remains two, so persistent hangs or server errors still fail the second attempt. Authentication and input failures remain fail-fast.

## User Impact

No product/runtime behavior changes. Release validation becomes resilient to one-off provider 5xx responses and live-call timeouts without weakening the final gate.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/ci-live-command-retry.test.ts` — 4/4 passed.
- `bash -n scripts/ci-live-command-retry.sh` — passed.
- Focused formatting and `git diff --check` — passed.
- Fresh uncommitted-patch autoreview — zero findings, `patch is correct` (0.95 confidence).
- Exact observed failures: [xAI HTTP 500 job](https://github.com/openclaw/openclaw/actions/runs/29381121976/job/87245057733) and [ZAI timeout job](https://github.com/openclaw/openclaw/actions/runs/29389075438/job/87268548883).

The broader release-maintenance transcript is not attached because it contains unrelated operational context and is not a narrowly sanitizable PR transcript.
