### PR TITLE
test(clawhub): keep body timeout outside 500 retries

### DIFF
--- a/src/infra/clawhub.test.ts
+++ b/src/infra/clawhub.test.ts
@@ -1116,8 +1116,8 @@ describe("clawhub helpers", () => {
     const stalled = createStalledBodyResponse({
       firstChunk: new TextEncoder().encode("partial error"),
       headers: { "content-type": "text/plain" },
-      status: 500,
-      statusText: "Server Error",
+      status: 400,
+      statusText: "Bad Request",
     });
 
     await expect(
@@ -1126,7 +1126,7 @@ describe("clawhub helpers", () => {
         timeoutMs: 5,
         fetchImpl: async () => stalled.response,
       }),
-    ).rejects.toThrow("ClawHub /api/v1/search failed (500): Server Error");
+    ).rejects.toThrow("ClawHub /api/v1/search failed (400): Bad Request");
     expect(stalled.cancel).toHaveBeenCalledTimes(1);
     expect(stalled.cancel.mock.calls[0]?.[0]).toBeInstanceOf(Error);
   });


### PR DESCRIPTION
## What Problem This Solves

Commit `c3927271fad` correctly made ClawHub HTTP 500 responses retryable, but the existing stalled-error-body test reused one `Response` object for every retry. The first retry disposal therefore cancelled that response without an error reason, and the test later failed while checking for the timeout cancellation reason.

## Why This Change Was Made

Keep this test focused on its owner contract: bounding and cancelling a stalled error response body. A non-retryable HTTP 400 response exercises that same behavior without coupling the timeout test to the separate transient-retry contract.

## User Impact

No runtime behavior changes. This restores deterministic CI coverage after HTTP 500 retries were enabled.

## Evidence

- Before: `node scripts/run-vitest.mjs src/infra/clawhub.test.ts -t "times out and cancels stalled ClawHub error bodies"` failed after 14.19s because the cancellation reason was `undefined`.
- After: the same focused test passed in 1.28s.
- `node scripts/run-vitest.mjs src/infra/clawhub-retry.test.ts src/infra/clawhub.test.ts` — 79/79 tests passed.
- `git diff --check` passed.

Related regression source: `c3927271fad` (`fix(release): retry ClawHub internal errors`).
