### PR TITLE
fix(macos): hide update guide after app-only updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **macOS app-only updates:** hide the update guide action when the Gateway is managed separately and left unchanged.
 - **Mattermost progress command details:** accept the documented `streaming.preview.commandText` and `streaming.progress.commandText` modes in channel config validation and bundled metadata. Thanks @shakkernerd.
 - **1Password authorization handoff:** persist nonce-bound pending approvals in shared plugin state so hook and tool execution across broker instances remain single-use and fail closed.
 - **Control UI chat transcripts:** preserve loaded history across session and pane returns, bound automatic backscroll loading, virtualize long transcripts, retain hidden native run boundaries, and keep prepends, streaming, and responsive layouts from flickering or jumping. Thanks @shakkernerd.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **macOS app-only updates:** hide the update guide action when the Gateway is managed separately and left unchanged.
 - **Mattermost progress command details:** accept the documented `streaming.preview.commandText` and `streaming.progress.commandText` modes in channel config validation and bundled metadata. Thanks @shakkernerd.
 - **1Password authorization handoff:** persist nonce-bound pending approvals in shared plugin state so hook and tool execution across broker instances remain single-use and fail closed.
 - **Control UI chat transcripts:** preserve loaded history across session and pane returns, bound automatic backscroll loading, virtualize long transcripts, retain hidden native run boundaries, and keep prepends, streaming, and responsive layouts from flickering or jumping. Thanks @shakkernerd.

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -33187,6 +33187,14 @@
     },
     {
       "kind": "ui-call",
+      "line": 818,
+      "path": "apps/macos/Sources/OpenClaw/PostUpdate.swift",
+      "source": "Update guide",
+      "surface": "apple",
+      "id": "native.apple.e2ffc7753f75e1b8"
+    },
+    {
+      "kind": "ui-call",
       "line": 819,
       "path": "apps/macos/Sources/OpenClaw/PostUpdate.swift",
       "source": "Ask Discord",
@@ -33203,15 +33211,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 827,
-      "path": "apps/macos/Sources/OpenClaw/PostUpdate.swift",
-      "source": "Update guide",
-      "surface": "apple",
-      "id": "native.apple.e2ffc7753f75e1b8"
-    },
-    {
-      "kind": "ui-call",
-      "line": 830,
+      "line": 828,
       "path": "apps/macos/Sources/OpenClaw/PostUpdate.swift",
       "source": "Continue",
       "surface": "apple",

--- a/apps/.i18n/native/ar.json
+++ b/apps/.i18n/native/ar.json
@@ -20744,6 +20744,11 @@
       "translated": "يحتاج تحديث Gateway إلى مساعدة"
     },
     {
+      "id": "native.apple.e2ffc7753f75e1b8",
+      "source": "Update guide",
+      "translated": "دليل التحديث"
+    },
+    {
       "id": "native.apple.3a6aaa0aa0be82e7",
       "source": "Ask Discord",
       "translated": "اسأل Discord"
@@ -20752,11 +20757,6 @@
       "id": "native.apple.11b9ee23142b1060",
       "source": "Retry",
       "translated": "إعادة المحاولة"
-    },
-    {
-      "id": "native.apple.e2ffc7753f75e1b8",
-      "source": "Update guide",
-      "translated": "دليل التحديث"
     },
     {
       "id": "native.apple.144b21229f65f2a4",

--- a/apps/.i18n/native/de.json
+++ b/apps/.i18n/native/de.json
@@ -20744,6 +20744,11 @@
       "translated": "Gateway-Update benötigt Unterstützung"
     },
     {
+      "id": "native.apple.e2ffc7753f75e1b8",
+      "source": "Update guide",
+      "translated": "Update-Anleitung"
+    },
+    {
       "id": "native.apple.3a6aaa0aa0be82e7",
       "source": "Ask Discord",
       "translated": "Discord fragen"
@@ -20752,11 +20757,6 @@
       "id": "native.apple.11b9ee23142b1060",
       "source": "Retry",
       "translated": "Erneut versuchen"
-    },
-    {
-      "id": "native.apple.e2ffc7753f75e1b8",
-      "source": "Update guide",
-      "translated": "Update-Anleitung"
     },
     {
       "id": "native.apple.144b21229f65f2a4",

--- a/apps/.i18n/native/es.json
+++ b/apps/.i18n/native/es.json
@@ -20744,6 +20744,11 @@
       "translated": "La actualización del Gateway necesita ayuda"
     },
     {
+      "id": "native.apple.e2ffc7753f75e1b8",
+      "source": "Update guide",
+      "translated": "Guía de actualización"
+    },
+    {
       "id": "native.apple.3a6aaa0aa0be82e7",
       "source": "Ask Discord",
       "translated": "Preguntar en Discord"
@@ -20752,11 +20757,6 @@
       "id": "native.apple.11b9ee23142b1060",
       "source": "Retry",
       "translated": "Reintentar"
-    },
-    {
-      "id": "native.apple.e2ffc7753f75e1b8",
-      "source": "Update guide",
-      "translated": "Guía de actualización"
     },
     {
       "id": "native.apple.144b21229f65f2a4",

--- a/apps/.i18n/native/fa.json
+++ b/apps/.i18n/native/fa.json
@@ -20744,6 +20744,11 @@
       "translated": "به‌روزرسانی Gateway به کمک نیاز دارد"
     },
     {
+      "id": "native.apple.e2ffc7753f75e1b8",
+      "source": "Update guide",
+      "translated": "راهنمای به‌روزرسانی"
+    },
+    {
       "id": "native.apple.3a6aaa0aa0be82e7",
       "source": "Ask Discord",
       "translated": "از Discord بپرسید"
@@ -20752,11 +20757,6 @@
       "id": "native.apple.11b9ee23142b1060",
       "source": "Retry",
       "translated": "تلاش مجدد"
-    },
-    {
-      "id": "native.apple.e2ffc7753f75e1b8",
-      "source": "Update guide",
-      "translated": "راهنمای به‌روزرسانی"
     },
     {
       "id": "native.apple.144b21229f65f2a4",

--- a/apps/.i18n/native/fr.json
+++ b/apps/.i18n/native/fr.json
@@ -20744,6 +20744,11 @@
       "translated": "La mise à jour du Gateway nécessite une intervention"
     },
     {
+      "id": "native.apple.e2ffc7753f75e1b8",
+      "source": "Update guide",
+      "translated": "Guide de mise à jour"
+    },
+    {
       "id": "native.apple.3a6aaa0aa0be82e7",
       "source": "Ask Discord",
       "translated": "Demander sur Discord"
@@ -20752,11 +20757,6 @@
       "id": "native.apple.11b9ee23142b1060",
       "source": "Retry",
       "translated": "Réessayer"
-    },
-    {
-      "id": "native.apple.e2ffc7753f75e1b8",
-      "source": "Update guide",
-      "translated": "Guide de mise à jour"
     },
     {
       "id": "native.apple.144b21229f65f2a4",

--- a/apps/.i18n/native/hi.json
+++ b/apps/.i18n/native/hi.json
@@ -20744,6 +20744,11 @@
       "translated": "Gateway अपडेट के लिए सहायता चाहिए"
     },
     {
+      "id": "native.apple.e2ffc7753f75e1b8",
+      "source": "Update guide",
+      "translated": "अपडेट गाइड"
+    },
+    {
       "id": "native.apple.3a6aaa0aa0be82e7",
       "source": "Ask Discord",
       "translated": "Discord से पूछें"
@@ -20752,11 +20757,6 @@
       "id": "native.apple.11b9ee23142b1060",
       "source": "Retry",
       "translated": "पुनः प्रयास करें"
-    },
-    {
-      "id": "native.apple.e2ffc7753f75e1b8",
-      "source": "Update guide",
-      "translated": "अपडेट गाइड"
     },
     {
       "id": "native.apple.144b21229f65f2a4",

--- a/apps/.i18n/native/id.json
+++ b/apps/.i18n/native/id.json
@@ -20744,6 +20744,11 @@
       "translated": "Pembaruan Gateway memerlukan bantuan"
     },
     {
+      "id": "native.apple.e2ffc7753f75e1b8",
+      "source": "Update guide",
+      "translated": "Panduan pembaruan"
+    },
+    {
       "id": "native.apple.3a6aaa0aa0be82e7",
       "source": "Ask Discord",
       "translated": "Tanyakan di Discord"
@@ -20752,11 +20757,6 @@
       "id": "native.apple.11b9ee23142b1060",
       "source": "Retry",
       "translated": "Coba lagi"
-    },
-    {
-      "id": "native.apple.e2ffc7753f75e1b8",
-      "source": "Update guide",
-      "translated": "Panduan pembaruan"
     },
     {
       "id": "native.apple.144b21229f65f2a4",

--- a/apps/.i18n/native/it.json
+++ b/apps/.i18n/native/it.json
@@ -20744,6 +20744,11 @@
       "translated": "L'aggiornamento del Gateway richiede assistenza"
     },
     {
+      "id": "native.apple.e2ffc7753f75e1b8",
+      "source": "Update guide",
+      "translated": "Guida all’aggiornamento"
+    },
+    {
       "id": "native.apple.3a6aaa0aa0be82e7",
       "source": "Ask Discord",
       "translated": "Chiedi su Discord"
@@ -20752,11 +20757,6 @@
       "id": "native.apple.11b9ee23142b1060",
       "source": "Retry",
       "translated": "Riprova"
-    },
-    {
-      "id": "native.apple.e2ffc7753f75e1b8",
-      "source": "Update guide",
-      "translated": "Guida all’aggiornamento"
     },
     {
       "id": "native.apple.144b21229f65f2a4",

--- a/apps/.i18n/native/ja-JP.json
+++ b/apps/.i18n/native/ja-JP.json
@@ -20744,6 +20744,11 @@
       "translated": "Gateway のアップデートに対応が必要です"
     },
     {
+      "id": "native.apple.e2ffc7753f75e1b8",
+      "source": "Update guide",
+      "translated": "アップデートガイド"
+    },
+    {
       "id": "native.apple.3a6aaa0aa0be82e7",
       "source": "Ask Discord",
       "translated": "Discordで質問"
@@ -20752,11 +20757,6 @@
       "id": "native.apple.11b9ee23142b1060",
       "source": "Retry",
       "translated": "再試行"
-    },
-    {
-      "id": "native.apple.e2ffc7753f75e1b8",
-      "source": "Update guide",
-      "translated": "アップデートガイド"
     },
     {
       "id": "native.apple.144b21229f65f2a4",

--- a/apps/.i18n/native/ko.json
+++ b/apps/.i18n/native/ko.json
@@ -20744,6 +20744,11 @@
       "translated": "Gateway 업데이트에 도움이 필요함"
     },
     {
+      "id": "native.apple.e2ffc7753f75e1b8",
+      "source": "Update guide",
+      "translated": "업데이트 가이드"
+    },
+    {
       "id": "native.apple.3a6aaa0aa0be82e7",
       "source": "Ask Discord",
       "translated": "Discord에 문의"
@@ -20752,11 +20757,6 @@
       "id": "native.apple.11b9ee23142b1060",
       "source": "Retry",
       "translated": "다시 시도"
-    },
-    {
-      "id": "native.apple.e2ffc7753f75e1b8",
-      "source": "Update guide",
-      "translated": "업데이트 가이드"
     },
     {
       "id": "native.apple.144b21229f65f2a4",

--- a/apps/.i18n/native/nl.json
+++ b/apps/.i18n/native/nl.json
@@ -20744,6 +20744,11 @@
       "translated": "Gateway-update heeft hulp nodig"
     },
     {
+      "id": "native.apple.e2ffc7753f75e1b8",
+      "source": "Update guide",
+      "translated": "Updatehandleiding"
+    },
+    {
       "id": "native.apple.3a6aaa0aa0be82e7",
       "source": "Ask Discord",
       "translated": "Vraag het op Discord"
@@ -20752,11 +20757,6 @@
       "id": "native.apple.11b9ee23142b1060",
       "source": "Retry",
       "translated": "Opnieuw proberen"
-    },
-    {
-      "id": "native.apple.e2ffc7753f75e1b8",
-      "source": "Update guide",
-      "translated": "Updatehandleiding"
     },
     {
       "id": "native.apple.144b21229f65f2a4",

--- a/apps/.i18n/native/pl.json
+++ b/apps/.i18n/native/pl.json
@@ -20744,6 +20744,11 @@
       "translated": "Aktualizacja Gateway wymaga pomocy"
     },
     {
+      "id": "native.apple.e2ffc7753f75e1b8",
+      "source": "Update guide",
+      "translated": "Przewodnik po aktualizacji"
+    },
+    {
       "id": "native.apple.3a6aaa0aa0be82e7",
       "source": "Ask Discord",
       "translated": "Zapytaj na Discordzie"
@@ -20752,11 +20757,6 @@
       "id": "native.apple.11b9ee23142b1060",
       "source": "Retry",
       "translated": "Spróbuj ponownie"
-    },
-    {
-      "id": "native.apple.e2ffc7753f75e1b8",
-      "source": "Update guide",
-      "translated": "Przewodnik po aktualizacji"
     },
     {
       "id": "native.apple.144b21229f65f2a4",

--- a/apps/.i18n/native/pt-BR.json
+++ b/apps/.i18n/native/pt-BR.json
@@ -20744,6 +20744,11 @@
       "translated": "A atualização do Gateway precisa de ajuda"
     },
     {
+      "id": "native.apple.e2ffc7753f75e1b8",
+      "source": "Update guide",
+      "translated": "Guia de atualização"
+    },
+    {
       "id": "native.apple.3a6aaa0aa0be82e7",
       "source": "Ask Discord",
       "translated": "Perguntar no Discord"
@@ -20752,11 +20757,6 @@
       "id": "native.apple.11b9ee23142b1060",
       "source": "Retry",
       "translated": "Tentar novamente"
-    },
-    {
-      "id": "native.apple.e2ffc7753f75e1b8",
-      "source": "Update guide",
-      "translated": "Guia de atualização"
     },
     {
       "id": "native.apple.144b21229f65f2a4",

--- a/apps/.i18n/native/ru.json
+++ b/apps/.i18n/native/ru.json
@@ -20744,6 +20744,11 @@
       "translated": "Для обновления Gateway требуется помощь"
     },
     {
+      "id": "native.apple.e2ffc7753f75e1b8",
+      "source": "Update guide",
+      "translated": "Руководство по обновлению"
+    },
+    {
       "id": "native.apple.3a6aaa0aa0be82e7",
       "source": "Ask Discord",
       "translated": "Спросить в Discord"
@@ -20752,11 +20757,6 @@
       "id": "native.apple.11b9ee23142b1060",
       "source": "Retry",
       "translated": "Повторить"
-    },
-    {
-      "id": "native.apple.e2ffc7753f75e1b8",
-      "source": "Update guide",
-      "translated": "Руководство по обновлению"
     },
     {
       "id": "native.apple.144b21229f65f2a4",

--- a/apps/.i18n/native/sv.json
+++ b/apps/.i18n/native/sv.json
@@ -20744,6 +20744,11 @@
       "translated": "Gateway-uppdateringen behöver hjälp"
     },
     {
+      "id": "native.apple.e2ffc7753f75e1b8",
+      "source": "Update guide",
+      "translated": "Uppdateringsguide"
+    },
+    {
       "id": "native.apple.3a6aaa0aa0be82e7",
       "source": "Ask Discord",
       "translated": "Fråga Discord"
@@ -20752,11 +20757,6 @@
       "id": "native.apple.11b9ee23142b1060",
       "source": "Retry",
       "translated": "Försök igen"
-    },
-    {
-      "id": "native.apple.e2ffc7753f75e1b8",
-      "source": "Update guide",
-      "translated": "Uppdateringsguide"
     },
     {
       "id": "native.apple.144b21229f65f2a4",

--- a/apps/.i18n/native/th.json
+++ b/apps/.i18n/native/th.json
@@ -20744,6 +20744,11 @@
       "translated": "การอัปเดต Gateway ต้องการความช่วยเหลือ"
     },
     {
+      "id": "native.apple.e2ffc7753f75e1b8",
+      "source": "Update guide",
+      "translated": "คู่มือการอัปเดต"
+    },
+    {
       "id": "native.apple.3a6aaa0aa0be82e7",
       "source": "Ask Discord",
       "translated": "สอบถาม Discord"
@@ -20752,11 +20757,6 @@
       "id": "native.apple.11b9ee23142b1060",
       "source": "Retry",
       "translated": "ลองอีกครั้ง"
-    },
-    {
-      "id": "native.apple.e2ffc7753f75e1b8",
-      "source": "Update guide",
-      "translated": "คู่มือการอัปเดต"
     },
     {
       "id": "native.apple.144b21229f65f2a4",

--- a/apps/.i18n/native/tr.json
+++ b/apps/.i18n/native/tr.json
@@ -20744,6 +20744,11 @@
       "translated": "Gateway güncellemesi için yardım gerekiyor"
     },
     {
+      "id": "native.apple.e2ffc7753f75e1b8",
+      "source": "Update guide",
+      "translated": "Güncelleme kılavuzu"
+    },
+    {
       "id": "native.apple.3a6aaa0aa0be82e7",
       "source": "Ask Discord",
       "translated": "Discord'a sor"
@@ -20752,11 +20757,6 @@
       "id": "native.apple.11b9ee23142b1060",
       "source": "Retry",
       "translated": "Yeniden dene"
-    },
-    {
-      "id": "native.apple.e2ffc7753f75e1b8",
-      "source": "Update guide",
-      "translated": "Güncelleme kılavuzu"
     },
     {
       "id": "native.apple.144b21229f65f2a4",

--- a/apps/.i18n/native/uk.json
+++ b/apps/.i18n/native/uk.json
@@ -20744,6 +20744,11 @@
       "translated": "Для оновлення Gateway потрібна допомога"
     },
     {
+      "id": "native.apple.e2ffc7753f75e1b8",
+      "source": "Update guide",
+      "translated": "Посібник з оновлення"
+    },
+    {
       "id": "native.apple.3a6aaa0aa0be82e7",
       "source": "Ask Discord",
       "translated": "Запитати в Discord"
@@ -20752,11 +20757,6 @@
       "id": "native.apple.11b9ee23142b1060",
       "source": "Retry",
       "translated": "Повторити"
-    },
-    {
-      "id": "native.apple.e2ffc7753f75e1b8",
-      "source": "Update guide",
-      "translated": "Посібник з оновлення"
     },
     {
       "id": "native.apple.144b21229f65f2a4",

--- a/apps/.i18n/native/vi.json
+++ b/apps/.i18n/native/vi.json
@@ -20744,6 +20744,11 @@
       "translated": "Bản cập nhật Gateway cần được hỗ trợ"
     },
     {
+      "id": "native.apple.e2ffc7753f75e1b8",
+      "source": "Update guide",
+      "translated": "Hướng dẫn cập nhật"
+    },
+    {
       "id": "native.apple.3a6aaa0aa0be82e7",
       "source": "Ask Discord",
       "translated": "Hỏi Discord"
@@ -20752,11 +20757,6 @@
       "id": "native.apple.11b9ee23142b1060",
       "source": "Retry",
       "translated": "Thử lại"
-    },
-    {
-      "id": "native.apple.e2ffc7753f75e1b8",
-      "source": "Update guide",
-      "translated": "Hướng dẫn cập nhật"
     },
     {
       "id": "native.apple.144b21229f65f2a4",

--- a/apps/.i18n/native/zh-CN.json
+++ b/apps/.i18n/native/zh-CN.json
@@ -20744,6 +20744,11 @@
       "translated": "Gateway 更新需要协助"
     },
     {
+      "id": "native.apple.e2ffc7753f75e1b8",
+      "source": "Update guide",
+      "translated": "更新指南"
+    },
+    {
       "id": "native.apple.3a6aaa0aa0be82e7",
       "source": "Ask Discord",
       "translated": "咨询 Discord"
@@ -20752,11 +20757,6 @@
       "id": "native.apple.11b9ee23142b1060",
       "source": "Retry",
       "translated": "重试"
-    },
-    {
-      "id": "native.apple.e2ffc7753f75e1b8",
-      "source": "Update guide",
-      "translated": "更新指南"
     },
     {
       "id": "native.apple.144b21229f65f2a4",

--- a/apps/.i18n/native/zh-TW.json
+++ b/apps/.i18n/native/zh-TW.json
@@ -20744,6 +20744,11 @@
       "translated": "Gateway 更新需要協助"
     },
     {
+      "id": "native.apple.e2ffc7753f75e1b8",
+      "source": "Update guide",
+      "translated": "更新指南"
+    },
+    {
       "id": "native.apple.3a6aaa0aa0be82e7",
       "source": "Ask Discord",
       "translated": "詢問 Discord"
@@ -20752,11 +20757,6 @@
       "id": "native.apple.11b9ee23142b1060",
       "source": "Retry",
       "translated": "重試"
-    },
-    {
-      "id": "native.apple.e2ffc7753f75e1b8",
-      "source": "Update guide",
-      "translated": "更新指南"
     },
     {
       "id": "native.apple.144b21229f65f2a4",

--- a/apps/macos/Sources/OpenClaw/PostUpdate.swift
+++ b/apps/macos/Sources/OpenClaw/PostUpdate.swift
@@ -821,6 +821,7 @@ private struct PostUpdateView: View {
                 Button("Retry") { PostUpdateController.shared.retry() }
                     .buttonStyle(.borderedProminent)
             }
+        // External means the Gateway was intentionally left unchanged, so no recovery action is needed.
         case .complete, .external:
             HStack {
                 Spacer()

--- a/apps/macos/Sources/OpenClaw/PostUpdate.swift
+++ b/apps/macos/Sources/OpenClaw/PostUpdate.swift
@@ -823,9 +823,6 @@ private struct PostUpdateView: View {
             }
         case .complete, .external:
             HStack {
-                if self.model.phase == .external {
-                    Button("Update guide") { PostUpdateController.shared.openUpdateGuide() }
-                }
                 Spacer()
                 Button("Continue") { PostUpdateController.shared.close() }
                     .buttonStyle(.borderedProminent)


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users updating only the Mac app would see an unnecessary Update guide action even though their separately managed Gateway was intentionally left unchanged.

## Why This Change Was Made

The app-only completion state now offers only Continue. Update guide and Discord help remain available when a coordinated runtime update fails and recovery guidance is relevant.

## User Impact

Mac app-only updates finish with a simpler completion screen and no misleading Gateway recovery action.

## Evidence

- `swiftc -frontend -parse apps/macos/Sources/OpenClaw/PostUpdate.swift`
- `git diff --check`
- Autoreview: no accepted/actionable findings.
- Exact-head macOS build and test proof will come from PR CI before merge.
