### PR TITLE
refactor(gateway): privatize terminal shell quoting

### DIFF
--- a/scripts/deadcode-exports.baseline.mjs
+++ b/scripts/deadcode-exports.baseline.mjs
@@ -213,7 +213,6 @@ export const KNIP_UNUSED_EXPORT_BASELINE = [
   "src/entry.compile-cache.ts: shouldEnableOpenClawCompileCache",
   "src/flows/doctor-health-contributions.ts: createDoctorHealthContribution",
   "src/flows/doctor-health-contributions.ts: resolveDoctorHealthContributions",
-  "src/gateway/terminal/launch.ts: shellQuote",
   "src/hooks/gmail-setup-utils.ts: resetGmailSetupUtilsCachesForTest",
   "src/logging/diagnostic-run-activity.ts: markDiagnosticModelStartedForTest",
   "src/logging/diagnostic-run-activity.ts: markDiagnosticRunProgressForTest",

--- a/src/gateway/terminal/launch.test.ts
+++ b/src/gateway/terminal/launch.test.ts
@@ -5,7 +5,6 @@ import {
   buildTerminalEnv,
   createTerminalLaunchPolicy,
   resolveTerminalSpawnPlan,
-  shellQuote,
 } from "./launch.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
@@ -360,10 +359,6 @@ describe("buildTerminalEnv", () => {
 
 describe("resolveTerminalSpawnPlan", () => {
   it("quotes every command argument for a login shell", () => {
-    expect(shellQuote("plain")).toBe("'plain'");
-    expect(shellQuote("a b;$HOME")).toBe("'a b;$HOME'");
-    expect(shellQuote("it's")).toBe("'it'\"'\"'s'");
-
     const plan = resolveTerminalSpawnPlan({
       agentId: "main",
       cwd: "/work",

--- a/src/gateway/terminal/launch.ts
+++ b/src/gateway/terminal/launch.ts
@@ -289,7 +289,7 @@ export function buildTerminalEnv(baseEnv: NodeJS.ProcessEnv): Record<string, str
   return env;
 }
 
-export function shellQuote(value: string): string {
+function shellQuote(value: string): string {
   return `'${value.replaceAll("'", `'"'"'`)}'`;
 }
 


### PR DESCRIPTION
## Summary

- make terminal shell quoting module-private
- retain quoting coverage through the production spawn-plan boundary
- shrink the dead-export baseline from 251 to 250 with no additions or cascade

## Evidence

- final exact Testbox: https://github.com/openclaw/openclaw/actions/runs/29398545855 (byte-stable regeneration; 250/250)
- terminal launch suite: 16/16 green locally and on Testbox
- targeted format and type-aware lint green; broad core-types handoff was capped after the wrapper stranded
- fresh autoreview clean at 0.97
- source delta excluding baseline: +1/-6
