### PR TITLE
fix(crabbox): stop identity checks hanging on stalled IMDS

### DIFF
--- a/scripts/crabbox-untrusted-bootstrap.sh
+++ b/scripts/crabbox-untrusted-bootstrap.sh
@@ -13,12 +13,12 @@ shift
 unset NODE_OPTIONS
 
 imds_token="$(
-  /usr/bin/curl -fsS -X PUT \
+  /usr/bin/curl -fsS --connect-timeout 2 --max-time 5 -X PUT \
     -H "X-aws-ec2-metadata-token-ttl-seconds: 60" \
     http://169.254.169.254/latest/api/token
 )"
 iam_status="$(
-  /usr/bin/curl -sS -o /dev/null -w "%{http_code}" \
+  /usr/bin/curl -sS --connect-timeout 2 --max-time 5 -o /dev/null -w "%{http_code}" \
     -H "X-aws-ec2-metadata-token: ${imds_token}" \
     http://169.254.169.254/latest/meta-data/iam/security-credentials/
 )"

--- a/test/scripts/crabbox-untrusted-bootstrap.test.ts
+++ b/test/scripts/crabbox-untrusted-bootstrap.test.ts
@@ -1,0 +1,18 @@
+// Crabbox untrusted bootstrap tests cover the pre-execution identity boundary.
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+describe("scripts/crabbox-untrusted-bootstrap.sh", () => {
+  it("bounds both IMDSv2 identity requests", () => {
+    const script = readFileSync("scripts/crabbox-untrusted-bootstrap.sh", "utf8");
+    const imdsRequests = script.match(
+      /\/usr\/bin\/curl[\s\S]*?http:\/\/169\.254\.169\.254[^\n]*/gu,
+    );
+
+    expect(imdsRequests).toHaveLength(2);
+    for (const request of imdsRequests ?? []) {
+      expect(request).toContain("--connect-timeout 2");
+      expect(request).toContain("--max-time 5");
+    }
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where sanitized AWS Crabbox runs could hang before validating the no-IAM-role boundary when either link-local IMDSv2 request stalled.

## Why This Change Was Made

Both pre-execution IMDS calls now use a two-second connection deadline and a five-second total deadline. The existing fail-closed token and HTTP 404 checks remain unchanged.

## User Impact

Untrusted validation now reports an IMDS transport failure in finite time instead of occupying a Crabbox lease indefinitely before tests begin.

## Evidence

- Added a focused contract test that finds both IMDSv2 curl invocations and requires their connection and total deadlines.
- Controlled localhost no-response calibration of the same curl deadline mechanism returned exit 28 after approximately one second:

```json
{"connectTimeoutSeconds":1,"maxTimeSeconds":1,"exitCode":28,"elapsedMs":1015,"outcome":"timed-out"}
```

- `bash -n scripts/crabbox-untrusted-bootstrap.sh` passed.
- `git diff --check` passed.
- `oxfmt --check test/scripts/crabbox-untrusted-bootstrap.test.ts` passed.
- Current head `80d124fe9aa9042fc382607d8bd5a36e49ab9030` is rebased onto `bef86c8b88e779b686d0c1ceca50fb17c4b43528`; `git range-diff` showed the single-commit patch is identical.
- Claude Sonnet 4.6 autoreview: patch correct (0.95), no accepted or actionable findings.
- The first secretless fork CI run `29401134106` failed only in unrelated `test/scripts/plugin-lifecycle-measure.test.ts:325` (`ENOENT` waiting for `descendant.pid`); 2,451 sibling tests passed. Alix lacks permission to rerun failed jobs, so the identical rebase triggered fresh [CI run 29401921719](https://github.com/openclaw/openclaw/actions/runs/29401921719): 50 jobs passed, 12 out-of-scope jobs skipped, and none failed. [CodeQL run 29401921855](https://github.com/openclaw/openclaw/actions/runs/29401921855) passed all 7 selected analyses.
- AI-assisted: implemented with Codex. I inspected and understand the bootstrap identity boundary and test.

