### PR TITLE
fix(qa-lab): prevent Slack desktop bootstrap hangs

### DIFF
--- a/extensions/qa-lab/src/mantis/slack-desktop-smoke.runtime.test.ts
+++ b/extensions/qa-lab/src/mantis/slack-desktop-smoke.runtime.test.ts
@@ -200,14 +200,27 @@ describe("mantis Slack desktop smoke runtime", () => {
     expect(remoteScript).toContain("build-essential python3");
     expect(remoteScript).toContain("node_supports_type_stripping");
     expect(remoteScript).toContain("scripts/crabbox-untrusted-bootstrap.sh");
-    expect(remoteScript).toContain("https://nodejs.org/dist/v$node_version");
+    expect(remoteScript).toContain(
+      "curl -fsSL --connect-timeout 10 --max-time 120 https://deb.nodesource.com/setup_22.x",
+    );
+    expect(remoteScript).toContain(
+      'curl -fsSL --connect-timeout 10 --max-time 120 --retry 3 --retry-all-errors "$node_base_url/SHASUMS256.txt"',
+    );
+    expect(remoteScript).toContain(
+      'curl -fsSL --connect-timeout 10 --max-time 120 --retry 3 --retry-all-errors "$node_base_url/$node_archive"',
+    );
     expect(remoteScript).toContain('grep "  $node_archive$" SHASUMS256.txt | sha256sum -c -');
     expect(remoteScript).toContain('export PATH="$node_root/bin:$PATH"');
     expect(remoteScript).toContain("packageManager ??");
     expect(remoteScript).toContain("[0-9a-f]{128}");
     expect(remoteScript).toContain('console.log(match[1] + " " + match[2])');
     expect(remoteScript).toContain('active_pnpm_version="$(pnpm --version 2>/dev/null || true)"');
-    expect(remoteScript).toContain("https://registry.npmjs.org/pnpm/-/pnpm-$pnpm_version.tgz");
+    expect(remoteScript).toContain(
+      "curl -fsSL --connect-timeout 10 --max-time 120 --retry 3 --retry-all-errors",
+    );
+    expect(remoteScript).toContain('"https://registry.npmjs.org/pnpm/-/pnpm-$pnpm_version.tgz"');
+    expect(remoteScript?.match(/--connect-timeout 10 --max-time 120/gu)?.length).toBe(4);
+    expect(remoteScript?.match(/--retry 3 --retry-all-errors/gu)?.length).toBe(3);
     expect(remoteScript).toContain('sha512sum "$pnpm_archive"');
     expect(remoteScript).toContain('chmod +x "$pnpm_cli"');
     expect(remoteScript).toContain('ln -sfn "$pnpm_cli" "$pnpm_bin_dir/pnpm"');

--- a/extensions/qa-lab/src/mantis/slack-desktop-smoke.runtime.test.ts
+++ b/extensions/qa-lab/src/mantis/slack-desktop-smoke.runtime.test.ts
@@ -204,10 +204,10 @@ describe("mantis Slack desktop smoke runtime", () => {
       "curl -fsSL --connect-timeout 10 --max-time 120 https://deb.nodesource.com/setup_22.x",
     );
     expect(remoteScript).toContain(
-      'curl -fsSL --connect-timeout 10 --max-time 120 --retry 3 --retry-all-errors "$node_base_url/SHASUMS256.txt"',
+      'curl -fsSL --connect-timeout 10 --max-time 120 --retry 3 --retry-max-time 120 --retry-all-errors "$node_base_url/SHASUMS256.txt"',
     );
     expect(remoteScript).toContain(
-      'curl -fsSL --connect-timeout 10 --max-time 120 --retry 3 --retry-all-errors "$node_base_url/$node_archive"',
+      'curl -fsSL --connect-timeout 10 --max-time 120 --retry 3 --retry-max-time 120 --retry-all-errors "$node_base_url/$node_archive"',
     );
     expect(remoteScript).toContain('grep "  $node_archive$" SHASUMS256.txt | sha256sum -c -');
     expect(remoteScript).toContain('export PATH="$node_root/bin:$PATH"');
@@ -216,11 +216,13 @@ describe("mantis Slack desktop smoke runtime", () => {
     expect(remoteScript).toContain('console.log(match[1] + " " + match[2])');
     expect(remoteScript).toContain('active_pnpm_version="$(pnpm --version 2>/dev/null || true)"');
     expect(remoteScript).toContain(
-      "curl -fsSL --connect-timeout 10 --max-time 120 --retry 3 --retry-all-errors",
+      "curl -fsSL --connect-timeout 10 --max-time 120 --retry 3 --retry-max-time 120 --retry-all-errors",
     );
     expect(remoteScript).toContain('"https://registry.npmjs.org/pnpm/-/pnpm-$pnpm_version.tgz"');
     expect(remoteScript?.match(/--connect-timeout 10 --max-time 120/gu)?.length).toBe(4);
-    expect(remoteScript?.match(/--retry 3 --retry-all-errors/gu)?.length).toBe(3);
+    expect(remoteScript?.match(/--retry 3 --retry-max-time 120 --retry-all-errors/gu)?.length).toBe(
+      3,
+    );
     expect(remoteScript).toContain('sha512sum "$pnpm_archive"');
     expect(remoteScript).toContain('chmod +x "$pnpm_cli"');
     expect(remoteScript).toContain('ln -sfn "$pnpm_cli" "$pnpm_bin_dir/pnpm"');

--- a/extensions/qa-lab/src/mantis/slack-desktop-smoke.runtime.ts
+++ b/extensions/qa-lab/src/mantis/slack-desktop-smoke.runtime.ts
@@ -726,9 +726,11 @@ run_mantis_remote_body() {
       node_tmp="$(mktemp -d)"
       node_archive="node-v$node_version-linux-$node_arch.tar.xz"
       node_base_url="https://nodejs.org/dist/v$node_version"
-      curl -fsSL --connect-timeout 10 --max-time 120 --retry 3 --retry-all-errors "$node_base_url/SHASUMS256.txt" \
+      # Retry quick transient failures within 120 seconds, but do not start
+      # another long transfer after an attempt consumes that full deadline.
+      curl -fsSL --connect-timeout 10 --max-time 120 --retry 3 --retry-max-time 120 --retry-all-errors "$node_base_url/SHASUMS256.txt" \
         -o "$node_tmp/SHASUMS256.txt"
-      curl -fsSL --connect-timeout 10 --max-time 120 --retry 3 --retry-all-errors "$node_base_url/$node_archive" \
+      curl -fsSL --connect-timeout 10 --max-time 120 --retry 3 --retry-max-time 120 --retry-all-errors "$node_base_url/$node_archive" \
         -o "$node_tmp/$node_archive"
       (cd "$node_tmp" && grep "  $node_archive$" SHASUMS256.txt | sha256sum -c -)
       rm -rf "$node_root"
@@ -757,7 +759,9 @@ console.log(match[1] + " " + match[2]);
     pnpm_root="$out/pnpm-$pnpm_version"
     pnpm_archive="$pnpm_root/pnpm.tgz"
     mkdir -p "$pnpm_root"
-    curl -fsSL --connect-timeout 10 --max-time 120 --retry 3 --retry-all-errors \
+    # Retry quick transient failures within 120 seconds, but do not start
+    # another long transfer after an attempt consumes that full deadline.
+    curl -fsSL --connect-timeout 10 --max-time 120 --retry 3 --retry-max-time 120 --retry-all-errors \
       "https://registry.npmjs.org/pnpm/-/pnpm-$pnpm_version.tgz" \
       -o "$pnpm_archive"
     downloaded_pnpm_sha512="$(sha512sum "$pnpm_archive" | awk '{print $1}')"

--- a/extensions/qa-lab/src/mantis/slack-desktop-smoke.runtime.ts
+++ b/extensions/qa-lab/src/mantis/slack-desktop-smoke.runtime.ts
@@ -596,7 +596,7 @@ if [ -n "\${OPENCLAW_LIVE_OPENAI_KEY:-}" ] && [ -z "\${OPENAI_API_KEY:-}" ]; the
 fi
 if ! command -v node >/dev/null 2>&1; then
   sudo apt-get update -y >"$out/node-apt.log" 2>&1
-  curl -fsSL https://deb.nodesource.com/setup_22.x | sudo -E bash - >>"$out/node-apt.log" 2>&1
+  curl -fsSL --connect-timeout 10 --max-time 120 https://deb.nodesource.com/setup_22.x | sudo -E bash - >>"$out/node-apt.log" 2>&1
   sudo DEBIAN_FRONTEND=noninteractive apt-get install -y nodejs >>"$out/node-apt.log" 2>&1
 fi
 if ! command -v scrot >/dev/null 2>&1; then
@@ -726,9 +726,9 @@ run_mantis_remote_body() {
       node_tmp="$(mktemp -d)"
       node_archive="node-v$node_version-linux-$node_arch.tar.xz"
       node_base_url="https://nodejs.org/dist/v$node_version"
-      curl -fsSL --retry 3 --retry-all-errors "$node_base_url/SHASUMS256.txt" \
+      curl -fsSL --connect-timeout 10 --max-time 120 --retry 3 --retry-all-errors "$node_base_url/SHASUMS256.txt" \
         -o "$node_tmp/SHASUMS256.txt"
-      curl -fsSL --retry 3 --retry-all-errors "$node_base_url/$node_archive" \
+      curl -fsSL --connect-timeout 10 --max-time 120 --retry 3 --retry-all-errors "$node_base_url/$node_archive" \
         -o "$node_tmp/$node_archive"
       (cd "$node_tmp" && grep "  $node_archive$" SHASUMS256.txt | sha256sum -c -)
       rm -rf "$node_root"
@@ -757,7 +757,7 @@ console.log(match[1] + " " + match[2]);
     pnpm_root="$out/pnpm-$pnpm_version"
     pnpm_archive="$pnpm_root/pnpm.tgz"
     mkdir -p "$pnpm_root"
-    curl -fsSL --retry 3 --retry-all-errors \
+    curl -fsSL --connect-timeout 10 --max-time 120 --retry 3 --retry-all-errors \
       "https://registry.npmjs.org/pnpm/-/pnpm-$pnpm_version.tgz" \
       -o "$pnpm_archive"
     downloaded_pnpm_sha512="$(sha512sum "$pnpm_archive" | awk '{print $1}')"


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where QA Lab Slack desktop smoke runs could wait indefinitely, or stack several long attempts, while fetching the NodeSource setup script, Node.js checksum or archive, or the pnpm archive.

## Why This Change Was Made

The generated remote script now gives all four downloads a 10-second connection deadline and a 120-second per-transfer deadline. The three verified artifact downloads retain their existing retries for quick transient failures and add a 120-second retry window. curl checks that window before starting a retry, so an attempt that consumes the full 120-second transfer deadline does not start another long attempt. The piped NodeSource script is intentionally not retried because replaying a partially emitted script into `bash` is unsafe. The existing Slack `auth.test` request remains bounded by its 15-second `AbortSignal.timeout` deadline.

## User Impact

QA operators now get a finite, logged bootstrap failure instead of a Slack desktop smoke run remaining stuck in a download or repeatedly consuming full transfer deadlines.

## Evidence

- Exact head: `30fed2f60cadbf2ba868f9859b7fe6fd44585666`, cleanly rebased with both patch ids unchanged onto `87079d025e8305936f86bf37a01db663c4e6c86e`; the touched files remain unchanged through `main` at `d3dcb368950577a126d32113ee1b52e70f10f41a`.
- Generated-script assertions lock all four curl targets and per-transfer deadlines, all three retry windows, and the existing `AbortSignal.timeout(15_000)` call.
- The retry behavior follows the [official curl man page](https://curl.se/docs/manpage.html): `--max-time` resets per retry, while `--retry-max-time` is checked before curl starts a new retry.
- Secretless live NodeSource probe returned HTTP 200 in 0.70s. [NodeSource distributions](https://github.com/nodesource/distributions)
- Secretless live Node.js `v24.15.0` checksum probe returned HTTP 200 in 0.74s. [Node.js release files](https://nodejs.org/download/release/v24.15.0/)
- Secretless live pnpm `11.2.2` tarball probe returned HTTP 200 in 1.20s. [pnpm package](https://www.npmjs.com/package/pnpm)
- Secretless Slack `auth.test` probe without a token returned HTTP 200 with `not_authed`; no credential was used or printed. [Slack auth.test](https://api.slack.com/methods/auth.test)
- Controlled no-response curl calibration with `--max-time 1` exited 28 after 1,012 ms.
- `git diff --check upstream/main...HEAD` passed; both commits retained their pre-rebase stable patch ids.
- Two fresh Claude Sonnet autoreviews are clean; the full rebased branch review reports patch correct at 0.93 confidence with no accepted/actionable findings.
- Exact-head fork [CI run 29461715892](https://github.com/openclaw/openclaw/actions/runs/29461715892) passed with 53 successful jobs and a green `openclaw/ci-gate`; [CodeQL run 29461715855](https://github.com/openclaw/openclaw/actions/runs/29461715855) passed all 7 security jobs, and [Critical Quality run 29461715904](https://github.com/openclaw/openclaw/actions/runs/29461715904) passed.
- Exact-head [ClawSweeper run 29461774963](https://github.com/openclaw/clawsweeper/actions/runs/29461774963) reports patch correct at 0.91 confidence, 0 findings, and security cleared. Its remaining proof grade is C solely because the actual generated bootstrap path was not run against a stalled download.
- A generated-bootstrap stall run is not claimed: this session could not obtain a sanitized AWS lease because no Crabbox coordinator identity is configured, and the secretless fork workflows do not accept an injected stall endpoint.
- AI-assisted: implemented with Codex and reviewed with Claude. I inspected and understand the generated-script behavior.
