### PR TITLE
refactor(music-generation): privatize mode resolver

### DIFF
--- a/scripts/deadcode-exports.baseline.mjs
+++ b/scripts/deadcode-exports.baseline.mjs
@@ -219,7 +219,6 @@ export const KNIP_UNUSED_EXPORT_BASELINE = [
   "src/logging/diagnostic-run-activity.ts: markDiagnosticToolStartedForTest",
   "src/logging/redact-internal.ts: withFullContextToolPayloadRedaction",
   "src/logging/secret-redaction-registry.ts: resetSecretRedactionRegistryForTest",
-  "src/music-generation/capabilities.ts: resolveMusicGenerationMode",
   "src/node-host/invoke.ts: testing",
   "src/plugin-state/plugin-state-store.sqlite.ts: probePluginStateStore",
   "src/plugin-state/plugin-state-store.sqlite.ts: seedPluginStateDatabaseEntriesForTests",

--- a/src/music-generation/capabilities.test.ts
+++ b/src/music-generation/capabilities.test.ts
@@ -2,7 +2,6 @@
 import { describe, expect, it } from "vitest";
 import {
   listSupportedMusicGenerationModes,
-  resolveMusicGenerationMode,
   resolveMusicGenerationModeCapabilities,
 } from "./capabilities.js";
 import type { MusicGenerationProvider } from "./types.js";
@@ -56,8 +55,14 @@ describe("music-generation capabilities", () => {
   });
 
   it("detects generate vs edit mode from reference images", () => {
-    expect(resolveMusicGenerationMode({ inputImageCount: 0 })).toBe("generate");
-    expect(resolveMusicGenerationMode({ inputImageCount: 1 })).toBe("edit");
+    expect(resolveMusicGenerationModeCapabilities({ inputImageCount: 0 })).toEqual({
+      mode: "generate",
+      capabilities: undefined,
+    });
+    expect(resolveMusicGenerationModeCapabilities({ inputImageCount: 1 })).toEqual({
+      mode: "edit",
+      capabilities: undefined,
+    });
   });
 
   it("does not infer edit capabilities from aggregate fields", () => {

--- a/src/music-generation/capabilities.ts
+++ b/src/music-generation/capabilities.ts
@@ -13,9 +13,7 @@ import type {
  * these helpers choose the active mode and return the matching capability block.
  */
 /** Resolve generation mode from the presence of input images. */
-export function resolveMusicGenerationMode(params: {
-  inputImageCount?: number;
-}): MusicGenerationMode {
+function resolveMusicGenerationMode(params: { inputImageCount?: number }): MusicGenerationMode {
   return (params.inputImageCount ?? 0) > 0 ? "edit" : "generate";
 }
 


### PR DESCRIPTION
## What Problem This Solves

The dead-export ratchet still grandfathered an internal music-generation mode helper that has no external consumer.

## Why This Change Was Made

Keeps the helper module-private and moves its direct assertions through the retained capability resolver, preserving generate/edit behavior without an unnecessary exported surface.

## User Impact

No user-visible behavior change. Internal API surface and dead-export debt shrink.

## Evidence

- Production Knip baseline: 250 -> 249, with no additions or cascade.
- Focused Testbox: 4/4 music-generation capability tests, formatting, and type-aware lint green: https://github.com/openclaw/openclaw/actions/runs/29398733887
- Fresh autoreview: clean, 0.98 confidence.
- Final rebased Testbox: baseline regeneration byte-stable and exact deadcode 249/249: https://github.com/openclaw/openclaw/actions/runs/29399026528
- Production source delta excluding baseline: +1/-3, net -2 LOC.
