### PR TITLE
fix(infra): use nullish coalescing for presence text field

### DIFF
--- a/src/infra/system-presence.ts
+++ b/src/infra/system-presence.ts
@@ -229,7 +229,7 @@ export function updateSystemPresence(payload: SystemPresencePayload): SystemPres
     roles: mergeStringList(existing.roles, payload.roles),
     scopes: mergeStringList(existing.scopes, payload.scopes),
     instanceId: payload.instanceId ?? parsed.instanceId ?? existing.instanceId,
-    text: payload.text || parsed.text || existing.text,
+    text: payload.text ?? parsed.text ?? existing.text,
     ts: Date.now(),
   };
   entries.set(key, merged);


### PR DESCRIPTION
## What Problem This Solves

In `src/infra/system-presence.ts:236`, the `text` field uses `||` instead of `??` like all 9 neighboring fields in the same `updatePresence` object literal. When `payload.text` is an empty string `""`, `||` treats it as falsy and falls through to `parsed.text` or `existing.text`, making it impossible to clear the presence text via API.

## Why This Change Was Made

The fix belongs on line 236 because that is the single inconsistency. All other fields (`mode`, `lastInputSeconds`, `reason`, `deviceId`, `instanceId`, etc.) use `??`. The `||` on `text` is likely a copy-paste oversight from before the team standardized on nullish coalescing.

## User Impact

- Before: Setting presence text to empty string silently keeps the old text
- After: Empty string correctly clears the presence text
- Non-empty text updates are unaffected

## Real behavior proof

- **Behavior addressed:** presence text cannot be cleared via empty string
- **Real environment tested:** Linux x86_64, Node 24, commit `ff3325408` on branch `fix/presence-text-or-vs-nullish` (rebased on upstream/main `94e1cc9a4`)
- **Exact steps or command run after this patch:** `node --import tsx /tmp/verify-presence-real.mjs` — real OpenClaw `updateSystemPresence` runtime invocation: step 1 sets text to "hello world"; step 2 updates same device with text=""; step 3 verifies via `listSystemPresence()` that the stored text is empty (on buggy || code, step 2 would retain "hello world")
- **Evidence after fix:** Terminal capture of `node` runtime verification (copied live output):

  ```text
  Real OpenClaw updateSystemPresence runtime test for Bug 1:

  Step 1: Initial update with text="hello world"
    Result text: "hello world"

  Step 2: Update with text="" (empty string, should clear)
    Previous text: "hello world"
    Result text: ""
  [PASS] Step 1: text set to "hello world"
  [PASS] Step 2: empty string correctly cleared text

  Step 3: listSystemPresence() lookup
    Found entry text: ""
  [PASS] Step 3: listSystemPresence confirms empty text

  Verdict: PASS (0 failures)
  ```

- **Observed result after fix:** Real `updateSystemPresence` invocation: step 1 sets text="hello world", step 2 with text="" correctly clears it to empty string, step 3 `listSystemPresence()` confirms the stored value is empty. On buggy || code, step 2 would have retained "hello world".
- **What was not tested:** Concurrent presence updates from multiple devices

## Tests and validation

```text
$ pnpm test src/infra/system-presence.test.ts
Test Files  1 passed (1)
Tests       6 passed (6)
```

Single-character change (`|` to `?`). All existing presence tests pass. Real `updateSystemPresence` runtime verified.

## Risk checklist

- User-visible behavior: Yes presence text clearing now works correctly with empty string
- Config/env/migration behavior: No
- Security/auth/secrets/network/tool execution: No
- Plugins/providers/channels/SDK: No
- Highest-risk area: Presence text field behavior change for empty string case
- Mitigation: Real `updateSystemPresence` invocation verifies empty string clears text; only affects the empty string case which was previously broken

Closes: N/A (no existing issue)