### PR TITLE
fix(agents): clear acceptedSessionSpawns on compaction retry

### DIFF
--- a/src/agents/embedded-agent-subscribe.ts
+++ b/src/agents/embedded-agent-subscribe.ts
@@ -1261,6 +1261,7 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
     pendingMessagingTexts.clear();
     pendingMessagingTargets.clear();
     state.successfulCronAdds = 0;
+    state.acceptedSessionSpawns.length = 0;
     state.heartbeatToolResponse = undefined;
     state.pendingMessagingMediaUrls.clear();
     state.pendingToolMediaUrls = [];


### PR DESCRIPTION
## What Problem This Solves

Fixes a memory leak and permanent compaction block in embedded-agent sessions that use `sessions_spawn`. The `acceptedSessionSpawns` array grew unboundedly with each spawn call, and its non-empty state prevented conversation compaction from ever running again.

## Why This Change Was Made

`resetForCompactionRetry` is called to reset replay state before each compaction retry. It reset 20+ collections (`assistantTexts`, `toolMetas`, `messagingToolSentTexts`, etc.) but omitted `state.acceptedSessionSpawns`. The compaction guard at the top of the function checks `state.acceptedSessionSpawns.length > 0` and skips compaction when spawns exist — since the array was never cleared, compaction was permanently blocked after the first spawn.

## User Impact

Users of `sessions_spawn` (sub-session tool) will no longer experience unbounded conversation history growth from blocked compaction. Non-users of `sessions_spawn` are unaffected.

## Evidence

- **Real environment tested**: Linux, Node 24, branch `fix/bug-042-accepted-session-spawns-leak`
- **Exact steps or command run after this patch**:

  ```
  node scripts/run-vitest.mjs agents/embedded-agent-subscribe
  ```

- **Evidence after fix**:

  ```console
  $ node scripts/run-vitest.mjs agents/embedded-agent-subscribe
  Test Files  2 passed (2)
      Tests  40 passed (40)
  ```

- **Observed result after fix**: All 40 embedded-agent-subscribe tests pass. The fix is a single-line addition (`state.acceptedSessionSpawns.length = 0;`) placed alongside the other array resets in `resetForCompactionRetry`.
- **What was not tested**: No real E2E session with `sessions_spawn` was tested; the change is purely additive alongside 20+ identical reset lines.

### Real behavior proof

The fix mirrors the existing pattern for `messagingToolSentTexts.length = 0`, `toolMetas.length = 0`, and every other collection reset in the same function. The array lifecycle (initialized as `[]` at state creation, pushed on usage, cleared on reset) is identical to the sibling collections.

### Collision check

Searched open PRs touching `embedded-agent-subscribe.ts` and merged PRs for "acceptedSessionSpawns" — no collision.

---

AI-assisted.
