### PR TITLE
test(codex): stabilize nullable-turn watch proof on LTS

### DIFF
--- a/extensions/codex/src/app-server/run-attempt.turn-watches.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.turn-watches.test.ts
@@ -49,9 +49,7 @@ const DISABLED_CODEX_WEB_SEARCH_THREAD_CONFIG_FINGERPRINT = JSON.stringify({
   web_search: "disabled",
 });
 
-function writeCodexAppServerBinding(
-  ...args: Parameters<typeof writeRawCodexAppServerBinding>
-) {
+function writeCodexAppServerBinding(...args: Parameters<typeof writeRawCodexAppServerBinding>) {
   const [sessionFile, binding, lookup] = args;
   return writeRawCodexAppServerBinding(
     sessionFile,
@@ -704,7 +702,10 @@ describe("runCodexAppServerAttempt turn watches", () => {
     expect(harness.request.mock.calls.some(([method]) => method === "turn/interrupt")).toBe(true);
   });
 
-  it("counts handled nullable-turn elicitations as turn attempt progress", async () => {
+  it("refreshes the turn attempt watch for handled nullable-turn elicitations", async () => {
+    let nowMs = 1_000_000;
+    vi.spyOn(Date, "now").mockImplementation(() => nowMs);
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
     const harness = createStartedThreadHarness();
     vi.spyOn(elicitationBridge, "handleCodexAppServerElicitationRequest").mockResolvedValue({
       action: "accept",
@@ -715,7 +716,7 @@ describe("runCodexAppServerAttempt turn watches", () => {
       path.join(tempDir, "session.jsonl"),
       path.join(tempDir, "workspace"),
     );
-    params.timeoutMs = 100;
+    params.timeoutMs = 10_000;
     const onRunProgress = vi.fn();
     params.onRunProgress = onRunProgress;
 
@@ -732,10 +733,14 @@ describe("runCodexAppServerAttempt turn watches", () => {
         ),
       fastWait,
     );
+    const initialAttemptWatch = setTimeoutSpy.mock.calls.find(
+      ([callback]) => typeof callback === "function" && callback.name === "fireAttemptIdleTimeout",
+    )?.[0];
+    if (typeof initialAttemptWatch !== "function") {
+      throw new Error("Expected the initial turn attempt watch timer");
+    }
+    nowMs += 6_000;
 
-    await new Promise((resolve) => {
-      setTimeout(resolve, 60);
-    });
     await harness.handleServerRequest({
       id: "request-null-turn-elicitation",
       method: "mcpServer/elicitation/request",
@@ -749,9 +754,15 @@ describe("runCodexAppServerAttempt turn watches", () => {
         _meta: null,
       },
     });
-    await new Promise((resolve) => {
-      setTimeout(resolve, 60);
-    });
+    await vi.waitFor(
+      () =>
+        expect(onRunProgress).toHaveBeenCalledWith(
+          expect.objectContaining({ reason: "request:mcpServer/elicitation/request:start" }),
+        ),
+      fastWait,
+    );
+    nowMs += 6_000;
+    initialAttemptWatch();
 
     expect(harness.request.mock.calls.some(([method]) => method === "turn/interrupt")).toBe(false);
     await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });


### PR DESCRIPTION
## What Problem This Solves

The `extended-stable/2026.6.33` Plugin Prerelease lane intermittently failed `run-attempt.turn-watches.test.ts`. The test slept twice for 60 ms around a 100 ms watchdog, so loaded runners could fire the watchdog before the nullable-turn elicitation refreshed progress.

Backport of the test fix landed on main in #108420.

## Why This Change Was Made

The test now controls `Date.now`, captures the original attempt-idle callback, advances beyond its old deadline, and directly invokes it. This proves that a handled nullable-turn elicitation moved the watchdog deadline forward without depending on wall-clock scheduling.

The production path is unchanged. The upstream Codex protocol intentionally permits a nullable elicitation `turnId`.

## User Impact

No runtime behavior change. LTS release validation becomes deterministic while retaining the original watchdog-reset regression proof.

## Evidence

- Exact LTS base: `bc276f2858c1529baee5340149b086783c1f8538`.
- Trusted LTS Testbox: 65/65 Codex turn-watch tests passed: https://github.com/openclaw/openclaw/actions/runs/29448309870
- `git diff --check`: passed.
- Fresh release-branch autoreview: no accepted/actionable findings.

No changelog entry: test-only backport.
