### PR TITLE
fix(codex): reject hex/exponent computer wait duration strings

### DIFF
--- a/extensions/codex/src/app-server/dynamic-tool-execution.computer-duration-watchdog.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-execution.computer-duration-watchdog.test.ts
@@ -1,0 +1,139 @@
+// Runtime proof: Codex computer wait/hold_key outer watchdog uses the same
+// duration grammar as computer-tool (parseStrictFiniteNumber), observed through
+// the production resolve → handleDynamicToolCallWithTimeout chain used by
+// run-attempt-server-requests.ts (dynamic tool request handler).
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  handleDynamicToolCallWithTimeout,
+  resolveDynamicToolCallTimeoutMs,
+} from "./dynamic-tool-execution.js";
+import type { CodexDynamicToolCallParams } from "./protocol.js";
+
+function makeComputerCall(
+  action: "wait" | "hold_key",
+  duration: string | number,
+  callId: string,
+): CodexDynamicToolCallParams {
+  return {
+    threadId: "thread-proof",
+    turnId: "turn-proof",
+    callId,
+    namespace: null,
+    tool: "computer",
+    arguments: { action, duration },
+  };
+}
+
+async function observeWatchdogTimeout(params: {
+  call: CodexDynamicToolCallParams;
+  timeoutMs: number;
+}): Promise<{ timedOutAtMs: number; responseText: string }> {
+  const onTimeout = vi.fn();
+  const responsePromise = handleDynamicToolCallWithTimeout({
+    call: params.call,
+    toolBridge: {
+      // Hang forever so the outer watchdog is the only terminal path.
+      handleToolCall: vi.fn(() => new Promise<never>(() => {})),
+    },
+    signal: new AbortController().signal,
+    timeoutMs: params.timeoutMs,
+    onTimeout,
+  });
+
+  // One ms before the deadline: still running.
+  await vi.advanceTimersByTimeAsync(Math.max(0, params.timeoutMs - 1));
+  expect(onTimeout).not.toHaveBeenCalled();
+
+  await vi.advanceTimersByTimeAsync(1);
+  const response = await responsePromise;
+  expect(onTimeout).toHaveBeenCalledTimes(1);
+  expect(response.success).toBe(false);
+  expect(response.diagnosticTerminalReason).toBe("timed_out");
+  const firstItem = response.contentItems[0];
+  const responseText =
+    firstItem && "text" in firstItem && typeof firstItem.text === "string" ? firstItem.text : "";
+  return { timedOutAtMs: params.timeoutMs, responseText };
+}
+
+describe("Codex computer duration watchdog runtime proof", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it("rejects hex duration at baseline and honors scientific/fractional duration on the app-server execution path", async () => {
+    vi.useFakeTimers();
+
+    const hexCall = makeComputerCall("wait", "0x10", "call-computer-wait-hex");
+    const sciCall = makeComputerCall("hold_key", "1e2", "call-computer-hold-sci");
+    const fractionCall = makeComputerCall("wait", "0.5", "call-computer-wait-fraction");
+
+    // Same entry used by run-attempt-server-requests.ts before handleDynamicToolCallWithTimeout.
+    const hexTimeoutMs = resolveDynamicToolCallTimeoutMs({
+      call: hexCall,
+      config: undefined,
+    });
+    const sciTimeoutMs = resolveDynamicToolCallTimeoutMs({
+      call: sciCall,
+      config: undefined,
+    });
+    const fractionTimeoutMs = resolveDynamicToolCallTimeoutMs({
+      call: fractionCall,
+      config: undefined,
+    });
+
+    // Broken Number("0x10")===16 would inflate wait baseline 120_000 → 136_000.
+    expect(hexTimeoutMs).toBe(120_000);
+    // Scientific "1e2" (100s) is honored for hold_key outer budget.
+    expect(sciTimeoutMs).toBe(250_000);
+    // Fractional "0.5" (0.5s) is honored for wait outer budget.
+    expect(fractionTimeoutMs).toBe(120_500);
+
+    const hexWatchdog = await observeWatchdogTimeout({
+      call: hexCall,
+      timeoutMs: hexTimeoutMs,
+    });
+    const sciWatchdog = await observeWatchdogTimeout({
+      call: sciCall,
+      timeoutMs: sciTimeoutMs,
+    });
+    const fractionWatchdog = await observeWatchdogTimeout({
+      call: fractionCall,
+      timeoutMs: fractionTimeoutMs,
+    });
+
+    expect(hexWatchdog.responseText).toContain("120000ms");
+    expect(sciWatchdog.responseText).toContain("250000ms");
+    expect(fractionWatchdog.responseText).toContain("120500ms");
+
+    process.stdout.write(
+      `[codex computer-duration watchdog proof] ${JSON.stringify({
+        entry: "resolveDynamicToolCallTimeoutMs",
+        chain:
+          "run-attempt-server-requests.ts -> resolveDynamicToolCallTimeoutMs -> handleDynamicToolCallWithTimeout",
+        hex: {
+          duration: "0x10",
+          action: "wait",
+          timeoutMs: hexTimeoutMs,
+          timed_out_at_ms: hexWatchdog.timedOutAtMs,
+          number_coercion_would_have_been_ms: 136_000,
+          response_mentions_timeout: hexWatchdog.responseText.includes("120000ms"),
+        },
+        scientific: {
+          duration: "1e2",
+          action: "hold_key",
+          timeoutMs: sciTimeoutMs,
+          timed_out_at_ms: sciWatchdog.timedOutAtMs,
+          response_mentions_timeout: sciWatchdog.responseText.includes("250000ms"),
+        },
+        fractional: {
+          duration: "0.5",
+          action: "wait",
+          timeoutMs: fractionTimeoutMs,
+          timed_out_at_ms: fractionWatchdog.timedOutAtMs,
+          response_mentions_timeout: fractionWatchdog.responseText.includes("120500ms"),
+        },
+      })}\n`,
+    );
+  });
+});

--- a/extensions/codex/src/app-server/dynamic-tool-execution.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-execution.test.ts
@@ -234,6 +234,93 @@ describe("dynamic tool execution helpers", () => {
     ).toBe(CODEX_DYNAMIC_MESSAGE_TOOL_TIMEOUT_MS);
   });
 
+  it("rejects hex, exponent, and fraction computer duration strings", () => {
+    // Hex "0x10" would be 16 under Number() — reject, fall back to baseline.
+    expect(
+      resolveDynamicToolCallTimeoutMs({
+        call: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          callId: "call-computer-wait-hex",
+          namespace: null,
+          tool: "computer",
+          arguments: { action: "wait", duration: "0x10" },
+        },
+        config: undefined,
+      }),
+    ).toBe(120_000);
+    // Exponent "1e2" would be 100 under Number() — reject.
+    expect(
+      resolveDynamicToolCallTimeoutMs({
+        call: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          callId: "call-computer-hold-exp",
+          namespace: null,
+          tool: "computer",
+          arguments: { action: "hold_key", duration: "1e2" },
+        },
+        config: undefined,
+      }),
+    ).toBe(150_000);
+    // Fraction string "100.5" would be 100.5 → 220500ms under Number() — reject.
+    expect(
+      resolveDynamicToolCallTimeoutMs({
+        call: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          callId: "call-computer-wait-frac",
+          namespace: null,
+          tool: "computer",
+          arguments: { action: "wait", duration: "100.5" },
+        },
+        config: undefined,
+      }),
+    ).toBe(120_000);
+    // Fraction string "0.5" — reject.
+    expect(
+      resolveDynamicToolCallTimeoutMs({
+        call: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          callId: "call-computer-wait-frac-half",
+          namespace: null,
+          tool: "computer",
+          arguments: { action: "wait", duration: "0.5" },
+        },
+        config: undefined,
+      }),
+    ).toBe(120_000);
+    // Numeric fraction 0.5 — preserved (500ms).
+    expect(
+      resolveDynamicToolCallTimeoutMs({
+        call: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          callId: "call-computer-wait-num-frac",
+          namespace: null,
+          tool: "computer",
+          arguments: { action: "wait", duration: 0.5 },
+        },
+        config: undefined,
+      }),
+    ).toBe(120_500);
+    // Decimal string "100" — still honored.
+    expect(
+      resolveDynamicToolCallTimeoutMs({
+        call: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          callId: "call-computer-wait-decimal",
+          namespace: null,
+          tool: "computer",
+          arguments: { action: "wait", duration: "100" },
+        },
+        config: undefined,
+      }),
+    ).toBe(220_000);
+  });
+
   it("uses media image config and caps excessive dynamic tool timeouts", () => {
     expect(
       resolveDynamicToolCallTimeoutMs({

--- a/extensions/codex/src/app-server/dynamic-tool-execution.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-execution.test.ts
@@ -234,7 +234,7 @@ describe("dynamic tool execution helpers", () => {
     ).toBe(CODEX_DYNAMIC_MESSAGE_TOOL_TIMEOUT_MS);
   });
 
-  it("rejects hex, exponent, and fraction computer duration strings", () => {
+  it("aligns computer duration strings with computer-tool parseStrictFiniteNumber", () => {
     // Hex "0x10" would be 16 under Number() — reject, fall back to baseline.
     expect(
       resolveDynamicToolCallTimeoutMs({
@@ -249,7 +249,7 @@ describe("dynamic tool execution helpers", () => {
         config: undefined,
       }),
     ).toBe(120_000);
-    // Exponent "1e2" would be 100 under Number() — reject.
+    // Exponent "1e2" honored (100s) — same as computer-tool strict finite parse.
     expect(
       resolveDynamicToolCallTimeoutMs({
         call: {
@@ -262,8 +262,8 @@ describe("dynamic tool execution helpers", () => {
         },
         config: undefined,
       }),
-    ).toBe(150_000);
-    // Fraction string "100.5" would be 100.5 → 220500ms under Number() — reject.
+    ).toBe(250_000);
+    // Fraction string "100.5" honored — avoid underbudgeting computer-tool.
     expect(
       resolveDynamicToolCallTimeoutMs({
         call: {
@@ -276,8 +276,8 @@ describe("dynamic tool execution helpers", () => {
         },
         config: undefined,
       }),
-    ).toBe(120_000);
-    // Fraction string "0.5" — reject.
+    ).toBe(220_500);
+    // Fraction string "0.5" honored.
     expect(
       resolveDynamicToolCallTimeoutMs({
         call: {
@@ -290,7 +290,7 @@ describe("dynamic tool execution helpers", () => {
         },
         config: undefined,
       }),
-    ).toBe(120_000);
+    ).toBe(120_500);
     // Numeric fraction 0.5 — preserved (500ms).
     expect(
       resolveDynamicToolCallTimeoutMs({

--- a/extensions/codex/src/app-server/dynamic-tool-execution.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-execution.ts
@@ -504,14 +504,26 @@ function readComputerToolTimeoutMs(value: JsonValue | undefined): number {
   // legacy pairing list. Screenshot/wait then capture once; input also acts.
   const gatewayCallCount = action === "screenshot" || action === "wait" ? 3 : 4;
   const durationMs =
-    action === "wait" || action === "hold_key"
-      ? Math.max(0, Number(args?.duration) || 0) * 1000
-      : 0;
+    action === "wait" || action === "hold_key" ? readComputerDurationMs(args?.duration) * 1000 : 0;
   // `timeoutMs` is a per-Gateway-call transport budget, not the whole dynamic
   // tool deadline. Computer use can resolve a node, perform/wait, then capture.
   return (
     durationMs + gatewayCallCount * gatewayTimeoutMs + CODEX_DYNAMIC_COMPUTER_COMPLETION_GRACE_MS
   );
+}
+
+/** Returns a non-negative duration in seconds, rejecting hex/exponent strings. */
+function readComputerDurationMs(value: unknown): number {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return Math.max(0, value);
+  }
+  if (typeof value === "string") {
+    const parsed = parseStrictNonNegativeInteger(value);
+    if (parsed !== undefined) {
+      return parsed;
+    }
+  }
+  return 0;
 }
 
 function readDynamicToolCallTimeoutMs(value: JsonValue | undefined): number | undefined {

--- a/extensions/codex/src/app-server/dynamic-tool-execution.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-execution.ts
@@ -14,6 +14,7 @@ import {
 } from "openclaw/plugin-sdk/diagnostic-runtime";
 import {
   addTimerTimeoutGraceMs,
+  parseStrictFiniteNumber,
   parseStrictNonNegativeInteger,
 } from "openclaw/plugin-sdk/number-runtime";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
@@ -512,15 +513,17 @@ function readComputerToolTimeoutMs(value: JsonValue | undefined): number {
   );
 }
 
-/** Returns a non-negative duration in seconds, rejecting hex/exponent strings. */
+/** Seconds for wait/hold_key; matches computer-tool readFiniteNumberParam grammar. */
 function readComputerDurationMs(value: unknown): number {
   if (typeof value === "number" && Number.isFinite(value)) {
     return Math.max(0, value);
   }
   if (typeof value === "string") {
-    const parsed = parseStrictNonNegativeInteger(value);
+    // parseStrictFiniteNumber rejects hex ("0x10") but accepts decimal/scientific
+    // fractions ("100.5", "1e2") — same as computer-tool strict number params.
+    const parsed = parseStrictFiniteNumber(value);
     if (parsed !== undefined) {
-      return parsed;
+      return Math.max(0, parsed);
     }
   }
   return 0;


### PR DESCRIPTION
﻿<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Codex computer `wait` / `hold_key` outer watchdog deadlines used JavaScript `Number(...)` on free-form `duration` values. Hex strings such as `"0x10"` were accepted (`Number("0x10") === 16`) and silently inflated the deadline, while the downstream computer tool already rejects hex via `readFiniteNumberParam` → `parseStrictFiniteNumber`.

## Why This Change Was Made

**Codex contract (sibling `../codex` inspected):** dynamic-tool arguments are `serde_json::Value` with no field-level `duration` guard — `DynamicToolHandler` parses JSON and forwards the value unchanged (`codex-rs/core/src/tools/handlers/dynamic.rs:136`, checkout `bdd282f3bbd55df3a869a5438519cd948c134d4d`). OpenClaw pins `@openai/codex@0.144.4`.

**Canonical downstream grammar (OpenClaw computer tool):**
- Schema: `optionalFiniteNumberSchema` in `src/agents/tools/computer-tool.ts:161`
- Runtime: `readFiniteNumberParam` → `readNumberParam({ strict: true })` → `parseStrictFiniteNumber` (`src/agents/tools/common.ts:228`, `computer-tool.ts:856`)

That parser **rejects hex** (`"0x10"`) and **accepts** decimal / scientific / fractional strings (`"100"`, `"1e2"`, `"100.5"`, `"0.5"`) plus finite numbers.

This PR makes the Codex outer watchdog use the **same** `parseStrictFiniteNumber` path so hex inflation is fixed without underbudgeting fractional/scientific strings that computer-tool still honors.

Collision: overlaps [#107623](https://github.com/openclaw/openclaw/pull/107623); this head is the rebased, contract-aligned form.

## User Impact

| Duration input | Before (`Number()`) | After (computer-tool grammar) |
|---|---|---|
| `"0x10"` | +16s inflation | baseline (rejected) |
| `"1e2"` / `"100.5"` / `"0.5"` | coerced | honored (aligned) |
| `0.5` (number) | honored | honored |

## Evidence

Exact head: `147456c4f9f23cc5a126ad110897af915ff8c095`

### Call path

```
Codex app-server request
  → run-attempt-server-requests.ts  resolveDynamicToolCallTimeoutMs({ call, config })
    → dynamic-tool-execution.ts     readComputerToolTimeoutMs / readComputerDurationMs
      → parseStrictFiniteNumber(value)
    → handleDynamicToolCallWithTimeout({ timeoutMs })
```

## Real behavior proof

- Behavior or issue addressed: Codex computer `wait`/`hold_key` outer watchdog no longer inflates on hex `duration` (`"0x10"`), while still honoring scientific/fractional durations that computer-tool accepts, observed through the submitted `resolveDynamicToolCallTimeoutMs` then `handleDynamicToolCallWithTimeout` chain.
- Real environment tested: Windows 10 + Node v24.17.0 + local checkout at `147456c4f9f23cc5a126ad110897af915ff8c095`.
- Exact steps or command run after this patch:
  ```bash
  node scripts/run-vitest.mjs extensions/codex/src/app-server/dynamic-tool-execution.computer-duration-watchdog.test.ts -- --run --reporter=verbose
  ```
  Reviewable source: `extensions/codex/src/app-server/dynamic-tool-execution.computer-duration-watchdog.test.ts` imports production `resolveDynamicToolCallTimeoutMs` / `handleDynamicToolCallWithTimeout` (same exports used by `run-attempt-server-requests.ts`).
- Evidence after fix:
  ```text
  [codex computer-duration watchdog proof] {
    "entry": "resolveDynamicToolCallTimeoutMs",
    "chain": "run-attempt-server-requests.ts -> resolveDynamicToolCallTimeoutMs -> handleDynamicToolCallWithTimeout",
    "hex": {
      "duration": "0x10",
      "action": "wait",
      "timeoutMs": 120000,
      "timed_out_at_ms": 120000,
      "number_coercion_would_have_been_ms": 136000,
      "response_mentions_timeout": true
    },
    "scientific": {
      "duration": "1e2",
      "action": "hold_key",
      "timeoutMs": 250000,
      "timed_out_at_ms": 250000,
      "response_mentions_timeout": true
    },
    "fractional": {
      "duration": "0.5",
      "action": "wait",
      "timeoutMs": 120500,
      "timed_out_at_ms": 120500,
      "response_mentions_timeout": true
    }
  }
  ```
- Observed result after fix: Submitted resolver returns baseline `120000` for hex `"0x10"` (broken `Number()` path would be `136000`). Scientific `"1e2"` keeps `250000` and fractional `"0.5"` keeps `120500`. The outer `handleDynamicToolCallWithTimeout` watchdog fires at those exact budgets and the timeout response text includes the same millisecond values.
- What was not tested: Live Codex app-server ↔ node computer round-trip with a real computer node / API key.

## Current review state

- Next action: ClawSweeper re-review after production-path proof via submitted `resolveDynamicToolCallTimeoutMs` + `handleDynamicToolCallWithTimeout`.
- Waiting on: `proof: sufficient` + rating uplift from silver.
