### PR TITLE
fix(workboard): enforce worker terminal delivery

### DIFF
--- a/extensions/workboard/index.ts
+++ b/extensions/workboard/index.ts
@@ -6,6 +6,7 @@ import { registerWorkboardCommand } from "./src/command.js";
 import { cleanupWorkboardRunWorktree } from "./src/dispatcher-workspace.js";
 import { WorkboardStore } from "./src/store.js";
 import { createWorkboardTools } from "./src/tools.js";
+import { reconcileWorkboardRunEnd } from "./src/worker-terminal.js";
 import {
   guardWorkboardToolsForWorkspaceAccess,
   WORKBOARD_TOOL_NAMES,
@@ -21,6 +22,7 @@ export default definePluginEntry({
     registerWorkboardCommand({ api, store });
     api.registerService(createWorkboardChangeEventService(store));
     api.on("subagent_ended", async (event) => {
+      await reconcileWorkboardRunEnd({ store, event });
       if (event.runId) {
         await cleanupWorkboardRunWorktree({
           store,

--- a/extensions/workboard/src/dispatcher.test.ts
+++ b/extensions/workboard/src/dispatcher.test.ts
@@ -58,7 +58,7 @@ describe("dispatchAndStartWorkboardCards", () => {
     expect(worktrees.create).toHaveBeenCalledWith(
       expect.objectContaining({
         repoRoot: "/repo",
-        baseRef: "main",
+        baseRef: "origin/main",
         ownerKind: "workboard",
         ownerId: card.id,
       }),
@@ -74,7 +74,7 @@ describe("dispatchAndStartWorkboardCards", () => {
             path: "/state/worktrees/fingerprint/wb-card",
             branch: `openclaw/wb-${card.id}`,
             sourcePath: "/repo",
-            sourceBranch: "main",
+            sourceBranch: "origin/main",
           },
         },
       },
@@ -86,6 +86,41 @@ describe("dispatchAndStartWorkboardCards", () => {
       ownerKind: "workboard",
       ownerId: card.id,
     });
+  });
+
+  it("rejects managed worktrees based on a feature branch", async () => {
+    const store = new WorkboardStore(createMemoryStore());
+    const card = await store.create({
+      title: "Stacked worker",
+      status: "ready",
+      workspace: { kind: "worktree", path: "/repo", branch: "feature/other-card" },
+      workspaceAccess: { unrestricted: true },
+    });
+    const run = vi.fn();
+    const create = vi.fn();
+
+    const result = await dispatchAndStartWorkboardCards({
+      store,
+      subagent: { run },
+      worktrees: {
+        resolveCheckoutRoot: vi.fn().mockResolvedValue("/repo"),
+        create,
+        release: vi.fn(),
+        removeIfLossless: vi.fn(),
+      },
+      options: { maxStarts: 1, materializeWorktree: true },
+    });
+
+    expect(result.started).toEqual([]);
+    expect(result.startFailures).toEqual([
+      expect.objectContaining({
+        cardId: card.id,
+        error: expect.stringContaining("must be based on main"),
+      }),
+    ]);
+    expect(create).not.toHaveBeenCalled();
+    expect(run).not.toHaveBeenCalled();
+    await expect(store.get(card.id)).resolves.toMatchObject({ status: "blocked" });
   });
 
   it("requires explicit reauthorization for legacy cards under full-host dispatch", async () => {
@@ -721,7 +756,7 @@ describe("dispatchAndStartWorkboardCards", () => {
     expect(create).toHaveBeenCalledWith(
       expect.objectContaining({ repoRoot: "/repo", ownerId: card.id }),
     );
-    expect(create.mock.calls[0]?.[0]).not.toHaveProperty("baseRef");
+    expect(create.mock.calls[0]?.[0]).toMatchObject({ baseRef: "origin/main" });
   });
 
   it("claims ready cards and starts bounded subagent worker runs", async () => {
@@ -768,7 +803,8 @@ describe("dispatchAndStartWorkboardCards", () => {
       deliver: false,
     });
     expect(run.mock.calls[0]?.[0]?.message).toContain("Claim token:");
-    expect(run.mock.calls[0]?.[0]?.message).toContain("workboard_complete with the card id");
+    expect(run.mock.calls[0]?.[0]?.message).toContain("PR targeting main");
+    expect(run.mock.calls[0]?.[0]?.message).toContain("status review");
     expect(run.mock.calls[0]?.[0]?.message).not.toContain("ownerId and token");
     await expect(store.get(first.id)).resolves.toMatchObject({
       status: "running",

--- a/extensions/workboard/src/dispatcher.ts
+++ b/extensions/workboard/src/dispatcher.ts
@@ -122,7 +122,7 @@ async function materializeWorkspace(params: {
     return {};
   }
   const sourcePath = workspace.sourcePath ?? workspace.path;
-  const sourceBranch = workspace.sourcePath ? workspace.sourceBranch : workspace.branch;
+  const requestedSourceBranch = workspace.sourcePath ? workspace.sourceBranch : workspace.branch;
   if (!sourcePath || !path.isAbsolute(sourcePath)) {
     throw new Error("worktree workspace path must be an absolute git checkout path");
   }
@@ -147,10 +147,22 @@ async function materializeWorkspace(params: {
   if (!params.worktrees) {
     throw new Error("managed worktree runtime is unavailable");
   }
+  const allowedMainRefs = new Set([
+    "main",
+    "origin/main",
+    "refs/heads/main",
+    "refs/remotes/origin/main",
+  ]);
+  if (requestedSourceBranch && !allowedMainRefs.has(requestedSourceBranch)) {
+    throw new Error(
+      `managed feature worktrees must be based on main, not ${requestedSourceBranch}`,
+    );
+  }
+  const sourceBranch = "origin/main";
   const worktree = await params.worktrees.create({
     repoRoot: canonicalSourcePath,
     name: managedWorktreeName(params.card.id),
-    ...(sourceBranch ? { baseRef: sourceBranch } : {}),
+    baseRef: sourceBranch,
     ownerKind: "workboard",
     ownerId: params.card.id,
   });
@@ -199,8 +211,10 @@ function buildWorkerPrompt(params: {
     `Claim token: ${params.token}`,
     "",
     "Heartbeat with workboard_heartbeat using the card id and token while working.",
-    "When done, call workboard_complete with the card id, token, summary, and proof.",
-    "If blocked, call workboard_block with the card id, token, and reason.",
+    "Do not end the session normally until a lifecycle tool call succeeds.",
+    "For code changes: branch from origin/main, push, open a PR targeting main, then call workboard_complete with status review, summary, and proof including the PR URL.",
+    "For completed non-code work: perform the required action, then call workboard_complete with status done, summary, and proof.",
+    "If required work is absent from origin/main or delivery cannot be completed, call workboard_block with the reason, then terminate with an error/non-zero outcome.",
     "",
     params.context,
   ].join("\n");

--- a/extensions/workboard/src/store-inputs.ts
+++ b/extensions/workboard/src/store-inputs.ts
@@ -108,6 +108,7 @@ export type WorkboardBulkInput = {
 export type WorkboardCompleteInput = {
   ownerId?: unknown;
   token?: unknown;
+  status?: unknown;
   summary?: unknown;
   proof?: unknown;
   artifacts?: unknown;

--- a/extensions/workboard/src/store-workflow.ts
+++ b/extensions/workboard/src/store-workflow.ts
@@ -230,6 +230,10 @@ export class WorkboardWorkflowStore extends WorkboardPromoteStore {
     }
     assertCanMutateClaimedCard(existing, scope === null ? undefined : scope);
     const now = Date.now();
+    const status = normalizeStatus(input.status, "done");
+    if (status !== "review" && status !== "done") {
+      throw new Error("completion status must be review or done.");
+    }
     const createdCardIds = normalizeStringList(input.createdCardIds, "created card ids", 120);
     const childIds = cardChildIds(existing);
     for (const createdCardId of createdCardIds) {
@@ -267,12 +271,12 @@ export class WorkboardWorkflowStore extends WorkboardPromoteStore {
     };
     const execution =
       existing.execution?.status === "running"
-        ? { ...existing.execution, status: "done" as const, updatedAt: now }
+        ? { ...existing.execution, status, updatedAt: now }
         : existing.execution;
     return await this.updateCard(
       id,
       {
-        status: "done",
+        status,
         ...(execution ? { execution } : {}),
         metadata: {
           ...metadata,

--- a/extensions/workboard/src/store.test.ts
+++ b/extensions/workboard/src/store.test.ts
@@ -1702,6 +1702,23 @@ describe("WorkboardStore", () => {
     });
     expect(completed.metadata?.claim).toBeUndefined();
 
+    const reviewCard = await store.create({ title: "Code awaiting merge", status: "running" });
+    await store.claim(reviewCard.id, { ownerId: "main", token: "token-review" });
+    const review = await store.complete(reviewCard.id, {
+      ownerId: "main",
+      token: "token-review",
+      status: "review",
+      summary: "PR opened against main.",
+    });
+    expect(review).toMatchObject({ status: "review" });
+    expect(review.execution?.status).not.toBe("running");
+
+    await expect(
+      store.complete((await store.create({ title: "Invalid completion" })).id, {
+        status: "ready",
+      }),
+    ).rejects.toThrow(/completion status must be review or done/);
+
     const blockedCard = await store.create({
       title: "Blocked work",
       status: "running",

--- a/extensions/workboard/src/tools.test.ts
+++ b/extensions/workboard/src/tools.test.ts
@@ -413,6 +413,7 @@ describe("workboard tools", () => {
       await tools.get("workboard_complete")?.execute("call-4", {
         id: parent.id,
         token,
+        status: "done",
         summary: "Done.",
         createdCardIds: [child.id],
         proof: { status: "passed", command: "pnpm test extensions/workboard" },

--- a/extensions/workboard/src/tools.ts
+++ b/extensions/workboard/src/tools.ts
@@ -486,6 +486,11 @@ export function createWorkboardTools(params: {
         {
           id: cardIdField(),
           token: claimTokenField(),
+          status: Type.Optional(
+            Type.Union([Type.Literal("review"), Type.Literal("done")], {
+              description: "Review for code awaiting merge; done for completed non-code work.",
+            }),
+          ),
           summary: Type.Optional(Type.String({ description: "Completion summary." })),
           proof: Type.Optional(
             Type.Object(

--- a/extensions/workboard/src/worker-terminal.test.ts
+++ b/extensions/workboard/src/worker-terminal.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+import type { PersistedWorkboardCard, WorkboardKeyedStore } from "./persistence-types.js";
+import { WorkboardStore } from "./store.js";
+import { reconcileWorkboardRunEnd } from "./worker-terminal.js";
+
+function createMemoryStore<T = PersistedWorkboardCard>(): WorkboardKeyedStore<T> {
+  const entries = new Map<string, T>();
+  return {
+    async register(key, value) {
+      entries.set(key, value);
+    },
+    async lookup(key) {
+      return entries.get(key);
+    },
+    async delete(key) {
+      return entries.delete(key);
+    },
+    async entries() {
+      return [...entries].map(([key, value]) => ({ key, value }));
+    },
+  };
+}
+
+async function createRunningCard(store: WorkboardStore, runId: string) {
+  const card = await store.create({
+    title: "Developer delivery",
+    status: "running",
+    sessionKey: `agent:developer:subagent:${runId}`,
+    runId,
+    execution: {
+      id: `${runId}:execution`,
+      kind: "agent-session",
+      engine: "codex",
+      mode: "autonomous",
+      status: "running",
+      model: "default",
+      sessionKey: `agent:developer:subagent:${runId}`,
+      runId,
+      startedAt: 1,
+      updatedAt: 1,
+    },
+  });
+  await store.claim(card.id, { ownerId: "developer", token: `${runId}:token` });
+  return card;
+}
+
+describe("reconcileWorkboardRunEnd", () => {
+  it("blocks a normal exit that omitted lifecycle completion", async () => {
+    const store = new WorkboardStore(createMemoryStore());
+    const card = await createRunningCard(store, "run-normal");
+
+    await reconcileWorkboardRunEnd({ store, event: { runId: "run-normal", outcome: "ok" } });
+
+    const blocked = await store.get(card.id);
+    expect(blocked).toMatchObject({
+      status: "blocked",
+      execution: { status: "blocked" },
+      metadata: {
+        comments: [expect.objectContaining({ body: expect.stringContaining("ended normally") })],
+      },
+    });
+    expect(blocked?.metadata).not.toHaveProperty("claim");
+  });
+
+  it("records an abnormal exit as blocked with its error", async () => {
+    const store = new WorkboardStore(createMemoryStore());
+    const card = await createRunningCard(store, "run-error");
+
+    await reconcileWorkboardRunEnd({
+      store,
+      event: { runId: "run-error", outcome: "error", error: "prerequisite missing from main" },
+    });
+
+    await expect(store.get(card.id)).resolves.toMatchObject({
+      status: "blocked",
+      metadata: {
+        comments: [
+          expect.objectContaining({
+            body: expect.stringContaining("prerequisite missing from main"),
+          }),
+        ],
+      },
+    });
+  });
+
+  it.each(["review", "done", "blocked"] as const)(
+    "preserves an explicit %s lifecycle result",
+    async (status) => {
+      const store = new WorkboardStore(createMemoryStore());
+      const card = await createRunningCard(store, `run-${status}`);
+      if (status === "blocked") {
+        await store.block(card.id, { reason: "Explicit blocker." }, null);
+      } else {
+        await store.complete(card.id, { status, summary: "Delivered." }, null);
+      }
+
+      await reconcileWorkboardRunEnd({
+        store,
+        event: { runId: `run-${status}`, outcome: status === "blocked" ? "error" : "ok" },
+      });
+
+      await expect(store.get(card.id)).resolves.toMatchObject({ status });
+    },
+  );
+});

--- a/extensions/workboard/src/worker-terminal.ts
+++ b/extensions/workboard/src/worker-terminal.ts
@@ -1,0 +1,40 @@
+// Workboard worker terminal reconciliation fails closed when a worker exits
+// without committing its claimed card through the lifecycle tools.
+import { WorkboardStore } from "./store.js";
+
+type WorkboardRunEndEvent = {
+  runId?: string;
+  outcome?: "ok" | "error" | "timeout" | "killed" | "reset" | "deleted";
+  error?: string;
+};
+
+function terminalReason(event: WorkboardRunEndEvent): string {
+  if (event.outcome === "ok") {
+    return "Worker ended normally without successfully completing or blocking its Workboard card.";
+  }
+  const detail = event.error?.trim();
+  return detail
+    ? `Worker ended abnormally (${event.outcome ?? "error"}): ${detail}`
+    : `Worker ended abnormally (${event.outcome ?? "error"}).`;
+}
+
+export async function reconcileWorkboardRunEnd(params: {
+  store: WorkboardStore;
+  event: WorkboardRunEndEvent;
+}): Promise<void> {
+  const runId = params.event.runId?.trim();
+  if (!runId) {
+    return;
+  }
+  const card = (await params.store.list()).find((candidate) => candidate.runId === runId);
+  if (!card) {
+    return;
+  }
+  const lifecycleCommitted =
+    !card.metadata?.claim &&
+    (card.status === "review" || card.status === "done" || card.status === "blocked");
+  if (lifecycleCommitted) {
+    return;
+  }
+  await params.store.block(card.id, { reason: terminalReason(params.event) }, null);
+}


### PR DESCRIPTION
## What Problem This Solves

Workboard workers could finish normally without committing a lifecycle result, leaving cards running/claimed until lease recovery. Managed worktrees could also inherit a feature branch, allowing accidental PR stacking, and code delivery had no supported Review completion state.

Fixes #108490.

## Why This Change Was Made

- Reconcile every `subagent_ended` event against its Workboard card.
- Fail closed to Blocked when a worker exits without a successful complete/block call, preserving normal-vs-abnormal outcome details.
- Reject feature-branch worktree sources and always materialize managed worktrees from `origin/main`.
- Allow `workboard_complete` to select Review for code awaiting merge or Done for completed non-code work.
- Strengthen the dispatcher prompt with explicit heartbeat, PR-to-main, lifecycle, and blocked-exit requirements.

## User Impact

Workboard cards no longer silently remain Running after a worker omits its terminal lifecycle call. Feature work cannot be based on another feature branch. Code-producing workers can hand off a PR in Review without falsely marking the card Done.

## Evidence

- `node scripts/run-vitest.mjs extensions/workboard/src/worker-terminal.test.ts extensions/workboard/src/dispatcher.test.ts extensions/workboard/src/store.test.ts extensions/workboard/src/tools.test.ts`
  - 4 files passed; 129 tests passed.
- `corepack pnpm exec oxfmt --check ...` passed for all 10 changed files.
- `corepack pnpm exec oxlint ...` passed for all 10 changed files.
- `git diff --check` passed.

The full `check:changed` lane was attempted; its max-lines ratchet cannot evaluate correctly in this sparse checkout because unrelated extension/UI files are intentionally absent. The focused extension suite and file-level format/lint checks pass.
