### PR TITLE
fix(sessions): preserve boundary emoji in catalog tool calls

### DIFF
--- a/extensions/acpx/src/pi-session-catalog.test.ts
+++ b/extensions/acpx/src/pi-session-catalog.test.ts
@@ -28,7 +28,10 @@ const originalHome = process.env.HOME;
 const originalUserProfile = process.env.USERPROFILE;
 const originalPath = process.env.PATH;
 
-async function createPiStore(assistantText = "hi"): Promise<string> {
+async function createPiStore(
+  assistantText = "hi",
+  toolArguments: Record<string, unknown> = { command: "pwd" },
+): Promise<string> {
   const directory = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-pi-catalog-"));
   temporaryDirectories.push(directory);
   process.env.PI_CODING_AGENT_SESSION_DIR = directory;
@@ -60,7 +63,7 @@ async function createPiStore(assistantText = "hi"): Promise<string> {
         content: [
           { type: "thinking", thinking: "thinking" },
           { type: "text", text: assistantText },
-          { type: "toolCall", id: "call-1", name: "bash", arguments: { command: "pwd" } },
+          { type: "toolCall", id: "call-1", name: "bash", arguments: toolArguments },
         ],
       },
     },
@@ -272,6 +275,14 @@ describe("Pi session catalog", () => {
     const answer = transcript.items.find((item) => item.type === "agentMessage");
     expect(answer?.text?.endsWith("…")).toBe(true);
     expect(Buffer.byteLength(JSON.stringify(transcript), "utf8")).toBeLessThan(20 * 1024 * 1024);
+  });
+
+  it("does not split surrogate pairs when truncating tool arguments", async () => {
+    await createPiStore("hi", { value: `${"x".repeat(19_989)}😀tail` });
+    const transcript = await readLocalPiTranscriptPage({ threadId: "pi-session", limit: 20 });
+    const toolCall = transcript.items.find((item) => item.type === "toolCall");
+
+    expect(toolCall?.text).toBe(`bash\n{"value":"${"x".repeat(19_989)}…`);
   });
 
   it("reads legacy linear sessions and visible extended messages", async () => {

--- a/extensions/acpx/src/pi-session-catalog.ts
+++ b/extensions/acpx/src/pi-session-catalog.ts
@@ -5,6 +5,7 @@ import type {
   SessionsCatalogReadResult,
 } from "openclaw/plugin-sdk/session-catalog";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { listPiSummaryPage, readPiSessionById } from "./pi-session-store.js";
 
 const LOCAL_HOST_ID = "gateway";
@@ -225,7 +226,7 @@ function isoTimestamp(
 function jsonText(value: unknown, maxLength = 20_000): string | undefined {
   try {
     const text = JSON.stringify(value);
-    return text.length > maxLength ? `${text.slice(0, maxLength)}…` : text;
+    return text.length > maxLength ? `${truncateUtf16Safe(text, maxLength)}…` : text;
   } catch {
     return undefined;
   }

--- a/extensions/opencode/session-catalog.test.ts
+++ b/extensions/opencode/session-catalog.test.ts
@@ -31,7 +31,10 @@ const temporaryDirectories: string[] = [];
 const originalPath = process.env.PATH;
 const originalUnrelatedEnv = process.env.CATALOG_UNRELATED_ENV;
 
-async function installFakeOpenCode(assistantText = "hi"): Promise<string> {
+async function installFakeOpenCode(
+  assistantText = "hi",
+  toolInput: Record<string, unknown> = { command: "pwd" },
+): Promise<string> {
   const directory = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-opencode-catalog-"));
   temporaryDirectories.push(directory);
   const executable = path.join(directory, "opencode");
@@ -70,7 +73,7 @@ async function installFakeOpenCode(assistantText = "hi"): Promise<string> {
             id: "prt_tool",
             type: "tool",
             tool: "bash",
-            state: { status: "completed", input: { command: "pwd" }, output: "/workspace" },
+            state: { status: "completed", input: toolInput, output: "/workspace" },
           },
         ],
       },
@@ -195,6 +198,20 @@ describe("OpenCode session catalog", () => {
       const answer = transcript.items.find((item) => item.type === "agentMessage");
       expect(answer?.text?.endsWith("…")).toBe(true);
       expect(Buffer.byteLength(JSON.stringify(transcript), "utf8")).toBeLessThan(20 * 1024 * 1024);
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "does not split surrogate pairs when truncating tool input",
+    async () => {
+      await installFakeOpenCode("hi", { value: `${"x".repeat(19_989)}😀tail` });
+      const transcript = await readLocalOpenCodeTranscriptPage({
+        threadId: "ses_test",
+        limit: 20,
+      });
+      const toolCall = transcript.items.find((item) => item.type === "toolCall");
+
+      expect(toolCall?.text).toBe(`bash\n{"value":"${"x".repeat(19_989)}…`);
     },
   );
 

--- a/extensions/opencode/session-catalog.ts
+++ b/extensions/opencode/session-catalog.ts
@@ -6,6 +6,7 @@ import type {
   SessionsCatalogReadResult,
 } from "openclaw/plugin-sdk/session-catalog";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import {
   materializeWindowsSpawnProgram,
   resolveWindowsSpawnProgram,
@@ -341,7 +342,7 @@ export async function listLocalOpenCodeSessionPage(value?: unknown): Promise<Ope
 function jsonText(value: unknown, maxLength = 20_000): string | undefined {
   try {
     const text = JSON.stringify(value);
-    return text.length > maxLength ? `${text.slice(0, maxLength)}…` : text;
+    return text.length > maxLength ? `${truncateUtf16Safe(text, maxLength)}…` : text;
   } catch {
     return undefined;
   }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users viewing imported Pi or OpenCode session transcripts could see malformed replacement characters when serialized tool arguments crossed the 20,000 UTF-16 code-unit limit with an emoji on the boundary.

## Why This Change Was Made

Both sibling session catalog implementations now use the existing plugin SDK UTF-16-safe truncation helper while preserving the current JSON serialization, length limit, and ellipsis behavior. Focused regressions cover the same surrogate-pair boundary through each catalog's real transcript conversion path.

## User Impact

Long tool arguments in Pi and OpenCode session catalogs no longer end with an invalid lone surrogate when an emoji falls on the truncation boundary.

## Evidence

- Before: the Pi regression failed with the tool call ending in a lone `\ud83d` before the ellipsis.
- After: `node scripts/run-vitest.mjs extensions/acpx/src/pi-session-catalog.test.ts extensions/opencode/session-catalog.test.ts` passes all Windows-runnable coverage: Pi 17 passed / 1 skipped; OpenCode 4 passed / 6 existing platform-gated CLI tests skipped. CI exercises the OpenCode CLI regression on Linux.
- `oxfmt --check` passes for all four touched files.
- `git diff --check` passes.
- Commit autoreview with Codex `gpt-5.5`, high reasoning: `patch is correct` (0.86 confidence), no actionable findings.

AI-assisted: implementation and review were completed with Codex; the author reviewed the change and validation evidence.
