### PR TITLE
test(ui): await terminal readiness states

### DIFF
--- a/ui/src/components/terminal/terminal-panel-readiness.test.ts
+++ b/ui/src/components/terminal/terminal-panel-readiness.test.ts
@@ -94,14 +94,16 @@ describe("terminal panel readiness", () => {
       expect(panel.renderRoot.querySelector(".tp-connecting")?.textContent).toContain(
         "Connecting to session",
       );
+      expect(panel.renderRoot.querySelector(".tp-tab")?.classList.contains("is-connecting")).toBe(
+        true,
+      );
     });
-    expect(panel.renderRoot.querySelector(".tp-tab")?.classList.contains("is-connecting")).toBe(
-      true,
-    );
 
     open.resolve(terminalOpenResult("session-1"));
-    await vi.waitFor(() => expect(panel.renderRoot.querySelector(".tp-connecting")).toBeNull());
-    expect(panel.renderRoot.querySelector(".tp-tab")?.classList.contains("is-live")).toBe(true);
+    await vi.waitFor(() => {
+      expect(panel.renderRoot.querySelector(".tp-connecting")).toBeNull();
+      expect(panel.renderRoot.querySelector(".tp-tab")?.classList.contains("is-live")).toBe(true);
+    });
   });
 
   it("persists a catalog tab after its first output arrives", async () => {


### PR DESCRIPTION
## What Problem This Solves

Full release validation failed the Control UI suite in `terminal-panel-readiness.test.ts`. The test waited only for the panel-level connecting spinner, then immediately expected a connecting tab. Production intentionally renders the spinner as soon as `booting` starts, before the asynchronous terminal controller has created the tab, so the tab query can still be absent.

## Why This Change Was Made

The test now waits for each complete rendered readiness phase:

- connecting spinner plus connecting tab
- no connecting spinner plus live tab

This matches the component's explicit asynchronous boot sequence and removes timing dependence without weakening any assertion.

## User Impact

No product behavior change. Full CI and release validation stop failing when the valid panel-level boot state is observed before the tab is created.

## Evidence

- Failing exact-SHA UI job: https://github.com/openclaw/openclaw/actions/runs/29427625263/job/87394202010
- Direct AWS Crabbox focused proof: https://crabbox.openclaw.ai/portal/runs/run_26431aab585f
  - `pnpm test ui/src/components/terminal/terminal-panel-readiness.test.ts`: 4/4 passed
- Direct AWS Crabbox changed gates: https://crabbox.openclaw.ai/portal/runs/run_3fabc11140c9
  - `pnpm check:changed`: passed, including Control UI i18n, core-test types, format, and lint
- Fresh autoreview: clean
- No changelog: test-only reliability fix
