### PR TITLE
fix(codex): keep parent binding on cross-key handoff and stop foreign-transcript mirror warns

### DIFF
--- a/extensions/codex/index.test.ts
+++ b/extensions/codex/index.test.ts
@@ -412,7 +412,13 @@ describe("codex plugin", () => {
     );
     const sessionEnd = on.mock.calls.find(([name]) => name === "session_end")?.[1] as
       | ((
-          event: { sessionId: string; sessionKey?: string; reason?: string },
+          event: {
+            sessionId: string;
+            sessionKey?: string;
+            reason?: string;
+            nextSessionId?: string;
+            nextSessionKey?: string;
+          },
           ctx: { agentId?: string; sessionId: string; sessionKey?: string },
         ) => Promise<void>)
       | undefined;
@@ -446,6 +452,62 @@ describe("codex plugin", () => {
       );
       await expect(bindingStore.read(identity)).resolves.toBeUndefined();
     }
+
+    // Cross-key handoff (e.g. dashboard "New Chat"/fork): the parent's still-live
+    // binding must survive because the successor lives under a different key and
+    // owns its own Codex thread. Use a fresh parent key (session-1 above is now
+    // permanently retired). See #106778.
+    const parent = sessionBindingIdentity({
+      agentId: "worker",
+      sessionId: "parent-1",
+      sessionKey: "agent:worker:parent-1",
+    });
+    await bindingStore.mutate(parent, {
+      kind: "set",
+      binding: { threadId: "thread-parent", cwd: "/repo" },
+    });
+    await sessionEnd(
+      {
+        sessionId: "parent-1",
+        sessionKey: "agent:worker:parent-1",
+        reason: "new",
+        nextSessionId: "child-1",
+        nextSessionKey: "agent:worker:dashboard:child-1",
+      },
+      { agentId: "worker", sessionId: "parent-1" },
+    );
+    await expect(bindingStore.read(parent)).resolves.toMatchObject({ threadId: "thread-parent" });
+
+    // A same-key replacement that still names the successor id (physical rollover)
+    // has no distinct nextSessionKey, so it retires as before.
+    await sessionEnd(
+      {
+        sessionId: "parent-1",
+        sessionKey: "agent:worker:parent-1",
+        reason: "new",
+        nextSessionId: "parent-2",
+      },
+      { agentId: "worker", sessionId: "parent-1" },
+    );
+    await expect(bindingStore.read(parent)).resolves.toBeUndefined();
+
+    // Unknown current key: a handoff cannot be proven, so a successor key alone
+    // must not skip cleanup — the conservative path retires as before #106778.
+    const keyless = sessionBindingIdentity({ agentId: "worker", sessionId: "keyless-1" });
+    await bindingStore.mutate(keyless, {
+      kind: "set",
+      binding: { threadId: "thread-keyless", cwd: "/repo" },
+    });
+    await sessionEnd(
+      {
+        sessionId: "keyless-1",
+        reason: "new",
+        nextSessionId: "child-2",
+        nextSessionKey: "agent:worker:dashboard:child-2",
+      },
+      { agentId: "worker", sessionId: "keyless-1" },
+    );
+    await expect(bindingStore.read(keyless)).resolves.toBeUndefined();
   });
 
   it("adopts compaction successors before delayed lifecycle cleanup", async () => {

--- a/extensions/codex/index.ts
+++ b/extensions/codex/index.ts
@@ -280,6 +280,20 @@ export default definePluginEntry({
         return;
       }
       const sessionKey = event.sessionKey ?? ctx.sessionKey;
+      // A cross-key handoff (dashboard "New Chat", a fork) fires session_end on
+      // the parent only to start an INDEPENDENT child session under a different
+      // key; that child owns its own Codex thread binding (a Codex fork is a new
+      // thread, not a transfer of the parent's). Retiring the parent's still-live
+      // binding here would strand it, so skip when the successor provably lives
+      // under a different session key. The only cross-key emitter (gateway child
+      // creation) keeps the parent row live; same-key rollovers omit or repeat
+      // the key and still retire, as do unknown-current-key ends (no provable
+      // handoff) and later idle/daily/deleted ends. See #106778.
+      const endedSessionKey = sessionKey?.trim();
+      const nextSessionKey = event.nextSessionKey?.trim();
+      if (endedSessionKey && nextSessionKey && nextSessionKey !== endedSessionKey) {
+        return;
+      }
       const config = resolveCurrentConfig();
       const { sessionBindingIdentity } = await import("./src/app-server/session-binding.js");
       await bindingStore.retireSessionGeneration(

--- a/extensions/codex/src/app-server/session-history.test.ts
+++ b/extensions/codex/src/app-server/session-history.test.ts
@@ -110,11 +110,26 @@ describe("readCodexMirroredSessionHistoryMessages", () => {
     ).resolves.toEqual([]);
   });
 
-  it("returns undefined for malformed non-empty mirrored session files", async () => {
+  it("returns [] for transcripts that do not open with a Codex session marker", async () => {
+    // A non-Codex-shaped transcript (e.g. a non-Codex model run reusing this
+    // hook) is an empty mirror, not a read failure, so callers must not warn.
     const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-session-history-"));
     tempDirs.push(dir);
     const sessionFile = path.join(dir, "session.jsonl");
     await fs.writeFile(sessionFile, JSON.stringify({ type: "message", id: "orphan" }) + "\n");
+
+    await expect(
+      readCodexMirroredSessionHistoryMessages(mirroredTarget(sessionFile)),
+    ).resolves.toEqual([]);
+  });
+
+  it("returns undefined for a session header without a string id", async () => {
+    // A `session` header with corrupt metadata is a Codex transcript gone bad,
+    // not a foreign transcript — it must stay on the warn path.
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-session-history-"));
+    tempDirs.push(dir);
+    const sessionFile = path.join(dir, "session.jsonl");
+    await fs.writeFile(sessionFile, JSON.stringify({ type: "session", id: 42 }) + "\n");
 
     await expect(
       readCodexMirroredSessionHistoryMessages(mirroredTarget(sessionFile)),

--- a/extensions/codex/src/app-server/session-history.ts
+++ b/extensions/codex/src/app-server/session-history.ts
@@ -39,7 +39,17 @@ export async function readCodexMirroredSessionHistoryMessages(
       return [];
     }
     const firstEntry = entries[0] as { type?: unknown; id?: unknown } | undefined;
-    if (firstEntry?.type !== "session" || typeof firstEntry.id !== "string") {
+    if (firstEntry?.type !== "session") {
+      // A well-formed transcript that does not open with a `session` marker is
+      // simply not a Codex-mirrored session (e.g. a non-Codex model run reusing
+      // this hook) — an empty mirror, not a read failure, so callers must not
+      // warn. `undefined` stays reserved for genuine failures: read/parse errors
+      // (caught below) and malformed `session` headers (next check).
+      return [];
+    }
+    if (typeof firstEntry.id !== "string") {
+      // A `session` header without a string id is a corrupted Codex transcript,
+      // not a foreign one — keep it on the warn path.
       return undefined;
     }
     migrateSessionEntries(entries);


### PR DESCRIPTION
## What Problem This Solves

Two Codex plugin lifecycle bugs:

1. **#106778** — Creating a dashboard child ("New Chat") or fork fires `session_end` (reason `new`) on the parent session with the child's key in `nextSessionKey`. The Codex plugin's `session_end` handler unconditionally called `retireSessionGeneration`, permanently tombstoning the **still-live parent's** thread binding. The parent row is never replaced by gateway child creation (`src/gateway/session-create-service.ts` keeps it addressable), so the parent lost its native Codex thread for no reason.
2. **#106556** — `readCodexMirroredSessionHistoryMessages` returned `undefined` for any transcript that does not open with a Codex `session` marker. Non-Codex model runs legitimately produce that shape, so the codex harness hook logged `failed to read mirrored session history for codex harness hooks` on **every non-Codex model run**.

## Why This Change Was Made

- The `session_end` handler now skips retirement only when the successor **provably** lives under a different session key (`nextSessionKey` present, current key known, and different). Exhaustive emitter inventory: the only cross-key emitter is gateway child creation, which keeps the parent live. Same-key rollovers (auto-reply, `agent-handler-helpers` — which repeats the same key), unknown-current-key ends, deletions (no successor fields), and shutdown/restart (filtered reasons) all retire exactly as before.
- The mirrored-history reader now returns `[]` (empty mirror, no warn) for well-formed transcripts that are simply not Codex-mirrored, while keeping `undefined` (warn path) for genuine failures: read/parse errors and corrupted `session` headers (`type: "session"` without a string id). Malformed JSONL lines already warn inside `parseJsonlEntries`, so head corruption stays visible.

## User Impact

- Dashboard "New Chat" / fork no longer strands the parent conversation's native Codex thread binding; the parent keeps working after spawning a child.
- Log noise eliminated: no more spurious mirrored-session-history warning on every non-Codex model run.

## Evidence

- Focused tests: `node scripts/run-vitest.mjs extensions/codex/index.test.ts extensions/codex/src/app-server/session-history.test.ts` — 30/30 pass, including new regression coverage: cross-key handoff preserves parent binding; same-key rollover with `nextSessionId` still retires; unknown-current-key end with successor key still retires; non-Codex transcript returns `[]`; corrupt `session` header returns `undefined`.
- Cross-key emission contract verified against `src/gateway/session-create-service.ts` (emits parent `session_end` reason `new` + child `nextSessionKey`; parent row not replaced) and `src/plugins/hook-types.ts` (`PluginHookSessionEndEvent.nextSessionKey`).
- Autoreview (Codex gpt-5.6-sol, xhigh): clean — "no accepted/actionable findings"; two earlier findings fixed (unknown-key conservative retire, malformed-header warn path), two rejected with emitter-inventory evidence recorded inline.
- Known proof gap: pre-push `check:changed` heavy lane blocked by a Blacksmith backend outage (`context deadline exceeded`, twice); hosted CI on this PR covers the same gates.

Fixes #106778
Fixes #106556
