### PR TITLE
fix(ui): keep fullscreen terminal loads exception-free

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Control UI terminal tabs:** keep the new-session control outside Web Awesome until a terminal tab exists, preventing active-tab exceptions during fullscreen terminal loads and reconnects.
 - **Mattermost progress command details:** accept the documented `streaming.preview.commandText` and `streaming.progress.commandText` modes in channel config validation and bundled metadata. Thanks @shakkernerd.
 - **1Password authorization handoff:** persist nonce-bound pending approvals in shared plugin state so hook and tool execution across broker instances remain single-use and fail closed.
 - **Control UI chat transcripts:** preserve loaded history across session and pane returns, bound automatic backscroll loading, virtualize long transcripts, retain hidden native run boundaries, and keep prepends, streaming, and responsive layouts from flickering or jumping. Thanks @shakkernerd.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Control UI terminal tabs:** keep the new-session control outside Web Awesome until a terminal tab exists, preventing active-tab exceptions during fullscreen terminal loads and reconnects.
 - **Mattermost progress command details:** accept the documented `streaming.preview.commandText` and `streaming.progress.commandText` modes in channel config validation and bundled metadata. Thanks @shakkernerd.
 - **1Password authorization handoff:** persist nonce-bound pending approvals in shared plugin state so hook and tool execution across broker instances remain single-use and fail closed.
 - **Control UI chat transcripts:** preserve loaded history across session and pane returns, bound automatic backscroll loading, virtualize long transcripts, retain hidden native run boundaries, and keep prepends, streaming, and responsive layouts from flickering or jumping. Thanks @shakkernerd.

--- a/ui/src/components/terminal/terminal-panel-tabs.test.ts
+++ b/ui/src/components/terminal/terminal-panel-tabs.test.ts
@@ -1,0 +1,58 @@
+/* @vitest-environment jsdom */
+
+import { render } from "lit";
+import { describe, expect, it, vi } from "vitest";
+import { renderTerminalPanelTabs } from "./terminal-panel-tabs.ts";
+
+describe("renderTerminalPanelTabs", () => {
+  it("keeps the new-session control outside Web Awesome until a tab exists", () => {
+    const container = document.createElement("div");
+    const onNew = vi.fn();
+
+    render(
+      renderTerminalPanelTabs({
+        tabs: [],
+        activeId: null,
+        booting: false,
+        onSelect: vi.fn(),
+        onClose: vi.fn(),
+        onNew,
+      }),
+      container,
+    );
+
+    expect(container.querySelector("wa-tab-group")).toBeNull();
+    const button = container.querySelector<HTMLButtonElement>(".tp-new");
+    expect(button?.hasAttribute("slot")).toBe(false);
+    button?.click();
+    expect(onNew).toHaveBeenCalledOnce();
+  });
+
+  it("slots the new-session control into a nonempty tab group", () => {
+    const container = document.createElement("div");
+
+    render(
+      renderTerminalPanelTabs({
+        tabs: [
+          {
+            id: "tab-1",
+            sequence: 1,
+            shellName: "bash",
+            agentId: "main",
+            cwd: "/work",
+            status: "live",
+          },
+        ],
+        activeId: "tab-1",
+        booting: false,
+        onSelect: vi.fn(),
+        onClose: vi.fn(),
+        onNew: vi.fn(),
+      }),
+      container,
+    );
+
+    expect(container.querySelector("wa-tab-group")).not.toBeNull();
+    expect(container.querySelector(".tp-new")?.getAttribute("slot")).toBe("nav");
+  });
+});

--- a/ui/src/components/terminal/terminal-panel-tabs.ts
+++ b/ui/src/components/terminal/terminal-panel-tabs.ts
@@ -50,6 +50,24 @@ export function renderTerminalPanelTabs(params: {
   onClose: (id: string) => void;
   onNew: () => void;
 }) {
+  const newButton = (slotted: boolean) => html`
+    <button
+      slot=${slotted ? "nav" : nothing}
+      class="tp-new"
+      type="button"
+      ?disabled=${params.booting}
+      title=${t("terminal.newSession")}
+      aria-label=${t("terminal.newSession")}
+      @click=${params.onNew}
+    >
+      ${PLUS_GLYPH}
+    </button>
+  `;
+  if (params.tabs.length === 0) {
+    // Web Awesome 3.10 dereferences its first tab when an empty group becomes
+    // visible. Keep the new-session control outside the group until one exists.
+    return newButton(false);
+  }
   return html`
     <wa-tab-group
       class="tp-tabs"
@@ -84,17 +102,7 @@ export function renderTerminalPanelTabs(params: {
           </button>
         `;
       })}
-      <button
-        slot="nav"
-        class="tp-new"
-        type="button"
-        ?disabled=${params.booting}
-        title=${t("terminal.newSession")}
-        aria-label=${t("terminal.newSession")}
-        @click=${params.onNew}
-      >
-        ${PLUS_GLYPH}
-      </button>
+      ${newButton(true)}
     </wa-tab-group>
   `;
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users opening or reconnecting to the fullscreen terminal would hit a Web Awesome page exception before the first terminal tab existed.

## Why This Change Was Made

The new-session control now renders outside the tab group until a real terminal tab exists, then moves into the tab group's navigation slot. This preserves the same UI while avoiding Web Awesome 3.10's invalid empty-group active-tab path.

## User Impact

Fullscreen terminal loads and reconnects stay exception-free before a session starts. Existing terminal tabs and the new-session action behave unchanged.

## Evidence

- Crabbox production build with a real Gateway, browser, PTY, and authenticated Codex 0.144.4.
- 300 fragmented OSC 10/11/12 round trips across 100 stress iterations; 20 browser reload/reconnect cycles.
- Before: 21 page exceptions (initial load plus every reconnect), all from Web Awesome resolving the active tab of an empty group.
- After: zero page errors and zero console errors; composer color and layout remained stable across all reconnects.
- Screenshot contract: initial gray composer, typed/cleared text, no raw OSC sequences, and identical reconnect screenshots all passed.
- Focused tests: 21 passing across terminal panel and terminal tab rendering.
- Changed gate: format, i18n, core-test/UI typechecks, and changed-file lint passed on Blacksmith Testbox.
- Autoreview: clean, no accepted/actionable findings.

### Before

Sanitized Crabbox capture before the fix. The exception is browser-console-only; the visible terminal still renders.

<img width="1440" height="863" alt="Fullscreen terminal before the empty-tab fix" src="https://github.com/user-attachments/assets/f2d01dfc-322c-4206-bca0-52dbf9d8d3e5" />

### After

Sanitized Crabbox capture after 20 reconnects, with zero page or console errors.

<img width="1440" height="863" alt="Fullscreen terminal after 20 reconnects" src="https://github.com/user-attachments/assets/95644f5d-0d00-4182-b5a7-1ff7d5cc9722" />

Crabbox run: https://crabbox.openclaw.ai/portal/runs/run_81665d067255

Provenance: clearly introduced by #106865 when the fullscreen terminal moved to Web Awesome tabs; code author, PR author, and merger were @steipete.
