### PR TITLE
refactor(proxy-capture): privatize server helpers

### DIFF
--- a/scripts/deadcode-exports.baseline.mjs
+++ b/scripts/deadcode-exports.baseline.mjs
@@ -224,8 +224,6 @@ export const KNIP_UNUSED_EXPORT_BASELINE = [
   "src/plugin-state/plugin-state-store.sqlite.ts: seedPluginStateDatabaseEntriesForTests",
   "src/plugin-state/plugin-state-store.sqlite.ts: setMaxPluginStateEntriesPerPluginForTests",
   "src/plugin-state/plugin-state-store.ts: clearPluginStateStoreForTests",
-  "src/proxy-capture/proxy-server.ts: assertDebugProxyDirectUpstreamAllowed",
-  "src/proxy-capture/proxy-server.ts: parseConnectTarget",
   "src/sessions/session-key-utils.ts: isCasePreservingPeer",
   "src/sessions/session-lifecycle-admission.ts: runExclusiveSessionLifecycle",
   "src/sessions/session-state-events.ts: pruneSessionStateEvents",

--- a/src/proxy-capture/proxy-server.managed-proxy.test.ts
+++ b/src/proxy-capture/proxy-server.managed-proxy.test.ts
@@ -7,7 +7,7 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import type { DebugProxySettings } from "./env.js";
-import { assertDebugProxyDirectUpstreamAllowed, startDebugProxyServer } from "./proxy-server.js";
+import { startDebugProxyServer } from "./proxy-server.js";
 import { closeDebugProxyCaptureStore } from "./store.sqlite.js";
 
 let testRoot: string | undefined;
@@ -47,7 +47,10 @@ async function makeSettings(): Promise<DebugProxySettings> {
   };
 }
 
-async function connectThroughProxy(proxyUrl: string): Promise<string> {
+async function connectThroughProxy(
+  proxyUrl: string,
+  connectTarget = "example.com:443",
+): Promise<string> {
   const target = new URL(proxyUrl);
   const socket = new Socket();
   let data = "";
@@ -59,7 +62,7 @@ async function connectThroughProxy(proxyUrl: string): Promise<string> {
     socket.once("error", reject);
     socket.connect(Number(target.port), target.hostname, resolve);
   });
-  socket.write("CONNECT example.com:443 HTTP/1.1\r\nHost: example.com:443\r\n\r\n");
+  socket.write(`CONNECT ${connectTarget} HTTP/1.1\r\nHost: ${connectTarget}\r\n\r\n`);
   await new Promise<void>((resolve) => {
     socket.once("end", resolve);
   });
@@ -168,35 +171,25 @@ describe("debug proxy managed-proxy direct upstream policy", () => {
     await cleanupTestDirs();
   });
 
-  it("allows direct upstreams when managed proxy mode is inactive", () => {
-    expect(assertDebugProxyDirectUpstreamAllowed()).toBeUndefined();
-  });
-
-  it("rejects direct upstreams while managed proxy mode is active", () => {
-    process.env["OPENCLAW_PROXY_ACTIVE"] = "1";
-
-    expect(() => assertDebugProxyDirectUpstreamAllowed()).toThrow(
-      /Debug proxy direct upstream forwarding is disabled/,
-    );
-  });
-
-  it("uses shared truthy parsing for managed proxy mode", () => {
-    process.env["OPENCLAW_PROXY_ACTIVE"] = "true";
-
-    expect(() => assertDebugProxyDirectUpstreamAllowed()).toThrow(
-      /Debug proxy direct upstream forwarding is disabled/,
-    );
-  });
-
-  it("allows direct upstreams with explicit diagnostic override", () => {
+  it("allows HTTP upstreams with the explicit diagnostic override", async () => {
     process.env["OPENCLAW_PROXY_ACTIVE"] = "1";
     process.env["OPENCLAW_DEBUG_PROXY_ALLOW_DIRECT_CONNECT_WITH_MANAGED_PROXY"] = "1";
+    const origin = await startCanaryOrigin();
+    const server = await startDebugProxyServer({ settings: await makeSettings() });
+    try {
+      const response = await requestThroughProxy(server.proxyUrl, origin.url);
 
-    expect(assertDebugProxyDirectUpstreamAllowed()).toBeUndefined();
+      expect(response).toContain("200 OK");
+      expect(response).toContain("ok");
+      expect(origin.requestCount()).toBe(1);
+    } finally {
+      await server.stop();
+      await origin.stop();
+    }
   });
 
   it("rejects CONNECT upstreams before opening direct sockets while managed proxy mode is active", async () => {
-    process.env["OPENCLAW_PROXY_ACTIVE"] = "1";
+    process.env["OPENCLAW_PROXY_ACTIVE"] = "true";
     const server = await startDebugProxyServer({ settings: await makeSettings() });
     try {
       const response = await connectThroughProxy(server.proxyUrl);
@@ -208,6 +201,33 @@ describe("debug proxy managed-proxy direct upstream policy", () => {
       await server.stop();
     }
   });
+
+  it("accepts bracketed IPv6 CONNECT targets before applying upstream policy", async () => {
+    process.env["OPENCLAW_PROXY_ACTIVE"] = "1";
+    const server = await startDebugProxyServer({ settings: await makeSettings() });
+    try {
+      const response = await connectThroughProxy(server.proxyUrl, "[::1]:8443");
+
+      expect(response).toContain("403 Forbidden");
+      expect(response).not.toContain("400 Bad Request");
+    } finally {
+      await server.stop();
+    }
+  });
+
+  it.each(["[::1]:99999", "api.openai.com:1e3", "api.openai.com:0x50"])(
+    "rejects invalid CONNECT target %s",
+    async (connectTarget) => {
+      const server = await startDebugProxyServer({ settings: await makeSettings() });
+      try {
+        const response = await connectThroughProxy(server.proxyUrl, connectTarget);
+
+        expect(response).toContain("400 Bad Request");
+      } finally {
+        await server.stop();
+      }
+    },
+  );
 
   it("rejects absolute-form HTTP proxy requests before opening direct upstreams while managed proxy mode is active", async () => {
     process.env["OPENCLAW_PROXY_ACTIVE"] = "1";

--- a/src/proxy-capture/proxy-server.test.ts
+++ b/src/proxy-capture/proxy-server.test.ts
@@ -11,7 +11,7 @@ import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import type { DebugProxySettings } from "./env.js";
-import { parseConnectTarget, startDebugProxyServer } from "./proxy-server.js";
+import { startDebugProxyServer } from "./proxy-server.js";
 import { closeDebugProxyCaptureStore, getDebugProxyCaptureStore } from "./store.sqlite.js";
 
 let testRoot: string | undefined;
@@ -230,28 +230,6 @@ async function postThroughProxy(params: {
 
 afterEach(async () => {
   await cleanupTestRoot();
-});
-
-describe("parseConnectTarget", () => {
-  it("parses bracketed IPv6 CONNECT targets safely", () => {
-    expect(parseConnectTarget("[::1]:8443")).toEqual({
-      hostname: "::1",
-      port: 8443,
-    });
-  });
-
-  it("parses unbracketed host:port CONNECT targets", () => {
-    expect(parseConnectTarget("api.openai.com:443")).toEqual({
-      hostname: "api.openai.com",
-      port: 443,
-    });
-  });
-
-  it("rejects invalid CONNECT ports", () => {
-    expect(() => parseConnectTarget("[::1]:99999")).toThrow("Invalid CONNECT target port");
-    expect(() => parseConnectTarget("api.openai.com:1e3")).toThrow("Invalid CONNECT target port");
-    expect(() => parseConnectTarget("api.openai.com:0x50")).toThrow("Invalid CONNECT target port");
-  });
 });
 
 describe("startDebugProxyServer", () => {

--- a/src/proxy-capture/proxy-server.ts
+++ b/src/proxy-capture/proxy-server.ts
@@ -36,7 +36,7 @@ function allowsDirectConnectWithManagedProxy(env: NodeJS.ProcessEnv = process.en
   return isTruthyEnvValue(env[DEBUG_PROXY_DIRECT_CONNECT_OVERRIDE]);
 }
 
-export function assertDebugProxyDirectUpstreamAllowed(env: NodeJS.ProcessEnv = process.env): void {
+function assertDebugProxyDirectUpstreamAllowed(env: NodeJS.ProcessEnv = process.env): void {
   if (!isManagedProxyActive(env) || allowsDirectConnectWithManagedProxy(env)) {
     return;
   }
@@ -71,7 +71,7 @@ function createProxyCaptureRecorder(params: {
   };
 }
 
-export function parseConnectTarget(rawTarget: string | undefined): {
+function parseConnectTarget(rawTarget: string | undefined): {
   hostname: string;
   port: number;
 } {


### PR DESCRIPTION
## What Problem This Solves

The dead-export ratchet still grandfathered two proxy-capture server helpers that have no production consumer outside their owner module.

## Why This Change Was Made

Keeps both helpers module-private and moves parsing and managed-proxy policy assertions through the real proxy server boundary. This preserves CONNECT parsing and the direct-upstream security policy without exposing test-only internals.

## User Impact

No user-visible behavior change. Internal API surface and dead-export debt shrink.

## Evidence

- Production Knip baseline: 249 -> 247, with no additions or cascade.
- Focused Testbox: 11/11 proxy server tests and formatting green: https://github.com/openclaw/openclaw/actions/runs/29399277275
- Coverage includes managed-proxy HTTP/CONNECT rejection, explicit diagnostic override, truthy environment parsing, bracketed IPv6 CONNECT parsing, and invalid-port rejection.
- Fresh autoreview: clean, 0.98 confidence.
- Final rebased Testbox: baseline regeneration byte-stable and exact deadcode 247/247: https://github.com/openclaw/openclaw/actions/runs/29399580082
- Scoped type-aware lint stalled without diagnostics on two fresh Testboxes and was capped under the direct-land override.
- Production source delta excluding baseline: +2/-2, net 0 LOC; total source/test delta excluding baseline: +49/-51, net -2 LOC.
