### PR TITLE
fix: gateway startup fails on legacy default channel allowlists

### DIFF
--- a/src/infra/state-migrations.channel-pairing.test.ts
+++ b/src/infra/state-migrations.channel-pairing.test.ts
@@ -83,6 +83,27 @@ describe("legacy channel pairing state migration", () => {
     );
   });
 
+  it("imports a built-in channel's explicit default account without channel config", async () => {
+    const { env, sourceDir } = await createFixture();
+    const filePath = path.join(sourceDir, "whatsapp-default-allowFrom.json");
+    writeJson(filePath, {
+      version: 1,
+      allowFrom: ["+12025550101", "+12025550102", "+12025550103"],
+    });
+
+    const detected = detectLegacyChannelPairingState({ sourceDir });
+    const result = migrateLegacyChannelPairingState({ detected, env });
+
+    expect(result.warnings).toEqual([]);
+    expect(result.changes).toEqual([
+      "Migrated 3 whatsapp/default allowFrom entries → shared SQLite state",
+    ]);
+    expect(fs.existsSync(filePath)).toBe(false);
+    expect(readChannelPairingStateSnapshot("whatsapp", env).allowFrom).toEqual({
+      default: ["+12025550101", "+12025550102", "+12025550103"],
+    });
+  });
+
   it("merges with authoritative SQLite rows and keeps unreadable sources", async () => {
     const { env, sourceDir } = await createFixture();
     const createdAt = new Date().toISOString();
@@ -157,6 +178,27 @@ describe("legacy channel pairing state migration", () => {
     ]);
     expect(fs.existsSync(filePath)).toBe(true);
     expect(readChannelPairingStateSnapshot("telegram", env).allowFrom).toEqual({});
+  });
+
+  it("does not infer default accounts for external channels", async () => {
+    const { env, sourceDir } = await createFixture();
+    const filePath = path.join(sourceDir, "custom-channel-default-allowFrom.json");
+    writeJson(filePath, { version: 1, allowFrom: ["external-user"] });
+
+    const detected = detectLegacyChannelPairingState({
+      sourceDir,
+      configuredChannelIds: ["custom-channel"],
+    });
+    const result = migrateLegacyChannelPairingState({ detected, env });
+
+    expect(result.changes).toEqual([]);
+    expect(result.warnings).toEqual([
+      expect.stringContaining(
+        "Legacy channel allowFrom channel/account is unresolved; left in place",
+      ),
+    ]);
+    expect(fs.existsSync(filePath)).toBe(true);
+    expect(readChannelPairingStateSnapshot("custom-channel", env).allowFrom).toEqual({});
   });
 
   it("leaves overlapping channel and account filename interpretations in place", async () => {

--- a/src/infra/state-migrations.channel-pairing.ts
+++ b/src/infra/state-migrations.channel-pairing.ts
@@ -113,6 +113,9 @@ function parseAllowFromFilename(
     } else if (matchingAccountIds.length > 1) {
       hasAccountCollision = true;
     } else if (accountKey === DEFAULT_ACCOUNT_ID && CHANNEL_IDS.includes(channel)) {
+      // "default" is canonical, so bundled `<channel>-default` files resolve without config.
+      // Keep this on CHANNEL_IDS: knownChannelIds also includes configured and pairing-file ids.
+      // After safeAccountKey finds no match, those other channels must remain unresolved.
       targets.push({ channel: channel as PairingChannel, accountId: DEFAULT_ACCOUNT_ID });
     }
   }

--- a/src/infra/state-migrations.channel-pairing.ts
+++ b/src/infra/state-migrations.channel-pairing.ts
@@ -112,6 +112,8 @@ function parseAllowFromFilename(
       targets.push({ channel: channel as PairingChannel, accountId: matchingAccountIds[0] });
     } else if (matchingAccountIds.length > 1) {
       hasAccountCollision = true;
+    } else if (accountKey === DEFAULT_ACCOUNT_ID && CHANNEL_IDS.includes(channel)) {
+      targets.push({ channel: channel as PairingChannel, accountId: DEFAULT_ACCOUNT_ID });
     }
   }
   if (hasAccountCollision || targets.length > 1) {


### PR DESCRIPTION
Fixes #108421
Related to #108299

## What Problem This Solves

Fixes an issue where users upgrading from OpenClaw `2026.7.1` to
`2026.7.2-beta.1` could no longer start the Gateway when a legacy
`credentials/whatsapp-default-allowFrom.json` file remained and no
`channels.whatsapp` section existed.

The startup migration reported the legacy file as unresolved and left it in
place. `openclaw doctor --fix` detected the same warning but could not complete
the migration, so Gateway startup continued to refuse readiness.

## Why This Change Was Made

Legacy scoped allowFrom filenames are parsed as a channel ID plus an account
key. The migration already knows `whatsapp` is a bundled channel through
`CHANNEL_IDS`, but it previously accepted the `default` account suffix only
when that account had also been discovered from channel configuration or
bindings. With no `channels.whatsapp` section, the explicit `default` suffix
therefore had no configured match and was classified as unresolved.

The parser now recognizes an explicit `default` suffix as the canonical default
account when, and only when, the parsed channel is a bundled OpenClaw channel.
The existing migration then imports the allowlist into the shared SQLite pairing
state and removes the legacy JSON file.

This is intentionally narrower than adding `default` to every discovered
channel:

- External plugin channels still require an explicit configured account match.
- Sanitized account-name collisions remain ambiguous.
- Filenames with overlapping channel/account interpretations remain ambiguous.
- No Doctor orchestration, startup readiness, configuration, SQLite schema, or
  plugin migration behavior changes.

Special-casing WhatsApp was also considered, but rejected because `default` is
the canonical account ID across bundled channels. Restricting the general rule
to `CHANNEL_IDS` preserves the core/plugin ownership boundary without adding a
channel-specific exception.

## User Impact

Affected upgrades can automatically migrate
`whatsapp-default-allowFrom.json` into the SQLite pairing state under the
`default` account. The legacy file is removed after a successful import, so
startup migrations complete without requiring users to recreate channel
configuration or manually relocate the file.

## Evidence

The positive regression test creates the reported version-1 object shape with:

- bundled channel `whatsapp`;
- no `channels.whatsapp` configuration;
- an explicit `default` account suffix;
- properly formatted fictional E.164 allowlist entries.

It verifies that:

- no unresolved warning is emitted;
- all entries are stored in SQLite under `whatsapp/default`;
- the migration reports success; and
- the legacy source file is removed.

A negative regression test creates
`custom-channel-default-allowFrom.json` for an external configured channel with
no configured account. It verifies that the migration remains unresolved,
leaves the source file in place, and writes no SQLite allowlist.

Executed locally:

- `node scripts/run-vitest.mjs src/infra/state-migrations.channel-pairing.test.ts`
  — 6 tests passed;
- targeted `oxlint` for both changed files;
- `pnpm format` for both changed files; and
- `git diff --check`.

The full changed TypeScript/lint fan-out is left to PR CI because the configured
Blacksmith Testbox tooling is unavailable on this host.

AI-assisted: implemented and manually reviewed with Codex. No agent transcript
is attached.
