### PR TITLE
fix(ci): intermittent large-shard failures from in-job Vitest concurrency

### DIFF
--- a/scripts/lib/ci-node-test-plan.mjs
+++ b/scripts/lib/ci-node-test-plan.mjs
@@ -1381,12 +1381,12 @@ function createCompactNodeTestShardBundles(options = {}) {
         ...(bin.hasWholeConfigGroup
           ? { timeoutMinutes: COMPACT_WHOLE_NODE_TEST_TIMEOUT_MINUTES }
           : {}),
-        // 4 vCPU bins run their plans serially: overlapping two Vitest runs
-        // there starves process-spawning tests (worker-startup timeouts in
-        // core-runtime-infra-process, tooling process-group waits), and the
-        // packed weights are contention-inflated so serializing is roughly
-        // wall-neutral. Exclusive spawn/signal bins stay serial everywhere.
-        ...(bin.exclusive || runnerClass === "small" ? { planConcurrency: 1 } : {}),
+        // Every compact bin runs its plans serially. Overlapping two Vitest
+        // runs on one runner starves timing-sensitive tests on both runner
+        // classes (worker-startup timeouts on 4 vCPU, UI-animation and
+        // lock-timing flakes on 8 vCPU), and the packed weights are
+        // contention-inflated so serializing is roughly wall-neutral.
+        planConcurrency: 1,
       });
     }
   }

--- a/test/scripts/ci-node-test-plan.test.ts
+++ b/test/scripts/ci-node-test-plan.test.ts
@@ -203,10 +203,9 @@ describe("scripts/lib/ci-node-test-plan.mjs", () => {
     expect(jobOf("agentic-agents-core-runner-embedded")).toBeGreaterThanOrEqual(0);
     expect(jobOf("core-unit-fast")).toBeGreaterThanOrEqual(0);
     expect(jobOf("agentic-agents-core-runner-embedded")).not.toBe(jobOf("core-unit-fast"));
-    // Spawn/signal-timing suites flake next to a concurrent sibling Vitest
-    // run; their bins never mix with regular groups, and every 4 vCPU bin
-    // runs serially because overlapping Vitest runs starve process-spawning
-    // tests on that runner class.
+    // Spawn/signal-timing suites never mix with regular groups, and every
+    // compact bin runs serially: overlapping Vitest runs flake timing-
+    // sensitive tests on both runner classes.
     const exclusiveGroupRe = /^core-tooling(?:-\d+|-isolated|-docker)?$|^core-runtime-tui-pty$/u;
     for (const shard of compact) {
       const exclusiveCount = shard.groups.filter((group) =>
@@ -215,11 +214,7 @@ describe("scripts/lib/ci-node-test-plan.mjs", () => {
       if (exclusiveCount > 0) {
         expect(exclusiveCount).toBe(shard.groups.length);
       }
-      if (exclusiveCount > 0 || !shard.runner.includes("-8vcpu-")) {
-        expect(shard.planConcurrency).toBe(1);
-      } else {
-        expect(shard.planConcurrency).toBeUndefined();
-      }
+      expect(shard.planConcurrency).toBe(1);
     }
     expect(
       compact.filter((shard) =>


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where PR CI test shards intermittently fail on 8 vCPU runners even after #108239 serialized the 4 vCPU class: post-fix sampling (runs created after 10:35Z) still showed ~10% of PR runs failing in large compact bins with timing signatures — `terminal-panel-readiness` animation assertions failing while the co-plan logs 90s no-output stalls (run 29409500498), and `session-write-lock` stale-lock retry timing (run 29409287318).

## Why This Change Was Made

Two-way plan concurrency inside one runner is not reliable for this suite on either runner class: timing-sensitive tests (spawn/worker startup, UI animation frames, lock-retry windows) flake when a sibling Vitest run competes for the same cores. Every compact bin now carries `planConcurrency: 1`. This keeps all the rest of the recent CI work (runtime-balanced packing, group splits, diff-gated heavy lanes, targeted plans, the extracted shard runner) and is roughly wall-neutral because the packing weights were measured under contention and are inflated 40-100% versus solo runtimes.

## User Impact

No product change. Removes the remaining intermittent shard failures on unrelated PRs introduced by in-job concurrency; expected full-scope PR wall stays ~5-6 minutes with balanced serial bins.

## Evidence

- Post-#108239 sampling (27 completed PR runs created after 10:35Z): 16 green; of 11 red, most failed their own lint/type/docs checks, but runs 29409500498 and 29409287318 failed only in large compact bins with the contention-timing signatures quoted above.
- Solo vs contended timings (runs 29392858230 / 29395969440) documented in the hint table justify wall-neutrality of serialization.
- `test/scripts/ci-node-test-plan.test.ts` asserts every compact bin carries `planConcurrency: 1`; green locally.
