### PR TITLE
fix(opencode): reject output stream failures in session catalog

### DIFF
--- a/extensions/opencode/session-catalog.test.ts
+++ b/extensions/opencode/session-catalog.test.ts
@@ -1,5 +1,5 @@
-import fs from "node:fs/promises";
 import { EventEmitter } from "node:events";
+import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
@@ -577,9 +577,8 @@ describe("OpenCode session catalog", () => {
     const spawn = vi.fn(() => child);
     vi.resetModules();
     vi.doMock("node:child_process", () => ({ spawn }));
-    const { listLocalOpenCodeSessionPage: listWithMockedSpawn } = await import(
-      "./session-catalog.js"
-    );
+    const { listLocalOpenCodeSessionPage: listWithMockedSpawn } =
+      await import("./session-catalog.js");
 
     const listing = listWithMockedSpawn({ limit: 20 });
     await vi.waitFor(() => expect(spawn).toHaveBeenCalledTimes(1));

--- a/extensions/opencode/session-catalog.test.ts
+++ b/extensions/opencode/session-catalog.test.ts
@@ -1,4 +1,5 @@
-import { EventEmitter } from "node:events";
+import type { ChildProcess } from "node:child_process";
+import { once } from "node:events";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -8,6 +9,20 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 const nodeHostMocks = vi.hoisted(() => ({
   runNodePtyCommand: vi.fn(async () => ({ exitCode: 0 })),
 }));
+const childProcessMocks = vi.hoisted(() => ({
+  children: [] as ChildProcess[],
+  spawn: vi.fn(),
+}));
+
+vi.mock("node:child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:child_process")>();
+  childProcessMocks.spawn.mockImplementation((...args: Parameters<typeof actual.spawn>) => {
+    const child = actual.spawn(...args);
+    childProcessMocks.children.push(child);
+    return child;
+  });
+  return { ...actual, spawn: childProcessMocks.spawn };
+});
 
 vi.mock("openclaw/plugin-sdk/node-host", async (importOriginal) => {
   const actual = await importOriginal<typeof import("openclaw/plugin-sdk/node-host")>();
@@ -136,10 +151,52 @@ if (args[0] === "--pure" && args[1] === "db" && args.includes("--format") && arg
   return directory;
 }
 
+async function installHangingOpenCode(): Promise<void> {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-opencode-stream-"));
+  temporaryDirectories.push(directory);
+  const executableName = process.platform === "win32" ? "opencode.js" : "opencode";
+  await fs.writeFile(
+    path.join(directory, executableName),
+    `${process.platform === "win32" ? "" : "#!/usr/bin/env node\n"}setTimeout(() => process.stdout.write("ready\\n"), 50);
+setInterval(() => {}, 1_000);
+`,
+  );
+  if (process.platform !== "win32") {
+    await fs.chmod(path.join(directory, executableName), 0o755);
+  }
+  process.env.PATH = `${directory}${path.delimiter}${originalPath ?? ""}`;
+  if (process.platform === "win32") {
+    // The production resolver converts a PATHEXT-resolved .js command into
+    // process.execPath plus the script path, so this remains a direct real-child spawn.
+    process.env.PATHEXT = `.JS;${originalPathExt ?? ".EXE;.CMD;.BAT;.COM"}`;
+  }
+}
+
+function isProcessRunning(pid: number | undefined): boolean {
+  if (!pid) {
+    return false;
+  }
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function stopChild(child: ChildProcess | undefined): Promise<void> {
+  if (!child || !isProcessRunning(child.pid)) {
+    return;
+  }
+  const closed = once(child, "close");
+  child.kill("SIGKILL");
+  await closed;
+}
+
 afterEach(async () => {
   nodeHostMocks.runNodePtyCommand.mockClear();
-  vi.doUnmock("node:child_process");
-  vi.resetModules();
+  childProcessMocks.spawn.mockClear();
+  await Promise.all(childProcessMocks.children.splice(0).map((child) => stopChild(child)));
   process.env.PATH = originalPath;
   if (originalPathExt === undefined) {
     delete process.env.PATHEXT;
@@ -557,37 +614,34 @@ describe("OpenCode session catalog", () => {
     );
   });
 
-  it("rejects local session listing when the OpenCode stdout stream fails", async () => {
-    const directory = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-opencode-stream-"));
-    temporaryDirectories.push(directory);
-    const executableName = process.platform === "win32" ? "opencode.js" : "opencode";
-    await fs.writeFile(path.join(directory, executableName), "");
-    process.env.PATH = `${directory}${path.delimiter}${originalPath ?? ""}`;
-    if (process.platform === "win32") {
-      process.env.PATHEXT = `.JS;${originalPathExt ?? ".EXE;.CMD;.BAT;.COM"}`;
-    }
+  it.each(["stdout", "stderr"] as const)(
+    "rejects and reaps the real OpenCode child when its %s pipe fails",
+    async (streamName) => {
+      await installHangingOpenCode();
+      const uncaughtException = vi.fn();
+      process.on("uncaughtExceptionMonitor", uncaughtException);
+      let child: ChildProcess | undefined;
+      try {
+        const listing = listLocalOpenCodeSessionPage({ limit: 20 });
+        await vi.waitFor(() => expect(childProcessMocks.spawn).toHaveBeenCalledTimes(1));
+        child = childProcessMocks.children[0];
+        expect(child?.pid).toBeTypeOf("number");
+        await once(child!.stdout!, "data");
 
-    const stdout = new EventEmitter();
-    const stderr = new EventEmitter();
-    const child = Object.assign(new EventEmitter(), {
-      stdout,
-      stderr,
-      kill: vi.fn(),
-    });
-    const spawn = vi.fn(() => child);
-    vi.resetModules();
-    vi.doMock("node:child_process", () => ({ spawn }));
-    const { listLocalOpenCodeSessionPage: listWithMockedSpawn } =
-      await import("./session-catalog.js");
+        child![streamName]!.destroy(new Error(`${streamName} EPIPE`));
 
-    const listing = listWithMockedSpawn({ limit: 20 });
-    await vi.waitFor(() => expect(spawn).toHaveBeenCalledTimes(1));
-    stdout.emit("error", new Error("stdout EPIPE"));
-    child.emit("close", 0);
-
-    await expect(listing).rejects.toThrow("OpenCode stdout stream failed: stdout EPIPE");
-    expect(child.kill).toHaveBeenCalledWith("SIGKILL");
-  });
+        await expect(listing).rejects.toThrow(
+          `OpenCode ${streamName} stream failed: ${streamName} EPIPE`,
+        );
+        await new Promise<void>((resolve) => setImmediate(resolve));
+        expect(uncaughtException).not.toHaveBeenCalled();
+        expect(isProcessRunning(child!.pid)).toBe(false);
+      } finally {
+        process.off("uncaughtExceptionMonitor", uncaughtException);
+        await stopChild(child);
+      }
+    },
+  );
 
   it("fans out paired-node listing instead of blocking later hosts", async () => {
     let provider: Parameters<OpenClawPluginApi["registerSessionCatalog"]>[0] | undefined;

--- a/extensions/opencode/session-catalog.test.ts
+++ b/extensions/opencode/session-catalog.test.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs/promises";
+import { EventEmitter } from "node:events";
 import os from "node:os";
 import path from "node:path";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
@@ -45,6 +46,7 @@ import {
 
 const temporaryDirectories: string[] = [];
 const originalPath = process.env.PATH;
+const originalPathExt = process.env.PATHEXT;
 const originalUnrelatedEnv = process.env.CATALOG_UNRELATED_ENV;
 
 function captureOpenCodeSessionRegistrations(pluginConfig: unknown = {}) {
@@ -136,7 +138,14 @@ if (args[0] === "--pure" && args[1] === "db" && args.includes("--format") && arg
 
 afterEach(async () => {
   nodeHostMocks.runNodePtyCommand.mockClear();
+  vi.doUnmock("node:child_process");
+  vi.resetModules();
   process.env.PATH = originalPath;
+  if (originalPathExt === undefined) {
+    delete process.env.PATHEXT;
+  } else {
+    process.env.PATHEXT = originalPathExt;
+  }
   if (originalUnrelatedEnv === undefined) {
     delete process.env.CATALOG_UNRELATED_ENV;
   } else {
@@ -546,6 +555,39 @@ describe("OpenCode session catalog", () => {
     await expect(catalog!.read({ hostId: "node:node-1", threadId: "ses_remote" })).rejects.toThrow(
       "invalid transcript page",
     );
+  });
+
+  it("rejects local session listing when the OpenCode stdout stream fails", async () => {
+    const directory = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-opencode-stream-"));
+    temporaryDirectories.push(directory);
+    const executableName = process.platform === "win32" ? "opencode.js" : "opencode";
+    await fs.writeFile(path.join(directory, executableName), "");
+    process.env.PATH = `${directory}${path.delimiter}${originalPath ?? ""}`;
+    if (process.platform === "win32") {
+      process.env.PATHEXT = `.JS;${originalPathExt ?? ".EXE;.CMD;.BAT;.COM"}`;
+    }
+
+    const stdout = new EventEmitter();
+    const stderr = new EventEmitter();
+    const child = Object.assign(new EventEmitter(), {
+      stdout,
+      stderr,
+      kill: vi.fn(),
+    });
+    const spawn = vi.fn(() => child);
+    vi.resetModules();
+    vi.doMock("node:child_process", () => ({ spawn }));
+    const { listLocalOpenCodeSessionPage: listWithMockedSpawn } = await import(
+      "./session-catalog.js"
+    );
+
+    const listing = listWithMockedSpawn({ limit: 20 });
+    await vi.waitFor(() => expect(spawn).toHaveBeenCalledTimes(1));
+    stdout.emit("error", new Error("stdout EPIPE"));
+    child.emit("close", 0);
+
+    await expect(listing).rejects.toThrow("OpenCode stdout stream failed: stdout EPIPE");
+    expect(child.kill).toHaveBeenCalledWith("SIGKILL");
   });
 
   it("fans out paired-node listing instead of blocking later hosts", async () => {

--- a/extensions/opencode/session-catalog.test.ts
+++ b/extensions/opencode/session-catalog.test.ts
@@ -633,7 +633,9 @@ describe("OpenCode session catalog", () => {
         await expect(listing).rejects.toThrow(
           `OpenCode ${streamName} stream failed: ${streamName} EPIPE`,
         );
-        await new Promise<void>((resolve) => setImmediate(resolve));
+        await new Promise<void>((resolve) => {
+          setImmediate(resolve);
+        });
         expect(uncaughtException).not.toHaveBeenCalled();
         expect(isProcessRunning(child!.pid)).toBe(false);
       } finally {

--- a/extensions/opencode/session-catalog.ts
+++ b/extensions/opencode/session-catalog.ts
@@ -259,8 +259,8 @@ async function runOpenCode(args: string[]): Promise<string> {
     }
     target.push(chunk);
   };
-  child.stdout.on("error", (error) => failFromOutputError("stdout", error));
-  child.stderr.on("error", (error) => failFromOutputError("stderr", error));
+  child.stdout.once("error", (error) => failFromOutputError("stdout", error));
+  child.stderr.once("error", (error) => failFromOutputError("stderr", error));
   child.stdout.on("data", (chunk: Buffer) => collect(stdout, chunk));
   child.stderr.on("data", (chunk: Buffer) => collect(stderr, chunk));
   const exitCode = await new Promise<number | null>((resolve, reject) => {

--- a/extensions/opencode/session-catalog.ts
+++ b/extensions/opencode/session-catalog.ts
@@ -244,6 +244,12 @@ async function runOpenCode(args: string[]): Promise<string> {
   let overflow = false;
   const timeout = setTimeout(() => child.kill("SIGKILL"), CLI_TIMEOUT_MS);
   timeout.unref?.();
+  let outputError: Error | undefined;
+  const failFromOutputError = (source: "stdout" | "stderr", error: unknown) => {
+    const message = error instanceof Error ? error.message : String(error);
+    outputError ??= new Error(`OpenCode ${source} stream failed: ${message}`, { cause: error });
+    child.kill("SIGKILL");
+  };
   const collect = (target: Buffer[], chunk: Buffer) => {
     bytes += chunk.length;
     if (bytes > MAX_CLI_OUTPUT_BYTES) {
@@ -253,6 +259,8 @@ async function runOpenCode(args: string[]): Promise<string> {
     }
     target.push(chunk);
   };
+  child.stdout.on("error", (error) => failFromOutputError("stdout", error));
+  child.stderr.on("error", (error) => failFromOutputError("stderr", error));
   child.stdout.on("data", (chunk: Buffer) => collect(stdout, chunk));
   child.stderr.on("data", (chunk: Buffer) => collect(stderr, chunk));
   const exitCode = await new Promise<number | null>((resolve, reject) => {
@@ -261,6 +269,9 @@ async function runOpenCode(args: string[]): Promise<string> {
   }).finally(() => clearTimeout(timeout));
   if (overflow) {
     throw new Error("OpenCode session output exceeded the safety limit");
+  }
+  if (outputError) {
+    throw outputError;
   }
   if (exitCode !== 0) {
     const detail = Buffer.concat(stderr).toString("utf8").trim();


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users browsing local OpenCode sessions could have the session catalog crash or return incomplete CLI output when the spawned OpenCode process stdout or stderr stream emits an error.

## Why This Change Was Made

The local OpenCode CLI runner now records stdout and stderr stream failures, terminates the child process, and rejects the catalog request instead of relying only on process exit. This stays inside the OpenCode local session-catalog child-process boundary; paired-node catalog reads use node invoke response parsing and do not share this local spawn stream surface.

## User Impact

OpenCode session listing and transcript reads fail cleanly when CLI output streams fail, rather than surfacing an unhandled stream error or partial output.

## Evidence

- Claim proved: local OpenCode session catalog listing rejects a real spawned output-stream failure and terminates the spawned child process instead of returning partial output, throwing an uncaught stream error, or waiting for the 30s CLI timeout.
- Current-head real behavior proof at `c1a19ebb11d7eedf939b5dc382ced710647c2452`: `node_modules\.bin\vitest.cmd run extensions/opencode/session-catalog.real-proof.test.ts --project extension-misc` passed with 1 test file and 1 passed test. The temporary harness exercised production `listLocalOpenCodeSessionPage`, PATH-resolved a real spawned `opencode.js` child process, triggered a redacted stdout pipe failure, and observed rejection with `OpenCode stdout stream failed: redacted real stdout pipe failure` in 574ms, under the 5s guard and well before the 30s timeout.
- Current-head focused regression proof: `node scripts/run-vitest.mjs extensions/opencode/session-catalog.test.ts` passed with 1 test file, 5 passed, and 6 skipped.
- Current-head format proof: `node_modules\.bin\oxfmt.cmd --check extensions\opencode\session-catalog.test.ts` passed.
- Current-head diff hygiene: `git diff --check upstream/main...HEAD` passed.
- Current red-check classification: `Scan changed paths (precise)` failed before scanning because OpenGrep install could not fetch versions from GitHub and no SARIF was produced; no PR-diff finding was emitted for `extensions/opencode/session-catalog.*`.