### PR TITLE
improve: speed SQLite reliability CLI rejection

### DIFF
--- a/scripts/bench-sqlite-reliability.ts
+++ b/scripts/bench-sqlite-reliability.ts
@@ -4,7 +4,6 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { CliUsageError, parseSqliteReliabilityCli } from "./lib/sqlite-reliability-cli.js";
 import type { ReliabilityReport } from "./lib/sqlite-reliability-contract.js";
-import { runReliabilityStress } from "./lib/sqlite-reliability-runner.js";
 
 function printUsage(): void {
   console.log(`OpenClaw SQLite reliability stress proof
@@ -63,6 +62,7 @@ async function main(argv: string[]): Promise<void> {
       return;
     }
     const { options } = cli;
+    const { runReliabilityStress } = await import("./lib/sqlite-reliability-runner.js");
     const report = await runReliabilityStress(options);
     if (options.output) {
       fs.mkdirSync(path.dirname(options.output), { recursive: true });


### PR DESCRIPTION
## What Problem This Solves

The SQLite reliability tooling test spent about 2.44 seconds loading the full stress runner before rejecting malformed CLI input. That eager work made a four-test tooling file one of the slowest files in the tooling suite even though invalid input never needs the runner.

## Why This Change Was Made

Load the stress runner only after CLI parsing succeeds and the help fast path has returned. Valid reliability stress runs keep the same runner and await behavior; malformed and help invocations avoid importing the state, snapshot, and compaction graph.

## User Impact

No product behavior changes. Maintainer test feedback is faster, and invalid/help invocations of the internal SQLite reliability script return without unnecessary startup work.

## Evidence

- Fresh tooling profile: 6,025 tests passed; 215.1s wall. The malformed-argument case cost 2.44s before this change.
- Three focused samples preserved 4/4 passing tests. Median file time improved from 7.66s to 5.69s (25.8% faster); the malformed-argument case measured 74ms after the change.
- Latest-main focused proof: `pnpm test test/scripts/bench-sqlite-reliability.test.ts` — 4 passed.
- `pnpm check:changed` — passed.
- `pnpm build` — passed.
- Blacksmith Testbox through Crabbox: `tbx_01kxjer3qasp31b5s5hrsxgbk9`, Actions run 29401428770.
- Autoreview: clean, no accepted/actionable findings.

AI-assisted: Codex. I reviewed the one-line lazy-import boundary and understand the behavior it preserves.
