### PR TITLE
fix: clear stale task and OAuth doctor warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Doctor TaskFlow and OAuth repairs:** ignore retained terminal blocked TaskFlows after their child records expire, and force accepted OAuth refresh repairs so expiring credentials actually rotate. Fixes #108097 and #108098.
 - **Mattermost progress command details:** accept the documented `streaming.preview.commandText` and `streaming.progress.commandText` modes in channel config validation and bundled metadata. Thanks @shakkernerd.
 - **1Password authorization handoff:** persist nonce-bound pending approvals in shared plugin state so hook and tool execution across broker instances remain single-use and fail closed.
 - **Control UI chat transcripts:** preserve loaded history across session and pane returns, bound automatic backscroll loading, virtualize long transcripts, retain hidden native run boundaries, and keep prepends, streaming, and responsive layouts from flickering or jumping. Thanks @shakkernerd.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Doctor TaskFlow and OAuth repairs:** ignore retained terminal blocked TaskFlows after their child records expire, and force accepted OAuth refresh repairs so expiring credentials actually rotate. Fixes #108097 and #108098.
 - **Mattermost progress command details:** accept the documented `streaming.preview.commandText` and `streaming.progress.commandText` modes in channel config validation and bundled metadata. Thanks @shakkernerd.
 - **1Password authorization handoff:** persist nonce-bound pending approvals in shared plugin state so hook and tool execution across broker instances remain single-use and fail closed.
 - **Control UI chat transcripts:** preserve loaded history across session and pane returns, bound automatic backscroll loading, virtualize long transcripts, retain hidden native run boundaries, and keep prepends, streaming, and responsive layouts from flickering or jumping. Thanks @shakkernerd.

--- a/src/commands/doctor-auth.profile-health.test.ts
+++ b/src/commands/doctor-auth.profile-health.test.ts
@@ -466,7 +466,7 @@ describe("noteAuthProfileHealth", () => {
     );
   });
 
-  it("passes the target agent dir when refreshing OAuth profiles", async () => {
+  it("forces refresh for expiring OAuth profiles in the target agent dir", async () => {
     const now = 1_700_000_000_000;
     vi.spyOn(Date, "now").mockReturnValue(now);
     const coderDir = path.join(tempDir, "coder-agent");
@@ -477,7 +477,7 @@ describe("noteAuthProfileHealth", () => {
     );
     authProfileMocks.ensureAuthProfileStore.mockImplementation((agentDir) => {
       if (agentDir === coderDir) {
-        return expiredStore("openai-codex:coder", now - 60_000);
+        return expiredStore("openai-codex:coder", now + 60 * 60_000);
       }
       return { version: 1, profiles: {} };
     });
@@ -501,6 +501,7 @@ describe("noteAuthProfileHealth", () => {
     expect(authProfileMocks.resolveApiKeyForProfile).toHaveBeenCalledWith(
       expect.objectContaining({
         agentDir: coderDir,
+        forceRefresh: true,
         profileId: "openai-codex:coder",
       }),
     );

--- a/src/commands/doctor-auth.ts
+++ b/src/commands/doctor-auth.ts
@@ -522,6 +522,7 @@ async function noteAuthProfileHealthForTarget(params: {
           store,
           profileId: profile.profileId,
           agentDir: params.target.agentDir,
+          forceRefresh: true,
         });
       } catch (err) {
         const message = formatErrorMessage(err);

--- a/src/commands/doctor-workspace-status.test.ts
+++ b/src/commands/doctor-workspace-status.test.ts
@@ -240,6 +240,13 @@ describe("noteWorkspaceStatus", () => {
         status: "blocked",
         blockedTaskId: "task-missing",
       },
+      {
+        flowId: "flow-history",
+        syncMode: "task_mirrored",
+        status: "blocked",
+        blockedTaskId: "task-pruned",
+        endedAt: 100,
+      },
     ]);
     mocks.listTasksForFlowId.mockReturnValue([]);
 

--- a/src/commands/doctor-workspace-status.ts
+++ b/src/commands/doctor-workspace-status.ts
@@ -42,6 +42,7 @@ function collectTaskFlowRecoveryFindings(): TaskFlowRecoveryFinding[] {
       });
     }
     if (
+      flow.endedAt == null &&
       flow.status === "blocked" &&
       flow.blockedTaskId &&
       !tasks.some((task) => task.taskId === flow.blockedTaskId)

--- a/src/tasks/task-flow-registry.audit.test.ts
+++ b/src/tasks/task-flow-registry.audit.test.ts
@@ -235,6 +235,25 @@ describe("task-flow-registry audit", () => {
     });
   });
 
+  it("does not flag retained terminal blocked flows after their task is pruned", () => {
+    const now = 60 * 60_000;
+    const flow: TaskFlowRecord = {
+      flowId: "flow-terminal-blocked",
+      syncMode: "task_mirrored",
+      ownerKey: "agent:main:main",
+      revision: 0,
+      status: "blocked",
+      notifyPolicy: "done_only",
+      goal: "Historical blocked task",
+      blockedTaskId: "task-pruned",
+      createdAt: 1,
+      updatedAt: 100,
+      endedAt: 100,
+    };
+
+    expect(listTaskFlowAuditFindings({ flows: [flow], now })).toStrictEqual([]);
+  });
+
   it("reports cancel-stuck before maintenance finalizes the flow", async () => {
     await withTaskFlowAuditStateDir(async () => {
       const flow = createManagedTaskFlow({

--- a/src/tasks/task-flow-registry.audit.ts
+++ b/src/tasks/task-flow-registry.audit.ts
@@ -191,7 +191,7 @@ export function listTaskFlowAuditFindings(
       );
     }
 
-    if (flow.status === "blocked" && ageMs >= staleBlockedMs) {
+    if (flow.status === "blocked" && flow.endedAt == null && ageMs >= staleBlockedMs) {
       findings.push(
         createFinding({
           severity: "warn",
@@ -246,7 +246,7 @@ export function listTaskFlowAuditFindings(
       );
     }
 
-    if (flow.blockedTaskId?.trim()) {
+    if (flow.endedAt == null && flow.blockedTaskId?.trim()) {
       const blockedTaskId = flow.blockedTaskId.trim();
       if (!linkedTasks.some((task) => task.taskId === blockedTaskId)) {
         findings.push(


### PR DESCRIPTION
Fixes #108097
Fixes #108098

## What Problem This Solves

Fixes an issue where operators running `openclaw doctor --all` could keep seeing stale TaskFlow warnings after the affected parent task had already ended, and accepted OAuth repairs could leave an expired profile unchanged.

## Why This Change Was Made

TaskFlow audits now restrict missing blocked-child findings to live parent tasks. Accepted OAuth repairs now force a provider refresh, so the repair action actually replaces stale credentials instead of reusing them.

## User Impact

Doctor output clears resolved TaskFlow findings and can repair rejected or expired OAuth profiles in one pass.

## Evidence

- `node scripts/run-vitest.mjs src/commands/doctor-workspace-status.test.ts src/tasks/task-flow-registry.audit.test.ts src/commands/doctor-auth.profile-health.test.ts` — 3 files, 37 tests passed across 2 shards.
- Blacksmith Testbox `pnpm check:changed` — passed at this head: https://github.com/openclaw/openclaw/actions/runs/29397971682
- Fresh autoreview: clean, confidence 0.95.
