### PR TITLE
fix(plugins): fully roll back failed registrations

### DIFF
--- a/src/plugins/loader-channel-runtime.ts
+++ b/src/plugins/loader-channel-runtime.ts
@@ -247,7 +247,10 @@ export function loadSetupRuntimeChannelCandidate(params: {
     }
   }
   if (registrationPlan.mode === "setup-runtime" && mergedSetupRegistration.registerSetupRuntime) {
-    const transaction = createPluginRegistrationTransaction({ registry: registryBuilder.registry });
+    const transaction = createPluginRegistrationTransaction({
+      registry: registryBuilder.registry,
+      currentRecord: record,
+    });
     try {
       runPluginRegisterSync(
         (registrationApi) => mergedSetupRegistration.registerSetupRuntime?.(registrationApi),

--- a/src/plugins/loader-cli-registry.ts
+++ b/src/plugins/loader-cli-registry.ts
@@ -321,7 +321,7 @@ export async function loadOpenClawPluginCliRegistry(
         registerCli: (registrar, opts) => registerCli(record, registrar, opts),
       },
     });
-    const transaction = createPluginRegistrationTransaction({ registry });
+    const transaction = createPluginRegistrationTransaction({ registry, currentRecord: record });
     try {
       withProfile({ pluginId: record.id, source: record.source }, "cli-metadata:register", () =>
         runPluginRegisterSync(register, api),

--- a/src/plugins/loader-runtime-candidate.ts
+++ b/src/plugins/loader-runtime-candidate.ts
@@ -491,6 +491,7 @@ export function loadRuntimePluginCandidate(params: {
   });
   const transaction = createPluginRegistrationTransaction({
     registry,
+    currentRecord: record,
     rollbackGlobalSideEffects: () =>
       params.registryBuilder.rollbackPluginGlobalSideEffects(record.id),
   });

--- a/src/plugins/plugin-graceful-init-failure.test.ts
+++ b/src/plugins/plugin-graceful-init-failure.test.ts
@@ -137,6 +137,40 @@ describe("graceful plugin initialization failure", () => {
     expect(failed.failedAt?.getTime()).toBeLessThanOrEqual(after.getTime());
   });
 
+  it("rolls back partial metadata without breaking an earlier class-backed service", async () => {
+    const stable = writePlugin({
+      id: "a-stable-service-plugin",
+      body: `class StableService {
+        constructor() { this.id = "stable-service"; }
+        start() {}
+        ping() { return "still-alive"; }
+      }
+      module.exports = { id: "a-stable-service-plugin", register(api) {
+        api.registerService(new StableService());
+      } };`,
+    });
+    const failing = writePlugin({
+      id: "z-partial-register-failure",
+      body: `module.exports = { id: "z-partial-register-failure", register(api) {
+        api.registerService({ id: "failed-service", start() {} });
+        api.registerHttpRoute({ path: "/failed", auth: "plugin", handler: async () => true });
+        throw new Error("fail after partial registration");
+      } };`,
+    });
+
+    const registry = await loadPlugins([stable.file, failing.file]);
+    const failed = requirePluginEntry(registry, "z-partial-register-failure");
+    const stableService = registry.services.find((entry) => entry.service.id === "stable-service")
+      ?.service as { ping?: () => string } | undefined;
+
+    expect(failed.status).toBe("error");
+    expect(failed.services).toEqual([]);
+    expect(failed.httpRoutes).toBe(0);
+    expect(registry.services.map((entry) => entry.service.id)).toEqual(["stable-service"]);
+    expect(registry.httpRoutes).toEqual([]);
+    expect(stableService?.ping?.()).toBe("still-alive");
+  });
+
   it("records validation failures before register", async () => {
     const plugin = writePlugin({
       id: "missing-register",

--- a/src/plugins/plugin-registration-transaction.test.ts
+++ b/src/plugins/plugin-registration-transaction.test.ts
@@ -10,6 +10,8 @@ import {
   snapshotPluginProcessGlobalState,
 } from "./plugin-registration-transaction.js";
 import { createEmptyPluginRegistry } from "./registry-empty.js";
+import { createPluginRecord } from "./status.test-helpers.js";
+import type { WorkerProvider } from "./types.js";
 
 describe("plugin registration transaction", () => {
   let initialProcessGlobalState: PluginProcessGlobalState;
@@ -50,6 +52,59 @@ describe("plugin registration transaction", () => {
       pluginId: "active-memory",
       capability: { promptBuilder: activePromptBuilder },
     });
+  });
+
+  it("restores current record metadata mutated before the record enters the registry", () => {
+    const registry = createEmptyPluginRegistry();
+    const record = createPluginRecord({ id: "failed-plugin" });
+    const transaction = createPluginRegistrationTransaction({ registry, currentRecord: record });
+
+    record.providerIds.push("failed-provider");
+    record.httpRoutes += 1;
+    record.error = "partial failure";
+
+    transaction.rollback();
+
+    expect(record.providerIds).toEqual([]);
+    expect(record.httpRoutes).toBe(0);
+    expect(record).not.toHaveProperty("error");
+  });
+
+  it("restores mutable registration metadata while preserving plugin-owned callbacks", () => {
+    const registry = createEmptyPluginRegistry();
+    const rawHandler = async () => undefined;
+    const workerProvider: WorkerProvider = {
+      id: "worker",
+      provision: async () => {
+        throw new Error("not called");
+      },
+      inspect: async () => ({ status: "unknown" }),
+      destroy: async () => {},
+    };
+    registry.agentToolResultMiddlewares.push({
+      pluginId: "existing-plugin",
+      handler: rawHandler,
+      rawHandler,
+      runtimes: ["openclaw"],
+      source: "test",
+    });
+    registry.workerProviders.set("worker", {
+      pluginId: "existing-plugin",
+      pluginName: "Existing",
+      provider: workerProvider,
+      source: "test",
+    });
+    const transaction = createPluginRegistrationTransaction({ registry });
+
+    registry.agentToolResultMiddlewares[0]!.runtimes.push("codex");
+    registry.workerProviders.get("worker")!.pluginName = "Mutated";
+
+    transaction.rollback();
+
+    expect(registry.agentToolResultMiddlewares[0]?.runtimes).toEqual(["openclaw"]);
+    expect(registry.agentToolResultMiddlewares[0]?.rawHandler).toBe(rawHandler);
+    expect(registry.workerProviders.get("worker")?.pluginName).toBe("Existing");
+    expect(registry.workerProviders.get("worker")?.provider).toBe(workerProvider);
   });
 
   it("keeps snapshot registry writes while restoring globals for non-activating commits", () => {

--- a/src/plugins/plugin-registration-transaction.ts
+++ b/src/plugins/plugin-registration-transaction.ts
@@ -30,7 +30,7 @@ import {
   listMemoryPromptSupplements,
   restoreMemoryPluginState,
 } from "./memory-state.js";
-import type { PluginRegistry } from "./registry-types.js";
+import type { PluginRecord, PluginRegistry } from "./registry-types.js";
 
 export type PluginProcessGlobalState = {
   agentHarnesses: ReturnType<typeof listRegisteredAgentHarnesses>;
@@ -75,32 +75,70 @@ export function restorePluginProcessGlobalState(state: PluginProcessGlobalState)
   });
 }
 
-function snapshotPluginRegistry(registry: PluginRegistry): PluginRegistry {
-  return Object.fromEntries(
-    Object.entries(registry).map(([key, value]) => {
-      if (Array.isArray(value)) {
-        // Clone the array and each plain-object element so mutations to
-        // individual record properties are isolated from the snapshot.
-        return [
-          key,
-          value.map((item) =>
-            item && typeof item === "object" && !Array.isArray(item) ? { ...item } : item,
-          ),
-        ];
-      }
-      if (value instanceof Map) {
-        return [key, new Map(value)];
-      }
-      if (value && typeof value === "object") {
-        return [key, { ...value }];
-      }
-      return [key, value];
-    }),
-  ) as PluginRegistry;
+function cloneRegistrationEnvelope<T>(value: T): T {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return value;
+  }
+  // Registration envelopes own their metadata arrays and dates. Nested plugin runtime
+  // objects and callbacks keep their identity because the transaction does not own them.
+  const clone = { ...value } as Record<string, unknown>;
+  for (const [key, field] of Object.entries(clone)) {
+    if (Array.isArray(field)) {
+      clone[key] = [...field];
+    } else if (field instanceof Date) {
+      clone[key] = new Date(field);
+    }
+  }
+  return clone as T;
 }
 
-function restorePluginRegistry(registry: PluginRegistry, snapshot: PluginRegistry): void {
-  Object.assign(registry, snapshot);
+type PluginRegistrySnapshot = {
+  registry: PluginRegistry;
+  currentRecord?: PluginRecord;
+};
+
+function snapshotPluginRegistry(
+  registry: PluginRegistry,
+  currentRecord?: PluginRecord,
+): PluginRegistrySnapshot {
+  return {
+    registry: Object.fromEntries(
+      Object.entries(registry).map(([key, value]) => {
+        if (Array.isArray(value)) {
+          return [key, value.map((entry) => cloneRegistrationEnvelope(entry))];
+        }
+        if (value instanceof Map) {
+          return [
+            key,
+            new Map(
+              [...value].map(([entryKey, entry]) => [entryKey, cloneRegistrationEnvelope(entry)]),
+            ),
+          ];
+        }
+        if (value && typeof value === "object") {
+          return [key, cloneRegistrationEnvelope(value)];
+        }
+        return [key, value];
+      }),
+    ) as PluginRegistry,
+    currentRecord: currentRecord ? cloneRegistrationEnvelope(currentRecord) : undefined,
+  };
+}
+
+function restorePluginRegistry(
+  registry: PluginRegistry,
+  snapshot: PluginRegistrySnapshot,
+  currentRecord?: PluginRecord,
+): void {
+  if (currentRecord && snapshot.currentRecord) {
+    // Registration mutates this record before registry.plugins owns it; restore the same
+    // object so the subsequent error entry reports only committed metadata.
+    for (const key of Object.keys(currentRecord)) {
+      Reflect.deleteProperty(currentRecord, key);
+    }
+    Object.assign(currentRecord, snapshot.currentRecord);
+  }
+  Object.assign(registry, snapshot.registry);
 }
 
 type PluginRegistrationTransaction = {
@@ -110,9 +148,11 @@ type PluginRegistrationTransaction = {
 
 export function createPluginRegistrationTransaction(params: {
   registry: PluginRegistry;
+  /** Record mutated by register() before registry.plugins owns it. */
+  currentRecord?: PluginRecord;
   rollbackGlobalSideEffects?: () => void;
 }): PluginRegistrationTransaction {
-  const registrySnapshot = snapshotPluginRegistry(params.registry);
+  const registrySnapshot = snapshotPluginRegistry(params.registry, params.currentRecord);
   const processGlobalState = snapshotPluginProcessGlobalState();
   let settled = false;
 
@@ -135,7 +175,7 @@ export function createPluginRegistrationTransaction(params: {
     rollback: () => {
       settle(() => {
         params.rollbackGlobalSideEffects?.();
-        restorePluginRegistry(params.registry, registrySnapshot);
+        restorePluginRegistry(params.registry, registrySnapshot, params.currentRecord);
         restorePluginProcessGlobalState(processGlobalState);
       });
     },

--- a/src/plugins/plugin-registration-transaction.ts
+++ b/src/plugins/plugin-registration-transaction.ts
@@ -79,7 +79,14 @@ function snapshotPluginRegistry(registry: PluginRegistry): PluginRegistry {
   return Object.fromEntries(
     Object.entries(registry).map(([key, value]) => {
       if (Array.isArray(value)) {
-        return [key, [...value]];
+        // Clone the array and each plain-object element so mutations to
+        // individual record properties are isolated from the snapshot.
+        return [
+          key,
+          value.map((item) =>
+            item && typeof item === "object" && !Array.isArray(item) ? { ...item } : item,
+          ),
+        ];
       }
       if (value instanceof Map) {
         return [key, new Map(value)];


### PR DESCRIPTION
Closes #106647

## What Problem This Solves

Fixes an issue where a plugin that throws during registration can still publish partial metadata on its error record, such as registered service IDs and HTTP route counters. The transaction previously snapshotted only objects already inside the registry, while the active `PluginRecord` is mutated before it is inserted into `registry.plugins`; nested registration-envelope metadata could also remain shared with the live registry.

## Why This Change Was Made

The registration transaction is the single owner for rollback across full runtime, setup-runtime channel, and CLI-metadata loading. It now snapshots the active record plus transaction-owned envelope metadata (arrays, dates, and Map values) while deliberately preserving handler, service, provider, and other plugin-owned runtime object identities.

A whole-registry `structuredClone` was rejected because registry entries contain functions and class-backed runtime objects. Updating every registrar to use immutable replacement was also rejected because it would spread one rollback invariant across many owners. The targeted transaction snapshot keeps the fix bounded and makes all three current-main loader callers explicit.

Related implementation history was checked: #107001 and #107541 identified the active-record gap but are closed; #107273 uses unsafe whole-registry structured cloning; #108084 clones registry-contained envelopes but does not snapshot the active record before insertion.

## User Impact

After a registration exception, operators see an error record that describes the failure without advertising capabilities that were rolled back. Previously loaded class-backed services and callbacks remain usable, and successful registration behavior is unchanged.

## Real behavior proof

- **Behavior addressed:** A plugin that registers a service and HTTP route before throwing leaves those capability IDs and counters on its failed registry record after rollback.
- **Real environment tested:** Linux x86_64, Node v24.15.0, current head `f70b5bb5e5c` on branch `fix/plugin-snapshot-deep-clone-106647`; the copied runtime transcript was run on patch-identical head `ab4edadbe32` before the final main refresh.
- **Exact steps or command run after this patch:** `OPENCLAW_SOURCE_ROOT="$PWD" node --import tsx /tmp/verify-plugin-rollback.mjs` - directly imports the production plugin loader, loads a class-backed service plugin, then loads a second filesystem plugin that registers a service and route before throwing.
- **Evidence after fix:** Terminal capture of `node` runtime verification (copied live stdout):

  ```text
  Before patch (origin/main):
  [FAIL] aborted record metadata restored: services=["failed-service"] httpRoutes=1
  [PASS] partial registry entries removed: services=["stable-service"] httpRoutes=0
  [PASS] prior class-backed service remains callable: ping="still-alive"
  BASE_EXIT=1

  After patch:
  [PASS] aborted record metadata restored: services=[] httpRoutes=0
  [PASS] partial registry entries removed: services=["stable-service"] httpRoutes=0
  [PASS] prior class-backed service remains callable: ping="still-alive"
  PATCH_EXIT=0
  ```

- **Observed result after fix:** The aborted plugin's error record contains no rolled-back service IDs or route count, registry collections contain only the earlier service, and that class-backed service still executes its prototype method.
- **What was not tested:** A packaged Gateway restart with a third-party installed plugin and non-Linux platforms were not exercised locally; PR CI covers the repository build, type, platform, and merge-tree gates.

## Tests and validation

```text
$ node scripts/run-vitest.mjs src/plugins/plugin-registration-transaction.test.ts
Test Files  1 passed (1)
Tests       4 passed (4)

$ node scripts/run-vitest.mjs src/plugins/plugin-graceful-init-failure.test.ts
Test Files  1 passed (1)
Tests       6 passed (6)

$ node scripts/run-vitest.mjs src/agents/harness/selection.test.ts
Test Files  1 passed (1)
Tests       99 passed (99)

$ node scripts/run-vitest.mjs src/state/openclaw-state-db.test.ts
Test Files  1 passed (1)
Tests       75 passed (75)

$ node scripts/run-vitest.mjs src/gateway/server-methods-list.test.ts
Test Files  1 passed (1)
Tests       16 passed (16)

$ oxfmt --check <six changed files>
All matched files use the correct format.

$ oxlint --deny-warnings <six changed files>
EXIT=0

$ git diff --check
EXIT=0
```

The first two files cover the transaction invariant and the real loader failure path. The final three are the exact files that failed on the previous 340-commit-old CI baseline; they pass after rebasing onto current `main`.

## Risk checklist

- User-visible behavior: Yes - failed plugin records no longer retain capabilities that rollback removed; successful registrations are unchanged.
- Config/env/migration behavior: No - no config, environment variable, persisted state, schema, or migration changes.
- Security/auth/secrets/network/tool execution: No - the patch changes in-memory snapshot/restore behavior only and adds no new execution or trust path.
- Plugins/providers/channels/SDK: Yes - internal plugin registration rollback changes across runtime, setup-runtime, and CLI-metadata loaders; no public Plugin SDK signature changes.
- Highest-risk area: Snapshotting enough mutable metadata without cloning or replacing plugin-owned callbacks and class instances, plus bounded startup-only copy cost.
- Mitigation: Registry-aware envelope cloning preserves nested runtime identity; unit coverage exercises arrays and Map values; direct production-loader proof verifies rollback and a prior class-backed service; the work runs only at registration boundaries, not request hot paths.

## Provenance and review

Current head after final main refresh: `f70b5bb5e5c01148fe5f4f6ad1353147a7d75605` (rebased onto the latest `origin/main`).

Provenance: clearly introduced by #104902 (`d2ad471a8c9b`, July 12, 2026), authored and merged by @vincentkoc when registration rollback was centralized. The behavior is shipped in `v2026.7.2-beta.1`.

Best-fix verdict: the transaction owner is the best bounded repair layer. Alternatives considered were whole-registry `structuredClone` (rejects functions and breaks runtime object identity) and registrar-by-registrar immutable rewrites (too broad and easy to make one-sided).

Autoreview was attempted twice with the required Codex helper; both runs reached approximately 18 minutes and ended with `codex engine failed (1)` without findings or a clean result. No Autoreview result is claimed; the source-path review, before/after runtime proof, focused tests, and PR CI remain the evidence.

## AI disclosure

AI-assisted: yes. I reviewed the implementation, source-path analysis, runtime proof, and validation results. The new commit includes an AI co-author trailer, and maintainers may edit the branch.
