### PR TITLE
fix(maint): keep PR maintenance delta-only

### DIFF
--- a/.github/actions/detect-docs-changes/action.yml
+++ b/.github/actions/detect-docs-changes/action.yml
@@ -23,8 +23,10 @@ runs:
     - name: Detect docs-only changes
       id: check
       shell: bash
+      env:
+        BASE_SHA: ${{ inputs.base-sha }}
       run: |
-        BASE="${{ inputs.base-sha }}"
+        BASE="$BASE_SHA"
 
         # Fail-safe: if we can't diff, assume non-docs (run everything)
         CHANGED=$(git diff --name-only "$BASE" HEAD 2>/dev/null || echo "UNKNOWN")

--- a/.github/actions/detect-docs-changes/action.yml
+++ b/.github/actions/detect-docs-changes/action.yml
@@ -4,6 +4,11 @@ description: >
   markdown (.md/.mdx). Fail-safe: if detection fails, outputs false (run
   everything). Uses git diff — no API calls, no extra permissions needed.
 
+inputs:
+  base-sha:
+    description: Exact base commit to compare with the checked-out tree.
+    required: true
+
 outputs:
   docs_only:
     description: "'true' if all changes are docs/markdown, 'false' otherwise"
@@ -19,13 +24,7 @@ runs:
       id: check
       shell: bash
       run: |
-        if [ "${{ github.event_name }}" = "push" ]; then
-          BASE="${{ github.event.before }}"
-        else
-          # Use the exact base SHA from the event payload — stable regardless
-          # of base branch movement (avoids origin/<ref> drift).
-          BASE="${{ github.event.pull_request.base.sha }}"
-        fi
+        BASE="${{ inputs.base-sha }}"
 
         # Fail-safe: if we can't diff, assume non-docs (run everything)
         CHANGED=$(git diff --name-only "$BASE" HEAD 2>/dev/null || echo "UNKNOWN")

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,7 @@ jobs:
     timeout-minutes: 20
     outputs:
       checkout_revision: ${{ steps.checkout_ref.outputs.sha }}
+      diff_base_revision: ${{ steps.diff_base.outputs.sha }}
       docs_only: ${{ steps.manifest.outputs.docs_only }}
       docs_changed: ${{ steps.manifest.outputs.docs_changed }}
       run_node: ${{ steps.manifest.outputs.run_node }}
@@ -242,6 +243,21 @@ jobs:
         id: checkout_ref
         run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
+      - name: Resolve exact diff base
+        id: diff_base
+        env:
+          EVENT_BASE_SHA: ${{ github.event_name == 'push' && github.event.before || github.event.pull_request.base.sha || '' }}
+        run: |
+          set -euo pipefail
+          base_sha="$EVENT_BASE_SHA"
+          if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
+            # A long-lived PR event can retain an old base SHA. The tested merge
+            # commit's first parent is the exact target tree for this run.
+            base_sha="$(node scripts/lib/merge-head-diff-base.mjs \
+              --base "$base_sha" --head HEAD --prefer-first-parent)"
+          fi
+          echo "sha=$base_sha" >> "$GITHUB_OUTPUT"
+
       - name: Validate historical release target
         id: historical_target
         if: inputs.historical_target_tag != ''
@@ -290,13 +306,15 @@ jobs:
         if: github.event_name != 'workflow_dispatch'
         uses: ./.github/actions/ensure-base-commit
         with:
-          base-sha: ${{ github.event_name == 'push' && github.event.before || github.event.pull_request.base.sha }}
+          base-sha: ${{ steps.diff_base.outputs.sha }}
           fetch-ref: ${{ github.event_name == 'push' && github.ref_name || github.event.pull_request.base.ref }}
 
       - name: Detect docs-only changes
         id: docs_scope
         if: github.event_name != 'workflow_dispatch'
         uses: ./.github/actions/detect-docs-changes
+        with:
+          base-sha: ${{ steps.diff_base.outputs.sha }}
 
       - name: Detect changed scopes
         id: changed_scope
@@ -306,10 +324,10 @@ jobs:
           set -euo pipefail
 
           if [ "${{ github.event_name }}" = "push" ]; then
-            BASE="${{ github.event.before }}"
+            BASE="${{ steps.diff_base.outputs.sha }}"
             node scripts/ci-changed-scope.mjs --base "$BASE" --head HEAD
           else
-            BASE="${{ github.event.pull_request.base.sha }}"
+            BASE="${{ steps.diff_base.outputs.sha }}"
             node scripts/ci-changed-scope.mjs --base "$BASE" --head HEAD --merge-head-first-parent
           fi
 
@@ -676,7 +694,7 @@ jobs:
             for attempt in 1 2 3; do
               timeout --signal=TERM --kill-after=10s 120s git -C "$GITHUB_WORKSPACE" \
                 -c protocol.version=2 \
-                fetch --no-tags --prune --no-recurse-submodules --depth=1 origin \
+                fetch --no-tags --prune --no-recurse-submodules --depth=2 origin \
                 "+${ref}:refs/remotes/origin/checkout" && return 0
               fetch_status="$?"
               if [ "$fetch_status" != "124" ] && [ "$fetch_status" != "137" ]; then
@@ -705,17 +723,40 @@ jobs:
           fi
           git -C "$GITHUB_WORKSPACE" checkout --detach refs/remotes/origin/checkout
 
+      - name: Resolve security diff base
+        id: diff_base
+        env:
+          EVENT_BASE_SHA: ${{ github.event_name == 'push' && github.event.before || github.event.pull_request.base.sha || '' }}
+        run: |
+          set -euo pipefail
+          base_sha="$EVENT_BASE_SHA"
+          if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
+            # Do not execute a helper from the untrusted PR tree before trusted
+            # pre-commit configuration is selected.
+            read -r head_sha first_parent second_parent extra <<< \
+              "$(git rev-list --parents -n 1 HEAD)"
+            if [[
+              "$head_sha" = "$(git rev-parse HEAD)" &&
+              "$first_parent" =~ ^[0-9a-f]{40}$ &&
+              "$second_parent" =~ ^[0-9a-f]{40}$ &&
+              -z "${extra:-}"
+            ]]; then
+              base_sha="$first_parent"
+            fi
+          fi
+          echo "sha=$base_sha" >> "$GITHUB_OUTPUT"
+
       - name: Ensure security base commit
         if: github.event_name != 'workflow_dispatch'
         uses: ./.github/actions/ensure-base-commit
         with:
-          base-sha: ${{ github.event_name == 'push' && github.event.before || github.event.pull_request.base.sha }}
+          base-sha: ${{ steps.diff_base.outputs.sha }}
           fetch-ref: ${{ github.event_name == 'push' && github.ref_name || github.event.pull_request.base.ref }}
 
       - name: Prepare trusted pre-commit config
         if: github.event_name == 'pull_request'
         env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          BASE_SHA: ${{ steps.diff_base.outputs.sha }}
           BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |
           set -euo pipefail
@@ -753,7 +794,7 @@ jobs:
 
       - name: Audit changed GitHub workflows with zizmor
         env:
-          BASE_SHA: ${{ github.event_name == 'push' && github.event.before || github.event.pull_request.base.sha }}
+          BASE_SHA: ${{ steps.diff_base.outputs.sha }}
         run: |
           set -euo pipefail
 
@@ -870,7 +911,7 @@ jobs:
         if: github.event_name == 'pull_request'
         uses: ./.github/actions/ensure-base-commit
         with:
-          base-sha: ${{ github.event.pull_request.base.sha }}
+          base-sha: ${{ needs.preflight.outputs.diff_base_revision }}
           fetch-ref: ${{ github.event.pull_request.base.ref }}
 
       - name: Setup Node environment
@@ -1767,7 +1808,7 @@ jobs:
           FORMAT_CHECK: ${{ needs.preflight.outputs.run_format_check }}
           OPENCLAW_LOCAL_CHECK: "0"
           TASK: ${{ matrix.task }}
-          PR_BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || '' }}
+          PR_BASE_SHA: ${{ github.event_name == 'pull_request' && needs.preflight.outputs.diff_base_revision || '' }}
         shell: bash
         run: |
           set -euo pipefail

--- a/scripts/pr-lib/gates.sh
+++ b/scripts/pr-lib/gates.sh
@@ -2,7 +2,7 @@ run_hosted_prepare_gates() {
   local pr="$1"
   local current_head="$2"
   local changelog_only="$3"
-  local recent_sha="${4:-}"
+  local recent_sha=""
   local remote_head
   remote_head=$(gh pr view "$pr" --json headRefOid --jq .headRefOid)
   if [ "$remote_head" != "$current_head" ]; then
@@ -41,10 +41,6 @@ run_hosted_prepare_gates() {
     args+=(--changelog-only)
   fi
   run_quiet_logged "hosted CI/Testbox gates" ".local/gates-hosted-checks.log" node "${args[@]}"
-}
-
-compute_pr_patch_id() {
-  git diff --binary "$1" "$2" | git patch-id --verbatim | awk 'NR == 1 { print $1 }'
 }
 
 pin_worktree_bundled_plugins_dir() {
@@ -398,36 +394,14 @@ prepare_gates() {
   fi
 
   if [ "${OPENCLAW_TESTBOX:-}" = "1" ]; then
-    gates_mode="hosted_exact_or_recent_rebase"
+    gates_mode="hosted_exact_or_recent_parent"
     remote_gates_provider=""
     remote_gates_lease_id=""
     remote_gates_run_url=""
     if [ "$changelog_only" = "true" ]; then
       run_quiet_logged "git diff --check" ".local/gates-diff-check.log" git diff --check origin/main...HEAD
     fi
-    local recent_hosted_sha=""
-    if [ -s .local/prep-sync.env ]; then
-      # shellcheck disable=SC1091
-      source .local/prep-sync.env
-      local current_prep_tree
-      current_prep_tree=$(git rev-parse "${current_head}^{tree}")
-      if [ "${PREP_SYNC_TREE:-}" != "$current_prep_tree" ]; then
-        echo "Prepared PR head no longer matches the recorded sync tree."
-        exit 1
-      fi
-      if [ -z "${PREP_SYNC_MAINLINE_BASE_SHA:-}" ] || [ -z "${PREP_SYNC_PATCH_ID:-}" ]; then
-        echo "Prepared PR sync evidence is incomplete."
-        exit 1
-      fi
-      local current_patch_id
-      current_patch_id=$(compute_pr_patch_id "$PREP_SYNC_MAINLINE_BASE_SHA" "$current_head")
-      if [ "$current_patch_id" != "$PREP_SYNC_PATCH_ID" ]; then
-        echo "Prepared PR patch no longer matches the verified pre-rebase patch."
-        exit 1
-      fi
-      recent_hosted_sha="${PREP_SYNC_EVIDENCE_SHA:-}"
-    fi
-    run_hosted_prepare_gates "$pr" "$current_head" "$changelog_only" "$recent_hosted_sha"
+    run_hosted_prepare_gates "$pr" "$current_head" "$changelog_only"
     hosted_gates_head="$current_head"
   elif [ "$reuse_gates" = "true" ]; then
     gates_mode="reused_docs_only"

--- a/scripts/pr-lib/prepare-core.sh
+++ b/scripts/pr-lib/prepare-core.sh
@@ -47,17 +47,6 @@ verify_prep_branch_matches_prepared_head() {
   exit 1
 }
 
-resolve_prep_sync_evidence_sha() {
-  local local_pre_sync_head="$1"
-  local remote_pre_sync_head="$2"
-  local local_tree
-  local_tree=$(git rev-parse "${local_pre_sync_head}^{tree}") || return 1
-  local remote_tree
-  remote_tree=$(git rev-parse "${remote_pre_sync_head}^{tree}") || return 1
-  [ "$local_tree" = "$remote_tree" ] || return 1
-  printf '%s\n' "$remote_pre_sync_head"
-}
-
 prepare_init() {
   local pr="$1"
   enter_worktree "$pr" true
@@ -178,18 +167,6 @@ prepare_push() {
     echo "Unable to resolve the prepared mainline base."
     exit 1
   }
-  if [ -s .local/prep-sync.env ]; then
-    # shellcheck disable=SC1091
-    source .local/prep-sync.env
-    local current_prep_tree
-    current_prep_tree=$(git rev-parse "${local_prep_head_sha}^{tree}")
-    if [ "${PREP_SYNC_TREE:-}" != "$current_prep_tree" ] || [ -z "${PREP_SYNC_MAINLINE_BASE_SHA:-}" ]; then
-      echo "Prepared PR head no longer matches the verified sync tree."
-      exit 1
-    fi
-    mainline_base_sha="$PREP_SYNC_MAINLINE_BASE_SHA"
-    rm -f .local/prep-sync.env
-  fi
   local pushed_from_sha="$PUSHED_FROM_SHA"
   local pr_head_sha_after="$PR_HEAD_SHA_AFTER_PUSH"
 
@@ -246,47 +223,15 @@ prepare_sync_head() {
   require_artifact .local/prep-context.env
 
   checkout_prep_branch "$pr"
-  # A new sync supersedes any prior rebase-evidence stamp. Leaving it behind
-  # can make the next prepare reject a correctly published retry as stale.
-  rm -f .local/prep-sync.env
-
-  local pre_sync_head
-  pre_sync_head=$(git rev-parse HEAD)
 
   # shellcheck disable=SC1091
   source .local/pr-meta.env
   # shellcheck disable=SC1091
   source .local/prep-context.env
 
-  local rebased=false
-  local prep_sync_patch_changed=false
-  local prep_sync_patch_id=""
+  # merge-verify owns relevance-aware mainline drift. Keep the hosted PR head
+  # as the publication parent so fork updates contain only reviewed fixups.
   git fetch origin main
-  if ! git merge-base --is-ancestor origin/main HEAD; then
-    local pre_sync_base
-    pre_sync_base=$(git merge-base "$pre_sync_head" origin/main)
-    local pre_sync_patch_id
-    pre_sync_patch_id=$(compute_pr_patch_id "$pre_sync_base" "$pre_sync_head")
-    if [ -z "$pre_sync_patch_id" ]; then
-      echo "Unable to fingerprint the pre-rebase PR patch."
-      exit 1
-    fi
-    git rebase origin/main
-    rebased=true
-    if [ "${OPENCLAW_TESTBOX:-}" = "1" ]; then
-      prep_sync_patch_id=$(compute_pr_patch_id origin/main HEAD)
-      if [ "$prep_sync_patch_id" != "$pre_sync_patch_id" ]; then
-        echo "Rebase changed the PR patch; fresh hosted evidence is required."
-        prep_sync_patch_changed=true
-      else
-        echo "A patch-identical recent pre-rebase hosted run may be reusable after push."
-      fi
-      rm -f .local/gates.env .local/prep.env
-    else
-      prepare_gates "$pr"
-      checkout_prep_branch "$pr"
-    fi
-  fi
 
   local prep_head_sha
   prep_head_sha=$(git rev-parse HEAD)
@@ -294,6 +239,7 @@ prepare_sync_head() {
 
   local lease_sha
   lease_sha=$(gh pr view "$pr" --json headRefOid --jq .headRefOid)
+  verify_prep_head_extends_hosted_head "$lease_sha" || exit 1
   local push_result_env=".local/prepare-sync-result.env"
 
   verify_pr_head_branch_matches_expected "$pr" "$PR_HEAD"
@@ -323,44 +269,8 @@ prepare_sync_head() {
 
   cat >> .local/prep.md <<EOF_PREP
 - Prep head sync completed to branch $PR_HEAD.
-- Rebased onto origin/main: $rebased.
+- Preserved hosted PR ancestry; merge verification owns mainline drift.
 - Verified the remote PR head tree matches the local prep head.
-EOF_PREP
-
-  if [ "$rebased" = "true" ] && [ "${OPENCLAW_TESTBOX:-}" = "1" ]; then
-    local prep_sync_tree
-    prep_sync_tree=$(git rev-parse "${local_prep_head_sha}^{tree}")
-    local prep_sync_evidence_sha=""
-    if [ "$prep_sync_patch_changed" = "false" ] && ! prep_sync_evidence_sha=$(
-        resolve_prep_sync_evidence_sha "$pre_sync_head" "$pushed_from_sha"
-      ); then
-      echo "Pre-sync local and hosted trees differ; fresh exact-head evidence is required."
-    fi
-    # Preserve local lineage separately from the hosted SHA: GraphQL creates
-    # a remote commit with the same tree but the old branch parent.
-    printf '%s=%q\n' \
-      PREP_SYNC_MAINLINE_BASE_SHA "$mainline_base_sha" \
-      PREP_SYNC_TREE "$prep_sync_tree" \
-      PREP_SYNC_PATCH_ID "$prep_sync_patch_id" \
-      PREP_SYNC_EVIDENCE_SHA "$prep_sync_evidence_sha" \
-      > .local/prep-sync.env
-    if [ -n "$prep_sync_evidence_sha" ]; then
-      cat >> .local/prep.md <<EOF_PREP
-- Cleared stale prepare artifacts. Run prepare-run again; it may reuse green hosted evidence from $prep_sync_evidence_sha within the freshness window.
-EOF_PREP
-    else
-      cat >> .local/prep.md <<EOF_PREP
-- Cleared stale prepare artifacts. Fresh exact-head hosted evidence is required because the prior hosted tree did not match the local pre-rebase tree.
-EOF_PREP
-    fi
-    echo "prepare-sync-head complete"
-    echo "prep_head_sha=$prep_head_sha"
-    echo "Run prepare-run again to verify the available hosted evidence."
-    return
-  fi
-
-  cat >> .local/prep.md <<EOF_PREP
-- Prepare gates reran automatically when the sync rebase changed the prep head.
 EOF_PREP
 
   # Security: shell-escape values to prevent command injection via propagated PR_HEAD.

--- a/scripts/pr-lib/push.sh
+++ b/scripts/pr-lib/push.sh
@@ -25,11 +25,26 @@ resolve_head_push_url() {
 # Pushes the diff between expected_head_oid and local HEAD as file additions/deletions.
 # File bytes are read from git objects (not the working tree) to avoid
 # symlink/special-file dereference risks from untrusted fork content.
+verify_prep_head_extends_hosted_head() {
+  local expected_oid="$1"
+  if ! git cat-file -e "${expected_oid}^{commit}" 2>/dev/null; then
+    echo "Prep sync cannot resolve hosted head $expected_oid locally; re-run prepare-init." >&2
+    return 1
+  fi
+  if ! git merge-base --is-ancestor "$expected_oid" HEAD; then
+    echo "Prep sync refused rewritten history: hosted head $expected_oid is not an ancestor of local HEAD." >&2
+    echo "Recreate the prep branch from the hosted PR head and replay only reviewed fixup commits." >&2
+    return 1
+  fi
+}
+
 graphql_push_to_fork() {
   local repo_nwo="$1"
   local branch="$2"
   local expected_oid="$3"
   local max_blob_bytes=$((5 * 1024 * 1024))
+
+  verify_prep_head_extends_hosted_head "$expected_oid" || return 1
 
   local additions="[]"
   local deletions="[]"

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -1387,7 +1387,8 @@ describe("ci workflow guards", () => {
     expect(action).toContain("base-sha:");
     expect(action).toContain("docs_only:");
     expect(action).toContain("docs_changed:");
-    expect(action).toContain('BASE="${{ inputs.base-sha }}"');
+    expect(action).toContain("BASE_SHA: ${{ inputs.base-sha }}");
+    expect(action).toContain('BASE="$BASE_SHA"');
     expect(action).toContain(
       'CHANGED=$(git diff --name-only "$BASE" HEAD 2>/dev/null || echo "UNKNOWN")',
     );

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -1384,10 +1384,10 @@ describe("ci workflow guards", () => {
   it("keeps docs-change detection fail-safe and fixture-aware", () => {
     const action = readFileSync(".github/actions/detect-docs-changes/action.yml", "utf8");
 
+    expect(action).toContain("base-sha:");
     expect(action).toContain("docs_only:");
     expect(action).toContain("docs_changed:");
-    expect(action).toContain('BASE="${{ github.event.before }}"');
-    expect(action).toContain('BASE="${{ github.event.pull_request.base.sha }}"');
+    expect(action).toContain('BASE="${{ inputs.base-sha }}"');
     expect(action).toContain(
       'CHANGED=$(git diff --name-only "$BASE" HEAD 2>/dev/null || echo "UNKNOWN")',
     );
@@ -1646,7 +1646,7 @@ describe("ci workflow guards", () => {
       expect(checkoutStep.run, jobName).toContain("timed out on attempt $attempt; retrying");
       expect(checkoutStep.run, jobName).not.toContain("if timeout --signal=TERM");
       expect(checkoutStep.run, jobName).toContain("-c protocol.version=2");
-      const expectedDepth = jobName === "preflight" ? 2 : 1;
+      const expectedDepth = jobName === "skills-python" ? 1 : 2;
       expect(checkoutStep.run, jobName).toContain(
         `fetch --no-tags --prune --no-recurse-submodules --depth=${expectedDepth} origin`,
       );
@@ -1896,6 +1896,7 @@ describe("ci workflow guards", () => {
   });
 
   it("runs dependency policy guards in PR CI preflight", () => {
+    const parsedWorkflow = readCiWorkflow();
     const workflow = readFileSync(".github/workflows/ci.yml", "utf8");
     const preflightGuards = workflow.slice(
       workflow.indexOf("guards)"),
@@ -1910,6 +1911,26 @@ describe("ci workflow guards", () => {
     expect(workflow).toContain("check-shrinkwrap");
     expect(shrinkwrapGuards).toContain("pnpm deps:shrinkwrap:check");
     expect(preflightGuards).toContain("pnpm deps:patches:check");
+    expect(parsedWorkflow.jobs.preflight.outputs.diff_base_revision).toBe(
+      "${{ steps.diff_base.outputs.sha }}",
+    );
+    expect(
+      parsedWorkflow.jobs.preflight.steps.find(
+        (step: WorkflowStep) => step.name === "Resolve exact diff base",
+      ).run,
+    ).toContain("--prefer-first-parent");
+    const securityDiffBase = parsedWorkflow.jobs["security-fast"].steps.find(
+      (step: WorkflowStep) => step.name === "Resolve security diff base",
+    ).run;
+    expect(securityDiffBase).toContain("git rev-list --parents -n 1 HEAD");
+    expect(securityDiffBase).not.toContain("node scripts/lib/merge-head-diff-base.mjs");
+    expect(
+      parsedWorkflow.jobs["check-shard"].steps.find(
+        (step: WorkflowStep) => step.name === "Run check shard",
+      ).env.PR_BASE_SHA,
+    ).toBe(
+      "${{ github.event_name == 'pull_request' && needs.preflight.outputs.diff_base_revision || '' }}",
+    );
   });
 
   it("uses stable deadcode checks for current and frozen checkouts", () => {

--- a/test/scripts/pr-prepare-gates.test.ts
+++ b/test/scripts/pr-prepare-gates.test.ts
@@ -47,7 +47,12 @@ function sanitizedEnv(overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
 
 function runGatesBash(
   script: string,
-  options: { cwd?: string; env?: NodeJS.ProcessEnv; sourcePrepareCore?: boolean } = {},
+  options: {
+    cwd?: string;
+    env?: NodeJS.ProcessEnv;
+    sourcePrepareCore?: boolean;
+    sourcePush?: boolean;
+  } = {},
 ) {
   return spawnSync(
     "bash",
@@ -58,6 +63,7 @@ function runGatesBash(
         `script_parent_dir='${repoRoot}/scripts'`,
         `source '${repoRoot}/scripts/pr-lib/common.sh'`,
         `source '${repoRoot}/scripts/pr-lib/gates.sh'`,
+        ...(options.sourcePush ? [`source '${repoRoot}/scripts/pr-lib/push.sh'`] : []),
         ...(options.sourcePrepareCore
           ? [`source '${repoRoot}/scripts/pr-lib/prepare-core.sh'`]
           : []),
@@ -164,6 +170,7 @@ function makeSyncRepo(options: { needsRebase: boolean }): string {
   git("checkout", "-q", "prep");
 
   mkdirSync(join(repoDir, ".local"));
+  writeFileSync(join(repoDir, ".local", "hosted-sha"), `${git("rev-parse", "HEAD")}\n`);
   writeFileSync(
     join(repoDir, ".local", "pr-meta.env"),
     "PR_NUMBER=4242\nPR_AUTHOR=steipete\nPR_URL=https://example.test/pr/4242\n",
@@ -176,11 +183,11 @@ function makeSyncRepo(options: { needsRebase: boolean }): string {
 function prepareSyncHeadStubs(): string[] {
   return [
     "enter_worktree() { :; }",
-    "hosted_sha=$(git rev-parse HEAD)",
+    "hosted_sha=$(cat .local/hosted-sha)",
     'gh() { printf "%s\\n" "$hosted_sha"; }',
     "verify_pr_head_branch_matches_expected() { :; }",
+    'verify_prep_head_extends_hosted_head() { git merge-base --is-ancestor "$1" HEAD; }',
     "push_prep_head_to_pr_branch() {",
-    '  [ ! -e .local/prep-sync.env ] || { echo "stale sync evidence reached publication" >&2; return 97; }',
     '  local result_env="$7"',
     "  touch .local/published",
     '  printf \'PUSH_PREP_HEAD_SHA=%q\\nPUSH_LOCAL_PREP_HEAD_SHA=%q\\nPUSHED_FROM_SHA=%q\\nPR_HEAD_SHA_AFTER_PUSH=%q\\n\' "$3" "$3" "$hosted_sha" "$3" > "$result_env"',
@@ -473,102 +480,73 @@ describe("lease-retry gate stamp refresh", () => {
 });
 
 describe("prepare sync-head transitions", () => {
-  it("publishes a changed-patch Testbox rebase with fresh sync evidence", () => {
+  it("publishes only appended fixups when main advances", () => {
     const repoDir = makeSyncRepo({ needsRebase: true });
-    writeFileSync(join(repoDir, ".local", "prep-sync.env"), "PREP_SYNC_TREE=stale\n");
-    writeFileSync(join(repoDir, ".local", "gates.env"), "GATES_MODE=stale\n");
-    writeFileSync(join(repoDir, ".local", "prep.env"), "PREP_HEAD_SHA=stale\n");
+    writeFileSync(join(repoDir, "fixup.ts"), "export const fixed = true;\n");
+    for (const args of [
+      ["add", "fixup.ts"],
+      ["commit", "-qm", "reviewed fixup"],
+    ]) {
+      const commit = spawnSync("git", args, { cwd: repoDir, encoding: "utf8" });
+      expect(commit.status, commit.stderr).toBe(0);
+    }
+    const localHead = spawnSync("git", ["rev-parse", "HEAD"], {
+      cwd: repoDir,
+      encoding: "utf8",
+    }).stdout.trim();
 
     const result = runGatesBash(
       [
         ...prepareSyncHeadStubs(),
-        "resolve_prep_sync_evidence_sha() { touch .local/evidence-called; printf '%s\\n' \"$2\"; }",
         "prepare_sync_head 4242",
-        "source .local/prep-sync.env",
-        'test "$PREP_SYNC_TREE" = "$(git rev-parse HEAD^{tree})"',
-        'test "$PREP_SYNC_PATCH_ID" = "$(compute_pr_patch_id origin/main HEAD)"',
-        'test -z "$PREP_SYNC_EVIDENCE_SHA"',
+        `test "$(git rev-parse HEAD)" = "${localHead}"`,
+        'test "$(git diff --name-only "$hosted_sha" HEAD)" = "fixup.ts"',
+        'git merge-base --is-ancestor "$hosted_sha" HEAD',
+        "! git merge-base --is-ancestor origin/main HEAD",
         "test -e .local/published",
-        "test ! -e .local/evidence-called",
-        "test ! -e .local/gates.env",
-        "test ! -e .local/prep.env",
-        'printf "SYNC_EVIDENCE=<%s>\\n" "$PREP_SYNC_EVIDENCE_SHA"',
+        "grep -F 'Preserved hosted PR ancestry' .local/prep.md",
       ].join("\n"),
       { cwd: repoDir, env: { OPENCLAW_TESTBOX: "1" }, sourcePrepareCore: true },
     );
 
     expect(result.status, result.stderr).toBe(0);
-    expect(result.stdout).toContain("Rebase changed the PR patch");
     expect(result.stdout).toContain("prepare-sync-head complete");
-    expect(result.stdout).toContain("SYNC_EVIDENCE=<>\n");
-  });
-
-  it("clears stale sync evidence before a new publication attempt", () => {
-    const repoDir = makeSyncRepo({ needsRebase: false });
-    writeFileSync(join(repoDir, ".local", "prep-sync.env"), "PREP_SYNC_TREE=stale\n");
-
-    const result = runGatesBash(
-      [
-        ...prepareSyncHeadStubs(),
-        "prepare_sync_head 4242",
-        "test -e .local/published",
-        "test ! -e .local/prep-sync.env",
-        'printf "STALE_SYNC_EXISTS=no\\n"',
-      ].join("\n"),
-      { cwd: repoDir, env: { OPENCLAW_TESTBOX: "1" }, sourcePrepareCore: true },
-    );
-
-    expect(result.status, result.stderr).toBe(0);
-    expect(result.stdout).toContain("STALE_SYNC_EXISTS=no\n");
+    expect(result.stdout).not.toContain("Rebase");
   });
 });
 
-describe("prepare gate stamp transitions", () => {
-  it("preserves whitespace in the rebase patch fingerprint", () => {
-    const { repoDir, headSha: baseSha } = makeRetryRepo();
-    writeFileSync(join(repoDir, "config.yml"), "root:\n  child: value\n");
-    spawnSync("git", ["add", "config.yml"], { cwd: repoDir });
-    spawnSync(
-      "git",
-      ["-c", "user.name=t", "-c", "user.email=t@example.com", "commit", "-qm", "two spaces"],
-      { cwd: repoDir },
-    );
-    const twoSpaceSha = spawnSync("git", ["rev-parse", "HEAD"], {
-      cwd: repoDir,
-      encoding: "utf8",
-    }).stdout.trim();
-    writeFileSync(join(repoDir, "config.yml"), "root:\n    child: value\n");
-    spawnSync("git", ["add", "config.yml"], { cwd: repoDir });
-    spawnSync(
-      "git",
-      ["-c", "user.name=t", "-c", "user.email=t@example.com", "commit", "-qm", "four spaces"],
-      { cwd: repoDir },
-    );
-    const fourSpaceSha = spawnSync("git", ["rev-parse", "HEAD"], {
-      cwd: repoDir,
-      encoding: "utf8",
-    }).stdout.trim();
+describe("GraphQL fork publication", () => {
+  it("accepts fixups appended to the hosted head", () => {
+    const { repoDir, headSha } = makeRetryRepo();
+    writeFileSync(join(repoDir, "fixup.ts"), "export const fixed = true;\n");
+    for (const args of [
+      ["add", "fixup.ts"],
+      ["commit", "-qm", "reviewed fixup"],
+    ]) {
+      const commit = spawnSync("git", args, { cwd: repoDir, encoding: "utf8" });
+      expect(commit.status, commit.stderr).toBe(0);
+    }
 
     const result = runGatesBash(
       [
-        `compute_pr_patch_id ${baseSha} ${twoSpaceSha}`,
-        `compute_pr_patch_id ${baseSha} ${fourSpaceSha}`,
+        'gh() { touch .local/gh-called; printf \'%s\\n\' \'{"data":{"createCommitOnBranch":{"commit":{"oid":"signed-head","url":"https://example.test/commit"}}}}\'; }',
+        `graphql_push_to_fork example/repo topic ${headSha}`,
+        "test -e .local/gh-called",
       ].join("\n"),
-      { cwd: repoDir },
+      { cwd: repoDir, sourcePush: true },
     );
-    expect(result.status).toBe(0);
-    const patchIds = result.stdout.trim().split("\n");
-    expect(patchIds).toHaveLength(2);
-    expect(patchIds[0]).not.toBe(patchIds[1]);
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain("signed-head");
   });
 
-  it("uses the hosted pre-sync SHA only when its tree matches the local prep head", () => {
+  it("rejects rewritten history before encoding files or calling GitHub", () => {
     const { repoDir, headSha } = makeRetryRepo();
     const tree = spawnSync("git", ["rev-parse", "HEAD^{tree}"], {
       cwd: repoDir,
       encoding: "utf8",
     }).stdout.trim();
-    const remoteSha = spawnSync(
+    const unrelatedHead = spawnSync(
       "git",
       [
         "-c",
@@ -577,51 +555,32 @@ describe("prepare gate stamp transitions", () => {
         "user.email=t@example.com",
         "commit-tree",
         tree,
-        "-p",
-        headSha,
         "-m",
-        "hosted head",
+        "rewritten",
       ],
       { cwd: repoDir, encoding: "utf8" },
     ).stdout.trim();
-
-    const matching = runGatesBash(`resolve_prep_sync_evidence_sha ${headSha} ${remoteSha}`, {
+    const checkout = spawnSync("git", ["checkout", "-q", "--detach", unrelatedHead], {
       cwd: repoDir,
-      sourcePrepareCore: true,
+      encoding: "utf8",
     });
-    expect(matching.status).toBe(0);
-    expect(matching.stdout.trim()).toBe(remoteSha);
+    expect(checkout.status, checkout.stderr).toBe(0);
 
-    writeFileSync(join(repoDir, "changed.ts"), "export {};\n");
-    spawnSync("git", ["add", "changed.ts"], { cwd: repoDir });
-    spawnSync(
-      "git",
-      ["-c", "user.name=t", "-c", "user.email=t@example.com", "commit", "-qm", "different"],
-      { cwd: repoDir },
-    );
-    const mismatched = runGatesBash(
-      `resolve_prep_sync_evidence_sha ${headSha} $(git rev-parse HEAD)`,
-      { cwd: repoDir, sourcePrepareCore: true },
-    );
-    expect(mismatched.status).not.toBe(0);
-  });
-
-  it("forwards only the recorded pre-rebase SHA as recent evidence", () => {
     const result = runGatesBash(
       [
-        "gh() { if [ \"$1\" = pr ]; then printf 'deadbeef\\n'; else printf 'openclaw/openclaw\\n'; fi; }",
-        "run_quiet_logged() { printf 'ARG:%s\\n' \"$@\"; }",
-        "run_hosted_prepare_gates 100606 deadbeef false cafebabe",
+        "gh() { touch .local/gh-called; return 99; }",
+        `graphql_push_to_fork example/repo topic ${headSha}`,
       ].join("\n"),
+      { cwd: repoDir, sourcePush: true },
     );
 
-    expect(result.status).toBe(0);
-    expect(result.stdout).toContain("ARG:hosted CI/Testbox gates");
-    expect(result.stdout).toContain(`ARG:${repoRoot}/scripts/verify-pr-hosted-gates.mjs`);
-    expect(result.stdout).toContain("ARG:--pr\nARG:100606");
-    expect(result.stdout).toContain("ARG:--recent-sha\nARG:cafebabe");
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("refused rewritten history");
+    expect(existsSync(join(repoDir, ".local", "gh-called"))).toBe(false);
   });
+});
 
+describe("prepare gate stamp transitions", () => {
   it.each([
     ["CHANGELOG.md", true],
     ["changed.ts", false],
@@ -711,33 +670,7 @@ describe("prepare gate stamp transitions", () => {
       ["-c", "user.name=t", "-c", "user.email=t@example.com", "commit", "-qm", "change"],
       { cwd: repoDir },
     );
-    const prepTree = spawnSync("git", ["rev-parse", "HEAD^{tree}"], {
-      cwd: repoDir,
-      encoding: "utf8",
-    }).stdout.trim();
-    const mainlineBase = spawnSync("git", ["rev-parse", "refs/remotes/origin/main"], {
-      cwd: repoDir,
-      encoding: "utf8",
-    }).stdout.trim();
-    const patchId = spawnSync(
-      "bash",
-      [
-        "-c",
-        "git diff --binary refs/remotes/origin/main HEAD | git patch-id --verbatim | awk 'NR == 1 { print $1 }'",
-      ],
-      { cwd: repoDir, encoding: "utf8" },
-    ).stdout.trim();
     writeFileSync(join(repoDir, ".local", "pr-meta.env"), "PR_AUTHOR=steipete\n");
-    writeFileSync(
-      join(repoDir, ".local", "prep-sync.env"),
-      [
-        `PREP_SYNC_MAINLINE_BASE_SHA=${mainlineBase}`,
-        `PREP_SYNC_TREE=${prepTree}`,
-        `PREP_SYNC_PATCH_ID=${patchId}`,
-        "PREP_SYNC_EVIDENCE_SHA=cafebabe",
-        "",
-      ].join("\n"),
-    );
     writeFileSync(
       join(repoDir, ".local", "gates.env"),
       [
@@ -756,7 +689,7 @@ describe("prepare gate stamp transitions", () => {
         "checkout_prep_branch() { :; }",
         "path_is_docsish() { return 1; }",
         "changelog_required_for_changed_files() { return 1; }",
-        "run_hosted_prepare_gates() { printf 'RECENT:%s\\n' \"${4:-}\"; }",
+        "run_hosted_prepare_gates() { printf 'HOSTED\\n'; }",
         "prepare_gates 4242",
         "cat .local/gates.env",
       ].join("\n"),
@@ -764,8 +697,8 @@ describe("prepare gate stamp transitions", () => {
     );
 
     expect(result.status).toBe(0);
-    expect(result.stdout).toContain("GATES_MODE=hosted_exact_or_recent_rebase");
-    expect(result.stdout).toContain("RECENT:cafebabe");
+    expect(result.stdout).toContain("GATES_MODE=hosted_exact_or_recent_parent");
+    expect(result.stdout).toContain("HOSTED");
     expect(result.stdout).toContain("REMOTE_GATES_LEASE_ID=''");
     expect(result.stdout).not.toContain("tbx_stale");
   });

--- a/test/scripts/pr-prepare-gates.test.ts
+++ b/test/scripts/pr-prepare-gates.test.ts
@@ -94,17 +94,9 @@ function makeRetryRepo(): { repoDir: string; stubBin: string; headSha: string } 
   mkdirSync(repoDir);
   for (const args of [
     ["init", "-q"],
-    [
-      "-c",
-      "user.name=t",
-      "-c",
-      "user.email=t@example.com",
-      "commit",
-      "-q",
-      "--allow-empty",
-      "-m",
-      "retry head",
-    ],
+    ["config", "user.name", "t"],
+    ["config", "user.email", "t@example.com"],
+    ["commit", "-q", "--allow-empty", "-m", "retry head"],
   ]) {
     const result = spawnSync("git", args, { cwd: repoDir, encoding: "utf8" });
     expect(result.status).toBe(0);


### PR DESCRIPTION
Closes #108016

## What Problem This Solves

Fixes two stale-main assumptions that made maintainer updates to long-lived contributor PRs slow and unsafe: `scripts/pr prepare-sync-head` rebased the contributor branch, and PR CI compared the tested merge commit with an old event base SHA.

## Why This Change Was Made

Fork sync now preserves the hosted PR head as its publication parent and publishes only appended reviewed fixups. Mainline drift remains merge verification's responsibility; rewritten prep history fails before any file encoding or GitHub call. CI resolves the tested merge commit's exact first parent once, then uses that canonical base for changed-file routing, docs scope, security checks, and downstream guards. The security lane parses Git parents directly instead of executing an untrusted PR helper before selecting trusted configuration.

## User Impact

No product runtime behavior changes. Maintainers can land independent contributor PRs without rebasing every branch after unrelated merges, old PRs no longer fan out over unrelated changes, and malformed fork syncs fail quickly with a precise recovery instruction.

## Evidence

- Blacksmith Testbox `tbx_01kxj2k5cnhm2fxdeapqhwgbzb`: focused coordinator/CI tests 89/89 passed; `pnpm check:changed` passed.
- Blacksmith Testbox changed-surface gate: https://github.com/openclaw/openclaw/actions/runs/29389868293
- Live stale-base replay from PR #95729: old event SHA produced 12,521 changed files; exact tested merge parent produced the actual 10-file PR delta.
- Live fork-sync reproduction against PR #95729: rewritten ancestry rejected before payload construction, then a valid one-file fixup published successfully.
- Live polluted-history repair against PR #97827: hosted PR collapsed from 123 files to its reviewed 9-file delta.
- `bash -n scripts/pr-lib/gates.sh scripts/pr-lib/prepare-core.sh scripts/pr-lib/push.sh` — passed.
- Fresh `$autoreview --mode local` — clean after resolving the security-boundary finding.
