### PR TITLE
fix(release): harden frozen target validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1694,6 +1694,8 @@ jobs:
 
       - name: Run Node test shard
         env:
+          JOB_WORKFLOW_REPOSITORY: ${{ job.workflow_repository }}
+          JOB_WORKFLOW_SHA: ${{ job.workflow_sha }}
           NODE_OPTIONS: --max-old-space-size=8192
           OPENCLAW_NODE_TEST_GROUPS_JSON: ${{ toJson(matrix.groups || null) }}
           OPENCLAW_NODE_TEST_CONFIGS_JSON: ${{ toJson(matrix.configs) }}
@@ -1712,14 +1714,23 @@ jobs:
             # Frozen release targets can predate the workflow-owned shard runner.
             # Load only that runner from the exact trusted workflow commit while
             # keeping its child tests rooted in the checked-out candidate.
+            if [[ ! "$JOB_WORKFLOW_REPOSITORY" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]; then
+              echo "invalid job workflow repository: $JOB_WORKFLOW_REPOSITORY" >&2
+              exit 1
+            fi
+            if [[ ! "$JOB_WORKFLOW_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+              echo "invalid job workflow SHA: $JOB_WORKFLOW_SHA" >&2
+              exit 1
+            fi
             harness_root="${RUNNER_TEMP}/openclaw-ci-shard-runner"
-            git fetch --no-tags --depth=1 origin "$GITHUB_SHA"
+            workflow_remote="https://github.com/${JOB_WORKFLOW_REPOSITORY}.git"
+            git fetch --no-tags --depth=1 "$workflow_remote" "$JOB_WORKFLOW_SHA"
             for file in \
               scripts/ci-run-node-test-shard.mjs \
               scripts/lib/direct-run.mjs \
               scripts/lib/local-heavy-check-runtime.mjs; do
               mkdir -p "${harness_root}/$(dirname "$file")"
-              git show "${GITHUB_SHA}:${file}" > "${harness_root}/${file}"
+              git show "${JOB_WORKFLOW_SHA}:${file}" > "${harness_root}/${file}"
             done
             runner="${harness_root}/${runner}"
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1693,9 +1693,10 @@ jobs:
         run: echo "OPENCLAW_VITEST_MAX_WORKERS=2" >> "$GITHUB_ENV"
 
       - name: Run Node test shard
+        # actionlint 1.7.11 lacks GitHub's current job.workflow_* fields. Serialize the
+        # non-secret job context, then validate the defining workflow identity below.
         env:
-          JOB_WORKFLOW_REPOSITORY: ${{ job.workflow_repository }}
-          JOB_WORKFLOW_SHA: ${{ job.workflow_sha }}
+          JOB_CONTEXT_JSON: ${{ toJSON(job) }}
           NODE_OPTIONS: --max-old-space-size=8192
           OPENCLAW_NODE_TEST_GROUPS_JSON: ${{ toJson(matrix.groups || null) }}
           OPENCLAW_NODE_TEST_CONFIGS_JSON: ${{ toJson(matrix.configs) }}
@@ -1714,23 +1715,25 @@ jobs:
             # Frozen release targets can predate the workflow-owned shard runner.
             # Load only that runner from the exact trusted workflow commit while
             # keeping its child tests rooted in the checked-out candidate.
-            if [[ ! "$JOB_WORKFLOW_REPOSITORY" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]; then
-              echo "invalid job workflow repository: $JOB_WORKFLOW_REPOSITORY" >&2
+            job_workflow_repository=$(jq -r '.workflow_repository // empty' <<<"$JOB_CONTEXT_JSON")
+            job_workflow_sha=$(jq -r '.workflow_sha // empty' <<<"$JOB_CONTEXT_JSON")
+            if [[ ! "$job_workflow_repository" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]; then
+              echo "invalid job workflow repository: $job_workflow_repository" >&2
               exit 1
             fi
-            if [[ ! "$JOB_WORKFLOW_SHA" =~ ^[0-9a-f]{40}$ ]]; then
-              echo "invalid job workflow SHA: $JOB_WORKFLOW_SHA" >&2
+            if [[ ! "$job_workflow_sha" =~ ^[0-9a-f]{40}$ ]]; then
+              echo "invalid job workflow SHA: $job_workflow_sha" >&2
               exit 1
             fi
             harness_root="${RUNNER_TEMP}/openclaw-ci-shard-runner"
-            workflow_remote="https://github.com/${JOB_WORKFLOW_REPOSITORY}.git"
-            git fetch --no-tags --depth=1 "$workflow_remote" "$JOB_WORKFLOW_SHA"
+            workflow_remote="https://github.com/${job_workflow_repository}.git"
+            git fetch --no-tags --depth=1 "$workflow_remote" "$job_workflow_sha"
             for file in \
               scripts/ci-run-node-test-shard.mjs \
               scripts/lib/direct-run.mjs \
               scripts/lib/local-heavy-check-runtime.mjs; do
               mkdir -p "${harness_root}/$(dirname "$file")"
-              git show "${JOB_WORKFLOW_SHA}:${file}" > "${harness_root}/${file}"
+              git show "${job_workflow_sha}:${file}" > "${harness_root}/${file}"
             done
             runner="${harness_root}/${runner}"
           fi

--- a/.github/workflows/full-release-validation.yml
+++ b/.github/workflows/full-release-validation.yml
@@ -1053,6 +1053,9 @@ jobs:
             -f allow_unreleased_changelog="$ALLOW_UNRELEASED_CHANGELOG"
             -f rerun_group="$child_rerun_group"
           )
+          if [[ -n "${TARGET_CONTEXT_REF// }" ]]; then
+            args+=(-f allow_frozen_target_scenario_omissions=true)
+          fi
           if [[ -n "${LIVE_SUITE_FILTER// }" ]]; then
             args+=(-f live_suite_filter="$LIVE_SUITE_FILTER")
           fi

--- a/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
+++ b/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
@@ -47,6 +47,11 @@ on:
         required: false
         default: ""
         type: string
+      allow_frozen_target_scenario_omissions:
+        description: Trusted opt-in to omit survivor scenarios absent from a canonical frozen target
+        required: false
+        default: false
+        type: boolean
       shared_image_policy:
         description: Shared Docker image transport
         required: true
@@ -389,6 +394,7 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
   NODE_VERSION: "24.15.0"
   OPENCLAW_DOCKER_E2E_ALLOW_UNRELEASED_CHANGELOG: ${{ inputs.allow_unreleased_changelog }}
+  OPENCLAW_ALLOW_FROZEN_TARGET_SCENARIO_OMISSIONS: ${{ inputs.allow_frozen_target_scenario_omissions && '1' || '0' }}
   OPENCLAW_UPGRADE_SURVIVOR_TARGET_ROOT: ${{ github.workspace }}
 
 jobs:

--- a/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
+++ b/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
@@ -190,6 +190,11 @@ on:
         required: false
         default: ""
         type: string
+      allow_frozen_target_scenario_omissions:
+        description: Trusted opt-in to omit survivor scenarios absent from a canonical frozen target
+        required: false
+        default: false
+        type: boolean
       package_artifact_name:
         description: Existing workflow artifact containing openclaw-current.tgz; blank packs the selected ref
         required: false

--- a/.github/workflows/openclaw-release-checks.yml
+++ b/.github/workflows/openclaw-release-checks.yml
@@ -56,6 +56,11 @@ on:
         required: false
         default: false
         type: boolean
+      allow_frozen_target_scenario_omissions:
+        description: Allow trusted compatibility filtering for a canonical frozen release target
+        required: false
+        default: false
+        type: boolean
       rerun_group:
         description: Release check group to run
         required: false
@@ -722,6 +727,7 @@ jobs:
     uses: ./.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
     with:
       advisory: ${{ startsWith(github.ref, 'refs/heads/tideclaw/alpha/') }}
+      allow_frozen_target_scenario_omissions: ${{ inputs.allow_frozen_target_scenario_omissions }}
       allow_unreleased_changelog: ${{ needs.resolve_target.outputs.allow_unreleased_changelog == 'true' }}
       # Live-provider suites depend on third-party model deployments; beta
       # treats only those as advisory while repo E2E stays blocking and
@@ -796,6 +802,7 @@ jobs:
     uses: ./.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
     with:
       advisory: ${{ startsWith(github.ref, 'refs/heads/tideclaw/alpha/') }}
+      allow_frozen_target_scenario_omissions: ${{ inputs.allow_frozen_target_scenario_omissions }}
       allow_unreleased_changelog: ${{ needs.resolve_target.outputs.allow_unreleased_changelog == 'true' }}
       ref: ${{ needs.resolve_target.outputs.revision }}
       include_repo_e2e: false

--- a/scripts/lib/docker-e2e-plan.d.mts
+++ b/scripts/lib/docker-e2e-plan.d.mts
@@ -40,6 +40,7 @@ export type DockerE2ePlan = {
   includeOpenWebUI: boolean;
   lanes: DockerE2ePlanLane[];
   mainLanes: DockerE2ePlanLane[];
+  omittedUnsupportedLanes: string[];
   needs: {
     bareImage: boolean;
     e2eImage: boolean;
@@ -79,6 +80,7 @@ export function lanesNeedE2eImageKind(
 export function lanesNeedOpenClawPackage(poolLanes: DockerE2eLane[]): boolean;
 export function findLaneByName(name: string): DockerE2eLane | undefined;
 export function resolveDockerE2ePlan(options: DockerE2ePlanOptions): {
+  omittedUnsupportedLaneNames: string[];
   orderedLanes: DockerE2eLane[];
   orderedTailLanes: DockerE2eLane[];
   plan: DockerE2ePlan;

--- a/scripts/lib/docker-e2e-plan.mjs
+++ b/scripts/lib/docker-e2e-plan.mjs
@@ -257,6 +257,24 @@ function supportsUpgradeSurvivorAcpToolsBridge(baselineSpec) {
   return comparePublishedReleaseVersion(version, { year: 2026, month: 4, patch: 22 }) >= 0;
 }
 
+function supportsUpgradeSurvivorScenarioAtBaseline(scenario, baselineSpec) {
+  return (
+    (scenario !== "plugin-deps-cleanup" ||
+      supportsUpgradeSurvivorPluginDependencyCleanup(baselineSpec)) &&
+    (scenario !== "acpx-openclaw-tools-bridge" ||
+      supportsUpgradeSurvivorAcpToolsBridge(baselineSpec))
+  );
+}
+
+function expandedUpgradeSurvivorLaneName(poolLaneName, baselineSpec, scenario) {
+  const suffixParts = [
+    baselineSpec ? sanitizeLaneNameSuffix(baselineSpec) : "",
+    scenario && scenario !== "base" ? sanitizeLaneNameSuffix(scenario) : "",
+  ].filter(Boolean);
+  const suffix = suffixParts.join("-");
+  return suffix ? `${poolLaneName}-${suffix}` : poolLaneName;
+}
+
 function expandUpgradeSurvivorBaselineLanes(
   poolLanes,
   rawBaselineSpecs,
@@ -275,53 +293,52 @@ function expandUpgradeSurvivorBaselineLanes(
   // harness cannot seed or assert. Filter by the selected tree's concrete
   // harness contract so validation never schedules an impossible target lane.
   const configuredScenarios = parseUpgradeSurvivorScenarios(rawScenarios);
-  const requestedScenarios =
-    configuredScenarios.length > 0 ? configuredScenarios : baselineSpecs.length > 0 ? ["base"] : [];
-  const supportedScenarios =
-    requestedScenarios.length > 0
-      ? filterUpgradeSurvivorScenariosForTarget(requestedScenarios, targetRoot)
-      : [];
+  const requestedScenarios = configuredScenarios.length > 0 ? configuredScenarios : ["base"];
+  const supportedScenarios = filterUpgradeSurvivorScenariosForTarget(
+    requestedScenarios,
+    targetRoot,
+  );
+  const supportedScenarioSet = new Set(supportedScenarios);
+  const unsupportedScenarios = targetRoot
+    ? requestedScenarios.filter((scenario) => !supportedScenarioSet.has(scenario))
+    : [];
   const scenarios = configuredScenarios.length > 0 ? supportedScenarios : [];
-  const targetSupportsNoRequestedScenario =
-    Boolean(targetRoot) && requestedScenarios.length > 0 && supportedScenarios.length === 0;
-  if (targetSupportsNoRequestedScenario) {
-    const omittedLaneNames = poolLanes
-      .filter(
-        (poolLane) =>
-          poolLane.name === "published-upgrade-survivor" || poolLane.name === "update-migration",
-      )
-      .map((poolLane) => poolLane.name);
+  const matrixBaselines = baselineSpecs.length > 0 ? baselineSpecs : [undefined];
+  const survivorLanes = poolLanes.filter(
+    (poolLane) =>
+      poolLane.name === "published-upgrade-survivor" || poolLane.name === "update-migration",
+  );
+  const omittedLaneNames = survivorLanes.flatMap((poolLane) =>
+    matrixBaselines.flatMap((baselineSpec) =>
+      unsupportedScenarios
+        .filter((scenario) => supportsUpgradeSurvivorScenarioAtBaseline(scenario, baselineSpec))
+        .map((scenario) => expandedUpgradeSurvivorLaneName(poolLane.name, baselineSpec, scenario)),
+    ),
+  );
+  if (supportedScenarios.length === 0 && unsupportedScenarios.length > 0) {
     return {
-      lanes: poolLanes.filter((poolLane) => !omittedLaneNames.includes(poolLane.name)),
+      lanes: poolLanes.filter(
+        (poolLane) =>
+          poolLane.name !== "published-upgrade-survivor" && poolLane.name !== "update-migration",
+      ),
       omittedLaneNames,
     };
   }
   if (baselineSpecs.length === 0 && scenarios.length === 0) {
-    return { lanes: poolLanes, omittedLaneNames: [] };
+    return { lanes: poolLanes, omittedLaneNames };
   }
   return {
     lanes: poolLanes.flatMap((poolLane) => {
       if (poolLane.name !== "published-upgrade-survivor" && poolLane.name !== "update-migration") {
         return [poolLane];
       }
-      const matrixBaselines = baselineSpecs.length > 0 ? baselineSpecs : [undefined];
       const matrixScenarios = scenarios.length > 0 ? scenarios : [undefined];
       return matrixBaselines.flatMap((baselineSpec) =>
         matrixScenarios
-          .filter(
-            (scenario) =>
-              (scenario !== "plugin-deps-cleanup" ||
-                supportsUpgradeSurvivorPluginDependencyCleanup(baselineSpec)) &&
-              (scenario !== "acpx-openclaw-tools-bridge" ||
-                supportsUpgradeSurvivorAcpToolsBridge(baselineSpec)),
-          )
+          .filter((scenario) => supportsUpgradeSurvivorScenarioAtBaseline(scenario, baselineSpec))
           .map((scenario) => {
-            const suffixParts = [
-              baselineSpec ? sanitizeLaneNameSuffix(baselineSpec) : "",
-              scenario && scenario !== "base" ? sanitizeLaneNameSuffix(scenario) : "",
-            ].filter(Boolean);
-            const suffix = suffixParts.join("-");
-            const name = suffix ? `${poolLane.name}-${suffix}` : poolLane.name;
+            const name = expandedUpgradeSurvivorLaneName(poolLane.name, baselineSpec, scenario);
+            const suffix = name.slice(poolLane.name.length + 1);
             const commandPrefix = [
               `OPENCLAW_UPGRADE_SURVIVOR_ARTIFACT_DIR="$PWD/.artifacts/upgrade-survivor/${name}"`,
               baselineSpec
@@ -343,7 +360,7 @@ function expandUpgradeSurvivorBaselineLanes(
           }),
       );
     }),
-    omittedLaneNames: [],
+    omittedLaneNames,
   };
 }
 

--- a/scripts/lib/docker-e2e-plan.mjs
+++ b/scripts/lib/docker-e2e-plan.mjs
@@ -3,6 +3,7 @@
 // lane plan. It intentionally does not define scenario commands.
 import { existsSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
+import ts from "typescript";
 import {
   BUNDLED_PLUGIN_INSTALL_UNINSTALL_SHARDS,
   DEFAULT_LIVE_RETRIES,
@@ -102,11 +103,53 @@ function filterUpgradeSurvivorScenariosForTarget(scenarios, targetRoot) {
     return [];
   }
   const assertionsSource = readFileSync(assertionsFile, "utf8");
-  const scenariosInitializer =
-    /const SCENARIOS = new Set\(\[([\s\S]*?)\]\);/u.exec(assertionsSource)?.[1] ?? "";
-  const supportedScenarios = new Set(
-    [...scenariosInitializer.matchAll(/"([^"]+)"/gu)].map((match) => match[1]),
+  const sourceFile = ts.createSourceFile(
+    assertionsFile,
+    assertionsSource,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.JS,
   );
+  const parseDiagnostic = sourceFile.parseDiagnostics[0];
+  if (parseDiagnostic) {
+    throw new Error(
+      `cannot parse frozen upgrade-survivor scenarios from ${assertionsFile}: ${ts.flattenDiagnosticMessageText(parseDiagnostic.messageText, "\n")}`,
+    );
+  }
+  let scenarioDeclaration;
+  for (const statement of sourceFile.statements) {
+    if (
+      !ts.isVariableStatement(statement) ||
+      (statement.declarationList.flags & ts.NodeFlags.Const) === 0
+    ) {
+      continue;
+    }
+    scenarioDeclaration = statement.declarationList.declarations.find(
+      (declaration) => ts.isIdentifier(declaration.name) && declaration.name.text === "SCENARIOS",
+    );
+    if (scenarioDeclaration) {
+      break;
+    }
+  }
+  const initializer = scenarioDeclaration?.initializer;
+  const scenarioArray =
+    initializer &&
+    ts.isNewExpression(initializer) &&
+    ts.isIdentifier(initializer.expression) &&
+    initializer.expression.text === "Set" &&
+    initializer.arguments?.length === 1 &&
+    ts.isArrayLiteralExpression(initializer.arguments[0])
+      ? initializer.arguments[0]
+      : undefined;
+  if (
+    !scenarioArray ||
+    scenarioArray.elements.some((element) => !ts.isStringLiteralLike(element))
+  ) {
+    throw new Error(
+      `cannot read frozen upgrade-survivor scenarios from ${assertionsFile}: expected const SCENARIOS = new Set([<string literals>])`,
+    );
+  }
+  const supportedScenarios = new Set(scenarioArray.elements.map((element) => element.text));
   return scenarios.filter((scenario) => supportedScenarios.has(scenario));
 }
 

--- a/scripts/lib/docker-e2e-plan.mjs
+++ b/scripts/lib/docker-e2e-plan.mjs
@@ -228,15 +228,18 @@ function expandUpgradeSurvivorBaselineLanes(
   const scenarios = filterUpgradeSurvivorScenariosForTarget(requestedScenarios, targetRoot);
   const targetSupportsNoRequestedScenario =
     Boolean(targetRoot) && requestedScenarios.length > 0 && scenarios.length === 0;
+  if (targetSupportsNoRequestedScenario) {
+    return poolLanes.filter(
+      (poolLane) =>
+        poolLane.name !== "published-upgrade-survivor" && poolLane.name !== "update-migration",
+    );
+  }
   if (baselineSpecs.length === 0 && scenarios.length === 0) {
     return poolLanes;
   }
   return poolLanes.flatMap((poolLane) => {
     if (poolLane.name !== "published-upgrade-survivor" && poolLane.name !== "update-migration") {
       return [poolLane];
-    }
-    if (targetSupportsNoRequestedScenario) {
-      return [];
     }
     const matrixBaselines = baselineSpecs.length > 0 ? baselineSpecs : [undefined];
     const matrixScenarios = scenarios.length > 0 ? scenarios : [undefined];

--- a/scripts/lib/docker-e2e-plan.mjs
+++ b/scripts/lib/docker-e2e-plan.mjs
@@ -263,6 +263,13 @@ function expandUpgradeSurvivorBaselineLanes(
   targetRoot,
   rawScenarios = "",
 ) {
+  const hasUpgradeSurvivorLane = poolLanes.some(
+    (poolLane) =>
+      poolLane.name === "published-upgrade-survivor" || poolLane.name === "update-migration",
+  );
+  if (!hasUpgradeSurvivorLane) {
+    return { lanes: poolLanes, omittedLaneNames: [] };
+  }
   const baselineSpecs = parseUpgradeSurvivorBaselineSpecs(rawBaselineSpecs);
   // Trusted-current planners may know scenarios that a frozen target's Docker
   // harness cannot seed or assert. Filter by the selected tree's concrete
@@ -270,10 +277,10 @@ function expandUpgradeSurvivorBaselineLanes(
   const configuredScenarios = parseUpgradeSurvivorScenarios(rawScenarios);
   const requestedScenarios =
     configuredScenarios.length > 0 ? configuredScenarios : baselineSpecs.length > 0 ? ["base"] : [];
-  const supportedScenarios = filterUpgradeSurvivorScenariosForTarget(
-    requestedScenarios,
-    targetRoot,
-  );
+  const supportedScenarios =
+    requestedScenarios.length > 0
+      ? filterUpgradeSurvivorScenariosForTarget(requestedScenarios, targetRoot)
+      : [];
   const scenarios = configuredScenarios.length > 0 ? supportedScenarios : [];
   const targetSupportsNoRequestedScenario =
     Boolean(targetRoot) && requestedScenarios.length > 0 && supportedScenarios.length === 0;
@@ -430,7 +437,7 @@ export function findLaneByName(name) {
       process.env.OPENCLAW_UPGRADE_SURVIVOR_BASELINE_SPECS,
       undefined,
       process.env.OPENCLAW_UPGRADE_SURVIVOR_SCENARIOS,
-    ),
+    ).lanes,
   ).find((poolLane) => poolLane.name === name);
 }
 
@@ -546,16 +553,8 @@ export function resolveDockerE2ePlan(options) {
       upgradeSurvivorScenarios,
     ).lanes,
   );
-  // Selectable lanes are a lookup catalog, not the scheduled plan. Record an
-  // omission only when a requested lane or release chunk consumes it.
-  const selectableLanes = dedupeLanes(
-    expandUpgradeSurvivorBaselineLanes(
-      unexpandedSelectableLanes,
-      upgradeSurvivorBaselines,
-      options.upgradeSurvivorTargetRoot,
-      upgradeSurvivorScenarios,
-    ).lanes,
-  );
+  // Selectable lanes are a target-agnostic lookup catalog. Frozen target
+  // contracts are read only after a survivor lane is actually requested.
   const releaseLanes =
     options.selectedLaneNames.length === 0 && options.profile === RELEASE_PATH_PROFILE
       ? options.planReleaseAll
@@ -572,21 +571,41 @@ export function resolveDockerE2ePlan(options) {
   const selectedLanes =
     options.selectedLaneNames.length > 0
       ? options.selectedLaneNames.flatMap((selectedName) => {
-          const expandedLane = selectableLanes.find((poolLane) => poolLane.name === selectedName);
-          if (expandedLane) {
-            return [expandedLane];
-          }
-          if (unfilteredSelectableLanes.some((poolLane) => poolLane.name === selectedName)) {
-            omittedUnsupportedLaneNames.add(selectedName);
-            return [];
-          }
           const unexpandedLane = unexpandedSelectableLanes.find(
             (poolLane) => poolLane.name === selectedName,
           );
           if (unexpandedLane) {
             return expandRequestedSurvivorLanes([unexpandedLane]);
           }
-          selectNamedLanes(selectableLanes, [selectedName], "OPENCLAW_DOCKER_ALL_LANES");
+          const expandedLane = unfilteredSelectableLanes.find(
+            (poolLane) => poolLane.name === selectedName,
+          );
+          if (expandedLane) {
+            const survivorBaseLane = unexpandedSelectableLanes.find(
+              (poolLane) =>
+                (poolLane.name === "published-upgrade-survivor" ||
+                  poolLane.name === "update-migration") &&
+                selectedName.startsWith(`${poolLane.name}-`),
+            );
+            if (!survivorBaseLane) {
+              return [expandedLane];
+            }
+            const targetExpansion = expandUpgradeSurvivorBaselineLanes(
+              [survivorBaseLane],
+              upgradeSurvivorBaselines,
+              options.upgradeSurvivorTargetRoot,
+              upgradeSurvivorScenarios,
+            );
+            const supportedLane = targetExpansion.lanes.find(
+              (poolLane) => poolLane.name === selectedName,
+            );
+            if (supportedLane) {
+              return [supportedLane];
+            }
+            omittedUnsupportedLaneNames.add(selectedName);
+            return [];
+          }
+          selectNamedLanes(unfilteredSelectableLanes, [selectedName], "OPENCLAW_DOCKER_ALL_LANES");
           return [];
         })
       : undefined;

--- a/scripts/lib/docker-e2e-plan.mjs
+++ b/scripts/lib/docker-e2e-plan.mjs
@@ -102,7 +102,12 @@ function filterUpgradeSurvivorScenariosForTarget(scenarios, targetRoot) {
     return [];
   }
   const assertionsSource = readFileSync(assertionsFile, "utf8");
-  return scenarios.filter((scenario) => assertionsSource.includes(JSON.stringify(scenario)));
+  const scenariosInitializer =
+    /const SCENARIOS = new Set\(\[([\s\S]*?)\]\);/u.exec(assertionsSource)?.[1] ?? "";
+  const supportedScenarios = new Set(
+    [...scenariosInitializer.matchAll(/"([^"]+)"/gu)].map((match) => match[1]),
+  );
+  return scenarios.filter((scenario) => supportedScenarios.has(scenario));
 }
 
 export function normalizeUpgradeSurvivorBaselineSpec(raw) {
@@ -209,21 +214,29 @@ function supportsUpgradeSurvivorAcpToolsBridge(baselineSpec) {
   return comparePublishedReleaseVersion(version, { year: 2026, month: 4, patch: 22 }) >= 0;
 }
 
-function expandUpgradeSurvivorBaselineLanes(poolLanes, rawBaselineSpecs, rawScenarios, targetRoot) {
+function expandUpgradeSurvivorBaselineLanes(
+  poolLanes,
+  rawBaselineSpecs,
+  targetRoot,
+  rawScenarios = "",
+) {
   const baselineSpecs = parseUpgradeSurvivorBaselineSpecs(rawBaselineSpecs);
   // Trusted-current planners may know scenarios that a frozen target's Docker
   // harness cannot seed or assert. Filter by the selected tree's concrete
   // harness contract so validation never schedules an impossible target lane.
-  const scenarios = filterUpgradeSurvivorScenariosForTarget(
-    parseUpgradeSurvivorScenarios(rawScenarios),
-    targetRoot,
-  );
+  const requestedScenarios = parseUpgradeSurvivorScenarios(rawScenarios);
+  const scenarios = filterUpgradeSurvivorScenariosForTarget(requestedScenarios, targetRoot);
+  const targetSupportsNoRequestedScenario =
+    Boolean(targetRoot) && requestedScenarios.length > 0 && scenarios.length === 0;
   if (baselineSpecs.length === 0 && scenarios.length === 0) {
     return poolLanes;
   }
   return poolLanes.flatMap((poolLane) => {
     if (poolLane.name !== "published-upgrade-survivor" && poolLane.name !== "update-migration") {
       return [poolLane];
+    }
+    if (targetSupportsNoRequestedScenario) {
+      return [];
     }
     const matrixBaselines = baselineSpecs.length > 0 ? baselineSpecs : [undefined];
     const matrixScenarios = scenarios.length > 0 ? scenarios : [undefined];
@@ -354,6 +367,7 @@ export function findLaneByName(name) {
     expandUpgradeSurvivorBaselineLanes(
       [...allReleasePathLanes({ includeOpenWebUI: true }), ...mainLanes, ...tailLanes],
       process.env.OPENCLAW_UPGRADE_SURVIVOR_BASELINE_SPECS,
+      undefined,
       process.env.OPENCLAW_UPGRADE_SURVIVOR_SCENARIOS,
     ),
   ).find((poolLane) => poolLane.name === name);
@@ -453,8 +467,8 @@ export function resolveDockerE2ePlan(options) {
     expandUpgradeSurvivorBaselineLanes(
       unexpandedSelectableLanes,
       upgradeSurvivorBaselines,
-      upgradeSurvivorScenarios,
       options.upgradeSurvivorTargetRoot,
+      upgradeSurvivorScenarios,
     ),
   );
   const releaseLanes =
@@ -463,8 +477,8 @@ export function resolveDockerE2ePlan(options) {
         ? expandUpgradeSurvivorBaselineLanes(
             allReleasePathLanes({ includeOpenWebUI: options.includeOpenWebUI, releaseProfile }),
             upgradeSurvivorBaselines,
-            upgradeSurvivorScenarios,
             options.upgradeSurvivorTargetRoot,
+            upgradeSurvivorScenarios,
           )
         : expandUpgradeSurvivorBaselineLanes(
             releasePathChunkLanes(options.releaseChunk, {
@@ -472,8 +486,8 @@ export function resolveDockerE2ePlan(options) {
               releaseProfile,
             }),
             upgradeSurvivorBaselines,
-            upgradeSurvivorScenarios,
             options.upgradeSurvivorTargetRoot,
+            upgradeSurvivorScenarios,
           )
       : undefined;
   const selectedLanes =
@@ -490,8 +504,8 @@ export function resolveDockerE2ePlan(options) {
             return expandUpgradeSurvivorBaselineLanes(
               [unexpandedLane],
               upgradeSurvivorBaselines,
-              upgradeSurvivorScenarios,
               options.upgradeSurvivorTargetRoot,
+              upgradeSurvivorScenarios,
             );
           }
           selectNamedLanes(selectableLanes, [selectedName], "OPENCLAW_DOCKER_ALL_LANES");

--- a/scripts/lib/docker-e2e-plan.mjs
+++ b/scripts/lib/docker-e2e-plan.mjs
@@ -267,62 +267,77 @@ function expandUpgradeSurvivorBaselineLanes(
   // Trusted-current planners may know scenarios that a frozen target's Docker
   // harness cannot seed or assert. Filter by the selected tree's concrete
   // harness contract so validation never schedules an impossible target lane.
-  const requestedScenarios = parseUpgradeSurvivorScenarios(rawScenarios);
-  const scenarios = filterUpgradeSurvivorScenariosForTarget(requestedScenarios, targetRoot);
+  const configuredScenarios = parseUpgradeSurvivorScenarios(rawScenarios);
+  const requestedScenarios =
+    configuredScenarios.length > 0 ? configuredScenarios : baselineSpecs.length > 0 ? ["base"] : [];
+  const supportedScenarios = filterUpgradeSurvivorScenariosForTarget(
+    requestedScenarios,
+    targetRoot,
+  );
+  const scenarios = configuredScenarios.length > 0 ? supportedScenarios : [];
   const targetSupportsNoRequestedScenario =
-    Boolean(targetRoot) && requestedScenarios.length > 0 && scenarios.length === 0;
+    Boolean(targetRoot) && requestedScenarios.length > 0 && supportedScenarios.length === 0;
   if (targetSupportsNoRequestedScenario) {
-    return poolLanes.filter(
-      (poolLane) =>
-        poolLane.name !== "published-upgrade-survivor" && poolLane.name !== "update-migration",
-    );
+    const omittedLaneNames = poolLanes
+      .filter(
+        (poolLane) =>
+          poolLane.name === "published-upgrade-survivor" || poolLane.name === "update-migration",
+      )
+      .map((poolLane) => poolLane.name);
+    return {
+      lanes: poolLanes.filter((poolLane) => !omittedLaneNames.includes(poolLane.name)),
+      omittedLaneNames,
+    };
   }
   if (baselineSpecs.length === 0 && scenarios.length === 0) {
-    return poolLanes;
+    return { lanes: poolLanes, omittedLaneNames: [] };
   }
-  return poolLanes.flatMap((poolLane) => {
-    if (poolLane.name !== "published-upgrade-survivor" && poolLane.name !== "update-migration") {
-      return [poolLane];
-    }
-    const matrixBaselines = baselineSpecs.length > 0 ? baselineSpecs : [undefined];
-    const matrixScenarios = scenarios.length > 0 ? scenarios : [undefined];
-    return matrixBaselines.flatMap((baselineSpec) =>
-      matrixScenarios
-        .filter(
-          (scenario) =>
-            (scenario !== "plugin-deps-cleanup" ||
-              supportsUpgradeSurvivorPluginDependencyCleanup(baselineSpec)) &&
-            (scenario !== "acpx-openclaw-tools-bridge" ||
-              supportsUpgradeSurvivorAcpToolsBridge(baselineSpec)),
-        )
-        .map((scenario) => {
-          const suffixParts = [
-            baselineSpec ? sanitizeLaneNameSuffix(baselineSpec) : "",
-            scenario && scenario !== "base" ? sanitizeLaneNameSuffix(scenario) : "",
-          ].filter(Boolean);
-          const suffix = suffixParts.join("-");
-          const name = suffix ? `${poolLane.name}-${suffix}` : poolLane.name;
-          const commandPrefix = [
-            `OPENCLAW_UPGRADE_SURVIVOR_ARTIFACT_DIR="$PWD/.artifacts/upgrade-survivor/${name}"`,
-            baselineSpec
-              ? `OPENCLAW_UPGRADE_SURVIVOR_BASELINE_SPEC=${shellQuote(baselineSpec)}`
-              : "",
-            scenario ? `OPENCLAW_UPGRADE_SURVIVOR_SCENARIO=${shellQuote(scenario)}` : "",
-          ]
-            .filter(Boolean)
-            .join(" ");
-          return Object.assign({}, poolLane, {
-            cacheKey: poolLane.cacheKey
-              ? suffix
-                ? `${poolLane.cacheKey}-${suffix}`
-                : poolLane.cacheKey
-              : name,
-            command: commandPrefix ? `${commandPrefix} ${poolLane.command}` : poolLane.command,
-            name,
-          });
-        }),
-    );
-  });
+  return {
+    lanes: poolLanes.flatMap((poolLane) => {
+      if (poolLane.name !== "published-upgrade-survivor" && poolLane.name !== "update-migration") {
+        return [poolLane];
+      }
+      const matrixBaselines = baselineSpecs.length > 0 ? baselineSpecs : [undefined];
+      const matrixScenarios = scenarios.length > 0 ? scenarios : [undefined];
+      return matrixBaselines.flatMap((baselineSpec) =>
+        matrixScenarios
+          .filter(
+            (scenario) =>
+              (scenario !== "plugin-deps-cleanup" ||
+                supportsUpgradeSurvivorPluginDependencyCleanup(baselineSpec)) &&
+              (scenario !== "acpx-openclaw-tools-bridge" ||
+                supportsUpgradeSurvivorAcpToolsBridge(baselineSpec)),
+          )
+          .map((scenario) => {
+            const suffixParts = [
+              baselineSpec ? sanitizeLaneNameSuffix(baselineSpec) : "",
+              scenario && scenario !== "base" ? sanitizeLaneNameSuffix(scenario) : "",
+            ].filter(Boolean);
+            const suffix = suffixParts.join("-");
+            const name = suffix ? `${poolLane.name}-${suffix}` : poolLane.name;
+            const commandPrefix = [
+              `OPENCLAW_UPGRADE_SURVIVOR_ARTIFACT_DIR="$PWD/.artifacts/upgrade-survivor/${name}"`,
+              baselineSpec
+                ? `OPENCLAW_UPGRADE_SURVIVOR_BASELINE_SPEC=${shellQuote(baselineSpec)}`
+                : "",
+              scenario ? `OPENCLAW_UPGRADE_SURVIVOR_SCENARIO=${shellQuote(scenario)}` : "",
+            ]
+              .filter(Boolean)
+              .join(" ");
+            return Object.assign({}, poolLane, {
+              cacheKey: poolLane.cacheKey
+                ? suffix
+                  ? `${poolLane.cacheKey}-${suffix}`
+                  : poolLane.cacheKey
+                : name,
+              command: commandPrefix ? `${commandPrefix} ${poolLane.command}` : poolLane.command,
+              name,
+            });
+          }),
+      );
+    }),
+    omittedLaneNames: [],
+  };
 }
 
 function dedupeLanes(poolLanes) {
@@ -480,6 +495,7 @@ function buildPlanJson(params) {
       weight: laneWeight(poolLane),
     })),
     mainLanes: params.orderedLanes.map((poolLane) => poolLane.name),
+    omittedUnsupportedLanes: params.omittedUnsupportedLaneNames,
     needs: {
       bareImage: imageKinds.includes("bare"),
       e2eImage: imageKinds.length > 0,
@@ -509,31 +525,48 @@ export function resolveDockerE2ePlan(options) {
     ...retriedMainLanes,
     ...retriedTailLanes,
   ]);
+  const omittedUnsupportedLaneNames = new Set();
+  const expandRequestedSurvivorLanes = (poolLanes) => {
+    const expansion = expandUpgradeSurvivorBaselineLanes(
+      poolLanes,
+      upgradeSurvivorBaselines,
+      options.upgradeSurvivorTargetRoot,
+      upgradeSurvivorScenarios,
+    );
+    for (const laneName of expansion.omittedLaneNames) {
+      omittedUnsupportedLaneNames.add(laneName);
+    }
+    return expansion.lanes;
+  };
+  const unfilteredSelectableLanes = dedupeLanes(
+    expandUpgradeSurvivorBaselineLanes(
+      unexpandedSelectableLanes,
+      upgradeSurvivorBaselines,
+      undefined,
+      upgradeSurvivorScenarios,
+    ).lanes,
+  );
+  // Selectable lanes are a lookup catalog, not the scheduled plan. Record an
+  // omission only when a requested lane or release chunk consumes it.
   const selectableLanes = dedupeLanes(
     expandUpgradeSurvivorBaselineLanes(
       unexpandedSelectableLanes,
       upgradeSurvivorBaselines,
       options.upgradeSurvivorTargetRoot,
       upgradeSurvivorScenarios,
-    ),
+    ).lanes,
   );
   const releaseLanes =
     options.selectedLaneNames.length === 0 && options.profile === RELEASE_PATH_PROFILE
       ? options.planReleaseAll
-        ? expandUpgradeSurvivorBaselineLanes(
+        ? expandRequestedSurvivorLanes(
             allReleasePathLanes({ includeOpenWebUI: options.includeOpenWebUI, releaseProfile }),
-            upgradeSurvivorBaselines,
-            options.upgradeSurvivorTargetRoot,
-            upgradeSurvivorScenarios,
           )
-        : expandUpgradeSurvivorBaselineLanes(
+        : expandRequestedSurvivorLanes(
             releasePathChunkLanes(options.releaseChunk, {
               includeOpenWebUI: options.includeOpenWebUI,
               releaseProfile,
             }),
-            upgradeSurvivorBaselines,
-            options.upgradeSurvivorTargetRoot,
-            upgradeSurvivorScenarios,
           )
       : undefined;
   const selectedLanes =
@@ -543,16 +576,15 @@ export function resolveDockerE2ePlan(options) {
           if (expandedLane) {
             return [expandedLane];
           }
+          if (unfilteredSelectableLanes.some((poolLane) => poolLane.name === selectedName)) {
+            omittedUnsupportedLaneNames.add(selectedName);
+            return [];
+          }
           const unexpandedLane = unexpandedSelectableLanes.find(
             (poolLane) => poolLane.name === selectedName,
           );
           if (unexpandedLane) {
-            return expandUpgradeSurvivorBaselineLanes(
-              [unexpandedLane],
-              upgradeSurvivorBaselines,
-              options.upgradeSurvivorTargetRoot,
-              upgradeSurvivorScenarios,
-            );
+            return expandRequestedSurvivorLanes([unexpandedLane]);
           }
           selectNamedLanes(selectableLanes, [selectedName], "OPENCLAW_DOCKER_ALL_LANES");
           return [];
@@ -574,10 +606,12 @@ export function resolveDockerE2ePlan(options) {
   const orderedLanes = options.orderLanes(configuredLanes, options.timingStore);
   const orderedTailLanes = options.orderLanes(configuredTailLanes, options.timingStore);
   return {
+    omittedUnsupportedLaneNames: [...omittedUnsupportedLaneNames],
     orderedLanes,
     orderedTailLanes,
     plan: buildPlanJson({
       includeOpenWebUI: options.includeOpenWebUI,
+      omittedUnsupportedLaneNames: [...omittedUnsupportedLaneNames],
       orderedLanes,
       orderedTailLanes,
       profile: options.profile,

--- a/scripts/test-docker-all.mjs
+++ b/scripts/test-docker-all.mjs
@@ -1511,22 +1511,23 @@ async function main() {
   appendExtension(baseEnv, "codex");
 
   const timingStore = await loadTimingStore(timingsFile, timingsEnabled);
-  const { orderedLanes, orderedTailLanes, plan, scheduledLanes } = resolveDockerE2ePlan({
-    includeOpenWebUI,
-    liveMode,
-    liveRetries,
-    orderLanes,
-    planReleaseAll: planJson && planReleaseAll,
-    profile,
-    releaseChunk,
-    releaseProfile,
-    selectedLaneNames,
-    timingStore,
-    upgradeSurvivorBaselines: process.env.OPENCLAW_UPGRADE_SURVIVOR_BASELINE_SPECS,
-    upgradeSurvivorScenarios: process.env.OPENCLAW_UPGRADE_SURVIVOR_SCENARIOS,
-    upgradeSurvivorTargetRoot: process.env.OPENCLAW_UPGRADE_SURVIVOR_TARGET_ROOT,
-  });
-  if (scheduledLanes.length === 0) {
+  const { omittedUnsupportedLaneNames, orderedLanes, orderedTailLanes, plan, scheduledLanes } =
+    resolveDockerE2ePlan({
+      includeOpenWebUI,
+      liveMode,
+      liveRetries,
+      orderLanes,
+      planReleaseAll: planJson && planReleaseAll,
+      profile,
+      releaseChunk,
+      releaseProfile,
+      selectedLaneNames,
+      timingStore,
+      upgradeSurvivorBaselines: process.env.OPENCLAW_UPGRADE_SURVIVOR_BASELINE_SPECS,
+      upgradeSurvivorScenarios: process.env.OPENCLAW_UPGRADE_SURVIVOR_SCENARIOS,
+      upgradeSurvivorTargetRoot: process.env.OPENCLAW_UPGRADE_SURVIVOR_TARGET_ROOT,
+    });
+  if (scheduledLanes.length === 0 && omittedUnsupportedLaneNames.length === 0) {
     throw new Error(
       [
         "resolved zero Docker lanes",
@@ -1539,6 +1540,8 @@ async function main() {
       ].join("; "),
     );
   }
+  const omittedUnsupportedLanes =
+    omittedUnsupportedLaneNames.length > 0 ? omittedUnsupportedLaneNames : undefined;
 
   if (planJson) {
     process.stdout.write(`${JSON.stringify(plan, null, 2)}\n`);
@@ -1586,8 +1589,28 @@ async function main() {
   );
   printLaneManifest("Main", orderedLanes, timingStore);
   printLaneManifest("Tail", orderedTailLanes, timingStore);
+  if (omittedUnsupportedLanes) {
+    console.log(
+      `==> Docker lanes omitted: target lacks ${omittedUnsupportedLanes.join(", ")} scenario support`,
+    );
+  }
   if (dryRun) {
     console.log("==> Dry run complete");
+    return;
+  }
+
+  if (scheduledLanes.length === 0) {
+    await writeSummary({
+      chunk: releaseChunk || undefined,
+      failures: [],
+      lanes: [],
+      omittedUnsupportedLanes,
+      phases,
+      profile,
+      selectedLanes: selectedLaneNames.length > 0 ? selectedLaneNames : undefined,
+      startedAt: runStartedAt,
+      status: "passed",
+    });
     return;
   }
 
@@ -1677,6 +1700,7 @@ async function main() {
         functional: baseEnv.OPENCLAW_DOCKER_E2E_FUNCTIONAL_IMAGE,
       },
       lanes: allResults,
+      omittedUnsupportedLanes,
       phases,
       profile,
       selectedLanes: selectedLaneNames.length > 0 ? selectedLaneNames : undefined,
@@ -1716,6 +1740,7 @@ async function main() {
         functional: baseEnv.OPENCLAW_DOCKER_E2E_FUNCTIONAL_IMAGE,
       },
       lanes: allResults,
+      omittedUnsupportedLanes,
       phases,
       profile,
       selectedLanes: selectedLaneNames.length > 0 ? selectedLaneNames : undefined,
@@ -1745,6 +1770,7 @@ async function main() {
         functional: baseEnv.OPENCLAW_DOCKER_E2E_FUNCTIONAL_IMAGE,
       },
       lanes: allResults,
+      omittedUnsupportedLanes,
       phases,
       profile,
       selectedLanes: selectedLaneNames.length > 0 ? selectedLaneNames : undefined,
@@ -1763,6 +1789,7 @@ async function main() {
       functional: baseEnv.OPENCLAW_DOCKER_E2E_FUNCTIONAL_IMAGE,
     },
     lanes: allResults,
+    omittedUnsupportedLanes,
     phases,
     profile,
     selectedLanes: selectedLaneNames.length > 0 ? selectedLaneNames : undefined,

--- a/scripts/test-docker-all.mjs
+++ b/scripts/test-docker-all.mjs
@@ -1460,6 +1460,10 @@ async function main() {
   const preflightCleanup = parseBool(process.env.OPENCLAW_DOCKER_ALL_PREFLIGHT_CLEANUP, true);
   const timingsEnabled = parseBool(process.env.OPENCLAW_DOCKER_ALL_TIMINGS, true);
   const buildEnabled = parseBool(process.env.OPENCLAW_DOCKER_ALL_BUILD, true);
+  const allowFrozenTargetScenarioOmissions = parseBool(
+    process.env.OPENCLAW_ALLOW_FROZEN_TARGET_SCENARIO_OMISSIONS,
+    false,
+  );
   const planJson =
     cliOptions.planJson || parseBool(process.env.OPENCLAW_DOCKER_ALL_PLAN_JSON, false);
   const planReleaseAll = parseBool(process.env.OPENCLAW_DOCKER_ALL_PLAN_RELEASE_ALL, false);
@@ -1527,6 +1531,11 @@ async function main() {
       upgradeSurvivorScenarios: process.env.OPENCLAW_UPGRADE_SURVIVOR_SCENARIOS,
       upgradeSurvivorTargetRoot: process.env.OPENCLAW_UPGRADE_SURVIVOR_TARGET_ROOT,
     });
+  if (omittedUnsupportedLaneNames.length > 0 && !allowFrozenTargetScenarioOmissions) {
+    throw new Error(
+      `frozen target scenario omissions require trusted workflow opt-in: ${omittedUnsupportedLaneNames.join(", ")}`,
+    );
+  }
   if (scheduledLanes.length === 0 && omittedUnsupportedLaneNames.length === 0) {
     throw new Error(
       [

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -2643,15 +2643,16 @@ describe("ci workflow guards", () => {
     expect(runStep.env.OPENCLAW_VITEST_NO_OUTPUT_RETRY).toBe("1");
     expect(runStep.env.OPENCLAW_NODE_TEST_ENV_JSON).toBe("${{ toJson(matrix.env) }}");
     expect(runStep.env.OPENCLAW_NODE_TEST_TARGETS_JSON).toBe("${{ toJson(matrix.targets) }}");
-    expect(runStep.env.JOB_WORKFLOW_REPOSITORY).toBe("${{ job.workflow_repository }}");
-    expect(runStep.env.JOB_WORKFLOW_SHA).toBe("${{ job.workflow_sha }}");
+    expect(runStep.env.JOB_CONTEXT_JSON).toBe("${{ toJSON(job) }}");
     // Shard execution policy lives in the unit-tested wrapper script. Frozen
     // release targets load that wrapper from the exact trusted workflow SHA.
     for (const expected of [
       'runner="scripts/ci-run-node-test-shard.mjs"',
       'if [[ ! -f "$runner" ]]',
-      'git fetch --no-tags --depth=1 "$workflow_remote" "$JOB_WORKFLOW_SHA"',
-      'git show "${JOB_WORKFLOW_SHA}:${file}" > "${harness_root}/${file}"',
+      "job_workflow_repository=$(jq -r '.workflow_repository // empty' <<<\"$JOB_CONTEXT_JSON\")",
+      "job_workflow_sha=$(jq -r '.workflow_sha // empty' <<<\"$JOB_CONTEXT_JSON\")",
+      'git fetch --no-tags --depth=1 "$workflow_remote" "$job_workflow_sha"',
+      'git show "${job_workflow_sha}:${file}" > "${harness_root}/${file}"',
       'node "$runner"',
     ]) {
       expect(runStep.run).toContain(expected);

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -2643,13 +2643,15 @@ describe("ci workflow guards", () => {
     expect(runStep.env.OPENCLAW_VITEST_NO_OUTPUT_RETRY).toBe("1");
     expect(runStep.env.OPENCLAW_NODE_TEST_ENV_JSON).toBe("${{ toJson(matrix.env) }}");
     expect(runStep.env.OPENCLAW_NODE_TEST_TARGETS_JSON).toBe("${{ toJson(matrix.targets) }}");
+    expect(runStep.env.JOB_WORKFLOW_REPOSITORY).toBe("${{ job.workflow_repository }}");
+    expect(runStep.env.JOB_WORKFLOW_SHA).toBe("${{ job.workflow_sha }}");
     // Shard execution policy lives in the unit-tested wrapper script. Frozen
     // release targets load that wrapper from the exact trusted workflow SHA.
     for (const expected of [
       'runner="scripts/ci-run-node-test-shard.mjs"',
       'if [[ ! -f "$runner" ]]',
-      'git fetch --no-tags --depth=1 origin "$GITHUB_SHA"',
-      'git show "${GITHUB_SHA}:${file}" > "${harness_root}/${file}"',
+      'git fetch --no-tags --depth=1 "$workflow_remote" "$JOB_WORKFLOW_SHA"',
+      'git show "${JOB_WORKFLOW_SHA}:${file}" > "${harness_root}/${file}"',
       'node "$runner"',
     ]) {
       expect(runStep.run).toContain(expected);

--- a/test/scripts/docker-all-scheduler.test.ts
+++ b/test/scripts/docker-all-scheduler.test.ts
@@ -301,6 +301,33 @@ describe("scripts/test-docker-all scheduler", () => {
     }
   });
 
+  it("rejects candidate-controlled survivor omissions without trusted opt-in", () => {
+    const root = mkdtempSync(`${tmpdir()}/openclaw-docker-all-untrusted-filter-`);
+    const assertionsFile = path.join(root, "scripts/e2e/lib/upgrade-survivor/assertions.mjs");
+    try {
+      mkdirSync(path.dirname(assertionsFile), { recursive: true });
+      writeFileSync(assertionsFile, 'const SCENARIOS = new Set(["unrelated"]);\n');
+      const result = spawnSync(process.execPath, ["scripts/test-docker-all.mjs"], {
+        cwd: process.cwd(),
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          OPENCLAW_ALLOW_FROZEN_TARGET_SCENARIO_OMISSIONS: "0",
+          OPENCLAW_DOCKER_ALL_DRY_RUN: "1",
+          OPENCLAW_DOCKER_ALL_LANES: "published-upgrade-survivor",
+          OPENCLAW_DOCKER_ALL_TIMINGS: "0",
+          OPENCLAW_UPGRADE_SURVIVOR_TARGET_ROOT: root,
+        },
+      });
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain("require trusted workflow opt-in");
+      expect(result.stdout).not.toContain("Dry run complete");
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
   it("writes a passing summary when a frozen target cannot run selected survivor lanes", () => {
     const root = mkdtempSync(`${tmpdir()}/openclaw-docker-all-filtered-`);
     const logDir = path.join(root, "logs");
@@ -313,6 +340,7 @@ describe("scripts/test-docker-all scheduler", () => {
         encoding: "utf8",
         env: {
           ...process.env,
+          OPENCLAW_ALLOW_FROZEN_TARGET_SCENARIO_OMISSIONS: "1",
           OPENCLAW_DOCKER_ALL_BUILD: "0",
           OPENCLAW_DOCKER_ALL_LANES: "published-upgrade-survivor",
           OPENCLAW_DOCKER_ALL_LOG_DIR: logDir,
@@ -348,6 +376,7 @@ describe("scripts/test-docker-all scheduler", () => {
         encoding: "utf8",
         env: {
           ...process.env,
+          OPENCLAW_ALLOW_FROZEN_TARGET_SCENARIO_OMISSIONS: "1",
           OPENCLAW_DOCKER_ALL_DRY_RUN: "1",
           OPENCLAW_DOCKER_ALL_LANES: "published-upgrade-survivor,plugin-binding-command-escape",
           OPENCLAW_DOCKER_ALL_TIMINGS: "0",

--- a/test/scripts/docker-all-scheduler.test.ts
+++ b/test/scripts/docker-all-scheduler.test.ts
@@ -327,7 +327,11 @@ describe("scripts/test-docker-all scheduler", () => {
       const summary = JSON.parse(readFileSync(path.join(logDir, "summary.json"), "utf8"));
       expect(summary.status).toBe("passed");
       expect(summary.lanes).toEqual([]);
-      expect(summary.omittedUnsupportedLanes).toEqual(["published-upgrade-survivor"]);
+      expect(summary.omittedUnsupportedLanes).toHaveLength(10);
+      expect(summary.omittedUnsupportedLanes).toContain("published-upgrade-survivor");
+      expect(summary.omittedUnsupportedLanes).toContain(
+        "published-upgrade-survivor-versioned-runtime-deps",
+      );
     } finally {
       rmSync(root, { force: true, recursive: true });
     }

--- a/test/scripts/docker-all-scheduler.test.ts
+++ b/test/scripts/docker-all-scheduler.test.ts
@@ -12,7 +12,7 @@ import {
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import { parse } from "yaml";
 import { DEFAULT_RESOURCE_LIMITS } from "../../scripts/lib/docker-e2e-plan.mjs";
 import {
@@ -32,6 +32,7 @@ import {
   tailFile,
   writeRunSummary,
 } from "../../scripts/test-docker-all.mjs";
+import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 import { createScriptTestHarness } from "./test-helpers.js";
 
 const limits = {
@@ -43,6 +44,7 @@ const limits = {
 };
 const posixIt = process.platform === "win32" ? it.skip : it;
 const { createTempDir } = createScriptTestHarness();
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 const LIVE_E2E_WORKFLOW = ".github/workflows/openclaw-live-and-e2e-checks-reusable.yml";
 
 function expectDeclaredDispatchInputs(command: string): void {
@@ -302,7 +304,7 @@ describe("scripts/test-docker-all scheduler", () => {
   });
 
   it("rejects candidate-controlled survivor omissions without trusted opt-in", () => {
-    const root = mkdtempSync(`${tmpdir()}/openclaw-docker-all-untrusted-filter-`);
+    const root = tempDirs.make("openclaw-docker-all-untrusted-filter-");
     const assertionsFile = path.join(root, "scripts/e2e/lib/upgrade-survivor/assertions.mjs");
     try {
       mkdirSync(path.dirname(assertionsFile), { recursive: true });
@@ -329,7 +331,7 @@ describe("scripts/test-docker-all scheduler", () => {
   });
 
   it("writes a passing summary when a frozen target cannot run selected survivor lanes", () => {
-    const root = mkdtempSync(`${tmpdir()}/openclaw-docker-all-filtered-`);
+    const root = tempDirs.make("openclaw-docker-all-filtered-");
     const logDir = path.join(root, "logs");
     const assertionsFile = path.join(root, "scripts/e2e/lib/upgrade-survivor/assertions.mjs");
     try {
@@ -366,7 +368,7 @@ describe("scripts/test-docker-all scheduler", () => {
   });
 
   it("reports omitted frozen-target lanes when another selected lane remains runnable", () => {
-    const root = mkdtempSync(`${tmpdir()}/openclaw-docker-all-mixed-filtered-`);
+    const root = tempDirs.make("openclaw-docker-all-mixed-filtered-");
     const assertionsFile = path.join(root, "scripts/e2e/lib/upgrade-survivor/assertions.mjs");
     try {
       mkdirSync(path.dirname(assertionsFile), { recursive: true });

--- a/test/scripts/docker-all-scheduler.test.ts
+++ b/test/scripts/docker-all-scheduler.test.ts
@@ -301,6 +301,66 @@ describe("scripts/test-docker-all scheduler", () => {
     }
   });
 
+  it("writes a passing summary when a frozen target cannot run selected survivor lanes", () => {
+    const root = mkdtempSync(`${tmpdir()}/openclaw-docker-all-filtered-`);
+    const logDir = path.join(root, "logs");
+    const assertionsFile = path.join(root, "scripts/e2e/lib/upgrade-survivor/assertions.mjs");
+    try {
+      mkdirSync(path.dirname(assertionsFile), { recursive: true });
+      writeFileSync(assertionsFile, 'const SCENARIOS = new Set(["unrelated"]);\n');
+      const result = spawnSync(process.execPath, ["scripts/test-docker-all.mjs"], {
+        cwd: process.cwd(),
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          OPENCLAW_DOCKER_ALL_BUILD: "0",
+          OPENCLAW_DOCKER_ALL_LANES: "published-upgrade-survivor",
+          OPENCLAW_DOCKER_ALL_LOG_DIR: logDir,
+          OPENCLAW_DOCKER_ALL_TIMINGS: "0",
+          OPENCLAW_UPGRADE_SURVIVOR_SCENARIOS: "reported-issues",
+          OPENCLAW_UPGRADE_SURVIVOR_TARGET_ROOT: root,
+        },
+      });
+
+      expect(result.status, result.stderr).toBe(0);
+      expect(result.stdout).toContain("Docker lanes omitted");
+      const summary = JSON.parse(readFileSync(path.join(logDir, "summary.json"), "utf8"));
+      expect(summary.status).toBe("passed");
+      expect(summary.lanes).toEqual([]);
+      expect(summary.omittedUnsupportedLanes).toEqual(["published-upgrade-survivor"]);
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  it("reports omitted frozen-target lanes when another selected lane remains runnable", () => {
+    const root = mkdtempSync(`${tmpdir()}/openclaw-docker-all-mixed-filtered-`);
+    const assertionsFile = path.join(root, "scripts/e2e/lib/upgrade-survivor/assertions.mjs");
+    try {
+      mkdirSync(path.dirname(assertionsFile), { recursive: true });
+      writeFileSync(assertionsFile, 'const SCENARIOS = new Set(["unrelated"]);\n');
+      const result = spawnSync(process.execPath, ["scripts/test-docker-all.mjs"], {
+        cwd: process.cwd(),
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          OPENCLAW_DOCKER_ALL_DRY_RUN: "1",
+          OPENCLAW_DOCKER_ALL_LANES: "published-upgrade-survivor,plugin-binding-command-escape",
+          OPENCLAW_DOCKER_ALL_TIMINGS: "0",
+          OPENCLAW_UPGRADE_SURVIVOR_SCENARIOS: "reported-issues",
+          OPENCLAW_UPGRADE_SURVIVOR_TARGET_ROOT: root,
+        },
+      });
+
+      expect(result.status, result.stderr).toBe(0);
+      expect(result.stdout).toContain("Docker lanes omitted");
+      expect(result.stdout).toContain("published-upgrade-survivor");
+      expect(result.stdout).toContain("plugin-binding-command-escape");
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
   posixIt("writes Docker run artifacts when cleanup smoke fails", async () => {
     const root = mkdtempSync(`${tmpdir()}/openclaw-docker-all-cleanup-`);
     const logDir = path.join(root, "logs");

--- a/test/scripts/docker-e2e-plan.test.ts
+++ b/test/scripts/docker-e2e-plan.test.ts
@@ -819,6 +819,21 @@ describe("scripts/lib/docker-e2e-plan", () => {
     expect(plan.lanes).toEqual([]);
   });
 
+  it("omits unsupported scenario-only survivor lanes without explicit baselines", () => {
+    const targetRoot = tempDirs.make("openclaw-frozen-scenario-only-harness-");
+    const assertionsFile = join(targetRoot, "scripts/e2e/lib/upgrade-survivor/assertions.mjs");
+    mkdirSync(dirname(assertionsFile), { recursive: true });
+    writeFileSync(assertionsFile, 'const SCENARIOS = new Set(["unrelated"]);\n');
+
+    const plan = planFor({
+      selectedLaneNames: ["published-upgrade-survivor"],
+      upgradeSurvivorScenarios: "reported-issues",
+      upgradeSurvivorTargetRoot: targetRoot,
+    });
+
+    expect(plan.lanes).toEqual([]);
+  });
+
   it("skips plugin dependency cleanup for baselines without packaged plugin dirs", () => {
     const plan = planFor({
       selectedLaneNames: ["published-upgrade-survivor"],

--- a/test/scripts/docker-e2e-plan.test.ts
+++ b/test/scripts/docker-e2e-plan.test.ts
@@ -817,6 +817,56 @@ describe("scripts/lib/docker-e2e-plan", () => {
     });
 
     expect(plan.lanes).toEqual([]);
+    expect(plan.omittedUnsupportedLanes).toEqual(["published-upgrade-survivor"]);
+  });
+
+  it("omits baseline-only survivor lanes when the target lacks the implicit base scenario", () => {
+    const targetRoot = tempDirs.make("openclaw-frozen-no-base-upgrade-harness-");
+    const assertionsFile = join(targetRoot, "scripts/e2e/lib/upgrade-survivor/assertions.mjs");
+    mkdirSync(dirname(assertionsFile), { recursive: true });
+    writeFileSync(assertionsFile, 'const SCENARIOS = new Set(["unrelated"]);\n');
+
+    const plan = planFor({
+      selectedLaneNames: ["published-upgrade-survivor"],
+      upgradeSurvivorBaselines: "2026.6.11",
+      upgradeSurvivorTargetRoot: targetRoot,
+    });
+
+    expect(plan.lanes).toEqual([]);
+    expect(plan.omittedUnsupportedLanes).toEqual(["published-upgrade-survivor"]);
+  });
+
+  it("reports an unsupported survivor lane beside runnable selected lanes", () => {
+    const targetRoot = tempDirs.make("openclaw-frozen-mixed-upgrade-harness-");
+    const assertionsFile = join(targetRoot, "scripts/e2e/lib/upgrade-survivor/assertions.mjs");
+    mkdirSync(dirname(assertionsFile), { recursive: true });
+    writeFileSync(assertionsFile, 'const SCENARIOS = new Set(["unrelated"]);\n');
+
+    const plan = planFor({
+      selectedLaneNames: ["published-upgrade-survivor", "plugin-binding-command-escape"],
+      upgradeSurvivorScenarios: "reported-issues",
+      upgradeSurvivorTargetRoot: targetRoot,
+    });
+
+    expect(plan.lanes.map((lane) => lane.name)).toEqual(["plugin-binding-command-escape"]);
+    expect(plan.omittedUnsupportedLanes).toEqual(["published-upgrade-survivor"]);
+  });
+
+  it("reports an explicitly selected expanded survivor lane as unsupported", () => {
+    const targetRoot = tempDirs.make("openclaw-frozen-expanded-upgrade-harness-");
+    const assertionsFile = join(targetRoot, "scripts/e2e/lib/upgrade-survivor/assertions.mjs");
+    mkdirSync(dirname(assertionsFile), { recursive: true });
+    writeFileSync(assertionsFile, 'const SCENARIOS = new Set(["unrelated"]);\n');
+
+    const selectedLane = "published-upgrade-survivor-2026.6.11";
+    const plan = planFor({
+      selectedLaneNames: [selectedLane],
+      upgradeSurvivorBaselines: "2026.6.11",
+      upgradeSurvivorTargetRoot: targetRoot,
+    });
+
+    expect(plan.lanes).toEqual([]);
+    expect(plan.omittedUnsupportedLanes).toEqual([selectedLane]);
   });
 
   it("omits unsupported scenario-only survivor lanes without explicit baselines", () => {

--- a/test/scripts/docker-e2e-plan.test.ts
+++ b/test/scripts/docker-e2e-plan.test.ts
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import {
   DEFAULT_LIVE_RETRIES,
   RELEASE_PATH_PROFILE,
+  findLaneByName,
   parseLaneSelection,
   resolveDockerE2ePlan,
 } from "../../scripts/lib/docker-e2e-plan.mjs";
@@ -104,6 +105,12 @@ function bundledPluginSweepLane(index: number): ReturnType<typeof summarizeLane>
 }
 
 describe("scripts/lib/docker-e2e-plan", () => {
+  it("finds a named lane through the expanded catalog", () => {
+    expect(findLaneByName("plugin-binding-command-escape")?.name).toBe(
+      "plugin-binding-command-escape",
+    );
+  });
+
   it("routes live Docker scripts through the nested trusted release harness", () => {
     const sourceLane = allReleasePathLanes({ releaseProfile: "beta" }).find(
       (candidate) => candidate.name === "live-codex-npm-plugin",
@@ -900,6 +907,25 @@ describe("scripts/lib/docker-e2e-plan", () => {
         upgradeSurvivorTargetRoot: targetRoot,
       }),
     ).toThrow("expected const SCENARIOS = new Set([<string literals>])");
+  });
+
+  it("does not inspect a frozen survivor contract for unrelated selected lanes", () => {
+    const targetRoot = tempDirs.make("openclaw-frozen-unrelated-lane-harness-");
+    const assertionsFile = join(targetRoot, "scripts/e2e/lib/upgrade-survivor/assertions.mjs");
+    mkdirSync(dirname(assertionsFile), { recursive: true });
+    writeFileSync(
+      assertionsFile,
+      'const supported = ["base"];\nconst SCENARIOS = new Set(supported);\n',
+    );
+
+    const plan = planFor({
+      selectedLaneNames: ["plugin-binding-command-escape"],
+      upgradeSurvivorScenarios: "reported-issues",
+      upgradeSurvivorTargetRoot: targetRoot,
+    });
+
+    expect(plan.lanes.map((lane) => lane.name)).toEqual(["plugin-binding-command-escape"]);
+    expect(plan.omittedUnsupportedLanes).toEqual([]);
   });
 
   it("fails closed when a frozen target scenario contract is mutable", () => {

--- a/test/scripts/docker-e2e-plan.test.ts
+++ b/test/scripts/docker-e2e-plan.test.ts
@@ -769,7 +769,7 @@ describe("scripts/lib/docker-e2e-plan", () => {
     mkdirSync(dirname(assertionsFile), { recursive: true });
     writeFileSync(
       assertionsFile,
-      [
+      `const SCENARIOS = new Set([\n${[
         "base",
         "feishu-channel",
         "bootstrap-persona",
@@ -781,7 +781,7 @@ describe("scripts/lib/docker-e2e-plan", () => {
         "versioned-runtime-deps",
       ]
         .map((scenario) => JSON.stringify(scenario))
-        .join("\n"),
+        .join(",\n")}\n]);\nconst unrelated = "acpx-openclaw-tools-bridge";\n`,
     );
     const plan = planFor({
       selectedLaneNames: ["published-upgrade-survivor"],
@@ -801,6 +801,22 @@ describe("scripts/lib/docker-e2e-plan", () => {
       "published-upgrade-survivor-2026.6.11-tilde-log-path",
       "published-upgrade-survivor-2026.6.11-versioned-runtime-deps",
     ]);
+  });
+
+  it("omits survivor lanes when the target exposes none of the requested scenarios", () => {
+    const targetRoot = tempDirs.make("openclaw-frozen-empty-upgrade-harness-");
+    const assertionsFile = join(targetRoot, "scripts/e2e/lib/upgrade-survivor/assertions.mjs");
+    mkdirSync(dirname(assertionsFile), { recursive: true });
+    writeFileSync(assertionsFile, 'const SCENARIOS = new Set(["unrelated"]);\n');
+
+    const plan = planFor({
+      selectedLaneNames: ["published-upgrade-survivor"],
+      upgradeSurvivorBaselines: "2026.6.11",
+      upgradeSurvivorScenarios: "reported-issues",
+      upgradeSurvivorTargetRoot: targetRoot,
+    });
+
+    expect(plan.lanes).toEqual([]);
   });
 
   it("skips plugin dependency cleanup for baselines without packaged plugin dirs", () => {

--- a/test/scripts/docker-e2e-plan.test.ts
+++ b/test/scripts/docker-e2e-plan.test.ts
@@ -808,6 +808,9 @@ describe("scripts/lib/docker-e2e-plan", () => {
       "published-upgrade-survivor-2026.6.11-tilde-log-path",
       "published-upgrade-survivor-2026.6.11-versioned-runtime-deps",
     ]);
+    expect(plan.omittedUnsupportedLanes).toEqual([
+      "published-upgrade-survivor-2026.6.11-acpx-openclaw-tools-bridge",
+    ]);
   });
 
   it("omits survivor lanes when the target exposes none of the requested scenarios", () => {
@@ -824,7 +827,11 @@ describe("scripts/lib/docker-e2e-plan", () => {
     });
 
     expect(plan.lanes).toEqual([]);
-    expect(plan.omittedUnsupportedLanes).toEqual(["published-upgrade-survivor"]);
+    expect(plan.omittedUnsupportedLanes).toHaveLength(10);
+    expect(plan.omittedUnsupportedLanes).toContain("published-upgrade-survivor-2026.6.11");
+    expect(plan.omittedUnsupportedLanes).toContain(
+      "published-upgrade-survivor-2026.6.11-versioned-runtime-deps",
+    );
   });
 
   it("omits baseline-only survivor lanes when the target lacks the implicit base scenario", () => {
@@ -836,6 +843,21 @@ describe("scripts/lib/docker-e2e-plan", () => {
     const plan = planFor({
       selectedLaneNames: ["published-upgrade-survivor"],
       upgradeSurvivorBaselines: "2026.6.11",
+      upgradeSurvivorTargetRoot: targetRoot,
+    });
+
+    expect(plan.lanes).toEqual([]);
+    expect(plan.omittedUnsupportedLanes).toEqual(["published-upgrade-survivor-2026.6.11"]);
+  });
+
+  it("omits an unconfigured survivor lane when the target lacks the implicit base scenario", () => {
+    const targetRoot = tempDirs.make("openclaw-frozen-default-base-harness-");
+    const assertionsFile = join(targetRoot, "scripts/e2e/lib/upgrade-survivor/assertions.mjs");
+    mkdirSync(dirname(assertionsFile), { recursive: true });
+    writeFileSync(assertionsFile, 'const SCENARIOS = new Set(["unrelated"]);\n');
+
+    const plan = planFor({
+      selectedLaneNames: ["published-upgrade-survivor"],
       upgradeSurvivorTargetRoot: targetRoot,
     });
 
@@ -856,7 +878,11 @@ describe("scripts/lib/docker-e2e-plan", () => {
     });
 
     expect(plan.lanes.map((lane) => lane.name)).toEqual(["plugin-binding-command-escape"]);
-    expect(plan.omittedUnsupportedLanes).toEqual(["published-upgrade-survivor"]);
+    expect(plan.omittedUnsupportedLanes).toHaveLength(10);
+    expect(plan.omittedUnsupportedLanes).toContain("published-upgrade-survivor");
+    expect(plan.omittedUnsupportedLanes).toContain(
+      "published-upgrade-survivor-versioned-runtime-deps",
+    );
   });
 
   it("reports an explicitly selected expanded survivor lane as unsupported", () => {
@@ -889,6 +915,23 @@ describe("scripts/lib/docker-e2e-plan", () => {
     });
 
     expect(plan.lanes).toEqual([]);
+  });
+
+  it("does not fall back to base when an unsupported scenario is baseline-incompatible", () => {
+    const targetRoot = tempDirs.make("openclaw-frozen-incompatible-scenario-harness-");
+    const assertionsFile = join(targetRoot, "scripts/e2e/lib/upgrade-survivor/assertions.mjs");
+    mkdirSync(dirname(assertionsFile), { recursive: true });
+    writeFileSync(assertionsFile, 'const SCENARIOS = new Set(["unrelated"]);\n');
+
+    const plan = planFor({
+      selectedLaneNames: ["published-upgrade-survivor"],
+      upgradeSurvivorBaselines: "2026.4.21",
+      upgradeSurvivorScenarios: "acpx-openclaw-tools-bridge",
+      upgradeSurvivorTargetRoot: targetRoot,
+    });
+
+    expect(plan.lanes).toEqual([]);
+    expect(plan.omittedUnsupportedLanes).toEqual([]);
   });
 
   it("fails closed when a frozen target scenario contract is not a literal set", () => {

--- a/test/scripts/docker-e2e-plan.test.ts
+++ b/test/scripts/docker-e2e-plan.test.ts
@@ -780,7 +780,7 @@ describe("scripts/lib/docker-e2e-plan", () => {
         "tilde-log-path",
         "versioned-runtime-deps",
       ]
-        .map((scenario) => JSON.stringify(scenario))
+        .map((scenario) => `'${scenario}'`)
         .join(",\n")}\n]);\nconst unrelated = "acpx-openclaw-tools-bridge";\n`,
     );
     const plan = planFor({
@@ -832,6 +832,39 @@ describe("scripts/lib/docker-e2e-plan", () => {
     });
 
     expect(plan.lanes).toEqual([]);
+  });
+
+  it("fails closed when a frozen target scenario contract is not a literal set", () => {
+    const targetRoot = tempDirs.make("openclaw-frozen-indirect-scenario-harness-");
+    const assertionsFile = join(targetRoot, "scripts/e2e/lib/upgrade-survivor/assertions.mjs");
+    mkdirSync(dirname(assertionsFile), { recursive: true });
+    writeFileSync(
+      assertionsFile,
+      'const supported = ["base"];\nconst SCENARIOS = new Set(supported);\n',
+    );
+
+    expect(() =>
+      planFor({
+        selectedLaneNames: ["published-upgrade-survivor"],
+        upgradeSurvivorScenarios: "reported-issues",
+        upgradeSurvivorTargetRoot: targetRoot,
+      }),
+    ).toThrow("expected const SCENARIOS = new Set([<string literals>])");
+  });
+
+  it("fails closed when a frozen target scenario contract is mutable", () => {
+    const targetRoot = tempDirs.make("openclaw-frozen-mutable-scenario-harness-");
+    const assertionsFile = join(targetRoot, "scripts/e2e/lib/upgrade-survivor/assertions.mjs");
+    mkdirSync(dirname(assertionsFile), { recursive: true });
+    writeFileSync(assertionsFile, 'let SCENARIOS = new Set(["base"]);\n');
+
+    expect(() =>
+      planFor({
+        selectedLaneNames: ["published-upgrade-survivor"],
+        upgradeSurvivorScenarios: "reported-issues",
+        upgradeSurvivorTargetRoot: targetRoot,
+      }),
+    ).toThrow("expected const SCENARIOS = new Set([<string literals>])");
   });
 
   it("skips plugin dependency cleanup for baselines without packaged plugin dirs", () => {

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -1359,6 +1359,9 @@ describe("package artifact reuse", () => {
 
   it("lets reusable Docker E2E consume an already resolved package artifact", () => {
     const workflow = readFileSync(LIVE_E2E_WORKFLOW, "utf8");
+    const parsedWorkflow = parse(workflow) as {
+      on?: { workflow_call?: { inputs?: Record<string, unknown> } };
+    };
     const packageJson = readFileSync(PACKAGE_JSON, "utf8");
     const scheduler = readFileSync("scripts/test-docker-all.mjs", "utf8");
     const publishedUpgradeSurvivor = readFileSync(UPGRADE_SURVIVOR_RUN_SCRIPT, "utf8");
@@ -1375,6 +1378,9 @@ describe("package artifact reuse", () => {
     expect(workflow).toContain("published_upgrade_survivor_baseline:");
     expect(workflow).toContain("published_upgrade_survivor_baselines:");
     expect(workflow).toContain("published_upgrade_survivor_scenarios:");
+    expect(parsedWorkflow.on?.workflow_call?.inputs).toHaveProperty(
+      "allow_frozen_target_scenario_omissions",
+    );
     expect(workflow).toContain("docker_e2e_bare_image:");
     expect(workflow).toContain("docker_e2e_functional_image:");
     expect(workflow).toContain("OPENCLAW_DOCKER_E2E_SELECTED_SHA:");

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -1388,6 +1388,9 @@ describe("package artifact reuse", () => {
       "OPENCLAW_UPGRADE_SURVIVOR_SCENARIOS: ${{ inputs.published_upgrade_survivor_scenarios }}",
     );
     expect(workflow).toContain("OPENCLAW_UPGRADE_SURVIVOR_TARGET_ROOT: ${{ github.workspace }}");
+    expect(workflow).toContain(
+      "OPENCLAW_ALLOW_FROZEN_TARGET_SCENARIO_OMISSIONS: ${{ inputs.allow_frozen_target_scenario_omissions && '1' || '0' }}",
+    );
     expect(workflow).toContain("Download current-run OpenClaw Docker E2E package");
     expect(workflow).toContain("Download previous-run OpenClaw Docker E2E package");
     expect(workflow).toContain("inputs.package_artifact_id != ''");
@@ -2203,6 +2206,9 @@ describe("package artifact reuse", () => {
     );
     expect(workflow).toContain("include_release_path_suites: false");
     expect(workflow).toContain("include_release_path_suites: true");
+    expect(workflow).toContain(
+      "allow_frozen_target_scenario_omissions: ${{ inputs.allow_frozen_target_scenario_omissions }}",
+    );
     expect(workflow).toContain("uses: ./.github/workflows/package-acceptance.yml");
     expect(workflow).toContain(
       "source: ${{ (needs.resolve_target.outputs.package_acceptance_package_spec != '' || needs.resolve_target.outputs.release_package_spec != '') && 'npm' || 'artifact' }}",

--- a/test/scripts/plugin-prerelease-test-plan.test.ts
+++ b/test/scripts/plugin-prerelease-test-plan.test.ts
@@ -428,6 +428,7 @@ describe("scripts/lib/plugin-prerelease-test-plan.mjs", () => {
     );
     expect(releaseChecksStep.env?.TARGET_CONTEXT_REF).toBe("${{ inputs.target_context_ref }}");
     expect(releaseChecksScript).toContain('-f ref="$release_checks_target_ref"');
+    expect(releaseChecksScript).toContain("args+=(-f allow_frozen_target_scenario_omissions=true)");
     expect(releaseWorkflowSource).toContain('--arg targetContextRef "$TARGET_CONTEXT_REF"');
     expect(releaseWorkflowSource).toContain("targetContextRef: $targetContextRef");
     expect(normalCiScript).toContain('dispatch_and_wait ci.yml "$dispatch_run_name" "${args[@]}"');


### PR DESCRIPTION
## What Problem This Solves

Follow-up to #108189. The frozen-target validation path can still false-green when an older target omits requested upgrade-survivor scenarios, exposes a malformed scenario declaration, or lacks a scenario-only lane. The current CI shard fallback also derives its runner from caller context instead of the workflow commit that defines the job.

## Why This Change Was Made

- Parse the target harness scenario contract as an exact static top-level set and fail closed on malformed or indirect declarations.
- Expand only requested survivor lanes, preserve baseline compatibility rules, and report every intentionally omitted lane in plans and summaries.
- Require a trusted, false-by-default workflow opt-in before frozen-target scenario omissions may pass. Full Release Validation supplies it only for validated canonical release refs/tags.
- Fetch the fallback CI shard runner from the validated job-defining workflow repository and SHA.
- Auto-clean new frozen-target test fixtures and preserve contributor credit from #108189.

## User Impact

Release validation remains compatible with older supported targets, but candidate-controlled omissions and malformed target contracts can no longer silently turn required release proof green.

## Evidence

- Testbox focused suite: 224 tests passed across Docker scheduler/planner, release workflow, plugin prerelease, and CI workflow guards.
- Testbox run: https://github.com/openclaw/openclaw/actions/runs/29415296997
- Testbox changed-surface gate: formatting, script/test types, lint, Docker shell syntax, and scheduler dry-run passed.
- Fresh branch autoreview: no accepted/actionable findings.
- No version bump, tag, publish, registry, deploy, cloud mutation, or macOS proof.
