### PR TITLE
fix(telegram): stop doctor repeating expired cache warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Telegram legacy cache cleanup:** archive expired sent-message and message-dispatch cache sidecars when no live entries remain, preventing `openclaw doctor --fix` from reporting the same transient cache files forever.
 - **Mattermost progress command details:** accept the documented `streaming.preview.commandText` and `streaming.progress.commandText` modes in channel config validation and bundled metadata. Thanks @shakkernerd.
 - **1Password authorization handoff:** persist nonce-bound pending approvals in shared plugin state so hook and tool execution across broker instances remain single-use and fail closed.
 - **Control UI chat transcripts:** preserve loaded history across session and pane returns, bound automatic backscroll loading, virtualize long transcripts, retain hidden native run boundaries, and keep prepends, streaming, and responsive layouts from flickering or jumping. Thanks @shakkernerd.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Telegram legacy cache cleanup:** archive expired sent-message and message-dispatch cache sidecars when no live entries remain, preventing `openclaw doctor --fix` from reporting the same transient cache files forever.
 - **Mattermost progress command details:** accept the documented `streaming.preview.commandText` and `streaming.progress.commandText` modes in channel config validation and bundled metadata. Thanks @shakkernerd.
 - **1Password authorization handoff:** persist nonce-bound pending approvals in shared plugin state so hook and tool execution across broker instances remain single-use and fail closed.
 - **Control UI chat transcripts:** preserve loaded history across session and pane returns, bound automatic backscroll loading, virtualize long transcripts, retain hidden native run boundaries, and keep prepends, streaming, and responsive layouts from flickering or jumping. Thanks @shakkernerd.

--- a/extensions/telegram/src/state-migrations.test.ts
+++ b/extensions/telegram/src/state-migrations.test.ts
@@ -429,6 +429,7 @@ describe("telegram state migrations", () => {
         kind: "plugin-state-import",
         sourcePath: sentMessagePath,
         namespace: "telegram.sent-messages",
+        cleanupWhenEmpty: true,
       });
       expect(byLabel.get("Telegram thread bindings")).toMatchObject({
         kind: "plugin-state-import",
@@ -440,6 +441,7 @@ describe("telegram state migrations", () => {
         pluginId: TELEGRAM_MESSAGE_DISPATCH_DEDUPE_STATE_PLUGIN_ID,
         sourcePath: dispatchPath,
         namespace: dispatchNamespace,
+        cleanupWhenEmpty: true,
       });
       const dispatchPlan = byLabel.get("Telegram message dispatch dedupe");
       if (!dispatchPlan || dispatchPlan.kind !== "plugin-state-import") {
@@ -470,6 +472,55 @@ describe("telegram state migrations", () => {
           throw new Error(`expected plugin-state import plan: ${label}`);
         }
         expect(await plan.readEntries()).toHaveLength(1);
+      }
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("cleans up expired Telegram TTL cache sidecars with no importable entries", async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "openclaw-telegram-state-migration-"));
+    const env = { ...process.env, OPENCLAW_STATE_DIR: dir };
+    const storePath = resolveStorePath(undefined, { env });
+    const sentMessagePath = `${storePath}.telegram-sent-messages.json`;
+    const dispatchPath = resolveTelegramMessageDispatchLegacyPath({
+      storePath,
+      namespace: "ops",
+    });
+    const expiredAt = Date.now() - 8 * 24 * 60 * 60 * 1000;
+    try {
+      await mkdir(path.dirname(sentMessagePath), { recursive: true });
+      await writeFile(sentMessagePath, JSON.stringify({ 7: { 42: expiredAt } }));
+      await writeFile(
+        dispatchPath,
+        JSON.stringify({ [JSON.stringify(["message", "7", 42])]: expiredAt }),
+      );
+
+      const cfg = {
+        channels: {
+          telegram: {
+            accounts: {
+              ops: {
+                botToken: "test",
+              },
+            },
+          },
+        },
+      } as OpenClawConfig;
+      const plans = await detectTelegramLegacyStateMigrations({ cfg, env });
+      const expiredPlans = plans.filter(
+        (plan) =>
+          plan.kind === "plugin-state-import" &&
+          (plan.sourcePath === sentMessagePath || plan.sourcePath === dispatchPath),
+      );
+
+      expect(expiredPlans).toHaveLength(2);
+      for (const plan of expiredPlans) {
+        expect(plan).toMatchObject({ cleanupSource: "rename", cleanupWhenEmpty: true });
+        if (plan.kind !== "plugin-state-import") {
+          throw new Error("expected Telegram TTL cache import plan");
+        }
+        expect(await plan.readEntries()).toStrictEqual([]);
       }
     } finally {
       await rm(dir, { recursive: true, force: true });

--- a/extensions/telegram/src/state-migrations.ts
+++ b/extensions/telegram/src/state-migrations.ts
@@ -472,6 +472,7 @@ function detectTelegramSentMessageCacheLegacyStateMigration(params: {
       maxEntries: TELEGRAM_SENT_MESSAGE_CACHE_MAX_ENTRIES,
       scopeKey: "",
       cleanupSource: "rename",
+      cleanupWhenEmpty: true,
       preview: `- Telegram sent-message cache: ${source.sourcePath} → plugin state (${TELEGRAM_SENT_MESSAGE_CACHE_NAMESPACE})`,
       readEntries: () =>
         listTelegramLegacySentMessageCacheEntries({
@@ -549,6 +550,7 @@ function detectTelegramMessageDispatchLegacyStateMigration(params: {
         defaultTtlMs: TELEGRAM_MESSAGE_DISPATCH_DEDUPE_TTL_MS,
         scopeKey: "",
         cleanupSource: "rename",
+        cleanupWhenEmpty: true,
         preview: `- Telegram message dispatch dedupe: ${sourcePath} → plugin state (${namespace})`,
         shouldReplaceExistingEntry: ({ existingValue, incomingValue }) =>
           shouldReplacePersistentDedupeEntry({ existingValue, incomingValue }),


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where `openclaw doctor --fix` would keep reporting retired Telegram sent-message and message-dispatch cache sidecars when every valid entry had already expired.

## Why This Change Was Made

The two TTL-filtered cache migrations now opt into empty-source cleanup. Doctor still archives each source as `.migrated`; persistent and non-TTL migrations are unchanged. A focused regression covers both cache types after their retention windows expire.

## User Impact

Operators can run Doctor once to retire these stale transient caches instead of seeing the same warning forever.

## Evidence

- Blacksmith Testbox `tbx_01kxjnrsf1pqbyajpx0cxbewpw`: `pnpm test extensions/telegram/src/state-migrations.test.ts` — 9/9 passed.
- Same Testbox: path-scoped `pnpm check:changed` — formatting, typechecks, lint, database-first guard, runtime sidecar guard, and import-cycle checks passed.
- Structured Codex autoreview: clean, confidence 0.95.
- AI-assisted change. No agent transcript attached because the originating session includes unrelated private operational context; the regression and commands above are the complete public proof.
