### PR TITLE
fix(release): support frozen Matrix QA profiles

### DIFF
--- a/.github/workflows/qa-live-transports-convex.yml
+++ b/.github/workflows/qa-live-transports-convex.yml
@@ -475,7 +475,23 @@ jobs:
               ;;
           esac
 
-          output_dir=".artifacts/qa-e2e/matrix-live-${INPUT_MATRIX_PROFILE}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          resolve_matrix_profile() {
+            local requested="$1"
+            local help_text="$2"
+            if [[ "${requested}" == "release" ]] && ! grep -Fq "fast, release, transport" <<<"${help_text}"; then
+              printf 'fast\n'
+              return
+            fi
+            printf '%s\n' "${requested}"
+          }
+
+          matrix_help="$(pnpm openclaw qa matrix --help 2>&1)"
+          matrix_profile="$(resolve_matrix_profile "${INPUT_MATRIX_PROFILE}" "${matrix_help}")"
+          if [[ "${matrix_profile}" != "${INPUT_MATRIX_PROFILE}" ]]; then
+            echo "Selected target does not support Matrix profile '${INPUT_MATRIX_PROFILE}'; using '${matrix_profile}'."
+          fi
+
+          output_dir=".artifacts/qa-e2e/matrix-live-${matrix_profile}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           echo "output_dir=${output_dir}" >> "$GITHUB_OUTPUT"
 
           for attempt in $(seq 1 "${MATRIX_ATTEMPTS}"); do
@@ -486,7 +502,7 @@ jobs:
               --provider-mode "${MATRIX_PROVIDER_MODE}" \
               --model "${MATRIX_PRIMARY_MODEL}" \
               --alt-model "${MATRIX_ALTERNATE_MODEL}" \
-              --profile "${INPUT_MATRIX_PROFILE}" \
+              --profile "${matrix_profile}" \
               --fast; then
               exit 0
             fi

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -2387,8 +2387,26 @@ describe("package artifact reuse", () => {
       'echo "Matrix live lane failed on attempt ${attempt}; retrying..." >&2',
     );
     expect(qaWorkflow).not.toContain("OPENCLAW_QA_MATRIX_CANARY_TIMEOUT_MS");
-    expect(qaWorkflow).toContain('--profile "${INPUT_MATRIX_PROFILE}"');
+    expect(qaWorkflow).toContain('--profile "${matrix_profile}"');
     expect(qaWorkflow).not.toContain("--fail-fast");
+
+    const matrixRunScript = workflowStep(matrixJob, "Run Matrix live lane").run ?? "";
+    const resolveMatrixProfile = shellFunctionSource(matrixRunScript, "resolve_matrix_profile");
+    const resolveProfile = (requested: string, helpText: string) =>
+      execFileSync(
+        "bash",
+        [
+          "-c",
+          `${resolveMatrixProfile}\nresolve_matrix_profile "$1" "$2"`,
+          "resolve-matrix-profile",
+          requested,
+          helpText,
+        ],
+        { encoding: "utf8" },
+      ).trim();
+    expect(resolveProfile("release", "profiles: all, fast, release, transport")).toBe("release");
+    expect(resolveProfile("release", "profiles: all, fast, transport")).toBe("fast");
+    expect(resolveProfile("e2ee-smoke", "profiles: all, fast, transport")).toBe("e2ee-smoke");
   });
 
   it("runs live transport lanes nightly while release checks stay gated", () => {


### PR DESCRIPTION
## What Problem This Solves

Current release validation passes the newer Matrix QA profile `release` into the selected target checkout. Frozen release candidate `9db92c67e8393ac53ac2f36baac39c5b74422ca4` predates that profile, so its Matrix CLI rejects the request before any scenario runs.

Full Release Validation run 29411839897 reproduced this in Release Checks child 29411858472, job 87341074703. Both attempts exited with:

`unknown Matrix QA profile "release"; expected one of: all, fast, transport, media, e2ee-smoke, e2ee-deep, e2ee-cli`

## Why This Change Was Made

The trusted reusable workflow now reads the selected target's own Matrix QA help contract. If the requested profile is `release` but that target does not advertise it, the workflow uses the target's existing `fast` release-critical profile. Current targets continue using `release`; every other explicit profile is unchanged.

This keeps compatibility in the current trusted harness and avoids backporting current QA Lab/runtime work into a frozen release.

## User Impact

Maintainers can run current Full Release Validation against older frozen candidates without receiving a guaranteed pre-scenario Matrix failure. Current release candidates retain the intended two-scenario `release` profile.

## Evidence

- Reproduction: https://github.com/openclaw/openclaw/actions/runs/29411839897
- Failed child job: https://github.com/openclaw/openclaw/actions/runs/29411858472/job/87341074703
- Exact frozen-target proof: https://github.com/openclaw/openclaw/actions/runs/29412868684 — requested `release`, logged the `fast` fallback, and passed the Matrix lane.
- Proof artifact: `8342084124`, `release-qa-live-matrix-9db92c67e8393ac53ac2f36baac39c5b74422ca4`, `sha256:7ab3137bd1daca7752b9af71cd23c8526f63dfd11728481194ea23944f93e151`.
- `node scripts/run-vitest.mjs test/scripts/package-acceptance-workflow.test.ts -t "routes release Matrix through the QA Lab selector"` — 1 passed.
- The resolver test proves current help keeps `release`, frozen help maps only `release` to `fast`, and unrelated profiles remain unchanged.
- `actionlint .github/workflows/qa-live-transports-convex.yml`
- `git diff --check`

No release candidate code, tag, or publication workflow is changed or dispatched by this PR.
