### PR TITLE
fix(discord): keep voice participant labels UTF-16 safe at truncation boundary

### DIFF
--- a/extensions/discord/src/voice/participant-context.test.ts
+++ b/extensions/discord/src/voice/participant-context.test.ts
@@ -1,6 +1,35 @@
 // Discord tests cover voice participant classification.
 import { describe, expect, it } from "vitest";
-import { countDiscordVoiceHumanParticipants } from "./participant-context.js";
+import {
+  countDiscordVoiceHumanParticipants,
+  formatDiscordVoiceParticipantStateLine,
+} from "./participant-context.js";
+
+describe("formatDiscordVoiceParticipantStateLine", () => {
+  it.each([
+    {
+      name: "drops an emoji split by the label limit",
+      nick: `${"x".repeat(99)}😀tail`,
+      expected: "x".repeat(99),
+    },
+    {
+      name: "keeps an emoji that ends at the label limit",
+      nick: `${"x".repeat(98)}😀tail`,
+      expected: `${"x".repeat(98)}😀`,
+    },
+    { name: "keeps a short label unchanged", nick: "Ada", expected: "Ada" },
+  ])("$name", ({ nick, expected }) => {
+    const line = formatDiscordVoiceParticipantStateLine({
+      userId: "user-1",
+      state: {
+        user_id: "user-1",
+        member: { nick },
+      } as never,
+    });
+
+    expect(line).toBe(`- user_id="user-1" display_name=${JSON.stringify(expected)}`);
+  });
+});
 
 describe("countDiscordVoiceHumanParticipants", () => {
   it("counts people while excluding the agent and other bots", () => {

--- a/extensions/discord/src/voice/participant-context.ts
+++ b/extensions/discord/src/voice/participant-context.ts
@@ -1,4 +1,5 @@
 import type { DiscordAccountConfig, OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import type { APIVoiceState, Client } from "../internal/discord.js";
 import type { GatewayPlugin } from "../internal/gateway.js";
 import { type DiscordVoiceIngressContext, resolveDiscordVoiceIngressContext } from "./ingress.js";
@@ -23,7 +24,7 @@ function normalizeLabel(value: unknown): string | undefined {
     return undefined;
   }
   const normalized = value.replace(/\s+/g, " ").trim();
-  return normalized ? normalized.slice(0, 100) : undefined;
+  return normalized ? truncateUtf16Safe(normalized, 100) : undefined;
 }
 
 function memberLabel(state: APIVoiceState): string | undefined {


### PR DESCRIPTION
## What Problem This Solves

Discord voice participant labels are normalized and capped at 100 UTF-16 code units before they are serialized into roster events and agent context. The existing raw `slice(0, 100)` could end on the high half of a surrogate pair, producing a malformed label such as a trailing `\ud83d`.

## Why This Change Was Made

The Discord plugin already consumes `truncateUtf16Safe` from `openclaw/plugin-sdk/text-utility-runtime` for other bounded user-visible strings. Reusing it at the shared `normalizeLabel` boundary keeps roster snapshots, join/leave events, nicknames, global names, usernames, and resolved speaker-context labels consistent without adding a parallel helper.

The regression test uses exact serialized roster-line output for both sides of the cutoff:

- 99 ASCII units plus an emoji crosses the limit, so the incomplete emoji is dropped.
- 98 ASCII units plus an emoji ends exactly at the limit, so the complete emoji is preserved.
- A short label is unchanged.

## User Impact

Any over-limit Discord voice display label reaching the roster boundary now remains well-formed instead of carrying an orphan UTF-16 surrogate into membership events or agent context.

## Evidence

- Before-fix boundary reproduction: 101 UTF-16 input units become 100 output units with `loneHighSurrogate: true` and final code unit `d83d` under raw `slice(0, 100)`.
- `node scripts/run-vitest.mjs extensions/discord/src/voice/participant-context.test.ts` -> 1 file, 5 tests passed.
- Direct runtime formatter probe -> split case emitted 99 ASCII units, fit case emitted 98 ASCII units plus the complete emoji, and both reported `loneSurrogate: false` in the actual serialized roster line.
- Canonical `oxfmt --check` on both touched files -> clean.
- `git diff --check origin/main...HEAD` -> clean.
- `$HOME/.claude/skills/autoreview/scripts/autoreview --mode branch --base origin/main` -> clean on final head, no accepted/actionable findings, patch correct at 0.98 confidence.
- The Discord voice sibling sweep found no second unsafe user-visible string truncation; voice log previews already use the shared helper.

ClawSweeper requested a live Discord capture with a greater-than-100-unit member name. That move is intentionally not required here: Discord documents usernames and nicknames as at most 32 characters without defining UTF-16 counting semantics, so a greater-than-100-unit live fixture is not a stable API contract. The transformation is deterministic and is exercised through the real roster-line formatter on both adjacent UTF-16 boundaries.

## Risk checklist

- User-visible behavior change: Yes, limited to labels whose 100-unit cutoff splits a surrogate pair.
- Config / environment / migration change: No.
- Security / auth / secrets / network / tool-execution change: No.
- Dependency change: No; this reuses an existing public Plugin SDK helper.

AI-assisted maintainer refinement: the winning contributor patch was rebased and its regression test tightened. The commit credits the authors of #108278, #108300, and #111438 with `Co-authored-by` trailers.
