### PR TITLE
fix(ci): refresh generated docs map

### DIFF
--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -7377,6 +7377,8 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
   - H2: Compatibility policy
   - H2: How to migrate
   - H2: Import path reference
+  - H2: Removed compatibility surfaces
+  - H3: Private testing barrel
   - H2: Active deprecations
   - H2: Talk and realtime voice migration
   - H2: Removal timeline


### PR DESCRIPTION
Related: #108020

## What Problem This Solves

Fixes an issue where the docs validation job fails after the plugin SDK migration guide gained two headings without a matching generated docs-map refresh.

## Why This Change Was Made

Regenerates `docs/docs_map.md` from the current documentation sources. The resulting diff adds only the missing "Removed compatibility surfaces" and "Private testing barrel" headings.

## User Impact

No published documentation content changes. Developers can run the docs validation lane successfully again, and the generated navigation map matches the source docs.

## Evidence

- Before: `node scripts/generate-docs-map.mjs --check` reports `docs/docs_map.md is out of date` on current `main`.
- After: `node scripts/generate-docs-map.mjs --check` passes.
- `git diff --check` passes.
- Diff is limited to two generated heading entries in `docs/docs_map.md`.

AI-assisted: yes. The generated diff and validation output were reviewed.
