### PR TITLE
fix(e2e): keep gateway suspension probes within deadline

### DIFF
--- a/scripts/e2e/lib/gateway-network/client.d.mts
+++ b/scripts/e2e/lib/gateway-network/client.d.mts
@@ -20,6 +20,14 @@ export function assertSuspendedProbes(
   health: Record<string, unknown>,
   readiness: Record<string, unknown>,
 ): void;
+export function runGatewaySuspensionPreRestartClient(
+  options: { statePath: string; token: string; url: string; timeoutMs?: number },
+  deps?: { fetchImpl?: typeof fetch },
+): Promise<void>;
+export function runGatewaySuspensionPostRestartClient(
+  options: { statePath: string; token: string; url: string; timeoutMs?: number },
+  deps?: { fetchImpl?: typeof fetch },
+): Promise<void>;
 export function responseError(method: string, response: GatewayFrame): Error;
 export function runGatewayNetworkClient(
   options: { token: string; url: string; timeoutMs?: number },

--- a/scripts/e2e/lib/gateway-network/client.mjs
+++ b/scripts/e2e/lib/gateway-network/client.mjs
@@ -13,6 +13,11 @@ function remainingDeadlineMs(deadline) {
   return Math.max(1, deadline - Date.now());
 }
 
+function deadlineSignal(deadline) {
+  // Keep headers and response-body reads inside the same phase-wide client deadline.
+  return AbortSignal.timeout(remainingDeadlineMs(deadline));
+}
+
 async function openSocket(url, timeoutMs = 10_000) {
   const ws = new WebSocket(url);
   await waitForWebSocketOpen(ws, timeoutMs, "ws open timeout");
@@ -50,31 +55,35 @@ function httpUrl(url, pathname = "/") {
   return target.toString();
 }
 
-async function readJson(response, label) {
+async function readJson(response, label, signal) {
   let body;
   try {
     body = await response.json();
   } catch {
+    signal.throwIfAborted();
     throw new Error(`${label} returned non-JSON HTTP ${response.status}`);
   }
   return { status: response.status, body };
 }
 
-async function adminRpc({ token, url }, method, params = {}) {
-  const response = await fetch(httpUrl(url, "/api/v1/admin/rpc"), {
+async function adminRpc({ deadline, fetchImpl, token, url }, method, params = {}) {
+  const signal = deadlineSignal(deadline);
+  const response = await fetchImpl(httpUrl(url, "/api/v1/admin/rpc"), {
     method: "POST",
     headers: {
       Authorization: `Bearer ${token}`,
       "Content-Type": "application/json",
     },
     body: JSON.stringify({ id: `e2e-${method}`, method, params }),
+    signal,
   });
-  return await readJson(response, `Admin RPC ${method}`);
+  return await readJson(response, `Admin RPC ${method}`, signal);
 }
 
-async function readProbe(url, pathname) {
-  const response = await fetch(httpUrl(url, pathname));
-  return await readJson(response, pathname);
+async function readProbe({ deadline, fetchImpl, url }, pathname) {
+  const signal = deadlineSignal(deadline);
+  const response = await fetchImpl(httpUrl(url, pathname), { signal });
+  return await readJson(response, pathname, signal);
 }
 
 async function requestUpgradeRejection(url, timeoutMs) {
@@ -185,25 +194,35 @@ function assertAdminSuccess(response, message) {
   return assertRpcSuccess(response.body, message);
 }
 
-async function runGatewaySuspensionPreRestartClient({
-  statePath,
-  token,
-  url,
-  timeoutMs = readGatewayNetworkClientConnectTimeoutMs(),
-}) {
+export async function runGatewaySuspensionPreRestartClient(
+  { statePath, token, url, timeoutMs = readGatewayNetworkClientConnectTimeoutMs() },
+  deps = {},
+) {
   const startedAt = Date.now();
-  const rpc = (method, params) => adminRpc({ token, url }, method, params);
+  const requestContext = {
+    deadline: startedAt + timeoutMs,
+    fetchImpl: deps.fetchImpl ?? fetch,
+    token,
+    url,
+  };
+  const rpc = (method, params) => adminRpc(requestContext, method, params);
   const firstLease = assertReadySuspensionResponse(
     await rpc("gateway.suspend.prepare", { requestId: "gateway-network-live-contract" }),
   );
 
-  assertSuspendedProbes(await readProbe(url, "/healthz"), await readProbe(url, "/readyz"));
+  assertSuspendedProbes(
+    await readProbe(requestContext, "/healthz"),
+    await readProbe(requestContext, "/readyz"),
+  );
 
   const blockedAdminHealth = await rpc("health");
   assert.equal(blockedAdminHealth.status, 503, "Admin health must return HTTP 503");
   assertGatewaySuspendingError(blockedAdminHealth.body);
 
-  const upgrade = await requestUpgradeRejection(url, timeoutMs);
+  const upgrade = await requestUpgradeRejection(
+    url,
+    remainingDeadlineMs(requestContext.deadline),
+  );
   assert.equal(upgrade.status, 503, "new websocket upgrade must return HTTP 503");
   assert.equal(
     upgrade.body,
@@ -241,7 +260,10 @@ async function runGatewaySuspensionPreRestartClient({
   );
   assert.equal(repeatedResume?.resumed, false, "repeat resume must be idempotent");
 
-  assertHealthyProbes(await readProbe(url, "/healthz"), await readProbe(url, "/readyz"));
+  assertHealthyProbes(
+    await readProbe(requestContext, "/healthz"),
+    await readProbe(requestContext, "/readyz"),
+  );
 
   const requestId = "gateway-network-restart-contract";
   const secondLease = assertReadySuspensionResponse(
@@ -258,11 +280,20 @@ async function runGatewaySuspensionPreRestartClient({
   emitPhase("pre-restart", startedAt);
 }
 
-async function runGatewaySuspensionPostRestartClient({ statePath, token, url }) {
+export async function runGatewaySuspensionPostRestartClient(
+  { statePath, token, url, timeoutMs = readGatewayNetworkClientConnectTimeoutMs() },
+  deps = {},
+) {
   const startedAt = Date.now();
+  const requestContext = {
+    deadline: startedAt + timeoutMs,
+    fetchImpl: deps.fetchImpl ?? fetch,
+    token,
+    url,
+  };
   const state = JSON.parse(await readFile(statePath, "utf8"));
   assert(Date.now() < state.expiresAtMs, "restart proof exceeded the original lease");
-  const rpc = (method, params) => adminRpc({ token, url }, method, params);
+  const rpc = (method, params) => adminRpc(requestContext, method, params);
 
   const oldStatus = assertAdminSuccess(
     await rpc("gateway.suspend.status", { suspensionId: state.suspensionId }),
@@ -275,7 +306,10 @@ async function runGatewaySuspensionPostRestartClient({ statePath, token, url }) 
   );
   assert(oldResume?.resumed === false, "old lease resume must be idempotently inactive");
 
-  assertHealthyProbes(await readProbe(url, "/healthz"), await readProbe(url, "/readyz"));
+  assertHealthyProbes(
+    await readProbe(requestContext, "/healthz"),
+    await readProbe(requestContext, "/readyz"),
+  );
   assertAdminSuccess(await rpc("health"), "Admin health after restart");
 
   const replacement = assertReadySuspensionResponse(

--- a/scripts/e2e/lib/gateway-network/client.mjs
+++ b/scripts/e2e/lib/gateway-network/client.mjs
@@ -219,10 +219,7 @@ export async function runGatewaySuspensionPreRestartClient(
   assert.equal(blockedAdminHealth.status, 503, "Admin health must return HTTP 503");
   assertGatewaySuspendingError(blockedAdminHealth.body);
 
-  const upgrade = await requestUpgradeRejection(
-    url,
-    remainingDeadlineMs(requestContext.deadline),
-  );
+  const upgrade = await requestUpgradeRejection(url, remainingDeadlineMs(requestContext.deadline));
   assert.equal(upgrade.status, 503, "new websocket upgrade must return HTTP 503");
   assert.equal(
     upgrade.body,

--- a/test/scripts/gateway-network-client.test.ts
+++ b/test/scripts/gateway-network-client.test.ts
@@ -1,9 +1,8 @@
 // Gateway Network Client tests cover gateway network client script behavior.
 import { EventEmitter } from "node:events";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { writeFileSync } from "node:fs";
 import { join } from "node:path";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   type GatewayFrame,
   assertGatewaySuspendingError,
@@ -15,6 +14,9 @@ import {
 } from "../../scripts/e2e/lib/gateway-network/client.mjs";
 import { readGatewayNetworkClientConnectTimeoutMs } from "../../scripts/e2e/lib/gateway-network/limits.mjs";
 import { onceFrame } from "../../scripts/e2e/lib/gateway-network/ws-frames.mjs";
+import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 describe("gateway network client", () => {
   function rejectWhenAborted(signal: AbortSignal | null | undefined): Promise<never> {
@@ -147,7 +149,7 @@ describe("gateway network client", () => {
   });
 
   it("bounds a stalled post-restart admin request by the client deadline", async () => {
-    const workDir = mkdtempSync(join(tmpdir(), "openclaw-gateway-network-post-restart-"));
+    const workDir = tempDirs.make("openclaw-gateway-network-post-restart-");
     const statePath = join(workDir, "suspension.json");
     writeFileSync(
       statePath,
@@ -163,26 +165,22 @@ describe("gateway network client", () => {
       return rejectWhenAborted(requestSignal);
     });
 
-    try {
-      const startedAt = Date.now();
-      await expect(
-        runGatewaySuspensionPostRestartClient(
-          {
-            statePath,
-            token: "x",
-            url: "ws://127.0.0.1:12345",
-            timeoutMs: 25,
-          },
-          { fetchImpl },
-        ),
-      ).rejects.toMatchObject({ name: "TimeoutError" });
+    const startedAt = Date.now();
+    await expect(
+      runGatewaySuspensionPostRestartClient(
+        {
+          statePath,
+          token: "x",
+          url: "ws://127.0.0.1:12345",
+          timeoutMs: 25,
+        },
+        { fetchImpl },
+      ),
+    ).rejects.toMatchObject({ name: "TimeoutError" });
 
-      expect(Date.now() - startedAt).toBeLessThan(500);
-      expect(requestSignal?.aborted).toBe(true);
-      expect(fetchImpl).toHaveBeenCalledOnce();
-    } finally {
-      rmSync(workDir, { recursive: true, force: true });
-    }
+    expect(Date.now() - startedAt).toBeLessThan(500);
+    expect(requestSignal?.aborted).toBe(true);
+    expect(fetchImpl).toHaveBeenCalledOnce();
   });
 
   it("resolves matching frames and ignores unrelated frames", async () => {

--- a/test/scripts/gateway-network-client.test.ts
+++ b/test/scripts/gateway-network-client.test.ts
@@ -1,5 +1,8 @@
 // Gateway Network Client tests cover gateway network client script behavior.
 import { EventEmitter } from "node:events";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import {
   type GatewayFrame,
@@ -7,11 +10,26 @@ import {
   assertReadySuspensionResponse,
   assertSuspendedProbes,
   runGatewayNetworkClient,
+  runGatewaySuspensionPostRestartClient,
+  runGatewaySuspensionPreRestartClient,
 } from "../../scripts/e2e/lib/gateway-network/client.mjs";
 import { readGatewayNetworkClientConnectTimeoutMs } from "../../scripts/e2e/lib/gateway-network/limits.mjs";
 import { onceFrame } from "../../scripts/e2e/lib/gateway-network/ws-frames.mjs";
 
-describe("gateway network WebSocket open guard", () => {
+describe("gateway network client", () => {
+  function rejectWhenAborted(signal: AbortSignal | null | undefined): Promise<never> {
+    expect(signal).toBeInstanceOf(AbortSignal);
+    const requestSignal = signal as AbortSignal;
+    return new Promise((_, reject) => {
+      const rejectWithReason = () => reject(requestSignal.reason);
+      if (requestSignal.aborted) {
+        rejectWithReason();
+        return;
+      }
+      requestSignal.addEventListener("abort", rejectWithReason, { once: true });
+    });
+  }
+
   function healthResponse() {
     return {
       ok: true,
@@ -58,6 +76,113 @@ describe("gateway network WebSocket open guard", () => {
         OPENCLAW_GATEWAY_NETWORK_CONNECT_READY_TIMEOUT_MS: "3000",
       }),
     ).toBe(3000);
+  });
+
+  it("bounds a stalled suspension admin request by the client deadline", async () => {
+    let requestSignal: AbortSignal | null | undefined;
+    const fetchImpl = vi.fn<typeof fetch>((_input, init) => {
+      requestSignal = init?.signal;
+      return rejectWhenAborted(requestSignal);
+    });
+
+    const startedAt = Date.now();
+    await expect(
+      runGatewaySuspensionPreRestartClient(
+        {
+          statePath: "/tmp/unused-gateway-network-state.json",
+          token: "x",
+          url: "ws://127.0.0.1:12345",
+          timeoutMs: 25,
+        },
+        { fetchImpl },
+      ),
+    ).rejects.toMatchObject({ name: "TimeoutError" });
+
+    expect(Date.now() - startedAt).toBeLessThan(500);
+    expect(requestSignal?.aborted).toBe(true);
+    expect(fetchImpl).toHaveBeenCalledOnce();
+  });
+
+  it("keeps a stalled suspension response body inside the client deadline", async () => {
+    let callCount = 0;
+    let bodySignal: AbortSignal | null | undefined;
+    const fetchImpl = vi.fn<typeof fetch>(async (_input, init) => {
+      callCount += 1;
+      if (callCount === 1) {
+        return Response.json({
+          ok: true,
+          payload: {
+            status: "ready",
+            suspensionId: "lease-1",
+            expiresAtMs: Date.now() + 10_000,
+            activeCount: 0,
+            blockers: [],
+          },
+        });
+      }
+      bodySignal = init?.signal;
+      return {
+        status: 200,
+        json: () => rejectWhenAborted(bodySignal),
+      } as Response;
+    });
+
+    const startedAt = Date.now();
+    await expect(
+      runGatewaySuspensionPreRestartClient(
+        {
+          statePath: "/tmp/unused-gateway-network-state.json",
+          token: "x",
+          url: "ws://127.0.0.1:12345",
+          timeoutMs: 25,
+        },
+        { fetchImpl },
+      ),
+    ).rejects.toMatchObject({ name: "TimeoutError" });
+
+    expect(Date.now() - startedAt).toBeLessThan(500);
+    expect(bodySignal?.aborted).toBe(true);
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(String(fetchImpl.mock.calls[1]?.[0])).toContain("/healthz");
+  });
+
+  it("bounds a stalled post-restart admin request by the client deadline", async () => {
+    const workDir = mkdtempSync(join(tmpdir(), "openclaw-gateway-network-post-restart-"));
+    const statePath = join(workDir, "suspension.json");
+    writeFileSync(
+      statePath,
+      JSON.stringify({
+        requestId: "gateway-network-restart-contract",
+        suspensionId: "lease-before-restart",
+        expiresAtMs: Date.now() + 10_000,
+      }),
+    );
+    let requestSignal: AbortSignal | null | undefined;
+    const fetchImpl = vi.fn<typeof fetch>((_input, init) => {
+      requestSignal = init?.signal;
+      return rejectWhenAborted(requestSignal);
+    });
+
+    try {
+      const startedAt = Date.now();
+      await expect(
+        runGatewaySuspensionPostRestartClient(
+          {
+            statePath,
+            token: "x",
+            url: "ws://127.0.0.1:12345",
+            timeoutMs: 25,
+          },
+          { fetchImpl },
+        ),
+      ).rejects.toMatchObject({ name: "TimeoutError" });
+
+      expect(Date.now() - startedAt).toBeLessThan(500);
+      expect(requestSignal?.aborted).toBe(true);
+      expect(fetchImpl).toHaveBeenCalledOnce();
+    } finally {
+      rmSync(workDir, { recursive: true, force: true });
+    }
   });
 
   it("resolves matching frames and ignores unrelated frames", async () => {

--- a/test/scripts/gateway-network-client.test.ts
+++ b/test/scripts/gateway-network-client.test.ts
@@ -123,10 +123,9 @@ describe("gateway network client", () => {
         });
       }
       bodySignal = init?.signal;
-      return {
-        status: 200,
-        json: () => rejectWhenAborted(bodySignal),
-      } as Response;
+      const response = new Response(null, { status: 200 });
+      vi.spyOn(response, "json").mockImplementation(() => rejectWhenAborted(bodySignal));
+      return response;
     });
 
     const startedAt = Date.now();


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where gateway-network suspension checks could hang indefinitely when an admin or health HTTP request stalled before headers or while reading JSON. The surrounding Docker phase had a deadline, but these requests did not participate in it.

## Why This Change Was Made

Pre-restart and post-restart suspension HTTP operations now share the existing client phase deadline. Each request receives the remaining budget, and the same signal remains active through JSON body parsing.

## User Impact

There is no product runtime change. Gateway network E2E failures now stop within the configured client deadline and preserve the outer phase budget.

## Evidence

- `git diff --check`
- `node --check scripts/e2e/lib/gateway-network/client.mjs`
- Regression coverage includes stalled admin requests, stalled response bodies, and the post-restart path in `test/scripts/gateway-network-client.test.ts`
- Independent autoreview rerun after feedback: clean, no accepted/actionable findings
- Fork CI: [run 29396904682](https://github.com/openclaw/openclaw/actions/runs/29396904682) passed, including all required test, type, lint, build, and CI-gate checks; shared iOS/macOS scans also passed in [run 29396904688](https://github.com/openclaw/openclaw/actions/runs/29396904688)

AI-assisted: yes. Allow edits by maintainers is enabled.
