### PR TITLE
fix(agents): treat read-only shell inspection as replay-safe

### DIFF
--- a/extensions/codex/src/app-server/event-projector-items.test.ts
+++ b/extensions/codex/src/app-server/event-projector-items.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { isMutatingNativeToolItem } from "./event-projector-items.js";
+import type { CodexThreadItem } from "./protocol.js";
+
+function commandItem(command: string): CodexThreadItem {
+  return {
+    id: "cmd-1",
+    type: "commandExecution",
+    title: "Command",
+    status: "completed",
+    name: null,
+    tool: null,
+    server: null,
+    command,
+    cwd: "/workspace",
+    query: null,
+    aggregatedOutput: null,
+    text: "",
+    changes: [],
+    exitCode: 0,
+    durationMs: 1,
+    commandActions: [],
+  };
+}
+
+describe("isMutatingNativeToolItem", () => {
+  it("classifies proven read-only shell inspection as non-mutating (#101890)", () => {
+    expect(isMutatingNativeToolItem(commandItem("rg TODO src"))).toBe(false);
+    expect(isMutatingNativeToolItem(commandItem("ls -la"))).toBe(false);
+    expect(isMutatingNativeToolItem(commandItem("cat package.json"))).toBe(false);
+  });
+
+  it("keeps mutating, ambiguous, and unknown commandExecution fail-closed", () => {
+    expect(isMutatingNativeToolItem(commandItem("npm install"))).toBe(true);
+    expect(isMutatingNativeToolItem(commandItem("rm -rf /tmp/x"))).toBe(true);
+    expect(isMutatingNativeToolItem(commandItem(""))).toBe(true);
+    expect(
+      isMutatingNativeToolItem({
+        id: "patch-1",
+        type: "fileChange",
+        title: "File change",
+        status: "completed",
+        name: null,
+        tool: null,
+        server: null,
+        command: null,
+        cwd: null,
+        query: null,
+        aggregatedOutput: null,
+        text: "",
+        changes: [],
+      }),
+    ).toBe(true);
+  });
+
+  it("ignores commandActions presentation hints for mutation classification", () => {
+    const item = {
+      ...commandItem("npm publish"),
+      commandActions: [{ type: "search", query: "npm publish" }],
+    };
+    expect(isMutatingNativeToolItem(item)).toBe(true);
+  });
+});

--- a/extensions/codex/src/app-server/event-projector-items.ts
+++ b/extensions/codex/src/app-server/event-projector-items.ts
@@ -1,3 +1,4 @@
+import { isReplaySafeToolCall } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { readItemString } from "./event-projector-values.js";
 import type { CodexThreadItem } from "./protocol.js";
 
@@ -164,9 +165,11 @@ export function shouldRecordNativeToolTranscript(item: CodexThreadItem): boolean
 
 export function isMutatingNativeToolItem(item: CodexThreadItem): boolean {
   if (item.type === "commandExecution") {
-    // Codex commandActions describe presentation, not safety. Upstream may
-    // classify mutating commands as read/search, so native commands fail closed.
-    return true;
+    // Prefer shared shell replay-safety analysis over commandActions presentation
+    // hints (those can mislabel mutating commands as read/search). Unknown or
+    // non-read-only commands stay fail-closed as mutating/side-effecting.
+    const command = typeof item.command === "string" ? item.command : "";
+    return !isReplaySafeToolCall("bash", { command });
   }
   return (
     item.type === "fileChange" ||

--- a/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
+++ b/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
@@ -2960,6 +2960,31 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     ).toEqual({ hadPotentialSideEffects: true, replaySafe: false });
   });
 
+  it("treats only read-only shell inspection tool metas as replay-safe (#101890)", () => {
+    expect(
+      buildAttemptReplayMetadata({
+        toolMetas: [
+          { toolName: "exec", replaySafe: true },
+          { toolName: "bash", replaySafe: true },
+        ],
+        didSendViaMessagingTool: false,
+        messagingToolSentTexts: [],
+        messagingToolSentMediaUrls: [],
+      }),
+    ).toEqual({ hadPotentialSideEffects: false, replaySafe: true });
+  });
+
+  it("still treats unmarked shell tool metas as replay-unsafe (#101890 fail-closed)", () => {
+    expect(
+      buildAttemptReplayMetadata({
+        toolMetas: [{ toolName: "exec" }],
+        didSendViaMessagingTool: false,
+        messagingToolSentTexts: [],
+        messagingToolSentMediaUrls: [],
+      }),
+    ).toEqual({ hadPotentialSideEffects: true, replaySafe: false });
+  });
+
   it("treats committed messaging media as replay-invalid side effect metadata", () => {
     expect(
       buildAttemptReplayMetadata({

--- a/src/agents/tool-mutation.test.ts
+++ b/src/agents/tool-mutation.test.ts
@@ -49,7 +49,9 @@ describe("tool mutation helpers", () => {
     ["bash", "gh pr view 123 --repo openclaw/openclaw --json title,state"],
   ])("treats read-only shell command as non-mutating: %s %s", (toolName, command) => {
     expect(isMutatingToolCall(toolName, { command })).toBe(false);
+    expect(isReplaySafeToolCall(toolName, { command })).toBe(true);
     expect(buildToolMutationState(toolName, { command }).mutatingAction).toBe(false);
+    expect(buildToolMutationState(toolName, { command }).replaySafe).toBe(true);
     expect(
       buildToolMutationState(toolName, { command }, command).actionFingerprint,
     ).toBeUndefined();
@@ -103,7 +105,9 @@ describe("tool mutation helpers", () => {
     ["exec", "gh api --method POST repos/openclaw/openclaw/issues"],
   ])("keeps ambiguous or mutating shell command mutating: %s %s", (toolName, command) => {
     expect(isMutatingToolCall(toolName, { command })).toBe(true);
+    expect(isReplaySafeToolCall(toolName, { command })).toBe(false);
     expect(buildToolMutationState(toolName, { command }, command).mutatingAction).toBe(true);
+    expect(buildToolMutationState(toolName, { command }, command).replaySafe).toBe(false);
     expect(buildToolMutationState(toolName, { command }, command).actionFingerprint).toBe(
       `tool=${toolName}|meta=${command.toLowerCase().replace(/\s+/g, " ")}`,
     );
@@ -267,7 +271,12 @@ describe("tool mutation helpers", () => {
     expect(isReplaySafeToolCall("nodes", { action: "describe" })).toBe(true);
     expect(isReplaySafeToolCall("nodes", { action: "pending" })).toBe(true);
     expect(isReplaySafeToolCall("nodes", { action: "approve" })).toBe(false);
-    expect(isReplaySafeToolCall("exec", { command: "rg TODO src" })).toBe(false);
+    expect(isReplaySafeToolCall("exec", { command: "rg TODO src" })).toBe(true);
+    expect(isReplaySafeToolCall("bash", { command: "ls -la" })).toBe(true);
+    expect(isReplaySafeToolCall("exec", { command: "cat package.json" })).toBe(true);
+    expect(isReplaySafeToolCall("exec", { command: "rm -rf /tmp/x" })).toBe(false);
+    expect(isReplaySafeToolCall("bash", { command: "npm install" })).toBe(false);
+    expect(isReplaySafeToolCall("exec", { command: "" })).toBe(false);
     expect(isReplaySafeToolCall("process", { action: "list" })).toBe(true);
     expect(isReplaySafeToolCall("process", { action: "log", sessionId: "run-1" })).toBe(true);
     expect(isReplaySafeToolCall("process", { action: "poll", sessionId: "run-1" })).toBe(false);

--- a/src/agents/tool-mutation.ts
+++ b/src/agents/tool-mutation.ts
@@ -392,7 +392,10 @@ export function isReplaySafeToolCall(toolName: string, args: unknown): boolean {
   switch (normalized) {
     case "exec":
     case "bash":
-      return false;
+      // Reuse the same command-content analysis as mutation classification so
+      // proven read-only shell inspection can participate in strict-agentic
+      // non-visible retry. Ambiguous/mutating commands stay fail-closed.
+      return isPlainReadOnlyShellCommand(readShellCommand(record));
     case "process":
       return action != null && PROCESS_REPLAY_SAFE_ACTIONS.has(action);
     case "message":


### PR DESCRIPTION
## What Problem This Solves

Fixes #101890 — strict-agentic non-visible retry was blocked after turns that only ran proven read-only shell inspection (`exec`/`bash` with commands such as `rg`, `ls`, `cat`). Those calls were already classified as non-mutating, but `isReplaySafeToolCall` still returned `false` for every `exec`/`bash` invocation, so attempt replay metadata marked potential side effects and the retry path skipped. Codex native `commandExecution` items had the same fail-closed gap via `isMutatingNativeToolItem`.

## Why This Change Was Made

ClawSweeper localized the gap to shared shell replay-safety classification and the Codex projector consumer path. Reusing the existing `isPlainReadOnlyShellCommand` analysis keeps fail-closed defaults for ambiguous or mutating commands, without adding config knobs or new public SDK exports.

## User Impact

Strict-agentic and Codex terminal turns that only inspect the workspace with read-only shell commands can now participate in the normal non-visible retry path instead of ending without a visible answer. Mutating, ambiguous, empty, and unknown commands remain replay-unsafe.

## Evidence

### Summary of changes

- `src/agents/tool-mutation.ts`: `isReplaySafeToolCall("exec"|"bash")` returns true only when `isPlainReadOnlyShellCommand` accepts the command text.
- `extensions/codex/src/app-server/event-projector-items.ts`: `isMutatingNativeToolItem` for `commandExecution` reuses `isReplaySafeToolCall("bash", { command })` via the existing Plugin SDK export (no new public SDK surface).
- Focused regression tests for helper classification, attempt replay metadata, and Codex native item mutability.

### Verification

Verification host: local macOS (Crabbox bypass)

```text
node scripts/run-vitest.mjs src/agents/tool-mutation.test.ts
# 65 passed

node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
# 131 passed

node scripts/run-vitest.mjs extensions/codex/src/app-server/event-projector-items.test.ts
# 3 passed

git diff --check  # clean
oxfmt --check <changed files>  # clean
oxlint <changed files>  # 0 warnings/errors
```

`pnpm check:changed` failed on an unrelated pre-existing max-lines baseline entry for `src/agents/modes/interactive/theme/theme.ts` (not touched by this PR). Path-scoped static checks on the changed surface passed.

### Real behavior proof

- **Behavior addressed:** Strict-agentic / Codex retry after terminal turns that only performed proven read-only shell inspection was blocked because shell tools were always treated as replay-unsafe.
- **Environment:** local macOS; PR head `5cd3b7c099fc`; sibling Codex checkout at `da4c8ca57d40` (`openai/codex`); focused Vitest + direct consumer-path runtime probe via `tsx` importing the PR modules (no secrets in transcript).
- **Current-main contrast:** On main, `isReplaySafeToolCall("exec", { command: "rg TODO src" })` is `false` even though `isMutatingToolCall` is already `false` for that command; `buildAttemptReplayMetadata` with unmarked/`replaySafe: false` shell metas reports `hadPotentialSideEffects: true`. Codex `isMutatingNativeToolItem` always returns `true` for `commandExecution`.
- **Sibling Codex source audit (CS rank-up):** Direct inspection of sibling `../codex` at `da4c8ca57d40b074bdc1b5b1218851100150c56b` confirms:
  - `ThreadItem::CommandExecution` carries an authoritative `command: String` plus separate presentation-oriented `command_actions: Vec<CommandAction>` (`codex-rs/app-server-protocol/src/protocol/v2/item.rs`).
  - Emission builders set `command` from `shlex_join(&payload.command)` and derive `command_actions` from `parsed_cmd` (`codex-rs/app-server-protocol/src/protocol/item_builders.rs` — `build_command_execution_begin_item` / `end_item` / approval request).
  - App-server docs describe `commandActions` for UI summarization, not as a safety authority (`codex-rs/app-server/README.md` commandExecution section).
  - Therefore OpenClaw correctly classifies native items with `isReplaySafeToolCall("bash", { command: item.command })` and must not trust `commandActions` (which can label a mutating argv as `Read`/`Search`).
- **Exact steps run after this patch (2026-07-16T08:45:10Z):**
  1. `node scripts/run-vitest.mjs src/agents/tool-mutation.test.ts -t "read-only shell|ambiguous or mutating shell"` → 50 passed
  2. `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run.incomplete-turn.test.ts -t "101890"` → 4 passed (attempt-replay metadata path)
  3. `node scripts/run-vitest.mjs extensions/codex/src/app-server/event-projector-items.test.ts` → 3 passed
  4. Direct runtime probe importing `isReplaySafeToolCall` / `buildAttemptReplayMetadata` / `isMutatingNativeToolItem` from this head (transcript below)
- **Evidence after fix (redacted terminal transcript):**

```text
=== Real behavior proof transcript ===
date_utc: 2026-07-16T08:42:34Z
pr_head: 5cd3b7c099fc47b37ea974534404cf519ff8192a
host: local macOS
sibling_codex_sha: da4c8ca57d40b074bdc1b5b1218851100150c56b

=== A) Focused consumer-path tests ===
(node:7784) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
(Use `node --trace-warnings ...` to show where the warning was created)


 RUN  v4.1.9 /Users/wuqingxuan/.grok/worktrees/openclaw-review/pr-108388

(node:7784) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
(Use `node --trace-warnings ...` to show where the warning was created)
 ✓ |unit-fast| ../../src/agents/tool-mutation.test.ts (65 tests | 15 skipped) 8ms

 Test Files  1 passed (1)
      Tests  50 passed | 15 skipped (65)
   Start at  16:42:45
   Duration  98ms (transform 9ms, setup 15ms, import 10ms, tests 8ms, environment 0ms)


(node:8169) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
(Use `node --trace-warnings ...` to show where the warning was created)



 RUN  v4.1.9 /Users/wuqingxuan/.grok/worktrees/openclaw-review/pr-108388

(node:8169) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
(Use `node --trace-warnings ...` to show where the warning was created)
 ✓ |agents-core| ../../src/agents/embedded-agent-runner/run.incomplete-turn.test.ts (131 tests | 129 skipped) 18317ms
(node:8169) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
(Use `node --trace-warnings ...` to show where the warning was created)
 ✓ |agents-embedded-agent| ../../src/agents/embedded-agent-runner/run.incomplete-turn.test.ts (131 tests | 129 skipped) 12805ms

 Test Files  2 passed (2)
      Tests  4 passed | 258 skipped (262)
   Start at  16:42:56
   Duration  32.22s (transform 14.07s, setup 565ms, import 372ms, tests 31.12s, environment 0ms)


[test] starting test/vitest/vitest.extension-codex.config.ts
(node:9850) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
(Use `node --trace-warnings ...` to show where the warning was created)

 RUN  v4.1.9 /Users/wuqingxuan/.grok/worktrees/openclaw-review/pr-108388

(node:9850) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
(Use `node --trace-warnings ...` to show where the warning was created)
 ✓ |extension-codex| extensions/codex/src/app-server/event-projector-items.test.ts (3 tests) 9ms

 Test Files  1 passed (1)
      Tests  3 passed (3)
   Start at  16:43:30
   Duration  8.53s (transform 6.94s, setup 263ms, import 8.18s, tests 9ms, environment 0ms)

[test] passed 1 Vitest shard in 10.85s

=== B) Direct consumer-path runtime probe ===
(node:10174) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
(Use `node --trace-warnings ...` to show where the warning was created)
--- shared shell classifier ---
{"command":"rg TODO src","isReplaySafeToolCall":true,"isMutatingToolCall":false,"replaySafe":true}
{"command":"ls -la src/agents","isReplaySafeToolCall":true,"isMutatingToolCall":false,"replaySafe":true}
{"command":"cat package.json","isReplaySafeToolCall":true,"isMutatingToolCall":false,"replaySafe":true}
{"command":"gh pr view 108388 --json title","isReplaySafeToolCall":true,"isMutatingToolCall":false,"replaySafe":true}
{"command":"rm -rf /tmp/x","isReplaySafeToolCall":false,"isMutatingToolCall":true,"replaySafe":false}
{"command":"npm install left-pad","isReplaySafeToolCall":false,"isMutatingToolCall":true,"replaySafe":false}
{"command":"echo hi > /tmp/x","isReplaySafeToolCall":false,"isMutatingToolCall":true,"replaySafe":false}
{"command":"git checkout main","isReplaySafeToolCall":false,"isMutatingToolCall":true,"replaySafe":false}
{"command":"<empty>","isReplaySafeToolCall":false,"isMutatingToolCall":true,"replaySafe":false}
--- attempt replay metadata (non-visible retry gate input) ---
only proven read-only shell metas: { hadPotentialSideEffects: false, replaySafe: true }
unmarked shell metas fail-closed: { hadPotentialSideEffects: true, replaySafe: false }
mixed read-only + unsafe: { hadPotentialSideEffects: true, replaySafe: false }
mutating only: { hadPotentialSideEffects: true, replaySafe: false }
--- Codex native commandExecution projector ---
{"itemType":"commandExecution","command":"rg TODO src","misleadingActions":false,"isMutatingNativeToolItem":false}
{"itemType":"commandExecution","command":"ls -la","misleadingActions":false,"isMutatingNativeToolItem":false}
{"itemType":"commandExecution","command":"cat package.json","misleadingActions":false,"isMutatingNativeToolItem":false}
{"itemType":"commandExecution","command":"npm install left-pad","misleadingActions":false,"isMutatingNativeToolItem":true}
{"itemType":"commandExecution","command":"rm -rf /tmp/x","misleadingActions":true,"isMutatingNativeToolItem":true}
{"itemType":"commandExecution","command":"","misleadingActions":false,"isMutatingNativeToolItem":true}
{"itemType":"fileChange","command":null,"misleadingActions":false,"isMutatingNativeToolItem":true}
control: misleading commandActions Read does not authorize replay of rm (mutating=true)

=== C) Sibling Codex source audit (required by CS) ===
codex_sha: da4c8ca57d40b074bdc1b5b1218851100150c56b
ThreadItem::CommandExecution fields: command (authoritative string) + command_actions (presentation parse)
files:
  codex-rs/app-server-protocol/src/protocol/v2/item.rs — CommandExecution { command, command_actions, ... }
  codex-rs/app-server-protocol/src/protocol/item_builders.rs — build_command_execution_{begin,end,approval}_item set command via shlex_join(&payload.command); command_actions from parsed_cmd
  codex-rs/app-server/README.md — commandExecution documented with command + commandActions for UI summarize
conclusion: OpenClaw correctly classifies via item.command string only; commandActions are presentation and can mislabel (e.g. Read) so must not gate safety
```

- **Control check:** Mutating/empty/ambiguous shell inputs and a Codex `commandExecution` whose `commandActions` claim `Read` for `rm -rf` remain mutating/replay-unsafe. Unmarked shell metas stay fail-closed (`hadPotentialSideEffects: true`).
- **Observed result after fix:** Proven read-only shell inspection is replay-safe through mutation state and attempt replay metadata; Codex native `commandExecution` uses the same command-string classifier; mutating commands still block retry.
- **What was not tested:** Live multi-turn strict-agentic GPT-5 provider session and live native Codex harness turn (no OpenAI GPT-5 credentials in this proof environment). The acceptance path exercised here is the same consumer helpers and attempt-replay metadata used by non-visible retry, plus direct sibling Codex protocol source confirmation.


### Fix quality

- **compatibility:** No config/schema/SDK export additions; reuses existing `isReplaySafeToolCall` Plugin SDK export only.
- **performance:** O(1) command-string classification already used for mutation; no new I/O.
- **usability:** Removes a silent “turn ends without answer after inspection only” failure mode.
- **security:** Fail-closed for empty/unknown/mutating shell; does not trust Codex `commandActions` presentation hints.

Fixes #101890

---

This PR was authored with AI assistance (Grok).

