### PR TITLE
fix(qa): Matrix approval release checks use updated config

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -182,6 +182,7 @@ Skills own workflows; root owns hard policy and routing.
 - `gh pr view` takes the branch positionally; no `--head` flag.
 - `gh pr diff` has no `--stat`; use `gh pr view --json changedFiles,additions,deletions` or `git diff --stat`.
 - zsh: quote `gh api` endpoints containing `?` or brackets; otherwise glob expansion corrupts the invocation.
+- `gh pr checks --json`: use `link`, not nonexistent `detailsUrl`.
 - Blacksmith Testbox status/stop: `--id <tbx_id>`; no status JSON flag.
 - Crabbox final timing JSON = proof complete; if portal sync hangs after it, interrupt wrapper only.
 - Sparse-sync temp checkout may claim kept Testbox; repo-path reuse needs `--reclaim`.
@@ -199,6 +200,7 @@ Skills own workflows; root owns hard policy and routing.
 - `rg`: options/globs before `--`; `--` immediately before a leading-dash pattern only.
 - `gh --jq` is not standalone `jq`; pipe JSON to `jq` for variables or `--arg`.
 - Shared checkout: serialize `git fetch`; on ref-lock failure, re-read the ref before retry.
+- Git fetch/pull yielding without completion: inspect/stop only the owned process before retry; never overlap retries.
 - `gh api --paginate '<endpoint>' | jq -s ...`; gh `--slurp` may emit nothing and forbids `--jq`/`--template`.
 - Main-bound workflow dispatch: resolve server `main` SHA immediately before dispatch; retry if identity fails after `main` advances.
 - `gh run view --json` uses `attempt`, not `attemptNumber`.

--- a/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-environment.test.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-environment.test.ts
@@ -1,0 +1,104 @@
+// QA Lab Matrix tests cover scenario environment readiness boundaries.
+import { describe, expect, it, vi } from "vitest";
+
+const buildMatrixQaConfig = vi.hoisted(() =>
+  vi.fn(() => ({ channels: { matrix: { execApprovals: { enabled: true } } } })),
+);
+
+vi.mock("../substrate/config.js", () => ({ buildMatrixQaConfig }));
+vi.mock("./scenario-runtime-room.js", () => ({ runMatrixQaCanary: vi.fn() }));
+
+import { createMatrixQaScenarioEnvironment } from "./scenario-environment.js";
+
+describe("matrix scenario environment", () => {
+  it("waits for config restart settle before accepting Matrix readiness", async () => {
+    const callOrder: string[] = [];
+    let configReadCount = 0;
+    let statusReadCount = 0;
+    const gateway = {
+      baseUrl: "http://127.0.0.1:12345",
+      runtimeEnv: {},
+      tempRoot: "/tmp/matrix-qa",
+      workspaceDir: "/tmp/matrix-qa/workspace",
+      call: vi.fn(async (method: string) => {
+        callOrder.push(method);
+        if (method === "config.get") {
+          configReadCount += 1;
+          return configReadCount === 1 ? { config: {} } : { hash: "config-hash" };
+        }
+        if (method === "config.patch") {
+          return { ok: true };
+        }
+        if (method === "channels.status") {
+          statusReadCount += 1;
+          return {
+            channelAccounts: {
+              matrix: [
+                {
+                  accountId: "sut",
+                  connected: true,
+                  healthState: "healthy",
+                  lastStartAt: 100,
+                  restartPending: false,
+                  running: true,
+                },
+              ],
+            },
+          };
+        }
+        if (method === "exec.approval.request") {
+          return { id: "approval-1", status: "accepted" };
+        }
+        throw new Error(`unexpected gateway method ${method}`);
+      }),
+    };
+    const environment = createMatrixQaScenarioEnvironment({
+      accountId: "sut",
+      harness: { baseUrl: "http://127.0.0.1:8008", recording: {} } as never,
+      observedEvents: [],
+      provisioning: {
+        driver: { accessToken: "fixture", userId: "@driver:test" },
+        observer: { accessToken: "fixture", userId: "@observer:test" },
+        roomId: "!room:test",
+        sut: { accessToken: "fixture", userId: "@sut:test" },
+        topology: { rooms: [] },
+      } as never,
+    });
+    const waitForConfigRestartSettle = vi.fn(async () => {
+      callOrder.push("config.settle");
+    });
+
+    const prepared = await environment.prepareFlow({
+      config: {},
+      gateway,
+      outputDir: "/tmp/matrix-qa/output",
+      timeoutMs: 1_000,
+      waitForConfigRestartSettle,
+    });
+    const scenarioContext = prepared.scenarioContext;
+    await scenarioContext.gatewayCall?.(
+      "exec.approval.request",
+      { id: "approval-1" },
+      { expectFinal: false, timeoutMs: 1_000 },
+    );
+
+    expect(statusReadCount).toBe(1);
+    expect(callOrder).toEqual([
+      "config.get",
+      "config.get",
+      "config.patch",
+      "config.settle",
+      "channels.status",
+      "exec.approval.request",
+    ]);
+    expect(waitForConfigRestartSettle).toHaveBeenCalledWith({
+      restartDelayMs: 0,
+      timeoutMs: 1_000,
+    });
+    expect(gateway.call).toHaveBeenLastCalledWith(
+      "exec.approval.request",
+      { id: "approval-1" },
+      { expectFinal: false, timeoutMs: 1_000 },
+    );
+  });
+});

--- a/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-environment.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-environment.ts
@@ -51,7 +51,7 @@ async function patchGatewayConfig(params: {
       throw new Error("Matrix QA config patch requires config.get hash");
     }
     try {
-      await params.gateway.call(
+      return (await params.gateway.call(
         "config.patch",
         {
           raw: JSON.stringify(params.patch, null, 2),
@@ -60,8 +60,7 @@ async function patchGatewayConfig(params: {
           restartDelayMs: params.restartDelayMs ?? 0,
         },
         { timeoutMs: 60_000 },
-      );
-      return;
+      )) as { noop?: boolean };
     } catch (error) {
       if (attempt === 0 && isStaleConfigPatchError(error)) {
         continue;
@@ -69,6 +68,7 @@ async function patchGatewayConfig(params: {
       throw error;
     }
   }
+  throw new Error("Matrix QA config patch exhausted retries");
 }
 
 async function waitForMatrixAccountReady(params: {
@@ -148,11 +148,17 @@ export function createMatrixQaScenarioEnvironment(params: MatrixQaScenarioEnviro
       sutUserId: params.provisioning.sut.userId,
       topology: params.provisioning.topology,
     });
-    await patchGatewayConfig({
+    const patchResult = await patchGatewayConfig({
       gateway: input.gateway,
       patch: gatewayConfig as Record<string, unknown>,
       replacePaths: ["channels.matrix", "messages", "agents.defaults", "tools"],
     });
+    if (patchResult.noop !== true) {
+      await input.waitForConfigRestartSettle({
+        restartDelayMs: 0,
+        timeoutMs: input.timeoutMs,
+      });
+    }
     await waitForMatrixAccountReady({
       accountId: params.accountId,
       gateway: input.gateway,
@@ -179,7 +185,7 @@ export function createMatrixQaScenarioEnvironment(params: MatrixQaScenarioEnviro
       gatewayCall: async (
         method: string,
         callParams?: Record<string, unknown>,
-        opts?: { timeoutMs?: number },
+        opts?: { expectFinal?: boolean; timeoutMs?: number },
       ) => await input.gateway.call(method, callParams ?? {}, opts),
       outputDir: input.outputDir,
       registrationToken: params.harness.registrationToken,
@@ -243,13 +249,14 @@ export function createMatrixQaScenarioEnvironment(params: MatrixQaScenarioEnviro
       patchGatewayConfig: async (
         patch: Record<string, unknown>,
         opts?: { replacePaths?: string[]; restartDelayMs?: number },
-      ) =>
+      ) => {
         await patchGatewayConfig({
           gateway: input.gateway,
           patch,
           replacePaths: opts?.replacePaths,
           restartDelayMs: opts?.restartDelayMs,
-        }),
+        });
+      },
       readGatewayAccountStartAt: async (accountId: string) =>
         (await readMatrixAccountStatuses(input.gateway)).find(
           (account) => account.accountId === accountId,

--- a/extensions/qa-lab/src/qa-transport.ts
+++ b/extensions/qa-lab/src/qa-transport.ts
@@ -22,6 +22,7 @@ export type QaTransportGatewayClient = {
     method: string,
     params?: unknown,
     options?: {
+      expectFinal?: boolean;
       timeoutMs?: number;
     },
   ) => Promise<unknown>;

--- a/extensions/qa-lab/src/suite-runtime-flow.ts
+++ b/extensions/qa-lab/src/suite-runtime-flow.ts
@@ -337,6 +337,8 @@ export function createQaSuiteScenarioStepRunner(
             gateway: env.gateway,
             outputDir: env.outputDir,
             timeoutMs: execution.timeoutMs ?? deps.liveTurnTimeoutMs(env, 60_000),
+            waitForConfigRestartSettle: async (options) =>
+              await waitForConfigRestartSettle(env, options?.restartDelayMs, options?.timeoutMs),
           });
           if (prepared) {
             Object.assign(vars, prepared);

--- a/extensions/qa-lab/src/suite-runtime-types.ts
+++ b/extensions/qa-lab/src/suite-runtime-types.ts
@@ -24,6 +24,7 @@ type QaRuntimeGatewayClient = {
     method: string,
     params?: unknown,
     options?: {
+      expectFinal?: boolean;
       timeoutMs?: number;
     },
   ) => Promise<unknown>;

--- a/extensions/qa-lab/src/suite.test.ts
+++ b/extensions/qa-lab/src/suite.test.ts
@@ -133,6 +133,7 @@ describe("qa suite", () => {
       gateway: env.gateway,
       outputDir: "/tmp/qa-output",
       timeoutMs: 45_000,
+      waitForConfigRestartSettle: expect.any(Function),
     });
     expect(scenarioStep).not.toHaveBeenCalled();
   });

--- a/src/plugin-sdk/qa-runner-runtime.ts
+++ b/src/plugin-sdk/qa-runner-runtime.ts
@@ -43,7 +43,11 @@ type QaRunnerTransportFlowPreparationInput = {
     tempRoot: string;
     workspaceDir: string;
     runtimeEnv: NodeJS.ProcessEnv;
-    call: (method: string, params?: unknown, options?: { timeoutMs?: number }) => Promise<unknown>;
+    call: (
+      method: string,
+      params?: unknown,
+      options?: { expectFinal?: boolean; timeoutMs?: number },
+    ) => Promise<unknown>;
     restartAfterStateMutation?: (
       mutateState: (context: {
         configPath: string;
@@ -53,6 +57,10 @@ type QaRunnerTransportFlowPreparationInput = {
       }) => Promise<void>,
     ) => Promise<void>;
   };
+  waitForConfigRestartSettle: (options?: {
+    restartDelayMs?: number;
+    timeoutMs?: number;
+  }) => Promise<void>;
   outputDir: string;
   timeoutMs: number;
 };


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the Matrix approval release check could run against the previous live channel configuration immediately after a scenario config patch, causing a deterministic `approval request status was <missing> instead of accepted` failure.

## Why This Change Was Made

Matrix scenario preparation now uses QA Lab's existing config-restart settle boundary before accepting channel readiness after a non-noop patch. The QA transport gateway contract also carries the existing `expectFinal` request option end to end, and the regression test locks both ordering and option forwarding. No product runtime behavior changes.

## User Impact

Maintainers get reliable Matrix approval coverage in Full Release Validation instead of a false release blocker caused by stale test configuration.

## Evidence

- Failing exact-head release validation: https://github.com/openclaw/openclaw/actions/runs/29401349911
- Focused Testbox: https://github.com/openclaw/openclaw/actions/runs/29403366354 — 2 files, 28 tests passed
- Full changed-surface Testbox: https://github.com/openclaw/openclaw/actions/runs/29403486704 — core and extension types, lint, formatting, SDK guards, and architecture guards passed
- Fresh autoreview: clean, no accepted/actionable findings
