### PR TITLE
fix(mcp): isolate per-server failures so healthy MCP tools still materialize

### DIFF
--- a/src/agents/agent-bundle-mcp-runtime.test.ts
+++ b/src/agents/agent-bundle-mcp-runtime.test.ts
@@ -1012,9 +1012,9 @@ describe("session MCP runtime", () => {
 
       // Broken server: no server entry, only diagnostic
       expect(catalog.servers.broken).toBeUndefined();
-      expect(catalog.diagnostics?.some(
-        (d) => d.serverName === "broken" && d.message.length > 0,
-      )).toBe(true);
+      expect(
+        catalog.diagnostics?.some((d) => d.serverName === "broken" && d.message.length > 0),
+      ).toBe(true);
     } finally {
       await runtime.dispose();
       await fs.rm(tempDir, { recursive: true, force: true });

--- a/src/agents/agent-bundle-mcp-runtime.test.ts
+++ b/src/agents/agent-bundle-mcp-runtime.test.ts
@@ -977,6 +977,50 @@ describe("session MCP runtime", () => {
     }
   });
 
+  it("isolates a broken MCP server so healthy servers still materialize tools", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "bundle-mcp-isolate-fail-"));
+    const goodPath = path.join(tempDir, "healthy.mjs");
+    const brokenPath = path.join(tempDir, "broken.mjs");
+    await writeListToolsMcpServer({
+      filePath: goodPath,
+      logPath: path.join(tempDir, "good.log"),
+      tools: [{ name: "healthy_tool", inputSchema: { type: "object", properties: {} } }],
+    });
+    // broken server exits immediately — MCP connect will fail
+    await writeExecutable(brokenPath, "#!/usr/bin/env node\nprocess.exit(1);\n");
+
+    const runtime = await getOrCreateSessionMcpRuntime({
+      sessionId: "session-isolate-fail",
+      sessionKey: "agent:test:session-isolate-fail",
+      workspaceDir: "/workspace",
+      cfg: {
+        mcp: {
+          servers: {
+            healthy: { command: process.execPath, args: [goodPath] },
+            broken: { command: process.execPath, args: [brokenPath] },
+          },
+        },
+      },
+    });
+
+    try {
+      const catalog = await runtime.getCatalog();
+
+      // Healthy server: tools materialized
+      expect(catalog.servers.healthy).toBeDefined();
+      expect(catalog.tools.map((t) => t.toolName)).toContain("healthy_tool");
+
+      // Broken server: no server entry, only diagnostic
+      expect(catalog.servers.broken).toBeUndefined();
+      expect(catalog.diagnostics?.some(
+        (d) => d.serverName === "broken" && d.message.length > 0,
+      )).toBe(true);
+    } finally {
+      await runtime.dispose();
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it("filters listed MCP tools with per-server include and exclude rules", async () => {
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "bundle-mcp-tool-filter-"));
     const serverPath = path.join(tempDir, "tool-filter.mjs");

--- a/src/agents/agent-bundle-mcp-runtime.ts
+++ b/src/agents/agent-bundle-mcp-runtime.ts
@@ -570,82 +570,81 @@ export function createSessionMcpRuntime(params: {
               let session: BundleMcpSession | undefined;
               let reusedSession = false;
               try {
-
-              session = sessions.get(serverName);
-              while (
-                session &&
-                !session.retiring &&
-                !session.connected &&
-                !session.connectPromise
-              ) {
-                // A closed SDK client cannot reconnect cleanly on the same transport.
-                await retireSessionIfCurrent(serverName, session);
-                // Retirement yields while closing. Preserve any replacement that a
-                // newer catalog generation installed during that await.
                 session = sessions.get(serverName);
-              }
-              if (session?.retiring) {
-                session = undefined;
-              }
-              reusedSession = Boolean(session);
-              if (!session) {
-                const client = new Client(
-                  {
-                    name: "openclaw-bundle-mcp",
-                    version: "0.0.0",
-                  },
-                  {
-                    ...buildMcpClientOptions(mcpAppsEnabled),
-                    jsonSchemaValidator: createMcpJsonSchemaValidator(),
-                    listChanged: {
-                      tools: {
-                        autoRefresh: false,
-                        debounceMs: 0,
-                        onChanged: (error) => {
-                          if (error) {
-                            logWarn(
-                              `bundle-mcp: failed to refresh changed tool list for server "${serverName}": ${redactErrorUrls(error)}`,
-                            );
-                          }
-                          catalogInvalidationGeneration += 1;
-                          catalog = null;
-                          catalogInFlight = undefined;
+                while (
+                  session &&
+                  !session.retiring &&
+                  !session.connected &&
+                  !session.connectPromise
+                ) {
+                  // A closed SDK client cannot reconnect cleanly on the same transport.
+                  await retireSessionIfCurrent(serverName, session);
+                  // Retirement yields while closing. Preserve any replacement that a
+                  // newer catalog generation installed during that await.
+                  session = sessions.get(serverName);
+                }
+                if (session?.retiring) {
+                  session = undefined;
+                }
+                reusedSession = Boolean(session);
+                if (!session) {
+                  const client = new Client(
+                    {
+                      name: "openclaw-bundle-mcp",
+                      version: "0.0.0",
+                    },
+                    {
+                      ...buildMcpClientOptions(mcpAppsEnabled),
+                      jsonSchemaValidator: createMcpJsonSchemaValidator(),
+                      listChanged: {
+                        tools: {
+                          autoRefresh: false,
+                          debounceMs: 0,
+                          onChanged: (error) => {
+                            if (error) {
+                              logWarn(
+                                `bundle-mcp: failed to refresh changed tool list for server "${serverName}": ${redactErrorUrls(error)}`,
+                              );
+                            }
+                            catalogInvalidationGeneration += 1;
+                            catalog = null;
+                            catalogInFlight = undefined;
+                          },
                         },
                       },
                     },
-                  },
-                );
-                const createdSession: BundleMcpSession = {
-                  serverName,
-                  client,
-                  transport: resolved.transport,
-                  transportType: resolved.transportType,
-                  requestTimeoutMs: resolved.requestTimeoutMs,
-                  supportsParallelToolCalls: resolved.supportsParallelToolCalls,
-                  connected: false,
-                  retiring: false,
-                  catalogUseCount: 0,
-                  sharedAcrossCatalogGenerations: false,
-                  detachStderr: resolved.detachStderr,
-                };
-                // The SDK exposes lifecycle hooks as callback properties. A close is
-                // terminal for this client/transport pair.
-                // oxlint-disable-next-line unicorn/prefer-add-event-listener -- MCP Client is not an EventTarget.
-                client.onclose = () => {
-                  createdSession.connected = false;
-                  createdSession.disconnectReason = "mcp transport closed";
-                };
-                session = createdSession;
-                sessions.set(serverName, session);
-              }
+                  );
+                  const createdSession: BundleMcpSession = {
+                    serverName,
+                    client,
+                    transport: resolved.transport,
+                    transportType: resolved.transportType,
+                    requestTimeoutMs: resolved.requestTimeoutMs,
+                    supportsParallelToolCalls: resolved.supportsParallelToolCalls,
+                    connected: false,
+                    retiring: false,
+                    catalogUseCount: 0,
+                    sharedAcrossCatalogGenerations: false,
+                    detachStderr: resolved.detachStderr,
+                  };
+                  // The SDK exposes lifecycle hooks as callback properties. A close is
+                  // terminal for this client/transport pair.
+                  // oxlint-disable-next-line unicorn/prefer-add-event-listener -- MCP Client is not an EventTarget.
+                  client.onclose = () => {
+                    createdSession.connected = false;
+                    createdSession.disconnectReason = "mcp transport closed";
+                  };
+                  session = createdSession;
+                  sessions.set(serverName, session);
+                }
 
-              if (session.catalogUseCount === 0) {
-                session.sharedAcrossCatalogGenerations = false;
-              }
-              if (reusedSession && session.catalogUseCount > 0) {
-                session.sharedAcrossCatalogGenerations = true;
-              }
-              session.catalogUseCount += 1;
+                if (session.catalogUseCount === 0) {
+                  session.sharedAcrossCatalogGenerations = false;
+                }
+                if (reusedSession && session.catalogUseCount > 0) {
+                  session.sharedAcrossCatalogGenerations = true;
+                }
+                session.catalogUseCount += 1;
                 failIfDisposed();
                 await ensureSessionConnected(session, resolved.connectionTimeoutMs);
                 failIfDisposed();

--- a/src/agents/agent-bundle-mcp-runtime.ts
+++ b/src/agents/agent-bundle-mcp-runtime.ts
@@ -567,8 +567,11 @@ export function createSessionMcpRuntime(params: {
           ({ serverName, rawServer, resolved, safeServerName, launchDescription }) =>
             async (): Promise<ServerResult> => {
               failIfDisposed();
+              let session: BundleMcpSession | undefined;
+              let reusedSession = false;
+              try {
 
-              let session = sessions.get(serverName);
+              session = sessions.get(serverName);
               while (
                 session &&
                 !session.retiring &&
@@ -584,7 +587,7 @@ export function createSessionMcpRuntime(params: {
               if (session?.retiring) {
                 session = undefined;
               }
-              const reusedSession = Boolean(session);
+              reusedSession = Boolean(session);
               if (!session) {
                 const client = new Client(
                   {
@@ -643,7 +646,6 @@ export function createSessionMcpRuntime(params: {
                 session.sharedAcrossCatalogGenerations = true;
               }
               session.catalogUseCount += 1;
-              try {
                 failIfDisposed();
                 await ensureSessionConnected(session, resolved.connectionTimeoutMs);
                 failIfDisposed();
@@ -726,6 +728,7 @@ export function createSessionMcpRuntime(params: {
                   diagnostics: [] as McpToolCatalogDiagnostic[],
                 };
               } catch (error) {
+                failIfDisposed();
                 const message = redactErrorUrls(error);
                 if (!disposed) {
                   const action = reusedSession ? "refresh" : "start";
@@ -741,16 +744,18 @@ export function createSessionMcpRuntime(params: {
                     message,
                   },
                 ];
-                const sharedWithNewerGeneration =
-                  session.sharedAcrossCatalogGenerations || session.catalogUseCount > 1;
-                if (!session.connected) {
-                  // A close is terminal for every catalog generation sharing this
-                  // session. The identity guard preserves any newer replacement.
-                  await retireSessionIfCurrent(serverName, session);
-                } else if (!reusedSession && !sharedWithNewerGeneration) {
-                  // Catalog invalidation can overlap generations; an older failed
-                  // generation must not dispose a session a newer one already reused.
-                  await retireSessionIfCurrent(serverName, session);
+                if (session) {
+                  const sharedWithNewerGeneration =
+                    session.sharedAcrossCatalogGenerations || session.catalogUseCount > 1;
+                  if (!session.connected) {
+                    // A close is terminal for every catalog generation sharing this
+                    // session. The identity guard preserves any newer replacement.
+                    await retireSessionIfCurrent(serverName, session);
+                  } else if (!reusedSession && !sharedWithNewerGeneration) {
+                    // Catalog invalidation can overlap generations; an older failed
+                    // generation must not dispose a session a newer one already reused.
+                    await retireSessionIfCurrent(serverName, session);
+                  }
                 }
                 failIfDisposed();
                 return {
@@ -760,9 +765,11 @@ export function createSessionMcpRuntime(params: {
                   diagnostics: diags,
                 } as ServerResult;
               } finally {
-                session.catalogUseCount -= 1;
-                if (session.catalogUseCount === 0) {
-                  session.sharedAcrossCatalogGenerations = false;
+                if (session) {
+                  session.catalogUseCount -= 1;
+                  if (session.catalogUseCount === 0) {
+                    session.sharedAcrossCatalogGenerations = false;
+                  }
                 }
               }
             },


### PR DESCRIPTION
#### What Problem This Solves

Close #106665

When one MCP server fails to connect or crashes during catalog materialization, the uncaught error propagates through `runTasksWithConcurrency` → `firstError` → `dispose ALL sessions` → throw to agent run setup. This kills the entire agent bundle runtime — healthy MCP server tools are lost along with the broken one.

#### Why This Change Was Made

The existing per-server task's `try/catch` started at `ensureSessionConnected` (line 646), leaving session creation, `Client` construction, and map operations unprotected. Any error before the `try` escaped through `runTasksWithConcurrency`'s `firstError` mechanism.

This moves the `try` boundary to cover the full per-server task lifecycle, hoists `session` and `reusedSession` declarations outside the `try`, and adds `failIfDisposed()` re-throw inside the `catch` so disposal still propagates. External failures (network, crash, protocol errors) become `McpToolCatalogDiagnostic` entries without affecting healthy servers.

#### User Impact

No visible impact under normal operation. When an MCP server fails, the agent run continues with available tools from healthy servers instead of aborting entirely.

#### Evidence

- **Type check:** `tsgo` core passes
- **Lint:** `oxlint` clean
- **Tests:** `agent-bundle-mcp-runtime.test.ts` — 74 tests (+1: `isolates a broken MCP server so healthy servers still materialize tools`)
- **Change scope:** 2 files, +67 −16 lines
  - `src/agents/agent-bundle-mcp-runtime.ts` — move `try/catch` boundary up to cover full per-server lifecycle
  - `src/agents/agent-bundle-mcp-runtime.test.ts` — new test with real MCP subprocess (healthy + `process.exit(1)` broken)
  - No config, CLI, SDK, docs surface affected

- **Live standalone proof — real MCP processes:**

```
[bundle-mcp] failed to start server "broken" (.../mcp-broken.py): McpError: MCP error -32000: Connection closed

Catalog Result:
  catalog.tools: ["healthy_tool"]
  catalog.servers: ["healthy"]
  catalog.diagnostics: 1 entry → server="broken"

✓ healthy server in catalog
✓ healthy_tool in tool list
✓ broken server has no catalog entry
✓ broken server has a diagnostic entry
✓ all tools come from healthy server only
```

- **Real Gateway proof — production agent run with 2 MCP servers:**

```
15:10:46 [bundle-mcp] failed to start server "broken" (python3 /tmp/mcp-broken.py): McpError: MCP error -32000: Connection closed

15:10:46 [agent/embedded] core-plugin-tool stages: ... plugin-tools:5141ms ... bundle-tools:120ms ...
15:10:47 [agent/embedded] prep stages: ... stream-setup:136ms → stream-ready (5674ms total)
15:10:47 [provider-transport-fetch] model-fetch: provider=zte status=200

✓ Broken server error captured as diagnostic — no gateway crash
✓ Agent run completed full lifecycle (plugin-tools → bundle-tools → stream-ready → model-fetch)
✓ Gateway remained live, model call returned 200
✓ Healthy MCP server connected successfully (no error log)
```
