### PR TITLE
fix(codex): structured abort detection, tool-schema repair, native-result middleware relay

### DIFF
--- a/docs/plugins/sdk-migration.md
+++ b/docs/plugins/sdk-migration.md
@@ -175,7 +175,10 @@ SDK.
     runtime-neutral middleware:
 
     ```typescript
-    // OpenClaw and Codex runtime dynamic tools
+    // OpenClaw runtime tools and Codex runtime dynamic tools (result may be
+    // transformed). Codex-native tool results are also relayed for observation,
+    // but their transformed output never reaches the model: the Codex
+    // PostToolUse hook contract cannot replace a native tool response.
     api.registerAgentToolResultMiddleware(async (event) => {
       return compactToolResult(event);
     }, {

--- a/extensions/codex/src/app-server/attempt-notification-state.ts
+++ b/extensions/codex/src/app-server/attempt-notification-state.ts
@@ -68,17 +68,11 @@ export function isTerminalCodexTurnNotificationForTurn(params: {
   notification: CodexServerNotification;
   threadId: string;
   turnId: string;
-  currentPromptTexts: string[];
 }): boolean {
   if (!isCodexNotificationForTurn(params.notification.params, params.threadId, params.turnId)) {
     return false;
   }
-  return (
-    params.notification.method === "turn/completed" ||
-    isCodexTurnAbortMarkerNotification(params.notification, {
-      currentPromptTexts: params.currentPromptTexts,
-    })
-  );
+  return params.notification.method === "turn/completed";
 }
 
 /**
@@ -285,7 +279,6 @@ export function applyCodexTurnNotificationState(params: {
     notification,
     threadId: params.threadId,
     turnId: params.turnId,
-    currentPromptTexts: params.currentPromptTexts,
   });
 
   return {

--- a/extensions/codex/src/app-server/attempt-notifications.test.ts
+++ b/extensions/codex/src/app-server/attempt-notifications.test.ts
@@ -1,6 +1,27 @@
 // Attempt-notification tests cover Codex app-server envelope parsing and diagnostics.
 import { describe, expect, it } from "vitest";
-import { describeNotificationActivity } from "./attempt-notifications.js";
+import {
+  describeNotificationActivity,
+  isCodexTurnAbortMarkerNotification,
+} from "./attempt-notifications.js";
+import type { CodexServerNotification } from "./protocol.js";
+
+function abortMarkerNotification(params: {
+  role: "user" | "developer";
+  text: string;
+}): CodexServerNotification {
+  return {
+    method: "rawResponseItem/completed",
+    params: {
+      item: {
+        id: "abort-marker-1",
+        type: "message",
+        role: params.role,
+        content: [{ type: "input_text", text: params.text }],
+      },
+    },
+  };
+}
 
 describe("describeNotificationActivity", () => {
   it("does not split surrogate pairs in assistant text previews", () => {
@@ -16,5 +37,61 @@ describe("describeNotificationActivity", () => {
     });
 
     expect(details?.lastAssistantTextPreview).toBe(`${"x".repeat(236)}...`);
+  });
+});
+
+describe("isCodexTurnAbortMarkerNotification", () => {
+  it("accepts a wrapped user marker", () => {
+    expect(
+      isCodexTurnAbortMarkerNotification(
+        abortMarkerNotification({
+          role: "user",
+          text: "<turn_aborted>\nuser interruption hint\n</turn_aborted>",
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("accepts a wrapped developer marker", () => {
+    expect(
+      isCodexTurnAbortMarkerNotification(
+        abortMarkerNotification({
+          role: "developer",
+          text: "<turn_aborted>\ndeveloper interruption hint\n</turn_aborted>",
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("accepts arbitrary wrapped body prose", () => {
+    expect(
+      isCodexTurnAbortMarkerNotification(
+        abortMarkerNotification({
+          role: "user",
+          text: "<turn_aborted>\nwording may change independently\n</turn_aborted>",
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects a malformed wrapper", () => {
+    expect(
+      isCodexTurnAbortMarkerNotification(
+        abortMarkerNotification({
+          role: "user",
+          text: "<turn_aborted>\nmissing closing tag",
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("rejects the current user prompt echoed through raw response events", () => {
+    const currentPrompt = "<turn_aborted>\nliteral user prompt\n</turn_aborted>";
+    expect(
+      isCodexTurnAbortMarkerNotification(
+        abortMarkerNotification({ role: "user", text: currentPrompt }),
+        { currentPromptText: currentPrompt },
+      ),
+    ).toBe(false);
   });
 });

--- a/extensions/codex/src/app-server/attempt-notifications.ts
+++ b/extensions/codex/src/app-server/attempt-notifications.ts
@@ -12,10 +12,6 @@ import {
 
 const CODEX_TURN_ABORT_MARKER_START = "<turn_aborted>";
 const CODEX_TURN_ABORT_MARKER_END = "</turn_aborted>";
-const CODEX_INTERRUPTED_USER_GUIDANCE =
-  "The user interrupted the previous turn on purpose. Any running unified exec processes may still be running in the background. If any tools/commands were aborted, they may have partially executed.";
-const CODEX_INTERRUPTED_DEVELOPER_GUIDANCE =
-  "The previous turn was interrupted on purpose. Any running unified exec processes may still be running in the background. If any tools/commands were aborted, they may have partially executed.";
 
 /** Builds compact activity metadata for watchdog and diagnostic updates. */
 export function describeNotificationActivity(
@@ -345,7 +341,11 @@ export function isCodexTurnAbortMarkerNotification(
   }
   const item = notification.params.item;
   const role = isJsonObject(item) ? readString(item, "role") : undefined;
-  if (!isJsonObject(item) || (role !== "user" && role !== "developer")) {
+  if (
+    !isJsonObject(item) ||
+    readString(item, "type") !== "message" ||
+    (role !== "user" && role !== "developer")
+  ) {
     return false;
   }
   const text = extractRawResponseItemText(item).trim();
@@ -355,11 +355,7 @@ export function isCodexTurnAbortMarkerNotification(
   if (role === "user" && currentPromptTexts.includes(text)) {
     return false;
   }
-  const markerBody = readCodexTurnAbortMarkerBody(text);
-  return (
-    markerBody === CODEX_INTERRUPTED_USER_GUIDANCE ||
-    markerBody === CODEX_INTERRUPTED_DEVELOPER_GUIDANCE
-  );
+  return readCodexTurnAbortMarkerBody(text) !== undefined;
 }
 
 function readCodexTurnAbortMarkerBody(text: string): string | undefined {

--- a/extensions/codex/src/app-server/dynamic-tools.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tools.test.ts
@@ -565,6 +565,31 @@ describe("createCodexDynamicToolBridge", () => {
     });
   });
 
+  it("repairs a null dynamic-tool schema type before Codex registration", () => {
+    const bridge = createCodexDynamicToolBridge({
+      tools: [
+        createTool({
+          name: "codex_app__automation_update",
+          parameters: {
+            type: null,
+            properties: {
+              action: { type: "string", description: null },
+            },
+          } as never,
+        }),
+      ],
+      signal: new AbortController().signal,
+    });
+
+    expect(flattenSpecsWithNamespace(bridge.specs)[0]?.inputSchema).toEqual({
+      type: "object",
+      properties: {
+        action: { type: "string" },
+      },
+    });
+    expect(bridge.telemetry.quarantinedTools).toEqual([]);
+  });
+
   it("quarantines dynamic tools with unsupported input schemas", async () => {
     const warn = vi.spyOn(embeddedAgentLog, "warn").mockImplementation(() => undefined);
     const diagnosticEvents: DiagnosticEventPayload[] = [];

--- a/extensions/codex/src/app-server/dynamic-tools.ts
+++ b/extensions/codex/src/app-server/dynamic-tools.ts
@@ -44,6 +44,7 @@ import {
 import { emitTrustedDiagnosticEvent } from "openclaw/plugin-sdk/diagnostic-runtime";
 import { expectDefined } from "openclaw/plugin-sdk/expect-runtime";
 import type { ImageContent, TextContent } from "openclaw/plugin-sdk/llm";
+import { normalizeOpenAIToolSchemas } from "openclaw/plugin-sdk/provider-tools";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { resolveAgentContextLimitValue } from "./agent-context-limits.js";
@@ -964,8 +965,14 @@ function projectCodexDynamicTools(tools: readonly AnyAgentTool[]): {
       quarantinedTools.push(descriptor.diagnostic);
       continue;
     }
+    const normalizedParameters = normalizeOpenAIToolSchemas({
+      provider: "openai",
+      modelApi: "openai-chatgpt-responses",
+      // The shared normalizer only reads parameters; do not expose unreadable plugin fields.
+      tools: [{ parameters: descriptor.parameters } as AnyAgentTool],
+    })[0]?.parameters;
     const projection = projectRuntimeToolInputSchema(
-      descriptor.parameters,
+      normalizedParameters ?? descriptor.parameters,
       `${descriptor.name}.inputSchema`,
     );
     if (projection.violations.length > 0) {

--- a/extensions/codex/src/app-server/run-attempt-notification-controller.ts
+++ b/extensions/codex/src/app-server/run-attempt-notification-controller.ts
@@ -10,6 +10,7 @@ import {
   readCodexNotificationItem,
   readRawResponseToolCallId,
 } from "./attempt-notifications.js";
+import { readCodexTurnCompletedNotification } from "./protocol-validators.js";
 import type { CodexServerNotification } from "./protocol.js";
 import type { CodexAttemptLifecycleController } from "./run-attempt-lifecycle-controller.js";
 import type { CodexAttemptResources } from "./run-attempt-resources.js";
@@ -58,7 +59,6 @@ export function createCodexAttemptNotificationController(
       notification,
       threadId: resourceState.thread.threadId,
       turnId: notificationTurnId,
-      currentPromptTexts: [turnState.codexTurnPromptText],
     });
   const handleNotification = async (notification: CodexServerNotification) => {
     const projector = projectorRef.current;
@@ -87,6 +87,9 @@ export function createCodexAttemptNotificationController(
       onReportExecutionNotification: reportExecutionNotification,
     });
     state.turnCrossedToolHandoff = notificationState.turnCrossedToolHandoff;
+    if (notificationState.isTurnAbortMarker) {
+      state.sawCodexInterruptMarker = true;
+    }
     const hookNotification = readCodexFinalizationHookNotification(
       notification,
       resourceState.thread.threadId,
@@ -181,7 +184,10 @@ export function createCodexAttemptNotificationController(
         }
       }
       if (notificationState.isTurnTerminal) {
-        if (notificationState.isTurnAbortMarker) {
+        const completedTurn = readCodexTurnCompletedNotification(notification.params)?.turn;
+        // App-server collapses abort reasons; interrupted plus this marker is the
+        // only user-interrupt discriminator until Codex exposes abortReason.
+        if (completedTurn?.status === "interrupted" && state.sawCodexInterruptMarker) {
           projector.markAborted();
         }
         if (!state.timedOut && !runAbortController.signal.aborted) {

--- a/extensions/codex/src/app-server/run-attempt-turn-state.ts
+++ b/extensions/codex/src/app-server/run-attempt-turn-state.ts
@@ -45,6 +45,9 @@ export function createCodexAttemptTurnState(resources: CodexAttemptResources) {
     rateLimitsRevisionBeforeLastTurnStart: undefined as number | undefined,
     completed: false,
     terminalTurnNotificationQueued: false,
+    // App-server collapses user interrupts and replacements to "interrupted";
+    // this marker remains the user-interrupt hint until Codex exposes abortReason.
+    sawCodexInterruptMarker: false,
     timedOut: false,
     turnCompletionIdleTimedOut: false,
     turnWatchTimeoutKind: undefined as CodexAttemptTurnWatchTimeoutKind | undefined,

--- a/extensions/codex/src/app-server/run-attempt.native-hook-relay.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.native-hook-relay.test.ts
@@ -10,7 +10,11 @@ import {
   onInternalDiagnosticEvent,
   type DiagnosticEventPayload,
 } from "openclaw/plugin-sdk/diagnostic-runtime";
-import { describe, expect, it, vi } from "vitest";
+import {
+  createEmptyPluginRegistry,
+  setActivePluginRegistry,
+} from "openclaw/plugin-sdk/plugin-test-runtime";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import * as approvalBridge from "./approval-bridge.js";
 import { CodexAppServerRpcError } from "./client.js";
 import { nativeHookRelayUnregisterQueue } from "./native-hook-relay-state.js";
@@ -30,6 +34,10 @@ import {
 } from "./session-binding.test-helpers.js";
 
 setupRunAttemptTestHooks();
+
+afterEach(() => {
+  setActivePluginRegistry(createEmptyPluginRegistry());
+});
 
 const testing = {
   flushPendingCodexNativeHookRelayUnregistersForTests(): void {
@@ -55,6 +63,70 @@ function writeCodexAppServerBinding(...args: Parameters<typeof writeRawCodexAppS
 }
 
 describe("runCodexAppServerAttempt native hook relay", () => {
+  it("relays native tool results through Codex result middleware", async () => {
+    const middleware = vi.fn(async () => undefined);
+    const registry = createEmptyPluginRegistry();
+    registry.agentToolResultMiddlewares.push({
+      pluginId: "tokenjuice",
+      pluginName: "Tokenjuice",
+      rawHandler: middleware,
+      handler: middleware,
+      runtimes: ["codex"],
+      source: "test",
+    });
+    setActivePluginRegistry(registry);
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    const harness = createStartedThreadHarness();
+
+    const run = runCodexAppServerAttempt(createParams(sessionFile, workspaceDir), {
+      nativeHookRelay: {
+        enabled: true,
+        events: ["post_tool_use"],
+      },
+    });
+    await harness.waitForMethod("turn/start");
+    const startRequest = harness.requests.find((request) => request.method === "thread/start");
+    const startConfig = (startRequest?.params as { config?: Record<string, unknown> } | undefined)
+      ?.config;
+    expect(startConfig?.["hooks.PostToolUse"]).not.toEqual([]);
+    const relayId = extractRelayIdFromThreadRequest(startRequest?.params);
+
+    await invokeNativeHookRelay({
+      provider: "codex",
+      relayId,
+      event: "post_tool_use",
+      rawPayload: {
+        hook_event_name: "PostToolUse",
+        tool_name: "Bash",
+        tool_use_id: "native-call-1",
+        tool_input: { command: "pnpm test" },
+        tool_response: { output: "ok", exit_code: 0 },
+      },
+    });
+
+    expect(middleware).toHaveBeenCalledWith(
+      expect.objectContaining({
+        toolCallId: "native-call-1",
+        toolName: "exec",
+        args: { command: "pnpm test" },
+        result: {
+          content: [
+            {
+              type: "text",
+              text: '{\n  "output": "ok",\n  "exit_code": 0\n}',
+            },
+          ],
+          details: { output: "ok", exit_code: 0 },
+        },
+      }),
+      expect.objectContaining({ runtime: "codex" }),
+    );
+
+    await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+    await run;
+  });
+
   it("registers native hook relay config for an enabled Codex turn and cleans it up", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     const workspaceDir = path.join(tempDir, "workspace");

--- a/extensions/codex/src/app-server/run-attempt.turn-watches.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.turn-watches.test.ts
@@ -3206,13 +3206,9 @@ describe("runCodexAppServerAttempt turn watches", () => {
   });
 
   it("clears the thread binding after a completion-idle timeout so the next turn starts fresh", async () => {
-    // Regression for openclaw#89974. The "user interrupted the previous turn on
-    // purpose" wording is Codex's generic <turn_aborted> rollout marker, written
-    // whenever a turn is interrupted (including OpenClaw's own watchdog abort).
-    // OpenClaw cannot change that text (turn/interrupt carries no reason); it can
-    // only avoid replaying it. This proves a turn_completion_idle_timeout clears
-    // the timed-out thread's binding so the next turn starts a fresh thread
-    // rather than resuming the thread that may hold that marker.
+    // Regression for openclaw#89974. Codex writes a generic <turn_aborted>
+    // marker for every interrupted turn. Clearing the timed-out binding keeps
+    // that marker out of the next turn by starting a fresh thread.
     vi.spyOn(embeddedAgentLog, "warn").mockImplementation(() => undefined);
     const sessionFile = path.join(tempDir, "session-89974.jsonl");
     const workspaceDir = path.join(tempDir, "workspace-89974");
@@ -4576,7 +4572,7 @@ describe("runCodexAppServerAttempt turn watches", () => {
     });
   });
 
-  it("does not recover a completed reply when a queued native abort marker follows it", async () => {
+  it("waits for interrupted turn completion after a queued native abort marker", async () => {
     let releaseProjection!: () => void;
     let markProjectionStarted!: () => void;
     const projectionGate = new Promise<void>((resolve) => {
@@ -4600,6 +4596,10 @@ describe("runCodexAppServerAttempt turn watches", () => {
     const run = runCodexAppServerAttempt(params, {
       turnAssistantCompletionIdleTimeoutMs: 5,
       turnTerminalIdleTimeoutMs: 500,
+    });
+    let resolved = false;
+    void run.then(() => {
+      resolved = true;
     });
     await harness.waitForMethod("turn/start");
     await harness.notify(completedAssistant("msg-final-1", "Done."));
@@ -4644,6 +4644,20 @@ describe("runCodexAppServerAttempt turn watches", () => {
 
     releaseProjection();
     await Promise.all([pendingProjection, pendingAbort]);
+
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
+    expect(resolved).toBe(false);
+
+    await harness.notify({
+      method: "turn/completed",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        turn: { id: "turn-1", status: "interrupted", items: [] },
+      },
+    });
 
     await expect(run).resolves.toMatchObject({
       aborted: true,
@@ -4830,7 +4844,7 @@ describe("runCodexAppServerAttempt turn watches", () => {
     );
   });
 
-  it("releases completion and native hook relay state when Codex raw-events an interrupted turn marker", async () => {
+  it("releases completion and native hook relay state after marker plus interrupted completion", async () => {
     const harness = createStartedThreadHarness();
     const run = runCodexAppServerAttempt(
       createParams(path.join(tempDir, "session.jsonl"), path.join(tempDir, "workspace")),
@@ -4860,6 +4874,21 @@ describe("runCodexAppServerAttempt turn watches", () => {
             },
           ],
         },
+      },
+    });
+
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
+    expect(resolved).toBe(false);
+    expect(nativeHookRelayTesting.getNativeHookRelayRegistrationForTests(relayId)).toBeDefined();
+
+    await harness.notify({
+      method: "turn/completed",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        turn: { id: "turn-1", status: "interrupted", items: [] },
       },
     });
 
@@ -5271,8 +5300,7 @@ describe("runCodexAppServerAttempt turn watches", () => {
 
   it("does not treat a user prompt containing the interrupted marker as terminal", async () => {
     const harness = createStartedThreadHarness();
-    const markerPrompt =
-      "<turn_aborted>\nThe user interrupted the previous turn on purpose. Any running unified exec processes may still be running in the background. If any tools/commands were aborted, they may have partially executed.\n</turn_aborted>";
+    const markerPrompt = "<turn_aborted>\narbitrary prompt prose\n</turn_aborted>";
     const params = createParams(
       path.join(tempDir, "session.jsonl"),
       path.join(tempDir, "workspace"),

--- a/src/agents/harness/native-hook-relay.ts
+++ b/src/agents/harness/native-hook-relay.ts
@@ -31,6 +31,7 @@ import { toErrorObject } from "../../infra/errors.js";
 import { resolveOpenClawPackageRootSync } from "../../infra/openclaw-root.js";
 import { privateFileStoreSync } from "../../infra/private-file-store.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
+import { listAgentToolResultMiddlewares } from "../../plugins/agent-tool-result-middleware.js";
 import { hasGlobalHooks } from "../../plugins/hook-runner-global.js";
 import { PluginApprovalResolutions } from "../../plugins/types.js";
 import {
@@ -44,9 +45,11 @@ import {
 import { stableStringify } from "../stable-stringify.js";
 import { resolveToolLoopDetectionConfig } from "../tool-loop-detection-config.js";
 import { normalizeToolName } from "../tool-policy.js";
+import { payloadTextResult } from "../tools/common.js";
 import { callGatewayTool } from "../tools/gateway.js";
 import { runAgentHarnessAfterToolCallHook } from "./hook-helpers.js";
 import { runAgentHarnessBeforeAgentFinalizeHook } from "./lifecycle-hook-helpers.js";
+import { createAgentToolResultMiddlewareRunner } from "./tool-result-middleware.js";
 
 type JsonValue = null | boolean | number | string | JsonValue[] | { [key: string]: JsonValue };
 
@@ -616,7 +619,7 @@ function nativeHookRelayEventHasLocalWork(
     return hasBeforeToolCallPolicy() || nativePreToolUseMayRunLoopDetection(registration);
   }
   if (event === "post_tool_use") {
-    return hasGlobalHooks("after_tool_call");
+    return hasGlobalHooks("after_tool_call") || listAgentToolResultMiddlewares("codex").length > 0;
   }
   if (event === "before_agent_finalize") {
     return hasGlobalHooks("before_agent_finalize");
@@ -1528,6 +1531,28 @@ async function runNativeHookRelayPostToolUse(params: {
   const toolName = normalizeNativeHookToolName(params.invocation.toolName);
   const toolCallId =
     params.invocation.toolUseId ?? `${params.invocation.event}:${params.invocation.receivedAt}`;
+  const startArgs = params.adapter.readToolInput(params.invocation.rawPayload);
+  const rawResult = params.adapter.readToolResponse(params.invocation.rawPayload);
+  // Native results are observe-only for middleware: codex-rs PostToolUse hooks
+  // cannot replace tool_response (PostToolUseOutcome has no result field), so a
+  // transformed result reaches only after_tool_call observers, never the model.
+  const hasToolResultMiddleware = listAgentToolResultMiddlewares("codex").length > 0;
+  const result = !hasToolResultMiddleware
+    ? rawResult
+    : await createAgentToolResultMiddlewareRunner({
+        runtime: "codex",
+        ...(params.registration.agentId ? { agentId: params.registration.agentId } : {}),
+        sessionId: params.registration.sessionId,
+        ...(params.registration.sessionKey ? { sessionKey: params.registration.sessionKey } : {}),
+        runId: params.registration.runId,
+      }).applyToolResultMiddleware({
+        turnId: params.invocation.turnId,
+        toolCallId,
+        toolName,
+        args: startArgs,
+        ...(params.invocation.cwd ? { cwd: params.invocation.cwd } : {}),
+        result: payloadTextResult(rawResult),
+      });
   await runAgentHarnessAfterToolCallHook({
     toolName,
     toolCallId,
@@ -1536,8 +1561,8 @@ async function runNativeHookRelayPostToolUse(params: {
     sessionId: params.registration.sessionId,
     ...(params.registration.sessionKey ? { sessionKey: params.registration.sessionKey } : {}),
     ...(params.registration.channelId ? { channelId: params.registration.channelId } : {}),
-    startArgs: params.adapter.readToolInput(params.invocation.rawPayload),
-    result: params.adapter.readToolResponse(params.invocation.rawPayload),
+    startArgs,
+    result,
   });
   return params.adapter.renderNoopResponse(params.invocation.event);
 }

--- a/src/plugin-sdk/provider-tools.test.ts
+++ b/src/plugin-sdk/provider-tools.test.ts
@@ -269,6 +269,58 @@ describe("buildProviderToolCompatFamilyHooks", () => {
     ).toStrictEqual([]);
   });
 
+  it("repairs null and inferred OpenAI tool schema types", () => {
+    expect(
+      normalizeOpenAIParameters({
+        type: null,
+        description: null,
+        default: null,
+        properties: {
+          payload: {
+            properties: { value: { type: "string", format: null } },
+          },
+          tags: {
+            items: { type: "string" },
+          },
+        },
+      }),
+    ).toEqual({
+      type: "object",
+      properties: {
+        payload: {
+          type: "object",
+          properties: { value: { type: "string" } },
+        },
+        tags: {
+          type: "array",
+          items: { type: "string" },
+        },
+      },
+    });
+  });
+
+  it("keeps unrepairable null schema constraints for downstream quarantine", () => {
+    // Null constraint keywords must not be silently dropped into a wider
+    // schema; only annotation nulls are repairable. An uninferable type: null
+    // is restored so projection rejects the tool instead of accepting
+    // undeclared arguments.
+    expect(
+      normalizeOpenAIParameters({
+        type: "object",
+        properties: {
+          payload: { type: null, description: "no shape hints" },
+          config: { type: "object", properties: {}, additionalProperties: null },
+        },
+      }),
+    ).toEqual({
+      type: "object",
+      properties: {
+        payload: { type: null, description: "no shape hints" },
+        config: { type: "object", properties: {}, required: [], additionalProperties: null },
+      },
+    });
+  });
+
   it("preserves explicit empty properties maps when normalizing strict openai schemas", () => {
     const hooks = buildProviderToolCompatFamilyHooks("openai");
     const parameters = {

--- a/src/plugin-sdk/provider-tools.ts
+++ b/src/plugin-sdk/provider-tools.ts
@@ -179,6 +179,17 @@ const OPENAI_STRICT_COMPAT_SCHEMA_MAP_KEYS = new Set([
   "properties",
 ]);
 
+// Annotation-only keywords whose null values can be dropped without changing
+// what the schema accepts; null constraint keywords must stay so projection
+// quarantines the tool instead of widening it.
+const OPENAI_NULLABLE_ANNOTATION_KEYS = new Set([
+  "default",
+  "description",
+  "examples",
+  "format",
+  "title",
+]);
+
 const OPENAI_STRICT_COMPAT_SCHEMA_NESTED_KEYS = new Set([
   "additionalProperties",
   "allOf",
@@ -234,8 +245,23 @@ function normalizeOpenAIStrictCompatSchemaRecursive(
 
   const record = schema as Record<string, unknown>;
   let changed = false;
+  let hadNullType = false;
   const normalized: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(record)) {
+    // Repair only null-valued entries that carry no constraint semantics:
+    // annotation keywords, and `type: null` when the shape inference below can
+    // supply the real type. Null constraint keywords (additionalProperties,
+    // required, enum, ...) stay put so projection quarantines instead of
+    // silently accepting arguments the plugin never declared.
+    if (value === null && OPENAI_NULLABLE_ANNOTATION_KEYS.has(key)) {
+      changed = true;
+      continue;
+    }
+    if (value === null && key === "type") {
+      hadNullType = true;
+      changed = true;
+      continue;
+    }
     const next = OPENAI_STRICT_COMPAT_SCHEMA_MAP_KEYS.has(key)
       ? normalizeOpenAIStrictCompatSchemaMap(value)
       : OPENAI_STRICT_COMPAT_SCHEMA_NESTED_KEYS.has(key)
@@ -260,14 +286,19 @@ function normalizeOpenAIStrictCompatSchemaRecursive(
   }
 
   const hasObjectShapeHints =
-    !("type" in normalized) &&
-    ((normalized.properties &&
+    (normalized.properties &&
       typeof normalized.properties === "object" &&
       !Array.isArray(normalized.properties)) ||
-      Array.isArray(normalized.required));
-  if (hasObjectShapeHints) {
-    normalized.type = "object";
+    Array.isArray(normalized.required);
+  const hasArrayShapeHints = "items" in normalized;
+  if (!("type" in normalized) && hasObjectShapeHints !== hasArrayShapeHints) {
+    normalized.type = hasObjectShapeHints ? "object" : "array";
     changed = true;
+  } else if (hadNullType && !("type" in normalized)) {
+    // Inference failed (no hints, or ambiguous object+array hints): restore the
+    // invalid `type: null` so downstream projection quarantines the tool
+    // instead of shipping an unconstrained schema.
+    normalized.type = null;
   }
   if (normalized.type === "object" && !("properties" in normalized)) {
     normalized.properties = {};

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.discord-group.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.discord-group.json
@@ -129,7 +129,9 @@
   {
     "description": "List ids allowed for `sessions_spawn(runtime:\"subagent\")`.",
     "inputSchema": {
+      "additionalProperties": false,
       "properties": {},
+      "required": [],
       "type": "object"
     },
     "name": "agents_list",

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.heartbeat-turn.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.heartbeat-turn.json
@@ -129,7 +129,9 @@
   {
     "description": "List ids allowed for `sessions_spawn(runtime:\"subagent\")`.",
     "inputSchema": {
+      "additionalProperties": false,
       "properties": {},
+      "required": [],
       "type": "object"
     },
     "name": "agents_list",

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
@@ -129,7 +129,9 @@
   {
     "description": "List ids allowed for `sessions_spawn(runtime:\"subagent\")`.",
     "inputSchema": {
+      "additionalProperties": false,
       "properties": {},
+      "required": [],
       "type": "object"
     },
     "name": "agents_list",

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
@@ -208,8 +208,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 53832,
-    "roughTokens": 13458
+    "chars": 53891,
+    "roughTokens": 13473
   },
   "openClawDeveloperInstructions": {
     "chars": 3431,
@@ -220,8 +220,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6989
   },
   "totalWithDynamicToolsJson": {
-    "chars": 81790,
-    "roughTokens": 20448
+    "chars": 81849,
+    "roughTokens": 20463
   },
   "userInputText": {
     "chars": 1442,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
@@ -208,8 +208,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 53559,
-    "roughTokens": 13390
+    "chars": 53618,
+    "roughTokens": 13405
   },
   "openClawDeveloperInstructions": {
     "chars": 2322,
@@ -220,8 +220,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6610
   },
   "totalWithDynamicToolsJson": {
-    "chars": 79999,
-    "roughTokens": 20000
+    "chars": 80058,
+    "roughTokens": 20015
   },
   "userInputText": {
     "chars": 1033,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
@@ -209,8 +209,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 54849,
-    "roughTokens": 13713
+    "chars": 54908,
+    "roughTokens": 13727
   },
   "openClawDeveloperInstructions": {
     "chars": 2341,
@@ -221,8 +221,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6745
   },
   "totalWithDynamicToolsJson": {
-    "chars": 81828,
-    "roughTokens": 20457
+    "chars": 81887,
+    "roughTokens": 20472
   },
   "userInputText": {
     "chars": 1271,


### PR DESCRIPTION
## What Problem This Solves

Three Codex plugin bugs sharing one theme: parsing codex-rs prose/raw payloads instead of using structured contracts.

1. **#99268** — The harness detected turn aborts by byte-matching two verbatim private codex-rs prose strings (copied from `codex-rs/core/src/context/turn_aborted.rs`) inside `<turn_aborted>` markers. Any upstream wording change silently breaks abort detection, and the marker alone terminated the attempt before the real `turn/completed` arrived.
2. **#106277 / #97913** — A dynamic-tool `inputSchema` with `type: null` (observed: `codex_app__automation_update`) was passed through or quarantined without any repair attempt, causing HTTP 400 on the Codex endpoint or dropped tools.
3. **#95597** — Codex-native tool results relayed through `post_tool_use` bypassed `agentToolResultMiddleware` entirely; plugin middleware only ever saw OpenClaw-executed dynamic tools.

## Why This Change Was Made

- **Abort detection** now keys off the structured protocol: only the correlated `turn/completed` is terminal, and `markAborted` fires when its validated status is `interrupted` and the interrupt-marker hint was seen. The marker is reduced to a wording-independent hint (wrapper tags only, prose constants deleted) because codex-rs's app-server collapses all four abort reasons (`Interrupted|Replaced|ReviewEnded|BudgetLimited`) into status `interrupted` — the marker is the only user-interrupt discriminator until codex-rs exposes `abortReason` (verified against `codex-rs/app-server/src/bespoke_event_handling.rs:1450-1459`, `codex-rs/hooks/…`, `codex-rs/core/src/tasks/mod.rs:865-901`). Prompt-echo exclusion is retained; the marker never terminates the attempt itself, closing the crash/disconnect window where prose matching masked transport failures as clean user aborts.
- **Schema repair** extends the shared `normalizeOpenAIToolSchemas` helper (no plugin-local normalizer, per the extensions boundary rules): annotation-only nulls (`description`, `format`, `default`, `examples`, `title`) are stripped; `type: null` / missing `type` is inferred from unambiguous object/array shape hints; unrepairable null constraints (`additionalProperties: null`, uninferable `type: null`, …) are preserved so projection still quarantines instead of silently widening what the tool accepts. Upstream note: pinned codex 0.144.4 already repairs *native app* schemas (`codex-rs/tools/src/json_schema.rs`), so the remaining exposure was OpenClaw's own dynamic-tool path.
- **Middleware relay** activates the `post_tool_use` relay when codex-runtime `agentToolResultMiddleware` is registered and runs the existing middleware runner at the awaited relay boundary. Observe-only by contract: codex-rs `PostToolUseOutcome` has no result-replacement field (`codex-rs/hooks/src/events/post_tool_use.rs:38-44`), so transformed output reaches `after_tool_call` observers, never the model. Docs updated to state this precisely.

## User Impact

- User interrupts remain correctly classified as cancellations across codex-rs wording changes; replacements/review-ends are no longer at risk of misclassification, and a lost `turn/completed` no longer masks a transport failure as a clean abort.
- Plugin tools with sloppy-but-repairable schemas work instead of failing the whole request with HTTP 400 or being dropped; genuinely invalid schemas still quarantine (fail closed).
- Plugin authors' `agentToolResultMiddleware` now observes Codex-native tool results, closing the visibility gap between runtimes.

## Evidence

- Focused tests (all pass): `attempt-notifications.test.ts` 6/6 (new marker-contract cases: user/developer marker, arbitrary body, malformed wrapper, prompt echo), `run-attempt.turn-watches.test.ts` 94/94 (marker-only no longer terminal; interrupted completion + hint → aborted with relay cleanup; interrupted without marker stays `aborted:false`; local cancel + interrupted stays aborted), `run-attempt.test.ts` 115/115, `dynamic-tools.test.ts` 106/106 (type:null repaired, quarantine preserved), `provider-tools.test.ts` 12/12 (repair + fail-closed null constraints), core + codex `native-hook-relay` suites 83 + 17.
- codex-rs contracts verified directly at pinned 0.144.4 source (files/lines above).
- Autoreview (Codex gpt-5.6-sol, xhigh): clean — one earlier over-permissive-normalization finding fixed (null constraint keywords now fail closed), one impossible-transformation finding resolved by contract verification + docs/comment (PostToolUse cannot replace tool_response), one prompt-echo finding rejected (both sides already trimmed).

Fixes #99268
Fixes #97913
Fixes #95597
Closes #106277

(#106277's native-app-tool case was fixed upstream in codex 0.144.x — `codex-rs/tools/src/json_schema.rs` repairs app schemas; this PR closes the remaining OpenClaw-side dynamic-tool exposure.)
