### PR TITLE
refactor(acp): trim internal dead exports

### DIFF
--- a/config/knip.config.ts
+++ b/config/knip.config.ts
@@ -21,6 +21,8 @@ const rootEntries = [
   // Runtime modules loaded by path or namespace; static export tracing cannot see their contract.
   // Jiti virtualizes openclaw/plugin-sdk/agent-sessions through this cycle-safe barrel.
   "src/agents/sessions/extension-sdk.ts!",
+  // Plugin-SDK ACP facades expose the registry's runtime signatures.
+  "src/acp/runtime/registry.ts!",
   "src/plugins/runtime/index.ts!",
   "src/plugins/source-display.ts!",
   "src/mcp/codex-supervision-tools-serve.ts!",

--- a/scripts/deadcode-exports.baseline.mjs
+++ b/scripts/deadcode-exports.baseline.mjs
@@ -2,8 +2,6 @@
 // New entries fail CI. After deleting dead code, run `pnpm deadcode:exports:update`.
 // Do not add entries to avoid fixing new findings.
 export const KNIP_UNUSED_EXPORT_BASELINE = [
-  "src/acp/control-plane/active-turns.ts: resetAcpActiveTurnsForTests",
-  "src/acp/runtime/registry.ts: AcpRuntimeBackend",
   "src/agents/agent-hooks/compaction-safeguard.ts: testing",
   "src/agents/agent-tools.before-tool-call.ts: BeforeToolCallBlockedError",
   "src/agents/agent-tools.before-tool-call.ts: testing",

--- a/src/acp/control-plane/active-turns.test-support.ts
+++ b/src/acp/control-plane/active-turns.test-support.ts
@@ -1,0 +1,14 @@
+/** Test-only access to the process-global ACP active-turn registry. */
+import { resolveGlobalSingleton } from "../../shared/global-singleton.js";
+
+type AcpActiveTurnState = {
+  activeTurnKeys: Set<string>;
+};
+
+const ACP_ACTIVE_TURN_STATE_KEY = Symbol.for("openclaw.acp.activeTurns");
+
+export function resetAcpActiveTurnsForTests(): void {
+  resolveGlobalSingleton<AcpActiveTurnState>(ACP_ACTIVE_TURN_STATE_KEY, () => ({
+    activeTurnKeys: new Set<string>(),
+  })).activeTurnKeys.clear();
+}

--- a/src/acp/control-plane/active-turns.ts
+++ b/src/acp/control-plane/active-turns.ts
@@ -44,8 +44,3 @@ export function isAcpTurnActive(sessionKey: string): boolean {
   }
   return getAcpActiveTurnState().activeTurnKeys.has(normalizeActorKey(sessionKey));
 }
-
-/** Clears active-turn state for isolated tests. */
-export function resetAcpActiveTurnsForTests() {
-  getAcpActiveTurnState().activeTurnKeys.clear();
-}

--- a/src/acp/control-plane/manager.test-helpers.ts
+++ b/src/acp/control-plane/manager.test-helpers.ts
@@ -5,7 +5,7 @@ import { resetAcpManagerTaskStateForTests } from "../../../test/helpers/acp-mana
 import type { OpenClawConfig } from "../../config/config.js";
 import type { AcpSessionRuntimeOptions, SessionAcpMeta } from "../../config/sessions/types.js";
 import { deleteTestEnvValue, setTestEnvValue } from "../../test-utils/env.js";
-import { resetAcpActiveTurnsForTests } from "./active-turns.js";
+import { resetAcpActiveTurnsForTests } from "./active-turns.test-support.js";
 
 export type { AcpRuntime, OpenClawConfig, SessionAcpMeta };
 


### PR DESCRIPTION
## What Problem This Solves

ACP still occupied two dead-export baseline rows: one test-only reset and one intentional plugin-SDK runtime signature that Knip could not trace.

## Why This Change Was Made

Moves the reset into explicit test support and models the ACP registry as a Knip root because plugin-SDK ACP facades expose its runtime signatures. Runtime behavior and the shipped SDK API remain unchanged.

## User Impact

No user-visible behavior change. ACP now contributes zero grandfathered dead exports.

## Evidence

- Baseline: 246 -> 244, +0/-2; `src/acp/**`: 2 -> 0.
- Production/config source excluding baseline and test support: +2/-5, net -3 LOC.
- Testbox `tbx_01kxje4rq6waew99sg5pgssg4x`: 118/118 ACP tests; format; type-aware lint; core/test types; plugin SDK API hash and surface checks green.
- Fresh-base Testbox `tbx_01kxjejxg1a8esys1sxvsvjqyf`: regeneration byte-stable at 244; exact deadcode and plugin SDK API hash checks green.
- Fresh autoreview: clean, 0.94 confidence.
