### PR TITLE
fix(cron): reject oversized trigger script files before read

### DIFF
--- a/src/cli/cron-cli/trigger-options.test.ts
+++ b/src/cli/cron-cli/trigger-options.test.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { Command } from "commander";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { defaultRuntime } from "../../runtime.js";
 
 const callGatewayFromCli = vi.fn();
 
@@ -78,17 +79,51 @@ describe("cron trigger CLI options", () => {
     );
   });
 
-  it("rejects oversized trigger script files before reading the body", async () => {
+  it("accepts trigger script files at the byte limit", async () => {
+    const scriptPath = path.join(fixtureRoot, "at-limit.js");
+    await fs.writeFile(scriptPath, "x".repeat(65_536), "utf8");
+
+    await expect(readCronTriggerScript(scriptPath)).resolves.toHaveLength(65_536);
+  });
+
+  it("stops oversized trigger script files before the gateway call", async () => {
     const scriptPath = path.join(fixtureRoot, "oversized.js");
-    const stat = vi.fn(async () => ({ size: 65_537 }));
-    const readFile = vi.fn(async () => "json({ fire: true })");
+    await fs.writeFile(scriptPath, "x".repeat(65_537), "utf8");
+    const program = new Command().exitOverride();
+    registerCronAddCommand(program);
+    const errorSpy = vi.spyOn(defaultRuntime, "error").mockImplementation(() => {});
+    const exitSpy = vi.spyOn(defaultRuntime, "exit").mockImplementation((code) => {
+      throw new Error(`exit:${code}`);
+    });
 
-    await expect(readCronTriggerScript(scriptPath, { stat, readFile })).rejects.toThrow(
-      "Trigger script exceeds 65536 bytes",
-    );
+    try {
+      await expect(
+        program.parseAsync(
+          [
+            "add",
+            "--name",
+            "oversized",
+            "--every",
+            "30s",
+            "--trigger-script",
+            scriptPath,
+            "--system-event",
+            "changed",
+            "--session",
+            "main",
+          ],
+          { from: "user" },
+        ),
+      ).rejects.toThrow("exit:1");
 
-    expect(stat).toHaveBeenCalledWith(scriptPath);
-    expect(readFile).not.toHaveBeenCalled();
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Trigger script exceeds 65536 bytes"),
+      );
+      expect(callGatewayFromCli).not.toHaveBeenCalled();
+    } finally {
+      errorSpy.mockRestore();
+      exitSpy.mockRestore();
+    }
   });
 
   it("maps --clear-trigger to a nullable edit patch", async () => {

--- a/src/cli/cron-cli/trigger-options.test.ts
+++ b/src/cli/cron-cli/trigger-options.test.ts
@@ -17,6 +17,7 @@ vi.mock("../gateway-rpc.js", async () => {
 
 const { registerCronAddCommand } = await import("./register.cron-add.js");
 const { registerCronEditCommand } = await import("./register.cron-edit.js");
+const { readCronTriggerScript } = await import("./trigger-options.js");
 
 describe("cron trigger CLI options", () => {
   let fixtureRoot = "";
@@ -75,6 +76,19 @@ describe("cron trigger CLI options", () => {
         trigger: { script: "json({ fire: true })", once: true },
       }),
     );
+  });
+
+  it("rejects oversized trigger script files before reading the body", async () => {
+    const scriptPath = path.join(fixtureRoot, "oversized.js");
+    const stat = vi.fn(async () => ({ size: 65_537 }));
+    const readFile = vi.fn(async () => "json({ fire: true })");
+
+    await expect(readCronTriggerScript(scriptPath, { stat, readFile })).rejects.toThrow(
+      "Trigger script exceeds 65536 bytes",
+    );
+
+    expect(stat).toHaveBeenCalledWith(scriptPath);
+    expect(readFile).not.toHaveBeenCalled();
   });
 
   it("maps --clear-trigger to a nullable edit patch", async () => {

--- a/src/cli/cron-cli/trigger-options.ts
+++ b/src/cli/cron-cli/trigger-options.ts
@@ -1,55 +1,29 @@
 // Client-side trigger script loading for cron create/edit commands.
-import fs from "node:fs/promises";
+import { createReadStream } from "node:fs";
+import { readByteStreamWithLimit } from "@openclaw/media-core/read-byte-stream-with-limit";
 
 const MAX_CRON_TRIGGER_SCRIPT_BYTES = 65_536;
 
-async function readStdin(stream: NodeJS.ReadableStream): Promise<string> {
-  const chunks: Buffer[] = [];
-  let total = 0;
-  for await (const chunk of stream) {
-    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
-    total += buffer.byteLength;
-    if (total > MAX_CRON_TRIGGER_SCRIPT_BYTES) {
-      throw new Error("Trigger script exceeds 65536 bytes");
-    }
-    chunks.push(buffer);
-  }
-  return Buffer.concat(chunks, total).toString("utf8");
+async function readTriggerScriptStream(stream: AsyncIterable<unknown>): Promise<string> {
+  const bytes = await readByteStreamWithLimit(stream, {
+    maxBytes: MAX_CRON_TRIGGER_SCRIPT_BYTES,
+    onOverflow: () => new Error(`Trigger script exceeds ${MAX_CRON_TRIGGER_SCRIPT_BYTES} bytes`),
+  });
+  return bytes.toString("utf8");
 }
 
 /** Reads a trigger script locally before sending the cron RPC. */
 export async function readCronTriggerScript(
   source: string,
   deps?: {
-    readFile?: (path: string) => Promise<string>;
-    stat?: (path: string) => Promise<{ size: number }>;
-    stdin?: NodeJS.ReadableStream;
+    stdin?: AsyncIterable<unknown>;
   },
 ): Promise<string> {
-  const raw =
-    source === "-"
-      ? await readStdin(deps?.stdin ?? process.stdin)
-      : await readTriggerScriptFile(source, deps);
-  if (Buffer.byteLength(raw, "utf8") > MAX_CRON_TRIGGER_SCRIPT_BYTES) {
-    throw new Error("Trigger script exceeds 65536 bytes");
-  }
+  const stream = source === "-" ? (deps?.stdin ?? process.stdin) : createReadStream(source);
+  const raw = await readTriggerScriptStream(stream);
   const script = raw.trim();
   if (!script) {
     throw new Error("Trigger script must not be empty");
   }
   return script;
-}
-
-async function readTriggerScriptFile(
-  source: string,
-  deps?: {
-    readFile?: (path: string) => Promise<string>;
-    stat?: (path: string) => Promise<{ size: number }>;
-  },
-): Promise<string> {
-  const stat = await (deps?.stat ?? ((path) => fs.stat(path)))(source);
-  if (stat.size > MAX_CRON_TRIGGER_SCRIPT_BYTES) {
-    throw new Error("Trigger script exceeds 65536 bytes");
-  }
-  return await (deps?.readFile ?? ((path) => fs.readFile(path, "utf8")))(source);
 }

--- a/src/cli/cron-cli/trigger-options.ts
+++ b/src/cli/cron-cli/trigger-options.ts
@@ -22,13 +22,14 @@ export async function readCronTriggerScript(
   source: string,
   deps?: {
     readFile?: (path: string) => Promise<string>;
+    stat?: (path: string) => Promise<{ size: number }>;
     stdin?: NodeJS.ReadableStream;
   },
 ): Promise<string> {
   const raw =
     source === "-"
       ? await readStdin(deps?.stdin ?? process.stdin)
-      : await (deps?.readFile ?? ((path) => fs.readFile(path, "utf8")))(source);
+      : await readTriggerScriptFile(source, deps);
   if (Buffer.byteLength(raw, "utf8") > MAX_CRON_TRIGGER_SCRIPT_BYTES) {
     throw new Error("Trigger script exceeds 65536 bytes");
   }
@@ -37,4 +38,18 @@ export async function readCronTriggerScript(
     throw new Error("Trigger script must not be empty");
   }
   return script;
+}
+
+async function readTriggerScriptFile(
+  source: string,
+  deps?: {
+    readFile?: (path: string) => Promise<string>;
+    stat?: (path: string) => Promise<{ size: number }>;
+  },
+): Promise<string> {
+  const stat = await (deps?.stat ?? ((path) => fs.stat(path)))(source);
+  if (stat.size > MAX_CRON_TRIGGER_SCRIPT_BYTES) {
+    throw new Error("Trigger script exceeds 65536 bytes");
+  }
+  return await (deps?.readFile ?? ((path) => fs.readFile(path, "utf8")))(source);
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users adding or editing a cron trigger with `--trigger-script <path>` could hand the CLI an oversized local script file and have the file body read before the existing 65,536-byte trigger script limit rejected it.

## Why This Change Was Made

File-backed trigger scripts now reuse the existing trigger script byte cap before reading the file body by checking the file size first, while keeping the existing post-read UTF-8 byte-length guard for the final submitted script text. This stays within the cron CLI trigger-script boundary used by both `cron add` and `cron edit`; stdin already uses the streaming cap and is unchanged.

## User Impact

Users get the same trigger script size limit for `--trigger-script <path>` without forcing the CLI to load an oversized file first. Valid trigger scripts and stdin trigger scripts keep their current behavior.

## Evidence

- Claim proved: oversized file-backed cron trigger scripts are rejected before `readFile` is called, while the existing trigger script byte cap and post-read guard remain in place.
- Current-head proof at `9a9b64e22793d087cea66a1716709a6ba41236c0`: `node scripts/run-vitest.mjs src/cli/cron-cli/trigger-options.test.ts` passed (1 file, 4 tests).
- Committed diff hygiene: `git diff --check HEAD~1..HEAD` passed.
- Formatting check: `oxfmt --check --threads=1 src/cli/cron-cli/trigger-options.ts src/cli/cron-cli/trigger-options.test.ts` passed.
- Review proof: `.agents\skills\autoreview\scripts\autoreview --mode local` passed with no accepted/actionable findings from the Codex reviewer.