### PR TITLE
fix(agents): keep continuation bootstrap marker across short reads

### DIFF
--- a/src/agents/bootstrap-files.test.ts
+++ b/src/agents/bootstrap-files.test.ts
@@ -3,7 +3,7 @@ import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   clearInternalHooks,
   registerInternalHook,
@@ -495,6 +495,7 @@ describe("hasCompletedBootstrapTurn", () => {
   });
 
   afterEach(async () => {
+    vi.restoreAllMocks();
     await fs.rm(tmpDir, { recursive: true, force: true });
   });
 
@@ -637,6 +638,37 @@ describe("hasCompletedBootstrapTurn", () => {
       ].join("\n") + "\n",
       "utf8",
     );
+    expect(await hasCompletedBootstrapTurn(sessionFile)).toBe(true);
+  });
+
+  it("finds a recent full bootstrap marker when the tail read returns short", async () => {
+    const sessionFile = path.join(tmpDir, "short-read-tail.jsonl");
+    const lines = [
+      JSON.stringify({ type: "message", message: { role: "user", content: "hello" } }),
+      JSON.stringify({ type: "message", message: { role: "assistant", content: "hi" } }),
+      JSON.stringify({
+        type: "custom",
+        customType: FULL_BOOTSTRAP_COMPLETED_CUSTOM_TYPE,
+        data: { timestamp: 1 },
+      }),
+    ];
+    await fs.writeFile(sessionFile, `${lines.join("\n")}\n`, "utf8");
+
+    const realOpen = fs.open.bind(fs);
+    vi.spyOn(fs, "open").mockImplementation(async (...args) => {
+      const handle = await realOpen(...args);
+      const realRead = handle.read.bind(handle);
+      return new Proxy(handle, {
+        get(target, prop, receiver) {
+          if (prop === "read") {
+            return (buffer: Buffer, offset: number, length: number, position: number) =>
+              realRead(buffer, offset, Math.min(length, 16), position);
+          }
+          return Reflect.get(target, prop, receiver);
+        },
+      });
+    });
+
     expect(await hasCompletedBootstrapTurn(sessionFile)).toBe(true);
   });
 

--- a/src/agents/bootstrap-files.ts
+++ b/src/agents/bootstrap-files.ts
@@ -8,6 +8,7 @@ import { normalizeOptionalString } from "@openclaw/normalization-core/string-coe
 import { parseSqliteSessionFileMarker } from "../config/sessions/sqlite-marker.js";
 import type { AgentContextInjection } from "../config/types.agent-defaults.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { readFileWindowFully } from "../infra/file-read.js";
 import { resolveUserPath } from "../utils.js";
 import { resolveAgentConfig, resolveSessionAgentIds } from "./agent-scope.js";
 import { getOrLoadBootstrapFiles } from "./bootstrap-cache.js";
@@ -37,7 +38,6 @@ export const FULL_BOOTSTRAP_COMPLETED_CUSTOM_TYPE = "openclaw:bootstrap-context:
 const BOOTSTRAP_WARNING_DEDUPE_LIMIT = 1024;
 const seenBootstrapWarnings = new Set<string>();
 const bootstrapWarningOrder: string[] = [];
-type BootstrapSessionFileHandle = Awaited<ReturnType<typeof fs.open>>;
 
 function rememberBootstrapWarning(key: string): boolean {
   // Warning keys include workspace/session/message so repeated setup failures
@@ -69,27 +69,6 @@ export function resolveContextInjectionMode(
   return config?.agents?.defaults?.contextInjection ?? "always";
 }
 
-async function readBootstrapTailWindowFully(
-  fh: BootstrapSessionFileHandle,
-  buffer: Buffer,
-  position: number,
-): Promise<number> {
-  let totalRead = 0;
-  while (totalRead < buffer.length) {
-    const { bytesRead } = await fh.read(
-      buffer,
-      totalRead,
-      buffer.length - totalRead,
-      position + totalRead,
-    );
-    if (bytesRead <= 0) {
-      break;
-    }
-    totalRead += bytesRead;
-  }
-  return totalRead;
-}
-
 /** Checks whether the session transcript still has a valid full-bootstrap marker. */
 export async function hasCompletedBootstrapTurn(sessionFile: string): Promise<boolean> {
   if (parseSqliteSessionFileMarker(sessionFile)) {
@@ -109,7 +88,7 @@ export async function hasCompletedBootstrapTurn(sessionFile: string): Promise<bo
       }
       const start = stat.size - bytesToRead;
       const buffer = Buffer.allocUnsafe(bytesToRead);
-      const bytesRead = await readBootstrapTailWindowFully(fh, buffer, start);
+      const bytesRead = await readFileWindowFully(fh, buffer, start);
       let text = buffer.toString("utf-8", 0, bytesRead);
       if (start > 0) {
         const firstNewline = text.indexOf("\n");

--- a/src/agents/bootstrap-files.ts
+++ b/src/agents/bootstrap-files.ts
@@ -37,6 +37,7 @@ export const FULL_BOOTSTRAP_COMPLETED_CUSTOM_TYPE = "openclaw:bootstrap-context:
 const BOOTSTRAP_WARNING_DEDUPE_LIMIT = 1024;
 const seenBootstrapWarnings = new Set<string>();
 const bootstrapWarningOrder: string[] = [];
+type BootstrapSessionFileHandle = Awaited<ReturnType<typeof fs.open>>;
 
 function rememberBootstrapWarning(key: string): boolean {
   // Warning keys include workspace/session/message so repeated setup failures
@@ -68,6 +69,27 @@ export function resolveContextInjectionMode(
   return config?.agents?.defaults?.contextInjection ?? "always";
 }
 
+async function readBootstrapTailWindowFully(
+  fh: BootstrapSessionFileHandle,
+  buffer: Buffer,
+  position: number,
+): Promise<number> {
+  let totalRead = 0;
+  while (totalRead < buffer.length) {
+    const { bytesRead } = await fh.read(
+      buffer,
+      totalRead,
+      buffer.length - totalRead,
+      position + totalRead,
+    );
+    if (bytesRead <= 0) {
+      break;
+    }
+    totalRead += bytesRead;
+  }
+  return totalRead;
+}
+
 /** Checks whether the session transcript still has a valid full-bootstrap marker. */
 export async function hasCompletedBootstrapTurn(sessionFile: string): Promise<boolean> {
   if (parseSqliteSessionFileMarker(sessionFile)) {
@@ -87,7 +109,7 @@ export async function hasCompletedBootstrapTurn(sessionFile: string): Promise<bo
       }
       const start = stat.size - bytesToRead;
       const buffer = Buffer.allocUnsafe(bytesToRead);
-      const { bytesRead } = await fh.read(buffer, 0, bytesToRead, start);
+      const bytesRead = await readBootstrapTailWindowFully(fh, buffer, start);
       let text = buffer.toString("utf-8", 0, bytesRead);
       if (start > 0) {
         const firstNewline = text.indexOf("\n");

--- a/src/commands/channels/logs.ts
+++ b/src/commands/channels/logs.ts
@@ -3,9 +3,10 @@ import fs from "node:fs/promises";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { theme } from "../../../packages/terminal-core/src/theme.js";
 import { normalizeChannelId as normalizeBundledChannelId } from "../../channels/registry.js";
+import { readFileWindowFully } from "../../infra/file-read.js";
 import { parseStrictPositiveInteger } from "../../infra/parse-finite-number.js";
 import { getResolvedLoggerSettings } from "../../logging.js";
-import { readLogWindowFully, resolveLogFile } from "../../logging/log-tail.js";
+import { resolveLogFile } from "../../logging/log-tail.js";
 import { parseLogLine } from "../../logging/parse-log-line.js";
 import { listManifestChannelContributionIds } from "../../plugins/manifest-contribution-ids.js";
 import { defaultRuntime, type RuntimeEnv, writeRuntimeJson } from "../../runtime.js";
@@ -87,7 +88,7 @@ async function readTailLines(file: string, limit: number): Promise<string[]> {
       return [];
     }
     const buffer = Buffer.alloc(length);
-    const bytesRead = await readLogWindowFully(handle, buffer, start);
+    const bytesRead = await readFileWindowFully(handle, buffer, start);
     const text = buffer.toString("utf8", 0, bytesRead);
     let lines = text.split("\n");
     if (start > 0 && prefix !== "\n") {

--- a/src/infra/file-read.ts
+++ b/src/infra/file-read.ts
@@ -1,0 +1,23 @@
+import type { FileHandle } from "node:fs/promises";
+
+/** Fills a bounded positional-read buffer unless the file reaches EOF. */
+export async function readFileWindowFully(
+  handle: FileHandle,
+  buffer: Buffer,
+  position: number,
+): Promise<number> {
+  let bytesRead = 0;
+  while (bytesRead < buffer.length) {
+    const result = await handle.read(
+      buffer,
+      bytesRead,
+      buffer.length - bytesRead,
+      position + bytesRead,
+    );
+    if (result.bytesRead === 0) {
+      break;
+    }
+    bytesRead += result.bytesRead;
+  }
+  return bytesRead;
+}

--- a/src/logging/log-tail.ts
+++ b/src/logging/log-tail.ts
@@ -1,6 +1,7 @@
 // Log tail helpers read recent log lines with optional parsing and redaction.
-import fs, { type FileHandle } from "node:fs/promises";
+import fs from "node:fs/promises";
 import path from "node:path";
+import { readFileWindowFully } from "../infra/file-read.js";
 import { getResolvedLoggerSettings } from "../logging.js";
 import { clamp } from "../utils.js";
 import { redactSensitiveLines, resolveRedactOptions } from "./redact.js";
@@ -24,28 +25,6 @@ export type LogTailPayload = {
 
 function isRollingLogFile(file: string): boolean {
   return ROLLING_LOG_RE.test(path.basename(file));
-}
-
-/** Fills a bounded positional-read buffer unless the file reaches EOF. */
-export async function readLogWindowFully(
-  handle: FileHandle,
-  buffer: Buffer,
-  position: number,
-): Promise<number> {
-  let bytesRead = 0;
-  while (bytesRead < buffer.length) {
-    const result = await handle.read(
-      buffer,
-      bytesRead,
-      buffer.length - bytesRead,
-      position + bytesRead,
-    );
-    if (result.bytesRead === 0) {
-      break;
-    }
-    bytesRead += result.bytesRead;
-  }
-  return bytesRead;
 }
 
 /** Resolves a rolling daily log path to the newest existing rolling log when needed. */
@@ -148,7 +127,7 @@ async function readLogSlice(params: {
 
     const length = Math.max(0, size - start);
     const buffer = Buffer.alloc(length);
-    const bytesRead = await readLogWindowFully(handle, buffer, start);
+    const bytesRead = await readFileWindowFully(handle, buffer, start);
     const text = buffer.toString("utf8", 0, bytesRead);
     let lines = text.split("\n");
     if (start > 0 && prefix !== "\n") {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where continuation sessions could re-inject full bootstrap context when the transcript tail read returned short before the full-bootstrap completion marker. On filesystems that allow short positional reads, `continuation-skip` could misread an existing completed turn as missing and restart the heavier bootstrap path.

## Why This Change Was Made

The continuation marker scanner now fills its bounded tail window until EOF or the requested window is read, preserving the existing scan size and compaction semantics.

## User Impact

Continuation runs keep their intended lightweight bootstrap behavior even when the transcript file read completes in multiple chunks.

## Evidence

- `node scripts/run-vitest.mjs src/agents/bootstrap-files.test.ts`: 40 passed.
- `git diff --check`: passed.
- Real production-module proof with `FileHandle.read` capped at 16 bytes per call:

```text
Baseline on origin/main (bb3fae834810cf466be70668b1bce2bd16e31227):
entrypoint: hasCompletedBootstrapTurn
read-boundary: fs.open FileHandle.read capped at 16 bytes per call
marker-detected: false
compaction-negative-control: false

After this branch:
entrypoint: hasCompletedBootstrapTurn
read-boundary: fs.open FileHandle.read capped at 16 bytes per call
marker-detected: true
compaction-negative-control: false
```

<details>
<summary>live-proof.mjs</summary>

```js
import fs from "node:fs/promises";
import os from "node:os";
import path from "node:path";
import { pathToFileURL } from "node:url";

const repoRoot = process.cwd();
const { FULL_BOOTSTRAP_COMPLETED_CUSTOM_TYPE, hasCompletedBootstrapTurn } = await import(
  pathToFileURL(path.join(repoRoot, "src/agents/bootstrap-files.ts")).href
);

const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-bootstrap-marker-proof-"));
const realOpen = fs.open.bind(fs);

fs.open = async (...args) => {
  const handle = await realOpen(...args);
  const realRead = handle.read.bind(handle);
  return new Proxy(handle, {
    get(target, prop, receiver) {
      if (prop === "read") {
        return (buffer, offset, length, position) =>
          realRead(buffer, offset, Math.min(length, 16), position);
      }
      return Reflect.get(target, prop, receiver);
    },
  });
};

async function writeTranscript(name, records) {
  const sessionFile = path.join(tmpDir, `${name}.jsonl`);
  await fs.writeFile(sessionFile, `${records.map((record) => JSON.stringify(record)).join("\n")}\n`);
  return sessionFile;
}

try {
  const markerFile = await writeTranscript("marker", [
    { type: "message", message: { role: "user", content: "hello" } },
    { type: "message", message: { role: "assistant", content: "hi" } },
    {
      type: "custom",
      customType: FULL_BOOTSTRAP_COMPLETED_CUSTOM_TYPE,
      data: { timestamp: 1 },
    },
  ]);
  const compactedFile = await writeTranscript("compacted", [
    {
      type: "custom",
      customType: FULL_BOOTSTRAP_COMPLETED_CUSTOM_TYPE,
      data: { timestamp: 1 },
    },
    { type: "compaction", summary: "trimmed" },
  ]);

  console.log(`entrypoint: hasCompletedBootstrapTurn`);
  console.log(`read-boundary: fs.open FileHandle.read capped at 16 bytes per call`);
  console.log(`marker-detected: ${await hasCompletedBootstrapTurn(markerFile)}`);
  console.log(`compaction-negative-control: ${await hasCompletedBootstrapTurn(compactedFile)}`);
} finally {
  fs.open = realOpen;
  await fs.rm(tmpDir, { recursive: true, force: true });
}
```

</details>

AI-assisted: built with Codex
