### PR TITLE
fix(matrix): keep draft previews for queued followups

### DIFF
--- a/extensions/matrix/src/matrix/monitor/handler.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.test.ts
@@ -2897,6 +2897,7 @@ describe("matrix monitor handler draft streaming", () => {
       context?: { assistantMessageIndex?: number },
     ) => Promise<void> | void;
     onAssistantMessageStart?: () => void;
+    onQueuedFollowupAdmitted?: () => Promise<void> | void;
     suppressDefaultToolProgressMessages?: boolean;
     onToolStart?: (payload: {
       itemId?: string;
@@ -3777,6 +3778,34 @@ describe("matrix monitor handler draft streaming", () => {
 
       await vi.advanceTimersByTimeAsync(50);
       expect(sendSingleTextMessageMatrixMock).not.toHaveBeenCalled();
+      await finish();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("starts a fresh Matrix draft for queued followups after the primary final", async () => {
+    vi.useFakeTimers();
+    try {
+      const { dispatch } = createStreamingHarness();
+      const { deliver, opts, finish } = await dispatch();
+
+      opts.onPartialReply?.({ text: "Primary answer" });
+      await vi.waitFor(() => {
+        expect(sendSingleTextMessageMatrixMock).toHaveBeenCalledTimes(1);
+      });
+
+      await deliver({ text: "Primary answer" }, { kind: "final" });
+
+      sendSingleTextMessageMatrixMock.mockClear();
+      sendSingleTextMessageMatrixMock.mockResolvedValue({ messageId: "$draft2", roomId: "!room" });
+
+      await opts.onQueuedFollowupAdmitted?.();
+      opts.onPartialReply?.({ text: "Queued followup answer" });
+      await vi.advanceTimersByTimeAsync(50);
+
+      expect(sendSingleTextMessageMatrixMock).toHaveBeenCalledTimes(1);
+      expect(singleTextMessageBody()).toBe("Queued followup answer");
       await finish();
     } finally {
       vi.useRealTimers();

--- a/extensions/matrix/src/matrix/monitor/handler.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.test.ts
@@ -3812,6 +3812,38 @@ describe("matrix monitor handler draft streaming", () => {
     }
   });
 
+  it("starts fresh progress drafts for queued followups after the primary final", async () => {
+    vi.useFakeTimers();
+    try {
+      const { dispatch } = createStreamingHarness({
+        streaming: "progress",
+        previewToolProgressEnabled: true,
+      });
+      const { deliver, opts, finish } = await dispatch();
+
+      await opts.onToolStart?.({ name: "read_file" });
+      await vi.advanceTimersByTimeAsync(5_000);
+      expect(sendSingleTextMessageMatrixMock).toHaveBeenCalledTimes(1);
+
+      await deliver({ text: "Primary answer" }, { kind: "final" });
+
+      sendSingleTextMessageMatrixMock.mockClear();
+      sendSingleTextMessageMatrixMock.mockResolvedValue({ messageId: "$draft2", roomId: "!room" });
+
+      await opts.onQueuedFollowupAdmitted?.();
+      await opts.onToolStart?.({ name: "exec" });
+      await vi.advanceTimersByTimeAsync(4_999);
+      expect(sendSingleTextMessageMatrixMock).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(1);
+      expect(sendSingleTextMessageMatrixMock).toHaveBeenCalledTimes(1);
+      expect(singleTextMessageBody()).toMatch(/`🛠️ Exec`$/);
+      await finish();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("resets draft block offsets on assistant message start", async () => {
     const { dispatch } = createStreamingHarness();
     const { deliver, opts, finish } = await dispatch();

--- a/extensions/matrix/src/matrix/monitor/handler.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.ts
@@ -2044,6 +2044,20 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
         latestDraftFullText = "";
       };
 
+      const resetDraftDeliveryState = async () => {
+        await draftStream?.discardPending();
+        draftStream?.reset();
+        draftConsumed = false;
+        currentDraftMessageGeneration = 0;
+        currentDraftBlockOffset = 0;
+        latestDraftFullText = "";
+        pendingDraftBoundaries.length = 0;
+        latestQueuedDraftBoundaryOffsets.clear();
+        currentDraftReplyToId = draftReplyToId;
+        progressDraftGate.cancel();
+        resetPreviewToolProgress();
+      };
+
       const { dispatcher, replyOptions, markDispatchIdle, markRunComplete } =
         core.channel.reply.createReplyDispatcherWithTyping({
           ...prefixOptions,
@@ -2481,6 +2495,7 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
                               resetPreviewToolProgress();
                             }
                           : undefined,
+                        onQueuedFollowupAdmitted: draftStream ? resetDraftDeliveryState : undefined,
                         ...buildPreviewToolProgressReplyOptions(),
                         onModelSelected,
                       },

--- a/extensions/matrix/src/matrix/monitor/handler.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.ts
@@ -2054,7 +2054,7 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
         pendingDraftBoundaries.length = 0;
         latestQueuedDraftBoundaryOffsets.clear();
         currentDraftReplyToId = draftReplyToId;
-        progressDraftGate.cancel();
+        progressDraftGate.reset();
         resetPreviewToolProgress();
       };
 


### PR DESCRIPTION
## What Problem This Solves

Matrix draft previews stopped after the primary final reply. A queued followup reused the stopped stream, so its live partial or progress preview was lost.

## Why This Change Was Made

The Matrix handler now resets its draft delivery bookkeeping at the generic `onQueuedFollowupAdmitted` boundary. Same-turn ghost partials remain blocked after final delivery.

The maintainer fixup re-arms the progress-draft gate with `reset()` rather than permanently disposing it with `cancel()`. Terminal cleanup still cancels the gate.

## User Impact

Queued Matrix followups now start fresh draft previews in both ordinary partial/quiet mode and delayed `streaming.mode: "progress"` mode.

## Evidence

- Exact improved head: `ff0dccf98030135c4e4b08a43cd897e52c4acc1a`.
- Blacksmith Testbox `tbx_01kxjcftr8ec4526aamv1jdaxd`: real Matrix handler suite, 118/118 passed; changed files passed `oxfmt --check`.
- Regressions prove a fresh post-final draft for queued partial replies and a second delayed tool-progress draft after queued admission.
- Exact pre-fix contributor-head CI gate: [run 29396320320](https://github.com/openclaw/openclaw/actions/runs/29396320320), green. Fresh exact-head CI is required after the maintainer fixup.
- Autoreview: local fixup and full improved branch both clean.

AI-assisted change. No contributor changelog edit.
