### PR TITLE
fix(agents): surface claude-cli logged-out sessions as actionable re-auth errors

### DIFF
--- a/src/agents/auth-profiles/oauth-refresh-failure.test.ts
+++ b/src/agents/auth-profiles/oauth-refresh-failure.test.ts
@@ -120,6 +120,30 @@ describe("oauth refresh failure hints", () => {
     });
   });
 
+  it("classifies claude-cli logged-out sessions as a provider refresh failure", () => {
+    // Verbatim `-p --output-format json` result text from Claude Code v2.1.206
+    // when the CLI session is logged out (`claude auth status` loggedIn: false).
+    const loggedOutMessage = "Provider claude-cli failed: Not logged in \u00b7 Please run /login";
+    expect(classifyOAuthRefreshFailure(loggedOutMessage)).toEqual({
+      provider: "claude-cli",
+      reason: "sign_in_again",
+    });
+  });
+
+  it("classifies structured claude-cli logged-out failures without the provider prefix in the message", () => {
+    const error = new FailoverError("Not logged in \u00b7 Please run /login", {
+      reason: "auth",
+      provider: "claude-cli",
+      model: "claude-sonnet-4-20250514",
+      status: 401,
+    });
+
+    expect(classifyOAuthRefreshFailureError(error)).toEqual({
+      provider: "claude-cli",
+      reason: "sign_in_again",
+    });
+  });
+
   it("does not classify a 401 auth failure without claude-cli prefix as a refresh failure", () => {
     // A generic 401 from another provider should NOT be treated as an OAuth
     // refresh failure — it lacks the "claude-cli" provider prefix.

--- a/src/agents/auth-profiles/oauth-refresh-failure.ts
+++ b/src/agents/auth-profiles/oauth-refresh-failure.ts
@@ -47,13 +47,16 @@ export class OAuthRefreshFailureError extends Error {
 const OAUTH_REFRESH_FAILURE_PROVIDER_RE = /OAuth token refresh failed for ([^:]+):/i;
 const SAFE_PROVIDER_ID_RE = /^[a-z0-9][a-z0-9._-]*$/;
 // Matches the error surfaced via FailoverError when the `claude` subprocess
-// has an expired/invalid OAuth token.  The message always includes the
-// "claude-cli" provider prefix (injected by the failover layer) and the
-// literal 401 status plus Anthropic's "Invalid authentication credentials"
-// phrase, so the pattern is narrow enough to avoid false-positives from
-// unrelated provider 401 failures.
+// has an expired/invalid OAuth token or no login at all.  The message always
+// includes the "claude-cli" provider prefix (injected by the failover layer)
+// plus one of the CLI's auth-failure phrases: "Failed to authenticate" /
+// "401 Invalid authentication credentials" for expired tokens, or
+// "Not logged in · Please run /login" when the CLI session was logged out
+// (verbatim `-p --output-format json` result text on Claude Code v2.1.206),
+// so the pattern is narrow enough to avoid false-positives from unrelated
+// provider 401 failures.
 const CLAUDE_CLI_AUTH_FAILURE_RE =
-  /\bclaude-cli\b.+?\b(failed to authenticate|401\s+invalid authentication credentials)\b/is;
+  /\bclaude-cli\b.+?(\bfailed to authenticate\b|\b401\s+invalid authentication credentials\b|\bnot logged in\b.{0,20}\bplease run \/login\b)/is;
 
 function isClaudeCliExpiredOAuthMessage(message: string): boolean {
   return CLAUDE_CLI_AUTH_FAILURE_RE.test(message);
@@ -85,7 +88,9 @@ function isStructuredClaudeCliExpiredOAuthFailure(err: unknown): boolean {
   const combined = `${message}\n${rawError}`;
   const lower = combined.toLowerCase();
   return (
-    lower.includes("failed to authenticate") || lower.includes("invalid authentication credentials")
+    lower.includes("failed to authenticate") ||
+    lower.includes("invalid authentication credentials") ||
+    lower.includes("not logged in")
   );
 }
 
@@ -155,6 +160,11 @@ export function classifyOAuthRefreshFailureReason(
   if (lower.includes("expired or revoked") || lower.includes("revoked")) {
     return "revoked";
   }
+  if (lower.includes("not logged in")) {
+    // The claude subprocess emits "Not logged in · Please run /login" when its
+    // CLI session was logged out entirely (as opposed to an expired token).
+    return "sign_in_again";
+  }
   if (isClaudeCliExpiredOAuthMessage(message)) {
     // The claude subprocess emits "401 Invalid authentication credentials"
     // when its stored OAuth token has expired.  Map this to "revoked" so the
@@ -182,9 +192,12 @@ export function classifyOAuthRefreshFailureError(err: unknown): OAuthRefreshFail
   let candidate = err;
   while (candidate && typeof candidate === "object") {
     if (isStructuredClaudeCliExpiredOAuthFailure(candidate)) {
+      const message = candidate instanceof Error ? candidate.message : "";
       return {
         provider: "claude-cli",
-        reason: "revoked",
+        // Logged-out ("Not logged in") classifies as sign_in_again; expired
+        // tokens keep the historical "revoked" reason.
+        reason: classifyOAuthRefreshFailureReason(message) ?? "revoked",
       };
     }
     if (candidate instanceof OAuthRefreshFailureError) {

--- a/src/agents/embedded-agent-helpers/failover-matches.test.ts
+++ b/src/agents/embedded-agent-helpers/failover-matches.test.ts
@@ -52,6 +52,12 @@ describe("Z.ai vendor error codes (#48988)", () => {
       expect(raw.length).toBeGreaterThan(512);
       expect(isBillingErrorMessage(raw)).toBe(true);
     });
+
+    it("classifies the Claude CLI logged-out result text as auth", () => {
+      // Verbatim `-p --output-format json` result text on Claude Code v2.1.206
+      // when the CLI session is logged out (#103773).
+      expect(isAuthErrorMessage("Not logged in · Please run /login")).toBe(true);
+    });
   });
 
   describe("error 1113 — wrong endpoint or invalid credentials", () => {

--- a/src/agents/embedded-agent-helpers/failover-matches.ts
+++ b/src/agents/embedded-agent-helpers/failover-matches.ts
@@ -32,6 +32,12 @@ const COMMON_AUTH_ERROR_PATTERNS = [
   "unauthorized",
   "forbidden",
   "access denied",
+  // Claude Code CLI logged-out result text ("Not logged in · Please run
+  // /login", verbatim on v2.1.206); without this the claude-cli backend's
+  // logged-out state classifies as "unknown" and users get the generic
+  // failure copy instead of a re-auth hint (#103773).
+  "not logged in",
+  /please run \/login/i,
   "insufficient permissions",
   "insufficient permission",
   /missing scopes?:/i,

--- a/src/auto-reply/reply/agent-runner-execution-auth-failures.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution-auth-failures.test.ts
@@ -242,6 +242,30 @@ describe("runAgentTurnWithFallback: authentication failures", () => {
     }
   });
 
+  it("surfaces the claude-cli re-auth hint when the CLI session is logged out", async () => {
+    // Verbatim result text from Claude Code v2.1.206 in -p mode when the CLI
+    // is logged out; previously this classified as "unknown" and users got the
+    // generic failure copy with no pointer at `claude auth login` (#103773).
+    state.runEmbeddedAgentMock.mockRejectedValueOnce(
+      new FailoverError("Not logged in \u00b7 Please run /login", {
+        reason: "auth",
+        provider: "claude-cli",
+        model: "claude-sonnet-4-20250514",
+        status: 401,
+      }),
+    );
+
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const result = await runAgentTurnWithFallback(createMinimalRunAgentTurnParams());
+
+    expect(result.kind).toBe("final");
+    if (result.kind === "final") {
+      expect(result.payload.text).toBe(
+        "⚠️ Model login expired on the gateway for claude-cli. Re-auth with `claude auth login && openclaw models auth login --provider anthropic --method cli` in a terminal, then try again.",
+      );
+    }
+  });
+
   it("surfaces direct provider auth guidance for missing API keys", async () => {
     state.runEmbeddedAgentMock.mockRejectedValueOnce(
       new Error(


### PR DESCRIPTION
Closes #103773

## What Problem This Solves

Fixes an issue where users messaging through the `claude-cli` backend would get a generic "Something went wrong… use /new" reply when the Claude CLI session was logged out (`claude auth status` → `loggedIn: false`). `/new` did not help, and operators had to manually inspect the gateway and run `claude auth status` to discover the real cause.

## Why This Change Was Made

Extend the existing Claude CLI authentication classification and re-auth reply path so the logged-out CLI result text (`Not logged in · Please run /login`) is treated as auth failure with reason `sign_in_again`, while expired-token 401 failures keep the existing `revoked` mapping. The agent-turn failure reply then surfaces the same actionable `claude auth login && openclaw models auth login --provider anthropic --method cli` guidance already used for expired CLI OAuth.

Compatibility: no config, protocol, or SDK surface changes; additive pattern matching only. Performance: hot-path cost is a few extra substring/regex checks on error paths only. Usability: users get a recovery command instead of a dead-end generic error. Security: local error classification only; no new trust boundary, secrets, or allowlist changes.

## User Impact

When Claude CLI is logged out, channel/agent replies now name the auth problem and tell operators to re-auth with the CLI login command, instead of a generic failure that suggests starting a new session.

## Evidence

Verification host: local macOS (Crabbox bypass).

```text
pnpm check:changed   # pass (lanes=core, coreTests)
pnpm test:changed    # pass (45 + 16 tests)
node scripts/run-vitest.mjs src/agents/auth-profiles/oauth-refresh-failure.test.ts \
  src/agents/embedded-agent-helpers/failover-matches.test.ts \
  src/auto-reply/reply/agent-runner-execution-auth-failures.test.ts
# all pass
node scripts/run-vitest.mjs src/auto-reply/reply/agent-runner-execution-auth-failures.test.ts -t "logged out"
# ✓ surfaces the claude-cli re-auth hint when the CLI session is logged out
```

Focused agent-turn proof (post-patch):

```text
✓ |unit-fast-isolated| agent-runner-execution-auth-failures.test.ts
  ✓ surfaces the claude-cli re-auth hint when the CLI session is logged out
Expected final payload:
⚠️ Model login expired on the gateway for claude-cli. Re-auth with `claude auth login && openclaw models auth login --provider anthropic --method cli` in a terminal, then try again.
```

Classifier proof (logged-out string → `sign_in_again`):

```text
classifyOAuthRefreshFailure("Provider claude-cli failed: Not logged in · Please run /login")
→ { provider: "claude-cli", reason: "sign_in_again" }
```

## Real behavior proof

- Behavior addressed: Logged-out Claude CLI sessions no longer collapse into the generic agent-turn failure copy; users get the existing claude-cli re-auth command.
- Environment: local macOS, OpenClaw checkout at `fix/103773-claude-cli-logged-out-auth` (`7111ed5fa`), Node Vitest unit-fast / unit-fast-isolated configs.
- Current-main contrast: On `origin/main`, `CLAUDE_CLI_AUTH_FAILURE_RE` and structured Claude CLI auth matching only recognized "failed to authenticate" / "401 Invalid authentication credentials". Verbatim logged-out text `Not logged in · Please run /login` did not classify as OAuth refresh failure, so `runAgentTurnWithFallback` fell through to generic failure copy. Auth-error text matchers also did not treat that string as auth.
- Exact steps or command run after this patch:
  1. `node scripts/run-vitest.mjs src/agents/auth-profiles/oauth-refresh-failure.test.ts`
  2. `node scripts/run-vitest.mjs src/agents/embedded-agent-helpers/failover-matches.test.ts`
  3. `node scripts/run-vitest.mjs src/auto-reply/reply/agent-runner-execution-auth-failures.test.ts -t "logged out"`
- Evidence after fix: The logged-out agent-turn case asserts `result.kind === "final"` and payload text exactly equal to the Model login expired / `claude auth login && openclaw models auth login --provider anthropic --method cli` re-auth message. Classifier tests assert `reason: "sign_in_again"` for both provider-prefixed and structured FailoverError forms. `isAuthErrorMessage("Not logged in · Please run /login")` is true.
- Control check: Existing expired-token claude-cli 401 cases still map to `revoked` and still surface the same re-auth command; non-claude-cli 401 messages remain unmapped as OAuth refresh failures.
- Observed result after fix: All 61 focused tests across the three files pass; the agent-turn path returns the actionable re-auth reply for the logged-out signature.
- What was not tested: Live gateway with a real logged-out `claude` binary and Telegram/channel delivery recording; live Anthropic cloud calls (not required for this classification/reply path).

## AI disclosure

This PR was authored with AI assistance (Grok).
