### PR TITLE
test(release): align protected publish workflow assertion

### DIFF
--- a/test/scripts/plugin-npm-extended-stable-workflow.test.ts
+++ b/test/scripts/plugin-npm-extended-stable-workflow.test.ts
@@ -357,7 +357,13 @@ describe("plugin npm extended-stable workflow", () => {
     );
     expect(consume.run).toContain("--workflow-jobs-metadata");
     expect(consume.run).toContain("--source-package-json-sha256");
-    expect(consume.run).toContain('[[ "$WORKFLOW_REF" == "refs/heads/main" ]]');
+    expect(consume.run).toContain(
+      '[[ "$WORKFLOW_REF" =~ ^refs/tags/release-publish/([a-f0-9]{12})-[1-9][0-9]*$ ]]',
+    );
+    expect(consume.run).toContain('"${WORKFLOW_SHA:0:12}" == "$workflow_sha_prefix"');
+    expect(consume.run).toContain(
+      '[[ "$WORKFLOW_REF" == "refs/heads/main" || "$sha_pinned_release_publish" == "true" ]]',
+    );
     expect(consume.run).toContain('git merge-base --is-ancestor "$WORKFLOW_SHA" origin/main');
     expect(
       step(parsed.jobs?.publish_plugins_npm, "Checkout trusted publication tooling").with?.ref,


### PR DESCRIPTION
## What Problem This Solves

Repairs the current `main` CI baseline after the protected publish tooling added SHA-pinned `release-publish/*` workflow refs but left the extended-stable workflow test asserting the previous main-only guard.

## Why This Change Was Made

The workflow intentionally accepts either `refs/heads/main` or a protected tag whose 12-character SHA prefix matches the exact workflow SHA. The test now verifies both accepted routes and the SHA-binding check instead of looking for the removed main-only expression.

## User Impact

No runtime behavior changes. The release workflow's existing security contract is accurately covered and the unrelated CI failure blocking small PRs is removed.

AI-assisted. No transcript attached because the originating session contains private infrastructure and credential metadata.

## Evidence

- Blacksmith Testbox `tbx_01kxjk32gyqdqz1k7nzd3m3a9h` ([Actions run 29406126532](https://github.com/openclaw/openclaw/actions/runs/29406126532)): `pnpm test test/scripts/plugin-npm-extended-stable-workflow.test.ts` — 9 tests passed.
- `pnpm exec oxfmt --check test/scripts/plugin-npm-extended-stable-workflow.test.ts` passed.
- `git diff --check` passed.
- Failure reproduced in PR #108205 CI job `checks-node-compact-small-7`: https://github.com/openclaw/openclaw/actions/runs/29405715163/job/87320689399
