### PR TITLE
ci: restore workflow sanity and ClawHub shard

### DIFF
--- a/.github/workflows/workflow-sanity.yml
+++ b/.github/workflows/workflow-sanity.yml
@@ -179,7 +179,7 @@ jobs:
           sudo install -m 0755 actionlint /usr/local/bin/actionlint
 
       - name: Lint workflows
-        run: actionlint
+        run: actionlint -shellcheck=
 
       - name: Audit all workflows with zizmor
         shell: bash

--- a/src/infra/clawhub.test.ts
+++ b/src/infra/clawhub.test.ts
@@ -1113,22 +1113,29 @@ describe("clawhub helpers", () => {
   });
 
   it("times out and cancels stalled ClawHub error bodies", async () => {
-    const stalled = createStalledBodyResponse({
-      firstChunk: new TextEncoder().encode("partial error"),
-      headers: { "content-type": "text/plain" },
-      status: 500,
-      statusText: "Server Error",
-    });
+    const stalledResponses: ReturnType<typeof createStalledBodyResponse>[] = [];
 
     await expect(
       searchClawHubSkills({
         query: "calendar",
         timeoutMs: 5,
-        fetchImpl: async () => stalled.response,
+        fetchImpl: async () => {
+          const stalled = createStalledBodyResponse({
+            firstChunk: new TextEncoder().encode("partial error"),
+            headers: { "content-type": "text/plain", "retry-after": "0" },
+            status: 500,
+            statusText: "Server Error",
+          });
+          stalledResponses.push(stalled);
+          return stalled.response;
+        },
       }),
     ).rejects.toThrow("ClawHub /api/v1/search failed (500): Server Error");
-    expect(stalled.cancel).toHaveBeenCalledTimes(1);
-    expect(stalled.cancel.mock.calls[0]?.[0]).toBeInstanceOf(Error);
+    for (const stalled of stalledResponses) {
+      expect(stalled.cancel).toHaveBeenCalledTimes(1);
+    }
+    const finalResponse = stalledResponses.at(-1);
+    expect(finalResponse?.cancel.mock.calls[0]?.[0]).toBeInstanceOf(Error);
   });
 
   it("bounds oversized successful ClawHub JSON responses and cancels the stream", async () => {
@@ -1171,7 +1178,8 @@ describe("clawhub helpers", () => {
     try {
       await searchClawHubSkills({
         query: "calendar",
-        fetchImpl: async () => new Response(oversized, { status: 500 }),
+        fetchImpl: async () =>
+          new Response(oversized, { status: 500, headers: { "retry-after": "0" } }),
       });
     } catch (caught) {
       error = caught;


### PR DESCRIPTION
## Summary

- stop Workflow Sanity from invoking ShellCheck indirectly through actionlint
- preserve actionlint workflow validation and the repository's separate ShellCheck coverage
- make ClawHub error-body tests compatible with retryable HTTP 500 responses

## Problem

The new large release workflow makes actionlint's implicit ShellCheck pass stall for more than 12 minutes. Comparable Workflow Sanity runs normally finish in about 40 seconds. The actionlint configuration already documents that ShellCheck runs separately and ignores its diagnostics here.

The latest main also retries HTTP 500 responses. Two error-body tests reused a one-shot response or waited through the full retry schedule, causing the node shard to fail or spend 14 seconds per assertion. They now return fresh bodies per attempt, use zero-delay retries, and verify every body is cancelled.

## Proof

- full workflow scan with actionlint 1.7.11 and ShellCheck disabled: 0.037 seconds
- full ClawHub test file: 71 passed
- ClawHub retry tests: 8 passed
- git diff --check
- autoreview clean, overall correct 0.91
