### PR TITLE
refactor(vllm): remove unused registration shim

### DIFF
--- a/extensions/vllm/register.runtime.ts
+++ b/extensions/vllm/register.runtime.ts
@@ -1,8 +1,0 @@
-// Vllm plugin module implements register behavior.
-export {
-  buildVllmProvider,
-  VLLM_DEFAULT_API_KEY_ENV_VAR,
-  VLLM_DEFAULT_BASE_URL,
-  VLLM_MODEL_PLACEHOLDER,
-  VLLM_PROVIDER_LABEL,
-} from "./api.js";


### PR DESCRIPTION
## What Problem This Solves

Current main dead-code validation fails after #108497 because `extensions/vllm/register.runtime.ts` is now correctly identified as an unused file.

Failure: https://github.com/openclaw/openclaw/actions/runs/29458423626/job/87496703659

## Why This Change Was Made

Delete the orphan re-export shim. The vLLM manifest exposes only `index.ts`; repository search finds no callers; the real plugin entry imports the same symbols directly from `api.ts`.

## User Impact

None. Removes dead private source; vLLM registration and provider behavior are unchanged.

## Evidence

- `node scripts/run-vitest.mjs extensions/vllm` — 24/24 passed
- `git diff --check`
- Fresh autoreview — clean, correctness confidence 0.97
- vLLM package manifest: only `./index.ts` is an extension entry
