### PR TITLE
fix(agents): remove hex slice truncation in pending tool call IDs

### DIFF
--- a/src/agents/embedded-agent-runner/run/terminal-resolution.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-resolution.ts
@@ -465,7 +465,7 @@ function completeEmbeddedRun(
           : {}),
         stopReason,
         pendingToolCalls: input.attempt.clientToolCalls?.map((call) => ({
-          id: randomBytes(5).toString("hex").slice(0, 9),
+          id: randomBytes(5).toString("hex"),
           name: call.name,
           arguments: JSON.stringify(call.params),
         })),


### PR DESCRIPTION
## What Problem This Solves

`randomBytes(5).toString("hex").slice(0, 9)` in `terminal-resolution.ts:468` truncates the last hex character from the generated pending tool call ID. Five random bytes produce 10 hex characters; slicing to 9 loses one hex digit, reducing the ID space by 93.75% (from 1,099,511,627,776 to 68,719,476,736 possible IDs) and risking collisions under load.

## Fix

Remove the `.slice(0, 9)` call. The full 10-character hex output from `randomBytes(5).toString("hex")` matches the pattern used in `commitments/store.ts:237` and 9 other call sites in the project that never truncate their hex IDs.

## Evidence

### Before fix (main branch): hex truncation

```
$ node -e "const { randomBytes } = require('crypto'); ..."
=== Before fix (slice(0, 9)) ===
randomBytes(5).toString(hex): 928ee3be20 (length: 10)
After slice(0, 9): 928ee3be2 (length: 9)
Last hex char lost, reducing entropy from 5 bytes (40 bits) to ~36 bits

=== Collision risk ===
9-char hex space: 16^9 = 68,719,476,736 possible IDs
10-char hex space: 16^10 = 1,099,511,627,776 possible IDs
Space reduction: 93.75% fewer unique IDs possible with 9 chars
```

### After fix (this PR): full hex preserved

```
randomBytes(5).toString(hex): 4d7aa93e52 (length: 10)
Full 5 bytes (40 bits) of entropy preserved
```

### Consistency with project patterns

All other `randomBytes().toString("hex")` call sites in the project use full hex output without truncation:
- `commitments/store.ts:237` — `randomBytes(5).toString("hex")` (10 chars, no slice)
- 9 other call sites — same pattern, no truncation

This change aligns with the established project convention.

## Test plan

- [x] Existing `session.test.ts` tests pass (2/2)
- [x] Change is obviously correct — removing a truncation that loses entropy
- [x] Matches the pattern used in all other `randomBytes().toString("hex")` call sites