### PR TITLE
fix(ui): sessions page shows stored sessions by default

### DIFF
--- a/ui/src/e2e/session-list-filter.e2e.test.ts
+++ b/ui/src/e2e/session-list-filter.e2e.test.ts
@@ -108,6 +108,103 @@ describeControlUiE2e("Control UI session-list event scope", () => {
     expect(await currentPage.getByText(hiddenLabel, { exact: true }).count()).toBe(0);
   });
 
+  it("keeps older Gateway sessions consistent between the sidebar and Sessions page", async () => {
+    const sessionKey = "agent:main:older-stored";
+    const sessionLabel = "Older stored session";
+    const populatedResponse = {
+      count: 1,
+      defaults: { contextTokens: null, model: null, modelProvider: null },
+      path: "",
+      sessions: [
+        {
+          key: sessionKey,
+          kind: "direct",
+          label: sessionLabel,
+          updatedAt: 1,
+        },
+      ],
+      ts: 1,
+    };
+    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
+    const context = await browser.newContext({ viewport: { height: 800, width: 1200 } });
+    const currentPage = await context.newPage();
+    page = currentPage;
+    const gateway = await installMockGateway(currentPage, {
+      sessionKey: "agent:main:main",
+      methodResponses: {
+        "sessions.list": {
+          cases: [
+            {
+              match: { activeMinutes: 60 },
+              response: {
+                count: 0,
+                defaults: populatedResponse.defaults,
+                path: "",
+                sessions: [],
+                ts: 2,
+              },
+            },
+            { response: populatedResponse },
+          ],
+        },
+      },
+    });
+
+    await currentPage.goto(`${server?.baseUrl ?? ""}chat`);
+    const sidebarRow = currentPage.locator(
+      `.sidebar-recent-session[data-session-key="${sessionKey}"]`,
+    );
+    await sidebarRow.getByText(sessionLabel, { exact: true }).waitFor({ timeout: 10_000 });
+    const sidebarRequests = await gateway.getRequests("sessions.list");
+    const sidebarParams = sidebarRequests.find(
+      (request) =>
+        (request.params as { includeUnknown?: unknown } | undefined)?.includeUnknown === true,
+    )?.params as Record<string, unknown> | undefined;
+    expect(sidebarParams).toMatchObject({ limit: 50 });
+    expect(sidebarParams).not.toHaveProperty("activeMinutes");
+
+    await currentPage.goto(`${server?.baseUrl ?? ""}sessions`);
+    const sessionsPage = currentPage.locator("openclaw-sessions-page");
+    await sessionsPage.getByText(sessionLabel, { exact: true }).waitFor({ timeout: 10_000 });
+    const initialPageRequests = await gateway.getRequests("sessions.list");
+    const initialPageParams = initialPageRequests.find(
+      (request) =>
+        (request.params as { includeUnknown?: unknown } | undefined)?.includeUnknown === false,
+    )?.params as Record<string, unknown> | undefined;
+    expect(initialPageParams).toMatchObject({ limit: 50 });
+    expect(initialPageParams).not.toHaveProperty("activeMinutes");
+
+    const activeMinutes = sessionsPage.getByLabel("Updated within");
+    const limit = sessionsPage.getByLabel("Limit");
+    await expect.poll(() => activeMinutes.inputValue()).toBe("");
+    await expect.poll(() => limit.inputValue()).toBe("50");
+
+    let requestCount = initialPageRequests.length;
+    await activeMinutes.fill("60");
+    await expect
+      .poll(async () => (await gateway.getRequests("sessions.list")).length)
+      .toBeGreaterThan(requestCount);
+    const filteredParams = (await gateway.getRequests("sessions.list")).at(-1)?.params as
+      | Record<string, unknown>
+      | undefined;
+    expect(filteredParams).toMatchObject({ activeMinutes: 60, limit: 50 });
+    await expect.poll(() => sessionsPage.getByText(sessionLabel, { exact: true }).count()).toBe(0);
+
+    requestCount = (await gateway.getRequests("sessions.list")).length;
+    await sessionsPage.getByRole("button", { name: "Show all" }).click();
+    await expect
+      .poll(async () => (await gateway.getRequests("sessions.list")).length)
+      .toBeGreaterThan(requestCount);
+    await sessionsPage.getByText(sessionLabel, { exact: true }).waitFor();
+    const resetParams = (await gateway.getRequests("sessions.list")).at(-1)?.params as
+      | Record<string, unknown>
+      | undefined;
+    expect(resetParams).toMatchObject({ includeUnknown: false, limit: 50 });
+    expect(resetParams).not.toHaveProperty("activeMinutes");
+    await expect.poll(() => activeMinutes.inputValue()).toBe("");
+    await expect.poll(() => limit.inputValue()).toBe("50");
+  });
+
   it("omits noncanonical numeric filters from sessions.list requests", async () => {
     browser = await chromium.launch({ executablePath: chromiumExecutablePath });
     const context = await browser.newContext({ viewport: { height: 800, width: 1200 } });

--- a/ui/src/lib/sessions/index.ts
+++ b/ui/src/lib/sessions/index.ts
@@ -77,6 +77,12 @@ export type SessionListOptions = {
   append?: boolean;
 };
 
+/** Gateway rosters omit recency so Chat and Settings agree.
+ * The explicit cap keeps list work bounded. */
+export const DEFAULT_SESSION_LIST_QUERY = {
+  limit: 50,
+} as const satisfies SessionListOptions;
+
 type SessionRefreshOptions = SessionListOptions & {
   force?: boolean;
   // Sidebar startup hydration must not block session creation or drop the open session.
@@ -281,7 +287,7 @@ function buildSessionListParams(options: SessionListOptions = {}): Record<string
     ...SESSION_LIST_PARAMS,
   };
   if (options.limit === undefined) {
-    params.limit = 50;
+    params.limit = DEFAULT_SESSION_LIST_QUERY.limit;
   } else if (options.limit > 0) {
     params.limit = Math.floor(options.limit);
   }

--- a/ui/src/pages/chat/chat-session.ts
+++ b/ui/src/pages/chat/chat-session.ts
@@ -3,6 +3,7 @@ import { resolveChatModelOverrideValue } from "../../lib/chat/model-select-state
 import { normalizeThinkLevel } from "../../lib/chat/thinking.ts";
 import { isSessionRunActive } from "../../lib/session-run-state.ts";
 import {
+  DEFAULT_SESSION_LIST_QUERY,
   scopedAgentParamsForSession,
   scopedAgentListParamsForRefreshTarget,
   scopedAgentListParamsForSession,
@@ -20,9 +21,6 @@ import { normalizeOptionalString } from "../../lib/string-coerce.ts";
 import type { ChatHistoryResult } from "./chat-history.ts";
 import { getPendingChatPickerPatch, patchChatSessionSettings } from "./chat-settings-patches.ts";
 export { getPendingChatPickerPatch };
-
-const CHAT_SESSION_LIST_ACTIVE_MINUTES = 0;
-const CHAT_SESSION_LIST_LIMIT = 50;
 
 type ChatSessionListHost = {
   sessionsShowArchived?: boolean;
@@ -60,8 +58,7 @@ function buildChatSessionListOptions(
   options: { offset?: number; append?: boolean; search?: string | null } = {},
 ): SessionListOptions {
   const result: SessionListOptions = {
-    activeMinutes: CHAT_SESSION_LIST_ACTIVE_MINUTES,
-    limit: CHAT_SESSION_LIST_LIMIT,
+    ...DEFAULT_SESSION_LIST_QUERY,
     includeGlobal: true,
     includeUnknown: true,
     configuredAgentsOnly: true,

--- a/ui/src/pages/route-provenance.test.ts
+++ b/ui/src/pages/route-provenance.test.ts
@@ -118,6 +118,25 @@ describe("route preload gateway provenance", () => {
     expect(data.gatewaySnapshot).toBe(originalSnapshot);
   });
 
+  it("preloads a bounded session roster without an implicit recency filter", async () => {
+    const list = vi.fn(async (_options: unknown) => null);
+    await loadRoute<SessionsRouteData>(sessionsPage, {
+      gateway: mutableGateway(snapshot(null, false)).gateway,
+      sessions: { list },
+      runtimeConfig: { ensureLoaded: vi.fn(async () => undefined) },
+      agentSelection: { state: { selectedId: null, scopeId: null } },
+    } as unknown as ApplicationContext);
+
+    expect(list).toHaveBeenCalledWith({
+      limit: 50,
+      search: undefined,
+      includeGlobal: true,
+      includeUnknown: false,
+      showArchived: false,
+    });
+    expect(list.mock.calls[0]?.[0]).not.toHaveProperty("activeMinutes");
+  });
+
   it("keeps usage provenance from before its async preload", async () => {
     const client = {
       request: vi.fn(async () => ({})),

--- a/ui/src/pages/sessions/route.ts
+++ b/ui/src/pages/sessions/route.ts
@@ -2,6 +2,7 @@ import type { RouteLocation } from "@openclaw/uirouter";
 import { definePage } from "@openclaw/uirouter";
 import { html } from "lit";
 import type { ApplicationContext } from "../../app/context.ts";
+import { DEFAULT_SESSION_LIST_QUERY } from "../../lib/sessions/index.ts";
 import { parseAgentSessionKey } from "../../lib/sessions/session-key.ts";
 import type { SessionsRouteData } from "./sessions-page.ts";
 
@@ -24,8 +25,7 @@ async function loadSessionsRoute(
   const [sessions] = await Promise.all([
     context.sessions
       .list({
-        activeMinutes: options.expandedSessionKey || options.showArchived ? 0 : 60,
-        limit: 50,
+        ...DEFAULT_SESSION_LIST_QUERY,
         search: options.expandedSessionKey ?? undefined,
         includeGlobal: true,
         includeUnknown: Boolean(options.expandedSessionKey),

--- a/ui/src/pages/sessions/sessions-page.ts
+++ b/ui/src/pages/sessions/sessions-page.ts
@@ -21,6 +21,7 @@ import { isGatewayMethodAdvertised } from "../../lib/gateway-methods.ts";
 import { isWorkboardEnabledInConfigSnapshot } from "../../lib/plugin-activation.ts";
 import type { SessionsGroupBy } from "../../lib/sessions/grouping.ts";
 import {
+  DEFAULT_SESSION_LIST_QUERY,
   filterSessionRows,
   scopedAgentParamsForSession,
   searchForSession,
@@ -73,8 +74,8 @@ class SessionsPage extends OpenClawLightDomElement {
   @state() private result: SessionsListResult | null = null;
   @state() private loading = false;
   @state() private error: string | null = null;
-  @state() private activeMinutes = "60";
-  @state() private limit = "50";
+  @state() private activeMinutes = "";
+  @state() private limit = String(DEFAULT_SESSION_LIST_QUERY.limit);
   @state() private includeGlobal = true;
   @state() private includeUnknown = false;
   @state() private showArchived = false;
@@ -332,15 +333,15 @@ class SessionsPage extends OpenClawLightDomElement {
     this.showArchived = data.showArchived;
     if (data.expandedSessionKey) {
       this.activeMinutes = "";
-      this.limit = "";
+      this.limit = String(DEFAULT_SESSION_LIST_QUERY.limit);
       this.includeGlobal = true;
       this.includeUnknown = true;
       this.searchQuery = "";
       this.page = 0;
       this.selectedKeys = new Set();
     } else {
-      this.activeMinutes = "60";
-      this.limit = "50";
+      this.activeMinutes = "";
+      this.limit = String(DEFAULT_SESSION_LIST_QUERY.limit);
       this.includeGlobal = true;
       this.includeUnknown = false;
     }
@@ -421,8 +422,9 @@ class SessionsPage extends OpenClawLightDomElement {
     const deepLinkKey = this.deepLinkSessionKey;
     const scopeAgentId = this.context?.agentSelection.state.scopeId ?? undefined;
     return {
-      activeMinutes: deepLinkKey || this.showArchived ? 0 : parseFilterInteger(this.activeMinutes),
-      limit: deepLinkKey ? 50 : parseFilterInteger(this.limit),
+      activeMinutes:
+        deepLinkKey || this.showArchived ? undefined : parseFilterInteger(this.activeMinutes),
+      limit: deepLinkKey ? DEFAULT_SESSION_LIST_QUERY.limit : parseFilterInteger(this.limit),
       search: deepLinkKey ?? undefined,
       includeGlobal: deepLinkKey ? true : this.includeGlobal,
       includeUnknown: deepLinkKey ? true : this.includeUnknown,
@@ -1144,9 +1146,9 @@ class SessionsPage extends OpenClawLightDomElement {
           onFiltersChange: (next) => this.updateFilters(next),
           onClearFilters: () => {
             this.activeMinutes = "";
-            this.limit = "";
+            this.limit = String(DEFAULT_SESSION_LIST_QUERY.limit);
             this.includeGlobal = true;
-            this.includeUnknown = true;
+            this.includeUnknown = false;
             this.showArchived = false;
             this.searchQuery = "";
             this.page = 0;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users opening Settings → Sessions could see zero sessions when every stored Gateway session was older than 60 minutes, even though the chat sidebar showed those same valid sessions.

## Why This Change Was Made

The chat sidebar and Sessions page now share one bounded Gateway roster default: no implicit recency filter and a limit of 50. The Sessions page starts with a blank “Updated within” field, its reset action restores that same contract, and explicit recency filters still work. External Codex/Claude session catalogs are unchanged.

## User Impact

Stored Gateway sessions remain discoverable from both the sidebar and Settings → Sessions instead of disappearing from one surface based on an invisible default window.

## Evidence

- Before fix: the focused browser regression failed because the older session appeared in Chat but not on Sessions ([Testbox run](https://github.com/openclaw/openclaw/actions/runs/29401877157)).
- After fix on base `b4d82f47299b12b2ffe6c0a9fb4146c8700854a1`, Blacksmith Testbox `tbx_01kxjmrps8qevmqdm61dgna328` ([run](https://github.com/openclaw/openclaw/actions/runs/29407876630)):
  - 55/55 focused Vitest tests passed.
  - 3/3 Control UI Playwright E2E tests passed, including sidebar → Sessions consistency, explicit recency filtering, and reset.
  - `pnpm check:changed` passed all selected guards, formatting, i18n, core/UI typechecks, and lint with 0 warnings/errors.
- Fresh autoreview reported no accepted/actionable findings.
- Real AWS Crabbox `cbx_9364a9bffd91` ([Gateway setup run](https://crabbox.openclaw.ai/portal/runs/run_b6a2498d7ade), [deterministic age-fixture run](https://crabbox.openclaw.ai/portal/runs/run_244cc52f4e12)):
  - Built the actual Control UI and started the real Gateway from this PR head.
  - Created `main` and `older-stored` through `openclaw agent --local`. A deterministic local mock served only the model response.
  - For a bounded exact reproduction, the isolated Crabbox session metadata was backdated through the current production session accessor; both rows then reported 120 minutes old. No live/user session data was used.
  - The chat sidebar showed both stored keys.
  - Initial Settings → Sessions load showed the same two rows as “2h ago”, with a blank “Updated within” value and limit 50.
  - Entering the previous implicit default of `60` showed zero rows; “Show all” cleared it and restored both two-hour-old rows.
  - Desktop recordings and sidebar/default/filter/reset screenshots were captured from that live Gateway flow.
