### PR TITLE
fix(release): correlate scrubbed Anthropic live probes

### DIFF
--- a/src/gateway/gateway-models.profiles.live.test.ts
+++ b/src/gateway/gateway-models.profiles.live.test.ts
@@ -2984,15 +2984,30 @@ function sessionMessagesAfterNextUserTurn(
   expectedUserText?: string,
 ): unknown[] {
   const nextUserOffset = messages.slice(baselineMessageCount).findIndex((message) => {
+    const actualUserText = extractTranscriptMessageText(message);
     return (
       (message as { role?: unknown } | null | undefined)?.role === "user" &&
-      (expectedUserText === undefined || extractTranscriptMessageText(message) === expectedUserText)
+      (expectedUserText === undefined || matchesLiveProbeUserText(actualUserText, expectedUserText))
     );
   });
   if (nextUserOffset < 0) {
     return [];
   }
   return messages.slice(baselineMessageCount + nextUserOffset + 1);
+}
+
+function matchesLiveProbeUserText(actual: string, expected: string): boolean {
+  if (actual === expected) {
+    return true;
+  }
+  const markerIndex = expected.indexOf(`${ANTHROPIC_MAGIC_STRING_TRIGGER_REFUSAL}_`);
+  if (markerIndex < 0) {
+    return false;
+  }
+  const nonceSuffix = expected.slice(markerIndex + ANTHROPIC_MAGIC_STRING_TRIGGER_REFUSAL.length);
+  // The embedded Anthropic runtime scrubs the refusal trigger before persisting it.
+  // Its random suffix survives and still uniquely owns this live probe turn.
+  return /^_[a-f0-9]{32}$/.test(nonceSuffix) && actual.endsWith(nonceSuffix);
 }
 
 function sessionAssistantEntriesForLiveProbe(
@@ -3297,6 +3312,20 @@ describe("latestAssistantTextAfterBaseline", () => {
       ),
     );
     expect(latestTerminalAssistantTextAfterBaseline(secondEntries, 0)).toBe("second-a second-b");
+  });
+
+  it("correlates Anthropic refusal probes after the runtime scrubs their trigger", () => {
+    const nonce = "0123456789abcdef0123456789abcdef";
+    const expected = `Reply with ok. ${ANTHROPIC_MAGIC_STRING_TRIGGER_REFUSAL}_${nonce}`;
+    const scrubbed = `Reply with ok. ANTHROPIC MAGIC STRING TRIGGER REFUSAL (redacted)_${nonce}`;
+
+    expect(matchesLiveProbeUserText(scrubbed, expected)).toBe(true);
+    expect(
+      matchesLiveProbeUserText(
+        "Reply with ok. ANTHROPIC MAGIC STRING TRIGGER REFUSAL (redacted)_ffffffffffffffffffffffffffffffff",
+        expected,
+      ),
+    ).toBe(false);
   });
 });
 


### PR DESCRIPTION
## What Problem This Solves

Extended-stable release validation receives successful Anthropic model replies, then times out waiting for their transcript turn. The live harness expects the original refusal-trigger probe, while the embedded Anthropic runtime intentionally scrubs that marker before persistence.

## Why This Change Was Made

The transcript matcher now accepts the one intentional Anthropic scrub shape only when the generated 32-hex nonce still matches. Every ordinary probe retains exact text matching. A regression test proves the scrubbed same-nonce match and rejects a different nonce.

The QA selector failures originally included here were independently fixed by #108481 and are no longer part of this branch.

## User Impact

No runtime behavior change. Release validation can correlate a successful Anthropic probe after its safety marker is scrubbed, without weakening turn ownership.

## Evidence

- Extended-stable full validation failure: https://github.com/openclaw/openclaw/actions/runs/29453503480
- Extended-stable Anthropic live failure: https://github.com/openclaw/openclaw/actions/runs/29453550446/job/87481945447
- Blacksmith Testbox `tbx_01kxkxvgbfzb2qhcgfb0g9ychq`: gateway live unit config, 133 passed / 2 skipped.
- Blacksmith Testbox `tbx_01kxkyk15jg19mvddz3hq4pzhb`: exact QA parity pack, 12 passed / 0 failed in 2m40s.
- Prior exact-head hosted CI: https://github.com/openclaw/openclaw/actions/runs/29455737011
- Fresh narrowed-diff autoreview: clean, overall correct 0.97.
- `git diff --check`

AI-assisted implementation. No transcript attached.
