### PR TITLE
feat(linux): discover gateways on the LAN via Bonjour

### DIFF
--- a/apps/linux/README.md
+++ b/apps/linux/README.md
@@ -1,6 +1,6 @@
 # OpenClaw for Linux
 
-The Linux companion is a Tauri v2 desktop shell for a local OpenClaw Gateway. It installs the CLI when needed, delegates Gateway service management to `openclaw gateway`, opens the Gateway-served Control UI with its resolved auth URL, and stays available in the system tray.
+The Linux companion is a Tauri v2 desktop shell for OpenClaw Gateways. It discovers nearby Gateways over Bonjour, installs the CLI when needed, delegates local Gateway service management to `openclaw gateway`, opens the selected Gateway's Control UI, and stays available in the system tray.
 
 ## Linux prerequisites
 

--- a/apps/linux/src-tauri/Cargo.lock
+++ b/apps/linux/src-tauri/Cargo.lock
@@ -766,6 +766,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "flume"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e139bc46ca777eb5efaf62df0ab8cc5fd400866427e56c68b22e414e53bd3be"
+dependencies = [
+ "spin",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1441,6 +1450,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "if-addrs"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0a05c691e1fae256cf7013d99dad472dc52d5543322761f83ec8d47eab40d2b"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "image"
 version = "0.25.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1701,6 +1720,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "mdns-sd"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb75febbe5fa1837a52fdbd1c735e168286c5c645fc2ddd31526f65c49941c2e"
+dependencies = [
+ "fastrand",
+ "flume",
+ "if-addrs",
+ "mio",
+ "socket-pktinfo",
+ "socket2",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1738,6 +1771,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -2049,6 +2083,7 @@ dependencies = [
  "cairo-rs",
  "image",
  "libc",
+ "mdns-sd",
  "serde",
  "serde_json",
  "tauri",
@@ -2764,6 +2799,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
+name = "socket-pktinfo"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e8e43b4bdce7cff8a4d3f8025ee38fce5ca138fab868ebbf9529c81328fbf9d"
+dependencies = [
+ "libc",
+ "socket2",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "socket2"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2819,6 +2865,15 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
+dependencies = [
+ "lock_api",
 ]
 
 [[package]]

--- a/apps/linux/src-tauri/Cargo.toml
+++ b/apps/linux/src-tauri/Cargo.toml
@@ -15,6 +15,7 @@ tauri-build = "2.6.3"
 [dependencies]
 base64 = "0.22.1"
 image = { version = "0.25.10", default-features = false, features = ["jpeg", "png"] }
+mdns-sd = { version = "0.20", default-features = false }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.150"
 tauri = { version = "2.11.5", features = ["image-png", "tray-icon"] }

--- a/apps/linux/src-tauri/build.rs
+++ b/apps/linux/src-tauri/build.rs
@@ -4,6 +4,8 @@ fn main() {
     const COMMANDS: &[&str] = &[
         "bootstrap",
         "canvas_a2ui_action",
+        "connect_discovered_gateway",
+        "discover_gateways",
         "gateway_action",
         "install_cli",
     ];

--- a/apps/linux/src-tauri/permissions/autogenerated/connect_discovered_gateway.toml
+++ b/apps/linux/src-tauri/permissions/autogenerated/connect_discovered_gateway.toml
@@ -1,0 +1,11 @@
+# Automatically generated - DO NOT EDIT!
+
+[[permission]]
+identifier = "allow-connect-discovered-gateway"
+description = "Enables the connect_discovered_gateway command without any pre-configured scope."
+commands.allow = ["connect_discovered_gateway"]
+
+[[permission]]
+identifier = "deny-connect-discovered-gateway"
+description = "Denies the connect_discovered_gateway command without any pre-configured scope."
+commands.deny = ["connect_discovered_gateway"]

--- a/apps/linux/src-tauri/permissions/autogenerated/discover_gateways.toml
+++ b/apps/linux/src-tauri/permissions/autogenerated/discover_gateways.toml
@@ -1,0 +1,11 @@
+# Automatically generated - DO NOT EDIT!
+
+[[permission]]
+identifier = "allow-discover-gateways"
+description = "Enables the discover_gateways command without any pre-configured scope."
+commands.allow = ["discover_gateways"]
+
+[[permission]]
+identifier = "deny-discover-gateways"
+description = "Denies the discover_gateways command without any pre-configured scope."
+commands.deny = ["discover_gateways"]

--- a/apps/linux/src-tauri/src/discovery.rs
+++ b/apps/linux/src-tauri/src/discovery.rs
@@ -1,0 +1,765 @@
+use mdns_sd::{ResolvedService, ServiceDaemon, ServiceEvent};
+use serde::Serialize;
+use std::collections::BTreeMap;
+use std::net::IpAddr;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+use std::thread;
+use tauri::Url;
+
+const GATEWAY_SERVICE_TYPE: &str = "_openclaw-gw._tcp.local.";
+
+type GatewayMap = Arc<Mutex<BTreeMap<String, DiscoveredGateway>>>;
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DiscoveredGateway {
+    pub name: String,
+    pub host: String,
+    pub port: u16,
+    pub addresses: Vec<String>,
+    pub tls: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tls_fingerprint_sha256: Option<String>,
+    pub direct_reachable: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tailnet_dns: Option<String>,
+}
+
+impl DiscoveredGateway {
+    fn from_service(service: &ResolvedService) -> Option<Self> {
+        let host = validated_service_host(service.get_hostname())?;
+        let mut addresses = service
+            .get_addresses()
+            .iter()
+            // ScopedIp's Display preserves the interface required by IPv6 link-local routes.
+            .map(ToString::to_string)
+            .collect::<Vec<_>>();
+        addresses.sort();
+        addresses.dedup();
+        if addresses.is_empty() {
+            return None;
+        }
+
+        let name = txt_value(service, "displayName")
+            .map(|name| prettify_instance_name(&name))
+            .filter(|name| !name.is_empty())
+            .unwrap_or_else(|| service_instance_name(service.get_fullname()));
+
+        Some(Self {
+            name,
+            host,
+            port: service.get_port(),
+            addresses,
+            tls: txt_bool(service, "gatewayTls"),
+            tls_fingerprint_sha256: txt_value(service, "gatewayTlsSha256"),
+            direct_reachable: txt_bool(service, "gatewayDirectReachable"),
+            tailnet_dns: txt_value(service, "tailnetDns"),
+        })
+    }
+
+    fn advertises_direct_transport(&self) -> bool {
+        // The desktop has no SSH/relay transport, so match the native client's direct-selection gate.
+        self.tls || self.direct_reachable || self.host.to_ascii_lowercase().ends_with(".ts.net")
+    }
+
+    fn has_safe_resolved_address(&self) -> bool {
+        let addresses = self
+            .addresses
+            .iter()
+            .filter_map(|address| resolved_ip_address(address))
+            .collect::<Vec<_>>();
+        if addresses.is_empty() {
+            return false;
+        }
+        self.tls
+            || (is_trusted_plaintext_host(&self.host)
+                && addresses.iter().all(is_trusted_plaintext_address))
+    }
+}
+
+struct DiscoveryRuntime {
+    daemon: ServiceDaemon,
+    receiver_alive: Arc<AtomicBool>,
+}
+
+#[derive(Default)]
+pub struct GatewayDiscovery {
+    gateways: GatewayMap,
+    runtime: Mutex<Option<DiscoveryRuntime>>,
+    generation: Arc<AtomicU64>,
+}
+
+impl GatewayDiscovery {
+    fn start(&self) -> Result<(), String> {
+        let mut runtime = self
+            .runtime
+            .lock()
+            .map_err(|_| "Gateway discovery lock is unavailable.".to_string())?;
+        if runtime
+            .as_ref()
+            .is_some_and(|runtime| runtime.receiver_alive.load(Ordering::Acquire))
+        {
+            return Ok(());
+        }
+        if let Some(stale) = runtime.take() {
+            let _ = stale.daemon.shutdown();
+        }
+        clear_gateways(&self.gateways);
+
+        let mdns = ServiceDaemon::new()
+            .map_err(|error| format!("Could not start gateway discovery: {error}"))?;
+        let events = match mdns.browse(GATEWAY_SERVICE_TYPE) {
+            Ok(events) => events,
+            Err(error) => {
+                let _ = mdns.shutdown();
+                return Err(format!("Could not browse for gateways: {error}"));
+            }
+        };
+        let gateways = Arc::clone(&self.gateways);
+        let receiver_alive = Arc::new(AtomicBool::new(true));
+        let thread_receiver_alive = Arc::clone(&receiver_alive);
+        let generation = self
+            .generation
+            .fetch_add(1, Ordering::AcqRel)
+            .wrapping_add(1);
+        let current_generation = Arc::clone(&self.generation);
+        // A dead receiver makes the next snapshot rebuild discovery. The generation
+        // prevents an old receiver from clearing a newer runtime's snapshot on exit.
+        let thread = thread::Builder::new()
+            .name("openclaw-gateway-discovery".to_string())
+            .spawn(move || {
+                while let Ok(event) = events.recv() {
+                    if !apply_event(&gateways, event) {
+                        break;
+                    }
+                }
+                thread_receiver_alive.store(false, Ordering::Release);
+                clear_gateways_if_current(&gateways, &current_generation, generation);
+            });
+        if let Err(error) = thread {
+            let _ = mdns.shutdown();
+            return Err(format!("Could not run gateway discovery: {error}"));
+        }
+        *runtime = Some(DiscoveryRuntime {
+            daemon: mdns,
+            receiver_alive,
+        });
+        Ok(())
+    }
+
+    fn snapshot(&self) -> Result<Vec<DiscoveredGateway>, String> {
+        self.start()?;
+        let mut gateways = self
+            .gateways
+            .lock()
+            .map_err(|_| "Gateway discovery snapshot is unavailable.".to_string())?
+            .values()
+            .cloned()
+            .collect::<Vec<_>>();
+        gateways.sort_by(|left, right| {
+            left.name
+                .to_ascii_lowercase()
+                .cmp(&right.name.to_ascii_lowercase())
+                .then_with(|| left.host.cmp(&right.host))
+                .then_with(|| left.port.cmp(&right.port))
+        });
+        Ok(gateways)
+    }
+
+    fn dashboard_url(&self, host: &str, port: u16, tls: bool) -> Result<Url, String> {
+        let host = validated_service_host(host)
+            .ok_or_else(|| "The discovered gateway returned an invalid host.".to_string())?;
+        let gateways = self
+            .gateways
+            .lock()
+            .map_err(|_| "Gateway discovery snapshot is unavailable.".to_string())?;
+        let gateway = gateways
+            .values()
+            .find(|gateway| gateway.host == host && gateway.port == port && gateway.tls == tls)
+            .ok_or_else(|| "The discovered gateway is no longer available.".to_string())?;
+        if !gateway.advertises_direct_transport() {
+            return Err(
+                "The discovered gateway does not advertise a direct connection.".to_string(),
+            );
+        }
+        if !gateway.has_safe_resolved_address() {
+            return Err(
+                "The discovered gateway does not have a safe resolved address.".to_string(),
+            );
+        }
+        let mut url = Url::parse(if gateway.tls {
+            "https://localhost/"
+        } else {
+            "http://localhost/"
+        })
+        .expect("static dashboard URL should parse");
+        if gateway.tls {
+            // TLS binds the validated SRV hostname through certificate validation and SNI.
+            url.set_host(Some(&gateway.host))
+                .map_err(|_| "The discovered gateway returned an invalid host.".to_string())?;
+        } else {
+            // Plaintext has no certificate binding, so navigate to the same private address
+            // validated in this snapshot instead of letting WebKit resolve the hostname again.
+            let address = gateway
+                .addresses
+                .iter()
+                .filter_map(|address| resolved_ip_address(address))
+                .find(is_trusted_plaintext_address)
+                .ok_or_else(|| {
+                    "The discovered gateway does not have a safe resolved address.".to_string()
+                })?;
+            url.set_ip_host(address)
+                .map_err(|_| "The discovered gateway returned an invalid host.".to_string())?;
+        }
+        url.set_port(Some(gateway.port))
+            .map_err(|_| "The discovered gateway returned an invalid port.".to_string())?;
+        Ok(url)
+    }
+}
+
+fn apply_event(gateways: &GatewayMap, event: ServiceEvent) -> bool {
+    let Ok(mut gateways) = gateways.lock() else {
+        return true;
+    };
+    match event {
+        ServiceEvent::ServiceResolved(service) => {
+            let fullname = service.get_fullname().to_string();
+            match DiscoveredGateway::from_service(&service) {
+                Some(gateway) => {
+                    gateways.insert(fullname, gateway);
+                }
+                None => {
+                    gateways.remove(&fullname);
+                }
+            }
+        }
+        // mdns-sd emits this for goodbye packets and expired cached records.
+        ServiceEvent::ServiceRemoved(_, fullname) => {
+            gateways.remove(&fullname);
+        }
+        ServiceEvent::SearchStopped(_) => return false,
+        _ => {}
+    }
+    true
+}
+
+fn clear_gateways(gateways: &GatewayMap) {
+    if let Ok(mut gateways) = gateways.lock() {
+        gateways.clear();
+    }
+}
+
+fn clear_gateways_if_current(
+    gateways: &GatewayMap,
+    current_generation: &AtomicU64,
+    generation: u64,
+) {
+    let Ok(mut gateways) = gateways.lock() else {
+        return;
+    };
+    // Replacement receivers insert under this lock, so a stale receiver cannot
+    // pass the generation check and later erase a newer snapshot.
+    if current_generation.load(Ordering::Acquire) == generation {
+        gateways.clear();
+    }
+}
+
+fn txt_value(service: &ResolvedService, key: &str) -> Option<String> {
+    let value = service.get_property_val_str(key)?.trim();
+    (!value.is_empty()).then(|| value.to_string())
+}
+
+fn txt_bool(service: &ResolvedService, key: &str) -> bool {
+    txt_value(service, key).is_some_and(|value| {
+        value == "1" || value.eq_ignore_ascii_case("true") || value.eq_ignore_ascii_case("yes")
+    })
+}
+
+fn validated_service_host(raw: &str) -> Option<String> {
+    if raw.is_empty() || raw != raw.trim() {
+        return None;
+    }
+    let host = raw.strip_suffix('.').unwrap_or(raw);
+    if host.is_empty() || host.len() > 253 {
+        return None;
+    }
+    let valid_labels = host.split('.').all(|label| {
+        !label.is_empty()
+            && label.len() <= 63
+            && !label.starts_with('-')
+            && !label.ends_with('-')
+            && label
+                .bytes()
+                .all(|byte| byte.is_ascii_alphanumeric() || byte == b'-')
+    });
+    if !valid_labels {
+        return None;
+    }
+    let mut url = Url::parse("https://localhost/").expect("static validation URL should parse");
+    url.set_host(Some(host)).ok()?;
+    if !url
+        .host_str()
+        .is_some_and(|normalized| normalized.eq_ignore_ascii_case(host))
+    {
+        return None;
+    }
+    Some(host.to_string())
+}
+
+fn resolved_ip_address(address: &str) -> Option<IpAddr> {
+    address
+        .split_once('%')
+        .map_or(address, |(address, _scope)| address)
+        .parse()
+        .ok()
+}
+
+fn is_trusted_plaintext_host(host: &str) -> bool {
+    let host = host.to_ascii_lowercase();
+    host == "localhost"
+        || host.ends_with(".local")
+        || host.ends_with(".ts.net")
+        || host
+            .parse::<IpAddr>()
+            .is_ok_and(|address| is_trusted_plaintext_address(&address))
+}
+
+fn is_trusted_plaintext_address(address: &IpAddr) -> bool {
+    match address {
+        IpAddr::V4(address) => {
+            let [first, second, _, _] = address.octets();
+            address.is_loopback()
+                || address.is_private()
+                || address.is_link_local()
+                || (first == 100 && (64..=127).contains(&second))
+        }
+        IpAddr::V6(address) => {
+            let first = address.segments()[0];
+            address.is_loopback() || first & 0xfe00 == 0xfc00 || first & 0xffc0 == 0xfe80
+        }
+    }
+}
+
+fn service_instance_name(fullname: &str) -> String {
+    let instance = strip_ascii_suffix(fullname, GATEWAY_SERVICE_TYPE).trim_end_matches('.');
+    let name = prettify_instance_name(&decode_bonjour_name(instance));
+    if name.is_empty() {
+        "OpenClaw Gateway".to_string()
+    } else {
+        name
+    }
+}
+
+fn prettify_instance_name(name: &str) -> String {
+    let normalized = name.split_whitespace().collect::<Vec<_>>().join(" ");
+    let without_conflict = strip_conflict_suffix(&normalized).trim();
+    strip_ascii_suffix(without_conflict, " (OpenClaw)")
+        .trim()
+        .to_string()
+}
+
+fn strip_ascii_suffix<'a>(value: &'a str, suffix: &str) -> &'a str {
+    let start = value.len().saturating_sub(suffix.len());
+    if value
+        .get(start..)
+        .is_some_and(|candidate| candidate.eq_ignore_ascii_case(suffix))
+    {
+        &value[..start]
+    } else {
+        value
+    }
+}
+
+fn strip_conflict_suffix(value: &str) -> &str {
+    let Some(prefix) = value.strip_suffix(')') else {
+        return value;
+    };
+    let Some(open) = prefix.rfind(" (") else {
+        return value;
+    };
+    if prefix[open + 2..]
+        .chars()
+        .all(|character| character.is_ascii_digit())
+    {
+        &prefix[..open]
+    } else {
+        value
+    }
+}
+
+fn decode_bonjour_name(value: &str) -> String {
+    let bytes = value.as_bytes();
+    let mut decoded = Vec::with_capacity(bytes.len());
+    let mut index = 0;
+    while index < bytes.len() {
+        if bytes[index] == b'\\' && index + 3 < bytes.len() {
+            let digits = &bytes[index + 1..index + 4];
+            if digits.iter().all(u8::is_ascii_digit) {
+                let number = u16::from(digits[0] - b'0') * 100
+                    + u16::from(digits[1] - b'0') * 10
+                    + u16::from(digits[2] - b'0');
+                if let Ok(number) = u8::try_from(number) {
+                    decoded.push(number);
+                    index += 4;
+                    continue;
+                }
+            }
+        }
+        decoded.push(bytes[index]);
+        index += 1;
+    }
+    String::from_utf8_lossy(&decoded).into_owned()
+}
+
+#[tauri::command]
+pub fn discover_gateways(
+    state: tauri::State<'_, GatewayDiscovery>,
+) -> Result<Vec<DiscoveredGateway>, String> {
+    state.snapshot()
+}
+
+#[tauri::command]
+pub fn connect_discovered_gateway(
+    app: tauri::AppHandle,
+    desktop: tauri::State<'_, crate::DesktopState>,
+    discovery: tauri::State<'_, GatewayDiscovery>,
+    host: String,
+    port: u16,
+    tls: bool,
+) -> Result<(), String> {
+    let url = discovery.dashboard_url(&host, port, tls)?;
+    desktop.navigate_remote(&app, url)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mdns_sd::ServiceInfo;
+
+    fn service() -> ResolvedService {
+        let properties = [
+            ("transport", "gateway"),
+            ("displayName", "Studio (OpenClaw)"),
+            ("gatewayTls", "yes"),
+            ("gatewayTlsSha256", "A1B2"),
+            ("gatewayDirectReachable", "1"),
+            ("tailnetDns", "studio.example.ts.net"),
+        ];
+        ServiceInfo::new(
+            GATEWAY_SERVICE_TYPE,
+            "studio (OpenClaw)",
+            "studio.local.",
+            "192.168.1.7,2001:db8::7",
+            18789,
+            &properties[..],
+        )
+        .expect("service should be valid")
+        .as_resolved_service()
+    }
+
+    #[test]
+    fn maps_gateway_service_contract() {
+        let gateway = DiscoveredGateway::from_service(&service()).expect("valid gateway");
+        assert_eq!(gateway.name, "Studio");
+        assert_eq!(gateway.host, "studio.local");
+        assert_eq!(gateway.port, 18789);
+        assert_eq!(gateway.addresses, ["192.168.1.7", "2001:db8::7"]);
+        assert!(gateway.tls);
+        assert_eq!(gateway.tls_fingerprint_sha256.as_deref(), Some("A1B2"));
+        assert!(gateway.direct_reachable);
+        assert_eq!(
+            gateway.tailnet_dns.as_deref(),
+            Some("studio.example.ts.net")
+        );
+    }
+
+    #[test]
+    fn builds_dashboard_url_from_resolved_endpoint() {
+        let discovery = GatewayDiscovery::default();
+        apply_event(
+            &discovery.gateways,
+            ServiceEvent::ServiceResolved(Box::new(service())),
+        );
+        assert_eq!(
+            discovery
+                .dashboard_url("studio.local", 18789, true)
+                .expect("dashboard URL")
+                .as_str(),
+            "https://studio.local:18789/"
+        );
+    }
+
+    #[test]
+    fn plaintext_dashboard_url_uses_validated_resolved_ipv4_address() {
+        let service = ServiceInfo::new(
+            GATEWAY_SERVICE_TYPE,
+            "plaintext IPv4 (OpenClaw)",
+            "plaintext-ipv4.local.",
+            "192.168.1.9",
+            18789,
+            &[("gatewayDirectReachable", "1")][..],
+        )
+        .expect("service should be valid")
+        .as_resolved_service();
+        let discovery = GatewayDiscovery::default();
+        apply_event(
+            &discovery.gateways,
+            ServiceEvent::ServiceResolved(Box::new(service)),
+        );
+
+        assert_eq!(
+            discovery
+                .dashboard_url("plaintext-ipv4.local", 18789, false)
+                .expect("plaintext dashboard URL")
+                .as_str(),
+            "http://192.168.1.9:18789/"
+        );
+    }
+
+    #[test]
+    fn plaintext_dashboard_url_brackets_validated_resolved_ipv6_address() {
+        let service = ServiceInfo::new(
+            GATEWAY_SERVICE_TYPE,
+            "plaintext IPv6 (OpenClaw)",
+            "plaintext-ipv6.local.",
+            "fd00::7",
+            18789,
+            &[("gatewayDirectReachable", "1")][..],
+        )
+        .expect("service should be valid")
+        .as_resolved_service();
+        let discovery = GatewayDiscovery::default();
+        apply_event(
+            &discovery.gateways,
+            ServiceEvent::ServiceResolved(Box::new(service)),
+        );
+
+        assert_eq!(
+            discovery
+                .dashboard_url("plaintext-ipv6.local", 18789, false)
+                .expect("plaintext IPv6 dashboard URL")
+                .as_str(),
+            "http://[fd00::7]:18789/"
+        );
+    }
+
+    #[test]
+    fn rejects_unsafe_advertised_hosts() {
+        for host in [
+            "attacker.example:443",
+            "user@attacker.example",
+            "attacker.example/path",
+            "attacker.example\\path",
+            "attacker.example?query",
+            "attacker.example#fragment",
+            " attacker.example",
+            "attacker.example ",
+            "attacker.example..",
+            "-attacker.example",
+            "attacker-.example",
+            "attacker_name.local",
+            "127.1",
+            "0177.0.0.1",
+            "0x7f000001",
+            "2130706433",
+            "fe80::1",
+        ] {
+            assert_eq!(validated_service_host(host), None, "host={host}");
+        }
+        assert_eq!(
+            validated_service_host("studio.example.ts.net."),
+            Some("studio.example.ts.net".to_string())
+        );
+    }
+
+    #[test]
+    fn rejects_public_plaintext_resolved_address() {
+        let service = ServiceInfo::new(
+            GATEWAY_SERVICE_TYPE,
+            "public plaintext (OpenClaw)",
+            "public-plaintext.local.",
+            "198.51.100.7",
+            18789,
+            &[("gatewayDirectReachable", "1")][..],
+        )
+        .expect("service should be valid")
+        .as_resolved_service();
+        let discovery = GatewayDiscovery::default();
+        apply_event(
+            &discovery.gateways,
+            ServiceEvent::ServiceResolved(Box::new(service)),
+        );
+
+        assert_eq!(
+            discovery
+                .dashboard_url("public-plaintext.local", 18789, false)
+                .expect_err("public plaintext should not connect"),
+            "The discovered gateway does not have a safe resolved address."
+        );
+    }
+
+    #[test]
+    fn rejects_public_plaintext_hostname_even_with_private_resolution() {
+        let service = ServiceInfo::new(
+            GATEWAY_SERVICE_TYPE,
+            "public hostname (OpenClaw)",
+            "dashboard.example.com.",
+            "192.168.1.9",
+            18789,
+            &[("gatewayDirectReachable", "1")][..],
+        )
+        .expect("service should be valid")
+        .as_resolved_service();
+        let discovery = GatewayDiscovery::default();
+        apply_event(
+            &discovery.gateways,
+            ServiceEvent::ServiceResolved(Box::new(service)),
+        );
+
+        assert_eq!(
+            discovery
+                .dashboard_url("dashboard.example.com", 18789, false)
+                .expect_err("public plaintext hostname should not connect"),
+            "The discovered gateway does not have a safe resolved address."
+        );
+    }
+
+    #[test]
+    fn keeps_validated_tls_hostname_with_ipv6_resolution() {
+        let service = ServiceInfo::new(
+            GATEWAY_SERVICE_TYPE,
+            "ipv6 tls (OpenClaw)",
+            "ipv6-tls.local.",
+            "2001:db8::7",
+            443,
+            &[("gatewayTls", "1")][..],
+        )
+        .expect("service should be valid")
+        .as_resolved_service();
+        let discovery = GatewayDiscovery::default();
+        apply_event(
+            &discovery.gateways,
+            ServiceEvent::ServiceResolved(Box::new(service)),
+        );
+
+        assert_eq!(
+            discovery
+                .dashboard_url("ipv6-tls.local", 443, true)
+                .expect("IPv6 dashboard URL")
+                .as_str(),
+            "https://ipv6-tls.local/"
+        );
+    }
+
+    #[test]
+    fn preserves_ipv6_scope_while_validating_the_resolved_address() {
+        let scoped = "fe80::7%en0";
+        assert_eq!(
+            resolved_ip_address(scoped),
+            Some("fe80::7".parse().expect("IPv6 address"))
+        );
+        let gateway = DiscoveredGateway {
+            name: "Scoped IPv6".to_string(),
+            host: "scoped.local".to_string(),
+            port: 18789,
+            addresses: vec![scoped.to_string()],
+            tls: false,
+            tls_fingerprint_sha256: None,
+            direct_reachable: true,
+            tailnet_dns: None,
+        };
+        assert!(gateway.has_safe_resolved_address());
+        assert_eq!(gateway.addresses, [scoped]);
+    }
+
+    #[test]
+    fn rejects_gateway_without_direct_transport() {
+        let service = ServiceInfo::new(
+            GATEWAY_SERVICE_TYPE,
+            "relay only (OpenClaw)",
+            "relay-only.local.",
+            "192.168.1.8",
+            18789,
+            &[("transport", "gateway")][..],
+        )
+        .expect("service should be valid")
+        .as_resolved_service();
+        let discovery = GatewayDiscovery::default();
+        apply_event(
+            &discovery.gateways,
+            ServiceEvent::ServiceResolved(Box::new(service)),
+        );
+        assert_eq!(
+            discovery
+                .dashboard_url("relay-only.local", 18789, false)
+                .expect_err("relay-only gateway should not connect"),
+            "The discovered gateway does not advertise a direct connection."
+        );
+    }
+
+    #[test]
+    fn removal_event_expires_snapshot_entry() {
+        let gateways = GatewayMap::default();
+        let service = service();
+        let fullname = service.get_fullname().to_string();
+        apply_event(&gateways, ServiceEvent::ServiceResolved(Box::new(service)));
+        assert_eq!(gateways.lock().expect("snapshot lock").len(), 1);
+
+        apply_event(
+            &gateways,
+            ServiceEvent::ServiceRemoved(GATEWAY_SERVICE_TYPE.to_string(), fullname),
+        );
+        assert!(gateways.lock().expect("snapshot lock").is_empty());
+    }
+
+    #[test]
+    fn rejected_refresh_expires_previous_snapshot_entry() {
+        let gateways = GatewayMap::default();
+        let service = service();
+        apply_event(
+            &gateways,
+            ServiceEvent::ServiceResolved(Box::new(service.clone())),
+        );
+        assert_eq!(gateways.lock().expect("snapshot lock").len(), 1);
+
+        let mut invalid_refresh = service;
+        invalid_refresh.host = "attacker.example:443".to_string();
+        apply_event(
+            &gateways,
+            ServiceEvent::ServiceResolved(Box::new(invalid_refresh)),
+        );
+
+        assert!(gateways.lock().expect("snapshot lock").is_empty());
+    }
+
+    #[test]
+    fn stopped_search_marks_receiver_for_restart() {
+        let gateways = GatewayMap::default();
+        assert!(!apply_event(
+            &gateways,
+            ServiceEvent::SearchStopped(GATEWAY_SERVICE_TYPE.to_string())
+        ));
+    }
+
+    #[test]
+    fn stale_receiver_cannot_clear_a_newer_snapshot() {
+        let gateways = GatewayMap::default();
+        let service = service();
+        apply_event(&gateways, ServiceEvent::ServiceResolved(Box::new(service)));
+        let generation = AtomicU64::new(2);
+
+        clear_gateways_if_current(&gateways, &generation, 1);
+
+        assert_eq!(gateways.lock().expect("snapshot lock").len(), 1);
+    }
+
+    #[test]
+    fn decodes_and_prettifies_fallback_name() {
+        assert_eq!(
+            service_instance_name("Peter\\032Studio\\032(OpenClaw)._openclaw-gw._tcp.local."),
+            "Peter Studio"
+        );
+        assert_eq!(prettify_instance_name("Studio (OpenClaw) (2)"), "Studio");
+    }
+}

--- a/apps/linux/src-tauri/src/main.rs
+++ b/apps/linux/src-tauri/src/main.rs
@@ -1,6 +1,7 @@
 #[cfg(target_os = "linux")]
 mod canvas;
 mod cli;
+mod discovery;
 mod gateway;
 mod installer;
 mod tray;
@@ -8,7 +9,7 @@ mod tray;
 use cli::{CliError, OpenClawCli};
 use gateway::{GatewayAction, GatewaySnapshot};
 use installer::InstallChannel;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::Duration;
@@ -17,12 +18,56 @@ use tauri::{AppHandle, Manager, State, Url, WebviewWindow};
 const CONNECTED_WATCH_INTERVAL: Duration = Duration::from_secs(15);
 const RECONNECT_INTERVAL: Duration = Duration::from_secs(3);
 
+#[derive(Default)]
+struct NavigationState {
+    // One lock owns both fields so the intent check and WebView navigation cannot interleave.
+    remote_dashboard: bool,
+    watch_generation: u64,
+}
+
+impl NavigationState {
+    fn cancel_watchdog(&mut self) {
+        self.watch_generation = self.watch_generation.wrapping_add(1);
+    }
+
+    fn select_remote(&mut self) {
+        self.cancel_watchdog();
+        self.remote_dashboard = true;
+    }
+
+    fn permit_local(&mut self, force: bool, expected_generation: Option<u64>) -> bool {
+        if expected_generation.is_some_and(|expected| expected != self.watch_generation) {
+            return false;
+        }
+        if self.remote_dashboard && !force {
+            return false;
+        }
+        if force {
+            self.cancel_watchdog();
+            self.remote_dashboard = false;
+        }
+        true
+    }
+
+    fn begin_watchdog(&mut self) -> Option<u64> {
+        if self.remote_dashboard {
+            return None;
+        }
+        self.cancel_watchdog();
+        Some(self.watch_generation)
+    }
+
+    fn watchdog_is_current(&self, generation: u64) -> bool {
+        !self.remote_dashboard && self.watch_generation == generation
+    }
+}
+
 struct DesktopInner {
     cli: Mutex<Option<OpenClawCli>>,
+    navigation: Mutex<NavigationState>,
     operation: Mutex<()>,
     local_url: Url,
     tray: Mutex<Option<tray::TrayHandles>>,
-    watch_generation: AtomicU64,
     quitting: AtomicBool,
 }
 
@@ -36,10 +81,10 @@ impl DesktopState {
         Self {
             inner: Arc::new(DesktopInner {
                 cli: Mutex::new(None),
+                navigation: Mutex::new(NavigationState::default()),
                 operation: Mutex::new(()),
                 local_url,
                 tray: Mutex::new(None),
-                watch_generation: AtomicU64::new(0),
                 quitting: AtomicBool::new(false),
             }),
         }
@@ -65,9 +110,11 @@ impl DesktopState {
             Err(error) => return Err(error.to_string()),
         };
         let ready = gateway::ensure_ready(&cli)?;
-        self.navigate(app, &ready.dashboard_url)?;
+        let navigated = self.navigate_local(app, &ready.dashboard_url, false, None, true)?;
         self.update_tray(&ready.snapshot);
-        self.start_watchdog(app.clone());
+        if navigated {
+            self.start_watchdog(app.clone());
+        }
         Ok(ready.snapshot)
     }
 
@@ -85,9 +132,11 @@ impl DesktopState {
         let cli = OpenClawCli::discover().map_err(|error| error.to_string())?;
         *self.inner.cli.lock().expect("CLI mutex poisoned") = Some(cli.clone());
         let ready = gateway::ensure_ready(&cli)?;
-        self.navigate(app, &ready.dashboard_url)?;
+        let navigated = self.navigate_local(app, &ready.dashboard_url, false, None, true)?;
         self.update_tray(&ready.snapshot);
-        self.start_watchdog(app.clone());
+        if navigated {
+            self.start_watchdog(app.clone());
+        }
         Ok(ready.snapshot)
     }
 
@@ -107,20 +156,28 @@ impl DesktopState {
         let cli = self.resolve_cli().map_err(|error| error.to_string())?;
         let snapshot = gateway::act(&cli, action)?;
         if matches!(action, GatewayAction::Stop) {
-            self.show_local(app, "stopped")?;
+            self.show_local(app, "stopped", false, None)?;
             self.update_tray(&snapshot);
             return Ok(snapshot);
         }
 
         let ready = gateway::dashboard(&cli, snapshot)?;
-        self.navigate(app, &ready.dashboard_url)?;
+        let navigated = self.navigate_local(app, &ready.dashboard_url, false, None, true)?;
         self.update_tray(&ready.snapshot);
-        self.start_watchdog(app.clone());
+        if navigated {
+            self.start_watchdog(app.clone());
+        }
         Ok(ready.snapshot)
     }
 
+    pub fn connect_explicit_local(&self, app: &AppHandle) -> Result<GatewaySnapshot, String> {
+        // The click returns immediately; a later remote selection still wins while connect runs.
+        self.show_local(app, "reconnecting", true, None)?;
+        self.connect(app)
+    }
+
     pub fn show_error(&self, app: &AppHandle, _error: &str) {
-        let _ = self.show_local(app, "error");
+        let _ = self.show_local(app, "error", false, None);
         self.update_tray(&GatewaySnapshot::reconnecting("Gateway action failed."));
         tray::show_window(app);
     }
@@ -155,34 +212,100 @@ impl DesktopState {
         }
     }
 
-    fn navigate(&self, app: &AppHandle, target: &str) -> Result<(), String> {
+    // Caller holds the navigation lock, keeping the final arbitration check and navigation atomic.
+    fn navigate_locked(
+        &self,
+        app: &AppHandle,
+        target: &str,
+        reveal_window: bool,
+    ) -> Result<(), String> {
         let url =
             Url::parse(target).map_err(|_| "Dashboard returned an invalid URL.".to_string())?;
         main_window(app)?
             .navigate(url)
             .map_err(|error| format!("Could not open dashboard: {error}"))?;
+        if reveal_window {
+            tray::show_window(app);
+        }
+        Ok(())
+    }
+
+    fn navigate_local(
+        &self,
+        app: &AppHandle,
+        target: &str,
+        force: bool,
+        expected_generation: Option<u64>,
+        reveal_window: bool,
+    ) -> Result<bool, String> {
+        let mut navigation = self
+            .inner
+            .navigation
+            .lock()
+            .map_err(|_| "Dashboard navigation lock is unavailable.".to_string())?;
+        if !navigation.permit_local(force, expected_generation) {
+            return Ok(false);
+        }
+        self.navigate_locked(app, target, reveal_window)?;
+        Ok(true)
+    }
+
+    pub fn navigate_remote(&self, app: &AppHandle, target: Url) -> Result<(), String> {
+        let mut navigation = self
+            .inner
+            .navigation
+            .lock()
+            .map_err(|_| "Dashboard navigation lock is unavailable.".to_string())?;
+        let window = main_window(app)?;
+        navigation.select_remote();
+        if let Err(error) = window.navigate(target) {
+            navigation.remote_dashboard = false;
+            return Err(format!("Could not open discovered gateway: {error}"));
+        }
         tray::show_window(app);
         Ok(())
     }
 
-    fn show_local(&self, app: &AppHandle, mode: &str) -> Result<(), String> {
+    fn show_local(
+        &self,
+        app: &AppHandle,
+        mode: &str,
+        force: bool,
+        expected_generation: Option<u64>,
+    ) -> Result<bool, String> {
         let mut url = self.inner.local_url.clone();
         url.query_pairs_mut().clear().append_pair("mode", mode);
-        main_window(app)?
-            .navigate(url)
-            .map_err(|error| format!("Could not open local screen: {error}"))
+        // Status/watchdog updates may change the hidden WebView, but must not reveal it.
+        self.navigate_local(app, url.as_str(), force, expected_generation, false)
     }
 
     fn cancel_watchdog(&self) {
-        self.inner.watch_generation.fetch_add(1, Ordering::SeqCst);
+        if let Ok(mut navigation) = self.inner.navigation.lock() {
+            navigation.cancel_watchdog();
+        }
+    }
+
+    fn watchdog_is_current(&self, generation: u64) -> bool {
+        self.inner
+            .navigation
+            .lock()
+            .is_ok_and(|navigation| navigation.watchdog_is_current(generation))
     }
 
     fn start_watchdog(&self, app: AppHandle) {
-        let generation = self.inner.watch_generation.fetch_add(1, Ordering::SeqCst) + 1;
+        let generation = {
+            let Ok(mut navigation) = self.inner.navigation.lock() else {
+                return;
+            };
+            let Some(generation) = navigation.begin_watchdog() else {
+                return;
+            };
+            generation
+        };
         let state = self.clone();
         thread::spawn(move || loop {
             thread::sleep(CONNECTED_WATCH_INTERVAL);
-            if state.inner.watch_generation.load(Ordering::SeqCst) != generation {
+            if !state.watchdog_is_current(generation) {
                 return;
             }
             let Ok(_operation) = state.inner.operation.try_lock() else {
@@ -201,11 +324,16 @@ impl DesktopState {
             }
 
             let mut displayed_phase = snapshot.phase;
-            let _ = state.show_local(&app, local_mode(&snapshot));
+            if matches!(
+                state.show_local(&app, local_mode(&snapshot), false, Some(generation)),
+                Ok(false)
+            ) {
+                return;
+            }
             state.update_tray(&snapshot);
             drop(_operation);
             loop {
-                if state.inner.watch_generation.load(Ordering::SeqCst) != generation {
+                if !state.watchdog_is_current(generation) {
                     return;
                 }
                 if let Ok(_operation) = state.inner.operation.try_lock() {
@@ -216,14 +344,29 @@ impl DesktopState {
                     state.update_tray(&snapshot);
                     if snapshot.reachable {
                         if let Ok(ready) = gateway::dashboard(&cli, snapshot) {
-                            if state.navigate(&app, &ready.dashboard_url).is_ok() {
-                                state.update_tray(&ready.snapshot);
-                                break;
+                            match state.navigate_local(
+                                &app,
+                                &ready.dashboard_url,
+                                false,
+                                Some(generation),
+                                false,
+                            ) {
+                                Ok(true) => {
+                                    state.update_tray(&ready.snapshot);
+                                    break;
+                                }
+                                Ok(false) => return,
+                                Err(_) => {}
                             }
                         }
                     } else if snapshot.phase != displayed_phase {
                         displayed_phase = snapshot.phase;
-                        let _ = state.show_local(&app, local_mode(&snapshot));
+                        if matches!(
+                            state.show_local(&app, local_mode(&snapshot), false, Some(generation),),
+                            Ok(false)
+                        ) {
+                            return;
+                        }
                     }
                 }
                 thread::sleep(RECONNECT_INTERVAL);
@@ -237,6 +380,46 @@ fn local_mode(snapshot: &GatewaySnapshot) -> &'static str {
         "stopped"
     } else {
         "reconnecting"
+    }
+}
+
+#[cfg(test)]
+mod navigation_tests {
+    use super::NavigationState;
+
+    #[test]
+    fn newer_remote_selection_blocks_older_local_navigation() {
+        let mut navigation = NavigationState::default();
+        assert!(navigation.permit_local(false, None));
+
+        navigation.select_remote();
+
+        assert!(!navigation.permit_local(false, None));
+        assert!(navigation.remote_dashboard);
+    }
+
+    #[test]
+    fn newer_remote_selection_invalidates_watchdog_navigation() {
+        let mut navigation = NavigationState::default();
+        let watchdog = navigation.begin_watchdog().expect("watchdog generation");
+
+        navigation.select_remote();
+
+        assert!(!navigation.permit_local(false, Some(watchdog)));
+        assert!(!navigation.watchdog_is_current(watchdog));
+    }
+
+    #[test]
+    fn explicit_local_then_later_remote_preserves_latest_intent() {
+        let mut navigation = NavigationState::default();
+        navigation.select_remote();
+        assert!(navigation.permit_local(true, None));
+        assert!(!navigation.remote_dashboard);
+
+        navigation.select_remote();
+
+        assert!(!navigation.permit_local(false, None));
+        assert!(navigation.remote_dashboard);
     }
 }
 
@@ -291,6 +474,7 @@ fn main() {
             .expect("tauri.conf.json must define the main window");
         let state = DesktopState::new(window.url()?);
         app.manage(state.clone());
+        app.manage(discovery::GatewayDiscovery::default());
         #[cfg(target_os = "linux")]
         match canvas::CanvasBridge::start(app.handle().clone()) {
             Ok(bridge) => {
@@ -305,12 +489,16 @@ fn main() {
     let builder = builder.invoke_handler(tauri::generate_handler![
         bootstrap,
         canvas::canvas_a2ui_action,
+        discovery::connect_discovered_gateway,
+        discovery::discover_gateways,
         install_cli,
         gateway_action
     ]);
     #[cfg(not(target_os = "linux"))]
     let builder = builder.invoke_handler(tauri::generate_handler![
         bootstrap,
+        discovery::connect_discovered_gateway,
+        discovery::discover_gateways,
         install_cli,
         gateway_action
     ]);

--- a/apps/linux/src-tauri/src/tray.rs
+++ b/apps/linux/src-tauri/src/tray.rs
@@ -128,7 +128,7 @@ fn handle_menu(app: &AppHandle, state: &DesktopState, id: &str) {
 
 fn spawn_connect(app: AppHandle, state: DesktopState) {
     std::thread::spawn(move || {
-        if let Err(error) = state.connect(&app) {
+        if let Err(error) = state.connect_explicit_local(&app) {
             state.show_error(&app, &error);
         }
     });

--- a/apps/linux/src-tauri/tauri.conf.json
+++ b/apps/linux/src-tauri/tauri.conf.json
@@ -31,6 +31,8 @@
           "windows": ["main"],
           "permissions": [
             "allow-bootstrap",
+            "allow-connect-discovered-gateway",
+            "allow-discover-gateways",
             "allow-gateway-action",
             "allow-install-cli",
             "core:event:allow-listen",

--- a/apps/linux/ui/index.html
+++ b/apps/linux/ui/index.html
@@ -10,7 +10,7 @@
   <body>
     <main class="shell">
       <section class="brand" aria-label="OpenClaw">
-        <span class="brand-mark" aria-hidden="true"><i></i><i></i></span>
+        <img class="brand-mark" src="mascot.svg" alt="" aria-hidden="true" />
         <span>OPENCLAW</span>
       </section>
 
@@ -45,6 +45,16 @@
         <div id="action-controls" class="controls hidden">
           <button id="primary-action" class="primary">Try again</button>
         </div>
+
+        <section id="discovery" class="discovery" aria-labelledby="discovery-title">
+          <div class="discovery-head">
+            <span id="discovery-title">GATEWAYS ON THIS NETWORK</span>
+            <span id="discovery-status">SEARCHING</span>
+          </div>
+          <div id="gateway-list" class="gateway-list">
+            <p class="discovery-empty">Looking for nearby OpenClaw gateways…</p>
+          </div>
+        </section>
 
         <div id="log-wrap" class="log-wrap hidden">
           <div class="log-head">

--- a/apps/linux/ui/main.js
+++ b/apps/linux/ui/main.js
@@ -9,6 +9,8 @@ const elements = {
   channel: document.querySelector("#channel"),
   description: document.querySelector("#description"),
   eyebrow: document.querySelector("#eyebrow"),
+  gatewayList: document.querySelector("#gateway-list"),
+  discoveryStatus: document.querySelector("#discovery-status"),
   installButton: document.querySelector("#install-button"),
   installControls: document.querySelector("#install-controls"),
   installLog: document.querySelector("#install-log"),
@@ -20,6 +22,8 @@ const elements = {
 };
 
 let primaryAction = null;
+let discoveryPending = false;
+let discoverySignature = null;
 
 function show(element, visible) {
   element.classList.toggle("hidden", !visible);
@@ -62,6 +66,87 @@ function friendlyError(error) {
     return error;
   }
   return error?.message || "OpenClaw could not complete the operation.";
+}
+
+function gatewayHost(gateway) {
+  return (gateway.host || "").trim().replace(/\.$/, "");
+}
+
+function canConnectDirect(gateway) {
+  return (
+    gateway.tls ||
+    gateway.directReachable ||
+    gatewayHost(gateway).toLowerCase().endsWith(".ts.net")
+  );
+}
+
+function renderGateways(gateways) {
+  elements.gatewayList.replaceChildren();
+  elements.discoveryStatus.textContent = gateways.length ? `${gateways.length} FOUND` : "SEARCHING";
+  if (!gateways.length) {
+    const empty = document.createElement("p");
+    empty.className = "discovery-empty";
+    empty.textContent = "Looking for nearby OpenClaw gateways…";
+    elements.gatewayList.append(empty);
+    return;
+  }
+
+  for (const gateway of gateways) {
+    const button = document.createElement("button");
+    button.className = "gateway-card";
+    button.type = "button";
+    button.disabled = !canConnectDirect(gateway);
+    if (button.disabled) {
+      button.title = "This gateway does not advertise a direct connection.";
+    }
+
+    const copy = document.createElement("span");
+    copy.className = "gateway-copy";
+    const name = document.createElement("span");
+    name.className = "gateway-name";
+    name.textContent = gateway.name;
+    const endpoint = document.createElement("span");
+    endpoint.className = "gateway-endpoint";
+    endpoint.textContent = `${gatewayHost(gateway)}:${gateway.port}`;
+    copy.append(name, endpoint);
+
+    const badge = document.createElement("span");
+    badge.className = `gateway-badge${gateway.tls ? " secure" : ""}`;
+    badge.textContent = gateway.tls ? "TLS" : "HTTP";
+    button.append(copy, badge);
+    button.addEventListener("click", () => {
+      button.disabled = true;
+      void invoke("connect_discovered_gateway", {
+        host: gateway.host,
+        port: gateway.port,
+        tls: gateway.tls,
+      }).catch(() => {
+        button.disabled = false;
+        elements.discoveryStatus.textContent = "CONNECT FAILED";
+      });
+    });
+    elements.gatewayList.append(button);
+  }
+}
+
+async function refreshGateways() {
+  if (discoveryPending) {
+    return;
+  }
+  discoveryPending = true;
+  try {
+    const gateways = await invoke("discover_gateways");
+    const signature = JSON.stringify(gateways);
+    if (signature !== discoverySignature) {
+      discoverySignature = signature;
+      renderGateways(gateways);
+    }
+  } catch {
+    discoverySignature = null;
+    elements.discoveryStatus.textContent = "UNAVAILABLE";
+  } finally {
+    discoveryPending = false;
+  }
 }
 
 async function connect() {
@@ -154,6 +239,8 @@ elements.primaryAction.addEventListener("click", () => {
 });
 
 await listen("install-progress", ({ payload }) => appendLog(payload.line));
+void refreshGateways();
+window.setInterval(() => void refreshGateways(), 2000);
 
 const mode = new URLSearchParams(window.location.search).get("mode");
 if (mode === "reconnecting") {

--- a/apps/linux/ui/mascot.svg
+++ b/apps/linux/ui/mascot.svg
@@ -1,0 +1,54 @@
+<svg viewBox="0 0 120 120" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="lobster-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#ff4d4d"/>
+      <stop offset="100%" stop-color="#991b1b"/>
+    </linearGradient>
+  </defs>
+  <!-- SMIL, not CSS: Chromium/Safari only run declarative SMIL inside <img>-loaded
+       SVGs, and every app surface loads this file via <img src>. Mirrors the
+       openclaw.ai hero mascot keyframes (float 4s, wiggle 2s, blink 3s, snap 4s). -->
+  <g>
+    <animateTransform attributeName="transform" type="translate" additive="sum"
+      values="0 0; 0 -5; 0 0" keyTimes="0; 0.5; 1" dur="4s" repeatCount="indefinite"
+      calcMode="spline" keySplines="0.42 0 0.58 1; 0.42 0 0.58 1"/>
+    <!-- Body -->
+    <path d="M60 10 C30 10 15 35 15 55 C15 75 30 95 45 100 L45 110 L55 110 L55 100 C55 100 60 102 65 100 L65 110 L75 110 L75 100 C90 95 105 75 105 55 C105 35 90 10 60 10Z" fill="url(#lobster-gradient)"/>
+    <!-- Left Claw (hinges on its body-facing edge) -->
+    <path d="M20 45 C5 40 0 50 5 60 C10 70 20 65 25 55 C28 48 25 45 20 45Z" fill="url(#lobster-gradient)">
+      <animateTransform attributeName="transform" type="rotate"
+        values="0 26 53; 0 26 53; -8 26 53; 0 26 53; 0 26 53" keyTimes="0; 0.85; 0.9; 0.95; 1"
+        dur="4s" repeatCount="indefinite"
+        calcMode="spline" keySplines="0.42 0 0.58 1; 0.42 0 0.58 1; 0.42 0 0.58 1; 0.42 0 0.58 1"/>
+    </path>
+    <!-- Right Claw (snaps 0.2s after the left) -->
+    <path d="M100 45 C115 40 120 50 115 60 C110 70 100 65 95 55 C92 48 95 45 100 45Z" fill="url(#lobster-gradient)">
+      <animateTransform attributeName="transform" type="rotate"
+        values="0 94 53; 0 94 53; -8 94 53; 0 94 53; 0 94 53" keyTimes="0; 0.85; 0.9; 0.95; 1"
+        dur="4s" begin="0.2s" repeatCount="indefinite"
+        calcMode="spline" keySplines="0.42 0 0.58 1; 0.42 0 0.58 1; 0.42 0 0.58 1; 0.42 0 0.58 1"/>
+    </path>
+    <!-- Antenna -->
+    <path d="M45 15 Q35 5 30 8" stroke="#ff4d4d" stroke-width="3" stroke-linecap="round">
+      <animateTransform attributeName="transform" type="rotate"
+        values="0 37.5 11; -3 37.5 11; 3 37.5 11; 0 37.5 11" keyTimes="0; 0.25; 0.75; 1"
+        dur="2s" repeatCount="indefinite"
+        calcMode="spline" keySplines="0.42 0 0.58 1; 0.42 0 0.58 1; 0.42 0 0.58 1"/>
+    </path>
+    <path d="M75 15 Q85 5 90 8" stroke="#ff4d4d" stroke-width="3" stroke-linecap="round">
+      <animateTransform attributeName="transform" type="rotate"
+        values="0 82.5 11; -3 82.5 11; 3 82.5 11; 0 82.5 11" keyTimes="0; 0.25; 0.75; 1"
+        dur="2s" repeatCount="indefinite"
+        calcMode="spline" keySplines="0.42 0 0.58 1; 0.42 0 0.58 1; 0.42 0 0.58 1"/>
+    </path>
+    <!-- Eyes -->
+    <circle cx="45" cy="35" r="6" fill="#050810"/>
+    <circle cx="75" cy="35" r="6" fill="#050810"/>
+    <circle cx="46" cy="34" r="2.5" fill="#00e5cc">
+      <animate attributeName="opacity" values="1; 1; 0.3; 1" keyTimes="0; 0.9; 0.95; 1" dur="3s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="76" cy="34" r="2.5" fill="#00e5cc">
+      <animate attributeName="opacity" values="1; 1; 0.3; 1" keyTimes="0; 0.9; 0.95; 1" dur="3s" repeatCount="indefinite"/>
+    </circle>
+  </g>
+</svg>

--- a/apps/linux/ui/styles.css
+++ b/apps/linux/ui/styles.css
@@ -16,7 +16,7 @@ body {
   min-width: 320px;
   min-height: 100vh;
   margin: 0;
-  overflow: hidden;
+  overflow: auto;
   background:
     radial-gradient(circle at 50% -20%, rgb(255 92 92 / 12%), transparent 42%),
     #0e1015;
@@ -52,30 +52,10 @@ body::before {
 }
 
 .brand-mark {
-  position: relative;
   display: block;
-  width: 27px;
-  height: 24px;
-}
-
-.brand-mark i {
-  position: absolute;
-  bottom: 1px;
-  width: 15px;
-  height: 19px;
-  border: 3px solid #ff5c5c;
-  border-radius: 11px 11px 7px 7px;
-  box-shadow: 0 0 18px rgb(255 92 92 / 25%);
-}
-
-.brand-mark i:first-child {
-  left: 0;
-  transform: rotate(-20deg);
-}
-
-.brand-mark i:last-child {
-  right: 0;
-  transform: rotate(20deg);
+  width: 30px;
+  height: 30px;
+  filter: drop-shadow(0 0 18px rgb(255 92 92 / 25%));
 }
 
 .panel {
@@ -232,6 +212,97 @@ button.primary:hover:not(:disabled) {
   margin: 10px 0 0;
   color: #717686;
   font-size: 12px;
+}
+
+.discovery {
+  margin-top: 28px;
+  padding-top: 24px;
+  border-top: 1px solid #292d38;
+}
+
+.discovery-head {
+  display: flex;
+  justify-content: space-between;
+  color: #858a9a;
+  font-size: 10px;
+  font-weight: 720;
+  letter-spacing: 0.15em;
+}
+
+#discovery-status {
+  color: #ff7777;
+}
+
+.gateway-list {
+  display: grid;
+  gap: 8px;
+  max-height: 190px;
+  margin-top: 11px;
+  overflow: auto;
+}
+
+.gateway-card {
+  display: flex;
+  justify-content: space-between;
+  width: 100%;
+  padding: 11px 13px;
+  text-align: left;
+  background: #151820;
+}
+
+.gateway-card:disabled {
+  cursor: not-allowed;
+}
+
+.gateway-card:hover:not(:disabled) {
+  /* Rows live inside the overflow:auto list, so keep the border highlight but
+     drop the generic button lift — a 1px translate clips the top row's border. */
+  transform: none;
+}
+
+.gateway-copy {
+  display: grid;
+  gap: 3px;
+  min-width: 0;
+}
+
+.gateway-name,
+.gateway-endpoint {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.gateway-name {
+  color: #f6f7fb;
+  font-size: 13px;
+}
+
+.gateway-endpoint,
+.discovery-empty {
+  color: #858a9a;
+  font-size: 11px;
+}
+
+.gateway-badge {
+  align-self: center;
+  margin-left: 12px;
+  padding: 4px 7px;
+  border: 1px solid #3a3e4b;
+  border-radius: 999px;
+  color: #9ba0af;
+  font-size: 9px;
+  letter-spacing: 0.1em;
+}
+
+.gateway-badge.secure {
+  border-color: rgb(255 92 92 / 45%);
+  color: #ff8b8b;
+  background: rgb(255 92 92 / 8%);
+}
+
+.discovery-empty {
+  margin: 5px 0 0;
 }
 
 .log-wrap {

--- a/docs/platforms/linux.md
+++ b/docs/platforms/linux.md
@@ -19,6 +19,7 @@ The OpenClaw Linux companion is a Tauri desktop app for a local Gateway. It:
 - installs the OpenClaw CLI and managed Node runtime when they are missing
 - attaches to a healthy Gateway before attempting service changes
 - delegates install, start, stop, and restart operations to the CLI-managed systemd user service
+- discovers nearby Bonjour Gateways and opens their Control UI from the resolved service endpoint
 - opens the Gateway-served Control UI with its resolved authentication URL
 - renders agent-driven Canvas and bundled A2UI content for a colocated CLI node host
 - remains available from the system tray when its window is closed


### PR DESCRIPTION
## What Problem This Solves

The Linux desktop companion could only install the CLI and start a **local** gateway. If a gateway was already running elsewhere on the LAN (another Mac, a home server), there was no way to find and open it — you had to know and type its URL. The native macOS/iOS apps already discover gateways over Bonjour; the desktop app did not.

## Why This Change Was Made

- New `apps/linux/src-tauri/src/discovery.rs`: one lifetime `mdns-sd` browser for `_openclaw-gw._tcp.local.`, a fullname-keyed snapshot (resolved updates replace, goodbye/TTL removes), mirroring the gateway advertiser's TXT contract (`extensions/bonjour/src/advertiser.ts`) and the native clients' semantics.
- New `discover_gateways` / `connect_discovered_gateway` Tauri commands; the bootstrap page lists discovered gateways (name, resolved `host:port`, TLS/HTTP badge) and connecting navigates the dashboard WebView to the resolved endpoint. Local install stays the primary path.
- `mdns-sd` is a normal (cross-platform) dependency, so this rides on the macOS/Windows build enablement (#108004) — the same code compiles on all three.
- Navigation arbitration (`main.rs`): a single mutex governs local/remote/bootstrap/reconnect/watchdog navigation, re-checking remote intent and the watchdog generation **inside the lock** immediately before navigating, so a late local action or the reconnect watchdog cannot steal the WebView back after a remote selection; explicit Connect / tray "Open Dashboard" is the intent to return to local.

**Security** (mirrors the native clients — routing never trusts raw TXT): the dashboard URL is built only after strict DNS-label host validation (rejects `:`/`@`/`/`/userinfo), a live-snapshot tuple match, a direct-transport gate, and — for plaintext HTTP — a trusted host class (`.local`/`.ts.net`/loopback/RFC1918/CGNAT/link-local/ULA) **and** all-private resolved A/AAAA addresses. A hostile LAN advertiser pointing at a public host is rejected. Refs `apps/macos/.../GatewayDiscoveryHelpers.swift:47-63`, `GatewayRemoteConfig.swift:197-245`. mDNS instance names render via `textContent` (no XSS). A dead mDNS daemon/closed receiver triggers one bounded re-init on the next snapshot.

Also: the bootstrap header now uses the real Clawd mascot (`ui/public/favicon.svg`) instead of the abstract claw-mark placeholder, and the discovered-gateway row no longer clips its top border on hover (rows inside the `overflow:auto` list drop the generic button lift).

## User Impact

The desktop app's "Connecting" screen now shows a live "Gateways on this network" list; one click opens a discovered gateway's Control UI. No tokens, no persisted state, no new config keys. Headless and other-platform behavior is unchanged.

## Evidence

- macOS (arm64, local): `cargo build` + `cargo test` green (16 tests, incl. 3 hostile-record host-validation rejections and nav-ordering); `cargo fmt --check` clean.
- Linux (AWS Crabbox): `cargo build` + `cargo test` green (24 tests).
- **Live LAN test on this Mac:** a real `dns-sd` advertiser (`_openclaw-gw._tcp`, `Test Studio`, `steipete-mbp-4.local:18789`) was discovered and rendered in the list within seconds; the mascot header and non-clipping hover border were verified by screenshot.
- Adversarial autoreview (Codex gpt-5.6-sol xhigh) found 5 defects (1 security, 2 nav races, 2 robustness); all fixed and re-reviewed clean.
