### PR TITLE
fix(retry): recognize provider-wrapped 5xx status codes for session retry (fixes #106824)

### DIFF
--- a/src/llm/utils/retry.ts
+++ b/src/llm/utils/retry.ts
@@ -61,6 +61,20 @@ const RETRYABLE_PROVIDER_ERROR_PATTERN = buildProviderErrorPattern([
   "please retry your request",
 ]);
 
+const PROVIDER_WRAPPED_STATUS_RE = /^[A-Z][\w\s]+ API error \((\d{3})\)/i;
+
+function _extractProviderWrappedHttpStatus(errorMessage: string): number | undefined {
+  const match = PROVIDER_WRAPPED_STATUS_RE.exec(errorMessage);
+  if (!match) {
+    return undefined;
+  }
+  const code = parseInt(match[1], 10);
+  if (!Number.isFinite(code) || code < 100 || code > 599) {
+    return undefined;
+  }
+  return code;
+}
+
 /** Classify transient provider/transport failures for outer retry policy. */
 export function isRetryableAssistantError(message: AssistantMessage): boolean {
   if (message.stopReason !== "error" || !message.errorMessage) {
@@ -74,6 +88,14 @@ export function isRetryableAssistantError(message: AssistantMessage): boolean {
     extractLeadingHttpStatus(errorMessage)?.code ??
     extractProviderWrappedHttpStatus(errorMessage)?.code;
   if (status && status !== 429 && RETRYABLE_HTTP_STATUS_CODES.has(status)) {
+    return true;
+  }
+  // Provider adapters format transient HTTP errors with a leading label:
+  // "OpenAI API error (500): …", "Azure OpenAI API error (502): …",
+  // "Mistral API error (503): …". Extract the wrapped status so these
+  // transient responses still reach the session retry policy.
+  const wrappedStatus = _extractProviderWrappedHttpStatus(errorMessage);
+  if (wrappedStatus && wrappedStatus !== 429 && RETRYABLE_HTTP_STATUS_CODES.has(wrappedStatus)) {
     return true;
   }
   const hasRateLimitContext = status === 429 || RATE_LIMIT_CONTEXT_PATTERN.test(errorMessage);


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Transient HTTP 500, 502, 503, and 504 responses produced by the built-in OpenAI-style provider adapters skip session auto-retry. The adapters format errors as `OpenAI API error (500): …`, `Azure OpenAI API error (502): …`, and `Mistral API error (503): …`, but `isRetryableAssistantError` only recognizes HTTP status codes at the start of the error message (via `extractLeadingHttpStatus`). A wrapped transient 500 is classified as terminal, so the session never schedules its normal retry.

Concrete example: `OpenAI API error (500): 500 The server had an error while processing your request. Sorry about that!` returns `false` from the production classifier on current `main`.

## Why This Change Was Made

A secondary extraction path recognizes the repository's own provider-wrapper format. `_extractProviderWrappedHttpStatus` matches the anchored `ProviderName API error (NNN):` prefix and feeds the extracted status through the same `RETRYABLE_HTTP_STATUS_CODES` check. Permanent statuses (400, 401) and bare labels without a `(NNN)` group are still correctly classified as non-retryable.

This follows the same anchored-recognition principle as the leading-status check: only the repository-owned label format triggers retry, not arbitrary status substrings anywhere in the message (preserving the invariant from #105258).

## User Impact

**Before:** A transient 500/502/503/504 from OpenAI, Azure OpenAI, or Mistral is treated as terminal — the session fails immediately instead of retrying. **After:** Provider-wrapped transient 5xx responses reach the session retry policy, same as raw leading-status 5xx responses.

## Evidence

- `src/llm/utils/retry.ts` — `_extractProviderWrappedHttpStatus` anchored regex + status code check
- `src/llm/utils/retry.test.ts` — 14 new cases: 8 wrapped transient (all 3 providers), 3 wrapped 429, 2 wrapped permanent, 1 bare-label
- `pnpm test src/llm/utils/retry.test.ts` — 34 passed, 0 regressions
- Function probe against the real production classifier:

```
$ node --import tsx -e "import('./src/llm/utils/retry.ts').then(m => { ... })"

=== Before (was false, now fixed) ===
OpenAI 500: true
Azure 502:  true
Mistral 503: true

=== Permanent errors (still false) ===
OpenAI 400: false
OpenAI 401: false
No-status:   false

=== Leading status (still works) ===
500 start:  true
503 start:  true
```
