### PR TITLE
fix(ui): align release E2E with current chat contracts

### DIFF
--- a/config/max-lines-baseline.txt
+++ b/config/max-lines-baseline.txt
@@ -516,7 +516,6 @@ src/agents/model-fallback.ts
 src/agents/model-selection-shared.ts
 src/agents/model-selection.test.ts
 src/agents/models.profiles.live.test.ts
-src/agents/modes/interactive/theme/theme.ts
 src/agents/openai-completions-transport.ts
 src/agents/openai-responses-transport.ts
 src/agents/openai-transport-stream.base.test-utils.ts

--- a/ui/src/e2e/approval-flow.e2e.test.ts
+++ b/ui/src/e2e/approval-flow.e2e.test.ts
@@ -104,7 +104,7 @@ describeControlUiE2e("Control UI approval flow", () => {
     await currentPage.getByRole("button", { name: "Stop generating" }).waitFor();
 
     await composer.fill("/approve approval-123 allow-once");
-    await currentPage.getByRole("button", { name: "Queue message" }).click();
+    await currentPage.getByRole("button", { name: "Steer into the active run" }).click();
 
     await expect
       .poll(async () => (await gateway.getRequests("chat.send")).length, { timeout: 10_000 })

--- a/ui/src/e2e/chat-large-paste-99213.e2e.test.ts
+++ b/ui/src/e2e/chat-large-paste-99213.e2e.test.ts
@@ -234,6 +234,7 @@ describeControlUiE2e("Control UI #99213 large screenshot paste proof", () => {
       const runId = requireString(params.idempotencyKey, "chat send idempotency key");
       await gateway.emitChatFinal({ runId, text: "Large screenshot paste proof received." });
       await recorded.page
+        .locator(".chat-thread-inner")
         .getByText("Large screenshot paste proof received.")
         .waitFor({ timeout: 10_000 });
       const sentScreenshot = path.join(artifactDir, "02-sent-large-image.png");

--- a/ui/src/e2e/chat-run-lifecycle.e2e.test.ts
+++ b/ui/src/e2e/chat-run-lifecycle.e2e.test.ts
@@ -288,7 +288,7 @@ describeControlUiE2e("Control UI chat run lifecycle", () => {
       yielded: true,
     });
 
-    await currentPage.getByText(finalText, { exact: true }).waitFor();
+    await currentPage.locator(".chat-thread-inner").getByText(finalText, { exact: true }).waitFor();
     expect(await currentPage.getByRole("button", { name: "Stop generating" }).count()).toBe(0);
     await expect.poll(() => mainSession.locator(".session-run-spinner").count()).toBe(0);
     await expect

--- a/ui/src/e2e/mantis-chat-proof.e2e.test.ts
+++ b/ui/src/e2e/mantis-chat-proof.e2e.test.ts
@@ -123,7 +123,7 @@ describeMantisWebUiChat("Mantis Control UI web chat proof", () => {
       await page.screenshot({ fullPage: true, path: path.join(artifactDir, "web-ui-chat.png") });
 
       await gateway.emitChatFinal({ runId: params.idempotencyKey ?? "", text: reply });
-      await page.getByText(reply).waitFor({ timeout: 10_000 });
+      await page.locator(".chat-thread-inner").getByText(reply).waitFor({ timeout: 10_000 });
       await writeFile(
         path.join(artifactDir, "web-ui-chat-proof.json"),
         `${JSON.stringify(


### PR DESCRIPTION
## What Problem This Solves

Resolves release validation failures where Control UI E2E checks no longer matched the current chat accessibility and active-run follow-up contracts.

## Why This Change Was Made

The affected chat-response locators now target the visible message thread instead of also matching the screen-reader live announcement. The approval flow now selects the current default steer action during an active run.

The same changed gate exposed a stale max-lines exemption left behind after `theme.ts` fell below the limit on current `main`; this PR removes that obsolete baseline entry so current-main validation can proceed.

## User Impact

No product behavior change. Release E2E validation now exercises the intended current UI behavior without strict-locator ambiguity or a stale action label.

## Evidence

- Prior failing Full Release Validation child: https://github.com/openclaw/openclaw/actions/runs/29427626707
- Prior failing UI E2E job: https://github.com/openclaw/openclaw/actions/runs/29427626707/job/87395135781
- Direct AWS focused proof, 4 files / 7 tests green: https://crabbox.openclaw.ai/portal/runs/run_e2eadce52aa3
- Max-lines ratchet: `max-lines ratchet OK: 1204 grandfathered suppressions`
- Exact-head GitHub-hosted fallback: https://github.com/openclaw/openclaw/actions/runs/29432193569
- `git diff --check`
- Fresh structured autoreview: clean, no accepted or actionable findings

No changelog entry: test-only release-infrastructure correction.
