### PR TITLE
fix: prevent cumulative usage from inflating session context

### DIFF
--- a/src/agents/command/session-store.test.ts
+++ b/src/agents/command/session-store.test.ts
@@ -1242,6 +1242,59 @@ describe("updateSessionStoreAfterAgentRun", () => {
     });
   });
 
+  it("uses non-CLI last-call usage when promptTokens is unavailable", async () => {
+    await withTempSessionStore(async ({ storePath }) => {
+      const sessionKey = "agent:main:explicit:test-responses-cumulative-usage";
+      const sessionId = "test-responses-cumulative-usage-session";
+      const sessionStore: Record<string, SessionEntry> = {
+        [sessionKey]: {
+          sessionId,
+          updatedAt: 1,
+        },
+      };
+      await seedSessionStore(storePath, sessionStore);
+
+      await updateSessionStoreAfterAgentRun({
+        cfg: {} as OpenClawConfig,
+        contextTokensOverride: 1_000_000,
+        sessionId,
+        sessionKey,
+        storePath,
+        sessionStore,
+        defaultProvider: "custom-openai",
+        defaultModel: "responses-model",
+        result: {
+          meta: {
+            durationMs: 1,
+            agentMeta: {
+              sessionId,
+              provider: "custom-openai",
+              model: "responses-model",
+              usage: {
+                input: 497_720,
+                output: 7_485,
+                cacheRead: 1_323_520,
+                cacheWrite: 0,
+                total: 1_828_725,
+              },
+              lastCallUsage: {
+                input: 38_333,
+                output: 66,
+                cacheRead: 120_320,
+                cacheWrite: 0,
+                total: 158_719,
+              },
+            },
+          },
+        } as EmbeddedAgentRunResult,
+      });
+
+      expect(sessionStore[sessionKey]?.totalTokens).toBe(158_653);
+      expect(sessionStore[sessionKey]?.totalTokensFresh).toBe(true);
+      expect(loadPersistedSessionEntry(storePath, sessionKey)?.totalTokens).toBe(158_653);
+    });
+  });
+
   it("uses the compaction snapshot when non-CLI last-call context is unavailable", async () => {
     await withTempSessionStore(async ({ storePath }) => {
       const sessionKey = "agent:main:explicit:test-unavailable-context";
@@ -1469,7 +1522,7 @@ describe("updateSessionStoreAfterAgentRun", () => {
     });
   });
 
-  it("prefers fresh usage over positive compaction tokensAfter", async () => {
+  it("prefers fresh last-call usage over positive compaction tokensAfter", async () => {
     await withTempSessionStore(async ({ storePath }) => {
       const cfg = {} as OpenClawConfig;
       const sessionKey = "agent:main:explicit:test-positive-compaction-with-usage";
@@ -1516,7 +1569,7 @@ describe("updateSessionStoreAfterAgentRun", () => {
         } as EmbeddedAgentRunResult,
       });
 
-      expect(sessionStore[sessionKey]?.totalTokens).toBe(120_000);
+      expect(sessionStore[sessionKey]?.totalTokens).toBe(95_000);
       expect(sessionStore[sessionKey]?.totalTokensFresh).toBe(true);
       expect(sessionStore[sessionKey]?.inputTokens).toBe(100_000);
       expect(sessionStore[sessionKey]?.outputTokens).toBe(3_000);

--- a/src/agents/command/session-store.ts
+++ b/src/agents/command/session-store.ts
@@ -212,13 +212,11 @@ export async function updateSessionStoreAfterAgentRun(params: {
     const { estimateUsageCost, resolveModelCostConfig } = await getUsageFormatModule();
     const input = usage.input ?? 0;
     const output = usage.output ?? 0;
-    const usageForContext = isCliProvider(providerUsed, cfg)
-      ? lastCallUsage
-      : lastCallUsage?.contextUsage
-        ? lastCallUsage
-        : usage;
     const totalTokens = deriveSessionTotalTokens({
-      usage: promptTokens ? undefined : usageForContext,
+      lastCallUsage,
+      // CLI aggregate usage is cumulative by contract; without a last-call
+      // snapshot it cannot describe the current context window.
+      usage: isCliProvider(providerUsed, cfg) ? undefined : usage,
       contextTokens,
       promptTokens,
     });

--- a/src/agents/command/session-store.ts
+++ b/src/agents/command/session-store.ts
@@ -214,9 +214,6 @@ export async function updateSessionStoreAfterAgentRun(params: {
     const output = usage.output ?? 0;
     const totalTokens = deriveSessionTotalTokens({
       lastCallUsage,
-      // CLI aggregate usage is cumulative by contract; without a last-call
-      // snapshot it cannot describe the current context window.
-      usage: isCliProvider(providerUsed, cfg) ? undefined : usage,
       contextTokens,
       promptTokens,
     });

--- a/src/agents/embedded-agent-runner/run/attempt-phase-lifecycle.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-phase-lifecycle.test.ts
@@ -63,6 +63,7 @@ describe("embedded attempt phase lifecycle state", () => {
         getCompactionCount: () => 0,
         getCurrentAttemptAssistant: () => undefined,
         getUsageTotals: () => undefined,
+        getLastAssistantUsage: () => undefined,
       } as never,
       state: {
         promptError: null,

--- a/src/agents/embedded-agent-runner/run/attempt-stream-settle.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-stream-settle.ts
@@ -7,7 +7,7 @@ import type { subscribeEmbeddedAgentSession } from "../../embedded-agent-subscri
 import type { AgentMessage } from "../../runtime/index.js";
 import type { AgentSession, SessionManager } from "../../sessions/index.js";
 import { projectToolSearchTargetTranscriptMessages } from "../../tool-search.js";
-import { normalizeUsage, type NormalizedUsage } from "../../usage.js";
+import { hasNonzeroUsage, normalizeUsage, type NormalizedUsage } from "../../usage.js";
 import { isRunnerAbortError } from "../abort.js";
 import { isCacheTtlEligibleProvider, readLastCacheTtlTimestamp } from "../cache-ttl.js";
 import { log } from "../logger.js";
@@ -28,6 +28,7 @@ import {
 import {
   buildContextEnginePromptCacheInfo,
   findCurrentAttemptAssistantMessage,
+  findLatestCurrentAttemptUsageSnapshot,
   resolvePromptCacheTouchTimestamp,
 } from "./attempt.context-engine-helpers.js";
 import type { createEmbeddedAttemptSessionLockController } from "./attempt.session-lock.js";
@@ -288,7 +289,6 @@ export async function settleEmbeddedAttemptStream(input: {
       prePromptMessageCount: input.prePromptMessageCount,
     });
     currentAttemptCompletedAssistant = subscription.getCurrentAttemptAssistant();
-    const usageAssistant = currentAttemptCompletedAssistant ?? currentAttemptAssistant;
     attemptUsage = subscription.getUsageTotals();
     cacheBreak = input.cache.observabilityEnabled
       ? completePromptCacheObservation({
@@ -298,7 +298,21 @@ export async function settleEmbeddedAttemptStream(input: {
           usage: attemptUsage,
         })
       : null;
-    lastCallUsage = normalizeUsage(usageAssistant?.usage);
+    const transcriptUsageSnapshot = findLatestCurrentAttemptUsageSnapshot({
+      messagesSnapshot,
+      prePromptMessageCount: input.prePromptMessageCount,
+    });
+    const completedAssistantUsage = normalizeUsage(currentAttemptCompletedAssistant?.usage);
+    lastCallUsage =
+      subscription.getLastAssistantUsage() ??
+      (hasNonzeroUsage(completedAssistantUsage)
+        ? completedAssistantUsage
+        : transcriptUsageSnapshot?.usage);
+    // Keep cache timing bound to the assistant that supplied the exact usage.
+    // A terminal zero-usage abort must not advance TTL for the previous call.
+    const usageAssistant = hasNonzeroUsage(completedAssistantUsage)
+      ? currentAttemptCompletedAssistant
+      : transcriptUsageSnapshot?.assistant;
     const promptCacheObservation =
       input.cache.observabilityEnabled &&
       (cacheBreak || input.cache.changesForTurn || typeof attemptUsage?.cacheRead === "number")

--- a/src/agents/embedded-agent-runner/run/attempt-stream-settle.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-stream-settle.ts
@@ -28,7 +28,7 @@ import {
 import {
   buildContextEnginePromptCacheInfo,
   findCurrentAttemptAssistantMessage,
-  findLatestCurrentAttemptUsageSnapshot,
+  findLatestUncompactedAttemptUsageSnapshot,
   resolvePromptCacheTouchTimestamp,
 } from "./attempt.context-engine-helpers.js";
 import type { createEmbeddedAttemptSessionLockController } from "./attempt.session-lock.js";
@@ -298,9 +298,10 @@ export async function settleEmbeddedAttemptStream(input: {
           usage: attemptUsage,
         })
       : null;
-    const transcriptUsageSnapshot = findLatestCurrentAttemptUsageSnapshot({
+    const transcriptUsageSnapshot = findLatestUncompactedAttemptUsageSnapshot({
       messagesSnapshot,
       prePromptMessageCount: input.prePromptMessageCount,
+      compactionOccurred: compactionOccurredThisAttempt,
     });
     const completedAssistantUsage = normalizeUsage(currentAttemptCompletedAssistant?.usage);
     lastCallUsage =

--- a/src/agents/embedded-agent-runner/run/attempt.context-engine-helpers.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.context-engine-helpers.test.ts
@@ -1,12 +1,17 @@
 import { describe, expect, it } from "vitest";
-import type { AgentMessage } from "../../runtime/index.js";
+import type { AssistantMessage } from "../../runtime/index.js";
 import { findLatestUncompactedAttemptUsageSnapshot } from "./attempt.context-engine-helpers.js";
 
 const ASSISTANT_WITH_USAGE = {
   role: "assistant",
   content: [],
+  api: "openai-responses",
+  provider: "openai",
+  model: "gpt-5.4",
+  stopReason: "stop",
+  timestamp: 1,
   usage: { input: 12, output: 4, total: 16 },
-} as AgentMessage;
+} satisfies AssistantMessage;
 
 describe("findLatestUncompactedAttemptUsageSnapshot", () => {
   it("uses current-attempt transcript usage when no compaction changed the context", () => {

--- a/src/agents/embedded-agent-runner/run/attempt.context-engine-helpers.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.context-engine-helpers.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import type { AssistantMessage } from "../../runtime/index.js";
+import type { AssistantMessage } from "../../../llm/types.js";
 import { findLatestUncompactedAttemptUsageSnapshot } from "./attempt.context-engine-helpers.js";
 
 const ASSISTANT_WITH_USAGE = {
@@ -10,7 +10,14 @@ const ASSISTANT_WITH_USAGE = {
   model: "gpt-5.4",
   stopReason: "stop",
   timestamp: 1,
-  usage: { input: 12, output: 4, total: 16 },
+  usage: {
+    input: 12,
+    output: 4,
+    cacheRead: 0,
+    cacheWrite: 0,
+    totalTokens: 16,
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+  },
 } satisfies AssistantMessage;
 
 describe("findLatestUncompactedAttemptUsageSnapshot", () => {

--- a/src/agents/embedded-agent-runner/run/attempt.context-engine-helpers.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.context-engine-helpers.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import type { AgentMessage } from "../../runtime/index.js";
+import { findLatestUncompactedAttemptUsageSnapshot } from "./attempt.context-engine-helpers.js";
+
+const ASSISTANT_WITH_USAGE = {
+  role: "assistant",
+  content: [],
+  usage: { input: 12, output: 4, total: 16 },
+} as AgentMessage;
+
+describe("findLatestUncompactedAttemptUsageSnapshot", () => {
+  it("uses current-attempt transcript usage when no compaction changed the context", () => {
+    expect(
+      findLatestUncompactedAttemptUsageSnapshot({
+        messagesSnapshot: [ASSISTANT_WITH_USAGE],
+        prePromptMessageCount: 0,
+        compactionOccurred: false,
+      })?.usage,
+    ).toMatchObject({ input: 12, output: 4, total: 16 });
+  });
+
+  it("does not resurrect transcript usage across a compaction retry", () => {
+    expect(
+      findLatestUncompactedAttemptUsageSnapshot({
+        messagesSnapshot: [ASSISTANT_WITH_USAGE],
+        prePromptMessageCount: 0,
+        compactionOccurred: true,
+      }),
+    ).toBeUndefined();
+  });
+});

--- a/src/agents/embedded-agent-runner/run/attempt.context-engine-helpers.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.context-engine-helpers.ts
@@ -9,7 +9,7 @@ import {
   type BootstrapMode,
 } from "../../bootstrap-mode.js";
 import type { AgentMessage } from "../../runtime/index.js";
-import { normalizeUsage, type NormalizedUsage } from "../../usage.js";
+import { hasNonzeroUsage, normalizeUsage, type NormalizedUsage } from "../../usage.js";
 import type { PromptCacheChange } from "../prompt-cache-observability.js";
 import type { EmbeddedRunAttemptResult } from "./types.js";
 export {
@@ -139,6 +139,25 @@ export function findCurrentAttemptAssistantMessage(params: {
     .find((message): message is AssistantMessage => message.role === "assistant");
 }
 
+/** Finds the newest usable per-call usage without letting a zero-usage abort erase it. */
+export function findLatestCurrentAttemptUsageSnapshot(params: {
+  messagesSnapshot: AgentMessage[];
+  prePromptMessageCount: number;
+}): { assistant: AssistantMessage; usage: NormalizedUsage } | undefined {
+  for (const message of params.messagesSnapshot
+    .slice(Math.max(0, params.prePromptMessageCount))
+    .toReversed()) {
+    if (message.role !== "assistant") {
+      continue;
+    }
+    const usage = normalizeUsage(message.usage);
+    if (hasNonzeroUsage(usage)) {
+      return { assistant: message, usage };
+    }
+  }
+  return undefined;
+}
+
 function parsePromptCacheTouchTimestamp(value: unknown): number | null {
   if (typeof value === "number" && Number.isFinite(value)) {
     return value;
@@ -186,20 +205,18 @@ export function buildLoopPromptCacheInfo(params: {
   retention?: "none" | "short" | "long";
   fallbackLastCacheTouchAt?: number | null;
 }): EmbeddedRunAttemptResult["promptCache"] {
-  const currentAttemptAssistant = findCurrentAttemptAssistantMessage({
+  const latestUsageSnapshot = findLatestCurrentAttemptUsageSnapshot({
     messagesSnapshot: params.messagesSnapshot,
     prePromptMessageCount: params.prePromptMessageCount,
   });
-  // Normalize only the assistant produced by this attempt so older transcript
-  // usage does not masquerade as a fresh cache touch.
-  const lastCallUsage = normalizeUsage(currentAttemptAssistant?.usage);
+  const lastCallUsage = latestUsageSnapshot?.usage;
 
   return buildContextEnginePromptCacheInfo({
     retention: params.retention,
     lastCallUsage,
     lastCacheTouchAt: resolvePromptCacheTouchTimestamp({
       lastCallUsage,
-      assistantTimestamp: currentAttemptAssistant?.timestamp,
+      assistantTimestamp: latestUsageSnapshot?.assistant.timestamp,
       fallbackLastCacheTouchAt: params.fallbackLastCacheTouchAt,
     }),
   });

--- a/src/agents/embedded-agent-runner/run/attempt.context-engine-helpers.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.context-engine-helpers.ts
@@ -158,6 +158,18 @@ export function findLatestCurrentAttemptUsageSnapshot(params: {
   return undefined;
 }
 
+/** Prevents transcript fallback from crossing a compaction-owned context boundary. */
+export function findLatestUncompactedAttemptUsageSnapshot(params: {
+  messagesSnapshot: AgentMessage[];
+  prePromptMessageCount: number;
+  compactionOccurred: boolean;
+}): { assistant: AssistantMessage; usage: NormalizedUsage } | undefined {
+  if (params.compactionOccurred) {
+    return undefined;
+  }
+  return findLatestCurrentAttemptUsageSnapshot(params);
+}
+
 function parsePromptCacheTouchTimestamp(value: unknown): number | null {
   if (typeof value === "number" && Number.isFinite(value)) {
     return value;

--- a/src/agents/embedded-agent-runner/run/attempt.context-engine-helpers.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.context-engine-helpers.ts
@@ -140,7 +140,7 @@ export function findCurrentAttemptAssistantMessage(params: {
 }
 
 /** Finds the newest usable per-call usage without letting a zero-usage abort erase it. */
-export function findLatestCurrentAttemptUsageSnapshot(params: {
+function findLatestCurrentAttemptUsageSnapshot(params: {
   messagesSnapshot: AgentMessage[];
   prePromptMessageCount: number;
 }): { assistant: AssistantMessage; usage: NormalizedUsage } | undefined {

--- a/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts
@@ -3225,6 +3225,35 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
     expect(promptCache?.lastCacheTouchAt).toBe(Date.parse("2026-04-16T16:49:59.536Z"));
   });
 
+  it("keeps the latest nonzero usage when an aborted assistant reports zeros", () => {
+    const completedAssistant = {
+      role: "assistant",
+      content: "tool use",
+      timestamp: "2026-04-16T16:49:59.536Z",
+      usage: { input: 38_333, output: 66, cacheRead: 120_320, total: 158_719 },
+    } as unknown as AgentMessage;
+    const abortedAssistant = {
+      role: "assistant",
+      content: "",
+      timestamp: "2026-04-16T16:50:00.000Z",
+      stopReason: "aborted",
+      usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    } as unknown as AgentMessage;
+
+    const promptCache = buildLoopPromptCacheInfo({
+      messagesSnapshot: [seedMessage, completedAssistant, abortedAssistant],
+      prePromptMessageCount: 1,
+      retention: "short",
+    });
+
+    expect(promptCache?.lastCallUsage).toMatchObject({
+      input: 38_333,
+      cacheRead: 120_320,
+      total: 158_719,
+    });
+    expect(promptCache?.lastCacheTouchAt).toBe(Date.parse("2026-04-16T16:49:59.536Z"));
+  });
+
   it("falls back to the persisted cache touch when loop usage has no cache metrics", () => {
     const toolUseAssistant = {
       role: "assistant",

--- a/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.test-support.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.test-support.ts
@@ -155,6 +155,7 @@ function createSubscriptionMock(): SubscriptionMock {
     didSendDeterministicApprovalPrompt: () => false,
     getLastToolError: () => undefined,
     getUsageTotals: () => undefined,
+    getLastAssistantUsage: () => undefined,
     getCompactionCount: () => 0,
     getLastCompactionTokensAfter: () => undefined,
     getItemLifecycle: () => ({ startedCount: 0, completedCount: 0, activeCount: 0 }),

--- a/src/agents/embedded-agent-runner/run/helpers.test.ts
+++ b/src/agents/embedded-agent-runner/run/helpers.test.ts
@@ -275,6 +275,26 @@ describe("buildUsageAgentMetaFields", () => {
     expect(fields.lastCallUsage).toEqual(latestCallUsage);
     expect(fields.promptTokens).toBeUndefined();
   });
+
+  it("does not label aggregate attempt usage as last-call usage", () => {
+    const usageAccumulator = createUsageAccumulator();
+    mergeUsageIntoAccumulator(usageAccumulator, {
+      input: 497_720,
+      output: 7_485,
+      cacheRead: 1_323_520,
+      total: 1_828_725,
+    });
+
+    const fields = buildUsageAgentMetaFields({
+      usageAccumulator,
+      lastAssistantUsage: { input: 0, output: 0, cacheRead: 0, total: 0 },
+      lastRunPromptUsage: undefined,
+    });
+
+    expect(fields.usage?.input).toBe(497_720);
+    expect(fields.lastCallUsage).toBeUndefined();
+    expect(fields.promptTokens).toBeUndefined();
+  });
 });
 
 describe("buildErrorAgentMeta", () => {

--- a/src/agents/embedded-agent-runner/run/helpers.ts
+++ b/src/agents/embedded-agent-runner/run/helpers.ts
@@ -15,7 +15,7 @@ import {
   type NormalizedUsage,
 } from "../../usage.js";
 import type { EmbeddedAgentMeta } from "../types.js";
-import { toLastCallUsage, toNormalizedUsage, type UsageAccumulator } from "../usage-accumulator.js";
+import { toNormalizedUsage, type UsageAccumulator } from "../usage-accumulator.js";
 
 type UsageSnapshot = {
   input?: number;
@@ -232,7 +232,7 @@ export function buildUsageAgentMetaFields(params: {
     ? lastAssistantUsage
     : hasNonzeroUsage(params.lastRunPromptUsage)
       ? params.lastRunPromptUsage
-      : toLastCallUsage(params.usageAccumulator);
+      : undefined;
   const promptTokens = deriveContextPromptTokens({
     lastCallUsage: params.lastRunPromptUsage,
   });

--- a/src/agents/embedded-agent-runner/usage-accumulator.test.ts
+++ b/src/agents/embedded-agent-runner/usage-accumulator.test.ts
@@ -1,10 +1,9 @@
-// Usage accumulator tests cover multi-call token aggregation and last-call
-// snapshots used for billing metadata on embedded run results.
+// Usage accumulator tests cover multi-call token aggregation used for billing
+// metadata on embedded run results.
 import { describe, expect, it } from "vitest";
 import {
   createUsageAccumulator,
   mergeUsageIntoAccumulator,
-  toLastCallUsage,
   toNormalizedUsage,
 } from "./usage-accumulator.js";
 
@@ -51,11 +50,6 @@ function createAccumulatorWithUsage(...usages: UsageInput[]) {
   return acc;
 }
 
-const emptyAccumulatorCases = [
-  { name: "toNormalizedUsage", resolve: toNormalizedUsage },
-  { name: "toLastCallUsage", resolve: toLastCallUsage },
-];
-
 describe("usage-accumulator", () => {
   describe("mergeUsageIntoAccumulator", () => {
     it("accumulates usage across multiple API calls", () => {
@@ -67,22 +61,6 @@ describe("usage-accumulator", () => {
       expect(acc.cacheRead).toBe(246_000);
       expect(acc.cacheWrite).toBe(5_000);
       expect(acc.total).toBe(251_490);
-    });
-
-    it("stores the exact final call snapshot", () => {
-      const acc = createAccumulatorWithUsage(FIRST_USAGE, FINAL_USAGE);
-
-      expect(acc.lastInput).toBe(150);
-      expect(acc.lastOutput).toBe(40);
-      expect(acc.lastReasoningTokens).toBe(7);
-      expect(acc.lastCacheRead).toBe(84_000);
-      expect(acc.lastCacheWrite).toBe(0);
-      expect(acc.lastContextUsage).toEqual({
-        state: "available",
-        promptTokens: 84_150,
-        totalTokens: 84_190,
-      });
-      expect(acc.lastTotal).toBe(84_190);
     });
 
     it("ignores undefined or zero-only usage", () => {
@@ -101,16 +79,11 @@ describe("usage-accumulator", () => {
     });
   });
 
-  describe("empty accumulator", () => {
-    it.each(emptyAccumulatorCases)(
-      "$name returns undefined for an empty accumulator",
-      ({ resolve }) => {
-        expect(resolve(createUsageAccumulator())).toBeUndefined();
-      },
-    );
-  });
-
   describe("toNormalizedUsage", () => {
+    it("returns undefined for an empty accumulator", () => {
+      expect(toNormalizedUsage(createUsageAccumulator())).toBeUndefined();
+    });
+
     it("returns accumulated totals for billing", () => {
       const acc = createUsageAccumulator();
 
@@ -155,41 +128,6 @@ describe("usage-accumulator", () => {
         cacheWrite: undefined,
         total: 150,
       });
-    });
-  });
-
-  describe("toLastCallUsage", () => {
-    it("returns the exact final call snapshot", () => {
-      const acc = createAccumulatorWithUsage(FIRST_USAGE, FINAL_USAGE);
-
-      expect(toLastCallUsage(acc)).toEqual({
-        input: 150,
-        output: 40,
-        reasoningTokens: 7,
-        cacheRead: 84_000,
-        cacheWrite: undefined,
-        contextUsage: {
-          state: "available",
-          promptTokens: 84_150,
-          totalTokens: 84_190,
-        },
-        total: 84_190,
-      });
-    });
-
-    it("preserves an unavailable context snapshot", () => {
-      const acc = createUsageAccumulator();
-      mergeUsageIntoAccumulator(acc, {
-        input: 12,
-        output: 15_104,
-        cacheRead: 819_661,
-        cacheWrite: 93_130,
-        contextUsage: { state: "unavailable" },
-        total: 927_907,
-      });
-
-      expect(toLastCallUsage(acc)?.contextUsage).toEqual({ state: "unavailable" });
-      expect(toNormalizedUsage(acc)?.contextUsage).toBeUndefined();
     });
   });
 });

--- a/src/agents/embedded-agent-runner/usage-accumulator.ts
+++ b/src/agents/embedded-agent-runner/usage-accumulator.ts
@@ -1,7 +1,7 @@
 /**
  * Accumulates and normalizes per-call token usage across embedded runs.
  */
-import type { ContextUsage, NormalizedUsage } from "../usage.js";
+import type { NormalizedUsage } from "../usage.js";
 
 export type UsageAccumulator = {
   input: number;
@@ -10,14 +10,6 @@ export type UsageAccumulator = {
   cacheWrite: number;
   reasoningTokens: number;
   total: number;
-  /** Exact usage snapshot from the most recent API call. */
-  lastInput: number;
-  lastOutput: number;
-  lastCacheRead: number;
-  lastCacheWrite: number;
-  lastContextUsage?: ContextUsage;
-  lastReasoningTokens: number;
-  lastTotal: number;
 };
 
 export const createUsageAccumulator = (): UsageAccumulator => ({
@@ -27,12 +19,6 @@ export const createUsageAccumulator = (): UsageAccumulator => ({
   cacheWrite: 0,
   reasoningTokens: 0,
   total: 0,
-  lastInput: 0,
-  lastOutput: 0,
-  lastCacheRead: 0,
-  lastCacheWrite: 0,
-  lastReasoningTokens: 0,
-  lastTotal: 0,
 });
 
 type MaybeUsage = NormalizedUsage | undefined;
@@ -69,13 +55,6 @@ export const mergeUsageIntoAccumulator = (target: UsageAccumulator, usage: Maybe
   target.cacheWrite += usage.cacheWrite ?? 0;
   target.reasoningTokens += usage.reasoningTokens ?? 0;
   target.total += callTotal;
-  target.lastInput = usage.input ?? 0;
-  target.lastOutput = usage.output ?? 0;
-  target.lastCacheRead = usage.cacheRead ?? 0;
-  target.lastCacheWrite = usage.cacheWrite ?? 0;
-  target.lastContextUsage = usage.contextUsage ? { ...usage.contextUsage } : undefined;
-  target.lastReasoningTokens = usage.reasoningTokens ?? 0;
-  target.lastTotal = callTotal;
 };
 
 export const toNormalizedUsage = (usage: UsageAccumulator): NormalizedUsage | undefined => {
@@ -96,28 +75,5 @@ export const toNormalizedUsage = (usage: UsageAccumulator): NormalizedUsage | un
     cacheWrite: usage.cacheWrite || undefined,
     ...(usage.reasoningTokens > 0 ? { reasoningTokens: usage.reasoningTokens } : {}),
     total: usage.total || undefined,
-  };
-};
-
-export const toLastCallUsage = (usage: UsageAccumulator): NormalizedUsage | undefined => {
-  const hasUsage =
-    usage.lastInput > 0 ||
-    usage.lastOutput > 0 ||
-    usage.lastCacheRead > 0 ||
-    usage.lastCacheWrite > 0 ||
-    usage.lastContextUsage !== undefined ||
-    usage.lastReasoningTokens > 0 ||
-    usage.lastTotal > 0;
-  if (!hasUsage) {
-    return undefined;
-  }
-  return {
-    input: usage.lastInput || undefined,
-    output: usage.lastOutput || undefined,
-    cacheRead: usage.lastCacheRead || undefined,
-    cacheWrite: usage.lastCacheWrite || undefined,
-    ...(usage.lastContextUsage ? { contextUsage: { ...usage.lastContextUsage } } : {}),
-    ...(usage.lastReasoningTokens > 0 ? { reasoningTokens: usage.lastReasoningTokens } : {}),
-    total: usage.lastTotal || undefined,
   };
 };

--- a/src/agents/embedded-agent-subscribe.handlers.tools.media.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.media.test.ts
@@ -78,6 +78,7 @@ function createMockContext(overrides?: {
     recordAssistantUsage: vi.fn(),
     incrementCompactionCount: vi.fn(),
     getUsageTotals: vi.fn(() => undefined),
+    getLastAssistantUsage: vi.fn(() => undefined),
     getCompactionCount: vi.fn(() => 0),
   } as unknown as EmbeddedAgentSubscribeContext;
 }

--- a/src/agents/embedded-agent-subscribe.handlers.types.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.types.ts
@@ -256,6 +256,7 @@ export type EmbeddedAgentSubscribeContext = {
   incrementCompactionCount: () => void;
   noteCompactionTokensAfter: (value: unknown) => void;
   getUsageTotals: () => NormalizedUsage | undefined;
+  getLastAssistantUsage: () => NormalizedUsage | undefined;
   getCompactionCount: () => number;
   getLastCompactionTokensAfter: () => number | undefined;
   emitAssistantStreamData: (

--- a/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.splits-long-single-line-fenced-blocks-reopen.test.ts
+++ b/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.splits-long-single-line-fenced-blocks-reopen.test.ts
@@ -85,6 +85,44 @@ describe("subscribeEmbeddedAgentSession", () => {
     await waitPromise;
     expect(resolved).toBe(true);
   });
+
+  it("clears the exact usage snapshot when compaction starts a new attempt", () => {
+    const listeners: SessionEventHandler[] = [];
+    const session = {
+      subscribe: (listener: SessionEventHandler) => {
+        listeners.push(listener);
+        return () => {};
+      },
+    } as unknown as Parameters<typeof subscribeEmbeddedAgentSession>[0]["session"];
+    const subscription = subscribeEmbeddedAgentSession({ session, runId: "run-usage-reset" });
+    const assistantMessage = {
+      role: "assistant",
+      content: [{ type: "text", text: "before compaction" }],
+      usage: {
+        input: 100,
+        output: 20,
+        cacheRead: 300,
+        cacheWrite: 0,
+        totalTokens: 420,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+      },
+    } as AssistantMessage;
+
+    for (const listener of listeners) {
+      listener({ type: "message_end", message: assistantMessage });
+    }
+    expect(subscription.getLastAssistantUsage()).toMatchObject({
+      input: 100,
+      output: 20,
+      cacheRead: 300,
+      total: 420,
+    });
+
+    for (const listener of listeners) {
+      listener({ type: "compaction_end", willRetry: true });
+    }
+    expect(subscription.getLastAssistantUsage()).toBeUndefined();
+  });
   it("resolves after compaction ends without retry", async () => {
     const listeners: SessionEventHandler[] = [];
     const session = {

--- a/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.subscribeembeddedagentsession.test.ts
+++ b/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.subscribeembeddedagentsession.test.ts
@@ -312,6 +312,31 @@ describe("subscribeEmbeddedAgentSession", () => {
       cacheWrite: undefined,
       total: 120,
     });
+    expect(subscription.getLastAssistantUsage()).toEqual({
+      input: 100,
+      output: 20,
+      total: 120,
+    });
+  });
+
+  it("retains the last nonzero call when a later aborted message reports zero usage", () => {
+    const { emit, subscription } = createSubscribedSessionHarness({ runId: "run" });
+    const usage = { input: 38_333, output: 66, cacheRead: 120_320, totalTokens: 158_719 };
+
+    emit({ type: "message_start", message: { role: "assistant" } });
+    emit({ type: "message_end", message: { role: "assistant", usage } });
+    emit({ type: "message_start", message: { role: "assistant" } });
+    emit({
+      type: "message_end",
+      message: { role: "assistant", stopReason: "aborted", usage: makeZeroUsageSnapshot() },
+    });
+
+    expect(subscription.getLastAssistantUsage()).toEqual({
+      input: 38_333,
+      output: 66,
+      cacheRead: 120_320,
+      total: 158_719,
+    });
   });
 
   it.each(THINKING_TAG_CASES)(

--- a/src/agents/embedded-agent-subscribe.ts
+++ b/src/agents/embedded-agent-subscribe.ts
@@ -1288,8 +1288,9 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
     state.lastDeliveredBlockReplyText = undefined;
     state.toolExecutionSinceLastBlockReply = false;
     // A retry is a new model attempt. A silent retry must not inherit the
-    // completed assistant from the attempt that triggered compaction.
+    // completed assistant or pre-compaction context snapshot.
     currentAttemptAssistant = undefined;
+    lastAssistantUsage = undefined;
     state.replayState = mergeEmbeddedRunReplayState(state.replayState, params.initialReplayState);
     state.livenessState = "working";
     resetAssistantMessageState(0);

--- a/src/agents/embedded-agent-subscribe.ts
+++ b/src/agents/embedded-agent-subscribe.ts
@@ -254,6 +254,7 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
     reasoningTokens: 0,
     total: 0,
   };
+  let lastAssistantUsage: ReturnType<typeof normalizeUsage>;
   let compactionCount = 0;
   let currentAttemptAssistant: AssistantMessage | undefined;
 
@@ -643,6 +644,9 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
       usage.total ??
       (usage.input ?? 0) + (usage.output ?? 0) + (usage.cacheRead ?? 0) + (usage.cacheWrite ?? 0);
     usageTotals.total += usageTotal;
+    // A terminal abort may report zeros after several completed model calls.
+    // Retain the latest committed nonzero call so context accounting stays exact.
+    lastAssistantUsage = { ...usage };
     state.assistantUsageCommitted = true;
   };
   const recordAssistantUsage = (usageLike: unknown) => {
@@ -677,6 +681,7 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
       total: usageTotals.total || derivedTotal || undefined,
     };
   };
+  const getLastAssistantUsage = () => (lastAssistantUsage ? { ...lastAssistantUsage } : undefined);
   const incrementCompactionCount = () => {
     compactionCount += 1;
   };
@@ -1345,6 +1350,7 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
     incrementCompactionCount,
     noteCompactionTokensAfter,
     getUsageTotals,
+    getLastAssistantUsage,
     getCompactionCount: () => compactionCount,
     getLastCompactionTokensAfter: () => state.lastCompactionTokensAfter,
   };
@@ -1493,6 +1499,7 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
     didSendDeterministicApprovalPrompt: () => state.deterministicApprovalPromptSent,
     getLastToolError: () => (state.lastToolError ? { ...state.lastToolError } : undefined),
     getUsageTotals,
+    getLastAssistantUsage,
     getCompactionCount: () => compactionCount,
     getLastCompactionTokensAfter: () => state.lastCompactionTokensAfter,
     waitForPendingEvents: () => state.pendingEventChain ?? Promise.resolve(),

--- a/src/agents/usage.test.ts
+++ b/src/agents/usage.test.ts
@@ -476,6 +476,20 @@ describe("deriveContextPromptTokens", () => {
 });
 
 describe("deriveSessionTotalTokens", () => {
+  it("prefers last-call usage over aggregate billing usage", () => {
+    expect(
+      deriveSessionTotalTokens({
+        lastCallUsage: { input: 38_333, output: 66, cacheRead: 120_320, total: 158_719 },
+        usage: {
+          input: 497_720,
+          output: 7_485,
+          cacheRead: 1_323_520,
+          total: 1_828_725,
+        },
+      }),
+    ).toBe(158_653);
+  });
+
   it("prefers the explicit context snapshot over aggregate billing buckets", () => {
     expect(
       deriveSessionTotalTokens({

--- a/src/agents/usage.ts
+++ b/src/agents/usage.ts
@@ -337,14 +337,8 @@ export function deriveContextPromptTokens(params: {
 
 /** Derive the session prompt-token snapshot stored for context display. */
 export function deriveSessionTotalTokens(params: {
-  usage?: {
-    input?: number;
-    output?: number;
-    total?: number;
-    cacheRead?: number;
-    cacheWrite?: number;
-    contextUsage?: ContextUsage;
-  };
+  lastCallUsage?: NormalizedUsage;
+  usage?: NormalizedUsage;
   contextTokens?: number;
   promptTokens?: number;
 }): number | undefined {
@@ -353,13 +347,14 @@ export function deriveSessionTotalTokens(params: {
     typeof promptOverride === "number" && Number.isFinite(promptOverride) && promptOverride > 0;
 
   const usage = params.usage;
-  if (!usage && !hasPromptOverride) {
+  if (!params.lastCallUsage && !usage && !hasPromptOverride) {
     return undefined;
   }
 
   // NOTE: SessionEntry.totalTokens is used as a prompt/context snapshot.
   // It intentionally excludes completion/output tokens.
   const promptTokens = deriveContextPromptTokens({
+    lastCallUsage: params.lastCallUsage,
     promptTokens: hasPromptOverride ? promptOverride : undefined,
     usage,
   });

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -1248,9 +1248,7 @@ async function finalizeCronRun(params: {
     const totalTokens =
       typeof lastCallTotalTokens === "number" && lastCallTotalTokens > 0
         ? lastCallTotalTokens
-        : lastCallUsage?.contextUsage?.state === "unavailable"
-          ? undefined
-          : deriveSessionTotalTokens({ usage, contextTokens, promptTokens });
+        : undefined;
     const runEstimatedCostUsd = resolveNonNegativeNumber(
       estimateUsageCost({
         usage,

--- a/src/cron/isolated-agent/run.usage-accounting.test.ts
+++ b/src/cron/isolated-agent/run.usage-accounting.test.ts
@@ -65,11 +65,11 @@ describe("runCronIsolatedAgentTurn usage accounting", () => {
     });
   });
 
-  it("falls back to aggregate usage when final-call usage is empty", async () => {
+  it("does not use aggregate usage when final-call usage is empty", async () => {
     const cronSession = makeCronSession();
     resolveCronSessionMock.mockReturnValue(cronSession);
     mockRunCronFallbackPassthrough();
-    deriveSessionTotalTokensMock.mockReturnValueOnce(undefined).mockReturnValueOnce(77000);
+    deriveSessionTotalTokensMock.mockReturnValueOnce(undefined);
     runEmbeddedAgentMock.mockResolvedValueOnce({
       payloads: [{ text: "done" }],
       meta: {
@@ -93,9 +93,9 @@ describe("runCronIsolatedAgentTurn usage accounting", () => {
     const result = await runCronIsolatedAgentTurn(makeIsolatedAgentParamsFixture());
 
     expect(result.status).toBe("ok");
-    expect(cronSession.sessionEntry.totalTokens).toBe(77000);
-    expect(cronSession.sessionEntry.totalTokensFresh).toBe(true);
-    expect(deriveSessionTotalTokensMock).toHaveBeenNthCalledWith(1, {
+    expect(cronSession.sessionEntry.totalTokens).toBeUndefined();
+    expect(cronSession.sessionEntry.totalTokensFresh).toBe(false);
+    expect(deriveSessionTotalTokensMock).toHaveBeenCalledWith({
       usage: {
         input: 0,
         output: 0,
@@ -105,23 +105,14 @@ describe("runCronIsolatedAgentTurn usage accounting", () => {
       contextTokens: 128000,
       promptTokens: undefined,
     });
-    expect(deriveSessionTotalTokensMock).toHaveBeenNthCalledWith(2, {
-      usage: {
-        input: 75000,
-        output: 2000,
-        cacheRead: 5000,
-        cacheWrite: 0,
-      },
-      contextTokens: 128000,
-      promptTokens: undefined,
-    });
+    expect(deriveSessionTotalTokensMock).toHaveBeenCalledTimes(1);
   });
 
-  it("falls back to aggregate usage when final-call usage is output-only", async () => {
+  it("does not use aggregate usage when final-call usage is output-only", async () => {
     const cronSession = makeCronSession();
     resolveCronSessionMock.mockReturnValue(cronSession);
     mockRunCronFallbackPassthrough();
-    deriveSessionTotalTokensMock.mockReturnValueOnce(undefined).mockReturnValueOnce(77000);
+    deriveSessionTotalTokensMock.mockReturnValueOnce(undefined);
     runEmbeddedAgentMock.mockResolvedValueOnce({
       payloads: [{ text: "done" }],
       meta: {
@@ -135,18 +126,14 @@ describe("runCronIsolatedAgentTurn usage accounting", () => {
     const result = await runCronIsolatedAgentTurn(makeIsolatedAgentParamsFixture());
 
     expect(result.status).toBe("ok");
-    expect(cronSession.sessionEntry.totalTokens).toBe(77000);
-    expect(cronSession.sessionEntry.totalTokensFresh).toBe(true);
-    expect(deriveSessionTotalTokensMock).toHaveBeenNthCalledWith(1, {
+    expect(cronSession.sessionEntry.totalTokens).toBeUndefined();
+    expect(cronSession.sessionEntry.totalTokensFresh).toBe(false);
+    expect(deriveSessionTotalTokensMock).toHaveBeenCalledWith({
       usage: { output: 125 },
       contextTokens: 128000,
       promptTokens: undefined,
     });
-    expect(deriveSessionTotalTokensMock).toHaveBeenNthCalledWith(2, {
-      usage: { input: 75000, output: 2000 },
-      contextTokens: 128000,
-      promptTokens: undefined,
-    });
+    expect(deriveSessionTotalTokensMock).toHaveBeenCalledTimes(1);
   });
 
   it("does not fall back to aggregate billing when final-call context is unavailable", async () => {


### PR DESCRIPTION
Closes #108238

## What Problem This Solves

OpenAI Responses-compatible providers can finish a multi-call tool loop with a zero-usage `aborted` assistant message. When the earlier calls reported cached prompt tokens, OpenClaw lost the last valid per-call snapshot and mislabeled the run-wide usage accumulator as `lastCallUsage`. Session persistence then stored cumulative billing usage as the current context size, causing false context-limit and compaction decisions.

## Why This Change Was Made

- The embedded subscription retains the latest committed nonzero assistant usage across a later zero-usage abort.
- Attempt settlement carries that exact per-call snapshot into prompt-cache and terminal metadata.
- Aggregate attempt usage is no longer presented or consumed as a current-context snapshot when an exact snapshot is unavailable.
- Explicit `promptTokens` and `contextUsage` snapshots keep their existing precedence, including `contextUsage: unavailable` fail-closed behavior from #99864.

## End-to-End Reproduction Conditions

The issue requires this combination; a normal successful call or an abort without cache usage does not reproduce it:

1. OpenClaw `2026.7.1` at reporter SHA `2d2ddc4`.
2. A non-CLI custom provider using the `openai-responses` API.
3. One Gateway-backed agent turn that performs several sequential model/tool calls.
4. Responses usage includes `cached_tokens` on each completed call.
5. A later call is cancelled through the Gateway, leaving a terminal `aborted` assistant with zero usage.
6. Read the persisted session entry and compare run-wide billing fields with `totalTokens`.

The Crabbox `local-container` scenario used the real `https://ollama.com/v1` endpoint and `deepseek-v4-flash:cloud`. A loopback Responses-compatible proxy changed only each completed response's usage metadata to set `cached_tokens` to 80% of `input_tokens`; model output, tool calls, prompts, and lifecycle events remained live. After four completed Responses calls, the client received `SIGTERM`, sent `chat.abort`, and the scenario read the session through `openclaw sessions`.

| Code | Completed calls | Terminal state | Persisted `totalTokens` |
|---|---:|---|---:|
| Reporter version `2d2ddc4` | 4 | aborted | `68,524` (run cumulative, reproduced) |
| Initial PR head `5d32dec` | 4 | aborted | `63,956` (still cumulative; first fix was insufficient) |
| Current PR head `039012f` | 4 | aborted | `16,114` (latest call snapshot) |

All runs used `local-container`, Node 24, an isolated state directory, real Gateway persistence, and the same live-provider flow. No API key or prompt/response content was recorded.

## User Impact

Long tool runs with prompt-cache hits no longer make a small current context appear several times larger after cancellation. When OpenClaw has no trustworthy current-context snapshot, it reports the token snapshot as unknown instead of treating cumulative billing usage as context pressure.

## Evidence

- Focused Node 24 tests: 5 files, 256 passed.
- `git diff --check`: passed.
- Full-branch autoreview: clean; no accepted/actionable findings.
- Final live proof: Crabbox provider `local-container`, lease `cbx_a65eed8de010` (`quick-prawn`), exit 0; lease stopped automatically.
