### PR TITLE
fix(telegram): keep tool rows visible under progress preambles

### DIFF
--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-d79413170fd0a7a9601c36231fe72c691248cf667e02c80232756e0baad44549  plugin-sdk-api-baseline.json
-3b0b2398c5c26b6605c7e7b851c77073137b6a2655c2355cca6340f3acc38278  plugin-sdk-api-baseline.jsonl
+bc217b6821feb0891c64e0aaa9453e57cdbe4b17ce831fd9a3fdb7423d255424  plugin-sdk-api-baseline.json
+4033a75ff63c730a4d2340b555d3eafecd6a168e350ebe2a902fc470bf687ee9  plugin-sdk-api-baseline.jsonl

--- a/extensions/telegram/src/bot-message-dispatch-progress.ts
+++ b/extensions/telegram/src/bot-message-dispatch-progress.ts
@@ -41,8 +41,6 @@ function buildTelegramThinkingProgressLine(progressTokens: number): ChannelProgr
 }
 
 function buildTelegramTextToolProgressLine(text: string): ChannelProgressDraftLine {
-  // Keep tool-progress strings distinguishable from reasoning strings when a
-  // preamble headline makes the renderer select work-lane rows explicitly.
   return {
     kind: "item",
     label: "",
@@ -81,7 +79,7 @@ export function createTelegramProgressController(params: {
     reasoningLinePrefix: "🧠 ",
     commentaryLinePrefix: "💬 ",
     commentaryItalics: false,
-    renderLinesWithPreamble: true,
+    updateOnLineChange: true,
     update: async (streamText, options) => {
       draftEverRendered = true;
       await params.draft.prepareAnswerLaneForToolProgress();

--- a/extensions/telegram/src/bot-message-dispatch-progress.ts
+++ b/extensions/telegram/src/bot-message-dispatch-progress.ts
@@ -70,6 +70,7 @@ export function createTelegramProgressController(params: {
     reasoningLinePrefix: "🧠 ",
     commentaryLinePrefix: "💬 ",
     commentaryItalics: false,
+    renderLinesWithPreamble: true,
     update: async (streamText, options) => {
       draftEverRendered = true;
       await params.draft.prepareAnswerLaneForToolProgress();

--- a/extensions/telegram/src/bot-message-dispatch-progress.ts
+++ b/extensions/telegram/src/bot-message-dispatch-progress.ts
@@ -40,6 +40,17 @@ function buildTelegramThinkingProgressLine(progressTokens: number): ChannelProgr
   };
 }
 
+function buildTelegramTextToolProgressLine(text: string): ChannelProgressDraftLine {
+  // Keep tool-progress strings distinguishable from reasoning strings when a
+  // preamble headline makes the renderer select work-lane rows explicitly.
+  return {
+    kind: "item",
+    label: "",
+    text,
+    prefix: false,
+  };
+}
+
 export function createTelegramProgressController(params: {
   accountId: string;
   chatId: TelegramMessageContext["chatId"];
@@ -111,7 +122,10 @@ export function createTelegramProgressController(params: {
     if (!canPushToolProgress()) {
       return false;
     }
-    return await compositor.pushToolProgress(line, options);
+    return await compositor.pushToolProgress(
+      typeof line === "string" ? buildTelegramTextToolProgressLine(line) : line,
+      options,
+    );
   };
   const pushReasoningProgress = async (payload: {
     text?: string;

--- a/extensions/telegram/src/bot-message-dispatch.progress-rendering.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.progress-rendering.test.ts
@@ -56,8 +56,8 @@ describeTelegramDispatch("dispatchTelegramMessage progress-rendering", () => {
 
     expect(draftStream.updatePreview).toHaveBeenLastCalledWith(
       telegramProgressPreview(
-        "Shelling\n\nChecking recent context",
-        "<b>Shelling</b>\nChecking recent context",
+        "Shelling\n\nChecking recent context\n🛠️ Exec",
+        "<b>Shelling</b>\nChecking recent context\n<b>🛠️ Exec</b>",
       ),
     );
   });

--- a/extensions/telegram/src/bot-message-dispatch.progress-rendering.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.progress-rendering.test.ts
@@ -62,6 +62,36 @@ describeTelegramDispatch("dispatchTelegramMessage progress-rendering", () => {
     );
   });
 
+  it("keeps memory-search tool rows beneath a preamble", async () => {
+    const draftStream = createSequencedDraftStream(2001);
+    createTelegramDraftStream.mockReturnValue(draftStream);
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ replyOptions }) => {
+      await replyOptions?.onReplyStart?.();
+      await replyOptions?.onItemEvent?.({
+        kind: "preamble",
+        itemId: "preamble-1",
+        progressText: "Checking memory",
+      });
+      await replyOptions?.onToolStart?.({
+        name: "memory_search",
+        phase: "start",
+        toolCallId: "memory-search-1",
+        args: { query: "release status" },
+      });
+      return { queuedFinal: false };
+    });
+
+    await dispatchWithContext({
+      context: createContext(),
+      streamMode: "progress",
+      telegramCfg: { streaming: { mode: "progress" } },
+    });
+
+    const preview = draftStream.updatePreview.mock.calls.at(-1)?.[0];
+    expect(preview?.text).toContain("Checking memory");
+    expect(preview?.text).toContain("Memory Search");
+  });
+
   it("keeps the progress draft label when tool progress lines are hidden", async () => {
     const draftStream = createSequencedDraftStream(2001);
     createTelegramDraftStream.mockReturnValue(draftStream);

--- a/extensions/telegram/src/bot-message-dispatch.progress-updates.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.progress-updates.test.ts
@@ -1,10 +1,5 @@
-import { createAgentRunEventHandler } from "openclaw/plugin-sdk/plugin-test-runtime";
-import { dispatchReplyWithBufferedBlockDispatcher as dispatchReplyThroughRuntime } from "openclaw/plugin-sdk/reply-dispatch-runtime";
 import { expect, it } from "vitest";
 import {
-  type DispatchReplyWithBufferedBlockDispatcherArgs,
-  type TelegramBotDeps,
-  type TelegramMessageContext,
   describeTelegramDispatch,
   createContext,
   createReasoningStreamContext,
@@ -24,7 +19,6 @@ import {
   recordOutboundMessageForPromptContext,
   setupDraftStreams,
   telegramProgressPreview,
-  telegramDepsForTest,
 } from "./bot-message-dispatch.test-harness.js";
 
 describeTelegramDispatch("dispatchTelegramMessage progress-updates", () => {
@@ -261,70 +255,33 @@ describeTelegramDispatch("dispatchTelegramMessage progress-updates", () => {
     expect(draftStream.flush).toHaveBeenCalled();
   });
 
-  it("keeps eight rolling Codex tool rows beneath a preamble with verbose off", async () => {
+  it("keeps eight rolling tool rows beneath a preamble with verbose off", async () => {
     const draftStream = createSequencedDraftStream(2001);
     createTelegramDraftStream.mockReturnValue(draftStream);
-    const deps = {
-      ...telegramDepsForTest,
-      dispatchReplyWithBufferedBlockDispatcher: async (
-        params: DispatchReplyWithBufferedBlockDispatcherArgs,
-      ) =>
-        await dispatchReplyThroughRuntime({
-          ...params,
-          replyResolver: async (_ctx, opts) => {
-            const onAgentEvent = createAgentRunEventHandler({
-              turn: {
-                sessionCtx: { MessageSid: "456" },
-                opts,
-                typingSignals: { signalToolStart: async () => undefined },
-                toolProgressDetail: "raw",
-                applyReplyToMode: (payload: unknown) => payload,
-                sessionKey: "telegram-progress-test",
-              } as Parameters<typeof createAgentRunEventHandler>[0]["turn"],
-              lifecycleBackstop: {
-                emit: () => undefined,
-                getDeferredError: () => undefined,
-                note: () => undefined,
-              },
-              notifyAgentRunStart: () => undefined,
-              sourceRepliesAreToolOnly: false,
-              provider: "openai",
-              model: "gpt-test",
-              notifyUserAboutCompaction: false,
-              onCompactionCompleted: () => 0,
-              messageToolDeliveryState: { toolCallIds: new Set(), completed: false },
-            });
-            await onAgentEvent({
-              stream: "assistant",
-              data: {
-                phase: "commentary",
-                itemId: "preamble-1",
-                text: "I'll make exactly 10 harmless, read-only tool calls.",
-              },
-            });
-            for (let index = 1; index <= 10; index += 1) {
-              await onAgentEvent({
-                stream: "tool",
-                data: {
-                  phase: "start",
-                  name: "exec",
-                  toolCallId: `exec-${index}`,
-                  args: { command: `command-${index}` },
-                },
-              });
-            }
-            return { text: "Done" };
-          },
-        }),
-    } satisfies TelegramBotDeps;
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        await replyOptions?.onReplyStart?.();
+        await replyOptions?.onAssistantMessageStart?.();
+        await replyOptions?.onItemEvent?.({
+          kind: "preamble",
+          itemId: "preamble-1",
+          progressText: "I'll make exactly 10 harmless, read-only tool calls.",
+        });
+        for (let index = 1; index <= 10; index += 1) {
+          await replyOptions?.onToolStart?.({
+            phase: "start",
+            name: "exec",
+            toolCallId: `exec-${index}`,
+            args: { command: `command-${index}` },
+          });
+        }
+        await dispatcherOptions.deliver({ text: "Done" }, { kind: "final" });
+        return { queuedFinal: true };
+      },
+    );
 
     await dispatchWithContext({
-      context: createContext({
-        ctxPayload: {
-          SessionKey: "telegram-progress-test",
-          ChatType: "direct",
-        } as TelegramMessageContext["ctxPayload"],
-      }),
+      context: createContext(),
       cfg: { agents: { defaults: { verboseDefault: "off" } } },
       streamMode: "progress",
       telegramCfg: {
@@ -333,7 +290,6 @@ describeTelegramDispatch("dispatchTelegramMessage progress-updates", () => {
           progress: { commandText: "raw", maxLines: 8, toolProgress: true },
         },
       },
-      telegramDeps: deps,
     });
 
     const rollingPreview = draftStream.updatePreview.mock.calls.at(-1)?.[0];
@@ -660,6 +616,74 @@ describeTelegramDispatch("dispatchTelegramMessage progress-updates", () => {
         "<b>Shelling</b>\nChecking recent context\n<b>🛠️ Exec</b>",
       ),
     );
+  });
+
+  it("keeps fast-mode string progress beneath a Telegram preamble", async () => {
+    const draftStream = createSequencedDraftStream(2001);
+    createTelegramDraftStream.mockReturnValue(draftStream);
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        await replyOptions?.onReplyStart?.();
+        await replyOptions?.onItemEvent?.({
+          kind: "preamble",
+          itemId: "preamble-1",
+          progressText: "Checking recent context",
+        });
+        await dispatcherOptions.deliver(
+          {
+            text: "Fast mode enabled",
+            channelData: { openclawProgressKind: "fast-mode-auto" },
+          },
+          { kind: "tool" },
+        );
+        return { queuedFinal: false };
+      },
+    );
+
+    await dispatchWithContext({
+      context: createContext(),
+      streamMode: "progress",
+      telegramCfg: {
+        streaming: { mode: "progress", progress: { label: "Shelling" } },
+      },
+    });
+
+    expect(draftStream.updatePreview).toHaveBeenLastCalledWith(
+      telegramProgressPreview(
+        "Shelling\n\nChecking recent context\nFast mode enabled",
+        "<b>Shelling</b>\nChecking recent context\nFast mode enabled",
+      ),
+    );
+    expect(deliverReplies).not.toHaveBeenCalled();
+  });
+
+  it("keeps string tool-result progress beneath a Telegram preamble", async () => {
+    const draftStream = createSequencedDraftStream(2001);
+    createTelegramDraftStream.mockReturnValue(draftStream);
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ replyOptions }) => {
+      await replyOptions?.onReplyStart?.();
+      await replyOptions?.onItemEvent?.({
+        kind: "preamble",
+        itemId: "preamble-1",
+        progressText: "Checking recent context",
+      });
+      await replyOptions?.onToolResult?.({ text: "Background task still running" });
+      return { queuedFinal: false };
+    });
+
+    await dispatchWithContext({
+      context: createContext(),
+      streamMode: "progress",
+      telegramCfg: {
+        richMessages: true,
+        streaming: { mode: "progress", progress: { label: "Shelling" } },
+      },
+    });
+
+    const preview = draftStream.updatePreview.mock.calls.at(-1)?.[0];
+    expect(preview?.text).toBe("Shelling\nChecking recent context\nBackground task still running");
+    expect(JSON.stringify(preview?.richMessage)).toContain("Background task still running");
+    expect(deliverReplies).not.toHaveBeenCalled();
   });
 
   it("retracts the Telegram preamble headline by item identity", async () => {

--- a/extensions/telegram/src/bot-message-dispatch.progress-updates.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.progress-updates.test.ts
@@ -1,5 +1,10 @@
+import { createAgentRunEventHandler } from "openclaw/plugin-sdk/plugin-test-runtime";
+import { dispatchReplyWithBufferedBlockDispatcher as dispatchReplyThroughRuntime } from "openclaw/plugin-sdk/reply-dispatch-runtime";
 import { expect, it } from "vitest";
 import {
+  type DispatchReplyWithBufferedBlockDispatcherArgs,
+  type TelegramBotDeps,
+  type TelegramMessageContext,
   describeTelegramDispatch,
   createContext,
   createReasoningStreamContext,
@@ -19,6 +24,7 @@ import {
   recordOutboundMessageForPromptContext,
   setupDraftStreams,
   telegramProgressPreview,
+  telegramDepsForTest,
 } from "./bot-message-dispatch.test-harness.js";
 
 describeTelegramDispatch("dispatchTelegramMessage progress-updates", () => {
@@ -253,6 +259,95 @@ describeTelegramDispatch("dispatchTelegramMessage progress-updates", () => {
       telegramProgressPreview("Shelling\n\n🛠️ Exec", "<b>Shelling</b>\n<b>🛠️ Exec</b>"),
     );
     expect(draftStream.flush).toHaveBeenCalled();
+  });
+
+  it("keeps eight rolling Codex tool rows beneath a preamble with verbose off", async () => {
+    const draftStream = createSequencedDraftStream(2001);
+    createTelegramDraftStream.mockReturnValue(draftStream);
+    const deps = {
+      ...telegramDepsForTest,
+      dispatchReplyWithBufferedBlockDispatcher: async (
+        params: DispatchReplyWithBufferedBlockDispatcherArgs,
+      ) =>
+        await dispatchReplyThroughRuntime({
+          ...params,
+          replyResolver: async (_ctx, opts) => {
+            const onAgentEvent = createAgentRunEventHandler({
+              turn: {
+                sessionCtx: { MessageSid: "456" },
+                opts,
+                typingSignals: { signalToolStart: async () => undefined },
+                toolProgressDetail: "raw",
+                applyReplyToMode: (payload: unknown) => payload,
+                sessionKey: "telegram-progress-test",
+              } as Parameters<typeof createAgentRunEventHandler>[0]["turn"],
+              lifecycleBackstop: {
+                emit: () => undefined,
+                getDeferredError: () => undefined,
+                note: () => undefined,
+              },
+              notifyAgentRunStart: () => undefined,
+              sourceRepliesAreToolOnly: false,
+              provider: "openai",
+              model: "gpt-test",
+              notifyUserAboutCompaction: false,
+              onCompactionCompleted: () => 0,
+              messageToolDeliveryState: { toolCallIds: new Set(), completed: false },
+            });
+            await onAgentEvent({
+              stream: "assistant",
+              data: {
+                phase: "commentary",
+                itemId: "preamble-1",
+                text: "I'll make exactly 10 harmless, read-only tool calls.",
+              },
+            });
+            for (let index = 1; index <= 10; index += 1) {
+              await onAgentEvent({
+                stream: "tool",
+                data: {
+                  phase: "start",
+                  name: "exec",
+                  toolCallId: `exec-${index}`,
+                  args: { command: `command-${index}` },
+                },
+              });
+            }
+            return { text: "Done" };
+          },
+        }),
+    } satisfies TelegramBotDeps;
+
+    await dispatchWithContext({
+      context: createContext({
+        ctxPayload: {
+          SessionKey: "telegram-progress-test",
+          ChatType: "direct",
+        } as TelegramMessageContext["ctxPayload"],
+      }),
+      cfg: { agents: { defaults: { verboseDefault: "off" } } },
+      streamMode: "progress",
+      telegramCfg: {
+        streaming: {
+          mode: "progress",
+          progress: { commandText: "raw", maxLines: 8, toolProgress: true },
+        },
+      },
+      telegramDeps: deps,
+    });
+
+    const rollingPreview = draftStream.updatePreview.mock.calls.at(-1)?.[0];
+    expect(rollingPreview?.text).toContain("I'll make exactly 10 harmless, read-only tool calls.");
+    expect(rollingPreview?.text).not.toContain("<code>command-1</code>");
+    expect(rollingPreview?.text).not.toContain("<code>command-2</code>");
+    for (let index = 3; index <= 10; index += 1) {
+      expect(rollingPreview?.text).toContain(`command-${index}`);
+    }
+    expectDeliveredReply(0, { text: "Done" });
+    const collapsePreview = draftStream.finalizeToPreview.mock.calls.at(-1)?.[0] as
+      | { text?: string }
+      | undefined;
+    expect(collapsePreview?.text).toMatch(/^🛠️ 10 tool calls · ⏱️ \d+s$/u);
   });
 
   it("renders command status without command output in Telegram progress draft previews", async () => {
@@ -561,8 +656,8 @@ describeTelegramDispatch("dispatchTelegramMessage progress-updates", () => {
 
     expect(draftStream.updatePreview).toHaveBeenCalledWith(
       telegramProgressPreview(
-        "Shelling\n\nChecking recent context",
-        "<b>Shelling</b>\nChecking recent context",
+        "Shelling\n\nChecking recent context\n🛠️ Exec",
+        "<b>Shelling</b>\nChecking recent context\n<b>🛠️ Exec</b>",
       ),
     );
   });

--- a/extensions/telegram/src/progress-draft-preview.ts
+++ b/extensions/telegram/src/progress-draft-preview.ts
@@ -151,12 +151,7 @@ function isStatusHeadlineWorkLine(
   if (typeof line === "string") {
     return false;
   }
-  return (
-    line.icon !== "🧠" &&
-    line.label !== "Commentary" &&
-    !line.id?.startsWith("reasoning:") &&
-    !line.id?.startsWith("commentary:")
-  );
+  return !line.id?.startsWith("reasoning:") && !line.id?.startsWith("commentary:");
 }
 
 export function renderTelegramProgressDraftPreview(

--- a/extensions/telegram/src/progress-draft-preview.ts
+++ b/extensions/telegram/src/progress-draft-preview.ts
@@ -50,16 +50,16 @@ function renderTelegramProgressStringLine(text: string): string {
   return renderTelegramHtmlText(clipped);
 }
 
+function renderTelegramProgressText(text: string): string {
+  return text.split(/\r?\n/u).map(renderTelegramProgressStringLine).filter(Boolean).join("<br>");
+}
+
 function renderTelegramProgressLine(line: ChannelProgressDraftCompositorLine): string {
   if (typeof line === "string") {
-    return line.split(/\r?\n/u).map(renderTelegramProgressStringLine).filter(Boolean).join("<br>");
+    return renderTelegramProgressText(line);
   }
-  if (!line.icon && line.label === "Commentary") {
-    return line.text
-      .split(/\r?\n/u)
-      .map(renderTelegramProgressStringLine)
-      .filter(Boolean)
-      .join("<br>");
+  if (!line.icon && (!line.label || line.label === "Commentary")) {
+    return renderTelegramProgressText(line.text);
   }
   const label = [line.icon, line.label].filter(Boolean).join(" ");
   const parts = [`<b>${escapeTelegramProgressHtml(label)}</b>`];
@@ -109,20 +109,20 @@ function markdownLineToRichText(text: string): RichText {
   return clipped;
 }
 
+function progressTextToRichText(text: string): RichText | undefined {
+  const parts = text
+    .split(/\r?\n/u)
+    .map(markdownLineToRichText)
+    .filter((part) => part !== "");
+  return parts.length ? joinRichText(parts, "\n") : undefined;
+}
+
 function progressLineToRichText(line: ChannelProgressDraftCompositorLine): RichText | undefined {
   if (typeof line === "string") {
-    const parts = line
-      .split(/\r?\n/u)
-      .map(markdownLineToRichText)
-      .filter((part) => part !== "");
-    return parts.length ? joinRichText(parts, "\n") : undefined;
+    return progressTextToRichText(line);
   }
-  if (!line.icon && line.label === "Commentary") {
-    const parts = line.text
-      .split(/\r?\n/u)
-      .map(markdownLineToRichText)
-      .filter((part) => part !== "");
-    return parts.length ? joinRichText(parts, "\n") : undefined;
+  if (!line.icon && (!line.label || line.label === "Commentary")) {
+    return progressTextToRichText(line.text);
   }
   const label = [line.icon, line.label].filter(Boolean).join(" ");
   const parts: RichText[] = [boldRichText(label)];

--- a/extensions/telegram/src/progress-draft-preview.ts
+++ b/extensions/telegram/src/progress-draft-preview.ts
@@ -145,6 +145,20 @@ function buildProgressRichBlocks(parts: RichText[]): InputRichBlock[] {
   return [paragraphBlock(joinRichText(parts, "\n"))];
 }
 
+function isStatusHeadlineWorkLine(
+  line: ChannelProgressDraftCompositorLine,
+): line is Exclude<ChannelProgressDraftCompositorLine, string> {
+  if (typeof line === "string") {
+    return false;
+  }
+  return (
+    line.icon !== "🧠" &&
+    line.label !== "Commentary" &&
+    !line.id?.startsWith("reasoning:") &&
+    !line.id?.startsWith("commentary:")
+  );
+}
+
 export function renderTelegramProgressDraftPreview(
   text: string,
   lines: readonly ChannelProgressDraftCompositorLine[],
@@ -157,26 +171,39 @@ export function renderTelegramProgressDraftPreview(
       .split(/\r?\n/u)
       .map((line) => line.trim())
       .filter(Boolean);
+    const workLines = lines.filter(isStatusHeadlineWorkLine);
+    const renderedLines = workLines.map(renderTelegramProgressLine).filter(Boolean);
     if (!richMessages) {
-      const html =
+      const renderedStatusLines =
         statusLines.length > 1
           ? [
               `<b>${escapeTelegramProgressHtml(statusLines[0] ?? "")}</b>`,
               ...statusLines.slice(1).map(renderTelegramProgressStringLine),
-            ].join("<br>")
-          : statusLines.map(renderTelegramProgressStringLine).join("<br>");
-      return { text: html, parseMode: "HTML" };
+            ]
+          : statusLines.map(renderTelegramProgressStringLine);
+      return { text: [...renderedStatusLines, ...renderedLines].join("<br>"), parseMode: "HTML" };
     }
-    const richParts: RichText[] =
+    const richStatusParts: RichText[] =
       statusLines.length > 1
         ? [boldRichText(statusLines[0] ?? ""), ...statusLines.slice(1).map(markdownLineToRichText)]
         : statusLines.map(markdownLineToRichText);
+    const richLineParts = workLines
+      .map(progressLineToRichText)
+      .filter((part): part is RichText => part !== undefined);
+    const plainLineTexts = workLines
+      .map((line) => line.text)
+      .map((line) => line.trim())
+      .filter(Boolean);
+    const plainText = [...statusLines, ...plainLineTexts].join("\n");
     return {
-      text: trimmed,
-      richMessage: buildTelegramRichBlocksPlan(buildProgressRichBlocks(richParts), {
-        skipEntityDetection: true,
-        plainText: trimmed,
-      }).richMessage,
+      text: plainText,
+      richMessage: buildTelegramRichBlocksPlan(
+        buildProgressRichBlocks([...richStatusParts, ...richLineParts]),
+        {
+          skipEntityDetection: true,
+          plainText,
+        },
+      ).richMessage,
     };
   }
   const renderedLines = lines.map(renderTelegramProgressLine).filter(Boolean);

--- a/src/channels/progress-draft-compositor.test.ts
+++ b/src/channels/progress-draft-compositor.test.ts
@@ -389,6 +389,26 @@ describe("createChannelProgressDraftCompositor", () => {
     expect(update).toHaveBeenCalledWith("Reading the workspace.", { flush: true, lines: [] });
   });
 
+  it("publishes rolling tool-line changes beneath a stable preamble headline", async () => {
+    const update = vi.fn();
+    const progress = createChannelProgressDraftCompositor({
+      entry: { streaming: { mode: "progress", progress: { maxLines: 8 } } },
+      mode: "progress",
+      active: true,
+      seed: "test",
+      renderLinesWithPreamble: true,
+      update,
+    });
+
+    await progress.pushPreambleHeadline("Reading the workspace.");
+    await progress.pushToolProgress("🛠️ Exec one", { startImmediately: true });
+    await progress.pushToolProgress("🛠️ Exec two", { startImmediately: true });
+
+    expect(update).toHaveBeenLastCalledWith("Reading the workspace.", {
+      lines: ["🛠️ Exec one", "🛠️ Exec two"],
+    });
+  });
+
   it("rejects control-only preambles without clobbering a valid headline", async () => {
     let nowMs = 0;
     const update = vi.fn();

--- a/src/channels/progress-draft-compositor.test.ts
+++ b/src/channels/progress-draft-compositor.test.ts
@@ -396,7 +396,7 @@ describe("createChannelProgressDraftCompositor", () => {
       mode: "progress",
       active: true,
       seed: "test",
-      renderLinesWithPreamble: true,
+      updateOnLineChange: true,
       update,
     });
 

--- a/src/channels/progress-draft-compositor.ts
+++ b/src/channels/progress-draft-compositor.ts
@@ -51,7 +51,8 @@ export function createChannelProgressDraftCompositor(params: {
   update: (text: string, options?: ChannelProgressDraftUpdateOptions) => Promise<void> | void;
   deleteCurrent?: () => Promise<void> | void;
   tryNativeUpdate?: (text: string) => Promise<boolean> | boolean;
-  renderLinesWithPreamble?: boolean;
+  /** Publish when structured lines change even if the rendered text does not. */
+  updateOnLineChange?: boolean;
   formatLine?: (line: string) => string;
   isEmptyLine?: (line: ChannelProgressDraftCompositorLine | undefined) => boolean;
   shouldStartNow?: (line: ChannelProgressDraftCompositorLine | undefined) => boolean;
@@ -143,11 +144,8 @@ export function createChannelProgressDraftCompositor(params: {
       return false;
     }
     const text = formatDraftText();
-    const headlineLinesChanged =
-      params.renderLinesWithPreamble === true &&
-      Boolean(preambleText) &&
-      lines !== lastRenderedLines;
-    if (!text || (text === lastRenderedText && !headlineLinesChanged)) {
+    const linesChanged = params.updateOnLineChange === true && lines !== lastRenderedLines;
+    if (!text || (text === lastRenderedText && !linesChanged)) {
       return false;
     }
     lastRenderedText = text;

--- a/src/channels/progress-draft-compositor.ts
+++ b/src/channels/progress-draft-compositor.ts
@@ -51,6 +51,7 @@ export function createChannelProgressDraftCompositor(params: {
   update: (text: string, options?: ChannelProgressDraftUpdateOptions) => Promise<void> | void;
   deleteCurrent?: () => Promise<void> | void;
   tryNativeUpdate?: (text: string) => Promise<boolean> | boolean;
+  renderLinesWithPreamble?: boolean;
   formatLine?: (line: string) => string;
   isEmptyLine?: (line: ChannelProgressDraftCompositorLine | undefined) => boolean;
   shouldStartNow?: (line: ChannelProgressDraftCompositorLine | undefined) => boolean;
@@ -88,6 +89,7 @@ export function createChannelProgressDraftCompositor(params: {
   let progressSuppressed = false;
   let lines: ChannelProgressDraftCompositorLine[] = [];
   let lastRenderedText = "";
+  let lastRenderedLines = lines;
   let reasoningRawText = "";
   let lastReasoningLine: string | undefined;
   // Model preambles and narration share the status slot while tool lines keep
@@ -127,6 +129,7 @@ export function createChannelProgressDraftCompositor(params: {
     progressSuppressed = suppressed;
     lines = [];
     lastRenderedText = "";
+    lastRenderedLines = lines;
     reasoningRawText = "";
     lastReasoningLine = undefined;
     preambleText = "";
@@ -140,10 +143,15 @@ export function createChannelProgressDraftCompositor(params: {
       return false;
     }
     const text = formatDraftText();
-    if (!text || text === lastRenderedText) {
+    const headlineLinesChanged =
+      params.renderLinesWithPreamble === true &&
+      Boolean(preambleText) &&
+      lines !== lastRenderedLines;
+    if (!text || (text === lastRenderedText && !headlineLinesChanged)) {
       return false;
     }
     lastRenderedText = text;
+    lastRenderedLines = lines;
     await params.update(text, { ...options, lines: [...lines] });
     return true;
   };
@@ -241,6 +249,7 @@ export function createChannelProgressDraftCompositor(params: {
       if (text && (await params.tryNativeUpdate(text))) {
         lines = nextLines;
         lastRenderedText = text;
+        lastRenderedLines = lines;
         return true;
       }
     }
@@ -254,6 +263,7 @@ export function createChannelProgressDraftCompositor(params: {
         return false;
       }
       lastRenderedText = text;
+      lastRenderedLines = lines;
       await params.update(text, { lines: [...lines] });
       return true;
     }

--- a/src/plugin-sdk/plugin-test-runtime.ts
+++ b/src/plugin-sdk/plugin-test-runtime.ts
@@ -21,6 +21,7 @@ export {
 } from "../infra/diagnostic-events.js";
 export { runWithDiagnosticTraceContext } from "../infra/diagnostic-trace-context.js";
 export { logMessageDispatchStarted, logMessageProcessed } from "../logging/diagnostic.js";
+export { createAgentRunEventHandler } from "../auto-reply/reply/agent-runner-event-handler.js";
 export { resolveBundledExplicitProviderContractsFromPublicArtifacts } from "../plugins/provider-contract-public-artifacts.js";
 export {
   initializeGlobalHookRunner,

--- a/src/plugin-sdk/plugin-test-runtime.ts
+++ b/src/plugin-sdk/plugin-test-runtime.ts
@@ -21,7 +21,6 @@ export {
 } from "../infra/diagnostic-events.js";
 export { runWithDiagnosticTraceContext } from "../infra/diagnostic-trace-context.js";
 export { logMessageDispatchStarted, logMessageProcessed } from "../logging/diagnostic.js";
-export { createAgentRunEventHandler } from "../auto-reply/reply/agent-runner-event-handler.js";
 export { resolveBundledExplicitProviderContractsFromPublicArtifacts } from "../plugins/provider-contract-public-artifacts.js";
 export {
   initializeGlobalHookRunner,


### PR DESCRIPTION
Related: #106026

## What Problem This Solves

Fixes an issue where Telegram users with `streaming.mode: progress` and verbose output off would see only the model's preamble in the ephemeral progress draft while tools were running. The rolling tool rows were masked until the draft collapsed and the permanent final reply arrived.

The first bad commit is `8d465d71b5f72450a1c71b21f6af6e7e99293759` (#106026). It made a model preamble the status headline, but Telegram's status-headline renderer discarded the accumulated line metadata. The shared compositor also deduplicated only on the unchanged headline text, so later tool rows stopped producing draft updates.

## Why This Change Was Made

Telegram now opts into line-aware updates while a preamble is active and renders bounded structured work rows beneath that headline. Reasoning and commentary remain buffered behind the headline, the configured `maxLines` limit still owns the rolling window, and Discord/Mattermost retain their existing behavior because the new compositor capability is opt-in.

Both Telegram HTML previews and rich-message previews use the same filtered work-row set.

## User Impact

A progress-mode Telegram turn now keeps one ephemeral draft showing the preamble plus the newest configured tool rows (for example, the latest 8 of 10 calls). The existing lifecycle is unchanged: the progress window collapses and the permanent final reply is delivered normally.

## Evidence

- Real pre-fix observation: on OpenClaw 2026.7.2, the Telegram client showed a preamble-only ephemeral draft for the reported turn. The corresponding raw Codex rollout contained the commentary preamble followed by all visible tool-start events, proving the events reached OpenClaw but were masked at draft composition/rendering.
- First-bad source proof: #106026 introduced both the status-headline-only Telegram branch and the text-only compositor dedupe. Its parent had no model-preamble headline path.
- Codex contract proof at upstream Codex `87b808bb57`: `codex-rs/app-server-protocol/src/protocol/event_mapping.rs` maps command starts to `item/started`, while `protocol/v2/item.rs` represents them as `CommandExecution`; OpenClaw's Codex projector normalizes those into `stream: "tool"` start/result events. This confirms the producer contract was intact.
- Added a full callback-chain regression: 10 Codex-style tool starts flow through `createAgentRunEventHandler`, the real buffered reply dispatcher, and Telegram progress rendering with verbose off. It asserts the preamble plus only rows 3-10, permanent final delivery, and a 10-tool collapse summary.
- Added shared compositor coverage for successive line changes under an unchanged preamble.
- Updated both preamble orderings: preamble before tools and preamble after a tool start.

Validation:

- `node scripts/run-vitest.mjs extensions/telegram/src/bot-message-dispatch.test.ts --reporter=dot` — 212/212 passed.
- `node scripts/run-vitest.mjs src/channels/progress-draft-compositor.test.ts --reporter=dot` — 29/29 passed.
- Post-rebase focused Telegram + compositor regression run — 6/6 passed.
- `pnpm check` — preflight, all TypeScript projects, lint, formatting, and policy guards passed.
- Post-narrowing `pnpm tsgo:core && pnpm tsgo:extensions && pnpm tsgo:test:root` — passed.
- The prescribed `check-changed` remote delegation did not start because the installed Crabbox binary failed its own version/help sanity check; no code check failed, and GitHub CI remains the remote gate.

Duplicate audit: no open issue or PR matches progress-mode preambles masking rolling tool rows. #93249 is related but different: it fixes in-flight answer preambles in partial streaming and explicitly excludes progress mode.
