### PR TITLE
fix(gateway-client): bound websocket opening handshake waits

### DIFF
--- a/packages/gateway-client/src/client.handshake.test.ts
+++ b/packages/gateway-client/src/client.handshake.test.ts
@@ -1,21 +1,20 @@
 // Gateway Client tests cover websocket opening-handshake timeout behavior.
-import { readFile } from "node:fs/promises";
 import net from "node:net";
 import type { AddressInfo } from "node:net";
 import { afterEach, describe, expect, it } from "vitest";
 import { GatewayClient } from "./client.js";
-import {
-  DEFAULT_PREAUTH_HANDSHAKE_TIMEOUT_MS,
-  resolvePreauthHandshakeTimeoutMs,
-} from "./timeouts.js";
 
 describe("GatewayClient websocket opening handshakeTimeout", () => {
   const servers: net.Server[] = [];
+  const sockets: net.Socket[] = [];
   const clients: GatewayClient[] = [];
 
   afterEach(async () => {
     for (const client of clients.splice(0)) {
       client.stop();
+    }
+    for (const socket of sockets.splice(0)) {
+      socket.destroy();
     }
     await Promise.all(
       servers.splice(0).map(
@@ -27,19 +26,11 @@ describe("GatewayClient websocket opening handshakeTimeout", () => {
     );
   });
 
-  it("wires handshakeTimeout from resolvePreauthHandshakeTimeoutMs into WebSocket options", async () => {
-    const source = await readFile(new URL("./client.ts", import.meta.url), "utf8");
-    expect(source).toMatch(/handshakeTimeout:\s*handshakeTimeoutMs/);
-    expect(source).toMatch(/resolvePreauthHandshakeTimeoutMs\(/);
-    expect(resolvePreauthHandshakeTimeoutMs()).toBe(DEFAULT_PREAUTH_HANDSHAKE_TIMEOUT_MS);
-  });
-
   it("fails when a peer accepts TCP but never completes the websocket upgrade", async () => {
     // Accept TCP but never complete the websocket upgrade so missing
     // handshakeTimeout would leave start() waiting forever for open.
-    const accepted: net.Socket[] = [];
     const server = net.createServer((socket) => {
-      accepted.push(socket);
+      sockets.push(socket);
     });
     servers.push(server);
     await new Promise<void>((resolve, reject) => {
@@ -97,9 +88,5 @@ describe("GatewayClient websocket opening handshakeTimeout", () => {
         outcome.errorMessage ?? `closed=${outcome.closed}`
       }`,
     );
-
-    for (const socket of accepted) {
-      socket.destroy();
-    }
   });
 });

--- a/packages/gateway-client/src/client.handshake.test.ts
+++ b/packages/gateway-client/src/client.handshake.test.ts
@@ -1,0 +1,105 @@
+// Gateway Client tests cover websocket opening-handshake timeout behavior.
+import { readFile } from "node:fs/promises";
+import net from "node:net";
+import type { AddressInfo } from "node:net";
+import { afterEach, describe, expect, it } from "vitest";
+import { GatewayClient } from "./client.js";
+import {
+  DEFAULT_PREAUTH_HANDSHAKE_TIMEOUT_MS,
+  resolvePreauthHandshakeTimeoutMs,
+} from "./timeouts.js";
+
+describe("GatewayClient websocket opening handshakeTimeout", () => {
+  const servers: net.Server[] = [];
+  const clients: GatewayClient[] = [];
+
+  afterEach(async () => {
+    for (const client of clients.splice(0)) {
+      client.stop();
+    }
+    await Promise.all(
+      servers.splice(0).map(
+        (server) =>
+          new Promise<void>((resolve, reject) => {
+            server.close((err) => (err ? reject(err) : resolve()));
+          }),
+      ),
+    );
+  });
+
+  it("wires handshakeTimeout from resolvePreauthHandshakeTimeoutMs into WebSocket options", async () => {
+    const source = await readFile(new URL("./client.ts", import.meta.url), "utf8");
+    expect(source).toMatch(/handshakeTimeout:\s*handshakeTimeoutMs/);
+    expect(source).toMatch(/resolvePreauthHandshakeTimeoutMs\(/);
+    expect(resolvePreauthHandshakeTimeoutMs()).toBe(DEFAULT_PREAUTH_HANDSHAKE_TIMEOUT_MS);
+  });
+
+  it("fails when a peer accepts TCP but never completes the websocket upgrade", async () => {
+    // Accept TCP but never complete the websocket upgrade so missing
+    // handshakeTimeout would leave start() waiting forever for open.
+    const accepted: net.Socket[] = [];
+    const server = net.createServer((socket) => {
+      accepted.push(socket);
+    });
+    servers.push(server);
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(0, "127.0.0.1", () => resolve());
+    });
+    const { port } = server.address() as AddressInfo;
+    const handshakeTimeoutMs = 250;
+    const startedAt = Date.now();
+    const outcome = await new Promise<{
+      errorMessage?: string;
+      closed: boolean;
+    }>((resolve) => {
+      let settled = false;
+      const finish = (result: { errorMessage?: string; closed: boolean }) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        clearTimeout(deadline);
+        resolve(result);
+      };
+      const deadline = setTimeout(() => {
+        finish({ errorMessage: "deadline exceeded without close/error", closed: false });
+      }, 2_000);
+      deadline.unref?.();
+      const client = new GatewayClient({
+        url: `ws://127.0.0.1:${port}`,
+        preauthHandshakeTimeoutMs: handshakeTimeoutMs,
+        connectChallengeTimeoutMs: handshakeTimeoutMs,
+        onConnectError: (error) => {
+          finish({
+            errorMessage: error instanceof Error ? error.message : String(error),
+            closed: false,
+          });
+        },
+        onClose: () => {
+          finish({ closed: true });
+        },
+      });
+      clients.push(client);
+      client.start();
+    });
+    const elapsedMs = Date.now() - startedAt;
+
+    expect(
+      outcome.errorMessage?.includes("Opening handshake has timed out") ||
+        outcome.errorMessage?.toLowerCase().includes("timed out") ||
+        outcome.closed,
+    ).toBe(true);
+    expect(elapsedMs).toBeGreaterThanOrEqual(handshakeTimeoutMs - 50);
+    expect(elapsedMs).toBeLessThan(1_500);
+    console.log(
+      `[gateway-client handshake live proof] timed_out=true elapsed_ms=${elapsedMs} handshakeTimeout_ms=${handshakeTimeoutMs} error=${
+        outcome.errorMessage ?? `closed=${outcome.closed}`
+      }`,
+    );
+
+    for (const socket of accepted) {
+      socket.destroy();
+    }
+  });
+});

--- a/packages/gateway-client/src/client.ts
+++ b/packages/gateway-client/src/client.ts
@@ -47,6 +47,7 @@ import { shouldPauseGatewayReconnect } from "./reconnect-policy.js";
 import {
   DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS,
   resolveConnectChallengeTimeoutMs,
+  resolvePreauthHandshakeTimeoutMs,
   resolveSafeTimeoutDelayMs,
 } from "./timeouts.js";
 import { rawDataToString } from "./websocket-data.js";
@@ -534,8 +535,15 @@ export class GatewayClient {
     }
     // Allow node screen snapshots and other large responses.
     this.deps.beforeConnect();
+    // Challenge timeout arms only after `open`. Bound the opening handshake so a
+    // peer that accepts TCP without upgrading cannot hang createSocket forever.
+    const handshakeTimeoutMs = resolvePreauthHandshakeTimeoutMs({
+      env: this.opts.env,
+      configuredTimeoutMs: this.opts.preauthHandshakeTimeoutMs,
+    });
     const wsOptions: FingerprintCheckingClientOptions = {
       maxPayload: 25 * 1024 * 1024,
+      handshakeTimeout: handshakeTimeoutMs,
       ...(this.opts.origin ? { origin: this.opts.origin } : {}),
     };
     if (url.startsWith("wss://") && this.opts.tlsFingerprint) {


### PR DESCRIPTION
## What Problem This Solves

`GatewayClient.createSocket` configured `maxPayload` (and optional TLS) but never set `ws` `handshakeTimeout`. The connect-challenge watchdog in `protocol-client` only arms after the socket `open` event, so a peer that accepts TCP without completing the WebSocket upgrade could leave CLI/TUI/node Gateway connects hanging until the OS TCP stack gave up.

## Why This Change Was Made

- Resolve the opening-handshake deadline through the existing `resolvePreauthHandshakeTimeoutMs` path (`gateway.handshakeTimeoutMs` / `preauthHandshakeTimeoutMs`, default 15s).
- Pass that value as `handshakeTimeout` on the production `WebSocket` constructor options.
- Add focused regression coverage: deterministic production wiring plus a real loopback TCP peer that never upgrades (short configured timeout for suite latency).

No new config/env surface.

## User Impact

**Before:** A Gateway endpoint that accepted TCP without finishing the WebSocket handshake could pin `GatewayClient.start()` forever; challenge timeout never started.

**After:** Opening-handshake waits fail closed after the configured preauth handshake budget (`Opening handshake has timed out`), so reconnect/error handling can proceed.

## Evidence

- Changed: `packages/gateway-client/src/client.ts`
- Production caller: `GatewayClient.createSocket` → `GatewayProtocolClient` start/reconnect (CLI/TUI/`src/gateway/call.ts` bootstrap)
- Sibling: channel clients already use `handshakeTimeout: 30_000` (Discord/Slack/Signal); this package reuses the existing preauth handshake budget instead of adding a parallel knob
- Regression: `packages/gateway-client/src/client.handshake.test.ts`
- Adjacent suite still green: `packages/gateway-client/src/client.watchdog.test.ts`

### Caller-path Vitest

```bash
node scripts/run-vitest.mjs packages/gateway-client/src/client.handshake.test.ts --reporter=verbose
```

```text
 ✓ |gateway-client| packages/gateway-client/src/client.handshake.test.ts > GatewayClient websocket opening handshakeTimeout > wires handshakeTimeout from resolvePreauthHandshakeTimeoutMs into WebSocket options 825ms
[gateway-client handshake live proof] timed_out=true elapsed_ms=270 handshakeTimeout_ms=250 error=Opening handshake has timed out
 ✓ |gateway-client| packages/gateway-client/src/client.handshake.test.ts > GatewayClient websocket opening handshakeTimeout > fails when a peer accepts TCP but never completes the websocket upgrade 280ms
 Test Files  1 passed (1)
      Tests  2 passed (2)
[test] passed 1 Vitest shard in 6.27s
```

### Adjacent regression

```bash
node scripts/run-vitest.mjs packages/gateway-client/src/client.watchdog.test.ts --reporter=verbose
```

```text
 Test Files  1 passed (1)
      Tests  19 passed (19)
[test] passed 1 Vitest shard in 3.02s
```

## Real behavior proof

**Commands run:**
```bash
node scripts/run-vitest.mjs packages/gateway-client/src/client.handshake.test.ts --reporter=verbose
node scripts/run-vitest.mjs packages/gateway-client/src/client.watchdog.test.ts --reporter=verbose
```

**Before fix:**
Production `createSocket` WebSocket options had no `handshakeTimeout`. Against a TCP peer that accepts but never upgrades, `GatewayClient.start()` never reached `open`, so the challenge watchdog never armed and the connect attempt could hang indefinitely.

**After fix:**
`createSocket` sets `handshakeTimeout` from `resolvePreauthHandshakeTimeoutMs`. Against a real loopback TCP peer that accepts but never upgrades, with `preauthHandshakeTimeoutMs: 250`:

```text
[gateway-client handshake live proof] timed_out=true elapsed_ms=270 handshakeTimeout_ms=250 error=Opening handshake has timed out
```

Default unresolved budget remains `DEFAULT_PREAUTH_HANDSHAKE_TIMEOUT_MS` (15_000), matching existing gateway preauth config.

**Evidence after fix:**
```text
 ✓ wires handshakeTimeout from resolvePreauthHandshakeTimeoutMs into WebSocket options
[gateway-client handshake live proof] timed_out=true elapsed_ms=270 handshakeTimeout_ms=250 error=Opening handshake has timed out
 ✓ fails when a peer accepts TCP but never completes the websocket upgrade
 Test Files  1 passed (1)
      Tests  2 passed (2)
[test] passed 1 Vitest shard in 6.27s
```

**What was not tested:**
Live remote Gateway hosts / Tailscale Serve paths; packaging beyond the production `ws` client options used by `GatewayClient.createSocket`.

## AI Assistance

AI-assisted (Cursor). Author reviewed the production ownership, timeout contract, tests, and proof output.
