### PR TITLE
fix(openai): ignore blank speech API env keys

### DIFF
--- a/extensions/openai/speech-provider.test.ts
+++ b/extensions/openai/speech-provider.test.ts
@@ -376,6 +376,79 @@ describe("buildOpenAISpeechProvider", () => {
     }
   });
 
+  it("does not treat a whitespace OPENAI_API_KEY as configured", () => {
+    const previousKey = process.env.OPENAI_API_KEY;
+    process.env.OPENAI_API_KEY = "   ";
+    try {
+      const provider = buildOpenAISpeechProvider();
+
+      expect(provider.isConfigured({ providerConfig: {}, timeoutMs: 30_000 })).toBe(false);
+    } finally {
+      if (previousKey === undefined) {
+        delete process.env.OPENAI_API_KEY;
+      } else {
+        process.env.OPENAI_API_KEY = previousKey;
+      }
+    }
+  });
+
+  it("rejects whitespace OPENAI_API_KEY before speech synthesis", async () => {
+    const previousKey = process.env.OPENAI_API_KEY;
+    process.env.OPENAI_API_KEY = "   ";
+    const provider = buildOpenAISpeechProvider();
+    const fetchMock = vi.fn(async () => new Response(new Uint8Array([1, 2, 3]), { status: 200 }));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    try {
+      await expect(
+        provider.synthesize({
+          text: "hello",
+          cfg: {} as never,
+          providerConfig: {
+            model: "gpt-4o-mini-tts",
+            voice: "alloy",
+          },
+          target: "audio-file",
+          timeoutMs: 1_000,
+        }),
+      ).rejects.toThrow("OpenAI API key missing");
+      expect(fetchMock).not.toHaveBeenCalled();
+    } finally {
+      if (previousKey === undefined) {
+        delete process.env.OPENAI_API_KEY;
+      } else {
+        process.env.OPENAI_API_KEY = previousKey;
+      }
+    }
+  });
+
+  it("rejects whitespace OPENAI_API_KEY before telephony synthesis", async () => {
+    const previousKey = process.env.OPENAI_API_KEY;
+    process.env.OPENAI_API_KEY = "   ";
+    const provider = buildOpenAISpeechProvider();
+    const fetchMock = vi.fn(async () => new Response(new Uint8Array([1, 2, 3]), { status: 200 }));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    try {
+      await expect(
+        provider.synthesizeTelephony?.({
+          text: "hello",
+          cfg: {} as never,
+          providerConfig: {
+            model: "gpt-4o-mini-tts",
+            voice: "alloy",
+          },
+          timeoutMs: 1_000,
+        }),
+      ).rejects.toThrow("OpenAI API key missing");
+      expect(fetchMock).not.toHaveBeenCalled();
+    } finally {
+      if (previousKey === undefined) {
+        delete process.env.OPENAI_API_KEY;
+      } else {
+        process.env.OPENAI_API_KEY = previousKey;
+      }
+    }
+  });
+
   it("preserves talk responseFormat overrides", () => {
     const provider = buildOpenAISpeechProvider();
 

--- a/extensions/openai/speech-provider.ts
+++ b/extensions/openai/speech-provider.ts
@@ -50,6 +50,10 @@ type OpenAITtsProviderOverrides = {
   speed?: number;
 };
 
+function resolveOpenAISpeechApiKey(config: OpenAITtsProviderConfig): string | undefined {
+  return trimToUndefined(config.apiKey) ?? trimToUndefined(process.env.OPENAI_API_KEY);
+}
+
 function normalizeOpenAISpeechResponseFormat(
   value: unknown,
 ): OpenAiSpeechResponseFormat | undefined {
@@ -322,7 +326,7 @@ export function buildOpenAISpeechProvider(): SpeechProviderPlugin {
     }),
     listVoices: async () => OPENAI_TTS_VOICES.map((voice) => ({ id: voice, name: voice })),
     isConfigured: ({ providerConfig }) =>
-      Boolean(readOpenAIProviderConfig(providerConfig).apiKey || process.env.OPENAI_API_KEY),
+      Boolean(resolveOpenAISpeechApiKey(readOpenAIProviderConfig(providerConfig))),
     prepareSynthesis: (ctx) => {
       const config = readOpenAIProviderConfig(ctx.providerConfig);
       if (config.instructions) {
@@ -343,7 +347,7 @@ export function buildOpenAISpeechProvider(): SpeechProviderPlugin {
     synthesize: async (req) => {
       const config = readOpenAIProviderConfig(req.providerConfig);
       const overrides = readOpenAIOverrides(req.providerOverrides, config.baseUrl);
-      const apiKey = config.apiKey || process.env.OPENAI_API_KEY;
+      const apiKey = resolveOpenAISpeechApiKey(config);
       if (!apiKey) {
         throw new Error("OpenAI API key missing");
       }
@@ -378,7 +382,7 @@ export function buildOpenAISpeechProvider(): SpeechProviderPlugin {
     synthesizeTelephony: async (req) => {
       const config = readOpenAIProviderConfig(req.providerConfig);
       const overrides = readOpenAIOverrides(req.providerOverrides, config.baseUrl);
-      const apiKey = config.apiKey || process.env.OPENAI_API_KEY;
+      const apiKey = resolveOpenAISpeechApiKey(config);
       if (!apiKey) {
         throw new Error("OpenAI API key missing");
       }


### PR DESCRIPTION
## What Problem This Solves

Fixes #108186.

OpenAI speech provider readiness and synthesis treated a whitespace-only `OPENAI_API_KEY` environment value as configured. That let a blank env entry pass local checks and reach request construction instead of failing fast as a missing API key.

## Why This Change Was Made

Configured OpenAI speech keys already go through string normalization, but the environment fallback was read directly. This change routes both configured and environment keys through the same trim-to-empty handling before `isConfigured`, `synthesize`, and `synthesizeTelephony` use the value.

## User Impact

Users with an accidentally blank `OPENAI_API_KEY` now get the local `OpenAI API key missing` error and the provider no longer appears configured from whitespace alone. Valid configured keys and valid env keys continue to work.

## Evidence

```text
node scripts/run-vitest.mjs extensions/openai/speech-provider.test.ts
Test Files  1 passed (1)
Tests  25 passed (25)
```

```text
git diff --check
```

```text
oxfmt --check --threads=1 extensions/openai/speech-provider.ts extensions/openai/speech-provider.test.ts
All matched files use the correct format.
```

```text
autoreview --mode branch --base upstream/main
autoreview clean: no accepted/actionable findings reported
overall: patch is correct (0.96)
```
