### PR TITLE
improve: tighten more async test polling

### DIFF
--- a/test/clawrouter-managed-gateway.e2e.test.ts
+++ b/test/clawrouter-managed-gateway.e2e.test.ts
@@ -227,7 +227,8 @@ async function waitForGatewayReadiness(
   instance: OpenClawTestInstance,
 ): Promise<{ ready: boolean; failing: string[] }> {
   const url = `http://127.0.0.1:${instance.port}/readyz`;
-  for (let attempt = 0; attempt < 200; attempt += 1) {
+  // Preserve the 10-second readiness budget while detecting startup sooner.
+  for (let attempt = 0; attempt < 1_000; attempt += 1) {
     try {
       const response = await fetch(url);
       if (response.ok) {
@@ -236,7 +237,7 @@ async function waitForGatewayReadiness(
     } catch {
       // The listener can open before startup readiness settles.
     }
-    await delay(50);
+    await delay(10);
   }
   throw new Error(`gateway did not become ready: ${instance.logs()}`);
 }

--- a/test/scripts/clawhub-fixture-server.test.ts
+++ b/test/scripts/clawhub-fixture-server.test.ts
@@ -56,7 +56,8 @@ async function startFixtureServer(profile: string) {
   const readStderr = collectStream(child.stderr);
   servers.push(child);
 
-  for (let attempt = 0; attempt < 100; attempt += 1) {
+  // Preserve the 2.5-second startup budget while detecting the port file sooner.
+  for (let attempt = 0; attempt < 500; attempt += 1) {
     if (existsSync(portFile)) {
       const port = Number(readFileSync(portFile, "utf8"));
       if (Number.isInteger(port) && port > 0) {
@@ -66,7 +67,7 @@ async function startFixtureServer(profile: string) {
     if (child.exitCode !== null) {
       throw new Error(`fixture server exited early: stdout=${readStdout()} stderr=${readStderr()}`);
     }
-    await delay(25);
+    await delay(5);
   }
 
   throw new Error(`fixture server did not write a port: stderr=${readStderr()}`);

--- a/test/scripts/e2e-temp-state-dir.test.ts
+++ b/test/scripts/e2e-temp-state-dir.test.ts
@@ -17,11 +17,12 @@ import { describe, expect, it } from "vitest";
 import { createE2eStateDir } from "../../scripts/e2e/lib/temp-state-dir.ts";
 
 async function waitForFile(filePath: string) {
-  for (let attempt = 0; attempt < 100; attempt += 1) {
+  // Preserve the 2-second file budget while detecting child readiness sooner.
+  for (let attempt = 0; attempt < 400; attempt += 1) {
     if (existsSync(filePath)) {
       return;
     }
-    await delay(20);
+    await delay(5);
   }
   throw new Error(`Timed out waiting for ${filePath}`);
 }

--- a/test/scripts/openclaw-cross-os-release-checks.test.ts
+++ b/test/scripts/openclaw-cross-os-release-checks.test.ts
@@ -119,7 +119,7 @@ async function waitForFile(filePath: string, timeoutMs: number): Promise<void> {
     if (existsSync(filePath)) {
       return;
     }
-    await delay(25);
+    await delay(5);
   }
   throw new Error(`timeout waiting for ${filePath}`);
 }
@@ -130,7 +130,7 @@ async function waitForDead(pid: number, timeoutMs: number): Promise<void> {
     if (!isProcessAlive(pid)) {
       return;
     }
-    await delay(25);
+    await delay(5);
   }
   throw new Error(`process still alive: ${pid}`);
 }
@@ -1704,11 +1704,12 @@ describe("scripts/openclaw-cross-os-release-checks", () => {
     await new Promise<void>((resolvePromise) => {
       server.close(() => resolvePromise());
     });
-    for (let attempt = 0; attempt < 20; attempt += 1) {
+    // Preserve the 500 ms close budget while detecting port release sooner.
+    for (let attempt = 0; attempt < 100; attempt += 1) {
       if (!(await canConnectToLoopbackPort(port, 100))) {
         return;
       }
-      await delay(25);
+      await delay(5);
     }
     expect(await canConnectToLoopbackPort(port, 100)).toBe(false);
   });

--- a/test/scripts/parallels-npm-update-smoke.test.ts
+++ b/test/scripts/parallels-npm-update-smoke.test.ts
@@ -55,7 +55,7 @@ async function waitForDead(pid: number, timeoutMs: number): Promise<void> {
       return;
     }
     await new Promise((resolve) => {
-      setTimeout(resolve, 20);
+      setTimeout(resolve, 5);
     });
   }
   throw new Error(`timeout waiting for pid ${pid} to exit`);
@@ -68,7 +68,7 @@ async function waitFor(predicate: () => boolean, label: string, timeoutMs = 2_00
       return;
     }
     await new Promise((resolve) => {
-      setTimeout(resolve, 20);
+      setTimeout(resolve, 5);
     });
   }
   throw new Error(`timeout waiting for ${label}`);

--- a/test/scripts/parallels-smoke-model.test.ts
+++ b/test/scripts/parallels-smoke-model.test.ts
@@ -214,7 +214,7 @@ async function waitFor(predicate: () => boolean, timeoutMs = 3_000): Promise<voi
     if (predicate()) {
       return;
     }
-    await delay(25);
+    await delay(5);
   }
   throw new Error("condition was not met before timeout");
 }

--- a/test/scripts/plugin-gateway-gauntlet.test.ts
+++ b/test/scripts/plugin-gateway-gauntlet.test.ts
@@ -89,7 +89,7 @@ describe("plugin gateway gauntlet helpers", () => {
       if (await predicate()) {
         return;
       }
-      await delay(25);
+      await delay(5);
     }
     throw new Error("condition was not met before timeout");
   }

--- a/test/scripts/plugin-lifecycle-measure.test.ts
+++ b/test/scripts/plugin-lifecycle-measure.test.ts
@@ -48,7 +48,7 @@ function waitForPidExit(pid: number, timeoutMs: number): boolean {
     if (!pidExists(pid)) {
       return true;
     }
-    Atomics.wait(waitView, 0, 0, 25);
+    Atomics.wait(waitView, 0, 0, 5);
   }
   return !pidExists(pid);
 }
@@ -61,7 +61,7 @@ function waitForPath(filePath: string, timeoutMs: number): boolean {
     if (existsSync(filePath)) {
       return true;
     }
-    Atomics.wait(waitView, 0, 0, 25);
+    Atomics.wait(waitView, 0, 0, 5);
   }
   return existsSync(filePath);
 }

--- a/test/scripts/prepare-extension-package-boundary-artifacts.test.ts
+++ b/test/scripts/prepare-extension-package-boundary-artifacts.test.ts
@@ -58,7 +58,7 @@ async function waitForFile(filePath: string, timeoutMs: number): Promise<string>
     } catch {
       // Not created yet.
     }
-    await delay(25);
+    await delay(5);
   }
   throw new Error(`Timed out waiting for ${filePath}`);
 }
@@ -81,7 +81,7 @@ async function waitForDead(pid: number, timeoutMs: number) {
     if (!isProcessAlive(pid)) {
       return;
     }
-    await delay(25);
+    await delay(5);
   }
   throw new Error(`Process ${pid} was still alive after ${timeoutMs}ms`);
 }

--- a/test/scripts/resolve-openclaw-package-candidate.test.ts
+++ b/test/scripts/resolve-openclaw-package-candidate.test.ts
@@ -68,7 +68,7 @@ async function waitForFile(filePath: string, timeoutMs: number): Promise<void> {
     if (existsSync(filePath)) {
       return;
     }
-    await sleep(25);
+    await sleep(5);
   }
   throw new Error(`timeout waiting for ${filePath}`);
 }
@@ -79,7 +79,7 @@ async function waitForDead(pid: number, timeoutMs: number): Promise<void> {
     if (!isProcessAlive(pid)) {
       return;
     }
-    await sleep(25);
+    await sleep(5);
   }
   throw new Error(`process still alive: ${pid}`);
 }

--- a/test/scripts/run-oxlint.test.ts
+++ b/test/scripts/run-oxlint.test.ts
@@ -33,7 +33,7 @@ async function waitFor(predicate: () => boolean, timeoutMs: number): Promise<voi
       return;
     }
     await new Promise((resolvePoll) => {
-      setTimeout(resolvePoll, 25);
+      setTimeout(resolvePoll, 5);
     });
   }
   throw new Error("condition was not met before timeout");

--- a/test/scripts/run-vitest.test.ts
+++ b/test/scripts/run-vitest.test.ts
@@ -1016,7 +1016,7 @@ async function waitFor(condition: () => boolean, timeoutMs = 3_000) {
     if (Date.now() - startedAt > timeoutMs) {
       throw new Error("timed out waiting for condition");
     }
-    await delay(25);
+    await delay(5);
   }
 }
 

--- a/test/scripts/test-extension.test.ts
+++ b/test/scripts/test-extension.test.ts
@@ -993,7 +993,7 @@ async function waitFor(condition: () => boolean, timeoutMs = 3_000): Promise<voi
     if (Date.now() - startedAt > timeoutMs) {
       throw new Error("timed out waiting for condition");
     }
-    await delay(25);
+    await delay(5);
   }
 }
 

--- a/test/scripts/test-live-shard.test.ts
+++ b/test/scripts/test-live-shard.test.ts
@@ -568,7 +568,7 @@ async function waitFor(condition: () => boolean, timeoutMs: number): Promise<voi
     if (Date.now() - startedAt > timeoutMs) {
       throw new Error("timed out waiting for condition");
     }
-    await delay(25);
+    await delay(5);
   }
 }
 

--- a/test/scripts/test-live.test.ts
+++ b/test/scripts/test-live.test.ts
@@ -249,7 +249,7 @@ async function waitFor(condition: () => boolean, timeoutMs = 3_000) {
     if (Date.now() - startedAt > timeoutMs) {
       throw new Error("timed out waiting for condition");
     }
-    await delay(25);
+    await delay(5);
   }
 }
 


### PR DESCRIPTION
## What Problem This Solves

Test helpers polling asynchronous subprocess, file, port, and readiness state can wait up to 25–50 ms after the expected condition has already become true. Across local and CI runs, that adds avoidable idle latency.

## Why This Change Was Made

Tightens polling intervals to 5–10 ms across 15 independent test helpers. Fixed-attempt loops increase their attempt counts proportionally, preserving their existing 500 ms–10 second timeout budgets; deadline-based loops keep their existing deadlines.

## User Impact

No user-visible runtime impact. Maintainer test feedback can arrive sooner, without reducing slow-machine tolerance.

## Evidence

- Blacksmith Testbox `tbx_01kxkpthjgek8qz42qzwq89gf9`: 15 focused files, 628 tests passed across tooling and gateway E2E shards.
- Same Testbox: `pnpm check:changed` passed (format, test-root types, lint, and repository guards).
- Warmed tooling-only comparison remained noise-bound: 23.88 s before versus 25.69 s after. No aggregate speed claim is inferred from that sample; the bounded improvement is reduced condition-detection latency (worst case 25–50 ms to 5–10 ms).
- Fresh autoreview: no findings, correctness confidence 0.98.
