### PR TITLE
fix(acp): skip unsupported automatic thinking config in manager gate

### DIFF
--- a/extensions/acpx/src/runtime.test.ts
+++ b/extensions/acpx/src/runtime.test.ts
@@ -7,6 +7,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   AcpRuntimeError,
   type AcpRuntime,
+  type AcpRuntimeCapabilities,
   type AcpRuntimeEvent,
   type AcpRuntimeTurn,
 } from "../runtime-api.js";
@@ -40,6 +41,7 @@ function makeRuntime(
     ensureSession: AcpRuntime["ensureSession"];
     startTurn: NonNullable<AcpRuntime["startTurn"]>;
     runTurn: AcpRuntime["runTurn"];
+    getCapabilities: NonNullable<AcpRuntime["getCapabilities"]>;
     getStatus: NonNullable<AcpRuntime["getStatus"]>;
     setConfigOption: NonNullable<AcpRuntime["setConfigOption"]>;
     isHealthy(): boolean;
@@ -83,6 +85,7 @@ function makeRuntime(
           ensureSession: AcpRuntime["ensureSession"];
           startTurn: NonNullable<AcpRuntime["startTurn"]>;
           runTurn: AcpRuntime["runTurn"];
+          getCapabilities: NonNullable<AcpRuntime["getCapabilities"]>;
           getStatus: NonNullable<AcpRuntime["getStatus"]>;
           setConfigOption: NonNullable<AcpRuntime["setConfigOption"]>;
           isHealthy(): boolean;
@@ -1074,6 +1077,111 @@ describe("AcpxRuntime fresh reset wrapper", () => {
     });
   });
 
+  it("forwards getCapabilities input handles and injects non-mutating reasoning aliases", async () => {
+    const baseStore: TestSessionStore = {
+      load: vi.fn(async () => ({
+        acpxRecordId: "agent:codex:acp:test",
+        agentCommand: CODEX_ACP_COMMAND,
+      })),
+      save: vi.fn(async () => {}),
+    };
+    const { runtime, delegate } = makeRuntime(baseStore);
+    const delegateCapabilities: AcpRuntimeCapabilities = {
+      controls: ["session/set_config_option"],
+      configOptionKeys: ["reasoning_effort", "model"],
+    };
+    const getCapabilities = vi
+      .spyOn(delegate, "getCapabilities")
+      .mockResolvedValue(delegateCapabilities);
+
+    const handle: Parameters<NonNullable<AcpRuntime["getCapabilities"]>>[0]["handle"] = {
+      sessionKey: "agent:codex:acp:test",
+      backend: "acpx",
+      runtimeSessionName: "agent:codex:acp:test",
+      acpxRecordId: "agent:codex:acp:test",
+    };
+    const input = { handle };
+
+    const result = await runtime.getCapabilities?.(input);
+
+    expect(getCapabilities).toHaveBeenCalledWith(input);
+    expect(result?.configOptionKeys).toEqual([
+      "reasoning_effort",
+      "model",
+      "thinking",
+      "thought_level",
+    ]);
+    expect(result?.configOptionKeys).not.toContain("effort");
+    // Delegate-owned arrays remain unchanged.
+    expect(delegateCapabilities.configOptionKeys).toEqual(["reasoning_effort", "model"]);
+  });
+
+  it("does not inject aliases when reasoning_effort is not advertised", async () => {
+    const baseStore: TestSessionStore = {
+      load: vi.fn(async () => ({
+        acpxRecordId: "agent:claude:acp:test",
+        agentCommand: "npx @agentclientprotocol/claude-agent-acp",
+      })),
+      save: vi.fn(async () => {}),
+    };
+    const { runtime, delegate } = makeRuntime(baseStore);
+    const getCapabilities = vi.spyOn(delegate, "getCapabilities").mockResolvedValue({
+      controls: ["session/set_config_option"],
+      configOptionKeys: ["model", "timeout_seconds"],
+    });
+
+    const handle: Parameters<NonNullable<AcpRuntime["getCapabilities"]>>[0]["handle"] = {
+      sessionKey: "agent:claude:acp:test",
+      backend: "acpx",
+      runtimeSessionName: "agent:claude:acp:test",
+      acpxRecordId: "agent:claude:acp:test",
+    };
+
+    const result = await runtime.getCapabilities?.({ handle });
+
+    expect(getCapabilities).toHaveBeenCalledWith({ handle });
+    expect(result?.configOptionKeys).toEqual(["model", "timeout_seconds"]);
+    expect(result?.configOptionKeys).not.toContain("thinking");
+    expect(result?.configOptionKeys).not.toContain("thought_level");
+    expect(result?.configOptionKeys).not.toContain("effort");
+  });
+
+  it("does not inject aliases for non-Codex agents even when reasoning_effort is advertised", async () => {
+    const baseStore: TestSessionStore = {
+      load: vi.fn(async () => ({
+        acpxRecordId: "agent:claude:acp:test",
+        agentCommand: "npx @agentclientprotocol/claude-agent-acp",
+      })),
+      save: vi.fn(async () => {}),
+    };
+    const { runtime, delegate } = makeRuntime(baseStore);
+    const delegateCapabilities: AcpRuntimeCapabilities = {
+      controls: ["session/set_config_option"],
+      configOptionKeys: ["reasoning_effort", "model"],
+    };
+    const getCapabilities = vi
+      .spyOn(delegate, "getCapabilities")
+      .mockResolvedValue(delegateCapabilities);
+
+    const handle: Parameters<NonNullable<AcpRuntime["getCapabilities"]>>[0]["handle"] = {
+      sessionKey: "agent:claude:acp:test",
+      backend: "acpx",
+      runtimeSessionName: "agent:claude:acp:test",
+      acpxRecordId: "agent:claude:acp:test",
+    };
+
+    const result = await runtime.getCapabilities?.({ handle });
+
+    expect(getCapabilities).toHaveBeenCalledWith({ handle });
+    // Non-Codex agents should NOT get aliases — the acpx setConfigOption
+    // only translates thinking/thought_level for Codex ACP sessions.
+    expect(result?.configOptionKeys).toEqual(["reasoning_effort", "model"]);
+    expect(result?.configOptionKeys).not.toContain("thinking");
+    expect(result?.configOptionKeys).not.toContain("thought_level");
+    // Delegate-owned arrays remain unchanged.
+    expect(delegateCapabilities.configOptionKeys).toEqual(["reasoning_effort", "model"]);
+  });
+
   it("normalizes Codex ACP thinking config controls to reasoning effort", async () => {
     const baseStore: TestSessionStore = {
       load: vi.fn(async () => ({
@@ -1101,6 +1209,44 @@ describe("AcpxRuntime fresh reset wrapper", () => {
       handle,
       key: "reasoning_effort",
       value: "low",
+    });
+  });
+
+  it("forwards unsupported thinking config rejection for non-Codex ACP sessions", async () => {
+    const unsupportedThinkingError = new AcpRuntimeError(
+      "ACP_BACKEND_UNSUPPORTED_CONTROL",
+      "unsupported thinking",
+    );
+    const baseStore: TestSessionStore = {
+      load: vi.fn(async () => ({
+        acpxRecordId: "agent:gemini:acp:test",
+        agentCommand: "gemini --experimental-acp",
+      })),
+      save: vi.fn(async () => {}),
+    };
+    const { runtime, delegate } = makeRuntime(baseStore);
+    const setConfigOption = vi
+      .spyOn(delegate, "setConfigOption")
+      .mockRejectedValue(unsupportedThinkingError);
+    const handle: Parameters<NonNullable<AcpRuntime["setConfigOption"]>>[0]["handle"] = {
+      sessionKey: "agent:gemini:acp:test",
+      backend: "acpx",
+      runtimeSessionName: "agent:gemini:acp:test",
+      acpxRecordId: "agent:gemini:acp:test",
+    };
+
+    await expect(
+      runtime.setConfigOption({
+        handle,
+        key: "thinking",
+        value: "high",
+      }),
+    ).rejects.toBe(unsupportedThinkingError);
+
+    expect(setConfigOption).toHaveBeenCalledWith({
+      handle,
+      key: "thinking",
+      value: "high",
     });
   });
 

--- a/extensions/acpx/src/runtime.test.ts
+++ b/extensions/acpx/src/runtime.test.ts
@@ -1005,9 +1005,9 @@ describe("AcpxRuntime fresh reset wrapper", () => {
       sessionKey: "agent:codex:acp:test",
       agent: "codex",
       mode: "persistent",
-      model: "gpt-5.4/xhigh",
+      model: "gpt-5.4",
       thinking: "x-high",
-      sessionOptions: { model: "gpt-5.4/xhigh" },
+      sessionOptions: { model: "gpt-5.4" },
     });
   });
 
@@ -1077,7 +1077,7 @@ describe("AcpxRuntime fresh reset wrapper", () => {
     });
   });
 
-  it("forwards getCapabilities input handles and injects non-mutating reasoning aliases", async () => {
+  it("forwards getCapabilities input handles to the ACPX delegate", async () => {
     const baseStore: TestSessionStore = {
       load: vi.fn(async () => ({
         acpxRecordId: "agent:codex:acp:test",
@@ -1105,84 +1105,13 @@ describe("AcpxRuntime fresh reset wrapper", () => {
     const result = await runtime.getCapabilities?.(input);
 
     expect(getCapabilities).toHaveBeenCalledWith(input);
-    expect(result?.configOptionKeys).toEqual([
-      "reasoning_effort",
-      "model",
-      "thinking",
-      "thought_level",
-    ]);
-    expect(result?.configOptionKeys).not.toContain("effort");
-    // Delegate-owned arrays remain unchanged.
-    expect(delegateCapabilities.configOptionKeys).toEqual(["reasoning_effort", "model"]);
+    expect(result).toBe(delegateCapabilities);
   });
 
-  it("does not inject aliases when reasoning_effort is not advertised", async () => {
-    const baseStore: TestSessionStore = {
-      load: vi.fn(async () => ({
-        acpxRecordId: "agent:claude:acp:test",
-        agentCommand: "npx @agentclientprotocol/claude-agent-acp",
-      })),
-      save: vi.fn(async () => {}),
-    };
-    const { runtime, delegate } = makeRuntime(baseStore);
-    const getCapabilities = vi.spyOn(delegate, "getCapabilities").mockResolvedValue({
-      controls: ["session/set_config_option"],
-      configOptionKeys: ["model", "timeout_seconds"],
-    });
-
-    const handle: Parameters<NonNullable<AcpRuntime["getCapabilities"]>>[0]["handle"] = {
-      sessionKey: "agent:claude:acp:test",
-      backend: "acpx",
-      runtimeSessionName: "agent:claude:acp:test",
-      acpxRecordId: "agent:claude:acp:test",
-    };
-
-    const result = await runtime.getCapabilities?.({ handle });
-
-    expect(getCapabilities).toHaveBeenCalledWith({ handle });
-    expect(result?.configOptionKeys).toEqual(["model", "timeout_seconds"]);
-    expect(result?.configOptionKeys).not.toContain("thinking");
-    expect(result?.configOptionKeys).not.toContain("thought_level");
-    expect(result?.configOptionKeys).not.toContain("effort");
-  });
-
-  it("does not inject aliases for non-Codex agents even when reasoning_effort is advertised", async () => {
-    const baseStore: TestSessionStore = {
-      load: vi.fn(async () => ({
-        acpxRecordId: "agent:claude:acp:test",
-        agentCommand: "npx @agentclientprotocol/claude-agent-acp",
-      })),
-      save: vi.fn(async () => {}),
-    };
-    const { runtime, delegate } = makeRuntime(baseStore);
-    const delegateCapabilities: AcpRuntimeCapabilities = {
-      controls: ["session/set_config_option"],
-      configOptionKeys: ["reasoning_effort", "model"],
-    };
-    const getCapabilities = vi
-      .spyOn(delegate, "getCapabilities")
-      .mockResolvedValue(delegateCapabilities);
-
-    const handle: Parameters<NonNullable<AcpRuntime["getCapabilities"]>>[0]["handle"] = {
-      sessionKey: "agent:claude:acp:test",
-      backend: "acpx",
-      runtimeSessionName: "agent:claude:acp:test",
-      acpxRecordId: "agent:claude:acp:test",
-    };
-
-    const result = await runtime.getCapabilities?.({ handle });
-
-    expect(getCapabilities).toHaveBeenCalledWith({ handle });
-    // Non-Codex agents should NOT get aliases — the acpx setConfigOption
-    // only translates thinking/thought_level for Codex ACP sessions.
-    expect(result?.configOptionKeys).toEqual(["reasoning_effort", "model"]);
-    expect(result?.configOptionKeys).not.toContain("thinking");
-    expect(result?.configOptionKeys).not.toContain("thought_level");
-    // Delegate-owned arrays remain unchanged.
-    expect(delegateCapabilities.configOptionKeys).toEqual(["reasoning_effort", "model"]);
-  });
-
-  it("normalizes Codex ACP thinking config controls to reasoning effort", async () => {
+  it.each([
+    { key: "thinking", value: "minimal", expected: "low" },
+    { key: "reasoning_effort", value: "x-high", expected: "xhigh" },
+  ])("normalizes Codex ACP $key=$value to reasoning effort", async ({ key, value, expected }) => {
     const baseStore: TestSessionStore = {
       load: vi.fn(async () => ({
         acpxRecordId: "agent:codex:acp:test",
@@ -1201,14 +1130,14 @@ describe("AcpxRuntime fresh reset wrapper", () => {
 
     await runtime.setConfigOption({
       handle,
-      key: "thinking",
-      value: "minimal",
+      key,
+      value,
     });
 
     expect(setConfigOption).toHaveBeenCalledWith({
       handle,
       key: "reasoning_effort",
-      value: "low",
+      value: expected,
     });
   });
 

--- a/extensions/acpx/src/runtime.ts
+++ b/extensions/acpx/src/runtime.ts
@@ -570,15 +570,6 @@ function normalizeCodexAcpModelOverride(
   };
 }
 
-function codexAcpSessionModelId(override: CodexAcpModelOverride): string {
-  if (!override.model) {
-    return "";
-  }
-  return override.reasoningEffort
-    ? `${override.model}/${override.reasoningEffort}`
-    : override.model;
-}
-
 function normalizeClaudeAcpModelOverride(rawModel: string | undefined): string | undefined {
   const raw = rawModel?.trim();
   if (!raw) {
@@ -1117,9 +1108,7 @@ export class AcpxRuntime implements AcpRuntime {
 
     const normalizedInput = {
       ...ensureInput,
-      ...(codexAcpSessionModelId(codexModelOverride)
-        ? { model: codexAcpSessionModelId(codexModelOverride) }
-        : {}),
+      ...(codexModelOverride.model ? { model: codexModelOverride.model } : {}),
     };
     return await this.runWithLaunchLease({
       sessionKey: input.sessionKey,
@@ -1286,31 +1275,10 @@ export class AcpxRuntime implements AcpRuntime {
     };
   }
 
-  async getCapabilities(
+  getCapabilities(
     input?: Parameters<NonNullable<AcpRuntime["getCapabilities"]>>[0],
   ): ReturnType<BaseAcpxRuntime["getCapabilities"]> {
-    const raw = this.delegate.getCapabilities(input);
-    const caps = raw instanceof Promise ? await raw : raw;
-    const keys = caps.configOptionKeys ? [...caps.configOptionKeys] : undefined;
-    // Only inject thinking aliases for Codex ACP sessions — the acpx
-    // setConfigOption only translates thinking/thought_level to
-    // reasoning_effort for Codex ACP, so advertising aliases to
-    // non-Codex agents would claim support that doesn't exist.
-    if (keys?.includes("reasoning_effort") && input?.handle) {
-      const command = await this.resolveCommandForHandle(input.handle);
-      if (isCodexAcpCommand(command)) {
-        const aliases = ["thinking", "thought_level"];
-        for (const alias of aliases) {
-          if (!keys.includes(alias)) {
-            keys.push(alias);
-          }
-        }
-      }
-    }
-    return {
-      ...caps,
-      ...(keys ? { configOptionKeys: keys } : {}),
-    };
+    return this.delegate.getCapabilities(input);
   }
 
   async getStatus(
@@ -1377,6 +1345,7 @@ export class AcpxRuntime implements AcpRuntime {
     }
     await delegate.setConfigOption(input);
   }
+
   async cancel(input: Parameters<AcpRuntime["cancel"]>[0]): Promise<void> {
     const record = await this.sessionStore.load(
       input.handle.acpxRecordId ?? input.handle.sessionKey,
@@ -1430,7 +1399,6 @@ export {
 export const testing = {
   appendCodexAcpConfigOverrides,
   assertSupportedRuntimeSessionMode,
-  codexAcpSessionModelId,
   isClaudeAcpCommand,
   isCodexAcpCommand,
   normalizeClaudeAcpModelOverride,

--- a/extensions/acpx/src/runtime.ts
+++ b/extensions/acpx/src/runtime.ts
@@ -1286,8 +1286,31 @@ export class AcpxRuntime implements AcpRuntime {
     };
   }
 
-  getCapabilities(): ReturnType<BaseAcpxRuntime["getCapabilities"]> {
-    return this.delegate.getCapabilities();
+  async getCapabilities(
+    input?: Parameters<NonNullable<AcpRuntime["getCapabilities"]>>[0],
+  ): ReturnType<BaseAcpxRuntime["getCapabilities"]> {
+    const raw = this.delegate.getCapabilities(input);
+    const caps = raw instanceof Promise ? await raw : raw;
+    const keys = caps.configOptionKeys ? [...caps.configOptionKeys] : undefined;
+    // Only inject thinking aliases for Codex ACP sessions — the acpx
+    // setConfigOption only translates thinking/thought_level to
+    // reasoning_effort for Codex ACP, so advertising aliases to
+    // non-Codex agents would claim support that doesn't exist.
+    if (keys?.includes("reasoning_effort") && input?.handle) {
+      const command = await this.resolveCommandForHandle(input.handle);
+      if (isCodexAcpCommand(command)) {
+        const aliases = ["thinking", "thought_level"];
+        for (const alias of aliases) {
+          if (!keys.includes(alias)) {
+            keys.push(alias);
+          }
+        }
+      }
+    }
+    return {
+      ...caps,
+      ...(keys ? { configOptionKeys: keys } : {}),
+    };
   }
 
   async getStatus(
@@ -1354,7 +1377,6 @@ export class AcpxRuntime implements AcpRuntime {
     }
     await delegate.setConfigOption(input);
   }
-
   async cancel(input: Parameters<AcpRuntime["cancel"]>[0]): Promise<void> {
     const record = await this.sessionStore.load(
       input.handle.acpxRecordId ?? input.handle.sessionKey,

--- a/src/acp/control-plane/manager.runtime-config.test.ts
+++ b/src/acp/control-plane/manager.runtime-config.test.ts
@@ -771,6 +771,101 @@ describe("AcpSessionManager runtime config", () => {
     );
   });
 
+  it("does not send automatic thinking when the backend advertises no thinking control", async () => {
+    const runtimeState = createRuntime();
+    runtimeState.getCapabilities.mockResolvedValue({
+      controls: ["session/set_config_option"],
+      configOptionKeys: ["mode", "model"],
+    });
+    hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+      id: "acpx",
+      runtime: runtimeState.runtime,
+    });
+    hoisted.readAcpSessionEntryMock.mockReturnValue({
+      sessionKey: "agent:opencode:acp:session-1",
+      storeSessionKey: "agent:opencode:acp:session-1",
+      acp: readySessionMeta({
+        agent: "opencode",
+        runtimeOptions: { thinking: "high" },
+      }),
+    });
+
+    const manager = new AcpSessionManager();
+    await manager.runTurn({
+      provenance: "system",
+      cfg: baseCfg,
+      sessionKey: "agent:opencode:acp:session-1",
+      text: "do work",
+      mode: "prompt",
+      requestId: "run-opencode-no-thinking",
+    });
+
+    expect(runtimeState.setConfigOption).not.toHaveBeenCalled();
+    expect(runtimeState.runTurn).toHaveBeenCalledOnce();
+  });
+
+  it("maps automatic Codex thinking to the advertised reasoning effort control", async () => {
+    const runtimeState = createRuntime();
+    runtimeState.getCapabilities.mockResolvedValue({
+      controls: ["session/set_config_option"],
+      configOptionKeys: ["model", "reasoning_effort"],
+    });
+    hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+      id: "acpx",
+      runtime: runtimeState.runtime,
+    });
+    hoisted.readAcpSessionEntryMock.mockReturnValue({
+      sessionKey: "agent:codex:acp:session-1",
+      storeSessionKey: "agent:codex:acp:session-1",
+      acp: readySessionMeta({ runtimeOptions: { thinking: "high" } }),
+    });
+
+    const manager = new AcpSessionManager();
+    await manager.runTurn({
+      provenance: "system",
+      cfg: baseCfg,
+      sessionKey: "agent:codex:acp:session-1",
+      text: "do work",
+      mode: "prompt",
+      requestId: "run-codex-reasoning",
+    });
+
+    expectMockCallFields(runtimeState.setConfigOption, {
+      key: "reasoning_effort",
+      value: "high",
+    });
+  });
+
+  it("rejects an explicit thinking write when the backend does not advertise it", async () => {
+    const runtimeState = createRuntime();
+    runtimeState.getCapabilities.mockResolvedValue({
+      controls: ["session/set_config_option"],
+      configOptionKeys: ["mode", "model"],
+    });
+    hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+      id: "acpx",
+      runtime: runtimeState.runtime,
+    });
+    hoisted.readAcpSessionEntryMock.mockReturnValue({
+      sessionKey: "agent:opencode:acp:session-1",
+      storeSessionKey: "agent:opencode:acp:session-1",
+      acp: readySessionMeta({ agent: "opencode" }),
+    });
+
+    const manager = new AcpSessionManager();
+    await expectRejectedRecord(
+      manager.setSessionConfigOption({
+        cfg: baseCfg,
+        sessionKey: "agent:opencode:acp:session-1",
+        key: "thinking",
+        value: "high",
+      }),
+      { code: "ACP_BACKEND_UNSUPPORTED_CONTROL" },
+    );
+
+    expect(runtimeState.setConfigOption).not.toHaveBeenCalled();
+  });
+
   it("maps explicit thinking config updates to advertised effort keys", async () => {
     const runtimeState = createRuntime();
     runtimeState.getCapabilities.mockResolvedValue({

--- a/src/acp/control-plane/manager.runtime-controls.ts
+++ b/src/acp/control-plane/manager.runtime-controls.ts
@@ -19,6 +19,7 @@ import {
 } from "./runtime-options.js";
 
 const OPTIONAL_TIMEOUT_CONFIG_KEYS = new Set(["timeout", "timeout_seconds"]);
+const THINKING_CONFIG_KEYS = new Set(["thinking", "effort", "reasoning_effort", "thought_level"]);
 
 function extractConfigOptionKeys(value: unknown): string[] {
   if (!Array.isArray(value)) {
@@ -47,12 +48,20 @@ function isOptionalTimeoutConfigKey(key: string): boolean {
   return OPTIONAL_TIMEOUT_CONFIG_KEYS.has(normalizeLowercaseStringOrEmpty(key));
 }
 
+function isThinkingConfigKey(key: string): boolean {
+  return THINKING_CONFIG_KEYS.has(normalizeLowercaseStringOrEmpty(key));
+}
+
+function isUnsupportedControlRejection(error: unknown): boolean {
+  const errorCode = error && typeof error === "object" ? (error as { code?: unknown }).code : null;
+  return errorCode === "ACP_BACKEND_UNSUPPORTED_CONTROL";
+}
+
 function isUnsupportedOptionalTimeoutConfigRejection(key: string, error: unknown): boolean {
   if (!isOptionalTimeoutConfigKey(key)) {
     return false;
   }
-  const errorCode = error && typeof error === "object" ? (error as { code?: unknown }).code : null;
-  if (errorCode === "ACP_BACKEND_UNSUPPORTED_CONTROL") {
+  if (isUnsupportedControlRejection(error)) {
     return true;
   }
   const message =
@@ -179,6 +188,9 @@ export async function applyManagerRuntimeControls(params: {
             advertisedKeys.size > 0 &&
             !advertisedKeys.has(normalizeLowercaseStringOrEmpty(key))
           ) {
+            if (isThinkingConfigKey(key)) {
+              continue;
+            }
             throw new AcpRuntimeError(
               "ACP_BACKEND_UNSUPPORTED_CONTROL",
               `ACP backend "${backend}" does not accept config key "${key}".`,
@@ -191,7 +203,10 @@ export async function applyManagerRuntimeControls(params: {
               value,
             });
           } catch (error) {
-            if (isUnsupportedOptionalTimeoutConfigRejection(key, error)) {
+            if (
+              isUnsupportedOptionalTimeoutConfigRejection(key, error) ||
+              (isThinkingConfigKey(key) && isUnsupportedControlRejection(error))
+            ) {
               continue;
             }
             throw error;

--- a/src/acp/control-plane/manager.runtime-controls.ts
+++ b/src/acp/control-plane/manager.runtime-controls.ts
@@ -188,9 +188,6 @@ export async function applyManagerRuntimeControls(params: {
             advertisedKeys.size > 0 &&
             !advertisedKeys.has(normalizeLowercaseStringOrEmpty(key))
           ) {
-            if (isThinkingConfigKey(key)) {
-              continue;
-            }
             throw new AcpRuntimeError(
               "ACP_BACKEND_UNSUPPORTED_CONTROL",
               `ACP backend "${backend}" does not accept config key "${key}".`,

--- a/src/acp/control-plane/runtime-options.test.ts
+++ b/src/acp/control-plane/runtime-options.test.ts
@@ -90,3 +90,19 @@ describe("buildRuntimeConfigOptionPairs timeout advertisement", () => {
     ]);
   });
 });
+
+describe("buildRuntimeConfigOptionPairs thinking advertisement", () => {
+  it("omits automatic thinking when the backend advertises no thinking alias", () => {
+    expect(buildRuntimeConfigOptionPairs({ thinking: "high" }, ["mode", "model"])).toEqual([]);
+  });
+
+  it("maps automatic thinking to the advertised reasoning_effort alias", () => {
+    expect(
+      buildRuntimeConfigOptionPairs({ thinking: "high" }, ["model", "reasoning_effort"]),
+    ).toEqual([["reasoning_effort", "high"]]);
+  });
+
+  it("keeps automatic thinking when advertised keys are unknown", () => {
+    expect(buildRuntimeConfigOptionPairs({ thinking: "high" })).toEqual([["thinking", "high"]]);
+  });
+});

--- a/src/acp/control-plane/runtime-options.ts
+++ b/src/acp/control-plane/runtime-options.ts
@@ -329,7 +329,7 @@ export function buildRuntimeConfigOptionPairs(
   if (normalized.model) {
     pairs.set(resolveRuntimeConfigOptionKey("model", advertisedConfigOptionKeys), normalized.model);
   }
-  if (normalized.thinking) {
+  if (normalized.thinking && shouldEmitThinkingConfigOption(advertisedConfigOptionKeys)) {
     pairs.set(
       resolveRuntimeConfigOptionKey("thinking", advertisedConfigOptionKeys),
       normalized.thinking,
@@ -357,6 +357,16 @@ export function buildRuntimeConfigOptionPairs(
     }
   }
   return [...pairs.entries()];
+}
+
+function shouldEmitThinkingConfigOption(advertisedConfigOptionKeys?: readonly string[]): boolean {
+  const advertisedKeys = buildAdvertisedConfigOptionKeyMap(advertisedConfigOptionKeys);
+  return (
+    advertisedKeys.size === 0 ||
+    RUNTIME_CONFIG_OPTION_ALIASES.thinking.some((alias) =>
+      advertisedKeys.has(normalizeLowercaseStringOrEmpty(alias)),
+    )
+  );
 }
 
 function shouldEmitTimeoutConfigOption(advertisedConfigOptionKeys?: readonly string[]): boolean {

--- a/src/gateway/gateway-acp-spawn-defaults.live.test.ts
+++ b/src/gateway/gateway-acp-spawn-defaults.live.test.ts
@@ -6,6 +6,7 @@ import fs from "node:fs/promises";
 import net from "node:net";
 import os from "node:os";
 import path from "node:path";
+import { asNullableRecord } from "@openclaw/normalization-core/record-coerce";
 import { describe, expect, it } from "vitest";
 import { getAcpSessionManager } from "../acp/control-plane/manager.js";
 import { getAcpRuntimeBackend } from "../acp/runtime/registry.js";
@@ -30,6 +31,9 @@ import { startGatewayServer } from "./server.js";
 
 const LIVE = isLiveTestEnabled();
 const ACP_SPAWN_DEFAULTS_LIVE = isTruthyEnvValue(process.env.OPENCLAW_LIVE_ACP_SPAWN_DEFAULTS);
+const ACP_THINKING_CONTROLS_LIVE = isTruthyEnvValue(
+  process.env.OPENCLAW_LIVE_ACP_THINKING_CONTROLS,
+);
 const describeLive = LIVE && ACP_SPAWN_DEFAULTS_LIVE ? describe : describe.skip;
 const CONNECT_TIMEOUT_MS = resolvePositiveInteger(
   process.env.OPENCLAW_LIVE_ACP_SPAWN_DEFAULTS_CONNECT_TIMEOUT_MS,
@@ -57,6 +61,37 @@ function resolveThinking(): string {
   return process.env.OPENCLAW_LIVE_ACP_SPAWN_DEFAULTS_THINKING?.trim() || "high";
 }
 
+function resolveHarnessReasoningEffort(): string | undefined {
+  const thinking = resolveThinking().toLowerCase();
+  if (thinking === "off") {
+    return undefined;
+  }
+  if (thinking === "minimal") {
+    return "low";
+  }
+  if (thinking === "x-high") {
+    return "xhigh";
+  }
+  return thinking;
+}
+
+function resolveHarnessBaselineReasoningEffort(): string {
+  return resolveHarnessReasoningEffort() === "low" ? "medium" : "low";
+}
+
+function findRuntimeConfigOption(status: unknown, id: string): Record<string, unknown> | undefined {
+  const statusRecord = asNullableRecord(status);
+  const details = asNullableRecord(statusRecord?.details);
+  const configOptions = details?.configOptions;
+  if (!Array.isArray(configOptions)) {
+    return undefined;
+  }
+  return (
+    configOptions.map((option) => asNullableRecord(option)).find((option) => option?.id === id) ??
+    undefined
+  );
+}
+
 function resolveHarnessModel(): string {
   return process.env.OPENCLAW_LIVE_ACP_BIND_CODEX_MODEL?.trim() || "gpt-5.6-luna";
 }
@@ -65,7 +100,10 @@ function resolveAcpAgentId(): string {
   return process.env.OPENCLAW_LIVE_ACP_SPAWN_DEFAULTS_AGENT?.trim() || "codex";
 }
 
-function resolveAcpAgentCommand(): { command: string; args?: string[] } {
+function resolveAcpAgentCommand(agentId: string): { command: string; args?: string[] } {
+  if (agentId === "opencode") {
+    return { command: "opencode", args: ["acp"] };
+  }
   const codexHome = process.env.CODEX_HOME?.trim();
   return {
     command: "env",
@@ -102,9 +140,18 @@ async function prepareCodexHomeForLiveSpawnDefaultsTest(tempRoot: string): Promi
     }
   }
   const modelLine = `model = ${JSON.stringify(resolveHarnessModel())}`;
-  const nextConfig = /^model\s*=.*$/m.test(rawConfig)
+  let nextConfig = /^model\s*=.*$/m.test(rawConfig)
     ? rawConfig.replace(/^model\s*=.*$/m, modelLine)
     : `${modelLine}\n${rawConfig}`;
+  const baselineReasoningEffort = resolveHarnessBaselineReasoningEffort();
+  const reasoningLine = `model_reasoning_effort = ${JSON.stringify(baselineReasoningEffort)}`;
+  nextConfig = /^model_reasoning_effort\s*=.*$/m.test(nextConfig)
+    ? nextConfig.replace(/^model_reasoning_effort\s*=.*$/m, reasoningLine)
+    : `${reasoningLine}\n${nextConfig}`;
+  const planReasoningLine = `plan_mode_reasoning_effort = ${JSON.stringify(baselineReasoningEffort)}`;
+  nextConfig = /^plan_mode_reasoning_effort\s*=.*$/m.test(nextConfig)
+    ? nextConfig.replace(/^plan_mode_reasoning_effort\s*=.*$/m, planReasoningLine)
+    : `${planReasoningLine}\n${nextConfig}`;
   await fs.writeFile(targetConfigPath, nextConfig, "utf8");
   process.env.CODEX_HOME = codexHome;
 }
@@ -179,6 +226,123 @@ async function waitForSessionEntry(params: {
     await sleep(250);
   }
   throw new Error(`timed out waiting for ACP session entry ${params.sessionKey}`);
+}
+
+async function runOpenCodeThinkingControlProof(params: {
+  cfg: OpenClawConfig;
+  model: string;
+  thinking: string;
+  sessionKeys: string[];
+}): Promise<void> {
+  const sessionKey = `agent:opencode:acp:${randomUUID()}`;
+  const manager = getAcpSessionManager();
+  await manager.initializeSession({
+    cfg: params.cfg,
+    sessionKey,
+    agent: "opencode",
+    mode: "persistent",
+    runtimeOptions: {
+      model: params.model,
+      thinking: params.thinking,
+    },
+  });
+  params.sessionKeys.push(sessionKey);
+
+  await manager.runTurn({
+    cfg: params.cfg,
+    sessionKey,
+    provenance: "system",
+    text: "Reply with exactly LIVE-ACP-SPAWN-DEFAULTS-OK",
+    mode: "prompt",
+    requestId: randomUUID(),
+  });
+  const status = await manager.getSessionStatus({ cfg: params.cfg, sessionKey });
+  expect(status.runtimeOptions).toMatchObject({
+    model: params.model,
+    thinking: params.thinking,
+  });
+  expect(status.capabilities.configOptionKeys).toEqual(expect.arrayContaining(["mode", "model"]));
+  for (const key of ["thinking", "effort", "reasoning_effort", "thought_level"]) {
+    expect(status.capabilities.configOptionKeys).not.toContain(key);
+  }
+  await expect(
+    manager.setSessionConfigOption({
+      cfg: params.cfg,
+      sessionKey,
+      key: "thinking",
+      value: params.thinking,
+    }),
+  ).rejects.toMatchObject({ code: "ACP_BACKEND_UNSUPPORTED_CONTROL" });
+  console.info(
+    "[live-acp-spawn-defaults] opencode automatic thinking skipped; explicit write rejected",
+  );
+}
+
+async function runCodexThinkingControlProof(params: {
+  cfg: OpenClawConfig;
+  model: string;
+  thinking: string;
+  sessionKeys: string[];
+}): Promise<void> {
+  const sessionKey = `agent:codex:acp:${randomUUID()}`;
+  const manager = getAcpSessionManager();
+  const baselineReasoningEffort = resolveHarnessBaselineReasoningEffort();
+  await manager.initializeSession({
+    cfg: params.cfg,
+    sessionKey,
+    agent: "codex",
+    mode: "persistent",
+    runtimeOptions: {
+      model: params.model,
+      thinking: baselineReasoningEffort,
+    },
+  });
+  params.sessionKeys.push(sessionKey);
+
+  await manager.runTurn({
+    cfg: params.cfg,
+    sessionKey,
+    provenance: "system",
+    text: "Reply with exactly LIVE-ACP-SPAWN-DEFAULTS-OK",
+    mode: "prompt",
+    requestId: randomUUID(),
+  });
+  const initialStatus = await manager.getSessionStatus({ cfg: params.cfg, sessionKey });
+  const initialReasoningEffortOption = findRuntimeConfigOption(
+    initialStatus.runtimeStatus,
+    "reasoning_effort",
+  );
+  expect(initialReasoningEffortOption).toEqual(
+    expect.objectContaining({ currentValue: baselineReasoningEffort }),
+  );
+
+  await manager.updateSessionRuntimeOptions({
+    cfg: params.cfg,
+    sessionKey,
+    patch: { thinking: params.thinking },
+  });
+  await manager.runTurn({
+    cfg: params.cfg,
+    sessionKey,
+    provenance: "system",
+    text: "Reply with exactly LIVE-ACP-SPAWN-DEFAULTS-OK",
+    mode: "prompt",
+    requestId: randomUUID(),
+  });
+  const status = await manager.getSessionStatus({ cfg: params.cfg, sessionKey });
+  expect(status.capabilities.configOptionKeys).toContain("reasoning_effort");
+  const expectedReasoningEffort = resolveHarnessReasoningEffort();
+  const reasoningEffortOption = findRuntimeConfigOption(status.runtimeStatus, "reasoning_effort");
+  expect(reasoningEffortOption).toBeDefined();
+  if (expectedReasoningEffort) {
+    expect(reasoningEffortOption).toEqual(
+      expect.objectContaining({ currentValue: expectedReasoningEffort }),
+    );
+  } else {
+    // Codex ACP has no disabled effort value. `off` means leave its model default untouched.
+    expect(reasoningEffortOption?.currentValue).toBe(baselineReasoningEffort);
+  }
+  console.info(`[live-acp-spawn-defaults] codex reasoning_effort=${params.thinking} confirmed`);
 }
 
 function createConfig(params: {
@@ -257,7 +421,7 @@ function createConfig(params: {
             permissionMode: "approve-all",
             nonInteractivePermissions: "deny",
             agents: {
-              [params.acpAgentId]: resolveAcpAgentCommand(),
+              [params.acpAgentId]: resolveAcpAgentCommand(params.acpAgentId),
             },
           },
         },
@@ -290,7 +454,9 @@ describeLive("gateway live (ACP spawn defaults)", () => {
       process.env.OPENCLAW_SKIP_CANVAS_HOST = "1";
       process.env.OPENCLAW_GATEWAY_TOKEN = token;
       process.env.OPENCLAW_GATEWAY_PORT = String(port);
-      await prepareCodexHomeForLiveSpawnDefaultsTest(tempRoot);
+      if (acpAgentId === "codex") {
+        await prepareCodexHomeForLiveSpawnDefaultsTest(tempRoot);
+      }
 
       const cfg = createConfig({
         port,
@@ -315,6 +481,14 @@ describeLive("gateway live (ACP spawn defaults)", () => {
         await waitForGatewayPort({ host: "127.0.0.1", port, timeoutMs: CONNECT_TIMEOUT_MS });
         await waitForAcpBackendReady();
         const runtimeCfg = getRuntimeConfig();
+        if (ACP_THINKING_CONTROLS_LIVE) {
+          const runProof =
+            acpAgentId === "opencode"
+              ? runOpenCodeThinkingControlProof
+              : runCodexThinkingControlProof;
+          await runProof({ cfg: runtimeCfg, model: subagentModel, thinking, sessionKeys });
+          return;
+        }
         const configuredDefaultResult = await spawnAcpDirect(
           {
             task: "Reply with exactly LIVE-ACP-SPAWN-DEFAULTS-OK",
@@ -338,7 +512,6 @@ describeLive("gateway live (ACP spawn defaults)", () => {
           model: subagentModel,
           thinking,
         });
-
         const primaryOnlyResult = await spawnAcpDirect(
           {
             task: "Reply with exactly LIVE-ACP-SPAWN-PRIMARY-DEFAULT-OK",


### PR DESCRIPTION
## What Problem This Solves

Fixes #103802. ACP session startup could fail when automatic inherited thinking defaults were sent to a backend that advertised no thinking control, such as OpenCode. Explicit user configuration writes must remain strict.

## Why This Change Was Made

Automatic runtime options now consult the backend's advertised config-option keys before emitting thinking controls. A strict non-empty list without a thinking alias suppresses the automatic write; an empty or missing list retains the ACP runtime contract that keys are accepted but no strict list was advertised.

Codex ACP advertises `reasoning_effort`, so the manager maps the canonical thinking setting to that key. ACPX forwards handle-scoped capabilities without synthesizing aliases, normalizes Codex reasoning values at the owner boundary, and passes a bare model id instead of a brittle `model/effort` composite id.

Explicit `setSessionConfigOption` calls still reject unadvertised keys with `ACP_BACKEND_UNSUPPORTED_CONTROL`.

## User Impact

OpenCode ACP sessions no longer fail because of inherited thinking defaults. Codex ACP sessions continue to receive supported reasoning-effort controls. Invalid explicit configuration remains visible to the caller.

## Evidence

- Focused manager/runtime/ACPX regression suite: 90 tests passed.
- Live OpenCode ACP: automatic thinking omitted; explicit thinking write rejected.
- Live Codex ACP: session started at a distinct `low` baseline, automatic manager reconciliation changed the advertised `reasoning_effort` option to `high`, and the backend reported the new value.
- Hosted `check:changed`: formatting, four TypeScript configurations, core/plugin lint, architecture/boundary guards, import cycles, and storage guards passed on Blacksmith Testbox.
- Fresh autoreview after rebase: no accepted/actionable findings.

No `CHANGELOG.md` edit: contributor PR; release-note context is recorded here.

Co-authored-by: Erick Kinnee <erick@ekinnee.dev>
