### PR TITLE
fix(sessions): commit reduced session index before deleting evicted transcripts

### DIFF
--- a/src/config/sessions/disk-budget.test.ts
+++ b/src/config/sessions/disk-budget.test.ts
@@ -641,6 +641,87 @@ describe("enforceSessionDiskBudget", () => {
       expect(result.removedEntries).toBe(1);
     });
   });
+
+  it("commits the reduced session index before deleting an evicted transcript", async () => {
+    await withTempDir({ prefix: "openclaw-disk-budget-commit-order-" }, async (dir) => {
+      const storePath = path.join(dir, "sessions.json");
+      const oldKey = "agent:main:subagent:old-worker";
+      const activeKey = "agent:main:main";
+      const oldTranscript = path.join(dir, "old.jsonl");
+      const activeTranscript = path.join(dir, "active.jsonl");
+      const store: Record<string, SessionEntry> = {
+        [oldKey]: { sessionId: "old", updatedAt: 1 },
+        [activeKey]: { sessionId: "active", updatedAt: 2 },
+      };
+      await fs.writeFile(storePath, JSON.stringify(store, null, 2), "utf-8");
+      await fs.writeFile(oldTranscript, "t".repeat(10 * 1024), "utf-8");
+      await fs.writeFile(activeTranscript, "a".repeat(64), "utf-8");
+
+      let commitCalls = 0;
+      let transcriptPresentAtCommit: boolean | null = null;
+      let indexPresentActiveOnlyAtCommit: boolean | null = null;
+      const result = await enforceSessionDiskBudget({
+        store,
+        storePath,
+        activeSessionKey: activeKey,
+        maintenance: { maxDiskBytes: 100, highWaterBytes: 100 },
+        warnOnly: false,
+        commitEvictedIndex: async () => {
+          commitCalls += 1;
+          transcriptPresentAtCommit = nodeFs.existsSync(oldTranscript);
+          await fs.writeFile(storePath, JSON.stringify({ [activeKey]: store[activeKey] }, null, 2));
+          const persisted = JSON.parse(await fs.readFile(storePath, "utf-8")) as Record<
+            string,
+            SessionEntry
+          >;
+          indexPresentActiveOnlyAtCommit =
+            persisted[activeKey] !== undefined && persisted[oldKey] === undefined;
+        },
+      });
+
+      expectBudgetResult(result);
+      expect(commitCalls).toBe(1);
+      expect(transcriptPresentAtCommit).toBe(true);
+      expect(indexPresentActiveOnlyAtCommit).toBe(true);
+      expect(result.removedEntries).toBe(1);
+      expect(result.removedFiles).toBeGreaterThanOrEqual(1);
+      expect(store[oldKey]).toBeUndefined();
+      expect(store).toHaveProperty(activeKey);
+      await expectPathMissing(oldTranscript);
+      await expectPathExists(activeTranscript);
+    });
+  });
+
+  it("retains the evicted transcript when the index commit fails", async () => {
+    await withTempDir({ prefix: "openclaw-disk-budget-commit-fail-" }, async (dir) => {
+      const storePath = path.join(dir, "sessions.json");
+      const oldKey = "agent:main:subagent:old-worker";
+      const activeKey = "agent:main:main";
+      const oldTranscript = path.join(dir, "old.jsonl");
+      const store: Record<string, SessionEntry> = {
+        [oldKey]: { sessionId: "old", updatedAt: 1 },
+        [activeKey]: { sessionId: "active", updatedAt: 2 },
+      };
+      await fs.writeFile(storePath, JSON.stringify(store, null, 2), "utf-8");
+      await fs.writeFile(oldTranscript, "t".repeat(10 * 1024), "utf-8");
+
+      const commitFailure = new Error("simulated store-write failure");
+      await expect(
+        enforceSessionDiskBudget({
+          store,
+          storePath,
+          activeSessionKey: activeKey,
+          maintenance: { maxDiskBytes: 100, highWaterBytes: 100 },
+          warnOnly: false,
+          commitEvictedIndex: async () => {
+            throw commitFailure;
+          },
+        }),
+      ).rejects.toBe(commitFailure);
+
+      await expectPathExists(oldTranscript);
+    });
+  });
 });
 
 describe("pruneUnreferencedSessionArtifacts", () => {

--- a/src/config/sessions/disk-budget.test.ts
+++ b/src/config/sessions/disk-budget.test.ts
@@ -378,6 +378,9 @@ describe("enforceSessionDiskBudget", () => {
           highWaterBytes: 1,
         },
         warnOnly: false,
+        commitEvictedIndex: async () => {
+          await fs.writeFile(storePath, JSON.stringify(store, null, 2), "utf-8");
+        },
       });
 
       expectBudgetResult(result);
@@ -719,6 +722,36 @@ describe("enforceSessionDiskBudget", () => {
         }),
       ).rejects.toBe(commitFailure);
 
+      await expectPathExists(oldTranscript);
+    });
+  });
+
+  it("retains evicted artifacts when no durable index commit is available", async () => {
+    await withTempDir({ prefix: "openclaw-disk-budget-missing-commit-" }, async (dir) => {
+      const storePath = path.join(dir, "sessions.json");
+      const oldKey = "agent:main:subagent:old-worker";
+      const activeKey = "agent:main:main";
+      const oldTranscript = path.join(dir, "old.jsonl");
+      const store: Record<string, SessionEntry> = {
+        [oldKey]: { sessionId: "old", updatedAt: 1 },
+        [activeKey]: { sessionId: "active", updatedAt: 2 },
+      };
+      await fs.writeFile(storePath, JSON.stringify(store, null, 2), "utf-8");
+      await fs.writeFile(oldTranscript, "t".repeat(10 * 1024), "utf-8");
+
+      const result = await enforceSessionDiskBudget({
+        store,
+        storePath,
+        activeSessionKey: activeKey,
+        maintenance: { maxDiskBytes: 100, highWaterBytes: 100 },
+        warnOnly: false,
+      });
+
+      expectBudgetResult(result);
+      expect(result.removedEntries).toBe(1);
+      expect(result.removedFiles).toBe(0);
+      expect(result.totalBytesAfter).toBeGreaterThan(result.highWaterBytes);
+      expect(store[oldKey]).toBeUndefined();
       await expectPathExists(oldTranscript);
     });
   });

--- a/src/config/sessions/disk-budget.ts
+++ b/src/config/sessions/disk-budget.ts
@@ -638,6 +638,7 @@ export async function enforceSessionDiskBudget(params: {
   let removedFiles = 0;
   let removedEntries = 0;
   let freedBytes = 0;
+  const commitEvictedIndex = params.commitEvictedIndex;
 
   const referencedPaths = resolveReferencedSessionArtifactPaths({
     sessionsDir,
@@ -707,6 +708,11 @@ export async function enforceSessionDiskBudget(params: {
 
   const deferredEvictedArtifactPaths: string[] = [];
   const planEvictedArtifactRemoval = (rawPath: string, canonicalPathHint?: string): number => {
+    // An evicted artifact may only be unlinked after its reduced index is durable.
+    // Callers without that boundary retain the artifact as a reclaimable orphan.
+    if (!dryRun && !commitEvictedIndex) {
+      return 0;
+    }
     const resolvedPath = path.resolve(rawPath);
     const canonicalPath = canonicalPathHint ?? canonicalizePathForComparison(resolvedPath);
     if (simulatedRemovedPaths.has(canonicalPath)) {
@@ -820,8 +826,8 @@ export async function enforceSessionDiskBudget(params: {
     }
   }
 
-  if (!dryRun && deferredEvictedArtifactPaths.length > 0) {
-    await params.commitEvictedIndex?.();
+  if (!dryRun && commitEvictedIndex && deferredEvictedArtifactPaths.length > 0) {
+    await commitEvictedIndex();
     for (const filePath of deferredEvictedArtifactPaths) {
       const deletedBytes = await removeFileForBudget({
         filePath,

--- a/src/config/sessions/disk-budget.ts
+++ b/src/config/sessions/disk-budget.ts
@@ -553,6 +553,7 @@ export async function enforceSessionDiskBudget(params: {
   dryRun?: boolean;
   log?: SessionDiskBudgetLogger;
   onRemoveFile?: (canonicalPath: string) => void;
+  commitEvictedIndex?: () => Promise<void>;
 }): Promise<SessionDiskBudgetSweepResult | null> {
   const maxBytes = params.maintenance.maxDiskBytes;
   const highWaterBytes = params.maintenance.highWaterBytes;
@@ -704,6 +705,22 @@ export async function enforceSessionDiskBudget(params: {
     removedFiles += 1;
   }
 
+  const deferredEvictedArtifactPaths: string[] = [];
+  const planEvictedArtifactRemoval = (rawPath: string, canonicalPathHint?: string): number => {
+    const resolvedPath = path.resolve(rawPath);
+    const canonicalPath = canonicalPathHint ?? canonicalizePathForComparison(resolvedPath);
+    if (simulatedRemovedPaths.has(canonicalPath)) {
+      return 0;
+    }
+    const size = fileSizesByPath.get(canonicalPath) ?? 0;
+    if (size <= 0) {
+      return 0;
+    }
+    simulatedRemovedPaths.add(canonicalPath);
+    deferredEvictedArtifactPaths.push(resolvedPath);
+    return size;
+  };
+
   if (total > highWaterBytes) {
     const activeSessionKey = normalizeOptionalLowercaseString(params.activeSessionKey);
     const sessionIdRefCounts = buildSessionIdRefCounts(params.store);
@@ -762,20 +779,16 @@ export async function enforceSessionDiskBudget(params: {
                 tempStaleCutoffMs,
               )
             ) {
-              const deletedBytes = await removePromptBlobFileForBudget({
-                file: blobFile,
-                projectedPromptBlobRefCounts,
-                promptBlobCutoffMs: promptBlobOrphanCutoffMs,
-                tempCutoffMs: tempStaleCutoffMs,
-                dryRun,
-                fileSizesByPath,
-                simulatedRemovedPaths,
-                onRemovedPath: params.onRemoveFile,
-              });
-              if (deletedBytes > 0) {
-                total -= deletedBytes;
-                freedBytes += deletedBytes;
-                removedFiles += 1;
+              const plannedBytes = planEvictedArtifactRemoval(
+                blobFile.path,
+                blobFile.canonicalPath,
+              );
+              if (plannedBytes > 0) {
+                total -= plannedBytes;
+                if (dryRun) {
+                  freedBytes += plannedBytes;
+                  removedFiles += 1;
+                }
               }
             }
           }
@@ -794,20 +807,34 @@ export async function enforceSessionDiskBudget(params: {
       }
       sessionIdRefCounts.delete(sessionId);
       for (const artifactPath of resolveSessionArtifactPathsForEntry({ sessionsDir, entry })) {
-        const deletedBytes = await removeFileForBudget({
-          filePath: artifactPath,
-          dryRun,
-          fileSizesByPath,
-          simulatedRemovedPaths,
-          onRemovedPath: params.onRemoveFile,
-        });
-        if (deletedBytes <= 0) {
+        const plannedBytes = planEvictedArtifactRemoval(artifactPath);
+        if (plannedBytes <= 0) {
           continue;
         }
-        total -= deletedBytes;
-        freedBytes += deletedBytes;
-        removedFiles += 1;
+        total -= plannedBytes;
+        if (dryRun) {
+          freedBytes += plannedBytes;
+          removedFiles += 1;
+        }
       }
+    }
+  }
+
+  if (!dryRun && deferredEvictedArtifactPaths.length > 0) {
+    await params.commitEvictedIndex?.();
+    for (const filePath of deferredEvictedArtifactPaths) {
+      const deletedBytes = await removeFileForBudget({
+        filePath,
+        dryRun: false,
+        fileSizesByPath,
+        simulatedRemovedPaths,
+        onRemovedPath: params.onRemoveFile,
+      });
+      if (deletedBytes <= 0) {
+        continue;
+      }
+      freedBytes += deletedBytes;
+      removedFiles += 1;
     }
   }
 

--- a/src/config/sessions/sessions.test.ts
+++ b/src/config/sessions/sessions.test.ts
@@ -25,6 +25,7 @@ import { readSessionStoreCache, writeSessionStoreCache } from "./store-cache.js"
 import {
   clearSessionStoreCacheForTest,
   loadSessionStore,
+  saveSessionStore,
   updateSessionStore,
   updateSessionStoreEntry,
 } from "./store.js";
@@ -853,6 +854,38 @@ describe("session store writer queue", () => {
     expect(writeOptions?.mode).toBe(0o600);
     expect(writeOptions?.beforeRename).toBeTypeOf("function");
     writeSpy.mockRestore();
+  });
+
+  it("uses a durable index write before disk-budget eviction deletes transcripts", async () => {
+    const oldKey = "agent:main:subagent:old-worker";
+    const activeKey = "agent:main:main";
+    const now = Date.now();
+    const store: Record<string, SessionEntry> = {
+      [oldKey]: { sessionId: "old", updatedAt: now - 1_000 },
+      [activeKey]: { sessionId: "active", updatedAt: now },
+    };
+    const { dir, storePath } = await makeTmpStore(store);
+    await fsPromises.writeFile(path.join(dir, "old.jsonl"), "t".repeat(10 * 1024), "utf-8");
+    await fsPromises.writeFile(path.join(dir, "active.jsonl"), "a".repeat(64), "utf-8");
+
+    const writeSpy = vi.spyOn(jsonFiles, "writeTextAtomic");
+    try {
+      await saveSessionStore(storePath, store, {
+        activeSessionKey: activeKey,
+        maintenanceOverride: { mode: "enforce", maxDiskBytes: 100, highWaterBytes: 100 },
+      });
+
+      expect(writeSpy).toHaveBeenCalledTimes(1);
+      const [writtenPath, , writeOptions] = requireWriteTextAtomicCall(writeSpy);
+      expect(writtenPath).toBe(storePath);
+      expect(writeOptions?.durable).toBe(true);
+      expect(store[oldKey]).toBeUndefined();
+      await expect(fsPromises.access(path.join(dir, "old.jsonl"))).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+    } finally {
+      writeSpy.mockRestore();
+    }
   });
 
   it("can persist a known single entry without touching hydrated prompts from other sessions", async () => {

--- a/src/config/sessions/store-maintenance-operations.ts
+++ b/src/config/sessions/store-maintenance-operations.ts
@@ -62,6 +62,7 @@ type FileBackedSessionStoreMaintenanceParams = {
   maintenanceConfig?: ResolvedSessionMaintenanceConfig;
   log: SessionMaintenanceLogger;
   artifacts: RemovedSessionArtifactCleanup;
+  commitReducedStore?: () => Promise<void>;
 };
 
 type FileBackedSessionStoreMaintenanceResult = {
@@ -251,6 +252,7 @@ async function applyEnforcedMaintenance(params: {
     maintenance: params.maintenance,
     warnOnly: false,
     log: params.operation.log,
+    commitEvictedIndex: params.operation.commitReducedStore,
   });
   await params.operation.onMaintenanceApplied?.({
     mode: params.maintenance.mode,

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -756,6 +756,7 @@ async function saveSessionStoreUnlocked(
         serialized: JSON.stringify(projected.store, null, 2),
         serializedPromptRefs: collectStorePromptRefs(projected.store),
         promptBlobs: [...projected.promptBlobs.values()],
+        durable: true,
       });
     };
     const maintenance = await applyFileBackedSessionStoreMaintenance({
@@ -1224,12 +1225,13 @@ async function writeSessionStoreAtomic(params: {
   cloneSerialized?: string;
   promptBlobs: Iterable<SessionSkillPromptBlobProjection>;
   takeOwnership?: boolean;
+  durable?: boolean;
 }): Promise<void> {
   // Stage the temp as `sessions.json.<pid>.<uuid>.tmp` (not the generic
   // `.fs-safe-replace.*`) so a temp orphaned by a crash between write and rename
   // is identifiable as a session-store temp and reclaimable by cleanup (#56827).
   await writeTextAtomic(params.storePath, params.serialized, {
-    durable: false,
+    durable: params.durable ?? false,
     mode: 0o600,
     tempPrefix: path.basename(params.storePath),
     beforeRename: async () => {

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -748,6 +748,16 @@ async function saveSessionStoreUnlocked(
 
   let maintenanceChangedStore = false;
   if (!opts?.skipMaintenance) {
+    const commitReducedStore = async (): Promise<void> => {
+      const projected = projectSessionStoreForPersistence({ storePath, store });
+      await writeSessionStoreAtomic({
+        storePath,
+        store,
+        serialized: JSON.stringify(projected.store, null, 2),
+        serializedPromptRefs: collectStorePromptRefs(projected.store),
+        promptBlobs: [...projected.promptBlobs.values()],
+      });
+    };
     const maintenance = await applyFileBackedSessionStoreMaintenance({
       storePath,
       store,
@@ -757,6 +767,7 @@ async function saveSessionStoreUnlocked(
       maintenanceOverride: opts?.maintenanceOverride,
       maintenanceConfig: opts?.maintenanceConfig,
       log,
+      commitReducedStore,
       artifacts: {
         archiveRemovedSessionTranscripts,
         removeRemovedSessionTrajectoryArtifacts: async (params) => {


### PR DESCRIPTION
## What Problem This Solves
When a file-backed session store exceeds its disk budget, the last-resort sweep evicts the oldest non-preserved sessions. For each evicted session it removed the in-memory entry and then permanently deleted that session's transcript artifact, and only after the whole maintenance pass returned did the caller serialize and atomically replace `sessions.json`. Between the transcript deletion and the index write, the durable `sessions.json` on disk still references sessions whose transcripts are already gone. A kill, power loss, or a following store-write failure in that window leaves durable metadata pointing at permanently deleted conversation history, which is unrecoverable. This happens during low-disk maintenance, exactly when write failures are most likely.

The file-backed store is a documented supported path (explicit `session.store`, migration, discovery, offline maintenance) and the disk-budget API is publicly exported, so this is reachable outside the SQLite default.

## Why This Change Was Made

### Root cause
`enforceSessionDiskBudget` deleted the evicted entry's owned artifacts inline, before the reduced index was persisted (`src/config/sessions/disk-budget.ts`).

before:
```ts
sessionIdRefCounts.delete(sessionId);
for (const artifactPath of resolveSessionArtifactPathsForEntry({ sessionsDir, entry })) {
  const deletedBytes = await removeFileForBudget({
    filePath: artifactPath,
    dryRun,
    fileSizesByPath,
    simulatedRemovedPaths,
    onRemovedPath: params.onRemoveFile,
  });
  if (deletedBytes <= 0) {
    continue;
  }
  total -= deletedBytes;
  freedBytes += deletedBytes;
  removedFiles += 1;
}
```

The caller (`saveSessionStoreUnlocked`) only serialized and atomically replaced `sessions.json` after the maintenance pass returned, so the delete always preceded the index commit.

### Fix
The sweep now plans the evicted entries' owned-artifact deletions (transcript, trajectory sidecars, and a prompt blob orphaned by the eviction), accounting their freed bytes so the eviction stop condition is unchanged, and defers the physical unlink until after an injected `commitEvictedIndex` callback atomically persists the reduced index.

after:
```ts
sessionIdRefCounts.delete(sessionId);
for (const artifactPath of resolveSessionArtifactPathsForEntry({ sessionsDir, entry })) {
  const plannedBytes = planEvictedArtifactRemoval(artifactPath);
  if (plannedBytes <= 0) {
    continue;
  }
  total -= plannedBytes;
  if (dryRun) {
    freedBytes += plannedBytes;
    removedFiles += 1;
  }
}
```

```ts
if (!dryRun && commitEvictedIndex && deferredEvictedArtifactPaths.length > 0) {
  await commitEvictedIndex();
  for (const filePath of deferredEvictedArtifactPaths) {
    const deletedBytes = await removeFileForBudget({
      filePath,
      dryRun: false,
      fileSizesByPath,
      simulatedRemovedPaths,
      onRemovedPath: params.onRemoveFile,
    });
    if (deletedBytes <= 0) {
      continue;
    }
    freedBytes += deletedBytes;
    removedFiles += 1;
  }
}
```

`saveSessionStoreUnlocked` supplies the callback, which atomically writes the reduced `sessions.json` (`writeSessionStoreAtomic`) before the artifacts are unlinked. A crash after the commit leaves only reclaimable orphan files; a crash before it retains the transcript. If the commit fails, the deletions never run and the transcript is kept. Lower-level callers that cannot supply a durable commit boundary now retain just-evicted artifacts as reclaimable orphans, do not count those bytes as freed, and report that the high-water target remains unmet.

### Why this is the right boundary
The disk-budget eviction is the only path that hard-deletes session transcripts; prune and cap archive them, and already-detached orphans (unreferenced artifacts, archive files, orphaned prompt blobs whose entry was not just evicted) are still cleaned inline because deleting them creates no dangling reference. Only the just-evicted entries' owned artifacts move behind the index commit, which matches the store's existing invariant that entry-retention rows commit before artifact cleanup (`store-maintenance-operations.ts`). The commit callback reuses the same projection/serialization the normal save path uses, so when maintenance evicts, the subsequent normal persist finds the serialized store already current and does no second write. The SQLite-backed store is unaffected (it commits rows transactionally and does not use this function).

## User Impact

File-backed session stores no longer risk permanent transcript loss during disk-budget eviction. Normal saves still reclaim evicted artifacts after the reduced index is durable; lower-level callers without a durable commit boundary retain those artifacts safely and report the remaining disk pressure.

## Evidence

### Focused validation
- Follow-up durable-mode contract: `node scripts/run-vitest.mjs src/config/sessions/sessions.test.ts -t "keeps session store writes atomic|uses a durable index write"` passes, 2/2. The public save path selects `durable: true` for the destructive reduced-index commit, while the ordinary hot path remains `durable: false`.
- `node scripts/run-vitest.mjs src/config/sessions/disk-budget.test.ts` passes, 22/22 (19 existing plus ordering, commit-failure, and missing-boundary regressions).
- Missing-boundary coverage verifies the entry can be evicted in memory while its transcript is retained, no file removal is reported, and the sweep remains above high water.
- Adjacent suites green: `store.pruning.test.ts` and `store.pruning.integration.test.ts` (76 tests).
- `oxlint src/config/sessions/disk-budget.ts src/config/sessions/disk-budget.test.ts`, `oxfmt --check ...`, and `git diff --check` clean.
- `tsgo -p tsconfig.core.json` currently reaches unrelated declaration errors in `packages/retry/src/index.ts`, `src/auto-reply/reply/dispatch-from-config.lifecycle.ts`, and `src/media-understanding/audio.test-helpers.ts` involving `AbortSignal`/`Response`; no touched-file type error was reported.

### Real behavior proof
Behavior addressed: disk-budget eviction must never permanently delete an evicted session artifact unless the reduced durable index has committed first. The follow-up also closes the lower-level missing-callback path identified in review.

Real environment tested: head `4dd4ea4f35517ad084bc13a5da18f3fb0c00094b`, using real temporary directories, a real on-disk `sessions.json`, a 10 KB old transcript, an active transcript, and the production disk-budget implementation. The public-path scenario invoked `saveSessionStore(..., { maintenanceOverride: { mode: "enforce", maxDiskBytes: 100, highWaterBytes: 100 } })`. The missing-boundary scenario invoked the exported `enforceSessionDiskBudget` without `commitEvictedIndex`. No filesystem deletion was mocked; for the public path, `fs.promises.rm` was wrapped only to read the already-persisted index at the exact unlink boundary.

Observed result:
```
ordinary hot-path durable option: false
public disk-budget commit durable option: true
# Public save path
public save deletion observed: true
public save index references evicted session at deletion: false
public save evicted transcript exists after save: false
public save active transcript exists after save: true
public save final persisted keys: ["agent:main:main"]

# Lower-level sweep with no durable commit callback
missing boundary evicted transcript retained: true
missing boundary removal callbacks: 0
missing boundary removed files: 0
missing boundary durable index still unchanged: true
missing boundary reports above high-water: true
```

The public writer preserves normal eviction behavior and deletes only after the reduced index is durable. When the boundary is unavailable, the sweep fails safe: it removes no owned artifact, makes no false freed-byte claim, and leaves the durable index and transcript mutually consistent. The earlier pristine-base observation remains the before-state: the durable index still referenced the evicted session at transcript unlink time.

What was not tested: no real power loss or process kill was induced; the critical ordering was observed by snapshotting the durable index at deletion time. The full build and large test typecheck were not run.
## Notes
Open PR #97103 also edits `store.ts` and `store-maintenance-operations.ts`, but in different sections (archive-cleanup reporting for the sessions-cleanup command); it does not change the eviction or index-commit ordering. There may be a trivial rebase overlap in the maintenance params type.

