### PR TITLE
refactor(deadcode): repair system-agent export ratchet

### DIFF
--- a/scripts/deadcode-exports.baseline.mjs
+++ b/scripts/deadcode-exports.baseline.mjs
@@ -124,7 +124,6 @@ export const KNIP_UNUSED_EXPORT_BASELINE = [
   "src/agents/tools/image-tool.ts: resolveImageModelConfigForTool",
   "src/agents/tools/image-tool.ts: testing",
   "src/agents/tools/model-config.helpers.ts: hasDirectProviderApiKeyAuthForTool",
-  "src/agents/tools/openclaw-delegate-tool.ts: createOpenClawDelegateTool",
   "src/agents/tools/sessions-resolution.ts: testing",
   "src/agents/tools/sessions-send-tool.a2a.ts: testing",
   "src/agents/tools/sessions-spawn-visible-admission.ts: VisibleChildReservation",
@@ -225,8 +224,6 @@ export const KNIP_UNUSED_EXPORT_BASELINE = [
   "src/skills/lifecycle/upload-store.ts: createSkillUploadStore",
   "src/skills/runtime/refresh.ts: resetSkillsRefreshForTest",
   "src/skills/runtime/remote-skills.ts: resetRemoteNodeSkillsForTests",
-  "src/state/openclaw-state-db-operator-approval-migration.ts: hasCanonicalOperatorApprovalKinds",
-  "src/state/openclaw-state-db-operator-approval-migration.ts: repairOperatorApprovalKinds (operatorApprovalMigration)",
   "src/system-agent/agent-turn.ts: runSystemAgentTurnWithDeps",
   "src/tasks/detached-task-runtime.ts: resetDetachedTaskLifecycleRuntimeForTests",
   "src/tasks/detached-task-runtime.ts: setDetachedTaskLifecycleRuntime",
@@ -240,9 +237,6 @@ export const KNIP_UNUSED_EXPORT_BASELINE = [
   "src/tasks/task-registry.ts: resetTaskRegistryForTests",
   "src/tasks/task-registry.ts: setTaskRegistryControlRuntimeForTests",
   "src/tasks/task-registry.ts: setTaskRegistryDeliveryRuntimeForTests",
-  "ui/src/app/exec-approval.ts: parseExecApprovalRequested",
-  "ui/src/app/exec-approval.ts: parsePluginApprovalRequested",
-  "ui/src/app/exec-approval.ts: parseSystemAgentApprovalRequested",
 ];
 
 // Platform-variant findings. Allowed when present; never required.

--- a/src/agents/tools/openclaw-delegate-tool.test.ts
+++ b/src/agents/tools/openclaw-delegate-tool.test.ts
@@ -1,22 +1,31 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { GATEWAY_OWNER_ONLY_CORE_TOOLS } from "../../security/dangerous-tools.js";
-import type { InProcessGatewayCaller } from "./in-process-gateway.js";
-import { createOpenClawDelegateTool } from "./openclaw-delegate-tool.js";
+import { callInProcessGatewayTool } from "./in-process-gateway.js";
+import { createOpenClawDelegateToolsForRun } from "./openclaw-delegate-tool.js";
+
+vi.mock("./in-process-gateway.js", () => ({
+  callInProcessGatewayTool: vi.fn(),
+}));
+
+const callGateway = vi.mocked(callInProcessGatewayTool);
+
+beforeEach(() => {
+  callGateway.mockReset();
+});
 
 describe("openclaw delegation tool", () => {
   it("relays context and surfaces pending approval", async () => {
-    const callGateway = vi.fn(async () => ({
+    callGateway.mockResolvedValue({
       sessionId: "ignored-by-client",
       reply: "Approval pending.",
       action: "none",
       needsApproval: true,
       proposalId: "system-agent:proposal-1",
-    }));
-    const tool = createOpenClawDelegateTool({
-      requesterAgentId: "main",
-      agentSessionKey: "agent:main:dm:one",
-      turnSourceChannel: "webchat",
-      callGateway: callGateway as InProcessGatewayCaller,
+    });
+    const [tool] = createOpenClawDelegateToolsForRun({
+      sessionAgentId: "main",
+      runSessionKey: "agent:main:dm:one",
+      agentChannel: "webchat",
     });
 
     const result = await tool.execute("call-1", { message: "Add channel." });
@@ -39,13 +48,13 @@ describe("openclaw delegation tool", () => {
   });
 
   it("reuses one session and accepts explicit continuation", async () => {
-    const callGateway = vi.fn(async (method: string, params: Record<string, unknown>) => ({
+    callGateway.mockImplementation(async (_method: string, params: Record<string, unknown>) => ({
       sessionId: params.sessionId,
       reply: "Done.",
     }));
-    const tool = createOpenClawDelegateTool({
-      agentSessionKey: "agent:main:main",
-      callGateway: callGateway as InProcessGatewayCaller,
+    const [tool] = createOpenClawDelegateToolsForRun({
+      sessionAgentId: "main",
+      runSessionKey: "agent:main:main",
     });
 
     await tool.execute("call-1", { message: "First." });

--- a/src/agents/tools/openclaw-delegate-tool.ts
+++ b/src/agents/tools/openclaw-delegate-tool.ts
@@ -24,7 +24,7 @@ function stableDelegationSessionId(sessionKey: string | undefined): string {
     : `delegate-${randomUUID()}`;
 }
 
-export function createOpenClawDelegateTool(options?: {
+function createOpenClawDelegateTool(options?: {
   requesterAgentId?: string;
   agentSessionKey?: string;
   turnSourceChannel?: string;

--- a/src/state/openclaw-state-db-operator-approval-migration.test.ts
+++ b/src/state/openclaw-state-db-operator-approval-migration.test.ts
@@ -2,8 +2,8 @@
 import { DatabaseSync } from "node:sqlite";
 import { describe, expect, it } from "vitest";
 import {
-  hasCanonicalOperatorApprovalKinds,
-  repairOperatorApprovalKinds,
+  assertCanonicalOperatorApprovalKinds,
+  repairOperatorApprovalSchema,
 } from "./openclaw-state-db-operator-approval-migration.js";
 import { OPENCLAW_STATE_SCHEMA_SQL } from "./openclaw-state-schema.generated.js";
 
@@ -42,11 +42,15 @@ describe("repairOperatorApprovalKinds", () => {
     const db = new DatabaseSync(":memory:");
     db.exec(legacyTwoKindCreateSql());
     seedRow(db, "exec");
-    expect(hasCanonicalOperatorApprovalKinds(db)).toBe(false);
+    expect(() => assertCanonicalOperatorApprovalKinds(db, ":memory:")).toThrow(
+      "legacy operator approval schema",
+    );
 
-    expect(repairOperatorApprovalKinds(db)).toBe(true);
+    expect(repairOperatorApprovalSchema(db)).toEqual([
+      "Migrated shared state operator approvals → OpenClaw system changes",
+    ]);
 
-    expect(hasCanonicalOperatorApprovalKinds(db)).toBe(true);
+    expect(() => assertCanonicalOperatorApprovalKinds(db, ":memory:")).not.toThrow();
     const rows = db.prepare("SELECT approval_id, kind FROM operator_approvals").all();
     expect(rows).toEqual([{ approval_id: "a1", kind: "exec" }]);
     db.close();
@@ -55,7 +59,7 @@ describe("repairOperatorApprovalKinds", () => {
   it("is a no-op when the schema is already canonical", () => {
     const db = new DatabaseSync(":memory:");
     db.exec(canonicalOperatorApprovalCreateSql());
-    expect(repairOperatorApprovalKinds(db)).toBe(false);
+    expect(repairOperatorApprovalSchema(db)).toEqual([]);
     db.close();
   });
 
@@ -68,7 +72,7 @@ describe("repairOperatorApprovalKinds", () => {
     );
     seedRow(db, "custom-thing");
 
-    expect(repairOperatorApprovalKinds(db)).toBe(false);
+    expect(repairOperatorApprovalSchema(db)).toEqual([]);
 
     // The unrecognized table is left untouched.
     const rows = db.prepare("SELECT approval_id, kind FROM operator_approvals").all();

--- a/src/state/openclaw-state-db-operator-approval-migration.ts
+++ b/src/state/openclaw-state-db-operator-approval-migration.ts
@@ -40,7 +40,7 @@ function tableSql(db: DatabaseSync): string | undefined {
   return typeof row?.sql === "string" ? row.sql : undefined;
 }
 
-export function hasCanonicalOperatorApprovalKinds(db: DatabaseSync): boolean {
+function hasCanonicalOperatorApprovalKinds(db: DatabaseSync): boolean {
   if (!tableExists(db, "operator_approvals")) {
     return true;
   }
@@ -116,7 +116,7 @@ function canonicalCreateSql(): string {
   );
 }
 
-export function repairOperatorApprovalKinds(db: DatabaseSync): boolean {
+function repairOperatorApprovalKinds(db: DatabaseSync): boolean {
   if (
     hasCanonicalOperatorApprovalKinds(db) ||
     tableExists(db, "operator_approvals_migration_new") ||

--- a/ui/src/app/exec-approval.test.ts
+++ b/ui/src/app/exec-approval.test.ts
@@ -3,14 +3,19 @@ import { describe, expect, it, vi } from "vitest";
 import {
   enqueueExecApprovalPrompt,
   isStaleApprovalResolutionError,
-  parseExecApprovalRequested,
-  parsePluginApprovalRequested,
-  parseSystemAgentApprovalRequested,
+  parseApprovalRequestedEvent,
   clearResolvedExecApprovalPrompt,
   refreshPendingApprovalQueue,
   type ExecApprovalPromptState,
   type ExecApprovalRequest,
 } from "./exec-approval.ts";
+
+const parseExecApprovalRequested = (payload: unknown) =>
+  parseApprovalRequestedEvent("exec.approval.requested", payload);
+const parsePluginApprovalRequested = (payload: unknown) =>
+  parseApprovalRequestedEvent("plugin.approval.requested", payload);
+const parseSystemAgentApprovalRequested = (payload: unknown) =>
+  parseApprovalRequestedEvent("openclaw.approval.requested", payload);
 
 type RequestFn = (method: string, params?: unknown) => Promise<unknown>;
 

--- a/ui/src/app/exec-approval.ts
+++ b/ui/src/app/exec-approval.ts
@@ -106,7 +106,7 @@ function parseAllowedDecisions(value: unknown): ExecApprovalDecision[] | undefin
   return decisions.length > 0 ? decisions : undefined;
 }
 
-export function parseExecApprovalRequested(payload: unknown): ExecApprovalRequest | null {
+function parseExecApprovalRequested(payload: unknown): ExecApprovalRequest | null {
   if (!isRecord(payload)) {
     return null;
   }
@@ -160,7 +160,7 @@ export function parseExecApprovalResolved(payload: unknown): ExecApprovalResolve
   };
 }
 
-export function parsePluginApprovalRequested(payload: unknown): ExecApprovalRequest | null {
+function parsePluginApprovalRequested(payload: unknown): ExecApprovalRequest | null {
   if (!isRecord(payload)) {
     return null;
   }
@@ -201,7 +201,7 @@ export function parsePluginApprovalRequested(payload: unknown): ExecApprovalRequ
   };
 }
 
-export function parseSystemAgentApprovalRequested(payload: unknown): ExecApprovalRequest | null {
+function parseSystemAgentApprovalRequested(payload: unknown): ExecApprovalRequest | null {
   if (!isRecord(payload)) {
     return null;
   }


### PR DESCRIPTION
## Summary

- privatize six internal exports introduced by the system-agent delegation change
- preserve coverage through retained production boundaries
- remove the six-row dead-export baseline growth

## Evidence

- production Knip regeneration byte-stable at 235 entries
- focused agents, state migration, and Control UI suites: 32/32 passing
- formatting and scoped type-aware lint green
- fresh autoreview clean at 0.97 confidence

## Scope

Internal ratchet repair only. No public behavior or API change.
