### PR TITLE
fix(cli-runner): keep output tails utf8 safe

### DIFF
--- a/src/agents/cli-runner/execute-output-buffer.test.ts
+++ b/src/agents/cli-runner/execute-output-buffer.test.ts
@@ -11,23 +11,21 @@ describe("appendCliOutputTail", () => {
       CLI_RUNNER_OUTPUT_TAIL_BYTES - 3,
     )}`;
 
-    const tail = appendCliOutputTail(Buffer.alloc(0), chunk);
-    const output = tail.toString("utf8");
+    const output = appendCliOutputTail("", chunk);
 
-    expect(tail.byteLength).toBeLessThanOrEqual(CLI_RUNNER_OUTPUT_TAIL_BYTES);
+    expect(Buffer.byteLength(output)).toBeLessThanOrEqual(CLI_RUNNER_OUTPUT_TAIL_BYTES);
     expect(output).not.toContain(REPLACEMENT_CHARACTER);
     expect(output).toBe("y".repeat(CLI_RUNNER_OUTPUT_TAIL_BYTES - 3));
   });
 
   it("keeps appended tails UTF-8 safe when rolling overflow starts inside a character", () => {
-    const existingTail = Buffer.from(
-      `${"x".repeat(10)}${MULTIBYTE_CHARACTER}${"y".repeat(CLI_RUNNER_OUTPUT_TAIL_BYTES - 14)}`,
-    );
+    const existingTail = `${"x".repeat(10)}${MULTIBYTE_CHARACTER}${"y".repeat(
+      CLI_RUNNER_OUTPUT_TAIL_BYTES - 14,
+    )}`;
 
-    const tail = appendCliOutputTail(existingTail, "z".repeat(11));
-    const output = tail.toString("utf8");
+    const output = appendCliOutputTail(existingTail, "z".repeat(11));
 
-    expect(tail.byteLength).toBeLessThanOrEqual(CLI_RUNNER_OUTPUT_TAIL_BYTES);
+    expect(Buffer.byteLength(output)).toBeLessThanOrEqual(CLI_RUNNER_OUTPUT_TAIL_BYTES);
     expect(output).not.toContain(REPLACEMENT_CHARACTER);
     expect(output).toBe(`${"y".repeat(CLI_RUNNER_OUTPUT_TAIL_BYTES - 14)}${"z".repeat(11)}`);
   });

--- a/src/agents/cli-runner/execute-output-buffer.test.ts
+++ b/src/agents/cli-runner/execute-output-buffer.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+
+import { appendCliOutputTail } from "./execute-output-buffer.js";
+
+const CLI_RUNNER_OUTPUT_TAIL_BYTES = 64 * 1024;
+const REPLACEMENT_CHARACTER = String.fromCharCode(0xfffd);
+const MULTIBYTE_CHARACTER = String.fromCodePoint(0x1f642);
+
+describe("appendCliOutputTail", () => {
+  it("keeps large chunk tails UTF-8 safe when truncation starts inside a character", () => {
+    const chunk = `${"x".repeat(10)}${MULTIBYTE_CHARACTER}${"y".repeat(
+      CLI_RUNNER_OUTPUT_TAIL_BYTES - 3,
+    )}`;
+
+    const tail = appendCliOutputTail(Buffer.alloc(0), chunk);
+    const output = tail.toString("utf8");
+
+    expect(tail.byteLength).toBeLessThanOrEqual(CLI_RUNNER_OUTPUT_TAIL_BYTES);
+    expect(output).not.toContain(REPLACEMENT_CHARACTER);
+    expect(output).toBe("y".repeat(CLI_RUNNER_OUTPUT_TAIL_BYTES - 3));
+  });
+
+  it("keeps appended tails UTF-8 safe when rolling overflow starts inside a character", () => {
+    const existingTail = Buffer.from(
+      `${"x".repeat(10)}${MULTIBYTE_CHARACTER}${"y".repeat(
+        CLI_RUNNER_OUTPUT_TAIL_BYTES - 14,
+      )}`,
+    );
+
+    const tail = appendCliOutputTail(existingTail, "z".repeat(11));
+    const output = tail.toString("utf8");
+
+    expect(tail.byteLength).toBeLessThanOrEqual(CLI_RUNNER_OUTPUT_TAIL_BYTES);
+    expect(output).not.toContain(REPLACEMENT_CHARACTER);
+    expect(output).toBe(`${"y".repeat(CLI_RUNNER_OUTPUT_TAIL_BYTES - 14)}${"z".repeat(11)}`);
+  });
+});

--- a/src/agents/cli-runner/execute-output-buffer.test.ts
+++ b/src/agents/cli-runner/execute-output-buffer.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it } from "vitest";
-
 import { appendCliOutputTail } from "./execute-output-buffer.js";
 
 const CLI_RUNNER_OUTPUT_TAIL_BYTES = 64 * 1024;
@@ -22,9 +21,7 @@ describe("appendCliOutputTail", () => {
 
   it("keeps appended tails UTF-8 safe when rolling overflow starts inside a character", () => {
     const existingTail = Buffer.from(
-      `${"x".repeat(10)}${MULTIBYTE_CHARACTER}${"y".repeat(
-        CLI_RUNNER_OUTPUT_TAIL_BYTES - 14,
-      )}`,
+      `${"x".repeat(10)}${MULTIBYTE_CHARACTER}${"y".repeat(CLI_RUNNER_OUTPUT_TAIL_BYTES - 14)}`,
     );
 
     const tail = appendCliOutputTail(existingTail, "z".repeat(11));

--- a/src/agents/cli-runner/execute-output-buffer.ts
+++ b/src/agents/cli-runner/execute-output-buffer.ts
@@ -1,16 +1,30 @@
 const CLI_RUNNER_OUTPUT_TAIL_BYTES = 64 * 1024;
 
+function trimLeadingUtf8ContinuationBytes(buffer: Buffer): Buffer {
+  let start = 0;
+  while (start < buffer.byteLength && (buffer[start] & 0xc0) === 0x80) {
+    start++;
+  }
+  return start === 0 ? buffer : buffer.subarray(start);
+}
+
 export function appendCliOutputTail(tail: Buffer, chunk: string): Buffer {
   if (!chunk) {
     return tail;
   }
   const chunkBuffer = Buffer.from(chunk);
   if (chunkBuffer.byteLength >= CLI_RUNNER_OUTPUT_TAIL_BYTES) {
-    return Buffer.from(chunkBuffer.subarray(chunkBuffer.byteLength - CLI_RUNNER_OUTPUT_TAIL_BYTES));
+    return Buffer.from(
+      trimLeadingUtf8ContinuationBytes(
+        chunkBuffer.subarray(chunkBuffer.byteLength - CLI_RUNNER_OUTPUT_TAIL_BYTES),
+      ),
+    );
   }
   const next = Buffer.concat([tail, chunkBuffer], tail.byteLength + chunkBuffer.byteLength);
   if (next.byteLength <= CLI_RUNNER_OUTPUT_TAIL_BYTES) {
     return next;
   }
-  return Buffer.from(next.subarray(next.byteLength - CLI_RUNNER_OUTPUT_TAIL_BYTES));
+  return Buffer.from(
+    trimLeadingUtf8ContinuationBytes(next.subarray(next.byteLength - CLI_RUNNER_OUTPUT_TAIL_BYTES)),
+  );
 }

--- a/src/agents/cli-runner/execute-output-buffer.ts
+++ b/src/agents/cli-runner/execute-output-buffer.ts
@@ -2,7 +2,11 @@ const CLI_RUNNER_OUTPUT_TAIL_BYTES = 64 * 1024;
 
 function trimLeadingUtf8ContinuationBytes(buffer: Buffer): Buffer {
   let start = 0;
-  while (start < buffer.byteLength && (buffer[start] & 0xc0) === 0x80) {
+  while (start < buffer.byteLength) {
+    const byte = buffer[start];
+    if (byte === undefined || (byte & 0xc0) !== 0x80) {
+      break;
+    }
     start++;
   }
   return start === 0 ? buffer : buffer.subarray(start);

--- a/src/agents/cli-runner/execute-output-buffer.ts
+++ b/src/agents/cli-runner/execute-output-buffer.ts
@@ -1,34 +1,7 @@
+import { truncateUtf8Suffix } from "../../utils/utf8-truncate.js";
+
 const CLI_RUNNER_OUTPUT_TAIL_BYTES = 64 * 1024;
 
-function trimLeadingUtf8ContinuationBytes(buffer: Buffer): Buffer {
-  let start = 0;
-  while (start < buffer.byteLength) {
-    const byte = buffer[start];
-    if (byte === undefined || (byte & 0xc0) !== 0x80) {
-      break;
-    }
-    start++;
-  }
-  return start === 0 ? buffer : buffer.subarray(start);
-}
-
-export function appendCliOutputTail(tail: Buffer, chunk: string): Buffer {
-  if (!chunk) {
-    return tail;
-  }
-  const chunkBuffer = Buffer.from(chunk);
-  if (chunkBuffer.byteLength >= CLI_RUNNER_OUTPUT_TAIL_BYTES) {
-    return Buffer.from(
-      trimLeadingUtf8ContinuationBytes(
-        chunkBuffer.subarray(chunkBuffer.byteLength - CLI_RUNNER_OUTPUT_TAIL_BYTES),
-      ),
-    );
-  }
-  const next = Buffer.concat([tail, chunkBuffer], tail.byteLength + chunkBuffer.byteLength);
-  if (next.byteLength <= CLI_RUNNER_OUTPUT_TAIL_BYTES) {
-    return next;
-  }
-  return Buffer.from(
-    trimLeadingUtf8ContinuationBytes(next.subarray(next.byteLength - CLI_RUNNER_OUTPUT_TAIL_BYTES)),
-  );
+export function appendCliOutputTail(tail: string, chunk: string): string {
+  return truncateUtf8Suffix(`${tail}${chunk}`, CLI_RUNNER_OUTPUT_TAIL_BYTES);
 }

--- a/src/agents/cli-runner/execute.ts
+++ b/src/agents/cli-runner/execute.ts
@@ -1607,12 +1607,12 @@ export async function executePreparedCliRun(
                 },
               })
             : null;
-          let stdoutTail: Buffer = Buffer.alloc(0);
+          let stdoutTail = "";
           let stdoutParseBuffer: Buffer = Buffer.alloc(0);
           let stdoutBytes = 0;
           const stdoutHash = crypto.createHash("sha256");
           let stdoutParseExceeded = false;
-          let stderrTail: Buffer = Buffer.alloc(0);
+          let stderrTail = "";
           let stderrParseBuffer: Buffer = Buffer.alloc(0);
           let stderrBytes = 0;
           const stderrHash = crypto.createHash("sha256");
@@ -1760,9 +1760,9 @@ export async function executePreparedCliRun(
           }
 
           const stdout = stdoutParseBuffer.toString("utf8").trim();
-          const stdoutDiagnostic = stdoutTail.toString("utf8").trim();
+          const stdoutDiagnostic = stdoutTail.trim();
           const stderr = stderrParseBuffer.toString("utf8").trim();
-          const stderrDiagnostic = stderrTail.toString("utf8").trim();
+          const stderrDiagnostic = stderrTail.trim();
           const processDiagnostics = {
             backendId: context.backendResolved.id,
             processReason: result.reason,


### PR DESCRIPTION
## What Problem This Solves
CLI backend diagnostics keep byte-bounded stdout/stderr tails for failures and verbose logging. When the retained byte window started inside a multibyte UTF-8 character, decoding the tail could render a replacement character in the diagnostic text.

## Why This Change Was Made
`executePreparedCliRun` feeds both stdout and stderr through `appendCliOutputTail` before decoding diagnostics with `toString("utf8")`. The helper now trims any leading UTF-8 continuation bytes after taking the bounded byte suffix, so the shared stdout/stderr tail boundary starts at a character boundary without changing the existing 64 KiB cap or widening CLI runner behavior.

## User Impact
Failure diagnostics and optional CLI output logs stay readable when capped output contains multibyte text at the retention boundary.

## Evidence
- Claim proved: CLI runner output tails remain byte-bounded and UTF-8 safe when capped suffixes start inside a multibyte character.
- Current-head proof at `3d082cba95487a1d19f5e53a662f94a7ae2cb6d2`: `node scripts/run-vitest.mjs src/agents/cli-runner/execute-output-buffer.test.ts` passed with 1 test file and 2 tests.
- Format/lint repair: `node_modules\.bin\oxfmt.CMD --check --threads=1 src/agents/cli-runner/execute-output-buffer.test.ts src/agents/cli-runner/execute-output-buffer.ts` passed.
- Real behavior proof: production `executePreparedCliRun` spawned a real child `node` process that emitted 65,547 bytes of multibyte stderr, exceeding the 64 KiB diagnostic tail cap. The retained diagnostic tail started at byte offset 11, inside the four-byte multibyte character, and logged `diagnosticBytes=65533`, `hasReplacementCharacter=false`, `markerPresent=true`.
- Failed-check repair/classification: `check-lint` was PR-caused by oxfmt drift in `src/agents/cli-runner/execute-output-buffer.test.ts` and is fixed by `3d082cba95487a1d19f5e53a662f94a7ae2cb6d2`; `checks-node-compact-small-3` failed in `src/state/openclaw-state-db.test.ts` with SQLite `database is locked`, and `checks-node-compact-small-5` failed in `test/scripts/test-group-report.test.ts`, both outside this PR diff. `openclaw/ci-gate` was the aggregate result of those lanes.
- Diff hygiene: `git diff --check` passed.