### PR TITLE
fix(line): retry inbound media download while LINE reports 202 (still preparing)

### DIFF
--- a/extensions/line/src/download.test.ts
+++ b/extensions/line/src/download.test.ts
@@ -1,18 +1,30 @@
 // Line tests cover download plugin behavior.
-import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { Readable } from "node:stream";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const getMessageContentMock = vi.hoisted(() => vi.fn());
+const getMessageContentWithHttpInfoMock = vi.hoisted(() => vi.fn());
 const saveMediaStreamMock = vi.hoisted(() => vi.fn());
 
 vi.mock("@line/bot-sdk", () => ({
   messagingApi: {
     MessagingApiBlobClient: class {
-      getMessageContent(messageId: string) {
-        return getMessageContentMock(messageId);
+      getMessageContentWithHttpInfo(messageId: string) {
+        return getMessageContentWithHttpInfoMock(messageId);
       }
     },
   },
 }));
+
+function httpInfo(status: number, body: unknown): unknown {
+  return { httpResponse: { status } as unknown as Response, body };
+}
+
+// A `202 Accepted` (still preparing) response carries an empty, destroyable body,
+// mirroring what the SDK hands back before LINE finishes preparing the content.
+function stillPreparing(): unknown {
+  return httpInfo(202, Readable.from([]));
+}
 
 vi.mock("openclaw/plugin-sdk/runtime-env", () => ({
   createSubsystemLogger: () => {
@@ -70,10 +82,20 @@ describe("downloadLineMedia", () => {
     vi.resetModules();
   });
 
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   beforeEach(() => {
     vi.restoreAllMocks();
     getMessageContentMock.mockReset();
+    getMessageContentWithHttpInfoMock.mockReset();
     saveMediaStreamMock.mockReset();
+    // By default the content is ready on first request (HTTP 200); the body is
+    // whatever the content mock is primed to return for the case.
+    getMessageContentWithHttpInfoMock.mockImplementation(async (messageId: string) =>
+      httpInfo(200, await getMessageContentMock(messageId)),
+    );
     saveMediaStreamMock.mockImplementation(
       async (stream: AsyncIterable<Buffer>, contentType?: string, subdir?: string) => {
         const chunksLocal: Buffer[] = [];
@@ -173,5 +195,39 @@ describe("downloadLineMedia", () => {
     saveMediaStreamMock.mockRejectedValueOnce(new Error("Media exceeds 0MB limit"));
 
     await expect(downloadLineMedia("mid-bad", "token")).rejects.toThrow(/Media exceeds/i);
+  });
+
+  it("retries 202 (still preparing) responses until the content is ready", async () => {
+    const m4aHeader = Buffer.from([
+      0x00, 0x00, 0x00, 0x1c, 0x66, 0x74, 0x79, 0x70, 0x4d, 0x34, 0x41, 0x20,
+    ]);
+    // Preparing twice (202) before the content becomes downloadable (200).
+    getMessageContentWithHttpInfoMock
+      .mockResolvedValueOnce(stillPreparing())
+      .mockResolvedValueOnce(stillPreparing())
+      .mockResolvedValueOnce(httpInfo(200, chunks([m4aHeader])));
+
+    vi.useFakeTimers();
+    const pending = downloadLineMedia("mid-preparing", "token");
+    await vi.runAllTimersAsync();
+    const result = await pending;
+
+    expect(getMessageContentWithHttpInfoMock).toHaveBeenCalledTimes(3);
+    expect(result.contentType).toBe("audio/x-m4a");
+    expect(result.size).toBe(m4aHeader.length);
+  });
+
+  it("throws instead of saving an empty file when content never becomes ready", async () => {
+    // Fresh empty body per attempt so each retry destroys its own stream.
+    getMessageContentWithHttpInfoMock.mockImplementation(async () => stillPreparing());
+
+    vi.useFakeTimers();
+    const pending = downloadLineMedia("mid-stuck", "token");
+    const rejection = expect(pending).rejects.toThrow(/still preparing/i);
+    await vi.runAllTimersAsync();
+    await rejection;
+
+    expect(getMessageContentWithHttpInfoMock).toHaveBeenCalledTimes(6);
+    expect(saveMediaStreamMock).not.toHaveBeenCalled();
   });
 });

--- a/extensions/line/src/download.test.ts
+++ b/extensions/line/src/download.test.ts
@@ -1,29 +1,25 @@
 // Line tests cover download plugin behavior.
-import { Readable } from "node:stream";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
-const getMessageContentMock = vi.hoisted(() => vi.fn());
-const getMessageContentWithHttpInfoMock = vi.hoisted(() => vi.fn());
+const fetchMock = vi.hoisted(() => vi.fn());
+const delayMock = vi.hoisted(() => vi.fn());
 const saveMediaStreamMock = vi.hoisted(() => vi.fn());
 
-vi.mock("@line/bot-sdk", () => ({
-  messagingApi: {
-    MessagingApiBlobClient: class {
-      getMessageContentWithHttpInfo(messageId: string) {
-        return getMessageContentWithHttpInfoMock(messageId);
-      }
-    },
-  },
+vi.mock("node:timers/promises", () => ({
+  setTimeout: delayMock,
 }));
 
-function httpInfo(status: number, body: unknown): unknown {
-  return { httpResponse: { status } as unknown as Response, body };
+function responseWithChunks(status: number, parts: Buffer[]): Response {
+  return new Response(Buffer.concat(parts), { status });
 }
 
-// A `202 Accepted` (still preparing) response carries an empty, destroyable body,
-// mirroring what the SDK hands back before LINE finishes preparing the content.
-function stillPreparing(): unknown {
-  return httpInfo(202, Readable.from([]));
+function cancellableResponse(status: number): {
+  response: Response;
+  cancel: ReturnType<typeof vi.fn>;
+} {
+  const cancel = vi.fn();
+  const body = new ReadableStream<Uint8Array>({ cancel });
+  return { response: new Response(body, { status }), cancel };
 }
 
 vi.mock("openclaw/plugin-sdk/runtime-env", () => ({
@@ -45,12 +41,6 @@ vi.mock("openclaw/plugin-sdk/media-store", () => ({
 }));
 
 let downloadLineMedia: typeof import("./download.js").downloadLineMedia;
-
-async function* chunks(parts: Buffer[]): AsyncGenerator<Buffer> {
-  for (const part of parts) {
-    yield part;
-  }
-}
 
 function saveMediaStreamCall(): unknown[] {
   const call = saveMediaStreamMock.mock.calls.at(0);
@@ -76,9 +66,10 @@ describe("downloadLineMedia", () => {
   });
 
   afterAll(() => {
-    vi.doUnmock("@line/bot-sdk");
+    vi.doUnmock("node:timers/promises");
     vi.doUnmock("openclaw/plugin-sdk/runtime-env");
     vi.doUnmock("openclaw/plugin-sdk/media-store");
+    vi.unstubAllGlobals();
     vi.resetModules();
   });
 
@@ -88,14 +79,10 @@ describe("downloadLineMedia", () => {
 
   beforeEach(() => {
     vi.restoreAllMocks();
-    getMessageContentMock.mockReset();
-    getMessageContentWithHttpInfoMock.mockReset();
+    vi.stubGlobal("fetch", fetchMock);
+    fetchMock.mockReset();
+    delayMock.mockReset().mockResolvedValue(undefined);
     saveMediaStreamMock.mockReset();
-    // By default the content is ready on first request (HTTP 200); the body is
-    // whatever the content mock is primed to return for the case.
-    getMessageContentWithHttpInfoMock.mockImplementation(async (messageId: string) =>
-      httpInfo(200, await getMessageContentMock(messageId)),
-    );
     saveMediaStreamMock.mockImplementation(
       async (stream: AsyncIterable<Buffer>, contentType?: string, subdir?: string) => {
         const chunksLocal: Buffer[] = [];
@@ -114,10 +101,18 @@ describe("downloadLineMedia", () => {
 
   it("persists inbound media with the shared media store", async () => {
     const jpeg = Buffer.from([0xff, 0xd8, 0xff, 0x00]);
-    getMessageContentMock.mockResolvedValueOnce(chunks([jpeg]));
+    fetchMock.mockResolvedValueOnce(responseWithChunks(200, [jpeg]));
 
     const result = await downloadLineMedia("mid-jpeg", "token");
 
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api-data.line.me/v2/bot/message/mid-jpeg/content",
+      expect.objectContaining({
+        headers: { Authorization: "Bearer token" },
+        redirect: "error",
+        signal: expect.any(AbortSignal),
+      }),
+    );
     expect(saveMediaStreamMock).toHaveBeenCalledTimes(1);
     const call = saveMediaStreamCall();
     expect(call[1]).toBeUndefined();
@@ -133,10 +128,13 @@ describe("downloadLineMedia", () => {
   it("does not pass the external messageId to saveMediaStream", async () => {
     const messageId = "a/../../../../etc/passwd";
     const jpeg = Buffer.from([0xff, 0xd8, 0xff, 0x00]);
-    getMessageContentMock.mockResolvedValueOnce(chunks([jpeg]));
+    fetchMock.mockResolvedValueOnce(responseWithChunks(200, [jpeg]));
 
     const result = await downloadLineMedia(messageId, "token");
 
+    expect(fetchMock.mock.calls[0]?.[0]).toBe(
+      "https://api-data.line.me/v2/bot/message/a%2F..%2F..%2F..%2F..%2Fetc%2Fpasswd/content",
+    );
     expect(result.size).toBe(jpeg.length);
     expect(result.contentType).toBe("image/jpeg");
     for (const arg of saveMediaStreamCall()) {
@@ -146,19 +144,21 @@ describe("downloadLineMedia", () => {
     }
   });
 
-  it("delegates oversized media rejection to saveMediaStream", async () => {
-    getMessageContentMock.mockResolvedValueOnce(chunks([Buffer.alloc(4), Buffer.alloc(4)]));
+  it("cancels content when the media store rejects it", async () => {
+    const content = cancellableResponse(200);
+    fetchMock.mockResolvedValueOnce(content.response);
     saveMediaStreamMock.mockRejectedValueOnce(new Error("Media exceeds 0MB limit"));
 
     await expect(downloadLineMedia("mid", "token", 7)).rejects.toThrow(/Media exceeds/i);
     expect(saveMediaStreamMock).toHaveBeenCalledTimes(1);
+    expect(content.cancel).toHaveBeenCalledTimes(1);
   });
 
   it("uses media store content type for M4A media", async () => {
     const m4aHeader = Buffer.from([
       0x00, 0x00, 0x00, 0x1c, 0x66, 0x74, 0x79, 0x70, 0x4d, 0x34, 0x41, 0x20,
     ]);
-    getMessageContentMock.mockResolvedValueOnce(chunks([m4aHeader]));
+    fetchMock.mockResolvedValueOnce(responseWithChunks(200, [m4aHeader]));
 
     const result = await downloadLineMedia("mid-audio", "token");
 
@@ -167,7 +167,7 @@ describe("downloadLineMedia", () => {
   });
 
   it("passes original filenames to the media store for extension fallback", async () => {
-    getMessageContentMock.mockResolvedValueOnce(chunks([Buffer.from("unknown-audio-bytes")]));
+    fetchMock.mockResolvedValueOnce(responseWithChunks(200, [Buffer.from("unknown-audio-bytes")]));
 
     await downloadLineMedia("mid-file-audio", "token", 10 * 1024 * 1024, {
       originalFilename: "voice-note.m4a",
@@ -182,52 +182,88 @@ describe("downloadLineMedia", () => {
     const mp4 = Buffer.from([
       0x00, 0x00, 0x00, 0x1c, 0x66, 0x74, 0x79, 0x70, 0x69, 0x73, 0x6f, 0x6d,
     ]);
-    getMessageContentMock.mockResolvedValueOnce(chunks([mp4]));
+    fetchMock.mockResolvedValueOnce(responseWithChunks(200, [mp4]));
 
     const result = await downloadLineMedia("mid-mp4", "token");
 
     expect(result.contentType).toBe("video/mp4");
   });
 
-  it("propagates media store failures", async () => {
-    const jpeg = Buffer.from([0xff, 0xd8, 0xff, 0x00]);
-    getMessageContentMock.mockResolvedValueOnce(chunks([jpeg]));
-    saveMediaStreamMock.mockRejectedValueOnce(new Error("Media exceeds 0MB limit"));
-
-    await expect(downloadLineMedia("mid-bad", "token")).rejects.toThrow(/Media exceeds/i);
-  });
-
-  it("retries 202 (still preparing) responses until the content is ready", async () => {
+  it("retries 202 responses and cancels every discarded body", async () => {
     const m4aHeader = Buffer.from([
       0x00, 0x00, 0x00, 0x1c, 0x66, 0x74, 0x79, 0x70, 0x4d, 0x34, 0x41, 0x20,
     ]);
-    // Preparing twice (202) before the content becomes downloadable (200).
-    getMessageContentWithHttpInfoMock
-      .mockResolvedValueOnce(stillPreparing())
-      .mockResolvedValueOnce(stillPreparing())
-      .mockResolvedValueOnce(httpInfo(200, chunks([m4aHeader])));
+    const first = cancellableResponse(202);
+    const second = cancellableResponse(202);
+    fetchMock
+      .mockResolvedValueOnce(first.response)
+      .mockResolvedValueOnce(second.response)
+      .mockResolvedValueOnce(responseWithChunks(200, [m4aHeader]));
 
-    vi.useFakeTimers();
-    const pending = downloadLineMedia("mid-preparing", "token");
-    await vi.runAllTimersAsync();
-    const result = await pending;
+    const result = await downloadLineMedia("mid-preparing", "token");
 
-    expect(getMessageContentWithHttpInfoMock).toHaveBeenCalledTimes(3);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(delayMock).toHaveBeenNthCalledWith(1, 500, undefined, {
+      signal: expect.any(AbortSignal),
+    });
+    expect(delayMock).toHaveBeenNthCalledWith(2, 1000, undefined, {
+      signal: expect.any(AbortSignal),
+    });
+    expect(first.cancel).toHaveBeenCalledTimes(1);
+    expect(second.cancel).toHaveBeenCalledTimes(1);
     expect(result.contentType).toBe("audio/x-m4a");
     expect(result.size).toBe(m4aHeader.length);
   });
 
-  it("throws instead of saving an empty file when content never becomes ready", async () => {
-    // Fresh empty body per attempt so each retry destroys its own stream.
-    getMessageContentWithHttpInfoMock.mockImplementation(async () => stillPreparing());
+  it("cancels every response when content never becomes ready", async () => {
+    const attempts = Array.from({ length: 6 }, () => cancellableResponse(202));
+    for (const attempt of attempts) {
+      fetchMock.mockResolvedValueOnce(attempt.response);
+    }
+
+    await expect(downloadLineMedia("mid-stuck", "token")).rejects.toThrow(/still preparing/i);
+
+    expect(fetchMock).toHaveBeenCalledTimes(6);
+    expect(delayMock).toHaveBeenCalledTimes(5);
+    expect(delayMock.mock.calls.map((call) => call[0])).toEqual([500, 1000, 2000, 4000, 4000]);
+    for (const attempt of attempts) {
+      expect(attempt.cancel).toHaveBeenCalledTimes(1);
+    }
+    expect(saveMediaStreamMock).not.toHaveBeenCalled();
+  });
+
+  it("cancels error responses without retrying", async () => {
+    const response = cancellableResponse(404);
+    fetchMock.mockResolvedValueOnce(response.response);
+
+    await expect(downloadLineMedia("mid-missing", "token")).rejects.toThrow(/HTTP 404/i);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(response.cancel).toHaveBeenCalledTimes(1);
+    expect(saveMediaStreamMock).not.toHaveBeenCalled();
+  });
+
+  it("aborts a hung content request at the total readiness deadline", async () => {
+    let requestSignal: AbortSignal | undefined;
+    fetchMock.mockImplementation(
+      async (_input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+        requestSignal = init?.signal ?? undefined;
+        return await new Promise<Response>((_resolve, reject) => {
+          requestSignal?.addEventListener("abort", () => reject(new Error("fetch aborted")), {
+            once: true,
+          });
+        });
+      },
+    );
 
     vi.useFakeTimers();
-    const pending = downloadLineMedia("mid-stuck", "token");
-    const rejection = expect(pending).rejects.toThrow(/still preparing/i);
-    await vi.runAllTimersAsync();
+    const pending = downloadLineMedia("mid-hung", "token");
+    const rejection = expect(pending).rejects.toThrow(/did not become ready within 15 seconds/i);
+    await vi.advanceTimersByTimeAsync(15_000);
     await rejection;
 
-    expect(getMessageContentWithHttpInfoMock).toHaveBeenCalledTimes(6);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(requestSignal?.aborted).toBe(true);
     expect(saveMediaStreamMock).not.toHaveBeenCalled();
   });
 });

--- a/extensions/line/src/download.ts
+++ b/extensions/line/src/download.ts
@@ -1,4 +1,5 @@
 // Line plugin module implements download behavior.
+import { setTimeout as delay } from "node:timers/promises";
 import { messagingApi } from "@line/bot-sdk";
 import { saveMediaStream } from "openclaw/plugin-sdk/media-store";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
@@ -7,6 +8,40 @@ interface DownloadResult {
   path: string;
   contentType?: string;
   size: number;
+}
+
+// LINE prepares inbound media asynchronously: right after a message arrives the
+// content endpoint answers `202 Accepted` with an empty body, and saving that body
+// would persist a 0-byte file, silently dropping the user's media. Poll the content
+// endpoint with capped exponential backoff until it stops reporting 202. The
+// transcoding-status endpoint is not a reliable gate here: it can report "succeeded"
+// while the content request still returns 202.
+const CONTENT_READY_MAX_ATTEMPTS = 6;
+const CONTENT_READY_BASE_DELAY_MS = 500;
+const CONTENT_READY_MAX_DELAY_MS = 4000;
+
+function contentBackoffDelayMs(attempt: number): number {
+  return Math.min(CONTENT_READY_BASE_DELAY_MS * 2 ** attempt, CONTENT_READY_MAX_DELAY_MS);
+}
+
+async function fetchLineContentWhenReady(
+  client: messagingApi.MessagingApiBlobClient,
+  messageId: string,
+): Promise<AsyncIterable<Buffer>> {
+  for (let attempt = 0; attempt < CONTENT_READY_MAX_ATTEMPTS; attempt++) {
+    const { httpResponse, body } = await client.getMessageContentWithHttpInfo(messageId);
+    if (httpResponse.status !== 202) {
+      return body as AsyncIterable<Buffer>;
+    }
+    // Release the empty "still preparing" response before waiting to retry.
+    body.destroy();
+    if (attempt < CONTENT_READY_MAX_ATTEMPTS - 1) {
+      await delay(contentBackoffDelayMs(attempt));
+    }
+  }
+  throw new Error(
+    `LINE media for message ${messageId} was still preparing (HTTP 202) after ${CONTENT_READY_MAX_ATTEMPTS} attempts`,
+  );
 }
 
 export async function downloadLineMedia(
@@ -19,9 +54,9 @@ export async function downloadLineMedia(
     channelAccessToken,
   });
 
-  const response = await client.getMessageContent(messageId);
+  const content = await fetchLineContentWhenReady(client, messageId);
   const saved = await saveMediaStream(
-    response as AsyncIterable<Buffer>,
+    content,
     undefined,
     "inbound",
     maxBytes,

--- a/extensions/line/src/download.ts
+++ b/extensions/line/src/download.ts
@@ -5,6 +5,7 @@ import type { ReadableStream as NodeReadableStream } from "node:stream/web";
 import { setTimeout as delay } from "node:timers/promises";
 import { saveMediaStream } from "openclaw/plugin-sdk/media-store";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
+import { fetchWithRuntimeDispatcherOrMockedGlobal } from "openclaw/plugin-sdk/runtime-fetch";
 
 interface DownloadResult {
   path: string;
@@ -33,7 +34,7 @@ async function fetchLineContentWhenReady(
   deadline.unref();
   try {
     for (let attempt = 0; attempt < CONTENT_READY_MAX_ATTEMPTS; attempt++) {
-      const response = await fetch(
+      const response = await fetchWithRuntimeDispatcherOrMockedGlobal(
         `${LINE_CONTENT_BASE_URL}/${encodeURIComponent(messageId)}/content`,
         {
           headers: { Authorization: `Bearer ${channelAccessToken}` },

--- a/extensions/line/src/download.ts
+++ b/extensions/line/src/download.ts
@@ -1,6 +1,8 @@
 // Line plugin module implements download behavior.
+import { Readable } from "node:stream";
+import { finished } from "node:stream/promises";
+import type { ReadableStream as NodeReadableStream } from "node:stream/web";
 import { setTimeout as delay } from "node:timers/promises";
-import { messagingApi } from "@line/bot-sdk";
 import { saveMediaStream } from "openclaw/plugin-sdk/media-store";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 
@@ -10,35 +12,64 @@ interface DownloadResult {
   size: number;
 }
 
-// LINE prepares inbound media asynchronously: right after a message arrives the
-// content endpoint answers `202 Accepted` with an empty body, and saving that body
-// would persist a 0-byte file, silently dropping the user's media. Poll the content
-// endpoint with capped exponential backoff until it stops reporting 202. The
-// transcoding-status endpoint is not a reliable gate here: it can report "succeeded"
-// while the content request still returns 202.
+// LINE prepares inbound media asynchronously. Poll the content endpoint itself
+// because the transcoding-status endpoint does not cover every media type.
 const CONTENT_READY_MAX_ATTEMPTS = 6;
 const CONTENT_READY_BASE_DELAY_MS = 500;
 const CONTENT_READY_MAX_DELAY_MS = 4000;
+const CONTENT_READY_TIMEOUT_MS = 15_000;
+const LINE_CONTENT_BASE_URL = "https://api-data.line.me/v2/bot/message";
 
 function contentBackoffDelayMs(attempt: number): number {
   return Math.min(CONTENT_READY_BASE_DELAY_MS * 2 ** attempt, CONTENT_READY_MAX_DELAY_MS);
 }
 
 async function fetchLineContentWhenReady(
-  client: messagingApi.MessagingApiBlobClient,
   messageId: string,
-): Promise<AsyncIterable<Buffer>> {
-  for (let attempt = 0; attempt < CONTENT_READY_MAX_ATTEMPTS; attempt++) {
-    const { httpResponse, body } = await client.getMessageContentWithHttpInfo(messageId);
-    if (httpResponse.status !== 202) {
-      return body as AsyncIterable<Buffer>;
+  channelAccessToken: string,
+): Promise<Readable> {
+  const controller = new AbortController();
+  const deadline = setTimeout(() => controller.abort(), CONTENT_READY_TIMEOUT_MS);
+  deadline.unref();
+  try {
+    for (let attempt = 0; attempt < CONTENT_READY_MAX_ATTEMPTS; attempt++) {
+      const response = await fetch(
+        `${LINE_CONTENT_BASE_URL}/${encodeURIComponent(messageId)}/content`,
+        {
+          headers: { Authorization: `Bearer ${channelAccessToken}` },
+          redirect: "error",
+          signal: controller.signal,
+        },
+      );
+      if (response.status === 200) {
+        if (!response.body) {
+          throw new Error(`LINE media response for message ${messageId} had no body`);
+        }
+        return Readable.fromWeb(response.body as NodeReadableStream<Uint8Array>);
+      }
+
+      await response.body?.cancel();
+      if (response.status !== 202) {
+        throw new Error(
+          `LINE media download failed for message ${messageId} (HTTP ${response.status})`,
+        );
+      }
+      if (attempt < CONTENT_READY_MAX_ATTEMPTS - 1) {
+        await delay(contentBackoffDelayMs(attempt), undefined, { signal: controller.signal });
+      }
     }
-    // Release the empty "still preparing" response before waiting to retry.
-    body.destroy();
-    if (attempt < CONTENT_READY_MAX_ATTEMPTS - 1) {
-      await delay(contentBackoffDelayMs(attempt));
+  } catch (err) {
+    if (controller.signal.aborted) {
+      throw new Error(
+        `LINE media for message ${messageId} did not become ready within ${CONTENT_READY_TIMEOUT_MS / 1000} seconds`,
+        { cause: err },
+      );
     }
+    throw err;
+  } finally {
+    clearTimeout(deadline);
   }
+
   throw new Error(
     `LINE media for message ${messageId} was still preparing (HTTP 202) after ${CONTENT_READY_MAX_ATTEMPTS} attempts`,
   );
@@ -50,18 +81,21 @@ export async function downloadLineMedia(
   maxBytes = 10 * 1024 * 1024,
   options?: { originalFilename?: string },
 ): Promise<DownloadResult> {
-  const client = new messagingApi.MessagingApiBlobClient({
-    channelAccessToken,
-  });
-
-  const content = await fetchLineContentWhenReady(client, messageId);
-  const saved = await saveMediaStream(
-    content,
-    undefined,
-    "inbound",
-    maxBytes,
-    options?.originalFilename,
-  );
+  const content = await fetchLineContentWhenReady(messageId, channelAccessToken);
+  let saved: Awaited<ReturnType<typeof saveMediaStream>>;
+  try {
+    saved = await saveMediaStream(
+      content,
+      undefined,
+      "inbound",
+      maxBytes,
+      options?.originalFilename,
+    );
+  } catch (err) {
+    content.destroy();
+    await finished(content).catch(() => undefined);
+    throw err;
+  }
   logVerbose(`line: persisted media ${messageId} to ${saved.path} (${saved.size} bytes)`);
 
   return {


### PR DESCRIPTION
## What Problem This Solves

LINE can answer `GET /v2/bot/message/{messageId}/content` with `202 Accepted` while inbound media is still being prepared. OpenClaw previously passed that empty response to the media store and could persist a 0-byte attachment. This fixes the remaining download half of #96163; #96403 handled filename/classification.

## Why This Is the Right Fix

LINE documents `202` on the content endpoint as the not-ready signal. The plugin now polls that endpoint directly, retries only `202`, and uses capped exponential backoff: 500ms, 1s, 2s, 4s, 4s; six total attempts. A 15-second readiness deadline aborts a hung request or backoff. Redirects are rejected so the bearer token cannot be forwarded to another origin.

The plugin SDK runtime-fetch path is intentional. `@line/bot-sdk` 11.1.0 wraps the response reader in a Node `Readable` without a destroy hook, so destroying that wrapper does not cancel the underlying web stream. This implementation uses the dispatcher-aware plugin SDK fetch wrapper, cancels every discarded `202` or error response, converts the accepted `200` body with `Readable.fromWeb`, and destroys/awaits that stream if the media store rejects it.

No plugin SDK API changes. The exported `downloadLineMedia` signature and plugin SDK imports remain unchanged; the generated SDK baseline and plugin-boundary checks pass.

## User Impact

Media sent during LINE's preparation window is retried and delivered instead of becoming a 0-byte attachment. Exhausted, failed, or hung downloads surface through the existing media-unavailable path instead of leaking response bodies or silently saving empty content.

## Evidence

Contributor live LINE evidence, gathered with the production download path (message IDs redacted):

```
Still preparing:
  t+0 content request -> HTTP 202, 0 bytes
  retry              -> 121252 bytes written, elapsed 956ms

Ready immediately:
  t+0 content request -> HTTP 200
  download            -> 3236 bytes written, elapsed 399ms
```

Maintainer proof (live credentials unavailable; mocked recorded sequences accepted for this path):

```
node scripts/run-vitest.mjs extensions/line/src/download.test.ts
  10 passed

node scripts/check-changed.mjs -- extensions/line/src/download.ts extensions/line/src/download.test.ts
  Blacksmith Testbox exit 0
  format, SDK baseline/boundaries, extension prod/test types, lint,
  media-download guard, and import-cycle checks passed
```

Regression coverage includes `202 -> 202 -> 200`, six exhausted `202` responses, non-`202` errors, a hung request, downstream media-store rejection, exact cancellation of every unconsumed body, encoded message IDs, and the full backoff schedule.

Official contract: https://developers.line.biz/en/reference/messaging-api/#get-content and https://developers.line.biz/en/docs/messaging-api/retrying-api-request/

Fixes #96163
