### PR TITLE
fix(openai-responses): reconcile terminal tool calls

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -1545,7 +1545,7 @@ packages/ai/src/transports/openai-responses-payload-policy.ts	3
 packages/ai/src/transports/openai-responses-prompt-observer-internal.ts	2
 packages/ai/src/transports/openai-responses-replay-internal.ts	11
 packages/ai/src/transports/openai-responses-replay-messages-internal.ts	15
-packages/ai/src/transports/openai-responses-stream-internal.ts	3
+packages/ai/src/transports/openai-responses-stream-internal.ts	2
 packages/ai/src/transports/openai-responses-stream-observer-internal.ts	1
 packages/ai/src/transports/openai-responses-stream-slots-internal.ts	2
 packages/ai/src/transports/openai-responses-stream-terminal-internal.ts	2

--- a/packages/ai/src/providers/openai-responses-shared.test.ts
+++ b/packages/ai/src/providers/openai-responses-shared.test.ts
@@ -2065,10 +2065,12 @@ describe("processResponsesStream", () => {
         responseEvents([
           {
             type: "response.output_item.added",
+            output_index: 0,
             item: { type: "function_call", name: "computer", arguments: "" },
           },
           {
             type: "response.output_item.done",
+            output_index: 0,
             item: { type: "function_call", name: "computer", arguments: "{}" },
           },
           { type: "response.completed", response: { id: "resp_idless", status: "completed" } },

--- a/packages/ai/src/providers/openai-responses-shared.test.ts
+++ b/packages/ai/src/providers/openai-responses-shared.test.ts
@@ -2473,7 +2473,7 @@ describe("processResponsesStream", () => {
         stream,
         nativeOpenAIModel,
       ),
-    ).rejects.toThrow("Responses stream completed with unresolved tool calls");
+    ).rejects.toThrow("Responses stream changed output item identity");
     expect(events.map((event) => event.type)).toEqual(["toolcall_start", "toolcall_delta"]);
   });
 

--- a/packages/ai/src/providers/openai-responses-tool-call-tracker.ts
+++ b/packages/ai/src/providers/openai-responses-tool-call-tracker.ts
@@ -58,10 +58,13 @@ export function createResponsesToolCallTracker<TState extends ResponsesToolCallS
   const resolveCompatible = (
     candidates: Iterable<TState>,
     identity: ResponsesToolCallIdentity,
+    allowUnmatchedIdentity: boolean,
   ): TState | undefined => {
     const uniqueCandidates = [...new Set(candidates)];
     if (!identity.itemId && !identity.callId) {
-      return uniqueCandidates.length === 1 ? uniqueCandidates.at(0) : undefined;
+      return allowUnmatchedIdentity && uniqueCandidates.length === 1
+        ? uniqueCandidates.at(0)
+        : undefined;
     }
     const compatible = uniqueCandidates.filter((state) => !identitiesConflict(state, identity));
     const matches = compatible.filter((state) => sharesIdentity(state, identity));
@@ -73,7 +76,10 @@ export function createResponsesToolCallTracker<TState extends ResponsesToolCallS
     // Only a sole active call may adopt an identity it did not already know.
     // Parallel calls require a positive match so missing indices stay fail-closed.
     const soleCompatible =
-      uniqueCandidates.length === 1 && compatible.length === 1 && matches.length === 0
+      allowUnmatchedIdentity &&
+      uniqueCandidates.length === 1 &&
+      compatible.length === 1 &&
+      matches.length === 0
         ? compatible.at(0)
         : undefined;
     return soleCompatible ? adoptIdentity(soleCompatible, identity) : undefined;
@@ -95,6 +101,7 @@ export function createResponsesToolCallTracker<TState extends ResponsesToolCallS
     resolve(
       event: ResponsesToolCallEvent,
       identity: ResponsesToolCallIdentity = readEventIdentity(event),
+      allowUnmatchedIdentity = true,
     ): TState | undefined {
       const outputIndex = readOutputIndex(event);
       if (outputIndex !== undefined) {
@@ -110,7 +117,7 @@ export function createResponsesToolCallTracker<TState extends ResponsesToolCallS
 
         // A compatibility stream may add calls without indices, then start
         // including them. Bind only the one identity-matched (or sole) candidate.
-        const unindexed = resolveCompatible(unindexedCalls, identity);
+        const unindexed = resolveCompatible(unindexedCalls, identity, allowUnmatchedIdentity);
         if (unindexed) {
           unindexedCalls.delete(unindexed);
           indexedCalls.set(outputIndex, unindexed);
@@ -118,7 +125,11 @@ export function createResponsesToolCallTracker<TState extends ResponsesToolCallS
         return unindexed;
       }
 
-      return resolveCompatible([...indexedCalls.values(), ...unindexedCalls], identity);
+      return resolveCompatible(
+        [...indexedCalls.values(), ...unindexedCalls],
+        identity,
+        allowUnmatchedIdentity,
+      );
     },
 
     forget(toolCall: TState): void {
@@ -140,6 +151,11 @@ export function createResponsesToolCallTracker<TState extends ResponsesToolCallS
 
     hasActive(): boolean {
       return indexedCalls.size > 0 || unindexedCalls.size > 0;
+    },
+
+    hasExactlyActive(expected: readonly TState[]): boolean {
+      const active = new Set([...indexedCalls.values(), ...unindexedCalls]);
+      return active.size === expected.length && expected.every((state) => active.has(state));
     },
   };
 }

--- a/packages/ai/src/providers/openai-responses-tool-call-tracker.ts
+++ b/packages/ai/src/providers/openai-responses-tool-call-tracker.ts
@@ -4,6 +4,7 @@ export type ResponsesToolCallIdentity = { itemId?: string; callId?: string };
 
 export type ResponsesToolCallState = ResponsesToolCallIdentity & {
   argumentStreamReliable: boolean;
+  outputIndex?: number;
 };
 
 type ResponsesToolCallEvent = {
@@ -95,6 +96,7 @@ export function createResponsesToolCallTracker<TState extends ResponsesToolCallS
       if (indexedCalls.has(outputIndex)) {
         throw new Error(`Responses stream reused active tool-call output index ${outputIndex}`);
       }
+      state.outputIndex = outputIndex;
       indexedCalls.set(outputIndex, state);
     },
 
@@ -120,6 +122,7 @@ export function createResponsesToolCallTracker<TState extends ResponsesToolCallS
         const unindexed = resolveCompatible(unindexedCalls, identity, allowUnmatchedIdentity);
         if (unindexed) {
           unindexedCalls.delete(unindexed);
+          unindexed.outputIndex = outputIndex;
           indexedCalls.set(outputIndex, unindexed);
         }
         return unindexed;

--- a/packages/ai/src/transports/openai-responses-stream-internal.ts
+++ b/packages/ai/src/transports/openai-responses-stream-internal.ts
@@ -195,6 +195,20 @@ export async function processResponsesStream<TApi extends Api>(
     streamingToolCall: StreamingToolCallState | undefined,
     validated: Pick<ToolCall, "name" | "arguments">,
   ): void => {
+    const identity = {
+      type: item.type,
+      id: item.id || streamingToolCall?.itemId,
+      call_id: item.call_id || streamingToolCall?.callId,
+    };
+    const finalOutputIndex = outputIndex ?? streamingToolCall?.outputIndex;
+    // A wholly anonymous, unindexed done event cannot be deduplicated. Keep
+    // its active owner until the terminal snapshot supplies an output position.
+    if (finalOutputIndex === undefined && !identity.id && !identity.call_id) {
+      if (!streamingToolCall) {
+        throw new Error("Responses stream completed tool call without an output identity");
+      }
+      return;
+    }
     if (streamingToolCall) {
       streamingToolCalls.forget(streamingToolCall);
       for (const slot of outputSlots.values()) {
@@ -203,7 +217,7 @@ export async function processResponsesStream<TApi extends Api>(
         }
       }
     }
-    terminal.emitToolCallCompletion(item, outputIndex, streamingToolCall, validated);
+    terminal.emitToolCallCompletion(identity, finalOutputIndex, streamingToolCall, validated);
   };
   const prepareTerminalToolCalls = (items: ResponseOutputItem[]) => {
     const prepared = new Map<number, () => void>();
@@ -627,7 +641,6 @@ export async function processResponsesStream<TApi extends Api>(
           if (!streamingToolCall && streamingToolCalls.hasActive()) {
             continue;
           }
-          const streamedArguments = streamingToolCall?.block.partialJson ?? "";
           const completedArguments =
             typeof item.arguments === "string" ? item.arguments : undefined;
           if (
@@ -637,14 +650,9 @@ export async function processResponsesStream<TApi extends Api>(
           ) {
             continue;
           }
-          const finalArguments =
-            completedArguments !== undefined &&
-            (completedArguments.length > 0 || !streamedArguments)
-              ? completedArguments
-              : streamedArguments;
           const validated = resolveCompletedResponsesToolCall(item, {
             name: streamingToolCall?.block.name,
-            arguments: finalArguments,
+            arguments: completedArguments || streamingToolCall?.block.partialJson || "",
           });
 
           finalizeToolCall(item, readResponsesOutputIndex(event), streamingToolCall, validated);

--- a/packages/ai/src/transports/openai-responses-stream-internal.ts
+++ b/packages/ai/src/transports/openai-responses-stream-internal.ts
@@ -56,6 +56,7 @@ export async function processResponsesStream<TApi extends Api>(
   model: Model<TApi>,
   options?: ResponsesStreamOptions,
 ) {
+  type CompletedToolCall = Extract<ResponseOutputItem, { type: "function_call" }>;
   type StreamingToolCallBlock = ToolCall & { partialJson: string };
   type StreamingToolCallState = ResponsesToolCallState & {
     block: StreamingToolCallBlock;
@@ -176,19 +177,85 @@ export async function processResponsesStream<TApi extends Api>(
       }
     }
   };
-  const { finalizeResponse, finalizeFailedResponse, recoverTerminalOutput } =
-    createResponsesTerminalController({
-      output,
-      stream,
-      model,
-      options,
-      outputs,
-      getLastTextBlock: () => lastTextBlock,
-      setLastTextBlock: (block) => {
-        lastTextBlock = block;
-      },
-      markFinalized: () => undefined,
-    });
+  const terminal = createResponsesTerminalController({
+    output,
+    stream,
+    model,
+    options,
+    outputs,
+    getLastTextBlock: () => lastTextBlock,
+    setLastTextBlock: (block) => {
+      lastTextBlock = block;
+    },
+  });
+
+  const finalizeToolCall = (
+    item: CompletedToolCall,
+    outputIndex: number | undefined,
+    streamingToolCall: StreamingToolCallState | undefined,
+    validated: Pick<ToolCall, "name" | "arguments">,
+  ): void => {
+    if (streamingToolCall) {
+      streamingToolCalls.forget(streamingToolCall);
+      for (const slot of outputSlots.values()) {
+        if (slot.type === "toolCall" && slot.toolCall === streamingToolCall) {
+          outputSlots.forget(slot);
+        }
+      }
+    }
+    terminal.emitToolCallCompletion(item, outputIndex, streamingToolCall, validated);
+  };
+  const prepareTerminalToolCalls = (items: ResponseOutputItem[]) => {
+    const prepared = new Map<number, () => void>();
+    const recovered: StreamingToolCallState[] = [];
+    const callIds = new Set<string>();
+    const allowUnmatchedIdentity =
+      items.filter(
+        (item, index) => item.type === "function_call" && !outputs.get(item, index)?.completed,
+      ).length === 1;
+    for (const [outputIndex, item] of items.entries()) {
+      const tracked = outputs.get(item, outputIndex);
+      if (item.type !== "function_call") {
+        continue;
+      }
+      if (item.call_id && callIds.has(item.call_id)) {
+        throw new Error("Responses stream repeated a terminal tool-call identity");
+      }
+      if (item.call_id) {
+        callIds.add(item.call_id);
+      }
+      // Completed positions must be skipped before resolve can adopt an
+      // unindexed active call. The positional tracker still checks identity.
+      if (tracked?.completed) {
+        continue;
+      }
+      const state = streamingToolCalls.resolve(
+        { output_index: outputIndex },
+        readResponsesToolCallItemIdentity(item),
+        allowUnmatchedIdentity,
+      );
+      if (tracked && !state) {
+        throw new Error("Responses stream completed with unresolved tool calls");
+      }
+      const validated = resolveCompletedResponsesToolCall(item, { name: state?.block.name });
+      if (state) {
+        recovered.push(state);
+      }
+      prepared.set(outputIndex, () => finalizeToolCall(item, outputIndex, state, validated));
+    }
+    if (!streamingToolCalls.hasExactlyActive(recovered)) {
+      throw new Error("Responses stream completed with unresolved tool calls");
+    }
+    // All terminal calls and active-call coverage are validated before any
+    // toolcall_end can authorize execution; terminal ordering is checked next.
+    return (outputIndex: number) => {
+      const complete = prepared.get(outputIndex);
+      if (!complete) {
+        throw new Error("Responses stream completed with unresolved tool calls");
+      }
+      complete();
+    };
+  };
 
   const guardedStream = adaptResponsesStream(
     withFirstStreamEventTimeout(openaiStream, {
@@ -548,6 +615,9 @@ export async function processResponsesStream<TApi extends Api>(
           }
           outputSlots.forget(outputSlot);
         } else if (item.type === "function_call") {
+          if (outputs.get(item, readResponsesOutputIndex(event))?.completed) {
+            continue;
+          }
           const streamingToolCall = streamingToolCalls.resolve(
             event,
             readResponsesToolCallItemIdentity(item),
@@ -577,58 +647,18 @@ export async function processResponsesStream<TApi extends Api>(
             arguments: finalArguments,
           });
 
-          let toolCall: ToolCall;
-          let contentIndex: number;
-          if (streamingToolCall) {
-            const block = streamingToolCall.block;
-            // The SDK permits the added item to omit its item id, then supplies
-            // the canonical id on completion. Upgrade the same public block so
-            // replay and its function_call_output retain both identities.
-            block.id = resolveResponsesToolCallId(item, block.id);
-            block.name = validated.name;
-            // Finalize in-place and strip the scratch buffer so replay only
-            // carries parsed arguments.
-            block.arguments = validated.arguments;
-            delete (block as { partialJson?: string }).partialJson;
-            toolCall = block;
-            contentIndex = streamingToolCall.contentIndex;
-          } else {
-            toolCall = {
-              type: "toolCall",
-              id: resolveResponsesToolCallId(item),
-              name: validated.name,
-              arguments: validated.arguments,
-            };
-            // Some compatible streams only send the completed item. Preserve
-            // the normal balanced lifecycle and persist the call for replay.
-            blocks.push(toolCall);
-            contentIndex = blocks.length - 1;
-            stream.push({ type: "toolcall_start", contentIndex, partial: output });
-          }
-
-          if (streamingToolCall) {
-            streamingToolCalls.forget(streamingToolCall);
-            for (const slot of outputSlots.values()) {
-              if (slot.type === "toolCall" && slot.toolCall === streamingToolCall) {
-                outputSlots.forget(slot);
-              }
-            }
-          }
-          stream.push({
-            type: "toolcall_end",
-            contentIndex,
-            toolCall,
-            partial: output,
-          });
-          outputs.set(item, contentIndex, readResponsesOutputIndex(event), true);
+          finalizeToolCall(item, readResponsesOutputIndex(event), streamingToolCall, validated);
         }
       } else if (event.type === "response.completed" || event.type === "response.incomplete") {
-        if (streamingToolCalls.hasActive()) {
+        if (event.type === "response.incomplete" && streamingToolCalls.hasActive()) {
           throw new Error("Responses stream completed with unresolved tool calls");
         }
-        finalizeResponse(event.response, event.type);
+        terminal.finalizeResponse(event.response, event.type);
         if (event.type === "response.completed" || output.stopReason === "length") {
-          recoverTerminalOutput(event.response.output ?? [], event.type === "response.completed");
+          const items = event.response.output ?? [];
+          const completeToolCall =
+            event.type === "response.completed" ? prepareTerminalToolCalls(items) : undefined;
+          terminal.recoverTerminalOutput(items, completeToolCall);
         }
         terminalResponse = event.type === "response.completed" ? event.response : null;
         if (
@@ -644,7 +674,7 @@ export async function processResponsesStream<TApi extends Api>(
         );
       } else if (event.type === "response.failed") {
         const failure = normalizeResponsesFailedEvent(isRecord(event) ? event : {}, model);
-        finalizeFailedResponse(event.response, failure.responseId);
+        terminal.finalizeFailedResponse(event.response, failure.responseId);
         throw new ResponsesStreamFailure(failure, event.response);
       }
     }

--- a/packages/ai/src/transports/openai-responses-stream-slots-internal.ts
+++ b/packages/ai/src/transports/openai-responses-stream-slots-internal.ts
@@ -51,9 +51,8 @@ export function createResponsesOutputTracker() {
     if ((item.type === "reasoning" || item.type === "message") && item.id) {
       return `${item.type}:${item.id}`;
     }
-    return item.type === "function_call"
-      ? `function_call:${item.call_id ?? item.id ?? ""}`
-      : undefined;
+    const callId = item.call_id ?? item.id;
+    return item.type === "function_call" && callId ? `function_call:${callId}` : undefined;
   };
   const get = (item: ResponsesOutputIdentityItem, outputIndex?: number) => {
     const key = identity(item);

--- a/packages/ai/src/transports/openai-responses-stream-terminal-internal.ts
+++ b/packages/ai/src/transports/openai-responses-stream-terminal-internal.ts
@@ -204,7 +204,7 @@ export function createResponsesTerminalController(params: {
     return index;
   };
   const emitToolCallCompletion = (
-    item: Extract<ResponseOutputItem, { type: "function_call" }>,
+    item: { type: "function_call"; id?: string; call_id?: string },
     outputIndex: number | undefined,
     started: { block: ToolCall; contentIndex: number } | undefined,
     validated: Pick<ToolCall, "name" | "arguments">,

--- a/packages/ai/src/transports/openai-responses-stream-terminal-internal.ts
+++ b/packages/ai/src/transports/openai-responses-stream-terminal-internal.ts
@@ -212,10 +212,10 @@ export function createResponsesTerminalController(params: {
     // Complete the same public block with authoritative identities and arguments;
     // scratch JSON must never survive into transcript replay.
     const completed = { id: resolveResponsesToolCallId(item, started?.block.id), ...validated };
-    const toolCall: ToolCall = started
+    const toolCall: ToolCall & { partialJson?: string } = started
       ? Object.assign(started.block, completed)
       : { type: "toolCall", ...completed };
-    delete (toolCall as { partialJson?: string }).partialJson;
+    delete toolCall.partialJson;
     const contentIndex = started?.contentIndex ?? blocks.length;
     if (!started) {
       blocks.push(toolCall);

--- a/packages/ai/src/transports/openai-responses-stream-terminal-internal.ts
+++ b/packages/ai/src/transports/openai-responses-stream-terminal-internal.ts
@@ -113,7 +113,6 @@ export function createResponsesTerminalController(params: {
   outputs: ResponsesOutputTracker;
   getLastTextBlock: () => TextBlockReference | null;
   setLastTextBlock: (block: TextBlockReference | null) => void;
-  markFinalized: () => void;
 }) {
   const { output, stream, model, options } = params;
   const blocks = output.content;
@@ -204,21 +203,31 @@ export function createResponsesTerminalController(params: {
     stream.push({ type: "text_end", contentIndex: index, content: text, partial: output });
     return index;
   };
-  const appendToolCall = (item: Extract<ResponseOutputItem, { type: "function_call" }>): number => {
-    const validated = resolveCompletedResponsesToolCall(item);
-    const toolCall: ToolCall = {
-      type: "toolCall",
-      id: resolveResponsesToolCallId(item),
-      name: validated.name,
-      arguments: validated.arguments,
-    };
-    blocks.push(toolCall);
-    const contentIndex = blocks.length - 1;
-    stream.push({ type: "toolcall_start", contentIndex, partial: output });
+  const emitToolCallCompletion = (
+    item: Extract<ResponseOutputItem, { type: "function_call" }>,
+    outputIndex: number | undefined,
+    started: { block: ToolCall; contentIndex: number } | undefined,
+    validated: Pick<ToolCall, "name" | "arguments">,
+  ): void => {
+    // Complete the same public block with authoritative identities and arguments;
+    // scratch JSON must never survive into transcript replay.
+    const completed = { id: resolveResponsesToolCallId(item, started?.block.id), ...validated };
+    const toolCall: ToolCall = started
+      ? Object.assign(started.block, completed)
+      : { type: "toolCall", ...completed };
+    delete (toolCall as { partialJson?: string }).partialJson;
+    const contentIndex = started?.contentIndex ?? blocks.length;
+    if (!started) {
+      blocks.push(toolCall);
+      stream.push({ type: "toolcall_start", contentIndex, partial: output });
+    }
+    params.outputs.set(item, contentIndex, outputIndex, true);
     stream.push({ type: "toolcall_end", contentIndex, toolCall, partial: output });
-    return contentIndex;
   };
-  const recoverTerminalOutput = (items: ResponseOutputItem[], includeToolCalls: boolean) => {
+  const recoverTerminalOutput = (
+    items: ResponseOutputItem[],
+    completeToolCall?: (outputIndex: number) => void,
+  ) => {
     let hasCompletedLaterOutput = false;
     for (const [outputIndex, item] of [...items.entries()].toReversed()) {
       const tracked = params.outputs.get(item, outputIndex);
@@ -234,15 +243,12 @@ export function createResponsesTerminalController(params: {
         hasCompletedLaterOutput = true;
         continue;
       }
-      if (item.type === "function_call" && !includeToolCalls) {
+      if (item.type === "function_call" && !completeToolCall) {
         continue;
       }
       // Previously emitted content indexes cannot be reordered after a missing earlier item.
       if (hasCompletedLaterOutput) {
         throw new Error("Responses stream omitted an output item before completed output");
-      }
-      if (item.type === "function_call") {
-        resolveCompletedResponsesToolCall(item);
       }
     }
     for (const [terminalIndex, item] of items.entries()) {
@@ -281,11 +287,11 @@ export function createResponsesTerminalController(params: {
             model,
             options?.reasoningReplayMetadata,
           );
-        } else if (includeToolCalls && item.type === "function_call") {
-          if (params.outputs.get(item, terminalIndex)) {
+        } else if (completeToolCall && item.type === "function_call") {
+          if (params.outputs.get(item, terminalIndex)?.completed) {
             continue;
           }
-          params.outputs.set(item, appendToolCall(item), terminalIndex, true);
+          completeToolCall(terminalIndex);
         }
       }
     }
@@ -323,7 +329,6 @@ export function createResponsesTerminalController(params: {
     >["response"],
     terminalEventType: "response.completed" | "response.incomplete",
   ) => {
-    params.markFinalized();
     backfillReasoning(response.output ?? []);
     finalizeTerminalFacts(response);
     const terminal = resolveResponsesTerminalStopReason({
@@ -335,5 +340,10 @@ export function createResponsesTerminalController(params: {
     output.stopReason = terminal.stopReason;
     output.errorMessage = terminal.errorMessage;
   };
-  return { finalizeResponse, finalizeFailedResponse: finalizeTerminalFacts, recoverTerminalOutput };
+  return {
+    finalizeResponse,
+    finalizeFailedResponse: finalizeTerminalFacts,
+    recoverTerminalOutput,
+    emitToolCallCompletion,
+  };
 }

--- a/packages/ai/src/transports/openai-responses-stream-terminal-tools.test.ts
+++ b/packages/ai/src/transports/openai-responses-stream-terminal-tools.test.ts
@@ -17,6 +17,71 @@ const added = (slot: number, overrides: Record<string, unknown> = {}) => ({
 });
 
 describe("Responses terminal tool completion", () => {
+  it("does not repeat an anonymous unindexed call after its item-done event", async () => {
+    const anonymous = { id: undefined, call_id: undefined };
+    const result = await runFixture([
+      { ...added(0, anonymous), output_index: undefined },
+      { type: "response.output_item.done", item: tool(0, anonymous) },
+      completed("resp_anonymous_done", [tool(0, anonymous)]),
+    ]);
+    expect(result.error).toBeNull();
+    expect(result.content).toHaveLength(1);
+    expect(result.events.filter((event) => event.type === "toolcall_end")).toEqual([
+      { type: "toolcall_end", contentIndex: 0 },
+    ]);
+  });
+
+  it("rejects an anonymous call with no stream or terminal position without completing it", async () => {
+    const anonymous = { id: undefined, call_id: undefined };
+    const result = await runFixture([
+      { ...added(0, anonymous), output_index: undefined },
+      { type: "response.output_item.done", item: tool(0, anonymous) },
+      completed("resp_no_position", []),
+    ]);
+    expect(result.error).toBe("Responses stream completed with unresolved tool calls");
+    expect(result.events.filter((event) => event.type === "toolcall_end")).toEqual([]);
+  });
+
+  it.each(["indexed", "identified"])(
+    "retains a known %s owner when its done event omits identity",
+    async (identity) => {
+      const anonymous = { id: undefined, call_id: undefined };
+      const result = await runFixture([
+        identity === "indexed" ? added(0, anonymous) : { ...added(0), output_index: undefined },
+        { type: "response.output_item.done", item: tool(0, anonymous) },
+        completed("resp_known_owner", []),
+      ]);
+      expect(result.error).toBeNull();
+      expect(result.events.filter((event) => event.type === "toolcall_end")).toEqual([
+        { type: "toolcall_end", contentIndex: 0 },
+      ]);
+    },
+  );
+
+  it("rejects an anonymous unindexed done-only call without silently dropping it", async () => {
+    const item = tool(0, { id: undefined, call_id: undefined });
+    const result = await runFixture([
+      { type: "response.output_item.done", item },
+      completed("resp_done_only", [item]),
+    ]);
+    expect(result.error).toBe("Responses stream completed tool call without an output identity");
+    expect(result.content).toHaveLength(0);
+    expect(result.events.filter((event) => event.type === "toolcall_end")).toEqual([]);
+  });
+
+  it("does not publish anonymous unindexed completions before ambiguous terminal matching", async () => {
+    const anonymous = { id: undefined, call_id: undefined };
+    const result = await runFixture([
+      { ...added(0, anonymous), output_index: undefined },
+      { type: "response.output_item.done", item: tool(0, anonymous) },
+      { ...added(1, anonymous), output_index: undefined },
+      { type: "response.output_item.done", item: tool(1, anonymous) },
+      completed("resp_ambiguous_done", [tool(0), tool(1)]),
+    ]);
+    expect(result.error).not.toBeNull();
+    expect(result.events.filter((event) => event.type === "toolcall_end")).toEqual([]);
+  });
+
   it.each(["indexed", "rotated", "unindexed", "anonymous"])(
     "completes a %s call exactly once when its item-done event is missing",
     async (identity) => {

--- a/packages/ai/src/transports/openai-responses-stream-terminal-tools.test.ts
+++ b/packages/ai/src/transports/openai-responses-stream-terminal-tools.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from "vitest";
+import { completed, runFixture } from "./openai-responses-stream-parity.test-helpers.js";
+
+const tool = (slot: number, overrides: Record<string, unknown> = {}) => ({
+  type: "function_call",
+  id: `fc_${slot}`,
+  call_id: `call_${slot}`,
+  name: "lookup",
+  arguments: JSON.stringify({ slot }),
+  status: "completed",
+  ...overrides,
+});
+const added = (slot: number, overrides: Record<string, unknown> = {}) => ({
+  type: "response.output_item.added",
+  output_index: slot,
+  item: tool(slot, { arguments: "", status: "in_progress", ...overrides }),
+});
+
+describe("Responses terminal tool completion", () => {
+  it.each(["indexed", "rotated", "unindexed", "anonymous"])(
+    "completes a %s call exactly once when its item-done event is missing",
+    async (identity) => {
+      const anonymous = identity === "anonymous" ? { id: undefined, call_id: undefined } : {};
+      const item = tool(0, {
+        ...anonymous,
+        ...(identity === "rotated" ? { id: "fc_terminal_rotated" } : {}),
+        arguments: '{"slot":0,"id":9007199254740993}',
+      });
+      const result = await runFixture([
+        {
+          ...added(0, anonymous),
+          ...(identity === "unindexed" || identity === "anonymous"
+            ? { output_index: undefined }
+            : {}),
+        },
+        completed("resp_missing_done", [item]),
+      ]);
+      expect(result.error).toBeNull();
+      expect(result.stopReason).toBe("toolUse");
+      expect(result.events).toEqual([
+        { type: "toolcall_start", contentIndex: 0 },
+        { type: "toolcall_end", contentIndex: 0 },
+      ]);
+      expect(result.content).toEqual([
+        {
+          type: "toolCall",
+          id:
+            identity === "anonymous"
+              ? "call_<generated>"
+              : `call_0|${identity === "rotated" ? "fc_terminal_rotated" : "fc_0"}`,
+          name: "lookup",
+          arguments: { slot: 0, id: "9007199254740993" },
+          partialJson: false,
+        },
+      ]);
+    },
+  );
+
+  it("does not adopt an unindexed anonymous call into an already completed position", async () => {
+    const anonymous = { id: undefined, call_id: undefined };
+    const result = await runFixture([
+      { type: "response.output_item.done", output_index: 0, item: tool(0, anonymous) },
+      { ...added(1, anonymous), output_index: undefined },
+      completed("resp_anonymous", [tool(0, anonymous), tool(1, anonymous)]),
+    ]);
+    expect(result.error).toBeNull();
+    expect(
+      result.content.map((block) => (block.type === "toolCall" ? block.arguments : null)),
+    ).toEqual([{ slot: 0 }, { slot: 1 }]);
+    expect(result.events.filter((event) => event.type === "toolcall_end")).toEqual([
+      { type: "toolcall_end", contentIndex: 0 },
+      { type: "toolcall_end", contentIndex: 1 },
+    ]);
+  });
+
+  it.each([
+    ["malformed arguments", { arguments: '{"slot":' }],
+    ["non-object arguments", { arguments: "[]" }],
+    ["incomplete status", { status: "incomplete" }],
+    ["changed name", { name: "delete_record" }],
+    ["changed call identity", { call_id: "call_conflicting" }],
+  ])(
+    "rejects a terminal batch with later %s before any tool completes",
+    async (_name, override) => {
+      const result = await runFixture([
+        added(0),
+        added(1),
+        completed("resp_invalid_batch", [tool(0), tool(1, override)]),
+      ]);
+      expect(result.error).not.toBeNull();
+      expect(result.events.filter((event) => event.type === "toolcall_end")).toEqual([]);
+    },
+  );
+
+  it("rejects a changed completed call identity before another active call completes", async () => {
+    const result = await runFixture([
+      { type: "response.output_item.done", output_index: 0, item: tool(0) },
+      added(1),
+      completed("resp_completed_conflict", [tool(0, { call_id: "call_conflicting" }), tool(1)]),
+    ]);
+    expect(result.error).toBe("Responses stream changed output item identity");
+    expect(result.events.filter((event) => event.type === "toolcall_end")).toEqual([
+      { type: "toolcall_end", contentIndex: 0 },
+    ]);
+  });
+
+  it.each([
+    ["missing call", []],
+    ["duplicate call", [tool(0), tool(0)]],
+    ["unmatched call", [tool(0, { call_id: "call_other" })]],
+  ])("rejects a terminal %s without completing the active call", async (_name, items) => {
+    const result = await runFixture([added(0), completed("resp_unresolved", items)]);
+    expect(result.error).not.toBeNull();
+    expect(result.events.filter((event) => event.type === "toolcall_end")).toEqual([]);
+  });
+
+  it("never completes active tools from an incomplete response", async () => {
+    const result = await runFixture([
+      added(0),
+      {
+        type: "response.incomplete",
+        response: { id: "resp_incomplete", status: "incomplete", output: [tool(0)] },
+      },
+    ]);
+    expect(result.error).toBe("Responses stream completed with unresolved tool calls");
+    expect(result.events.filter((event) => event.type === "toolcall_end")).toEqual([]);
+  });
+
+  it.each([1, 2])(
+    "rejects %i anonymous unindexed calls with ambiguous terminal positions",
+    async (count) => {
+      const result = await runFixture([
+        ...Array.from({ length: count }, (_, slot) => ({
+          ...added(slot, { id: undefined, call_id: undefined }),
+          output_index: undefined,
+        })),
+        completed("resp_ambiguous", [tool(0), tool(1)]),
+      ]);
+      expect(result.error).not.toBeNull();
+      expect(result.events.filter((event) => event.type === "toolcall_end")).toEqual([]);
+    },
+  );
+
+  it("completes indexed anonymous and terminal-only calls without duplicate callbacks", async () => {
+    const result = await runFixture([
+      added(0, { id: undefined, call_id: undefined }),
+      completed("resp_indexed_and_new", [tool(0), tool(1)]),
+    ]);
+    expect(result.error).toBeNull();
+    expect(result.content).toHaveLength(2);
+    expect(result.events.filter((event) => event.type === "toolcall_end")).toEqual([
+      { type: "toolcall_end", contentIndex: 0 },
+      { type: "toolcall_end", contentIndex: 1 },
+    ]);
+  });
+});

--- a/src/agents/openai-transport-stream.streaming.test.ts
+++ b/src/agents/openai-transport-stream.streaming.test.ts
@@ -378,47 +378,6 @@ describe("openai transport stream", () => {
     ]);
   });
 
-  it("keeps idless Responses tool-call ids stable and response-unique", async () => {
-    const runOnce = async () => {
-      const model = createAzureResponsesModel();
-      const output = createResponsesAssistantOutput(model);
-      const events: CapturedStreamEvent[] = [];
-      await testing.processResponsesStream(
-        streamChunks([
-          {
-            type: "response.output_item.added",
-            item: { type: "function_call", name: "computer", arguments: "" },
-          },
-          {
-            type: "response.output_item.done",
-            item: { type: "function_call", name: "computer", arguments: "{}" },
-          },
-          { type: "response.completed", response: { id: "resp_idless", status: "completed" } },
-        ]),
-        output,
-        { push: (event) => events.push(event as CapturedStreamEvent) },
-        model,
-      );
-      const block = output.content.find((entry) => entry.type === "toolCall") as
-        | { id?: string }
-        | undefined;
-      const end = events.find((event) => event.type === "toolcall_end") as
-        | { toolCall?: { id?: string } }
-        | undefined;
-      if (!block?.id || !end?.toolCall?.id) {
-        throw new Error("missing tool-call lifecycle");
-      }
-      return { blockId: block.id, endId: end.toolCall.id };
-    };
-
-    const first = await runOnce();
-    const second = await runOnce();
-    expect(first.blockId).toMatch(/^call_[0-9a-f]{24}$/);
-    expect(first.endId).toBe(first.blockId);
-    expect(second.endId).toBe(second.blockId);
-    expect(second.blockId).not.toBe(first.blockId);
-  });
-
   it("materializes one stable tool call for a done-only idless Responses item", async () => {
     const model = createAzureResponsesModel();
     const output = createResponsesAssistantOutput(model);


### PR DESCRIPTION
Closes #108460.

## What Problem This Solves

Some compatible OpenAI Responses streams finish with a complete function-call snapshot but omit its per-item `response.output_item.done` event. The shared parser currently rejects the active call before examining that snapshot, turning a usable Copilot tool turn into `Responses stream completed with unresolved tool calls`.

## Why This Change Was Made

Rebuilt this repair on current main after #122560 landed its positional output tracker. Streaming and terminal completion now share one finalizer. Terminal recovery validates the whole batch, stable call identities, argument objects, active-call coverage, and output ordering before emitting any new tool completion. Completed positions are skipped before unindexed identity adoption; malformed, incomplete, unmatched, duplicate, conflicting, and ambiguous calls remain rejected.

The same investigation found that anonymous calls shared an empty identity alias, allowing a new unindexed call to overwrite a completed position. Anonymous calls now have no identity alias; actual positions retain ownership. A terminal batch with several pending candidates cannot arbitrarily adopt a sole anonymous unindexed call.

ClawSweeper then caught a related lifecycle gap: an anonymous unindexed `added → done → completed` sequence could complete twice after losing its alias. Completion now retains the active owner until the terminal snapshot supplies a position, while recorded real positions and identities remain usable when later events omit them. An unidentified done event with no active owner fails visibly; it cannot silently disappear or create a second tool. This uses the existing owner, not another completed-call registry.

This removes the duplicate terminal append path and a no-op finalization hook. There is no new config, retry policy, provider special case, public API, database, or dependency change. Thanks @snotty for the original repair and reproduction; original co-author credit is preserved.

## User Impact

Complete Copilot tool turns survive a missing per-item completion event, tools complete once, and exact large-integer arguments remain intact. Invalid or conflicting terminal data does not authorize a tool. The rotated-ID behavior landed in #122560 remains covered.

## Evidence

Candidate: `b4419a1c784c88ccbca1d06cd665e19a22638c3e`, based on `a369c7ca02097cde8b95575ac3c015ffdc80b6af`. Changes after live-tested `2f524def05d` only shrink one assertion-baseline entry and delete a duplicated core test; all four production source hashes are unchanged and match the independently captured live source bytes.

Before production edits, the focused regression failed six of fifteen cases on the base; the missing-done variants produced the reported unresolved-call error. The subsequent anonymous-done regression also failed on the published predecessor, producing two tool calls instead of one. After repair, **190 tests pass across four focused files**, including indexed, rotated, unindexed and anonymous calls, completed-position isolation, malformed/conflicting batches, incomplete responses, the full anonymous added/done/completed lifecycle, and existing stable/rotated message-recovery cases.

```sh
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs \
  packages/ai/src/transports/openai-responses-stream-terminal-tools.test.ts \
  packages/ai/src/transports/openai-responses-stream-terminal-recovery.test.ts \
  packages/ai/src/transports/openai-responses-stream-parity.test.ts \
  packages/ai/src/providers/openai-responses-shared.test.ts

GOMAXPROCS=1 node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.test.packages.json
```

Package test typechecking, targeted oxlint, formatting, and `git diff --check` pass. Fresh structured Codex review through P2 and an independent source review found no actionable defects in the final repair. CI caught assertion bookkeeping twice: an unnecessary cast was removed through an accurate local scratch-field type, then the newly stale allowance was tightened from 3 to 2. Complete max-lines, environment-count, and assertion-safety ratchets now pass; no allowance was increased. A copied core generated-ID fixture was then removed after proving it directly re-exported the same package parser and duplicated the retained canonical assertions. **252 focused tests pass across seven package/core files**, including actual core HTTP/adapter tests. [Full hosted CI on exact final head b4419a1 passed](https://github.com/openclaw/openclaw/actions/runs/33035776606); all 135 jobs completed without failures.

### Actual Copilot behavior

A diagnostic deliberately withheld **only one first-response function-call `response.output_item.done` event** from a real Copilot `gpt-5.6-luna` Responses stream. Argument events and the completed terminal snapshot were unchanged. This is fault injection; it does not claim the vendor naturally omitted that event.

- Before: HTTP 200 reached the actual parser, which returned the unresolved-call error; no tool executed.
- After: one valid tool completed, a harmless local callback ran exactly once, and a real second HTTP 200 request returned the exact fresh nonce supplied only in the tool result, absent from the initial prompt.
- A source-blind validator independently selected the nonce and executed the diagnostic. Provider item IDs naturally rotated while output position and stable call ID remained consistent. All four changed production-file hashes match the committed candidate.

The primary missing-done positive was rerun on clean published `2f524def05d235e5145cb5bfc56cbc3bf568e4d6`: exactly one event suppressed, one valid completed call, one callback, and two actual HTTP 200 requests with the fresh tool-result-only nonce returned exactly by the model. The artifact records no uncommitted source paths and matches all four production hashes.

After the anonymous lifecycle repair, the independent validator repeated current-source behavior checks:

- Anonymous lifecycle: retained every real event but removed identities and output indexes only from one function-call added event, one done event, and six argument events. The terminal snapshot remained unchanged. Exactly one local callback ran, its resolved call ID matched the real terminal call ID, and the actual second HTTP 200 response returned the fresh nonce supplied only by that callback. No events were dropped.
- Conflict guard: one real HTTP 200 stream, one withheld item-done event, and only the terminal stable call ID changed. The parser returned `Responses stream changed output item identity`; zero tool callbacks executed and no follow-up request was sent.
- Text deduplication: one real HTTP 200 response naturally used three message IDs at the same output position; the diagnostic additionally replaced only the terminal message ID. The result contained exactly one text block with the requested fresh nonce.

These three final diagnostics made four actual HTTP 200 requests. They were captured against frozen uncommitted source over predecessor `5b726447`; all four recorded production hashes match the final committed Gitblobs at `2f524def05d235e5145cb5bfc56cbc3bf568e4d6`. This binds the tested bytes to the commit without falsely calling the earlier working-tree HEAD the tested revision.

This proves the actual provider transport, local tool callback, and actual provider follow-up; it is not a full Gateway tool-runner or channel UI test.

### Upstream contracts and review follow-through

Directly inspected OpenAI SDK 7.5.0 `src/resources/responses/responses.ts:6204-6253` and `src/lib/responses/ResponseStream.ts:167-190`: item events carry an output-array index, and streaming uses that position. Direct sibling Codex inspection covered `codex-rs/codex-api/src/sse/responses.rs:355,477` and `endpoint/responses_websocket.rs:818`; item completion is distinct from terminal response metadata.

The ClawSweeper requests for current-candidate real behavior, direct contracts, and a single canonical finalizer are addressed above. The historical unresolved-call guard was carried forward by #114263, not newly introduced there. The empty anonymous alias dates to #120457 and was retained by the newer positional tracker.

The newer P1 and rank-up request for anonymous unindexed added/done/completed coverage is addressed at the canonical completion producer. The existing generated-ID stability test now supplies SDK-required `output_index`; all original ID assertions are unchanged. Its original #103422 fixture had no terminal event at all, and #109615 later added one. It did not establish an observed provider contract omitting every identity, position, and terminal output. Separate tests now explicitly reject that unidentifiable shape before any tool completion. No persistent data model changes are involved; the review's serialized-state signal refers to test fixtures, not storage.

Production **+164/-98 (net +66)**; tests **+224/-42 (net +182)**. The remaining growth validates the complete terminal batch before tool execution and records actual position/identity at the lifecycle owner; it replaces the prior candidate's separate finalized-state tracking rather than adding another tracker. The 41-line core test deletion removes duplicate coverage; the package owner retains all four generated-ID security assertions.

Other metadata: assertion baseline +1/-1, strictly reducing the permitted debt.

Co-authored-by: snotty <snotty@users.noreply.github.com>
