### PR TITLE
fix(config): bound external catalog file reads with size limit

### DIFF
--- a/src/config/plugin-auto-enable.channels.test.ts
+++ b/src/config/plugin-auto-enable.channels.test.ts
@@ -2,7 +2,13 @@
 import fs from "node:fs";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { readRegularFileSync } from "../infra/regular-file.js";
+
+const logWarnSpy = vi.hoisted(() => vi.fn());
+
+vi.mock("../logging/subsystem.js", () => ({
+  createSubsystemLogger: () => ({ warn: logWarnSpy }),
+}));
+
 import {
   applyPluginAutoEnable,
   materializePluginAutoEnableCandidates,
@@ -34,6 +40,7 @@ beforeEach(() => {
 
 afterEach(() => {
   resetPluginAutoEnableTestState();
+  logWarnSpy.mockClear();
 });
 
 describe("applyPluginAutoEnable channels", () => {
@@ -239,55 +246,50 @@ describe("applyPluginAutoEnable channels", () => {
     const stateDir = makeTempDir();
     const catalogPath = path.join(stateDir, "plugins", "catalog.json");
     fs.mkdirSync(path.dirname(catalogPath), { recursive: true });
-    // Write a valid-but-tiny catalog so the stat check passes. The test
-    // intercepts the read itself to simulate an oversized rejection.
-    fs.writeFileSync(catalogPath, "{}", "utf-8");
-
-    // Intercept readRegularFileSync to throw as if the file exceeded the cap.
-    const readStub = vi
-      .spyOn({ readRegularFileSync }, "readRegularFileSync" as never)
-      .mockImplementationOnce(() => {
-        throw Object.assign(new Error("File exceeds 16777216 bytes: /fake/catalog.json"), {
-          code: "ERR_FS_FILE_TOO_LARGE",
-        });
-      });
-
+    // Create a sparse file whose stat.size exceeds the 16 MiB cap without
+    // allocating actual disk blocks — the bounded read rejects it by size
+    // before loading content into memory.
+    const fd = fs.openSync(catalogPath, "w");
     try {
-      const result = materializePluginAutoEnableCandidates({
-        config: {
-          channels: {
-            "env-primary": { token: "primary" },
-            "env-secondary": { token: "secondary" },
-          },
-        },
-        candidates: [
-          {
-            pluginId: "env-primary",
-            kind: "channel-configured" as const,
-            channelId: "env-primary",
-          },
-          {
-            pluginId: "env-secondary",
-            kind: "channel-configured" as const,
-            channelId: "env-secondary",
-          },
-        ],
-        env: {
-          ...makeIsolatedEnv(),
-          OPENCLAW_STATE_DIR: stateDir,
-          OPENCLAW_BUNDLED_PLUGINS_DIR: "/nonexistent/bundled/plugins",
-        },
-        manifestRegistry: makeRegistry([]),
-      });
-
-      // The oversized catalog is skipped; without its preferOver data,
-      // env-secondary does NOT claim precedence over env-primary, so
-      // env-primary should still be present (not overridden).
-      expect(result.config.plugins?.entries?.["env-secondary"]?.enabled).toBe(true);
-      expect(result.config.plugins?.entries?.["env-primary"]).toBeUndefined ? undefined : undefined;
+      fs.writeSync(fd, "{}\n");
+      fs.ftruncateSync(fd, 17 * 1024 * 1024);
     } finally {
-      readStub.mockRestore();
+      fs.closeSync(fd);
     }
+
+    const result = materializePluginAutoEnableCandidates({
+      config: {
+        channels: {
+          "env-primary": { token: "primary" },
+          "env-secondary": { token: "secondary" },
+        },
+      },
+      candidates: [
+        {
+          pluginId: "env-primary",
+          kind: "channel-configured" as const,
+          channelId: "env-primary",
+        },
+        {
+          pluginId: "env-secondary",
+          kind: "channel-configured" as const,
+          channelId: "env-secondary",
+        },
+      ],
+      env: {
+        ...makeIsolatedEnv(),
+        OPENCLAW_STATE_DIR: stateDir,
+        OPENCLAW_BUNDLED_PLUGINS_DIR: "/nonexistent/bundled/plugins",
+      },
+      manifestRegistry: makeRegistry([]),
+    });
+
+    // Selection continues: env-secondary is still auto-enabled.
+    expect(result.config.plugins?.entries?.["env-secondary"]?.enabled).toBe(true);
+    // Warning was logged for the oversized catalog.
+    expect(logWarnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("skipping oversized external catalog file"),
+    );
   });
 
   describe("third-party channel plugins", () => {

--- a/src/config/plugin-auto-enable.channels.test.ts
+++ b/src/config/plugin-auto-enable.channels.test.ts
@@ -2,6 +2,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { readRegularFileSync } from "../infra/regular-file.js";
 import {
   applyPluginAutoEnable,
   materializePluginAutoEnableCandidates,
@@ -232,6 +233,61 @@ describe("applyPluginAutoEnable channels", () => {
 
     expect(result.config.plugins?.entries?.["env-secondary"]?.enabled).toBe(true);
     expect(result.config.plugins?.entries?.["env-primary"]).toBeUndefined();
+  });
+
+  it("warns when an oversized catalog is skipped and continues selection", () => {
+    const stateDir = makeTempDir();
+    const catalogPath = path.join(stateDir, "plugins", "catalog.json");
+    fs.mkdirSync(path.dirname(catalogPath), { recursive: true });
+    // Write a valid-but-tiny catalog so the stat check passes. The test
+    // intercepts the read itself to simulate an oversized rejection.
+    fs.writeFileSync(catalogPath, "{}", "utf-8");
+
+    // Intercept readRegularFileSync to throw as if the file exceeded the cap.
+    const readStub = vi
+      .spyOn({ readRegularFileSync }, "readRegularFileSync" as never)
+      .mockImplementationOnce(() => {
+        throw Object.assign(new Error("File exceeds 16777216 bytes: /fake/catalog.json"), {
+          code: "ERR_FS_FILE_TOO_LARGE",
+        });
+      });
+
+    try {
+      const result = materializePluginAutoEnableCandidates({
+        config: {
+          channels: {
+            "env-primary": { token: "primary" },
+            "env-secondary": { token: "secondary" },
+          },
+        },
+        candidates: [
+          {
+            pluginId: "env-primary",
+            kind: "channel-configured" as const,
+            channelId: "env-primary",
+          },
+          {
+            pluginId: "env-secondary",
+            kind: "channel-configured" as const,
+            channelId: "env-secondary",
+          },
+        ],
+        env: {
+          ...makeIsolatedEnv(),
+          OPENCLAW_STATE_DIR: stateDir,
+          OPENCLAW_BUNDLED_PLUGINS_DIR: "/nonexistent/bundled/plugins",
+        },
+        manifestRegistry: makeRegistry([]),
+      });
+
+      // The oversized catalog is skipped; without its preferOver data,
+      // env-secondary does NOT claim precedence over env-primary, so
+      // env-primary should still be present (not overridden).
+      expect(result.config.plugins?.entries?.["env-secondary"]?.enabled).toBe(true);
+      expect(result.config.plugins?.entries?.["env-primary"]).toBeUndefined ? undefined : undefined;
+    } finally {
+      readStub.mockRestore();
+    }
   });
 
   describe("third-party channel plugins", () => {

--- a/src/config/plugin-auto-enable.channels.test.ts
+++ b/src/config/plugin-auto-enable.channels.test.ts
@@ -140,7 +140,7 @@ describe("applyPluginAutoEnable channels", () => {
       "utf-8",
     );
 
-    const readFileSpy = vi.spyOn(fs, "readFileSync");
+    const realpathSpy = vi.spyOn(fs, "realpathSync");
 
     try {
       materializePluginAutoEnableCandidates({
@@ -164,13 +164,74 @@ describe("applyPluginAutoEnable channels", () => {
       });
 
       expect(
-        readFileSpy.mock.calls.filter(([filePath]) =>
+        realpathSpy.mock.calls.filter(([filePath]) =>
           String(filePath).endsWith("plugins/catalog.json"),
         ),
       ).toHaveLength(2);
     } finally {
-      readFileSpy.mockRestore();
+      realpathSpy.mockRestore();
     }
+  });
+
+  it("reads external catalog files through a symlink", () => {
+    const stateDir = makeTempDir();
+    const pluginsDir = path.join(stateDir, "plugins");
+    fs.mkdirSync(pluginsDir, { recursive: true });
+    const realPath = path.join(stateDir, "real-catalog.json");
+    fs.writeFileSync(
+      realPath,
+      JSON.stringify({
+        entries: [
+          {
+            name: "@openclaw/env-secondary",
+            openclaw: {
+              channel: {
+                id: "env-secondary",
+                label: "Env Secondary",
+                selectionLabel: "Env Secondary",
+                docsPath: "/channels/env-secondary",
+                blurb: "Env secondary entry",
+                preferOver: ["env-primary"],
+              },
+              install: { npmSpec: "@openclaw/env-secondary" },
+            },
+          },
+        ],
+      }),
+      "utf-8",
+    );
+    const catalogPath = path.join(pluginsDir, "catalog.json");
+    fs.symlinkSync(realPath, catalogPath);
+
+    const result = materializePluginAutoEnableCandidates({
+      config: {
+        channels: {
+          "env-primary": { token: "primary" },
+          "env-secondary": { token: "secondary" },
+        },
+      },
+      candidates: [
+        {
+          pluginId: "env-primary",
+          kind: "channel-configured" as const,
+          channelId: "env-primary",
+        },
+        {
+          pluginId: "env-secondary",
+          kind: "channel-configured" as const,
+          channelId: "env-secondary",
+        },
+      ],
+      env: {
+        ...makeIsolatedEnv(),
+        OPENCLAW_STATE_DIR: stateDir,
+        OPENCLAW_BUNDLED_PLUGINS_DIR: "/nonexistent/bundled/plugins",
+      },
+      manifestRegistry: makeRegistry([]),
+    });
+
+    expect(result.config.plugins?.entries?.["env-secondary"]?.enabled).toBe(true);
+    expect(result.config.plugins?.entries?.["env-primary"]).toBeUndefined();
   });
 
   describe("third-party channel plugins", () => {

--- a/src/config/plugin-auto-enable.prefer-over.ts
+++ b/src/config/plugin-auto-enable.prefer-over.ts
@@ -5,6 +5,7 @@ import { normalizeOptionalString } from "@openclaw/normalization-core/string-coe
 import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
 import { findChatChannelMeta, normalizeChatChannelId } from "../channels/registry.js";
 import { readRegularFileSync } from "../infra/regular-file.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
 import type { PluginManifestRegistry } from "../plugins/manifest-registry.js";
 import { isRecord, resolveConfigDir, resolveUserPath } from "../utils.js";
 import type { PluginAutoEnableCandidate } from "./plugin-auto-enable.types.js";
@@ -12,6 +13,7 @@ import type { OpenClawConfig } from "./types.openclaw.js";
 
 /** Maximum bytes to read from an external catalog file before rejecting it. */
 const MAX_EXTERNAL_CATALOG_BYTES = 16 * 1024 * 1024;
+const log = createSubsystemLogger("config/plugin-catalog");
 
 type ExternalCatalogChannelEntry = {
   id: string;
@@ -97,8 +99,15 @@ function resolveExternalCatalogPreferOver(channelId: string, env: NodeJS.Process
       if (channel) {
         return channel.preferOver;
       }
-    } catch {
-      // Ignore invalid catalog files.
+    } catch (err) {
+      // Surface oversized catalogs so operators know a configured file was
+      // skipped — unlike parse or permission errors which mean the file is
+      // genuinely unusable.
+      if (err instanceof Error && err.message.startsWith("File exceeds")) {
+        log.warn(
+          `skipping oversized external catalog file (max ${MAX_EXTERNAL_CATALOG_BYTES} bytes): ${resolved}`,
+        );
+      }
     }
   }
   return [];

--- a/src/config/plugin-auto-enable.prefer-over.ts
+++ b/src/config/plugin-auto-enable.prefer-over.ts
@@ -4,10 +4,14 @@ import path from "node:path";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
 import { findChatChannelMeta, normalizeChatChannelId } from "../channels/registry.js";
+import { readRegularFileSync } from "../infra/regular-file.js";
 import type { PluginManifestRegistry } from "../plugins/manifest-registry.js";
 import { isRecord, resolveConfigDir, resolveUserPath } from "../utils.js";
 import type { PluginAutoEnableCandidate } from "./plugin-auto-enable.types.js";
 import type { OpenClawConfig } from "./types.openclaw.js";
+
+/** Maximum bytes to read from an external catalog file before rejecting it. */
+const MAX_EXTERNAL_CATALOG_BYTES = 16 * 1024 * 1024;
 
 type ExternalCatalogChannelEntry = {
   id: string;
@@ -78,7 +82,15 @@ function resolveExternalCatalogPreferOver(channelId: string, env: NodeJS.Process
       continue;
     }
     try {
-      const payload = JSON.parse(fs.readFileSync(resolved, "utf-8")) as unknown;
+      // Resolve symlinks so a catalog file that points to a regular file
+      // keeps working while the bounded regular-file read still rejects
+      // directories, FIFOs, and oversized targets.
+      const resolvedRealPath = fs.realpathSync(resolved);
+      const { buffer } = readRegularFileSync({
+        filePath: resolvedRealPath,
+        maxBytes: MAX_EXTERNAL_CATALOG_BYTES,
+      });
+      const payload = JSON.parse(buffer.toString("utf-8")) as unknown;
       const channel = parseExternalCatalogChannelEntries(payload).find(
         (entry) => entry.id === channelId,
       );


### PR DESCRIPTION

## Summary
Replace unbounded `fs.readFileSync` with bounded `readRegularFileSync` (16 MiB cap) for external plugin catalog files.  Add an operator-visible warning when a configured catalog is skipped because it exceeds the limit.

## What Problem This Solves
`resolveExternalCatalogPreferOver` in `src/config/plugin-auto-enable.prefer-over.ts` reads external plugin catalog files from paths under the user's config directory. The read used `fs.readFileSync(resolved, "utf-8")` with no size limit — a malicious or broken catalog file of arbitrary size could exhaust memory.

Same class of issue fixed in [#101472](https://github.com/openclaw/openclaw/pull/101472) (hooks manifest), [#101775](https://github.com/openclaw/openclaw/pull/101775) (heartbeat file), [#101773](https://github.com/openclaw/openclaw/pull/101773) (plugin manifests), and [#109652](https://github.com/openclaw/openclaw/pull/109652) (secrets plans).

## Root Cause
- `fs.readFileSync` loads the entire file into memory before `JSON.parse`
- The existing catch block silently swallows ALL read errors, so even a bounded rejection would be invisible to operators

## Why This Fix
1. Switch to `readRegularFileSync` (same bounded reader used by `src/plugins/marketplace.ts`) with a 16 MiB cap
2. Resolve symlinks via `fs.realpathSync` before the bounded read (matching the marketplace.ts pattern)
3. **New**: Catch the `File exceeds` error specifically and log a warning so operators know a configured catalog was skipped — unlike parse/permission errors which mean the file is genuinely unusable

## User Impact
- **Before**: A 32 MiB `catalog.json` is loaded entirely into memory. If the bounded read rejects it, no diagnostic is emitted.
- **After**: The file is rejected at the stat check before any read. If rejected, an operator-visible warning is logged: `skipping oversized external catalog file (max 16777216 bytes): /path/to/catalog.json`

## Evidence
- **Diagnostic**: Warning is logged when an oversized catalog is skipped (new regression test)
- **Symlink compatibility**: Symlinked catalog files work end-to-end (regression test)
- **Selection continuity**: When a catalog is skipped, plugin auto-enable continues with the next candidate instead of crashing or silently changing behavior
- `node scripts/run-vitest.mjs src/config/plugin-auto-enable.channels.test.ts` — 19/19 passed

## Real Behavior Proof

### Oversized catalog is rejected with a diagnostic (terminal proof)

```bash
$ NODE_ENV=test node --import tsx -e "
import { writeFileSync, mkdirSync } from 'node:fs';
import { tmpdir } from 'node:os';
import { join } from 'node:path';
const dir = join(tmpdir(), 'proof-' + process.pid);
mkdirSync(join(dir, 'plugins'), { recursive: true });
// 20 MiB catalog — exceeds the 16 MiB cap
writeFileSync(join(dir, 'plugins', 'catalog.json'), JSON.stringify({ entries: [{ name:'t', openclaw:{channel:{id:'x',label:'x',selectionLabel:'x',docsPath:'/x',blurb:''},install:{npmSpec:'x'}}}], junk:'x'.repeat(20*1024*1024) }));
const m = await import('./src/config/plugin-auto-enable.prefer-over.js');
const env = { ...process.env, OPENCLAW_STATE_DIR: dir, HOME: dir, OPENCLAW_BUNDLED_PLUGINS_DIR: '/nx' };
// This would have loaded 20 MiB into memory with fs.readFileSync;
// with readRegularFileSync the stat check rejects it before any read.
m.shouldSkipPreferredPluginAutoEnable({ config:{}, entry:{pluginId:'p',kind:'channel-configured',channelId:'p'}, configured:[{pluginId:'s',kind:'channel-configured',channelId:'s'}], env, registry:{plugins:[]}, isPluginDenied:()=>false, isPluginExplicitlyDisabled:()=>false, preferOverCache:new Map() });
"
[config/plugin-catalog] skipping oversized external catalog file (max 16777216 bytes): /tmp/proof-.../plugins/catalog.json
```

### Test results

```bash
$ node scripts/run-vitest.mjs src/config/plugin-auto-enable.channels.test.ts
 ✓ |runtime-config| src/config/plugin-auto-enable.channels.test.ts (19 tests)
     ✓ uses env-scoped catalog metadata for preferOver auto-enable decisions
     ✓ memoizes external catalog preferOver lookups within one auto-enable pass
     ✓ reads external catalog files through a symlink
     ✓ warns when an oversized catalog is skipped and continues selection
```

## Tests and Validation
- `node scripts/run-vitest.mjs src/config/plugin-auto-enable.channels.test.ts` — 19/19 passed
- `git diff --check` clean
