### PR TITLE
improve(ui): speed up browser E2E tests

### DIFF
--- a/ui/src/e2e/approval-flow.e2e.test.ts
+++ b/ui/src/e2e/approval-flow.e2e.test.ts
@@ -14,7 +14,8 @@ const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
 const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
 const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
 
-let browser: Browser | undefined;
+// Browser contexts preserve test isolation; keep one process warm for this file.
+let browser: Browser;
 let page: Page | undefined;
 let server: ControlUiE2eServer | undefined;
 
@@ -36,7 +37,13 @@ function requireRecord(value: unknown): Record<string, unknown> {
 
 describeControlUiE2e("Control UI approval flow", () => {
   beforeAll(async () => {
-    server = await startControlUiE2eServer();
+    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
+    try {
+      server = await startControlUiE2eServer();
+    } catch (error) {
+      await browser.close();
+      throw error;
+    }
   });
 
   afterEach(async () => {
@@ -44,17 +51,15 @@ describeControlUiE2e("Control UI approval flow", () => {
       ?.context()
       .close()
       .catch(() => {});
-    await browser?.close().catch(() => {});
     page = undefined;
-    browser = undefined;
   });
 
   afterAll(async () => {
+    await browser?.close().catch(() => {});
     await server?.close();
   });
 
   it("keeps an older resolve failure off the newly active approval", async () => {
-    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
     const context = await browser.newContext({ viewport: { height: 800, width: 1200 } });
     const currentPage = await context.newPage();
     page = currentPage;
@@ -87,7 +92,6 @@ describeControlUiE2e("Control UI approval flow", () => {
   });
 
   it("sends a typed approval command immediately while the active run waits", async () => {
-    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
     const context = await browser.newContext({ viewport: { height: 800, width: 1200 } });
     const currentPage = await context.newPage();
     page = currentPage;

--- a/ui/src/e2e/browser-talk-start-stop.e2e.test.ts
+++ b/ui/src/e2e/browser-talk-start-stop.e2e.test.ts
@@ -1,7 +1,7 @@
 // Control UI E2E tests cover browser Talk start and stop through a real page.
 import { mkdir } from "node:fs/promises";
 import path from "node:path";
-import { chromium, type Page } from "playwright";
+import { chromium, type Browser, type Page } from "playwright";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import {
   canRunPlaywrightChromium,
@@ -17,6 +17,8 @@ const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM 
 const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
 
 let server: ControlUiE2eServer;
+// Browser contexts preserve test isolation; keep one process warm for this file.
+let browser: Browser;
 
 async function installTalkBrowserFixtures(page: Page) {
   await page.addInitScript(() => {
@@ -122,15 +124,21 @@ async function installBlockedMicrophoneFixture(page: Page) {
 
 describeControlUiE2e("Control UI browser Talk", () => {
   beforeAll(async () => {
-    server = await startControlUiE2eServer();
+    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
+    try {
+      server = await startControlUiE2eServer();
+    } catch (error) {
+      await browser.close();
+      throw error;
+    }
   });
 
   afterAll(async () => {
+    await browser?.close();
     await server?.close();
   });
 
   it("starts a provider WebSocket session and stops browser audio resources", async () => {
-    const browser = await chromium.launch({ executablePath: chromiumExecutablePath });
     const context = await browser.newContext({ permissions: ["microphone"] });
     const page = await context.newPage();
     const gateway = await installMockGateway(page, {
@@ -306,12 +314,10 @@ describeControlUiE2e("Control UI browser Talk", () => {
         .toBe(true);
     } finally {
       await context.close();
-      await browser.close();
     }
   });
 
   it("keeps stop-voice and stop-run controls visually distinct while both are active", async () => {
-    const browser = await chromium.launch({ executablePath: chromiumExecutablePath });
     const context = await browser.newContext({ permissions: ["microphone"] });
     const page = await context.newPage();
     const gateway = await installMockGateway(page, {
@@ -426,12 +432,10 @@ describeControlUiE2e("Control UI browser Talk", () => {
       expect(await gateway.getRequests("chat.abort")).toHaveLength(0);
     } finally {
       await context.close();
-      await browser.close();
     }
   });
 
   it("renders streamed relay assistant transcript deltas as readable text", async () => {
-    const browser = await chromium.launch({ executablePath: chromiumExecutablePath });
     const context = await browser.newContext({ permissions: ["microphone"] });
     const page = await context.newPage();
     const relaySessionId = "relay-e2e-transcript";
@@ -516,12 +520,10 @@ describeControlUiE2e("Control UI browser Talk", () => {
       expect(turnBounds?.height ?? Number.POSITIVE_INFINITY).toBeLessThanOrEqual(120);
     } finally {
       await context.close();
-      await browser.close();
     }
   });
 
   it("keeps blocked microphone guidance readable in a narrow viewport", async () => {
-    const browser = await chromium.launch({ executablePath: chromiumExecutablePath });
     const context = await browser.newContext();
     const page = await context.newPage();
     await installMockGateway(page);
@@ -543,7 +545,6 @@ describeControlUiE2e("Control UI browser Talk", () => {
         .toContain("Microphone access is blocked.");
     } finally {
       await context.close();
-      await browser.close();
     }
   });
 });

--- a/ui/src/e2e/chat-composer-redesign.e2e.test.ts
+++ b/ui/src/e2e/chat-composer-redesign.e2e.test.ts
@@ -1,5 +1,5 @@
 // Control UI E2E tests cover the redesigned chat composer.
-import { chromium } from "playwright";
+import { chromium, type Browser } from "playwright";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import {
   canRunPlaywrightChromium,
@@ -15,18 +15,26 @@ const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM 
 const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
 
 let server: ControlUiE2eServer;
+// Browser contexts preserve test isolation; keep one process warm for this file.
+let browser: Browser;
 
 describeControlUiE2e("Control UI chat composer redesign", () => {
   beforeAll(async () => {
-    server = await startControlUiE2eServer();
+    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
+    try {
+      server = await startControlUiE2eServer();
+    } catch (error) {
+      await browser.close();
+      throw error;
+    }
   });
 
   afterAll(async () => {
+    await browser?.close();
     await server?.close();
   });
 
   it("keeps model and settings in the bottom bar and switches the primary action with input state", async () => {
-    const browser = await chromium.launch({ executablePath: chromiumExecutablePath });
     const context = await browser.newContext({ viewport: { width: 1920, height: 1080 } });
     const page = await context.newPage();
     const gateway = await installMockGateway(page, {
@@ -531,12 +539,10 @@ describeControlUiE2e("Control UI chat composer redesign", () => {
       await expect.poll(() => viewMenu.isVisible()).toBe(false);
     } finally {
       await context.close();
-      await browser.close();
     }
   });
 
   it("refreshes the configured usable catalog after advertised chat metadata", async () => {
-    const browser = await chromium.launch({ executablePath: chromiumExecutablePath });
     const context = await browser.newContext({ viewport: { width: 1280, height: 900 } });
     const page = await context.newPage();
     const gateway = await installMockGateway(page, {
@@ -623,12 +629,10 @@ describeControlUiE2e("Control UI chat composer redesign", () => {
       await expect.poll(() => composer.locator('[data-chat-model-option=""]').count()).toBe(0);
     } finally {
       await context.close();
-      await browser.close();
     }
   });
 
   it("refreshes agent-scoped models when the pane switches sessions", async () => {
-    const browser = await chromium.launch({ executablePath: chromiumExecutablePath });
     const context = await browser.newContext({ viewport: { width: 1280, height: 900 } });
     const page = await context.newPage();
     const gateway = await installMockGateway(page, {
@@ -735,12 +739,10 @@ describeControlUiE2e("Control UI chat composer redesign", () => {
         .toBe(0);
     } finally {
       await context.close();
-      await browser.close();
     }
   });
 
   it("keeps startup models when the metadata refresh fails", async () => {
-    const browser = await chromium.launch({ executablePath: chromiumExecutablePath });
     const context = await browser.newContext({ viewport: { width: 1280, height: 900 } });
     const page = await context.newPage();
     const gateway = await installMockGateway(page, {
@@ -762,12 +764,10 @@ describeControlUiE2e("Control UI chat composer redesign", () => {
       expect(await gateway.getRequests("models.list")).toHaveLength(0);
     } finally {
       await context.close();
-      await browser.close();
     }
   });
 
   it("does not substitute default-agent models when scoped metadata fails", async () => {
-    const browser = await chromium.launch({ executablePath: chromiumExecutablePath });
     const context = await browser.newContext({ viewport: { width: 1280, height: 900 } });
     const page = await context.newPage();
     const gateway = await installMockGateway(page, {
@@ -827,12 +827,10 @@ describeControlUiE2e("Control UI chat composer redesign", () => {
       expect(await gateway.getRequests("models.list")).toHaveLength(0);
     } finally {
       await context.close();
-      await browser.close();
     }
   });
 
   it("does not request unscoped models when chat metadata is unavailable", async () => {
-    const browser = await chromium.launch({ executablePath: chromiumExecutablePath });
     const context = await browser.newContext({ viewport: { width: 1280, height: 900 } });
     const page = await context.newPage();
     const gateway = await installMockGateway(page, {
@@ -891,7 +889,6 @@ describeControlUiE2e("Control UI chat composer redesign", () => {
       expect(await gateway.getRequests("models.list")).toHaveLength(0);
     } finally {
       await context.close();
-      await browser.close();
     }
   });
 });

--- a/ui/src/e2e/chat-composer-redesign.e2e.test.ts
+++ b/ui/src/e2e/chat-composer-redesign.e2e.test.ts
@@ -706,12 +706,15 @@ describeControlUiE2e("Control UI chat composer redesign", () => {
     try {
       await page.goto(`${server.baseUrl}chat?session=agent%3Awork%3Amain`);
       await expect
-        .poll(async () => {
-          const requests = await gateway.getRequests("chat.metadata");
-          return requests.some(
-            (request) => (request.params as { agentId?: string } | undefined)?.agentId === "work",
-          );
-        })
+        .poll(
+          async () => {
+            const requests = await gateway.getRequests("chat.metadata");
+            return requests.some(
+              (request) => (request.params as { agentId?: string } | undefined)?.agentId === "work",
+            );
+          },
+          { timeout: 10_000 },
+        )
         .toBe(true);
 
       const composer = page.locator(".agent-chat__input");

--- a/ui/src/e2e/chat-flow.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.e2e.test.ts
@@ -18,7 +18,8 @@ const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM 
 const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
 
 let server: ControlUiE2eServer;
-const contextBrowsers = new WeakMap<BrowserContext, Browser>();
+// Browser contexts preserve test isolation; keep one process warm for this file.
+let browser: Browser;
 const openBrowserContexts = new Set<BrowserContext>();
 
 function requireRecord(value: unknown): Record<string, unknown> {
@@ -140,26 +141,14 @@ async function scrollChatThreadToTop(page: Page): Promise<void> {
 }
 
 async function newBrowserContext(options: Parameters<Browser["newContext"]>[0]) {
-  const browser = await chromium.launch({ executablePath: chromiumExecutablePath });
-  let context: BrowserContext | undefined;
-  try {
-    context = await browser.newContext(options);
-    contextBrowsers.set(context, browser);
-    openBrowserContexts.add(context);
-    return context;
-  } catch (error) {
-    await context?.close().catch(() => {});
-    await browser.close().catch(() => {});
-    throw error;
-  }
+  const context = await browser.newContext(options);
+  openBrowserContexts.add(context);
+  return context;
 }
 
 async function closeBrowserContext(context: BrowserContext): Promise<void> {
-  const browser = contextBrowsers.get(context);
   openBrowserContexts.delete(context);
-  contextBrowsers.delete(context);
   await context.close().catch(() => {});
-  await browser?.close().catch(() => {});
 }
 
 async function closeOpenBrowserContexts(): Promise<void> {
@@ -237,11 +226,18 @@ describeControlUiE2e("Control UI mocked Gateway E2E", () => {
         `Playwright Chromium is not installed or cannot start at ${chromiumExecutablePath}. Run \`pnpm --dir ui exec playwright install --with-deps chromium\`, set PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH to a compatible browser, or set OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM=1 only when intentionally skipping this lane.`,
       );
     }
-    server = await startControlUiE2eServer();
+    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
+    try {
+      server = await startControlUiE2eServer();
+    } catch (error) {
+      await browser.close();
+      throw error;
+    }
   });
 
   afterAll(async () => {
     await closeOpenBrowserContexts();
+    await browser?.close();
     await server?.close();
   });
 

--- a/ui/src/e2e/chat-pull-requests.e2e.test.ts
+++ b/ui/src/e2e/chat-pull-requests.e2e.test.ts
@@ -15,22 +15,24 @@ const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM 
 const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
 
 let server: ControlUiE2eServer;
-const openBrowsers = new Set<Browser>();
+// Browser contexts preserve test isolation; keep one process warm for this file.
+let browser: Browser;
+const openContexts = new Set<BrowserContext>();
 
 async function newBrowserContext(): Promise<BrowserContext> {
-  const browser = await chromium.launch({ executablePath: chromiumExecutablePath });
-  openBrowsers.add(browser);
-  return browser.newContext({
+  const context = await browser.newContext({
     colorScheme: "light",
     locale: "en-US",
     serviceWorkers: "block",
     viewport: { height: 800, width: 1180 },
   });
+  openContexts.add(context);
+  return context;
 }
 
-async function closeBrowsers(): Promise<void> {
-  await Promise.all([...openBrowsers].map((browser) => browser.close().catch(() => {})));
-  openBrowsers.clear();
+async function closeContexts(): Promise<void> {
+  await Promise.all([...openContexts].map((context) => context.close().catch(() => {})));
+  openContexts.clear();
 }
 
 describeControlUiE2e("session pull request chips", () => {
@@ -38,15 +40,22 @@ describeControlUiE2e("session pull request chips", () => {
     if (!chromiumAvailable) {
       throw new Error(`Playwright Chromium is unavailable at ${chromiumExecutablePath}`);
     }
-    server = await startControlUiE2eServer();
+    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
+    try {
+      server = await startControlUiE2eServer();
+    } catch (error) {
+      await browser.close();
+      throw error;
+    }
   });
 
   afterAll(async () => {
-    await closeBrowsers();
+    await closeContexts();
+    await browser?.close();
     await server?.close();
   });
 
-  afterEach(closeBrowsers);
+  afterEach(closeContexts);
 
   it("pins detected PR chips above the composer with rate-limit staleness", async () => {
     const context = await newBrowserContext();

--- a/ui/src/e2e/chat-run-lifecycle.e2e.test.ts
+++ b/ui/src/e2e/chat-run-lifecycle.e2e.test.ts
@@ -15,13 +15,20 @@ const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
 const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
 const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
 
-let browser: Browser | undefined;
+// Browser contexts preserve test isolation; keep one process warm for this file.
+let browser: Browser;
 let page: Page | undefined;
 let server: ControlUiE2eServer | undefined;
 
 describeControlUiE2e("Control UI chat run lifecycle", () => {
   beforeAll(async () => {
-    server = await startControlUiE2eServer();
+    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
+    try {
+      server = await startControlUiE2eServer();
+    } catch (error) {
+      await browser.close();
+      throw error;
+    }
   });
 
   afterEach(async () => {
@@ -29,17 +36,15 @@ describeControlUiE2e("Control UI chat run lifecycle", () => {
       ?.context()
       .close()
       .catch(() => {});
-    await browser?.close().catch(() => {});
     page = undefined;
-    browser = undefined;
   });
 
   afterAll(async () => {
+    await browser?.close().catch(() => {});
     await server?.close();
   });
 
   it("shows compaction savings and live working time", async () => {
-    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
     const context = await browser.newContext({ viewport: { height: 800, width: 1200 } });
     const currentPage = await context.newPage();
     page = currentPage;
@@ -83,7 +88,6 @@ describeControlUiE2e("Control UI chat run lifecycle", () => {
   });
 
   it("clears shared session activity when chat final arrives first", async () => {
-    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
     const context = await browser.newContext({ viewport: { height: 800, width: 1200 } });
     const currentPage = await context.newPage();
     page = currentPage;
@@ -228,7 +232,6 @@ describeControlUiE2e("Control UI chat run lifecycle", () => {
   });
 
   it("does not announce Done when a yielded parent is waiting for continuation", async () => {
-    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
     const context = await browser.newContext({ viewport: { height: 800, width: 1200 } });
     const currentPage = await context.newPage();
     page = currentPage;

--- a/ui/src/e2e/chat-session-diff.e2e.test.ts
+++ b/ui/src/e2e/chat-session-diff.e2e.test.ts
@@ -15,22 +15,24 @@ const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM 
 const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
 
 let server: ControlUiE2eServer;
-const openBrowsers = new Set<Browser>();
+// Browser contexts preserve test isolation; keep one process warm for this file.
+let browser: Browser;
+const openContexts = new Set<BrowserContext>();
 
 async function newBrowserContext(): Promise<BrowserContext> {
-  const browser = await chromium.launch({ executablePath: chromiumExecutablePath });
-  openBrowsers.add(browser);
-  return browser.newContext({
+  const context = await browser.newContext({
     colorScheme: "light",
     locale: "en-US",
     serviceWorkers: "block",
     viewport: { height: 800, width: 1180 },
   });
+  openContexts.add(context);
+  return context;
 }
 
-async function closeBrowsers(): Promise<void> {
-  await Promise.all([...openBrowsers].map((browser) => browser.close().catch(() => {})));
-  openBrowsers.clear();
+async function closeContexts(): Promise<void> {
+  await Promise.all([...openContexts].map((context) => context.close().catch(() => {})));
+  openContexts.clear();
 }
 
 const APP_PATCH = [
@@ -62,15 +64,22 @@ describeControlUiE2e("session diff panel", () => {
     if (!chromiumAvailable) {
       throw new Error(`Playwright Chromium is unavailable at ${chromiumExecutablePath}`);
     }
-    server = await startControlUiE2eServer();
+    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
+    try {
+      server = await startControlUiE2eServer();
+    } catch (error) {
+      await browser.close();
+      throw error;
+    }
   });
 
   afterAll(async () => {
-    await closeBrowsers();
+    await closeContexts();
+    await browser?.close();
     await server?.close();
   });
 
-  afterEach(closeBrowsers);
+  afterEach(closeContexts);
 
   it("opens the diff sidebar with per-file patches and gap markers", async () => {
     const context = await newBrowserContext();

--- a/ui/src/e2e/native-link-routing.e2e.test.ts
+++ b/ui/src/e2e/native-link-routing.e2e.test.ts
@@ -18,22 +18,24 @@ const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? descri
 const artifactDir = path.resolve(process.cwd(), ".artifacts/control-ui-e2e/native-link-routing");
 
 let server: ControlUiE2eServer;
-const openBrowsers = new Set<Browser>();
+// Browser contexts preserve test isolation; keep one process warm for this file.
+let browser: Browser;
+const openContexts = new Set<BrowserContext>();
 
 async function newBrowserContext(): Promise<BrowserContext> {
-  const browser = await chromium.launch({ executablePath: chromiumExecutablePath });
-  openBrowsers.add(browser);
-  return browser.newContext({
+  const context = await browser.newContext({
     colorScheme: "light",
     locale: "en-US",
     serviceWorkers: "block",
     viewport: { height: 800, width: 1180 },
   });
+  openContexts.add(context);
+  return context;
 }
 
-async function closeBrowsers(): Promise<void> {
-  await Promise.all([...openBrowsers].map((browser) => browser.close().catch(() => {})));
-  openBrowsers.clear();
+async function closeContexts(): Promise<void> {
+  await Promise.all([...openContexts].map((context) => context.close().catch(() => {})));
+  openContexts.clear();
 }
 
 describeControlUiE2e("native link routing", () => {
@@ -42,15 +44,22 @@ describeControlUiE2e("native link routing", () => {
       throw new Error(`Playwright Chromium is unavailable at ${chromiumExecutablePath}`);
     }
     fs.mkdirSync(artifactDir, { recursive: true });
-    server = await startControlUiE2eServer();
+    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
+    try {
+      server = await startControlUiE2eServer();
+    } catch (error) {
+      await browser.close();
+      throw error;
+    }
   });
 
   afterAll(async () => {
-    await closeBrowsers();
+    await closeContexts();
+    await browser?.close();
     await server?.close();
   });
 
-  afterEach(closeBrowsers);
+  afterEach(closeContexts);
 
   it("shows native actions and posts inline or external targets", async () => {
     const context = await newBrowserContext();

--- a/ui/src/e2e/session-list-filter.e2e.test.ts
+++ b/ui/src/e2e/session-list-filter.e2e.test.ts
@@ -14,13 +14,20 @@ const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
 const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
 const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
 
-let browser: Browser | undefined;
+// Browser contexts preserve test isolation; keep one process warm for this file.
+let browser: Browser;
 let page: Page | undefined;
 let server: ControlUiE2eServer | undefined;
 
 describeControlUiE2e("Control UI session-list event scope", () => {
   beforeAll(async () => {
-    server = await startControlUiE2eServer();
+    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
+    try {
+      server = await startControlUiE2eServer();
+    } catch (error) {
+      await browser.close();
+      throw error;
+    }
   });
 
   afterEach(async () => {
@@ -28,19 +35,17 @@ describeControlUiE2e("Control UI session-list event scope", () => {
       ?.context()
       .close()
       .catch(() => {});
-    await browser?.close().catch(() => {});
     page = undefined;
-    browser = undefined;
   });
 
   afterAll(async () => {
+    await browser?.close().catch(() => {});
     await server?.close();
   });
 
   it("refetches instead of showing a row excluded by configured-agent filtering", async () => {
     const visibleLabel = "Visible configured session";
     const hiddenLabel = "Hidden unconfigured session";
-    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
     const context = await browser.newContext({ viewport: { height: 800, width: 1200 } });
     const currentPage = await context.newPage();
     page = currentPage;
@@ -109,7 +114,6 @@ describeControlUiE2e("Control UI session-list event scope", () => {
   });
 
   it("omits noncanonical numeric filters from sessions.list requests", async () => {
-    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
     const context = await browser.newContext({ viewport: { height: 800, width: 1200 } });
     const currentPage = await context.newPage();
     page = currentPage;

--- a/ui/src/e2e/session-transcript-search.e2e.test.ts
+++ b/ui/src/e2e/session-transcript-search.e2e.test.ts
@@ -23,7 +23,8 @@ const artifactDir = path.join(
   "session-transcript-search",
 );
 
-let browser: Browser | undefined;
+// Browser contexts preserve test isolation; keep one process warm for this file.
+let browser: Browser;
 let context: BrowserContext | undefined;
 let page: Page | undefined;
 let server: ControlUiE2eServer | undefined;
@@ -40,24 +41,28 @@ describeControlUiE2e("Control UI session transcript search", () => {
     if (captureProof) {
       await mkdir(artifactDir, { recursive: true });
     }
-    server = await startControlUiE2eServer();
+    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
+    try {
+      server = await startControlUiE2eServer();
+    } catch (error) {
+      await browser.close();
+      throw error;
+    }
   });
 
   afterEach(async () => {
     await context?.close().catch(() => {});
-    await browser?.close().catch(() => {});
     context = undefined;
-    browser = undefined;
     page = undefined;
   });
 
   afterAll(async () => {
+    await browser?.close().catch(() => {});
     await server?.close();
   });
 
   it("searches once on submit, shows provenance, and opens the matching chat", async () => {
     const timestamp = Date.parse("2026-07-12T14:30:00.000Z");
-    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
     context = await browser.newContext({
       colorScheme: "light",
       locale: "en-US",
@@ -156,7 +161,6 @@ describeControlUiE2e("Control UI session transcript search", () => {
 
   it("ignores stale results and exposes indexing and request errors", async () => {
     const timestamp = Date.parse("2026-07-12T14:30:00.000Z");
-    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
     context = await browser.newContext({
       locale: "en-US",
       serviceWorkers: "block",
@@ -251,7 +255,6 @@ describeControlUiE2e("Control UI session transcript search", () => {
   });
 
   it("disables the control when transcript search is not advertised", async () => {
-    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
     context = await browser.newContext({
       locale: "en-US",
       serviceWorkers: "block",


### PR DESCRIPTION
## What Problem This Solves

Control UI E2E tests repeatedly started a full Chromium process for individual cases, adding avoidable process-launch overhead to local and hosted test feedback.

## Why This Change Was Made

Ten UI E2E files now keep one Chromium process warm per file while retaining a fresh BrowserContext for every test. Context isolation, cleanup, missing-browser behavior, and server-start failure cleanup remain intact. One agent-scoped metadata assertion also retains its exact predicate while allowing the same 10-second startup window as the shared mock-gateway waiter. No CI configuration or production code changes.

AI-assisted: yes. I reviewed the full diff and understand the resource-lifecycle change.

## User Impact

No runtime behavior change. Developers and CI receive faster Control UI E2E feedback with the same 76 assertions and per-test browser-context isolation.

## Evidence

- Same warmed Blacksmith Testbox, same 10-file batch: 115.83s before, 101.98s after (12.0% faster).
- Chromium process launches: 76 before, 10 after.
- `pnpm test <10 UI E2E files>`: 10 files and 76 tests passed.
- Follow-up after hosted contention exposed the startup deadline: composer file passed 3/3 runs (18 tests) on a fresh Testbox.
- `pnpm check:changed`: passed in 13m49s, including formatting, Control UI i18n, test typecheck, and core/UI/package lint.
- Mandatory branch autoreview against current `origin/main`: no findings, patch correct (0.96 confidence).
