### PR TITLE
refactor(cron): isolate creator tool caps

### DIFF
--- a/src/agents/tools/cron-tool-creator-cap.test.ts
+++ b/src/agents/tools/cron-tool-creator-cap.test.ts
@@ -1,9 +1,7 @@
 import { describe, expect, it } from "vitest";
-import {
-  capCronJobToolsAllowOnCreate,
-  type CronJobUpdatePatchPlan,
-  planCronJobUpdatePatch,
-} from "./cron-tool-creator-cap.js";
+import { capCronJobToolsAllowOnCreate, planCronJobUpdatePatch } from "./cron-tool-creator-cap.js";
+
+type CronJobUpdatePatchPlan = ReturnType<typeof planCronJobUpdatePatch>;
 
 function readReadyPatch(plan: CronJobUpdatePatchPlan): Record<string, unknown> {
   expect(plan.kind).toBe("ready");

--- a/src/agents/tools/cron-tool-creator-cap.test.ts
+++ b/src/agents/tools/cron-tool-creator-cap.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "vitest";
+import {
+  capCronJobToolsAllowOnCreate,
+  type CronJobUpdatePatchPlan,
+  planCronJobUpdatePatch,
+} from "./cron-tool-creator-cap.js";
+
+function readReadyPatch(plan: CronJobUpdatePatchPlan): Record<string, unknown> {
+  expect(plan.kind).toBe("ready");
+  if (plan.kind !== "ready") {
+    throw new Error("expected a ready cron update patch");
+  }
+  return plan.patch;
+}
+
+describe("cron tool creator cap", () => {
+  it("caps trigger-script creates without changing transport-only jobs", () => {
+    const triggerJob = {
+      trigger: { script: "return true" },
+      payload: { kind: "systemEvent", text: "wake" },
+    };
+    const plainJob = {
+      payload: { kind: "systemEvent", text: "wake" },
+    };
+
+    capCronJobToolsAllowOnCreate(triggerJob, ["read", "cron"]);
+    capCronJobToolsAllowOnCreate(plainJob, ["read", "cron"]);
+
+    expect(triggerJob.payload).toEqual({
+      kind: "systemEvent",
+      text: "wake",
+      toolsAllow: ["read", "cron"],
+      toolsAllowIsDefault: true,
+    });
+    expect(plainJob.payload).toEqual({ kind: "systemEvent", text: "wake" });
+  });
+
+  it("caps explicit updates without loading the current job", () => {
+    const input = {
+      payload: { kind: "agentTurn", toolsAllow: ["read", "exec"] },
+    };
+
+    const patch = readReadyPatch(
+      planCronJobUpdatePatch({
+        patch: input,
+        creatorToolAllowlist: ["read", "cron"],
+      }),
+    );
+
+    expect(patch).toEqual({
+      payload: { kind: "agentTurn", toolsAllow: ["read"] },
+    });
+    expect(input).toEqual({
+      payload: { kind: "agentTurn", toolsAllow: ["read", "exec"] },
+    });
+  });
+
+  it("requests current state before deriving an implicit cap", () => {
+    expect(
+      planCronJobUpdatePatch({
+        patch: { enabled: false },
+        creatorToolAllowlist: ["read", "cron"],
+      }),
+    ).toEqual({ kind: "needs-current-job" });
+  });
+
+  it("preserves explicit narrower caps and re-derives stored defaults", () => {
+    const narrower = readReadyPatch(
+      planCronJobUpdatePatch({
+        patch: { enabled: false },
+        creatorToolAllowlist: ["read", "exec", "cron"],
+        currentJob: {
+          payload: { kind: "agentTurn", message: "work", toolsAllow: ["read"] },
+        },
+      }),
+    );
+    const storedDefault = readReadyPatch(
+      planCronJobUpdatePatch({
+        patch: { enabled: false },
+        creatorToolAllowlist: ["read", "cron"],
+        currentJob: {
+          payload: {
+            kind: "agentTurn",
+            message: "work",
+            toolsAllow: ["read"],
+            toolsAllowIsDefault: true,
+          },
+        },
+      }),
+    );
+
+    expect(narrower).toEqual({
+      enabled: false,
+      payload: { kind: "agentTurn", toolsAllow: ["read"] },
+    });
+    expect(storedDefault).toEqual({
+      enabled: false,
+      payload: {
+        kind: "agentTurn",
+        toolsAllow: ["read", "cron"],
+        toolsAllowIsDefault: true,
+      },
+    });
+  });
+
+  it("inherits kind for kind-less patches independently of creator policy", () => {
+    const patch = { payload: { model: null } };
+    expect(
+      planCronJobUpdatePatch({
+        patch,
+        creatorToolAllowlist: undefined,
+      }),
+    ).toEqual({ kind: "needs-current-job" });
+
+    expect(
+      readReadyPatch(
+        planCronJobUpdatePatch({
+          patch,
+          creatorToolAllowlist: undefined,
+          currentJob: { payload: { kind: "agentTurn", message: "work" } },
+        }),
+      ),
+    ).toEqual({ payload: { kind: "agentTurn", model: null } });
+  });
+});

--- a/src/agents/tools/cron-tool-creator-cap.ts
+++ b/src/agents/tools/cron-tool-creator-cap.ts
@@ -13,7 +13,7 @@ type NormalizedCronCreatorTool = {
   pluginId?: string;
 };
 
-export type CronJobUpdatePatchPlan =
+type CronJobUpdatePatchPlan =
   | { kind: "ready"; patch: Record<string, unknown> }
   | { kind: "needs-current-job" };
 

--- a/src/agents/tools/cron-tool-creator-cap.ts
+++ b/src/agents/tools/cron-tool-creator-cap.ts
@@ -1,0 +1,192 @@
+import { isRecord } from "../../utils.js";
+import { isToolAllowedByPolicyName } from "../tool-policy-match.js";
+import {
+  buildPluginToolGroups,
+  expandPolicyWithPluginGroups,
+  expandToolGroups,
+  normalizeToolName,
+} from "../tool-policy.js";
+import type { CronCreatorToolAllowlistEntry } from "./cron-tool.types.js";
+
+type NormalizedCronCreatorTool = {
+  name: string;
+  pluginId?: string;
+};
+
+export type CronJobUpdatePatchPlan =
+  | { kind: "ready"; patch: Record<string, unknown> }
+  | { kind: "needs-current-job" };
+
+function normalizeCronToolsAllow(values: readonly string[]): string[] {
+  const normalized: string[] = [];
+  const seen = new Set<string>();
+  for (const entry of expandToolGroups([...values])) {
+    const toolName = normalizeToolName(entry);
+    if (!toolName || seen.has(toolName)) {
+      continue;
+    }
+    seen.add(toolName);
+    normalized.push(toolName);
+  }
+  return normalized;
+}
+
+function normalizeCronCreatorToolsAllow(
+  values: readonly CronCreatorToolAllowlistEntry[],
+): NormalizedCronCreatorTool[] {
+  const normalized: NormalizedCronCreatorTool[] = [];
+  const seen = new Set<string>();
+  for (const entry of values) {
+    const name = normalizeToolName(typeof entry === "string" ? entry : entry.name);
+    if (!name || seen.has(name)) {
+      continue;
+    }
+    seen.add(name);
+    const pluginId =
+      typeof entry === "string" || typeof entry.pluginId !== "string"
+        ? undefined
+        : normalizeToolName(entry.pluginId);
+    normalized.push(pluginId ? { name, pluginId } : { name });
+  }
+  return normalized;
+}
+
+function hasCronTriggerScript(value: unknown): boolean {
+  return isRecord(value) && typeof value.script === "string" && value.script.trim().length > 0;
+}
+
+function capCronJobToolsAllow(params: {
+  payload: Record<string, unknown>;
+  trigger?: unknown;
+  creatorToolAllowlist: readonly CronCreatorToolAllowlistEntry[];
+  defaultToolsAllow?: unknown;
+}): void {
+  const writesToolsAllow = Object.hasOwn(params.payload, "toolsAllow");
+  if (
+    params.payload.kind !== "agentTurn" &&
+    !hasCronTriggerScript(params.trigger) &&
+    !writesToolsAllow
+  ) {
+    return;
+  }
+
+  const creatorToolsAllow = normalizeCronCreatorToolsAllow(params.creatorToolAllowlist);
+  const creatorToolNames = creatorToolsAllow.map((tool) => tool.name);
+  const requestedRaw = Object.hasOwn(params.payload, "toolsAllow")
+    ? params.payload.toolsAllow
+    : params.defaultToolsAllow;
+  if (!Array.isArray(requestedRaw)) {
+    params.payload.toolsAllow = creatorToolNames;
+    params.payload.toolsAllowIsDefault = true;
+    return;
+  }
+
+  const requestedToolsAllow = normalizeCronToolsAllow(
+    requestedRaw.filter((entry): entry is string => typeof entry === "string"),
+  );
+  if (requestedToolsAllow.length === 0) {
+    params.payload.toolsAllow = [];
+    delete params.payload.toolsAllowIsDefault;
+    return;
+  }
+  if (requestedToolsAllow.includes("*")) {
+    params.payload.toolsAllow = creatorToolNames;
+    params.payload.toolsAllowIsDefault = true;
+    return;
+  }
+
+  const pluginGroups = buildPluginToolGroups({
+    tools: creatorToolsAllow,
+    toolMeta: (tool) => (tool.pluginId ? { pluginId: tool.pluginId } : undefined),
+  });
+  const requestedPolicy = expandPolicyWithPluginGroups(
+    { allow: requestedToolsAllow },
+    pluginGroups,
+  );
+  params.payload.toolsAllow = creatorToolNames.filter((toolName) =>
+    isToolAllowedByPolicyName(toolName, requestedPolicy),
+  );
+  delete params.payload.toolsAllowIsDefault;
+}
+
+export function capCronJobToolsAllowOnCreate(
+  value: unknown,
+  creatorToolAllowlist: readonly CronCreatorToolAllowlistEntry[] | undefined,
+): void {
+  if (!creatorToolAllowlist || !isRecord(value) || !isRecord(value.payload)) {
+    return;
+  }
+  capCronJobToolsAllow({
+    payload: value.payload,
+    trigger: value.trigger,
+    creatorToolAllowlist,
+  });
+}
+
+function readCronPayloadKind(value: unknown): string | undefined {
+  return isRecord(value) && typeof value.kind === "string" ? value.kind : undefined;
+}
+
+/** Purely derives the agent-tool patch; current job state is requested only when required. */
+export function planCronJobUpdatePatch(params: {
+  patch: Record<string, unknown>;
+  creatorToolAllowlist: readonly CronCreatorToolAllowlistEntry[] | undefined;
+  currentJob?: Record<string, unknown>;
+}): CronJobUpdatePatchPlan {
+  const patch = structuredClone(params.patch);
+  const payload = isRecord(patch.payload) ? patch.payload : undefined;
+  const explicitPayloadKind = readCronPayloadKind(payload);
+  if (
+    params.creatorToolAllowlist &&
+    explicitPayloadKind !== undefined &&
+    payload &&
+    Object.hasOwn(payload, "toolsAllow")
+  ) {
+    capCronJobToolsAllow({
+      payload,
+      trigger: patch.trigger,
+      creatorToolAllowlist: params.creatorToolAllowlist,
+    });
+    return { kind: "ready", patch };
+  }
+
+  const needsStoredPayloadKind = payload !== undefined && explicitPayloadKind === undefined;
+  if (!needsStoredPayloadKind && !params.creatorToolAllowlist) {
+    return { kind: "ready", patch };
+  }
+  if (!params.currentJob) {
+    return { kind: "needs-current-job" };
+  }
+
+  const existingPayload = params.currentJob.payload;
+  const payloadKind = explicitPayloadKind ?? readCronPayloadKind(existingPayload);
+  if (payload && payloadKind !== undefined) {
+    payload.kind = payloadKind;
+    patch.payload = payload;
+  }
+  if (!params.creatorToolAllowlist) {
+    return { kind: "ready", patch };
+  }
+
+  const trigger = Object.hasOwn(patch, "trigger") ? patch.trigger : params.currentJob.trigger;
+  const writesToolsAllow = payload !== undefined && Object.hasOwn(payload, "toolsAllow");
+  if (payloadKind !== "agentTurn" && !hasCronTriggerScript(trigger) && !writesToolsAllow) {
+    return { kind: "ready", patch };
+  }
+
+  const nextPayload: Record<string, unknown> = payload ?? {};
+  if (payloadKind !== undefined) {
+    nextPayload.kind = payloadKind;
+  }
+  patch.payload = nextPayload;
+  capCronJobToolsAllow({
+    payload: nextPayload,
+    trigger,
+    creatorToolAllowlist: params.creatorToolAllowlist,
+    defaultToolsAllow:
+      isRecord(existingPayload) && existingPayload.toolsAllowIsDefault !== true
+        ? existingPayload.toolsAllow
+        : undefined,
+  });
+  return { kind: "ready", patch };
+}

--- a/src/agents/tools/cron-tool-write.ts
+++ b/src/agents/tools/cron-tool-write.ts
@@ -1,0 +1,101 @@
+// Agent cron-tool write safety and optimistic update orchestration.
+import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
+import { isRecord } from "../../utils.js";
+import { planCronJobUpdatePatch } from "./cron-tool-creator-cap.js";
+import type { CronCreatorToolAllowlistEntry, GatewayToolCaller } from "./cron-tool.types.js";
+import type { GatewayCallOptions } from "./gateway.js";
+
+export function assertNoCronShellExecution(value: unknown): void {
+  if (!isRecord(value)) {
+    return;
+  }
+  const payload = isRecord(value.payload) ? value.payload : undefined;
+  if (normalizeLowercaseStringOrEmpty(payload?.kind) === "command") {
+    throw new Error(
+      "cron command payloads cannot be created or edited through the agent cron tool; use the CLI or Gateway API.",
+    );
+  }
+  const schedule = isRecord(value.schedule) ? value.schedule : undefined;
+  if (schedule?.kind === "on-exit") {
+    throw new Error(
+      "cron on-exit schedules cannot be created or edited through the agent cron tool; use the CLI or Gateway API.",
+    );
+  }
+}
+
+async function prepareCronJobUpdateForGateway(params: {
+  id: string;
+  patch: Record<string, unknown>;
+  creatorToolAllowlist: readonly CronCreatorToolAllowlistEntry[] | undefined;
+  gatewayOpts: GatewayCallOptions;
+  callGateway: GatewayToolCaller;
+}): Promise<{ patch: Record<string, unknown>; expectedConfigRevision?: string }> {
+  const initialPlan = planCronJobUpdatePatch({
+    patch: params.patch,
+    creatorToolAllowlist: params.creatorToolAllowlist,
+  });
+  if (initialPlan.kind === "ready") {
+    return { patch: initialPlan.patch };
+  }
+
+  const existing = await params.callGateway("cron.get", params.gatewayOpts, { id: params.id });
+  const existingRecord = isRecord(existing) ? existing : undefined;
+  const expectedConfigRevision = existingRecord?.configRevision;
+  if (typeof expectedConfigRevision !== "string" || expectedConfigRevision.length === 0) {
+    throw new Error(
+      "cron.get response is missing configRevision; restart the Gateway before retrying this update",
+    );
+  }
+  const finalPlan = planCronJobUpdatePatch({
+    patch: params.patch,
+    creatorToolAllowlist: params.creatorToolAllowlist,
+    currentJob: existingRecord,
+  });
+  if (finalPlan.kind !== "ready") {
+    throw new Error("cron update patch planning did not use the loaded job");
+  }
+  return { patch: finalPlan.patch, expectedConfigRevision };
+}
+
+function isCronJobConfigRevisionConflict(error: unknown): boolean {
+  if (!(error instanceof Error) || error.name !== "GatewayClientRequestError") {
+    return false;
+  }
+  const details = isRecord((error as Error & { details?: unknown }).details)
+    ? (error as Error & { details: Record<string, unknown> }).details
+    : undefined;
+  return details?.code === "CRON_JOB_CHANGED";
+}
+
+export async function updateCronJobFromAgentTool(params: {
+  id: string;
+  patch: Record<string, unknown>;
+  creatorToolAllowlist: readonly CronCreatorToolAllowlistEntry[] | undefined;
+  gatewayOpts: GatewayCallOptions;
+  callGateway: GatewayToolCaller;
+}): Promise<unknown> {
+  const callerIncludedPayloadPatch = isRecord(params.patch.payload);
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    const prepared = await prepareCronJobUpdateForGateway(params);
+    if (callerIncludedPayloadPatch) {
+      // Kind-less caller payloads inherit the stored kind above. Recheck those
+      // edits, but not a toolsAllow cap synthesized internally.
+      assertNoCronShellExecution(prepared.patch);
+    }
+    try {
+      return await params.callGateway("cron.update", params.gatewayOpts, {
+        id: params.id,
+        patch: prepared.patch,
+        ...(prepared.expectedConfigRevision
+          ? { expectedConfigRevision: prepared.expectedConfigRevision }
+          : {}),
+      });
+    } catch (error) {
+      if (attempt === 0 && isCronJobConfigRevisionConflict(error)) {
+        continue;
+      }
+      throw error;
+    }
+  }
+  throw new Error("cron update retry exhausted");
+}

--- a/src/agents/tools/cron-tool.test.ts
+++ b/src/agents/tools/cron-tool.test.ts
@@ -2819,23 +2819,24 @@ describe("cron tool", () => {
   });
 
   it("retries cap derivation after a concurrent cron job update", async () => {
+    const conflict = Object.assign(
+      new Error("cron job definition no longer matches the loaded version"),
+      {
+        name: "GatewayClientRequestError",
+        details: {
+          code: "CRON_JOB_CHANGED",
+          expectedConfigRevision: "sha256:first",
+          actualConfigRevision: "sha256:second",
+        },
+      },
+    );
     callGatewayMock
       .mockResolvedValueOnce({
         id: "job-race",
         configRevision: "sha256:first",
         payload: { kind: "agentTurn", message: "hello", toolsAllow: ["read"] },
       })
-      .mockRejectedValueOnce(
-        new GatewayClientRequestError({
-          code: "INVALID_REQUEST",
-          message: "cron job definition no longer matches the loaded version",
-          details: {
-            code: "CRON_JOB_CHANGED",
-            expectedConfigRevision: "sha256:first",
-            actualConfigRevision: "sha256:second",
-          },
-        }),
-      )
+      .mockRejectedValueOnce(conflict)
       .mockResolvedValueOnce({
         id: "job-race",
         configRevision: "sha256:second",

--- a/src/agents/tools/cron-tool.ts
+++ b/src/agents/tools/cron-tool.ts
@@ -25,13 +25,7 @@ import {
   stringEnum,
 } from "../schema/typebox.js";
 import { CRON_TOOL_DISPLAY_SUMMARY } from "../tool-description-presets.js";
-import { isToolAllowedByPolicyName } from "../tool-policy-match.js";
-import {
-  buildPluginToolGroups,
-  expandPolicyWithPluginGroups,
-  expandToolGroups,
-  normalizeToolName,
-} from "../tool-policy.js";
+import { normalizeToolName } from "../tool-policy.js";
 import { setToolTerminalPresentation } from "../tool-terminal-presentation.js";
 import {
   type AnyAgentTool,
@@ -45,6 +39,8 @@ import {
   isEmptyRecoveredCronPatch,
   recoverCronObjectFromFlatParams,
 } from "./cron-tool-canonicalize.js";
+import { capCronJobToolsAllowOnCreate } from "./cron-tool-creator-cap.js";
+import { assertNoCronShellExecution, updateCronJobFromAgentTool } from "./cron-tool-write.js";
 import type {
   ChatMessage,
   CronCreatorToolAllowlistEntry,
@@ -52,7 +48,6 @@ import type {
   CronToolDeps,
   CronToolOptions,
   GatewayToolCaller,
-  NormalizedCronCreatorTool,
 } from "./cron-tool.types.js";
 import { withGatewayToolCallerIdentity } from "./gateway-caller-context.js";
 import { gatewayCallOptionSchemaProperties } from "./gateway-schema.js";
@@ -418,217 +413,6 @@ function stripExistingContext(text: string) {
     return text;
   }
   return text.slice(0, index).trim();
-}
-
-function assertNoCronShellExecution(value: unknown): void {
-  if (!isRecord(value)) {
-    return;
-  }
-  const payload = isRecord(value.payload) ? value.payload : undefined;
-  if (normalizeLowercaseStringOrEmpty(payload?.kind) === "command") {
-    throw new Error(
-      "cron command payloads cannot be created or edited through the agent cron tool; use the CLI or Gateway API.",
-    );
-  }
-  const schedule = isRecord(value.schedule) ? value.schedule : undefined;
-  if (schedule?.kind === "on-exit") {
-    throw new Error(
-      "cron on-exit schedules cannot be created or edited through the agent cron tool; use the CLI or Gateway API.",
-    );
-  }
-}
-
-function normalizeCronToolsAllow(values: readonly string[]): string[] {
-  const normalized: string[] = [];
-  const seen = new Set<string>();
-  for (const entry of expandToolGroups([...values])) {
-    const toolName = normalizeToolName(entry);
-    if (!toolName || seen.has(toolName)) {
-      continue;
-    }
-    seen.add(toolName);
-    normalized.push(toolName);
-  }
-  return normalized;
-}
-
-function normalizeCronCreatorToolsAllow(
-  values: readonly CronCreatorToolAllowlistEntry[],
-): NormalizedCronCreatorTool[] {
-  const normalized: NormalizedCronCreatorTool[] = [];
-  const seen = new Set<string>();
-  for (const entry of values) {
-    const name = normalizeToolName(typeof entry === "string" ? entry : entry.name);
-    if (!name || seen.has(name)) {
-      continue;
-    }
-    seen.add(name);
-    const pluginId =
-      typeof entry === "string" || typeof entry.pluginId !== "string"
-        ? undefined
-        : normalizeToolName(entry.pluginId);
-    normalized.push(pluginId ? { name, pluginId } : { name });
-  }
-  return normalized;
-}
-
-function cronCreatorToolNames(tools: readonly NormalizedCronCreatorTool[]): string[] {
-  return tools.map((tool) => tool.name);
-}
-
-function hasCronTriggerScript(value: unknown): boolean {
-  return isRecord(value) && typeof value.script === "string" && value.script.trim().length > 0;
-}
-
-function capCronJobToolsAllow(params: {
-  payload: Record<string, unknown>;
-  trigger?: unknown;
-  creatorToolAllowlist: CronCreatorToolAllowlistEntry[];
-  defaultToolsAllow?: unknown;
-}): void {
-  const writesToolsAllow = Object.hasOwn(params.payload, "toolsAllow");
-  if (
-    params.payload.kind !== "agentTurn" &&
-    !hasCronTriggerScript(params.trigger) &&
-    !writesToolsAllow
-  ) {
-    return;
-  }
-  const creatorToolsAllow = normalizeCronCreatorToolsAllow(params.creatorToolAllowlist);
-  const creatorToolNames = cronCreatorToolNames(creatorToolsAllow);
-  const requestedRaw = Object.hasOwn(params.payload, "toolsAllow")
-    ? params.payload.toolsAllow
-    : params.defaultToolsAllow;
-  if (!Array.isArray(requestedRaw)) {
-    params.payload.toolsAllow = creatorToolNames;
-    params.payload.toolsAllowIsDefault = true;
-    return;
-  }
-  const requestedToolsAllow = normalizeCronToolsAllow(
-    requestedRaw.filter((entry): entry is string => typeof entry === "string"),
-  );
-  if (requestedToolsAllow.length === 0) {
-    params.payload.toolsAllow = [];
-    delete params.payload.toolsAllowIsDefault;
-    return;
-  }
-  if (requestedToolsAllow.includes("*")) {
-    params.payload.toolsAllow = creatorToolNames;
-    params.payload.toolsAllowIsDefault = true;
-    return;
-  }
-  const pluginGroups = buildPluginToolGroups({
-    tools: creatorToolsAllow,
-    toolMeta: (tool) => (tool.pluginId ? { pluginId: tool.pluginId } : undefined),
-  });
-  const requestedPolicy = expandPolicyWithPluginGroups(
-    { allow: requestedToolsAllow },
-    pluginGroups,
-  );
-  params.payload.toolsAllow = creatorToolNames.filter((toolName) =>
-    isToolAllowedByPolicyName(toolName, requestedPolicy),
-  );
-  delete params.payload.toolsAllowIsDefault;
-}
-
-function capCronJobToolsAllowOnCreate(
-  value: unknown,
-  creatorToolAllowlist: CronCreatorToolAllowlistEntry[] | undefined,
-): void {
-  if (!creatorToolAllowlist || !isRecord(value) || !isRecord(value.payload)) {
-    return;
-  }
-  capCronJobToolsAllow({
-    payload: value.payload,
-    trigger: value.trigger,
-    creatorToolAllowlist,
-  });
-}
-
-function readCronPayloadKind(value: unknown): string | undefined {
-  if (!isRecord(value)) {
-    return undefined;
-  }
-  return typeof value.kind === "string" ? value.kind : undefined;
-}
-
-async function prepareCronJobUpdatePatch(params: {
-  id: string;
-  patch: Record<string, unknown>;
-  creatorToolAllowlist: CronCreatorToolAllowlistEntry[] | undefined;
-  gatewayOpts: GatewayCallOptions;
-  callGateway: GatewayToolCaller;
-}): Promise<string | undefined> {
-  const payload = isRecord(params.patch.payload) ? params.patch.payload : undefined;
-  const explicitPayloadKind = readCronPayloadKind(payload);
-  if (
-    params.creatorToolAllowlist &&
-    explicitPayloadKind !== undefined &&
-    payload &&
-    Object.hasOwn(payload, "toolsAllow")
-  ) {
-    capCronJobToolsAllow({
-      payload,
-      trigger: params.patch.trigger,
-      creatorToolAllowlist: params.creatorToolAllowlist,
-    });
-    return undefined;
-  }
-  const needsStoredPayloadKind = payload !== undefined && explicitPayloadKind === undefined;
-  if (!needsStoredPayloadKind && !params.creatorToolAllowlist) {
-    return undefined;
-  }
-  const existing = await params.callGateway("cron.get", params.gatewayOpts, {
-    id: params.id,
-  });
-  const existingRecord = isRecord(existing) ? existing : undefined;
-  const expectedConfigRevision = existingRecord?.configRevision;
-  if (typeof expectedConfigRevision !== "string" || expectedConfigRevision.length === 0) {
-    throw new Error(
-      "cron.get response is missing configRevision; restart the Gateway before retrying this update",
-    );
-  }
-  const existingPayload = existingRecord?.payload;
-  const existingPayloadKind = readCronPayloadKind(existingPayload);
-  const payloadKind = explicitPayloadKind ?? existingPayloadKind;
-  if (payload && payloadKind !== undefined) {
-    payload.kind = payloadKind;
-    params.patch.payload = payload;
-  }
-  if (!params.creatorToolAllowlist) {
-    return expectedConfigRevision;
-  }
-  const patchIncludesTrigger = Object.hasOwn(params.patch, "trigger");
-  const trigger = patchIncludesTrigger ? params.patch.trigger : existingRecord?.trigger;
-  const writesToolsAllow = payload !== undefined && Object.hasOwn(payload, "toolsAllow");
-  if (payloadKind !== "agentTurn" && !hasCronTriggerScript(trigger) && !writesToolsAllow) {
-    return expectedConfigRevision;
-  }
-  const nextPayload: Record<string, unknown> = payload ?? {};
-  if (payloadKind !== undefined) {
-    nextPayload.kind = payloadKind;
-  }
-  params.patch.payload = nextPayload;
-  capCronJobToolsAllow({
-    payload: nextPayload,
-    trigger,
-    creatorToolAllowlist: params.creatorToolAllowlist,
-    defaultToolsAllow:
-      isRecord(existingPayload) && existingPayload.toolsAllowIsDefault !== true
-        ? existingPayload.toolsAllow
-        : undefined,
-  });
-  return expectedConfigRevision;
-}
-
-function isCronJobConfigRevisionConflict(error: unknown): boolean {
-  if (!(error instanceof Error) || error.name !== "GatewayClientRequestError") {
-    return false;
-  }
-  const details = isRecord((error as Error & { details?: unknown }).details)
-    ? (error as Error & { details: Record<string, unknown> }).details
-    : undefined;
-  return details?.code === "CRON_JOB_CHANGED";
 }
 
 function truncateText(input: string, maxLen: number) {
@@ -1204,37 +988,15 @@ Restricted isolated runs may only self status/list, current get/runs, and remove
             if (callerScope) {
               assertCronToolSessionRefsMatchScope(patch, callerScope);
             }
-            const callerIncludedPayloadPatch = isRecord(patch.payload);
-            for (let attempt = 0; attempt < 2; attempt += 1) {
-              const preparedPatch = structuredClone(patch);
-              const expectedConfigRevision = await prepareCronJobUpdatePatch({
+            return jsonResult(
+              await updateCronJobFromAgentTool({
                 id,
-                patch: preparedPatch,
+                patch,
                 creatorToolAllowlist: opts?.creatorToolAllowlist,
                 gatewayOpts,
                 callGateway,
-              });
-              if (callerIncludedPayloadPatch) {
-                // Kind-less caller payloads inherit the stored kind above. Recheck
-                // those edits, but not a toolsAllow cap synthesized internally.
-                assertNoCronShellExecution(preparedPatch);
-              }
-              try {
-                return jsonResult(
-                  await callGateway("cron.update", gatewayOpts, {
-                    id,
-                    patch: preparedPatch,
-                    ...(expectedConfigRevision ? { expectedConfigRevision } : {}),
-                  }),
-                );
-              } catch (error) {
-                if (attempt === 0 && isCronJobConfigRevisionConflict(error)) {
-                  continue;
-                }
-                throw error;
-              }
-            }
-            throw new Error("cron update retry exhausted");
+              }),
+            );
           }
           case "remove": {
             const id = readCronJobIdParam(params);

--- a/src/agents/tools/cron-tool.types.ts
+++ b/src/agents/tools/cron-tool.types.ts
@@ -9,11 +9,6 @@ export type CronCreatorToolAllowlistEntry =
       pluginId?: string;
     };
 
-export type NormalizedCronCreatorTool = {
-  name: string;
-  pluginId?: string;
-};
-
 export type CronToolOptions = {
   agentSessionKey?: string;
   currentDeliveryContext?: DeliveryContext;

--- a/src/cron/store/payload-codec.ts
+++ b/src/cron/store/payload-codec.ts
@@ -10,6 +10,35 @@ import {
 } from "./scalar-codec.js";
 import type { CronJobInsert, CronJobRow } from "./schema.js";
 
+type CronPayloadToolAllow = Pick<CronPayload, "toolsAllow" | "toolsAllowIsDefault">;
+type CronPayloadToolAllowColumns = Pick<
+  CronJobInsert,
+  "payload_tools_allow_json" | "payload_tools_allow_is_default"
+>;
+
+function bindPayloadToolAllowColumns(payload: CronPayloadToolAllow): CronPayloadToolAllowColumns {
+  return {
+    payload_tools_allow_json: serializeJson(payload.toolsAllow),
+    payload_tools_allow_is_default: payload.toolsAllow
+      ? booleanToInteger(payload.toolsAllowIsDefault)
+      : null,
+  };
+}
+
+function payloadToolAllowFromRow(
+  row: Pick<CronJobRow, "payload_tools_allow_json" | "payload_tools_allow_is_default">,
+): CronPayloadToolAllow {
+  const toolsAllow = parseJsonArray(row.payload_tools_allow_json);
+  if (!toolsAllow) {
+    return {};
+  }
+  const toolsAllowIsDefault = integerToBoolean(row.payload_tools_allow_is_default);
+  return {
+    toolsAllow,
+    ...(toolsAllowIsDefault ? { toolsAllowIsDefault: true } : {}),
+  };
+}
+
 function parseExternalContentSource(raw: string | null): "gmail" | "webhook" | undefined {
   const parsed = raw ? parseJsonValue<unknown>(raw, undefined) : undefined;
   return parsed === "gmail" || parsed === "webhook" ? parsed : undefined;
@@ -88,10 +117,7 @@ export function bindPayloadColumns(
       payload_allow_unsafe_external_content: null,
       payload_external_content_source_json: null,
       payload_light_context: null,
-      payload_tools_allow_json: serializeJson(payload.toolsAllow),
-      payload_tools_allow_is_default: payload.toolsAllow
-        ? booleanToInteger(payload.toolsAllowIsDefault)
-        : null,
+      ...bindPayloadToolAllowColumns(payload),
     };
   }
   if (payload.kind === "command") {
@@ -111,10 +137,7 @@ export function bindPayloadColumns(
       payload_allow_unsafe_external_content: null,
       payload_external_content_source_json: null,
       payload_light_context: null,
-      payload_tools_allow_json: serializeJson(payload.toolsAllow),
-      payload_tools_allow_is_default: payload.toolsAllow
-        ? booleanToInteger(payload.toolsAllowIsDefault)
-        : null,
+      ...bindPayloadToolAllowColumns(payload),
     };
   }
   return {
@@ -127,10 +150,7 @@ export function bindPayloadColumns(
     payload_allow_unsafe_external_content: booleanToInteger(payload.allowUnsafeExternalContent),
     payload_external_content_source_json: serializeJson(payload.externalContentSource),
     payload_light_context: booleanToInteger(payload.lightContext),
-    payload_tools_allow_json: serializeJson(payload.toolsAllow),
-    payload_tools_allow_is_default: payload.toolsAllow
-      ? booleanToInteger(payload.toolsAllowIsDefault)
-      : null,
+    ...bindPayloadToolAllowColumns(payload),
   };
 }
 
@@ -140,16 +160,10 @@ export function payloadFromRow(row: CronJobRow): CronPayload | null {
     if (row.payload_message == null) {
       return null;
     }
-    const toolsAllow = parseJsonArray(row.payload_tools_allow_json);
-    const toolsAllowIsDefault =
-      row.payload_tools_allow_is_default != null
-        ? integerToBoolean(row.payload_tools_allow_is_default)
-        : undefined;
     return {
       kind: "systemEvent",
       text: row.payload_message,
-      ...(toolsAllow ? { toolsAllow } : {}),
-      ...(toolsAllow && toolsAllowIsDefault ? { toolsAllowIsDefault: true } : {}),
+      ...payloadToolAllowFromRow(row),
     };
   }
   if (row.payload_kind === "agentTurn") {
@@ -169,13 +183,6 @@ export function payloadFromRow(row: CronJobRow): CronPayload | null {
     );
     const lightContext =
       row.payload_light_context != null ? integerToBoolean(row.payload_light_context) : undefined;
-    const toolsAllow = row.payload_tools_allow_json
-      ? parseJsonArray(row.payload_tools_allow_json)
-      : undefined;
-    const toolsAllowIsDefault =
-      row.payload_tools_allow_is_default != null
-        ? integerToBoolean(row.payload_tools_allow_is_default)
-        : undefined;
     return {
       kind: "agentTurn",
       message: row.payload_message,
@@ -186,8 +193,7 @@ export function payloadFromRow(row: CronJobRow): CronPayload | null {
       ...(allowUnsafeExternalContent != null ? { allowUnsafeExternalContent } : {}),
       ...(externalContentSource ? { externalContentSource } : {}),
       ...(lightContext != null ? { lightContext } : {}),
-      ...(toolsAllow ? { toolsAllow } : {}),
-      ...(toolsAllow && toolsAllowIsDefault ? { toolsAllowIsDefault: true } : {}),
+      ...payloadToolAllowFromRow(row),
     };
   }
   if (row.payload_kind === "command") {
@@ -196,17 +202,11 @@ export function payloadFromRow(row: CronJobRow): CronPayload | null {
       return null;
     }
     const timeoutSeconds = normalizeNumber(row.payload_timeout_seconds);
-    const toolsAllow = parseJsonArray(row.payload_tools_allow_json);
-    const toolsAllowIsDefault =
-      row.payload_tools_allow_is_default != null
-        ? integerToBoolean(row.payload_tools_allow_is_default)
-        : undefined;
     return {
       kind: "command",
       ...command,
       ...(timeoutSeconds != null ? { timeoutSeconds } : {}),
-      ...(toolsAllow ? { toolsAllow } : {}),
-      ...(toolsAllow && toolsAllowIsDefault ? { toolsAllowIsDefault: true } : {}),
+      ...payloadToolAllowFromRow(row),
     };
   }
   return null;


### PR DESCRIPTION
Related: #104430

AI-assisted maintainer refactor.

## What Problem This Solves

The cron agent tool's creator-cap policy, gateway write orchestration, and SQLite payload codec were interleaved in one large module after the original safety fix. That made the policy harder to review in isolation and left duplicated persistence mapping for `toolsAllow` fields.

## Why This Change Was Made

Extract the pure creator-cap planner and the gateway write/retry boundary into focused modules, then share the SQLite bind/read helpers for creator-cap fields. The runtime policy and two-attempt optimistic config-revision retry remain unchanged; structural gateway errors remain supported for injected and wrapped callers.

## User Impact

No user-visible behavior change. Maintainers get one canonical policy path, direct planner tests, and a smaller cron tool module.

## Evidence

- Focused Blacksmith Testbox run: 212/212 tests passed across creator-cap, cron tool, and cron store suites: https://github.com/openclaw/openclaw/actions/runs/29398232462
- Changed gate passed format, production/test tsgo, lint, plugin SDK baseline, and repository guards: https://github.com/openclaw/openclaw/actions/runs/29397731599
- Final Testbox proof passed core, extension, script, and root test types; dead-code dependency, unused-file, and unused-export checks; and the focused planner suite: https://github.com/openclaw/openclaw/actions/runs/29400004406
- `oxfmt --check` and `git diff --check` passed.
- Mandatory whole-branch autoreview passed after addressing all findings.
