### PR TITLE
feat: trace Claude Code CLI model calls

### DIFF
--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -3695,6 +3695,8 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
   - H3: Environment variables
   - H2: Privacy and content capture
   - H2: Sampling and flushing
+  - H3: Model-call observation units
+  - H3: Claude Code CLI model-call fidelity
   - H2: Exported metrics
   - H3: Model usage
   - H3: Message flow

--- a/docs/gateway/opentelemetry.md
+++ b/docs/gateway/opentelemetry.md
@@ -215,6 +215,14 @@ claude-code` and identify OpenClaw's CLI boundary through
 - `paired-node-cli` - one-shot Claude Code execution delegated to a paired
   node.
 
+OpenClaw gives Claude CLI turns the same ownership hierarchy used by other
+agent runtimes: `openclaw.harness.run` (`openclaw.harness.id = claude-cli`)
+contains `openclaw.run`, which contains the Claude `openclaw.model.call`
+span. The harness and run spans are synthetic OpenClaw turn boundaries, not
+Claude Code internal phases. One-shot and managed stdio turns use the same
+hierarchy; a real fresh-session retry creates another model-call child inside
+the same OpenClaw run.
+
 The span starts when OpenClaw admits the prepared CLI turn and ends only after
 that turn succeeds or fails. For managed sessions, an interim success result
 does not end the span while Claude reports result-holding background agents or

--- a/docs/gateway/opentelemetry.md
+++ b/docs/gateway/opentelemetry.md
@@ -203,11 +203,30 @@ bus.
   stays on the same diagnostic trace when the emitting runtime has trusted
   trace context.
 
+### Model-call observation units
+
+Every `openclaw.model.call` span identifies what its lifecycle measures through
+`openclaw.model_call.observation_unit`:
+
+- `request` - one observable model/provider request. Native embedded model
+  calls use this unit, and exporters treat a missing value as `request` for
+  compatibility with older or external emitters.
+- `turn` - one opaque agent CLI turn that may contain hidden model requests,
+  retries, tool work, or background work. Claude Code CLI and Codex app-server
+  calls use this unit.
+
+Both units remain model-call spans so trace backends can render model input,
+output, usage, and hierarchy. OpenClaw records both in its
+`openclaw.model_call.*` metrics, which include the observation unit. Only
+`request` events contribute to `gen_ai.client.operation.duration`; excluding
+`turn` events prevents request-latency charts from mixing in full-turn latency.
+
 ### Claude Code CLI model-call fidelity
 
 Claude Code CLI turns emit one synthetic, turn-level `openclaw.model.call`
 span. These are not Anthropic HTTP request spans. They use `openclaw.api =
-claude-code` and identify OpenClaw's CLI boundary through
+claude-code`, `openclaw.model_call.observation_unit = turn`, and identify
+OpenClaw's CLI boundary through
 `openclaw.transport`:
 
 - `stdio` - one-shot local Claude Code process.
@@ -272,8 +291,8 @@ bounds; content remains off by default.
 - `openclaw.run.duration_ms` (histogram, attrs: `openclaw.channel`, `openclaw.provider`, `openclaw.model`)
 - `openclaw.context.tokens` (histogram, attrs: `openclaw.context`, `openclaw.channel`, `openclaw.provider`, `openclaw.model`)
 - `gen_ai.client.token.usage` (histogram, GenAI semantic-conventions metric, attrs: `gen_ai.token.type` = `input`/`output`, `gen_ai.provider.name`, `gen_ai.operation.name`, `gen_ai.request.model`)
-- `gen_ai.client.operation.duration` (histogram, seconds, GenAI semantic-conventions metric, attrs: `gen_ai.provider.name`, `gen_ai.operation.name`, `gen_ai.request.model`, optional `error.type`)
-- `openclaw.model_call.duration_ms` (histogram, attrs: `openclaw.provider`, `openclaw.model`, `openclaw.api`, `openclaw.transport`, plus `openclaw.errorCategory` and `openclaw.failureKind` on classified errors)
+- `gen_ai.client.operation.duration` (histogram, seconds, GenAI semantic-conventions metric for request-scoped model calls only; attrs: `gen_ai.provider.name`, `gen_ai.operation.name`, `gen_ai.request.model`, optional `error.type`)
+- `openclaw.model_call.duration_ms` (histogram, attrs: `openclaw.provider`, `openclaw.model`, `openclaw.api`, `openclaw.transport`, `openclaw.model_call.observation_unit`, plus `openclaw.errorCategory` and `openclaw.failureKind` on classified errors)
 - `openclaw.model_call.request_bytes` (histogram, UTF-8 byte size of the final model request payload; for Claude Code CLI, the observable prompt input/envelope described above; no raw payload content)
 - `openclaw.model_call.response_bytes` (histogram, UTF-8 byte size of streamed response chunk payloads; high-frequency text, thinking, and tool-call deltas count only incremental `delta` bytes; for Claude Code CLI, observed stdout bytes; no raw response content)
 - `openclaw.model_call.time_to_first_byte_ms` (histogram, elapsed time before the first streamed response event; for Claude Code CLI, first observable CLI output rather than network TTFB)
@@ -398,11 +417,11 @@ Liveness warnings also emit:
   - `openclaw.outcome`, `openclaw.channel`, `openclaw.provider`, `openclaw.model`, `openclaw.errorCategory`
 - `openclaw.model.call`
   - `gen_ai.system` by default, or `gen_ai.provider.name` when the latest GenAI semantic conventions are opted in
-  - `gen_ai.request.model`, `gen_ai.operation.name`, `openclaw.provider`, `openclaw.model`, `openclaw.api`, `openclaw.transport`
+  - `gen_ai.request.model`, `gen_ai.operation.name`, `openclaw.provider`, `openclaw.model`, `openclaw.api`, `openclaw.transport`, `openclaw.model_call.observation_unit` (`request` or `turn`)
   - `openclaw.errorCategory`, `error.type`, and optional `openclaw.failureKind` on errors
   - `openclaw.model_call.request_bytes`, `openclaw.model_call.response_bytes`, `openclaw.model_call.time_to_first_byte_ms`
   - `openclaw.model_call.prompt.input_messages_count`, `openclaw.model_call.prompt.input_messages_chars`, `openclaw.model_call.prompt.system_prompt_chars`, `openclaw.model_call.prompt.tool_definitions_count`, `openclaw.model_call.prompt.tool_definitions_chars`, `openclaw.model_call.prompt.total_chars` (safe component sizes only, no prompt text)
-  - `openclaw.model_call.usage.*` and `gen_ai.usage.*` when the model-call result carries provider usage for that individual call
+  - `openclaw.model_call.usage.*` and `gen_ai.usage.*` when the result carries usage for that request or aggregate turn
   - Span event `openclaw.provider.request` with attribute `openclaw.upstreamRequestIdHash` (bounded, hash-based) when the upstream provider result exposes a request id; raw ids are never exported
   - With `OTEL_SEMCONV_STABILITY_OPT_IN=gen_ai_latest_experimental`, model-call spans use the latest GenAI inference span name `{gen_ai.operation.name} {gen_ai.request.model}` and `CLIENT` span kind instead of `openclaw.model.call`.
 - `openclaw.harness.run`

--- a/docs/gateway/opentelemetry.md
+++ b/docs/gateway/opentelemetry.md
@@ -203,6 +203,58 @@ bus.
   stays on the same diagnostic trace when the emitting runtime has trusted
   trace context.
 
+### Claude Code CLI model-call fidelity
+
+Claude Code CLI turns emit one synthetic, turn-level `openclaw.model.call`
+span. These are not Anthropic HTTP request spans. They use `openclaw.api =
+claude-code` and identify OpenClaw's CLI boundary through
+`openclaw.transport`:
+
+- `stdio` - one-shot local Claude Code process.
+- `stdio-live` - one turn on a managed persistent Claude stdio session.
+- `paired-node-cli` - one-shot Claude Code execution delegated to a paired
+  node.
+
+The span starts when OpenClaw admits the prepared CLI turn and ends only after
+that turn succeeds or fails. For managed sessions, an interim success result
+does not end the span while Claude reports result-holding background agents or
+workflows; the final post-drain result does. Abort, timeout, process failure,
+output/parse failure, and other turn failures end the same span with an error.
+
+Claude Code reports per-assistant-message usage and may also report cumulative
+usage on its terminal result. OpenClaw reply accounting continues to use the
+last assistant message so existing cost semantics do not change; the
+turn-level model-call span uses terminal cumulative usage when available,
+including cache-read and cache-creation tokens.
+
+For these CLI spans, byte and timing fields describe the observable OpenClaw
+CLI boundary:
+
+- `openclaw.model_call.request_bytes` is the UTF-8 size of the prompt value
+  sent over one-shot stdin/argv, or the managed stdio JSONL user envelope. It
+  is not the size of Claude Code's hidden model request.
+- `openclaw.model_call.response_bytes` is the UTF-8 size of Claude CLI stdout
+  observed during the turn. It is not Anthropic HTTP response size.
+- `openclaw.model_call.time_to_first_byte_ms` is time to the first observable
+  Claude CLI stdout or stderr output. It is not network TTFB.
+
+With the matching granular `captureContent` fields enabled, the span exports
+the effective prompt OpenClaw sends to Claude Code, OpenClaw's appended system
+prompt, and visible assistant text/reasoning/tool-call identity through
+`gen_ai.input.messages`, `gen_ai.output.messages`, and
+`gen_ai.system_instructions`. Tool arguments, opaque thinking signatures, and
+tool results are omitted from the Claude assistant envelope. OpenClaw does not
+claim access to Claude Code's private system prompt, hidden resumed or
+compacted request payload, native internal tool schemas, raw Anthropic HTTP
+request, internal retries, upstream request id, or true network TTFB. Because
+Claude Code does not expose its effective native tool definitions accurately,
+these spans do not populate `gen_ai.tool.definitions`.
+
+External Claude harness tool spans remain metadata-only even when tool content
+capture is enabled. As with every model span, captured Claude CLI content uses
+the trusted listener-only path and the exporter's existing redaction and size
+bounds; content remains off by default.
+
 ## Exported metrics
 
 ### Model usage
@@ -214,9 +266,9 @@ bus.
 - `gen_ai.client.token.usage` (histogram, GenAI semantic-conventions metric, attrs: `gen_ai.token.type` = `input`/`output`, `gen_ai.provider.name`, `gen_ai.operation.name`, `gen_ai.request.model`)
 - `gen_ai.client.operation.duration` (histogram, seconds, GenAI semantic-conventions metric, attrs: `gen_ai.provider.name`, `gen_ai.operation.name`, `gen_ai.request.model`, optional `error.type`)
 - `openclaw.model_call.duration_ms` (histogram, attrs: `openclaw.provider`, `openclaw.model`, `openclaw.api`, `openclaw.transport`, plus `openclaw.errorCategory` and `openclaw.failureKind` on classified errors)
-- `openclaw.model_call.request_bytes` (histogram, UTF-8 byte size of the final model request payload; no raw payload content)
-- `openclaw.model_call.response_bytes` (histogram, UTF-8 byte size of streamed response chunk payloads; high-frequency text, thinking, and tool-call deltas count only incremental `delta` bytes; no raw response content)
-- `openclaw.model_call.time_to_first_byte_ms` (histogram, elapsed time before the first streamed response event)
+- `openclaw.model_call.request_bytes` (histogram, UTF-8 byte size of the final model request payload; for Claude Code CLI, the observable prompt input/envelope described above; no raw payload content)
+- `openclaw.model_call.response_bytes` (histogram, UTF-8 byte size of streamed response chunk payloads; high-frequency text, thinking, and tool-call deltas count only incremental `delta` bytes; for Claude Code CLI, observed stdout bytes; no raw response content)
+- `openclaw.model_call.time_to_first_byte_ms` (histogram, elapsed time before the first streamed response event; for Claude Code CLI, first observable CLI output rather than network TTFB)
 - `openclaw.model.failover` (counter, attrs: `openclaw.provider`, `openclaw.model`, `openclaw.failover.to_provider`, `openclaw.failover.to_model`, `openclaw.failover.reason`, `openclaw.failover.suspended`, `openclaw.lane`)
 - `openclaw.skill.used` (counter, attrs: `openclaw.skill.name`, `openclaw.skill.source`, `openclaw.skill.activation`, optional `openclaw.agent`, optional `openclaw.toolName`)
 

--- a/docs/gateway/opentelemetry.md
+++ b/docs/gateway/opentelemetry.md
@@ -216,16 +216,20 @@ Every `openclaw.model.call` span identifies what its lifecycle measures through
   calls use this unit.
 
 Both units remain model-call spans so trace backends can render model input,
-output, usage, and hierarchy. OpenClaw records both in its
-`openclaw.model_call.*` metrics, which include the observation unit. Only
-`request` events contribute to `gen_ai.client.operation.duration`; excluding
-`turn` events prevents request-latency charts from mixing in full-turn latency.
+output, usage, and hierarchy. Request spans use the API-derived GenAI operation
+(`chat`, `generate_content`, or `text_completion`), while turn spans use
+`gen_ai.operation.name = invoke_agent`. Both contribute to
+`gen_ai.client.operation.duration`, where the operation name keeps direct
+request latency separate from full-turn latency. OpenClaw's OTEL model-call
+metrics also include `openclaw.model_call.observation_unit`; the Prometheus
+model-call metrics expose the equivalent `observation_unit` label.
 
 ### Claude Code CLI model-call fidelity
 
 Claude Code CLI turns emit one synthetic, turn-level `openclaw.model.call`
 span. These are not Anthropic HTTP request spans. They use `openclaw.api =
 claude-code`, `openclaw.model_call.observation_unit = turn`, and identify
+the operation as `gen_ai.operation.name = invoke_agent`. They identify
 OpenClaw's CLI boundary through
 `openclaw.transport`:
 
@@ -291,7 +295,7 @@ bounds; content remains off by default.
 - `openclaw.run.duration_ms` (histogram, attrs: `openclaw.channel`, `openclaw.provider`, `openclaw.model`)
 - `openclaw.context.tokens` (histogram, attrs: `openclaw.context`, `openclaw.channel`, `openclaw.provider`, `openclaw.model`)
 - `gen_ai.client.token.usage` (histogram, GenAI semantic-conventions metric, attrs: `gen_ai.token.type` = `input`/`output`, `gen_ai.provider.name`, `gen_ai.operation.name`, `gen_ai.request.model`)
-- `gen_ai.client.operation.duration` (histogram, seconds, GenAI semantic-conventions metric for request-scoped model calls only; attrs: `gen_ai.provider.name`, `gen_ai.operation.name`, `gen_ai.request.model`, optional `error.type`)
+- `gen_ai.client.operation.duration` (histogram, seconds, GenAI semantic-conventions metric for model requests and synthetic agent turns; attrs: `gen_ai.provider.name`, `gen_ai.operation.name`, `gen_ai.request.model`, optional `error.type`; turn observations use `gen_ai.operation.name = invoke_agent`)
 - `openclaw.model_call.duration_ms` (histogram, attrs: `openclaw.provider`, `openclaw.model`, `openclaw.api`, `openclaw.transport`, `openclaw.model_call.observation_unit`, plus `openclaw.errorCategory` and `openclaw.failureKind` on classified errors)
 - `openclaw.model_call.request_bytes` (histogram, UTF-8 byte size of the final model request payload; for Claude Code CLI, the observable prompt input/envelope described above; no raw payload content)
 - `openclaw.model_call.response_bytes` (histogram, UTF-8 byte size of streamed response chunk payloads; high-frequency text, thinking, and tool-call deltas count only incremental `delta` bytes; for Claude Code CLI, observed stdout bytes; no raw response content)
@@ -423,7 +427,7 @@ Liveness warnings also emit:
   - `openclaw.model_call.prompt.input_messages_count`, `openclaw.model_call.prompt.input_messages_chars`, `openclaw.model_call.prompt.system_prompt_chars`, `openclaw.model_call.prompt.tool_definitions_count`, `openclaw.model_call.prompt.tool_definitions_chars`, `openclaw.model_call.prompt.total_chars` (safe component sizes only, no prompt text)
   - `openclaw.model_call.usage.*` and `gen_ai.usage.*` when the result carries usage for that request or aggregate turn
   - Span event `openclaw.provider.request` with attribute `openclaw.upstreamRequestIdHash` (bounded, hash-based) when the upstream provider result exposes a request id; raw ids are never exported
-  - With `OTEL_SEMCONV_STABILITY_OPT_IN=gen_ai_latest_experimental`, model-call spans use the latest GenAI inference span name `{gen_ai.operation.name} {gen_ai.request.model}` and `CLIENT` span kind instead of `openclaw.model.call`.
+  - With `OTEL_SEMCONV_STABILITY_OPT_IN=gen_ai_latest_experimental`, request spans use the latest GenAI inference span name `{gen_ai.operation.name} {gen_ai.request.model}`. Turn spans use `invoke_agent` because OpenClaw does not claim a native agent name from the opaque CLI boundary. Both use `CLIENT` span kind instead of `openclaw.model.call`.
 - `openclaw.harness.run`
   - `openclaw.harness.id`, `openclaw.harness.plugin`, `openclaw.outcome`, `openclaw.provider`, `openclaw.model`, `openclaw.channel`
   - On completion: `openclaw.harness.result_classification`, `openclaw.harness.yield_detected`, `openclaw.harness.items.started`, `openclaw.harness.items.completed`, `openclaw.harness.items.active`

--- a/docs/gateway/prometheus.md
+++ b/docs/gateway/prometheus.md
@@ -95,8 +95,8 @@ For traces, logs, OTLP push, and OpenTelemetry GenAI semantic attributes, see [O
 | ------------------------------------------------ | --------- | ----------------------------------------------------------------------------------------- |
 | `openclaw_run_completed_total`                   | counter   | `channel`, `model`, `outcome`, `provider`, `trigger`                                      |
 | `openclaw_run_duration_seconds`                  | histogram | `channel`, `model`, `outcome`, `provider`, `trigger`                                      |
-| `openclaw_model_call_total`                      | counter   | `api`, `error_category`, `model`, `outcome`, `provider`, `transport`                      |
-| `openclaw_model_call_duration_seconds`           | histogram | `api`, `error_category`, `model`, `outcome`, `provider`, `transport`                      |
+| `openclaw_model_call_total`                      | counter   | `api`, `error_category`, `model`, `observation_unit`, `outcome`, `provider`, `transport`  |
+| `openclaw_model_call_duration_seconds`           | histogram | `api`, `error_category`, `model`, `observation_unit`, `outcome`, `provider`, `transport`  |
 | `openclaw_model_failover_total`                  | counter   | `from_model`, `from_provider`, `lane`, `reason`, `suspended`, `to_model`, `to_provider`   |
 | `openclaw_model_tokens_total`                    | counter   | `agent`, `channel`, `model`, `provider`, `token_type`                                     |
 | `openclaw_gen_ai_client_token_usage`             | histogram | `model`, `provider`, `token_type`                                                         |
@@ -147,6 +147,11 @@ For traces, logs, OTLP push, and OpenTelemetry GenAI semantic attributes, see [O
 | `openclaw_prometheus_series_dropped_total`       | counter   | none                                                                                      |
 | `openclaw_diagnostic_async_queue_dropped_total`  | counter   | `drop_class`                                                                              |
 | `openclaw_diagnostic_async_queue_length`         | gauge     | none                                                                                      |
+
+For model-call metrics, `observation_unit="request"` measures one observable
+provider request. `observation_unit="turn"` measures a synthetic Claude Code
+or Codex CLI agent turn that can contain multiple hidden provider requests.
+Keep those series separate when comparing latency.
 
 ## Label policy
 

--- a/extensions/codex/src/app-server/run-attempt-turn-request.ts
+++ b/extensions/codex/src/app-server/run-attempt-turn-request.ts
@@ -59,6 +59,7 @@ export async function prepareCodexAttemptTurnRequest(
         : params.modelId,
       api: usesSupervisionConnection ? runtimeParams.model.api : params.model.api,
       transport: appServer.start.transport,
+      observationUnit: "turn",
       ...hookContextWindowFields,
       trace: codexModelCallTrace,
     },

--- a/extensions/codex/src/app-server/run-attempt.hooks.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.hooks.test.ts
@@ -356,10 +356,9 @@ describe("runCodexAppServerAttempt hooks and model diagnostics", () => {
       );
 
       const startedEvent = diagnosticEvents.find((event) => event.type === "model.call.started");
-      const completedEvent = diagnosticEvents.find(
-        (event) => event.type === "model.call.completed",
-      );
-      expect(startedEvent?.callId).toBe("diagnostic-run-1:codex-model:1");
+      const completedEvent = diagnosticEvents.find(({ type }) => type === "model.call.completed");
+      const expectedCallId = "diagnostic-run-1:codex-model:1";
+      expect(startedEvent).toMatchObject({ callId: expectedCallId, observationUnit: "turn" });
       expect(startedEvent?.trace?.traceId).toBeTypeOf("string");
       expect(JSON.stringify(startedEvent)).not.toContain("hello");
       const startedContent = diagnosticContentByType.get("model.call.started")?.modelContent;
@@ -368,7 +367,7 @@ describe("runCodexAppServerAttempt hooks and model diagnostics", () => {
       expect(startedContent?.systemPrompt).toContain(
         "You are a personal agent running inside OpenClaw.",
       );
-      expect(completedEvent?.callId).toBe("diagnostic-run-1:codex-model:1");
+      expect(completedEvent).toMatchObject({ callId: expectedCallId, observationUnit: "turn" });
       expect(JSON.stringify(completedEvent)).not.toContain("hello back");
       expect(
         JSON.stringify(diagnosticContentByType.get("model.call.completed")?.modelContent),

--- a/extensions/codex/src/app-server/run-attempt.hooks.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.hooks.test.ts
@@ -356,7 +356,7 @@ describe("runCodexAppServerAttempt hooks and model diagnostics", () => {
       );
 
       const startedEvent = diagnosticEvents.find((event) => event.type === "model.call.started");
-      const completedEvent = diagnosticEvents.find(({ type }) => type === "model.call.completed");
+      const completed = diagnosticEvents.find((event) => event.type === "model.call.completed");
       const expectedCallId = "diagnostic-run-1:codex-model:1";
       expect(startedEvent).toMatchObject({ callId: expectedCallId, observationUnit: "turn" });
       expect(startedEvent?.trace?.traceId).toBeTypeOf("string");
@@ -367,12 +367,12 @@ describe("runCodexAppServerAttempt hooks and model diagnostics", () => {
       expect(startedContent?.systemPrompt).toContain(
         "You are a personal agent running inside OpenClaw.",
       );
-      expect(completedEvent).toMatchObject({ callId: expectedCallId, observationUnit: "turn" });
-      expect(JSON.stringify(completedEvent)).not.toContain("hello back");
+      expect(completed).toMatchObject({ callId: expectedCallId, observationUnit: "turn" });
+      expect(JSON.stringify(completed)).not.toContain("hello back");
       expect(
         JSON.stringify(diagnosticContentByType.get("model.call.completed")?.modelContent),
       ).toContain("hello back");
-      expect(completedEvent?.requestPayloadBytes).toBeGreaterThan(0);
+      expect(completed?.requestPayloadBytes).toBeGreaterThan(0);
       expect(llmOutput).toHaveBeenCalledTimes(1);
       expect(diagnosticEvents.map((event) => event.type)).not.toContain("model.call.error");
     } finally {

--- a/extensions/diagnostics-otel/src/service-genai-attributes.ts
+++ b/extensions/diagnostics-otel/src/service-genai-attributes.ts
@@ -166,9 +166,21 @@ export function assignGenAiSpanIdentityAttrs(
 
 export function assignGenAiModelCallAttrs(
   attrs: Record<string, string | number | boolean>,
-  evt: { api?: string; model?: string; provider?: string },
+  evt: {
+    api?: string;
+    model?: string;
+    observationUnit?: "request" | "turn";
+    provider?: string;
+  },
 ): void {
   assignGenAiSpanIdentityAttrs(attrs, evt);
+  attrs["openclaw.model_call.observation_unit"] = modelCallObservationUnit(evt);
+}
+
+export function modelCallObservationUnit(evt: {
+  observationUnit?: "request" | "turn";
+}): "request" | "turn" {
+  return evt.observationUnit ?? "request";
 }
 
 export function modelCallSpanName(evt: { api?: string; model?: string }): string {

--- a/extensions/diagnostics-otel/src/service-genai-attributes.ts
+++ b/extensions/diagnostics-otel/src/service-genai-attributes.ts
@@ -1,4 +1,5 @@
 import { SpanKind } from "@opentelemetry/api";
+import { GEN_AI_OPERATION_NAME_VALUE_INVOKE_AGENT } from "@opentelemetry/semantic-conventions/incubating";
 import type { DiagnosticEventPayload } from "../api.js";
 import { redactSensitiveText } from "../api.js";
 import { lowCardinalityAttr } from "./service-attributes.js";
@@ -26,7 +27,13 @@ function emitLatestGenAiSemconv(): boolean {
 
 export function genAiOperationName(
   api: string | undefined,
-): "chat" | "generate_content" | "text_completion" {
+  observationUnit?: "request" | "turn",
+): "chat" | "generate_content" | "invoke_agent" | "text_completion" {
+  // CLI/app-server diagnostics bracket an opaque agent turn, not one inference request.
+  // Label that boundary as agent invocation so its latency stays distinct from request latency.
+  if (observationUnit === "turn") {
+    return GEN_AI_OPERATION_NAME_VALUE_INVOKE_AGENT;
+  }
   const normalized = api?.trim().toLowerCase();
   if (!normalized) {
     return "chat";
@@ -146,7 +153,12 @@ export function assignModelCallUsageAttrs(
 
 export function assignGenAiSpanIdentityAttrs(
   attrs: Record<string, string | number | boolean>,
-  input: { api?: string; model?: string; provider?: string },
+  input: {
+    api?: string;
+    model?: string;
+    observationUnit?: "request" | "turn";
+    provider?: string;
+  },
 ): void {
   if (emitLatestGenAiSemconv()) {
     attrs["gen_ai.provider.name"] = lowCardinalityAttr(input.provider);
@@ -161,7 +173,7 @@ export function assignGenAiSpanIdentityAttrs(
     // reads gen_ai.request.model). Keep the redacted raw model on the span.
     attrs["gen_ai.request.model"] = redactSensitiveText(input.model.trim());
   }
-  attrs["gen_ai.operation.name"] = genAiOperationName(input.api);
+  attrs["gen_ai.operation.name"] = genAiOperationName(input.api, input.observationUnit);
 }
 
 export function assignGenAiModelCallAttrs(
@@ -183,11 +195,18 @@ export function modelCallObservationUnit(evt: {
   return evt.observationUnit ?? "request";
 }
 
-export function modelCallSpanName(evt: { api?: string; model?: string }): string {
+export function modelCallSpanName(evt: {
+  api?: string;
+  model?: string;
+  observationUnit?: "request" | "turn";
+}): string {
   if (!emitLatestGenAiSemconv()) {
     return "openclaw.model.call";
   }
-  return `${genAiOperationName(evt.api)} ${lowCardinalityAttr(evt.model)}`;
+  const operationName = genAiOperationName(evt.api, evt.observationUnit);
+  return operationName === GEN_AI_OPERATION_NAME_VALUE_INVOKE_AGENT
+    ? operationName
+    : `${operationName} ${lowCardinalityAttr(evt.model)}`;
 }
 
 export function modelCallSpanKind(): SpanKind | undefined {

--- a/extensions/diagnostics-otel/src/service-recorders-model.ts
+++ b/extensions/diagnostics-otel/src/service-recorders-model.ts
@@ -11,6 +11,7 @@ import {
   genAiOperationName,
   modelCallSpanKind,
   modelCallSpanName,
+  modelCallObservationUnit,
   positiveFiniteNumber,
 } from "./service-genai-attributes.js";
 import { assignOtelModelContentAttributes } from "./service-genai-content.js";
@@ -39,6 +40,7 @@ export function createModelRecorders(runtime: DiagnosticsRecorderRuntime) {
     "openclaw.model": evt.model,
     "openclaw.api": lowCardinalityAttr(evt.api),
     "openclaw.transport": lowCardinalityAttr(evt.transport),
+    "openclaw.model_call.observation_unit": modelCallObservationUnit(evt),
   });
   const genAiModelCallMetricAttrs = (
     evt: ModelCallLifecycleDiagnosticEvent,
@@ -49,6 +51,20 @@ export function createModelRecorders(runtime: DiagnosticsRecorderRuntime) {
     "gen_ai.request.model": lowCardinalityAttr(evt.model),
     ...(errorType ? { "error.type": errorType } : {}),
   });
+  const recordGenAiModelCallDuration = (
+    evt: ModelCallLifecycleDiagnosticEvent,
+    errorType?: string,
+  ) => {
+    // The standard GenAI series stays request-scoped so opaque CLI-turn latency
+    // cannot be averaged with direct provider-request latency.
+    if (modelCallObservationUnit(evt) !== "request") {
+      return;
+    }
+    genAiOperationDurationHistogram.record(
+      evt.durationMs / 1000,
+      genAiModelCallMetricAttrs(evt, errorType),
+    );
+  };
   const recordModelCallSizeTimingMetrics = (
     evt: Extract<DiagnosticEventPayload, { type: "model.call.completed" | "model.call.error" }>,
     attrs: ReturnType<typeof modelCallMetricAttrs>,
@@ -105,7 +121,7 @@ export function createModelRecorders(runtime: DiagnosticsRecorderRuntime) {
     const metricAttrs = modelCallMetricAttrs(evt);
     modelCallDurationHistogram.record(evt.durationMs, metricAttrs);
     recordModelCallSizeTimingMetrics(evt, metricAttrs);
-    genAiOperationDurationHistogram.record(evt.durationMs / 1000, genAiModelCallMetricAttrs(evt));
+    recordGenAiModelCallDuration(evt);
     if (!tracesEnabled) {
       return;
     }
@@ -151,10 +167,7 @@ export function createModelRecorders(runtime: DiagnosticsRecorderRuntime) {
     };
     modelCallDurationHistogram.record(evt.durationMs, metricAttrs);
     recordModelCallSizeTimingMetrics(evt, metricAttrs);
-    genAiOperationDurationHistogram.record(
-      evt.durationMs / 1000,
-      genAiModelCallMetricAttrs(evt, errorType),
-    );
+    recordGenAiModelCallDuration(evt, errorType);
     if (!tracesEnabled) {
       return;
     }

--- a/extensions/diagnostics-otel/src/service-recorders-model.ts
+++ b/extensions/diagnostics-otel/src/service-recorders-model.ts
@@ -46,7 +46,7 @@ export function createModelRecorders(runtime: DiagnosticsRecorderRuntime) {
     evt: ModelCallLifecycleDiagnosticEvent,
     errorType?: string,
   ) => ({
-    "gen_ai.operation.name": genAiOperationName(evt.api),
+    "gen_ai.operation.name": genAiOperationName(evt.api, evt.observationUnit),
     "gen_ai.provider.name": lowCardinalityAttr(evt.provider),
     "gen_ai.request.model": lowCardinalityAttr(evt.model),
     ...(errorType ? { "error.type": errorType } : {}),
@@ -55,11 +55,6 @@ export function createModelRecorders(runtime: DiagnosticsRecorderRuntime) {
     evt: ModelCallLifecycleDiagnosticEvent,
     errorType?: string,
   ) => {
-    // The standard GenAI series stays request-scoped so opaque CLI-turn latency
-    // cannot be averaged with direct provider-request latency.
-    if (modelCallObservationUnit(evt) !== "request") {
-      return;
-    }
     genAiOperationDurationHistogram.record(
       evt.durationMs / 1000,
       genAiModelCallMetricAttrs(evt, errorType),

--- a/extensions/diagnostics-otel/src/service.test.ts
+++ b/extensions/diagnostics-otel/src/service.test.ts
@@ -2548,9 +2548,9 @@ describe("diagnostics-otel service", () => {
     await service.stop?.(ctx);
   });
 
-  test("exports GenAI client operation duration histogram without diagnostic identifiers", async () => {
+  test("exports GenAI client duration only for request-scoped model calls", async () => {
     const service = createDiagnosticsOtelService();
-    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { metrics: true });
+    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { traces: true, metrics: true });
     await service.start(ctx);
 
     emitDiagnosticEvent({
@@ -2561,6 +2561,7 @@ describe("diagnostics-otel service", () => {
       provider: "anthropic",
       model: "anthropic/claude-sonnet-4.6",
       api: "openai-completions",
+      observationUnit: "request",
       durationMs: 250,
     });
     emitDiagnosticEvent({
@@ -2573,6 +2574,29 @@ describe("diagnostics-otel service", () => {
       api: "google-generative-ai",
       durationMs: 1250,
       errorCategory: "TimeoutError",
+    });
+    emitDiagnosticEvent({
+      type: "model.call.completed",
+      runId: "run-1",
+      callId: "call-3",
+      provider: "anthropic",
+      model: "claude-opus-4-7",
+      api: "claude-code",
+      transport: "stdio-live",
+      observationUnit: "turn",
+      durationMs: 2500,
+    });
+    emitDiagnosticEvent({
+      type: "model.call.error",
+      runId: "run-1",
+      callId: "call-4",
+      provider: "openai",
+      model: "gpt-5.4",
+      api: "openai-responses",
+      transport: "stdio",
+      observationUnit: "turn",
+      durationMs: 3000,
+      errorCategory: "TurnError",
     });
     await flushDiagnosticEvents();
 
@@ -2597,6 +2621,24 @@ describe("diagnostics-otel service", () => {
       "gen_ai.request.model": "gemini-2.5-flash",
       "error.type": "TimeoutError",
     });
+    const openClawModelCallDuration = telemetryState.histograms.get(
+      "openclaw.model_call.duration_ms",
+    );
+    expect(openClawModelCallDuration?.record).toHaveBeenCalledTimes(4);
+    expect(
+      openClawModelCallDuration?.record.mock.calls.map(
+        (call) => call[1]?.["openclaw.model_call.observation_unit"],
+      ),
+    ).toEqual(["request", "request", "turn", "turn"]);
+    const spanObservationUnits = telemetryState.tracer.startSpan.mock.calls
+      .filter((call) => call[0] === "openclaw.model.call")
+      .map(
+        (call) =>
+          (call[1] as { attributes?: Record<string, unknown> }).attributes?.[
+            "openclaw.model_call.observation_unit"
+          ],
+      );
+    expect(spanObservationUnits).toEqual(["request", "request", "turn", "turn"]);
     expect(JSON.stringify(genAiOperationDuration?.record.mock.calls)).not.toContain("session-key");
     expect(JSON.stringify(genAiOperationDuration?.record.mock.calls)).not.toContain("run-1");
     await service.stop?.(ctx);

--- a/extensions/diagnostics-otel/src/service.test.ts
+++ b/extensions/diagnostics-otel/src/service.test.ts
@@ -2548,7 +2548,7 @@ describe("diagnostics-otel service", () => {
     await service.stop?.(ctx);
   });
 
-  test("exports GenAI client duration only for request-scoped model calls", async () => {
+  test("separates request and turn GenAI client duration by operation", async () => {
     const service = createDiagnosticsOtelService();
     const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { traces: true, metrics: true });
     await service.start(ctx);
@@ -2609,7 +2609,7 @@ describe("diagnostics-otel service", () => {
     const genAiOperationDuration = telemetryState.histograms.get(
       "gen_ai.client.operation.duration",
     );
-    expect(genAiOperationDuration?.record).toHaveBeenCalledTimes(2);
+    expect(genAiOperationDuration?.record).toHaveBeenCalledTimes(4);
     expect(genAiOperationDuration?.record).toHaveBeenCalledWith(0.25, {
       "gen_ai.operation.name": "text_completion",
       "gen_ai.provider.name": "anthropic",
@@ -2620,6 +2620,17 @@ describe("diagnostics-otel service", () => {
       "gen_ai.provider.name": "google",
       "gen_ai.request.model": "gemini-2.5-flash",
       "error.type": "TimeoutError",
+    });
+    expect(genAiOperationDuration?.record).toHaveBeenCalledWith(2.5, {
+      "gen_ai.operation.name": "invoke_agent",
+      "gen_ai.provider.name": "anthropic",
+      "gen_ai.request.model": "claude-opus-4-7",
+    });
+    expect(genAiOperationDuration?.record).toHaveBeenCalledWith(3, {
+      "gen_ai.operation.name": "invoke_agent",
+      "gen_ai.provider.name": "openai",
+      "gen_ai.request.model": "gpt-5.4",
+      "error.type": "TurnError",
     });
     const openClawModelCallDuration = telemetryState.histograms.get(
       "openclaw.model_call.duration_ms",
@@ -2639,6 +2650,20 @@ describe("diagnostics-otel service", () => {
           ],
       );
     expect(spanObservationUnits).toEqual(["request", "request", "turn", "turn"]);
+    const spanOperations = telemetryState.tracer.startSpan.mock.calls
+      .filter((call) => call[0] === "openclaw.model.call")
+      .map(
+        (call) =>
+          (call[1] as { attributes?: Record<string, unknown> }).attributes?.[
+            "gen_ai.operation.name"
+          ],
+      );
+    expect(spanOperations).toEqual([
+      "text_completion",
+      "generate_content",
+      "invoke_agent",
+      "invoke_agent",
+    ]);
     expect(JSON.stringify(genAiOperationDuration?.record.mock.calls)).not.toContain("session-key");
     expect(JSON.stringify(genAiOperationDuration?.record.mock.calls)).not.toContain("run-1");
     await service.stop?.(ctx);
@@ -3067,7 +3092,7 @@ describe("diagnostics-otel service", () => {
     await service.stop?.(ctx);
   });
 
-  test("uses latest GenAI inference span shape only when semconv opt-in is set", async () => {
+  test("uses latest GenAI request and agent span shapes only when semconv opt-in is set", async () => {
     process.env.OTEL_SEMCONV_STABILITY_OPT_IN = "http,gen_ai_latest_experimental";
 
     const service = createDiagnosticsOtelService();
@@ -3082,6 +3107,17 @@ describe("diagnostics-otel service", () => {
       model: "gpt-5.4",
       api: "openai-completions",
       durationMs: 80,
+    });
+    emitDiagnosticEvent({
+      type: "model.call.completed",
+      runId: "run-1",
+      callId: "call-2",
+      provider: "anthropic",
+      model: "claude-opus-4-7",
+      api: "claude-code",
+      transport: "stdio-live",
+      observationUnit: "turn",
+      durationMs: 90,
     });
     emitDiagnosticEvent({
       type: "model.usage",
@@ -3100,6 +3136,13 @@ describe("diagnostics-otel service", () => {
     expect(Object.hasOwn(modelCallOptions?.attributes ?? {}, "gen_ai.system")).toBe(false);
     expect(modelCallOptions?.startTime).toBeTypeOf("number");
     expect(modelCallOptions?.kind).toBe(2);
+    const agentTurnOptions = startedSpanOptions("invoke_agent");
+    expect(agentTurnOptions?.attributes?.["gen_ai.provider.name"]).toBe("anthropic");
+    expect(agentTurnOptions?.attributes?.["gen_ai.request.model"]).toBe("claude-opus-4-7");
+    expect(agentTurnOptions?.attributes?.["gen_ai.operation.name"]).toBe("invoke_agent");
+    expect(agentTurnOptions?.attributes?.["openclaw.model_call.observation_unit"]).toBe("turn");
+    expect(agentTurnOptions?.startTime).toBeTypeOf("number");
+    expect(agentTurnOptions?.kind).toBe(2);
     const modelUsageOptions = startedSpanOptions("openclaw.model.usage");
     expect(modelUsageOptions?.attributes?.["gen_ai.provider.name"]).toBe("openai");
     expect(modelUsageOptions?.attributes?.["gen_ai.request.model"]).toBe("gpt-5.4");

--- a/extensions/diagnostics-otel/src/service.test.ts
+++ b/extensions/diagnostics-otel/src/service.test.ts
@@ -5080,6 +5080,76 @@ describe("diagnostics-otel service", () => {
     await service.stop?.(ctx);
   });
 
+  test("exports Claude CLI turn content through the existing Phoenix GenAI keys", async () => {
+    const service = createDiagnosticsOtelService();
+    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, {
+      traces: true,
+      captureContent: {
+        enabled: true,
+        inputMessages: true,
+        outputMessages: true,
+        systemPrompt: true,
+        toolDefinitions: true,
+      },
+    });
+    await service.start(ctx);
+
+    emitTrustedModelCallCompletedWithContent(
+      {
+        runId: "run-claude-cli",
+        callId: "call-claude-cli",
+        provider: "anthropic",
+        model: "claude-sonnet-4-6",
+        api: "claude-code",
+        transport: "stdio-live",
+        durationMs: 80,
+      },
+      {
+        inputMessages: [{ role: "user", content: [{ type: "text", text: "trace this" }] }],
+        outputMessages: [
+          {
+            role: "assistant",
+            content: [
+              { type: "text", text: "trace complete" },
+              { type: "thinking", thinking: "checked the span" },
+              { type: "tool_call", id: "tool-1", name: "Read" },
+            ],
+            stopReason: "end_turn",
+          },
+        ],
+        systemPrompt: "OpenClaw appended instructions",
+      },
+    );
+    await flushDiagnosticEvents();
+
+    const modelCall = telemetryState.tracer.startSpan.mock.calls.find(
+      (call) => call[0] === "openclaw.model.call",
+    );
+    const attrs = (modelCall?.[1] as { attributes?: Record<string, unknown> } | undefined)
+      ?.attributes;
+    expect(attrs?.["openclaw.api"]).toBe("claude-code");
+    expect(attrs?.["openclaw.transport"]).toBe("stdio-live");
+    expect(JSON.parse(stringAttribute(attrs, "gen_ai.input.messages"))).toEqual([
+      { role: "user", parts: [{ type: "text", content: "trace this" }] },
+    ]);
+    expect(JSON.parse(stringAttribute(attrs, "gen_ai.output.messages"))).toEqual([
+      {
+        role: "assistant",
+        parts: [
+          { type: "text", content: "trace complete" },
+          { type: "reasoning", content: "checked the span" },
+          { type: "tool_call", id: "tool-1", name: "Read" },
+        ],
+        finish_reason: "end_turn",
+      },
+    ]);
+    expect(JSON.parse(stringAttribute(attrs, "gen_ai.system_instructions"))).toEqual([
+      { type: "text", content: "OpenClaw appended instructions" },
+    ]);
+    expect(Object.hasOwn(attrs ?? {}, "gen_ai.tool.definitions")).toBe(false);
+    await service.stop?.(ctx);
+  });
+
   test("emits semconv response text for tool response parts", async () => {
     const service = createDiagnosticsOtelService();
     const ctx = createOtelContext(OTEL_TEST_ENDPOINT, {

--- a/extensions/diagnostics-prometheus/src/service.test.ts
+++ b/extensions/diagnostics-prometheus/src/service.test.ts
@@ -131,6 +131,48 @@ describe("diagnostics-prometheus service", () => {
     expect(metrics.render()).toBe("");
   });
 
+  it("separates request and turn model-call metrics by observation unit", () => {
+    const metrics = createMetricsHarness();
+
+    metrics.record(
+      {
+        ...baseEvent(),
+        type: "model.call.completed",
+        runId: "run-1",
+        callId: "call-1",
+        provider: "openai",
+        model: "gpt-5.4",
+        api: "openai-responses",
+        transport: "http",
+        durationMs: 250,
+      },
+      trusted,
+    );
+    metrics.record(
+      {
+        ...baseEvent(),
+        type: "model.call.completed",
+        runId: "run-1",
+        callId: "call-2",
+        provider: "anthropic",
+        model: "claude-opus-4-7",
+        api: "claude-code",
+        transport: "stdio-live",
+        observationUnit: "turn",
+        durationMs: 2500,
+      },
+      trusted,
+    );
+
+    const rendered = metrics.render();
+    expect(rendered).toContain(
+      'openclaw_model_call_total{api="openai-responses",error_category="none",model="gpt-5.4",observation_unit="request",outcome="completed",provider="openai",transport="http"} 1',
+    );
+    expect(rendered).toContain(
+      'openclaw_model_call_duration_seconds_sum{api="claude-code",error_category="none",model="claude-opus-4-7",observation_unit="turn",outcome="completed",provider="anthropic",transport="stdio-live"} 2.5',
+    );
+  });
+
   it("drops untrusted plugin-emitted diagnostic events that spoof gateway stability signals", () => {
     const metrics = createMetricsHarness();
 

--- a/extensions/diagnostics-prometheus/src/service.ts
+++ b/extensions/diagnostics-prometheus/src/service.ts
@@ -323,6 +323,7 @@ function modelCallLabels(evt: {
   api?: string;
   errorCategory?: string;
   model?: string;
+  observationUnit?: "request" | "turn";
   provider?: string;
   transport?: string;
   type: string;
@@ -332,6 +333,7 @@ function modelCallLabels(evt: {
     error_category:
       evt.type === "model.call.error" ? lowCardinalityLabel(evt.errorCategory, "other") : "none",
     model: lowCardinalityLabel(evt.model),
+    observation_unit: evt.observationUnit === "turn" ? "turn" : "request",
     outcome: evt.type === "model.call.error" ? "error" : "completed",
     provider: lowCardinalityLabel(evt.provider),
     transport: lowCardinalityLabel(evt.transport),
@@ -584,13 +586,13 @@ function recordDiagnosticEvent(
     case "model.call.error":
       store.histogram(
         "openclaw_model_call_duration_seconds",
-        "Provider model call duration in seconds.",
+        "Model request or synthetic agent-turn duration in seconds.",
         modelCallLabels(evt),
         seconds(evt.durationMs),
       );
       store.counter(
         "openclaw_model_call_total",
-        "Provider model calls completed by outcome.",
+        "Model requests or synthetic agent turns completed by outcome.",
         modelCallLabels(evt),
       );
       return;

--- a/src/agents/cli-output.test.ts
+++ b/src/agents/cli-output.test.ts
@@ -2011,6 +2011,13 @@ describe("createCliJsonlStreamingParser", () => {
       cacheWrite: undefined,
       total: undefined,
     });
+    expect(output?.diagnosticUsage).toEqual({
+      input: 30,
+      output: 15,
+      cacheRead: 300,
+      cacheWrite: undefined,
+      total: undefined,
+    });
   });
 
   it("surfaces Claude tool_use start and result events", () => {

--- a/src/agents/cli-output.ts
+++ b/src/agents/cli-output.ts
@@ -15,7 +15,7 @@ import type {
   MessagingToolSourceReplyPayload,
 } from "./embedded-agent-messaging.types.js";
 
-type CliUsage = {
+export type CliUsage = {
   input?: number;
   output?: number;
   cacheRead?: number;
@@ -47,6 +47,8 @@ export type CliOutput = {
   rawText?: string;
   sessionId?: string;
   usage?: CliUsage;
+  /** Terminal cumulative turn usage for diagnostics; reply accounting keeps using `usage`. */
+  diagnosticUsage?: CliUsage;
   errorText?: string;
   terminalFailure?: CliTerminalFailure;
   diagnostics?: {
@@ -1210,12 +1212,15 @@ export function createCliJsonlStreamingParser(params: {
   onToolResult?: (delta: CliToolResultDelta) => void;
   onCommentaryText?: (text: string) => void;
   onSessionId?: (sessionId: string) => void;
+  onAssistantMessage?: (message: unknown) => void;
+  onUsage?: (usage: CliUsage, terminal: boolean) => void;
 }) {
   let lineBuffer = "";
   let assistantText = "";
   let pendingClaudeText = "";
   let sessionId: string | undefined;
   let usage: CliUsage | undefined;
+  let diagnosticUsage: CliUsage | undefined;
   let output: CliOutput | null = null;
   let parseErrorText = "";
   let rawChars = 0;
@@ -1267,6 +1272,17 @@ export function createCliJsonlStreamingParser(params: {
       params.onSessionId?.(parsedSessionId);
     }
     const nextUsage = readCliUsage(parsed);
+    const isClaudeTerminalResult =
+      isClaudeStreamJsonDialect({
+        backend: params.backend,
+        providerId: params.providerId,
+      }) && parsed.type === "result";
+    if (isClaudeTerminalResult && nextUsage && usage) {
+      diagnosticUsage = nextUsage;
+    }
+    if (nextUsage) {
+      params.onUsage?.(nextUsage, isClaudeTerminalResult);
+    }
     const shouldUseUsage =
       !isClaudeStreamJsonResult({
         backend: params.backend,
@@ -1275,6 +1291,9 @@ export function createCliJsonlStreamingParser(params: {
       }) || !usage;
     if (shouldUseUsage) {
       usage = nextUsage ?? usage;
+    }
+    if (parsed.type === "assistant" && isRecord(parsed.message)) {
+      params.onAssistantMessage?.(parsed.message);
     }
     const geminiErrorText = isGeminiStreamJsonDialect(params)
       ? readGeminiCliStreamJsonError(parsed)
@@ -1322,7 +1341,11 @@ export function createCliJsonlStreamingParser(params: {
       } else if (!nextText) {
         text = previousText;
       }
-      output = { ...result, text };
+      output = {
+        ...result,
+        text,
+        ...(diagnosticUsage ? { diagnosticUsage } : {}),
+      };
       return;
     }
 
@@ -1510,7 +1533,13 @@ export function createCliJsonlStreamingParser(params: {
     },
     getOutput() {
       if (parseErrorText) {
-        return { text: "", sessionId, usage, errorText: parseErrorText };
+        return {
+          text: "",
+          sessionId,
+          usage,
+          ...(diagnosticUsage ? { diagnosticUsage } : {}),
+          errorText: parseErrorText,
+        };
       }
       if (output) {
         return output;

--- a/src/agents/cli-runner.before-agent-reply-cron.test.ts
+++ b/src/agents/cli-runner.before-agent-reply-cron.test.ts
@@ -7,6 +7,11 @@ import {
   getAgentEventLifecycleGeneration,
   withAgentRunLifecycleGeneration,
 } from "../infra/agent-events.js";
+import {
+  onTrustedInternalDiagnosticEvent,
+  resetDiagnosticEventsForTest,
+  type DiagnosticEventPayload,
+} from "../infra/diagnostic-events.js";
 import type { CliOutput } from "./cli-output.js";
 import { cliBackendLog } from "./cli-runner/log.js";
 
@@ -84,6 +89,29 @@ const baseRunParams = {
 
 let runCliAgent: typeof import("./cli-runner.js").runCliAgent;
 
+async function captureRejectedClaudeRun(
+  params: Parameters<typeof runCliAgent>[0],
+): Promise<{ error: unknown; events: DiagnosticEventPayload[] }> {
+  const events: DiagnosticEventPayload[] = [];
+  const unsubscribe = onTrustedInternalDiagnosticEvent((event) => {
+    if ("runId" in event && event.runId === params.runId) {
+      events.push(event);
+    }
+  });
+  let error: unknown;
+  try {
+    await runCliAgent(params);
+  } catch (caught) {
+    error = caught;
+  } finally {
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
+    unsubscribe();
+  }
+  return { error, events };
+}
+
 function makeStubContext(params: typeof baseRunParams & { trigger?: string }) {
   // Stub only the prepared context shape runCliAgent needs after the hook gate.
   return {
@@ -123,9 +151,115 @@ beforeAll(async () => {
 
 afterEach(() => {
   vi.clearAllMocks();
+  resetDiagnosticEventsForTest();
 });
 
 describe("runCliAgent before_agent_reply seam", () => {
+  it("adds Claude CLI harness and run ownership at the runner entrypoint", async () => {
+    const events: DiagnosticEventPayload[] = [];
+    const unsubscribe = onTrustedInternalDiagnosticEvent((event) => {
+      if ("runId" in event && event.runId === "claude-entrypoint-run") {
+        events.push(event);
+      }
+    });
+    executePreparedCliRunMock.mockResolvedValue({ text: "real Claude reply" });
+
+    let result: Awaited<ReturnType<typeof runCliAgent>> | undefined;
+    try {
+      result = await runCliAgent({
+        ...baseRunParams,
+        provider: "claude-cli",
+        modelProvider: "anthropic",
+        model: "claude-opus-4-7",
+        runId: "claude-entrypoint-run",
+      });
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
+    } finally {
+      unsubscribe();
+    }
+
+    const harnessStarted = events.find((event) => event.type === "harness.run.started");
+    const runStarted = events.find((event) => event.type === "run.started");
+    expect(events).toHaveLength(4);
+    expect(events.map((event) => event.type)).toEqual(
+      expect.arrayContaining([
+        "harness.run.started",
+        "run.started",
+        "run.completed",
+        "harness.run.completed",
+      ]),
+    );
+    expect(harnessStarted).toMatchObject({
+      harnessId: "claude-cli",
+      provider: "anthropic",
+      model: "claude-opus-4-7",
+    });
+    expect(runStarted?.trace?.parentSpanId).toBe(harnessStarted?.trace?.spanId);
+    expect(result?.diagnosticTrace).toEqual(harnessStarted?.trace);
+  });
+
+  it("preserves the send phase when execution fails before successful cleanup", async () => {
+    executePreparedCliRunMock.mockRejectedValueOnce(new Error("CLI process failed"));
+
+    const { error, events } = await captureRejectedClaudeRun({
+      ...baseRunParams,
+      provider: "claude-cli",
+      modelProvider: "anthropic",
+      model: "claude-opus-4-7",
+      runId: "claude-send-error",
+      cleanupCliLiveSessionOnRunEnd: true,
+    });
+
+    expect(error).toMatchObject({ message: "CLI process failed" });
+    expect(closeClaudeLiveSessionForContextMock).toHaveBeenCalledTimes(1);
+    expect(events.find((event) => event.type === "harness.run.error")).toMatchObject({
+      type: "harness.run.error",
+      phase: "send",
+    });
+  });
+
+  it("classifies post-execution response validation failures as resolve", async () => {
+    executePreparedCliRunMock.mockResolvedValueOnce({ text: "" });
+
+    const { error, events } = await captureRejectedClaudeRun({
+      ...baseRunParams,
+      provider: "claude-cli",
+      modelProvider: "anthropic",
+      model: "claude-opus-4-7",
+      runId: "claude-resolve-error",
+    });
+
+    expect(error).toMatchObject({ message: "CLI backend returned an empty response." });
+    expect(events.find((event) => event.type === "harness.run.error")).toMatchObject({
+      type: "harness.run.error",
+      phase: "resolve",
+    });
+  });
+
+  it("classifies a surfaced outer cleanup failure as cleanup", async () => {
+    executePreparedCliRunMock.mockResolvedValueOnce({ text: "real Claude reply" });
+    closeClaudeLiveSessionForContextMock.mockRejectedValueOnce(
+      new Error("managed session cleanup failed"),
+    );
+
+    const { error, events } = await captureRejectedClaudeRun({
+      ...baseRunParams,
+      provider: "claude-cli",
+      modelProvider: "anthropic",
+      model: "claude-opus-4-7",
+      runId: "claude-cleanup-error",
+      cleanupCliLiveSessionOnRunEnd: true,
+    });
+
+    expect(error).toMatchObject({ message: "managed session cleanup failed" });
+    expect(events.find((event) => event.type === "harness.run.error")).toMatchObject({
+      type: "harness.run.error",
+      phase: "cleanup",
+    });
+  });
+
   it("rejects stale lifecycle ownership before CLI preparation", async () => {
     await expect(
       runCliAgent({

--- a/src/agents/cli-runner.reliability.test.ts
+++ b/src/agents/cli-runner.reliability.test.ts
@@ -23,7 +23,12 @@ import {
   resolveMcpLoopbackYieldContext,
   updateMcpLoopbackToolCallCapture,
 } from "../gateway/mcp-http.loopback-runtime.js";
-import { resetDiagnosticEventsForTest } from "../infra/diagnostic-events.js";
+import {
+  onTrustedInternalDiagnosticEvent,
+  resetDiagnosticEventsForTest,
+  setDiagnosticsEnabledForProcess,
+  waitForDiagnosticEventsDrained,
+} from "../infra/diagnostic-events.js";
 import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
 import type { getProcessSupervisor } from "../process/supervisor/index.js";
 import type { RunExit } from "../process/supervisor/types.js";
@@ -2008,6 +2013,21 @@ describe("runCliAgent reliability", () => {
   it.each(["timeout", "unknown", "context_overflow"] as const)(
     "retries a fresh CLI session after recoverable %s failover without a failed agent_end",
     async (reason) => {
+      const runId = `run-retry-${reason}`;
+      const modelCallEvents: Array<{ callId: string; type: string }> = [];
+      setDiagnosticsEnabledForProcess(true);
+      const stopDiagnostics = onTrustedInternalDiagnosticEvent((event) => {
+        if (
+          event.type !== "model.call.started" &&
+          event.type !== "model.call.completed" &&
+          event.type !== "model.call.error"
+        ) {
+          return;
+        }
+        if (event.runId === runId) {
+          modelCallEvents.push({ callId: event.callId, type: event.type });
+        }
+      });
       const hookRunner = {
         hasHooks: vi.fn((hookName: string) =>
           ["llm_input", "llm_output", "agent_end"].includes(hookName),
@@ -2083,7 +2103,7 @@ describe("runCliAgent reliability", () => {
       try {
         const context = buildPreparedContext({
           sessionKey: "agent:main:subagent:retry",
-          runId: `run-retry-${reason}`,
+          runId,
           cliSessionId: "stale-cli-session",
           provider: "claude-cli",
           model: "opus",
@@ -2125,7 +2145,18 @@ describe("runCliAgent reliability", () => {
         );
         expect(agentEndEvent.success).toBe(true);
         expect(agentEndEvent.error).toBeUndefined();
+        await waitForDiagnosticEventsDrained();
+        expect(modelCallEvents.map((event) => event.type)).toEqual([
+          "model.call.started",
+          "model.call.error",
+          "model.call.started",
+          "model.call.completed",
+        ]);
+        expect(modelCallEvents[0]?.callId).toBe(modelCallEvents[1]?.callId);
+        expect(modelCallEvents[2]?.callId).toBe(modelCallEvents[3]?.callId);
+        expect(modelCallEvents[0]?.callId).not.toBe(modelCallEvents[2]?.callId);
       } finally {
+        stopDiagnostics();
         fs.rmSync(dir, { recursive: true, force: true });
       }
     },

--- a/src/agents/cli-runner.spawn.test.ts
+++ b/src/agents/cli-runner.spawn.test.ts
@@ -643,6 +643,7 @@ describe("runCliAgent spawn path", () => {
       ]);
       expect(diagnostics.events[1]?.event).toMatchObject({
         transport: "paired-node-cli",
+        observationUnit: "turn",
         failureKind: "aborted",
       });
     } finally {
@@ -1047,6 +1048,7 @@ describe("runCliAgent spawn path", () => {
         model: "claude-sonnet-4-6",
         api: "claude-code",
         transport: "stdio",
+        observationUnit: "turn",
         promptStats: {
           inputMessagesCount: 1,
           inputMessagesChars: prompt.length,
@@ -2156,6 +2158,7 @@ describe("runCliAgent spawn path", () => {
       expect(completed?.event).toMatchObject({
         api: "claude-code",
         transport: "stdio-live",
+        observationUnit: "turn",
         requestPayloadBytes: Buffer.byteLength(writes[0] ?? ""),
         responseStreamBytes: Buffer.byteLength(interimChunk) + Buffer.byteLength(finalChunk),
         usage: {

--- a/src/agents/cli-runner.spawn.test.ts
+++ b/src/agents/cli-runner.spawn.test.ts
@@ -15,8 +15,11 @@ import { invokeNodeClaudeCliRun } from "../gateway/node-agent-cli-runtime.js";
 import { onAgentEvent, resetAgentEventsForTest } from "../infra/agent-events.js";
 import {
   onInternalDiagnosticEvent,
+  onTrustedInternalDiagnosticEvent,
   onTrustedToolExecutionEvent,
   setDiagnosticsEnabledForProcess,
+  type DiagnosticEventPayload,
+  type DiagnosticEventPrivateData,
   waitForDiagnosticEventsDrained,
 } from "../infra/diagnostic-events.js";
 import {
@@ -374,6 +377,31 @@ async function withTempOpenClawHome(run: (home: string) => Promise<void>): Promi
   }
 }
 
+type ModelCallLifecycleEvent = Extract<
+  DiagnosticEventPayload,
+  { type: "model.call.started" | "model.call.completed" | "model.call.error" }
+>;
+
+function captureModelCallDiagnostics(runId: string) {
+  const events: Array<{
+    event: ModelCallLifecycleEvent;
+    privateData: DiagnosticEventPrivateData;
+  }> = [];
+  const stop = onTrustedInternalDiagnosticEvent((event, _metadata, privateData) => {
+    if (
+      event.type !== "model.call.started" &&
+      event.type !== "model.call.completed" &&
+      event.type !== "model.call.error"
+    ) {
+      return;
+    }
+    if (event.runId === runId) {
+      events.push({ event, privateData });
+    }
+  });
+  return { events, stop };
+}
+
 describe("runCliAgent spawn path", () => {
   it("formats output digests without logging response content", () => {
     expect(formatCliBackendOutputDigest("one")).toBe("outBytes=3 outHash=7692c3ad3540");
@@ -599,13 +627,27 @@ describe("runCliAgent spawn path", () => {
       },
     });
     context.params.abortSignal = controller.signal;
+    const diagnostics = captureModelCallDiagnostics("run-node-abort");
 
-    const run = executePreparedCliRun(context);
-    await vi.waitFor(() => expect(invokeNode).toHaveBeenCalledOnce());
-    controller.abort();
+    try {
+      const run = executePreparedCliRun(context);
+      await vi.waitFor(() => expect(invokeNode).toHaveBeenCalledOnce());
+      controller.abort();
 
-    await expect(run).rejects.toMatchObject({ name: "AbortError" });
-    expect(invokeNode.mock.calls[0]?.[0].signal?.aborted).toBe(true);
+      await expect(run).rejects.toMatchObject({ name: "AbortError" });
+      await waitForDiagnosticEventsDrained();
+      expect(invokeNode.mock.calls[0]?.[0].signal?.aborted).toBe(true);
+      expect(diagnostics.events.map(({ event }) => event.type)).toEqual([
+        "model.call.started",
+        "model.call.error",
+      ]);
+      expect(diagnostics.events[1]?.event).toMatchObject({
+        transport: "paired-node-cli",
+        failureKind: "aborted",
+      });
+    } finally {
+      diagnostics.stop();
+    }
   });
 
   it("uses the canonical exec approval flow before retrying a node Claude run", async () => {
@@ -921,6 +963,309 @@ describe("runCliAgent spawn path", () => {
     };
     expect(input.input).toContain("Explain this diff");
     expect(input.argv).not.toContain("Explain this diff");
+  });
+
+  it("emits metadata-only one-shot Claude model-call diagnostics with aggregate usage", async () => {
+    const prompt = "Trace this turn";
+    const stdout =
+      [
+        JSON.stringify({ type: "system", subtype: "init", session_id: "cli-trace-1" }),
+        JSON.stringify({
+          type: "assistant",
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "traced reply" }],
+            usage: {
+              input_tokens: 11,
+              output_tokens: 6,
+              cache_read_input_tokens: 125,
+              cache_creation_input_tokens: 7,
+            },
+          },
+        }),
+        JSON.stringify({
+          type: "result",
+          subtype: "success",
+          session_id: "cli-trace-1",
+          result: "traced reply",
+          usage: {
+            input_tokens: 30,
+            output_tokens: 15,
+            cache_read_input_tokens: 300,
+            cache_creation_input_tokens: 12,
+            total_tokens: 357,
+          },
+        }),
+      ].join("\n") + "\n";
+    supervisorSpawnMock.mockResolvedValueOnce(
+      createManagedRun({
+        reason: "exit",
+        exitCode: 0,
+        exitSignal: null,
+        durationMs: 50,
+        stdout,
+        stderr: "",
+        timedOut: false,
+        noOutputTimedOut: false,
+      }),
+    );
+    const diagnostics = captureModelCallDiagnostics("run-claude-model-call-metadata");
+
+    try {
+      const output = await executePreparedCliRun(
+        buildPreparedCliRunContext({
+          provider: "claude-cli",
+          model: "claude-sonnet-4-6",
+          runId: "run-claude-model-call-metadata",
+          prompt,
+        }),
+      );
+      await waitForDiagnosticEventsDrained();
+
+      expect(output.usage).toEqual({
+        input: 11,
+        output: 6,
+        cacheRead: 125,
+        cacheWrite: 7,
+        total: undefined,
+      });
+      expect(output.diagnosticUsage).toEqual({
+        input: 30,
+        output: 15,
+        cacheRead: 300,
+        cacheWrite: 12,
+        total: 357,
+      });
+      expect(diagnostics.events.map(({ event }) => event.type)).toEqual([
+        "model.call.started",
+        "model.call.completed",
+      ]);
+      const started = diagnostics.events[0];
+      const completed = diagnostics.events[1];
+      expect(started?.event).toMatchObject({
+        provider: "anthropic",
+        model: "claude-sonnet-4-6",
+        api: "claude-code",
+        transport: "stdio",
+        promptStats: {
+          inputMessagesCount: 1,
+          inputMessagesChars: prompt.length,
+          systemPromptChars: "You are a helpful assistant.".length,
+          totalChars: prompt.length + "You are a helpful assistant.".length,
+        },
+      });
+      expect(completed?.event).toMatchObject({
+        provider: "anthropic",
+        model: "claude-sonnet-4-6",
+        api: "claude-code",
+        transport: "stdio",
+        requestPayloadBytes: Buffer.byteLength(prompt),
+        responseStreamBytes: Buffer.byteLength(stdout),
+        timeToFirstByteMs: expect.any(Number),
+        usage: {
+          input: 30,
+          output: 15,
+          cacheRead: 300,
+          cacheWrite: 12,
+          total: 357,
+        },
+      });
+      expect(completed?.event.callId).toBe(started?.event.callId);
+      expect(completed?.event).not.toHaveProperty("upstreamRequestIdHash");
+      expect(started?.privateData.modelContent).toBeUndefined();
+      expect(completed?.privateData.modelContent).toBeUndefined();
+    } finally {
+      diagnostics.stop();
+    }
+  });
+
+  it("captures only representable Claude prompt, system, and assistant content when opted in", async () => {
+    const prompt = "Explain the trace";
+    const stdout =
+      [
+        JSON.stringify({
+          type: "assistant",
+          message: {
+            role: "assistant",
+            stop_reason: "end_turn",
+            content: [
+              { type: "text", text: "visible answer" },
+              { type: "thinking", thinking: "visible reasoning", signature: "opaque-signature" },
+              {
+                type: "tool_use",
+                id: "tool-1",
+                name: "Read",
+                input: { path: "/private/path" },
+              },
+            ],
+          },
+        }),
+        JSON.stringify({ type: "result", result: "visible answer" }),
+      ].join("\n") + "\n";
+    supervisorSpawnMock.mockResolvedValueOnce(
+      createManagedRun({
+        reason: "exit",
+        exitCode: 0,
+        exitSignal: null,
+        durationMs: 50,
+        stdout,
+        stderr: "",
+        timedOut: false,
+        noOutputTimedOut: false,
+      }),
+    );
+    const diagnostics = captureModelCallDiagnostics("run-claude-model-call-content");
+
+    try {
+      await executePreparedCliRun(
+        buildPreparedCliRunContext({
+          provider: "claude-cli",
+          model: "claude-sonnet-4-6",
+          runId: "run-claude-model-call-content",
+          prompt,
+          config: {
+            diagnostics: {
+              enabled: true,
+              otel: {
+                enabled: true,
+                traces: true,
+                captureContent: {
+                  enabled: true,
+                  inputMessages: true,
+                  outputMessages: true,
+                  systemPrompt: true,
+                  toolDefinitions: true,
+                },
+              },
+            },
+          },
+        }),
+      );
+      await waitForDiagnosticEventsDrained();
+
+      const completed = diagnostics.events.find(
+        ({ event }) => event.type === "model.call.completed",
+      );
+      expect(completed?.privateData.modelContent).toEqual({
+        inputMessages: [{ role: "user", content: [{ type: "text", text: prompt }] }],
+        systemPrompt: "You are a helpful assistant.",
+        outputMessages: [
+          {
+            role: "assistant",
+            stopReason: "end_turn",
+            content: [
+              { type: "text", text: "visible answer" },
+              { type: "thinking", thinking: "visible reasoning" },
+              { type: "tool_call", id: "tool-1", name: "Read" },
+            ],
+          },
+        ],
+      });
+      expect(completed?.privateData.modelContent?.toolDefinitions).toBeUndefined();
+      expect(JSON.stringify(completed?.privateData.modelContent)).not.toContain("/private/path");
+      expect(JSON.stringify(completed?.privateData.modelContent)).not.toContain("opaque-signature");
+    } finally {
+      diagnostics.stop();
+    }
+  });
+
+  it("emits one Claude model-call error when one-shot process startup fails", async () => {
+    supervisorSpawnMock.mockRejectedValueOnce(new Error("claude process spawn failed"));
+    const diagnostics = captureModelCallDiagnostics("run-claude-model-call-spawn-error");
+
+    try {
+      await expect(
+        executePreparedCliRun(
+          buildPreparedCliRunContext({
+            provider: "claude-cli",
+            model: "claude-sonnet-4-6",
+            runId: "run-claude-model-call-spawn-error",
+            prompt: "fail now",
+          }),
+        ),
+      ).rejects.toThrow("claude process spawn failed");
+      await waitForDiagnosticEventsDrained();
+
+      expect(diagnostics.events.map(({ event }) => event.type)).toEqual([
+        "model.call.started",
+        "model.call.error",
+      ]);
+      expect(diagnostics.events[1]?.event).toMatchObject({
+        errorCategory: "Error",
+        requestPayloadBytes: Buffer.byteLength("fail now"),
+      });
+      expect(diagnostics.events[1]?.privateData.errorMessage).toBe("claude process spawn failed");
+    } finally {
+      diagnostics.stop();
+    }
+  });
+
+  it.each([
+    {
+      label: "timeout",
+      runId: "run-claude-model-call-timeout",
+      exit: {
+        reason: "overall-timeout" as const,
+        exitCode: null,
+        exitSignal: null,
+        durationMs: 50,
+        stdout: "",
+        stderr: "",
+        timedOut: true,
+        noOutputTimedOut: false,
+      },
+      errorCategory: "timeout",
+      failureKind: "timeout",
+    },
+    {
+      label: "parse failure",
+      runId: "run-claude-model-call-parse-error",
+      exit: {
+        reason: "exit" as const,
+        exitCode: 0,
+        exitSignal: null,
+        durationMs: 50,
+        stdout: `${JSON.stringify({ type: "system", subtype: "unexpected" })}\n`,
+        stderr: "",
+        timedOut: false,
+        noOutputTimedOut: false,
+      },
+      errorCategory: "unknown",
+      failureKind: undefined,
+    },
+  ])("emits one Claude model-call error for $label", async (testCase) => {
+    supervisorSpawnMock.mockResolvedValueOnce(createManagedRun(testCase.exit));
+    const diagnostics = captureModelCallDiagnostics(testCase.runId);
+
+    try {
+      await expect(
+        executePreparedCliRun(
+          buildPreparedCliRunContext({
+            provider: "claude-cli",
+            model: "claude-sonnet-4-6",
+            runId: testCase.runId,
+          }),
+        ),
+      ).rejects.toThrow();
+      await waitForDiagnosticEventsDrained();
+
+      expect(diagnostics.events.map(({ event }) => event.type)).toEqual([
+        "model.call.started",
+        "model.call.error",
+      ]);
+      expect(diagnostics.events[1]?.event).toMatchObject({
+        errorCategory: testCase.errorCategory,
+      });
+      if (testCase.failureKind) {
+        expect(diagnostics.events[1]?.event).toMatchObject({
+          failureKind: testCase.failureKind,
+        });
+      } else {
+        expect(diagnostics.events[1]?.event).not.toHaveProperty("failureKind");
+      }
+    } finally {
+      diagnostics.stop();
+    }
   });
 
   it("passes Claude system prompts through a file instead of argv", async () => {
@@ -1685,6 +2030,209 @@ describe("runCliAgent spawn path", () => {
     }
   });
 
+  it("keeps one managed Claude model call open until background task results drain", async () => {
+    let stdoutListener: ((chunk: string) => void) | undefined;
+    const writes: string[] = [];
+    const cancel = vi.fn();
+    const interimChunk =
+      [
+        JSON.stringify({ type: "system", subtype: "init", session_id: "live-trace" }),
+        JSON.stringify({
+          type: "assistant",
+          session_id: "live-trace",
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "working" }],
+            usage: { input_tokens: 4, output_tokens: 1, cache_read_input_tokens: 20 },
+          },
+        }),
+        JSON.stringify({
+          type: "system",
+          subtype: "background_tasks_changed",
+          tasks: [{ task_id: "task-1", task_type: "local_agent", description: "research" }],
+        }),
+        JSON.stringify({
+          type: "result",
+          subtype: "success",
+          session_id: "live-trace",
+          result: "working",
+          usage: { input_tokens: 5, output_tokens: 1, cache_read_input_tokens: 25 },
+        }),
+      ].join("\n") + "\n";
+    const finalChunk =
+      [
+        JSON.stringify({ type: "system", subtype: "background_tasks_changed", tasks: [] }),
+        JSON.stringify({
+          type: "assistant",
+          session_id: "live-trace",
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "finished" }],
+            usage: { input_tokens: 6, output_tokens: 2, cache_read_input_tokens: 30 },
+          },
+        }),
+        JSON.stringify({
+          type: "result",
+          subtype: "success",
+          session_id: "live-trace",
+          result: "finished",
+          usage: {
+            input_tokens: 10,
+            output_tokens: 3,
+            cache_read_input_tokens: 50,
+            cache_creation_input_tokens: 2,
+          },
+        }),
+      ].join("\n") + "\n";
+    const stdin = {
+      write: vi.fn((data: string, cb?: (err?: Error | null) => void) => {
+        writes.push(data);
+        stdoutListener?.(interimChunk);
+        cb?.();
+      }),
+      end: vi.fn(),
+    };
+    supervisorSpawnMock.mockImplementationOnce(async (...args: unknown[]) => {
+      const input = (args[0] ?? {}) as { onStdout?: (chunk: string) => void };
+      stdoutListener = input.onStdout;
+      return {
+        runId: "live-model-call",
+        pid: 2345,
+        startedAtMs: Date.now(),
+        stdin,
+        wait: vi.fn(() => new Promise(() => {})),
+        cancel,
+      };
+    });
+    const diagnostics = captureModelCallDiagnostics("run-live-model-call-background");
+
+    try {
+      const run = executePreparedCliRun(
+        buildPreparedCliRunContext({
+          provider: "claude-cli",
+          model: "claude-sonnet-4-6",
+          runId: "run-live-model-call-background",
+          prompt: "research this",
+          backend: { liveSession: "claude-stdio" },
+          config: {
+            diagnostics: {
+              enabled: true,
+              otel: {
+                enabled: true,
+                traces: true,
+                captureContent: {
+                  enabled: true,
+                  inputMessages: true,
+                  outputMessages: true,
+                  systemPrompt: true,
+                },
+              },
+            },
+          },
+        }),
+      );
+      await vi.waitFor(() => expect(writes).toHaveLength(1));
+      await waitForDiagnosticEventsDrained();
+      expect(diagnostics.events.map(({ event }) => event.type)).toEqual(["model.call.started"]);
+
+      stdoutListener?.(finalChunk);
+      const output = await run;
+      await waitForDiagnosticEventsDrained();
+
+      expect(output.text).toContain("working");
+      expect(output.text).toContain("finished");
+      expect(output.usage).toEqual({
+        input: 6,
+        output: 2,
+        cacheRead: 30,
+        cacheWrite: undefined,
+        total: undefined,
+      });
+      expect(diagnostics.events.map(({ event }) => event.type)).toEqual([
+        "model.call.started",
+        "model.call.completed",
+      ]);
+      const completed = diagnostics.events[1];
+      expect(completed?.event).toMatchObject({
+        api: "claude-code",
+        transport: "stdio-live",
+        requestPayloadBytes: Buffer.byteLength(writes[0] ?? ""),
+        responseStreamBytes: Buffer.byteLength(interimChunk) + Buffer.byteLength(finalChunk),
+        usage: {
+          input: 10,
+          output: 3,
+          cacheRead: 50,
+          cacheWrite: 2,
+        },
+      });
+      expect(completed?.privateData.modelContent?.outputMessages).toEqual([
+        { role: "assistant", content: [{ type: "text", text: "working" }] },
+        { role: "assistant", content: [{ type: "text", text: "finished" }] },
+      ]);
+      expect(cancel).not.toHaveBeenCalled();
+    } finally {
+      diagnostics.stop();
+    }
+  });
+
+  it("emits one terminal model-call error for a managed Claude result failure", async () => {
+    let stdoutListener: ((chunk: string) => void) | undefined;
+    const stdin = {
+      write: vi.fn((_data: string, cb?: (err?: Error | null) => void) => {
+        stdoutListener?.(
+          `${JSON.stringify({
+            type: "result",
+            subtype: "error_during_execution",
+            is_error: true,
+            session_id: "live-error",
+            result: "managed turn failed",
+            usage: { input_tokens: 8, output_tokens: 2, cache_read_input_tokens: 40 },
+          })}\n`,
+        );
+        cb?.();
+      }),
+      end: vi.fn(),
+    };
+    supervisorSpawnMock.mockImplementationOnce(async (...args: unknown[]) => {
+      const input = (args[0] ?? {}) as { onStdout?: (chunk: string) => void };
+      stdoutListener = input.onStdout;
+      return {
+        runId: "live-model-call-error",
+        pid: 2346,
+        startedAtMs: Date.now(),
+        stdin,
+        wait: vi.fn(() => new Promise(() => {})),
+        cancel: vi.fn(),
+      };
+    });
+    const diagnostics = captureModelCallDiagnostics("run-live-model-call-error");
+
+    try {
+      await expect(
+        executePreparedCliRun(
+          buildPreparedCliRunContext({
+            provider: "claude-cli",
+            model: "claude-sonnet-4-6",
+            runId: "run-live-model-call-error",
+            backend: { liveSession: "claude-stdio" },
+          }),
+        ),
+      ).rejects.toThrow(/managed turn failed/i);
+      await waitForDiagnosticEventsDrained();
+
+      expect(diagnostics.events.map(({ event }) => event.type)).toEqual([
+        "model.call.started",
+        "model.call.error",
+      ]);
+      expect(diagnostics.events[1]?.event).toMatchObject({
+        transport: "stdio-live",
+        usage: { input: 8, output: 2, cacheRead: 40 },
+      });
+    } finally {
+      diagnostics.stop();
+    }
+  });
+
   it("reuses a Claude live session process across turns", async () => {
     const logInfoSpy = vi.spyOn(cliBackendLog, "info").mockImplementation(() => undefined);
     const agentEvents: unknown[] = [];
@@ -2294,6 +2842,43 @@ describe("runCliAgent spawn path", () => {
     expect(logWarnSpy).toHaveBeenCalledWith(
       expect.stringContaining("outer resource cleanup failed after confirmed message delivery"),
     );
+  });
+
+  it("emits a model-call error when successful Claude output is followed by cleanup failure", async () => {
+    const runId = "run-claude-cleanup-failure";
+    const diagnostics = captureModelCallDiagnostics(runId);
+    const cleanupError = new Error("system prompt cleanup failed");
+    setCliRunnerExecuteTestDeps({
+      writeCliSystemPromptFile: async () => ({
+        filePath: "/tmp/system-prompt.md",
+        cleanup: async () => {
+          throw cleanupError;
+        },
+      }),
+    });
+    mockSuccessfulClaudeJsonlRun();
+
+    try {
+      await expect(
+        executePreparedCliRun(
+          buildPreparedCliRunContext({
+            provider: "claude-cli",
+            model: "claude-sonnet-4-6",
+            runId,
+          }),
+        ),
+      ).rejects.toThrow("system prompt cleanup failed");
+      await waitForDiagnosticEventsDrained();
+
+      expect(diagnostics.events.map(({ event }) => event.type)).toEqual([
+        "model.call.started",
+        "model.call.error",
+      ]);
+      expect(diagnostics.events[1]?.event.callId).toBe(diagnostics.events[0]?.event.callId);
+    } finally {
+      diagnostics.stop();
+      setCliRunnerExecuteTestDeps({ writeCliSystemPromptFile });
+    }
   });
 
   it("wraps primitive and frozen failures to preserve delivery evidence", () => {

--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -37,6 +37,10 @@ import {
 import { cliBackendLog, formatCliBackendOutputDigest } from "./cli-runner/log.js";
 import { hashCliReseedPrompt } from "./cli-runner/reseed-envelope.js";
 import {
+  runClaudeCliAgentTurnWithDiagnostics,
+  type ClaudeCliRunDiagnosticLifecycle,
+} from "./cli-runner/run-diagnostics.js";
+import {
   loadCliSessionContextEngineMessages,
   loadCliSessionHistoryMessages,
 } from "./cli-runner/session-history.js";
@@ -460,15 +464,23 @@ async function finalizeCliContextEngineTurn(params: {
 export function runCliAgent(paramsInput: RunCliAgentParams): Promise<EmbeddedAgentRunResult> {
   const lifecycleGeneration =
     paramsInput.lifecycleGeneration ?? captureAgentRunLifecycleGeneration(paramsInput.runId);
+  const params = {
+    ...paramsInput,
+    lifecycleGeneration,
+  };
   return withAgentRunLifecycleGeneration(lifecycleGeneration, () =>
-    runCliAgentInternal({
-      ...paramsInput,
-      lifecycleGeneration,
-    }),
+    isClaudeCliProvider(params.provider)
+      ? runClaudeCliAgentTurnWithDiagnostics(params, (diagnosticLifecycle) =>
+          runCliAgentInternal(params, diagnosticLifecycle),
+        )
+      : runCliAgentInternal(params),
   );
 }
 
-async function runCliAgentInternal(params: RunCliAgentParams): Promise<EmbeddedAgentRunResult> {
+async function runCliAgentInternal(
+  params: RunCliAgentParams,
+  diagnosticLifecycle?: ClaudeCliRunDiagnosticLifecycle,
+): Promise<EmbeddedAgentRunResult> {
   assertAgentRunLifecycleGenerationCurrent(params.lifecycleGeneration!);
   // The hook gate must fire before prepareCliRunContext — that call allocates
   // backend resources released only by runPreparedCliAgent's try…finally.
@@ -536,7 +548,7 @@ async function runCliAgentInternal(params: RunCliAgentParams): Promise<EmbeddedA
   let result: EmbeddedAgentRunResult | undefined;
   let runError: unknown;
   try {
-    result = await runPreparedCliAgent(context);
+    result = await runPreparedCliAgent(context, diagnosticLifecycle);
   } catch (error) {
     runError = error;
   }
@@ -565,6 +577,7 @@ async function runCliAgentInternal(params: RunCliAgentParams): Promise<EmbeddedA
     if (runError || result?.didSendViaMessagingTool === true) {
       log.warn(`cli run cleanup failed after completion: ${formatErrorMessage(cleanupError)}`);
     } else {
+      diagnosticLifecycle?.setPhase("cleanup");
       runError =
         cleanupError instanceof Error ? cleanupError : new Error(formatErrorMessage(cleanupError));
     }
@@ -578,6 +591,7 @@ async function runCliAgentInternal(params: RunCliAgentParams): Promise<EmbeddedA
 /** Runs an already-prepared CLI agent context through hooks and execution. */
 export async function runPreparedCliAgent(
   context: PreparedCliRunContext,
+  diagnosticLifecycle?: ClaudeCliRunDiagnosticLifecycle,
 ): Promise<EmbeddedAgentRunResult> {
   const { executePreparedCliRun } = await import("./cli-runner/execute.runtime.js");
   const { params } = context;
@@ -908,7 +922,14 @@ export async function runPreparedCliAgent(
               timeoutMs,
             },
           };
-    const output = await executePreparedCliRun(attemptContext, cliSessionIdToUse);
+    diagnosticLifecycle?.setPhase("send");
+    const output = await executePreparedCliRun(
+      attemptContext,
+      cliSessionIdToUse,
+      diagnosticLifecycle ? { onPhase: diagnosticLifecycle.setPhase } : undefined,
+    );
+    // Test facades and non-instrumented executors may not signal the boundary.
+    diagnosticLifecycle?.setPhase("resolve");
     const sourceReplyMirror = resolveCliSourceReplyMirror(output);
     const assistantText = sourceReplyMirror.delivered
       ? (sourceReplyMirror.visibleText ?? "")
@@ -1409,6 +1430,7 @@ export async function runPreparedCliAgent(
           `CLI run also failed before backend cleanup: ${formatErrorMessage(runError)}`,
         );
       }
+      diagnosticLifecycle?.setPhase("cleanup");
       throw cleanupError;
     }
     cliBackendLog.warn(

--- a/src/agents/cli-runner/claude-live-session.background-tasks.test.ts
+++ b/src/agents/cli-runner/claude-live-session.background-tasks.test.ts
@@ -163,6 +163,7 @@ function startLiveTurn(params: {
   timeoutMs?: number;
   noOutputTimeoutMs?: number;
   useResume?: boolean;
+  onPhase?: (phase: "send" | "resolve") => void;
 }) {
   const context = buildPreparedCliRunContext({
     runId: params.runId,
@@ -177,6 +178,7 @@ function startLiveTurn(params: {
     noOutputTimeoutMs: params.noOutputTimeoutMs ?? 5_000,
     getProcessSupervisor: getProcessSupervisorForTest,
     onAssistantDelta: () => {},
+    onPhase: params.onPhase,
     cleanup: async () => {},
   });
 }
@@ -189,7 +191,11 @@ describe("claude live session provisional results", () => {
     "defers the interim success result until $taskType ($label) tasks drain",
     async ({ taskType }) => {
       const driver = installLiveStdoutDriver();
-      const resultPromise = startLiveTurn({ runId: `run-bg-interim-${taskType}` });
+      const phases: Array<"send" | "resolve"> = [];
+      const resultPromise = startLiveTurn({
+        runId: `run-bg-interim-${taskType}`,
+        onPhase: (phase) => phases.push(phase),
+      });
       await driver.stdout.waitReady();
 
       // Tool spawn + authoritative outstanding-task list + immediate tool_result.
@@ -267,6 +273,7 @@ describe("claude live session provisional results", () => {
       );
       await Promise.resolve();
       expect(settled).toBe(false);
+      expect(phases).toEqual(["resolve", "send"]);
       expect(driver.cancel).not.toHaveBeenCalled();
       await waitForDiagnosticEventsDrained();
       expect(
@@ -308,6 +315,7 @@ describe("claude live session provisional results", () => {
       );
 
       const result = await resultPromise;
+      expect(phases).toEqual(["resolve", "send", "resolve"]);
       expect(result.output.text).toContain("Working on it in the background.");
       expect(result.output.text).toContain("Subagent finished: subagent final output");
       expect(driver.cancel).not.toHaveBeenCalled();
@@ -713,7 +721,11 @@ describe("claude live session provisional results", () => {
 
   it("fails the turn on an error result even when background tasks are outstanding", async () => {
     const driver = installLiveStdoutDriver();
-    const resultPromise = startLiveTurn({ runId: "run-bg-error" });
+    const phases: Array<"send" | "resolve"> = [];
+    const resultPromise = startLiveTurn({
+      runId: "run-bg-error",
+      onPhase: (phase) => phases.push(phase),
+    });
     await driver.stdout.waitReady();
 
     driver.stdout.emit(
@@ -738,6 +750,7 @@ describe("claude live session provisional results", () => {
       name: "FailoverError",
       rawError: expect.stringMatching(/agent crashed/i),
     });
+    expect(phases).toEqual(["resolve"]);
   });
 
   it("does not no-output-abort while a background task is outstanding within the blocked-tool floor", async () => {

--- a/src/agents/cli-runner/claude-live-session.ts
+++ b/src/agents/cli-runner/claude-live-session.ts
@@ -82,6 +82,7 @@ type ClaudeLiveTurn = {
   toolEventCount: number;
   streamingParser: ReturnType<typeof createCliJsonlStreamingParser>;
   onCliOutput?: (chunk: string, stream: "stderr" | "stdout") => void;
+  onPhase?: (phase: "send" | "resolve") => void;
   execPermission: ClaudeLiveExecPermission;
   resolve: (output: CliOutput) => void;
   reject: (error: unknown) => void;
@@ -1110,6 +1111,7 @@ function handleClaudeLiveLine(session: ClaudeLiveSession, line: string): void {
   if (parsed.type !== "result") {
     return;
   }
+  turn.onPhase?.("resolve");
   const raw = turn.rawLines.join("\n");
   // Reuse the parser that classified pre-tool text as commentary. Reparsing the
   // transcript loses that boundary when Claude's terminal result is empty.
@@ -1140,6 +1142,8 @@ function handleClaudeLiveLine(session: ClaudeLiveSession, line: string): void {
   // outstanding subagent/workflow tasks: keep the turn open for the final
   // post-drain result. Other listed types (e.g. local_bash) do not hold it.
   if (session.outstandingBackgroundTaskIds.size > 0) {
+    // An interim result is not terminal; background work returns the run to send.
+    turn.onPhase?.("send");
     emitClaudeLiveProgress(turn, "cli_live:result_deferred_background_tasks");
     return;
   }
@@ -1379,6 +1383,7 @@ function createTurn(params: {
   onAssistantMessage?: (message: unknown) => void;
   onUsage?: (usage: CliUsage, terminal: boolean) => void;
   onCliOutput?: (chunk: string, stream: "stderr" | "stdout") => void;
+  onPhase?: (phase: "send" | "resolve") => void;
   session: ClaudeLiveSession;
   execPermission: ClaudeLiveExecPermission;
   resolve: (output: CliOutput) => void;
@@ -1428,6 +1433,7 @@ function createTurn(params: {
       onUsage: params.onUsage,
     }),
     onCliOutput: params.onCliOutput,
+    onPhase: params.onPhase,
     execPermission: params.execPermission,
     resolve: params.resolve,
     reject: params.reject,
@@ -1518,6 +1524,7 @@ export async function runClaudeLiveSessionTurn(params: {
   onUsage?: (usage: CliUsage, terminal: boolean) => void;
   onCliOutput?: (chunk: string, stream: "stderr" | "stdout") => void;
   onRequestPayload?: (payload: string) => void;
+  onPhase?: (phase: "send" | "resolve") => void;
   cleanup: () => Promise<void>;
 }): Promise<ClaudeLiveRunResult> {
   const key = buildClaudeLiveKey(params.context);
@@ -1745,6 +1752,7 @@ export async function runClaudeLiveSessionTurn(params: {
       onAssistantMessage: params.onAssistantMessage,
       onUsage: params.onUsage,
       onCliOutput: params.onCliOutput,
+      onPhase: params.onPhase,
       session: liveSession,
       execPermission,
       resolve,

--- a/src/agents/cli-runner/claude-live-session.ts
+++ b/src/agents/cli-runner/claude-live-session.ts
@@ -30,6 +30,7 @@ import {
   extractCliErrorMessage,
   parseCliOutput,
   type CliOutput,
+  type CliUsage,
   type CliStreamJsonOutputLimits,
   type CliStreamingDelta,
   type CliThinkingDelta,
@@ -80,6 +81,7 @@ type ClaudeLiveTurn = {
   completedToolCallIds: Set<string>;
   toolEventCount: number;
   streamingParser: ReturnType<typeof createCliJsonlStreamingParser>;
+  onCliOutput?: (chunk: string, stream: "stderr" | "stdout") => void;
   execPermission: ClaudeLiveExecPermission;
   resolve: (output: CliOutput) => void;
   reject: (error: unknown) => void;
@@ -1152,6 +1154,7 @@ function handleClaudeLiveLine(session: ClaudeLiveSession, line: string): void {
 }
 
 function handleClaudeStdout(session: ClaudeLiveSession, chunk: string) {
+  session.currentTurn?.onCliOutput?.(chunk, "stdout");
   resetNoOutputTimer(session);
   session.stdoutBuffer += chunk;
   const maxPendingLineChars =
@@ -1250,13 +1253,13 @@ function createClaudeUserInputMessage(content: string): string {
   })}\n`;
 }
 
-async function writeTurnInput(session: ClaudeLiveSession, prompt: string): Promise<void> {
+async function writeTurnInput(session: ClaudeLiveSession, payload: string): Promise<void> {
   const stdin = session.managedRun.stdin;
   if (!stdin) {
     throw new Error("Claude CLI live session stdin is unavailable");
   }
   await new Promise<void>((resolve, reject) => {
-    stdin.write(createClaudeUserInputMessage(prompt), (error) => {
+    stdin.write(payload, (error) => {
       if (error) {
         reject(error);
         return;
@@ -1305,6 +1308,7 @@ async function createClaudeLiveSession(params: {
       },
       onStderr: (chunk) => {
         if (session) {
+          session.currentTurn?.onCliOutput?.(chunk, "stderr");
           session.stderr += chunk;
           if (session.stderr.length > LIVE_SESSION_LIMITS.maxStderrChars) {
             closeLiveSession(
@@ -1372,6 +1376,9 @@ function createTurn(params: {
   ) => ClaudeLiveToolTerminalOutcome | undefined;
   onCommentaryText?: (text: string) => void;
   onSessionId?: (sessionId: string) => void;
+  onAssistantMessage?: (message: unknown) => void;
+  onUsage?: (usage: CliUsage, terminal: boolean) => void;
+  onCliOutput?: (chunk: string, stream: "stderr" | "stdout") => void;
   session: ClaudeLiveSession;
   execPermission: ClaudeLiveExecPermission;
   resolve: (output: CliOutput) => void;
@@ -1417,7 +1424,10 @@ function createTurn(params: {
       },
       onCommentaryText: params.onCommentaryText,
       onSessionId: params.onSessionId,
+      onAssistantMessage: params.onAssistantMessage,
+      onUsage: params.onUsage,
     }),
+    onCliOutput: params.onCliOutput,
     execPermission: params.execPermission,
     resolve: params.resolve,
     reject: params.reject,
@@ -1504,6 +1514,10 @@ export async function runClaudeLiveSessionTurn(params: {
   onCommentaryText?: (text: string) => void;
   onMcpCaptureReady?: (captureKey: string) => void;
   onSessionId?: (sessionId: string) => void;
+  onAssistantMessage?: (message: unknown) => void;
+  onUsage?: (usage: CliUsage, terminal: boolean) => void;
+  onCliOutput?: (chunk: string, stream: "stderr" | "stdout") => void;
+  onRequestPayload?: (payload: string) => void;
   cleanup: () => Promise<void>;
 }): Promise<ClaudeLiveRunResult> {
   const key = buildClaudeLiveKey(params.context);
@@ -1728,6 +1742,9 @@ export async function runClaudeLiveSessionTurn(params: {
       resolveToolResultTerminalOutcome: params.resolveToolResultTerminalOutcome,
       onCommentaryText: params.onCommentaryText,
       onSessionId: params.onSessionId,
+      onAssistantMessage: params.onAssistantMessage,
+      onUsage: params.onUsage,
+      onCliOutput: params.onCliOutput,
       session: liveSession,
       execPermission,
       resolve,
@@ -1756,7 +1773,9 @@ export async function runClaudeLiveSessionTurn(params: {
       abort();
     } else {
       try {
-        await Promise.race([writeTurnInput(liveSession, params.prompt), outputPromise]);
+        const requestPayload = createClaudeUserInputMessage(params.prompt);
+        params.onRequestPayload?.(requestPayload);
+        await Promise.race([writeTurnInput(liveSession, requestPayload), outputPromise]);
       } catch (error) {
         closeLiveSession(liveSession, "abort", error);
       }

--- a/src/agents/cli-runner/execute.ts
+++ b/src/agents/cli-runner/execute.ts
@@ -386,10 +386,15 @@ if (process.env.VITEST || process.env.NODE_ENV === "test") {
   };
 }
 
+export type ExecutePreparedCliRunOptions = {
+  onPhase?: (phase: "send" | "resolve" | "cleanup") => void;
+};
+
 /** Executes a prepared CLI run context and returns normalized CLI output. */
 export async function executePreparedCliRun(
   context: PreparedCliRunContext,
   cliSessionIdToUse?: string,
+  options?: ExecutePreparedCliRunOptions,
 ): Promise<CliOutput> {
   const params = context.params;
   if (params.abortSignal?.aborted) {
@@ -1593,7 +1598,9 @@ export async function executePreparedCliRun(
             onUsage: claudeModelCallDiagnostics?.observeUsage,
             onCliOutput: claudeModelCallDiagnostics?.observeCliOutput,
             onRequestPayload: claudeModelCallDiagnostics?.observeRequestPayload,
+            onPhase: options?.onPhase,
           });
+          options?.onPhase?.("resolve");
           const rawText = liveResult.output.text;
           runOutput = {
             ...liveResult.output,
@@ -1740,13 +1747,14 @@ export async function executePreparedCliRun(
               params.abortSignal?.removeEventListener("abort", abortManagedRun);
             }
           }
-          streamingParser?.finish();
           if (
             (params.abortSignal?.aborted || nodeRunAbortSignal?.aborted) &&
             result.reason === "manual-cancel"
           ) {
             throw createCliAbortError();
           }
+          options?.onPhase?.("resolve");
+          streamingParser?.finish();
           const streamingParserErrorText =
             outputMode === "jsonl" ? (streamingParser?.getErrorText() ?? null) : null;
           if (streamingParserErrorText) {
@@ -1844,6 +1852,7 @@ export async function executePreparedCliRun(
           }
 
           if (result.exitCode !== 0 || result.reason !== "exit") {
+            options?.onPhase?.("send");
             if (result.reason === "no-output-timeout" || result.noOutputTimedOut) {
               const timeoutReason = `CLI produced no output for ${Math.round(noOutputTimeoutMs / 1000)}s and was terminated.`;
               cliBackendLog.warn(
@@ -2157,6 +2166,7 @@ export async function executePreparedCliRun(
     }
   }
   if (outerCleanupError !== undefined) {
+    options?.onPhase?.("cleanup");
     claudeModelCallDiagnostics?.emitError(outerCleanupError);
     throw outerCleanupError;
   }

--- a/src/agents/cli-runner/execute.ts
+++ b/src/agents/cli-runner/execute.ts
@@ -386,7 +386,7 @@ if (process.env.VITEST || process.env.NODE_ENV === "test") {
   };
 }
 
-export type ExecutePreparedCliRunOptions = {
+type ExecutePreparedCliRunOptions = {
   onPhase?: (phase: "send" | "resolve" | "cleanup") => void;
 };
 

--- a/src/agents/cli-runner/execute.ts
+++ b/src/agents/cli-runner/execute.ts
@@ -19,7 +19,7 @@ import {
 } from "../../infra/agent-events.js";
 import { emitTrustedDiagnosticEvent } from "../../infra/diagnostic-events.js";
 import { isTruthyEnvValue } from "../../infra/env.js";
-import { formatErrorMessage } from "../../infra/errors.js";
+import { formatErrorMessage, toErrorObject } from "../../infra/errors.js";
 import {
   resolveEventSessionKeyForPolicy,
   resolveEventSessionRoutingPolicy,
@@ -121,6 +121,7 @@ import {
   formatCliBackendOutputDigest,
   LEGACY_CLAUDE_CLI_LOG_OUTPUT_ENV,
 } from "./log.js";
+import { createClaudeCliModelCallDiagnostics } from "./model-call-diagnostics.js";
 import { createCliOutputFailoverError } from "./output-error.js";
 import type { CliReusableSession, PreparedCliRunContext } from "./types.js";
 
@@ -542,6 +543,21 @@ export async function executePreparedCliRun(
 
   let completedOutput: CliOutput | undefined;
   let executionError: unknown;
+  let outerCleanupError: Error | undefined;
+  const useManagedClaudeLiveSession =
+    shouldUseClaudeLiveSession(context) && !params.onSuccessfulAuthBinding;
+  // Fresh-session retries invoke this function again. Keep one helper per
+  // observable CLI attempt so every started call retains its own terminal event.
+  const claudeModelCallDiagnostics = createClaudeCliModelCallDiagnostics({
+    context,
+    prompt,
+    systemPrompt: systemPromptArg ?? undefined,
+    transport: nodePlacement
+      ? "paired-node-cli"
+      : useManagedClaudeLiveSession
+        ? "stdio-live"
+        : "stdio",
+  });
   let forkResumeClaimed = false;
   let forkSuccessorObserved = false;
   let forkSuccessorPersistence: Promise<void> | undefined;
@@ -590,6 +606,7 @@ export async function executePreparedCliRun(
       if (params.lifecycleGeneration) {
         assertAgentRunLifecycleGenerationCurrent(params.lifecycleGeneration);
       }
+      claudeModelCallDiagnostics?.emitStarted();
       if (params.forkCliSessionOnResume && useResume) {
         if (!params.persistCliSessionForkSuccessor) {
           throw new Error("CLI session fork successor persistence is unavailable");
@@ -855,10 +872,6 @@ export async function executePreparedCliRun(
         };
       };
       let finalizeParsedTools = () => {};
-      // Opaque owner proof must describe a child spawned for this turn. A
-      // warm stdio session could have been created from an older executable.
-      const useManagedClaudeLiveSession =
-        shouldUseClaudeLiveSession(context) && !params.onSuccessfulAuthBinding;
       try {
         cliBackendLog.info(
           buildCliExecLogLine({
@@ -1576,6 +1589,10 @@ export async function executePreparedCliRun(
             onSessionId: (sessionId) => {
               observeForkSuccessor(sessionId);
             },
+            onAssistantMessage: claudeModelCallDiagnostics?.observeAssistantMessage,
+            onUsage: claudeModelCallDiagnostics?.observeUsage,
+            onCliOutput: claudeModelCallDiagnostics?.observeCliOutput,
+            onRequestPayload: claudeModelCallDiagnostics?.observeRequestPayload,
           });
           const rawText = liveResult.output.text;
           runOutput = {
@@ -1605,6 +1622,8 @@ export async function executePreparedCliRun(
                 onSessionId: (sessionId) => {
                   observeForkSuccessor(sessionId);
                 },
+                onAssistantMessage: claudeModelCallDiagnostics?.observeAssistantMessage,
+                onUsage: claudeModelCallDiagnostics?.observeUsage,
               })
             : null;
           let stdoutTail = "";
@@ -1618,6 +1637,7 @@ export async function executePreparedCliRun(
           const stderrHash = crypto.createHash("sha256");
           let stderrParseExceeded = false;
           const consumeStdout = (chunk: string) => {
+            claudeModelCallDiagnostics?.observeCliOutput(chunk, "stdout");
             stdoutBytes += Buffer.byteLength(chunk);
             stdoutHash.update(chunk);
             stdoutTail = appendCliOutputTail(stdoutTail, chunk);
@@ -1629,6 +1649,7 @@ export async function executePreparedCliRun(
             streamingParser?.push(chunk);
           };
           const consumeStderr = (chunk: string) => {
+            claudeModelCallDiagnostics?.observeCliOutput(chunk, "stderr");
             stderrBytes += Buffer.byteLength(chunk);
             stderrHash.update(chunk);
             stderrTail = appendCliOutputTail(stderrTail, chunk);
@@ -1649,6 +1670,7 @@ export async function executePreparedCliRun(
           let nodeRunAbortSignal: AbortSignal | undefined;
           let nodeRunTruncated = false;
           let result: RunExit;
+          claudeModelCallDiagnostics?.observeRequestPayload(stdin ?? argsPrompt ?? "");
           if (nodePlacement) {
             const nodeRun = await executeNodeClaudeRun({
               context,
@@ -2103,9 +2125,9 @@ export async function executePreparedCliRun(
       forkResumeClaimed = false;
       throw new Error("forked CLI session did not report a successor session id");
     }
-    return completedOutput;
   } catch (error) {
     executionError = error;
+    claudeModelCallDiagnostics?.emitError(error);
     let failure = error;
     try {
       await finishForkSuccessorPersistence();
@@ -2120,15 +2142,32 @@ export async function executePreparedCliRun(
     }
     throw failure;
   } finally {
-    if (!fallbackClaudeSkillsPluginCleanupOwned) {
-      await cleanupOuterResource(fallbackClaudeSkillsPlugin?.cleanup);
-    }
-    if (systemPromptFile) {
-      await cleanupOuterResource(systemPromptFile.cleanup);
-    }
-    if (cleanupImages) {
-      await cleanupOuterResource(cleanupImages);
+    try {
+      if (!fallbackClaudeSkillsPluginCleanupOwned) {
+        await cleanupOuterResource(fallbackClaudeSkillsPlugin?.cleanup);
+      }
+      if (systemPromptFile) {
+        await cleanupOuterResource(systemPromptFile.cleanup);
+      }
+      if (cleanupImages) {
+        await cleanupOuterResource(cleanupImages);
+      }
+    } catch (error) {
+      outerCleanupError = toErrorObject(error, "CLI outer resource cleanup failed");
     }
   }
+  if (outerCleanupError !== undefined) {
+    claudeModelCallDiagnostics?.emitError(outerCleanupError);
+    throw outerCleanupError;
+  }
+  if (!completedOutput) {
+    const error = new Error("CLI run completed without output");
+    claudeModelCallDiagnostics?.emitError(error);
+    throw error;
+  }
+  // Success stays provisional until fallible persistence and cleanup finish;
+  // otherwise a rejected turn would be exported as completed.
+  claudeModelCallDiagnostics?.emitCompleted(completedOutput);
+  return completedOutput;
 }
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/agents/cli-runner/model-call-diagnostics.ts
+++ b/src/agents/cli-runner/model-call-diagnostics.ts
@@ -150,6 +150,7 @@ export function createClaudeCliModelCallDiagnostics(params: {
     model: params.context.normalizedModel,
     api: "claude-code",
     transport: params.transport,
+    observationUnit: "turn" as const,
     ...(contextWindow
       ? {
           contextTokenBudget: contextWindow.tokens,

--- a/src/agents/cli-runner/model-call-diagnostics.ts
+++ b/src/agents/cli-runner/model-call-diagnostics.ts
@@ -1,0 +1,308 @@
+/** Trusted turn-level model-call diagnostics for the Claude Code CLI runtime. */
+import crypto from "node:crypto";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import {
+  diagnosticErrorCategory,
+  diagnosticErrorFailureKind,
+  diagnosticErrorMessage,
+} from "../../infra/diagnostic-error-metadata.js";
+import {
+  emitTrustedDiagnosticEventWithPrivateData,
+  type DiagnosticEventPrivateData,
+  type DiagnosticModelCallContent,
+} from "../../infra/diagnostic-events.js";
+import {
+  cloneDiagnosticContentValue,
+  resolveDiagnosticModelContentCapturePolicy,
+} from "../../infra/diagnostic-llm-content.js";
+import {
+  createDiagnosticTraceContextFromActiveScope,
+  freezeDiagnosticTraceContext,
+} from "../../infra/diagnostic-trace-context.js";
+import type { CliOutput, CliUsage } from "../cli-output.js";
+import { isFailoverError } from "../failover-error.js";
+import type { PreparedCliRunContext } from "./types.js";
+
+type TrustedDiagnosticEventInput = Parameters<typeof emitTrustedDiagnosticEventWithPrivateData>[0];
+type ModelCallFailureKind = Extract<
+  TrustedDiagnosticEventInput,
+  { type: "model.call.error" }
+>["failureKind"];
+
+function assistantContentBlock(block: unknown): Record<string, unknown> | undefined {
+  if (!isRecord(block)) {
+    return undefined;
+  }
+  if (block.type === "text" && typeof block.text === "string") {
+    return { type: "text", text: block.text };
+  }
+  if (block.type === "thinking" && typeof block.thinking === "string") {
+    return { type: "thinking", thinking: block.thinking };
+  }
+  if (
+    (block.type === "tool_use" ||
+      block.type === "server_tool_use" ||
+      block.type === "mcp_tool_use") &&
+    typeof block.name === "string"
+  ) {
+    return {
+      type: "tool_call",
+      name: block.name,
+      ...(typeof block.id === "string" ? { id: block.id } : {}),
+    };
+  }
+  return undefined;
+}
+
+// Claude's assistant envelopes can contain native tool arguments and opaque
+// thinking signatures. Keep only the visible response blocks OpenClaw can
+// represent accurately; external harness tool spans stay metadata-only.
+function normalizeClaudeAssistantMessage(message: unknown): Record<string, unknown> | undefined {
+  if (!isRecord(message)) {
+    return undefined;
+  }
+  const content =
+    typeof message.content === "string"
+      ? [{ type: "text", text: message.content }]
+      : Array.isArray(message.content)
+        ? message.content
+            .map(assistantContentBlock)
+            .filter((block): block is Record<string, unknown> => Boolean(block))
+        : [];
+  if (content.length === 0) {
+    return undefined;
+  }
+  return {
+    role: "assistant",
+    content,
+    ...(typeof message.stop_reason === "string" ? { stopReason: message.stop_reason } : {}),
+  };
+}
+
+function hasTextContent(messages: readonly Record<string, unknown>[]): boolean {
+  return messages.some(
+    (message) =>
+      Array.isArray(message.content) &&
+      message.content.some(
+        (block) => isRecord(block) && block.type === "text" && typeof block.text === "string",
+      ),
+  );
+}
+
+function privateData(params: {
+  modelContent?: DiagnosticModelCallContent;
+  errorMessage?: string;
+}): DiagnosticEventPrivateData | undefined {
+  if (!params.modelContent && !params.errorMessage) {
+    return undefined;
+  }
+  return {
+    ...(params.errorMessage ? { errorMessage: params.errorMessage } : {}),
+    ...(params.modelContent ? { modelContent: params.modelContent } : {}),
+  };
+}
+
+function failureKindForClaudeCli(
+  error: unknown,
+  abortSignal: AbortSignal | undefined,
+): ModelCallFailureKind | undefined {
+  if (isFailoverError(error) && error.reason === "timeout") {
+    return "timeout";
+  }
+  const inferred = diagnosticErrorFailureKind(error);
+  if (inferred) {
+    return inferred;
+  }
+  return abortSignal?.aborted ? "aborted" : undefined;
+}
+
+function usageField(usage: CliUsage | undefined): { usage?: CliUsage } {
+  return usage ? { usage } : {};
+}
+
+/** Creates one exactly-once Claude CLI model-call lifecycle for a prepared turn. */
+export function createClaudeCliModelCallDiagnostics(params: {
+  context: PreparedCliRunContext;
+  prompt: string;
+  systemPrompt?: string;
+  transport: "paired-node-cli" | "stdio" | "stdio-live";
+  now?: () => number;
+}) {
+  if (params.context.backendResolved.id !== "claude-cli") {
+    return undefined;
+  }
+
+  const now = params.now ?? (() => Date.now());
+  const capture = resolveDiagnosticModelContentCapturePolicy(
+    params.context.params.config ?? params.context.contextEngineConfig,
+  );
+  const contextWindow = params.context.contextWindowInfo;
+  const trace = freezeDiagnosticTraceContext(createDiagnosticTraceContextFromActiveScope());
+  const baseFields = {
+    runId: params.context.params.runId,
+    callId: `${params.context.params.runId}:claude-cli:${crypto.randomUUID()}`,
+    ...(params.context.params.sessionKey ? { sessionKey: params.context.params.sessionKey } : {}),
+    sessionId: params.context.params.sessionId,
+    provider:
+      params.context.backendResolved.modelProvider ??
+      params.context.params.modelProvider ??
+      "anthropic",
+    model: params.context.normalizedModel,
+    api: "claude-code",
+    transport: params.transport,
+    ...(contextWindow
+      ? {
+          contextTokenBudget: contextWindow.tokens,
+          contextWindowSource: contextWindow.source,
+          ...(contextWindow.referenceTokens
+            ? { contextWindowReferenceTokens: contextWindow.referenceTokens }
+            : {}),
+        }
+      : {}),
+    promptStats: {
+      inputMessagesCount: 1,
+      inputMessagesChars: params.prompt.length,
+      ...(params.systemPrompt ? { systemPromptChars: params.systemPrompt.length } : {}),
+      totalChars: params.prompt.length + (params.systemPrompt?.length ?? 0),
+    },
+    trace,
+  };
+  const capturedAssistantMessages: Record<string, unknown>[] = [];
+  let started = false;
+  let terminalEmitted = false;
+  let startedAt = 0;
+  let requestPayloadBytes: number | undefined;
+  let responseStreamBytes = 0;
+  let firstCliOutputAt: number | undefined;
+  let observedUsage: CliUsage | undefined;
+  let observedTerminalUsage: CliUsage | undefined;
+
+  const baseModelContent = (): DiagnosticModelCallContent | undefined => {
+    if (!capture.anyModelContent) {
+      return undefined;
+    }
+    const content: DiagnosticModelCallContent = {
+      ...(capture.inputMessages
+        ? {
+            inputMessages: cloneDiagnosticContentValue([
+              { role: "user", content: [{ type: "text", text: params.prompt }] },
+            ]),
+          }
+        : {}),
+      ...(capture.systemPrompt && params.systemPrompt ? { systemPrompt: params.systemPrompt } : {}),
+    };
+    return Object.keys(content).length > 0 ? content : undefined;
+  };
+  const outputMessages = (output?: CliOutput): unknown => {
+    const messages = capturedAssistantMessages.slice();
+    const responseText = output?.rawText ?? output?.text;
+    if (!hasTextContent(messages) && responseText) {
+      messages.push({ role: "assistant", content: [{ type: "text", text: responseText }] });
+    }
+    return cloneDiagnosticContentValue(messages);
+  };
+  const completedModelContent = (output?: CliOutput): DiagnosticModelCallContent | undefined => {
+    const base = baseModelContent();
+    if (!capture.outputMessages) {
+      return base;
+    }
+    return {
+      ...base,
+      outputMessages: outputMessages(output),
+    };
+  };
+  const sizeTimingFields = () => ({
+    ...(requestPayloadBytes !== undefined ? { requestPayloadBytes } : {}),
+    ...(responseStreamBytes > 0 ? { responseStreamBytes } : {}),
+    ...(firstCliOutputAt !== undefined
+      ? { timeToFirstByteMs: Math.max(0, firstCliOutputAt - startedAt) }
+      : {}),
+  });
+
+  return {
+    emitStarted: (): void => {
+      if (started) {
+        return;
+      }
+      started = true;
+      startedAt = now();
+      emitTrustedDiagnosticEventWithPrivateData(
+        {
+          type: "model.call.started",
+          ...baseFields,
+        },
+        privateData({ modelContent: baseModelContent() }),
+      );
+    },
+    observeRequestPayload: (payload: string): void => {
+      requestPayloadBytes = Buffer.byteLength(payload, "utf8");
+    },
+    observeCliOutput: (chunk: string, stream: "stderr" | "stdout"): void => {
+      if (!chunk) {
+        return;
+      }
+      firstCliOutputAt ??= now();
+      if (stream === "stdout") {
+        responseStreamBytes += Buffer.byteLength(chunk, "utf8");
+      }
+    },
+    observeAssistantMessage: (message: unknown): void => {
+      if (!capture.outputMessages) {
+        return;
+      }
+      const normalized = normalizeClaudeAssistantMessage(message);
+      if (normalized) {
+        capturedAssistantMessages.push(normalized);
+      }
+    },
+    observeUsage: (usage: CliUsage, terminal: boolean): void => {
+      observedUsage = usage;
+      if (terminal) {
+        observedTerminalUsage = usage;
+      }
+    },
+    emitCompleted: (output: CliOutput): void => {
+      if (!started || terminalEmitted) {
+        return;
+      }
+      terminalEmitted = true;
+      emitTrustedDiagnosticEventWithPrivateData(
+        {
+          type: "model.call.completed",
+          ...baseFields,
+          durationMs: Math.max(0, now() - startedAt),
+          ...sizeTimingFields(),
+          ...usageField(
+            output.diagnosticUsage ?? observedTerminalUsage ?? output.usage ?? observedUsage,
+          ),
+        },
+        privateData({ modelContent: completedModelContent(output) }),
+      );
+    },
+    emitError: (error: unknown): void => {
+      if (!started || terminalEmitted) {
+        return;
+      }
+      terminalEmitted = true;
+      const failureKind = failureKindForClaudeCli(error, params.context.params.abortSignal);
+      emitTrustedDiagnosticEventWithPrivateData(
+        {
+          type: "model.call.error",
+          ...baseFields,
+          durationMs: Math.max(0, now() - startedAt),
+          errorCategory:
+            (isFailoverError(error) ? error.reason : undefined) ??
+            failureKind ??
+            diagnosticErrorCategory(error),
+          ...(failureKind ? { failureKind } : {}),
+          ...sizeTimingFields(),
+          ...usageField(observedTerminalUsage ?? observedUsage),
+        },
+        privateData({
+          modelContent: completedModelContent(),
+          errorMessage: diagnosticErrorMessage(error),
+        }),
+      );
+    },
+  };
+}

--- a/src/agents/cli-runner/run-diagnostics.test.ts
+++ b/src/agents/cli-runner/run-diagnostics.test.ts
@@ -78,6 +78,7 @@ describe("Claude CLI run diagnostics", () => {
                 model: "claude-opus-4-7",
                 api: "claude-code",
                 transport: "stdio-live",
+                observationUnit: "turn",
                 trace: modelTrace,
               },
               undefined,
@@ -92,6 +93,7 @@ describe("Claude CLI run diagnostics", () => {
                 model: "claude-opus-4-7",
                 api: "claude-code",
                 transport: "stdio-live",
+                observationUnit: "turn",
                 durationMs: 5,
                 trace: modelTrace,
               },
@@ -133,6 +135,7 @@ describe("Claude CLI run diagnostics", () => {
     expect(harnessStarted.trace?.parentSpanId).toBe(parentTrace.spanId);
     expect(runStarted.trace?.parentSpanId).toBe(harnessStarted.trace?.spanId);
     expect(modelStarted.trace?.parentSpanId).toBe(runStarted.trace?.spanId);
+    expect(modelStarted.observationUnit).toBe("turn");
     expect(callbackTrace).toEqual(runStarted.trace);
     expect(result?.diagnosticTrace).toEqual(harnessStarted.trace);
     expect(

--- a/src/agents/cli-runner/run-diagnostics.test.ts
+++ b/src/agents/cli-runner/run-diagnostics.test.ts
@@ -1,0 +1,257 @@
+// Verifies Claude CLI synthetic harness/run hierarchy and terminal events.
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  emitTrustedDiagnosticEventWithPrivateData,
+  onTrustedInternalDiagnosticEvent,
+  resetDiagnosticEventsForTest,
+  type DiagnosticEventPayload,
+  type DiagnosticEventPrivateData,
+} from "../../infra/diagnostic-events.js";
+import {
+  createDiagnosticTraceContextFromActiveScope,
+  freezeDiagnosticTraceContext,
+  getActiveDiagnosticTraceContext,
+  runWithDiagnosticTraceContext,
+  type DiagnosticTraceContext,
+} from "../../infra/diagnostic-trace-context.js";
+import { runClaudeCliAgentTurnWithDiagnostics } from "./run-diagnostics.js";
+
+const parentTrace: DiagnosticTraceContext = {
+  traceId: "11111111111111111111111111111111",
+  spanId: "2222222222222222",
+  traceFlags: "01",
+};
+
+function captureLifecycle(runId: string) {
+  const events: Array<{
+    event: DiagnosticEventPayload;
+    privateData: DiagnosticEventPrivateData;
+  }> = [];
+  const unsubscribe = onTrustedInternalDiagnosticEvent((event, _metadata, privateData) => {
+    if ("runId" in event && event.runId === runId) {
+      events.push({ event, privateData });
+    }
+  });
+  return { events, unsubscribe };
+}
+
+async function flushDiagnosticEvents(): Promise<void> {
+  await new Promise<void>((resolve) => {
+    setImmediate(resolve);
+  });
+}
+
+describe("Claude CLI run diagnostics", () => {
+  afterEach(() => {
+    resetDiagnosticEventsForTest();
+  });
+
+  it("nests model calls beneath synthetic run and harness spans", async () => {
+    const runId = "run-claude-hierarchy";
+    const diagnostics = captureLifecycle(runId);
+    let callbackTrace: DiagnosticTraceContext | undefined;
+    let result: { diagnosticTrace?: DiagnosticTraceContext } | undefined;
+    try {
+      result = await runWithDiagnosticTraceContext(parentTrace, () =>
+        runClaudeCliAgentTurnWithDiagnostics(
+          {
+            runId,
+            sessionId: "session-1",
+            sessionKey: "agent:test-claude-agent:main",
+            modelProvider: "anthropic",
+            model: "claude-opus-4-7",
+            trigger: "user",
+            messageChannel: "webchat",
+          },
+          async () => {
+            callbackTrace = getActiveDiagnosticTraceContext();
+            const modelTrace = freezeDiagnosticTraceContext(
+              createDiagnosticTraceContextFromActiveScope(),
+            );
+            emitTrustedDiagnosticEventWithPrivateData(
+              {
+                type: "model.call.started",
+                runId,
+                callId: "call-1",
+                sessionId: "session-1",
+                provider: "anthropic",
+                model: "claude-opus-4-7",
+                api: "claude-code",
+                transport: "stdio-live",
+                trace: modelTrace,
+              },
+              undefined,
+            );
+            emitTrustedDiagnosticEventWithPrivateData(
+              {
+                type: "model.call.completed",
+                runId,
+                callId: "call-1",
+                sessionId: "session-1",
+                provider: "anthropic",
+                model: "claude-opus-4-7",
+                api: "claude-code",
+                transport: "stdio-live",
+                durationMs: 5,
+                trace: modelTrace,
+              },
+              undefined,
+            );
+            return {
+              payloads: [{ text: "ok" }],
+              meta: { durationMs: 5, finalAssistantVisibleText: "ok" },
+            };
+          },
+        ),
+      );
+      await flushDiagnosticEvents();
+    } finally {
+      diagnostics.unsubscribe();
+    }
+
+    expect(diagnostics.events).toHaveLength(6);
+    expect(diagnostics.events.map(({ event }) => event.type)).toEqual(
+      expect.arrayContaining([
+        "harness.run.started",
+        "run.started",
+        "model.call.started",
+        "model.call.completed",
+        "run.completed",
+        "harness.run.completed",
+      ]),
+    );
+    const harnessStarted = diagnostics.events.find(
+      ({ event }) => event.type === "harness.run.started",
+    )?.event as Extract<DiagnosticEventPayload, { type: "harness.run.started" }>;
+    const runStarted = diagnostics.events.find(({ event }) => event.type === "run.started")
+      ?.event as Extract<DiagnosticEventPayload, { type: "run.started" }>;
+    const modelStarted = diagnostics.events.find(({ event }) => event.type === "model.call.started")
+      ?.event as Extract<DiagnosticEventPayload, { type: "model.call.started" }>;
+    expect(harnessStarted.harnessId).toBe("claude-cli");
+    expect(harnessStarted.provider).toBe("anthropic");
+    expect(harnessStarted.trace?.traceId).toBe(parentTrace.traceId);
+    expect(harnessStarted.trace?.parentSpanId).toBe(parentTrace.spanId);
+    expect(runStarted.trace?.parentSpanId).toBe(harnessStarted.trace?.spanId);
+    expect(modelStarted.trace?.parentSpanId).toBe(runStarted.trace?.spanId);
+    expect(callbackTrace).toEqual(runStarted.trace);
+    expect(result?.diagnosticTrace).toEqual(harnessStarted.trace);
+    expect(
+      diagnostics.events.find(({ event }) => event.type === "run.completed")?.event,
+    ).toMatchObject({
+      type: "run.completed",
+      outcome: "completed",
+    });
+    expect(
+      diagnostics.events.find(({ event }) => event.type === "harness.run.completed")?.event,
+    ).toMatchObject({
+      type: "harness.run.completed",
+      outcome: "completed",
+    });
+  });
+
+  it("emits one terminal run and harness event when the Claude turn fails", async () => {
+    const runId = "run-claude-hierarchy-error";
+    const diagnostics = captureLifecycle(runId);
+    try {
+      await expect(
+        runClaudeCliAgentTurnWithDiagnostics(
+          {
+            runId,
+            sessionId: "session-2",
+            modelProvider: "anthropic",
+            model: "claude-opus-4-7",
+          },
+          async (lifecycle) => {
+            lifecycle.setPhase("cleanup");
+            throw new Error("managed session cleanup failed");
+          },
+        ),
+      ).rejects.toThrow("managed session cleanup failed");
+      await flushDiagnosticEvents();
+    } finally {
+      diagnostics.unsubscribe();
+    }
+
+    expect(diagnostics.events).toHaveLength(4);
+    expect(diagnostics.events.map(({ event }) => event.type)).toEqual(
+      expect.arrayContaining([
+        "harness.run.started",
+        "run.started",
+        "run.completed",
+        "harness.run.error",
+      ]),
+    );
+    expect(
+      diagnostics.events.find(({ event }) => event.type === "run.completed")?.event,
+    ).toMatchObject({
+      type: "run.completed",
+      outcome: "error",
+    });
+    expect(
+      diagnostics.events.find(({ event }) => event.type === "harness.run.error")?.event,
+    ).toMatchObject({
+      type: "harness.run.error",
+      phase: "cleanup",
+    });
+    expect(
+      diagnostics.events
+        .slice(2)
+        .every(({ privateData }) => privateData.errorMessage === "managed session cleanup failed"),
+    ).toBe(true);
+  });
+
+  it.each([
+    {
+      label: "abort",
+      error: Object.assign(new Error("operation was aborted"), { code: "ABORT_ERR" }),
+      harnessOutcome: "aborted" as const,
+    },
+    {
+      label: "timeout",
+      error: new Error("CLI exceeded timeout (30s) and was terminated"),
+      harnessOutcome: "timed_out" as const,
+    },
+  ])("completes the harness once for a thrown $label", async ({ error, harnessOutcome }) => {
+    const runId = `run-claude-hierarchy-${harnessOutcome}`;
+    const diagnostics = captureLifecycle(runId);
+    try {
+      await expect(
+        runClaudeCliAgentTurnWithDiagnostics(
+          {
+            runId,
+            sessionId: "session-termination",
+            modelProvider: "anthropic",
+            model: "claude-opus-4-7",
+          },
+          async (lifecycle) => {
+            lifecycle.setPhase("send");
+            throw error;
+          },
+        ),
+      ).rejects.toThrow(error.message);
+      await flushDiagnosticEvents();
+    } finally {
+      diagnostics.unsubscribe();
+    }
+
+    expect(diagnostics.events).toHaveLength(4);
+    expect(
+      diagnostics.events.find(({ event }) => event.type === "run.completed")?.event,
+    ).toMatchObject({
+      type: "run.completed",
+      outcome: "aborted",
+    });
+    expect(
+      diagnostics.events.filter(
+        ({ event }) => event.type === "harness.run.completed" || event.type === "harness.run.error",
+      ),
+    ).toHaveLength(1);
+    expect(
+      diagnostics.events.find(({ event }) => event.type === "harness.run.completed")?.event,
+    ).toMatchObject({
+      type: "harness.run.completed",
+      outcome: harnessOutcome,
+    });
+    expect(diagnostics.events.some(({ event }) => event.type === "harness.run.error")).toBe(false);
+  });
+});

--- a/src/agents/cli-runner/run-diagnostics.ts
+++ b/src/agents/cli-runner/run-diagnostics.ts
@@ -1,0 +1,198 @@
+/** Trusted run hierarchy for Claude Code CLI-backed agent turns. */
+import {
+  diagnosticErrorCategory,
+  diagnosticErrorFailureKind,
+  diagnosticErrorMessage,
+} from "../../infra/diagnostic-error-metadata.js";
+import {
+  emitTrustedDiagnosticEvent,
+  emitTrustedDiagnosticEventWithPrivateData,
+  type DiagnosticHarnessRunErrorEvent,
+} from "../../infra/diagnostic-events.js";
+import {
+  createChildDiagnosticTraceContext,
+  createDiagnosticTraceContextFromActiveScope,
+  freezeDiagnosticTraceContext,
+  runWithDiagnosticTraceContext,
+  type DiagnosticTraceContext,
+} from "../../infra/diagnostic-trace-context.js";
+import type { EmbeddedAgentRunResult } from "../embedded-agent-runner.js";
+import { isSignalTimeoutReason, isTimeoutError } from "../failover-error.js";
+import type { RunCliAgentParams } from "./types.js";
+
+type ClaudeCliRunPhase = DiagnosticHarnessRunErrorEvent["phase"];
+
+export type ClaudeCliRunDiagnosticLifecycle = {
+  setPhase: (phase: ClaudeCliRunPhase) => void;
+};
+
+type ClaudeCliRunDiagnosticParams = Pick<
+  RunCliAgentParams,
+  | "abortSignal"
+  | "messageChannel"
+  | "messageProvider"
+  | "model"
+  | "modelProvider"
+  | "runId"
+  | "sessionId"
+  | "sessionKey"
+  | "trigger"
+>;
+
+function diagnosticBase(params: ClaudeCliRunDiagnosticParams, trace: DiagnosticTraceContext) {
+  const channel = params.messageChannel ?? params.messageProvider;
+  return {
+    runId: params.runId,
+    sessionId: params.sessionId,
+    ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
+    provider: params.modelProvider ?? "anthropic",
+    ...(params.model ? { model: params.model } : {}),
+    ...(params.trigger ? { trigger: params.trigger } : {}),
+    ...(channel ? { channel } : {}),
+    trace,
+  };
+}
+
+function resultRunOutcome(
+  result: EmbeddedAgentRunResult,
+): "completed" | "aborted" | "blocked" | "error" {
+  if (result.meta.livenessState === "blocked") {
+    return "blocked";
+  }
+  if (result.meta.aborted === true) {
+    return "aborted";
+  }
+  if (result.meta.error) {
+    return "error";
+  }
+  return "completed";
+}
+
+function errorHarnessOutcome(
+  error: unknown,
+  abortSignal: AbortSignal | undefined,
+): "aborted" | "timed_out" | "error" {
+  const failureKind = diagnosticErrorFailureKind(error);
+  if (failureKind === "timeout") {
+    return "timed_out";
+  }
+  if (failureKind === "aborted") {
+    return abortSignal?.aborted && isSignalTimeoutReason(abortSignal.reason)
+      ? "timed_out"
+      : "aborted";
+  }
+  if (abortSignal?.aborted === true) {
+    return isSignalTimeoutReason(abortSignal.reason) ? "timed_out" : "aborted";
+  }
+  if (isTimeoutError(error)) {
+    return "timed_out";
+  }
+  return "error";
+}
+
+/**
+ * Wraps one OpenClaw Claude CLI turn in synthetic harness/run boundaries.
+ * The child run scope makes every real Claude CLI model call nest beneath it.
+ */
+export async function runClaudeCliAgentTurnWithDiagnostics(
+  params: ClaudeCliRunDiagnosticParams,
+  run: (lifecycle: ClaudeCliRunDiagnosticLifecycle) => Promise<EmbeddedAgentRunResult>,
+): Promise<EmbeddedAgentRunResult> {
+  const harnessTrace = freezeDiagnosticTraceContext(createDiagnosticTraceContextFromActiveScope());
+  const runTrace = freezeDiagnosticTraceContext(createChildDiagnosticTraceContext(harnessTrace));
+  const harnessBase = {
+    ...diagnosticBase(params, harnessTrace),
+    harnessId: "claude-cli",
+  };
+  const runBase = diagnosticBase(params, runTrace);
+  const startedAt = Date.now();
+  let phase: ClaudeCliRunPhase = "prepare";
+
+  emitTrustedDiagnosticEvent({
+    type: "harness.run.started",
+    ...harnessBase,
+  });
+  emitTrustedDiagnosticEvent({
+    type: "run.started",
+    ...runBase,
+  });
+
+  try {
+    const result = await runWithDiagnosticTraceContext(runTrace, () =>
+      run({
+        setPhase: (nextPhase) => {
+          phase = nextPhase;
+        },
+      }),
+    );
+    const runOutcome = resultRunOutcome(result);
+    const resultErrorMessage = result.meta.error?.message;
+    const runErrorMessage = runOutcome === "error" ? resultErrorMessage : undefined;
+    emitTrustedDiagnosticEventWithPrivateData(
+      {
+        type: "run.completed",
+        ...runBase,
+        durationMs: Date.now() - startedAt,
+        outcome: runOutcome,
+        ...(runOutcome === "blocked" ? { blockedBy: "before_agent_run" } : {}),
+        ...(runOutcome === "error" && result.meta.error
+          ? { errorCategory: result.meta.error.kind }
+          : {}),
+      },
+      runErrorMessage ? { errorMessage: runErrorMessage } : undefined,
+    );
+    emitTrustedDiagnosticEventWithPrivateData(
+      {
+        type: "harness.run.completed",
+        ...harnessBase,
+        durationMs: Date.now() - startedAt,
+        outcome:
+          result.meta.timeoutPhase !== undefined
+            ? "timed_out"
+            : runOutcome === "aborted"
+              ? "aborted"
+              : runOutcome === "completed"
+                ? "completed"
+                : "error",
+        ...(typeof result.meta.yielded === "boolean" ? { yieldDetected: result.meta.yielded } : {}),
+      },
+      resultErrorMessage && (runOutcome === "error" || runOutcome === "blocked")
+        ? { errorMessage: resultErrorMessage }
+        : undefined,
+    );
+    return result.diagnosticTrace ? result : { ...result, diagnosticTrace: harnessTrace };
+  } catch (error) {
+    const errorMessage = diagnosticErrorMessage(error);
+    const harnessOutcome = errorHarnessOutcome(error, params.abortSignal);
+    emitTrustedDiagnosticEventWithPrivateData(
+      {
+        type: "run.completed",
+        ...runBase,
+        durationMs: Date.now() - startedAt,
+        outcome: harnessOutcome === "error" ? "error" : "aborted",
+        ...(harnessOutcome === "error" ? { errorCategory: diagnosticErrorCategory(error) } : {}),
+      },
+      errorMessage ? { errorMessage } : undefined,
+    );
+    if (harnessOutcome === "error") {
+      emitTrustedDiagnosticEventWithPrivateData(
+        {
+          type: "harness.run.error",
+          ...harnessBase,
+          durationMs: Date.now() - startedAt,
+          phase,
+          errorCategory: diagnosticErrorCategory(error),
+        },
+        errorMessage ? { errorMessage } : undefined,
+      );
+    } else {
+      emitTrustedDiagnosticEvent({
+        type: "harness.run.completed",
+        ...harnessBase,
+        durationMs: Date.now() - startedAt,
+        outcome: harnessOutcome,
+      });
+    }
+    throw error;
+  }
+}

--- a/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.test.ts
@@ -215,6 +215,7 @@ describe("wrapStreamFnWithDiagnosticModelCallEvents", () => {
     expect(startedEvent.model).toBe("gpt-5.4");
     expect(startedEvent.api).toBe("openai-responses");
     expect(startedEvent.transport).toBe("http");
+    expect(startedEvent.observationUnit).toBe("request");
     expect(events[0]?.trace?.parentSpanId).toBe("00f067aa0ba902b7");
     const completedEvent = getEvent(events, 1);
     expect(completedEvent.type).toBe("model.call.completed");

--- a/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.ts
@@ -392,6 +392,7 @@ function baseModelCallEvent(
     model: ctx.model,
     ...(ctx.api && { api: ctx.api }),
     ...(ctx.transport && { transport: ctx.transport }),
+    observationUnit: "request",
     ...(ctx.contextTokenBudget ? { contextTokenBudget: ctx.contextTokenBudget } : {}),
     ...(ctx.contextWindowSource ? { contextWindowSource: ctx.contextWindowSource } : {}),
     ...(ctx.contextWindowReferenceTokens

--- a/src/infra/diagnostic-events.ts
+++ b/src/infra/diagnostic-events.ts
@@ -599,6 +599,8 @@ type DiagnosticModelCallBaseEvent = DiagnosticBaseEvent & {
   model: string;
   api?: string;
   transport?: string;
+  /** Defaults to request for emitters created before turn-level CLI diagnostics. */
+  observationUnit?: "request" | "turn";
   contextTokenBudget?: number;
   contextWindowSource?: "model" | "modelsConfig" | "agentContextTokens" | "default";
   contextWindowReferenceTokens?: number;


### PR DESCRIPTION
## What Problem This Solves

Claude Code CLI turns did not emit trusted `model.call.started`, `model.call.completed`, and `model.call.error` diagnostics. Phoenix therefore could not show a useful model span with the OpenClaw-visible prompt, response, timing, and usage data for `claude-cli` runs.

## Why This Change Was Made

Add synthetic turn-level model-call tracing at the honest Claude Code CLI boundary for one-shot, managed persistent stdio, and paired-node execution. Each admitted attempt now receives exactly one terminal lifecycle event, including retry attempts, aborts, timeouts, process/parse failures, deferred background completion, persistence failure, and cleanup failure.

Content capture reuses the existing trusted capture policy and remains disabled by default. Granular capture includes only the effective OpenClaw prompt, OpenClaw-appended system prompt, and visible assistant blocks. It intentionally excludes Claude Code private prompts, hidden resume/compaction payloads, native tool schemas and arguments, raw Anthropic HTTP traffic, internal retries, upstream request IDs, and network TTFB.

Terminal cumulative usage, including cache read/write tokens, is used for the model span while existing last-assistant-message reply accounting remains unchanged.

## User Impact

Operators using OpenTelemetry/Phoenix can inspect a truthful Claude CLI model span with useful lifecycle, prompt/response, byte, timing, and aggregate usage data when content capture is explicitly enabled. Default installations remain metadata-only, and native OpenClaw/Codex tracing behavior is unchanged.

AI-assisted: yes (Codex). I reviewed the implementation and validation results.

## Evidence

<img width="765" height="767" alt="image" src="https://github.com/user-attachments/assets/bd045dec-5fcd-4b78-bf27-076486803f70" />

- `node scripts/run-vitest.mjs src/agents/cli-output.test.ts src/agents/cli-runner.spawn.test.ts src/agents/cli-runner/claude-live-session.background-tasks.test.ts`: 3 files, 170 tests passed.
- Retry lifecycle regression filter: 6 tests passed; proves matched `started → error` and `started → completed` call IDs across fresh-session recovery.
- Post-success cleanup regression filter: 2 tests passed; proves cleanup rejection emits error rather than completion.
- `node scripts/run-vitest.mjs extensions/diagnostics-otel/src/service.test.ts`: 1 file, 108 tests passed, including `gen_ai.input.messages`, `gen_ai.output.messages`, and `gen_ai.system_instructions`.
- Blacksmith Testbox: core production types, core test types, extension test types, and touched-file lint passed. Final correction proof: [run 29416165438](https://github.com/openclaw/openclaw/actions/runs/29416165438).
- `oxfmt --check` and `git diff --check`: passed.
- Fresh structured autoreview after fixes: clean, no accepted/actionable findings; patch correct (0.86).
