### PR TITLE
fix(ui): restore scrollbar in skill workshop board mode

### DIFF
--- a/ui/src/styles/skill-workshop.css
+++ b/ui/src/styles/skill-workshop.css
@@ -43,10 +43,28 @@
   margin-top: var(--space-4);
 }
 
-/* Replaces the old .content--skill-workshop > .skill-workshop rule: the board
-   nests inside the hub tabpanel now, and dropping min-height: 0 at either
-   level would let tall boards grow the page instead of scrolling internally. */
-.sw-hub-panel > .skill-workshop {
+/* The board nests inside the hub tabpanel, which may wrap it in an inner
+   mode-switching tab panel. The inner tab panel must be a flex container so
+   the height constraint passes through to .skill-workshop. Shadow-DOM part
+   overrides make the tab panel's internal wrapper a flex column that fills
+   the host; width:100% preserves the full-width block behavior. */
+#skill-workshop-mode-panel {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
+.sw-hub-panel::part(base),
+#skill-workshop-mode-panel::part(base) {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  min-height: 0;
+  width: 100%;
+}
+
+.sw-hub-panel .skill-workshop {
   flex: 1 1 auto;
   min-height: 0;
 }
@@ -1025,7 +1043,8 @@
   }
 }
 
-/* Progressive history review */
+/* Progressive history review — flex-shrink:0 keeps the banner from
+   collapsing when the board flex container is height-constrained. */
 .sw-history {
   position: relative;
   display: grid;
@@ -1035,6 +1054,7 @@
   margin: 18px 0 22px;
   padding: 24px 26px;
   overflow: hidden;
+  flex-shrink: 0;
   border: 1px solid color-mix(in srgb, var(--accent) 24%, var(--border));
   border-radius: 18px;
   background:


### PR DESCRIPTION
## What Problem This Solves

In the Skill Workshop page, when viewing proposals in board mode, neither the proposal list (left panel) nor the proposal detail body (right panel) shows a scrollbar. Users can only see the content that fits on screen and cannot scroll to view the rest.

Fixes #108196

## Why This Change Was Made

The flex height constraint chain was broken at three points in `ui/src/styles/skill-workshop.css`:

1. **CSS child selector mismatch**: `.sw-hub-panel > .skill-workshop` used the `>` direct-child combinator, but `.skill-workshop` is nested inside an inner `wa-tab-panel#skill-workshop-mode-panel`, so the rule never matched. Fixed by switching to a descendant selector.
2. **Missing flex styles on inner tab panel**: `wa-tab-panel#skill-workshop-mode-panel` defaulted to `display: block`, which cannot pass through flex height constraints. Added explicit flex container styles.
3. **Shadow DOM boundary**: The `wa-tab-panel` shadow DOM internal `slot[part="base"]` also needed `::part(base)` flex overrides to fill the host element height.

## User Impact

Users of the Skill Workshop in board mode can now properly scroll through both the proposal list and the proposal detail body.

## Evidence

- `cd ui && pnpm build` — passed.
- Exact-head CI gate — passed.
- CSS-only fix, scoped to Skill Workshop.

### Before

The queue and detail content are clipped with no usable scrollbar.

<img width="1901" height="961" alt="Skill Workshop board before the fix, with clipped proposal content" src="https://github.com/user-attachments/assets/e610f997-14fd-436c-bb8c-de2cdc89d202" />

### After

Both panes expose their intended scrollable content.

<img width="1908" height="956" alt="Skill Workshop board after the fix, with restored scrollbars" src="https://github.com/user-attachments/assets/0fc2e980-7fb7-4d90-81c1-990e9dcf9337" />
