### PR TITLE
fix(e2e): stop multi-node health checks hanging past deadline

### DIFF
--- a/scripts/e2e/multi-node-update-docker.sh
+++ b/scripts/e2e/multi-node-update-docker.sh
@@ -419,7 +419,9 @@ const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 let last = "timeout";
 while (Date.now() < deadline) {
   try {
-    const response = await fetch(url);
+    // Keep each request inside the outer probe budget so a stalled fetch cannot outlive it.
+    const remainingMs = Math.max(1, deadline - Date.now());
+    const response = await fetch(url, { signal: AbortSignal.timeout(remainingMs) });
     if (response.ok) {
       process.exit(0);
     }
@@ -427,7 +429,11 @@ while (Date.now() < deadline) {
   } catch (error) {
     last = error instanceof Error ? error.message : String(error);
   }
-  await sleep(500);
+  const remainingDelayMs = deadline - Date.now();
+  if (remainingDelayMs <= 0) {
+    break;
+  }
+  await sleep(Math.min(500, remainingDelayMs));
 }
 console.error(last);
 process.exit(1);

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -13,6 +13,7 @@ import {
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
+import { pathToFileURL } from "node:url";
 import { describe, expect, it } from "vitest";
 
 const HELPER_PATH = "scripts/lib/docker-build.sh";
@@ -4030,6 +4031,62 @@ heartbeat_elapsed="\${BASH_REMATCH[1]}"
     expect(runner).toContain("FAIL: gateway install failed before update");
     expect(runner).not.toContain('gateway-install.err" || true');
     expect(runner).not.toContain("WARNING: Gateway status probe failed");
+  });
+
+  it("keeps a stalled multi-node health request inside the probe deadline", () => {
+    const runner = readFileSync(MULTI_NODE_UPDATE_DOCKER_E2E_PATH, "utf8");
+    const startMarker = "if PORT=18789 node <<NODE\n";
+    const endMarker = "\nNODE\n  then";
+    const start = runner.indexOf(startMarker);
+    const end = runner.indexOf(endMarker, start + startMarker.length);
+    expect(start).toBeGreaterThanOrEqual(0);
+    expect(end).toBeGreaterThan(start);
+    const probe = runner.slice(start + startMarker.length, end);
+    const workDir = mkdtempSync(join(tmpdir(), "openclaw-multi-node-health-timeout-"));
+    const preloadPath = join(workDir, "stalling-fetch.mjs");
+
+    try {
+      writeFileSync(
+        preloadPath,
+        [
+          "// Advance the deadline when the request aborts without waiting 30 wall-clock seconds.",
+          "const realSetTimeout = globalThis.setTimeout;",
+          "let now = 0;",
+          "Date.now = () => now;",
+          "Object.defineProperty(AbortSignal, 'timeout', { value(delayMs) {",
+          "  const controller = new AbortController();",
+          "  realSetTimeout(() => {",
+          "    now += delayMs;",
+          "    controller.abort(new DOMException('health deadline elapsed', 'TimeoutError'));",
+          "  }, 0);",
+          "  return controller.signal;",
+          "} });",
+          "globalThis.fetch = async (_url, init = {}) => await new Promise((_resolve, reject) => {",
+          "  init.signal.addEventListener('abort', () => {",
+          "    process.stderr.write('hung fetch aborted\\n');",
+          "    reject(init.signal.reason);",
+          "  }, { once: true });",
+          "});",
+        ].join("\n"),
+      );
+
+      const result = spawnSync(
+        process.execPath,
+        ["--import", pathToFileURL(preloadPath).href, "--input-type=module", "--eval", probe],
+        {
+          encoding: "utf8",
+          env: { ...process.env, PORT: "18789" },
+          timeout: 5_000,
+        },
+      );
+
+      expect(result.error).toBeUndefined();
+      expect(result.status).toBe(1);
+      expect(result.stderr.match(/hung fetch aborted/gu)).toHaveLength(1);
+      expect(result.stderr).toContain("health deadline elapsed");
+    } finally {
+      rmSync(workDir, { force: true, recursive: true });
+    }
   });
 
   it("caps package acceptance legacy compatibility at 2026.4.25", () => {

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -14,7 +14,10 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
 import { pathToFileURL } from "node:url";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 const HELPER_PATH = "scripts/lib/docker-build.sh";
 const DOCKER_ALL_SCHEDULER_PATH = "scripts/test-docker-all.mjs";
@@ -4042,51 +4045,47 @@ heartbeat_elapsed="\${BASH_REMATCH[1]}"
     expect(start).toBeGreaterThanOrEqual(0);
     expect(end).toBeGreaterThan(start);
     const probe = runner.slice(start + startMarker.length, end);
-    const workDir = mkdtempSync(join(tmpdir(), "openclaw-multi-node-health-timeout-"));
+    const workDir = tempDirs.make("openclaw-multi-node-health-timeout-");
     const preloadPath = join(workDir, "stalling-fetch.mjs");
 
-    try {
-      writeFileSync(
-        preloadPath,
-        [
-          "// Advance the deadline when the request aborts without waiting 30 wall-clock seconds.",
-          "const realSetTimeout = globalThis.setTimeout;",
-          "let now = 0;",
-          "Date.now = () => now;",
-          "Object.defineProperty(AbortSignal, 'timeout', { value(delayMs) {",
-          "  const controller = new AbortController();",
-          "  realSetTimeout(() => {",
-          "    now += delayMs;",
-          "    controller.abort(new DOMException('health deadline elapsed', 'TimeoutError'));",
-          "  }, 0);",
-          "  return controller.signal;",
-          "} });",
-          "globalThis.fetch = async (_url, init = {}) => await new Promise((_resolve, reject) => {",
-          "  init.signal.addEventListener('abort', () => {",
-          "    process.stderr.write('hung fetch aborted\\n');",
-          "    reject(init.signal.reason);",
-          "  }, { once: true });",
-          "});",
-        ].join("\n"),
-      );
+    writeFileSync(
+      preloadPath,
+      [
+        "// Advance the deadline when the request aborts without waiting 30 wall-clock seconds.",
+        "const realSetTimeout = globalThis.setTimeout;",
+        "let now = 0;",
+        "Date.now = () => now;",
+        "Object.defineProperty(AbortSignal, 'timeout', { value(delayMs) {",
+        "  const controller = new AbortController();",
+        "  realSetTimeout(() => {",
+        "    now += delayMs;",
+        "    controller.abort(new DOMException('health deadline elapsed', 'TimeoutError'));",
+        "  }, 0);",
+        "  return controller.signal;",
+        "} });",
+        "globalThis.fetch = async (_url, init = {}) => await new Promise((_resolve, reject) => {",
+        "  init.signal.addEventListener('abort', () => {",
+        "    process.stderr.write('hung fetch aborted\\n');",
+        "    reject(init.signal.reason);",
+        "  }, { once: true });",
+        "});",
+      ].join("\n"),
+    );
 
-      const result = spawnSync(
-        process.execPath,
-        ["--import", pathToFileURL(preloadPath).href, "--input-type=module", "--eval", probe],
-        {
-          encoding: "utf8",
-          env: { ...process.env, PORT: "18789" },
-          timeout: 5_000,
-        },
-      );
+    const result = spawnSync(
+      process.execPath,
+      ["--import", pathToFileURL(preloadPath).href, "--input-type=module", "--eval", probe],
+      {
+        encoding: "utf8",
+        env: { ...process.env, PORT: "18789" },
+        timeout: 5_000,
+      },
+    );
 
-      expect(result.error).toBeUndefined();
-      expect(result.status).toBe(1);
-      expect(result.stderr.match(/hung fetch aborted/gu)).toHaveLength(1);
-      expect(result.stderr).toContain("health deadline elapsed");
-    } finally {
-      rmSync(workDir, { force: true, recursive: true });
-    }
+    expect(result.error).toBeUndefined();
+    expect(result.status).toBe(1);
+    expect(result.stderr.match(/hung fetch aborted/gu)).toHaveLength(1);
+    expect(result.stderr).toContain("health deadline elapsed");
   });
 
   it("caps package acceptance legacy compatibility at 2026.4.25", () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the multi-node update Docker E2E could remain stuck in its health check when a gateway connection accepted the request but never returned response headers. That left the probe running beyond its documented 30-second readiness deadline.

## Why This Change Was Made

Each health request now uses the remaining phase deadline as its abort timeout, and retry sleeps are clamped to the same deadline. The regression test executes the real inline Node probe with a fetch that only settles when its signal aborts.

## User Impact

There is no product runtime change. Contributors and maintainers now get a bounded failure instead of an indefinitely hung multi-node update check.

## Evidence

- Controlled stalled-header proof used a standalone `node:net` server on a random `127.0.0.1` port. The server accepted and read the `/healthz` request but returned zero response bytes.
- Without an abort signal, the baseline was still running after 750 ms and required the outer watchdog to terminate it (`EXPECTED_HANG_OBSERVED`).
- With the production deadline/remaining-time/`fetch(..., { signal: AbortSignal.timeout(remainingMs) })` algorithm and a 500 ms phase window scaled down from 30 seconds, three independent runs caught `TimeoutError` in 502.6-503.3 ms, exited with code 1, and closed the TCP socket. Result: `PASS`.
- The isolated proof used Node `v22.22.0`, did not load contributor repository code, and did not access external networks or credentials. It directly validates the stalled-header transport behavior, but is not presented as a Node 24 full-Docker E2E run.
- `git diff --check`
- `bash -n scripts/e2e/multi-node-update-docker.sh`
- Focused regression coverage added in `test/scripts/docker-build-helper.test.ts`
- Independent autoreview: clean, no accepted/actionable findings
- Fork CI: [run 29397270194](https://github.com/openclaw/openclaw/actions/runs/29397270194) passed, including all required test, type, lint, build, and CI-gate checks

AI-assisted: yes. Allow edits by maintainers is enabled.
