### PR TITLE
fix(ui): add keyboard navigation to theme mode toggle

### DIFF
--- a/ui/src/components/theme-mode-toggle.ts
+++ b/ui/src/components/theme-mode-toggle.ts
@@ -57,6 +57,16 @@ export class ThemeModeToggle extends LitElement {
     const direction = event.key === "ArrowRight" ? "next" : "prev";
     const nextMode = getNextMode(this.mode, direction);
     this.handleModeChange(nextMode, event);
+
+    // Focus the newly selected button after mode change
+    requestAnimationFrame(() => {
+      const buttons = this.querySelectorAll<HTMLButtonElement>(".topbar-theme-mode__btn");
+      const options: ThemeMode[] = ["system", "light", "dark"];
+      const nextIndex = options.indexOf(nextMode);
+      if (nextIndex >= 0 && buttons[nextIndex]) {
+        buttons[nextIndex].focus();
+      }
+    });
   };
 
   override render() {

--- a/ui/src/components/theme-mode-toggle.ts
+++ b/ui/src/components/theme-mode-toggle.ts
@@ -10,6 +10,20 @@ export type ThemeModeChangeDetail = {
   element: HTMLElement;
 };
 
+const MODE_ORDER: ThemeMode[] = ["system", "light", "dark"];
+
+function getNextMode(current: ThemeMode, direction: "next" | "prev"): ThemeMode {
+  const currentIndex = MODE_ORDER.indexOf(current);
+  if (currentIndex === -1) {
+    return MODE_ORDER[0];
+  }
+  const nextIndex =
+    direction === "next"
+      ? (currentIndex + 1) % MODE_ORDER.length
+      : (currentIndex - 1 + MODE_ORDER.length) % MODE_ORDER.length;
+  return MODE_ORDER[nextIndex];
+}
+
 export class ThemeModeToggle extends LitElement {
   override createRenderRoot() {
     return this;
@@ -35,34 +49,47 @@ export class ThemeModeToggle extends LitElement {
     );
   };
 
+  private readonly handleKeyDown = (event: KeyboardEvent) => {
+    if (event.key !== "ArrowLeft" && event.key !== "ArrowRight") {
+      return;
+    }
+    event.preventDefault();
+    const direction = event.key === "ArrowRight" ? "next" : "prev";
+    const nextMode = getNextMode(this.mode, direction);
+    this.handleModeChange(nextMode, event);
+  };
+
   override render() {
-    const options: Array<{ id: ThemeMode; labelKey: string }> = [
-      { id: "system", labelKey: "common.system" },
-      { id: "light", labelKey: "common.light" },
-      { id: "dark", labelKey: "common.dark" },
+    const options: Array<{ id: ThemeMode; labelKey: string; icon: string }> = [
+      { id: "system", labelKey: "common.system", icon: icons.monitor },
+      { id: "light", labelKey: "common.light", icon: icons.sun },
+      { id: "dark", labelKey: "common.dark", icon: icons.moon },
     ];
 
+    const activeIndex = options.findIndex((option) => option.id === this.mode);
+
     return html`
-      <div class="topbar-theme-mode" role="group" aria-label=${t("common.colorMode")}>
-        ${options.map((option) => {
+      <div
+        class="topbar-theme-mode"
+        role="group"
+        aria-label=${t("common.colorMode")}
+        @keydown=${this.handleKeyDown}
+      >
+        ${options.map((option, index) => {
           const label = t(option.labelKey);
           const tooltip = t("common.colorModeOption", { mode: label });
+          const isActive = option.id === this.mode;
           return html`
             <openclaw-tooltip .content=${tooltip}>
               <button
                 type="button"
-                class="topbar-theme-mode__btn ${option.id === this.mode
-                  ? "topbar-theme-mode__btn--active"
-                  : ""}"
+                class="topbar-theme-mode__btn ${isActive ? "topbar-theme-mode__btn--active" : ""}"
                 aria-label=${tooltip}
-                aria-pressed=${option.id === this.mode}
+                aria-pressed=${isActive}
+                tabindex=${index === activeIndex ? "0" : "-1"}
                 @click=${(event: Event) => this.handleModeChange(option.id, event)}
               >
-                ${option.id === "system"
-                  ? icons.monitor
-                  : option.id === "light"
-                    ? icons.sun
-                    : icons.moon}
+                ${option.icon}
               </button>
             </openclaw-tooltip>
           `;


### PR DESCRIPTION
<!--
Optional linked context:
Related: UI accessibility improvements for theme switching
-->

## What Problem This Solves

Fixes an accessibility issue where keyboard-only users cannot efficiently switch between theme modes (system, light, dark) using the theme mode toggle in the topbar. Currently, users must tab through all three buttons individually and press Enter/Space for each one, which is cumbersome and doesn't follow standard radio group interaction patterns.

## Why This Change Was Made

The theme mode toggle functions as a radio group (mutually exclusive options), but lacked proper keyboard navigation. This improvement adds:

1. **Arrow key navigation**: Users can press ArrowRight/ArrowLeft to cycle through theme modes, following WAI-ARIA radio group best practices
2. **Roving tabindex**: Only the active button is in the tab order (tabindex="0"), while inactive buttons have tabindex="-1". This allows users to tab directly to the selected option and use arrows to switch
3. **Clean mode cycling logic**: The `getNextMode` helper handles wrapping from the last mode back to the first (and vice versa), ensuring smooth cycling

The key insight is that theme mode selection is a radio group interaction, not three independent buttons. Standard radio group patterns dictate arrow key navigation with roving tabindex.

## User Impact

- **Better keyboard accessibility**: Keyboard users can now switch themes with a single tab to reach the control, then arrow keys to cycle through options
- **Faster theme switching**: No need to tab through all three buttons; one tab + arrow keys is all that's needed
- **Consistent with platform conventions**: Follows standard radio group interaction patterns that users expect
- **Screen reader friendly**: The roving tabindex pattern is well-supported by assistive technologies

## Evidence

The implementation follows WAI-ARIA Authoring Practices for radio groups:
- Arrow keys cycle through options
- Only the selected option is in the tab order
- The group has `role="group"` with an `aria-label`

Key code changes:
- `handleKeyDown` captures ArrowLeft/ArrowRight and cycles modes
- `getNextMode` handles circular navigation (dark → system → light → dark)
- `tabindex` is dynamically set based on active state
- Icons are pre-computed in the options array for cleaner rendering

Before: Tab → Tab → Tab (through all 3 buttons) → Enter (to activate)
After: Tab (to active button) → ArrowRight/ArrowLeft (to cycle)

This is a standard accessibility pattern that significantly improves the experience for keyboard and assistive technology users.
