### PR TITLE
test: fix realtime transcription lint

### DIFF
--- a/extensions/elevenlabs/realtime-transcription-provider.test.ts
+++ b/extensions/elevenlabs/realtime-transcription-provider.test.ts
@@ -11,7 +11,7 @@ let cleanup: (() => Promise<void>) | undefined;
 
 async function createRealtimeServer(onRequest: (url: URL) => void) {
   const server = createServer();
-  const wss = new WebSocketServer({ noServer: true });
+  const wss = new WebSocketServer({ noServer: true, maxPayload: 1024 * 1024 });
   const clients = new Set<WebSocket>();
   server.on("upgrade", (request, socket, head) => {
     onRequest(new URL(request.url ?? "/", "http://127.0.0.1"));

--- a/extensions/elevenlabs/realtime-transcription-provider.test.ts
+++ b/extensions/elevenlabs/realtime-transcription-provider.test.ts
@@ -17,17 +17,29 @@ async function createRealtimeServer(onRequest: (url: URL) => void) {
     onRequest(new URL(request.url ?? "/", "http://127.0.0.1"));
     wss.handleUpgrade(request, socket, head, (ws) => {
       clients.add(ws);
-      ws.on("close", () => clients.delete(ws));
+      ws.on("close", () => {
+        clients.delete(ws);
+      });
       ws.send(JSON.stringify({ message_type: "session_started" }));
     });
   });
-  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", resolve);
+  });
   cleanup = async () => {
     for (const ws of clients) {
       ws.terminate();
     }
-    await new Promise<void>((resolve) => wss.close(() => resolve()));
-    await new Promise<void>((resolve) => server.close(() => resolve()));
+    await new Promise<void>((resolve) => {
+      wss.close(() => {
+        resolve();
+      });
+    });
+    await new Promise<void>((resolve) => {
+      server.close(() => {
+        resolve();
+      });
+    });
   };
   return `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
 }

--- a/extensions/mistral/realtime-transcription-provider.test.ts
+++ b/extensions/mistral/realtime-transcription-provider.test.ts
@@ -11,7 +11,7 @@ let cleanup: (() => Promise<void>) | undefined;
 
 async function createRealtimeServer(onRequest: (url: URL) => void) {
   const server = createServer();
-  const wss = new WebSocketServer({ noServer: true });
+  const wss = new WebSocketServer({ noServer: true, maxPayload: 1024 * 1024 });
   const clients = new Set<WebSocket>();
   server.on("upgrade", (request, socket, head) => {
     onRequest(new URL(request.url ?? "/", "http://127.0.0.1"));

--- a/extensions/mistral/realtime-transcription-provider.test.ts
+++ b/extensions/mistral/realtime-transcription-provider.test.ts
@@ -17,17 +17,29 @@ async function createRealtimeServer(onRequest: (url: URL) => void) {
     onRequest(new URL(request.url ?? "/", "http://127.0.0.1"));
     wss.handleUpgrade(request, socket, head, (ws) => {
       clients.add(ws);
-      ws.on("close", () => clients.delete(ws));
+      ws.on("close", () => {
+        clients.delete(ws);
+      });
       ws.send(JSON.stringify({ type: "session.created" }));
     });
   });
-  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", resolve);
+  });
   cleanup = async () => {
     for (const ws of clients) {
       ws.terminate();
     }
-    await new Promise<void>((resolve) => wss.close(() => resolve()));
-    await new Promise<void>((resolve) => server.close(() => resolve()));
+    await new Promise<void>((resolve) => {
+      wss.close(() => {
+        resolve();
+      });
+    });
+    await new Promise<void>((resolve) => {
+      server.close(() => {
+        resolve();
+      });
+    });
   };
   return `http://127.0.0.1:${(server.address() as AddressInfo).port}/v1`;
 }


### PR DESCRIPTION
Fixes exact-current-main CI lint failures in the Mistral and ElevenLabs realtime transcription provider tests.

The Promise executors and WebSocket close handlers now use block bodies, preserving behavior while satisfying `no-promise-executor-return`.

Proof:
- `pnpm exec oxlint extensions/mistral/realtime-transcription-provider.test.ts extensions/elevenlabs/realtime-transcription-provider.test.ts`
- `node scripts/run-vitest.mjs extensions/mistral/realtime-transcription-provider.test.ts extensions/elevenlabs/realtime-transcription-provider.test.ts`
- `pnpm exec oxfmt --check extensions/mistral/realtime-transcription-provider.test.ts extensions/elevenlabs/realtime-transcription-provider.test.ts`
- autoreview clean
