### PR TITLE
refactor(codex): trim session catalog exports

### DIFF
--- a/extensions/codex/src/session-catalog.test.ts
+++ b/extensions/codex/src/session-catalog.test.ts
@@ -18,15 +18,14 @@ import {
   type CodexAppServerThreadBinding,
 } from "./app-server/session-binding.test-helpers.js";
 import { catalogError } from "./session-catalog-parsing.js";
+import { CODEX_TERMINAL_RESUME_COMMAND } from "./session-catalog-terminal.js";
 import {
   CODEX_LOCAL_SESSION_HOST_ID,
-  CODEX_TERMINAL_RESUME_COMMAND,
   codexSessionCatalogRuntime,
   createCodexSessionCatalogControl,
   createCodexSessionCatalogNodeHostCommands,
   createCodexSessionCatalogNodeInvokePolicies,
 } from "./session-catalog.js";
-import { classifyCodexUpstreamTurns } from "./session-upstream-activity.js";
 
 const CODEX_APP_SERVER_THREADS_LIST_COMMAND = "codex.appServer.threads.list.v1";
 const CODEX_APP_SERVER_THREAD_TURNS_LIST_COMMAND = "codex.appServer.thread.turns.list.v1";
@@ -1600,25 +1599,6 @@ describe("Codex supervision actions", () => {
         userMessageCount: 2,
       },
     ]);
-    const baseline = baselines[0];
-    if (!baseline) {
-      throw new Error("expected canonical upstream baseline");
-    }
-    expect(
-      classifyCodexUpstreamTurns({
-        probe: {
-          sessionKey,
-          agentId: "main",
-          threadId: "thread-1",
-          hostId: CODEX_LOCAL_SESSION_HOST_ID,
-          upstreamKind: "codex-app-server",
-          upstreamRef: { connectionFingerprint: "catalog-connection" },
-          marker: baseline,
-          ownRecentUserTexts: [],
-        },
-        turns: [canonicalTurn],
-      }),
-    ).toBeUndefined();
   });
 
   it("keeps adopted sessions discoverable when the configured default agent changes", async () => {

--- a/extensions/codex/src/session-catalog.ts
+++ b/extensions/codex/src/session-catalog.ts
@@ -119,7 +119,6 @@ export {
   CODEX_LOCAL_SESSION_HOST_ID,
   CODEX_SESSION_CATALOG_MAX_PAGE_LIMIT,
 } from "./session-catalog-parsing.js";
-export { CODEX_TERMINAL_RESUME_COMMAND } from "./session-catalog-terminal.js";
 
 type CodexSessionCatalogRequestSnapshot = {
   requestTimeoutMs: number;

--- a/extensions/codex/src/session-upstream-activity.test.ts
+++ b/extensions/codex/src/session-upstream-activity.test.ts
@@ -1,11 +1,11 @@
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
 import type { SessionUpstreamProbe } from "openclaw/plugin-sdk/session-catalog";
 import { describe, expect, it, vi } from "vitest";
 import { CodexAppServerRpcError } from "./app-server/client.js";
 import type { CodexTurn } from "./app-server/protocol.js";
-import {
-  checkCodexUpstreamActivity,
-  classifyCodexUpstreamTurns,
-} from "./session-upstream-activity.js";
+import type { CodexAppServerBindingStore } from "./app-server/session-binding.js";
+import type { CodexSessionCatalogControl } from "./session-catalog-types.js";
+import { createChecker } from "./session-upstream-activity.js";
 
 function probe(overrides: Partial<SessionUpstreamProbe> = {}): SessionUpstreamProbe {
   return {
@@ -33,10 +33,63 @@ function turn(id: string, itemTypes: string[], startedAt: number): CodexTurn {
   };
 }
 
+function createControl(overrides: Partial<CodexSessionCatalogControl> = {}) {
+  const withPinnedConnection = vi.fn(
+    async (run: (value: CodexSessionCatalogControl) => Promise<unknown>) => await run(control),
+  ) as unknown as CodexSessionCatalogControl["withPinnedConnection"];
+  const control = {
+    connectionFingerprint: "connection-1",
+    withPinnedConnection,
+    listPage: vi.fn(async () => ({ sessions: [] })),
+    listDescendantPage: vi.fn(async () => ({ data: [] })),
+    listTurnPage: vi.fn(async () => ({ data: [] })),
+    readThread: vi.fn(async (threadId: string) => ({ id: threadId }) as never),
+    archiveThread: vi.fn(async () => undefined),
+    ...overrides,
+  } as CodexSessionCatalogControl;
+  return control;
+}
+
+function createActivityChecker(params: {
+  control: CodexSessionCatalogControl;
+  sessionId?: string;
+  binding?: {
+    threadId: string;
+    connectionScope?: "supervision";
+    supervisionSourceThreadId?: string;
+  };
+}) {
+  const api = {
+    runtime: {
+      agent: {
+        session: {
+          getSessionEntry: () => (params.sessionId ? { sessionId: params.sessionId } : undefined),
+        },
+      },
+    },
+  } as unknown as OpenClawPluginApi;
+  const bindingStore = {
+    read: vi.fn(async () => params.binding),
+  } as unknown as CodexAppServerBindingStore;
+  return createChecker({
+    api,
+    bindingStore,
+    control: params.control,
+    getRuntimeConfig: () => undefined,
+  });
+}
+
+async function checkTurns(params: { probe: SessionUpstreamProbe; turns: CodexTurn[] }) {
+  const control = createControl({
+    listTurnPage: vi.fn(async () => ({ data: params.turns })),
+  });
+  return await createActivityChecker({ control })([params.probe]);
+}
+
 describe("Codex upstream activity", () => {
-  it("counts userMessage turns and uses the latest human timestamp", () => {
-    expect(
-      classifyCodexUpstreamTurns({
+  it("counts userMessage turns and uses the latest human timestamp", async () => {
+    await expect(
+      checkTurns({
         probe: probe(),
         turns: [
           turn("turn-4", ["agentMessage"], 400),
@@ -45,27 +98,29 @@ describe("Codex upstream activity", () => {
           turn("turn-1", ["userMessage"], 100),
         ],
       }),
-    ).toEqual({
-      kind: "activity",
-      sessionKey: "agent:main:adopted:codex",
-      occurredAt: 300_000,
-      humanTurns: 1,
-      nextMarker: { turnId: "turn-4", userMessageCount: 0 },
-      dedupeId: "turn-4:0",
-    });
+    ).resolves.toEqual([
+      {
+        kind: "activity",
+        sessionKey: "agent:main:adopted:codex",
+        occurredAt: 300_000,
+        humanTurns: 1,
+        nextMarker: { turnId: "turn-4", userMessageCount: 0 },
+        dedupeId: "turn-4:0",
+      },
+    ]);
   });
 
-  it("leaves empty-page existence classification to the provider", () => {
-    expect(classifyCodexUpstreamTurns({ probe: probe(), turns: [] })).toBeUndefined();
+  it("keeps an existing thread linked when its turn page is empty", async () => {
+    await expect(checkTurns({ probe: probe(), turns: [] })).resolves.toEqual([]);
   });
 
-  it("accepts an empty page for a thread with no materialized turn", () => {
-    expect(
-      classifyCodexUpstreamTurns({
+  it("accepts an empty page for a thread with no materialized turn", async () => {
+    await expect(
+      checkTurns({
         probe: probe({ marker: { turnId: null, userMessageCount: 0 } }),
         turns: [],
       }),
-    ).toBeUndefined();
+    ).resolves.toEqual([]);
   });
 
   it("uses the pinned connection and a bounded descending summary page", async () => {
@@ -73,16 +128,23 @@ describe("Codex upstream activity", () => {
       data: [turn("turn-2", ["userMessage"], 200), turn("turn-1", [], 100)],
     }));
     const readThread = vi.fn(async () => ({}) as never);
-    const control: Parameters<typeof checkCodexUpstreamActivity>[1] = {
-      connectionFingerprint: "connection-1",
+    const control = createControl({
       listTurnPage,
       readThread,
-      withPinnedConnection: async (run) => await run(control),
-    };
+    });
+    const checkUpstreamActivity = createActivityChecker({
+      control,
+      sessionId: "session-1",
+      binding: {
+        threadId: "thread-canonical",
+        connectionScope: "supervision",
+        supervisionSourceThreadId: "thread-1",
+      },
+    });
 
-    await expect(
-      checkCodexUpstreamActivity([probe()], control, async () => "thread-canonical"),
-    ).resolves.toEqual([expect.objectContaining({ dedupeId: "turn-2:1", humanTurns: 1 })]);
+    await expect(checkUpstreamActivity([probe()])).resolves.toEqual([
+      expect.objectContaining({ dedupeId: "turn-2:1", humanTurns: 1 }),
+    ]);
     expect(listTurnPage).toHaveBeenCalledWith({
       threadId: "thread-canonical",
       limit: 100,
@@ -94,16 +156,21 @@ describe("Codex upstream activity", () => {
 
   it("keeps a rolled-back thread linked when thread/read succeeds", async () => {
     const readThread = vi.fn(async () => ({}) as never);
-    const control: Parameters<typeof checkCodexUpstreamActivity>[1] = {
-      connectionFingerprint: "connection-1",
+    const control = createControl({
       listTurnPage: async () => ({ data: [] }),
       readThread,
-      withPinnedConnection: async (run) => await run(control),
-    };
+    });
+    const checkUpstreamActivity = createActivityChecker({
+      control,
+      sessionId: "session-1",
+      binding: {
+        threadId: "thread-canonical",
+        connectionScope: "supervision",
+        supervisionSourceThreadId: "thread-1",
+      },
+    });
 
-    await expect(
-      checkCodexUpstreamActivity([probe()], control, async () => "thread-canonical"),
-    ).resolves.toEqual([]);
+    await expect(checkUpstreamActivity([probe()])).resolves.toEqual([]);
     expect(readThread).toHaveBeenCalledWith("thread-canonical", false);
   });
 
@@ -114,14 +181,12 @@ describe("Codex upstream activity", () => {
         "thread/read",
       );
     });
-    const control: Parameters<typeof checkCodexUpstreamActivity>[1] = {
-      connectionFingerprint: "connection-1",
+    const control = createControl({
       listTurnPage: async () => ({ data: [] }),
       readThread,
-      withPinnedConnection: async (run) => await run(control),
-    };
+    });
 
-    await expect(checkCodexUpstreamActivity([probe()], control)).resolves.toEqual([
+    await expect(createActivityChecker({ control })([probe()])).resolves.toEqual([
       { kind: "missing", sessionKey: "agent:main:adopted:codex" },
     ]);
     expect(readThread).toHaveBeenCalledWith("thread-1", false);
@@ -131,14 +196,12 @@ describe("Codex upstream activity", () => {
     const readThread = vi.fn(async () => {
       throw new CodexAppServerRpcError({ code: -32603, message: "store hiccup" }, "thread/read");
     });
-    const control: Parameters<typeof checkCodexUpstreamActivity>[1] = {
-      connectionFingerprint: "connection-1",
+    const control = createControl({
       listTurnPage: async () => ({ data: [] }),
       readThread,
-      withPinnedConnection: async (run) => await run(control),
-    };
+    });
 
-    await expect(checkCodexUpstreamActivity([probe()], control)).resolves.toEqual([]);
+    await expect(createActivityChecker({ control })([probe()])).resolves.toEqual([]);
   });
 
   it("treats other invalid-request thread/read failures as inconclusive", async () => {
@@ -148,14 +211,12 @@ describe("Codex upstream activity", () => {
         "thread/read",
       );
     });
-    const control: Parameters<typeof checkCodexUpstreamActivity>[1] = {
-      connectionFingerprint: "connection-1",
+    const control = createControl({
       listTurnPage: async () => ({ data: [] }),
       readThread,
-      withPinnedConnection: async (run) => await run(control),
-    };
+    });
 
-    await expect(checkCodexUpstreamActivity([probe()], control)).resolves.toEqual([]);
+    await expect(createActivityChecker({ control })([probe()])).resolves.toEqual([]);
   });
 
   it("detects deletion of a thread baselined with no materialized turn", async () => {
@@ -165,18 +226,15 @@ describe("Codex upstream activity", () => {
         "thread/read",
       );
     });
-    const control: Parameters<typeof checkCodexUpstreamActivity>[1] = {
-      connectionFingerprint: "connection-1",
+    const control = createControl({
       listTurnPage: async () => ({ data: [] }),
       readThread,
-      withPinnedConnection: async (run) => await run(control),
-    };
+    });
 
     await expect(
-      checkCodexUpstreamActivity(
-        [probe({ marker: { turnId: null, userMessageCount: 0 } })],
-        control,
-      ),
+      createActivityChecker({ control })([
+        probe({ marker: { turnId: null, userMessageCount: 0 } }),
+      ]),
     ).resolves.toEqual([{ kind: "missing", sessionKey: "agent:main:adopted:codex" }]);
   });
 
@@ -187,54 +245,56 @@ describe("Codex upstream activity", () => {
       }
       return { data: [turn("turn-2", ["userMessage"], 200), turn("turn-1", [], 100)] };
     });
-    const control: Parameters<typeof checkCodexUpstreamActivity>[1] = {
-      connectionFingerprint: "connection-1",
+    const control = createControl({
       listTurnPage,
       readThread: async () => ({}) as never,
-      withPinnedConnection: async (run) => await run(control),
-    };
+    });
 
     await expect(
-      checkCodexUpstreamActivity(
-        [probe({ threadId: "thread-stale" }), probe({ sessionKey: "healthy" })],
-        control,
-      ),
+      createActivityChecker({ control })([
+        probe({ threadId: "thread-stale" }),
+        probe({ sessionKey: "healthy" }),
+      ]),
     ).resolves.toEqual([expect.objectContaining({ sessionKey: "healthy" })]);
   });
 
-  it("detects a steer-appended user message on the marker turn", () => {
-    expect(
-      classifyCodexUpstreamTurns({
+  it("detects a steer-appended user message on the marker turn", async () => {
+    await expect(
+      checkTurns({
         probe: probe({ marker: { turnId: "turn-1", userMessageCount: 1 } }),
         turns: [turn("turn-1", ["userMessage", "agentMessage", "userMessage"], 100)],
       }),
-    ).toEqual({
-      kind: "activity",
-      sessionKey: "agent:main:adopted:codex",
-      occurredAt: 100_000,
-      humanTurns: 1,
-      nextMarker: { turnId: "turn-1", userMessageCount: 2 },
-      dedupeId: "turn-1:2",
-    });
+    ).resolves.toEqual([
+      {
+        kind: "activity",
+        sessionKey: "agent:main:adopted:codex",
+        occurredAt: 100_000,
+        humanTurns: 1,
+        nextMarker: { turnId: "turn-1", userMessageCount: 2 },
+        dedupeId: "turn-1:2",
+      },
+    ]);
   });
 
-  it("upgrades a legacy turn marker without reporting existing steers", () => {
-    expect(
-      classifyCodexUpstreamTurns({
+  it("upgrades a legacy turn marker without reporting existing steers", async () => {
+    await expect(
+      checkTurns({
         probe: probe({ marker: { turnId: "turn-1" } }),
         turns: [turn("turn-1", ["userMessage", "agentMessage", "userMessage"], 100)],
       }),
-    ).toEqual({
-      kind: "activity",
-      sessionKey: "agent:main:adopted:codex",
-      humanTurns: 0,
-      nextMarker: { turnId: "turn-1", userMessageCount: 2 },
-    });
+    ).resolves.toEqual([
+      {
+        kind: "activity",
+        sessionKey: "agent:main:adopted:codex",
+        humanTurns: 0,
+        nextMarker: { turnId: "turn-1", userMessageCount: 2 },
+      },
+    ]);
   });
 
-  it("filters OpenClaw-authored user items by normalized transcript text", () => {
-    expect(
-      classifyCodexUpstreamTurns({
+  it("filters OpenClaw-authored user items by normalized transcript text", async () => {
+    await expect(
+      checkTurns({
         probe: probe({
           marker: { turnId: "turn-1", userMessageCount: 0 },
           ownRecentUserTexts: ["same prompt"],
@@ -253,17 +313,19 @@ describe("Codex upstream activity", () => {
           },
         ],
       }),
-    ).toEqual({
-      kind: "activity",
-      sessionKey: "agent:main:adopted:codex",
-      humanTurns: 0,
-      nextMarker: { turnId: "turn-1", userMessageCount: 1 },
-    });
+    ).resolves.toEqual([
+      {
+        kind: "activity",
+        sessionKey: "agent:main:adopted:codex",
+        humanTurns: 0,
+        nextMarker: { turnId: "turn-1", userMessageCount: 1 },
+      },
+    ]);
   });
 
-  it("filters a batched OpenClaw steer by its component transcript texts", () => {
-    expect(
-      classifyCodexUpstreamTurns({
+  it("filters a batched OpenClaw steer by its component transcript texts", async () => {
+    await expect(
+      checkTurns({
         probe: probe({
           marker: { turnId: "turn-1", userMessageCount: 0 },
           ownRecentUserTexts: ["first steer", "second steer"],
@@ -285,11 +347,13 @@ describe("Codex upstream activity", () => {
           },
         ],
       }),
-    ).toEqual({
-      kind: "activity",
-      sessionKey: "agent:main:adopted:codex",
-      humanTurns: 0,
-      nextMarker: { turnId: "turn-1", userMessageCount: 1 },
-    });
+    ).resolves.toEqual([
+      {
+        kind: "activity",
+        sessionKey: "agent:main:adopted:codex",
+        humanTurns: 0,
+        nextMarker: { turnId: "turn-1", userMessageCount: 1 },
+      },
+    ]);
   });
 });

--- a/extensions/codex/src/session-upstream-activity.ts
+++ b/extensions/codex/src/session-upstream-activity.ts
@@ -72,7 +72,7 @@ function upstreamConnectionFingerprint(probe: SessionUpstreamProbe): string | un
     : undefined;
 }
 
-export function classifyCodexUpstreamTurns(params: {
+function classifyCodexUpstreamTurns(params: {
   probe: SessionUpstreamProbe;
   turns: CodexTurn[];
   now?: number;
@@ -149,7 +149,7 @@ function normalizeUserMessageTexts(item: CodexTurn["items"][number]): string[] {
   return contentTexts?.length ? contentTexts : [(typed.text ?? "").trim().replace(/\s+/g, " ")];
 }
 
-export async function checkCodexUpstreamActivity(
+async function checkCodexUpstreamActivity(
   probes: SessionUpstreamProbe[],
   control: CodexUpstreamControl,
   resolveThreadId: (probe: SessionUpstreamProbe) => Promise<string> = async (probe) =>

--- a/scripts/deadcode-exports.baseline.mjs
+++ b/scripts/deadcode-exports.baseline.mjs
@@ -2,9 +2,6 @@
 // New entries fail CI. After deleting dead code, run `pnpm deadcode:exports:update`.
 // Do not add entries to avoid fixing new findings.
 export const KNIP_UNUSED_EXPORT_BASELINE = [
-  "extensions/codex/src/session-catalog.ts: CODEX_TERMINAL_RESUME_COMMAND",
-  "extensions/codex/src/session-upstream-activity.ts: checkCodexUpstreamActivity (upstream)",
-  "extensions/codex/src/session-upstream-activity.ts: classifyCodexUpstreamTurns",
   "src/acp/control-plane/active-turns.ts: resetAcpActiveTurnsForTests",
   "src/acp/runtime/registry.ts: AcpRuntimeBackend",
   "src/agents/agent-hooks/compaction-safeguard.ts: testing",


### PR DESCRIPTION
## What Problem This Solves

The shrink-only dead-export ratchet still carried three internal Codex session-catalog exports that had no production, package, lazy, dynamic, or documented API consumer.

## Why This Change Was Made

The catalog command constant now stays at its canonical terminal owner, while upstream activity classification is tested through the retained production `createChecker` boundary. No Codex protocol, CLI command, plugin API, or runtime behavior changes.

The production dead-export baseline shrinks from 287 to 284 entries. Production source excluding the baseline is +2/-3 lines (net -1); the baseline is +0/-3.

## User Impact

No user-visible change. Internal Codex session supervision keeps the same terminal-resume, turn-list, and missing-thread behavior with a smaller exported surface.

## Evidence

- Exact production Knip: regenerated baseline is byte-stable at 284 entries; `pnpm deadcode:exports` passes. Final exact Testbox run: https://github.com/openclaw/openclaw/actions/runs/29392831872
- Full Codex extension suite: 109 files, 2,546 tests passed. Proof Testbox run: https://github.com/openclaw/openclaw/actions/runs/29392404359
- Focused local proof: `session-upstream-activity.test.ts` + `session-catalog.test.ts`, 98 tests passed.
- Scoped oxfmt and type-aware oxlint passed; extension types and all test-type lanes passed.
- Fresh `.agents/skills/autoreview/scripts/autoreview --mode local`: clean, no accepted/actionable findings, 0.96.

Upstream Codex hard-gate inspection used official `openai/codex` commit `3afbd8dd45c4fe91d61eeec309f612b82c522892`:

- `codex-rs/app-server-protocol/src/protocol/common.rs:638-648` defines `thread/read` and concurrent experimental `thread/turns/list`.
- `codex-rs/app-server-protocol/src/protocol/v2/thread.rs:1318-1346` defines turns-list paging, descending/default item-view inputs, and cursors.
- `codex-rs/app-server-protocol/src/protocol/v2/thread_data.rs:231-250` defines turn ids, items, status, timestamps, and duration.
- `codex-rs/app-server-protocol/src/protocol/v2/item.rs:227-234` and `:798-805` define and map user-message content.
- `codex-rs/app-server/src/request_processors/thread_processor.rs:2235-2304` implements `thread/read` and the exact `thread not loaded:` result.
- `codex-rs/app-server/src/request_processors/thread_processor.rs:2420-2573` implements turns-list paging/defaults; `:2634-2691` covers rollout/history fallback; `:4298-4311` maps read errors; `:4330-4354` maps stored turns.
- `codex-rs/app-server/src/error_code.rs:3-12` confirms invalid-request code `-32600`.
- `codex-rs/cli/src/main.rs:180-181`, `:311-328`, `:1243-1264`, `:2364-2391`, and `:3273-3290` confirm `codex resume SESSION_ID` positional dispatch.

AI-assisted: yes. I understand and reviewed the complete change.
