### PR TITLE
fix(synology-chat): replies target the wrong user when Unicode nicknames span response chunks

### DIFF
--- a/extensions/synology-chat/src/client.test.ts
+++ b/extensions/synology-chat/src/client.test.ts
@@ -344,6 +344,36 @@ describe("resolveLegacyWebhookNameToChatUserId", () => {
     expect(result).toBe(4);
   });
 
+  it("preserves UTF-8 when user_list splits a nickname across response chunks", async () => {
+    const nickname = "猫";
+    const responseBody = Buffer.from(
+      JSON.stringify({
+        success: true,
+        data: { users: [{ user_id: 4, username: "jmn67", nickname }] },
+      }),
+      "utf8",
+    );
+    const nicknameOffset = responseBody.indexOf(Buffer.from(nickname, "utf8"));
+    const splitAt = nicknameOffset + 1;
+    vi.mocked(https.get).mockImplementation(((_url, _opts, callback) => {
+      const res = createMockResponseEmitter(200);
+      process.nextTick(() => {
+        callback?.(res);
+        res.emit("data", responseBody.subarray(0, splitAt));
+        res.emit("data", responseBody.subarray(splitAt));
+        res.emit("end");
+      });
+      return createMockRequestEmitter();
+    }) as MockRequestHandler);
+
+    const result = await resolveLegacyWebhookNameToChatUserId({
+      incomingUrl: baseUrl,
+      mutableWebhookUsername: nickname,
+    });
+
+    expect(result).toBe(4);
+  });
+
   it("resolves user by username when nickname does not match", async () => {
     mockUserListResponse([
       { user_id: 4, username: "jmn67", nickname: "" },

--- a/extensions/synology-chat/src/client.test.ts
+++ b/extensions/synology-chat/src/client.test.ts
@@ -1,6 +1,7 @@
 // Synology Chat tests cover client plugin behavior.
 import { EventEmitter } from "node:events";
 import type { ClientRequest, IncomingMessage, RequestOptions } from "node:http";
+import { PassThrough } from "node:stream";
 import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from "vitest";
 
 const ssrfMocks = {
@@ -46,6 +47,7 @@ type MockHttpCall = [
   RequestOptions & { rejectUnauthorized?: boolean },
   RequestCallback?,
 ];
+type MockResponse = IncomingMessage & PassThrough;
 
 function firstHttpsRequestCall(label = "Synology Chat HTTPS request"): MockHttpCall {
   const call = vi.mocked(https.request).mock.calls[0];
@@ -63,10 +65,10 @@ function firstHttpsGetCall(label = "Synology Chat HTTPS get"): MockHttpCall {
   return call as MockHttpCall;
 }
 
-function createMockResponseEmitter(statusCode: number): IncomingMessage {
-  const res = new EventEmitter() as Partial<IncomingMessage>;
+function createMockResponseEmitter(statusCode: number): MockResponse {
+  const res = new PassThrough() as PassThrough & Partial<IncomingMessage>;
   res.statusCode = statusCode;
-  return res as unknown as IncomingMessage;
+  return res as unknown as MockResponse;
 }
 
 function createMockRequestEmitter(): ClientRequest {
@@ -90,8 +92,7 @@ function mockResponse(statusCode: number, body: string) {
     const res = createMockResponseEmitter(statusCode);
     process.nextTick(() => {
       callback?.(res);
-      res.emit("data", Buffer.from(body));
-      res.emit("end");
+      res.end(body);
     });
     return createMockRequestEmitter();
   }) as MockRequestHandler);
@@ -298,8 +299,7 @@ function mockUserListResponseImpl(users: Array<Record<string, unknown>>, once: b
     const res = createMockResponseEmitter(200);
     process.nextTick(() => {
       callback?.(res);
-      res.emit("data", Buffer.from(JSON.stringify({ success: true, data: { users } })));
-      res.emit("end");
+      res.end(JSON.stringify({ success: true, data: { users } }));
     });
     return createMockRequestEmitter();
   };
@@ -359,9 +359,8 @@ describe("resolveLegacyWebhookNameToChatUserId", () => {
       const res = createMockResponseEmitter(200);
       process.nextTick(() => {
         callback?.(res);
-        res.emit("data", responseBody.subarray(0, splitAt));
-        res.emit("data", responseBody.subarray(splitAt));
-        res.emit("end");
+        res.write(responseBody.subarray(0, splitAt));
+        res.end(responseBody.subarray(splitAt));
       });
       return createMockRequestEmitter();
     }) as MockRequestHandler);

--- a/extensions/synology-chat/src/client.ts
+++ b/extensions/synology-chat/src/client.ts
@@ -5,6 +5,7 @@
 
 import * as http from "node:http";
 import * as https from "node:https";
+import { StringDecoder } from "node:string_decoder";
 import { safeParseJsonWithSchema, safeParseWithSchema } from "openclaw/plugin-sdk/extension-shared";
 import { parseStrictNonNegativeInteger } from "openclaw/plugin-sdk/number-runtime";
 import { sleep } from "openclaw/plugin-sdk/runtime-env";
@@ -182,11 +183,13 @@ async function fetchChatUsers(
 
     const req = transport
       .get(listUrl, requestOptions, (res) => {
+        const decoder = new StringDecoder("utf8");
         let data = "";
         res.on("data", (c: Buffer) => {
-          data += c.toString();
+          data += decoder.write(c);
         });
         res.on("end", () => {
+          data += decoder.end();
           const result = safeParseJsonWithSchema(ChatUserListResponseSchema, data);
           if (!result) {
             log?.warn("fetchChatUsers: failed to parse user_list response");

--- a/extensions/synology-chat/src/client.ts
+++ b/extensions/synology-chat/src/client.ts
@@ -5,7 +5,6 @@
 
 import * as http from "node:http";
 import * as https from "node:https";
-import { StringDecoder } from "node:string_decoder";
 import { safeParseJsonWithSchema, safeParseWithSchema } from "openclaw/plugin-sdk/extension-shared";
 import { parseStrictNonNegativeInteger } from "openclaw/plugin-sdk/number-runtime";
 import { sleep } from "openclaw/plugin-sdk/runtime-env";
@@ -183,13 +182,12 @@ async function fetchChatUsers(
 
     const req = transport
       .get(listUrl, requestOptions, (res) => {
-        const decoder = new StringDecoder("utf8");
+        res.setEncoding("utf8");
         let data = "";
-        res.on("data", (c: Buffer) => {
-          data += decoder.write(c);
+        res.on("data", (chunk: string) => {
+          data += chunk;
         });
         res.on("end", () => {
-          data += decoder.end();
           const result = safeParseJsonWithSchema(ChatUserListResponseSchema, data);
           if (!result) {
             log?.warn("fetchChatUsers: failed to parse user_list response");
@@ -327,13 +325,10 @@ function doPost(url: string, body: string, allowInsecureSsl = false): Promise<bo
         rejectUnauthorized: !allowInsecureSsl,
       },
       (res) => {
-        let data = "";
-        res.on("data", (chunk: Buffer) => {
-          data += chunk.toString();
-        });
         res.on("end", () => {
           resolve(res.statusCode === 200);
         });
+        res.resume();
       },
     );
 


### PR DESCRIPTION
<!--
Optional linked context:
Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
below this comment.

Required PR title:
type: user-facing description
Use a parenthesized scope only when it adds clarity:
fix(auth): login redirect loops when session cookie is expired

Types: feat, fix, improve, refactor, docs, chore.
For fixes, describe the user-visible symptom and trigger:
fix: task list fails to load when user has no environments
Avoid implementation details such as:
fix: add null check to task query
-->

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where Synology Chat replies could target the wrong user or fail when `dangerouslyAllowNameMatching` was enabled and the `user_list` response split a Unicode nickname across HTTP chunks.

Synology outgoing webhooks and the chatbot API can use different user-id spaces. The compatibility path resolves the canonical chatbot user id by nickname. Independent per-chunk UTF-8 decoding could corrupt that nickname, miss the match, and fall back to the webhook-local id.

## Why This Change Was Made

Decode the Synology `user_list` response as one stateful UTF-8 stream before JSON parsing and caching. The fix stays at the response owner and preserves the existing schema validation, five-minute cache, request timeout, TLS behavior, matching order, and fallback policy.

No config, schema, migration, public API, or default behavior changes. The opt-in `dangerouslyAllowNameMatching` boundary is unchanged.

## User Impact

Synology Chat users with Unicode nicknames now keep the canonical chatbot recipient id even when the NAS or network fragments the response inside a multibyte character. ASCII names and normal unsplit responses continue to behave as before.

## Evidence

### Before

Pinned discovery main `7748574c4b373eb3d29ff5113ce87c0c13260f5c` and the final latest-main snapshot `6ce439da25652a0e7588df5b58388cbc22f89545` both reproduced the issue through the real plugin HTTP path:

```text
ascii inbound_status=204
unicode inbound_status=204
ascii expected_user_ids=[4] actual_user_ids=[4]
unicode WARN Could not resolve Chat API user_id for "猫" — falling back to webhook user_id 1. Reply delivery may fail.
unicode expected_user_ids=[4] actual_user_ids=[1]
```

The exact regression test also failed before the production change with `expected undefined to be 4`.

### After

A real plugin-runtime proof used two local TCP HTTP servers: one exposed the production Synology webhook handler, and one emulated the Synology `user_list` and chatbot endpoints. The Unicode response was split after the first byte of `猫`.

```text
ascii INFO Message from alice (1): /status
ascii inbound_status=204
unicode INFO Message from 猫 (1): /status
unicode inbound_status=204
ascii INFO Reply sent to alice (4): local command response
unicode INFO Reply sent to 猫 (4): local command response
ascii expected_user_ids=[4] actual_user_ids=[4]
unicode expected_user_ids=[4] actual_user_ids=[4]
```

### Validation

- Synology client suite: 23 tests passed.
- Synology plugin `tsgo --noEmit`: passed.
- Targeted oxlint: passed.
- Targeted oxfmt check: passed.
- `git diff --check`: passed.
- Open-PR competition scan: 80 recalled PRs assessed; no same-problem open PR.
- Related history checked: merged #23709 introduced canonical user-id resolution but did not cover UTF-8 chunk boundaries.

The repository changed-surface wrapper classified this for remote Testbox, but its local handoff did not start because pnpm retried an unrelated Matrix crypto postinstall download and timed out. No changed-surface pass is claimed; hosted CI remains the broad validation boundary.
