### PR TITLE
fix(clickclack): stop promptly during reconnect delay

### DIFF
--- a/extensions/clickclack/src/gateway.test.ts
+++ b/extensions/clickclack/src/gateway.test.ts
@@ -573,6 +573,7 @@ describe("ClickClack gateway", () => {
       message: 'ClickClack ws message failed: {"code":"ECONNRESET","retryable":true}',
       cause: rejection,
     });
+    expect(socket.close).toHaveBeenCalledOnce();
     expect(ctx.setStatus).toHaveBeenLastCalledWith({
       accountId: "default",
       running: false,

--- a/extensions/clickclack/src/gateway.test.ts
+++ b/extensions/clickclack/src/gateway.test.ts
@@ -472,6 +472,37 @@ describe("ClickClack gateway", () => {
     await run;
   });
 
+  it("cancels the reconnect delay when the gateway aborts", async () => {
+    vi.useFakeTimers();
+    try {
+      const firstSocket = new FakeSocket();
+      const secondSocket = new FakeSocket();
+      mocks.client.websocket.mockReturnValueOnce(firstSocket).mockReturnValueOnce(secondSocket);
+      const abort = new AbortController();
+      const ctx = createGatewayContext(abort.signal);
+      const run = startClickClackGatewayAccount(ctx);
+
+      await vi.advanceTimersByTimeAsync(0);
+      expect(mocks.client.websocket).toHaveBeenCalledTimes(1);
+
+      firstSocket.emit("close");
+      await vi.advanceTimersByTimeAsync(0);
+      expect(vi.getTimerCount()).toBe(1);
+
+      abort.abort();
+      await run;
+
+      expect(vi.getTimerCount()).toBe(0);
+      expect(mocks.client.websocket).toHaveBeenCalledTimes(1);
+      expect(ctx.setStatus).toHaveBeenLastCalledWith({
+        accountId: "default",
+        running: false,
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("does not log reconnect warnings when abort closes a connecting websocket", async () => {
     const socket = new FakeSocket();
     socket.emitErrorOnClose = true;

--- a/extensions/clickclack/src/gateway.ts
+++ b/extensions/clickclack/src/gateway.ts
@@ -4,6 +4,7 @@
  */
 import type { ChannelGatewayContext } from "openclaw/plugin-sdk/channel-contract";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import { sleepWithAbort } from "openclaw/plugin-sdk/runtime-env";
 import type { RawData } from "ws";
 import { resolveClickClackInboundAccess } from "./access.js";
 import { resolveClickClackAccount } from "./accounts.js";
@@ -297,9 +298,15 @@ export async function startClickClackGatewayAccount(
         });
       });
       if (!ctx.abortSignal.aborted) {
-        await new Promise((resolve) => {
-          setTimeout(resolve, account.reconnectMs);
-        });
+        try {
+          // The gateway abort owns both the active socket and its reconnect delay;
+          // otherwise shutdown can remain pending for the full configured backoff.
+          await sleepWithAbort(account.reconnectMs, ctx.abortSignal);
+        } catch (error) {
+          if (!ctx.abortSignal.aborted) {
+            throw error;
+          }
+        }
       }
     }
   } finally {

--- a/extensions/clickclack/src/gateway.ts
+++ b/extensions/clickclack/src/gateway.ts
@@ -188,6 +188,14 @@ export async function startClickClackGatewayAccount(
     workspace: workspaceId,
     botUserId: configuredAccount.botUserId ?? me.id,
   };
+  const processIncomingEvent = (event: ClickClackEvent) =>
+    processEvent({
+      account,
+      config: ctx.cfg,
+      client,
+      event,
+      botUserId: account.botUserId,
+    });
   if (account.commandMenu) {
     await syncClickClackCommandMenu({ cfg: ctx.cfg, client, log: ctx.log });
   }
@@ -222,15 +230,7 @@ export async function startClickClackGatewayAccount(
           workspaceId,
           afterCursor,
           abortSignal: ctx.abortSignal,
-          onEvent: async (event) => {
-            await processEvent({
-              account,
-              config: ctx.cfg,
-              client,
-              event,
-              botUserId: account.botUserId,
-            });
-          },
+          onEvent: processIncomingEvent,
         });
       }
       if (ctx.abortSignal.aborted) {
@@ -240,14 +240,27 @@ export async function startClickClackGatewayAccount(
       await new Promise<void>((resolve, reject) => {
         let settled = false;
         let removeAbortListener: (() => void) | undefined;
-        const finishSocketCycle = () => {
+        const finishSocketCycle = (error?: unknown) => {
           if (settled) {
             return;
           }
           settled = true;
           removeAbortListener?.();
           removeAbortListener = undefined;
-          resolve();
+          if (error === undefined) {
+            resolve();
+            return;
+          }
+          // A failed message ends this socket's ownership. Closing it prevents
+          // the old connection from surviving beside the supervisor's restart.
+          socket.close();
+          reject(
+            error instanceof Error
+              ? error
+              : new Error(`ClickClack ws message failed: ${formatErrorMessage(error)}`, {
+                  cause: error,
+                }),
+          );
         };
         const abort = () => {
           socket.close();
@@ -265,24 +278,10 @@ export async function startClickClackGatewayAccount(
               return;
             }
             afterCursor = event.cursor || afterCursor;
-            await processEvent({
-              account,
-              config: ctx.cfg,
-              client,
-              event,
-              botUserId: account.botUserId ?? "",
-            });
-          })().catch((e: unknown) =>
-            reject(
-              e instanceof Error
-                ? e
-                : new Error(`ClickClack ws message failed: ${formatErrorMessage(e)}`, {
-                    cause: e,
-                  }),
-            ),
-          );
+            await processIncomingEvent(event);
+          })().catch(finishSocketCycle);
         });
-        socket.on("close", finishSocketCycle);
+        socket.on("close", () => finishSocketCycle());
         socket.on("error", (error) => {
           if (settled || ctx.abortSignal.aborted) {
             finishSocketCycle();


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators stopping a ClickClack gateway during its reconnect delay would wait for the full configured backoff before the account monitor stopped. With the supported configuration range, shutdown could remain pending for up to 60 seconds after the active WebSocket had already closed.

## Why This Change Was Made

The reconnect delay now uses the shared abort-aware sleep contract with the gateway's existing abort signal, while preserving the normal reconnect schedule and propagating unexpected sleep failures. The main regression risk is accidentally suppressing ordinary reconnects; the existing reconnect test remains active and the new lifecycle test verifies that only an explicit gateway abort cancels the pending delay.

## User Impact

Stopping or restarting a ClickClack account now completes promptly even when the gateway is between WebSocket connections, and its running status is cleared without waiting out the configured reconnect delay.

## Evidence

I ran the same local harness against the real exported `startClickClackGatewayAccount` on current `upstream/main` and on this branch. The only test environment was a real loopback HTTP and WebSocket server standing in for ClickClack; the gateway loop, REST client, WebSocket client, reconnect delay, abort signal, and status updates were production code.

Before the fix, aborting 100 ms after the loopback server closed the first socket still waited almost the entire 2-second reconnect delay:

```text
{
  "productionEntry": "startClickClackGatewayAccount",
  "transport": "real loopback HTTP + WebSocket",
  "reconnectMs": 2000,
  "abortSettleMs": 1931,
  "connectionCount": 1,
  "finalRunning": false,
  "result": "FAIL"
}
```

After the fix, the same production path settled immediately, did not open a second socket, and cleared running status:

```text
$ node --import tsx --no-warnings contrib/clickclack-reconnect-proof.mts
{
  "productionEntry": "startClickClackGatewayAccount",
  "transport": "real loopback HTTP + WebSocket",
  "reconnectMs": 2000,
  "abortSettleMs": 1,
  "connectionCount": 1,
  "finalRunning": false,
  "result": "PASS"
}
```

The premise was also checked directly in the shared `sleepWithAbort` implementation: abort clears its pending timer and removes its listener before rejecting, while this caller ignores that rejection only when the gateway signal is actually aborted.

Focused regression coverage, including the pre-existing normal reconnect control:

```text
$ node scripts/run-vitest.mjs extensions/clickclack/src/gateway.test.ts
Test Files  1 passed (1)
Tests       17 passed (17)
```

Scoped changed-file checks passed for both modified files, including formatting, dependency guards, extension classification, and the Plugin SDK API baseline. A live external ClickClack deployment was not used; the observed failure and fix occur entirely in the production gateway's local reconnect lifecycle after a real WebSocket disconnect.

AI-assisted: Codex helped implement and review the patch; the loopback behavior proof and focused tests above were run manually.
