### PR TITLE
fix(ci): support frozen Codex binding sidecars

### DIFF
--- a/scripts/e2e/lib/codex-npm-plugin-live/assertions.mjs
+++ b/scripts/e2e/lib/codex-npm-plugin-live/assertions.mjs
@@ -85,7 +85,20 @@ function readTextFileTail(filePath, label, maxBytes = MAX_ERROR_TAIL_BYTES) {
   }
 }
 
-function readCodexBinding(sessionId, sessionKey) {
+function readCodexBinding(sessionId, sessionKey, entry) {
+  if (sessionStoreContract === "legacy-json") {
+    const sessionFile = typeof entry?.sessionFile === "string" ? entry.sessionFile : "";
+    if (!sessionFile) {
+      throw new Error(`missing legacy Codex session file for ${sessionId}`);
+    }
+    const bindingPath = `${sessionFile}.codex-app-server.json`;
+    const binding = readJson(bindingPath);
+    if (![1, 2].includes(binding.schemaVersion) || typeof binding.threadId !== "string") {
+      throw new Error(`invalid legacy Codex app-server binding: ${JSON.stringify(binding)}`);
+    }
+    return binding;
+  }
+
   const dbPath = path.join(stateDir(), "state", "openclaw.sqlite");
   if (!fs.existsSync(dbPath)) {
     throw new Error(`missing OpenClaw state database: ${dbPath}`);
@@ -524,7 +537,7 @@ function assertAgentTurn() {
     throw new Error(`missing OpenClaw transcript events for ${sessionId}`);
   }
 
-  const binding = readCodexBinding(sessionId, sessionKey);
+  const binding = readCodexBinding(sessionId, sessionKey, entry);
   if (typeof binding.threadId !== "string") {
     throw new Error(`invalid Codex app-server binding: ${JSON.stringify(binding)}`);
   }

--- a/test/scripts/codex-install-assertions.test.ts
+++ b/test/scripts/codex-install-assertions.test.ts
@@ -265,8 +265,16 @@ function createLegacyCodexNpmPluginLiveFixture(root: string) {
   const fixture = createCodexNpmPluginLiveFixture(root);
   const stateDir = path.join(root, "state");
   rmSync(path.join(stateDir, "agents", "main", "agent", "openclaw-agent.sqlite"));
+  rmSync(path.join(stateDir, "state", "openclaw.sqlite"));
   const sessionFile = path.join(stateDir, "agents", "main", "sessions", "session.jsonl");
   writeJson(sessionFile, { type: "message" });
+  writeJson(`${sessionFile}.codex-app-server.json`, {
+    schemaVersion: 2,
+    threadId: "thread-codex-npm-live",
+    cwd: stateDir,
+    model: "gpt-5.4",
+    modelProvider: "codex",
+  });
   writeJson(path.join(stateDir, "agents", "main", "sessions", "sessions.json"), {
     "agent:main:codex-npm-plugin-live": {
       sessionId: fixture.sessionId,
@@ -367,7 +375,7 @@ describe("Codex install helpers", () => {
     expect(result.stderr).toBe("");
   });
 
-  it("accepts the explicit frozen-target JSON session contract", () => {
+  it("accepts the explicit frozen-target JSON session and sidecar binding contract", () => {
     const root = makeTempDir(tempDirs, "openclaw-codex-npm-live-legacy-");
     const fixture = createLegacyCodexNpmPluginLiveFixture(root);
 


### PR DESCRIPTION
## What Problem This Solves

Full Release Validation of the frozen v2026.6.11-based extended-stable candidate failed in the `live-codex-npm-plugin` Docker lane after all three Codex turns succeeded. The trusted current harness selected the target's `legacy-json` session contract but still required the later SQLite Codex binding store, producing `missing Codex app-server binding row`.

Failure evidence: https://github.com/openclaw/openclaw/actions/runs/29395737466/job/87291717923

## Why This Change Was Made

PR #105337 added frozen-target JSON session support, but its legacy fixture retained the SQLite plugin binding database created by the current-target fixture. That made the test pass without exercising the actual pre-cutover sidecar contract.

This keeps current targets SQLite-strict. Only the already-explicit `legacy-json` contract reads the adjacent `*.codex-app-server.json` binding used by the frozen target. It does not import SQLite or current runtime work into the release candidate.

Codex contract check: sibling Codex App Server source confirms `thread/start` and `thread/resume` responses carry the canonical thread and model/provider metadata; persistence location remains OpenClaw-owned. Checked `codex-rs/app-server-protocol/src/protocol/v2/thread.rs`, `codex-rs/app-server/src/request_processors/thread_processor.rs`, and `codex-rs/app-server/src/request_processors/thread_lifecycle.rs`.

## User Impact

Trusted release validation can accurately test frozen pre-SQLite OpenClaw targets without weakening current-target state validation or changing product/runtime behavior.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/codex-install-assertions.test.ts` — 8/8 passed
- `pnpm exec oxfmt --check scripts/e2e/lib/codex-npm-plugin-live/assertions.mjs test/scripts/codex-install-assertions.test.ts` — passed
- `git diff --check` — passed
- The legacy fixture now deletes both SQLite stores and succeeds using only a v6.11-style JSON session plus binding sidecar.

Provenance: SQLite-only binding validation came from #103467; #105337 added frozen JSON-session selection but its fixture retained SQLite binding state, leaving the compatibility path incomplete.
