### PR TITLE
fix(pr): preserve signed merge commits

### DIFF
--- a/scripts/pr-lib/push.sh
+++ b/scripts/pr-lib/push.sh
@@ -46,6 +46,13 @@ graphql_push_to_fork() {
 
   verify_prep_head_extends_hosted_head "$expected_oid" || return 1
 
+  local merge_commit
+  merge_commit=$(git rev-list --min-parents=2 --max-count=1 "$expected_oid"..HEAD)
+  if [ -n "$merge_commit" ]; then
+    echo "GraphQL push cannot preserve merge ancestry; publish the verified signed merge with git transport." >&2
+    return 1
+  fi
+
   local additions="[]"
   local deletions="[]"
 
@@ -106,6 +113,8 @@ graphql_push_to_fork() {
 
   local commit_headline
   commit_headline=$(git log -1 --format=%s HEAD)
+  local commit_body
+  commit_body=$(git log -1 --format=%b HEAD)
 
   local query
   query=$(cat <<'GRAPHQL'
@@ -129,11 +138,12 @@ GRAPHQL
     --arg branch "$branch" \
     --arg oid "$expected_oid" \
     --arg headline "$commit_headline" \
+    --arg body "$commit_body" \
     --slurpfile additions "$additions_file" \
     --slurpfile deletions "$deletions_file" \
     '{input: {
       branch: { repositoryNameWithOwner: $nwo, branchName: $branch },
-      message: { headline: $headline },
+      message: { headline: $headline, body: $body },
       fileChanges: { additions: $additions[0], deletions: $deletions[0] },
       expectedHeadOid: $oid
     }}')
@@ -233,24 +243,46 @@ resolve_prhead_remote_sha() {
   printf '%s\n' "$remote_sha"
 }
 
+verify_prep_first_parent_range_signed() {
+  local base_sha="$1"
+  local prep_head_sha="$2"
+
+  git merge-base --is-ancestor "$base_sha" "$prep_head_sha" || return 1
+
+  local commits
+  commits=$(git rev-list --first-parent "$base_sha..$prep_head_sha") || return 1
+  local commit
+  while IFS= read -r commit; do
+    [ -n "$commit" ] || continue
+    git verify-commit "$commit" >/dev/null 2>&1 || return 1
+  done <<< "$commits"
+}
+
 push_prep_head_once() {
   local pr_head="$1"
   local lease_sha="$2"
   local prep_head_sha="$3"
 
-  if [ -n "${PR_HEAD_OWNER:-}" ] && [ -n "${PR_HEAD_REPO_NAME:-}" ] && [ "${OPENCLAW_PR_PUSH_MODE:-graphql}" != "git" ]; then
+  local push_mode="${OPENCLAW_PR_PUSH_MODE:-auto}"
+  if [ "$push_mode" = "auto" ] && verify_prep_first_parent_range_signed "$lease_sha" "$prep_head_sha"; then
+    push_mode="git"
+  elif [ "$push_mode" = "auto" ]; then
+    push_mode="graphql"
+  fi
+
+  if [ -n "${PR_HEAD_OWNER:-}" ] && [ -n "${PR_HEAD_REPO_NAME:-}" ] && [ "$push_mode" != "git" ]; then
     echo "Pushing PR branch through GitHub createCommitOnBranch so the prepared commit is verified." >&2
     graphql_push_to_fork "${PR_HEAD_OWNER}/${PR_HEAD_REPO_NAME}" "$pr_head" "$lease_sha"
     return $?
   fi
 
-  if [ "${OPENCLAW_ALLOW_UNSIGNED_GIT_PUSH:-}" != "1" ]; then
+  if ! verify_prep_first_parent_range_signed "$lease_sha" "$prep_head_sha" && [ "${OPENCLAW_ALLOW_UNSIGNED_GIT_PUSH:-}" != "1" ]; then
     echo "Refusing git-protocol PR branch push because it can publish unsigned commits." >&2
-    echo "Use the default GitHub createCommitOnBranch path, or set OPENCLAW_ALLOW_UNSIGNED_GIT_PUSH=1 for an explicit manual override." >&2
+    echo "Sign the prep commit, use GitHub createCommitOnBranch, or set OPENCLAW_ALLOW_UNSIGNED_GIT_PUSH=1 for an explicit manual override." >&2
     return 2
   fi
 
-  git push --force-with-lease=refs/heads/$pr_head:$lease_sha prhead HEAD:$pr_head >&2
+  git push --force-with-lease=refs/heads/$pr_head:$lease_sha prhead "$prep_head_sha:refs/heads/$pr_head" >&2
   printf '%s\n' "$prep_head_sha"
 }
 

--- a/test/scripts/pr-prepare-gates.test.ts
+++ b/test/scripts/pr-prepare-gates.test.ts
@@ -508,12 +508,12 @@ describe("prepare sync-head transitions", () => {
 });
 
 describe("GraphQL fork publication", () => {
-  it("accepts fixups appended to the hosted head", () => {
+  it("accepts appended fixups and preserves the commit body", () => {
     const { repoDir, headSha } = makeRetryRepo();
     writeFileSync(join(repoDir, "fixup.ts"), "export const fixed = true;\n");
     for (const args of [
       ["add", "fixup.ts"],
-      ["commit", "-qm", "reviewed fixup"],
+      ["commit", "-qm", "reviewed fixup\n\nCo-authored-by: Helper <helper@example.com>"],
     ]) {
       const commit = spawnSync("git", args, { cwd: repoDir, encoding: "utf8" });
       expect(commit.status, commit.stderr).toBe(0);
@@ -521,15 +521,45 @@ describe("GraphQL fork publication", () => {
 
     const result = runGatesBash(
       [
-        'gh() { touch .local/gh-called; printf \'%s\\n\' \'{"data":{"createCommitOnBranch":{"commit":{"oid":"signed-head","url":"https://example.test/commit"}}}}\'; }',
+        'gh() { cat > .local/graphql-payload.json; printf \'%s\\n\' \'{"data":{"createCommitOnBranch":{"commit":{"oid":"signed-head","url":"https://example.test/commit"}}}}\'; }',
         `graphql_push_to_fork example/repo topic ${headSha}`,
-        "test -e .local/gh-called",
+        'test "$(jq -r .variables.input.message.headline .local/graphql-payload.json)" = "reviewed fixup"',
+        'test "$(jq -r .variables.input.message.body .local/graphql-payload.json)" = "Co-authored-by: Helper <helper@example.com>"',
       ].join("\n"),
       { cwd: repoDir, sourcePush: true },
     );
 
     expect(result.status, result.stderr).toBe(0);
     expect(result.stdout).toContain("signed-head");
+  });
+
+  it("rejects merge commits before encoding files or calling GitHub", () => {
+    const { repoDir, headSha } = makeRetryRepo();
+    const baseBranch = spawnSync("git", ["branch", "--show-current"], {
+      cwd: repoDir,
+      encoding: "utf8",
+    }).stdout.trim();
+    for (const args of [
+      ["checkout", "-qb", "other"],
+      ["commit", "-qm", "other", "--allow-empty"],
+      ["checkout", "-q", baseBranch],
+      ["merge", "-q", "--no-ff", "other", "-m", "merge other"],
+    ]) {
+      const command = spawnSync("git", args, { cwd: repoDir, encoding: "utf8" });
+      expect(command.status, command.stderr).toBe(0);
+    }
+
+    const result = runGatesBash(
+      [
+        "gh() { touch .local/gh-called; return 99; }",
+        `graphql_push_to_fork example/repo topic ${headSha}`,
+      ].join("\n"),
+      { cwd: repoDir, sourcePush: true },
+    );
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("cannot preserve merge ancestry");
+    expect(existsSync(join(repoDir, ".local", "gh-called"))).toBe(false);
   });
 
   it("rejects rewritten history before encoding files or calling GitHub", () => {
@@ -569,6 +599,46 @@ describe("GraphQL fork publication", () => {
     expect(result.status).not.toBe(0);
     expect(result.stderr).toContain("refused rewritten history");
     expect(existsSync(join(repoDir, ".local", "gh-called"))).toBe(false);
+  });
+});
+
+describe("fork publication transport", () => {
+  it("uses git transport automatically for a verified signed prep commit", () => {
+    const { repoDir } = makeRetryRepo();
+    const result = runGatesBash(
+      [
+        "PR_HEAD_OWNER=contributor",
+        "PR_HEAD_REPO_NAME=repo",
+        "git() { printf '%s\\n' \"$*\" >> .local/git-calls; case \"$1\" in rev-list) printf '%s\\n' prepared;; esac; return 0; }",
+        "graphql_push_to_fork() { touch .local/graphql-called; return 99; }",
+        "push_prep_head_once topic hosted prepared",
+        "grep -F 'verify-commit prepared' .local/git-calls",
+        "grep -F 'push --force-with-lease=refs/heads/topic:hosted prhead prepared:refs/heads/topic' .local/git-calls",
+        "test ! -e .local/graphql-called",
+      ].join("\n"),
+      { cwd: repoDir, sourcePush: true },
+    );
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain("prepared");
+  });
+
+  it("keeps unsigned single-parent fixups on GitHub-signed GraphQL publication", () => {
+    const { repoDir } = makeRetryRepo();
+    const result = runGatesBash(
+      [
+        "PR_HEAD_OWNER=contributor",
+        "PR_HEAD_REPO_NAME=repo",
+        "git() { case \"$1\" in rev-list) printf '%s\\n' prepared;; verify-commit) return 1;; esac; return 0; }",
+        "graphql_push_to_fork() { touch .local/graphql-called; printf '%s\\n' signed-head; }",
+        "push_prep_head_once topic hosted prepared",
+        "test -e .local/graphql-called",
+      ].join("\n"),
+      { cwd: repoDir, sourcePush: true },
+    );
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain("signed-head");
   });
 });
 


### PR DESCRIPTION
## What Problem This Solves

The PR coordinator's fork-update path always flattened local prep history through GitHub's `createCommitOnBranch` mutation. A real conflict resolution for #92294 produced a signed two-parent merge; flattening it would have discarded the main parent and attempted to encode 6,503 files, 432,302 insertions, and 234,950 deletions as one web-editor commit.

That made the coordinator CPU-bound before any GitHub request and lost the exact ancestry needed to explain and verify the conflict resolution.

Follow-up to #108016.

## Why This Change Was Made

- Auto mode now selects git transport only when every newly appended first-parent commit has a valid local signature.
- The git refspec pushes the exact verified prep OID, not mutable `HEAD`.
- Unsigned single-parent fixups continue through GitHub-signed `createCommitOnBranch` publication.
- GraphQL publication refuses a merge anywhere in the appended range before encoding file contents because the mutation can create only a single-parent commit.
- GraphQL publication now forwards the commit body, preserving `Co-authored-by` attribution.

GitHub documents `createCommitOnBranch` as appending a commit whose parent is the branch head, and its `CommitMessage` input supports both `headline` and `body`: https://docs.github.com/en/graphql/reference/commits

## User Impact

Maintainer conflict resolutions no longer trigger a multi-thousand-file GraphQL flattening attempt. Signed merge commits keep their exact parent graph and contributor attribution; ordinary unsigned fixups keep the existing GitHub-verified path.

## Evidence

- Live #92294 publication: signed merge `259ac59d90e30c33326b49cb0b7b5b17e153416d` pushed with both parents intact and became mergeable.
- The new GraphQL guard rejected that exact pathological range before reading or encoding its 6,503 changed files.
- Testbox `tbx_01kxjad2chstn8edgfbpa9y7m5`: 34/34 coordinator tests passed.
- Remote changed-file gate passed: format, test-root typecheck, script lint, boundary checks, dependency pins, and package patch guard.
- `bash -n scripts/pr-lib/push.sh`: passed.
- Fresh autoreview: no accepted or actionable findings, correctness 0.93.
