### PR TITLE
docs(plugin-sdk): refresh generated API hashes

### DIFF
--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-aaab273f4a65e33165556b0a9b35a4de1bebbef4786214de59de9efb32ffb1a3  plugin-sdk-api-baseline.json
-05dc60f0b6a4189a11f6409da696d55c9ee246ae7e89b775f23f6dc4ac874e17  plugin-sdk-api-baseline.jsonl
+308ef1abf94e5d086c0d7fcd048c50eba5b1cd256553e4abf673222037a730eb  plugin-sdk-api-baseline.json
+5e4073d0ab87f9c3d12b5d7a13814503b0f844837cc3dd0d93145c6e9120e417  plugin-sdk-api-baseline.jsonl


### PR DESCRIPTION
## What Problem This Solves

`main`'s tracked Plugin SDK API hash manifest no longer matches the API baselines generated from current source. That makes `pnpm check:changed` fail before it can validate unrelated changes.

## Why This Change Was Made

Refresh the two generated hashes from the canonical baseline generator. The JSON and JSONL baseline payloads are intentionally generated on demand and are not tracked.

## User Impact

No runtime behavior changes. Contributor and maintainer changed-file gates can run past the Plugin SDK baseline check again.

## Evidence

- Blacksmith Testbox `tbx_01kxjjv5fzhfvrafefeaqf6g2w`
- `pnpm check:changed` passed, including `scripts/generate-plugin-sdk-api-baseline.ts --check`
- Fresh autoreview: clean, confidence 0.99
