### PR TITLE
fix(macos): silence Xcode 27 source warnings

### DIFF
--- a/apps/macos/Sources/OpenClaw/DashboardLinkBrowserTabBar.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardLinkBrowserTabBar.swift
@@ -182,11 +182,17 @@ private final class DashboardLinkBrowserTabItemView: NSView {
 
     override func draw(_ dirtyRect: NSRect) {
         super.draw(dirtyRect)
+        // SDK 27 restores AppKit's "Color" suffix; older Swift importers expose
+        // the same API as quinaryLabel.
+        #if compiler(>=6.4)
+        let hoverColor = NSColor.quinaryLabelColor
+        #else
+        let hoverColor = NSColor.quinaryLabel
+        #endif
         let color: NSColor? = if self.isActive {
             .quaternaryLabelColor
         } else if self.isHovered {
-            // macOS 14+ spells this without the "Color" suffix; quinaryLabelColor does not exist.
-            .quinaryLabel
+            hoverColor
         } else {
             nil
         }

--- a/apps/macos/Sources/OpenClaw/DockIconManager.swift
+++ b/apps/macos/Sources/OpenClaw/DockIconManager.swift
@@ -58,7 +58,7 @@ final class DockIconManager: NSObject, @unchecked Sendable {
     }
 
     private func setupObservers() {
-        Task { @MainActor in
+        Task { @MainActor [self] in
             guard let app = NSApp else {
                 self.logger.warning("NSApp not ready, delaying Dock observers")
                 try? await Task.sleep(for: .milliseconds(200))

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSpeechController.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSpeechController.swift
@@ -227,7 +227,7 @@ public final class OpenClawChatSpeechController {
 /// Whole-clip playback for gateway-rendered container audio. File metadata
 /// helps AVAudioPlayer parse clips whose type is not obvious from the bytes.
 @MainActor
-final class ChatSpeechClipPlayer: NSObject, ChatSpeechClipPlaying, @preconcurrency AVAudioPlayerDelegate {
+final class ChatSpeechClipPlayer: NSObject, ChatSpeechClipPlaying {
     private var player: AVAudioPlayer?
     private var continuation: CheckedContinuation<Bool, Never>?
 
@@ -275,6 +275,14 @@ final class ChatSpeechClipPlayer: NSObject, ChatSpeechClipPlaying, @preconcurren
         continuation?.resume(returning: finished)
     }
 }
+
+// SDK 27 imports AVAudioPlayerDelegate with compatible isolation. Older SDKs
+// still need the preconcurrency bridge for this main-actor implementation.
+#if compiler(>=6.4)
+extension ChatSpeechClipPlayer: AVAudioPlayerDelegate {}
+#else
+extension ChatSpeechClipPlayer: @preconcurrency AVAudioPlayerDelegate {}
+#endif
 
 /// On-device fallback voice via AVSpeechSynthesizer.
 @MainActor

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/CameraAuthorization.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/CameraAuthorization.swift
@@ -8,11 +8,19 @@ public enum CameraAuthorization {
         case .authorized:
             return true
         case .notDetermined:
+            #if compiler(>=6.4)
+            return await withCheckedContinuation { cont in
+                AVCaptureDevice.requestAccess(for: mediaType) { granted in
+                    cont.resume(returning: granted)
+                }
+            }
+            #else
             return await withCheckedContinuation(isolation: nil) { cont in
                 AVCaptureDevice.requestAccess(for: mediaType) { granted in
                     cont.resume(returning: granted)
                 }
             }
+            #endif
         case .denied, .restricted:
             return false
         @unknown default:

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/DeviceIdentity.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/DeviceIdentity.swift
@@ -196,6 +196,16 @@ public enum DeviceIdentityStore {
         self.loadOrCreate(profile: .primary)
     }
 
+    #if compiler(>=6.4)
+    static func withStateDirectory<T>(
+        _ url: URL,
+        operation: nonisolated(nonsending) () async throws -> T) async rethrows -> T
+    {
+        try await DeviceIdentityPaths.$scopedStateDirURL.withValue(
+            url,
+            operation: operation)
+    }
+    #else
     static func withStateDirectory<T>(
         _ url: URL,
         operation: () async throws -> T,
@@ -206,6 +216,7 @@ public enum DeviceIdentityStore {
             operation: operation,
             isolation: isolation)
     }
+    #endif
 
     public static func loadOrCreate(profile: GatewayDeviceIdentityProfile) -> DeviceIdentity {
         self.loadOrCreate(

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayNodeSession.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayNodeSession.swift
@@ -1316,7 +1316,7 @@ extension GatewayNodeSession {
         }
 
         let receiptID = UUID()
-        let task = Task {
+        let task = Task { [self] in
             await Self.invokeWithTimeout(
                 request: request,
                 timeoutMs: timeoutMs,

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/TalkBufferedAudioPlayer.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/TalkBufferedAudioPlayer.swift
@@ -10,7 +10,7 @@ import OSLog
 /// silently failing playback can never hang the talk loop. Shared by the iOS
 /// and macOS talk runtimes.
 @MainActor
-public final class TalkBufferedAudioPlayer: NSObject, @preconcurrency AVAudioPlayerDelegate {
+public final class TalkBufferedAudioPlayer: NSObject {
     public static let shared = TalkBufferedAudioPlayer()
 
     override public init() {
@@ -168,4 +168,12 @@ public final class TalkBufferedAudioPlayer: NSObject, @preconcurrency AVAudioPla
         })
     }
 }
+
+// SDK 27 imports AVAudioPlayerDelegate with compatible isolation. Older SDKs
+// still need the preconcurrency bridge for this main-actor implementation.
+#if compiler(>=6.4)
+extension TalkBufferedAudioPlayer: AVAudioPlayerDelegate {}
+#else
+extension TalkBufferedAudioPlayer: @preconcurrency AVAudioPlayerDelegate {}
+#endif
 #endif


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where developers building the macOS app with Xcode 27 would receive deprecation, importer, and capture-semantics warnings from OpenClaw-owned Swift sources.

## Why This Change Was Made

The Swift 6.4-specific APIs and names are selected behind compiler gates, preserving the existing Swift 6.3 paths. Task captures are made explicit without changing their existing ownership semantics. This intentionally does not suppress the separate AXorcist/Commander package-identity warning, which must be corrected by the owning dependency.

## User Impact

No runtime behavior changes. Developers get a quieter Xcode 27 build, while the currently supported older Swift toolchain remains source-compatible.

AI-assisted: yes. I reviewed the resulting code and understand the compiler-gated behavior.

## Evidence

- Xcode 27 / Swift 6.4: `swift build -c debug --product OpenClaw --arch arm64` completed successfully on clawmac. No OpenClaw-owned source warnings remained; only the known AXorcist dependency-identity warning was emitted.
- SwiftFormat 0.62.1: all 7 touched Swift files pass the repository configuration (`0/7 files require formatting`).
- `git diff --check` passes.
- Fresh structured autoreview against `origin/main`: clean, no accepted/actionable findings (confidence 0.93).
