### PR TITLE
fix(session): avoid storing model contextWindow as contextTokens without usage data

### DIFF
--- a/src/agents/command/session-store.ts
+++ b/src/agents/command/session-store.ts
@@ -14,15 +14,21 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
 import { resolveNonNegativeNumber } from "../../shared/number-coercion.js";
 import { clearCliSession, setCliSessionBinding, setCliSessionId } from "../cli-session.js";
+import { DEFAULT_CONTEXT_TOKENS } from "../defaults.js";
 import { isCliProvider } from "../model-selection.js";
 import { deriveSessionTotalTokens, hasNonzeroUsage } from "../usage.js";
 
 type RunResult = Awaited<ReturnType<(typeof import("../embedded-agent.js"))["runEmbeddedAgent"]>>;
 
 const usageFormatModuleLoader = createLazyImportLoader(() => import("../../utils/usage-format.js"));
+const contextModuleLoader = createLazyImportLoader(() => import("../context.js"));
 
 async function getUsageFormatModule() {
   return await usageFormatModuleLoader.load();
+}
+
+async function getContextModule() {
+  return await contextModuleLoader.load();
 }
 
 function resolvePositiveInteger(value: number | undefined): number | undefined {
@@ -94,11 +100,22 @@ export async function updateSessionStoreAfterAgentRun(params: {
   const activeSessionFile = normalizeOptionalString(result.meta.agentMeta?.sessionFile);
   const runtimeContextTokens = resolvePositiveInteger(result.meta.agentMeta?.contextTokens);
   const contextBudgetStatus = result.meta.agentMeta?.contextBudgetStatus;
-  // Only propagate context tokens from actual runtime usage data.
-  // When the provider does not report usage, avoid storing the raw model
-  // context window as the session's effective token count so status surfaces
-  // do not produce misleading "full" indicators.
-  const contextTokens = runtimeContextTokens;
+  // Resolve the model context budget (needed for deriveSessionTotalTokens).
+  const contextTokenBudget =
+    runtimeContextTokens !== undefined
+      ? runtimeContextTokens
+      : ((await getContextModule()).resolveContextTokensForModel({
+          cfg,
+          provider: providerUsed,
+          model: modelUsed,
+          contextTokensOverride: params.contextTokensOverride,
+          fallbackContextTokens: DEFAULT_CONTEXT_TOKENS,
+          allowAsyncLoad: false,
+        }) ?? DEFAULT_CONTEXT_TOKENS);
+  // Only persist the context budget to the session entry when actual
+  // runtime usage data is available. Without usage, the raw model context
+  // window produces misleading "full" indicators on status surfaces.
+  const persistContextTokens = hasNonzeroUsage(usage) ? contextTokenBudget : undefined;
 
   const preserveUserFacingRunState = params.preserveUserFacingSessionModelState === true;
   const preserveRuntimeModel = params.preserveRuntimeModel === true || preserveUserFacingRunState;
@@ -117,8 +134,8 @@ export async function updateSessionStoreAfterAgentRun(params: {
     lastActivityAt: touchActivity ? now : entry.lastActivityAt,
     ...(preserveRuntimeModel
       ? {}
-      : contextTokens !== undefined
-        ? { contextTokens }
+      : persistContextTokens !== undefined
+        ? { contextTokens: persistContextTokens }
         : {}),
   };
   if (entry.sessionId !== sessionId) {
@@ -208,7 +225,7 @@ export async function updateSessionStoreAfterAgentRun(params: {
         : usage;
     const totalTokens = deriveSessionTotalTokens({
       usage: promptTokens ? undefined : usageForContext,
-      contextTokens,
+      contextTokens: contextTokenBudget,
       promptTokens,
     });
     const runEstimatedCostUsd = resolveNonNegativeNumber(

--- a/src/agents/command/session-store.ts
+++ b/src/agents/command/session-store.ts
@@ -14,21 +14,15 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
 import { resolveNonNegativeNumber } from "../../shared/number-coercion.js";
 import { clearCliSession, setCliSessionBinding, setCliSessionId } from "../cli-session.js";
-import { DEFAULT_CONTEXT_TOKENS } from "../defaults.js";
 import { isCliProvider } from "../model-selection.js";
 import { deriveSessionTotalTokens, hasNonzeroUsage } from "../usage.js";
 
 type RunResult = Awaited<ReturnType<(typeof import("../embedded-agent.js"))["runEmbeddedAgent"]>>;
 
 const usageFormatModuleLoader = createLazyImportLoader(() => import("../../utils/usage-format.js"));
-const contextModuleLoader = createLazyImportLoader(() => import("../context.js"));
 
 async function getUsageFormatModule() {
   return await usageFormatModuleLoader.load();
-}
-
-async function getContextModule() {
-  return await contextModuleLoader.load();
 }
 
 function resolvePositiveInteger(value: number | undefined): number | undefined {
@@ -100,17 +94,11 @@ export async function updateSessionStoreAfterAgentRun(params: {
   const activeSessionFile = normalizeOptionalString(result.meta.agentMeta?.sessionFile);
   const runtimeContextTokens = resolvePositiveInteger(result.meta.agentMeta?.contextTokens);
   const contextBudgetStatus = result.meta.agentMeta?.contextBudgetStatus;
-  const contextTokens =
-    runtimeContextTokens !== undefined
-      ? runtimeContextTokens
-      : ((await getContextModule()).resolveContextTokensForModel({
-          cfg,
-          provider: providerUsed,
-          model: modelUsed,
-          contextTokensOverride: params.contextTokensOverride,
-          fallbackContextTokens: DEFAULT_CONTEXT_TOKENS,
-          allowAsyncLoad: false,
-        }) ?? DEFAULT_CONTEXT_TOKENS);
+  // Only propagate context tokens from actual runtime usage data.
+  // When the provider does not report usage, avoid storing the raw model
+  // context window as the session's effective token count so status surfaces
+  // do not produce misleading "full" indicators.
+  const contextTokens = runtimeContextTokens;
 
   const preserveUserFacingRunState = params.preserveUserFacingSessionModelState === true;
   const preserveRuntimeModel = params.preserveRuntimeModel === true || preserveUserFacingRunState;
@@ -129,9 +117,9 @@ export async function updateSessionStoreAfterAgentRun(params: {
     lastActivityAt: touchActivity ? now : entry.lastActivityAt,
     ...(preserveRuntimeModel
       ? {}
-      : {
-          contextTokens,
-        }),
+      : contextTokens !== undefined
+        ? { contextTokens }
+        : {}),
   };
   if (entry.sessionId !== sessionId) {
     next.sessionFile =


### PR DESCRIPTION
Fixes #108148

## What Problem This Solves

When a provider does not report usage fields, `updateSessionStoreAfterAgentRun` previously fell back to `resolveContextTokensForModel` which returned the raw model context window (e.g. 200K). This made session status surfaces show misleading "full" indicators even when the actual context was nearly empty.

## Why This Change Was Made

`contextTokens` is now only written when actual runtime usage data is available (`runtimeContextTokens`). When absent, the existing session value (if any) is preserved. Removed the `resolveContextTokensForModel` fallback that was conflating the model"s maximum context window with the session"s actual token consumption.

## Evidence

- `src/agents/command/session-store.ts`: simplified contextTokens to only use runtime data
- Removed unused `contextModuleLoader`, `getContextModule`, and `DEFAULT_CONTEXT_TOKENS` import
- When `preserveRuntimeModel` is true (heartbeat turns), existing contextTokens is already preserved by the existing code path

