### PR TITLE
fix: text-only Mattermost replies fail with blank attachment fields

### DIFF
--- a/extensions/mattermost/src/channel.send-loopback.test.ts
+++ b/extensions/mattermost/src/channel.send-loopback.test.ts
@@ -1,0 +1,104 @@
+// Mattermost tests cover the action-to-REST send path over loopback.
+import { createPluginRuntimeMock } from "openclaw/plugin-sdk/plugin-test-runtime";
+import { withServer } from "openclaw/plugin-sdk/test-env";
+import { describe, expect, it, vi } from "vitest";
+import { mattermostPlugin } from "./channel.js";
+import type { OpenClawConfig } from "./runtime-api.js";
+import { setMattermostRuntime } from "./runtime.js";
+
+const CHANNEL_ID = "aaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+describe("Mattermost send action loopback", () => {
+  it("sends text with blank attachment placeholders and rejects nonblank payloads", async () => {
+    const requests: Array<{ path: string; body: unknown }> = [];
+
+    await withServer(
+      (request, response) => {
+        let body = "";
+        request.setEncoding("utf8");
+        request.on("data", (chunk) => {
+          body += chunk;
+        });
+        request.on("end", () => {
+          requests.push({
+            path: request.url ?? "",
+            body: JSON.parse(body) as unknown,
+          });
+          response.writeHead(201, { "content-type": "application/json" });
+          response.end(JSON.stringify({ id: "post-loopback", channel_id: CHANNEL_ID }));
+        });
+      },
+      async (baseUrl) => {
+        setMattermostRuntime(
+          createPluginRuntimeMock({
+            channel: {
+              activity: {
+                record: vi.fn(),
+                get: vi.fn(() => ({ inboundAt: null, outboundAt: null })),
+              },
+            },
+          }),
+        );
+        const cfg = {
+          channels: {
+            mattermost: {
+              botToken: ["loopback", "fixture"].join("-"),
+              baseUrl,
+              network: { dangerouslyAllowPrivateNetwork: true },
+            },
+          },
+        } as OpenClawConfig;
+        const handleAction = mattermostPlugin.actions?.handleAction;
+        if (!handleAction) {
+          throw new Error("Mattermost send action missing");
+        }
+
+        const result = await handleAction({
+          channel: "mattermost",
+          action: "send",
+          params: {
+            to: `channel:${CHANNEL_ID}`,
+            message: "loopback proof",
+            buffer: "",
+            base64: "  ",
+          },
+          cfg,
+          accountId: "default",
+        });
+
+        expect(result.content).toEqual([
+          {
+            type: "text",
+            text: JSON.stringify({
+              ok: true,
+              channel: "mattermost",
+              messageId: "post-loopback",
+              channelId: CHANNEL_ID,
+            }),
+          },
+        ]);
+        expect(requests).toEqual([
+          {
+            path: "/api/v4/posts",
+            body: { channel_id: CHANNEL_ID, message: "loopback proof" },
+          },
+        ]);
+
+        await expect(
+          handleAction({
+            channel: "mattermost",
+            action: "send",
+            params: {
+              to: `channel:${CHANNEL_ID}`,
+              message: "must not send",
+              base64: "cmVwb3J0",
+            },
+            cfg,
+            accountId: "default",
+          }),
+        ).rejects.toThrow("buffer/base64 payloads are not supported");
+        expect(requests).toHaveLength(1);
+      },
+    );
+  });
+});

--- a/extensions/mattermost/src/channel.test.ts
+++ b/extensions/mattermost/src/channel.test.ts
@@ -1109,25 +1109,54 @@ describe("mattermostPlugin", () => {
       expect(sendMessageMattermostMock).not.toHaveBeenCalled();
     });
 
-    it("rejects unsupported buffer-only Mattermost send attachments", async () => {
+    it.each(["buffer", "base64"] as const)(
+      "rejects unsupported %s-only Mattermost send attachments",
+      async (field) => {
+        const cfg = createMattermostTestConfig();
+
+        await expect(
+          mattermostPlugin.actions?.handleAction?.(
+            createMattermostActionContext({
+              action: "send",
+              params: {
+                to: "channel:CHAN1",
+                message: "report",
+                [field]: "cmVwb3J0",
+                filename: "report.md",
+              },
+              cfg,
+              accountId: "default",
+            }),
+          ),
+        ).rejects.toThrow("buffer/base64 payloads are not supported");
+        expect(sendMessageMattermostMock).not.toHaveBeenCalled();
+      },
+    );
+
+    it.each([
+      { location: "top-level", params: { buffer: "", base64: "  " } },
+      {
+        location: "nested",
+        params: { attachments: [{ buffer: "", base64: "  " }] },
+      },
+    ])("ignores blank $location attachment payload fields", async ({ params }) => {
       const cfg = createMattermostTestConfig();
 
-      await expect(
-        mattermostPlugin.actions?.handleAction?.(
-          createMattermostActionContext({
-            action: "send",
-            params: {
-              to: "channel:CHAN1",
-              message: "report",
-              buffer: "cmVwb3J0",
-              filename: "report.md",
-            },
-            cfg,
-            accountId: "default",
-          }),
-        ),
-      ).rejects.toThrow("buffer/base64 payloads are not supported");
-      expect(sendMessageMattermostMock).not.toHaveBeenCalled();
+      await mattermostPlugin.actions?.handleAction?.(
+        createMattermostActionContext({
+          action: "send",
+          params: {
+            to: "channel:CHAN1",
+            message: "plain text",
+            ...params,
+          },
+          cfg,
+          accountId: "default",
+        }),
+      );
+
+      const options = expectSingleMattermostSend("channel:CHAN1", "plain text");
+      expect(options.mediaUrl).toBeUndefined();
     });
 
     it("rejects mixed supported and unsupported Mattermost send attachments", async () => {

--- a/extensions/mattermost/src/channel.ts
+++ b/extensions/mattermost/src/channel.ts
@@ -615,8 +615,9 @@ function collectMattermostAttachmentMedia(params: Record<string, unknown>): {
   ];
   mediaUrlCandidates.push(...readMattermostStringArrayParam(params, "mediaUrls"));
 
-  let hasUnsupportedAttachmentPayload =
-    typeof params.buffer === "string" || typeof params.base64 === "string";
+  let hasUnsupportedAttachmentPayload = Boolean(
+    readMattermostStringParam(params, "buffer") ?? readMattermostStringParam(params, "base64"),
+  );
   if (Array.isArray(params.attachments)) {
     for (const attachment of params.attachments) {
       if (!attachment || typeof attachment !== "object" || Array.isArray(attachment)) {
@@ -631,8 +632,9 @@ function collectMattermostAttachmentMedia(params: Record<string, unknown>): {
         readMattermostStringParam(record, "fileUrl"),
         readMattermostStringParam(record, "url"),
       );
-      hasUnsupportedAttachmentPayload ||= typeof record.buffer === "string";
-      hasUnsupportedAttachmentPayload ||= typeof record.base64 === "string";
+      hasUnsupportedAttachmentPayload ||= Boolean(
+        readMattermostStringParam(record, "buffer") ?? readMattermostStringParam(record, "base64"),
+      );
     }
   }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes text-only Mattermost replies being dropped when an action payload contains blank `buffer` or `base64` attachment placeholders.

## Why This Change Was Made

The Mattermost send action treated every string-valued binary attachment field as unsupported, including empty and whitespace-only placeholders. The Mattermost-owned validation boundary now normalizes both top-level and nested `buffer` / `base64` fields: blanks are absent, while every nonblank payload remains rejected before transport.

## User Impact

Ordinary text-only Mattermost replies now send when callers include blank attachment placeholders. Unsupported nonblank binary payloads still fail clearly instead of being silently dropped or sent.

## Evidence

- Focused tests: `node scripts/run-vitest.mjs extensions/mattermost/src/channel.send-loopback.test.ts extensions/mattermost/src/channel.test.ts extensions/mattermost/src/mattermost/send.test.ts` — 3 files, 98 tests passed.
- Real send-path proof: no maintainer Mattermost credentials were available, so the allowed loopback transport was used. `extensions/mattermost/src/channel.send-loopback.test.ts` exercises the actual action handler, lazy runtime sender, SSRF-guarded REST client, and `POST /api/v4/posts`; blank placeholders produced one redacted text post and the returned message receipt. A subsequent nonblank `base64` payload raised the expected unsupported-payload error, and the loopback request count remained one.
- Hosted changed gate: `node scripts/check-changed.mjs -- extensions/mattermost/src/channel.ts extensions/mattermost/src/channel.test.ts extensions/mattermost/src/channel.send-loopback.test.ts` — passed, including extension production/test typechecks, formatting, lint, plugin boundaries, and import cycles: https://github.com/openclaw/openclaw/actions/runs/29498564741
- `git diff --check` passed.
- Maintainer autoreview passed with no actionable findings (0.97 confidence).
- Mattermost's official create-post contract uses authenticated `POST /api/v4/posts` with `channel_id` and `message`, matching the loopback proof path.

AI-assisted: yes.

Co-authored-by: Andrey Gruzdev <44225021+Canvinus@users.noreply.github.com>
