### PR TITLE
fix(ui): prevent agent-select avatar fetch hangs

### DIFF
--- a/ui/src/components/agent-select.test.ts
+++ b/ui/src/components/agent-select.test.ts
@@ -114,6 +114,7 @@ it("fetches local avatars with the bearer credential when token auth is active",
     expect(element.querySelector(".agent-select__avatar--text")?.textContent?.trim()).toBe("A");
     expect(fetchMock).toHaveBeenCalledWith("/avatar/alpha", {
       headers: { Authorization: "Bearer tok" },
+      signal: expect.any(AbortSignal),
     });
 
     await vi.waitFor(() => {
@@ -160,6 +161,7 @@ it("refetches a failed local avatar after the auth credential rotates", async ()
     await vi.waitFor(() => {
       expect(fetchMock).toHaveBeenLastCalledWith("/avatar/alpha", {
         headers: { Authorization: "Bearer tok2" },
+        signal: expect.any(AbortSignal),
       });
       expect(
         element.querySelector<HTMLImageElement>("img.agent-select__avatar")?.getAttribute("src"),
@@ -167,6 +169,53 @@ it("refetches a failed local avatar after the auth credential rotates", async ()
     });
   } finally {
     element.remove();
+    vi.unstubAllGlobals();
+  }
+});
+
+it("aborts a stalled local avatar fetch after the request deadline", async () => {
+  vi.useFakeTimers();
+  const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
+    const signal = init?.signal;
+    if (!signal) {
+      throw new Error("missing agent avatar fetch signal");
+    }
+    return await new Promise<Response>((_resolve, reject) => {
+      signal.addEventListener(
+        "abort",
+        () => {
+          reject(signal.reason as Error);
+        },
+        { once: true },
+      );
+    });
+  });
+  vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+  const element = await createAgentSelect({
+    authToken: "tok",
+    identityById: { alpha: createIdentity("alpha", { avatar: "/avatar/alpha" }) },
+  });
+
+  try {
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [, fetchInit] = fetchMock.mock.calls[0] ?? [];
+    expect(fetchInit?.signal?.aborted).toBe(false);
+    expect(element.querySelector(".agent-select__avatar--text")?.textContent?.trim()).toBe("A");
+
+    await vi.advanceTimersByTimeAsync(29_999);
+    expect(fetchInit?.signal?.aborted).toBe(false);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(fetchInit?.signal?.aborted).toBe(true);
+
+    await vi.waitFor(() => {
+      expect(element.querySelector("img.agent-select__avatar")).toBeNull();
+      expect(element.querySelector(".agent-select__avatar--text")?.textContent?.trim()).toBe("A");
+    });
+    expect(vi.getTimerCount()).toBe(0);
+  } finally {
+    element.remove();
+    vi.useRealTimers();
     vi.unstubAllGlobals();
   }
 });

--- a/ui/src/components/agent-select.test.ts
+++ b/ui/src/components/agent-select.test.ts
@@ -173,6 +173,70 @@ it("refetches a failed local avatar after the auth credential rotates", async ()
   }
 });
 
+it("aborts the stale request on auth rotation without duplicating the current fetch", async () => {
+  vi.stubGlobal(
+    "URL",
+    class extends URL {
+      static override createObjectURL = vi.fn(() => "blob:rotated-avatar");
+      static override revokeObjectURL = vi.fn();
+    },
+  );
+  const pending: Array<{
+    resolve: (response: Response) => void;
+    signal: AbortSignal;
+  }> = [];
+  const fetchMock = vi.fn((_url: string, init?: RequestInit) => {
+    const signal = init?.signal;
+    if (!signal) {
+      throw new Error("missing agent avatar fetch signal");
+    }
+    return new Promise<Response>((resolve, reject) => {
+      pending.push({ resolve, signal });
+      signal.addEventListener("abort", () => reject(new Error("avatar fetch aborted")), {
+        once: true,
+      });
+    });
+  });
+  vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+  const element = await createAgentSelect({
+    authToken: "tok",
+    identityById: { alpha: createIdentity("alpha", { avatar: "/avatar/alpha" }) },
+  });
+
+  try {
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    element.authToken = "tok2";
+    await element.updateComplete;
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+
+    expect(pending[0]?.signal.aborted).toBe(true);
+    expect(
+      fetchMock.mock.calls.map(([, init]) => new Headers(init?.headers).get("Authorization")),
+    ).toEqual(["Bearer tok", "Bearer tok2"]);
+
+    // Let the canceled request's rejection settle, then force another render while
+    // the replacement is pending. It must not clear the replacement's route claim.
+    await Promise.resolve();
+    element.identityById = { ...element.identityById };
+    await element.updateComplete;
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    pending[1]?.resolve({
+      ok: true,
+      blob: async () => new Blob(["avatar"]),
+    } as Response);
+    await vi.waitFor(() => {
+      expect(
+        element.querySelector<HTMLImageElement>("img.agent-select__avatar")?.getAttribute("src"),
+      ).toBe("blob:rotated-avatar");
+    });
+  } finally {
+    element.remove();
+    vi.unstubAllGlobals();
+  }
+});
+
 it("aborts a stalled local avatar fetch after the request deadline", async () => {
   vi.useFakeTimers();
   const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
@@ -208,6 +272,50 @@ it("aborts a stalled local avatar fetch after the request deadline", async () =>
     await vi.advanceTimersByTimeAsync(1);
     expect(fetchInit?.signal?.aborted).toBe(true);
 
+    await vi.waitFor(() => {
+      expect(element.querySelector("img.agent-select__avatar")).toBeNull();
+      expect(element.querySelector(".agent-select__avatar--text")?.textContent?.trim()).toBe("A");
+    });
+    expect(vi.getTimerCount()).toBe(0);
+  } finally {
+    element.remove();
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  }
+});
+
+it("aborts a stalled local avatar body after the request deadline", async () => {
+  vi.useFakeTimers();
+  const blob = vi.fn<() => Promise<Blob>>();
+  const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
+    const signal = init?.signal;
+    if (!signal) {
+      throw new Error("missing agent avatar fetch signal");
+    }
+    blob.mockImplementation(
+      () =>
+        new Promise<Blob>((_resolve, reject) => {
+          signal.addEventListener("abort", () => reject(new Error("avatar body read aborted")), {
+            once: true,
+          });
+        }),
+    );
+    return { ok: true, blob } as unknown as Response;
+  });
+  vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+  const element = await createAgentSelect({
+    authToken: "tok",
+    identityById: { alpha: createIdentity("alpha", { avatar: "/avatar/alpha" }) },
+  });
+
+  try {
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    await vi.waitFor(() => expect(blob).toHaveBeenCalledTimes(1));
+    const [, fetchInit] = fetchMock.mock.calls[0] ?? [];
+
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(fetchInit?.signal?.aborted).toBe(true);
     await vi.waitFor(() => {
       expect(element.querySelector("img.agent-select__avatar")).toBeNull();
       expect(element.querySelector(".agent-select__avatar--text")?.textContent?.trim()).toBe("A");

--- a/ui/src/components/agent-select.ts
+++ b/ui/src/components/agent-select.ts
@@ -15,6 +15,7 @@ import { OpenClawLightDomElement } from "../lit/openclaw-element.ts";
 import { icons } from "./icons.ts";
 
 type WebAwesomeSelectEvent = Event & { detail: { item: Element } };
+type AvatarFetch = { authToken: string; controller: AbortController };
 
 /** Bound local avatar fetches so a stalled Control UI media route cannot pin pending state forever. */
 const AGENT_SELECT_AVATAR_FETCH_TIMEOUT_MS = 30_000;
@@ -29,10 +30,10 @@ export class AgentSelect extends OpenClawLightDomElement {
   @property({ attribute: false }) onSelect: (agentId: string) => void = () => {};
 
   private readonly avatarBlobUrlByRoute = new Map<string, string>();
-  private readonly avatarRoutesPending = new Set<string>();
+  private readonly avatarFetchByRoute = new Map<string, AvatarFetch>();
 
   override disconnectedCallback() {
-    this.releaseAvatarBlobUrls();
+    this.resetAvatarState();
     super.disconnectedCallback();
   }
 
@@ -40,28 +41,40 @@ export class AgentSelect extends OpenClawLightDomElement {
     // Cached blobs and failures belong to the credential that fetched them;
     // a rotated token must refetch with the current authorization.
     if (changed.has("authToken")) {
-      this.releaseAvatarBlobUrls();
+      this.resetAvatarState();
     }
   }
 
-  private releaseAvatarBlobUrls() {
+  private resetAvatarState() {
+    for (const request of this.avatarFetchByRoute.values()) {
+      request.controller.abort();
+    }
     for (const blobUrl of this.avatarBlobUrlByRoute.values()) {
       if (blobUrl) {
         URL.revokeObjectURL(blobUrl);
       }
     }
     this.avatarBlobUrlByRoute.clear();
-    this.avatarRoutesPending.clear();
+    this.avatarFetchByRoute.clear();
   }
 
   private ensureLocalAvatar(url: string, authToken: string) {
-    if (this.avatarRoutesPending.has(url)) {
+    if (this.avatarFetchByRoute.has(url)) {
       return;
     }
-    this.avatarRoutesPending.add(url);
-    void this.fetchLocalAvatarBlobUrl(url, authToken).then((blobUrl) => {
+    const request: AvatarFetch = { authToken, controller: new AbortController() };
+    this.avatarFetchByRoute.set(url, request);
+    void this.fetchLocalAvatarBlobUrl(url, request).then((blobUrl) => {
+      // Rotation can start a replacement before the aborted request settles.
+      // Only the request still owning this route may clear or cache its state.
+      if (this.avatarFetchByRoute.get(url) !== request) {
+        if (blobUrl) {
+          URL.revokeObjectURL(blobUrl);
+        }
+        return;
+      }
       if (!this.isConnected || this.authToken !== authToken) {
-        this.avatarRoutesPending.delete(url);
+        this.avatarFetchByRoute.delete(url);
         if (blobUrl) {
           URL.revokeObjectURL(blobUrl);
         }
@@ -70,23 +83,23 @@ export class AgentSelect extends OpenClawLightDomElement {
       // Cache the result (including empty miss) before clearing pending so a
       // concurrent re-render cannot start a second unbounded fetch for the same URL.
       this.avatarBlobUrlByRoute.set(url, blobUrl);
-      this.avatarRoutesPending.delete(url);
+      this.avatarFetchByRoute.delete(url);
       if (blobUrl) {
         this.requestUpdate();
       }
     });
   }
 
-  private async fetchLocalAvatarBlobUrl(url: string, authToken: string): Promise<string> {
-    const controller = new AbortController();
+  private async fetchLocalAvatarBlobUrl(url: string, request: AvatarFetch): Promise<string> {
     const timeout = setTimeout(
-      () => controller.abort(new DOMException("agent avatar fetch timed out", "TimeoutError")),
+      () =>
+        request.controller.abort(new DOMException("agent avatar fetch timed out", "TimeoutError")),
       AGENT_SELECT_AVATAR_FETCH_TIMEOUT_MS,
     );
     try {
       const res = await fetch(url, {
-        headers: { Authorization: `Bearer ${authToken}` },
-        signal: controller.signal,
+        headers: { Authorization: `Bearer ${request.authToken}` },
+        signal: request.controller.signal,
       });
       if (!res.ok) {
         return "";

--- a/ui/src/components/agent-select.ts
+++ b/ui/src/components/agent-select.ts
@@ -16,6 +16,9 @@ import { icons } from "./icons.ts";
 
 type WebAwesomeSelectEvent = Event & { detail: { item: Element } };
 
+/** Bound local avatar fetches so a stalled Control UI media route cannot pin pending state forever. */
+const AGENT_SELECT_AVATAR_FETCH_TIMEOUT_MS = 30_000;
+
 export class AgentSelect extends OpenClawLightDomElement {
   @property({ attribute: false }) agents: GatewayAgentRow[] = [];
   @property({ attribute: false }) selectedId: string | null = null;
@@ -56,22 +59,46 @@ export class AgentSelect extends OpenClawLightDomElement {
       return;
     }
     this.avatarRoutesPending.add(url);
-    void fetch(url, { headers: { Authorization: `Bearer ${authToken}` } })
-      .then(async (res) => (res.ok ? URL.createObjectURL(await res.blob()) : ""))
-      .catch(() => "")
-      .then((blobUrl) => {
+    void this.fetchLocalAvatarBlobUrl(url, authToken).then((blobUrl) => {
+      if (!this.isConnected || this.authToken !== authToken) {
         this.avatarRoutesPending.delete(url);
-        if (!this.isConnected || this.authToken !== authToken) {
-          if (blobUrl) {
-            URL.revokeObjectURL(blobUrl);
-          }
-          return;
-        }
-        this.avatarBlobUrlByRoute.set(url, blobUrl);
         if (blobUrl) {
-          this.requestUpdate();
+          URL.revokeObjectURL(blobUrl);
         }
+        return;
+      }
+      // Cache the result (including empty miss) before clearing pending so a
+      // concurrent re-render cannot start a second unbounded fetch for the same URL.
+      this.avatarBlobUrlByRoute.set(url, blobUrl);
+      this.avatarRoutesPending.delete(url);
+      if (blobUrl) {
+        this.requestUpdate();
+      }
+    });
+  }
+
+  private async fetchLocalAvatarBlobUrl(url: string, authToken: string): Promise<string> {
+    const controller = new AbortController();
+    const timeout = setTimeout(
+      () => controller.abort(new DOMException("agent avatar fetch timed out", "TimeoutError")),
+      AGENT_SELECT_AVATAR_FETCH_TIMEOUT_MS,
+    );
+    try {
+      const res = await fetch(url, {
+        headers: { Authorization: `Bearer ${authToken}` },
+        signal: controller.signal,
       });
+      if (!res.ok) {
+        return "";
+      }
+      return URL.createObjectURL(await res.blob());
+    } catch {
+      // Timeouts and transport failures share the empty-string miss path so the
+      // picker keeps the text fallback instead of leaving avatarRoutesPending set.
+      return "";
+    } finally {
+      clearTimeout(timeout);
+    }
   }
 
   private renderAvatar(agent: GatewayAgentRow) {

--- a/ui/src/e2e/agent-select-avatar-timeout.e2e.test.ts
+++ b/ui/src/e2e/agent-select-avatar-timeout.e2e.test.ts
@@ -1,0 +1,114 @@
+// Control UI tests cover bounded authenticated agent-picker avatar fetches.
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+import { chromium, type Browser, type Page } from "playwright";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  canRunPlaywrightChromium,
+  installMockGateway,
+  resolvePlaywrightChromiumExecutablePath,
+  startControlUiE2eServer,
+  type ControlUiE2eServer,
+} from "../test-helpers/control-ui-e2e.ts";
+
+const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
+const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
+const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
+const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+const captureUiProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
+const proofDir = path.join(
+  process.cwd(),
+  ".artifacts",
+  "control-ui-e2e",
+  "agent-select-avatar-timeout",
+);
+
+let browser: Browser;
+let server: ControlUiE2eServer;
+
+async function screenshot(page: Page, name: string) {
+  if (!captureUiProof) {
+    return;
+  }
+  await mkdir(proofDir, { recursive: true });
+  await page.screenshot({
+    animations: "disabled",
+    fullPage: true,
+    path: path.join(proofDir, name),
+  });
+}
+
+describeControlUiE2e("Control UI agent picker avatar timeout", () => {
+  beforeAll(async () => {
+    if (!chromiumAvailable) {
+      throw new Error(`Playwright Chromium is not available at ${chromiumExecutablePath}`);
+    }
+    server = await startControlUiE2eServer();
+    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
+  });
+
+  afterAll(async () => {
+    await browser?.close();
+    await server?.close();
+  });
+
+  it("aborts a stalled authenticated avatar request and keeps the text fallback", async () => {
+    const context = await browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    await page.clock.install();
+
+    let avatarRequestCount = 0;
+    let avatarAuthorization: string | undefined;
+    const failedAvatarRequests: string[] = [];
+    page.on("requestfailed", (request) => {
+      if (new URL(request.url()).pathname === "/avatar/main") {
+        failedAvatarRequests.push(request.failure()?.errorText ?? "unknown");
+      }
+    });
+    await page.route(/\/avatar\/main$/, (route) => {
+      avatarRequestCount += 1;
+      avatarAuthorization = route.request().headers().authorization;
+      // Leave the route unanswered. The page-owned deadline must cancel it.
+    });
+    await installMockGateway(page, {
+      methodResponses: {
+        "agent.identity.get": {
+          agentId: "main",
+          avatar: "/avatar/main",
+          avatarStatus: "local",
+          name: "Main agent",
+        },
+      },
+    });
+
+    try {
+      const response = await page.goto(`${server.baseUrl}agents`);
+      expect(response?.status()).toBe(200);
+      const picker = page.locator("openclaw-agent-select");
+      await expect
+        .poll(() => picker.locator(".agent-select__avatar--text").first().textContent())
+        .toBe("O");
+      expect(avatarRequestCount).toBe(1);
+      expect(avatarAuthorization).toBe("Bearer e2e-device-token");
+      await screenshot(page, "01-request-stalled.png");
+
+      await page.clock.runFor(30_000);
+      await expect.poll(() => failedAvatarRequests.length).toBe(1);
+      await expect.poll(() => picker.locator("img.agent-select__avatar").count()).toBe(0);
+      await expect
+        .poll(() => picker.locator(".agent-select__avatar--text").first().textContent())
+        .toBe("O");
+
+      // A later render must use the cached miss instead of launching another fetch.
+      await picker.locator(".agent-select__trigger").click();
+      expect(avatarRequestCount).toBe(1);
+      await screenshot(page, "02-timeout-fallback.png");
+    } finally {
+      await context.close();
+    }
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the Control UI agent picker could leave a local avatar fetch pending forever when the authenticated avatar media route accepted the connection but never responded. While that fetch stayed unresolved, `avatarRoutesPending` kept the URL pinned and the picker stayed on the text fallback with no bounded recovery.

## Why This Change Was Made

`AgentSelect.fetchLocalAvatarBlobUrl` now attaches a 30-second `AbortController` deadline to the authenticated local avatar `fetch`, covering both response headers and the blob body read, and clears the timer on every exit path. Timeout and transport failures share the existing empty-string miss path so the text fallback remains. The success/miss result is cached before clearing `avatarRoutesPending` so a concurrent re-render cannot start a second unbounded fetch for the same URL.

## User Impact

Control UI users get a bounded agent-avatar miss instead of a picker that never recovers when the local avatar route stalls.

## Evidence

- Base: current `upstream/main` at submit time.
- Caller-path production surface: `ui/src/components/agent-select.ts` (`ensureLocalAvatar` → `fetchLocalAvatarBlobUrl`).
- AI-assisted: implemented with Cursor Grok; I inspected and understand the fetch helper behavior.

### Focused timeout proof

```bash
node scripts/run-vitest.mjs ui/src/components/agent-select.test.ts --reporter=verbose -t "stalled local avatar"
```

```text
✓ |ui| ui/src/components/agent-select.test.ts > aborts a stalled local avatar fetch after the request deadline 43ms

Test Files  1 passed (1)
     Tests  1 passed | 11 skipped (12)
```

### Full caller suite

```bash
node scripts/run-vitest.mjs ui/src/components/agent-select.test.ts --reporter=verbose
```

```text
✓ |ui| ui/src/components/agent-select.test.ts > aborts a stalled local avatar fetch after the request deadline 11ms
...
Test Files  1 passed (1)
     Tests  12 passed (12)
```

- `./node_modules/.bin/oxfmt --check ui/src/components/agent-select.ts ui/src/components/agent-select.test.ts` — passed
- `./node_modules/.bin/oxlint ui/src/components/agent-select.ts ui/src/components/agent-select.test.ts` — passed
- `git diff --check` — passed
- No visual layout or copy changed, so screenshots are not applicable.

## Real behavior proof

- **Behavior or issue addressed:** Control UI agent-select local avatar fetches abort after 30s instead of hanging indefinitely and pinning `avatarRoutesPending`.
- **Canonical reachability path:** Control UI agent picker render → `resolveRenderableAvatarUrl` for a same-origin `/…` avatar with bearer auth → `ensureLocalAvatar` → `fetchLocalAvatarBlobUrl` → authenticated `fetch` with `AbortSignal` → text fallback on timeout miss.
- **Boundary crossed:** local-runtime; Vitest jsdom exercises the production `AgentSelect` custom element and its real `fetchLocalAvatarBlobUrl` caller path with a stalled `fetch` mock.
- **Shared helper / provider constraint check:** N/A — browser `fetch` + `AbortController` only; no provider HTTP helper involved.
- **Real environment tested:** macOS, Node for Vitest UI lane, jsdom, production `ui/src/components/agent-select.ts`.
- **Exact steps or command run after this patch:** `node scripts/run-vitest.mjs ui/src/components/agent-select.test.ts --reporter=verbose -t "stalled local avatar"` then the full `agent-select.test.ts` suite.
- **Evidence after fix:**

```text
✓ |ui| ui/src/components/agent-select.test.ts > aborts a stalled local avatar fetch after the request deadline 43ms
Test Files  1 passed (1)
     Tests  1 passed | 11 skipped (12)

✓ full suite: 12 passed (12)
signal aborted=false at 29999ms; aborted=true at 30000ms; timer count=0 after settle; text fallback retained
```

- **Observed result after fix:** A stalled avatar response is aborted at the 30s deadline with `TimeoutError`, the picker keeps the text fallback, and the timeout timer is cleared.
- **What was not tested:** Live Gateway + browser session with a deliberately hung avatar route (requires a stalled media endpoint). Sibling Control UI avatar timeout work already covers related surfaces (`chat-avatar`, managed outgoing images).
- **Fix classification:** Root cause fix.

## Risk / Compatibility

Low. Successful avatar fetches under 30s are unchanged. Timeout shares the existing empty-string miss path used for non-OK responses.
