### PR TITLE
fix(agents): reject synchronous sessions_send self-targets, break down missing-cost entries, dedup usage merges

### DIFF
--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -510,6 +510,7 @@ export function createSessionsSendTool(opts?: {
       // Normalize sessionKey/sessionId input into a canonical session key.
       const resolvedKey = visibleSession.key;
       const displayKey = visibleSession.displayKey;
+      const requesterSessionKey = opts?.agentSessionKey ? effectiveRequesterKey : undefined;
       const timeoutMs =
         finiteSecondsToTimerSafeMilliseconds(timeoutSeconds, {
           floorSeconds: true,
@@ -517,6 +518,16 @@ export function createSessionsSendTool(opts?: {
       const announceTimeoutMs = timeoutSeconds === 0 ? 30_000 : timeoutMs;
       const idempotencyKey = crypto.randomUUID();
       let runId: string = idempotencyKey;
+      // Fire-and-forget self-send remains a channel-delivery path. A synchronous
+      // self-send would wait behind its own active session lane until timeout.
+      if (timeoutSeconds !== 0 && requesterSessionKey === resolvedKey) {
+        return jsonResult({
+          runId,
+          status: "error",
+          error: "sessions_send cannot target the calling session; use your own reply instead",
+          sessionKey: unresolvedDisplayKey,
+        });
+      }
       if (parseSessionThreadInfo(resolvedKey).threadId) {
         return jsonResult({
           runId: crypto.randomUUID(),
@@ -557,7 +568,6 @@ export function createSessionsSendTool(opts?: {
         });
       }
 
-      const requesterSessionKey = opts?.agentSessionKey ? effectiveRequesterKey : undefined;
       const requesterChannel = opts?.agentChannel;
       const sameSessionA2A = requesterSessionKey === resolvedKey;
       const isIsolatedCronRequester = isCronRunSessionKey(requesterSessionKey);

--- a/src/agents/tools/sessions.test.ts
+++ b/src/agents/tools/sessions.test.ts
@@ -1116,8 +1116,40 @@ describe("sessions_send gating", () => {
     expect(requireGatewayRequest().method).toBe("sessions.resolve");
   });
 
-  it("does not reuse a stale assistant reply when no new reply appears", async () => {
+  it("rejects a synchronous target that resolves to the calling session", async () => {
+    callGatewayMock.mockResolvedValueOnce({ key: MAIN_AGENT_SESSION_KEY });
     const tool = createMainSessionsSendTool();
+
+    const result = await tool.execute("call-self-send", {
+      sessionKey: "current",
+      message: "use this as my reply",
+    });
+
+    expect(requireDetails(result)).toMatchObject({
+      status: "error",
+      error: "sessions_send cannot target the calling session; use your own reply instead",
+      sessionKey: "current",
+    });
+    expect(callGatewayMock).toHaveBeenCalledTimes(1);
+    expect(requireGatewayRequest().method).toBe("sessions.resolve");
+    expect(callGatewayMock.mock.calls).not.toContainEqual([
+      expect.objectContaining({ method: "agent" }),
+    ]);
+  });
+
+  it("keeps synchronous distinct-target sends unchanged", async () => {
+    const targetSessionKey = "agent:main:other";
+    const tool = createSessionsSendTool({
+      agentSessionKey: MAIN_AGENT_SESSION_KEY,
+      agentChannel: MAIN_AGENT_CHANNEL,
+      config: {
+        session: { scope: "per-sender", mainKey: "main" },
+        tools: {
+          agentToAgent: { enabled: false },
+          sessions: { visibility: "all" },
+        },
+      } as never,
+    });
     let historyCalls = 0;
     const staleAssistantMessage = {
       role: "assistant",
@@ -1130,7 +1162,7 @@ describe("sessions_send gating", () => {
       if (request.method === "sessions.list") {
         return {
           path: "/tmp/sessions.json",
-          sessions: [{ key: MAIN_AGENT_SESSION_KEY, kind: "direct" }],
+          sessions: [{ key: targetSessionKey, kind: "direct" }],
         };
       }
       if (request.method === "agent") {
@@ -1147,7 +1179,7 @@ describe("sessions_send gating", () => {
     });
 
     const result = await tool.execute("call-stale-send", {
-      sessionKey: MAIN_AGENT_SESSION_KEY,
+      sessionKey: targetSessionKey,
       message: "ping",
       timeoutSeconds: 1,
     });
@@ -1156,7 +1188,7 @@ describe("sessions_send gating", () => {
     const details = requireDetails(result);
     expect(details.status).toBe("ok");
     expect(details.reply).toBeUndefined();
-    expect(details.sessionKey).toBe(MAIN_AGENT_SESSION_KEY);
+    expect(details.sessionKey).toBe(targetSessionKey);
   });
 
   it("passes a baseline into fire-and-forget same-session A2A delivery", async () => {
@@ -1312,7 +1344,18 @@ describe("sessions_send gating", () => {
   );
 
   it("caps oversized timeoutSeconds before waiting for the target run", async () => {
-    const tool = createMainSessionsSendTool();
+    const targetSessionKey = "agent:main:other";
+    const tool = createSessionsSendTool({
+      agentSessionKey: MAIN_AGENT_SESSION_KEY,
+      agentChannel: MAIN_AGENT_CHANNEL,
+      config: {
+        session: { scope: "per-sender", mainKey: "main" },
+        tools: {
+          agentToAgent: { enabled: false },
+          sessions: { visibility: "all" },
+        },
+      } as never,
+    });
     const waitTimeouts: unknown[] = [];
 
     callGatewayMock.mockImplementation(async (opts: unknown) => {
@@ -1320,7 +1363,7 @@ describe("sessions_send gating", () => {
       if (request.method === "sessions.list") {
         return {
           path: "/tmp/sessions.json",
-          sessions: [{ key: MAIN_AGENT_SESSION_KEY, kind: "direct" }],
+          sessions: [{ key: targetSessionKey, kind: "direct" }],
         };
       }
       if (request.method === "agent") {
@@ -1337,7 +1380,7 @@ describe("sessions_send gating", () => {
     });
 
     const result = await tool.execute("call-huge-timeout", {
-      sessionKey: MAIN_AGENT_SESSION_KEY,
+      sessionKey: targetSessionKey,
       message: "ping",
       timeoutSeconds: Number.MAX_SAFE_INTEGER,
     });

--- a/src/cli/gateway-cli.coverage.test.ts
+++ b/src/cli/gateway-cli.coverage.test.ts
@@ -261,6 +261,43 @@ describe("gateway-cli coverage", () => {
     expect(costCall?.params).toEqual({ days: 7, agentScope: "all" });
   });
 
+  it("prints the provider/model breakdown for missing costs", async () => {
+    callGateway.mockResolvedValue({
+      updatedAt: 1,
+      days: 7,
+      daily: [],
+      totals: {
+        input: 12,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 12,
+        totalCost: 0,
+        inputCost: 0,
+        outputCost: 0,
+        cacheReadCost: 0,
+        cacheWriteCost: 0,
+        missingCostEntries: 12,
+        missingCostByModel: {
+          "openai/gpt-5.6-sol": 10,
+          "openai-codex/gpt-5.5": 2,
+        },
+      },
+      cacheStatus: {
+        status: "fresh",
+        cachedFiles: 1,
+        pendingFiles: 0,
+        staleFiles: 0,
+      },
+    });
+
+    await runGatewayCommand(["gateway", "usage-cost", "--days", "7"]);
+
+    expect(runtimeLogs.join("\n")).toContain(
+      "Missing cost: 12 (openai/gpt-5.6-sol 10, openai-codex/gpt-5.5 2)",
+    );
+  });
+
   it("waits for real all-agent usage caches before printing totals", async () => {
     const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-usage-cost-cli-"));
     const config = {

--- a/src/cli/gateway-cli/register.ts
+++ b/src/cli/gateway-cli/register.ts
@@ -255,6 +255,7 @@ async function renderCostUsageSummaryAsync(
   days: number,
   rich: boolean,
 ): Promise<string[]> {
+  const { formatMissingCostEntries } = await import("../../infra/session-cost-usage-totals.js");
   const { formatTokenCount, formatUsd } = await loadUsageFormatModule();
   const totalCost = formatUsd(summary.totals.totalCost) ?? "$0.00";
   const totalTokens = formatTokenCount(summary.totals.totalTokens) ?? "0";
@@ -265,7 +266,7 @@ async function renderCostUsageSummaryAsync(
 
   if (summary.totals.missingCostEntries > 0) {
     lines.push(
-      `${colorize(rich, theme.muted, "Missing entries:")} ${summary.totals.missingCostEntries}`,
+      `${colorize(rich, theme.muted, "Missing cost:")} ${formatMissingCostEntries(summary.totals)}`,
     );
   }
 

--- a/src/infra/session-cost-usage-totals.ts
+++ b/src/infra/session-cost-usage-totals.ts
@@ -30,6 +30,7 @@ export function cloneCostUsageTotals(totals: CostUsageTotals): CostUsageTotals {
     cacheReadCost: totals.cacheReadCost,
     cacheWriteCost: totals.cacheWriteCost,
     missingCostEntries: totals.missingCostEntries,
+    ...(totals.missingCostByModel ? { missingCostByModel: { ...totals.missingCostByModel } } : {}),
   };
 }
 
@@ -45,4 +46,22 @@ export function addCostUsageTotals(target: CostUsageTotals, source: CostUsageTot
   target.cacheReadCost += source.cacheReadCost;
   target.cacheWriteCost += source.cacheWriteCost;
   target.missingCostEntries += source.missingCostEntries;
+  if (source.missingCostByModel) {
+    target.missingCostByModel ??= {};
+    for (const [model, count] of Object.entries(source.missingCostByModel)) {
+      target.missingCostByModel[model] = (target.missingCostByModel[model] ?? 0) + count;
+    }
+  }
+}
+
+export function formatMissingCostEntries(totals: CostUsageTotals): string {
+  const byModel = Object.entries(totals.missingCostByModel ?? {})
+    .filter(([, count]) => count > 0)
+    .toSorted(
+      ([modelA, countA], [modelB, countB]) => countB - countA || modelA.localeCompare(modelB),
+    );
+  if (byModel.length === 0) {
+    return String(totals.missingCostEntries);
+  }
+  return `${totals.missingCostEntries} (${byModel.map(([model, count]) => `${model} ${count}`).join(", ")})`;
 }

--- a/src/infra/session-cost-usage.test.ts
+++ b/src/infra/session-cost-usage.test.ts
@@ -458,6 +458,51 @@ describe("session cost usage", () => {
     });
   });
 
+  it("breaks missing costs down by raw provider and model attribution", async () => {
+    const root = await makeSessionCostRoot("cost-missing-by-model");
+    const sessionsDir = path.join(root, "agents", "main", "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
+    const sessionFile = path.join(sessionsDir, "sess-missing-by-model.jsonl");
+    const timestamp = Date.now() - 1_000;
+    const entries = [
+      ["openai", "gpt-5.6-sol"],
+      ["openai", "gpt-5.6-sol"],
+      ["openai-codex", "gpt-5.5"],
+    ].map(([provider, model], index) => ({
+      type: "message",
+      timestamp: new Date(timestamp + index).toISOString(),
+      message: {
+        role: "assistant",
+        provider,
+        model,
+        usage: {
+          input: 1,
+          output: 0,
+          totalTokens: 1,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+        },
+      },
+    }));
+    await fs.writeFile(
+      sessionFile,
+      entries.map((entry) => JSON.stringify(entry)).join("\n"),
+      "utf-8",
+    );
+
+    clearGatewayModelPricingState();
+    await withStateDir(root, async () => {
+      const summary = await loadCostUsageSummary();
+      expect(summary.totals.missingCostEntries).toBe(3);
+      expect(summary.totals.missingCostByModel).toEqual({
+        "openai/gpt-5.6-sol": 2,
+        "openai-codex/gpt-5.5": 1,
+      });
+
+      const sessionSummary = await loadSessionCostSummary({ sessionFile });
+      expect(sessionSummary?.missingCostByModel).toEqual(summary.totals.missingCostByModel);
+    });
+  });
+
   it("uses top-level transcript provider and model when recomputing session-log cost", async () => {
     const root = await makeSessionCostRoot("cost-known-pricing-top-level-metadata");
     const sessionsDir = path.join(root, "agents", "main", "sessions");
@@ -992,6 +1037,7 @@ describe("session cost usage", () => {
         refreshMode: "sync-when-empty",
       });
       expect(warmed.cacheStatus?.status).toBe("fresh");
+      expect(warmed.totals.missingCostByModel).toEqual({ "openai/gpt-5.5": 2 });
 
       await loadSessionCostSummariesFromCache({
         sessions,
@@ -1005,6 +1051,10 @@ describe("session cost usage", () => {
             requestRefresh: false,
           });
           expect(cached.cacheStatus.status).toBe("fresh");
+          expect(cached.summaries.map((summary) => summary?.missingCostByModel)).toEqual([
+            { "openai/gpt-5.5": 1 },
+            { "openai/gpt-5.5": 1 },
+          ]);
         },
         { interval: 10, timeout: 2_000 },
       );

--- a/src/infra/session-cost-usage.ts
+++ b/src/infra/session-cost-usage.ts
@@ -104,7 +104,7 @@ export type {
 
 // Bump when the durable cache schema or the meaning of cached totals changes, so
 // older builds are rebuilt instead of served stale.
-const USAGE_COST_CACHE_VERSION = 7;
+const USAGE_COST_CACHE_VERSION = 8;
 const USAGE_COST_TRANSCRIPT_STAT_CONCURRENCY = 32;
 // Checkpoint policy for refreshCostUsageCache: bound the cost of full cache
 // serialization when scanning thousands of session files. Smaller of the two
@@ -1115,9 +1115,17 @@ const applyCostBreakdown = (totals: CostUsageTotals, costBreakdown: CostBreakdow
 };
 
 // Legacy function for backwards compatibility (no cost breakdown available)
-const applyCostTotal = (totals: CostUsageTotals, costTotal: number | undefined) => {
+const applyCostTotal = (
+  totals: CostUsageTotals,
+  costTotal: number | undefined,
+  provider?: string,
+  model?: string,
+) => {
   if (costTotal === undefined) {
     totals.missingCostEntries += 1;
+    const modelKey = `${normalizeOptionalString(provider) ?? "unknown"}/${normalizeOptionalString(model) ?? "unknown"}`;
+    totals.missingCostByModel ??= {};
+    totals.missingCostByModel[modelKey] = (totals.missingCostByModel[modelKey] ?? 0) + 1;
     return;
   }
   totals.totalCost += costTotal;
@@ -1501,7 +1509,7 @@ export async function loadCostUsageSummary(params?: {
         if (entry.costBreakdown?.total !== undefined) {
           applyCostBreakdown(bucket, entry.costBreakdown);
         } else {
-          applyCostTotal(bucket, entry.costTotal);
+          applyCostTotal(bucket, entry.costTotal, entry.provider, entry.model);
         }
         dailyMap.set(dayKey, bucket);
 
@@ -1509,7 +1517,7 @@ export async function loadCostUsageSummary(params?: {
         if (entry.costBreakdown?.total !== undefined) {
           applyCostBreakdown(totals, entry.costBreakdown);
         } else {
-          applyCostTotal(totals, entry.costTotal);
+          applyCostTotal(totals, entry.costTotal, entry.provider, entry.model);
         }
       },
     });
@@ -1581,7 +1589,7 @@ async function scanUsageFileForCache(params: {
         if (entry.costBreakdown?.total !== undefined) {
           applyCostBreakdown(entryTotals, entry.costBreakdown);
         } else {
-          applyCostTotal(entryTotals, entry.costTotal);
+          applyCostTotal(entryTotals, entry.costTotal, entry.provider, entry.model);
         }
         addTotals(totals, entryTotals);
         if (ts !== undefined) {
@@ -2287,7 +2295,7 @@ export async function loadSessionCostSummary(params: {
       if (entry.costBreakdown?.total !== undefined) {
         applyCostBreakdown(totals, entry.costBreakdown);
       } else {
-        applyCostTotal(totals, entry.costTotal);
+        applyCostTotal(totals, entry.costTotal, entry.provider, entry.model);
       }
 
       if (dayKey !== undefined && quarterBucket) {
@@ -2363,7 +2371,7 @@ export async function loadSessionCostSummary(params: {
         if (entry.costBreakdown?.total !== undefined) {
           applyCostBreakdown(existing.totals, entry.costBreakdown);
         } else {
-          applyCostTotal(existing.totals, entry.costTotal);
+          applyCostTotal(existing.totals, entry.costTotal, entry.provider, entry.model);
         }
         modelUsageMap.set(key, existing);
       }

--- a/src/infra/session-cost-usage.types.ts
+++ b/src/infra/session-cost-usage.types.ts
@@ -45,6 +45,8 @@ export type CostUsageTotals = {
   cacheReadCost: number;
   cacheWriteCost: number;
   missingCostEntries: number;
+  /** Missing-cost entry counts keyed by the raw `provider/model` attribution. */
+  missingCostByModel?: Record<string, number>;
 };
 
 type CostUsageDailyEntry = CostUsageTotals & {

--- a/src/status/codex-synthetic-usage.test.ts
+++ b/src/status/codex-synthetic-usage.test.ts
@@ -54,7 +54,7 @@ describe("mergeUsageSummaries", () => {
             windows: [{ label: "Week", usedPercent: 40 }],
             billing: [
               { type: "balance", amount: 12.5, unit: "credits" },
-              { type: "subscription", amount: 20, unit: "usd", period: "month" },
+              { type: "spend", amount: 20, unit: "usd", period: "month" },
             ],
           },
         ],

--- a/src/status/codex-synthetic-usage.test.ts
+++ b/src/status/codex-synthetic-usage.test.ts
@@ -43,6 +43,41 @@ describe("mergeUsageSummaries", () => {
     });
   });
 
+  it("lets preferred billing replace duplicate secondary entries without dropping siblings", () => {
+    const merged = mergeUsageSummaries(
+      {
+        updatedAt: 1,
+        providers: [
+          {
+            provider: "openai",
+            displayName: "OpenAI",
+            windows: [{ label: "Week", usedPercent: 40 }],
+            billing: [
+              { type: "balance", amount: 12.5, unit: "credits" },
+              { type: "subscription", amount: 20, unit: "usd", period: "month" },
+            ],
+          },
+        ],
+      },
+      {
+        updatedAt: 2,
+        providers: [
+          {
+            provider: "openai",
+            displayName: "Codex",
+            windows: [{ label: "5h", usedPercent: 10 }],
+            billing: [{ type: "balance", amount: 8, unit: "credits" }],
+          },
+        ],
+      },
+    );
+
+    expect(merged.providers[0]?.billing).toEqual([
+      { type: "balance", amount: 8, unit: "credits" },
+      { type: "subscription", amount: 20, unit: "usd", period: "month" },
+    ]);
+  });
+
   it("ranks billing-only snapshots above errors", () => {
     const merged = mergeUsageSummaries(
       {

--- a/src/status/codex-synthetic-usage.test.ts
+++ b/src/status/codex-synthetic-usage.test.ts
@@ -74,7 +74,7 @@ describe("mergeUsageSummaries", () => {
 
     expect(merged.providers[0]?.billing).toEqual([
       { type: "balance", amount: 8, unit: "credits" },
-      { type: "subscription", amount: 20, unit: "usd", period: "month" },
+      { type: "spend", amount: 20, unit: "usd", period: "month" },
     ]);
   });
 

--- a/src/status/codex-synthetic-usage.ts
+++ b/src/status/codex-synthetic-usage.ts
@@ -70,15 +70,23 @@ function usageSnapshotRank(snapshot: ProviderUsageSnapshot): number {
   return snapshot.error ? 0 : 1;
 }
 
+type Precedence<T> = [preferred: T, secondary: T];
+function byPrecedence<T>(candidate: T, existing: T, rank: (value: T) => number): Precedence<T> {
+  const candidateRank = rank(candidate);
+  const existingRank = rank(existing);
+  return candidateRank >= existingRank && !(candidateRank === 0 && existingRank === 0)
+    ? [candidate, existing]
+    : [existing, candidate];
+}
+
 function billingEntryKey(entry: ProviderUsageBilling): string {
   const period = "period" in entry ? (entry.period ?? "") : "";
   return [entry.type, entry.label ?? "", entry.unit, period].join("\0");
 }
 
-function mergeBilling(
-  preferred: ProviderUsageSnapshot,
-  secondary: ProviderUsageSnapshot,
-): ProviderUsageBilling[] | undefined {
+function mergeBilling([preferred, secondary]: Precedence<ProviderUsageSnapshot>):
+  | ProviderUsageBilling[]
+  | undefined {
   const entries = new Map<string, ProviderUsageBilling>();
   for (const entry of secondary.billing ?? []) {
     entries.set(billingEntryKey(entry), entry);
@@ -89,12 +97,9 @@ function mergeBilling(
   return entries.size > 0 ? [...entries.values()] : undefined;
 }
 
-function mergeUsageSnapshots(
-  preferred: ProviderUsageSnapshot,
-  secondary: ProviderUsageSnapshot,
-): ProviderUsageSnapshot {
-  const billing = mergeBilling(preferred, secondary);
-  // Synthetic and OAuth sources can own different facts for the same provider.
+function mergeUsageSnapshots(precedence: Precedence<ProviderUsageSnapshot>): ProviderUsageSnapshot {
+  const [preferred, secondary] = precedence;
+  const billing = mergeBilling(precedence);
   // Preserve complementary plan/billing data while the preferred source owns windows/errors.
   return {
     ...secondary,
@@ -129,18 +134,11 @@ export function mergeUsageSummaries(
       providersById.set(provider.provider, provider);
       continue;
     }
-    const providerRank = usageSnapshotRank(provider);
-    const existingRank = usageSnapshotRank(existing);
-    // Synthetic errors must not hide the concrete provider endpoint's error.
-    // Synthetic data still wins equal displayable ranks so its live windows stay authoritative.
-    const preferred =
-      providerRank === 0 && existingRank === 0
-        ? existing
-        : providerRank >= existingRank
-          ? provider
-          : existing;
-    const secondary = preferred === provider ? existing : provider;
-    providersById.set(provider.provider, mergeUsageSnapshots(preferred, secondary));
+    // Preserve concrete endpoint errors; synthetic data wins equal displayable ranks.
+    providersById.set(
+      provider.provider,
+      mergeUsageSnapshots(byPrecedence(provider, existing, usageSnapshotRank)),
+    );
   }
   return {
     updatedAt: base.updatedAt,

--- a/src/status/status-runtime-lines.ts
+++ b/src/status/status-runtime-lines.ts
@@ -3,6 +3,7 @@ import type { SessionEntry } from "../config/sessions.js";
 import { resolveSessionFilePath, resolveSessionFilePathOptions } from "../config/sessions/paths.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { formatDurationCompact } from "../infra/format-time/format-duration.ts";
+import { formatMissingCostEntries } from "../infra/session-cost-usage-totals.js";
 import {
   loadSessionCostSummariesFromCache,
   resolveExistingUsageSessionFile,
@@ -71,7 +72,10 @@ async function resolveSessionCostLine(params: {
     if (!summary) {
       return undefined;
     }
-    const cost = summary.missingCostEntries > 0 ? "cost partial" : formatUsd(summary.totalCost);
+    const cost =
+      summary.missingCostEntries > 0
+        ? `missing cost: ${formatMissingCostEntries(summary)}`
+        : formatUsd(summary.totalCost);
     return `💵 ${cost ? `${cost} · ` : ""}${formatTokenCount(summary.totalTokens)} tok (today)`;
   } catch {
     return undefined;

--- a/src/status/status-text.test.ts
+++ b/src/status/status-text.test.ts
@@ -216,13 +216,17 @@ describe("session status cost line", () => {
           outputCost: 0.23,
           cacheReadCost: 0,
           cacheWriteCost: 0,
-          missingCostEntries: 1,
+          missingCostEntries: 12,
+          missingCostByModel: {
+            "openai/gpt-5.6-sol": 10,
+            "openai-codex/gpt-5.5": 2,
+          },
         },
       ],
     });
 
     await expect(appendSessionCostLine(null, {}, "main", sessionEntry)).resolves.toBe(
-      "💵 cost partial · 456k tok (today)",
+      "💵 missing cost: 12 (openai/gpt-5.6-sol 10, openai-codex/gpt-5.5 2) · 456k tok (today)",
     );
   });
 });


### PR DESCRIPTION
## What Problem This Solves

Three Codex-adjacent reporting/behavior bugs:

1. **#107172** — A Codex-runtime session could call `sessions_send` with a target that resolved to **its own active session key**. The message enqueued on the sender's own lane (held by the in-flight turn), blocked until the lane timeout, and surfaced as a "Done." empty-reply fallback.
2. **#98348** — Zero-priced usage (Codex models deliberately ship `cost: 0`, which `isModelPricingKnown` treats as unknown) incremented an opaque `missingCostEntries` counter with no way to see **which** provider/model was unattributed.
3. **#107497** — `codex-synthetic-usage.ts` repeated the same preferred-vs-secondary precedence ranking across three merge helpers.

## Why This Change Was Made

- **Self-target guard**: after canonical session-key resolution and before dispatch, a synchronous send (`timeoutSeconds !== 0`) whose resolved target equals the requester's key fails fast with "sessions_send cannot target the calling session; use your own reply instead". The legitimate self-send path is preserved: `timeoutSeconds: 0` fire-and-forget channel-delivery/A2A flow is untouched, and cron/system-event delivery uses a separate mechanism.
- **Missing-cost breakdown**: an optional `missingCostByModel: Record<"provider/model", count>` rides alongside the existing scalar (kept for compatibility), aggregated where raw provider attribution already exists, with a cache-version bump and clone/merge support; the status runtime line and gateway CLI cost line render it compactly (`Missing cost: 3 (openai/gpt-5.6-sol 2, openai-codex/gpt-5.5 1)`).
- **Merge dedup**: one generic precedence helper feeds all three merges; identical ranking semantics, production file net −2 LOC, plus new billing-precedence coverage.

## User Impact

- No more mysterious lane-timeout "Done." replies from agent self-sends; the agent gets an actionable error immediately.
- `/status` and `openclaw gateway` cost output attribute missing-cost turns to concrete provider/model pairs.

## Evidence

- Focused suites (all pass): session-cost-usage 43+ (new breakdown/aggregation/clone-merge cases), codex-synthetic-usage (precedence coverage added), sessions tool 46 (self-target rejected; distinct target unaffected; fire-and-forget preserved), status-text, gateway-cli coverage.
- Live loopback proof during implementation showed the formatted breakdown line with JSON retaining scalar + map.
- Autoreview (Codex gpt-5.6-sol, xhigh): clean on first pass (0.94).

Fixes #107172
Fixes #98348
Fixes #107497
