### PR TITLE
fix: stabilize full-suite test shards

### DIFF
--- a/packages/ai/src/api-registry.test.ts
+++ b/packages/ai/src/api-registry.test.ts
@@ -66,8 +66,11 @@ describe("LLM API registry", () => {
   });
 
   it("shares default runtime registrations across duplicated module instances", async () => {
+    // File URLs preserve the cache-busting query through Vitest project shards.
+    // Computed relative imports can escape into unresolved Vite /@fs paths.
     const duplicateRuntime = (await import(
-      ["./internal/default-runtime.js", "duplicate-runtime"].join("?")
+      /* @vite-ignore */ new URL("./internal/default-runtime.ts?duplicate-runtime", import.meta.url)
+        .href
     )) as typeof import("./internal/default-runtime.js");
     const streamSimple = vi.fn(emptyStream);
     duplicateRuntime.registerApiProvider(

--- a/test/vitest/vitest.agents-paths.mjs
+++ b/test/vitest/vitest.agents-paths.mjs
@@ -6,9 +6,11 @@ export const agentsAllTestPatterns = ["src/agents/**/*.test.ts"];
 export const agentsCoreIsolatedTestFiles = [
   "src/agents/image-generation-task-status.test.ts",
   "src/agents/media-generation-task-status-shared.test.ts",
+  "src/agents/mcp-http-fetch.test.ts",
   "src/agents/mcp-transport.test.ts",
   "src/agents/model-auth-env.provider-aliases.test.ts",
   "src/agents/model-selection.plugin-runtime.test.ts",
+  "src/agents/models-config.runtime-source-snapshot.test.ts",
   "src/agents/video-generation-task-status.test.ts",
 ];
 


### PR DESCRIPTION
Related: #107442

## What Problem This Solves

Fixes an issue where the full 279-shard landing gate would fail on rotating shared-worker test pollution and a Vite duplicate-module resolution error, blocking unrelated pull requests.

## Why This Change Was Made

Moves the two remaining process-global mock suites into the existing isolated agents-core project. Uses an explicit cache-busted file URL for the API registry duplicate-module test so Vite preserves the query across project shards.

## User Impact

No product behavior change. Maintainers get a stable landing gate with the affected tests still covered exactly once.

## Evidence

- Baseline exact gate reproduced 14 failures across `mcp-http-fetch.test.ts` and `models-config.runtime-source-snapshot.test.ts`.
- Isolated agents-core project: 5/5 passes, 63 tests per run.
- API registry support shard: 5/5 passes, 4 tests per run.
- Routing coverage: 302 tests passed.
- Manual exact-gate attempts showed no test failures before Blacksmith transport termination; hosted PR-head Testbox proof follows through `scripts/pr prepare-run`.
- Fresh autoreview: clean, no accepted or actionable findings.

AI-assisted change. I reviewed and understand the patch.
