### PR TITLE
fix(extensions): prevent corrupted UTF-8 in api.exec output

### DIFF
--- a/src/agents/sessions/exec.test.ts
+++ b/src/agents/sessions/exec.test.ts
@@ -152,6 +152,27 @@ describe("execCommand", () => {
     expect(result.stderrTruncatedChars).toBe(3);
   });
 
+  it("preserves UTF-8 characters split across stdout and stderr chunks", async () => {
+    const child = createStubChild();
+    const wait = createDeferred<number | null>();
+    spawnMock.mockReturnValue(child);
+    completionMock.mockReturnValue(wait.promise);
+    const { execCommand } = await import("./exec.js");
+
+    const resultPromise = execCommand("cmd", [], "/tmp");
+    const stdout = Buffer.from("stdout-😀-complete", "utf8");
+    const stderr = Buffer.from("stderr-😀-complete", "utf8");
+    child.stdout.emit("data", stdout.subarray(0, 9));
+    child.stderr.emit("data", stderr.subarray(0, 9));
+    child.stdout.emit("data", stdout.subarray(9));
+    child.stderr.emit("data", stderr.subarray(9));
+    wait.resolve(0);
+
+    const result = await resultPromise;
+    expect(result.stdout).toBe("stdout-😀-complete");
+    expect(result.stderr).toBe("stderr-😀-complete");
+  });
+
   it("fails instead of silently truncating default exec output", async () => {
     const child = createStubChild();
     const wait = createDeferred<number | null>();

--- a/src/agents/sessions/exec.test.ts
+++ b/src/agents/sessions/exec.test.ts
@@ -173,6 +173,23 @@ describe("execCommand", () => {
     expect(result.stderr).toBe("stderr-😀-complete");
   });
 
+  it("flushes incomplete UTF-8 sequences when the process exits", async () => {
+    const child = createStubChild();
+    const wait = createDeferred<number | null>();
+    spawnMock.mockReturnValue(child);
+    completionMock.mockReturnValue(wait.promise);
+    const { execCommand } = await import("./exec.js");
+
+    const resultPromise = execCommand("cmd", [], "/tmp");
+    child.stdout.emit("data", Buffer.from([0xe2, 0x82]));
+    child.stderr.emit("data", Buffer.from([0xf0, 0x9f, 0x98]));
+    wait.resolve(0);
+
+    const result = await resultPromise;
+    expect(result.stdout).toBe("�");
+    expect(result.stderr).toBe("�");
+  });
+
   it("fails instead of silently truncating default exec output", async () => {
     const child = createStubChild();
     const wait = createDeferred<number | null>();

--- a/src/agents/sessions/exec.ts
+++ b/src/agents/sessions/exec.ts
@@ -2,6 +2,7 @@
  * Shared command execution utilities for extensions and custom tools.
  */
 
+import { StringDecoder } from "node:string_decoder";
 import { sliceUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { releaseChildProcessOutputAfterExit } from "../../process/child-process.js";
 import { spawnCommand } from "../../process/exec.js";
@@ -41,6 +42,10 @@ type OutputCapture = {
   text: string;
   truncatedChars: number;
 };
+
+function decodeCapturedOutput(decoder: StringDecoder, chunk: Buffer | string): string {
+  return Buffer.isBuffer(chunk) ? decoder.write(chunk) : `${decoder.end()}${chunk}`;
+}
 
 function clampMaxOutputChars(value: number | undefined): number {
   if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
@@ -95,6 +100,8 @@ export async function execCommand(
 
     let stdout: OutputCapture = { text: "", truncatedChars: 0 };
     let stderr: OutputCapture = { text: "", truncatedChars: 0 };
+    const stdoutDecoder = new StringDecoder("utf8");
+    const stderrDecoder = new StringDecoder("utf8");
     let killed = false;
     let timeoutId: NodeJS.Timeout | undefined;
     let forceKillTimer: NodeJS.Timeout | undefined;
@@ -121,6 +128,16 @@ export async function execCommand(
       }
       if (options?.signal) {
         options.signal.removeEventListener("abort", killProcess);
+      }
+      const stdoutBeforeFlush = stdout.truncatedChars;
+      stdout = appendCapturedOutput(stdout, stdoutDecoder.end(), maxOutputChars, truncateOutput);
+      if (!truncateOutput && stdout.truncatedChars > stdoutBeforeFlush && !outputLimitExceeded) {
+        outputLimitExceeded = "stdout";
+      }
+      const stderrBeforeFlush = stderr.truncatedChars;
+      stderr = appendCapturedOutput(stderr, stderrDecoder.end(), maxOutputChars, truncateOutput);
+      if (!truncateOutput && stderr.truncatedChars > stderrBeforeFlush && !outputLimitExceeded) {
+        outputLimitExceeded = "stderr";
       }
       if (outputLimitExceeded) {
         stderr = appendCapturedOutput(
@@ -184,7 +201,12 @@ export async function execCommand(
 
     proc.stdout?.on("data", (data) => {
       const before = stdout.truncatedChars;
-      stdout = appendCapturedOutput(stdout, data, maxOutputChars, truncateOutput);
+      stdout = appendCapturedOutput(
+        stdout,
+        decodeCapturedOutput(stdoutDecoder, data),
+        maxOutputChars,
+        truncateOutput,
+      );
       if (stdout.truncatedChars > before) {
         markOutputLimitExceeded("stdout");
       }
@@ -192,7 +214,12 @@ export async function execCommand(
 
     proc.stderr?.on("data", (data) => {
       const before = stderr.truncatedChars;
-      stderr = appendCapturedOutput(stderr, data, maxOutputChars, truncateOutput);
+      stderr = appendCapturedOutput(
+        stderr,
+        decodeCapturedOutput(stderrDecoder, data),
+        maxOutputChars,
+        truncateOutput,
+      );
       if (stderr.truncatedChars > before) {
         markOutputLimitExceeded("stderr");
       }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where session extensions using `api.exec` could receive corrupted stdout or stderr when a multibyte UTF-8 character was split across child-process output chunks. Valid output such as `😀` could become replacement characters before the extension consumed the result.

## Why This Change Was Made

Each child output stream now owns a stateful UTF-8 decoder and flushes it before the final `ExecResult` is assembled. This is a root-cause fix at the byte-to-text boundary; stdout and stderr remain independent, and the existing character limits, truncation accounting, timeout behavior, and process-tree cleanup are unchanged.

## User Impact

Extension authors can rely on `api.exec` returning intact Unicode text even when the operating system splits a code point across stream chunks. There is no API shape or configuration change.

## Evidence

On current `main`, an inline session extension calling the real `api.exec` wrapper against a real child process reproduced the corruption in both streams:

```text
{"kind":"openclaw.extension-api-exec-utf8-chunks.v1","execution_ok":true,"problem_present":true,"observation":"stdout=\"stdout-���-complete\" stderr=\"stderr-���-complete\""}
```

With this change, the same child deliberately splitting the emoji bytes across separate writes returns intact text:

```text
{"kind":"openclaw.extension-api-exec-utf8-chunks.v1","execution_ok":true,"problem_present":false,"observation":"stdout=\"stdout-😀-complete\" stderr=\"stderr-😀-complete\""}
```

The unsplit control follows the same extension API path and remains unchanged:

```text
{"kind":"openclaw.extension-api-exec-utf8-chunks.v1","execution_ok":true,"problem_present":false,"observation":"stdout=\"stdout-😀-complete\" stderr=\"stderr-😀-complete\""}
```

The complete owning test file also passes, including output caps, UTF-16-safe truncation, timeout, and stream-error coverage:

```text
Test Files  1 passed (1)
Tests       8 passed (8)
```
