### PR TITLE
fix(plugins): keep official plugin config across bundled-to-external moves, harden npm metadata parsing

### DIFF
--- a/src/commands/doctor/shared/stale-plugin-config.test.ts
+++ b/src/commands/doctor/shared/stale-plugin-config.test.ts
@@ -4,7 +4,6 @@ import type { OpenClawConfig } from "../../../config/config.js";
 import type { PluginInstallRecord } from "../../../config/types.plugins.js";
 import type { PluginManifestRecord } from "../../../plugins/manifest-registry.js";
 import * as manifestRegistry from "../../../plugins/manifest-registry.js";
-import { VERSION_BOUND_RUNTIME_PLUGIN_POLICY_IDS_BY_SURFACE } from "./configured-runtime-plugin-installs.js";
 import {
   collectStalePluginConfigWarnings,
   maybeRepairStalePluginConfig,
@@ -55,18 +54,18 @@ describe("doctor stale plugin config helpers", () => {
   it("finds stale plugin policy and entry refs", () => {
     const hits = scanStalePluginConfig({
       plugins: {
-        allow: ["discord", "acpx"],
+        allow: ["discord", "stale-plugin"],
         deny: ["openai", "missing-deny"],
         entries: {
           "voice-call": { enabled: true },
-          acpx: { enabled: true },
+          "stale-plugin": { enabled: true },
         },
       },
     } as OpenClawConfig);
 
     expect(hits).toEqual([
       {
-        pluginId: "acpx",
+        pluginId: "stale-plugin",
         pathLabel: "plugins.allow",
         surface: "allow",
       },
@@ -76,8 +75,8 @@ describe("doctor stale plugin config helpers", () => {
         surface: "deny",
       },
       {
-        pluginId: "acpx",
-        pathLabel: "plugins.entries.acpx",
+        pluginId: "stale-plugin",
+        pathLabel: "plugins.entries.stale-plugin",
         surface: "entries",
       },
     ]);
@@ -86,19 +85,19 @@ describe("doctor stale plugin config helpers", () => {
   it("removes stale plugin ids from policy lists and entries without changing valid refs", () => {
     const result = maybeRepairStalePluginConfig({
       plugins: {
-        allow: ["discord", "acpx", "voice-call"],
+        allow: ["discord", "stale-plugin", "voice-call"],
         deny: ["openai", "missing-deny"],
         entries: {
           "voice-call": { enabled: true },
-          acpx: { enabled: true },
+          "stale-plugin": { enabled: true },
         },
       },
     } as OpenClawConfig);
 
     expect(result.changes).toEqual([
-      "- plugins.allow: removed 1 stale plugin id (acpx)",
+      "- plugins.allow: removed 1 stale plugin id (stale-plugin)",
       "- plugins.deny: removed 1 stale plugin id (missing-deny)",
-      "- plugins.entries: removed 1 stale plugin entry (acpx)",
+      "- plugins.entries: removed 1 stale plugin entry (stale-plugin)",
     ]);
     expect(result.config.plugins?.allow).toEqual(["discord", "voice-call"]);
     expect(result.config.plugins?.deny).toEqual(["openai"]);
@@ -144,18 +143,26 @@ describe("doctor stale plugin config helpers", () => {
     });
   });
 
-  it("stale-plugin-config removes codex from allowlist when called without preservePluginIds (repair-sequencing passes preservePluginIds)", () => {
+  it("preserves official external plugin config before installation", () => {
     const result = maybeRepairStalePluginConfig({
       plugins: {
-        allow: ["codex"],
+        allow: ["codex", "missing-plugin"],
+        deny: ["codex", "missing-deny"],
+        entries: {
+          codex: { enabled: true },
+          "missing-plugin": { enabled: true },
+        },
       },
     } as OpenClawConfig);
 
-    // maybeRepairStalePluginConfig alone removes codex because it is not in
-    // knownIds. The preservation of version-bound runtime plugins happens at
-    // the caller (repair-sequencing.ts) via preservePluginIds.
-    expect(result.changes).toEqual(["- plugins.allow: removed 1 stale plugin id (codex)"]);
-    expect(result.config.plugins?.allow).toEqual([]);
+    expect(result.changes).toEqual([
+      "- plugins.allow: removed 1 stale plugin id (missing-plugin)",
+      "- plugins.deny: removed 1 stale plugin id (missing-deny)",
+      "- plugins.entries: removed 1 stale plugin entry (missing-plugin)",
+    ]);
+    expect(result.config.plugins?.allow).toEqual(["codex"]);
+    expect(result.config.plugins?.deny).toEqual(["codex"]);
+    expect(result.config.plugins?.entries).toEqual({ codex: { enabled: true } });
   });
 
   it("preserves codex in policy surfaces while the version-bound plugin is absent", () => {
@@ -266,12 +273,12 @@ describe("doctor stale plugin config helpers", () => {
   it("keeps built-in channel ids in restrictive plugin config", () => {
     const result = maybeRepairStalePluginConfig({
       plugins: {
-        allow: ["telegram", "whatsapp", "acpx"],
+        allow: ["telegram", "whatsapp", "stale-plugin"],
         deny: ["openai", "missing-deny"],
         entries: {
           telegram: { enabled: true },
           whatsapp: { enabled: true },
-          acpx: { enabled: true },
+          "stale-plugin": { enabled: true },
         },
       },
       channels: {
@@ -283,9 +290,9 @@ describe("doctor stale plugin config helpers", () => {
     } as OpenClawConfig);
 
     expect(result.changes).toEqual([
-      "- plugins.allow: removed 1 stale plugin id (acpx)",
+      "- plugins.allow: removed 1 stale plugin id (stale-plugin)",
       "- plugins.deny: removed 1 stale plugin id (missing-deny)",
-      "- plugins.entries: removed 1 stale plugin entry (acpx)",
+      "- plugins.entries: removed 1 stale plugin entry (stale-plugin)",
     ]);
     expect(result.config.plugins?.allow).toEqual(["telegram", "whatsapp"]);
     expect(result.config.plugins?.deny).toEqual(["openai"]);
@@ -387,9 +394,9 @@ describe("doctor stale plugin config helpers", () => {
     const cfg = {
       plugins: {
         enabled: false,
-        allow: ["acpx"],
+        allow: ["stale-plugin"],
         entries: {
-          acpx: { enabled: true },
+          "stale-plugin": { enabled: true },
         },
       },
       channels: {
@@ -437,9 +444,9 @@ describe("doctor stale plugin config helpers", () => {
 
     const cfg = {
       plugins: {
-        allow: ["acpx"],
+        allow: ["stale-plugin"],
         entries: {
-          acpx: { enabled: true },
+          "stale-plugin": { enabled: true },
         },
       },
     } as OpenClawConfig;
@@ -447,13 +454,13 @@ describe("doctor stale plugin config helpers", () => {
     const hits = scanStalePluginConfig(cfg);
     expect(hits).toEqual([
       {
-        pluginId: "acpx",
+        pluginId: "stale-plugin",
         pathLabel: "plugins.allow",
         surface: "allow",
       },
       {
-        pluginId: "acpx",
-        pathLabel: "plugins.entries.acpx",
+        pluginId: "stale-plugin",
+        pathLabel: "plugins.entries.stale-plugin",
         surface: "entries",
       },
     ]);
@@ -470,22 +477,12 @@ describe("doctor stale plugin config helpers", () => {
     expect(warnings.at(-1)).toContain("Auto-removal is paused");
   });
 
-  it("filters version-bound Codex policy from actionable stale warnings", () => {
+  it("keeps official allow ids out of actionable stale warnings", () => {
     const cfg = {
-      models: {
-        providers: {
-          openai: {
-            baseUrl: "https://api.openai.com/v1",
-            models: [],
-            agentRuntime: { id: "openclaw" },
-          },
-        },
-      },
       plugins: {
-        allow: ["codex", "acpx"],
+        allow: ["codex", "stale-plugin"],
         entries: {
-          codex: {},
-          acpx: { enabled: true },
+          "stale-plugin": { enabled: true },
         },
       },
     } as OpenClawConfig;
@@ -493,18 +490,13 @@ describe("doctor stale plugin config helpers", () => {
     const hits = scanStalePluginConfig(cfg);
     expect(hits).toEqual([
       {
-        pluginId: "codex",
+        pluginId: "stale-plugin",
         pathLabel: "plugins.allow",
         surface: "allow",
       },
       {
-        pluginId: "acpx",
-        pathLabel: "plugins.allow",
-        surface: "allow",
-      },
-      {
-        pluginId: "acpx",
-        pathLabel: "plugins.entries.acpx",
+        pluginId: "stale-plugin",
+        pathLabel: "plugins.entries.stale-plugin",
         surface: "entries",
       },
     ]);
@@ -512,10 +504,9 @@ describe("doctor stale plugin config helpers", () => {
       collectStalePluginConfigWarnings({
         hits,
         doctorFixCommand: "openclaw doctor --fix",
-        surfacePreservePluginIds: VERSION_BOUND_RUNTIME_PLUGIN_POLICY_IDS_BY_SURFACE,
       }),
     ).toEqual([
-      "- Stale plugin references (plugins.allow/deny/entries): acpx.",
+      "- Stale plugin references (plugins.allow/deny/entries): stale-plugin.",
       '- Run "openclaw doctor --fix" to remove stale plugin ids and dangling channel references.',
     ]);
   });
@@ -533,101 +524,13 @@ describe("doctor stale plugin config helpers", () => {
     expect(maybeRepairStalePluginConfig(cfg)).toEqual({ config: cfg, changes: [] });
   });
 
-  it("uses the scan environment snapshot for implicit OpenAI routing", () => {
-    const cfg = {
-      plugins: {
-        entries: {
-          codex: {},
-        },
-      },
-    } as OpenClawConfig;
-
-    expect(
-      scanStalePluginConfig(cfg, {
-        OPENAI_BASE_URL: "https://proxy.example.invalid/v1",
-      }),
-    ).toStrictEqual([]);
-    expect(
-      scanStalePluginConfig(cfg, {
-        OPENAI_BASE_URL: "https://api.openai.com/v1",
-      }),
-    ).toEqual([
-      {
-        pluginId: "codex",
-        pathLabel: "plugins.entries.codex",
-        surface: "entries",
-      },
-    ]);
-  });
-
-  it("keeps Codex entry diagnostics when OpenAI wildcard policy falls back to Codex", () => {
-    const cfg = {
-      models: {
-        providers: {
-          openai: {
-            baseUrl: "https://api.openai.com/v1",
-            models: [],
-            agentRuntime: { id: "pi" },
-          },
-        },
-      },
-      agents: {
-        defaults: {
-          models: {
-            "openai/*": { agentRuntime: { id: "default" } },
-          },
-        },
-      },
-      plugins: {
-        entries: {
-          codex: {},
-        },
-      },
-    } as OpenClawConfig;
-
-    expect(scanStalePluginConfig(cfg)).toEqual([
-      {
-        pluginId: "codex",
-        pathLabel: "plugins.entries.codex",
-        surface: "entries",
-      },
-    ]);
-  });
-
-  it("still reports an explicitly enabled missing Codex plugin entry as stale", () => {
-    const cfg = {
-      models: {
-        providers: {
-          openai: {
-            baseUrl: "https://api.openai.com/v1",
-            models: [],
-            agentRuntime: { id: "pi" },
-          },
-        },
-      },
-      plugins: {
-        entries: {
-          codex: { enabled: true },
-        },
-      },
-    } as OpenClawConfig;
-
-    expect(scanStalePluginConfig(cfg)).toEqual([
-      {
-        pluginId: "codex",
-        pathLabel: "plugins.entries.codex",
-        surface: "entries",
-      },
-    ]);
-  });
-
   it("treats legacy OpenAI Codex plugin ids as stale during scan and repair", () => {
     const cfg = {
       plugins: {
-        allow: ["openai-codex", "acpx"],
+        allow: ["openai-codex", "stale-plugin"],
         entries: {
           "openai-codex": { enabled: true },
-          acpx: { enabled: true },
+          "stale-plugin": { enabled: true },
         },
       },
     } as OpenClawConfig;
@@ -639,7 +542,7 @@ describe("doctor stale plugin config helpers", () => {
         surface: "allow",
       },
       {
-        pluginId: "acpx",
+        pluginId: "stale-plugin",
         pathLabel: "plugins.allow",
         surface: "allow",
       },
@@ -649,8 +552,8 @@ describe("doctor stale plugin config helpers", () => {
         surface: "entries",
       },
       {
-        pluginId: "acpx",
-        pathLabel: "plugins.entries.acpx",
+        pluginId: "stale-plugin",
+        pathLabel: "plugins.entries.stale-plugin",
         surface: "entries",
       },
     ]);

--- a/src/commands/doctor/shared/stale-plugin-config.ts
+++ b/src/commands/doctor/shared/stale-plugin-config.ts
@@ -2,11 +2,14 @@
 import { sanitizeForLog } from "../../../../packages/terminal-core/src/ansi.js";
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../../../agents/agent-scope.js";
 import { CHANNEL_IDS } from "../../../channels/ids.js";
-import { shouldSuppressMissingCodexPluginDiagnostics } from "../../../config/codex-plugin-diagnostics.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import { normalizePluginId } from "../../../plugins/config-state.js";
 import { loadInstalledPluginIndexInstallRecordsSync } from "../../../plugins/installed-plugin-index-records.js";
 import { loadManifestMetadataSnapshot } from "../../../plugins/manifest-contract-eligibility.js";
+import {
+  listOfficialExternalPluginCatalogEntries,
+  resolveOfficialExternalPluginId,
+} from "../../../plugins/official-external-plugin-catalog.js";
 import { defaultSlotIdForKey, type PluginSlotKey } from "../../../plugins/slots.js";
 import { asObjectRecord } from "./object.js";
 import {
@@ -25,6 +28,7 @@ type StalePluginConfigHit = {
 
 type StalePluginRegistryState = {
   knownIds: Set<string>;
+  officialIds: Set<string>;
   knownChannelIds: Set<string>;
   missingInstalledIds: Set<string>;
   hasDiscoveryErrors: boolean;
@@ -42,6 +46,12 @@ function collectPluginRegistryState(
     env: environment,
   }).manifestRegistry;
   const knownIds = new Set(registry.plugins.map((plugin) => plugin.id));
+  // Official catalog config remains valid even when its package is not installed yet.
+  const officialIds = new Set(
+    listOfficialExternalPluginCatalogEntries()
+      .map((entry) => normalizePluginId(resolveOfficialExternalPluginId(entry) ?? ""))
+      .filter(Boolean),
+  );
   const installedIds = new Set<string>();
   for (const pluginId of Object.keys(cfg.plugins?.installs ?? {})) {
     const normalized = normalizePluginId(pluginId);
@@ -72,6 +82,7 @@ function collectPluginRegistryState(
   }
   return {
     knownIds,
+    officialIds,
     knownChannelIds,
     missingInstalledIds: new Set([...installedIds].filter((pluginId) => !knownIds.has(pluginId))),
     hasDiscoveryErrors: registry.diagnostics.some((diag) => diag.level === "error"),
@@ -98,20 +109,15 @@ export function scanStalePluginConfig(
     return [];
   }
   const environment = env ?? process.env;
-  return scanStalePluginConfigWithState(
-    cfg,
-    collectPluginRegistryState(cfg, environment),
-    environment,
-  );
+  return scanStalePluginConfigWithState(cfg, collectPluginRegistryState(cfg, environment));
 }
 
 function scanStalePluginConfigWithState(
   cfg: OpenClawConfig,
   registryState: StalePluginRegistryState,
-  env: NodeJS.ProcessEnv,
 ): StalePluginConfigHit[] {
   const plugins = asObjectRecord(cfg.plugins);
-  const { knownIds } = registryState;
+  const { knownIds, officialIds } = registryState;
   const hits: StalePluginConfigHit[] = [];
   const staleEvidenceIds = new Set(registryState.missingInstalledIds);
 
@@ -122,7 +128,12 @@ function scanStalePluginConfigWithState(
         continue;
       }
       const pluginId = normalizePluginId(rawPluginId);
-      if (!pluginId || knownIds.has(pluginId) || registryState.knownChannelIds.has(pluginId)) {
+      if (
+        !pluginId ||
+        knownIds.has(pluginId) ||
+        officialIds.has(pluginId) ||
+        registryState.knownChannelIds.has(pluginId)
+      ) {
         continue;
       }
       hits.push({ pluginId: rawPluginId, pathLabel: `plugins.${surface}`, surface });
@@ -134,10 +145,12 @@ function scanStalePluginConfigWithState(
   if (entries) {
     for (const rawPluginId of Object.keys(entries)) {
       const pluginId = normalizePluginId(rawPluginId);
-      if (!pluginId || knownIds.has(pluginId) || registryState.knownChannelIds.has(pluginId)) {
-        continue;
-      }
-      if (pluginId === "codex" && shouldSuppressMissingCodexPluginDiagnostics(cfg, env)) {
+      if (
+        !pluginId ||
+        knownIds.has(pluginId) ||
+        officialIds.has(pluginId) ||
+        registryState.knownChannelIds.has(pluginId)
+      ) {
         continue;
       }
       hits.push({
@@ -353,7 +366,7 @@ export function maybeRepairStalePluginConfig(
   }
 
   const hits = filterRepairableStalePluginHits({
-    hits: scanStalePluginConfigWithState(cfg, registryState, environment),
+    hits: scanStalePluginConfigWithState(cfg, registryState),
     preservePluginIds: params?.preservePluginIds,
     surfacePreservePluginIds: params?.surfacePreservePluginIds,
   });

--- a/src/config/config.plugin-validation.test.ts
+++ b/src/config/config.plugin-validation.test.ts
@@ -1001,7 +1001,8 @@ describe("config plugin validation", () => {
       expect(res.warnings ?? []).toContainEqual(
         expect.objectContaining({
           path: "plugins.allow",
-          message: expect.stringContaining("plugin not installed: codex"),
+          message:
+            "plugin not installed: codex — install the official external plugin with: openclaw plugins install @openclaw/codex",
         }),
       );
     });

--- a/src/config/plugin-auto-enable.core.test.ts
+++ b/src/config/plugin-auto-enable.core.test.ts
@@ -977,6 +977,25 @@ describe("applyPluginAutoEnable core", () => {
     expect(result.changes).toContain("discord plugin config present, added to plugin allowlist.");
   });
 
+  it("preserves official external plugin entries before installation", () => {
+    const result = materializePluginAutoEnableCandidates({
+      config: {
+        plugins: {
+          allow: ["glueclaw"],
+          entries: {
+            codex: { enabled: true },
+          },
+        },
+      },
+      candidates: [],
+      env,
+      manifestRegistry: makeRegistry([]),
+    });
+
+    expect(result.config.plugins?.allow).toEqual(["glueclaw", "codex"]);
+    expect(result.changes).toContain("codex plugin config present, added to plugin allowlist.");
+  });
+
   it("does not preserve stale configured plugin entries in restrictive plugins.allow", () => {
     const result = materializePluginAutoEnableCandidates({
       config: {

--- a/src/config/plugin-auto-enable.shared.ts
+++ b/src/config/plugin-auto-enable.shared.ts
@@ -20,6 +20,7 @@ import type { PluginDiscoveryResult } from "../plugins/discovery.js";
 import { collectConfiguredSpeechProviderIds } from "../plugins/gateway-startup-speech-providers.js";
 import { resolveInstalledPluginIndexPolicyHash } from "../plugins/installed-plugin-index-policy.js";
 import type { PluginManifestRecord, PluginManifestRegistry } from "../plugins/manifest-registry.js";
+import { isOfficialExternalPluginId } from "../plugins/official-external-plugin-catalog.js";
 import { loadPluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
 import { resolveOwningPluginIdsForModelRef } from "../plugins/providers.js";
 import { resolvePluginSetupAutoEnableReasons } from "../plugins/setup-registry.js";
@@ -968,7 +969,10 @@ function isKnownPluginId(pluginId: string, manifestRegistry: PluginManifestRegis
   if (normalizeChatChannelId(pluginId)) {
     return true;
   }
-  return manifestRegistry.plugins.some((plugin) => plugin.id === pluginId);
+  return (
+    manifestRegistry.plugins.some((plugin) => plugin.id === pluginId) ||
+    isOfficialExternalPluginId(pluginId)
+  );
 }
 
 function materializeConfiguredPluginEntryAllowlist(params: {

--- a/src/infra/install-source-utils.test.ts
+++ b/src/infra/install-source-utils.test.ts
@@ -188,8 +188,8 @@ describe("resolveNpmSpecMetadata", () => {
   const npmViewMetadata = {
     name: "@openclaw/codex",
     version: "2026.6.11",
-    "dist.integrity": "sha512-test-integrity",
-    "dist.shasum": "abc123",
+    "dist.integrity": "placeholder",
+    "dist.shasum": "placeholder",
     openclaw: {
       extensions: ["./index.ts"],
     },
@@ -209,8 +209,8 @@ describe("resolveNpmSpecMetadata", () => {
         name: "@openclaw/codex",
         version: "2026.6.11",
         resolvedSpec: "@openclaw/codex@2026.6.11",
-        integrity: "sha512-test-integrity",
-        shasum: "abc123",
+        integrity: "placeholder",
+        shasum: "placeholder",
         packageOpenClaw: {
           extensions: ["./index.ts"],
         },
@@ -218,21 +218,142 @@ describe("resolveNpmSpecMetadata", () => {
     });
   });
 
-  it("rejects multi-version arrays instead of guessing which integrity to trust", async () => {
+  it("selects the newest multi-version entry satisfying the requested range", async () => {
     mockPackCommandResult({
       stdout: JSON.stringify([
+        {
+          ...npmViewMetadata,
+          version: "2026.5.9",
+          "dist.integrity": "older-placeholder",
+        },
         npmViewMetadata,
         {
           ...npmViewMetadata,
           version: "2026.6.12",
-          "dist.integrity": "sha512-other-integrity",
+          "dist.integrity": "newer-placeholder",
+        },
+        {
+          ...npmViewMetadata,
+          version: "2026.7.0-beta.1",
+          "dist.integrity": "prerelease-placeholder",
         },
       ]),
     });
 
-    await expect(resolveNpmSpecMetadata({ spec: "@openclaw/codex@^2026.6" })).resolves.toEqual({
+    await expect(resolveNpmSpecMetadata({ spec: "@openclaw/codex@^2026.6.0" })).resolves.toEqual({
+      ok: true,
+      metadata: expect.objectContaining({
+        version: "2026.6.12",
+        integrity: "newer-placeholder",
+      }),
+    });
+  });
+
+  it("prefers the max satisfying version over publication order", async () => {
+    // npm view arrays follow publication order: a backport published after a
+    // higher release must not win range resolution.
+    mockPackCommandResult({
+      stdout: JSON.stringify([
+        {
+          ...npmViewMetadata,
+          version: "2026.6.12",
+          "dist.integrity": "newer-placeholder",
+        },
+        {
+          ...npmViewMetadata,
+          version: "2026.6.9",
+          "dist.integrity": "backport-placeholder",
+        },
+      ]),
+    });
+
+    await expect(resolveNpmSpecMetadata({ spec: "@openclaw/codex@^2026.6.0" })).resolves.toEqual({
+      ok: true,
+      metadata: expect.objectContaining({
+        version: "2026.6.12",
+        integrity: "newer-placeholder",
+      }),
+    });
+  });
+
+  it("fails when no multi-version entry satisfies the requested range", async () => {
+    mockPackCommandResult({
+      stdout: JSON.stringify([
+        {
+          ...npmViewMetadata,
+          version: "2025.1.0",
+          "dist.integrity": "older-placeholder",
+        },
+      ]),
+    });
+
+    await expect(resolveNpmSpecMetadata({ spec: "@openclaw/codex@^2026.6.0" })).resolves.toEqual({
       ok: false,
-      error: "npm view produced incomplete package metadata",
+      error: "npm view produced incomplete package metadata (missing: name, version)",
+      category: "metadata-env",
+    });
+  });
+
+  it("uses the last multi-version entry when the selector is not a semver range", async () => {
+    mockPackCommandResult({
+      stdout: JSON.stringify([npmViewMetadata, { ...npmViewMetadata, version: "2026.6.12" }]),
+    });
+
+    const result = await resolveNpmSpecMetadata({ spec: "@openclaw/codex@latest" });
+
+    expect(result).toEqual({
+      ok: true,
+      metadata: expect.objectContaining({ version: "2026.6.12" }),
+    });
+  });
+
+  it("normalizes nested dist metadata", async () => {
+    mockPackCommandResult({
+      stdout: JSON.stringify({
+        name: "@openclaw/codex",
+        version: "2026.6.11",
+        dist: { integrity: "nested-placeholder", shasum: "nested-placeholder" },
+      }),
+    });
+
+    const result = await resolveNpmSpecMetadata({ spec: "@openclaw/codex" });
+
+    expect(result).toEqual({
+      ok: true,
+      metadata: {
+        name: "@openclaw/codex",
+        version: "2026.6.11",
+        resolvedSpec: "@openclaw/codex@2026.6.11",
+        integrity: "nested-placeholder",
+        shasum: "nested-placeholder",
+      },
+    });
+  });
+
+  it("accepts metadata without an openclaw block", async () => {
+    const { openclaw: _openclaw, ...withoutOpenClaw } = npmViewMetadata;
+    mockPackCommandResult({ stdout: JSON.stringify(withoutOpenClaw) });
+
+    const result = await resolveNpmSpecMetadata({ spec: "@openclaw/codex" });
+
+    expect(result).toEqual({
+      ok: true,
+      metadata: {
+        name: "@openclaw/codex",
+        version: "2026.6.11",
+        resolvedSpec: "@openclaw/codex@2026.6.11",
+        integrity: "placeholder",
+        shasum: "placeholder",
+      },
+    });
+  });
+
+  it("reports which required metadata fields are missing", async () => {
+    mockPackCommandResult({ stdout: JSON.stringify({ version: "2026.6.11" }) });
+
+    await expect(resolveNpmSpecMetadata({ spec: "@openclaw/codex" })).resolves.toEqual({
+      ok: false,
+      error: "npm view produced incomplete package metadata (missing: name)",
       category: "metadata-env",
     });
   });

--- a/src/infra/install-source-utils.ts
+++ b/src/infra/install-source-utils.ts
@@ -4,7 +4,11 @@ import path from "node:path";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
-import { gt as gtSemver, satisfies as satisfiesSemver, validRange as validSemverRange } from "semver";
+import {
+  gt as gtSemver,
+  satisfies as satisfiesSemver,
+  validRange as validSemverRange,
+} from "semver";
 import { runCommandWithTimeout } from "../process/exec.js";
 import { resolveUserPath } from "../utils.js";
 import { resolveArchiveKind } from "./archive.js";

--- a/src/infra/install-source-utils.ts
+++ b/src/infra/install-source-utils.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
+import { gt as gtSemver, satisfies as satisfiesSemver, validRange as validSemverRange } from "semver";
 import { runCommandWithTimeout } from "../process/exec.js";
 import { resolveUserPath } from "../utils.js";
 import { resolveArchiveKind } from "./archive.js";
@@ -57,11 +58,42 @@ export function createNpmMetadataEnv(
   return env;
 }
 
-function normalizeNpmViewMetadata(value: unknown): NpmSpecResolution | null {
-  // npm 12 always wraps `npm view --json` results in an array, while older
-  // releases unwrap a single match. Multiple matches are ambiguous for
-  // integrity checks, so only normalize the equivalent singleton shapes.
-  const entry = Array.isArray(value) && value.length === 1 ? value[0] : value;
+function resolveNpmSpecVersionSelector(spec: string): string | undefined {
+  const separator = spec.lastIndexOf("@");
+  return separator > 0 ? normalizeOptionalString(spec.slice(separator + 1)) : undefined;
+}
+
+function selectNpmViewMetadataEntry(value: unknown, spec: string): unknown {
+  if (!Array.isArray(value)) {
+    return value;
+  }
+  const entries = value.filter((entry) => isRecord(entry) && !Array.isArray(entry));
+  const selector = resolveNpmSpecVersionSelector(spec);
+  const range = selector ? validSemverRange(selector) : null;
+  if (range) {
+    // npm view output order tracks publication, not SemVer (a backport can be
+    // published after a higher release), so pick the max satisfying version.
+    let best: { entry: unknown; version: string } | undefined;
+    for (const entry of entries) {
+      const version = normalizeOptionalString(entry.version);
+      if (!version || !satisfiesSemver(version, range)) {
+        continue;
+      }
+      if (!best || gtSemver(version, best.version)) {
+        best = { entry, version };
+      }
+    }
+    // A recognized range with no satisfying entry must fail the metadata read
+    // rather than silently resolve outside the requested constraint.
+    return best?.entry;
+  }
+  return entries.at(-1);
+}
+
+function normalizeNpmViewMetadata(value: unknown, spec: string): NpmSpecResolution | null {
+  // npm output varies by version, selector, and field projection. npm orders
+  // view arrays ascending, so non-semver selectors intentionally use the last entry.
+  const entry = selectNpmViewMetadataEntry(value, spec);
   if (!isRecord(entry) || Array.isArray(entry)) {
     return null;
   }
@@ -126,11 +158,14 @@ export async function resolveNpmSpecMetadata(params: { spec: string; timeoutMs?:
 
   try {
     const parsed = JSON.parse(res.stdout.trim()) as unknown;
-    const metadata = normalizeNpmViewMetadata(parsed);
+    const metadata = normalizeNpmViewMetadata(parsed, params.spec);
     if (!metadata?.name || !metadata.version) {
+      const missingFields = [!metadata?.name ? "name" : null, !metadata?.version ? "version" : null]
+        .filter((field): field is string => field !== null)
+        .join(", ");
       return {
         ok: false,
-        error: "npm view produced incomplete package metadata",
+        error: `npm view produced incomplete package metadata (missing: ${missingFields})`,
         category: "metadata-env",
       };
     }

--- a/src/plugins/official-external-plugin-catalog.ts
+++ b/src/plugins/official-external-plugin-catalog.ts
@@ -1271,6 +1271,17 @@ export function listOfficialExternalPluginCatalogEntries(): OfficialExternalPlug
   return dedupeOfficialExternalPluginCatalogEntries(bundledOfficialExternalPluginCatalogEntries());
 }
 
+/** Returns whether an id is the canonical id of an official external plugin. */
+export function isOfficialExternalPluginId(pluginId: string): boolean {
+  const normalized = normalizeOptionalString(pluginId)?.toLowerCase();
+  if (!normalized) {
+    return false;
+  }
+  return listOfficialExternalPluginCatalogEntries().some(
+    (entry) => resolveOfficialExternalPluginId(entry)?.toLowerCase() === normalized,
+  );
+}
+
 /** Resolves official external plugin owners for configured capability provider ids. */
 export function resolveOfficialExternalProviderContractPluginIds(params: {
   contract: OfficialExternalProviderContract;


### PR DESCRIPTION
## What Problem This Solves

Three install/doctor resilience bugs around the codex bundled→external transition:

1. **#107226** — `doctor --fix` silently dropped the `plugins.allow` entry for a bundled→externalized plugin (codex) on machines where the external package was not yet installed: the doctor stale-config scan and plugin auto-enable only accepted ids from the discovered manifest registry, so an official-but-not-installed id looked like garbage. That unregistered the agent harness while the gateway reported healthy.
2. **#107842** — `npm view <spec> … --json` metadata normalization only unwrapped singleton arrays and one dist shape; multi-version output, dotted vs nested `dist` keys, or an absent `openclaw` block collapsed to "npm view produced incomplete package metadata" and blocked gateway startup during `@openclaw/codex` install.
3. **#107219** — an unknown CLI command could crash instead of printing suggestions: the codex plugin's `register()` called `api.runtime.state.openSyncKeyedStore` eagerly, and the base (non-proxied) plugin runtime rejects state access by design (`src/plugins/runtime/index.ts:334-341`).

## Why This Change Was Made

- **Official-catalog ids are valid pre-install config**: the doctor stale-plugin scan and auto-enable now treat ids from the official external-plugin catalog as known even when not installed (`installed` diagnostics remain actionable), and only genuinely unknown ids are pruned. This also *deletes* the codex-specific `shouldSuppressMissingCodexPluginDiagnostics` special case from the doctor scan in favor of the generic rule — one fewer hardcoded plugin id in core.
- **Robust npm metadata**: handles object and multi-version array output, selects the **maximum satisfying semver** (npm view arrays follow publication order — a backport published after a higher release must not win), fails closed when a recognized range has no satisfying entry (never silently resolves outside the requested constraint), accepts flat `dist.*` and nested `dist` shapes, tolerates missing `openclaw` blocks, and names the missing fields in the error.
- **Lazy binding store** (landed with #108311 alongside its regression test, noted here for the record): plugin registration defers `openSyncKeyedStore` to first binding use, so control-plane loads (CLI suggestions use manifest/light metadata — verified: `src/plugins/cli-registry-loader.ts`, `extensions/codex/cli-metadata.ts`) can never crash on state access.

## User Impact

- Upgrading through the codex bundled→external transition no longer silently kills the agent harness; operators get an actionable "allowed but not installed" state instead of a vanished config entry.
- `openclaw plugins install` / gateway startup survives npm registry metadata shape variance and never pins a version outside the requested range.
- Typo'd CLI commands print suggestions instead of a register crash.

## Evidence

- Focused suites (all pass): install-source-utils 25 (new: multi-version selection, max-satisfying over publication order, fail-closed unmatched range, dotted/nested dist, absent openclaw, missing-field error), doctor stale-plugin-config 17, plugin auto-enable + validation 167, codex plugin register 22 (incl. base-runtime no-crash regression, landed with #108311).
- Remote changed-surface gate (implementation round): format, typechecks, lint, boundaries, guards — green.
- Autoreview (Codex gpt-5.6-sol, xhigh): clean after two review-driven fixes (max-satisfying semver instead of positional order; fail-closed unmatched range).

Fixes #107226
Fixes #107842
Fixes #107219
