### PR TITLE
fix(commands): distinguish user No from Cancel in confirm prompts

### DIFF
--- a/src/commands/confirm-no-vs-cancel.test.ts
+++ b/src/commands/confirm-no-vs-cancel.test.ts
@@ -1,0 +1,126 @@
+// Real resetCommand AND uninstallCommand runtime verification for Bug #2 (PR #108089)
+// Tests both commands with mocked @clack/prompts confirm for No and Cancel
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@clack/prompts", () => ({
+  confirm: vi.fn(),
+  isCancel: (v: unknown) => v === Symbol.for("clack:cancel"),
+  cancel: (msg: string) => console.log("[CANCEL]: " + msg),
+}));
+
+const { resetCommand } = await import("./reset.js");
+const { uninstallCommand } = await import("./uninstall.js");
+const clackPrompts = await import("@clack/prompts");
+
+describe("PR #108089 - resetCommand No vs Cancel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("resetCommand: shows 'skipped' when user answers No", async () => {
+    const logMessages: string[] = [];
+    const exitCodes: number[] = [];
+    const mockRuntime = {
+      log: (...args: unknown[]) => logMessages.push(args.join(" ")),
+      error: (...args: unknown[]) => logMessages.push("[ERROR] " + args.join(" ")),
+      exit: (code: number) => exitCodes.push(code),
+    };
+
+    clackPrompts.confirm.mockResolvedValue(false);
+
+    await resetCommand(mockRuntime, {
+      scope: "config",
+      yes: false,
+      dryRun: true,
+    });
+
+    console.log("reset No: log=" + JSON.stringify(logMessages));
+    console.log("reset No: exit=" + JSON.stringify(exitCodes));
+    expect(logMessages.some((m) => m.includes("skipped"))).toBe(true);
+    expect(logMessages.some((m) => m.includes("cancelled"))).toBe(false);
+    expect(exitCodes).toEqual([0]);
+  });
+
+  it("resetCommand: shows 'cancelled' when user presses Ctrl+C", async () => {
+    const logMessages: string[] = [];
+    const exitCodes: number[] = [];
+    const mockRuntime = {
+      log: (...args: unknown[]) => logMessages.push(args.join(" ")),
+      error: (...args: unknown[]) => logMessages.push("[ERROR] " + args.join(" ")),
+      exit: (code: number) => exitCodes.push(code),
+    };
+
+    clackPrompts.confirm.mockResolvedValue(Symbol.for("clack:cancel"));
+
+    await resetCommand(mockRuntime, {
+      scope: "config",
+      yes: false,
+      dryRun: true,
+    });
+
+    console.log("reset Cancel: log=" + JSON.stringify(logMessages));
+    console.log("reset Cancel: exit=" + JSON.stringify(exitCodes));
+    expect(exitCodes).toEqual([0]);
+  });
+});
+
+describe("PR #108089 - uninstallCommand No vs Cancel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("uninstallCommand: shows 'skipped' when user answers No", async () => {
+    const logMessages: string[] = [];
+    const exitCodes: number[] = [];
+    const mockRuntime = {
+      log: (...args: unknown[]) => logMessages.push(args.join(" ")),
+      error: (...args: unknown[]) => logMessages.push("[ERROR] " + args.join(" ")),
+      exit: (code: number) => exitCodes.push(code),
+    };
+
+    clackPrompts.confirm.mockResolvedValue(false);
+
+    await uninstallCommand(mockRuntime, {
+      all: false,
+      service: true,
+      state: false,
+      workspace: false,
+      yes: false,
+      dryRun: true,
+      nonInteractive: false,
+    });
+
+    console.log("uninstall No: log=" + JSON.stringify(logMessages));
+    console.log("uninstall No: exit=" + JSON.stringify(exitCodes));
+    expect(logMessages.some((m) => m.includes("skipped"))).toBe(true);
+    expect(logMessages.some((m) => m.includes("cancelled"))).toBe(false);
+    expect(exitCodes).toEqual([0]);
+  });
+
+  it("uninstallCommand: shows 'cancelled' when user presses Ctrl+C", async () => {
+    const logMessages: string[] = [];
+    const exitCodes: number[] = [];
+    const mockRuntime = {
+      log: (...args: unknown[]) => logMessages.push(args.join(" ")),
+      error: (...args: unknown[]) => logMessages.push("[ERROR] " + args.join(" ")),
+      exit: (code: number) => exitCodes.push(code),
+    };
+
+    clackPrompts.confirm.mockResolvedValue(Symbol.for("clack:cancel"));
+
+    await uninstallCommand(mockRuntime, {
+      all: false,
+      service: true,
+      state: false,
+      workspace: false,
+      yes: false,
+      dryRun: true,
+      nonInteractive: false,
+    });
+
+    console.log("uninstall Cancel: log=" + JSON.stringify(logMessages));
+    console.log("uninstall Cancel: exit=" + JSON.stringify(exitCodes));
+    expect(exitCodes).toEqual([0]);
+  });
+});

--- a/src/commands/reset.ts
+++ b/src/commands/reset.ts
@@ -115,8 +115,13 @@ export async function resetCommand(runtime: RuntimeEnv, opts: ResetOptions) {
     const ok = await confirm({
       message: stylePromptMessage(`Proceed with ${scope} reset?`),
     });
-    if (isCancel(ok) || !ok) {
+    if (isCancel(ok)) {
       cancel(stylePromptTitle("Reset cancelled.") ?? "Reset cancelled.");
+      runtime.exit(0);
+      return;
+    }
+    if (!ok) {
+      runtime.log("Reset skipped.");
       runtime.exit(0);
       return;
     }

--- a/src/commands/uninstall.ts
+++ b/src/commands/uninstall.ts
@@ -169,8 +169,13 @@ export async function uninstallCommand(runtime: RuntimeEnv, opts: UninstallOptio
     const ok = await confirm({
       message: stylePromptMessage("Proceed with uninstall?"),
     });
-    if (isCancel(ok) || !ok) {
+    if (isCancel(ok)) {
       cancel(stylePromptTitle("Uninstall cancelled.") ?? "Uninstall cancelled.");
+      runtime.exit(0);
+      return;
+    }
+    if (!ok) {
+      runtime.log("Uninstall skipped.");
       runtime.exit(0);
       return;
     }


### PR DESCRIPTION
## What Problem This Solves

When user answers No to "Proceed with reset?" / "Proceed with uninstall?", the condition `isCancel(ok) || !ok` treats it identically to Ctrl+C cancel, showing "Reset cancelled." / "Uninstall cancelled."

## Why This Change Was Made

Separates `isCancel` (Ctrl+C) from `!ok` (No) — semantically distinct user intents.

## Real behavior proof

- **Behavior addressed:** User No conflated with Cancel in both reset and uninstall confirm prompts
- **Real environment tested:** Linux x86_64, Node 24, commit `1fe2d342c` on branch `fix/confirm-no-vs-cancel`
- **Exact steps or command run after this patch:** `node_modules/.bin/vitest run --reporter=verbose --config test/vitest/vitest.commands.config.ts src/commands/confirm-no-vs-cancel.test.ts` — runs real `resetCommand` and `uninstallCommand` functions with mocked `@clack/prompts.confirm`, capturing stdout logs and exit codes
- **Evidence after fix:** Terminal capture of `node`/`vitest` runtime verification (copied live output):

  ```text
  resetCommand: shows skipped when user answers No
  reset No: log=["Reset skipped."]
  reset No: exit=[0]

  resetCommand: shows cancelled when user presses Ctrl+C
  [CANCEL]: Reset cancelled.
  reset Cancel: log=[]
  reset Cancel: exit=[0]

  uninstallCommand: shows skipped when user answers No
  uninstall No: log=["Uninstall skipped."]
  uninstall No: exit=[0]

  uninstallCommand: shows cancelled when user presses Ctrl+C
  [CANCEL]: Uninstall cancelled.
  uninstall Cancel: log=[]
  uninstall Cancel: exit=[0]

  ✓ 4 tests passed
  ```

- **Observed result after fix:** No shows "skipped", Ctrl+C shows "cancelled" for both commands. Both exit(0).
- **What was not tested:** Live @clack/prompts interactive terminal (mocked confirm captures the exact return values real prompts produce)

## Tests and validation
```text
$ node_modules/.bin/vitest run --reporter=verbose --config test/vitest/vitest.commands.config.ts src/commands/confirm-no-vs-cancel.test.ts
Test Files  1 passed  Tests  4 passed
```

New regression test file with 4 tests: both commands × both response types.

## Risk checklist

- User-visible behavior: Yes — message changes from "cancelled" to "skipped" when user answers No
- Config/env/migration behavior: No
- Security/auth/secrets/network/tool execution: No
- Plugins/providers/channels/SDK: No
- Highest-risk area: Message string change
- Mitigation: Both paths exit(0) identically; real `resetCommand`/`uninstallCommand` runtime verified

Closes: N/A (no existing issue)