### PR TITLE
fix(agents): decode only read bytes in bounded CLI session tails

### DIFF
--- a/src/agents/cli-runner/session-history.test.ts
+++ b/src/agents/cli-runner/session-history.test.ts
@@ -72,6 +72,14 @@ function createSessionTranscript(params: {
   return sessionFile;
 }
 
+function createOversizedSessionTranscript(rootDir: string, sessionId: string): string {
+  return createSessionTranscript({
+    rootDir,
+    sessionId,
+    messages: ["x".repeat(MAX_CLI_SESSION_HISTORY_FILE_BYTES), "tail history"],
+  });
+}
+
 function requireRecord(value: unknown, label: string): Record<string, unknown> {
   if (!value || typeof value !== "object") {
     throw new Error(`expected ${label}`);
@@ -426,46 +434,8 @@ describe("loadCliSessionHistoryMessages", () => {
 
   it("loads a bounded tail from oversized transcript files", async () => {
     const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-cli-state-"));
-    const sessionFile = path.join(
-      stateDir,
-      "agents",
-      "main",
-      "sessions",
-      "session-oversized.jsonl",
-    );
+    const sessionFile = createOversizedSessionTranscript(stateDir, "session-oversized");
     const warnSpy = vi.spyOn(cliBackendLog, "warn").mockImplementation(() => undefined);
-    fs.mkdirSync(path.dirname(sessionFile), { recursive: true });
-    fs.writeFileSync(
-      sessionFile,
-      [
-        JSON.stringify({
-          type: "session",
-          version: CURRENT_SESSION_VERSION,
-          id: "session-oversized",
-          timestamp: new Date(0).toISOString(),
-          cwd: stateDir,
-        }),
-        JSON.stringify({
-          type: "message",
-          id: "old",
-          parentId: null,
-          timestamp: new Date(1).toISOString(),
-          message: {
-            role: "user",
-            content: "x".repeat(MAX_CLI_SESSION_HISTORY_FILE_BYTES),
-            timestamp: 1,
-          },
-        }),
-        JSON.stringify({
-          type: "message",
-          id: "tail",
-          parentId: "old",
-          timestamp: new Date(2).toISOString(),
-          message: { role: "user", content: "tail history", timestamp: 2 },
-        }),
-      ].join("\n") + "\n",
-      "utf-8",
-    );
 
     try {
       await withCliSessionState(stateDir, async () => {
@@ -489,46 +459,8 @@ describe("loadCliSessionHistoryMessages", () => {
 
   it("keeps bounded tails parseable when the transcript shrinks after stat", async () => {
     const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-cli-state-"));
-    const sessionFile = path.join(
-      stateDir,
-      "agents",
-      "main",
-      "sessions",
-      "session-oversized-shrink.jsonl",
-    );
+    const sessionFile = createOversizedSessionTranscript(stateDir, "session-oversized-shrink");
     const warnSpy = vi.spyOn(cliBackendLog, "warn").mockImplementation(() => undefined);
-    fs.mkdirSync(path.dirname(sessionFile), { recursive: true });
-    fs.writeFileSync(
-      sessionFile,
-      [
-        JSON.stringify({
-          type: "session",
-          version: CURRENT_SESSION_VERSION,
-          id: "session-oversized-shrink",
-          timestamp: new Date(0).toISOString(),
-          cwd: stateDir,
-        }),
-        JSON.stringify({
-          type: "message",
-          id: "old",
-          parentId: null,
-          timestamp: new Date(1).toISOString(),
-          message: {
-            role: "user",
-            content: "x".repeat(MAX_CLI_SESSION_HISTORY_FILE_BYTES),
-            timestamp: 1,
-          },
-        }),
-        JSON.stringify({
-          type: "message",
-          id: "tail",
-          parentId: "old",
-          timestamp: new Date(2).toISOString(),
-          message: { role: "user", content: "tail history", timestamp: 2 },
-        }),
-      ].join("\n") + "\n",
-      "utf-8",
-    );
     // Report a stale, larger size for the session file so the bounded
     // positional read hits EOF early, as when the CLI compacts the transcript
     // between the size probe and the read.

--- a/src/agents/cli-runner/session-history.test.ts
+++ b/src/agents/cli-runner/session-history.test.ts
@@ -1,5 +1,6 @@
 // Covers CLI session transcript loading and reseeding boundaries.
 import fs from "node:fs";
+import fsp from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { CURRENT_SESSION_VERSION } from "openclaw/plugin-sdk/agent-sessions";
@@ -481,6 +482,81 @@ describe("loadCliSessionHistoryMessages", () => {
         );
       });
     } finally {
+      warnSpy.mockRestore();
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps bounded tails parseable when the transcript shrinks after stat", async () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-cli-state-"));
+    const sessionFile = path.join(
+      stateDir,
+      "agents",
+      "main",
+      "sessions",
+      "session-oversized-shrink.jsonl",
+    );
+    const warnSpy = vi.spyOn(cliBackendLog, "warn").mockImplementation(() => undefined);
+    fs.mkdirSync(path.dirname(sessionFile), { recursive: true });
+    fs.writeFileSync(
+      sessionFile,
+      [
+        JSON.stringify({
+          type: "session",
+          version: CURRENT_SESSION_VERSION,
+          id: "session-oversized-shrink",
+          timestamp: new Date(0).toISOString(),
+          cwd: stateDir,
+        }),
+        JSON.stringify({
+          type: "message",
+          id: "old",
+          parentId: null,
+          timestamp: new Date(1).toISOString(),
+          message: {
+            role: "user",
+            content: "x".repeat(MAX_CLI_SESSION_HISTORY_FILE_BYTES),
+            timestamp: 1,
+          },
+        }),
+        JSON.stringify({
+          type: "message",
+          id: "tail",
+          parentId: "old",
+          timestamp: new Date(2).toISOString(),
+          message: { role: "user", content: "tail history", timestamp: 2 },
+        }),
+      ].join("\n") + "\n",
+      "utf-8",
+    );
+    // Report a stale, larger size for the session file so the bounded
+    // positional read hits EOF early, as when the CLI compacts the transcript
+    // between the size probe and the read.
+    const realFspStat = fsp.stat;
+    const statSpy = vi.spyOn(fsp, "stat").mockImplementation(async (target, ...rest) => {
+      const stats = await realFspStat(target as Parameters<typeof realFspStat>[0], ...rest);
+      if (String(target).endsWith("session-oversized-shrink.jsonl")) {
+        return { ...stats, size: stats.size + 4096, isFile: () => true } as typeof stats;
+      }
+      return stats;
+    });
+
+    try {
+      await withCliSessionState(stateDir, async () => {
+        const history = await loadCliSessionHistoryMessages({
+          sessionId: "session-oversized-shrink",
+          sessionFile,
+          sessionKey: "agent:main:main",
+          agentId: "main",
+        });
+        expect(history).toHaveLength(1);
+        expectMessageFields(history[0], { role: "user", content: "tail history" });
+        expect(warnSpy).not.toHaveBeenCalledWith(
+          expect.stringContaining("cli session history parse failed"),
+        );
+      });
+    } finally {
+      statSpy.mockRestore();
       warnSpy.mockRestore();
       fs.rmSync(stateDir, { recursive: true, force: true });
     }

--- a/src/agents/cli-runner/session-history.test.ts
+++ b/src/agents/cli-runner/session-history.test.ts
@@ -534,11 +534,16 @@ describe("loadCliSessionHistoryMessages", () => {
     // between the size probe and the read.
     const realFspStat = fsp.stat;
     const statSpy = vi.spyOn(fsp, "stat").mockImplementation(async (target, ...rest) => {
-      const stats = await realFspStat(target as Parameters<typeof realFspStat>[0], ...rest);
       if (String(target).endsWith("session-oversized-shrink.jsonl")) {
-        return { ...stats, size: stats.size + 4096, isFile: () => true } as typeof stats;
+        const stats = await realFspStat(target as Parameters<typeof realFspStat>[0]);
+        // Proxy keeps the Stats prototype (isFile etc.) and only inflates the
+        // reported size past EOF; spreading a Stats instance would drop both.
+        return new Proxy(stats, {
+          get: (obj, prop, receiver) =>
+            prop === "size" ? obj.size + 4096 : Reflect.get(obj, prop, receiver),
+        });
       }
-      return stats;
+      return realFspStat(target as Parameters<typeof realFspStat>[0], ...rest);
     });
 
     try {

--- a/src/agents/cli-runner/session-history.test.ts
+++ b/src/agents/cli-runner/session-history.test.ts
@@ -4,7 +4,8 @@ import fsp from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { CURRENT_SESSION_VERSION } from "openclaw/plugin-sdk/agent-sessions";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import { withEnvAsync } from "../../test-utils/env.js";
 import { MAX_AGENT_HOOK_HISTORY_MESSAGES } from "../harness/hook-history.js";
 import { cliBackendLog } from "./log.js";
@@ -21,6 +22,7 @@ const MAX_CLI_SESSION_HISTORY_FILE_BYTES = 5 * 1024 * 1024;
 const MAX_CLI_SESSION_HISTORY_MESSAGES = MAX_AGENT_HOOK_HISTORY_MESSAGES;
 const MAX_CLI_SESSION_RESEED_HISTORY_CHARS = 12 * 1024;
 const MAX_AUTO_CLI_SESSION_RESEED_HISTORY_CHARS = 256 * 1024;
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 function createSessionTranscript(params: {
   rootDir: string;
@@ -458,7 +460,7 @@ describe("loadCliSessionHistoryMessages", () => {
   });
 
   it("uses the opened file size when the transcript shrinks after stat", async () => {
-    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-cli-state-"));
+    const stateDir = tempDirs.make("openclaw-cli-state-");
     const sessionFile = createOversizedSessionTranscript(stateDir, "session-oversized-shrink");
     const warnSpy = vi.spyOn(cliBackendLog, "warn").mockImplementation(() => undefined);
     // Report a stale size whose bounded-read offset is beyond the real EOF,
@@ -496,7 +498,6 @@ describe("loadCliSessionHistoryMessages", () => {
     } finally {
       statSpy.mockRestore();
       warnSpy.mockRestore();
-      fs.rmSync(stateDir, { recursive: true, force: true });
     }
   });
 

--- a/src/agents/cli-runner/session-history.test.ts
+++ b/src/agents/cli-runner/session-history.test.ts
@@ -457,13 +457,12 @@ describe("loadCliSessionHistoryMessages", () => {
     }
   });
 
-  it("keeps bounded tails parseable when the transcript shrinks after stat", async () => {
+  it("uses the opened file size when the transcript shrinks after stat", async () => {
     const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-cli-state-"));
     const sessionFile = createOversizedSessionTranscript(stateDir, "session-oversized-shrink");
     const warnSpy = vi.spyOn(cliBackendLog, "warn").mockImplementation(() => undefined);
-    // Report a stale, larger size for the session file so the bounded
-    // positional read hits EOF early, as when the CLI compacts the transcript
-    // between the size probe and the read.
+    // Report a stale size whose bounded-read offset is beyond the real EOF,
+    // as when the CLI compacts the transcript between the path stat and open.
     const realFspStat = fsp.stat;
     const statSpy = vi.spyOn(fsp, "stat").mockImplementation(async (target, ...rest) => {
       if (String(target).endsWith("session-oversized-shrink.jsonl")) {
@@ -472,7 +471,9 @@ describe("loadCliSessionHistoryMessages", () => {
         // reported size past EOF; spreading a Stats instance would drop both.
         return new Proxy(stats, {
           get: (obj, prop, receiver) =>
-            prop === "size" ? obj.size + 4096 : Reflect.get(obj, prop, receiver),
+            prop === "size"
+              ? obj.size + MAX_CLI_SESSION_HISTORY_FILE_BYTES + 4096
+              : Reflect.get(obj, prop, receiver),
         });
       }
       return realFspStat(target as Parameters<typeof realFspStat>[0], ...rest);

--- a/src/agents/cli-runner/session-history.ts
+++ b/src/agents/cli-runner/session-history.ts
@@ -17,6 +17,7 @@ import {
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { isPathInside } from "../../infra/path-guards.js";
+import { readLogWindowFully } from "../../logging/log-tail.js";
 import { resolveSessionAgentIds } from "../agent-scope.js";
 import {
   limitAgentHookHistoryMessages,
@@ -328,8 +329,11 @@ async function readBoundedCliSessionTranscript(
   const handle = await fsp.open(filePath, "r");
   try {
     const buffer = Buffer.alloc(MAX_CLI_SESSION_HISTORY_FILE_BYTES);
-    await handle.read(buffer, 0, buffer.length, fileSize - buffer.length);
-    const tail = buffer.toString("utf-8");
+    // Positional reads may return short (or hit EOF early when the file
+    // shrinks after stat); decode only the bytes actually read so trailing
+    // NUL padding never corrupts the JSONL tail.
+    const bytesRead = await readLogWindowFully(handle, buffer, fileSize - buffer.length);
+    const tail = buffer.subarray(0, bytesRead).toString("utf-8");
     const firstLineEnd = tail.indexOf("\n");
     const completeTail = firstLineEnd >= 0 ? tail.slice(firstLineEnd + 1) : "";
     const headerLine = await readCliSessionHeaderLine(filePath);

--- a/src/agents/cli-runner/session-history.ts
+++ b/src/agents/cli-runner/session-history.ts
@@ -16,8 +16,8 @@ import {
 } from "../../config/sessions/transcript-tree.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { formatErrorMessage } from "../../infra/errors.js";
+import { readFileWindowFully } from "../../infra/file-read.js";
 import { isPathInside } from "../../infra/path-guards.js";
-import { readLogWindowFully } from "../../logging/log-tail.js";
 import { resolveSessionAgentIds } from "../agent-scope.js";
 import {
   limitAgentHookHistoryMessages,
@@ -332,7 +332,7 @@ async function readBoundedCliSessionTranscript(
     // Positional reads may return short (or hit EOF early when the file
     // shrinks after stat); decode only the bytes actually read so trailing
     // NUL padding never corrupts the JSONL tail.
-    const bytesRead = await readLogWindowFully(handle, buffer, fileSize - buffer.length);
+    const bytesRead = await readFileWindowFully(handle, buffer, fileSize - buffer.length);
     const tail = buffer.subarray(0, bytesRead).toString("utf-8");
     const firstLineEnd = tail.indexOf("\n");
     const completeTail = firstLineEnd >= 0 ? tail.slice(firstLineEnd + 1) : "";

--- a/src/agents/cli-runner/session-history.ts
+++ b/src/agents/cli-runner/session-history.ts
@@ -317,23 +317,32 @@ async function readCliSessionHeaderLine(filePath: string): Promise<string | unde
 
 async function readBoundedCliSessionTranscript(
   filePath: string,
-  fileSize: number,
 ): Promise<{ content: string; truncated: boolean }> {
-  if (fileSize <= MAX_CLI_SESSION_HISTORY_FILE_BYTES) {
-    return { content: await fsp.readFile(filePath, "utf-8"), truncated: false };
-  }
-
-  cliBackendLog.warn(
-    `cli session history truncated to last ${MAX_CLI_SESSION_HISTORY_FILE_BYTES} bytes: ${filePath}`,
-  );
   const handle = await fsp.open(filePath, "r");
   try {
-    const buffer = Buffer.alloc(MAX_CLI_SESSION_HISTORY_FILE_BYTES);
-    // Positional reads may return short (or hit EOF early when the file
-    // shrinks after stat); decode only the bytes actually read so trailing
-    // NUL padding never corrupts the JSONL tail.
-    const bytesRead = await readFileWindowFully(handle, buffer, fileSize - buffer.length);
+    let buffer = Buffer.alloc(0);
+    let bytesRead = 0;
+    let position = 0;
+    // Compaction can shrink the open file between stat and read. Retry from
+    // the new tail after EOF so a stale offset cannot discard valid history.
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      const currentSize = (await handle.stat()).size;
+      const readLength = Math.min(currentSize, MAX_CLI_SESSION_HISTORY_FILE_BYTES);
+      position = Math.max(0, currentSize - readLength);
+      buffer = Buffer.alloc(readLength);
+      bytesRead = await readFileWindowFully(handle, buffer, position);
+      if (bytesRead === buffer.length || position === 0) {
+        break;
+      }
+    }
     const tail = buffer.subarray(0, bytesRead).toString("utf-8");
+    if (position === 0) {
+      return { content: tail, truncated: false };
+    }
+
+    cliBackendLog.warn(
+      `cli session history truncated to last ${MAX_CLI_SESSION_HISTORY_FILE_BYTES} bytes: ${filePath}`,
+    );
     const firstLineEnd = tail.indexOf("\n");
     const completeTail = firstLineEnd >= 0 ? tail.slice(firstLineEnd + 1) : "";
     const headerLine = await readCliSessionHeaderLine(filePath);
@@ -453,7 +462,7 @@ async function loadCliSessionEntries(params: {
     if (!stat.isFile()) {
       return [];
     }
-    const transcript = await readBoundedCliSessionTranscript(realSessionFile, stat.size);
+    const transcript = await readBoundedCliSessionTranscript(realSessionFile);
     const entries = parseCliSessionEntries(transcript.content);
     if (!entries) {
       return [];


### PR DESCRIPTION
## What Problem This Solves

CLI backend sessions can lose their restored history when an oversized transcript shrinks around its bounded tail read. The old reader selected its positional offset from a pre-open stat, performed one read, ignored `bytesRead`, and decoded the entire allocation. A stale offset could land beyond EOF; a short read could append NUL bytes. Either case could make strict JSONL parsing discard otherwise valid history.

## Why This Change Was Made

The reader now derives the bounded window from the opened file handle, uses the shared `readFileWindowFully` short-read loop, decodes only the bytes actually read, and retries once from the resized tail if the file shrinks again after open. The 5 MiB cap and incomplete-first-line behavior remain unchanged.

Nearby cleanup extracts one oversized-transcript test fixture and uses the shared auto-cleanup temp-directory tracker.

## User Impact

CLI backend sessions with oversized transcripts keep their restored history during concurrent compaction or short reads instead of silently starting from scratch.

## Evidence

- Regression: inflates the pre-open stat beyond the real opened transcript size and proves the valid tail survives without a parse warning.
- Focused test: `src/agents/cli-runner/session-history.test.ts` — 27/27 passed.
- Exact-head Blacksmith changed gate passed on `471a5004e8823`: formatting, core and core-test typechecks, lint, storage guards, import-cycle checks, and the test-temp report.
- Blacksmith proof: https://github.com/openclaw/openclaw/actions/runs/29493145602
- Fresh exact-branch Autoreview: clean, confidence 0.96.

AI-assisted: built with Codex
