### PR TITLE
fix(secrets): inactive web refs no longer block agent turns

### DIFF
--- a/src/cli/command-secret-gateway.test.ts
+++ b/src/cli/command-secret-gateway.test.ts
@@ -1311,6 +1311,56 @@ describe("resolveCommandSecretRefsViaGateway", () => {
     });
   });
 
+  it("accepts an inactive web ref after an incomplete gateway snapshot", async () => {
+    const restoreDeps = setGoogleWebSearchTargetDeps();
+    const webPath = "plugins.entries.google.config.webSearch.apiKey";
+    try {
+      callGateway.mockResolvedValueOnce({
+        assignments: [],
+        diagnostics: [],
+      });
+      const result = await resolveCommandSecretRefsViaGateway({
+        config: {
+          tools: {
+            web: {
+              search: {
+                enabled: false,
+                provider: "gemini",
+              },
+            },
+          },
+          plugins: {
+            entries: {
+              google: {
+                config: {
+                  webSearch: {
+                    apiKey: {
+                      source: "env",
+                      provider: "default",
+                      id: "missing-disabled-web-ref",
+                    },
+                  },
+                },
+              },
+            },
+          },
+        } as OpenClawConfig,
+        commandName: "agent",
+        targetIds: new Set([webPath]),
+      });
+
+      expect(result.hadUnresolvedTargets).toBe(false);
+      expect(result.targetStatesByPath[webPath]).toBe("inactive_surface");
+      expect(
+        result.diagnostics.some((entry) =>
+          entry.includes(`${webPath}: tools.web.search is disabled.`),
+        ),
+      ).toBe(true);
+    } finally {
+      restoreDeps();
+    }
+  });
+
   it("limits strict local fallback analysis to unresolved gateway paths", async () => {
     const locallyRecoveredKey = "TALK_API_KEY_PARTIAL_GATEWAY_LOCAL";
     await withEnvValue(locallyRecoveredKey, "recovered-locally", async () => {

--- a/src/cli/command-secret-gateway.test.ts
+++ b/src/cli/command-secret-gateway.test.ts
@@ -1361,6 +1361,72 @@ describe("resolveCommandSecretRefsViaGateway", () => {
     }
   });
 
+  it.each([
+    {
+      label: "search",
+      path: "plugins.entries.google.config.webSearch.apiKey",
+      setupDeps: setGoogleWebSearchTargetDeps,
+      config: {
+        tools: { web: { search: { provider: "unregistered-provider" } } },
+        plugins: {
+          entries: {
+            google: {
+              config: {
+                webSearch: {
+                  apiKey: {
+                    source: "env",
+                    provider: "default",
+                    id: "missing-active-web-search-ref",
+                  },
+                },
+              },
+            },
+          },
+        },
+      } as OpenClawConfig,
+    },
+    {
+      label: "fetch",
+      path: "plugins.entries.firecrawl.config.webFetch.apiKey",
+      setupDeps: setFirecrawlWebFetchTargetDeps,
+      config: {
+        tools: { web: { fetch: { provider: "unregistered-provider" } } },
+        plugins: {
+          entries: {
+            firecrawl: {
+              config: {
+                webFetch: {
+                  apiKey: {
+                    source: "env",
+                    provider: "default",
+                    id: "missing-active-web-fetch-ref",
+                  },
+                },
+              },
+            },
+          },
+        },
+      } as OpenClawConfig,
+    },
+  ])("fails closed when a configured web $label provider owner cannot be proven", async (test) => {
+    const restoreDeps = test.setupDeps();
+    try {
+      callGateway.mockResolvedValueOnce({
+        assignments: [],
+        diagnostics: [],
+      });
+      await expect(
+        resolveCommandSecretRefsViaGateway({
+          config: test.config,
+          commandName: "agent",
+          targetIds: new Set([test.path]),
+        }),
+      ).rejects.toThrow(`${test.path} is unresolved in the active runtime snapshot`);
+    } finally {
+      restoreDeps();
+    }
+  });
+
   it("limits strict local fallback analysis to unresolved gateway paths", async () => {
     const locallyRecoveredKey = "TALK_API_KEY_PARTIAL_GATEWAY_LOCAL";
     await withEnvValue(locallyRecoveredKey, "recovered-locally", async () => {

--- a/src/cli/command-secret-gateway.ts
+++ b/src/cli/command-secret-gateway.ts
@@ -192,14 +192,16 @@ function classifyRuntimeWebTargetPathState(params: {
       if (!configuredProvider) {
         return "active";
       }
-      return commandSecretGatewayDeps.resolveManifestContractOwnerPluginId({
+      const configuredPluginId = commandSecretGatewayDeps.resolveManifestContractOwnerPluginId({
         contract: "webFetchProviders",
         value: configuredProvider,
         origin: "bundled",
         config: params.config,
-      }) === pluginId
-        ? "active"
-        : "inactive";
+      });
+      if (!configuredPluginId) {
+        return "unknown";
+      }
+      return configuredPluginId === pluginId ? "active" : "inactive";
     }
     const search = params.config.tools?.web?.search;
     if (search?.enabled === false) {
@@ -209,14 +211,16 @@ function classifyRuntimeWebTargetPathState(params: {
     if (!configuredProvider) {
       return "active";
     }
-    return commandSecretGatewayDeps.resolveManifestContractOwnerPluginId({
+    const configuredPluginId = commandSecretGatewayDeps.resolveManifestContractOwnerPluginId({
       contract: "webSearchProviders",
       value: configuredProvider,
       origin: "bundled",
       config: params.config,
-    }) === pluginId
-      ? "active"
-      : "inactive";
+    });
+    if (!configuredPluginId) {
+      return "unknown";
+    }
+    return configuredPluginId === pluginId ? "active" : "inactive";
   }
 
   const match = /^tools\.web\.search\.([^.]+)\.apiKey$/.exec(params.path);

--- a/src/cli/command-secret-gateway.ts
+++ b/src/cli/command-secret-gateway.ts
@@ -1119,8 +1119,18 @@ export async function resolveCommandSecretRefsViaGateway(params: {
         optionalActivePaths: params.optionalActivePaths,
         resolutionPolicy,
       });
+      const handledPaths = new Set<string>();
+      const locallyResolvedPaths = new Set<string>();
       for (const unresolved of analyzed.unresolved) {
-        if (localFallback.targetStatesByPath[unresolved.path] !== "resolved_local") {
+        const localState = localFallback.targetStatesByPath[unresolved.path];
+        if (localState === "inactive_surface") {
+          // A partial gateway snapshot can omit inactive refs as well as unresolved refs.
+          // Local inactive classification is terminal even though it materializes no value.
+          targetStatesByPath[unresolved.path] = localState;
+          handledPaths.add(unresolved.path);
+          continue;
+        }
+        if (localState !== "resolved_local") {
           continue;
         }
         setPathExistingStrict(
@@ -1128,16 +1138,12 @@ export async function resolveCommandSecretRefsViaGateway(params: {
           unresolved.pathSegments,
           getPath(localFallback.resolvedConfig, unresolved.pathSegments),
         );
-        targetStatesByPath[unresolved.path] = "resolved_local";
+        targetStatesByPath[unresolved.path] = localState;
+        handledPaths.add(unresolved.path);
+        locallyResolvedPaths.add(unresolved.path);
       }
-      const recoveredPaths = new Set(
-        Object.entries(localFallback.targetStatesByPath)
-          .filter(([, state]) => state === "resolved_local")
-          .map(([path]) => path),
-      );
-      const stillUnresolved = analyzed.unresolved.filter(
-        (entry) => !recoveredPaths.has(entry.path),
-      );
+      diagnostics = dedupeDiagnostics([...diagnostics, ...localFallback.diagnostics]);
+      const stillUnresolved = analyzed.unresolved.filter((entry) => !handledPaths.has(entry.path));
       if (stillUnresolved.length > 0) {
         if (enforcesResolvedSecrets(mode)) {
           throw new Error(
@@ -1149,17 +1155,16 @@ export async function resolveCommandSecretRefsViaGateway(params: {
         }
         diagnostics = dedupeDiagnostics([
           ...diagnostics,
-          ...localFallback.diagnostics,
           ...buildUnresolvedDiagnostics(params.commandName, stillUnresolved, mode),
         ]);
         for (const unresolved of stillUnresolved) {
           targetStatesByPath[unresolved.path] = "unresolved";
         }
-      } else if (recoveredPaths.size > 0) {
+      } else if (locallyResolvedPaths.size > 0) {
         diagnostics = dedupeDiagnostics([
           ...diagnostics,
-          `${params.commandName}: resolved ${recoveredPaths.size} secret ${
-            recoveredPaths.size === 1 ? "path" : "paths"
+          `${params.commandName}: resolved ${locallyResolvedPaths.size} secret ${
+            locallyResolvedPaths.size === 1 ? "path" : "paths"
           } locally after the gateway snapshot was incomplete.`,
         ]);
       }

--- a/src/gateway/server-startup-inactive-web-secret.test.ts
+++ b/src/gateway/server-startup-inactive-web-secret.test.ts
@@ -1,0 +1,118 @@
+/** Gateway startup coverage for active and inactive web-provider SecretRefs. */
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import { getActiveSecretsRuntimeSnapshot } from "../secrets/runtime.js";
+import { withEnvAsync } from "../test-utils/env.js";
+import { getFreePort, installGatewayTestHooks, startGatewayServer } from "./test-helpers.js";
+
+vi.mock("./operator-approval-store.js", async () => {
+  const actual = await vi.importActual<typeof import("./operator-approval-store.js")>(
+    "./operator-approval-store.js",
+  );
+  return {
+    ...actual,
+    closeOrphanedOperatorApprovals: vi.fn(() => 0),
+    pruneTerminalOperatorApprovals: vi.fn(() => 0),
+  };
+});
+
+const INACTIVE_SECRET_ENV = "OPENCLAW_TEST_INACTIVE_WEB_SEARCH_SECRET";
+const ACTIVE_SECRET_ENV = "OPENCLAW_TEST_ACTIVE_WEB_SEARCH_SECRET";
+const SECRET_PATH = "plugins.entries.google.config.webSearch.apiKey";
+const BUNDLED_PLUGINS_DIR = fileURLToPath(new URL("../../extensions", import.meta.url));
+
+installGatewayTestHooks({ scope: "suite" });
+
+function buildConfig(params: { enabled: boolean; envVar: string }): OpenClawConfig {
+  return {
+    gateway: {
+      mode: "local",
+      bind: "loopback",
+      auth: { mode: "none" },
+    },
+    secrets: {
+      providers: {
+        default: { source: "env" },
+      },
+    },
+    tools: {
+      web: {
+        search: {
+          enabled: params.enabled,
+          provider: "gemini",
+        },
+      },
+    },
+    plugins: {
+      enabled: true,
+      entries: {
+        google: {
+          enabled: true,
+          config: {
+            webSearch: {
+              apiKey: {
+                source: "env",
+                provider: "default",
+                id: params.envVar,
+              },
+            },
+          },
+        },
+      },
+    },
+  } as OpenClawConfig;
+}
+
+async function writeConfig(config: OpenClawConfig): Promise<void> {
+  const { writeConfigFile } = await import("../config/config.js");
+  await writeConfigFile(config);
+}
+
+describe("gateway startup web-provider SecretRefs", () => {
+  let server: Awaited<ReturnType<typeof startGatewayServer>> | undefined;
+
+  afterEach(async () => {
+    await server?.close();
+    server = undefined;
+  });
+
+  it("starts and warns when an unresolved web secret is provably inactive", async () => {
+    await withEnvAsync(
+      {
+        [INACTIVE_SECRET_ENV]: undefined,
+        OPENCLAW_BUNDLED_PLUGINS_DIR: BUNDLED_PLUGINS_DIR,
+        OPENCLAW_DISABLE_BUNDLED_PLUGINS: undefined,
+      },
+      async () => {
+        await writeConfig(buildConfig({ enabled: false, envVar: INACTIVE_SECRET_ENV }));
+
+        server = await startGatewayServer(await getFreePort(), { auth: { mode: "none" } });
+
+        expect(getActiveSecretsRuntimeSnapshot()?.warnings).toContainEqual(
+          expect.objectContaining({
+            code: "SECRETS_REF_IGNORED_INACTIVE_SURFACE",
+            path: SECRET_PATH,
+          }),
+        );
+      },
+    );
+  });
+
+  it("fails closed when the unresolved web secret is active", async () => {
+    await withEnvAsync(
+      {
+        [ACTIVE_SECRET_ENV]: undefined,
+        OPENCLAW_BUNDLED_PLUGINS_DIR: BUNDLED_PLUGINS_DIR,
+        OPENCLAW_DISABLE_BUNDLED_PLUGINS: undefined,
+      },
+      async () => {
+        await writeConfig(buildConfig({ enabled: true, envVar: ACTIVE_SECRET_ENV }));
+
+        await expect(
+          startGatewayServer(await getFreePort(), { auth: { mode: "none" } }),
+        ).rejects.toThrow(/Startup failed: required secrets are unavailable/);
+      },
+    );
+  });
+});

--- a/src/gateway/server-startup-inactive-web-secret.test.ts
+++ b/src/gateway/server-startup-inactive-web-secret.test.ts
@@ -1,10 +1,41 @@
 /** Gateway startup coverage for active and inactive web-provider SecretRefs. */
-import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import { getActiveSecretsRuntimeSnapshot } from "../secrets/runtime.js";
 import { withEnvAsync } from "../test-utils/env.js";
 import { getFreePort, installGatewayTestHooks, startGatewayServer } from "./test-helpers.js";
+
+const { webSearchProviders } = vi.hoisted(() => {
+  const credentialPath = "plugins.entries.google.config.webSearch.apiKey";
+  return {
+    webSearchProviders: [
+      {
+        pluginId: "google",
+        id: "gemini",
+        label: "Gemini",
+        hint: "Gateway startup test provider",
+        envVars: ["GEMINI_API_KEY"],
+        placeholder: "gemini-...",
+        signupUrl: "https://example.com/gemini",
+        autoDetectOrder: 20,
+        credentialPath,
+        inactiveSecretPaths: [credentialPath],
+        getCredentialValue: (config: { apiKey?: unknown } | undefined) => config?.apiKey,
+        setCredentialValue: (config: { apiKey?: unknown }, value: unknown) => {
+          config.apiKey = value;
+        },
+        getConfiguredCredentialValue: (config: OpenClawConfig | undefined) => {
+          const pluginConfig = config?.plugins?.entries?.google?.config;
+          return pluginConfig && typeof pluginConfig === "object"
+            ? (pluginConfig as { webSearch?: { apiKey?: unknown } }).webSearch?.apiKey
+            : undefined;
+        },
+        setConfiguredCredentialValue: () => {},
+        createTool: () => null,
+      },
+    ],
+  };
+});
 
 vi.mock("./operator-approval-store.js", async () => {
   const actual = await vi.importActual<typeof import("./operator-approval-store.js")>(
@@ -17,10 +48,34 @@ vi.mock("./operator-approval-store.js", async () => {
   };
 });
 
+vi.mock("../secrets/runtime-web-tools-manifest.runtime.js", () => ({
+  resolveManifestContractPluginIds: ({ contract }: { contract: string }) =>
+    contract === "webSearchProviders" ? ["google"] : [],
+  resolveManifestContractOwnerPluginId: ({ value }: { value: string }) =>
+    value === "gemini" ? "google" : undefined,
+  resolveManifestContractPluginIdsByCompatibilityRuntimePath: () => [],
+}));
+
+vi.mock("../plugins/web-provider-public-artifacts.explicit.js", () => ({
+  resolveBundledExplicitWebSearchProvidersFromPublicArtifacts: () => webSearchProviders,
+  resolveBundledExplicitWebFetchProvidersFromPublicArtifacts: () => [],
+}));
+
+vi.mock("../secrets/runtime-web-tools-public-artifacts.runtime.js", () => ({
+  resolveBundledWebSearchProvidersFromPublicArtifacts: () => webSearchProviders,
+  resolveBundledWebFetchProvidersFromPublicArtifacts: () => [],
+}));
+
+vi.mock("../secrets/runtime-web-tools-fallback.runtime.js", () => ({
+  runtimeWebToolsFallbackProviders: {
+    resolvePluginWebSearchProviders: () => webSearchProviders,
+    resolvePluginWebFetchProviders: () => [],
+  },
+}));
+
 const INACTIVE_SECRET_ENV = "OPENCLAW_TEST_INACTIVE_WEB_SEARCH_SECRET";
 const ACTIVE_SECRET_ENV = "OPENCLAW_TEST_ACTIVE_WEB_SEARCH_SECRET";
 const SECRET_PATH = "plugins.entries.google.config.webSearch.apiKey";
-const BUNDLED_PLUGINS_DIR = fileURLToPath(new URL("../../extensions", import.meta.url));
 
 installGatewayTestHooks({ scope: "suite" });
 
@@ -78,41 +133,27 @@ describe("gateway startup web-provider SecretRefs", () => {
   });
 
   it("starts and warns when an unresolved web secret is provably inactive", async () => {
-    await withEnvAsync(
-      {
-        [INACTIVE_SECRET_ENV]: undefined,
-        OPENCLAW_BUNDLED_PLUGINS_DIR: BUNDLED_PLUGINS_DIR,
-        OPENCLAW_DISABLE_BUNDLED_PLUGINS: undefined,
-      },
-      async () => {
-        await writeConfig(buildConfig({ enabled: false, envVar: INACTIVE_SECRET_ENV }));
+    await withEnvAsync({ [INACTIVE_SECRET_ENV]: undefined }, async () => {
+      await writeConfig(buildConfig({ enabled: false, envVar: INACTIVE_SECRET_ENV }));
 
-        server = await startGatewayServer(await getFreePort(), { auth: { mode: "none" } });
+      server = await startGatewayServer(await getFreePort(), { auth: { mode: "none" } });
 
-        expect(getActiveSecretsRuntimeSnapshot()?.warnings).toContainEqual(
-          expect.objectContaining({
-            code: "SECRETS_REF_IGNORED_INACTIVE_SURFACE",
-            path: SECRET_PATH,
-          }),
-        );
-      },
-    );
+      expect(getActiveSecretsRuntimeSnapshot()?.warnings).toContainEqual(
+        expect.objectContaining({
+          code: "SECRETS_REF_IGNORED_INACTIVE_SURFACE",
+          path: SECRET_PATH,
+        }),
+      );
+    });
   });
 
   it("fails closed when the unresolved web secret is active", async () => {
-    await withEnvAsync(
-      {
-        [ACTIVE_SECRET_ENV]: undefined,
-        OPENCLAW_BUNDLED_PLUGINS_DIR: BUNDLED_PLUGINS_DIR,
-        OPENCLAW_DISABLE_BUNDLED_PLUGINS: undefined,
-      },
-      async () => {
-        await writeConfig(buildConfig({ enabled: true, envVar: ACTIVE_SECRET_ENV }));
+    await withEnvAsync({ [ACTIVE_SECRET_ENV]: undefined }, async () => {
+      await writeConfig(buildConfig({ enabled: true, envVar: ACTIVE_SECRET_ENV }));
 
-        await expect(
-          startGatewayServer(await getFreePort(), { auth: { mode: "none" } }),
-        ).rejects.toThrow(/Startup failed: required secrets are unavailable/);
-      },
-    );
+      await expect(
+        startGatewayServer(await getFreePort(), { auth: { mode: "none" } }),
+      ).rejects.toThrow(/Startup failed: required secrets are unavailable/);
+    });
   });
 });


### PR DESCRIPTION
Related: #105536

## Summary

Accept locally classified inactive SecretRefs as terminal when a successful Gateway `secrets.resolve` response contains only a partial command snapshot.

## What Problem This Solves

Fixes an issue where ordinary agent turns could fail before model execution when a disabled or non-selected web provider retained a SecretRef and the active Gateway returned a valid but incomplete secrets snapshot.

## Root Cause

PR #105160 changed the Gateway command resolver to preserve authoritative assignments from partial runtime snapshots. That made the caller's targeted local-fallback merge reachable for paths omitted by a successful Gateway response.

Before this change, that merge accepted only `resolved_local`. The existing local resolver correctly classified omitted disabled-provider paths as `inactive_surface`, but the merge ignored that terminal state and relabeled the path unresolved. In strict agent preparation, it then threw `is unresolved in the active runtime snapshot` before the agent run began.

The related #105536 addresses how new runtime snapshots collect inactive web-provider credentials. This change is complementary: it repairs the established partial-result fallback contract even when a Gateway snapshot omits an inactive path.

## Why This Change Was Made

The partial-result merge now handles both locally materialized values and locally proven inactive paths. Genuine unresolved paths keep the existing strict failure behavior, and the local-resolution summary still counts only paths that materialized a value.

## User Impact

Agent turns no longer fail merely because an inactive web provider credential is absent from an otherwise valid partial Gateway snapshot. Missing credentials on active surfaces still fail as before.

## Evidence

On current `main`, the added regression failed with 1 failed / 35 passed and `agent: plugins.entries.google.config.webSearch.apiKey is unresolved in the active runtime snapshot`. With this patch, the focused CLI and runtime-secret command passes both Vitest shards with 40 tests passed; strict preparation records the omitted path as `inactive_surface` with no unresolved targets.

## Real behavior proof

- **Before behavior:** the added focused regression failed on current `main` with 1 failed / 35 passed and `agent: plugins.entries.google.config.webSearch.apiKey is unresolved in the active runtime snapshot`.
- **Exact after-patch command:** `node scripts/run-vitest.mjs src/cli/command-secret-gateway.test.ts src/secrets/runtime-command-secrets.test.ts`
- **Copied after result:** 2 Vitest shards passed; 40 tests passed.
- **Observed after behavior:** strict agent preparation returns `hadUnresolvedTargets: false`, preserves the configured SecretRef, records `inactive_surface`, and retains the existing inactive-surface diagnostic.

## Verification

- `node scripts/run-vitest.mjs src/cli/command-secret-gateway.test.ts src/secrets/runtime-command-secrets.test.ts` — 40 tests passed.
- `./node_modules/.bin/oxlint src/cli/command-secret-gateway.ts src/cli/command-secret-gateway.test.ts` — passed.
- `./node_modules/.bin/oxfmt --check src/cli/command-secret-gateway.ts src/cli/command-secret-gateway.test.ts` — passed.
- `git diff --check` — passed.
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted --stream-engine-output` — clean, no findings; patch correct at 0.94 confidence.

## What was not tested

A live Telegram turn against a restarted patched Gateway was not run because that would mutate the operator's live service. The full remote changed gate was attempted but did not execute: Blacksmith Testbox authentication and the owned AWS Crabbox broker login are unavailable on this host. Exact-head non-draft PR CI is the authoritative broad gate.
