### PR TITLE
fix(ci): use actionlint large-script deadlock repair

### DIFF
--- a/.github/workflows/workflow-sanity.yml
+++ b/.github/workflows/workflow-sanity.yml
@@ -162,24 +162,24 @@ jobs:
       - name: Install pre-commit
         run: python -m pip install --disable-pip-version-check pre-commit==4.2.0
 
+      - name: Setup Go for actionlint
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version: "1.25.12"
+          cache: false
+
       - name: Install actionlint
         shell: bash
+        env:
+          # Unreleased upstream fix for stdin deadlock on run blocks larger than 64 KiB.
+          ACTIONLINT_COMMIT: fd33e9f582a01a02885c93ae3775e1190cf63653
         run: |
           set -euo pipefail
-          ACTIONLINT_VERSION="1.7.11"
-          archive="actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
-          base_url="https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}"
-          # GitHub release downloads occasionally return transient 5xx responses.
-          # Retry all curl errors here so workflow-sanity does not fail closed on
-          # a one-off release edge outage.
-          curl --retry 5 --retry-delay 2 --retry-all-errors -sSfL -o "${archive}" "${base_url}/${archive}"
-          curl --retry 5 --retry-delay 2 --retry-all-errors -sSfL -o checksums.txt "${base_url}/actionlint_${ACTIONLINT_VERSION}_checksums.txt"
-          grep " ${archive}\$" checksums.txt | sha256sum -c -
-          tar -xzf "${archive}" actionlint
-          sudo install -m 0755 actionlint /usr/local/bin/actionlint
+          go install "github.com/rhysd/actionlint/cmd/actionlint@${ACTIONLINT_COMMIT}"
+          actionlint -version | grep -F "${ACTIONLINT_COMMIT:0:12}"
 
       - name: Lint workflows
-        run: actionlint -shellcheck=
+        run: actionlint
 
       - name: Audit all workflows with zizmor
         shell: bash

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -1618,6 +1618,18 @@ describe("ci workflow guards", () => {
     }
   });
 
+  it("pins actionlint after its large-run-block deadlock fix", () => {
+    const workflow = readFileSync(".github/workflows/workflow-sanity.yml", "utf8");
+
+    expect(workflow).toContain('go-version: "1.25.12"');
+    expect(workflow).toContain("ACTIONLINT_COMMIT: fd33e9f582a01a02885c93ae3775e1190cf63653");
+    expect(workflow).toContain(
+      'go install "github.com/rhysd/actionlint/cmd/actionlint@${ACTIONLINT_COMMIT}"',
+    );
+    expect(workflow).toContain("run: actionlint\n");
+    expect(workflow).not.toContain("actionlint -shellcheck=");
+  });
+
   it("bounds shared base commit fetches", () => {
     const action = readFileSync(".github/actions/ensure-base-commit/action.yml", "utf8");
     const exactFetch = action.indexOf('fetch_base_ref --no-tags --depth=1 origin "$BASE_SHA"');


### PR DESCRIPTION
## What Problem This Solves

Workflow Sanity deadlocked in `actionlint` once an inline `run:` block exceeded the platform pipe capacity. PR #108437 restored CI by passing `-shellcheck=`, but that also disables actionlint's ShellCheck analysis of embedded workflow `run:` blocks. The standalone pre-commit ShellCheck hook covers shell files, not those YAML blocks.

## Why This Change Was Made

Actionlint upstream fixed this exact stdin deadlock after v1.7.12 in verified commit `fd33e9f582a01a02885c93ae3775e1190cf63653`. Until the next actionlint release, Workflow Sanity builds that exact commit and restores the normal `actionlint` invocation, retaining embedded-shell analysis without the deadlock.

## User Impact

Workflow Sanity keeps full actionlint and embedded ShellCheck coverage while large inline workflow scripts complete normally. No product or release behavior changes.

## Evidence

- Stable actionlint reproduces the hang once the release publisher's inline script crosses the platform pipe capacity.
- `go run github.com/rhysd/actionlint/cmd/actionlint@fd33e9f582a01a02885c93ae3775e1190cf63653` checked the complete current workflow set, including embedded ShellCheck, in 5.44 seconds after rebasing onto #108437.
- `node scripts/run-vitest.mjs test/scripts/ci-workflow-guards.test.ts -t "pins actionlint after its large-run-block deadlock fix"` passed.
- The guard asserts both the exact upstream commit and that `-shellcheck=` is absent.
- `git diff --check` passed.

Upstream fix: https://github.com/rhysd/actionlint/commit/fd33e9f582a01a02885c93ae3775e1190cf63653
