### PR TITLE
improve: speed doctor preview warning tests

### DIFF
--- a/src/commands/doctor/shared/preview-warnings.test.ts
+++ b/src/commands/doctor/shared/preview-warnings.test.ts
@@ -306,6 +306,14 @@ vi.mock("./active-tool-schema-warnings.js", () => ({
   collectActiveToolSchemaProjectionWarnings: () => activeToolSchemaState.warnings,
 }));
 
+vi.mock("./codex-route-warnings.js", () => ({
+  collectCodexRouteWarnings: vi.fn(() => []),
+}));
+
+vi.mock("./context-engine-host-compat.js", () => ({
+  collectContextEngineHostCompatibilityWarnings: vi.fn(async () => []),
+}));
+
 function manifest(id: string): TestManifestRecord {
   return {
     id,


### PR DESCRIPTION
## What Problem This Solves

The doctor preview-warning suite spent 3.2 seconds loading Codex-route and context-engine compatibility collectors during an asset-notice test that does not exercise either warning surface.

## Why This Change Was Made

The aggregation suite now mocks those two independently tested warning collectors with empty deterministic results. The real preview aggregation, Codex asset scan, and remaining warning paths stay under test; production code is unchanged.

## User Impact

No user-visible behavior change. Developers and CI get faster doctor preview-warning feedback.

## Evidence

- 44/44 focused tests passing before and after.
- Personal Codex asset test: 3.203s -> 136ms (95.8% faster).
- Test-body time: 3.37s -> 1.38s (59.1% faster).
- Whole Vitest file: 4.60s -> 3.49s (24.1% faster).
- Baseline Testbox: https://github.com/openclaw/openclaw/actions/runs/29389574250
- Optimized Testbox: https://github.com/openclaw/openclaw/actions/runs/29389677306
- `check:changed` reached an inherited stale `extensions/discord/src/actions/runtime.guild.ts` max-lines baseline entry already present on `origin/main`; no failure involved the changed test file.
- Fresh autoreview: clean, confidence 0.98.
