### PR TITLE
fix(codex): app-server failures corrupt Unicode diagnostics across stderr chunks

### DIFF
--- a/extensions/codex/src/app-server/client.test.ts
+++ b/extensions/codex/src/app-server/client.test.ts
@@ -430,6 +430,21 @@ describe("CodexAppServerClient", () => {
     );
   });
 
+  it("preserves split UTF-8 in app-server stderr exit errors", async () => {
+    const harness = createClientHarness();
+    clients.push(harness.client);
+    const pending = harness.client.request("test/method");
+    const character = Buffer.from("猫", "utf8");
+
+    harness.process.stderr.write(Buffer.concat([Buffer.from("fatal "), character.subarray(0, 1)]));
+    harness.process.stderr.write(Buffer.concat([character.subarray(1), Buffer.from(" boot\n")]));
+    harness.process.emit("exit", 1, null);
+
+    await expect(pending).rejects.toThrow(
+      'codex app-server exited: code=1 signal=null stderr="fatal 猫 boot"',
+    );
+  });
+
   it("does not write to stdin after the child process exits", () => {
     const harness = createClientHarness();
     clients.push(harness.client);

--- a/extensions/codex/src/app-server/client.ts
+++ b/extensions/codex/src/app-server/client.ts
@@ -260,8 +260,8 @@ export class CodexAppServerClient {
     child.stdout.on("error", (error) =>
       this.closeWithError(error instanceof Error ? error : new Error(String(error))),
     );
-    child.stderr.on("data", (chunk: Buffer | string) => {
-      const text = chunk.toString("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stderr.on("data", (text: string) => {
       this.stderrTail = appendBoundedTail(this.stderrTail, text, CODEX_APP_SERVER_STDERR_TAIL_MAX);
       const trimmed = text.trim();
       if (trimmed) {


### PR DESCRIPTION
## What Problem This Solves

Codex app-server stderr diagnostics were decoded independently per raw pipe chunk. A multibyte UTF-8 character split across chunks became replacement characters, so an exit such as `fatal 猫 boot` surfaced as `fatal ��� boot`.

## Why This Change Was Made

The child stderr stream now owns stateful UTF-8 decoding via `setEncoding("utf8")` before text reaches logging, bounded-tail retention, redaction, or exit errors. Node's Readable contract explicitly preserves multibyte characters delivered across chunks at this seam.

Sibling Codex source confirms the contract: stdio JSON-RPC uses stdin/stdout, while app-server tracing and startup diagnostics write stderr. No protocol, configuration, error-shape, or tail-budget change.

## Changes

- Configure Codex app-server stderr for stateful UTF-8 decoding.
- Type stderr data events as strings after encoding is set.
- Add a client regression that splits the three-byte UTF-8 encoding of `猫` across two writes.
- Rebase on current main and drop the stale unrelated shared-client fixture commit.

## User Impact

Codex app-server failure diagnostics preserve complete Unicode characters across OS pipe chunk boundaries.

## Evidence

Exact head: `d4dfa49ecda36c8bf3dd89e7abdc03415a8ae51b`.

```text
env -u NODE_PATH node scripts/run-vitest.mjs extensions/codex/src/app-server/client.test.ts extensions/codex/src/app-server/shared-client.test.ts
Test Files  2 passed (2)
Tests  81 passed (81)
```

Temporarily restoring the old per-chunk decoder makes the focused client suite fail 1/29 with `fatal ��� boot`; restoring stream decoding passes 29/29.

Hosted changed gate: https://github.com/openclaw/openclaw/actions/runs/29498221119 (`exitCode: 0`). Autoreview found no accepted/actionable findings.

## Intentionally out of scope

- No app-server protocol or transport framing changes.
- No configuration or compatibility path.
- No unrelated shared-client fixture change.
