### PR TITLE
fix(skills): prevent plan-document output in Skill Workshop proposal_content

### DIFF
--- a/src/agents/skill-workshop-prompt.ts
+++ b/src/agents/skill-workshop-prompt.ts
@@ -10,6 +10,7 @@ export function buildSkillWorkshopPromptSection(): string[] {
     "## Skill Workshop",
     "Durable reusable skill/playbook/workflow work: `skill_workshop`; never write proposal/skill files directly.",
     "Generated = pending proposal. Apply/reject/quarantine only explicit user ask.",
+    "proposal_content = final skill body content, not a plan or change description.",
     "",
   ];
 }

--- a/src/agents/skill-workshop-prompt.ts
+++ b/src/agents/skill-workshop-prompt.ts
@@ -10,7 +10,7 @@ export function buildSkillWorkshopPromptSection(): string[] {
     "## Skill Workshop",
     "Durable reusable skill/playbook/workflow work: `skill_workshop`; never write proposal/skill files directly.",
     "Generated = pending proposal. Apply/reject/quarantine only explicit user ask.",
-    "proposal_content = final skill body content, not a plan or change description.",
+    "proposal_content = complete final skill body, never plan/diff; update/revise preserves unchanged content.",
     "",
   ];
 }

--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -789,11 +789,12 @@ describe("buildAgentSystemPrompt", () => {
   it("instructs models to use skill_workshop only when the tool is available", () => {
     const section = buildSkillWorkshopPromptSection();
     const sectionText = section.join("\n");
-    expect(section.length).toBeLessThanOrEqual(4);
+    expect(section.length).toBeLessThanOrEqual(5);
     expect(sectionText).toContain("Durable reusable skill/playbook/workflow work");
     expect(sectionText).toContain("`skill_workshop`");
     expect(sectionText).toContain("Generated = pending proposal");
     expect(sectionText).toContain("only explicit user ask");
+    expect(sectionText).toContain("final skill body content");
 
     const withoutTool = buildAgentSystemPrompt({
       workspaceDir: "/tmp/openclaw",

--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -788,13 +788,13 @@ describe("buildAgentSystemPrompt", () => {
 
   it("instructs models to use skill_workshop only when the tool is available", () => {
     const section = buildSkillWorkshopPromptSection();
-    const sectionText = section.join("\n");
-    expect(section.length).toBeLessThanOrEqual(5);
-    expect(sectionText).toContain("Durable reusable skill/playbook/workflow work");
-    expect(sectionText).toContain("`skill_workshop`");
-    expect(sectionText).toContain("Generated = pending proposal");
-    expect(sectionText).toContain("only explicit user ask");
-    expect(sectionText).toContain("final skill body content");
+    expect(section).toEqual([
+      "## Skill Workshop",
+      "Durable reusable skill/playbook/workflow work: `skill_workshop`; never write proposal/skill files directly.",
+      "Generated = pending proposal. Apply/reject/quarantine only explicit user ask.",
+      "proposal_content = complete final skill body, never plan/diff; update/revise preserves unchanged content.",
+      "",
+    ]);
 
     const withoutTool = buildAgentSystemPrompt({
       workspaceDir: "/tmp/openclaw",

--- a/src/agents/tools/skill-workshop-tool.test.ts
+++ b/src/agents/tools/skill-workshop-tool.test.ts
@@ -44,6 +44,16 @@ describe("skill_workshop tool", () => {
     expect(schema).toContain("shortens the proposal listing entry");
   });
 
+  it("documents that proposal_content must be final skill body content, not a plan or change description", () => {
+    const tool = createSkillWorkshopTool({ workspaceDir: "/tmp/openclaw" });
+    const schema = JSON.stringify(tool.parameters);
+
+    expect(schema).toContain("final skill body");
+    expect(schema).toContain("not a plan");
+    expect(schema).toContain("change description");
+    expect(schema).toContain("Proposal frontmatter is added automatically");
+  });
+
   it("is exposed in the OpenClaw tool set", async () => {
     const workspaceDir = await tempDirs.make("openclaw-skill-workshop-tool-");
     const tools = createOpenClawTools({

--- a/src/agents/tools/skill-workshop-tool.test.ts
+++ b/src/agents/tools/skill-workshop-tool.test.ts
@@ -47,10 +47,15 @@ describe("skill_workshop tool", () => {
   it("documents that proposal_content must be final skill body content, not a plan or change description", () => {
     const tool = createSkillWorkshopTool({ workspaceDir: "/tmp/openclaw" });
     const schema = JSON.stringify(tool.parameters);
+    const proposalOnlySchema = JSON.stringify(
+      createSkillWorkshopTool({ workspaceDir: "/tmp/openclaw", proposalOnly: true }).parameters,
+    );
 
     expect(schema).toContain("final skill body");
     expect(schema).toContain("not a plan");
     expect(schema).toContain("change description");
+    expect(schema).toContain("preserve all existing content");
+    expect(proposalOnlySchema).toContain("preserve all existing content");
     expect(schema).toContain("Proposal frontmatter is added automatically");
   });
 
@@ -688,7 +693,8 @@ describe("skill_workshop tool", () => {
       action: "update",
       skill_name: "weather-planner",
       description: "Refresh weather planning steps",
-      proposal_content: "# Weather Planner\n\nCheck weather, alerts, and timing.\n",
+      proposal_content:
+        "# Weather Planner\n\n## Steps\n\nCheck weather before outdoor recommendations.\nCheck alerts and timing.\n\n## Tips\n\nPack layers.\n",
     });
 
     expect((update.content[0] as { text: string }).text).toBe(
@@ -699,6 +705,25 @@ describe("skill_workshop tool", () => {
       kind: "update",
       skillKey: "weather-planner",
     });
+
+    const revisedUpdate = await tool.execute("call-revise-update", {
+      action: "revise",
+      proposal_id: (update.details as { id: string }).id,
+      proposal_content:
+        "# Weather Planner\n\n## Steps\n\nCheck weather before outdoor recommendations.\nCheck alerts, timing, and location.\n\n## Tips\n\nPack layers.\n",
+    });
+    expect(revisedUpdate.details).toMatchObject({ kind: "update", proposedVersion: "v2" });
+    await tool.execute("call-apply-update", {
+      action: "apply",
+      proposal_id: (revisedUpdate.details as { id: string }).id,
+    });
+    const revisedSkill = await fs.readFile(
+      path.join(workspaceDir, "skills", "weather-planner", "SKILL.md"),
+      "utf8",
+    );
+    expect(revisedSkill).toContain("Check weather before outdoor recommendations.");
+    expect(revisedSkill).toContain("Check alerts, timing, and location.");
+    expect(revisedSkill).toContain("## Tips\n\nPack layers.");
 
     const rejected = await tool.execute("call-3", {
       action: "create",

--- a/src/agents/tools/skill-workshop-tool.ts
+++ b/src/agents/tools/skill-workshop-tool.ts
@@ -122,8 +122,8 @@ function buildSkillWorkshopToolSchema(proposalOnly: boolean, supportsCompletion:
       proposal_content: Type.Optional(
         Type.String({
           description: proposalOnly
-            ? "Complete final skill body for action=create or action=revise. Must be the full skill content ready to become the active SKILL.md — not a plan, diff, change description, or implementation notes. Proposal frontmatter is added automatically. Keep under configured skills.workshop.maxSkillBytes; default max is 40000 bytes."
-            : "Complete final skill body for action=create, action=update, or action=revise. Must be the full skill content ready to become the active SKILL.md — not a plan, diff, change description, or implementation notes. For update/revise, reproduce all existing sections with modifications applied. Proposal frontmatter is added automatically. Keep under configured skills.workshop.maxSkillBytes; default max is 40000 bytes.",
+            ? "Complete final skill body for action=create or action=revise. Must be the full skill content ready to become the active SKILL.md — not a plan, diff, change description, or implementation notes. On revise, preserve all existing content except changes the user explicitly requested. Proposal frontmatter is added automatically. Keep under configured skills.workshop.maxSkillBytes; default max is 40000 bytes."
+            : "Complete final skill body for action=create, action=update, or action=revise. Must be the full skill content ready to become the active SKILL.md — not a plan, diff, change description, or implementation notes. On update/revise, preserve all existing content except changes the user explicitly requested. Proposal frontmatter is added automatically. Keep under configured skills.workshop.maxSkillBytes; default max is 40000 bytes.",
         }),
       ),
       support_files: Type.Optional(

--- a/src/agents/tools/skill-workshop-tool.ts
+++ b/src/agents/tools/skill-workshop-tool.ts
@@ -122,8 +122,8 @@ function buildSkillWorkshopToolSchema(proposalOnly: boolean, supportsCompletion:
       proposal_content: Type.Optional(
         Type.String({
           description: proposalOnly
-            ? "Full proposed procedure markdown for action=create or action=revise. It will be stored as PROPOSAL.md. Keep under configured skills.workshop.maxSkillBytes; default max is 40000 bytes."
-            : "Full proposed procedure markdown for action=create, action=update, or action=revise. It will be stored as PROPOSAL.md. Keep under configured skills.workshop.maxSkillBytes; default max is 40000 bytes.",
+            ? "Complete final skill body for action=create or action=revise. Must be the full skill content ready to become the active SKILL.md — not a plan, diff, change description, or implementation notes. Proposal frontmatter is added automatically. Keep under configured skills.workshop.maxSkillBytes; default max is 40000 bytes."
+            : "Complete final skill body for action=create, action=update, or action=revise. Must be the full skill content ready to become the active SKILL.md — not a plan, diff, change description, or implementation notes. For update/revise, reproduce all existing sections with modifications applied. Proposal frontmatter is added automatically. Keep under configured skills.workshop.maxSkillBytes; default max is 40000 bytes.",
         }),
       ),
       support_files: Type.Optional(


### PR DESCRIPTION
Closes #107708

## What Problem This Solves

Fixes an issue where Skill Workshop could return a plan, diff, or change description instead of a complete proposed skill body during create, update, or revision flows.

## Why This Change Was Made

The model-facing prompt and tool schemas now require the complete final skill body. Update and revision contracts also require unchanged existing content to be preserved. This is narrowly a generation-contract fix: it does not validate arbitrary proposal content or make applying an unsafe proposal impossible; that separate apply-boundary work remains tracked in #107707.

## User Impact

Skill Workshop proposals are now explicitly instructed to be directly reviewable and applicable, with existing skill content retained unless the requested revision changes it.

## Evidence

- Focused lifecycle and system-prompt tests: 117 passed.
- An update/revise/apply regression test proves original skill content survives a revision round-trip while requested additions are retained.
- Both normal and internal review tool schemas are covered.
- Prompt-section ordering is asserted as an exact array to protect deterministic prompt-cache bytes.
- Hosted changed-surface gate passed: https://github.com/openclaw/openclaw/actions/runs/29497850003

AI-assisted maintainer repair and validation completed before landing.
