### PR TITLE
fix(workboard): dispatch after terminal cards retain claims

### DIFF
--- a/extensions/workboard/src/dispatcher.test.ts
+++ b/extensions/workboard/src/dispatcher.test.ts
@@ -886,6 +886,39 @@ describe("dispatchAndStartWorkboardCards", () => {
     expect(run).not.toHaveBeenCalled();
   });
 
+  it("does not let stale claims on done cards consume an owner running slot", async () => {
+    const store = new WorkboardStore(createMemoryStore());
+    const done = await store.create({
+      title: "Completed without releasing claim",
+      status: "ready",
+      agentId: "codex-main",
+    });
+    await store.claim(done.id, { ownerId: "codex-main", token: "stale-token" });
+    await store.update(done.id, { status: "done" });
+    const ready = await store.create({
+      title: "Next ready card",
+      status: "ready",
+      priority: "high",
+      agentId: "codex-main",
+      workspaceAccess: { unrestricted: true },
+    });
+    const run = vi.fn().mockResolvedValue({ runId: "run-next" });
+
+    const result = await dispatchAndStartWorkboardCards({
+      store,
+      subagent: { run },
+      options: { now: 10, maxStarts: 3 },
+    });
+
+    expect((await store.get(done.id))?.metadata?.claim).toMatchObject({
+      ownerId: "codex-main",
+    });
+    expect(result.started).toEqual([
+      expect.objectContaining({ cardId: ready.id, runId: "run-next" }),
+    ]);
+    expect(run).toHaveBeenCalledOnce();
+  });
+
   it("blocks a card when worker start fails after claim", async () => {
     const store = new WorkboardStore(createMemoryStore());
     const card = await store.create({

--- a/extensions/workboard/src/dispatcher.test.ts
+++ b/extensions/workboard/src/dispatcher.test.ts
@@ -919,6 +919,36 @@ describe("dispatchAndStartWorkboardCards", () => {
     expect(run).toHaveBeenCalledOnce();
   });
 
+  it("keeps a done card with a running execution in the owner running slot", async () => {
+    const store = new WorkboardStore(createMemoryStore());
+    const running = await store.create({
+      title: "Completed card with active execution",
+      status: "ready",
+      agentId: "codex-main",
+    });
+    await store.update(running.id, {
+      status: "done",
+      execution: { runId: "run-active", status: "running" },
+    });
+    await store.create({
+      title: "Next ready card",
+      status: "ready",
+      priority: "high",
+      agentId: "codex-main",
+      workspaceAccess: { unrestricted: true },
+    });
+    const run = vi.fn().mockResolvedValue({ runId: "run-next" });
+
+    const result = await dispatchAndStartWorkboardCards({
+      store,
+      subagent: { run },
+      options: { now: 10, maxStarts: 3 },
+    });
+
+    expect(result.started).toEqual([]);
+    expect(run).not.toHaveBeenCalled();
+  });
+
   it("blocks a card when worker start fails after claim", async () => {
     const store = new WorkboardStore(createMemoryStore());
     const card = await store.create({

--- a/extensions/workboard/src/dispatcher.ts
+++ b/extensions/workboard/src/dispatcher.ts
@@ -231,9 +231,10 @@ function selectStartableCards(
   const runningByOwner = new Map<string, number>();
   for (const card of cards) {
     const consumesOwnerSlot =
-      card.status === "running" ||
-      Boolean(card.metadata?.claim) ||
-      card.execution?.status === "running";
+      card.status !== "done" &&
+      (card.status === "running" ||
+        Boolean(card.metadata?.claim) ||
+        card.execution?.status === "running");
     if (!consumesOwnerSlot || cardIsArchived(card)) {
       continue;
     }

--- a/extensions/workboard/src/dispatcher.ts
+++ b/extensions/workboard/src/dispatcher.ts
@@ -231,10 +231,9 @@ function selectStartableCards(
   const runningByOwner = new Map<string, number>();
   for (const card of cards) {
     const consumesOwnerSlot =
-      card.status !== "done" &&
-      (card.status === "running" ||
-        Boolean(card.metadata?.claim) ||
-        card.execution?.status === "running");
+      card.status === "running" ||
+      (card.status !== "done" && Boolean(card.metadata?.claim)) ||
+      card.execution?.status === "running";
     if (!consumesOwnerSlot || cardIsArchived(card)) {
       continue;
     }


### PR DESCRIPTION
Closes #108361

## What Problem This Solves

Fixes an issue where a Workboard card moved to `done` while retaining a stale claim would keep consuming its assigned agent's only dispatcher slot. Every later ready card for that agent could remain stranded even though the earlier card was already terminal.

## Why This Change Was Made

The dispatcher now excludes terminal `done` cards from owner-capacity accounting while preserving the existing behavior for claimed review cards and genuinely running executions. A focused regression reproduces the stale-claim state through the real store and verifies that the next ready card starts.

## User Impact

Operators can move a card to done after a worker exits without the completion tool and still dispatch later cards assigned to the same agent. Active and review work continues to reserve the owner slot as before.

## Evidence

- `npx --yes oxfmt@latest --check extensions/workboard/src/dispatcher.ts extensions/workboard/src/dispatcher.test.ts` — passed.
- `npx --yes oxlint@latest --tsconfig config/tsconfig/oxlint.core.json extensions/workboard/src/dispatcher.ts extensions/workboard/src/dispatcher.test.ts` — 0 warnings, 0 errors.
- `git diff upstream/main...HEAD --check` — passed.
- Diff secret scan — clean.
- Focused Vitest was attempted with `node scripts/run-vitest.mjs extensions/workboard/src/dispatcher.test.ts --reporter=dot`, but the isolated dependency install remained incomplete (`linkify-it` missing after package downloads stalled). Exact-head CI is expected to run the regression in the repository environment.

AI-assisted; the final diff and validation were reviewed locally.
