### PR TITLE
improve: speed doctor plugin install tests

### DIFF
--- a/src/commands/doctor/shared/missing-configured-plugin-install.test.ts
+++ b/src/commands/doctor/shared/missing-configured-plugin-install.test.ts
@@ -11,6 +11,7 @@ import {
   resolveClawHubInstallSpecsForUpdateChannel,
   resolveNpmInstallSpecsForUpdateChannel,
 } from "../../../plugins/install-channel-specs.js";
+import type { BundledProviderPolicySurface } from "../../../plugins/provider-policy-surface.js";
 import { VERSION } from "../../../version.js";
 import { applyLegacyDoctorMigrations } from "./legacy-config-compat.js";
 
@@ -74,6 +75,27 @@ const mocks = vi.hoisted(() => ({
   resolveOfficialExternalProviderPluginIds: vi.fn(),
   resolveOfficialExternalProviderPluginIdsForEnv: vi.fn(),
   resolveOfficialExternalWebProviderContractPluginIdsForEnv: vi.fn(),
+  resolveDirectBundledProviderPolicySurface: vi.fn(
+    (pluginId: string): BundledProviderPolicySurface | null =>
+      pluginId === "openai"
+        ? {
+            normalizeModelCatalogId: ({ modelId }) => modelId,
+            resolveModelRoutes: ({ requestTransportOverrides }) => ({
+              kind: "routes",
+              routes: [
+                {
+                  api: "openai-responses",
+                  baseUrl: "https://api.openai.com/v1",
+                  authRequirement: "api-key",
+                  requestTransportOverrides: requestTransportOverrides ?? "none",
+                  runtimePolicy: { compatibleIds: ["openclaw", "codex"] },
+                },
+              ],
+              defaultRuntimeId: "codex",
+            }),
+          }
+        : null,
+  ),
   resolveDefaultPluginExtensionsDir: vi.fn(() => "/tmp/openclaw-plugins"),
   resolveDefaultPluginNpmDir: vi.fn(() => "/tmp/openclaw-npm"),
   resolvePluginNpmProjectsDir: vi.fn((npmDir = "/tmp/openclaw-npm") =>
@@ -201,6 +223,13 @@ vi.mock("../../../plugins/official-external-plugin-catalog.js", () => ({
 
 vi.mock("../../../plugins/provider-install-catalog.js", () => ({
   resolveProviderInstallCatalogEntries: mocks.resolveProviderInstallCatalogEntries,
+}));
+
+vi.mock("../../../plugins/provider-policy-surface.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../../plugins/provider-policy-surface.js")>()),
+  // This suite owns install repair. Provider artifact loading and route policy
+  // have dedicated tests, so keep the OpenAI runtime-selection seam in memory.
+  resolveDirectBundledProviderPolicySurface: mocks.resolveDirectBundledProviderPolicySurface,
 }));
 
 vi.mock("../../../plugins/doctor-contract-registry.js", async (importOriginal) => {
@@ -2524,6 +2553,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
       env: {},
     });
 
+    expect(mocks.resolveDirectBundledProviderPolicySurface).toHaveBeenCalledWith("openai");
     expect(mocks.updateNpmInstalledPlugins).not.toHaveBeenCalled();
     expectRecordFields(mockCallArg(mocks.installPluginFromNpmSpec), {
       spec: expectedNpmInstallSpec("@openclaw/codex"),


### PR DESCRIPTION
## What Problem This Solves

The doctor plugin-install test file spent most of its time loading the real bundled OpenAI provider-policy artifact even though this suite owns install repair, not artifact loading or route-policy behavior.

## Why This Change Was Made

The suite now supplies a typed in-memory provider-policy surface at its existing runtime-selection seam. Dedicated harness-runtime, provider-policy loader, and OpenAI provider-policy suites continue to exercise the real artifact and route behavior.

## User Impact

No product behavior changes. Maintainers get a faster doctor test file and quicker focused CI feedback.

## Evidence

- Focused file: 84 tests pass.
- Slow case: 678 ms before, 3 ms after (99.6% faster).
- Whole file: 3.05 s before, 1.26 s after (58.7% faster).
- Coverage-preservation run: 144 tests pass across the doctor repair, harness runtime, provider-policy loader, and OpenAI provider-policy suites.
- Changed gate: passed on Blacksmith Testbox tbx_01kxj2j0wtwfwpwt5ynjdt4d7c in 2m52s.
- Testbox run: https://github.com/openclaw/openclaw/actions/runs/29390494783
- Fresh autoreview: no accepted or actionable findings.
- AI-assisted: yes; change understood and reviewed.
