### PR TITLE
improve(test): speed Telegram archive stress fixture

### DIFF
--- a/test/scripts/release-telegram-candidate-archive.test.ts
+++ b/test/scripts/release-telegram-candidate-archive.test.ts
@@ -306,9 +306,23 @@ with open(sys.argv[1], "wb") as output:
     root.type = tarfile.DIRTYPE
     output.write(root.tobuf(format=tarfile.USTAR_FORMAT))
 
+    # Only the short ASCII name changes across these empty regular members.
+    # Reuse one stdlib-generated USTAR header and adjust its name/checksum so
+    # the 100k-member stress case spends its time in the reader under test.
+    member_header = bytearray(
+        tarfile.TarInfo("candidate/f000000").tobuf(format=tarfile.USTAR_FORMAT)
+    )
+    member_header[:100] = b"\0" * 100
+    member_header[148:156] = b" " * 8
+    member_base_checksum = sum(member_header)
+
     for index in range(member_count - 2):
-        member = tarfile.TarInfo(f"candidate/f{index:06d}")
-        output.write(member.tobuf(format=tarfile.USTAR_FORMAT))
+        name = f"candidate/f{index:06d}".encode("ascii")
+        header = member_header.copy()
+        header[:len(name)] = name
+        checksum = member_base_checksum + sum(name)
+        header[148:156] = f"{checksum:06o}\0 ".encode("ascii")
+        output.write(header)
 
     output.write(b"\0" * 1024)
 `;


### PR DESCRIPTION
## What Problem This Solves

The Telegram release archive guard's 100,000-member memory test spent a large share of its runtime reconstructing invariant empty USTAR headers instead of exercising the streaming reader under test.

## Why This Change Was Made

The fixture now asks Python's standard library for one canonical empty-member USTAR header, reuses its invariant fields, and updates only the short ASCII name and checksum for each member. The 100,000-member workload, archive size class, reader behavior, and all 37 test cases remain unchanged.

## User Impact

No user-visible product behavior changes. Maintainers and CI workers wait less for the tooling test shard while retaining the same archive-safety and bounded-memory proof.

AI-assisted: Codex.

## Evidence

- Fresh tooling profile on current main: this file ranked 7th at 4.73s for 37 tests.
- Focused before, three runs: 4.04-4.06s test time; the 100,000-member case took 1.84-1.94s.
- Focused after, three runs: 3.32-3.36s test time; the 100,000-member case took 1.07-1.14s.
- File runtime improved about 18%; the targeted stress case improved about 42%.
- `corepack pnpm test test/scripts/release-telegram-candidate-archive.test.ts` (three before and three after runs; 37/37 passed each run)
- `corepack pnpm check:changed`
- `node_modules/.bin/oxfmt --check --threads=1 test/scripts/release-telegram-candidate-archive.test.ts`
- Fresh autoreview: no actionable findings, correctness confidence 0.98.
- Blacksmith Testbox runs: `tbx_01kxj9w8zgv6qfyd8msakrevkt` / Actions `29396557367` (before), `tbx_01kxja2gh18k95fwx1mbzre3wn` / Actions `29396743388` (after and changed gate).
