### PR TITLE
test(ui): add regression coverage for sessionKey persistence

### DIFF
--- a/ui/src/app/gateway-store.test.ts
+++ b/ui/src/app/gateway-store.test.ts
@@ -15,6 +15,19 @@ const HELLO: GatewayHelloOk = {
   auth: { role: "operator", scopes: [] },
 };
 
+const HELLO_WITH_DEFAULTS: GatewayHelloOk = {
+  type: "hello-ok",
+  protocol: 1,
+  auth: { role: "operator", scopes: [] },
+  snapshot: {
+    sessionDefaults: {
+      mainSessionKey: "agent:agent-1:main",
+      defaultAgentId: "agent-1",
+      mainKey: "main",
+    },
+  },
+};
+
 class FakeGatewayClient {
   started = 0;
   stopped = 0;
@@ -232,5 +245,70 @@ describe("createApplicationGateway reconnecting snapshot", () => {
 
     expect(current().opts.url).toBe(otherGateway);
     expect(localStorage.getItem(selectionKey)).toBe(otherGateway);
+  });
+
+  it("persists sessionKey to localStorage on HELLO with session defaults (fresh browser)", () => {
+    const pageGateway = "ws://127.0.0.1:18789";
+    const settings = {
+      ...loadSettings(),
+      gatewayUrl: pageGateway,
+      token: "test-token",
+    };
+    const { gateway, current } = createStore({ settings });
+
+    // Fresh browser: default sessionKey is "main".
+    expect(loadSettings().sessionKey).toBe("main");
+
+    gateway.start();
+    // HELLO resolves the default sessionKey from sessionDefaults.
+    current().opts.onHello?.(HELLO_WITH_DEFAULTS);
+
+    // Snapshot gets the resolved sessionKey.
+    expect(gateway.snapshot.sessionKey).toBe("agent:agent-1:main");
+    // localStorage is persisted by onHello.
+    const stored = loadSettings();
+    expect(stored.sessionKey).toBe("agent:agent-1:main");
+  });
+
+  it("persists sessionKey to localStorage on sidebar click even when it matches snapshot", () => {
+    const pageGateway = "ws://127.0.0.1:18789";
+    const settings = {
+      ...loadSettings(),
+      gatewayUrl: pageGateway,
+      token: "test-token",
+    };
+    const { gateway, current } = createStore({ settings });
+
+    gateway.start();
+    current().opts.onHello?.(HELLO_WITH_DEFAULTS);
+    expect(gateway.snapshot.sessionKey).toBe("agent:agent-1:main");
+
+    // Click the same session in the sidebar — setSessionKey with matching key.
+    gateway.setSessionKey("agent:agent-1:main");
+
+    // Must persist even though it matches the in-memory value.
+    const stored = loadSettings();
+    expect(stored.sessionKey).toBe("agent:agent-1:main");
+  });
+
+  it("preserves sessionKey across reconnect without explicit override", () => {
+    const pageGateway = "ws://127.0.0.1:18789";
+    const settings = {
+      ...loadSettings(),
+      gatewayUrl: pageGateway,
+      token: "test-token",
+    };
+    const { gateway, current } = createStore({ settings });
+
+    gateway.start();
+    current().opts.onHello?.(HELLO_WITH_DEFAULTS);
+    expect(gateway.snapshot.sessionKey).toBe("agent:agent-1:main");
+
+    // Reconnect without an explicit sessionKey override.
+    gateway.connect();
+    expect(gateway.snapshot.sessionKey).toBe("agent:agent-1:main");
+
+    const stored = loadSettings();
+    expect(stored.sessionKey).toBe("agent:agent-1:main");
   });
 });


### PR DESCRIPTION
## Summary

Current main already persists sessionKey to localStorage via the onHello handler when HELLO resolves session defaults. Add regression tests to prevent reintroduction of the blank-chat-on-refresh bug (#108031).

- Problem: setSessionKey short-circuits when the key matches snapshot.sessionKey, and previously there was no HELLO-time persistence
- Solution: Current main already handles this via onHello persistence. This PR adds regression test coverage only.
- What changed: `ui/src/app/gateway-store.test.ts` (+78 lines, 3 new tests)
- What did NOT change: No source code changes to `gateway-store.ts`

## Change Type

- [x] Bug fix (regression test coverage)

## Scope

- [x] UI / DX

## Linked Issue

- Fixes #108031
- [x] This PR fixes a bug or regression

## Motivation

The Control UI showed a blank chat after page refresh when using multiple agents (#108031). The root cause was that setSessionKey short-circuited when the key matched snapshot.sessionKey, and HELLO didn't persist. Current main fixes this with HELLO-time persistence; this PR adds tests to guard against regression.

## Real behavior proof

- Behavior addressed: sessionKey persistence on HELLO with session defaults
- Real environment tested: Linux, Node 24.13, branch `fix/control-ui-session-persist-108031`
- Exact steps or command run after this patch:

```console
$ node scripts/run-vitest.mjs run ui/src/app/gateway-store.test.ts
```

- Evidence after fix (unit tests on rebased `b8b064a9483`):

```console
 Test Files  1 passed (1)
      Tests  12 passed (12)
```

- Playwright E2E proof (mock gateway, real Chromium):
  1. Start Vite dev server → launch Chromium → fresh browser context
  2. Navigate to chat → mock gateway issues HELLO with `sessionDefaults.mainSessionKey: "agent:main:multi-agent"`
  3. Verify `localStorage` was written with the correct sessionKey
  4. Reload the page → verify same sessionKey still in `localStorage`
  5. Verify the sidebar session row is visible after reload

- Proof transcript (`.artifacts/control-ui-e2e/session-persistence-proof/proof-output.txt`):

```
localStorage settings keys after HELLO: ["openclaw.control.settings.v1:ws://127.0.0.1:18789"]
sessionsByGateway: { "ws://127.0.0.1:18789": { "sessionKey": "agent:main:multi-agent", ... } }
✓ sessionKey correctly persisted

After page reload:
  Same localStorage key → same value → sessionKey still "agent:main:multi-agent"
  Sidebar session row visible after reload: true
```

- Screenshots: `01-after-hello.png` (post-HELLO UI), `02-after-reload.png` (post-reload UI)
<img width="1280" height="900" alt="01-after-hello" src="https://github.com/user-attachments/assets/0c9a981c-d1b3-43f4-b24f-6ec4eb47c949" />
<img width="1280" height="900" alt="02-after-reload" src="https://github.com/user-attachments/assets/a7757851-8e33-403f-83ad-cfafe2e7d9d7" />

## Security Impact

- [x] New permissions/capabilities? No
- [x] Secrets/tokens handling changed? No
- [x] New/changed network calls? No
- [x] Command/tool execution surface changed? No
- [x] Data access scope changed? No

## Human Verification

- Verified scenarios: Fresh browser HELLO persistence, sidebar click with matching key, reconnect without explicit override
- Edge cases checked: Empty sessionKey still guarded, explicit session switches still persist, non-matching key clicks

## Compatibility / Migration

- [x] Backward compatible? Yes
- [x] Config/env changes? No
- [x] Migration needed? No

## Best-fix Verdict

- **Best fix**: Yes — the actual fix (HELLO-time persistence) was already in main; this PR adds the missing regression tests
- **Alternative considered**: Removing setSessionKey short-circuit guard (unnecessary since HELLO persistence already handles it)

## AI Assistance

- **AI-assisted**: Yes
- **AI model**: deepseek-v4-flash
- **Human confirmed understanding of code changes**: Yes

---

Fixes #108031