### PR TITLE
fix(zalo): use timing-safe hosted media token checks

### DIFF
--- a/extensions/zalo/src/outbound-media.test.ts
+++ b/extensions/zalo/src/outbound-media.test.ts
@@ -248,6 +248,27 @@ describe("zalo outbound hosted media", () => {
     expect(response.res.end).toHaveBeenCalledWith("Unauthorized");
   });
 
+  it("rejects hosted media requests without a token", async () => {
+    const hostedUrl = await prepareHostedZaloMediaUrl({
+      mediaUrl: "https://example.com/photo.png",
+      webhookUrl: "https://gateway.example.com/zalo-webhook",
+      maxBytes: 1024,
+    });
+    const response = createMockResponse();
+
+    const handled = await tryHandleHostedZaloMediaRequest(
+      {
+        method: "GET",
+        url: new URL(hostedUrl).pathname,
+      } as never,
+      response.res as never,
+    );
+
+    expect(handled).toBe(true);
+    expect(response.res.statusCode).toBe(401);
+    expect(response.res.end).toHaveBeenCalledWith("Unauthorized");
+  });
+
   it("rejects malformed hosted media ids before touching disk", async () => {
     const response = createMockResponse();
 

--- a/extensions/zalo/src/outbound-media.ts
+++ b/extensions/zalo/src/outbound-media.ts
@@ -10,6 +10,7 @@ import {
   type HostedOutboundMediaMetaRecord,
   type HostedOutboundMediaStore,
 } from "openclaw/plugin-sdk/outbound-media";
+import { safeEqualSecret } from "openclaw/plugin-sdk/security-runtime";
 import { resolveWebhookPath } from "openclaw/plugin-sdk/webhook-ingress";
 import { getZaloRuntime } from "./runtime.js";
 
@@ -160,7 +161,7 @@ export async function tryHandleHostedZaloMediaRequest(
     return true;
   }
 
-  if (url.searchParams.get("token") !== entry.metadata.token) {
+  if (!safeEqualSecret(url.searchParams.get("token"), entry.metadata.token)) {
     res.statusCode = 401;
     res.end("Unauthorized");
     return true;


### PR DESCRIPTION
## What Problem This Solves

Zalo hosted outbound media URLs use a short-lived bearer token to protect media while Zalo retrieves it. The request handler compared that credential with ordinary string equality instead of the shared secret-comparison primitive.

## Why This Change Was Made

Routes the hosted-media token check through `safeEqualSecret`, matching other credential-bearing plugin surfaces. The patch stays within the Zalo plugin boundary and does not add dependencies, configuration, compatibility behavior, or public API.

## User Impact

Valid hosted-media URLs continue to serve media once. Incorrect or missing tokens continue to receive HTTP 401, with credential comparison now using the shared timing-safe implementation.

## Evidence

Exact head: `915039023fd10875517a27f73b04e48f02a6f514`.

- Node `24.18.0`, Vitest `4.1.9`
- `node scripts/run-vitest.mjs extensions/zalo/src/outbound-media.test.ts --reporter=verbose` -> 10 passed
- `oxfmt --check extensions/zalo/src/outbound-media.ts extensions/zalo/src/outbound-media.test.ts` -> passed
- `git diff --check` -> passed

Testbox and brokered Crabbox are unavailable to this external contributor, so the focused repository test wrapper was used as the documented local fallback. Fresh autoreview was attempted with Claude twice plus a lightweight model; the service timed out each time. OpenCode refused because its isolation contract was insufficient, Pi was unavailable, and Codex is blocked by the current network region. No clean autoreview result is claimed; GitHub CI and normal maintainer review remain required.

## Agent Transcript

<details>
<summary>Redacted Codex session transcript</summary>

```text
User requested a new, independently branched OpenClaw security contribution optimized for mergeability.

Codex synchronized the fork and clean main worktree to official main at 55a822dc6. Candidate review rejected Gateway connectNonce because it is a public challenge and rejected the loopback native-hook relay because it does not cross the documented trust boundary.

Codex selected the Zalo hosted outbound-media capability token because it protects remotely fetched, short-lived media. The approved design reused the existing Plugin SDK safeEqualSecret contract, preserved all HTTP behavior, and added missing-token regression coverage.

Implementation changed extensions/zalo/src/outbound-media.ts and extensions/zalo/src/outbound-media.test.ts. The focused Zalo shard passed 10/10 on Node 24.18.0 and Vitest 4.1.9; formatting and git diff checks passed. Autoreview infrastructure was attempted but unavailable, and that proof gap is recorded above.
```

</details>
