### PR TITLE
fix(embedded-runner): clear tool-search catalog when a run aborts during prep

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt.tool-search-catalog-abort.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.tool-search-catalog-abort.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { testing as toolSearchTesting } from "../../tool-search.js";
+import {
+  cleanupTempPaths,
+  createContextEngineAttemptRunner,
+  createContextEngineBootstrapAndAssemble,
+  getHoisted,
+  preloadRunEmbeddedAttemptForTests,
+  resetEmbeddedAttemptHarness,
+} from "./attempt.spawn-workspace.test-support.js";
+
+const hoisted = getHoisted();
+const tempPaths: string[] = [];
+
+function catalogProbeTools() {
+  return [
+    {
+      name: "tool_search",
+      description: "tool-search control surface",
+      parameters: { type: "object", properties: {} },
+      execute: async () => "",
+    },
+    {
+      name: "cataloged_probe_tool",
+      description: "deferred behind the catalog",
+      parameters: { type: "object", properties: {} },
+      execute: async () => "",
+    },
+  ];
+}
+
+describe("runEmbeddedAttempt tool-search catalog cleanup", () => {
+  beforeAll(async () => {
+    await preloadRunEmbeddedAttemptForTests();
+  });
+
+  beforeEach(() => {
+    resetEmbeddedAttemptHarness();
+    toolSearchTesting.sessionCatalogs.clear();
+  });
+
+  afterEach(async () => {
+    await cleanupTempPaths(tempPaths);
+    tempPaths.length = 0;
+    toolSearchTesting.sessionCatalogs.clear();
+  });
+
+  it("clears the registered run catalog when the run aborts during prep", async () => {
+    const abortController = new AbortController();
+    const prompt = vi.fn(async () => {});
+    const abortError = new Error("stopped during lock acquisition");
+    abortError.name = "AbortError";
+    let markLockRequested!: () => void;
+    const lockRequested = new Promise<void>((resolve) => {
+      markLockRequested = resolve;
+    });
+    hoisted.acquireSessionWriteLockMock.mockImplementationOnce(async (params) => {
+      markLockRequested();
+      await new Promise<void>((resolve) => {
+        params.signal?.addEventListener("abort", () => resolve(), { once: true });
+      });
+      throw params.signal?.reason;
+    });
+    hoisted.createOpenClawCodingToolsMock.mockImplementation(() => catalogProbeTools());
+
+    const runId = "run-catalog-abort";
+    const attempt = createContextEngineAttemptRunner({
+      contextEngine: createContextEngineBootstrapAndAssemble(),
+      sessionKey: "agent:main:telegram:direct:123",
+      tempPaths,
+      sessionPrompt: prompt,
+      attemptOverrides: {
+        runId,
+        abortSignal: abortController.signal,
+        disableTools: false,
+        config: {
+          tools: { toolSearch: { enabled: true, mode: "tools" } },
+        },
+      },
+    });
+    await lockRequested;
+    // Guards the test itself: without a registered catalog the assertion below
+    // would pass vacuously.
+    expect([...toolSearchTesting.sessionCatalogs.keys()]).toContain(`run:${runId}`);
+
+    abortController.abort(abortError);
+    await expect(attempt).rejects.toBe(abortError);
+
+    expect(toolSearchTesting.sessionCatalogs.has(`run:${runId}`)).toBe(false);
+  });
+});

--- a/src/agents/embedded-agent-runner/run/attempt.tool-search-catalog-abort.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.tool-search-catalog-abort.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { testing as toolSearchTesting } from "../../tool-search.js";
+import { testing as toolSearchTesting } from "../../tool-search.test-support.js";
 import {
   cleanupTempPaths,
   createContextEngineAttemptRunner,

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -273,8 +273,13 @@ export async function runEmbeddedAttempt(
       catalogToolHookContext,
       deferredDirectoryToolsCallable,
       effectiveTools,
+      toolSearch,
       toolSearchRunPlan,
     } = preparedToolCatalog;
+    // Arms the early-exit catalog clear: the run-scoped catalog is registered in
+    // a process-global map that only clearToolSearchCatalog deletes from, so a
+    // prep-phase abort after registration leaks the entry without this.
+    toolSearchCatalogApplied = toolSearch.catalogRegistered;
     const preparedSystemPrompt = await prepareEmbeddedAttemptSystemPrompt({
       activeContextEngine,
       attempt: params,


### PR DESCRIPTION
## What Problem This Solves

`runEmbeddedAttempt` registers a run-scoped tool-search catalog during prep, and `cleanupEmbeddedPrepResourcesAfterEarlyExit` is supposed to clear it if the run exits before the normal teardown runs. That cleanup is currently unreachable: `toolSearchCatalogApplied` is declared `false` (`attempt.ts:91`), read as the guard (`:93`) and reset to `false` (`:101`), but it is never assigned `true` anywhere in the repository.

```
$ rg -n "toolSearchCatalogApplied" src
src/agents/embedded-agent-runner/run/attempt.ts:91:  let toolSearchCatalogApplied = false;
src/agents/embedded-agent-runner/run/attempt.ts:93:    if (toolSearchCatalogApplied) {
src/agents/embedded-agent-runner/run/attempt.ts:101:      toolSearchCatalogApplied = false;
```

The assignment existed before the runtime internalization refactor and was dropped at the move site when catalog application moved into `prepareEmbeddedAttemptToolCatalog`:

```
$ git show bb46b79d3c1^:src/agents/pi-embedded-runner/run/attempt.ts | rg -n "toolSearchCatalogApplied"
1479:  let toolSearchCatalogApplied = false;
1494:    if (toolSearchCatalogApplied) {
1502:      toolSearchCatalogApplied = false;
2120:    toolSearchCatalogApplied = true;     <- lost
```

Catalogs live in a process-global map (`tool-search.ts:416-422`, `globalThis` + `Symbol.for`) keyed `run:${runId}`. The only `delete` is inside `clearToolSearchCatalog` (`tool-search.ts:1105`); there is no TTL, cap or sweeper. So when a run is cancelled during prep after the catalog registers, the entry is never removed.

## Why This Change Was Made

The value needed to arm the guard is already computed and returned, just not consumed. `prepareEmbeddedAttemptToolCatalog` returns `toolSearch` (`attempt-tool-catalog.ts:238`), whose `catalogRegistered` is `true` exactly where `sessionCatalogs.set()` runs (`tool-search.ts:1955/1980/2001`). `attempt.ts:272-277` destructured four fields from that result and omitted `toolSearch`.

Two surfaces confirm the intended contract:

- The normal teardown sibling clears **unconditionally**, with no applied-guard: `attempt-session-cleanup.ts:113`. Teardown always clears the catalog.
- Inside the same early-exit cleanup, the other two prepared resources dispose correctly — `bundleMcpRuntime` (`attempt.ts:104`) and `bundleLspRuntime` (`:111`). Only the catalog's guard is never armed.

Reading `catalogRegistered` also keeps the disabled case correct without a branch: it is `false` when tool-search/code-mode is off, so the clear stays skipped exactly when nothing was registered.

## User Impact

On a long-running gateway, every agent run cancelled during prep (user stop, restart interrupt) permanently leaks one tool-search catalog — its tool entries and schemas — with no mechanism to reclaim it. Runs that complete or fail after prep are unaffected, since the normal teardown path clears correctly. Only affects configurations with tool-search or code-mode enabled.

## Evidence

New regression test `src/agents/embedded-agent-runner/run/attempt.tool-search-catalog-abort.test.ts` drives the real `runEmbeddedAttempt` via the existing spawn-workspace harness, registers a real catalog through the real `applyToolSearchCatalog` path (`tool-search.js` is not mocked), aborts during eager session-lock acquisition, and asserts the catalog key is gone from the real `sessionCatalogs` map.

The test asserts the catalog is present at abort time before asserting it is cleared, so it cannot pass vacuously.

Existing coverage misses this because `attempt-abort.test.ts:139` stubs `cleanupAfterEarlyAbort` with `vi.fn()` and asserts only that it fires, never what it does.

## Real behavior proof

Behavior addressed: a run-scoped tool-search catalog registered during prep is never removed from the process-global `sessionCatalogs` map when the run aborts during prep, because the guard controlling the early-exit `clearToolSearchCatalog` call can never be true.

Real environment tested: local repo checkout at `732fb5f9e61`, Node 24, real `runEmbeddedAttempt` entry point with the real `src/agents/tool-search.ts` module (not mocked) and the real process-global `sessionCatalogs` map observed through its own `testing` export.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/attempt.tool-search-catalog-abort.test.ts`

Evidence after fix:

```
 Test Files  1 passed (1)
      Tests  1 passed (1)
```

Fail-on-main verified by restoring the pristine file (`git checkout origin/main -- src/agents/embedded-agent-runner/run/attempt.ts`) and re-running the same test:

```
 × clears the registered run catalog when the run aborts during prep
AssertionError: expected true to be false // Object.is equality
 Test Files  1 failed (1)
```

That `true` is `sessionCatalogs.has("run:run-catalog-abort")` after the abort — the leaked entry. A probe of the same run printed the map keys directly:

```
at lock (catalog registered):  ["run:run-catalog-probe"]
after abort, on main:          ["run:run-catalog-probe"]   <- leaked
after abort, with this patch:  []                          <- cleared
```

Observed result after fix: the catalog registers during prep as before, and the prep-abort path now removes it, leaving the map empty. Neighbouring suites stay green: `attempt.abort-race.test.ts`, `attempt-abort.test.ts`, `attempt-session-cleanup.test.ts` and `tool-search.test.ts` = 4 files / 64 tests passed. `oxlint --type-aware` and `oxfmt` clean on both changed files.

What was not tested: no live long-running gateway was used to observe cumulative heap growth across many cancelled runs; the leak is demonstrated at the map level rather than as a measured RSS delta. The full repository typecheck and full suite were not run locally and are left to CI.
