### PR TITLE
fix(qa-lab): prevent Telegram desktop bootstrap hangs

### DIFF
--- a/extensions/qa-lab/src/mantis/telegram-desktop-builder.runtime.test.ts
+++ b/extensions/qa-lab/src/mantis/telegram-desktop-builder.runtime.test.ts
@@ -109,8 +109,12 @@ describe("mantis Telegram desktop builder runtime", () => {
     expect(runCommand?.env?.OPENCLAW_MANTIS_TELEGRAM_SUT_BOT_TOKEN).toBe("sut-token");
     const remoteScript = runCommand?.args.at(-1);
     expect(remoteScript).toContain(
-      "curl -fsSL --connect-timeout 10 --max-time 120 https://deb.nodesource.com/setup_22.x",
+      'curl -fsSL --connect-timeout 10 --max-time 120 https://deb.nodesource.com/setup_22.x -o "$out/nodesource-setup.sh"',
     );
+    expect(remoteScript).toContain(
+      'sudo -E bash "$out/nodesource-setup.sh" >>"$out/node-apt.log" 2>&1',
+    );
+    expect(remoteScript).not.toContain("setup_22.x | sudo");
     expect(remoteScript).toContain(
       'curl -fsSL --connect-timeout 10 --max-time 600 --retry 2 --retry-delay 2 https://telegram.org/dl/desktop/linux -o "$out/telegram-desktop.tar.xz"',
     );

--- a/extensions/qa-lab/src/mantis/telegram-desktop-builder.runtime.test.ts
+++ b/extensions/qa-lab/src/mantis/telegram-desktop-builder.runtime.test.ts
@@ -108,7 +108,16 @@ describe("mantis Telegram desktop builder runtime", () => {
     expect(runCommand?.env?.OPENCLAW_MANTIS_TELEGRAM_GROUP_ID).toBe("-1001234567890");
     expect(runCommand?.env?.OPENCLAW_MANTIS_TELEGRAM_SUT_BOT_TOKEN).toBe("sut-token");
     const remoteScript = runCommand?.args.at(-1);
-    expect(remoteScript).toContain("https://telegram.org/dl/desktop/linux");
+    expect(remoteScript).toContain(
+      "curl -fsSL --connect-timeout 10 --max-time 120 https://deb.nodesource.com/setup_22.x",
+    );
+    expect(remoteScript).toContain(
+      'curl -fsSL --connect-timeout 10 --max-time 600 --retry 2 --retry-delay 2 https://telegram.org/dl/desktop/linux -o "$out/telegram-desktop.tar.xz"',
+    );
+    expect(remoteScript?.match(/--connect-timeout 10/gu)?.length).toBe(2);
+    expect(remoteScript?.match(/--max-time 120/gu)?.length).toBe(1);
+    expect(remoteScript?.match(/--max-time 600/gu)?.length).toBe(1);
+    expect(remoteScript?.match(/--retry 2 --retry-delay 2/gu)?.length).toBe(1);
     expect(remoteScript).toContain('-workdir "$telegram_profile_dir"');
     expect(remoteScript).toContain("OPENCLAW_MANTIS_TELEGRAM_DESKTOP_PROFILE_TGZ_B64");
     expect(remoteScript).toContain(

--- a/extensions/qa-lab/src/mantis/telegram-desktop-builder.runtime.ts
+++ b/extensions/qa-lab/src/mantis/telegram-desktop-builder.runtime.ts
@@ -314,7 +314,9 @@ if [ -n "\${OPENCLAW_LIVE_OPENAI_KEY:-}" ] && [ -z "\${OPENAI_API_KEY:-}" ]; the
 fi
 if ! command -v node >/dev/null 2>&1; then
   sudo apt-get update -y >"$out/node-apt.log" 2>&1
-  curl -fsSL --connect-timeout 10 --max-time 120 https://deb.nodesource.com/setup_22.x | sudo -E bash - >>"$out/node-apt.log" 2>&1
+  # Complete the setup download before execution; a timed-out stream may be partial.
+  curl -fsSL --connect-timeout 10 --max-time 120 https://deb.nodesource.com/setup_22.x -o "$out/nodesource-setup.sh"
+  sudo -E bash "$out/nodesource-setup.sh" >>"$out/node-apt.log" 2>&1
   sudo DEBIAN_FRONTEND=noninteractive apt-get install -y nodejs >>"$out/node-apt.log" 2>&1
 fi
 if ! command -v scrot >/dev/null 2>&1 || ! command -v curl >/dev/null 2>&1 || ! command -v xz >/dev/null 2>&1; then

--- a/extensions/qa-lab/src/mantis/telegram-desktop-builder.runtime.ts
+++ b/extensions/qa-lab/src/mantis/telegram-desktop-builder.runtime.ts
@@ -314,7 +314,7 @@ if [ -n "\${OPENCLAW_LIVE_OPENAI_KEY:-}" ] && [ -z "\${OPENAI_API_KEY:-}" ]; the
 fi
 if ! command -v node >/dev/null 2>&1; then
   sudo apt-get update -y >"$out/node-apt.log" 2>&1
-  curl -fsSL https://deb.nodesource.com/setup_22.x | sudo -E bash - >>"$out/node-apt.log" 2>&1
+  curl -fsSL --connect-timeout 10 --max-time 120 https://deb.nodesource.com/setup_22.x | sudo -E bash - >>"$out/node-apt.log" 2>&1
   sudo DEBIAN_FRONTEND=noninteractive apt-get install -y nodejs >>"$out/node-apt.log" 2>&1
 fi
 if ! command -v scrot >/dev/null 2>&1 || ! command -v curl >/dev/null 2>&1 || ! command -v xz >/dev/null 2>&1; then
@@ -329,7 +329,7 @@ telegram_root="$HOME/.local/share/openclaw-mantis/telegram-desktop-bin"
 telegram_bin="$telegram_root/Telegram/Telegram"
 if [ ! -x "$telegram_bin" ]; then
   mkdir -p "$telegram_root"
-  curl -fsSL https://telegram.org/dl/desktop/linux -o "$out/telegram-desktop.tar.xz"
+  curl -fsSL --connect-timeout 10 --max-time 600 --retry 2 --retry-delay 2 https://telegram.org/dl/desktop/linux -o "$out/telegram-desktop.tar.xz"
   tar -xJf "$out/telegram-desktop.tar.xz" -C "$telegram_root"
 fi
 if [ -z "$telegram_profile_dir" ] || [ "$telegram_profile_dir" = "\\$HOME/.local/share/TelegramDesktop" ]; then


### PR DESCRIPTION
## What Problem This Solves

QA Lab Telegram Desktop builder runs could wait indefinitely while fetching the NodeSource setup script or Telegram Desktop archive. A timed-out streamed setup script could also reach `bash` partially.

## Why This Change Was Made

The generated remote script now downloads the NodeSource setup script to a file with a 10-second connection deadline and a 120-second transfer deadline, then executes it only after the download succeeds. The Telegram Desktop archive gets the same connection deadline, a 600-second per-attempt deadline, and two finite retries with a 2-second delay. Existing Telegram Bot API requests remain bounded by their 15-second `AbortSignal.timeout` deadlines.

## User Impact

QA operators get a finite, logged bootstrap failure instead of a proof run stuck in a download. A failed NodeSource transfer cannot execute a partial setup script.

## Evidence

- Exact head: `35076edf3a23d8e0cb49f0e4a328bf91998ec98c`.
- Focused generated-script test: 2/2 passed.
- `git diff --check origin/main...HEAD` passed.
- Fresh full-branch Codex autoreview: patch correct, confidence 0.97, no accepted/actionable findings.
- [Native Mantis Telegram Desktop proof](https://github.com/openclaw/openclaw/actions/runs/29431210456) passed against the immutable PR head.
- Secretless live probes returned HTTP 200 for the NodeSource setup script and the official Telegram Desktop archive route.
- The timeout and retry behavior follows the [official curl man page](https://curl.se/docs/manpage.html); the archive comes from [Telegram Desktop](https://desktop.telegram.org/).
- AI-assisted: implemented with Codex and reviewed by the maintainer. The generated remote-script behavior was inspected directly.
