### PR TITLE
fix(googlechat): drop invalid thread resource names before send

### DIFF
--- a/extensions/googlechat/src/api.ts
+++ b/extensions/googlechat/src/api.ts
@@ -178,6 +178,19 @@ async function fetchBuffer(
   });
 }
 
+/**
+ * A Google Chat `thread` must be a `spaces/{space}/threads/{thread}` resource
+ * name that belongs to the target space. Reply routing sometimes yields other
+ * shapes — a bare id, a `spaces/{space}/messages/{message}` name, or a thread
+ * from a different (or wrongly-cased) space — and passing any of those makes the
+ * Chat API reject the whole send with `400 INVALID_ARGUMENT`. Accept only a
+ * well-formed, same-space thread name; callers drop the rest so the message
+ * still delivers to the space (as a new thread) instead of failing outright.
+ */
+function isUsableGoogleChatThreadName(thread: string, space: string): boolean {
+  return /^spaces\/[^/]+\/threads\/[^/]+$/.test(thread) && thread.startsWith(`${space}/threads/`);
+}
+
 export async function sendGoogleChatMessage(params: {
   account: ResolvedGoogleChatAccount;
   space: string;
@@ -186,6 +199,7 @@ export async function sendGoogleChatMessage(params: {
   cardsV2?: GoogleChatCardV2[];
 }): Promise<{ messageName?: string; threadName?: string } | null> {
   const { account, space, text, thread, cardsV2 } = params;
+  const usableThread = thread && isUsableGoogleChatThreadName(thread, space) ? thread : undefined;
   if (
     text &&
     (!cardsV2 || cardsV2.length === 0) &&
@@ -200,11 +214,11 @@ export async function sendGoogleChatMessage(params: {
   if (cardsV2 && cardsV2.length > 0) {
     body.cardsV2 = cardsV2;
   }
-  if (thread) {
-    body.thread = { name: thread };
+  if (usableThread) {
+    body.thread = { name: usableThread };
   }
   const urlObj = new URL(`${CHAT_API_BASE}/${space}/messages`);
-  if (thread) {
+  if (usableThread) {
     urlObj.searchParams.set("messageReplyOption", "REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD");
   }
   const url = urlObj.toString();

--- a/extensions/googlechat/src/targets.test.ts
+++ b/extensions/googlechat/src/targets.test.ts
@@ -568,6 +568,58 @@ describe("sendGoogleChatMessage", () => {
     expect(String(url)).not.toContain("messageReplyOption=");
   });
 
+  it.each([
+    ["a bare id", "113887189178345237288721356"],
+    ["a thread key without prefix", "pytxeqyhqck"],
+    ["a message resource name", "spaces/AAA/messages/1720896000000.000000"],
+    ["a space resource name", "spaces/AAA"],
+    ["a thread from a different space", "spaces/BBB/threads/xyz"],
+  ])(
+    "drops an invalid thread resource name (%s) and posts to the space",
+    async (_label, badThread) => {
+      const fetchMock = stubSuccessfulSend("spaces/AAA/messages/126");
+
+      const result = await sendGoogleChatMessage({
+        account,
+        space: "spaces/AAA",
+        text: "hello",
+        thread: badThread,
+      });
+
+      const url = mockCallArg(fetchMock);
+      const init = mockCallArg(fetchMock, 0, 1) as RequestInit | undefined;
+      // Invalid thread must not be forwarded, and the reply option must be omitted
+      // so the Chat API accepts the send instead of returning 400 INVALID_ARGUMENT.
+      expect(String(url)).not.toContain("messageReplyOption=");
+      if (typeof init?.body !== "string") {
+        throw new Error("Expected Google Chat request body");
+      }
+      const body = JSON.parse(init.body) as { thread?: unknown };
+      expect(body.thread).toBeUndefined();
+      expect(result).toEqual({ messageName: "spaces/AAA/messages/126" });
+    },
+  );
+
+  it("keeps a valid same-space thread resource name", async () => {
+    const fetchMock = stubSuccessfulSend("spaces/AAA/messages/127", "spaces/AAA/threads/xyz");
+
+    await sendGoogleChatMessage({
+      account,
+      space: "spaces/AAA",
+      text: "hello",
+      thread: "spaces/AAA/threads/xyz",
+    });
+
+    const url = mockCallArg(fetchMock);
+    const init = mockCallArg(fetchMock, 0, 1) as RequestInit | undefined;
+    expect(String(url)).toContain("messageReplyOption=REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD");
+    if (typeof init?.body !== "string") {
+      throw new Error("Expected Google Chat request body");
+    }
+    const body = JSON.parse(init.body) as { thread?: { name?: unknown } };
+    expect(body.thread?.name).toBe("spaces/AAA/threads/xyz");
+  });
+
   it("sends cardsV2 with the text fallback", async () => {
     const fetchMock = stubSuccessfulSend("spaces/AAA/messages/125");
     const cardsV2 = [


### PR DESCRIPTION
## Summary

`sendGoogleChatMessage` forwards the reply-routing `thread` straight into the
Chat API request. When routing yields something that is **not** a valid
`spaces/{space}/threads/{thread}` resource name — a bare id, a
`spaces/{space}/messages/{message}` name, or a thread from a different (or
wrongly-cased) space — the API rejects the whole send with
`400 INVALID_ARGUMENT` and the reply is silently dropped, even though the agent
already produced it and ran any side effects.

This guards the send so the `thread` field (and the `messageReplyOption`
fallback) is applied only when the thread is well-formed **and** belongs to the
target space. Otherwise the message is delivered to the space as a new thread
instead of failing outright.

Revives the approach of #28153 (auto-closed as stale) and addresses the failure
mode behind #64313. Complements the DM-only fix in #87054, which only stops
setting `replyToId` on the ingress side.

## Changes

- `extensions/googlechat/src/api.ts`: add `isUsableGoogleChatThreadName(thread, space)` and gate the `thread`/`messageReplyOption` usage on it.
- `extensions/googlechat/src/targets.test.ts`: cover the drop-invalid cases (bare id, thread key, message name, space name, foreign-space thread) and confirm a valid same-space thread is preserved.

## Test plan

- `node scripts/test-projects.mjs extensions/googlechat/src/targets.test.ts` → 39/39 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W7pvAaMii7o42ZgVFmUdk5

## What Problem This Solves

Google Chat DM replies can disappear after OpenClaw deletes the typing placeholder: an invalid reply thread is forwarded to Google Chat, which rejects the completed reply with `400 INVALID_ARGUMENT`. This is the reproduced P1 customer failure in #115742.

## Why This Change Was Made

Validate thread resource names at the shared Google Chat outbound API owner. Keep a valid same-space `spaces/{space}/threads/{thread}` target; omit malformed, message-resource, and foreign-space targets and the corresponding reply option so the reply is delivered as a new thread.

## User Impact

Completed Google Chat replies are delivered instead of silently disappearing. Valid same-space threaded replies keep their existing behavior. No new configuration or operator action is required.

## Evidence

Maintainer independently exercised the actual production `deliverGoogleChatReply -> sendGoogleChatMessage -> google-auth-library RSA/JWT OAuth -> SSRF-guarded HTTP` path against a local real HTTP server. One real OAuth token exchange authenticated every Chat request:

```text
current main: DELETE /v1/spaces/AAA/messages/typing -> 200
current main: POST thread=113887189178345237288721356 replyOption=REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD -> 400 INVALID_ARGUMENT; completed reply lost
positive control / proposed wire shape: POST thread=<omitted> replyOption=<omitted> -> 200; reply delivered
same-space control: POST thread=spaces/AAA/threads/valid -> 200; reply stays threaded
foreign-space negative: POST thread=spaces/BBB/threads/foreign -> 400
message-resource negative: POST thread=spaces/AAA/messages/message-1 -> 400
```

Independent live customer verification applied this exact guard to a real staging Google Chat bot: 4 DM exchanges over approximately 10 minutes, including a 156-second multi-tool turn; all 4 replies arrived, with zero invalid-thread errors, dropped replies, or duplicate replies: https://github.com/openclaw/openclaw/pull/108324#issuecomment-5130649428 and https://github.com/openclaw/openclaw/pull/108324#issuecomment-5130724879.

Focused contributor coverage: `node scripts/test-projects.mjs extensions/googlechat/src/targets.test.ts` (39 passing). Exact-head full hosted CI: https://github.com/openclaw/openclaw/actions/runs/30709830635.

Google Chat thread contract: https://developers.google.com/workspace/chat/api/reference/rest/v1/spaces.messages#Thread and https://developers.google.com/workspace/chat/api/reference/rest/v1/spaces.messages/create#messagereplyoption.

Fixes #115742
