### PR TITLE
ci: prune stale theme max-lines baseline

### DIFF
--- a/config/max-lines-baseline.txt
+++ b/config/max-lines-baseline.txt
@@ -516,7 +516,6 @@ src/agents/model-fallback.ts
 src/agents/model-selection-shared.ts
 src/agents/model-selection.test.ts
 src/agents/models.profiles.live.test.ts
-src/agents/modes/interactive/theme/theme.ts
 src/agents/openai-completions-transport.ts
 src/agents/openai-responses-transport.ts
 src/agents/openai-transport-stream.base.test-utils.ts


### PR DESCRIPTION
## Summary

Remove the stale max-lines baseline entry for `src/agents/modes/interactive/theme/theme.ts`.

## Why

PR #108376 reduced the file below the ratchet threshold but left its baseline entry behind. Fresh pull request CI now fails `checks-fast-max-lines-ratchet` on every merge tree.

## Evidence

- `node scripts/check-max-lines-ratchet.mjs --base origin/main`
- `git diff --check`
- Fresh autoreview: clean, confidence 0.98

## Changelog

Not required. CI baseline maintenance only.
