### PR TITLE
improve: speed exec no-output timer test

### DIFF
--- a/src/process/exec.no-output-timer.test.ts
+++ b/src/process/exec.no-output-timer.test.ts
@@ -9,22 +9,22 @@ describe("runCommandWithTimeout no-output timer", () => {
       "let timer",
       "const emit = () => {",
       "  process.stdout.write('.')",
-      "  if (++count === 6) { clearInterval(timer); process.exit(0) }",
+      "  if (++count === 21) { clearInterval(timer); process.exit(0) }",
       "}",
       "emit()",
-      "timer = setInterval(emit, 500)",
+      "timer = setInterval(emit, 100)",
     ].join(";");
     const result = await runCommandWithTimeout([process.execPath, "-e", script], {
       timeoutMs: 10_000,
       // Leave ample process-startup margin while keeping total runtime above
       // this threshold, so only output-driven resets let the child finish.
-      noOutputTimeoutMs: 2_000,
+      noOutputTimeoutMs: 1_500,
     });
 
     expect(result).toMatchObject({
       code: 0,
       noOutputTimedOut: false,
-      stdout: "......",
+      stdout: ".....................",
       termination: "exit",
     });
   });


### PR DESCRIPTION
## What Problem This Solves

The exec no-output timer suite waits about 2.5 seconds in its output-reset case, making one four-test file a top-five unit-fast hotspot.

## Why This Change Was Made

The real child-process proof now emits every 100 ms instead of every 500 ms. It retains a 1.5-second process-startup allowance and the original 500 ms separation between the no-reset deadline and normal child completion, preserving both flake resistance and regression sensitivity.

## User Impact

No product behavior changes. Maintainers get faster focused tests and unit-fast feedback.

## Evidence

- Focused file: 4/4 tests pass.
- Output-reset case: 2528 ms before, 2026 ms after (19.9% faster).
- Whole file: 3.01 s before, 2.48 s after (17.6% faster).
- Final timing shape repeated five times: 5/5 pass, 2.46-2.48 s per file.
- Changed gate: passed on Blacksmith Testbox tbx_01kxj3x6c5fda0c5rw95jr9d32.
- Baseline Testbox action: https://github.com/openclaw/openclaw/actions/runs/29391342342
- Final Testbox action: https://github.com/openclaw/openclaw/actions/runs/29391498645
- Fresh autoreview: clean after restoring safe startup and proof-window margins.
- AI-assisted: yes; change understood and reviewed.
