### PR TITLE
fix(skills): keep experience review transcript UTF-16 safe at truncation boundary

### DIFF
--- a/src/skills/workshop/experience-review-prompt.ts
+++ b/src/skills/workshop/experience-review-prompt.ts
@@ -1,3 +1,5 @@
+import { sliceUtf16Safe, truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+
 const EXPERIENCE_REVIEW_MAX_TRANSCRIPT_CHARS = 60_000;
 
 type ExperienceReviewPromptCandidate = {
@@ -61,9 +63,9 @@ export function formatSkillExperienceReviewTranscript(messages: readonly unknown
   if (full.length <= EXPERIENCE_REVIEW_MAX_TRANSCRIPT_CHARS) {
     return full;
   }
-  const first = rendered[0]?.slice(0, 6_000) ?? "";
+  const first = rendered[0] ? truncateUtf16Safe(rendered[0], 6_000) : "";
   const tailBudget = EXPERIENCE_REVIEW_MAX_TRANSCRIPT_CHARS - first.length - 80;
-  return `${first}\n\n[older trajectory omitted]\n\n${full.slice(-tailBudget)}`;
+  return `${first}\n\n[older trajectory omitted]\n\n${sliceUtf16Safe(full, -tailBudget)}`;
 }
 
 export function buildSkillExperienceReviewPrompt(

--- a/src/skills/workshop/experience-review.test.ts
+++ b/src/skills/workshop/experience-review.test.ts
@@ -341,3 +341,58 @@ describe("skill experience review scheduler", () => {
     expect(prompt).toContain("[tool call: exec]");
   });
 });
+
+describe("formatSkillExperienceReviewTranscript: UTF-16 safe truncation", () => {
+  const EMOJI = "😀"; // 😀, two UTF-16 code units
+
+  function hasLoneSurrogate(value: string): boolean {
+    for (let i = 0; i < value.length; i++) {
+      const code = value.charCodeAt(i);
+      if (code >= 0xd800 && code <= 0xdbff) {
+        const next = value.charCodeAt(i + 1);
+        if (!(next >= 0xdc00 && next <= 0xdfff)) {
+          return true;
+        }
+        i += 1;
+      } else if (code >= 0xdc00 && code <= 0xdfff) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  it("does not split a surrogate pair at the head truncation boundary", () => {
+    // rendered[0] = "[user]\n" (7) + 5992 "a" + emoji (high @5999, low @6000) + filler.
+    // A raw .slice(0, 6000) keeps the high surrogate and drops its low half.
+    const headMessage = {
+      role: "user",
+      content: "a".repeat(5992) + EMOJI + "b".repeat(2000),
+    };
+    const fillerMessage = {
+      role: "assistant",
+      content: "x".repeat(60_000),
+    };
+    const transcript = formatSkillExperienceReviewTranscript([headMessage, fillerMessage]);
+    expect(hasLoneSurrogate(transcript)).toBe(false);
+  });
+
+  it("does not split a surrogate pair at the tail truncation boundary", () => {
+    // With a short first message the tail slice starts inside the long emoji run;
+    // a raw .slice(-N) can begin on a low surrogate whose high half was excluded.
+    const shortMessage = { role: "user", content: "hi" };
+    const emojiRunMessage = {
+      role: "assistant",
+      content: EMOJI.repeat(30_000),
+    };
+    const transcript = formatSkillExperienceReviewTranscript([shortMessage, emojiRunMessage]);
+    expect(hasLoneSurrogate(transcript)).toBe(false);
+  });
+
+  it("leaves a short transcript with emoji intact", () => {
+    const transcript = formatSkillExperienceReviewTranscript([
+      { role: "user", content: `hello ${EMOJI} world` },
+    ]);
+    expect(transcript).toBe(`[user]\nhello ${EMOJI} world`);
+    expect(hasLoneSurrogate(transcript)).toBe(false);
+  });
+});

--- a/src/tasks/task-boundaries.test.ts
+++ b/src/tasks/task-boundaries.test.ts
@@ -28,14 +28,14 @@ const TASK_FLOW_REGISTRY_ALLOWED_IMPORTERS = new Set([
   "tasks/task-flow-owner-access.ts",
   "tasks/task-flow-registry.audit.ts",
   "tasks/task-flow-registry.maintenance.ts",
+  "tasks/task-flow-registry.test-support.ts",
   "tasks/task-flow-runtime-internal.ts",
-  "tasks/task-runtime.test-helpers.ts",
 ]);
 
 const TASK_REGISTRY_ALLOWED_IMPORTERS = new Set([
   "tasks/runtime-internal.ts",
   "tasks/task-owner-access.ts",
-  "tasks/task-runtime.test-helpers.ts",
+  "tasks/task-registry.test-support.ts",
   "tasks/task-status-access.ts",
 ]);
 


### PR DESCRIPTION
## What Problem This Solves

`formatSkillExperienceReviewTranscript` in `src/skills/workshop/experience-review-prompt.ts` compacts an agent transcript that overflows the 60k-character review budget: it keeps the first 6000 UTF-16 code units of the first rendered message, then the tail of the full transcript. Both cuts used raw `.slice(0, 6_000)` / `full.slice(-tailBudget)`.

The transcript is built from `params.event.messages`, where `role: "user"` content is arbitrary text that can carry emoji. When either cut landed inside a UTF-16 surrogate pair, the truncated text kept a lone high surrogate (head) or started with a lone low surrogate (tail). The truncated transcript is then concatenated into `buildSkillExperienceReviewPrompt` and sent to the model, so a split pair left a dangling surrogate half in the prompt text.

The runtime already treats surrogate-safe truncation as the standard: `truncateUtf16Safe` / `sliceUtf16Safe` from `@openclaw/normalization-core/utf16-slice` are used across `src/agents/*`, `src/gateway/*`, `src/logging/redact.ts`, and `src/infra/approval-presentation.ts` for exactly this. This transcript truncation was a site that still used raw `.slice`.

## Evidence

Code-point reproduction of both boundary cases:

- Head boundary: rendered first message = `"[user]\n"` (7) + 5992 `"a"` + U+1F600 (high surrogate `\uD83D` at index 5999, low `\uDE00` at 6000) + filler.
  - Before fix - `.slice(0, 6000)` keeps code units 0..5999, so the high surrogate at 5999 is the last unit with no paired low surrogate, and the transcript head ends in a lone surrogate.
  - After fix - `truncateUtf16Safe(rendered[0], 6_000)` detects the surrogate pair straddling the cut and backs off to 5999, ending on the last `"a"`.

- Tail boundary: a short first message (`"hi"`) plus a long second message of 30000 U+1F600. `tailBudget` works out so the tail slice starts at index 112 of the full transcript, which is the low surrogate of an emoji whose high half sits at index 111 (outside the slice).
  - Before fix - `full.slice(-tailBudget)` begins on that lone low surrogate.
  - After fix - `sliceUtf16Safe(full, -tailBudget)` sees the cut starts on a low surrogate preceded by its high half and advances the start past the pair, so the tail begins on a complete emoji.

Added 3 regression tests to `src/skills/workshop/experience-review.test.ts` (new `formatSkillExperienceReviewTranscript: UTF-16 safe truncation` describe block): head boundary split, tail boundary split, and a short-transcript passthrough that leaves emoji intact. Each boundary test scans the result for any lone surrogate and asserts none is present.

Verified the tests are genuine regression guards by running them against the pre-fix code: the two boundary cases fail (`expected true to be false` -- a lone surrogate was detected at the head and the tail cut), then all pass after the fix.

```
Test Files  1 passed (1)
     Tests  15 passed (15)
```

`npx oxlint` on both changed files: clean (exit 0). Local vitest run via the repo vitest runner: 15/15 pass.

What was not tested: a live skill experience review run producing an emoji-bearing transcript end to end. The transformation is pure string truncation over the rendered transcript, so the deterministic code-point analysis plus the regression tests fully cover the behavior; no live review environment is required to prove the surrogate boundary.
<img width="743" height="108" alt="image" src="https://github.com/user-attachments/assets/862c0181-0aa6-4593-83db-e9d0f38c491f" />


## Tests and validation

- `src/skills/workshop/experience-review.test.ts` - added a `formatSkillExperienceReviewTranscript: UTF-16 safe truncation` describe block with 3 cases (head boundary split emoji, tail boundary split emoji, short-transcript emoji passthrough). Existing scheduler/prompt tests unchanged.
- Pre-fix: the two split-emoji cases fail (lone surrogate detected at the head and tail cut). Post-fix: 15/15 pass.

## Risk checklist

- User-visible behavior change: Yes - experience review transcripts that previously ended (head) or began (tail) in a split emoji (lone surrogate) now back off to a clean code-unit boundary. Only affects transcripts longer than 60000 code units whose cut lands inside a surrogate pair, and only the conservative background learning prompt.
- Config / environment / migration change: No.
- Security / auth / secrets / network / tool-execution change: No.
- Highest-risk area: prompt text fed to the model. Mitigated by reusing the already-adopted `truncateUtf16Safe` / `sliceUtf16Safe` helpers (same import path the rest of the runtime uses for surrogate-safe truncation) rather than inventing new logic.
