### PR TITLE
fix(mcp): preserve image blocks in normalizeToolCallContent

### DIFF
--- a/src/gateway/mcp-http.handlers.ts
+++ b/src/gateway/mcp-http.handlers.ts
@@ -37,6 +37,11 @@ function normalizeToolCallContent(result: unknown): ContentBlock[] {
   const content = (result as { content?: unknown })?.content;
   if (Array.isArray(content)) {
     return content.map((block) => {
+      // Preserve image blocks directly so data and mimeType are not lost
+      // before schema validation.
+      if (isRecord(block) && block.type === "image") {
+        return block as ContentBlock;
+      }
       const parsed = ContentBlockSchema.safeParse(block);
       if (parsed.success && MCP_LOOPBACK_CONTENT_TYPES.has(parsed.data.type)) {
         return parsed.data;


### PR DESCRIPTION
Fixes #108082

## What Problem This Solves

MCP tool results that contain image content blocks (e.g. browser screenshots) lose their `data` and `mimeType` fields because `normalizeToolCallContent` validates every block through `ContentBlockSchema.safeParse`, which may not accept image blocks in the shape returned by tools. The image data is silently dropped and the block is stringified.

## Why This Change Was Made

Added an early guard in `normalizeToolCallContent` that preserves image blocks (`type: "image"`) directly before schema validation. This ensures the `data` and `mimeType` fields survive the normalization pass and reach the MCP client intact.

## Evidence

- `src/gateway/mcp-http.handlers.ts`: 5-line guard before ContentBlockSchema validation
- Existing text/resource blocks continue to go through schema validation as before
- `isRecord` already imported from `@openclaw/normalization-core/record-coerce`

