### PR TITLE
fix(cron): honor AbortSignal in waitForActiveCronTaskRuns poll

### DIFF
--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -943,8 +943,10 @@ export async function runGatewayLoop(params: {
       rotateAgentEventLifecycleGeneration();
       advanceCronActiveJobGeneration();
       abortActiveCronTaskRuns("Gateway restarting.");
-      const drainAbort = new AbortController();
-      const cronTaskDrain = await waitForActiveCronTaskRuns(1_000, drainAbort.signal);
+      // Combine the wall-clock deadline with an AbortSignal so the drain
+      // poll exits promptly when the timeout fires — this makes the helper's
+      // new signal parameter functional at the production call site.
+      const cronTaskDrain = await waitForActiveCronTaskRuns(1_000, AbortSignal.timeout(1_000));
       const cronDrain = await waitForActiveCronJobs(1_000);
       if (!cronTaskDrain.drained || !cronDrain.drained) {
         gatewayLog.warn(

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -943,7 +943,8 @@ export async function runGatewayLoop(params: {
       rotateAgentEventLifecycleGeneration();
       advanceCronActiveJobGeneration();
       abortActiveCronTaskRuns("Gateway restarting.");
-      const cronTaskDrain = await waitForActiveCronTaskRuns(1_000);
+      const drainAbort = new AbortController();
+      const cronTaskDrain = await waitForActiveCronTaskRuns(1_000, drainAbort.signal);
       const cronDrain = await waitForActiveCronJobs(1_000);
       if (!cronTaskDrain.drained || !cronDrain.drained) {
         gatewayLog.warn(

--- a/src/cron/service/active-run-cancellation.test.ts
+++ b/src/cron/service/active-run-cancellation.test.ts
@@ -85,3 +85,58 @@ describe("cron task cancellation tracking", () => {
     await vi.waitFor(() => expect(getSuspensionVisibleCronTaskRunCount()).toBe(0));
   });
 });
+
+describe("waitForActiveCronTaskRuns abort", () => {
+  it("resolves early when the signal is already aborted", async () => {
+    resetActiveCronTaskRunsForTests();
+    trackActiveCronTaskRunSettlement(new Promise<never>(() => {}));
+
+    const controller = new AbortController();
+    controller.abort();
+
+    const started = Date.now();
+    const result = await waitForActiveCronTaskRuns(10_000, controller.signal);
+    expect(Date.now() - started).toBeLessThan(100);
+    expect(result.drained).toBe(false);
+    expect(result.active).toBeGreaterThan(0);
+    resetActiveCronTaskRunsForTests();
+  });
+
+  it("wakes the poll when the signal is aborted mid-wait", async () => {
+    vi.useFakeTimers();
+    try {
+      resetActiveCronTaskRunsForTests();
+      trackActiveCronTaskRunSettlement(new Promise<never>(() => {}));
+
+      const controller = new AbortController();
+      const promise = waitForActiveCronTaskRuns(10_000, controller.signal);
+
+      await vi.advanceTimersByTimeAsync(80);
+      controller.abort();
+      await vi.advanceTimersByTimeAsync(0);
+
+      const result = await promise;
+      expect(result.drained).toBe(false);
+      expect(result.active).toBeGreaterThan(0);
+    } finally {
+      vi.useRealTimers();
+      resetActiveCronTaskRunsForTests();
+    }
+  });
+
+  it("honours the deadline when no signal is provided", async () => {
+    vi.useFakeTimers();
+    try {
+      resetActiveCronTaskRunsForTests();
+      trackActiveCronTaskRunSettlement(new Promise<never>(() => {}));
+
+      const promise = waitForActiveCronTaskRuns(500);
+      await vi.advanceTimersByTimeAsync(600);
+      const result = await promise;
+      expect(result.drained).toBe(false);
+    } finally {
+      vi.useRealTimers();
+      resetActiveCronTaskRunsForTests();
+    }
+  });
+});

--- a/src/cron/service/active-run-cancellation.ts
+++ b/src/cron/service/active-run-cancellation.ts
@@ -97,17 +97,31 @@ export function retireActiveCronTaskRunTracking(): void {
   settlingCronTaskRuns.clear();
 }
 
-export async function waitForActiveCronTaskRuns(timeoutMs: number): Promise<{
+export async function waitForActiveCronTaskRuns(
+  timeoutMs: number,
+  signal?: AbortSignal,
+): Promise<{
   drained: boolean;
   active: number;
 }> {
   const deadline = Date.now() + Math.max(0, Math.floor(timeoutMs));
   while (
     (activeCronTaskRunsByRunId.size > 0 || settlingCronTaskRuns.size > 0) &&
-    Date.now() < deadline
+    Date.now() < deadline &&
+    !signal?.aborted
   ) {
     await new Promise<void>((resolve) => {
-      setTimeout(resolve, DEFAULT_CRON_TASK_RUN_DRAIN_POLL_MS);
+      const timer = setTimeout(resolve, DEFAULT_CRON_TASK_RUN_DRAIN_POLL_MS);
+      if (signal) {
+        signal.addEventListener(
+          "abort",
+          () => {
+            clearTimeout(timer);
+            resolve();
+          },
+          { once: true },
+        );
+      }
     });
   }
   return {

--- a/src/cron/service/active-run-cancellation.ts
+++ b/src/cron/service/active-run-cancellation.ts
@@ -111,16 +111,18 @@ export async function waitForActiveCronTaskRuns(
     !signal?.aborted
   ) {
     await new Promise<void>((resolve) => {
-      const timer = setTimeout(resolve, DEFAULT_CRON_TASK_RUN_DRAIN_POLL_MS);
+      let cleanup: (() => void) | undefined;
+      const timer = setTimeout(() => {
+        cleanup?.();
+        resolve();
+      }, DEFAULT_CRON_TASK_RUN_DRAIN_POLL_MS);
       if (signal) {
-        signal.addEventListener(
-          "abort",
-          () => {
-            clearTimeout(timer);
-            resolve();
-          },
-          { once: true },
-        );
+        const onAbort = () => {
+          clearTimeout(timer);
+          resolve();
+        };
+        signal.addEventListener("abort", onAbort, { once: true });
+        cleanup = () => signal.removeEventListener("abort", onAbort);
       }
     });
   }


### PR DESCRIPTION
## Summary
Add an optional `AbortSignal` parameter to `waitForActiveCronTaskRuns` so the poll loop exits early when aborted, and wire it from the gateway restart drain path via `AbortSignal.timeout(1_000)`.

## What Problem This Solves
`waitForActiveCronTaskRuns` polls in a `while` loop with `setTimeout` until all active cron task runs drain or the deadline passes. If a gateway restart needs to proceed quickly, the poll loop blocks until the full deadline expires. With an `AbortSignal`, the poll can be woken immediately when the caller cancels.

**Code evidence**: [active-run-cancellation.ts:100-127](src/cron/service/active-run-cancellation.ts#L100-L127)

## Root Cause
- The poll loop used bare `setTimeout` with no early-exit mechanism
- The gateway restart path `run-loop.ts:946` already had a fixed 1s deadline but no way to cancel mid-wait

## Why This Fix
1. Add optional `signal?: AbortSignal` parameter — backward compatible
2. When signal is provided, listen for `abort` and resolve the wait promise immediately
3. Clean up the abort listener when the timer fires normally
4. Wire `AbortSignal.timeout(1_000)` from the production restart drain path — functionally equivalent to the existing deadline but makes the signal parameter live

## User Impact
- **Before**: Gateway restart always waits full 1s for cron task drain
- **After**: Same behavior (1s deadline) but signal infrastructure is in place for future lifecycle-driven abort

## Evidence
- **Before** (upstream/main): `waitForActiveCronTaskRuns` had no abort mechanism — poll always ran to deadline
- **After** (with fix): `waitForActiveCronTaskRuns` resolves early when signal is aborted

## Real Behavior Proof

```bash
$ npx vitest run src/cron/service/active-run-cancellation.test.ts
Tests  6 passed (6)

# New tests:
# ✓ resolves early when the signal is already aborted
# ✓ wakes the poll when the signal is aborted mid-wait
# ✓ honours the deadline when no signal is provided
```

### Production call site (gateway restart drain)
```typescript
// run-loop.ts:946
const cronTaskDrain = await waitForActiveCronTaskRuns(1_000, AbortSignal.timeout(1_000));
```

The `AbortSignal.timeout(1_000)` fires after 1s, matching the existing deadline. When a lifecycle signal owner is designated by maintainers, this call site can accept a real restart-coalescing signal without further changes to `waitForActiveCronTaskRuns`.

## Tests and Validation
- `npx vitest run src/cron/service/active-run-cancellation.test.ts` — 6 passed
- Branch rebased on latest upstream/main (0 commits behind)
- 3 new tests: pre-aborted signal, mid-wait abort, no-signal deadline