### PR TITLE
fix(reef): bound relay transport JSON response reads to prevent OOM

### DIFF
--- a/extensions/reef/src/transport.test.ts
+++ b/extensions/reef/src/transport.test.ts
@@ -106,6 +106,59 @@ describe("ReefTransportClient device authentication", () => {
     ).toBe(true);
   });
 
+  it("rejects oversized relay success responses before buffering the full body", async () => {
+    const hugeBody = JSON.stringify({ data: "x".repeat(2 * 1024 * 1024) });
+    const fetcher: typeof fetch = async () =>
+      new Response(hugeBody, {
+        headers: { "content-type": "application/json" },
+      });
+    const client = new ReefTransportClient(
+      "https://relay.example",
+      "alice",
+      keys,
+      fetcher,
+      () => ts,
+    );
+
+    await expect(client.listFriends()).rejects.toThrow("exceeds");
+  });
+
+  it("rejects oversized relay error responses without leaking the body", async () => {
+    const hugeError = JSON.stringify({
+      error: "x".repeat(128 * 1024),
+    });
+    const fetcher: typeof fetch = async () =>
+      new Response(hugeError, {
+        status: 502,
+        headers: { "content-type": "application/json" },
+      });
+    const client = new ReefTransportClient(
+      "https://relay.example",
+      "alice",
+      keys,
+      fetcher,
+      () => ts,
+    );
+
+    await expect(client.listFriends()).rejects.toThrow("relay HTTP 502");
+  });
+
+  it("parses normal-sized relay responses unchanged", async () => {
+    const fetcher: typeof fetch = async () =>
+      Response.json({ friendships: [{ peer: "bob", status: "accepted" }] });
+    const client = new ReefTransportClient(
+      "https://relay.example",
+      "alice",
+      keys,
+      fetcher,
+      () => ts,
+    );
+
+    await expect(client.listFriends()).resolves.toEqual({
+      friendships: [{ peer: "bob", status: "accepted" }],
+    });
+  });
+
   it("bumps ts monotonically so identical same-second requests never share a replay key", async () => {
     const seenTs: string[] = [];
     const fetcher: typeof fetch = async (_input, init) => {

--- a/extensions/reef/src/transport.ts
+++ b/extensions/reef/src/transport.ts
@@ -1,8 +1,12 @@
+import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
 import { sha256Hex, signDeviceRequest, utf8 } from "../protocol/index.js";
 import type { Envelope, SignedReceipt } from "../protocol/index.js";
 import type { InboxEntry, ReefKeys, RelayFriend } from "./types.js";
 
 type FetchLike = typeof fetch;
+
+const REEF_TRANSPORT_ERROR_BODY_MAX_BYTES = 64 * 1024;
+const REEF_TRANSPORT_RESPONSE_MAX_BYTES = 1024 * 1024;
 
 export class ReefRelayError extends Error {
   constructor(
@@ -144,17 +148,31 @@ export class ReefTransportClient {
     if (!response.ok) {
       let message = `relay HTTP ${response.status}`;
       try {
-        const parsed = (await response.json()) as { error?: string };
+        const errorBody = await readResponseWithLimit(
+          response,
+          REEF_TRANSPORT_ERROR_BODY_MAX_BYTES,
+          {
+            onOverflow: ({ maxBytes }) =>
+              new Error(`Reef relay error response exceeds ${maxBytes} bytes`),
+          },
+        );
+        const parsed = JSON.parse(errorBody.toString()) as { error?: string };
         if (parsed.error) {
           message = parsed.error;
         }
-      } catch {}
+      } catch {
+        // Use the status-based message when body read fails (overflow, invalid
+        // JSON, or network error). The parsed error string is best-effort.
+      }
       throw new ReefRelayError(response.status, message);
     }
     if (response.status === 204) {
       return undefined as T;
     }
-    return (await response.json()) as T;
+    const body = await readResponseWithLimit(response, REEF_TRANSPORT_RESPONSE_MAX_BYTES, {
+      onOverflow: ({ maxBytes }) => new Error(`Reef relay response exceeds ${maxBytes} bytes`),
+    });
+    return JSON.parse(body.toString()) as T;
   }
 }
 


### PR DESCRIPTION
## What Problem This Solves

`ReefTransportClient.request()` used unbounded `response.json()` for both error and success relay responses. A malicious or misconfigured relay could return an oversized JSON payload, forcing the runtime to buffer it entirely into memory.

## Why This Change Was Made

Error response bodies are now capped at **64 KiB** and success response bodies at **1 MiB** via `readResponseWithLimit`. The existing status-code fallback message (`relay HTTP ${status}`) is preserved when the error body read overflows or fails to parse.

## User Impact

No user-visible change. Normal relay responses parse identically. An oversized response now throws an explicit error.

## Evidence

### Controlled-size proof

```
$ node --import tsx extensions/reef/src/transport.proof.mts
PASS: normal-sized relay response parsed correctly
PASS: oversized relay response rejected without OOM
PASS: oversized error response falls back to status message
3 passed, 0 failed
```

### Regression tests

```
$ node scripts/run-vitest.mjs extensions/reef/src/transport.test.ts --run
 ✓ rejects oversized relay success responses before buffering the full body
 ✓ rejects oversized relay error responses without leaking the body
 ✓ parses normal-sized relay responses unchanged
 Test Files  1 passed (1) | Tests  6 passed (6)
```

### Full reef suite

```
Test Files  11 passed | 1 skipped (12) | Tests  110 passed | 2 skipped (112)
```
The single skipped file is a pre-existing failure on main.

- `oxfmt --check` on changed files: clean.

### Proof gap

No real Reef relay in this environment. The proof uses an injected fetch mock exercising the production `request()` path with controlled body sizes.

## Root Cause

In `ReefTransportClient.request()`, `response.json()` reads the entire body without a size bound. `readResponseWithLimit` rejects incrementally after the cap, before the full body is buffered.

## AI Assistance

AI-assisted: implemented with Claude Code. I inspected and understand the response-bounding behavior.