### PR TITLE
fix(plugins): clone registration record metadata for transactional rollback isolation

### DIFF
--- a/src/plugins/loader-channel-runtime.ts
+++ b/src/plugins/loader-channel-runtime.ts
@@ -254,7 +254,10 @@ export function loadSetupRuntimeChannelCandidate(params: {
     }
   }
   if (registrationPlan.mode === "setup-runtime" && mergedSetupRegistration.registerSetupRuntime) {
-    const transaction = createPluginRegistrationTransaction({ registry: registryBuilder.registry });
+    const transaction = createPluginRegistrationTransaction({
+      registry: registryBuilder.registry,
+      activeRecord: record,
+    });
     try {
       runPluginRegisterSync(
         (registrationApi) => mergedSetupRegistration.registerSetupRuntime?.(registrationApi),

--- a/src/plugins/loader-cli-registry.ts
+++ b/src/plugins/loader-cli-registry.ts
@@ -330,7 +330,7 @@ export async function loadOpenClawPluginCliRegistry(
         registerCli: (registrar, opts) => registerCli(record, registrar, opts),
       },
     });
-    const transaction = createPluginRegistrationTransaction({ registry });
+    const transaction = createPluginRegistrationTransaction({ registry, activeRecord: record });
     try {
       withProfile({ pluginId: record.id, source: record.source }, "cli-metadata:register", () =>
         runPluginRegisterSync(register, api),

--- a/src/plugins/loader-runtime-candidate.ts
+++ b/src/plugins/loader-runtime-candidate.ts
@@ -529,6 +529,7 @@ export function loadRuntimePluginCandidate(params: {
   });
   const transaction = createPluginRegistrationTransaction({
     registry,
+    activeRecord: record,
     rollbackGlobalSideEffects: () =>
       params.registryBuilder.rollbackPluginGlobalSideEffects(record.id),
   });

--- a/src/plugins/plugin-graceful-init-failure.test.ts
+++ b/src/plugins/plugin-graceful-init-failure.test.ts
@@ -137,6 +137,40 @@ describe("graceful plugin initialization failure", () => {
     expect(failed.failedAt?.getTime()).toBeLessThanOrEqual(after.getTime());
   });
 
+  it("rolls back partial metadata without breaking an earlier class-backed service", async () => {
+    const stable = writePlugin({
+      id: "a-stable-service-plugin",
+      body: `class StableService {
+        constructor() { this.id = "stable-service"; }
+        start() {}
+        ping() { return "still-alive"; }
+      }
+      module.exports = { id: "a-stable-service-plugin", register(api) {
+        api.registerService(new StableService());
+      } };`,
+    });
+    const failing = writePlugin({
+      id: "z-partial-register-failure",
+      body: `module.exports = { id: "z-partial-register-failure", register(api) {
+        api.registerService({ id: "failed-service", start() {} });
+        api.registerHttpRoute({ path: "/failed", auth: "plugin", handler: async () => true });
+        throw new Error("fail after partial registration");
+      } };`,
+    });
+
+    const registry = await loadPlugins([stable.file, failing.file]);
+    const failed = requirePluginEntry(registry, "z-partial-register-failure");
+    const stableService = registry.services.find((entry) => entry.service.id === "stable-service")
+      ?.service as { ping?: () => string } | undefined;
+
+    expect(failed.status).toBe("error");
+    expect(failed.services).toEqual([]);
+    expect(failed.httpRoutes).toBe(0);
+    expect(registry.services.map((entry) => entry.service.id)).toEqual(["stable-service"]);
+    expect(registry.httpRoutes).toEqual([]);
+    expect(stableService?.ping?.()).toBe("still-alive");
+  });
+
   it("records validation failures before register", async () => {
     const plugin = writePlugin({
       id: "missing-register",

--- a/src/plugins/plugin-registration-transaction.test.ts
+++ b/src/plugins/plugin-registration-transaction.test.ts
@@ -84,6 +84,103 @@ describe("plugin registration transaction", () => {
     });
   });
 
+  it("deep-clones nested objects in arrays so mutations do not leak through rollback (#106647)", () => {
+    const registry = createEmptyPluginRegistry();
+    registry.plugins.push({
+      id: "test-plugin",
+      name: "Test Plugin",
+      source: "test-source",
+      origin: "global" as const,
+      enabled: true,
+      status: "loaded" as const,
+      toolNames: [],
+      hookNames: [],
+      channelIds: [],
+      cliBackendIds: [],
+      providerIds: [],
+      embeddingProviderIds: [],
+      speechProviderIds: [],
+      realtimeTranscriptionProviderIds: [],
+      realtimeVoiceProviderIds: [],
+      mediaUnderstandingProviderIds: [],
+      transcriptSourceProviderIds: [],
+      imageGenerationProviderIds: [],
+      videoGenerationProviderIds: [],
+      musicGenerationProviderIds: [],
+      webFetchProviderIds: [],
+      webSearchProviderIds: [],
+      migrationProviderIds: [],
+      memoryEmbeddingProviderIds: [],
+      agentHarnessIds: [],
+      cliCommands: [],
+      services: [],
+      gatewayDiscoveryServiceIds: [],
+      commands: [],
+      httpRoutes: 0,
+      hookCount: 0,
+      configSchema: false,
+    });
+
+    const transaction = createPluginRegistrationTransaction({ registry });
+
+    // Mutate a nested property on the PluginRecord that was captured in the snapshot
+    registry.plugins[0]!.status = "error";
+    registry.plugins[0]!.enabled = false;
+
+    transaction.rollback();
+
+    // After rollback, the original values should be restored
+    expect(registry.plugins[0]!.status).toBe("loaded");
+    expect(registry.plugins[0]!.enabled).toBe(true);
+  });
+
+  it("deep-clones Map values so nested mutations do not leak through rollback (#106647)", () => {
+    const registry = createEmptyPluginRegistry();
+    registry.workerProviders.set("test-worker", {
+      pluginId: "test-plugin",
+      pluginName: "Test",
+      provider: { id: "worker-1" } as import("./types.js").WorkerProvider,
+      source: "test-source",
+    });
+
+    const transaction = createPluginRegistrationTransaction({ registry });
+
+    // Mutate a property on the Map value
+    const entry = registry.workerProviders.get("test-worker")!;
+    entry.pluginName = "Mutated";
+
+    transaction.rollback();
+
+    // After rollback, the original value should be restored
+    expect(registry.workerProviders.get("test-worker")!.pluginName).toBe("Test");
+  });
+
+  it("preserves functions by reference in cloned objects (#106647)", () => {
+    const registry = createEmptyPluginRegistry();
+    const myResolver = () => "resolved";
+    registry.hostedMediaResolvers.push({
+      pluginId: "test-plugin",
+      resolver: myResolver,
+      source: "test-source",
+    });
+
+    const transaction = createPluginRegistrationTransaction({ registry });
+
+    // Push a new entry during the transaction
+    registry.hostedMediaResolvers.push({
+      pluginId: "another-plugin",
+      resolver: () => "another",
+      source: "another-source",
+    });
+
+    transaction.rollback();
+
+    // After rollback, the array should be restored to the snapshot
+    expect(registry.hostedMediaResolvers).toHaveLength(1);
+    // The original resolver function reference should be preserved
+    expect(registry.hostedMediaResolvers[0]!.resolver).toBe(myResolver);
+  });
+
   it("keeps snapshot registry writes while restoring globals for non-activating commits", () => {
     const registry = createEmptyPluginRegistry();
     const activePromptBuilder = () => ["active"];

--- a/src/plugins/plugin-registration-transaction.test.ts
+++ b/src/plugins/plugin-registration-transaction.test.ts
@@ -84,7 +84,7 @@ describe("plugin registration transaction", () => {
     });
   });
 
-  it("deep-clones nested objects in arrays so mutations do not leak through rollback (#106647)", () => {
+  it("isolates PluginRecord metadata mutations in arrays through shallow record cloning (#106647)", () => {
     const registry = createEmptyPluginRegistry();
     registry.plugins.push({
       id: "test-plugin",
@@ -134,7 +134,7 @@ describe("plugin registration transaction", () => {
     expect(registry.plugins[0]!.enabled).toBe(true);
   });
 
-  it("deep-clones Map values so nested mutations do not leak through rollback (#106647)", () => {
+  it("isolates Map entry metadata mutations through shallow record cloning (#106647)", () => {
     const registry = createEmptyPluginRegistry();
     registry.workerProviders.set("test-worker", {
       pluginId: "test-plugin",
@@ -179,6 +179,46 @@ describe("plugin registration transaction", () => {
     expect(registry.hostedMediaResolvers).toHaveLength(1);
     // The original resolver function reference should be preserved
     expect(registry.hostedMediaResolvers[0]!.resolver).toBe(myResolver);
+  });
+
+  it("preserves class instances and their prototypes by reference in cloned records (#106647)", () => {
+    const registry = createEmptyPluginRegistry();
+
+    class TestProvider {
+      id = "provider-1";
+      label = "Test Provider";
+      chat(model: string) {
+        return `chat-${model}`;
+      }
+      listModels() {
+        return ["model-a"];
+      }
+      start() {}
+      stop() {}
+    }
+    const providerInstance = new TestProvider();
+
+    registry.providers.push({
+      pluginId: "test-plugin",
+      pluginName: "Test",
+      provider: providerInstance as import("./types.js").ProviderPlugin,
+      source: "test-source",
+    });
+
+    const transaction = createPluginRegistrationTransaction({ registry });
+
+    // Mutate metadata during transaction
+    registry.providers[0]!.pluginName = "Mutated";
+
+    transaction.rollback();
+
+    // After rollback, metadata is restored
+    expect(registry.providers[0]!.pluginName).toBe("Test");
+    // The provider instance is the same object reference (not a plain-object copy)
+    expect(registry.providers[0]!.provider).toBe(providerInstance);
+    // Class prototype is intact — methods are callable
+    expect(registry.providers[0]!.provider.chat("gpt-5")).toBe("chat-gpt-5");
+    expect(Object.getPrototypeOf(registry.providers[0]!.provider)).toBe(TestProvider.prototype);
   });
 
   it("keeps snapshot registry writes while restoring globals for non-activating commits", () => {

--- a/src/plugins/plugin-registration-transaction.test.ts
+++ b/src/plugins/plugin-registration-transaction.test.ts
@@ -322,12 +322,95 @@ describe("plugin registration transaction", () => {
     expect(rollbackSideEffects).toHaveBeenCalledOnce();
   });
 
-  it("restores the active PluginRecord's array fields after a failed registration (loader #106647)", () => {
+  it("restores the active PluginRecord's arrays and scalars after a failed registration (loader #106647)", () => {
     const registry = createEmptyPluginRegistry();
 
     // Simulate the loader pattern: record exists before transaction,
-    // register() mutates its id-collection arrays and the registry,
-    // then loader pushes record to registry.plugins.
+    // register() mutates its id-collection arrays, scalars, and the registry.
+    const record = {
+      id: "test-plugin",
+      name: "Test Plugin",
+      source: "test-source",
+      origin: "global" as const,
+      enabled: true,
+      status: "loaded" as const,
+      toolNames: [] as string[],
+      hookNames: [] as string[],
+      providerIds: [] as string[],
+      channelIds: [] as string[],
+      cliBackendIds: [] as string[],
+      embeddingProviderIds: [] as string[],
+      speechProviderIds: [] as string[],
+      realtimeTranscriptionProviderIds: [] as string[],
+      realtimeVoiceProviderIds: [] as string[],
+      mediaUnderstandingProviderIds: [] as string[],
+      transcriptSourceProviderIds: [] as string[],
+      imageGenerationProviderIds: [] as string[],
+      videoGenerationProviderIds: [] as string[],
+      musicGenerationProviderIds: [] as string[],
+      webFetchProviderIds: [] as string[],
+      webSearchProviderIds: [] as string[],
+      migrationProviderIds: [] as string[],
+      memoryEmbeddingProviderIds: [] as string[],
+      agentHarnessIds: [] as string[],
+      cliCommands: [] as string[],
+      services: [] as string[],
+      gatewayDiscoveryServiceIds: [] as string[],
+      commands: [] as string[],
+      httpRoutes: 0,
+      hookCount: 0,
+      configSchema: false,
+      memorySlotSelected: false,
+    };
+
+    const transaction = createPluginRegistrationTransaction({
+      registry,
+      activeRecord: record,
+    });
+
+    // During register(), plugin API mutates record arrays, scalars, and the registry
+    record.toolNames.push("bad-tool");
+    record.hookNames.push("bad-hook");
+    record.providerIds.push("bad-provider");
+    record.httpRoutes = 5;
+    record.hookCount = 3;
+    record.configSchema = true;
+    record.memorySlotSelected = true;
+    record.enabled = false;
+    registry.tools.push({
+      pluginId: "test-plugin",
+      factory: () => ({}) as unknown as import("./types.js").AnyAgentTool,
+      names: ["bad-tool"],
+      optional: false,
+      source: "test-source",
+    });
+
+    // Loader pushes record to registry.plugins (loader-runtime-candidate L505)
+    registry.plugins.push(record);
+
+    // Plugin fails, loader calls rollback (L509)
+    transaction.rollback();
+
+    // Registry snapshot correctly removes the record from plugins
+    expect(registry.plugins).toHaveLength(0);
+    expect(registry.tools).toHaveLength(0);
+
+    // Active record's array fields are restored
+    expect(record.toolNames).toEqual([]);
+    expect(record.hookNames).toEqual([]);
+    expect(record.providerIds).toEqual([]);
+
+    // Active record's scalar fields are restored
+    expect(record.httpRoutes).toBe(0);
+    expect(record.hookCount).toBe(0);
+    expect(record.configSchema).toBe(false);
+    expect(record.memorySlotSelected).toBe(false);
+    expect(record.enabled).toBe(true);
+  });
+
+  it("preserves runtime object identity on the active PluginRecord through rollback (#106647)", () => {
+    const registry = createEmptyPluginRegistry();
+
     const record = {
       id: "test-plugin",
       name: "Test Plugin",
@@ -363,38 +446,27 @@ describe("plugin registration transaction", () => {
       configSchema: false,
     };
 
+    // Plugin-owned runtime objects on the record must survive rollback by reference
+    const configUiHints = { myHint: { kind: "select" } };
+    (record as Record<string, unknown>)["configUiHints"] = configUiHints;
+
     const transaction = createPluginRegistrationTransaction({
       registry,
       activeRecord: record,
     });
 
-    // During register(), plugin API mutates record arrays and the registry
-    record.toolNames.push("bad-tool");
-    record.hookNames.push("bad-hook");
-    record.providerIds.push("bad-provider");
-    registry.tools.push({
-      pluginId: "test-plugin",
-      factory: () => ({}) as unknown as import("./types.js").AnyAgentTool,
-      names: ["bad-tool"],
-      optional: false,
-      source: "test-source",
-    });
+    // Mutate scalars and arrays during register()
+    record.httpRoutes = 5;
+    record.toolNames.push("tool-1");
 
-    // Loader pushes record to registry.plugins (loader-runtime-candidate L505)
-    registry.plugins.push(record);
-
-    // Plugin fails, loader calls rollback (L509)
     transaction.rollback();
 
-    // Registry snapshot correctly removes the record from plugins
-    expect(registry.plugins).toHaveLength(0);
-    expect(registry.tools).toHaveLength(0);
-
-    // Active record's array fields are restored — recordPluginError can safely
-    // re-push the record without stale ids from the failed registration.
+    // Scalars and arrays restored
+    expect(record.httpRoutes).toBe(0);
     expect(record.toolNames).toEqual([]);
-    expect(record.hookNames).toEqual([]);
-    expect(record.providerIds).toEqual([]);
+
+    // Runtime object preserved by reference identity
+    expect((record as Record<string, unknown>)["configUiHints"]).toBe(configUiHints);
   });
 
   it("keeps snapshot registry writes while restoring globals for non-activating commits", () => {

--- a/src/plugins/plugin-registration-transaction.test.ts
+++ b/src/plugins/plugin-registration-transaction.test.ts
@@ -201,7 +201,7 @@ describe("plugin registration transaction", () => {
     registry.providers.push({
       pluginId: "test-plugin",
       pluginName: "Test",
-      provider: providerInstance as import("./types.js").ProviderPlugin,
+      provider: providerInstance as unknown as import("./types.js").ProviderPlugin,
       source: "test-source",
     });
 
@@ -217,8 +217,8 @@ describe("plugin registration transaction", () => {
     // The provider instance is the same object reference (not a plain-object copy)
     expect(registry.providers[0]!.provider).toBe(providerInstance);
     // Class prototype is intact — methods are callable
-    expect(registry.providers[0]!.provider.chat("gpt-5")).toBe("chat-gpt-5");
-    expect(Object.getPrototypeOf(registry.providers[0]!.provider)).toBe(TestProvider.prototype);
+    expect(registry.providers[0]!.provider).toBeInstanceOf(TestProvider);
+    expect(providerInstance.chat("gpt-5")).toBe("chat-gpt-5");
   });
 
   it("keeps snapshot registry writes while restoring globals for non-activating commits", () => {

--- a/src/plugins/plugin-registration-transaction.test.ts
+++ b/src/plugins/plugin-registration-transaction.test.ts
@@ -322,6 +322,81 @@ describe("plugin registration transaction", () => {
     expect(rollbackSideEffects).toHaveBeenCalledOnce();
   });
 
+  it("restores the active PluginRecord's array fields after a failed registration (loader #106647)", () => {
+    const registry = createEmptyPluginRegistry();
+
+    // Simulate the loader pattern: record exists before transaction,
+    // register() mutates its id-collection arrays and the registry,
+    // then loader pushes record to registry.plugins.
+    const record = {
+      id: "test-plugin",
+      name: "Test Plugin",
+      source: "test-source",
+      origin: "global" as const,
+      enabled: true,
+      status: "loaded" as const,
+      toolNames: [] as string[],
+      hookNames: [] as string[],
+      providerIds: [] as string[],
+      channelIds: [] as string[],
+      cliBackendIds: [] as string[],
+      embeddingProviderIds: [] as string[],
+      speechProviderIds: [] as string[],
+      realtimeTranscriptionProviderIds: [] as string[],
+      realtimeVoiceProviderIds: [] as string[],
+      mediaUnderstandingProviderIds: [] as string[],
+      transcriptSourceProviderIds: [] as string[],
+      imageGenerationProviderIds: [] as string[],
+      videoGenerationProviderIds: [] as string[],
+      musicGenerationProviderIds: [] as string[],
+      webFetchProviderIds: [] as string[],
+      webSearchProviderIds: [] as string[],
+      migrationProviderIds: [] as string[],
+      memoryEmbeddingProviderIds: [] as string[],
+      agentHarnessIds: [] as string[],
+      cliCommands: [] as string[],
+      services: [] as string[],
+      gatewayDiscoveryServiceIds: [] as string[],
+      commands: [] as string[],
+      httpRoutes: 0,
+      hookCount: 0,
+      configSchema: false,
+    };
+
+    const transaction = createPluginRegistrationTransaction({
+      registry,
+      activeRecord: record,
+    });
+
+    // During register(), plugin API mutates record arrays and the registry
+    record.toolNames.push("bad-tool");
+    record.hookNames.push("bad-hook");
+    record.providerIds.push("bad-provider");
+    registry.tools.push({
+      pluginId: "test-plugin",
+      factory: () => ({}) as unknown as import("./types.js").AnyAgentTool,
+      names: ["bad-tool"],
+      optional: false,
+      source: "test-source",
+    });
+
+    // Loader pushes record to registry.plugins (loader-runtime-candidate L505)
+    registry.plugins.push(record);
+
+    // Plugin fails, loader calls rollback (L509)
+    transaction.rollback();
+
+    // Registry snapshot correctly removes the record from plugins
+    expect(registry.plugins).toHaveLength(0);
+    expect(registry.tools).toHaveLength(0);
+
+    // Active record's array fields are restored — recordPluginError can safely
+    // re-push the record without stale ids from the failed registration.
+    expect(record.toolNames).toEqual([]);
+    expect(record.hookNames).toEqual([]);
+    expect(record.providerIds).toEqual([]);
+  });
+
   it("keeps snapshot registry writes while restoring globals for non-activating commits", () => {
     const registry = createEmptyPluginRegistry();
     const activePromptBuilder = () => ["active"];

--- a/src/plugins/plugin-registration-transaction.test.ts
+++ b/src/plugins/plugin-registration-transaction.test.ts
@@ -324,6 +324,7 @@ describe("plugin registration transaction", () => {
 
   it("restores the active PluginRecord's arrays and scalars after a failed registration (loader #106647)", () => {
     const registry = createEmptyPluginRegistry();
+    const initialFailureDate = new Date(123);
 
     // Simulate the loader pattern: record exists before transaction,
     // register() mutates its id-collection arrays, scalars, and the registry.
@@ -361,6 +362,7 @@ describe("plugin registration transaction", () => {
       hookCount: 0,
       configSchema: false,
       memorySlotSelected: false,
+      failedAt: initialFailureDate,
     };
 
     const transaction = createPluginRegistrationTransaction({
@@ -377,6 +379,7 @@ describe("plugin registration transaction", () => {
     record.configSchema = true;
     record.memorySlotSelected = true;
     record.enabled = false;
+    initialFailureDate.setTime(456);
     (record as Record<string, unknown>).transientMetadata = "leaked";
     registry.tools.push({
       pluginId: "test-plugin",
@@ -407,6 +410,8 @@ describe("plugin registration transaction", () => {
     expect(record.configSchema).toBe(false);
     expect(record.memorySlotSelected).toBe(false);
     expect(record.enabled).toBe(true);
+    expect(record.failedAt?.getTime()).toBe(123);
+    expect(record.failedAt).not.toBe(initialFailureDate);
     expect(record).not.toHaveProperty("transientMetadata");
   });
 

--- a/src/plugins/plugin-registration-transaction.test.ts
+++ b/src/plugins/plugin-registration-transaction.test.ts
@@ -221,6 +221,107 @@ describe("plugin registration transaction", () => {
     expect(providerInstance.chat("gpt-5")).toBe("chat-gpt-5");
   });
 
+  it("preserves earlier class-backed plugin registrations when a later plugin fails and rolls back (loader scenario #106647)", () => {
+    const registry = createEmptyPluginRegistry();
+
+    // Simulate a real plugin provider with class-backed state (methods, prototypes)
+    class GoodProvider {
+      id = "good-provider";
+      label = "Good Provider";
+      chat(model: string) {
+        return `good-${model}`;
+      }
+      listModels() {
+        return ["good-model"];
+      }
+      start() {}
+      stop() {}
+    }
+    const goodProviderInstance = new GoodProvider();
+
+    // Transaction 1: "good-plugin" registers successfully (mirrors loader-runtime-candidate L492-507)
+    const tx1 = createPluginRegistrationTransaction({ registry });
+
+    registry.providers.push({
+      pluginId: "good-plugin",
+      pluginName: "Good Plugin",
+      provider: goodProviderInstance as unknown as import("./types.js").ProviderPlugin,
+      source: "good-source",
+    });
+    registry.plugins.push({
+      id: "good-plugin",
+      name: "Good Plugin",
+      source: "good-source",
+      origin: "global" as const,
+      enabled: true,
+      status: "loaded" as const,
+      toolNames: [],
+      hookNames: [],
+      channelIds: [],
+      cliBackendIds: [],
+      providerIds: ["good-provider"],
+      embeddingProviderIds: [],
+      speechProviderIds: [],
+      realtimeTranscriptionProviderIds: [],
+      realtimeVoiceProviderIds: [],
+      mediaUnderstandingProviderIds: [],
+      transcriptSourceProviderIds: [],
+      imageGenerationProviderIds: [],
+      videoGenerationProviderIds: [],
+      musicGenerationProviderIds: [],
+      webFetchProviderIds: [],
+      webSearchProviderIds: [],
+      migrationProviderIds: [],
+      memoryEmbeddingProviderIds: [],
+      agentHarnessIds: [],
+      cliCommands: [],
+      services: [],
+      gatewayDiscoveryServiceIds: [],
+      commands: [],
+      httpRoutes: 0,
+      hookCount: 0,
+      configSchema: false,
+    });
+
+    tx1.commit({ activate: true });
+
+    // Transaction 2: "bad-plugin" writes to registry then fails (mirrors loader-runtime-candidate L508-522)
+    const rollbackSideEffects = vi.fn();
+    const tx2 = createPluginRegistrationTransaction({
+      registry,
+      rollbackGlobalSideEffects: rollbackSideEffects,
+    });
+
+    registry.providers.push({
+      pluginId: "bad-plugin",
+      pluginName: "Bad Plugin",
+      provider: { id: "bad-provider" } as unknown as import("./types.js").ProviderPlugin,
+      source: "bad-source",
+    });
+    // Bad plugin's registration mutates the good plugin's metadata (simulating side effects)
+    registry.plugins[0]!.status = "error";
+    registry.providers[0]!.pluginName = "Corrupted";
+
+    // Bad plugin fails, loader calls rollback
+    tx2.rollback();
+
+    // After rollback: bad plugin's provider is gone
+    expect(registry.providers).toHaveLength(1);
+    expect(registry.providers[0]!.pluginId).toBe("good-plugin");
+
+    // Good plugin's metadata is restored
+    expect(registry.plugins[0]!.status).toBe("loaded");
+    expect(registry.providers[0]!.pluginName).toBe("Good Plugin");
+
+    // Good plugin's class-backed provider instance preserved by reference
+    expect(registry.providers[0]!.provider).toBe(goodProviderInstance);
+    expect(registry.providers[0]!.provider).toBeInstanceOf(GoodProvider);
+    expect(goodProviderInstance.chat("gpt-5")).toBe("good-gpt-5");
+
+    // rollbackGlobalSideEffects was called (loader contract)
+    expect(rollbackSideEffects).toHaveBeenCalledOnce();
+  });
+
   it("keeps snapshot registry writes while restoring globals for non-activating commits", () => {
     const registry = createEmptyPluginRegistry();
     const activePromptBuilder = () => ["active"];

--- a/src/plugins/plugin-registration-transaction.test.ts
+++ b/src/plugins/plugin-registration-transaction.test.ts
@@ -377,6 +377,7 @@ describe("plugin registration transaction", () => {
     record.configSchema = true;
     record.memorySlotSelected = true;
     record.enabled = false;
+    (record as Record<string, unknown>).transientMetadata = "leaked";
     registry.tools.push({
       pluginId: "test-plugin",
       factory: () => ({}) as unknown as import("./types.js").AnyAgentTool,
@@ -406,6 +407,7 @@ describe("plugin registration transaction", () => {
     expect(record.configSchema).toBe(false);
     expect(record.memorySlotSelected).toBe(false);
     expect(record.enabled).toBe(true);
+    expect(record).not.toHaveProperty("transientMetadata");
   });
 
   it("preserves runtime object identity on the active PluginRecord through rollback (#106647)", () => {

--- a/src/plugins/plugin-registration-transaction.ts
+++ b/src/plugins/plugin-registration-transaction.ts
@@ -93,7 +93,7 @@ export function restorePluginProcessGlobalState(state: PluginProcessGlobalState)
  *
  * A generic recursive deep-clone would convert every plugin-owned object
  * into a plain object, losing prototypes, internal slots, symbols, and
- * shared identity.  Shallow-cloning is correct here because the mutable
+ * shared identity. Shallow-cloning is correct here because the mutable
  * fields on registration records are primitives (strings, numbers,
  * booleans, Dates), and the opaque fields are class instances that the
  * registry must not reconstitute.
@@ -164,9 +164,12 @@ function snapshotActiveRecord(record: PluginRecord): ActiveRecordSnapshot {
 }
 
 function restoreActiveRecord(record: PluginRecord, snapshot: ActiveRecordSnapshot): void {
-  for (const key of Object.keys(snapshot)) {
-    (record as Record<string, unknown>)[key] = snapshot[key];
+  // Registration may create optional metadata that did not exist when the
+  // transaction began. Remove the live shape before restoring the snapshot.
+  for (const key of Object.keys(record)) {
+    Reflect.deleteProperty(record, key);
   }
+  Object.assign(record, snapshot);
 }
 
 type PluginRegistrationTransaction = {

--- a/src/plugins/plugin-registration-transaction.ts
+++ b/src/plugins/plugin-registration-transaction.ts
@@ -86,41 +86,53 @@ export function restorePluginProcessGlobalState(state: PluginProcessGlobalState)
   restoreSessionDiscussionProvider(state.sessionDiscussionProvider);
 }
 
-function deepCloneRegistryValue<T>(value: T): T {
-  if (value === null || value === undefined) {
-    return value;
-  }
-  if (typeof value !== "object") {
-    return value;
-  }
+/**
+ * Shallow-clone a registration record so metadata mutations do not leak
+ * through rollback, while preserving opaque plugin-owned instances
+ * (providers, services, channels, harnesses, resolvers) by reference.
+ *
+ * A generic recursive deep-clone would convert every plugin-owned object
+ * into a plain object, losing prototypes, internal slots, symbols, and
+ * shared identity.  Shallow-cloning is correct here because the mutable
+ * fields on registration records are primitives (strings, numbers,
+ * booleans, Dates), and the opaque fields are class instances that the
+ * registry must not reconstitute.
+ */
+function cloneRegistryEntry(value: unknown): unknown {
+  if (value === null || value === undefined) return value;
+  if (typeof value !== "object") return value;
+  if (Array.isArray(value)) return value.map((item) => cloneRegistryEntry(item));
   if (value instanceof Map) {
-    return new Map([...value].map(([k, v]) => [k, deepCloneRegistryValue(v)])) as unknown as T;
+    return new Map([...value].map(([k, v]) => [k, cloneRegistryEntry(v)]));
   }
-  if (Array.isArray(value)) {
-    return value.map((item) => deepCloneRegistryValue(item)) as unknown as T;
-  }
-  if (value instanceof Date) {
-    return new Date(value) as unknown as T;
-  }
+  if (value instanceof Date) return new Date(value);
+  // Shallow-clone so primitive metadata fields become independent copies
+  // while opaque plugin-owned objects stay by reference.
   const cloned: Record<string, unknown> = {};
   for (const key of Object.keys(value)) {
     const val = (value as Record<string, unknown>)[key];
-    cloned[key] = typeof val === "function" ? val : deepCloneRegistryValue(val);
+    if (val instanceof Date) {
+      cloned[key] = new Date(val);
+    } else if (Array.isArray(val)) {
+      cloned[key] = [...val];
+    } else {
+      cloned[key] = val;
+    }
   }
-  return cloned as unknown as T;
+  return cloned;
 }
 
 function snapshotPluginRegistry(registry: PluginRegistry): PluginRegistry {
   return Object.fromEntries(
     Object.entries(registry).map(([key, value]) => {
       if (Array.isArray(value)) {
-        return [key, value.map((item) => deepCloneRegistryValue(item))];
+        return [key, value.map((item) => cloneRegistryEntry(item))];
       }
       if (value instanceof Map) {
-        return [key, new Map([...value].map(([k, v]) => [k, deepCloneRegistryValue(v)]))];
+        return [key, new Map([...value].map(([k, v]) => [k, cloneRegistryEntry(v)]))];
       }
       if (value && typeof value === "object") {
-        return [key, deepCloneRegistryValue(value)];
+        return [key, cloneRegistryEntry(value)];
       }
       return [key, value];
     }),

--- a/src/plugins/plugin-registration-transaction.ts
+++ b/src/plugins/plugin-registration-transaction.ts
@@ -152,25 +152,15 @@ function restorePluginRegistry(registry: PluginRegistry, snapshot: PluginRegistr
 }
 
 /**
- * Snapshot the active PluginRecord's array-valued fields so they can be
- * restored on rollback.  The record is not yet in the registry when the
- * transaction starts, but loader callers mutate the record's id-collection
- * arrays during register() and push the record to registry.plugins after
- * commit.  On rollback the registry snapshot correctly removes the record,
- * but recordPluginError later re-pushes it — with mutated arrays unless
- * we capture them here.
+ * Snapshot of the active PluginRecord's transaction-owned mutable fields.
+ * Captured with cloneRegistryEntry so arrays, Dates, and primitives become
+ * independent copies while runtime objects (configUiHints, configJsonSchema,
+ * contracts) stay by reference.
  */
-type ActiveRecordSnapshot = Record<string, readonly unknown[]>;
+type ActiveRecordSnapshot = Record<string, unknown>;
 
 function snapshotActiveRecord(record: PluginRecord): ActiveRecordSnapshot {
-  const snap: Record<string, unknown> = {};
-  for (const key of Object.keys(record)) {
-    const val = (record as Record<string, unknown>)[key];
-    if (Array.isArray(val)) {
-      snap[key] = [...val];
-    }
-  }
-  return snap as ActiveRecordSnapshot;
+  return cloneRegistryEntry(record) as ActiveRecordSnapshot;
 }
 
 function restoreActiveRecord(record: PluginRecord, snapshot: ActiveRecordSnapshot): void {
@@ -189,7 +179,8 @@ export function createPluginRegistrationTransaction(params: {
   rollbackGlobalSideEffects?: () => void;
   /** Active PluginRecord being registered by the caller (mutated during
    *  register() before being pushed to registry.plugins).  When set, its
-   *  mutable array fields are snapshotted and restored on rollback. */
+   *  mutable metadata fields (arrays, scalars, flags, Dates) are snapshotted
+   *  and restored on rollback while runtime objects keep their identity. */
   activeRecord?: PluginRecord;
 }): PluginRegistrationTransaction {
   const registrySnapshot = params.registry ? snapshotPluginRegistry(params.registry) : undefined;

--- a/src/plugins/plugin-registration-transaction.ts
+++ b/src/plugins/plugin-registration-transaction.ts
@@ -99,13 +99,21 @@ export function restorePluginProcessGlobalState(state: PluginProcessGlobalState)
  * registry must not reconstitute.
  */
 function cloneRegistryEntry(value: unknown): unknown {
-  if (value === null || value === undefined) return value;
-  if (typeof value !== "object") return value;
-  if (Array.isArray(value)) return value.map((item) => cloneRegistryEntry(item));
+  if (value === null || value === undefined) {
+    return value;
+  }
+  if (typeof value !== "object") {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => cloneRegistryEntry(item));
+  }
   if (value instanceof Map) {
     return new Map([...value].map(([k, v]) => [k, cloneRegistryEntry(v)]));
   }
-  if (value instanceof Date) return new Date(value);
+  if (value instanceof Date) {
+    return new Date(value);
+  }
   // Shallow-clone so primitive metadata fields become independent copies
   // while opaque plugin-owned objects stay by reference.
   const cloned: Record<string, unknown> = {};

--- a/src/plugins/plugin-registration-transaction.ts
+++ b/src/plugins/plugin-registration-transaction.ts
@@ -86,17 +86,41 @@ export function restorePluginProcessGlobalState(state: PluginProcessGlobalState)
   restoreSessionDiscussionProvider(state.sessionDiscussionProvider);
 }
 
+function deepCloneRegistryValue<T>(value: T): T {
+  if (value === null || value === undefined) {
+    return value;
+  }
+  if (typeof value !== "object") {
+    return value;
+  }
+  if (value instanceof Map) {
+    return new Map([...value].map(([k, v]) => [k, deepCloneRegistryValue(v)])) as unknown as T;
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => deepCloneRegistryValue(item)) as unknown as T;
+  }
+  if (value instanceof Date) {
+    return new Date(value) as unknown as T;
+  }
+  const cloned: Record<string, unknown> = {};
+  for (const key of Object.keys(value)) {
+    const val = (value as Record<string, unknown>)[key];
+    cloned[key] = typeof val === "function" ? val : deepCloneRegistryValue(val);
+  }
+  return cloned as unknown as T;
+}
+
 function snapshotPluginRegistry(registry: PluginRegistry): PluginRegistry {
   return Object.fromEntries(
     Object.entries(registry).map(([key, value]) => {
       if (Array.isArray(value)) {
-        return [key, [...value]];
+        return [key, value.map((item) => deepCloneRegistryValue(item))];
       }
       if (value instanceof Map) {
-        return [key, new Map(value as ReadonlyMap<unknown, unknown>)];
+        return [key, new Map([...value].map(([k, v]) => [k, deepCloneRegistryValue(v)]))];
       }
       if (value && typeof value === "object") {
-        return [key, { ...value }];
+        return [key, deepCloneRegistryValue(value)];
       }
       return [key, value];
     }),

--- a/src/plugins/plugin-registration-transaction.ts
+++ b/src/plugins/plugin-registration-transaction.ts
@@ -31,7 +31,7 @@ import {
   listMemoryPromptSupplements,
   restoreMemoryPluginState,
 } from "./memory-state.js";
-import type { PluginRegistry } from "./registry-types.js";
+import type { PluginRecord, PluginRegistry } from "./registry-types.js";
 import {
   getSessionDiscussionProvider,
   restoreSessionDiscussionProvider,
@@ -151,6 +151,34 @@ function restorePluginRegistry(registry: PluginRegistry, snapshot: PluginRegistr
   Object.assign(registry, snapshot);
 }
 
+/**
+ * Snapshot the active PluginRecord's array-valued fields so they can be
+ * restored on rollback.  The record is not yet in the registry when the
+ * transaction starts, but loader callers mutate the record's id-collection
+ * arrays during register() and push the record to registry.plugins after
+ * commit.  On rollback the registry snapshot correctly removes the record,
+ * but recordPluginError later re-pushes it — with mutated arrays unless
+ * we capture them here.
+ */
+type ActiveRecordSnapshot = Record<string, readonly unknown[]>;
+
+function snapshotActiveRecord(record: PluginRecord): ActiveRecordSnapshot {
+  const snap: Record<string, unknown> = {};
+  for (const key of Object.keys(record)) {
+    const val = (record as Record<string, unknown>)[key];
+    if (Array.isArray(val)) {
+      snap[key] = [...val];
+    }
+  }
+  return snap as ActiveRecordSnapshot;
+}
+
+function restoreActiveRecord(record: PluginRecord, snapshot: ActiveRecordSnapshot): void {
+  for (const key of Object.keys(snapshot)) {
+    (record as Record<string, unknown>)[key] = snapshot[key];
+  }
+}
+
 type PluginRegistrationTransaction = {
   commit: (params: { activate: boolean }) => void;
   rollback: () => void;
@@ -159,9 +187,16 @@ type PluginRegistrationTransaction = {
 export function createPluginRegistrationTransaction(params: {
   registry?: PluginRegistry;
   rollbackGlobalSideEffects?: () => void;
+  /** Active PluginRecord being registered by the caller (mutated during
+   *  register() before being pushed to registry.plugins).  When set, its
+   *  mutable array fields are snapshotted and restored on rollback. */
+  activeRecord?: PluginRecord;
 }): PluginRegistrationTransaction {
   const registrySnapshot = params.registry ? snapshotPluginRegistry(params.registry) : undefined;
   const processGlobalState = snapshotPluginProcessGlobalState();
+  const activeRecordSnapshot = params.activeRecord
+    ? snapshotActiveRecord(params.activeRecord)
+    : null;
   let settled = false;
 
   const settle = (action: () => void): void => {
@@ -187,6 +222,9 @@ export function createPluginRegistrationTransaction(params: {
           restorePluginRegistry(params.registry, registrySnapshot);
         }
         restorePluginProcessGlobalState(processGlobalState);
+        if (activeRecordSnapshot && params.activeRecord) {
+          restoreActiveRecord(params.activeRecord, activeRecordSnapshot);
+        }
       });
     },
   };


### PR DESCRIPTION
Closes #106647

## What Problem This Solves

A plugin that throws during registration could leave partial capabilities on its failed `PluginRecord`, and could mutate nested registry-entry metadata through a shallow transaction snapshot. Rollback removed the top-level registry entries but did not reliably restore the metadata operators and later runtime consumers read.

## Why This Is the Best Fix

The registration transaction is the single rollback owner for runtime, setup-runtime channel, and CLI-metadata loading. It now snapshots the active record and transaction-owned registration envelopes, including arrays and Dates, while deliberately preserving handler, provider, service, and other plugin-owned runtime objects by identity.

A whole-registry `structuredClone` is unsafe because the registry contains functions and class-backed objects. Registrar-by-registrar immutable rewrites would scatter one rollback invariant across many capability owners. Restoring the exact active-record shape also removes optional metadata created after the transaction began instead of merely overwriting keys that existed in the snapshot.

This refresh combines the current, mergeable implementation from this PR with the production-loader regression and exact-record restoration insight from #108143. Both contributors retain credit.

## User Impact

After a registration exception, the failed plugin record no longer advertises services, routes, tools, or optional metadata that rollback removed. Previously loaded class-backed services and callbacks keep their identity and remain callable. Successful registration behavior is unchanged.

## Evidence

- Blacksmith Testbox `tbx_01kym7gy6vw02zh0ehcpdnmn0r`, run https://github.com/openclaw/openclaw/actions/runs/30354688132:
  - 18 focused transaction and production-loader tests passed.
  - `pnpm check:changed` passed for the six-file plugin loader/transaction surface.
  - `pnpm build` passed, including Plugin SDK export and Control UI artifact checks.
- Blacksmith Testbox `tbx_01kym8vqk0mnargcc7hrpad6t4`, run https://github.com/openclaw/openclaw/actions/runs/30356261041:
  - the final 12 transaction tests passed after adding Date value and identity coverage.
  - core and core-test `tsgo` checks passed.
- Targeted `oxfmt`, `oxlint --deny-warnings`, and `git diff --check` passed on the final files.
- Fresh Codex autoreview on exact head `9d1a1982407fd8cfafb15fd454a99723b99a4216`: clean, no accepted or actionable findings.

## Risk Checklist

- User-visible behavior: failed plugin metadata is now transactionally accurate.
- Config, env, persistence, schema, migration: no changes.
- Security, auth, secrets, network: no new surface.
- Plugin SDK: no public API signature changes.
- Runtime risk: snapshot work occurs only at registration boundaries, not request hot paths.

## Provenance

The shallow rollback behavior was introduced when registration rollback was centralized in #104902. This PR preserves @lee-xydt's current implementation and incorporates @zhanxingxin1998's real-loader proof and exact-shape restoration work from #108143.

## AI Disclosure

AI-assisted: yes. Maintainer review, current-main refresh, live Testbox proof, and final Codex autoreview were completed before the branch update.
