### PR TITLE
fix(cron): exponential backoff for session reaper on persistent failures

### DIFF
--- a/src/cron/session-reaper.test.ts
+++ b/src/cron/session-reaper.test.ts
@@ -447,4 +447,162 @@ describe("sweepCronRunSessions", () => {
       listSpy.mockRestore();
     }
   });
+
+  it("applies exponential backoff on consecutive persistence failures (#106577)", async () => {
+    const now = Date.now();
+    const warn = vi.fn();
+    const failingLog: Logger = { ...log, warn };
+    const eacces = Object.assign(new Error("EACCES: permission denied, open 'sessions.json'"), {
+      code: "EACCES",
+    });
+    const listSpy = vi.spyOn(sessionAccessor, "listSessionEntries").mockImplementation(() => {
+      throw eacces;
+    });
+
+    try {
+      // Failure 1 at t=0; next backoff = 5min (5*2^0)
+      await sweepCronRunSessions({ sessionStorePath: storePath, nowMs: now, log: failingLog });
+      expect(listSpy).toHaveBeenCalledTimes(1);
+
+      // Failure 2 at t=5min; next backoff = 10min (5*2^1)
+      await sweepCronRunSessions({
+        sessionStorePath: storePath,
+        nowMs: now + 5 * 60_000,
+        log: failingLog,
+      });
+      expect(listSpy).toHaveBeenCalledTimes(2);
+
+      // t=10min is still within 10min backoff from failure 2 → throttled
+      warn.mockClear();
+      await sweepCronRunSessions({
+        sessionStorePath: storePath,
+        nowMs: now + 10 * 60_000,
+        log: failingLog,
+      });
+      expect(warn).not.toHaveBeenCalled();
+      expect(listSpy).toHaveBeenCalledTimes(2);
+
+      // Failure 3 at t=15min (5+10=15); next backoff = 20min (5*2^2)
+      await sweepCronRunSessions({
+        sessionStorePath: storePath,
+        nowMs: now + 15 * 60_000,
+        log: failingLog,
+      });
+      expect(listSpy).toHaveBeenCalledTimes(3);
+
+      // t=25min is within 20min backoff from failure 3 (15+20=35) → throttled
+      await sweepCronRunSessions({
+        sessionStorePath: storePath,
+        nowMs: now + 25 * 60_000,
+        log: failingLog,
+      });
+      expect(listSpy).toHaveBeenCalledTimes(3);
+
+      // Failure 4 at t=35min (15+20=35); next backoff = 40min (5*2^3)
+      await sweepCronRunSessions({
+        sessionStorePath: storePath,
+        nowMs: now + 35 * 60_000,
+        log: failingLog,
+      });
+      expect(listSpy).toHaveBeenCalledTimes(4);
+    } finally {
+      listSpy.mockRestore();
+    }
+  });
+
+  it("resets backoff after a successful sweep (#106577)", async () => {
+    const now = Date.now();
+    const warn = vi.fn();
+    const failingLog: Logger = { ...log, warn };
+    const eacces = Object.assign(new Error("EACCES: permission denied, open 'sessions.json'"), {
+      code: "EACCES",
+    });
+
+    const listSpy = vi.spyOn(sessionAccessor, "listSessionEntries");
+
+    try {
+      // First call fails
+      listSpy.mockImplementationOnce(() => {
+        throw eacces;
+      });
+      await sweepCronRunSessions({ sessionStorePath: storePath, nowMs: now, log: failingLog });
+      expect(listSpy).toHaveBeenCalledTimes(1);
+      expect(warn).toHaveBeenCalledTimes(1);
+
+      // Second call succeeds (returns no entries), resetting backoff
+      listSpy.mockImplementationOnce(() => []);
+      const result = await sweepCronRunSessions({
+        sessionStorePath: storePath,
+        nowMs: now + 5 * 60_000,
+        log: failingLog,
+      });
+      expect(result.swept).toBe(true);
+      expect(result.pruned).toBe(0);
+
+      // After success, the next sweep at normal 5min interval should work
+      listSpy.mockImplementationOnce(() => []);
+      const result2 = await sweepCronRunSessions({
+        sessionStorePath: storePath,
+        nowMs: now + 10 * 60_000,
+        log,
+      });
+      expect(result2.swept).toBe(true);
+
+      // Immediate retry should be throttled at the normal 5min interval
+      const throttled = await sweepCronRunSessions({
+        sessionStorePath: storePath,
+        nowMs: now + 10 * 60_000 + 1_000,
+        log,
+      });
+      expect(throttled.swept).toBe(false);
+    } finally {
+      listSpy.mockRestore();
+    }
+  });
+
+  it("caps backoff at MAX_BACKOFF_MS (1 hour) (#106577)", async () => {
+    const now = Date.now();
+    const warn = vi.fn();
+    const failingLog: Logger = { ...log, warn };
+    const eacces = Object.assign(new Error("EACCES: permission denied, open 'sessions.json'"), {
+      code: "EACCES",
+    });
+    const listSpy = vi.spyOn(sessionAccessor, "listSessionEntries").mockImplementation(() => {
+      throw eacces;
+    });
+
+    try {
+      // Drive 5 consecutive failures so backoff reaches the 60min cap.
+      // After failure N, effectiveSweepIntervalMs = min(5*2^(N-1), 60) min.
+      // lastSweepAtMs is set at the start of each attempt, not after success.
+      let t = now;
+      const intervals = [5, 10, 20, 40, 60];
+      let lastSweepTime = 0;
+      for (const interval of intervals) {
+        await sweepCronRunSessions({ sessionStorePath: storePath, nowMs: t, log: failingLog });
+        lastSweepTime = t;
+        t += interval * 60_000;
+      }
+      // 5 failures; next backoff = min(5*2^4, 60) = 60min
+      const callsAfterLoop = listSpy.mock.calls.length;
+
+      // Attempt at lastSweepTime + 59min is still within 60min backoff → throttled
+      await sweepCronRunSessions({
+        sessionStorePath: storePath,
+        nowMs: lastSweepTime + 59 * 60_000,
+        log: failingLog,
+      });
+      expect(listSpy.mock.calls.length).toBe(callsAfterLoop);
+
+      // Attempt at lastSweepTime + 60min should proceed
+      await sweepCronRunSessions({
+        sessionStorePath: storePath,
+        nowMs: lastSweepTime + 60 * 60_000,
+        log: failingLog,
+      });
+      expect(listSpy.mock.calls.length).toBe(callsAfterLoop + 1);
+    } finally {
+      listSpy.mockRestore();
+    }
+  });
 });

--- a/src/cron/session-reaper.ts
+++ b/src/cron/session-reaper.ts
@@ -17,7 +17,21 @@ const DEFAULT_RETENTION_MS = 24 * 3_600_000; // 24 hours
 /** Minimum interval between reaper sweeps (avoid running every timer tick). */
 const MIN_SWEEP_INTERVAL_MS = 5 * 60_000; // 5 minutes
 
+/** Maximum backoff interval after consecutive persistence failures. */
+const MAX_BACKOFF_MS = 60 * 60_000; // 1 hour
+
 const lastSweepAtMsByStore = new Map<string, number>();
+const consecutiveFailuresByStore = new Map<string, number>();
+
+/** Resolves the effective sweep interval, applying exponential backoff after consecutive failures. */
+function effectiveSweepIntervalMs(storePath: string): number {
+  const failures = consecutiveFailuresByStore.get(storePath) ?? 0;
+  if (failures === 0) {
+    return MIN_SWEEP_INTERVAL_MS;
+  }
+  const backoff = MIN_SWEEP_INTERVAL_MS * 2 ** (failures - 1);
+  return Math.min(backoff, MAX_BACKOFF_MS);
+}
 
 /** Resolves cron run-session retention; `false` disables pruning, bad strings fall back safely. */
 function resolveRetentionMs(cronConfig?: CronConfig): number | null {
@@ -61,7 +75,10 @@ export async function sweepCronRunSessions(params: {
 
   // Timer ticks can be frequent; throttle per store path to avoid repeated
   // session-store I/O while preserving a force path for deterministic tests.
-  if (!params.force && now - lastSweepAtMs < MIN_SWEEP_INTERVAL_MS) {
+  // After consecutive failures, the interval grows exponentially up to
+  // MAX_BACKOFF_MS so a broken store does not consume CPU every 5 minutes.
+  const interval = effectiveSweepIntervalMs(storePath);
+  if (!params.force && now - lastSweepAtMs < interval) {
     return { swept: false, pruned: 0 };
   }
 
@@ -127,6 +144,7 @@ export async function sweepCronRunSessions(params: {
     }
   } catch (err) {
     params.log.warn({ err: String(err) }, "cron-reaper: failed to sweep session store");
+    consecutiveFailuresByStore.set(storePath, (consecutiveFailuresByStore.get(storePath) ?? 0) + 1);
     return { swept: false, pruned: 0 };
   }
 
@@ -144,10 +162,13 @@ export async function sweepCronRunSessions(params: {
     );
   }
 
+  consecutiveFailuresByStore.delete(storePath);
+
   return { swept: true, pruned };
 }
 
 /** Resets per-store reaper throttles between tests. */
 export function resetReaperThrottle(): void {
   lastSweepAtMsByStore.clear();
+  consecutiveFailuresByStore.clear();
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the session reaper in `src/cron/session-reaper.ts` retries at a fixed 5-minute interval after every persistence failure. When the session store is broken (e.g., database locked, read-only filesystem), the reaper continuously attempts cleanup every 5 minutes for the lifetime of the process, causing CPU thrashing and log bloat without any recovery path.

Closes #106577

## Why This Change Was Made

Added exponential backoff to the reaper sweep throttle so consecutive persistence failures progressively increase the retry interval from the baseline 5 minutes up to a 1-hour cap (5 → 10 → 20 → 40 → 60 min). A successful sweep resets the backoff to the normal interval. The existing throttle mechanics (per-store tracking, `force` override for tests) are preserved.

## User Impact

Operators running gateways with broken or temporarily unavailable session stores will no longer see unbounded CPU and log consumption from the reaper. Instead, the reaper backs off progressively and retries at increasing intervals, resuming normal behavior once the store recovers.

## Evidence

- 3 new test cases pass:
  - `"applies exponential backoff on consecutive persistence failures (#106577)"` — verifies 5→10→20→40min backoff progression
  - `"resets backoff after a successful sweep (#106577)"` — verifies backoff resets on success
  - `"caps backoff at MAX_BACKOFF_MS (1 hour) (#106577)"` — verifies the 60-minute cap and boundary behavior
- All pre-existing tests remain in the same state (10 fail due to SQLite version in this environment, 6 pass; my changes do not affect those outcomes)
- `oxlint` and `oxfmt` pass on changed files

```
$ node scripts/run-vitest.mjs src/cron/session-reaper.test.ts
      Tests  10 failed | 9 passed (19)
# 10 failures are pre-existing (Node 22.22.0 SQLite version check)
# 9 passes = 6 pre-existing + 3 new
```