### PR TITLE
fix(abort): cancel owner-scoped ACP tasks on requester stop

### DIFF
--- a/src/auto-reply/reply/abort.test.ts
+++ b/src/auto-reply/reply/abort.test.ts
@@ -102,6 +102,19 @@ const taskRegistryMocks = vi.hoisted(() => ({
         createdAt: number;
       }>,
   ),
+  cancelOwnedTaskRunById: vi.fn(
+    async (params: { cfg: unknown; taskId: string; callerOwnerKey: string; reason?: string }) => ({
+      found: true,
+      cancelled: true,
+      task: {
+        taskId: params.taskId,
+        status: "cancelled",
+        error: params.reason ?? "owner-stopped",
+        runtime: "acp",
+        ownerKey: params.callerOwnerKey,
+      },
+    }),
+  ),
   isTerminalTaskStatus: vi.fn((status: string) =>
     ["succeeded", "failed", "timed_out", "lost", "cancelled"].includes(status),
   ),
@@ -109,6 +122,7 @@ const taskRegistryMocks = vi.hoisted(() => ({
 
 vi.mock("../../tasks/task-owner-access.js", () => ({
   listTasksForOwnerKey: taskRegistryMocks.listTasksForOwnerKey,
+  cancelOwnedTaskRunById: taskRegistryMocks.cancelOwnedTaskRunById,
 }));
 
 vi.mock("../../tasks/task-executor-policy.js", () => ({
@@ -286,6 +300,27 @@ describe("abort detection", () => {
     commandQueueMocks.clearCommandLane.mockClear().mockReturnValue(1);
     acpManagerMocks.resolveSession.mockReset().mockReturnValue({ kind: "none" });
     acpManagerMocks.cancelSession.mockReset().mockResolvedValue(undefined);
+    taskRegistryMocks.listTasksForOwnerKey.mockReset().mockReturnValue([]);
+    taskRegistryMocks.cancelOwnedTaskRunById
+      .mockReset()
+      .mockImplementation(
+        async (params: {
+          cfg: unknown;
+          taskId: string;
+          callerOwnerKey: string;
+          reason?: string;
+        }) => ({
+          found: true,
+          cancelled: true,
+          task: {
+            taskId: params.taskId,
+            status: "cancelled",
+            error: params.reason ?? "owner-stopped",
+            runtime: "acp",
+            ownerKey: params.callerOwnerKey,
+          },
+        }),
+      );
     runtimeAbortMocks.abortEmbeddedAgentRun.mockReset().mockReturnValue(true);
     runtimeAbortMocks.resolveActiveEmbeddedRunSessionId.mockReset().mockReturnValue(undefined);
     subagentRegistryMocks.getLatestSubagentRunByChildSessionKey.mockReset().mockReturnValue(null);
@@ -1245,7 +1280,7 @@ describe("abort detection", () => {
     expectSessionLaneCleared(childKey);
   });
 
-  it("continues stopping siblings when one termination persistence write fails", () => {
+  it("continues stopping siblings when one termination persistence write fails", async () => {
     subagentRegistryMocks.markSubagentRunTerminated.mockClear();
     const sessionKey = "telegram:persistence-failure-parent";
     const firstChildKey = "agent:main:subagent:persistence-failure-first";
@@ -1271,12 +1306,12 @@ describe("abort detection", () => {
       })
       .mockReturnValue(1);
 
-    expect(
+    await expect(
       stopSubagentsForRequester({
         cfg: {} as OpenClawConfig,
         requesterSessionKey: sessionKey,
       }),
-    ).toEqual({ stopped: 2 });
+    ).resolves.toEqual({ stopped: 2 });
     expect(subagentRegistryMocks.markSubagentRunTerminated).toHaveBeenCalledTimes(2);
     expectSessionLaneCleared(firstChildKey);
     expectSessionLaneCleared(secondChildKey);
@@ -1338,7 +1373,7 @@ describe("abort detection", () => {
     expectSessionLaneCleared(depth2Key);
   });
 
-  it("stops a subagent that is paused after yielding", () => {
+  it("stops a subagent that is paused after yielding", async () => {
     subagentRegistryMocks.listSubagentRunsForRequester.mockClear();
     subagentRegistryMocks.markSubagentRunTerminated.mockClear();
     const sessionKey = "telegram:yield-parent";
@@ -1360,7 +1395,7 @@ describe("abort detection", () => {
       ])
       .mockReturnValueOnce([]);
 
-    const result = stopSubagentsForRequester({
+    const result = await stopSubagentsForRequester({
       cfg: {} as OpenClawConfig,
       requesterSessionKey: sessionKey,
     });
@@ -1550,7 +1585,7 @@ describe("abort detection", () => {
     expect(terminatedRun.childSessionKey).toBe(depth2Key);
   });
 
-  it("stopSubagentsForRequester does not traverse a child that moved to a newer parent", () => {
+  it("stopSubagentsForRequester does not traverse a child that moved to a newer parent", async () => {
     subagentRegistryMocks.listSubagentRunsForRequester.mockClear();
     subagentRegistryMocks.markSubagentRunTerminated.mockClear();
     const oldParentKey = "agent:main:subagent:old-parent";
@@ -1614,7 +1649,7 @@ describe("abort detection", () => {
       return null;
     });
 
-    const result = stopSubagentsForRequester({
+    const result = await stopSubagentsForRequester({
       cfg: {} as OpenClawConfig,
       requesterSessionKey: oldParentKey,
     });
@@ -1625,7 +1660,7 @@ describe("abort detection", () => {
 
   it("stopSubagentsForRequester cancels active ACP detached tasks not in the subagent registry", async () => {
     subagentRegistryMocks.listSubagentRunsForRequester.mockReset().mockReturnValue([]);
-    acpManagerMocks.cancelSession.mockClear();
+    taskRegistryMocks.cancelOwnedTaskRunById.mockClear();
     taskRegistryMocks.listTasksForOwnerKey.mockReset().mockReturnValueOnce([
       {
         taskId: "task-acp-1",
@@ -1642,18 +1677,16 @@ describe("abort detection", () => {
       },
     ]);
 
-    const result = stopSubagentsForRequester({
+    const result = await stopSubagentsForRequester({
       cfg: {} as OpenClawConfig,
       requesterSessionKey: "telegram:owner",
     });
 
     expect(result).toEqual({ stopped: 1 });
-    await new Promise<void>((resolve) => {
-      setTimeout(resolve, 0);
-    });
-    expect(acpManagerMocks.cancelSession).toHaveBeenCalledWith(
+    expect(taskRegistryMocks.cancelOwnedTaskRunById).toHaveBeenCalledWith(
       expect.objectContaining({
-        sessionKey: "acp:session:orphan-1",
+        taskId: "task-acp-1",
+        callerOwnerKey: "telegram:owner",
         reason: "owner-stopped",
       }),
     );
@@ -1676,7 +1709,7 @@ describe("abort detection", () => {
         createdAt: now,
       },
     ]);
-    acpManagerMocks.cancelSession.mockClear();
+    taskRegistryMocks.cancelOwnedTaskRunById.mockClear();
     taskRegistryMocks.listTasksForOwnerKey.mockReset().mockReturnValueOnce([
       {
         taskId: "task-terminal",
@@ -1706,18 +1739,15 @@ describe("abort detection", () => {
       },
     ]);
 
-    const result = stopSubagentsForRequester({
+    const result = await stopSubagentsForRequester({
       cfg: {} as OpenClawConfig,
       requesterSessionKey: "telegram:owner",
     });
 
     expect(result.stopped).toBeGreaterThanOrEqual(1);
-    await new Promise<void>((resolve) => {
-      setTimeout(resolve, 0);
-    });
-    expect(acpManagerMocks.cancelSession).toHaveBeenCalledTimes(1);
-    expect(acpManagerMocks.cancelSession).toHaveBeenCalledWith(
-      expect.objectContaining({ sessionKey: activeAcpKey }),
+    expect(taskRegistryMocks.cancelOwnedTaskRunById).toHaveBeenCalledTimes(1);
+    expect(taskRegistryMocks.cancelOwnedTaskRunById).toHaveBeenCalledWith(
+      expect.objectContaining({ taskId: "task-active", reason: "owner-stopped" }),
     );
   });
 
@@ -1737,7 +1767,7 @@ describe("abort detection", () => {
         endedAt: now - 1_000,
       },
     ]);
-    acpManagerMocks.cancelSession.mockClear();
+    taskRegistryMocks.cancelOwnedTaskRunById.mockClear();
     taskRegistryMocks.listTasksForOwnerKey.mockReset().mockReturnValueOnce([
       {
         taskId: "task-active",
@@ -1754,19 +1784,51 @@ describe("abort detection", () => {
       },
     ]);
 
-    const result = stopSubagentsForRequester({
+    const result = await stopSubagentsForRequester({
       cfg: {} as OpenClawConfig,
       requesterSessionKey: "telegram:owner",
     });
 
     expect(result.stopped).toBe(1);
-    await new Promise<void>((resolve) => {
-      setTimeout(resolve, 0);
-    });
-    expect(acpManagerMocks.cancelSession).toHaveBeenCalledTimes(1);
-    expect(acpManagerMocks.cancelSession).toHaveBeenCalledWith(
-      expect.objectContaining({ sessionKey: sharedChildKey }),
+    expect(taskRegistryMocks.cancelOwnedTaskRunById).toHaveBeenCalledTimes(1);
+    expect(taskRegistryMocks.cancelOwnedTaskRunById).toHaveBeenCalledWith(
+      expect.objectContaining({
+        taskId: "task-active",
+        reason: "owner-stopped",
+      }),
     );
+  });
+
+  it("stopSubagentsForRequester does not count ACP tasks when lifecycle cancel fails", async () => {
+    subagentRegistryMocks.listSubagentRunsForRequester.mockReset().mockReturnValue([]);
+    taskRegistryMocks.cancelOwnedTaskRunById.mockClear().mockResolvedValueOnce({
+      found: true,
+      cancelled: false,
+      reason: "Task is already terminal.",
+    });
+    taskRegistryMocks.listTasksForOwnerKey.mockReset().mockReturnValueOnce([
+      {
+        taskId: "task-stale",
+        runtime: "acp",
+        status: "running",
+        childSessionKey: "acp:session:stale",
+        ownerKey: "telegram:owner",
+        task: "stale acp task",
+        requesterSessionKey: "telegram:owner",
+        scopeKind: "session",
+        deliveryStatus: "pending",
+        notifyPolicy: "default",
+        createdAt: Date.now() - 1_000,
+      },
+    ]);
+
+    const result = await stopSubagentsForRequester({
+      cfg: {} as OpenClawConfig,
+      requesterSessionKey: "telegram:owner",
+    });
+
+    expect(result).toEqual({ stopped: 0 });
+    expect(taskRegistryMocks.cancelOwnedTaskRunById).toHaveBeenCalledTimes(1);
   });
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/auto-reply/reply/abort.test.ts
+++ b/src/auto-reply/reply/abort.test.ts
@@ -85,6 +85,36 @@ vi.mock("../../acp/control-plane/manager.js", () => ({
   }),
 }));
 
+const taskRegistryMocks = vi.hoisted(() => ({
+  listTasksForOwnerKey: vi.fn(
+    () =>
+      [] as Array<{
+        taskId: string;
+        runtime: string;
+        status: string;
+        childSessionKey?: string;
+        ownerKey: string;
+        task: string;
+        requesterSessionKey: string;
+        scopeKind: string;
+        deliveryStatus: string;
+        notifyPolicy: string;
+        createdAt: number;
+      }>,
+  ),
+  isTerminalTaskStatus: vi.fn((status: string) =>
+    ["succeeded", "failed", "timed_out", "lost", "cancelled"].includes(status),
+  ),
+}));
+
+vi.mock("../../tasks/task-owner-access.js", () => ({
+  listTasksForOwnerKey: taskRegistryMocks.listTasksForOwnerKey,
+}));
+
+vi.mock("../../tasks/task-executor-policy.js", () => ({
+  isTerminalTaskStatus: taskRegistryMocks.isTerminalTaskStatus,
+}));
+
 const suiteTempDirs = createSuiteTempRootTracker({ prefix: "openclaw-abort-" });
 
 describe("abort detection", () => {
@@ -1591,6 +1621,152 @@ describe("abort detection", () => {
 
     expect(result).toEqual({ stopped: 0 });
     expect(subagentRegistryMocks.markSubagentRunTerminated).not.toHaveBeenCalled();
+  });
+
+  it("stopSubagentsForRequester cancels active ACP detached tasks not in the subagent registry", async () => {
+    subagentRegistryMocks.listSubagentRunsForRequester.mockReset().mockReturnValue([]);
+    acpManagerMocks.cancelSession.mockClear();
+    taskRegistryMocks.listTasksForOwnerKey.mockReset().mockReturnValueOnce([
+      {
+        taskId: "task-acp-1",
+        runtime: "acp",
+        status: "running",
+        childSessionKey: "acp:session:orphan-1",
+        ownerKey: "telegram:owner",
+        task: "background acp task",
+        requesterSessionKey: "telegram:owner",
+        scopeKind: "session",
+        deliveryStatus: "pending",
+        notifyPolicy: "default",
+        createdAt: Date.now() - 5_000,
+      },
+    ]);
+
+    const result = stopSubagentsForRequester({
+      cfg: {} as OpenClawConfig,
+      requesterSessionKey: "telegram:owner",
+    });
+
+    expect(result).toEqual({ stopped: 1 });
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 0);
+    });
+    expect(acpManagerMocks.cancelSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionKey: "acp:session:orphan-1",
+        reason: "owner-stopped",
+      }),
+    );
+  });
+
+  it("stopSubagentsForRequester skips terminal ACP tasks and active subagent-covered children", async () => {
+    const subagentChildKey = "agent:main:subagent:covered-child";
+    const terminalAcpKey = "acp:session:already-done";
+    const activeAcpKey = "acp:session:active-orphan";
+    const now = Date.now();
+
+    subagentRegistryMocks.listSubagentRunsForRequester.mockReset().mockReturnValueOnce([
+      {
+        runId: "run-covered",
+        childSessionKey: subagentChildKey,
+        requesterSessionKey: "telegram:owner",
+        requesterDisplayKey: "telegram:owner",
+        task: "covered by subagent registry",
+        cleanup: "keep",
+        createdAt: now,
+      },
+    ]);
+    acpManagerMocks.cancelSession.mockClear();
+    taskRegistryMocks.listTasksForOwnerKey.mockReset().mockReturnValueOnce([
+      {
+        taskId: "task-terminal",
+        runtime: "acp",
+        status: "succeeded",
+        childSessionKey: terminalAcpKey,
+        ownerKey: "telegram:owner",
+        task: "already done",
+        requesterSessionKey: "telegram:owner",
+        scopeKind: "session",
+        deliveryStatus: "delivered",
+        notifyPolicy: "default",
+        createdAt: now - 10_000,
+      },
+      {
+        taskId: "task-active",
+        runtime: "acp",
+        status: "running",
+        childSessionKey: activeAcpKey,
+        ownerKey: "telegram:owner",
+        task: "active orphan",
+        requesterSessionKey: "telegram:owner",
+        scopeKind: "session",
+        deliveryStatus: "pending",
+        notifyPolicy: "default",
+        createdAt: now - 2_000,
+      },
+    ]);
+
+    const result = stopSubagentsForRequester({
+      cfg: {} as OpenClawConfig,
+      requesterSessionKey: "telegram:owner",
+    });
+
+    expect(result.stopped).toBeGreaterThanOrEqual(1);
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 0);
+    });
+    expect(acpManagerMocks.cancelSession).toHaveBeenCalledTimes(1);
+    expect(acpManagerMocks.cancelSession).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionKey: activeAcpKey }),
+    );
+  });
+
+  it("stopSubagentsForRequester does not let an ended subagent record mask an active ACP task", async () => {
+    const sharedChildKey = "acp:session:shared-child";
+    const now = Date.now();
+
+    subagentRegistryMocks.listSubagentRunsForRequester.mockReset().mockReturnValueOnce([
+      {
+        runId: "run-ended",
+        childSessionKey: sharedChildKey,
+        requesterSessionKey: "telegram:owner",
+        requesterDisplayKey: "telegram:owner",
+        task: "ended subagent",
+        cleanup: "keep",
+        createdAt: now - 5_000,
+        endedAt: now - 1_000,
+      },
+    ]);
+    acpManagerMocks.cancelSession.mockClear();
+    taskRegistryMocks.listTasksForOwnerKey.mockReset().mockReturnValueOnce([
+      {
+        taskId: "task-active",
+        runtime: "acp",
+        status: "running",
+        childSessionKey: sharedChildKey,
+        ownerKey: "telegram:owner",
+        task: "active acp task",
+        requesterSessionKey: "telegram:owner",
+        scopeKind: "session",
+        deliveryStatus: "pending",
+        notifyPolicy: "default",
+        createdAt: now - 1_000,
+      },
+    ]);
+
+    const result = stopSubagentsForRequester({
+      cfg: {} as OpenClawConfig,
+      requesterSessionKey: "telegram:owner",
+    });
+
+    expect(result.stopped).toBe(1);
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 0);
+    });
+    expect(acpManagerMocks.cancelSession).toHaveBeenCalledTimes(1);
+    expect(acpManagerMocks.cancelSession).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionKey: sharedChildKey }),
+    );
   });
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/auto-reply/reply/abort.ts
+++ b/src/auto-reply/reply/abort.ts
@@ -33,7 +33,7 @@ import { logVerbose } from "../../globals.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { isAcpSessionKey, parseAgentSessionKey } from "../../routing/session-key.js";
 import { isTerminalTaskStatus } from "../../tasks/task-executor-policy.js";
-import { listTasksForOwnerKey } from "../../tasks/task-owner-access.js";
+import { cancelOwnedTaskRunById, listTasksForOwnerKey } from "../../tasks/task-owner-access.js";
 import { resolveCommandAuthorization } from "../command-auth.js";
 import type { FinalizedMsgContext } from "../templating.js";
 import {
@@ -60,6 +60,7 @@ const defaultAbortDeps = {
   listSubagentRunsForController,
   markSubagentRunTerminated,
   listTasksForOwnerKey,
+  cancelOwnedTaskRunById,
   isTerminalTaskStatus,
 };
 
@@ -88,6 +89,8 @@ export const testing = {
       deps?.markSubagentRunTerminated ?? defaultAbortDeps.markSubagentRunTerminated;
     abortDeps.listTasksForOwnerKey =
       deps?.listTasksForOwnerKey ?? defaultAbortDeps.listTasksForOwnerKey;
+    abortDeps.cancelOwnedTaskRunById =
+      deps?.cancelOwnedTaskRunById ?? defaultAbortDeps.cancelOwnedTaskRunById;
     abortDeps.isTerminalTaskStatus =
       deps?.isTerminalTaskStatus ?? defaultAbortDeps.isTerminalTaskStatus;
   },
@@ -103,6 +106,7 @@ export const testing = {
     abortDeps.listSubagentRunsForController = defaultAbortDeps.listSubagentRunsForController;
     abortDeps.markSubagentRunTerminated = defaultAbortDeps.markSubagentRunTerminated;
     abortDeps.listTasksForOwnerKey = defaultAbortDeps.listTasksForOwnerKey;
+    abortDeps.cancelOwnedTaskRunById = defaultAbortDeps.cancelOwnedTaskRunById;
     abortDeps.isTerminalTaskStatus = defaultAbortDeps.isTerminalTaskStatus;
   },
 };
@@ -224,10 +228,10 @@ function markSubagentRunTerminatedBestEffort(
   }
 }
 
-export function stopSubagentsForRequester(params: {
+export async function stopSubagentsForRequester(params: {
   cfg: OpenClawConfig;
   requesterSessionKey?: string;
-}): { stopped: number } {
+}): Promise<{ stopped: number }> {
   const requesterKey = normalizeRequesterSessionKey(params.cfg, params.requesterSessionKey);
   if (!requesterKey) {
     return { stopped: 0 };
@@ -308,7 +312,7 @@ export function stopSubagentsForRequester(params: {
     }
 
     // Cascade: also stop any sub-sub-agents spawned by this child.
-    const cascadeResult = stopSubagentsForRequester({
+    const cascadeResult = await stopSubagentsForRequester({
       cfg: params.cfg,
       requesterSessionKey: childKey,
     });
@@ -316,8 +320,8 @@ export function stopSubagentsForRequester(params: {
   }
 
   // ACP spawns create owner-scoped task records, not subagent-registry runs.
-  // Cancel non-terminal ACP children that the subagent walk did not already cover.
-  // Cancel is fire-and-forget: AcpSessionManager owns mode-aware process cleanup.
+  // Route non-terminal ACP children through the canonical task cancellation
+  // lifecycle so durable state, flow abort, and delivery stay coordinated.
   for (const task of abortDeps.listTasksForOwnerKey(requesterKey)) {
     const childKey = normalizeOptionalString(task.childSessionKey);
     if (
@@ -329,15 +333,25 @@ export function stopSubagentsForRequester(params: {
       continue;
     }
     seenChildKeys.add(childKey);
-    stopped += 1;
-    abortDeps
-      .getAcpSessionManager()
-      .cancelSession({ cfg: params.cfg, sessionKey: childKey, reason: "owner-stopped" })
-      .catch((err: unknown) => {
-        logVerbose(
-          `abort: failed to cancel ACP task ${task.taskId} for ${requesterKey}: ${formatErrorMessage(err)}`,
-        );
+    try {
+      const cancelResult = await abortDeps.cancelOwnedTaskRunById({
+        cfg: params.cfg,
+        taskId: task.taskId,
+        callerOwnerKey: requesterKey,
+        reason: "owner-stopped",
       });
+      if (cancelResult.cancelled) {
+        stopped += 1;
+      } else {
+        logVerbose(
+          `abort: ACP task ${task.taskId} for ${requesterKey} not cancelled: ${cancelResult.reason ?? "unknown"}`,
+        );
+      }
+    } catch (err: unknown) {
+      logVerbose(
+        `abort: failed to cancel ACP task ${task.taskId} for ${requesterKey}: ${formatErrorMessage(err)}`,
+      );
+    }
   }
 
   if (stopped > 0) {
@@ -498,7 +512,7 @@ export async function tryFastAbortFromMessage(params: {
         `abort: cleared followups=${cleared.followupCleared} lane=${cleared.laneCleared} keys=${cleared.keys.join(",")}`,
       );
     }
-    const { stopped } = stopSubagentsForRequester({ cfg, requesterSessionKey });
+    const { stopped } = await stopSubagentsForRequester({ cfg, requesterSessionKey });
     if (activeAbortRejected && !aborted) {
       return {
         handled: true,
@@ -539,6 +553,6 @@ export async function tryFastAbortFromMessage(params: {
   if (abortKey) {
     setAbortMemory(abortKey, true);
   }
-  const { stopped } = stopSubagentsForRequester({ cfg, requesterSessionKey });
+  const { stopped } = await stopSubagentsForRequester({ cfg, requesterSessionKey });
   return { handled: true, aborted: false, stoppedSubagents: stopped };
 }

--- a/src/auto-reply/reply/abort.ts
+++ b/src/auto-reply/reply/abort.ts
@@ -32,6 +32,8 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { logVerbose } from "../../globals.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { isAcpSessionKey, parseAgentSessionKey } from "../../routing/session-key.js";
+import { isTerminalTaskStatus } from "../../tasks/task-executor-policy.js";
+import { listTasksForOwnerKey } from "../../tasks/task-owner-access.js";
 import { resolveCommandAuthorization } from "../command-auth.js";
 import type { FinalizedMsgContext } from "../templating.js";
 import {
@@ -57,6 +59,8 @@ const defaultAbortDeps = {
   getLatestSubagentRunByChildSessionKey,
   listSubagentRunsForController,
   markSubagentRunTerminated,
+  listTasksForOwnerKey,
+  isTerminalTaskStatus,
 };
 
 const abortDeps = {
@@ -82,6 +86,10 @@ export const testing = {
       deps?.listSubagentRunsForController ?? defaultAbortDeps.listSubagentRunsForController;
     abortDeps.markSubagentRunTerminated =
       deps?.markSubagentRunTerminated ?? defaultAbortDeps.markSubagentRunTerminated;
+    abortDeps.listTasksForOwnerKey =
+      deps?.listTasksForOwnerKey ?? defaultAbortDeps.listTasksForOwnerKey;
+    abortDeps.isTerminalTaskStatus =
+      deps?.isTerminalTaskStatus ?? defaultAbortDeps.isTerminalTaskStatus;
   },
   resetDepsForTests(): void {
     abortDeps.getAcpSessionManager = defaultAbortDeps.getAcpSessionManager;
@@ -94,6 +102,8 @@ export const testing = {
       defaultAbortDeps.getLatestSubagentRunByChildSessionKey;
     abortDeps.listSubagentRunsForController = defaultAbortDeps.listSubagentRunsForController;
     abortDeps.markSubagentRunTerminated = defaultAbortDeps.markSubagentRunTerminated;
+    abortDeps.listTasksForOwnerKey = defaultAbortDeps.listTasksForOwnerKey;
+    abortDeps.isTerminalTaskStatus = defaultAbortDeps.isTerminalTaskStatus;
   },
 };
 
@@ -248,10 +258,6 @@ export function stopSubagentsForRequester(params: {
     }
   }
   const runs = Array.from(dedupedRunsByChildKey.values());
-  if (runs.length === 0) {
-    return { stopped: 0 };
-  }
-
   const seenChildKeys = new Set<string>();
   let stopped = 0;
 
@@ -260,9 +266,14 @@ export function stopSubagentsForRequester(params: {
     if (!childKey || seenChildKeys.has(childKey)) {
       continue;
     }
-    seenChildKeys.add(childKey);
+    // Only mark active runs as seen so an ended subagent record cannot mask an
+    // active ACP detached task that shares the same child session key.
+    const isActiveRun = !run.endedAt || run.pauseReason === "sessions_yield";
+    if (isActiveRun) {
+      seenChildKeys.add(childKey);
+    }
 
-    if (!run.endedAt || run.pauseReason === "sessions_yield") {
+    if (isActiveRun) {
       const cleared = clearSessionQueues([childKey]);
       const parsed = parseAgentSessionKey(childKey);
       const storePath = resolveStorePath(params.cfg.session?.store, { agentId: parsed?.agentId });
@@ -302,6 +313,31 @@ export function stopSubagentsForRequester(params: {
       requesterSessionKey: childKey,
     });
     stopped += cascadeResult.stopped;
+  }
+
+  // ACP spawns create owner-scoped task records, not subagent-registry runs.
+  // Cancel non-terminal ACP children that the subagent walk did not already cover.
+  // Cancel is fire-and-forget: AcpSessionManager owns mode-aware process cleanup.
+  for (const task of abortDeps.listTasksForOwnerKey(requesterKey)) {
+    const childKey = normalizeOptionalString(task.childSessionKey);
+    if (
+      task.runtime !== "acp" ||
+      abortDeps.isTerminalTaskStatus(task.status) ||
+      !childKey ||
+      seenChildKeys.has(childKey)
+    ) {
+      continue;
+    }
+    seenChildKeys.add(childKey);
+    stopped += 1;
+    abortDeps
+      .getAcpSessionManager()
+      .cancelSession({ cfg: params.cfg, sessionKey: childKey, reason: "owner-stopped" })
+      .catch((err: unknown) => {
+        logVerbose(
+          `abort: failed to cancel ACP task ${task.taskId} for ${requesterKey}: ${formatErrorMessage(err)}`,
+        );
+      });
   }
 
   if (stopped > 0) {

--- a/src/auto-reply/reply/commands-session-abort.ts
+++ b/src/auto-reply/reply/commands-session-abort.ts
@@ -166,7 +166,7 @@ export const handleStopCommand: CommandHandler = async (params, allowTextCommand
   );
   await triggerInternalHook(hookEvent);
 
-  const { stopped } = stopSubagentsForRequester({
+  const { stopped } = await stopSubagentsForRequester({
     cfg: params.cfg,
     requesterSessionKey: abortTarget.key ?? params.sessionKey,
   });

--- a/src/gateway/session-reset-service.ts
+++ b/src/gateway/session-reset-service.ts
@@ -360,7 +360,10 @@ async function ensureSessionRuntimeCleanup(params: {
   clearSessionResetRuntimeState([...queueKeys], {
     activeReplySessionId: params.sessionId,
   });
-  stopSubagentsForRequester({ cfg: params.cfg, requesterSessionKey: params.target.canonicalKey });
+  await stopSubagentsForRequester({
+    cfg: params.cfg,
+    requesterSessionKey: params.target.canonicalKey,
+  });
   if (!params.sessionId) {
     params.assertCurrent?.();
     clearBootstrapSnapshot(params.target.canonicalKey);

--- a/src/tasks/task-owner-access.test.ts
+++ b/src/tasks/task-owner-access.test.ts
@@ -3,12 +3,13 @@ import { afterEach, describe, expect, it } from "vitest";
 import { captureEnv } from "../test-utils/env.js";
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import {
+  cancelOwnedTaskRunById,
   findLatestTaskForRelatedSessionKeyForOwner,
   findTaskByRunIdForOwner,
   getTaskByIdForOwner,
   resolveTaskForLookupTokenForOwner,
 } from "./task-owner-access.js";
-import { createTaskRecord as createTaskRecordOrNull } from "./task-registry.js";
+import { createTaskRecord as createTaskRecordOrNull, getTaskById } from "./task-registry.js";
 import type { TaskRecord } from "./task-registry.types.js";
 import { resetTaskRegistryForTests } from "./task-runtime.test-helpers.js";
 
@@ -151,6 +152,34 @@ describe("task owner access", () => {
           callerOwnerKey: "agent:main:main",
         }),
       ).toBeUndefined();
+    });
+  });
+
+  it("cancelOwnedTaskRunById rejects non-owner callers without mutating the task", async () => {
+    await withTaskRegistryTempDir(async () => {
+      const task = createTaskRecord({
+        runtime: "acp",
+        ownerKey: "agent:main:main",
+        scopeKind: "session",
+        childSessionKey: "agent:main:acp:child-1",
+        runId: "owner-cancel-guard-run",
+        task: "Protected acp task",
+        status: "running",
+      });
+
+      const result = await cancelOwnedTaskRunById({
+        cfg: {} as never,
+        taskId: task.taskId,
+        callerOwnerKey: "agent:main:subagent:other-parent",
+        reason: "owner-stopped",
+      });
+
+      expect(result).toEqual({
+        found: false,
+        cancelled: false,
+        reason: "Task not found.",
+      });
+      expect(getTaskById(task.taskId)?.status).toBe("running");
     });
   });
 });

--- a/src/tasks/task-owner-access.ts
+++ b/src/tasks/task-owner-access.ts
@@ -1,6 +1,8 @@
 // Normalizes task owner keys and checks requester access to task records.
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
+  cancelTaskById,
   findTaskByRunId,
   getTaskById,
   listTasksForOwnerKey,
@@ -77,6 +79,31 @@ export function cancelTaskByIdForOwner(params: {
     status: "cancelled",
     endedAt: params.endedAt,
     terminalSummary: params.terminalSummary,
+  });
+}
+
+/**
+ * Cancel an owner-visible task through the canonical task cancellation path
+ * (runtime controller + durable terminal state + delivery coordination).
+ * Distinct from cancelTaskByIdForOwner, which only marks the record terminal.
+ */
+export async function cancelOwnedTaskRunById(params: {
+  cfg: OpenClawConfig;
+  taskId: string;
+  callerOwnerKey: string;
+  reason?: string;
+}): Promise<{ found: boolean; cancelled: boolean; reason?: string; task?: TaskRecord }> {
+  const task = getTaskByIdForOwner({
+    taskId: params.taskId,
+    callerOwnerKey: params.callerOwnerKey,
+  });
+  if (!task) {
+    return { found: false, cancelled: false, reason: "Task not found." };
+  }
+  return cancelTaskById({
+    cfg: params.cfg,
+    taskId: task.taskId,
+    reason: params.reason,
   });
 }
 

--- a/src/tasks/task-owner-access.ts
+++ b/src/tasks/task-owner-access.ts
@@ -3,6 +3,7 @@ import { normalizeOptionalString } from "@openclaw/normalization-core/string-coe
 import {
   findTaskByRunId,
   getTaskById,
+  listTasksForOwnerKey,
   listTasksForRelatedSessionKey,
   markTaskTerminalById as markTaskTerminalRecordById,
   resolveTaskForLookupToken,
@@ -10,6 +11,10 @@ import {
 } from "./task-registry.js";
 import type { TaskNotifyPolicy, TaskRecord } from "./task-registry.types.js";
 import { buildTaskStatusSnapshot } from "./task-status.js";
+
+// Owner-scoped abort and status callers use this access seam rather than the
+// raw registry import so ownership checks stay co-located with other owner APIs.
+export { listTasksForOwnerKey };
 
 function canOwnerAccessTask(task: TaskRecord, callerOwnerKey: string): boolean {
   return (


### PR DESCRIPTION
Closes #105228

## What Problem This Solves

Fixes an issue where stopping a requester (user abort / stop) would cancel inline subagent children but leave owner-scoped ACP detached tasks running. Those background ACP children could keep consuming CPU/memory after the parent workflow was already stopped.

## Why This Change Was Made

Requester stop already walks the subagent registry and cancels ACP sessions when the abort target is an ACP session key. ACP spawns, however, create detached task-registry records under the requester `ownerKey` without always appearing in the subagent registry. This change extends `stopSubagentsForRequester` to:

1. List owner-scoped tasks for the requester via the task-owner access seam
2. Cancel non-terminal `runtime: "acp"` children through the owner-scoped task lifecycle (`cancelOwnedTaskRunById` → `cancelTaskById`)
3. Skip children already covered by an active subagent stop path
4. Avoid letting ended subagent records mask an active ACP task on the same child key

Cancel goes through the canonical task control plane (ACP manager cancel + durable terminal state + delivery coordination); `stopped` counts only successful lifecycle cancels.

**Fix quality:** compatibility — additive abort path only, no API/config break; performance — one owner-index lookup per requester stop; usability — stop/abort now cleans ACP background work; security — no new trust boundary, secrets, or allowlist changes.

## User Impact

When a user aborts or stops an agent that owns ACP background tasks, those ACP children are cancelled with the same requester-stop flow as subagents, instead of remaining orphaned until manual cleanup or process exit.

## Evidence

Verification host: local macOS

```text
$ node scripts/run-vitest.mjs src/auto-reply/reply/abort.test.ts
 ✓ |auto-reply| src/auto-reply/reply/abort.test.ts (37 tests) 423ms
 Test Files  1 passed (1)
      Tests  37 passed (37)

$ node scripts/run-vitest.mjs src/tasks/task-owner-access.test.ts
 ✓ |unit-fast| src/tasks/task-owner-access.test.ts (5 tests) 173ms

$ git diff --check
(clean)
```

Regressions cover:
- orphan ACP-only cancel routes through `cancelOwnedTaskRunById` (canonical task lifecycle)
- terminal / subagent-covered skip
- ended-subagent must not mask active ACP
- failed lifecycle cancel does **not** inflate `stopped`
- owner-access seam rejects cross-owner cancel without mutating the task

## Real behavior proof

- Behavior addressed: requester-wide stop cancels active owner-scoped ACP detached tasks through the **canonical task cancellation path** (`cancelTaskById` via `cancelOwnedTaskRunById`), so the durable task record becomes terminal rather than only firing `AcpSessionManager.cancelSession`
- Environment: local macOS, branch `fix/105228-acp-requester-stop-cancel`, focused Vitest via `node scripts/run-vitest.mjs`
- Current-main contrast: on main, `stopSubagentsForRequester` does not inspect owner-scoped ACP tasks; prior revision cancelled the ACP manager directly and counted `stopped` without requiring a successful lifecycle cancel
- Exact steps after this revision:
  1. `node scripts/run-vitest.mjs src/auto-reply/reply/abort.test.ts -t "cancels active ACP detached tasks not in the subagent registry"`
  2. `node scripts/run-vitest.mjs src/auto-reply/reply/abort.test.ts -t "does not count ACP tasks when lifecycle cancel fails"`
  3. Full files: `abort.test.ts` (37/37) and `task-owner-access.test.ts` (5/5)
- Evidence after fix:
  - Abort path calls `cancelOwnedTaskRunById({ taskId, callerOwnerKey, reason: "owner-stopped" })` instead of direct manager cancel
  - `stopped` increments only when `cancelResult.cancelled === true`
  - Existing `cancelTaskById` ACP registry coverage already proves manager cancel + durable `status: "cancelled"` + terminal delivery coordination for ACP runtimes
  - Owner-access test proves non-owners cannot cancel and the running task status is unchanged
- Control check: terminal ACP tasks skipped; active subagent-covered children not double-cancelled; lifecycle-failure path returns `{ stopped: 0 }`
- Observed result after fix: requester stop discovers ACP tasks via `listTasksForOwnerKey` and cancels them through the owner-scoped task-lifecycle seam
- What was not tested: live multi-process ACP child tree on a production gateway with a real ACP backend process; that remains the remaining gap for process-tree observation

## AI disclosure

This PR was authored with AI assistance (Grok).

