### PR TITLE
fix(macos): skip post-update window for app-only updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **macOS app-only updates:** relaunch directly into the updated app without showing the post-update Gateway window when no managed Gateway update, repair, or installation is needed.
 - **Mattermost progress command details:** accept the documented `streaming.preview.commandText` and `streaming.progress.commandText` modes in channel config validation and bundled metadata. Thanks @shakkernerd.
 - **1Password authorization handoff:** persist nonce-bound pending approvals in shared plugin state so hook and tool execution across broker instances remain single-use and fail closed.
 - **Control UI chat transcripts:** preserve loaded history across session and pane returns, bound automatic backscroll loading, virtualize long transcripts, retain hidden native run boundaries, and keep prepends, streaming, and responsive layouts from flickering or jumping. Thanks @shakkernerd.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **macOS app-only updates:** relaunch directly into the updated app without showing the post-update Gateway window when no managed Gateway update, repair, or installation is needed.
 - **Mattermost progress command details:** accept the documented `streaming.preview.commandText` and `streaming.progress.commandText` modes in channel config validation and bundled metadata. Thanks @shakkernerd.
 - **1Password authorization handoff:** persist nonce-bound pending approvals in shared plugin state so hook and tool execution across broker instances remain single-use and fail closed.
 - **Control UI chat transcripts:** preserve loaded history across session and pane returns, bound automatic backscroll loading, virtualize long transcripts, retain hidden native run boundaries, and keep prepends, streaming, and responsive layouts from flickering or jumping. Thanks @shakkernerd.

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -32907,7 +32907,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 306,
+      "line": 310,
       "path": "apps/macos/Sources/OpenClaw/PostUpdate.swift",
       "source": "OpenClaw updated",
       "surface": "apple",
@@ -32915,7 +32915,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 325,
+      "line": 329,
       "path": "apps/macos/Sources/OpenClaw/PostUpdate.swift",
       "source": "Finishing your OpenClaw update",
       "surface": "apple",
@@ -32923,7 +32923,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 326,
+      "line": 330,
       "path": "apps/macos/Sources/OpenClaw/PostUpdate.swift",
       "source": "Checking the Mac app and Gateway…",
       "surface": "apple",
@@ -32931,55 +32931,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 341,
-      "path": "apps/macos/Sources/OpenClaw/PostUpdate.swift",
-      "source": "The Mac app is updated. Gateway setup is not configured on this Mac.",
-      "surface": "apple",
-      "id": "native.apple.3a2e38e488490964"
-    },
-    {
-      "kind": "ui-localized-call",
-      "line": 363,
-      "path": "apps/macos/Sources/OpenClaw/PostUpdate.swift",
-      "source": "The Gateway could not be checked.",
-      "surface": "apple",
-      "id": "native.apple.3abafcfb64b362fb"
-    },
-    {
-      "kind": "ui-localized-call-multiline",
-      "line": 365,
-      "path": "apps/macos/Sources/OpenClaw/PostUpdate.swift",
-      "source": "OpenClaw could not read the Gateway service ownership record. Retry after checking the Gateway LaunchAgent.",
-      "surface": "apple",
-      "id": "native.apple.00e3d2037782506c"
-    },
-    {
-      "kind": "ui-localized-call",
-      "line": 375,
-      "path": "apps/macos/Sources/OpenClaw/PostUpdate.swift",
-      "source": "The Mac node could not be checked.",
-      "surface": "apple",
-      "id": "native.apple.c4b8806a570dad31"
-    },
-    {
-      "kind": "ui-localized-call-multiline",
-      "line": 377,
-      "path": "apps/macos/Sources/OpenClaw/PostUpdate.swift",
-      "source": "OpenClaw could not read the node service ownership record. Retry after checking the node LaunchAgent.",
-      "surface": "apple",
-      "id": "native.apple.0483bf19d612560b"
-    },
-    {
-      "kind": "ui-localized-call-multiline",
-      "line": 412,
-      "path": "apps/macos/Sources/OpenClaw/PostUpdate.swift",
-      "source": "The Mac app is updated. Gateway \\(found) is newer than app \\(required), so OpenClaw left it unchanged.",
-      "surface": "apple",
-      "id": "native.apple.1c57b3fcc10eabe7"
-    },
-    {
-      "kind": "ui-localized-call",
-      "line": 437,
+      "line": 433,
       "path": "apps/macos/Sources/OpenClaw/PostUpdate.swift",
       "source": "Gateway recovery failed.",
       "surface": "apple",
@@ -32987,23 +32939,15 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 438,
+      "line": 434,
       "path": "apps/macos/Sources/OpenClaw/PostUpdate.swift",
       "source": "The managed OpenClaw runtime could not be reinstalled.",
       "surface": "apple",
       "id": "native.apple.91debe404bb7affc"
     },
     {
-      "kind": "ui-localized-call-multiline",
-      "line": 444,
-      "path": "apps/macos/Sources/OpenClaw/PostUpdate.swift",
-      "source": "The Mac app is updated. This Gateway is managed separately, so OpenClaw left it unchanged.",
-      "surface": "apple",
-      "id": "native.apple.3522be8112301d9f"
-    },
-    {
       "kind": "ui-localized-call",
-      "line": 453,
+      "line": 441,
       "path": "apps/macos/Sources/OpenClaw/PostUpdate.swift",
       "source": "Restarting and verifying the Gateway…",
       "surface": "apple",
@@ -33011,7 +32955,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 454,
+      "line": 442,
       "path": "apps/macos/Sources/OpenClaw/PostUpdate.swift",
       "source": "Verifying the Mac node runtime…",
       "surface": "apple",
@@ -33019,7 +32963,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 465,
+      "line": 456,
       "path": "apps/macos/Sources/OpenClaw/PostUpdate.swift",
       "source": "Letting your agent know you’re back…",
       "surface": "apple",
@@ -33027,7 +32971,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 497,
+      "line": 488,
       "path": "apps/macos/Sources/OpenClaw/PostUpdate.swift",
       "source": "Welcome back",
       "surface": "apple",
@@ -33035,7 +32979,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 499,
+      "line": 490,
       "path": "apps/macos/Sources/OpenClaw/PostUpdate.swift",
       "source": "OpenClaw \\(receipt.toVersion) and its Gateway are ready.",
       "surface": "apple",
@@ -33043,7 +32987,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 500,
+      "line": 491,
       "path": "apps/macos/Sources/OpenClaw/PostUpdate.swift",
       "source": "OpenClaw \\(receipt.toVersion) and its Mac node runtime are ready.",
       "surface": "apple",
@@ -33051,7 +32995,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 503,
+      "line": 494,
       "path": "apps/macos/Sources/OpenClaw/PostUpdate.swift",
       "source": "Your agent could not be notified yet. OpenClaw will retry after the next app launch.",
       "surface": "apple",
@@ -33059,7 +33003,7 @@
     },
     {
       "kind": "ui-localized-call-multiline",
-      "line": 507,
+      "line": 498,
       "path": "apps/macos/Sources/OpenClaw/PostUpdate.swift",
       "source": "OpenClaw could not notify your agent automatically. The app and Gateway update are complete.",
       "surface": "apple",
@@ -33067,7 +33011,7 @@
     },
     {
       "kind": "ui-localized-call-multiline",
-      "line": 513,
+      "line": 504,
       "path": "apps/macos/Sources/OpenClaw/PostUpdate.swift",
       "source": "OpenClaw could not notify your agent automatically. The app and Mac node update are complete.",
       "surface": "apple",
@@ -33075,7 +33019,7 @@
     },
     {
       "kind": "ui-localized-call-multiline",
-      "line": 520,
+      "line": 511,
       "path": "apps/macos/Sources/OpenClaw/PostUpdate.swift",
       "source": "OpenClaw could not confirm the agent notification. It will not retry, to avoid a duplicate welcome.",
       "surface": "apple",
@@ -33083,7 +33027,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 526,
+      "line": 517,
       "path": "apps/macos/Sources/OpenClaw/PostUpdate.swift",
       "source": "The remote Gateway is older than this Mac app, so OpenClaw skipped the agent notification.",
       "surface": "apple",
@@ -33091,7 +33035,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 528,
+      "line": 519,
       "path": "apps/macos/Sources/OpenClaw/PostUpdate.swift",
       "source": "The Gateway remains paused, so OpenClaw did not wake your agent.",
       "surface": "apple",
@@ -33099,7 +33043,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 556,
+      "line": 547,
       "path": "apps/macos/Sources/OpenClaw/PostUpdate.swift",
       "source": "Gateway verification failed.",
       "surface": "apple",
@@ -33107,7 +33051,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 557,
+      "line": 548,
       "path": "apps/macos/Sources/OpenClaw/PostUpdate.swift",
       "source": "The managed runtime does not match the updated Mac app.",
       "surface": "apple",
@@ -33115,7 +33059,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 563,
+      "line": 554,
       "path": "apps/macos/Sources/OpenClaw/PostUpdate.swift",
       "source": "The Mac node did not restart.",
       "surface": "apple",
@@ -33123,7 +33067,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 569,
+      "line": 560,
       "path": "apps/macos/Sources/OpenClaw/PostUpdate.swift",
       "source": "The Mac node did not become ready.",
       "surface": "apple",
@@ -33131,7 +33075,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 570,
+      "line": 561,
       "path": "apps/macos/Sources/OpenClaw/PostUpdate.swift",
       "source": "The node service restarted but did not remain running.",
       "surface": "apple",
@@ -33139,7 +33083,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 581,
+      "line": 572,
       "path": "apps/macos/Sources/OpenClaw/PostUpdate.swift",
       "source": "The Gateway did not start.",
       "surface": "apple",
@@ -33147,7 +33091,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 582,
+      "line": 573,
       "path": "apps/macos/Sources/OpenClaw/PostUpdate.swift",
       "source": "The update is installed, but Gateway health did not become ready.",
       "surface": "apple",
@@ -33155,7 +33099,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 594,
+      "line": 585,
       "path": "apps/macos/Sources/OpenClaw/PostUpdate.swift",
       "source": "The Gateway could not reconnect.",
       "surface": "apple",
@@ -33163,7 +33107,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 596,
+      "line": 587,
       "path": "apps/macos/Sources/OpenClaw/PostUpdate.swift",
       "source": "OpenClaw installed the update but could not verify the Gateway connection.",
       "surface": "apple",
@@ -33171,15 +33115,39 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 754,
+      "line": 789,
       "path": "apps/macos/Sources/OpenClaw/PostUpdate.swift",
-      "source": "Mac app updated",
+      "source": "The Gateway could not be checked.",
       "surface": "apple",
-      "id": "native.apple.8bf292892311882e"
+      "id": "native.apple.3abafcfb64b362fb"
+    },
+    {
+      "kind": "ui-localized-call-multiline",
+      "line": 791,
+      "path": "apps/macos/Sources/OpenClaw/PostUpdate.swift",
+      "source": "OpenClaw could not read the Gateway service ownership record. Retry after checking the Gateway LaunchAgent.",
+      "surface": "apple",
+      "id": "native.apple.00e3d2037782506c"
     },
     {
       "kind": "ui-localized-call",
-      "line": 761,
+      "line": 797,
+      "path": "apps/macos/Sources/OpenClaw/PostUpdate.swift",
+      "source": "The Mac node could not be checked.",
+      "surface": "apple",
+      "id": "native.apple.c4b8806a570dad31"
+    },
+    {
+      "kind": "ui-localized-call-multiline",
+      "line": 799,
+      "path": "apps/macos/Sources/OpenClaw/PostUpdate.swift",
+      "source": "OpenClaw could not read the node service ownership record. Retry after checking the node LaunchAgent.",
+      "surface": "apple",
+      "id": "native.apple.0483bf19d612560b"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 810,
       "path": "apps/macos/Sources/OpenClaw/PostUpdate.swift",
       "source": "Gateway update needs help",
       "surface": "apple",
@@ -33187,7 +33155,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 818,
+      "line": 867,
       "path": "apps/macos/Sources/OpenClaw/PostUpdate.swift",
       "source": "Update guide",
       "surface": "apple",
@@ -33195,7 +33163,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 819,
+      "line": 868,
       "path": "apps/macos/Sources/OpenClaw/PostUpdate.swift",
       "source": "Ask Discord",
       "surface": "apple",
@@ -33203,7 +33171,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 821,
+      "line": 870,
       "path": "apps/macos/Sources/OpenClaw/PostUpdate.swift",
       "source": "Retry",
       "surface": "apple",
@@ -33211,7 +33179,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 828,
+      "line": 876,
       "path": "apps/macos/Sources/OpenClaw/PostUpdate.swift",
       "source": "Continue",
       "surface": "apple",

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -32907,7 +32907,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 310,
+      "line": 311,
       "path": "apps/macos/Sources/OpenClaw/PostUpdate.swift",
       "source": "OpenClaw updated",
       "surface": "apple",
@@ -32915,7 +32915,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 329,
+      "line": 330,
       "path": "apps/macos/Sources/OpenClaw/PostUpdate.swift",
       "source": "Finishing your OpenClaw update",
       "surface": "apple",
@@ -32923,7 +32923,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 330,
+      "line": 331,
       "path": "apps/macos/Sources/OpenClaw/PostUpdate.swift",
       "source": "Checking the Mac app and Gateway…",
       "surface": "apple",
@@ -32931,7 +32931,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 433,
+      "line": 439,
       "path": "apps/macos/Sources/OpenClaw/PostUpdate.swift",
       "source": "Gateway recovery failed.",
       "surface": "apple",
@@ -32939,7 +32939,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 434,
+      "line": 440,
       "path": "apps/macos/Sources/OpenClaw/PostUpdate.swift",
       "source": "The managed OpenClaw runtime could not be reinstalled.",
       "surface": "apple",
@@ -32947,7 +32947,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 441,
+      "line": 447,
       "path": "apps/macos/Sources/OpenClaw/PostUpdate.swift",
       "source": "Restarting and verifying the Gateway…",
       "surface": "apple",
@@ -32955,7 +32955,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 442,
+      "line": 448,
       "path": "apps/macos/Sources/OpenClaw/PostUpdate.swift",
       "source": "Verifying the Mac node runtime…",
       "surface": "apple",
@@ -32963,7 +32963,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 456,
+      "line": 462,
       "path": "apps/macos/Sources/OpenClaw/PostUpdate.swift",
       "source": "Letting your agent know you’re back…",
       "surface": "apple",
@@ -32971,7 +32971,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 488,
+      "line": 494,
       "path": "apps/macos/Sources/OpenClaw/PostUpdate.swift",
       "source": "Welcome back",
       "surface": "apple",
@@ -32979,7 +32979,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 490,
+      "line": 496,
       "path": "apps/macos/Sources/OpenClaw/PostUpdate.swift",
       "source": "OpenClaw \\(receipt.toVersion) and its Gateway are ready.",
       "surface": "apple",
@@ -32987,7 +32987,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 491,
+      "line": 497,
       "path": "apps/macos/Sources/OpenClaw/PostUpdate.swift",
       "source": "OpenClaw \\(receipt.toVersion) and its Mac node runtime are ready.",
       "surface": "apple",
@@ -32995,7 +32995,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 494,
+      "line": 500,
       "path": "apps/macos/Sources/OpenClaw/PostUpdate.swift",
       "source": "Your agent could not be notified yet. OpenClaw will retry after the next app launch.",
       "surface": "apple",
@@ -33003,7 +33003,7 @@
     },
     {
       "kind": "ui-localized-call-multiline",
-      "line": 498,
+      "line": 504,
       "path": "apps/macos/Sources/OpenClaw/PostUpdate.swift",
       "source": "OpenClaw could not notify your agent automatically. The app and Gateway update are complete.",
       "surface": "apple",
@@ -33011,7 +33011,7 @@
     },
     {
       "kind": "ui-localized-call-multiline",
-      "line": 504,
+      "line": 510,
       "path": "apps/macos/Sources/OpenClaw/PostUpdate.swift",
       "source": "OpenClaw could not notify your agent automatically. The app and Mac node update are complete.",
       "surface": "apple",
@@ -33019,7 +33019,7 @@
     },
     {
       "kind": "ui-localized-call-multiline",
-      "line": 511,
+      "line": 517,
       "path": "apps/macos/Sources/OpenClaw/PostUpdate.swift",
       "source": "OpenClaw could not confirm the agent notification. It will not retry, to avoid a duplicate welcome.",
       "surface": "apple",
@@ -33027,7 +33027,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 517,
+      "line": 523,
       "path": "apps/macos/Sources/OpenClaw/PostUpdate.swift",
       "source": "The remote Gateway is older than this Mac app, so OpenClaw skipped the agent notification.",
       "surface": "apple",
@@ -33035,7 +33035,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 519,
+      "line": 525,
       "path": "apps/macos/Sources/OpenClaw/PostUpdate.swift",
       "source": "The Gateway remains paused, so OpenClaw did not wake your agent.",
       "surface": "apple",
@@ -33043,7 +33043,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 547,
+      "line": 553,
       "path": "apps/macos/Sources/OpenClaw/PostUpdate.swift",
       "source": "Gateway verification failed.",
       "surface": "apple",
@@ -33051,7 +33051,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 548,
+      "line": 554,
       "path": "apps/macos/Sources/OpenClaw/PostUpdate.swift",
       "source": "The managed runtime does not match the updated Mac app.",
       "surface": "apple",
@@ -33059,7 +33059,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 554,
+      "line": 560,
       "path": "apps/macos/Sources/OpenClaw/PostUpdate.swift",
       "source": "The Mac node did not restart.",
       "surface": "apple",
@@ -33067,7 +33067,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 560,
+      "line": 566,
       "path": "apps/macos/Sources/OpenClaw/PostUpdate.swift",
       "source": "The Mac node did not become ready.",
       "surface": "apple",
@@ -33075,7 +33075,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 561,
+      "line": 567,
       "path": "apps/macos/Sources/OpenClaw/PostUpdate.swift",
       "source": "The node service restarted but did not remain running.",
       "surface": "apple",
@@ -33083,7 +33083,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 572,
+      "line": 578,
       "path": "apps/macos/Sources/OpenClaw/PostUpdate.swift",
       "source": "The Gateway did not start.",
       "surface": "apple",
@@ -33091,7 +33091,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 573,
+      "line": 579,
       "path": "apps/macos/Sources/OpenClaw/PostUpdate.swift",
       "source": "The update is installed, but Gateway health did not become ready.",
       "surface": "apple",
@@ -33099,7 +33099,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 585,
+      "line": 591,
       "path": "apps/macos/Sources/OpenClaw/PostUpdate.swift",
       "source": "The Gateway could not reconnect.",
       "surface": "apple",
@@ -33107,7 +33107,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 587,
+      "line": 593,
       "path": "apps/macos/Sources/OpenClaw/PostUpdate.swift",
       "source": "OpenClaw installed the update but could not verify the Gateway connection.",
       "surface": "apple",
@@ -33115,7 +33115,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 789,
+      "line": 798,
       "path": "apps/macos/Sources/OpenClaw/PostUpdate.swift",
       "source": "The Gateway could not be checked.",
       "surface": "apple",
@@ -33123,7 +33123,7 @@
     },
     {
       "kind": "ui-localized-call-multiline",
-      "line": 791,
+      "line": 800,
       "path": "apps/macos/Sources/OpenClaw/PostUpdate.swift",
       "source": "OpenClaw could not read the Gateway service ownership record. Retry after checking the Gateway LaunchAgent.",
       "surface": "apple",
@@ -33131,7 +33131,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 797,
+      "line": 806,
       "path": "apps/macos/Sources/OpenClaw/PostUpdate.swift",
       "source": "The Mac node could not be checked.",
       "surface": "apple",
@@ -33139,7 +33139,7 @@
     },
     {
       "kind": "ui-localized-call-multiline",
-      "line": 799,
+      "line": 808,
       "path": "apps/macos/Sources/OpenClaw/PostUpdate.swift",
       "source": "OpenClaw could not read the node service ownership record. Retry after checking the node LaunchAgent.",
       "surface": "apple",
@@ -33147,7 +33147,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 810,
+      "line": 819,
       "path": "apps/macos/Sources/OpenClaw/PostUpdate.swift",
       "source": "Gateway update needs help",
       "surface": "apple",
@@ -33155,7 +33155,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 867,
+      "line": 876,
       "path": "apps/macos/Sources/OpenClaw/PostUpdate.swift",
       "source": "Update guide",
       "surface": "apple",
@@ -33163,7 +33163,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 868,
+      "line": 877,
       "path": "apps/macos/Sources/OpenClaw/PostUpdate.swift",
       "source": "Ask Discord",
       "surface": "apple",
@@ -33171,7 +33171,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 870,
+      "line": 879,
       "path": "apps/macos/Sources/OpenClaw/PostUpdate.swift",
       "source": "Retry",
       "surface": "apple",
@@ -33179,7 +33179,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 876,
+      "line": 885,
       "path": "apps/macos/Sources/OpenClaw/PostUpdate.swift",
       "source": "Continue",
       "surface": "apple",

--- a/apps/.i18n/native/ar.json
+++ b/apps/.i18n/native/ar.json
@@ -20584,36 +20584,6 @@
       "translated": "جارٍ التحقق من تطبيق Mac وGateway…"
     },
     {
-      "id": "native.apple.3a2e38e488490964",
-      "source": "The Mac app is updated. Gateway setup is not configured on this Mac.",
-      "translated": "تم تحديث تطبيق Mac. لم تتم تهيئة إعداد Gateway على جهاز Mac هذا."
-    },
-    {
-      "id": "native.apple.3abafcfb64b362fb",
-      "source": "The Gateway could not be checked.",
-      "translated": "تعذر التحقق من Gateway."
-    },
-    {
-      "id": "native.apple.00e3d2037782506c",
-      "source": "OpenClaw could not read the Gateway service ownership record. Retry after checking the Gateway LaunchAgent.",
-      "translated": "تعذر على OpenClaw قراءة سجل ملكية خدمة Gateway. أعد المحاولة بعد التحقق من Gateway LaunchAgent."
-    },
-    {
-      "id": "native.apple.c4b8806a570dad31",
-      "source": "The Mac node could not be checked.",
-      "translated": "تعذر التحقق من عقدة Mac."
-    },
-    {
-      "id": "native.apple.0483bf19d612560b",
-      "source": "OpenClaw could not read the node service ownership record. Retry after checking the node LaunchAgent.",
-      "translated": "تعذر على OpenClaw قراءة سجل ملكية خدمة العقدة. أعد المحاولة بعد التحقق من node LaunchAgent."
-    },
-    {
-      "id": "native.apple.1c57b3fcc10eabe7",
-      "source": "The Mac app is updated. Gateway \\(found) is newer than app \\(required), so OpenClaw left it unchanged.",
-      "translated": "تم تحديث تطبيق Mac. إصدار Gateway \\(found) أحدث من إصدار التطبيق \\(required)، لذا تركه OpenClaw دون تغيير."
-    },
-    {
       "id": "native.apple.e9b1899627402a15",
       "source": "Gateway recovery failed.",
       "translated": "فشل استرداد Gateway."
@@ -20622,11 +20592,6 @@
       "id": "native.apple.91debe404bb7affc",
       "source": "The managed OpenClaw runtime could not be reinstalled.",
       "translated": "تعذرت إعادة تثبيت بيئة تشغيل OpenClaw المُدارة."
-    },
-    {
-      "id": "native.apple.3522be8112301d9f",
-      "source": "The Mac app is updated. This Gateway is managed separately, so OpenClaw left it unchanged.",
-      "translated": "تم تحديث تطبيق Mac. تتم إدارة Gateway هذا بشكل منفصل، لذا تركه OpenClaw دون تغيير."
     },
     {
       "id": "native.apple.1cc391ec928070c4",
@@ -20734,9 +20699,24 @@
       "translated": "ثبّت OpenClaw التحديث، لكنه تعذّر عليه التحقق من اتصال Gateway."
     },
     {
-      "id": "native.apple.8bf292892311882e",
-      "source": "Mac app updated",
-      "translated": "تم تحديث تطبيق Mac"
+      "id": "native.apple.3abafcfb64b362fb",
+      "source": "The Gateway could not be checked.",
+      "translated": "تعذر التحقق من Gateway."
+    },
+    {
+      "id": "native.apple.00e3d2037782506c",
+      "source": "OpenClaw could not read the Gateway service ownership record. Retry after checking the Gateway LaunchAgent.",
+      "translated": "تعذر على OpenClaw قراءة سجل ملكية خدمة Gateway. أعد المحاولة بعد التحقق من Gateway LaunchAgent."
+    },
+    {
+      "id": "native.apple.c4b8806a570dad31",
+      "source": "The Mac node could not be checked.",
+      "translated": "تعذر التحقق من عقدة Mac."
+    },
+    {
+      "id": "native.apple.0483bf19d612560b",
+      "source": "OpenClaw could not read the node service ownership record. Retry after checking the node LaunchAgent.",
+      "translated": "تعذر على OpenClaw قراءة سجل ملكية خدمة العقدة. أعد المحاولة بعد التحقق من node LaunchAgent."
     },
     {
       "id": "native.apple.d0f712a2ed470a3e",

--- a/apps/.i18n/native/de.json
+++ b/apps/.i18n/native/de.json
@@ -20584,36 +20584,6 @@
       "translated": "Mac-App und Gateway werden überprüft…"
     },
     {
-      "id": "native.apple.3a2e38e488490964",
-      "source": "The Mac app is updated. Gateway setup is not configured on this Mac.",
-      "translated": "Die Mac-App wurde aktualisiert. Die Gateway-Einrichtung ist auf diesem Mac nicht konfiguriert."
-    },
-    {
-      "id": "native.apple.3abafcfb64b362fb",
-      "source": "The Gateway could not be checked.",
-      "translated": "Das Gateway konnte nicht überprüft werden."
-    },
-    {
-      "id": "native.apple.00e3d2037782506c",
-      "source": "OpenClaw could not read the Gateway service ownership record. Retry after checking the Gateway LaunchAgent.",
-      "translated": "OpenClaw konnte den Eigentümerschaftseintrag des Gateway-Dienstes nicht lesen. Versuchen Sie es erneut, nachdem Sie den Gateway LaunchAgent überprüft haben."
-    },
-    {
-      "id": "native.apple.c4b8806a570dad31",
-      "source": "The Mac node could not be checked.",
-      "translated": "Der Mac-Knoten konnte nicht überprüft werden."
-    },
-    {
-      "id": "native.apple.0483bf19d612560b",
-      "source": "OpenClaw could not read the node service ownership record. Retry after checking the node LaunchAgent.",
-      "translated": "OpenClaw konnte den Eigentümerschaftseintrag des Knotendienstes nicht lesen. Versuchen Sie es erneut, nachdem Sie den Knoten-LaunchAgent überprüft haben."
-    },
-    {
-      "id": "native.apple.1c57b3fcc10eabe7",
-      "source": "The Mac app is updated. Gateway \\(found) is newer than app \\(required), so OpenClaw left it unchanged.",
-      "translated": "Die Mac-App wurde aktualisiert. Gateway \\(found) ist neuer als die App-Version \\(required), daher hat OpenClaw es unverändert gelassen."
-    },
-    {
       "id": "native.apple.e9b1899627402a15",
       "source": "Gateway recovery failed.",
       "translated": "Die Gateway-Wiederherstellung ist fehlgeschlagen."
@@ -20622,11 +20592,6 @@
       "id": "native.apple.91debe404bb7affc",
       "source": "The managed OpenClaw runtime could not be reinstalled.",
       "translated": "Die verwaltete OpenClaw-Laufzeitumgebung konnte nicht neu installiert werden."
-    },
-    {
-      "id": "native.apple.3522be8112301d9f",
-      "source": "The Mac app is updated. This Gateway is managed separately, so OpenClaw left it unchanged.",
-      "translated": "Die Mac-App wurde aktualisiert. Dieses Gateway wird separat verwaltet, daher hat OpenClaw es unverändert gelassen."
     },
     {
       "id": "native.apple.1cc391ec928070c4",
@@ -20734,9 +20699,24 @@
       "translated": "OpenClaw hat das Update installiert, konnte die Gateway-Verbindung jedoch nicht überprüfen."
     },
     {
-      "id": "native.apple.8bf292892311882e",
-      "source": "Mac app updated",
-      "translated": "Mac-App aktualisiert"
+      "id": "native.apple.3abafcfb64b362fb",
+      "source": "The Gateway could not be checked.",
+      "translated": "Das Gateway konnte nicht überprüft werden."
+    },
+    {
+      "id": "native.apple.00e3d2037782506c",
+      "source": "OpenClaw could not read the Gateway service ownership record. Retry after checking the Gateway LaunchAgent.",
+      "translated": "OpenClaw konnte den Eigentümerschaftseintrag des Gateway-Dienstes nicht lesen. Versuchen Sie es erneut, nachdem Sie den Gateway LaunchAgent überprüft haben."
+    },
+    {
+      "id": "native.apple.c4b8806a570dad31",
+      "source": "The Mac node could not be checked.",
+      "translated": "Der Mac-Knoten konnte nicht überprüft werden."
+    },
+    {
+      "id": "native.apple.0483bf19d612560b",
+      "source": "OpenClaw could not read the node service ownership record. Retry after checking the node LaunchAgent.",
+      "translated": "OpenClaw konnte den Eigentümerschaftseintrag des Knotendienstes nicht lesen. Versuchen Sie es erneut, nachdem Sie den Knoten-LaunchAgent überprüft haben."
     },
     {
       "id": "native.apple.d0f712a2ed470a3e",

--- a/apps/.i18n/native/es.json
+++ b/apps/.i18n/native/es.json
@@ -20584,36 +20584,6 @@
       "translated": "Comprobando la app para Mac y Gateway…"
     },
     {
-      "id": "native.apple.3a2e38e488490964",
-      "source": "The Mac app is updated. Gateway setup is not configured on this Mac.",
-      "translated": "La app para Mac está actualizada. La configuración de Gateway no está establecida en este Mac."
-    },
-    {
-      "id": "native.apple.3abafcfb64b362fb",
-      "source": "The Gateway could not be checked.",
-      "translated": "No se pudo comprobar Gateway."
-    },
-    {
-      "id": "native.apple.00e3d2037782506c",
-      "source": "OpenClaw could not read the Gateway service ownership record. Retry after checking the Gateway LaunchAgent.",
-      "translated": "OpenClaw no pudo leer el registro de propiedad del servicio Gateway. Vuelve a intentarlo después de comprobar el LaunchAgent de Gateway."
-    },
-    {
-      "id": "native.apple.c4b8806a570dad31",
-      "source": "The Mac node could not be checked.",
-      "translated": "No se pudo comprobar el nodo Mac."
-    },
-    {
-      "id": "native.apple.0483bf19d612560b",
-      "source": "OpenClaw could not read the node service ownership record. Retry after checking the node LaunchAgent.",
-      "translated": "OpenClaw no pudo leer el registro de propiedad del servicio del nodo. Vuelve a intentarlo después de comprobar el LaunchAgent del nodo."
-    },
-    {
-      "id": "native.apple.1c57b3fcc10eabe7",
-      "source": "The Mac app is updated. Gateway \\(found) is newer than app \\(required), so OpenClaw left it unchanged.",
-      "translated": "La app para Mac está actualizada. Gateway \\(found) es más reciente que la app \\(required), por lo que OpenClaw no lo modificó."
-    },
-    {
       "id": "native.apple.e9b1899627402a15",
       "source": "Gateway recovery failed.",
       "translated": "La recuperación de Gateway falló."
@@ -20622,11 +20592,6 @@
       "id": "native.apple.91debe404bb7affc",
       "source": "The managed OpenClaw runtime could not be reinstalled.",
       "translated": "No se pudo reinstalar el entorno de ejecución administrado de OpenClaw."
-    },
-    {
-      "id": "native.apple.3522be8112301d9f",
-      "source": "The Mac app is updated. This Gateway is managed separately, so OpenClaw left it unchanged.",
-      "translated": "La app para Mac está actualizada. Este Gateway se administra por separado, por lo que OpenClaw no lo modificó."
     },
     {
       "id": "native.apple.1cc391ec928070c4",
@@ -20734,9 +20699,24 @@
       "translated": "OpenClaw instaló la actualización, pero no pudo verificar la conexión con el Gateway."
     },
     {
-      "id": "native.apple.8bf292892311882e",
-      "source": "Mac app updated",
-      "translated": "App para Mac actualizada"
+      "id": "native.apple.3abafcfb64b362fb",
+      "source": "The Gateway could not be checked.",
+      "translated": "No se pudo comprobar Gateway."
+    },
+    {
+      "id": "native.apple.00e3d2037782506c",
+      "source": "OpenClaw could not read the Gateway service ownership record. Retry after checking the Gateway LaunchAgent.",
+      "translated": "OpenClaw no pudo leer el registro de propiedad del servicio Gateway. Vuelve a intentarlo después de comprobar el LaunchAgent de Gateway."
+    },
+    {
+      "id": "native.apple.c4b8806a570dad31",
+      "source": "The Mac node could not be checked.",
+      "translated": "No se pudo comprobar el nodo Mac."
+    },
+    {
+      "id": "native.apple.0483bf19d612560b",
+      "source": "OpenClaw could not read the node service ownership record. Retry after checking the node LaunchAgent.",
+      "translated": "OpenClaw no pudo leer el registro de propiedad del servicio del nodo. Vuelve a intentarlo después de comprobar el LaunchAgent del nodo."
     },
     {
       "id": "native.apple.d0f712a2ed470a3e",

--- a/apps/.i18n/native/fa.json
+++ b/apps/.i18n/native/fa.json
@@ -20584,36 +20584,6 @@
       "translated": "در حال بررسی برنامه Mac و Gateway…"
     },
     {
-      "id": "native.apple.3a2e38e488490964",
-      "source": "The Mac app is updated. Gateway setup is not configured on this Mac.",
-      "translated": "برنامه Mac به‌روز شده است. راه‌اندازی Gateway در این Mac پیکربندی نشده است."
-    },
-    {
-      "id": "native.apple.3abafcfb64b362fb",
-      "source": "The Gateway could not be checked.",
-      "translated": "بررسی Gateway ممکن نبود."
-    },
-    {
-      "id": "native.apple.00e3d2037782506c",
-      "source": "OpenClaw could not read the Gateway service ownership record. Retry after checking the Gateway LaunchAgent.",
-      "translated": "OpenClaw نتوانست سابقه مالکیت سرویس Gateway را بخواند. پس از بررسی LaunchAgent مربوط به Gateway دوباره تلاش کنید."
-    },
-    {
-      "id": "native.apple.c4b8806a570dad31",
-      "source": "The Mac node could not be checked.",
-      "translated": "بررسی گره Mac ممکن نبود."
-    },
-    {
-      "id": "native.apple.0483bf19d612560b",
-      "source": "OpenClaw could not read the node service ownership record. Retry after checking the node LaunchAgent.",
-      "translated": "OpenClaw نتوانست سابقه مالکیت سرویس گره را بخواند. پس از بررسی LaunchAgent مربوط به گره دوباره تلاش کنید."
-    },
-    {
-      "id": "native.apple.1c57b3fcc10eabe7",
-      "source": "The Mac app is updated. Gateway \\(found) is newer than app \\(required), so OpenClaw left it unchanged.",
-      "translated": "برنامه Mac به‌روز شده است. Gateway \\(found) جدیدتر از نسخه \\(required) موردنیاز برنامه است، بنابراین OpenClaw آن را بدون تغییر باقی گذاشت."
-    },
-    {
       "id": "native.apple.e9b1899627402a15",
       "source": "Gateway recovery failed.",
       "translated": "بازیابی Gateway ناموفق بود."
@@ -20622,11 +20592,6 @@
       "id": "native.apple.91debe404bb7affc",
       "source": "The managed OpenClaw runtime could not be reinstalled.",
       "translated": "نصب مجدد محیط اجرای مدیریت‌شده OpenClaw ممکن نبود."
-    },
-    {
-      "id": "native.apple.3522be8112301d9f",
-      "source": "The Mac app is updated. This Gateway is managed separately, so OpenClaw left it unchanged.",
-      "translated": "برنامه Mac به‌روز شده است. این Gateway به‌صورت جداگانه مدیریت می‌شود، بنابراین OpenClaw آن را بدون تغییر باقی گذاشت."
     },
     {
       "id": "native.apple.1cc391ec928070c4",
@@ -20734,9 +20699,24 @@
       "translated": "OpenClaw به‌روزرسانی را نصب کرد، اما نتوانست اتصال Gateway را تأیید کند."
     },
     {
-      "id": "native.apple.8bf292892311882e",
-      "source": "Mac app updated",
-      "translated": "برنامه Mac به‌روزرسانی شد"
+      "id": "native.apple.3abafcfb64b362fb",
+      "source": "The Gateway could not be checked.",
+      "translated": "بررسی Gateway ممکن نبود."
+    },
+    {
+      "id": "native.apple.00e3d2037782506c",
+      "source": "OpenClaw could not read the Gateway service ownership record. Retry after checking the Gateway LaunchAgent.",
+      "translated": "OpenClaw نتوانست سابقه مالکیت سرویس Gateway را بخواند. پس از بررسی LaunchAgent مربوط به Gateway دوباره تلاش کنید."
+    },
+    {
+      "id": "native.apple.c4b8806a570dad31",
+      "source": "The Mac node could not be checked.",
+      "translated": "بررسی گره Mac ممکن نبود."
+    },
+    {
+      "id": "native.apple.0483bf19d612560b",
+      "source": "OpenClaw could not read the node service ownership record. Retry after checking the node LaunchAgent.",
+      "translated": "OpenClaw نتوانست سابقه مالکیت سرویس گره را بخواند. پس از بررسی LaunchAgent مربوط به گره دوباره تلاش کنید."
     },
     {
       "id": "native.apple.d0f712a2ed470a3e",

--- a/apps/.i18n/native/fr.json
+++ b/apps/.i18n/native/fr.json
@@ -20584,36 +20584,6 @@
       "translated": "Vérification de l’app Mac et du Gateway…"
     },
     {
-      "id": "native.apple.3a2e38e488490964",
-      "source": "The Mac app is updated. Gateway setup is not configured on this Mac.",
-      "translated": "L’app Mac est à jour. Le Gateway n’est pas configuré sur ce Mac."
-    },
-    {
-      "id": "native.apple.3abafcfb64b362fb",
-      "source": "The Gateway could not be checked.",
-      "translated": "Le Gateway n’a pas pu être vérifié."
-    },
-    {
-      "id": "native.apple.00e3d2037782506c",
-      "source": "OpenClaw could not read the Gateway service ownership record. Retry after checking the Gateway LaunchAgent.",
-      "translated": "OpenClaw n’a pas pu lire l’enregistrement de propriété du service Gateway. Réessayez après avoir vérifié le LaunchAgent du Gateway."
-    },
-    {
-      "id": "native.apple.c4b8806a570dad31",
-      "source": "The Mac node could not be checked.",
-      "translated": "Le nœud Mac n’a pas pu être vérifié."
-    },
-    {
-      "id": "native.apple.0483bf19d612560b",
-      "source": "OpenClaw could not read the node service ownership record. Retry after checking the node LaunchAgent.",
-      "translated": "OpenClaw n’a pas pu lire l’enregistrement de propriété du service de nœud. Réessayez après avoir vérifié le LaunchAgent du nœud."
-    },
-    {
-      "id": "native.apple.1c57b3fcc10eabe7",
-      "source": "The Mac app is updated. Gateway \\(found) is newer than app \\(required), so OpenClaw left it unchanged.",
-      "translated": "L’app Mac est à jour. Le Gateway \\(found) est plus récent que l’app \\(required), OpenClaw l’a donc laissé inchangé."
-    },
-    {
       "id": "native.apple.e9b1899627402a15",
       "source": "Gateway recovery failed.",
       "translated": "Échec de la récupération du Gateway."
@@ -20622,11 +20592,6 @@
       "id": "native.apple.91debe404bb7affc",
       "source": "The managed OpenClaw runtime could not be reinstalled.",
       "translated": "L’environnement d’exécution OpenClaw géré n’a pas pu être réinstallé."
-    },
-    {
-      "id": "native.apple.3522be8112301d9f",
-      "source": "The Mac app is updated. This Gateway is managed separately, so OpenClaw left it unchanged.",
-      "translated": "L’app Mac est à jour. Ce Gateway est géré séparément, OpenClaw l’a donc laissé inchangé."
     },
     {
       "id": "native.apple.1cc391ec928070c4",
@@ -20734,9 +20699,24 @@
       "translated": "OpenClaw a installé la mise à jour, mais n’a pas pu vérifier la connexion au Gateway."
     },
     {
-      "id": "native.apple.8bf292892311882e",
-      "source": "Mac app updated",
-      "translated": "App Mac mise à jour"
+      "id": "native.apple.3abafcfb64b362fb",
+      "source": "The Gateway could not be checked.",
+      "translated": "Le Gateway n’a pas pu être vérifié."
+    },
+    {
+      "id": "native.apple.00e3d2037782506c",
+      "source": "OpenClaw could not read the Gateway service ownership record. Retry after checking the Gateway LaunchAgent.",
+      "translated": "OpenClaw n’a pas pu lire l’enregistrement de propriété du service Gateway. Réessayez après avoir vérifié le LaunchAgent du Gateway."
+    },
+    {
+      "id": "native.apple.c4b8806a570dad31",
+      "source": "The Mac node could not be checked.",
+      "translated": "Le nœud Mac n’a pas pu être vérifié."
+    },
+    {
+      "id": "native.apple.0483bf19d612560b",
+      "source": "OpenClaw could not read the node service ownership record. Retry after checking the node LaunchAgent.",
+      "translated": "OpenClaw n’a pas pu lire l’enregistrement de propriété du service de nœud. Réessayez après avoir vérifié le LaunchAgent du nœud."
     },
     {
       "id": "native.apple.d0f712a2ed470a3e",

--- a/apps/.i18n/native/hi.json
+++ b/apps/.i18n/native/hi.json
@@ -20584,36 +20584,6 @@
       "translated": "Mac ऐप और Gateway की जाँच की जा रही है…"
     },
     {
-      "id": "native.apple.3a2e38e488490964",
-      "source": "The Mac app is updated. Gateway setup is not configured on this Mac.",
-      "translated": "Mac ऐप अपडेट हो गया है। इस Mac पर Gateway सेटअप कॉन्फ़िगर नहीं है।"
-    },
-    {
-      "id": "native.apple.3abafcfb64b362fb",
-      "source": "The Gateway could not be checked.",
-      "translated": "Gateway की जाँच नहीं की जा सकी।"
-    },
-    {
-      "id": "native.apple.00e3d2037782506c",
-      "source": "OpenClaw could not read the Gateway service ownership record. Retry after checking the Gateway LaunchAgent.",
-      "translated": "OpenClaw, Gateway सेवा के स्वामित्व का रिकॉर्ड नहीं पढ़ सका। Gateway LaunchAgent की जाँच करने के बाद फिर से प्रयास करें।"
-    },
-    {
-      "id": "native.apple.c4b8806a570dad31",
-      "source": "The Mac node could not be checked.",
-      "translated": "Mac नोड की जाँच नहीं की जा सकी।"
-    },
-    {
-      "id": "native.apple.0483bf19d612560b",
-      "source": "OpenClaw could not read the node service ownership record. Retry after checking the node LaunchAgent.",
-      "translated": "OpenClaw, नोड सेवा के स्वामित्व का रिकॉर्ड नहीं पढ़ सका। नोड LaunchAgent की जाँच करने के बाद फिर से प्रयास करें।"
-    },
-    {
-      "id": "native.apple.1c57b3fcc10eabe7",
-      "source": "The Mac app is updated. Gateway \\(found) is newer than app \\(required), so OpenClaw left it unchanged.",
-      "translated": "Mac ऐप अपडेट हो गया है। Gateway \\(found), ऐप \\(required) से नया है, इसलिए OpenClaw ने इसमें कोई बदलाव नहीं किया।"
-    },
-    {
       "id": "native.apple.e9b1899627402a15",
       "source": "Gateway recovery failed.",
       "translated": "Gateway रिकवरी विफल रही।"
@@ -20622,11 +20592,6 @@
       "id": "native.apple.91debe404bb7affc",
       "source": "The managed OpenClaw runtime could not be reinstalled.",
       "translated": "प्रबंधित OpenClaw रनटाइम को फिर से इंस्टॉल नहीं किया जा सका।"
-    },
-    {
-      "id": "native.apple.3522be8112301d9f",
-      "source": "The Mac app is updated. This Gateway is managed separately, so OpenClaw left it unchanged.",
-      "translated": "Mac ऐप अपडेट हो गया है। यह Gateway अलग से प्रबंधित होता है, इसलिए OpenClaw ने इसमें कोई बदलाव नहीं किया।"
     },
     {
       "id": "native.apple.1cc391ec928070c4",
@@ -20734,9 +20699,24 @@
       "translated": "OpenClaw ने अपडेट इंस्टॉल कर दिया, लेकिन Gateway कनेक्शन सत्यापित नहीं कर सका।"
     },
     {
-      "id": "native.apple.8bf292892311882e",
-      "source": "Mac app updated",
-      "translated": "Mac ऐप अपडेट किया गया"
+      "id": "native.apple.3abafcfb64b362fb",
+      "source": "The Gateway could not be checked.",
+      "translated": "Gateway की जाँच नहीं की जा सकी।"
+    },
+    {
+      "id": "native.apple.00e3d2037782506c",
+      "source": "OpenClaw could not read the Gateway service ownership record. Retry after checking the Gateway LaunchAgent.",
+      "translated": "OpenClaw, Gateway सेवा के स्वामित्व का रिकॉर्ड नहीं पढ़ सका। Gateway LaunchAgent की जाँच करने के बाद फिर से प्रयास करें।"
+    },
+    {
+      "id": "native.apple.c4b8806a570dad31",
+      "source": "The Mac node could not be checked.",
+      "translated": "Mac नोड की जाँच नहीं की जा सकी।"
+    },
+    {
+      "id": "native.apple.0483bf19d612560b",
+      "source": "OpenClaw could not read the node service ownership record. Retry after checking the node LaunchAgent.",
+      "translated": "OpenClaw, नोड सेवा के स्वामित्व का रिकॉर्ड नहीं पढ़ सका। नोड LaunchAgent की जाँच करने के बाद फिर से प्रयास करें।"
     },
     {
       "id": "native.apple.d0f712a2ed470a3e",

--- a/apps/.i18n/native/id.json
+++ b/apps/.i18n/native/id.json
@@ -20584,36 +20584,6 @@
       "translated": "Memeriksa aplikasi Mac dan Gateway…"
     },
     {
-      "id": "native.apple.3a2e38e488490964",
-      "source": "The Mac app is updated. Gateway setup is not configured on this Mac.",
-      "translated": "Aplikasi Mac telah diperbarui. Penyiapan Gateway belum dikonfigurasi di Mac ini."
-    },
-    {
-      "id": "native.apple.3abafcfb64b362fb",
-      "source": "The Gateway could not be checked.",
-      "translated": "Gateway tidak dapat diperiksa."
-    },
-    {
-      "id": "native.apple.00e3d2037782506c",
-      "source": "OpenClaw could not read the Gateway service ownership record. Retry after checking the Gateway LaunchAgent.",
-      "translated": "OpenClaw tidak dapat membaca catatan kepemilikan layanan Gateway. Coba lagi setelah memeriksa LaunchAgent Gateway."
-    },
-    {
-      "id": "native.apple.c4b8806a570dad31",
-      "source": "The Mac node could not be checked.",
-      "translated": "Node Mac tidak dapat diperiksa."
-    },
-    {
-      "id": "native.apple.0483bf19d612560b",
-      "source": "OpenClaw could not read the node service ownership record. Retry after checking the node LaunchAgent.",
-      "translated": "OpenClaw tidak dapat membaca catatan kepemilikan layanan node. Coba lagi setelah memeriksa LaunchAgent node."
-    },
-    {
-      "id": "native.apple.1c57b3fcc10eabe7",
-      "source": "The Mac app is updated. Gateway \\(found) is newer than app \\(required), so OpenClaw left it unchanged.",
-      "translated": "Aplikasi Mac telah diperbarui. Gateway \\(found) lebih baru daripada aplikasi \\(required), jadi OpenClaw membiarkannya tanpa perubahan."
-    },
-    {
       "id": "native.apple.e9b1899627402a15",
       "source": "Gateway recovery failed.",
       "translated": "Pemulihan Gateway gagal."
@@ -20622,11 +20592,6 @@
       "id": "native.apple.91debe404bb7affc",
       "source": "The managed OpenClaw runtime could not be reinstalled.",
       "translated": "Runtime OpenClaw terkelola tidak dapat diinstal ulang."
-    },
-    {
-      "id": "native.apple.3522be8112301d9f",
-      "source": "The Mac app is updated. This Gateway is managed separately, so OpenClaw left it unchanged.",
-      "translated": "Aplikasi Mac telah diperbarui. Gateway ini dikelola secara terpisah, jadi OpenClaw membiarkannya tanpa perubahan."
     },
     {
       "id": "native.apple.1cc391ec928070c4",
@@ -20734,9 +20699,24 @@
       "translated": "OpenClaw menginstal pembaruan tetapi tidak dapat memverifikasi koneksi Gateway."
     },
     {
-      "id": "native.apple.8bf292892311882e",
-      "source": "Mac app updated",
-      "translated": "Aplikasi Mac diperbarui"
+      "id": "native.apple.3abafcfb64b362fb",
+      "source": "The Gateway could not be checked.",
+      "translated": "Gateway tidak dapat diperiksa."
+    },
+    {
+      "id": "native.apple.00e3d2037782506c",
+      "source": "OpenClaw could not read the Gateway service ownership record. Retry after checking the Gateway LaunchAgent.",
+      "translated": "OpenClaw tidak dapat membaca catatan kepemilikan layanan Gateway. Coba lagi setelah memeriksa LaunchAgent Gateway."
+    },
+    {
+      "id": "native.apple.c4b8806a570dad31",
+      "source": "The Mac node could not be checked.",
+      "translated": "Node Mac tidak dapat diperiksa."
+    },
+    {
+      "id": "native.apple.0483bf19d612560b",
+      "source": "OpenClaw could not read the node service ownership record. Retry after checking the node LaunchAgent.",
+      "translated": "OpenClaw tidak dapat membaca catatan kepemilikan layanan node. Coba lagi setelah memeriksa LaunchAgent node."
     },
     {
       "id": "native.apple.d0f712a2ed470a3e",

--- a/apps/.i18n/native/it.json
+++ b/apps/.i18n/native/it.json
@@ -20584,36 +20584,6 @@
       "translated": "Verifica dell'app per Mac e del Gateway…"
     },
     {
-      "id": "native.apple.3a2e38e488490964",
-      "source": "The Mac app is updated. Gateway setup is not configured on this Mac.",
-      "translated": "L'app per Mac è aggiornata. La configurazione del Gateway non è impostata su questo Mac."
-    },
-    {
-      "id": "native.apple.3abafcfb64b362fb",
-      "source": "The Gateway could not be checked.",
-      "translated": "Non è stato possibile verificare il Gateway."
-    },
-    {
-      "id": "native.apple.00e3d2037782506c",
-      "source": "OpenClaw could not read the Gateway service ownership record. Retry after checking the Gateway LaunchAgent.",
-      "translated": "OpenClaw non è riuscito a leggere il record di proprietà del servizio Gateway. Riprova dopo aver verificato il LaunchAgent del Gateway."
-    },
-    {
-      "id": "native.apple.c4b8806a570dad31",
-      "source": "The Mac node could not be checked.",
-      "translated": "Non è stato possibile verificare il nodo Mac."
-    },
-    {
-      "id": "native.apple.0483bf19d612560b",
-      "source": "OpenClaw could not read the node service ownership record. Retry after checking the node LaunchAgent.",
-      "translated": "OpenClaw non è riuscito a leggere il record di proprietà del servizio del nodo. Riprova dopo aver verificato il LaunchAgent del nodo."
-    },
-    {
-      "id": "native.apple.1c57b3fcc10eabe7",
-      "source": "The Mac app is updated. Gateway \\(found) is newer than app \\(required), so OpenClaw left it unchanged.",
-      "translated": "L'app per Mac è aggiornata. Il Gateway \\(found) è più recente dell'app \\(required), quindi OpenClaw lo ha lasciato invariato."
-    },
-    {
       "id": "native.apple.e9b1899627402a15",
       "source": "Gateway recovery failed.",
       "translated": "Ripristino del Gateway non riuscito."
@@ -20622,11 +20592,6 @@
       "id": "native.apple.91debe404bb7affc",
       "source": "The managed OpenClaw runtime could not be reinstalled.",
       "translated": "Non è stato possibile reinstallare il runtime OpenClaw gestito."
-    },
-    {
-      "id": "native.apple.3522be8112301d9f",
-      "source": "The Mac app is updated. This Gateway is managed separately, so OpenClaw left it unchanged.",
-      "translated": "L'app per Mac è aggiornata. Questo Gateway è gestito separatamente, quindi OpenClaw lo ha lasciato invariato."
     },
     {
       "id": "native.apple.1cc391ec928070c4",
@@ -20734,9 +20699,24 @@
       "translated": "OpenClaw ha installato l'aggiornamento, ma non ha potuto verificare la connessione al Gateway."
     },
     {
-      "id": "native.apple.8bf292892311882e",
-      "source": "Mac app updated",
-      "translated": "App per Mac aggiornata"
+      "id": "native.apple.3abafcfb64b362fb",
+      "source": "The Gateway could not be checked.",
+      "translated": "Non è stato possibile verificare il Gateway."
+    },
+    {
+      "id": "native.apple.00e3d2037782506c",
+      "source": "OpenClaw could not read the Gateway service ownership record. Retry after checking the Gateway LaunchAgent.",
+      "translated": "OpenClaw non è riuscito a leggere il record di proprietà del servizio Gateway. Riprova dopo aver verificato il LaunchAgent del Gateway."
+    },
+    {
+      "id": "native.apple.c4b8806a570dad31",
+      "source": "The Mac node could not be checked.",
+      "translated": "Non è stato possibile verificare il nodo Mac."
+    },
+    {
+      "id": "native.apple.0483bf19d612560b",
+      "source": "OpenClaw could not read the node service ownership record. Retry after checking the node LaunchAgent.",
+      "translated": "OpenClaw non è riuscito a leggere il record di proprietà del servizio del nodo. Riprova dopo aver verificato il LaunchAgent del nodo."
     },
     {
       "id": "native.apple.d0f712a2ed470a3e",

--- a/apps/.i18n/native/ja-JP.json
+++ b/apps/.i18n/native/ja-JP.json
@@ -20584,36 +20584,6 @@
       "translated": "MacアプリとGatewayを確認しています…"
     },
     {
-      "id": "native.apple.3a2e38e488490964",
-      "source": "The Mac app is updated. Gateway setup is not configured on this Mac.",
-      "translated": "Macアプリはアップデートされました。このMacではGatewayのセットアップが構成されていません。"
-    },
-    {
-      "id": "native.apple.3abafcfb64b362fb",
-      "source": "The Gateway could not be checked.",
-      "translated": "Gatewayを確認できませんでした。"
-    },
-    {
-      "id": "native.apple.00e3d2037782506c",
-      "source": "OpenClaw could not read the Gateway service ownership record. Retry after checking the Gateway LaunchAgent.",
-      "translated": "OpenClawはGatewayサービスの所有権レコードを読み取れませんでした。GatewayのLaunchAgentを確認してから再試行してください。"
-    },
-    {
-      "id": "native.apple.c4b8806a570dad31",
-      "source": "The Mac node could not be checked.",
-      "translated": "Macノードを確認できませんでした。"
-    },
-    {
-      "id": "native.apple.0483bf19d612560b",
-      "source": "OpenClaw could not read the node service ownership record. Retry after checking the node LaunchAgent.",
-      "translated": "OpenClawはノードサービスの所有権レコードを読み取れませんでした。ノードのLaunchAgentを確認してから再試行してください。"
-    },
-    {
-      "id": "native.apple.1c57b3fcc10eabe7",
-      "source": "The Mac app is updated. Gateway \\(found) is newer than app \\(required), so OpenClaw left it unchanged.",
-      "translated": "Macアプリはアップデートされました。Gateway \\(found) はアプリ \\(required) より新しいため、OpenClawは変更しませんでした。"
-    },
-    {
       "id": "native.apple.e9b1899627402a15",
       "source": "Gateway recovery failed.",
       "translated": "Gatewayの復旧に失敗しました。"
@@ -20622,11 +20592,6 @@
       "id": "native.apple.91debe404bb7affc",
       "source": "The managed OpenClaw runtime could not be reinstalled.",
       "translated": "管理対象のOpenClawランタイムを再インストールできませんでした。"
-    },
-    {
-      "id": "native.apple.3522be8112301d9f",
-      "source": "The Mac app is updated. This Gateway is managed separately, so OpenClaw left it unchanged.",
-      "translated": "Macアプリはアップデートされました。このGatewayは個別に管理されているため、OpenClawは変更しませんでした。"
     },
     {
       "id": "native.apple.1cc391ec928070c4",
@@ -20734,9 +20699,24 @@
       "translated": "OpenClaw はアップデートをインストールしましたが、Gateway への接続を確認できませんでした。"
     },
     {
-      "id": "native.apple.8bf292892311882e",
-      "source": "Mac app updated",
-      "translated": "Mac アプリを更新しました"
+      "id": "native.apple.3abafcfb64b362fb",
+      "source": "The Gateway could not be checked.",
+      "translated": "Gatewayを確認できませんでした。"
+    },
+    {
+      "id": "native.apple.00e3d2037782506c",
+      "source": "OpenClaw could not read the Gateway service ownership record. Retry after checking the Gateway LaunchAgent.",
+      "translated": "OpenClawはGatewayサービスの所有権レコードを読み取れませんでした。GatewayのLaunchAgentを確認してから再試行してください。"
+    },
+    {
+      "id": "native.apple.c4b8806a570dad31",
+      "source": "The Mac node could not be checked.",
+      "translated": "Macノードを確認できませんでした。"
+    },
+    {
+      "id": "native.apple.0483bf19d612560b",
+      "source": "OpenClaw could not read the node service ownership record. Retry after checking the node LaunchAgent.",
+      "translated": "OpenClawはノードサービスの所有権レコードを読み取れませんでした。ノードのLaunchAgentを確認してから再試行してください。"
     },
     {
       "id": "native.apple.d0f712a2ed470a3e",

--- a/apps/.i18n/native/ko.json
+++ b/apps/.i18n/native/ko.json
@@ -20584,36 +20584,6 @@
       "translated": "Mac 앱과 Gateway 확인 중…"
     },
     {
-      "id": "native.apple.3a2e38e488490964",
-      "source": "The Mac app is updated. Gateway setup is not configured on this Mac.",
-      "translated": "Mac 앱이 업데이트되었습니다. 이 Mac에는 Gateway 설정이 구성되어 있지 않습니다."
-    },
-    {
-      "id": "native.apple.3abafcfb64b362fb",
-      "source": "The Gateway could not be checked.",
-      "translated": "Gateway를 확인할 수 없습니다."
-    },
-    {
-      "id": "native.apple.00e3d2037782506c",
-      "source": "OpenClaw could not read the Gateway service ownership record. Retry after checking the Gateway LaunchAgent.",
-      "translated": "OpenClaw에서 Gateway 서비스 소유권 기록을 읽을 수 없습니다. Gateway LaunchAgent를 확인한 후 다시 시도하세요."
-    },
-    {
-      "id": "native.apple.c4b8806a570dad31",
-      "source": "The Mac node could not be checked.",
-      "translated": "Mac 노드를 확인할 수 없습니다."
-    },
-    {
-      "id": "native.apple.0483bf19d612560b",
-      "source": "OpenClaw could not read the node service ownership record. Retry after checking the node LaunchAgent.",
-      "translated": "OpenClaw에서 노드 서비스 소유권 기록을 읽을 수 없습니다. 노드 LaunchAgent를 확인한 후 다시 시도하세요."
-    },
-    {
-      "id": "native.apple.1c57b3fcc10eabe7",
-      "source": "The Mac app is updated. Gateway \\(found) is newer than app \\(required), so OpenClaw left it unchanged.",
-      "translated": "Mac 앱이 업데이트되었습니다. Gateway \\(found)이(가) 앱 \\(required)보다 최신이므로 OpenClaw에서 변경하지 않았습니다."
-    },
-    {
       "id": "native.apple.e9b1899627402a15",
       "source": "Gateway recovery failed.",
       "translated": "Gateway 복구에 실패했습니다."
@@ -20622,11 +20592,6 @@
       "id": "native.apple.91debe404bb7affc",
       "source": "The managed OpenClaw runtime could not be reinstalled.",
       "translated": "관리형 OpenClaw 런타임을 다시 설치할 수 없습니다."
-    },
-    {
-      "id": "native.apple.3522be8112301d9f",
-      "source": "The Mac app is updated. This Gateway is managed separately, so OpenClaw left it unchanged.",
-      "translated": "Mac 앱이 업데이트되었습니다. 이 Gateway는 별도로 관리되므로 OpenClaw에서 변경하지 않았습니다."
     },
     {
       "id": "native.apple.1cc391ec928070c4",
@@ -20734,9 +20699,24 @@
       "translated": "OpenClaw에서 업데이트를 설치했지만 Gateway 연결을 확인하지 못했습니다."
     },
     {
-      "id": "native.apple.8bf292892311882e",
-      "source": "Mac app updated",
-      "translated": "Mac 앱 업데이트됨"
+      "id": "native.apple.3abafcfb64b362fb",
+      "source": "The Gateway could not be checked.",
+      "translated": "Gateway를 확인할 수 없습니다."
+    },
+    {
+      "id": "native.apple.00e3d2037782506c",
+      "source": "OpenClaw could not read the Gateway service ownership record. Retry after checking the Gateway LaunchAgent.",
+      "translated": "OpenClaw에서 Gateway 서비스 소유권 기록을 읽을 수 없습니다. Gateway LaunchAgent를 확인한 후 다시 시도하세요."
+    },
+    {
+      "id": "native.apple.c4b8806a570dad31",
+      "source": "The Mac node could not be checked.",
+      "translated": "Mac 노드를 확인할 수 없습니다."
+    },
+    {
+      "id": "native.apple.0483bf19d612560b",
+      "source": "OpenClaw could not read the node service ownership record. Retry after checking the node LaunchAgent.",
+      "translated": "OpenClaw에서 노드 서비스 소유권 기록을 읽을 수 없습니다. 노드 LaunchAgent를 확인한 후 다시 시도하세요."
     },
     {
       "id": "native.apple.d0f712a2ed470a3e",

--- a/apps/.i18n/native/nl.json
+++ b/apps/.i18n/native/nl.json
@@ -20584,36 +20584,6 @@
       "translated": "De Mac-app en Gateway controleren…"
     },
     {
-      "id": "native.apple.3a2e38e488490964",
-      "source": "The Mac app is updated. Gateway setup is not configured on this Mac.",
-      "translated": "De Mac-app is bijgewerkt. Gateway-configuratie is niet ingesteld op deze Mac."
-    },
-    {
-      "id": "native.apple.3abafcfb64b362fb",
-      "source": "The Gateway could not be checked.",
-      "translated": "De Gateway kon niet worden gecontroleerd."
-    },
-    {
-      "id": "native.apple.00e3d2037782506c",
-      "source": "OpenClaw could not read the Gateway service ownership record. Retry after checking the Gateway LaunchAgent.",
-      "translated": "OpenClaw kon de eigendomsregistratie van de Gateway-service niet lezen. Probeer het opnieuw nadat je de Gateway LaunchAgent hebt gecontroleerd."
-    },
-    {
-      "id": "native.apple.c4b8806a570dad31",
-      "source": "The Mac node could not be checked.",
-      "translated": "De Mac-node kon niet worden gecontroleerd."
-    },
-    {
-      "id": "native.apple.0483bf19d612560b",
-      "source": "OpenClaw could not read the node service ownership record. Retry after checking the node LaunchAgent.",
-      "translated": "OpenClaw kon de eigendomsregistratie van de node-service niet lezen. Probeer het opnieuw nadat je de node LaunchAgent hebt gecontroleerd."
-    },
-    {
-      "id": "native.apple.1c57b3fcc10eabe7",
-      "source": "The Mac app is updated. Gateway \\(found) is newer than app \\(required), so OpenClaw left it unchanged.",
-      "translated": "De Mac-app is bijgewerkt. Gateway \\(found) is nieuwer dan app \\(required), dus OpenClaw heeft deze ongewijzigd gelaten."
-    },
-    {
       "id": "native.apple.e9b1899627402a15",
       "source": "Gateway recovery failed.",
       "translated": "Herstel van Gateway mislukt."
@@ -20622,11 +20592,6 @@
       "id": "native.apple.91debe404bb7affc",
       "source": "The managed OpenClaw runtime could not be reinstalled.",
       "translated": "De beheerde OpenClaw-runtime kon niet opnieuw worden geïnstalleerd."
-    },
-    {
-      "id": "native.apple.3522be8112301d9f",
-      "source": "The Mac app is updated. This Gateway is managed separately, so OpenClaw left it unchanged.",
-      "translated": "De Mac-app is bijgewerkt. Deze Gateway wordt afzonderlijk beheerd, dus OpenClaw heeft deze ongewijzigd gelaten."
     },
     {
       "id": "native.apple.1cc391ec928070c4",
@@ -20734,9 +20699,24 @@
       "translated": "OpenClaw heeft de update geïnstalleerd, maar kon de verbinding met de Gateway niet verifiëren."
     },
     {
-      "id": "native.apple.8bf292892311882e",
-      "source": "Mac app updated",
-      "translated": "Mac-app bijgewerkt"
+      "id": "native.apple.3abafcfb64b362fb",
+      "source": "The Gateway could not be checked.",
+      "translated": "De Gateway kon niet worden gecontroleerd."
+    },
+    {
+      "id": "native.apple.00e3d2037782506c",
+      "source": "OpenClaw could not read the Gateway service ownership record. Retry after checking the Gateway LaunchAgent.",
+      "translated": "OpenClaw kon de eigendomsregistratie van de Gateway-service niet lezen. Probeer het opnieuw nadat je de Gateway LaunchAgent hebt gecontroleerd."
+    },
+    {
+      "id": "native.apple.c4b8806a570dad31",
+      "source": "The Mac node could not be checked.",
+      "translated": "De Mac-node kon niet worden gecontroleerd."
+    },
+    {
+      "id": "native.apple.0483bf19d612560b",
+      "source": "OpenClaw could not read the node service ownership record. Retry after checking the node LaunchAgent.",
+      "translated": "OpenClaw kon de eigendomsregistratie van de node-service niet lezen. Probeer het opnieuw nadat je de node LaunchAgent hebt gecontroleerd."
     },
     {
       "id": "native.apple.d0f712a2ed470a3e",

--- a/apps/.i18n/native/pl.json
+++ b/apps/.i18n/native/pl.json
@@ -20584,36 +20584,6 @@
       "translated": "Sprawdzanie aplikacji na Maca i Gateway…"
     },
     {
-      "id": "native.apple.3a2e38e488490964",
-      "source": "The Mac app is updated. Gateway setup is not configured on this Mac.",
-      "translated": "Aplikacja na Maca została zaktualizowana. Gateway nie jest skonfigurowany na tym Macu."
-    },
-    {
-      "id": "native.apple.3abafcfb64b362fb",
-      "source": "The Gateway could not be checked.",
-      "translated": "Nie udało się sprawdzić Gateway."
-    },
-    {
-      "id": "native.apple.00e3d2037782506c",
-      "source": "OpenClaw could not read the Gateway service ownership record. Retry after checking the Gateway LaunchAgent.",
-      "translated": "OpenClaw nie mógł odczytać informacji o właścicielu usługi Gateway. Spróbuj ponownie po sprawdzeniu LaunchAgent usługi Gateway."
-    },
-    {
-      "id": "native.apple.c4b8806a570dad31",
-      "source": "The Mac node could not be checked.",
-      "translated": "Nie udało się sprawdzić węzła Maca."
-    },
-    {
-      "id": "native.apple.0483bf19d612560b",
-      "source": "OpenClaw could not read the node service ownership record. Retry after checking the node LaunchAgent.",
-      "translated": "OpenClaw nie mógł odczytać informacji o właścicielu usługi węzła. Spróbuj ponownie po sprawdzeniu LaunchAgent węzła."
-    },
-    {
-      "id": "native.apple.1c57b3fcc10eabe7",
-      "source": "The Mac app is updated. Gateway \\(found) is newer than app \\(required), so OpenClaw left it unchanged.",
-      "translated": "Aplikacja na Maca została zaktualizowana. Gateway \\(found) jest nowszy niż aplikacja \\(required), dlatego OpenClaw pozostawił go bez zmian."
-    },
-    {
       "id": "native.apple.e9b1899627402a15",
       "source": "Gateway recovery failed.",
       "translated": "Odzyskiwanie Gateway nie powiodło się."
@@ -20622,11 +20592,6 @@
       "id": "native.apple.91debe404bb7affc",
       "source": "The managed OpenClaw runtime could not be reinstalled.",
       "translated": "Nie udało się ponownie zainstalować zarządzanego środowiska uruchomieniowego OpenClaw."
-    },
-    {
-      "id": "native.apple.3522be8112301d9f",
-      "source": "The Mac app is updated. This Gateway is managed separately, so OpenClaw left it unchanged.",
-      "translated": "Aplikacja na Maca została zaktualizowana. Ten Gateway jest zarządzany oddzielnie, dlatego OpenClaw pozostawił go bez zmian."
     },
     {
       "id": "native.apple.1cc391ec928070c4",
@@ -20734,9 +20699,24 @@
       "translated": "OpenClaw zainstalował aktualizację, ale nie mógł zweryfikować połączenia z Gateway."
     },
     {
-      "id": "native.apple.8bf292892311882e",
-      "source": "Mac app updated",
-      "translated": "Zaktualizowano aplikację na Maca"
+      "id": "native.apple.3abafcfb64b362fb",
+      "source": "The Gateway could not be checked.",
+      "translated": "Nie udało się sprawdzić Gateway."
+    },
+    {
+      "id": "native.apple.00e3d2037782506c",
+      "source": "OpenClaw could not read the Gateway service ownership record. Retry after checking the Gateway LaunchAgent.",
+      "translated": "OpenClaw nie mógł odczytać informacji o właścicielu usługi Gateway. Spróbuj ponownie po sprawdzeniu LaunchAgent usługi Gateway."
+    },
+    {
+      "id": "native.apple.c4b8806a570dad31",
+      "source": "The Mac node could not be checked.",
+      "translated": "Nie udało się sprawdzić węzła Maca."
+    },
+    {
+      "id": "native.apple.0483bf19d612560b",
+      "source": "OpenClaw could not read the node service ownership record. Retry after checking the node LaunchAgent.",
+      "translated": "OpenClaw nie mógł odczytać informacji o właścicielu usługi węzła. Spróbuj ponownie po sprawdzeniu LaunchAgent węzła."
     },
     {
       "id": "native.apple.d0f712a2ed470a3e",

--- a/apps/.i18n/native/pt-BR.json
+++ b/apps/.i18n/native/pt-BR.json
@@ -20584,36 +20584,6 @@
       "translated": "Verificando o aplicativo para Mac e o Gateway…"
     },
     {
-      "id": "native.apple.3a2e38e488490964",
-      "source": "The Mac app is updated. Gateway setup is not configured on this Mac.",
-      "translated": "O aplicativo para Mac está atualizado. A configuração do Gateway não está definida neste Mac."
-    },
-    {
-      "id": "native.apple.3abafcfb64b362fb",
-      "source": "The Gateway could not be checked.",
-      "translated": "Não foi possível verificar o Gateway."
-    },
-    {
-      "id": "native.apple.00e3d2037782506c",
-      "source": "OpenClaw could not read the Gateway service ownership record. Retry after checking the Gateway LaunchAgent.",
-      "translated": "O OpenClaw não conseguiu ler o registro de propriedade do serviço Gateway. Tente novamente após verificar o LaunchAgent do Gateway."
-    },
-    {
-      "id": "native.apple.c4b8806a570dad31",
-      "source": "The Mac node could not be checked.",
-      "translated": "Não foi possível verificar o nó do Mac."
-    },
-    {
-      "id": "native.apple.0483bf19d612560b",
-      "source": "OpenClaw could not read the node service ownership record. Retry after checking the node LaunchAgent.",
-      "translated": "O OpenClaw não conseguiu ler o registro de propriedade do serviço do nó. Tente novamente após verificar o LaunchAgent do nó."
-    },
-    {
-      "id": "native.apple.1c57b3fcc10eabe7",
-      "source": "The Mac app is updated. Gateway \\(found) is newer than app \\(required), so OpenClaw left it unchanged.",
-      "translated": "O aplicativo para Mac está atualizado. O Gateway \\(found) é mais recente que o aplicativo \\(required), por isso o OpenClaw o manteve inalterado."
-    },
-    {
       "id": "native.apple.e9b1899627402a15",
       "source": "Gateway recovery failed.",
       "translated": "Falha na recuperação do Gateway."
@@ -20622,11 +20592,6 @@
       "id": "native.apple.91debe404bb7affc",
       "source": "The managed OpenClaw runtime could not be reinstalled.",
       "translated": "Não foi possível reinstalar o ambiente de execução gerenciado do OpenClaw."
-    },
-    {
-      "id": "native.apple.3522be8112301d9f",
-      "source": "The Mac app is updated. This Gateway is managed separately, so OpenClaw left it unchanged.",
-      "translated": "O aplicativo para Mac está atualizado. Este Gateway é gerenciado separadamente, por isso o OpenClaw o manteve inalterado."
     },
     {
       "id": "native.apple.1cc391ec928070c4",
@@ -20734,9 +20699,24 @@
       "translated": "O OpenClaw instalou a atualização, mas não conseguiu verificar a conexão com o Gateway."
     },
     {
-      "id": "native.apple.8bf292892311882e",
-      "source": "Mac app updated",
-      "translated": "Aplicativo para Mac atualizado"
+      "id": "native.apple.3abafcfb64b362fb",
+      "source": "The Gateway could not be checked.",
+      "translated": "Não foi possível verificar o Gateway."
+    },
+    {
+      "id": "native.apple.00e3d2037782506c",
+      "source": "OpenClaw could not read the Gateway service ownership record. Retry after checking the Gateway LaunchAgent.",
+      "translated": "O OpenClaw não conseguiu ler o registro de propriedade do serviço Gateway. Tente novamente após verificar o LaunchAgent do Gateway."
+    },
+    {
+      "id": "native.apple.c4b8806a570dad31",
+      "source": "The Mac node could not be checked.",
+      "translated": "Não foi possível verificar o nó do Mac."
+    },
+    {
+      "id": "native.apple.0483bf19d612560b",
+      "source": "OpenClaw could not read the node service ownership record. Retry after checking the node LaunchAgent.",
+      "translated": "O OpenClaw não conseguiu ler o registro de propriedade do serviço do nó. Tente novamente após verificar o LaunchAgent do nó."
     },
     {
       "id": "native.apple.d0f712a2ed470a3e",

--- a/apps/.i18n/native/ru.json
+++ b/apps/.i18n/native/ru.json
@@ -20584,36 +20584,6 @@
       "translated": "Проверка приложения для Mac и Gateway…"
     },
     {
-      "id": "native.apple.3a2e38e488490964",
-      "source": "The Mac app is updated. Gateway setup is not configured on this Mac.",
-      "translated": "Приложение для Mac обновлено. Gateway не настроен на этом Mac."
-    },
-    {
-      "id": "native.apple.3abafcfb64b362fb",
-      "source": "The Gateway could not be checked.",
-      "translated": "Не удалось проверить Gateway."
-    },
-    {
-      "id": "native.apple.00e3d2037782506c",
-      "source": "OpenClaw could not read the Gateway service ownership record. Retry after checking the Gateway LaunchAgent.",
-      "translated": "OpenClaw не удалось прочитать запись о владельце службы Gateway. Повторите попытку после проверки LaunchAgent для Gateway."
-    },
-    {
-      "id": "native.apple.c4b8806a570dad31",
-      "source": "The Mac node could not be checked.",
-      "translated": "Не удалось проверить узел Mac."
-    },
-    {
-      "id": "native.apple.0483bf19d612560b",
-      "source": "OpenClaw could not read the node service ownership record. Retry after checking the node LaunchAgent.",
-      "translated": "OpenClaw не удалось прочитать запись о владельце службы узла. Повторите попытку после проверки LaunchAgent для узла."
-    },
-    {
-      "id": "native.apple.1c57b3fcc10eabe7",
-      "source": "The Mac app is updated. Gateway \\(found) is newer than app \\(required), so OpenClaw left it unchanged.",
-      "translated": "Приложение для Mac обновлено. Версия Gateway \\(found) новее версии приложения \\(required), поэтому OpenClaw не стал её изменять."
-    },
-    {
       "id": "native.apple.e9b1899627402a15",
       "source": "Gateway recovery failed.",
       "translated": "Не удалось восстановить Gateway."
@@ -20622,11 +20592,6 @@
       "id": "native.apple.91debe404bb7affc",
       "source": "The managed OpenClaw runtime could not be reinstalled.",
       "translated": "Не удалось переустановить управляемую среду выполнения OpenClaw."
-    },
-    {
-      "id": "native.apple.3522be8112301d9f",
-      "source": "The Mac app is updated. This Gateway is managed separately, so OpenClaw left it unchanged.",
-      "translated": "Приложение для Mac обновлено. Этот Gateway управляется отдельно, поэтому OpenClaw не стал его изменять."
     },
     {
       "id": "native.apple.1cc391ec928070c4",
@@ -20734,9 +20699,24 @@
       "translated": "OpenClaw установил обновление, но не смог проверить подключение к Gateway."
     },
     {
-      "id": "native.apple.8bf292892311882e",
-      "source": "Mac app updated",
-      "translated": "Приложение для Mac обновлено"
+      "id": "native.apple.3abafcfb64b362fb",
+      "source": "The Gateway could not be checked.",
+      "translated": "Не удалось проверить Gateway."
+    },
+    {
+      "id": "native.apple.00e3d2037782506c",
+      "source": "OpenClaw could not read the Gateway service ownership record. Retry after checking the Gateway LaunchAgent.",
+      "translated": "OpenClaw не удалось прочитать запись о владельце службы Gateway. Повторите попытку после проверки LaunchAgent для Gateway."
+    },
+    {
+      "id": "native.apple.c4b8806a570dad31",
+      "source": "The Mac node could not be checked.",
+      "translated": "Не удалось проверить узел Mac."
+    },
+    {
+      "id": "native.apple.0483bf19d612560b",
+      "source": "OpenClaw could not read the node service ownership record. Retry after checking the node LaunchAgent.",
+      "translated": "OpenClaw не удалось прочитать запись о владельце службы узла. Повторите попытку после проверки LaunchAgent для узла."
     },
     {
       "id": "native.apple.d0f712a2ed470a3e",

--- a/apps/.i18n/native/sv.json
+++ b/apps/.i18n/native/sv.json
@@ -20584,36 +20584,6 @@
       "translated": "Kontrollerar Mac-appen och Gateway…"
     },
     {
-      "id": "native.apple.3a2e38e488490964",
-      "source": "The Mac app is updated. Gateway setup is not configured on this Mac.",
-      "translated": "Mac-appen är uppdaterad. Gateway-konfigurationen har inte konfigurerats på denna Mac."
-    },
-    {
-      "id": "native.apple.3abafcfb64b362fb",
-      "source": "The Gateway could not be checked.",
-      "translated": "Gateway kunde inte kontrolleras."
-    },
-    {
-      "id": "native.apple.00e3d2037782506c",
-      "source": "OpenClaw could not read the Gateway service ownership record. Retry after checking the Gateway LaunchAgent.",
-      "translated": "OpenClaw kunde inte läsa ägarposten för Gateway-tjänsten. Försök igen efter att ha kontrollerat Gateway LaunchAgent."
-    },
-    {
-      "id": "native.apple.c4b8806a570dad31",
-      "source": "The Mac node could not be checked.",
-      "translated": "Mac-noden kunde inte kontrolleras."
-    },
-    {
-      "id": "native.apple.0483bf19d612560b",
-      "source": "OpenClaw could not read the node service ownership record. Retry after checking the node LaunchAgent.",
-      "translated": "OpenClaw kunde inte läsa ägarposten för nodtjänsten. Försök igen efter att ha kontrollerat nodens LaunchAgent."
-    },
-    {
-      "id": "native.apple.1c57b3fcc10eabe7",
-      "source": "The Mac app is updated. Gateway \\(found) is newer than app \\(required), so OpenClaw left it unchanged.",
-      "translated": "Mac-appen är uppdaterad. Gateway \\(found) är nyare än appen \\(required), så OpenClaw lämnade den oförändrad."
-    },
-    {
       "id": "native.apple.e9b1899627402a15",
       "source": "Gateway recovery failed.",
       "translated": "Återställningen av Gateway misslyckades."
@@ -20622,11 +20592,6 @@
       "id": "native.apple.91debe404bb7affc",
       "source": "The managed OpenClaw runtime could not be reinstalled.",
       "translated": "Den hanterade OpenClaw-körmiljön kunde inte installeras om."
-    },
-    {
-      "id": "native.apple.3522be8112301d9f",
-      "source": "The Mac app is updated. This Gateway is managed separately, so OpenClaw left it unchanged.",
-      "translated": "Mac-appen är uppdaterad. Denna Gateway hanteras separat, så OpenClaw lämnade den oförändrad."
     },
     {
       "id": "native.apple.1cc391ec928070c4",
@@ -20734,9 +20699,24 @@
       "translated": "OpenClaw installerade uppdateringen men kunde inte verifiera anslutningen till Gateway."
     },
     {
-      "id": "native.apple.8bf292892311882e",
-      "source": "Mac app updated",
-      "translated": "Mac-appen har uppdaterats"
+      "id": "native.apple.3abafcfb64b362fb",
+      "source": "The Gateway could not be checked.",
+      "translated": "Gateway kunde inte kontrolleras."
+    },
+    {
+      "id": "native.apple.00e3d2037782506c",
+      "source": "OpenClaw could not read the Gateway service ownership record. Retry after checking the Gateway LaunchAgent.",
+      "translated": "OpenClaw kunde inte läsa ägarposten för Gateway-tjänsten. Försök igen efter att ha kontrollerat Gateway LaunchAgent."
+    },
+    {
+      "id": "native.apple.c4b8806a570dad31",
+      "source": "The Mac node could not be checked.",
+      "translated": "Mac-noden kunde inte kontrolleras."
+    },
+    {
+      "id": "native.apple.0483bf19d612560b",
+      "source": "OpenClaw could not read the node service ownership record. Retry after checking the node LaunchAgent.",
+      "translated": "OpenClaw kunde inte läsa ägarposten för nodtjänsten. Försök igen efter att ha kontrollerat nodens LaunchAgent."
     },
     {
       "id": "native.apple.d0f712a2ed470a3e",

--- a/apps/.i18n/native/th.json
+++ b/apps/.i18n/native/th.json
@@ -20584,36 +20584,6 @@
       "translated": "กำลังตรวจสอบแอป Mac และ Gateway…"
     },
     {
-      "id": "native.apple.3a2e38e488490964",
-      "source": "The Mac app is updated. Gateway setup is not configured on this Mac.",
-      "translated": "อัปเดตแอป Mac แล้ว แต่ยังไม่ได้กำหนดค่าการตั้งค่า Gateway บน Mac เครื่องนี้"
-    },
-    {
-      "id": "native.apple.3abafcfb64b362fb",
-      "source": "The Gateway could not be checked.",
-      "translated": "ไม่สามารถตรวจสอบ Gateway ได้"
-    },
-    {
-      "id": "native.apple.00e3d2037782506c",
-      "source": "OpenClaw could not read the Gateway service ownership record. Retry after checking the Gateway LaunchAgent.",
-      "translated": "OpenClaw ไม่สามารถอ่านบันทึกความเป็นเจ้าของบริการ Gateway ได้ โปรดลองอีกครั้งหลังจากตรวจสอบ Gateway LaunchAgent"
-    },
-    {
-      "id": "native.apple.c4b8806a570dad31",
-      "source": "The Mac node could not be checked.",
-      "translated": "ไม่สามารถตรวจสอบโหนด Mac ได้"
-    },
-    {
-      "id": "native.apple.0483bf19d612560b",
-      "source": "OpenClaw could not read the node service ownership record. Retry after checking the node LaunchAgent.",
-      "translated": "OpenClaw ไม่สามารถอ่านบันทึกความเป็นเจ้าของบริการโหนดได้ โปรดลองอีกครั้งหลังจากตรวจสอบ node LaunchAgent"
-    },
-    {
-      "id": "native.apple.1c57b3fcc10eabe7",
-      "source": "The Mac app is updated. Gateway \\(found) is newer than app \\(required), so OpenClaw left it unchanged.",
-      "translated": "อัปเดตแอป Mac แล้ว Gateway \\(found) ใหม่กว่าแอป \\(required) ดังนั้น OpenClaw จึงไม่ได้เปลี่ยนแปลง Gateway"
-    },
-    {
       "id": "native.apple.e9b1899627402a15",
       "source": "Gateway recovery failed.",
       "translated": "กู้คืน Gateway ไม่สำเร็จ"
@@ -20622,11 +20592,6 @@
       "id": "native.apple.91debe404bb7affc",
       "source": "The managed OpenClaw runtime could not be reinstalled.",
       "translated": "ไม่สามารถติดตั้งรันไทม์ OpenClaw ที่มีการจัดการใหม่ได้"
-    },
-    {
-      "id": "native.apple.3522be8112301d9f",
-      "source": "The Mac app is updated. This Gateway is managed separately, so OpenClaw left it unchanged.",
-      "translated": "อัปเดตแอป Mac แล้ว Gateway นี้ได้รับการจัดการแยกต่างหาก ดังนั้น OpenClaw จึงไม่ได้เปลี่ยนแปลง Gateway"
     },
     {
       "id": "native.apple.1cc391ec928070c4",
@@ -20734,9 +20699,24 @@
       "translated": "OpenClaw ติดตั้งการอัปเดตแล้ว แต่ไม่สามารถตรวจสอบการเชื่อมต่อ Gateway ได้"
     },
     {
-      "id": "native.apple.8bf292892311882e",
-      "source": "Mac app updated",
-      "translated": "อัปเดตแอป Mac แล้ว"
+      "id": "native.apple.3abafcfb64b362fb",
+      "source": "The Gateway could not be checked.",
+      "translated": "ไม่สามารถตรวจสอบ Gateway ได้"
+    },
+    {
+      "id": "native.apple.00e3d2037782506c",
+      "source": "OpenClaw could not read the Gateway service ownership record. Retry after checking the Gateway LaunchAgent.",
+      "translated": "OpenClaw ไม่สามารถอ่านบันทึกความเป็นเจ้าของบริการ Gateway ได้ โปรดลองอีกครั้งหลังจากตรวจสอบ Gateway LaunchAgent"
+    },
+    {
+      "id": "native.apple.c4b8806a570dad31",
+      "source": "The Mac node could not be checked.",
+      "translated": "ไม่สามารถตรวจสอบโหนด Mac ได้"
+    },
+    {
+      "id": "native.apple.0483bf19d612560b",
+      "source": "OpenClaw could not read the node service ownership record. Retry after checking the node LaunchAgent.",
+      "translated": "OpenClaw ไม่สามารถอ่านบันทึกความเป็นเจ้าของบริการโหนดได้ โปรดลองอีกครั้งหลังจากตรวจสอบ node LaunchAgent"
     },
     {
       "id": "native.apple.d0f712a2ed470a3e",

--- a/apps/.i18n/native/tr.json
+++ b/apps/.i18n/native/tr.json
@@ -20584,36 +20584,6 @@
       "translated": "Mac uygulaması ve Gateway kontrol ediliyor…"
     },
     {
-      "id": "native.apple.3a2e38e488490964",
-      "source": "The Mac app is updated. Gateway setup is not configured on this Mac.",
-      "translated": "Mac uygulaması güncellendi. Gateway kurulumu bu Mac'te yapılandırılmamış."
-    },
-    {
-      "id": "native.apple.3abafcfb64b362fb",
-      "source": "The Gateway could not be checked.",
-      "translated": "Gateway kontrol edilemedi."
-    },
-    {
-      "id": "native.apple.00e3d2037782506c",
-      "source": "OpenClaw could not read the Gateway service ownership record. Retry after checking the Gateway LaunchAgent.",
-      "translated": "OpenClaw, Gateway hizmetinin sahiplik kaydını okuyamadı. Gateway LaunchAgent'ı kontrol ettikten sonra yeniden deneyin."
-    },
-    {
-      "id": "native.apple.c4b8806a570dad31",
-      "source": "The Mac node could not be checked.",
-      "translated": "Mac düğümü kontrol edilemedi."
-    },
-    {
-      "id": "native.apple.0483bf19d612560b",
-      "source": "OpenClaw could not read the node service ownership record. Retry after checking the node LaunchAgent.",
-      "translated": "OpenClaw, düğüm hizmetinin sahiplik kaydını okuyamadı. Düğüm LaunchAgent'ını kontrol ettikten sonra yeniden deneyin."
-    },
-    {
-      "id": "native.apple.1c57b3fcc10eabe7",
-      "source": "The Mac app is updated. Gateway \\(found) is newer than app \\(required), so OpenClaw left it unchanged.",
-      "translated": "Mac uygulaması güncellendi. Gateway \\(found), uygulama \\(required) sürümünden daha yeni olduğundan OpenClaw onu değiştirmedi."
-    },
-    {
       "id": "native.apple.e9b1899627402a15",
       "source": "Gateway recovery failed.",
       "translated": "Gateway kurtarma işlemi başarısız oldu."
@@ -20622,11 +20592,6 @@
       "id": "native.apple.91debe404bb7affc",
       "source": "The managed OpenClaw runtime could not be reinstalled.",
       "translated": "Yönetilen OpenClaw çalışma zamanı yeniden yüklenemedi."
-    },
-    {
-      "id": "native.apple.3522be8112301d9f",
-      "source": "The Mac app is updated. This Gateway is managed separately, so OpenClaw left it unchanged.",
-      "translated": "Mac uygulaması güncellendi. Bu Gateway ayrı olarak yönetildiğinden OpenClaw onu değiştirmedi."
     },
     {
       "id": "native.apple.1cc391ec928070c4",
@@ -20734,9 +20699,24 @@
       "translated": "OpenClaw güncellemeyi yükledi ancak Gateway bağlantısını doğrulayamadı."
     },
     {
-      "id": "native.apple.8bf292892311882e",
-      "source": "Mac app updated",
-      "translated": "Mac uygulaması güncellendi"
+      "id": "native.apple.3abafcfb64b362fb",
+      "source": "The Gateway could not be checked.",
+      "translated": "Gateway kontrol edilemedi."
+    },
+    {
+      "id": "native.apple.00e3d2037782506c",
+      "source": "OpenClaw could not read the Gateway service ownership record. Retry after checking the Gateway LaunchAgent.",
+      "translated": "OpenClaw, Gateway hizmetinin sahiplik kaydını okuyamadı. Gateway LaunchAgent'ı kontrol ettikten sonra yeniden deneyin."
+    },
+    {
+      "id": "native.apple.c4b8806a570dad31",
+      "source": "The Mac node could not be checked.",
+      "translated": "Mac düğümü kontrol edilemedi."
+    },
+    {
+      "id": "native.apple.0483bf19d612560b",
+      "source": "OpenClaw could not read the node service ownership record. Retry after checking the node LaunchAgent.",
+      "translated": "OpenClaw, düğüm hizmetinin sahiplik kaydını okuyamadı. Düğüm LaunchAgent'ını kontrol ettikten sonra yeniden deneyin."
     },
     {
       "id": "native.apple.d0f712a2ed470a3e",

--- a/apps/.i18n/native/uk.json
+++ b/apps/.i18n/native/uk.json
@@ -20584,36 +20584,6 @@
       "translated": "Перевірка застосунку для Mac і Gateway…"
     },
     {
-      "id": "native.apple.3a2e38e488490964",
-      "source": "The Mac app is updated. Gateway setup is not configured on this Mac.",
-      "translated": "Застосунок для Mac оновлено. Gateway не налаштовано на цьому Mac."
-    },
-    {
-      "id": "native.apple.3abafcfb64b362fb",
-      "source": "The Gateway could not be checked.",
-      "translated": "Не вдалося перевірити Gateway."
-    },
-    {
-      "id": "native.apple.00e3d2037782506c",
-      "source": "OpenClaw could not read the Gateway service ownership record. Retry after checking the Gateway LaunchAgent.",
-      "translated": "OpenClaw не вдалося прочитати запис про власника служби Gateway. Повторіть спробу після перевірки Gateway LaunchAgent."
-    },
-    {
-      "id": "native.apple.c4b8806a570dad31",
-      "source": "The Mac node could not be checked.",
-      "translated": "Не вдалося перевірити вузол Mac."
-    },
-    {
-      "id": "native.apple.0483bf19d612560b",
-      "source": "OpenClaw could not read the node service ownership record. Retry after checking the node LaunchAgent.",
-      "translated": "OpenClaw не вдалося прочитати запис про власника служби вузла. Повторіть спробу після перевірки LaunchAgent вузла."
-    },
-    {
-      "id": "native.apple.1c57b3fcc10eabe7",
-      "source": "The Mac app is updated. Gateway \\(found) is newer than app \\(required), so OpenClaw left it unchanged.",
-      "translated": "Застосунок для Mac оновлено. Gateway \\(found) новіший за версію \\(required), потрібну застосунку, тому OpenClaw не вносив до нього змін."
-    },
-    {
       "id": "native.apple.e9b1899627402a15",
       "source": "Gateway recovery failed.",
       "translated": "Не вдалося відновити Gateway."
@@ -20622,11 +20592,6 @@
       "id": "native.apple.91debe404bb7affc",
       "source": "The managed OpenClaw runtime could not be reinstalled.",
       "translated": "Не вдалося повторно встановити кероване середовище виконання OpenClaw."
-    },
-    {
-      "id": "native.apple.3522be8112301d9f",
-      "source": "The Mac app is updated. This Gateway is managed separately, so OpenClaw left it unchanged.",
-      "translated": "Застосунок для Mac оновлено. Цей Gateway керується окремо, тому OpenClaw не вносив до нього змін."
     },
     {
       "id": "native.apple.1cc391ec928070c4",
@@ -20734,9 +20699,24 @@
       "translated": "OpenClaw установив оновлення, але не зміг перевірити підключення до Gateway."
     },
     {
-      "id": "native.apple.8bf292892311882e",
-      "source": "Mac app updated",
-      "translated": "Програму для Mac оновлено"
+      "id": "native.apple.3abafcfb64b362fb",
+      "source": "The Gateway could not be checked.",
+      "translated": "Не вдалося перевірити Gateway."
+    },
+    {
+      "id": "native.apple.00e3d2037782506c",
+      "source": "OpenClaw could not read the Gateway service ownership record. Retry after checking the Gateway LaunchAgent.",
+      "translated": "OpenClaw не вдалося прочитати запис про власника служби Gateway. Повторіть спробу після перевірки Gateway LaunchAgent."
+    },
+    {
+      "id": "native.apple.c4b8806a570dad31",
+      "source": "The Mac node could not be checked.",
+      "translated": "Не вдалося перевірити вузол Mac."
+    },
+    {
+      "id": "native.apple.0483bf19d612560b",
+      "source": "OpenClaw could not read the node service ownership record. Retry after checking the node LaunchAgent.",
+      "translated": "OpenClaw не вдалося прочитати запис про власника служби вузла. Повторіть спробу після перевірки LaunchAgent вузла."
     },
     {
       "id": "native.apple.d0f712a2ed470a3e",

--- a/apps/.i18n/native/vi.json
+++ b/apps/.i18n/native/vi.json
@@ -20584,36 +20584,6 @@
       "translated": "Đang kiểm tra ứng dụng Mac và Gateway…"
     },
     {
-      "id": "native.apple.3a2e38e488490964",
-      "source": "The Mac app is updated. Gateway setup is not configured on this Mac.",
-      "translated": "Ứng dụng Mac đã được cập nhật. Gateway chưa được thiết lập trên máy Mac này."
-    },
-    {
-      "id": "native.apple.3abafcfb64b362fb",
-      "source": "The Gateway could not be checked.",
-      "translated": "Không thể kiểm tra Gateway."
-    },
-    {
-      "id": "native.apple.00e3d2037782506c",
-      "source": "OpenClaw could not read the Gateway service ownership record. Retry after checking the Gateway LaunchAgent.",
-      "translated": "OpenClaw không thể đọc bản ghi quyền sở hữu dịch vụ Gateway. Hãy thử lại sau khi kiểm tra LaunchAgent của Gateway."
-    },
-    {
-      "id": "native.apple.c4b8806a570dad31",
-      "source": "The Mac node could not be checked.",
-      "translated": "Không thể kiểm tra nút Mac."
-    },
-    {
-      "id": "native.apple.0483bf19d612560b",
-      "source": "OpenClaw could not read the node service ownership record. Retry after checking the node LaunchAgent.",
-      "translated": "OpenClaw không thể đọc bản ghi quyền sở hữu dịch vụ nút. Hãy thử lại sau khi kiểm tra LaunchAgent của nút."
-    },
-    {
-      "id": "native.apple.1c57b3fcc10eabe7",
-      "source": "The Mac app is updated. Gateway \\(found) is newer than app \\(required), so OpenClaw left it unchanged.",
-      "translated": "Ứng dụng Mac đã được cập nhật. Gateway \\(found) mới hơn ứng dụng \\(required), vì vậy OpenClaw không thay đổi Gateway."
-    },
-    {
       "id": "native.apple.e9b1899627402a15",
       "source": "Gateway recovery failed.",
       "translated": "Khôi phục Gateway không thành công."
@@ -20622,11 +20592,6 @@
       "id": "native.apple.91debe404bb7affc",
       "source": "The managed OpenClaw runtime could not be reinstalled.",
       "translated": "Không thể cài đặt lại môi trường chạy OpenClaw được quản lý."
-    },
-    {
-      "id": "native.apple.3522be8112301d9f",
-      "source": "The Mac app is updated. This Gateway is managed separately, so OpenClaw left it unchanged.",
-      "translated": "Ứng dụng Mac đã được cập nhật. Gateway này được quản lý riêng, vì vậy OpenClaw không thay đổi Gateway."
     },
     {
       "id": "native.apple.1cc391ec928070c4",
@@ -20734,9 +20699,24 @@
       "translated": "OpenClaw đã cài đặt bản cập nhật nhưng không thể xác minh kết nối Gateway."
     },
     {
-      "id": "native.apple.8bf292892311882e",
-      "source": "Mac app updated",
-      "translated": "Đã cập nhật ứng dụng Mac"
+      "id": "native.apple.3abafcfb64b362fb",
+      "source": "The Gateway could not be checked.",
+      "translated": "Không thể kiểm tra Gateway."
+    },
+    {
+      "id": "native.apple.00e3d2037782506c",
+      "source": "OpenClaw could not read the Gateway service ownership record. Retry after checking the Gateway LaunchAgent.",
+      "translated": "OpenClaw không thể đọc bản ghi quyền sở hữu dịch vụ Gateway. Hãy thử lại sau khi kiểm tra LaunchAgent của Gateway."
+    },
+    {
+      "id": "native.apple.c4b8806a570dad31",
+      "source": "The Mac node could not be checked.",
+      "translated": "Không thể kiểm tra nút Mac."
+    },
+    {
+      "id": "native.apple.0483bf19d612560b",
+      "source": "OpenClaw could not read the node service ownership record. Retry after checking the node LaunchAgent.",
+      "translated": "OpenClaw không thể đọc bản ghi quyền sở hữu dịch vụ nút. Hãy thử lại sau khi kiểm tra LaunchAgent của nút."
     },
     {
       "id": "native.apple.d0f712a2ed470a3e",

--- a/apps/.i18n/native/zh-CN.json
+++ b/apps/.i18n/native/zh-CN.json
@@ -20584,36 +20584,6 @@
       "translated": "正在检查 Mac App 和 Gateway…"
     },
     {
-      "id": "native.apple.3a2e38e488490964",
-      "source": "The Mac app is updated. Gateway setup is not configured on this Mac.",
-      "translated": "Mac App 已更新。此 Mac 上尚未配置 Gateway。"
-    },
-    {
-      "id": "native.apple.3abafcfb64b362fb",
-      "source": "The Gateway could not be checked.",
-      "translated": "无法检查 Gateway。"
-    },
-    {
-      "id": "native.apple.00e3d2037782506c",
-      "source": "OpenClaw could not read the Gateway service ownership record. Retry after checking the Gateway LaunchAgent.",
-      "translated": "OpenClaw 无法读取 Gateway 服务所有权记录。请检查 Gateway LaunchAgent 后重试。"
-    },
-    {
-      "id": "native.apple.c4b8806a570dad31",
-      "source": "The Mac node could not be checked.",
-      "translated": "无法检查 Mac 节点。"
-    },
-    {
-      "id": "native.apple.0483bf19d612560b",
-      "source": "OpenClaw could not read the node service ownership record. Retry after checking the node LaunchAgent.",
-      "translated": "OpenClaw 无法读取节点服务所有权记录。请检查节点 LaunchAgent 后重试。"
-    },
-    {
-      "id": "native.apple.1c57b3fcc10eabe7",
-      "source": "The Mac app is updated. Gateway \\(found) is newer than app \\(required), so OpenClaw left it unchanged.",
-      "translated": "Mac App 已更新。Gateway \\(found) 比 App 所需的版本 \\(required) 更新，因此 OpenClaw 未对其进行更改。"
-    },
-    {
       "id": "native.apple.e9b1899627402a15",
       "source": "Gateway recovery failed.",
       "translated": "Gateway 恢复失败。"
@@ -20622,11 +20592,6 @@
       "id": "native.apple.91debe404bb7affc",
       "source": "The managed OpenClaw runtime could not be reinstalled.",
       "translated": "无法重新安装由 OpenClaw 管理的运行时。"
-    },
-    {
-      "id": "native.apple.3522be8112301d9f",
-      "source": "The Mac app is updated. This Gateway is managed separately, so OpenClaw left it unchanged.",
-      "translated": "Mac App 已更新。此 Gateway 由其他方式单独管理，因此 OpenClaw 未对其进行更改。"
     },
     {
       "id": "native.apple.1cc391ec928070c4",
@@ -20734,9 +20699,24 @@
       "translated": "OpenClaw 已安装更新，但无法验证 Gateway 连接。"
     },
     {
-      "id": "native.apple.8bf292892311882e",
-      "source": "Mac app updated",
-      "translated": "Mac 应用已更新"
+      "id": "native.apple.3abafcfb64b362fb",
+      "source": "The Gateway could not be checked.",
+      "translated": "无法检查 Gateway。"
+    },
+    {
+      "id": "native.apple.00e3d2037782506c",
+      "source": "OpenClaw could not read the Gateway service ownership record. Retry after checking the Gateway LaunchAgent.",
+      "translated": "OpenClaw 无法读取 Gateway 服务所有权记录。请检查 Gateway LaunchAgent 后重试。"
+    },
+    {
+      "id": "native.apple.c4b8806a570dad31",
+      "source": "The Mac node could not be checked.",
+      "translated": "无法检查 Mac 节点。"
+    },
+    {
+      "id": "native.apple.0483bf19d612560b",
+      "source": "OpenClaw could not read the node service ownership record. Retry after checking the node LaunchAgent.",
+      "translated": "OpenClaw 无法读取节点服务所有权记录。请检查节点 LaunchAgent 后重试。"
     },
     {
       "id": "native.apple.d0f712a2ed470a3e",

--- a/apps/.i18n/native/zh-TW.json
+++ b/apps/.i18n/native/zh-TW.json
@@ -20584,36 +20584,6 @@
       "translated": "正在檢查 Mac App 和 Gateway…"
     },
     {
-      "id": "native.apple.3a2e38e488490964",
-      "source": "The Mac app is updated. Gateway setup is not configured on this Mac.",
-      "translated": "Mac App 已更新。此 Mac 尚未設定 Gateway。"
-    },
-    {
-      "id": "native.apple.3abafcfb64b362fb",
-      "source": "The Gateway could not be checked.",
-      "translated": "無法檢查 Gateway。"
-    },
-    {
-      "id": "native.apple.00e3d2037782506c",
-      "source": "OpenClaw could not read the Gateway service ownership record. Retry after checking the Gateway LaunchAgent.",
-      "translated": "OpenClaw 無法讀取 Gateway 服務的擁有權記錄。請檢查 Gateway LaunchAgent 後重試。"
-    },
-    {
-      "id": "native.apple.c4b8806a570dad31",
-      "source": "The Mac node could not be checked.",
-      "translated": "無法檢查 Mac 節點。"
-    },
-    {
-      "id": "native.apple.0483bf19d612560b",
-      "source": "OpenClaw could not read the node service ownership record. Retry after checking the node LaunchAgent.",
-      "translated": "OpenClaw 無法讀取節點服務的擁有權記錄。請檢查節點 LaunchAgent 後重試。"
-    },
-    {
-      "id": "native.apple.1c57b3fcc10eabe7",
-      "source": "The Mac app is updated. Gateway \\(found) is newer than app \\(required), so OpenClaw left it unchanged.",
-      "translated": "Mac App 已更新。Gateway \\(found) 比 App \\(required) 更新，因此 OpenClaw 未進行變更。"
-    },
-    {
       "id": "native.apple.e9b1899627402a15",
       "source": "Gateway recovery failed.",
       "translated": "Gateway 復原失敗。"
@@ -20622,11 +20592,6 @@
       "id": "native.apple.91debe404bb7affc",
       "source": "The managed OpenClaw runtime could not be reinstalled.",
       "translated": "無法重新安裝由 OpenClaw 管理的執行環境。"
-    },
-    {
-      "id": "native.apple.3522be8112301d9f",
-      "source": "The Mac app is updated. This Gateway is managed separately, so OpenClaw left it unchanged.",
-      "translated": "Mac App 已更新。此 Gateway 由其他方式管理，因此 OpenClaw 未進行變更。"
     },
     {
       "id": "native.apple.1cc391ec928070c4",
@@ -20734,9 +20699,24 @@
       "translated": "OpenClaw 已安裝更新，但無法驗證 Gateway 連線。"
     },
     {
-      "id": "native.apple.8bf292892311882e",
-      "source": "Mac app updated",
-      "translated": "Mac App 已更新"
+      "id": "native.apple.3abafcfb64b362fb",
+      "source": "The Gateway could not be checked.",
+      "translated": "無法檢查 Gateway。"
+    },
+    {
+      "id": "native.apple.00e3d2037782506c",
+      "source": "OpenClaw could not read the Gateway service ownership record. Retry after checking the Gateway LaunchAgent.",
+      "translated": "OpenClaw 無法讀取 Gateway 服務的擁有權記錄。請檢查 Gateway LaunchAgent 後重試。"
+    },
+    {
+      "id": "native.apple.c4b8806a570dad31",
+      "source": "The Mac node could not be checked.",
+      "translated": "無法檢查 Mac 節點。"
+    },
+    {
+      "id": "native.apple.0483bf19d612560b",
+      "source": "OpenClaw could not read the node service ownership record. Retry after checking the node LaunchAgent.",
+      "translated": "OpenClaw 無法讀取節點服務的擁有權記錄。請檢查節點 LaunchAgent 後重試。"
     },
     {
       "id": "native.apple.d0f712a2ed470a3e",

--- a/apps/macos/Sources/OpenClaw/PostUpdate.swift
+++ b/apps/macos/Sources/OpenClaw/PostUpdate.swift
@@ -195,7 +195,6 @@ final class PostUpdateModel {
         case verifying
         case notifying
         case complete
-        case external
         case failed
     }
 
@@ -207,7 +206,7 @@ final class PostUpdateModel {
     var isWorking: Bool {
         switch self.phase {
         case .checking, .updating, .verifying, .notifying: true
-        case .complete, .external, .failed: false
+        case .complete, .failed: false
         }
     }
 
@@ -215,10 +214,16 @@ final class PostUpdateModel {
         switch self.phase {
         case .checking, .updating, .verifying, .notifying: .thinking
         case .complete: .celebrating
-        case .external: .attentive
         case .failed: .sad
         }
     }
+}
+
+enum PostUpdateGatewayAction: Equatable {
+    case none
+    case repair
+    case update
+    case install
 }
 
 struct PostUpdateSessionsResponse: Decodable {
@@ -267,7 +272,6 @@ final class PostUpdateController: NSObject, NSWindowDelegate {
             allowsUpdateWorkflow: !CLIInstallBuild.isDebug)
         else { return false }
         self.receipt = receipt
-        self.show()
         self.run()
         return true
     }
@@ -337,11 +341,12 @@ final class PostUpdateController: NSObject, NSWindowDelegate {
     private func finishUpdate(receipt: PostAppUpdateReceipt) async {
         let connectionMode = AppStateStore.shared.connectionMode
         guard CLIInstallPrompter.shouldManageCLI(connectionMode: connectionMode) else {
-            self.finishExternal(String(
-                localized: "The Mac app is updated. Gateway setup is not configured on this Mac."))
+            self.finishSilently()
             return
         }
 
+        // Resume a definitely uncommitted notification before the Gateway action
+        // gate; a ready runtime must not discard it as an app-only receipt.
         if Self.isNotificationOnlyRetry(receipt) {
             await self.finishNotification(receipt: receipt, connectionMode: connectionMode)
             return
@@ -359,25 +364,17 @@ final class PostUpdateController: NSObject, NSWindowDelegate {
         switch connectionMode {
         case .local:
             guard let programArguments = GatewayLaunchAgentManager.launchdProgramArguments() else {
-                self.fail(
-                    message: String(localized: "The Gateway could not be checked."),
-                    details: String(
-                        localized: """
-                        OpenClaw could not read the Gateway service ownership record. \
-                        Retry after checking the Gateway LaunchAgent.
-                        """))
+                self.finishAfterOwnershipCheckFailure(
+                    connectionMode: connectionMode,
+                    receipt: receipt)
                 return
             }
             runtimeProgramArguments = programArguments
         case .remote:
             guard let programArguments = NodeServiceManager.launchdProgramArguments() else {
-                self.fail(
-                    message: String(localized: "The Mac node could not be checked."),
-                    details: String(
-                        localized: """
-                        OpenClaw could not read the node service ownership record. \
-                        Retry after checking the node LaunchAgent.
-                        """))
+                self.finishAfterOwnershipCheckFailure(
+                    connectionMode: connectionMode,
+                    receipt: receipt)
                 return
             }
             runtimeProgramArguments = programArguments
@@ -392,31 +389,31 @@ final class PostUpdateController: NSObject, NSWindowDelegate {
             launchAgentWriteDisabled: GatewayLaunchAgentManager.isLaunchAgentWriteDisabled())
         let restartGateway = connectionMode == .local && !AppStateStore.shared.isPaused
 
-        switch managedStatus {
-        case .ready where ownsManagedRuntime:
-            if receipt.gatewayUpdateIncomplete {
-                self.model.phase = .updating
-                let outcome = await CLIInstaller.updateManaged(
-                    targetVersion: receipt.toVersion,
-                    restartGateway: restartGateway,
-                    repair: true)
-                { [weak self] message in
-                    self?.model.message = message
-                }
-                guard self.consume(outcome) else { return }
-                self.setGatewayUpdateIncomplete(false, receipt: receipt)
+        // App-only relaunches stay invisible. The window belongs only to
+        // confirmed managed Gateway work and its recovery path.
+        switch Self.gatewayAction(
+            status: managedStatus,
+            ownsManagedRuntime: ownsManagedRuntime,
+            gatewayUpdateIncomplete: receipt.gatewayUpdateIncomplete)
+        {
+        case .none:
+            self.finishSilently()
+            return
+        case .repair:
+            self.model.phase = .updating
+            self.show()
+            let outcome = await CLIInstaller.updateManaged(
+                targetVersion: receipt.toVersion,
+                restartGateway: restartGateway,
+                repair: true)
+            { [weak self] message in
+                self?.model.message = message
             }
-        case let .incompatible(_, found, required) where ownsManagedRuntime:
-            guard CLIInstallPrompter.isManagedUpgrade(found: found, required: required) else {
-                self.finishExternal(String(
-                    localized: """
-                    The Mac app is updated. Gateway \(found) is newer than app \(required), \
-                    so OpenClaw left it unchanged.
-                    """))
-                return
-            }
+            guard self.consume(outcome) else { return }
+        case .update:
             self.setGatewayUpdateIncomplete(true, receipt: receipt)
             self.model.phase = .updating
+            self.show()
             let outcome = await CLIInstaller.updateManaged(
                 targetVersion: receipt.toVersion,
                 restartGateway: restartGateway)
@@ -424,11 +421,10 @@ final class PostUpdateController: NSObject, NSWindowDelegate {
                 self?.model.message = message
             }
             guard self.consume(outcome) else { return }
-            self.setGatewayUpdateIncomplete(false, receipt: receipt)
-        case .missing where ownsManagedRuntime,
-             .unusable where ownsManagedRuntime:
+        case .install:
             self.setGatewayUpdateIncomplete(true, receipt: receipt)
             self.model.phase = .updating
+            self.show()
             let installed = await CLIInstaller.install(target: .exact(receipt.toVersion)) { [weak self] message in
                 self?.model.message = message
             }
@@ -438,14 +434,6 @@ final class PostUpdateController: NSObject, NSWindowDelegate {
                     details: String(localized: "The managed OpenClaw runtime could not be reinstalled."))
                 return
             }
-            self.setGatewayUpdateIncomplete(false, receipt: receipt)
-        default:
-            self.finishExternal(String(
-                localized: """
-                The Mac app is updated. This Gateway is managed separately, \
-                so OpenClaw left it unchanged.
-                """))
-            return
         }
 
         self.model.phase = .verifying
@@ -453,6 +441,9 @@ final class PostUpdateController: NSObject, NSWindowDelegate {
             ? String(localized: "Restarting and verifying the Gateway…")
             : String(localized: "Verifying the Mac node runtime…")
         guard await self.verifyRuntime(connectionMode: connectionMode) else { return }
+        // Verification owns the persistence boundary: clearing earlier would
+        // turn a failed health check into a silent app-only completion on retry.
+        self.setGatewayUpdateIncomplete(false, receipt: receipt)
 
         await self.finishNotification(receipt: receipt, connectionMode: connectionMode)
     }
@@ -690,6 +681,29 @@ final class PostUpdateController: NSObject, NSWindowDelegate {
             !receipt.gatewayUpdateIncomplete
     }
 
+    static func gatewayAction(
+        status: CLIInstaller.Status,
+        ownsManagedRuntime: Bool,
+        gatewayUpdateIncomplete: Bool) -> PostUpdateGatewayAction
+    {
+        guard ownsManagedRuntime else { return .none }
+        return switch status {
+        case .ready:
+            gatewayUpdateIncomplete ? .repair : .none
+        case let .incompatible(_, found, required):
+            CLIInstallPrompter.isManagedUpgrade(found: found, required: required) ? .update : .none
+        case .missing, .unusable:
+            .install
+        }
+    }
+
+    static func shouldPresentOwnershipFailure(
+        connectionMode: AppState.ConnectionMode,
+        gatewayUpdateIncomplete: Bool) -> Bool
+    {
+        gatewayUpdateIncomplete && connectionMode != .unconfigured
+    }
+
     static func remoteNotificationBlocker(
         gatewayVersion: String?,
         appVersion: String) -> PostUpdateNotificationOutcome?
@@ -748,12 +762,47 @@ final class PostUpdateController: NSObject, NSWindowDelegate {
         }
     }
 
-    private func finishExternal(_ message: String) {
+    private func finishSilently() {
         PostAppUpdateReceiptStore.clear()
-        self.model.phase = .external
-        self.model.title = String(localized: "Mac app updated")
-        self.model.message = message
-        self.model.details = nil
+        self.receipt = nil
+        self.close()
+    }
+
+    private func finishAfterOwnershipCheckFailure(
+        connectionMode: AppState.ConnectionMode,
+        receipt: PostAppUpdateReceipt)
+    {
+        guard Self.shouldPresentOwnershipFailure(
+            connectionMode: connectionMode,
+            gatewayUpdateIncomplete: receipt.gatewayUpdateIncomplete)
+        else {
+            self.finishSilently()
+            return
+        }
+
+        // An incomplete receipt proves app-owned Gateway work already began.
+        // Keep it retryable when the service record is temporarily unreadable.
+        self.show()
+        switch connectionMode {
+        case .local:
+            self.fail(
+                message: String(localized: "The Gateway could not be checked."),
+                details: String(
+                    localized: """
+                    OpenClaw could not read the Gateway service ownership record. \
+                    Retry after checking the Gateway LaunchAgent.
+                    """))
+        case .remote:
+            self.fail(
+                message: String(localized: "The Mac node could not be checked."),
+                details: String(
+                    localized: """
+                    OpenClaw could not read the node service ownership record. \
+                    Retry after checking the node LaunchAgent.
+                    """))
+        case .unconfigured:
+            self.finishSilently()
+        }
     }
 
     private func fail(message: String, details: String?) {
@@ -821,8 +870,7 @@ private struct PostUpdateView: View {
                 Button("Retry") { PostUpdateController.shared.retry() }
                     .buttonStyle(.borderedProminent)
             }
-        // External means the Gateway was intentionally left unchanged, so no recovery action is needed.
-        case .complete, .external:
+        case .complete:
             HStack {
                 Spacer()
                 Button("Continue") { PostUpdateController.shared.close() }

--- a/apps/macos/Sources/OpenClaw/PostUpdate.swift
+++ b/apps/macos/Sources/OpenClaw/PostUpdate.swift
@@ -221,6 +221,7 @@ final class PostUpdateModel {
 
 enum PostUpdateGatewayAction: Equatable {
     case none
+    case ownershipFailure
     case repair
     case update
     case install
@@ -398,6 +399,11 @@ final class PostUpdateController: NSObject, NSWindowDelegate {
         {
         case .none:
             self.finishSilently()
+            return
+        case .ownershipFailure:
+            self.finishAfterOwnershipCheckFailure(
+                connectionMode: connectionMode,
+                receipt: receipt)
             return
         case .repair:
             self.model.phase = .updating
@@ -686,6 +692,9 @@ final class PostUpdateController: NSObject, NSWindowDelegate {
         ownsManagedRuntime: Bool,
         gatewayUpdateIncomplete: Bool) -> PostUpdateGatewayAction
     {
+        if gatewayUpdateIncomplete, !ownsManagedRuntime {
+            return .ownershipFailure
+        }
         guard ownsManagedRuntime else { return .none }
         return switch status {
         case .ready:

--- a/apps/macos/Tests/OpenClawIPCTests/UpdateOrchestrationTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/UpdateOrchestrationTests.swift
@@ -242,6 +242,53 @@ struct UpdateOrchestrationTests {
             launchAgentWriteDisabled: false))
     }
 
+    @Test func `post-update window is reserved for managed Gateway work`() {
+        let managed = CLIInstaller.managedExecutableLocation()
+
+        #expect(PostUpdateController.gatewayAction(
+            status: .ready(location: managed, version: "2026.7.4"),
+            ownsManagedRuntime: true,
+            gatewayUpdateIncomplete: false) == .none)
+        #expect(PostUpdateController.gatewayAction(
+            status: .ready(location: managed, version: "2026.7.4"),
+            ownsManagedRuntime: true,
+            gatewayUpdateIncomplete: true) == .repair)
+        #expect(PostUpdateController.gatewayAction(
+            status: .incompatible(location: managed, found: "2026.7.3", required: "2026.7.4"),
+            ownsManagedRuntime: true,
+            gatewayUpdateIncomplete: false) == .update)
+        #expect(PostUpdateController.gatewayAction(
+            status: .missing(location: managed),
+            ownsManagedRuntime: true,
+            gatewayUpdateIncomplete: false) == .install)
+        #expect(PostUpdateController.gatewayAction(
+            status: .incompatible(location: managed, found: "2026.7.5", required: "2026.7.4"),
+            ownsManagedRuntime: true,
+            gatewayUpdateIncomplete: false) == .none)
+        #expect(PostUpdateController.gatewayAction(
+            status: .incompatible(location: managed, found: "2026.7.3", required: "2026.7.4"),
+            ownsManagedRuntime: false,
+            gatewayUpdateIncomplete: false) == .none)
+    }
+
+    @Test func `incomplete managed update keeps ownership failures retryable`() {
+        #expect(PostUpdateController.shouldPresentOwnershipFailure(
+            connectionMode: .local,
+            gatewayUpdateIncomplete: true))
+        #expect(PostUpdateController.shouldPresentOwnershipFailure(
+            connectionMode: .remote,
+            gatewayUpdateIncomplete: true))
+        #expect(!PostUpdateController.shouldPresentOwnershipFailure(
+            connectionMode: .local,
+            gatewayUpdateIncomplete: false))
+        #expect(!PostUpdateController.shouldPresentOwnershipFailure(
+            connectionMode: .remote,
+            gatewayUpdateIncomplete: false))
+        #expect(!PostUpdateController.shouldPresentOwnershipFailure(
+            connectionMode: .unconfigured,
+            gatewayUpdateIncomplete: true))
+    }
+
     @Test func `notification retries only definitely uncommitted sends`() {
         #expect(PostUpdateController.notificationSendFailureOutcome(
             OpenClawChatTransportSendError.notDispatched) == .retryLater)

--- a/apps/macos/Tests/OpenClawIPCTests/UpdateOrchestrationTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/UpdateOrchestrationTests.swift
@@ -269,6 +269,10 @@ struct UpdateOrchestrationTests {
             status: .incompatible(location: managed, found: "2026.7.3", required: "2026.7.4"),
             ownsManagedRuntime: false,
             gatewayUpdateIncomplete: false) == .none)
+        #expect(PostUpdateController.gatewayAction(
+            status: .ready(location: managed, version: "2026.7.4"),
+            ownsManagedRuntime: false,
+            gatewayUpdateIncomplete: true) == .ownershipFailure)
     }
 
     @Test func `incomplete managed update keeps ownership failures retryable`() {

--- a/docs/install/updating.md
+++ b/docs/install/updating.md
@@ -251,8 +251,9 @@ Gateways, and manually managed local Gateways.
 In the signed macOS app, a local app-owned Gateway changes that card to
 **Update Mac app + Gateway**. Sparkle updates the app first; after relaunch, the
 app runs `openclaw update --tag <app-version> --json`, restarts its Gateway,
-and verifies health in a setup-style progress window. Failure details stay
-visible with Retry, [Update guide](/install/updating), and
+and verifies health in a setup-style progress window. The window appears only
+when that managed Gateway needs update, repair, or installation; app-only updates relaunch
+directly into the app. Failure details stay visible with Retry, [Update guide](/install/updating), and
 [Discord](https://discord.gg/clawd) actions. The app never uses this coordinated
 path for a remote or externally managed Gateway, never downgrades a newer
 Gateway, and never overrides an `extended-stable` channel pin.


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users updating only the Mac app would see a post-update window even when their Gateway needed no managed work.

## Why This Change Was Made

The Mac app now decides the managed Gateway action before presenting the post-update window. App-only and separately managed paths finish silently; confirmed managed Gateway update, repair, installation, and persisted recovery paths keep the existing progress and recovery UI.

Incomplete managed-update receipts remain retryable through ownership and verification failures. Notification-only retries resume before the Gateway action gate.

## User Impact

After an app-only update, OpenClaw relaunches directly into the app. The post-update window appears only when the app-owned managed Gateway needs work or recovery.

## Evidence

- Blacksmith changed gate: https://github.com/openclaw/openclaw/actions/runs/29399119722 — exit 0; formatting and policy checks passed; 178 tests passed.
- Swift parse and SwiftFormat checks passed for the changed controller and orchestration tests.
- Native app localization inventory and all 21 locale artifacts validated.
- Docs map and diff checks passed.
- Fresh autoreview passed after the receipt-recovery fixes.
- Regression coverage exercises app-only, update, install, repair, external ownership, incomplete ownership-loss, and notification-retry decisions.

The supplied before screenshot shows the unwanted app-only completion window. The corrected state has no replacement window: relaunch returns directly to the normal app.
