### PR TITLE
fix(discord): voice roster labels preserve boundary emoji

### DIFF
--- a/extensions/discord/src/voice/participant-context.test.ts
+++ b/extensions/discord/src/voice/participant-context.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { formatDiscordVoiceParticipantStateLine } from "./participant-context.js";
+
+describe("formatDiscordVoiceParticipantStateLine", () => {
+  it("does not split surrogate pairs when truncating display names", () => {
+    const line = formatDiscordVoiceParticipantStateLine({
+      userId: "user-1",
+      state: {
+        user_id: "user-1",
+        member: { nick: `${"x".repeat(99)}😀tail` },
+      } as never,
+    });
+
+    expect(line).toBe(`- user_id="user-1" display_name="${"x".repeat(99)}"`);
+  });
+});

--- a/extensions/discord/src/voice/participant-context.ts
+++ b/extensions/discord/src/voice/participant-context.ts
@@ -1,4 +1,5 @@
 import type { DiscordAccountConfig, OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import type { APIVoiceState, Client } from "../internal/discord.js";
 import type { GatewayPlugin } from "../internal/gateway.js";
 import { type DiscordVoiceIngressContext, resolveDiscordVoiceIngressContext } from "./ingress.js";
@@ -23,7 +24,7 @@ function normalizeLabel(value: unknown): string | undefined {
     return undefined;
   }
   const normalized = value.replace(/\s+/g, " ").trim();
-  return normalized ? normalized.slice(0, 100) : undefined;
+  return normalized ? truncateUtf16Safe(normalized, 100) : undefined;
 }
 
 function memberLabel(state: APIVoiceState): string | undefined {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Discord voice participants with a display name crossing the 100 UTF-16 code-unit limit could have a trailing emoji split into an invalid lone surrogate in voice roster events and agent context.

## Why This Change Was Made

Voice participant labels now use the existing plugin SDK UTF-16-safe truncation helper while preserving the current normalization and 100-code-unit limit. A focused regression test covers a surrogate pair exactly at the truncation boundary.

## User Impact

Long Discord nicknames, global names, and usernames no longer produce malformed replacement characters in voice participant labels when an emoji falls on the length boundary.

## Evidence

- Before: the focused regression produced `display_name="<99 x characters>\ud83d"`.
- After: `node scripts/run-vitest.mjs extensions/discord/src/voice/participant-context.test.ts` passes (1 test).
- `oxfmt --check` passes for both touched files.
- `git diff --check` passes.
- Commit autoreview with Codex `gpt-5.5`, high reasoning: `patch is correct` (0.83 confidence), no actionable findings.

AI-assisted: implementation and review were completed with Codex; the author reviewed the change and validation evidence.
