### PR TITLE
fix(xai): release realtime reconnect delay on close

### DIFF
--- a/extensions/xai/realtime-voice-bridge.ts
+++ b/extensions/xai/realtime-voice-bridge.ts
@@ -8,6 +8,7 @@ import type {
   RealtimeVoiceBridge,
   RealtimeVoiceToolResultOptions,
 } from "openclaw/plugin-sdk/realtime-voice";
+import { sleepWithAbort } from "openclaw/plugin-sdk/runtime-env";
 import WebSocket from "ws";
 import {
   XAI_REALTIME_BASE_RECONNECT_DELAY_MS,
@@ -43,9 +44,13 @@ export class XaiRealtimeVoiceBridge extends XaiRealtimeVoiceEvents implements Re
   private connectionUrl = "";
   private readonly flowId = randomUUID();
   private sessionReadyFired = false;
+  private reconnectAbortController = new AbortController();
 
   async connect(): Promise<void> {
     this.intentionallyClosed = false;
+    if (this.reconnectAbortController.signal.aborted) {
+      this.reconnectAbortController = new AbortController();
+    }
     this.reconnectAttempts = 0;
     await this.doConnect();
   }
@@ -107,6 +112,9 @@ export class XaiRealtimeVoiceBridge extends XaiRealtimeVoiceEvents implements Re
 
   close(): void {
     this.intentionallyClosed = true;
+    // The bridge owns both its active socket and reconnect delay; canceling
+    // both keeps terminal close from retaining callbacks for the full backoff.
+    this.reconnectAbortController.abort();
     this.connected = false;
     this.sessionConfigured = false;
     this.pendingToolResultAcks.clear();
@@ -315,9 +323,15 @@ export class XaiRealtimeVoiceBridge extends XaiRealtimeVoiceEvents implements Re
       type: "session.reconnect.scheduled",
       detail: `reason=${reason} attempt=${attempt} delayMs=${delay}`,
     });
-    await new Promise((resolve) => {
-      setTimeout(resolve, delay);
-    });
+    const reconnectSignal = this.reconnectAbortController.signal;
+    try {
+      await sleepWithAbort(delay, reconnectSignal);
+    } catch (error) {
+      if (!reconnectSignal.aborted) {
+        throw error;
+      }
+      return;
+    }
     if (this.intentionallyClosed) {
       return;
     }

--- a/extensions/xai/realtime-voice-provider.test.ts
+++ b/extensions/xai/realtime-voice-provider.test.ts
@@ -1580,6 +1580,48 @@ describe("buildXaiRealtimeVoiceProvider", () => {
     expect(onReady).toHaveBeenCalledOnce();
   });
 
+  it("cancels a pending reconnect when the bridge closes", async () => {
+    vi.useFakeTimers();
+    resolveApiKeyForProviderMock.mockResolvedValueOnce({ apiKey: ["xai", "test"].join("-") });
+    const provider = buildXaiRealtimeVoiceProvider();
+    const onError = vi.fn();
+    const onClose = vi.fn();
+    const bridge = provider.createBridge({
+      providerConfig: { sessionResumption: true },
+      onAudio: vi.fn(),
+      onClearAudio: vi.fn(),
+      onError,
+      onClose,
+    });
+
+    const connecting = bridge.connect();
+    await vi.waitFor(() => expect(FakeWebSocket.instances.length).toBe(1));
+    const firstSocket = requireSocket();
+    firstSocket.readyState = FakeWebSocket.OPEN;
+    firstSocket.emit("open");
+    firstSocket.emit(
+      "message",
+      Buffer.from(
+        JSON.stringify({ type: "conversation.created", conversation: { id: "conv_close" } }),
+      ),
+    );
+    firstSocket.emit("message", Buffer.from(JSON.stringify({ type: "session.updated" })));
+    await connecting;
+
+    firstSocket.close(1006, "connection lost");
+    await vi.advanceTimersByTimeAsync(0);
+    expect(vi.getTimerCount()).toBe(1);
+
+    bridge.close();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(vi.getTimerCount()).toBe(0);
+    expect(FakeWebSocket.instances).toHaveLength(1);
+    expect(onError).not.toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledWith("completed");
+  });
+
   it("enables xAI session resumption and reconnects with the created conversation id", async () => {
     vi.useFakeTimers();
     vi.stubEnv("XAI_API_KEY", "xai-env"); // pragma: allowlist secret

--- a/extensions/xai/realtime-voice-provider.test.ts
+++ b/extensions/xai/realtime-voice-provider.test.ts
@@ -1580,18 +1580,16 @@ describe("buildXaiRealtimeVoiceProvider", () => {
     expect(onReady).toHaveBeenCalledOnce();
   });
 
-  it("cancels a pending reconnect when the bridge closes", async () => {
+  it("cancels a pending reconnect and allows a later explicit connect", async () => {
     vi.useFakeTimers();
-    resolveApiKeyForProviderMock.mockResolvedValueOnce({ apiKey: ["xai", "test"].join("-") });
+    resolveApiKeyForProviderMock.mockResolvedValue({ apiKey: ["xai", "test"].join("-") });
     const provider = buildXaiRealtimeVoiceProvider();
     const onError = vi.fn();
-    const onClose = vi.fn();
     const bridge = provider.createBridge({
       providerConfig: { sessionResumption: true },
       onAudio: vi.fn(),
       onClearAudio: vi.fn(),
       onError,
-      onClose,
     });
 
     const connecting = bridge.connect();
@@ -1618,8 +1616,19 @@ describe("buildXaiRealtimeVoiceProvider", () => {
     expect(vi.getTimerCount()).toBe(0);
     expect(FakeWebSocket.instances).toHaveLength(1);
     expect(onError).not.toHaveBeenCalled();
-    expect(onClose).toHaveBeenCalledTimes(1);
-    expect(onClose).toHaveBeenCalledWith("completed");
+
+    const reconnecting = bridge.connect();
+    await vi.waitFor(() => expect(FakeWebSocket.instances.length).toBe(2));
+    const reconnectedSocket = requireSocket(1);
+    reconnectedSocket.readyState = FakeWebSocket.OPEN;
+    reconnectedSocket.emit("open");
+    reconnectedSocket.emit("message", Buffer.from(JSON.stringify({ type: "session.updated" })));
+    await reconnecting;
+
+    expect(bridge.isConnected()).toBe(true);
+    expect(FakeWebSocket.instances).toHaveLength(2);
+    expect(onError).not.toHaveBeenCalled();
+    bridge.close();
   });
 
   it("enables xAI session resumption and reconnects with the created conversation id", async () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where closing an xAI realtime voice bridge during a reconnect backoff left asynchronous work alive until the full 1/2/4/8/16-second delay expired. Provider teardown could therefore retain the bridge, resumed conversation state, and callbacks after the caller had closed it.

## Why This Change Was Made

The xAI bridge now owns an abortable reconnect delay and cancels it together with the active socket on `close()`. Normal resumable websocket reconnects keep the existing conversation-id guards and exponential schedule, so the change is limited to terminal bridge teardown.

## User Impact

xAI realtime voice sessions now finish teardown promptly when closed during reconnect backoff, without retaining the session until the scheduled delay expires or opening a replacement socket.

## Evidence

Real behavior proof on Linux 6.8.0-134-generic x86_64 with Node v24.18.0. I drove the exported `buildXaiRealtimeVoiceProvider().createBridge()` production path through a real localhost TCP/WebSocket server; the only substituted boundary was the upstream xAI endpoint. The server accepted a session update, returned a real `conversation.created` id plus `session.updated`, terminated the socket to enter the production resumable reconnect scheduler, and the public `bridge.close()` ran 20ms into the one-second backoff.

The same temporary harness against current `upstream/main` reproduced the retained timer. The bridge made one connection and emitted no errors, but the process could not drain until the remaining backoff elapsed:

```text
$ /usr/bin/time -f 'wall=%e' node --import tsx .tmp-xai-reconnect-proof.ts cancel
{"mode":"cancel","connections":1,"reconnectElapsedMs":21,"errors":[],"activeResourcesAfterClose":["PipeWrap","PipeWrap","TCPServerWrap","Timeout"]}
{"mode":"cancel","retainedAfterCloseMs":979,"connections":1}
```

Against this branch, the same production path drained immediately after close and still created only one connection:

```text
$ /usr/bin/time -f 'wall=%e' node --import tsx .tmp-xai-reconnect-proof.ts cancel
{"mode":"cancel","connections":1,"reconnectElapsedMs":20,"errors":[],"activeResourcesAfterClose":["PipeWrap","PipeWrap","TCPServerWrap"]}
{"mode":"cancel","retainedAfterCloseMs":2,"connections":1}
```

Negative control: without calling `close()` during backoff, the same server observed the normal reconnect after the configured first delay, including the resumed conversation id in the second connection URL:

```text
$ /usr/bin/time -f 'wall=%e' node --import tsx .tmp-xai-reconnect-proof.ts normal
{"mode":"normal","connections":2,"reconnectElapsedMs":1003,"errors":[],"activeResourcesAfterClose":["PipeWrap","PipeWrap","TCPServerWrap","TCPSocketWrap","Timeout","Timeout"]}
{"mode":"normal","retainedAfterCloseMs":1,"connections":2}
```

The abort premise was verified in the public plugin SDK implementation: `sleepWithAbort` clears its timer and abort listener before rejecting, and the bridge catches only its own aborted reconnect signal.

Focused regression suite and local static checks:

```text
$ node scripts/run-vitest.mjs extensions/xai/realtime-voice-provider.test.ts
Test Files  1 passed (1)
Tests       36 passed (36)

$ ./node_modules/.bin/oxlint extensions/xai/realtime-voice-bridge.ts extensions/xai/realtime-voice-provider.test.ts
$ git diff --check
```

Structured review:

```text
$ .agents/skills/autoreview/scripts/autoreview --mode uncommitted --stream-engine-output
autoreview clean: no accepted/actionable findings reported
overall: patch is correct (0.91)
```

Full repository checks were left to GitHub Actions. No live credentialed xAI audio round-trip was run; the affected behavior is local bridge teardown after a real WebSocket disconnect, before provider-specific audio response processing.

AI-assisted: Codex helped implement and review the patch; the real WebSocket proof and focused validation above were run on the contributor machine.
