### PR TITLE
fix(plugins): remove stale scheduler job records on registration rollback (fixes #106825)

### DIFF
--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -2,6 +2,7 @@
 import { clearCodeModeNamespacesForPlugin } from "../agents/code-mode-namespaces.js";
 import { clearContextEnginesForOwner } from "../context-engine/registry.js";
 import { clearPluginCommandsForPlugin } from "./command-registry-state.js";
+import { clearPluginHostRuntimeState } from "./host-hook-runtime.js";
 import { clearPluginInteractiveHandlersForPlugin } from "./interactive-registry.js";
 import { createPluginApiFactory } from "./registry-api.js";
 import { createPluginRegistrars } from "./registry-registrars.js";
@@ -43,6 +44,7 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
     clearPluginInteractiveHandlersForPlugin(pluginId);
     clearCodeModeNamespacesForPlugin(pluginId);
     clearContextEnginesForOwner(`plugin:${pluginId}`);
+    clearPluginHostRuntimeState({ pluginId });
     registrars.rollbackHooks(pluginId);
   };
 


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

When a plugin calls `registerSessionSchedulerJob()` during its `register()` function and then throws an exception later in the same `register()`, the transaction rollback in `registry.ts` restores the in-memory registry (`registry.sessionSchedulerJobs`) but does not remove the live scheduler job record from `host-hook-runtime`'s module-global `schedulerJobsByPlugin` map. The stale record persists for the process lifetime — normal cleanup sweeps cannot reach it because the job is no longer in the registry.

This is a resource leak: the plugin's scheduler job entry stays in the runtime state with no owner, and the plugin's cleanup callback is never invoked.

## Why This Change Was Made

`rollbackPluginGlobalSideEffects` already clears commands, interactive handlers, code-mode namespaces, and context engines for the failed plugin. This change adds `clearPluginHostRuntimeState({ pluginId })` to also remove the plugin's scheduler job entries from the host-hook-runtime module-global state, keeping the rollback cleanup consistent across all side-effect categories.

## User Impact

**Before:** A failed plugin registration leaves a stale scheduler job record in the runtime state, leaking memory and preventing normal cleanup sweeps from tracking it. **After:** The rollback synchronously removes the plugin's scheduler job entries, so there is no residual state from a failed registration.

## Evidence

- `src/plugins/registry.ts` — one-line addition: `clearPluginHostRuntimeState({ pluginId })` in `rollbackPluginGlobalSideEffects`
- `src/plugins/host-hook-runtime.ts` — `clearPluginHostRuntimeState` already handles the `{ pluginId }` case, deleting from `schedulerJobsByPlugin`
- `pnpm test src/plugins/plugin-registration-transaction.test.ts` — 2 passed, 0 regressions
- `pnpm test src/plugins/` — all plugin tests pass
