### PR TITLE
refactor: split plugin loader responsibilities

### DIFF
--- a/config/max-lines-baseline.txt
+++ b/config/max-lines-baseline.txt
@@ -1033,7 +1033,6 @@ src/plugins/loader.discovery-and-security.test-utils.ts
 src/plugins/loader.hooks-and-runtime.test-utils.ts
 src/plugins/loader.registration.test-utils.ts
 src/plugins/loader.test-harness.ts
-src/plugins/loader.ts
 src/plugins/management-service.ts
 src/plugins/manifest-registry.test.ts
 src/plugins/manifest-registry.ts

--- a/src/plugins/loader-cache.ts
+++ b/src/plugins/loader-cache.ts
@@ -1,0 +1,524 @@
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { resolveConfigEnvVars } from "../config/env-substitution.js";
+import { createConfigRuntimeEnv } from "../config/env-vars.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { PluginInstallRecord } from "../config/types.plugins.js";
+import { tryReadJsonSync } from "../infra/json-files.js";
+import { resolveUserPath } from "../utils.js";
+import { resolvePluginActivationSourceConfig } from "./activation-source-config.js";
+import {
+  applyTestPluginDefaults,
+  createPluginActivationSource,
+  normalizePluginsConfig,
+  type NormalizedPluginsConfig,
+  type PluginActivationConfigSource,
+} from "./config-state.js";
+import { resolveOpenClawDevSourceRoot } from "./dev-source-root.js";
+import { loadInstalledPluginIndexInstallRecordsSync } from "./installed-plugin-index-records.js";
+import { pluginLoaderCacheInstances, type CachedPluginState } from "./loader-cache-instances.js";
+import type { PluginLoadOptions } from "./loader-types.js";
+import {
+  fingerprintPluginDiscoveryContext,
+  resolvePluginDiscoveryContext,
+} from "./plugin-control-plane-context.js";
+import {
+  hasExplicitPluginIdScope,
+  normalizePluginIdScope,
+  serializePluginIdScope,
+} from "./plugin-scope.js";
+import type { PluginRegistry } from "./registry.js";
+import type { PluginSdkResolutionPreference } from "./sdk-alias.js";
+
+export type RuntimeSubagentMode = "default" | "explicit" | "gateway-bindable";
+
+export const { scoped: pluginLoaderCacheState } = pluginLoaderCacheInstances;
+const { fullWorkspace: fullWorkspacePluginLoaderCacheState } = pluginLoaderCacheInstances;
+
+export function clearPluginRegistryLoadCache(): void {
+  pluginLoaderCacheState.clearCachedRegistries();
+  fullWorkspacePluginLoaderCacheState.clearCachedRegistries();
+}
+
+function getPluginRegistryCache(onlyPluginIds?: string[]) {
+  return onlyPluginIds ? pluginLoaderCacheState : fullWorkspacePluginLoaderCacheState;
+}
+
+function getCachedPluginRegistry(
+  cacheKey: string,
+  onlyPluginIds?: string[],
+): CachedPluginState | undefined {
+  return getPluginRegistryCache(onlyPluginIds).get(cacheKey);
+}
+
+export function setCachedPluginRegistry(
+  cacheKey: string,
+  state: CachedPluginState,
+  onlyPluginIds?: string[],
+): void {
+  getPluginRegistryCache(onlyPluginIds).set(cacheKey, state);
+}
+
+export function getReusableCachedPluginRegistry(params: {
+  cacheKey: string;
+  onlyPluginIds: string[] | undefined;
+  runtimeSubagentMode: RuntimeSubagentMode;
+  options: PluginLoadOptions;
+}):
+  | {
+      state: CachedPluginState;
+      cacheKey: string;
+      runtimeSubagentMode: RuntimeSubagentMode;
+    }
+  | undefined {
+  const exact = getCachedPluginRegistry(params.cacheKey, params.onlyPluginIds);
+  if (exact) {
+    return {
+      state: exact,
+      cacheKey: params.cacheKey,
+      runtimeSubagentMode: params.runtimeSubagentMode,
+    };
+  }
+  if (params.runtimeSubagentMode !== "default") {
+    return undefined;
+  }
+  const gatewayBindableContext = resolvePluginLoadCacheContext({
+    ...params.options,
+    runtimeOptions: {
+      ...params.options.runtimeOptions,
+      allowGatewaySubagentBinding: true,
+    },
+  });
+  const gatewayBindable = getCachedPluginRegistry(
+    gatewayBindableContext.cacheKey,
+    gatewayBindableContext.onlyPluginIds,
+  );
+  if (!gatewayBindable) {
+    return undefined;
+  }
+  return {
+    state: gatewayBindable,
+    cacheKey: gatewayBindableContext.cacheKey,
+    runtimeSubagentMode: gatewayBindableContext.runtimeSubagentMode,
+  };
+}
+
+function resolveBundledPackageRootForCache(stockRoot?: string): string | undefined {
+  if (!stockRoot) {
+    return undefined;
+  }
+  const resolved = path.resolve(stockRoot);
+  const parent = path.dirname(resolved);
+  if (
+    path.basename(resolved) === "extensions" &&
+    (path.basename(parent) === "dist" || path.basename(parent) === "dist-runtime")
+  ) {
+    return path.dirname(parent);
+  }
+  const sourcePackageRoot = parent;
+  if (fs.existsSync(path.join(sourcePackageRoot, "package.json"))) {
+    return sourcePackageRoot;
+  }
+  return undefined;
+}
+
+function readPackageVersionForCache(packageJsonPath: string): string {
+  const parsed = tryReadJsonSync(packageJsonPath);
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return "unknown";
+  }
+  const version = (parsed as { version?: unknown }).version;
+  return typeof version === "string" && version.trim() ? version.trim() : "unknown";
+}
+
+const bundledPackageCacheIdentityByStockRoot = new Map<
+  string,
+  {
+    packageJson: string;
+    packageRoot: string;
+    packageVersion: string;
+    size: number;
+    mtimeMs: number;
+  }
+>();
+
+function resolveBundledPackageCacheIdentity(stockRoot?: string) {
+  if (!stockRoot) {
+    return undefined;
+  }
+  const packageRoot = resolveBundledPackageRootForCache(stockRoot);
+  if (!packageRoot) {
+    return undefined;
+  }
+  const stockRootKey = path.resolve(stockRoot);
+  const cached = bundledPackageCacheIdentityByStockRoot.get(stockRootKey);
+  if (cached) {
+    return cached;
+  }
+  const packageJsonPath = path.join(packageRoot, "package.json");
+  try {
+    const stat = fs.statSync(packageJsonPath);
+    const identity = {
+      packageJson: safeRealpathOrResolve(packageJsonPath),
+      packageRoot: safeRealpathOrResolve(packageRoot),
+      packageVersion: readPackageVersionForCache(packageJsonPath),
+      size: stat.size,
+      mtimeMs: stat.mtimeMs,
+    };
+    bundledPackageCacheIdentityByStockRoot.set(stockRootKey, identity);
+    return identity;
+  } catch {
+    const identity = {
+      packageJson: path.resolve(packageJsonPath),
+      packageRoot: safeRealpathOrResolve(packageRoot),
+      packageVersion: "missing",
+      size: -1,
+      mtimeMs: -1,
+    };
+    bundledPackageCacheIdentityByStockRoot.set(stockRootKey, identity);
+    return identity;
+  }
+}
+
+function buildCacheKey(params: {
+  workspaceDir?: string;
+  plugins: NormalizedPluginsConfig;
+  activationMetadataKey?: string;
+  installs?: Record<string, PluginInstallRecord>;
+  env: NodeJS.ProcessEnv;
+  devSourceRoot?: string | null;
+  onlyPluginIds?: string[];
+  includeSetupOnlyChannelPlugins?: boolean;
+  forceSetupOnlyChannelPlugins?: boolean;
+  requireSetupEntryForSetupOnlyChannelPlugins?: boolean;
+  preferSetupRuntimeForChannelPlugins?: boolean;
+  forceFullRuntimeForChannelPlugins?: boolean;
+  preferBuiltPluginArtifacts?: boolean;
+  resolveRawConfigEnvVars?: boolean;
+  toolDiscovery?: boolean;
+  loadModules?: boolean;
+  runtimeSubagentMode?: RuntimeSubagentMode;
+  pluginSdkResolution?: PluginSdkResolutionPreference;
+  coreGatewayMethodNames?: string[];
+  activate?: boolean;
+}): string {
+  const discoveryContext = resolvePluginDiscoveryContext({
+    workspaceDir: params.workspaceDir,
+    loadPaths: params.plugins.loadPaths,
+    env: params.env,
+  });
+  const { roots, loadPaths } = discoveryContext;
+  const bundledPackage = resolveBundledPackageCacheIdentity(roots.stock);
+  const installs = Object.fromEntries(
+    Object.entries(params.installs ?? {}).map(([pluginId, install]) => [
+      pluginId,
+      {
+        ...install,
+        installPath:
+          typeof install.installPath === "string"
+            ? resolveUserPath(install.installPath, params.env)
+            : install.installPath,
+        sourcePath:
+          typeof install.sourcePath === "string"
+            ? resolveUserPath(install.sourcePath, params.env)
+            : install.sourcePath,
+      },
+    ]),
+  );
+  const startupChannelMode =
+    params.forceFullRuntimeForChannelPlugins === true
+      ? "force-full"
+      : params.preferSetupRuntimeForChannelPlugins === true
+        ? "prefer-setup"
+        : "full";
+  return `${roots.workspace ?? ""}::${roots.global ?? ""}::${roots.stock ?? ""}::${JSON.stringify({
+    bundledPackage,
+    devSourceRoot: params.devSourceRoot ?? "",
+    discoveryFingerprint: fingerprintPluginDiscoveryContext(discoveryContext),
+    ...params.plugins,
+    installs,
+    loadPaths,
+    activationMetadataKey: params.activationMetadataKey ?? "",
+  })}::${serializePluginIdScope(params.onlyPluginIds)}::${params.includeSetupOnlyChannelPlugins === true ? "setup-only" : "runtime"}::${params.forceSetupOnlyChannelPlugins === true ? "force-setup" : "normal-setup"}::${params.requireSetupEntryForSetupOnlyChannelPlugins === true ? "require-setup-entry" : "allow-full-fallback"}::${startupChannelMode}::${params.preferBuiltPluginArtifacts === true ? "prefer-built-artifacts" : "source-default"}::${params.resolveRawConfigEnvVars === true ? "resolve-raw-env" : "runtime-config"}::${params.loadModules === false ? "manifest-only" : "load-modules"}::${params.toolDiscovery === true ? "tool-discovery" : "default-discovery"}::${params.runtimeSubagentMode ?? "default"}::${params.pluginSdkResolution ?? "auto"}::${JSON.stringify(params.coreGatewayMethodNames ?? [])}::${params.activate === false ? "snapshot" : "active"}`;
+}
+
+export function resolveRuntimeSubagentMode(
+  runtimeOptions: PluginLoadOptions["runtimeOptions"],
+): RuntimeSubagentMode {
+  if (runtimeOptions?.allowGatewaySubagentBinding === true) {
+    return "gateway-bindable";
+  }
+  if (runtimeOptions?.subagent) {
+    return "explicit";
+  }
+  return "default";
+}
+
+function buildActivationMetadataHash(params: {
+  activationSource: PluginActivationConfigSource;
+  autoEnabledReasons: Readonly<Record<string, string[]>>;
+}): string {
+  const enabledSourceChannels = Object.entries(
+    (params.activationSource.rootConfig?.channels as Record<string, unknown>) ?? {},
+  )
+    .filter(([, value]) => {
+      if (!value || typeof value !== "object" || Array.isArray(value)) {
+        return false;
+      }
+      return (value as { enabled?: unknown }).enabled === true;
+    })
+    .map(([channelId]) => channelId)
+    .toSorted((left, right) => left.localeCompare(right));
+  const pluginEntryStates = Object.entries(params.activationSource.plugins.entries)
+    .map(([pluginId, entry]) => [pluginId, entry?.enabled ?? null] as const)
+    .toSorted(([left], [right]) => left.localeCompare(right));
+  const autoEnableReasonEntries = Object.entries(params.autoEnabledReasons)
+    .map(([pluginId, reasons]) => [pluginId, [...reasons]] as const)
+    .toSorted(([left], [right]) => left.localeCompare(right));
+
+  return createHash("sha256")
+    .update(
+      JSON.stringify({
+        enabled: params.activationSource.plugins.enabled,
+        allow: params.activationSource.plugins.allow,
+        deny: params.activationSource.plugins.deny,
+        memorySlot: params.activationSource.plugins.slots.memory,
+        entries: pluginEntryStates,
+        enabledChannels: enabledSourceChannels,
+        autoEnabledReasons: autoEnableReasonEntries,
+      }),
+    )
+    .digest("hex");
+}
+
+function redactPluginConfigForCacheKey(plugins: NormalizedPluginsConfig): NormalizedPluginsConfig {
+  const entries = Object.fromEntries(
+    Object.entries(plugins.entries).map(([pluginId, entry]) => [
+      pluginId,
+      "config" in entry ? { ...entry, config: "<plugin-config>" } : entry,
+    ]),
+  );
+  return { ...plugins, entries };
+}
+
+function resolveCoreGatewayMethodNames(options: PluginLoadOptions): string[] {
+  const names = new Set(options.coreGatewayMethodNames ?? []);
+  for (const name of Object.keys(options.coreGatewayHandlers ?? {})) {
+    names.add(name);
+  }
+  return Array.from(names).toSorted();
+}
+
+export function resolvePluginLoadCacheContext(options: PluginLoadOptions = {}) {
+  const shouldResolveRawConfigEnvVars = options.resolveRawConfigEnvVars === true;
+  const baseEnv = options.env ?? process.env;
+  const rawConfig = options.config ?? {};
+  const rawActivationSourceConfig = resolvePluginActivationSourceConfig({
+    config: options.config,
+    activationSourceConfig: options.activationSourceConfig,
+  });
+  const env = shouldResolveRawConfigEnvVars ? createConfigRuntimeEnv(rawConfig, baseEnv) : baseEnv;
+  const cfg = applyTestPluginDefaults(
+    shouldResolveRawConfigEnvVars
+      ? (resolveConfigEnvVars(rawConfig, env, {
+          onMissing: () => undefined,
+        }) as OpenClawConfig)
+      : rawConfig,
+    env,
+  );
+  const activationSourceConfig = shouldResolveRawConfigEnvVars
+    ? (resolveConfigEnvVars(rawActivationSourceConfig, env, {
+        onMissing: () => undefined,
+      }) as OpenClawConfig)
+    : rawActivationSourceConfig;
+  const normalized = normalizePluginsConfig(cfg.plugins);
+  const activationSource = createPluginActivationSource({ config: activationSourceConfig });
+  const trustNormalized = mergeTrustPluginConfigFromActivationSource({
+    normalized,
+    activationSource,
+  });
+  const onlyPluginIds = normalizePluginIdScope(options.onlyPluginIds);
+  const includeSetupOnlyChannelPlugins = options.includeSetupOnlyChannelPlugins === true;
+  const forceSetupOnlyChannelPlugins = options.forceSetupOnlyChannelPlugins === true;
+  const requireSetupEntryForSetupOnlyChannelPlugins =
+    options.requireSetupEntryForSetupOnlyChannelPlugins === true;
+  const preferSetupRuntimeForChannelPlugins = options.preferSetupRuntimeForChannelPlugins === true;
+  const forceFullRuntimeForChannelPlugins = options.forceFullRuntimeForChannelPlugins === true;
+  const preferBuiltPluginArtifacts = options.preferBuiltPluginArtifacts === true;
+  const runtimeSubagentMode = resolveRuntimeSubagentMode(options.runtimeOptions);
+  const coreGatewayMethodNames = resolveCoreGatewayMethodNames(options);
+  const installRecords = {
+    ...(options.installRecords ?? loadInstalledPluginIndexInstallRecordsSync({ env })),
+    ...cfg.plugins?.installs,
+  };
+  const devSourceRoot = resolveOpenClawDevSourceRoot(env);
+  const cacheKey = buildCacheKey({
+    workspaceDir: options.workspaceDir,
+    plugins: shouldResolveRawConfigEnvVars
+      ? redactPluginConfigForCacheKey(trustNormalized)
+      : trustNormalized,
+    activationMetadataKey: buildActivationMetadataHash({
+      activationSource,
+      autoEnabledReasons: options.autoEnabledReasons ?? {},
+    }),
+    installs: installRecords,
+    env,
+    devSourceRoot,
+    onlyPluginIds,
+    includeSetupOnlyChannelPlugins,
+    forceSetupOnlyChannelPlugins,
+    requireSetupEntryForSetupOnlyChannelPlugins,
+    preferSetupRuntimeForChannelPlugins,
+    forceFullRuntimeForChannelPlugins,
+    preferBuiltPluginArtifacts,
+    resolveRawConfigEnvVars: options.resolveRawConfigEnvVars,
+    toolDiscovery: options.toolDiscovery,
+    loadModules: options.loadModules,
+    runtimeSubagentMode,
+    pluginSdkResolution: options.pluginSdkResolution,
+    coreGatewayMethodNames,
+    activate: options.activate,
+  });
+  return {
+    env,
+    cfg,
+    normalized: trustNormalized,
+    activationSourceConfig,
+    activationSource,
+    autoEnabledReasons: options.autoEnabledReasons ?? {},
+    onlyPluginIds,
+    includeSetupOnlyChannelPlugins,
+    forceSetupOnlyChannelPlugins,
+    requireSetupEntryForSetupOnlyChannelPlugins,
+    preferSetupRuntimeForChannelPlugins,
+    forceFullRuntimeForChannelPlugins,
+    preferBuiltPluginArtifacts,
+    shouldActivate: options.activate !== false,
+    shouldLoadModules: options.loadModules !== false,
+    runtimeSubagentMode,
+    installRecords,
+    devSourceRoot,
+    cacheKey,
+  };
+}
+
+function mergeTrustPluginConfigFromActivationSource(params: {
+  normalized: NormalizedPluginsConfig;
+  activationSource: PluginActivationConfigSource;
+}): NormalizedPluginsConfig {
+  const source = params.activationSource.plugins;
+  const allow = mergePluginTrustList(params.normalized.allow, source.allow);
+  const deny = mergePluginTrustList(params.normalized.deny, source.deny);
+  const loadPaths = mergePluginTrustList(params.normalized.loadPaths, source.loadPaths);
+  if (
+    allow === params.normalized.allow &&
+    deny === params.normalized.deny &&
+    loadPaths === params.normalized.loadPaths
+  ) {
+    return params.normalized;
+  }
+  return { ...params.normalized, allow, deny, loadPaths };
+}
+
+function mergePluginTrustList(runtimeList: string[], sourceList: readonly string[]): string[] {
+  if (sourceList.length === 0) {
+    return runtimeList;
+  }
+  const merged = [...runtimeList];
+  const seen = new Set(merged);
+  for (const entry of sourceList) {
+    if (!seen.has(entry)) {
+      merged.push(entry);
+      seen.add(entry);
+    }
+  }
+  return merged.length === runtimeList.length ? runtimeList : merged;
+}
+
+export function hasExplicitCompatibilityInputs(options: PluginLoadOptions): boolean {
+  return (
+    options.config !== undefined ||
+    options.activationSourceConfig !== undefined ||
+    options.autoEnabledReasons !== undefined ||
+    options.workspaceDir !== undefined ||
+    options.env !== undefined ||
+    options.resolveRawConfigEnvVars !== undefined ||
+    hasExplicitPluginIdScope(options.onlyPluginIds) ||
+    options.runtimeOptions !== undefined ||
+    options.pluginSdkResolution !== undefined ||
+    options.coreGatewayHandlers !== undefined ||
+    options.includeSetupOnlyChannelPlugins === true ||
+    options.forceSetupOnlyChannelPlugins === true ||
+    options.requireSetupEntryForSetupOnlyChannelPlugins === true ||
+    options.preferSetupRuntimeForChannelPlugins === true ||
+    options.preferBuiltPluginArtifacts === true ||
+    options.loadModules === false
+  );
+}
+
+export function pluginLoadOptionsMatchCacheKey(
+  options: PluginLoadOptions,
+  expectedCacheKey: string,
+): boolean {
+  return resolvePluginLoadCacheContext(options).cacheKey === expectedCacheKey;
+}
+
+export function pluginToolDiscoveryOptionsMatchActiveCacheKey(
+  options: PluginLoadOptions,
+  expectedCacheKey: string,
+): boolean {
+  if (options.toolDiscovery !== true) {
+    return false;
+  }
+  const fullRuntimeOptions = { ...options, toolDiscovery: undefined };
+  if (pluginLoadOptionsMatchCacheKey(fullRuntimeOptions, expectedCacheKey)) {
+    return true;
+  }
+  if (options.activate !== false) {
+    return false;
+  }
+  return pluginLoadOptionsMatchCacheKey(
+    { ...fullRuntimeOptions, activate: true },
+    expectedCacheKey,
+  );
+}
+
+function registryContainsPluginScope(
+  registry: PluginRegistry,
+  onlyPluginIds: readonly string[] | undefined,
+): boolean {
+  if (!onlyPluginIds || onlyPluginIds.length === 0) {
+    return false;
+  }
+  const loadedPluginIds = new Set(registry.plugins.map((plugin) => plugin.id));
+  return onlyPluginIds.every((pluginId) => loadedPluginIds.has(pluginId));
+}
+
+export function scopedPluginLoadOptionsMatchWiderActiveCacheKey(
+  options: PluginLoadOptions,
+  expectedCacheKey: string,
+  activeRegistry: PluginRegistry,
+): boolean {
+  const { onlyPluginIds } = resolvePluginLoadCacheContext(options);
+  if (!registryContainsPluginScope(activeRegistry, onlyPluginIds)) {
+    return false;
+  }
+  return pluginLoadOptionsMatchCacheKey({ ...options, onlyPluginIds: undefined }, expectedCacheKey);
+}
+
+export function resolvePluginRegistryLoadCacheKey(options: PluginLoadOptions = {}): string {
+  return resolvePluginLoadCacheContext(options).cacheKey;
+}
+
+export function isPluginRegistryLoadInFlight(options: PluginLoadOptions = {}): boolean {
+  return pluginLoaderCacheState.isLoadInFlight(resolvePluginRegistryLoadCacheKey(options));
+}
+
+function safeRealpathOrResolve(value: string): string {
+  try {
+    return fs.realpathSync(value);
+  } catch {
+    return path.resolve(value);
+  }
+}

--- a/src/plugins/loader-channel-registration.ts
+++ b/src/plugins/loader-channel-registration.ts
@@ -1,0 +1,284 @@
+import fs from "node:fs";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { openRootFileSync } from "../infra/boundary-file-read.js";
+import type { PluginCandidate } from "./discovery.js";
+import {
+  channelPluginIdBelongsToManifest,
+  loadBundledRuntimeChannelPlugin,
+  mergeSetupRuntimeChannelPlugin,
+  resolveBundledRuntimeChannelRegistration,
+  resolveSetupChannelRegistration,
+  shouldDeferConfiguredChannelFullRuntimeMerge,
+} from "./loader-channel-setup.js";
+import type { PluginModuleLoader } from "./loader-module.js";
+import { runPluginRegisterSync } from "./loader-module.js";
+import { recordPluginError } from "./loader-records.js";
+import type { PluginRegistrationPlan } from "./loader-registration.js";
+import type { PluginManifestRecord } from "./manifest-registry.js";
+import { withProfile } from "./plugin-load-profile.js";
+import { createPluginRegistrationTransaction } from "./plugin-registration-transaction.js";
+import {
+  resolveCanonicalDistRuntimeSource,
+  type resolvePluginRuntimeArtifact,
+} from "./plugin-runtime-artifact-resolution.js";
+import type { createPluginRegistry } from "./registry.js";
+import type { PluginRecord, PluginRegistry } from "./registry.js";
+import type { OpenClawPluginModule, PluginLogger } from "./types.js";
+
+type PluginRegistryBuilder = ReturnType<typeof createPluginRegistry>;
+
+/**
+ * Register a channel setup entry when the selected plan uses one.
+ * Returns true once the setup path owns the candidate, including handled failures.
+ */
+export function registerSetupChannelPlugin(params: {
+  registrationPlan: PluginRegistrationPlan;
+  manifestRecord: PluginManifestRecord;
+  moduleExport: OpenClawPluginModule;
+  record: PluginRecord;
+  registry: PluginRegistry;
+  seenIds: Map<string, PluginRecord["origin"]>;
+  candidate: PluginCandidate;
+  cfg: OpenClawConfig;
+  env: NodeJS.ProcessEnv;
+  entryHooks: Parameters<PluginRegistryBuilder["createApi"]>[1]["hookPolicy"];
+  createApi: PluginRegistryBuilder["createApi"];
+  loadPluginModule: PluginModuleLoader;
+  runtimeCandidateEntry: ReturnType<typeof resolvePluginRuntimeArtifact>;
+  rejectHardlinks: boolean;
+  safeSetupSource: string;
+  preferSetupRuntimeForChannelPlugins: boolean;
+  logger: PluginLogger;
+  pushPluginLoadError: (message: string) => void;
+}): boolean {
+  const { registrationPlan, manifestRecord } = params;
+  if (!registrationPlan.loadSetupEntry || !manifestRecord.setupSource) {
+    return false;
+  }
+  const setupRegistration = resolveSetupChannelRegistration(params.moduleExport);
+  if (setupRegistration.loadError) {
+    recordSetupError(params, {
+      phase: "load",
+      error: setupRegistration.loadError,
+      logMessage: "failed to load setup entry",
+      diagnosticMessage: "failed to load setup entry: ",
+    });
+    return true;
+  }
+  if (!setupRegistration.plugin) {
+    return false;
+  }
+  if (
+    !channelPluginIdBelongsToManifest({
+      channelId: setupRegistration.plugin.id,
+      pluginId: params.record.id,
+      manifestChannels: manifestRecord.channels,
+    })
+  ) {
+    params.pushPluginLoadError(
+      `plugin id mismatch (config uses "${params.record.id}", setup export uses "${setupRegistration.plugin.id}")`,
+    );
+    return true;
+  }
+
+  const api = params.createApi(params.record, {
+    config: params.cfg,
+    pluginConfig: {},
+    hookPolicy: params.entryHooks,
+    registrationMode: registrationPlan.mode,
+  });
+  let mergedSetupRegistration = setupRegistration;
+  let runtimeSetterApplied = false;
+  if (
+    registrationPlan.loadSetupRuntimeEntry &&
+    setupRegistration.usesBundledSetupContract &&
+    !shouldDeferConfiguredChannelFullRuntimeMerge({
+      manifestChannels: manifestRecord.channels,
+      startupDeferConfiguredChannelFullLoadUntilAfterListen:
+        manifestRecord.startupDeferConfiguredChannelFullLoadUntilAfterListen,
+      cfg: params.cfg,
+      env: params.env,
+      preferSetupRuntimeForChannelPlugins: params.preferSetupRuntimeForChannelPlugins,
+    }) &&
+    resolveCanonicalDistRuntimeSource(params.runtimeCandidateEntry.source) !==
+      params.safeSetupSource
+  ) {
+    const runtimeSource = resolveCanonicalDistRuntimeSource(params.runtimeCandidateEntry.source);
+    const runtimeRoot = resolveCanonicalDistRuntimeSource(params.runtimeCandidateEntry.rootDir);
+    const opened = openRootFileSync({
+      absolutePath: runtimeSource,
+      rootPath: runtimeRoot,
+      boundaryLabel: "plugin root",
+      rejectHardlinks: params.rejectHardlinks,
+      skipLexicalRootCheck: true,
+    });
+    if (!opened.ok) {
+      params.pushPluginLoadError("plugin entry path escapes plugin root or fails alias checks");
+      return true;
+    }
+    const safeRuntimeSource = opened.path;
+    fs.closeSync(opened.fd);
+    let runtimeModule: OpenClawPluginModule;
+    try {
+      runtimeModule = withProfile(
+        { pluginId: params.record.id, source: safeRuntimeSource },
+        "load-setup-runtime-entry",
+        () => params.loadPluginModule(safeRuntimeSource) as OpenClawPluginModule,
+      );
+    } catch (error) {
+      recordSetupError(params, {
+        phase: "load",
+        error,
+        logMessage: "failed to load setup-runtime entry",
+        diagnosticMessage: "failed to load setup-runtime entry: ",
+      });
+      return true;
+    }
+    const runtimeRegistration = resolveBundledRuntimeChannelRegistration(runtimeModule);
+    if (runtimeRegistration.id && runtimeRegistration.id !== params.record.id) {
+      params.pushPluginLoadError(
+        `plugin id mismatch (config uses "${params.record.id}", runtime entry uses "${runtimeRegistration.id}")`,
+      );
+      return true;
+    }
+    if (runtimeRegistration.setChannelRuntime) {
+      try {
+        runtimeRegistration.setChannelRuntime(api.runtime);
+        runtimeSetterApplied = true;
+      } catch (error) {
+        recordSetupError(params, {
+          phase: "load",
+          error,
+          logMessage: "failed to apply setup-runtime channel runtime",
+          diagnosticMessage: "failed to apply setup-runtime channel runtime: ",
+        });
+        return true;
+      }
+    }
+    const runtimePluginRegistration = loadBundledRuntimeChannelPlugin({
+      registration: runtimeRegistration,
+    });
+    if (runtimePluginRegistration.loadError) {
+      recordSetupError(params, {
+        phase: "load",
+        error: runtimePluginRegistration.loadError,
+        logMessage: "failed to load setup-runtime channel entry",
+        diagnosticMessage: "failed to load setup-runtime channel entry: ",
+      });
+      return true;
+    }
+    if (runtimePluginRegistration.plugin) {
+      if (
+        runtimePluginRegistration.plugin.id &&
+        runtimePluginRegistration.plugin.id !== params.record.id
+      ) {
+        params.pushPluginLoadError(
+          `plugin id mismatch (config uses "${params.record.id}", runtime export uses "${runtimePluginRegistration.plugin.id}")`,
+        );
+        return true;
+      }
+      mergedSetupRegistration = {
+        ...setupRegistration,
+        plugin: mergeSetupRuntimeChannelPlugin(
+          runtimePluginRegistration.plugin,
+          setupRegistration.plugin,
+        ),
+        setChannelRuntime:
+          runtimeRegistration.setChannelRuntime ?? setupRegistration.setChannelRuntime,
+      };
+    }
+  }
+
+  const setupPlugin = mergedSetupRegistration.plugin;
+  if (!setupPlugin) {
+    return true;
+  }
+  if (
+    !channelPluginIdBelongsToManifest({
+      channelId: setupPlugin.id,
+      pluginId: params.record.id,
+      manifestChannels: manifestRecord.channels,
+    })
+  ) {
+    params.pushPluginLoadError(
+      `plugin id mismatch (config uses "${params.record.id}", setup export uses "${setupPlugin.id}")`,
+    );
+    return true;
+  }
+  if (!runtimeSetterApplied) {
+    try {
+      mergedSetupRegistration.setChannelRuntime?.(api.runtime);
+    } catch (error) {
+      recordSetupError(params, {
+        phase: "load",
+        error,
+        logMessage: "failed to apply setup channel runtime",
+        diagnosticMessage: "failed to apply setup channel runtime: ",
+      });
+      return true;
+    }
+  }
+  if (registrationPlan.mode === "setup-runtime") {
+    const registerSetupRuntime = mergedSetupRegistration.registerSetupRuntime;
+    if (registerSetupRuntime) {
+      const transaction = createPluginRegistrationTransaction({ registry: params.registry });
+      try {
+        runPluginRegisterSync((registrationApi) => registerSetupRuntime(registrationApi), api);
+        transaction.commit({ activate: true });
+      } catch (error) {
+        transaction.rollback();
+        recordSetupError(params, {
+          phase: "register",
+          error,
+          logMessage: "failed to register setup-runtime channel side effects",
+          diagnosticMessage: "failed to register setup-runtime channel side effects: ",
+        });
+        return true;
+      }
+    }
+  }
+  try {
+    api.registerChannel(setupPlugin);
+  } catch (error) {
+    recordSetupError(params, {
+      phase: "load",
+      error,
+      logMessage: "failed to register setup channel",
+      diagnosticMessage: "failed to register setup channel: ",
+    });
+    return true;
+  }
+  params.registry.plugins.push(params.record);
+  params.seenIds.set(params.record.id, params.candidate.origin);
+  return true;
+}
+
+function recordSetupError(
+  params: {
+    logger: PluginLogger;
+    registry: PluginRegistry;
+    record: PluginRecord;
+    seenIds: Map<string, PluginRecord["origin"]>;
+    candidate: PluginCandidate;
+  },
+  error: {
+    phase: PluginRecord["failurePhase"];
+    error: unknown;
+    logMessage: string;
+    diagnosticMessage: string;
+  },
+): void {
+  recordPluginError({
+    logger: params.logger,
+    registry: params.registry,
+    record: params.record,
+    seenIds: params.seenIds,
+    pluginId: params.record.id,
+    origin: params.candidate.origin,
+    phase: error.phase,
+    error: error.error,
+    logPrefix: `[plugins] ${params.record.id} ${error.logMessage} from ${params.record.source}: `,
+    diagnosticMessagePrefix: error.diagnosticMessage,
+    diagnosticCode: "channel-setup-failure",
+  });
+}

--- a/src/plugins/loader-cli.ts
+++ b/src/plugins/loader-cli.ts
@@ -1,0 +1,375 @@
+import fs from "node:fs";
+import path from "node:path";
+import type { GatewayRequestHandler } from "../gateway/server-methods/types.js";
+import { openRootFileSync } from "../infra/boundary-file-read.js";
+import { resolveUserPath } from "../utils.js";
+import { buildPluginApi } from "./api-builder.js";
+import { resolveMemorySlotDecision } from "./config-state.js";
+import { discoverOpenClawPlugins } from "./discovery.js";
+import { shouldRejectHardlinkedPluginFiles } from "./hardlink-policy.js";
+import { pluginLoaderCacheState, resolvePluginLoadCacheContext } from "./loader-cache.js";
+import { createPluginModuleLoader, runPluginRegisterSync } from "./loader-module.js";
+import { warnWhenAllowlistIsOpen } from "./loader-provenance.js";
+import {
+  formatMissingPluginRegisterError,
+  markPluginActivationDisabled,
+  recordPluginError,
+} from "./loader-records.js";
+import {
+  formatBundledChannelWrongLoaderError,
+  pushDiagnostics,
+  pushPluginValidationError,
+  resolvePluginModuleExport,
+  validatePluginConfig,
+} from "./loader-registration.js";
+import {
+  applyPluginManifestRecordDetails,
+  createManifestPluginRecord,
+  defaultPluginLogger,
+  matchesScopedPluginOrDreamingSidecar,
+  preparePluginCandidates,
+  resolveAuthorizedDreamingSidecar,
+  resolvePluginCandidateActivation,
+  safeRealpathOrResolve,
+} from "./loader-shared.js";
+import type { PluginLoadOptions } from "./loader-types.js";
+import { loadPluginManifestRegistry } from "./manifest-registry.js";
+import { withProfile } from "./plugin-load-profile.js";
+import { createPluginRegistrationTransaction } from "./plugin-registration-transaction.js";
+import { createPluginIdScopeSet } from "./plugin-scope.js";
+import { createPluginRegistry } from "./registry.js";
+import type { PluginRecord, PluginRegistry } from "./registry.js";
+import type { PluginRuntime } from "./runtime/types.js";
+import { hasKind, kindsEqual } from "./slots.js";
+import type { OpenClawPluginModule } from "./types.js";
+
+const CLI_METADATA_ENTRY_BASENAMES = [
+  "cli-metadata.ts",
+  "cli-metadata.js",
+  "cli-metadata.mjs",
+  "cli-metadata.cjs",
+] as const;
+
+export async function loadOpenClawPluginCliRegistry(
+  options: PluginLoadOptions = {},
+): Promise<PluginRegistry> {
+  const {
+    env,
+    cfg,
+    normalized,
+    activationSource,
+    autoEnabledReasons,
+    onlyPluginIds,
+    cacheKey,
+    installRecords,
+    devSourceRoot,
+  } = resolvePluginLoadCacheContext({ ...options, activate: false });
+  const logger = options.logger ?? defaultPluginLogger();
+  const onlyPluginIdSet = createPluginIdScopeSet(onlyPluginIds);
+  const loadPluginModule = createPluginModuleLoader({
+    devSourceRoot,
+    pluginSdkResolution: options.pluginSdkResolution,
+  });
+  const { registry, registerCli } = createPluginRegistry({
+    logger,
+    runtime: {} as PluginRuntime,
+    coreGatewayHandlers: options.coreGatewayHandlers as Record<string, GatewayRequestHandler>,
+    ...(options.coreGatewayMethodNames !== undefined && {
+      coreGatewayMethodNames: options.coreGatewayMethodNames,
+    }),
+    activateGlobalSideEffects: false,
+  });
+  const discovery =
+    options.discovery ??
+    discoverOpenClawPlugins({
+      workspaceDir: options.workspaceDir,
+      extraPaths: normalized.loadPaths,
+      env,
+      installRecords,
+    });
+  const manifestRegistry = loadPluginManifestRegistry({
+    config: cfg,
+    workspaceDir: options.workspaceDir,
+    env,
+    candidates: discovery.candidates,
+    diagnostics: discovery.diagnostics,
+    installRecords: Object.keys(installRecords).length > 0 ? installRecords : undefined,
+  });
+  pushDiagnostics(registry.diagnostics, manifestRegistry.diagnostics);
+  warnWhenAllowlistIsOpen({
+    emitWarning: false,
+    logger,
+    pluginsEnabled: normalized.enabled,
+    allow: normalized.allow,
+    warningCacheKey: `${cacheKey}::cli-metadata`,
+    warningCache: pluginLoaderCacheState,
+    explicitlyEnabledPluginIds: new Set(
+      Object.entries(normalized.entries)
+        .filter(([, entry]) => entry.enabled === true)
+        .map(([pluginId]) => pluginId),
+    ),
+    discoverablePlugins: manifestRegistry.plugins
+      .filter((plugin) => !onlyPluginIdSet || onlyPluginIdSet.has(plugin.id))
+      .map((plugin) => ({ id: plugin.id, source: plugin.source, origin: plugin.origin })),
+  });
+  const { manifestByRoot, orderedCandidates } = preparePluginCandidates({
+    discovery,
+    manifestRegistry,
+    normalizedLoadPaths: normalized.loadPaths,
+    env,
+    installRecords,
+  });
+  const seenIds = new Map<string, PluginRecord["origin"]>();
+  const memorySlot = normalized.slots.memory;
+  let selectedMemoryPluginId: string | null = null;
+  const dreamingSidecar = resolveAuthorizedDreamingSidecar({
+    cfg,
+    normalized,
+    activationSource,
+    manifestRegistry,
+    memorySlot,
+  });
+
+  for (const candidate of orderedCandidates) {
+    const manifestRecord = manifestByRoot.get(candidate.rootDir);
+    if (!manifestRecord) {
+      continue;
+    }
+    const pluginId = manifestRecord.id;
+    if (
+      !matchesScopedPluginOrDreamingSidecar({
+        onlyPluginIdSet,
+        pluginId,
+        sidecar: dreamingSidecar,
+      })
+    ) {
+      continue;
+    }
+    const { activationState, enableState, isDreamingSidecar } = resolvePluginCandidateActivation({
+      pluginId,
+      candidate,
+      manifestRecord,
+      cfg,
+      normalized,
+      activationSource,
+      autoEnabledReasons,
+      dreamingSidecar,
+    });
+    const existingOrigin = seenIds.get(pluginId);
+    if (existingOrigin) {
+      const duplicate = createManifestPluginRecord({
+        candidate,
+        manifestRecord,
+        enabled: false,
+        activationState,
+      });
+      duplicate.status = "disabled";
+      duplicate.error = `overridden by ${existingOrigin} plugin`;
+      markPluginActivationDisabled(duplicate, duplicate.error);
+      registry.plugins.push(duplicate);
+      continue;
+    }
+    const record = createManifestPluginRecord({
+      candidate,
+      manifestRecord,
+      enabled: enableState.enabled,
+      activationState,
+    });
+    applyPluginManifestRecordDetails(record, manifestRecord);
+    const pushPluginLoadError = (message: string) =>
+      pushPluginValidationError({
+        registry,
+        seenIds,
+        pluginId,
+        origin: candidate.origin,
+        record,
+        message,
+      });
+    if (!enableState.enabled) {
+      record.status = "disabled";
+      record.error = enableState.reason;
+      markPluginActivationDisabled(record, enableState.reason);
+      registry.plugins.push(record);
+      seenIds.set(pluginId, candidate.origin);
+      continue;
+    }
+    if (record.format === "bundle") {
+      registry.plugins.push(record);
+      seenIds.set(pluginId, candidate.origin);
+      continue;
+    }
+    if (!manifestRecord.configSchema) {
+      pushPluginLoadError("missing config schema");
+      continue;
+    }
+    const entry = normalized.entries[pluginId];
+    const validatedConfig = validatePluginConfig({
+      schema: manifestRecord.configSchema,
+      cacheKey: manifestRecord.schemaCacheKey,
+      value: entry?.config,
+    });
+    if (!validatedConfig.ok) {
+      logger.error(`[plugins] ${record.id} invalid config: ${validatedConfig.error.join(", ")}`);
+      pushPluginLoadError(`invalid config: ${validatedConfig.error.join(", ")}`);
+      continue;
+    }
+
+    const pluginRoot = safeRealpathOrResolve(candidate.rootDir);
+    const cliMetadataSource = resolveCliMetadataEntrySource(candidate.rootDir);
+    const sourceForCliMetadata =
+      candidate.origin === "bundled"
+        ? cliMetadataSource
+          ? safeRealpathOrResolve(cliMetadataSource)
+          : null
+        : (cliMetadataSource ?? candidate.source);
+    if (!sourceForCliMetadata) {
+      record.status = "loaded";
+      registry.plugins.push(record);
+      seenIds.set(pluginId, candidate.origin);
+      continue;
+    }
+    const opened = openRootFileSync({
+      absolutePath: sourceForCliMetadata,
+      rootPath: pluginRoot,
+      boundaryLabel: "plugin root",
+      rejectHardlinks: shouldRejectHardlinkedPluginFiles({
+        origin: candidate.origin,
+        rootDir: candidate.rootDir,
+        env,
+      }),
+      skipLexicalRootCheck: true,
+    });
+    if (!opened.ok) {
+      pushPluginLoadError("plugin entry path escapes plugin root or fails alias checks");
+      continue;
+    }
+    const safeSource = opened.path;
+    fs.closeSync(opened.fd);
+    let moduleExport: OpenClawPluginModule;
+    try {
+      moduleExport = withProfile(
+        { pluginId: record.id, source: safeSource },
+        "cli-metadata",
+        () => loadPluginModule(safeSource) as OpenClawPluginModule,
+      );
+    } catch (error) {
+      recordPluginError({
+        logger,
+        registry,
+        record,
+        seenIds,
+        pluginId,
+        origin: candidate.origin,
+        phase: "load",
+        error,
+        logPrefix: `[plugins] ${record.id} failed to load from ${record.source}: `,
+        diagnosticMessagePrefix: "failed to load plugin: ",
+      });
+      continue;
+    }
+    const { definition, register } = resolvePluginModuleExport(moduleExport);
+    if (definition?.id && definition.id !== record.id) {
+      pushPluginLoadError(
+        `plugin id mismatch (config uses "${record.id}", export uses "${definition.id}")`,
+      );
+      continue;
+    }
+    record.name = definition?.name ?? record.name;
+    record.description = definition?.description ?? record.description;
+    record.version = definition?.version ?? record.version;
+    if (record.kind && definition?.kind && !kindsEqual(record.kind, definition.kind)) {
+      registry.diagnostics.push({
+        level: "warn",
+        pluginId: record.id,
+        source: record.source,
+        message: `plugin kind mismatch (manifest uses "${String(record.kind)}", export uses "${String(definition.kind)}")`,
+      });
+    }
+    record.kind = definition?.kind ?? record.kind;
+    if (!isDreamingSidecar) {
+      const memoryDecision = resolveMemorySlotDecision({
+        id: record.id,
+        kind: record.kind,
+        slot: memorySlot,
+        selectedId: selectedMemoryPluginId,
+      });
+      if (!memoryDecision.enabled) {
+        record.enabled = false;
+        record.status = "disabled";
+        record.error = memoryDecision.reason;
+        markPluginActivationDisabled(record, memoryDecision.reason);
+        registry.plugins.push(record);
+        seenIds.set(pluginId, candidate.origin);
+        continue;
+      }
+      if (memoryDecision.selected && hasKind(record.kind, "memory")) {
+        selectedMemoryPluginId = record.id;
+        record.memorySlotSelected = true;
+      }
+    }
+    if (typeof register !== "function") {
+      const wrongLoaderError = formatBundledChannelWrongLoaderError(record.kind);
+      if (wrongLoaderError) {
+        logger.error(
+          `[plugins] ${record.id} ${wrongLoaderError}; ensure plugin is loaded via bundled channel discovery, not legacy plugin loader`,
+        );
+        pushPluginLoadError(wrongLoaderError);
+      } else {
+        logger.error(`[plugins] ${record.id} missing register/activate export`);
+        pushPluginLoadError(formatMissingPluginRegisterError(moduleExport, env));
+      }
+      continue;
+    }
+    const api = buildPluginApi({
+      id: record.id,
+      name: record.name,
+      version: record.version,
+      description: record.description,
+      source: record.source,
+      rootDir: record.rootDir,
+      registrationMode: "cli-metadata",
+      config: cfg,
+      pluginConfig: validatedConfig.value,
+      runtime: {} as PluginRuntime,
+      logger,
+      resolvePath: (input) => resolveUserPath(input),
+      handlers: {
+        registerCli: (registrar, opts) => registerCli(record, registrar, opts),
+      },
+    });
+    const transaction = createPluginRegistrationTransaction({ registry });
+    try {
+      withProfile({ pluginId: record.id, source: record.source }, "cli-metadata:register", () =>
+        runPluginRegisterSync(register, api),
+      );
+      registry.plugins.push(record);
+      seenIds.set(pluginId, candidate.origin);
+      transaction.commit({ activate: true });
+    } catch (error) {
+      transaction.rollback();
+      recordPluginError({
+        logger,
+        registry,
+        record,
+        seenIds,
+        pluginId,
+        origin: candidate.origin,
+        phase: "register",
+        error,
+        logPrefix: `[plugins] ${record.id} failed during register from ${record.source}: `,
+        diagnosticMessagePrefix: "plugin failed during register: ",
+      });
+    }
+  }
+  return registry;
+}
+
+function resolveCliMetadataEntrySource(rootDir: string): string | null {
+  for (const basename of CLI_METADATA_ENTRY_BASENAMES) {
+    const candidate = path.join(rootDir, basename);
+    if (fs.existsSync(candidate)) {
+      return candidate;
+    }
+  }
+  return null;
+}

--- a/src/plugins/loader-module.ts
+++ b/src/plugins/loader-module.ts
@@ -1,0 +1,219 @@
+import { toSafeImportPath } from "../shared/import-specifier.js";
+import { attachPluginApiFacades } from "./api-facades.js";
+import { isLateCallablePluginApiMethod } from "./api-lifecycle.js";
+import type { PluginLoadOptions } from "./loader-types.js";
+import { withProfile } from "./plugin-load-profile.js";
+import {
+  createPluginModuleLoaderCache,
+  getCachedPluginModuleLoader,
+  type PluginModuleLoaderCache,
+} from "./plugin-module-loader-cache.js";
+import { installOpenClawPluginSdkNativeResolver } from "./plugin-sdk-native-resolver.js";
+import type { PluginRuntime } from "./runtime/types.js";
+import {
+  buildPluginLoaderAliasMap,
+  type PluginRuntimeModuleResolution,
+  type PluginSdkResolutionPreference,
+  resolvePluginRuntimeModulePathWithDiagnostics,
+} from "./sdk-alias.js";
+import type { OpenClawPluginApi, OpenClawPluginDefinition } from "./types.js";
+
+export type PluginModuleLoader = (modulePath: string) => unknown;
+
+function isPromiseLike(value: unknown): value is PromiseLike<unknown> {
+  return (
+    (typeof value === "object" || typeof value === "function") &&
+    value !== null &&
+    typeof (value as { then?: unknown }).then === "function"
+  );
+}
+
+function createGuardedPluginRegistrationApi(api: OpenClawPluginApi): {
+  api: OpenClawPluginApi;
+  close: () => void;
+} {
+  let closed = false;
+  const guardedApi = attachPluginApiFacades(
+    new Proxy(api, {
+      get(target, prop, receiver) {
+        const value = Reflect.get(target, prop, receiver);
+        if (typeof value !== "function") {
+          return value;
+        }
+        if (typeof prop === "string" && isLateCallablePluginApiMethod(prop)) {
+          return (...args: unknown[]) => Reflect.apply(value, target, args);
+        }
+        return (...args: unknown[]) => {
+          const isLateCallableMethod =
+            typeof prop === "string" && isLateCallablePluginApiMethod(prop);
+          if (closed && !isLateCallableMethod) {
+            return undefined;
+          }
+          return Reflect.apply(value, target, args);
+        };
+      },
+    }),
+  );
+  return {
+    api: guardedApi,
+    close: () => {
+      closed = true;
+    },
+  };
+}
+
+export function runPluginRegisterSync(
+  register: NonNullable<OpenClawPluginDefinition["register"]>,
+  api: Parameters<NonNullable<OpenClawPluginDefinition["register"]>>[0],
+): void {
+  const guarded = createGuardedPluginRegistrationApi(api);
+  try {
+    const result = register(guarded.api);
+    if (isPromiseLike(result)) {
+      void Promise.resolve(result).catch(() => {});
+      throw new Error("plugin register must be synchronous");
+    }
+  } finally {
+    guarded.close();
+  }
+}
+
+export function createPluginModuleLoader(options: {
+  devSourceRoot?: string | null;
+  pluginSdkResolution?: PluginSdkResolutionPreference;
+}): PluginModuleLoader {
+  const moduleLoaders: PluginModuleLoaderCache = createPluginModuleLoaderCache();
+  const createLoaderForModule = (modulePath: string) => {
+    installOpenClawPluginSdkNativeResolver({
+      argv1: process.argv[1],
+      moduleUrl: import.meta.url,
+      pluginModulePath: modulePath,
+      devSourceRoot: options.devSourceRoot,
+      pluginSdkResolution: options.pluginSdkResolution,
+    });
+    return getCachedPluginModuleLoader({
+      cache: moduleLoaders,
+      modulePath,
+      importerUrl: import.meta.url,
+      loaderFilename: modulePath,
+      devSourceRoot: options.devSourceRoot,
+      aliasMap: buildPluginLoaderAliasMap(
+        modulePath,
+        process.argv[1],
+        import.meta.url,
+        options.pluginSdkResolution,
+        options.devSourceRoot,
+      ),
+      pluginSdkResolution: options.pluginSdkResolution,
+    });
+  };
+  return (modulePath: string): unknown =>
+    createLoaderForModule(modulePath)(toSafeImportPath(modulePath));
+}
+
+function formatPluginRuntimeModuleResolutionError(params: {
+  resolution: PluginRuntimeModuleResolution;
+  pluginSdkResolution?: PluginSdkResolutionPreference;
+}): string {
+  const { resolution } = params;
+  const candidates = resolution.candidates.length > 0 ? resolution.candidates.join(", ") : "<none>";
+  return [
+    "Unable to resolve plugin runtime module",
+    `loader=${resolution.modulePath ?? "<unresolved>"}`,
+    `packageRoot=${resolution.packageRoot ?? "<none>"}`,
+    `pluginSdkResolution=${params.pluginSdkResolution ?? "auto"}`,
+    `candidates=${candidates}`,
+    ...(resolution.error ? [`resolverError=${resolution.error}`] : []),
+  ].join("; ");
+}
+
+const LAZY_RUNTIME_REFLECTION_KEYS = [
+  "version",
+  "gateway",
+  "config",
+  "agent",
+  "subagent",
+  "system",
+  "media",
+  "mediaUnderstanding",
+  "tts",
+  "stt",
+  "channel",
+  "events",
+  "logging",
+  "state",
+  "modelAuth",
+  "imageGeneration",
+  "videoGeneration",
+  "musicGeneration",
+  "llm",
+] as const satisfies readonly (keyof PluginRuntime)[];
+
+export function createLazyPluginRuntime(params: {
+  loadPluginModule: PluginModuleLoader;
+  devSourceRoot?: string | null;
+  pluginSdkResolution?: PluginSdkResolutionPreference;
+  runtimeOptions?: PluginLoadOptions["runtimeOptions"];
+}): PluginRuntime {
+  let createPluginRuntimeFactory:
+    | ((options?: PluginLoadOptions["runtimeOptions"]) => PluginRuntime)
+    | null = null;
+  const resolveCreatePluginRuntime = () => {
+    if (createPluginRuntimeFactory) {
+      return createPluginRuntimeFactory;
+    }
+    const resolution = resolvePluginRuntimeModulePathWithDiagnostics({
+      devSourceRoot: params.devSourceRoot,
+      pluginSdkResolution: params.pluginSdkResolution,
+    });
+    if (!resolution.resolvedPath) {
+      throw new Error(
+        formatPluginRuntimeModuleResolutionError({
+          resolution,
+          pluginSdkResolution: params.pluginSdkResolution,
+        }),
+      );
+    }
+    const runtimeModule = withProfile({ source: resolution.resolvedPath }, "runtime-module", () =>
+      params.loadPluginModule(resolution.resolvedPath as string),
+    ) as {
+      createPluginRuntime?: (options?: PluginLoadOptions["runtimeOptions"]) => PluginRuntime;
+    };
+    if (typeof runtimeModule.createPluginRuntime !== "function") {
+      throw new Error("Plugin runtime module missing createPluginRuntime export");
+    }
+    createPluginRuntimeFactory = runtimeModule.createPluginRuntime;
+    return createPluginRuntimeFactory;
+  };
+
+  let resolvedRuntime: PluginRuntime | null = null;
+  const resolveRuntime = (): PluginRuntime => {
+    resolvedRuntime ??= resolveCreatePluginRuntime()(params.runtimeOptions);
+    return resolvedRuntime;
+  };
+  const reflectionKeys = new Set<PropertyKey>(LAZY_RUNTIME_REFLECTION_KEYS);
+  const resolveDescriptor = (prop: PropertyKey): PropertyDescriptor | undefined => {
+    if (!reflectionKeys.has(prop)) {
+      return Reflect.getOwnPropertyDescriptor(resolveRuntime() as object, prop);
+    }
+    return {
+      configurable: true,
+      enumerable: true,
+      get: () => Reflect.get(resolveRuntime() as object, prop),
+      set: (value: unknown) => {
+        Reflect.set(resolveRuntime() as object, prop, value);
+      },
+    };
+  };
+  return new Proxy({} as PluginRuntime, {
+    get: (_target, prop, receiver) => Reflect.get(resolveRuntime(), prop, receiver),
+    set: (_target, prop, value, receiver) => Reflect.set(resolveRuntime(), prop, value, receiver),
+    has: (_target, prop) => reflectionKeys.has(prop) || Reflect.has(resolveRuntime(), prop),
+    ownKeys: () => [...LAZY_RUNTIME_REFLECTION_KEYS],
+    getOwnPropertyDescriptor: (_target, prop) => resolveDescriptor(prop),
+    defineProperty: (_target, prop, attributes) =>
+      Reflect.defineProperty(resolveRuntime() as object, prop, attributes),
+    deleteProperty: (_target, prop) => Reflect.deleteProperty(resolveRuntime() as object, prop),
+    getPrototypeOf: () => Reflect.getPrototypeOf(resolveRuntime() as object),
+  });
+}

--- a/src/plugins/loader-registration.ts
+++ b/src/plugins/loader-registration.ts
@@ -8,7 +8,7 @@ import type { PluginRecord, PluginRegistry } from "./registry.js";
 import { validateJsonSchemaValue } from "./schema-validator.js";
 import type { OpenClawPluginDefinition, PluginRegistrationMode } from "./types.js";
 
-export class PluginLoadFailureError extends Error {
+class PluginLoadFailureError extends Error {
   readonly pluginIds: string[];
   readonly registry: PluginRegistry;
 

--- a/src/plugins/loader-registration.ts
+++ b/src/plugins/loader-registration.ts
@@ -1,0 +1,274 @@
+import { err as resultError, ok, type Result } from "@openclaw/normalization-core/result";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { shouldLoadChannelPluginInSetupRuntime } from "./loader-channel-setup.js";
+import type { PluginManifestRecord } from "./manifest-registry.js";
+import type { PluginDiagnostic } from "./manifest-types.js";
+import { unwrapDefaultModuleExport } from "./module-export.js";
+import type { PluginRecord, PluginRegistry } from "./registry.js";
+import { validateJsonSchemaValue } from "./schema-validator.js";
+import type { OpenClawPluginDefinition, PluginRegistrationMode } from "./types.js";
+
+export class PluginLoadFailureError extends Error {
+  readonly pluginIds: string[];
+  readonly registry: PluginRegistry;
+
+  constructor(registry: PluginRegistry) {
+    const failedPlugins = registry.plugins.filter((entry) => entry.status === "error");
+    const summary = failedPlugins
+      .map((entry) => `${entry.id}: ${entry.error ?? "unknown plugin load error"}`)
+      .join("; ");
+    super(`plugin load failed: ${summary}`);
+    this.name = "PluginLoadFailureError";
+    this.pluginIds = failedPlugins.map((entry) => entry.id);
+    this.registry = registry;
+  }
+}
+
+export type PluginRegistrationPlan = {
+  /** Public compatibility label passed to plugin register(api). */
+  mode: PluginRegistrationMode;
+  /** Load a setup entry instead of the normal runtime entry. */
+  loadSetupEntry: boolean;
+  /** Setup flow also needs the runtime channel entry for runtime setters/plugin shape. */
+  loadSetupRuntimeEntry: boolean;
+  /** Apply runtime capability policy such as memory-slot selection. */
+  runRuntimeCapabilityPolicy: boolean;
+  /** Register metadata that only belongs to live activation, not discovery snapshots. */
+  runFullActivationOnlyRegistrations: boolean;
+};
+
+/** Convert loader intent into explicit entrypoint and activation behavior. */
+export function resolvePluginRegistrationPlan(params: {
+  canLoadScopedSetupOnlyChannelPlugin: boolean;
+  scopedSetupOnlyChannelPluginRequested: boolean;
+  requireSetupEntryForSetupOnlyChannelPlugins: boolean;
+  enableStateEnabled: boolean;
+  shouldLoadModules: boolean;
+  validateOnly: boolean;
+  shouldActivate: boolean;
+  manifestRecord: PluginManifestRecord;
+  cfg: OpenClawConfig;
+  env: NodeJS.ProcessEnv;
+  preferSetupRuntimeForChannelPlugins: boolean;
+  forceFullRuntimeForChannelPlugins: boolean;
+  toolDiscovery: boolean;
+}): PluginRegistrationPlan | null {
+  if (params.canLoadScopedSetupOnlyChannelPlugin) {
+    return {
+      mode: "setup-only",
+      loadSetupEntry: true,
+      loadSetupRuntimeEntry: false,
+      runRuntimeCapabilityPolicy: false,
+      runFullActivationOnlyRegistrations: false,
+    };
+  }
+  if (
+    params.scopedSetupOnlyChannelPluginRequested &&
+    params.requireSetupEntryForSetupOnlyChannelPlugins
+  ) {
+    return null;
+  }
+  if (!params.enableStateEnabled) {
+    return null;
+  }
+  if (params.toolDiscovery) {
+    return {
+      mode: "tool-discovery",
+      loadSetupEntry: false,
+      loadSetupRuntimeEntry: false,
+      runRuntimeCapabilityPolicy: true,
+      runFullActivationOnlyRegistrations: false,
+    };
+  }
+  const loadSetupRuntimeEntry =
+    !params.forceFullRuntimeForChannelPlugins &&
+    params.shouldLoadModules &&
+    !params.validateOnly &&
+    shouldLoadChannelPluginInSetupRuntime({
+      manifestChannels: params.manifestRecord.channels,
+      setupSource: params.manifestRecord.setupSource,
+      startupDeferConfiguredChannelFullLoadUntilAfterListen:
+        params.manifestRecord.startupDeferConfiguredChannelFullLoadUntilAfterListen,
+      cfg: params.cfg,
+      env: params.env,
+      preferSetupRuntimeForChannelPlugins: params.preferSetupRuntimeForChannelPlugins,
+    });
+  if (loadSetupRuntimeEntry) {
+    return {
+      mode: "setup-runtime",
+      loadSetupEntry: true,
+      loadSetupRuntimeEntry: true,
+      runRuntimeCapabilityPolicy: false,
+      runFullActivationOnlyRegistrations: false,
+    };
+  }
+  const mode = params.shouldActivate ? "full" : "discovery";
+  return {
+    mode,
+    loadSetupEntry: false,
+    loadSetupRuntimeEntry: false,
+    runRuntimeCapabilityPolicy: true,
+    runFullActivationOnlyRegistrations: mode === "full",
+  };
+}
+
+export function applyManifestSnapshotMetadata(
+  record: PluginRecord,
+  manifestRecord: PluginManifestRecord,
+): void {
+  record.channelIds = [...(manifestRecord.channels ?? [])];
+  record.providerIds = [...(manifestRecord.providers ?? [])];
+  record.cliBackendIds = [
+    ...(manifestRecord.cliBackends ?? []),
+    ...(manifestRecord.setup?.cliBackends ?? []),
+  ];
+  record.commands = (manifestRecord.commandAliases ?? []).map((alias) => alias.name);
+}
+
+export function validatePluginConfig(params: {
+  schema?: Record<string, unknown>;
+  cacheKey?: string;
+  value?: unknown;
+}): Result<Record<string, unknown> | undefined, string[]> {
+  const { schema, value } = params;
+  if (!schema) {
+    return ok(value as Record<string, unknown> | undefined);
+  }
+  if (isEmptyPluginConfigJsonSchema(schema)) {
+    if (
+      value === undefined ||
+      (value &&
+        typeof value === "object" &&
+        !Array.isArray(value) &&
+        Object.keys(value).length === 0)
+    ) {
+      return ok({});
+    }
+    if (!value || typeof value !== "object" || Array.isArray(value)) {
+      return resultError(["<root>: must be object"]);
+    }
+    return resultError(["<root>: config must be empty"]);
+  }
+  const result = validateJsonSchemaValue({
+    schema,
+    cacheKey: params.cacheKey ?? JSON.stringify(schema),
+    value: value ?? {},
+    applyDefaults: true,
+  });
+  return result.ok
+    ? ok(result.value as Record<string, unknown> | undefined)
+    : resultError(result.errors.map((error) => error.text));
+}
+
+function isEmptyPluginConfigJsonSchema(schema: Record<string, unknown>): boolean {
+  if (schema.type !== "object" || schema.additionalProperties !== false) {
+    return false;
+  }
+  const properties = schema.properties;
+  if (
+    !properties ||
+    typeof properties !== "object" ||
+    Array.isArray(properties) ||
+    Object.keys(properties).length > 0
+  ) {
+    return false;
+  }
+  return !(
+    "required" in schema ||
+    "dependentRequired" in schema ||
+    "dependencies" in schema ||
+    "minProperties" in schema ||
+    "allOf" in schema ||
+    "anyOf" in schema ||
+    "oneOf" in schema ||
+    "not" in schema
+  );
+}
+
+export function resolvePluginModuleExport(moduleExport: unknown): {
+  definition?: OpenClawPluginDefinition;
+  register?: OpenClawPluginDefinition["register"];
+} {
+  const seen = new Set<unknown>();
+  const candidates: unknown[] = [unwrapDefaultModuleExport(moduleExport), moduleExport];
+  for (let index = 0; index < candidates.length && index < 12; index += 1) {
+    const resolved = candidates[index];
+    if (seen.has(resolved)) {
+      continue;
+    }
+    seen.add(resolved);
+    if (typeof resolved === "function") {
+      return { register: resolved as OpenClawPluginDefinition["register"] };
+    }
+    if (resolved && typeof resolved === "object") {
+      const definition = resolved as OpenClawPluginDefinition;
+      const register = definition.register ?? definition.activate;
+      if (typeof register === "function") {
+        return { definition, register };
+      }
+      for (const key of ["default", "module"]) {
+        if (key in definition) {
+          candidates.push((definition as Record<string, unknown>)[key]);
+        }
+      }
+    }
+  }
+  const resolved = candidates[0];
+  if (typeof resolved === "function") {
+    return { register: resolved as OpenClawPluginDefinition["register"] };
+  }
+  if (resolved && typeof resolved === "object") {
+    const definition = resolved as OpenClawPluginDefinition;
+    return { definition, register: definition.register ?? definition.activate };
+  }
+  return {};
+}
+
+function kindIncludes(kind: unknown, target: string): boolean {
+  return kind === target || (Array.isArray(kind) && kind.includes(target));
+}
+
+export function formatBundledChannelWrongLoaderError(kind: unknown): string | null {
+  if (kindIncludes(kind, "bundled-channel-setup-entry")) {
+    return "bundled channel setup entry requires setup-runtime loader";
+  }
+  if (kindIncludes(kind, "bundled-channel-entry")) {
+    return "bundled channel entry requires setup-runtime loader";
+  }
+  return null;
+}
+
+export function pushDiagnostics(diagnostics: PluginDiagnostic[], append: PluginDiagnostic[]): void {
+  diagnostics.push(...append);
+}
+
+export function pushPluginValidationError(params: {
+  registry: PluginRegistry;
+  seenIds: Map<string, PluginRecord["origin"]>;
+  pluginId: string;
+  origin: PluginRecord["origin"];
+  record: PluginRecord;
+  message: string;
+}): void {
+  params.record.status = "error";
+  params.record.error = params.message;
+  params.record.failedAt = new Date();
+  params.record.failurePhase = "validation";
+  params.registry.plugins.push(params.record);
+  params.seenIds.set(params.pluginId, params.origin);
+  params.registry.diagnostics.push({
+    level: "error",
+    pluginId: params.record.id,
+    source: params.record.source,
+    message: params.record.error,
+  });
+}
+
+export function maybeThrowOnPluginLoadError(
+  registry: PluginRegistry,
+  throwOnLoadError: boolean | undefined,
+): void {
+  if (throwOnLoadError && registry.plugins.some((entry) => entry.status === "error")) {
+    throw new PluginLoadFailureError(registry);
+  }
+}

--- a/src/plugins/loader-runtime-candidate.ts
+++ b/src/plugins/loader-runtime-candidate.ts
@@ -304,8 +304,6 @@ export function loadRuntimePluginCandidate(
     rootDir: candidate.rootDir,
     env: context.env,
   });
-  // The artifact resolver canonicalizes both source and root from staging-only
-  // dist-runtime paths before this boundary check and module import.
   const opened = openRootFileSync({
     absolutePath: loadEntry.source,
     rootPath: loadEntry.rootDir,

--- a/src/plugins/loader-runtime-candidate.ts
+++ b/src/plugins/loader-runtime-candidate.ts
@@ -297,11 +297,15 @@ export function loadRuntimePluginCandidate(
     registrationPlan.loadSetupEntry && runtimeSetupEntry
       ? runtimeSetupEntry
       : runtimeCandidateEntry;
+  // `resolvePluginRuntimeArtifact` canonicalizes source/root together. Keep that
+  // pair intact or staged dist-runtime aliases can fail this boundary check.
   const rejectHardlinks = shouldRejectHardlinkedPluginFiles({
     origin: candidate.origin,
     rootDir: candidate.rootDir,
     env: context.env,
   });
+  // The artifact resolver canonicalizes both source and root from staging-only
+  // dist-runtime paths before this boundary check and module import.
   const opened = openRootFileSync({
     absolutePath: loadEntry.source,
     rootPath: loadEntry.rootDir,

--- a/src/plugins/loader-runtime-candidate.ts
+++ b/src/plugins/loader-runtime-candidate.ts
@@ -1,0 +1,566 @@
+import fs from "node:fs";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { openRootFileSync } from "../infra/boundary-file-read.js";
+import { inspectBundleMcpRuntimeSupport } from "./bundle-mcp.js";
+import {
+  resolveMemorySlotDecision,
+  type NormalizedPluginsConfig,
+  type PluginActivationConfigSource,
+} from "./config-state.js";
+import type { PluginCandidate } from "./discovery.js";
+import { shouldRejectHardlinkedPluginFiles } from "./hardlink-policy.js";
+import { registerSetupChannelPlugin } from "./loader-channel-registration.js";
+import type { PluginModuleLoader } from "./loader-module.js";
+import { runPluginRegisterSync } from "./loader-module.js";
+import {
+  formatMissingPluginRegisterError,
+  markPluginActivationDisabled,
+  recordPluginError,
+} from "./loader-records.js";
+import {
+  applyManifestSnapshotMetadata,
+  formatBundledChannelWrongLoaderError,
+  pushPluginValidationError,
+  resolvePluginModuleExport,
+  resolvePluginRegistrationPlan,
+  validatePluginConfig,
+} from "./loader-registration.js";
+import {
+  applyPluginManifestRecordDetails,
+  createManifestPluginRecord,
+  detailPluginStartupTrace,
+  matchesScopedPluginOrDreamingSidecar,
+  resolvePluginCandidateActivation,
+  safeRealpathOrResolve,
+  type AuthorizedDreamingSidecar,
+} from "./loader-shared.js";
+import type { PluginLoadOptions } from "./loader-types.js";
+import {
+  hasExplicitManifestOwnerTrust,
+  resolveManifestOwnerBasePolicyBlock,
+} from "./manifest-owner-policy.js";
+import type { PluginManifestRecord } from "./manifest-registry.js";
+import { withProfile } from "./plugin-load-profile.js";
+import { createPluginRegistrationTransaction } from "./plugin-registration-transaction.js";
+import { resolvePluginRuntimeArtifact } from "./plugin-runtime-artifact-resolution.js";
+import type { createPluginRegistry } from "./registry.js";
+import type { PluginRecord, PluginRegistry } from "./registry.js";
+import { recordImportedPluginId } from "./runtime.js";
+import { hasKind, kindsEqual } from "./slots.js";
+import type { OpenClawPluginModule, PluginLogger } from "./types.js";
+
+type PluginRegistryBuilder = ReturnType<typeof createPluginRegistry>;
+
+export type RuntimePluginLoadState = {
+  seenIds: Map<string, PluginRecord["origin"]>;
+  selectedMemoryPluginId: string | null;
+  memorySlotMatched: boolean;
+  pluginLoadAttemptCount: number;
+};
+
+export type RuntimePluginLoadContext = {
+  options: PluginLoadOptions;
+  env: NodeJS.ProcessEnv;
+  cfg: OpenClawConfig;
+  normalized: NormalizedPluginsConfig;
+  activationSource: PluginActivationConfigSource;
+  autoEnabledReasons: Readonly<Record<string, string[]>>;
+  onlyPluginIdSet: ReadonlySet<string> | null;
+  includeSetupOnlyChannelPlugins: boolean;
+  forceSetupOnlyChannelPlugins: boolean;
+  requireSetupEntryForSetupOnlyChannelPlugins: boolean;
+  preferSetupRuntimeForChannelPlugins: boolean;
+  forceFullRuntimeForChannelPlugins: boolean;
+  preferBuiltPluginArtifacts: boolean;
+  shouldActivate: boolean;
+  shouldLoadModules: boolean;
+  validateOnly: boolean;
+  memorySlot: string | null | undefined;
+  dreamingSidecar: AuthorizedDreamingSidecar | null;
+  registry: PluginRegistry;
+  createApi: PluginRegistryBuilder["createApi"];
+  rollbackPluginGlobalSideEffects: PluginRegistryBuilder["rollbackPluginGlobalSideEffects"];
+  registerReload: PluginRegistryBuilder["registerReload"];
+  registerNodeHostCommand: PluginRegistryBuilder["registerNodeHostCommand"];
+  registerSecurityAuditCollector: PluginRegistryBuilder["registerSecurityAuditCollector"];
+  loadPluginModule: PluginModuleLoader;
+  logger: PluginLogger;
+};
+
+export function loadRuntimePluginCandidate(
+  context: RuntimePluginLoadContext,
+  candidate: PluginCandidate,
+  manifestRecord: PluginManifestRecord,
+  state: RuntimePluginLoadState,
+): void {
+  const pluginId = manifestRecord.id;
+  if (
+    !matchesScopedPluginOrDreamingSidecar({
+      onlyPluginIdSet: context.onlyPluginIdSet,
+      pluginId,
+      sidecar: context.dreamingSidecar,
+    })
+  ) {
+    return;
+  }
+  const { activationState, enableState, isDreamingSidecar } = resolvePluginCandidateActivation({
+    pluginId,
+    candidate,
+    manifestRecord,
+    cfg: context.cfg,
+    normalized: context.normalized,
+    activationSource: context.activationSource,
+    autoEnabledReasons: context.autoEnabledReasons,
+    dreamingSidecar: context.dreamingSidecar,
+  });
+  const existingOrigin = state.seenIds.get(pluginId);
+  if (existingOrigin) {
+    const duplicate = createManifestPluginRecord({
+      candidate,
+      manifestRecord,
+      enabled: false,
+      activationState,
+    });
+    duplicate.status = "disabled";
+    duplicate.error = `overridden by ${existingOrigin} plugin`;
+    markPluginActivationDisabled(duplicate, duplicate.error);
+    context.registry.plugins.push(duplicate);
+    return;
+  }
+
+  const entry = context.normalized.entries[pluginId];
+  const record = createManifestPluginRecord({
+    candidate,
+    manifestRecord,
+    enabled: enableState.enabled,
+    activationState,
+  });
+  applyPluginManifestRecordDetails(record, manifestRecord);
+  const localSetupBasePolicyBlock = resolveManifestOwnerBasePolicyBlock({
+    plugin: { id: pluginId },
+    normalizedConfig: context.normalized,
+  });
+  const trustedLocalScopedChannelSetupImport =
+    localSetupBasePolicyBlock === null &&
+    (hasExplicitManifestOwnerTrust({
+      plugin: { id: pluginId },
+      normalizedConfig: context.normalized,
+    }) ||
+      (candidate.origin === "workspace" && activationState.source === "auto"));
+  const blockUntrustedLocalScopedChannelSetupImport =
+    context.includeSetupOnlyChannelPlugins &&
+    !context.validateOnly &&
+    Boolean(context.onlyPluginIdSet) &&
+    manifestRecord.channels.length > 0 &&
+    candidate.origin !== "bundled" &&
+    !trustedLocalScopedChannelSetupImport;
+  const pushPluginLoadError = (message: string) =>
+    pushPluginValidationError({
+      registry: context.registry,
+      seenIds: state.seenIds,
+      pluginId,
+      origin: candidate.origin,
+      record,
+      message,
+    });
+  if (blockUntrustedLocalScopedChannelSetupImport) {
+    record.status = "disabled";
+    record.error =
+      activationState.reason ??
+      enableState.reason ??
+      "local plugin requires explicit trust for setup";
+    markPluginActivationDisabled(record, record.error);
+    context.registry.plugins.push(record);
+    return;
+  }
+
+  const pluginRoot = safeRealpathOrResolve(candidate.rootDir);
+  const runtimeCandidateEntry = resolvePluginRuntimeArtifact({
+    source: candidate.source,
+    rootDir: pluginRoot,
+    origin: candidate.origin,
+    preferBuiltPluginArtifacts: context.preferBuiltPluginArtifacts,
+    packageManifest: candidate.packageManifest,
+  });
+  const runtimeSetupEntry = manifestRecord.setupSource
+    ? resolvePluginRuntimeArtifact({
+        source: manifestRecord.setupSource,
+        rootDir: pluginRoot,
+        origin: candidate.origin,
+        preferBuiltPluginArtifacts: context.preferBuiltPluginArtifacts,
+        packageManifest: candidate.packageManifest,
+      })
+    : undefined;
+  const scopedSetupOnlyChannelPluginRequested =
+    context.includeSetupOnlyChannelPlugins &&
+    !context.validateOnly &&
+    Boolean(context.onlyPluginIdSet) &&
+    manifestRecord.channels.length > 0 &&
+    (!enableState.enabled || context.forceSetupOnlyChannelPlugins);
+  const registrationPlan = resolvePluginRegistrationPlan({
+    canLoadScopedSetupOnlyChannelPlugin:
+      scopedSetupOnlyChannelPluginRequested &&
+      (candidate.origin !== "workspace" || enableState.enabled) &&
+      (!context.requireSetupEntryForSetupOnlyChannelPlugins || Boolean(manifestRecord.setupSource)),
+    scopedSetupOnlyChannelPluginRequested,
+    requireSetupEntryForSetupOnlyChannelPlugins:
+      context.requireSetupEntryForSetupOnlyChannelPlugins,
+    enableStateEnabled: enableState.enabled,
+    shouldLoadModules: context.shouldLoadModules,
+    validateOnly: context.validateOnly,
+    shouldActivate: context.shouldActivate,
+    manifestRecord,
+    cfg: context.cfg,
+    env: context.env,
+    preferSetupRuntimeForChannelPlugins: context.forceFullRuntimeForChannelPlugins
+      ? false
+      : context.preferSetupRuntimeForChannelPlugins,
+    forceFullRuntimeForChannelPlugins: context.forceFullRuntimeForChannelPlugins,
+    toolDiscovery: context.options.toolDiscovery === true,
+  });
+  if (!registrationPlan) {
+    record.status = "disabled";
+    record.error = enableState.reason;
+    markPluginActivationDisabled(record, enableState.reason);
+    context.registry.plugins.push(record);
+    state.seenIds.set(pluginId, candidate.origin);
+    return;
+  }
+  if (!enableState.enabled) {
+    record.status = "disabled";
+    record.error = enableState.reason;
+    markPluginActivationDisabled(record, enableState.reason);
+  }
+  if (record.format === "bundle") {
+    registerBundleRecord(context, record, enableState.enabled, state);
+    return;
+  }
+
+  if (
+    registrationPlan.runRuntimeCapabilityPolicy &&
+    candidate.origin === "bundled" &&
+    hasKind(manifestRecord.kind, "memory") &&
+    !isDreamingSidecar
+  ) {
+    const earlyMemoryDecision = resolveMemorySlotDecision({
+      id: record.id,
+      kind: manifestRecord.kind,
+      slot: context.memorySlot,
+      selectedId: state.selectedMemoryPluginId,
+    });
+    if (!earlyMemoryDecision.enabled) {
+      disableRecord(context.registry, state, record, candidate, earlyMemoryDecision.reason);
+      return;
+    }
+  }
+  if (!manifestRecord.configSchema) {
+    pushPluginLoadError("missing config schema");
+    return;
+  }
+  if (!context.shouldLoadModules && registrationPlan.runRuntimeCapabilityPolicy) {
+    const memoryDecision = resolveMemorySlotDecision({
+      id: record.id,
+      kind: record.kind,
+      slot: context.memorySlot,
+      selectedId: state.selectedMemoryPluginId,
+    });
+    if (!memoryDecision.enabled && !isDreamingSidecar) {
+      disableRecord(context.registry, state, record, candidate, memoryDecision.reason);
+      return;
+    }
+    if (memoryDecision.selected && hasKind(record.kind, "memory")) {
+      state.selectedMemoryPluginId = record.id;
+      state.memorySlotMatched = true;
+      record.memorySlotSelected = true;
+    }
+  }
+  const validatedConfig = validatePluginConfig({
+    schema: manifestRecord.configSchema,
+    cacheKey: manifestRecord.schemaCacheKey,
+    value: entry?.config,
+  });
+  if (!validatedConfig.ok) {
+    context.logger.error(
+      `[plugins] ${record.id} invalid config: ${validatedConfig.error.join(", ")}`,
+    );
+    pushPluginLoadError(`invalid config: ${validatedConfig.error.join(", ")}`);
+    return;
+  }
+  if (!context.shouldLoadModules) {
+    applyManifestSnapshotMetadata(record, manifestRecord);
+    context.registry.plugins.push(record);
+    state.seenIds.set(pluginId, candidate.origin);
+    return;
+  }
+
+  const loadEntry =
+    registrationPlan.loadSetupEntry && runtimeSetupEntry
+      ? runtimeSetupEntry
+      : runtimeCandidateEntry;
+  const rejectHardlinks = shouldRejectHardlinkedPluginFiles({
+    origin: candidate.origin,
+    rootDir: candidate.rootDir,
+    env: context.env,
+  });
+  const opened = openRootFileSync({
+    absolutePath: loadEntry.source,
+    rootPath: loadEntry.rootDir,
+    boundaryLabel: "plugin root",
+    rejectHardlinks,
+    skipLexicalRootCheck: true,
+  });
+  if (!opened.ok) {
+    pushPluginLoadError("plugin entry path escapes plugin root or fails alias checks");
+    return;
+  }
+  const safeSource = opened.path;
+  fs.closeSync(opened.fd);
+  let moduleExport: OpenClawPluginModule;
+  let moduleLoadMs: number;
+  let moduleLoadFailed = false;
+  const beforeModuleLoad = performance.now();
+  try {
+    context.logger.debug?.(`[plugins] loading ${record.id} from ${safeSource}`);
+    recordImportedPluginId(record.id);
+    state.pluginLoadAttemptCount++;
+    moduleExport = withProfile(
+      { pluginId: record.id, source: safeSource },
+      registrationPlan.mode,
+      () => context.loadPluginModule(safeSource) as OpenClawPluginModule,
+    );
+  } catch (error) {
+    recordPluginError({
+      logger: context.logger,
+      registry: context.registry,
+      record,
+      seenIds: state.seenIds,
+      pluginId,
+      origin: candidate.origin,
+      phase: "load",
+      error,
+      logPrefix: `[plugins] ${record.id} failed to load from ${record.source}: `,
+      diagnosticMessagePrefix: "failed to load plugin: ",
+    });
+    moduleLoadFailed = true;
+    return;
+  } finally {
+    moduleLoadMs = performance.now() - beforeModuleLoad;
+    detailPluginStartupTrace(context.options.startupTrace, record.id, [
+      ["loadMs", moduleLoadMs],
+      ["loadFailedCount", moduleLoadFailed ? 1 : 0],
+    ]);
+  }
+
+  if (
+    registerSetupChannelPlugin({
+      registrationPlan,
+      manifestRecord,
+      moduleExport,
+      record,
+      registry: context.registry,
+      seenIds: state.seenIds,
+      candidate,
+      cfg: context.cfg,
+      env: context.env,
+      entryHooks: entry?.hooks,
+      createApi: context.createApi,
+      loadPluginModule: context.loadPluginModule,
+      runtimeCandidateEntry,
+      rejectHardlinks,
+      safeSetupSource: safeSource,
+      preferSetupRuntimeForChannelPlugins: context.preferSetupRuntimeForChannelPlugins,
+      logger: context.logger,
+      pushPluginLoadError,
+    })
+  ) {
+    return;
+  }
+  const { definition, register } = resolvePluginModuleExport(moduleExport);
+  if (definition?.id && definition.id !== record.id) {
+    pushPluginLoadError(
+      `plugin id mismatch (config uses "${record.id}", export uses "${definition.id}")`,
+    );
+    return;
+  }
+  record.name = definition?.name ?? record.name;
+  record.description = definition?.description ?? record.description;
+  record.version = definition?.version ?? record.version;
+  if (record.kind && definition?.kind && !kindsEqual(record.kind, definition.kind)) {
+    context.registry.diagnostics.push({
+      level: "warn",
+      pluginId: record.id,
+      source: record.source,
+      message: `plugin kind mismatch (manifest uses "${String(record.kind)}", export uses "${String(definition.kind)}")`,
+    });
+  }
+  record.kind = definition?.kind ?? record.kind;
+  if (hasKind(record.kind, "memory") && context.memorySlot === record.id) {
+    state.memorySlotMatched = true;
+  }
+  if (registrationPlan.runRuntimeCapabilityPolicy && !isDreamingSidecar) {
+    const memoryDecision = resolveMemorySlotDecision({
+      id: record.id,
+      kind: record.kind,
+      slot: context.memorySlot,
+      selectedId: state.selectedMemoryPluginId,
+    });
+    if (!memoryDecision.enabled) {
+      disableRecord(context.registry, state, record, candidate, memoryDecision.reason);
+      return;
+    }
+    if (memoryDecision.selected && hasKind(record.kind, "memory")) {
+      state.selectedMemoryPluginId = record.id;
+      record.memorySlotSelected = true;
+    }
+  }
+  if (registrationPlan.runFullActivationOnlyRegistrations) {
+    if (definition?.reload) {
+      context.registerReload(record, definition.reload);
+    }
+    for (const command of definition?.nodeHostCommands ?? []) {
+      context.registerNodeHostCommand(record, command);
+    }
+    for (const collector of definition?.securityAuditCollectors ?? []) {
+      context.registerSecurityAuditCollector(record, collector);
+    }
+  }
+  if (context.validateOnly) {
+    context.registry.plugins.push(record);
+    state.seenIds.set(pluginId, candidate.origin);
+    return;
+  }
+  if (typeof register !== "function") {
+    const wrongLoaderError = formatBundledChannelWrongLoaderError(record.kind);
+    if (wrongLoaderError) {
+      context.logger.error(
+        `[plugins] ${record.id} ${wrongLoaderError}; ensure plugin is loaded via bundled channel discovery, not legacy plugin loader`,
+      );
+      pushPluginLoadError(wrongLoaderError);
+    } else {
+      context.logger.error(`[plugins] ${record.id} missing register/activate export`);
+      pushPluginLoadError(formatMissingPluginRegisterError(moduleExport, context.env));
+    }
+    return;
+  }
+  const api = context.createApi(record, {
+    config: context.cfg,
+    pluginConfig: validatedConfig.value,
+    hookPolicy: entry?.hooks,
+    registrationMode: registrationPlan.mode,
+  });
+  const transaction = createPluginRegistrationTransaction({
+    registry: context.registry,
+    rollbackGlobalSideEffects: () => context.rollbackPluginGlobalSideEffects(record.id),
+  });
+  const beforeRegister = performance.now();
+  let registerFailed = false;
+  try {
+    withProfile(
+      { pluginId: record.id, source: record.source },
+      `${registrationPlan.mode}:register`,
+      () => runPluginRegisterSync(register, api),
+    );
+    context.registry.plugins.push(record);
+    state.seenIds.set(pluginId, candidate.origin);
+    transaction.commit({ activate: context.shouldActivate });
+  } catch (error) {
+    transaction.rollback();
+    recordPluginError({
+      logger: context.logger,
+      registry: context.registry,
+      record,
+      seenIds: state.seenIds,
+      pluginId,
+      origin: candidate.origin,
+      phase: "register",
+      error,
+      logPrefix: `[plugins] ${record.id} failed during register from ${record.source}: `,
+      diagnosticMessagePrefix: "plugin failed during register: ",
+    });
+    registerFailed = true;
+  } finally {
+    const registerMs = performance.now() - beforeRegister;
+    detailPluginStartupTrace(context.options.startupTrace, record.id, [
+      ["registerMs", registerMs],
+      ["loadAndRegisterMs", moduleLoadMs + registerMs],
+      ["registerFailedCount", registerFailed ? 1 : 0],
+    ]);
+  }
+}
+
+function registerBundleRecord(
+  context: RuntimePluginLoadContext,
+  record: PluginRecord,
+  enabled: boolean,
+  state: RuntimePluginLoadState,
+): void {
+  const unsupportedCapabilities = (record.bundleCapabilities ?? []).filter(
+    (capability) =>
+      capability !== "skills" &&
+      capability !== "mcpServers" &&
+      capability !== "settings" &&
+      !(
+        ["commands", "agents", "outputStyles", "lspServers"].includes(capability) &&
+        (record.bundleFormat === "claude" || record.bundleFormat === "cursor")
+      ) &&
+      !(
+        capability === "hooks" &&
+        (record.bundleFormat === "codex" || record.bundleFormat === "claude")
+      ),
+  );
+  for (const capability of unsupportedCapabilities) {
+    context.registry.diagnostics.push({
+      level: "warn",
+      pluginId: record.id,
+      source: record.source,
+      message: `bundle capability detected but not wired into OpenClaw yet: ${capability}`,
+    });
+  }
+  if (
+    enabled &&
+    record.rootDir &&
+    record.bundleFormat &&
+    (record.bundleCapabilities ?? []).includes("mcpServers")
+  ) {
+    const support = inspectBundleMcpRuntimeSupport({
+      pluginId: record.id,
+      rootDir: record.rootDir,
+      bundleFormat: record.bundleFormat,
+    });
+    for (const message of support.diagnostics) {
+      context.registry.diagnostics.push({
+        level: "warn",
+        pluginId: record.id,
+        source: record.source,
+        message,
+      });
+    }
+    if (support.unsupportedServerNames.length > 0) {
+      context.registry.diagnostics.push({
+        level: "warn",
+        pluginId: record.id,
+        source: record.source,
+        message:
+          "bundle MCP servers use unsupported transports or incomplete configs " +
+          `(stdio only today): ${support.unsupportedServerNames.join(", ")}`,
+      });
+    }
+  }
+  context.registry.plugins.push(record);
+  state.seenIds.set(record.id, record.origin);
+}
+
+function disableRecord(
+  registry: PluginRegistry,
+  state: RuntimePluginLoadState,
+  record: PluginRecord,
+  candidate: PluginCandidate,
+  reason: string | undefined,
+): void {
+  record.enabled = false;
+  record.status = "disabled";
+  record.error = reason;
+  markPluginActivationDisabled(record, reason);
+  registry.plugins.push(record);
+  state.seenIds.set(record.id, candidate.origin);
+}

--- a/src/plugins/loader-shared.ts
+++ b/src/plugins/loader-shared.ts
@@ -1,0 +1,262 @@
+import fs from "node:fs";
+import path from "node:path";
+import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { PluginInstallRecord } from "../config/types.plugins.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
+import {
+  DEFAULT_MEMORY_DREAMING_PLUGIN_ID,
+  resolveMemoryDreamingConfig,
+  resolveMemoryDreamingPluginConfig,
+} from "../memory-host-sdk/dreaming.js";
+import {
+  resolveEffectiveEnableState,
+  resolveEffectivePluginActivationState,
+  type NormalizedPluginsConfig,
+  type PluginActivationConfigSource,
+} from "./config-state.js";
+import { isPluginEnabledByDefaultForPlatform } from "./default-enablement.js";
+import type { PluginCandidate, PluginDiscoveryResult } from "./discovery.js";
+import { collectPluginManifestCompatCodes } from "./installed-plugin-index-record-builder.js";
+import { buildProvenanceIndex, compareDuplicateCandidateOrder } from "./loader-provenance.js";
+import { createPluginRecord, formatAutoEnabledActivationReason } from "./loader-records.js";
+import type { PluginLoadOptions } from "./loader-types.js";
+import type { PluginManifestRecord, PluginManifestRegistry } from "./manifest-registry.js";
+import type { PluginRecord } from "./registry.js";
+import { hasKind } from "./slots.js";
+import { encodeStartupTraceSegment } from "./startup-trace-segment.js";
+
+export function detailPluginStartupTrace(
+  startupTrace: PluginLoadOptions["startupTrace"] | undefined,
+  pluginId: string,
+  metrics: ReadonlyArray<readonly [string, number | string]>,
+): void {
+  startupTrace?.detail(
+    `plugins.gateway-load.plugin.${encodeStartupTraceSegment(pluginId)}`,
+    metrics,
+  );
+}
+
+export type AuthorizedDreamingSidecar = {
+  engineId: string;
+  selectedMemoryPluginId: string;
+};
+
+function resolveDreamingSidecarEngineId(params: {
+  cfg: OpenClawConfig;
+  memorySlot: string | null | undefined;
+}): string | null {
+  const normalizedMemorySlot = normalizeLowercaseStringOrEmpty(params.memorySlot);
+  if (
+    !normalizedMemorySlot ||
+    normalizedMemorySlot === "none" ||
+    normalizedMemorySlot === DEFAULT_MEMORY_DREAMING_PLUGIN_ID
+  ) {
+    return null;
+  }
+  const dreamingConfig = resolveMemoryDreamingConfig({
+    pluginConfig: resolveMemoryDreamingPluginConfig(params.cfg),
+    cfg: params.cfg,
+  });
+  return dreamingConfig.enabled ? DEFAULT_MEMORY_DREAMING_PLUGIN_ID : null;
+}
+
+export function resolveAuthorizedDreamingSidecar(params: {
+  cfg: OpenClawConfig;
+  normalized: NormalizedPluginsConfig;
+  activationSource: PluginActivationConfigSource;
+  manifestRegistry: PluginManifestRegistry;
+  memorySlot: string | null | undefined;
+}): AuthorizedDreamingSidecar | null {
+  const engineId = resolveDreamingSidecarEngineId({
+    cfg: params.cfg,
+    memorySlot: params.memorySlot,
+  });
+  if (!engineId || !params.normalized.enabled || !params.activationSource.plugins.enabled) {
+    return null;
+  }
+  const selectedMemoryPluginId = normalizeLowercaseStringOrEmpty(params.memorySlot);
+  if (!selectedMemoryPluginId || selectedMemoryPluginId === engineId) {
+    return null;
+  }
+  if (
+    params.normalized.deny.includes(engineId) ||
+    params.activationSource.plugins.deny.includes(engineId) ||
+    params.normalized.entries[engineId]?.enabled === false ||
+    params.activationSource.plugins.entries[engineId]?.enabled === false
+  ) {
+    return null;
+  }
+  const selectedMemoryPlugin = params.manifestRegistry.plugins.find(
+    (plugin) => plugin.id === selectedMemoryPluginId,
+  );
+  const sidecarPlugin = params.manifestRegistry.plugins.find((plugin) => plugin.id === engineId);
+  if (
+    !selectedMemoryPlugin ||
+    !sidecarPlugin ||
+    !hasKind(selectedMemoryPlugin.kind, "memory") ||
+    !hasKind(sidecarPlugin.kind, "memory")
+  ) {
+    return null;
+  }
+  const selectedEnableState = resolveEffectiveEnableState({
+    id: selectedMemoryPlugin.id,
+    origin: selectedMemoryPlugin.origin,
+    config: params.normalized,
+    rootConfig: params.cfg,
+    enabledByDefault: isPluginEnabledByDefaultForPlatform(selectedMemoryPlugin),
+    activationSource: params.activationSource,
+  });
+  return selectedEnableState.enabled ? { engineId, selectedMemoryPluginId } : null;
+}
+
+export function matchesScopedPluginOrDreamingSidecar(params: {
+  onlyPluginIdSet: ReadonlySet<string> | null;
+  pluginId: string;
+  sidecar: AuthorizedDreamingSidecar | null;
+}): boolean {
+  if (!params.onlyPluginIdSet || params.onlyPluginIdSet.has(params.pluginId)) {
+    return true;
+  }
+  return (
+    params.pluginId === params.sidecar?.engineId &&
+    params.onlyPluginIdSet.has(params.sidecar.selectedMemoryPluginId)
+  );
+}
+
+export function resolvePluginCandidateActivation(params: {
+  pluginId: string;
+  candidate: PluginCandidate;
+  manifestRecord: PluginManifestRecord;
+  cfg: OpenClawConfig;
+  normalized: NormalizedPluginsConfig;
+  activationSource: PluginActivationConfigSource;
+  autoEnabledReasons: Readonly<Record<string, string[]>>;
+  dreamingSidecar: AuthorizedDreamingSidecar | null;
+}) {
+  const isDreamingSidecar = params.dreamingSidecar?.engineId === params.pluginId;
+  const activationState = isDreamingSidecar
+    ? {
+        enabled: true,
+        activated: true,
+        explicitlyEnabled: false,
+        source: "auto" as const,
+        reason: `dreaming sidecar for selected memory slot "${params.dreamingSidecar?.selectedMemoryPluginId ?? ""}"`,
+      }
+    : resolveEffectivePluginActivationState({
+        id: params.pluginId,
+        origin: params.candidate.origin,
+        config: params.normalized,
+        rootConfig: params.cfg,
+        enabledByDefault: isPluginEnabledByDefaultForPlatform(params.manifestRecord),
+        activationSource: params.activationSource,
+        autoEnabledReason: formatAutoEnabledActivationReason(
+          params.autoEnabledReasons[params.pluginId],
+        ),
+      });
+  const enableState = isDreamingSidecar
+    ? { enabled: true, reason: undefined }
+    : resolveEffectiveEnableState({
+        id: params.pluginId,
+        origin: params.candidate.origin,
+        config: params.normalized,
+        rootConfig: params.cfg,
+        enabledByDefault: isPluginEnabledByDefaultForPlatform(params.manifestRecord),
+        activationSource: params.activationSource,
+      });
+  return { activationState, enableState, isDreamingSidecar };
+}
+
+export function createManifestPluginRecord(params: {
+  candidate: PluginCandidate;
+  manifestRecord: PluginManifestRecord;
+  enabled: boolean;
+  activationState: ReturnType<typeof resolveEffectivePluginActivationState>;
+}): PluginRecord {
+  const { candidate, manifestRecord } = params;
+  return createPluginRecord({
+    id: manifestRecord.id,
+    name: manifestRecord.name ?? manifestRecord.id,
+    description: manifestRecord.description,
+    version: manifestRecord.version,
+    packageName: manifestRecord.packageName,
+    format: manifestRecord.format,
+    bundleFormat: manifestRecord.bundleFormat,
+    bundleCapabilities: manifestRecord.bundleCapabilities,
+    source: candidate.source,
+    rootDir: candidate.rootDir,
+    origin: candidate.origin,
+    workspaceDir: candidate.workspaceDir,
+    trustedOfficialInstall: manifestRecord.trustedOfficialInstall,
+    enabled: params.enabled,
+    compat: collectPluginManifestCompatCodes(manifestRecord),
+    activationState: params.activationState,
+    syntheticAuthRefs: manifestRecord.syntheticAuthRefs,
+    channelIds: manifestRecord.channels,
+    providerIds: manifestRecord.providers,
+    configSchema: Boolean(manifestRecord.configSchema),
+    contracts: manifestRecord.contracts,
+  });
+}
+
+export function applyPluginManifestRecordDetails(
+  record: PluginRecord,
+  manifestRecord: PluginManifestRecord,
+): void {
+  record.kind = manifestRecord.kind;
+  record.configUiHints = manifestRecord.configUiHints;
+  record.configJsonSchema = manifestRecord.configSchema;
+}
+
+export function createPluginCandidatesFromManifestRegistry(
+  manifestRegistry: PluginManifestRegistry,
+): PluginCandidate[] {
+  return manifestRegistry.plugins.map((record) => ({
+    idHint: record.id,
+    rootDir: record.rootDir,
+    source: record.source,
+    ...(record.setupSource !== undefined ? { setupSource: record.setupSource } : {}),
+    origin: record.origin,
+    ...(record.workspaceDir !== undefined ? { workspaceDir: record.workspaceDir } : {}),
+    ...(record.format !== undefined ? { format: record.format } : {}),
+    ...(record.bundleFormat !== undefined ? { bundleFormat: record.bundleFormat } : {}),
+    ...(record.packageManifest !== undefined ? { packageManifest: record.packageManifest } : {}),
+  }));
+}
+
+export function preparePluginCandidates(params: {
+  discovery: PluginDiscoveryResult;
+  manifestRegistry: PluginManifestRegistry;
+  normalizedLoadPaths: string[];
+  env: NodeJS.ProcessEnv;
+  installRecords: Record<string, PluginInstallRecord>;
+}) {
+  const provenance = buildProvenanceIndex({
+    normalizedLoadPaths: params.normalizedLoadPaths,
+    env: params.env,
+    installRecords: params.installRecords,
+  });
+  const manifestByRoot = new Map(
+    params.manifestRegistry.plugins.map((record) => [record.rootDir, record]),
+  );
+  const orderedCandidates = [...params.discovery.candidates].toSorted((left, right) =>
+    compareDuplicateCandidateOrder({
+      left,
+      right,
+      manifestByRoot,
+      provenance,
+      env: params.env,
+    }),
+  );
+  return { manifestByRoot, orderedCandidates, provenance };
+}
+
+export const defaultPluginLogger = () => createSubsystemLogger("plugins");
+
+export function safeRealpathOrResolve(value: string): string {
+  try {
+    return fs.realpathSync(value);
+  } catch {
+    return path.resolve(value);
+  }
+}

--- a/src/plugins/loader-types.ts
+++ b/src/plugins/loader-types.ts
@@ -1,0 +1,59 @@
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { PluginInstallRecord } from "../config/types.plugins.js";
+import type { GatewayRequestHandler } from "../gateway/server-methods/types.js";
+import type { PluginDiscoveryResult } from "./discovery.js";
+import type { PluginManifestRegistry } from "./manifest-registry.js";
+import type { PluginRegistryParams } from "./registry-types.js";
+import type { CreatePluginRuntimeOptions } from "./runtime/types.js";
+import type { PluginSdkResolutionPreference } from "./sdk-alias.js";
+import type { PluginLogger } from "./types.js";
+
+export type PluginLoadOptions = {
+  config?: OpenClawConfig;
+  activationSourceConfig?: OpenClawConfig;
+  autoEnabledReasons?: Readonly<Record<string, string[]>>;
+  workspaceDir?: string;
+  installRecords?: Record<string, PluginInstallRecord>;
+  // Allows callers to resolve plugin roots and load paths against an explicit env
+  // instead of the process-global environment.
+  env?: NodeJS.ProcessEnv;
+  // Direct raw-config callers can opt into the same single env-substitution pass
+  // config IO normally performs before plugin validation.
+  resolveRawConfigEnvVars?: boolean;
+  logger?: PluginLogger;
+  coreGatewayHandlers?: Record<string, GatewayRequestHandler>;
+  coreGatewayMethodNames?: readonly string[];
+  hostServices?: PluginRegistryParams["hostServices"];
+  runtimeOptions?: CreatePluginRuntimeOptions;
+  startupTrace?: {
+    detail: (name: string, metrics: ReadonlyArray<readonly [string, number | string]>) => void;
+  };
+  pluginSdkResolution?: PluginSdkResolutionPreference;
+  cache?: boolean;
+  mode?: "full" | "validate";
+  onlyPluginIds?: string[];
+  includeSetupOnlyChannelPlugins?: boolean;
+  forceSetupOnlyChannelPlugins?: boolean;
+  requireSetupEntryForSetupOnlyChannelPlugins?: boolean;
+  /**
+   * Prefer `setupEntry` for configured channel plugins that explicitly opt in
+   * via package metadata because their setup entry covers the pre-listen startup surface.
+   */
+  preferSetupRuntimeForChannelPlugins?: boolean;
+  /**
+   * Load channel runtime entries even when setup entries are available. Plugin CLI
+   * registration needs the runtime entry because setup entries only own setup state.
+   */
+  forceFullRuntimeForChannelPlugins?: boolean;
+  /**
+   * For hot startup paths, prefer bundled plugin JS artifacts over source TS
+   * entrypoints when both are present in a source checkout.
+   */
+  preferBuiltPluginArtifacts?: boolean;
+  toolDiscovery?: boolean;
+  activate?: boolean;
+  loadModules?: boolean;
+  throwOnLoadError?: boolean;
+  manifestRegistry?: PluginManifestRegistry;
+  discovery?: PluginDiscoveryResult;
+};

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -1,370 +1,70 @@
 // Discovers, validates, and loads plugin metadata and runtime entrypoints.
-import { createHash } from "node:crypto";
-import fs from "node:fs";
-import path from "node:path";
-import { err as resultError, ok, type Result } from "@openclaw/normalization-core/result";
-import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { clearAgentHarnesses } from "../agents/harness/registry.js";
-import { resolveConfigEnvVars } from "../config/env-substitution.js";
-import { createConfigRuntimeEnv } from "../config/env-vars.js";
-import type { OpenClawConfig } from "../config/types.openclaw.js";
-import type { PluginInstallRecord } from "../config/types.plugins.js";
 import type { GatewayRequestHandler } from "../gateway/server-methods/types.js";
-import { openRootFileSync } from "../infra/boundary-file-read.js";
-import { tryReadJsonSync } from "../infra/json-files.js";
-import { createSubsystemLogger } from "../logging/subsystem.js";
-import {
-  DEFAULT_MEMORY_DREAMING_PLUGIN_ID,
-  resolveMemoryDreamingConfig,
-  resolveMemoryDreamingPluginConfig,
-} from "../memory-host-sdk/dreaming.js";
-import { toSafeImportPath } from "../shared/import-specifier.js";
 import { clearDetachedTaskLifecycleRuntimeRegistration } from "../tasks/detached-task-runtime-state.js";
-import { resolveUserPath } from "../utils.js";
-import { resolvePluginActivationSourceConfig } from "./activation-source-config.js";
-import { buildPluginApi } from "./api-builder.js";
-import { attachPluginApiFacades } from "./api-facades.js";
-import { isLateCallablePluginApiMethod } from "./api-lifecycle.js";
-import { inspectBundleMcpRuntimeSupport } from "./bundle-mcp.js";
 import { clearPluginCommands } from "./command-registry-state.js";
 import { clearCompactionProviders } from "./compaction-provider.js";
-import {
-  applyTestPluginDefaults,
-  createPluginActivationSource,
-  normalizePluginsConfig,
-  resolveEffectiveEnableState,
-  resolveEffectivePluginActivationState,
-  resolveMemorySlotDecision,
-  type PluginActivationConfigSource,
-  type NormalizedPluginsConfig,
-} from "./config-state.js";
-import { isPluginEnabledByDefaultForPlatform } from "./default-enablement.js";
-import { resolveOpenClawDevSourceRoot } from "./dev-source-root.js";
-import {
-  discoverOpenClawPlugins,
-  type PluginCandidate,
-  type PluginDiscoveryResult,
-} from "./discovery.js";
+import { discoverOpenClawPlugins } from "./discovery.js";
 import { clearEmbeddingProviders } from "./embedding-providers.js";
-import { shouldRejectHardlinkedPluginFiles } from "./hardlink-policy.js";
 import { initializeGlobalHookRunner } from "./hook-runner-global.js";
-import { collectPluginManifestCompatCodes } from "./installed-plugin-index-record-builder.js";
-import { loadInstalledPluginIndexInstallRecordsSync } from "./installed-plugin-index-records.js";
 import { clearPluginInteractiveHandlers } from "./interactive-registry.js";
-import { pluginLoaderCacheInstances, type CachedPluginState } from "./loader-cache-instances.js";
 import {
-  channelPluginIdBelongsToManifest,
-  loadBundledRuntimeChannelPlugin,
-  mergeSetupRuntimeChannelPlugin,
-  resolveBundledRuntimeChannelRegistration,
-  resolveSetupChannelRegistration,
-  shouldDeferConfiguredChannelFullRuntimeMerge,
-  shouldLoadChannelPluginInSetupRuntime,
-} from "./loader-channel-setup.js";
+  clearPluginRegistryLoadCache,
+  getReusableCachedPluginRegistry,
+  hasExplicitCompatibilityInputs,
+  isPluginRegistryLoadInFlight,
+  pluginLoaderCacheState,
+  pluginLoadOptionsMatchCacheKey,
+  pluginToolDiscoveryOptionsMatchActiveCacheKey,
+  resolvePluginLoadCacheContext,
+  resolvePluginRegistryLoadCacheKey,
+  resolveRuntimeSubagentMode,
+  scopedPluginLoadOptionsMatchWiderActiveCacheKey,
+  setCachedPluginRegistry,
+  type RuntimeSubagentMode,
+} from "./loader-cache.js";
+import { createLazyPluginRuntime, createPluginModuleLoader } from "./loader-module.js";
+import { warnAboutUntrackedLoadedPlugins, warnWhenAllowlistIsOpen } from "./loader-provenance.js";
+import { formatPluginFailureSummary } from "./loader-records.js";
+import { maybeThrowOnPluginLoadError, pushDiagnostics } from "./loader-registration.js";
 import {
-  buildProvenanceIndex,
-  compareDuplicateCandidateOrder,
-  warnAboutUntrackedLoadedPlugins,
-  warnWhenAllowlistIsOpen,
-} from "./loader-provenance.js";
+  loadRuntimePluginCandidate,
+  type RuntimePluginLoadContext,
+  type RuntimePluginLoadState,
+} from "./loader-runtime-candidate.js";
 import {
-  createPluginRecord,
-  formatAutoEnabledActivationReason,
-  formatMissingPluginRegisterError,
-  formatPluginFailureSummary,
-  markPluginActivationDisabled,
-  recordPluginError,
-} from "./loader-records.js";
-import {
-  hasExplicitManifestOwnerTrust,
-  resolveManifestOwnerBasePolicyBlock,
-} from "./manifest-owner-policy.js";
-import {
-  loadPluginManifestRegistry,
-  type PluginManifestRecord,
-  type PluginManifestRegistry,
-} from "./manifest-registry.js";
+  createPluginCandidatesFromManifestRegistry,
+  defaultPluginLogger,
+  preparePluginCandidates,
+  resolveAuthorizedDreamingSidecar,
+} from "./loader-shared.js";
+import type { PluginLoadOptions } from "./loader-types.js";
+import { loadPluginManifestRegistry } from "./manifest-registry.js";
 import type { PluginDiagnostic } from "./manifest-types.js";
 import { clearMemoryEmbeddingProviders } from "./memory-embedding-providers.js";
 import { clearMemoryPluginState } from "./memory-state.js";
-import { unwrapDefaultModuleExport } from "./module-export.js";
 import {
-  fingerprintPluginDiscoveryContext,
-  resolvePluginDiscoveryContext,
-} from "./plugin-control-plane-context.js";
-import { withProfile } from "./plugin-load-profile.js";
-import {
-  createPluginModuleLoaderCache,
-  getCachedPluginModuleLoader,
-  type PluginModuleLoaderCache,
-} from "./plugin-module-loader-cache.js";
-import {
-  createPluginRegistrationTransaction,
   restorePluginProcessGlobalState,
   snapshotPluginProcessGlobalState,
 } from "./plugin-registration-transaction.js";
-import {
-  resolveCanonicalDistRuntimeSource,
-  resolvePluginRuntimeArtifact,
-} from "./plugin-runtime-artifact-resolution.js";
-import {
-  createPluginIdScopeSet,
-  hasExplicitPluginIdScope,
-  normalizePluginIdScope,
-  serializePluginIdScope,
-} from "./plugin-scope.js";
-import { installOpenClawPluginSdkNativeResolver } from "./plugin-sdk-native-resolver.js";
+import { createPluginIdScopeSet, normalizePluginIdScope } from "./plugin-scope.js";
 import { createEmptyPluginRegistry } from "./registry-empty.js";
-import type { PluginRegistryParams } from "./registry-types.js";
-import { createPluginRegistry, type PluginRecord, type PluginRegistry } from "./registry.js";
+import { createPluginRegistry, type PluginRegistry } from "./registry.js";
 import {
   getActivePluginRegistry,
   getActivePluginRegistryKey,
   getActivePluginRuntimeSubagentMode,
-  recordImportedPluginId,
   setActivePluginRegistry,
 } from "./runtime.js";
-import type { CreatePluginRuntimeOptions } from "./runtime/types.js";
-import type { PluginRuntime } from "./runtime/types.js";
-import { validateJsonSchemaValue } from "./schema-validator.js";
-import {
-  buildPluginLoaderAliasMap,
-  type PluginRuntimeModuleResolution,
-  type PluginSdkResolutionPreference,
-  resolvePluginRuntimeModulePathWithDiagnostics,
-} from "./sdk-alias.js";
-import { hasKind, kindsEqual } from "./slots.js";
-import { encodeStartupTraceSegment } from "./startup-trace-segment.js";
-import type {
-  OpenClawPluginApi,
-  OpenClawPluginDefinition,
-  OpenClawPluginModule,
-  PluginLogger,
-  PluginRegistrationMode,
-} from "./types.js";
 
-export type PluginLoadOptions = {
-  config?: OpenClawConfig;
-  activationSourceConfig?: OpenClawConfig;
-  autoEnabledReasons?: Readonly<Record<string, string[]>>;
-  workspaceDir?: string;
-  installRecords?: Record<string, PluginInstallRecord>;
-  // Allows callers to resolve plugin roots and load paths against an explicit env
-  // instead of the process-global environment.
-  env?: NodeJS.ProcessEnv;
-  // Direct raw-config callers can opt into the same single env-substitution pass
-  // config IO normally performs before plugin validation.
-  resolveRawConfigEnvVars?: boolean;
-  logger?: PluginLogger;
-  coreGatewayHandlers?: Record<string, GatewayRequestHandler>;
-  coreGatewayMethodNames?: readonly string[];
-  hostServices?: PluginRegistryParams["hostServices"];
-  runtimeOptions?: CreatePluginRuntimeOptions;
-  startupTrace?: {
-    detail: (name: string, metrics: ReadonlyArray<readonly [string, number | string]>) => void;
-  };
-  pluginSdkResolution?: PluginSdkResolutionPreference;
-  cache?: boolean;
-  mode?: "full" | "validate";
-  onlyPluginIds?: string[];
-  includeSetupOnlyChannelPlugins?: boolean;
-  forceSetupOnlyChannelPlugins?: boolean;
-  requireSetupEntryForSetupOnlyChannelPlugins?: boolean;
-  /**
-   * Prefer `setupEntry` for configured channel plugins that explicitly opt in
-   * via package metadata because their setup entry covers the pre-listen startup surface.
-   */
-  preferSetupRuntimeForChannelPlugins?: boolean;
-  /**
-   * Load channel runtime entries even when setup entries are available. Plugin CLI
-   * registration needs the runtime entry because setup entries only own setup state.
-   */
-  forceFullRuntimeForChannelPlugins?: boolean;
-  /**
-   * For hot startup paths, prefer bundled plugin JS artifacts over source TS
-   * entrypoints when both are present in a source checkout.
-   */
-  preferBuiltPluginArtifacts?: boolean;
-  toolDiscovery?: boolean;
-  activate?: boolean;
-  loadModules?: boolean;
-  throwOnLoadError?: boolean;
-  manifestRegistry?: PluginManifestRegistry;
-  discovery?: PluginDiscoveryResult;
+export type { PluginLoadOptions } from "./loader-types.js";
+export { loadOpenClawPluginCliRegistry } from "./loader-cli.js";
+export {
+  clearPluginRegistryLoadCache,
+  isPluginRegistryLoadInFlight,
+  resolvePluginRegistryLoadCacheKey,
 };
 
-function detailPluginStartupTrace(
-  startupTrace: PluginLoadOptions["startupTrace"] | undefined,
-  pluginId: string,
-  metrics: ReadonlyArray<readonly [string, number | string]>,
-): void {
-  startupTrace?.detail(
-    `plugins.gateway-load.plugin.${encodeStartupTraceSegment(pluginId)}`,
-    metrics,
-  );
-}
-
-const CLI_METADATA_ENTRY_BASENAMES = [
-  "cli-metadata.ts",
-  "cli-metadata.js",
-  "cli-metadata.mjs",
-  "cli-metadata.cjs",
-] as const;
-
-function resolveDreamingSidecarEngineId(params: {
-  cfg: OpenClawConfig;
-  memorySlot: string | null | undefined;
-}): string | null {
-  const normalizedMemorySlot = normalizeLowercaseStringOrEmpty(params.memorySlot);
-  if (
-    !normalizedMemorySlot ||
-    normalizedMemorySlot === "none" ||
-    normalizedMemorySlot === DEFAULT_MEMORY_DREAMING_PLUGIN_ID
-  ) {
-    return null;
-  }
-  const dreamingConfig = resolveMemoryDreamingConfig({
-    pluginConfig: resolveMemoryDreamingPluginConfig(params.cfg),
-    cfg: params.cfg,
-  });
-  return dreamingConfig.enabled ? DEFAULT_MEMORY_DREAMING_PLUGIN_ID : null;
-}
-
-type AuthorizedDreamingSidecar = {
-  engineId: string;
-  selectedMemoryPluginId: string;
-};
-
-function resolveAuthorizedDreamingSidecar(params: {
-  cfg: OpenClawConfig;
-  normalized: NormalizedPluginsConfig;
-  activationSource: PluginActivationConfigSource;
-  manifestRegistry: PluginManifestRegistry;
-  memorySlot: string | null | undefined;
-}): AuthorizedDreamingSidecar | null {
-  const engineId = resolveDreamingSidecarEngineId({
-    cfg: params.cfg,
-    memorySlot: params.memorySlot,
-  });
-  if (!engineId || !params.normalized.enabled || !params.activationSource.plugins.enabled) {
-    return null;
-  }
-  const selectedMemoryPluginId = normalizeLowercaseStringOrEmpty(params.memorySlot);
-  if (!selectedMemoryPluginId || selectedMemoryPluginId === engineId) {
-    return null;
-  }
-  if (
-    params.normalized.deny.includes(engineId) ||
-    params.activationSource.plugins.deny.includes(engineId) ||
-    params.normalized.entries[engineId]?.enabled === false ||
-    params.activationSource.plugins.entries[engineId]?.enabled === false
-  ) {
-    return null;
-  }
-  const selectedMemoryPlugin = params.manifestRegistry.plugins.find(
-    (plugin) => plugin.id === selectedMemoryPluginId,
-  );
-  const sidecarPlugin = params.manifestRegistry.plugins.find((plugin) => plugin.id === engineId);
-  if (
-    !selectedMemoryPlugin ||
-    !sidecarPlugin ||
-    !hasKind(selectedMemoryPlugin.kind, "memory") ||
-    !hasKind(sidecarPlugin.kind, "memory")
-  ) {
-    return null;
-  }
-  const selectedEnableState = resolveEffectiveEnableState({
-    id: selectedMemoryPlugin.id,
-    origin: selectedMemoryPlugin.origin,
-    config: params.normalized,
-    rootConfig: params.cfg,
-    enabledByDefault: isPluginEnabledByDefaultForPlatform(selectedMemoryPlugin),
-    activationSource: params.activationSource,
-  });
-  return selectedEnableState.enabled ? { engineId, selectedMemoryPluginId } : null;
-}
-
-function isAuthorizedDreamingSidecarPlugin(params: {
-  sidecar: AuthorizedDreamingSidecar | null;
-  pluginId: string;
-}): boolean {
-  return params.sidecar?.engineId === params.pluginId;
-}
-
-function matchesScopedPluginOrDreamingSidecar(params: {
-  onlyPluginIdSet: ReadonlySet<string> | null;
-  pluginId: string;
-  sidecar: AuthorizedDreamingSidecar | null;
-}): boolean {
-  if (
-    matchesScopedPluginRequest({
-      onlyPluginIdSet: params.onlyPluginIdSet,
-      pluginId: params.pluginId,
-    })
-  ) {
-    return true;
-  }
-  return (
-    params.pluginId === params.sidecar?.engineId &&
-    params.onlyPluginIdSet?.has(params.sidecar.selectedMemoryPluginId) === true
-  );
-}
-
-class PluginLoadFailureError extends Error {
-  readonly pluginIds: string[];
-  readonly registry: PluginRegistry;
-
-  constructor(registry: PluginRegistry) {
-    const failedPlugins = registry.plugins.filter((entry) => entry.status === "error");
-    const summary = failedPlugins
-      .map((entry) => `${entry.id}: ${entry.error ?? "unknown plugin load error"}`)
-      .join("; ");
-    super(`plugin load failed: ${summary}`);
-    this.name = "PluginLoadFailureError";
-    this.pluginIds = failedPlugins.map((entry) => entry.id);
-    this.registry = registry;
-  }
-}
-
-const { scoped: pluginLoaderCacheState, fullWorkspace: fullWorkspacePluginLoaderCacheState } =
-  pluginLoaderCacheInstances;
-const LAZY_RUNTIME_REFLECTION_KEYS = [
-  "version",
-  "gateway",
-  "config",
-  "agent",
-  "subagent",
-  "system",
-  "media",
-  "mediaUnderstanding",
-  "tts",
-  "stt",
-  "channel",
-  "events",
-  "logging",
-  "state",
-  "modelAuth",
-  "imageGeneration",
-  "videoGeneration",
-  "musicGeneration",
-  "llm",
-] as const satisfies readonly (keyof PluginRuntime)[];
-
-function createPluginCandidatesFromManifestRegistry(
-  manifestRegistry: PluginManifestRegistry,
-): PluginCandidate[] {
-  return manifestRegistry.plugins.map((record) => ({
-    idHint: record.id,
-    rootDir: record.rootDir,
-    source: record.source,
-    ...(record.setupSource !== undefined ? { setupSource: record.setupSource } : {}),
-    origin: record.origin,
-    ...(record.workspaceDir !== undefined ? { workspaceDir: record.workspaceDir } : {}),
-    ...(record.format !== undefined ? { format: record.format } : {}),
-    ...(record.bundleFormat !== undefined ? { bundleFormat: record.bundleFormat } : {}),
-    ...(record.packageManifest !== undefined ? { packageManifest: record.packageManifest } : {}),
-  }));
-}
 export function clearActivatedPluginRuntimeState(): void {
   clearAgentHarnesses();
   clearPluginCommands();
@@ -376,745 +76,16 @@ export function clearActivatedPluginRuntimeState(): void {
   clearMemoryPluginState();
 }
 
-export function clearPluginRegistryLoadCache(): void {
-  pluginLoaderCacheState.clearCachedRegistries();
-  fullWorkspacePluginLoaderCacheState.clearCachedRegistries();
-}
-
-const defaultLogger = () => createSubsystemLogger("plugins");
-
-function isPromiseLike(value: unknown): value is PromiseLike<unknown> {
-  return (
-    (typeof value === "object" || typeof value === "function") &&
-    value !== null &&
-    typeof (value as { then?: unknown }).then === "function"
-  );
-}
-
-function createGuardedPluginRegistrationApi(api: OpenClawPluginApi): {
-  api: OpenClawPluginApi;
-  close: () => void;
-} {
-  let closed = false;
-  const guardedApi = attachPluginApiFacades(
-    new Proxy(api, {
-      get(target, prop, receiver) {
-        const value = Reflect.get(target, prop, receiver);
-        if (typeof value !== "function") {
-          return value;
-        }
-        if (typeof prop === "string" && isLateCallablePluginApiMethod(prop)) {
-          return (...args: unknown[]) => Reflect.apply(value, target, args);
-        }
-        return (...args: unknown[]) => {
-          const isLateCallableMethod =
-            typeof prop === "string" && isLateCallablePluginApiMethod(prop);
-          if (closed && !isLateCallableMethod) {
-            return undefined;
-          }
-          return Reflect.apply(value, target, args);
-        };
-      },
-    }),
-  );
-  return {
-    api: guardedApi,
-    close: () => {
-      closed = true;
-    },
-  };
-}
-
-function runPluginRegisterSync(
-  register: NonNullable<OpenClawPluginDefinition["register"]>,
-  api: Parameters<NonNullable<OpenClawPluginDefinition["register"]>>[0],
-): void {
-  const guarded = createGuardedPluginRegistrationApi(api);
-  try {
-    const result = register(guarded.api);
-    if (isPromiseLike(result)) {
-      void Promise.resolve(result).catch(() => {});
-      throw new Error("plugin register must be synchronous");
-    }
-  } finally {
-    guarded.close();
-  }
-}
-
-function createPluginModuleLoader(options: {
-  devSourceRoot?: string | null;
-  pluginSdkResolution?: PluginSdkResolutionPreference;
-}) {
-  const moduleLoaders: PluginModuleLoaderCache = createPluginModuleLoaderCache();
-  const createLoaderForModule = (modulePath: string) => {
-    installOpenClawPluginSdkNativeResolver({
-      argv1: process.argv[1],
-      moduleUrl: import.meta.url,
-      pluginModulePath: modulePath,
-      devSourceRoot: options.devSourceRoot,
-      pluginSdkResolution: options.pluginSdkResolution,
-    });
-    return getCachedPluginModuleLoader({
-      cache: moduleLoaders,
-      modulePath,
-      importerUrl: import.meta.url,
-      loaderFilename: modulePath,
-      devSourceRoot: options.devSourceRoot,
-      aliasMap: buildPluginLoaderAliasMap(
-        modulePath,
-        process.argv[1],
-        import.meta.url,
-        options.pluginSdkResolution,
-        options.devSourceRoot,
-      ),
-      pluginSdkResolution: options.pluginSdkResolution,
-    });
-  };
-  return (modulePath: string): unknown =>
-    createLoaderForModule(modulePath)(toSafeImportPath(modulePath));
-}
-
-function formatPluginRuntimeModuleResolutionError(params: {
-  resolution: PluginRuntimeModuleResolution;
-  pluginSdkResolution?: PluginSdkResolutionPreference;
-}): string {
-  const { resolution } = params;
-  const candidates = resolution.candidates.length > 0 ? resolution.candidates.join(", ") : "<none>";
-  return [
-    "Unable to resolve plugin runtime module",
-    `loader=${resolution.modulePath ?? "<unresolved>"}`,
-    `packageRoot=${resolution.packageRoot ?? "<none>"}`,
-    `pluginSdkResolution=${params.pluginSdkResolution ?? "auto"}`,
-    `candidates=${candidates}`,
-    ...(resolution.error ? [`resolverError=${resolution.error}`] : []),
-  ].join("; ");
-}
-function getPluginRegistryCache(onlyPluginIds?: string[]) {
-  return onlyPluginIds ? pluginLoaderCacheState : fullWorkspacePluginLoaderCacheState;
-}
-
-function getCachedPluginRegistry(
-  cacheKey: string,
-  onlyPluginIds?: string[],
-): CachedPluginState | undefined {
-  return getPluginRegistryCache(onlyPluginIds).get(cacheKey);
-}
-
-function setCachedPluginRegistry(
-  cacheKey: string,
-  state: CachedPluginState,
-  onlyPluginIds?: string[],
-): void {
-  getPluginRegistryCache(onlyPluginIds).set(cacheKey, state);
-}
-
-function getReusableCachedPluginRegistry(params: {
-  cacheKey: string;
-  onlyPluginIds: string[] | undefined;
-  runtimeSubagentMode: "default" | "explicit" | "gateway-bindable";
-  options: PluginLoadOptions;
-}):
-  | {
-      state: CachedPluginState;
-      cacheKey: string;
-      runtimeSubagentMode: "default" | "explicit" | "gateway-bindable";
-    }
-  | undefined {
-  const exact = getCachedPluginRegistry(params.cacheKey, params.onlyPluginIds);
-  if (exact) {
-    return {
-      state: exact,
-      cacheKey: params.cacheKey,
-      runtimeSubagentMode: params.runtimeSubagentMode,
-    };
-  }
-  if (params.runtimeSubagentMode !== "default") {
-    return undefined;
-  }
-  const gatewayBindableContext = resolvePluginLoadCacheContext({
-    ...params.options,
-    runtimeOptions: {
-      ...params.options.runtimeOptions,
-      allowGatewaySubagentBinding: true,
-    },
-  });
-  const gatewayBindable = getCachedPluginRegistry(
-    gatewayBindableContext.cacheKey,
-    gatewayBindableContext.onlyPluginIds,
-  );
-  if (!gatewayBindable) {
-    return undefined;
-  }
-  return {
-    state: gatewayBindable,
-    cacheKey: gatewayBindableContext.cacheKey,
-    runtimeSubagentMode: gatewayBindableContext.runtimeSubagentMode,
-  };
-}
-
-function resolveBundledPackageRootForCache(stockRoot?: string): string | undefined {
-  if (!stockRoot) {
-    return undefined;
-  }
-  const resolved = path.resolve(stockRoot);
-  const parent = path.dirname(resolved);
-  if (
-    path.basename(resolved) === "extensions" &&
-    (path.basename(parent) === "dist" || path.basename(parent) === "dist-runtime")
-  ) {
-    return path.dirname(parent);
-  }
-  const sourcePackageRoot = parent;
-  if (fs.existsSync(path.join(sourcePackageRoot, "package.json"))) {
-    return sourcePackageRoot;
-  }
-  return undefined;
-}
-
-function readPackageVersionForCache(packageJsonPath: string): string {
-  const parsed = tryReadJsonSync(packageJsonPath);
-  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-    return "unknown";
-  }
-  const version = (parsed as { version?: unknown }).version;
-  return typeof version === "string" && version.trim() ? version.trim() : "unknown";
-}
-
-const bundledPackageCacheIdentityByStockRoot = new Map<
-  string,
-  {
-    packageJson: string;
-    packageRoot: string;
-    packageVersion: string;
-    size: number;
-    mtimeMs: number;
-  }
->();
-
-function resolveBundledPackageCacheIdentity(stockRoot?: string):
-  | {
-      packageJson: string;
-      packageRoot: string;
-      packageVersion: string;
-      size: number;
-      mtimeMs: number;
-    }
-  | undefined {
-  if (!stockRoot) {
-    return undefined;
-  }
-  const packageRoot = resolveBundledPackageRootForCache(stockRoot);
-  if (!packageRoot) {
-    return undefined;
-  }
-  const stockRootKey = path.resolve(stockRoot);
-  const cached = bundledPackageCacheIdentityByStockRoot.get(stockRootKey);
-  if (cached) {
-    return cached;
-  }
-  const packageJsonPath = path.join(packageRoot, "package.json");
-  try {
-    const stat = fs.statSync(packageJsonPath);
-    const identity = {
-      packageJson: safeRealpathOrResolve(packageJsonPath),
-      packageRoot: safeRealpathOrResolve(packageRoot),
-      packageVersion: readPackageVersionForCache(packageJsonPath),
-      size: stat.size,
-      mtimeMs: stat.mtimeMs,
-    };
-    bundledPackageCacheIdentityByStockRoot.set(stockRootKey, identity);
-    return identity;
-  } catch {
-    const identity = {
-      packageJson: path.resolve(packageJsonPath),
-      packageRoot: safeRealpathOrResolve(packageRoot),
-      packageVersion: "missing",
-      size: -1,
-      mtimeMs: -1,
-    };
-    bundledPackageCacheIdentityByStockRoot.set(stockRootKey, identity);
-    return identity;
-  }
-}
-
-function buildCacheKey(params: {
-  workspaceDir?: string;
-  plugins: NormalizedPluginsConfig;
-  activationMetadataKey?: string;
-  installs?: Record<string, PluginInstallRecord>;
-  env: NodeJS.ProcessEnv;
-  devSourceRoot?: string | null;
-  onlyPluginIds?: string[];
-  includeSetupOnlyChannelPlugins?: boolean;
-  forceSetupOnlyChannelPlugins?: boolean;
-  requireSetupEntryForSetupOnlyChannelPlugins?: boolean;
-  preferSetupRuntimeForChannelPlugins?: boolean;
-  forceFullRuntimeForChannelPlugins?: boolean;
-  preferBuiltPluginArtifacts?: boolean;
-  resolveRawConfigEnvVars?: boolean;
-  toolDiscovery?: boolean;
-  loadModules?: boolean;
-  runtimeSubagentMode?: "default" | "explicit" | "gateway-bindable";
-  pluginSdkResolution?: PluginSdkResolutionPreference;
-  coreGatewayMethodNames?: string[];
-  activate?: boolean;
-}): string {
-  const discoveryContext = resolvePluginDiscoveryContext({
-    workspaceDir: params.workspaceDir,
-    loadPaths: params.plugins.loadPaths,
-    env: params.env,
-  });
-  const { roots, loadPaths } = discoveryContext;
-  const bundledPackage = resolveBundledPackageCacheIdentity(roots.stock);
-  const devSourceRoot = params.devSourceRoot ?? "";
-  const installs = Object.fromEntries(
-    Object.entries(params.installs ?? {}).map(([pluginId, install]) => [
-      pluginId,
-      {
-        ...install,
-        installPath:
-          typeof install.installPath === "string"
-            ? resolveUserPath(install.installPath, params.env)
-            : install.installPath,
-        sourcePath:
-          typeof install.sourcePath === "string"
-            ? resolveUserPath(install.sourcePath, params.env)
-            : install.sourcePath,
-      },
-    ]),
-  );
-  const scopeKey = serializePluginIdScope(params.onlyPluginIds);
-  const setupOnlyKey = params.includeSetupOnlyChannelPlugins === true ? "setup-only" : "runtime";
-  const setupOnlyModeKey =
-    params.forceSetupOnlyChannelPlugins === true ? "force-setup" : "normal-setup";
-  const setupOnlyRequirementKey =
-    params.requireSetupEntryForSetupOnlyChannelPlugins === true
-      ? "require-setup-entry"
-      : "allow-full-fallback";
-  const startupChannelMode =
-    params.forceFullRuntimeForChannelPlugins === true
-      ? "force-full"
-      : params.preferSetupRuntimeForChannelPlugins === true
-        ? "prefer-setup"
-        : "full";
-  const bundledArtifactMode =
-    params.preferBuiltPluginArtifacts === true ? "prefer-built-artifacts" : "source-default";
-  const rawConfigEnvMode =
-    params.resolveRawConfigEnvVars === true ? "resolve-raw-env" : "runtime-config";
-  const moduleLoadMode = params.loadModules === false ? "manifest-only" : "load-modules";
-  const discoveryMode = params.toolDiscovery === true ? "tool-discovery" : "default-discovery";
-  const runtimeSubagentMode = params.runtimeSubagentMode ?? "default";
-  const gatewayMethodsKey = JSON.stringify(params.coreGatewayMethodNames ?? []);
-  const activationMode = params.activate === false ? "snapshot" : "active";
-  return `${roots.workspace ?? ""}::${roots.global ?? ""}::${roots.stock ?? ""}::${JSON.stringify({
-    bundledPackage,
-    devSourceRoot,
-    discoveryFingerprint: fingerprintPluginDiscoveryContext(discoveryContext),
-    ...params.plugins,
-    installs,
-    loadPaths,
-    activationMetadataKey: params.activationMetadataKey ?? "",
-  })}::${scopeKey}::${setupOnlyKey}::${setupOnlyModeKey}::${setupOnlyRequirementKey}::${startupChannelMode}::${bundledArtifactMode}::${rawConfigEnvMode}::${moduleLoadMode}::${discoveryMode}::${runtimeSubagentMode}::${params.pluginSdkResolution ?? "auto"}::${gatewayMethodsKey}::${activationMode}`;
-}
-
-function matchesScopedPluginRequest(params: {
-  onlyPluginIdSet: ReadonlySet<string> | null;
-  pluginId: string;
-}): boolean {
-  const scopedIds = params.onlyPluginIdSet;
-  if (!scopedIds) {
-    return true;
-  }
-  return scopedIds.has(params.pluginId);
-}
-
-function resolveRuntimeSubagentMode(
-  runtimeOptions: PluginLoadOptions["runtimeOptions"],
-): "default" | "explicit" | "gateway-bindable" {
-  if (runtimeOptions?.allowGatewaySubagentBinding === true) {
-    return "gateway-bindable";
-  }
-  if (runtimeOptions?.subagent) {
-    return "explicit";
-  }
-  return "default";
-}
-
-function buildActivationMetadataHash(params: {
-  activationSource: PluginActivationConfigSource;
-  autoEnabledReasons: Readonly<Record<string, string[]>>;
-}): string {
-  const enabledSourceChannels = Object.entries(
-    (params.activationSource.rootConfig?.channels as Record<string, unknown>) ?? {},
-  )
-    .filter(([, value]) => {
-      if (!value || typeof value !== "object" || Array.isArray(value)) {
-        return false;
-      }
-      return (value as { enabled?: unknown }).enabled === true;
-    })
-    .map(([channelId]) => channelId)
-    .toSorted((left, right) => left.localeCompare(right));
-  const pluginEntryStates = Object.entries(params.activationSource.plugins.entries)
-    .map(([pluginId, entry]) => [pluginId, entry?.enabled ?? null] as const)
-    .toSorted(([left], [right]) => left.localeCompare(right));
-  const autoEnableReasonEntries = Object.entries(params.autoEnabledReasons)
-    .map(([pluginId, reasons]) => [pluginId, [...reasons]] as const)
-    .toSorted(([left], [right]) => left.localeCompare(right));
-
-  return createHash("sha256")
-    .update(
-      JSON.stringify({
-        enabled: params.activationSource.plugins.enabled,
-        allow: params.activationSource.plugins.allow,
-        deny: params.activationSource.plugins.deny,
-        memorySlot: params.activationSource.plugins.slots.memory,
-        entries: pluginEntryStates,
-        enabledChannels: enabledSourceChannels,
-        autoEnabledReasons: autoEnableReasonEntries,
-      }),
-    )
-    .digest("hex");
-}
-
-function redactPluginConfigForCacheKey(plugins: NormalizedPluginsConfig): NormalizedPluginsConfig {
-  const entries = Object.fromEntries(
-    Object.entries(plugins.entries).map(([pluginId, entry]) => [
-      pluginId,
-      "config" in entry ? { ...entry, config: "<plugin-config>" } : entry,
-    ]),
-  );
-  return { ...plugins, entries };
-}
-
-function hasExplicitCompatibilityInputs(options: PluginLoadOptions): boolean {
-  return (
-    options.config !== undefined ||
-    options.activationSourceConfig !== undefined ||
-    options.autoEnabledReasons !== undefined ||
-    options.workspaceDir !== undefined ||
-    options.env !== undefined ||
-    options.resolveRawConfigEnvVars !== undefined ||
-    hasExplicitPluginIdScope(options.onlyPluginIds) ||
-    options.runtimeOptions !== undefined ||
-    options.pluginSdkResolution !== undefined ||
-    options.coreGatewayHandlers !== undefined ||
-    options.includeSetupOnlyChannelPlugins === true ||
-    options.forceSetupOnlyChannelPlugins === true ||
-    options.requireSetupEntryForSetupOnlyChannelPlugins === true ||
-    options.preferSetupRuntimeForChannelPlugins === true ||
-    options.preferBuiltPluginArtifacts === true ||
-    options.loadModules === false
-  );
-}
-
-function resolveCoreGatewayMethodNames(options: PluginLoadOptions): string[] {
-  const names = new Set(options.coreGatewayMethodNames ?? []);
-  for (const name of Object.keys(options.coreGatewayHandlers ?? {})) {
-    names.add(name);
-  }
-  return Array.from(names).toSorted();
-}
-
-function pluginLoadOptionsMatchCacheKey(
-  options: PluginLoadOptions,
-  expectedCacheKey: string,
-): boolean {
-  return resolvePluginLoadCacheContext(options).cacheKey === expectedCacheKey;
-}
-
-function pluginToolDiscoveryOptionsMatchActiveCacheKey(
-  options: PluginLoadOptions,
-  expectedCacheKey: string,
-): boolean {
-  if (options.toolDiscovery !== true) {
-    return false;
-  }
-  const fullRuntimeOptions = {
-    ...options,
-    toolDiscovery: undefined,
-  };
-  if (pluginLoadOptionsMatchCacheKey(fullRuntimeOptions, expectedCacheKey)) {
-    return true;
-  }
-  if (options.activate !== false) {
-    return false;
-  }
-  return pluginLoadOptionsMatchCacheKey(
-    {
-      ...fullRuntimeOptions,
-      activate: true,
-    },
-    expectedCacheKey,
-  );
-}
-
-function registryContainsPluginScope(
+function activatePluginRegistry(
   registry: PluginRegistry,
-  onlyPluginIds: readonly string[] | undefined,
-): boolean {
-  if (!onlyPluginIds || onlyPluginIds.length === 0) {
-    return false;
-  }
-  const loadedPluginIds = new Set(registry.plugins.map((plugin) => plugin.id));
-  return onlyPluginIds.every((pluginId) => loadedPluginIds.has(pluginId));
-}
-
-function scopedPluginLoadOptionsMatchWiderActiveCacheKey(
-  options: PluginLoadOptions,
-  expectedCacheKey: string,
-  activeRegistry: PluginRegistry,
-): boolean {
-  const { onlyPluginIds } = resolvePluginLoadCacheContext(options);
-  if (!registryContainsPluginScope(activeRegistry, onlyPluginIds)) {
-    return false;
-  }
-  return pluginLoadOptionsMatchCacheKey(
-    {
-      ...options,
-      onlyPluginIds: undefined,
-    },
-    expectedCacheKey,
-  );
-}
-
-type PluginRegistrationPlan = {
-  /** Public compatibility label passed to plugin register(api). */
-  mode: PluginRegistrationMode;
-  /** Load a setup entry instead of the normal runtime entry. */
-  loadSetupEntry: boolean;
-  /** Setup flow also needs the runtime channel entry for runtime setters/plugin shape. */
-  loadSetupRuntimeEntry: boolean;
-  /** Apply runtime capability policy such as memory-slot selection. */
-  runRuntimeCapabilityPolicy: boolean;
-  /** Register metadata that only belongs to live activation, not discovery snapshots. */
-  runFullActivationOnlyRegistrations: boolean;
-};
-
-/**
- * Convert loader intent into explicit behavior flags.
- *
- * Registration modes are plugin-facing labels; this plan is the internal source
- * of truth for which entrypoint to load and which activation-only policies run.
- */
-function resolvePluginRegistrationPlan(params: {
-  canLoadScopedSetupOnlyChannelPlugin: boolean;
-  scopedSetupOnlyChannelPluginRequested: boolean;
-  requireSetupEntryForSetupOnlyChannelPlugins: boolean;
-  enableStateEnabled: boolean;
-  shouldLoadModules: boolean;
-  validateOnly: boolean;
-  shouldActivate: boolean;
-  manifestRecord: PluginManifestRecord;
-  cfg: OpenClawConfig;
-  env: NodeJS.ProcessEnv;
-  preferSetupRuntimeForChannelPlugins: boolean;
-  forceFullRuntimeForChannelPlugins: boolean;
-  toolDiscovery: boolean;
-}): PluginRegistrationPlan | null {
-  if (params.canLoadScopedSetupOnlyChannelPlugin) {
-    return {
-      mode: "setup-only",
-      loadSetupEntry: true,
-      loadSetupRuntimeEntry: false,
-      runRuntimeCapabilityPolicy: false,
-      runFullActivationOnlyRegistrations: false,
-    };
-  }
-  if (
-    params.scopedSetupOnlyChannelPluginRequested &&
-    params.requireSetupEntryForSetupOnlyChannelPlugins
-  ) {
-    return null;
-  }
-  if (!params.enableStateEnabled) {
-    return null;
-  }
-  if (params.toolDiscovery) {
-    return {
-      mode: "tool-discovery",
-      loadSetupEntry: false,
-      loadSetupRuntimeEntry: false,
-      runRuntimeCapabilityPolicy: true,
-      runFullActivationOnlyRegistrations: false,
-    };
-  }
-  const loadSetupRuntimeEntry =
-    !params.forceFullRuntimeForChannelPlugins &&
-    params.shouldLoadModules &&
-    !params.validateOnly &&
-    shouldLoadChannelPluginInSetupRuntime({
-      manifestChannels: params.manifestRecord.channels,
-      setupSource: params.manifestRecord.setupSource,
-      startupDeferConfiguredChannelFullLoadUntilAfterListen:
-        params.manifestRecord.startupDeferConfiguredChannelFullLoadUntilAfterListen,
-      cfg: params.cfg,
-      env: params.env,
-      preferSetupRuntimeForChannelPlugins: params.preferSetupRuntimeForChannelPlugins,
-    });
-  if (loadSetupRuntimeEntry) {
-    return {
-      mode: "setup-runtime",
-      loadSetupEntry: true,
-      loadSetupRuntimeEntry: true,
-      runRuntimeCapabilityPolicy: false,
-      runFullActivationOnlyRegistrations: false,
-    };
-  }
-  const mode = params.shouldActivate ? "full" : "discovery";
-  return {
-    mode,
-    loadSetupEntry: false,
-    loadSetupRuntimeEntry: false,
-    runRuntimeCapabilityPolicy: true,
-    runFullActivationOnlyRegistrations: mode === "full",
-  };
-}
-
-function applyManifestSnapshotMetadata(
-  record: PluginRecord,
-  manifestRecord: PluginManifestRecord,
+  cacheKey: string,
+  runtimeSubagentMode: RuntimeSubagentMode,
+  workspaceDir?: string,
 ): void {
-  record.channelIds = [...(manifestRecord.channels ?? [])];
-  record.providerIds = [...(manifestRecord.providers ?? [])];
-  record.cliBackendIds = [
-    ...(manifestRecord.cliBackends ?? []),
-    ...(manifestRecord.setup?.cliBackends ?? []),
-  ];
-  record.commands = (manifestRecord.commandAliases ?? []).map((alias) => alias.name);
-}
-
-function resolvePluginLoadCacheContext(options: PluginLoadOptions = {}) {
-  const shouldResolveRawConfigEnvVars = options.resolveRawConfigEnvVars === true;
-  const baseEnv = options.env ?? process.env;
-  const rawConfig = options.config ?? {};
-  const rawActivationSourceConfig = resolvePluginActivationSourceConfig({
-    config: options.config,
-    activationSourceConfig: options.activationSourceConfig,
-  });
-  const env = shouldResolveRawConfigEnvVars ? createConfigRuntimeEnv(rawConfig, baseEnv) : baseEnv;
-  const cfg = applyTestPluginDefaults(
-    shouldResolveRawConfigEnvVars
-      ? (resolveConfigEnvVars(rawConfig, env, {
-          onMissing: () => undefined,
-        }) as OpenClawConfig)
-      : rawConfig,
-    env,
-  );
-  const activationSourceConfig = shouldResolveRawConfigEnvVars
-    ? (resolveConfigEnvVars(rawActivationSourceConfig, env, {
-        onMissing: () => undefined,
-      }) as OpenClawConfig)
-    : rawActivationSourceConfig;
-  const normalized = normalizePluginsConfig(cfg.plugins);
-  const activationSource = createPluginActivationSource({
-    config: activationSourceConfig,
-  });
-  const trustNormalized = mergeTrustPluginConfigFromActivationSource({
-    normalized,
-    activationSource,
-  });
-  const onlyPluginIds = normalizePluginIdScope(options.onlyPluginIds);
-  const includeSetupOnlyChannelPlugins = options.includeSetupOnlyChannelPlugins === true;
-  const forceSetupOnlyChannelPlugins = options.forceSetupOnlyChannelPlugins === true;
-  const requireSetupEntryForSetupOnlyChannelPlugins =
-    options.requireSetupEntryForSetupOnlyChannelPlugins === true;
-  const preferSetupRuntimeForChannelPlugins = options.preferSetupRuntimeForChannelPlugins === true;
-  const forceFullRuntimeForChannelPlugins = options.forceFullRuntimeForChannelPlugins === true;
-  const preferBuiltPluginArtifacts = options.preferBuiltPluginArtifacts === true;
-  const runtimeSubagentMode = resolveRuntimeSubagentMode(options.runtimeOptions);
-  const coreGatewayMethodNames = resolveCoreGatewayMethodNames(options);
-  const installRecords = {
-    ...(options.installRecords ?? loadInstalledPluginIndexInstallRecordsSync({ env })),
-    ...cfg.plugins?.installs,
-  };
-  const devSourceRoot = resolveOpenClawDevSourceRoot(env);
-  const cacheKey = buildCacheKey({
-    workspaceDir: options.workspaceDir,
-    plugins: shouldResolveRawConfigEnvVars
-      ? redactPluginConfigForCacheKey(trustNormalized)
-      : trustNormalized,
-    activationMetadataKey: buildActivationMetadataHash({
-      activationSource,
-      autoEnabledReasons: options.autoEnabledReasons ?? {},
-    }),
-    installs: installRecords,
-    env,
-    devSourceRoot,
-    onlyPluginIds,
-    includeSetupOnlyChannelPlugins,
-    forceSetupOnlyChannelPlugins,
-    requireSetupEntryForSetupOnlyChannelPlugins,
-    preferSetupRuntimeForChannelPlugins,
-    forceFullRuntimeForChannelPlugins,
-    preferBuiltPluginArtifacts,
-    resolveRawConfigEnvVars: options.resolveRawConfigEnvVars,
-    toolDiscovery: options.toolDiscovery,
-    loadModules: options.loadModules,
-    runtimeSubagentMode,
-    pluginSdkResolution: options.pluginSdkResolution,
-    ...(coreGatewayMethodNames !== undefined && { coreGatewayMethodNames }),
-    activate: options.activate,
-  });
-  return {
-    env,
-    cfg,
-    normalized: trustNormalized,
-    activationSourceConfig,
-    activationSource,
-    autoEnabledReasons: options.autoEnabledReasons ?? {},
-    onlyPluginIds,
-    includeSetupOnlyChannelPlugins,
-    forceSetupOnlyChannelPlugins,
-    requireSetupEntryForSetupOnlyChannelPlugins,
-    preferSetupRuntimeForChannelPlugins,
-    forceFullRuntimeForChannelPlugins,
-    preferBuiltPluginArtifacts,
-    shouldActivate: options.activate !== false,
-    shouldLoadModules: options.loadModules !== false,
-    runtimeSubagentMode,
-    installRecords,
-    devSourceRoot,
-    cacheKey,
-  };
-}
-
-function mergeTrustPluginConfigFromActivationSource(params: {
-  normalized: NormalizedPluginsConfig;
-  activationSource: PluginActivationConfigSource;
-}): NormalizedPluginsConfig {
-  const source = params.activationSource.plugins;
-  const allow = mergePluginTrustList(params.normalized.allow, source.allow);
-  const deny = mergePluginTrustList(params.normalized.deny, source.deny);
-  const loadPaths = mergePluginTrustList(params.normalized.loadPaths, source.loadPaths);
-  if (
-    allow === params.normalized.allow &&
-    deny === params.normalized.deny &&
-    loadPaths === params.normalized.loadPaths
-  ) {
-    return params.normalized;
-  }
-  return {
-    ...params.normalized,
-    allow,
-    deny,
-    loadPaths,
-  };
-}
-
-function mergePluginTrustList(runtimeList: string[], sourceList: readonly string[]): string[] {
-  if (sourceList.length === 0) {
-    return runtimeList;
-  }
-  const merged = [...runtimeList];
-  const seen = new Set(merged);
-  for (const entry of sourceList) {
-    if (!seen.has(entry)) {
-      merged.push(entry);
-      seen.add(entry);
-    }
-  }
-  return merged.length === runtimeList.length ? runtimeList : merged;
+  // The runner resolves hooks from active and pinned registries. Reinitialize on
+  // every activation so scope and activation order cannot drop registered hooks.
+  setActivePluginRegistry(registry, cacheKey, runtimeSubagentMode, workspaceDir);
+  initializeGlobalHookRunner(registry);
 }
 
 function getCompatibleActivePluginRegistry(
@@ -1143,56 +114,28 @@ function getCompatibleActivePluginRegistry(
       return false;
     }
     return pluginLoadOptionsMatchCacheKey(
-      {
-        ...candidate,
-        coreGatewayMethodNames: activeRegistry.coreGatewayMethodNames,
-      },
+      { ...candidate, coreGatewayMethodNames: activeRegistry.coreGatewayMethodNames },
       activeCacheKey,
     );
   };
-  const matchesCompatibleActiveRegistry = (candidate: PluginLoadOptions): boolean => {
-    if (matchesActiveCacheKey(candidate)) {
-      return true;
-    }
-    if (
-      scopedPluginLoadOptionsMatchWiderActiveCacheKey(candidate, activeCacheKey, activeRegistry)
-    ) {
-      return true;
-    }
-    return pluginToolDiscoveryOptionsMatchActiveCacheKey(candidate, activeCacheKey);
-  };
+  const matchesCompatibleActiveRegistry = (candidate: PluginLoadOptions): boolean =>
+    matchesActiveCacheKey(candidate) ||
+    scopedPluginLoadOptionsMatchWiderActiveCacheKey(candidate, activeCacheKey, activeRegistry) ||
+    pluginToolDiscoveryOptionsMatchActiveCacheKey(candidate, activeCacheKey);
+  const matchesActivationVariants = (candidate: PluginLoadOptions): boolean =>
+    matchesCompatibleActiveRegistry(candidate) ||
+    (!loadContext.shouldActivate &&
+      matchesCompatibleActiveRegistry({ ...candidate, activate: true }));
 
-  if (matchesCompatibleActiveRegistry(options)) {
+  if (matchesActivationVariants(options)) {
     return activeRegistry;
   }
-  if (!loadContext.shouldActivate) {
-    const activatingOptions = {
-      ...options,
-      activate: true,
-    };
-    if (matchesCompatibleActiveRegistry(activatingOptions)) {
-      return activeRegistry;
-    }
-  }
   const activeRuntimeSubagentMode = getActivePluginRuntimeSubagentMode();
-  if (activeRuntimeSubagentMode === "gateway-bindable") {
-    const gatewayStartupOptions: PluginLoadOptions = {
-      ...options,
-      preferBuiltPluginArtifacts: true,
-    };
-    if (matchesCompatibleActiveRegistry(gatewayStartupOptions)) {
-      return activeRegistry;
-    }
-    if (!loadContext.shouldActivate) {
-      const activatingGatewayStartupOptions: PluginLoadOptions = {
-        ...options,
-        activate: true,
-        preferBuiltPluginArtifacts: true,
-      };
-      if (matchesCompatibleActiveRegistry(activatingGatewayStartupOptions)) {
-        return activeRegistry;
-      }
-    }
+  if (
+    activeRuntimeSubagentMode === "gateway-bindable" &&
+    matchesActivationVariants({ ...options, preferBuiltPluginArtifacts: true })
+  ) {
+    return activeRegistry;
   }
   if (
     loadContext.runtimeSubagentMode === "default" &&
@@ -1205,34 +148,12 @@ function getCompatibleActivePluginRegistry(
         allowGatewaySubagentBinding: true,
       },
     };
-    const gatewayStartupOptions: PluginLoadOptions = {
-      ...gatewayBindableOptions,
-      preferBuiltPluginArtifacts: true,
-    };
-    if (!loadContext.shouldActivate) {
-      const activatingGatewayBindableOptions: PluginLoadOptions = {
-        ...options,
-        activate: true,
-        runtimeOptions: {
-          ...options.runtimeOptions,
-          allowGatewaySubagentBinding: true,
-        },
-      };
-      const activatingGatewayStartupOptions: PluginLoadOptions = {
-        ...activatingGatewayBindableOptions,
+    if (
+      matchesActivationVariants(gatewayBindableOptions) ||
+      matchesActivationVariants({
+        ...gatewayBindableOptions,
         preferBuiltPluginArtifacts: true,
-      };
-      if (
-        matchesCompatibleActiveRegistry(gatewayBindableOptions) ||
-        matchesCompatibleActiveRegistry(gatewayStartupOptions) ||
-        matchesCompatibleActiveRegistry(activatingGatewayBindableOptions) ||
-        matchesCompatibleActiveRegistry(activatingGatewayStartupOptions)
-      ) {
-        return activeRegistry;
-      }
-    } else if (
-      matchesCompatibleActiveRegistry(gatewayBindableOptions) ||
-      matchesCompatibleActiveRegistry(gatewayStartupOptions)
+      })
     ) {
       return activeRegistry;
     }
@@ -1250,9 +171,8 @@ export function resolveRuntimePluginRegistry(
   if (compatible) {
     return compatible;
   }
-  // Helper/runtime callers should not recurse into the same snapshot load while
-  // plugin registration is still in flight. Let direct loadOpenClawPlugins(...)
-  // callers surface the hard error instead.
+  // Helper/runtime callers must not recurse into the same snapshot load while
+  // plugin registration is in flight. Direct loads still surface the hard error.
   if (isPluginRegistryLoadInFlight(options)) {
     return undefined;
   }
@@ -1265,193 +185,10 @@ export function getRuntimePluginRegistryForLoadOptions(
   return resolveRuntimePluginRegistry(options);
 }
 
-export function resolvePluginRegistryLoadCacheKey(options: PluginLoadOptions = {}): string {
-  return resolvePluginLoadCacheContext(options).cacheKey;
-}
-
-export function isPluginRegistryLoadInFlight(options: PluginLoadOptions = {}): boolean {
-  return pluginLoaderCacheState.isLoadInFlight(resolvePluginRegistryLoadCacheKey(options));
-}
-
 export function resolveCompatibleRuntimePluginRegistry(
   options?: PluginLoadOptions,
 ): PluginRegistry | undefined {
-  // Check whether the active runtime registry is already compatible with these
-  // load options. Unlike resolveRuntimePluginRegistry, this never triggers a
-  // fresh plugin load on cache miss.
   return getCompatibleActivePluginRegistry(options);
-}
-
-function validatePluginConfig(params: {
-  schema?: Record<string, unknown>;
-  cacheKey?: string;
-  value?: unknown;
-}): Result<Record<string, unknown> | undefined, string[]> {
-  const { schema, value } = params;
-  if (!schema) {
-    return ok(value as Record<string, unknown> | undefined);
-  }
-  if (isEmptyPluginConfigJsonSchema(schema)) {
-    if (
-      value === undefined ||
-      (value &&
-        typeof value === "object" &&
-        !Array.isArray(value) &&
-        Object.keys(value).length === 0)
-    ) {
-      return ok({});
-    }
-    if (!value || typeof value !== "object" || Array.isArray(value)) {
-      return resultError(["<root>: must be object"]);
-    }
-    return resultError(["<root>: config must be empty"]);
-  }
-  const cacheKey = params.cacheKey ?? JSON.stringify(schema);
-  const result = validateJsonSchemaValue({
-    schema,
-    cacheKey,
-    value: value ?? {},
-    applyDefaults: true,
-  });
-  if (result.ok) {
-    return ok(result.value as Record<string, unknown> | undefined);
-  }
-  return resultError(result.errors.map((error) => error.text));
-}
-
-function isEmptyPluginConfigJsonSchema(schema: Record<string, unknown>): boolean {
-  if (schema.type !== "object" || schema.additionalProperties !== false) {
-    return false;
-  }
-  const properties = schema.properties;
-  if (
-    !properties ||
-    typeof properties !== "object" ||
-    Array.isArray(properties) ||
-    Object.keys(properties).length > 0
-  ) {
-    return false;
-  }
-  return !(
-    "required" in schema ||
-    "dependentRequired" in schema ||
-    "dependencies" in schema ||
-    "minProperties" in schema ||
-    "allOf" in schema ||
-    "anyOf" in schema ||
-    "oneOf" in schema ||
-    "not" in schema
-  );
-}
-
-function resolvePluginModuleExport(moduleExport: unknown): {
-  definition?: OpenClawPluginDefinition;
-  register?: OpenClawPluginDefinition["register"];
-} {
-  const seen = new Set<unknown>();
-  const candidates: unknown[] = [unwrapDefaultModuleExport(moduleExport), moduleExport];
-  for (let index = 0; index < candidates.length && index < 12; index += 1) {
-    const resolved = candidates[index];
-    if (seen.has(resolved)) {
-      continue;
-    }
-    seen.add(resolved);
-    if (typeof resolved === "function") {
-      return {
-        register: resolved as OpenClawPluginDefinition["register"],
-      };
-    }
-    if (resolved && typeof resolved === "object") {
-      const def = resolved as OpenClawPluginDefinition;
-      const register = def.register ?? def.activate;
-      if (typeof register === "function") {
-        return { definition: def, register };
-      }
-      for (const key of ["default", "module"]) {
-        if (key in def) {
-          candidates.push((def as Record<string, unknown>)[key]);
-        }
-      }
-    }
-  }
-  const resolved = candidates[0];
-  if (typeof resolved === "function") {
-    return {
-      register: resolved as OpenClawPluginDefinition["register"],
-    };
-  }
-  if (resolved && typeof resolved === "object") {
-    const def = resolved as OpenClawPluginDefinition;
-    const register = def.register ?? def.activate;
-    return { definition: def, register };
-  }
-  return {};
-}
-
-function kindIncludes(kind: unknown, target: string): boolean {
-  return kind === target || (Array.isArray(kind) && kind.includes(target));
-}
-
-function formatBundledChannelWrongLoaderError(kind: unknown): string | null {
-  if (kindIncludes(kind, "bundled-channel-setup-entry")) {
-    return "bundled channel setup entry requires setup-runtime loader";
-  }
-  if (kindIncludes(kind, "bundled-channel-entry")) {
-    return "bundled channel entry requires setup-runtime loader";
-  }
-  return null;
-}
-
-function pushDiagnostics(diagnostics: PluginDiagnostic[], append: PluginDiagnostic[]) {
-  diagnostics.push(...append);
-}
-
-function pushPluginValidationError(params: {
-  registry: PluginRegistry;
-  seenIds: Map<string, PluginRecord["origin"]>;
-  pluginId: string;
-  origin: PluginRecord["origin"];
-  record: PluginRecord;
-  message: string;
-}) {
-  params.record.status = "error";
-  params.record.error = params.message;
-  params.record.failedAt = new Date();
-  params.record.failurePhase = "validation";
-  params.registry.plugins.push(params.record);
-  params.seenIds.set(params.pluginId, params.origin);
-  params.registry.diagnostics.push({
-    level: "error",
-    pluginId: params.record.id,
-    source: params.record.source,
-    message: params.record.error,
-  });
-}
-
-function maybeThrowOnPluginLoadError(
-  registry: PluginRegistry,
-  throwOnLoadError: boolean | undefined,
-): void {
-  if (!throwOnLoadError) {
-    return;
-  }
-  if (!registry.plugins.some((entry) => entry.status === "error")) {
-    return;
-  }
-  throw new PluginLoadFailureError(registry);
-}
-
-function activatePluginRegistry(
-  registry: PluginRegistry,
-  cacheKey: string,
-  runtimeSubagentMode: "default" | "explicit" | "gateway-bindable",
-  workspaceDir?: string,
-): void {
-  // Always re-initialize: the global runner resolves hooks from the live
-  // registry set (active + pinned surfaces), so activation order and scope
-  // cannot drop hooks the way the old preserve-one-runner gate did (#91918).
-  setActivePluginRegistry(registry, cacheKey, runtimeSubagentMode, workspaceDir);
-  initializeGlobalHookRunner(registry);
 }
 
 export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegistry {
@@ -1461,16 +198,18 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
     const emptyRegistry = createEmptyPluginRegistry();
     if (options.activate !== false) {
       clearActivatedPluginRuntimeState();
+      const runtimeSubagentMode = resolveRuntimeSubagentMode(options.runtimeOptions);
       activatePluginRegistry(
         emptyRegistry,
-        `empty-plugin-scope::${resolveRuntimeSubagentMode(options.runtimeOptions)}::${options.workspaceDir ?? ""}`,
-        resolveRuntimeSubagentMode(options.runtimeOptions),
+        `empty-plugin-scope::${runtimeSubagentMode}::${options.workspaceDir ?? ""}`,
+        runtimeSubagentMode,
         options.workspaceDir,
       );
     }
     return emptyRegistry;
   }
 
+  const loadContext = resolvePluginLoadCacheContext(options);
   const {
     env,
     cfg,
@@ -1490,11 +229,10 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
     runtimeSubagentMode,
     installRecords,
     devSourceRoot,
-  } = resolvePluginLoadCacheContext(options);
-  const logger = options.logger ?? defaultLogger();
+  } = loadContext;
+  const logger = options.logger ?? defaultPluginLogger();
   const validateOnly = options.mode === "validate";
   const onlyPluginIdSet = createPluginIdScopeSet(onlyPluginIds);
-
   const cacheEnabled = options.cache !== false && options.resolveRawConfigEnvVars !== true;
   if (cacheEnabled) {
     const cached = getReusableCachedPluginRegistry({
@@ -1516,127 +254,33 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
       return cached.state.registry;
     }
   }
+
   pluginLoaderCacheState.beginLoad(cacheKey);
   try {
-    // Clear previously registered plugin state before reloading.
-    // Skip for non-activating (snapshot) loads to avoid wiping commands from other plugins.
     if (shouldActivate) {
       clearActivatedPluginRuntimeState();
     }
-
-    // Lazy: avoid creating module loaders when all plugins are disabled (common in unit tests).
     const loadPluginModule = createPluginModuleLoader({
       devSourceRoot,
       pluginSdkResolution: options.pluginSdkResolution,
     });
-
-    let createPluginRuntimeFactory:
-      | ((options?: CreatePluginRuntimeOptions) => PluginRuntime)
-      | null = null;
-    const resolveCreatePluginRuntime = (): ((
-      options?: CreatePluginRuntimeOptions,
-    ) => PluginRuntime) => {
-      if (createPluginRuntimeFactory) {
-        return createPluginRuntimeFactory;
-      }
-      const runtimeModuleResolution = resolvePluginRuntimeModulePathWithDiagnostics({
-        devSourceRoot,
-        pluginSdkResolution: options.pluginSdkResolution,
-      });
-      const runtimeModulePath = runtimeModuleResolution.resolvedPath;
-      if (!runtimeModulePath) {
-        throw new Error(
-          formatPluginRuntimeModuleResolutionError({
-            resolution: runtimeModuleResolution,
-            pluginSdkResolution: options.pluginSdkResolution,
-          }),
-        );
-      }
-      const runtimeModule = withProfile(
-        { source: runtimeModulePath },
-        "runtime-module",
-        () =>
-          loadPluginModule(runtimeModulePath) as {
-            createPluginRuntime?: (options?: CreatePluginRuntimeOptions) => PluginRuntime;
-          },
-      );
-      if (typeof runtimeModule.createPluginRuntime !== "function") {
-        throw new Error("Plugin runtime module missing createPluginRuntime export");
-      }
-      createPluginRuntimeFactory = runtimeModule.createPluginRuntime;
-      return createPluginRuntimeFactory;
-    };
-
-    // Lazily initialize the runtime so startup paths that discover/skip plugins do
-    // not eagerly load every channel/runtime dependency tree.
-    let resolvedRuntime: PluginRuntime | null = null;
-    const resolveRuntime = (): PluginRuntime => {
-      resolvedRuntime ??= resolveCreatePluginRuntime()(options.runtimeOptions);
-      return resolvedRuntime;
-    };
-    const lazyRuntimeReflectionKeySet = new Set<PropertyKey>(LAZY_RUNTIME_REFLECTION_KEYS);
-    const resolveLazyRuntimeDescriptor = (prop: PropertyKey): PropertyDescriptor | undefined => {
-      if (!lazyRuntimeReflectionKeySet.has(prop)) {
-        return Reflect.getOwnPropertyDescriptor(resolveRuntime() as object, prop);
-      }
-      return {
-        configurable: true,
-        enumerable: true,
-        get() {
-          return Reflect.get(resolveRuntime() as object, prop);
-        },
-        set(value: unknown) {
-          Reflect.set(resolveRuntime() as object, prop, value);
-        },
-      };
-    };
-    const runtime = new Proxy({} as PluginRuntime, {
-      get(_target, prop, receiver) {
-        return Reflect.get(resolveRuntime(), prop, receiver);
-      },
-      set(_target, prop, value, receiver) {
-        return Reflect.set(resolveRuntime(), prop, value, receiver);
-      },
-      has(_target, prop) {
-        return lazyRuntimeReflectionKeySet.has(prop) || Reflect.has(resolveRuntime(), prop);
-      },
-      ownKeys() {
-        return [...LAZY_RUNTIME_REFLECTION_KEYS];
-      },
-      getOwnPropertyDescriptor(_target, prop) {
-        return resolveLazyRuntimeDescriptor(prop);
-      },
-      defineProperty(_target, prop, attributes) {
-        return Reflect.defineProperty(resolveRuntime() as object, prop, attributes);
-      },
-      deleteProperty(_target, prop) {
-        return Reflect.deleteProperty(resolveRuntime() as object, prop);
-      },
-      getPrototypeOf() {
-        return Reflect.getPrototypeOf(resolveRuntime() as object);
-      },
+    const runtime = createLazyPluginRuntime({
+      loadPluginModule,
+      devSourceRoot,
+      pluginSdkResolution: options.pluginSdkResolution,
+      runtimeOptions: options.runtimeOptions,
     });
-
-    const {
-      registry,
-      createApi,
-      rollbackPluginGlobalSideEffects,
-      registerReload,
-      registerNodeHostCommand,
-      registerSecurityAuditCollector,
-    } = createPluginRegistry({
+    const registryBuilder = createPluginRegistry({
       logger,
       runtime,
       coreGatewayHandlers: options.coreGatewayHandlers as Record<string, GatewayRequestHandler>,
       ...(options.coreGatewayMethodNames !== undefined && {
         coreGatewayMethodNames: options.coreGatewayMethodNames,
       }),
-      ...(options.hostServices !== undefined && {
-        hostServices: options.hostServices,
-      }),
+      ...(options.hostServices !== undefined && { hostServices: options.hostServices }),
       activateGlobalSideEffects: shouldActivate,
     });
-
+    const { registry } = registryBuilder;
     const suppliedManifestRegistry = options.manifestRegistry;
     const discovery = suppliedManifestRegistry
       ? {
@@ -1673,39 +317,24 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
           .filter(([, entry]) => entry.enabled === true)
           .map(([pluginId]) => pluginId),
       ),
-      // Keep warning input scoped as well so partial snapshot loads only mention the
-      // plugins that were intentionally requested for this registry.
       discoverablePlugins: manifestRegistry.plugins
         .filter((plugin) => !onlyPluginIdSet || onlyPluginIdSet.has(plugin.id))
-        .map((plugin) => ({
-          id: plugin.id,
-          source: plugin.source,
-          origin: plugin.origin,
-        })),
+        .map((plugin) => ({ id: plugin.id, source: plugin.source, origin: plugin.origin })),
     });
-    const provenance = buildProvenanceIndex({
+    const { manifestByRoot, orderedCandidates, provenance } = preparePluginCandidates({
+      discovery,
+      manifestRegistry,
       normalizedLoadPaths: normalized.loadPaths,
       env,
       installRecords,
     });
-
-    const manifestByRoot = new Map(
-      manifestRegistry.plugins.map((record) => [record.rootDir, record]),
-    );
-    const orderedCandidates = [...discovery.candidates].toSorted((left, right) => {
-      return compareDuplicateCandidateOrder({
-        left,
-        right,
-        manifestByRoot,
-        provenance,
-        env,
-      });
-    });
-
-    const seenIds = new Map<string, PluginRecord["origin"]>();
     const memorySlot = normalized.slots.memory;
-    let selectedMemoryPluginId: string | null = null;
-    let memorySlotMatched = false;
+    const state: RuntimePluginLoadState = {
+      seenIds: new Map(),
+      selectedMemoryPluginId: null,
+      memorySlotMatched: false,
+      pluginLoadAttemptCount: 0,
+    };
     const dreamingSidecar = resolveAuthorizedDreamingSidecar({
       cfg,
       normalized,
@@ -1713,822 +342,53 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
       manifestRegistry,
       memorySlot,
     });
+    const candidateContext: RuntimePluginLoadContext = {
+      options,
+      env,
+      cfg,
+      normalized,
+      activationSource,
+      autoEnabledReasons,
+      onlyPluginIdSet,
+      includeSetupOnlyChannelPlugins,
+      forceSetupOnlyChannelPlugins,
+      requireSetupEntryForSetupOnlyChannelPlugins,
+      preferSetupRuntimeForChannelPlugins,
+      forceFullRuntimeForChannelPlugins,
+      preferBuiltPluginArtifacts,
+      shouldActivate,
+      shouldLoadModules,
+      validateOnly,
+      memorySlot,
+      dreamingSidecar,
+      registry,
+      createApi: registryBuilder.createApi,
+      rollbackPluginGlobalSideEffects: registryBuilder.rollbackPluginGlobalSideEffects,
+      registerReload: registryBuilder.registerReload,
+      registerNodeHostCommand: registryBuilder.registerNodeHostCommand,
+      registerSecurityAuditCollector: registryBuilder.registerSecurityAuditCollector,
+      loadPluginModule,
+      logger,
+    };
     const pluginLoadStartMs = performance.now();
-    let pluginLoadAttemptCount = 0;
-
     for (const candidate of orderedCandidates) {
       const manifestRecord = manifestByRoot.get(candidate.rootDir);
-      if (!manifestRecord) {
-        continue;
-      }
-      const pluginId = manifestRecord.id;
-      const matchesRequestedScope = matchesScopedPluginOrDreamingSidecar({
-        onlyPluginIdSet,
-        pluginId,
-        sidecar: dreamingSidecar,
-      });
-      // Filter again at import time as a final guard. The earlier manifest filter keeps
-      // warnings scoped; this one prevents loading/registering anything outside the scope.
-      if (!matchesRequestedScope) {
-        continue;
-      }
-      const isDreamingSidecar = isAuthorizedDreamingSidecarPlugin({
-        sidecar: dreamingSidecar,
-        pluginId,
-      });
-      const activationState = isDreamingSidecar
-        ? {
-            enabled: true,
-            activated: true,
-            explicitlyEnabled: false,
-            source: "auto" as const,
-            reason: `dreaming sidecar for selected memory slot "${dreamingSidecar?.selectedMemoryPluginId ?? ""}"`,
-          }
-        : resolveEffectivePluginActivationState({
-            id: pluginId,
-            origin: candidate.origin,
-            config: normalized,
-            rootConfig: cfg,
-            enabledByDefault: isPluginEnabledByDefaultForPlatform(manifestRecord),
-            activationSource,
-            autoEnabledReason: formatAutoEnabledActivationReason(autoEnabledReasons[pluginId]),
-          });
-      const existingOrigin = seenIds.get(pluginId);
-      if (existingOrigin) {
-        const record = createPluginRecord({
-          id: pluginId,
-          name: manifestRecord.name ?? pluginId,
-          description: manifestRecord.description,
-          version: manifestRecord.version,
-          packageName: manifestRecord.packageName,
-          format: manifestRecord.format,
-          bundleFormat: manifestRecord.bundleFormat,
-          bundleCapabilities: manifestRecord.bundleCapabilities,
-          source: candidate.source,
-          rootDir: candidate.rootDir,
-          origin: candidate.origin,
-          workspaceDir: candidate.workspaceDir,
-          trustedOfficialInstall: manifestRecord.trustedOfficialInstall,
-          enabled: false,
-          compat: collectPluginManifestCompatCodes(manifestRecord),
-          activationState,
-          syntheticAuthRefs: manifestRecord.syntheticAuthRefs,
-          channelIds: manifestRecord.channels,
-          providerIds: manifestRecord.providers,
-          configSchema: Boolean(manifestRecord.configSchema),
-          contracts: manifestRecord.contracts,
-        });
-        record.status = "disabled";
-        record.error = `overridden by ${existingOrigin} plugin`;
-        markPluginActivationDisabled(record, record.error);
-        registry.plugins.push(record);
-        continue;
-      }
-
-      const enableState = isDreamingSidecar
-        ? { enabled: true }
-        : resolveEffectiveEnableState({
-            id: pluginId,
-            origin: candidate.origin,
-            config: normalized,
-            rootConfig: cfg,
-            enabledByDefault: isPluginEnabledByDefaultForPlatform(manifestRecord),
-            activationSource,
-          });
-      const entry = normalized.entries[pluginId];
-      const record = createPluginRecord({
-        id: pluginId,
-        name: manifestRecord.name ?? pluginId,
-        description: manifestRecord.description,
-        version: manifestRecord.version,
-        packageName: manifestRecord.packageName,
-        format: manifestRecord.format,
-        bundleFormat: manifestRecord.bundleFormat,
-        bundleCapabilities: manifestRecord.bundleCapabilities,
-        source: candidate.source,
-        rootDir: candidate.rootDir,
-        origin: candidate.origin,
-        workspaceDir: candidate.workspaceDir,
-        trustedOfficialInstall: manifestRecord.trustedOfficialInstall,
-        enabled: enableState.enabled,
-        compat: collectPluginManifestCompatCodes(manifestRecord),
-        activationState,
-        syntheticAuthRefs: manifestRecord.syntheticAuthRefs,
-        channelIds: manifestRecord.channels,
-        providerIds: manifestRecord.providers,
-        configSchema: Boolean(manifestRecord.configSchema),
-        contracts: manifestRecord.contracts,
-      });
-      record.kind = manifestRecord.kind;
-      record.configUiHints = manifestRecord.configUiHints;
-      record.configJsonSchema = manifestRecord.configSchema;
-      const localSetupBasePolicyBlock = resolveManifestOwnerBasePolicyBlock({
-        plugin: { id: pluginId },
-        normalizedConfig: normalized,
-      });
-      const trustedLocalScopedChannelSetupImport =
-        localSetupBasePolicyBlock === null &&
-        (hasExplicitManifestOwnerTrust({
-          plugin: { id: pluginId },
-          normalizedConfig: normalized,
-        }) ||
-          (candidate.origin === "workspace" && activationState.source === "auto"));
-      // Scoped setup-only loads intentionally bypass normal activation so setup
-      // can reach explicitly trusted local plugins. Reapply the non-bundled
-      // trust boundary here so default-only workspace/config/global plugins never import.
-      const blockUntrustedLocalScopedChannelSetupImport =
-        includeSetupOnlyChannelPlugins &&
-        !validateOnly &&
-        Boolean(onlyPluginIdSet) &&
-        manifestRecord.channels.length > 0 &&
-        candidate.origin !== "bundled" &&
-        !trustedLocalScopedChannelSetupImport;
-      const pushPluginLoadError = (message: string) =>
-        pushPluginValidationError({
-          registry,
-          seenIds,
-          pluginId,
-          origin: candidate.origin,
-          record,
-          message,
-        });
-      if (blockUntrustedLocalScopedChannelSetupImport) {
-        record.status = "disabled";
-        record.error =
-          activationState.reason ??
-          enableState.reason ??
-          "local plugin requires explicit trust for setup";
-        markPluginActivationDisabled(record, record.error);
-        // Manifest-registry duplicate resolution already canonicalizes same-id
-        // plugin shadows before this load loop. Do not claim `seenIds` here:
-        // different-id trusted fallbacks still need a chance to load later.
-        registry.plugins.push(record);
-        continue;
-      }
-      const pluginRoot = safeRealpathOrResolve(candidate.rootDir);
-      const runtimeCandidateEntry = resolvePluginRuntimeArtifact({
-        source: candidate.source,
-        rootDir: pluginRoot,
-        origin: candidate.origin,
-        preferBuiltPluginArtifacts,
-        packageManifest: candidate.packageManifest,
-      });
-      const runtimeSetupEntry = manifestRecord.setupSource
-        ? resolvePluginRuntimeArtifact({
-            source: manifestRecord.setupSource,
-            rootDir: pluginRoot,
-            origin: candidate.origin,
-            preferBuiltPluginArtifacts,
-            packageManifest: candidate.packageManifest,
-          })
-        : undefined;
-
-      const scopedSetupOnlyChannelPluginRequested =
-        includeSetupOnlyChannelPlugins &&
-        !validateOnly &&
-        Boolean(onlyPluginIdSet) &&
-        manifestRecord.channels.length > 0 &&
-        (!enableState.enabled || forceSetupOnlyChannelPlugins);
-      const canLoadScopedSetupOnlyChannelPlugin =
-        scopedSetupOnlyChannelPluginRequested &&
-        (candidate.origin !== "workspace" || enableState.enabled) &&
-        (!requireSetupEntryForSetupOnlyChannelPlugins || Boolean(manifestRecord.setupSource));
-      const registrationPlan = resolvePluginRegistrationPlan({
-        canLoadScopedSetupOnlyChannelPlugin,
-        scopedSetupOnlyChannelPluginRequested,
-        requireSetupEntryForSetupOnlyChannelPlugins,
-        enableStateEnabled: enableState.enabled,
-        shouldLoadModules,
-        validateOnly,
-        shouldActivate,
-        manifestRecord,
-        cfg,
-        env,
-        preferSetupRuntimeForChannelPlugins: forceFullRuntimeForChannelPlugins
-          ? false
-          : preferSetupRuntimeForChannelPlugins,
-        forceFullRuntimeForChannelPlugins,
-        toolDiscovery: options.toolDiscovery === true,
-      });
-
-      if (!registrationPlan) {
-        record.status = "disabled";
-        record.error = enableState.reason;
-        markPluginActivationDisabled(record, enableState.reason);
-        registry.plugins.push(record);
-        seenIds.set(pluginId, candidate.origin);
-        continue;
-      }
-      const registrationMode = registrationPlan.mode;
-      if (!enableState.enabled) {
-        record.status = "disabled";
-        record.error = enableState.reason;
-        markPluginActivationDisabled(record, enableState.reason);
-      }
-
-      if (record.format === "bundle") {
-        const unsupportedCapabilities = (record.bundleCapabilities ?? []).filter(
-          (capability) =>
-            capability !== "skills" &&
-            capability !== "mcpServers" &&
-            capability !== "settings" &&
-            !(
-              (capability === "commands" ||
-                capability === "agents" ||
-                capability === "outputStyles" ||
-                capability === "lspServers") &&
-              (record.bundleFormat === "claude" || record.bundleFormat === "cursor")
-            ) &&
-            !(
-              capability === "hooks" &&
-              (record.bundleFormat === "codex" || record.bundleFormat === "claude")
-            ),
-        );
-        for (const capability of unsupportedCapabilities) {
-          registry.diagnostics.push({
-            level: "warn",
-            pluginId: record.id,
-            source: record.source,
-            message: `bundle capability detected but not wired into OpenClaw yet: ${capability}`,
-          });
-        }
-        if (
-          enableState.enabled &&
-          record.rootDir &&
-          record.bundleFormat &&
-          (record.bundleCapabilities ?? []).includes("mcpServers")
-        ) {
-          const runtimeSupport = inspectBundleMcpRuntimeSupport({
-            pluginId: record.id,
-            rootDir: record.rootDir,
-            bundleFormat: record.bundleFormat,
-          });
-          for (const message of runtimeSupport.diagnostics) {
-            registry.diagnostics.push({
-              level: "warn",
-              pluginId: record.id,
-              source: record.source,
-              message,
-            });
-          }
-          if (runtimeSupport.unsupportedServerNames.length > 0) {
-            registry.diagnostics.push({
-              level: "warn",
-              pluginId: record.id,
-              source: record.source,
-              message:
-                "bundle MCP servers use unsupported transports or incomplete configs " +
-                `(stdio only today): ${runtimeSupport.unsupportedServerNames.join(", ")}`,
-            });
-          }
-        }
-        registry.plugins.push(record);
-        seenIds.set(pluginId, candidate.origin);
-        continue;
-      }
-      // Fast-path bundled memory plugins that are guaranteed disabled by slot policy.
-      // This avoids opening/importing heavy memory plugin modules that will never register.
-      // Exception: the dreaming engine (memory-core by default) must load alongside the
-      // selected memory slot plugin so dreaming can run even when lancedb holds the slot.
-      if (
-        registrationPlan.runRuntimeCapabilityPolicy &&
-        candidate.origin === "bundled" &&
-        hasKind(manifestRecord.kind, "memory")
-      ) {
-        if (!isDreamingSidecar) {
-          const earlyMemoryDecision = resolveMemorySlotDecision({
-            id: record.id,
-            kind: manifestRecord.kind,
-            slot: memorySlot,
-            selectedId: selectedMemoryPluginId,
-          });
-          if (!earlyMemoryDecision.enabled) {
-            record.enabled = false;
-            record.status = "disabled";
-            record.error = earlyMemoryDecision.reason;
-            markPluginActivationDisabled(record, earlyMemoryDecision.reason);
-            registry.plugins.push(record);
-            seenIds.set(pluginId, candidate.origin);
-            continue;
-          }
-        }
-      }
-
-      if (!manifestRecord.configSchema) {
-        pushPluginLoadError("missing config schema");
-        continue;
-      }
-
-      if (!shouldLoadModules && registrationPlan.runRuntimeCapabilityPolicy) {
-        const memoryDecision = resolveMemorySlotDecision({
-          id: record.id,
-          kind: record.kind,
-          slot: memorySlot,
-          selectedId: selectedMemoryPluginId,
-        });
-
-        if (!memoryDecision.enabled && !isDreamingSidecar) {
-          record.enabled = false;
-          record.status = "disabled";
-          record.error = memoryDecision.reason;
-          markPluginActivationDisabled(record, memoryDecision.reason);
-          registry.plugins.push(record);
-          seenIds.set(pluginId, candidate.origin);
-          continue;
-        }
-
-        if (memoryDecision.selected && hasKind(record.kind, "memory")) {
-          selectedMemoryPluginId = record.id;
-          memorySlotMatched = true;
-          record.memorySlotSelected = true;
-        }
-      }
-
-      const validatedConfig = validatePluginConfig({
-        schema: manifestRecord.configSchema,
-        cacheKey: manifestRecord.schemaCacheKey,
-        value: entry?.config,
-      });
-
-      if (!validatedConfig.ok) {
-        logger.error(`[plugins] ${record.id} invalid config: ${validatedConfig.error.join(", ")}`);
-        pushPluginLoadError(`invalid config: ${validatedConfig.error.join(", ")}`);
-        continue;
-      }
-
-      if (!shouldLoadModules) {
-        applyManifestSnapshotMetadata(record, manifestRecord);
-        registry.plugins.push(record);
-        seenIds.set(pluginId, candidate.origin);
-        continue;
-      }
-
-      const loadEntry =
-        registrationPlan.loadSetupEntry && runtimeSetupEntry
-          ? runtimeSetupEntry
-          : runtimeCandidateEntry;
-      const moduleLoadSource = resolveCanonicalDistRuntimeSource(loadEntry.source);
-      const moduleRoot = resolveCanonicalDistRuntimeSource(loadEntry.rootDir);
-      const rejectHardlinks = shouldRejectHardlinkedPluginFiles({
-        origin: candidate.origin,
-        rootDir: candidate.rootDir,
-        env,
-      });
-      const opened = openRootFileSync({
-        absolutePath: moduleLoadSource,
-        rootPath: moduleRoot,
-        boundaryLabel: "plugin root",
-        rejectHardlinks,
-        skipLexicalRootCheck: true,
-      });
-      if (!opened.ok) {
-        pushPluginLoadError("plugin entry path escapes plugin root or fails alias checks");
-        continue;
-      }
-      const safeSource = opened.path;
-      fs.closeSync(opened.fd);
-
-      let mod: OpenClawPluginModule | null = null;
-      let moduleLoadMs = 0;
-      let moduleLoadFailed = false;
-      const beforeModuleLoad = performance.now();
-      try {
-        // Track the plugin as imported once module evaluation begins. Top-level
-        // code may have already executed even if evaluation later throws.
-        recordImportedPluginId(record.id);
-        pluginLoadAttemptCount++;
-        logger.debug?.(`[plugins] loading ${record.id} from ${safeSource}`);
-        mod = withProfile(
-          { pluginId: record.id, source: safeSource },
-          registrationMode,
-          () => loadPluginModule(safeSource) as OpenClawPluginModule,
-        );
-      } catch (err) {
-        recordPluginError({
-          logger,
-          registry,
-          record,
-          seenIds,
-          pluginId,
-          origin: candidate.origin,
-          phase: "load",
-          error: err,
-          logPrefix: `[plugins] ${record.id} failed to load from ${record.source}: `,
-          diagnosticMessagePrefix: "failed to load plugin: ",
-        });
-        moduleLoadFailed = true;
-        continue;
-      } finally {
-        moduleLoadMs = performance.now() - beforeModuleLoad;
-        detailPluginStartupTrace(options.startupTrace, record.id, [
-          ["loadMs", moduleLoadMs],
-          ["loadFailedCount", moduleLoadFailed ? 1 : 0],
-        ]);
-      }
-
-      if (registrationPlan.loadSetupEntry && manifestRecord.setupSource) {
-        const setupRegistration = resolveSetupChannelRegistration(mod);
-        if (setupRegistration.loadError) {
-          recordPluginError({
-            logger,
-            registry,
-            record,
-            seenIds,
-            pluginId,
-            origin: candidate.origin,
-            phase: "load",
-            error: setupRegistration.loadError,
-            logPrefix: `[plugins] ${record.id} failed to load setup entry from ${record.source}: `,
-            diagnosticMessagePrefix: "failed to load setup entry: ",
-            diagnosticCode: "channel-setup-failure",
-          });
-          continue;
-        }
-        if (setupRegistration.plugin) {
-          if (
-            !channelPluginIdBelongsToManifest({
-              channelId: setupRegistration.plugin.id,
-              pluginId: record.id,
-              manifestChannels: manifestRecord.channels,
-            })
-          ) {
-            pushPluginLoadError(
-              `plugin id mismatch (config uses "${record.id}", setup export uses "${setupRegistration.plugin.id}")`,
-            );
-            continue;
-          }
-          const api = createApi(record, {
-            config: cfg,
-            pluginConfig: {},
-            hookPolicy: entry?.hooks,
-            registrationMode,
-          });
-          let mergedSetupRegistration = setupRegistration;
-          let runtimeSetterApplied = false;
-          if (
-            registrationPlan.loadSetupRuntimeEntry &&
-            setupRegistration.usesBundledSetupContract &&
-            !shouldDeferConfiguredChannelFullRuntimeMerge({
-              manifestChannels: manifestRecord.channels,
-              startupDeferConfiguredChannelFullLoadUntilAfterListen:
-                manifestRecord.startupDeferConfiguredChannelFullLoadUntilAfterListen,
-              cfg,
-              env,
-              preferSetupRuntimeForChannelPlugins,
-            }) &&
-            resolveCanonicalDistRuntimeSource(runtimeCandidateEntry.source) !== safeSource
-          ) {
-            const runtimeModuleSource = resolveCanonicalDistRuntimeSource(
-              runtimeCandidateEntry.source,
-            );
-            const runtimeModuleRoot = resolveCanonicalDistRuntimeSource(
-              runtimeCandidateEntry.rootDir,
-            );
-            const runtimeOpened = openRootFileSync({
-              absolutePath: runtimeModuleSource,
-              rootPath: runtimeModuleRoot,
-              boundaryLabel: "plugin root",
-              rejectHardlinks,
-              skipLexicalRootCheck: true,
-            });
-            if (!runtimeOpened.ok) {
-              pushPluginLoadError("plugin entry path escapes plugin root or fails alias checks");
-              continue;
-            }
-            const safeRuntimeSource = runtimeOpened.path;
-            fs.closeSync(runtimeOpened.fd);
-            let runtimeMod: OpenClawPluginModule | null = null;
-            try {
-              runtimeMod = withProfile(
-                { pluginId: record.id, source: safeRuntimeSource },
-                "load-setup-runtime-entry",
-                () => loadPluginModule(safeRuntimeSource) as OpenClawPluginModule,
-              );
-            } catch (err) {
-              recordPluginError({
-                logger,
-                registry,
-                record,
-                seenIds,
-                pluginId,
-                origin: candidate.origin,
-                phase: "load",
-                error: err,
-                logPrefix: `[plugins] ${record.id} failed to load setup-runtime entry from ${record.source}: `,
-                diagnosticMessagePrefix: "failed to load setup-runtime entry: ",
-                diagnosticCode: "channel-setup-failure",
-              });
-              continue;
-            }
-            const runtimeRegistration = resolveBundledRuntimeChannelRegistration(runtimeMod);
-            if (runtimeRegistration.id && runtimeRegistration.id !== record.id) {
-              pushPluginLoadError(
-                `plugin id mismatch (config uses "${record.id}", runtime entry uses "${runtimeRegistration.id}")`,
-              );
-              continue;
-            }
-            if (runtimeRegistration.setChannelRuntime) {
-              try {
-                runtimeRegistration.setChannelRuntime(api.runtime);
-                runtimeSetterApplied = true;
-              } catch (err) {
-                recordPluginError({
-                  logger,
-                  registry,
-                  record,
-                  seenIds,
-                  pluginId,
-                  origin: candidate.origin,
-                  phase: "load",
-                  error: err,
-                  logPrefix: `[plugins] ${record.id} failed to apply setup-runtime channel runtime from ${record.source}: `,
-                  diagnosticMessagePrefix: "failed to apply setup-runtime channel runtime: ",
-                  diagnosticCode: "channel-setup-failure",
-                });
-                continue;
-              }
-            }
-            const runtimePluginRegistration = loadBundledRuntimeChannelPlugin({
-              registration: runtimeRegistration,
-            });
-            if (runtimePluginRegistration.loadError) {
-              recordPluginError({
-                logger,
-                registry,
-                record,
-                seenIds,
-                pluginId,
-                origin: candidate.origin,
-                phase: "load",
-                error: runtimePluginRegistration.loadError,
-                logPrefix: `[plugins] ${record.id} failed to load setup-runtime channel entry from ${record.source}: `,
-                diagnosticMessagePrefix: "failed to load setup-runtime channel entry: ",
-                diagnosticCode: "channel-setup-failure",
-              });
-              continue;
-            }
-            if (runtimePluginRegistration.plugin) {
-              if (
-                runtimePluginRegistration.plugin.id &&
-                runtimePluginRegistration.plugin.id !== record.id
-              ) {
-                pushPluginLoadError(
-                  `plugin id mismatch (config uses "${record.id}", runtime export uses "${runtimePluginRegistration.plugin.id}")`,
-                );
-                continue;
-              }
-              mergedSetupRegistration = {
-                ...setupRegistration,
-                plugin: mergeSetupRuntimeChannelPlugin(
-                  runtimePluginRegistration.plugin,
-                  setupRegistration.plugin,
-                ),
-                setChannelRuntime:
-                  runtimeRegistration.setChannelRuntime ?? setupRegistration.setChannelRuntime,
-              };
-            }
-          }
-          const mergedSetupPlugin = mergedSetupRegistration.plugin;
-          if (!mergedSetupPlugin) {
-            continue;
-          }
-          if (
-            !channelPluginIdBelongsToManifest({
-              channelId: mergedSetupPlugin.id,
-              pluginId: record.id,
-              manifestChannels: manifestRecord.channels,
-            })
-          ) {
-            pushPluginLoadError(
-              `plugin id mismatch (config uses "${record.id}", setup export uses "${mergedSetupPlugin.id}")`,
-            );
-            continue;
-          }
-          if (!runtimeSetterApplied) {
-            try {
-              mergedSetupRegistration.setChannelRuntime?.(api.runtime);
-            } catch (err) {
-              recordPluginError({
-                logger,
-                registry,
-                record,
-                seenIds,
-                pluginId,
-                origin: candidate.origin,
-                phase: "load",
-                error: err,
-                logPrefix: `[plugins] ${record.id} failed to apply setup channel runtime from ${record.source}: `,
-                diagnosticMessagePrefix: "failed to apply setup channel runtime: ",
-                diagnosticCode: "channel-setup-failure",
-              });
-              continue;
-            }
-          }
-          if (registrationMode === "setup-runtime") {
-            const registerSetupRuntime = mergedSetupRegistration.registerSetupRuntime;
-            if (registerSetupRuntime) {
-              const transaction = createPluginRegistrationTransaction({ registry });
-              try {
-                runPluginRegisterSync(
-                  (registrationApi) => registerSetupRuntime(registrationApi),
-                  api,
-                );
-                transaction.commit({ activate: true });
-              } catch (err) {
-                transaction.rollback();
-                recordPluginError({
-                  logger,
-                  registry,
-                  record,
-                  seenIds,
-                  pluginId,
-                  origin: candidate.origin,
-                  phase: "register",
-                  error: err,
-                  logPrefix: `[plugins] ${record.id} failed to register setup-runtime channel side effects from ${record.source}: `,
-                  diagnosticMessagePrefix:
-                    "failed to register setup-runtime channel side effects: ",
-                  diagnosticCode: "channel-setup-failure",
-                });
-                continue;
-              }
-            }
-          }
-          try {
-            api.registerChannel(mergedSetupPlugin);
-          } catch (err) {
-            recordPluginError({
-              logger,
-              registry,
-              record,
-              seenIds,
-              pluginId,
-              origin: candidate.origin,
-              phase: "load",
-              error: err,
-              logPrefix: `[plugins] ${record.id} failed to register setup channel from ${record.source}: `,
-              diagnosticMessagePrefix: "failed to register setup channel: ",
-              diagnosticCode: "channel-setup-failure",
-            });
-            continue;
-          }
-          registry.plugins.push(record);
-          seenIds.set(pluginId, candidate.origin);
-          continue;
-        }
-      }
-
-      const resolved = resolvePluginModuleExport(mod);
-      const definition = resolved.definition;
-      const register = resolved.register;
-
-      if (definition?.id && definition.id !== record.id) {
-        pushPluginLoadError(
-          `plugin id mismatch (config uses "${record.id}", export uses "${definition.id}")`,
-        );
-        continue;
-      }
-
-      record.name = definition?.name ?? record.name;
-      record.description = definition?.description ?? record.description;
-      record.version = definition?.version ?? record.version;
-      const manifestKind = record.kind;
-      const exportKind = definition?.kind;
-      if (manifestKind && exportKind && !kindsEqual(manifestKind, exportKind)) {
-        registry.diagnostics.push({
-          level: "warn",
-          pluginId: record.id,
-          source: record.source,
-          message: `plugin kind mismatch (manifest uses "${String(manifestKind)}", export uses "${String(exportKind)}")`,
-        });
-      }
-      record.kind = definition?.kind ?? record.kind;
-
-      if (hasKind(record.kind, "memory") && memorySlot === record.id) {
-        memorySlotMatched = true;
-      }
-
-      if (registrationPlan.runRuntimeCapabilityPolicy) {
-        if (!isDreamingSidecar) {
-          const memoryDecision = resolveMemorySlotDecision({
-            id: record.id,
-            kind: record.kind,
-            slot: memorySlot,
-            selectedId: selectedMemoryPluginId,
-          });
-
-          if (!memoryDecision.enabled) {
-            record.enabled = false;
-            record.status = "disabled";
-            record.error = memoryDecision.reason;
-            markPluginActivationDisabled(record, memoryDecision.reason);
-            registry.plugins.push(record);
-            seenIds.set(pluginId, candidate.origin);
-            continue;
-          }
-
-          if (memoryDecision.selected && hasKind(record.kind, "memory")) {
-            selectedMemoryPluginId = record.id;
-            record.memorySlotSelected = true;
-          }
-        }
-      }
-
-      if (registrationPlan.runFullActivationOnlyRegistrations) {
-        if (definition?.reload) {
-          registerReload(record, definition.reload);
-        }
-        for (const nodeHostCommand of definition?.nodeHostCommands ?? []) {
-          registerNodeHostCommand(record, nodeHostCommand);
-        }
-        for (const collector of definition?.securityAuditCollectors ?? []) {
-          registerSecurityAuditCollector(record, collector);
-        }
-      }
-
-      if (validateOnly) {
-        registry.plugins.push(record);
-        seenIds.set(pluginId, candidate.origin);
-        continue;
-      }
-
-      if (typeof register !== "function") {
-        const bundledChannelWrongLoaderError = formatBundledChannelWrongLoaderError(record.kind);
-        if (bundledChannelWrongLoaderError) {
-          logger.error(
-            `[plugins] ${record.id} ${bundledChannelWrongLoaderError}; ensure plugin is loaded via bundled channel discovery, not legacy plugin loader`,
-          );
-          pushPluginLoadError(bundledChannelWrongLoaderError);
-        } else {
-          logger.error(`[plugins] ${record.id} missing register/activate export`);
-          pushPluginLoadError(formatMissingPluginRegisterError(mod, env));
-        }
-        continue;
-      }
-
-      const api = createApi(record, {
-        config: cfg,
-        pluginConfig: validatedConfig.value,
-        hookPolicy: entry?.hooks,
-        registrationMode,
-      });
-      const transaction = createPluginRegistrationTransaction({
-        registry,
-        rollbackGlobalSideEffects: () => rollbackPluginGlobalSideEffects(record.id),
-      });
-
-      const beforeRegister = performance.now();
-      let registerFailed = false;
-      try {
-        withProfile(
-          { pluginId: record.id, source: record.source },
-          `${registrationMode}:register`,
-          () => runPluginRegisterSync(register, api),
-        );
-        registry.plugins.push(record);
-        seenIds.set(pluginId, candidate.origin);
-        transaction.commit({ activate: shouldActivate });
-      } catch (err) {
-        transaction.rollback();
-        recordPluginError({
-          logger,
-          registry,
-          record,
-          seenIds,
-          pluginId,
-          origin: candidate.origin,
-          phase: "register",
-          error: err,
-          logPrefix: `[plugins] ${record.id} failed during register from ${record.source}: `,
-          diagnosticMessagePrefix: "plugin failed during register: ",
-        });
-        registerFailed = true;
-      } finally {
-        const registerMs = performance.now() - beforeRegister;
-        detailPluginStartupTrace(options.startupTrace, record.id, [
-          ["registerMs", registerMs],
-          ["loadAndRegisterMs", moduleLoadMs + registerMs],
-          ["registerFailedCount", registerFailed ? 1 : 0],
-        ]);
+      if (manifestRecord) {
+        loadRuntimePluginCandidate(candidateContext, candidate, manifestRecord, state);
       }
     }
-
     const pluginLoadElapsedMs = performance.now() - pluginLoadStartMs;
-    if (pluginLoadAttemptCount > 0) {
+    if (state.pluginLoadAttemptCount > 0) {
       logger.debug?.(
-        `[plugins] loaded ${registry.plugins.length} plugin(s) (${pluginLoadAttemptCount} attempted) in ${pluginLoadElapsedMs.toFixed(1)}ms`,
+        `[plugins] loaded ${registry.plugins.length} plugin(s) (${state.pluginLoadAttemptCount} attempted) in ${pluginLoadElapsedMs.toFixed(1)}ms`,
       );
     }
-
-    // Scoped snapshot loads may intentionally omit the configured memory plugin, so only
-    // emit the missing-memory diagnostic for full registry loads.
-    if (!onlyPluginIdSet && typeof memorySlot === "string" && !memorySlotMatched) {
+    if (!onlyPluginIdSet && typeof memorySlot === "string" && !state.memorySlotMatched) {
       registry.diagnostics.push({
         level: "warn",
         message: `memory slot plugin not found or not marked as memory: ${memorySlot}`,
       });
     }
-
     warnAboutUntrackedLoadedPlugins({
       registry,
       provenance,
@@ -2537,9 +397,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
       logger,
       env,
     });
-
     maybeThrowOnPluginLoadError(registry, options.throwOnLoadError);
-
     if (shouldActivate && options.mode !== "validate") {
       const failedPlugins = registry.plugins.filter((plugin) => plugin.failedAt != null);
       if (failedPlugins.length > 0) {
@@ -2550,14 +408,10 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
         );
       }
     }
-
     if (cacheEnabled) {
       setCachedPluginRegistry(
         cacheKey,
-        {
-          registry,
-          processGlobalState: snapshotPluginProcessGlobalState(),
-        },
+        { registry, processGlobalState: snapshotPluginProcessGlobalState() },
         onlyPluginIds,
       );
     }
@@ -2569,430 +423,3 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
     pluginLoaderCacheState.finishLoad(cacheKey);
   }
 }
-
-export async function loadOpenClawPluginCliRegistry(
-  options: PluginLoadOptions = {},
-): Promise<PluginRegistry> {
-  const {
-    env,
-    cfg,
-    normalized,
-    activationSource,
-    autoEnabledReasons,
-    onlyPluginIds,
-    cacheKey,
-    installRecords,
-    devSourceRoot,
-  } = resolvePluginLoadCacheContext({
-    ...options,
-    activate: false,
-  });
-  const logger = options.logger ?? defaultLogger();
-  const onlyPluginIdSet = createPluginIdScopeSet(onlyPluginIds);
-  const loadPluginModule = createPluginModuleLoader({
-    devSourceRoot,
-    pluginSdkResolution: options.pluginSdkResolution,
-  });
-  const { registry, registerCli } = createPluginRegistry({
-    logger,
-    runtime: {} as PluginRuntime,
-    coreGatewayHandlers: options.coreGatewayHandlers as Record<string, GatewayRequestHandler>,
-    ...(options.coreGatewayMethodNames !== undefined && {
-      coreGatewayMethodNames: options.coreGatewayMethodNames,
-    }),
-    activateGlobalSideEffects: false,
-  });
-
-  const discovery =
-    options.discovery ??
-    discoverOpenClawPlugins({
-      workspaceDir: options.workspaceDir,
-      extraPaths: normalized.loadPaths,
-      env,
-      installRecords,
-    });
-  const manifestRegistry = loadPluginManifestRegistry({
-    config: cfg,
-    workspaceDir: options.workspaceDir,
-    env,
-    candidates: discovery.candidates,
-    diagnostics: discovery.diagnostics,
-    installRecords: Object.keys(installRecords).length > 0 ? installRecords : undefined,
-  });
-  pushDiagnostics(registry.diagnostics, manifestRegistry.diagnostics);
-  warnWhenAllowlistIsOpen({
-    emitWarning: false,
-    logger,
-    pluginsEnabled: normalized.enabled,
-    allow: normalized.allow,
-    warningCacheKey: `${cacheKey}::cli-metadata`,
-    warningCache: pluginLoaderCacheState,
-    explicitlyEnabledPluginIds: new Set(
-      Object.entries(normalized.entries)
-        .filter(([, entry]) => entry.enabled === true)
-        .map(([pluginId]) => pluginId),
-    ),
-    discoverablePlugins: manifestRegistry.plugins
-      .filter((plugin) => !onlyPluginIdSet || onlyPluginIdSet.has(plugin.id))
-      .map((plugin) => ({
-        id: plugin.id,
-        source: plugin.source,
-        origin: plugin.origin,
-      })),
-  });
-  const provenance = buildProvenanceIndex({
-    normalizedLoadPaths: normalized.loadPaths,
-    env,
-    installRecords,
-  });
-  const manifestByRoot = new Map(
-    manifestRegistry.plugins.map((record) => [record.rootDir, record]),
-  );
-  const orderedCandidates = [...discovery.candidates].toSorted((left, right) => {
-    return compareDuplicateCandidateOrder({
-      left,
-      right,
-      manifestByRoot,
-      provenance,
-      env,
-    });
-  });
-
-  const seenIds = new Map<string, PluginRecord["origin"]>();
-  const memorySlot = normalized.slots.memory;
-  let selectedMemoryPluginId: string | null = null;
-  const dreamingSidecar = resolveAuthorizedDreamingSidecar({
-    cfg,
-    normalized,
-    activationSource,
-    manifestRegistry,
-    memorySlot,
-  });
-
-  for (const candidate of orderedCandidates) {
-    const manifestRecord = manifestByRoot.get(candidate.rootDir);
-    if (!manifestRecord) {
-      continue;
-    }
-    const pluginId = manifestRecord.id;
-    if (
-      !matchesScopedPluginOrDreamingSidecar({
-        onlyPluginIdSet,
-        pluginId,
-        sidecar: dreamingSidecar,
-      })
-    ) {
-      continue;
-    }
-    const isDreamingSidecar = isAuthorizedDreamingSidecarPlugin({
-      sidecar: dreamingSidecar,
-      pluginId,
-    });
-    const activationState = isDreamingSidecar
-      ? {
-          enabled: true,
-          activated: true,
-          explicitlyEnabled: false,
-          source: "auto" as const,
-          reason: `dreaming sidecar for selected memory slot "${dreamingSidecar?.selectedMemoryPluginId ?? ""}"`,
-        }
-      : resolveEffectivePluginActivationState({
-          id: pluginId,
-          origin: candidate.origin,
-          config: normalized,
-          rootConfig: cfg,
-          enabledByDefault: isPluginEnabledByDefaultForPlatform(manifestRecord),
-          activationSource,
-          autoEnabledReason: formatAutoEnabledActivationReason(autoEnabledReasons[pluginId]),
-        });
-    const existingOrigin = seenIds.get(pluginId);
-    if (existingOrigin) {
-      const record = createPluginRecord({
-        id: pluginId,
-        name: manifestRecord.name ?? pluginId,
-        description: manifestRecord.description,
-        version: manifestRecord.version,
-        packageName: manifestRecord.packageName,
-        format: manifestRecord.format,
-        bundleFormat: manifestRecord.bundleFormat,
-        bundleCapabilities: manifestRecord.bundleCapabilities,
-        source: candidate.source,
-        rootDir: candidate.rootDir,
-        origin: candidate.origin,
-        workspaceDir: candidate.workspaceDir,
-        trustedOfficialInstall: manifestRecord.trustedOfficialInstall,
-        enabled: false,
-        compat: collectPluginManifestCompatCodes(manifestRecord),
-        activationState,
-        syntheticAuthRefs: manifestRecord.syntheticAuthRefs,
-        channelIds: manifestRecord.channels,
-        providerIds: manifestRecord.providers,
-        configSchema: Boolean(manifestRecord.configSchema),
-        contracts: manifestRecord.contracts,
-      });
-      record.status = "disabled";
-      record.error = `overridden by ${existingOrigin} plugin`;
-      markPluginActivationDisabled(record, record.error);
-      registry.plugins.push(record);
-      continue;
-    }
-
-    const enableState = isDreamingSidecar
-      ? { enabled: true }
-      : resolveEffectiveEnableState({
-          id: pluginId,
-          origin: candidate.origin,
-          config: normalized,
-          rootConfig: cfg,
-          enabledByDefault: isPluginEnabledByDefaultForPlatform(manifestRecord),
-          activationSource,
-        });
-    const entry = normalized.entries[pluginId];
-    const record = createPluginRecord({
-      id: pluginId,
-      name: manifestRecord.name ?? pluginId,
-      description: manifestRecord.description,
-      version: manifestRecord.version,
-      packageName: manifestRecord.packageName,
-      format: manifestRecord.format,
-      bundleFormat: manifestRecord.bundleFormat,
-      bundleCapabilities: manifestRecord.bundleCapabilities,
-      source: candidate.source,
-      rootDir: candidate.rootDir,
-      origin: candidate.origin,
-      workspaceDir: candidate.workspaceDir,
-      trustedOfficialInstall: manifestRecord.trustedOfficialInstall,
-      enabled: enableState.enabled,
-      compat: collectPluginManifestCompatCodes(manifestRecord),
-      activationState,
-      syntheticAuthRefs: manifestRecord.syntheticAuthRefs,
-      channelIds: manifestRecord.channels,
-      providerIds: manifestRecord.providers,
-      configSchema: Boolean(manifestRecord.configSchema),
-      contracts: manifestRecord.contracts,
-    });
-    record.kind = manifestRecord.kind;
-    record.configUiHints = manifestRecord.configUiHints;
-    record.configJsonSchema = manifestRecord.configSchema;
-    const pushPluginLoadError = (message: string) =>
-      pushPluginValidationError({
-        registry,
-        seenIds,
-        pluginId,
-        origin: candidate.origin,
-        record,
-        message,
-      });
-
-    if (!enableState.enabled) {
-      record.status = "disabled";
-      record.error = enableState.reason;
-      markPluginActivationDisabled(record, enableState.reason);
-      registry.plugins.push(record);
-      seenIds.set(pluginId, candidate.origin);
-      continue;
-    }
-
-    if (record.format === "bundle") {
-      registry.plugins.push(record);
-      seenIds.set(pluginId, candidate.origin);
-      continue;
-    }
-
-    if (!manifestRecord.configSchema) {
-      pushPluginLoadError("missing config schema");
-      continue;
-    }
-
-    const validatedConfig = validatePluginConfig({
-      schema: manifestRecord.configSchema,
-      cacheKey: manifestRecord.schemaCacheKey,
-      value: entry?.config,
-    });
-    if (!validatedConfig.ok) {
-      logger.error(`[plugins] ${record.id} invalid config: ${validatedConfig.error.join(", ")}`);
-      pushPluginLoadError(`invalid config: ${validatedConfig.error.join(", ")}`);
-      continue;
-    }
-
-    const pluginRoot = safeRealpathOrResolve(candidate.rootDir);
-    const cliMetadataSource = resolveCliMetadataEntrySource(candidate.rootDir);
-    const sourceForCliMetadata =
-      candidate.origin === "bundled"
-        ? cliMetadataSource
-          ? safeRealpathOrResolve(cliMetadataSource)
-          : null
-        : (cliMetadataSource ?? candidate.source);
-    if (!sourceForCliMetadata) {
-      record.status = "loaded";
-      registry.plugins.push(record);
-      seenIds.set(pluginId, candidate.origin);
-      continue;
-    }
-    const opened = openRootFileSync({
-      absolutePath: sourceForCliMetadata,
-      rootPath: pluginRoot,
-      boundaryLabel: "plugin root",
-      rejectHardlinks: shouldRejectHardlinkedPluginFiles({
-        origin: candidate.origin,
-        rootDir: candidate.rootDir,
-        env,
-      }),
-      skipLexicalRootCheck: true,
-    });
-    if (!opened.ok) {
-      pushPluginLoadError("plugin entry path escapes plugin root or fails alias checks");
-      continue;
-    }
-    const safeSource = opened.path;
-    fs.closeSync(opened.fd);
-
-    let mod: OpenClawPluginModule | null;
-    try {
-      mod = withProfile(
-        { pluginId: record.id, source: safeSource },
-        "cli-metadata",
-        () => loadPluginModule(safeSource) as OpenClawPluginModule,
-      );
-    } catch (err) {
-      recordPluginError({
-        logger,
-        registry,
-        record,
-        seenIds,
-        pluginId,
-        origin: candidate.origin,
-        phase: "load",
-        error: err,
-        logPrefix: `[plugins] ${record.id} failed to load from ${record.source}: `,
-        diagnosticMessagePrefix: "failed to load plugin: ",
-      });
-      continue;
-    }
-
-    const resolved = resolvePluginModuleExport(mod);
-    const definition = resolved.definition;
-    const register = resolved.register;
-
-    if (definition?.id && definition.id !== record.id) {
-      pushPluginLoadError(
-        `plugin id mismatch (config uses "${record.id}", export uses "${definition.id}")`,
-      );
-      continue;
-    }
-
-    record.name = definition?.name ?? record.name;
-    record.description = definition?.description ?? record.description;
-    record.version = definition?.version ?? record.version;
-    const manifestKind = record.kind;
-    const exportKind = definition?.kind;
-    if (manifestKind && exportKind && !kindsEqual(manifestKind, exportKind)) {
-      registry.diagnostics.push({
-        level: "warn",
-        pluginId: record.id,
-        source: record.source,
-        message: `plugin kind mismatch (manifest uses "${String(manifestKind)}", export uses "${String(exportKind)}")`,
-      });
-    }
-    record.kind = definition?.kind ?? record.kind;
-
-    if (!isDreamingSidecar) {
-      const memoryDecision = resolveMemorySlotDecision({
-        id: record.id,
-        kind: record.kind,
-        slot: memorySlot,
-        selectedId: selectedMemoryPluginId,
-      });
-      if (!memoryDecision.enabled) {
-        record.enabled = false;
-        record.status = "disabled";
-        record.error = memoryDecision.reason;
-        markPluginActivationDisabled(record, memoryDecision.reason);
-        registry.plugins.push(record);
-        seenIds.set(pluginId, candidate.origin);
-        continue;
-      }
-      if (memoryDecision.selected && hasKind(record.kind, "memory")) {
-        selectedMemoryPluginId = record.id;
-        record.memorySlotSelected = true;
-      }
-    }
-
-    if (typeof register !== "function") {
-      const bundledChannelWrongLoaderError = formatBundledChannelWrongLoaderError(record.kind);
-      if (bundledChannelWrongLoaderError) {
-        logger.error(
-          `[plugins] ${record.id} ${bundledChannelWrongLoaderError}; ensure plugin is loaded via bundled channel discovery, not legacy plugin loader`,
-        );
-        pushPluginLoadError(bundledChannelWrongLoaderError);
-      } else {
-        logger.error(`[plugins] ${record.id} missing register/activate export`);
-        pushPluginLoadError(formatMissingPluginRegisterError(mod, env));
-      }
-      continue;
-    }
-
-    const api = buildPluginApi({
-      id: record.id,
-      name: record.name,
-      version: record.version,
-      description: record.description,
-      source: record.source,
-      rootDir: record.rootDir,
-      registrationMode: "cli-metadata",
-      config: cfg,
-      pluginConfig: validatedConfig.value,
-      runtime: {} as PluginRuntime,
-      logger,
-      resolvePath: (input) => resolveUserPath(input),
-      handlers: {
-        registerCli: (registrar, opts) => registerCli(record, registrar, opts),
-      },
-    });
-
-    const transaction = createPluginRegistrationTransaction({ registry });
-    try {
-      withProfile({ pluginId: record.id, source: record.source }, "cli-metadata:register", () =>
-        runPluginRegisterSync(register, api),
-      );
-      registry.plugins.push(record);
-      seenIds.set(pluginId, candidate.origin);
-      transaction.commit({ activate: true });
-    } catch (err) {
-      transaction.rollback();
-      recordPluginError({
-        logger,
-        registry,
-        record,
-        seenIds,
-        pluginId,
-        origin: candidate.origin,
-        phase: "register",
-        error: err,
-        logPrefix: `[plugins] ${record.id} failed during register from ${record.source}: `,
-        diagnosticMessagePrefix: "plugin failed during register: ",
-      });
-    }
-  }
-
-  return registry;
-}
-
-function safeRealpathOrResolve(value: string): string {
-  try {
-    return fs.realpathSync(value);
-  } catch {
-    return path.resolve(value);
-  }
-}
-
-function resolveCliMetadataEntrySource(rootDir: string): string | null {
-  for (const basename of CLI_METADATA_ENTRY_BASENAMES) {
-    const candidate = path.join(rootDir, basename);
-    if (fs.existsSync(candidate)) {
-      return candidate;
-    }
-  }
-  return null;
-}
-/* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */


### PR DESCRIPTION
## What Problem This Solves

The plugin loader had grown to nearly 3,000 lines and mixed cache identity, module loading, registration planning, setup-channel handling, runtime candidate loading, CLI metadata, and shared record helpers. That made ownership and review difficult and required a max-lines baseline suppression.

## Why This Change Was Made

This maintainer-requested refactor keeps `loader.ts` as the public orchestration facade while moving cohesive responsibilities into eight focused modules. It also consolidates active-registry activation variants, preserves the existing runtime and CLI behavior, and removes the loader from the max-lines baseline.

## User Impact

No intended user-visible behavior change. Maintainers get smaller ownership boundaries and a loader facade reduced from 2,998 to 425 lines; net production lines still decrease.

## Evidence

- `pnpm test src/plugins/loader.test.ts src/plugins/loader.bundle.test.ts src/plugins/loader.cli-metadata.test.ts src/plugins/loader.native-module-loader.test.ts src/plugins/loader.runtime-registry.test.ts`: 194 tests passed.
- `pnpm build`: passed, including runtime bundles and Control UI build.
- `pnpm check:changed`: passed on the final runtime diff, including format, max-lines ratchet, core and test typechecks, full core/script lint, plugin boundaries, runtime import cycles, and repository guards.
- Final branch `autoreview --mode branch --base origin/main`: clean, patch correct (0.96), no accepted or actionable findings.

## Built Runtime Proof

Runtime-affecting head `fb70bfb7a47aa8bc171fc239834551dbcd365d40` was built on a clean Linux Testbox, then exercised through `node dist/index.js` with an isolated state directory. Current head `5f797897cea5a1cc82bca22a6c68644cdf96fd94` differs only by inline comments documenting the already-existing source/root canonicalization contract.

- Compiled `plugins list --json`: 147 plugins discovered, 80 bundled plugins loaded, no loader diagnostics.
- The public CLI scaffolded and built a standalone `loader-proof` tool plugin, then the compiled CLI linked it. Runtime inspection reported `origin: config`, `enabled: true`, `activated: true`, `imported: true`, `status: loaded`, tool `echo`, and no diagnostics.
- The compiled gateway started on loopback with that external plugin. Health returned successfully in 59 ms. Gateway `plugins.list` included enabled `loader-proof`.

Sanitized terminal excerpt:

```text
built_head=fb70bfb7a47aa8bc171fc239834551dbcd365d40
plugin inventory: total=147 bundledLoaded=80 diagnostics=0
external plugin: loader-proof status=loaded origin=config enabled=true
runtime inspect: activated=true imported=true tools=[echo] diagnostics=0
[gateway] loading configuration…
[gateway] starting...
[gateway] http server listening (14 plugins: acpx, anthropic, browser, canvas, device-pair, file-transfer, linux-canvas, linux-node, loader-proof, memory-core, ollama, opencode, phone-control, talk-voice; 1.0s)
[gateway] ready
[gateway] agent runtime plugins pre-warmed in 85ms
[ws] ⇄ res ✓ plugins.list 212ms
health: true (59ms)
```

AI-assisted: Codex implemented and validated this change. I understand the code and its loader boundaries.
