### PR TITLE
fix(sandbox): force POSIX locale in stat command for locale-independent error detection (fixes #106576)

### DIFF
--- a/src/agents/sandbox/fs-bridge-shell-command-plans.ts
+++ b/src/agents/sandbox/fs-bridge-shell-command-plans.ts
@@ -22,7 +22,7 @@ export function buildStatPlan(
 ): SandboxFsCommandPlan {
   return {
     checks: [{ target, options: { action: "stat files" } }],
-    script: 'set -eu\ncd -- "$1"\nstat -c "%F|%s|%y" -- "$2"',
+    script: 'set -eu\ncd -- "$1"\nLC_ALL=C stat -c "%F|%s|%y" -- "$2"',
     args: [anchoredTarget.canonicalParentPath, anchoredTarget.basename],
     allowFailure: true,
   };


### PR DESCRIPTION
## What Problem This Solves

The sandbox `stat` implementation checks for file absence by matching the English string `"No such file or directory"` in stderr (`fs-bridge.ts:211`). On container environments with non-English locales (French, German, Japanese, etc.), `stat` outputs localized error messages that fail this check, causing runtime exceptions instead of returning `null`.

## Why This Change Was Made

Prefix the `stat` command with `LC_ALL=C` to force POSIX-locale error output regardless of the container's configured locale. This is a one-character addition to the shell command plan in `buildStatPlan`.

## User Impact

**Before:** Sandbox `stat` operations fail with runtime exceptions on non-English container locales. **After:** File-not-found detection works correctly regardless of locale.

## Evidence

- `src/agents/sandbox/fs-bridge-shell-command-plans.ts:25` — one-line change: `LC_ALL=C stat` instead of `stat`
- `pnpm test src/agents/sandbox/fs-bridge.shell.test.ts` — 16 passed, 0 regressions
- The `stat` command plan now produces the POSIX-locale script:
```
set -eu
cd -- "$1"
LC_ALL=C stat -c "%F|%s|%y" -- "$2"
```
</details>