### PR TITLE
fix(memory-core): write MEMORY.md atomically during short-term promotion

### DIFF
--- a/extensions/memory-core/src/short-term-promotion.test.ts
+++ b/extensions/memory-core/src/short-term-promotion.test.ts
@@ -3284,6 +3284,10 @@ describe("short-term promotion", () => {
         const memoryPath = path.join(workspaceDir, "MEMORY.md");
         const seeded = "# Long-Term Memory\n\nSome small existing content.\n";
         await fs.writeFile(memoryPath, seeded, "utf-8");
+        if (process.platform !== "win32") {
+          await fs.chmod(workspaceDir, 0o750);
+          await fs.chmod(memoryPath, 0o640);
+        }
 
         await recordShortTermRecalls({
           workspaceDir,
@@ -3321,6 +3325,10 @@ describe("short-term promotion", () => {
         expect(applied.compactedDates).toEqual([]);
         const memoryText = await fs.readFile(memoryPath, "utf-8");
         expect(memoryText).toContain("Some small existing content.");
+        if (process.platform !== "win32") {
+          expect((await fs.stat(workspaceDir)).mode & 0o7777).toBe(0o750);
+          expect((await fs.stat(memoryPath)).mode & 0o7777).toBe(0o640);
+        }
       });
     });
   });
@@ -3339,7 +3347,6 @@ describe("short-term promotion", () => {
         const filler = "pad line filler content ".repeat(9_000);
         const seeded = `# Long-Term Memory\n\n${filler}\n- ${sentinel}\n`;
         await fs.writeFile(memoryPath, seeded, "utf-8");
-        const seededBytes = Buffer.byteLength(seeded);
 
         await recordShortTermRecalls({
           workspaceDir,
@@ -3397,8 +3404,20 @@ describe("short-term promotion", () => {
         ).rejects.toMatchObject({ code: "EFBIG" });
 
         const after = await fs.readFile(memoryPath, "utf-8");
-        expect(after).toContain(sentinel);
-        expect(Buffer.byteLength(after)).toBe(seededBytes);
+        expect(after).toBe(seeded);
+        await expect(
+          rankShortTermPromotionCandidates({
+            workspaceDir,
+            minScore: 0,
+            minRecallCount: 0,
+            minUniqueQueries: 0,
+          }),
+        ).resolves.toHaveLength(1);
+        expect(
+          (await fs.readdir(workspaceDir)).filter((entry) =>
+            entry.startsWith("MEMORY.md.promotion"),
+          ),
+        ).toEqual([]);
       });
     });
   });

--- a/extensions/memory-core/src/short-term-promotion.test.ts
+++ b/extensions/memory-core/src/short-term-promotion.test.ts
@@ -3324,6 +3324,85 @@ describe("short-term promotion", () => {
       });
     });
   });
+
+  describe("MEMORY.md atomic promotion write", () => {
+    it("preserves the existing MEMORY.md when the promotion write fails mid-flight", async () => {
+      await withTempWorkspace(async (workspaceDir) => {
+        await writeDailyMemoryNote(workspaceDir, "2026-04-29", [
+          "Notes",
+          "",
+          "Rotate the staging Postgres credentials before next deploy.",
+        ]);
+
+        const memoryPath = path.join(workspaceDir, "MEMORY.md");
+        const sentinel = "FINAL-USER-MEMORY-SENTINEL-do-not-lose";
+        const filler = "pad line filler content ".repeat(9_000);
+        const seeded = `# Long-Term Memory\n\n${filler}\n- ${sentinel}\n`;
+        await fs.writeFile(memoryPath, seeded, "utf-8");
+        const seededBytes = Buffer.byteLength(seeded);
+
+        await recordShortTermRecalls({
+          workspaceDir,
+          query: "rotate creds",
+          nowMs: Date.parse("2026-04-29T10:00:00.000Z"),
+          results: [
+            {
+              path: "memory/2026-04-29.md",
+              startLine: 3,
+              endLine: 3,
+              score: 0.96,
+              snippet: "Rotate the staging Postgres credentials before next deploy.",
+              source: "memory",
+            },
+          ],
+        });
+
+        const ranked = await rankShortTermPromotionCandidates({
+          workspaceDir,
+          minScore: 0,
+          minRecallCount: 0,
+          minUniqueQueries: 0,
+        });
+
+        const truncateAt = 51_200;
+        const originalWriteFile = fs.writeFile.bind(fs);
+        vi.spyOn(fs, "writeFile").mockImplementation((async (
+          target: Parameters<typeof fs.writeFile>[0],
+          data: Parameters<typeof fs.writeFile>[1],
+          options?: Parameters<typeof fs.writeFile>[2],
+        ) => {
+          const targetPath =
+            typeof target === "string" ? target : target instanceof URL ? target.pathname : "";
+          if (targetPath && path.basename(targetPath).startsWith("MEMORY.md")) {
+            const text =
+              typeof data === "string" ? data : Buffer.from(data as Uint8Array).toString();
+            await originalWriteFile(target, text.slice(0, truncateAt), options);
+            throw Object.assign(new Error("EFBIG: file too large, write"), {
+              code: "EFBIG",
+            });
+          }
+          return originalWriteFile(target, data, options);
+        }) as typeof fs.writeFile);
+
+        await expect(
+          applyShortTermPromotions({
+            workspaceDir,
+            candidates: ranked,
+            minScore: 0,
+            minRecallCount: 0,
+            minUniqueQueries: 0,
+            nowMs: Date.parse("2026-04-29T10:00:00.000Z"),
+            memoryFileMaxChars: 5_000_000,
+          }),
+        ).rejects.toMatchObject({ code: "EFBIG" });
+
+        const after = await fs.readFile(memoryPath, "utf-8");
+        expect(after).toContain(sentinel);
+        expect(Buffer.byteLength(after)).toBe(seededBytes);
+      });
+    });
+  });
+
   it("shows signalCount instead of just recallCount in promotion annotations", async () => {
     await withTempWorkspace(async (workspaceDir) => {
       const nowMs = Date.parse("2026-05-28T10:00:00.000Z");

--- a/extensions/memory-core/src/short-term-promotion.ts
+++ b/extensions/memory-core/src/short-term-promotion.ts
@@ -2531,12 +2531,16 @@ export async function applyShortTermPromotions(
       compactedDates = compaction.droppedDates;
       const baseMemory = compaction.compacted;
       const header = baseMemory.trim().length > 0 ? "" : "# Long-Term Memory\n\n";
+      const workspaceMode = (await fs.stat(workspaceDir)).mode & 0o7777;
       await replaceFileAtomic({
         filePath: memoryPath,
         content: `${header}${withTrailingNewline(baseMemory)}${section}`,
+        dirMode: workspaceMode,
         mode: 0o600,
         preserveExistingMode: true,
         tempPrefix: `${path.basename(memoryPath)}.promotion`,
+        syncTempFile: true,
+        syncParentDir: true,
         throwOnCleanupError: true,
       });
     }

--- a/extensions/memory-core/src/short-term-promotion.ts
+++ b/extensions/memory-core/src/short-term-promotion.ts
@@ -12,6 +12,7 @@ import {
 } from "openclaw/plugin-sdk/memory-core-host-status";
 import { appendMemoryHostEvent } from "openclaw/plugin-sdk/memory-host-events";
 import { sleep } from "openclaw/plugin-sdk/runtime-env";
+import { replaceFileAtomic } from "openclaw/plugin-sdk/security-runtime";
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeStringEntries,
@@ -2530,11 +2531,14 @@ export async function applyShortTermPromotions(
       compactedDates = compaction.droppedDates;
       const baseMemory = compaction.compacted;
       const header = baseMemory.trim().length > 0 ? "" : "# Long-Term Memory\n\n";
-      await fs.writeFile(
-        memoryPath,
-        `${header}${withTrailingNewline(baseMemory)}${section}`,
-        "utf-8",
-      );
+      await replaceFileAtomic({
+        filePath: memoryPath,
+        content: `${header}${withTrailingNewline(baseMemory)}${section}`,
+        mode: 0o600,
+        preserveExistingMode: true,
+        tempPrefix: `${path.basename(memoryPath)}.promotion`,
+        throwOnCleanupError: true,
+      });
     }
 
     for (const candidate of rehydratedSelected) {


### PR DESCRIPTION
## Summary
Scheduled deep-memory promotion can permanently lose user long-term memory. `applyShortTermPromotions` rewrites `MEMORY.md` with a single non-atomic `fs.writeFile`, which truncates the file to zero before streaming the new content. If the OS write fails part way through (for example `EFBIG` on a size-limited or full volume), `MEMORY.md` is left truncated to the bytes written before the failure, and everything past that point is gone. The dreaming cron path ranks candidates and invokes this writer automatically (`extensions/memory-core/src/dreaming.ts`), so this happens with no user in the loop. Because the recall store is only updated after the write, the promotion stays eligible and the next run reads the already-truncated file.

## Root cause
`extensions/memory-core/src/short-term-promotion.ts:2533`, inside `applyShortTermPromotions`:

```ts
// before
const header = baseMemory.trim().length > 0 ? "" : "# Long-Term Memory\n\n";
await fs.writeFile(
  memoryPath,
  `${header}${withTrailingNewline(baseMemory)}${section}`,
  "utf-8",
);
```

`fs.writeFile` opens `MEMORY.md` with the truncate flag and then writes. A failure between the truncate and the completed write leaves a partially written, corrupted file in place.

## Fix
Write through the canonical atomic primitive so the target file is only ever replaced by a fully written temp file:

```ts
// after
const header = baseMemory.trim().length > 0 ? "" : "# Long-Term Memory\n\n";
await replaceFileAtomic({
  filePath: memoryPath,
  content: `${header}${withTrailingNewline(baseMemory)}${section}`,
  mode: 0o600,
  preserveExistingMode: true,
  tempPrefix: `${path.basename(memoryPath)}.promotion`,
  throwOnCleanupError: true,
});
```

`replaceFileAtomic` writes to a temp file, fsyncs, and renames over the target. If the write fails, the temp file is discarded and the existing `MEMORY.md` is never touched. On success the content is byte-for-byte identical to the previous writer, and `preserveExistingMode` keeps the mode of any existing file.

## Why this is the right boundary
`applyShortTermPromotions` owns the `MEMORY.md` write, and `replaceFileAtomic` (`src/infra/replace-file.ts`, re-exported through `openclaw/plugin-sdk/security-runtime`) is the repository's durable-write primitive for exactly this failure class. The same memory-core extension already writes its sibling `DREAMS.md` atomically through this helper (`extensions/memory-core/src/dreaming-dreams-file.ts`); `MEMORY.md` was the one file in the subsystem still using a raw write. This is the only `MEMORY.md` writer in the promotion path, so there is no sibling surface left unaddressed.

Related but distinct: `#95598` and `#80916` are open and also touch `short-term-promotion.ts`, but both change candidate filtering (which snippets get promoted); neither touches the `applyShortTermPromotions` write path, so there is no line overlap. `#88029` (merged) applied the same atomic-write fix to `auth.json` for the identical interrupted-write corruption class. I did not find any issue or PR covering the durability of the `MEMORY.md` promotion write. Note: this write was last set by `#61540` (2026-04-06), not by `688a129e` (which is an unrelated Docker planning change).

## Verification
- `node scripts/run-vitest.mjs extensions/memory-core/src/short-term-promotion.test.ts` passes 72/72 (71 existing plus one new).
- The new colocated test fails on pristine `origin/main` (the trailing sentinel is truncated away) and passes with the patch.
- `node scripts/run-oxlint.mjs` and `oxfmt --check` are clean on both changed files.
- `node scripts/run-tsgo.mjs -p tsconfig.core.json` passes.

## Real behavior proof
Behavior addressed: scheduled promotion truncates `MEMORY.md` and permanently drops user long-term memory when the OS write fails part way through.
Real environment tested: the real `applyShortTermPromotions` runtime was driven on pristine `origin/main` 9497450 and on the patched tree with identical inputs. The on-disk `MEMORY.md`, the promotion lock, the recall store, the candidate ranking, and the budget compaction all stayed real; only the `fs.writeFile` syscall was forced to fail with `EFBIG` after a partial write, to reproduce the reported OS condition at its narrowest seam.
Exact steps or command run after this patch: seed a 216062-byte `MEMORY.md` whose last line is a unique sentinel, record a real recall for a daily note, rank the candidate, then invoke `applyShortTermPromotions` with the injected `EFBIG` write failure and read `MEMORY.md` back from disk (plus a re-rank to show eligibility).
Evidence after fix:
```
# BEFORE (pristine main 9497450)
{"errorCode":"EFBIG","beforeBytes":216062,"afterBytes":51200,"tailSurvived":false}
{"eligibleCandidates":1}
# AFTER (this patch, identical inputs)
{"errorCode":"EFBIG","beforeBytes":216062,"afterBytes":216062,"tailSurvived":true}
{"eligibleCandidates":1}
```
Observed result after fix: the failing write no longer changes `MEMORY.md` on disk. The file stays at 216062 bytes with its trailing user-memory sentinel intact, instead of collapsing to 51200 bytes with the tail gone, and the promotion stays eligible so it is retried on the next run from an intact file.
What was not tested: no real filesystem raised `EFBIG` from an actual full or size-limited volume; the failure was injected at the `fs.writeFile` boundary. The full repository build was not run.
## Maintainer hardening

After rebasing, maintainer review enabled the shared primitive's temp-file and parent-directory synchronization and preserved the existing workspace directory mode. Regression coverage now also proves exact byte preservation, promotion retry eligibility, temp cleanup after failure, and workspace/file mode preservation on success.