### PR TITLE
fix(doctor): stop warning on healthy Claude CLI token rotation

### DIFF
--- a/src/commands/doctor-auth.profile-health.test.ts
+++ b/src/commands/doctor-auth.profile-health.test.ts
@@ -31,6 +31,9 @@ vi.mock("../agents/auth-profiles.js", () => ({
 }));
 
 vi.mock("../../packages/terminal-core/src/note.js", () => ({ note: vi.fn() }));
+vi.mock("../agents/auth-profiles/doctor.js", () => ({
+  formatAuthDoctorHint: vi.fn(async () => "Re-authenticate this profile."),
+}));
 
 import { note } from "../../packages/terminal-core/src/note.js";
 import { collectAuthProfileHealthFindings, noteAuthProfileHealth } from "./doctor-auth.js";
@@ -106,6 +109,101 @@ describe("noteAuthProfileHealth", () => {
         message: "Auth profile openai:default is expired (0m).",
         path: expectedAuthStorePath(mainDir),
         target: "openai:default",
+      }),
+    ]);
+  });
+
+  it("does not warn while Claude CLI owns refresh of an expiring access token", async () => {
+    const now = 1_700_000_000_000;
+    vi.spyOn(Date, "now").mockReturnValue(now);
+    const mainDir = path.join(tempDir, "main-agent");
+    authProfileMocks.hasAnyAuthProfileStoreSource.mockReturnValue(true);
+    authProfileMocks.ensureAuthProfileStore.mockReturnValue({
+      version: 1,
+      profiles: {
+        "anthropic:claude-cli": {
+          type: "oauth",
+          provider: "claude-cli",
+          access: "access",
+          refresh: "refresh",
+          expires: now + 3 * 60 * 60_000,
+        },
+      },
+    });
+
+    const findings = await collectAuthProfileHealthFindings({
+      cfg: {
+        agents: { list: [{ id: "main", default: true, agentDir: mainDir }] },
+      } as OpenClawConfig,
+    });
+
+    expect(findings).toEqual([]);
+  });
+
+  it("keeps expiring warnings for static and custom Claude CLI profiles", async () => {
+    const now = 1_700_000_000_000;
+    vi.spyOn(Date, "now").mockReturnValue(now);
+    const mainDir = path.join(tempDir, "main-agent");
+    authProfileMocks.hasAnyAuthProfileStoreSource.mockReturnValue(true);
+    authProfileMocks.ensureAuthProfileStore.mockReturnValue({
+      version: 1,
+      profiles: {
+        "anthropic:claude-cli": {
+          type: "token",
+          provider: "claude-cli",
+          token: "token",
+          expires: now + 3 * 60 * 60_000,
+        },
+        "anthropic:custom-cli": {
+          type: "oauth",
+          provider: "claude-cli",
+          access: "access",
+          refresh: "refresh",
+          expires: now + 3 * 60 * 60_000,
+        },
+      },
+    });
+
+    const findings = await collectAuthProfileHealthFindings({
+      cfg: {
+        agents: { list: [{ id: "main", default: true, agentDir: mainDir }] },
+      } as OpenClawConfig,
+    });
+
+    expect(findings.map((finding) => finding.target)).toEqual([
+      "anthropic:claude-cli",
+      "anthropic:custom-cli",
+    ]);
+  });
+
+  it("still warns once a Claude CLI access token is expired", async () => {
+    const now = 1_700_000_000_000;
+    vi.spyOn(Date, "now").mockReturnValue(now);
+    const mainDir = path.join(tempDir, "main-agent");
+    authProfileMocks.hasAnyAuthProfileStoreSource.mockReturnValue(true);
+    authProfileMocks.ensureAuthProfileStore.mockReturnValue({
+      version: 1,
+      profiles: {
+        "anthropic:claude-cli": {
+          type: "oauth",
+          provider: "claude-cli",
+          access: "access",
+          refresh: "refresh",
+          expires: now - 60_000,
+        },
+      },
+    });
+
+    const findings = await collectAuthProfileHealthFindings({
+      cfg: {
+        agents: { list: [{ id: "main", default: true, agentDir: mainDir }] },
+      } as OpenClawConfig,
+    });
+
+    expect(findings).toEqual([
+      expect.objectContaining({
+        message: "Auth profile anthropic:claude-cli is expired (0m).",
+        target: "anthropic:claude-cli",
       }),
     ]);
   });

--- a/src/commands/doctor-auth.ts
+++ b/src/commands/doctor-auth.ts
@@ -21,6 +21,7 @@ import {
   resolveApiKeyForProfile,
   resolveProfileUnusableUntilForDisplay,
 } from "../agents/auth-profiles.js";
+import { CLAUDE_CLI_PROFILE_ID } from "../agents/auth-profiles/constants.js";
 import { formatAuthDoctorHint } from "../agents/auth-profiles/doctor.js";
 import {
   buildOAuthRefreshFailureLoginCommand,
@@ -38,6 +39,7 @@ import type { DoctorPrompter } from "./doctor-prompter.js";
 
 const OPENAI_PROVIDER_ID = "openai";
 const LEGACY_CODEX_PROVIDER_ID = "openai-codex";
+const CLAUDE_CLI_PROVIDER_ID = "claude-cli";
 const CODEX_OAUTH_WARNING_TITLE = "Codex OAuth";
 const OPENAI_BASE_URL = "https://api.openai.com/v1";
 const LEGACY_CODEX_APIS = new Set(["openai-responses", "openai-completions"]);
@@ -341,6 +343,16 @@ function authProfileCooldownToHealthFinding(params: {
 function isAuthProfileHealthIssue(profile: AuthHealthSummary["profiles"][number]): boolean {
   if (profile.type === "api_key") {
     return profile.status === "missing";
+  }
+  // Claude CLI refreshes its short-lived access token when the process runs.
+  // Warn once that external credential is unusable, not throughout its normal lifetime.
+  if (
+    profile.profileId === CLAUDE_CLI_PROFILE_ID &&
+    profile.provider === CLAUDE_CLI_PROVIDER_ID &&
+    profile.type === "oauth" &&
+    profile.status === "expiring"
+  ) {
+    return false;
   }
   return (
     (profile.type === "oauth" || profile.type === "token") &&


### PR DESCRIPTION
Related: #83598

## What Problem This Solves

Fixes an issue where operators using the canonical Claude CLI OAuth profile would see `openclaw doctor` warn that the credential was expiring throughout its normal short lifetime, even while Claude CLI authentication was healthy and usable.

## Why This Change Was Made

Doctor now treats only the canonical `anthropic:claude-cli` OAuth profile's pre-expiry state as normal rotation. Missing or expired credentials still warn, as do expiring static-token and custom Claude CLI profiles. This matches Claude Code's current runtime behavior, which refreshes an expired OAuth access token reactively during execution.

## User Impact

Healthy Claude CLI-backed installations no longer carry a permanent model-auth warning. Operators still receive actionable diagnostics when the credential is actually unusable or is not owned by the managed Claude CLI OAuth path.

AI-assisted. No transcript is attached because the originating session contains private infrastructure and credential metadata.

## Evidence

- Blacksmith Testbox `tbx_01kxjjj4ypfjes2h9rgc4cm1n9` ([Actions run 29405568968](https://github.com/openclaw/openclaw/actions/runs/29405568968)): `pnpm test src/commands/doctor-auth.profile-health.test.ts src/commands/doctor-claude-cli.test.ts` — 28 tests passed; the final rebase changed only commit identity.
- Regression coverage proves the canonical OAuth profile is quiet while expiring, while expired, static-token, and custom-profile cases still warn.
- Fresh structured autoreview with GPT-5.6 Sol xhigh against the repaired final `origin/main` base: no actionable findings, confidence 0.96.
- `git diff --check` and targeted `oxfmt --check` passed.
- Upstream contract: Anthropic's Claude Code changelog documents reactive OAuth access-token refresh on 401: https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md
