### PR TITLE
improve: tighten additional async test polling

### DIFF
--- a/extensions/codex/src/app-server/sandbox-exec-server.test-helpers.ts
+++ b/extensions/codex/src/app-server/sandbox-exec-server.test-helpers.ts
@@ -214,7 +214,8 @@ export async function waitForHttpBodyDeltas(
   notifications: Array<{ method: string; params?: unknown }>,
   count: number,
 ): Promise<unknown[]> {
-  for (let attempt = 0; attempt < 20; attempt += 1) {
+  // Preserve the 500 ms failure budget while checking completed streams sooner.
+  for (let attempt = 0; attempt < 100; attempt += 1) {
     const deltas = notifications
       .filter((notification) => notification.method === "http/request/bodyDelta")
       .map((notification) => notification.params);
@@ -222,7 +223,7 @@ export async function waitForHttpBodyDeltas(
       return deltas;
     }
     await new Promise((resolve) => {
-      setTimeout(resolve, 25);
+      setTimeout(resolve, 5);
     });
   }
   throw new Error(`expected ${count} http body deltas`);

--- a/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-cli-stream-error.test.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-cli-stream-error.test.ts
@@ -92,7 +92,7 @@ async function waitForPidFile(pathToCheck: string, timeoutMs: number): Promise<n
         return pid;
       }
     } catch {}
-    await sleep(25);
+    await sleep(5);
   }
   throw new Error(`Timed out waiting for a PID in ${pathToCheck}`);
 }
@@ -104,7 +104,7 @@ async function waitForFile(pathToCheck: string, timeoutMs: number): Promise<void
       await readFile(pathToCheck);
       return;
     } catch {}
-    await sleep(25);
+    await sleep(5);
   }
   throw new Error(`Timed out waiting for ${pathToCheck}`);
 }

--- a/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-cli.test.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-cli.test.ts
@@ -36,7 +36,7 @@ async function waitForPidFile(pathToCheck: string, timeoutMs: number): Promise<n
         return pid;
       }
     } catch {}
-    await sleep(25);
+    await sleep(5);
   }
   throw new Error(`Timed out waiting for a PID in ${pathToCheck}`);
 }
@@ -47,7 +47,7 @@ async function waitForProcessExit(pid: number, timeoutMs: number): Promise<void>
     if (!isProcessRunning(pid)) {
       return;
     }
-    await sleep(25);
+    await sleep(5);
   }
   throw new Error(`Timed out waiting for process ${pid} to exit`);
 }

--- a/extensions/qa-lab/src/model-catalog.runtime.test.ts
+++ b/extensions/qa-lab/src/model-catalog.runtime.test.ts
@@ -17,7 +17,7 @@ async function waitForFile(filePath: string, timeoutMs: number): Promise<void> {
       return;
     } catch {
       await new Promise((resolvePoll) => {
-        setTimeout(resolvePoll, 25);
+        setTimeout(resolvePoll, 5);
       });
     }
   }
@@ -40,7 +40,7 @@ async function waitForDead(pid: number, timeoutMs: number): Promise<void> {
       return;
     }
     await new Promise((resolvePoll) => {
-      setTimeout(resolvePoll, 25);
+      setTimeout(resolvePoll, 5);
     });
   }
   throw new Error(`timed out waiting for pid ${pid} to exit`);

--- a/extensions/qa-lab/src/test-file-scenario-runner.test.ts
+++ b/extensions/qa-lab/src/test-file-scenario-runner.test.ts
@@ -35,7 +35,7 @@ async function readPid(filePath: string, timeoutMs: number) {
     } catch {
       // retry until the process writes its pid
     }
-    await sleep(25);
+    await sleep(5);
   }
   throw new Error(`timeout waiting for pid in ${filePath}`);
 }
@@ -46,7 +46,7 @@ async function waitForDead(pid: number, timeoutMs: number) {
     if (!isProcessRunning(pid)) {
       return;
     }
-    await sleep(25);
+    await sleep(5);
   }
   throw new Error(`process ${pid} still alive`);
 }

--- a/packages/memory-host-sdk/src/host/qmd-process.real.test.ts
+++ b/packages/memory-host-sdk/src/host/qmd-process.real.test.ts
@@ -34,7 +34,7 @@ async function waitUntil(params: {
       throw new Error(`timed out waiting for ${params.description}`);
     }
     await new Promise<void>((resolve) => {
-      setTimeout(resolve, 20);
+      setTimeout(resolve, 5);
     });
   }
 }

--- a/src/gateway/server.node-pairing-ssh-verify.test.ts
+++ b/src/gateway/server.node-pairing-ssh-verify.test.ts
@@ -42,7 +42,7 @@ async function waitFor<T>(
       return value;
     }
     await new Promise((resolve) => {
-      setTimeout(resolve, 50);
+      setTimeout(resolve, 10);
     });
   }
   throw new Error(`timed out waiting for ${what}`);

--- a/test/e2e/qa-lab/plugins/plugin-lifecycle-probe.e2e.test.ts
+++ b/test/e2e/qa-lab/plugins/plugin-lifecycle-probe.e2e.test.ts
@@ -43,7 +43,7 @@ async function waitForFile(pathToCheck: string, timeoutMs: number): Promise<void
     if (existsSync(pathToCheck)) {
       return;
     }
-    await sleep(25);
+    await sleep(5);
   }
   throw new Error(`Timed out waiting for ${pathToCheck}`);
 }

--- a/test/e2e/qa-lab/runtime/package-openclaw-for-docker.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/package-openclaw-for-docker.e2e.test.ts
@@ -47,7 +47,7 @@ async function readPid(filePath: string, timeoutMs: number): Promise<number> {
         return pid;
       }
     }
-    await sleep(25);
+    await sleep(5);
   }
   throw new Error(`timeout waiting for a positive pid in ${filePath}`);
 }
@@ -58,7 +58,7 @@ async function waitForDead(pid: number, timeoutMs: number): Promise<void> {
     if (!isProcessAlive(pid)) {
       return;
     }
-    await sleep(25);
+    await sleep(5);
   }
   throw new Error(`process still alive: ${pid}`);
 }

--- a/test/scripts/docker-all-scheduler.test.ts
+++ b/test/scripts/docker-all-scheduler.test.ts
@@ -103,7 +103,7 @@ async function waitFor(predicate: () => boolean, timeoutMs = 5_000): Promise<voi
     if (predicate()) {
       return;
     }
-    await delay(25);
+    await delay(5);
   }
   throw new Error("condition was not met before timeout");
 }

--- a/test/scripts/managed-child-process.test.ts
+++ b/test/scripts/managed-child-process.test.ts
@@ -312,7 +312,7 @@ async function waitFor(condition: () => boolean, timeoutMs = 3_000) {
     if (Date.now() - startedAt > timeoutMs) {
       throw new Error("timed out waiting for condition");
     }
-    await delay(25);
+    await delay(5);
   }
 }
 

--- a/test/scripts/plugins-assertions.test.ts
+++ b/test/scripts/plugins-assertions.test.ts
@@ -132,7 +132,7 @@ function waitForDead(pid: number, timeoutMs = 2_000): void {
     if (Date.now() - startedAt > timeoutMs) {
       throw new Error(`pid ${pid} is still alive`);
     }
-    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 20);
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 5);
   }
 }
 
@@ -145,14 +145,14 @@ function runPluginsSweepShell(script: string, env: NodeJS.ProcessEnv = {}) {
 }
 
 async function waitForPortFile(portFile: string): Promise<number> {
-  for (let attempt = 0; attempt < 50; attempt += 1) {
+  for (let attempt = 0; attempt < 200; attempt += 1) {
     if (existsSync(portFile)) {
       const port = Number(readFileSync(portFile, "utf8"));
       if (Number.isInteger(port) && port > 0) {
         return port;
       }
     }
-    await new Promise((resolve) => setTimeout(resolve, 20));
+    await new Promise((resolve) => setTimeout(resolve, 5));
   }
   throw new Error(`timed out waiting for ${portFile}`);
 }

--- a/test/scripts/run-additional-boundary-checks.test.ts
+++ b/test/scripts/run-additional-boundary-checks.test.ts
@@ -66,7 +66,7 @@ async function waitForFile(filePath: string, timeoutMs: number): Promise<void> {
     if (fs.existsSync(filePath)) {
       return;
     }
-    await sleep(25);
+    await sleep(5);
   }
   throw new Error(`timeout waiting for ${filePath}`);
 }
@@ -77,7 +77,7 @@ async function waitForDead(pid: number, timeoutMs: number): Promise<void> {
     if (!isProcessAlive(pid)) {
       return;
     }
-    await sleep(25);
+    await sleep(5);
   }
   throw new Error(`process still alive: ${pid}`);
 }
@@ -88,7 +88,7 @@ async function waitForNotRunning(pid: number, timeoutMs: number): Promise<void> 
     if (!isProcessAlive(pid) || isProcessZombie(pid)) {
       return;
     }
-    await sleep(25);
+    await sleep(5);
   }
   throw new Error(`process still running: ${pid}`);
 }


### PR DESCRIPTION
## What Problem This Solves

Async test helpers often wait 20-50 ms after their condition becomes true. Across process, file, port, and HTTP-stream tests, those fixed polling delays add avoidable suite latency.

## Why This Change Was Made

Tighten polling in 13 independent test surfaces. Deadline-based helpers keep their existing timeout, while attempt-based helpers increase their attempt count so the nominal failure budget remains unchanged.

## User Impact

No user-visible behavior changes. Maintainers get faster feedback from affected test suites.

## Evidence

- Blacksmith Testbox: 315 focused tests passed across 6 Vitest shards.
- Same warm lease and exact command: 41.67s before, 37.01s after (11.2% faster).
- Remote command time: 43.259s before, 41.101s after.
- Local autoreview: clean, 0 findings, 0.98 confidence.
- Changed checks passed through formatting and dependency guards. The Plugin SDK baseline check also fails on clean origin/main at 77d07dc3e98, so it is unrelated to this test-only patch.
- git diff --check passed.
