### PR TITLE
test(qa): backport live selector coverage alignment

### DIFF
--- a/extensions/qa-lab/src/live-transports/live-transport-adapters.test.ts
+++ b/extensions/qa-lab/src/live-transports/live-transport-adapters.test.ts
@@ -19,8 +19,10 @@ vi.mock("./whatsapp/adapter.runtime.js", () => ({
 }));
 
 import { slackQaCliRegistration } from "./slack/cli.js";
+import { SLACK_QA_DEFAULT_SCENARIO_IDS } from "./slack/profiles.js";
 import { telegramQaCliRegistration } from "./telegram/cli.js";
 import { whatsappQaCliRegistration } from "./whatsapp/cli.js";
+import { resolveWhatsAppQaScenarioIds } from "./whatsapp/profiles.js";
 
 const slackQaAdapterFactory = slackQaCliRegistration.adapterFactory;
 const telegramQaAdapterFactory = telegramQaCliRegistration.adapterFactory;
@@ -36,26 +38,14 @@ const factories = [
 ] as const;
 
 describe("live transport adapter factories", () => {
-  it("assigns shared thread scenarios to Slack", () => {
-    expect(slackQaAdapterFactory.scenarioIds).toEqual([
-      "channel-chat-baseline",
-      "channel-canary",
-      "channel-mention-gating",
-      "channel-top-level-reply-shape",
-      "thread-follow-up",
-      "thread-isolation",
-    ]);
+  it("assigns the canonical live scenario defaults to Slack", () => {
+    expect(slackQaAdapterFactory.scenarioIds).toEqual(SLACK_QA_DEFAULT_SCENARIO_IDS);
   });
 
-  it("keeps WhatsApp routing flows available without making them DM-safe CLI defaults", () => {
-    expect(whatsappQaAdapterFactory.scenarioIds).toEqual([
-      "dm-chat-baseline",
-      "channel-canary",
-      "channel-dm-group-routing",
-      "channel-mention-gating",
-      "channel-top-level-reply-shape",
-      "whatsapp-help-command",
-    ]);
+  it("assigns the canonical live-frontier scenario defaults to WhatsApp", () => {
+    expect(whatsappQaAdapterFactory.scenarioIds).toEqual(
+      resolveWhatsAppQaScenarioIds({ providerMode: "live-frontier" }),
+    );
   });
 
   it.each([

--- a/extensions/qa-lab/src/live-transports/matrix/matrix-scenario-flows.test.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/matrix-scenario-flows.test.ts
@@ -38,7 +38,7 @@ function readModuleBinding(
 describe("Matrix QA Lab scenario flows", () => {
   const catalog = readQaBootstrapScenarioCatalog();
   const scenarios = catalog.scenarios.filter((scenario) => {
-    if (scenario.execution.kind !== "flow") {
+    if (scenario.execution.kind !== "flow" || scenario.execution.channel !== "matrix") {
       return false;
     }
     return scenario.execution.flow?.steps.some((step) =>


### PR DESCRIPTION
## What Problem This Solves

Exact beta Full Release Validation at `4dc491dc3f4cbf096fb25c4b9506d44878be4330` fails Plugin Prerelease because QA Lab selector tests still assert retired literal scenario sets and the Matrix flow test reads all channel flows.

Failed evidence: https://github.com/openclaw/openclaw/actions/runs/29457724528/job/87494572587

## Why This Change Was Made

Backport the test-only fix from main PR #108481. Assertions now derive Slack and WhatsApp expectations from their canonical selectors, while Matrix coverage explicitly filters Matrix-channel flows. Deterministic regressions remain visible; stale duplicated expectations are removed.

## User Impact

No runtime behavior change. Restores beta release validation against the current QA scenario catalog.

## Evidence

- `node scripts/run-vitest.mjs extensions/qa-lab/src/live-transports/live-transport-adapters.test.ts extensions/qa-lab/src/live-transports/matrix/matrix-scenario-flows.test.ts` — 8/8 passed
- `git diff --check`
- Fresh release-freeze autoreview — clean, correctness confidence 0.96
- Main canonical change: #108481 / `555c38f483689cc6c73df709d3a73e28eccb6f1d`
