### PR TITLE
fix(ios): preserve active chat across foreground reconnects

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -22875,7 +22875,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 3813,
+      "line": 3819,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Approval needed",
       "surface": "apple",
@@ -22883,7 +22883,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 3814,
+      "line": 3820,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Action required",
       "surface": "apple",
@@ -22891,7 +22891,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 4491,
+      "line": 4497,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Connecting...",
       "surface": "apple",
@@ -22899,7 +22899,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 4492,
+      "line": 4498,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Reconnecting...",
       "surface": "apple",
@@ -22907,7 +22907,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 4836,
+      "line": 4842,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Connected",
       "surface": "apple",
@@ -22915,7 +22915,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 4836,
+      "line": 4842,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Offline",
       "surface": "apple",
@@ -22923,7 +22923,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 5978,
+      "line": 5984,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "No chat messages yet",
       "surface": "apple",
@@ -22931,7 +22931,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 6177,
+      "line": 6183,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Connecting…",
       "surface": "apple",
@@ -22939,7 +22939,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 6177,
+      "line": 6183,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Reconnecting…",
       "surface": "apple",
@@ -22947,7 +22947,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 8462,
+      "line": 8468,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Approval",
       "surface": "apple",
@@ -22955,7 +22955,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 8462,
+      "line": 8468,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "This approval was already",
       "surface": "apple",
@@ -22963,7 +22963,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 8468,
+      "line": 8474,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "This approval was already set to Always Allow.",
       "surface": "apple",
@@ -22971,7 +22971,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 8469,
+      "line": 8475,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Approval set to Always Allow.",
       "surface": "apple",
@@ -22979,7 +22979,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 9773,
+      "line": 9779,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "\\(urlText.prefix(500))…",
       "surface": "apple",

--- a/apps/ios/Sources/Model/NodeAppModel.swift
+++ b/apps/ios/Sources/Model/NodeAppModel.swift
@@ -3412,7 +3412,7 @@ extension NodeAppModel {
             nodeOptions: connectOptions)
         let previousGatewayStableID = self.activeGatewayConnectConfig?.effectiveStableID
             ?? self.connectedGatewayID
-        let preserveGatewayProblem = previousGatewayStableID.map {
+        let isSameGatewayTarget = previousGatewayStableID.map {
             !$0.isEmpty && GatewayStableIdentifier.matches($0, effectiveStableID)
         } ?? false
         let targetChanged = previousGatewayStableID.map {
@@ -3449,7 +3449,8 @@ extension NodeAppModel {
         self.activeGatewayConnectConfig = nextConfig
         prepareForGatewayConnect(
             stableID: effectiveStableID,
-            preservingGatewayProblem: preserveGatewayProblem)
+            preservingGatewayProblem: isSameGatewayTarget,
+            preservingFocusedChatSession: isSameGatewayTarget)
         if operatorLoopRequired {
             startOperatorGatewayLoop(
                 url: url,
@@ -3693,7 +3694,8 @@ extension NodeAppModel {
 
     private func prepareForGatewayConnect(
         stableID: String,
-        preservingGatewayProblem: Bool = false)
+        preservingGatewayProblem: Bool = false,
+        preservingFocusedChatSession: Bool = false)
     {
         self.invalidateNodePushToTalkRoute()
         self.operatorTalkConnectionGeneration &+= 1
@@ -3730,7 +3732,11 @@ extension NodeAppModel {
         self.gatewayDefaultAgentId = nil
         self.gatewayAgents = []
         self.selectedAgentId = GatewaySettingsStore.loadGatewaySelectedAgentId(stableID: stableID)
-        self.focusedChatSessionKey = nil
+        // Session keys are gateway-owned: transport reconnects keep the active chat,
+        // while initial connects and target changes must not inherit another route.
+        if !preservingFocusedChatSession {
+            self.focusedChatSessionKey = nil
+        }
         self.synchronizeTalkSessionKey()
         self.homeCanvasRevision &+= 1
         self.apnsLastRegisteredTokenHex = nil

--- a/apps/ios/Tests/GatewayConnectionControllerTests.swift
+++ b/apps/ios/Tests/GatewayConnectionControllerTests.swift
@@ -500,7 +500,7 @@ private func waitForActiveGateway(stableID: String, appModel: NodeAppModel) asyn
         #expect(appModel.gatewayPairingRequestId == nil)
     }
 
-    @Test @MainActor func `same target reconnect preserves focused chat and target switch clears it`() throws {
+    @Test @MainActor func `stable gateway owner preserves focused chat across route changes`() throws {
         let appModel = NodeAppModel()
         defer { appModel.disconnectGateway() }
         let currentConfig = Self.makeGatewayConnectConfig()
@@ -508,10 +508,13 @@ private func waitForActiveGateway(stableID: String, appModel: NodeAppModel) asyn
         appModel.applyGatewayConnectConfig(currentConfig)
         appModel.focusChatSession(focusedSessionKey)
 
-        appModel.applyGatewayConnectConfig(currentConfig, forceReconnect: true)
+        let replacementURL = try #require(URL(string: "wss://127.0.0.1:2"))
+        let refreshedRoute = Self.makeGatewayConnectConfig(
+            url: replacementURL,
+            stableID: currentConfig.stableID)
+        appModel.applyGatewayConnectConfig(refreshedRoute, forceReconnect: true)
         #expect(appModel.chatSessionKey == focusedSessionKey)
 
-        let replacementURL = try #require(URL(string: "wss://replacement.example.com:443"))
         let replacementConfig = Self.makeGatewayConnectConfig(
             url: replacementURL,
             stableID: "manual|replacement.example.com|443")

--- a/apps/ios/Tests/GatewayConnectionControllerTests.swift
+++ b/apps/ios/Tests/GatewayConnectionControllerTests.swift
@@ -500,6 +500,26 @@ private func waitForActiveGateway(stableID: String, appModel: NodeAppModel) asyn
         #expect(appModel.gatewayPairingRequestId == nil)
     }
 
+    @Test @MainActor func `same target reconnect preserves focused chat and target switch clears it`() throws {
+        let appModel = NodeAppModel()
+        defer { appModel.disconnectGateway() }
+        let currentConfig = Self.makeGatewayConnectConfig()
+        let focusedSessionKey = "agent:main:ios-focused"
+        appModel.applyGatewayConnectConfig(currentConfig)
+        appModel.focusChatSession(focusedSessionKey)
+
+        appModel.applyGatewayConnectConfig(currentConfig, forceReconnect: true)
+        #expect(appModel.chatSessionKey == focusedSessionKey)
+
+        let replacementURL = try #require(URL(string: "wss://replacement.example.com:443"))
+        let replacementConfig = Self.makeGatewayConnectConfig(
+            url: replacementURL,
+            stableID: "manual|replacement.example.com|443")
+        appModel.applyGatewayConnectConfig(replacementConfig, forceReconnect: true)
+
+        #expect(appModel.chatSessionKey != focusedSessionKey)
+    }
+
     @Test func `gateway connect config matches equivalent inputs`() {
         let lhs = Self.makeGatewayConnectConfig()
         let rhs = GatewayConnectConfig(
@@ -2537,11 +2557,14 @@ private func waitForActiveGateway(stableID: String, appModel: NodeAppModel) asyn
         defer { appModel.disconnectGateway() }
 
         let config = Self.makeGatewayConnectConfig()
+        let focusedSessionKey = "agent:main:ios-foreground-focused"
         appModel.applyGatewayConnectConfig(config)
+        appModel.focusChatSession(focusedSessionKey)
         await appModel._test_restartGatewaySessionsAfterForegroundStaleConnection()
 
         #expect(appModel.gatewayStatusText == "Reconnecting…")
         #expect(appModel.activeGatewayConnectConfig?.hasSameConnectionInputs(as: config) == true)
+        #expect(appModel.chatSessionKey == focusedSessionKey)
         #expect(appModel._test_hasGatewayLoopTasks().node)
         #expect(appModel._test_hasGatewayLoopTasks().operator)
     }


### PR DESCRIPTION
Related: #108233

## What Problem This Solves

Fixes an issue where iOS users who opened a non-default chat could be returned to the default `main` chat after the app resumed from the background and replaced a stale Gateway connection.

The confirmed failure is loss of the active chat selection during a same-Gateway reconnect. The separate issue claim that reconnecting creates new `ios-<uuid>` sessions is not established by the reconnect path and is intentionally not claimed or changed here.

## Why This Change Was Made

Connection preparation now distinguishes a reconnect to the same stable Gateway target from an initial connection or target switch. Same-target reconnects preserve the focused chat session, while initial connections and Gateway changes continue clearing it so a session key cannot cross Gateway ownership boundaries.

Regression coverage exercises the foreground stale-connection restart directly and verifies both sides of the target boundary: same-target reconnect preserves focus, target replacement clears it.

## User Impact

After locking and reopening the iPhone, users can remain in the chat they were using when the app has to reconnect to the same Gateway. Switching to a different Gateway still starts from that Gateway's own routing state.

## Evidence

- Added focused regression coverage in `GatewayConnectionControllerTests` for foreground stale-connection recovery.
- Added a same-target versus replacement-target regression test.
- `swiftc -frontend -parse` passed for both changed Swift files.
- SwiftFormat 0.62.1: `0/2 files require formatting`.
- `git diff --check` passed.
- CI run [29468004775](https://github.com/openclaw/openclaw/actions/runs/29468004775) passed `native-i18n`, `ios-build`, and `openclaw/ci-gate` on commit `b1538b4d7f0`.
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted --stream-engine-output`: clean, no accepted/actionable findings.
- iOS XCTest and simulator build were not run locally because this machine has only Command Line Tools, not a full Xcode installation. The PR's iOS CI lane remains the required build/test proof.
- SwiftLint could not start for the same reason: SourceKit could not load `sourcekitdInProc.framework` without full Xcode.

AI-assisted: yes. The submitted code and its scope were reviewed before push.