### PR TITLE
fix(android): keep header logo in brand colors

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt
@@ -599,7 +599,7 @@ private fun OverviewHeader(
     verticalAlignment = Alignment.CenterVertically,
     horizontalArrangement = Arrangement.spacedBy(10.dp),
   ) {
-    OpenClawMascot(modifier = Modifier.size(25.dp), tint = ClawTheme.colors.text)
+    OpenClawMascot(modifier = Modifier.size(25.dp))
     Text(
       text = nativeString("OpenClaw"),
       style = ClawTheme.type.title.copy(fontSize = 17.sp, lineHeight = 21.sp),

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt
@@ -628,7 +628,7 @@ private fun VoiceHeader(
       verticalAlignment = Alignment.CenterVertically,
       horizontalArrangement = Arrangement.spacedBy(10.dp),
     ) {
-      OpenClawMascot(modifier = Modifier.size(25.dp), tint = ClawTheme.colors.text)
+      OpenClawMascot(modifier = Modifier.size(25.dp))
       Text(
         text = nativeString("OpenClaw"),
         style = ClawTheme.type.title.copy(fontSize = 17.sp, lineHeight = 21.sp),

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt
@@ -647,7 +647,7 @@ private fun ChatHeader(
       verticalAlignment = Alignment.CenterVertically,
       horizontalArrangement = Arrangement.spacedBy(10.dp),
     ) {
-      OpenClawMascot(modifier = Modifier.size(25.dp), tint = ClawTheme.colors.text)
+      OpenClawMascot(modifier = Modifier.size(25.dp))
       Text(
         text = nativeString("OpenClaw"),
         style = ClawTheme.type.title.copy(fontSize = 17.sp, lineHeight = 21.sp),


### PR DESCRIPTION
[AI-assisted]
## What Problem This Solves

The OpenClaw mascot in the Android Chat, Home, and Voice headers inherited the current text color, so it appeared black in Light Mode and white in Dark Mode instead of using the OpenClaw brand colors.

## Why This Change Was Made

Those three header call sites explicitly supplied ClawTheme.colors.text even though OpenClawMascot already provides the coral brand gradient when no tint is set. Removing only those overrides preserves the shared component and every other mascot usage.

## User Impact

The OpenClaw logo now keeps its coral/red brand appearance in both Light and Dark Mode across the primary Android headers.

## Evidence

> [!NOTE]
> ### Validation
>
> - [x] `git diff --check` — passed
> - [x] `pnpm run native:i18n:sync` — passed with changed=false
> - [x] `pnpm run native:i18n:check` — passed
> - [x] `pnpm run android:i18n:check` — passed
> - [x] `pnpm run apple:i18n:check` — passed
> - [x] `pnpm android:assemble` — completed successfully for the exact Base and patched After states
> - [x] `adb -s emulator-5556 install -r openclaw-2026.7.2-play-debug.apk` — passed; the installed package matched the built patched APK byte-for-byte

> [!TIP]
> ### Real Behavior Proof
>
> Android emulator behavior verified with the exact patched APK.
>
> - [x] **Environment:** Lane-b API 36 Android emulator at 1080x2400 with font scale 1.0; screenshots and recordings are operator-attested from the exact Base and patched APKs.
> - [x] **Precondition:** The locked Base APK and patched APK were built separately, digest-bound, installed on the same emulator, and opened on the same Home header and theme controls.
> - [x] **Before:** With the Base APK, the header mascot followed the theme text color: black in Light Mode and white in Dark Mode.
> - [x] **After:** With the patched APK and the same theme switches, the header mascot retained its coral/red gradient in both modes.
> - [x] **Result:** The Home header visibly preserves the brand color across Light and Dark Mode; the same explicit tint override was removed from the Chat and Voice header call sites.
> - [x] **Remaining proof gap:** Online Gateway pairing was intentionally not performed. The visual assets are operator-attested rather than agent-validated; the screenshot table uses the Light Mode pair, while both theme states are shown in the recordings.

<table>
  <tr><th>Before</th><th>After</th></tr>
  <tr>
    <td><img width="260" src="https://github.com/user-attachments/assets/0b51f270-7ff6-484e-89f2-ab9dcaebf379" alt="Before" /></td>
    <td><img width="260" src="https://github.com/user-attachments/assets/e3bf30d4-3d9f-4972-8fa5-74df7eafd463" alt="After" /></td>
  </tr>
</table>

Before behavior recording:

https://github.com/user-attachments/assets/ea73efb4-91cb-4d8c-8df0-7f676ad694c5

After behavior recording:

https://github.com/user-attachments/assets/ed688e88-6282-4fef-9770-ebf2435bc231
