### PR TITLE
fix(test): order session lock cleanup imports

### DIFF
--- a/test/setup-openclaw-runtime.ts
+++ b/test/setup-openclaw-runtime.ts
@@ -69,36 +69,38 @@ function loadWorkerCleanupHelpers(): Promise<WorkerCleanupHelpers> {
   const globalState = globalThis as typeof globalThis & {
     [WORKER_CLEANUP_HELPERS]?: Promise<WorkerCleanupHelpers>;
   };
-  globalState[WORKER_CLEANUP_HELPERS] ??= Promise.all([
-    vi.importActual<typeof import("../src/agents/context-runtime-state.js")>(
-      "../src/agents/context-runtime-state.js",
-    ),
-    vi.importActual<typeof import("../src/agents/models-config-state.test-support.js")>(
-      "../src/agents/models-config-state.test-support.js",
-    ),
-    vi.importActual<typeof import("../src/agents/session-write-lock.js")>(
-      "../src/agents/session-write-lock.js",
-    ),
-    vi.importActual<typeof import("../src/agents/session-write-lock.test-support.js")>(
-      "../src/agents/session-write-lock.test-support.js",
-    ),
-    vi.importActual<typeof import("../src/config/sessions/store-cache.js")>(
-      "../src/config/sessions/store-cache.js",
-    ),
-    vi.importActual<typeof import("../src/config/sessions/store-writer-state.js")>(
-      "../src/config/sessions/store-writer-state.js",
-    ),
-    vi.importActual<typeof import("../src/infra/file-lock.js")>("../src/infra/file-lock.js"),
-  ]).then(
-    ([
+  globalState[WORKER_CLEANUP_HELPERS] ??= (async () => {
+    // The support module reads the actual lock module's test API during evaluation.
+    // Load that provider first so mocked gateway suites cannot race its registration.
+    const sessionWriteLock = await vi.importActual<
+      typeof import("../src/agents/session-write-lock.js")
+    >("../src/agents/session-write-lock.js");
+    const [
       contextRuntimeState,
       modelsConfigState,
-      sessionWriteLock,
       sessionWriteLockTestSupport,
       sessionStoreCache,
       sessionStoreWriterState,
       fileLock,
-    ]) => ({
+    ] = await Promise.all([
+      vi.importActual<typeof import("../src/agents/context-runtime-state.js")>(
+        "../src/agents/context-runtime-state.js",
+      ),
+      vi.importActual<typeof import("../src/agents/models-config-state.test-support.js")>(
+        "../src/agents/models-config-state.test-support.js",
+      ),
+      vi.importActual<typeof import("../src/agents/session-write-lock.test-support.js")>(
+        "../src/agents/session-write-lock.test-support.js",
+      ),
+      vi.importActual<typeof import("../src/config/sessions/store-cache.js")>(
+        "../src/config/sessions/store-cache.js",
+      ),
+      vi.importActual<typeof import("../src/config/sessions/store-writer-state.js")>(
+        "../src/config/sessions/store-writer-state.js",
+      ),
+      vi.importActual<typeof import("../src/infra/file-lock.js")>("../src/infra/file-lock.js"),
+    ]);
+    return {
       clearSessionStoreCaches: sessionStoreCache.clearSessionStoreCaches,
       drainFileLockStateForTest: fileLock.drainFileLockStateForTest,
       drainSessionStoreWriterQueuesForTest:
@@ -109,8 +111,8 @@ function loadWorkerCleanupHelpers(): Promise<WorkerCleanupHelpers> {
       resetModelsJsonReadyCacheForTest: modelsConfigState.resetModelsJsonReadyCacheForTest,
       resetSessionWriteLockStateForTest:
         sessionWriteLockTestSupport.resetSessionWriteLockStateForTest,
-    }),
-  );
+    };
+  })();
   return globalState[WORKER_CLEANUP_HELPERS];
 }
 


### PR DESCRIPTION
## What Problem This Solves

Gateway startup suites can fail during global test setup with `Cannot read properties of undefined (reading 'testing')` when the session write-lock test-support module evaluates before the actual lock module registers its private test API. This regressed after #108285.

## Why This Change Was Made

Load the actual session write-lock provider before importing its consumer. Keep the remaining independent cleanup helpers parallel. This makes the registration dependency explicit without restoring a public test-only export.

## User Impact

Test infrastructure only. Restores deterministic gateway suite startup and unblocks main/release validation CI.

## Evidence

- Failing exact-head CI job: https://github.com/openclaw/openclaw/actions/runs/29416858653/job/87357260370
- Focused Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/29417387370 — 9 files, 134 tests passed
- `pnpm check:changed` on Blacksmith Testbox — passed
- Fresh autoreview at `a5af5cf9a893ce948cbff6ef1faf7f4b7df045f1` — clean

No changelog: internal test setup correction.
