### PR TITLE
docs: correct AGENTS.md scoped-guide list and link architecture docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,7 @@ Skills own workflows; root owns hard policy and routing.
 
 - Core TS: `src/`, `ui/`, `packages/`; plugins: `extensions/`; SDK: `src/plugin-sdk/*`; channels: `src/channels/*`; loader: `src/plugins/*`; protocol: `packages/gateway-protocol/*`; docs/apps: `docs/`, `apps/`.
 - Installers: sibling `../openclaw.ai`.
-- Scoped guides: `extensions/`, `src/{plugin-sdk,channels,plugins,gateway,agents}/`, `packages/`, `test/helpers*/`, `docs/`, `ui/`, `scripts/`.
+- Scoped guides: `extensions/`, `src/{agents,channels,gateway,infra/outbound,plugin-sdk,plugins,tui}/`, `apps/{android,ios}/`, `test/`, `test/helpers/`, `docs/`, `ui/`, `scripts/`.
 
 ## Docs
 
@@ -54,6 +54,7 @@ Skills own workflows; root owns hard policy and routing.
 
 ## Architecture
 
+- Big-picture system narrative before these policy rules: `docs/concepts/architecture.md` (gateway/protocol/clients), `docs/agent-runtime-architecture.md` (agent runtime layout), `docs/plugins/architecture.md` (plugin capability model).
 - Core stays plugin-agnostic. No bundled ids/defaults/policy in core when manifest/registry/capability contracts work.
 - Plugins cross into core only via `openclaw/plugin-sdk/*`, manifest metadata, injected runtime helpers, documented barrels (`api.ts`, `runtime-api.ts`).
 - Plugin prod code: no core `src/**`, `src/plugin-sdk-internal/**`, other plugin `src/**`, or relative outside package.


### PR DESCRIPTION
## What Problem This Solves

Root `AGENTS.md` sends agents to a scoped guide that does not exist, and omits four directories that do have one.

Its `Map` section lists `packages/` as a scoped-guide location. There is no `packages/AGENTS.md`. Meanwhile `src/infra/outbound/`, `src/tui/`, `apps/android/`, and `apps/ios/` all have substantial scoped guides that the list never mentions, and `test/helpers*/` glosses over `test/AGENTS.md` itself. An agent following the root file to find the guides that own a subtree is pointed at an empty directory while skipping four real guides — including both mobile platform guides.

Separately, the `Architecture` section opens directly into policy bullets with no pointer to the three narrative architecture docs that already exist in this repo. An agent orienting from the root file has no route to the system overview, so the big-picture docs are effectively unreachable from the entry point that agents are told to read first.

## Why This Change Was Made

Two line-level accuracy fixes, both derived from the current tree rather than from memory.

The scoped-guide list was rebuilt by enumerating every `AGENTS.md` in the repo, excluding `node_modules` and test fixtures, and is now the real set. `packages/` is dropped because it has no guide; `src/infra/outbound/` and `src/tui/` are added; `apps/{android,ios}/` are added; `test/` is listed alongside `test/helpers/` because both have one.

The `Architecture` section gains a single line naming the three existing narrative docs and what each covers, placed before the policy bullets so the ordering reads overview-then-rules.

Deliberately out of scope: this PR no longer carries the `.gitignore` change or the product one-liner that earlier revisions bundled. The `.gitignore` change was split into #114070 and has since been withdrawn, since it can only land with security-sensitive-file authorization from a maintainer; either way it no longer gates this PR. The product one-liner remains separate in #101855 because it is an editorial-scope decision rather than a factual correction. This PR is now purely factual fixes to `AGENTS.md`.

## User Impact

No runtime or user-visible product change. Agents and contributors reading root `AGENTS.md` get a scoped-guide list that matches the repository and a route from root policy to the architecture docs.

## Evidence

Enumerating every scoped guide in the tree:

```
$ find . -name AGENTS.md -not -path "*/node_modules/*" -not -path "./.git/*" \
    | sed 's|/AGENTS.md||' | sort
.
./.agents/skills/autoreview
./apps/android
./apps/ios
./docs
./docs/reference/templates
./extensions
./extensions/acpx
./extensions/oc-path/src/oc-path/tests/fixtures/real
./extensions/telegram
./scripts
./src/agents
./src/agents/embedded-agent-runner/run
./src/agents/tools
./src/channels
./src/channels/plugins/contracts/test-helpers
./src/gateway
./src/gateway/server-methods
./src/infra/outbound
./src/plugins
./src/plugin-sdk
./src/tui
./test
./test/helpers
./ui
```

No `packages/` entry; `src/infra/outbound`, `src/tui`, `apps/android`, `apps/ios`, and `test/` are all present. The updated list keeps the file's telegraph style and covers the top-level owners without enumerating nested helper guides.

All three architecture doc paths verified present:

```
EXISTS 152L  docs/concepts/architecture.md
EXISTS  61L  docs/agent-runtime-architecture.md
EXISTS 459L  docs/plugins/architecture.md
```

Docs-only change, 2 insertions and 1 deletion in a single file. `git diff --check` clean.
