### PR TITLE
fix: clarify SQLite version error message to prevent user confusion

### DIFF
--- a/scripts/install-cli.sh
+++ b/scripts/install-cli.sh
@@ -625,7 +625,7 @@ install_alpine_node() {
     installed_version="$("$(node_bin)" -v 2>/dev/null || echo unknown)"
     required_version="$(required_node_version)"
     sqlite_version="$(linked_node_sqlite_version)"
-    fail "Alpine Node package must provide Node >= ${required_version} with WAL-reset-safe SQLite 3.51.3+ (or patched 3.50.7+/3.44.6+); found Node ${installed_version}, SQLite ${sqlite_version}."
+    fail "Alpine Node package must provide Node >= ${required_version} with WAL-reset-safe SQLite 3.51.3+, 3.50.7+ within 3.50.x, or 3.44.6+ within 3.44.x; found Node ${installed_version}, SQLite ${sqlite_version}."
   fi
 
   installed_version="$("$(node_bin)" -v 2>/dev/null || echo unknown)"

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -221,7 +221,7 @@ function Check-Node {
                 } else {
                     $sqliteVersion
                 }
-                Write-Host "[!] Node.js $nodeVersion uses SQLite $sqliteVersionLabel; SQLite 3.51.3+ (or patched 3.50.7+/3.44.6+) is required" -ForegroundColor Yellow
+                Write-Host "[!] Node.js $nodeVersion uses SQLite $sqliteVersionLabel; SQLite 3.51.3+, 3.50.7+ within 3.50.x, or 3.44.6+ within 3.44.x is required" -ForegroundColor Yellow
                 return $false
             } else {
                 Write-Host "[!] Node.js $nodeVersion found, but Node 22.22.3+, Node 24.15.0+, or Node 25.9.0+ is required" -ForegroundColor Yellow

--- a/src/infra/node-sqlite.test.ts
+++ b/src/infra/node-sqlite.test.ts
@@ -42,14 +42,13 @@ async function withNodeSharedSqliteValue(value: unknown, run: () => Promise<void
 function expectedUnsafeSqliteError(version: string, shared: boolean): string {
   const wording = shared ? "uses shared system" : "embeds";
   const remediation = shared
-    ? "Upgrade the system SQLite library to 3.51.3+ or specific patched versions (3.44.6/3.50.7), or use a Node build embedding a safe version."
+    ? "Upgrade the system SQLite library to one of those safe versions, or use a Node build embedding a safe version."
     : "Upgrade to Node 22.22.3+, 24.15.0+, or 25.9.0+ before retrying.";
   return (
     "SQLite support is unavailable or unsafe in this Node runtime. " +
-    "OpenClaw requires SQLite 3.51.3+ (or the specific patched versions 3.44.6+ in the 3.44.x series or 3.50.7+ in the 3.50.x series) for WAL safety; " +
+    "OpenClaw requires SQLite 3.51.3+, 3.50.7+ within 3.50.x, or 3.44.6+ within 3.44.x for WAL safety; " +
     `Node ${process.versions.node} ${wording} SQLite ${version}, which is affected by the upstream WAL-reset ` +
-    `database corruption bug. The SQLite team released fixes for 3.51.3+, 3.50.7+ (3.50.x only), and 3.44.6+ (3.44.x only). ` +
-    remediation
+    `database corruption bug. ${remediation}`
   );
 }
 
@@ -70,21 +69,13 @@ describe("node SQLite safety", () => {
     },
   );
 
-  it.each([
-    "3.51.2",
-    "3.51.0",
-    "3.50.6",
-    "3.49.1",
-    "3.46.1",
-    "3.46.0",
-    "3.45.0",
-    "3.44.5",
-    "invalid",
-    "3.51",
-  ])("rejects vulnerable or unknown SQLite %s", async (version) => {
-    const { requireNodeSqlite } = await loadNodeSqliteWithVersion(version);
-    expect(() => requireNodeSqlite()).toThrow(`SQLite ${version}, which is affected`);
-  });
+  it.each(["3.51.2", "3.51.0", "3.50.6", "3.49.1", "3.46.1", "3.44.5", "invalid", "3.51"])(
+    "rejects vulnerable or unknown SQLite %s",
+    async (version) => {
+      const { requireNodeSqlite } = await loadNodeSqliteWithVersion(version);
+      expect(() => requireNodeSqlite()).toThrow(`SQLite ${version}, which is affected`);
+    },
+  );
 
   it.each([true, "true"])(
     "rejects vulnerable shared SQLite with system-library remediation (%j)",

--- a/src/infra/node-sqlite.test.ts
+++ b/src/infra/node-sqlite.test.ts
@@ -46,9 +46,9 @@ function expectedUnsafeSqliteError(version: string, shared: boolean): string {
     : "Upgrade to Node 22.22.3+, 24.15.0+, or 25.9.0+ before retrying.";
   return (
     "SQLite support is unavailable or unsafe in this Node runtime. " +
-    "OpenClaw requires SQLite 3.51.3+ (or the specific patched versions 3.44.6+ or 3.50.7+) for WAL safety; " +
+    "OpenClaw requires SQLite 3.51.3+ (or the specific patched versions 3.44.6+ in the 3.44.x series or 3.50.7+ in the 3.50.x series) for WAL safety; " +
     `Node ${process.versions.node} ${wording} SQLite ${version}, which is affected by the upstream WAL-reset ` +
-    `database corruption bug. The SQLite team released fixes for 3.51.3+, 3.50.7+, and 3.44.6+ only. ` +
+    `database corruption bug. The SQLite team released fixes for 3.51.3+, 3.50.7+ (3.50.x only), and 3.44.6+ (3.44.x only). ` +
     remediation
   );
 }

--- a/src/infra/node-sqlite.test.ts
+++ b/src/infra/node-sqlite.test.ts
@@ -42,13 +42,14 @@ async function withNodeSharedSqliteValue(value: unknown, run: () => Promise<void
 function expectedUnsafeSqliteError(version: string, shared: boolean): string {
   const wording = shared ? "uses shared system" : "embeds";
   const remediation = shared
-    ? "Upgrade the system SQLite library to 3.51.3+ (or patched 3.50.7+/3.44.6+), or use a Node build embedding a safe version."
+    ? "Upgrade the system SQLite library to 3.51.3+ or specific patched versions (3.44.6/3.50.7), or use a Node build embedding a safe version."
     : "Upgrade to Node 22.22.3+, 24.15.0+, or 25.9.0+ before retrying.";
   return (
     "SQLite support is unavailable or unsafe in this Node runtime. " +
-    "OpenClaw requires SQLite 3.51.3+ (or patched 3.50.7+/3.44.6+) for WAL safety; " +
+    "OpenClaw requires SQLite 3.51.3+ (or the specific patched versions 3.44.6+ or 3.50.7+) for WAL safety; " +
     `Node ${process.versions.node} ${wording} SQLite ${version}, which is affected by the upstream WAL-reset ` +
-    `database corruption bug. ${remediation}`
+    `database corruption bug. The SQLite team released fixes for 3.51.3+, 3.50.7+, and 3.44.6+ only. ` +
+    remediation
   );
 }
 
@@ -69,13 +70,21 @@ describe("node SQLite safety", () => {
     },
   );
 
-  it.each(["3.51.2", "3.51.0", "3.50.6", "3.49.1", "3.44.5", "invalid", "3.51"])(
-    "rejects vulnerable or unknown SQLite %s",
-    async (version) => {
-      const { requireNodeSqlite } = await loadNodeSqliteWithVersion(version);
-      expect(() => requireNodeSqlite()).toThrow(`SQLite ${version}, which is affected`);
-    },
-  );
+  it.each([
+    "3.51.2",
+    "3.51.0",
+    "3.50.6",
+    "3.49.1",
+    "3.46.1",
+    "3.46.0",
+    "3.45.0",
+    "3.44.5",
+    "invalid",
+    "3.51",
+  ])("rejects vulnerable or unknown SQLite %s", async (version) => {
+    const { requireNodeSqlite } = await loadNodeSqliteWithVersion(version);
+    expect(() => requireNodeSqlite()).toThrow(`SQLite ${version}, which is affected`);
+  });
 
   it.each([true, "true"])(
     "rejects vulnerable shared SQLite with system-library remediation (%j)",

--- a/src/infra/node-sqlite.ts
+++ b/src/infra/node-sqlite.ts
@@ -17,12 +17,13 @@ function assertSqliteWalResetSafeVersion(version: string, nodeVersion: string): 
     variables?.node_shared_sqlite === true || variables?.node_shared_sqlite === "true";
   const wording = isShared ? "uses shared system" : "embeds";
   const remediation = isShared
-    ? "Upgrade the system SQLite library to 3.51.3+ (or patched 3.50.7+/3.44.6+), or use a Node build embedding a safe version."
+    ? "Upgrade the system SQLite library to 3.51.3+ or specific patched versions (3.44.6/3.50.7), or use a Node build embedding a safe version."
     : "Upgrade to Node 22.22.3+, 24.15.0+, or 25.9.0+ before retrying.";
   throw new Error(
-    `OpenClaw requires SQLite 3.51.3+ (or patched 3.50.7+/3.44.6+) for WAL safety; ` +
+    `OpenClaw requires SQLite 3.51.3+ (or the specific patched versions 3.44.6+ or 3.50.7+) for WAL safety; ` +
       `Node ${nodeVersion} ${wording} SQLite ${version}, which is affected by the upstream WAL-reset ` +
-      `database corruption bug. ${remediation}`,
+      `database corruption bug. The SQLite team released fixes for 3.51.3+, 3.50.7+, and 3.44.6+ only. ` +
+      remediation,
   );
 }
 

--- a/src/infra/node-sqlite.ts
+++ b/src/infra/node-sqlite.ts
@@ -17,13 +17,12 @@ function assertSqliteWalResetSafeVersion(version: string, nodeVersion: string): 
     variables?.node_shared_sqlite === true || variables?.node_shared_sqlite === "true";
   const wording = isShared ? "uses shared system" : "embeds";
   const remediation = isShared
-    ? "Upgrade the system SQLite library to 3.51.3+ or specific patched versions (3.44.6/3.50.7), or use a Node build embedding a safe version."
+    ? "Upgrade the system SQLite library to one of those safe versions, or use a Node build embedding a safe version."
     : "Upgrade to Node 22.22.3+, 24.15.0+, or 25.9.0+ before retrying.";
   throw new Error(
-    `OpenClaw requires SQLite 3.51.3+ (or the specific patched versions 3.44.6+ in the 3.44.x series or 3.50.7+ in the 3.50.x series) for WAL safety; ` +
+    `OpenClaw requires SQLite 3.51.3+, 3.50.7+ within 3.50.x, or 3.44.6+ within 3.44.x for WAL safety; ` +
       `Node ${nodeVersion} ${wording} SQLite ${version}, which is affected by the upstream WAL-reset ` +
-      `database corruption bug. The SQLite team released fixes for 3.51.3+, 3.50.7+ (3.50.x only), and 3.44.6+ (3.44.x only). ` +
-      remediation,
+      `database corruption bug. ${remediation}`,
   );
 }
 

--- a/src/infra/node-sqlite.ts
+++ b/src/infra/node-sqlite.ts
@@ -20,9 +20,9 @@ function assertSqliteWalResetSafeVersion(version: string, nodeVersion: string): 
     ? "Upgrade the system SQLite library to 3.51.3+ or specific patched versions (3.44.6/3.50.7), or use a Node build embedding a safe version."
     : "Upgrade to Node 22.22.3+, 24.15.0+, or 25.9.0+ before retrying.";
   throw new Error(
-    `OpenClaw requires SQLite 3.51.3+ (or the specific patched versions 3.44.6+ or 3.50.7+) for WAL safety; ` +
+    `OpenClaw requires SQLite 3.51.3+ (or the specific patched versions 3.44.6+ in the 3.44.x series or 3.50.7+ in the 3.50.x series) for WAL safety; ` +
       `Node ${nodeVersion} ${wording} SQLite ${version}, which is affected by the upstream WAL-reset ` +
-      `database corruption bug. The SQLite team released fixes for 3.51.3+, 3.50.7+, and 3.44.6+ only. ` +
+      `database corruption bug. The SQLite team released fixes for 3.51.3+, 3.50.7+ (3.50.x only), and 3.44.6+ (3.44.x only). ` +
       remediation,
   );
 }

--- a/test/scripts/install-cli.test.ts
+++ b/test/scripts/install-cli.test.ts
@@ -701,7 +701,7 @@ describe("install-cli.sh", () => {
       expect(result.status).toBe(1);
       expect(readFileSync(apkLog, "utf8")).toContain("add --no-cache nodejs npm");
       expect(result.stdout).toContain(
-        "Alpine Node package must provide Node >= 22.22.3 with WAL-reset-safe SQLite",
+        "Alpine Node package must provide Node >= 22.22.3 with WAL-reset-safe SQLite 3.51.3+, 3.50.7+ within 3.50.x, or 3.44.6+ within 3.44.x",
       );
       expect(result.stdout).toContain("found Node v22.18.0, SQLite unavailable");
     } finally {

--- a/test/scripts/install-ps1.test.ts
+++ b/test/scripts/install-ps1.test.ts
@@ -134,6 +134,7 @@ describe("install.ps1 failure handling", () => {
           "$cases = @{",
           "  '3.44.5' = $false",
           "  '3.44.6' = $true",
+          "  '3.46.1' = $false",
           "  '3.50.6' = $false",
           "  '3.50.7' = $true",
           "  '3.51.2' = $false",
@@ -503,6 +504,9 @@ describe("install.ps1 failure handling", () => {
     expect(checkNodeBody).toContain("$sqliteProbe | & $nodePath -");
     expect(checkNodeBody).not.toContain("& $nodePath -e");
     expect(checkNodeBody).toContain("Test-NodeSqliteSupported -Version $sqliteVersion");
+    expect(checkNodeBody).toContain(
+      "SQLite 3.51.3+, 3.50.7+ within 3.50.x, or 3.44.6+ within 3.44.x is required",
+    );
     expect(source).toContain("Please install Node.js 24.15+ manually:");
   });
 


### PR DESCRIPTION
Related: #108273

## What Problem This Solves

Fixes an issue where the SQLite WAL-safety diagnostic could make `3.44.6+` look like a global numeric floor, even though SQLite 3.46.1 remains unsafe because the fix was backported only within the 3.44.x and 3.50.x maintenance lines.

## Why This Change Was Made

The runtime, PowerShell installer, and shell installer now use one precise contract: SQLite 3.51.3+, 3.50.7+ within 3.50.x, or 3.44.6+ within 3.44.x. Version acceptance logic and the corruption guard are unchanged.

## User Impact

Users rejected on SQLite 3.46.1 now see why a numerically higher version is still outside the safe release lines and which runtime or system SQLite upgrade resolves it.

## Evidence

- `node scripts/run-vitest.mjs src/infra/node-sqlite.test.ts test/scripts/install-ps1.test.ts test/scripts/install-cli.test.ts`: 67 passed, 11 platform skips.
- Exact SQLite 3.46.1 rejection is covered in the runtime test and PowerShell installer version matrix.
- Runtime, PowerShell, and Alpine installer expectations assert the new maintenance-line wording.
- `node scripts/check-changed.mjs -- src/infra/node-sqlite.ts src/infra/node-sqlite.test.ts scripts/install.ps1 scripts/install-cli.sh test/scripts/install-ps1.test.ts test/scripts/install-cli.test.ts`: hosted Blacksmith Testbox passed: https://github.com/openclaw/openclaw/actions/runs/29496865796
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted --stream-engine-output`: clean, no actionable findings, confidence 0.98.
- `git diff --check`: passed.

## Risk checklist

- [x] No version acceptance change
- [x] No API or config change
- [x] No migration
- [x] Existing corruption guard remains fail-closed

## Current review state

Maintainer repair complete. Ready for merge after exact-head CI.

---

🤖 AI-assisted: original contribution developed with AI assistance; maintainer repair reviewed with Codex autoreview.

Co-authored-by: 林意斌0668000448 <lin.yibin@xydigit.com>
