### PR TITLE
perf(ci): mount node deps from a Blacksmith sticky disk in test shards

### DIFF
--- a/.github/actions/setup-node-env/action.yml
+++ b/.github/actions/setup-node-env/action.yml
@@ -82,6 +82,10 @@ runs:
           echo "PNPM_CONFIG_STORE_DIR=/var/tmp/openclaw-node-deps/store"
           echo "PNPM_CONFIG_MODULES_DIR=/var/tmp/openclaw-node-deps/node_modules"
           echo "PNPM_CONFIG_VIRTUAL_STORE_DIR=/var/tmp/openclaw-node-deps/virtual-store"
+          # Later steps run `pnpm exec` without the relocation flags; without
+          # this, pnpm's verify-deps-before-run sees the relocated layout as
+          # drift and re-installs everything mid-step (hydrate does the same).
+          echo "npm_config_verify_deps_before_run=false"
           # The cold install (once per lockfile) links ~1200 packages into the
           # relocated modules dir; unthrottled linking EMFILEs pnpm there
           # (crabbox-hydrate throttles to 1 for the same reason). Warm jobs do

--- a/.github/actions/setup-node-env/action.yml
+++ b/.github/actions/setup-node-env/action.yml
@@ -74,6 +74,9 @@ runs:
         set -euo pipefail
         # Store, virtual store, and modules dir must share the sticky disk's
         # filesystem so pnpm keeps hardlinking instead of copying packages.
+        # The install step below symlinks the checkout's node_modules onto
+        # PNPM_CONFIG_MODULES_DIR, so Node resolution from the checkout still
+        # works (same layout crabbox-hydrate.yml uses in production).
         # zizmor: ignore[github-env] static trusted paths defined in this composite action.
         {
           echo "PNPM_CONFIG_STORE_DIR=/var/tmp/openclaw-node-deps/store"

--- a/.github/actions/setup-node-env/action.yml
+++ b/.github/actions/setup-node-env/action.yml
@@ -175,7 +175,11 @@ runs:
         append_pnpm_option_arg PNPM_CONFIG_VIRTUAL_STORE_DIR virtual-store-dir
         if [ -n "${PNPM_CONFIG_MODULES_DIR:-}" ]; then
           mkdir -p "$PNPM_CONFIG_MODULES_DIR"
-          ln -sfn . "$PNPM_CONFIG_MODULES_DIR/node_modules"
+          # The node_modules -> . self-link must NOT exist while pnpm runs:
+          # its bin walk descends through the cycle (node_modules/node_modules/
+          # ...) re-resolving every level, exhausting even a 65536 fd limit.
+          # The post-install block recreates the link once pnpm is done.
+          rm -f "$PNPM_CONFIG_MODULES_DIR/node_modules"
           export NODE_PATH="$PNPM_CONFIG_MODULES_DIR${NODE_PATH:+:$NODE_PATH}"
         fi
         pnpm "${install_args[@]}" || pnpm "${install_args[@]}"

--- a/.github/actions/setup-node-env/action.yml
+++ b/.github/actions/setup-node-env/action.yml
@@ -82,10 +82,12 @@ runs:
           echo "PNPM_CONFIG_STORE_DIR=/var/tmp/openclaw-node-deps/store"
           echo "PNPM_CONFIG_MODULES_DIR=/var/tmp/openclaw-node-deps/node_modules"
           echo "PNPM_CONFIG_VIRTUAL_STORE_DIR=/var/tmp/openclaw-node-deps/virtual-store"
-          # Later steps run `pnpm exec` without the relocation flags; without
-          # this, pnpm's verify-deps-before-run sees the relocated layout as
-          # drift and re-installs everything mid-step (hydrate does the same).
-          echo "npm_config_verify_deps_before_run=false"
+          # Later `pnpm exec`/`pnpm run` invocations re-check dep state and
+          # reinstall mid-step when they judge the relocated layout stale.
+          # pnpm natively honors PNPM_CONFIG_* env vars (verified: `pnpm
+          # config get verify-deps-before-run` -> false); this is the same
+          # switch crabbox-hydrate ships for this exact layout.
+          echo "PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false"
           # The cold install (once per lockfile) links ~1200 packages into the
           # relocated modules dir; unthrottled linking EMFILEs pnpm there
           # (crabbox-hydrate throttles to 1 for the same reason). Warm jobs do

--- a/.github/actions/setup-node-env/action.yml
+++ b/.github/actions/setup-node-env/action.yml
@@ -27,6 +27,14 @@ inputs:
     description: Whether to save the pnpm store with actions/cache after install when no exact cache restored.
     required: false
     default: "false"
+  sticky-disk:
+    description: >
+      Mount a Blacksmith sticky disk holding the pnpm store, node_modules, and
+      virtual store instead of restoring the pnpm store from actions/cache.
+      Only valid on Blacksmith Linux runners; pass use-actions-cache: "false"
+      alongside.
+    required: false
+    default: "false"
 runs:
   using: composite
   steps:
@@ -47,6 +55,31 @@ runs:
         set -euo pipefail
         source "$GITHUB_ACTION_PATH/../setup-pnpm-store-cache/ensure-node.sh"
         openclaw_ensure_node "$REQUESTED_NODE_VERSION"
+
+    - name: Mount dependency sticky disk
+      if: inputs.sticky-disk == 'true'
+      uses: useblacksmith/stickydisk@5b350170ae4ef55b536b548ef5f5896e76a6b54f # v1.4.0
+      with:
+        # Keyed on install inputs: the first job per lockfile change installs
+        # onto a fresh disk and snapshots it once (if-missing); every later job
+        # clones that snapshot and pnpm install is a near no-op verify.
+        key: ${{ github.repository }}-node-deps-v1-${{ inputs.node-version }}-${{ hashFiles('package.json', 'pnpm-lock.yaml', 'pnpm-workspace.yaml') }}
+        path: /var/tmp/openclaw-node-deps
+        commit: if-missing
+
+    - name: Configure sticky dependency layout
+      if: inputs.sticky-disk == 'true'
+      shell: bash
+      run: |
+        set -euo pipefail
+        # Store, virtual store, and modules dir must share the sticky disk's
+        # filesystem so pnpm keeps hardlinking instead of copying packages.
+        # zizmor: ignore[github-env] static trusted paths defined in this composite action.
+        {
+          echo "PNPM_CONFIG_STORE_DIR=/var/tmp/openclaw-node-deps/store"
+          echo "PNPM_CONFIG_MODULES_DIR=/var/tmp/openclaw-node-deps/node_modules"
+          echo "PNPM_CONFIG_VIRTUAL_STORE_DIR=/var/tmp/openclaw-node-deps/virtual-store"
+        } >> "$GITHUB_ENV"
 
     - name: Setup pnpm
       id: setup-pnpm
@@ -124,6 +157,7 @@ runs:
         append_pnpm_option_arg PNPM_CONFIG_CHILD_CONCURRENCY child-concurrency
         append_pnpm_option_arg PNPM_CONFIG_MODULES_DIR modules-dir
         append_pnpm_option_arg PNPM_CONFIG_NETWORK_CONCURRENCY network-concurrency
+        append_pnpm_option_arg PNPM_CONFIG_STORE_DIR store-dir
         append_pnpm_option_arg PNPM_CONFIG_VIRTUAL_STORE_DIR virtual-store-dir
         if [ -n "${PNPM_CONFIG_MODULES_DIR:-}" ]; then
           mkdir -p "$PNPM_CONFIG_MODULES_DIR"

--- a/.github/actions/setup-node-env/action.yml
+++ b/.github/actions/setup-node-env/action.yml
@@ -130,9 +130,12 @@ runs:
         FROZEN_LOCKFILE: ${{ inputs.frozen-lockfile }}
       run: |
         set -euo pipefail
-        # Large parallel installs (sticky-disk cold path) can exhaust the
-        # default soft fd limit; raise it best-effort before pnpm runs.
-        ulimit -n 65536 2>/dev/null || true
+        # Large parallel installs (sticky-disk cold path) can exhaust the soft
+        # fd limit: pnpm's bin-linking fans out one manifest read per package
+        # (~1200 here). Raise to the hard limit — a fixed 65536 silently
+        # no-ops when the runner's hard limit is lower.
+        ulimit -n "$(ulimit -Hn)" 2>/dev/null || true
+        echo "fd limits: soft=$(ulimit -Sn) hard=$(ulimit -Hn)"
         export PATH="$NODE_BIN:$PATH"
         which node
         node -v

--- a/.github/actions/setup-node-env/action.yml
+++ b/.github/actions/setup-node-env/action.yml
@@ -82,6 +82,11 @@ runs:
           echo "PNPM_CONFIG_STORE_DIR=/var/tmp/openclaw-node-deps/store"
           echo "PNPM_CONFIG_MODULES_DIR=/var/tmp/openclaw-node-deps/node_modules"
           echo "PNPM_CONFIG_VIRTUAL_STORE_DIR=/var/tmp/openclaw-node-deps/virtual-store"
+          # The cold install (once per lockfile) links ~1200 packages into the
+          # relocated modules dir; unthrottled linking EMFILEs pnpm there
+          # (crabbox-hydrate throttles to 1 for the same reason). Warm jobs do
+          # a no-op verify, so this only bounds the first run per lockfile.
+          echo "PNPM_CONFIG_CHILD_CONCURRENCY=4"
         } >> "$GITHUB_ENV"
 
     - name: Setup pnpm
@@ -125,6 +130,9 @@ runs:
         FROZEN_LOCKFILE: ${{ inputs.frozen-lockfile }}
       run: |
         set -euo pipefail
+        # Large parallel installs (sticky-disk cold path) can exhaust the
+        # default soft fd limit; raise it best-effort before pnpm runs.
+        ulimit -n 65536 2>/dev/null || true
         export PATH="$NODE_BIN:$PATH"
         which node
         node -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1675,8 +1675,10 @@ jobs:
         with:
           node-version: "${{ matrix.node_version || '24.x' }}"
           install-bun: "false"
-          # Blacksmith runs mount deps from a sticky disk instead of restoring
-          # the ~1GB pnpm store tar in every job; fork/dispatch runs are
+          # Mirrors this job's runs-on ternary exactly: every canonical-repo
+          # run that lands on a Blacksmith runner (including fork PRs, which
+          # run Blacksmith here) mounts deps from a sticky disk instead of
+          # restoring the ~1GB pnpm store tar; workflow_dispatch runs are
           # GitHub-hosted and keep the actions/cache path.
           sticky-disk: ${{ github.event_name != 'workflow_dispatch' && github.repository == 'openclaw/openclaw' && 'true' || 'false' }}
           use-actions-cache: ${{ github.event_name != 'workflow_dispatch' && github.repository == 'openclaw/openclaw' && 'false' || 'true' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1675,6 +1675,11 @@ jobs:
         with:
           node-version: "${{ matrix.node_version || '24.x' }}"
           install-bun: "false"
+          # Blacksmith runs mount deps from a sticky disk instead of restoring
+          # the ~1GB pnpm store tar in every job; fork/dispatch runs are
+          # GitHub-hosted and keep the actions/cache path.
+          sticky-disk: ${{ github.event_name != 'workflow_dispatch' && github.repository == 'openclaw/openclaw' && 'true' || 'false' }}
+          use-actions-cache: ${{ github.event_name != 'workflow_dispatch' && github.repository == 'openclaw/openclaw' && 'false' || 'true' }}
 
       - name: Setup Go for docs i18n
         if: matrix.requires_go == true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1675,13 +1675,15 @@ jobs:
         with:
           node-version: "${{ matrix.node_version || '24.x' }}"
           install-bun: "false"
-          # Mirrors this job's runs-on ternary exactly: every canonical-repo
-          # run that lands on a Blacksmith runner (including fork PRs, which
-          # run Blacksmith here) mounts deps from a sticky disk instead of
-          # restoring the ~1GB pnpm store tar; workflow_dispatch runs are
-          # GitHub-hosted and keep the actions/cache path.
-          sticky-disk: ${{ github.event_name != 'workflow_dispatch' && github.repository == 'openclaw/openclaw' && 'true' || 'false' }}
-          use-actions-cache: ${{ github.event_name != 'workflow_dispatch' && github.repository == 'openclaw/openclaw' && 'false' || 'true' }}
+          # Blacksmith same-repo runs mount deps from a sticky disk instead of
+          # restoring the ~1GB pnpm store tar. Fork PRs are excluded even
+          # though they run on Blacksmith here: sticky snapshots are
+          # repository-global and writable (commit: if-missing), so untrusted
+          # fork code must never produce a snapshot a trusted run could clone.
+          # workflow_dispatch runs are GitHub-hosted and also keep the
+          # actions/cache path.
+          sticky-disk: ${{ github.event_name != 'workflow_dispatch' && github.repository == 'openclaw/openclaw' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'openclaw/openclaw') && 'true' || 'false' }}
+          use-actions-cache: ${{ github.event_name != 'workflow_dispatch' && github.repository == 'openclaw/openclaw' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'openclaw/openclaw') && 'false' || 'true' }}
 
       - name: Setup Go for docs i18n
         if: matrix.requires_go == true


### PR DESCRIPTION
## What Problem This Solves

Every Linux CI job pays a fixed ~20s dependency tax: restoring the ~1.1GB pnpm store from actions/cache (~13s) plus `pnpm install` linking (~8s). Across the ~25 jobs of a full-scope PR run that is both wall clock on the critical path and a large amount of repeated network transfer.

## Why This Change Was Made

Test-shard jobs on Blacksmith runners now mount a sticky disk (`useblacksmith/stickydisk@v1.4.0`, SHA-pinned) holding the pnpm store, `node_modules`, and the pnpm virtual store on one filesystem — reusing the repo's existing `PNPM_CONFIG_MODULES_DIR`/`PNPM_CONFIG_VIRTUAL_STORE_DIR` relocation machinery already proven in `crabbox-hydrate.yml` (same-filesystem layout keeps pnpm hardlinking instead of copying). The disk is keyed on install inputs (`package.json`, `pnpm-lock.yaml`, `pnpm-workspace.yaml`) with `commit: if-missing`: the first job per lockfile change installs onto a fresh disk and snapshots once; every later job clones the snapshot in ~1-2s and `pnpm install` becomes a near no-op verify. Fork and `workflow_dispatch` runs are GitHub-hosted and keep the existing actions/cache path unchanged.

Rollout is deliberately scoped to `checks-node-core-test-nondist-shard` (the widest job fleet) so this PR's own CI proves the layout before any follow-up extends it to other lanes.

## User Impact

No product change. Test-shard jobs shed most of their per-job dependency setup (~20s → ~3-5s expected), which is wall clock on the PR critical path and a large cut in per-run cache network transfer.

## Evidence

- Dependency contract inspected: `useblacksmith/stickydisk` action.yml (key/path/commit inputs, node24 runtime), README architecture notes; keyed snapshots are cloned per job and `if-missing` avoids per-job commit cost.
- Same-filesystem relocation layout is production-proven in this repo by `.github/workflows/crabbox-hydrate.yml` (`/var/tmp/openclaw-pnpm` modules + virtual store).
- `test/scripts/ci-workflow-guards.test.ts` green (pin audit covers the new SHA-pinned action).
- This PR's own CI run exercises the sticky-disk path on every nondist test shard; the Setup Node environment step timing before/after is the direct proof.
- Reviewer concern "pnpm treats modules-dir as project-relative" empirically refuted: exact composite sequence (pre-link, `pnpm install --modules-dir=<absolute> --virtual-store-dir=... --store-dir=...`, `rm -rf node_modules && ln -sfn <modules-dir> node_modules`) installs the direct dependency link into the absolute modules dir and `require()` from the project resolves through the symlink (pnpm 11.x). Same absolute layout crabbox-hydrate runs in production.
- Fork PRs are excluded from the sticky path (they run Blacksmith here — verified on fork run 29404263408 — but writable repository-global snapshots must never be produced by untrusted code); they keep the actions/cache path.
