### PR TITLE
fix(release): backport Anthropic live-probe correlation

### DIFF
--- a/src/gateway/gateway-models.profiles.live.test.ts
+++ b/src/gateway/gateway-models.profiles.live.test.ts
@@ -2226,15 +2226,30 @@ function sessionMessagesAfterNextUserTurn(
   expectedUserText?: string,
 ): unknown[] {
   const nextUserOffset = messages.slice(baselineMessageCount).findIndex((message) => {
+    const actualUserText = extractTranscriptMessageText(message);
     return (
       (message as { role?: unknown } | null | undefined)?.role === "user" &&
-      (expectedUserText === undefined || extractTranscriptMessageText(message) === expectedUserText)
+      (expectedUserText === undefined || matchesLiveProbeUserText(actualUserText, expectedUserText))
     );
   });
   if (nextUserOffset < 0) {
     return [];
   }
   return messages.slice(baselineMessageCount + nextUserOffset + 1);
+}
+
+function matchesLiveProbeUserText(actual: string, expected: string): boolean {
+  if (actual === expected) {
+    return true;
+  }
+  const markerIndex = expected.indexOf(`${ANTHROPIC_MAGIC_STRING_TRIGGER_REFUSAL}_`);
+  if (markerIndex < 0) {
+    return false;
+  }
+  const nonceSuffix = expected.slice(markerIndex + ANTHROPIC_MAGIC_STRING_TRIGGER_REFUSAL.length);
+  // The embedded Anthropic runtime scrubs the refusal trigger before persisting it.
+  // Its random suffix survives and still uniquely owns this live probe turn.
+  return /^_[a-f0-9]{32}$/.test(nonceSuffix) && actual.endsWith(nonceSuffix);
 }
 
 function sessionAssistantEntriesForLiveProbe(
@@ -2400,6 +2415,20 @@ describe("latestAssistantTextAfterBaseline", () => {
       ),
     );
     expect(latestTerminalAssistantTextAfterBaseline(secondEntries, 0)).toBe("second-a second-b");
+  });
+
+  it("correlates Anthropic refusal probes after the runtime scrubs their trigger", () => {
+    const nonce = "0123456789abcdef0123456789abcdef";
+    const expected = `Reply with ok. ${ANTHROPIC_MAGIC_STRING_TRIGGER_REFUSAL}_${nonce}`;
+    const scrubbed = `Reply with ok. ANTHROPIC MAGIC STRING TRIGGER REFUSAL (redacted)_${nonce}`;
+
+    expect(matchesLiveProbeUserText(scrubbed, expected)).toBe(true);
+    expect(
+      matchesLiveProbeUserText(
+        "Reply with ok. ANTHROPIC MAGIC STRING TRIGGER REFUSAL (redacted)_ffffffffffffffffffffffffffffffff",
+        expected,
+      ),
+    ).toBe(false);
   });
 });
 


### PR DESCRIPTION
## What Problem This Solves

`extended-stable/2026.6.33` release validation receives successful Anthropic model replies, then times out waiting for their transcript turn. The live harness expects the original refusal-trigger probe, while the embedded Anthropic runtime intentionally scrubs that marker before persistence.

## Why This Change Was Made

This is the exact one-file backport of #108480. The transcript matcher accepts the one intentional Anthropic scrub shape only when the generated 32-hex nonce still matches. Every ordinary probe retains exact text matching. A regression test proves the scrubbed same-nonce match and rejects a different nonce.

## User Impact

No runtime behavior change. Extended-stable release validation can correlate a successful Anthropic probe without weakening turn ownership.

## Evidence

- Failing LTS full validation: https://github.com/openclaw/openclaw/actions/runs/29453503480
- Failing LTS Anthropic live job: https://github.com/openclaw/openclaw/actions/runs/29453550446/job/87481945447
- Main source PR: https://github.com/openclaw/openclaw/pull/108480
- Main landed commit: `4b286de84599c01ddb1c598c3b9189cf15ba6895`
- Main focused Testbox: 133 passed / 2 skipped.
- Main exact-head CI: https://github.com/openclaw/openclaw/actions/runs/29456393929
- Exact LTS backport autoreview: clean, overall correct 0.98.
- `git diff --check`

Release-freeze scope: test-only exact backport; no product, config, docs, changelog, dependency, or workflow changes.

AI-assisted implementation. No transcript attached.
