### PR TITLE
fix(retry): detect provider-wrapped 5xx status codes for session retry

### DIFF
--- a/src/llm/utils/retry.test.ts
+++ b/src/llm/utils/retry.test.ts
@@ -56,7 +56,7 @@ describe("isRetryableAssistantError", () => {
   });
 
   it.each([
-    "OpenAI API error (500): upstream timeout",
+    "OpenAI API error (500): 500 The server had an error while processing your request. Sorry about that!",
     "Azure OpenAI API error (502): bad gateway",
     "Mistral API error (503): service unavailable",
     "OpenAI API error (504): gateway timeout",
@@ -65,10 +65,35 @@ describe("isRetryableAssistantError", () => {
   });
 
   it.each([
-    "OpenAI API error (401): unauthorized",
-    "Request failed after rendering item (500): invalid input",
-  ])("does not retry permanent or unstructured parenthesized statuses: %s", (text) => {
+    ["bad request", "OpenAI API error (400): invalid_request_error"],
+    ["authentication failure", "OpenAI API error (401): Invalid authentication credentials"],
+    [
+      "authorization failure",
+      "Azure OpenAI API error (403): OAuth authentication is currently not allowed for this organization",
+    ],
+    ["model not found", "Mistral API error (404): model not found"],
+    [
+      "quota exhausted",
+      "OpenAI API error (429): insufficient_quota: Your account has insufficient quota balance to run this request.",
+    ],
+    ["content policy", "Provider finish_reason: content_filter"],
+    ["unstructured status", "Request failed after rendering item (500): invalid input"],
+    [
+      "status in user text",
+      'Invalid request: user text contained "OpenAI API error (500): invalid input"',
+    ],
+  ])("does not retry permanent errors (%s): %s", (_label, text) => {
     expect(isRetryableAssistantError(errorMessage(text))).toBe(false);
+  });
+
+  it("retries a provider-wrapped short-window rate limit", () => {
+    expect(
+      isRetryableAssistantError(
+        errorMessage(
+          "OpenAI API error (429): RESOURCE_EXHAUSTED: Quota exceeded for requests per minute; please retry your request",
+        ),
+      ),
+    ).toBe(true);
   });
 
   it.each([

--- a/src/llm/utils/retry.test.ts
+++ b/src/llm/utils/retry.test.ts
@@ -56,6 +56,22 @@ describe("isRetryableAssistantError", () => {
   });
 
   it.each([
+    "OpenAI API error (500): upstream timeout",
+    "Azure OpenAI API error (502): bad gateway",
+    "Mistral API error (503): service unavailable",
+    "OpenAI API error (504): gateway timeout",
+  ])("retries provider-wrapped transient HTTP statuses: %s", (text) => {
+    expect(isRetryableAssistantError(errorMessage(text))).toBe(true);
+  });
+
+  it.each([
+    "OpenAI API error (401): unauthorized",
+    "Request failed after rendering item (500): invalid input",
+  ])("does not retry permanent or unstructured parenthesized statuses: %s", (text) => {
+    expect(isRetryableAssistantError(errorMessage(text))).toBe(false);
+  });
+
+  it.each([
     "429 You exceeded your daily request limit. Please try again in 24 hours.",
     "rate limit reached for requests. Retry after 6h.",
     "429 RPM limit exceeded; Retry-After: 2 hours",

--- a/src/llm/utils/retry.ts
+++ b/src/llm/utils/retry.ts
@@ -16,9 +16,9 @@ const NON_RETRYABLE_PROVIDER_LIMIT_ERROR_PATTERN = buildProviderErrorPattern([
 ]);
 
 const RETRYABLE_HTTP_STATUS_CODES = new Set([429, 500, 502, 503, 504]);
-// Match only the adapter-owned prefix; arbitrary "(500)" substrings must stay terminal.
-const PROVIDER_WRAPPED_HTTP_STATUS_RE =
-  /^(?:[a-z][\w.-]*[ \t]+)+api[ \t]+error[ \t]*\((\d{3})\)[ \t]*:/i;
+// These are the only built-in adapters that own this envelope. Keep the start anchor
+// and prefix allowlist narrow so echoed user text cannot become retry metadata.
+const PROVIDER_WRAPPED_HTTP_STATUS_RE = /^(?:OpenAI|Azure OpenAI|Mistral) API error \((\d{3})\):/;
 const RATE_LIMIT_CONTEXT_PATTERN = buildProviderErrorPattern([
   "rate.?limit",
   "too many requests",

--- a/src/llm/utils/retry.ts
+++ b/src/llm/utils/retry.ts
@@ -16,6 +16,9 @@ const NON_RETRYABLE_PROVIDER_LIMIT_ERROR_PATTERN = buildProviderErrorPattern([
 ]);
 
 const RETRYABLE_HTTP_STATUS_CODES = new Set([429, 500, 502, 503, 504]);
+// Match only the adapter-owned prefix; arbitrary "(500)" substrings must stay terminal.
+const PROVIDER_WRAPPED_HTTP_STATUS_RE =
+  /^(?:[a-z][\w.-]*[ \t]+)+api[ \t]+error[ \t]*\((\d{3})\)[ \t]*:/i;
 const RATE_LIMIT_CONTEXT_PATTERN = buildProviderErrorPattern([
   "rate.?limit",
   "too many requests",
@@ -58,6 +61,15 @@ const RETRYABLE_PROVIDER_ERROR_PATTERN = buildProviderErrorPattern([
   "please retry your request",
 ]);
 
+function extractRetryHttpStatus(errorMessage: string): number | undefined {
+  const leadingStatus = extractLeadingHttpStatus(errorMessage)?.code;
+  if (leadingStatus !== undefined) {
+    return leadingStatus;
+  }
+  const wrappedStatus = PROVIDER_WRAPPED_HTTP_STATUS_RE.exec(errorMessage)?.[1];
+  return wrappedStatus === undefined ? undefined : Number(wrappedStatus);
+}
+
 /** Classify transient provider/transport failures for outer retry policy. */
 export function isRetryableAssistantError(message: AssistantMessage): boolean {
   if (message.stopReason !== "error" || !message.errorMessage) {
@@ -67,7 +79,7 @@ export function isRetryableAssistantError(message: AssistantMessage): boolean {
   if (NON_RETRYABLE_PROVIDER_LIMIT_ERROR_PATTERN.test(errorMessage)) {
     return false;
   }
-  const status = extractLeadingHttpStatus(errorMessage)?.code;
+  const status = extractRetryHttpStatus(errorMessage);
   if (status && status !== 429 && RETRYABLE_HTTP_STATUS_CODES.has(status)) {
     return true;
   }

--- a/src/shared/assistant-error-format.ts
+++ b/src/shared/assistant-error-format.ts
@@ -12,6 +12,8 @@ const HTTP_STATUS_CODE_PREFIX_RE = new RegExp(
   `^(?:http\\s*)?(\\d{3})(?:${HTTP_STATUS_DELIMITER_RE.source}([\\s\\S]+))?$`,
   "i",
 );
+/** Provider-wrapped errors embed the status in parentheses (e.g. "OpenAI API error (500): …"). */
+const PARENTHESIZED_STATUS_RE = /\((\d{3})\)/;
 const HTML_ERROR_PREFIX_RE = /^\s*(?:<!doctype\s+html\b|<html\b)/i;
 const HTML_CLOSE_RE = /<\/html>/i;
 const CLOUDFLARE_HTML_ERROR_CODES = new Set([521, 522, 523, 524, 525, 526, 530]);
@@ -97,14 +99,23 @@ export function parseApiErrorPayload(raw?: string): ErrorPayload | null {
 
 export function extractLeadingHttpStatus(raw: string): { code: number; rest: string } | null {
   const match = raw.match(HTTP_STATUS_CODE_PREFIX_RE);
-  if (!match) {
-    return null;
+  if (match) {
+    const code = Number(match[1]);
+    if (!Number.isFinite(code)) {
+      return null;
+    }
+    return { code, rest: (match[2] ?? "").trim() };
   }
-  const code = Number(match[1]);
-  if (!Number.isFinite(code)) {
-    return null;
+  // Provider adapters wrap errors with a label prefix (e.g. "OpenAI API error (500): …"),
+  // so the status code is not at the very beginning of the message.
+  const parenMatch = raw.match(PARENTHESIZED_STATUS_RE);
+  if (parenMatch) {
+    const code = Number(parenMatch[1]);
+    if (Number.isFinite(code)) {
+      return { code, rest: raw.trim() };
+    }
   }
-  return { code, rest: (match[2] ?? "").trim() };
+  return null;
 }
 
 export function isCloudflareOrHtmlErrorPage(raw: string): boolean {

--- a/src/shared/assistant-error-format.ts
+++ b/src/shared/assistant-error-format.ts
@@ -12,8 +12,6 @@ const HTTP_STATUS_CODE_PREFIX_RE = new RegExp(
   `^(?:http\\s*)?(\\d{3})(?:${HTTP_STATUS_DELIMITER_RE.source}([\\s\\S]+))?$`,
   "i",
 );
-/** Provider-wrapped errors embed the status in parentheses (e.g. "OpenAI API error (500): …"). */
-const PARENTHESIZED_STATUS_RE = /\((\d{3})\)/;
 const HTML_ERROR_PREFIX_RE = /^\s*(?:<!doctype\s+html\b|<html\b)/i;
 const HTML_CLOSE_RE = /<\/html>/i;
 const CLOUDFLARE_HTML_ERROR_CODES = new Set([521, 522, 523, 524, 525, 526, 530]);
@@ -99,23 +97,14 @@ export function parseApiErrorPayload(raw?: string): ErrorPayload | null {
 
 export function extractLeadingHttpStatus(raw: string): { code: number; rest: string } | null {
   const match = raw.match(HTTP_STATUS_CODE_PREFIX_RE);
-  if (match) {
-    const code = Number(match[1]);
-    if (!Number.isFinite(code)) {
-      return null;
-    }
-    return { code, rest: (match[2] ?? "").trim() };
+  if (!match) {
+    return null;
   }
-  // Provider adapters wrap errors with a label prefix (e.g. "OpenAI API error (500): …"),
-  // so the status code is not at the very beginning of the message.
-  const parenMatch = raw.match(PARENTHESIZED_STATUS_RE);
-  if (parenMatch) {
-    const code = Number(parenMatch[1]);
-    if (Number.isFinite(code)) {
-      return { code, rest: raw.trim() };
-    }
+  const code = Number(match[1]);
+  if (!Number.isFinite(code)) {
+    return null;
   }
-  return null;
+  return { code, rest: (match[2] ?? "").trim() };
 }
 
 export function isCloudflareOrHtmlErrorPage(raw: string): boolean {


### PR DESCRIPTION
Closes #106824

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where transient 500, 502, 503, and 504 responses emitted by built-in provider adapters skipped session auto-retry. OpenAI Responses, Azure OpenAI Responses, and Mistral format these failures as `Provider API error (<status>): ...`, while the retry classifier only recognized a status at the beginning of the message.

## Why This Change Was Made

The retry classifier now recognizes only an anchored, adapter-owned `... API error (<status>):` prefix in addition to the existing leading-status format. This stays inside the retry policy owner instead of broadening the shared leading-status parser, preserving the permanent-error and rate-limit protections introduced by #105258: arbitrary `(500)` substrings still do not become HTTP statuses.

Carrying structured HTTP status metadata on `AssistantMessage` would avoid text parsing, but that is a wider cross-provider and message-contract change than this focused regression requires.

## User Impact

Sessions can automatically retry temporary built-in provider outages instead of failing the turn immediately. Permanent provider errors, long-window quota failures, and unrelated messages containing parenthesized numbers remain terminal.

## Evidence

### Real behavior proof

- **Behavior addressed:** Built-in provider-wrapped transient 5xx messages now enter session retry without reintroducing arbitrary status-substring matches.
- **Real environment tested:** Linux x86_64, Node 24.15.0, commit `290efae0785dcb52607e871651013f09daf65b5b` on branch `fix/retry-provider-5xx-106824`.
- **Exact steps or command run after this patch:** `node --import tsx .artifacts/verify-retry-provider-status.mjs` - invoked the production `isRetryableAssistantError` classifier with exact OpenAI, Azure OpenAI, and Mistral wrapper shapes plus permanent and unstructured counterexamples.
- **Evidence after fix:** Terminal capture of `node` runtime verification (copied live output):

  ```text
  {"result":"PASS","outcomes":[{"errorMessage":"OpenAI API error (500): upstream timeout","expected":true,"actual":true,"ok":true},{"errorMessage":"Azure OpenAI API error (502): bad gateway","expected":true,"actual":true,"ok":true},{"errorMessage":"Mistral API error (503): service unavailable","expected":true,"actual":true,"ok":true},{"errorMessage":"OpenAI API error (504): gateway timeout","expected":true,"actual":true,"ok":true},{"errorMessage":"OpenAI API error (401): unauthorized","expected":false,"actual":false,"ok":true},{"errorMessage":"Request failed after rendering item (500): invalid input","expected":false,"actual":false,"ok":true}]}
  ```

- **Observed result after fix:** All four structured transient provider errors returned `true`; the permanent 401 and arbitrary parenthesized 500 returned `false`.
- **What was not tested:** No billed live provider request was forced to return a 5xx response. The production classifier and nearest embedded-agent rate-limit/failover regression were exercised locally; broader AgentSession scheduling and cross-platform behavior are left to CI.

### Tests and validation

```text
$ node scripts/run-vitest.mjs src/llm/utils/retry.test.ts src/agents/embedded-agent-runner/run/assistant-failover.test.ts
Test Files  2 passed (2)
Tests       59 passed (59)

$ oxfmt --check src/llm/utils/retry.ts src/llm/utils/retry.test.ts
All matched files use the correct format.

$ oxlint src/llm/utils/retry.ts src/llm/utils/retry.test.ts
EXIT=0

$ git diff --check origin/main...HEAD
EXIT=0
```

The focused retry tests cover the three repository-owned provider wrapper families, all transient status codes in scope, a permanent status, and an arbitrary parenthesized substring. The embedded-agent regression confirms `Provider API error (429)` is still not misclassified as a known short-window rate limit.

### Risk checklist

- User-visible behavior: Yes - transient provider-wrapped 5xx failures can now trigger the existing session retry policy.
- Config/env/migration behavior: No - no configuration, persistence, or migration changes.
- Security/auth/secrets/network/tool execution: No - the change only classifies an existing assistant error string.
- Plugins/providers/channels/SDK: Yes - it recognizes the established provider-adapter error envelope without changing provider or SDK contracts.
- Highest-risk area: Parsing a status too broadly could retry permanent failures or change rate-limit/failover policy.
- Mitigation: The new parser requires an anchored `API error (<status>):` envelope, remains local to session retry, filters through the existing retryable status allowlist, and has permanent/unstructured and embedded-agent counterexamples.

## AI assistance

This PR is AI-assisted. Claude Code contributed the original investigation and OpenAI Codex helped maintain, narrow, test, and review the update. I reviewed the resulting code and understand its behavior. The local structured Codex autoreview engine exited without producing either findings or a clean result; GitHub CI and repository review remain authoritative.
