### PR TITLE
feat: verify ClickClack setup after channel add

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
-- **ClickClack guided setup:** configure ClickClack from `openclaw onboard` or `openclaw channels add clickclack` with URL, token, and workspace prompts, default-account env fallback, and nonfatal live connection validation. Thanks @shakkernerd.
+- **ClickClack guided setup:** configure ClickClack from `openclaw onboard` or `openclaw channels add clickclack` with URL, token, and workspace prompts, default-account env fallback, nonfatal live connection validation, and gateway-aware next steps that connect automatically when OpenClaw is already running. Thanks @shakkernerd.
 - **ClickClack command menus:** publish each bot's native OpenClaw commands to ClickClack composer autocomplete at gateway startup, with per-account opt-out and nonfatal compatibility handling for older tokens and servers. Thanks @shakkernerd.
 - **Skill Workshop approvals:** run agent-initiated apply, reject, and quarantine actions without an additional approval prompt by default while preserving `skills.workshop.approvalPolicy: "pending"` as an opt-in approval gate. Thanks @shakkernerd.
 - **TUI fuzzy selectors:** delegate list matching to pi-tui, adding slash-token and alpha-number matching while removing the local matcher fork.

--- a/docs/channels/clickclack.md
+++ b/docs/channels/clickclack.md
@@ -13,14 +13,21 @@ Use this when you want an OpenClaw agent to appear as a ClickClack bot user. Cli
 ## Quick setup
 
 In ClickClack, open **Workspace settings → Integrations → OpenClaw**, create a
-bot, and copy its token. Then configure the channel and start the gateway:
+bot, and copy its token. Then configure the channel:
 
 ```bash
 openclaw channels add clickclack --base-url https://clickclack.example.com --token ccb_... --workspace default
-openclaw gateway
 ```
 
 `workspace` accepts a workspace id (`wsp_...`), slug, or display name.
+`channels add` verifies the server, token, and workspace after saving, then
+reports whether the running gateway picked up the new account. If OpenClaw is
+already running, ClickClack connects automatically and no second command is
+needed. Otherwise, start it with:
+
+```bash
+openclaw gateway
+```
 
 For guided setup, run:
 

--- a/extensions/clickclack/src/setup-core.test.ts
+++ b/extensions/clickclack/src/setup-core.test.ts
@@ -1,7 +1,14 @@
 // ClickClack tests cover non-interactive setup validation and config writes.
 import { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk/account-id";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import { describe, expect, it } from "vitest";
+import { createNonExitingRuntimeEnv } from "openclaw/plugin-sdk/plugin-test-runtime";
+import { describe, expect, it, vi } from "vitest";
+
+const verifyClickClackAccountAfterSetup = vi.hoisted(() => vi.fn());
+
+vi.mock("./setup-verify.js", () => ({
+  verifyClickClackAccountAfterSetup,
+}));
 import {
   applyClickClackCredentialConfig,
   clickClackSetupAdapter,
@@ -293,6 +300,33 @@ describe("ClickClack setup adapter", () => {
     ).toMatchObject({
       enabled: true,
       tokenFile: "/run/secrets/clickclack",
+    });
+  });
+
+  it("runs post-write verification with the saved account config", async () => {
+    const cfg = {
+      channels: {
+        clickclack: {
+          baseUrl: "https://clickclack.example",
+          token: "ccb_test",
+          workspace: "default",
+        },
+      },
+    } as OpenClawConfig;
+    const runtime = createNonExitingRuntimeEnv();
+
+    await clickClackSetupAdapter.afterAccountConfigWritten?.({
+      previousCfg: {},
+      cfg,
+      accountId: DEFAULT_ACCOUNT_ID,
+      input: {},
+      runtime,
+    });
+
+    expect(verifyClickClackAccountAfterSetup).toHaveBeenCalledWith({
+      cfg,
+      accountId: DEFAULT_ACCOUNT_ID,
+      runtime,
     });
   });
 });

--- a/extensions/clickclack/src/setup-core.ts
+++ b/extensions/clickclack/src/setup-core.ts
@@ -211,4 +211,12 @@ export const clickClackSetupAdapter: ChannelSetupAdapter = {
       useEnv: input.useEnv,
     });
   },
+  afterAccountConfigWritten: async ({ cfg, accountId, runtime }) => {
+    const { verifyClickClackAccountAfterSetup } = await import("./setup-verify.js");
+    await verifyClickClackAccountAfterSetup({
+      cfg: cfg as CoreConfig,
+      accountId,
+      runtime,
+    });
+  },
 };

--- a/extensions/clickclack/src/setup-surface.ts
+++ b/extensions/clickclack/src/setup-surface.ts
@@ -1,5 +1,4 @@
 // ClickClack plugin module implements guided setup behavior.
-import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import {
   createStandardChannelSetupStatus,
   createSetupTranslator,
@@ -10,30 +9,16 @@ import {
   type ChannelSetupWizard,
 } from "openclaw/plugin-sdk/setup";
 import { listClickClackAccountIds, resolveClickClackAccount } from "./accounts.js";
-import { createClickClackClient } from "./http-client.js";
-import { resolveWorkspaceId } from "./resolve.js";
 import {
   applyClickClackCredentialConfig,
   applyClickClackSetupConfigPatch,
   normalizeClickClackBaseUrl,
 } from "./setup-core.js";
+import { checkClickClackSetupConnection } from "./setup-verify.js";
 import type { CoreConfig, ResolvedClickClackAccount } from "./types.js";
 
 const t = createSetupTranslator();
 const channel = "clickclack" as const;
-
-function isHttpStatus(error: unknown, status: number): boolean {
-  return (
-    typeof error === "object" &&
-    error !== null &&
-    "status" in error &&
-    (error as { status?: unknown }).status === status
-  );
-}
-
-function isWorkspaceNotFound(error: unknown): boolean {
-  return error instanceof Error && error.message.startsWith("ClickClack workspace not found:");
-}
 
 function hasConfiguredClickClackCredential(account: ResolvedClickClackAccount): boolean {
   return (
@@ -166,39 +151,33 @@ export const clickClackSetupWizard: ChannelSetupWizard = {
     },
   ],
   finalize: async ({ cfg, accountId, credentialValues, prompter }) => {
-    const account = resolveClickClackAccount({
+    const result = await checkClickClackSetupConnection({
       cfg: cfg as CoreConfig,
       accountId,
+      token: credentialValues.token,
     });
-    try {
-      const client = createClickClackClient({
-        baseUrl: account.baseUrl,
-        token: credentialValues.token || account.token,
-      });
-      const me = await client.me();
-      const workspaceId = await resolveWorkspaceId(client, account.workspace);
-      const workspaces = await client.workspaces();
-      const workspace = workspaces.find((candidate) => candidate.id === workspaceId);
-      if (!workspace) {
-        throw new Error(`ClickClack workspace not found: ${account.workspace}`);
-      }
+    if (result.status === "connected") {
       await prompter.note(
         t("wizard.clickclack.connected", {
-          handle: me.handle,
-          workspace: workspace.name,
+          handle: result.handle,
+          workspace: result.workspaceName,
         }),
         t("wizard.clickclack.connectionTitle"),
       );
-    } catch (error) {
-      const message = isHttpStatus(error, 401)
-        ? t("wizard.clickclack.invalidToken")
-        : isWorkspaceNotFound(error)
-          ? t("wizard.clickclack.workspaceNotFound", { workspace: account.workspace })
-          : t("wizard.clickclack.connectionFailed", {
-              error: formatErrorMessage(error),
-            });
-      await prompter.note(message, t("wizard.clickclack.validationWarningTitle"));
+      return;
     }
+    if (result.status === "skipped-env-token" || result.status === "skipped-unconfigured") {
+      return;
+    }
+    const message =
+      result.status === "invalid-token"
+        ? t("wizard.clickclack.invalidToken")
+        : result.status === "workspace-not-found"
+          ? t("wizard.clickclack.workspaceNotFound", { workspace: result.workspace })
+          : t("wizard.clickclack.connectionFailed", {
+              error: result.error,
+            });
+    await prompter.note(message, t("wizard.clickclack.validationWarningTitle"));
   },
   disable: (cfg) => setSetupChannelEnabled(cfg, channel, false),
 };

--- a/extensions/clickclack/src/setup-verify.test.ts
+++ b/extensions/clickclack/src/setup-verify.test.ts
@@ -1,0 +1,174 @@
+// ClickClack tests cover post-write connection verification and gateway guidance.
+import { createNonExitingRuntimeEnv } from "openclaw/plugin-sdk/plugin-test-runtime";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  callGatewayFromCli: vi.fn(),
+  createClient: vi.fn(),
+  me: vi.fn(),
+  resolveWorkspaceId: vi.fn(),
+  workspaces: vi.fn(),
+}));
+
+vi.mock("openclaw/plugin-sdk/gateway-runtime", () => ({
+  callGatewayFromCli: mocks.callGatewayFromCli,
+}));
+
+vi.mock("./http-client.js", () => ({
+  createClickClackClient: (options: unknown) => {
+    mocks.createClient(options);
+    return {
+      me: mocks.me,
+      workspaces: mocks.workspaces,
+    };
+  },
+}));
+
+vi.mock("./resolve.js", () => ({
+  resolveWorkspaceId: mocks.resolveWorkspaceId,
+}));
+
+import { verifyClickClackAccountAfterSetup } from "./setup-verify.js";
+import type { CoreConfig } from "./types.js";
+
+const configuredAccount = {
+  channels: {
+    clickclack: {
+      baseUrl: "https://clickclack.example",
+      token: "ccb_test",
+      workspace: "default",
+    },
+  },
+} satisfies CoreConfig;
+
+function createRuntime() {
+  return createNonExitingRuntimeEnv();
+}
+
+async function verify(
+  cfg: CoreConfig = configuredAccount,
+  runtime = createRuntime(),
+): Promise<ReturnType<typeof createRuntime>> {
+  await verifyClickClackAccountAfterSetup({
+    cfg,
+    accountId: "default",
+    runtime,
+  });
+  return runtime;
+}
+
+describe("ClickClack post-write setup verification", () => {
+  beforeEach(() => {
+    vi.unstubAllEnvs();
+    mocks.callGatewayFromCli.mockReset().mockResolvedValue({ ok: true });
+    mocks.createClient.mockReset();
+    mocks.me.mockReset().mockResolvedValue({ id: "usr_bot", handle: "openclaw" });
+    mocks.resolveWorkspaceId.mockReset().mockResolvedValue("wsp_default");
+    mocks.workspaces
+      .mockReset()
+      .mockResolvedValue([
+        { id: "wsp_default", name: "clickclack", slug: "default", created_at: "2026-01-01" },
+      ]);
+  });
+
+  it("prints the resolved bot and workspace without blocking setup", async () => {
+    const runtime = await verify();
+
+    expect(runtime.log).toHaveBeenNthCalledWith(
+      1,
+      "Connected as @openclaw — workspace clickclack resolved.",
+    );
+    expect(runtime.log).toHaveBeenNthCalledWith(
+      2,
+      "OpenClaw is running — ClickClack will connect automatically.",
+    );
+  });
+
+  it.each([
+    {
+      name: "an invalid token",
+      arrange: () => mocks.me.mockRejectedValue({ status: 401 }),
+      expected: "ClickClack rejected the bot token (401). Copy a current token and rerun setup.",
+    },
+    {
+      name: "a missing workspace",
+      arrange: () => {
+        mocks.resolveWorkspaceId.mockResolvedValue("wsp_missing");
+        mocks.workspaces.mockResolvedValue([]);
+      },
+      expected:
+        'Workspace "default" was not found. Check the id, slug, or name, list available workspaces, and rerun setup.',
+    },
+    {
+      name: "a network failure",
+      arrange: () => mocks.me.mockRejectedValue(new Error("network unavailable")),
+      expected:
+        "Connection check failed: network unavailable. Setup was saved; fix the connection and rerun setup.",
+    },
+  ])("logs a warning for $name and continues", async ({ arrange, expected }) => {
+    arrange();
+    const runtime = createRuntime();
+
+    await expect(verify(configuredAccount, runtime)).resolves.toBe(runtime);
+    expect(runtime.log).toHaveBeenNthCalledWith(1, expected);
+    expect(runtime.log).toHaveBeenNthCalledWith(
+      2,
+      "OpenClaw is running — ClickClack will connect automatically.",
+    );
+  });
+
+  it("skips client verification when the implicit env token is unavailable", async () => {
+    vi.stubEnv("CLICKCLACK_BOT_TOKEN", "");
+    const runtime = await verify({
+      channels: {
+        clickclack: {
+          baseUrl: "https://clickclack.example",
+          workspace: "default",
+        },
+      },
+    } as CoreConfig);
+
+    expect(mocks.createClient).not.toHaveBeenCalled();
+    expect(runtime.log).toHaveBeenNthCalledWith(
+      1,
+      "Token comes from CLICKCLACK_BOT_TOKEN; verification skipped.",
+    );
+  });
+
+  it.each([
+    {
+      name: "running",
+      arrange: () => mocks.callGatewayFromCli.mockResolvedValue({ ok: true }),
+      expected: "OpenClaw is running — ClickClack will connect automatically.",
+    },
+    {
+      name: "not running",
+      arrange: () =>
+        mocks.callGatewayFromCli.mockRejectedValue(
+          Object.assign(new Error("gateway closed (1006): no listener"), {
+            name: "GatewayTransportError",
+            kind: "closed",
+            code: 1006,
+          }),
+        ),
+      expected: "Start OpenClaw to connect: openclaw gateway",
+    },
+    {
+      name: "unavailable",
+      arrange: () => mocks.callGatewayFromCli.mockRejectedValue(new Error("probe failed")),
+      expected:
+        "If OpenClaw is running it connects automatically; otherwise start it with: openclaw gateway",
+    },
+  ])("prints the gateway next step when status is $name", async ({ arrange, expected }) => {
+    arrange();
+    const runtime = await verify();
+
+    expect(runtime.log).toHaveBeenNthCalledWith(2, expected);
+    expect(mocks.callGatewayFromCli).toHaveBeenCalledWith(
+      "health",
+      { timeout: "1000", json: true },
+      undefined,
+      { expectFinal: false, progress: false },
+    );
+  });
+});

--- a/extensions/clickclack/src/setup-verify.ts
+++ b/extensions/clickclack/src/setup-verify.ts
@@ -1,19 +1,27 @@
 // ClickClack plugin module implements shared setup connection verification.
 import { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk/account-id";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { hasConfiguredSecretInput } from "openclaw/plugin-sdk/setup";
 import { resolveClickClackAccount } from "./accounts.js";
 import { createClickClackClient } from "./http-client.js";
 import { resolveWorkspaceId } from "./resolve.js";
 import type { CoreConfig, ResolvedClickClackAccount } from "./types.js";
 
-export type ClickClackSetupConnectionResult =
+type ClickClackSetupConnectionResult =
   | { status: "connected"; handle: string; workspaceName: string }
   | { status: "invalid-token" }
   | { status: "workspace-not-found"; workspace: string }
   | { status: "failed"; error: string }
   | { status: "skipped-env-token" }
   | { status: "skipped-unconfigured" };
+
+type ClickClackGatewayStatus = "running" | "not-running" | "unavailable";
+
+const GATEWAY_RUNNING_MESSAGE = "OpenClaw is running — ClickClack will connect automatically.";
+const GATEWAY_NOT_RUNNING_MESSAGE = "Start OpenClaw to connect: openclaw gateway";
+const GATEWAY_UNKNOWN_MESSAGE =
+  "If OpenClaw is running it connects automatically; otherwise start it with: openclaw gateway";
 
 function isHttpStatus(error: unknown, status: number): boolean {
   return (
@@ -92,5 +100,95 @@ export async function checkClickClackSetupConnection(params: {
       status: "failed",
       error: formatErrorMessage(error),
     };
+  }
+}
+
+function isGatewayNotRunningError(error: unknown): boolean {
+  if (
+    typeof error === "object" &&
+    error !== null &&
+    "name" in error &&
+    "kind" in error &&
+    "code" in error &&
+    (error as { name?: unknown }).name === "GatewayTransportError" &&
+    (error as { kind?: unknown }).kind === "closed" &&
+    (error as { code?: unknown }).code === 1006
+  ) {
+    return true;
+  }
+  const message = formatErrorMessage(error).toLowerCase();
+  return message.includes("econnrefused") || message.includes("connection refused");
+}
+
+async function probeClickClackGatewayStatus(): Promise<ClickClackGatewayStatus> {
+  try {
+    const { callGatewayFromCli } = await import("openclaw/plugin-sdk/gateway-runtime");
+    await callGatewayFromCli("health", { timeout: "1000", json: true }, undefined, {
+      expectFinal: false,
+      progress: false,
+    });
+    return "running";
+  } catch (error) {
+    return isGatewayNotRunningError(error) ? "not-running" : "unavailable";
+  }
+}
+
+function formatClickClackConnectionLog(
+  result: ClickClackSetupConnectionResult,
+): string | undefined {
+  switch (result.status) {
+    case "connected":
+      return `Connected as @${result.handle} — workspace ${result.workspaceName} resolved.`;
+    case "invalid-token":
+      return "ClickClack rejected the bot token (401). Copy a current token and rerun setup.";
+    case "workspace-not-found":
+      return `Workspace "${result.workspace}" was not found. Check the id, slug, or name, list available workspaces, and rerun setup.`;
+    case "failed":
+      return `Connection check failed: ${result.error}. Setup was saved; fix the connection and rerun setup.`;
+    case "skipped-env-token":
+      return "Token comes from CLICKCLACK_BOT_TOKEN; verification skipped.";
+    case "skipped-unconfigured":
+      return undefined;
+  }
+  return undefined;
+}
+
+function formatClickClackGatewayLog(status: ClickClackGatewayStatus): string {
+  switch (status) {
+    case "running":
+      return GATEWAY_RUNNING_MESSAGE;
+    case "not-running":
+      return GATEWAY_NOT_RUNNING_MESSAGE;
+    case "unavailable":
+      return GATEWAY_UNKNOWN_MESSAGE;
+  }
+  return GATEWAY_UNKNOWN_MESSAGE;
+}
+
+export async function verifyClickClackAccountAfterSetup(params: {
+  cfg: CoreConfig;
+  accountId: string;
+  runtime: RuntimeEnv;
+}): Promise<void> {
+  try {
+    const result = await checkClickClackSetupConnection({
+      cfg: params.cfg,
+      accountId: params.accountId,
+    });
+    const message = formatClickClackConnectionLog(result);
+    if (message) {
+      params.runtime.log(message);
+    }
+  } catch (error) {
+    params.runtime.log(
+      `Connection check failed: ${formatErrorMessage(error)}. Setup was saved; fix the connection and rerun setup.`,
+    );
+  }
+
+  try {
+    const status = await probeClickClackGatewayStatus();
+    params.runtime.log(formatClickClackGatewayLog(status));
+  } catch {
+    params.runtime.log(GATEWAY_UNKNOWN_MESSAGE);
   }
 }

--- a/extensions/clickclack/src/setup-verify.ts
+++ b/extensions/clickclack/src/setup-verify.ts
@@ -1,0 +1,96 @@
+// ClickClack plugin module implements shared setup connection verification.
+import { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk/account-id";
+import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import { hasConfiguredSecretInput } from "openclaw/plugin-sdk/setup";
+import { resolveClickClackAccount } from "./accounts.js";
+import { createClickClackClient } from "./http-client.js";
+import { resolveWorkspaceId } from "./resolve.js";
+import type { CoreConfig, ResolvedClickClackAccount } from "./types.js";
+
+export type ClickClackSetupConnectionResult =
+  | { status: "connected"; handle: string; workspaceName: string }
+  | { status: "invalid-token" }
+  | { status: "workspace-not-found"; workspace: string }
+  | { status: "failed"; error: string }
+  | { status: "skipped-env-token" }
+  | { status: "skipped-unconfigured" };
+
+function isHttpStatus(error: unknown, status: number): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "status" in error &&
+    (error as { status?: unknown }).status === status
+  );
+}
+
+function isWorkspaceNotFound(error: unknown): boolean {
+  return error instanceof Error && error.message.startsWith("ClickClack workspace not found:");
+}
+
+function usesUnavailableImplicitEnvToken(
+  account: ResolvedClickClackAccount,
+  tokenOverride: string,
+): boolean {
+  return (
+    account.accountId === DEFAULT_ACCOUNT_ID &&
+    Boolean(account.baseUrl && account.workspace) &&
+    !tokenOverride &&
+    !account.token &&
+    !hasConfiguredSecretInput(account.config.token) &&
+    !account.config.tokenFile?.trim()
+  );
+}
+
+export async function checkClickClackSetupConnection(params: {
+  cfg: CoreConfig;
+  accountId?: string;
+  token?: string;
+}): Promise<ClickClackSetupConnectionResult> {
+  let workspaceInput = "";
+  try {
+    const account = resolveClickClackAccount({
+      cfg: params.cfg,
+      accountId: params.accountId,
+    });
+    workspaceInput = account.workspace;
+    const token = params.token?.trim() || account.token;
+    if (usesUnavailableImplicitEnvToken(account, token)) {
+      return { status: "skipped-env-token" };
+    }
+    if (!account.baseUrl || !account.workspace || !token) {
+      return { status: "skipped-unconfigured" };
+    }
+
+    const client = createClickClackClient({
+      baseUrl: account.baseUrl,
+      token,
+    });
+    const me = await client.me();
+    const workspaceId = await resolveWorkspaceId(client, account.workspace);
+    const workspaces = await client.workspaces();
+    const workspace = workspaces.find((candidate) => candidate.id === workspaceId);
+    if (!workspace) {
+      throw new Error(`ClickClack workspace not found: ${account.workspace}`);
+    }
+    return {
+      status: "connected",
+      handle: me.handle,
+      workspaceName: workspace.name,
+    };
+  } catch (error) {
+    if (isHttpStatus(error, 401)) {
+      return { status: "invalid-token" };
+    }
+    if (isWorkspaceNotFound(error)) {
+      return {
+        status: "workspace-not-found",
+        workspace: workspaceInput,
+      };
+    }
+    return {
+      status: "failed",
+      error: formatErrorMessage(error),
+    };
+  }
+}


### PR DESCRIPTION
## Summary

- share ClickClack connection verification between guided setup and post-write setup
- verify the bot identity and workspace after `channels add` without rolling back saved configuration on failure
- detect whether the OpenClaw gateway is running and print the appropriate next step
- document automatic connection when a running gateway hot-reloads the new account

## Testing

- `pnpm test extensions/clickclack/src/setup-core.test.ts extensions/clickclack/src/setup-surface.test.ts extensions/clickclack/src/setup-verify.test.ts`
- `pnpm check:changed`
- manually verified with a live ClickClack setup and running OpenClaw gateway