### PR TITLE
fix: load channel metadata in group prompt tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,7 +126,7 @@ Skills own workflows; root owns hard policy and routing.
 - Checks in a trusted Codex worktree or linked/sparse checkout: avoid direct local `pnpm check*`; use `node scripts/check-changed.mjs [--staged|-- <files...>]`. It can classify without installed dependencies and delegates heavy or dependency-missing proof before loading package-backed helpers. For untrusted source, do not execute this repository-controlled wrapper locally.
 - Extension tests: `pnpm test:extensions`, `pnpm test extensions`, `pnpm test extensions/<id>`.
 - Typecheck: `tsgo` lanes only (`pnpm tsgo*`, `pnpm check:test-types`); never add `tsc --noEmit`, `typecheck`, `check:types`.
-- Formatting: `oxfmt`, not Prettier. Use repo wrappers (`pnpm format:*`, `scripts/run-oxlint.mjs`; full `pnpm lint:*` only when scope requires).
+- Formatting: `oxfmt`, not Prettier. Write paths with `pnpm format <paths>`; no `format:write` script. Checks use repo wrappers (`pnpm format:*`, `scripts/run-oxlint.mjs`; full `pnpm lint:*` only when scope requires).
 - SDK surface gate: `pnpm plugin-sdk:surface:check`; no `plugin-sdk:surface-report` script.
 - Build before push when build output, packaging, lazy/module boundaries, dynamic imports, or published surfaces can change; agent builds default to the selected remote box unless platform-specific proof requires another remote host.
 

--- a/src/auto-reply/reply.triggers.group-intro-prompts.cases.ts
+++ b/src/auto-reply/reply.triggers.group-intro-prompts.cases.ts
@@ -1,6 +1,8 @@
 /** Reusable group-intro prompt assertions shared by auto-reply trigger tests. */
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { makeCfg } from "../../test/helpers/auto-reply/trigger-handling-test-harness.js";
+import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../plugins/runtime.js";
+import { createChannelTestPluginBase, createTestRegistry } from "../test-utils/channel-plugins.js";
 import { buildGroupChatContext, buildGroupIntro } from "./reply/groups.js";
 
 type GetReplyFromConfig = typeof import("./reply.js").getReplyFromConfig;
@@ -8,6 +10,25 @@ type InboundMessage = Parameters<GetReplyFromConfig>[0];
 
 export function registerGroupIntroPromptCases(): void {
   describe("group intro prompts", () => {
+    beforeEach(() => {
+      resetPluginRuntimeStateForTest();
+      setActivePluginRegistry(
+        createTestRegistry([
+          {
+            pluginId: "telegram",
+            source: "test",
+            plugin: {
+              ...createChannelTestPluginBase({ id: "telegram" }),
+              messaging: { defaultMarkdownTableMode: "block" },
+            },
+          },
+        ]),
+      );
+    });
+    afterEach(() => {
+      resetPluginRuntimeStateForTest();
+    });
+
     type GroupIntroCase = {
       name: string;
       message: InboundMessage;


### PR DESCRIPTION
## What Problem This Solves

Resolves a release-validation failure where the group-intro E2E expected Telegram's channel-specific Markdown guidance without installing the channel metadata that controls that guidance.

## Why This Change Was Made

The test now installs a scoped Telegram channel registry before each group-intro case and clears it afterward. Exact Telegram and non-Telegram prompt assertions remain intact. The contributor instructions also record the repository's actual formatter write invocation after an observed command mistake.

## User Impact

No runtime behavior change. Release validation now tests channel-specific group prompts against the metadata contract instead of ambient registry state.

## Evidence

- Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/29397616309
- Focused result: 5 passed, 16 skipped
- `git diff --check`
- `pnpm format src/auto-reply/reply.triggers.group-intro-prompts.cases.ts AGENTS.md`
- Fresh autoreview: clean, confidence 0.93
