### PR TITLE
fix(android): enlarge voice note recording controls

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/VoiceNoteComposer.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/VoiceNoteComposer.kt
@@ -166,7 +166,7 @@ internal fun VoiceNoteRecordingControls(
       )
       Surface(
         onClick = onCancel,
-        modifier = Modifier.size(36.dp),
+        modifier = Modifier.size(ClawTheme.spacing.touchTarget),
         shape = CircleShape,
         color = ClawTheme.colors.canvas,
         contentColor = ClawTheme.colors.text,
@@ -177,7 +177,7 @@ internal fun VoiceNoteRecordingControls(
       }
       Surface(
         onClick = onDone,
-        modifier = Modifier.size(36.dp),
+        modifier = Modifier.size(ClawTheme.spacing.touchTarget),
         shape = CircleShape,
         color = ClawTheme.colors.primary,
         contentColor = ClawTheme.colors.primaryText,


### PR DESCRIPTION
[AI-assisted]
## What Problem This Solves

While recording a voice note, the cancel and finish actions render as 36 dp circles, below the app's existing 48 dp touch-target standard. That makes the two most important recording controls unnecessarily difficult to tap.

## Why This Change Was Made

Use ClawTheme.spacing.touchTarget for both recording actions instead of a hard-coded 36 dp size. This reuses the established 48 dp design token and leaves recording, attachment, send, and audio behavior unchanged.

## User Impact

Cancel and finish are easier to tap during voice-note recording and remain visually consistent with other Android controls. The change does not alter how recordings are created, staged, sent, or cancelled.

## Evidence

> [!NOTE]
> ### Validation
>
> - [x] `git diff --check` — passed
> - [x] `pnpm native:i18n:sync` — passed with changed=false
> - [x] `pnpm native:i18n:check` — passed
> - [x] `pnpm android:i18n:check` — passed
> - [x] `pnpm apple:i18n:check` — passed
> - [x] `node scripts/ensure-cli-startup-build.mjs` — passed
> - [x] `pnpm android:assemble` — completed successfully for the exact Base and patched After states
> - [x] `adb -s emulator-5558 install -r` — installed the patched APK successfully; the installed APK matched the built APK byte-for-byte

> [!TIP]
> ### Real Behavior Proof
>
> Android emulator behavior verified with the exact patched APK.
>
> - [x] **Environment:** Android 16 API 36 emulator at 1080x2400 with font scale 1.0.
> - [x] **Precondition:** The app was paired and online, microphone permission was granted, and the Chat composer was open. The local recording flow required no model request.
> - [x] **Before:** Tapping the Chat composer microphone showed the recording row with 36 dp cancel and finish action surfaces.
> - [x] **After:** The same flow with the exact patched APK showed both actions using the existing 48 dp touch-target token while the timer, waveform, cancel, and finish interactions remained available.
> - [x] **Result:** Both recording actions now meet the app's 48 dp touch-target standard without changing voice-note behavior.
> - [x] **Remaining proof gap:** Automated media inspection and final automated proof completion were not performed; the supplied emulator media is operator-attested.

<table>
  <tr><th>Before</th><th>After</th></tr>
  <tr>
    <td><img width="260" src="https://github.com/user-attachments/assets/5cd312c0-8369-462e-9b0f-d19c29a0657c" alt="Before" /></td>
    <td><img width="260" src="https://github.com/user-attachments/assets/b7b51de7-5d92-4c57-9e51-48981c7a9774" alt="After" /></td>
  </tr>
</table>

Before behavior recording:

https://github.com/user-attachments/assets/e26d05d7-fdea-406c-a1dd-1e68eec92a92

After behavior recording:

https://github.com/user-attachments/assets/3ee758df-cd7d-48a7-9a96-c63d814b8281
