### PR TITLE
fix(android): preserve emoji in app session labels

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/SessionKey.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/SessionKey.kt
@@ -32,6 +32,6 @@ internal fun buildAndroidAppSessionLabel(
   deviceId: String,
 ): String {
   val deviceSuffix = deviceId.take(12)
-  val displaySuffix = displayName?.trim()?.take(96)?.takeIf { it.isNotEmpty() }
+  val displaySuffix = displayName?.trim()?.takeUtf16Safe(96)?.takeIf { it.isNotEmpty() }
   return listOfNotNull("OpenClaw App", displaySuffix, deviceSuffix).joinToString(" · ")
 }

--- a/apps/android/app/src/test/java/ai/openclaw/app/SessionKeyTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/SessionKeyTest.kt
@@ -22,6 +22,22 @@ class SessionKeyTest {
   }
 
   @Test
+  fun buildAndroidAppSessionLabelPreservesUtf16BoundariesAtDisplayNameLimit() {
+    val deviceId = "1234567890abcdef"
+    val splitPairPrefix = "a".repeat(95)
+    assertEquals(
+      "OpenClaw App · $splitPairPrefix · 1234567890ab",
+      buildAndroidAppSessionLabel("$splitPairPrefix😀tail", deviceId),
+    )
+
+    val completePairPrefix = "a".repeat(94)
+    assertEquals(
+      "OpenClaw App · $completePairPrefix😀 · 1234567890ab",
+      buildAndroidAppSessionLabel("$completePairPrefix😀tail", deviceId),
+    )
+  }
+
+  @Test
   fun resolveAgentIdFromMainSessionKeyParsesCanonicalAgentKey() {
     assertEquals("ops", resolveAgentIdFromMainSessionKey("agent:ops:main"))
     assertNull(resolveAgentIdFromMainSessionKey("global"))


### PR DESCRIPTION
## What Problem This Solves

Android builds the app's main-session label from the user-controlled profile display name. The existing `take(96)` truncation counts UTF-16 code units and can leave an unpaired high surrogate when an emoji crosses the limit.

## Why This Change Was Made

Reuse the existing Android `takeUtf16Safe` helper at the label's current 96-code-unit cap. This keeps the existing size contract while dropping a split surrogate pair instead of emitting malformed text.

## User Impact

App session labels remain valid Unicode when a display-name emoji lands on the truncation boundary. Display names and device suffixes otherwise render exactly as before.

## Evidence

- Added regression coverage for both a split surrogate pair and a complete pair at the 96-code-unit limit.
- `git diff --check` passes.
- Independent read-only review completed with no remaining actionable findings.
- Commit parent: `723c2f81ad341c6cd6fb2ea6738c6a34776b70a9` (latest `main` at synchronization time).
- Hosted fork CI is pending; local Gradle execution was intentionally skipped under the contributor-code validation policy.

AI-assisted change; no agent transcript attached.
