### PR TITLE
fix(agents): stabilize stale lock retry test

### DIFF
--- a/src/agents/session-write-lock.test.ts
+++ b/src/agents/session-write-lock.test.ts
@@ -633,7 +633,13 @@ describe("acquireSessionWriteLock", () => {
       }) as typeof fs.readFile);
 
       try {
-        const lock = await acquireSessionWriteLock({ sessionFile, timeoutMs: 800, staleMs: 10 });
+        // Keep the original lock stale while the replacement stays fresh for the full acquire
+        // budget. Worker scheduling must not turn the replacement into another stale report.
+        const lock = await acquireSessionWriteLock({
+          sessionFile,
+          timeoutMs: 800,
+          staleMs: 60_000,
+        });
         await lock.release();
         expect(lockReads).toBeGreaterThanOrEqual(3);
         await expectPathMissing(lockPath);


### PR DESCRIPTION
## What Problem This Solves

Resolves intermittent `SessionWriteLockStaleError` failures in the parallel agents test suite when the stale-lock retry test replaces an old owner lock with a new payload-less lock.

## Why This Change Was Made

The test now gives the replacement lock a freshness window longer than the complete acquisition budget while keeping the original 120-second-old lock stale. This removes wall-clock scheduler sensitivity without changing production lock policy.

## User Impact

No user-visible runtime change. Maintainers get deterministic session write-lock coverage under loaded parallel workers.

## Evidence

- Blacksmith Testbox `tbx_01kxkyj1m6ztgnrqhyvx701ara`: 50 consecutive focused passes through `node scripts/run-vitest.mjs src/agents/session-write-lock.test.ts` on Linux / Node 24.
- Parallel `pnpm test src/agents`: `session-write-lock.test.ts` passed 54/54 under suite load. One attempt later lost an unrelated Vitest worker; the retry completed 630/631 files and failed only `run.timeout-triggered-compaction.test.ts` with a stale gateway lifecycle.
- `pnpm check:changed`: green, including format, core-test typecheck, and changed-file lint.
- Autoreview: clean, no accepted or actionable findings.

AI-assisted change. I reviewed the timing contract and dependency implementation and understand the test-only fix.
