### PR TITLE
refactor(gateway): make secret assignment projection explicit

### DIFF
--- a/src/gateway/server-startup-config.ts
+++ b/src/gateway/server-startup-config.ts
@@ -297,7 +297,7 @@ export function createRuntimeSecretsActivator(params: {
           activationParams.activate &&
           !params.prepareRuntimeSecretsSnapshot &&
           !params.activateRuntimeSecretsSnapshot &&
-          assignmentConfig === sourceConfig
+          assignmentConfig === undefined
         ) {
           const fastPath = prepareSecretsRuntimeFastPathSnapshot({
             config: sourceConfig,
@@ -339,7 +339,7 @@ export function createRuntimeSecretsActivator(params: {
           () =>
             prepareRuntimeSecretsSnapshot({
               config: sourceConfig,
-              ...(assignmentConfig !== sourceConfig ? { assignmentConfig } : {}),
+              ...(assignmentConfig !== undefined ? { assignmentConfig } : {}),
               ...(activationParams.env ? { env: activationParams.env } : {}),
               includeAuthStoreRefs: activationParams.includeAuthStoreRefs,
               ...(startupManifestRegistry ? { manifestRegistry: startupManifestRegistry } : {}),

--- a/src/gateway/server-startup-secret-surfaces.test.ts
+++ b/src/gateway/server-startup-secret-surfaces.test.ts
@@ -27,7 +27,8 @@ describe("gateway startup secret surfaces", () => {
 
     expect(projection.sourceConfig).toBe(config);
     expect(projection.sourceConfig.channels).toBeDefined();
-    expect(projection.assignmentConfig.channels).toBeUndefined();
+    expect(projection.assignmentConfig).toBeDefined();
+    expect(projection.assignmentConfig?.channels).toBeUndefined();
   });
 
   it.each(["reload", "restart-check"] as const)(
@@ -45,7 +46,7 @@ describe("gateway startup secret surfaces", () => {
       });
 
       expect(projection.sourceConfig).toBe(config);
-      expect(projection.assignmentConfig).toBe(config);
+      expect(projection.assignmentConfig).toBeUndefined();
     },
   );
 
@@ -59,7 +60,7 @@ describe("gateway startup secret surfaces", () => {
     });
 
     expect(projection.sourceConfig).toBe(config);
-    expect(projection.assignmentConfig).toBe(config);
+    expect(projection.assignmentConfig).toBeUndefined();
   });
 
   it("preserves explicit skip behavior", () => {
@@ -70,6 +71,6 @@ describe("gateway startup secret surfaces", () => {
     });
 
     expect(projection.sourceConfig.channels).toBeUndefined();
-    expect(projection.assignmentConfig).toBe(projection.sourceConfig);
+    expect(projection.assignmentConfig).toBeUndefined();
   });
 });

--- a/src/gateway/server-startup-secret-surfaces.ts
+++ b/src/gateway/server-startup-secret-surfaces.ts
@@ -13,14 +13,14 @@ export function resolveGatewayStartupSecretProjection(params: {
   reason: GatewaySecretsActivationReason;
   channelAutostartSuppression?: ChannelAutostartSuppression | null;
   env?: NodeJS.ProcessEnv;
-}): { sourceConfig: OpenClawConfig; assignmentConfig: OpenClawConfig } {
+}): { sourceConfig: OpenClawConfig; assignmentConfig?: OpenClawConfig } {
   const sourceConfig = resolveGatewayStartupSourceConfig(params.config, params.env ?? process.env);
   if (
     params.reason !== "startup" ||
     params.channelAutostartSuppression == null ||
     !sourceConfig.channels
   ) {
-    return { sourceConfig, assignmentConfig: sourceConfig };
+    return { sourceConfig };
   }
   return {
     sourceConfig,


### PR DESCRIPTION
Related: #106826

## What Problem This Solves

The startup recovery fix inferred whether a restricted SecretRef assignment surface existed by comparing config object identity. That implicit sentinel made the contract harder to read and easier to break during later refactors.

## Why This Change Was Made

The startup projection now returns `assignmentConfig` only when channel assignments must be restricted. Callers branch on that explicit optional state while preserving the full source config for resolution and recovery.

## User Impact

No user-visible behavior change. Crash-loop recovery, explicit channel skipping, reloads, and restart checks retain the behavior landed in #106826.

## Evidence

- `node scripts/run-vitest.mjs src/gateway/server-startup-secret-surfaces.test.ts src/gateway/server-startup-config.breaker-secrets.integration.test.ts src/gateway/server-startup-config.secrets.test.ts` — 3 files and 28 tests passed.
- `./node_modules/.bin/oxfmt --check src/gateway/server-startup-secret-surfaces.ts src/gateway/server-startup-config.ts src/gateway/server-startup-secret-surfaces.test.ts` — passed.
- `git diff --check origin/main...HEAD` — passed.
- Autoreview — clean, no accepted or actionable findings.

AI-assisted: yes.
