### PR TITLE
test: tighten async polling intervals

### DIFF
--- a/src/commands/sessions-tail.test.ts
+++ b/src/commands/sessions-tail.test.ts
@@ -77,7 +77,7 @@ async function waitForRuntimeOutput(
       throw new Error(`Timed out waiting for output containing ${pattern}`);
     }
     await new Promise((resolve) => {
-      setTimeout(resolve, 25);
+      setTimeout(resolve, 5);
     });
   }
 }

--- a/src/infra/update-runner.test.ts
+++ b/src/infra/update-runner.test.ts
@@ -66,7 +66,7 @@ async function waitForProcessExit(pid: number, timeoutMs = 2_000): Promise<boole
       return true;
     }
     await new Promise<void>((resolve) => {
-      setTimeout(resolve, 25);
+      setTimeout(resolve, 5);
     });
   }
   return !isProcessAlive(pid);

--- a/test/openclaw-launcher.e2e.test.ts
+++ b/test/openclaw-launcher.e2e.test.ts
@@ -88,7 +88,7 @@ async function waitForJsonFile<T>(filePath: string, timeoutMs: number): Promise<
     } catch (error) {
       lastError = error;
       await new Promise((resolve) => {
-        setTimeout(resolve, 25);
+        setTimeout(resolve, 5);
       });
     }
   }

--- a/test/scripts/dev-tooling-safety.test.ts
+++ b/test/scripts/dev-tooling-safety.test.ts
@@ -36,7 +36,7 @@ async function waitForCondition(predicate: () => boolean, timeoutMs = 5_000): Pr
       return;
     }
     await new Promise((resolve) => {
-      setTimeout(resolve, 50);
+      setTimeout(resolve, 10);
     });
   }
   throw new Error("timed out waiting for condition");

--- a/test/scripts/e2e-run-with-pty.test.ts
+++ b/test/scripts/e2e-run-with-pty.test.ts
@@ -194,7 +194,7 @@ async function waitFor(condition: () => boolean, timeoutMs = 3_000) {
       throw new Error("timed out waiting for condition");
     }
     await new Promise((resolve) => {
-      setTimeout(resolve, 25);
+      setTimeout(resolve, 5);
     });
   }
 }

--- a/test/scripts/pr-operation-lock.test.ts
+++ b/test/scripts/pr-operation-lock.test.ts
@@ -289,7 +289,7 @@ async function waitFor(predicate: () => boolean, timeoutMs = 5000) {
     if (predicate()) {
       return true;
     }
-    await new Promise((resolve) => setTimeout(resolve, 25));
+    await new Promise((resolve) => setTimeout(resolve, 5));
   }
   return false;
 }

--- a/test/scripts/pr-prepare-gates.test.ts
+++ b/test/scripts/pr-prepare-gates.test.ts
@@ -193,7 +193,7 @@ async function waitFor(predicate: () => boolean, timeoutMs: number): Promise<boo
     if (predicate()) {
       return true;
     }
-    await new Promise((resolve) => setTimeout(resolve, 50));
+    await new Promise((resolve) => setTimeout(resolve, 10));
   }
   return predicate();
 }

--- a/test/scripts/profile-extension-memory.test.ts
+++ b/test/scripts/profile-extension-memory.test.ts
@@ -17,7 +17,7 @@ async function waitForCondition(predicate: () => boolean, timeoutMs = 5_000): Pr
       return;
     }
     await new Promise((resolve) => {
-      setTimeout(resolve, 50);
+      setTimeout(resolve, 10);
     });
   }
   throw new Error("timed out waiting for condition");

--- a/test/scripts/run-with-env.test.ts
+++ b/test/scripts/run-with-env.test.ts
@@ -43,7 +43,7 @@ async function waitFor(predicate: () => boolean, label: string, timeoutMs = 3_00
       throw new Error(`timed out waiting for ${label}`);
     }
     await new Promise<void>((resolve) => {
-      setTimeout(resolve, 25);
+      setTimeout(resolve, 5);
     });
   }
 }

--- a/test/scripts/secret-provider-integrations.test.ts
+++ b/test/scripts/secret-provider-integrations.test.ts
@@ -28,7 +28,7 @@ async function waitFor(predicate: () => boolean, timeoutMs = 5_000): Promise<voi
       return;
     }
     await new Promise((resolve) => {
-      setTimeout(resolve, 25);
+      setTimeout(resolve, 5);
     });
   }
   throw new Error("condition was not met before timeout");

--- a/test/scripts/telegram-user-credential.test.ts
+++ b/test/scripts/telegram-user-credential.test.ts
@@ -46,7 +46,7 @@ async function waitForFile(filePath: string, timeoutMs: number): Promise<void> {
       return;
     }
     await new Promise((resolve) => {
-      setTimeout(resolve, 25);
+      setTimeout(resolve, 5);
     });
   }
   throw new Error(`timeout waiting for ${filePath}`);
@@ -59,7 +59,7 @@ async function waitForDead(pid: number, timeoutMs: number): Promise<void> {
       return;
     }
     await new Promise((resolve) => {
-      setTimeout(resolve, 25);
+      setTimeout(resolve, 5);
     });
   }
   throw new Error(`process still alive: ${pid}`);

--- a/test/scripts/test-group-report.test.ts
+++ b/test/scripts/test-group-report.test.ts
@@ -53,7 +53,7 @@ async function waitForFile(filePath: string, timeoutMs: number): Promise<void> {
     if (fs.existsSync(filePath)) {
       return;
     }
-    await sleep(25);
+    await sleep(5);
   }
   throw new Error(`timed out waiting for ${filePath}`);
 }
@@ -64,7 +64,7 @@ async function waitForDead(pid: number, timeoutMs: number): Promise<void> {
     if (!isProcessAlive(pid)) {
       return;
     }
-    await sleep(25);
+    await sleep(5);
   }
   throw new Error(`timed out waiting for pid ${pid} to exit`);
 }

--- a/test/scripts/test-install-sh-docker.test.ts
+++ b/test/scripts/test-install-sh-docker.test.ts
@@ -234,7 +234,7 @@ async function waitForCondition(
     if (predicate()) {
       return;
     }
-    await new Promise((resolve) => setTimeout(resolve, 25));
+    await new Promise((resolve) => setTimeout(resolve, 5));
   }
   throw new Error(`timed out waiting for ${label}`);
 }

--- a/test/scripts/ui.test.ts
+++ b/test/scripts/ui.test.ts
@@ -18,7 +18,7 @@ async function waitFor(predicate: () => boolean, label: string, timeoutMs = 3_00
       throw new Error(`timed out waiting for ${label}`);
     }
     await new Promise<void>((resolve) => {
-      setTimeout(resolve, 25);
+      setTimeout(resolve, 5);
     });
   }
 }


### PR DESCRIPTION
## What Problem This Solves

Async test helpers used coarse 25-50 ms polling across process, file, lock, UI, launcher, session-tail, and credential fixtures. Successful state transitions could therefore sit idle for most of a polling interval.

## Why This Change Was Made

Fourteen bounded optimization rounds reduce polling cadence to 5-10 ms while preserving every existing overall timeout and success/failure condition. No production code or test deadline budget changes.

## User Impact

No runtime behavior change. Test workers detect completed async transitions sooner across 14 suites.

## Evidence

- Polling latency ceiling reduced 80%: 25 ms to 5 ms and 50 ms to 10 ms.
- Exact rebased head: 465 tests passed across tooling, infra, commands, and E2E projects.
- Three repeated targeted passes passed before final rebase.
- Changed gate passed: formatting, typechecks, core/scripts lint, guards.
- Fresh branch autoreview: no findings.
