### PR TITLE
test(release): cover protected plugin publish refs

### DIFF
--- a/test/scripts/plugin-npm-extended-stable-workflow.test.ts
+++ b/test/scripts/plugin-npm-extended-stable-workflow.test.ts
@@ -357,12 +357,14 @@ describe("plugin npm extended-stable workflow", () => {
     );
     expect(consume.run).toContain("--workflow-jobs-metadata");
     expect(consume.run).toContain("--source-package-json-sha256");
+    expect(consume.run).toContain("sha_pinned_release_publish=false");
     expect(consume.run).toContain(
       '[[ "$WORKFLOW_REF" =~ ^refs/tags/release-publish/([a-f0-9]{12})-[1-9][0-9]*$ ]]',
     );
     expect(consume.run).toContain(
       '[[ "$WORKFLOW_SHA" =~ ^[a-f0-9]{40}$ && "${WORKFLOW_SHA:0:12}" == "$workflow_sha_prefix" ]]',
     );
+    expect(consume.run).toContain("sha_pinned_release_publish=true");
     expect(consume.run).toContain(
       '[[ "$WORKFLOW_REF" == "refs/heads/main" || "$sha_pinned_release_publish" == "true" ]]',
     );


### PR DESCRIPTION
## What Problem This Solves

Main PR #108223 fixed the stale plugin publication workflow fragments after protected `release-publish/*` refs were added. The structural test still did not require the pinned-path flag to initialize fail-closed and become enabled after a valid tag/SHA match.

Context: https://github.com/openclaw/openclaw/pull/108223

## Why This Change Was Made

Add the two missing state-transition assertions: `sha_pinned_release_publish=false` before validation and `sha_pinned_release_publish=true` after the protected tag matches the exact workflow SHA prefix. Existing main assertions continue to cover tag format, SHA binding, the final main-or-pinned gate, and main ancestry.

## User Impact

No product behavior change. Stronger regression coverage for the protected plugin publication path.

## Evidence

- Blacksmith Testbox `tbx_01kxjkv23x5z6teya325b2r8c0`: 1 file, 9 tests passed. https://github.com/openclaw/openclaw/actions/runs/29406923670
- `git diff --check`
- Fresh exact-diff autoreview: clean, confidence 0.98.

No agent transcript included, per maintainer instruction.
