### PR TITLE
test(hooks): isolate Gmail setup module cache

### DIFF
--- a/scripts/deadcode-exports.baseline.mjs
+++ b/scripts/deadcode-exports.baseline.mjs
@@ -213,7 +213,6 @@ export const KNIP_UNUSED_EXPORT_BASELINE = [
   "src/entry.compile-cache.ts: shouldEnableOpenClawCompileCache",
   "src/flows/doctor-health-contributions.ts: createDoctorHealthContribution",
   "src/flows/doctor-health-contributions.ts: resolveDoctorHealthContributions",
-  "src/hooks/gmail-setup-utils.ts: resetGmailSetupUtilsCachesForTest",
   "src/logging/diagnostic-run-activity.ts: markDiagnosticModelStartedForTest",
   "src/logging/diagnostic-run-activity.ts: markDiagnosticRunProgressForTest",
   "src/logging/diagnostic-run-activity.ts: markDiagnosticToolStartedForTest",

--- a/src/hooks/gmail-setup-utils.test.ts
+++ b/src/hooks/gmail-setup-utils.test.ts
@@ -4,12 +4,6 @@ import os from "node:os";
 import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { withEnvAsync } from "../test-utils/env.js";
-import {
-  ensureTailscaleEndpoint,
-  resetGmailSetupUtilsCachesForTest,
-  runGcloud,
-} from "./gmail-setup-utils.js";
-
 const itUnix = process.platform === "win32" ? it.skip : it;
 const runCommandWithTimeoutMock = vi.fn();
 
@@ -18,14 +12,19 @@ vi.mock("../process/exec.js", () => ({
 }));
 
 beforeEach(() => {
+  vi.resetModules();
   runCommandWithTimeoutMock.mockClear();
-  resetGmailSetupUtilsCachesForTest();
 });
+
+async function loadGmailSetupUtils() {
+  return await import("./gmail-setup-utils.js");
+}
 
 describe("runGcloud interpreter resolution", () => {
   itUnix(
     "resolves a working python path and caches the result",
     async () => {
+      const { runGcloud } = await loadGmailSetupUtils();
       const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-python-"));
       try {
         const realPython = path.join(tmp, "python-real");
@@ -78,6 +77,7 @@ describe("runGcloud", () => {
   itUnix(
     "overrides an inherited CLOUDSDK_PYTHON value with a resolved interpreter",
     async () => {
+      const { runGcloud } = await loadGmailSetupUtils();
       const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gcloud-python-"));
       try {
         const realPython = path.join(tmp, "python-real");
@@ -132,6 +132,7 @@ describe("runGcloud", () => {
   );
 
   itUnix("unsets inherited CLOUDSDK_PYTHON when no trusted interpreter is found", async () => {
+    const { runGcloud } = await loadGmailSetupUtils();
     await withEnvAsync(
       {
         CLOUDSDK_PYTHON: "/tmp/attacker-python",
@@ -161,6 +162,7 @@ describe("runGcloud", () => {
 
 describe("ensureTailscaleEndpoint", () => {
   it("includes stdout and exit code when tailscale serve fails", async () => {
+    const { ensureTailscaleEndpoint } = await loadGmailSetupUtils();
     runCommandWithTimeoutMock
       .mockResolvedValueOnce({
         stdout: JSON.stringify({ Self: { DNSName: "host.tailnet.ts.net." } }),
@@ -194,6 +196,7 @@ describe("ensureTailscaleEndpoint", () => {
   });
 
   it("includes JSON parse failure details with stdout", async () => {
+    const { ensureTailscaleEndpoint } = await loadGmailSetupUtils();
     runCommandWithTimeoutMock.mockResolvedValueOnce({
       stdout: "not-json",
       stderr: "",
@@ -219,6 +222,7 @@ describe("ensureTailscaleEndpoint", () => {
   });
 
   it("passes abort signal to tailscale status and serve commands", async () => {
+    const { ensureTailscaleEndpoint } = await loadGmailSetupUtils();
     const abortController = new AbortController();
     runCommandWithTimeoutMock
       .mockResolvedValueOnce({

--- a/src/hooks/gmail-setup-utils.ts
+++ b/src/hooks/gmail-setup-utils.ts
@@ -13,10 +13,6 @@ let cachedPythonPath: string | null | undefined;
 let gcloudBin: string | undefined;
 const MAX_OUTPUT_CHARS = 800;
 
-export function resetGmailSetupUtilsCachesForTest(): void {
-  cachedPythonPath = undefined;
-}
-
 function trimOutput(value: string): string {
   const trimmed = value.trim();
   if (!trimmed) {


### PR DESCRIPTION
## What Problem This Solves

The dead-export ratchet still grandfathered a production cache-reset function used only by Gmail setup utility tests.

## Why This Change Was Made

Removes the production test seam and gives each test a fresh module instance with Vitest module isolation. Cache behavior remains covered through the retained runGcloud boundary.

## User Impact

No user-visible behavior change. Internal API surface and dead-export debt shrink.

## Evidence

- Production Knip baseline: 247 -> 246, with no additions or cascade.
- Focused Testbox: 6/6 Gmail setup utility tests and formatting green: https://github.com/openclaw/openclaw/actions/runs/29399830051
- Fresh autoreview: clean, 0.98 confidence.
- Final rebased Testbox: baseline regeneration byte-stable and exact deadcode 246/246: https://github.com/openclaw/openclaw/actions/runs/29400185278
- Scoped type-aware lint stalled without diagnostics on Testbox and was capped under the direct-land override.
- Production source delta excluding baseline: +0/-4, net -4 LOC; total source/test delta excluding baseline: +11/-11, net 0 LOC.
- Four newer main commits touch only Matrix, CI, Android, and session-catalog paths; no hooks or baseline overlap.
