### PR TITLE
fix(media-understanding): add 3-level model fallback chain to video buildRequest

### DIFF
--- a/src/media-understanding/runner.entries.ts
+++ b/src/media-understanding/runner.entries.ts
@@ -978,6 +978,16 @@ export async function runProviderEntry(params: {
     workspaceDir: params.workspaceDir,
   });
   const authSource = auth.source ?? `provider:${providerId}`;
+  const model =
+    entry.model?.trim() ||
+    (await import("./defaults.js")).resolveDefaultMediaModel({
+      cfg,
+      providerId,
+      capability: "video",
+      workspaceDir: params.workspaceDir,
+      providerRegistry: params.providerRegistry,
+    }) ||
+    entry.model;
   const buildRequest = (requestAuth: { kind: "api-key"; apiKey: string } | { kind: "none" }) => ({
     buffer: media.buffer,
     fileName: media.fileName,
@@ -990,7 +1000,7 @@ export async function runProviderEntry(params: {
     baseUrl,
     headers,
     request,
-    model: entry.model,
+    model,
     prompt,
     timeoutMs,
     fetchFn,
@@ -1009,7 +1019,7 @@ export async function runProviderEntry(params: {
     attachmentIndex: params.attachmentIndex,
     text: trimOutput(result.text, maxChars),
     provider: providerId,
-    model: result.model ?? entry.model,
+    model: result.model ?? model,
   };
 }
 

--- a/src/media-understanding/runner.video.test.ts
+++ b/src/media-understanding/runner.video.test.ts
@@ -355,7 +355,6 @@ describe("runCapability video provider wiring", () => {
             providers: {
               moonshot: {
                 auth: "api-key",
-                apiKey: "moonshot-key", // pragma: allowlist secret
                 models: [],
               },
             },
@@ -397,61 +396,6 @@ describe("runCapability video provider wiring", () => {
         expect(output.provider).toBe("moonshot");
         expect(output.model).toBe("kimi-k2.5");
         expect(seenModel).toBe("kimi-k2.5");
-      });
-    });
-  });
-
-  it("preserves undefined model for self-defaulting video config entries without defaultModels", async () => {
-    let seenModel: string | undefined;
-
-    await withTempDir({ prefix: "openclaw-video-entry-no-default-" }, async (isolatedAgentDir) => {
-      await withVideoFixture("openclaw-video-entry-no-default", async ({ ctx, media, cache }) => {
-        const cfg = {
-          models: {
-            providers: {
-              moonshot: {
-                auth: "api-key",
-                apiKey: "moonshot-key", // pragma: allowlist secret
-                models: [],
-              },
-            },
-          },
-          tools: {
-            media: {
-              video: {
-                models: [{ provider: "moonshot" }],
-              },
-            },
-          },
-        } as unknown as OpenClawConfig;
-
-        const result = await runCapability({
-          capability: "video",
-          cfg,
-          ctx,
-          agentDir: isolatedAgentDir,
-          attachments: cache,
-          media,
-          providerRegistry: new Map<string, MediaUnderstandingProvider>([
-            [
-              "moonshot",
-              {
-                id: "moonshot",
-                capabilities: ["video"],
-                describeVideo: async (req) => {
-                  seenModel = req.model;
-                  return { text: "moonshot", model: "provider-default" };
-                },
-              },
-            ],
-          ]),
-        });
-
-        expect(result.decision.outcome).toBe("success");
-        const output = requireCapabilityOutput(result, 0);
-        expect(output.provider).toBe("moonshot");
-        expect(output.model).toBe("provider-default");
-        expect(seenModel).toBeUndefined();
       });
     });
   });

--- a/src/media-understanding/runner.video.test.ts
+++ b/src/media-understanding/runner.video.test.ts
@@ -345,6 +345,117 @@ describe("runCapability video provider wiring", () => {
     );
   });
 
+  it("resolves provider registry defaultModels.video when a config entry has no explicit model", async () => {
+    let seenModel: string | undefined;
+
+    await withTempDir({ prefix: "openclaw-video-entry-default-" }, async (isolatedAgentDir) => {
+      await withVideoFixture("openclaw-video-entry-default", async ({ ctx, media, cache }) => {
+        const cfg = {
+          models: {
+            providers: {
+              moonshot: {
+                auth: "api-key",
+                apiKey: "moonshot-key", // pragma: allowlist secret
+                models: [],
+              },
+            },
+          },
+          tools: {
+            media: {
+              video: {
+                models: [{ provider: "moonshot" }],
+              },
+            },
+          },
+        } as unknown as OpenClawConfig;
+
+        const result = await runCapability({
+          capability: "video",
+          cfg,
+          ctx,
+          agentDir: isolatedAgentDir,
+          attachments: cache,
+          media,
+          providerRegistry: new Map<string, MediaUnderstandingProvider>([
+            [
+              "moonshot",
+              {
+                id: "moonshot",
+                capabilities: ["video"],
+                defaultModels: { video: "kimi-k2.5" },
+                describeVideo: async (req) => {
+                  seenModel = req.model;
+                  return { text: "moonshot", model: req.model };
+                },
+              },
+            ],
+          ]),
+        });
+
+        expect(result.decision.outcome).toBe("success");
+        const output = requireCapabilityOutput(result, 0);
+        expect(output.provider).toBe("moonshot");
+        expect(output.model).toBe("kimi-k2.5");
+        expect(seenModel).toBe("kimi-k2.5");
+      });
+    });
+  });
+
+  it("preserves undefined model for self-defaulting video config entries without defaultModels", async () => {
+    let seenModel: string | undefined;
+
+    await withTempDir({ prefix: "openclaw-video-entry-no-default-" }, async (isolatedAgentDir) => {
+      await withVideoFixture("openclaw-video-entry-no-default", async ({ ctx, media, cache }) => {
+        const cfg = {
+          models: {
+            providers: {
+              moonshot: {
+                auth: "api-key",
+                apiKey: "moonshot-key", // pragma: allowlist secret
+                models: [],
+              },
+            },
+          },
+          tools: {
+            media: {
+              video: {
+                models: [{ provider: "moonshot" }],
+              },
+            },
+          },
+        } as unknown as OpenClawConfig;
+
+        const result = await runCapability({
+          capability: "video",
+          cfg,
+          ctx,
+          agentDir: isolatedAgentDir,
+          attachments: cache,
+          media,
+          providerRegistry: new Map<string, MediaUnderstandingProvider>([
+            [
+              "moonshot",
+              {
+                id: "moonshot",
+                capabilities: ["video"],
+                describeVideo: async (req) => {
+                  seenModel = req.model;
+                  return { text: "moonshot", model: "provider-default" };
+                },
+              },
+            ],
+          ]),
+        });
+
+        expect(result.decision.outcome).toBe("success");
+        const output = requireCapabilityOutput(result, 0);
+        expect(output.provider).toBe("moonshot");
+        expect(output.model).toBe("provider-default");
+        expect(seenModel).toBeUndefined();
+      });
+    });
+  });
+
   it("does not use provider api config as video auth modelApi", async () => {
     const modelAuth = await import("../agents/model-auth.js");
     const resolveApiKeyForProvider = vi.mocked(modelAuth.resolveApiKeyForProvider);


### PR DESCRIPTION
## What Problem This Solves

Explicit video-understanding entries without a `model` did not apply the provider registry's declared `defaultModels.video` value before execution. Auto-selected video entries already resolve that metadata, and the sibling audio path resolves its provider default.

This was a model-selection and reporting inconsistency, not a demonstrated general provider outage. The bundled Google, Moonshot, and Qwen implementations already self-default when the request omits a model.

## Why This Change Was Made

The video branch now resolves models in this order:

1. A non-empty explicit entry model.
2. The prepared provider registry's canonical video default.
3. The original optional entry value, preserving self-defaulting providers without declared metadata.

The resolved value is sent to `describeVideo` and used in the capability output when the provider does not report a model. No config key or new default surface is added.

## User Impact

Model-less explicit video entries now use and report the same declared provider default as OpenClaw's automatic video-selection path. Explicit models remain authoritative, and providers without default metadata keep their existing self-defaulting behavior.

## Evidence

- `node scripts/run-vitest.mjs src/media-understanding/runner.video.test.ts`: 7/7 passed after the final rebase.
- The focused regression verifies that a configured model-less entry receives `defaultModels.video` from the supplied provider registry and reports that model.
- Existing adjacent coverage verifies explicit models, auto-selected defaults, and self-defaulting providers.
- [Hosted changed gate](https://github.com/openclaw/openclaw/actions/runs/29498418230): passed, including formatting, types, lint, dependency, SDK, architecture, and database-first guards.
- Fresh full-branch autoreview: no findings, confidence 0.93.

## Maintainer Cleanup

Rebased onto current main at review time. Removed a duplicate self-defaulting test and its unnecessary dummy credential; final surface is +67/-2 instead of +123/-2.
