### PR TITLE
fix: recover GitHub Copilot sessions with invalid tool call ids

### DIFF
--- a/src/agents/embedded-agent-runner/run-loop.ts
+++ b/src/agents/embedded-agent-runner/run-loop.ts
@@ -29,6 +29,10 @@ import { prepareAndDispatchEmbeddedRunAttempt } from "./run/attempt-dispatch-pre
 import { normalizeEmbeddedRunAttempt } from "./run/attempt-normalization.js";
 import { recoverEmbeddedRunAttempt } from "./run/attempt-recovery.js";
 import { forgetPromptBuildDrainCacheForRun } from "./run/attempt.prompt-helpers.js";
+import {
+  shouldForceToolCallIdSanitization,
+  shouldRetryWithForcedToolCallIdSanitization,
+} from "./run/attempt.transcript-policy.js";
 import { hasCodexAppServerRecoveryRetryBudget } from "./run/codex-app-server-recovery.js";
 import { createEmbeddedRunCompactionRuntime } from "./run/compaction-runtime.js";
 import { createEmbeddedRunContextRecoveryState } from "./run/context-recovery-state.js";
@@ -269,6 +273,7 @@ export async function runPreparedEmbeddedLoop(
       sessionPromptState,
     });
     let authRetryPending = false;
+    let forceToolCallIdSanitizationApi: string | undefined;
     let accumulatedReplayState = createEmbeddedRunReplayState();
     // Hoisted so the retry-limit error path can use the most recent API total.
     let lastTurnTotal: number | undefined;
@@ -313,6 +318,10 @@ export async function runPreparedEmbeddedLoop(
       const runtimeAuthRetry: boolean = authRetryPending;
       authRetryPending = false;
       attemptedThinking.add(thinkLevel);
+      const forceToolCallIdSanitization = shouldForceToolCallIdSanitization({
+        forceToolCallIdSanitizationApi,
+        modelApi: effectiveModel.api,
+      });
       const codexAppServerRecoveryRetryAvailable = hasCodexAppServerRecoveryRetryBudget({
         alreadyRetried: codexAppServerRecoveryRetries > 0,
         runLoopIterations,
@@ -327,6 +336,7 @@ export async function runPreparedEmbeddedLoop(
         replayState: accumulatedReplayState,
         provider,
         modelId,
+        forceToolCallIdSanitization,
         startupStagesEmitted,
         bootstrapPromptWarningSignaturesSeen,
         resolveRuntimeFallbackReason,
@@ -435,6 +445,19 @@ export async function runPreparedEmbeddedLoop(
         continue;
       }
       const { shouldSurfaceCodexCompletionTimeout } = recovery;
+
+      if (
+        shouldRetryWithForcedToolCallIdSanitization({
+          cloudCodeAssistFormatError: attempt.cloudCodeAssistFormatError,
+          errorMessage: attemptAssistant?.errorMessage,
+          forceToolCallIdSanitizationApi,
+          modelApi: effectiveModel.api,
+        })
+      ) {
+        forceToolCallIdSanitizationApi = effectiveModel.api;
+        lastRetryFailoverReason = "format";
+        continue;
+      }
 
       const assistantFailureOutcome = await handleEmbeddedAssistantFailure({
         runParams: params,

--- a/src/agents/embedded-agent-runner/run/attempt-dispatch-preparation.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-dispatch-preparation.ts
@@ -32,6 +32,7 @@ export async function prepareAndDispatchEmbeddedRunAttempt(input: {
   replayState: ReturnType<typeof createEmbeddedRunReplayState>;
   provider: string;
   modelId: string;
+  forceToolCallIdSanitization: boolean;
   startupStagesEmitted: boolean;
   bootstrapPromptWarningSignaturesSeen: string[];
   resolveRuntimeFallbackReason: () => string | null;
@@ -188,6 +189,7 @@ export async function prepareAndDispatchEmbeddedRunAttempt(input: {
       agentHarnessId: runtime.agentHarness.id,
       expectedRuntimeArtifact: expectedHarnessArtifact?.artifact,
       runtimePlan,
+      forceToolCallIdSanitization: input.forceToolCallIdSanitization,
       model: runtime.effectiveModel,
       resolvedApiKey: resolvedStreamApiKey,
       authProfileId: runtime.lastProfileId,

--- a/src/agents/embedded-agent-runner/run/attempt-session-manager-prepare.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-session-manager-prepare.ts
@@ -72,6 +72,7 @@ export async function prepareEmbeddedAttemptSessionManager(input: {
     },
     provider: attempt.provider,
     modelId: attempt.modelId,
+    forceToolCallIdSanitization: attempt.forceToolCallIdSanitization,
     config: attempt.config,
     env: process.env,
   });

--- a/src/agents/embedded-agent-runner/run/attempt.transcript-policy.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.transcript-policy.test.ts
@@ -2,7 +2,11 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ProviderRuntimeModel } from "../../../plugins/provider-runtime-model.types.js";
 import type { AgentRuntimePlan } from "../../runtime-plan/types.js";
-import { resolveAttemptTranscriptPolicy } from "./attempt.transcript-policy.js";
+import {
+  resolveAttemptTranscriptPolicy,
+  shouldForceToolCallIdSanitization,
+  shouldRetryWithForcedToolCallIdSanitization,
+} from "./attempt.transcript-policy.js";
 
 const resolveProviderRuntimePluginMock = vi.hoisted(() => vi.fn());
 
@@ -64,6 +68,106 @@ describe("resolveAttemptTranscriptPolicy", () => {
       }),
     ).toBe(plannedPolicy);
     expect(resolvePolicy).toHaveBeenCalledWith(runtimePlanModelContext);
+  });
+
+  it("forces strict tool call id sanitization after a provider format retry", () => {
+    const plannedPolicy = {
+      sanitizeMode: "images-only",
+      sanitizeToolCallIds: false,
+      toolCallIdMode: "strict9",
+      preserveNativeAnthropicToolUseIds: false,
+      repairToolUseResultPairing: true,
+      preserveSignatures: false,
+      dropThinkingBlocks: false,
+      applyGoogleTurnOrdering: false,
+      validateGeminiTurns: false,
+      validateAnthropicTurns: false,
+      allowSyntheticToolResults: false,
+    } as const;
+    const runtimePlan = {
+      transcript: {
+        resolvePolicy: vi.fn(() => plannedPolicy),
+      },
+    } as unknown as AgentRuntimePlan;
+
+    const policy = resolveAttemptTranscriptPolicy({
+      runtimePlan,
+      runtimePlanModelContext: {
+        workspaceDir: ".",
+        modelApi: "anthropic-messages",
+      },
+      provider: "github-copilot",
+      modelId: "claude-sonnet-4",
+      forceToolCallIdSanitization: true,
+    });
+
+    expect(policy).toEqual({
+      ...plannedPolicy,
+      sanitizeToolCallIds: true,
+      toolCallIdMode: "strict",
+    });
+  });
+
+  it("allows exactly one forced sanitization retry for a provider format error", () => {
+    expect(
+      shouldRetryWithForcedToolCallIdSanitization({
+        cloudCodeAssistFormatError: true,
+        errorMessage: "messages.17.content.0.tool_use.id: String should match pattern",
+        modelApi: "anthropic-messages",
+      }),
+    ).toBe(true);
+    expect(
+      shouldRetryWithForcedToolCallIdSanitization({
+        cloudCodeAssistFormatError: true,
+        errorMessage: "tool call id was invalid and must match the required pattern",
+        modelApi: "anthropic-messages",
+      }),
+    ).toBe(true);
+    expect(
+      shouldRetryWithForcedToolCallIdSanitization({
+        cloudCodeAssistFormatError: true,
+        errorMessage: "messages.17.content.0.tool_use.id: String should match pattern",
+        forceToolCallIdSanitizationApi: "anthropic-messages",
+        modelApi: "anthropic-messages",
+      }),
+    ).toBe(false);
+    expect(
+      shouldRetryWithForcedToolCallIdSanitization({
+        cloudCodeAssistFormatError: true,
+        errorMessage: "invalid request format",
+        modelApi: "anthropic-messages",
+      }),
+    ).toBe(false);
+    expect(
+      shouldRetryWithForcedToolCallIdSanitization({
+        cloudCodeAssistFormatError: true,
+        errorMessage: "messages.17.content.0.tool_use.id: String should match pattern",
+        modelApi: "openai-responses",
+      }),
+    ).toBe(false);
+    expect(
+      shouldRetryWithForcedToolCallIdSanitization({
+        cloudCodeAssistFormatError: true,
+        errorMessage: "messages.17.content.0.tool_use.id: String should match pattern",
+        forceToolCallIdSanitizationApi: "anthropic-messages",
+        modelApi: "openai-responses",
+      }),
+    ).toBe(false);
+  });
+
+  it("limits forced sanitization to the API that rejected the transcript", () => {
+    expect(
+      shouldForceToolCallIdSanitization({
+        forceToolCallIdSanitizationApi: "anthropic-messages",
+        modelApi: "anthropic-messages",
+      }),
+    ).toBe(true);
+    expect(
+      shouldForceToolCallIdSanitization({
+        forceToolCallIdSanitizationApi: "anthropic-messages",
+        modelApi: "openai-responses",
+      }),
+    ).toBe(false);
   });
 
   it("keeps the legacy provider transcript fallback when no RuntimePlan is available", () => {

--- a/src/agents/embedded-agent-runner/run/attempt.transcript-policy.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.transcript-policy.ts
@@ -10,6 +10,34 @@ type AttemptRuntimeModelContext = NonNullable<
   Parameters<AgentRuntimePlan["transcript"]["resolvePolicy"]>[0]
 >;
 
+export function shouldForceToolCallIdSanitization(params: {
+  forceToolCallIdSanitizationApi?: string;
+  modelApi?: string;
+}): boolean {
+  return (
+    params.forceToolCallIdSanitizationApi !== undefined &&
+    params.forceToolCallIdSanitizationApi === params.modelApi
+  );
+}
+
+export function shouldRetryWithForcedToolCallIdSanitization(params: {
+  cloudCodeAssistFormatError: boolean;
+  errorMessage?: string;
+  forceToolCallIdSanitizationApi?: string;
+  modelApi?: string;
+}): boolean {
+  const isOpenAIResponsesApi =
+    params.modelApi === "openai-responses" ||
+    params.modelApi === "openai-chatgpt-responses" ||
+    params.modelApi === "azure-openai-responses";
+  return (
+    params.cloudCodeAssistFormatError &&
+    !shouldForceToolCallIdSanitization(params) &&
+    !isOpenAIResponsesApi &&
+    /tool[._\s-]+(?:use|call)[._\s-]+id/i.test(params.errorMessage ?? "")
+  );
+}
+
 /**
  * Adapts the RuntimePlan model context to the legacy provider-runtime model
  * shape used by transcript-policy fallbacks.
@@ -30,10 +58,11 @@ export function resolveAttemptTranscriptPolicy(params: {
   runtimePlanModelContext: AttemptRuntimeModelContext;
   provider: string;
   modelId: string;
+  forceToolCallIdSanitization?: boolean;
   config?: OpenClawConfig;
   env?: NodeJS.ProcessEnv;
 }): TranscriptPolicy {
-  return (
+  const policy =
     params.runtimePlan?.transcript.resolvePolicy(params.runtimePlanModelContext) ??
     resolveTranscriptPolicy({
       modelApi: params.runtimePlanModelContext.modelApi,
@@ -43,6 +72,13 @@ export function resolveAttemptTranscriptPolicy(params: {
       workspaceDir: params.runtimePlanModelContext.workspaceDir,
       env: params.env ?? process.env,
       model: asProviderRuntimeModel(params.runtimePlanModelContext.model),
-    })
-  );
+    });
+  if (!params.forceToolCallIdSanitization) {
+    return policy;
+  }
+  return {
+    ...policy,
+    sanitizeToolCallIds: true,
+    toolCallIdMode: "strict",
+  };
 }

--- a/src/agents/embedded-agent-runner/run/run-attempt-dispatch.ts
+++ b/src/agents/embedded-agent-runner/run/run-attempt-dispatch.ts
@@ -44,6 +44,7 @@ type AttemptRuntime = {
   agentHarnessId: string;
   expectedRuntimeArtifact?: AgentHarnessRuntimeArtifactBinding;
   runtimePlan: AgentRuntimePlan;
+  forceToolCallIdSanitization: boolean;
   model: EmbeddedRunAttemptParams["model"];
   resolvedApiKey?: string;
   authProfileId?: string;
@@ -249,6 +250,7 @@ export async function dispatchEmbeddedRunAttempt(input: {
       : {}),
     runtimePlan: runtime.runtimePlan,
     observeToolTerminal,
+    forceToolCallIdSanitization: runtime.forceToolCallIdSanitization,
     model: applyAuthHeaderOverride(
       applyLocalNoAuthHeaderOverride(runtime.model, runtime.apiKeyInfo),
       runtime.runtimeAuthActive ? null : runtime.apiKeyInfo,

--- a/src/agents/embedded-agent-runner/run/types.ts
+++ b/src/agents/embedded-agent-runner/run/types.ts
@@ -128,6 +128,8 @@ export type EmbeddedRunAttemptParams = EmbeddedRunAttemptBase & {
   runtimePlan?: AgentRuntimePlan;
   /** Reports terminal tool facts to the host-owned attempt outcome accumulator. */
   observeToolTerminal?: EmbeddedRunAttemptToolTerminalObserver;
+  /** Force replay-safe tool call IDs after a provider rejects the prior transcript format. */
+  forceToolCallIdSanitization?: boolean;
   /** Host-issued scope for harnesses that mirror native child runs into task state. */
   agentHarnessTaskRuntimeScope?: AgentHarnessTaskRuntimeScope;
   /** Storage-neutral trajectory target for harness-owned runtime trace artifacts. */


### PR DESCRIPTION
Closes #108002

## What Problem This Solves

Fixes an issue where users running Claude through GitHub Copilot could receive the same invalid tool-call ID rejection repeatedly even after OpenClaw announced that tool calls would be sanitized on retry.

## Why This Change Was Made

The first explicit tool-call ID format rejection now triggers one bounded retry with strict replay ID sanitization enabled. The retry recognizes dotted, underscored, spaced, and hyphenated provider error forms, overrides weaker planned ID modes, and applies only to the API that rejected the transcript. Repeated errors, unrelated format failures, and later fallback APIs continue through the existing recovery paths without inheriting the forced policy.

## User Impact

Malformed historical tool-call IDs can be repaired on the immediate retry instead of wasting multiple provider attempts before falling back to another model. OpenAI Responses transports and unrelated request-format failures retain their existing behavior.

## Evidence

- Before: the issue log shows a GitHub Copilot Claude request rejected with `messages.17.content.0.tool_use.id: String should match pattern`, followed by the same failure after the sanitize-on-retry message.
- After: focused coverage verifies one strict retry for documented separator variants, no retry loop after a repeated rejection, no match for generic format errors, no forced retry for Responses APIs, and no forced sanitization leaking from an Anthropic-format attempt into an OpenAI Responses fallback.
- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/attempt.transcript-policy.test.ts` passed: 1 file, 6 tests.
- `pnpm tsgo:core:test` passed for the core test type graph.
- Production type validation and the full build passed earlier on the same production change surface; the rebased branch retains those paths unchanged.
- Targeted `oxfmt`, `oxlint`, and `git diff --check` validation passed for the touched files.
- The bundled autoreview helper completed with no actionable findings after the retry and fallback boundaries were applied.
- Live GitHub Copilot provider validation was not run because no disposable provider transcript containing a rejected malformed ID was available. The remaining proof limitation is an after-fix provider transcript from a real Copilot setup.

Disclosure: AI was used to understand the codebase and review the fix.
