### PR TITLE
fix(doctor): force refresh when accepting the expiring OAuth repair (#108098)

### DIFF
--- a/src/commands/doctor-auth.profile-health.test.ts
+++ b/src/commands/doctor-auth.profile-health.test.ts
@@ -506,6 +506,37 @@ describe("noteAuthProfileHealth", () => {
     );
   });
 
+  it("forces a refresh when the operator accepts the expiring-token repair (#108098)", async () => {
+    const now = 1_700_000_000_000;
+    vi.spyOn(Date, "now").mockReturnValue(now);
+    const agentDir = path.join(tempDir, "main-agent");
+    writeAuthStore(agentDir);
+    authProfileMocks.hasAnyAuthProfileStoreSource.mockReturnValue(true);
+    // Access token expires inside doctor's 24h warn window but is still valid now, so the
+    // resolver would return it untouched unless the accepted repair forces a refresh.
+    authProfileMocks.ensureAuthProfileStore.mockReturnValue(
+      expiredStore("openai-codex:default", now + 60 * 60 * 1000),
+    );
+    authProfileMocks.resolveApiKeyForProfile.mockResolvedValue("token");
+
+    await noteAuthProfileHealth({
+      cfg: {
+        agents: { list: [{ id: "main", default: true, agentDir }] },
+      } as OpenClawConfig,
+      prompter: {
+        confirmAutoFix: vi.fn(async () => true),
+      } as unknown as DoctorPrompter,
+      allowKeychainPrompt: false,
+    });
+
+    expect(authProfileMocks.resolveApiKeyForProfile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        profileId: "openai-codex:default",
+        forceRefresh: true,
+      }),
+    );
+  });
+
   it.each([
     [
       "openai-codex:default",

--- a/src/commands/doctor-auth.ts
+++ b/src/commands/doctor-auth.ts
@@ -517,11 +517,15 @@ async function noteAuthProfileHealthForTarget(params: {
     const errors: string[] = [];
     for (const profile of refreshTargets) {
       try {
+        // Explicit operator-accepted repair must force one refresh: without it the
+        // resolver returns the still-valid (but doctor-warned) access token untouched,
+        // so an accepted "refresh now" leaves the same expiring warning (#108098).
         await resolveApiKeyForProfile({
           cfg: params.cfg,
           store,
           profileId: profile.profileId,
           agentDir: params.target.agentDir,
+          forceRefresh: true,
         });
       } catch (err) {
         const message = formatErrorMessage(err);


### PR DESCRIPTION
## What Problem This Solves

Fixes #108098. Interactive `openclaw doctor` offers `Refresh expiring OAuth tokens now?` for OAuth profiles whose access token expires inside doctor's 24h warn window. Accepting it called `resolveApiKeyForProfile` **without** `forceRefresh`, so for a token that is expiring-but-still-valid (inside doctor's warn window yet outside the runtime's near-expiry refresh threshold) the resolver returned the existing access token untouched. Doctor then recomputed the exact same `expiring` warning — the accepted repair did nothing.

## Why This Change Was Made

An operator-accepted repair should actually repair. The resolver already supports `forceRefresh` (`src/agents/auth-profiles/oauth.ts`); doctor's explicit refresh path just wasn't using it. Passing `forceRefresh: true` forces one refresh attempt per refresh-capable expiring profile, persists the new credential, and then the existing post-repair `buildAuthHealthSummary` recompute reflects the fresh expiry.

## User Impact

`openclaw doctor` → accept `Refresh expiring OAuth tokens now?` now actually refreshes expiring OAuth credentials instead of leaving the same warning on the next run. No config or API surface change; failure handling (re-auth guidance on refresh errors) is unchanged.

## Evidence

- Root cause is as described in the issue (doctor called the resolver without `forceRefresh`); the one-line prod change adds `forceRefresh: true` at that call site (`src/commands/doctor-auth.ts`).
- New regression `forces a refresh when the operator accepts the expiring-token repair (#108098)` in `doctor-auth.profile-health.test.ts`: an expiring profile (`expires = now + 1h`, inside the 24h window) + accepted prompt asserts `resolveApiKeyForProfile` is called with `forceRefresh: true`.
- Discriminator: reverting the prod line to omit `forceRefresh` fails **only** this new test (18 other profile-health tests stay green).
- Local (trusted checkout): `node scripts/run-vitest.mjs run src/commands/doctor-auth.profile-health.test.ts` → 19/19; `oxfmt --check` and `oxlint` clean; changed files type-clean under `tsgo`.
