### PR TITLE
fix(config): fall back to provider-level contextWindow/maxTokens in model defaults

### DIFF
--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -219,26 +219,22 @@ export function applyModelDefaults(
           modelMutated = true;
         }
 
+        const providerContextWindow = isPositiveNumber(normalizedProvider.contextWindow)
+          ? normalizedProvider.contextWindow
+          : DEFAULT_CONTEXT_TOKENS;
         const contextWindow = isPositiveNumber(raw.contextWindow)
           ? raw.contextWindow
-          : isPositiveNumber(normalizedProvider.contextWindow)
-            ? normalizedProvider.contextWindow
-            : DEFAULT_CONTEXT_TOKENS;
+          : providerContextWindow;
         if (raw.contextWindow !== contextWindow) {
           modelMutated = true;
         }
 
-        const defaultMaxTokens = Math.min(
-          isPositiveNumber(normalizedProvider.maxTokens)
-            ? normalizedProvider.maxTokens
-            : DEFAULT_MODEL_MAX_TOKENS,
-          contextWindow,
-        );
+        const providerMaxTokens = isPositiveNumber(normalizedProvider.maxTokens)
+          ? normalizedProvider.maxTokens
+          : DEFAULT_MODEL_MAX_TOKENS;
         const rawMaxTokens = isPositiveNumber(raw.maxTokens)
           ? raw.maxTokens
-          : isPositiveNumber(normalizedProvider.maxTokens)
-            ? normalizedProvider.maxTokens
-            : defaultMaxTokens;
+          : providerMaxTokens;
         const maxTokens = resolveNormalizedProviderModelMaxTokens({
           providerId,
           modelId: id,

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -221,13 +221,24 @@ export function applyModelDefaults(
 
         const contextWindow = isPositiveNumber(raw.contextWindow)
           ? raw.contextWindow
-          : DEFAULT_CONTEXT_TOKENS;
+          : isPositiveNumber(normalizedProvider.contextWindow)
+            ? normalizedProvider.contextWindow
+            : DEFAULT_CONTEXT_TOKENS;
         if (raw.contextWindow !== contextWindow) {
           modelMutated = true;
         }
 
-        const defaultMaxTokens = Math.min(DEFAULT_MODEL_MAX_TOKENS, contextWindow);
-        const rawMaxTokens = isPositiveNumber(raw.maxTokens) ? raw.maxTokens : defaultMaxTokens;
+        const defaultMaxTokens = Math.min(
+          isPositiveNumber(normalizedProvider.maxTokens)
+            ? normalizedProvider.maxTokens
+            : DEFAULT_MODEL_MAX_TOKENS,
+          contextWindow,
+        );
+        const rawMaxTokens = isPositiveNumber(raw.maxTokens)
+          ? raw.maxTokens
+          : isPositiveNumber(normalizedProvider.maxTokens)
+            ? normalizedProvider.maxTokens
+            : defaultMaxTokens;
         const maxTokens = resolveNormalizedProviderModelMaxTokens({
           providerId,
           modelId: id,

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -232,9 +232,7 @@ export function applyModelDefaults(
         const providerMaxTokens = isPositiveNumber(normalizedProvider.maxTokens)
           ? normalizedProvider.maxTokens
           : DEFAULT_MODEL_MAX_TOKENS;
-        const rawMaxTokens = isPositiveNumber(raw.maxTokens)
-          ? raw.maxTokens
-          : providerMaxTokens;
+        const rawMaxTokens = isPositiveNumber(raw.maxTokens) ? raw.maxTokens : providerMaxTokens;
         const maxTokens = resolveNormalizedProviderModelMaxTokens({
           providerId,
           modelId: id,

--- a/src/config/model-alias-defaults.test.ts
+++ b/src/config/model-alias-defaults.test.ts
@@ -429,6 +429,63 @@ describe("applyModelDefaults", () => {
     expect(model?.maxTokens).toBe(8192);
   });
 
+  it("inherits provider-level contextWindow and maxTokens", () => {
+    const cfg = buildProxyProviderConfig();
+    const provider = cfg.models.providers.myproxy;
+    Object.assign(provider, { contextWindow: 50_000, maxTokens: 4096 });
+    const modelConfig = provider.models[0] as { contextWindow?: number; maxTokens?: number };
+    delete modelConfig.contextWindow;
+    delete modelConfig.maxTokens;
+
+    const next = applyModelDefaults(cfg);
+    const model = next.models?.providers?.myproxy?.models?.[0];
+
+    expect(model?.contextWindow).toBe(50_000);
+    expect(model?.maxTokens).toBe(4096);
+  });
+
+  it("keeps per-model token limits above provider defaults", () => {
+    const cfg = buildProxyProviderConfig({ contextWindow: 32_768, maxTokens: 2048 });
+    const provider = cfg.models.providers.myproxy;
+    Object.assign(provider, { contextWindow: 50_000, maxTokens: 4096 });
+
+    const next = applyModelDefaults(cfg);
+    const model = next.models?.providers?.myproxy?.models?.[0];
+
+    expect(model?.contextWindow).toBe(32_768);
+    expect(model?.maxTokens).toBe(2048);
+  });
+
+  it("clamps inherited provider maxTokens to the inherited contextWindow", () => {
+    const cfg = buildProxyProviderConfig();
+    const provider = cfg.models.providers.myproxy;
+    Object.assign(provider, { contextWindow: 4096, maxTokens: 8192 });
+    const modelConfig = provider.models[0] as { contextWindow?: number; maxTokens?: number };
+    delete modelConfig.contextWindow;
+    delete modelConfig.maxTokens;
+
+    const next = applyModelDefaults(cfg);
+    const model = next.models?.providers?.myproxy?.models?.[0];
+
+    expect(model?.contextWindow).toBe(4096);
+    expect(model?.maxTokens).toBe(4096);
+  });
+
+  it("ignores invalid provider-level token defaults", () => {
+    const cfg = buildProxyProviderConfig();
+    const provider = cfg.models.providers.myproxy;
+    Object.assign(provider, { contextWindow: 0, maxTokens: -1 });
+    const modelConfig = provider.models[0] as { contextWindow?: number; maxTokens?: number };
+    delete modelConfig.contextWindow;
+    delete modelConfig.maxTokens;
+
+    const next = applyModelDefaults(cfg);
+    const model = next.models?.providers?.myproxy?.models?.[0];
+
+    expect(model?.contextWindow).toBe(DEFAULT_CONTEXT_TOKENS);
+    expect(model?.maxTokens).toBe(8192);
+  });
+
   it("clamps maxTokens to contextWindow", () => {
     const cfg = buildProxyProviderConfig({ contextWindow: 32768, maxTokens: 40960 });
 
@@ -447,6 +504,21 @@ describe("applyModelDefaults", () => {
 
     expect(model?.contextWindow).toBe(262144);
     expect(model?.maxTokens).toBe(16384);
+  });
+
+  it("normalizes inherited mistral maxTokens that match the full context window", () => {
+    const cfg = buildMistralProviderConfig();
+    const provider = cfg.models.providers.mistral;
+    Object.assign(provider, { contextWindow: 262_144, maxTokens: 262_144 });
+    const modelConfig = provider.models[0] as { contextWindow?: number; maxTokens?: number };
+    delete modelConfig.contextWindow;
+    delete modelConfig.maxTokens;
+
+    const next = applyModelDefaults(cfg);
+    const model = next.models?.providers?.mistral?.models?.[0];
+
+    expect(model?.contextWindow).toBe(262_144);
+    expect(model?.maxTokens).toBe(16_384);
   });
 
   it("propagates a provider policy api default to models", () => {


### PR DESCRIPTION
Closes #105803

## What Problem This Solves

Fixes an issue where users configuring `contextWindow` or `maxTokens` once at the provider level would see static configured models ignore those values and fall back to global defaults unless every model repeated them.

## Why This Change Was Made

The static config materialization path now uses the same precedence as the discovered-model path: per-model value, then provider-level value, then the global default. Existing output-token clamping and Mistral safety normalization remain in the canonical defaulting path.

## User Impact

Users can define shared token limits once under `models.providers.<provider>`. Explicit per-model values still win, invalid provider-level values still fall back safely, and `maxTokens` cannot exceed the effective context window.

## Evidence

### Real behavior proof

- **Behavior or issue addressed:** provider-level `contextWindow` and `maxTokens` were ignored during a real static config load.
- **Real environment tested:** secretless GitHub Actions runner, Ubuntu 24.04, Node 24, patch head `4a44a1d0494cca70c293e7476490fb911c8e5849` plus a temporary proof-only workflow commit. The proof branch was deleted after the run. The current branch is a semantic-equivalent rebase onto upstream main at `ce653addc81a6dfdd74e71efd38151e9c5d9b2e4`.
- **Exact steps or command run:** wrote an isolated `openclaw.json`, set `OPENCLAW_CONFIG_PATH` and `OPENCLAW_STATE_DIR`, then ran `node --import tsx --input-type=module` and called `loadConfig({ pin: false, skipPluginValidation: true, skipShellEnvFallback: true })`.
- **Evidence after fix:** Terminal capture from the successful `node` config-load run: https://github.com/zhanxingxin1998/openclaw/actions/runs/29501001707

```json
{
  "providerInheritanceAndClamp": {
    "contextWindow": 50000,
    "maxTokens": 50000
  },
  "perModelPrecedence": {
    "contextWindow": 32000,
    "maxTokens": 2000
  },
  "mistralSafetyNormalization": {
    "contextWindow": 262144,
    "maxTokens": 16384
  }
}
```

- **Observed result after fix:** provider-only values survive the actual config-loading path, inherited output tokens are clamped to the inherited context window, explicit model values take precedence, and Mistral's safe output cap still applies.
- **What was not tested:** a live provider API request or long-running Gateway session; this change only materializes numeric model limits and does not alter provider transport behavior.

### Regression coverage

Focused tests in `src/config/model-alias-defaults.test.ts` cover:

- provider-level inheritance;
- per-model precedence;
- inherited `maxTokens` clamping;
- invalid provider-level fallback;
- inherited Mistral safety normalization.

All checks on the current exact head `ce653addc81a6dfdd74e71efd38151e9c5d9b2e4` are green: 64 successful, 35 skipped, and 1 neutral check with no failures, including `check-lint`, production/test type checks, `build-artifacts`, CodeQL config-boundary review, the Real behavior proof gate, and all selected test shards.

### Compatibility note

Existing configurations that already set provider-level values will begin honoring them for models without explicit overrides. This is the intended behavior described by the public config surface and #105803; per-model settings remain authoritative.

### Alternative considered

#105807 changes the same canonical `applyModelDefaults` boundary and additionally propagates provider-level `contextTokens`. This PR intentionally limits the compatibility change to the two fields reported and reproduced by #105803, while covering invalid provider values and inherited Mistral normalization. Maintainers can choose the broader candidate if `contextTokens` should be activated in the same release; only one implementation should land.
