### PR TITLE
fix(plugins): unwrap npm view array response in normalizeNpmViewMetadata

### DIFF
--- a/src/infra/install-source-utils.test.ts
+++ b/src/infra/install-source-utils.test.ts
@@ -6,6 +6,7 @@ import { createTrackedTempDirs } from "../test-utils/tracked-temp-dirs.js";
 import {
   packNpmSpecToArchive,
   resolveArchiveSourcePath,
+  resolveNpmSpecMetadata,
   withTempDir,
 } from "./install-source-utils.js";
 
@@ -353,6 +354,79 @@ describe("packNpmSpecToArchive", () => {
     expect(result).toEqual({
       ok: false,
       error: "npm pack failed: network timeout",
+    });
+  });
+});
+
+describe("resolveNpmSpecMetadata", () => {
+  it("unwraps single-element npm view --json array output", async () => {
+    runCommandWithTimeoutMock.mockResolvedValue({
+      stdout: JSON.stringify([
+        {
+          name: "openclaw-plugin",
+          version: "1.2.3",
+          "dist.integrity": "sha512-test-integrity",
+          "dist.shasum": "abc123",
+        },
+      ]),
+      stderr: "",
+      code: 0,
+      signal: null,
+      killed: false,
+    });
+
+    const result = await resolveNpmSpecMetadata({ spec: "openclaw-plugin" });
+
+    expect(result).toEqual({
+      ok: true,
+      metadata: {
+        name: "openclaw-plugin",
+        version: "1.2.3",
+        resolvedSpec: "openclaw-plugin@1.2.3",
+        integrity: "sha512-test-integrity",
+        shasum: "abc123",
+      },
+    });
+  });
+
+  it("rejects empty array output as incomplete metadata", async () => {
+    runCommandWithTimeoutMock.mockResolvedValue({
+      stdout: "[]",
+      stderr: "",
+      code: 0,
+      signal: null,
+      killed: false,
+    });
+
+    const result = await resolveNpmSpecMetadata({ spec: "openclaw-plugin" });
+
+    expect(result).toEqual({
+      ok: false,
+      error: "npm view produced incomplete package metadata",
+    });
+  });
+
+  it("handles non-array single-object output (backward compat)", async () => {
+    runCommandWithTimeoutMock.mockResolvedValue({
+      stdout: JSON.stringify({
+        name: "openclaw-plugin",
+        version: "1.2.3",
+      }),
+      stderr: "",
+      code: 0,
+      signal: null,
+      killed: false,
+    });
+
+    const result = await resolveNpmSpecMetadata({ spec: "openclaw-plugin" });
+
+    expect(result).toEqual({
+      ok: true,
+      metadata: {
+        name: "openclaw-plugin",
+        version: "1.2.3",
+        resolvedSpec: "openclaw-plugin@1.2.3",
+      },
     });
   });
 });

--- a/src/infra/install-source-utils.ts
+++ b/src/infra/install-source-utils.ts
@@ -57,10 +57,12 @@ export function createNpmMetadataEnv(
 }
 
 function normalizeNpmViewMetadata(value: unknown): NpmSpecResolution | null {
-  if (!value || typeof value !== "object") {
+  // npm view --json always returns an array of entries; unwrap single-element results
+  const entry = Array.isArray(value) ? value[0] : value;
+  if (!entry || typeof entry !== "object") {
     return null;
   }
-  const rec = value as Record<string, unknown>;
+  const rec = entry as Record<string, unknown>;
   const name = normalizeOptionalString(rec.name);
   const version = normalizeOptionalString(rec.version);
   const resolvedSpec = name && version ? `${name}@${version}` : undefined;


### PR DESCRIPTION
## Summary

`npm view --json` always returns an array of entries even for single package queries, but `normalizeNpmViewMetadata` treated the parsed value as a plain object. This caused every plugin install/update/repair operation to fail with "npm view produced incomplete package metadata".

## Fix

Add array unwrap logic matching the existing pattern used by `parseNpmPackJsonOutput` in the same file. When `npm view --json` returns `[{...}]`, extract the first element before normalization.

## Verification

- [x] Existing tests pass (19/19)
- [x] Added test cases for array output, empty array, and backward-compatible single-object output
- [x] `pnpm test src/infra/install-source-utils.test.ts` passes

## References

Fixes #107222

🤖 Generated with [Claude Code](https://claude.com/claude-code)