### PR TITLE
fix(gateway): cloud session resumes after gateway restart

### DIFF
--- a/src/gateway/server-worker-placement-startup.ts
+++ b/src/gateway/server-worker-placement-startup.ts
@@ -18,6 +18,7 @@ import {
   type WorkerPlacementDispatchService,
 } from "./worker-environments/placement-dispatch.js";
 import type { WorkerSessionPlacementStore } from "./worker-environments/placement-store.js";
+import { createReclaimedPlacementRedispatch } from "./worker-environments/reclaimed-placement-redispatch.js";
 import type { WorkerEnvironmentService } from "./worker-environments/service.js";
 import { createWorkerSessionTurnPlacementProvider } from "./worker-environments/worker-turn-launcher.js";
 import { createWorkerWorkspaceOperationCoordinator } from "./worker-environments/workspace-operation-coordinator.js";
@@ -459,6 +460,10 @@ export function createGatewayWorkerPlacementRuntime(params: GatewayWorkerPlaceme
     environments: params.environments,
     placements: params.placements,
     admitNewPlacements: params.admitNewPlacements,
+    redispatchReclaimed: createReclaimedPlacementRedispatch({
+      environments: params.environments,
+      dispatch: dispatchService.dispatch,
+    }),
     workspaceOperations,
   });
   const recoverPendingWorkspaceReconciliations = async (): Promise<void> => {

--- a/src/gateway/worker-environments/reclaimed-placement-redispatch.test.ts
+++ b/src/gateway/worker-environments/reclaimed-placement-redispatch.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from "vitest";
+import type { WorkerSessionPlacementRecord } from "./placement-record.js";
+import { createReclaimedPlacementRedispatch } from "./reclaimed-placement-redispatch.js";
+
+type ReclaimedWorkerPlacement = Extract<WorkerSessionPlacementRecord, { state: "reclaimed" }>;
+
+const placement = {
+  state: "reclaimed",
+  sessionId: "session-1",
+  sessionKey: "agent:main:cloud-session",
+  agentId: "main",
+  environmentId: "worker:previous",
+} as ReclaimedWorkerPlacement;
+
+describe("createReclaimedPlacementRedispatch", () => {
+  it("reuses the previous environment profile for a fresh dispatch", async () => {
+    const active = { state: "active" } as Extract<
+      WorkerSessionPlacementRecord,
+      { state: "active" }
+    >;
+    const dispatch = vi.fn(async () => active);
+    const redispatch = createReclaimedPlacementRedispatch({
+      environments: {
+        get: () => ({ profileId: "development" }) as never,
+      },
+      dispatch,
+    });
+
+    await expect(redispatch(placement)).resolves.toBe(active);
+    expect(dispatch).toHaveBeenCalledWith({
+      sessionId: placement.sessionId,
+      sessionKey: placement.sessionKey,
+      agentId: placement.agentId,
+      profileId: "development",
+    });
+  });
+
+  it("fails closed when the prior environment record is unavailable", async () => {
+    const redispatch = createReclaimedPlacementRedispatch({
+      environments: { get: () => undefined },
+      dispatch: vi.fn(),
+    });
+
+    await expect(redispatch(placement)).rejects.toThrow(
+      "Reclaimed worker placement has no environment record: worker:previous",
+    );
+  });
+});

--- a/src/gateway/worker-environments/reclaimed-placement-redispatch.ts
+++ b/src/gateway/worker-environments/reclaimed-placement-redispatch.ts
@@ -1,0 +1,25 @@
+import type { WorkerPlacementDispatchService } from "./placement-dispatch.js";
+import type { WorkerSessionPlacementRecord } from "./placement-record.js";
+import type { WorkerEnvironmentService } from "./service.js";
+
+type ReclaimedWorkerPlacement = Extract<WorkerSessionPlacementRecord, { state: "reclaimed" }>;
+
+export function createReclaimedPlacementRedispatch(params: {
+  environments: Pick<WorkerEnvironmentService, "get">;
+  dispatch: WorkerPlacementDispatchService["dispatch"];
+}) {
+  return async (placement: ReclaimedWorkerPlacement) => {
+    const previousEnvironment = params.environments.get(placement.environmentId);
+    if (!previousEnvironment) {
+      throw new Error(
+        `Reclaimed worker placement has no environment record: ${placement.environmentId}`,
+      );
+    }
+    return await params.dispatch({
+      sessionId: placement.sessionId,
+      sessionKey: placement.sessionKey,
+      agentId: placement.agentId,
+      profileId: previousEnvironment.profileId,
+    });
+  };
+}


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a cloud-backed session could fail its next turn after the Gateway restarted and recovered its worker placement.

## Why This Change Was Made

Reclaimed placements now redispatch through the normal placement service using the profile recorded on their prior environment. The path fails closed when that durable environment record is unavailable.

## User Impact

Cloud-backed sessions can resume with a fresh worker generation after Gateway restart recovery instead of failing before reply.

## Evidence

- Reproduced from an exact-current-main restart-window error.
- Added focused success and missing-record regression coverage.
- `node scripts/run-vitest.mjs src/gateway/worker-environments/reclaimed-placement-redispatch.test.ts` — 2 passed.
- Targeted formatting and `git diff --check` pass.
- Autoreview clean.
