### PR TITLE
test(codex): bound guarded shared-client requests

### DIFF
--- a/extensions/codex/src/app-server/shared-client.test.ts
+++ b/extensions/codex/src/app-server/shared-client.test.ts
@@ -598,11 +598,15 @@ describe("shared Codex app-server client", () => {
       expect(harness.writes).toHaveLength(writeCountBeforeThreadRequests);
 
       const releaseFence = await acquireCodexNativeConfigFence(fenceKey as string);
+      const guardedRequestOptions = { timeoutMs: 5_000 };
       const guardedRequests = [
-        client.request("thread/start", {}),
-        client.request("thread/resume", { threadId: "thread-1" }),
-        client.request("thread/fork", { threadId: "thread-1" }),
+        client.request("thread/start", {}, guardedRequestOptions),
+        client.request("thread/resume", { threadId: "thread-1" }, guardedRequestOptions),
+        client.request("thread/fork", { threadId: "thread-1" }, guardedRequestOptions),
       ];
+      const guardedRequestAssertions = guardedRequests.map((request) =>
+        expect(request).rejects.toThrow("managed executable selection changed during startup"),
+      );
       await Promise.resolve();
       expect(harness.writes).toHaveLength(writeCountBeforeThreadRequests);
       await fs.mkdir(path.join(agentDir, "codex-home"), { recursive: true });
@@ -611,14 +615,7 @@ describe("shared Codex app-server client", () => {
         '[plugins."computer-use@openai-bundled"]\nenabled = true\n',
       );
       releaseFence();
-      await Promise.all(
-        guardedRequests.map(
-          async (request) =>
-            await expect(request).rejects.toThrow(
-              "managed executable selection changed during startup",
-            ),
-        ),
-      );
+      await Promise.all(guardedRequestAssertions);
       expect(harness.writes).toHaveLength(writeCountBeforeThreadRequests);
       expect(() =>
         assertCodexAppServerClientStartSelectionCurrent({ client, startOptions, agentDir }),


### PR DESCRIPTION
## What Problem This Solves

Full release validation exposed a deterministic Codex extension shard failure in `shared-client.test.ts`. A guarded `thread/start`, `thread/resume`, or `thread/fork` request now requires a positive finite timeout or abort signal, but the persisted Computer Use selection-change test still issued all three requests without either. They rejected immediately with the contract error and produced unhandled rejection noise instead of exercising the held native-config fence.

## Why This Change Was Made

The test now supplies the same bounded five-second request timeout used by adjacent Codex lifecycle tests. It also attaches all rejection assertions before releasing the fence, so fast rejection timing cannot escape as unhandled promises.

The runtime guard remains unchanged. Upstream Codex still defines these as ordinary JSON-RPC thread methods; the timeout is OpenClaw's local lifecycle bound.

## User Impact

No product behavior change. Release and plugin-prerelease CI reliably exercises the intended managed-executable selection-change path.

## Evidence

- Failing exact-SHA release lane: https://github.com/openclaw/openclaw/actions/runs/29427361415/job/87393186295
- Blacksmith Testbox through Crabbox: https://github.com/openclaw/openclaw/actions/runs/29427924409
  - `pnpm test extensions/codex/src/app-server/shared-client.test.ts`: 52/52 passed
  - `pnpm check:changed`: passed
- Fresh autoreview: clean
- No changelog: test-only reliability fix
