### PR TITLE
test(discord): isolate component registry runtime

### DIFF
--- a/extensions/discord/src/components.test.ts
+++ b/extensions/discord/src/components.test.ts
@@ -1,6 +1,7 @@
 // Discord tests cover components plugin behavior.
 import { ButtonStyle, MessageFlags } from "discord-api-types/v10";
 import { MAX_DATE_TIMESTAMP_MS } from "openclaw/plugin-sdk/number-runtime";
+import { createPluginRuntimeStore } from "openclaw/plugin-sdk/runtime-store";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { clearDiscordComponentEntriesForTest } from "./components-registry.test-support.js";
 import type { DiscordComponentEntry, DiscordModalEntry } from "./components.js";
@@ -17,8 +18,13 @@ let parseDiscordComponentCustomIdForInteraction: typeof import("./components.js"
 let parseDiscordModalCustomId: typeof import("./components.js").parseDiscordModalCustomId;
 let parseDiscordModalCustomIdForInteraction: typeof import("./components.js").parseDiscordModalCustomIdForInteraction;
 let readDiscordComponentSpec: typeof import("./components.js").readDiscordComponentSpec;
-let clearDiscordRuntime: typeof import("./runtime.js").clearDiscordRuntime;
 let setDiscordRuntime: typeof import("./runtime.js").setDiscordRuntime;
+type DiscordRuntime = Parameters<typeof import("./runtime.js").setDiscordRuntime>[0];
+
+const { clearRuntime: clearDiscordRuntime } = createPluginRuntimeStore<DiscordRuntime>({
+  pluginId: "discord",
+  errorMessage: "Discord runtime not initialized",
+});
 
 beforeAll(async () => {
   ({
@@ -37,7 +43,7 @@ beforeAll(async () => {
     parseDiscordModalCustomIdForInteraction,
     readDiscordComponentSpec,
   } = await import("./components.js"));
-  ({ clearDiscordRuntime, setDiscordRuntime } = await import("./runtime.js"));
+  ({ setDiscordRuntime } = await import("./runtime.js"));
 });
 
 describe("discord components", () => {

--- a/extensions/discord/src/components.test.ts
+++ b/extensions/discord/src/components.test.ts
@@ -1,7 +1,7 @@
 // Discord tests cover components plugin behavior.
 import { ButtonStyle, MessageFlags } from "discord-api-types/v10";
 import { MAX_DATE_TIMESTAMP_MS } from "openclaw/plugin-sdk/number-runtime";
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { clearDiscordComponentEntriesForTest } from "./components-registry.test-support.js";
 import type { DiscordComponentEntry, DiscordModalEntry } from "./components.js";
 
@@ -17,6 +17,8 @@ let parseDiscordComponentCustomIdForInteraction: typeof import("./components.js"
 let parseDiscordModalCustomId: typeof import("./components.js").parseDiscordModalCustomId;
 let parseDiscordModalCustomIdForInteraction: typeof import("./components.js").parseDiscordModalCustomIdForInteraction;
 let readDiscordComponentSpec: typeof import("./components.js").readDiscordComponentSpec;
+let clearDiscordRuntime: typeof import("./runtime.js").clearDiscordRuntime;
+let setDiscordRuntime: typeof import("./runtime.js").setDiscordRuntime;
 
 beforeAll(async () => {
   ({
@@ -35,6 +37,7 @@ beforeAll(async () => {
     parseDiscordModalCustomIdForInteraction,
     readDiscordComponentSpec,
   } = await import("./components.js"));
+  ({ clearDiscordRuntime, setDiscordRuntime } = await import("./runtime.js"));
 });
 
 describe("discord components", () => {
@@ -309,8 +312,15 @@ describe("discord components", () => {
 
 describe("discord component registry", () => {
   beforeEach(() => {
+    // The runtime slot is global across Vitest files; discard sibling mocks
+    // before this suite opens its persistent registry stores.
+    clearDiscordRuntime();
     clearDiscordComponentEntriesForTest();
     vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    clearDiscordRuntime();
   });
 
   const componentsRegistryModuleUrl = new URL("./components-registry.ts", import.meta.url).href;
@@ -477,7 +487,6 @@ describe("discord component registry", () => {
     const openKeyedStore = vi.fn((opts: { namespace: string }) =>
       opts.namespace === "discord.components" ? componentStore : modalStore,
     );
-    const { setDiscordRuntime } = await import("./runtime.js");
     setDiscordRuntime({
       state: { openKeyedStore },
       logging: { getChildLogger: () => ({ warn: vi.fn() }) },
@@ -559,7 +568,6 @@ describe("discord component registry", () => {
     const openKeyedStore = vi.fn((opts: { namespace: string }) =>
       opts.namespace === "discord.components" ? componentStore : modalStore,
     );
-    const { setDiscordRuntime } = await import("./runtime.js");
     setDiscordRuntime({
       state: { openKeyedStore },
       logging: { getChildLogger: () => ({ warn: vi.fn() }) },
@@ -652,7 +660,6 @@ describe("discord component registry", () => {
     const openKeyedStore = vi.fn((opts: { namespace: string }) =>
       opts.namespace === "discord.components" ? componentStore : modalStore,
     );
-    const { setDiscordRuntime } = await import("./runtime.js");
     setDiscordRuntime({
       state: { openKeyedStore },
       logging: { getChildLogger: () => ({ warn: vi.fn() }) },
@@ -676,7 +683,6 @@ describe("discord component registry", () => {
   it("falls back to the in-memory registry when persistent state cannot open", async () => {
     const warn = vi.fn();
     const cause = new TypeError("disk busy");
-    const { setDiscordRuntime } = await import("./runtime.js");
     setDiscordRuntime({
       state: {
         openKeyedStore: vi.fn(() => {

--- a/extensions/discord/src/runtime.ts
+++ b/extensions/discord/src/runtime.ts
@@ -15,11 +15,10 @@ type DiscordRuntime = PluginRuntime & {
 
 const {
   setRuntime: setDiscordRuntime,
-  clearRuntime: clearDiscordRuntime,
   tryGetRuntime: getOptionalDiscordRuntime,
   getRuntime: getDiscordRuntime,
 } = createPluginRuntimeStore<DiscordRuntime>({
   pluginId: "discord",
   errorMessage: "Discord runtime not initialized",
 });
-export { clearDiscordRuntime, getDiscordRuntime, getOptionalDiscordRuntime, setDiscordRuntime };
+export { getDiscordRuntime, getOptionalDiscordRuntime, setDiscordRuntime };

--- a/extensions/discord/src/runtime.ts
+++ b/extensions/discord/src/runtime.ts
@@ -15,10 +15,11 @@ type DiscordRuntime = PluginRuntime & {
 
 const {
   setRuntime: setDiscordRuntime,
+  clearRuntime: clearDiscordRuntime,
   tryGetRuntime: getOptionalDiscordRuntime,
   getRuntime: getDiscordRuntime,
 } = createPluginRuntimeStore<DiscordRuntime>({
   pluginId: "discord",
   errorMessage: "Discord runtime not initialized",
 });
-export { getDiscordRuntime, getOptionalDiscordRuntime, setDiscordRuntime };
+export { clearDiscordRuntime, getDiscordRuntime, getOptionalDiscordRuntime, setDiscordRuntime };


### PR DESCRIPTION
## What Problem This Solves

Plugin Prerelease failed on current `main` because Discord component-registry tests inherited a process-global runtime mock from another Vitest file. That stale mock exposed only `lookup` and `register`; component consumption then called the real keyed-store `delete` contract and failed with `TypeError: store.delete is not a function`.

Failure: https://github.com/openclaw/openclaw/actions/runs/29437606839/job/87428126307

## Why This Change Was Made

The Discord runtime already uses the shared runtime store's `clearRuntime` operation. This change exposes that internal clear operation and makes the component-registry suite clear the global slot before and after each test. Tests now own their runtime state instead of depending on cross-file execution order.

## User Impact

No product behavior change. Plugin prerelease and extension tests are deterministic when Discord test files share a worker.

## Evidence

- Blacksmith Testbox-through-Crabbox `tbx_01kxkedhv4vz4rz6v56wz1gwdt`:
  - focused Discord channel + component registry: 57/57 tests passed
  - exact failed Plugin Prerelease shard: all 298 files passed
  - `pnpm check:changed`: passed, including extension production/test typechecks, lint, format, boundaries, and import-cycle checks
- `git diff --check`: passed
- Fresh whole-diff autoreview: clean

Changelog not required: test isolation only.
