### PR TITLE
fix: restore palette-aware embedded terminal surfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Control UI terminal colors:** answer default foreground and background color queries in embedded terminals so palette-aware TUIs render their intended surfaces instead of falling back to unstyled backgrounds.
 - **Mattermost progress command details:** accept the documented `streaming.preview.commandText` and `streaming.progress.commandText` modes in channel config validation and bundled metadata. Thanks @shakkernerd.
 - **1Password authorization handoff:** persist nonce-bound pending approvals in shared plugin state so hook and tool execution across broker instances remain single-use and fail closed.
 - **Control UI chat transcripts:** preserve loaded history across session and pane returns, bound automatic backscroll loading, virtualize long transcripts, retain hidden native run boundaries, and keep prepends, streaming, and responsive layouts from flickering or jumping. Thanks @shakkernerd.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Control UI terminal colors:** answer default foreground and background color queries in embedded terminals so palette-aware TUIs render their intended surfaces instead of falling back to unstyled backgrounds.
 - **Mattermost progress command details:** accept the documented `streaming.preview.commandText` and `streaming.progress.commandText` modes in channel config validation and bundled metadata. Thanks @shakkernerd.
 - **1Password authorization handoff:** persist nonce-bound pending approvals in shared plugin state so hook and tool execution across broker instances remain single-use and fail closed.
 - **Control UI chat transcripts:** preserve loaded history across session and pane returns, bound automatic backscroll loading, virtualize long transcripts, retain hidden native run boundaries, and keep prepends, streaming, and responsive layouts from flickering or jumping. Thanks @shakkernerd.

--- a/ui/src/components/terminal/terminal-color-queries.test.ts
+++ b/ui/src/components/terminal/terminal-color-queries.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it, vi } from "vitest";
+import { createTerminalDefaultColorQueryResponder } from "./terminal-color-queries.ts";
+
+const DARK_COLORS = { foreground: "#d7dae0", background: "#0e1015", cursor: "#ff5c5c" };
+const LIGHT_COLORS = { foreground: "#1b1e26", background: "#f7f8fa", cursor: "#1b1e26" };
+
+describe("terminal default-color query responder", () => {
+  it("answers OSC 10 and 11 queries with Ghostty-compatible RGB values", () => {
+    const reply = vi.fn();
+    const responder = createTerminalDefaultColorQueryResponder(() => DARK_COLORS, reply);
+
+    responder.observe("prefix\u001b]10;?\u001b\\\u001b]11;?\u0007suffix");
+
+    expect(reply.mock.calls.map(([data]) => data)).toEqual([
+      "\u001b]10;rgb:d7d7/dada/e0e0\u001b\\",
+      "\u001b]11;rgb:0e0e/1010/1515\u0007",
+    ]);
+  });
+
+  it("answers multi-parameter queries and preserves their terminator", () => {
+    const reply = vi.fn();
+    const responder = createTerminalDefaultColorQueryResponder(() => DARK_COLORS, reply);
+
+    responder.observe("\u001b]10;?;?;?\u0007");
+
+    expect(reply.mock.calls.map(([data]) => data)).toEqual([
+      "\u001b]10;rgb:d7d7/dada/e0e0\u0007",
+      "\u001b]11;rgb:0e0e/1010/1515\u0007",
+      "\u001b]12;rgb:ffff/5c5c/5c5c\u0007",
+    ]);
+  });
+
+  it("recognizes each query across every stream split", () => {
+    for (const query of ["\u001b]10;?\u0007", "\u001b]11;?\u001b\\"]) {
+      for (let split = 1; split < query.length; split += 1) {
+        const reply = vi.fn();
+        const responder = createTerminalDefaultColorQueryResponder(() => DARK_COLORS, reply);
+
+        responder.observe(query.slice(0, split));
+        expect(reply).not.toHaveBeenCalled();
+        responder.observe(query.slice(split));
+
+        expect(reply).toHaveBeenCalledOnce();
+      }
+    }
+  });
+
+  it("uses the current colors when the terminal theme changes", () => {
+    let colors = DARK_COLORS;
+    const reply = vi.fn();
+    const responder = createTerminalDefaultColorQueryResponder(() => colors, reply);
+
+    responder.observe("\u001b]11;?\u001b\\");
+    colors = LIGHT_COLORS;
+    responder.observe("\u001b]11;?\u001b\\");
+
+    expect(reply.mock.calls.map(([data]) => data)).toEqual([
+      "\u001b]11;rgb:0e0e/1010/1515\u001b\\",
+      "\u001b]11;rgb:f7f7/f8f8/fafa\u001b\\",
+    ]);
+  });
+
+  it("ignores unrelated OSC commands", () => {
+    const reply = vi.fn();
+    const responder = createTerminalDefaultColorQueryResponder(() => DARK_COLORS, reply);
+
+    responder.observe("\u001b]13;?\u001b\\");
+
+    expect(reply).not.toHaveBeenCalled();
+  });
+
+  it("suppresses historical replies while retaining a replay's trailing query prefix", () => {
+    const reply = vi.fn();
+    const responder = createTerminalDefaultColorQueryResponder(() => DARK_COLORS, reply);
+
+    responder.primeFromReplay("\u001b]10;?\u001b\\history\u001b]11;");
+    expect(reply).not.toHaveBeenCalled();
+    responder.observe("?\u001b\\");
+
+    expect(reply).toHaveBeenCalledOnce();
+    expect(reply).toHaveBeenCalledWith("\u001b]11;rgb:0e0e/1010/1515\u001b\\");
+  });
+});

--- a/ui/src/components/terminal/terminal-color-queries.ts
+++ b/ui/src/components/terminal/terminal-color-queries.ts
@@ -1,0 +1,118 @@
+export type TerminalDynamicColors = {
+  foreground: string;
+  background: string;
+  cursor: string;
+};
+
+type DynamicColorName = keyof TerminalDynamicColors;
+
+const ESC = "\u001b";
+const BEL = "\u0007";
+const ST = `${ESC}\\`;
+const MAX_PENDING_COLOR_SEQUENCE_CHARS = 1024;
+
+const DYNAMIC_COLOR_SLOTS = [
+  { color: "foreground", slot: 10 },
+  { color: "background", slot: 11 },
+  { color: "cursor", slot: 12 },
+] as const satisfies Array<{ color: DynamicColorName; slot: number }>;
+const DYNAMIC_COLOR_HEADERS = DYNAMIC_COLOR_SLOTS.map(({ slot }) => ({
+  sequence: `${ESC}]${slot};`,
+  slot,
+}));
+
+type OscTerminator = typeof BEL | typeof ST;
+
+function findOscTerminator(
+  data: string,
+  start: number,
+): { index: number; terminator: OscTerminator } | null {
+  for (let index = start; index < data.length; index += 1) {
+    if (data[index] === BEL) {
+      return { index, terminator: BEL };
+    }
+    if (data[index] === ESC && data[index + 1] === "\\") {
+      return { index, terminator: ST };
+    }
+  }
+  return null;
+}
+
+function formatOscColor(slot: number, color: string, terminator: OscTerminator): string | null {
+  const match = /^#([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$/iu.exec(color);
+  if (!match) {
+    return null;
+  }
+  const [, red, green, blue] = match;
+  return `${ESC}]${slot};rgb:${red}${red}/${green}${green}/${blue}${blue}${terminator}`;
+}
+
+/** Answers streamed OSC 10-12 dynamic-color queries like a native terminal. */
+export function createTerminalDefaultColorQueryResponder(
+  getColors: () => TerminalDynamicColors,
+  reply: (data: string) => void,
+) {
+  let pending = "";
+
+  const process = (data: string, shouldReply: boolean): void => {
+    pending += data;
+    while (pending.length > 0) {
+      const queryStart = pending.indexOf(`${ESC}]`);
+      if (queryStart === -1) {
+        pending = pending.endsWith(ESC) ? ESC : "";
+        return;
+      }
+      if (queryStart > 0) {
+        pending = pending.slice(queryStart);
+      }
+
+      const header = DYNAMIC_COLOR_HEADERS.find(({ sequence }) => pending.startsWith(sequence));
+      if (!header) {
+        if (DYNAMIC_COLOR_HEADERS.some(({ sequence }) => sequence.startsWith(pending))) {
+          return;
+        }
+        pending = pending.slice(1);
+        continue;
+      }
+
+      const end = findOscTerminator(pending, header.sequence.length);
+      if (!end) {
+        if (pending.length <= MAX_PENDING_COLOR_SEQUENCE_CHARS) {
+          return;
+        }
+        pending = pending.slice(1);
+        continue;
+      }
+
+      if (shouldReply) {
+        const colors = getColors();
+        let slot = header.slot;
+        const payload = pending.slice(header.sequence.length, end.index);
+        for (const value of payload.split(";")) {
+          if (!value) {
+            continue;
+          }
+          const target = DYNAMIC_COLOR_SLOTS.find((entry) => entry.slot === slot);
+          if (value === "?" && target) {
+            const response = formatOscColor(slot, colors[target.color], end.terminator);
+            if (response) {
+              reply(response);
+            }
+          }
+          slot += 1;
+        }
+      }
+      pending = pending.slice(end.index + end.terminator.length);
+    }
+  };
+
+  return {
+    observe(data: string): void {
+      process(data, true);
+    },
+    primeFromReplay(data: string): void {
+      pending = "";
+      process(data, false);
+    },
+  };
+}

--- a/ui/src/components/terminal/terminal-connection.test.ts
+++ b/ui/src/components/terminal/terminal-connection.test.ts
@@ -185,7 +185,7 @@ describe("TerminalConnection", () => {
     const client = makeFakeClient();
     const conn = new TerminalConnection(client);
     const data: string[] = [];
-    const replays: string[] = [];
+    const replays: Array<{ snapshot: string; newlyObservedFrom: number }> = [];
     const recovery = deferred<{
       sessionId: string;
       agentId: string;
@@ -199,7 +199,7 @@ describe("TerminalConnection", () => {
       { cols: 80, rows: 24 },
       {
         onData: (chunk) => data.push(chunk),
-        onReplay: (snapshot) => replays.push(snapshot),
+        onReplay: (snapshot, newlyObservedFrom) => replays.push({ snapshot, newlyObservedFrom }),
         onExit: () => {},
       },
     );
@@ -228,11 +228,13 @@ describe("TerminalConnection", () => {
       shell: "/bin/zsh",
       cwd: "/work",
       confined: false,
-      buffer: "authoritative snapshot",
+      buffer: "hello??worldcovered",
       seq: 19,
     });
 
-    await vi.waitFor(() => expect(replays).toEqual(["authoritative snapshot"]));
+    await vi.waitFor(() =>
+      expect(replays).toEqual([{ snapshot: "hello??worldcovered", newlyObservedFrom: 5 }]),
+    );
     expect(data).toEqual(["hello"]);
     expect(client.requests.filter((request) => request.method === "terminal.attach")).toHaveLength(
       1,

--- a/ui/src/components/terminal/terminal-connection.ts
+++ b/ui/src/components/terminal/terminal-connection.ts
@@ -59,7 +59,7 @@ type TerminalExitInfo = {
 type SessionSink = {
   onData: (data: string) => void;
   /** Clears emulator state before replaying the authoritative ring snapshot. */
-  onReplay?: (data: string) => void;
+  onReplay?: (data: string, newlyObservedFrom: number) => void;
   onExit: (info: TerminalExitInfo) => void;
 };
 
@@ -259,7 +259,11 @@ export class TerminalConnection {
     this.streams.set(sessionId, stream);
     this.lastTerminalActivityAtMs = Date.now();
     if (replay !== undefined) {
-      (sink.onReplay ?? sink.onData)(replay);
+      if (sink.onReplay) {
+        sink.onReplay(replay, replay.length);
+      } else {
+        sink.onData(replay);
+      }
     }
     this.flushPending(sessionId, stream, coveredThroughSeq, replay !== undefined);
     this.scheduleLivenessCheck();
@@ -333,6 +337,7 @@ export class TerminalConnection {
           this.flushPending(sessionId, stream, undefined, true);
           return;
         }
+        const previouslyObservedThrough = stream.expectedSeq;
         stream.seqMode = "offset";
         stream.expectedSeq = offset;
         if (!stream.sink.onReplay) {
@@ -343,7 +348,15 @@ export class TerminalConnection {
           this.client.forceReconnect("terminal replay reset unavailable");
           return;
         }
-        stream.sink.onReplay(result.buffer);
+        // The ring may include both bytes already delivered and the gap's
+        // missing suffix. Preserve that boundary so response-producing
+        // emulators do not answer historical control queries twice.
+        const replayStart = offset - result.buffer.length;
+        const newlyObservedFrom =
+          typeof previouslyObservedThrough === "number"
+            ? Math.max(0, Math.min(result.buffer.length, previouslyObservedThrough - replayStart))
+            : 0;
+        stream.sink.onReplay(result.buffer, newlyObservedFrom);
         stream.recovering = false;
         this.flushPending(sessionId, stream, offset, true);
       })

--- a/ui/src/components/terminal/terminal-panel.test.ts
+++ b/ui/src/components/terminal/terminal-panel.test.ts
@@ -7,7 +7,10 @@ import type { TerminalGatewayClient } from "./terminal-connection.ts";
 
 type CreateOptions = {
   parent: HTMLElement;
-  terminalOptions?: { fontFamily?: string };
+  terminalOptions?: {
+    fontFamily?: string;
+    theme?: { background?: string; foreground?: string };
+  };
   onData?: (bytes: Uint8Array) => void;
   onResize?: (size: { columns: number; rows: number }) => void;
 };
@@ -241,6 +244,56 @@ describe("OpenClawTerminalPanel", () => {
       controller.terminal,
       0,
     );
+  });
+
+  it("answers live OSC default-color queries with the terminal theme", async () => {
+    const controller = createTerminalController();
+    createGhosttyTerminalMock.mockResolvedValue(controller);
+    const requests: Array<{ method: string; params: unknown }> = [];
+    let listener: ((event: { event: string; payload: unknown }) => void) | undefined;
+    const client: TerminalGatewayClient = {
+      forceReconnect: () => {},
+      request: async <T>(method: string, params?: unknown) => {
+        requests.push({ method, params });
+        return (method === "terminal.open" ? terminalOpenResult("session-1") : {}) as T;
+      },
+      addEventListener: (nextListener) => {
+        listener = nextListener;
+        return () => {};
+      },
+    };
+    const panel = document.createElement(TERMINAL_PANEL_ELEMENT_NAME) as OpenClawTerminalPanel;
+    panel.client = client;
+    panel.available = true;
+    document.body.append(panel);
+    panel.toggle();
+    await vi.waitFor(() => {
+      expect(requests.some(({ method }) => method === "terminal.resize")).toBe(true);
+    });
+
+    const query = "\u001b]10;?\u001b\\\u001b]11;?\u001b\\";
+    listener?.({
+      event: "terminal.data",
+      payload: { sessionId: "session-1", seq: query.length, data: query },
+    });
+
+    await vi.waitFor(() => {
+      expect(requests).toContainEqual({
+        method: "terminal.input",
+        params: {
+          sessionId: "session-1",
+          data: "\u001b]10;rgb:d7d7/dada/e0e0\u001b\\",
+        },
+      });
+      expect(requests).toContainEqual({
+        method: "terminal.input",
+        params: {
+          sessionId: "session-1",
+          data: "\u001b]11;rgb:0e0e/1010/1515\u001b\\",
+        },
+      });
+    });
+    expect(new TextDecoder().decode(controller.write.mock.calls[0]?.[0])).toBe(query);
   });
 
   it("flushes keystrokes entered while open is in flight after resize resync", async () => {

--- a/ui/src/components/terminal/terminal-panel.ts
+++ b/ui/src/components/terminal/terminal-panel.ts
@@ -15,6 +15,7 @@ import {
   TERMINAL_PANEL_TOGGLE_EVENT,
   type TerminalPanelToggleDetail,
 } from "../panel-toggle-contract.ts";
+import { createTerminalDefaultColorQueryResponder } from "./terminal-color-queries.ts";
 import {
   TerminalConnection,
   type TerminalGatewayClient,
@@ -41,13 +42,14 @@ import {
   type TerminalTabReadinessState,
 } from "./terminal-tab-readiness.ts";
 import { TerminalTaskQueue } from "./terminal-task-queue.ts";
-import { terminalTheme } from "./terminal-theme.ts";
+import { terminalDynamicColors, terminalTheme } from "./terminal-theme.ts";
 
 type TerminalDock = DockPanelSide;
 type TerminalTabState = TerminalPanelTab &
   TerminalTabReadinessState & {
     gatewaySessionId: string;
     pendingInput: StartupInputBuffer;
+    defaultColorQueries: ReturnType<typeof createTerminalDefaultColorQueryResponder>;
     controller: GhosttyTerminalController;
     shell: string;
     host: HTMLDivElement;
@@ -527,6 +529,10 @@ export class OpenClawTerminalPanel extends OpenClawLitElement {
       connection,
       () => tabRef.current?.gatewaySessionId,
     );
+    const defaultColorQueries = createTerminalDefaultColorQueryResponder(
+      () => terminalDynamicColors(this.themeMode),
+      (data) => startupInput.onData(TERMINAL_OUTPUT_ENCODER.encode(data)),
+    );
     let controller: GhosttyTerminalController;
     try {
       controller = await this.createTerminal({
@@ -561,6 +567,7 @@ export class OpenClawTerminalPanel extends OpenClawLitElement {
       sequence: this.tabSeq,
       gatewaySessionId: "",
       pendingInput: startupInput.buffer,
+      defaultColorQueries,
       shellName: null,
       shell: "",
       agentId: null,
@@ -585,6 +592,10 @@ export class OpenClawTerminalPanel extends OpenClawLitElement {
       // connection.open/attach from writing to an already-disposed terminal.
       onData: (data: string) => {
         if (!tab.cancelled) {
+          // ghostty-web 0.4.0's WASM handler ignores all OSC color operations,
+          // including setters. Report the configured renderer colors here so
+          // palette-aware TUIs receive the same defaults as native Ghostty.
+          tab.defaultColorQueries.observe(data);
           tab.controller.write(TERMINAL_OUTPUT_ENCODER.encode(data));
           if (data.length > 0) {
             this.readiness.markReady(tab);
@@ -593,8 +604,12 @@ export class OpenClawTerminalPanel extends OpenClawLitElement {
       },
       // A replay is authoritative. Reset parser, screen, and scrollback so a
       // gap cannot leave stale cells or a partial escape sequence behind.
-      onReplay: (data: string) => {
+      onReplay: (data: string, newlyObservedFrom: number) => {
         if (!tab.cancelled) {
+          // Suppress complete historical queries, then answer only the suffix
+          // recovered after a sequence gap. A split query may cross the seam.
+          tab.defaultColorQueries.primeFromReplay(data.slice(0, newlyObservedFrom));
+          tab.defaultColorQueries.observe(data.slice(newlyObservedFrom));
           tab.controller.terminal.reset();
           if (data) {
             tab.controller.write(TERMINAL_OUTPUT_ENCODER.encode(data));

--- a/ui/src/components/terminal/terminal-theme.ts
+++ b/ui/src/components/terminal/terminal-theme.ts
@@ -1,5 +1,6 @@
 // Maps the Control UI light/dark surfaces onto the terminal's 16-color theme.
 import type { CreateGhosttyTerminalOptions } from "@openclaw/libterminal/browser";
+import type { TerminalDynamicColors } from "./terminal-color-queries.ts";
 
 type TerminalTheme = NonNullable<
   NonNullable<CreateGhosttyTerminalOptions["terminalOptions"]>["theme"]
@@ -26,14 +27,22 @@ const ANSI = {
   brightWhite: "#ffffff",
 } as const;
 
+const DYNAMIC_COLORS = {
+  dark: { background: "#0e1015", cursor: "#ff5c5c", foreground: "#d7dae0" },
+  light: { background: "#f7f8fa", cursor: "#1b1e26", foreground: "#1b1e26" },
+} as const satisfies Record<"dark" | "light", TerminalDynamicColors>;
+
+export function terminalDynamicColors(mode: "dark" | "light"): TerminalDynamicColors {
+  return DYNAMIC_COLORS[mode];
+}
+
 /** Builds the terminal theme for the given Control UI color mode. */
 export function terminalTheme(mode: "dark" | "light"): TerminalTheme {
+  const colors = terminalDynamicColors(mode);
   if (mode === "light") {
     return {
       ...ANSI,
-      background: "#f7f8fa",
-      foreground: "#1b1e26",
-      cursor: "#1b1e26",
+      ...colors,
       cursorAccent: "#f7f8fa",
       selectionBackground: "rgba(90, 162, 255, 0.30)",
       black: "#3a3f4b",
@@ -42,9 +51,7 @@ export function terminalTheme(mode: "dark" | "light"): TerminalTheme {
   }
   return {
     ...ANSI,
-    background: "#0e1015",
-    foreground: "#d7dae0",
-    cursor: "#ff5c5c",
+    ...colors,
     cursorAccent: "#0e1015",
     selectionBackground: "rgba(90, 162, 255, 0.32)",
   };

--- a/ui/src/e2e/terminal-embedded.e2e.test.ts
+++ b/ui/src/e2e/terminal-embedded.e2e.test.ts
@@ -79,6 +79,23 @@ describeControlUiE2e("embedded terminal document", () => {
         cols: expect.any(Number),
         rows: expect.any(Number),
       });
+      const colorQueries = "\u001b]10;?\u001b\\\u001b]11;?\u001b\\";
+      await gateway.emitGatewayEvent("terminal.data", {
+        sessionId: "terminal-e2e",
+        seq: colorQueries.length,
+        data: colorQueries,
+      });
+      await expect.poll(async () => (await gateway.getRequests("terminal.input")).length).toBe(2);
+      expect((await gateway.getRequests("terminal.input")).map(({ params }) => params)).toEqual([
+        {
+          sessionId: "terminal-e2e",
+          data: "\u001b]10;rgb:1b1b/1e1e/2626\u001b\\",
+        },
+        {
+          sessionId: "terminal-e2e",
+          data: "\u001b]11;rgb:f7f7/f8f8/fafa\u001b\\",
+        },
+      ]);
       expect(await page.locator("openclaw-login-gate").count()).toBe(0);
       expect(await page.locator("openclaw-terminal-panel").count()).toBe(1);
       const closeControlMetrics = await page


### PR DESCRIPTION
Closes #108055

## What Problem This Solves

Fixes an issue where users running palette-aware TUIs such as OpenAI Codex in the embedded Control UI terminal would lose intended surfaces, including Codex's shaded composer bar, because default terminal colors could not be discovered.

## Why This Change Was Made

The embedded ghostty-web WASM build ignores OSC color operations. The terminal panel now answers OSC 10/11/12 queries from its active renderer theme with Ghostty-compatible replies, including multi-slot queries and BEL/ST terminators. Stream replay carries its observed-byte boundary so historical probes are not answered twice while queries recovered after an output gap still receive a reply.

## User Impact

Codex and other palette-aware TUIs now render their intended foreground/background surfaces in the embedded terminal, matching native Ghostty more closely.

## Evidence

- Controlled live comparison using Codex CLI 0.144.4 with `--no-alt-screen`: before, no OSC 10/11 replies and no shaded composer; after, two replies in about 3 ms and the expected full-width gray composer.
- Blacksmith Testbox `tbx_01kxj6d16bz4365cjd6mdws2vz`: UI production/test TypeScript, production build and asset budgets, 56 focused tests, and browser E2E all passed on `189d99578b343cb7accb80e2ebfb93779a6ea469` ([run 29393470544](https://github.com/openclaw/openclaw/actions/runs/29393470544)).
- Local focused unit tests: 56 passed. Browser E2E: 1 passed. `oxlint`, `oxfmt`, and `git diff --check`: clean.
- Source-blind behavior validation: satisfies contract, 0.98 confidence. Autoreview: clean, no accepted/actionable findings.

### Before

<img width="1440" height="900" alt="OpenClaw embedded terminal before OSC color-query replies" src="https://github.com/user-attachments/assets/7fc439cc-c94b-4c5c-b5e1-d217fd21faf3" />

### After

<img width="1440" height="900" alt="OpenClaw embedded terminal after OSC color-query replies" src="https://github.com/user-attachments/assets/2df74bca-e842-4aa0-b6f2-3ace271af38d" />
