### PR TITLE
fix: prevent test shard cleanup failures

### DIFF
--- a/src/agents/session-write-lock.test-support.ts
+++ b/src/agents/session-write-lock.test-support.ts
@@ -41,4 +41,26 @@ export function resetSessionWriteLockStateForTest(): void {
   getTestApi().resetSessionWriteLockStateForTest();
 }
 
-export const testing = getTestApi().testing;
+export const testing: SessionWriteLockTestApi["testing"] = {
+  get cleanupSignals() {
+    return getTestApi().testing.cleanupSignals;
+  },
+  handleTerminationSignal(signal) {
+    getTestApi().testing.handleTerminationSignal(signal);
+  },
+  inspectLockPayloadForTest(payload, staleMs, nowMs, opts) {
+    return getTestApi().testing.inspectLockPayloadForTest(payload, staleMs, nowMs, opts);
+  },
+  releaseAllLocksSync() {
+    getTestApi().testing.releaseAllLocksSync();
+  },
+  runLockWatchdogCheck(nowMs) {
+    return getTestApi().testing.runLockWatchdogCheck(nowMs);
+  },
+  resolveRemainingAcquireTimeoutMs(timeoutMs, startedAtMs, nowMs) {
+    return getTestApi().testing.resolveRemainingAcquireTimeoutMs(timeoutMs, startedAtMs, nowMs);
+  },
+  setProcessStartTimeResolverForTest(resolver) {
+    getTestApi().testing.setProcessStartTimeResolverForTest(resolver);
+  },
+};


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Node test shards would fail during shared cleanup when a mocked session-lock runtime delayed installing its private test API.

## Why This Change Was Made

The test-support facade now resolves the private session-lock API when each helper is used instead of capturing it during module evaluation. The runtime API remains private and production behavior is unchanged.

## User Impact

No user-visible impact. CI test shards can complete reliably with isolated module mocks.

## Evidence

- Failing main run: https://github.com/openclaw/openclaw/actions/runs/29416192523
- `pnpm exec vitest run --config test/vitest/vitest.auto-reply-reply.config.ts src/auto-reply/reply/get-reply.fast-path.test.ts` — 22 passed
- `pnpm exec vitest run --config test/vitest/vitest.gateway-server.config.ts src/gateway/server-startup.test.ts` — 6 passed
- `pnpm exec oxfmt --check src/agents/session-write-lock.test-support.ts`
- Autoreview: clean, no accepted/actionable findings
