### PR TITLE
fix(sessions): snapshot last-call context, not aggregate cacheRead (#108238)

### DIFF
--- a/src/agents/command/session-store.test.ts
+++ b/src/agents/command/session-store.test.ts
@@ -1051,6 +1051,47 @@ describe("updateSessionStoreAfterAgentRun", () => {
     });
   });
 
+  it("snapshots the last-call context, not aggregate cacheRead, for cache-heavy sessions (#108238)", async () => {
+    await withTempSessionStore(async ({ storePath }) => {
+      const cfg = {} as OpenClawConfig;
+      const sessionKey = "agent:main:explicit:test-cache-hits";
+      const sessionId = "test-session-108238";
+
+      const sessionStore: Record<string, SessionEntry> = {};
+      await seedSessionStore(storePath, sessionStore);
+
+      const result: EmbeddedAgentRunResult = {
+        meta: {
+          durationMs: 500,
+          agentMeta: {
+            sessionId,
+            provider: "openai",
+            model: "gpt-5.6-sol",
+            // Aggregate usage sums cacheRead across every prompt-cache hit this run.
+            usage: { input: 497_720, output: 7_485, cacheRead: 1_323_520, cacheWrite: 0 },
+            // The last model call's prompt is small — this is the live context size.
+            lastCallUsage: { input: 60_000, output: 7_485, cacheRead: 15_000, cacheWrite: 0 },
+          },
+        },
+      };
+
+      await updateSessionStoreAfterAgentRun({
+        cfg,
+        sessionId,
+        sessionKey,
+        storePath,
+        sessionStore,
+        defaultProvider: "openai",
+        defaultModel: "gpt-5.6-sol",
+        result,
+      });
+
+      // The snapshot must reflect the last call's prompt (input + cacheRead = 75000), not the
+      // aggregate input + cacheRead + cacheWrite (1,821,240) that read as context overflow (#108238).
+      expect(sessionStore[sessionKey]?.totalTokens).toBe(75_000);
+    });
+  });
+
   it("persists estimated context budget status without marking stale usage fresh", async () => {
     await withTempSessionStore(async ({ storePath }) => {
       const cfg = {} as OpenClawConfig;
@@ -1516,7 +1557,10 @@ describe("updateSessionStoreAfterAgentRun", () => {
         } as EmbeddedAgentRunResult,
       });
 
-      expect(sessionStore[sessionKey]?.totalTokens).toBe(120_000);
+      // The context snapshot is the last call's prompt (input 91000 + cacheRead 4000 = 95000),
+      // not the aggregate input + cacheRead (120000) that sums cacheRead across calls (#108238).
+      // The point of this case still holds: fresh usage wins over the compaction snapshot (80000).
+      expect(sessionStore[sessionKey]?.totalTokens).toBe(95_000);
       expect(sessionStore[sessionKey]?.totalTokensFresh).toBe(true);
       expect(sessionStore[sessionKey]?.inputTokens).toBe(100_000);
       expect(sessionStore[sessionKey]?.outputTokens).toBe(3_000);

--- a/src/agents/command/session-store.ts
+++ b/src/agents/command/session-store.ts
@@ -213,11 +213,14 @@ export async function updateSessionStoreAfterAgentRun(params: {
     const { estimateUsageCost, resolveModelCostConfig } = await getUsageFormatModule();
     const input = usage.input ?? 0;
     const output = usage.output ?? 0;
+    // SessionEntry.totalTokens is a current-context snapshot (usage.ts deriveSessionTotalTokens),
+    // so prefer the last model call's usage: its input+cacheRead is the prompt actually sent that
+    // turn. The aggregate `usage` sums cacheRead across every call, so a session with many prompt-
+    // cache hits reads as far over the context window even when the live transcript is small
+    // (#108238). Fall back to the aggregate only when no last-call usage is available.
     const usageForContext = isCliProvider(providerUsed, cfg)
       ? lastCallUsage
-      : lastCallUsage?.contextUsage
-        ? lastCallUsage
-        : usage;
+      : (lastCallUsage ?? usage);
     const totalTokens = deriveSessionTotalTokens({
       usage: promptTokens ? undefined : usageForContext,
       contextTokens,


### PR DESCRIPTION
## What Problem This Solves

Fixes #108238. `SessionEntry.totalTokens` is a **current-context snapshot** (`deriveSessionTotalTokens` in `src/agents/usage.ts`, "used as a prompt/context snapshot… excludes completion tokens"). In `updateSessionStoreAfterAgentRun`, the usage fed into that snapshot was chosen as:

```ts
const usageForContext = isCliProvider(providerUsed, cfg)
  ? lastCallUsage
  : lastCallUsage?.contextUsage ? lastCallUsage : usage; // ← aggregate run usage
```

For a non-CLI provider whose last-call usage carries no authoritative `contextUsage` (e.g. `gpt-5.6-sol`), the snapshot fell back to the **aggregate run usage**, which sums `cacheRead` across every model call in the run. A session with many prompt-cache hits then reads as far over its context window even when the live transcript is small. The reporter's entry:

```
inputTokens 497720 + cacheRead 1323520 + cacheWrite 0 = totalTokens 1821240 → "1821k/800k (228%)"
```

…while the actual transcript was ~75k, falsely reporting context overflow and tripping/stalling compaction.

## Why This Change Was Made

The last model call's `input + cacheRead` **is** the prompt actually sent that turn, i.e. the live context. The aggregate is a per-run usage/cost total and multi-counts `cacheRead`, so it is wrong as a context snapshot. The CLI-provider branch and the `contextUsage` branch already prefer `lastCallUsage`; this just extends that to the last remaining case (last-call usage present but without `contextUsage`), completing the last-call-context intent of #99864. The aggregate is still used when no last-call usage exists.

## User Impact

`openclaw sessions` / context-usage display and compaction now reflect the real current context for cache-heavy sessions on providers that don't report `contextUsage`, instead of climbing to hundreds of percent and stalling compaction. No config or API change.

## Evidence

- Prod change is one branch in `src/agents/command/session-store.ts` (`lastCallUsage?.contextUsage ? lastCallUsage : usage` → `lastCallUsage ?? usage`).
- New regression `snapshots the last-call context, not aggregate cacheRead, for cache-heavy sessions (#108238)`: aggregate usage `{input 497720, cacheRead 1323520}` + small `lastCallUsage {input 60000, cacheRead 15000}` → asserts snapshot `totalTokens = 75000` (last-call prompt), not `1821240` (aggregate).
- Discriminator: reverting the prod branch fails this test (gets `1821240`).
- One existing test (`prefers fresh usage over positive compaction tokensAfter`) asserted the pre-fix aggregate value (`120000`); its snapshot is now the last-call value (`95000`). Its actual point — fresh usage wins over the compaction snapshot (`80000`) with `totalTokensFresh: true` — is unchanged. Comment added explaining the value.
- Local (trusted checkout): `node scripts/run-vitest.mjs run src/agents/command/session-store.test.ts` → 55/55; `oxfmt --check` + `oxlint` clean; changed files type-clean under `tsgo`.
