### PR TITLE
fix(marketplaces): allow trusted feed key rotation

### DIFF
--- a/src/plugins/official-external-plugin-catalog-snapshot-store.ts
+++ b/src/plugins/official-external-plugin-catalog-snapshot-store.ts
@@ -14,6 +14,7 @@ import {
 } from "../state/openclaw-state-db.js";
 import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
 import {
+  HostedCatalogSignedFeedMonotonicityError,
   type HostedOfficialExternalPluginCatalogMetadata,
   type HostedOfficialExternalPluginCatalogSnapshot,
   type HostedOfficialExternalPluginCatalogSnapshotMonotonicState,
@@ -160,7 +161,7 @@ function isMonotonicRollback(params: {
   if (params.candidate.sequence > params.current.sequence) {
     return false;
   }
-  if (params.current.generatedAt === undefined) {
+  if (params.candidate.generatedAt === undefined || params.current.generatedAt === undefined) {
     return false;
   }
   return Date.parse(params.candidate.generatedAt) < Date.parse(params.current.generatedAt);
@@ -179,7 +180,9 @@ function assertSignedSnapshotWriteIsMonotonic(params: {
     return;
   }
   if (isMonotonicRollback({ candidate: params.candidate, current })) {
-    throw new Error("hosted catalog signed feed sequence is older than current snapshot");
+    throw new HostedCatalogSignedFeedMonotonicityError(
+      "hosted catalog signed feed sequence is older than current snapshot",
+    );
   }
   if (params.candidate.sequence !== current.sequence || current.generatedAt === undefined) {
     return;
@@ -189,7 +192,9 @@ function assertSignedSnapshotWriteIsMonotonic(params: {
     candidate?.sequence === params.candidate.sequence &&
     candidate.payloadSha256 !== current.payloadSha256
   ) {
-    throw new Error("hosted catalog signed feed payload changed without a sequence increment");
+    throw new HostedCatalogSignedFeedMonotonicityError(
+      "hosted catalog signed feed payload changed without a sequence increment",
+    );
   }
 }
 
@@ -208,11 +213,11 @@ function rowToSnapshot(
   };
   const trust = rowToTrustState(row);
   const storedMonotonic = trust ? readMonotonicStateFromBody(row.body) : undefined;
-  const monotonic = storedMonotonic?.generatedAt
+  const monotonic = storedMonotonic
     ? {
         mode: "signed-feed" as const,
         sequence: storedMonotonic.sequence,
-        generatedAt: storedMonotonic.generatedAt,
+        ...(storedMonotonic.generatedAt ? { generatedAt: storedMonotonic.generatedAt } : {}),
       }
     : undefined;
   return {

--- a/src/plugins/official-external-plugin-catalog-snapshot-store.ts
+++ b/src/plugins/official-external-plugin-catalog-snapshot-store.ts
@@ -188,11 +188,20 @@ function rowToSnapshot(
     ...(row.last_modified ? { lastModified: row.last_modified } : {}),
   };
   const trust = rowToTrustState(row);
+  const storedMonotonic = trust ? readMonotonicStateFromBody(row.body) : undefined;
+  const monotonic = storedMonotonic?.generatedAt
+    ? {
+        mode: "signed-feed" as const,
+        sequence: storedMonotonic.sequence,
+        generatedAt: storedMonotonic.generatedAt,
+      }
+    : undefined;
   return {
     body: row.body,
     metadata,
     savedAt: row.saved_at,
     ...(trust ? { trust } : {}),
+    ...(monotonic ? { monotonic } : {}),
   };
 }
 

--- a/src/plugins/official-external-plugin-catalog-snapshot-store.ts
+++ b/src/plugins/official-external-plugin-catalog-snapshot-store.ts
@@ -1,4 +1,5 @@
 /** Persists hosted official external plugin catalog snapshots in OpenClaw state. */
+import { createHash } from "node:crypto";
 import { existsSync } from "node:fs";
 import {
   executeSqliteQuerySync,
@@ -51,6 +52,7 @@ type HostedCatalogSnapshotDatabase = Pick<
 type StoredHostedCatalogMonotonicState = {
   sequence: number;
   generatedAt?: string;
+  payloadSha256: string;
 };
 
 function resolveStoreEnv(
@@ -117,9 +119,11 @@ function readMonotonicStateFromBody(body: string): StoredHostedCatalogMonotonicS
       sequence?: unknown;
       generatedAt?: unknown;
     };
+    const payload =
+      typeof document.payload === "string" ? decodeBase64Payload(document.payload) : body;
     const feed =
       typeof document.payload === "string"
-        ? (JSON.parse(decodeBase64Payload(document.payload)) as {
+        ? (JSON.parse(payload) as {
             sequence?: unknown;
             generatedAt?: unknown;
           })
@@ -131,11 +135,15 @@ function readMonotonicStateFromBody(body: string): StoredHostedCatalogMonotonicS
       typeof feed.generatedAt !== "string" ||
       parseOfficialExternalPluginCatalogTimestamp(feed.generatedAt) === undefined
     ) {
-      return { sequence: feed.sequence };
+      return {
+        sequence: feed.sequence,
+        payloadSha256: createHash("sha256").update(payload).digest("hex"),
+      };
     }
     return {
       sequence: feed.sequence,
       generatedAt: feed.generatedAt,
+      payloadSha256: createHash("sha256").update(payload).digest("hex"),
     };
   } catch {
     return undefined;
@@ -160,6 +168,7 @@ function isMonotonicRollback(params: {
 
 function assertSignedSnapshotWriteIsMonotonic(params: {
   candidate: HostedOfficialExternalPluginCatalogSnapshotMonotonicState | undefined;
+  candidateBody: string;
   current: HostedCatalogSnapshotRow | undefined;
 }): void {
   if (params.candidate?.mode !== "signed-feed" || params.current?.trust_mode !== "signed") {
@@ -171,6 +180,16 @@ function assertSignedSnapshotWriteIsMonotonic(params: {
   }
   if (isMonotonicRollback({ candidate: params.candidate, current })) {
     throw new Error("hosted catalog signed feed sequence is older than current snapshot");
+  }
+  if (params.candidate.sequence !== current.sequence || current.generatedAt === undefined) {
+    return;
+  }
+  const candidate = readMonotonicStateFromBody(params.candidateBody);
+  if (
+    candidate?.sequence === params.candidate.sequence &&
+    candidate.payloadSha256 !== current.payloadSha256
+  ) {
+    throw new Error("hosted catalog signed feed payload changed without a sequence increment");
   }
 }
 
@@ -265,6 +284,7 @@ export function createSqliteHostedOfficialExternalPluginCatalogSnapshotStore(
         ) as HostedCatalogSnapshotRow | undefined;
         assertSignedSnapshotWriteIsMonotonic({
           candidate: snapshot.monotonic,
+          candidateBody: snapshot.body,
           current,
         });
         executeSqliteQuerySync(

--- a/src/plugins/official-external-plugin-catalog.test.ts
+++ b/src/plugins/official-external-plugin-catalog.test.ts
@@ -546,6 +546,54 @@ describe("official external plugin catalog", () => {
     }
   });
 
+  it("rejects signed payload changes at the same sequence while allowing re-signing", async () => {
+    const stateDir = mkdtempSync(path.join(os.tmpdir(), "openclaw-signed-snapshot-equivocation-"));
+    const feed = hostedCatalogFeed({ sequence: 10, pluginName: "@openclaw/signed-v10" });
+    const original = signedHostedCatalogFeed({ feed });
+    const resigned = signedHostedCatalogFeed({ feed, keyId: "acme-rotated" });
+    const conflictingFeed = hostedCatalogFeed({
+      sequence: 10,
+      pluginName: "@openclaw/conflicting-v10",
+    });
+    const conflicting = signedHostedCatalogFeed({ feed: conflictingFeed });
+    const snapshotStore = createSqliteHostedOfficialExternalPluginCatalogSnapshotStore({
+      stateDir,
+    });
+
+    try {
+      expect(resigned.body).not.toBe(original.body);
+      await snapshotStore.write(
+        signedHostedCatalogSnapshot({
+          body: original.body,
+          monotonic: { sequence: feed.sequence, generatedAt: feed.generatedAt },
+        }),
+      );
+      await snapshotStore.write(
+        signedHostedCatalogSnapshot({
+          body: resigned.body,
+          monotonic: { sequence: feed.sequence, generatedAt: feed.generatedAt },
+        }),
+      );
+      await expect(
+        snapshotStore.write(
+          signedHostedCatalogSnapshot({
+            body: conflicting.body,
+            monotonic: {
+              sequence: conflictingFeed.sequence,
+              generatedAt: conflictingFeed.generatedAt,
+            },
+          }),
+        ),
+      ).rejects.toThrow("payload changed without a sequence increment");
+      await expect(
+        snapshotStore.read("https://packages.acme.example/openclaw/feed"),
+      ).resolves.toMatchObject({ body: resigned.body });
+    } finally {
+      closeOpenClawStateDatabaseForTest();
+      rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
+
   it("replaces malformed signed SQLite snapshot metadata with a valid snapshot", async () => {
     const stateDir = mkdtempSync(path.join(os.tmpdir(), "openclaw-signed-snapshot-repair-"));
     const url = "https://packages.acme.example/openclaw/feed";

--- a/src/plugins/official-external-plugin-catalog.test.ts
+++ b/src/plugins/official-external-plugin-catalog.test.ts
@@ -95,6 +95,7 @@ function hostedCatalogFeed(params: {
 function signedHostedCatalogFeed(params: {
   feed: OfficialExternalPluginCatalogFeed;
   privateKeyPem?: string;
+  keyId?: string;
 }): { body: string; privateKeyPem: string; publicKeyPem: string } {
   const keys = params.privateKeyPem
     ? {
@@ -125,7 +126,7 @@ function signedHostedCatalogFeed(params: {
       payload: payloadBytes.toString("base64url"),
       signatures: [
         {
-          keyid: "acme-root",
+          keyid: params.keyId ?? "acme-root",
           sig: crypto
             .sign(null, signingInput, crypto.createPrivateKey(keys.privateKeyPem))
             .toString("base64url"),
@@ -154,14 +155,14 @@ function toLegacyBetaSignedEnvelope(body: string): string {
   });
 }
 
-function signedCatalogConfig(publicKeyPem: string): HostedCatalogConfig {
+function signedCatalogConfig(publicKeyPem: string, keyId = "acme-root"): HostedCatalogConfig {
   return {
     feeds: {
       acme: {
         url: "https://packages.acme.example/openclaw/feed",
         verification: {
           mode: "signed",
-          keys: [{ keyId: "acme-root", publicKey: publicKeyPem }],
+          keys: [{ keyId, publicKey: publicKeyPem }],
         },
       },
     },
@@ -783,6 +784,77 @@ describe("official external plugin catalog", () => {
     }
     expect(writeSpy).not.toHaveBeenCalled();
     await expect(snapshotStore.read(url)).resolves.toMatchObject({ body: current.body });
+  });
+
+  it("uses accepted monotonic metadata when trusted signing keys rotate", async () => {
+    const previous = signedHostedCatalogFeed({
+      feed: hostedCatalogFeed({ sequence: 8, pluginName: "@openclaw/signed-v8" }),
+      keyId: "acme-root-2026-q2",
+    });
+    const current = signedHostedCatalogFeed({
+      feed: hostedCatalogFeed({ sequence: 9, pluginName: "@openclaw/signed-v9" }),
+      keyId: "acme-root-2026-q3",
+    });
+    const stateDir = mkdtempSync(path.join(os.tmpdir(), "openclaw-signed-key-rotation-"));
+    const snapshotStore = createSqliteHostedOfficialExternalPluginCatalogSnapshotStore({
+      stateDir,
+    });
+
+    try {
+      const acceptedPrevious = await loadHostedCatalog({
+        feedProfile: "acme",
+        catalogConfig: signedCatalogConfig(previous.publicKeyPem, "acme-root-2026-q2"),
+        fetchImpl: vi.fn(async () => new Response(previous.body, { status: 200 })),
+        now: () => new Date("2026-06-22T00:00:08.000Z"),
+        snapshotStore,
+      });
+      expect(acceptedPrevious.source).toBe("hosted");
+
+      const acceptedCurrent = await loadHostedCatalog({
+        feedProfile: "acme",
+        catalogConfig: signedCatalogConfig(current.publicKeyPem, "acme-root-2026-q3"),
+        fetchImpl: vi.fn(async () => new Response(current.body, { status: 200 })),
+        now: () => new Date("2026-06-22T00:00:09.000Z"),
+        snapshotStore,
+      });
+
+      expect(acceptedCurrent.source, JSON.stringify(acceptedCurrent)).toBe("hosted");
+      expect(acceptedCurrent.entries.map((entry) => entry.name)).toEqual(["@openclaw/signed-v9"]);
+      if (acceptedCurrent.source === "hosted") {
+        expect(acceptedCurrent.trust?.signedBy).toBe("acme-root-2026-q3");
+      }
+
+      const rolledBack = signedHostedCatalogFeed({
+        feed: hostedCatalogFeed({ sequence: 7, pluginName: "@openclaw/signed-v7" }),
+        keyId: "acme-root-2026-q4",
+      });
+      const rejectedRollback = await loadHostedCatalog({
+        feedProfile: "acme",
+        catalogConfig: signedCatalogConfig(rolledBack.publicKeyPem, "acme-root-2026-q4"),
+        fetchImpl: vi.fn(async () => new Response(rolledBack.body, { status: 200 })),
+        now: () => new Date("2026-06-22T00:00:10.000Z"),
+        snapshotStore,
+      });
+
+      expect(rejectedRollback.source).toBe("bundled-fallback");
+      expect(rejectedRollback.entries).toEqual([]);
+      if (rejectedRollback.source === "bundled-fallback") {
+        expect(rejectedRollback.error).toContain("signed feed sequence is older");
+        expect(rejectedRollback.error).toContain("snapshot fallback failed");
+      }
+
+      const retainedCurrent = await loadHostedCatalog({
+        feedProfile: "acme",
+        catalogConfig: signedCatalogConfig(current.publicKeyPem, "acme-root-2026-q3"),
+        offline: true,
+        snapshotStore,
+      });
+      expect(retainedCurrent.source).toBe("hosted-snapshot");
+      expect(retainedCurrent.entries.map((entry) => entry.name)).toEqual(["@openclaw/signed-v9"]);
+    } finally {
+      closeOpenClawStateDatabaseForTest();
+      rmSync(stateDir, { recursive: true, force: true });
+    }
   });
 
   it("fails closed for unsigned signed-profile responses and re-verifies offline snapshots", async () => {

--- a/src/plugins/official-external-plugin-catalog.test.ts
+++ b/src/plugins/official-external-plugin-catalog.test.ts
@@ -743,6 +743,52 @@ describe("official external plugin catalog", () => {
     expect(writeSpy).not.toHaveBeenCalled();
   });
 
+  it("retains the accepted snapshot when a signed payload changes at the same sequence", async () => {
+    const acceptedFeed = hostedCatalogFeed({
+      sequence: 10,
+      pluginName: "@openclaw/signed-v10",
+    });
+    const accepted = signedHostedCatalogFeed({ feed: acceptedFeed });
+    const conflicting = signedHostedCatalogFeed({
+      feed: hostedCatalogFeed({ sequence: 10, pluginName: "@openclaw/conflicting-v10" }),
+      privateKeyPem: accepted.privateKeyPem,
+    });
+    const stateDir = mkdtempSync(path.join(os.tmpdir(), "openclaw-signed-equivocation-load-"));
+    const snapshotStore = createSqliteHostedOfficialExternalPluginCatalogSnapshotStore({
+      stateDir,
+    });
+    const catalogConfig = signedCatalogConfig(accepted.publicKeyPem);
+
+    try {
+      const initial = await loadHostedCatalog({
+        feedProfile: "acme",
+        catalogConfig,
+        fetchImpl: vi.fn(async () => new Response(accepted.body, { status: 200 })),
+        snapshotStore,
+      });
+      expect(initial.source).toBe("hosted");
+
+      const result = await loadHostedCatalog({
+        feedProfile: "acme",
+        catalogConfig,
+        fetchImpl: vi.fn(async () => new Response(conflicting.body, { status: 200 })),
+        snapshotStore,
+      });
+
+      expect(result.source).toBe("hosted-snapshot");
+      expect(result.entries.map((entry) => entry.name)).toEqual(["@openclaw/signed-v10"]);
+      if (result.source === "hosted-snapshot") {
+        expect(result.error).toContain("payload changed without a sequence increment");
+      }
+      await expect(
+        snapshotStore.read("https://packages.acme.example/openclaw/feed"),
+      ).resolves.toMatchObject({ body: accepted.body });
+    } finally {
+      closeOpenClawStateDatabaseForTest();
+      rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
+
   it("rejects malformed feed timestamps before rollback handling", async () => {
     const malformed = signedHostedCatalogFeed({
       feed: {
@@ -899,6 +945,58 @@ describe("official external plugin catalog", () => {
       });
       expect(retainedCurrent.source).toBe("hosted-snapshot");
       expect(retainedCurrent.entries.map((entry) => entry.name)).toEqual(["@openclaw/signed-v9"]);
+    } finally {
+      closeOpenClawStateDatabaseForTest();
+      rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it("repairs malformed timestamp snapshots after trusted signing keys rotate", async () => {
+    const malformed = signedHostedCatalogFeed({
+      feed: {
+        ...hostedCatalogFeed({ sequence: 10, pluginName: "@openclaw/malformed-current" }),
+        generatedAt: "not-a-date",
+      },
+      keyId: "acme-root-2026-q2",
+    });
+    const repairedFeed = hostedCatalogFeed({
+      sequence: 10,
+      pluginName: "@openclaw/repaired-current",
+    });
+    const repaired = signedHostedCatalogFeed({
+      feed: repairedFeed,
+      keyId: "acme-root-2026-q3",
+    });
+    const stateDir = mkdtempSync(path.join(os.tmpdir(), "openclaw-signed-rotation-repair-"));
+    const snapshotStore = createSqliteHostedOfficialExternalPluginCatalogSnapshotStore({
+      stateDir,
+    });
+
+    try {
+      await snapshotStore.write(
+        signedHostedCatalogSnapshot({
+          body: malformed.body,
+          monotonic: { sequence: 10, generatedAt: "not-a-date" },
+        }),
+      );
+      await expect(
+        snapshotStore.read("https://packages.acme.example/openclaw/feed"),
+      ).resolves.toMatchObject({
+        monotonic: { mode: "signed-feed", sequence: 10 },
+      });
+
+      const result = await loadHostedCatalog({
+        feedProfile: "acme",
+        catalogConfig: signedCatalogConfig(repaired.publicKeyPem, "acme-root-2026-q3"),
+        fetchImpl: vi.fn(async () => new Response(repaired.body, { status: 200 })),
+        snapshotStore,
+      });
+
+      expect(result.source, JSON.stringify(result)).toBe("hosted");
+      expect(result.entries.map((entry) => entry.name)).toEqual(["@openclaw/repaired-current"]);
+      await expect(
+        snapshotStore.read("https://packages.acme.example/openclaw/feed"),
+      ).resolves.toMatchObject({ body: repaired.body });
     } finally {
       closeOpenClawStateDatabaseForTest();
       rmSync(stateDir, { recursive: true, force: true });

--- a/src/plugins/official-external-plugin-catalog.ts
+++ b/src/plugins/official-external-plugin-catalog.ts
@@ -205,10 +205,17 @@ export type HostedOfficialExternalPluginCatalogTrustState = {
   verifiedAt: string;
 };
 
+export class HostedCatalogSignedFeedMonotonicityError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "HostedCatalogSignedFeedMonotonicityError";
+  }
+}
+
 export type HostedOfficialExternalPluginCatalogSnapshotMonotonicState = {
   mode: "signed-feed";
   sequence: number;
-  generatedAt: string;
+  generatedAt?: string;
 };
 
 export type HostedOfficialExternalPluginCatalogLoadResult =
@@ -1078,7 +1085,9 @@ async function loadHostedOfficialExternalPluginCatalogEntries(params?: {
             current,
           })
         ) {
-          throw new Error("hosted catalog signed feed sequence is older than current snapshot");
+          throw new HostedCatalogSignedFeedMonotonicityError(
+            "hosted catalog signed feed sequence is older than current snapshot",
+          );
         }
       }
     }
@@ -1106,10 +1115,7 @@ async function loadHostedOfficialExternalPluginCatalogEntries(params?: {
           : {}),
       })
       .catch((err: unknown) => {
-        if (
-          err instanceof Error &&
-          err.message.includes("hosted catalog signed feed sequence is older")
-        ) {
+        if (err instanceof HostedCatalogSignedFeedMonotonicityError) {
           throw err;
         }
         if (params?.requireSnapshotWrite) {

--- a/src/plugins/official-external-plugin-catalog.ts
+++ b/src/plugins/official-external-plugin-catalog.ts
@@ -1054,20 +1054,30 @@ async function loadHostedOfficialExternalPluginCatalogEntries(params?: {
     if (snapshotStore && parsed.trust?.mode === "signed") {
       const currentSnapshot = await snapshotStore.read(url.href);
       if (currentSnapshot?.trust?.mode === "signed") {
-        // Only an authenticated invalid-timestamp payload is repairable. Signature
-        // and trust failures must remain fail-closed so rollback checks cannot be bypassed.
-        const current = await parseHostedCatalogFeedBody({
-          body: currentSnapshot.body,
-          verification: source.verification,
-          verifiedAt: currentSnapshot.trust.verifiedAt,
-          allowLegacyBetaEnvelope: true,
-        }).catch((err: unknown) => {
-          if (err instanceof HostedCatalogFeedTimestampError) {
-            return { feed: { sequence: err.sequence } };
-          }
-          throw err;
-        });
-        if (isHostedCatalogSignedFeedRollback({ candidate: parsed.feed, current: current.feed })) {
+        const current =
+          currentSnapshot.monotonic?.mode === "signed-feed"
+            ? currentSnapshot.monotonic
+            : (
+                await parseHostedCatalogFeedBody({
+                  body: currentSnapshot.body,
+                  verification: source.verification,
+                  verifiedAt: currentSnapshot.trust.verifiedAt,
+                  allowLegacyBetaEnvelope: true,
+                }).catch((err: unknown) => {
+                  // Only an authenticated invalid-timestamp payload is repairable. Signature
+                  // and trust failures must remain fail-closed so rollback checks cannot be bypassed.
+                  if (err instanceof HostedCatalogFeedTimestampError) {
+                    return { feed: { sequence: err.sequence } };
+                  }
+                  throw err;
+                })
+              ).feed;
+        if (
+          isHostedCatalogSignedFeedRollback({
+            candidate: parsed.feed,
+            current,
+          })
+        ) {
           throw new Error("hosted catalog signed feed sequence is older than current snapshot");
         }
       }


### PR DESCRIPTION
## Summary  - compare newly verified signed feeds against persisted accepted monotonic metadata - avoid requiring an old snapshot to verify under a newly rotated key merely to perform rollback comparison - retain fail-closed fallback behavior when the old snapshot does not satisfy the current trust policy - restore persisted monotonic metadata when signed snapshots are loaded from SQLite - cover successful key rotation, lower-sequence rejection, and retained snapshot fallback through the durable store - preserve merged #110037 policy: live feeds require standard DSSE while persisted beta snapshots remain readable  ## Real behavior proof  Behavior or issue addressed: A newly valid higher-sequence hosted feed could be rejected after trusted signing keys rotated because OpenClaw reverified the old snapshot with the new key before comparing sequences. The durable proof also exposed that SQLite stored accepted monotonic metadata but dropped it when reconstructing a snapshot.  Real environment tested: Windows checkout using Node 24.15.0 and SQLite 3.51.3. The production hosted-catalog loader and real SQLite snapshot store were exercised with a temporary state database and generated Ed25519 Q2/Q3/Q4 key pairs. Network responses used the existing guarded-fetch harness so the signed bytes and trust transitions were deterministic.  Exact steps or command run after this patch:  ```powershell & "$env:LOCALAPPDATA\pnpm\store\v11\links\@\node\24.15.0\4b86559dec5f3e7def9c585f1a41d64f741f7930cf3b31f21bf2b4e73beef981\node_modules\node\bin\node.exe" scripts/run-vitest.mjs src/plugins/official-external-plugin-catalog.test.ts --run ```  The durable regression: 1. Opens the real SQLite marketplace state store. 2. Accepts sequence 8 signed by `acme-root-2026-q2`. 3. Reopens the persisted snapshot, replaces configured trust with `acme-root-2026-q3`, and accepts sequence 9. 4. Replaces configured trust with `acme-root-2026-q4` and rejects sequence 7. 5. Reloads the retained sequence 9 snapshot under the Q3 policy.  Evidence after fix: The full catalog suite reported 46 tests passed. The key-rotation case persisted each accepted revision through SQLite and verified the retained snapshot after the rollback attempt.  Observed result after fix: Sequence 9 was accepted under the rotated Q3 key. Sequence 7 under Q4 failed closed with the rollback diagnostic. Sequence 9 remained persisted and readable under its accepted Q3 policy. Persisted signed snapshots now reconstruct their accepted monotonic record from the authenticated body; unsigned rows cannot acquire that authority.  What was not tested: A production publisher endpoint or production key-management system was not used. The proof intentionally uses generated keys and deterministic guarded network responses while exercising the real production loader and durable SQLite implementation.  ## Validation  - full hosted catalog suite on Node 24.15.0 / SQLite 3.51.3: 50 passed - targeted `oxfmt --check` - targeted type-aware `oxlint` - `git diff --check` - final `codex review --base upstream/main`: no actionable correctness issues   
## Maintainer decision

Approved for ordinary hosted-feed key rotation. Previously accepted signed-feed monotonic metadata may remain rollback-authoritative across routine configured-key rotation, while every newly fetched feed must verify under the current trust set. Emergency key compromise or revocation is a separate operator recovery path that clears or rebuilds local hosted-feed snapshot state. 
