### PR TITLE
fix(plugins): canonicalize plugin entry path per process to prevent duplicate register()

### DIFF
--- a/src/plugins/loader-cache.ts
+++ b/src/plugins/loader-cache.ts
@@ -1,6 +1,7 @@
 import { pluginLoaderCacheInstances, type CachedPluginState } from "./loader-cache-instances.js";
 import { resolvePluginLoadCacheContext } from "./loader-load-context.js";
 import type { PluginLoadOptions, PluginRuntimeSubagentMode } from "./loader-types.js";
+import { clearPluginRuntimeArtifactResolutionMemo } from "./plugin-runtime-artifact-resolution.js";
 
 export const pluginLoaderCacheState = pluginLoaderCacheInstances.scoped;
 const fullWorkspacePluginLoaderCacheState = pluginLoaderCacheInstances.fullWorkspace;
@@ -69,6 +70,7 @@ export function getReusableCachedPluginRegistry(params: {
 }
 
 export function clearPluginRegistryLoadCache(): void {
+  clearPluginRuntimeArtifactResolutionMemo();
   pluginLoaderCacheState.clearCachedRegistries();
   fullWorkspacePluginLoaderCacheState.clearCachedRegistries();
 }

--- a/src/plugins/loader-runtime-candidate.ts
+++ b/src/plugins/loader-runtime-candidate.ts
@@ -186,6 +186,8 @@ export function loadRuntimePluginCandidate(params: {
 
   const pluginRoot = safeRealpathOrResolve(candidate.rootDir);
   const runtimeCandidateEntry = resolvePluginRuntimeArtifact({
+    pluginId,
+    entryKind: "runtime",
     source: candidate.source,
     rootDir: pluginRoot,
     origin: candidate.origin,
@@ -194,6 +196,8 @@ export function loadRuntimePluginCandidate(params: {
   });
   const runtimeSetupEntry = manifestRecord.setupSource
     ? resolvePluginRuntimeArtifact({
+        pluginId,
+        entryKind: "setup",
         source: manifestRecord.setupSource,
         rootDir: pluginRoot,
         origin: candidate.origin,

--- a/src/plugins/loader-shared.ts
+++ b/src/plugins/loader-shared.ts
@@ -31,6 +31,7 @@ import type { PluginManifestRecord, PluginManifestRegistry } from "./manifest-re
 import type { PluginDiagnostic } from "./manifest-types.js";
 import { clearMemoryEmbeddingProviders } from "./memory-embedding-providers.js";
 import { clearMemoryPluginState } from "./memory-state.js";
+import { clearPluginRuntimeArtifactResolutionMemo } from "./plugin-runtime-artifact-resolution.js";
 import type { PluginRecord, PluginRegistry } from "./registry.js";
 import { setActivePluginRegistry } from "./runtime.js";
 import { validateJsonSchemaValue } from "./schema-validator.js";
@@ -164,6 +165,7 @@ export function createPluginCandidatesFromManifestRegistry(
 }
 
 export function clearActivatedPluginRuntimeState(): void {
+  clearPluginRuntimeArtifactResolutionMemo();
   clearAgentHarnesses();
   clearPluginCommands();
   clearCompactionProviders();

--- a/src/plugins/plugin-runtime-artifact-identity.ts
+++ b/src/plugins/plugin-runtime-artifact-identity.ts
@@ -119,6 +119,8 @@ export function fingerprintPluginRuntimeArtifact(
 ): string {
   const runtimeArtifact = record.source
     ? resolvePluginRuntimeArtifact({
+        pluginId: record.pluginId,
+        entryKind: "runtime",
         source: record.source,
         rootDir: record.rootDir,
         origin: record.origin,

--- a/src/plugins/plugin-runtime-artifact-resolution.test.ts
+++ b/src/plugins/plugin-runtime-artifact-resolution.test.ts
@@ -1,0 +1,231 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { withEnv } from "../test-utils/env.js";
+import {
+  clearActivatedPluginRuntimeState,
+  clearPluginRegistryLoadCache,
+  loadOpenClawPlugins,
+} from "./loader.js";
+import { resetPluginLoaderTestStateForTest } from "./loader.test-fixtures.js";
+import {
+  clearPluginRuntimeArtifactResolutionMemo,
+  resolvePluginRuntimeArtifact,
+} from "./plugin-runtime-artifact-resolution.js";
+import { pinActivePluginChannelRegistry } from "./runtime.js";
+
+const tempDirs: string[] = [];
+
+function createBundledPluginFixture(): {
+  rootDir: string;
+  source: string;
+  builtSource: string;
+} {
+  const packageRoot = fs.realpathSync(
+    fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-plugin-runtime-artifact-")),
+  );
+  tempDirs.push(packageRoot);
+  const rootDir = path.join(packageRoot, "extensions", "fixture");
+  const source = path.join(rootDir, "index.ts");
+  const builtSource = path.join(packageRoot, "dist", "extensions", "fixture", "index.js");
+  fs.mkdirSync(path.dirname(source), { recursive: true });
+  fs.mkdirSync(path.dirname(builtSource), { recursive: true });
+  fs.writeFileSync(source, "export default { register() {} };\n");
+  fs.writeFileSync(builtSource, 'module.exports = { id: "fixture", register() {} };\n');
+  fs.writeFileSync(
+    path.join(rootDir, "openclaw.plugin.json"),
+    JSON.stringify({
+      id: "fixture",
+      configSchema: { type: "object", additionalProperties: false, properties: {} },
+    }),
+  );
+  return {
+    rootDir: fs.realpathSync(rootDir),
+    source: fs.realpathSync(source),
+    builtSource: fs.realpathSync(builtSource),
+  };
+}
+
+function resolveFixture(params: {
+  rootDir: string;
+  source: string;
+  preferBuiltPluginArtifacts: boolean;
+}) {
+  return resolvePluginRuntimeArtifact({
+    pluginId: "fixture",
+    entryKind: "runtime",
+    rootDir: params.rootDir,
+    source: params.source,
+    origin: "bundled",
+    preferBuiltPluginArtifacts: params.preferBuiltPluginArtifacts,
+  });
+}
+
+afterEach(() => {
+  resetPluginLoaderTestStateForTest();
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("resolvePluginRuntimeArtifact", () => {
+  it.each([
+    { firstPreference: false, firstArtifact: "source" },
+    { firstPreference: true, firstArtifact: "built" },
+  ])(
+    "pins the first $firstArtifact path so one plugin instance registers once",
+    ({ firstPreference }) => {
+      const fixture = createBundledPluginFixture();
+      const first = resolveFixture({
+        ...fixture,
+        preferBuiltPluginArtifacts: firstPreference,
+      });
+      const second = resolveFixture({
+        ...fixture,
+        preferBuiltPluginArtifacts: !firstPreference,
+      });
+
+      expect(first.source).toBe(firstPreference ? fixture.builtSource : fixture.source);
+      expect(second).toEqual(first);
+    },
+  );
+
+  it("aliases different physical inputs for the same logical runtime entry", () => {
+    const fixture = createBundledPluginFixture();
+    const first = resolveFixture({
+      ...fixture,
+      preferBuiltPluginArtifacts: false,
+    });
+    const aliased = resolvePluginRuntimeArtifact({
+      pluginId: "fixture",
+      entryKind: "runtime",
+      rootDir: fixture.rootDir,
+      source: fixture.builtSource,
+      origin: "bundled",
+      preferBuiltPluginArtifacts: true,
+    });
+
+    expect(aliased).toEqual(first);
+  });
+
+  it("keeps runtime and setup entries distinct within one plugin root", () => {
+    const fixture = createBundledPluginFixture();
+    const setupSource = path.join(fixture.rootDir, "setup-entry.ts");
+    fs.writeFileSync(setupSource, "export default { register() {} };\n");
+    const runtime = resolveFixture({
+      ...fixture,
+      preferBuiltPluginArtifacts: false,
+    });
+    const setup = resolvePluginRuntimeArtifact({
+      pluginId: "fixture",
+      entryKind: "setup",
+      rootDir: fixture.rootDir,
+      source: fs.realpathSync(setupSource),
+      origin: "bundled",
+      preferBuiltPluginArtifacts: false,
+    });
+
+    expect(runtime.source).toBe(fixture.source);
+    expect(setup.source).toBe(fs.realpathSync(setupSource));
+  });
+
+  it("re-resolves after activated runtime state is cleared", () => {
+    const fixture = createBundledPluginFixture();
+    const sourceResolution = resolveFixture({
+      ...fixture,
+      preferBuiltPluginArtifacts: false,
+    });
+
+    clearActivatedPluginRuntimeState();
+
+    const builtResolution = resolveFixture({
+      ...fixture,
+      preferBuiltPluginArtifacts: true,
+    });
+    expect(sourceResolution.source).toBe(fixture.source);
+    expect(builtResolution.source).toBe(fixture.builtSource);
+  });
+
+  it("re-resolves after the registry load cache is cleared", () => {
+    const fixture = createBundledPluginFixture();
+    const sourceResolution = resolveFixture({
+      ...fixture,
+      preferBuiltPluginArtifacts: false,
+    });
+
+    clearPluginRegistryLoadCache();
+
+    const builtResolution = resolveFixture({
+      ...fixture,
+      preferBuiltPluginArtifacts: true,
+    });
+    expect(sourceResolution.source).toBe(fixture.source);
+    expect(builtResolution.source).toBe(fixture.builtSource);
+  });
+
+  it("keeps one physical entry across activating registry assemblies", () => {
+    const fixture = createBundledPluginFixture();
+    const config = {
+      plugins: {
+        allow: ["fixture"],
+        entries: { fixture: { enabled: true } },
+      },
+    };
+
+    const [first, second] = withEnv(
+      {
+        OPENCLAW_BUNDLED_PLUGINS_DIR: path.dirname(fixture.rootDir),
+        OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR: "1",
+        OPENCLAW_DISABLE_BUNDLED_PLUGINS: undefined,
+      },
+      () => {
+        const sourceRegistry = loadOpenClawPlugins({
+          cache: false,
+          config,
+          onlyPluginIds: ["fixture"],
+          preferBuiltPluginArtifacts: false,
+        });
+        pinActivePluginChannelRegistry(sourceRegistry);
+        const builtPreferredRegistry = loadOpenClawPlugins({
+          cache: false,
+          config,
+          onlyPluginIds: ["fixture"],
+          preferBuiltPluginArtifacts: true,
+        });
+        return [sourceRegistry, builtPreferredRegistry];
+      },
+    );
+
+    expect(first.plugins.find((plugin) => plugin.id === "fixture")?.source).toBe(fixture.source);
+    expect(second.plugins.find((plugin) => plugin.id === "fixture")?.source).toBe(fixture.source);
+  });
+
+  it("leaves dist-only installs unchanged because both preferences resolve the built entry", () => {
+    const packageRoot = fs.realpathSync(
+      fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-plugin-runtime-dist-only-")),
+    );
+    tempDirs.push(packageRoot);
+    const rootDir = path.join(packageRoot, "dist", "extensions", "fixture");
+    const source = path.join(rootDir, "index.js");
+    fs.mkdirSync(rootDir, { recursive: true });
+    fs.writeFileSync(source, "export default { register() {} };\n");
+    const canonicalRootDir = fs.realpathSync(rootDir);
+    const canonicalSource = fs.realpathSync(source);
+
+    const sourcePreferred = resolveFixture({
+      rootDir: canonicalRootDir,
+      source: canonicalSource,
+      preferBuiltPluginArtifacts: false,
+    });
+    clearPluginRuntimeArtifactResolutionMemo();
+    const builtPreferred = resolveFixture({
+      rootDir: canonicalRootDir,
+      source: canonicalSource,
+      preferBuiltPluginArtifacts: true,
+    });
+
+    expect(sourcePreferred).toEqual({ source: canonicalSource, rootDir: canonicalRootDir });
+    expect(builtPreferred).toEqual(sourcePreferred);
+  });
+});

--- a/src/plugins/plugin-runtime-artifact-resolution.ts
+++ b/src/plugins/plugin-runtime-artifact-resolution.ts
@@ -4,12 +4,24 @@ import path from "node:path";
 import type { OpenClawPackageManifest } from "./manifest.js";
 import type { PluginOrigin } from "./plugin-origin.types.js";
 
+type ResolvedPluginRuntimeArtifact = { source: string; rootDir: string };
+type PluginRuntimeArtifactEntryKind = "runtime" | "setup";
+
+// Pin one physical path per plugin id and logical entry for this runtime lifecycle.
+// Registry surfaces may disagree on artifact preference, but hooks and tools must
+// share one evaluated module instance so register() runs once.
+const resolvedPluginRuntimeArtifacts = new Map<string, ResolvedPluginRuntimeArtifact>();
+
 function safeRealpathOrResolve(value: string): string {
   try {
     return fs.realpathSync(value);
   } catch {
     return path.resolve(value);
   }
+}
+
+export function clearPluginRuntimeArtifactResolutionMemo(): void {
+  resolvedPluginRuntimeArtifacts.clear();
 }
 
 /** Canonical packaged runtime replaces staging-only dist-runtime artifacts. */
@@ -156,15 +168,27 @@ function resolvePreferredBuiltRuntimeArtifact(params: {
 
 /** Applies both loader selection phases in their runtime order. */
 export function resolvePluginRuntimeArtifact(params: {
+  pluginId: string;
+  entryKind: PluginRuntimeArtifactEntryKind;
   source: string;
   rootDir: string;
   origin: PluginOrigin;
   preferBuiltPluginArtifacts: boolean;
   packageManifest?: OpenClawPackageManifest;
 }): { source: string; rootDir: string } {
-  const preferred = resolvePreferredBuiltRuntimeArtifact(params);
-  return {
+  const rootDir = resolveCanonicalDistRuntimeSource(safeRealpathOrResolve(params.rootDir));
+  const source = resolveCanonicalDistRuntimeSource(safeRealpathOrResolve(params.source));
+  const memoKey = JSON.stringify([params.pluginId, rootDir, params.entryKind]);
+  const cached = resolvedPluginRuntimeArtifacts.get(memoKey);
+  if (cached) {
+    return { ...cached };
+  }
+
+  const preferred = resolvePreferredBuiltRuntimeArtifact({ ...params, source, rootDir });
+  const resolved = {
     source: resolveCanonicalDistRuntimeSource(preferred.source),
     rootDir: resolveCanonicalDistRuntimeSource(preferred.rootDir),
   };
+  resolvedPluginRuntimeArtifacts.set(memoKey, resolved);
+  return { ...resolved };
 }


### PR DESCRIPTION
## What Problem This Solves

On a git-channel / source-checkout install where both `extensions/<id>/index.ts` and `dist/extensions/<id>/index.js` exist, a bundled plugin's `register()` runs twice in one gateway process, producing two live plugin instances. Typed hooks (`before_tool_call`) bind to one instance while `registerTool` factory tools execute from the other, so any plugin coordinating state between a hook and its tool fails nondeterministically. This was hit live by the `onepassword` broker: hook and tool ran in the same process 2ms apart with identical ids, yet the executing instance's in-memory map was empty.

Closes #107933.

## Why This Change Was Made

Root cause: `preferBuiltPluginArtifacts` is both the switch that picks the physical entry file (`resolvePluginRuntimeArtifact` → source `.ts` vs built `.js`) and part of the load-options cache key. A second activation route with different options misses registry reuse and does a fresh load; because the two loads resolve different physical paths, the path-keyed module loader cache (`plugin-module-loader-cache.ts`) evaluates the entry module twice — two closures, two live instances. On a published dist-only install there is no `.ts`, both loads resolve to the same `.js`, the cache dedupes, and no twin appears — hence git-channel-only.

Fix: memoize the first resolved runtime entry path per `pluginId + realpath(rootDir) + entryKind` for the process lifecycle, so every later resolution returns the same physical path regardless of `preferBuiltPluginArtifacts`. Both assemblies then converge on one module instance and the existing path-keyed cache collapses them. The memo is cleared by `clearActivatedPluginRuntimeState()` and `clearPluginRegistryLoadCache()` so reload / install / doctor re-resolve cleanly; normal registry reassembly preserves it (that is what makes the two assemblies converge). Runtime and setup entry kinds are memoized separately since they legitimately differ. Per-surface registry divergence semantics are untouched — two surfaces may still exist, they now point at one module instance.

## User Impact

Bundled plugins that keep state across a hook/tool boundary work correctly on git-channel installs. No behavior change on published dist-only installs (the memo is a proven no-op there). No config or API change.

## Evidence

- 8 focused tests in `plugin-runtime-artifact-resolution.test.ts`: preference-stable resolution, physical-path aliasing, runtime/setup separation, re-resolution after each invalidation path, and the decisive `keeps one physical entry across activating registry assemblies` test that drives the real two-assembly `loadOpenClawPlugins` scenario with opposite preferences and asserts a single resolved path.
- Artifact resolution + identity suites 12/12; core tsgo exit 0; plugin oxlint exit 0; `git diff --check` clean.
- Autoreview (Codex gpt-5.6-sol xhigh): clean, no actionable findings.
- Root cause and mechanism documented in #107933.
