### PR TITLE
fix(nextcloud-talk): reject oversized API password files

### DIFF
--- a/extensions/nextcloud-talk/src/api-credentials.test.ts
+++ b/extensions/nextcloud-talk/src/api-credentials.test.ts
@@ -1,0 +1,84 @@
+import { linkSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { resolveNextcloudTalkApiCredentials } from "./api-credentials.js";
+
+const tempDirs: string[] = [];
+
+function createFixtureFile(contents: string): string {
+  const tempDir = mkdtempSync(path.join(tmpdir(), "nextcloud-talk-api-credentials-"));
+  tempDirs.push(tempDir);
+  const passwordFile = path.join(tempDir, "password");
+  writeFileSync(passwordFile, contents, "utf8");
+  return passwordFile;
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+describe("resolveNextcloudTalkApiCredentials", () => {
+  it("reads and trims a file-backed API password", () => {
+    const fixturePath = createFixtureFile(" example\n");
+
+    expect(
+      resolveNextcloudTalkApiCredentials({ apiUser: " admin ", apiPasswordFile: fixturePath }),
+    ).toEqual({ apiUser: "admin", apiPassword: "example" });
+  });
+
+  it("does not resolve oversized API password files", () => {
+    const fixturePath = createFixtureFile("x".repeat(16 * 1024 + 1));
+
+    expect(
+      resolveNextcloudTalkApiCredentials({ apiUser: "admin", apiPasswordFile: fixturePath }),
+    ).toBeUndefined();
+  });
+
+  it("keeps inline API password precedence over the file", () => {
+    const fixturePath = createFixtureFile("x".repeat(16 * 1024 + 1));
+
+    expect(
+      resolveNextcloudTalkApiCredentials({
+        apiUser: "admin",
+        apiPassword: "example",
+        apiPasswordFile: fixturePath,
+      }),
+    ).toEqual({ apiUser: "admin", apiPassword: "example" });
+  });
+
+  it("returns undefined for missing and empty API password files", () => {
+    const missingFile = createFixtureFile("unused");
+    rmSync(missingFile);
+    const emptyFile = createFixtureFile(" \n");
+
+    expect(
+      resolveNextcloudTalkApiCredentials({ apiUser: "admin", apiPasswordFile: missingFile }),
+    ).toBeUndefined();
+    expect(
+      resolveNextcloudTalkApiCredentials({ apiUser: "admin", apiPasswordFile: emptyFile }),
+    ).toBeUndefined();
+  });
+
+  it.runIf(process.platform !== "win32")("preserves symlinked API password files", () => {
+    const targetFile = createFixtureFile("example");
+    const symlinkFile = path.join(path.dirname(targetFile), "password-link");
+    symlinkSync(targetFile, symlinkFile);
+
+    expect(
+      resolveNextcloudTalkApiCredentials({ apiUser: "admin", apiPasswordFile: symlinkFile }),
+    ).toEqual({ apiUser: "admin", apiPassword: "example" });
+  });
+
+  it.runIf(process.platform !== "win32")("preserves hardlinked API password files", () => {
+    const targetFile = createFixtureFile("example");
+    const hardlinkFile = path.join(path.dirname(targetFile), "password-hardlink");
+    linkSync(targetFile, hardlinkFile);
+
+    expect(
+      resolveNextcloudTalkApiCredentials({ apiUser: "admin", apiPasswordFile: hardlinkFile }),
+    ).toEqual({ apiUser: "admin", apiPassword: "example" });
+  });
+});

--- a/extensions/nextcloud-talk/src/api-credentials.ts
+++ b/extensions/nextcloud-talk/src/api-credentials.ts
@@ -1,5 +1,5 @@
 // Nextcloud Talk plugin module implements api credentials behavior.
-import { readFileSync } from "node:fs";
+import { tryReadSecretFileSync } from "openclaw/plugin-sdk/secret-file-runtime";
 import { normalizeResolvedSecretInputString } from "./secret-input.js";
 
 export function resolveNextcloudTalkApiCredentials(params: {
@@ -24,8 +24,14 @@ export function resolveNextcloudTalkApiCredentials(params: {
     return undefined;
   }
   try {
-    const filePassword = readFileSync(params.apiPasswordFile, "utf-8").trim();
-    return filePassword ? { apiUser, apiPassword: filePassword } : undefined;
+    const fileValue = tryReadSecretFileSync(
+      params.apiPasswordFile,
+      "Nextcloud Talk API password",
+      // Existing apiPasswordFile paths may be symlinks or hardlinks. Keep that
+      // contract while gaining the shared credential size and pinned-read checks.
+      { rejectHardlinks: false },
+    );
+    return fileValue ? { apiUser, apiPassword: fileValue } : undefined;
   } catch {
     return undefined;
   }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators using `channels.nextcloud-talk.apiPasswordFile` could have an arbitrarily large file loaded as the Nextcloud API password during room-type lookup and bot status preflight. A mistaken or bogus file could therefore be retained and encoded into request credentials before any Nextcloud request was made.

## Why This Change Was Made

The API password resolver now uses OpenClaw's existing pinned secret-file reader and its 16 KiB credential limit. The change keeps inline-password precedence and the existing missing, empty, symlink, and hardlink behavior; it does not change configuration shape or the network callers.

AI-assisted: yes. I inspected the production resolver, both callers, the sibling bot-secret reader, and the installed `@openclaw/fs-safe` source/types/docs before making the change.

## User Impact

Nextcloud Talk operators can continue using normal API password files, including existing symlink or hardlink layouts, while oversized credential files are rejected before request credentials are produced.

## Evidence

**Real-machine production-path proof:** Linux, Node `v24.18.0`; the commands directly imported `resolveNextcloudTalkApiCredentials` from the production module (no mocked resolver).

**Before / negative control:** On base `6a237b5d3`, a 20 KiB real file was accepted in full:

```bash
node --import tsx --input-type=module -e 'import { mkdtempSync, writeFileSync, rmSync } from "node:fs"; import { tmpdir } from "node:os"; import path from "node:path"; import { resolveNextcloudTalkApiCredentials } from "./extensions/nextcloud-talk/src/api-credentials.ts"; const dir=mkdtempSync(path.join(tmpdir(),"nextcloud-api-proof-before-")); try { const file=path.join(dir,"password"); writeFileSync(file,"x".repeat(20*1024)); const result=resolveNextcloudTalkApiCredentials({apiUser:"admin",apiPasswordFile:file}); console.log(JSON.stringify({inputBytes:20*1024,acceptedPasswordChars:result?.apiPassword.length ?? null,credentialsProduced:Boolean(result)})); } finally { rmSync(dir,{recursive:true,force:true}); }'
```

```text
{"inputBytes":20480,"acceptedPasswordChars":20480,"credentialsProduced":true}
```

Latest main at PR preparation was `9cdc0c34957afc760e037f83f6ba795a0bb81fe9`. The resolver and both callers were unchanged from the tested base; the resolver blob was identical:

```text
6a237b5d3:extensions/nextcloud-talk/src/api-credentials.ts  2c29f8c7509a91f02aa765e8c7b7b28871ebd68f
9cdc0c349:extensions/nextcloud-talk/src/api-credentials.ts  2c29f8c7509a91f02aa765e8c7b7b28871ebd68f
```

**Premise:** I inspected installed `@openclaw/fs-safe@0.4.1` source, types, and `docs/secret-file.md`. `tryReadSecretFileSync` defaults to `DEFAULT_SECRET_FILE_MAX_BYTES = 16 * 1024`, checks size before the pinned descriptor read, trims content, returns `undefined` for a missing path, and permits retaining the prior hardlink behavior with `rejectHardlinks: false`. `openclaw/plugin-sdk/secret-file-runtime` re-exports that helper for plugin production code.

**After / negative controls:** On commit `d108220d7103aaa1dfec3489b7185e447b30b569`, the same production resolver rejected the 20 KiB file while a normal file and existing symlink/hardlink layouts still resolved:

```bash
node --import tsx --input-type=module -e 'import { linkSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs"; import { tmpdir } from "node:os"; import path from "node:path"; import { resolveNextcloudTalkApiCredentials as resolve } from "./extensions/nextcloud-talk/src/api-credentials.ts"; const dir=mkdtempSync(path.join(tmpdir(),"nextcloud-api-proof-after-")); try { const oversized=path.join(dir,"oversized"); const normal=path.join(dir,"normal"); const symlink=path.join(dir,"symlink"); const hardlink=path.join(dir,"hardlink"); writeFileSync(oversized,"x".repeat(20*1024)); writeFileSync(normal," example\n"); symlinkSync(normal,symlink); linkSync(normal,hardlink); const summarize=(file)=>{const result=resolve({apiUser:"admin",apiPasswordFile:file}); return {credentialsProduced:Boolean(result),passwordChars:result?.apiPassword.length ?? null};}; console.log(JSON.stringify({oversized:summarize(oversized),normal:summarize(normal),symlink:summarize(symlink),hardlink:summarize(hardlink)})); } finally { rmSync(dir,{recursive:true,force:true}); }'
```

```text
{"oversized":{"credentialsProduced":false,"passwordChars":null},"normal":{"credentialsProduced":true,"passwordChars":7},"symlink":{"credentialsProduced":true,"passwordChars":7},"hardlink":{"credentialsProduced":true,"passwordChars":7}}
```

**Focused validation:**

```bash
node scripts/run-vitest.mjs extensions/nextcloud-talk/src/api-credentials.test.ts extensions/nextcloud-talk/src/room-info.test.ts extensions/nextcloud-talk/src/bot-preflight.test.ts
```

```text
Test Files  3 passed (3)
Tests       22 passed (22)
```

Also passed targeted `oxfmt --check`, targeted `oxlint`, and `git diff --check`. Autoreview reported no accepted/actionable findings and rated the patch correct at `0.98` confidence.

Not tested against a live Nextcloud server because the request paths and network code are unchanged. The full `check:changed` lane was not run locally because it automatically delegated to Blacksmith/Testbox, which is unavailable and prohibited in this external-contributor workflow; fork CI remains the wide validation path.
