### PR TITLE
fix: restore task boundary CI after test seam split

### DIFF
--- a/src/tasks/task-boundaries.test.ts
+++ b/src/tasks/task-boundaries.test.ts
@@ -29,13 +29,13 @@ const TASK_FLOW_REGISTRY_ALLOWED_IMPORTERS = new Set([
   "tasks/task-flow-registry.audit.ts",
   "tasks/task-flow-registry.maintenance.ts",
   "tasks/task-flow-runtime-internal.ts",
-  "tasks/task-runtime.test-helpers.ts",
+  "tasks/task-flow-registry.test-support.ts",
 ]);
 
 const TASK_REGISTRY_ALLOWED_IMPORTERS = new Set([
   "tasks/runtime-internal.ts",
   "tasks/task-owner-access.ts",
-  "tasks/task-runtime.test-helpers.ts",
+  "tasks/task-registry.test-support.ts",
   "tasks/task-status-access.ts",
 ]);
 


### PR DESCRIPTION
Related: #108338

## What Problem This Solves

Fixes an issue where main CI fails in `src/tasks/task-boundaries.test.ts` after registry test access moved to dedicated test-support seams.

## Why This Change Was Made

The boundary test now names the two registry-specific test-support importers that replaced the former shared helper imports. Test-support files remain explicitly allowlisted instead of being globally excluded, preserving the architecture guard.

## User Impact

No runtime behavior change. Main CI can validate the intended task registry boundaries again.

## Evidence

- Baseline failure: https://github.com/openclaw/openclaw/actions/runs/29423700280/job/87380676727
- Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/29424422033
- Focused test: `src/tasks/task-boundaries.test.ts` — 5/5 passed
- Remote `check:changed` passed
- Fresh autoreview: no accepted or actionable findings
