### PR TITLE
fix(openai): stop realtime voice reconnects promptly on close

### DIFF
--- a/extensions/openai/realtime-voice-provider.test.ts
+++ b/extensions/openai/realtime-voice-provider.test.ts
@@ -1101,6 +1101,40 @@ describe("buildOpenAIRealtimeVoiceProvider", () => {
     bridge.close();
   });
 
+  it("cancels a pending reconnect when the bridge closes", async () => {
+    vi.useFakeTimers();
+    const provider = buildOpenAIRealtimeVoiceProvider();
+    const onError = vi.fn();
+    const bridge = provider.createBridge({
+      providerConfig: { apiKey: "sk-test" }, // pragma: allowlist secret
+      onAudio: vi.fn(),
+      onClearAudio: vi.fn(),
+      onError,
+    });
+    const connecting = bridge.connect();
+    const socket = FakeWebSocket.instances[0];
+    if (!socket) {
+      throw new Error("expected bridge to create a websocket");
+    }
+
+    socket.readyState = FakeWebSocket.OPEN;
+    socket.emit("open");
+    socket.emit("message", Buffer.from(JSON.stringify({ type: "session.updated" })));
+    await connecting;
+
+    socket.readyState = FakeWebSocket.CLOSED;
+    socket.emit("close", 1006, Buffer.from("transient drop"));
+    await vi.advanceTimersByTimeAsync(0);
+    expect(vi.getTimerCount()).toBe(1);
+
+    bridge.close();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(vi.getTimerCount()).toBe(0);
+    expect(FakeWebSocket.instances).toHaveLength(1);
+    expect(onError).not.toHaveBeenCalled();
+  });
+
   it("keeps Azure deployment bridges on deployment-compatible session payloads", async () => {
     const provider = buildOpenAIRealtimeVoiceProvider();
     const bridge = provider.createBridge({

--- a/extensions/openai/realtime-voice-provider.test.ts
+++ b/extensions/openai/realtime-voice-provider.test.ts
@@ -1101,7 +1101,7 @@ describe("buildOpenAIRealtimeVoiceProvider", () => {
     bridge.close();
   });
 
-  it("cancels a pending reconnect when the bridge closes", async () => {
+  it("cancels a pending reconnect and allows a later explicit connect", async () => {
     vi.useFakeTimers();
     const provider = buildOpenAIRealtimeVoiceProvider();
     const onError = vi.fn();
@@ -1133,6 +1133,21 @@ describe("buildOpenAIRealtimeVoiceProvider", () => {
     expect(vi.getTimerCount()).toBe(0);
     expect(FakeWebSocket.instances).toHaveLength(1);
     expect(onError).not.toHaveBeenCalled();
+
+    const reconnecting = bridge.connect();
+    const reconnectedSocket = FakeWebSocket.instances[1];
+    if (!reconnectedSocket) {
+      throw new Error("expected bridge to reconnect after close");
+    }
+    reconnectedSocket.readyState = FakeWebSocket.OPEN;
+    reconnectedSocket.emit("open");
+    reconnectedSocket.emit("message", Buffer.from(JSON.stringify({ type: "session.updated" })));
+    await reconnecting;
+
+    expect(bridge.isConnected()).toBe(true);
+    expect(FakeWebSocket.instances).toHaveLength(2);
+    expect(onError).not.toHaveBeenCalled();
+    bridge.close();
   });
 
   it("keeps Azure deployment bridges on deployment-compatible session payloads", async () => {

--- a/extensions/openai/realtime-voice-provider.ts
+++ b/extensions/openai/realtime-voice-provider.ts
@@ -27,7 +27,7 @@ import {
   REALTIME_VOICE_AUDIO_FORMAT_G711_ULAW_8KHZ,
   REALTIME_VOICE_AUDIO_FORMAT_PCM16_24KHZ,
 } from "openclaw/plugin-sdk/realtime-voice";
-import { warn } from "openclaw/plugin-sdk/runtime-env";
+import { sleepWithAbort, warn } from "openclaw/plugin-sdk/runtime-env";
 import {
   normalizeResolvedSecretInputString,
   normalizeSecretInputString,
@@ -506,6 +506,7 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
   private sessionReadyFired = false;
   private reconnectReason: string | undefined;
   private activeConnectionReason: string | undefined;
+  private reconnectAbortController = new AbortController();
   private readonly audioFormat: RealtimeVoiceAudioFormat;
 
   constructor(private readonly config: OpenAIRealtimeVoiceBridgeConfig) {
@@ -514,6 +515,9 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
 
   async connect(): Promise<void> {
     this.intentionallyClosed = false;
+    if (this.reconnectAbortController.signal.aborted) {
+      this.reconnectAbortController = new AbortController();
+    }
     this.reconnectAttempts = 0;
     await this.doConnect();
   }
@@ -587,6 +591,9 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
 
   close(): void {
     this.intentionallyClosed = true;
+    // The bridge owns both its active socket and reconnect delay; canceling
+    // both keeps terminal close from retaining callbacks for the full backoff.
+    this.reconnectAbortController.abort();
     this.connected = false;
     this.sessionConfigured = false;
     if (this.ws) {
@@ -881,9 +888,15 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
       type: "session.reconnect.scheduled",
       detail: `reason=${reason} attempt=${attempt} delayMs=${delay}`,
     });
-    await new Promise((resolve) => {
-      setTimeout(resolve, delay);
-    });
+    const reconnectSignal = this.reconnectAbortController.signal;
+    try {
+      await sleepWithAbort(delay, reconnectSignal);
+    } catch (error) {
+      if (!reconnectSignal.aborted) {
+        throw error;
+      }
+      return;
+    }
     if (this.intentionallyClosed) {
       return;
     }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where closing an OpenAI realtime voice bridge during a reconnect backoff left asynchronous work alive until the full 1/2/4/8/16-second delay expired. Provider teardown could therefore retain the bridge configuration and callbacks after the caller had closed the bridge.

## Why This Change Was Made

The bridge now owns an abortable reconnect delay and cancels it together with the active socket on `close()`. Normal websocket-drop and max-duration reconnects still use the existing exponential schedule; the focused tests cover both the cancellation path and successful max-duration rotation, guarding against either a delayed close or an over-broad reconnect cancellation.

## User Impact

OpenAI realtime voice sessions now finish teardown promptly when closed during reconnect backoff, without waiting up to the remaining scheduled delay or opening another socket.

## Evidence

Real behavior proof on Linux 6.8.0-134-generic x86_64 with Node v24.18.0. I drove the real exported `buildOpenAIRealtimeVoiceProvider()` through a real localhost WebSocket server; the only substituted boundary was the upstream OpenAI endpoint. The server completed a realtime session, terminated the socket to enter the production reconnect scheduler, and the public `bridge.close()` ran 20ms into the one-second backoff.

The same harness against current `upstream/main` reproduced the retained timer:

```text
$ node --import tsx ../contrib/openai-reconnect-close-proof.mts
{"phase":"close-returned","closeAfterScheduleMs":21,"connections":1}
{"phase":"event-loop-drained","drainAfterScheduleMs":1001,"drainAfterCloseMs":980,"connections":1}
```

Against this branch, the event loop drained immediately after close and no reconnect socket was created:

```text
$ node --import tsx contrib/openai-reconnect-close-proof.mts
{"phase":"close-returned","closeAfterScheduleMs":22,"connections":1}
{"phase":"event-loop-drained","drainAfterScheduleMs":22,"drainAfterCloseMs":0,"connections":1}
```

Focused regression suite:

```text
$ node scripts/run-vitest.mjs extensions/openai/realtime-voice-provider.test.ts
Test Files  1 passed (1)
Tests       66 passed (66)
```

Formatting and review:

```text
$ ./node_modules/.bin/oxfmt --check extensions/openai/realtime-voice-provider.ts extensions/openai/realtime-voice-provider.test.ts
All matched files use the correct format.

$ .agents/skills/autoreview/scripts/autoreview --mode uncommitted
autoreview clean: no accepted/actionable findings reported
overall: patch is correct (0.94)
```

Full repository checks were left to GitHub Actions. No live OpenAI credentialed audio round-trip was run; the affected behavior is the local bridge teardown after a real WebSocket disconnect, before any provider-specific response processing.

AI-assisted: Codex helped implement and review the patch; the real WebSocket proof and focused validation above were run manually.
