### PR TITLE
test(github-copilot): align token endpoint fixtures

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -198,6 +198,7 @@ Skills own workflows; root owns hard policy and routing.
 - After every PR push, rerun `scripts/pr review-init`; checkout alone leaves stale guard SHA.
 - `rg`: options/globs before `--`; `--` immediately before a leading-dash pattern only.
 - `gh --jq` is not standalone `jq`; pipe JSON to `jq` for variables or `--arg`.
+- Shared checkout: serialize `git fetch`; on ref-lock failure, re-read the ref before retry.
 - `gh api --paginate '<endpoint>' | jq -s ...`; gh `--slurp` may emit nothing and forbids `--jq`/`--template`.
 - Main-bound workflow dispatch: resolve server `main` SHA immediately before dispatch; retry if identity fails after `main` advances.
 - `gh run view --json` uses `attempt`, not `attemptNumber`.

--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -7377,6 +7377,8 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
   - H2: Compatibility policy
   - H2: How to migrate
   - H2: Import path reference
+  - H2: Removed compatibility surfaces
+  - H3: Private testing barrel
   - H2: Active deprecations
   - H2: Talk and realtime voice migration
   - H2: Removal timeline

--- a/extensions/github-copilot/models.test.ts
+++ b/extensions/github-copilot/models.test.ts
@@ -55,6 +55,10 @@ function requireResolvedModel(ctx: ProviderResolveDynamicModelContext) {
   return result;
 }
 
+function copilotCredentialFixture(proxyHost: string): string {
+  return `test-token-placeholder;proxy-ep=${proxyHost};`;
+}
+
 describe("resolveCopilotForwardCompatModel", () => {
   it("returns undefined for empty modelId", () => {
     expect(resolveCopilotForwardCompatModel(createMockCtx(""))).toBeUndefined();
@@ -341,17 +345,18 @@ describe("github-copilot token", () => {
   const cachePath = "/tmp/openclaw-state/credentials/github-copilot.token.json";
 
   beforeEach(() => {
-    jsonStoreMocks.loadJsonFile.mockClear();
-    jsonStoreMocks.saveJsonFile.mockClear();
+    jsonStoreMocks.loadJsonFile.mockReset();
+    jsonStoreMocks.saveJsonFile.mockReset();
   });
 
-  it("derives baseUrl from token", () => {
-    expect(deriveCopilotApiBaseUrlFromToken("token;proxy-ep=proxy.example.com;")).toBe(
-      "https://api.example.com",
-    );
-    expect(deriveCopilotApiBaseUrlFromToken("token;proxy-ep=https://proxy.foo.bar;")).toBe(
-      "https://api.foo.bar",
-    );
+  it("derives baseUrl only from trusted Copilot token hosts", () => {
+    expect(deriveCopilotApiBaseUrlFromToken("token;proxy-ep=proxy.example.com;")).toBeNull();
+    expect(deriveCopilotApiBaseUrlFromToken("token;proxy-ep=https://proxy.foo.bar;")).toBeNull();
+    expect(
+      deriveCopilotApiBaseUrlFromToken(
+        copilotCredentialFixture("proxy.individual.githubcopilot.com"),
+      ),
+    ).toBe("https://api.individual.githubcopilot.com");
   });
 
   it("uses cache when token is still valid", async () => {
@@ -375,7 +380,7 @@ describe("github-copilot token", () => {
     });
 
     expect(res.token).toBe("cached;proxy-ep=proxy.example.com;");
-    expect(res.baseUrl).toBe("https://api.example.com");
+    expect(res.baseUrl).toBe("https://api.individual.githubcopilot.com");
     expect(res.source).toContain("cache:");
     expect(fetchImpl).not.toHaveBeenCalled();
   });
@@ -405,7 +410,7 @@ describe("github-copilot token", () => {
     });
 
     expect(res.token).toBe("fresh;proxy-ep=https://proxy.contoso.test;");
-    expect(res.baseUrl).toBe("https://api.contoso.test");
+    expect(res.baseUrl).toBe("https://api.individual.githubcopilot.com");
     const [, calledInit] = fetchImpl.mock.calls[0] ?? [];
     expect(((calledInit as RequestInit).headers as Record<string, string>)["Accept-Encoding"]).toBe(
       "identity",


### PR DESCRIPTION
## What Problem This Solves

Full Release Validation at `d702f6fb33480530c4e9a2b45bfd3ab02fa10c0c` failed Plugin Prerelease because `extensions/github-copilot/models.test.ts` still expected arbitrary token `proxy-ep` hosts to be accepted after the main security hardening in `c0f7fb3b864c48bdab4113d4de133f5fb3209c25` began rejecting them.

Failed run: https://github.com/openclaw/openclaw/actions/runs/29392144383

## Why This Change Was Made

The production trust policy is correct. The tests now assert that arbitrary proxy hosts are rejected, that a GitHub-owned Copilot host is accepted, and that cached or freshly exchanged tokens with rejected hints fall back to the trusted public Copilot API endpoint. JSON-store mocks now reset between tests so prior implementations cannot leak across cases.

`AGENTS.md` also records the shared-checkout fetch guard learned during this release-prep run: serialize fetches and re-read the ref after a lock race before retrying.

The branch replays the two-line generated docs-map update from current main commit `fc56b554039cc87222a2b47b4153737d9e427781` so exact-head CI is self-consistent despite the branch's older merge base. The replay is byte-identical to main and produces no net docs change when landed.

## User Impact

No runtime behavior change. Release validation again tests the intended security boundary instead of stale pre-hardening behavior.

## Evidence

- Testbox `tbx_01kxj5nbvqgcnazfr4swrg8r26`: 31/31 focused tests passed.
- Testbox Actions: https://github.com/openclaw/openclaw/actions/runs/29392857368
- `node_modules/.bin/oxfmt --check AGENTS.md extensions/github-copilot/models.test.ts`
- `git diff --check`
- Fresh autoreview: clean, confidence 0.93.
- Fresh whole-head autoreview after the docs-map replay: clean, confidence 0.95.
- Exact-head CI: https://github.com/openclaw/openclaw/actions/runs/29393690827

No changelog entry: test and maintainer-invocation guidance only.
