### PR TITLE
fix(ai): guard JSON.stringify against circular references in stream error handlers (fixes #106570, fixes #106568)

### DIFF
--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -788,7 +788,16 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicOpti
         output.content = [];
       }
       output.stopReason = requestOptions?.signal?.aborted ? "aborted" : "error";
-      output.errorMessage = error instanceof Error ? error.message : JSON.stringify(error);
+      output.errorMessage =
+        error instanceof Error
+          ? error.message
+          : (() => {
+              try {
+                return JSON.stringify(error);
+              } catch {
+                return String(error);
+              }
+            })();
       stream.push({ type: "error", reason: output.stopReason, error: output });
       stream.end();
     }

--- a/packages/ai/src/providers/google-shared.ts
+++ b/packages/ai/src/providers/google-shared.ts
@@ -466,7 +466,16 @@ export async function runGoogleGenerateContentLifecycle<T extends GoogleApiType>
       }
     }
     output.stopReason = options?.signal?.aborted ? "aborted" : "error";
-    output.errorMessage = error instanceof Error ? error.message : JSON.stringify(error);
+    output.errorMessage =
+      error instanceof Error
+        ? error.message
+        : (() => {
+            try {
+              return JSON.stringify(error);
+            } catch {
+              return String(error);
+            }
+          })();
     stream.push({ type: "error", reason: output.stopReason, error: output });
     stream.end();
   }

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -562,7 +562,16 @@ export const streamOpenAICompletions: StreamFunction<
         delete (block as { streamIndex?: number }).streamIndex;
       }
       output.stopReason = options?.signal?.aborted ? "aborted" : "error";
-      output.errorMessage = error instanceof Error ? error.message : JSON.stringify(error);
+      output.errorMessage =
+        error instanceof Error
+          ? error.message
+          : (() => {
+              try {
+                return JSON.stringify(error);
+              } catch {
+                return String(error);
+              }
+            })();
       // Some providers via OpenRouter give additional information in this field.
       const rawMetadata = (error as { error?: { metadata?: { raw?: string } } })?.error?.metadata
         ?.raw;


### PR DESCRIPTION
## What Problem This Solves

Catch blocks in the OpenAI Completions, Google, and Anthropic stream handlers call `JSON.stringify(error)` on non-Error exceptions to build `errorMessage`. When the caught object contains circular references — common in network/socket errors where `socket._handle` or request-response cycles create reference loops — this throws `TypeError: Converting circular structure to JSON`, skipping `stream.end()` and leaking file descriptors.

Two sibling providers already ship the fix: `openai-responses.ts` and `azure-openai-responses.ts` wrap `JSON.stringify` in try/catch with a `String(error)` fallback. The Mistral provider has a dedicated `safeJsonStringify` helper. These three stream handlers were missed.

## Why This Change Was Made

A try/catch wrapper around `JSON.stringify(error)` with `String(error)` fallback, matching the exact pattern already used by the OpenAI Responses and Azure OpenAI Responses providers.

## User Impact

**Before:** A stream error with a circular error object (e.g., a failed fetch that carries a raw socket) crashes the stream handler, prevents `stream.end()`, and leaks resources. **After:** The error message is safely stringified via `String(error)` fallback and the stream closes normally.

## Evidence

- `packages/ai/src/providers/openai-completions.ts:565` — guarded (fixes #106570)
- `packages/ai/src/providers/google-shared.ts:469` — guarded (fixes #106568)
- `packages/ai/src/providers/anthropic.ts:791` — guarded (sibling, same pattern)
- `pnpm test packages/ai/src/providers/openai-completions.test.ts packages/ai/src/providers/google-shared.test.ts packages/ai/src/providers/anthropic.test.ts` — 119 passed, 0 regressions
- Function probe demonstrating the guard:

```
$ node --import tsx -e "..."

=== Before (crashes on circular objects) ===
CRASH: Converting circular structure to JSON
    --- property `self` closes the circle

=== After (safe on circular objects) ===
safeStringify: [object Object]
Error.message works: test-error
String fallback works: [object Object]
```
</details>