### PR TITLE
test(agents): register session lock helpers in vitest workers

### DIFF
--- a/src/agents/session-write-lock.ts
+++ b/src/agents/session-write-lock.ts
@@ -1102,7 +1102,13 @@ function resetSessionWriteLockStateForTest(): void {
   resolveProcessStartTimeForLock = getProcessStartTime;
 }
 
-if (process.env.VITEST || process.env.NODE_ENV === "test") {
+if (
+  process.env.VITEST ||
+  process.env.VITEST_MODE ||
+  process.env.VITEST_POOL_ID ||
+  process.env.VITEST_WORKER_ID ||
+  process.env.NODE_ENV === "test"
+) {
   (globalThis as Record<PropertyKey, unknown>)[Symbol.for("openclaw.sessionWriteLockTestApi")] = {
     resetSessionWriteLockStateForTest,
     testing,

--- a/src/agents/session-write-lock.worker-env.test.ts
+++ b/src/agents/session-write-lock.worker-env.test.ts
@@ -1,0 +1,39 @@
+import { expect, it } from "vitest";
+
+const SESSION_WRITE_LOCK_TEST_API = Symbol.for("openclaw.sessionWriteLockTestApi");
+const testEnvKeys = [
+  "VITEST",
+  "VITEST_MODE",
+  "VITEST_POOL_ID",
+  "VITEST_WORKER_ID",
+  "NODE_ENV",
+] as const;
+
+it("registers the test API for a Vitest worker without VITEST", async () => {
+  const previousEnv = Object.fromEntries(testEnvKeys.map((key) => [key, process.env[key]]));
+
+  try {
+    for (const key of testEnvKeys) {
+      delete process.env[key];
+    }
+    process.env.VITEST_POOL_ID = "worker-only-regression";
+
+    await import("./session-write-lock.js");
+
+    expect((globalThis as Record<PropertyKey, unknown>)[SESSION_WRITE_LOCK_TEST_API]).toMatchObject(
+      {
+        resetSessionWriteLockStateForTest: expect.any(Function),
+        testing: expect.any(Object),
+      },
+    );
+  } finally {
+    for (const key of testEnvKeys) {
+      const value = previousEnv[key];
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  }
+});

--- a/src/agents/session-write-lock.worker-env.test.ts
+++ b/src/agents/session-write-lock.worker-env.test.ts
@@ -1,4 +1,4 @@
-import { expect, it } from "vitest";
+import { expect, it, vi } from "vitest";
 
 const SESSION_WRITE_LOCK_TEST_API = Symbol.for("openclaw.sessionWriteLockTestApi");
 const testEnvKeys = [
@@ -11,12 +11,15 @@ const testEnvKeys = [
 
 it("registers the test API for a Vitest worker without VITEST", async () => {
   const previousEnv = Object.fromEntries(testEnvKeys.map((key) => [key, process.env[key]]));
+  const previousTestApi = (globalThis as Record<PropertyKey, unknown>)[SESSION_WRITE_LOCK_TEST_API];
 
   try {
     for (const key of testEnvKeys) {
       delete process.env[key];
     }
     process.env.VITEST_POOL_ID = "worker-only-regression";
+    delete (globalThis as Record<PropertyKey, unknown>)[SESSION_WRITE_LOCK_TEST_API];
+    vi.resetModules();
 
     await import("./session-write-lock.js");
 
@@ -35,5 +38,11 @@ it("registers the test API for a Vitest worker without VITEST", async () => {
         process.env[key] = value;
       }
     }
+    if (previousTestApi === undefined) {
+      delete (globalThis as Record<PropertyKey, unknown>)[SESSION_WRITE_LOCK_TEST_API];
+    } else {
+      (globalThis as Record<PropertyKey, unknown>)[SESSION_WRITE_LOCK_TEST_API] = previousTestApi;
+    }
+    vi.resetModules();
   }
 });


### PR DESCRIPTION
## What Problem This Solves

Vitest worker environments do not consistently set `process.env.VITEST` while `session-write-lock.ts` is evaluated. This can skip test-only helper registration and fail compact CI shards before their tests run.

Production behavior is unchanged. The guard recognizes `VITEST_MODE`, `VITEST_POOL_ID`, and `VITEST_WORKER_ID`.

## Evidence

Exact rebased head: `f47747b090f333f30989b91cc45d171bbb99fc14`

- Formatting, direct lint, and `git diff --check upstream/main...HEAD` passed.
- Normal and `VITEST_POOL_ID=1` gateway suites both passed: 2 files / 18 tests.
