### PR TITLE
fix(infra): keep system-agent approval text UTF-16 safe at truncation boundary

### DIFF
--- a/src/infra/approval-presentation.test.ts
+++ b/src/infra/approval-presentation.test.ts
@@ -45,6 +45,18 @@ function buildSystemAgentPresentation(request: {
 // Matches a high UTF-16 surrogate with no paired low surrogate following it.
 const LONE_HIGH_SURROGATE = /[\uD800-\uDBFF](?![\uDC00-\uDFFF])/u;
 
+// buildApprovalPresentation returns a kind-tagged union; narrow to the
+// system-agent variant before reading its title/description.
+function systemAgentText(
+  presentation: ReturnType<typeof buildSystemAgentPresentation>,
+  field: "title" | "description",
+): string {
+  if (!presentation || presentation.kind !== "system-agent") {
+    throw new Error("expected a system-agent presentation");
+  }
+  return presentation[field];
+}
+
 describe("buildApprovalPresentation", () => {
   it("sanitizes exec routing metadata and preserves empty values as null", () => {
     const githubToken = `ghp_${"a".repeat(100)}`;
@@ -142,8 +154,8 @@ describe("buildApprovalPresentation (system-agent)", () => {
     const title = `${"a".repeat(79)}\u{1F600}`;
     const presentation = buildSystemAgentPresentation({ title, description: "d" });
     expect(presentation).not.toBeNull();
-    expect(LONE_HIGH_SURROGATE.test(presentation?.title ?? "")).toBe(false);
-    expect(presentation?.title).toBe("a".repeat(79));
+    expect(LONE_HIGH_SURROGATE.test(systemAgentText(presentation, "title"))).toBe(false);
+    expect(systemAgentText(presentation, "title")).toBe("a".repeat(79));
   });
 
   it("keeps an emoji that fits within the title limit intact", () => {
@@ -151,8 +163,8 @@ describe("buildApprovalPresentation (system-agent)", () => {
     const title = `${"a".repeat(78)}\u{1F600}`;
     const presentation = buildSystemAgentPresentation({ title, description: "d" });
     expect(presentation).not.toBeNull();
-    expect(LONE_HIGH_SURROGATE.test(presentation?.title ?? "")).toBe(false);
-    expect(presentation?.title).toBe(`${"a".repeat(78)}\u{1F600}`);
+    expect(LONE_HIGH_SURROGATE.test(systemAgentText(presentation, "title"))).toBe(false);
+    expect(systemAgentText(presentation, "title")).toBe(`${"a".repeat(78)}\u{1F600}`);
   });
 
   it("drops a split emoji at the description boundary instead of leaving a lone surrogate", () => {
@@ -160,7 +172,7 @@ describe("buildApprovalPresentation (system-agent)", () => {
     const description = `${"a".repeat(511)}\u{1F6E1}`;
     const presentation = buildSystemAgentPresentation({ title: "t", description });
     expect(presentation).not.toBeNull();
-    expect(LONE_HIGH_SURROGATE.test(presentation?.description ?? "")).toBe(false);
-    expect(presentation?.description).toBe("a".repeat(511));
+    expect(LONE_HIGH_SURROGATE.test(systemAgentText(presentation, "description"))).toBe(false);
+    expect(systemAgentText(presentation, "description")).toBe("a".repeat(511));
   });
 });

--- a/src/infra/approval-presentation.test.ts
+++ b/src/infra/approval-presentation.test.ts
@@ -23,40 +23,6 @@ function buildPluginPresentation(request: {
   return buildApprovalPresentation({ kind: "plugin", request, allowedDecisions });
 }
 
-function buildSystemAgentPresentation(request: {
-  title: string;
-  description: string;
-  proposalHash?: string;
-}) {
-  return buildApprovalPresentation({
-    kind: "system-agent",
-    request: {
-      title: request.title,
-      description: request.description,
-      command: "true",
-      proposalHash: request.proposalHash ?? "a".repeat(64),
-      allowedDecisions,
-      sessionId: "s1",
-    },
-    allowedDecisions,
-  });
-}
-
-// Matches a high UTF-16 surrogate with no paired low surrogate following it.
-const LONE_HIGH_SURROGATE = /[\uD800-\uDBFF](?![\uDC00-\uDFFF])/u;
-
-// buildApprovalPresentation returns a kind-tagged union; narrow to the
-// system-agent variant before reading its title/description.
-function systemAgentText(
-  presentation: ReturnType<typeof buildSystemAgentPresentation>,
-  field: "title" | "description",
-): string {
-  if (!presentation || presentation.kind !== "system-agent") {
-    throw new Error("expected a system-agent presentation");
-  }
-  return presentation[field];
-}
-
 describe("buildApprovalPresentation", () => {
   it("sanitizes exec routing metadata and preserves empty values as null", () => {
     const githubToken = `ghp_${"a".repeat(100)}`;
@@ -145,34 +111,42 @@ describe("buildApprovalPresentation", () => {
       }),
     ).toBeNull();
   });
+
 });
 
 describe("buildApprovalPresentation (system-agent)", () => {
+  function buildSystemAgentPresentation(request: { title: string; description: string }) {
+    return buildApprovalPresentation({
+      kind: "system-agent",
+      request: {
+        ...request,
+        command: "true",
+        proposalHash: "a".repeat(64),
+        allowedDecisions,
+        sessionId: "s1",
+      },
+      allowedDecisions,
+    });
+  }
+
   it("drops a split emoji at the title boundary instead of leaving a lone surrogate", () => {
-    // 79 ASCII chars + 😀 (U+1F600, two UTF-16 code units) = 81 code units.
-    // A raw .slice(0, 80) keeps the lone high surrogate; truncateUtf16Safe backs off.
     const title = `${"a".repeat(79)}\u{1F600}`;
     const presentation = buildSystemAgentPresentation({ title, description: "d" });
-    expect(presentation).not.toBeNull();
-    expect(LONE_HIGH_SURROGATE.test(systemAgentText(presentation, "title"))).toBe(false);
-    expect(systemAgentText(presentation, "title")).toBe("a".repeat(79));
+    expect(presentation).toMatchObject({ kind: "system-agent", title: "a".repeat(79) });
   });
 
   it("keeps an emoji that fits within the title limit intact", () => {
-    // 78 ASCII chars + 😀 = 80 code units, so the emoji fits without truncation.
     const title = `${"a".repeat(78)}\u{1F600}`;
     const presentation = buildSystemAgentPresentation({ title, description: "d" });
-    expect(presentation).not.toBeNull();
-    expect(LONE_HIGH_SURROGATE.test(systemAgentText(presentation, "title"))).toBe(false);
-    expect(systemAgentText(presentation, "title")).toBe(`${"a".repeat(78)}\u{1F600}`);
+    expect(presentation).toMatchObject({ kind: "system-agent", title });
   });
 
   it("drops a split emoji at the description boundary instead of leaving a lone surrogate", () => {
-    // 511 ASCII chars + 🛡 (U+1F6E1, two UTF-16 code units) = 513 code units.
     const description = `${"a".repeat(511)}\u{1F6E1}`;
     const presentation = buildSystemAgentPresentation({ title: "t", description });
-    expect(presentation).not.toBeNull();
-    expect(LONE_HIGH_SURROGATE.test(systemAgentText(presentation, "description"))).toBe(false);
-    expect(systemAgentText(presentation, "description")).toBe("a".repeat(511));
+    expect(presentation).toMatchObject({
+      kind: "system-agent",
+      description: "a".repeat(511),
+    });
   });
 });

--- a/src/infra/approval-presentation.test.ts
+++ b/src/infra/approval-presentation.test.ts
@@ -111,7 +111,6 @@ describe("buildApprovalPresentation", () => {
       }),
     ).toBeNull();
   });
-
 });
 
 describe("buildApprovalPresentation (system-agent)", () => {

--- a/src/infra/approval-presentation.test.ts
+++ b/src/infra/approval-presentation.test.ts
@@ -23,6 +23,28 @@ function buildPluginPresentation(request: {
   return buildApprovalPresentation({ kind: "plugin", request, allowedDecisions });
 }
 
+function buildSystemAgentPresentation(request: {
+  title: string;
+  description: string;
+  proposalHash?: string;
+}) {
+  return buildApprovalPresentation({
+    kind: "system-agent",
+    request: {
+      title: request.title,
+      description: request.description,
+      command: "true",
+      proposalHash: request.proposalHash ?? "a".repeat(64),
+      allowedDecisions,
+      sessionId: "s1",
+    },
+    allowedDecisions,
+  });
+}
+
+// Matches a high UTF-16 surrogate with no paired low surrogate following it.
+const LONE_HIGH_SURROGATE = /[\uD800-\uDBFF](?![\uDC00-\uDFFF])/u;
+
 describe("buildApprovalPresentation", () => {
   it("sanitizes exec routing metadata and preserves empty values as null", () => {
     const githubToken = `ghp_${"a".repeat(100)}`;
@@ -110,5 +132,35 @@ describe("buildApprovalPresentation", () => {
         description: `${description}${String.fromCodePoint(0x1f6e1)}`,
       }),
     ).toBeNull();
+  });
+});
+
+describe("buildApprovalPresentation (system-agent)", () => {
+  it("drops a split emoji at the title boundary instead of leaving a lone surrogate", () => {
+    // 79 ASCII chars + 😀 (U+1F600, two UTF-16 code units) = 81 code units.
+    // A raw .slice(0, 80) keeps the lone high surrogate; truncateUtf16Safe backs off.
+    const title = `${"a".repeat(79)}\u{1F600}`;
+    const presentation = buildSystemAgentPresentation({ title, description: "d" });
+    expect(presentation).not.toBeNull();
+    expect(LONE_HIGH_SURROGATE.test(presentation?.title ?? "")).toBe(false);
+    expect(presentation?.title).toBe("a".repeat(79));
+  });
+
+  it("keeps an emoji that fits within the title limit intact", () => {
+    // 78 ASCII chars + 😀 = 80 code units, so the emoji fits without truncation.
+    const title = `${"a".repeat(78)}\u{1F600}`;
+    const presentation = buildSystemAgentPresentation({ title, description: "d" });
+    expect(presentation).not.toBeNull();
+    expect(LONE_HIGH_SURROGATE.test(presentation?.title ?? "")).toBe(false);
+    expect(presentation?.title).toBe(`${"a".repeat(78)}\u{1F600}`);
+  });
+
+  it("drops a split emoji at the description boundary instead of leaving a lone surrogate", () => {
+    // 511 ASCII chars + 🛡 (U+1F6E1, two UTF-16 code units) = 513 code units.
+    const description = `${"a".repeat(511)}\u{1F6E1}`;
+    const presentation = buildSystemAgentPresentation({ title: "t", description });
+    expect(presentation).not.toBeNull();
+    expect(LONE_HIGH_SURROGATE.test(presentation?.description ?? "")).toBe(false);
+    expect(presentation?.description).toBe("a".repeat(511));
   });
 });

--- a/src/infra/approval-presentation.ts
+++ b/src/infra/approval-presentation.ts
@@ -40,12 +40,6 @@ function isWithinCodePointLimit(value: string, maxLength: number): boolean {
   return Array.from(value).length <= maxLength;
 }
 
-// Display-size caps for system-agent approval text. truncateUtf16Safe keeps the
-// cut on a UTF-16 code-unit boundary so an emoji (surrogate pair) straddling the
-// limit does not leave a lone high surrogate in the reviewer-facing title/description.
-const SYSTEM_AGENT_APPROVAL_TITLE_MAX_LENGTH = 80;
-const SYSTEM_AGENT_APPROVAL_DESCRIPTION_MAX_LENGTH = 512;
-
 function sanitizeOptionalSingleLine(value: unknown): string | null {
   const normalized = normalizeOptionalString(value);
   return normalized ? sanitizeExecApprovalDisplayText(normalized) : null;
@@ -133,14 +127,8 @@ function buildSystemAgentApprovalPresentation(params: {
   }
   return {
     kind: "system-agent",
-    title: truncateUtf16Safe(
-      sanitizeExecApprovalDisplayText(title),
-      SYSTEM_AGENT_APPROVAL_TITLE_MAX_LENGTH,
-    ),
-    description: truncateUtf16Safe(
-      sanitizeExecApprovalWarningText(description),
-      SYSTEM_AGENT_APPROVAL_DESCRIPTION_MAX_LENGTH,
-    ),
+    title: truncateUtf16Safe(sanitizeExecApprovalDisplayText(title), 80),
+    description: truncateUtf16Safe(sanitizeExecApprovalWarningText(description), 512),
     proposalHash: request.proposalHash,
     agentId: sanitizeOptionalSingleLine(request.agentId),
     allowedDecisions: ["allow-once", "deny"],

--- a/src/infra/approval-presentation.ts
+++ b/src/infra/approval-presentation.ts
@@ -1,5 +1,6 @@
 // Builds the canonical reviewer-safe projection for durable approvals.
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import type {
   ApprovalDecision,
   ApprovalKind,
@@ -38,6 +39,12 @@ function normalizeDecisionList(decisions: readonly ApprovalDecision[]): Approval
 function isWithinCodePointLimit(value: string, maxLength: number): boolean {
   return Array.from(value).length <= maxLength;
 }
+
+// Display-size caps for system-agent approval text. truncateUtf16Safe keeps the
+// cut on a UTF-16 code-unit boundary so an emoji (surrogate pair) straddling the
+// limit does not leave a lone high surrogate in the reviewer-facing title/description.
+const SYSTEM_AGENT_APPROVAL_TITLE_MAX_LENGTH = 80;
+const SYSTEM_AGENT_APPROVAL_DESCRIPTION_MAX_LENGTH = 512;
 
 function sanitizeOptionalSingleLine(value: unknown): string | null {
   const normalized = normalizeOptionalString(value);
@@ -126,8 +133,14 @@ function buildSystemAgentApprovalPresentation(params: {
   }
   return {
     kind: "system-agent",
-    title: sanitizeExecApprovalDisplayText(title).slice(0, 80),
-    description: sanitizeExecApprovalWarningText(description).slice(0, 512),
+    title: truncateUtf16Safe(
+      sanitizeExecApprovalDisplayText(title),
+      SYSTEM_AGENT_APPROVAL_TITLE_MAX_LENGTH,
+    ),
+    description: truncateUtf16Safe(
+      sanitizeExecApprovalWarningText(description),
+      SYSTEM_AGENT_APPROVAL_DESCRIPTION_MAX_LENGTH,
+    ),
     proposalHash: request.proposalHash,
     agentId: sanitizeOptionalSingleLine(request.agentId),
     allowedDecisions: ["allow-once", "deny"],


### PR DESCRIPTION
## What Problem This Solves

`buildSystemAgentApprovalPresentation` in `src/infra/approval-presentation.ts` builds the reviewer-facing title and description for a system-agent approval request from the external `SystemAgentApprovalRequestPayload`. It truncated the sanitized title/description with raw `.slice(0, 80)` / `.slice(0, 512)`.

The sanitization step (`sanitizeExecApprovalDisplayText` / `sanitizeExecApprovalWarningText`) redacts secrets and escapes invisible characters but deliberately keeps visible emoji. So when the 80th (or 512th) UTF-16 code unit landed inside a surrogate pair, the truncated text kept a lone high surrogate that then flowed into the reviewer-facing approval title/description.

The same file already treats code-point safety as important: the plugin-approval path uses `isWithinCodePointLimit` (counts via `Array.from`), and the exec display path truncates with `truncateUtf16Safe`. The system-agent path was the one truncation site that still used a raw `.slice`.

## Evidence

Code-point reproduction of the boundary case:

- Title input = 79 ASCII chars + U+1F600 (😀, two UTF-16 code units) = 81 code units.
  - Before fix - `.slice(0, 80)` keeps code units 0..79; the unit at index 79 is the high surrogate 0xD83D with no paired low surrogate, so the title ends in a lone surrogate.
  - After fix - `truncateUtf16Safe(sanitized, 80)` detects the high surrogate at the cut and backs off to 79 code units; output is 79 ASCII chars, no lone surrogate.
- Description input = 511 ASCII chars + U+1F6E1 (🛡) = 513 code units - same split at the 512 boundary.

Added 3 regression tests to `src/infra/approval-presentation.test.ts` (new `system-agent` describe block): split emoji at the title boundary is dropped instead of leaving a lone surrogate; an emoji that fits within the title limit is kept intact; split emoji at the description boundary is dropped.

Verified the tests are genuine regression guards by running them against the pre-fix code: the two boundary cases fail with `expected true to be false` (lone surrogate detected at the title and description cut), then all pass after the fix.

```
Test Files  1 passed (1)
     Tests  7 passed (7)
```

`npx oxlint` on both changed files: clean (exit 0). Local vitest run via the repo vitest runner: 7/7 pass.

What was not tested: a live system-agent delegation producing an emoji-bearing approval title end to end. The transformation is a pure string truncation over the sanitized payload, so the deterministic code-point analysis + regression tests fully cover the behavior; no live delegation environment is required to prove the surrogate boundary.
<img width="734" height="148" alt="image" src="https://github.com/user-attachments/assets/fdf44a1d-96c5-439e-9e53-12f7a8deb4be" />


## Tests and validation

- `src/infra/approval-presentation.test.ts` - added a `system-agent` describe block with 3 cases (title boundary split emoji, fitting emoji, description boundary split emoji). Existing exec/plugin cases unchanged.
- Pre-fix: the two split-emoji cases fail (lone surrogate present). Post-fix: 7/7 pass.

## Risk checklist

- User-visible behavior change: Yes - system-agent approval titles/descriptions that previously ended in a split emoji (lone surrogate) now drop the split emoji and stay well-formed. Only affects texts longer than 80 (title) or 512 (description) code units whose cut lands inside a surrogate pair.
- Config / environment / migration change: No.
- Security / auth / secrets / network / tool-execution change: No. Sanitization (secret redaction, invisible escaping) is unchanged; only the final truncation step is made surrogate-safe.
- Highest-risk area: reviewer-facing approval text. Mitigated by reusing the already-adopted `truncateUtf16Safe` helper (same import path the exec display path already uses) rather than inventing new logic.
