### PR TITLE
fix(memory): use FTS-only when optional embeddings are unavailable

### DIFF
--- a/extensions/memory-core/src/memory/index.test.ts
+++ b/extensions/memory-core/src/memory/index.test.ts
@@ -45,6 +45,7 @@ let providerCloseCalls = 0;
 let providerCloseFailuresRemaining = 0;
 let providerCloseGate: Promise<void> | null = null;
 let providerInitGate: Promise<void> | null = null;
+let providerInitError: Error | null = null;
 let providerCalls: Array<{ provider?: string; model?: string; outputDimensionality?: number }> = [];
 let forceNoProvider = false;
 const originalMemoryIndexStateDir = process.env.OPENCLAW_STATE_DIR;
@@ -132,6 +133,9 @@ vi.mock("./embeddings.js", () => {
         outputDimensionality: options.outputDimensionality,
       });
       await providerInitGate;
+      if (providerInitError) {
+        throw providerInitError;
+      }
       if (forceNoProvider) {
         return {
           provider: null,
@@ -314,6 +318,7 @@ describe("memory index", () => {
     providerCloseFailuresRemaining = 0;
     providerCloseGate = null;
     providerInitGate = null;
+    providerInitError = null;
     providerCalls = [];
     forceNoProvider = false;
 
@@ -593,6 +598,92 @@ describe("memory index", () => {
           chunks: status.chunks,
         },
       ]);
+    } finally {
+      await manager.close?.();
+    }
+  });
+
+  it.each([
+    { label: "missing provider", provider: undefined },
+    { label: "auto provider", provider: "auto" },
+  ])("falls back to FTS-only when optional $label initialization fails", async ({ provider }) => {
+    providerInitError = new Error('No API key found for provider "openai"');
+    const cfg = createCfg({
+      provider,
+      hybrid: { enabled: true, vectorWeight: 0.5, textWeight: 0.5 },
+    });
+    const manager = await getFreshManager(cfg);
+    try {
+      await expect(manager.sync({ reason: "test" })).resolves.toBeUndefined();
+
+      expect(providerCalls.map((call) => call.provider)).toContain("openai");
+      expect(manager.status().custom?.providerState).toMatchObject({
+        mode: "fts-only",
+        attemptedProviderId: "openai",
+      });
+
+      if (manager.status().fts?.available) {
+        const results = await manager.search("alpha");
+        expect(results.length).toBeGreaterThan(0);
+        expect(results[0]?.path).toContain("memory/2026-01-12.md");
+      }
+    } finally {
+      await manager.close?.();
+    }
+  });
+
+  it("uses existing FTS rows when an optional provider becomes unavailable", async () => {
+    const cfg = createCfg({
+      hybrid: { enabled: true, vectorWeight: 0.5, textWeight: 0.5 },
+    });
+    const indexedManager = await getFreshManager(cfg);
+    try {
+      await indexedManager.sync({ reason: "test" });
+      if (!indexedManager.status().fts?.available) {
+        return;
+      }
+    } finally {
+      await indexedManager.close?.();
+    }
+
+    providerCalls = [];
+    providerInitError = new Error('No API key found for provider "openai"');
+    const fallbackManager = await getFreshManager(cfg);
+    try {
+      const results = await fallbackManager.search("alpha");
+
+      expect(providerCalls.map((call) => call.provider)).toContain("openai");
+      expect(results.length).toBeGreaterThan(0);
+      expect(results[0]?.path).toContain("memory/2026-01-12.md");
+      expect(fallbackManager.status().custom?.providerState).toMatchObject({
+        mode: "fts-only",
+        attemptedProviderId: "openai",
+      });
+      expect(fallbackManager.status().custom?.optionalProviderFtsFallback).toMatchObject({
+        enabled: true,
+        mode: "read-only",
+      });
+    } finally {
+      await fallbackManager.close?.();
+    }
+  });
+
+  it("keeps explicit memory embedding providers fail-closed when initialization fails", async () => {
+    providerInitError = new Error('No API key found for provider "openai"');
+    const cfg = createCfg({
+      provider: "openai",
+      hybrid: { enabled: true, vectorWeight: 0.5, textWeight: 0.5 },
+    });
+    const manager = await getFreshManager(cfg);
+    try {
+      await expect(manager.sync({ reason: "test" })).rejects.toThrow(
+        'No API key found for provider "openai"',
+      );
+      expect(providerCalls.map((call) => call.provider)).toContain("openai");
+      expect(manager.status().custom?.providerState).toMatchObject({
+        mode: "pending",
+        requestedProvider: "openai",
+      });
     } finally {
       await manager.close?.();
     }

--- a/extensions/memory-core/src/memory/index.test.ts
+++ b/extensions/memory-core/src/memory/index.test.ts
@@ -604,90 +604,119 @@ describe("memory index", () => {
   });
 
   it.each([
-    { label: "missing provider", provider: undefined },
-    { label: "auto provider", provider: "auto" },
-  ])("falls back to FTS-only when optional $label initialization fails", async ({ provider }) => {
-    providerInitError = new Error('No API key found for provider "openai"');
-    const cfg = createCfg({
-      provider,
-      hybrid: { enabled: true, vectorWeight: 0.5, textWeight: 0.5 },
-    });
-    const manager = await getFreshManager(cfg);
-    try {
-      await expect(manager.sync({ reason: "test" })).resolves.toBeUndefined();
-
-      expect(providerCalls.map((call) => call.provider)).toContain("openai");
-      expect(manager.status().custom?.providerState).toMatchObject({
-        mode: "fts-only",
-        attemptedProviderId: "openai",
+    {
+      failureMode: "returned provider-null",
+      providerLabel: "missing provider",
+      provider: undefined,
+    },
+    { failureMode: "returned provider-null", providerLabel: "auto provider", provider: "auto" },
+    { failureMode: "thrown error", providerLabel: "missing provider", provider: undefined },
+    { failureMode: "thrown error", providerLabel: "auto provider", provider: "auto" },
+  ])(
+    "falls back to FTS-only for optional $providerLabel after a $failureMode result",
+    async ({ failureMode, provider }) => {
+      if (failureMode === "returned provider-null") {
+        forceNoProvider = true;
+      } else {
+        providerInitError = new Error('No API key found for provider "openai"');
+      }
+      const cfg = createCfg({
+        provider,
+        hybrid: { enabled: true, vectorWeight: 0.5, textWeight: 0.5 },
       });
+      const manager = await getFreshManager(cfg);
+      try {
+        await expect(manager.sync({ reason: "test" })).resolves.toBeUndefined();
 
-      if (manager.status().fts?.available) {
-        const results = await manager.search("alpha");
+        expect(providerCalls.map((call) => call.provider)).toContain("openai");
+        expect(manager.status().custom?.providerState).toMatchObject({
+          mode: "fts-only",
+          attemptedProviderId: "openai",
+        });
+
+        if (manager.status().fts?.available) {
+          const results = await manager.search("alpha");
+          expect(results.length).toBeGreaterThan(0);
+          expect(results[0]?.path).toContain("memory/2026-01-12.md");
+        }
+      } finally {
+        await manager.close?.();
+      }
+    },
+  );
+
+  it.each(["returned provider-null", "thrown error"])(
+    "uses existing FTS rows when an optional provider becomes unavailable via a %s",
+    async (failureMode) => {
+      const cfg = createCfg({
+        hybrid: { enabled: true, vectorWeight: 0.5, textWeight: 0.5 },
+      });
+      const indexedManager = await getFreshManager(cfg);
+      try {
+        await indexedManager.sync({ reason: "test" });
+        if (!indexedManager.status().fts?.available) {
+          return;
+        }
+      } finally {
+        await indexedManager.close?.();
+      }
+
+      providerCalls = [];
+      if (failureMode === "returned provider-null") {
+        forceNoProvider = true;
+      } else {
+        providerInitError = new Error('No API key found for provider "openai"');
+      }
+      const fallbackManager = await getFreshManager(cfg);
+      try {
+        const results = await fallbackManager.search("alpha");
+
+        expect(providerCalls.map((call) => call.provider)).toContain("openai");
         expect(results.length).toBeGreaterThan(0);
         expect(results[0]?.path).toContain("memory/2026-01-12.md");
+        expect(fallbackManager.status().custom?.providerState).toMatchObject({
+          mode: "fts-only",
+          attemptedProviderId: "openai",
+        });
+        expect(fallbackManager.status().custom?.optionalProviderFtsFallback).toMatchObject({
+          enabled: true,
+          mode: "read-only",
+        });
+      } finally {
+        await fallbackManager.close?.();
       }
-    } finally {
-      await manager.close?.();
-    }
-  });
+    },
+  );
 
-  it("uses existing FTS rows when an optional provider becomes unavailable", async () => {
-    const cfg = createCfg({
-      hybrid: { enabled: true, vectorWeight: 0.5, textWeight: 0.5 },
-    });
-    const indexedManager = await getFreshManager(cfg);
-    try {
-      await indexedManager.sync({ reason: "test" });
-      if (!indexedManager.status().fts?.available) {
-        return;
+  it.each(["returned provider-null", "thrown error"])(
+    "keeps explicit memory embedding providers fail-closed after a %s",
+    async (failureMode) => {
+      if (failureMode === "returned provider-null") {
+        forceNoProvider = true;
+      } else {
+        providerInitError = new Error('No API key found for provider "openai"');
       }
-    } finally {
-      await indexedManager.close?.();
-    }
-
-    providerCalls = [];
-    providerInitError = new Error('No API key found for provider "openai"');
-    const fallbackManager = await getFreshManager(cfg);
-    try {
-      const results = await fallbackManager.search("alpha");
-
-      expect(providerCalls.map((call) => call.provider)).toContain("openai");
-      expect(results.length).toBeGreaterThan(0);
-      expect(results[0]?.path).toContain("memory/2026-01-12.md");
-      expect(fallbackManager.status().custom?.providerState).toMatchObject({
-        mode: "fts-only",
-        attemptedProviderId: "openai",
+      const cfg = createCfg({
+        provider: "openai",
+        hybrid: { enabled: true, vectorWeight: 0.5, textWeight: 0.5 },
       });
-      expect(fallbackManager.status().custom?.optionalProviderFtsFallback).toMatchObject({
-        enabled: true,
-        mode: "read-only",
-      });
-    } finally {
-      await fallbackManager.close?.();
-    }
-  });
-
-  it("keeps explicit memory embedding providers fail-closed when initialization fails", async () => {
-    providerInitError = new Error('No API key found for provider "openai"');
-    const cfg = createCfg({
-      provider: "openai",
-      hybrid: { enabled: true, vectorWeight: 0.5, textWeight: 0.5 },
-    });
-    const manager = await getFreshManager(cfg);
-    try {
-      await expect(manager.sync({ reason: "test" })).rejects.toThrow(
-        'No API key found for provider "openai"',
-      );
-      expect(providerCalls.map((call) => call.provider)).toContain("openai");
-      expect(manager.status().custom?.providerState).toMatchObject({
-        mode: "pending",
-        requestedProvider: "openai",
-      });
-    } finally {
-      await manager.close?.();
-    }
-  });
+      const manager = await getFreshManager(cfg);
+      try {
+        await expect(manager.sync({ reason: "test" })).rejects.toThrow(
+          failureMode === "returned provider-null"
+            ? 'Memory sync unavailable: embedding provider "openai" is configured but unavailable.'
+            : 'No API key found for provider "openai"',
+        );
+        expect(providerCalls.map((call) => call.provider)).toContain("openai");
+        expect(manager.status().custom?.providerState).toMatchObject({
+          mode: "pending",
+          requestedProvider: "openai",
+        });
+      } finally {
+        await manager.close?.();
+      }
+    },
+  );
 
   it("keeps existing file index rows when chunk publication fails", async () => {
     const cfg = createCfg({});

--- a/extensions/memory-core/src/memory/index.test.ts
+++ b/extensions/memory-core/src/memory/index.test.ts
@@ -1317,30 +1317,6 @@ describe("memory index", () => {
     }
   });
 
-  it("does not search stale provider rows after embeddings become unavailable", async () => {
-    const oldCfg = createCfg({
-      model: "semantic-embed",
-      hybrid: { enabled: true, vectorWeight: 0.5, textWeight: 0.5 },
-    });
-    const oldManager = await getFreshManager(oldCfg);
-    await oldManager.sync({ reason: "test", force: true });
-    await oldManager.close?.();
-
-    forceNoProvider = true;
-    const nextManager = await getFreshManager(oldCfg);
-    try {
-      const results = await nextManager.search("alpha");
-
-      expect(results).toStrictEqual([]);
-      expect(nextManager.status().dirty).toBe(true);
-      expect(nextManager.status().custom?.indexIdentity).toMatchObject({
-        status: "mismatched",
-      });
-    } finally {
-      await nextManager.close?.();
-    }
-  });
-
   it("does not rebuild missing semantic metadata when embeddings are unavailable", async () => {
     const oldCfg = createCfg({
       model: "semantic-embed",

--- a/extensions/memory-core/src/memory/index.test.ts
+++ b/extensions/memory-core/src/memory/index.test.ts
@@ -560,6 +560,7 @@ describe("memory index", () => {
         { reason: "test", force: true },
       ]),
     ).resolves.toBeUndefined();
+    await expect(manager.sync({ reason: "test" })).resolves.toBeUndefined();
   });
 
   async function getFtsSessionManager(params: {

--- a/extensions/memory-core/src/memory/manager-reindex-state.test.ts
+++ b/extensions/memory-core/src/memory/manager-reindex-state.test.ts
@@ -196,6 +196,38 @@ describe("memory reindex state", () => {
     ).toEqual({ status: "valid" });
   });
 
+  it("accepts an FTS-only index without vector dimensions when sqlite-vec is available", () => {
+    expect(
+      resolveMemoryIndexIdentityState(
+        createIdentityParams({
+          provider: null,
+          providerKey: "none",
+          vectorReady: true,
+          meta: createMeta({
+            provider: "none",
+            model: "fts-only",
+            providerKey: "none",
+            vectorDims: undefined,
+          }),
+        }),
+      ),
+    ).toEqual({ status: "valid" });
+  });
+
+  it("still rejects a semantic index without vector dimensions when sqlite-vec is available", () => {
+    expect(
+      resolveMemoryIndexIdentityState(
+        createIdentityParams({
+          vectorReady: true,
+          meta: createMeta({ vectorDims: undefined }),
+        }),
+      ),
+    ).toEqual({
+      status: "mismatched",
+      reason: "index vector dimensions are missing",
+    });
+  });
+
   it("marks identity dirty when extraPaths change", () => {
     const workspaceDir = "/tmp/workspace";
     const firstScopeHash = resolveConfiguredScopeHash({

--- a/extensions/memory-core/src/memory/manager-reindex-state.ts
+++ b/extensions/memory-core/src/memory/manager-reindex-state.ts
@@ -192,7 +192,12 @@ export function resolveMemoryIndexIdentityState(params: {
       reason: "index chunking changed",
     };
   }
-  if (params.vectorReady && params.hasIndexedChunks !== false && !meta.vectorDims) {
+  if (
+    params.provider &&
+    params.vectorReady &&
+    params.hasIndexedChunks !== false &&
+    !meta.vectorDims
+  ) {
     return {
       status: "mismatched",
       reason: "index vector dimensions are missing",

--- a/extensions/memory-core/src/memory/manager-source-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-source-sync-ops.ts
@@ -61,7 +61,7 @@ export abstract class MemoryManagerSourceSyncOps extends MemoryManagerSessionSyn
       `DELETE FROM memory_index_chunks WHERE path = ? AND source = ?`,
     );
     const deleteVectorRowsByPathAndSource =
-      this.vector.enabled && this.vector.available
+      this.vector.enabled && this.vector.available && this.vector.dims
         ? this.db.prepare(
             `DELETE FROM ${VECTOR_TABLE} WHERE id IN (SELECT id FROM memory_index_chunks WHERE path = ? AND source = ?)`,
           )
@@ -191,7 +191,7 @@ export abstract class MemoryManagerSourceSyncOps extends MemoryManagerSessionSyn
       `DELETE FROM memory_index_chunks WHERE path = ? AND source = ?`,
     );
     const deleteVectorRowsByPathAndSource =
-      this.vector.enabled && this.vector.available
+      this.vector.enabled && this.vector.available && this.vector.dims
         ? this.db.prepare(
             `DELETE FROM ${VECTOR_TABLE} WHERE id IN (SELECT id FROM memory_index_chunks WHERE path = ? AND source = ?)`,
           )

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -560,12 +560,28 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     }
     if (!this.providerInitPromise) {
       this.providerInitPromise = (async () => {
-        const providerResult = await MemoryIndexManager.loadProviderResult({
-          cfg: this.cfg,
-          agentId: this.agentId,
-          settings: this.settings,
-          acquireLocalService: this.acquireLocalService,
-        });
+        let providerResult: EmbeddingProviderResult;
+        try {
+          providerResult = await MemoryIndexManager.loadProviderResult({
+            cfg: this.cfg,
+            agentId: this.agentId,
+            settings: this.settings,
+            acquireLocalService: this.acquireLocalService,
+          });
+        } catch (err) {
+          if (this.providerRequirement.mode !== "optional") {
+            throw err;
+          }
+          const reason = formatErrorMessage(err);
+          log.warn(
+            `memory embeddings: optional provider "${this.settings.provider}" unavailable; using FTS-only mode: ${reason}`,
+          );
+          providerResult = {
+            provider: null,
+            requestedProvider: this.settings.provider,
+            providerUnavailableReason: `Optional embedding provider unavailable: ${reason}`,
+          };
+        }
         this.applyProviderResult(providerResult);
         this.providerKey = this.computeProviderKey();
         this.batch = this.resolveBatchConfig();
@@ -688,6 +704,30 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     return state;
   }
 
+  private canSearchExistingSemanticIndexWithFtsOnly(): boolean {
+    if (
+      this.provider ||
+      this.providerRequirement.mode !== "optional" ||
+      !this.providerUnavailableReason?.startsWith("Optional embedding provider unavailable:") ||
+      !this.fts.enabled ||
+      !this.fts.available
+    ) {
+      return false;
+    }
+    const meta = this.readMeta();
+    if (!meta || meta.model === "fts-only" || meta.provider === "none") {
+      return false;
+    }
+    const existingSemanticState = this.resolveCurrentIndexIdentityState({
+      meta,
+      provider: { id: meta.provider, model: meta.model },
+      providerKeyKnown: false,
+      vectorReady: false,
+      hasIndexedChunks: true,
+    });
+    return existingSemanticState.status === "valid";
+  }
+
   async search(
     query: string,
     opts?: {
@@ -763,7 +803,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     const indexIdentity = this.refreshIndexIdentityDirty({
       providerKeyKnown: this.providerInitialized,
     });
-    if (indexIdentity.status !== "valid") {
+    if (indexIdentity.status !== "valid" && !this.canSearchExistingSemanticIndexWithFtsOnly()) {
       return [];
     }
     const minScore = opts?.minScore ?? this.settings.query.minScore;
@@ -1462,6 +1502,11 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
         searchMode: providerInfo.searchMode,
         providerState: this.providerLifecycle,
         providerUnavailableReason: this.providerUnavailableReason,
+        optionalProviderFtsFallback: {
+          enabled: this.canSearchExistingSemanticIndexWithFtsOnly(),
+          mode: "read-only",
+          reason: this.providerUnavailableReason,
+        },
         indexIdentity: this.indexIdentityState,
         readonlyRecovery: {
           attempts: this.readonlyRecoveryAttempts,

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -704,14 +704,17 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     return state;
   }
 
+  private isOptionalProviderUnavailable(): boolean {
+    return (
+      this.providerInitialized &&
+      !this.provider &&
+      this.providerRequirement.mode === "optional" &&
+      this.providerLifecycle.mode === "fts-only"
+    );
+  }
+
   private canSearchExistingSemanticIndexWithFtsOnly(): boolean {
-    if (
-      this.provider ||
-      this.providerRequirement.mode !== "optional" ||
-      !this.providerUnavailableReason?.startsWith("Optional embedding provider unavailable:") ||
-      !this.fts.enabled ||
-      !this.fts.available
-    ) {
+    if (!this.isOptionalProviderUnavailable() || !this.fts.enabled || !this.fts.available) {
       return false;
     }
     const meta = this.readMeta();

--- a/extensions/memory-core/src/tools.test.ts
+++ b/extensions/memory-core/src/tools.test.ts
@@ -1095,6 +1095,91 @@ describe("memory_search unavailable payloads", () => {
     expect(getMemorySyncMockCalls()).toBe(0);
   });
 
+  it("surfaces results from optional-provider FTS fallback even when semantic identity is paused", async () => {
+    setMemorySearchImpl(async () => [
+      {
+        path: "memory/2026-01-12.md",
+        startLine: 1,
+        endLine: 3,
+        score: 0.7,
+        textScore: 0.7,
+        snippet: "Alpha memory line.",
+        source: "memory" as const,
+      },
+    ]);
+    setMemoryCustomStatus({
+      indexIdentity: {
+        status: "mismatched",
+        reason: "index was built for provider mock, expected none",
+      },
+      providerState: {
+        mode: "fts-only",
+        reason: 'Optional embedding provider unavailable: No API key found for provider "openai"',
+      },
+      optionalProviderFtsFallback: {
+        enabled: true,
+        mode: "read-only",
+      },
+    });
+
+    const tool = createMemorySearchToolOrThrow({
+      config: {
+        agents: { list: [{ id: "main", default: true }] },
+        memory: { citations: "off" },
+      },
+    });
+    const result = await tool.execute("optional-provider-fts-fallback", {
+      query: "alpha",
+    });
+    const details = result.details as { results?: Array<{ path: string }> };
+
+    expect(details.results?.map((entry) => entry.path)).toEqual(["memory/2026-01-12.md"]);
+    expect(getMemorySyncMockCalls()).toBe(0);
+  });
+
+  it("returns zero-hit optional-provider FTS fallback searches without forcing sync", async () => {
+    let searchCalls = 0;
+    setMemorySearchImpl(async () => {
+      searchCalls += 1;
+      return [];
+    });
+    setMemoryCustomStatus({
+      indexIdentity: {
+        status: "mismatched",
+        reason: "index was built for model text-embedding-3-small, expected fts-only",
+      },
+      providerState: {
+        mode: "fts-only",
+        reason: 'Optional embedding provider unavailable: No API key found for provider "openai"',
+      },
+      optionalProviderFtsFallback: {
+        enabled: true,
+        mode: "read-only",
+      },
+    });
+
+    const tool = createMemorySearchToolOrThrow({
+      config: {
+        agents: { list: [{ id: "main", default: true }] },
+        memory: { citations: "off" },
+      },
+    });
+    const result = await tool.execute("optional-provider-fts-fallback-zero-hit", {
+      query: "no lexical match",
+    });
+    const details = result.details as {
+      results?: Array<unknown>;
+      unavailable?: boolean;
+      disabled?: boolean;
+    };
+
+    expect(details.results).toEqual([]);
+    expect(details.unavailable).toBeUndefined();
+    expect(details.disabled).toBeUndefined();
+    expect(searchCalls).toBe(1);
+    expect(getMemorySyncMockCalls()).toBe(0);
+  });
+
   it("returns structured search debug metadata for qmd results", async () => {
     setMemoryBackend("qmd");
     setMemorySearchImpl(async (opts) => {

--- a/extensions/memory-core/src/tools.test.ts
+++ b/extensions/memory-core/src/tools.test.ts
@@ -1114,7 +1114,7 @@ describe("memory_search unavailable payloads", () => {
       },
       providerState: {
         mode: "fts-only",
-        reason: 'Optional embedding provider unavailable: No API key found for provider "openai"',
+        reason: 'No API key found for provider "openai"',
       },
       optionalProviderFtsFallback: {
         enabled: true,
@@ -1150,7 +1150,7 @@ describe("memory_search unavailable payloads", () => {
       },
       providerState: {
         mode: "fts-only",
-        reason: 'Optional embedding provider unavailable: No API key found for provider "openai"',
+        reason: 'No API key found for provider "openai"',
       },
       optionalProviderFtsFallback: {
         enabled: true,

--- a/extensions/memory-core/src/tools.ts
+++ b/extensions/memory-core/src/tools.ts
@@ -174,10 +174,26 @@ const PAUSED_MEMORY_INDEX_WARNING =
   "Tell the user: memory search is paused because the memory index was built with a different embedding provider/model/settings.";
 const PAUSED_MEMORY_INDEX_ACTION =
   "Tell the user to run: openclaw memory status --index or openclaw memory index --force.";
+const OPTIONAL_EMBEDDING_PROVIDER_UNAVAILABLE_PREFIX = "Optional embedding provider unavailable:";
+
+function hasOptionalProviderFtsFallback(status: { custom?: unknown }): boolean {
+  const custom = asRecord(status.custom);
+  const providerState = asRecord(custom?.providerState);
+  const fallbackState = asRecord(custom?.optionalProviderFtsFallback);
+  const reason = typeof providerState?.reason === "string" ? providerState.reason.trim() : "";
+  return (
+    providerState?.mode === "fts-only" &&
+    reason.startsWith(OPTIONAL_EMBEDDING_PROVIDER_UNAVAILABLE_PREFIX) &&
+    fallbackState?.enabled === true
+  );
+}
 
 function resolvePausedMemoryIndexIdentityReason(status: { custom?: unknown }): string | undefined {
   const indexIdentity = asRecord(asRecord(status.custom)?.indexIdentity);
   if (indexIdentity?.status !== "mismatched" && indexIdentity?.status !== "missing") {
+    return undefined;
+  }
+  if (hasOptionalProviderFtsFallback(status)) {
     return undefined;
   }
   return typeof indexIdentity.reason === "string" && indexIdentity.reason.trim()
@@ -700,6 +716,7 @@ export function createMemorySearchTool(options: {
                 // retry. Long-lived QMD managers must not run update work in the tool hot path.
                 if (
                   rawResults.length === 0 &&
+                  !hasOptionalProviderFtsFallback(statusBeforeRetry) &&
                   activeMemory.manager.sync &&
                   (statusBeforeRetry.backend !== "qmd" || options.oneShotCliRun === true)
                 ) {

--- a/extensions/memory-core/src/tools.ts
+++ b/extensions/memory-core/src/tools.ts
@@ -174,17 +174,15 @@ const PAUSED_MEMORY_INDEX_WARNING =
   "Tell the user: memory search is paused because the memory index was built with a different embedding provider/model/settings.";
 const PAUSED_MEMORY_INDEX_ACTION =
   "Tell the user to run: openclaw memory status --index or openclaw memory index --force.";
-const OPTIONAL_EMBEDDING_PROVIDER_UNAVAILABLE_PREFIX = "Optional embedding provider unavailable:";
 
 function hasOptionalProviderFtsFallback(status: { custom?: unknown }): boolean {
   const custom = asRecord(status.custom);
   const providerState = asRecord(custom?.providerState);
   const fallbackState = asRecord(custom?.optionalProviderFtsFallback);
-  const reason = typeof providerState?.reason === "string" ? providerState.reason.trim() : "";
   return (
     providerState?.mode === "fts-only" &&
-    reason.startsWith(OPTIONAL_EMBEDDING_PROVIDER_UNAVAILABLE_PREFIX) &&
-    fallbackState?.enabled === true
+    fallbackState?.enabled === true &&
+    fallbackState?.mode === "read-only"
   );
 }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users who did not configure a memory embedding provider could see memory sync/search fail when the default optional embedding provider could not initialize, such as when no OpenAI API key is available.

## Why This Change Was Made

The memory manager already distinguishes explicit embedding providers from optional default/auto providers. This change keeps explicit providers fail-closed, but converts both returned provider-null results and thrown initialization failures for optional providers into the existing typed FTS-only provider state so keyword memory remains available.

It also keeps existing semantic indexes readable through their FTS rows when an optional provider later becomes unavailable. That fallback is read-only for the old semantic index: sync still refuses to downgrade it, and the memory_search tool surfaces both positive and zero-hit FTS fallback searches instead of reporting the index as paused.

The live CLI proof also exposed two fresh-index edge cases that are now covered: an FTS-only index is valid without vector dimensions even when sqlite-vec can load, and later syncs do not prepare vector-table deletes when no vector table exists.

## User Impact

Users can leave `memorySearch.provider` unset or set to `auto` without being required to configure an OpenAI key. Explicit `provider: "openai"` configurations still fail when OpenAI auth is unavailable, so intentional provider requirements remain visible.

## Evidence

Branch refreshed onto `upstream/main` `deccdb5e57`; proof head is `14d20c015b`.

- Final-head focused regression run: 3 files, 145 tests passed
- Final-head `tsgo:extensions`, focused `oxfmt --check`, and `git diff --check`: passed
- Final-head full `pnpm build`: passed
- Full `pnpm check` reached an unrelated upstream baseline guard failure in `extensions/whatsapp/src/inbound/monitor.ts:1592`; this PR does not modify that file, and the direct guard reproduces against the upstream content. All PR-scoped checks pass.
- Current-main private-conversation source scoping is preserved; the focused regression run includes the upstream test that keeps remember-only session transcripts out of ordinary manager searches
- The two isolated real CLI scenarios below were rerun after rebasing the complete memory patch onto current memory-core behavior; the final follow-up refresh added only unrelated browser WebSocket timeout changes from main

### Real CLI: fresh install without embedding credentials

Ran the built `openclaw.mjs` under an isolated `HOME`, `OPENCLAW_STATE_DIR`, config, and workspace. No credential environment variables or host auth files were exposed. `memorySearch.provider` was omitted (the optional default OpenAI path), and the workspace contained one memory file with marker `FRESH_FTS_FALLBACK_108229`.

```text
$ openclaw memory index --force --verbose
[memory] embeddings: optional provider "openai" unavailable; using FTS-only mode: ... | missing-provider-auth
[memory] sync: indexing memory files

$ openclaw memory search FRESH_FTS_FALLBACK_108229 --json
{
  "results": [{
    "path": "MEMORY.md",
    "snippet": "... FRESH_FTS_FALLBACK_108229 ...",
    "source": "memory"
  }]
}

$ openclaw memory status --deep --json
files=1 chunks=1 dirty=false
provider=none requestedProvider=openai
fts.enabled=true fts.available=true
custom.searchMode=fts-only
custom.providerState.mode=fts-only
custom.indexIdentity.status=valid
```

The search completed without a missing-vector-table sync error.

### Real CLI: existing semantic index after credentials disappear

In a second isolated environment, the real OpenAI memory adapter indexed one file against a local OpenAI-compatible HTTP fixture using a proof-only key. The fixture returned 3-dimensional embeddings. Before removing the key, deep status reported `provider=openai`, `model=text-embedding-3-small`, `semanticAvailable=true`, `vector.dims=3`, and a valid index identity.

Then the proof key was removed from config and the HTTP fixture was stopped.

```text
$ openclaw memory status --deep --json
[memory] embeddings: optional provider "openai" unavailable; using FTS-only mode: ... | missing-provider-auth
files=1 chunks=1
provider=none requestedProvider=openai
fts.enabled=true fts.available=true
vector.dims=3 semanticAvailable=false
custom.searchMode=fts-only
custom.providerState.mode=fts-only
custom.optionalProviderFtsFallback.enabled=true
custom.optionalProviderFtsFallback.mode=read-only

$ openclaw memory search EXISTING_SEMANTIC_FTS_108229 --json
[memory] sync failed (search): ... Refusing to run sync in fts-only fallback mode to protect existing vector index (current model: text-embedding-3-small).
{
  "results": [{
    "path": "MEMORY.md",
    "snippet": "... EXISTING_SEMANTIC_FTS_108229 ...",
    "source": "memory"
  }]
}
```

Data-level inspection immediately before and after fallback search/status was unchanged:

```json
{
  "meta": {
    "provider": "openai",
    "model": "text-embedding-3-small",
    "vectorDims": 3
  },
  "chunkModels": [{ "model": "text-embedding-3-small", "count": 1 }],
  "ftsRows": 1,
  "vectorRows": 1
}
```

This demonstrates both the keyword hit and the read-only preservation of the existing semantic index.
