### PR TITLE
fix: gateway-owned work fails through same-host relay

### DIFF
--- a/config/max-lines-baseline.txt
+++ b/config/max-lines-baseline.txt
@@ -876,7 +876,6 @@ src/gateway/server-methods/usage.ts
 src/gateway/server-node-events.test.ts
 src/gateway/server-node-events.ts
 src/gateway/server-plugins.test.ts
-src/gateway/server-plugins.ts
 src/gateway/server-reload-handlers.test.ts
 src/gateway/server-reload-handlers.ts
 src/gateway/server-restart-sentinel.test.ts

--- a/packages/gateway-client/src/client.ts
+++ b/packages/gateway-client/src/client.ts
@@ -44,7 +44,11 @@ import {
   type GatewayProtocolSocketHandlers,
 } from "./protocol-client.js";
 import { shouldPauseGatewayReconnect } from "./reconnect-policy.js";
-import { resolveConnectChallengeTimeoutMs, resolveSafeTimeoutDelayMs } from "./timeouts.js";
+import {
+  DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS,
+  resolveConnectChallengeTimeoutMs,
+  resolveSafeTimeoutDelayMs,
+} from "./timeouts.js";
 import { rawDataToString } from "./websocket-data.js";
 
 export type DeviceIdentity = {
@@ -407,7 +411,7 @@ export class GatewayClient {
     this.requestTimeoutMs =
       typeof opts.requestTimeoutMs === "number" && Number.isFinite(opts.requestTimeoutMs)
         ? resolveSafeTimeoutDelayMs(opts.requestTimeoutMs, { minMs: 0 })
-        : 30_000;
+        : DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS;
     this.protocol = new GatewayProtocolClient<AssembledConnect>({
       createSocket: (handlers) => this.createSocket(handlers),
       createRequestId: randomUUID,

--- a/packages/gateway-client/src/timeouts.ts
+++ b/packages/gateway-client/src/timeouts.ts
@@ -12,6 +12,8 @@ function parseStrictPositiveInteger(value: string): number | undefined {
 export const MAX_SAFE_TIMEOUT_DELAY_MS = 2_147_483_647;
 /** Default server-side window for gateway preauth handshakes. */
 export const DEFAULT_PREAUTH_HANDSHAKE_TIMEOUT_MS = 15_000;
+/** Default deadline for a single non-streaming Gateway request. */
+export const DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS = 30_000;
 /** Minimum client watchdog delay for connect challenge setup. */
 export const MIN_CONNECT_CHALLENGE_TIMEOUT_MS = 250;
 /** Default maximum client watchdog delay, aligned with the preauth server timeout. */

--- a/src/agents/main-session-restart-dispatch.ts
+++ b/src/agents/main-session-restart-dispatch.ts
@@ -206,6 +206,7 @@ export async function resumeMainSession(params: {
   const reusingRecoveryRunId = recoveryRunId === claimedRunId;
   const dispatchSessionKey = params.canonicalSessionKey ?? params.sessionKey;
   const recoverySessionKeys = Array.from(new Set([dispatchSessionKey, params.sessionKey]));
+  let dispatchOutcomeUnknown = false;
   try {
     // Persist one stable RPC id before dispatch. A transport rejection is
     // ambiguous; retries must reuse this id so accepted work cannot duplicate.
@@ -268,10 +269,14 @@ export async function resumeMainSession(params: {
     if (params.forceRestartSafeTools) {
       log.info(`dispatching restart-safe recovery for ${params.sessionKey}`);
     }
+    // Once dispatch starts, any rejection is ambiguous because the stable RPC
+    // may still have been accepted; a successful return resolves that ambiguity.
+    dispatchOutcomeUnknown = true;
     const dispatchResult = await params.gatewayRuntime.dispatchAgent<{
       runId: string;
       status?: unknown;
     }>(agentParams, 10_000);
+    dispatchOutcomeUnknown = false;
     let terminalStatus = normalizeRestartRecoveryTerminalStatus(dispatchResult.status);
     if (!terminalStatus && reusingRecoveryRunId && dispatchResult.status === "accepted") {
       terminalStatus = await probeRestartRecoveryTerminalStatus(
@@ -295,11 +300,7 @@ export async function resumeMainSession(params: {
     );
     return true;
   } catch (error) {
-    if (
-      reusingRecoveryRunId &&
-      error instanceof Error &&
-      error.name === "GatewayClientRequestError"
-    ) {
+    if (reusingRecoveryRunId && dispatchOutcomeUnknown) {
       const terminalStatus = await probeRestartRecoveryTerminalStatus(
         recoveryRunId,
         params.gatewayRuntime,

--- a/src/agents/main-session-restart-dispatch.ts
+++ b/src/agents/main-session-restart-dispatch.ts
@@ -5,7 +5,7 @@ import type { SessionEntry } from "../config/sessions.js";
 import { buildRestartRecoveryClaimCleanupPatch } from "../config/sessions/restart-recovery-state.js";
 import { applySessionEntryReplacements } from "../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { callGateway } from "../gateway/call.js";
+import type { GatewayRecoveryRuntime } from "../gateway/server-instance-runtime.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { CommandLane } from "../process/lanes.js";
 import { resolveSendPolicy } from "../sessions/send-policy.js";
@@ -86,13 +86,13 @@ function normalizeRestartRecoveryTerminalStatus(
 
 async function probeRestartRecoveryTerminalStatus(
   runId: string,
+  gatewayRuntime: GatewayRecoveryRuntime,
 ): Promise<RestartRecoveryTerminalStatus | undefined> {
   try {
-    const result = await callGateway<{ endedAt?: unknown; status?: unknown }>({
-      method: "agent.wait",
-      params: { runId, timeoutMs: 0 },
-      timeoutMs: 2_000,
-    });
+    const result = await gatewayRuntime.waitForAgent<{ endedAt?: unknown; status?: unknown }>(
+      { runId, timeoutMs: 0 },
+      2_000,
+    );
     const status = normalizeRestartRecoveryTerminalStatus(result.status);
     // A zero-time wait also reports timeout for active or unknown work.
     return status === "timeout" && typeof result.endedAt !== "number" ? undefined : status;
@@ -189,6 +189,7 @@ export async function resumeMainSession(params: {
   pendingFinalDeliveryText?: string | null;
   forceRestartSafeTools?: boolean;
   sessionWorkAdmissionHandoffId?: string;
+  gatewayRuntime: GatewayRecoveryRuntime;
 }): Promise<boolean> {
   const sanitizedPendingText =
     typeof params.pendingFinalDeliveryText === "string"
@@ -267,14 +268,16 @@ export async function resumeMainSession(params: {
     if (params.forceRestartSafeTools) {
       log.info(`dispatching restart-safe recovery for ${params.sessionKey}`);
     }
-    const dispatchResult = await callGateway<{ runId: string; status?: unknown }>({
-      method: "agent",
-      params: agentParams,
-      timeoutMs: 10_000,
-    });
+    const dispatchResult = await params.gatewayRuntime.dispatchAgent<{
+      runId: string;
+      status?: unknown;
+    }>(agentParams, 10_000);
     let terminalStatus = normalizeRestartRecoveryTerminalStatus(dispatchResult.status);
     if (!terminalStatus && reusingRecoveryRunId && dispatchResult.status === "accepted") {
-      terminalStatus = await probeRestartRecoveryTerminalStatus(recoveryRunId);
+      terminalStatus = await probeRestartRecoveryTerminalStatus(
+        recoveryRunId,
+        params.gatewayRuntime,
+      );
     }
     await settleRestartRecoveryDispatch({
       expectedRecoveryRunId: recoveryRunId,
@@ -297,7 +300,10 @@ export async function resumeMainSession(params: {
       error instanceof Error &&
       error.name === "GatewayClientRequestError"
     ) {
-      const terminalStatus = await probeRestartRecoveryTerminalStatus(recoveryRunId);
+      const terminalStatus = await probeRestartRecoveryTerminalStatus(
+        recoveryRunId,
+        params.gatewayRuntime,
+      );
       if (terminalStatus) {
         await settleRestartRecoveryDispatch({
           expectedRecoveryRunId: recoveryRunId,

--- a/src/agents/main-session-restart-dispatch.ts
+++ b/src/agents/main-session-restart-dispatch.ts
@@ -5,7 +5,7 @@ import type { SessionEntry } from "../config/sessions.js";
 import { buildRestartRecoveryClaimCleanupPatch } from "../config/sessions/restart-recovery-state.js";
 import { applySessionEntryReplacements } from "../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import type { GatewayRecoveryRuntime } from "../gateway/server-instance-runtime.js";
+import type { GatewayRecoveryRuntime } from "../gateway/server-instance-runtime.types.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { CommandLane } from "../process/lanes.js";
 import { resolveSendPolicy } from "../sessions/send-policy.js";

--- a/src/agents/main-session-restart-recovery.test.ts
+++ b/src/agents/main-session-restart-recovery.test.ts
@@ -13,7 +13,7 @@ import {
   replaceSessionEntry,
 } from "../config/sessions/session-accessor.js";
 import { callGateway } from "../gateway/call.js";
-import type { GatewayRecoveryRuntime } from "../gateway/server-instance-runtime.js";
+import type { GatewayRecoveryRuntime } from "../gateway/server-instance-runtime.types.js";
 import {
   getAgentEventLifecycleGeneration,
   registerAgentRunContext,

--- a/src/agents/main-session-restart-recovery.test.ts
+++ b/src/agents/main-session-restart-recovery.test.ts
@@ -1051,6 +1051,50 @@ describe("main-session-restart-recovery", () => {
     expect(settled?.restartRecoveryDeliverySourceRunId).toBeUndefined();
   });
 
+  it("settles a reused recovery RPC after its dispatch wait times out", async () => {
+    const sessionsDir = await makeSessionsDir();
+    const storePath = path.join(sessionsDir, "sessions.json");
+    await writeStore(sessionsDir, {
+      "agent:main:main": {
+        sessionId: "main-session",
+        updatedAt: Date.now() - 10_000,
+        status: "running",
+        abortedLastRun: true,
+        restartRecoveryDeliveryRunId: "recovery-run",
+        restartRecoveryDeliverySourceRunId: "control-ui-run",
+      },
+    });
+    await writeTranscript(sessionsDir, "main-session", [
+      { role: "user", content: "run the tool" },
+      { role: "assistant", content: [{ type: "toolCall", id: "call-1", name: "exec" }] },
+      { role: "toolResult", content: "done" },
+    ]);
+    vi.mocked(callGateway)
+      .mockRejectedValueOnce(new Error("gateway request timeout for agent"))
+      .mockResolvedValueOnce({
+        runId: "recovery-run",
+        status: "ok",
+        endedAt: Date.now(),
+      });
+
+    await expect(recoverRestartAbortedMainSessions({ stateDir: tmpDir })).resolves.toEqual({
+      recovered: 1,
+      failed: 0,
+      skipped: 0,
+    });
+
+    expect(firstGatewayParams().idempotencyKey).toBe("recovery-run");
+    expect(vi.mocked(callGateway).mock.calls[1]?.[0]).toMatchObject({
+      method: "agent.wait",
+      params: { runId: "recovery-run", timeoutMs: 0 },
+    });
+    expect(loadSessionEntry({ sessionKey: "agent:main:main", storePath })).toMatchObject({
+      abortedLastRun: false,
+      restartRecoveryTerminalRunIds: ["control-ui-run"],
+      status: "done",
+    });
+  });
+
   it("does not deliver restart recovery when session send policy denies sends", async () => {
     const sessionsDir = await makeSessionsDir();
     await writeStore(sessionsDir, {

--- a/src/agents/main-session-restart-recovery.test.ts
+++ b/src/agents/main-session-restart-recovery.test.ts
@@ -13,6 +13,7 @@ import {
   replaceSessionEntry,
 } from "../config/sessions/session-accessor.js";
 import { callGateway } from "../gateway/call.js";
+import type { GatewayRecoveryRuntime } from "../gateway/server-instance-runtime.js";
 import {
   getAgentEventLifecycleGeneration,
   registerAgentRunContext,
@@ -38,10 +39,10 @@ import {
   markRestartAbortedMainSessions,
   markRestartAbortedMainSessionsFromLocks,
   markStartupOrphanedMainSessionsForRecovery,
-  recoverStartupOrphanedMainSessions,
-  recoverRestartAbortedMainSessions,
-  retryRestartAbortedMainSessionRecovery,
-  scheduleRestartAbortedMainSessionRecovery,
+  recoverStartupOrphanedMainSessions as recoverStartupOrphanedMainSessionsBase,
+  recoverRestartAbortedMainSessions as recoverRestartAbortedMainSessionsBase,
+  retryRestartAbortedMainSessionRecovery as retryRestartAbortedMainSessionRecoveryBase,
+  scheduleRestartAbortedMainSessionRecovery as scheduleRestartAbortedMainSessionRecoveryBase,
 } from "./main-session-restart-recovery.js";
 import type { SessionLockInspection } from "./session-write-lock.js";
 
@@ -52,6 +53,32 @@ const transcriptMocks = vi.hoisted(() => ({
 vi.mock("../gateway/call.js", () => ({
   callGateway: vi.fn(async () => ({ runId: "run-resumed" })),
 }));
+
+const mockRecoveryRuntime = {
+  dispatchAgent: async <T>(params: Record<string, unknown>, timeoutMs?: number) =>
+    (await callGateway({ method: "agent", params, timeoutMs })) as T,
+  waitForAgent: async <T>(params: Record<string, unknown>, timeoutMs?: number) =>
+    (await callGateway({ method: "agent.wait", params, timeoutMs })) as T,
+  sendRecoveryNotice: async <T>(params: Record<string, unknown>, timeoutMs?: number) =>
+    (await callGateway({ method: "message.action", params, timeoutMs })) as T,
+};
+
+type RecoveryParams<T extends { gatewayRuntime: unknown }> = Omit<T, "gatewayRuntime"> &
+  Partial<Pick<T, "gatewayRuntime">>;
+
+const recoverRestartAbortedMainSessions = (
+  params: RecoveryParams<Parameters<typeof recoverRestartAbortedMainSessionsBase>[0]>,
+) => recoverRestartAbortedMainSessionsBase({ gatewayRuntime: mockRecoveryRuntime, ...params });
+const recoverStartupOrphanedMainSessions = (
+  params: RecoveryParams<Parameters<typeof recoverStartupOrphanedMainSessionsBase>[0]>,
+) => recoverStartupOrphanedMainSessionsBase({ gatewayRuntime: mockRecoveryRuntime, ...params });
+const retryRestartAbortedMainSessionRecovery = (
+  params: RecoveryParams<Parameters<typeof retryRestartAbortedMainSessionRecoveryBase>[0]>,
+) => retryRestartAbortedMainSessionRecoveryBase({ gatewayRuntime: mockRecoveryRuntime, ...params });
+const scheduleRestartAbortedMainSessionRecovery = (
+  params: RecoveryParams<Parameters<typeof scheduleRestartAbortedMainSessionRecoveryBase>[0]>,
+) =>
+  scheduleRestartAbortedMainSessionRecoveryBase({ gatewayRuntime: mockRecoveryRuntime, ...params });
 
 vi.mock("../config/sessions/transcript.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../config/sessions/transcript.js")>();
@@ -1627,6 +1654,48 @@ describe("main-session-restart-recovery", () => {
     });
   });
 
+  it("dispatches an abandoned durable claim through its owning Gateway instance", async () => {
+    const sessionsDir = await makeSessionsDir();
+    const storePath = path.join(sessionsDir, "sessions.json");
+    await writeStore(sessionsDir, {
+      "agent:main:main": {
+        sessionId: "main-session",
+        updatedAt: Date.now() - 10_000,
+        status: "running",
+        abortedLastRun: true,
+        restartRecoveryDeliveryRunId: "recovery-main",
+        restartRecoveryDeliverySourceRunId: "source-main",
+      },
+    });
+    await writeTranscript(sessionsDir, "main-session", [
+      { role: "user", content: "recover without a socket" },
+    ]);
+    const dispatchAgent = vi.fn(async () => ({ runId: "recovery-main", status: "accepted" }));
+
+    const result = await retryRestartAbortedMainSessionRecovery({
+      expectedRecoveryRunId: "recovery-main",
+      expectedRecoverySourceRunId: "source-main",
+      expectedSessionId: "main-session",
+      sessionKey: "agent:main:main",
+      storePath,
+      gatewayRuntime: {
+        dispatchAgent: dispatchAgent as GatewayRecoveryRuntime["dispatchAgent"],
+        waitForAgent: vi.fn(),
+        sendRecoveryNotice: vi.fn(),
+      },
+    });
+
+    expect(result).toEqual({ recovered: 1, failed: 0, skipped: 0 });
+    expect(dispatchAgent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        idempotencyKey: "recovery-main",
+        sessionKey: "agent:main:main",
+      }),
+      10_000,
+    );
+    expect(callGateway).not.toHaveBeenCalled();
+  });
+
   it("targets a legacy durable row through its canonical agent session key", async () => {
     const sessionsDir = await makeSessionsDir();
     const storePath = path.join(sessionsDir, "sessions.json");
@@ -2208,13 +2277,9 @@ describe("main-session-restart-recovery", () => {
       | {
           method?: string;
           params?: Record<string, unknown>;
-          clientName?: string;
-          mode?: string;
         }
       | undefined;
     expect(gatewayCall?.method).toBe("message.action");
-    expect(gatewayCall?.clientName).toBe("gateway-client");
-    expect(gatewayCall?.mode).toBe("backend");
     expect(gatewayCall?.params).toMatchObject({
       channel: "discord",
       action: "send",

--- a/src/agents/main-session-restart-recovery.ts
+++ b/src/agents/main-session-restart-recovery.ts
@@ -21,7 +21,7 @@ import {
 } from "../config/sessions/session-accessor.js";
 import { appendAssistantMessageToSessionTranscript } from "../config/sessions/transcript.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import type { GatewayRecoveryRuntime } from "../gateway/server-instance-runtime.js";
+import type { GatewayRecoveryRuntime } from "../gateway/server-instance-runtime.types.js";
 import { readSessionMessagesAsync } from "../gateway/session-transcript-readers.js";
 import { resolveGatewaySessionStoreTarget } from "../gateway/session-utils.js";
 import {

--- a/src/agents/main-session-restart-recovery.ts
+++ b/src/agents/main-session-restart-recovery.ts
@@ -5,10 +5,6 @@
 import fs from "node:fs";
 import path from "node:path";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
-import {
-  GATEWAY_CLIENT_MODES,
-  GATEWAY_CLIENT_NAMES,
-} from "../../packages/gateway-protocol/src/client-info.js";
 import { resolveStateDir } from "../config/paths.js";
 import {
   type RestartRecoveryRun,
@@ -25,7 +21,7 @@ import {
 } from "../config/sessions/session-accessor.js";
 import { appendAssistantMessageToSessionTranscript } from "../config/sessions/transcript.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { callGateway } from "../gateway/call.js";
+import type { GatewayRecoveryRuntime } from "../gateway/server-instance-runtime.js";
 import { readSessionMessagesAsync } from "../gateway/session-transcript-readers.js";
 import { resolveGatewaySessionStoreTarget } from "../gateway/session-utils.js";
 import {
@@ -748,6 +744,7 @@ async function sendUnresumableSessionNotice(params: {
   entry: SessionEntry;
   reason: string;
   sessionKey: string;
+  gatewayRuntime: GatewayRecoveryRuntime;
 }): Promise<void> {
   const messageParams: Record<string, unknown> = {
     to: params.deliveryContext.to,
@@ -771,13 +768,7 @@ async function sendUnresumableSessionNotice(params: {
   }
 
   try {
-    await callGateway({
-      method: "message.action",
-      params: actionParams,
-      timeoutMs: 10_000,
-      clientName: GATEWAY_CLIENT_NAMES.GATEWAY_CLIENT,
-      mode: GATEWAY_CLIENT_MODES.BACKEND,
-    });
+    await params.gatewayRuntime.sendRecoveryNotice(actionParams, 10_000);
     log.info(
       `sent interrupted main session recovery notice: ${params.sessionKey} (${params.reason})`,
     );
@@ -899,6 +890,7 @@ async function recoverStore(params: {
   sessionWorkAdmissionHandoffId?: string;
   activeSessionIds?: Iterable<string>;
   activeSessionKeys?: Iterable<string>;
+  gatewayRuntime: GatewayRecoveryRuntime;
 }): Promise<{ recovered: number; failed: number; skipped: number }> {
   const result = { recovered: 0, failed: 0, skipped: 0 };
   const providedActiveSessionIds =
@@ -984,6 +976,7 @@ async function recoverStore(params: {
         pendingFinalDeliveryText: entry.pendingFinalDeliveryText,
         forceRestartSafeTools: true,
         sessionWorkAdmissionHandoffId: params.sessionWorkAdmissionHandoffId,
+        gatewayRuntime: params.gatewayRuntime,
       });
       if (resumed) {
         params.resumedSessionKeys.add(resumeDedupeKey);
@@ -1023,6 +1016,7 @@ async function recoverStore(params: {
           sessionKey,
           pendingFinalDeliveryText: entry.pendingFinalDeliveryText,
           sessionWorkAdmissionHandoffId: params.sessionWorkAdmissionHandoffId,
+          gatewayRuntime: params.gatewayRuntime,
         });
         if (resumed) {
           params.resumedSessionKeys.add(resumeDedupeKey);
@@ -1047,6 +1041,7 @@ async function recoverStore(params: {
         pendingFinalDeliveryText: entry.pendingFinalDeliveryText,
         forceRestartSafeTools: hasReplaySafeCodeModeCheckpointInCurrentTurn(messages),
         sessionWorkAdmissionHandoffId: params.sessionWorkAdmissionHandoffId,
+        gatewayRuntime: params.gatewayRuntime,
       });
       if (resumed) {
         params.resumedSessionKeys.add(resumeDedupeKey);
@@ -1105,6 +1100,7 @@ async function recoverStore(params: {
             entry,
             reason: resumePolicy.blockReason,
             sessionKey,
+            gatewayRuntime: params.gatewayRuntime,
           });
         }
         result.failed++;
@@ -1123,6 +1119,7 @@ async function recoverStore(params: {
       pendingFinalDeliveryText: entry.pendingFinalDeliveryText,
       forceRestartSafeTools: resumePolicy.forceRestartSafeTools,
       sessionWorkAdmissionHandoffId: params.sessionWorkAdmissionHandoffId,
+      gatewayRuntime: params.gatewayRuntime,
     });
     if (resumed) {
       params.resumedSessionKeys.add(resumeDedupeKey);
@@ -1153,15 +1150,14 @@ async function resolveRestartRecoveryStorePaths(params: {
   return [...storePaths].toSorted((a, b) => a.localeCompare(b));
 }
 
-export async function recoverRestartAbortedMainSessions(
-  params: {
-    cfg?: OpenClawConfig;
-    stateDir?: string;
-    resumedSessionKeys?: Set<string>;
-    activeSessionIds?: Iterable<string>;
-    activeSessionKeys?: Iterable<string>;
-  } = {},
-): Promise<{ recovered: number; failed: number; skipped: number }> {
+export async function recoverRestartAbortedMainSessions(params: {
+  cfg?: OpenClawConfig;
+  stateDir?: string;
+  resumedSessionKeys?: Set<string>;
+  activeSessionIds?: Iterable<string>;
+  activeSessionKeys?: Iterable<string>;
+  gatewayRuntime: GatewayRecoveryRuntime;
+}): Promise<{ recovered: number; failed: number; skipped: number }> {
   const result = { recovered: 0, failed: 0, skipped: 0 };
   const resumedSessionKeys = params.resumedSessionKeys ?? new Set<string>();
 
@@ -1172,6 +1168,7 @@ export async function recoverRestartAbortedMainSessions(
       resumedSessionKeys,
       activeSessionIds: params.activeSessionIds,
       activeSessionKeys: params.activeSessionKeys,
+      gatewayRuntime: params.gatewayRuntime,
     });
     result.recovered += storeResult.recovered;
     result.failed += storeResult.failed;
@@ -1195,6 +1192,7 @@ export async function retryRestartAbortedMainSessionRecovery(params: {
   expectedSessionId: string;
   sessionKey: string;
   storePath: string;
+  gatewayRuntime: GatewayRecoveryRuntime;
 }): Promise<{ recovered: number; failed: number; skipped: number }> {
   const expectedClaim: ExpectedRestartRecoveryClaim = {
     canonicalSessionKey: params.canonicalSessionKey,
@@ -1232,6 +1230,7 @@ export async function retryRestartAbortedMainSessionRecovery(params: {
           resumedSessionKeys: new Set<string>(),
           expectedClaim,
           sessionWorkAdmissionHandoffId: handoffId,
+          gatewayRuntime: params.gatewayRuntime,
         }),
     );
   } finally {
@@ -1239,16 +1238,15 @@ export async function retryRestartAbortedMainSessionRecovery(params: {
   }
 }
 
-export async function recoverStartupOrphanedMainSessions(
-  params: {
-    cfg?: OpenClawConfig;
-    stateDir?: string;
-    activeSessionIds?: Iterable<string>;
-    activeSessionKeys?: Iterable<string>;
-    updatedBeforeMs?: number;
-    resumedSessionKeys?: Set<string>;
-  } = {},
-): Promise<{ marked: number; recovered: number; failed: number; skipped: number }> {
+export async function recoverStartupOrphanedMainSessions(params: {
+  cfg?: OpenClawConfig;
+  stateDir?: string;
+  activeSessionIds?: Iterable<string>;
+  activeSessionKeys?: Iterable<string>;
+  updatedBeforeMs?: number;
+  resumedSessionKeys?: Set<string>;
+  gatewayRuntime: GatewayRecoveryRuntime;
+}): Promise<{ marked: number; recovered: number; failed: number; skipped: number }> {
   const startupRecoveryCutoffMs = params.updatedBeforeMs ?? Date.now();
   const marked = await markStartupOrphanedMainSessionsForRecovery({
     cfg: params.cfg,
@@ -1263,6 +1261,7 @@ export async function recoverStartupOrphanedMainSessions(
     resumedSessionKeys: params.resumedSessionKeys,
     activeSessionIds: params.activeSessionIds,
     activeSessionKeys: params.activeSessionKeys,
+    gatewayRuntime: params.gatewayRuntime,
   });
   return {
     marked: marked.marked,
@@ -1272,14 +1271,13 @@ export async function recoverStartupOrphanedMainSessions(
   };
 }
 
-export function scheduleRestartAbortedMainSessionRecovery(
-  params: {
-    cfg?: OpenClawConfig;
-    delayMs?: number;
-    maxRetries?: number;
-    stateDir?: string;
-  } = {},
-): void {
+export function scheduleRestartAbortedMainSessionRecovery(params: {
+  cfg?: OpenClawConfig;
+  delayMs?: number;
+  maxRetries?: number;
+  stateDir?: string;
+  gatewayRuntime: GatewayRecoveryRuntime;
+}): void {
   const initialDelay = params.delayMs ?? DEFAULT_RECOVERY_DELAY_MS;
   const maxRetries = params.maxRetries ?? MAX_RECOVERY_RETRIES;
   const resumedSessionKeys = new Set<string>();
@@ -1297,6 +1295,7 @@ export function scheduleRestartAbortedMainSessionRecovery(
           stateDir: params.stateDir,
           resumedSessionKeys,
           updatedBeforeMs: startupRecoveryCutoffMs,
+          gatewayRuntime: params.gatewayRuntime,
         }),
     )
       .then((result) => {

--- a/src/agents/subagent-orphan-recovery.restart-integration.test.ts
+++ b/src/agents/subagent-orphan-recovery.restart-integration.test.ts
@@ -11,7 +11,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { setRuntimeConfigSnapshot } from "../config/config.js";
-import { callGateway } from "../gateway/call.js";
+import type { GatewayRecoveryRuntime } from "../gateway/server-instance-runtime.types.js";
 import { createRunningTaskRun } from "../tasks/detached-task-runtime.js";
 import { findTaskByRunId } from "../tasks/task-registry.js";
 import {
@@ -20,7 +20,7 @@ import {
 } from "../tasks/task-runtime.test-helpers.js";
 import { captureEnv } from "../test-utils/env.js";
 import { cleanupSessionStateForTest } from "../test-utils/session-state-cleanup.js";
-import { recoverOrphanedSubagentSessions } from "./subagent-orphan-recovery.js";
+import { recoverOrphanedSubagentSessions as recoverOrphanedSubagentSessionsWithRuntime } from "./subagent-orphan-recovery.js";
 import {
   createSubagentRegistryTestDeps,
   readSubagentSessionStore,
@@ -36,9 +36,20 @@ import {
 } from "./subagent-registry.test-helpers.js";
 import type { SubagentRunRecord } from "./subagent-registry.types.js";
 
-vi.mock("../gateway/call.js", () => ({
-  callGateway: vi.fn(async () => ({ runId: "resumed-run-id" })),
+const dispatchAgent = vi.fn(async (_payload: Record<string, unknown>, _timeoutMs?: number) => ({
+  runId: "resumed-run-id",
 }));
+const gatewayRuntime: GatewayRecoveryRuntime = {
+  dispatchAgent: dispatchAgent as GatewayRecoveryRuntime["dispatchAgent"],
+  waitForAgent: vi.fn(),
+  sendRecoveryNotice: vi.fn(),
+};
+
+function recoverOrphanedSubagentSessions(
+  params: Omit<Parameters<typeof recoverOrphanedSubagentSessionsWithRuntime>[0], "gatewayRuntime">,
+) {
+  return recoverOrphanedSubagentSessionsWithRuntime({ ...params, gatewayRuntime });
+}
 
 vi.mock("../gateway/session-utils.fs.js", () => ({
   readSessionMessagesAsync: vi.fn(async () => []),
@@ -77,8 +88,8 @@ describe("subagent orphan recovery — faithful restart path", () => {
       runSubagentAnnounceFlow: vi.fn(async () => true),
       onAgentEvent: vi.fn(() => () => undefined),
     });
-    vi.mocked(callGateway).mockClear();
-    vi.mocked(callGateway).mockResolvedValue({ runId: "resumed-run-id" } as never);
+    dispatchAgent.mockReset();
+    dispatchAgent.mockResolvedValue({ runId: "resumed-run-id" });
   });
 
   afterEach(async () => {
@@ -134,7 +145,7 @@ describe("subagent orphan recovery — faithful restart path", () => {
     });
 
     const after = getSubagentRunByChildSessionKey(childSessionKey);
-    expect(vi.mocked(callGateway)).not.toHaveBeenCalled();
+    expect(dispatchAgent).not.toHaveBeenCalled();
     expect(after?.endedAt).toBeTypeOf("number");
     expect(after?.outcome?.status).toBe("error");
     expect(result.recovered).toBe(0);
@@ -181,16 +192,18 @@ describe("subagent orphan recovery — faithful restart path", () => {
     });
 
     console.log(
-      `[proof] fresh recovery: result=${JSON.stringify(result)} gatewayCalls=${
-        vi.mocked(callGateway).mock.calls.length
+      `[proof] fresh recovery: result=${JSON.stringify(result)} runtimeDispatches=${
+        dispatchAgent.mock.calls.length
       }`,
     );
 
-    // Fresh aborted run passed the stale gate and reached a real resume call.
-    const agentCalls = vi
-      .mocked(callGateway)
-      .mock.calls.filter((args) => (args[0] as { method?: string })?.method === "agent");
-    expect(agentCalls).toHaveLength(1);
+    // Fresh aborted run passed the stale gate and reached the instance-owned dispatcher.
+    expect(dispatchAgent).toHaveBeenCalledOnce();
+    expect(dispatchAgent.mock.calls[0]?.[0]).toMatchObject({
+      sessionKey: childSessionKey,
+      lane: "subagent",
+      deliver: false,
+    });
     expect(result.recovered).toBe(1);
   });
 
@@ -240,7 +253,7 @@ describe("subagent orphan recovery — faithful restart path", () => {
 
     const runs = listSubagentRunsForRequester("agent:main:main");
     expect(updated).toBe(1);
-    expect(callGateway).not.toHaveBeenCalled();
+    expect(dispatchAgent).not.toHaveBeenCalled();
     expect(runs.some((entry) => entry.runId === staleRecord.runId)).toBe(false);
     expect(runs).toContainEqual(expect.objectContaining({ runId: freshRecord.runId }));
     expect(runs.find((entry) => entry.runId === freshRecord.runId)?.endedAt).toBeUndefined();

--- a/src/agents/subagent-orphan-recovery.test.ts
+++ b/src/agents/subagent-orphan-recovery.test.ts
@@ -4,7 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as config from "../config/config.js";
 import * as sessions from "../config/sessions.js";
 import * as sessionAccessor from "../config/sessions/session-accessor.js";
-import * as gateway from "../gateway/call.js";
+import type { GatewayRecoveryRuntime } from "../gateway/server-instance-runtime.types.js";
 import * as sessionUtils from "../gateway/session-transcript-readers.js";
 import {
   getActiveGatewayRootWorkCount,
@@ -14,8 +14,8 @@ import {
 import { resolveInternalSessionEffectsTarget } from "./internal-session-effects.js";
 import * as announceDelivery from "./subagent-announce-delivery.js";
 import {
-  recoverOrphanedSubagentSessions,
-  scheduleOrphanRecovery,
+  recoverOrphanedSubagentSessions as recoverOrphanedSubagentSessionsWithRuntime,
+  scheduleOrphanRecovery as scheduleOrphanRecoveryWithRuntime,
 } from "./subagent-orphan-recovery.js";
 import * as subagentRegistrySteerRuntime from "./subagent-registry-steer-runtime.js";
 import type { SubagentRunRecord } from "./subagent-registry.types.js";
@@ -24,6 +24,27 @@ const loggerMocks = vi.hoisted(() => ({
   info: vi.fn(),
   warn: vi.fn(),
 }));
+
+const dispatchAgent = vi.fn(async (_payload: Record<string, unknown>, _timeoutMs?: number) => ({
+  runId: "test-run-id",
+}));
+const gatewayRuntime: GatewayRecoveryRuntime = {
+  dispatchAgent: dispatchAgent as GatewayRecoveryRuntime["dispatchAgent"],
+  waitForAgent: vi.fn(),
+  sendRecoveryNotice: vi.fn(),
+};
+
+function recoverOrphanedSubagentSessions(
+  params: Omit<Parameters<typeof recoverOrphanedSubagentSessionsWithRuntime>[0], "gatewayRuntime">,
+) {
+  return recoverOrphanedSubagentSessionsWithRuntime({ ...params, gatewayRuntime });
+}
+
+function scheduleOrphanRecovery(
+  params: Omit<Parameters<typeof scheduleOrphanRecoveryWithRuntime>[0], "getGatewayRuntime">,
+) {
+  return scheduleOrphanRecoveryWithRuntime({ ...params, getGatewayRuntime: () => gatewayRuntime });
+}
 
 // Mocks are installed before importing the recovery module so registry/runtime
 // helpers resolve to deterministic restart fixtures.
@@ -95,10 +116,6 @@ vi.mock("../config/sessions/session-accessor.js", () => ({
   patchSessionEntry: sessionMocks.patchSessionEntry,
 }));
 
-vi.mock("../gateway/call.js", () => ({
-  callGateway: vi.fn(async () => ({ runId: "test-run-id" })),
-}));
-
 vi.mock("../gateway/session-transcript-readers.js", () => ({
   readSessionMessagesAsync: vi.fn(async () => []),
 }));
@@ -160,15 +177,14 @@ async function expectSkippedRecovery(store: ReturnType<typeof sessions.loadSessi
 
   expect(result.recovered).toBe(0);
   expect(result.skipped).toBe(1);
-  expect(gateway.callGateway).not.toHaveBeenCalled();
+  expect(dispatchAgent).not.toHaveBeenCalled();
 }
 
 function getResumeMessage() {
-  const call = requireRecord(
-    firstCallParam(vi.mocked(gateway.callGateway).mock.calls, "resume gateway"),
+  const params = requireRecord(
+    firstCallParam(dispatchAgent.mock.calls, "resume gateway"),
     "resume gateway params",
   );
-  const params = call.params as Record<string, unknown>;
   return params.message as string;
 }
 
@@ -192,6 +208,8 @@ describe("subagent-orphan-recovery", () => {
     vi.useFakeTimers();
     vi.clearAllMocks();
     resetGatewayWorkAdmission();
+    dispatchAgent.mockReset();
+    dispatchAgent.mockResolvedValue({ runId: "test-run-id" });
     vi.mocked(subagentRegistrySteerRuntime.finalizeInterruptedSubagentRun)
       .mockReset()
       .mockResolvedValue(1);
@@ -226,18 +244,17 @@ describe("subagent-orphan-recovery", () => {
     expect(result.failed).toBe(0);
     expect(result.skipped).toBe(0);
 
-    // Recovery resumes through the gateway and records the new run id so the
+    // Recovery resumes through the instance runtime and records the new run id so the
     // registry follows the resumed transcript instead of the idempotency key.
-    expect(gateway.callGateway).toHaveBeenCalledOnce();
+    expect(dispatchAgent).toHaveBeenCalledOnce();
     const opts = requireRecord(
-      firstCallParam(vi.mocked(gateway.callGateway).mock.calls, "gateway resume"),
+      firstCallParam(dispatchAgent.mock.calls, "gateway resume"),
       "gateway resume params",
     );
-    expect(opts.method).toBe("agent");
-    const params = opts.params as Record<string, unknown>;
-    expect(params.sessionKey).toBe("agent:main:subagent:test-session-1");
-    expect(params.message).toContain("gateway reload");
-    expect(params.message).toContain("Test task: implement feature X");
+    expect(opts.sessionKey).toBe("agent:main:subagent:test-session-1");
+    expect(opts.message).toContain("gateway reload");
+    expect(opts.message).toContain("Test task: implement feature X");
+    expect(dispatchAgent.mock.calls[0]?.[1]).toBe(10_000);
     expect(subagentRegistrySteerRuntime.replaceSubagentRunAfterSteer).toHaveBeenCalledOnce();
     const replaceParams = requireRecord(
       firstCallParam(
@@ -259,7 +276,7 @@ describe("subagent-orphan-recovery", () => {
     expect(replaceParams.transcriptTarget).not.toEqual(
       resolveInternalSessionEffectsTarget({
         agentId: "main",
-        runId: params.idempotencyKey as string,
+        runId: opts.idempotencyKey as string,
         storePath: "/tmp/test-sessions.json",
       }),
     );
@@ -294,7 +311,7 @@ describe("subagent-orphan-recovery", () => {
     expect(result.recovered).toBe(0);
     expect(result.failed).toBe(0);
     expect(result.skipped).toBe(1);
-    expect(gateway.callGateway).not.toHaveBeenCalled();
+    expect(dispatchAgent).not.toHaveBeenCalled();
     expect(subagentRegistrySteerRuntime.finalizeInterruptedSubagentRun).toHaveBeenCalledOnce();
     const finalizeParams = requireRecord(
       firstCallParam(
@@ -334,7 +351,7 @@ describe("subagent-orphan-recovery", () => {
         error: expect.stringContaining("stale aborted subagent run not resumed"),
       },
     ]);
-    expect(gateway.callGateway).not.toHaveBeenCalled();
+    expect(dispatchAgent).not.toHaveBeenCalled();
   });
 
   it("retries a stale predecessor after its same-session successor resumes", async () => {
@@ -398,7 +415,7 @@ describe("subagent-orphan-recovery", () => {
     });
 
     expect(second).toMatchObject({ recovered: 0, failed: 0, skipped: 2 });
-    expect(gateway.callGateway).toHaveBeenCalledOnce();
+    expect(dispatchAgent).toHaveBeenCalledOnce();
     expect(subagentRegistrySteerRuntime.finalizeInterruptedSubagentRun).toHaveBeenCalledTimes(2);
     expect(subagentRegistrySteerRuntime.finalizeInterruptedSubagentRun).toHaveBeenNthCalledWith(
       2,
@@ -424,7 +441,7 @@ describe("subagent-orphan-recovery", () => {
 
     expect(result.recovered).toBe(0);
     expect(result.skipped).toBe(1);
-    expect(gateway.callGateway).not.toHaveBeenCalled();
+    expect(dispatchAgent).not.toHaveBeenCalled();
   });
 
   it("recovers restart-aborted timeout runs even when the registry marked them ended", async () => {
@@ -453,7 +470,7 @@ describe("subagent-orphan-recovery", () => {
     expect(result.recovered).toBe(1);
     expect(result.failed).toBe(0);
     expect(result.skipped).toBe(0);
-    expect(gateway.callGateway).toHaveBeenCalledOnce();
+    expect(dispatchAgent).toHaveBeenCalledOnce();
     expect(legacyTimeout.terminalOwner).toBeUndefined();
   });
 
@@ -487,7 +504,7 @@ describe("subagent-orphan-recovery", () => {
     });
     expect(config.getRuntimeConfig).not.toHaveBeenCalled();
     expect(sessions.loadSessionStore).not.toHaveBeenCalled();
-    expect(gateway.callGateway).not.toHaveBeenCalled();
+    expect(dispatchAgent).not.toHaveBeenCalled();
   });
 
   it("handles multiple orphaned sessions", async () => {
@@ -541,10 +558,10 @@ describe("subagent-orphan-recovery", () => {
 
     expect(result.recovered).toBe(2);
     expect(result.skipped).toBe(1);
-    expect(gateway.callGateway).toHaveBeenCalledTimes(2);
+    expect(dispatchAgent).toHaveBeenCalledTimes(2);
   });
 
-  it("handles callGateway failure gracefully and preserves abortedLastRun flag", async () => {
+  it("handles instance dispatch failure gracefully and preserves abortedLastRun flag", async () => {
     vi.mocked(sessions.loadSessionStore).mockReturnValue({
       "agent:main:subagent:test-session-1": {
         sessionId: "session-abc",
@@ -553,7 +570,7 @@ describe("subagent-orphan-recovery", () => {
       },
     });
 
-    vi.mocked(gateway.callGateway).mockRejectedValue(new Error("gateway unavailable"));
+    dispatchAgent.mockRejectedValue(new Error("gateway unavailable"));
 
     const activeRuns = new Map<string, SubagentRunRecord>();
     activeRuns.set("run-1", createTestRunRecord());
@@ -590,8 +607,8 @@ describe("subagent-orphan-recovery", () => {
   });
 
   it("clears abortedLastRun flag after successful resume", async () => {
-    // Ensure callGateway succeeds for this test
-    vi.mocked(gateway.callGateway).mockResolvedValue({ runId: "resumed-run" } as never);
+    // Ensure instance dispatch succeeds for this test
+    dispatchAgent.mockResolvedValue({ runId: "resumed-run" } as never);
 
     const store = {
       "agent:main:subagent:test-session-1": {
@@ -625,7 +642,7 @@ describe("subagent-orphan-recovery", () => {
   });
 
   it("persists accepted recovery attempts after successful resume", async () => {
-    vi.mocked(gateway.callGateway).mockResolvedValue({ runId: "resumed-run" } as never);
+    dispatchAgent.mockResolvedValue({ runId: "resumed-run" } as never);
     const store = mockSingleAbortedSession();
 
     await recoverOrphanedSubagentSessions({
@@ -666,7 +683,7 @@ describe("subagent-orphan-recovery", () => {
     expect(blockedRun.runId).toBe("run-1");
     expect(blockedRun.childSessionKey).toBe("agent:main:subagent:test-session-1");
     expect(blockedRun.error).toContain("recovery blocked after 2 rapid accepted resume attempts");
-    expect(gateway.callGateway).not.toHaveBeenCalled();
+    expect(dispatchAgent).not.toHaveBeenCalled();
     expect(sessionAccessor.patchSessionEntry).toHaveBeenCalledOnce();
 
     const sessionEntry = requireRecord(
@@ -700,7 +717,7 @@ describe("subagent-orphan-recovery", () => {
     expect(result.failed).toBe(0);
     expect(result.skipped).toBe(1);
     expect(result.failedRuns).toHaveLength(1);
-    expect(gateway.callGateway).not.toHaveBeenCalled();
+    expect(dispatchAgent).not.toHaveBeenCalled();
     expect(sessionAccessor.patchSessionEntry).not.toHaveBeenCalled();
   });
 
@@ -774,7 +791,7 @@ describe("subagent-orphan-recovery", () => {
   });
 
   it("prevents duplicate resume when the session accessor write fails", async () => {
-    vi.mocked(gateway.callGateway).mockResolvedValue({ runId: "new-run" } as never);
+    dispatchAgent.mockResolvedValue({ runId: "new-run" } as never);
     vi.mocked(sessionAccessor.patchSessionEntry).mockRejectedValueOnce(new Error("write failed"));
 
     vi.mocked(sessions.loadSessionStore).mockReturnValue({
@@ -798,12 +815,12 @@ describe("subagent-orphan-recovery", () => {
 
     expect(result.recovered).toBe(1);
     expect(result.skipped).toBe(1);
-    expect(gateway.callGateway).toHaveBeenCalledOnce();
+    expect(dispatchAgent).toHaveBeenCalledOnce();
     expect(sessionAccessor.patchSessionEntry).toHaveBeenCalledOnce();
   });
 
   it("does not retry a session after the gateway accepted resume but run remap failed", async () => {
-    vi.mocked(gateway.callGateway).mockResolvedValue({ runId: "new-run" } as never);
+    dispatchAgent.mockResolvedValue({ runId: "new-run" } as never);
     vi.mocked(subagentRegistrySteerRuntime.replaceSubagentRunAfterSteer).mockReturnValue(false);
 
     vi.mocked(sessions.loadSessionStore).mockReturnValue({
@@ -831,7 +848,7 @@ describe("subagent-orphan-recovery", () => {
     expect(first.failed).toBe(0);
     expect(second.recovered).toBe(0);
     expect(second.skipped).toBe(1);
-    expect(gateway.callGateway).toHaveBeenCalledOnce();
+    expect(dispatchAgent).toHaveBeenCalledOnce();
     expect(sessionAccessor.patchSessionEntry).toHaveBeenCalledOnce();
   });
 
@@ -844,7 +861,7 @@ describe("subagent-orphan-recovery", () => {
       },
     });
     const admittedRootCounts: number[] = [];
-    vi.mocked(gateway.callGateway).mockImplementation(async () => {
+    dispatchAgent.mockImplementation(async () => {
       admittedRootCounts.push(getActiveGatewayRootWorkCount());
       throw new Error("service restart");
     });
@@ -885,9 +902,34 @@ describe("subagent-orphan-recovery", () => {
         "Subagent run was interrupted by a gateway restart or connection loss. Automatic recovery failed after 2 attempts. Please retry. (service restart)",
     });
   });
+
+  it("uses the replacement Gateway runtime when the instance changes before recovery", async () => {
+    mockSingleAbortedSession();
+    const replacementDispatch = vi.fn(async () => ({ runId: "replacement-run" }));
+    const replacementRuntime: GatewayRecoveryRuntime = {
+      dispatchAgent: replacementDispatch as GatewayRecoveryRuntime["dispatchAgent"],
+      waitForAgent: vi.fn(),
+      sendRecoveryNotice: vi.fn(),
+    };
+    let currentRuntime: GatewayRecoveryRuntime | undefined = gatewayRuntime;
+
+    scheduleOrphanRecoveryWithRuntime({
+      getGatewayRuntime: () => currentRuntime,
+      getActiveRuns: () => createActiveRuns(createTestRunRecord()),
+      delayMs: 1,
+      maxRetries: 0,
+    });
+    currentRuntime = replacementRuntime;
+
+    await vi.advanceTimersByTimeAsync(1);
+
+    expect(dispatchAgent).not.toHaveBeenCalled();
+    expect(replacementDispatch).toHaveBeenCalledOnce();
+  });
+
   it("waits for suspension to reopen before mutating an orphaned session", async () => {
     mockSingleAbortedSession();
-    vi.mocked(gateway.callGateway).mockResolvedValue({ runId: "resumed-run" });
+    dispatchAgent.mockResolvedValue({ runId: "resumed-run" });
     const suspension = tryBeginGatewaySuspendAdmission(() => {});
     expect(suspension?.commit()).toBe(true);
 
@@ -898,14 +940,14 @@ describe("subagent-orphan-recovery", () => {
     });
 
     await vi.advanceTimersByTimeAsync(1);
-    expect(gateway.callGateway).not.toHaveBeenCalled();
+    expect(dispatchAgent).not.toHaveBeenCalled();
     expect(sessionAccessor.patchSessionEntry).not.toHaveBeenCalled();
     expect(getActiveGatewayRootWorkCount()).toBe(0);
 
     expect(suspension?.release()).toBe(true);
     await vi.advanceTimersByTimeAsync(0);
 
-    expect(gateway.callGateway).toHaveBeenCalledOnce();
+    expect(dispatchAgent).toHaveBeenCalledOnce();
     expect(sessionAccessor.patchSessionEntry).toHaveBeenCalledOnce();
     expect(getActiveGatewayRootWorkCount()).toBe(0);
   });
@@ -914,7 +956,7 @@ describe("subagent-orphan-recovery", () => {
     "retries the exact interrupted terminal when finalization first %s",
     async (mode) => {
       mockSingleAbortedSession();
-      vi.mocked(gateway.callGateway).mockRejectedValueOnce(new Error("service restart"));
+      dispatchAgent.mockRejectedValueOnce(new Error("service restart"));
       if (mode === "returns zero") {
         vi.mocked(
           subagentRegistrySteerRuntime.finalizeInterruptedSubagentRun,
@@ -948,7 +990,7 @@ describe("subagent-orphan-recovery", () => {
 
   it("logs an incomplete interrupted terminal after its retry budget is exhausted", async () => {
     mockSingleAbortedSession();
-    vi.mocked(gateway.callGateway).mockRejectedValueOnce(new Error("service restart"));
+    dispatchAgent.mockRejectedValueOnce(new Error("service restart"));
     vi.mocked(subagentRegistrySteerRuntime.finalizeInterruptedSubagentRun).mockResolvedValue(0);
 
     scheduleOrphanRecovery({

--- a/src/agents/subagent-orphan-recovery.ts
+++ b/src/agents/subagent-orphan-recovery.ts
@@ -18,7 +18,7 @@ import {
   type SessionEntry,
 } from "../config/sessions.js";
 import { loadSessionEntry, patchSessionEntry } from "../config/sessions/session-accessor.js";
-import { callGateway } from "../gateway/call.js";
+import type { GatewayRecoveryRuntime } from "../gateway/server-instance-runtime.types.js";
 import { readSessionMessagesAsync } from "../gateway/session-transcript-readers.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
@@ -149,9 +149,10 @@ function extractMessageText(msg: unknown): string | undefined {
 }
 
 /**
- * Send a resume message to an orphaned subagent session via the gateway agent method.
+ * Send a resume message through the owning Gateway's in-process agent dispatcher.
  */
 async function resumeOrphanedSession(params: {
+  gatewayRuntime: GatewayRecoveryRuntime;
   sessionKey: string;
   task: string;
   lastHumanMessage?: string;
@@ -166,9 +167,8 @@ async function resumeOrphanedSession(params: {
 
   try {
     const idempotencyKey = crypto.randomUUID();
-    const result = await callGateway<{ runId: string }>({
-      method: "agent",
-      params: {
+    const result = await params.gatewayRuntime.dispatchAgent<{ runId: string }>(
+      {
         message: resumeMessage,
         sessionKey: params.sessionKey,
         idempotencyKey,
@@ -183,8 +183,8 @@ async function resumeOrphanedSession(params: {
         sessionEffects: "internal",
         suppressPromptPersistence: true,
       },
-      timeoutMs: 10_000,
-    });
+      10_000,
+    );
     const remapped = replaceSubagentRunAfterSteer({
       previousRunId: params.originalRunId,
       nextRunId: result.runId,
@@ -229,6 +229,7 @@ async function resumeOrphanedSession(params: {
  * 2. Send a synthetic resume message to trigger a new LLM turn
  */
 export async function recoverOrphanedSubagentSessions(params: {
+  gatewayRuntime: GatewayRecoveryRuntime;
   getActiveRuns: () => Map<string, SubagentRunRecord>;
   /** Persisted across retries so already-resumed sessions are not resumed again. */
   resumedSessionKeys?: Set<string>;
@@ -457,9 +458,10 @@ export async function recoverOrphanedSubagentSessions(params: {
 
         // Resume the session with the original task context.
         // We intentionally do NOT clear abortedLastRun before attempting
-        // the resume — if callGateway fails (e.g. gateway still booting),
+        // the resume — if instance dispatch fails (e.g. Gateway still booting),
         // the flag stays true so the next restart can retry.
         const resumeResult = await resumeOrphanedSession({
+          gatewayRuntime: params.gatewayRuntime,
           sessionKey: childSessionKey,
           task: runRecord.task,
           lastHumanMessage: extractMessageText(lastHumanMessage),
@@ -588,6 +590,7 @@ async function finalizeInterruptedRunWithRetry(params: {
  * If recovery fails (e.g. gateway not yet ready), retries with exponential backoff.
  */
 export function scheduleOrphanRecovery(params: {
+  getGatewayRuntime: () => GatewayRecoveryRuntime | undefined;
   getActiveRuns: () => Map<string, SubagentRunRecord>;
   delayMs?: number;
   maxRetries?: number;
@@ -602,8 +605,18 @@ export function scheduleOrphanRecovery(params: {
       // Every delayed/retry scan owns a fresh root lease. Keep terminal
       // mutation in the same lease so suspension cannot become ready mid-attempt.
       void runWithGatewayIndependentRootWorkAdmission(async () => {
+        // Resolve at attempt time so a Gateway replacement cannot leave a
+        // debounced recovery bound to the closed instance it was scheduled by.
+        const gatewayRuntime = params.getGatewayRuntime();
+        if (!gatewayRuntime) {
+          if (attempt < maxRetries) {
+            attemptRecovery(attempt + 1, delay * RETRY_BACKOFF_MULTIPLIER);
+          }
+          return;
+        }
         const result = await recoverOrphanedSubagentSessions({
-          ...params,
+          gatewayRuntime,
+          getActiveRuns: params.getActiveRuns,
           resumedSessionKeys,
           pendingStaleFinalizations,
         });

--- a/src/agents/subagent-registry.announce-loop-guard.test.ts
+++ b/src/agents/subagent-registry.announce-loop-guard.test.ts
@@ -42,6 +42,8 @@ vi.mock("../config/sessions.js", () => ({
 }));
 
 vi.mock("../config/sessions/session-accessor.js", () => ({
+  listSessionEntries: () =>
+    Object.entries(sessionStore).map(([sessionKey, entry]) => ({ sessionKey, entry })),
   loadSessionEntry: (scope: { sessionKey: keyof typeof sessionStore }) =>
     sessionStore[scope.sessionKey],
   patchSessionEntry: async () => null,

--- a/src/agents/subagent-registry.persistence.test-support.ts
+++ b/src/agents/subagent-registry.persistence.test-support.ts
@@ -75,6 +75,11 @@ export function createSubagentRegistryTestDeps(
     ensureContextEnginesInitialized: vi.fn(),
     ensureRuntimePluginsLoaded: vi.fn(),
     getRuntimeConfig: vi.fn(() => ({})),
+    getGatewayRecoveryRuntime: vi.fn(() => ({
+      dispatchAgent: vi.fn(),
+      waitForAgent: vi.fn(),
+      sendRecoveryNotice: vi.fn(),
+    })),
     resolveAgentTimeoutMs: vi.fn(() => 100),
     resolveContextEngine: vi.fn(async () => ({
       info: { id: "test", name: "Test", version: "0.0.1" },

--- a/src/agents/subagent-registry.persistence.test.ts
+++ b/src/agents/subagent-registry.persistence.test.ts
@@ -768,16 +768,11 @@ describe("subagent registry persistence", () => {
     });
 
     restartRegistry();
-    await waitForRegistryWork(
-      () =>
-        vi.mocked(callGateway).mock.calls.length > 0 &&
-        vi.mocked(scheduleOrphanRecovery).mock.calls.length > 0,
-    );
+    await waitForRegistryWork(() => vi.mocked(scheduleOrphanRecovery).mock.calls.length > 0);
 
-    expect(callGateway).toHaveBeenCalledTimes(1);
-    const [request] = vi.mocked(callGateway).mock.calls.at(0) ?? [];
-    expectFields(request, { method: "agent.wait" });
-    expectFields((request as { params?: unknown } | undefined)?.params, { runId });
+    // The dead pre-restart run must not be queried before orphan recovery can
+    // replace it with a fresh turn through the Gateway-owned runtime.
+    expect(callGateway).not.toHaveBeenCalled();
     expect(scheduleOrphanRecovery).toHaveBeenCalledOnce();
     expect(
       listSubagentRunsForRequester("agent:main:main").some((entry) => entry.runId === runId),

--- a/src/agents/subagent-registry.test-helpers.ts
+++ b/src/agents/subagent-registry.test-helpers.ts
@@ -36,6 +36,9 @@ type RegistryTestApi = {
 
 type RegistryDeps = {
   callGateway: typeof import("../gateway/call.js").callGateway;
+  getGatewayRecoveryRuntime: () =>
+    | import("../gateway/server-instance-runtime.types.js").GatewayRecoveryRuntime
+    | undefined;
   captureSubagentCompletionReply: typeof import("./subagent-announce.js").captureSubagentCompletionReply;
   cleanupBrowserSessionsForLifecycleEnd: typeof import("../browser-lifecycle-cleanup.js").cleanupBrowserSessionsForLifecycleEnd;
   getSubagentRunsSnapshotForRead: typeof import("./subagent-registry-state.js").getSubagentRunsSnapshotForRead;

--- a/src/agents/subagent-registry.test.ts
+++ b/src/agents/subagent-registry.test.ts
@@ -187,6 +187,11 @@ const mocks = vi.hoisted(() => ({
   runSubagentEnded: vi.fn(async () => {}),
   removeInternalSessionEffectsSession: vi.fn(async () => {}),
   resolveAgentTimeoutMs: vi.fn(() => 1_000),
+  getGatewayRecoveryRuntime: vi.fn(() => ({
+    dispatchAgent: vi.fn(),
+    waitForAgent: vi.fn(),
+    sendRecoveryNotice: vi.fn(),
+  })),
   scheduleOrphanRecovery: vi.fn(),
 }));
 
@@ -314,6 +319,7 @@ describe("subagent registry seam flow", () => {
       callGateway: mocks.callGateway as typeof import("../gateway/call.js").callGateway,
       captureSubagentCompletionReply: mocks.captureSubagentCompletionReply,
       cleanupBrowserSessionsForLifecycleEnd: mocks.cleanupBrowserSessionsForLifecycleEnd,
+      getGatewayRecoveryRuntime: mocks.getGatewayRecoveryRuntime,
       onAgentEvent: mocks.onAgentEvent,
       persistSubagentRunsToDisk: mocks.persistSubagentRunsToDisk,
       persistSubagentRunsToDiskOrThrow: mocks.persistSubagentRunsToDiskOrThrow,
@@ -610,6 +616,51 @@ describe("subagent registry seam flow", () => {
       .find((entry) => entry.runId === "run-interrupted-wait");
     expect(run?.endedAt).toBeUndefined();
     expect(run?.outcome).toBeUndefined();
+  });
+
+  it("does not fall back to network recovery without an instance-bound runtime", async () => {
+    mod.testing.setDepsForTest({
+      getGatewayRecoveryRuntime: () => undefined,
+    });
+
+    mod.scheduleSubagentOrphanRecovery({ delayMs: 1 });
+    await Promise.resolve();
+
+    expect(mocks.scheduleOrphanRecovery).not.toHaveBeenCalled();
+  });
+
+  it("keeps a debounced recovery bound to the current Gateway runtime", async () => {
+    const originalImplementation = mocks.getGatewayRecoveryRuntime.getMockImplementation();
+    const firstRuntime = {
+      dispatchAgent: vi.fn(),
+      waitForAgent: vi.fn(),
+      sendRecoveryNotice: vi.fn(),
+    };
+    const replacementRuntime = {
+      dispatchAgent: vi.fn(),
+      waitForAgent: vi.fn(),
+      sendRecoveryNotice: vi.fn(),
+    };
+    mocks.getGatewayRecoveryRuntime.mockReturnValue(firstRuntime);
+
+    try {
+      mod.scheduleSubagentOrphanRecovery({ delayMs: 1 });
+      await waitForFast(() => expect(mocks.scheduleOrphanRecovery).toHaveBeenCalledOnce());
+      const scheduled = requireRecord(
+        getMockCallArg(mocks.scheduleOrphanRecovery, 0, 0, "orphan recovery"),
+        "orphan recovery params",
+      );
+      const getGatewayRuntime = scheduled.getGatewayRuntime;
+      expect(typeof getGatewayRuntime).toBe("function");
+
+      mocks.getGatewayRecoveryRuntime.mockReturnValue(replacementRuntime);
+      mod.scheduleSubagentOrphanRecovery({ delayMs: 1 });
+
+      expect(mocks.scheduleOrphanRecovery).toHaveBeenCalledOnce();
+      expect((getGatewayRuntime as () => unknown)()).toBe(replacementRuntime);
+    } finally {
+      mocks.getGatewayRecoveryRuntime.mockImplementation(originalImplementation!);
+    }
   });
 
   it("keeps parent run active when agent.wait times out before child session settles", async () => {

--- a/src/agents/subagent-registry.test.ts
+++ b/src/agents/subagent-registry.test.ts
@@ -11,6 +11,7 @@ import type {
   SessionEntryPatchContext,
   SessionEntryPatchOptions,
 } from "../config/sessions/session-accessor.js";
+import type { GatewayRecoveryRuntime } from "../gateway/server-instance-runtime.types.js";
 import { registerGatewayRecoveryRuntime } from "../gateway/server-recovery-runtime-context.js";
 import type { AgentEventPayload } from "../infra/agent-events.js";
 import {
@@ -623,7 +624,7 @@ describe("subagent registry seam flow", () => {
     const waitForAgent = vi.fn(async () => ({ status: "pending" }));
     const release = registerGatewayRecoveryRuntime({
       dispatchAgent: vi.fn(),
-      waitForAgent,
+      waitForAgent: waitForAgent as GatewayRecoveryRuntime["waitForAgent"],
       sendRecoveryNotice: vi.fn(),
     });
 

--- a/src/agents/subagent-registry.test.ts
+++ b/src/agents/subagent-registry.test.ts
@@ -11,8 +11,6 @@ import type {
   SessionEntryPatchContext,
   SessionEntryPatchOptions,
 } from "../config/sessions/session-accessor.js";
-import type { GatewayRecoveryRuntime } from "../gateway/server-instance-runtime.types.js";
-import { registerGatewayRecoveryRuntime } from "../gateway/server-recovery-runtime-context.js";
 import type { AgentEventPayload } from "../infra/agent-events.js";
 import {
   getActiveGatewayRootWorkCount,
@@ -618,38 +616,6 @@ describe("subagent registry seam flow", () => {
       .find((entry) => entry.runId === "run-interrupted-wait");
     expect(run?.endedAt).toBeUndefined();
     expect(run?.outcome).toBeUndefined();
-  });
-
-  it("waits through the active Gateway instance runtime when lifecycle-owned", async () => {
-    const waitForAgent = vi.fn(async () => ({ status: "pending" }));
-    const release = registerGatewayRecoveryRuntime({
-      dispatchAgent: vi.fn(),
-      waitForAgent: waitForAgent as GatewayRecoveryRuntime["waitForAgent"],
-      sendRecoveryNotice: vi.fn(),
-    });
-
-    try {
-      mod.registerSubagentRun({
-        runId: "run-instance-wait",
-        childSessionKey: "agent:main:subagent:instance-wait",
-        requesterSessionKey: "agent:main:main",
-        requesterDisplayKey: "main",
-        task: "wait in process",
-        cleanup: "keep",
-      });
-
-      await waitForFast(() => expect(waitForAgent).toHaveBeenCalledOnce());
-
-      expect(waitForAgent).toHaveBeenCalledWith(
-        { runId: "run-instance-wait", timeoutMs: 1_000 },
-        3_000,
-      );
-      expect(mocks.callGateway).not.toHaveBeenCalledWith(
-        expect.objectContaining({ method: "agent.wait" }),
-      );
-    } finally {
-      release();
-    }
   });
 
   it("does not fall back to network recovery without an instance-bound runtime", async () => {

--- a/src/agents/subagent-registry.test.ts
+++ b/src/agents/subagent-registry.test.ts
@@ -11,6 +11,7 @@ import type {
   SessionEntryPatchContext,
   SessionEntryPatchOptions,
 } from "../config/sessions/session-accessor.js";
+import { registerGatewayRecoveryRuntime } from "../gateway/server-recovery-runtime-context.js";
 import type { AgentEventPayload } from "../infra/agent-events.js";
 import {
   getActiveGatewayRootWorkCount,
@@ -616,6 +617,38 @@ describe("subagent registry seam flow", () => {
       .find((entry) => entry.runId === "run-interrupted-wait");
     expect(run?.endedAt).toBeUndefined();
     expect(run?.outcome).toBeUndefined();
+  });
+
+  it("waits through the active Gateway instance runtime when lifecycle-owned", async () => {
+    const waitForAgent = vi.fn(async () => ({ status: "pending" }));
+    const release = registerGatewayRecoveryRuntime({
+      dispatchAgent: vi.fn(),
+      waitForAgent,
+      sendRecoveryNotice: vi.fn(),
+    });
+
+    try {
+      mod.registerSubagentRun({
+        runId: "run-instance-wait",
+        childSessionKey: "agent:main:subagent:instance-wait",
+        requesterSessionKey: "agent:main:main",
+        requesterDisplayKey: "main",
+        task: "wait in process",
+        cleanup: "keep",
+      });
+
+      await waitForFast(() => expect(waitForAgent).toHaveBeenCalledOnce());
+
+      expect(waitForAgent).toHaveBeenCalledWith(
+        { runId: "run-instance-wait", timeoutMs: 1_000 },
+        3_000,
+      );
+      expect(mocks.callGateway).not.toHaveBeenCalledWith(
+        expect.objectContaining({ method: "agent.wait" }),
+      );
+    } finally {
+      release();
+    }
   });
 
   it("does not fall back to network recovery without an instance-bound runtime", async () => {

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -949,7 +949,18 @@ function restoreSubagentRunsOnce() {
     ensureListener();
     // Always start sweeper — session-mode runs (no archiveAtMs) also need TTL cleanup.
     startSweeper();
-    for (const runId of subagentRuns.keys()) {
+    const restoredSessionCache: SubagentSessionStoreCache = new Map();
+    for (const [runId, entry] of subagentRuns) {
+      // An aborted persisted session belongs to orphan recovery. Waiting on its
+      // pre-restart run can terminalize it before the replacement turn starts.
+      if (
+        loadSubagentSessionEntry({
+          childSessionKey: entry.childSessionKey,
+          storeCache: restoredSessionCache,
+        })?.abortedLastRun === true
+      ) {
+        continue;
+      }
       resumeSubagentRun(runId);
     }
 

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -1693,7 +1693,20 @@ const subagentRunManager = createSubagentRunManager({
   resumedRuns,
   persist: persistSubagentRuns,
   persistOrThrow: persistSubagentRunsOrThrow,
-  callGateway: (request) => subagentRegistryDeps.callGateway(request),
+  callGateway: async <T>(request: Parameters<typeof callGateway>[0]) => {
+    if (request.method === "agent.wait") {
+      const gatewayRuntime = getGatewayRecoveryRuntime();
+      if (gatewayRuntime) {
+        // Registry waits are Gateway-owned lifecycle work. Keep them on the
+        // owning instance when one exists; standalone processes authenticate normally.
+        return await gatewayRuntime.waitForAgent<T>(
+          (request.params ?? {}) as Record<string, unknown>,
+          request.timeoutMs ?? undefined,
+        );
+      }
+    }
+    return await subagentRegistryDeps.callGateway<T>(request);
+  },
   getRuntimeConfig: () => subagentRegistryDeps.getRuntimeConfig(),
   ensureListener,
   startSweeper,

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -9,6 +9,8 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { ResolveContextEngineOptions } from "../context-engine/registry.js";
 import type { ContextEngine, SubagentEndReason } from "../context-engine/types.js";
 import { callGateway } from "../gateway/call.js";
+import type { GatewayRecoveryRuntime } from "../gateway/server-instance-runtime.types.js";
+import { getGatewayRecoveryRuntime } from "../gateway/server-recovery-runtime-context.js";
 import { getAgentRunContext, onAgentEvent } from "../infra/agent-events.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import {
@@ -119,6 +121,7 @@ type BrowserCleanupModule = Pick<
 
 type SubagentRegistryDeps = {
   callGateway: typeof callGateway;
+  getGatewayRecoveryRuntime: () => GatewayRecoveryRuntime | undefined;
   captureSubagentCompletionReply: SubagentAnnounceModule["captureSubagentCompletionReply"];
   cleanupBrowserSessionsForLifecycleEnd: typeof cleanupBrowserSessionsForLifecycleEnd;
   getSubagentRunsSnapshotForRead: typeof getSubagentRunsSnapshotForRead;
@@ -158,6 +161,7 @@ async function loadCleanupBrowserSessionsForLifecycleEnd(): Promise<
 
 const defaultSubagentRegistryDeps: SubagentRegistryDeps = {
   callGateway,
+  getGatewayRecoveryRuntime,
   captureSubagentCompletionReply: async (sessionKey, options) =>
     (await loadSubagentAnnounceModule()).captureSubagentCompletionReply(sessionKey, options),
   cleanupBrowserSessionsForLifecycleEnd: async (params) =>
@@ -366,6 +370,11 @@ function resolveCompletionFromTerminalTask(
 }
 
 export function scheduleSubagentOrphanRecovery(params?: { delayMs?: number; maxRetries?: number }) {
+  const gatewayRuntime = subagentRegistryDeps.getGatewayRecoveryRuntime();
+  if (!gatewayRuntime) {
+    log.warn("subagent orphan recovery deferred until the Gateway instance runtime is available");
+    return;
+  }
   const now = Date.now();
   if (now - lastOrphanRecoveryScheduleAt < ORPHAN_RECOVERY_DEBOUNCE_MS) {
     return;
@@ -376,6 +385,9 @@ export function scheduleSubagentOrphanRecovery(params?: { delayMs?: number; maxR
       // This import only installs timers. Each delayed or retrying recovery
       // attempt owns independent root admission inside the recovery module.
       scheduleOrphanRecovery({
+        // Retries follow the process's current lifecycle-bound Gateway
+        // principal instead of retaining the instance that scheduled them.
+        getGatewayRuntime: subagentRegistryDeps.getGatewayRecoveryRuntime,
         getActiveRuns: () => subagentRuns,
         delayMs: params?.delayMs,
         maxRetries: params?.maxRetries,
@@ -941,8 +953,8 @@ function restoreSubagentRunsOnce() {
       resumeSubagentRun(runId);
     }
 
-    // Cold-start restore path: queue the same recovery pass that restart
-    // startup also uses so resumed children are handled through one seam.
+    // Cold-start restore can precede instance-runtime registration. The post-attach
+    // startup pass retries this seam once the lifecycle-bound principal exists.
     scheduleSubagentOrphanRecovery();
   } catch (err) {
     log.warn(

--- a/src/channels/plugins/exec-approval-local.ts
+++ b/src/channels/plugins/exec-approval-local.ts
@@ -5,7 +5,7 @@
  */
 import type { ReplyPayload } from "../../auto-reply/reply-payload.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import { getGatewayNativeApprovalRuntime } from "../../infra/approval-gateway-resolver.js";
+import { getGatewayNativeApprovalRuntime } from "../../infra/approval-gateway-runtime-context.js";
 import { hasActiveApprovalNativeRouteRuntime } from "../../infra/approval-native-route-coordinator.js";
 import { getChannelPlugin, normalizeChannelId } from "./registry.js";
 

--- a/src/channels/plugins/exec-approval-local.ts
+++ b/src/channels/plugins/exec-approval-local.ts
@@ -5,6 +5,7 @@
  */
 import type { ReplyPayload } from "../../auto-reply/reply-payload.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { getGatewayNativeApprovalRuntime } from "../../infra/approval-gateway-resolver.js";
 import { hasActiveApprovalNativeRouteRuntime } from "../../infra/approval-native-route-coordinator.js";
 import { getChannelPlugin, normalizeChannelId } from "./registry.js";
 
@@ -28,11 +29,17 @@ export function shouldSuppressLocalExecApprovalPrompt(params: {
       hint: {
         kind: "approval-pending",
         approvalKind: "exec",
-        nativeRouteActive: hasActiveApprovalNativeRouteRuntime({
-          channel,
-          accountId: params.accountId,
-          approvalKind: "exec",
-        }),
+        nativeRouteActive:
+          getGatewayNativeApprovalRuntime()?.routeCoordinator.hasActiveRuntime({
+            channel,
+            accountId: params.accountId,
+            approvalKind: "exec",
+          }) ??
+          hasActiveApprovalNativeRouteRuntime({
+            channel,
+            accountId: params.accountId,
+            approvalKind: "exec",
+          }),
       },
     }) ?? false
   );

--- a/src/gateway/server-channels.approval-bootstrap.test.ts
+++ b/src/gateway/server-channels.approval-bootstrap.test.ts
@@ -3,7 +3,8 @@
  */
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ChannelId, ChannelPlugin } from "../channels/plugins/types.public.js";
-import { getGatewayNativeApprovalRuntime } from "../infra/approval-gateway-resolver.js";
+import { getGatewayNativeApprovalRuntime } from "../infra/approval-gateway-runtime-context.js";
+import type { GatewayNativeApprovalRuntime } from "../infra/approval-gateway-runtime.types.js";
 import {
   createSubsystemLogger,
   runtimeForLogger,
@@ -15,7 +16,6 @@ import { createRuntimeChannel } from "../plugins/runtime/runtime-channel.js";
 import type { PluginRuntime } from "../plugins/runtime/types.js";
 import { DEFAULT_ACCOUNT_ID } from "../routing/session-key.js";
 import type { RuntimeEnv } from "../runtime.js";
-import type { GatewayNativeApprovalRuntime } from "./server-instance-runtime.js";
 
 const hoisted = vi.hoisted(() => ({
   startChannelApprovalHandlerBootstrap: vi.fn(async () => async () => {}),

--- a/src/gateway/server-channels.approval-bootstrap.test.ts
+++ b/src/gateway/server-channels.approval-bootstrap.test.ts
@@ -3,6 +3,7 @@
  */
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ChannelId, ChannelPlugin } from "../channels/plugins/types.public.js";
+import { getGatewayNativeApprovalRuntime } from "../infra/approval-gateway-resolver.js";
 import {
   createSubsystemLogger,
   runtimeForLogger,
@@ -14,6 +15,7 @@ import { createRuntimeChannel } from "../plugins/runtime/runtime-channel.js";
 import type { PluginRuntime } from "../plugins/runtime/types.js";
 import { DEFAULT_ACCOUNT_ID } from "../routing/session-key.js";
 import type { RuntimeEnv } from "../runtime.js";
+import type { GatewayNativeApprovalRuntime } from "./server-instance-runtime.js";
 
 const hoisted = vi.hoisted(() => ({
   startChannelApprovalHandlerBootstrap: vi.fn(async () => async () => {}),
@@ -91,6 +93,7 @@ function createManager(
   createChannelManager: typeof import("./server-channels.js").createChannelManager,
   options?: {
     channelRuntime?: PluginRuntime["channel"];
+    nativeApprovalRuntime?: GatewayNativeApprovalRuntime;
   },
 ) {
   const log = createSubsystemLogger("gateway/server-channels-approval-bootstrap-test");
@@ -102,6 +105,9 @@ function createManager(
     channelLogs,
     channelRuntimeEnvs,
     ...(options?.channelRuntime ? { channelRuntime: options.channelRuntime } : {}),
+    ...(options?.nativeApprovalRuntime
+      ? { getNativeApprovalRuntime: () => options.nativeApprovalRuntime }
+      : {}),
   });
 }
 
@@ -125,6 +131,12 @@ describe("server-channels approval bootstrap", () => {
   it("starts and stops the shared approval bootstrap with the channel lifecycle", async () => {
     const channelRuntime = createRuntimeChannel();
     const stopApprovalBootstrap = vi.fn(async () => {});
+    const nativeApprovalRuntime = {
+      request: vi.fn(),
+      requestRoute: vi.fn(),
+      routeCoordinator: {} as never,
+      subscribe: vi.fn(),
+    } as GatewayNativeApprovalRuntime;
     hoisted.startChannelApprovalHandlerBootstrap.mockResolvedValue(stopApprovalBootstrap);
 
     const started = createDeferred();
@@ -134,6 +146,7 @@ describe("server-channels approval bootstrap", () => {
         abortSignal,
         channelRuntime: channelRuntimeLocal,
       }: Parameters<NonNullable<NonNullable<ChannelPlugin["gateway"]>["startAccount"]>>[0]) => {
+        expect(getGatewayNativeApprovalRuntime()).toBe(nativeApprovalRuntime);
         channelRuntimeLocal?.runtimeContexts.register({
           channelId: "discord",
           accountId: DEFAULT_ACCOUNT_ID,
@@ -155,7 +168,10 @@ describe("server-channels approval bootstrap", () => {
     );
 
     installTestRegistry(createTestPlugin({ startAccount }));
-    const manager = createManager(createChannelManager, { channelRuntime });
+    const manager = createManager(createChannelManager, {
+      channelRuntime,
+      nativeApprovalRuntime,
+    });
 
     await manager.startChannels();
     await started.promise;
@@ -168,6 +184,7 @@ describe("server-channels approval bootstrap", () => {
           cfg: unknown;
           accountId?: string;
           channelRuntime?: PluginRuntime["channel"];
+          gatewayRuntime?: GatewayNativeApprovalRuntime;
         },
       ]
     >;
@@ -175,6 +192,7 @@ describe("server-channels approval bootstrap", () => {
     expect(approvalBootstrapArg?.plugin.id).toBe("discord");
     expect(approvalBootstrapArg?.cfg).toEqual({});
     expect(approvalBootstrapArg?.accountId).toBe(DEFAULT_ACCOUNT_ID);
+    expect(approvalBootstrapArg?.gatewayRuntime).toBe(nativeApprovalRuntime);
     expect(typeof approvalBootstrapArg?.channelRuntime?.runtimeContexts.register).toBe("function");
     expect(typeof approvalBootstrapArg?.channelRuntime?.runtimeContexts.get).toBe("function");
     expect(typeof approvalBootstrapArg?.channelRuntime?.runtimeContexts.watch).toBe("function");

--- a/src/gateway/server-channels.ts
+++ b/src/gateway/server-channels.ts
@@ -5,6 +5,7 @@ import { resolveChannelDefaultAccountId } from "../channels/plugins/helpers.js";
 import { type ChannelId, getChannelPlugin, listChannelPlugins } from "../channels/plugins/index.js";
 import type { ChannelAccountSnapshot } from "../channels/plugins/types.public.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { withGatewayNativeApprovalRuntime } from "../infra/approval-gateway-resolver.js";
 import { startChannelApprovalHandlerBootstrap } from "../infra/approval-handler-bootstrap.js";
 import { type BackoffPolicy, sleepWithAbort } from "../infra/backoff.js";
 import { createTaskScopedChannelRuntime } from "../infra/channel-runtime-context.js";
@@ -31,6 +32,7 @@ import type {
   ChannelRuntimeSnapshot,
   StartChannelOptions,
 } from "./server-channel-runtime.types.js";
+import type { GatewayNativeApprovalRuntime } from "./server-instance-runtime.js";
 
 const RESTART_POLICY: BackoffPolicy = {
   initialMs: 5_000,
@@ -214,6 +216,7 @@ type ChannelManagerOptions = {
   getPluginHttpRouteRegistry?: () => PluginRegistry;
   startupTrace?: GatewayStartupTrace;
   deferStartupAccountStartsUntil?: Promise<void>;
+  getNativeApprovalRuntime?: () => GatewayNativeApprovalRuntime | undefined;
 };
 
 type StopChannelOptions = {
@@ -612,6 +615,7 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
                   cfg,
                   accountId: id,
                   channelRuntime: channelRuntimeForTask,
+                  gatewayRuntime: opts.getNativeApprovalRuntime?.(),
                   logger: log,
                 }),
             );
@@ -649,20 +653,22 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
                   channelRunDurationMs = Date.now() - startedAt;
                 };
                 try {
-                  return startAccount({
-                    cfg,
-                    accountId: id,
-                    account,
-                    runtime,
-                    abortSignal: abort.signal,
-                    log,
-                    getStatus: () => getRuntime(channelId, id),
-                    setStatus: (next) =>
-                      isCurrentTask()
-                        ? setRuntimeFromTaskStatus(channelId, id, next, abort.signal)
-                        : getRuntime(channelId, id),
-                    ...(channelRuntimeForTask ? { channelRuntime: channelRuntimeForTask } : {}),
-                  }).finally(recordDuration);
+                  return withGatewayNativeApprovalRuntime(opts.getNativeApprovalRuntime?.(), () =>
+                    startAccount({
+                      cfg,
+                      accountId: id,
+                      account,
+                      runtime,
+                      abortSignal: abort.signal,
+                      log,
+                      getStatus: () => getRuntime(channelId, id),
+                      setStatus: (next) =>
+                        isCurrentTask()
+                          ? setRuntimeFromTaskStatus(channelId, id, next, abort.signal)
+                          : getRuntime(channelId, id),
+                      ...(channelRuntimeForTask ? { channelRuntime: channelRuntimeForTask } : {}),
+                    }),
+                  ).finally(recordDuration);
                 } catch (error) {
                   recordDuration();
                   throw error;

--- a/src/gateway/server-channels.ts
+++ b/src/gateway/server-channels.ts
@@ -5,7 +5,8 @@ import { resolveChannelDefaultAccountId } from "../channels/plugins/helpers.js";
 import { type ChannelId, getChannelPlugin, listChannelPlugins } from "../channels/plugins/index.js";
 import type { ChannelAccountSnapshot } from "../channels/plugins/types.public.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { withGatewayNativeApprovalRuntime } from "../infra/approval-gateway-resolver.js";
+import { withGatewayNativeApprovalRuntime } from "../infra/approval-gateway-runtime-context.js";
+import type { GatewayNativeApprovalRuntime } from "../infra/approval-gateway-runtime.types.js";
 import { startChannelApprovalHandlerBootstrap } from "../infra/approval-handler-bootstrap.js";
 import { type BackoffPolicy, sleepWithAbort } from "../infra/backoff.js";
 import { createTaskScopedChannelRuntime } from "../infra/channel-runtime-context.js";
@@ -32,7 +33,6 @@ import type {
   ChannelRuntimeSnapshot,
   StartChannelOptions,
 } from "./server-channel-runtime.types.js";
-import type { GatewayNativeApprovalRuntime } from "./server-instance-runtime.js";
 
 const RESTART_POLICY: BackoffPolicy = {
   initialMs: 5_000,

--- a/src/gateway/server-in-process-dispatch.ts
+++ b/src/gateway/server-in-process-dispatch.ts
@@ -12,7 +12,7 @@ export type GatewayMethodDispatchResponse = {
   meta?: Record<string, unknown>;
 };
 
-export type InProcessGatewayDispatchOptions = {
+type InProcessGatewayDispatchOptions = {
   client: GatewayRequestOptions["client"];
   context: GatewayRequestOptions["context"];
   expectFinal?: boolean;

--- a/src/gateway/server-in-process-dispatch.ts
+++ b/src/gateway/server-in-process-dispatch.ts
@@ -1,0 +1,194 @@
+import { randomUUID } from "node:crypto";
+import { GatewayClientRequestError } from "../../packages/gateway-client/src/index.js";
+import type { ErrorShape } from "../../packages/gateway-protocol/src/schema/frames.js";
+import { resolveSafeTimeoutDelayMs } from "../utils/timer-delay.js";
+import type { GatewayMethodRegistry } from "./methods/registry.js";
+import type { GatewayRequestOptions } from "./server-methods/types.js";
+
+export type GatewayMethodDispatchResponse = {
+  ok: boolean;
+  payload?: unknown;
+  error?: ErrorShape;
+  meta?: Record<string, unknown>;
+};
+
+export type InProcessGatewayDispatchOptions = {
+  client: GatewayRequestOptions["client"];
+  context: GatewayRequestOptions["context"];
+  expectFinal?: boolean;
+  isWebchatConnect?: GatewayRequestOptions["isWebchatConnect"];
+  methodRegistry?: GatewayMethodRegistry;
+  onAccepted?: (payload: unknown) => void;
+  requestIdPrefix?: string;
+  timeoutMs?: number;
+};
+
+export function unwrapGatewayMethodDispatchResponse(
+  method: string,
+  response: GatewayMethodDispatchResponse,
+): unknown {
+  if (!response.ok) {
+    throw new GatewayClientRequestError({
+      code: response.error?.code,
+      message: response.error?.message ?? `Gateway method "${method}" failed.`,
+      details: response.error?.details,
+      retryable: response.error?.retryable,
+      retryAfterMs: response.error?.retryAfterMs,
+    });
+  }
+  return response.payload;
+}
+
+function resolveDispatchDeadlineMs(timeoutMs?: number): number | undefined {
+  if (typeof timeoutMs !== "number" || !Number.isFinite(timeoutMs)) {
+    return undefined;
+  }
+  return Date.now() + resolveSafeTimeoutDelayMs(timeoutMs);
+}
+
+function resolveRemainingDispatchTimeoutMs(deadlineMs?: number): number | undefined {
+  return deadlineMs === undefined
+    ? undefined
+    : resolveSafeTimeoutDelayMs(deadlineMs - Date.now(), { minMs: 0 });
+}
+
+async function waitForDispatch<T>(
+  method: string,
+  promise: Promise<T>,
+  deadlineMs?: number,
+): Promise<T> {
+  const remainingTimeoutMs = resolveRemainingDispatchTimeoutMs(deadlineMs);
+  if (remainingTimeoutMs === undefined) {
+    return await promise;
+  }
+  let timeout: NodeJS.Timeout | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_resolve, reject) => {
+        timeout = setTimeout(() => {
+          reject(new Error(`gateway request timeout for ${method}`));
+        }, remainingTimeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+  }
+}
+
+/** Dispatches one request through the ordinary Gateway router without opening a transport. */
+export async function dispatchGatewayRequestInProcessRaw(
+  method: string,
+  params: unknown,
+  options: InProcessGatewayDispatchOptions,
+): Promise<GatewayMethodDispatchResponse> {
+  let firstResponse: GatewayMethodDispatchResponse | undefined;
+  let finalResponse: GatewayMethodDispatchResponse | undefined;
+  let resolveFirstResponse: ((response: GatewayMethodDispatchResponse) => void) | undefined;
+  let rejectFirstResponse: ((err: Error) => void) | undefined;
+  let resolveFinalResponse: ((response: GatewayMethodDispatchResponse) => void) | undefined;
+  let rejectFinalResponse: ((err: Error) => void) | undefined;
+  let postFirstResponseError: Error | undefined;
+  const firstResponsePromise = new Promise<GatewayMethodDispatchResponse>((resolve, reject) => {
+    resolveFirstResponse = resolve;
+    rejectFirstResponse = reject;
+  });
+  const deadlineMs = resolveDispatchDeadlineMs(options.timeoutMs);
+  const { handleGatewayRequest } = await import("./server-methods.js");
+  void handleGatewayRequest({
+    req: {
+      type: "req",
+      id: `${options.requestIdPrefix ?? "in-process"}-${randomUUID()}`,
+      method,
+      params,
+    },
+    client: options.client,
+    isWebchatConnect: options.isWebchatConnect ?? (() => false),
+    respond: (ok, payload, error, meta) => {
+      const response = { ok, payload, error, ...(meta ? { meta } : {}) };
+      if (!firstResponse) {
+        firstResponse = response;
+        resolveFirstResponse?.(response);
+        return;
+      }
+      if (!finalResponse) {
+        finalResponse = response;
+        resolveFinalResponse?.(response);
+      }
+    },
+    context: options.context,
+    methodRegistry: options.methodRegistry,
+  })
+    .then(() => {
+      if (!firstResponse) {
+        rejectFirstResponse?.(
+          new Error(`Gateway method "${method}" completed without a response.`),
+        );
+      }
+    })
+    .catch((err: unknown) => {
+      const error = err instanceof Error ? err : new Error(String(err));
+      if (!firstResponse) {
+        rejectFirstResponse?.(error);
+        return;
+      }
+      postFirstResponseError = error;
+      rejectFinalResponse?.(error);
+    });
+
+  firstResponse = await waitForDispatch(method, firstResponsePromise, deadlineMs);
+  const firstPayload = firstResponse.payload as { status?: unknown } | undefined;
+  if (options.expectFinal !== true || firstPayload?.status !== "accepted") {
+    return firstResponse;
+  }
+  options.onAccepted?.(firstResponse.payload);
+  if (postFirstResponseError) {
+    throw postFirstResponseError;
+  }
+  return (
+    finalResponse ??
+    (await new Promise<GatewayMethodDispatchResponse>((resolve, reject) => {
+      resolveFinalResponse = resolve;
+      const timeoutMs = resolveRemainingDispatchTimeoutMs(deadlineMs);
+      const timeout =
+        timeoutMs === undefined
+          ? undefined
+          : setTimeout(() => reject(new Error(`gateway request timeout for ${method}`)), timeoutMs);
+      const clearFinalTimeout = () => {
+        if (timeout) {
+          clearTimeout(timeout);
+        }
+      };
+      rejectFinalResponse = (err) => {
+        clearFinalTimeout();
+        reject(err);
+      };
+      if (postFirstResponseError) {
+        rejectFinalResponse(postFirstResponseError);
+        return;
+      }
+      if (finalResponse) {
+        clearFinalTimeout();
+        resolve(finalResponse);
+        return;
+      }
+      resolveFinalResponse = (response) => {
+        clearFinalTimeout();
+        resolve(response);
+      };
+    }))
+  );
+}
+
+export async function dispatchGatewayRequestInProcess<T>(
+  method: string,
+  params: unknown,
+  options: InProcessGatewayDispatchOptions,
+): Promise<T> {
+  return unwrapGatewayMethodDispatchResponse(
+    method,
+    await dispatchGatewayRequestInProcessRaw(method, params, options),
+  ) as T;
+}

--- a/src/gateway/server-instance-runtime.test.ts
+++ b/src/gateway/server-instance-runtime.test.ts
@@ -6,6 +6,7 @@ import { APPROVALS_SCOPE, WRITE_SCOPE } from "./method-scopes.js";
 import { createGatewayMethodRegistry } from "./methods/registry.js";
 import { createGatewayInstanceRuntime } from "./server-instance-runtime.js";
 import type { GatewayRequestContext, GatewayRequestHandlers } from "./server-methods/types.js";
+import { getGatewayRecoveryRuntime } from "./server-recovery-runtime-context.js";
 
 function createContext(): GatewayRequestContext {
   return {
@@ -41,6 +42,7 @@ describe("createGatewayInstanceRuntime", () => {
       getMethodRegistry: () => registry,
       isDispatchAvailable: () => available,
     });
+    expect(getGatewayRecoveryRuntime()).toBe(runtime.recovery);
 
     await expect(runtime.recovery.dispatchAgent({ message: "test" })).rejects.toThrow(
       "Gateway instance dispatch unavailable",
@@ -60,6 +62,7 @@ describe("createGatewayInstanceRuntime", () => {
     });
 
     runtime.close();
+    expect(getGatewayRecoveryRuntime()).toBeUndefined();
     await expect(runtime.recovery.waitForAgent({ runId: "run-1" })).rejects.toThrow(
       "Gateway instance dispatch unavailable",
     );
@@ -77,6 +80,7 @@ describe("createGatewayInstanceRuntime", () => {
       getMethodRegistry: () => registry,
       isDispatchAvailable: () => true,
     });
+    expect(getGatewayRecoveryRuntime()).toBe(second.recovery);
     const onRequested = vi.fn();
     const unsubscribe = first.nativeApprovals.subscribe({
       eventKinds: new Set(["exec"]),
@@ -110,7 +114,9 @@ describe("createGatewayInstanceRuntime", () => {
     expect(first.approvalEvents.publishRequested("exec", request)).toBe(0);
     expect(declined).not.toHaveBeenCalled();
     first.close();
+    expect(getGatewayRecoveryRuntime()).toBe(second.recovery);
     second.close();
+    expect(getGatewayRecoveryRuntime()).toBeUndefined();
   });
 
   it("rejects methods outside each closed internal principal", async () => {
@@ -126,6 +132,7 @@ describe("createGatewayInstanceRuntime", () => {
     await expect(runtime.nativeApprovals.requestRoute("config.get" as "send", {})).rejects.toThrow(
       "internal principal cannot dispatch config.get",
     );
+    runtime.close();
   });
 
   it("preserves a trusted approval resolver display name", async () => {
@@ -146,6 +153,7 @@ describe("createGatewayInstanceRuntime", () => {
         { clientDisplayName: "Telegram approval (owner)" },
       ),
     ).resolves.toEqual({ displayName: "Telegram approval (owner)" });
+    runtime.close();
   });
 
   it("preserves the Gateway client's approval request deadline", async () => {

--- a/src/gateway/server-instance-runtime.test.ts
+++ b/src/gateway/server-instance-runtime.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ExecApprovalRequest } from "../infra/exec-approvals.js";
+import { APPROVALS_SCOPE, WRITE_SCOPE } from "./method-scopes.js";
+import { createGatewayMethodRegistry } from "./methods/registry.js";
+import { createGatewayInstanceRuntime } from "./server-instance-runtime.js";
+import type { GatewayRequestContext, GatewayRequestHandlers } from "./server-methods/types.js";
+
+function createContext(): GatewayRequestContext {
+  return {
+    logGateway: {
+      warn: vi.fn(),
+      error: vi.fn(),
+    },
+  } as unknown as GatewayRequestContext;
+}
+
+function createRegistry(handlers: GatewayRequestHandlers) {
+  return createGatewayMethodRegistry(
+    Object.entries(handlers).map(([name, handler]) => ({
+      name,
+      handler,
+      owner: { kind: "core" as const, area: "test" },
+      scope: name.includes("approval") ? APPROVALS_SCOPE : WRITE_SCOPE,
+    })),
+  );
+}
+
+describe("createGatewayInstanceRuntime", () => {
+  it("uses the live registry and fails closed when the owning instance closes", async () => {
+    let version = "one";
+    let available = false;
+    let registry = createRegistry({
+      agent: ({ respond }) => respond(true, { version }),
+      "agent.wait": ({ respond }) => respond(true, { status: "ok" }),
+      "message.action": ({ respond }) => respond(true, { ok: true }),
+    });
+    const runtime = createGatewayInstanceRuntime({
+      getContext: createContext,
+      getMethodRegistry: () => registry,
+      isDispatchAvailable: () => available,
+    });
+
+    await expect(runtime.recovery.dispatchAgent({ message: "test" })).rejects.toThrow(
+      "Gateway instance dispatch unavailable",
+    );
+    available = true;
+    await expect(runtime.recovery.dispatchAgent({ message: "test" })).resolves.toEqual({
+      version: "one",
+    });
+    version = "two";
+    registry = createRegistry({
+      agent: ({ respond }) => respond(true, { version }),
+      "agent.wait": ({ respond }) => respond(true, { status: "ok" }),
+      "message.action": ({ respond }) => respond(true, { ok: true }),
+    });
+    await expect(runtime.recovery.dispatchAgent({ message: "test" })).resolves.toEqual({
+      version: "two",
+    });
+
+    runtime.close();
+    await expect(runtime.recovery.waitForAgent({ runId: "run-1" })).rejects.toThrow(
+      "Gateway instance dispatch unavailable",
+    );
+  });
+
+  it("keeps approval subscribers isolated by Gateway instance and unregisters exactly once", () => {
+    const registry = createRegistry({});
+    const first = createGatewayInstanceRuntime({
+      getContext: createContext,
+      getMethodRegistry: () => registry,
+      isDispatchAvailable: () => true,
+    });
+    const second = createGatewayInstanceRuntime({
+      getContext: createContext,
+      getMethodRegistry: () => registry,
+      isDispatchAvailable: () => true,
+    });
+    const onRequested = vi.fn();
+    const unsubscribe = first.nativeApprovals.subscribe({
+      eventKinds: new Set(["exec"]),
+      shouldHandle: () => true,
+      onRequested,
+      onResolved: vi.fn(),
+    });
+    const request = {
+      id: "approval-1",
+      request: {},
+      createdAtMs: 1,
+      expiresAtMs: 2,
+    } as ExecApprovalRequest;
+
+    expect(second.approvalEvents.publishRequested("exec", request)).toBe(0);
+    expect(first.approvalEvents.publishRequested("plugin", request)).toBe(0);
+    expect(first.approvalEvents.publishRequested("exec", request)).toBe(1);
+    expect(onRequested).toHaveBeenCalledOnce();
+
+    unsubscribe();
+    unsubscribe();
+    expect(first.approvalEvents.publishRequested("exec", request)).toBe(0);
+
+    const declined = vi.fn();
+    first.nativeApprovals.subscribe({
+      eventKinds: new Set(["exec"]),
+      shouldHandle: () => false,
+      onRequested: declined,
+      onResolved: vi.fn(),
+    });
+    expect(first.approvalEvents.publishRequested("exec", request)).toBe(0);
+    expect(declined).not.toHaveBeenCalled();
+    first.close();
+    second.close();
+  });
+
+  it("rejects methods outside each closed internal principal", async () => {
+    const runtime = createGatewayInstanceRuntime({
+      getContext: createContext,
+      getMethodRegistry: () => createRegistry({}),
+      isDispatchAvailable: () => true,
+    });
+
+    await expect(runtime.nativeApprovals.request("config.get", {})).rejects.toThrow(
+      "internal principal cannot dispatch config.get",
+    );
+    await expect(runtime.nativeApprovals.requestRoute("config.get" as "send", {})).rejects.toThrow(
+      "internal principal cannot dispatch config.get",
+    );
+  });
+
+  it("preserves a trusted approval resolver display name", async () => {
+    const runtime = createGatewayInstanceRuntime({
+      getContext: createContext,
+      getMethodRegistry: () =>
+        createRegistry({
+          "exec.approval.list": ({ client, respond }) =>
+            respond(true, { displayName: client?.connect.client.displayName }),
+        }),
+      isDispatchAvailable: () => true,
+    });
+
+    await expect(
+      runtime.nativeApprovals.request(
+        "exec.approval.list",
+        {},
+        { clientDisplayName: "Telegram approval (owner)" },
+      ),
+    ).resolves.toEqual({ displayName: "Telegram approval (owner)" });
+  });
+});

--- a/src/gateway/server-instance-runtime.test.ts
+++ b/src/gateway/server-instance-runtime.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS } from "../../packages/gateway-client/src/timeouts.js";
 import type { ExecApprovalRequest } from "../infra/exec-approvals.js";
 import { APPROVALS_SCOPE, WRITE_SCOPE } from "./method-scopes.js";
 import { createGatewayMethodRegistry } from "./methods/registry.js";
@@ -144,5 +145,37 @@ describe("createGatewayInstanceRuntime", () => {
         { clientDisplayName: "Telegram approval (owner)" },
       ),
     ).resolves.toEqual({ displayName: "Telegram approval (owner)" });
+  });
+
+  it("preserves the Gateway client's approval request deadline", async () => {
+    vi.useFakeTimers();
+    try {
+      let markStarted!: () => void;
+      const started = new Promise<void>((resolve) => {
+        markStarted = resolve;
+      });
+      const runtime = createGatewayInstanceRuntime({
+        getContext: createContext,
+        getMethodRegistry: () =>
+          createRegistry({
+            send: async () => {
+              markStarted();
+              await new Promise<never>(() => {});
+            },
+          }),
+        isDispatchAvailable: () => true,
+      });
+
+      const request = runtime.nativeApprovals.requestRoute("send", { message: "test" });
+      const error = request.catch((value: unknown) => value);
+      await started;
+      await vi.advanceTimersByTimeAsync(DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS);
+      const caught = await error;
+      expect(caught).toBeInstanceOf(Error);
+      expect((caught as Error).message).toContain("gateway request timeout for send");
+      runtime.close();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/src/gateway/server-instance-runtime.test.ts
+++ b/src/gateway/server-instance-runtime.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS } from "../../packages/gateway-client/src/timeouts.js";
+import type { GatewayNativeApprovalMethod } from "../infra/approval-gateway-runtime-methods.js";
 import type { ExecApprovalRequest } from "../infra/exec-approvals.js";
 import { APPROVALS_SCOPE, WRITE_SCOPE } from "./method-scopes.js";
 import { createGatewayMethodRegistry } from "./methods/registry.js";
@@ -119,9 +120,9 @@ describe("createGatewayInstanceRuntime", () => {
       isDispatchAvailable: () => true,
     });
 
-    await expect(runtime.nativeApprovals.request("config.get", {})).rejects.toThrow(
-      "internal principal cannot dispatch config.get",
-    );
+    await expect(
+      runtime.nativeApprovals.request("config.get" as GatewayNativeApprovalMethod, {}),
+    ).rejects.toThrow("internal principal cannot dispatch config.get");
     await expect(runtime.nativeApprovals.requestRoute("config.get" as "send", {})).rejects.toThrow(
       "internal principal cannot dispatch config.get",
     );

--- a/src/gateway/server-instance-runtime.ts
+++ b/src/gateway/server-instance-runtime.ts
@@ -13,9 +13,13 @@ import { createApprovalNativeRouteCoordinator } from "../infra/approval-native-r
 import { APPROVALS_SCOPE, WRITE_SCOPE } from "./method-scopes.js";
 import type { GatewayMethodRegistry } from "./methods/registry.js";
 import { dispatchGatewayRequestInProcess } from "./server-in-process-dispatch.js";
-import type { GatewayInstanceRuntime } from "./server-instance-runtime.types.js";
+import type {
+  GatewayInstanceRuntime,
+  GatewayRecoveryRuntime,
+} from "./server-instance-runtime.types.js";
 import type { GatewayRequestContext } from "./server-methods/types.js";
 import { createSyntheticPluginRuntimeClient } from "./server-plugin-runtime-client.js";
+import { registerGatewayRecoveryRuntime } from "./server-recovery-runtime-context.js";
 
 type GatewayInstanceRuntimeOptions = {
   getContext: () => GatewayRequestContext;
@@ -61,6 +65,34 @@ export function createGatewayInstanceRuntime(
   const approvalMethods = new Set<GatewayNativeApprovalMethod>(GATEWAY_NATIVE_APPROVAL_METHODS);
   const approvalRouteClient = createSyntheticPluginRuntimeClient({ scopes: [WRITE_SCOPE] });
   const approvalRouteMethods = new Set(["send"]);
+
+  const recovery: GatewayRecoveryRuntime = {
+    dispatchAgent: async <T>(payload: Record<string, unknown>, timeoutMs?: number) =>
+      await dispatch<T>({
+        allowedMethods: recoveryMethods,
+        client: recoveryClient,
+        method: "agent",
+        payload,
+        timeoutMs,
+      }),
+    waitForAgent: async <T>(payload: Record<string, unknown>, timeoutMs?: number) =>
+      await dispatch<T>({
+        allowedMethods: recoveryMethods,
+        client: recoveryClient,
+        method: "agent.wait",
+        payload,
+        timeoutMs,
+      }),
+    sendRecoveryNotice: async <T>(payload: Record<string, unknown>, timeoutMs?: number) =>
+      await dispatch<T>({
+        allowedMethods: recoveryNoticeMethods,
+        client: recoveryClient,
+        method: "message.action",
+        payload,
+        timeoutMs,
+      }),
+  };
+  const releaseRecoveryRuntime = registerGatewayRecoveryRuntime(recovery);
 
   const publish = (
     kind: GatewayApprovalEventKind,
@@ -148,34 +180,10 @@ export function createGatewayInstanceRuntime(
         };
       },
     },
-    recovery: {
-      dispatchAgent: async <T>(payload: Record<string, unknown>, timeoutMs?: number) =>
-        await dispatch<T>({
-          allowedMethods: recoveryMethods,
-          client: recoveryClient,
-          method: "agent",
-          payload,
-          timeoutMs,
-        }),
-      waitForAgent: async <T>(payload: Record<string, unknown>, timeoutMs?: number) =>
-        await dispatch<T>({
-          allowedMethods: recoveryMethods,
-          client: recoveryClient,
-          method: "agent.wait",
-          payload,
-          timeoutMs,
-        }),
-      sendRecoveryNotice: async <T>(payload: Record<string, unknown>, timeoutMs?: number) =>
-        await dispatch<T>({
-          allowedMethods: recoveryNoticeMethods,
-          client: recoveryClient,
-          method: "message.action",
-          payload,
-          timeoutMs,
-        }),
-    },
+    recovery,
     close: () => {
       closed = true;
+      releaseRecoveryRuntime();
       approvalSubscribers.clear();
       routeCoordinator.close();
     },

--- a/src/gateway/server-instance-runtime.ts
+++ b/src/gateway/server-instance-runtime.ts
@@ -9,11 +9,7 @@ import { createApprovalNativeRouteCoordinator } from "../infra/approval-native-r
 import { APPROVALS_SCOPE, WRITE_SCOPE } from "./method-scopes.js";
 import type { GatewayMethodRegistry } from "./methods/registry.js";
 import { dispatchGatewayRequestInProcess } from "./server-in-process-dispatch.js";
-import type {
-  GatewayApprovalEventPublisher,
-  GatewayInstanceRuntime,
-  GatewayRecoveryRuntime,
-} from "./server-instance-runtime.types.js";
+import type { GatewayInstanceRuntime } from "./server-instance-runtime.types.js";
 import type { GatewayRequestContext } from "./server-methods/types.js";
 import { createSyntheticPluginRuntimeClient } from "./server-plugin-runtime-client.js";
 

--- a/src/gateway/server-instance-runtime.ts
+++ b/src/gateway/server-instance-runtime.ts
@@ -4,35 +4,18 @@ import type {
   GatewayApprovalEventSubscriber,
   GatewayApprovalRequest,
   GatewayApprovalResolved,
-  GatewayNativeApprovalRuntime,
 } from "../infra/approval-gateway-runtime.types.js";
 import { createApprovalNativeRouteCoordinator } from "../infra/approval-native-route-coordinator.js";
 import { APPROVALS_SCOPE, WRITE_SCOPE } from "./method-scopes.js";
 import type { GatewayMethodRegistry } from "./methods/registry.js";
 import { dispatchGatewayRequestInProcess } from "./server-in-process-dispatch.js";
+import type {
+  GatewayApprovalEventPublisher,
+  GatewayInstanceRuntime,
+  GatewayRecoveryRuntime,
+} from "./server-instance-runtime.types.js";
 import type { GatewayRequestContext } from "./server-methods/types.js";
 import { createSyntheticPluginRuntimeClient } from "./server-plugin-runtime-client.js";
-
-export type GatewayApprovalEventPublisher = {
-  publishRequested: (kind: GatewayApprovalEventKind, request: unknown) => number;
-  publishResolved: (kind: GatewayApprovalEventKind, resolved: unknown) => void;
-};
-
-export type GatewayRecoveryRuntime = {
-  dispatchAgent: <T = unknown>(params: Record<string, unknown>, timeoutMs?: number) => Promise<T>;
-  waitForAgent: <T = unknown>(params: Record<string, unknown>, timeoutMs?: number) => Promise<T>;
-  sendRecoveryNotice: <T = unknown>(
-    params: Record<string, unknown>,
-    timeoutMs?: number,
-  ) => Promise<T>;
-};
-
-export type GatewayInstanceRuntime = {
-  approvalEvents: GatewayApprovalEventPublisher;
-  nativeApprovals: GatewayNativeApprovalRuntime;
-  recovery: GatewayRecoveryRuntime;
-  close: () => void;
-};
 
 type GatewayInstanceRuntimeOptions = {
   getContext: () => GatewayRequestContext;

--- a/src/gateway/server-instance-runtime.ts
+++ b/src/gateway/server-instance-runtime.ts
@@ -1,0 +1,224 @@
+import {
+  createApprovalNativeRouteCoordinator,
+  type ApprovalNativeRouteCoordinator,
+} from "../infra/approval-native-route-coordinator.js";
+import type { ExecApprovalRequest, ExecApprovalResolved } from "../infra/exec-approvals.js";
+import type { PluginApprovalRequest, PluginApprovalResolved } from "../infra/plugin-approvals.js";
+import { APPROVALS_SCOPE, WRITE_SCOPE } from "./method-scopes.js";
+import type { GatewayMethodRegistry } from "./methods/registry.js";
+import { dispatchGatewayRequestInProcess } from "./server-in-process-dispatch.js";
+import type { GatewayRequestContext } from "./server-methods/types.js";
+import { createSyntheticPluginRuntimeClient } from "./server-plugin-runtime-client.js";
+
+type ApprovalEventKind = "exec" | "plugin";
+type ApprovalRequest = ExecApprovalRequest | PluginApprovalRequest;
+type ApprovalResolved = ExecApprovalResolved | PluginApprovalResolved;
+
+export type GatewayApprovalEventSubscriber = {
+  eventKinds: ReadonlySet<ApprovalEventKind>;
+  shouldHandle: (request: ApprovalRequest) => boolean;
+  onRequested: (request: ApprovalRequest) => void;
+  onResolved: (resolved: ApprovalResolved) => void;
+};
+
+export type GatewayApprovalEventPublisher = {
+  publishRequested: (kind: ApprovalEventKind, request: unknown) => number;
+  publishResolved: (kind: ApprovalEventKind, resolved: unknown) => void;
+};
+
+export type GatewayNativeApprovalRuntime = {
+  request: <T = unknown>(
+    method: string,
+    params: Record<string, unknown>,
+    options?: { clientDisplayName?: string },
+  ) => Promise<T>;
+  requestRoute: <T = unknown>(method: "send", params: Record<string, unknown>) => Promise<T>;
+  routeCoordinator: ApprovalNativeRouteCoordinator;
+  subscribe: (subscriber: GatewayApprovalEventSubscriber) => () => void;
+};
+
+export type GatewayRecoveryRuntime = {
+  dispatchAgent: <T = unknown>(params: Record<string, unknown>, timeoutMs?: number) => Promise<T>;
+  waitForAgent: <T = unknown>(params: Record<string, unknown>, timeoutMs?: number) => Promise<T>;
+  sendRecoveryNotice: <T = unknown>(
+    params: Record<string, unknown>,
+    timeoutMs?: number,
+  ) => Promise<T>;
+};
+
+export type GatewayInstanceRuntime = {
+  approvalEvents: GatewayApprovalEventPublisher;
+  nativeApprovals: GatewayNativeApprovalRuntime;
+  recovery: GatewayRecoveryRuntime;
+  close: () => void;
+};
+
+type GatewayInstanceRuntimeOptions = {
+  getContext: () => GatewayRequestContext;
+  getMethodRegistry: () => GatewayMethodRegistry;
+  isDispatchAvailable: () => boolean;
+  logError?: (message: string) => void;
+};
+
+/** Creates closed internal principals bound to one concrete Gateway lifecycle. */
+export function createGatewayInstanceRuntime(
+  options: GatewayInstanceRuntimeOptions,
+): GatewayInstanceRuntime {
+  const approvalSubscribers = new Set<GatewayApprovalEventSubscriber>();
+  const routeCoordinator = createApprovalNativeRouteCoordinator();
+  let closed = false;
+
+  const dispatch = async <T>(params: {
+    allowedMethods: ReadonlySet<string>;
+    client: ReturnType<typeof createSyntheticPluginRuntimeClient>;
+    method: string;
+    payload: Record<string, unknown>;
+    timeoutMs?: number;
+  }): Promise<T> => {
+    if (closed || !options.isDispatchAvailable()) {
+      throw new Error(`Gateway instance dispatch unavailable for ${params.method}`);
+    }
+    if (!params.allowedMethods.has(params.method)) {
+      throw new Error(`Gateway internal principal cannot dispatch ${params.method}`);
+    }
+    return await dispatchGatewayRequestInProcess<T>(params.method, params.payload, {
+      client: params.client,
+      context: options.getContext(),
+      methodRegistry: options.getMethodRegistry(),
+      requestIdPrefix: "gateway-internal",
+      timeoutMs: params.timeoutMs,
+    });
+  };
+
+  const recoveryClient = createSyntheticPluginRuntimeClient({ scopes: [WRITE_SCOPE] });
+  const recoveryMethods = new Set(["agent", "agent.wait"]);
+  const recoveryNoticeMethods = new Set(["message.action"]);
+  const approvalClient = createSyntheticPluginRuntimeClient({ scopes: [APPROVALS_SCOPE] });
+  const approvalMethods = new Set([
+    "approval.resolve",
+    "exec.approval.get",
+    "exec.approval.list",
+    "exec.approval.resolve",
+    "plugin.approval.list",
+    "plugin.approval.resolve",
+  ]);
+  const approvalRouteClient = createSyntheticPluginRuntimeClient({ scopes: [WRITE_SCOPE] });
+  const approvalRouteMethods = new Set(["send"]);
+
+  const publish = (
+    kind: ApprovalEventKind,
+    callback: (subscriber: GatewayApprovalEventSubscriber) => void,
+    shouldDeliver?: (subscriber: GatewayApprovalEventSubscriber) => boolean,
+  ): number => {
+    if (closed) {
+      return 0;
+    }
+    let delivered = 0;
+    for (const subscriber of approvalSubscribers) {
+      if (!subscriber.eventKinds.has(kind)) {
+        continue;
+      }
+      try {
+        if (shouldDeliver && !shouldDeliver(subscriber)) {
+          continue;
+        }
+        callback(subscriber);
+        delivered += 1;
+      } catch (error) {
+        options.logError?.(`internal approval subscriber failed: ${String(error)}`);
+      }
+    }
+    return delivered;
+  };
+
+  return {
+    approvalEvents: {
+      publishRequested: (kind, request) =>
+        publish(
+          kind,
+          (subscriber) => subscriber.onRequested(request as ApprovalRequest),
+          (subscriber) => subscriber.shouldHandle(request as ApprovalRequest),
+        ),
+      publishResolved: (kind, resolved) => {
+        publish(kind, (subscriber) => subscriber.onResolved(resolved as ApprovalResolved));
+      },
+    },
+    nativeApprovals: {
+      request: async <T>(
+        method: string,
+        payload: Record<string, unknown>,
+        requestOptions?: { clientDisplayName?: string },
+      ) =>
+        await dispatch<T>({
+          allowedMethods: approvalMethods,
+          client: requestOptions?.clientDisplayName
+            ? {
+                ...approvalClient,
+                connect: {
+                  ...approvalClient.connect,
+                  client: {
+                    ...approvalClient.connect.client,
+                    displayName: requestOptions.clientDisplayName,
+                  },
+                },
+              }
+            : approvalClient,
+          method,
+          payload,
+        }),
+      requestRoute: async <T>(method: "send", payload: Record<string, unknown>) =>
+        await dispatch<T>({
+          allowedMethods: approvalRouteMethods,
+          client: approvalRouteClient,
+          method,
+          payload,
+        }),
+      routeCoordinator,
+      subscribe: (subscriber) => {
+        if (closed) {
+          throw new Error("Gateway instance approval runtime is closed");
+        }
+        approvalSubscribers.add(subscriber);
+        let subscribed = true;
+        return () => {
+          if (!subscribed) {
+            return;
+          }
+          subscribed = false;
+          approvalSubscribers.delete(subscriber);
+        };
+      },
+    },
+    recovery: {
+      dispatchAgent: async <T>(payload: Record<string, unknown>, timeoutMs?: number) =>
+        await dispatch<T>({
+          allowedMethods: recoveryMethods,
+          client: recoveryClient,
+          method: "agent",
+          payload,
+          timeoutMs,
+        }),
+      waitForAgent: async <T>(payload: Record<string, unknown>, timeoutMs?: number) =>
+        await dispatch<T>({
+          allowedMethods: recoveryMethods,
+          client: recoveryClient,
+          method: "agent.wait",
+          payload,
+          timeoutMs,
+        }),
+      sendRecoveryNotice: async <T>(payload: Record<string, unknown>, timeoutMs?: number) =>
+        await dispatch<T>({
+          allowedMethods: recoveryNoticeMethods,
+          client: recoveryClient,
+          method: "message.action",
+          payload,
+          timeoutMs,
+        }),
+    },
+    close: () => {
+      closed = true;
+      approvalSubscribers.clear();
+      routeCoordinator.close();
+    },
+  };
+}

--- a/src/gateway/server-instance-runtime.ts
+++ b/src/gateway/server-instance-runtime.ts
@@ -1,40 +1,21 @@
-import {
-  createApprovalNativeRouteCoordinator,
-  type ApprovalNativeRouteCoordinator,
-} from "../infra/approval-native-route-coordinator.js";
-import type { ExecApprovalRequest, ExecApprovalResolved } from "../infra/exec-approvals.js";
-import type { PluginApprovalRequest, PluginApprovalResolved } from "../infra/plugin-approvals.js";
+import { DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS } from "../../packages/gateway-client/src/timeouts.js";
+import type {
+  GatewayApprovalEventKind,
+  GatewayApprovalEventSubscriber,
+  GatewayApprovalRequest,
+  GatewayApprovalResolved,
+  GatewayNativeApprovalRuntime,
+} from "../infra/approval-gateway-runtime.types.js";
+import { createApprovalNativeRouteCoordinator } from "../infra/approval-native-route-coordinator.js";
 import { APPROVALS_SCOPE, WRITE_SCOPE } from "./method-scopes.js";
 import type { GatewayMethodRegistry } from "./methods/registry.js";
 import { dispatchGatewayRequestInProcess } from "./server-in-process-dispatch.js";
 import type { GatewayRequestContext } from "./server-methods/types.js";
 import { createSyntheticPluginRuntimeClient } from "./server-plugin-runtime-client.js";
 
-type ApprovalEventKind = "exec" | "plugin";
-type ApprovalRequest = ExecApprovalRequest | PluginApprovalRequest;
-type ApprovalResolved = ExecApprovalResolved | PluginApprovalResolved;
-
-export type GatewayApprovalEventSubscriber = {
-  eventKinds: ReadonlySet<ApprovalEventKind>;
-  shouldHandle: (request: ApprovalRequest) => boolean;
-  onRequested: (request: ApprovalRequest) => void;
-  onResolved: (resolved: ApprovalResolved) => void;
-};
-
 export type GatewayApprovalEventPublisher = {
-  publishRequested: (kind: ApprovalEventKind, request: unknown) => number;
-  publishResolved: (kind: ApprovalEventKind, resolved: unknown) => void;
-};
-
-export type GatewayNativeApprovalRuntime = {
-  request: <T = unknown>(
-    method: string,
-    params: Record<string, unknown>,
-    options?: { clientDisplayName?: string },
-  ) => Promise<T>;
-  requestRoute: <T = unknown>(method: "send", params: Record<string, unknown>) => Promise<T>;
-  routeCoordinator: ApprovalNativeRouteCoordinator;
-  subscribe: (subscriber: GatewayApprovalEventSubscriber) => () => void;
+  publishRequested: (kind: GatewayApprovalEventKind, request: unknown) => number;
+  publishResolved: (kind: GatewayApprovalEventKind, resolved: unknown) => void;
 };
 
 export type GatewayRecoveryRuntime = {
@@ -106,7 +87,7 @@ export function createGatewayInstanceRuntime(
   const approvalRouteMethods = new Set(["send"]);
 
   const publish = (
-    kind: ApprovalEventKind,
+    kind: GatewayApprovalEventKind,
     callback: (subscriber: GatewayApprovalEventSubscriber) => void,
     shouldDeliver?: (subscriber: GatewayApprovalEventSubscriber) => boolean,
   ): number => {
@@ -136,11 +117,11 @@ export function createGatewayInstanceRuntime(
       publishRequested: (kind, request) =>
         publish(
           kind,
-          (subscriber) => subscriber.onRequested(request as ApprovalRequest),
-          (subscriber) => subscriber.shouldHandle(request as ApprovalRequest),
+          (subscriber) => subscriber.onRequested(request as GatewayApprovalRequest),
+          (subscriber) => subscriber.shouldHandle(request as GatewayApprovalRequest),
         ),
       publishResolved: (kind, resolved) => {
-        publish(kind, (subscriber) => subscriber.onResolved(resolved as ApprovalResolved));
+        publish(kind, (subscriber) => subscriber.onResolved(resolved as GatewayApprovalResolved));
       },
     },
     nativeApprovals: {
@@ -165,6 +146,7 @@ export function createGatewayInstanceRuntime(
             : approvalClient,
           method,
           payload,
+          timeoutMs: DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS,
         }),
       requestRoute: async <T>(method: "send", payload: Record<string, unknown>) =>
         await dispatch<T>({
@@ -172,6 +154,7 @@ export function createGatewayInstanceRuntime(
           client: approvalRouteClient,
           method,
           payload,
+          timeoutMs: DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS,
         }),
       routeCoordinator,
       subscribe: (subscriber) => {

--- a/src/gateway/server-instance-runtime.ts
+++ b/src/gateway/server-instance-runtime.ts
@@ -1,4 +1,8 @@
 import { DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS } from "../../packages/gateway-client/src/timeouts.js";
+import {
+  GATEWAY_NATIVE_APPROVAL_METHODS,
+  type GatewayNativeApprovalMethod,
+} from "../infra/approval-gateway-runtime-methods.js";
 import type {
   GatewayApprovalEventKind,
   GatewayApprovalEventSubscriber,
@@ -54,14 +58,7 @@ export function createGatewayInstanceRuntime(
   const recoveryMethods = new Set(["agent", "agent.wait"]);
   const recoveryNoticeMethods = new Set(["message.action"]);
   const approvalClient = createSyntheticPluginRuntimeClient({ scopes: [APPROVALS_SCOPE] });
-  const approvalMethods = new Set([
-    "approval.resolve",
-    "exec.approval.get",
-    "exec.approval.list",
-    "exec.approval.resolve",
-    "plugin.approval.list",
-    "plugin.approval.resolve",
-  ]);
+  const approvalMethods = new Set<GatewayNativeApprovalMethod>(GATEWAY_NATIVE_APPROVAL_METHODS);
   const approvalRouteClient = createSyntheticPluginRuntimeClient({ scopes: [WRITE_SCOPE] });
   const approvalRouteMethods = new Set(["send"]);
 
@@ -105,7 +102,7 @@ export function createGatewayInstanceRuntime(
     },
     nativeApprovals: {
       request: async <T>(
-        method: string,
+        method: GatewayNativeApprovalMethod,
         payload: Record<string, unknown>,
         requestOptions?: { clientDisplayName?: string },
       ) =>

--- a/src/gateway/server-instance-runtime.types.ts
+++ b/src/gateway/server-instance-runtime.types.ts
@@ -1,0 +1,25 @@
+import type {
+  GatewayApprovalEventKind,
+  GatewayNativeApprovalRuntime,
+} from "../infra/approval-gateway-runtime.types.js";
+
+export type GatewayApprovalEventPublisher = {
+  publishRequested: (kind: GatewayApprovalEventKind, request: unknown) => number;
+  publishResolved: (kind: GatewayApprovalEventKind, resolved: unknown) => void;
+};
+
+export type GatewayRecoveryRuntime = {
+  dispatchAgent: <T = unknown>(params: Record<string, unknown>, timeoutMs?: number) => Promise<T>;
+  waitForAgent: <T = unknown>(params: Record<string, unknown>, timeoutMs?: number) => Promise<T>;
+  sendRecoveryNotice: <T = unknown>(
+    params: Record<string, unknown>,
+    timeoutMs?: number,
+  ) => Promise<T>;
+};
+
+export type GatewayInstanceRuntime = {
+  approvalEvents: GatewayApprovalEventPublisher;
+  nativeApprovals: GatewayNativeApprovalRuntime;
+  recovery: GatewayRecoveryRuntime;
+  close: () => void;
+};

--- a/src/gateway/server-methods/approval-publication.ts
+++ b/src/gateway/server-methods/approval-publication.ts
@@ -76,6 +76,20 @@ async function runSideEffect(params: {
   }
 }
 
+function runSynchronousSideEffect(params: {
+  context: GatewayRequestContext;
+  approvalKind: "exec" | "plugin";
+  run: () => void;
+}): void {
+  try {
+    params.run();
+  } catch (error) {
+    params.context.logGateway?.error?.(
+      `${params.approvalKind} approvals: unified resolve internal-subscriber failed: ${String(error)}`,
+    );
+  }
+}
+
 export async function publishAppliedApprovalResolution(params: {
   record: OperatorApprovalRecord;
   liveRecord: ExecApprovalRecord<ApprovalRequest>;
@@ -111,6 +125,15 @@ export async function publishAppliedApprovalResolution(params: {
         liveRecord: params.liveRecord,
       }),
   });
+  if (params.record.kind === "exec" || params.record.kind === "plugin") {
+    // Native approval routes are instance-local, so publish the canonical CAS
+    // winner directly instead of reconnecting to the Gateway over WebSocket.
+    runSynchronousSideEffect({
+      context: params.context,
+      approvalKind: params.record.kind,
+      run: () => params.context.approvalEvents?.publishResolved(params.record.kind, event),
+    });
+  }
   if (params.record.kind === "exec" && params.forwarder) {
     await runSideEffect({
       context: params.context,

--- a/src/gateway/server-methods/approval-publication.ts
+++ b/src/gateway/server-methods/approval-publication.ts
@@ -125,13 +125,14 @@ export async function publishAppliedApprovalResolution(params: {
         liveRecord: params.liveRecord,
       }),
   });
-  if (params.record.kind === "exec" || params.record.kind === "plugin") {
+  const nativeApprovalKind = params.record.kind;
+  if (nativeApprovalKind === "exec" || nativeApprovalKind === "plugin") {
     // Native approval routes are instance-local, so publish the canonical CAS
     // winner directly instead of reconnecting to the Gateway over WebSocket.
     runSynchronousSideEffect({
       context: params.context,
-      approvalKind: params.record.kind,
-      run: () => params.context.approvalEvents?.publishResolved(params.record.kind, event),
+      approvalKind: nativeApprovalKind,
+      run: () => params.context.approvalEvents?.publishResolved(nativeApprovalKind, event),
     });
   }
   if (params.record.kind === "exec" && params.forwarder) {

--- a/src/gateway/server-methods/approval-shared.test.ts
+++ b/src/gateway/server-methods/approval-shared.test.ts
@@ -377,6 +377,50 @@ describe("handlePendingApprovalRequest", () => {
     await requestPromise;
   });
 
+  it("counts an instance-local approval subscriber as a delivery route", async () => {
+    const manager = new ExecApprovalManager();
+    const record = manager.create({ command: "echo ok" }, 60_000, "approval-internal-route");
+    const decisionPromise = manager.register(record, 60_000);
+    const respond = vi.fn();
+    const publishRequested = vi.fn(() => 1);
+    const requestPromise = handlePendingApprovalRequest({
+      manager,
+      record,
+      decisionPromise,
+      respond,
+      context: {
+        broadcast: vi.fn(),
+        hasExecApprovalClients: () => false,
+        approvalEvents: {
+          publishRequested,
+          publishResolved: vi.fn(),
+        },
+      } as unknown as GatewayRequestContext,
+      requestEventName: "exec.approval.requested",
+      requestEvent: {
+        id: record.id,
+        request: record.request,
+        createdAtMs: record.createdAtMs,
+        expiresAtMs: record.expiresAtMs,
+      },
+      twoPhase: true,
+      deliverRequest: () => false,
+    });
+
+    await Promise.resolve();
+    expect(publishRequested).toHaveBeenCalledWith(
+      "exec",
+      expect.objectContaining({ id: record.id }),
+    );
+    expect(respond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({ status: "accepted", deliveryRoute: "approval-client" }),
+      undefined,
+    );
+    expect(manager.resolve(record.id, "allow-once")).toBe(true);
+    await requestPromise;
+  });
+
   it("checks plugin turn-source routes with plugin approval kind", async () => {
     const manager = new ExecApprovalManager();
     const record = manager.create(

--- a/src/gateway/server-methods/approval-shared.ts
+++ b/src/gateway/server-methods/approval-shared.ts
@@ -476,12 +476,19 @@ export async function handlePendingApprovalRequest<
         });
       }
     }
+    const internalApprovalSubscriberCount = suppressDelivery
+      ? 0
+      : (params.context.approvalEvents?.publishRequested(
+          params.approvalKind ?? "exec",
+          params.requestEvent,
+        ) ?? 0);
 
     const hasApprovalClients = suppressDelivery
       ? false
       : approvalClientConnIds !== null
-        ? approvalClientConnIds.size > 0
-        : (params.context.hasExecApprovalClients?.(params.clientConnId) ?? false);
+        ? approvalClientConnIds.size > 0 || internalApprovalSubscriberCount > 0
+        : (params.context.hasExecApprovalClients?.(params.clientConnId) ?? false) ||
+          internalApprovalSubscriberCount > 0;
     const deliveredResult = suppressDelivery ? false : params.deliverRequest();
     const delivered = isPromiseLike(deliveredResult) ? await deliveredResult : deliveredResult;
     // A turn-source route can approve without an active approval client, so keep
@@ -602,6 +609,7 @@ export async function handleApprovalResolve<TPayload, TResolvedEvent extends obj
     snapshot: ExecApprovalRecord<TPayload>;
   }) => boolean;
   resolvedEventName: string;
+  approvalKind?: "exec" | "plugin";
   buildResolvedEvent: (params: {
     approvalId: string;
     decision: ExecApprovalDecision;
@@ -736,6 +744,10 @@ export async function handleApprovalResolve<TPayload, TResolvedEvent extends obj
   } else {
     params.context.broadcast(params.resolvedEventName, resolvedEvent, { dropIfSlow: true });
   }
+  params.context.approvalEvents?.publishResolved(
+    params.approvalKind ?? (params.resolvedEventName.startsWith("plugin.") ? "plugin" : "exec"),
+    resolvedEvent as never,
+  );
 
   const followUps = [
     params.forwardResolved

--- a/src/gateway/server-methods/approval.test.ts
+++ b/src/gateway/server-methods/approval.test.ts
@@ -878,7 +878,7 @@ describe("unified approval handlers", () => {
       new Set(["approval-client"]),
       { dropIfSlow: true },
     );
-    expect(context.approvalEvents.publishResolved).toHaveBeenCalledWith(
+    expect(context.approvalEvents!.publishResolved).toHaveBeenCalledWith(
       "plugin",
       expect.objectContaining({
         id: pending.record.id,
@@ -978,7 +978,7 @@ describe("unified approval handlers", () => {
     expect(context.logGateway.error).toHaveBeenCalledWith(
       expect.stringContaining("exec approvals: unified resolve forwarder failed"),
     );
-    expect(context.approvalEvents.publishResolved).toHaveBeenCalledWith(
+    expect(context.approvalEvents!.publishResolved).toHaveBeenCalledWith(
       "exec",
       expect.objectContaining({ id: pending.record.id, decision: "deny" }),
     );

--- a/src/gateway/server-methods/approval.test.ts
+++ b/src/gateway/server-methods/approval.test.ts
@@ -214,6 +214,10 @@ function createContext(controlUiBasePath?: string) {
   return {
     broadcast: vi.fn(),
     broadcastToConnIds: vi.fn(),
+    approvalEvents: {
+      publishRequested: vi.fn(() => 0),
+      publishResolved: vi.fn(),
+    },
     getApprovalClientConnIds: vi.fn(() => new Set(["approval-client"])),
     getRuntimeConfig: () => ({ gateway: { controlUi: { basePath: controlUiBasePath } } }),
     logGateway: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
@@ -874,6 +878,14 @@ describe("unified approval handlers", () => {
       new Set(["approval-client"]),
       { dropIfSlow: true },
     );
+    expect(context.approvalEvents.publishResolved).toHaveBeenCalledWith(
+      "plugin",
+      expect.objectContaining({
+        id: pending.record.id,
+        decision: "deny",
+        resolvedBy: "Approval Test",
+      }),
+    );
     expect(getOperatorApproval({ id: pending.record.id, databaseOptions })?.resolver).toEqual({
       kind: "device",
       id: "phone-device",
@@ -965,6 +977,10 @@ describe("unified approval handlers", () => {
     );
     expect(context.logGateway.error).toHaveBeenCalledWith(
       expect.stringContaining("exec approvals: unified resolve forwarder failed"),
+    );
+    expect(context.approvalEvents.publishResolved).toHaveBeenCalledWith(
+      "exec",
+      expect.objectContaining({ id: pending.record.id, decision: "deny" }),
     );
   });
 

--- a/src/gateway/server-methods/chat-restart-recovery.ts
+++ b/src/gateway/server-methods/chat-restart-recovery.ts
@@ -25,7 +25,7 @@ import { isCronSessionKey, isSubagentSessionKey } from "../../routing/session-ke
 import { isAgentHarnessSessionKey } from "../../sessions/agent-harness-session-key.js";
 import { isAcpSessionKey } from "../../sessions/session-key-utils.js";
 import { parseInlineDirectives } from "../../utils/directive-tags.js";
-import type { GatewayRecoveryRuntime } from "../server-instance-runtime.js";
+import type { GatewayRecoveryRuntime } from "../server-instance-runtime.types.js";
 import type { GatewayRequestContext } from "./types.js";
 
 export { hasRestartRecoveryTerminalRun };

--- a/src/gateway/server-methods/chat-restart-recovery.ts
+++ b/src/gateway/server-methods/chat-restart-recovery.ts
@@ -25,6 +25,7 @@ import { isCronSessionKey, isSubagentSessionKey } from "../../routing/session-ke
 import { isAgentHarnessSessionKey } from "../../sessions/agent-harness-session-key.js";
 import { isAcpSessionKey } from "../../sessions/session-key-utils.js";
 import { parseInlineDirectives } from "../../utils/directive-tags.js";
+import type { GatewayRecoveryRuntime } from "../server-instance-runtime.js";
 import type { GatewayRequestContext } from "./types.js";
 
 export { hasRestartRecoveryTerminalRun };
@@ -151,6 +152,7 @@ export async function resolveDurableChatClaim(params: {
   persistedSessionKey: string;
   reloadEntry: () => SessionEntry | undefined;
   storePath: string;
+  recoveryRuntime?: GatewayRecoveryRuntime;
   warn: (message: string) => void;
 }): Promise<DurableChatClaimResolution> {
   let entry = params.entry;
@@ -163,6 +165,12 @@ export async function resolveDurableChatClaim(params: {
     if (recoverySessionError) {
       return { kind: "rejected", message: recoverySessionError };
     }
+    if (!params.recoveryRuntime) {
+      return {
+        kind: "pending",
+        message: "accepted chat turn recovery is waiting for the Gateway runtime; retry",
+      };
+    }
     try {
       const { retryRestartAbortedMainSessionRecovery } =
         await import("../../agents/main-session-restart-recovery.js");
@@ -174,6 +182,7 @@ export async function resolveDurableChatClaim(params: {
         expectedSessionId: entry.sessionId,
         sessionKey: params.persistedSessionKey,
         storePath: params.storePath,
+        gatewayRuntime: params.recoveryRuntime,
       });
     } catch (error) {
       params.warn(String(error));

--- a/src/gateway/server-methods/chat-send-pre-admission.ts
+++ b/src/gateway/server-methods/chat-send-pre-admission.ts
@@ -148,6 +148,7 @@ export async function runChatSendPreAdmission(params: {
     persistedSessionKey: legacyKey ?? sessionKey,
     reloadEntry: () => loadSessionEntry(rawSessionKey, sessionLoadOptions).entry,
     storePath,
+    recoveryRuntime: context.recoveryRuntime,
     warn: (message) =>
       context.logGateway.warn(`failed to retry durable chat recovery ${clientRunId}: ${message}`),
   });

--- a/src/gateway/server-methods/exec-approval.ts
+++ b/src/gateway/server-methods/exec-approval.ts
@@ -490,6 +490,7 @@ export function createExecApprovalHandlers(
             ? manager.resolveAutoReview(approvalId, resolvedBy)
             : manager.resolve(approvalId, decisionLocal, resolvedBy),
         resolvedEventName: "exec.approval.resolved",
+        approvalKind: "exec",
         buildResolvedEvent: ({
           approvalId,
           decision: decisionLocal,

--- a/src/gateway/server-methods/plugin-approval.ts
+++ b/src/gateway/server-methods/plugin-approval.ts
@@ -186,6 +186,7 @@ export function createPluginApprovalHandlers(
                 },
               },
         resolvedEventName: "plugin.approval.resolved",
+        approvalKind: "plugin",
         buildResolvedEvent: ({
           approvalId,
           decision: decisionLocal,

--- a/src/gateway/server-methods/shared-types.ts
+++ b/src/gateway/server-methods/shared-types.ts
@@ -42,7 +42,7 @@ import type { GatewayCronServiceContract } from "../server-cron-contract.js";
 import type {
   GatewayApprovalEventPublisher,
   GatewayRecoveryRuntime,
-} from "../server-instance-runtime.js";
+} from "../server-instance-runtime.types.js";
 import type { DedupeEntry } from "../server-shared.js";
 import type { GatewayEventLoopHealth } from "../server/event-loop-health.js";
 import type { TerminalLaunchResolution } from "../terminal/launch.js";

--- a/src/gateway/server-methods/shared-types.ts
+++ b/src/gateway/server-methods/shared-types.ts
@@ -39,6 +39,10 @@ import type {
   ChatRunRegistration,
 } from "../server-chat-state.js";
 import type { GatewayCronServiceContract } from "../server-cron-contract.js";
+import type {
+  GatewayApprovalEventPublisher,
+  GatewayRecoveryRuntime,
+} from "../server-instance-runtime.js";
 import type { DedupeEntry } from "../server-shared.js";
 import type { GatewayEventLoopHealth } from "../server/event-loop-health.js";
 import type { TerminalLaunchResolution } from "../terminal/launch.js";
@@ -147,6 +151,9 @@ export type GatewayRequestContext = {
   hasConnectedTalkNode: () => boolean;
   isConnectionActive?: (connId: string) => boolean;
   hasExecApprovalClients?: (excludeConnId?: string) => boolean;
+  /** Instance-local native approval subscribers; never derived from a network client. */
+  approvalEvents?: GatewayApprovalEventPublisher;
+  recoveryRuntime?: GatewayRecoveryRuntime;
   getApprovalClientConnIds?: <TPayload>(params?: {
     excludeConnId?: string;
     filter?: (client: GatewayClient, record?: ExecApprovalRecord<TPayload>) => boolean;

--- a/src/gateway/server-plugin-runtime-client.ts
+++ b/src/gateway/server-plugin-runtime-client.ts
@@ -21,7 +21,7 @@ export function createSyntheticPluginRuntimeClient(params?: {
   pluginRuntimeOwnerId?: string;
   runtimePluginToolGrant?: RuntimePluginToolGrant;
   scopes?: string[];
-}): GatewayRequestOptions["client"] {
+}): NonNullable<GatewayRequestOptions["client"]> {
   const pluginRuntimeOwnerId =
     typeof params?.pluginRuntimeOwnerId === "string" && params.pluginRuntimeOwnerId.trim()
       ? params.pluginRuntimeOwnerId.trim()

--- a/src/gateway/server-plugins.ts
+++ b/src/gateway/server-plugins.ts
@@ -4,8 +4,6 @@ import { randomUUID } from "node:crypto";
 import { performance } from "node:perf_hooks";
 import { parseModelCatalogRef } from "@openclaw/model-catalog-core/model-catalog-refs";
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
-import { GatewayClientRequestError } from "../../packages/gateway-client/src/index.js";
-import type { ErrorShape } from "../../packages/gateway-protocol/src/schema/frames.js";
 import { normalizeModelRef, parseModelRef } from "../agents/model-selection.js";
 import { applyPluginAutoEnable } from "../config/plugin-auto-enable.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -22,9 +20,13 @@ import type { RuntimePluginToolGrant } from "../plugins/runtime/tool-grant.js";
 import type { PluginRuntime, RuntimeGatewayRequestOptions } from "../plugins/runtime/types.js";
 import type { PluginLogger, PluginOrigin } from "../plugins/types.js";
 import { resolveGlobalSingleton } from "../shared/global-singleton.js";
-import { resolveSafeTimeoutDelayMs } from "../utils/timer-delay.js";
 import { ADMIN_SCOPE } from "./method-scopes.js";
 import { normalizeOperatorScopeList, type OperatorScope } from "./operator-scopes.js";
+import {
+  dispatchGatewayRequestInProcessRaw,
+  type GatewayMethodDispatchResponse,
+  unwrapGatewayMethodDispatchResponse,
+} from "./server-in-process-dispatch.js";
 import type { GatewayRequestHandler, GatewayRequestOptions } from "./server-methods/types.js";
 import { getFallbackGatewayContext } from "./server-plugin-fallback-context.js";
 import {
@@ -244,71 +246,7 @@ type DispatchGatewayMethodInProcessOptions = {
   timeoutMs?: number;
 };
 
-export type GatewayMethodDispatchResponse = {
-  ok: boolean;
-  payload?: unknown;
-  error?: ErrorShape;
-  meta?: Record<string, unknown>;
-};
-
-function unwrapGatewayMethodDispatchResponse(
-  method: string,
-  response: GatewayMethodDispatchResponse,
-): unknown {
-  if (!response.ok) {
-    throw new GatewayClientRequestError({
-      code: response.error?.code,
-      message: response.error?.message ?? `Gateway method "${method}" failed.`,
-      details: response.error?.details,
-      retryable: response.error?.retryable,
-      retryAfterMs: response.error?.retryAfterMs,
-    });
-  }
-  return response.payload;
-}
-
-function resolveInProcessDispatchTimeoutMs(timeoutMs?: number): number | undefined {
-  return typeof timeoutMs === "number" && Number.isFinite(timeoutMs)
-    ? resolveSafeTimeoutDelayMs(timeoutMs)
-    : undefined;
-}
-
-function resolveInProcessDispatchDeadlineMs(timeoutMs?: number): number | undefined {
-  const safeTimeoutMs = resolveInProcessDispatchTimeoutMs(timeoutMs);
-  return safeTimeoutMs === undefined ? undefined : Date.now() + safeTimeoutMs;
-}
-
-function resolveRemainingInProcessDispatchTimeoutMs(deadlineMs?: number): number | undefined {
-  return deadlineMs === undefined
-    ? undefined
-    : resolveSafeTimeoutDelayMs(deadlineMs - Date.now(), { minMs: 0 });
-}
-
-async function waitForInProcessDispatch<T>(
-  method: string,
-  promise: Promise<T>,
-  deadlineMs?: number,
-): Promise<T> {
-  const remainingTimeoutMs = resolveRemainingInProcessDispatchTimeoutMs(deadlineMs);
-  if (remainingTimeoutMs === undefined) {
-    return await promise;
-  }
-  let timeout: NodeJS.Timeout | undefined;
-  try {
-    return await Promise.race([
-      promise,
-      new Promise<never>((_resolve, reject) => {
-        timeout = setTimeout(() => {
-          reject(new Error(`gateway request timeout for ${method}`));
-        }, remainingTimeoutMs);
-      }),
-    ]);
-  } finally {
-    if (timeout) {
-      clearTimeout(timeout);
-    }
-  }
-}
+export type { GatewayMethodDispatchResponse } from "./server-in-process-dispatch.js";
 
 export async function dispatchGatewayMethodInProcessRaw(
   method: string,
@@ -329,19 +267,6 @@ export async function dispatchGatewayMethodInProcessRaw(
     );
   }
 
-  let firstResponse: GatewayMethodDispatchResponse | undefined;
-  let finalResponse: GatewayMethodDispatchResponse | undefined;
-  let resolveFirstResponse: ((response: GatewayMethodDispatchResponse) => void) | undefined;
-  let rejectFirstResponse: ((err: Error) => void) | undefined;
-  let resolveFinalResponse: ((response: GatewayMethodDispatchResponse) => void) | undefined;
-  let rejectFinalResponse: ((err: Error) => void) | undefined;
-  let postFirstResponseError: Error | undefined;
-  const firstResponsePromise = new Promise<GatewayMethodDispatchResponse>((resolve, reject) => {
-    resolveFirstResponse = resolve;
-    rejectFirstResponse = reject;
-  });
-  const deadlineMs = resolveInProcessDispatchDeadlineMs(options?.timeoutMs);
-  const { handleGatewayRequest } = await import("./server-methods.js");
   const pluginRuntimeOwnerId =
     typeof options?.pluginRuntimeOwnerId === "string" && options.pluginRuntimeOwnerId.trim()
       ? options.pluginRuntimeOwnerId.trim()
@@ -371,93 +296,18 @@ export async function dispatchGatewayMethodInProcessRaw(
   if (options?.disableSyntheticClient === true && !scopedClient) {
     throw new Error(`In-process gateway dispatch requires a scoped client (method: ${method}).`);
   }
-  void handleGatewayRequest({
-    req: {
-      type: "req",
-      id: `plugin-subagent-${randomUUID()}`,
-      method,
-      params,
-    },
+  return await dispatchGatewayRequestInProcessRaw(method, params, {
     client:
       options?.forceSyntheticClient === true
         ? syntheticClient
         : (scopedClient ?? (options?.disableSyntheticClient === true ? null : syntheticClient)),
-    isWebchatConnect,
-    respond: (ok, payload, error, meta) => {
-      const response = { ok, payload, error, ...(meta ? { meta } : {}) };
-      if (!firstResponse) {
-        firstResponse = response;
-        resolveFirstResponse?.(response);
-        return;
-      }
-      if (!finalResponse) {
-        finalResponse = response;
-        resolveFinalResponse?.(response);
-      }
-    },
     context,
-  })
-    .then(() => {
-      if (!firstResponse) {
-        rejectFirstResponse?.(
-          new Error(`Gateway method "${method}" completed without a response.`),
-        );
-      }
-    })
-    .catch((err: unknown) => {
-      const error = err instanceof Error ? err : new Error(String(err));
-      if (!firstResponse) {
-        rejectFirstResponse?.(error);
-        return;
-      }
-      postFirstResponseError = error;
-      rejectFinalResponse?.(error);
-    });
-
-  firstResponse = await waitForInProcessDispatch(method, firstResponsePromise, deadlineMs);
-  const firstPayload = firstResponse.payload as { status?: unknown } | undefined;
-  if (options?.expectFinal !== true || firstPayload?.status !== "accepted") {
-    return firstResponse;
-  }
-  options.onAccepted?.(firstResponse.payload);
-  if (postFirstResponseError) {
-    throw postFirstResponseError;
-  }
-  const final =
-    finalResponse ??
-    (await new Promise<GatewayMethodDispatchResponse>((resolve, reject) => {
-      resolveFinalResponse = resolve;
-      const timeoutMs = resolveRemainingInProcessDispatchTimeoutMs(deadlineMs);
-      const timeout =
-        timeoutMs === undefined
-          ? undefined
-          : setTimeout(() => {
-              reject(new Error(`gateway request timeout for ${method}`));
-            }, timeoutMs);
-      const clearFinalTimeout = () => {
-        if (timeout) {
-          clearTimeout(timeout);
-        }
-      };
-      rejectFinalResponse = (err) => {
-        clearFinalTimeout();
-        reject(err);
-      };
-      if (postFirstResponseError) {
-        rejectFinalResponse(postFirstResponseError);
-        return;
-      }
-      if (finalResponse) {
-        clearFinalTimeout();
-        resolve(finalResponse);
-        return;
-      }
-      resolveFinalResponse = (response) => {
-        clearFinalTimeout();
-        resolve(response);
-      };
-    }));
-  return final;
+    expectFinal: options?.expectFinal,
+    isWebchatConnect,
+    onAccepted: options?.onAccepted,
+    requestIdPrefix: "plugin-subagent",
+    timeoutMs: options?.timeoutMs,
+  });
 }
 
 async function dispatchGatewayMethod<T>(

--- a/src/gateway/server-plugins.ts
+++ b/src/gateway/server-plugins.ts
@@ -703,4 +703,3 @@ export function loadGatewayPlugins(params: {
   ]);
   return { pluginRegistry, gatewayMethods };
 }
-/* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/gateway/server-recovery-runtime-context.ts
+++ b/src/gateway/server-recovery-runtime-context.ts
@@ -1,0 +1,30 @@
+import type { GatewayRecoveryRuntime } from "./server-instance-runtime.types.js";
+
+type ActiveGatewayRecoveryRuntime = {
+  owner: symbol;
+  runtime: GatewayRecoveryRuntime;
+};
+
+let activeRuntime: ActiveGatewayRecoveryRuntime | undefined;
+
+/** Registers the recovery principal owned by the latest process-global Gateway instance. */
+export function registerGatewayRecoveryRuntime(runtime: GatewayRecoveryRuntime): () => void {
+  const owner = Symbol("gateway-recovery-runtime");
+  activeRuntime = { owner, runtime };
+  let released = false;
+  return () => {
+    if (released) {
+      return;
+    }
+    released = true;
+    // An older Gateway may finish closing after its replacement has registered.
+    // Never let that stale close clear the replacement's recovery authority.
+    if (activeRuntime?.owner === owner) {
+      activeRuntime = undefined;
+    }
+  };
+}
+
+export function getGatewayRecoveryRuntime(): GatewayRecoveryRuntime | undefined {
+  return activeRuntime?.runtime;
+}

--- a/src/gateway/server-startup-post-attach.test.ts
+++ b/src/gateway/server-startup-post-attach.test.ts
@@ -420,6 +420,7 @@ describe("startGatewayPostAttachRuntime", () => {
       cfg: { hooks: { internal: { enabled: false } } },
       gatewayRuntime: expect.any(Object),
     });
+    expect(hoisted.scheduleSubagentOrphanRecovery).toHaveBeenCalledWith();
     expect(methodsAtRecoveryRegistration).toStrictEqual([["chat.history", "models.list"]]);
     expect(hoisted.startGatewayMemoryBackend).not.toHaveBeenCalled();
   });

--- a/src/gateway/server-startup-post-attach.test.ts
+++ b/src/gateway/server-startup-post-attach.test.ts
@@ -418,6 +418,7 @@ describe("startGatewayPostAttachRuntime", () => {
     expect(log.info).toHaveBeenCalledWith("gateway ready");
     expect(hoisted.scheduleRestartAbortedMainSessionRecovery).toHaveBeenCalledWith({
       cfg: { hooks: { internal: { enabled: false } } },
+      gatewayRuntime: expect.any(Object),
     });
     expect(methodsAtRecoveryRegistration).toStrictEqual([["chat.history", "models.list"]]);
     expect(hoisted.startGatewayMemoryBackend).not.toHaveBeenCalled();
@@ -2561,6 +2562,11 @@ function createPostAttachParams(overrides: Partial<PostAttachParams> = {}): Post
     defaultWorkspaceDir: "/tmp/openclaw-workspace",
     deps: {} as never,
     startChannels: vi.fn(async () => {}),
+    recoveryRuntime: {
+      dispatchAgent: vi.fn(),
+      waitForAgent: vi.fn(),
+      sendRecoveryNotice: vi.fn(),
+    },
     logHooks: {
       info: vi.fn(),
       warn: vi.fn(),

--- a/src/gateway/server-startup-post-attach.ts
+++ b/src/gateway/server-startup-post-attach.ts
@@ -23,7 +23,7 @@ import {
   type GatewayUpdateAvailableEventPayload,
 } from "./events.js";
 import { STARTUP_UNAVAILABLE_GATEWAY_METHODS } from "./methods/core-descriptors.js";
-import type { GatewayRecoveryRuntime } from "./server-instance-runtime.js";
+import type { GatewayRecoveryRuntime } from "./server-instance-runtime.types.js";
 import type { refreshLatestUpdateRestartSentinel } from "./server-restart-sentinel.js";
 import type { GatewaySidecarStartupMode } from "./server-sidecar-startup-mode.js";
 import { scheduleContextCachePrewarm } from "./server-startup-context-cache-prewarm.js";

--- a/src/gateway/server-startup-post-attach.ts
+++ b/src/gateway/server-startup-post-attach.ts
@@ -910,16 +910,6 @@ export async function startGatewaySidecars(params: {
     },
   });
 
-  schedulePostReadySidecarTask({
-    startupTrace: params.startupTrace,
-    name: "sidecars.subagent-recovery",
-    log: params.log,
-    run: async () => {
-      const { scheduleSubagentOrphanRecovery } = await import("../agents/subagent-registry.js");
-      scheduleSubagentOrphanRecovery();
-    },
-  });
-
   if (params.cfg.hooks?.enabled && params.cfg.hooks.gmail?.account) {
     postReadySidecars.push(
       schedulePostReadySidecarTask({
@@ -1327,6 +1317,12 @@ export async function startGatewayPostAttachRuntime(
           });
         } catch (err) {
           params.log.warn(`main-session restart recovery failed to schedule: ${String(err)}`);
+        }
+        try {
+          const { scheduleSubagentOrphanRecovery } = await import("../agents/subagent-registry.js");
+          scheduleSubagentOrphanRecovery();
+        } catch (err) {
+          params.log.warn(`subagent restart recovery failed to schedule: ${String(err)}`);
         }
         // Capture the orphan-recovery cutoff before new startup-gated agent
         // work can create sessions that the recovery scan must leave alone.

--- a/src/gateway/server-startup-post-attach.ts
+++ b/src/gateway/server-startup-post-attach.ts
@@ -23,6 +23,7 @@ import {
   type GatewayUpdateAvailableEventPayload,
 } from "./events.js";
 import { STARTUP_UNAVAILABLE_GATEWAY_METHODS } from "./methods/core-descriptors.js";
+import type { GatewayRecoveryRuntime } from "./server-instance-runtime.js";
 import type { refreshLatestUpdateRestartSentinel } from "./server-restart-sentinel.js";
 import type { GatewaySidecarStartupMode } from "./server-sidecar-startup-mode.js";
 import { scheduleContextCachePrewarm } from "./server-startup-context-cache-prewarm.js";
@@ -1125,6 +1126,7 @@ export async function startGatewayPostAttachRuntime(
     defaultWorkspaceDir: string;
     deps: CliDeps;
     startChannels: () => Promise<void>;
+    recoveryRuntime: GatewayRecoveryRuntime;
     logHooks: {
       info: (msg: string) => void;
       warn: (msg: string) => void;
@@ -1319,7 +1321,10 @@ export async function startGatewayPostAttachRuntime(
         try {
           const { scheduleRestartAbortedMainSessionRecovery } =
             await loadMainSessionRestartRecoveryModule();
-          scheduleRestartAbortedMainSessionRecovery({ cfg: params.cfgAtStart });
+          scheduleRestartAbortedMainSessionRecovery({
+            cfg: params.cfgAtStart,
+            gatewayRuntime: params.recoveryRuntime,
+          });
         } catch (err) {
           params.log.warn(`main-session restart recovery failed to schedule: ${String(err)}`);
         }

--- a/src/gateway/server.chat.gateway-server-chat-b.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat-b.test.ts
@@ -228,6 +228,11 @@ function createDirectChatContext(): GatewayRequestContext {
     nodeSendToSession: vi.fn(),
     registerToolEventRecipient: vi.fn(),
     getRuntimeConfig: () => ({}),
+    recoveryRuntime: {
+      dispatchAgent: vi.fn(),
+      waitForAgent: vi.fn(),
+      sendRecoveryNotice: vi.fn(),
+    },
     dedupe: new Map(),
   } as unknown as GatewayRequestContext;
 }
@@ -2700,6 +2705,7 @@ describe("gateway server chat", () => {
         expectedSessionId: "sess-main",
         sessionKey: "main",
         storePath,
+        gatewayRuntime: expect.any(Object),
       });
       expect(dispatchInboundMessageMock).not.toHaveBeenCalled();
       expect(loadExactSessionEntry({ sessionKey: "main", storePath })?.entry).toMatchObject({

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -121,6 +121,7 @@ import type { ChannelAutostartSuppression } from "./server-channels.js";
 import { resolveGatewayControlUiRootState } from "./server-control-ui-root.js";
 import { createLazyGatewayCronState } from "./server-cron-lazy.js";
 import { createGatewayCronReconciliation } from "./server-cron-reconciled.js";
+import type { GatewayInstanceRuntime } from "./server-instance-runtime.js";
 import { applyGatewayLaneConcurrency, resolveGatewayLaneConcurrency } from "./server-lanes.js";
 import { createGatewayServerLiveState, type GatewayServerLiveState } from "./server-live-state.js";
 import { GATEWAY_EVENTS } from "./server-methods-list.js";
@@ -1086,6 +1087,10 @@ export async function startGatewayServer(
   const startupAccountStartsReady = new Promise<void>((resolve) => {
     releaseStartupAccountStarts = resolve;
   });
+  let gatewayInstanceRuntime: GatewayInstanceRuntime | undefined;
+  // Internal principals belong to this server generation and become usable only after bind.
+  // Closing flips this first so delayed recovery/channel work cannot enter a retired context.
+  let gatewayInstanceDispatchReady = false;
   const { createChannelManager } = await import("./server-channels.js");
   const channelManager = createChannelManager({
     getRuntimeConfig: () => {
@@ -1100,6 +1105,7 @@ export async function startGatewayServer(
     getPluginHttpRouteRegistry: () => pluginRegistry,
     startupTrace,
     deferStartupAccountStartsUntil: startupAccountStartsReady,
+    getNativeApprovalRuntime: () => gatewayInstanceRuntime?.nativeApprovals,
   });
   channelManager.setAutostartSuppression(opts.channelAutostartSuppression ?? null);
   const sidecarStartup = opts.sidecarStartup ?? "start";
@@ -1299,6 +1305,8 @@ export async function startGatewayServer(
   };
   const markClosePreludeStarted = () => {
     closePreludeStarted = true;
+    gatewayInstanceDispatchReady = false;
+    gatewayInstanceRuntime?.close();
     cronReconciliation.invalidate();
     clearPostReadyMaintenanceTimer();
     retainedPluginCleanupHandle?.stop();
@@ -1923,6 +1931,16 @@ export async function startGatewayServer(
       },
     );
     currentPluginRegistryGatewayContext = gatewayRequestContext;
+    const { createGatewayInstanceRuntime } = await import("./server-instance-runtime.js");
+    const gatewayInstanceRuntimeLocal = createGatewayInstanceRuntime({
+      getContext: () => gatewayRequestContext,
+      getMethodRegistry: () => attachedGatewayMethodRegistry,
+      isDispatchAvailable: () => gatewayInstanceDispatchReady && !closePreludeStarted,
+      logError: (message) => log.error(message),
+    });
+    gatewayInstanceRuntime = gatewayInstanceRuntimeLocal;
+    gatewayRequestContext.approvalEvents = gatewayInstanceRuntimeLocal.approvalEvents;
+    gatewayRequestContext.recoveryRuntime = gatewayInstanceRuntimeLocal.recovery;
 
     const fallbackGatewayContextCleanup: unknown = setFallbackGatewayContextResolver(
       () => gatewayRequestContext,
@@ -1995,6 +2013,7 @@ export async function startGatewayServer(
       }),
     );
     await startupTrace.measure("http.listen", () => startListening());
+    gatewayInstanceDispatchReady = true;
     startupTrace.mark("http.bound");
     const sessionDeliveryRecoveryMaxEnqueuedAt = Date.now();
     let postAttachRuntimeReturned = false;
@@ -2064,6 +2083,7 @@ export async function startGatewayServer(
             defaultWorkspaceDir,
             deps,
             startChannels,
+            recoveryRuntime: gatewayInstanceRuntimeLocal.recovery,
             logHooks,
             logChannels,
             unavailableGatewayMethods,

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -121,7 +121,7 @@ import type { ChannelAutostartSuppression } from "./server-channels.js";
 import { resolveGatewayControlUiRootState } from "./server-control-ui-root.js";
 import { createLazyGatewayCronState } from "./server-cron-lazy.js";
 import { createGatewayCronReconciliation } from "./server-cron-reconciled.js";
-import type { GatewayInstanceRuntime } from "./server-instance-runtime.js";
+import type { GatewayInstanceRuntime } from "./server-instance-runtime.types.js";
 import { applyGatewayLaneConcurrency, resolveGatewayLaneConcurrency } from "./server-lanes.js";
 import { createGatewayServerLiveState, type GatewayServerLiveState } from "./server-live-state.js";
 import { GATEWAY_EVENTS } from "./server-methods-list.js";

--- a/src/infra/approval-gateway-resolver.test.ts
+++ b/src/infra/approval-gateway-resolver.test.ts
@@ -1,10 +1,8 @@
 // Covers approval resolution over the gateway client.
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { GatewayNativeApprovalRuntime } from "../gateway/server-instance-runtime.js";
-import {
-  resolveApprovalOverGateway,
-  withGatewayNativeApprovalRuntime,
-} from "./approval-gateway-resolver.js";
+import { resolveApprovalOverGateway } from "./approval-gateway-resolver.js";
+import { withGatewayNativeApprovalRuntime } from "./approval-gateway-runtime-context.js";
+import type { GatewayNativeApprovalRuntime } from "./approval-gateway-runtime.types.js";
 
 const hoisted = vi.hoisted(() => ({
   withOperatorApprovalsGatewayClient: vi.fn(),

--- a/src/infra/approval-gateway-resolver.test.ts
+++ b/src/infra/approval-gateway-resolver.test.ts
@@ -1,6 +1,10 @@
 // Covers approval resolution over the gateway client.
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { resolveApprovalOverGateway } from "./approval-gateway-resolver.js";
+import type { GatewayNativeApprovalRuntime } from "../gateway/server-instance-runtime.js";
+import {
+  resolveApprovalOverGateway,
+  withGatewayNativeApprovalRuntime,
+} from "./approval-gateway-resolver.js";
 
 const hoisted = vi.hoisted(() => ({
   withOperatorApprovalsGatewayClient: vi.fn(),
@@ -89,6 +93,37 @@ describe("resolveApprovalOverGateway", () => {
       kind: "plugin",
       decision: "deny",
     });
+  });
+
+  it("uses the channel task's owning Gateway principal without opening a client", async () => {
+    const request = vi.fn(async () => ({ applied: true, approval: recordedApproval }));
+    const result = await withGatewayNativeApprovalRuntime(
+      {
+        request: request as GatewayNativeApprovalRuntime["request"],
+        requestRoute: vi.fn(),
+        routeCoordinator: {} as never,
+        subscribe: vi.fn(),
+      },
+      async () =>
+        await resolveApprovalOverGateway({
+          cfg: {} as never,
+          approvalId: "approval-1",
+          approvalKind: "exec",
+          decision: "deny",
+        }),
+    );
+
+    expect(request).toHaveBeenCalledWith(
+      "approval.resolve",
+      {
+        id: "approval-1",
+        kind: "exec",
+        decision: "deny",
+      },
+      { clientDisplayName: "Approval (unknown)" },
+    );
+    expect(result).toEqual({ applied: true, approval: recordedApproval });
+    expect(hoisted.withOperatorApprovalsGatewayClient).not.toHaveBeenCalled();
   });
 
   it("preserves protocol-valid boundary whitespace in canonical approval ids", async () => {

--- a/src/infra/approval-gateway-resolver.ts
+++ b/src/infra/approval-gateway-resolver.ts
@@ -10,6 +10,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { withOperatorApprovalsGatewayClient } from "../gateway/operator-approvals-client.js";
 import { isApprovalNotFoundError } from "./approval-errors.js";
 import { getGatewayNativeApprovalRuntime } from "./approval-gateway-runtime-context.js";
+import type { GatewayNativeApprovalMethod } from "./approval-gateway-runtime-methods.js";
 
 type ResolveApprovalOverGatewayBaseParams = {
   cfg: OpenClawConfig;
@@ -96,7 +97,10 @@ export async function resolveApprovalOverGateway(
     params.clientDisplayName ?? `Approval (${params.senderId?.trim() || "unknown"})`;
 
   const requestWithClient = async (gatewayClient: {
-    request: <T = unknown>(method: string, params: Record<string, unknown>) => Promise<T>;
+    request: <T = unknown>(
+      method: GatewayNativeApprovalMethod,
+      params: Record<string, unknown>,
+    ) => Promise<T>;
   }) => {
     if (hasCanonicalKind) {
       const resolveParams: ApprovalResolveParams = {
@@ -133,8 +137,10 @@ export async function resolveApprovalOverGateway(
   const gatewayRuntime = getGatewayNativeApprovalRuntime();
   const result = gatewayRuntime
     ? await requestWithClient({
-        request: async <T>(method: string, requestParams: Record<string, unknown>) =>
-          await gatewayRuntime.request<T>(method, requestParams, { clientDisplayName }),
+        request: async <T>(
+          method: GatewayNativeApprovalMethod,
+          requestParams: Record<string, unknown>,
+        ) => await gatewayRuntime.request<T>(method, requestParams, { clientDisplayName }),
       })
     : await withOperatorApprovalsGatewayClient(
         {

--- a/src/infra/approval-gateway-resolver.ts
+++ b/src/infra/approval-gateway-resolver.ts
@@ -1,4 +1,5 @@
 // Resolves exec and plugin approvals through the gateway client.
+import { AsyncLocalStorage } from "node:async_hooks";
 import type {
   ApprovalDecision,
   ApprovalKind,
@@ -8,6 +9,8 @@ import type {
 import { isWellFormedApprovalId } from "../../packages/gateway-protocol/src/schema/approvals.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { withOperatorApprovalsGatewayClient } from "../gateway/operator-approvals-client.js";
+import type { GatewayNativeApprovalRuntime } from "../gateway/server-instance-runtime.js";
+import { resolveGlobalSingleton } from "../shared/global-singleton.js";
 import { isApprovalNotFoundError } from "./approval-errors.js";
 
 type ResolveApprovalOverGatewayBaseParams = {
@@ -47,6 +50,26 @@ type LegacyResolveApprovalOverGatewayParams = ResolveApprovalOverGatewayBasePara
 type ResolveApprovalOverGatewayParams =
   | CanonicalResolveApprovalOverGatewayParams
   | LegacyResolveApprovalOverGatewayParams;
+
+const APPROVAL_GATEWAY_RUNTIME_SCOPE_KEY: unique symbol = Symbol.for(
+  "openclaw.approvalGatewayRuntimeScope",
+);
+const approvalGatewayRuntimeScope = resolveGlobalSingleton<
+  AsyncLocalStorage<GatewayNativeApprovalRuntime>
+>(APPROVAL_GATEWAY_RUNTIME_SCOPE_KEY, () => new AsyncLocalStorage<GatewayNativeApprovalRuntime>());
+
+/** Runs one channel account task with its owning Gateway approval principal. */
+export function withGatewayNativeApprovalRuntime<T>(
+  runtime: GatewayNativeApprovalRuntime | undefined,
+  run: () => T,
+): T {
+  return runtime ? approvalGatewayRuntimeScope.run(runtime, run) : run();
+}
+
+/** Returns the Gateway approval principal for the current channel account task. */
+export function getGatewayNativeApprovalRuntime(): GatewayNativeApprovalRuntime | undefined {
+  return approvalGatewayRuntimeScope.getStore();
+}
 
 /**
  * Resolves a shipped legacy approval control through its kind-specific Gateway adapter.
@@ -91,49 +114,57 @@ export async function resolveApprovalOverGateway(
   if (typeof approvalId !== "string" || !isWellFormedApprovalId(approvalId)) {
     throw new Error("approval resolution requires an approval id");
   }
+  const clientDisplayName =
+    params.clientDisplayName ?? `Approval (${params.senderId?.trim() || "unknown"})`;
 
-  const result = await withOperatorApprovalsGatewayClient(
-    {
-      config: params.cfg,
-      gatewayUrl: params.gatewayUrl,
-      clientDisplayName:
-        params.clientDisplayName ?? `Approval (${params.senderId?.trim() || "unknown"})`,
-    },
-    async (gatewayClient) => {
-      if (hasCanonicalKind) {
-        const resolveParams: ApprovalResolveParams = {
-          id: approvalId,
-          kind: canonicalKind,
-          decision: params.decision,
-        };
-        return await gatewayClient.request<ApprovalResolveResult>(
-          "approval.resolve",
-          resolveParams,
-        );
-      }
-
-      const requestLegacyResolve = async (
-        method: "exec.approval.resolve" | "plugin.approval.resolve",
-      ): Promise<void> => {
-        await gatewayClient.request(method, {
-          id: approvalId,
-          decision: params.decision,
-        });
+  const requestWithClient = async (gatewayClient: {
+    request: <T = unknown>(method: string, params: Record<string, unknown>) => Promise<T>;
+  }) => {
+    if (hasCanonicalKind) {
+      const resolveParams: ApprovalResolveParams = {
+        id: approvalId,
+        kind: canonicalKind,
+        decision: params.decision,
       };
-      if (legacyMethod === "plugin" || (!legacyMethod && approvalId.startsWith("plugin:"))) {
-        await requestLegacyResolve("plugin.approval.resolve");
-        return undefined;
-      }
-      try {
-        await requestLegacyResolve("exec.approval.resolve");
-      } catch (error) {
-        if (allowPluginFallback !== true || !isApprovalNotFoundError(error)) {
-          throw error;
-        }
-        await requestLegacyResolve("plugin.approval.resolve");
-      }
+      return await gatewayClient.request<ApprovalResolveResult>("approval.resolve", resolveParams);
+    }
+
+    const requestLegacyResolve = async (
+      method: "exec.approval.resolve" | "plugin.approval.resolve",
+    ): Promise<void> => {
+      await gatewayClient.request(method, {
+        id: approvalId,
+        decision: params.decision,
+      });
+    };
+    if (legacyMethod === "plugin" || (!legacyMethod && approvalId.startsWith("plugin:"))) {
+      await requestLegacyResolve("plugin.approval.resolve");
       return undefined;
-    },
-  );
+    }
+    try {
+      await requestLegacyResolve("exec.approval.resolve");
+    } catch (error) {
+      if (allowPluginFallback !== true || !isApprovalNotFoundError(error)) {
+        throw error;
+      }
+      await requestLegacyResolve("plugin.approval.resolve");
+    }
+    return undefined;
+  };
+
+  const gatewayRuntime = getGatewayNativeApprovalRuntime();
+  const result = gatewayRuntime
+    ? await requestWithClient({
+        request: async <T>(method: string, requestParams: Record<string, unknown>) =>
+          await gatewayRuntime.request<T>(method, requestParams, { clientDisplayName }),
+      })
+    : await withOperatorApprovalsGatewayClient(
+        {
+          config: params.cfg,
+          gatewayUrl: params.gatewayUrl,
+          clientDisplayName,
+        },
+        requestWithClient,
+      );
   return hasCanonicalKind ? result : undefined;
 }

--- a/src/infra/approval-gateway-resolver.ts
+++ b/src/infra/approval-gateway-resolver.ts
@@ -1,5 +1,4 @@
 // Resolves exec and plugin approvals through the gateway client.
-import { AsyncLocalStorage } from "node:async_hooks";
 import type {
   ApprovalDecision,
   ApprovalKind,
@@ -9,9 +8,8 @@ import type {
 import { isWellFormedApprovalId } from "../../packages/gateway-protocol/src/schema/approvals.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { withOperatorApprovalsGatewayClient } from "../gateway/operator-approvals-client.js";
-import type { GatewayNativeApprovalRuntime } from "../gateway/server-instance-runtime.js";
-import { resolveGlobalSingleton } from "../shared/global-singleton.js";
 import { isApprovalNotFoundError } from "./approval-errors.js";
+import { getGatewayNativeApprovalRuntime } from "./approval-gateway-runtime-context.js";
 
 type ResolveApprovalOverGatewayBaseParams = {
   cfg: OpenClawConfig;
@@ -50,26 +48,6 @@ type LegacyResolveApprovalOverGatewayParams = ResolveApprovalOverGatewayBasePara
 type ResolveApprovalOverGatewayParams =
   | CanonicalResolveApprovalOverGatewayParams
   | LegacyResolveApprovalOverGatewayParams;
-
-const APPROVAL_GATEWAY_RUNTIME_SCOPE_KEY: unique symbol = Symbol.for(
-  "openclaw.approvalGatewayRuntimeScope",
-);
-const approvalGatewayRuntimeScope = resolveGlobalSingleton<
-  AsyncLocalStorage<GatewayNativeApprovalRuntime>
->(APPROVAL_GATEWAY_RUNTIME_SCOPE_KEY, () => new AsyncLocalStorage<GatewayNativeApprovalRuntime>());
-
-/** Runs one channel account task with its owning Gateway approval principal. */
-export function withGatewayNativeApprovalRuntime<T>(
-  runtime: GatewayNativeApprovalRuntime | undefined,
-  run: () => T,
-): T {
-  return runtime ? approvalGatewayRuntimeScope.run(runtime, run) : run();
-}
-
-/** Returns the Gateway approval principal for the current channel account task. */
-export function getGatewayNativeApprovalRuntime(): GatewayNativeApprovalRuntime | undefined {
-  return approvalGatewayRuntimeScope.getStore();
-}
 
 /**
  * Resolves a shipped legacy approval control through its kind-specific Gateway adapter.

--- a/src/infra/approval-gateway-runtime-context.ts
+++ b/src/infra/approval-gateway-runtime-context.ts
@@ -1,0 +1,23 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import { resolveGlobalSingleton } from "../shared/global-singleton.js";
+import type { GatewayNativeApprovalRuntime } from "./approval-gateway-runtime.types.js";
+
+const APPROVAL_GATEWAY_RUNTIME_SCOPE_KEY: unique symbol = Symbol.for(
+  "openclaw.approvalGatewayRuntimeScope",
+);
+const approvalGatewayRuntimeScope = resolveGlobalSingleton<
+  AsyncLocalStorage<GatewayNativeApprovalRuntime>
+>(APPROVAL_GATEWAY_RUNTIME_SCOPE_KEY, () => new AsyncLocalStorage<GatewayNativeApprovalRuntime>());
+
+/** Runs one channel account task with its owning Gateway approval principal. */
+export function withGatewayNativeApprovalRuntime<T>(
+  runtime: GatewayNativeApprovalRuntime | undefined,
+  run: () => T,
+): T {
+  return runtime ? approvalGatewayRuntimeScope.run(runtime, run) : run();
+}
+
+/** Returns the Gateway approval principal for the current channel account task. */
+export function getGatewayNativeApprovalRuntime(): GatewayNativeApprovalRuntime | undefined {
+  return approvalGatewayRuntimeScope.getStore();
+}

--- a/src/infra/approval-gateway-runtime-methods.ts
+++ b/src/infra/approval-gateway-runtime-methods.ts
@@ -1,0 +1,18 @@
+export const GATEWAY_NATIVE_APPROVAL_METHODS = [
+  "approval.resolve",
+  "exec.approval.get",
+  "exec.approval.list",
+  "exec.approval.resolve",
+  "plugin.approval.list",
+  "plugin.approval.resolve",
+] as const;
+
+export type GatewayNativeApprovalMethod = (typeof GATEWAY_NATIVE_APPROVAL_METHODS)[number];
+
+const gatewayNativeApprovalMethods = new Set<string>(GATEWAY_NATIVE_APPROVAL_METHODS);
+
+export function isGatewayNativeApprovalMethod(
+  method: string,
+): method is GatewayNativeApprovalMethod {
+  return gatewayNativeApprovalMethods.has(method);
+}

--- a/src/infra/approval-gateway-runtime.types.ts
+++ b/src/infra/approval-gateway-runtime.types.ts
@@ -1,0 +1,26 @@
+import type { ApprovalNativeRouteCoordinator } from "./approval-native-route-coordinator.js";
+import type { ExecApprovalRequest, ExecApprovalResolved } from "./exec-approvals.js";
+import type { PluginApprovalRequest, PluginApprovalResolved } from "./plugin-approvals.js";
+
+export type GatewayApprovalEventKind = "exec" | "plugin";
+export type GatewayApprovalRequest = ExecApprovalRequest | PluginApprovalRequest;
+export type GatewayApprovalResolved = ExecApprovalResolved | PluginApprovalResolved;
+
+export type GatewayApprovalEventSubscriber = {
+  eventKinds: ReadonlySet<GatewayApprovalEventKind>;
+  shouldHandle: (request: GatewayApprovalRequest) => boolean;
+  onRequested: (request: GatewayApprovalRequest) => void;
+  onResolved: (resolved: GatewayApprovalResolved) => void;
+};
+
+/** Gateway-owned authority and event transport for channel-native approval runtimes. */
+export type GatewayNativeApprovalRuntime = {
+  request: <T = unknown>(
+    method: string,
+    params: Record<string, unknown>,
+    options?: { clientDisplayName?: string },
+  ) => Promise<T>;
+  requestRoute: <T = unknown>(method: "send", params: Record<string, unknown>) => Promise<T>;
+  routeCoordinator: ApprovalNativeRouteCoordinator;
+  subscribe: (subscriber: GatewayApprovalEventSubscriber) => () => void;
+};

--- a/src/infra/approval-gateway-runtime.types.ts
+++ b/src/infra/approval-gateway-runtime.types.ts
@@ -1,3 +1,4 @@
+import type { GatewayNativeApprovalMethod } from "./approval-gateway-runtime-methods.js";
 import type { ApprovalNativeRouteCoordinator } from "./approval-native-route-coordinator.js";
 import type { ExecApprovalRequest, ExecApprovalResolved } from "./exec-approvals.js";
 import type { PluginApprovalRequest, PluginApprovalResolved } from "./plugin-approvals.js";
@@ -16,7 +17,7 @@ export type GatewayApprovalEventSubscriber = {
 /** Gateway-owned authority and event transport for channel-native approval runtimes. */
 export type GatewayNativeApprovalRuntime = {
   request: <T = unknown>(
-    method: string,
+    method: GatewayNativeApprovalMethod,
     params: Record<string, unknown>,
     options?: { clientDisplayName?: string },
   ) => Promise<T>;

--- a/src/infra/approval-handler-bootstrap.ts
+++ b/src/infra/approval-handler-bootstrap.ts
@@ -3,6 +3,7 @@ import { resolveChannelApprovalCapability } from "../channels/plugins/approvals.
 import type { ChannelRuntimeSurface } from "../channels/plugins/channel-runtime-surface.types.js";
 import type { ChannelPlugin } from "../channels/plugins/types.plugin.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { GatewayNativeApprovalRuntime } from "../gateway/server-instance-runtime.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import {
   CHANNEL_APPROVAL_NATIVE_RUNTIME_CONTEXT_CAPABILITY,
@@ -46,6 +47,7 @@ export async function startChannelApprovalHandlerBootstrap(params: {
   cfg: OpenClawConfig;
   accountId: string;
   channelRuntime?: ChannelRuntimeSurface;
+  gatewayRuntime?: GatewayNativeApprovalRuntime;
   logger?: ReturnType<typeof createSubsystemLogger>;
 }): Promise<() => Promise<void>> {
   const capability = resolveChannelApprovalCapability(params.plugin);
@@ -95,6 +97,7 @@ export async function startChannelApprovalHandlerBootstrap(params: {
       cfg: params.cfg,
       accountId: params.accountId,
       context,
+      gatewayRuntime: params.gatewayRuntime,
     });
     if (!handler) {
       return;

--- a/src/infra/approval-handler-bootstrap.ts
+++ b/src/infra/approval-handler-bootstrap.ts
@@ -3,8 +3,9 @@ import { resolveChannelApprovalCapability } from "../channels/plugins/approvals.
 import type { ChannelRuntimeSurface } from "../channels/plugins/channel-runtime-surface.types.js";
 import type { ChannelPlugin } from "../channels/plugins/types.plugin.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import type { GatewayNativeApprovalRuntime } from "../gateway/server-instance-runtime.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
+import { withGatewayNativeApprovalRuntime } from "./approval-gateway-runtime-context.js";
+import type { GatewayNativeApprovalRuntime } from "./approval-gateway-runtime.types.js";
 import {
   CHANNEL_APPROVAL_NATIVE_RUNTIME_CONTEXT_CAPABILITY,
   createChannelApprovalHandlerFromCapability,
@@ -88,17 +89,18 @@ export async function startChannelApprovalHandlerBootstrap(params: {
     if (generation !== activeGeneration) {
       return;
     }
-    const handler = await createChannelApprovalHandlerFromCapability({
-      capability,
-      label: `${params.plugin.id}/native-approvals`,
-      clientDisplayName: `${channelLabel} Native Approvals (${params.accountId})`,
-      channel: params.plugin.id,
-      channelLabel,
-      cfg: params.cfg,
-      accountId: params.accountId,
-      context,
-      gatewayRuntime: params.gatewayRuntime,
-    });
+    const handler = await withGatewayNativeApprovalRuntime(params.gatewayRuntime, () =>
+      createChannelApprovalHandlerFromCapability({
+        capability,
+        label: `${params.plugin.id}/native-approvals`,
+        clientDisplayName: `${channelLabel} Native Approvals (${params.accountId})`,
+        channel: params.plugin.id,
+        channelLabel,
+        cfg: params.cfg,
+        accountId: params.accountId,
+        context,
+      }),
+    );
     if (!handler) {
       return;
     }
@@ -109,7 +111,7 @@ export async function startChannelApprovalHandlerBootstrap(params: {
     }
     activeHandler = handler as ApprovalBootstrapHandler;
     try {
-      await handler.start();
+      await withGatewayNativeApprovalRuntime(params.gatewayRuntime, () => handler.start());
     } catch (error) {
       if (activeHandler === handler) {
         activeHandler = null;

--- a/src/infra/approval-handler-runtime.ts
+++ b/src/infra/approval-handler-runtime.ts
@@ -4,7 +4,6 @@ import type {
   ChannelApprovalNativeAdapter,
 } from "../channels/plugins/types.adapters.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import type { GatewayNativeApprovalRuntime } from "../gateway/server-instance-runtime.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import {
   CHANNEL_APPROVAL_NATIVE_RUNTIME_CONTEXT_CAPABILITY,
@@ -313,7 +312,6 @@ type ChannelApprovalHandlerRuntimeSpec<TRequest extends ApprovalRequest> = {
   clientDisplayName: string;
   cfg: OpenClawConfig;
   gatewayUrl?: string;
-  gatewayRuntime?: GatewayNativeApprovalRuntime;
   eventKinds?: readonly ExecApprovalChannelRuntimeEventKind[];
   channel?: string;
   channelLabel?: string;
@@ -417,7 +415,6 @@ export function createChannelApprovalHandler<
     clientDisplayName: adapter.runtime.clientDisplayName,
     cfg: adapter.runtime.cfg,
     gatewayUrl: adapter.runtime.gatewayUrl,
-    gatewayRuntime: adapter.runtime.gatewayRuntime,
     eventKinds: adapter.runtime.eventKinds,
     channel: adapter.runtime.channel,
     channelLabel: adapter.runtime.channelLabel,
@@ -451,7 +448,6 @@ export async function createChannelApprovalHandlerFromCapability(params: {
   cfg: OpenClawConfig;
   accountId?: string | null;
   gatewayUrl?: string;
-  gatewayRuntime?: GatewayNativeApprovalRuntime;
   context?: unknown;
   nowMs?: () => number;
 }): Promise<ChannelApprovalHandler | null> {
@@ -478,7 +474,6 @@ export async function createChannelApprovalHandlerFromCapability(params: {
       cfg: params.cfg,
       accountId: params.accountId,
       gatewayUrl: params.gatewayUrl,
-      gatewayRuntime: params.gatewayRuntime,
       eventKinds: nativeRuntime.eventKinds,
       nativeAdapter: params.capability?.native as ChannelApprovalNativeAdapter | null,
       ...(nativeRuntime.resolveApprovalKind

--- a/src/infra/approval-handler-runtime.ts
+++ b/src/infra/approval-handler-runtime.ts
@@ -4,6 +4,7 @@ import type {
   ChannelApprovalNativeAdapter,
 } from "../channels/plugins/types.adapters.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { GatewayNativeApprovalRuntime } from "../gateway/server-instance-runtime.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import {
   CHANNEL_APPROVAL_NATIVE_RUNTIME_CONTEXT_CAPABILITY,
@@ -312,6 +313,7 @@ type ChannelApprovalHandlerRuntimeSpec<TRequest extends ApprovalRequest> = {
   clientDisplayName: string;
   cfg: OpenClawConfig;
   gatewayUrl?: string;
+  gatewayRuntime?: GatewayNativeApprovalRuntime;
   eventKinds?: readonly ExecApprovalChannelRuntimeEventKind[];
   channel?: string;
   channelLabel?: string;
@@ -415,6 +417,7 @@ export function createChannelApprovalHandler<
     clientDisplayName: adapter.runtime.clientDisplayName,
     cfg: adapter.runtime.cfg,
     gatewayUrl: adapter.runtime.gatewayUrl,
+    gatewayRuntime: adapter.runtime.gatewayRuntime,
     eventKinds: adapter.runtime.eventKinds,
     channel: adapter.runtime.channel,
     channelLabel: adapter.runtime.channelLabel,
@@ -448,6 +451,7 @@ export async function createChannelApprovalHandlerFromCapability(params: {
   cfg: OpenClawConfig;
   accountId?: string | null;
   gatewayUrl?: string;
+  gatewayRuntime?: GatewayNativeApprovalRuntime;
   context?: unknown;
   nowMs?: () => number;
 }): Promise<ChannelApprovalHandler | null> {
@@ -474,6 +478,7 @@ export async function createChannelApprovalHandlerFromCapability(params: {
       cfg: params.cfg,
       accountId: params.accountId,
       gatewayUrl: params.gatewayUrl,
+      gatewayRuntime: params.gatewayRuntime,
       eventKinds: nativeRuntime.eventKinds,
       nativeAdapter: params.capability?.native as ChannelApprovalNativeAdapter | null,
       ...(nativeRuntime.resolveApprovalKind

--- a/src/infra/approval-native-route-coordinator.test.ts
+++ b/src/infra/approval-native-route-coordinator.test.ts
@@ -1,6 +1,9 @@
 // Covers native approval route reporting behavior.
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { createApprovalNativeRouteReporter as createApprovalNativeRouteReporterRaw } from "./approval-native-route-coordinator.js";
+import {
+  createApprovalNativeRouteCoordinator,
+  createApprovalNativeRouteReporter as createApprovalNativeRouteReporterRaw,
+} from "./approval-native-route-coordinator.js";
 
 const approvalRouteReporters: Array<ReturnType<typeof createApprovalNativeRouteReporterRaw>> = [];
 
@@ -25,6 +28,45 @@ function createGatewayRequestMock() {
 }
 
 describe("createApprovalNativeRouteReporter", () => {
+  it("isolates active routes and cleanup between Gateway instances", () => {
+    const first = createApprovalNativeRouteCoordinator();
+    const second = createApprovalNativeRouteCoordinator();
+    const firstReporter = first.createReporter({
+      handledKinds: new Set(["exec"]),
+      channel: "telegram",
+      accountId: "default",
+      requestGateway: createGatewayRequestMock(),
+    });
+    const secondReporter = second.createReporter({
+      handledKinds: new Set(["exec"]),
+      channel: "discord",
+      accountId: "default",
+      requestGateway: createGatewayRequestMock(),
+    });
+    firstReporter.start();
+    secondReporter.start();
+
+    expect(
+      first.hasActiveRuntime({
+        approvalKind: "exec",
+        channel: "telegram",
+        accountId: "default",
+      }),
+    ).toBe(true);
+    expect(
+      second.hasActiveRuntime({
+        approvalKind: "exec",
+        channel: "telegram",
+        accountId: "default",
+      }),
+    ).toBe(false);
+
+    first.close();
+    expect(first.hasActiveRuntime({ approvalKind: "exec", channel: "telegram" })).toBe(false);
+    expect(second.hasActiveRuntime({ approvalKind: "exec", channel: "discord" })).toBe(true);
+    second.close();
+  });
+
   it("caps route-notice cleanup timers to five minutes", () => {
     vi.useFakeTimers();
     try {

--- a/src/infra/approval-native-route-coordinator.test.ts
+++ b/src/infra/approval-native-route-coordinator.test.ts
@@ -67,6 +67,48 @@ describe("createApprovalNativeRouteReporter", () => {
     second.close();
   });
 
+  it("cannot revive routes or notices after the owning Gateway closes", async () => {
+    vi.useFakeTimers();
+    const coordinator = createApprovalNativeRouteCoordinator();
+    const requestGateway = createGatewayRequestMock();
+    const reporter = coordinator.createReporter({
+      handledKinds: new Set(["exec"]),
+      channel: "telegram",
+      accountId: "default",
+      requestGateway,
+    });
+    const request = {
+      id: "approval-after-close",
+      request: {
+        command: "echo hi",
+        turnSourceChannel: "telegram",
+        turnSourceTo: "chat:123",
+      },
+      createdAtMs: 0,
+      expiresAtMs: Date.now() + 60_000,
+    } as const;
+
+    reporter.start();
+    coordinator.close();
+    reporter.start();
+    reporter.observeRequest({ approvalKind: "exec", request });
+    await reporter.reportSkipped({ approvalKind: "exec", request });
+
+    const lateReporter = coordinator.createReporter({
+      handledKinds: new Set(["exec"]),
+      channel: "telegram",
+      accountId: "default",
+      requestGateway,
+    });
+    lateReporter.start();
+    lateReporter.observeRequest({ approvalKind: "exec", request });
+    await lateReporter.reportSkipped({ approvalKind: "exec", request });
+
+    expect(coordinator.hasActiveRuntime({ approvalKind: "exec", channel: "telegram" })).toBe(false);
+    expect(requestGateway).not.toHaveBeenCalled();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
   it("caps route-notice cleanup timers to five minutes", () => {
     vi.useFakeTimers();
     try {

--- a/src/infra/approval-native-route-coordinator.ts
+++ b/src/infra/approval-native-route-coordinator.ts
@@ -61,37 +61,55 @@ type RouteNoticeTarget = {
   threadId?: string | number | null;
 };
 
-const activeApprovalRouteRuntimes = new Map<string, ApprovalRouteRuntimeRecord>();
-const pendingApprovalRouteNotices = new Map<string, PendingApprovalRouteNotice>();
-let approvalRouteRuntimeSeq = 0;
+type ApprovalNativeRouteCoordinatorState = {
+  activeRuntimes: Map<string, ApprovalRouteRuntimeRecord>;
+  pendingNotices: Map<string, PendingApprovalRouteNotice>;
+  runtimeSeq: number;
+};
+
+function createApprovalNativeRouteCoordinatorState(): ApprovalNativeRouteCoordinatorState {
+  return {
+    activeRuntimes: new Map(),
+    pendingNotices: new Map(),
+    runtimeSeq: 0,
+  };
+}
+
+const defaultCoordinatorState = createApprovalNativeRouteCoordinatorState();
 const MAX_APPROVAL_ROUTE_NOTICE_TTL_MS = 5 * 60_000;
 
 function normalizeChannel(value?: string | null): string {
   return normalizeLowercaseStringOrEmpty(value);
 }
 
-function clearPendingApprovalRouteNotice(approvalId: string): void {
-  const entry = pendingApprovalRouteNotices.get(approvalId);
+function clearPendingApprovalRouteNotice(
+  state: ApprovalNativeRouteCoordinatorState,
+  approvalId: string,
+): void {
+  const entry = state.pendingNotices.get(approvalId);
   if (!entry) {
     return;
   }
-  pendingApprovalRouteNotices.delete(approvalId);
+  state.pendingNotices.delete(approvalId);
   if (entry.cleanupTimeout) {
     clearTimeout(entry.cleanupTimeout);
   }
 }
 
-function createPendingApprovalRouteNotice(params: {
-  request: ApprovalRequest;
-  approvalKind: ChannelApprovalKind;
-  expectedRuntimeIds?: Iterable<string>;
-}): PendingApprovalRouteNotice {
+function createPendingApprovalRouteNotice(
+  state: ApprovalNativeRouteCoordinatorState,
+  params: {
+    request: ApprovalRequest;
+    approvalKind: ChannelApprovalKind;
+    expectedRuntimeIds?: Iterable<string>;
+  },
+): PendingApprovalRouteNotice {
   const timeoutMs = Math.min(
     Math.max(0, params.request.expiresAtMs - Date.now()),
     MAX_APPROVAL_ROUTE_NOTICE_TTL_MS,
   );
   const cleanupTimeout = setTimeout(() => {
-    clearPendingApprovalRouteNotice(params.request.id);
+    clearPendingApprovalRouteNotice(state, params.request.id);
   }, timeoutMs);
   cleanupTimeout.unref?.();
   return {
@@ -168,6 +186,7 @@ function readAllowedDecisionStrings(request: ApprovalRequest): string[] | undefi
 }
 
 function resolveApprovalRouteNotice(params: {
+  state: ApprovalNativeRouteCoordinatorState;
   approvalKind: ChannelApprovalKind;
   request: ApprovalRequest;
   reports: readonly ApprovalRouteReport[];
@@ -197,7 +216,7 @@ function resolveApprovalRouteNotice(params: {
   if (!deliveredAnyTarget && params.reports.some(hasPlannedNativeTargets)) {
     return {
       requestGateway:
-        params.reports.find((report) => activeApprovalRouteRuntimes.has(report.runtimeId))
+        params.reports.find((report) => params.state.activeRuntimes.has(report.runtimeId))
           ?.requestGateway ?? expectDefined(params.reports[0], "reports entry at 0").requestGateway,
       target,
       text: resolveApprovalDeliveryFailedNoticeText({
@@ -255,7 +274,7 @@ function resolveApprovalRouteNotice(params: {
   }
 
   const requestGateway =
-    params.reports.find((report) => activeApprovalRouteRuntimes.has(report.runtimeId))
+    params.reports.find((report) => params.state.activeRuntimes.has(report.runtimeId))
       ?.requestGateway ?? params.reports[0]?.requestGateway;
   if (!requestGateway) {
     return null;
@@ -274,9 +293,20 @@ export function hasActiveApprovalNativeRouteRuntime(params: {
   channel?: string | null;
   accountId?: string | null;
 }): boolean {
+  return hasActiveApprovalNativeRouteRuntimeForState(defaultCoordinatorState, params);
+}
+
+function hasActiveApprovalNativeRouteRuntimeForState(
+  state: ApprovalNativeRouteCoordinatorState,
+  params: {
+    approvalKind: ChannelApprovalKind;
+    channel?: string | null;
+    accountId?: string | null;
+  },
+): boolean {
   const channel = normalizeChannel(params.channel);
   const accountId = normalizeOptionalString(params.accountId);
-  return Array.from(activeApprovalRouteRuntimes.values()).some((runtime) => {
+  return Array.from(state.activeRuntimes.values()).some((runtime) => {
     if (!runtime.handledKinds.has(params.approvalKind)) {
       return false;
     }
@@ -290,8 +320,11 @@ export function hasActiveApprovalNativeRouteRuntime(params: {
   });
 }
 
-async function maybeFinalizeApprovalRouteNotice(approvalId: string): Promise<void> {
-  const entry = pendingApprovalRouteNotices.get(approvalId);
+async function maybeFinalizeApprovalRouteNotice(
+  state: ApprovalNativeRouteCoordinatorState,
+  approvalId: string,
+): Promise<void> {
+  const entry = state.pendingNotices.get(approvalId);
   if (!entry || entry.finalized) {
     return;
   }
@@ -305,11 +338,12 @@ async function maybeFinalizeApprovalRouteNotice(approvalId: string): Promise<voi
   // Only runtimes observed with the request can block finalization; later runtimes must not delay it.
   const reports = Array.from(entry.reports.values());
   const notice = resolveApprovalRouteNotice({
+    state,
     approvalKind: entry.approvalKind,
     request: entry.request,
     reports,
   });
-  clearPendingApprovalRouteNotice(approvalId);
+  clearPendingApprovalRouteNotice(state, approvalId);
   if (!notice) {
     return;
   }
@@ -336,7 +370,20 @@ export function createApprovalNativeRouteReporter(params: {
   accountId?: string | null;
   requestGateway: GatewayRequestFn;
 }) {
-  const runtimeId = `native-approval-route:${++approvalRouteRuntimeSeq}`;
+  return createApprovalNativeRouteReporterForState(defaultCoordinatorState, params);
+}
+
+function createApprovalNativeRouteReporterForState(
+  state: ApprovalNativeRouteCoordinatorState,
+  params: {
+    handledKinds: ReadonlySet<ChannelApprovalKind>;
+    channel?: string;
+    channelLabel?: string;
+    accountId?: string | null;
+    requestGateway: GatewayRequestFn;
+  },
+) {
+  const runtimeId = `native-approval-route:${++state.runtimeSeq}`;
   let registered = false;
 
   const report = async (payload: {
@@ -349,8 +396,8 @@ export function createApprovalNativeRouteReporter(params: {
       return;
     }
     const entry =
-      pendingApprovalRouteNotices.get(payload.request.id) ??
-      createPendingApprovalRouteNotice({
+      state.pendingNotices.get(payload.request.id) ??
+      createPendingApprovalRouteNotice(state, {
         request: payload.request,
         approvalKind: payload.approvalKind,
         expectedRuntimeIds: [runtimeId],
@@ -366,8 +413,8 @@ export function createApprovalNativeRouteReporter(params: {
       deliveredTargets: payload.deliveredTargets,
       requestGateway: params.requestGateway,
     });
-    pendingApprovalRouteNotices.set(payload.request.id, entry);
-    await maybeFinalizeApprovalRouteNotice(payload.request.id);
+    state.pendingNotices.set(payload.request.id, entry);
+    await maybeFinalizeApprovalRouteNotice(state, payload.request.id);
   };
 
   return {
@@ -376,22 +423,22 @@ export function createApprovalNativeRouteReporter(params: {
         return;
       }
       const entry =
-        pendingApprovalRouteNotices.get(payload.request.id) ??
-        createPendingApprovalRouteNotice({
+        state.pendingNotices.get(payload.request.id) ??
+        createPendingApprovalRouteNotice(state, {
           request: payload.request,
           approvalKind: payload.approvalKind,
-          expectedRuntimeIds: Array.from(activeApprovalRouteRuntimes.values())
+          expectedRuntimeIds: Array.from(state.activeRuntimes.values())
             .filter((runtime) => runtime.handledKinds.has(payload.approvalKind))
             .map((runtime) => runtime.runtimeId),
         });
       entry.expectedRuntimeIds.add(runtimeId);
-      pendingApprovalRouteNotices.set(payload.request.id, entry);
+      state.pendingNotices.set(payload.request.id, entry);
     },
     start(): void {
       if (registered) {
         return;
       }
-      activeApprovalRouteRuntimes.set(runtimeId, {
+      state.activeRuntimes.set(runtimeId, {
         runtimeId,
         handledKinds: params.handledKinds,
         channel: params.channel,
@@ -429,15 +476,36 @@ export function createApprovalNativeRouteReporter(params: {
         return;
       }
       registered = false;
-      activeApprovalRouteRuntimes.delete(runtimeId);
-      for (const entry of pendingApprovalRouteNotices.values()) {
+      state.activeRuntimes.delete(runtimeId);
+      for (const entry of state.pendingNotices.values()) {
         entry.expectedRuntimeIds.delete(runtimeId);
         if (entry.expectedRuntimeIds.size === 0) {
-          clearPendingApprovalRouteNotice(entry.request.id);
+          clearPendingApprovalRouteNotice(state, entry.request.id);
           continue;
         }
-        await maybeFinalizeApprovalRouteNotice(entry.request.id);
+        await maybeFinalizeApprovalRouteNotice(state, entry.request.id);
       }
+    },
+  };
+}
+
+export type ApprovalNativeRouteCoordinator = {
+  createReporter: typeof createApprovalNativeRouteReporter;
+  hasActiveRuntime: typeof hasActiveApprovalNativeRouteRuntime;
+  close: () => void;
+};
+
+/** Creates an instance-local route coordinator so Gateway runtimes cannot share account state. */
+export function createApprovalNativeRouteCoordinator(): ApprovalNativeRouteCoordinator {
+  const state = createApprovalNativeRouteCoordinatorState();
+  return {
+    createReporter: (params) => createApprovalNativeRouteReporterForState(state, params),
+    hasActiveRuntime: (params) => hasActiveApprovalNativeRouteRuntimeForState(state, params),
+    close: () => {
+      for (const approvalId of Array.from(state.pendingNotices.keys())) {
+        clearPendingApprovalRouteNotice(state, approvalId);
+      }
+      state.activeRuntimes.clear();
     },
   };
 }

--- a/src/infra/approval-native-route-coordinator.ts
+++ b/src/infra/approval-native-route-coordinator.ts
@@ -65,6 +65,7 @@ type ApprovalNativeRouteCoordinatorState = {
   activeRuntimes: Map<string, ApprovalRouteRuntimeRecord>;
   pendingNotices: Map<string, PendingApprovalRouteNotice>;
   runtimeSeq: number;
+  closed: boolean;
 };
 
 function createApprovalNativeRouteCoordinatorState(): ApprovalNativeRouteCoordinatorState {
@@ -72,6 +73,7 @@ function createApprovalNativeRouteCoordinatorState(): ApprovalNativeRouteCoordin
     activeRuntimes: new Map(),
     pendingNotices: new Map(),
     runtimeSeq: 0,
+    closed: false,
   };
 }
 
@@ -392,7 +394,7 @@ function createApprovalNativeRouteReporterForState(
     deliveryPlan: ChannelApprovalNativeDeliveryPlan;
     deliveredTargets: readonly ChannelApprovalNativePlannedTarget[];
   }): Promise<void> => {
-    if (!registered || !params.handledKinds.has(payload.approvalKind)) {
+    if (state.closed || !registered || !params.handledKinds.has(payload.approvalKind)) {
       return;
     }
     const entry =
@@ -419,7 +421,7 @@ function createApprovalNativeRouteReporterForState(
 
   return {
     observeRequest(payload: { approvalKind: ChannelApprovalKind; request: ApprovalRequest }): void {
-      if (!registered || !params.handledKinds.has(payload.approvalKind)) {
+      if (state.closed || !registered || !params.handledKinds.has(payload.approvalKind)) {
         return;
       }
       const entry =
@@ -435,7 +437,7 @@ function createApprovalNativeRouteReporterForState(
       state.pendingNotices.set(payload.request.id, entry);
     },
     start(): void {
-      if (registered) {
+      if (state.closed || registered) {
         return;
       }
       state.activeRuntimes.set(runtimeId, {
@@ -502,6 +504,9 @@ export function createApprovalNativeRouteCoordinator(): ApprovalNativeRouteCoord
     createReporter: (params) => createApprovalNativeRouteReporterForState(state, params),
     hasActiveRuntime: (params) => hasActiveApprovalNativeRouteRuntimeForState(state, params),
     close: () => {
+      // Closing retires this Gateway-owned coordinator permanently. Delayed channel
+      // startup must not repopulate routes belonging to the retired instance.
+      state.closed = true;
       for (const approvalId of Array.from(state.pendingNotices.keys())) {
         clearPendingApprovalRouteNotice(state, approvalId);
       }

--- a/src/infra/approval-native-runtime.ts
+++ b/src/infra/approval-native-runtime.ts
@@ -2,6 +2,7 @@
 import type { ChannelApprovalNativeAdapter } from "../channels/plugins/approval-native.types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../utils/message-channel.js";
+import { getGatewayNativeApprovalRuntime } from "./approval-gateway-runtime-context.js";
 import {
   resolveChannelNativeApprovalDeliveryPlan,
   type ChannelApprovalNativePlannedTarget,
@@ -194,19 +195,20 @@ export function createChannelNativeApprovalRuntime<
   const handledEventKinds = new Set<ExecApprovalChannelRuntimeEventKind>(
     adapter.eventKinds ?? ["exec"],
   );
+  const gatewayRuntime = getGatewayNativeApprovalRuntime();
   const createRouteReporter =
-    adapter.gatewayRuntime?.routeCoordinator.createReporter ?? createApprovalNativeRouteReporter;
+    gatewayRuntime?.routeCoordinator.createReporter ?? createApprovalNativeRouteReporter;
   const routeReporter = createRouteReporter({
     handledKinds: handledEventKinds,
     channel: adapter.channel,
     channelLabel: adapter.channelLabel,
     accountId: adapter.accountId,
     requestGateway: async <T>(method: string, params: Record<string, unknown>): Promise<T> => {
-      if (adapter.gatewayRuntime) {
+      if (gatewayRuntime) {
         if (method !== "send") {
           throw new Error(`native approval route cannot dispatch ${method}`);
         }
-        return await adapter.gatewayRuntime.requestRoute<T>(method, params);
+        return await gatewayRuntime.requestRoute<T>(method, params);
       }
       const { callGatewayLeastPrivilege } = await import("../gateway/call.js");
       return await callGatewayLeastPrivilege<T>({
@@ -225,7 +227,6 @@ export function createChannelNativeApprovalRuntime<
     clientDisplayName: adapter.clientDisplayName,
     cfg: adapter.cfg,
     gatewayUrl: adapter.gatewayUrl,
-    gatewayRuntime: adapter.gatewayRuntime,
     eventKinds: adapter.eventKinds,
     isConfigured: adapter.isConfigured,
     shouldHandle: (request) => {

--- a/src/infra/approval-native-runtime.ts
+++ b/src/infra/approval-native-runtime.ts
@@ -194,12 +194,20 @@ export function createChannelNativeApprovalRuntime<
   const handledEventKinds = new Set<ExecApprovalChannelRuntimeEventKind>(
     adapter.eventKinds ?? ["exec"],
   );
-  const routeReporter = createApprovalNativeRouteReporter({
+  const createRouteReporter =
+    adapter.gatewayRuntime?.routeCoordinator.createReporter ?? createApprovalNativeRouteReporter;
+  const routeReporter = createRouteReporter({
     handledKinds: handledEventKinds,
     channel: adapter.channel,
     channelLabel: adapter.channelLabel,
     accountId: adapter.accountId,
     requestGateway: async <T>(method: string, params: Record<string, unknown>): Promise<T> => {
+      if (adapter.gatewayRuntime) {
+        if (method !== "send") {
+          throw new Error(`native approval route cannot dispatch ${method}`);
+        }
+        return await adapter.gatewayRuntime.requestRoute<T>(method, params);
+      }
       const { callGatewayLeastPrivilege } = await import("../gateway/call.js");
       return await callGatewayLeastPrivilege<T>({
         config: adapter.cfg,
@@ -217,6 +225,7 @@ export function createChannelNativeApprovalRuntime<
     clientDisplayName: adapter.clientDisplayName,
     cfg: adapter.cfg,
     gatewayUrl: adapter.gatewayUrl,
+    gatewayRuntime: adapter.gatewayRuntime,
     eventKinds: adapter.eventKinds,
     isConfigured: adapter.isConfigured,
     shouldHandle: (request) => {

--- a/src/infra/exec-approval-channel-runtime.test.ts
+++ b/src/infra/exec-approval-channel-runtime.test.ts
@@ -1,6 +1,7 @@
 // Covers gateway-backed approval channel runtime behavior.
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { GatewayClient } from "../gateway/client.js";
+import type { GatewayNativeApprovalRuntime } from "../gateway/server-instance-runtime.js";
 import { createDeferred } from "../test-utils/deferred.js";
 import type { ExecApprovalRequest } from "./exec-approvals.js";
 import type { PluginApprovalRequest, PluginApprovalResolved } from "./plugin-approvals.js";
@@ -316,6 +317,56 @@ describe("createExecApprovalChannelRuntime", () => {
       decision: "deny",
     });
     expect(mockGatewayClientRequests).toHaveBeenCalledWith("exec.approval.list", {});
+  });
+
+  it("subscribes before replay and dedupes live events that overlap the pending list", async () => {
+    const replay = createDeferred<ExecApprovalRequest[]>();
+    let subscriber:
+      | {
+          onRequested: (request: ExecApprovalRequest) => void;
+          onResolved: (resolved: never) => void;
+          shouldHandle: (request: ExecApprovalRequest) => boolean;
+        }
+      | undefined;
+    const unsubscribe = vi.fn();
+    const request = vi.fn(async (method: string) => {
+      expect(subscriber, "internal subscriber before replay").toBeDefined();
+      return method === "exec.approval.list" ? await replay.promise : { ok: true };
+    });
+    const shouldHandle = vi.fn(() => true);
+    const deliverRequested = vi.fn(async (approval: ExecApprovalRequest) => [{ id: approval.id }]);
+    const runtime = createExecApprovalChannelRuntime({
+      label: "test/exec-approvals",
+      clientDisplayName: "Test Exec Approvals",
+      cfg: {} as never,
+      gatewayRuntime: {
+        request: request as GatewayNativeApprovalRuntime["request"],
+        requestRoute: vi.fn(),
+        routeCoordinator: {} as never,
+        subscribe: (nextSubscriber) => {
+          subscriber = nextSubscriber as typeof subscriber;
+          return unsubscribe;
+        },
+      },
+      isConfigured: () => true,
+      shouldHandle,
+      deliverRequested,
+      finalizeResolved: async () => undefined,
+    });
+
+    await runtime.start();
+    const approval = createExecReplayRequest("overlap");
+    if (subscriber?.shouldHandle(approval)) {
+      subscriber.onRequested(approval);
+    }
+    replay.resolve([approval]);
+    await vi.waitFor(() => expect(deliverRequested).toHaveBeenCalledTimes(1));
+    expect(shouldHandle).toHaveBeenCalledTimes(1);
+
+    expect(mockCreateOperatorApprovalsGatewayClient).not.toHaveBeenCalled();
+    await runtime.stop();
+    await runtime.stop();
+    expect(unsubscribe).toHaveBeenCalledOnce();
   });
 
   it("rejects write RPCs before they reach the approvals-only gateway client", async () => {

--- a/src/infra/exec-approval-channel-runtime.test.ts
+++ b/src/infra/exec-approval-channel-runtime.test.ts
@@ -1,8 +1,9 @@
 // Covers gateway-backed approval channel runtime behavior.
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { GatewayClient } from "../gateway/client.js";
-import type { GatewayNativeApprovalRuntime } from "../gateway/server-instance-runtime.js";
 import { createDeferred } from "../test-utils/deferred.js";
+import { withGatewayNativeApprovalRuntime } from "./approval-gateway-runtime-context.js";
+import type { GatewayNativeApprovalRuntime } from "./approval-gateway-runtime.types.js";
 import type { ExecApprovalRequest } from "./exec-approvals.js";
 import type { PluginApprovalRequest, PluginApprovalResolved } from "./plugin-approvals.js";
 
@@ -335,24 +336,26 @@ describe("createExecApprovalChannelRuntime", () => {
     });
     const shouldHandle = vi.fn(() => true);
     const deliverRequested = vi.fn(async (approval: ExecApprovalRequest) => [{ id: approval.id }]);
-    const runtime = createExecApprovalChannelRuntime({
-      label: "test/exec-approvals",
-      clientDisplayName: "Test Exec Approvals",
-      cfg: {} as never,
-      gatewayRuntime: {
-        request: request as GatewayNativeApprovalRuntime["request"],
-        requestRoute: vi.fn(),
-        routeCoordinator: {} as never,
-        subscribe: (nextSubscriber) => {
-          subscriber = nextSubscriber as typeof subscriber;
-          return unsubscribe;
-        },
+    const gatewayRuntime: GatewayNativeApprovalRuntime = {
+      request: request as GatewayNativeApprovalRuntime["request"],
+      requestRoute: vi.fn(),
+      routeCoordinator: {} as never,
+      subscribe: (nextSubscriber) => {
+        subscriber = nextSubscriber as typeof subscriber;
+        return unsubscribe;
       },
-      isConfigured: () => true,
-      shouldHandle,
-      deliverRequested,
-      finalizeResolved: async () => undefined,
-    });
+    };
+    const runtime = withGatewayNativeApprovalRuntime(gatewayRuntime, () =>
+      createExecApprovalChannelRuntime({
+        label: "test/exec-approvals",
+        clientDisplayName: "Test Exec Approvals",
+        cfg: {} as never,
+        isConfigured: () => true,
+        shouldHandle,
+        deliverRequested,
+        finalizeResolved: async () => undefined,
+      }),
+    );
 
     await runtime.start();
     const approval = createExecReplayRequest("overlap");
@@ -362,6 +365,13 @@ describe("createExecApprovalChannelRuntime", () => {
     replay.resolve([approval]);
     await vi.waitFor(() => expect(deliverRequested).toHaveBeenCalledTimes(1));
     expect(shouldHandle).toHaveBeenCalledTimes(1);
+
+    await runtime.request("exec.approval.list", {});
+    expect(request).toHaveBeenLastCalledWith(
+      "exec.approval.list",
+      {},
+      { clientDisplayName: "Test Exec Approvals" },
+    );
 
     expect(mockCreateOperatorApprovalsGatewayClient).not.toHaveBeenCalled();
     await runtime.stop();

--- a/src/infra/exec-approval-channel-runtime.ts
+++ b/src/infra/exec-approval-channel-runtime.ts
@@ -5,6 +5,7 @@ import { startGatewayClientWhenEventLoopReady } from "../gateway/client-start-re
 import type { GatewayClient, GatewayReconnectPausedInfo } from "../gateway/client.js";
 import { isApprovalMethod } from "../gateway/method-scopes.js";
 import { createOperatorApprovalsGatewayClient } from "../gateway/operator-approvals-client.js";
+import type { GatewayNativeApprovalRuntime } from "../gateway/server-instance-runtime.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { formatErrorMessage } from "./errors.js";
 import type {
@@ -90,6 +91,8 @@ export function createExecApprovalChannelRuntime<
   const eventKinds = new Set<ExecApprovalChannelRuntimeEventKind>(adapter.eventKinds ?? ["exec"]);
   const pending = new Map<string, PendingApprovalEntry<TPending, TRequest, TResolved>>();
   let gatewayClient: GatewayClient | null = null;
+  let gatewayRuntime: GatewayNativeApprovalRuntime | null = null;
+  let unsubscribeGatewayRuntime: (() => void) | null = null;
   let started = false;
   let shouldRun = false;
   let startPromise: Promise<void> | null = null;
@@ -141,17 +144,16 @@ export function createExecApprovalChannelRuntime<
 
   const handleRequested = async (
     request: TRequest,
-    opts?: { ignoreIfInactive?: boolean },
+    opts?: { ignoreIfInactive?: boolean; alreadyAccepted?: boolean },
   ): Promise<void> => {
     if (opts?.ignoreIfInactive && !shouldKeepRunning()) {
       return;
     }
-    if (!adapter.shouldHandle(request)) {
-      return;
-    }
-
     if (pending.has(request.id)) {
       log.debug(`ignored duplicate request ${request.id}`);
+      return;
+    }
+    if (opts?.alreadyAccepted !== true && !adapter.shouldHandle(request)) {
       return;
     }
 
@@ -248,18 +250,21 @@ export function createExecApprovalChannelRuntime<
     }
   };
 
-  const replayPendingApprovals = async (client: GatewayClient): Promise<void> => {
+  const replayPendingApprovals = async (
+    client: Pick<GatewayClient, "request">,
+    externalClient?: GatewayClient,
+  ): Promise<void> => {
     try {
       for (const method of resolveApprovalReplayMethods(eventKinds)) {
-        if (stopClientIfInactive(client)) {
+        if (externalClient && stopClientIfInactive(externalClient)) {
           return;
         }
         const pendingRequests = await client.request<Array<TRequest>>(method, {});
-        if (stopClientIfInactive(client)) {
+        if (externalClient && stopClientIfInactive(externalClient)) {
           return;
         }
         for (const request of pendingRequests) {
-          if (stopClientIfInactive(client)) {
+          if (externalClient && stopClientIfInactive(externalClient)) {
             return;
           }
           await handleRequested(request, { ignoreIfInactive: true });
@@ -273,8 +278,11 @@ export function createExecApprovalChannelRuntime<
     }
   };
 
-  const startPendingApprovalReplay = (client: GatewayClient): void => {
-    const promise = replayPendingApprovals(client)
+  const startPendingApprovalReplay = (
+    client: Pick<GatewayClient, "request">,
+    externalClient?: GatewayClient,
+  ): void => {
+    const promise = replayPendingApprovals(client, externalClient)
       .catch((err: unknown) => {
         const message = formatErrorMessage(err);
         log.error(`error replaying pending approvals: ${message}`);
@@ -309,6 +317,38 @@ export function createExecApprovalChannelRuntime<
       startPromise = (async () => {
         if (!adapter.isConfigured()) {
           log.debug("disabled");
+          return;
+        }
+
+        if (adapter.gatewayRuntime) {
+          await adapter.beforeGatewayClientStart?.();
+          gatewayRuntime = adapter.gatewayRuntime;
+          // Subscribe before replay so a request created during the list calls is not lost.
+          unsubscribeGatewayRuntime = gatewayRuntime.subscribe({
+            eventKinds,
+            shouldHandle: (request) =>
+              shouldKeepRunning() && adapter.shouldHandle(request as TRequest),
+            onRequested: (request) => {
+              spawn(
+                "error handling approval request",
+                handleRequested(request as TRequest, {
+                  ignoreIfInactive: true,
+                  alreadyAccepted: true,
+                }),
+              );
+            },
+            onResolved: (resolved) => {
+              spawn("error handling approval resolved", handleResolved(resolved as TResolved));
+            },
+          });
+          if (!shouldRun) {
+            unsubscribeGatewayRuntime();
+            unsubscribeGatewayRuntime = null;
+            gatewayRuntime = null;
+            return;
+          }
+          started = true;
+          startPendingApprovalReplay({ request: gatewayRuntime.request });
           return;
         }
 
@@ -383,7 +423,7 @@ export function createExecApprovalChannelRuntime<
             return;
           }
           started = true;
-          startPendingApprovalReplay(client);
+          startPendingApprovalReplay(client, client);
         } catch (error) {
           gatewayClient = null;
           started = false;
@@ -404,6 +444,9 @@ export function createExecApprovalChannelRuntime<
       }
       const wasActive = started || gatewayClient !== null || replayPromise !== null;
       started = false;
+      unsubscribeGatewayRuntime?.();
+      unsubscribeGatewayRuntime = null;
+      gatewayRuntime = null;
       gatewayClient?.stop();
       gatewayClient = null;
       await waitForPendingApprovalReplay();
@@ -430,6 +473,9 @@ export function createExecApprovalChannelRuntime<
         throw new Error(
           `${adapter.label}: operator approvals runtime cannot dispatch ${method}; use a write-capable gateway client`,
         );
+      }
+      if (gatewayRuntime) {
+        return await gatewayRuntime.request<T>(method, params);
       }
       if (!gatewayClient) {
         throw new Error(`${adapter.label}: gateway client not connected`);

--- a/src/infra/exec-approval-channel-runtime.ts
+++ b/src/infra/exec-approval-channel-runtime.ts
@@ -5,8 +5,8 @@ import { startGatewayClientWhenEventLoopReady } from "../gateway/client-start-re
 import type { GatewayClient, GatewayReconnectPausedInfo } from "../gateway/client.js";
 import { isApprovalMethod } from "../gateway/method-scopes.js";
 import { createOperatorApprovalsGatewayClient } from "../gateway/operator-approvals-client.js";
-import type { GatewayNativeApprovalRuntime } from "../gateway/server-instance-runtime.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
+import { getGatewayNativeApprovalRuntime } from "./approval-gateway-runtime-context.js";
 import { formatErrorMessage } from "./errors.js";
 import type {
   ExecApprovalChannelRuntime,
@@ -23,6 +23,10 @@ export type {
 
 type ApprovalRequestEvent = ExecApprovalRequest | PluginApprovalRequest;
 type ApprovalResolvedEvent = ExecApprovalResolved | PluginApprovalResolved;
+
+type ApprovalReplayClient = {
+  request: <T = unknown>(method: string, params: Record<string, unknown>) => Promise<T>;
+};
 
 /** Error raised when the gateway pauses approval reconnects after a terminal startup failure. */
 export class ExecApprovalChannelRuntimeTerminalStartError extends Error {
@@ -89,9 +93,10 @@ export function createExecApprovalChannelRuntime<
   const log = createSubsystemLogger(adapter.label);
   const nowMs = adapter.nowMs ?? Date.now;
   const eventKinds = new Set<ExecApprovalChannelRuntimeEventKind>(adapter.eventKinds ?? ["exec"]);
+  const configuredGatewayRuntime = getGatewayNativeApprovalRuntime();
   const pending = new Map<string, PendingApprovalEntry<TPending, TRequest, TResolved>>();
   let gatewayClient: GatewayClient | null = null;
-  let gatewayRuntime: GatewayNativeApprovalRuntime | null = null;
+  let gatewayRuntime: typeof configuredGatewayRuntime;
   let unsubscribeGatewayRuntime: (() => void) | null = null;
   let started = false;
   let shouldRun = false;
@@ -251,7 +256,7 @@ export function createExecApprovalChannelRuntime<
   };
 
   const replayPendingApprovals = async (
-    client: Pick<GatewayClient, "request">,
+    client: ApprovalReplayClient,
     externalClient?: GatewayClient,
   ): Promise<void> => {
     try {
@@ -279,7 +284,7 @@ export function createExecApprovalChannelRuntime<
   };
 
   const startPendingApprovalReplay = (
-    client: Pick<GatewayClient, "request">,
+    client: ApprovalReplayClient,
     externalClient?: GatewayClient,
   ): void => {
     const promise = replayPendingApprovals(client, externalClient)
@@ -320,9 +325,9 @@ export function createExecApprovalChannelRuntime<
           return;
         }
 
-        if (adapter.gatewayRuntime) {
+        if (configuredGatewayRuntime) {
           await adapter.beforeGatewayClientStart?.();
-          gatewayRuntime = adapter.gatewayRuntime;
+          gatewayRuntime = configuredGatewayRuntime;
           // Subscribe before replay so a request created during the list calls is not lost.
           unsubscribeGatewayRuntime = gatewayRuntime.subscribe({
             eventKinds,
@@ -344,7 +349,7 @@ export function createExecApprovalChannelRuntime<
           if (!shouldRun) {
             unsubscribeGatewayRuntime();
             unsubscribeGatewayRuntime = null;
-            gatewayRuntime = null;
+            gatewayRuntime = undefined;
             return;
           }
           started = true;
@@ -446,7 +451,7 @@ export function createExecApprovalChannelRuntime<
       started = false;
       unsubscribeGatewayRuntime?.();
       unsubscribeGatewayRuntime = null;
-      gatewayRuntime = null;
+      gatewayRuntime = undefined;
       gatewayClient?.stop();
       gatewayClient = null;
       await waitForPendingApprovalReplay();
@@ -475,7 +480,9 @@ export function createExecApprovalChannelRuntime<
         );
       }
       if (gatewayRuntime) {
-        return await gatewayRuntime.request<T>(method, params);
+        return await gatewayRuntime.request<T>(method, params, {
+          clientDisplayName: adapter.clientDisplayName,
+        });
       }
       if (!gatewayClient) {
         throw new Error(`${adapter.label}: gateway client not connected`);

--- a/src/infra/exec-approval-channel-runtime.ts
+++ b/src/infra/exec-approval-channel-runtime.ts
@@ -7,6 +7,10 @@ import { isApprovalMethod } from "../gateway/method-scopes.js";
 import { createOperatorApprovalsGatewayClient } from "../gateway/operator-approvals-client.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { getGatewayNativeApprovalRuntime } from "./approval-gateway-runtime-context.js";
+import {
+  isGatewayNativeApprovalMethod,
+  type GatewayNativeApprovalMethod,
+} from "./approval-gateway-runtime-methods.js";
 import { formatErrorMessage } from "./errors.js";
 import type {
   ExecApprovalChannelRuntime,
@@ -23,9 +27,16 @@ export type {
 
 type ApprovalRequestEvent = ExecApprovalRequest | PluginApprovalRequest;
 type ApprovalResolvedEvent = ExecApprovalResolved | PluginApprovalResolved;
+type ApprovalReplayMethod = Extract<
+  GatewayNativeApprovalMethod,
+  "exec.approval.list" | "plugin.approval.list"
+>;
 
 type ApprovalReplayClient = {
-  request: <T = unknown>(method: string, params: Record<string, unknown>) => Promise<T>;
+  request: <T = unknown>(
+    method: ApprovalReplayMethod,
+    params: Record<string, unknown>,
+  ) => Promise<T>;
 };
 
 /** Error raised when the gateway pauses approval reconnects after a terminal startup failure. */
@@ -64,8 +75,8 @@ type PendingApprovalEntry<
 
 function resolveApprovalReplayMethods(
   eventKinds: ReadonlySet<ExecApprovalChannelRuntimeEventKind>,
-): string[] {
-  const methods: string[] = [];
+): ApprovalReplayMethod[] {
+  const methods: ApprovalReplayMethod[] = [];
   if (eventKinds.has("exec")) {
     methods.push("exec.approval.list");
   }
@@ -480,6 +491,11 @@ export function createExecApprovalChannelRuntime<
         );
       }
       if (gatewayRuntime) {
+        if (!isGatewayNativeApprovalMethod(method)) {
+          throw new Error(
+            `${adapter.label}: Gateway-owned approval runtime cannot dispatch ${method}`,
+          );
+        }
         return await gatewayRuntime.request<T>(method, params, {
           clientDisplayName: adapter.clientDisplayName,
         });

--- a/src/infra/exec-approval-channel-runtime.types.ts
+++ b/src/infra/exec-approval-channel-runtime.types.ts
@@ -1,6 +1,5 @@
 // Defines channel-native approval runtime contracts.
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import type { GatewayNativeApprovalRuntime } from "../gateway/server-instance-runtime.js";
 import type { ExecApprovalRequest, ExecApprovalResolved } from "./exec-approvals.js";
 import type { PluginApprovalRequest, PluginApprovalResolved } from "./plugin-approvals.js";
 
@@ -20,8 +19,6 @@ export type ExecApprovalChannelRuntimeAdapter<
   clientDisplayName: string;
   cfg: OpenClawConfig;
   gatewayUrl?: string;
-  /** Instance-owned transport used by Gateway-created channel runtimes. */
-  gatewayRuntime?: GatewayNativeApprovalRuntime;
   /** Defaults to exec-only; include plugin when the adapter can handle plugin approvals. */
   eventKinds?: readonly ExecApprovalChannelRuntimeEventKind[];
   isConfigured: () => boolean;

--- a/src/infra/exec-approval-channel-runtime.types.ts
+++ b/src/infra/exec-approval-channel-runtime.types.ts
@@ -1,5 +1,6 @@
 // Defines channel-native approval runtime contracts.
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { GatewayNativeApprovalRuntime } from "../gateway/server-instance-runtime.js";
 import type { ExecApprovalRequest, ExecApprovalResolved } from "./exec-approvals.js";
 import type { PluginApprovalRequest, PluginApprovalResolved } from "./plugin-approvals.js";
 
@@ -19,6 +20,8 @@ export type ExecApprovalChannelRuntimeAdapter<
   clientDisplayName: string;
   cfg: OpenClawConfig;
   gatewayUrl?: string;
+  /** Instance-owned transport used by Gateway-created channel runtimes. */
+  gatewayRuntime?: GatewayNativeApprovalRuntime;
   /** Defaults to exec-only; include plugin when the adapter can handle plugin approvals. */
   eventKinds?: readonly ExecApprovalChannelRuntimeEventKind[];
   isConfigured: () => boolean;


### PR DESCRIPTION
Closes #103636

## What Problem This Solves

Fixes an issue where Gateway-owned restart recovery and native approval work could fail when an operator's effective Gateway URL traversed a same-host relay. The relay correctly presented a non-loopback peer, but the internal backend client then lost the operator scope required to complete the workflow.

## Why This Change Was Made

Gateway-owned work now uses least-privilege, instance-bound in-process principals instead of authenticating back into the same Gateway over WebSocket. This keeps host-interface peers remote, preserves the external authentication and device-pairing boundary, and makes internal authority independent of network topology.

The refactor also preserves request deadlines, approval client identity, canonical resolution publication, account isolation, replay/live-event deduplication, and terminal Gateway lifecycle cleanup. The plugin-facing approval adapter shape remains unchanged.

## User Impact

Operators can use supported relay and proxy topologies without restart recovery or native approvals failing solely because an internal self-call returns through a host interface. External device-less host-interface clients still do not receive loopback-equivalent authority.

## Evidence

- Baseline live reproduction on `98e88ab1a6b7`: direct loopback succeeded while the host-interface relay failed backend `sessions.create` and `agent` calls with `missing scope: operator.write` (`run_70cf95e93287`).
- Exact-head main-session recovery proof on `377b26b4815`: the external relayed write remained denied, while startup recovery completed in-process with `recovered=1 failed=0`, persisted the expected assistant marker, and opened no recovery self-WebSocket ([`run_c28accde9629`](https://crabbox.openclaw.ai/portal/runs/run_c28accde9629)).
- Exact-head subagent recovery proof on `377b26b4815`: a real persisted interrupted subagent bypassed its dead pre-restart wait, recovered and completed through the lifecycle-bound principal, produced its child and parent model turns, and opened no internal relay connection; the sole scope failure was the intentional external write probe ([`run_9780bb796fde`](https://crabbox.openclaw.ai/portal/runs/run_9780bb796fde)).
- Exact-head native approval matrix on `377b26b4815`: all eight exec/plugin, live/replay, and resolve-after/resolve-during rows passed; every race row passed 9/9 with exactly-once delivery, callback, resolution, and finalization, and the configured relay saw no approval self-connection or scope/pairing failure ([`run_db7c259294b6`](https://crabbox.openclaw.ai/portal/runs/run_db7c259294b6)).
- Candidate native approval race soak on `e1a16bab06ad`: every delivery-race row passed 25/25 across three fresh Gateway processes, with exactly-once delivery/finalization and account isolation (`run_b3cab0ad34ba`, `run_9559b7dfc1f3`, `run_8f8cfa1c0130`).
- Head `60cfa1656a34`: 233 focused tests across the Gateway instance/startup runtime and subagent registry/recovery/announce-loop surfaces passed; fresh mandatory autoreview reported no actionable findings.
- Exact-head Blacksmith Testbox `tbx_01kxm1jqf8em1yjg5qs6hmyvvt`: targeted `pnpm check:changed` passed, including core/core-test typechecks, lint, boundary, database-first, and import-cycle gates; `pnpm build` also passed ([run](https://github.com/openclaw/openclaw/actions/runs/29458483615)).

AI-assisted: Yes (Codex).
