### PR TITLE
fix: prevent stale rescue approvals from executing

### DIFF
--- a/docs/cli/openclaw.md
+++ b/docs/cli/openclaw.md
@@ -287,6 +287,7 @@ Security contract for remote rescue:
 - Plugin search and list are read-only. Plugin install is always local-only (blocked in rescue, even when otherwise enabled) because it downloads executable code. Plugin uninstall is refused in both local OpenClaw and rescue; run `openclaw plugins uninstall <id>` from a terminal.
 - Remote rescue cannot open the local TUI or switch into an interactive agent session; use local `openclaw` for agent handoff.
 - Persistent writes still require approval, even in rescue mode.
+- Pending approvals are one-use. Any newer rescue command for the same account, channel, and sender revokes the older plan; failed execution also consumes approval, so resend the command to retry.
 - Every applied rescue operation is audited. Message-channel rescue records channel, account, sender, and source-address metadata; config-mutating operations also record config hashes before and after.
 - Secrets are never echoed. SecretRef inspection reports availability, not values.
 - If the Gateway is alive, rescue prefers Gateway typed operations; if it is dead, rescue uses only the minimal local repair surface that does not depend on the normal agent loop.

--- a/docs/refactor/database-first.md
+++ b/docs/refactor/database-first.md
@@ -1044,8 +1044,9 @@ sessionId})`; create, branch, continue, list, and fork flows live in their
   file remains file-backed, recovery snapshots stay next to the config file,
   and durable config audit/health state belongs to the Gateway SQLite store.
 - System-agent rescue pending approvals now use core SQLite plugin state instead
-  of `crestodian/rescue-pending/*.json`. Doctor imports legacy pending approval
-  files and removes them after successful import.
+  of `crestodian/rescue-pending/*.json` or `openclaw/rescue-pending/*.json`.
+  These short-lived security capabilities are never imported; doctor discards
+  both retired directories so an upgrade cannot reactivate a stale write.
 - Phone Control temporary arm state now uses SQLite plugin state instead of
   `plugins/phone-control/armed.json`. Doctor imports the legacy armed-state
   file into the `phone-control/arm-state` namespace and removes the file.
@@ -2238,6 +2239,7 @@ Add a repo check that fails new runtime writes to legacy state paths:
 - `audit/file-transfer.jsonl`
 - `audit/crestodian.jsonl`
 - `crestodian/rescue-pending/*.json`
+- `openclaw/rescue-pending/*.json`
 - `plugins/phone-control/armed.json`
 - Memory Wiki `.openclaw-wiki/log.jsonl`
 - Memory Wiki `.openclaw-wiki/state.json`

--- a/scripts/check-database-first-legacy-stores.mjs
+++ b/scripts/check-database-first-legacy-stores.mjs
@@ -91,6 +91,7 @@ const legacyStorePatterns = [
   /\bagents\/[^"'`]+\/agent\/(?:auth|models)\.json\b/u,
   /\b(?:credentials\/oauth|github-copilot\.token|openrouter-models|auth-profiles|auth-state|exec-approvals|workspace-state)\.json\b/u,
   /\btui\/last-session\.json\b/u,
+  /\b(?:crestodian|openclaw)\/rescue-pending\/[^"'`]*\.json\b/u,
   /\bcron\/(?:runs\/[^"'`]+\.jsonl|jobs\.json|jobs-state\.json)\b/u,
   /\b(?:process-leases|session-toggles|known-users|msteams-conversations|msteams-polls|msteams-sso-tokens|bot-storage|sync-store|thread-bindings|inbound-dedupe|startup-verification|storage-meta|crypto-idb-snapshot|command-deploy-cache|plugin-binding-approvals|plugins\/installs|config-health|port-guard|restart-sentinel|gateway-restart-intent|gateway-supervisor-restart-handoff)\.json\b/u,
   /\b(?:calls|ref-index|audit\/file-transfer|audit\/openclaw)\.jsonl\b/u,
@@ -105,6 +106,7 @@ const allowedRuntimeMigrationPaths = [
   "src/infra/session-state-migration.ts",
   "src/infra/state-migrations.ts",
   "src/infra/state-migrations.tui-last-session.ts",
+  "src/infra/state-migrations.rescue-pending.ts",
   "src/commands/session-state-migration.ts",
   "src/commands/doctor-state-migrations.test.ts",
 ];

--- a/scripts/e2e/system-agent-rescue-docker-client.ts
+++ b/scripts/e2e/system-agent-rescue-docker-client.ts
@@ -253,11 +253,9 @@ async function main() {
   assert(doctorRuns.length === 0, "remote rescue must not invoke doctor repair");
 
   const updatedConfig = JSON.parse(await fs.readFile(configPath, "utf8")) as OpenClawConfig;
+  const updatedModel = updatedConfig.agents?.defaults?.model;
   assert(
-    updatedConfig.agents?.defaults?.model &&
-      typeof updatedConfig.agents.defaults.model === "object" &&
-      "primary" in updatedConfig.agents.defaults.model &&
-      updatedConfig.agents.defaults.model.primary === "openai/gpt-5.2",
+    (typeof updatedModel === "string" ? updatedModel : updatedModel?.primary) === "openai/gpt-5.2",
     "config default model was not updated",
   );
   assert(updatedConfig.gateway?.port === 19001, "generic config set did not update gateway.port");

--- a/scripts/e2e/system-agent-rescue-docker-client.ts
+++ b/scripts/e2e/system-agent-rescue-docker-client.ts
@@ -51,6 +51,23 @@ async function invoke(commandBody: string, cfg: OpenClawConfig, isGroup = false)
   return text;
 }
 
+async function invokeWithDeps(
+  commandBody: string,
+  cfg: OpenClawConfig,
+  deps: NonNullable<Parameters<typeof runSystemAgentRescueMessage>[0]["deps"]>,
+): Promise<string> {
+  const result = await runSystemAgentRescueMessage({
+    cfg,
+    command: makeParams(commandBody, cfg).command,
+    commandBody,
+    agentId: "default",
+    isGroup: false,
+    deps,
+  });
+  assert(typeof result === "string", `Direct rescue command did not return text: ${commandBody}`);
+  return result;
+}
+
 async function main() {
   const tempState = await createE2eStateDir("openclaw-openclaw-");
   tempState.registerExitCleanup();
@@ -79,18 +96,30 @@ async function main() {
   assert(denied.includes("sandboxing is active"), "sandboxed rescue was not denied");
 
   const cfg: OpenClawConfig = {};
+  const deterministicInference = {
+    verifyInferenceConfig: async () => ({
+      ok: true as const,
+      modelRef: "openai/gpt-5.2",
+      latencyMs: 1,
+    }),
+  };
   const refusedTui = await invoke("/openclaw talk to agent", cfg);
   assert(
     refusedTui.includes("cannot open the local TUI"),
     "remote rescue TUI handoff was not refused",
   );
 
-  const plan = await invoke("/openclaw set default model openai/gpt-5.2", cfg);
+  // This packaged smoke verifies rescue persistence, not live provider credentials.
+  const plan = await invokeWithDeps(
+    "/openclaw set default model openai/gpt-5.2",
+    cfg,
+    deterministicInference,
+  );
   assert(
     plan.includes("Reply /openclaw yes to apply"),
     "persistent change did not require approval",
   );
-  const applied = await invoke("/openclaw yes", cfg);
+  const applied = await invokeWithDeps("/openclaw yes", cfg, deterministicInference);
   assert(applied.includes("Default model: openai/gpt-5.2"), "approved change did not apply");
 
   const configValid = await invoke("/openclaw validate config", cfg);
@@ -123,12 +152,13 @@ async function main() {
   const agentApplied = await invoke("/openclaw yes", cfg);
   assert(agentApplied.includes("[openclaw] done: agents.create"), "agent creation did not apply");
 
-  const setupPlan = await invoke(
+  const setupPlan = await invokeWithDeps(
     "/openclaw setup workspace /tmp/openclaw-setup model openai/gpt-5.2",
     cfg,
+    deterministicInference,
   );
   assert(setupPlan.includes("Reply /openclaw yes to apply"), "setup did not require approval");
-  const setupApplied = await invoke("/openclaw yes", cfg);
+  const setupApplied = await invokeWithDeps("/openclaw yes", cfg, deterministicInference);
   assert(setupApplied.includes("[openclaw] done: openclaw.setup"), "setup did not apply");
 
   const gatewayRestarts: string[] = [];

--- a/scripts/e2e/system-agent-rescue-docker-client.ts
+++ b/scripts/e2e/system-agent-rescue-docker-client.ts
@@ -234,7 +234,7 @@ async function main() {
 
   const doctorRuns: string[] = [];
   const doctorCommand = makeParams("/openclaw doctor fix", cfg).command;
-  const doctorPlan = await runSystemAgentRescueMessage({
+  const doctorReply = await runSystemAgentRescueMessage({
     cfg,
     command: doctorCommand,
     commandBody: "/openclaw doctor fix",
@@ -247,23 +247,10 @@ async function main() {
     },
   });
   assert(
-    doctorPlan?.includes("Reply /openclaw yes to apply"),
-    "doctor fix did not require approval",
+    doctorReply?.includes("openclaw doctor --fix"),
+    "remote doctor fix did not point to the local repair command",
   );
-  const doctorApplied = await runSystemAgentRescueMessage({
-    cfg,
-    command: doctorCommand,
-    commandBody: "/openclaw yes",
-    agentId: "default",
-    isGroup: false,
-    deps: {
-      runDoctor: async (_runtime, options) => {
-        doctorRuns.push(options.repair ? "repair" : "check");
-      },
-    },
-  });
-  assert(doctorApplied?.includes("[openclaw] done: doctor.fix"), "doctor fix did not apply");
-  assert(doctorRuns.join(",") === "repair", "doctor repair dependency was not invoked once");
+  assert(doctorRuns.length === 0, "remote rescue must not invoke doctor repair");
 
   const updatedConfig = JSON.parse(await fs.readFile(configPath, "utf8")) as OpenClawConfig;
   assert(
@@ -321,10 +308,6 @@ async function main() {
   assert(
     audits.some((audit) => audit.operation === "gateway.restart"),
     "gateway restart audit operation missing",
-  );
-  assert(
-    audits.some((audit) => audit.operation === "doctor.fix"),
-    "doctor fix audit missing",
   );
 
   console.log("OpenClaw rescue Docker E2E passed");

--- a/scripts/e2e/system-agent-rescue-docker-client.ts
+++ b/scripts/e2e/system-agent-rescue-docker-client.ts
@@ -24,6 +24,7 @@ function makeParams(commandBody: string, cfg: OpenClawConfig, isGroup = false) {
       surface: "whatsapp",
       channel: "whatsapp",
       channelId: "whatsapp",
+      accountId: "default",
       ownerList: ["user:owner"],
       senderIsOwner: true,
       isAuthorizedSender: true,
@@ -148,6 +149,41 @@ async function main() {
     gatewayPlan?.includes("Reply /openclaw yes to apply"),
     "gateway restart did not require approval",
   );
+  const pluginList = await runSystemAgentRescueMessage({
+    cfg,
+    command: gatewayCommand,
+    commandBody: "/openclaw plugins list",
+    agentId: "default",
+    isGroup: false,
+    deps: {
+      runPluginsList: async (runtime) => runtime.log("plugin rows"),
+    },
+  });
+  assert(pluginList === "plugin rows", "read-only rescue command did not run");
+  const revokedApproval = await runSystemAgentRescueMessage({
+    cfg,
+    command: gatewayCommand,
+    commandBody: "/openclaw yes",
+    agentId: "default",
+    isGroup: false,
+    deps: {
+      runGatewayRestart: async () => {
+        gatewayRestarts.push("restart");
+      },
+    },
+  });
+  assert(
+    revokedApproval === "No pending OpenClaw rescue change is waiting for approval.",
+    "fresh rescue command did not revoke the older pending change",
+  );
+  assert(gatewayRestarts.length === 0, "revoked gateway restart was invoked");
+  await runSystemAgentRescueMessage({
+    cfg,
+    command: gatewayCommand,
+    commandBody: "/openclaw restart gateway",
+    agentId: "default",
+    isGroup: false,
+  });
   const gatewayApplied = await runSystemAgentRescueMessage({
     cfg,
     command: gatewayCommand,

--- a/src/commands/doctor.e2e-harness.ts
+++ b/src/commands/doctor.e2e-harness.ts
@@ -280,6 +280,10 @@ function createLegacyStateMigrationDetectionResult(params?: {
       sourcePath: "/tmp/state/tui/last-session.json",
       hasLegacy: false,
     },
+    rescuePending: {
+      sourcePaths: ["/tmp/state/crestodian/rescue-pending", "/tmp/state/openclaw/rescue-pending"],
+      hasLegacy: false,
+    },
     channelPairing: {
       sourceDir: "/tmp/oauth",
       files: [],

--- a/src/infra/state-migrations.doctor.ts
+++ b/src/infra/state-migrations.doctor.ts
@@ -55,6 +55,10 @@ import {
   runLegacyMigrationPlans,
 } from "./state-migrations.plugin-state.js";
 import {
+  detectLegacyRescuePending,
+  discardLegacyRescuePending,
+} from "./state-migrations.rescue-pending.js";
+import {
   migrateLegacyConfigHealth,
   migrateLegacyCurrentConversationBindings,
   migrateLegacyPluginBindingApprovals,
@@ -377,6 +381,10 @@ export async function detectLegacyStateMigrations(params: {
     stateDir,
     doctorOnlyStateMigrations: params.doctorOnlyStateMigrations,
   });
+  const rescuePending = detectLegacyRescuePending({
+    stateDir,
+    doctorOnlyStateMigrations: params.doctorOnlyStateMigrations,
+  });
   const configuredChannels = Object.entries(params.cfg.channels ?? {});
   const configuredAccountIds = Object.fromEntries(
     configuredChannels.map(([channelId, value]) => {
@@ -525,6 +533,9 @@ export async function detectLegacyStateMigrations(params: {
   if (tuiLastSessions.hasLegacy) {
     preview.push("- TUI last-session pointers: legacy JSON file → shared SQLite state");
   }
+  if (rescuePending.hasLegacy) {
+    preview.push("- System-agent rescue approvals: discard retired pending JSON capabilities");
+  }
   if (channelPairing.hasLegacy) {
     preview.push("- Channel pairing state: legacy JSON files → shared SQLite state");
   }
@@ -611,6 +622,7 @@ export async function detectLegacyStateMigrations(params: {
       hasLegacy: hasCurrentConversationBindings,
     },
     tuiLastSessions,
+    rescuePending,
     channelPairing,
     execApprovals,
     warnings: pluginPlanWarnings,
@@ -793,6 +805,10 @@ export async function runLegacyStateMigrations(params: {
     detected: detected.tuiLastSessions,
     stateDir: detected.stateDir,
   });
+  const rescuePending = discardLegacyRescuePending({
+    detected: detected.rescuePending,
+    stateDir: detected.stateDir,
+  });
   const channelPairing = migrateLegacyChannelPairingState({
     detected: detected.channelPairing,
     env: { ...env, OPENCLAW_STATE_DIR: detected.stateDir },
@@ -835,6 +851,7 @@ export async function runLegacyStateMigrations(params: {
       ...pluginBindingApprovals.changes,
       ...currentConversationBindings.changes,
       ...tuiLastSessions.changes,
+      ...rescuePending.changes,
       ...channelPairing.changes,
       ...execApprovals.changes,
       ...preSessionChannelPlans.changes,
@@ -858,6 +875,7 @@ export async function runLegacyStateMigrations(params: {
       ...pluginBindingApprovals.warnings,
       ...currentConversationBindings.warnings,
       ...tuiLastSessions.warnings,
+      ...rescuePending.warnings,
       ...channelPairing.warnings,
       ...execApprovals.warnings,
       ...preSessionChannelPlans.warnings,

--- a/src/infra/state-migrations.rescue-pending.test.ts
+++ b/src/infra/state-migrations.rescue-pending.test.ts
@@ -1,0 +1,89 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  detectLegacyRescuePending,
+  discardLegacyRescuePending,
+} from "./state-migrations.rescue-pending.js";
+
+const tempDirs: string[] = [];
+
+function makeStateDir(): string {
+  const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-rescue-migration-"));
+  tempDirs.push(stateDir);
+  return stateDir;
+}
+
+function writeLegacyApproval(stateDir: string, owner: "crestodian" | "openclaw"): string {
+  const sourcePath = path.join(stateDir, owner, "rescue-pending", "approval.json");
+  fs.mkdirSync(path.dirname(sourcePath), { recursive: true });
+  fs.writeFileSync(sourcePath, "{}\n");
+  return sourcePath;
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("legacy rescue pending cleanup", () => {
+  it("discards both retired stores only during explicit doctor migration", () => {
+    const stateDir = makeStateDir();
+    const crestodianPath = writeLegacyApproval(stateDir, "crestodian");
+    const openclawPath = writeLegacyApproval(stateDir, "openclaw");
+
+    const runtimeDetection = detectLegacyRescuePending({ stateDir });
+    expect(runtimeDetection.hasLegacy).toBe(false);
+    expect(discardLegacyRescuePending({ detected: runtimeDetection, stateDir })).toEqual({
+      changes: [],
+      warnings: [],
+    });
+    expect(fs.existsSync(crestodianPath)).toBe(true);
+    expect(fs.existsSync(openclawPath)).toBe(true);
+
+    const doctorDetection = detectLegacyRescuePending({
+      stateDir,
+      doctorOnlyStateMigrations: true,
+    });
+    expect(doctorDetection.hasLegacy).toBe(true);
+    const result = discardLegacyRescuePending({ detected: doctorDetection, stateDir });
+
+    expect(result.warnings).toEqual([]);
+    expect(result.changes).toHaveLength(1);
+    expect(fs.existsSync(crestodianPath)).toBe(false);
+    expect(fs.existsSync(openclawPath)).toBe(false);
+    expect(detectLegacyRescuePending({ stateDir, doctorOnlyStateMigrations: true }).hasLegacy).toBe(
+      false,
+    );
+  });
+
+  it("recomputes fixed owner paths instead of trusting detection paths", () => {
+    const stateDir = makeStateDir();
+    const openclawPath = writeLegacyApproval(stateDir, "openclaw");
+
+    discardLegacyRescuePending({
+      detected: { hasLegacy: true, sourcePaths: [path.join(stateDir, "untrusted")] },
+      stateDir,
+    });
+
+    expect(fs.existsSync(openclawPath)).toBe(false);
+  });
+
+  it("refuses to traverse a symlinked owner directory", () => {
+    const stateDir = makeStateDir();
+    const externalDir = makeStateDir();
+    const externalApproval = writeLegacyApproval(externalDir, "openclaw");
+    fs.symlinkSync(path.join(externalDir, "openclaw"), path.join(stateDir, "openclaw"));
+
+    const detected = detectLegacyRescuePending({ stateDir, doctorOnlyStateMigrations: true });
+    const result = discardLegacyRescuePending({ detected, stateDir });
+
+    expect(result.changes).toEqual([]);
+    expect(result.warnings).toEqual([
+      expect.stringContaining("Refused to remove retired rescue approvals through unsafe path"),
+    ]);
+    expect(fs.existsSync(externalApproval)).toBe(true);
+  });
+});

--- a/src/infra/state-migrations.rescue-pending.test.ts
+++ b/src/infra/state-migrations.rescue-pending.test.ts
@@ -1,18 +1,16 @@
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import {
   detectLegacyRescuePending,
   discardLegacyRescuePending,
 } from "./state-migrations.rescue-pending.js";
 
-const tempDirs: string[] = [];
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 function makeStateDir(): string {
-  const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-rescue-migration-"));
-  tempDirs.push(stateDir);
-  return stateDir;
+  return tempDirs.make("openclaw-rescue-migration-");
 }
 
 function writeLegacyApproval(stateDir: string, owner: "crestodian" | "openclaw"): string {
@@ -21,12 +19,6 @@ function writeLegacyApproval(stateDir: string, owner: "crestodian" | "openclaw")
   fs.writeFileSync(sourcePath, "{}\n");
   return sourcePath;
 }
-
-afterEach(() => {
-  for (const dir of tempDirs.splice(0)) {
-    fs.rmSync(dir, { recursive: true, force: true });
-  }
-});
 
 describe("legacy rescue pending cleanup", () => {
   it("discards both retired stores only during explicit doctor migration", () => {

--- a/src/infra/state-migrations.rescue-pending.ts
+++ b/src/infra/state-migrations.rescue-pending.ts
@@ -1,12 +1,7 @@
 // Doctor-only cleanup for retired system-agent rescue approval directories.
 import fs from "node:fs";
 import path from "node:path";
-import type { MigrationMessages } from "./state-migrations.types.js";
-
-export type LegacyRescuePendingDetection = {
-  sourcePaths: string[];
-  hasLegacy: boolean;
-};
+import type { LegacyRescuePendingDetection, MigrationMessages } from "./state-migrations.types.js";
 
 function resolveLegacyRescuePendingPaths(stateDir: string): string[] {
   return ["crestodian", "openclaw"].map((owner) => path.join(stateDir, owner, "rescue-pending"));

--- a/src/infra/state-migrations.rescue-pending.ts
+++ b/src/infra/state-migrations.rescue-pending.ts
@@ -1,0 +1,79 @@
+// Doctor-only cleanup for retired system-agent rescue approval directories.
+import fs from "node:fs";
+import path from "node:path";
+import type { MigrationMessages } from "./state-migrations.types.js";
+
+export type LegacyRescuePendingDetection = {
+  sourcePaths: string[];
+  hasLegacy: boolean;
+};
+
+function resolveLegacyRescuePendingPaths(stateDir: string): string[] {
+  return ["crestodian", "openclaw"].map((owner) => path.join(stateDir, owner, "rescue-pending"));
+}
+
+function isSafeLegacyOwnerDirectory(stateDir: string, sourcePath: string): boolean {
+  const ownerPath = path.dirname(sourcePath);
+  try {
+    const owner = fs.lstatSync(ownerPath);
+    return (
+      owner.isDirectory() &&
+      !owner.isSymbolicLink() &&
+      path.resolve(path.dirname(ownerPath)) === path.resolve(stateDir)
+    );
+  } catch {
+    return false;
+  }
+}
+
+/** Detect retired security capabilities only during an explicit doctor run. */
+export function detectLegacyRescuePending(params: {
+  stateDir: string;
+  doctorOnlyStateMigrations?: boolean;
+}): LegacyRescuePendingDetection {
+  const sourcePaths = resolveLegacyRescuePendingPaths(params.stateDir);
+  return {
+    sourcePaths,
+    hasLegacy:
+      params.doctorOnlyStateMigrations === true &&
+      sourcePaths.some((sourcePath) => fs.existsSync(sourcePath)),
+  };
+}
+
+/** Discard retired one-shot capabilities; importing them could reactivate stale writes. */
+export function discardLegacyRescuePending(params: {
+  detected: LegacyRescuePendingDetection;
+  stateDir: string;
+}): MigrationMessages {
+  if (!params.detected.hasLegacy) {
+    return { changes: [], warnings: [] };
+  }
+
+  const removed: string[] = [];
+  const warnings: string[] = [];
+  // Recompute fixed owner paths instead of trusting paths carried through a
+  // stale detection result; doctor must never turn detection data into rm authority.
+  for (const sourcePath of resolveLegacyRescuePendingPaths(params.stateDir)) {
+    if (!fs.existsSync(sourcePath)) {
+      continue;
+    }
+    if (!isSafeLegacyOwnerDirectory(params.stateDir, sourcePath)) {
+      warnings.push(`Refused to remove retired rescue approvals through unsafe path ${sourcePath}`);
+      continue;
+    }
+    try {
+      fs.rmSync(sourcePath, { recursive: true, force: true });
+      removed.push(sourcePath);
+    } catch (error) {
+      warnings.push(`Failed removing retired rescue approvals at ${sourcePath}: ${String(error)}`);
+    }
+  }
+
+  return {
+    changes:
+      removed.length > 0
+        ? [`Discarded retired system-agent rescue approvals from ${removed.join(", ")}`]
+        : [],
+    warnings,
+  };
+}

--- a/src/infra/state-migrations.types.ts
+++ b/src/infra/state-migrations.types.ts
@@ -2,7 +2,11 @@ import type { ChannelLegacyStateMigrationPlan } from "../channels/plugins/types.
 import type { SessionScope } from "../config/sessions/types.js";
 import type { PluginDoctorStateMigration } from "../plugins/doctor-contract-registry.js";
 import type { LegacyChannelPairingStateDetection } from "./state-migrations.channel-pairing.js";
-import type { LegacyRescuePendingDetection } from "./state-migrations.rescue-pending.js";
+
+export type LegacyRescuePendingDetection = {
+  sourcePaths: string[];
+  hasLegacy: boolean;
+};
 
 export type SessionStoreAliasPlan = {
   hasDistinctAliases: boolean;

--- a/src/infra/state-migrations.types.ts
+++ b/src/infra/state-migrations.types.ts
@@ -2,6 +2,7 @@ import type { ChannelLegacyStateMigrationPlan } from "../channels/plugins/types.
 import type { SessionScope } from "../config/sessions/types.js";
 import type { PluginDoctorStateMigration } from "../plugins/doctor-contract-registry.js";
 import type { LegacyChannelPairingStateDetection } from "./state-migrations.channel-pairing.js";
+import type { LegacyRescuePendingDetection } from "./state-migrations.rescue-pending.js";
 
 export type SessionStoreAliasPlan = {
   hasDistinctAliases: boolean;
@@ -91,6 +92,7 @@ export type LegacyStateDetection = {
     sourcePath: string;
     hasLegacy: boolean;
   };
+  rescuePending: LegacyRescuePendingDetection;
   channelPairing: LegacyChannelPairingStateDetection;
   execApprovals: {
     sourcePath: string;

--- a/src/system-agent/rescue-message.test.ts
+++ b/src/system-agent/rescue-message.test.ts
@@ -276,6 +276,25 @@ describe("OpenClaw rescue message", () => {
     expect(reply).toContain("openclaw onboard");
   });
 
+  it("refuses doctor repairs without creating a pending approval", async () => {
+    await withRescueStateDir("doctor-fix-refused-", async () => {
+      const cfg: OpenClawConfig = { systemAgent: { rescue: { enabled: true } } };
+      const deps = {
+        runDoctor: vi.fn(async () => {
+          throw new Error("remote rescue must not run doctor repair");
+        }),
+      };
+
+      await expect(
+        runRescue("/openclaw doctor fix", cfg, commandContext(), deps),
+      ).resolves.toContain("run `openclaw doctor --fix` in a terminal");
+      await expect(runRescue("/openclaw yes", cfg, commandContext(), deps)).resolves.toBe(
+        "No pending OpenClaw rescue change is waiting for approval.",
+      );
+      expect(deps.runDoctor).not.toHaveBeenCalled();
+    });
+  });
+
   it("drops a pending rescue change on decline", async () => {
     await withRescueStateDir("decline-", async () => {
       const cfg: OpenClawConfig = { systemAgent: { rescue: { enabled: true } } };

--- a/src/system-agent/rescue-message.test.ts
+++ b/src/system-agent/rescue-message.test.ts
@@ -406,7 +406,7 @@ describe("OpenClaw rescue message", () => {
     });
   });
 
-  it("approves only the latest persistent plan in one route", async () => {
+  it("publishes concurrently invoked persistent plans in call order", async () => {
     await withRescueStateDir("latest-plan-", async () => {
       const cfg: OpenClawConfig = { systemAgent: { rescue: { enabled: true } } };
       const deps = {
@@ -414,8 +414,10 @@ describe("OpenClaw rescue message", () => {
         runGatewayStart: vi.fn(async () => {}),
       };
 
-      await runRescue("/openclaw restart gateway", cfg, commandContext(), deps);
-      await runRescue("/openclaw start gateway", cfg, commandContext(), deps);
+      const olderPlan = runRescue("/openclaw restart gateway", cfg, commandContext(), deps);
+      const newerPlan = runRescue("/openclaw start gateway", cfg, commandContext(), deps);
+      await expect(olderPlan).resolves.toContain("restart the Gateway");
+      await expect(newerPlan).resolves.toContain("start the Gateway");
       await expect(runRescue("/openclaw yes", cfg, commandContext(), deps)).resolves.toContain(
         "[openclaw] done: gateway.start",
       );

--- a/src/system-agent/rescue-message.test.ts
+++ b/src/system-agent/rescue-message.test.ts
@@ -2,9 +2,13 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { CommandContext } from "../auto-reply/reply/commands-types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import {
+  createCorePluginStateSyncKeyedStore,
+  resetPluginStateStoreForTests,
+} from "../plugin-state/plugin-state-store.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { withEnvAsync } from "../test-utils/env.js";
 import { extractSystemAgentRescueMessage, runSystemAgentRescueMessage } from "./rescue-message.js";
@@ -129,7 +133,12 @@ async function withRescueStateDir(
   run: (stateDir: string) => Promise<void>,
 ): Promise<void> {
   const stateDir = await makeStateDir(prefix);
-  await withEnvAsync({ OPENCLAW_STATE_DIR: stateDir }, async () => await run(stateDir));
+  resetPluginStateStoreForTests();
+  try {
+    await withEnvAsync({ OPENCLAW_STATE_DIR: stateDir }, async () => await run(stateDir));
+  } finally {
+    resetPluginStateStoreForTests();
+  }
 }
 
 function commandContext(overrides: Partial<CommandContext> = {}): CommandContext {
@@ -137,6 +146,7 @@ function commandContext(overrides: Partial<CommandContext> = {}): CommandContext
     surface: "whatsapp",
     channel: "whatsapp",
     channelId: "whatsapp",
+    accountId: "default",
     ownerList: ["user:owner"],
     senderIsOwner: true,
     isAuthorizedSender: true,
@@ -147,6 +157,15 @@ function commandContext(overrides: Partial<CommandContext> = {}): CommandContext
     to: "account:default",
     ...overrides,
   };
+}
+
+function openRescuePendingTestStore() {
+  return createCorePluginStateSyncKeyedStore<unknown>({
+    ownerId: "core:system-agent",
+    namespace: "rescue-pending",
+    maxEntries: 1_024,
+    overflowPolicy: "reject-new",
+  });
 }
 
 function requireFirstMockCall<T>(mock: { mock: { calls: T[][] } }, label: string): T[] {
@@ -185,6 +204,11 @@ describe("OpenClaw rescue message", () => {
     if (tempRoot) {
       await fs.rm(tempRoot, { recursive: true, force: true });
     }
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    resetPluginStateStoreForTests();
   });
 
   it("recognizes the OpenClaw rescue command", () => {
@@ -270,6 +294,180 @@ describe("OpenClaw rescue message", () => {
     });
   });
 
+  it("revokes a pending write when a fresh read-only command arrives", async () => {
+    await withRescueStateDir("read-revokes-", async () => {
+      const cfg: OpenClawConfig = { systemAgent: { rescue: { enabled: true } } };
+      const deps = {
+        runGatewayRestart: vi.fn(async () => {}),
+        runPluginsList: vi.fn(async (runtime: RuntimeEnv) => runtime.log("plugin rows")),
+      };
+
+      await expect(
+        runRescue("/openclaw restart gateway", cfg, commandContext(), deps),
+      ).resolves.toContain("Reply /openclaw yes to apply");
+      await expect(runRescue("/openclaw plugins list", cfg, commandContext(), deps)).resolves.toBe(
+        "plugin rows",
+      );
+      await expect(runRescue("/openclaw yes", cfg, commandContext(), deps)).resolves.toBe(
+        "No pending OpenClaw rescue change is waiting for approval.",
+      );
+      expect(deps.runGatewayRestart).not.toHaveBeenCalled();
+    });
+  });
+
+  it("consumes a pending approval at most once under concurrent approvals", async () => {
+    await withRescueStateDir("concurrent-approve-", async () => {
+      const cfg: OpenClawConfig = { systemAgent: { rescue: { enabled: true } } };
+      const deps = { runGatewayRestart: vi.fn(async () => {}) };
+
+      await runRescue("/openclaw restart gateway", cfg, commandContext(), deps);
+      const replies = await Promise.all([
+        runRescue("/openclaw yes", cfg, commandContext(), deps),
+        runRescue("/openclaw yes", cfg, commandContext(), deps),
+      ]);
+
+      expect(deps.runGatewayRestart).toHaveBeenCalledTimes(1);
+      expect(replies).toContain("No pending OpenClaw rescue change is waiting for approval.");
+      expect(replies.some((reply) => reply?.includes("[openclaw] done: gateway.restart"))).toBe(
+        true,
+      );
+    });
+  });
+
+  it("keeps failed execution consumed", async () => {
+    await withRescueStateDir("failed-consumed-", async () => {
+      const cfg: OpenClawConfig = { systemAgent: { rescue: { enabled: true } } };
+      const deps = {
+        runGatewayRestart: vi.fn(async () => {
+          throw new Error("restart failed");
+        }),
+      };
+
+      await runRescue("/openclaw restart gateway", cfg, commandContext(), deps);
+      await expect(runRescue("/openclaw yes", cfg, commandContext(), deps)).rejects.toThrow(
+        "restart failed",
+      );
+      await expect(runRescue("/openclaw yes", cfg, commandContext(), deps)).resolves.toBe(
+        "No pending OpenClaw rescue change is waiting for approval.",
+      );
+      expect(deps.runGatewayRestart).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("preserves a new plan created while the consumed plan executes", async () => {
+    await withRescueStateDir("replacement-during-execute-", async () => {
+      const cfg: OpenClawConfig = { systemAgent: { rescue: { enabled: true } } };
+      let releaseRestart: (() => void) | undefined;
+      let noteRestartEntered: (() => void) | undefined;
+      const restartEntered = new Promise<void>((resolve) => {
+        noteRestartEntered = resolve;
+      });
+      const restartGate = new Promise<void>((resolve) => {
+        releaseRestart = resolve;
+      });
+      const deps = {
+        runGatewayRestart: vi.fn(async () => {
+          noteRestartEntered?.();
+          await restartGate;
+        }),
+        runGatewayStart: vi.fn(async () => {}),
+      };
+
+      await runRescue("/openclaw restart gateway", cfg, commandContext(), deps);
+      const approval = runRescue("/openclaw yes", cfg, commandContext(), deps);
+      await restartEntered;
+      await runRescue("/openclaw start gateway", cfg, commandContext(), deps);
+      releaseRestart?.();
+      await expect(approval).resolves.toContain("[openclaw] done: gateway.restart");
+      await expect(runRescue("/openclaw yes", cfg, commandContext(), deps)).resolves.toContain(
+        "[openclaw] done: gateway.start",
+      );
+      expect(deps.runGatewayRestart).toHaveBeenCalledTimes(1);
+      expect(deps.runGatewayStart).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("approves only the latest persistent plan in one route", async () => {
+    await withRescueStateDir("latest-plan-", async () => {
+      const cfg: OpenClawConfig = { systemAgent: { rescue: { enabled: true } } };
+      const deps = {
+        runGatewayRestart: vi.fn(async () => {}),
+        runGatewayStart: vi.fn(async () => {}),
+      };
+
+      await runRescue("/openclaw restart gateway", cfg, commandContext(), deps);
+      await runRescue("/openclaw start gateway", cfg, commandContext(), deps);
+      await expect(runRescue("/openclaw yes", cfg, commandContext(), deps)).resolves.toContain(
+        "[openclaw] done: gateway.start",
+      );
+      expect(deps.runGatewayRestart).not.toHaveBeenCalled();
+      expect(deps.runGatewayStart).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("persists a pending approval only in SQLite across store reopen", async () => {
+    await withRescueStateDir("sqlite-reopen-", async (stateDir) => {
+      const cfg: OpenClawConfig = { systemAgent: { rescue: { enabled: true } } };
+      const deps = { runGatewayRestart: vi.fn(async () => {}) };
+
+      await runRescue("/openclaw restart gateway", cfg, commandContext(), deps);
+      resetPluginStateStoreForTests();
+
+      await expect(runRescue("/openclaw yes", cfg, commandContext(), deps)).resolves.toContain(
+        "[openclaw] done: gateway.restart",
+      );
+      expect(deps.runGatewayRestart).toHaveBeenCalledTimes(1);
+      await expect(fs.access(path.join(stateDir, "openclaw", "rescue-pending"))).rejects.toThrow(
+        /ENOENT/,
+      );
+    });
+  });
+
+  it("isolates pending approvals by account, channel, and sender", async () => {
+    await withRescueStateDir("route-isolation-", async () => {
+      const cfg: OpenClawConfig = { systemAgent: { rescue: { enabled: true } } };
+      const deps = { runGatewayRestart: vi.fn(async () => {}) };
+      const original = commandContext();
+
+      await runRescue("/openclaw restart gateway", cfg, original, deps);
+      for (const isolated of [
+        commandContext({ accountId: "secondary" }),
+        commandContext({ channelId: "telegram" }),
+        commandContext({ from: "user:other", senderId: "user:other" }),
+      ]) {
+        await expect(runRescue("/openclaw yes", cfg, isolated, deps)).resolves.toBe(
+          "No pending OpenClaw rescue change is waiting for approval.",
+        );
+      }
+      await expect(runRescue("/openclaw yes", cfg, original, deps)).resolves.toContain(
+        "[openclaw] done: gateway.restart",
+      );
+      expect(deps.runGatewayRestart).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("falls back to the channel destination when account id is absent", async () => {
+    await withRescueStateDir("route-account-fallback-", async () => {
+      const cfg: OpenClawConfig = { systemAgent: { rescue: { enabled: true } } };
+      const deps = { runGatewayRestart: vi.fn(async () => {}) };
+      const original = commandContext({ accountId: undefined, to: "bot:primary" });
+
+      await runRescue("/openclaw restart gateway", cfg, original, deps);
+      await expect(
+        runRescue(
+          "/openclaw yes",
+          cfg,
+          commandContext({ accountId: undefined, to: "bot:secondary" }),
+          deps,
+        ),
+      ).resolves.toBe("No pending OpenClaw rescue change is waiting for approval.");
+      await expect(runRescue("/openclaw yes", cfg, original, deps)).resolves.toContain(
+        "[openclaw] done: gateway.restart",
+      );
+      expect(deps.runGatewayRestart).toHaveBeenCalledTimes(1);
+    });
+  });
+
   it("refuses plugin install from remote rescue", async () => {
     const cfg: OpenClawConfig = { systemAgent: { rescue: { enabled: true } } };
     const deps = {
@@ -335,10 +533,11 @@ describe("OpenClaw rescue message", () => {
       expect(typeof model === "string" ? model : model?.primary).toBe("openai/gpt-5.2");
       const auditPath = path.join(tempDir, "audit", "system-agent.jsonl");
       const audit = JSON.parse((await fs.readFile(auditPath, "utf8")).trim()) as {
-        details?: { rescue?: boolean; channel?: string; senderId?: string };
+        details?: { rescue?: boolean; channel?: string; accountId?: string; senderId?: string };
       };
       expect(audit.details?.rescue).toBe(true);
       expect(audit.details?.channel).toBe("whatsapp");
+      expect(audit.details?.accountId).toBe("default");
       expect(audit.details?.senderId).toBe("user:owner");
     });
   });
@@ -388,29 +587,52 @@ describe("OpenClaw rescue message", () => {
     });
   });
 
-  it("rejects pending rescue approvals with invalid persisted expiry", async () => {
-    await withRescueStateDir("invalid-expiry-", async (tempDir) => {
+  it("expires pending approvals through the SQLite row TTL", async () => {
+    await withRescueStateDir("expired-", async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
       const cfg: OpenClawConfig = { systemAgent: { rescue: { enabled: true } } };
       const deps = { runGatewayRestart: vi.fn(async () => {}) };
 
-      await expect(
-        runRescue("/openclaw restart gateway", cfg, commandContext(), deps),
-      ).resolves.toContain("Reply /openclaw yes to apply");
-      const pendingDir = path.join(tempDir, "openclaw", "rescue-pending");
-      const [pendingFile] = await fs.readdir(pendingDir);
-      if (!pendingFile) {
-        throw new Error("expected pending rescue file");
-      }
-      const pendingPath = path.join(pendingDir, pendingFile);
-      const pending = JSON.parse(await fs.readFile(pendingPath, "utf8")) as { expiresAt?: string };
-      pending.expiresAt = "not-a-date";
-      await fs.writeFile(pendingPath, `${JSON.stringify(pending, null, 2)}\n`, "utf8");
+      await runRescue(
+        "/openclaw restart gateway",
+        { systemAgent: { rescue: { enabled: true, pendingTtlMinutes: 1 } } },
+        commandContext(),
+        deps,
+      );
+      vi.advanceTimersByTime(60_001);
 
       await expect(runRescue("/openclaw yes", cfg, commandContext(), deps)).resolves.toBe(
         "No pending OpenClaw rescue change is waiting for approval.",
       );
       expect(deps.runGatewayRestart).not.toHaveBeenCalled();
-      await expect(fs.stat(pendingPath)).rejects.toThrow(/ENOENT/);
+    });
+  });
+
+  it("consumes malformed pending rows without executing them", async () => {
+    await withRescueStateDir("malformed-", async () => {
+      const cfg: OpenClawConfig = { systemAgent: { rescue: { enabled: true } } };
+      const deps = { runGatewayRestart: vi.fn(async () => {}) };
+
+      await runRescue("/openclaw restart gateway", cfg, commandContext(), deps);
+      const store = openRescuePendingTestStore();
+      const [entry] = store.entries();
+      if (!entry) {
+        throw new Error("expected pending rescue row");
+      }
+      store.register(
+        entry.key,
+        { version: 1, operation: { kind: "gateway-restart", unexpected: true } },
+        { ttlMs: 60_000 },
+      );
+
+      await expect(runRescue("/openclaw yes", cfg, commandContext(), deps)).resolves.toBe(
+        "No pending OpenClaw rescue change is waiting for approval.",
+      );
+      await expect(runRescue("/openclaw yes", cfg, commandContext(), deps)).resolves.toBe(
+        "No pending OpenClaw rescue change is waiting for approval.",
+      );
+      expect(deps.runGatewayRestart).not.toHaveBeenCalled();
     });
   });
 

--- a/src/system-agent/rescue-message.ts
+++ b/src/system-agent/rescue-message.ts
@@ -239,6 +239,12 @@ function formatUnsupportedRemoteOperation(operation: SystemAgentOperation): stri
       "Run `openclaw onboard` locally; it live-tests the candidate route before saving it.",
     ].join(" ");
   }
+  if (operation.kind === "doctor-fix") {
+    return [
+      "OpenClaw rescue cannot run doctor repairs from a message channel because they can change the inference route powering this session.",
+      "Exit OpenClaw and run `openclaw doctor --fix` in a terminal.",
+    ].join(" ");
+  }
   if (operation.kind === "plugin-install") {
     return [
       "OpenClaw rescue cannot install plugins from a message channel by default because plugin install downloads executable code.",

--- a/src/system-agent/rescue-message.ts
+++ b/src/system-agent/rescue-message.ts
@@ -314,7 +314,7 @@ export async function runSystemAgentRescueMessage(
       nowMs === undefined
         ? undefined
         : resolveExpiresAtMsFromDurationMs(policy.pendingTtlMinutes * 60_000, { nowMs });
-    if (expiresAtMs === undefined) {
+    if (nowMs === undefined || expiresAtMs === undefined) {
       return "OpenClaw rescue could not create a pending approval because the expiry clock is invalid.";
     }
     const ttlMs = expiresAtMs - nowMs;

--- a/src/system-agent/rescue-message.ts
+++ b/src/system-agent/rescue-message.ts
@@ -1,15 +1,12 @@
 // OpenClaw rescue messages expose approved setup-helper commands over message channels.
-import { createHash, randomUUID } from "node:crypto";
-import fs from "node:fs/promises";
-import path from "node:path";
+import { createHash } from "node:crypto";
 import {
   asDateTimestampMs,
   resolveExpiresAtMsFromDurationMs,
 } from "@openclaw/normalization-core/number-coercion";
 import type { CommandContext } from "../auto-reply/reply/commands-types.js";
-import { resolveStateDir } from "../config/paths.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { tryReadJson, writeJson } from "../infra/json-files.js";
+import { createCorePluginStateSyncKeyedStore } from "../plugin-state/plugin-state-store.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { classifySystemAgentApprovalText } from "./approval-intent.js";
 import {
@@ -30,11 +27,8 @@ import { resolveSystemAgentRescuePolicy } from "./rescue-policy.js";
  * command output without exposing local TUI or plugin-install flows remotely.
  */
 type RescuePendingOperation = {
-  id: string;
-  createdAt: string;
-  expiresAt: string;
+  version: 1;
   operation: SystemAgentOperation;
-  auditDetails: Record<string, unknown>;
 };
 
 /** Input required to process one possible `/openclaw` rescue message. */
@@ -49,6 +43,8 @@ type SystemAgentRescueMessageInput = {
 };
 
 const SYSTEM_AGENT_COMMAND = "/openclaw";
+const RESCUE_PENDING_NAMESPACE = "rescue-pending";
+const RESCUE_PENDING_MAX_ENTRIES = 1_024;
 
 function createCaptureRuntime(): { runtime: RuntimeEnv; read: () => string } {
   const lines: string[] = [];
@@ -77,56 +73,141 @@ export function extractSystemAgentRescueMessage(commandBody: string): string | n
   return normalized.slice(SYSTEM_AGENT_COMMAND.length).trim();
 }
 
-function resolvePendingDir(env: NodeJS.ProcessEnv = process.env): string {
-  return path.join(resolveStateDir(env), "openclaw", "rescue-pending");
-}
-
-function resolvePendingPath(input: SystemAgentRescueMessageInput): string {
-  // Pending approval is scoped by sender/channel identity so unrelated chats cannot approve it.
+function resolvePendingKey(input: SystemAgentRescueMessageInput): string {
+  // Pending approval is scoped by account, channel, and sender identity so one
+  // owner route cannot approve a capability proposed through another route.
   const key = JSON.stringify({
+    accountId: resolveAccountDiscriminator(input.command),
     channel: input.command.channelId ?? input.command.channel,
     from: input.command.from,
     senderId: input.command.senderId,
   });
-  const digest = createHash("sha256").update(key).digest("hex").slice(0, 32);
-  return path.join(resolvePendingDir(input.env), `${digest}.json`);
+  return createHash("sha256").update(key).digest("hex").slice(0, 32);
 }
 
-async function readPending(
-  pendingPath: string,
-  now = new Date(),
-): Promise<RescuePendingOperation | null> {
-  try {
-    const parsed = await tryReadJson<RescuePendingOperation>(pendingPath);
-    if (!parsed) {
-      return null;
-    }
-    const expiresAtMs = asDateTimestampMs(Date.parse(parsed.expiresAt));
-    const nowMs = asDateTimestampMs(now.getTime());
-    if (expiresAtMs === undefined || nowMs === undefined || expiresAtMs <= nowMs) {
-      // Expired rescue approvals are deleted before returning so stale writes cannot linger.
-      await fs.rm(pendingPath, { force: true });
-      return null;
-    }
-    return parsed;
-  } catch {
+function resolveAccountDiscriminator(command: CommandContext): string {
+  return command.accountId?.trim() || command.to?.trim() || "default";
+}
+
+function openPendingStore(env?: NodeJS.ProcessEnv) {
+  return createCorePluginStateSyncKeyedStore<unknown>({
+    ownerId: "core:system-agent",
+    namespace: RESCUE_PENDING_NAMESPACE,
+    maxEntries: RESCUE_PENDING_MAX_ENTRIES,
+    overflowPolicy: "reject-new",
+    ...(env ? { env } : {}),
+  });
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    !Array.isArray(value) &&
+    Object.getPrototypeOf(value) === Object.prototype
+  );
+}
+
+function hasExactKeys(
+  value: Record<string, unknown>,
+  required: readonly string[],
+  optional: readonly string[] = [],
+): boolean {
+  const allowed = new Set([...required, ...optional]);
+  return (
+    required.every((key) => Object.hasOwn(value, key)) &&
+    Object.keys(value).every((key) => allowed.has(key))
+  );
+}
+
+function hasOptionalString(value: Record<string, unknown>, key: string): boolean {
+  return !Object.hasOwn(value, key) || isNonEmptyString(value[key]);
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function parsePendingOperation(value: unknown): SystemAgentOperation | null {
+  if (!isPlainRecord(value) || value.version !== 1 || !isPlainRecord(value.operation)) {
     return null;
   }
-}
-
-async function writePending(pendingPath: string, pending: RescuePendingOperation): Promise<void> {
-  await writeJson(pendingPath, pending, {
-    dirMode: 0o700,
-    mode: 0o600,
-    trailingNewline: true,
-  });
+  const operation = value.operation;
+  if (typeof operation.kind !== "string") {
+    return null;
+  }
+  switch (operation.kind) {
+    case "set-default-model":
+      if (!hasExactKeys(operation, ["kind", "model"]) || !isNonEmptyString(operation.model)) {
+        return null;
+      }
+      break;
+    case "config-set":
+      if (
+        !hasExactKeys(operation, ["kind", "path", "value"]) ||
+        !isNonEmptyString(operation.path) ||
+        !isNonEmptyString(operation.value)
+      ) {
+        return null;
+      }
+      break;
+    case "config-set-ref":
+      if (
+        !hasExactKeys(operation, ["kind", "path", "source", "id"], ["provider"]) ||
+        !isNonEmptyString(operation.path) ||
+        (operation.source !== "env" &&
+          operation.source !== "file" &&
+          operation.source !== "exec") ||
+        !isNonEmptyString(operation.id) ||
+        !hasOptionalString(operation, "provider")
+      ) {
+        return null;
+      }
+      break;
+    case "setup":
+      if (
+        !hasExactKeys(operation, ["kind"], ["workspace", "model"]) ||
+        !hasOptionalString(operation, "workspace") ||
+        !hasOptionalString(operation, "model")
+      ) {
+        return null;
+      }
+      break;
+    case "plugin-install":
+      if (!hasExactKeys(operation, ["kind", "spec"]) || !isNonEmptyString(operation.spec)) {
+        return null;
+      }
+      break;
+    case "create-agent":
+      if (
+        !hasExactKeys(operation, ["kind", "agentId"], ["workspace", "model"]) ||
+        !isNonEmptyString(operation.agentId) ||
+        !hasOptionalString(operation, "workspace") ||
+        !hasOptionalString(operation, "model")
+      ) {
+        return null;
+      }
+      break;
+    case "gateway-start":
+    case "gateway-stop":
+    case "gateway-restart":
+      if (!hasExactKeys(operation, ["kind"])) {
+        return null;
+      }
+      break;
+    default:
+      return null;
+  }
+  return isPersistentSystemAgentOperation(operation as SystemAgentOperation)
+    ? (operation as SystemAgentOperation)
+    : null;
 }
 
 function buildAuditDetails(input: SystemAgentRescueMessageInput): Record<string, unknown> {
   return {
     rescue: true,
     channel: input.command.channelId ?? input.command.channel,
-    accountId: input.command.to,
+    accountId: resolveAccountDiscriminator(input.command),
     senderId: input.command.senderId,
     from: input.command.from,
   };
@@ -185,37 +266,41 @@ export async function runSystemAgentRescueMessage(
     return policy.message;
   }
 
-  const pendingPath = resolvePendingPath(input);
+  const pendingStore = openPendingStore(input.env);
+  const pendingKey = resolvePendingKey(input);
+  const approvalIntent = classifySystemAgentApprovalText(rescueMessage);
   // Remote rescue never consults a model (a broken/compromised agent path must
   // not become a config editor); approval stays on the closed deterministic list.
-  if (classifySystemAgentApprovalText(rescueMessage) === "approve") {
-    const pending = await readPending(pendingPath);
-    if (!pending) {
+  if (approvalIntent === "approve") {
+    // Consume before any async execution. Concurrent approvals get at most one
+    // capability, and a failed execution cannot leave a replayable write.
+    const operation = parsePendingOperation(pendingStore.consume(pendingKey));
+    if (!operation) {
       return "No pending OpenClaw rescue change is waiting for approval.";
     }
-    const unsupported = formatUnsupportedRemoteOperation(pending.operation);
+    const unsupported = formatUnsupportedRemoteOperation(operation);
     if (unsupported) {
-      await fs.rm(pendingPath, { force: true });
       return unsupported;
     }
     const capture = createCaptureRuntime();
-    await executeSystemAgentOperation(pending.operation, capture.runtime, {
+    await executeSystemAgentOperation(operation, capture.runtime, {
       approved: true,
-      auditDetails: pending.auditDetails,
+      auditDetails: buildAuditDetails(input),
       deps: input.deps,
     });
-    await fs.rm(pendingPath, { force: true });
     return capture.read() || "OpenClaw rescue change applied.";
   }
 
-  if (classifySystemAgentApprovalText(rescueMessage) === "decline") {
-    const pending = await readPending(pendingPath);
-    await fs.rm(pendingPath, { force: true });
+  if (approvalIntent === "decline") {
+    const pending = parsePendingOperation(pendingStore.consume(pendingKey));
     return pending
       ? "Dropped the pending OpenClaw rescue change."
       : "No pending OpenClaw rescue change is waiting for approval.";
   }
 
+  // Any fresh command revokes the previous capability for this exact route.
+  // Persistent commands below replace it with their newly rendered plan.
+  pendingStore.delete(pendingKey);
   const operation = parseSystemAgentOperation(rescueMessage);
   const unsupported = formatUnsupportedRemoteOperation(operation);
   if (unsupported) {
@@ -232,13 +317,15 @@ export async function runSystemAgentRescueMessage(
     if (expiresAtMs === undefined) {
       return "OpenClaw rescue could not create a pending approval because the expiry clock is invalid.";
     }
-    await writePending(pendingPath, {
-      id: randomUUID(),
-      createdAt: now.toISOString(),
-      expiresAt: new Date(expiresAtMs).toISOString(),
-      operation,
-      auditDetails: buildAuditDetails(input),
-    });
+    const ttlMs = expiresAtMs - nowMs;
+    pendingStore.register(
+      pendingKey,
+      {
+        version: 1,
+        operation,
+      } satisfies RescuePendingOperation,
+      { ttlMs },
+    );
     return formatPersistentPlan(operation);
   }
 

--- a/src/system-agent/rescue-message.ts
+++ b/src/system-agent/rescue-message.ts
@@ -306,6 +306,8 @@ export async function runSystemAgentRescueMessage(
 
   // Any fresh command revokes the previous capability for this exact route.
   // Persistent commands below replace it with their newly rendered plan.
+  // Keep parse and registration below synchronous: invocation order must stay
+  // publication order. Async validation begins only after approval consumes the row.
   pendingStore.delete(pendingKey);
   const operation = parseSystemAgentOperation(rescueMessage);
   const unsupported = formatUnsupportedRemoteOperation(operation);

--- a/test/scripts/check-database-first-legacy-stores.test.ts
+++ b/test/scripts/check-database-first-legacy-stores.test.ts
@@ -185,6 +185,23 @@ describe("check-database-first-legacy-stores", () => {
     expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 4 }]);
   });
 
+  it("flags runtime writes to retired system-agent rescue approval stores", () => {
+    const violations = collectDatabaseFirstLegacyStoreViolations(
+      `
+        import { promises as fs } from "node:fs";
+        import path from "node:path";
+        await fs.writeFile(path.join(stateDir, "openclaw", "rescue-pending", \`\${key}.json\`), "{}\\n");
+        await fs.writeFile(path.join(stateDir, "crestodian", "rescue-pending", "old.json"), "{}\\n");
+      `,
+      "src/system-agent/rescue-writer.ts",
+    );
+
+    expect(violations).toEqual([
+      { kind: "legacy store filesystem write", line: 4 },
+      { kind: "legacy store filesystem write", line: 5 },
+    ]);
+  });
+
   it("flags legacy paths with dynamic agent id segments", () => {
     const violations = collectDatabaseFirstLegacyStoreViolations(
       `

--- a/test/scripts/docker-e2e-system-agent.test.ts
+++ b/test/scripts/docker-e2e-system-agent.test.ts
@@ -51,8 +51,11 @@ describe("OpenClaw Docker E2E scripts", () => {
     expect(source).toContain("runSystemAgentRescueMessage({");
     expect(source).toContain("sandboxing is active");
     expect(source).toContain("cannot open the local TUI");
+    expect(source).toContain("fresh rescue command did not revoke the older pending change");
     expect(source).toContain("[openclaw] done: gateway.restart");
-    expect(source).toContain("[openclaw] done: doctor.fix");
+    expect(source).toContain("remote doctor fix did not point to the local repair command");
+    expect(source).toContain("remote rescue must not invoke doctor repair");
+    expect(source).not.toContain("[openclaw] done: doctor.fix");
     expect(source).toContain("OpenClaw rescue Docker E2E passed");
   });
 });


### PR DESCRIPTION
Fixes #102930
Related #107227
Supersedes #103143

Thanks @yungchentang for identifying the stale-approval path and proposing the original fix.

## What Problem This Solves

Fixes an issue where users could send a new non-persistent rescue command after staging a persistent rescue change, then accidentally approve and execute the stale change later. Pending rescue approvals were also stored as JSON capabilities outside the canonical SQLite state store.

## Why This Change Was Made

Pending rescue approvals now live only in the shared SQLite plugin-state store, scoped by account, channel, and sender. Approval atomically consumes the capability before execution, every fresh rescue command revokes the previous capability for that route, and malformed or expired rows cannot execute.

Legacy JSON capability files are deliberately discarded by explicit doctor repair. They are never imported or read by steady-state runtime. Remote doctor repairs remain local-terminal-only.

## User Impact

Rescue approvals are one-use, route-isolated, expiry-backed, and replacement-safe. A newer rescue command cancels an older pending change, failed execution cannot leave a replayable approval, and restarts retain valid approvals without JSON sidecars.

Release note: System-agent rescue approvals now use SQLite and revoke stale pending changes before later approval.

## Evidence

- Focused regression suite: 584 tests passed across rescue handling, doctor migration, and database-first guard coverage.
- Packaged Docker rescue E2E passed on exact implementation behavior, including stale-approval revocation and local-only doctor repair.
- Blacksmith Testbox passed core and test type checks, script checks, targeted lint, database-first guards, import-cycle validation, build, package, and tarball proof.
- Full changed-gate blocker reproduced unchanged on clean current main: plugin SDK API baseline hash mismatch. All migration-owned lanes passed independently.
- Fresh full-branch autoreview: no accepted or actionable findings.
- Patch identity remained unchanged across the final main rebase; focused tests passed again on head.

AI-assisted: yes. Maintainer reviewed, refactored, and validated the final implementation.
