### PR TITLE
fix(android): preserve emoji in presence reason logs

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/node/NodePresenceAliveBeacon.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/node/NodePresenceAliveBeacon.kt
@@ -1,5 +1,6 @@
 package ai.openclaw.app.node
 
+import ai.openclaw.app.takeUtf16Safe
 import android.os.Build
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonPrimitive
@@ -109,6 +110,6 @@ internal object NodePresenceAliveBeacon {
     return value
       .map { ch -> if (ch.isISOControl()) ' ' else ch }
       .joinToString("")
-      .take(200)
+      .takeUtf16Safe(200)
   }
 }

--- a/apps/android/app/src/test/java/ai/openclaw/app/node/NodePresenceAliveBeaconTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/node/NodePresenceAliveBeaconTest.kt
@@ -98,4 +98,19 @@ class NodePresenceAliveBeaconTest {
     assertFalse(sanitized.contains("\t"))
     assertEquals(200, sanitized.length)
   }
+
+  @Test
+  fun sanitizeReasonForLog_preservesUtf16BoundariesAtLimit() {
+    val splitPairPrefix = "bad\n${"x".repeat(195)}"
+    assertEquals(
+      "bad ${"x".repeat(195)}",
+      NodePresenceAliveBeacon.sanitizeReasonForLog("$splitPairPrefix😀tail"),
+    )
+
+    val completePairPrefix = "bad\n${"x".repeat(194)}"
+    assertEquals(
+      "bad ${"x".repeat(194)}😀",
+      NodePresenceAliveBeacon.sanitizeReasonForLog("$completePairPrefix😀tail"),
+    )
+  }
 }


### PR DESCRIPTION
## What Problem This Solves

Android sanitizes gateway-provided `node.presence.alive` rejection reasons before logging them. The final `take(200)` can split an emoji and leave a lone high surrogate in the Android log message.

## Why This Change Was Made

Keep the existing control-character cleanup and 200-code-unit cap, but apply the shared Android `takeUtf16Safe` helper at the final truncation boundary.

## User Impact

Presence rejection diagnostics remain bounded and control-character-safe while preserving well-formed Unicode from gateway reason strings.

## Evidence

- Added regression coverage for split and complete surrogate pairs at the 200-code-unit limit, including the existing control-character sanitization.
- `git diff --check` passes.
- Independent read-only review completed with no remaining actionable findings.
- Commit parent: `723c2f81ad341c6cd6fb2ea6738c6a34776b70a9` (latest `main` at synchronization time).
- Hosted fork CI is pending; local Gradle execution was intentionally skipped under the contributor-code validation policy.

AI-assisted change; no agent transcript attached.
