### PR TITLE
perf(ci): gate QA smoke by smoke-visible changes and isolate the prompt snapshot lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -540,16 +540,18 @@ jobs:
               console.warn(`Changed Node test planning failed; using compact full suite: ${error}`);
             }
           }
-          // Targeted (narrow-diff) PRs skip the heavy packaging lanes unless the
-          // diff touches surfaces those lanes exist to prove: test-only diffs
-          // cannot change dist bytes, and QA smoke re-proves packaging/scenario
-          // surfaces that unit shards plus build smokes already cover elsewhere.
+          // Heavy packaging lanes run only when the diff touches surfaces they
+          // exist to prove: test-only diffs cannot change dist bytes, and QA
+          // smoke only sees changes on its scenario surface or inside the
+          // packaged CLI's import graph. QA gating is diff-based, so it also
+          // applies when test targeting fell back to the full compact suite.
           const changedScopeHasBuildImpact =
             changedNodeTestShards === null ||
             typeof changedNodeTestPlan.hasBuildArtifactAffectingChange !== "function" ||
             changedNodeTestPlan.hasBuildArtifactAffectingChange(changedPaths);
           const changedScopeHasQaImpact =
-            changedNodeTestShards === null ||
+            changedPaths === null ||
+            eventName !== "pull_request" ||
             typeof changedNodeTestPlan.hasQaSmokeAffectingChange !== "function" ||
             changedNodeTestPlan.hasQaSmokeAffectingChange(changedPaths);
           const runBuildArtifacts = runNodeFull && changedScopeHasBuildImpact;
@@ -1851,12 +1853,15 @@ jobs:
           - check_name: check-additional-boundaries-a
             group: boundaries
             boundary_shard: 1/4
-            # This shard runs ~4min on 8 vCPU and regularly owns the PR wall
-            # clock; extra cores shorten it for similar billed core-minutes.
-            runner: blacksmith-16vcpu-ubuntu-2404
+            runner: blacksmith-8vcpu-ubuntu-2404
           - check_name: check-additional-boundaries-bcd
             group: boundaries
             boundary_shard: 2/4,3/4,4/4
+            runner: blacksmith-8vcpu-ubuntu-2404
+          # Prompt snapshot regeneration runs real embedded-agent turns (~2min)
+          # and used to own the boundaries-a wall clock; keep it in its own lane.
+          - check_name: check-prompt-snapshots
+            group: prompt-snapshots
             runner: blacksmith-8vcpu-ubuntu-2404
           - check_name: check-session-accessor-boundary
             group: session-accessor-boundary
@@ -1969,6 +1974,13 @@ jobs:
           case "$ADDITIONAL_CHECK_GROUP" in
             boundaries)
               node scripts/run-additional-boundary-checks.mjs
+              ;;
+            prompt-snapshots)
+              if ! node -e 'const pkg = require("./package.json"); process.exit(pkg.scripts?.["prompt:snapshots:check"] ? 0 : 1);'; then
+                echo "[skip] prompt snapshot check is not present in this checkout"
+              else
+                run_check "prompt:snapshots:check" pnpm prompt:snapshots:check
+              fi
               ;;
             session-accessor-boundary)
               if [ ! -f scripts/check-session-accessor-boundary.mjs ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1976,11 +1976,10 @@ jobs:
               node scripts/run-additional-boundary-checks.mjs
               ;;
             prompt-snapshots)
-              if ! node -e 'const pkg = require("./package.json"); process.exit(pkg.scripts?.["prompt:snapshots:check"] ? 0 : 1);'; then
-                echo "[skip] prompt snapshot check is not present in this checkout"
-              else
-                run_check "prompt:snapshots:check" pnpm prompt:snapshots:check
-              fi
+              # No presence fallback: the boundary runner previously invoked
+              # this unconditionally, and silent success would drop snapshot
+              # drift coverage.
+              run_check "prompt:snapshots:check" pnpm prompt:snapshots:check
               ;;
             session-accessor-boundary)
               if [ ! -f scripts/check-session-accessor-boundary.mjs ]; then

--- a/scripts/lib/ci-changed-node-test-plan.mjs
+++ b/scripts/lib/ci-changed-node-test-plan.mjs
@@ -48,9 +48,11 @@ export function hasBuildArtifactAffectingChange(changedPaths) {
 // graph: the qa-lab harness and scenario data, the packaged-CLI build inputs,
 // the control UI (playwright scenario), the two channels the smoke profile
 // drives (matrix, telegram), and workspace packages whose package-specifier
-// imports the relative import graph cannot see.
+// imports the relative import graph cannot see. The QA lane's own
+// orchestration (this planner, the CI workflow, composite actions) is also
+// QA-impacting: changes to the gate must not be able to skip the gated lane.
 const QA_SMOKE_SURFACE_RE =
-  /^(?:extensions\/(?:matrix|qa-lab|telegram)|packages|qa|ui)\/|^scripts\/(?:build-all\.mjs|package-openclaw-for-docker\.mjs)$|^(?:openclaw\.mjs|package\.json|pnpm-lock\.yaml|npm-shrinkwrap\.json|pnpm-workspace\.yaml|tsdown\.config\.ts)$/u;
+  /^(?:extensions\/(?:matrix|qa-lab|telegram)|packages|qa|ui)\/|^scripts\/(?:build-all\.mjs|package-openclaw-for-docker\.mjs)$|^scripts\/lib\/ci-changed-node-test-plan\.mjs$|^\.github\/(?:workflows\/ci\.yml$|actions\/)|^(?:openclaw\.mjs|package\.json|pnpm-lock\.yaml|npm-shrinkwrap\.json|pnpm-workspace\.yaml|tsdown\.config\.ts)$/u;
 // The smoke profile runs the packaged CLI end to end, so its runtime blast
 // radius is exactly the CLI entry's import graph (dynamic imports included).
 const QA_SMOKE_RUNTIME_ENTRY = "src/index.ts";

--- a/scripts/lib/ci-changed-node-test-plan.mjs
+++ b/scripts/lib/ci-changed-node-test-plan.mjs
@@ -44,19 +44,39 @@ export function hasBuildArtifactAffectingChange(changedPaths) {
   return changedPaths.some((changedPath) => !isTestOnlyPath(changedPath));
 }
 
-const QA_SMOKE_CRITICAL_RE =
-  /^(?:extensions\/qa-lab|qa)\/|^scripts\/(?:build-all\.mjs|package-openclaw-for-docker\.mjs)$|^(?:package\.json|pnpm-lock\.yaml|npm-shrinkwrap\.json)$|^ui\//u;
+// Surfaces the CI smoke scenarios exercise outside the core runtime import
+// graph: the qa-lab harness and scenario data, the packaged-CLI build inputs,
+// the control UI (playwright scenario), the two channels the smoke profile
+// drives (matrix, telegram), and workspace packages whose package-specifier
+// imports the relative import graph cannot see.
+const QA_SMOKE_SURFACE_RE =
+  /^(?:extensions\/(?:matrix|qa-lab|telegram)|packages|qa|ui)\/|^scripts\/(?:build-all\.mjs|package-openclaw-for-docker\.mjs)$|^(?:openclaw\.mjs|package\.json|pnpm-lock\.yaml|npm-shrinkwrap\.json|pnpm-workspace\.yaml|tsdown\.config\.ts)$/u;
+// The smoke profile runs the packaged CLI end to end, so its runtime blast
+// radius is exactly the CLI entry's import graph (dynamic imports included).
+const QA_SMOKE_RUNTIME_ENTRY = "src/index.ts";
 
 /**
- * True when a changed path touches the QA smoke packaging/scenario surface.
- * Deliberate product tradeoff: targeted PRs outside this surface skip QA smoke
- * and rely on import-selected shards plus build-artifact CLI smokes. Targeting
- * only fires for narrow non-SDK-impacting diffs, and QA smoke still runs on
- * every node-scoped main push, so a missed regression breaks main visibly
- * instead of shipping silently.
+ * True when a changed path can influence the QA smoke scenarios: it touches
+ * the smoke surface directly, or the packaged CLI's import graph reaches it.
+ * Diffs outside both are invisible to the smoke profile, so the manifest may
+ * skip that lane regardless of whether test targeting fired.
  */
-export function hasQaSmokeAffectingChange(changedPaths) {
-  return changedPaths.some((changedPath) => QA_SMOKE_CRITICAL_RE.test(changedPath));
+export function hasQaSmokeAffectingChange(changedPaths, options = {}) {
+  const cwd = options.cwd ?? process.cwd();
+  if (changedPaths.some((changedPath) => QA_SMOKE_SURFACE_RE.test(changedPath))) {
+    return true;
+  }
+  const sourcePaths = changedPaths.filter(
+    (changedPath) => changedPath.startsWith("src/") && !isTestFileTarget(changedPath),
+  );
+  if (sourcePaths.length === 0) {
+    return false;
+  }
+  // Deleted sources cannot be graphed; fail safe to running the smoke lane.
+  if (sourcePaths.some((changedPath) => !existsSync(path.join(cwd, changedPath)))) {
+    return true;
+  }
+  return hasImportGraphImpactOnTargets(sourcePaths, [QA_SMOKE_RUNTIME_ENTRY], cwd);
 }
 
 function createBoundaryShard() {

--- a/scripts/run-additional-boundary-checks.mjs
+++ b/scripts/run-additional-boundary-checks.mjs
@@ -15,8 +15,10 @@ const POST_FORCE_KILL_WAIT_MS = 250;
 const MAX_TIMER_TIMEOUT_MS = 2_147_000_000;
 
 /** Ordered list of supplemental boundary checks used by CI sharding. */
+// prompt:snapshots:check is intentionally absent: it regenerates snapshots by
+// running real embedded-agent turns (~2min) and owns a dedicated CI lane
+// (check-prompt-snapshots) so no boundary shard carries that wall clock.
 export const BOUNDARY_CHECKS = [
-  ["prompt:snapshots:check", "pnpm", ["prompt:snapshots:check"]],
   ["plugin-extension-boundary", "pnpm", ["run", "lint:plugins:no-extension-imports"]],
   ["lint:docker-e2e", "pnpm", ["run", "lint:docker-e2e"]],
   ["lint:tmp:no-random-messaging", "pnpm", ["run", "lint:tmp:no-random-messaging"]],

--- a/test/scripts/ci-changed-node-test-plan.test.ts
+++ b/test/scripts/ci-changed-node-test-plan.test.ts
@@ -56,7 +56,15 @@ describe("CI changed Node test plan", () => {
     expect(hasBuildArtifactAffectingChange(["src/agents/foo.ts"])).toBe(true);
     expect(hasQaSmokeAffectingChange(["extensions/qa-lab/src/ci-smoke-plan.ts"])).toBe(true);
     expect(hasQaSmokeAffectingChange(["ui/src/app.ts"])).toBe(true);
-    expect(hasQaSmokeAffectingChange(["src/infra/retry.ts"])).toBe(false);
+    // Inside the packaged CLI's import graph -> the smoke scenarios can see it.
+    expect(hasQaSmokeAffectingChange(["src/infra/retry.ts"])).toBe(true);
+    // Smoke drives matrix + telegram; other channel plugins are invisible to it.
+    expect(hasQaSmokeAffectingChange(["extensions/telegram/src/index.ts"])).toBe(true);
+    expect(hasQaSmokeAffectingChange(["extensions/discord/src/index.ts"])).toBe(false);
+    expect(hasQaSmokeAffectingChange(["scripts/run-vitest.mjs"])).toBe(false);
+    expect(hasQaSmokeAffectingChange(["test/scripts/ci-node-test-plan.test.ts"])).toBe(false);
+    // Deleted source files cannot be graphed; fail safe to running QA smoke.
+    expect(hasQaSmokeAffectingChange(["src/infra/definitely-deleted-module.ts"])).toBe(true);
   });
 
   it("fails safe to the full plan for broad changes", () => {

--- a/test/scripts/ci-changed-node-test-plan.test.ts
+++ b/test/scripts/ci-changed-node-test-plan.test.ts
@@ -63,6 +63,11 @@ describe("CI changed Node test plan", () => {
     expect(hasQaSmokeAffectingChange(["extensions/discord/src/index.ts"])).toBe(false);
     expect(hasQaSmokeAffectingChange(["scripts/run-vitest.mjs"])).toBe(false);
     expect(hasQaSmokeAffectingChange(["test/scripts/ci-node-test-plan.test.ts"])).toBe(false);
+    // The QA lane's own orchestration must not be able to skip the lane.
+    expect(hasQaSmokeAffectingChange([".github/workflows/ci.yml"])).toBe(true);
+    expect(hasQaSmokeAffectingChange([".github/actions/setup-node-env/action.yml"])).toBe(true);
+    expect(hasQaSmokeAffectingChange(["scripts/lib/ci-changed-node-test-plan.mjs"])).toBe(true);
+    expect(hasQaSmokeAffectingChange([".github/workflows/labeler.yml"])).toBe(false);
     // Deleted source files cannot be graphed; fail safe to running QA smoke.
     expect(hasQaSmokeAffectingChange(["src/infra/definitely-deleted-module.ts"])).toBe(true);
   });

--- a/test/scripts/run-additional-boundary-checks.test.ts
+++ b/test/scripts/run-additional-boundary-checks.test.ts
@@ -109,12 +109,14 @@ async function waitForChildClose(
 }
 
 describe("run-additional-boundary-checks", () => {
-  it("runs prompt snapshot drift checks in CI", () => {
-    expect(BOUNDARY_CHECKS[0]).toEqual({
-      label: "prompt:snapshots:check",
-      command: "pnpm",
-      args: ["prompt:snapshots:check"],
-    });
+  it("keeps prompt snapshot drift checks in their dedicated CI lane", () => {
+    // The snapshot check regenerates prompts with real embedded-agent turns
+    // (~2min); packing it into a boundary shard makes that shard the PR wall
+    // clock, so it owns the check-prompt-snapshots lane instead.
+    expect(BOUNDARY_CHECKS.some((check) => check.label === "prompt:snapshots:check")).toBe(false);
+    const workflow = fs.readFileSync(".github/workflows/ci.yml", "utf8");
+    expect(workflow).toContain("check_name: check-prompt-snapshots");
+    expect(workflow).toContain('run_check "prompt:snapshots:check" pnpm prompt:snapshots:check');
   });
 
   it("normalizes concurrency input", () => {


### PR DESCRIPTION
## What Problem This Solves

After #108091 the full-scope PR critical path is the heavy lanes, not tests: QA smoke (~260s) and `check-additional-boundaries-a` (~181s, of which a single check — `prompt:snapshots:check` — is ~2 minutes while every sibling check is sub-second). QA smoke also ran on every full-scope PR even when the diff could not possibly influence its scenarios (e.g. non-smoke channel plugins, scripts, workflows, test-only mixes).

## Why This Change Was Made

Two bounded changes:

1. **QA smoke is diff-gated by what the smoke scenarios can actually see.** The CI smoke profile runs 12 scenarios through the packaged CLI (gateway, agents runtime, plugin lifecycle, control-UI playwright, matrix + telegram channels). `hasQaSmokeAffectingChange` now returns true when the diff touches that surface directly (qa-lab, `qa/`, packaging inputs, `ui/`, `extensions/matrix|telegram`, workspace packages) or when the packaged CLI's import graph (dynamic imports included, rooted at `src/index.ts`) reaches a changed source file. Deleted sources fail safe to running the lane. The gate now applies to all `pull_request` events — including full-scope ones — while pushes and dispatches keep QA unconditionally.
2. **`prompt:snapshots:check` gets its own lane.** It regenerates prompt snapshots by running real embedded-agent turns (~2min) and owned the boundaries-a wall clock; it moves from `BOUNDARY_CHECKS` into a dedicated `check-prompt-snapshots` matrix entry, and boundaries-a returns to 8vcpu since its remaining checks are sub-second.

## User Impact

No product behavior change. PRs whose diffs are invisible to the smoke scenarios (non-smoke channel/provider plugins, scripts, workflows, test-only changes) skip the 2×16vcpu QA smoke lane entirely; boundaries-a drops from ~181s to sub-minute for everyone. Core runtime (`src/**` reachable from the CLI entry), UI, packaging, and smoke-channel diffs keep QA smoke exactly as before.

## Evidence

- Path probes: `src/infra/retry.ts`, `src/gateway/server.ts`, `ui/`, `extensions/telegram` → QA runs; `extensions/discord`, `scripts/run-vitest.mjs`, test files, workflows, docs → QA skipped; deleted `src` files → QA runs (fail safe).
- boundaries-a job log (run 29395969440): `prompt:snapshots:check` 2m, all sibling checks ≤1s — the isolated lane removes exactly that pole.
- Focused tests green: `test/scripts/ci-changed-node-test-plan.test.ts`, `test/scripts/run-additional-boundary-checks.test.ts` (new lane assertions), `test/scripts/ci-workflow-guards.test.ts` — 91 passed, 1 skipped.
- This PR's own CI exercises both: it is scripts/workflow/test-only, so QA smoke should be skipped and `check-prompt-snapshots` should appear as its own job.
