### PR TITLE
test: order session lock cleanup imports

### DIFF
--- a/test/setup-openclaw-runtime.ts
+++ b/test/setup-openclaw-runtime.ts
@@ -69,36 +69,38 @@ function loadWorkerCleanupHelpers(): Promise<WorkerCleanupHelpers> {
   const globalState = globalThis as typeof globalThis & {
     [WORKER_CLEANUP_HELPERS]?: Promise<WorkerCleanupHelpers>;
   };
-  globalState[WORKER_CLEANUP_HELPERS] ??= Promise.all([
-    vi.importActual<typeof import("../src/agents/context-runtime-state.js")>(
-      "../src/agents/context-runtime-state.js",
-    ),
-    vi.importActual<typeof import("../src/agents/models-config-state.test-support.js")>(
-      "../src/agents/models-config-state.test-support.js",
-    ),
-    vi.importActual<typeof import("../src/agents/session-write-lock.js")>(
-      "../src/agents/session-write-lock.js",
-    ),
-    vi.importActual<typeof import("../src/agents/session-write-lock.test-support.js")>(
-      "../src/agents/session-write-lock.test-support.js",
-    ),
-    vi.importActual<typeof import("../src/config/sessions/store-cache.js")>(
-      "../src/config/sessions/store-cache.js",
-    ),
-    vi.importActual<typeof import("../src/config/sessions/store-writer-state.js")>(
-      "../src/config/sessions/store-writer-state.js",
-    ),
-    vi.importActual<typeof import("../src/infra/file-lock.js")>("../src/infra/file-lock.js"),
-  ]).then(
-    ([
+  globalState[WORKER_CLEANUP_HELPERS] ??= (async () => {
+    // The test-support facade reads the API installed by the real lock module at import time.
+    // Load that producer first so concurrent module evaluation cannot observe a missing API.
+    const sessionWriteLock = await vi.importActual<
+      typeof import("../src/agents/session-write-lock.js")
+    >("../src/agents/session-write-lock.js");
+    const [
       contextRuntimeState,
       modelsConfigState,
-      sessionWriteLock,
       sessionWriteLockTestSupport,
       sessionStoreCache,
       sessionStoreWriterState,
       fileLock,
-    ]) => ({
+    ] = await Promise.all([
+      vi.importActual<typeof import("../src/agents/context-runtime-state.js")>(
+        "../src/agents/context-runtime-state.js",
+      ),
+      vi.importActual<typeof import("../src/agents/models-config-state.test-support.js")>(
+        "../src/agents/models-config-state.test-support.js",
+      ),
+      vi.importActual<typeof import("../src/agents/session-write-lock.test-support.js")>(
+        "../src/agents/session-write-lock.test-support.js",
+      ),
+      vi.importActual<typeof import("../src/config/sessions/store-cache.js")>(
+        "../src/config/sessions/store-cache.js",
+      ),
+      vi.importActual<typeof import("../src/config/sessions/store-writer-state.js")>(
+        "../src/config/sessions/store-writer-state.js",
+      ),
+      vi.importActual<typeof import("../src/infra/file-lock.js")>("../src/infra/file-lock.js"),
+    ]);
+    return {
       clearSessionStoreCaches: sessionStoreCache.clearSessionStoreCaches,
       drainFileLockStateForTest: fileLock.drainFileLockStateForTest,
       drainSessionStoreWriterQueuesForTest:
@@ -109,8 +111,8 @@ function loadWorkerCleanupHelpers(): Promise<WorkerCleanupHelpers> {
       resetModelsJsonReadyCacheForTest: modelsConfigState.resetModelsJsonReadyCacheForTest,
       resetSessionWriteLockStateForTest:
         sessionWriteLockTestSupport.resetSessionWriteLockStateForTest,
-    }),
-  );
+    };
+  })();
   return globalState[WORKER_CLEANUP_HELPERS];
 }
 


### PR DESCRIPTION
## Summary

- load the real session write-lock module before its test-support facade
- preserve parallel loading for independent worker cleanup helpers

## Problem

The cleanup bootstrap started both modules in one `Promise.all`. The facade reads a global API installed by the real module during evaluation, so it could win the race and fail every test cleanup with `Cannot read properties of undefined (reading 'testing')`.

## Validation

- 117 focused tests across the two failing CI shards and the session write-lock suite
- path-scoped changed gate: formatting, test-root typecheck, script lint, and guards
- autoreview clean, confidence 0.98

No user-visible behavior change. No changelog entry needed.
