### PR TITLE
fix: npm 12 global updates no longer stop at the candidate guard

### DIFF
--- a/docs/cli/update.md
+++ b/docs/cli/update.md
@@ -297,9 +297,11 @@ install: OpenClaw installs the new package into a temporary npm prefix,
 lets the candidate package validate the host Node version during `preinstall`,
 and verifies the packaged `dist` inventory there. A packed completion guard
 stays outside that inventory until `preinstall` succeeds, so package managers
-that skip lifecycle scripts also stop before activation. OpenClaw then swaps the
-clean package tree into the real global prefix. If verification fails, post-update doctor,
-plugin sync, and restart work do not run from the suspect tree. Even when the
+that skip lifecycle scripts also stop before activation. On npm 12 and newer,
+the updater approves only the candidate OpenClaw lifecycle; transitive
+dependency scripts remain blocked. OpenClaw then swaps the clean package tree
+into the real global prefix. If verification fails, post-update doctor, plugin
+sync, and restart work do not run from the suspect tree. Even when the
 installed version already matches the target, the command refreshes the
 global package install, then runs plugin sync, a core-command completion
 refresh, and restart work. This keeps packaged sidecars and channel-owned

--- a/docs/install/updating.md
+++ b/docs/install/updating.md
@@ -164,7 +164,9 @@ Node version during `preinstall`; only then does OpenClaw verify the packaged
 `dist` inventory and swap the clean package tree into the real global prefix. A
 packed completion guard is omitted from the expected inventory and removed only
 after `preinstall` succeeds, so skipped lifecycle scripts also fail before the
-swap. This avoids npm overlaying a new package onto stale files from the old one. If the install
+swap. On npm 12 and newer, the updater approves only the candidate OpenClaw
+lifecycle; transitive dependency scripts remain blocked. This avoids npm
+overlaying a new package onto stale files from the old one. If the install
 command fails, OpenClaw retries once with `--omit=optional`, which helps hosts
 where native optional dependencies cannot compile.
 

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -705,11 +705,17 @@ describe("update-cli", () => {
     } else {
       expect(packagePackCommandCall()).toBeUndefined();
     }
+    const allowScriptsIdentity = isNpmGitPackageSpec(spec)
+      ? `./${path.basename(installSpec)}`
+      : spec.toLowerCase().startsWith("openclaw@")
+        ? "openclaw"
+        : spec;
     const call = packageInstallCommandCall();
     expect(call?.[0]).toEqual([
       "npm",
       "i",
       "-g",
+      `--allow-scripts=${allowScriptsIdentity}`,
       installSpec,
       "--no-fund",
       "--no-audit",
@@ -4591,6 +4597,7 @@ describe("update-cli", () => {
         "npm",
         "i",
         "-g",
+        "--allow-scripts=openclaw",
         "openclaw@latest",
         "--no-fund",
         "--no-audit",
@@ -4601,6 +4608,7 @@ describe("update-cli", () => {
         "npm",
         "i",
         "-g",
+        "--allow-scripts=openclaw",
         "openclaw@latest",
         "--omit=optional",
         "--no-fund",

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -475,7 +475,7 @@ async function runGitUpdate(params: {
         : null;
     const installStep = await runUpdateStep({
       name: "global install",
-      argv: globalInstallArgs(installTarget, updateRoot, undefined, installLocation),
+      argv: globalInstallArgs(installTarget, updateRoot, undefined, installLocation, updateRoot),
       cwd: updateRoot,
       env: installEnv,
       timeoutMs: effectiveTimeout,

--- a/src/infra/package-update-steps.test.ts
+++ b/src/infra/package-update-steps.test.ts
@@ -439,6 +439,7 @@ describe("runGlobalPackageUpdateSteps", () => {
           "npm",
           "i",
           "-g",
+          "--allow-scripts=./openclaw-2.0.0.tgz",
           "--prefix",
           stagePrefix,
           path.join(packDir, "openclaw-2.0.0.tgz"),
@@ -447,6 +448,7 @@ describe("runGlobalPackageUpdateSteps", () => {
           "--loglevel=error",
           "--min-release-age=0",
         ]);
+        expect(cwd).toBe(packDir);
         await writePackageRoot(path.join(stagePrefix, "lib", "node_modules", "openclaw"), "2.0.0");
         await fs.mkdir(path.join(stagePrefix, "bin"), { recursive: true });
         await fs.symlink(

--- a/src/infra/package-update-steps.ts
+++ b/src/infra/package-update-steps.ts
@@ -278,6 +278,7 @@ async function prepareNpmGitSourceInstallSpec(params: {
   installCwd?: string;
 }): Promise<{
   installSpec: string;
+  installCwd: string | null;
   packDir: string | null;
   steps: PackageUpdateStepResult[];
   failedStep: PackageUpdateStepResult | null;
@@ -286,7 +287,13 @@ async function prepareNpmGitSourceInstallSpec(params: {
     params.installTarget.manager !== "npm" ||
     !isNpmGitSourceInstallSpec(params.installSpec, params.packageName)
   ) {
-    return { installSpec: params.installSpec, packDir: null, steps: [], failedStep: null };
+    return {
+      installSpec: params.installSpec,
+      installCwd: params.installCwd ?? null,
+      packDir: null,
+      steps: [],
+      failedStep: null,
+    };
   }
 
   const packDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-update-pack-"));
@@ -307,6 +314,7 @@ async function prepareNpmGitSourceInstallSpec(params: {
   if (packStep.exitCode !== 0) {
     return {
       installSpec: params.installSpec,
+      installCwd: params.installCwd ?? null,
       packDir,
       steps: [packStep],
       failedStep: packStep,
@@ -326,6 +334,7 @@ async function prepareNpmGitSourceInstallSpec(params: {
     };
     return {
       installSpec: params.installSpec,
+      installCwd: params.installCwd ?? null,
       packDir,
       steps: [packStep, failedStep],
       failedStep,
@@ -334,6 +343,7 @@ async function prepareNpmGitSourceInstallSpec(params: {
 
   return {
     installSpec: tarball,
+    installCwd: packDir,
     packDir,
     steps: [packStep],
     failedStep: null,
@@ -575,7 +585,6 @@ export async function runGlobalPackageUpdateSteps(params: {
   afterVersion: string | null;
   failedStep: PackageUpdateStepResult | null;
 }> {
-  const installCwd = params.installCwd === undefined ? {} : { cwd: params.installCwd };
   const installEnv = params.env === undefined ? {} : { env: params.env };
   let stagedInstall: StagedNpmInstall | null | undefined;
   let packedInstallDir: string | null = null;
@@ -626,8 +635,9 @@ export async function runGlobalPackageUpdateSteps(params: {
         preparedSpec.installSpec,
         undefined,
         installLocation,
+        preparedSpec.installCwd,
       ),
-      ...installCwd,
+      ...(preparedSpec.installCwd ? { cwd: preparedSpec.installCwd } : {}),
       ...installEnv,
       timeoutMs: params.timeoutMs,
     });
@@ -657,12 +667,13 @@ export async function runGlobalPackageUpdateSteps(params: {
         preparedSpec.installSpec,
         undefined,
         stagedInstall?.prefix,
+        preparedSpec.installCwd,
       );
       if (fallbackArgv) {
         const fallbackStep = await params.runStep({
           name: "global update (omit optional)",
           argv: fallbackArgv,
-          ...installCwd,
+          ...(preparedSpec.installCwd ? { cwd: preparedSpec.installCwd } : {}),
           ...installEnv,
           timeoutMs: params.timeoutMs,
         });

--- a/src/infra/update-global.test.ts
+++ b/src/infra/update-global.test.ts
@@ -431,6 +431,7 @@ describe("update global helpers", () => {
         "npm",
         "i",
         "-g",
+        "--allow-scripts=openclaw",
         "openclaw@latest",
         "--no-fund",
         "--no-audit",
@@ -682,6 +683,7 @@ describe("update global helpers", () => {
       "npm",
       "i",
       "-g",
+      "--allow-scripts=openclaw",
       "--prefix",
       "/tmp/stage",
       "openclaw@latest",
@@ -694,6 +696,7 @@ describe("update global helpers", () => {
       "npm",
       "i",
       "-g",
+      "--allow-scripts=openclaw",
       "--prefix",
       "/tmp/stage",
       "openclaw@latest",
@@ -705,11 +708,39 @@ describe("update global helpers", () => {
     ]);
   });
 
+  it("allows only the resolved npm candidate lifecycle identity", () => {
+    expect(globalInstallArgs("npm", "/tmp/openclaw-2026.7.2.tgz")).toContain(
+      "--allow-scripts=/tmp/openclaw-2026.7.2.tgz",
+    );
+    expect(globalInstallArgs("npm", "openclaw@npm:@vendor/openclaw@1.2.3")).toContain(
+      "--allow-scripts=@vendor/openclaw",
+    );
+    expect(globalInstallArgs("npm", "openclaw@npm:vendor-openclaw@1.2.3")).toContain(
+      "--allow-scripts=vendor-openclaw",
+    );
+    expect(globalInstallArgs("npm", "./openclaw-candidate")).toContain(
+      "--allow-scripts=./openclaw-candidate",
+    );
+  });
+
+  it("keeps commas in ancestor directories out of npm's lifecycle policy", () => {
+    expect(
+      globalInstallArgs(
+        "npm",
+        "/tmp/build,cache/openclaw-candidate",
+        null,
+        null,
+        "/tmp/build,cache",
+      ),
+    ).toContain("--allow-scripts=./openclaw-candidate");
+  });
+
   it("builds global install argv for each supported manager", () => {
     expect(globalInstallArgs("npm", "openclaw@latest")).toEqual([
       "npm",
       "i",
       "-g",
+      "--allow-scripts=openclaw",
       "openclaw@latest",
       "--no-fund",
       "--no-audit",
@@ -741,6 +772,7 @@ describe("update global helpers", () => {
       "npm",
       "i",
       "-g",
+      "--allow-scripts=openclaw",
       "openclaw@latest",
       "--omit=optional",
       "--no-fund",

--- a/src/infra/update-global.ts
+++ b/src/infra/update-global.ts
@@ -108,6 +108,68 @@ function isExplicitPackageInstallSpec(value: string): boolean {
   );
 }
 
+function isRelativePackageInstallPath(value: string): boolean {
+  return /^(?:\.{1,2})(?:[\\/]|$)/u.test(value);
+}
+
+function resolveNpmInstallScriptsAllowFlag(spec: string, installCwd?: string | null): string {
+  const normalized = normalizePackageTarget(spec);
+  const unaliased = stripPrimaryPackageAlias(normalized);
+  let identity =
+    isExplicitPackageInstallSpec(normalized) ||
+    isExplicitPackageInstallSpec(unaliased) ||
+    isRelativePackageInstallPath(unaliased) ||
+    path.isAbsolute(normalized) ||
+    path.isAbsolute(unaliased)
+      ? unaliased
+      : PRIMARY_PACKAGE_NAME;
+  identity = resolveNpmAliasPackageName(identity) ?? identity;
+  if (installCwd && path.isAbsolute(identity)) {
+    // npm resolves relative allow-scripts identities against its cwd. Relativize
+    // first so commas in ancestor directories do not split the policy value.
+    const relativeIdentity = path.relative(installCwd, identity) || ".";
+    identity =
+      path.isAbsolute(relativeIdentity) ||
+      relativeIdentity === "." ||
+      relativeIdentity === ".." ||
+      relativeIdentity.startsWith(`..${path.sep}`)
+        ? relativeIdentity
+        : `./${relativeIdentity}`;
+  }
+  if (identity.includes(",")) {
+    throw new Error(
+      "npm cannot allow lifecycle scripts for an install target containing a comma; rename the package or source path",
+    );
+  }
+  return `--allow-scripts=${identity || PRIMARY_PACKAGE_NAME}`;
+}
+
+function resolveNpmAliasPackageName(spec: string): string | null {
+  if (!/^npm:/i.test(spec)) {
+    return null;
+  }
+  const target = spec.slice(spec.indexOf(":") + 1).trim();
+  if (target.startsWith("@")) {
+    const scopeSeparator = target.indexOf("/");
+    if (scopeSeparator <= 1) {
+      return null;
+    }
+    const versionSeparator = target.indexOf("@", scopeSeparator + 1);
+    return versionSeparator === -1 ? target : target.slice(0, versionSeparator);
+  }
+  const versionSeparator = target.indexOf("@");
+  const packageName = versionSeparator === -1 ? target : target.slice(0, versionSeparator);
+  return packageName || null;
+}
+
+function stripPrimaryPackageAlias(spec: string): string {
+  const normalized = normalizePackageTarget(spec);
+  const prefix = `${PRIMARY_PACKAGE_NAME}@`;
+  return normalized.toLowerCase().startsWith(prefix)
+    ? normalized.slice(prefix.length).trim()
+    : normalized;
+}
+
 /**
  * Extracts a pinned installed version from package specs like `openclaw@1.2.3`.
  * Moving tags, URLs, git refs, and aliases return null because they cannot be
@@ -905,6 +967,7 @@ export function globalInstallArgs(
   spec: string,
   pkgRoot?: string | null,
   installPrefix?: string | null,
+  installCwd?: string | null,
 ): string[] {
   const resolved = normalizeGlobalInstallCommand(managerOrCommand, pkgRoot);
   if (resolved.manager === "pnpm") {
@@ -924,6 +987,7 @@ export function globalInstallArgs(
     resolved.command,
     "i",
     "-g",
+    resolveNpmInstallScriptsAllowFlag(spec, installCwd),
     ...(installPrefix ? ["--prefix", installPrefix] : []),
     spec,
     ...NPM_GLOBAL_INSTALL_QUIET_FLAGS,
@@ -942,6 +1006,7 @@ export function globalInstallFallbackArgs(
   spec: string,
   pkgRoot?: string | null,
   installPrefix?: string | null,
+  installCwd?: string | null,
 ): string[] | null {
   const resolved = normalizeGlobalInstallCommand(managerOrCommand, pkgRoot);
   if (resolved.manager !== "npm") {
@@ -951,6 +1016,7 @@ export function globalInstallFallbackArgs(
     resolved.command,
     "i",
     "-g",
+    resolveNpmInstallScriptsAllowFlag(spec, installCwd),
     ...(installPrefix ? ["--prefix", installPrefix] : []),
     spec,
     "--omit=optional",

--- a/src/infra/update-runner.test.ts
+++ b/src/infra/update-runner.test.ts
@@ -451,11 +451,13 @@ describe("runGatewayUpdate", () => {
       : expected(normalizedArgv);
   };
 
-  const npmGlobalInstallCommand = (spec: string, extraArgs: string[] = []) =>
-    [
+  const npmGlobalInstallCommand = (spec: string, extraArgs: string[] = []) => {
+    const allowScriptsIdentity = spec.toLowerCase().startsWith("openclaw@") ? "openclaw" : spec;
+    return [
       "npm",
       "i",
       "-g",
+      `--allow-scripts=${allowScriptsIdentity}`,
       spec,
       ...extraArgs,
       "--no-fund",
@@ -463,6 +465,7 @@ describe("runGatewayUpdate", () => {
       "--loglevel=error",
       npmFreshnessArg,
     ].join(" ");
+  };
 
   function createGlobalNpmUpdateRunner(params: {
     pkgRoot: string;
@@ -2708,8 +2711,9 @@ describe("runGatewayUpdate", () => {
         argv[0] === "npm" &&
         argv[1] === "i" &&
         argv[2] === "-g" &&
-        path.basename(argv[3] ?? "") === "openclaw-2.0.0.tgz" &&
-        argv.slice(4).join(" ") === "--no-fund --no-audit --loglevel=error --min-release-age=0",
+        argv[3] === "--allow-scripts=./openclaw-2.0.0.tgz" &&
+        path.basename(argv[4] ?? "") === "openclaw-2.0.0.tgz" &&
+        argv.slice(5).join(" ") === "--no-fund --no-audit --loglevel=error --min-release-age=0",
       tag: "main",
     });
 
@@ -3059,7 +3063,7 @@ describe("runGatewayUpdate", () => {
     expect(result.mode).toBe("pnpm");
     expect(result.after?.version).toBe("2.0.0");
     const npmPrefixedGlobalInstallCalls = calls.filter((call) =>
-      call.startsWith("npm i -g --prefix "),
+      call.startsWith("npm i -g --allow-scripts=openclaw --prefix "),
     );
     const pnpmAddGlobalCalls = calls.filter((call) => call.startsWith("pnpm add -g"));
     expect(npmPrefixedGlobalInstallCalls.length).toBeGreaterThan(0);


### PR DESCRIPTION
Closes #107290
Related: #107239
Follow-up to #106994

## What Problem This Solves

Fixes an issue where npm 12 users running a global OpenClaw update would safely stop before activation because npm 12 blocks dependency lifecycle scripts by default, leaving the candidate completion guard in place.

## Why This Change Was Made

The updater now grants lifecycle permission only to the resolved OpenClaw candidate identity. Registry packages, npm aliases, local tarballs, local directories, and packed Git sources retain the identity and working directory npm uses for policy matching. Transitive dependency lifecycle scripts remain blocked on npm 12.

This is AI-assisted maintainer work. The implementation and npm contract were reviewed against npm's current official install documentation and npm 12 release guidance.

## User Impact

npm 12 global updates can complete the candidate Node-engine check and clean staged swap instead of failing at the completion guard. npm 11.9 remains compatible. Incompatible candidates still fail before the live install changes.

## Evidence

- Focused tests: 56 passed across `src/infra/update-global.test.ts` and `src/infra/package-update-steps.test.ts`.
- Source-blind packaged CLI validation: AWS Crabbox run `run_91388c39c39d`, lease `cbx_6cdc1e217077`, passed 4/4 scenarios: npm 12 update, npm 11.9 compatibility, UUID-redacted npm root, and incompatible-Node candidate preservation.
- The packaged tarball integrity check passed during the same validation.
- Docs MDX check passed: 732 files.
- Fresh branch autoreview against current `origin/main`: no accepted or actionable findings.
- `git diff --check` passed.

`CHANGELOG.md` is unchanged because release generation owns release notes.
