### PR TITLE
fix: preserve TUI restore state without JSON races

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **TUI last-session persistence:** store restore pointers atomically in shared SQLite, exclude heartbeat sessions, and migrate verified legacy JSON only through `openclaw doctor --fix`.
 - **Mattermost progress command details:** accept the documented `streaming.preview.commandText` and `streaming.progress.commandText` modes in channel config validation and bundled metadata. Thanks @shakkernerd.
 - **1Password authorization handoff:** persist nonce-bound pending approvals in shared plugin state so hook and tool execution across broker instances remain single-use and fail closed.
 - **Control UI chat transcripts:** preserve loaded history across session and pane returns, bound automatic backscroll loading, virtualize long transcripts, retain hidden native run boundaries, and keep prepends, streaming, and responsive layouts from flickering or jumping. Thanks @shakkernerd.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **TUI last-session persistence:** store restore pointers atomically in shared SQLite, exclude heartbeat sessions, and migrate verified legacy JSON only through `openclaw doctor --fix`.
 - **Mattermost progress command details:** accept the documented `streaming.preview.commandText` and `streaming.progress.commandText` modes in channel config validation and bundled metadata. Thanks @shakkernerd.
 - **1Password authorization handoff:** persist nonce-bound pending approvals in shared plugin state so hook and tool execution across broker instances remain single-use and fail closed.
 - **Control UI chat transcripts:** preserve loaded history across session and pane returns, bound automatic backscroll loading, virtualize long transcripts, retain hidden native run boundaries, and keep prepends, streaming, and responsive layouts from flickering or jumping. Thanks @shakkernerd.

--- a/docs/refactor/database-first.md
+++ b/docs/refactor/database-first.md
@@ -412,7 +412,10 @@ The branch already has a real shared SQLite base:
   payload, but typed columns are authoritative for hot queue routing/state.
 - TUI last-session restore pointers now live in typed shared
   `tui_last_sessions` rows keyed by the hashed TUI connection/session scope.
-  The old TUI JSON file is doctor migration input only.
+  Runtime reads and writes only SQLite, atomically upserts each scope, and
+  excludes heartbeat sessions. `openclaw doctor --fix` strictly validates the
+  old TUI JSON file, keeps newer SQLite rows, verifies the canonical result,
+  and removes the unchanged legacy file instead of leaving an archive.
 - Default TTS prefs now live in shared plugin-state SQLite rows keyed under the
   `speech-core` plugin. The old `settings/tts.json` file is doctor migration
   input only; runtime no longer reads or writes TTS prefs JSON files, and the

--- a/scripts/check-database-first-legacy-stores.mjs
+++ b/scripts/check-database-first-legacy-stores.mjs
@@ -90,6 +90,7 @@ const legacyStorePatterns = [
   /\bcache\/[^"'`]*\.json\b/u,
   /\bagents\/[^"'`]+\/agent\/(?:auth|models)\.json\b/u,
   /\b(?:credentials\/oauth|github-copilot\.token|openrouter-models|auth-profiles|auth-state|exec-approvals|workspace-state)\.json\b/u,
+  /\btui\/last-session\.json\b/u,
   /\bcron\/(?:runs\/[^"'`]+\.jsonl|jobs\.json|jobs-state\.json)\b/u,
   /\b(?:process-leases|session-toggles|known-users|msteams-conversations|msteams-polls|msteams-sso-tokens|bot-storage|sync-store|thread-bindings|inbound-dedupe|startup-verification|storage-meta|crypto-idb-snapshot|command-deploy-cache|plugin-binding-approvals|plugins\/installs|config-health|port-guard|restart-sentinel|gateway-restart-intent|gateway-supervisor-restart-handoff)\.json\b/u,
   /\b(?:calls|ref-index|audit\/file-transfer|audit\/openclaw)\.jsonl\b/u,
@@ -103,6 +104,7 @@ const allowedRuntimeMigrationPaths = [
   "src/commands/doctor/",
   "src/infra/session-state-migration.ts",
   "src/infra/state-migrations.ts",
+  "src/infra/state-migrations.tui-last-session.ts",
   "src/commands/session-state-migration.ts",
   "src/commands/doctor-state-migrations.test.ts",
 ];

--- a/scripts/deadcode-exports.baseline.mjs
+++ b/scripts/deadcode-exports.baseline.mjs
@@ -170,7 +170,6 @@ export const KNIP_UNUSED_EXPORT_BASELINE = [
   "src/commands/backup-shared.ts: resolveBackupPlanFromPaths",
   "src/commands/doctor-auth-oauth-sidecar.ts: testing",
   "src/commands/doctor-auth.ts: legacyCodexProviderOverrideToHealthFinding",
-  "src/commands/doctor-heartbeat-main-session-repair.ts: clearTuiLastSessionPointers",
   "src/commands/doctor-heartbeat-main-session-repair.ts: moveHeartbeatMainSessionEntry",
   "src/commands/doctor-heartbeat-main-session-repair.ts: resolveHeartbeatMainSessionRepairCandidate",
   "src/commands/doctor-sandbox.ts: resolveSandboxScript",

--- a/src/commands/doctor-heartbeat-main-session-repair.ts
+++ b/src/commands/doctor-heartbeat-main-session-repair.ts
@@ -1,6 +1,5 @@
 /** Doctor repair for main sessions accidentally occupied by synthetic heartbeat transcripts. */
 import fs from "node:fs";
-import path from "node:path";
 import { asNullableObjectRecord } from "@openclaw/normalization-core/record-coerce";
 import type { note } from "../../packages/terminal-core/src/note.js";
 import { isHeartbeatOkResponse, isHeartbeatUserMessage } from "../auto-reply/heartbeat-filter.js";
@@ -14,6 +13,7 @@ import { updateSessionStore } from "../config/sessions/store.js";
 import type { SessionEntry } from "../config/sessions/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { parseAgentSessionKey } from "../sessions/session-key-utils.js";
+import { clearTuiLastSessionPointers } from "../tui/tui-last-session.js";
 
 type DoctorPrompterLike = {
   confirmRuntimeRepair: (params: {
@@ -40,14 +40,6 @@ type HeartbeatMainSessionRepairCandidate = {
 
 function countLabel(count: number, singular: string, plural = `${singular}s`): string {
   return `${count} ${count === 1 ? singular : plural}`;
-}
-
-function existsFile(filePath: string): boolean {
-  try {
-    return fs.existsSync(filePath) && fs.statSync(filePath).isFile();
-  } catch {
-    return false;
-  }
 }
 
 function sessionEntryHasSyntheticHeartbeatOwnership(entry: SessionEntry): boolean {
@@ -199,50 +191,6 @@ export function moveHeartbeatMainSessionEntry(params: {
   return true;
 }
 
-function resolveTuiLastSessionPath(stateDir: string): string {
-  return path.join(stateDir, "tui", "last-session.json");
-}
-
-/** Removes TUI restore pointers that would reopen an archived heartbeat-owned main session. */
-export function clearTuiLastSessionPointers(params: {
-  filePath: string;
-  sessionKeys: ReadonlySet<string>;
-}): number {
-  if (params.sessionKeys.size === 0 || !existsFile(params.filePath)) {
-    return 0;
-  }
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(fs.readFileSync(params.filePath, "utf8"));
-  } catch {
-    return 0;
-  }
-  const store = asNullableObjectRecord(parsed);
-  if (!store) {
-    return 0;
-  }
-  let removed = 0;
-  const next: Record<string, unknown> = {};
-  for (const [key, value] of Object.entries(store)) {
-    const record = asNullableObjectRecord(value);
-    const sessionKey = record?.sessionKey;
-    if (typeof sessionKey === "string" && params.sessionKeys.has(sessionKey)) {
-      removed += 1;
-      continue;
-    }
-    next[key] = value;
-  }
-  if (removed === 0) {
-    return 0;
-  }
-  try {
-    fs.writeFileSync(params.filePath, `${JSON.stringify(next, null, 2)}\n`, { mode: 0o600 });
-  } catch {
-    return 0;
-  }
-  return removed;
-}
-
 /**
  * Prompts to archive a heartbeat-owned main session and clears stale TUI restore state.
  *
@@ -324,10 +272,17 @@ export async function repairHeartbeatPoisonedMainSession(params: {
   }
   params.store[recoveredKey] = movedEntry;
   delete params.store[mainKey];
-  const clearedPointers = clearTuiLastSessionPointers({
-    filePath: resolveTuiLastSessionPath(params.stateDir),
-    sessionKeys: new Set([mainKey]),
-  });
+  let clearedPointers = 0;
+  try {
+    clearedPointers = clearTuiLastSessionPointers({
+      stateDir: params.stateDir,
+      sessionKeys: new Set([mainKey]),
+    });
+  } catch (error) {
+    params.warnings.push(
+      `- Moved heartbeat-owned main session ${mainKey}, but could not clear its TUI restore pointers: ${String(error)}`,
+    );
+  }
   params.changes.push(`- Moved heartbeat-owned main session ${mainKey} to ${recoveredKey}.`);
   if (clearedPointers > 0) {
     params.changes.push(

--- a/src/commands/doctor-state-integrity.test.ts
+++ b/src/commands/doctor-state-integrity.test.ts
@@ -10,9 +10,14 @@ import {
   resolveSessionTranscriptsDirForAgent,
 } from "../config/sessions/paths.js";
 import type { SessionEntry } from "../config/sessions/types.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { captureEnv, deleteTestEnvValue, setTestEnvValue } from "../test-utils/env.js";
 import {
   clearTuiLastSessionPointers,
+  readTuiLastSessionKey,
+  writeTuiLastSessionKey,
+} from "../tui/tui-last-session.js";
+import {
   moveHeartbeatMainSessionEntry,
   resolveHeartbeatMainSessionRepairCandidate,
 } from "./doctor-heartbeat-main-session-repair.js";
@@ -121,6 +126,7 @@ describe("structured state integrity findings", () => {
   });
 
   afterEach(() => {
+    closeOpenClawStateDatabaseForTest();
     envSnapshot.restore();
     fs.rmSync(tempHome, { recursive: true, force: true });
   });
@@ -266,6 +272,7 @@ describe("doctor state integrity oauth dir checks", () => {
   });
 
   afterEach(() => {
+    closeOpenClawStateDatabaseForTest();
     envSnapshot.restore();
     fs.rmSync(tempHome, { recursive: true, force: true });
   });
@@ -664,23 +671,17 @@ describe("doctor state integrity oauth dir checks", () => {
         updatedAt: Date.now(),
       },
     });
-    const tuiLastSessionPath = path.join(
-      process.env.OPENCLAW_STATE_DIR ?? "",
-      "tui",
-      "last-session.json",
-    );
-    fs.mkdirSync(path.dirname(tuiLastSessionPath), { recursive: true });
-    fs.writeFileSync(
-      tuiLastSessionPath,
-      JSON.stringify(
-        {
-          default: { sessionKey: "agent:main:main", updatedAt: Date.now() },
-          telegram: { sessionKey: "agent:main:telegram:thread", updatedAt: Date.now() },
-        },
-        null,
-        2,
-      ),
-    );
+    const stateDir = process.env.OPENCLAW_STATE_DIR ?? "";
+    await writeTuiLastSessionKey({
+      scopeKey: "default",
+      sessionKey: "agent:main:main",
+      stateDir,
+    });
+    await writeTuiLastSessionKey({
+      scopeKey: "telegram",
+      sessionKey: "agent:main:telegram:thread",
+      stateDir,
+    });
 
     const confirmRuntimeRepair = vi.fn(async (params: { message: string }) =>
       params.message.startsWith("Move heartbeat-owned main session"),
@@ -698,12 +699,10 @@ describe("doctor state integrity oauth dir checks", () => {
     }
     expect(store[recoveredKey]?.sessionId).toBe("heartbeat-session");
 
-    const tuiStore = JSON.parse(fs.readFileSync(tuiLastSessionPath, "utf8")) as Record<
-      string,
-      { sessionKey?: string }
-    >;
-    expect(tuiStore.default).toBeUndefined();
-    expect(tuiStore.telegram?.sessionKey).toBe("agent:main:telegram:thread");
+    await expect(readTuiLastSessionKey({ scopeKey: "default", stateDir })).resolves.toBeNull();
+    await expect(readTuiLastSessionKey({ scopeKey: "telegram", stateDir })).resolves.toBe(
+      "agent:main:telegram:thread",
+    );
     expect(doctorChangesText()).toContain("Moved heartbeat-owned main session agent:main:main");
     expect(doctorChangesText()).toContain("Cleared 1 stale TUI last-session pointer");
   });
@@ -862,7 +861,7 @@ describe("doctor state integrity oauth dir checks", () => {
     }
   });
 
-  it("moves store entries and clears matching TUI pointers without touching others", () => {
+  it("moves store entries and clears matching TUI pointers without touching others", async () => {
     const store: Record<string, SessionEntry> = {
       "agent:main:main": { sessionId: "main-session", updatedAt: 1 },
     };
@@ -880,27 +879,30 @@ describe("doctor state integrity oauth dir checks", () => {
 
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-tui-pointer-clear-"));
     try {
-      const filePath = path.join(tempDir, "last-session.json");
-      fs.writeFileSync(
-        filePath,
-        JSON.stringify({
-          terminal: { sessionKey: "agent:main:main" },
-          telegram: { sessionKey: "agent:main:telegram:thread" },
-        }),
-      );
+      await writeTuiLastSessionKey({
+        scopeKey: "terminal",
+        sessionKey: "agent:main:main",
+        stateDir: tempDir,
+      });
+      await writeTuiLastSessionKey({
+        scopeKey: "telegram",
+        sessionKey: "agent:main:telegram:thread",
+        stateDir: tempDir,
+      });
       expect(
         clearTuiLastSessionPointers({
-          filePath,
+          stateDir: tempDir,
           sessionKeys: new Set(["agent:main:main"]),
         }),
       ).toBe(1);
-      const parsed = JSON.parse(fs.readFileSync(filePath, "utf8")) as Record<
-        string,
-        { sessionKey?: string }
-      >;
-      expect(parsed.terminal).toBeUndefined();
-      expect(parsed.telegram?.sessionKey).toBe("agent:main:telegram:thread");
+      await expect(
+        readTuiLastSessionKey({ scopeKey: "terminal", stateDir: tempDir }),
+      ).resolves.toBeNull();
+      await expect(
+        readTuiLastSessionKey({ scopeKey: "telegram", stateDir: tempDir }),
+      ).resolves.toBe("agent:main:telegram:thread");
     } finally {
+      closeOpenClawStateDatabaseForTest();
       fs.rmSync(tempDir, { recursive: true, force: true });
     }
   });

--- a/src/commands/doctor.e2e-harness.ts
+++ b/src/commands/doctor.e2e-harness.ts
@@ -276,6 +276,10 @@ function createLegacyStateMigrationDetectionResult(params?: {
       sourcePath: "/tmp/state/bindings/current-conversations.json",
       hasLegacy: false,
     },
+    tuiLastSessions: {
+      sourcePath: "/tmp/state/tui/last-session.json",
+      hasLegacy: false,
+    },
     channelPairing: {
       sourceDir: "/tmp/oauth",
       files: [],

--- a/src/flows/doctor-core-checks.ts
+++ b/src/flows/doctor-core-checks.ts
@@ -439,7 +439,10 @@ const legacyStateCheck: HealthCheck & { readonly defaultEnabled: false } = {
   defaultEnabled: false,
   async detect(ctx) {
     const { detectLegacyStateMigrations } = await import("../commands/doctor-state-migrations.js");
-    const detected = await detectLegacyStateMigrations({ cfg: ctx.cfg });
+    const detected = await detectLegacyStateMigrations({
+      cfg: ctx.cfg,
+      doctorOnlyStateMigrations: true,
+    });
     return [
       ...detected.preview.map(
         (line): HealthFinding => ({

--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -1447,6 +1447,7 @@ describe("doctor health contributions", () => {
 
     expect(mocks.detectLegacyStateMigrations).toHaveBeenCalledWith({
       cfg,
+      doctorOnlyStateMigrations: true,
       crossStateDirImports: false,
     });
     expect(mocks.runLegacyStateMigrations).toHaveBeenCalledWith({
@@ -1471,6 +1472,7 @@ describe("doctor health contributions", () => {
     await contribution.run(directRepairContext);
     expect(mocks.detectLegacyStateMigrations).toHaveBeenLastCalledWith({
       cfg: {},
+      doctorOnlyStateMigrations: true,
       crossStateDirImports: true,
     });
 
@@ -1484,6 +1486,7 @@ describe("doctor health contributions", () => {
     });
     expect(mocks.detectLegacyStateMigrations).toHaveBeenLastCalledWith({
       cfg: {},
+      doctorOnlyStateMigrations: true,
       crossStateDirImports: true,
     });
 
@@ -1494,6 +1497,7 @@ describe("doctor health contributions", () => {
     await contribution.run(automatedRepairContext);
     expect(mocks.detectLegacyStateMigrations).toHaveBeenLastCalledWith({
       cfg: {},
+      doctorOnlyStateMigrations: true,
       crossStateDirImports: false,
     });
   });

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -523,6 +523,7 @@ async function runLegacyStateHealth(ctx: DoctorHealthFlowContext): Promise<void>
     ctx.prompter.repairMode.canPrompt || ctx.prompter.shouldRepair;
   const legacyState = await detectLegacyStateMigrations({
     cfg: ctx.cfg,
+    doctorOnlyStateMigrations: true,
     crossStateDirImports:
       ctx.options.crossStateDirImports === true && operatorCanApproveCrossStateDirImports,
   });

--- a/src/infra/state-migrations.doctor.ts
+++ b/src/infra/state-migrations.doctor.ts
@@ -93,6 +93,10 @@ import {
   resolveLegacyPluginStateSidecarPath,
   resolveLegacyTaskRunsSidecarPath,
 } from "./state-migrations.storage.js";
+import {
+  detectLegacyTuiLastSessions,
+  migrateLegacyTuiLastSessions,
+} from "./state-migrations.tui-last-session.js";
 import type {
   DetectedPluginDoctorStateMigrationPlan,
   LegacyStateDetection,
@@ -202,6 +206,7 @@ export async function detectLegacyStateMigrations(params: {
   pluginSessionStoreAgentIds?: readonly string[];
   sessionStoreOwnership?: SessionStoreOwnership;
   crossStateDirImports?: boolean;
+  doctorOnlyStateMigrations?: boolean;
 }): Promise<LegacyStateDetection> {
   const env = params.env ?? process.env;
   const homedir = params.homedir ?? os.homedir;
@@ -368,6 +373,10 @@ export async function detectLegacyStateMigrations(params: {
     sourcePath: resolveLegacyCurrentConversationBindingsPath(stateDir),
   };
   const hasCurrentConversationBindings = fileExists(currentConversationBindings.sourcePath);
+  const tuiLastSessions = detectLegacyTuiLastSessions({
+    stateDir,
+    doctorOnlyStateMigrations: params.doctorOnlyStateMigrations,
+  });
   const configuredChannels = Object.entries(params.cfg.channels ?? {});
   const configuredAccountIds = Object.fromEntries(
     configuredChannels.map(([channelId, value]) => {
@@ -513,6 +522,9 @@ export async function detectLegacyStateMigrations(params: {
   if (hasCurrentConversationBindings) {
     preview.push("- Current-conversation bindings: legacy JSON file → shared SQLite state");
   }
+  if (tuiLastSessions.hasLegacy) {
+    preview.push("- TUI last-session pointers: legacy JSON file → shared SQLite state");
+  }
   if (channelPairing.hasLegacy) {
     preview.push("- Channel pairing state: legacy JSON files → shared SQLite state");
   }
@@ -598,6 +610,7 @@ export async function detectLegacyStateMigrations(params: {
       ...currentConversationBindings,
       hasLegacy: hasCurrentConversationBindings,
     },
+    tuiLastSessions,
     channelPairing,
     execApprovals,
     warnings: pluginPlanWarnings,
@@ -776,6 +789,10 @@ export async function runLegacyStateMigrations(params: {
     detected: detected.currentConversationBindings,
     stateDir: detected.stateDir,
   });
+  const tuiLastSessions = migrateLegacyTuiLastSessions({
+    detected: detected.tuiLastSessions,
+    stateDir: detected.stateDir,
+  });
   const channelPairing = migrateLegacyChannelPairingState({
     detected: detected.channelPairing,
     env: { ...env, OPENCLAW_STATE_DIR: detected.stateDir },
@@ -803,7 +820,7 @@ export async function runLegacyStateMigrations(params: {
   const channelPlans = await runLegacyMigrationPlans(
     detected.channelPlans.plans.filter((plan) => plan.kind !== "plugin-state-import"),
   );
-  const notices = mergeNotices([pluginInstallIndex, updateCheck, pluginPlans]);
+  const notices = mergeNotices([pluginInstallIndex, updateCheck, tuiLastSessions, pluginPlans]);
   return {
     changes: [
       ...stateSchema.changes,
@@ -817,6 +834,7 @@ export async function runLegacyStateMigrations(params: {
       ...configHealth.changes,
       ...pluginBindingApprovals.changes,
       ...currentConversationBindings.changes,
+      ...tuiLastSessions.changes,
       ...channelPairing.changes,
       ...execApprovals.changes,
       ...preSessionChannelPlans.changes,
@@ -839,6 +857,7 @@ export async function runLegacyStateMigrations(params: {
       ...configHealth.warnings,
       ...pluginBindingApprovals.warnings,
       ...currentConversationBindings.warnings,
+      ...tuiLastSessions.warnings,
       ...channelPairing.warnings,
       ...execApprovals.warnings,
       ...preSessionChannelPlans.warnings,

--- a/src/infra/state-migrations.tui-last-session.test.ts
+++ b/src/infra/state-migrations.tui-last-session.test.ts
@@ -1,0 +1,261 @@
+// Doctor TUI last-session migration tests cover strict import and source cleanup.
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
+import {
+  closeOpenClawStateDatabaseForTest,
+  runOpenClawStateWriteTransaction,
+} from "../state/openclaw-state-db.js";
+import { readTuiLastSessionKey } from "../tui/tui-last-session.js";
+import { executeSqliteQuerySync, getNodeSqliteKysely } from "./kysely-sync.js";
+import {
+  detectLegacyTuiLastSessions,
+  migrateLegacyTuiLastSessions,
+  resolveLegacyTuiLastSessionPath,
+} from "./state-migrations.tui-last-session.js";
+
+type TuiLastSessionTestDatabase = Pick<OpenClawStateKyselyDatabase, "tui_last_sessions">;
+
+const tempDirs: string[] = [];
+
+function makeStateDir(): string {
+  const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-tui-migration-"));
+  tempDirs.push(stateDir);
+  return stateDir;
+}
+
+function writeLegacyStore(stateDir: string, value: unknown): string {
+  const sourcePath = resolveLegacyTuiLastSessionPath(stateDir);
+  fs.mkdirSync(path.dirname(sourcePath), { recursive: true });
+  fs.writeFileSync(sourcePath, `${JSON.stringify(value, null, 2)}\n`, { mode: 0o600 });
+  return sourcePath;
+}
+
+function migrate(
+  stateDir: string,
+  overrides?: {
+    beforeClaim?: () => void;
+    beforeVerify?: () => void;
+    removeSource?: () => void;
+  },
+) {
+  const sourcePath = resolveLegacyTuiLastSessionPath(stateDir);
+  return migrateLegacyTuiLastSessions({
+    detected: { sourcePath, hasLegacy: true },
+    stateDir,
+    ...(overrides?.beforeClaim ? { beforeClaim: overrides.beforeClaim } : {}),
+    ...(overrides?.beforeVerify ? { beforeVerify: overrides.beforeVerify } : {}),
+    ...(overrides?.removeSource ? { removeSource: () => overrides.removeSource?.() } : {}),
+  });
+}
+
+function seedPointer(params: {
+  stateDir: string;
+  scopeKey: string;
+  sessionKey: string;
+  updatedAt: number;
+}): void {
+  runOpenClawStateWriteTransaction(
+    ({ db }) => {
+      executeSqliteQuerySync(
+        db,
+        getNodeSqliteKysely<TuiLastSessionTestDatabase>(db).insertInto("tui_last_sessions").values({
+          scope_key: params.scopeKey,
+          session_key: params.sessionKey,
+          updated_at: params.updatedAt,
+        }),
+      );
+    },
+    { env: { ...process.env, OPENCLAW_STATE_DIR: params.stateDir } },
+  );
+}
+
+afterEach(() => {
+  closeOpenClawStateDatabaseForTest();
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("legacy TUI last-session migration", () => {
+  it("runs only through explicit doctor detection and discards heartbeat pointers", async () => {
+    const stateDir = makeStateDir();
+    const sourcePath = writeLegacyStore(stateDir, {
+      terminal: { sessionKey: "agent:main:tui-123", updatedAt: 100 },
+      heartbeat: { sessionKey: "agent:main:telegram:direct:123:heartbeat", updatedAt: 200 },
+    });
+    const runtimeDetection = detectLegacyTuiLastSessions({ stateDir });
+    expect(runtimeDetection.hasLegacy).toBe(false);
+    await expect(readTuiLastSessionKey({ scopeKey: "terminal", stateDir })).resolves.toBeNull();
+    expect(fs.existsSync(sourcePath)).toBe(true);
+
+    const doctorDetection = detectLegacyTuiLastSessions({
+      stateDir,
+      doctorOnlyStateMigrations: true,
+    });
+    expect(doctorDetection.hasLegacy).toBe(true);
+    const result = migrateLegacyTuiLastSessions({
+      detected: doctorDetection,
+      stateDir,
+    });
+
+    expect(result.warnings).toEqual([]);
+    expect(result.changes).toContain(
+      "Migrated 1 TUI last-session pointer(s) → shared SQLite state",
+    );
+    expect(result.changes).toContain("Discarded 1 legacy heartbeat TUI restore pointer(s)");
+    expect(fs.existsSync(sourcePath)).toBe(false);
+    await expect(readTuiLastSessionKey({ scopeKey: "terminal", stateDir })).resolves.toBe(
+      "agent:main:tui-123",
+    );
+    await expect(readTuiLastSessionKey({ scopeKey: "heartbeat", stateDir })).resolves.toBeNull();
+    expect(fs.readdirSync(path.dirname(sourcePath))).not.toContain("last-session.json.migrated");
+  });
+
+  it.each([
+    ["non-object top level", []],
+    ["non-object record", { terminal: "agent:main:tui-123" }],
+    ["missing timestamp", { terminal: { sessionKey: "agent:main:tui-123" } }],
+    [
+      "unknown field",
+      { terminal: { sessionKey: "agent:main:tui-123", updatedAt: 100, extra: true } },
+    ],
+  ])("retains malformed source: %s", async (_label, value) => {
+    const stateDir = makeStateDir();
+    const sourcePath = writeLegacyStore(stateDir, value);
+
+    const result = migrate(stateDir);
+
+    expect(result.changes).toEqual([]);
+    expect(result.warnings.join("\n")).toContain("Failed reading legacy TUI last-session state");
+    expect(fs.existsSync(sourcePath)).toBe(true);
+    await expect(readTuiLastSessionKey({ scopeKey: "terminal", stateDir })).resolves.toBeNull();
+  });
+
+  it("keeps a newer SQLite pointer and removes its superseded source", async () => {
+    const stateDir = makeStateDir();
+    const sourcePath = writeLegacyStore(stateDir, {
+      terminal: { sessionKey: "agent:main:legacy", updatedAt: 100 },
+    });
+    seedPointer({
+      stateDir,
+      scopeKey: "terminal",
+      sessionKey: "agent:main:current",
+      updatedAt: 200,
+    });
+
+    const result = migrate(stateDir);
+
+    expect(result.warnings).toEqual([]);
+    expect(result.notices).toEqual([
+      "Kept 1 newer shared SQLite TUI last-session pointer(s) over legacy JSON",
+    ]);
+    expect(fs.existsSync(sourcePath)).toBe(false);
+    await expect(readTuiLastSessionKey({ scopeKey: "terminal", stateDir })).resolves.toBe(
+      "agent:main:current",
+    );
+  });
+
+  it("fails closed on equal-timestamp divergence", async () => {
+    const stateDir = makeStateDir();
+    const sourcePath = writeLegacyStore(stateDir, {
+      terminal: { sessionKey: "agent:main:legacy", updatedAt: 100 },
+    });
+    seedPointer({
+      stateDir,
+      scopeKey: "terminal",
+      sessionKey: "agent:main:current",
+      updatedAt: 100,
+    });
+
+    const result = migrate(stateDir);
+
+    expect(result.changes).toEqual([]);
+    expect(result.warnings.join("\n")).toContain(
+      "divergent JSON and SQLite pointers at the same timestamp",
+    );
+    expect(fs.existsSync(sourcePath)).toBe(true);
+    await expect(readTuiLastSessionKey({ scopeKey: "terminal", stateDir })).resolves.toBe(
+      "agent:main:current",
+    );
+  });
+
+  it("retains a source that changes before verification", async () => {
+    const stateDir = makeStateDir();
+    const sourcePath = writeLegacyStore(stateDir, {
+      terminal: { sessionKey: "agent:main:first", updatedAt: 100 },
+    });
+
+    const result = migrate(stateDir, {
+      beforeVerify: () => {
+        fs.writeFileSync(
+          sourcePath,
+          `${JSON.stringify({ terminal: { sessionKey: "agent:main:second", updatedAt: 200 } })}\n`,
+        );
+      },
+    });
+
+    expect(result.changes).toEqual([]);
+    expect(result.warnings.join("\n")).toContain("source changed after doctor loaded it");
+    expect(fs.existsSync(sourcePath)).toBe(true);
+    await expect(readTuiLastSessionKey({ scopeKey: "terminal", stateDir })).resolves.toBe(
+      "agent:main:first",
+    );
+  });
+
+  it("does not delete a replacement written after verification", async () => {
+    const stateDir = makeStateDir();
+    const sourcePath = writeLegacyStore(stateDir, {
+      terminal: { sessionKey: "agent:main:first", updatedAt: 100 },
+    });
+    const replacement = `${sourcePath}.replacement`;
+
+    const first = migrate(stateDir, {
+      beforeClaim: () => {
+        fs.writeFileSync(
+          replacement,
+          `${JSON.stringify({ terminal: { sessionKey: "agent:main:second", updatedAt: 200 } })}\n`,
+        );
+        fs.renameSync(replacement, sourcePath);
+      },
+    });
+
+    expect(first.changes).toEqual([]);
+    expect(first.warnings.join("\n")).toContain("source changed before doctor could claim it");
+    expect(fs.existsSync(sourcePath)).toBe(true);
+    await expect(readTuiLastSessionKey({ scopeKey: "terminal", stateDir })).resolves.toBe(
+      "agent:main:first",
+    );
+
+    const retry = migrate(stateDir);
+    expect(retry.warnings).toEqual([]);
+    expect(fs.existsSync(sourcePath)).toBe(false);
+    await expect(readTuiLastSessionKey({ scopeKey: "terminal", stateDir })).resolves.toBe(
+      "agent:main:second",
+    );
+  });
+
+  it("retries source cleanup without overwriting the verified row", async () => {
+    const stateDir = makeStateDir();
+    const sourcePath = writeLegacyStore(stateDir, {
+      terminal: { sessionKey: "agent:main:tui-123", updatedAt: 100 },
+    });
+
+    const first = migrate(stateDir, {
+      removeSource: () => {
+        throw new Error("simulated unlink failure");
+      },
+    });
+    expect(first.warnings.join("\n")).toContain("simulated unlink failure");
+    expect(fs.existsSync(sourcePath)).toBe(true);
+
+    const retry = migrate(stateDir);
+    expect(retry.warnings).toEqual([]);
+    expect(fs.existsSync(sourcePath)).toBe(false);
+    await expect(readTuiLastSessionKey({ scopeKey: "terminal", stateDir })).resolves.toBe(
+      "agent:main:tui-123",
+    );
+  });
+});

--- a/src/infra/state-migrations.tui-last-session.test.ts
+++ b/src/infra/state-migrations.tui-last-session.test.ts
@@ -13,7 +13,6 @@ import { executeSqliteQuerySync, getNodeSqliteKysely } from "./kysely-sync.js";
 import {
   detectLegacyTuiLastSessions,
   migrateLegacyTuiLastSessions,
-  resolveLegacyTuiLastSessionPath,
 } from "./state-migrations.tui-last-session.js";
 
 type TuiLastSessionTestDatabase = Pick<OpenClawStateKyselyDatabase, "tui_last_sessions">;
@@ -26,8 +25,12 @@ function makeStateDir(): string {
   return stateDir;
 }
 
+function legacyTuiLastSessionPath(stateDir: string): string {
+  return path.join(stateDir, "tui", "last-session.json");
+}
+
 function writeLegacyStore(stateDir: string, value: unknown): string {
-  const sourcePath = resolveLegacyTuiLastSessionPath(stateDir);
+  const sourcePath = legacyTuiLastSessionPath(stateDir);
   fs.mkdirSync(path.dirname(sourcePath), { recursive: true });
   fs.writeFileSync(sourcePath, `${JSON.stringify(value, null, 2)}\n`, { mode: 0o600 });
   return sourcePath;
@@ -41,7 +44,7 @@ function migrate(
     removeSource?: () => void;
   },
 ) {
-  const sourcePath = resolveLegacyTuiLastSessionPath(stateDir);
+  const sourcePath = legacyTuiLastSessionPath(stateDir);
   return migrateLegacyTuiLastSessions({
     detected: { sourcePath, hasLegacy: true },
     stateDir,

--- a/src/infra/state-migrations.tui-last-session.ts
+++ b/src/infra/state-migrations.tui-last-session.ts
@@ -1,0 +1,334 @@
+// Doctor-only import for the retired TUI last-session JSON store.
+import { createHash, randomUUID } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
+import {
+  openOpenClawStateDatabase,
+  runOpenClawStateWriteTransaction,
+} from "../state/openclaw-state-db.js";
+import {
+  executeSqliteQuerySync,
+  executeSqliteQueryTakeFirstSync,
+  getNodeSqliteKysely,
+} from "./kysely-sync.js";
+import type { LegacyStateDetection, MigrationMessages } from "./state-migrations.types.js";
+
+type TuiLastSessionMigrationDatabase = Pick<OpenClawStateKyselyDatabase, "tui_last_sessions">;
+
+type LegacyTuiLastSession = {
+  scopeKey: string;
+  sessionKey: string;
+  updatedAt: number;
+};
+
+type LegacySourceSnapshot = {
+  dev: number;
+  ino: number;
+  mtimeMs: number;
+  raw: string;
+  sha256: string;
+  size: number;
+};
+
+const LEGACY_RECORD_KEYS = new Set(["sessionKey", "updatedAt"]);
+
+export function resolveLegacyTuiLastSessionPath(stateDir: string): string {
+  return path.join(stateDir, "tui", "last-session.json");
+}
+
+/** Detect retired TUI state only when an explicit doctor flow opts in. */
+export function detectLegacyTuiLastSessions(params: {
+  stateDir: string;
+  doctorOnlyStateMigrations?: boolean;
+}): LegacyStateDetection["tuiLastSessions"] {
+  const sourcePath = resolveLegacyTuiLastSessionPath(params.stateDir);
+  return {
+    sourcePath,
+    hasLegacy: params.doctorOnlyStateMigrations === true && fs.existsSync(sourcePath),
+  };
+}
+
+function readLegacySourceSnapshot(sourcePath: string): LegacySourceSnapshot {
+  const before = fs.statSync(sourcePath);
+  if (!before.isFile()) {
+    throw new Error("legacy TUI last-session source is not a regular file");
+  }
+  const raw = fs.readFileSync(sourcePath, "utf8");
+  const after = fs.statSync(sourcePath);
+  if (
+    before.dev !== after.dev ||
+    before.ino !== after.ino ||
+    before.size !== after.size ||
+    before.mtimeMs !== after.mtimeMs
+  ) {
+    throw new Error("legacy TUI last-session source changed while doctor was reading it");
+  }
+  return {
+    dev: after.dev,
+    ino: after.ino,
+    mtimeMs: after.mtimeMs,
+    raw,
+    sha256: createHash("sha256").update(raw).digest("hex"),
+    size: after.size,
+  };
+}
+
+function assertLegacySourceUnchanged(sourcePath: string, expected: LegacySourceSnapshot): void {
+  const current = readLegacySourceSnapshot(sourcePath);
+  if (!legacySourceSnapshotsMatch(current, expected)) {
+    throw new Error("legacy TUI last-session source changed after doctor loaded it");
+  }
+}
+
+function legacySourceSnapshotsMatch(
+  current: LegacySourceSnapshot,
+  expected: LegacySourceSnapshot,
+): boolean {
+  return (
+    current.dev === expected.dev &&
+    current.ino === expected.ino &&
+    current.size === expected.size &&
+    current.mtimeMs === expected.mtimeMs &&
+    current.sha256 === expected.sha256
+  );
+}
+
+function restoreClaimAfterCleanupFailure(params: {
+  claimPath: string;
+  sourcePath: string;
+}): string | null {
+  if (!fs.existsSync(params.claimPath) || fs.existsSync(params.sourcePath)) {
+    return null;
+  }
+  try {
+    fs.renameSync(params.claimPath, params.sourcePath);
+    return null;
+  } catch (error) {
+    return `; the claimed source remains at ${params.claimPath} because restore also failed: ${String(error)}`;
+  }
+}
+
+function claimAndRemoveVerifiedLegacySource(params: {
+  sourcePath: string;
+  snapshot: LegacySourceSnapshot;
+  beforeClaim?: () => void;
+  removeSource?: (sourcePath: string) => void;
+}): void {
+  params.beforeClaim?.();
+  const claimPath = `${params.sourcePath}.doctor-importing-${process.pid}-${randomUUID()}`;
+  fs.renameSync(params.sourcePath, claimPath);
+  try {
+    const claimedSnapshot = readLegacySourceSnapshot(claimPath);
+    if (!legacySourceSnapshotsMatch(claimedSnapshot, params.snapshot)) {
+      throw new Error("legacy TUI last-session source changed before doctor could claim it");
+    }
+    (params.removeSource ?? fs.unlinkSync)(claimPath);
+  } catch (error) {
+    const restoreFailure = restoreClaimAfterCleanupFailure({
+      claimPath,
+      sourcePath: params.sourcePath,
+    });
+    throw new Error(`${String(error)}${restoreFailure ?? ""}`, { cause: error });
+  }
+}
+
+function isObjectRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function isHeartbeatSessionKey(sessionKey: string): boolean {
+  return sessionKey.toLowerCase().endsWith(":heartbeat");
+}
+
+function parseLegacyTuiLastSessions(raw: string): LegacyTuiLastSession[] {
+  const parsed = JSON.parse(raw) as unknown;
+  if (!isObjectRecord(parsed)) {
+    throw new Error("legacy TUI last-session store must be a JSON object");
+  }
+  const records: LegacyTuiLastSession[] = [];
+  for (const [scopeKey, value] of Object.entries(parsed)) {
+    if (!scopeKey || scopeKey.trim() !== scopeKey) {
+      throw new Error("legacy TUI last-session store contains an invalid scope key");
+    }
+    if (!isObjectRecord(value)) {
+      throw new Error(`legacy TUI last-session record ${scopeKey} must be an object`);
+    }
+    const unexpectedKey = Object.keys(value).find((key) => !LEGACY_RECORD_KEYS.has(key));
+    if (unexpectedKey) {
+      throw new Error(
+        `legacy TUI last-session record ${scopeKey} has unexpected field ${unexpectedKey}`,
+      );
+    }
+    const sessionKey = value.sessionKey;
+    const updatedAt = value.updatedAt;
+    if (
+      typeof sessionKey !== "string" ||
+      !sessionKey ||
+      sessionKey.trim() !== sessionKey ||
+      sessionKey === "unknown"
+    ) {
+      throw new Error(`legacy TUI last-session record ${scopeKey} has an invalid session key`);
+    }
+    if (!Number.isSafeInteger(updatedAt) || (updatedAt as number) < 0) {
+      throw new Error(`legacy TUI last-session record ${scopeKey} has an invalid timestamp`);
+    }
+    records.push({ scopeKey, sessionKey, updatedAt: updatedAt as number });
+  }
+  return records;
+}
+
+function rowMatches(
+  row: { session_key: string; updated_at: number } | undefined,
+  expected: LegacyTuiLastSession,
+): boolean {
+  return row?.session_key === expected.sessionKey && row.updated_at === expected.updatedAt;
+}
+
+/** Import, verify, and remove the retired JSON store during an explicit doctor repair. */
+export function migrateLegacyTuiLastSessions(params: {
+  detected: LegacyStateDetection["tuiLastSessions"];
+  stateDir: string;
+  beforeClaim?: () => void;
+  beforeVerify?: () => void;
+  removeSource?: (sourcePath: string) => void;
+}): MigrationMessages {
+  const changes: string[] = [];
+  const warnings: string[] = [];
+  const notices: string[] = [];
+  if (!params.detected.hasLegacy) {
+    return { changes, warnings };
+  }
+
+  let snapshot: LegacySourceSnapshot;
+  let records: LegacyTuiLastSession[];
+  try {
+    snapshot = readLegacySourceSnapshot(params.detected.sourcePath);
+    records = parseLegacyTuiLastSessions(snapshot.raw);
+  } catch (error) {
+    warnings.push(
+      `Failed reading legacy TUI last-session state ${params.detected.sourcePath}: ${String(error)}`,
+    );
+    return { changes, warnings };
+  }
+
+  const activeRecords = records.filter((record) => !isHeartbeatSessionKey(record.sessionKey));
+  const discardedHeartbeatCount = records.length - activeRecords.length;
+  const expectedRows = new Map<string, LegacyTuiLastSession>();
+  let importedCount = 0;
+  let supersededCount = 0;
+  try {
+    // No filesystem work belongs inside the synchronous SQLite commit section.
+    assertLegacySourceUnchanged(params.detected.sourcePath, snapshot);
+    runOpenClawStateWriteTransaction(
+      ({ db }) => {
+        const tuiDb = getNodeSqliteKysely<TuiLastSessionMigrationDatabase>(db);
+        for (const record of activeRecords) {
+          const existing = executeSqliteQueryTakeFirstSync(
+            db,
+            tuiDb
+              .selectFrom("tui_last_sessions")
+              .select(["session_key", "updated_at"])
+              .where("scope_key", "=", record.scopeKey),
+          );
+          if (!existing) {
+            executeSqliteQuerySync(
+              db,
+              tuiDb.insertInto("tui_last_sessions").values({
+                scope_key: record.scopeKey,
+                session_key: record.sessionKey,
+                updated_at: record.updatedAt,
+              }),
+            );
+            expectedRows.set(record.scopeKey, record);
+            importedCount += 1;
+            continue;
+          }
+          if (existing.updated_at === record.updatedAt) {
+            if (existing.session_key !== record.sessionKey) {
+              throw new Error(
+                `scope ${record.scopeKey} has divergent JSON and SQLite pointers at the same timestamp`,
+              );
+            }
+            expectedRows.set(record.scopeKey, record);
+            continue;
+          }
+          if (existing.updated_at > record.updatedAt) {
+            expectedRows.set(record.scopeKey, {
+              scopeKey: record.scopeKey,
+              sessionKey: existing.session_key,
+              updatedAt: existing.updated_at,
+            });
+            supersededCount += 1;
+            continue;
+          }
+          executeSqliteQuerySync(
+            db,
+            tuiDb
+              .updateTable("tui_last_sessions")
+              .set({ session_key: record.sessionKey, updated_at: record.updatedAt })
+              .where("scope_key", "=", record.scopeKey),
+          );
+          expectedRows.set(record.scopeKey, record);
+          importedCount += 1;
+        }
+      },
+      { env: { ...process.env, OPENCLAW_STATE_DIR: params.stateDir } },
+    );
+  } catch (error) {
+    warnings.push(`Failed migrating legacy TUI last-session state: ${String(error)}`);
+    return { changes, warnings };
+  }
+
+  try {
+    params.beforeVerify?.();
+    const database = openOpenClawStateDatabase({
+      env: { ...process.env, OPENCLAW_STATE_DIR: params.stateDir },
+    });
+    const tuiDb = getNodeSqliteKysely<TuiLastSessionMigrationDatabase>(database.db);
+    for (const expected of expectedRows.values()) {
+      const row = executeSqliteQueryTakeFirstSync(
+        database.db,
+        tuiDb
+          .selectFrom("tui_last_sessions")
+          .select(["session_key", "updated_at"])
+          .where("scope_key", "=", expected.scopeKey),
+      );
+      if (!rowMatches(row, expected)) {
+        throw new Error(`SQLite verification failed for scope ${expected.scopeKey}`);
+      }
+    }
+    assertLegacySourceUnchanged(params.detected.sourcePath, snapshot);
+  } catch (error) {
+    warnings.push(`Failed verifying legacy TUI last-session migration: ${String(error)}`);
+    return { changes, warnings };
+  }
+
+  try {
+    claimAndRemoveVerifiedLegacySource({
+      sourcePath: params.detected.sourcePath,
+      snapshot,
+      beforeClaim: params.beforeClaim,
+      removeSource: params.removeSource,
+    });
+  } catch (error) {
+    warnings.push(
+      `Migrated TUI last-session state but could not remove legacy source ${params.detected.sourcePath}: ${String(error)}`,
+    );
+    return { changes, warnings };
+  }
+
+  if (importedCount > 0) {
+    changes.push(`Migrated ${importedCount} TUI last-session pointer(s) → shared SQLite state`);
+  }
+  if (discardedHeartbeatCount > 0) {
+    changes.push(`Discarded ${discardedHeartbeatCount} legacy heartbeat TUI restore pointer(s)`);
+  }
+  changes.push("Removed legacy TUI last-session JSON after SQLite verification");
+  if (supersededCount > 0) {
+    notices.push(
+      `Kept ${supersededCount} newer shared SQLite TUI last-session pointer(s) over legacy JSON`,
+    );
+  }
+  return notices.length > 0 ? { changes, warnings, notices } : { changes, warnings };
+}

--- a/src/infra/state-migrations.tui-last-session.ts
+++ b/src/infra/state-migrations.tui-last-session.ts
@@ -33,7 +33,7 @@ type LegacySourceSnapshot = {
 
 const LEGACY_RECORD_KEYS = new Set(["sessionKey", "updatedAt"]);
 
-export function resolveLegacyTuiLastSessionPath(stateDir: string): string {
+function resolveLegacyTuiLastSessionPath(stateDir: string): string {
   return path.join(stateDir, "tui", "last-session.json");
 }
 

--- a/src/infra/state-migrations.types.ts
+++ b/src/infra/state-migrations.types.ts
@@ -87,6 +87,10 @@ export type LegacyStateDetection = {
     sourcePath: string;
     hasLegacy: boolean;
   };
+  tuiLastSessions: {
+    sourcePath: string;
+    hasLegacy: boolean;
+  };
   channelPairing: LegacyChannelPairingStateDetection;
   execApprovals: {
     sourcePath: string;

--- a/src/tui/tui-last-session.test.ts
+++ b/src/tui/tui-last-session.test.ts
@@ -3,8 +3,10 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import {
   buildTuiLastSessionScopeKey,
+  clearTuiLastSessionPointers,
   readTuiLastSessionKey,
   resolveRememberedTuiSessionKey,
   writeTuiLastSessionKey,
@@ -19,6 +21,7 @@ async function makeTempStateDir() {
 }
 
 afterEach(async () => {
+  closeOpenClawStateDatabaseForTest();
   await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
 });
 
@@ -38,8 +41,32 @@ describe("tui last session state", () => {
     });
 
     await expect(readTuiLastSessionKey({ scopeKey, stateDir })).resolves.toBe("agent:main:tui-123");
-    const raw = await fs.readFile(path.join(stateDir, "tui", "last-session.json"), "utf8");
-    expect(raw).not.toContain("127.0.0.1");
+    await expect(fs.stat(path.join(stateDir, "tui", "last-session.json"))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+
+    closeOpenClawStateDatabaseForTest();
+    await expect(readTuiLastSessionKey({ scopeKey, stateDir })).resolves.toBe("agent:main:tui-123");
+  });
+
+  it("atomically preserves concurrent updates to independent scopes", async () => {
+    const stateDir = await makeTempStateDir();
+    await Promise.all(
+      Array.from({ length: 40 }, (_, index) =>
+        writeTuiLastSessionKey({
+          scopeKey: index % 2 === 0 ? "terminal" : "remote",
+          sessionKey: `agent:main:tui-${index}`,
+          stateDir,
+        }),
+      ),
+    );
+
+    await expect(readTuiLastSessionKey({ scopeKey: "terminal", stateDir })).resolves.toBe(
+      "agent:main:tui-38",
+    );
+    await expect(readTuiLastSessionKey({ scopeKey: "remote", stateDir })).resolves.toBe(
+      "agent:main:tui-39",
+    );
   });
 
   it("restores only a remembered session that still belongs to the current agent", () => {
@@ -112,5 +139,30 @@ describe("tui last session state", () => {
         sessions,
       }),
     ).toBeNull();
+  });
+
+  it("clears only pointers owned by a retired session", async () => {
+    const stateDir = await makeTempStateDir();
+    await writeTuiLastSessionKey({
+      scopeKey: "terminal",
+      sessionKey: "agent:main:main",
+      stateDir,
+    });
+    await writeTuiLastSessionKey({
+      scopeKey: "remote",
+      sessionKey: "agent:main:telegram:thread",
+      stateDir,
+    });
+
+    expect(
+      clearTuiLastSessionPointers({
+        stateDir,
+        sessionKeys: new Set(["agent:main:main"]),
+      }),
+    ).toBe(1);
+    await expect(readTuiLastSessionKey({ scopeKey: "terminal", stateDir })).resolves.toBeNull();
+    await expect(readTuiLastSessionKey({ scopeKey: "remote", stateDir })).resolves.toBe(
+      "agent:main:telegram:thread",
+    );
   });
 });

--- a/src/tui/tui-last-session.ts
+++ b/src/tui/tui-last-session.ts
@@ -1,23 +1,25 @@
 // Stores and resolves the last TUI session per workspace.
 import { createHash } from "node:crypto";
-import path from "node:path";
-import { resolveStateDir } from "../config/paths.js";
-import { privateFileStore } from "../infra/private-file-store.js";
+import {
+  executeSqliteQuerySync,
+  executeSqliteQueryTakeFirstSync,
+  getNodeSqliteKysely,
+} from "../infra/kysely-sync.js";
 import { normalizeAgentId, parseAgentSessionKey } from "../routing/session-key.js";
+import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
+import {
+  openOpenClawStateDatabase,
+  runOpenClawStateWriteTransaction,
+} from "../state/openclaw-state-db.js";
 import type { TuiSessionList } from "./tui-backend.js";
 import type { SessionScope } from "./tui-types.js";
 
-// Persists the last human-selected TUI session per connection/agent/scope.
-type LastSessionRecord = {
-  sessionKey: string;
-  updatedAt: number;
-};
+type TuiLastSessionDatabase = Pick<OpenClawStateKyselyDatabase, "tui_last_sessions">;
 
-type LastSessionStore = Record<string, LastSessionRecord>;
-
-/** Resolves the private state file for remembered TUI sessions. */
-function resolveTuiLastSessionStatePath(stateDir = resolveStateDir()): string {
-  return path.join(stateDir, "tui", "last-session.json");
+function stateDatabaseOptions(stateDir?: string) {
+  return stateDir
+    ? { env: { ...process.env, OPENCLAW_STATE_DIR: stateDir } }
+    : { env: process.env };
 }
 
 /** Builds a stable private-store key for the current TUI connection, agent, and session scope. */
@@ -32,19 +34,6 @@ export function buildTuiLastSessionScopeKey(params: {
     .update(`${params.sessionScope}\n${agentId}\n${connectionUrl}`)
     .digest("hex")
     .slice(0, 32);
-}
-
-async function readStore(filePath: string): Promise<LastSessionStore> {
-  try {
-    const parsed = await privateFileStore(path.dirname(filePath)).readJsonIfExists(
-      path.basename(filePath),
-    );
-    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
-      ? (parsed as LastSessionStore)
-      : {};
-  } catch {
-    return {};
-  }
 }
 
 function normalizeMarker(value: unknown): string {
@@ -72,14 +61,21 @@ function isHeartbeatLikeTuiSession(session: TuiSessionList["sessions"][number]):
   return markers.some((marker) => normalizeMarker(marker) === "heartbeat");
 }
 
-/** Reads the remembered session key for a scope, ignoring missing or malformed stores. */
+/** Reads the remembered session key for a scope from canonical shared state. */
 export async function readTuiLastSessionKey(params: {
   scopeKey: string;
   stateDir?: string;
 }): Promise<string | null> {
-  const store = await readStore(resolveTuiLastSessionStatePath(params.stateDir));
-  const value = store[params.scopeKey]?.sessionKey;
-  return typeof value === "string" && value.trim() ? value.trim() : null;
+  const database = openOpenClawStateDatabase(stateDatabaseOptions(params.stateDir));
+  const row = executeSqliteQueryTakeFirstSync(
+    database.db,
+    getNodeSqliteKysely<TuiLastSessionDatabase>(database.db)
+      .selectFrom("tui_last_sessions")
+      .select("session_key")
+      .where("scope_key", "=", params.scopeKey),
+  );
+  const sessionKey = row?.session_key.trim() ?? "";
+  return sessionKey && !isHeartbeatSessionKey(sessionKey) ? sessionKey : null;
 }
 
 /** Writes the remembered session key unless it is empty, unknown, or heartbeat-owned. */
@@ -92,15 +88,45 @@ export async function writeTuiLastSessionKey(params: {
   if (!sessionKey || sessionKey === "unknown" || isHeartbeatSessionKey(sessionKey)) {
     return;
   }
-  const filePath = resolveTuiLastSessionStatePath(params.stateDir);
-  const store = await readStore(filePath);
-  store[params.scopeKey] = {
-    sessionKey,
-    updatedAt: Date.now(),
-  };
-  await privateFileStore(path.dirname(filePath)).writeJson(path.basename(filePath), store, {
-    trailingNewline: true,
-  });
+  const updatedAt = Date.now();
+  runOpenClawStateWriteTransaction(({ db }) => {
+    const tuiDb = getNodeSqliteKysely<TuiLastSessionDatabase>(db);
+    executeSqliteQuerySync(
+      db,
+      tuiDb
+        .insertInto("tui_last_sessions")
+        .values({
+          scope_key: params.scopeKey,
+          session_key: sessionKey,
+          updated_at: updatedAt,
+        })
+        .onConflict((conflict) =>
+          conflict.column("scope_key").doUpdateSet({
+            session_key: sessionKey,
+            updated_at: updatedAt,
+          }),
+        ),
+    );
+  }, stateDatabaseOptions(params.stateDir));
+}
+
+/** Removes restore pointers that target sessions retired by doctor repair. */
+export function clearTuiLastSessionPointers(params: {
+  sessionKeys: ReadonlySet<string>;
+  stateDir?: string;
+}): number {
+  if (params.sessionKeys.size === 0) {
+    return 0;
+  }
+  return runOpenClawStateWriteTransaction(({ db }) => {
+    const result = executeSqliteQuerySync(
+      db,
+      getNodeSqliteKysely<TuiLastSessionDatabase>(db)
+        .deleteFrom("tui_last_sessions")
+        .where("session_key", "in", [...params.sessionKeys]),
+    );
+    return Number(result.numAffectedRows ?? 0n);
+  }, stateDatabaseOptions(params.stateDir));
 }
 
 /** Resolves a remembered key to a currently listed session for the active agent. */

--- a/test/scripts/check-database-first-legacy-stores.test.ts
+++ b/test/scripts/check-database-first-legacy-stores.test.ts
@@ -172,6 +172,19 @@ describe("check-database-first-legacy-stores", () => {
     ]);
   });
 
+  it("flags runtime writes to the retired TUI last-session store", () => {
+    const violations = collectDatabaseFirstLegacyStoreViolations(
+      `
+        import { promises as fs } from "node:fs";
+        import path from "node:path";
+        await fs.writeFile(path.join(stateDir, "tui", "last-session.json"), "{}\\n");
+      `,
+      "src/tui/last-session-writer.ts",
+    );
+
+    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 4 }]);
+  });
+
   it("flags legacy paths with dynamic agent id segments", () => {
     const violations = collectDatabaseFirstLegacyStoreViolations(
       `


### PR DESCRIPTION
Related: #107227

## What Problem This Solves

Fixes an issue where TUI users could lose or race remembered session selections because restore pointers were stored in a shared JSON file outside the canonical SQLite state store.

## Why This Change Was Made

Moves TUI last-session pointers to typed shared SQLite rows with atomic per-scope upserts and transactional cleanup. Runtime no longer reads or writes the legacy JSON file. `openclaw doctor --fix` is the sole importer: it strictly validates legacy state, preserves newer SQLite rows, excludes heartbeat pointers, verifies the committed projection, atomically claims the unchanged source, and then deletes it without leaving a migrated archive.

Named artifacts, authored configuration, logs, backups, and external-tool file contracts are outside this migration.

## User Impact

TUI restore choices now survive concurrent writers without whole-file lost updates. Upgrades retain valid remembered sessions after doctor migration; stale heartbeat sessions cannot become restore targets. Malformed or concurrently replaced legacy files remain in place with a warning instead of risking data loss.

AI-assisted: implementation and review used Codex. Maintainer understands and reviewed the complete change.

## Evidence

- `node scripts/run-vitest.mjs src/infra/state-migrations.tui-last-session.test.ts src/tui/tui-last-session.test.ts src/commands/doctor-state-integrity.test.ts src/flows/doctor-health-contributions.test.ts test/scripts/check-database-first-legacy-stores.test.ts` — 610 tests passed across five shards.
- Targeted `oxfmt`, `oxlint`, `git diff --check`, and `node scripts/check-database-first-legacy-stores.mjs` — passed.
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted --stream-engine-output` — clean after fixing the accepted atomic-claim race finding.
- Blacksmith Testbox `tbx_01kxj5r0zhtpr6czeyezapjxnn` / run https://github.com/openclaw/openclaw/actions/runs/29392922485 — changed-file gate passed conflict, max-lines, changelog attribution, export, dependency, duplicate-coverage, and formatting checks; stopped on Plugin SDK baseline drift independently reproduced on clean `origin/main` at `7f1baa6d758bf`.
- Source-blind CLI validation on exact head `d559982`: doctor imported the normal pointer, discarded the heartbeat pointer, verified SQLite, removed JSON without an archive, converged cleanly on a second run, and retained malformed JSON byte-for-byte. Interactive restore was not claimed because no live Gateway fixture was available.
- CI found a missing doctor E2E harness fixture field; the fixture was corrected and all three harness consumers passed (35 tests). Targeted formatting, `git diff --check`, and fresh autoreview also passed.
- The following CI cohort passed production types and found dead-code export hygiene: one helper is now private and one stale baseline suppression was removed. Migration and dead-code baseline tests passed (20 tests); targeted formatting and fresh autoreview passed.
