### PR TITLE
fix(feishu): honor abortSignal in drive comment reply retry loop

### DIFF
--- a/extensions/feishu/src/comment-handler.test.ts
+++ b/extensions/feishu/src/comment-handler.test.ts
@@ -252,16 +252,22 @@ describe("handleFeishuCommentEvent", () => {
   });
 
   it("records a comment-thread inbound context with a routable Feishu origin", async () => {
+    const abortController = new AbortController();
     await handleFeishuCommentEvent({
       cfg: buildConfig(),
       accountId: "default",
       event: { event_id: "evt_1" },
       botOpenId: "ou_bot",
+      abortSignal: abortController.signal,
       runtime: {
         log: vi.fn(),
         error: vi.fn(),
       } as never,
     });
+
+    expect(resolveDriveCommentEventTurnMock).toHaveBeenCalledWith(
+      expect.objectContaining({ abortSignal: abortController.signal }),
+    );
 
     const runtime = (await import("./runtime.js")).getFeishuRuntime();
     const finalizeInboundContext = runtime.channel.reply.finalizeInboundContext as ReturnType<

--- a/extensions/feishu/src/comment-handler.ts
+++ b/extensions/feishu/src/comment-handler.ts
@@ -25,6 +25,7 @@ type HandleFeishuCommentEventParams = {
   runtime?: RuntimeEnv;
   event: FeishuDriveCommentNoticeEvent;
   botOpenId?: string;
+  abortSignal?: AbortSignal;
 };
 
 function buildCommentSessionKey(params: {
@@ -64,6 +65,7 @@ export async function handleFeishuCommentEvent(
     event: params.event,
     botOpenId: params.botOpenId,
     logger: log,
+    abortSignal: params.abortSignal,
   });
   if (!turn) {
     log(

--- a/extensions/feishu/src/monitor.account.ts
+++ b/extensions/feishu/src/monitor.account.ts
@@ -167,11 +167,7 @@ type RegisterEventHandlersContext = {
   runtime?: RuntimeEnv;
   chatHistories: Map<string, HistoryEntry[]>;
   fireAndForget?: boolean;
-  /**
-   * Owning monitor account abort signal. Handlers that run retry/polling
-   * loops must propagate this so an account teardown short-circuits the
-   * loop instead of running through its full delay budget.
-   */
+  /** Owning account signal; retrying handlers must propagate it. */
   abortSignal?: AbortSignal;
   /**
    * Optional status sink. When provided, the message handler will publish

--- a/extensions/feishu/src/monitor.account.ts
+++ b/extensions/feishu/src/monitor.account.ts
@@ -168,6 +168,12 @@ type RegisterEventHandlersContext = {
   chatHistories: Map<string, HistoryEntry[]>;
   fireAndForget?: boolean;
   /**
+   * Owning monitor account abort signal. Handlers that run retry/polling
+   * loops must propagate this so an account teardown short-circuits the
+   * loop instead of running through its full delay budget.
+   */
+  abortSignal?: AbortSignal;
+  /**
    * Optional status sink. When provided, the message handler will publish
    * `lastEventAt` on every inbound message for message recency. Transport
    * liveness is published by the transport layer.
@@ -274,7 +280,8 @@ function registerEventHandlers(
   eventDispatcher: Lark.EventDispatcher,
   context: RegisterEventHandlersContext,
 ): void {
-  const { cfg, accountId, channelRuntime, runtime, chatHistories, fireAndForget } = context;
+  const { cfg, accountId, channelRuntime, runtime, chatHistories, fireAndForget, abortSignal } =
+    context;
   const log = runtime?.log ?? console.log;
   const error = runtime?.error ?? console.error;
   const runFeishuHandler = async (params: { task: () => Promise<void>; errorMessage: string }) => {
@@ -341,6 +348,7 @@ function registerEventHandlers(
       accountId,
       runtime,
       fireAndForget,
+      abortSignal,
     }),
     "im.message.reaction.created_v1": async (data) => {
       await runFeishuHandler({
@@ -506,6 +514,7 @@ export async function monitorSingleAccount(params: MonitorSingleAccountParams): 
       runtime,
       chatHistories,
       fireAndForget: params.fireAndForget ?? true,
+      abortSignal,
       ...(params.statusSink ? { statusSink: params.statusSink } : {}),
     });
 

--- a/extensions/feishu/src/monitor.comment-notice-handler.ts
+++ b/extensions/feishu/src/monitor.comment-notice-handler.ts
@@ -24,8 +24,9 @@ export function createFeishuDriveCommentNoticeHandler(params: {
   runtime?: RuntimeEnv;
   fireAndForget?: boolean;
   getBotOpenId?: (accountId: string) => string | undefined;
+  abortSignal?: AbortSignal;
 }): (data: unknown) => Promise<void> {
-  const { cfg, accountId, runtime, fireAndForget } = params;
+  const { cfg, accountId, runtime, fireAndForget, abortSignal } = params;
   const log = runtime?.log ?? console.log;
   const error = runtime?.error ?? console.error;
   const enqueue = createSequentialQueue();
@@ -84,6 +85,7 @@ export function createFeishuDriveCommentNoticeHandler(params: {
             event,
             botOpenId: getBotOpenId(accountId),
             runtime,
+            abortSignal,
           });
         });
         await processingClaim?.commit();

--- a/extensions/feishu/src/monitor.comment.test.ts
+++ b/extensions/feishu/src/monitor.comment.test.ts
@@ -735,7 +735,7 @@ describe("resolveDriveCommentEventTurn", () => {
   });
 
   it("retries comment reply lookup when the requested reply is not immediately visible", async () => {
-    const waitMs = vi.fn(async () => {});
+    const waitMs = vi.fn(async () => true);
     const client = makeOpenApiClient({
       includeTargetReplyInBatch: false,
       repliesSequence: [
@@ -781,14 +781,63 @@ describe("resolveDriveCommentEventTurn", () => {
     expect(turn?.targetReplyText).toBe("Insert a sentence below this paragraph");
     expect(turn?.prompt).toContain("Insert a sentence below this paragraph");
     expect(waitMs).toHaveBeenCalledTimes(2);
-    expect(waitMs).toHaveBeenNthCalledWith(1, 1000);
-    expect(waitMs).toHaveBeenNthCalledWith(2, 1000);
+    expect(waitMs).toHaveBeenNthCalledWith(1, 1000, undefined);
+    expect(waitMs).toHaveBeenNthCalledWith(2, 1000, undefined);
     expect(
       client.request.mock.calls.filter(
         ([request]: [{ method: string; url: string }]) =>
           request.method === "GET" && request.url.includes("/replies"),
       ),
     ).toHaveLength(3);
+  });
+
+  it("stops the comment reply retry loop when the owning abortSignal fires", async () => {
+    const abortController = new AbortController();
+    // Simulate the owning monitor account calling abort mid-retry: the first
+    // waitMs returns false (abort observed), the loop must exit immediately,
+    // and the remaining attempts must not enqueue another fetchDriveCommentReplies.
+    const waitMs = vi.fn(async (_ms: number, signal?: AbortSignal) => {
+      if (signal?.aborted) {
+        return false;
+      }
+      abortController.abort();
+      return false;
+    });
+    const client = makeOpenApiClient({
+      includeTargetReplyInBatch: false,
+      repliesSequence: [
+        [
+          {
+            reply_id: "7623358762136374451",
+            text: "Earlier assistant summary",
+          },
+        ],
+      ],
+    });
+    const turn = await resolveDriveCommentEventTurn({
+      cfg: buildMonitorConfig(),
+      accountId: "default",
+      event: makeDriveCommentEvent({ reply_id: "7623358762999999999" }),
+      botOpenId: "ou_bot",
+      createClient: () => client as never,
+      abortSignal: abortController.signal,
+      waitMs,
+    });
+    expect(turn).not.toBeNull();
+    // First delay consumed the abort; no further waitMs calls and no further
+    // replies fetches after the initial miss.
+    expect(waitMs).toHaveBeenCalledTimes(1);
+    expect(waitMs).toHaveBeenNthCalledWith(1, 1000, abortController.signal);
+    expect(
+      client.request.mock.calls.filter(
+        ([request]: [{ method: string; url: string }]) =>
+          request.method === "GET" && request.url.includes("/replies"),
+      ),
+    ).toHaveLength(1);
+    // The requested reply never resolved (loop broke before retry could find it),
+    // so targetReplyText stays unset — the only fetched reply is the "earlier"
+    // one that is not the requested reply_id.
+    expect(turn?.targetReplyText).toBeUndefined();
   });
 
   it("ignores self-authored comment notices", async () => {

--- a/extensions/feishu/src/monitor.comment.test.ts
+++ b/extensions/feishu/src/monitor.comment.test.ts
@@ -30,6 +30,10 @@ afterAll(() => {
   vi.resetModules();
 });
 
+afterEach(() => {
+  vi.useRealTimers();
+});
+
 function buildMonitorConfig(): ClawdbotConfig {
   return {
     channels: {
@@ -201,7 +205,9 @@ function makeOpenApiClient(params: {
   };
 }
 
-async function setupCommentMonitorHandler(): Promise<(data: unknown) => Promise<void>> {
+async function setupCommentMonitorHandler(
+  abortSignal?: AbortSignal,
+): Promise<(data: unknown) => Promise<void>> {
   lastRuntime = createNonExitingRuntimeEnv();
 
   return createFeishuDriveCommentNoticeHandler({
@@ -210,6 +216,7 @@ async function setupCommentMonitorHandler(): Promise<(data: unknown) => Promise<
     runtime: lastRuntime,
     fireAndForget: true,
     getBotOpenId: () => "ou_bot",
+    abortSignal,
   });
 }
 
@@ -792,17 +799,8 @@ describe("resolveDriveCommentEventTurn", () => {
   });
 
   it("stops the comment reply retry loop when the owning abortSignal fires", async () => {
+    vi.useFakeTimers();
     const abortController = new AbortController();
-    // Simulate the owning monitor account calling abort mid-retry: the first
-    // waitMs returns false (abort observed), the loop must exit immediately,
-    // and the remaining attempts must not enqueue another fetchDriveCommentReplies.
-    const waitMs = vi.fn(async (_ms: number, signal?: AbortSignal) => {
-      if (signal?.aborted) {
-        return false;
-      }
-      abortController.abort();
-      return false;
-    });
     const client = makeOpenApiClient({
       includeTargetReplyInBatch: false,
       repliesSequence: [
@@ -814,29 +812,29 @@ describe("resolveDriveCommentEventTurn", () => {
         ],
       ],
     });
-    const turn = await resolveDriveCommentEventTurn({
+    const turnPromise = resolveDriveCommentEventTurn({
       cfg: buildMonitorConfig(),
       accountId: "default",
       event: makeDriveCommentEvent({ reply_id: "7623358762999999999" }),
       botOpenId: "ou_bot",
       createClient: () => client as never,
       abortSignal: abortController.signal,
-      waitMs,
     });
+
+    await vi.waitFor(() => {
+      expect(vi.getTimerCount()).toBe(1);
+    });
+    abortController.abort();
+    const turn = await turnPromise;
+
     expect(turn).not.toBeNull();
-    // First delay consumed the abort; no further waitMs calls and no further
-    // replies fetches after the initial miss.
-    expect(waitMs).toHaveBeenCalledTimes(1);
-    expect(waitMs).toHaveBeenNthCalledWith(1, 1000, abortController.signal);
+    expect(vi.getTimerCount()).toBe(0);
     expect(
       client.request.mock.calls.filter(
         ([request]: [{ method: string; url: string }]) =>
           request.method === "GET" && request.url.includes("/replies"),
       ),
     ).toHaveLength(1);
-    // The requested reply never resolved (loop broke before retry could find it),
-    // so targetReplyText stays unset — the only fetched reply is the "earlier"
-    // one that is not the requested reply_id.
     expect(turn?.targetReplyText).toBeUndefined();
   });
 
@@ -892,7 +890,8 @@ describe("drive.notice.comment_add_v1 monitor handler", () => {
   });
 
   it("dispatches comment notices through handleFeishuCommentEvent", async () => {
-    const onComment = await setupCommentMonitorHandler();
+    const abortController = new AbortController();
+    const onComment = await setupCommentMonitorHandler(abortController.signal);
 
     await onComment(makeDriveCommentEvent());
 
@@ -901,11 +900,13 @@ describe("drive.notice.comment_add_v1 monitor handler", () => {
       | {
           accountId?: string;
           botOpenId?: string;
+          abortSignal?: AbortSignal;
           event?: { comment_id?: string; event_id?: string };
         }
       | undefined;
     expect(handleArgs?.accountId).toBe("default");
     expect(handleArgs?.botOpenId).toBe("ou_bot");
+    expect(handleArgs?.abortSignal).toBe(abortController.signal);
     expect(handleArgs?.event?.event_id).toBe("10d9d60b990db39f96a4c2fd357fb877");
     expect(handleArgs?.event?.comment_id).toBe("7623358762119646411");
   });

--- a/extensions/feishu/src/monitor.comment.ts
+++ b/extensions/feishu/src/monitor.comment.ts
@@ -3,7 +3,7 @@ import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { asBoolean as readBoolean } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { sliceUtf16Safe, truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import type { ClawdbotConfig } from "../runtime-api.js";
-import { raceWithTimeoutAndAbort } from "./async.js";
+import { raceWithTimeoutAndAbort, waitForAbortableDelay } from "./async.js";
 import { createFeishuClient } from "./client.js";
 import {
   encodeQuery,
@@ -60,7 +60,8 @@ type ResolveDriveCommentEventParams = {
   createClient?: (account: ResolvedFeishuAccount) => FeishuRequestClient;
   verificationTimeoutMs?: number;
   logger?: (message: string) => void;
-  waitMs?: (ms: number) => Promise<void>;
+  abortSignal?: AbortSignal;
+  waitMs?: (ms: number, abortSignal?: AbortSignal) => Promise<boolean>;
 };
 
 type ResolvedDriveCommentEventTurn = {
@@ -364,10 +365,11 @@ async function resolveParsedCommentContent(params: {
   };
 }
 
-async function delayMs(ms: number): Promise<void> {
-  await new Promise((resolve) => {
-    setTimeout(resolve, ms);
-  });
+// Returns `true` when the full delay elapsed, `false` when the abort signal fired
+// first. The retry loop in `fetchDriveCommentContext` checks this so a stop on the
+// owning monitor account does not run through the full 6×1 s poll-miss window.
+async function delayMs(ms: number, abortSignal?: AbortSignal): Promise<boolean> {
+  return waitForAbortableDelay(ms, abortSignal);
 }
 
 function buildDriveCommentTargetUrl(params: {
@@ -733,7 +735,8 @@ async function fetchDriveCommentContext(params: {
   timeoutMs: number;
   logger?: (message: string) => void;
   accountId: string;
-  waitMs: (ms: number) => Promise<void>;
+  abortSignal?: AbortSignal;
+  waitMs: (ms: number, abortSignal?: AbortSignal) => Promise<boolean>;
 }): Promise<{
   documentTitle?: string;
   documentUrl?: string;
@@ -828,12 +831,21 @@ async function fetchDriveCommentContext(params: {
     }
     if (params.replyId && !embeddedTargetReply && !fetchedMatchedReply) {
       for (let attempt = 1; attempt <= FEISHU_COMMENT_REPLY_MISS_RETRY_LIMIT; attempt += 1) {
+        if (params.abortSignal?.aborted) {
+          break;
+        }
         params.logger?.(
           `feishu[${params.accountId}]: retrying comment reply lookup comment=${params.commentId} ` +
             `requested_reply=${params.replyId} attempt=${attempt}/${FEISHU_COMMENT_REPLY_MISS_RETRY_LIMIT} ` +
             `delay_ms=${FEISHU_COMMENT_REPLY_MISS_RETRY_DELAY_MS}`,
         );
-        await params.waitMs(FEISHU_COMMENT_REPLY_MISS_RETRY_DELAY_MS);
+        const delayElapsed = await params.waitMs(
+          FEISHU_COMMENT_REPLY_MISS_RETRY_DELAY_MS,
+          params.abortSignal,
+        );
+        if (!delayElapsed) {
+          break;
+        }
         const retried = await fetchDriveCommentReplies(params);
         if (retried.replies.length > 0) {
           params.logger?.(
@@ -1232,6 +1244,7 @@ async function resolveDriveCommentEventCore(params: ResolveDriveCommentEventPara
     createClient,
     verificationTimeoutMs = FEISHU_COMMENT_VERIFY_TIMEOUT_MS,
     logger,
+    abortSignal,
     waitMs = delayMs,
   } = params;
   const eventId = event.event_id?.trim();
@@ -1281,6 +1294,7 @@ async function resolveDriveCommentEventCore(params: ResolveDriveCommentEventPara
     timeoutMs: verificationTimeoutMs,
     logger,
     accountId,
+    abortSignal,
     waitMs,
   });
   return {

--- a/extensions/feishu/src/monitor.comment.ts
+++ b/extensions/feishu/src/monitor.comment.ts
@@ -365,13 +365,6 @@ async function resolveParsedCommentContent(params: {
   };
 }
 
-// Returns `true` when the full delay elapsed, `false` when the abort signal fired
-// first. The retry loop in `fetchDriveCommentContext` checks this so a stop on the
-// owning monitor account does not run through the full 6×1 s poll-miss window.
-async function delayMs(ms: number, abortSignal?: AbortSignal): Promise<boolean> {
-  return waitForAbortableDelay(ms, abortSignal);
-}
-
 function buildDriveCommentTargetUrl(params: {
   fileToken: string;
   fileType: CommentFileType;
@@ -1245,7 +1238,7 @@ async function resolveDriveCommentEventCore(params: ResolveDriveCommentEventPara
     verificationTimeoutMs = FEISHU_COMMENT_VERIFY_TIMEOUT_MS,
     logger,
     abortSignal,
-    waitMs = delayMs,
+    waitMs = waitForAbortableDelay,
   } = params;
   const eventId = event.event_id?.trim();
   const commentId = event.comment_id?.trim();


### PR DESCRIPTION
## What Problem This Solves

Feishu's drive-comment reply lookup retries `FEISHU_COMMENT_REPLY_MISS_RETRY_LIMIT = 6` times with `FEISHU_COMMENT_REPLY_MISS_RETRY_DELAY_MS = 1_000` between attempts when the requested reply is not immediately visible in the embedded batch payload. The inter-attempt delay in `monitor.comment.ts:367` used `setTimeout(resolve, ms)` and never received the owning monitor account's `AbortSignal`. When `monitorSingleAccount` (line 469) tears down the websocket or webhook for an account restart, the in-flight comment retry loop runs through the full ~6 s poll-miss window instead of stopping with the rest of the account lifecycle.

`monitor.bot-identity.ts:40` in the same plugin already uses the shared `waitForAbortableDelay(ms, abortSignal)` helper for the bot-identity recovery retry; only the comment reply retry path was unwired. The retry is exported through `fetchDriveCommentContext` → `resolveDriveCommentEventTurn` → `handleFeishuCommentEvent` → `createFeishuDriveCommentNoticeHandler`; none of those signatures accepted an `AbortSignal`, so the handler had no way to forward the account-level stop.

## Why This Change Was Made

- `delayMs` is now a thin wrapper over `waitForAbortableDelay` from `./async.js` and returns `Promise<boolean>` (true = full delay elapsed, false = aborted). The retry loop checks the boolean and exits instead of starting another 1 s delay.
- `fetchDriveCommentContext`, `ResolveDriveCommentEventParams`, `HandleFeishuCommentEventParams`, and `createFeishuDriveCommentNoticeHandler` each gain an optional `abortSignal?: AbortSignal`; `monitorSingleAccount` (which already held the signal at line 469) is the source, threaded via `registerEventHandlers`.
- No new config, no new env, no SDK change, no shared helper change. `abortSignal` stays optional everywhere — callers that never pass it get the old bare-`setTimeout` behavior via `waitForAbortableDelay(ms, undefined)`.

#104431 (merged) explicitly kept this result-predicate poll off `retryAsync`; this PR targets the delay-abort contract, orthogonal to that error-retry refactor.

## User Impact

Stopping or restarting a Feishu account no longer leaves a drive-comment reply retry loop running for up to ~6 s after the rest of the account has settled. The loop now exits on the abort event, the same cadence the sibling bot-identity recovery loop already follows. Happy-path behavior is unchanged — when the requested reply appears within the retry budget, the loop still breaks at the matching attempt.

## Evidence

**Fix before** (base `1f9a9281d9`; abort fires 374 ms into attempt 3's 1 s delay — the loop keeps polling for 3.6 s and 4 more fetches):

```text
[2118ms] log: retrying comment reply lookup attempt=3/6 delay_ms=1000
[2501ms] >>> owner abortSignal fires (monitor stop)
[3138ms] >>> replies fetch #4
[4149ms] >>> replies fetch #5
[5157ms] >>> replies fetch #6
[6164ms] >>> replies fetch #7
{"elapsedMs":6167,"replyFetchCount":7,"replyFetchesAfterAbort":4,"turnResolved":true}
```

**Fix after** (this head `4f1c0e99cf`; same harness — the abort interrupts the delay, no post-stop fetch):

```text
[2127ms] log: retrying comment reply lookup attempt=3/6 delay_ms=1000
[2501ms] >>> owner abortSignal fires (monitor stop)
[2502ms] log: comment reply resolution match_source=miss
{"elapsedMs":2505,"replyFetchCount":3,"replyFetchesAfterAbort":0,"turnResolved":true}
```

Blind rerun of the fixed head: `elapsedMs:2507, replyFetchCount:3, replyFetchesAfterAbort:0`.

**How the proof was produced**

Uncommitted `scratchpad/feishu-comment-abort-proof.ts` drives the production `resolveDriveCommentEventTurn` entry with no `createClient`/`waitMs` injection: the client comes from the real `createFeishuClient` factory with the account `domain` pointed at a loopback `node:http` stub of the Feishu OpenAPI (the same custom-domain seam private deployments use), the abort is a real `AbortController` standing in for the owning account signal, and all timers are real wall-clock. The stub serves tenant-token, doc-meta, and comment batch_query with replies that never contain the requested `reply_id`, then counts `GET …/replies` hits server-side. The before run is the same harness against base `1f9a9281d9`.

**Mutation proof**

Prod source stashed to `1f9a9281d9` with only the test change applied → the new regression test fails: `expected "vi.fn()" to be called 1 times, but got 6 times`.

**Tests & checks**

- `monitor.comment.test.ts` 17/17; focused feishu sweep (7 files) 82/82. Full-plugin sweep shows 17 pre-existing i18n failures on stock `1f9a9281d9` (`LANG=zh_CN.UTF-8` vs English string expectations), unrelated to this change.
- `run-tsgo -p tsconfig.extensions.json` exit=0; `run-oxlint` on 5 changed files exit=0; `oxfmt --check` exit=0; `git diff --check` clean.

Prod-only non-test LOC: `+28 / -9` across four files.

**Not tested**: a live Feishu tenant with real bot credentials. The loopback run exercises the real production client factory, Lark SDK request path, and retry loop over real HTTP — only the upstream server is stubbed, and `requestFeishuOpenApi` timeout behavior is intentionally untouched (bounded by `timeoutMs`, a separate concern from the poll-delay abort).
