### PR TITLE
style(infra): fix file reader formatting

### DIFF
--- a/src/infra/file-read.ts
+++ b/src/infra/file-read.ts
@@ -24,11 +24,7 @@ export async function readFileWindowFully(
 }
 
 /** Synchronously fills a bounded positional-read buffer unless the file reaches EOF. */
-export function readFileWindowFullySync(
-  fd: number,
-  buffer: Buffer,
-  position: number,
-): number {
+export function readFileWindowFullySync(fd: number, buffer: Buffer, position: number): number {
   let bytesRead = 0;
   while (bytesRead < buffer.length) {
     const count = fs.readSync(


### PR DESCRIPTION
## What Problem This Solves

Full CI at `55a822dc6877afd588dda6e8d17e64ba360041b5` fails both formatting jobs because `src/infra/file-read.ts` does not match oxfmt output.

## Why This Change Was Made

Apply the repository formatter to the synchronous file-reader signature. This is the complete deterministic failure from CI run https://github.com/openclaw/openclaw/actions/runs/29457411424 and the same-SHA main push run https://github.com/openclaw/openclaw/actions/runs/29457250898.

## User Impact

None. Formatting-only release-prep repair; runtime behavior and types are unchanged.

## Evidence

- `node_modules/.bin/oxfmt --check src/infra/file-read.ts`
- `node scripts/run-vitest.mjs src/commands/sessions-tail.test.ts` — 16/16 passed
- Fresh autoreview — clean, correctness confidence 0.99
- Same-SHA main push UI lane passed; the separate release-dispatch browser connection timeout occurred after 3,952 passing UI tests and is not reproduced by the main run.
