### PR TITLE
fix(ci): intermittent shard failures from spawn starvation on 4vcpu runners

### DIFF
--- a/scripts/lib/ci-node-test-plan.mjs
+++ b/scripts/lib/ci-node-test-plan.mjs
@@ -1381,9 +1381,12 @@ function createCompactNodeTestShardBundles(options = {}) {
         ...(bin.hasWholeConfigGroup
           ? { timeoutMinutes: COMPACT_WHOLE_NODE_TEST_TIMEOUT_MINUTES }
           : {}),
-        // Exclusive bins hold spawn/signal-timing suites; the shard runner
-        // must not overlap them with a concurrent sibling Vitest run.
-        ...(bin.exclusive ? { planConcurrency: 1 } : {}),
+        // 4 vCPU bins run their plans serially: overlapping two Vitest runs
+        // there starves process-spawning tests (worker-startup timeouts in
+        // core-runtime-infra-process, tooling process-group waits), and the
+        // packed weights are contention-inflated so serializing is roughly
+        // wall-neutral. Exclusive spawn/signal bins stay serial everywhere.
+        ...(bin.exclusive || runnerClass === "small" ? { planConcurrency: 1 } : {}),
       });
     }
   }

--- a/test/scripts/ci-node-test-plan.test.ts
+++ b/test/scripts/ci-node-test-plan.test.ts
@@ -204,16 +204,19 @@ describe("scripts/lib/ci-node-test-plan.mjs", () => {
     expect(jobOf("core-unit-fast")).toBeGreaterThanOrEqual(0);
     expect(jobOf("agentic-agents-core-runner-embedded")).not.toBe(jobOf("core-unit-fast"));
     // Spawn/signal-timing suites flake next to a concurrent sibling Vitest
-    // run; their bins must force the shard runner to concurrency 1 and never
-    // mix with regular groups.
+    // run; their bins never mix with regular groups, and every 4 vCPU bin
+    // runs serially because overlapping Vitest runs starve process-spawning
+    // tests on that runner class.
     const exclusiveGroupRe = /^core-tooling(?:-\d+|-isolated|-docker)?$|^core-runtime-tui-pty$/u;
     for (const shard of compact) {
       const exclusiveCount = shard.groups.filter((group) =>
         exclusiveGroupRe.test(group.shard_name),
       ).length;
       if (exclusiveCount > 0) {
-        expect(shard.planConcurrency).toBe(1);
         expect(exclusiveCount).toBe(shard.groups.length);
+      }
+      if (exclusiveCount > 0 || !shard.runner.includes("-8vcpu-")) {
+        expect(shard.planConcurrency).toBe(1);
       } else {
         expect(shard.planConcurrency).toBeUndefined();
       }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where PR CI test shards on 4 vCPU runners intermittently fail with spawn-starvation symptoms after #108091 introduced two-way plan concurrency: `session-accessor.reply-init-concurrency.test.ts` times out with "timeout waiting for concurrency worker startup" (run 29406794118), the sibling plan in the same job stalls past the 120s no-output watchdog, and further small-bin failures recurred across unrelated PRs (runs 29406963332, 29406917233) even after #108171 serialized the tooling suites specifically.

## Why This Change Was Made

Group-by-group exclusive marking (#108171) was whack-a-mole: the flake class is any process-spawning test sharing a 4 vCPU runner with a concurrent Vitest run. The compact planner now emits `planConcurrency: 1` for every bin on the 4 vCPU runner class; 8 vCPU (large) bins keep two-way concurrency, where no starvation has been observed. This is roughly wall-neutral for small bins because their packing weights were measured under contention and are inflated ~40-100% versus solo runtimes — serial execution of the same bins runs near the solo sums.

## User Impact

No product change. Removes the post-#108091 intermittent shard failures on unrelated PRs; large-runner bins keep their concurrency speedup.

## Evidence

- Failure signature on 4 vCPU bins: "timeout waiting for concurrency worker startup" ×3 in `core-runtime-infra-process` while the co-plan (`auto-reply-reply-commands-1`) logs 120-150s no-output stalls in the same job (run 29406794118, job log).
- Solo vs under-contention timings from runs 29392858230 / 29395969440: e.g. `core-runtime-tui-pty` 74s solo vs 150s contended, `core-unit-src-security` 84s vs 149s — the basis for "serial is roughly wall-neutral" on small bins.
- `test/scripts/ci-node-test-plan.test.ts` updated: every 4 vCPU bin asserts `planConcurrency: 1`; 8 vCPU non-exclusive bins stay concurrent.
