### PR TITLE
fix(docs): report malformed search JSON with CLI context

### DIFF
--- a/src/commands/docs.test.ts
+++ b/src/commands/docs.test.ts
@@ -75,6 +75,23 @@ describe("docsSearchCommand", () => {
     expect(runtime.exit).toHaveBeenCalledWith(1);
   });
 
+  it("reports malformed docs search JSON with CLI context", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response("{bad json", {
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    const runtime = makeRuntime();
+
+    await docsSearchCommand(["bad-json"], runtime);
+
+    expect(runtime.error).toHaveBeenCalledWith(
+      expect.stringContaining("Docs search failed: Docs search response is malformed JSON"),
+    );
+    expect(runtime.error).not.toHaveBeenCalledWith(expect.stringContaining("SyntaxError"));
+    expect(runtime.exit).toHaveBeenCalledWith(1);
+  });
+
   it("renders successful results from the Cloudflare docs search API", async () => {
     fetchMock.mockResolvedValueOnce(
       new Response(

--- a/src/commands/docs.test.ts
+++ b/src/commands/docs.test.ts
@@ -86,9 +86,9 @@ describe("docsSearchCommand", () => {
     await docsSearchCommand(["bad-json"], runtime);
 
     expect(runtime.error).toHaveBeenCalledWith(
-      expect.stringContaining("Docs search failed: Docs search response is malformed JSON"),
+      "Docs search failed: Docs search response is malformed JSON",
     );
-    expect(runtime.error).not.toHaveBeenCalledWith(expect.stringContaining("SyntaxError"));
+    expect(runtime.error).toHaveBeenCalledTimes(1);
     expect(runtime.exit).toHaveBeenCalledWith(1);
   });
 

--- a/src/commands/docs.ts
+++ b/src/commands/docs.ts
@@ -80,7 +80,12 @@ async function fetchDocsSearch(query: string): Promise<DocResult[]> {
     const bytes = await readResponseWithLimit(response, DOCS_SEARCH_RESPONSE_MAX_BYTES, {
       onOverflow: ({ maxBytes }) => new Error(`Docs search response exceeds ${maxBytes} bytes`),
     });
-    const payload = JSON.parse(new TextDecoder().decode(bytes)) as DocsSearchResponse;
+    let payload: DocsSearchResponse;
+    try {
+      payload = JSON.parse(new TextDecoder().decode(bytes)) as DocsSearchResponse;
+    } catch (cause) {
+      throw new Error("Docs search response is malformed JSON", { cause });
+    }
     return parseDocsSearchResults(payload.results);
   } finally {
     clearTimeout(timeout);


### PR DESCRIPTION
## What Problem This Solves
Docs search could fail with a raw JSON parse error when the hosted search API returned malformed JSON.

## Why This Change Was Made
The fix stays at the docs-search fetch boundary: it wraps JSON parsing with a contextual error and leaves the existing size cap, fetch path, and result rendering unchanged.

## User Impact
Users now get a clear CLI error for malformed docs search responses instead of opaque parser noise.

## Evidence
- Claim proved: malformed docs search JSON now surfaces a contextual CLI error and exits nonzero.
- Current-head real CLI-command proof at `faffcec3a309d731e558f3148511a536af6e937b`: `NO_COLOR=1 node --import tsx --input-type=module -` invoked the Commander `docs` command registration with argv `openclaw docs bad-json`, while `fetch` returned a malformed JSON response from the docs-search boundary.
- Observed terminal result from that command path:

```text
Docs search failed: Docs search response is malformed JSON
exit=1
```

- Focused test proof at `faffcec3a309d731e558f3148511a536af6e937b`: `node scripts/run-vitest.mjs src/commands/docs.test.ts` passed with 5 tests.
- Committed diff hygiene: `git diff --check HEAD~1..HEAD` passed.
- Review proof: `python .agents\skills\autoreview\scripts\autoreview --mode commit --commit HEAD --codex-bin C:\Users\86158\.codex\codex-pixel-autoreview.cmd` passed with no accepted/actionable findings.