### PR TITLE
test(ci): separate hooks output and exit deadlines

### DIFF
--- a/src/cli/hooks-cli.process.test.ts
+++ b/src/cli/hooks-cli.process.test.ts
@@ -9,6 +9,8 @@ import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 const activeChildren = new Set<ChildProcessWithoutNullStreams>();
+const outputTimeoutMs = 20_000;
+const exitAfterOutputTimeoutMs = 5_000;
 
 afterEach(async () => {
   await Promise.all(Array.from(activeChildren, terminateChild));
@@ -102,9 +104,9 @@ async function createLingeringPreloadFixture(): Promise<{
 
 async function runHooksCli(params: {
   args: string[];
+  label: string;
   env?: NodeJS.ProcessEnv;
   stdin?: string;
-  timeoutMessage: string;
 }) {
   const child = spawn(process.execPath, ["--import", "tsx", "src/entry.ts", ...params.args], {
     cwd: path.resolve("."),
@@ -121,12 +123,6 @@ async function runHooksCli(params: {
   let stderr = "";
   child.stdout.setEncoding("utf8");
   child.stderr.setEncoding("utf8");
-  child.stdout.on("data", (chunk: string) => {
-    stdout += chunk;
-  });
-  child.stderr.on("data", (chunk: string) => {
-    stderr += chunk;
-  });
   child.stdin.end(params.stdin ?? "");
 
   return await new Promise<{
@@ -136,10 +132,26 @@ async function runHooksCli(params: {
     stdout: string;
   }>((resolve, reject) => {
     let timedOut = false;
-    const timer = setTimeout(() => {
+    let outputObserved = false;
+    let timer = setTimeout(() => {
       timedOut = true;
       child.kill("SIGKILL");
-    }, 15_000);
+    }, outputTimeoutMs);
+    child.stdout.on("data", (chunk: string) => {
+      stdout += chunk;
+      if (outputObserved) {
+        return;
+      }
+      outputObserved = true;
+      clearTimeout(timer);
+      timer = setTimeout(() => {
+        timedOut = true;
+        child.kill("SIGKILL");
+      }, exitAfterOutputTimeoutMs);
+    });
+    child.stderr.on("data", (chunk: string) => {
+      stderr += chunk;
+    });
     child.once("error", (error) => {
       clearTimeout(timer);
       activeChildren.delete(child);
@@ -149,7 +161,10 @@ async function runHooksCli(params: {
       clearTimeout(timer);
       activeChildren.delete(child);
       if (timedOut) {
-        reject(new Error(`${params.timeoutMessage}\nstdout:\n${stdout}\nstderr:\n${stderr}`));
+        const timeoutMessage = outputObserved
+          ? `${params.label} did not exit within ${exitAfterOutputTimeoutMs}ms after emitting output`
+          : `${params.label} did not emit output within ${outputTimeoutMs}ms`;
+        reject(new Error(`${timeoutMessage}\nstdout:\n${stdout}\nstderr:\n${stderr}`));
         return;
       }
       resolve({ code, signal, stderr, stdout });
@@ -172,6 +187,7 @@ async function runHooksRelay(params: { event: "post_tool_use" | "pre_tool_use"; 
       "--timeout",
       "50",
     ],
+    label: `hooks relay ${params.event}`,
     env: {
       LINGER_MARKER: fixture.markerPath,
       NODE_OPTIONS: `--import=${pathToFileURL(fixture.preloadPath).href}`,
@@ -180,7 +196,6 @@ async function runHooksRelay(params: { event: "post_tool_use" | "pre_tool_use"; 
       OPENCLAW_STATE_DIR: fixture.stateDir,
     },
     stdin: params.stdin,
-    timeoutMessage: `hooks relay ${params.event} did not exit after emitting output`,
   });
   await expect(fs.readFile(fixture.markerPath, "utf8")).resolves.toBe("loaded\n");
   return result;
@@ -194,13 +209,13 @@ describe("hooks CLI process lifecycle", () => {
     // bootstraps sequential so low-core shards test lifecycle, not startup contention.
     const listResult = await runHooksCli({
       args: ["hooks", "list", "--json"],
+      label: "hooks list",
       env: {
         LINGER_MARKER: fixture.markerPath,
         OPENCLAW_CONFIG_PATH: fixture.configPath,
         OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
         OPENCLAW_STATE_DIR: fixture.stateDir,
       },
-      timeoutMessage: "hooks list did not exit after emitting output",
     });
     const relayResult = await runHooksRelay({ event: "pre_tool_use", stdin: "{}" });
 
@@ -216,5 +231,5 @@ describe("hooks CLI process lifecycle", () => {
         permissionDecisionReason: expect.any(String),
       },
     });
-  }, 35_000);
+  }, 60_000);
 });


### PR DESCRIPTION
## What Problem This Solves

The hooks process-lifecycle test used one 15-second wall-clock deadline for both CLI startup and the post-output exit contract. Under a loaded CI shard, a valid command could emit complete output near that deadline and be killed before its intentional one-shot exit ran.

## Why This Change Was Made

Track the two behaviors separately: allow up to 20 seconds to observe first stdout, then require the process to exit within 5 seconds after output begins. This preserves a strict leaked-handle regression check while removing startup load from that assertion. The enclosing Vitest timeout includes headroom for both sequential subprocesses and fixture cleanup.

## User Impact

No product behavior change. CI reports whether a hooks command failed to produce output or failed to exit after producing output, and avoids a false timeout caused only by slow startup.

## Evidence

- Fresh autoreview: clean, confidence 0.94.
- Focused Testbox: https://github.com/openclaw/openclaw/actions/runs/29400890837 (1/1 passed; process test 6.99 seconds).
- Prior focused baseline: https://github.com/openclaw/openclaw/actions/runs/29400178462 (1/1 passed).
- `pnpm format src/cli/hooks-cli.process.test.ts`
- `git diff --check`

No changelog entry: test-only CI hardening.
