### PR TITLE
fix(ci): refresh Plugin SDK API baseline

### DIFF
--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-153a0c98a554bb02e928fc3cb4e63d2d68cb13ba5e6f5f6a820f95c4b4c54e69  plugin-sdk-api-baseline.json
-8b47ed06bfced8f9785b15868b0367b3c5696c59928e430560080901d94c5bcd  plugin-sdk-api-baseline.jsonl
+b444c2b6b41e3ca125ab85e85f77e41d7f5777bd0fd973441dc75fd23271f7f2  plugin-sdk-api-baseline.json
+53d21f381046d12d8748bc29600b0ac43a885cc1bf8715ea490847b4bb75673f  plugin-sdk-api-baseline.jsonl


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the Plugin SDK API baseline gate fails on current main even though no pull-request change touches the SDK surface.

## Why This Change Was Made

Refreshes the tracked baseline hashes from the canonical Linux Node 24 generator output. No runtime or public API code changes.

## User Impact

No user-visible behavior change. Maintainer changed-surface checks can pass again.

## Evidence

- Linux Node 24 generation on exact main produced both committed hashes: Testbox `tbx_01kxj3j07nqpy3fm2rd42c5m01`, Actions run https://github.com/openclaw/openclaw/actions/runs/29391237299
- Exact baseline check and `check:changed` passed: Testbox `tbx_01kxj3nkzhaaz5qdvyap692xah`, Actions run https://github.com/openclaw/openclaw/actions/runs/29391322725
- Fresh branch autoreview: clean, confidence 0.99
