### PR TITLE
fix(ci): spawn-timing tooling suites flake under concurrent shard execution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -576,6 +576,7 @@ jobs:
                 requires_dist: shard.requiresDist,
                 runner: shard.runner,
                 timeout_minutes: shard.timeoutMinutes,
+                plan_concurrency: shard.planConcurrency,
                 targets: shard.targets,
                 requires_go:
                   shard.shardName === "core-tooling" ||
@@ -1700,6 +1701,7 @@ jobs:
           OPENCLAW_VITEST_SHARD_NAME: ${{ matrix.shard_name }}
           OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS: "300000"
           OPENCLAW_VITEST_NO_OUTPUT_RETRY: "1"
+          OPENCLAW_NODE_TEST_PLAN_CONCURRENCY: ${{ matrix.plan_concurrency }}
         shell: bash
         run: node scripts/ci-run-node-test-shard.mjs
 

--- a/scripts/ci-run-node-test-shard.mjs
+++ b/scripts/ci-run-node-test-shard.mjs
@@ -178,13 +178,16 @@ export async function runShardPlans(plans, options = {}) {
 
 if (isDirectRunUrl(process.argv[1], import.meta.url)) {
   const plans = resolveShardPlans();
+  // Bins holding spawn/signal-timing suites are marked planConcurrency 1 by
+  // the planner; overlapping them with a sibling Vitest run causes flakes.
+  const planConcurrency = Number(process.env.OPENCLAW_NODE_TEST_PLAN_CONCURRENCY) || undefined;
   const releaseLock = acquireLocalHeavyCheckLockSync({
     cwd: process.cwd(),
     env: process.env,
     toolName: "test",
   });
   try {
-    process.exitCode = await runShardPlans(plans);
+    process.exitCode = await runShardPlans(plans, { concurrency: planConcurrency });
   } finally {
     releaseLock();
   }

--- a/scripts/lib/ci-node-test-plan.d.mts
+++ b/scripts/lib/ci-node-test-plan.d.mts
@@ -17,6 +17,7 @@ export type NodeTestShard = {
   env?: Record<string, string>;
   groups?: NodeTestShardGroup[];
   timeoutMinutes?: number;
+  planConcurrency?: number;
 };
 
 export type NodeTestPlanOptions = {

--- a/scripts/lib/ci-node-test-plan.mjs
+++ b/scripts/lib/ci-node-test-plan.mjs
@@ -118,6 +118,17 @@ const COMPACT_GROUP_SECONDS_HINTS = new Map([
 ]);
 const DEFAULT_WHOLE_GROUP_SECONDS = 25;
 const DEFAULT_SECONDS_PER_TEST_FILE = 0.5;
+// Spawn/signal-timing suites (process-group waits, PTY smoke) flake when a
+// concurrent sibling Vitest run competes for the 4 vCPU runner. Pack them
+// into bins the shard runner executes at concurrency 1.
+const EXCLUSIVE_COMPACT_GROUP_RE =
+  /^core-tooling(?:-\d+|-isolated|-docker)?$|^core-runtime-tui-pty$/u;
+// Exclusive bins run serially, so their packed estimate is their wall clock.
+const COMPACT_EXCLUSIVE_JOB_SECONDS = 150;
+
+function isExclusiveCompactGroup(group) {
+  return EXCLUSIVE_COMPACT_GROUP_RE.test(group.shard_name);
+}
 
 function estimateCompactGroupSeconds(group) {
   const hint = COMPACT_GROUP_SECONDS_HINTS.get(group.shard_name);
@@ -1335,17 +1346,25 @@ function createCompactNodeTestShardBundles(options = {}) {
     );
     for (const group of sortedGroups) {
       const weight = estimateCompactGroupSeconds(group);
+      const exclusive = isExclusiveCompactGroup(group);
+      const secondsCap = exclusive ? COMPACT_EXCLUSIVE_JOB_SECONDS : COMPACT_NODE_TEST_JOB_SECONDS;
       const bin = bins.find(
         (candidate) =>
+          candidate.exclusive === exclusive &&
           candidate.groups.length < COMPACT_NODE_TEST_JOB_GROUPS &&
-          candidate.weight + weight <= COMPACT_NODE_TEST_JOB_SECONDS,
+          candidate.weight + weight <= secondsCap,
       );
       if (bin) {
         bin.groups.push(group);
         bin.weight += weight;
         bin.hasWholeConfigGroup ||= !group.includePatterns;
       } else {
-        bins.push({ groups: [group], hasWholeConfigGroup: !group.includePatterns, weight });
+        bins.push({
+          exclusive,
+          groups: [group],
+          hasWholeConfigGroup: !group.includePatterns,
+          weight,
+        });
       }
     }
 
@@ -1362,6 +1381,9 @@ function createCompactNodeTestShardBundles(options = {}) {
         ...(bin.hasWholeConfigGroup
           ? { timeoutMinutes: COMPACT_WHOLE_NODE_TEST_TIMEOUT_MINUTES }
           : {}),
+        // Exclusive bins hold spawn/signal-timing suites; the shard runner
+        // must not overlap them with a concurrent sibling Vitest run.
+        ...(bin.exclusive ? { planConcurrency: 1 } : {}),
       });
     }
   }

--- a/test/scripts/ci-node-test-plan.test.ts
+++ b/test/scripts/ci-node-test-plan.test.ts
@@ -203,6 +203,26 @@ describe("scripts/lib/ci-node-test-plan.mjs", () => {
     expect(jobOf("agentic-agents-core-runner-embedded")).toBeGreaterThanOrEqual(0);
     expect(jobOf("core-unit-fast")).toBeGreaterThanOrEqual(0);
     expect(jobOf("agentic-agents-core-runner-embedded")).not.toBe(jobOf("core-unit-fast"));
+    // Spawn/signal-timing suites flake next to a concurrent sibling Vitest
+    // run; their bins must force the shard runner to concurrency 1 and never
+    // mix with regular groups.
+    const exclusiveGroupRe = /^core-tooling(?:-\d+|-isolated|-docker)?$|^core-runtime-tui-pty$/u;
+    for (const shard of compact) {
+      const exclusiveCount = shard.groups.filter((group) =>
+        exclusiveGroupRe.test(group.shard_name),
+      ).length;
+      if (exclusiveCount > 0) {
+        expect(shard.planConcurrency).toBe(1);
+        expect(exclusiveCount).toBe(shard.groups.length);
+      } else {
+        expect(shard.planConcurrency).toBeUndefined();
+      }
+    }
+    expect(
+      compact.filter((shard) =>
+        shard.groups.some((group) => exclusiveGroupRe.test(group.shard_name)),
+      ).length,
+    ).toBeGreaterThan(0);
     expect(
       compact
         .flatMap((shard) =>


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where unrelated PRs fail CI after #108091: spawn/signal-timing tooling tests (`test/scripts/run-additional-boundary-checks.test.ts` "waits for timed-out process groups", `test/scripts/control-ui-i18n.test.ts` "waits for all process groups before re-raising parent signals") flake when the new shard runner overlaps them with a concurrent sibling Vitest run on 4 vCPU. Observed on 3 of the first 7 post-merge PR runs (`checks-node-compact-small-2`/`small-6` failures on runs 29400312425, 29400437167, 29400389902).

## Why This Change Was Made

The compact packer now marks spawn/signal-timing suites (`core-tooling-*`, `core-tooling-isolated`, `core-tooling-docker`, `core-runtime-tui-pty`) as exclusive: they pack only with each other into bins capped at 150s serial, and each such bin carries `planConcurrency: 1`, which the shard runner honors via `OPENCLAW_NODE_TEST_PLAN_CONCURRENCY` — those jobs run their plans strictly serially, exactly like the pre-#108091 execution model for these suites. All other bins keep two-way concurrency.

## User Impact

Unbreaks PR CI for everyone; no product behavior change. Adds ~2 small jobs to the compact matrix (23 total, still under the 28-slot cap) with no wall-clock regression since exclusive bins are capped at 150s.

## Evidence

- Plan output: tooling stripes land in four concurrency-1 bins (`core-tooling-3+isolated`, `core-tooling-1+docker`, `core-tooling-2`, `core-tooling-4`) and `core-runtime-tui-pty` runs solo; no exclusive group shares a bin with a regular group (asserted in `test/scripts/ci-node-test-plan.test.ts`).
- Focused tests green locally: `ci-node-test-plan.test.ts`, `ci-run-node-test-shard.test.ts`, `ci-workflow-guards.test.ts` (82 passed, 1 skipped).
- This PR's own CI run exercises the exclusive bins end to end.
