### PR TITLE
fix(cron): preserve same-ID history across configured stores

### DIFF
--- a/src/tasks/cron-history-retention.test.ts
+++ b/src/tasks/cron-history-retention.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import {
+  collectCronHistoryOverflowTaskIds,
+  CRON_HISTORY_KEEP_PER_JOB,
+} from "./cron-history-retention.js";
+import type { TaskRecord } from "./task-registry.types.js";
+
+function cronHistoryTask(params: {
+  taskId: string;
+  sourceId: string;
+  endedAt: number;
+  storeKey?: string;
+}): TaskRecord {
+  return {
+    taskId: params.taskId,
+    runtime: "cron",
+    sourceId: params.sourceId,
+    requesterSessionKey: "agent:main:main",
+    ownerKey: "system:cron:test",
+    scopeKind: "system",
+    task: "cron history",
+    status: "succeeded",
+    deliveryStatus: "not_applicable",
+    notifyPolicy: "silent",
+    createdAt: params.endedAt,
+    endedAt: params.endedAt,
+    lastEventAt: params.endedAt,
+    detail: params.storeKey ? { storeKey: params.storeKey } : undefined,
+  };
+}
+
+describe("collectCronHistoryOverflowTaskIds", () => {
+  it("keeps same-id cron history scoped to each configured store", () => {
+    const sourceId = "shared-explicit-job-id";
+    const storeA = Array.from({ length: CRON_HISTORY_KEEP_PER_JOB + 1 }, (_, index) =>
+      cronHistoryTask({
+        taskId: `store-a-${index}`,
+        sourceId,
+        storeKey: "store:a",
+        endedAt: index + 2,
+      }),
+    );
+    const storeB = cronHistoryTask({
+      taskId: "store-b-only-row",
+      sourceId,
+      storeKey: "store:b",
+      endedAt: 1,
+    });
+
+    expect(collectCronHistoryOverflowTaskIds([...storeA, storeB])).toEqual(new Set(["store-a-0"]));
+  });
+
+  it("keeps legacy rows without a store key in one per-job retention bucket", () => {
+    const tasks = Array.from({ length: CRON_HISTORY_KEEP_PER_JOB + 1 }, (_, index) =>
+      cronHistoryTask({
+        taskId: `legacy-${index}`,
+        sourceId: "legacy-job",
+        endedAt: index,
+      }),
+    );
+
+    expect(collectCronHistoryOverflowTaskIds(tasks)).toEqual(new Set(["legacy-0"]));
+  });
+});

--- a/src/tasks/cron-history-retention.ts
+++ b/src/tasks/cron-history-retention.ts
@@ -9,10 +9,18 @@ function isTerminalTask(task: TaskRecord): boolean {
   return task.status !== "queued" && task.status !== "running";
 }
 
+function cronStoreKeyForRetention(task: TaskRecord): string | undefined {
+  const detail = task.detail;
+  if (detail === null || typeof detail !== "object" || Array.isArray(detail)) {
+    return undefined;
+  }
+  return typeof detail.storeKey === "string" ? detail.storeKey : undefined;
+}
+
 export function collectCronHistoryOverflowTaskIds(tasks: readonly TaskRecord[]): Set<string> {
-  // sourceId is the ledger's global cron-job owner key; storeKey remains only
-  // a history-read partition and must not split the per-source retention cap.
-  const bySource = new Map<string, TaskRecord[]>();
+  // Cron job ids are unique within one configured store. Rows from releases
+  // before storeKey was recorded remain together in the undefined partition.
+  const byStoreAndSource = new Map<string | undefined, Map<string, TaskRecord[]>>();
   for (const task of tasks) {
     if (
       task.runtime !== "cron" ||
@@ -22,19 +30,24 @@ export function collectCronHistoryOverflowTaskIds(tasks: readonly TaskRecord[]):
     ) {
       continue;
     }
+    const storeKey = cronStoreKeyForRetention(task);
+    const bySource = byStoreAndSource.get(storeKey) ?? new Map<string, TaskRecord[]>();
     const rows = bySource.get(task.sourceId) ?? [];
     rows.push(task);
     bySource.set(task.sourceId, rows);
+    byStoreAndSource.set(storeKey, bySource);
   }
   const overflow = new Set<string>();
-  for (const rows of bySource.values()) {
-    rows.sort((left, right) => {
-      const leftAt = left.endedAt ?? left.lastEventAt ?? left.createdAt;
-      const rightAt = right.endedAt ?? right.lastEventAt ?? right.createdAt;
-      return rightAt - leftAt || right.taskId.localeCompare(left.taskId);
-    });
-    for (const task of rows.slice(CRON_HISTORY_KEEP_PER_JOB)) {
-      overflow.add(task.taskId);
+  for (const bySource of byStoreAndSource.values()) {
+    for (const rows of bySource.values()) {
+      rows.sort((left, right) => {
+        const leftAt = left.endedAt ?? left.lastEventAt ?? left.createdAt;
+        const rightAt = right.endedAt ?? right.lastEventAt ?? right.createdAt;
+        return rightAt - leftAt || right.taskId.localeCompare(left.taskId);
+      });
+      for (const task of rows.slice(CRON_HISTORY_KEEP_PER_JOB)) {
+        overflow.add(task.taskId);
+      }
     }
   }
   return overflow;


### PR DESCRIPTION
Closes #108427

## What Problem This Solves

Fixes an issue where users with multiple configured cron stores could lose history from one store when another store reused the same explicit job ID and exceeded the 2,000-run retention limit.

## Why This Change Was Made

Cron history retention now applies the existing per-job limit within each configured store, matching cron job persistence and history reads. Legacy task rows that predate `detail.storeKey` remain in one per-job fallback bucket, preserving their existing retention behavior. No configuration, protocol, or wire-format behavior changes.

## User Impact

Retention maintenance no longer selects one store's only historical run for deletion because a different store accumulated runs under the same job ID. Each configured store retains up to 2,000 terminal rows per job independently.

## Evidence

- Before on current main, the focused regression returned `Set { "store-a-0", "store-b-only-row" }`, incorrectly selecting store B's only row.
- After, the production retention selector returned:

```json
{"storeACount":2000,"storeBCount":1,"storeBOnlyRowPruned":false,"overflowTaskIds":[]}
```

- Focused and adjacent validation passed with Node 24.16:
  - `pnpm test src/tasks/cron-history-retention.test.ts src/tasks/task-registry.maintenance.issue-60299.test.ts src/cron/task-run-history.test.ts` (35 tests passed across 3 shards)
  - `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo`
  - `pnpm exec oxlint src/tasks/cron-history-retention.ts src/tasks/cron-history-retention.test.ts`
  - `pnpm exec oxfmt --check src/tasks/cron-history-retention.ts src/tasks/cron-history-retention.test.ts`
- `pnpm check:changed -- src/tasks/cron-history-retention.ts src/tasks/cron-history-retention.test.ts` passed repository policy checks, formatting, plugin boundaries, and core typecheck. Its core-test typecheck produced no output for 228 seconds and was interrupted; the changed tests compiled and passed through the focused Vitest shards above.

Disclosure: AI was used to understand the codebase and review the fix.
