### PR TITLE
fix(ui): automation counts stay at zero in Quick Settings

### DIFF
--- a/ui/src/pages/config/config-page.test.ts
+++ b/ui/src/pages/config/config-page.test.ts
@@ -167,6 +167,51 @@ describe("ConfigPage system info", () => {
   });
 });
 
+describe("ConfigPage automation inventory", () => {
+  it("loads Cron and Skills counts from the current Gateway", async () => {
+    const request = vi.fn((method: string) => {
+      if (method === "cron.list") {
+        return Promise.resolve({ jobs: [], total: 4 });
+      }
+      if (method === "skills.status") {
+        return Promise.resolve({ skills: [{}, {}] });
+      }
+      return Promise.reject(new Error(`Unexpected method: ${method}`));
+    });
+    const client = { request } as unknown as GatewayBrowserClient;
+    const gateway = {
+      snapshot: { client, connected: true },
+    } as ApplicationGateway;
+    const page = new ConfigPage();
+    const state = page as unknown as {
+      systemInfoGatewaySource: ApplicationGateway;
+      quickAutomationClient: GatewayBrowserClient;
+      quickAutomationRequestId: number;
+      cronJobCount: number | null;
+      skillCount: number | null;
+      loadQuickAutomationInventory: (
+        gateway: ApplicationGateway,
+        client: GatewayBrowserClient,
+        requestId: number,
+      ) => Promise<void>;
+    };
+    state.systemInfoGatewaySource = gateway;
+    state.quickAutomationClient = client;
+    state.quickAutomationRequestId = 1;
+
+    await state.loadQuickAutomationInventory(gateway, client, 1);
+
+    expect(request).toHaveBeenCalledWith("cron.list", {
+      includeDisabled: true,
+      limit: 1,
+      offset: 0,
+    });
+    expect(request).toHaveBeenCalledWith("skills.status", {});
+    expect(state.cronJobCount).toBe(4);
+    expect(state.skillCount).toBe(2);
+  });
+});
+
 describe("ConfigPage runtime config lifecycle", () => {
   it("loads replacement sources and clears sensitive reveal state", async () => {
     const page = new ConfigPage();

--- a/ui/src/pages/config/config-page.ts
+++ b/ui/src/pages/config/config-page.ts
@@ -4,7 +4,7 @@ import { html, nothing, type PropertyValues } from "lit";
 import { property, state } from "lit/decorators.js";
 import type { SystemInfoResult } from "../../../../packages/gateway-protocol/src/index.js";
 import { GatewayRequestError, type GatewayBrowserClient } from "../../api/gateway.ts";
-import type { FastMode } from "../../api/types.ts";
+import type { CronJobsListResult, FastMode, SkillStatusReport } from "../../api/types.ts";
 import { pathForRoute, type RouteId } from "../../app-route-paths.ts";
 import {
   applicationContext,
@@ -243,6 +243,8 @@ export class ConfigPage extends OpenClawLightDomElement {
   @state() private settingsMode: "quick" | "advanced" = "quick";
   @state() private systemInfo: SystemInfoResult | null = null;
   @state() private systemInfoUnavailable = false;
+  @state() private cronJobCount: number | null = null;
+  @state() private skillCount: number | null = null;
   @state() private microphoneDevices: RealtimeTalkInputDevice[] = [];
   @state() private microphoneLoading = false;
   @state() private microphoneError: string | null = null;
@@ -278,6 +280,8 @@ export class ConfigPage extends OpenClawLightDomElement {
   private systemInfoClient: GatewayBrowserClient | null = null;
   private systemInfoLoading = false;
   private systemInfoRequestId = 0;
+  private quickAutomationClient: GatewayBrowserClient | null = null;
+  private quickAutomationRequestId = 0;
   private readonly systemInfoPolling = new PollController(
     this,
     SYSTEM_INFO_POLL_INTERVAL_MS,
@@ -331,6 +335,8 @@ export class ConfigPage extends OpenClawLightDomElement {
     this.resetConfigViewState();
     this.systemInfoGatewaySource = null;
     this.systemInfoClient = null;
+    this.quickAutomationClient = null;
+    this.quickAutomationRequestId += 1;
     this.subscriptions.clear();
     super.disconnectedCallback();
   }
@@ -348,6 +354,7 @@ export class ConfigPage extends OpenClawLightDomElement {
       this.invalidateSystemInfoRequest();
     }
     this.syncSystemInfoPolling();
+    this.syncQuickAutomationInventory();
     this.scrollToPendingRouteTarget();
     // Device labels stay hidden until the user grants mic permission; the
     // refresh button next to the picker requests it explicitly.
@@ -436,11 +443,15 @@ export class ConfigPage extends OpenClawLightDomElement {
     if (gateway !== this.systemInfoGatewaySource) {
       this.systemInfoPolling.stop();
       this.invalidateSystemInfoRequest();
+      this.quickAutomationRequestId += 1;
       this.systemInfoGatewaySource = gateway;
       this.resetConfigViewState();
       this.systemInfoClient = null;
+      this.quickAutomationClient = null;
       this.systemInfo = null;
       this.systemInfoUnavailable = false;
+      this.cronJobCount = null;
+      this.skillCount = null;
     }
     this.handleSystemInfoGatewaySnapshot(gateway.snapshot);
   }
@@ -461,6 +472,12 @@ export class ConfigPage extends OpenClawLightDomElement {
     } else if (!snapshot.connected) {
       this.invalidateSystemInfoRequest();
       this.systemInfo = null;
+    }
+    if (!snapshot.connected) {
+      this.quickAutomationRequestId += 1;
+      this.quickAutomationClient = null;
+      this.cronJobCount = null;
+      this.skillCount = null;
     }
     if (snapshot.connected && snapshot.hello) {
       this.systemInfoUnavailable = !hasSystemInfo;
@@ -551,6 +568,47 @@ export class ConfigPage extends OpenClawLightDomElement {
         this.systemInfoLoading = false;
       }
     }
+  }
+
+  private syncQuickAutomationInventory() {
+    const gatewaySource = this.systemInfoGatewaySource;
+    const gateway = gatewaySource?.snapshot;
+    if (
+      !this.isConnected ||
+      !this.isSystemInfoVisible() ||
+      !gatewaySource ||
+      gatewaySource !== this.context.gateway ||
+      !gateway?.connected ||
+      !gateway.client ||
+      gateway.client === this.quickAutomationClient
+    ) {
+      return;
+    }
+    const requestId = ++this.quickAutomationRequestId;
+    this.quickAutomationClient = gateway.client;
+    void this.loadQuickAutomationInventory(gatewaySource, gateway.client, requestId);
+  }
+
+  private async loadQuickAutomationInventory(
+    gatewaySource: ApplicationContext["gateway"],
+    client: GatewayBrowserClient,
+    requestId: number,
+  ) {
+    const [cron, skills] = await Promise.all([
+      client
+        .request<CronJobsListResult>("cron.list", { includeDisabled: true, limit: 1, offset: 0 })
+        .catch(() => null),
+      client.request<SkillStatusReport>("skills.status", {}).catch(() => null),
+    ]);
+    if (
+      requestId !== this.quickAutomationRequestId ||
+      gatewaySource !== this.systemInfoGatewaySource ||
+      client !== this.quickAutomationClient
+    ) {
+      return;
+    }
+    this.cronJobCount = typeof cron?.total === "number" ? cron.total : null;
+    this.skillCount = Array.isArray(skills?.skills) ? skills.skills.length : null;
   }
 
   private navigate(routeId: RouteId) {
@@ -846,8 +904,8 @@ export class ConfigPage extends OpenClawLightDomElement {
       fastMode: fastMode === "auto" || typeof fastMode === "boolean" ? fastMode : false,
       channels: quickChannels(configObject),
       automation: {
-        cronJobCount: 0,
-        skillCount: 0,
+        cronJobCount: this.cronJobCount,
+        skillCount: this.skillCount,
         mcpServerCount: mcpServerCount(configObject),
       },
       security: extractQuickSettingsSecurity(configObject),

--- a/ui/src/pages/config/quick.ts
+++ b/ui/src/pages/config/quick.ts
@@ -58,8 +58,8 @@ export type QuickSettingsChannel = {
 };
 
 type QuickSettingsAutomation = {
-  cronJobCount: number;
-  skillCount: number;
+  cronJobCount: number | null;
+  skillCount: number | null;
   mcpServerCount: number;
 };
 
@@ -469,7 +469,7 @@ function renderAutomationsSection(props: QuickSettingsProps) {
           cronJobCount === 1
             ? "quickSettings.automation.scheduledTask"
             : "quickSettings.automation.scheduledTasks",
-          { count: String(cronJobCount) },
+          { count: cronJobCount == null ? "—" : String(cronJobCount) },
         ),
         t("quickSettings.automation.manage"),
         props.onManageCron,
@@ -479,7 +479,7 @@ function renderAutomationsSection(props: QuickSettingsProps) {
           skillCount === 1
             ? "quickSettings.automation.installedSkill"
             : "quickSettings.automation.installedSkills",
-          { count: String(skillCount) },
+          { count: skillCount == null ? "—" : String(skillCount) },
         ),
         t("quickSettings.automation.browse"),
         props.onBrowseSkills,


### PR DESCRIPTION
Closes #107852

## What Problem This Solves

Fixes an issue where users opening Settings > General would always see zero scheduled tasks and zero installed skills, even when their Gateway had Cron jobs and Skills available.

## Why This Change Was Made

Quick Settings previously supplied literal zero values for both inventories. The Config page now loads the Cron total and installed Skills count once for the current connected Gateway and passes those values into the existing Automations rows. Counts remain unknown rather than showing a false zero while loading or when an inventory request fails.

The existing MCP server count remains config-derived.

## User Impact

The Automations section now reports the current scheduled-task and installed-Skills totals instead of misleading zeroes.

## Evidence

- `node scripts/run-vitest.mjs ui/src/pages/config/config-page.test.ts ui/src/pages/config/quick.test.ts`
  - 2 files passed, 43 tests passed
- Targeted `oxlint` passed for the three changed TypeScript files
- `git diff --check` passed

The draft's single allowed autoreview round completed before this patch was simplified and was not rerun. Full changed-file validation was not run locally because it requires dependency reconciliation in this linked worktree. GitHub CI remains the broad validation path for this draft.

AI-assisted: Yes, with Codex. I reviewed the implementation and understand the behavior and tests.
