### PR TITLE
refactor(status): privatize session cost line

### DIFF
--- a/scripts/deadcode-exports.baseline.mjs
+++ b/scripts/deadcode-exports.baseline.mjs
@@ -240,7 +240,6 @@ export const KNIP_UNUSED_EXPORT_BASELINE = [
   "src/skills/lifecycle/upload-store.ts: createSkillUploadStore",
   "src/skills/runtime/refresh.ts: resetSkillsRefreshForTest",
   "src/skills/runtime/remote-skills.ts: resetRemoteNodeSkillsForTests",
-  "src/status/status-runtime-lines.ts: resolveSessionCostLine",
   "src/system-agent/agent-turn.ts: runSystemAgentTurnWithDeps",
   "src/tasks/detached-task-runtime.ts: resetDetachedTaskLifecycleRuntimeForTests",
   "src/tasks/detached-task-runtime.ts: setDetachedTaskLifecycleRuntime",

--- a/src/status/status-runtime-lines.ts
+++ b/src/status/status-runtime-lines.ts
@@ -16,19 +16,12 @@ export function buildStatusUptimeLine(): string {
   return `⏱️ Uptime: gateway ${format(gatewayMs)} · system ${format(systemMs)}`;
 }
 
-export async function resolveSessionCostLine(
-  params: {
-    cfg: OpenClawConfig;
-    agentId: string;
-    sessionEntry?: SessionEntry;
-    storePath?: string;
-  },
-  deps: {
-    load?: typeof loadSessionCostSummariesFromCache;
-    now?: () => number;
-    timeoutMs?: number;
-  } = {},
-): Promise<string | undefined> {
+async function resolveSessionCostLine(params: {
+  cfg: OpenClawConfig;
+  agentId: string;
+  sessionEntry?: SessionEntry;
+  storePath?: string;
+}): Promise<string | undefined> {
   const sessionId = params.sessionEntry?.sessionId?.trim();
   if (!sessionId) {
     return undefined;
@@ -51,14 +44,13 @@ export async function resolveSessionCostLine(
   if (!sessionFile) {
     return undefined;
   }
-  const now = deps.now?.() ?? Date.now();
+  const now = Date.now();
   const date = new Date(now);
   const startMs = new Date(date.getFullYear(), date.getMonth(), date.getDate()).getTime();
-  const timeoutMs = deps.timeoutMs ?? 3_500;
   let timeout: NodeJS.Timeout | undefined;
   try {
     const loaded = await Promise.race([
-      (deps.load ?? loadSessionCostSummariesFromCache)({
+      loadSessionCostSummariesFromCache({
         sessions: [{ sessionId, sessionFile }],
         config: params.cfg,
         agentId: params.agentId,
@@ -68,7 +60,7 @@ export async function resolveSessionCostLine(
         requestRefresh: false,
       }),
       new Promise<never>((_, reject) => {
-        timeout = setTimeout(() => reject(new Error("session cost timeout")), timeoutMs);
+        timeout = setTimeout(() => reject(new Error("session cost timeout")), 3_500);
       }),
     ]).finally(() => {
       if (timeout) {

--- a/src/status/status-text.test.ts
+++ b/src/status/status-text.test.ts
@@ -1,7 +1,19 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { formatSqliteSessionFileMarker } from "../config/sessions/sqlite-marker.js";
-import { resolveSessionCostLine } from "./status-runtime-lines.js";
+import { appendSessionCostLine } from "./status-runtime-lines.js";
 import { buildStatusText } from "./status-text.js";
+
+const mocks = vi.hoisted(() => ({
+  loadSessionCostSummariesFromCache: vi.fn(),
+}));
+
+vi.mock("../infra/session-cost-usage.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../infra/session-cost-usage.js")>();
+  return {
+    ...actual,
+    loadSessionCostSummariesFromCache: mocks.loadSessionCostSummariesFromCache,
+  };
+});
 
 type StatusTextParams = Parameters<typeof buildStatusText>[0];
 
@@ -108,8 +120,12 @@ describe("session status cost line", () => {
     }),
   };
 
+  beforeEach(() => {
+    mocks.loadSessionCostSummariesFromCache.mockReset();
+  });
+
   it("shows cached current-session cost and tokens", async () => {
-    const load = async () => ({
+    mocks.loadSessionCostSummariesFromCache.mockResolvedValue({
       cacheStatus: {
         status: "fresh" as const,
         cachedFiles: 1,
@@ -133,96 +149,80 @@ describe("session status cost line", () => {
       ],
     });
 
-    await expect(
-      resolveSessionCostLine(
-        { cfg: {}, agentId: "main", sessionEntry },
-        { load, now: () => new Date(2026, 6, 14, 12).getTime() },
-      ),
-    ).resolves.toBe("💵 $1.23 · 456k tok (today)");
+    await expect(appendSessionCostLine(null, {}, "main", sessionEntry)).resolves.toBe(
+      "💵 $1.23 · 456k tok (today)",
+    );
   });
 
   it("omits a cold cost cache", async () => {
-    await expect(
-      resolveSessionCostLine(
-        { cfg: {}, agentId: "main", sessionEntry },
-        {
-          load: async () => ({
-            cacheStatus: {
-              status: "partial",
-              cachedFiles: 0,
-              pendingFiles: 1,
-              staleFiles: 0,
-            },
-            summaries: [null],
-          }),
-        },
-      ),
-    ).resolves.toBeUndefined();
+    mocks.loadSessionCostSummariesFromCache.mockResolvedValue({
+      cacheStatus: {
+        status: "partial",
+        cachedFiles: 0,
+        pendingFiles: 1,
+        staleFiles: 0,
+      },
+      summaries: [null],
+    });
+
+    await expect(appendSessionCostLine(null, {}, "main", sessionEntry)).resolves.toBeNull();
   });
 
   it("omits a stale cached summary", async () => {
-    await expect(
-      resolveSessionCostLine(
-        { cfg: {}, agentId: "main", sessionEntry },
+    mocks.loadSessionCostSummariesFromCache.mockResolvedValue({
+      cacheStatus: {
+        status: "stale",
+        cachedFiles: 0,
+        pendingFiles: 1,
+        staleFiles: 1,
+      },
+      summaries: [
         {
-          load: async () => ({
-            cacheStatus: {
-              status: "stale",
-              cachedFiles: 0,
-              pendingFiles: 1,
-              staleFiles: 1,
-            },
-            summaries: [
-              {
-                input: 1,
-                output: 1,
-                cacheRead: 0,
-                cacheWrite: 0,
-                totalTokens: 2,
-                totalCost: 1,
-                inputCost: 1,
-                outputCost: 0,
-                cacheReadCost: 0,
-                cacheWriteCost: 0,
-                missingCostEntries: 0,
-              },
-            ],
-          }),
+          input: 1,
+          output: 1,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 2,
+          totalCost: 1,
+          inputCost: 1,
+          outputCost: 0,
+          cacheReadCost: 0,
+          cacheWriteCost: 0,
+          missingCostEntries: 0,
         },
-      ),
-    ).resolves.toBeUndefined();
+      ],
+    });
+
+    await expect(appendSessionCostLine(null, {}, "main", sessionEntry)).resolves.toBeNull();
   });
 
   it("marks incomplete pricing", async () => {
-    await expect(
-      resolveSessionCostLine(
-        { cfg: {}, agentId: "main", sessionEntry },
+    mocks.loadSessionCostSummariesFromCache.mockResolvedValue({
+      cacheStatus: {
+        status: "fresh",
+        cachedFiles: 1,
+        pendingFiles: 0,
+        staleFiles: 0,
+      },
+      summaries: [
         {
-          load: async () => ({
-            cacheStatus: {
-              status: "fresh",
-              cachedFiles: 1,
-              pendingFiles: 0,
-              staleFiles: 0,
-            },
-            summaries: [
-              {
-                input: 400_000,
-                output: 56_000,
-                cacheRead: 0,
-                cacheWrite: 0,
-                totalTokens: 456_000,
-                totalCost: 1.23,
-                inputCost: 1,
-                outputCost: 0.23,
-                cacheReadCost: 0,
-                cacheWriteCost: 0,
-                missingCostEntries: 1,
-              },
-            ],
-          }),
+          input: 400_000,
+          output: 56_000,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 456_000,
+          totalCost: 1.23,
+          inputCost: 1,
+          outputCost: 0.23,
+          cacheReadCost: 0,
+          cacheWriteCost: 0,
+          missingCostEntries: 1,
         },
-      ),
-    ).resolves.toBe("💵 cost partial · 456k tok (today)");
+      ],
+    });
+
+    await expect(appendSessionCostLine(null, {}, "main", sessionEntry)).resolves.toBe(
+      "💵 cost partial · 456k tok (today)",
+    );
   });
 });


### PR DESCRIPTION
## Summary

- privatize the internal session-cost formatter
- remove its test-only dependency-injection parameters
- keep cache behavior covered through the production `appendSessionCostLine` boundary
- shrink the dead-export baseline from 252 to 251 with no additions or cascade

## Evidence

- final exact Testbox: https://github.com/openclaw/openclaw/actions/runs/29398091069 (byte-stable regeneration; 251/251)
- focused status suite: 9/9 green locally and on Testbox
- targeted format and type-aware lint green
- core types attempt blocked by an orphan Testbox heavy-check lock; no related diagnostic
- fresh autoreview clean at 0.97
- production source, excluding baseline: +9/-17 (net -8)
