### PR TITLE
fix: preview sandboxed inbound images in Control UI

### DIFF
--- a/src/auto-reply/reply.triggers.trigger-handling.stages-inbound-media-into-sandbox-workspace.test.ts
+++ b/src/auto-reply/reply.triggers.trigger-handling.stages-inbound-media-into-sandbox-workspace.test.ts
@@ -3,6 +3,10 @@ import fs from "node:fs/promises";
 import path, { basename, dirname, join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { MEDIA_MAX_BYTES } from "../media/store.js";
+import {
+  buildPersistedUserTurnMediaInputsFromFields,
+  buildPersistedUserTurnMessage,
+} from "../sessions/user-turn-transcript.js";
 import { stageSandboxMedia } from "./reply/stage-sandbox-media.js";
 import {
   createSandboxMediaContexts,
@@ -193,6 +197,12 @@ describe("stageSandboxMedia", () => {
       expect(sessionCtx.MediaPath).toBe(stagedPath);
       expect(ctx.MediaUrl).toBe(stagedPath);
       expect(sessionCtx.MediaUrl).toBe(stagedPath);
+      expect(ctx.MediaWorkspaceDir).toBe(sandboxDir);
+      expect(sessionCtx.MediaWorkspaceDir).toBe(sandboxDir);
+      const persistedMessage = buildPersistedUserTurnMessage({
+        media: buildPersistedUserTurnMediaInputsFromFields(ctx),
+      });
+      expect(persistedMessage.MediaPath).toBe(join(sandboxDir, stagedPath));
       await expect(fs.readFile(join(sandboxDir, stagedPath), "utf8")).resolves.toBe("pdf-bytes");
     });
   });

--- a/src/auto-reply/reply/stage-sandbox-media.ts
+++ b/src/auto-reply/reply/stage-sandbox-media.ts
@@ -158,6 +158,12 @@ export async function stageSandboxMedia(params: {
     staged,
     hasPathsArray,
   });
+  if (sandbox && staged.size > 0) {
+    // Persisted transcripts need an absolute anchor for runner-relative media paths;
+    // otherwise Control UI treats media/inbound/... as an ordinary broken URL.
+    ctx.MediaWorkspaceDir = effectiveWorkspaceDir;
+    sessionCtx.MediaWorkspaceDir = effectiveWorkspaceDir;
+  }
 
   return { staged };
 }


### PR DESCRIPTION
Closes #108174

## What Problem This Solves

Fixes an issue where users reviewing sandboxed channel conversations in Control UI would see a broken inbound image preview even though the agent had successfully read and analyzed the image.

## Why This Change Was Made

When inbound media is copied into a sandbox, record the effective sandbox workspace as `MediaWorkspaceDir`. The existing transcript writer can then anchor runner-relative `media/inbound/...` paths before persistence, allowing the existing authenticated assistant-media route to serve them. The change applies only after at least one file was successfully staged into a sandbox; host-mode and rejected media paths are unchanged.

## User Impact

Inbound images staged for sandboxed agents remain visible in Control UI chat history. Agent image handling and the media proxy security boundary are unchanged.

## Evidence

- Reproduction test failed on current `main` with `MediaWorkspaceDir` undefined and passed after the fix.
- `node scripts/run-vitest.mjs src/auto-reply/reply.triggers.trigger-handling.stages-inbound-media-into-sandbox-workspace.test.ts` - 5 passed.
- `node scripts/run-vitest.mjs src/sessions/user-turn-transcript.test.ts src/auto-reply/reply.triggers.trigger-handling.stages-inbound-media-into-sandbox-workspace.test.ts` - 41 passed across two shards.
- `node scripts/run-vitest.mjs ui/src/pages/chat/components/chat-message.test.ts` - 91 passed.
- `pnpm format:check -- src/auto-reply/reply/stage-sandbox-media.ts src/auto-reply/reply.triggers.trigger-handling.stages-inbound-media-into-sandbox-workspace.test.ts` - passed.
- `.agents/skills/autoreview/scripts/autoreview --mode local` - clean, no accepted/actionable findings.

AI-assisted: yes. I reviewed the staging, transcript persistence, media allowlist, and Control UI proxy paths and understand the change.
