### PR TITLE
fix(ci): remove unused vLLM runtime bridge

### DIFF
--- a/extensions/vllm/register.runtime.ts
+++ b/extensions/vllm/register.runtime.ts
@@ -1,8 +1,0 @@
-// Vllm plugin module implements register behavior.
-export {
-  buildVllmProvider,
-  VLLM_DEFAULT_API_KEY_ENV_VAR,
-  VLLM_DEFAULT_BASE_URL,
-  VLLM_MODEL_PLACEHOLDER,
-  VLLM_PROVIDER_LABEL,
-} from "./api.js";


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the unused-file gate fails on current `main`, blocking unrelated pull requests with `extensions/vllm/register.runtime.ts` reported as unexpected dead code.

## Why This Change Was Made

Remove the obsolete internal re-export bridge. The vLLM plugin entrypoint already imports the same public values from `api.ts`, and no package export, manifest entry, loader, test, or production caller references `register.runtime.ts`.

## User Impact

No user-visible behavior change. Maintainers regain a green dead-code gate without adding an allowlist exception for an unreferenced internal file.

## Evidence

- Reproduced in PR #108419 `check-dependencies` job 87496997627 after #108497 tightened provider-extension roots.
- Repository-wide reference search found no consumer or contract for `extensions/vllm/register.runtime.ts`; `extensions/vllm/index.ts` owns registration and imports from `api.ts` directly.
- Blacksmith Testbox run 29458757049: `pnpm deadcode:unused-files` passed after deletion.
- `git diff --check`: passed.
- Fresh autoreview: no actionable findings, confidence 0.95.

AI-assisted: Codex traced the regression, verified the owner boundary, removed the dead bridge, and reviewed the patch. I understand the change and verified its behavior-neutral scope.
