### PR TITLE
fix(zalo): report unsupported message actions correctly

### DIFF
--- a/extensions/zalo/src/actions.test.ts
+++ b/extensions/zalo/src/actions.test.ts
@@ -29,5 +29,7 @@ describe("zaloMessageActions.describeMessageTool", () => {
       actions: ["send"],
       capabilities: [],
     });
+    expect(zaloMessageActions.supportsAction?.({ action: "send" })).toBe(true);
+    expect(zaloMessageActions.supportsAction?.({ action: "react" })).toBe(false);
   });
 });

--- a/extensions/zalo/src/actions.ts
+++ b/extensions/zalo/src/actions.ts
@@ -15,6 +15,7 @@ const loadZaloActionsRuntime = createLazyRuntimeNamedExport(
 );
 
 const providerId = "zalo";
+const ZALO_ACTIONS = new Set<ChannelMessageActionName>(["send"]);
 
 function listEnabledAccounts(cfg: OpenClawConfig, accountId?: string | null) {
   return (
@@ -28,9 +29,9 @@ export const zaloMessageActions: ChannelMessageActionAdapter = {
     if (accounts.length === 0) {
       return null;
     }
-    const actions = new Set<ChannelMessageActionName>(["send"]);
-    return { actions: Array.from(actions), capabilities: [] };
+    return { actions: Array.from(ZALO_ACTIONS), capabilities: [] };
   },
+  supportsAction: ({ action }) => ZALO_ACTIONS.has(action),
   extractToolSend: ({ args }) => extractToolSend(args, "sendMessage"),
   handleAction: async ({ action, params, cfg, accountId }) => {
     if (action === "send") {

--- a/src/infra/outbound/message-action-runner.plugin-dispatch.test.ts
+++ b/src/infra/outbound/message-action-runner.plugin-dispatch.test.ts
@@ -499,6 +499,30 @@ describe("runMessageAction plugin dispatch", () => {
       );
     });
 
+    it("rejects unsupported read actions before conversation authorization", async () => {
+      await expect(
+        runMessageAction({
+          cfg: {
+            channels: {
+              actionhub: {
+                enabled: true,
+              },
+            },
+          } as OpenClawConfig,
+          action: "react",
+          params: {
+            channel: "actionhub",
+            target: "other-conversation",
+            messageId: "om_123",
+            emoji: "eyes",
+          },
+          conversationReadOrigin: "delegated",
+          dryRun: false,
+        }),
+      ).rejects.toThrow("Message action react not supported for channel actionhub.");
+      expect(handleAction).not.toHaveBeenCalled();
+    });
+
     it("routes execution context ids into plugin handleAction", async () => {
       const stateDir = path.join("/tmp", "openclaw-plugin-dispatch-media-roots");
       const expectedWorkspaceRoot = path.resolve(stateDir, "workspace-alpha");


### PR DESCRIPTION
Closes #108431

## What Problem This Solves

Fixes an issue where users invoking an unsupported read-dependent Zalo message action could receive a conversation-policy error instead of an accurate unsupported-action error.

## Why This Change Was Made

The Zalo adapter now exposes one canonical supported-action set for both tool discovery and runtime support checks. The shared runner can therefore reject unsupported actions before conversation authorization or plugin execution, matching other restricted bundled adapters.

## User Impact

Unsupported Zalo message actions now fail with the correct diagnostic, avoiding irrelevant conversation-policy troubleshooting. Supported Zalo sends are unchanged.

## Evidence

- Blacksmith Testbox `tbx_01kxkgr51yb3ht0yd2ptp9aet9`: 38 shared plugin-dispatch tests and the focused Zalo adapter test passed.
- The regression test proves unsupported delegated actions reject before conversation authorization and before plugin execution.
- The same run passed 56 shared message-action authorization/security tests.
- `pnpm check:changed` passed, including formatting, SDK/API checks, plugin boundaries, tsgo lanes, core/extension lint, import cycles, and database-first guards.
- Fresh `$autoreview` reported no actionable findings.
- `git diff --check` passed.
- The focused remote run used the reviewed combined precursor tree containing this independent commit plus the separately submitted QA Channel fix; this PR has no dependency on that change. Exact-head CI is the final branch-specific gate.

AI-assisted: implementation, source audit, and validation were performed with Codex under maintainer direction.
