### PR TITLE
fix(diagnostics): prevent heartbeat stalls from aborting healthy runs

### DIFF
--- a/src/logging/diagnostic.test.ts
+++ b/src/logging/diagnostic.test.ts
@@ -456,6 +456,68 @@ describe("stuck session diagnostics threshold", () => {
     );
   });
 
+  it("defers active-run recovery when heartbeat delay reaches a lower abort threshold", () => {
+    const recoverStuckSession = vi.fn();
+    const warnSpy = vi.spyOn(diagnosticLogger, "warn").mockImplementation(() => undefined);
+
+    vi.setSystemTime(0);
+    startDiagnosticHeartbeat(
+      {
+        diagnostics: {
+          enabled: true,
+          stuckSessionWarnMs: 1_000,
+          stuckSessionAbortMs: 45_000,
+        },
+      },
+      { recoverStuckSession },
+    );
+    logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
+    markDiagnosticEmbeddedRunStarted({ sessionId: "s1", sessionKey: "main" });
+
+    vi.setSystemTime(15_000);
+    vi.advanceTimersByTime(30_000);
+
+    expectLoggerMessageContaining(warnSpy, "liveness heartbeat delayed");
+    expect(recoverStuckSession).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(30_000);
+
+    expectRecoveryCall(
+      recoverStuckSession,
+      { sessionId: "s1", sessionKey: "main", queueDepth: 0, allowActiveAbort: true },
+      ["ageMs", "stateGeneration"],
+    );
+  });
+
+  it("still recovers on an ordinary heartbeat with scheduling jitter", () => {
+    const recoverStuckSession = vi.fn();
+    const warnSpy = vi.spyOn(diagnosticLogger, "warn").mockImplementation(() => undefined);
+
+    vi.setSystemTime(0);
+    startDiagnosticHeartbeat(
+      {
+        diagnostics: {
+          enabled: true,
+          stuckSessionWarnMs: 1_000,
+          stuckSessionAbortMs: 1_000,
+        },
+      },
+      { recoverStuckSession },
+    );
+    logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
+    markDiagnosticEmbeddedRunStarted({ sessionId: "s1", sessionKey: "main" });
+
+    vi.setSystemTime(1);
+    vi.advanceTimersByTime(30_000);
+
+    expectNoLoggerMessageContaining(warnSpy, "liveness heartbeat delayed");
+    expectRecoveryCall(
+      recoverStuckSession,
+      { sessionId: "s1", sessionKey: "main", queueDepth: 0, allowActiveAbort: true },
+      ["ageMs", "stateGeneration"],
+    );
+  });
+
   it("does not warn while a processing session continues reporting progress", () => {
     const events: DiagnosticEventPayload[] = [];
     const unsubscribe = onDiagnosticEvent((event) => {

--- a/src/logging/diagnostic.test.ts
+++ b/src/logging/diagnostic.test.ts
@@ -456,7 +456,84 @@ describe("stuck session diagnostics threshold", () => {
     );
   });
 
-  it("defers active-run recovery when heartbeat delay reaches a lower abort threshold", () => {
+  it.each([
+    { stuckSessionAbortMs: 1_000, heartbeatOverdueMs: 1_000 },
+    { stuckSessionAbortMs: 30_000, heartbeatOverdueMs: 1_000 },
+    { stuckSessionAbortMs: 31_000, heartbeatOverdueMs: 1_000 },
+    { stuckSessionAbortMs: 45_000, heartbeatOverdueMs: 15_000 },
+    { stuckSessionAbortMs: 89_000, heartbeatOverdueMs: 59_000 },
+  ])(
+    "defers a liveness-delayed heartbeat with a $stuckSessionAbortMs ms abort threshold",
+    ({ stuckSessionAbortMs, heartbeatOverdueMs }) => {
+      const recoverStuckSession = vi.fn();
+      const warnSpy = vi.spyOn(diagnosticLogger, "warn").mockImplementation(() => undefined);
+
+      vi.setSystemTime(0);
+      startDiagnosticHeartbeat(
+        {
+          diagnostics: {
+            enabled: true,
+            stuckSessionWarnMs: 1_000,
+            stuckSessionAbortMs,
+          },
+        },
+        { recoverStuckSession },
+      );
+      logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
+      markDiagnosticEmbeddedRunStarted({ sessionId: "s1", sessionKey: "main" });
+
+      vi.setSystemTime(heartbeatOverdueMs);
+      vi.advanceTimersByTime(30_000);
+
+      expectLoggerMessageContaining(warnSpy, "liveness heartbeat delayed");
+      expect(recoverStuckSession).not.toHaveBeenCalled();
+
+      vi.advanceTimersByTime(30_000);
+
+      expectRecoveryCall(
+        recoverStuckSession,
+        { sessionId: "s1", sessionKey: "main", queueDepth: 0, allowActiveAbort: true },
+        ["ageMs", "stateGeneration"],
+      );
+    },
+  );
+
+  it.each([
+    { stuckSessionAbortMs: 1_000, schedulingJitterMs: 1 },
+    { stuckSessionAbortMs: 30_000, schedulingJitterMs: 999 },
+  ])(
+    "recovers at a $stuckSessionAbortMs ms abort threshold with ordinary scheduling jitter",
+    ({ stuckSessionAbortMs, schedulingJitterMs }) => {
+      const recoverStuckSession = vi.fn();
+      const warnSpy = vi.spyOn(diagnosticLogger, "warn").mockImplementation(() => undefined);
+
+      vi.setSystemTime(0);
+      startDiagnosticHeartbeat(
+        {
+          diagnostics: {
+            enabled: true,
+            stuckSessionWarnMs: 1_000,
+            stuckSessionAbortMs,
+          },
+        },
+        { recoverStuckSession },
+      );
+      logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
+      markDiagnosticEmbeddedRunStarted({ sessionId: "s1", sessionKey: "main" });
+
+      vi.setSystemTime(schedulingJitterMs);
+      vi.advanceTimersByTime(30_000);
+
+      expectNoLoggerMessageContaining(warnSpy, "liveness heartbeat delayed");
+      expectRecoveryCall(
+        recoverStuckSession,
+        { sessionId: "s1", sessionKey: "main", queueDepth: 0, allowActiveAbort: true },
+        ["ageMs", "stateGeneration"],
+      );
+    },
+  );
+
+  it("defers a material heartbeat stall even when elapsed time is below the abort threshold", () => {
     const recoverStuckSession = vi.fn();
     const warnSpy = vi.spyOn(diagnosticLogger, "warn").mockImplementation(() => undefined);
 
@@ -474,7 +551,16 @@ describe("stuck session diagnostics threshold", () => {
     logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
     markDiagnosticEmbeddedRunStarted({ sessionId: "s1", sessionKey: "main" });
 
-    vi.setSystemTime(15_000);
+    vi.advanceTimersByTime(20_000);
+    markDiagnosticSessionProgress({ sessionId: "s1", sessionKey: "main" });
+    markDiagnosticRunProgressForTest({
+      sessionId: "s1",
+      sessionKey: "main",
+      reason: "embedded_run:progress",
+    });
+    vi.advanceTimersByTime(10_000);
+
+    vi.setSystemTime(35_000);
     vi.advanceTimersByTime(30_000);
 
     expectLoggerMessageContaining(warnSpy, "liveness heartbeat delayed");
@@ -489,7 +575,7 @@ describe("stuck session diagnostics threshold", () => {
     );
   });
 
-  it("still recovers on an ordinary heartbeat with scheduling jitter", () => {
+  it("does not let ordinary heartbeat jitter consume the remaining abort budget", () => {
     const recoverStuckSession = vi.fn();
     const warnSpy = vi.spyOn(diagnosticLogger, "warn").mockImplementation(() => undefined);
 
@@ -499,7 +585,7 @@ describe("stuck session diagnostics threshold", () => {
         diagnostics: {
           enabled: true,
           stuckSessionWarnMs: 1_000,
-          stuckSessionAbortMs: 1_000,
+          stuckSessionAbortMs: 45_000,
         },
       },
       { recoverStuckSession },
@@ -507,10 +593,23 @@ describe("stuck session diagnostics threshold", () => {
     logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
     markDiagnosticEmbeddedRunStarted({ sessionId: "s1", sessionKey: "main" });
 
-    vi.setSystemTime(1);
+    vi.advanceTimersByTime(15_500);
+    markDiagnosticSessionProgress({ sessionId: "s1", sessionKey: "main" });
+    markDiagnosticRunProgressForTest({
+      sessionId: "s1",
+      sessionKey: "main",
+      reason: "embedded_run:progress",
+    });
+    vi.advanceTimersByTime(14_500);
+
+    vi.setSystemTime(30_999);
     vi.advanceTimersByTime(30_000);
 
     expectNoLoggerMessageContaining(warnSpy, "liveness heartbeat delayed");
+    expect(recoverStuckSession).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(30_000);
+
     expectRecoveryCall(
       recoverStuckSession,
       { sessionId: "s1", sessionKey: "main", queueDepth: 0, allowActiveAbort: true },

--- a/src/logging/diagnostic.ts
+++ b/src/logging/diagnostic.ts
@@ -509,6 +509,17 @@ function resolveStalledEmbeddedRunAbortMs(stuckSessionWarnMs: number): number {
   );
 }
 
+function resolveDiagnosticRecoverySkipHeartbeatDelayMs(stuckSessionAbortMs: number): number {
+  // setInterval callbacks normally arrive a little late. Reuse the liveness
+  // delay budget so ordinary jitter cannot suppress recovery indefinitely.
+  const jitterTolerantHeartbeatMs =
+    DIAGNOSTIC_HEARTBEAT_INTERVAL_MS + DEFAULT_LIVENESS_EVENT_LOOP_DELAY_WARN_MS;
+  return Math.min(
+    DIAGNOSTIC_HEARTBEAT_DELAY_RECOVERY_SKIP_MS,
+    Math.max(jitterTolerantHeartbeatMs, stuckSessionAbortMs),
+  );
+}
+
 function isStalledEmbeddedRunRecoveryEligible(params: {
   classification: SessionAttentionClassification | undefined;
   activity?: DiagnosticSessionActivitySnapshot;
@@ -1241,8 +1252,10 @@ export function startDiagnosticHeartbeat(
       lastDiagnosticHeartbeatTickAt === undefined ? 0 : now - lastDiagnosticHeartbeatTickAt;
     lastDiagnosticHeartbeatTickAt = now;
     // A late interval tick means the process was stalled, not the sessions.
-    // Acting on inflated ages here can abort healthy runs; the next on-time tick decides.
-    const skipRecoveryThisTick = tickDelayMs > DIAGNOSTIC_HEARTBEAT_DELAY_RECOVERY_SKIP_MS;
+    // Scale the guard down for low abort thresholds, then let an on-time tick decide.
+    const recoverySkipHeartbeatDelayMs =
+      resolveDiagnosticRecoverySkipHeartbeatDelayMs(stuckSessionAbortMs);
+    const skipRecoveryThisTick = tickDelayMs >= recoverySkipHeartbeatDelayMs;
     if (skipRecoveryThisTick) {
       diag.warn(
         `liveness heartbeat delayed ${Math.round(tickDelayMs)}ms; deferring recovery decisions`,

--- a/src/logging/diagnostic.ts
+++ b/src/logging/diagnostic.ts
@@ -89,7 +89,6 @@ const DEFAULT_LIVENESS_EVENT_LOOP_UTILIZATION_WARN = 0.95;
 const DEFAULT_LIVENESS_CPU_CORE_RATIO_WARN = 0.9;
 const DEFAULT_LIVENESS_WARN_COOLDOWN_MS = 120_000;
 const DIAGNOSTIC_HEARTBEAT_INTERVAL_MS = 30_000;
-const DIAGNOSTIC_HEARTBEAT_DELAY_RECOVERY_SKIP_MS = 3 * DIAGNOSTIC_HEARTBEAT_INTERVAL_MS;
 const loadStuckSessionRecoveryRuntime = createLazyRuntimeModule(
   () => import("./diagnostic-stuck-session-recovery.runtime.js"),
 );
@@ -506,17 +505,6 @@ function resolveStalledEmbeddedRunAbortMs(stuckSessionWarnMs: number): number {
   return Math.max(
     MIN_STALLED_EMBEDDED_RUN_ABORT_MS,
     stuckSessionWarnMs * STALLED_EMBEDDED_RUN_ABORT_WARN_MULTIPLIER,
-  );
-}
-
-function resolveDiagnosticRecoverySkipHeartbeatDelayMs(stuckSessionAbortMs: number): number {
-  // setInterval callbacks normally arrive a little late. Reuse the liveness
-  // delay budget so ordinary jitter cannot suppress recovery indefinitely.
-  const jitterTolerantHeartbeatMs =
-    DIAGNOSTIC_HEARTBEAT_INTERVAL_MS + DEFAULT_LIVENESS_EVENT_LOOP_DELAY_WARN_MS;
-  return Math.min(
-    DIAGNOSTIC_HEARTBEAT_DELAY_RECOVERY_SKIP_MS,
-    Math.max(jitterTolerantHeartbeatMs, stuckSessionAbortMs),
   );
 }
 
@@ -1248,17 +1236,18 @@ export function startDiagnosticHeartbeat(
     const stuckSessionAbortMs = resolveStuckSessionAbortMs(heartbeatConfig, stuckSessionWarnMs);
     const compactionSafetyTimeoutMs = resolveCompactionTimeoutMs(heartbeatConfig);
     const now = Date.now();
-    const tickDelayMs =
+    const heartbeatElapsedMs =
       lastDiagnosticHeartbeatTickAt === undefined ? 0 : now - lastDiagnosticHeartbeatTickAt;
     lastDiagnosticHeartbeatTickAt = now;
-    // A late interval tick means the process was stalled, not the sessions.
-    // Scale the guard down for low abort thresholds, then let an on-time tick decide.
-    const recoverySkipHeartbeatDelayMs =
-      resolveDiagnosticRecoverySkipHeartbeatDelayMs(stuckSessionAbortMs);
-    const skipRecoveryThisTick = tickDelayMs >= recoverySkipHeartbeatDelayMs;
-    if (skipRecoveryThisTick) {
+    const heartbeatOverdueMs = Math.max(0, heartbeatElapsedMs - DIAGNOSTIC_HEARTBEAT_INTERVAL_MS);
+    // Observe ordinary timer jitter at the scheduled tick so it cannot consume
+    // a run's remaining recovery budget. Material lateness can also hide queued
+    // progress events, so the next healthy heartbeat owns recovery instead.
+    const recoveryObservationNow = now - heartbeatOverdueMs;
+    const shouldDeferRecovery = heartbeatOverdueMs >= DEFAULT_LIVENESS_EVENT_LOOP_DELAY_WARN_MS;
+    if (shouldDeferRecovery) {
       diag.warn(
-        `liveness heartbeat delayed ${Math.round(tickDelayMs)}ms; deferring recovery decisions`,
+        `liveness heartbeat delayed ${Math.round(heartbeatElapsedMs)}ms; deferring recovery decisions`,
       );
     }
     pruneDiagnosticSessionStates(now, true);
@@ -1318,10 +1307,10 @@ export function startDiagnosticHeartbeat(
       });
 
     for (const [, state] of diagnosticSessionStates) {
-      const ageMs = now - state.lastActivity;
+      const ageMs = recoveryObservationNow - state.lastActivity;
       const activity = getDiagnosticSessionActivitySnapshot(
         { sessionId: state.sessionId, sessionKey: state.sessionKey },
-        now,
+        recoveryObservationNow,
       );
       const idleQueuedRecoverableStall = isIdleQueuedRecoverableSessionStall({
         state,
@@ -1343,7 +1332,7 @@ export function startDiagnosticHeartbeat(
           thresholdMs: stuckSessionWarnMs,
           abortThresholdMs: stuckSessionAbortMs,
         });
-        if (classification?.recoveryEligible && !skipRecoveryThisTick) {
+        if (classification?.recoveryEligible && !shouldDeferRecovery) {
           requestStuckSessionRecovery({
             recover: opts?.recoverStuckSession ?? recoverStuckSession,
             classification,
@@ -1361,7 +1350,7 @@ export function startDiagnosticHeartbeat(
           });
         } else if (
           classification &&
-          !skipRecoveryThisTick &&
+          !shouldDeferRecovery &&
           isActiveAbortRecoveryEligible({
             classification,
             activity,


### PR DESCRIPTION
## What Problem This Solves

Fixes #107415.

Fixes an issue where diagnostics heartbeat stalls could abort a healthy embedded run when `diagnostics.stuckSessionAbortMs` was configured below the fixed 90-second liveness guard.

## Why This Change Was Made

Recovery now evaluates sub-warning timer jitter at the scheduled heartbeat time, preventing callback phase from consuming a partly aged run's remaining abort budget. Once heartbeat lateness reaches the existing one-second event-loop warning boundary, recovery is deferred until the next healthy heartbeat because queued progress may still be hidden behind the stall.

This keeps the decision in the diagnostics heartbeat owner, adds no configuration or compatibility path, and covers the phase-alignment case that an abort-relative global cutoff misses.

## User Impact

Configured abort thresholds below 90 seconds remain effective for genuinely stalled runs without allowing observer-side event-loop stalls to abort healthy work. No public API, protocol, configuration, dependency, or storage surface changes.

## Evidence

- Configured thresholds of 1, 30, 31, 45, and 89 seconds pass focused fake-clock coverage, including a partly aged run and 999 ms ordinary jitter.
- Final Node 24 Blacksmith Testbox focused run: 83/83 passed ([run](https://github.com/openclaw/openclaw/actions/runs/29476622279)).
- Source-blind real-clock Testbox proof: a one-second threshold recovered exactly once at 30.004 seconds; an induced 45-second stall deferred recovery at 47.002 seconds and recovered exactly once on the next healthy heartbeat at 75.507 seconds ([run](https://github.com/openclaw/openclaw/actions/runs/29476730073)).
- Targeted `oxfmt`, `oxlint`, and `git diff --check` passed.
- Fresh full-branch autoreview reported no accepted or actionable findings.

AI-assisted implementation and review; the contributor remains responsible for the final diff.
