### PR TITLE
fix(ci): stop fallback Node setup hanging on downloads

### DIFF
--- a/.github/actions/setup-pnpm-store-cache/ensure-node.sh
+++ b/.github/actions/setup-pnpm-store-cache/ensure-node.sh
@@ -122,7 +122,8 @@ openclaw_resolve_node_download_version() {
   prefix="${prefix%%[xX]*}"
   prefix="v${prefix}"
   [[ "$prefix" == *. ]] || prefix="${prefix}."
-  curl -fsSL https://nodejs.org/dist/index.json |
+  curl -fsSL --connect-timeout 10 --max-time 120 --retry 2 --retry-delay 2 \
+    https://nodejs.org/dist/index.json |
     OPENCLAW_NODE_PREFIX="$prefix" python3 -c 'import json, os, sys
 prefix = os.environ["OPENCLAW_NODE_PREFIX"]
 for item in json.load(sys.stdin):
@@ -154,7 +155,7 @@ openclaw_node_download_platform() {
 
 openclaw_download_node() {
   local requested_node="$1"
-  local version platform archive_url install_root temp_root
+  local version platform archive_url archive_path install_root temp_root
   version="$(openclaw_resolve_node_download_version "$requested_node")"
   platform="$(openclaw_node_download_platform)" || return 1
   temp_root="${RUNNER_TEMP:-/tmp}"
@@ -163,13 +164,14 @@ openclaw_download_node() {
   fi
   install_root="${temp_root}/openclaw-node-${version}-${platform}"
   if [[ "$platform" == win-* ]]; then
-    local archive_path ps_archive_path ps_install_root ps_bin_dir node_bin_dir
+    local ps_archive_path ps_install_root ps_bin_dir node_bin_dir
     archive_path="${temp_root}/node-${version}-${platform}.zip"
     archive_url="https://nodejs.org/dist/${version}/node-${version}-${platform}.zip"
     rm -rf "$install_root"
     mkdir -p "$install_root"
     echo "Downloading Node ${version} from ${archive_url}"
-    curl -fsSL -o "$archive_path" "$archive_url"
+    curl -fsSL --connect-timeout 10 --max-time 120 --retry 2 --retry-delay 2 \
+      -o "$archive_path" "$archive_url"
     ps_archive_path="$archive_path"
     ps_install_root="$install_root"
     if command -v cygpath >/dev/null 2>&1; then
@@ -190,9 +192,20 @@ openclaw_download_node() {
     fi
   else
     archive_url="https://nodejs.org/dist/${version}/node-${version}-${platform}.tar.xz"
+    archive_path="${temp_root}/node-${version}-${platform}.tar.xz"
     mkdir -p "$install_root"
     echo "Downloading Node ${version} from ${archive_url}"
-    curl -fsSL "$archive_url" | tar -xJ -C "$install_root" --strip-components=1
+    rm -f "$archive_path"
+    if ! curl -fsSL --connect-timeout 10 --max-time 120 --retry 2 --retry-delay 2 \
+      -o "$archive_path" "$archive_url"; then
+      rm -f "$archive_path"
+      return 1
+    fi
+    if ! tar -xJf "$archive_path" -C "$install_root" --strip-components=1; then
+      rm -f "$archive_path"
+      return 1
+    fi
+    rm -f "$archive_path"
     openclaw_prepend_node_bin "$install_root/bin"
   fi
 }

--- a/test/scripts/setup-pnpm-store-cache-ensure-node.test.ts
+++ b/test/scripts/setup-pnpm-store-cache-ensure-node.test.ts
@@ -1,6 +1,14 @@
 // Setup Pnpm Store Cache Ensure Node tests cover setup pnpm store cache ensure node script behavior.
 import { spawnSync } from "node:child_process";
-import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { beforeAll, describe, expect, it } from "vitest";
@@ -30,6 +38,49 @@ exit 0
   );
   chmodSync(nodePath, 0o755);
   return nodePath;
+}
+
+function writeFakeCurl(binDir: string) {
+  mkdirSync(binDir, { recursive: true });
+  const curlPath = join(binDir, "curl");
+  writeFileSync(
+    curlPath,
+    `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >> "$OPENCLAW_FAKE_CURL_LOG"
+output=""
+url=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -o)
+      output="$2"
+      shift 2
+      ;;
+    http://* | https://*)
+      url="$1"
+      shift
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+if [[ -n "\${OPENCLAW_FAKE_CURL_FAIL_SUFFIX:-}" && "$url" == *"\${OPENCLAW_FAKE_CURL_FAIL_SUFFIX:-}" ]]; then
+  if [[ -n "$output" ]]; then
+    printf '%s' 'partial archive' > "$output"
+  fi
+  exit 28
+fi
+if [[ "$url" == */index.json ]]; then
+  printf '%s\\n' '[{"version":"v24.15.0"}]'
+elif [[ -n "$output" ]]; then
+  : > "$output"
+else
+  printf '%s' 'archive'
+fi
+`,
+  );
+  chmodSync(curlPath, 0o755);
 }
 
 function runEnsureNode(root: string, requested: string, extraEnv: NodeJS.ProcessEnv = {}) {
@@ -269,6 +320,83 @@ exit 1
     expect(runVersionMatch("24.15.0", "24.x").status).toBe(0);
     expect(runVersionMatch("25.8.1", "25.x").status).toBe(1);
     expect(runVersionMatch("25.9.0", "25.x").status).toBe(0);
+  });
+
+  it("bounds every Node distribution request", () => {
+    const root = mkdtempSync(join(tmpdir(), "openclaw-ensure-node-"));
+    try {
+      const helperBin = join(root, "bin");
+      const curlLog = join(root, "curl.log");
+      writeFakeCurl(helperBin);
+      const result = spawnSync(
+        "bash",
+        [
+          "-c",
+          [
+            "set -euo pipefail",
+            `export PATH=${JSON.stringify(`${helperBin}:${process.env.PATH ?? ""}`)}`,
+            `export OPENCLAW_FAKE_CURL_LOG=${JSON.stringify(curlLog)}`,
+            `source "${ensureNodeScript}"`,
+            'openclaw_resolve_node_download_version "24.x"',
+            "openclaw_prepend_node_bin() { :; }",
+            'openclaw_node_download_platform() { printf "win-x64\\n"; }',
+            "pwsh() { :; }",
+            `RUNNER_TEMP=${JSON.stringify(root)} openclaw_download_node "24.15.0"`,
+            'openclaw_node_download_platform() { printf "linux-x64\\n"; }',
+            "tar() { :; }",
+            `RUNNER_TEMP=${JSON.stringify(root)} openclaw_download_node "24.15.0"`,
+          ].join("\n"),
+        ],
+        { encoding: "utf8", env: process.env },
+      );
+
+      expect(result.status, result.stderr).toBe(0);
+      const curlCalls = readFileSync(curlLog, "utf8").trim().split("\n");
+      expect(curlCalls).toHaveLength(3);
+      for (const call of curlCalls) {
+        expect(call).toContain(
+          "-fsSL --connect-timeout 10 --max-time 120 --retry 2 --retry-delay 2",
+        );
+      }
+      expect(curlCalls[0]).toContain("https://nodejs.org/dist/index.json");
+      expect(curlCalls[1]).toContain("https://nodejs.org/dist/v24.15.0/node-v24.15.0-win-x64.zip");
+      expect(curlCalls[2]).toContain(
+        "https://nodejs.org/dist/v24.15.0/node-v24.15.0-linux-x64.tar.xz",
+      );
+      expect(existsSync(join(root, "node-v24.15.0-linux-x64.tar.xz"))).toBe(false);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("removes a partial POSIX archive after a timed-out download", () => {
+    const root = mkdtempSync(join(tmpdir(), "openclaw-ensure-node-"));
+    try {
+      const helperBin = join(root, "bin");
+      writeFakeCurl(helperBin);
+      const result = spawnSync(
+        "bash",
+        [
+          "-c",
+          [
+            "set -uo pipefail",
+            `export PATH=${JSON.stringify(`${helperBin}:${process.env.PATH ?? ""}`)}`,
+            `export OPENCLAW_FAKE_CURL_LOG=${JSON.stringify(join(root, "curl.log"))}`,
+            `export OPENCLAW_FAKE_CURL_FAIL_SUFFIX=${JSON.stringify(".tar.xz")}`,
+            `source "${ensureNodeScript}"`,
+            "openclaw_prepend_node_bin() { :; }",
+            'openclaw_node_download_platform() { printf "linux-x64\\n"; }',
+            `RUNNER_TEMP=${JSON.stringify(root)} openclaw_download_node "24.15.0"`,
+          ].join("\n"),
+        ],
+        { encoding: "utf8", env: process.env },
+      );
+
+      expect(result.status).toBe(1);
+      expect(existsSync(join(root, "node-v24.15.0-linux-x64.tar.xz"))).toBe(false);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 
   it("fails clearly when no matching node is available", () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where CI jobs using the shared pnpm setup action could remain stuck while resolving or downloading a fallback Node.js runtime from `nodejs.org`.

## Why This Change Was Made

The version index, Windows ZIP, and POSIX tarball requests now use a 10-second connection deadline, a 120-second per-attempt deadline, and two retries separated by two seconds. The POSIX path downloads to a temporary archive before extraction so retries cannot concatenate partial compressed streams, and it removes the archive on success or failure.

## User Impact

CI fallback setup now fails within a finite window on stalled downloads and does not leave a partial POSIX archive for a later attempt.

## Evidence

- Added fake-curl coverage that exercises all three Node distribution requests and locks their timeout/retry policy.
- Added a timed-out POSIX download regression that writes a partial archive, returns curl exit 28, and proves cleanup.
- `bash -n .github/actions/setup-pnpm-store-cache/ensure-node.sh` passed.
- `git diff --check` passed.
- `oxfmt --check test/scripts/setup-pnpm-store-cache-ensure-node.test.ts` passed.
- Current head `b93c5cd13d7c34e413da281146deafcdb18bbda9` is rebased onto `6eda184f27f791366f3c287c6a221d4f36d9c110`; `git range-diff` showed the single-commit patch is identical.
- Claude Sonnet 4.6 autoreview after the download-then-extract correction: patch correct (0.93), no accepted or actionable findings.
- The first secretless fork [CI run 29401218713](https://github.com/openclaw/openclaw/actions/runs/29401218713) failed only when the unrelated channel plugin-shape contract hook exceeded 120 seconds; its assertions passed and this PR does not touch channel code. Alix lacks permission to rerun failed jobs, so the identical rebase triggered fresh [CI run 29402316573](https://github.com/openclaw/openclaw/actions/runs/29402316573): 50 jobs passed, 12 out-of-scope jobs skipped, and none failed. [CodeQL run 29402316680](https://github.com/openclaw/openclaw/actions/runs/29402316680) passed all 7 selected analyses.
- AI-assisted: implemented with Codex. I inspected and understand the fallback download and cleanup paths.

