### PR TITLE
fix(config/sessions): avoid splitting surrogate pairs when shortening group ids

### DIFF
--- a/src/config/sessions/group.test.ts
+++ b/src/config/sessions/group.test.ts
@@ -1,7 +1,7 @@
 // Session group tests cover grouping and lookup of related sessions.
 import { describe, expect, it } from "vitest";
 import type { MsgContext } from "../../auto-reply/templating.js";
-import { buildGroupDisplayTitle, resolveGroupSessionKey } from "./group.js";
+import { buildGroupDisplayTitle, resolveGroupSessionKey, shortenGroupId } from "./group.js";
 
 describe("resolveGroupSessionKey", () => {
   it("preserves Signal group ids from the originating target", () => {
@@ -77,5 +77,47 @@ describe("buildGroupDisplayTitle", () => {
     expect(buildGroupDisplayTitle({ space: "Acme" })).toBe("Acme");
     expect(buildGroupDisplayTitle({})).toBeUndefined();
     expect(buildGroupDisplayTitle({ subject: "  " })).toBeUndefined();
+  });
+});
+
+function hasLoneSurrogate(s: string): boolean {
+  for (let i = 0; i < s.length; i++) {
+    const c = s.charCodeAt(i);
+    if (c >= 0xd800 && c <= 0xdbff) {
+      // High surrogate must be followed by a low surrogate.
+      if (i + 1 >= s.length || s.charCodeAt(i + 1) < 0xdc00 || s.charCodeAt(i + 1) > 0xdfff) {
+        return true;
+      }
+    } else if (c >= 0xdc00 && c <= 0xdfff) {
+      // Low surrogate must be preceded by a high surrogate.
+      if (i === 0 || s.charCodeAt(i - 1) < 0xd800 || s.charCodeAt(i - 1) > 0xdbff) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+describe("shortenGroupId", () => {
+  it("returns short ids unchanged", () => {
+    expect(shortenGroupId("short-id")).toBe("short-id");
+  });
+
+  it("does not split a surrogate pair at the head cut", () => {
+    // 5 ASCII code units, then an emoji surrogate pair, then ASCII padding.
+    // The old fixed slice(0, 6) cut kept the high surrogate only.
+    const id = "a".repeat(5) + "🎉" + "b".repeat(10);
+    const shortened = shortenGroupId(id);
+    expect(shortened).toContain("...");
+    expect(hasLoneSurrogate(shortened)).toBe(false);
+  });
+
+  it("does not split a surrogate pair at the tail cut", () => {
+    // 12 ASCII code units, then an emoji surrogate pair, then 3 ASCII code units.
+    // The old fixed slice(-4) cut kept the low surrogate only.
+    const id = "a".repeat(12) + "🎉" + "b".repeat(3);
+    const shortened = shortenGroupId(id);
+    expect(shortened).toContain("...");
+    expect(hasLoneSurrogate(shortened)).toBe(false);
   });
 });

--- a/src/config/sessions/group.ts
+++ b/src/config/sessions/group.ts
@@ -5,6 +5,7 @@ import {
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
 import { normalizeHyphenSlug } from "@openclaw/normalization-core/string-normalization";
+import { sliceUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import type { MsgContext } from "../../auto-reply/templating.js";
 import { listChannelPlugins } from "../../channels/plugins/registry.js";
 import { normalizeSessionPeerId } from "../../sessions/session-key-utils.js";
@@ -69,7 +70,8 @@ function resolveOriginatingGroupTargetId(params: {
   return null;
 }
 
-function shortenGroupId(value?: string) {
+/** @public Exported for unit testing. */
+export function shortenGroupId(value?: string) {
   const trimmed = normalizeOptionalString(value) ?? "";
   if (!trimmed) {
     return "";
@@ -77,7 +79,7 @@ function shortenGroupId(value?: string) {
   if (trimmed.length <= 14) {
     return trimmed;
   }
-  return `${trimmed.slice(0, 6)}...${trimmed.slice(-4)}`;
+  return `${sliceUtf16Safe(trimmed, 0, 6)}...${sliceUtf16Safe(trimmed, -4)}`;
 }
 
 /**


### PR DESCRIPTION
## What Problem This Solves

`buildGroupDisplayName` shortens very long group ids via `shortenGroupId`, which previously used raw `String.prototype.slice` to take the first 6 and last 4 UTF-16 code units. When the group id contains characters outside the Basic Multilingual Plane (e.g. emoji), `slice` can cut through a surrogate pair and produce a display label with a dangling surrogate half.

## Why This Change Was Made

This is a Unicode-boundary safety fix consistent with the existing `@openclaw/normalization-core/utf16-slice` helper (`sliceUtf16Safe`), which is already used elsewhere in the codebase for the same class of bug. The fix keeps the display logic identical for ASCII ids while guaranteeing well-formed UTF-16 output for surrogate-pair ids.

## Changes

- `src/config/sessions/group.ts`
  - Import `sliceUtf16Safe` from `@openclaw/normalization-core/utf16-slice`.
  - Export `shortenGroupId` (marked `@public` for unit testing) and use `sliceUtf16Safe` for the head and tail slices.
- `src/config/sessions/group.test.ts`
  - Import `shortenGroupId`.
  - Add regression tests that place a surrogate pair exactly across the head (`slice(0, 6)`) and tail (`slice(-4)`) cut points and assert directly that the result contains no isolated surrogate.

## User Impact

Group-session display labels for channels whose ids include non-BMP characters are now always well-formed strings, avoiding corrupted UI labels or downstream JSON serialization issues.

## Real behavior proof (required for external PRs)

- **Behavior addressed:** `shortenGroupId` no longer produces a dangling surrogate half when shortening group ids that contain emoji or other non-BMP characters.
- **Real environment tested:** local OpenClaw source checkout on Node v22.22.0; PR head `d445b18b20a`.
- **Exact steps or command run after this patch:**

```bash
./node_modules/.bin/oxlint src/config/sessions/group.ts src/config/sessions/group.test.ts
node scripts/run-vitest.mjs src/config/sessions/group.test.ts
node --import tsx -e "
import { sliceUtf16Safe } from './packages/normalization-core/src/utf16-slice.ts';
import { writeFileSync, readFileSync } from 'node:fs';
import { tmpdir } from 'node:os';
import { join } from 'node:path';
import { execSync } from 'node:child_process';
function hasLoneSurrogate(s) {
  for (let i = 0; i < s.length; i++) {
    const c = s.charCodeAt(i);
    if (c >= 0xD800 && c <= 0xDBFF) {
      if (i + 1 >= s.length || s.charCodeAt(i + 1) < 0xDC00 || s.charCodeAt(i + 1) > 0xDFFF) return true;
    } else if (c >= 0xDC00 && c <= 0xDFFF) {
      if (i === 0 || s.charCodeAt(i - 1) < 0xD800 || s.charCodeAt(i - 1) > 0xDBFF) return true;
    }
  }
  return false;
}
function shortenOld(value) {
  const trimmed = value ?? '';
  if (!trimmed) return '';
  if (trimmed.length <= 14) return trimmed;
  return \`\${trimmed.slice(0, 6)}...\${trimmed.slice(-4)}\`;
}
function shortenNew(value) {
  const trimmed = value ?? '';
  if (!trimmed) return '';
  if (trimmed.length <= 14) return trimmed;
  return \`\${sliceUtf16Safe(trimmed, 0, 6)}...\${sliceUtf16Safe(trimmed, -4)}\`;
}
const headCase = 'a'.repeat(5) + '🎉' + 'b'.repeat(10);
const tailCase = 'a'.repeat(12) + '🎉' + 'b'.repeat(3);
const out = join(tmpdir(), 'openclaw-proof-108274-' + Date.now() + '.json');
const report = {
  head: execSync('git rev-parse --short HEAD').toString().trim(),
  cases: [
    { name: 'head-cut', input: headCase, old: shortenOld(headCase), oldHasLone: hasLoneSurrogate(shortenOld(headCase)), new: shortenNew(headCase), newHasLone: hasLoneSurrogate(shortenNew(headCase)) },
    { name: 'tail-cut', input: tailCase, old: shortenOld(tailCase), oldHasLone: hasLoneSurrogate(shortenOld(tailCase)), new: shortenNew(tailCase), newHasLone: hasLoneSurrogate(shortenNew(tailCase)) },
  ],
};
writeFileSync(out, JSON.stringify(report, null, 2));
console.log(readFileSync(out, 'utf8'));
"
```

- **Evidence after fix:**

```text
$ ./node_modules/.bin/oxlint src/config/sessions/group.ts src/config/sessions/group.test.ts
$ node scripts/run-vitest.mjs src/config/sessions/group.test.ts
Test Files 1 passed
Tests 9 passed

$ node --import tsx -e "..."
{
  "head": "d445b18b20a",
  "cases": [
    {
      "name": "head-cut",
      "input": "aaaaa🎉bbbbbbbbbb",
      "old": "aaaaa\ud83c...bbbb",
      "oldHasLone": true,
      "new": "aaaaa...bbbb",
      "newHasLone": false
    },
    {
      "name": "tail-cut",
      "input": "aaaaaaaaaaaa🎉bbb",
      "old": "aaaaaa...\udf89bbb",
      "oldHasLone": true,
      "new": "aaaaaa...bbb",
      "newHasLone": false
    }
  ]
}
```

- **Observed result after fix:** With a party-popper emoji (`U+1F389`) placed exactly across the fixed head/tail cut points, the old `String.prototype.slice` implementation leaves an isolated high or low surrogate (`oldHasLone: true`), while the patched `sliceUtf16Safe` implementation backs off to keep the surrogate pair intact (`newHasLone: false`). The focused test suite now exercises both boundary cases directly and asserts `hasLoneSurrogate(result) === false`.
- **What was not tested:** Full production deployment and channel-specific end-to-end delivery were not run; this proof is scoped to the touched local runtime path.

## Intentionally out of scope

- No change to the displayed length budget (still 6 + "..." + 4 code units).
- No change to normalization or channel-specific group id parsing.
- Does not address response/JSON bounding or other unrelated UTF-16 sites.