### PR TITLE
refactor(github-copilot): move runtime auth into provider

### DIFF
--- a/extensions/github-copilot/domain.ts
+++ b/extensions/github-copilot/domain.ts
@@ -25,12 +25,16 @@ function readConfiguredGithubCopilotDomain(config?: OpenClawConfig): string | un
  */
 export function resolveGithubCopilotDomain(params?: {
   env?: NodeJS.ProcessEnv;
+  explicit?: string;
   config?: OpenClawConfig;
 }): string {
   const env = params?.env ?? process.env;
   const fromEnv = env.COPILOT_GITHUB_DOMAIN?.trim();
   if (fromEnv) {
     return normalizeGithubCopilotDomain(fromEnv);
+  }
+  if (params?.explicit) {
+    return normalizeGithubCopilotDomain(params.explicit);
   }
   return normalizeGithubCopilotDomain(readConfiguredGithubCopilotDomain(params?.config));
 }

--- a/extensions/github-copilot/index.test.ts
+++ b/extensions/github-copilot/index.test.ts
@@ -30,6 +30,7 @@ const mocks = vi.hoisted(() => ({
     release: vi.fn(async () => {}),
   })),
   resolveCopilotApiToken: vi.fn(),
+  configureCopilotTokenCacheStore: vi.fn<(openStore: () => unknown) => void>(),
 }));
 
 function requireAuthMethod<T>(methods: readonly T[], index: number): T {
@@ -51,6 +52,10 @@ vi.mock("./register.runtime.js", () => ({
   resolveCopilotApiToken: mocks.resolveCopilotApiToken,
   githubCopilotLoginCommand: mocks.githubCopilotLoginCommand,
   fetchCopilotUsage: vi.fn(),
+}));
+
+vi.mock("./token.js", () => ({
+  configureCopilotTokenCacheStore: mocks.configureCopilotTokenCacheStore,
 }));
 
 import plugin from "./index.js";
@@ -170,6 +175,34 @@ function registerProviderWithPluginConfig(pluginConfig: Record<string, unknown>)
 }
 
 describe("github-copilot plugin", () => {
+  it("binds a lazy provider-scoped token store", () => {
+    const store = {};
+    const openSyncKeyedStore = vi.fn(() => store);
+    plugin.register(
+      createTestPluginApi({
+        id: "github-copilot",
+        name: "GitHub Copilot",
+        source: "test",
+        config: {},
+        runtime: { state: { openSyncKeyedStore } } as never,
+      }),
+    );
+
+    const openStore = requireFirstMockArg<() => unknown>(
+      mocks.configureCopilotTokenCacheStore,
+      "token cache store binding",
+    );
+    expect(openSyncKeyedStore).not.toHaveBeenCalled();
+    expect(openStore()).toBe(store);
+    expect(openStore()).toBe(store);
+    expect(openSyncKeyedStore).toHaveBeenCalledOnce();
+    expect(openSyncKeyedStore).toHaveBeenCalledWith({
+      namespace: "token",
+      maxEntries: 8,
+      overflowPolicy: "evict-oldest",
+    });
+  });
+
   it("owns Claude replay thinking cleanup", () => {
     const provider = registerProviderWithPluginConfig({});
     const messages = [

--- a/extensions/github-copilot/index.ts
+++ b/extensions/github-copilot/index.ts
@@ -9,6 +9,7 @@ import {
   type UnifiedModelCatalogEntry,
   type UnifiedModelCatalogProviderContext,
 } from "openclaw/plugin-sdk/plugin-entry";
+import type { PluginStateSyncKeyedStore } from "openclaw/plugin-sdk/plugin-state-runtime";
 import {
   applyAuthProfileConfig,
   coerceSecretRef,
@@ -29,6 +30,12 @@ import {
   sanitizeGithubCopilotReplayHistory,
 } from "./replay-policy.js";
 import { wrapCopilotProviderStream } from "./stream.js";
+import {
+  COPILOT_TOKEN_CACHE_MAX_ENTRIES,
+  COPILOT_TOKEN_CACHE_NAMESPACE,
+  type CachedCopilotToken,
+} from "./token-cache.js";
+import { configureCopilotTokenCacheStore } from "./token.js";
 
 const COPILOT_ENV_VARS: [string, string, string] = [
   "COPILOT_GITHUB_TOKEN",
@@ -334,6 +341,16 @@ export default definePluginEntry({
   description: "Bundled GitHub Copilot provider plugin",
   register(api) {
     const startupPluginConfig = (api.pluginConfig ?? {}) as GithubCopilotPluginConfig;
+    let tokenCacheStore: PluginStateSyncKeyedStore<CachedCopilotToken> | undefined;
+    const openTokenCacheStore = () => {
+      tokenCacheStore ??= api.runtime.state.openSyncKeyedStore<CachedCopilotToken>({
+        namespace: COPILOT_TOKEN_CACHE_NAMESPACE,
+        maxEntries: COPILOT_TOKEN_CACHE_MAX_ENTRIES,
+        overflowPolicy: "evict-oldest",
+      });
+      return tokenCacheStore;
+    };
+    configureCopilotTokenCacheStore(openTokenCacheStore);
 
     function resolveCurrentPluginConfig(config?: OpenClawConfig): GithubCopilotPluginConfig {
       const runtimePluginConfig = resolvePluginConfigObject(config, "github-copilot");

--- a/extensions/github-copilot/models.test.ts
+++ b/extensions/github-copilot/models.test.ts
@@ -1,8 +1,10 @@
 // Github Copilot tests cover models plugin behavior.
 import { createHash } from "node:crypto";
 import { expectDefined } from "@openclaw/normalization-core";
+import type { PluginStateSyncKeyedStore } from "openclaw/plugin-sdk/plugin-state-runtime";
 import { createProviderUsageFetch, makeResponse } from "openclaw/plugin-sdk/test-env";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { CachedCopilotToken } from "./token.js";
 import { deriveCopilotApiBaseUrlFromToken, resolveCopilotApiToken } from "./token.js";
 import { fetchCopilotUsage } from "./usage.js";
 
@@ -416,6 +418,48 @@ describe("github-copilot token", () => {
       "identity",
     );
     expect(jsonStoreMocks.saveJsonFile).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps exchanges per source credential in plugin state", async () => {
+    const values = new Map<string, CachedCopilotToken>();
+    const register = vi.fn((key: string, value: CachedCopilotToken) => {
+      values.set(key, value);
+    });
+    const store = {
+      lookup: vi.fn((key: string) => values.get(key)),
+      register,
+    } as unknown as PluginStateSyncKeyedStore<CachedCopilotToken>;
+    const fetchImpl = vi.fn(async (_url: string, init?: RequestInit) => {
+      const source = new Headers(init?.headers).get("authorization")?.replace(/^Bearer\s+/u, "");
+      const exchange = `exchange-${source};proxy-ep=proxy.individual.githubcopilot.com;`;
+      return new Response(
+        JSON.stringify(
+          Object.fromEntries([
+            ["token", exchange],
+            ["expires_at", 2_000_000_000],
+          ]),
+        ),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    });
+    const resolve = (githubToken: string) =>
+      resolveCopilotApiToken({
+        githubToken,
+        fetchImpl: fetchImpl as typeof fetch,
+        openCacheStore: () => store,
+      });
+
+    const firstA = await resolve("source-a");
+    const firstB = await resolve("source-b");
+    const secondA = await resolve("source-a");
+
+    expect(firstA.token).toContain("exchange-source-a");
+    expect(firstB.token).toContain("exchange-source-b");
+    expect(secondA.token).toBe(firstA.token);
+    expect(secondA.source).toBe("cache:plugin-state");
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(register).toHaveBeenCalledTimes(2);
+    expect(values.size).toBe(2);
   });
 });
 

--- a/extensions/github-copilot/token-cache.ts
+++ b/extensions/github-copilot/token-cache.ts
@@ -1,0 +1,91 @@
+import { createHash } from "node:crypto";
+import { asDateTimestampMs } from "openclaw/plugin-sdk/number-runtime";
+import type { PluginStateSyncKeyedStore } from "openclaw/plugin-sdk/plugin-state-runtime";
+import { COPILOT_INTEGRATION_ID } from "openclaw/plugin-sdk/provider-auth";
+import { PUBLIC_GITHUB_COPILOT_DOMAIN } from "./domain.js";
+
+export const COPILOT_TOKEN_CACHE_NAMESPACE = "token";
+export const COPILOT_TOKEN_CACHE_MAX_ENTRIES = 8;
+
+export type CachedCopilotToken = {
+  token: string;
+  expiresAt: number;
+  updatedAt: number;
+  integrationId?: string;
+  sourceCredentialFingerprint?: string;
+  domain?: string;
+};
+
+export function fingerprintCopilotSourceCredential(githubToken: string): string {
+  return createHash("sha256").update(githubToken).digest("hex");
+}
+
+export function isCopilotTokenUsable(params: {
+  cache: CachedCopilotToken;
+  domain: string;
+  sourceCredentialFingerprint: string;
+  now?: number;
+}): boolean {
+  const expiresAt = asDateTimestampMs(params.cache.expiresAt);
+  // Pre-domain cache entries were public-only. Keep public upgrades warm while
+  // forcing tenant requests to exchange a tenant-scoped token.
+  const cacheDomain = params.cache.domain ?? PUBLIC_GITHUB_COPILOT_DOMAIN;
+  return (
+    params.cache.integrationId === COPILOT_INTEGRATION_ID &&
+    cacheDomain === params.domain &&
+    params.cache.sourceCredentialFingerprint === params.sourceCredentialFingerprint &&
+    expiresAt !== undefined &&
+    expiresAt - (params.now ?? Date.now()) > 5 * 60 * 1000
+  );
+}
+
+type CopilotTokenCache = {
+  path: string;
+  load(): CachedCopilotToken | undefined;
+  save(value: CachedCopilotToken): void;
+};
+
+export function resolveCopilotTokenCache(params: {
+  domain: string;
+  sourceCredentialFingerprint: string;
+  openCacheStore?: () => PluginStateSyncKeyedStore<CachedCopilotToken>;
+  cachePath?: string;
+  loadJsonFileImpl?: (path: string) => unknown;
+  saveJsonFileImpl?: (path: string, value: CachedCopilotToken) => void;
+}): CopilotTokenCache {
+  const usesExplicitCacheAdapter =
+    params.cachePath !== undefined ||
+    params.loadJsonFileImpl !== undefined ||
+    params.saveJsonFileImpl !== undefined;
+  if (usesExplicitCacheAdapter) {
+    // Explicit file adapters are test/compat seams only. Runtime state is SQLite.
+    const cachePath = params.cachePath?.trim() || "explicit-cache";
+    const loadJsonFileFn = params.loadJsonFileImpl ?? (() => undefined);
+    const saveJsonFileFn = params.saveJsonFileImpl ?? (() => undefined);
+    return {
+      path: cachePath,
+      load: () => loadJsonFileFn(cachePath) as CachedCopilotToken | undefined,
+      save: (value) => saveJsonFileFn(cachePath, value),
+    };
+  }
+
+  const store = params.openCacheStore?.();
+  if (!store) {
+    // Direct live/tests may call the provider helper without plugin registration.
+    // They exchange normally but do not persist runtime state outside SQLite.
+    return {
+      path: "uncached",
+      load: () => undefined,
+      save: () => undefined,
+    };
+  }
+  const key = `${params.domain}:${params.sourceCredentialFingerprint}`;
+  return {
+    path: "plugin-state",
+    load: () => store.lookup(key),
+    save: (value) =>
+      store.register(key, value, {
+        ttlMs: Math.max(1, value.expiresAt - Date.now()),
+      }),
+  };
+}

--- a/extensions/github-copilot/token.ts
+++ b/extensions/github-copilot/token.ts
@@ -1,6 +1,190 @@
-// Github Copilot plugin module implements token behavior.
-export {
-  DEFAULT_COPILOT_API_BASE_URL,
+// GitHub Copilot credential exchange and cache policy.
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import {
+  asDateTimestampMs,
+  parseStrictNonNegativeInteger,
+  resolveExpiresAtMsFromEpochSeconds,
+} from "openclaw/plugin-sdk/number-runtime";
+import type { PluginStateSyncKeyedStore } from "openclaw/plugin-sdk/plugin-state-runtime";
+import {
+  buildCopilotIdeHeaders,
+  COPILOT_INTEGRATION_ID,
   deriveCopilotApiBaseUrlFromToken,
-  resolveCopilotApiToken,
 } from "openclaw/plugin-sdk/provider-auth";
+import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
+import { PUBLIC_GITHUB_COPILOT_DOMAIN, resolveGithubCopilotDomain } from "./domain.js";
+import {
+  fingerprintCopilotSourceCredential,
+  isCopilotTokenUsable,
+  resolveCopilotTokenCache,
+  type CachedCopilotToken,
+} from "./token-cache.js";
+export { deriveCopilotApiBaseUrlFromToken } from "openclaw/plugin-sdk/provider-auth";
+export type { CachedCopilotToken } from "./token-cache.js";
+
+export const DEFAULT_COPILOT_API_BASE_URL = "https://api.individual.githubcopilot.com";
+const COPILOT_TOKEN_EXCHANGE_TIMEOUT_MS = 30_000;
+let openConfiguredCacheStore: (() => PluginStateSyncKeyedStore<CachedCopilotToken>) | undefined;
+
+/** Bind provider-scoped SQLite state when the bundled plugin registers. */
+export function configureCopilotTokenCacheStore(
+  openCacheStore: () => PluginStateSyncKeyedStore<CachedCopilotToken>,
+): void {
+  openConfiguredCacheStore = openCacheStore;
+}
+
+function copilotTokenUrl(domain: string): string {
+  return `https://api.${domain}/copilot_internal/v2/token`;
+}
+
+function copilotApiBaseFallback(domain: string): string {
+  return domain === PUBLIC_GITHUB_COPILOT_DOMAIN
+    ? DEFAULT_COPILOT_API_BASE_URL
+    : `https://copilot-api.${domain}`;
+}
+
+function resolveCopilotTokenExpiresAtMs(expiresAt: unknown): number | undefined {
+  const parsed =
+    typeof expiresAt === "number" && Number.isFinite(expiresAt)
+      ? expiresAt
+      : typeof expiresAt === "string" && expiresAt.trim().length > 0
+        ? parseStrictNonNegativeInteger(expiresAt)
+        : undefined;
+  if (parsed === undefined) {
+    return undefined;
+  }
+  return parsed < 100_000_000_000
+    ? resolveExpiresAtMsFromEpochSeconds(parsed)
+    : asDateTimestampMs(parsed);
+}
+
+function parseCopilotTokenResponse(value: unknown): { token: string; expiresAt: number } {
+  if (!value || typeof value !== "object") {
+    throw new Error("Unexpected response from GitHub Copilot token endpoint");
+  }
+  const record = value as Record<string, unknown>;
+  const { token: credential, expires_at: expiresAt } = record;
+  if (typeof credential !== "string" || credential.trim().length === 0) {
+    throw new Error("Copilot token response missing token");
+  }
+  if (
+    expiresAt === undefined ||
+    expiresAt === null ||
+    (typeof expiresAt === "string" && expiresAt.trim().length === 0)
+  ) {
+    throw new Error("Copilot token response missing expires_at");
+  }
+  const expiresAtMs = resolveCopilotTokenExpiresAtMs(expiresAt);
+  if (expiresAtMs === undefined) {
+    throw new Error("Copilot token response has invalid expires_at");
+  }
+  return { token: credential, expiresAt: expiresAtMs };
+}
+
+async function cancelUnreadResponseBody(response: Response): Promise<void> {
+  if (!response.bodyUsed) {
+    await response.body?.cancel().catch(() => undefined);
+  }
+}
+
+export type ResolveCopilotApiToken = typeof resolveCopilotApiToken;
+
+export async function resolveCopilotApiToken(params: {
+  githubToken: string;
+  env?: NodeJS.ProcessEnv;
+  fetchImpl?: typeof fetch;
+  cachePath?: string;
+  loadJsonFileImpl?: (path: string) => unknown;
+  saveJsonFileImpl?: (path: string, value: CachedCopilotToken) => void;
+  openCacheStore?: () => PluginStateSyncKeyedStore<CachedCopilotToken>;
+  githubDomain?: string;
+  config?: OpenClawConfig;
+}): Promise<{
+  token: string;
+  expiresAt: number;
+  source: string;
+  baseUrl: string;
+}> {
+  const env = params.env ?? process.env;
+  const domain = resolveGithubCopilotDomain({
+    env,
+    explicit: params.githubDomain,
+    config: params.config,
+  });
+  const tokenUrl = copilotTokenUrl(domain);
+  const apiBaseFallback = copilotApiBaseFallback(domain);
+  const sourceCredentialFingerprint = fingerprintCopilotSourceCredential(params.githubToken);
+  const cache = resolveCopilotTokenCache({
+    domain,
+    sourceCredentialFingerprint,
+    ...(params.openCacheStore || openConfiguredCacheStore
+      ? { openCacheStore: params.openCacheStore ?? openConfiguredCacheStore }
+      : {}),
+    ...(params.cachePath !== undefined ? { cachePath: params.cachePath } : {}),
+    ...(params.loadJsonFileImpl ? { loadJsonFileImpl: params.loadJsonFileImpl } : {}),
+    ...(params.saveJsonFileImpl ? { saveJsonFileImpl: params.saveJsonFileImpl } : {}),
+  });
+  const cached = cache.load();
+  if (
+    cached &&
+    typeof cached.token === "string" &&
+    typeof cached.expiresAt === "number" &&
+    isCopilotTokenUsable({ cache: cached, domain, sourceCredentialFingerprint })
+  ) {
+    const { token: credential } = cached;
+    return {
+      token: credential,
+      expiresAt: cached.expiresAt,
+      source: `cache:${cache.path}`,
+      baseUrl: deriveCopilotApiBaseUrlFromToken(cached.token) ?? apiBaseFallback,
+    };
+  }
+
+  const fetchImpl = params.fetchImpl ?? fetch;
+  const signal = AbortSignal.timeout(COPILOT_TOKEN_EXCHANGE_TIMEOUT_MS);
+  let payload: ReturnType<typeof parseCopilotTokenResponse>;
+  try {
+    const response = await fetchImpl(tokenUrl, {
+      method: "GET",
+      headers: {
+        Accept: "application/json",
+        Authorization: `Bearer ${params.githubToken}`,
+        "Copilot-Integration-Id": COPILOT_INTEGRATION_ID,
+        ...buildCopilotIdeHeaders({ includeApiVersion: true }),
+      },
+      signal,
+    });
+    if (!response.ok) {
+      await cancelUnreadResponseBody(response);
+      throw new Error(`Copilot token exchange failed: HTTP ${response.status}`);
+    }
+    payload = parseCopilotTokenResponse(
+      await readProviderJsonResponse(response, "github-copilot.token"),
+    );
+  } catch (error) {
+    if (signal.aborted && error === signal.reason) {
+      throw new Error(
+        `Copilot token exchange failed: timed out after ${COPILOT_TOKEN_EXCHANGE_TIMEOUT_MS}ms`,
+        { cause: error },
+      );
+    }
+    throw error;
+  }
+
+  const cachedPayload: CachedCopilotToken = {
+    token: payload.token,
+    expiresAt: payload.expiresAt,
+    updatedAt: Date.now(),
+    integrationId: COPILOT_INTEGRATION_ID,
+    sourceCredentialFingerprint,
+    domain,
+  };
+  cache.save(cachedPayload);
+  const { token: credential } = cachedPayload;
+  return {
+    token: credential,
+    expiresAt: cachedPayload.expiresAt,
+    source: `fetched:${tokenUrl}`,
+    baseUrl: deriveCopilotApiBaseUrlFromToken(cachedPayload.token) ?? apiBaseFallback,
+  };
+}

--- a/src/agents/simple-completion-runtime.test.ts
+++ b/src/agents/simple-completion-runtime.test.ts
@@ -20,7 +20,6 @@ const hoisted = vi.hoisted(() => ({
   getApiKeyForModelMock: vi.fn(),
   applyLocalNoAuthHeaderOverrideMock: vi.fn(),
   setRuntimeApiKeyMock: vi.fn(),
-  resolveCopilotApiTokenMock: vi.fn(),
   prepareProviderRuntimeAuthMock: vi.fn(),
   prepareModelForSimpleCompletionMock: vi.fn((params: { model: unknown }) => params.model),
   completeMock: vi.fn(),
@@ -54,10 +53,6 @@ vi.mock("./model-auth.js", () => ({
   applyLocalNoAuthHeaderOverride: hoisted.applyLocalNoAuthHeaderOverrideMock,
 }));
 
-vi.mock("../plugin-sdk/provider-auth.js", () => ({
-  resolveCopilotApiToken: hoisted.resolveCopilotApiTokenMock,
-}));
-
 vi.mock("../plugins/provider-runtime.runtime.js", () => ({
   prepareProviderRuntimeAuth: hoisted.prepareProviderRuntimeAuthMock,
 }));
@@ -74,7 +69,6 @@ beforeEach(() => {
   hoisted.getApiKeyForModelMock.mockReset();
   hoisted.applyLocalNoAuthHeaderOverrideMock.mockReset();
   hoisted.setRuntimeApiKeyMock.mockReset();
-  hoisted.resolveCopilotApiTokenMock.mockReset();
   hoisted.prepareProviderRuntimeAuthMock.mockReset();
   hoisted.prepareModelForSimpleCompletionMock.mockReset();
   hoisted.completeMock.mockReset();
@@ -104,13 +98,16 @@ beforeEach(() => {
     source: "env:TEST_API_KEY",
     mode: "api-key",
   });
-  hoisted.resolveCopilotApiTokenMock.mockResolvedValue({
-    token: "copilot-runtime-token",
-    expiresAt: Date.now() + 60_000,
-    source: "cache:/tmp/copilot-token.json",
-    baseUrl: "https://api.individual.githubcopilot.com",
-  });
-  hoisted.prepareProviderRuntimeAuthMock.mockResolvedValue(undefined);
+  hoisted.prepareProviderRuntimeAuthMock.mockImplementation(
+    async (params: { provider: string }) => {
+      return params.provider === "github-copilot"
+        ? {
+            apiKey: "copilot-runtime-token",
+            baseUrl: "https://api.individual.githubcopilot.com",
+          }
+        : undefined;
+    },
+  );
   hoisted.ensureAuthProfileStoreMock.mockReturnValue({ version: 1, profiles: {} });
 });
 
@@ -303,9 +300,13 @@ describe("prepareSimpleCompletionModel", () => {
       modelId: "gpt-4.1",
     });
 
-    expect(hoisted.resolveCopilotApiTokenMock).toHaveBeenCalledWith({
-      githubToken: "ghu_test",
-      config: undefined,
+    expect(callArg(hoisted.prepareProviderRuntimeAuthMock)).toMatchObject({
+      provider: "github-copilot",
+      context: {
+        apiKey: "ghu_test",
+        authMode: "token",
+        modelId: "gpt-4.1",
+      },
     });
     const [storedProvider, storedKey] = hoisted.setRuntimeApiKeyMock.mock.calls[0] as [
       string,
@@ -374,9 +375,9 @@ describe("prepareSimpleCompletionModel", () => {
       modelId: "gpt-4.1",
     });
 
-    expect(hoisted.resolveCopilotApiTokenMock).toHaveBeenCalledWith({
-      githubToken: sourceSecret,
-      config: undefined,
+    expect(callArg(hoisted.prepareProviderRuntimeAuthMock)).toMatchObject({
+      provider: "github-copilot",
+      context: { apiKey: sourceSentinel },
     });
     expectPreparedModelResult(result);
     expect(looksLikeSecretSentinel(result.auth.apiKey ?? "")).toBe(true);
@@ -399,10 +400,8 @@ describe("prepareSimpleCompletionModel", () => {
       source: "profile:github-copilot:default",
       mode: "token",
     });
-    hoisted.resolveCopilotApiTokenMock.mockResolvedValueOnce({
-      token: "copilot-runtime-token",
-      expiresAt: Date.now() + 60_000,
-      source: "cache:/tmp/copilot-token.json",
+    hoisted.prepareProviderRuntimeAuthMock.mockResolvedValueOnce({
+      apiKey: "copilot-runtime-token",
       baseUrl: "https://api.copilot.enterprise.example",
     });
 

--- a/src/agents/simple-completion-runtime.ts
+++ b/src/agents/simple-completion-runtime.ts
@@ -40,10 +40,7 @@ import {
 } from "./model-selection.js";
 import { OPENAI_PROVIDER_ID, isOpenAIProvider } from "./openai-routing.js";
 import { applyPreparedRuntimeAuthToModel } from "./provider-request-config.js";
-import {
-  protectPreparedProviderRuntimeAuth,
-  unwrapSecretSentinelsForProviderEgress,
-} from "./provider-secret-egress.js";
+import { protectPreparedProviderRuntimeAuth } from "./provider-secret-egress.js";
 import { resolveSimpleCompletionModelResolverWorkspace } from "./simple-completion-scope.js";
 import { prepareModelForSimpleCompletion } from "./simple-completion-transport.js";
 import { resolveUtilityModelRefForAgent } from "./utility-model.js";
@@ -181,29 +178,6 @@ async function setRuntimeApiKeyForCompletion(params: {
   workspaceDir?: string;
   profileId?: string;
 }): Promise<CompletionRuntimeCredential> {
-  if (params.model.provider === "github-copilot") {
-    const { resolveCopilotApiToken } = await import("../plugin-sdk/provider-auth.js");
-    const copilotToken = await resolveCopilotApiToken({
-      githubToken: unwrapSecretSentinelsForProviderEgress(
-        params.apiKey,
-        "GitHub Copilot runtime auth exchange",
-      ),
-      config: params.cfg,
-    });
-    const protectedAuth = protectPreparedProviderRuntimeAuth({
-      provider: params.model.provider,
-      preparedAuth: {
-        apiKey: copilotToken.token,
-        baseUrl: copilotToken.baseUrl,
-      },
-    });
-    const runtimeApiKey = protectedAuth?.apiKey ?? copilotToken.token;
-    params.authStorage.setRuntimeApiKey(params.model.provider, runtimeApiKey);
-    return {
-      apiKey: runtimeApiKey,
-      model: { ...params.model, baseUrl: copilotToken.baseUrl },
-    };
-  }
   const preparedAuth = protectPreparedProviderRuntimeAuth({
     provider: params.model.provider,
     preparedAuth: await prepareProviderRuntimeAuth({
@@ -218,10 +192,7 @@ async function setRuntimeApiKeyForCompletion(params: {
         provider: params.model.provider,
         modelId: params.model.id,
         model: params.model,
-        apiKey: unwrapSecretSentinelsForProviderEgress(
-          params.apiKey,
-          "provider runtime auth exchange",
-        ),
+        apiKey: params.apiKey,
         authMode: params.authMode,
         profileId: params.profileId,
       },

--- a/src/media-understanding/image-model-runtime.ts
+++ b/src/media-understanding/image-model-runtime.ts
@@ -9,13 +9,10 @@ import {
 import { normalizeModelRef } from "../agents/model-selection.js";
 import { ensureOpenClawModelsJson } from "../agents/models-config.js";
 import { resolveProviderModelMaterializationAuthMode } from "../agents/provider-model-route-auth.js";
-import {
-  protectPreparedProviderRuntimeAuth,
-  unwrapSecretSentinelsForProviderEgress,
-} from "../agents/provider-secret-egress.js";
+import { protectPreparedProviderRuntimeAuth } from "../agents/provider-secret-egress.js";
 import { providerUsesCredentialScopedModelMetadata } from "../agents/runtime-plan/credential-scoped-model.js";
 import type { Model } from "../llm/types.js";
-import { resolveCopilotApiToken } from "../plugin-sdk/provider-auth.js";
+import { prepareProviderRuntimeAuth } from "../plugins/provider-runtime.runtime.js";
 import type { ImageDescriptionRequest } from "./types.js";
 
 type ImageRuntimeParams = {
@@ -119,26 +116,30 @@ async function prepareResolvedImageRuntime(
     return { apiKey: "", model: applySecretRefHeaderSentinels(model, params.cfg) };
   }
   let apiKey = requireApiKey(apiKeyInfo, model.provider);
-  // Image tool bypasses prepareRuntimeAuth — exchange OAuth token for
-  // a short-lived Copilot API token so the integrator scope (vscode-chat)
-  // matches what runtime chat requests send.
-  if (model.provider === "github-copilot") {
-    const copilotToken = await resolveCopilotApiToken({
-      githubToken: unwrapSecretSentinelsForProviderEgress(
-        apiKey,
-        "GitHub Copilot image-auth exchange",
-      ),
-      config: params.cfg,
-    });
-    const protectedAuth = protectPreparedProviderRuntimeAuth({
+  const preparedAuth = protectPreparedProviderRuntimeAuth({
+    provider: model.provider,
+    preparedAuth: await prepareProviderRuntimeAuth({
       provider: model.provider,
-      preparedAuth: { apiKey: copilotToken.token, baseUrl: copilotToken.baseUrl },
-    });
-    apiKey = protectedAuth?.apiKey ?? copilotToken.token;
-    const runtimeBaseUrl = protectedAuth?.baseUrl?.trim();
-    if (runtimeBaseUrl) {
-      model = { ...model, baseUrl: runtimeBaseUrl };
-    }
+      config: params.cfg,
+      workspaceDir: params.workspaceDir,
+      env: process.env,
+      context: {
+        config: params.cfg,
+        workspaceDir: params.workspaceDir,
+        env: process.env,
+        provider: model.provider,
+        modelId: model.id,
+        model,
+        apiKey,
+        authMode: apiKeyInfo.mode,
+        profileId: apiKeyInfo.profileId,
+      },
+    }),
+  });
+  apiKey = preparedAuth?.apiKey?.trim() || apiKey;
+  const runtimeBaseUrl = preparedAuth?.baseUrl?.trim();
+  if (runtimeBaseUrl) {
+    model = { ...model, baseUrl: runtimeBaseUrl };
   }
   authStorage.setRuntimeApiKey(model.provider, apiKey);
   return { apiKey, model: applySecretRefHeaderSentinels(model, params.cfg) };

--- a/src/media-understanding/image.test.ts
+++ b/src/media-understanding/image.test.ts
@@ -35,9 +35,9 @@ const hoisted = vi.hoisted(() => ({
   fetchMock: vi.fn(),
   registerProviderStreamForModelMock: vi.fn(),
   prepareProviderDynamicModelMock: vi.fn(async () => {}),
+  prepareProviderRuntimeAuthMock: vi.fn(),
   resolveModelAsyncMock: vi.fn(),
   resolveModelWithRegistryMock: vi.fn(),
-  resolveCopilotApiTokenMock: vi.fn(),
   shouldPreferProviderRuntimeResolvedModelMock: vi.fn(() => false),
   unwrapSecretSentinelsForProviderEgressMock: vi.fn((value: string) => value),
 }));
@@ -52,9 +52,9 @@ const {
   fetchMock,
   registerProviderStreamForModelMock,
   prepareProviderDynamicModelMock,
+  prepareProviderRuntimeAuthMock,
   resolveModelAsyncMock,
   resolveModelWithRegistryMock,
-  resolveCopilotApiTokenMock,
   shouldPreferProviderRuntimeResolvedModelMock,
   unwrapSecretSentinelsForProviderEgressMock,
 } = hoisted;
@@ -147,6 +147,10 @@ vi.mock("../plugins/provider-runtime.js", async () => ({
   shouldPreferProviderRuntimeResolvedModel: shouldPreferProviderRuntimeResolvedModelMock,
 }));
 
+vi.mock("../plugins/provider-runtime.runtime.js", () => ({
+  prepareProviderRuntimeAuth: prepareProviderRuntimeAuthMock,
+}));
+
 vi.mock("../agents/embedded-agent-runner/model.js", () => ({
   resolveModelAsync: resolveModelAsyncMock,
 }));
@@ -157,7 +161,6 @@ vi.mock("../plugin-sdk/provider-auth.js", () => ({
     "User-Agent": "GitHubCopilotChat/0.35.0",
   }),
   COPILOT_INTEGRATION_ID: "vscode-chat",
-  resolveCopilotApiToken: resolveCopilotApiTokenMock,
 }));
 
 const { describeImageWithModel } = await import("./image.js");
@@ -212,11 +215,13 @@ describe("describeImageWithModel", () => {
         return { authStorage, model, modelRegistry };
       },
     );
-    resolveCopilotApiTokenMock.mockResolvedValue({
-      token: "copilot-api-token",
-      expiresAt: Date.now() + 60_000,
-      source: "test",
-      baseUrl: "https://api.githubcopilot.com",
+    prepareProviderRuntimeAuthMock.mockImplementation(async (params: { provider: string }) => {
+      return params.provider === "github-copilot"
+        ? {
+            apiKey: "copilot-api-token",
+            baseUrl: "https://api.githubcopilot.com",
+          }
+        : undefined;
     });
   });
 
@@ -1547,10 +1552,12 @@ describe("describeImageWithModel", () => {
 
     expect(completeMock).not.toHaveBeenCalled();
     expect(providerStreamFn).toHaveBeenCalledOnce();
-    expect(resolveCopilotApiTokenMock).toHaveBeenCalledWith({
-      githubToken: "oauth-test",
-      config: {},
-    });
+    expect(prepareProviderRuntimeAuthMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "github-copilot",
+        context: expect.objectContaining({ apiKey: "oauth-test", authMode: "oauth" }),
+      }),
+    );
     const storedToken = setRuntimeApiKeyMock.mock.calls[0]?.[1] as string;
     expect(setRuntimeApiKeyMock.mock.calls[0]?.[0]).toBe("github-copilot");
     expect(looksLikeSecretSentinel(storedToken)).toBe(true);
@@ -1620,10 +1627,12 @@ describe("describeImageWithModel", () => {
       timeoutMs: 1000,
     });
 
-    expect(resolveCopilotApiTokenMock).toHaveBeenCalledWith({
-      githubToken: sourceSecret,
-      config: {},
-    });
+    expect(prepareProviderRuntimeAuthMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "github-copilot",
+        context: expect.objectContaining({ apiKey: sourceSentinel, authMode: "token" }),
+      }),
+    );
     const storedToken = setRuntimeApiKeyMock.mock.calls[0]?.[1] as string;
     expect(looksLikeSecretSentinel(storedToken)).toBe(true);
     expect(resolveSecretSentinel(storedToken)).toBe("copilot-api-token");
@@ -1641,7 +1650,7 @@ describe("describeImageWithModel", () => {
         baseUrl: "https://api.githubcopilot.com",
       })),
     });
-    resolveCopilotApiTokenMock.mockRejectedValueOnce(
+    prepareProviderRuntimeAuthMock.mockRejectedValueOnce(
       new Error("Copilot token exchange failed: HTTP 401"),
     );
 

--- a/src/plugins/provider-runtime.test.ts
+++ b/src/plugins/provider-runtime.test.ts
@@ -1137,6 +1137,52 @@ describe("provider-runtime", () => {
     });
   });
 
+  it("unwraps secret sentinels only after finding the provider auth hook", async () => {
+    const { mintSecretSentinel } = await import("../secrets/sentinel.js");
+    const sourceToken = "provider-source-token";
+    const sourceSentinel = mintSecretSentinel(sourceToken, { label: "provider-runtime-test" });
+    const prepareRuntimeAuth = vi.fn(async () => ({ apiKey: "runtime-token" }));
+    resolvePluginProvidersMock.mockReturnValue([
+      {
+        id: DEMO_PROVIDER_ID,
+        label: "Demo",
+        auth: [],
+        prepareRuntimeAuth,
+      },
+    ]);
+
+    await prepareProviderRuntimeAuth({
+      provider: DEMO_PROVIDER_ID,
+      context: {
+        env: process.env,
+        provider: DEMO_PROVIDER_ID,
+        modelId: MODEL.id,
+        model: MODEL,
+        apiKey: sourceSentinel,
+        authMode: "token",
+      },
+    });
+
+    expect(prepareRuntimeAuth).toHaveBeenCalledWith(
+      expect.objectContaining({ apiKey: sourceToken }),
+    );
+
+    resolvePluginProvidersMock.mockReturnValue([]);
+    await expect(
+      prepareProviderRuntimeAuth({
+        provider: "provider-without-hook",
+        context: {
+          env: process.env,
+          provider: "provider-without-hook",
+          modelId: MODEL.id,
+          model: { ...MODEL, provider: "provider-without-hook" },
+          apiKey: "oc-sent-v2.unknown.end",
+          authMode: "token",
+        },
+      }),
+    ).resolves.toBeUndefined();
+  });
+
   it("returns no runtime plugin when the provider has no owning plugin", () => {
     expectProviderRuntimePluginLoad({
       provider: "anthropic",

--- a/src/plugins/provider-runtime.ts
+++ b/src/plugins/provider-runtime.ts
@@ -15,6 +15,7 @@ import {
   applyPluginTextReplacements,
   mergePluginTextTransforms,
 } from "../agents/plugin-text-transforms.js";
+import { unwrapSecretSentinelsForProviderEgress } from "../agents/provider-secret-egress.js";
 import type { ProviderSystemPromptContribution } from "../agents/system-prompt-contribution.js";
 import type { ModelProviderConfig } from "../config/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -646,7 +647,20 @@ export async function prepareProviderRuntimeAuth(params: {
   env?: NodeJS.ProcessEnv;
   context: ProviderPrepareRuntimeAuthContext;
 }) {
-  return await resolveProviderRuntimePlugin(params)?.prepareRuntimeAuth?.(params.context);
+  const prepareRuntimeAuth = resolveProviderRuntimePlugin(params)?.prepareRuntimeAuth;
+  if (!prepareRuntimeAuth) {
+    return undefined;
+  }
+  // Secret material crosses into provider code only when that provider owns an
+  // auth hook. Callers can safely pass sentinels without probing plugin state.
+  const preparedInput = unwrapSecretSentinelsForProviderEgress(
+    params.context.apiKey,
+    "provider runtime auth exchange",
+  );
+  return await prepareRuntimeAuth({
+    ...params.context,
+    apiKey: preparedInput,
+  });
 }
 
 export async function resolveProviderUsageAuthWithPlugin(params: {


### PR DESCRIPTION
Related: #105584

AI-assisted maintainer follow-up.

## What Problem This Solves

Resolves an ownership gap exposed while landing #105584: simple completion and image-model paths bypassed the generic provider runtime-auth hook, while the GitHub Copilot plugin delegated its token exchange and cache to a deprecated Plugin SDK compatibility helper. Provider state consequently lived under a core owner instead of the provider plugin.

## Why This Change Was Made

The GitHub Copilot plugin now owns its active token exchange and bounded, provider-scoped SQLite cache. Core callers use the generic provider runtime-auth hook, with secret-sentinel unwrapping centralized at that provider boundary. The deprecated Plugin SDK helper and legacy OAuth path remain unchanged for shipped compatibility, and the shared host allowlist remains the single canonical security policy.

## User Impact

No intended user-visible behavior change. GitHub Copilot authentication keeps the same endpoints, cache validity rules, fallback URLs, and storage-failure semantics, while completion and image-model callers now follow the same provider-owned runtime path.

## Evidence

- 193 focused tests passed across the GitHub Copilot plugin, simple completion, image-model runtime, and provider runtime.
- Targeted oxfmt and oxlint checks passed; `git diff --check` passed.
- Linux Node 24 production typechecks passed for core and plugins.
- Linux Node 24 test typechecks and full `pnpm build` passed.
- Fresh autoreview passed with no accepted or actionable findings, confidence 0.91.
- `check:changed` reached only the existing Plugin SDK API-baseline hash drift, reproduced unchanged on clean `origin/main`.

No changelog entry: behavior-neutral maintainer-requested refactor.
