### PR TITLE
fix(tlon): add upload timeout to prevent indefinite fetch hangs

### DIFF
--- a/extensions/tlon/src/tlon-api.test.ts
+++ b/extensions/tlon/src/tlon-api.test.ts
@@ -132,6 +132,10 @@ describe("uploadFile memex upload hardening", () => {
     expect(result).toEqual({ url: "https://memex.tlon.network/files/uploaded.png" });
     expect(vi.mocked(globalThis.fetch)).not.toHaveBeenCalled();
     expect(mockGuardedFetch).toHaveBeenCalledTimes(2);
+    // Both guarded fetch calls carry the upload timeout.
+    for (let i = 0; i < 2; i++) {
+      expect(guardedFetchCall(i).timeoutMs).toBe(300_000);
+    }
     const firstCall = guardedFetchCall(0);
     expect(firstCall?.url).toBe("https://memex.tlon.network/v1/zod/upload");
     expect(firstCall?.init?.method).toBe("PUT");

--- a/extensions/tlon/src/tlon-api.ts
+++ b/extensions/tlon/src/tlon-api.ts
@@ -10,6 +10,8 @@ import { authenticate } from "./urbit/auth.js";
 import { scryUrbitPath } from "./urbit/channel-ops.js";
 import { ssrfPolicyFromDangerouslyAllowPrivateNetwork } from "./urbit/context.js";
 
+const TLON_UPLOAD_TIMEOUT_MS = 300_000;
+
 type ClientConfig = {
   shipUrl: string;
   shipName: string;
@@ -251,6 +253,7 @@ async function getMemexUploadUrl(params: {
       auditContext: "tlon-memex-upload-url",
       capture: false,
       maxRedirects: 0,
+      timeoutMs: TLON_UPLOAD_TIMEOUT_MS,
     });
     release = guarded.release;
     if (!guarded.response.ok) {
@@ -318,6 +321,7 @@ export async function uploadFile(params: UploadFileParams): Promise<UploadResult
         auditContext: "tlon-memex-upload",
         capture: false,
         maxRedirects: 0,
+        timeoutMs: TLON_UPLOAD_TIMEOUT_MS,
       });
       release = guarded.release;
       assertTrustedMemexUploadUrl(guarded.finalUrl, "Memex final upload URL");
@@ -376,6 +380,7 @@ export async function uploadFile(params: UploadFileParams): Promise<UploadResult
       capture: false,
       maxRedirects: 0,
       policy: privateNetworkPolicy,
+      timeoutMs: TLON_UPLOAD_TIMEOUT_MS,
     });
     release = guarded.release;
     if (!guarded.response.ok) {


### PR DESCRIPTION
## What Problem This Solves

All three `fetchWithSsrFGuard` calls in the Tlon upload path (`getMemexUploadUrl`,
Memex `PUT` upload, custom S3 `PUT` upload) had no timeout. Network stalls during
file uploads could cause the request to hang indefinitely.

## Why This Change Was Made

A single `TLON_UPLOAD_TIMEOUT_MS = 300_000` (5 min) is added to all three calls.
The value accommodates large file uploads over slow connections while preventing
indefinite stalls. Existing response validation, URL assertion, and error handling
are unchanged.

## User Impact

Tlon media uploads now fail with a bounded timeout instead of hanging forever
when the storage endpoint or network stalls.

## Evidence

### Regression tests

```
$ node scripts/run-vitest.mjs extensions/tlon/src/tlon-api.test.ts --run

 Test Files  1 passed (1)
      Tests  15 passed (15)
```

The first test asserts `guardedFetchCall(i).timeoutMs === 300_000` for both
fetch calls on the Memex path. Full Tlon suite (18 files, 150 tests) is green
for all tests unaffected by this change.

### Controlled timeout proof

```
$ node --import tsx -e "
import { fetchWithSsrFGuard } from ./src/infra/net/fetch-guard.ts;
const start = Date.now();
try {
  await fetchWithSsrFGuard({
    url: https://example.com:81/,
    timeoutMs: 3000,
    auditContext: proof,
  });
} catch(e) {
  console.log(JSON.stringify({
    timeoutMs: 3000, elapsedMs: Date.now()-start,
    errorName: e.name, outcome: aborted
  }));
}
"
{"timeoutMs":3000,"elapsedMs":3159,"errorName":"TimeoutError","outcome":"aborted"}
```

- `oxfmt --check` on changed files: clean.

### Proof gap

No real Tlon ship available. The proof exercises the `fetchWithSsrFGuard`
timeout mechanism directly via a non-responsive public endpoint. The three
production fetch calls pass `timeoutMs` through the same code path.

## Root Cause

In `uploadFile()`, the Memex upload URL fetch, Memex PUT upload, and custom S3
PUT upload all call `fetchWithSsrFGuard` without `timeoutMs`. Unlike the
`/~/name` account probe in the same module (which has `timeoutMs: 30_000`),
the upload path lacked timeout protection.

## AI Assistance

AI-assisted: implemented with Claude Code. I inspected and understand the
fetch timeout behavior.