### PR TITLE
test(providers): satisfy promise executor lint

### DIFF
--- a/extensions/elevenlabs/realtime-transcription-provider.test.ts
+++ b/extensions/elevenlabs/realtime-transcription-provider.test.ts
@@ -17,17 +17,29 @@ async function createRealtimeServer(onRequest: (url: URL) => void) {
     onRequest(new URL(request.url ?? "/", "http://127.0.0.1"));
     wss.handleUpgrade(request, socket, head, (ws) => {
       clients.add(ws);
-      ws.on("close", () => clients.delete(ws));
+      ws.on("close", () => {
+        clients.delete(ws);
+      });
       ws.send(JSON.stringify({ message_type: "session_started" }));
     });
   });
-  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", resolve);
+  });
   cleanup = async () => {
     for (const ws of clients) {
       ws.terminate();
     }
-    await new Promise<void>((resolve) => wss.close(() => resolve()));
-    await new Promise<void>((resolve) => server.close(() => resolve()));
+    await new Promise<void>((resolve) => {
+      wss.close(() => {
+        resolve();
+      });
+    });
+    await new Promise<void>((resolve) => {
+      server.close(() => {
+        resolve();
+      });
+    });
   };
   return `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
 }

--- a/extensions/mistral/realtime-transcription-provider.test.ts
+++ b/extensions/mistral/realtime-transcription-provider.test.ts
@@ -17,17 +17,29 @@ async function createRealtimeServer(onRequest: (url: URL) => void) {
     onRequest(new URL(request.url ?? "/", "http://127.0.0.1"));
     wss.handleUpgrade(request, socket, head, (ws) => {
       clients.add(ws);
-      ws.on("close", () => clients.delete(ws));
+      ws.on("close", () => {
+        clients.delete(ws);
+      });
       ws.send(JSON.stringify({ type: "session.created" }));
     });
   });
-  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", resolve);
+  });
   cleanup = async () => {
     for (const ws of clients) {
       ws.terminate();
     }
-    await new Promise<void>((resolve) => wss.close(() => resolve()));
-    await new Promise<void>((resolve) => server.close(() => resolve()));
+    await new Promise<void>((resolve) => {
+      wss.close(() => {
+        resolve();
+      });
+    });
+    await new Promise<void>((resolve) => {
+      server.close(() => {
+        resolve();
+      });
+    });
   };
   return `http://127.0.0.1:${(server.address() as AddressInfo).port}/v1`;
 }


### PR DESCRIPTION
## What Problem This Solves

Current `main` fails the extension lint lane because new Mistral and ElevenLabs realtime transcription tests return callback values from Promise executors.

Exact failure: https://github.com/openclaw/openclaw/actions/runs/29461081614/job/87504536322

## Why This Change Was Made

Expand the concise WebSocket/server callbacks into block bodies. This preserves the existing startup and cleanup behavior while satisfying `no-promise-executor-return` in both sibling provider fixtures.

## User Impact

No product behavior change. Main CI returns to green and both provider tests retain equivalent lifecycle coverage.

## Evidence

- Blacksmith Testbox `tbx_01kxm2zth4vdanxv1ykgcbsxck`: 8/8 focused tests passed.
- Same Testbox: targeted oxlint passed with 0 warnings and 0 errors.
- Same Testbox: targeted oxfmt check passed.
- `git diff --check` passed.
- Fresh autoreview clean; correctness confidence 0.99.
