### PR TITLE
improve(ci): speed warm Node shards with sticky bind mount

### DIFF
--- a/.github/actions/register-bind-mount-cleanup/action.yml
+++ b/.github/actions/register-bind-mount-cleanup/action.yml
@@ -1,0 +1,11 @@
+name: Register bind mount cleanup
+description: Unmount a bind mount during post-job cleanup.
+inputs:
+  path:
+    description: Absolute bind-mount target to unmount.
+    required: true
+runs:
+  using: node24
+  main: main.cjs
+  post: post.cjs
+  post-if: always()

--- a/.github/actions/register-bind-mount-cleanup/main.cjs
+++ b/.github/actions/register-bind-mount-cleanup/main.cjs
@@ -1,0 +1,17 @@
+const fs = require("node:fs");
+const path = require("node:path");
+
+const mountPath = (process.env.INPUT_PATH ?? "").trim();
+const statePath = process.env.GITHUB_STATE;
+
+if (!mountPath || !path.isAbsolute(mountPath) || /[\r\n]/u.test(mountPath)) {
+  console.error("::error::Bind mount cleanup path must be an absolute single-line path");
+  process.exit(1);
+}
+if (!statePath) {
+  console.error("::error::GITHUB_STATE is unavailable");
+  process.exit(1);
+}
+
+fs.appendFileSync(statePath, `mountPath=${mountPath}\n`, "utf8");
+console.log(`Registered bind mount cleanup for ${mountPath}`);

--- a/.github/actions/register-bind-mount-cleanup/post.cjs
+++ b/.github/actions/register-bind-mount-cleanup/post.cjs
@@ -1,0 +1,31 @@
+const path = require("node:path");
+const { spawnSync } = require("node:child_process");
+
+const mountPath = (process.env.STATE_mountPath ?? "").trim();
+if (!mountPath || !path.isAbsolute(mountPath) || /[\r\n]/u.test(mountPath)) {
+  console.error("::error::Saved bind mount cleanup path is invalid");
+  process.exit(1);
+}
+
+const mountpoint = spawnSync("mountpoint", ["-q", mountPath], { stdio: "inherit" });
+if (mountpoint.error) {
+  console.error(`::error::Failed to inspect bind mount: ${mountpoint.error.message}`);
+  process.exit(1);
+}
+if (mountpoint.status === 32) {
+  console.log(`Bind mount already absent: ${mountPath}`);
+  process.exit(0);
+}
+if (mountpoint.status !== 0) {
+  console.error(`::error::mountpoint exited with status ${mountpoint.status}`);
+  process.exit(1);
+}
+
+const unmount = spawnSync("sudo", ["umount", mountPath], { stdio: "inherit" });
+if (unmount.error || unmount.status !== 0) {
+  const detail = unmount.error?.message ?? `status ${unmount.status}`;
+  console.error(`::error::Failed to unmount ${mountPath}: ${detail}`);
+  process.exit(1);
+}
+
+console.log(`Unmounted bind mount: ${mountPath}`);

--- a/.github/actions/setup-node-env/action.yml
+++ b/.github/actions/setup-node-env/action.yml
@@ -56,6 +56,29 @@ runs:
         source "$GITHUB_ACTION_PATH/../setup-pnpm-store-cache/ensure-node.sh"
         openclaw_ensure_node "$REQUESTED_NODE_VERSION"
 
+    - name: Setup pnpm
+      id: setup-pnpm
+      uses: ./.github/actions/setup-pnpm-store-cache
+      with:
+        node-version: ${{ inputs.node-version }}
+        use-actions-cache: ${{ inputs.use-actions-cache }}
+
+    - name: Validate sticky pnpm layout
+      if: inputs.sticky-disk == 'true'
+      shell: bash
+      run: |
+        set -euo pipefail
+        for config_name in modules-dir virtual-store-dir; do
+          config_value="$(pnpm config get "$config_name")"
+          case "$config_value" in
+            ""|undefined|null) ;;
+            *)
+              echo "::error::$config_name must be unset when sticky-disk is enabled; sticky mode requires pnpm's stock node_modules layout"
+              exit 2
+              ;;
+          esac
+        done
+
     - name: Mount dependency sticky disk
       if: inputs.sticky-disk == 'true'
       uses: useblacksmith/stickydisk@5b350170ae4ef55b536b548ef5f5896e76a6b54f # v1.4.0
@@ -95,13 +118,6 @@ runs:
         findmnt --target "$workspace_modules"
         # zizmor: ignore[github-env] static trusted path defined in this composite action.
         echo "PNPM_CONFIG_STORE_DIR=$sticky_store" >> "$GITHUB_ENV"
-
-    - name: Setup pnpm
-      id: setup-pnpm
-      uses: ./.github/actions/setup-pnpm-store-cache
-      with:
-        node-version: ${{ inputs.node-version }}
-        use-actions-cache: ${{ inputs.use-actions-cache }}
 
     - name: Setup Bun
       if: inputs.install-bun == 'true'

--- a/.github/actions/setup-node-env/action.yml
+++ b/.github/actions/setup-node-env/action.yml
@@ -88,6 +88,8 @@ runs:
         # exact warm hits trust the snapshotted stock layout without rescanning.
         key: ${{ github.repository }}-node-deps-bind-v2-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || 'protected' }}-${{ inputs.node-version }}-frozen-${{ inputs.frozen-lockfile }}-${{ hashFiles('**/package.json', 'pnpm-lock.yaml', 'pnpm-workspace.yaml', '.npmrc', '.pnpmfile.cjs', 'pnpmfile.cjs', '.github/actions/setup-node-env/sticky-importers.sh', 'scripts/postinstall-bundled-plugins.mjs', 'scripts/preinstall-package-manager-warning.mjs', 'scripts/prepare-git-hooks.mjs') }}
         path: /var/tmp/openclaw-node-deps
+        # v1.4.0 skips commit after failed/cancelled steps or ambiguous failure
+        # detection, so an incomplete first hydration cannot seed this key.
         commit: if-missing
 
     # Post actions run last-in-first-out. Register after stickydisk so this bind

--- a/.github/actions/setup-node-env/action.yml
+++ b/.github/actions/setup-node-env/action.yml
@@ -86,7 +86,7 @@ runs:
         # The key covers every dependency and lifecycle input. PR scope keeps
         # feature snapshots separate from protected pushes. The v2 marker lets
         # exact warm hits trust the snapshotted stock layout without rescanning.
-        key: ${{ github.repository }}-node-deps-bind-v2-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || 'protected' }}-${{ inputs.node-version }}-frozen-${{ inputs.frozen-lockfile }}-${{ hashFiles('**/package.json', 'pnpm-lock.yaml', 'pnpm-workspace.yaml', '.github/actions/setup-node-env/sticky-importers.sh', 'scripts/postinstall-bundled-plugins.mjs', 'scripts/preinstall-package-manager-warning.mjs', 'scripts/prepare-git-hooks.mjs') }}
+        key: ${{ github.repository }}-node-deps-bind-v2-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || 'protected' }}-${{ inputs.node-version }}-frozen-${{ inputs.frozen-lockfile }}-${{ hashFiles('**/package.json', 'pnpm-lock.yaml', 'pnpm-workspace.yaml', '.npmrc', '.pnpmfile.cjs', 'pnpmfile.cjs', '.github/actions/setup-node-env/sticky-importers.sh', 'scripts/postinstall-bundled-plugins.mjs', 'scripts/preinstall-package-manager-warning.mjs', 'scripts/prepare-git-hooks.mjs') }}
         path: /var/tmp/openclaw-node-deps
         commit: if-missing
 

--- a/.github/actions/setup-node-env/action.yml
+++ b/.github/actions/setup-node-env/action.yml
@@ -60,10 +60,10 @@ runs:
       if: inputs.sticky-disk == 'true'
       uses: useblacksmith/stickydisk@5b350170ae4ef55b536b548ef5f5896e76a6b54f # v1.4.0
       with:
-        # Keep this key distinct from the retired pnpm-relocation layout. The
-        # PR scope prevents feature-branch snapshots from reaching main. The
-        # first job per scope/input hash snapshots once; later jobs clone it.
-        key: ${{ github.repository }}-node-deps-bind-v1-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || 'protected' }}-${{ inputs.node-version }}-${{ hashFiles('package.json', 'pnpm-lock.yaml', 'pnpm-workspace.yaml') }}
+        # The key covers every dependency and lifecycle input. PR scope keeps
+        # feature snapshots separate from protected pushes. The v2 marker lets
+        # exact warm hits trust the snapshotted stock layout without rescanning.
+        key: ${{ github.repository }}-node-deps-bind-v2-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || 'protected' }}-${{ inputs.node-version }}-frozen-${{ inputs.frozen-lockfile }}-${{ hashFiles('**/package.json', 'pnpm-lock.yaml', 'pnpm-workspace.yaml', '.github/actions/setup-node-env/sticky-importers.sh', 'scripts/postinstall-bundled-plugins.mjs', 'scripts/preinstall-package-manager-warning.mjs', 'scripts/prepare-git-hooks.mjs') }}
         path: /var/tmp/openclaw-node-deps
         commit: if-missing
 
@@ -135,6 +135,8 @@ runs:
       env:
         CI: "true"
         FROZEN_LOCKFILE: ${{ inputs.frozen-lockfile }}
+        STICKY_DISK: ${{ inputs.sticky-disk }}
+        STICKY_ROOT: /var/tmp/openclaw-node-deps
       run: |
         set -euo pipefail
         export PATH="$NODE_BIN:$PATH"
@@ -179,11 +181,20 @@ runs:
           ln -sfn . "$PNPM_CONFIG_MODULES_DIR/node_modules"
           export NODE_PATH="$PNPM_CONFIG_MODULES_DIR${NODE_PATH:+:$NODE_PATH}"
         fi
-        pnpm "${install_args[@]}" || pnpm "${install_args[@]}"
-        if [ -n "${PNPM_CONFIG_MODULES_DIR:-}" ]; then
-          rm -rf node_modules
-          ln -sfn "$PNPM_CONFIG_MODULES_DIR" node_modules
-          ln -sfn . "$PNPM_CONFIG_MODULES_DIR/node_modules"
+        sticky_ready_marker="$STICKY_ROOT/.install-complete-v2"
+        if [ "$STICKY_DISK" = "true" ] && [ -f "$sticky_ready_marker" ]; then
+          bash "$GITHUB_ACTION_PATH/sticky-importers.sh" restore "$STICKY_ROOT" "$GITHUB_WORKSPACE"
+          echo "Sticky dependency snapshot is ready; skipping pnpm install"
+        else
+          pnpm "${install_args[@]}" || pnpm "${install_args[@]}"
+          if [ -n "${PNPM_CONFIG_MODULES_DIR:-}" ]; then
+            rm -rf node_modules
+            ln -sfn "$PNPM_CONFIG_MODULES_DIR" node_modules
+            ln -sfn . "$PNPM_CONFIG_MODULES_DIR/node_modules"
+          fi
+          if [ "$STICKY_DISK" = "true" ]; then
+            bash "$GITHUB_ACTION_PATH/sticky-importers.sh" capture "$STICKY_ROOT" "$GITHUB_WORKSPACE"
+          fi
         fi
 
     - name: Save pnpm store cache

--- a/.github/actions/setup-node-env/action.yml
+++ b/.github/actions/setup-node-env/action.yml
@@ -27,6 +27,14 @@ inputs:
     description: Whether to save the pnpm store with actions/cache after install when no exact cache restored.
     required: false
     default: "false"
+  sticky-disk:
+    description: >
+      Mount a Blacksmith sticky disk for the pnpm store and bind its
+      node_modules directory over the checkout's stock node_modules path.
+      Only valid on Blacksmith Linux runners; pass use-actions-cache: "false"
+      alongside.
+    required: false
+    default: "false"
 runs:
   using: composite
   steps:
@@ -47,6 +55,46 @@ runs:
         set -euo pipefail
         source "$GITHUB_ACTION_PATH/../setup-pnpm-store-cache/ensure-node.sh"
         openclaw_ensure_node "$REQUESTED_NODE_VERSION"
+
+    - name: Mount dependency sticky disk
+      if: inputs.sticky-disk == 'true'
+      uses: useblacksmith/stickydisk@5b350170ae4ef55b536b548ef5f5896e76a6b54f # v1.4.0
+      with:
+        # Keep this key distinct from the retired pnpm-relocation layout. The
+        # PR scope prevents feature-branch snapshots from reaching main. The
+        # first job per scope/input hash snapshots once; later jobs clone it.
+        key: ${{ github.repository }}-node-deps-bind-v1-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || 'protected' }}-${{ inputs.node-version }}-${{ hashFiles('package.json', 'pnpm-lock.yaml', 'pnpm-workspace.yaml') }}
+        path: /var/tmp/openclaw-node-deps
+        commit: if-missing
+
+    # Post actions run last-in-first-out. Register after stickydisk so this bind
+    # is gone before stickydisk flushes, unmounts, and snapshots its filesystem.
+    - name: Register sticky bind cleanup
+      if: inputs.sticky-disk == 'true'
+      uses: ./.github/actions/register-bind-mount-cleanup
+      with:
+        path: ${{ github.workspace }}/node_modules
+
+    - name: Bind sticky node_modules into workspace
+      if: inputs.sticky-disk == 'true'
+      shell: bash
+      run: |
+        set -euo pipefail
+        sticky_root=/var/tmp/openclaw-node-deps
+        sticky_modules="$sticky_root/node_modules"
+        sticky_store="$sticky_root/store"
+        workspace_modules="$GITHUB_WORKSPACE/node_modules"
+
+        mkdir -p "$sticky_modules" "$sticky_store" "$workspace_modules"
+        sudo mount --bind "$sticky_modules" "$workspace_modules"
+        mountpoint -q "$workspace_modules"
+        if [ "$(stat -c %d "$sticky_store")" != "$(stat -c %d "$workspace_modules")" ]; then
+          echo "::error::pnpm store and workspace node_modules must share a filesystem"
+          exit 1
+        fi
+        findmnt --target "$workspace_modules"
+        # zizmor: ignore[github-env] static trusted path defined in this composite action.
+        echo "PNPM_CONFIG_STORE_DIR=$sticky_store" >> "$GITHUB_ENV"
 
     - name: Setup pnpm
       id: setup-pnpm
@@ -124,6 +172,7 @@ runs:
         append_pnpm_option_arg PNPM_CONFIG_CHILD_CONCURRENCY child-concurrency
         append_pnpm_option_arg PNPM_CONFIG_MODULES_DIR modules-dir
         append_pnpm_option_arg PNPM_CONFIG_NETWORK_CONCURRENCY network-concurrency
+        append_pnpm_option_arg PNPM_CONFIG_STORE_DIR store-dir
         append_pnpm_option_arg PNPM_CONFIG_VIRTUAL_STORE_DIR virtual-store-dir
         if [ -n "${PNPM_CONFIG_MODULES_DIR:-}" ]; then
           mkdir -p "$PNPM_CONFIG_MODULES_DIR"

--- a/.github/actions/setup-node-env/action.yml
+++ b/.github/actions/setup-node-env/action.yml
@@ -118,6 +118,9 @@ runs:
         findmnt --target "$workspace_modules"
         # zizmor: ignore[github-env] static trusted path defined in this composite action.
         echo "PNPM_CONFIG_STORE_DIR=$sticky_store" >> "$GITHUB_ENV"
+        # pnpm exec may reconcile a restored workspace before nested builds.
+        # Sticky jobs already have every build tool, so invoke their Node entrypoints directly.
+        echo "OPENCLAW_BUILD_ALL_NO_PNPM=1" >> "$GITHUB_ENV"
 
     - name: Setup Bun
       if: inputs.install-bun == 'true'

--- a/.github/actions/setup-node-env/sticky-importers.sh
+++ b/.github/actions/setup-node-env/sticky-importers.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+mode="${1:?mode is required}"
+sticky_root="${2:?sticky root is required}"
+workspace="${3:?workspace is required}"
+archive="$sticky_root/importer-node-modules.tar"
+marker="$sticky_root/.install-complete-v2"
+
+case "$mode" in
+  capture)
+    mkdir -p "$sticky_root"
+    list_file="$(mktemp)"
+    temp_archive="$archive.tmp.$$"
+    cleanup() {
+      rm -f "$list_file" "$temp_archive"
+    }
+    trap cleanup EXIT
+    (
+      cd "$workspace"
+      find . -type d -name node_modules -prune ! -path ./node_modules -print0 >"$list_file"
+      tar --create --file "$temp_archive" --null --files-from "$list_file"
+    )
+    mv "$temp_archive" "$archive"
+    touch "$marker"
+    ;;
+  restore)
+    if [[ ! -f "$archive" ]]; then
+      echo "::error::sticky importer node_modules archive is missing: $archive" >&2
+      exit 1
+    fi
+    tar --extract --file "$archive" --directory "$workspace"
+    ;;
+  *)
+    echo "unsupported sticky importer mode: $mode" >&2
+    exit 2
+    ;;
+esac

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
       contents: read
     needs: [runner-admission]
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
-    runs-on: ${{ github.event_name == 'workflow_dispatch' && 'ubuntu-24.04' || (github.repository == 'openclaw/openclaw' && 'blacksmith-4vcpu-ubuntu-2404' || 'ubuntu-24.04') }}
+    runs-on: ${{ github.event_name == 'workflow_dispatch' && 'ubuntu-24.04' || (github.repository == 'openclaw/openclaw' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'openclaw/openclaw') && 'blacksmith-4vcpu-ubuntu-2404' || 'ubuntu-24.04') }}
     timeout-minutes: 20
     outputs:
       checkout_revision: ${{ steps.checkout_ref.outputs.sha }}
@@ -858,7 +858,7 @@ jobs:
       contents: read
     needs: [preflight]
     if: needs.preflight.outputs.run_node == 'true' || needs.preflight.outputs.run_check_docs == 'true'
-    runs-on: ${{ github.event_name == 'workflow_dispatch' && 'ubuntu-24.04' || (github.repository == 'openclaw/openclaw' && 'blacksmith-4vcpu-ubuntu-2404' || 'ubuntu-24.04') }}
+    runs-on: ${{ github.event_name == 'workflow_dispatch' && 'ubuntu-24.04' || (github.repository == 'openclaw/openclaw' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'openclaw/openclaw') && 'blacksmith-4vcpu-ubuntu-2404' || 'ubuntu-24.04') }}
     timeout-minutes: 20
     steps:
       - &linux_node_checkout_step
@@ -920,7 +920,7 @@ jobs:
       contents: read
     needs: [preflight]
     if: needs.preflight.outputs.run_build_artifacts == 'true'
-    runs-on: ${{ github.event_name == 'workflow_dispatch' && 'ubuntu-24.04' || (github.repository == 'openclaw/openclaw' && 'blacksmith-16vcpu-ubuntu-2404' || 'ubuntu-24.04') }}
+    runs-on: ${{ github.event_name == 'workflow_dispatch' && 'ubuntu-24.04' || (github.repository == 'openclaw/openclaw' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'openclaw/openclaw') && 'blacksmith-16vcpu-ubuntu-2404' || 'ubuntu-24.04') }}
     timeout-minutes: 20
     outputs:
       channels-result: ${{ steps.built_artifact_checks.outputs['channels-result'] }}
@@ -1135,7 +1135,7 @@ jobs:
       contents: read
     needs: [preflight]
     if: ${{ !cancelled() && always() && needs.preflight.outputs.run_native_i18n == 'true' }}
-    runs-on: ${{ github.event_name == 'workflow_dispatch' && 'ubuntu-24.04' || (github.repository == 'openclaw/openclaw' && 'blacksmith-4vcpu-ubuntu-2404' || 'ubuntu-24.04') }}
+    runs-on: ${{ github.event_name == 'workflow_dispatch' && 'ubuntu-24.04' || (github.repository == 'openclaw/openclaw' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'openclaw/openclaw') && 'blacksmith-4vcpu-ubuntu-2404' || 'ubuntu-24.04') }}
     timeout-minutes: 10
     steps:
       - name: Checkout
@@ -1164,7 +1164,7 @@ jobs:
     name: checks-ui
     needs: [preflight]
     if: needs.preflight.outputs.run_ui_tests == 'true'
-    runs-on: ${{ github.event_name == 'workflow_dispatch' && 'ubuntu-24.04' || (github.repository == 'openclaw/openclaw' && 'blacksmith-4vcpu-ubuntu-2404' || 'ubuntu-24.04') }}
+    runs-on: ${{ github.event_name == 'workflow_dispatch' && 'ubuntu-24.04' || (github.repository == 'openclaw/openclaw' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'openclaw/openclaw') && 'blacksmith-4vcpu-ubuntu-2404' || 'ubuntu-24.04') }}
     timeout-minutes: 20
     env:
       COMPATIBILITY_TARGET: ${{ needs.preflight.outputs.compatibility_target }}
@@ -1210,7 +1210,7 @@ jobs:
     # Locale refresh runs separately on main and nightly. Keep drift visible on
     # automatic runs without blocking unrelated work; release CI stays strict.
     continue-on-error: ${{ github.event_name != 'workflow_dispatch' }}
-    runs-on: ${{ github.event_name == 'workflow_dispatch' && 'ubuntu-24.04' || (github.repository == 'openclaw/openclaw' && 'blacksmith-4vcpu-ubuntu-2404' || 'ubuntu-24.04') }}
+    runs-on: ${{ github.event_name == 'workflow_dispatch' && 'ubuntu-24.04' || (github.repository == 'openclaw/openclaw' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'openclaw/openclaw') && 'blacksmith-4vcpu-ubuntu-2404' || 'ubuntu-24.04') }}
     timeout-minutes: 10
     steps:
       - *linux_node_checkout_step
@@ -1230,7 +1230,7 @@ jobs:
     name: ${{ matrix.check_name }}
     needs: [preflight]
     if: needs.preflight.outputs.run_checks_fast_core == 'true'
-    runs-on: ${{ github.event_name == 'workflow_dispatch' && 'ubuntu-24.04' || (github.repository == 'openclaw/openclaw' && (matrix.runner || 'blacksmith-4vcpu-ubuntu-2404') || 'ubuntu-24.04') }}
+    runs-on: ${{ github.event_name == 'workflow_dispatch' && 'ubuntu-24.04' || (github.repository == 'openclaw/openclaw' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'openclaw/openclaw') && (matrix.runner || 'blacksmith-4vcpu-ubuntu-2404') || 'ubuntu-24.04') }}
     timeout-minutes: 60
     strategy:
       fail-fast: false
@@ -1395,7 +1395,7 @@ jobs:
     name: QA Smoke CI (${{ matrix.name }})
     needs: [preflight]
     if: needs.preflight.outputs.run_qa_smoke_ci == 'true'
-    runs-on: ${{ github.event_name == 'workflow_dispatch' && 'ubuntu-24.04' || (github.repository == 'openclaw/openclaw' && 'blacksmith-16vcpu-ubuntu-2404' || 'ubuntu-24.04') }}
+    runs-on: ${{ github.event_name == 'workflow_dispatch' && 'ubuntu-24.04' || (github.repository == 'openclaw/openclaw' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'openclaw/openclaw') && 'blacksmith-16vcpu-ubuntu-2404' || 'ubuntu-24.04') }}
     timeout-minutes: 60
     strategy:
       fail-fast: false
@@ -1555,7 +1555,7 @@ jobs:
     name: ${{ matrix.checkName }}
     needs: [preflight]
     if: needs.preflight.outputs.run_plugin_contracts_shards == 'true'
-    runs-on: ${{ github.event_name == 'workflow_dispatch' && 'ubuntu-24.04' || (github.repository == 'openclaw/openclaw' && 'blacksmith-4vcpu-ubuntu-2404' || 'ubuntu-24.04') }}
+    runs-on: ${{ github.event_name == 'workflow_dispatch' && 'ubuntu-24.04' || (github.repository == 'openclaw/openclaw' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'openclaw/openclaw') && 'blacksmith-4vcpu-ubuntu-2404' || 'ubuntu-24.04') }}
     timeout-minutes: 60
     strategy:
       fail-fast: false
@@ -1593,7 +1593,7 @@ jobs:
     name: ${{ matrix.checkName }}
     needs: [preflight]
     if: needs.preflight.outputs.run_channel_contracts_shards == 'true'
-    runs-on: ${{ github.event_name == 'workflow_dispatch' && 'ubuntu-24.04' || (github.repository == 'openclaw/openclaw' && 'blacksmith-4vcpu-ubuntu-2404' || 'ubuntu-24.04') }}
+    runs-on: ${{ github.event_name == 'workflow_dispatch' && 'ubuntu-24.04' || (github.repository == 'openclaw/openclaw' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'openclaw/openclaw') && 'blacksmith-4vcpu-ubuntu-2404' || 'ubuntu-24.04') }}
     timeout-minutes: 60
     strategy:
       fail-fast: false
@@ -1631,7 +1631,7 @@ jobs:
     name: checks-node-compat-node22
     needs: [preflight]
     if: needs.preflight.outputs.run_build_artifacts == 'true' && github.event_name == 'workflow_dispatch'
-    runs-on: ${{ github.event_name == 'workflow_dispatch' && 'ubuntu-24.04' || (github.repository == 'openclaw/openclaw' && 'blacksmith-4vcpu-ubuntu-2404' || 'ubuntu-24.04') }}
+    runs-on: ${{ github.event_name == 'workflow_dispatch' && 'ubuntu-24.04' || (github.repository == 'openclaw/openclaw' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'openclaw/openclaw') && 'blacksmith-4vcpu-ubuntu-2404' || 'ubuntu-24.04') }}
     timeout-minutes: 60
     steps:
       - *linux_node_checkout_step
@@ -1660,7 +1660,7 @@ jobs:
     name: ${{ matrix.check_name }}
     needs: [preflight]
     if: needs.preflight.outputs.run_checks_node_core_nondist == 'true'
-    runs-on: ${{ github.event_name == 'workflow_dispatch' && 'ubuntu-24.04' || (github.repository == 'openclaw/openclaw' && (matrix.runner || 'blacksmith-4vcpu-ubuntu-2404') || 'ubuntu-24.04') }}
+    runs-on: ${{ github.event_name == 'workflow_dispatch' && 'ubuntu-24.04' || (github.repository == 'openclaw/openclaw' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'openclaw/openclaw') && (matrix.runner || 'blacksmith-4vcpu-ubuntu-2404') || 'ubuntu-24.04') }}
     timeout-minutes: ${{ matrix.timeout_minutes || 60 }}
     strategy:
       fail-fast: false
@@ -1675,6 +1675,11 @@ jobs:
         with:
           node-version: "${{ matrix.node_version || '24.x' }}"
           install-bun: "false"
+          # Blacksmith same-repo runs clone dependencies from a sticky disk.
+          # Fork PRs must keep actions/cache: sticky snapshots are writable,
+          # repository-global state and must never be produced by fork code.
+          sticky-disk: ${{ github.event_name != 'workflow_dispatch' && github.repository == 'openclaw/openclaw' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'openclaw/openclaw') && 'true' || 'false' }}
+          use-actions-cache: ${{ github.event_name != 'workflow_dispatch' && github.repository == 'openclaw/openclaw' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'openclaw/openclaw') && 'false' || 'true' }}
 
       - name: Setup Go for docs i18n
         if: matrix.requires_go == true
@@ -1746,7 +1751,7 @@ jobs:
     name: ${{ matrix.check_name }}
     needs: [preflight]
     if: ${{ !cancelled() && always() && needs.preflight.outputs.run_check == 'true' }}
-    runs-on: ${{ github.event_name == 'workflow_dispatch' && 'ubuntu-24.04' || (github.repository == 'openclaw/openclaw' && (matrix.runner || 'blacksmith-4vcpu-ubuntu-2404') || 'ubuntu-24.04') }}
+    runs-on: ${{ github.event_name == 'workflow_dispatch' && 'ubuntu-24.04' || (github.repository == 'openclaw/openclaw' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'openclaw/openclaw') && (matrix.runner || 'blacksmith-4vcpu-ubuntu-2404') || 'ubuntu-24.04') }}
     timeout-minutes: 20
     strategy:
       fail-fast: false
@@ -1875,7 +1880,7 @@ jobs:
     name: ${{ matrix.check_name }}
     needs: [preflight]
     if: ${{ !cancelled() && always() && needs.preflight.outputs.run_check_additional == 'true' }}
-    runs-on: ${{ github.event_name == 'workflow_dispatch' && 'ubuntu-24.04' || (github.repository == 'openclaw/openclaw' && (matrix.runner || 'blacksmith-4vcpu-ubuntu-2404') || 'ubuntu-24.04') }}
+    runs-on: ${{ github.event_name == 'workflow_dispatch' && 'ubuntu-24.04' || (github.repository == 'openclaw/openclaw' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'openclaw/openclaw') && (matrix.runner || 'blacksmith-4vcpu-ubuntu-2404') || 'ubuntu-24.04') }}
     timeout-minutes: 20
     strategy:
       fail-fast: false
@@ -2073,7 +2078,7 @@ jobs:
       contents: read
     needs: [preflight]
     if: needs.preflight.outputs.run_check_docs == 'true'
-    runs-on: ${{ github.event_name == 'workflow_dispatch' && 'ubuntu-24.04' || (github.repository == 'openclaw/openclaw' && 'blacksmith-4vcpu-ubuntu-2404' || 'ubuntu-24.04') }}
+    runs-on: ${{ github.event_name == 'workflow_dispatch' && 'ubuntu-24.04' || (github.repository == 'openclaw/openclaw' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'openclaw/openclaw') && 'blacksmith-4vcpu-ubuntu-2404' || 'ubuntu-24.04') }}
     timeout-minutes: 20
     steps:
       - *linux_node_checkout_step
@@ -2138,7 +2143,7 @@ jobs:
       contents: read
     needs: [preflight]
     if: needs.preflight.outputs.run_skills_python_job == 'true'
-    runs-on: ${{ github.event_name == 'workflow_dispatch' && 'ubuntu-24.04' || (github.repository == 'openclaw/openclaw' && 'blacksmith-4vcpu-ubuntu-2404' || 'ubuntu-24.04') }}
+    runs-on: ${{ github.event_name == 'workflow_dispatch' && 'ubuntu-24.04' || (github.repository == 'openclaw/openclaw' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'openclaw/openclaw') && 'blacksmith-4vcpu-ubuntu-2404' || 'ubuntu-24.04') }}
     timeout-minutes: 20
     steps:
       - name: Checkout
@@ -2193,7 +2198,7 @@ jobs:
     name: ${{ matrix.check_name }}
     needs: [preflight]
     if: needs.preflight.outputs.run_checks_windows == 'true'
-    runs-on: ${{ github.event_name == 'workflow_dispatch' && 'windows-2025' || (github.repository == 'openclaw/openclaw' && (matrix.runner || 'blacksmith-8vcpu-windows-2025') || 'windows-2025') }}
+    runs-on: ${{ github.event_name == 'workflow_dispatch' && 'windows-2025' || (github.repository == 'openclaw/openclaw' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'openclaw/openclaw') && (matrix.runner || 'blacksmith-8vcpu-windows-2025') || 'windows-2025') }}
     timeout-minutes: 60
     env:
       NODE_OPTIONS: --max-old-space-size=8192
@@ -2339,7 +2344,7 @@ jobs:
     name: ${{ matrix.check_name }}
     needs: [preflight]
     if: ${{ !cancelled() && always() && needs.preflight.outputs.run_macos_node == 'true' }}
-    runs-on: ${{ github.event_name == 'workflow_dispatch' && 'macos-15' || (github.repository == 'openclaw/openclaw' && 'blacksmith-6vcpu-macos-15' || 'macos-15') }}
+    runs-on: ${{ github.event_name == 'workflow_dispatch' && 'macos-15' || (github.repository == 'openclaw/openclaw' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'openclaw/openclaw') && 'blacksmith-6vcpu-macos-15' || 'macos-15') }}
     timeout-minutes: 20
     strategy:
       fail-fast: false
@@ -2378,7 +2383,7 @@ jobs:
     name: "macos-swift"
     needs: [preflight]
     if: needs.preflight.outputs.run_macos_swift == 'true'
-    runs-on: ${{ github.event_name == 'workflow_dispatch' && 'macos-26' || (github.repository == 'openclaw/openclaw' && 'blacksmith-12vcpu-macos-26' || 'macos-26') }}
+    runs-on: ${{ github.event_name == 'workflow_dispatch' && 'macos-26' || (github.repository == 'openclaw/openclaw' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'openclaw/openclaw') && 'blacksmith-12vcpu-macos-26' || 'macos-26') }}
     timeout-minutes: 20
     env:
       HISTORICAL_TARGET: ${{ needs.preflight.outputs.compatibility_target }}
@@ -2561,7 +2566,7 @@ jobs:
     name: "ios-build"
     needs: [preflight]
     if: needs.preflight.outputs.run_ios_build == 'true'
-    runs-on: ${{ github.event_name == 'workflow_dispatch' && 'macos-26' || (github.repository == 'openclaw/openclaw' && 'blacksmith-12vcpu-macos-26' || 'macos-26') }}
+    runs-on: ${{ github.event_name == 'workflow_dispatch' && 'macos-26' || (github.repository == 'openclaw/openclaw' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'openclaw/openclaw') && 'blacksmith-12vcpu-macos-26' || 'macos-26') }}
     timeout-minutes: 45
     env:
       HISTORICAL_TARGET: ${{ needs.preflight.outputs.compatibility_target }}
@@ -2663,7 +2668,7 @@ jobs:
     name: ${{ matrix.check_name }}
     needs: [preflight]
     if: needs.preflight.outputs.run_android_job == 'true'
-    runs-on: ${{ github.event_name == 'workflow_dispatch' && 'ubuntu-24.04' || (github.repository == 'openclaw/openclaw' && 'blacksmith-8vcpu-ubuntu-2404' || 'ubuntu-24.04') }}
+    runs-on: ${{ github.event_name == 'workflow_dispatch' && 'ubuntu-24.04' || (github.repository == 'openclaw/openclaw' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'openclaw/openclaw') && 'blacksmith-8vcpu-ubuntu-2404' || 'ubuntu-24.04') }}
     timeout-minutes: 20
     strategy:
       fail-fast: false

--- a/scripts/check-duplicates.mjs
+++ b/scripts/check-duplicates.mjs
@@ -8,6 +8,7 @@ const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), ".."
 const jscpdBin = path.join(repoRoot, "node_modules", "jscpd", "bin", "jscpd");
 
 const targets = [
+  ".github/actions",
   "src",
   "extensions",
   "examples",

--- a/scripts/ci-run-node-test-shard.d.mts
+++ b/scripts/ci-run-node-test-shard.d.mts
@@ -26,6 +26,11 @@ export function buildChildEnv(
   index: number,
 ): Record<string, string | undefined>;
 
+export function resolveShardChildCommand(
+  args: string[],
+  nodeExecPath?: string,
+): { command: string; args: string[] };
+
 export function runShardPlans(
   plans: ShardPlan[],
   options?: {

--- a/scripts/ci-run-node-test-shard.mjs
+++ b/scripts/ci-run-node-test-shard.mjs
@@ -117,9 +117,19 @@ function relayChildStream(stream, label) {
   };
 }
 
+export function resolveShardChildCommand(args, nodeExecPath = process.execPath) {
+  return {
+    command: nodeExecPath,
+    args: ["scripts/test-projects.mjs", ...args],
+  };
+}
+
 function runChild(args, childEnv, label) {
   return new Promise((resolve) => {
-    const child = spawn("pnpm", ["exec", "node", "scripts/test-projects.mjs", ...args], {
+    // Use Node directly. `pnpm exec node` may reconcile the workspace before
+    // tests, which destroys the sticky dependency fast path.
+    const childCommand = resolveShardChildCommand(args);
+    const child = spawn(childCommand.command, childCommand.args, {
       env: childEnv,
       stdio: ["ignore", "pipe", "pipe"],
     });

--- a/scripts/test-projects.test-support.mjs
+++ b/scripts/test-projects.test-support.mjs
@@ -689,6 +689,10 @@ const TOOLING_SOURCE_TEST_TARGETS = new Map([
     ["test/scripts/package-acceptance-workflow.test.ts", "test/scripts/ci-workflow-guards.test.ts"],
   ],
   [
+    ".github/actions/setup-node-env/sticky-importers.sh",
+    ["test/scripts/ci-workflow-guards.test.ts"],
+  ],
+  [
     ".github/actions/setup-pnpm-store-cache/action.yml",
     ["test/scripts/package-acceptance-workflow.test.ts", "test/scripts/ci-workflow-guards.test.ts"],
   ],

--- a/test/scripts/ci-run-node-test-shard.test.ts
+++ b/test/scripts/ci-run-node-test-shard.test.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   buildChildEnv,
+  resolveShardChildCommand,
   resolveShardPlans,
   runShardPlans,
 } from "../../scripts/ci-run-node-test-shard.mjs";
@@ -25,6 +26,13 @@ afterEach(() => {
 });
 
 describe("scripts/ci-run-node-test-shard.mjs", () => {
+  it("launches the child runner directly with Node", () => {
+    expect(resolveShardChildCommand(["one.config.ts"], "/runtime/node")).toEqual({
+      command: "/runtime/node",
+      args: ["scripts/test-projects.mjs", "one.config.ts"],
+    });
+  });
+
   it("prefers explicit targets and keeps one target per child", () => {
     const plans = resolveShardPlans({
       OPENCLAW_NODE_TEST_TARGETS_JSON: JSON.stringify(["a.test.ts", "b.test.ts"]),

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -1585,6 +1585,7 @@ describe("ci workflow guards", () => {
     );
     expect(bindStep.run).toContain('sudo mount --bind "$sticky_modules" "$workspace_modules"');
     expect(bindStep.run).toContain('echo "PNPM_CONFIG_STORE_DIR=$sticky_store"');
+    expect(bindStep.run).toContain('echo "OPENCLAW_BUILD_ALL_NO_PNPM=1"');
     expect(bindStep.run).not.toContain("PNPM_CONFIG_MODULES_DIR");
     expect(bindStep.run).not.toContain("PNPM_CONFIG_VIRTUAL_STORE_DIR");
     expect(installStep.env).toMatchObject({

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -1570,6 +1570,8 @@ describe("ci workflow guards", () => {
     expect(mountStep.with.key).toContain("format('pr-{0}', github.event.pull_request.number)");
     expect(mountStep.with.key).toContain("inputs.frozen-lockfile");
     expect(mountStep.with.key).toContain("hashFiles('**/package.json', 'pnpm-lock.yaml'");
+    expect(mountStep.with.key).toContain("'.npmrc'");
+    expect(mountStep.with.key).toContain("'.pnpmfile.cjs'");
     expect(mountStep.with.key).toContain(".github/actions/setup-node-env/sticky-importers.sh");
     expect(mountStep.with.key).toContain("scripts/postinstall-bundled-plugins.mjs");
     expect(cleanupStep).toMatchObject({

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -1494,6 +1494,93 @@ describe("ci workflow guards", () => {
     expect(workflow.jobs["pnpm-store-warmup"]["runs-on"]).toContain("blacksmith-4vcpu-ubuntu-2404");
   });
 
+  it("keeps sticky dependency snapshots on trusted Blacksmith Node shards", () => {
+    const workflow = readCiWorkflow();
+    const blacksmithJobs = Object.entries(workflow.jobs).filter(([, job]) => {
+      const runsOn = (job as { "runs-on"?: unknown })["runs-on"];
+      return typeof runsOn === "string" && runsOn.includes("blacksmith-");
+    });
+    const setupNodeStep = workflow.jobs["checks-node-core-test-nondist-shard"].steps.find(
+      (step: WorkflowStep) => step.name === "Setup Node environment",
+    );
+    const stickyCondition = setupNodeStep.with["sticky-disk"];
+    const cacheCondition = setupNodeStep.with["use-actions-cache"];
+    const action = parse(readFileSync(".github/actions/setup-node-env/action.yml", "utf8"));
+    const mountStep = action.runs.steps.find(
+      (step: WorkflowStep) => step.name === "Mount dependency sticky disk",
+    );
+    const cleanupStep = action.runs.steps.find(
+      (step: WorkflowStep) => step.name === "Register sticky bind cleanup",
+    );
+    const bindStep = action.runs.steps.find(
+      (step: WorkflowStep) => step.name === "Bind sticky node_modules into workspace",
+    );
+
+    expect(blacksmithJobs.length).toBeGreaterThan(0);
+    for (const [jobName, job] of blacksmithJobs) {
+      expect(
+        (job as { "runs-on": string })["runs-on"],
+        `${jobName} must route fork pull requests to GitHub-hosted runners`,
+      ).toContain(
+        "github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'openclaw/openclaw'",
+      );
+    }
+    expect(stickyCondition).toContain("github.event_name != 'workflow_dispatch'");
+    expect(stickyCondition).toContain(
+      "github.event.pull_request.head.repo.full_name == 'openclaw/openclaw'",
+    );
+    expect(cacheCondition).toContain("github.event_name != 'workflow_dispatch'");
+    expect(cacheCondition).toContain(
+      "github.event.pull_request.head.repo.full_name == 'openclaw/openclaw'",
+    );
+    expect(cacheCondition).toContain("&& 'false' || 'true'");
+    expect(action.inputs["sticky-disk"].default).toBe("false");
+    expect(mountStep).toMatchObject({
+      if: "inputs.sticky-disk == 'true'",
+      uses: "useblacksmith/stickydisk@5b350170ae4ef55b536b548ef5f5896e76a6b54f",
+      with: {
+        path: "/var/tmp/openclaw-node-deps",
+        commit: "if-missing",
+      },
+    });
+    expect(mountStep.with.key).toContain("node-deps-bind-v1-");
+    expect(mountStep.with.key).toContain("format('pr-{0}', github.event.pull_request.number)");
+    expect(mountStep.with.key).toContain("hashFiles('package.json', 'pnpm-lock.yaml'");
+    expect(cleanupStep).toMatchObject({
+      if: "inputs.sticky-disk == 'true'",
+      uses: "./.github/actions/register-bind-mount-cleanup",
+      with: { path: "${{ github.workspace }}/node_modules" },
+    });
+    expect(action.runs.steps.indexOf(mountStep)).toBeLessThan(
+      action.runs.steps.indexOf(cleanupStep),
+    );
+    expect(action.runs.steps.indexOf(cleanupStep)).toBeLessThan(
+      action.runs.steps.indexOf(bindStep),
+    );
+    expect(bindStep.run).toContain('sudo mount --bind "$sticky_modules" "$workspace_modules"');
+    expect(bindStep.run).toContain('echo "PNPM_CONFIG_STORE_DIR=$sticky_store"');
+    expect(bindStep.run).not.toContain("PNPM_CONFIG_MODULES_DIR");
+    expect(bindStep.run).not.toContain("PNPM_CONFIG_VIRTUAL_STORE_DIR");
+    const cleanupAction = parse(
+      readFileSync(".github/actions/register-bind-mount-cleanup/action.yml", "utf8"),
+    );
+    expect(cleanupAction.runs).toMatchObject({
+      using: "node24",
+      main: "main.cjs",
+      post: "post.cjs",
+      "post-if": "always()",
+    });
+    const cleanupPost = readFileSync(
+      ".github/actions/register-bind-mount-cleanup/post.cjs",
+      "utf8",
+    );
+    expect(cleanupPost).toContain("mountpoint.status === 32");
+    expect(cleanupPost).toContain('spawnSync("sudo", ["umount", mountPath]');
+    expect(readFileSync(".github/actions/setup-pnpm-store-cache/action.yml", "utf8")).toContain(
+      "actions/cache/restore@",
+    );
+  });
+
   it("uses bundled Node shards and telemetry-backed runner sizes", () => {
     const workflow = readCiWorkflow();
     const buildArtifactsTestbox = readBuildArtifactsTestboxWorkflow();

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -1508,6 +1508,12 @@ describe("ci workflow guards", () => {
     const stickyCondition = setupNodeStep.with["sticky-disk"];
     const cacheCondition = setupNodeStep.with["use-actions-cache"];
     const action = parse(readFileSync(".github/actions/setup-node-env/action.yml", "utf8"));
+    const validateLayoutStep = action.runs.steps.find(
+      (step: WorkflowStep) => step.name === "Validate sticky pnpm layout",
+    );
+    const setupPnpmStep = action.runs.steps.find(
+      (step: WorkflowStep) => step.name === "Setup pnpm",
+    );
     const mountStep = action.runs.steps.find(
       (step: WorkflowStep) => step.name === "Mount dependency sticky disk",
     );
@@ -1540,6 +1546,18 @@ describe("ci workflow guards", () => {
     );
     expect(cacheCondition).toContain("&& 'false' || 'true'");
     expect(action.inputs["sticky-disk"].default).toBe("false");
+    expect(validateLayoutStep.if).toBe("inputs.sticky-disk == 'true'");
+    expect(validateLayoutStep.run).toContain("for config_name in modules-dir virtual-store-dir");
+    expect(validateLayoutStep.run).toContain('config_value="$(pnpm config get "$config_name")"');
+    expect(validateLayoutStep.run).toContain(
+      "sticky mode requires pnpm's stock node_modules layout",
+    );
+    expect(action.runs.steps.indexOf(setupPnpmStep)).toBeLessThan(
+      action.runs.steps.indexOf(validateLayoutStep),
+    );
+    expect(action.runs.steps.indexOf(validateLayoutStep)).toBeLessThan(
+      action.runs.steps.indexOf(mountStep),
+    );
     expect(mountStep).toMatchObject({
       if: "inputs.sticky-disk == 'true'",
       uses: "useblacksmith/stickydisk@5b350170ae4ef55b536b548ef5f5896e76a6b54f",

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -7,6 +7,7 @@ import {
   mkdtempSync,
   readdirSync,
   readFileSync,
+  readlinkSync,
   rmSync,
   symlinkSync,
   writeFileSync,
@@ -43,6 +44,7 @@ const MATURITY_GENERATED_PR_PATHS = [
 ];
 
 type WorkflowStep = {
+  env?: Record<string, unknown>;
   name?: string;
   run?: string;
   uses?: string;
@@ -1515,6 +1517,9 @@ describe("ci workflow guards", () => {
     const bindStep = action.runs.steps.find(
       (step: WorkflowStep) => step.name === "Bind sticky node_modules into workspace",
     );
+    const installStep = action.runs.steps.find(
+      (step: WorkflowStep) => step.name === "Install dependencies",
+    );
 
     expect(blacksmithJobs.length).toBeGreaterThan(0);
     for (const [jobName, job] of blacksmithJobs) {
@@ -1543,9 +1548,12 @@ describe("ci workflow guards", () => {
         commit: "if-missing",
       },
     });
-    expect(mountStep.with.key).toContain("node-deps-bind-v1-");
+    expect(mountStep.with.key).toContain("node-deps-bind-v2-");
     expect(mountStep.with.key).toContain("format('pr-{0}', github.event.pull_request.number)");
-    expect(mountStep.with.key).toContain("hashFiles('package.json', 'pnpm-lock.yaml'");
+    expect(mountStep.with.key).toContain("inputs.frozen-lockfile");
+    expect(mountStep.with.key).toContain("hashFiles('**/package.json', 'pnpm-lock.yaml'");
+    expect(mountStep.with.key).toContain(".github/actions/setup-node-env/sticky-importers.sh");
+    expect(mountStep.with.key).toContain("scripts/postinstall-bundled-plugins.mjs");
     expect(cleanupStep).toMatchObject({
       if: "inputs.sticky-disk == 'true'",
       uses: "./.github/actions/register-bind-mount-cleanup",
@@ -1561,6 +1569,20 @@ describe("ci workflow guards", () => {
     expect(bindStep.run).toContain('echo "PNPM_CONFIG_STORE_DIR=$sticky_store"');
     expect(bindStep.run).not.toContain("PNPM_CONFIG_MODULES_DIR");
     expect(bindStep.run).not.toContain("PNPM_CONFIG_VIRTUAL_STORE_DIR");
+    expect(installStep.env).toMatchObject({
+      STICKY_DISK: "${{ inputs.sticky-disk }}",
+      STICKY_ROOT: "/var/tmp/openclaw-node-deps",
+    });
+    expect(installStep.run).toContain('sticky_ready_marker="$STICKY_ROOT/.install-complete-v2"');
+    expect(installStep.run).toContain(
+      'bash "$GITHUB_ACTION_PATH/sticky-importers.sh" restore "$STICKY_ROOT" "$GITHUB_WORKSPACE"',
+    );
+    expect(installStep.run).toContain("Sticky dependency snapshot is ready; skipping pnpm install");
+    expect(installStep.run.indexOf('pnpm "${install_args[@]}"')).toBeLessThan(
+      installStep.run.indexOf(
+        'bash "$GITHUB_ACTION_PATH/sticky-importers.sh" capture "$STICKY_ROOT" "$GITHUB_WORKSPACE"',
+      ),
+    );
     const cleanupAction = parse(
       readFileSync(".github/actions/register-bind-mount-cleanup/action.yml", "utf8"),
     );
@@ -1579,6 +1601,33 @@ describe("ci workflow guards", () => {
     expect(readFileSync(".github/actions/setup-pnpm-store-cache/action.yml", "utf8")).toContain(
       "actions/cache/restore@",
     );
+  });
+
+  it("restores importer-local node_modules from sticky snapshots", () => {
+    const root = mkdtempSync(path.join(tmpdir(), "openclaw-sticky-importers-"));
+    try {
+      const workspace = path.join(root, "workspace");
+      const stickyRoot = path.join(root, "sticky");
+      const rootModules = path.join(workspace, "node_modules");
+      const importerModules = path.join(workspace, "packages", "example", "node_modules");
+      const helper = path.resolve(".github/actions/setup-node-env/sticky-importers.sh");
+      mkdirSync(path.join(rootModules, "shared"), { recursive: true });
+      mkdirSync(importerModules, { recursive: true });
+      writeFileSync(path.join(rootModules, "root-sentinel"), "before", "utf8");
+      symlinkSync("../../../node_modules/shared", path.join(importerModules, "shared"));
+
+      execFileSync("bash", [helper, "capture", stickyRoot, workspace]);
+      rmSync(importerModules, { recursive: true });
+      writeFileSync(path.join(rootModules, "root-sentinel"), "after", "utf8");
+      execFileSync("bash", [helper, "restore", stickyRoot, workspace]);
+
+      expect(readlinkSync(path.join(importerModules, "shared"))).toBe(
+        "../../../node_modules/shared",
+      );
+      expect(readFileSync(path.join(rootModules, "root-sentinel"), "utf8")).toBe("after");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 
   it("uses bundled Node shards and telemetry-backed runner sizes", () => {


### PR DESCRIPTION
Related: #108211

## What Problem This Solves

Resolves a CI performance problem where every Node test shard restores the pnpm store and rebuilds the 170-package workspace dependency layout, costing roughly 20 seconds per shard even when manifests are unchanged.

## Why This Change Was Made

Same-repository Blacksmith runs now mount a manifest-keyed sticky disk at a neutral path, bind its node_modules directory over the checkout node_modules path, and keep the pnpm store on the same filesystem. This preserves pnpm's stock workspace layout and hardlinks. A post action removes the bind before the sticky disk snapshots or unmounts.

Sticky mode also validates pnpm's effective `modules-dir` and `virtual-store-dir` configuration before mounting, rejecting relocation settings from environment or project config instead of producing an incompatible snapshot. The snapshot key hashes repository pnpm configuration and pnpmfile hooks as well as manifests, lockfiles, and lifecycle scripts.

Fork pull requests and workflow dispatches remain on GitHub-hosted runners with actions/cache. Every Blacksmith runner selector now rejects fork pull requests, so untrusted fork code cannot produce or access sticky snapshots. Pull-request keys are also scoped by PR number; protected pushes use a separate scope.

AI-assisted implementation. I reviewed and understand the resulting workflow and cleanup behavior.

## User Impact

No product behavior change. Warm same-repository Node test shards spent 7-10 seconds in Setup Node environment (median 8 seconds, mean 7.9 seconds) on the final exact-head run, avoiding the workspace reinstall and reducing CI latency and Blacksmith work.

The shard launcher now invokes Node directly instead of going through `pnpm exec`. Sticky jobs also route nested tsdown, UI, and build-all work through the repository's existing direct Node entrypoints. Together these prevent pnpm from reconciling the 170-package workspace after setup and silently undoing the warm-path gain inside the test step.

## Evidence

- `actionlint .github/workflows/ci.yml`
- YAML parse for the workflow and both composite actions
- Node syntax checks for the bind cleanup main/post scripts
- Focused workflow and shard-launcher guard suites: 66 passed, 1 skipped
- Targeted oxfmt checks clean
- [Changed-gate Testbox proof](https://github.com/openclaw/openclaw/actions/runs/29451005976): test typechecks, formatting, lint, dependency, patch, and boundary gates green
- Mandatory autoreview caught the missing repository pnpm-config key inputs; the fix hashes `.npmrc` and standard pnpmfile hooks, and the final full-branch review reported no accepted or actionable findings
- [Cold Blacksmith proof](https://github.com/openclaw/openclaw/actions/runs/29438535424): attempt 1 installed and committed a 5.89 GiB snapshot after bind cleanup; exact-head warm attempts restored it and skipped pnpm install
- [Final-head config-aware seed proof](https://github.com/openclaw/openclaw/actions/runs/29455406153/attempts/1): the base-advanced manifest key cold-installed and committed a fresh snapshot after clean bind/root unmount; all 22 Node shards passed
- [Final-head warm proof](https://github.com/openclaw/openclaw/actions/runs/29455406153/attempts/2): the same exact head restored the snapshot, passed the effective-layout guard, and skipped pnpm install across all 22 Node shards
- Cold setup across 22 Node shards: 35-58 seconds, median 42 seconds, mean 42.9 seconds
- Warm setup across the final 22 Node shards: 7-10 seconds, median 8 seconds, mean 7.9 seconds
- The formerly failing small-1 TUI shard passed 29/29 tests; its completed log contains no Corepack, workspace Scope, Lockfile, Packages, or pnpm install-completion markers
- The same small-1 cleanup log confirms the workspace bind and sticky root both unmounted cleanly, and the existing snapshot was not recommitted
- Final exact-head result (`14976f00e4f0e7aa384b6948a3d3c502a4ae41c5`): 55 jobs green and 10 skipped, including all 22 Node test shards and Windows; all PR checks green
