### PR TITLE
fix(ci): install Crabline for package Telegram harness

### DIFF
--- a/scripts/e2e/npm-telegram-live-docker.sh
+++ b/scripts/e2e/npm-telegram-live-docker.sh
@@ -456,6 +456,12 @@ cp "$openclaw_package_dir/package.json" /app/package.json
 node scripts/e2e/lib/npm-telegram-live/prepare-package.mjs \
   /app/package.json \
   /app/node_modules/openclaw/package.json
+# QA Lab is mounted from source, so install its external runtime-only harness dependency
+# separately from the package candidate under test.
+crabline_version="$(
+  node -e 'process.stdout.write(require("./extensions/qa-lab/package.json").devDependencies["@openclaw/crabline"])'
+)"
+npm install -g "@openclaw/crabline@$crabline_version" --no-fund --no-audit
 for deps_dir in "$openclaw_package_dir/node_modules" /npm-global/lib/node_modules; do
   [ -d "$deps_dir" ] || continue
   for dependency_dir in "$deps_dir"/*; do

--- a/test/scripts/npm-telegram-live.test.ts
+++ b/test/scripts/npm-telegram-live.test.ts
@@ -267,6 +267,17 @@ describe("package Telegram live Docker E2E", () => {
     expect(script).toContain("zod");
   });
 
+  it("installs the mounted QA harness Crabline runtime dependency", () => {
+    const script = readFileSync(DOCKER_SCRIPT_PATH, "utf8");
+
+    expect(script).toContain(
+      'require("./extensions/qa-lab/package.json").devDependencies["@openclaw/crabline"]',
+    );
+    expect(script).toContain(
+      'npm install -g "@openclaw/crabline@$crabline_version" --no-fund --no-audit',
+    );
+  });
+
   it("lets npm-specific credential aliases override shared QA env", () => {
     expect(
       testing.resolveCredentialSource({


### PR DESCRIPTION
## Summary

- install the QA Lab harness's pinned Crabline runtime dependency inside the isolated package Telegram container
- keep the dependency separate from the OpenClaw package candidate under test
- cover version discovery and installation wiring with a regression test

## Proof

- `pnpm exec vitest run test/scripts/npm-telegram-live.test.ts`
- `bash -n scripts/e2e/npm-telegram-live-docker.sh`
- autoreview clean

Fixes the failure in Full Release Validation child run 29451240055: `Cannot find package '@openclaw/crabline' imported from /app/extensions/qa-lab/src/suite-launch.runtime.ts`.
