### PR TITLE
improve: speed bench model tests

### DIFF
--- a/test/scripts/bench-model.test.ts
+++ b/test/scripts/bench-model.test.ts
@@ -3,6 +3,8 @@ import { spawnSync } from "node:child_process";
 import { describe, expect, it } from "vitest";
 import { testing } from "../../scripts/bench-model.ts";
 
+// Keep this helper limited to one CLI error smoke plus the help smoke. Parser
+// edge cases stay in-process so this fast unit file avoids repeated cold TSX startup.
 function runBenchModel(args: string[]) {
   return spawnSync(process.execPath, ["--import", "tsx", "scripts/bench-model.ts", ...args], {
     cwd: process.cwd(),
@@ -38,39 +40,17 @@ describe("scripts/bench-model", () => {
 
   it("rejects malformed run counts instead of silently using defaults", () => {
     expect(() => testing.parseArgs(["--runs", "1e3"])).toThrow("--runs must be an integer");
-
-    const result = runBenchModel(["--runs", "1e3"]);
-
-    expect(result.status).toBe(1);
-    expect(result.stdout).toBe("");
-    expect(result.stderr).toContain("--runs must be an integer");
-    expect(result.stderr).not.toContain("Missing ANTHROPIC_API_KEY");
   });
 
-  it("rejects short flag values before checking provider credentials", () => {
+  it("rejects short flag values", () => {
     expect(() => testing.parseArgs(["--prompt", "-h"])).toThrow("--prompt requires a value");
     expect(() => testing.parseArgs(["--runs", "-h"])).toThrow("--runs requires a value");
-
-    const result = runBenchModel(["--prompt", "-h"]);
-
-    expect(result.status).toBe(1);
-    expect(result.stdout).toBe("");
-    expect(result.stderr.trim()).toBe("--prompt requires a value");
-    expect(result.stderr).not.toContain("Missing ANTHROPIC_API_KEY");
   });
 
-  it("rejects duplicate value flags before checking provider credentials", () => {
+  it("rejects duplicate value flags", () => {
     expect(() => testing.parseArgs(["--runs", "1", "--runs", "2"])).toThrow(
       "--runs was provided more than once",
     );
-
-    const result = runBenchModel(["--runs", "1", "--runs", "2"]);
-
-    expect(result.status).toBe(1);
-    expect(result.stdout).toBe("");
-    expect(result.stderr.trim()).toBe("--runs was provided more than once");
-    expect(result.stderr).not.toContain("Missing ANTHROPIC_API_KEY");
-    expect(result.stderr).not.toContain("\n    at ");
   });
 
   it("prints help without checking provider credentials", () => {


### PR DESCRIPTION
## What Problem This Solves

The fast unit suite paid for five cold TSX subprocess startups while testing the model benchmark CLI, even though three cases already asserted the parser behavior directly.

## Why This Change Was Made

Keep malformed-count, missing-value, and duplicate-flag assertions in-process. Retain representative subprocess smokes for the CLI error path and help path, preserving entrypoint wiring coverage without redundant cold starts.

## User Impact

No product behavior change. The focused test file runs about 69% faster while retaining all six tests.

## Evidence

- Testbox-through-Crabbox: `tbx_01kxj5jbscvg0657mn0vwap17a`
- Actions: https://github.com/openclaw/openclaw/actions/runs/29392785626
- Before: `pnpm test test/scripts/bench-model.test.ts -- --reporter=verbose` — 6/6 pass, Vitest duration 5.29s.
- After: same command — 6/6 pass, Vitest duration 1.65s (68.8% faster).
- `pnpm check:changed` — pass.
- `.agents/skills/autoreview/scripts/autoreview --mode local --stream-engine-output` — clean, no accepted/actionable findings.
