### PR TITLE
chore: speed PR operation lock tests

### DIFF
--- a/test/scripts/pr-operation-lock.test.ts
+++ b/test/scripts/pr-operation-lock.test.ts
@@ -11,16 +11,19 @@ import {
   cpSync,
   existsSync,
   mkdirSync,
+  mkdtempSync,
   readFileSync,
   realpathSync,
+  rmSync,
   symlinkSync,
   unlinkSync,
   writeFileSync,
 } from "node:fs";
+import { tmpdir } from "node:os";
 import { delimiter, dirname, join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { expectDefined } from "@openclaw/normalization-core";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
@@ -33,6 +36,7 @@ const worktreeScript = join(repoRoot, "scripts/pr-lib/worktree.sh");
 const lockRef = "refs/openclaw/pr-operation-locks/42";
 const detachedChildren = new WeakSet<ChildProcess>();
 const goneProcessGroups = new Set<number>();
+let templateRepo = "";
 
 // Direct preload affects only the supervisor; operation fixtures keep real clocks.
 // The source assertions below pin the production safety durations being accelerated.
@@ -62,18 +66,33 @@ function spawnDetached(command: string, args: readonly string[], options: SpawnO
   return child;
 }
 
-function createRepo(nestedName?: string) {
-  const tempRoot = tempDirs.make("openclaw-pr-operation-lock-");
-  const dir = nestedName ? join(tempRoot, nestedName) : tempRoot;
-  if (nestedName) {
-    mkdirSync(dir);
-  }
+function createTemplateRepo() {
+  const dir = mkdtempSync(join(tmpdir(), "openclaw-pr-operation-lock-template-"));
   execFileSync("git", ["init", "-q", "-b", "main"], { cwd: dir });
   execFileSync("git", ["config", "user.name", "OpenClaw Test"], { cwd: dir });
   execFileSync("git", ["config", "user.email", "test@openclaw.invalid"], { cwd: dir });
   writeFileSync(join(dir, "base.txt"), "base\n");
   execFileSync("git", ["add", "base.txt"], { cwd: dir });
   execFileSync("git", ["commit", "-qm", "base"], { cwd: dir });
+  return dir;
+}
+
+beforeAll(() => {
+  templateRepo = createTemplateRepo();
+});
+
+afterAll(() => {
+  rmSync(templateRepo, { force: true, recursive: true });
+});
+
+function createRepo(nestedName?: string) {
+  const tempRoot = tempDirs.make("openclaw-pr-operation-lock-");
+  const dir = nestedName ? join(tempRoot, nestedName) : tempRoot;
+  if (nestedName) {
+    mkdirSync(dir);
+  }
+  // Preserve per-test Git isolation without paying five setup processes per fixture.
+  cpSync(templateRepo, dir, { recursive: true });
   return dir;
 }
 


### PR DESCRIPTION
## What Problem This Solves

The PR operation-lock test file was the fourth-slowest file in the tooling suite because 46 fixtures each launched five Git setup processes.

## Why This Change Was Made

Prepare one committed repository template per test file, then copy it into each fixture. Every test still receives an independent working tree and `.git` directory; all 49 behavioral cases remain intact.

## User Impact

No runtime behavior changes. Maintainer feedback from this focused suite is about 19% faster.

## Evidence

- Same Blacksmith Testbox before: 49/49 passed; Vitest 7.22s, tests 7.05s.
- Same Blacksmith Testbox after: 49/49 passed; Vitest 5.83s, tests 5.70s.
- Confirmed 19.3% lower Vitest duration and 19.1% lower test time.
- Focused proof: https://github.com/openclaw/openclaw/actions/runs/29394329070
- `corepack pnpm check:changed`: passed on Testbox `tbx_01kxj860z4zqy5v82gj8fm4580`.
- Changed-gate proof: https://github.com/openclaw/openclaw/actions/runs/29394992075
- `autoreview --mode local`: clean, confidence 0.97.
- Non-visual test-only change; screenshots not applicable.

AI-assisted. I understand the fixture lifecycle and verified the preserved isolation contract.
