### PR TITLE
fix(mattermost): preserve thread roots and hydrate thread context

### DIFF
--- a/extensions/mattermost/src/channel.message-adapter.test.ts
+++ b/extensions/mattermost/src/channel.message-adapter.test.ts
@@ -192,7 +192,8 @@ describe("mattermost channel message adapter", () => {
     expect(sendMessageMattermostMock).toHaveBeenLastCalledWith("channel:parent-1", "threaded", {
       cfg: {},
       accountId: "default",
-      replyToId: "thread-1",
+      replyToId: undefined,
+      threadId: "thread-1",
     });
     expect(result.receipt.threadId).toBe("thread-1");
   });
@@ -213,6 +214,7 @@ describe("mattermost channel message adapter", () => {
       cfg: {},
       accountId: "default",
       replyToId: "post-parent-1",
+      threadId: "thread-1",
     });
     expect(result.receipt.replyToId).toBe("post-parent-1");
   });

--- a/extensions/mattermost/src/channel.test.ts
+++ b/extensions/mattermost/src/channel.test.ts
@@ -806,7 +806,8 @@ describe("mattermostPlugin", () => {
       );
 
       const options = expectSingleMattermostSend("channel:CHAN1", "hello");
-      expect(options.replyToId).toBe("post-root");
+      expect(options.replyToId).toBe("child-post");
+      expect(options.threadId).toBe("post-root");
     });
 
     it("keeps explicit replyToId precedence when threadId is also provided", async () => {
@@ -829,6 +830,7 @@ describe("mattermostPlugin", () => {
 
       const options = expectSingleMattermostSend("channel:CHAN1", "hello");
       expect(options.replyToId).toBe("explicit-root");
+      expect(options.threadId).toBe("post-root");
     });
 
     it("routes filePath send actions through Mattermost media upload options", async () => {
@@ -1444,7 +1446,8 @@ describe("mattermostPlugin", () => {
 
       const options = expectSingleMattermostSend("channel:CHAN1", "hello");
       expect(options.accountId).toBe("default");
-      expect(options.replyToId).toBe("post-root");
+      expect(options.replyToId).toBeUndefined();
+      expect(options.threadId).toBe("post-root");
     });
 
     it("uses threadId as fallback when replyToId is absent (sendMedia)", async () => {
@@ -1464,7 +1467,8 @@ describe("mattermostPlugin", () => {
 
       const options = expectSingleMattermostSend("channel:CHAN1", "caption");
       expect(options.accountId).toBe("default");
-      expect(options.replyToId).toBe("post-root");
+      expect(options.replyToId).toBeUndefined();
+      expect(options.threadId).toBe("post-root");
       expect(options.requireMediaUpload).toBeUndefined();
     });
   });

--- a/extensions/mattermost/src/channel.ts
+++ b/extensions/mattermost/src/channel.ts
@@ -453,9 +453,8 @@ const mattermostMessageActions: ChannelMessageActionAdapter = {
     // the current child post, so prefer threadId unless the caller supplied the
     // Mattermost-specific replyToId root directly.
     const replyToId =
-      normalizeOptionalString(params.replyToId) ??
-      normalizeOptionalString(params.threadId) ??
-      normalizeOptionalString(params.replyTo);
+      normalizeOptionalString(params.replyToId) ?? normalizeOptionalString(params.replyTo);
+    const threadId = normalizeOptionalString(params.threadId);
     const resolvedAccountId = accountId || undefined;
 
     const attachmentMedia = collectMattermostAttachmentMedia(params);
@@ -477,6 +476,7 @@ const mattermostMessageActions: ChannelMessageActionAdapter = {
       cfg,
       accountId: resolvedAccountId,
       replyToId,
+      threadId,
       buttons: buttons.length > 0 ? buttons : undefined,
       attachmentText: typeof params.attachmentText === "string" ? params.attachmentText : undefined,
       mediaUrl: attachmentMedia.mediaUrls[0],
@@ -503,7 +503,7 @@ const mattermostMessageActions: ChannelMessageActionAdapter = {
       details: {
         toolSend: {
           to: `channel:${result.channelId}`,
-          ...(replyToId ? { threadId: replyToId } : {}),
+          ...((threadId ?? replyToId) ? { threadId: threadId ?? replyToId } : {}),
         },
       },
     };
@@ -692,7 +692,8 @@ const mattermostOutbound: ChannelOutboundAdapter = {
         mediaReadFile: ctx.mediaReadFile ?? ctx.mediaAccess?.readFile,
         ...(ctx.mediaAccess?.workspaceDir ? { workspaceDir: ctx.mediaAccess.workspaceDir } : {}),
         requireMediaUpload: requiresMattermostMediaUpload(mediaUrl) ? true : undefined,
-        replyToId: ctx.replyToId ?? (ctx.threadId != null ? String(ctx.threadId) : undefined),
+        replyToId: ctx.replyToId ?? undefined,
+        threadId: ctx.threadId != null ? String(ctx.threadId) : undefined,
         buttons,
       });
       return attachChannelToResult("mattermost", result);
@@ -719,7 +720,8 @@ const mattermostOutbound: ChannelOutboundAdapter = {
       ).sendMessageMattermost(to, text, {
         cfg,
         accountId: accountId ?? undefined,
-        replyToId: replyToId ?? (threadId != null ? String(threadId) : undefined),
+        replyToId: replyToId ?? undefined,
+        threadId: threadId != null ? String(threadId) : undefined,
       }),
     sendMedia: async ({
       cfg,
@@ -743,7 +745,8 @@ const mattermostOutbound: ChannelOutboundAdapter = {
         mediaReadFile: mediaReadFile ?? mediaAccess?.readFile,
         ...(mediaAccess?.workspaceDir ? { workspaceDir: mediaAccess.workspaceDir } : {}),
         requireMediaUpload: requiresMattermostMediaUpload(mediaUrl) ? true : undefined,
-        replyToId: replyToId ?? (threadId != null ? String(threadId) : undefined),
+        replyToId: replyToId ?? undefined,
+        threadId: threadId != null ? String(threadId) : undefined,
       }),
   }),
 };

--- a/extensions/mattermost/src/mattermost/client.ts
+++ b/extensions/mattermost/src/mattermost/client.ts
@@ -301,6 +301,13 @@ export async function fetchMattermostChannel(
   return await client.request<MattermostChannel>(`/channels/${channelId}`);
 }
 
+export async function fetchMattermostPost(
+  client: MattermostClient,
+  postId: string,
+): Promise<MattermostPost> {
+  return await client.request<MattermostPost>(`/posts/${encodeURIComponent(postId)}`);
+}
+
 export async function fetchMattermostChannelByName(
   client: MattermostClient,
   teamId: string,

--- a/extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts
@@ -85,6 +85,8 @@ const mockState = vi.hoisted(() => ({
   dispatchReplyFromConfig: vi.fn(),
   enqueueSystemEvent: vi.fn(),
   fetchMattermostMe: vi.fn(),
+  fetchMattermostPost: vi.fn(),
+  fetchMattermostUser: vi.fn(),
   registerMattermostMonitorSlashCommands: vi.fn(),
   registerPluginHttpRoute: vi.fn(),
   recordMattermostThreadParticipation: vi.fn(),
@@ -102,6 +104,8 @@ vi.mock("./client.js", async () => {
     ...actual,
     createMattermostClient: mockState.createMattermostClient,
     fetchMattermostMe: mockState.fetchMattermostMe,
+    fetchMattermostPost: mockState.fetchMattermostPost,
+    fetchMattermostUser: mockState.fetchMattermostUser,
     normalizeMattermostBaseUrl: (value: string | undefined) => value?.trim() ?? "",
     updateMattermostPost: mockState.updateMattermostPost,
   };
@@ -445,6 +449,8 @@ describe("mattermost inbound user posts", () => {
       username: "openclaw",
       update_at: 1,
     });
+    mockState.fetchMattermostPost.mockRejectedValue(new Error("not found"));
+    mockState.fetchMattermostUser.mockRejectedValue(new Error("not found"));
     mockState.registerMattermostMonitorSlashCommands.mockResolvedValue(undefined);
     mockState.registerPluginHttpRoute.mockReturnValue(vi.fn());
     mockState.resolveChannelInfo.mockResolvedValue({
@@ -510,6 +516,49 @@ describe("mattermost inbound user posts", () => {
     expect(ctx?.MessageSid).toBe("post-inbound-system-event-regular");
     expect(ctx?.OriginatingChannel).toBe("mattermost");
     expect(ctx?.Provider).toBe("mattermost");
+  });
+
+  it("hydrates thread starter context for Mattermost thread replies", async () => {
+    const socket = new FakeWebSocket();
+    const abortController = new AbortController();
+    mockState.abortController = abortController;
+    mockState.fetchMattermostPost.mockResolvedValueOnce({
+      id: "root-post-1",
+      channel_id: "chan-1",
+      user_id: "root-user-1",
+      message: "root context",
+      file_ids: ["file-1"],
+    });
+    mockState.fetchMattermostUser.mockResolvedValueOnce({
+      id: "root-user-1",
+      username: "bob",
+    });
+
+    const monitor = monitorMattermostProvider({
+      config: testConfig,
+      runtime: testRuntime(),
+      abortSignal: abortController.signal,
+      webSocketFactory: () => socket,
+    });
+
+    await vi.waitFor(() => {
+      expect(socket.openListenerCount).toBeGreaterThan(0);
+    });
+    socket.emitOpen();
+
+    await emitMattermostChannelPost(socket, {
+      id: "reply-post-1",
+      message: "reply text",
+      rootId: "root-post-1",
+    });
+    socket.emitClose(1000);
+    await monitor;
+
+    const ctx = mockState.dispatchReplyFromConfig.mock.calls.at(0)?.[0].ctx;
+    expect(mockState.fetchMattermostPost).toHaveBeenCalledWith(expect.anything(), "root-post-1");
+    expect(ctx?.ThreadStarterBody).toBe("root context <media:file>");
+    expect(ctx?.ReplyToBody).toBe("root context <media:file>");
+    expect(ctx?.ReplyToSender).toBe("@bob");
   });
 
   it("keeps verbose inbound previews on complete UTF-16 boundaries", async () => {

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -19,7 +19,10 @@ import { resolveMattermostAccount, resolveMattermostReplyToMode } from "./accoun
 import {
   createMattermostClient,
   fetchMattermostMe,
+  fetchMattermostPost,
+  fetchMattermostUser,
   normalizeMattermostBaseUrl,
+  type MattermostClient,
   type MattermostPost,
   type MattermostUser,
 } from "./client.js";
@@ -204,6 +207,49 @@ function buildMattermostAttachmentPlaceholder(mediaList: MattermostMediaInfo[]):
   const suffix = mediaList.length === 1 ? label : `${label}s`;
   const tag = allImages ? "<media:image>" : "<media:document>";
   return `${tag} (${mediaList.length} ${suffix})`;
+}
+
+function formatMattermostPostBodyWithFiles(post: MattermostPost): string | undefined {
+  const text = normalizeOptionalString(post.message) ?? "";
+  const fileCount = Array.isArray(post.file_ids) ? post.file_ids.length : 0;
+  const fileSuffix =
+    fileCount > 0 ? (fileCount === 1 ? "<media:file>" : `<media:${fileCount} files>`) : "";
+  return normalizeOptionalString([text, fileSuffix].filter(Boolean).join(" "));
+}
+
+async function hydrateMattermostThreadContext(params: {
+  client: MattermostClient;
+  post: MattermostPost;
+  threadRootId?: string | null;
+}): Promise<{ threadStarterBody?: string; replyToBody?: string; replyToSender?: string }> {
+  const threadRootId = normalizeOptionalString(params.threadRootId);
+  if (!threadRootId) {
+    return {};
+  }
+  try {
+    const rootPost = await fetchMattermostPost(params.client, threadRootId);
+    const rootBody = formatMattermostPostBodyWithFiles(rootPost);
+    if (!rootBody) {
+      return {};
+    }
+    let replyToSender: string | undefined;
+    const rootUserId = normalizeOptionalString(rootPost.user_id);
+    if (rootUserId) {
+      try {
+        const rootUser = await fetchMattermostUser(params.client, rootUserId);
+        replyToSender = rootUser.username ? `@${rootUser.username}` : undefined;
+      } catch {
+        replyToSender = undefined;
+      }
+    }
+    return {
+      threadStarterBody: rootBody,
+      replyToBody: params.post.root_id === threadRootId ? rootBody : undefined,
+      replyToSender,
+    };
+  } catch {
+    return {};
+  }
 }
 
 function buildMattermostWsUrl(baseUrl: string): string {
@@ -1321,6 +1367,11 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
                 limit: historyLimit,
               })
             : undefined;
+        const hydratedThreadContext = await hydrateMattermostThreadContext({
+          client,
+          post,
+          threadRootId,
+        });
         const ctxPayload = core.channel.reply.finalizeInboundContext({
           Body: combinedBody,
           BodyForAgent: bodyForAgent,
@@ -1354,6 +1405,9 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
             allMessageIds.length > 1 ? allMessageIds[allMessageIds.length - 1] : undefined,
           ReplyToId: effectiveReplyToId,
           MessageThreadId: effectiveReplyToId,
+          ThreadStarterBody: hydratedThreadContext.threadStarterBody,
+          ReplyToBody: hydratedThreadContext.replyToBody,
+          ReplyToSender: hydratedThreadContext.replyToSender,
           Timestamp: typeof post.create_at === "number" ? post.create_at : undefined,
           WasMentioned: kind !== "direct" ? mentionDecision.effectiveWasMentioned : undefined,
           CommandAuthorized: commandAuthorized,

--- a/extensions/mattermost/src/mattermost/send.ts
+++ b/extensions/mattermost/src/mattermost/send.ts
@@ -20,11 +20,13 @@ import {
   createMattermostDirectChannelWithRetry,
   createMattermostPost,
   fetchMattermostChannelByName,
+  fetchMattermostPost,
   fetchMattermostMe,
   fetchMattermostUserByUsername,
   fetchMattermostUserTeams,
   normalizeMattermostBaseUrl,
   uploadMattermostFile,
+  type MattermostClient,
   type MattermostUser,
   type CreateDmChannelRetryOptions,
 } from "./client.js";
@@ -52,6 +54,8 @@ type MattermostSendOpts = {
   /** Fail the send if media cannot be loaded/uploaded instead of posting text-only. */
   requireMediaUpload?: boolean;
   replyToId?: string;
+  /** Mattermost thread root id. Preferred over replyToId when both are present. */
+  threadId?: string;
   props?: Record<string, unknown>;
   buttons?: Array<unknown>;
   attachmentText?: string;
@@ -143,6 +147,37 @@ function normalizeMessage(text: string, mediaUrl?: string): string {
 
 function isHttpUrl(value: string): boolean {
   return /^https?:\/\//i.test(value);
+}
+
+function normalizeMattermostPostId(value: string | null | undefined): string | undefined {
+  const normalized = normalizeOptionalString(value);
+  return normalized && /^[a-z0-9]{26}$/i.test(normalized) ? normalized : undefined;
+}
+
+async function resolveMattermostRootPostId(params: {
+  client: MattermostClient;
+  channelId: string;
+  threadId?: string | null;
+  replyToId?: string | null;
+}): Promise<string | undefined> {
+  const candidates = [params.threadId, params.replyToId]
+    .map((value) => normalizeMattermostPostId(value))
+    .filter((value): value is string => Boolean(value));
+
+  for (const candidate of candidates) {
+    try {
+      const post = await fetchMattermostPost(params.client, candidate);
+      if (post.channel_id && post.channel_id !== params.channelId) {
+        continue;
+      }
+      return normalizeMattermostPostId(post.root_id) ?? normalizeMattermostPostId(post.id);
+    } catch {
+      // A stale or inaccessible candidate should not block sending; fall back
+      // to the next candidate, then to the original normalized id below.
+    }
+  }
+
+  return candidates[0];
 }
 async function resolveBotUser(
   baseUrl: string,
@@ -471,7 +506,12 @@ export async function sendMessageMattermost(
   const post = await createMattermostPost(client, {
     channelId,
     message,
-    rootId: opts.replyToId,
+    rootId: await resolveMattermostRootPostId({
+      client,
+      channelId,
+      threadId: opts.threadId,
+      replyToId: opts.replyToId,
+    }),
     fileIds,
     props,
   });


### PR DESCRIPTION
## Summary
- keep Mattermost thread roots separate from generic reply ids when sending message actions/outbound payloads
- resolve Mattermost child post ids back to their root post before setting `root_id` on outbound posts
- hydrate `ThreadStarterBody`, `ReplyToBody`, and `ReplyToSender` for inbound Mattermost thread replies so agents receive useful thread context
- retain/cover local attachment upload forwarding behavior via existing Mattermost media options

## What Problem This Solves
OpenClaw's Mattermost plugin has needed local post-update hotfixes because threaded Mattermost conversations can lose the actual thread starter/reply context, and some send paths collapse `threadId` into generic `replyToId`. Mattermost expects outbound threaded replies to use the thread root post id as `root_id`; when a generic reply id points at a child post instead, replies can attach to the wrong context or lose thread continuity.

This PR upstreams those local Mattermost fixes so updates no longer require reapplying bundle patches after every OpenClaw release.

## Evidence
Local validation on the changed Mattermost surfaces:

```text
pnpm exec vitest run extensions/mattermost/src/channel.test.ts extensions/mattermost/src/mattermost/send.test.ts extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts --reporter=dot
# 3 passed, 103 tests passed

pnpm tsgo:extensions
# passed

pnpm lint:extensions
# Found 0 warnings and 0 errors.
```

Regression coverage added/updated for:
- preserving `threadId` separately from `replyToId` on Mattermost message actions and outbound sends
- resolving Mattermost child post ids back to the root post before sending threaded replies
- hydrating inbound thread starter/reply fields from the Mattermost API

## Tests
- `pnpm exec vitest run extensions/mattermost/src/channel.test.ts extensions/mattermost/src/mattermost/send.test.ts extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts --reporter=dot`
- `pnpm tsgo:extensions`
- `pnpm lint:extensions`
