### PR TITLE
fix(ci): align plugin release workflow proof

### DIFF
--- a/test/scripts/plugin-npm-extended-stable-workflow.test.ts
+++ b/test/scripts/plugin-npm-extended-stable-workflow.test.ts
@@ -357,7 +357,15 @@ describe("plugin npm extended-stable workflow", () => {
     );
     expect(consume.run).toContain("--workflow-jobs-metadata");
     expect(consume.run).toContain("--source-package-json-sha256");
-    expect(consume.run).toContain('[[ "$WORKFLOW_REF" == "refs/heads/main" ]]');
+    expect(consume.run).toContain(
+      '[[ "$WORKFLOW_REF" =~ ^refs/tags/release-publish/([a-f0-9]{12})-[1-9][0-9]*$ ]]',
+    );
+    expect(consume.run).toContain(
+      '[[ "$WORKFLOW_SHA" =~ ^[a-f0-9]{40}$ && "${WORKFLOW_SHA:0:12}" == "$workflow_sha_prefix" ]]',
+    );
+    expect(consume.run).toContain(
+      '[[ "$WORKFLOW_REF" == "refs/heads/main" || "$sha_pinned_release_publish" == "true" ]]',
+    );
     expect(consume.run).toContain('git merge-base --is-ancestor "$WORKFLOW_SHA" origin/main');
     expect(
       step(parsed.jobs?.publish_plugins_npm, "Checkout trusted publication tooling").with?.ref,


### PR DESCRIPTION
## What Problem This Solves

Resolves a CI failure where the plugin extended-stable workflow test still required main-only publication tooling after protected SHA-pinned release-publish tags became valid.

## Why This Change Was Made

The test now proves all parts of the current trust contract: the protected tag shape, the tag-to-workflow-SHA binding, the main-or-validated-tag gate, and the existing main ancestry check.

## User Impact

No runtime impact. CI now verifies the release workflow policy that is already implemented on main.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/plugin-npm-extended-stable-workflow.test.ts` — 9 passed
- `git diff --check`
- Fresh autoreview: clean, 0.97
