### PR TITLE
fix(system-agent): reject non-decimal wizard option numbers

### DIFF
--- a/src/system-agent/chat-engine.test.ts
+++ b/src/system-agent/chat-engine.test.ts
@@ -791,6 +791,27 @@ describe("SystemAgentChatEngine", () => {
     await defaultEngine.handle("yes");
   });
 
+  it("rejects non-decimal menu numbers in hosted wizard choices", async () => {
+    useTempStateDir();
+    const runs: unknown[] = [];
+    const engine = new SystemAgentChatEngine({
+      runAgentTurn: async () => null,
+      planWithAssistant: async () => null,
+      deps: { loadOverview: fakeOverviewLoader() },
+      runChannelSetupWizard: async (_channel, prompter) => {
+        runs.push(await prompter.select({ message: "DM mode", options: [{ value: "pair", label: "Pairing" }, { value: "open", label: "Open" }] }));
+        runs.push(await prompter.multiselect({ message: "Features", options: [{ value: "alerts", label: "Alerts" }, { value: "logs", label: "Logs" }] }));
+      },
+    });
+    expect((await engine.handle("connect telegram")).text).toContain("1. Pairing");
+    expect((await engine.handle("1e0")).text).toContain("I could not match that answer.");
+    expect(runs).toEqual([]);
+    expect((await engine.handle("1")).text).toContain("1. Alerts");
+    expect((await engine.handle("0x1")).text).toContain("I could not match that answer.");
+    expect(await engine.handle("1,2")).toHaveProperty("text", expect.stringContaining("telegram is configured"));
+    expect(runs).toEqual(["pair", ["alerts", "logs"]]);
+  });
+
   it("rejects a hosted channel commit after a concurrent inference-route change", async () => {
     useTempStateDir();
     const baseConfig: OpenClawConfig = {

--- a/src/system-agent/chat-engine.test.ts
+++ b/src/system-agent/chat-engine.test.ts
@@ -799,8 +799,24 @@ describe("SystemAgentChatEngine", () => {
       planWithAssistant: async () => null,
       deps: { loadOverview: fakeOverviewLoader() },
       runChannelSetupWizard: async (_channel, prompter) => {
-        runs.push(await prompter.select({ message: "DM mode", options: [{ value: "pair", label: "Pairing" }, { value: "open", label: "Open" }] }));
-        runs.push(await prompter.multiselect({ message: "Features", options: [{ value: "alerts", label: "Alerts" }, { value: "logs", label: "Logs" }] }));
+        runs.push(
+          await prompter.select({
+            message: "DM mode",
+            options: [
+              { value: "pair", label: "Pairing" },
+              { value: "open", label: "Open" },
+            ],
+          }),
+        );
+        runs.push(
+          await prompter.multiselect({
+            message: "Features",
+            options: [
+              { value: "alerts", label: "Alerts" },
+              { value: "logs", label: "Logs" },
+            ],
+          }),
+        );
       },
     });
     expect((await engine.handle("connect telegram")).text).toContain("1. Pairing");
@@ -808,7 +824,10 @@ describe("SystemAgentChatEngine", () => {
     expect(runs).toEqual([]);
     expect((await engine.handle("1")).text).toContain("1. Alerts");
     expect((await engine.handle("0x1")).text).toContain("I could not match that answer.");
-    expect(await engine.handle("1,2")).toHaveProperty("text", expect.stringContaining("telegram is configured"));
+    expect(await engine.handle("1,2")).toHaveProperty(
+      "text",
+      expect.stringContaining("telegram is configured"),
+    );
     expect(runs).toEqual(["pair", ["alerts", "logs"]]);
   });
 

--- a/src/system-agent/chat-engine.ts
+++ b/src/system-agent/chat-engine.ts
@@ -298,9 +298,11 @@ function parseWizardAnswer(step: WizardStep, text: string): { value: unknown } |
   }
   const options = step.options ?? [];
   const matchOption = (token: string) => {
-    const index = Number(token);
-    if (Number.isInteger(index) && index >= 1 && index <= options.length) {
-      return options[index - 1];
+    if (/^\d+$/.test(token)) {
+      const index = Number(token);
+      if (Number.isSafeInteger(index) && index >= 1 && index <= options.length) {
+        return options[index - 1];
+      }
     }
     const lower = token.toLowerCase();
     return options.find(


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users answering hosted setup wizard choice prompts in chat could select menu options with JavaScript numeric syntax such as `1e0` or `0x1` instead of the displayed decimal menu numbers.

## Why This Change Was Made

The system-agent chat wizard bridge now treats numeric menu answers as decimal digit tokens before matching by index, then falls back to the existing label/value text matching. This covers the shared select and multiselect parsing boundary without changing the underlying wizard session protocol, config, schema, provider, or channel setup behavior.

## User Impact

Hosted setup wizard prompts now re-render when users enter non-decimal menu-number syntax, while ordinary decimal choices such as `1` and `1,2` continue to work for single-select and multiselect prompts.

## Evidence

- Claim proved: hosted system-agent wizard select and multiselect prompts reject non-decimal menu-number tokens (`1e0`, `0x1`) and still accept displayed decimal menu choices.
- Current head: `e22eb5d7e0e06b1586e023a7e6b56ebc16ef9890`.
- Exact-head GitHub proof: `Real behavior proof` passed for `e22eb5d7e0e06b1586e023a7e6b56ebc16ef9890` (run `29594510910`, job `87931532892`).
- Current-head diff hygiene: `git diff --check upstream/main...HEAD -- src/system-agent/chat-engine.ts src/system-agent/chat-engine.test.ts` passed for `e22eb5d7e0e06b1586e023a7e6b56ebc16ef9890`.
- Rebase-refresh: `gh pr update-branch 108140 --repo openclaw/openclaw --rebase` succeeded; the PR diff remains limited to `src/system-agent/chat-engine.ts` and `src/system-agent/chat-engine.test.ts`.
- Exact-head CI: `check-test-types`, `check-lint`, `checks-fast-max-lines-ratchet`, and `openclaw/ci-gate` passed; inspect-pr-checks reported no failed or pending checks.
- Observed result: `1e0` and `0x1` returned `I could not match that answer.` and re-rendered the same wizard prompt; `1` and `1,2` advanced and completed the hosted Telegram setup wizard.