### PR TITLE
refactor(plugins): defer installed payload validation

### DIFF
--- a/src/plugins/update.test.ts
+++ b/src/plugins/update.test.ts
@@ -49,6 +49,7 @@ const installPluginFromClawHubMock = vi.fn();
 const installPluginFromGitSpecMock = vi.fn();
 const resolveBundledPluginSourcesMock = vi.fn();
 const runCommandWithTimeoutMock = vi.fn();
+const validatePackageExtensionEntriesForInstallMock = vi.fn();
 const tempDirs: string[] = [];
 
 vi.mock("./install.js", () => ({
@@ -92,6 +93,19 @@ vi.mock("./bundled-sources.js", () => ({
 vi.mock("../process/exec.js", () => ({
   runCommandWithTimeout: (...args: unknown[]) => runCommandWithTimeoutMock(...args),
 }));
+
+vi.mock("./package-entry-resolution.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./package-entry-resolution.js")>();
+  return {
+    ...actual,
+    validatePackageExtensionEntriesForInstall: async (
+      ...args: Parameters<typeof actual.validatePackageExtensionEntriesForInstall>
+    ) => {
+      validatePackageExtensionEntriesForInstallMock(...args);
+      return await actual.validatePackageExtensionEntriesForInstall(...args);
+    },
+  };
+});
 
 vi.resetModules();
 
@@ -523,6 +537,7 @@ describe("updateNpmInstalledPlugins", () => {
     resolveBundledPluginSourcesMock.mockReset();
     resolveBundledPluginSourcesMock.mockReturnValue(new Map());
     runCommandWithTimeoutMock.mockReset();
+    validatePackageExtensionEntriesForInstallMock.mockReset();
     const installPath = createInstalledPackageDir({
       name: "@martian-engineering/lossless-claw",
       version: "0.9.0",
@@ -567,6 +582,7 @@ describe("updateNpmInstalledPlugins", () => {
     resolveBundledPluginSourcesMock.mockReset();
     resolveBundledPluginSourcesMock.mockReturnValue(new Map());
     runCommandWithTimeoutMock.mockReset();
+    validatePackageExtensionEntriesForInstallMock.mockReset();
   });
 
   afterEach(() => {
@@ -2043,6 +2059,34 @@ describe("updateNpmInstalledPlugins", () => {
     ]);
   });
 
+  it("defers installed payload validation until metadata probing fails", async () => {
+    const installPath = createInstalledPackageDir({
+      name: "@martian-engineering/lossless-claw",
+      version: "0.9.0",
+      runnable: true,
+    });
+    mockNpmViewMetadata({
+      name: "@martian-engineering/lossless-claw",
+      version: "0.9.0",
+    });
+
+    const result = await updateNpmInstalledPlugins({
+      config: createNpmInstallConfig({
+        pluginId: "lossless-claw",
+        spec: "@martian-engineering/lossless-claw@^0.9.0",
+        installPath,
+        resolvedName: "@martian-engineering/lossless-claw",
+        resolvedSpec: "@martian-engineering/lossless-claw@0.9.0",
+        resolvedVersion: "0.9.0",
+      }),
+      pluginIds: ["lossless-claw"],
+      disableOnFailure: true,
+    });
+
+    expect(result.outcomes[0]?.status).toBe("unchanged");
+    expect(validatePackageExtensionEntriesForInstallMock).not.toHaveBeenCalled();
+  });
+
   it("preserves healthy plugin state when metadata probing fails before replacement", async () => {
     const warn = vi.fn();
     const installPath = createInstalledPackageDir({
@@ -2101,6 +2145,7 @@ describe("updateNpmInstalledPlugins", () => {
       memory: "lossless-claw",
       contextEngine: "lossless-claw",
     });
+    expect(validatePackageExtensionEntriesForInstallMock).toHaveBeenCalledTimes(1);
     expect(result.outcomes).toEqual([
       {
         pluginId: "lossless-claw",
@@ -2164,6 +2209,48 @@ describe("updateNpmInstalledPlugins", () => {
         message,
       },
     ]);
+  });
+
+  it("continues the plugin sweep when deferred payload validation throws", async () => {
+    const warn = vi.fn();
+    const installPath = createInstalledPackageDir({
+      name: "@acme/demo",
+      version: "1.0.0",
+      runnable: true,
+    });
+    runCommandWithTimeoutMock.mockResolvedValueOnce({
+      code: 1,
+      stdout: "",
+      stderr: "registry timeout",
+    });
+    validatePackageExtensionEntriesForInstallMock.mockImplementationOnce(() => {
+      throw new Error("permission denied");
+    });
+
+    const result = await updateNpmInstalledPlugins({
+      config: {
+        plugins: {
+          entries: { demo: { enabled: true } },
+          installs: {
+            demo: {
+              source: "npm",
+              spec: "@acme/demo@^1.0.0",
+              installPath,
+            },
+            local: {
+              source: "path",
+              installPath: "/tmp/local",
+            },
+          },
+        },
+      },
+      pluginIds: ["demo", "local"],
+      disableOnFailure: true,
+      logger: { warn },
+    });
+
+    expect(result.config.plugins?.entries?.demo?.enabled).toBe(false);
+    expect(result.outcomes.map(({ pluginId }) => pluginId)).toEqual(["demo", "local"]);
   });
 
   it("disables a missing plugin payload when metadata probing also fails", async () => {

--- a/src/plugins/update.ts
+++ b/src/plugins/update.ts
@@ -1676,17 +1676,11 @@ export async function updateNpmInstalledPlugins(params: {
       continue;
     }
     let currentVersion: string | undefined;
-    let installedPayloadRunnable: boolean;
+    let installedManifest: PackageManifest | undefined;
     try {
-      const installedManifest = readInstalledPackageManifest(installPath) as
-        | PackageManifest
-        | undefined;
+      installedManifest = readInstalledPackageManifest(installPath) as PackageManifest | undefined;
       currentVersion =
         typeof installedManifest?.version === "string" ? installedManifest.version : undefined;
-      installedPayloadRunnable =
-        Boolean(params.disableOnFailure) &&
-        currentVersion !== undefined &&
-        (await hasRunnableInstalledNpmPayload({ installPath, manifest: installedManifest }));
     } catch (err) {
       recordFailure(
         pluginId,
@@ -1694,6 +1688,24 @@ export async function updateNpmInstalledPlugins(params: {
       );
       continue;
     }
+    // Payload validation is filesystem work needed only to preserve state after metadata failures.
+    // Every failure path below ends this plugin iteration, so the result cannot be reused.
+    const hasRunnableInstalledPayloadForFailure = async (code?: string): Promise<boolean> => {
+      if (
+        code !== PLUGIN_INSTALL_ERROR_CODE.NPM_METADATA_FAILURE ||
+        !params.disableOnFailure ||
+        params.dryRun ||
+        currentVersion === undefined
+      ) {
+        return false;
+      }
+      try {
+        return await hasRunnableInstalledNpmPayload({ installPath, manifest: installedManifest });
+      } catch {
+        // Damaged or unreadable payloads fail closed without aborting the remaining plugin sweep.
+        return false;
+      }
+    };
     const extensionsDir = resolveRecordedExtensionsDir({
       pluginId,
       installPath,
@@ -1789,12 +1801,13 @@ export async function updateNpmInstalledPlugins(params: {
         }
       } else {
         if (!parseRegistryNpmSpec(effectiveSpec!)) {
+          const code =
+            metadataResult.category === "metadata-env"
+              ? PLUGIN_INSTALL_ERROR_CODE.NPM_METADATA_FAILURE
+              : undefined;
           recordFailure(pluginId, `Failed to check ${pluginId}: ${metadataResult.error}`, {
-            code:
-              metadataResult.category === "metadata-env"
-                ? PLUGIN_INSTALL_ERROR_CODE.NPM_METADATA_FAILURE
-                : undefined,
-            installedPayloadRunnable,
+            code,
+            installedPayloadRunnable: await hasRunnableInstalledPayloadForFailure(code),
           });
           continue;
         }
@@ -2004,6 +2017,7 @@ export async function updateNpmInstalledPlugins(params: {
           );
           continue;
         }
+        const code = "code" in probe && probe.code ? probe.code : undefined;
         recordFailure(
           pluginId,
           record.source === "npm" || usedOfficialNpmFallback
@@ -2042,8 +2056,8 @@ export async function updateNpmInstalledPlugins(params: {
                   }),
           {
             channelFallback: npmChannelFallback,
-            code: "code" in probe && probe.code ? probe.code : undefined,
-            installedPayloadRunnable,
+            code,
+            installedPayloadRunnable: await hasRunnableInstalledPayloadForFailure(code),
           },
         );
         continue;
@@ -2311,6 +2325,7 @@ export async function updateNpmInstalledPlugins(params: {
         );
         continue;
       }
+      const code = resultSource === "npm" && result && "code" in result ? result.code : undefined;
       recordFailure(
         pluginId,
         resultSource === "npm"
@@ -2349,8 +2364,8 @@ export async function updateNpmInstalledPlugins(params: {
                 }),
         {
           channelFallback: npmChannelFallback,
-          code: resultSource === "npm" && result && "code" in result ? result.code : undefined,
-          installedPayloadRunnable,
+          code,
+          installedPayloadRunnable: await hasRunnableInstalledPayloadForFailure(code),
         },
       );
       continue;


### PR DESCRIPTION
Related: #107063

AI-assisted: yes. The final diff passed the repository autoreview gate.

## What Problem This Solves

The post-update plugin sweep validates every installed plugin payload whenever disable-on-failure handling is active, even when npm metadata lookup succeeds. That adds unnecessary filesystem and entry-resolution work to healthy update paths.

## Why This Change Was Made

Defer installed-payload validation until an npm metadata failure can actually preserve existing state. Unreadable payloads fail closed as non-runnable without aborting the remaining plugin sweep. The plugin update owner boundary and #107063 state-preservation behavior stay unchanged.

## User Impact

No user-visible behavior change intended. Healthy update checks avoid redundant payload validation; metadata failures still preserve runnable installs and disable missing, corrupt, or unreadable installs.

## Evidence

- Blacksmith Testbox focused suite: `src/plugins/update.test.ts` — 120/120 passed (wrapper exit 0, run 29392765579).
- Blacksmith Testbox core production/test typechecks plus targeted oxlint — passed (wrapper exit 0, run 29392848313).
- `git diff --check` — passed.
- Repository autoreview — clean after fixing its accepted exception-boundary finding.
- `pnpm check:changed` formatting and preliminary guards passed; its Plugin SDK API baseline failure reproduces unchanged on clean `main` at `f0bcf899c0a1bee94474489590e448ad9b737b3a`.
