### PR TITLE
fix(ci): restore full-tree formatting

### DIFF
--- a/src/infra/file-read.ts
+++ b/src/infra/file-read.ts
@@ -24,11 +24,7 @@ export async function readFileWindowFully(
 }
 
 /** Synchronously fills a bounded positional-read buffer unless the file reaches EOF. */
-export function readFileWindowFullySync(
-  fd: number,
-  buffer: Buffer,
-  position: number,
-): number {
+export function readFileWindowFullySync(fd: number, buffer: Buffer, position: number): number {
   let bytesRead = 0;
   while (bytesRead < buffer.length) {
     const count = fs.readSync(


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the full repository formatting check fails on current `main`, blocking otherwise unrelated pull requests from landing.

## Why This Change Was Made

Run the repository formatter over the newly added synchronous file-window helper signature. This is formatter-only; runtime code, types, and behavior are unchanged.

## User Impact

No user-visible behavior change. Maintainers regain a green full-tree lint/format gate.

## Evidence

- Reproduced in PR #108419 CI job `check-lint`: `oxfmt --check` reported `src/infra/file-read.ts`.
- `oxfmt --check --threads=1 src/infra/file-read.ts`: passed after the change.
- `git diff --check`: passed.
- Fresh autoreview: no actionable findings, confidence 0.99.

AI-assisted: Codex performed the reproduction, formatting-only fix, and review. I understand the change and verified its behavior-neutral scope.
