### PR TITLE
fix(doctor): pass collectModelsMap for agents.list model ref scan

### DIFF
--- a/src/commands/doctor/shared/codex-route-config-scan.ts
+++ b/src/commands/doctor/shared/codex-route-config-scan.ts
@@ -149,6 +149,7 @@ export function collectConfigModelRefs(
         agentRuntime: asAgentRuntimePolicyConfig(agentRecord.agentRuntime),
         defaultsRuntime,
       }),
+      collectModelsMap: true,
       blockedModelIdentities,
     });
   }

--- a/src/commands/doctor/shared/codex-route-config-scan.ts
+++ b/src/commands/doctor/shared/codex-route-config-scan.ts
@@ -59,7 +59,6 @@ function collectAgentModelRefs(params: {
   agent: unknown;
   path: string;
   runtime?: string;
-  collectModelsMap?: boolean;
   blockedModelIdentities?: ReadonlySet<LegacyCodexModelIdentity>;
 }): void {
   const agent = asMutableRecord(params.agent);
@@ -108,14 +107,12 @@ function collectAgentModelRefs(params: {
     value: asMutableRecord(compaction?.memoryFlush)?.model,
     blockedModelIdentities: params.blockedModelIdentities,
   });
-  if (params.collectModelsMap) {
-    collectModelsMapRefs({
-      hits: params.hits,
-      path: `${params.path}.models`,
-      models: agent.models,
-      blockedModelIdentities: params.blockedModelIdentities,
-    });
-  }
+  collectModelsMapRefs({
+    hits: params.hits,
+    path: `${params.path}.models`,
+    models: agent.models,
+    blockedModelIdentities: params.blockedModelIdentities,
+  });
 }
 
 export function collectConfigModelRefs(
@@ -130,7 +127,6 @@ export function collectConfigModelRefs(
     agent: defaults,
     path: "agents.defaults",
     runtime: resolveRuntime({ defaultsRuntime }),
-    collectModelsMap: true,
     blockedModelIdentities,
   });
 
@@ -149,7 +145,6 @@ export function collectConfigModelRefs(
         agentRuntime: asAgentRuntimePolicyConfig(agentRecord.agentRuntime),
         defaultsRuntime,
       }),
-      collectModelsMap: true,
       blockedModelIdentities,
     });
   }

--- a/src/commands/doctor/shared/codex-route-warnings.test.ts
+++ b/src/commands/doctor/shared/codex-route-warnings.test.ts
@@ -195,6 +195,65 @@ describe("collectCodexRouteWarnings", () => {
     expect(warnings).toStrictEqual([]);
   });
 
+  it("warns when legacy openai-codex model refs are in agents.list.*.models maps", () => {
+    const warnings = collectCodexRouteWarnings({
+      cfg: {
+        agents: {
+          list: [
+            {
+              id: "worker",
+              model: "openai/gpt-5.5",
+              models: {
+                "openai-codex/gpt-5.4": { alias: "legacy" },
+              },
+            },
+          ],
+        },
+      } as unknown as OpenClawConfig,
+    });
+
+    expect(warnings).toStrictEqual([
+      [
+        "- Legacy `codex/*` and `openai-codex/*` model refs should be rewritten to `openai/*`.",
+        "- agents.list.worker.models.openai-codex/gpt-5.4: openai-codex/gpt-5.4 should become openai/gpt-5.4.",
+        "- Run `openclaw doctor --fix`: it rewrites configured model refs and stale sessions to `openai/*`, moves Codex intent to provider/model runtime policy, and clears old whole-agent runtime pins.",
+      ].join("\n"),
+    ]);
+  });
+
+  it("warns when legacy openai-codex model refs are in agents.list.*.models maps via repair path", () => {
+    const result = maybeRepairCodexRoutes({
+      cfg: {
+        agents: {
+          list: [
+            {
+              id: "worker",
+              model: "anthropic/claude-sonnet-4-6",
+              models: {
+                "openai-codex/gpt-5.4": { alias: "legacy" },
+              },
+            },
+          ],
+        },
+      } as unknown as OpenClawConfig,
+      shouldRepair: true,
+    });
+
+    expect(result.warnings).toStrictEqual([]);
+    expect(result.changes).toStrictEqual([
+      [
+        "Repaired Codex model routes:",
+        "- agents.list.worker.models.openai-codex/gpt-5.4: openai-codex/gpt-5.4 -> openai/gpt-5.4.",
+      ].join("\n"),
+      'Set agents.list.worker.models.openai/gpt-5.4.agentRuntime.id to "codex" so repaired OpenAI refs keep Codex auth routing.',
+    ]);
+    expect(result.cfg.agents?.list?.[0]?.models?.["openai/gpt-5.4"]?.alias).toBe("legacy");
+    expect(result.cfg.agents?.list?.[0]?.models?.["openai/gpt-5.4"]?.agentRuntime).toEqual({
+      id: "codex",
+    });
+    expect(result.cfg.agents?.list?.[0]?.models?.["openai-codex/gpt-5.4"]).toBeUndefined();
+  });
+
   it("warns when Codex app-server command includes inline arguments", () => {
     const warnings = collectCodexRouteWarnings({
       cfg: {

--- a/src/commands/doctor/shared/codex-route-warnings.test.ts
+++ b/src/commands/doctor/shared/codex-route-warnings.test.ts
@@ -221,7 +221,7 @@ describe("collectCodexRouteWarnings", () => {
     ]);
   });
 
-  it("warns when legacy openai-codex model refs are in agents.list.*.models maps via repair path", () => {
+  it("repairs legacy openai-codex model refs found only in agents.list.*.models maps", () => {
     const result = maybeRepairCodexRoutes({
       cfg: {
         agents: {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where `openclaw doctor --fix` skipped legacy Codex model refs (`openai-codex/*`) when they existed only in `agents.list.<id>.models.*`. Detection returned before the existing repair path could migrate those entries.

## Why This Change Was Made

The doctor scanner collected named model-map keys for `agents.defaults`, but not for entries in `agents.list`. The actual repair logic already canonicalized both surfaces.

The maintainer repair removes the optional scan mode entirely. The private collector now always scans each agent's primary model and named model map, matching the generic configured-model collector and preventing another caller omission.

## User Impact

Users whose only legacy Codex references are per-agent named model-map keys now receive accurate doctor diagnostics, and `openclaw doctor --fix` migrates those keys to `openai/*` while preserving their settings.

## Evidence

- Regression coverage isolates a config whose canonical primary model leaves a legacy reference only in `agents.list.*.models`.
- `node scripts/run-vitest.mjs src/commands/doctor/shared/codex-route-warnings.test.ts`: 128/128 passed.
- [Hosted changed gate](https://github.com/openclaw/openclaw/actions/runs/29496547343): passed, including formatting, types, lint, architecture, and test-type checks.
- [Real CLI fixture](https://github.com/openclaw/openclaw/actions/runs/29497186714): `openclaw doctor --fix --non-interactive` migrated `openai-codex/gpt-5.4` to `openai/gpt-5.4`, preserved its alias, and added the Codex runtime marker.
- Branch autoreview: no findings.
- Current exact-head `no-tabs` check: passed.
