### PR TITLE
refactor(deadcode): tighten Google and xAI extension roots

### DIFF
--- a/config/knip.config.ts
+++ b/config/knip.config.ts
@@ -373,6 +373,7 @@ const config = {
       project: ["index.js!", "scripts/**/*.js!"],
     },
     [`${BUNDLED_PLUGIN_ROOT_DIR}/amazon-bedrock-mantle`]: strictBundledPluginWorkspace(),
+    [`${BUNDLED_PLUGIN_ROOT_DIR}/acpx`]: strictBundledPluginWorkspace(),
     [`${BUNDLED_PLUGIN_ROOT_DIR}/azure-speech`]: strictBundledPluginWorkspace(),
     [`${BUNDLED_PLUGIN_ROOT_DIR}/cloudflare-ai-gateway`]: strictBundledPluginWorkspace(),
     [`${BUNDLED_PLUGIN_ROOT_DIR}/cohere`]: strictBundledPluginWorkspace(),
@@ -380,6 +381,7 @@ const config = {
     [`${BUNDLED_PLUGIN_ROOT_DIR}/elevenlabs`]: strictBundledPluginWorkspace(),
     [`${BUNDLED_PLUGIN_ROOT_DIR}/featherless`]: strictBundledPluginWorkspace(),
     [`${BUNDLED_PLUGIN_ROOT_DIR}/fireworks`]: strictBundledPluginWorkspace(),
+    [`${BUNDLED_PLUGIN_ROOT_DIR}/google`]: strictBundledPluginWorkspace(),
     [`${BUNDLED_PLUGIN_ROOT_DIR}/huggingface`]: strictBundledPluginWorkspace(),
     [`${BUNDLED_PLUGIN_ROOT_DIR}/kilocode`]: strictBundledPluginWorkspace(),
     [`${BUNDLED_PLUGIN_ROOT_DIR}/kimi-coding`]: strictBundledPluginWorkspace(),
@@ -396,6 +398,7 @@ const config = {
     [`${BUNDLED_PLUGIN_ROOT_DIR}/tencent`]: strictBundledPluginWorkspace(),
     [`${BUNDLED_PLUGIN_ROOT_DIR}/vllm`]: strictBundledPluginWorkspace(),
     [`${BUNDLED_PLUGIN_ROOT_DIR}/xiaomi`]: strictBundledPluginWorkspace(),
+    [`${BUNDLED_PLUGIN_ROOT_DIR}/xai`]: strictBundledPluginWorkspace(),
     [`${BUNDLED_PLUGIN_ROOT_DIR}/llama-cpp`]: {
       entry: bundledPluginEntries,
       project: ["index.ts!", "src/**/*.{js,mjs,ts}!"],
@@ -406,6 +409,7 @@ const config = {
         ...bundledPluginIgnoredRuntimeDependencies,
       ],
     },
+    [`${BUNDLED_PLUGIN_ROOT_DIR}/lmstudio`]: strictBundledPluginWorkspace(),
     [`${BUNDLED_PLUGIN_ROOT_DIR}/reef`]: {
       // Reef vendors its wire protocol under protocol/, which owns the noble
       // crypto dependencies. The protocol barrel is the vendored library's

--- a/extensions/google/embedding-provider.test.ts
+++ b/extensions/google/embedding-provider.test.ts
@@ -17,16 +17,7 @@ vi.mock("openclaw/plugin-sdk/memory-core-host-engine-embeddings", async (importO
   };
 });
 
-import {
-  buildGeminiEmbeddingRequest,
-  buildGeminiTextEmbeddingRequest,
-  createGeminiEmbeddingProvider,
-  DEFAULT_GEMINI_EMBEDDING_MODEL,
-  GEMINI_EMBEDDING_2_MODELS,
-  isGeminiEmbedding2Model,
-  normalizeGeminiModel,
-  resolveGeminiOutputDimensionality,
-} from "./embedding-provider.js";
+import { createGeminiEmbeddingProvider } from "./embedding-provider.js";
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -63,75 +54,40 @@ function requireFirstFetchInput(fetchMock: ReturnType<typeof vi.fn>): RequestInf
   return call[0] as RequestInfo | URL;
 }
 
-describe("Gemini embedding request helpers", () => {
-  it("builds requests and resolves model settings", () => {
-    expect(
-      buildGeminiTextEmbeddingRequest({
-        text: "hello",
-        taskType: "RETRIEVAL_DOCUMENT",
-        modelPath: "models/gemini-embedding-2-preview",
-        outputDimensionality: 1536,
-      }),
-    ).toEqual({
-      model: "models/gemini-embedding-2-preview",
-      content: { parts: [{ text: "hello" }] },
-      taskType: "RETRIEVAL_DOCUMENT",
-      outputDimensionality: 1536,
-    });
-    expect(
-      buildGeminiEmbeddingRequest({
-        input: {
-          text: "Image file: diagram.png",
-          parts: [
-            { type: "text", text: "Image file: diagram.png" },
-            { type: "inline-data", mimeType: "image/png", data: "abc123" },
-          ],
-        },
-        taskType: "RETRIEVAL_DOCUMENT",
-        modelPath: "models/gemini-embedding-2-preview",
-        outputDimensionality: 1536,
-      }),
-    ).toEqual({
-      model: "models/gemini-embedding-2-preview",
-      content: {
-        parts: [
-          { text: "Image file: diagram.png" },
-          { inlineData: { mimeType: "image/png", data: "abc123" } },
-        ],
-      },
-      taskType: "RETRIEVAL_DOCUMENT",
-      outputDimensionality: 1536,
-    });
-    expect(GEMINI_EMBEDDING_2_MODELS.has("gemini-embedding-2-preview")).toBe(true);
-    expect(isGeminiEmbedding2Model("gemini-embedding-2-preview")).toBe(true);
-    expect(isGeminiEmbedding2Model("gemini-embedding-001")).toBe(false);
-    expect(isGeminiEmbedding2Model("text-embedding-004")).toBe(false);
-    expect(resolveGeminiOutputDimensionality("gemini-embedding-001")).toBeUndefined();
-    expect(resolveGeminiOutputDimensionality("text-embedding-004")).toBeUndefined();
-    expect(resolveGeminiOutputDimensionality("gemini-embedding-2-preview")).toBe(3072);
-    expect(resolveGeminiOutputDimensionality("gemini-embedding-2-preview", 768)).toBe(768);
-    expect(resolveGeminiOutputDimensionality("gemini-embedding-2-preview", 1536)).toBe(1536);
-    expect(resolveGeminiOutputDimensionality("gemini-embedding-2-preview", 3072)).toBe(3072);
-    expect(() => resolveGeminiOutputDimensionality("gemini-embedding-2-preview", 512)).toThrow(
-      /Invalid outputDimensionality 512/,
-    );
-    expect(() => resolveGeminiOutputDimensionality("gemini-embedding-2-preview", 1024)).toThrow(
-      /Valid values: 768, 1536, 3072/,
-    );
-    expect(normalizeGeminiModel("models/gemini-embedding-2-preview")).toBe(
-      "gemini-embedding-2-preview",
-    );
-    expect(normalizeGeminiModel("gemini/gemini-embedding-2-preview")).toBe(
-      "gemini-embedding-2-preview",
-    );
-    expect(normalizeGeminiModel("google/gemini-embedding-2-preview")).toBe(
-      "gemini-embedding-2-preview",
-    );
-    expect(normalizeGeminiModel("")).toBe(DEFAULT_GEMINI_EMBEDDING_MODEL);
-  });
-});
-
 describe("Gemini embedding provider", () => {
+  it.each(["models/", "gemini/", "google/"])(
+    "normalizes the %s model prefix through the provider request",
+    async (prefix) => {
+      const fetchMock = installFetchMock(() => ({ embedding: { values: [1, 0] } }));
+      const { provider } = await createGeminiEmbeddingProvider({
+        config: {} as never,
+        provider: "gemini",
+        remote: { apiKey: "placeholder" },
+        model: `${prefix}gemini-embedding-2-preview`,
+        fallback: "none",
+      });
+
+      await provider.embedQuery("query");
+
+      expect(requireFirstFetchInput(fetchMock)).toBe(
+        "https://generativelanguage.googleapis.com/v1beta/models/gemini-embedding-2-preview:embedContent",
+      );
+    },
+  );
+
+  it("rejects unsupported Gemini 2 output dimensions through provider creation", async () => {
+    await expect(
+      createGeminiEmbeddingProvider({
+        config: {} as never,
+        provider: "gemini",
+        remote: { apiKey: "placeholder" },
+        model: "gemini-embedding-2-preview",
+        outputDimensionality: 1024,
+        fallback: "none",
+      }),
+    ).rejects.toThrow(/Valid values: 768, 1536, 3072/);
+  });
+
   it("handles legacy and v2 request/response behavior", async () => {
     const fetchMock = installFetchMock((input) => {
       const url = input instanceof URL ? input.href : typeof input === "string" ? input : input.url;

--- a/extensions/google/embedding-provider.ts
+++ b/extensions/google/embedding-provider.ts
@@ -50,7 +50,7 @@ type GeminiTaskType = NonNullable<MemoryEmbeddingProviderCreateOptions["taskType
 
 // --- gemini-embedding-2-preview support ---
 
-export const GEMINI_EMBEDDING_2_MODELS = new Set([
+const GEMINI_EMBEDDING_2_MODELS = new Set([
   "gemini-embedding-2-preview",
   // Add the GA model name here once released.
 ]);
@@ -113,7 +113,7 @@ function readGeminiBatchEmbeddings(
 }
 
 /** Builds the text-only Gemini embedding request shape used across direct and batch APIs. */
-export function buildGeminiTextEmbeddingRequest(params: {
+function buildGeminiTextEmbeddingRequest(params: {
   text: string;
   taskType: GeminiTaskType;
   outputDimensionality?: number;
@@ -158,7 +158,7 @@ export function buildGeminiEmbeddingRequest(params: {
  * Returns true if the given model name is a gemini-embedding-2 variant that
  * supports `outputDimensionality` and extended task types.
  */
-export function isGeminiEmbedding2Model(model: string): boolean {
+function isGeminiEmbedding2Model(model: string): boolean {
   return GEMINI_EMBEDDING_2_MODELS.has(model);
 }
 
@@ -166,10 +166,7 @@ export function isGeminiEmbedding2Model(model: string): boolean {
  * Validate and return the `outputDimensionality` for gemini-embedding-2 models.
  * Returns `undefined` for older models (they don't support the param).
  */
-export function resolveGeminiOutputDimensionality(
-  model: string,
-  requested?: number,
-): number | undefined {
+function resolveGeminiOutputDimensionality(model: string, requested?: number): number | undefined {
   if (!isGeminiEmbedding2Model(model)) {
     return undefined;
   }
@@ -198,7 +195,7 @@ function resolveRemoteApiKey(remoteApiKey: unknown): string | undefined {
   return trimmed;
 }
 
-export function normalizeGeminiModel(model: string): string {
+function normalizeGeminiModel(model: string): string {
   const trimmed = model.trim();
   if (!trimmed) {
     return DEFAULT_GEMINI_EMBEDDING_MODEL;

--- a/extensions/google/google-oauth.test-support.ts
+++ b/extensions/google/google-oauth.test-support.ts
@@ -1,0 +1,53 @@
+type OAuthSettingsFs = {
+  existsSync: (path: string) => boolean;
+  readFileSync: (path: string, encoding: "utf8") => string;
+  homedir: () => string;
+};
+
+type CredentialFs = {
+  existsSync: (path: string) => boolean;
+  readFileSync: (path: string, encoding: "utf8") => string;
+  realpathSync: (path: string) => string;
+  readdirSync: (path: string, options: { withFileTypes: true }) => import("node:fs").Dirent[];
+};
+
+type OAuthCredentialsTestApi = {
+  clearCredentialsCache: () => void;
+  setFs: (overrides?: Partial<CredentialFs>) => void;
+};
+
+type OAuthSettingsTestApi = {
+  setFs: (overrides?: Partial<OAuthSettingsFs>) => void;
+};
+
+type VertexAdcTestApi = {
+  reset: () => void;
+};
+
+function requireTestApi(key: string): unknown {
+  const api = (globalThis as Record<PropertyKey, unknown>)[Symbol.for(key)];
+  if (!api) {
+    throw new Error(`Google test API is unavailable: ${key}`);
+  }
+  return api;
+}
+
+export function clearGoogleOAuthCredentialsCache(): void {
+  (
+    requireTestApi("openclaw.google.oauthCredentialsTestApi") as OAuthCredentialsTestApi
+  ).clearCredentialsCache();
+}
+
+export function setGoogleOAuthCredentialsFs(overrides?: Partial<CredentialFs>): void {
+  (requireTestApi("openclaw.google.oauthCredentialsTestApi") as OAuthCredentialsTestApi).setFs(
+    overrides,
+  );
+}
+
+export function setGoogleOAuthSettingsFs(overrides?: Partial<OAuthSettingsFs>): void {
+  (requireTestApi("openclaw.google.oauthSettingsTestApi") as OAuthSettingsTestApi).setFs(overrides);
+}
+
+export function resetGoogleVertexAdcState(): void {
+  (requireTestApi("openclaw.google.vertexAdcTestApi") as VertexAdcTestApi).reset();
+}

--- a/extensions/google/oauth.credentials.ts
+++ b/extensions/google/oauth.credentials.ts
@@ -22,6 +22,8 @@ const defaultFs: CredentialFs = {
   readdirSync,
 };
 
+const OAUTH_CREDENTIALS_TEST_API_KEY = Symbol.for("openclaw.google.oauthCredentialsTestApi");
+
 let credentialFs: CredentialFs = defaultFs;
 const GEMINI_CLI_TREE_SEARCH_DEPTH = 10;
 
@@ -45,16 +47,16 @@ function resolveEnv(keys: string[]): string | undefined {
 let cachedGeminiCliCredentials: { clientId: string; clientSecret: string } | null = null;
 let geminiCliCredentialExtractError: string | null = null;
 
-export function clearCredentialsCache(): void {
+function clearCredentialsCache(): void {
   cachedGeminiCliCredentials = null;
   geminiCliCredentialExtractError = null;
 }
 
-export function setOAuthCredentialsFsForTest(overrides?: Partial<CredentialFs>): void {
+function setOAuthCredentialsFsForTest(overrides?: Partial<CredentialFs>): void {
   credentialFs = overrides ? { ...defaultFs, ...overrides } : defaultFs;
 }
 
-export function extractGeminiCliCredentials(): { clientId: string; clientSecret: string } | null {
+function extractGeminiCliCredentials(): { clientId: string; clientSecret: string } | null {
   if (cachedGeminiCliCredentials) {
     return cachedGeminiCliCredentials;
   }
@@ -361,4 +363,11 @@ export function resolveOAuthClientConfig(): { clientId: string; clientSecret?: s
   throw new Error(
     `Gemini CLI not found. Install it first: brew install gemini-cli (or npm install -g @google/gemini-cli), or set GEMINI_CLI_OAUTH_CLIENT_ID.${detail}`,
   );
+}
+
+if (process.env.VITEST) {
+  (globalThis as Record<PropertyKey, unknown>)[OAUTH_CREDENTIALS_TEST_API_KEY] = {
+    clearCredentialsCache,
+    setFs: setOAuthCredentialsFsForTest,
+  };
 }

--- a/extensions/google/oauth.settings.ts
+++ b/extensions/google/oauth.settings.ts
@@ -16,6 +16,8 @@ const defaultFs: OAuthSettingsFs = {
   homedir,
 };
 
+const OAUTH_SETTINGS_TEST_API_KEY = Symbol.for("openclaw.google.oauthSettingsTestApi");
+
 let oauthSettingsFs: OAuthSettingsFs = defaultFs;
 
 type GeminiCliAuthSettings = {
@@ -42,11 +44,11 @@ function readSettingsFile(): GeminiCliAuthSettings | null {
   }
 }
 
-export function setOAuthSettingsFsForTest(overrides?: Partial<OAuthSettingsFs>): void {
+function setOAuthSettingsFsForTest(overrides?: Partial<OAuthSettingsFs>): void {
   oauthSettingsFs = overrides ? { ...defaultFs, ...overrides } : defaultFs;
 }
 
-export function resolveGeminiCliSelectedAuthType(): string | undefined {
+function resolveGeminiCliSelectedAuthType(): string | undefined {
   const settings = readSettingsFile();
   if (settings) {
     const security = isRecord(settings.security) ? settings.security : undefined;
@@ -70,4 +72,10 @@ export function resolveGeminiCliSelectedAuthType(): string | undefined {
 
 export function isGeminiCliPersonalOAuth(): boolean {
   return resolveGeminiCliSelectedAuthType() === "oauth-personal";
+}
+
+if (process.env.VITEST) {
+  (globalThis as Record<PropertyKey, unknown>)[OAUTH_SETTINGS_TEST_API_KEY] = {
+    setFs: setOAuthSettingsFsForTest,
+  };
 }

--- a/extensions/google/oauth.test.ts
+++ b/extensions/google/oauth.test.ts
@@ -1,6 +1,11 @@
 // Google tests cover oauth plugin behavior.
 import { join, parse } from "node:path";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  clearGoogleOAuthCredentialsCache,
+  setGoogleOAuthCredentialsFs,
+  setGoogleOAuthSettingsFs,
+} from "./google-oauth.test-support.js";
 
 vi.mock("openclaw/plugin-sdk/runtime-env", async () => {
   const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/runtime-env")>(
@@ -57,16 +62,14 @@ function countMatching<T>(items: readonly T[], predicate: (item: T) => boolean):
   return count;
 }
 
-describe("resolveGeminiCliSelectedAuthType", () => {
+describe("isGeminiCliPersonalOAuth", () => {
   const ENV_KEYS = ["GOOGLE_GENAI_USE_GCA"] as const;
 
   let envSnapshot: Partial<Record<(typeof ENV_KEYS)[number], string>>;
-  let resolveGeminiCliSelectedAuthType: typeof import("./oauth.settings.js").resolveGeminiCliSelectedAuthType;
-  let setOAuthSettingsFsForTest: typeof import("./oauth.settings.js").setOAuthSettingsFsForTest;
+  let isGeminiCliPersonalOAuth: typeof import("./oauth.settings.js").isGeminiCliPersonalOAuth;
 
   beforeAll(async () => {
-    ({ resolveGeminiCliSelectedAuthType, setOAuthSettingsFsForTest } =
-      await import("./oauth.settings.js"));
+    ({ isGeminiCliPersonalOAuth } = await import("./oauth.settings.js"));
   });
 
   beforeEach(() => {
@@ -74,7 +77,7 @@ describe("resolveGeminiCliSelectedAuthType", () => {
     delete process.env.GOOGLE_GENAI_USE_GCA;
     mockSettingsExistsSync.mockReset();
     mockSettingsReadFileSync.mockReset();
-    setOAuthSettingsFsForTest({
+    setGoogleOAuthSettingsFs({
       existsSync: (...args) => mockSettingsExistsSync(...args),
       readFileSync: (...args) => mockSettingsReadFileSync(...args),
       homedir: () => "/mock/home",
@@ -90,14 +93,14 @@ describe("resolveGeminiCliSelectedAuthType", () => {
         process.env[key] = value;
       }
     }
-    setOAuthSettingsFsForTest();
+    setGoogleOAuthSettingsFs();
   });
 
   it("uses GOOGLE_GENAI_USE_GCA as an oauth-personal fallback when settings are absent", () => {
     process.env.GOOGLE_GENAI_USE_GCA = "true";
     mockSettingsExistsSync.mockReturnValue(false);
 
-    expect(resolveGeminiCliSelectedAuthType()).toBe("oauth-personal");
+    expect(isGeminiCliPersonalOAuth()).toBe(true);
   });
 
   it("prefers settings auth selection over the GOOGLE_GENAI_USE_GCA fallback", () => {
@@ -113,7 +116,7 @@ describe("resolveGeminiCliSelectedAuthType", () => {
       }),
     );
 
-    expect(resolveGeminiCliSelectedAuthType()).toBe("oauth-code-assist");
+    expect(isGeminiCliPersonalOAuth()).toBe(false);
   });
 
   it("reads the nested security auth selection from ~/.gemini/settings.json", () => {
@@ -128,7 +131,7 @@ describe("resolveGeminiCliSelectedAuthType", () => {
       }),
     );
 
-    expect(resolveGeminiCliSelectedAuthType()).toBe("oauth-personal");
+    expect(isGeminiCliPersonalOAuth()).toBe(true);
   });
 
   it("falls back to legacy top-level selectedAuthType keys", () => {
@@ -137,11 +140,11 @@ describe("resolveGeminiCliSelectedAuthType", () => {
       JSON.stringify({ selectedAuthType: "oauth-personal" }),
     );
 
-    expect(resolveGeminiCliSelectedAuthType()).toBe("oauth-personal");
+    expect(isGeminiCliPersonalOAuth()).toBe(true);
   });
 });
 
-describe("extractGeminiCliCredentials", () => {
+describe("resolveOAuthClientConfig", () => {
   const ENV_KEYS = [
     "OPENCLAW_GEMINI_OAUTH_CLIENT_ID",
     "OPENCLAW_GEMINI_OAUTH_CLIENT_SECRET",
@@ -160,13 +163,18 @@ describe("extractGeminiCliCredentials", () => {
 
   let originalPath: string | undefined;
   let envSnapshot: Partial<Record<(typeof ENV_KEYS)[number], string>>;
-  let extractGeminiCliCredentials: typeof import("./oauth.credentials.js").extractGeminiCliCredentials;
   let resolveOAuthClientConfig: typeof import("./oauth.credentials.js").resolveOAuthClientConfig;
-  let clearCredentialsCache: typeof import("./oauth.credentials.js").clearCredentialsCache;
-  let setOAuthCredentialsFsForTest: typeof import("./oauth.credentials.js").setOAuthCredentialsFsForTest;
+
+  function resolveExtractedCredentialsOrNull() {
+    try {
+      return resolveOAuthClientConfig();
+    } catch {
+      return null;
+    }
+  }
 
   async function installMockFs() {
-    setOAuthCredentialsFsForTest({
+    setGoogleOAuthCredentialsFs({
       existsSync: (...args) => mockExistsSync(...args),
       readFileSync: (...args) => mockReadFileSync(...args),
       realpathSync: (...args) => mockRealpathSync(...args),
@@ -454,12 +462,7 @@ describe("extractGeminiCliCredentials", () => {
   }
 
   beforeAll(async () => {
-    ({
-      extractGeminiCliCredentials,
-      resolveOAuthClientConfig,
-      clearCredentialsCache,
-      setOAuthCredentialsFsForTest,
-    } = await import("./oauth.credentials.js"));
+    ({ resolveOAuthClientConfig } = await import("./oauth.credentials.js"));
   });
 
   beforeEach(async () => {
@@ -482,22 +485,22 @@ describe("extractGeminiCliCredentials", () => {
         process.env[key] = value;
       }
     }
-    setOAuthCredentialsFsForTest();
+    setGoogleOAuthCredentialsFs();
   });
 
   it("returns null when gemini binary is not in PATH", () => {
     process.env.PATH = "/nonexistent";
     mockExistsSync.mockReturnValue(false);
 
-    clearCredentialsCache();
-    expect(extractGeminiCliCredentials()).toBeNull();
+    clearGoogleOAuthCredentialsCache();
+    expect(resolveExtractedCredentialsOrNull()).toBeNull();
   });
 
   it("includes missing binary details when resolving OAuth client config", async () => {
     process.env.PATH = "/nonexistent";
     mockExistsSync.mockReturnValue(false);
 
-    clearCredentialsCache();
+    clearGoogleOAuthCredentialsCache();
     expect(() => resolveOAuthClientConfig()).toThrow(
       /Details: Gemini CLI binary was not found in PATH/,
     );
@@ -506,8 +509,8 @@ describe("extractGeminiCliCredentials", () => {
   it("extracts credentials from oauth2.js in known path", () => {
     installGeminiLayout({ oauth2Exists: true, oauth2Content: FAKE_OAUTH2_CONTENT });
 
-    clearCredentialsCache();
-    const result = extractGeminiCliCredentials();
+    clearGoogleOAuthCredentialsCache();
+    const result = resolveExtractedCredentialsOrNull();
 
     expectFakeCliCredentials(result);
   });
@@ -515,8 +518,8 @@ describe("extractGeminiCliCredentials", () => {
   it("extracts credentials when PATH entry is an npm global shim", () => {
     installNpmShimLayout({ oauth2Exists: true, oauth2Content: FAKE_OAUTH2_CONTENT });
 
-    clearCredentialsCache();
-    const result = extractGeminiCliCredentials();
+    clearGoogleOAuthCredentialsCache();
+    const result = resolveExtractedCredentialsOrNull();
 
     expectFakeCliCredentials(result);
   });
@@ -529,8 +532,8 @@ describe("extractGeminiCliCredentials", () => {
       `,
     });
 
-    clearCredentialsCache();
-    const result = extractGeminiCliCredentials();
+    clearGoogleOAuthCredentialsCache();
+    const result = resolveExtractedCredentialsOrNull();
 
     expectFakeCliCredentials(result);
   });
@@ -538,8 +541,8 @@ describe("extractGeminiCliCredentials", () => {
   it("extracts credentials from Homebrew libexec installs", () => {
     installHomebrewLibexecLayout({ oauth2Content: FAKE_OAUTH2_CONTENT });
 
-    clearCredentialsCache();
-    const result = extractGeminiCliCredentials();
+    clearGoogleOAuthCredentialsCache();
+    const result = resolveExtractedCredentialsOrNull();
 
     expectFakeCliCredentials(result);
   });
@@ -547,14 +550,14 @@ describe("extractGeminiCliCredentials", () => {
   it("returns null when oauth2.js cannot be found", () => {
     installGeminiLayout({ oauth2Exists: false, readdir: [] });
 
-    clearCredentialsCache();
-    expect(extractGeminiCliCredentials()).toBeNull();
+    clearGoogleOAuthCredentialsCache();
+    expect(resolveExtractedCredentialsOrNull()).toBeNull();
   });
 
   it("includes missing oauth2.js details when resolving OAuth client config", async () => {
     installGeminiLayout({ oauth2Exists: false, readdir: [] });
 
-    clearCredentialsCache();
+    clearGoogleOAuthCredentialsCache();
     expect(() => resolveOAuthClientConfig()).toThrow(/Could not locate oauth2\.js/);
     expect(() => resolveOAuthClientConfig()).toThrow(/recursiveSearchDepth=10/);
   });
@@ -562,8 +565,8 @@ describe("extractGeminiCliCredentials", () => {
   it("returns null when oauth2.js lacks credentials", () => {
     installGeminiLayout({ oauth2Exists: true, oauth2Content: "// no credentials here" });
 
-    clearCredentialsCache();
-    expect(extractGeminiCliCredentials()).toBeNull();
+    clearGoogleOAuthCredentialsCache();
+    expect(resolveExtractedCredentialsOrNull()).toBeNull();
   });
 
   it("includes parse failure details when resolving OAuth client config", async () => {
@@ -573,7 +576,7 @@ describe("extractGeminiCliCredentials", () => {
       readdir: [],
     });
 
-    clearCredentialsCache();
+    clearGoogleOAuthCredentialsCache();
     expect(() => resolveOAuthClientConfig()).toThrow(
       /Candidate credential files did not contain a parseable OAuth client id\/secret/,
     );
@@ -585,7 +588,7 @@ describe("extractGeminiCliCredentials", () => {
       throw new Error("mock read failure");
     });
 
-    clearCredentialsCache();
+    clearGoogleOAuthCredentialsCache();
     expect(() => resolveOAuthClientConfig()).toThrow(
       /Unexpected errors occurred while reading candidate credential files\/directories/,
     );
@@ -595,15 +598,15 @@ describe("extractGeminiCliCredentials", () => {
   it("caches credentials after first extraction", () => {
     installGeminiLayout({ oauth2Exists: true, oauth2Content: FAKE_OAUTH2_CONTENT });
 
-    clearCredentialsCache();
+    clearGoogleOAuthCredentialsCache();
 
     // First call
-    const result1 = extractGeminiCliCredentials();
+    const result1 = resolveExtractedCredentialsOrNull();
     expectFakeCliCredentials(result1);
 
     // Second call should use cache (readFileSync not called again)
     const readCount = mockReadFileSync.mock.calls.length;
-    const result2 = extractGeminiCliCredentials();
+    const result2 = resolveExtractedCredentialsOrNull();
     expect(result2).toEqual(result1);
     expect(mockReadFileSync.mock.calls.length).toBe(readCount);
   });
@@ -614,8 +617,8 @@ describe("extractGeminiCliCredentials", () => {
       unrelatedOauth2Content: "// unrelated oauth file",
     });
 
-    clearCredentialsCache();
-    const result = extractGeminiCliCredentials();
+    clearGoogleOAuthCredentialsCache();
+    const result = resolveExtractedCredentialsOrNull();
 
     expectFakeCliCredentials(result);
     expect(
@@ -869,10 +872,9 @@ describe("loginGeminiCliOAuth", () => {
   });
 
   let envSnapshot: Partial<Record<(typeof ENV_KEYS)[number], string>>;
-  let setOAuthSettingsFsForTest: typeof import("./oauth.settings.js").setOAuthSettingsFsForTest;
 
   beforeAll(async () => {
-    ({ setOAuthSettingsFsForTest } = await import("./oauth.settings.js"));
+    await import("./oauth.settings.js");
   });
 
   beforeEach(() => {
@@ -886,7 +888,7 @@ describe("loginGeminiCliOAuth", () => {
     delete process.env.GOOGLE_GENAI_USE_GCA;
     mockSettingsExistsSync.mockReset();
     mockSettingsReadFileSync.mockReset();
-    setOAuthSettingsFsForTest({
+    setGoogleOAuthSettingsFs({
       existsSync: (...args) => mockSettingsExistsSync(...args),
       readFileSync: (...args) => mockSettingsReadFileSync(...args),
       homedir: () => "/mock/home",
@@ -903,7 +905,7 @@ describe("loginGeminiCliOAuth", () => {
         process.env[key] = value;
       }
     }
-    setOAuthSettingsFsForTest();
+    setGoogleOAuthSettingsFs();
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
   });

--- a/extensions/google/oauth.ts
+++ b/extensions/google/oauth.ts
@@ -1,6 +1,5 @@
 // Google plugin module implements oauth behavior.
 import type { OAuthCredential } from "openclaw/plugin-sdk/provider-auth";
-import { clearCredentialsCache, extractGeminiCliCredentials } from "./oauth.credentials.js";
 import {
   buildAuthUrl,
   generateOAuthState,
@@ -11,9 +10,6 @@ import {
 } from "./oauth.flow.js";
 import type { GeminiCliOAuthContext, GeminiCliOAuthCredentials } from "./oauth.shared.js";
 import { exchangeCodeForTokens, refreshTokensForGeminiCli } from "./oauth.token.js";
-
-export { clearCredentialsCache, extractGeminiCliCredentials };
-export type { GeminiCliOAuthContext, GeminiCliOAuthCredentials };
 
 export async function loginGeminiCliOAuth(
   ctx: GeminiCliOAuthContext,

--- a/extensions/google/speech-provider.test.ts
+++ b/extensions/google/speech-provider.test.ts
@@ -18,12 +18,11 @@ const {
 } = getProviderHttpMocks();
 
 let buildGoogleSpeechProvider: typeof import("./speech-provider.js").buildGoogleSpeechProvider;
-let testing: typeof import("./speech-provider.js").testing;
 
 const GOOGLE_TTS_JSON_CAP_BYTES = 16 * 1024 * 1024;
 
 beforeAll(async () => {
-  ({ buildGoogleSpeechProvider, testing } = await import("./speech-provider.js"));
+  ({ buildGoogleSpeechProvider } = await import("./speech-provider.js"));
 });
 
 installProviderHttpMockCleanup();
@@ -166,7 +165,7 @@ describe("Google speech provider", () => {
     expect(result.voiceCompatible).toBe(false);
     expect(result.audioBuffer.subarray(0, 4).toString("ascii")).toBe("RIFF");
     expect(result.audioBuffer.subarray(8, 12).toString("ascii")).toBe("WAVE");
-    expect(result.audioBuffer.readUInt32LE(24)).toBe(testing.GOOGLE_TTS_SAMPLE_RATE);
+    expect(result.audioBuffer.readUInt32LE(24)).toBe(24_000);
     expect(result.audioBuffer.subarray(44)).toEqual(Buffer.from([1, 0, 2, 0]));
     expect(transcodeAudioBufferToOpusMock).not.toHaveBeenCalled();
   });
@@ -242,7 +241,11 @@ describe("Google speech provider", () => {
   it("advertises all documented Gemini TTS-capable models", () => {
     const provider = buildGoogleSpeechProvider();
 
-    expect(provider.models).toEqual(testing.GOOGLE_TTS_MODELS);
+    expect(provider.models).toEqual([
+      "gemini-3.1-flash-tts-preview",
+      "gemini-2.5-flash-preview-tts",
+      "gemini-2.5-pro-preview-tts",
+    ]);
   });
 
   it("renders deterministic audio-profile-v1 prompts without generating tags", async () => {

--- a/extensions/google/speech-provider.ts
+++ b/extensions/google/speech-provider.ts
@@ -663,15 +663,3 @@ export function buildGoogleSpeechProvider(): SpeechProviderPlugin {
     },
   };
 }
-
-export const testing = {
-  DEFAULT_GOOGLE_TTS_MODEL,
-  DEFAULT_GOOGLE_TTS_VOICE,
-  GOOGLE_AUDIO_PROFILE_PROMPT_TEMPLATE,
-  GOOGLE_TTS_MODELS,
-  GOOGLE_TTS_SAMPLE_RATE,
-  normalizeGoogleTtsModel,
-  renderGoogleAudioProfilePrompt,
-  wrapPcm16MonoToWav,
-};
-export { testing as __testing };

--- a/extensions/google/transport-stream.test.ts
+++ b/extensions/google/transport-stream.test.ts
@@ -6,6 +6,7 @@ import { gzipSync } from "node:zlib";
 import { expectDefined } from "@openclaw/normalization-core";
 import type { Model } from "openclaw/plugin-sdk/llm";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { resetGoogleVertexAdcState } from "./google-oauth.test-support.js";
 
 const {
   buildGuardedModelFetchMock,
@@ -36,13 +37,9 @@ vi.mock("google-auth-library", () => ({
 }));
 
 let buildGoogleGenerativeAiParams: typeof import("./transport-stream.js").buildGoogleGenerativeAiParams;
-let buildGoogleGemini3FirstResponseRetryParams: typeof import("./transport-stream.js").buildGoogleGemini3FirstResponseRetryParams;
 let createGoogleGenerativeAiTransportStreamFn: typeof import("./transport-stream.js").createGoogleGenerativeAiTransportStreamFn;
 let createGoogleVertexTransportStreamFn: typeof import("./transport-stream.js").createGoogleVertexTransportStreamFn;
-let resolveGoogleGemini3FirstResponseRetryMs: typeof import("./transport-stream.js").resolveGoogleGemini3FirstResponseRetryMs;
-let hasGoogleVertexAuthorizedUserAdcSync: typeof import("./vertex-adc.js").hasGoogleVertexAuthorizedUserAdcSync;
 let resolveGoogleVertexAuthorizedUserHeaders: typeof import("./vertex-adc.js").resolveGoogleVertexAuthorizedUserHeaders;
-let resetGoogleVertexAuthorizedUserTokenCacheForTest: typeof import("./vertex-adc.js").resetGoogleVertexAuthorizedUserTokenCacheForTest;
 
 const MODEL_PROVIDER_REQUEST_TRANSPORT_SYMBOL = Symbol.for(
   "openclaw.modelProviderRequestTransport",
@@ -327,16 +324,10 @@ describe("google transport stream", () => {
   beforeAll(async () => {
     ({
       buildGoogleGenerativeAiParams,
-      buildGoogleGemini3FirstResponseRetryParams,
       createGoogleGenerativeAiTransportStreamFn,
       createGoogleVertexTransportStreamFn,
-      resolveGoogleGemini3FirstResponseRetryMs,
     } = await import("./transport-stream.js"));
-    ({
-      hasGoogleVertexAuthorizedUserAdcSync,
-      resolveGoogleVertexAuthorizedUserHeaders,
-      resetGoogleVertexAuthorizedUserTokenCacheForTest,
-    } = await import("./vertex-adc.js"));
+    ({ resolveGoogleVertexAuthorizedUserHeaders } = await import("./vertex-adc.js"));
   });
 
   beforeEach(() => {
@@ -345,7 +336,7 @@ describe("google transport stream", () => {
     googleAuthGetAccessTokenMock.mockReset();
     googleAuthMock.mockClear();
     buildGuardedModelFetchMock.mockReturnValue(guardedFetchMock);
-    resetGoogleVertexAuthorizedUserTokenCacheForTest();
+    resetGoogleVertexAdcState();
   });
 
   afterEach(() => {
@@ -861,41 +852,6 @@ describe("google transport stream", () => {
     expect(result.content[2]).toEqual({ type: "text", text: "answer" });
   });
 
-  it("builds a lean Gemini 3 first-response retry payload", () => {
-    const model = buildGeminiModel({
-      id: "gemini-3.1-pro-preview",
-      name: "Gemini 3.1 Pro Preview",
-    });
-    const retryPayload = buildGoogleGemini3FirstResponseRetryParams({
-      model,
-      request: {
-        contents: [{ role: "user", parts: [{ text: "hello" }] }],
-        generationConfig: {
-          thinkingConfig: {
-            includeThoughts: true,
-            thinkingLevel: "HIGH",
-          },
-        },
-      },
-    });
-
-    expect(retryPayload?.generationConfig).toEqual({
-      thinkingConfig: {
-        thinkingLevel: "LOW",
-      },
-    });
-  });
-
-  it("rejects non-integer Gemini 3 first-response retry env values", () => {
-    const envName = "OPENCLAW_GOOGLE_GEMINI_FIRST_RESPONSE_RETRY_MS";
-
-    expect(resolveGoogleGemini3FirstResponseRetryMs({ [envName]: "1200" })).toBe(1200);
-    expect(resolveGoogleGemini3FirstResponseRetryMs({ [envName]: "0" })).toBe(0);
-    expect(resolveGoogleGemini3FirstResponseRetryMs({ [envName]: "0x10" })).toBe(45_000);
-    expect(resolveGoogleGemini3FirstResponseRetryMs({ [envName]: "100.5" })).toBe(45_000);
-    expect(resolveGoogleGemini3FirstResponseRetryMs({ [envName]: "1e3" })).toBe(45_000);
-  });
-
   it("wraps malformed Gemini SSE JSON", async () => {
     guardedFetchMock.mockResolvedValueOnce(buildRawSseResponse("data: {not json\n\n"));
 
@@ -1099,26 +1055,41 @@ describe("google transport stream", () => {
     });
   });
 
-  it("detects supported Vertex ADC sources synchronously", async () => {
-    const tempDir = await mkdtemp(path.join(os.tmpdir(), "openclaw-google-vertex-adc-detect-"));
-    for (const type of ["authorized_user", "external_account", "service_account"]) {
-      const credentialsPath = path.join(tempDir, `${type}.json`);
-      await writeFile(credentialsPath, JSON.stringify({ type }), "utf8");
+  it.each([
+    ["eu", "https://aiplatform.eu.rep.googleapis.com"],
+    ["us", "https://aiplatform.us.rep.googleapis.com"],
+  ])(
+    "routes the %s Vertex multi-region through the production stream",
+    async (location, origin) => {
+      const tempDir = await mkdtemp(path.join(os.tmpdir(), "openclaw-google-vertex-region-"));
+      vi.stubEnv("GOOGLE_APPLICATION_CREDENTIALS", "");
+      vi.stubEnv("HOME", path.join(tempDir, "home"));
+      vi.stubEnv("APPDATA", "");
+      vi.stubEnv("GOOGLE_CLOUD_PROJECT", "demo");
+      vi.stubEnv("GOOGLE_CLOUD_LOCATION", location);
+      googleAuthGetAccessTokenMock.mockResolvedValueOnce("oauth-token");
+      guardedFetchMock.mockResolvedValueOnce(buildSseResponse([]));
+      const streamFn = createGoogleVertexTransportStreamFn();
+      const stream = await Promise.resolve(
+        streamFn(
+          buildGoogleVertexModel(),
+          { messages: [{ role: "user", content: "hello", timestamp: 0 }] } as Parameters<
+            typeof streamFn
+          >[1],
+          {
+            apiKey: "gcp-vertex-credentials",
+            fetch: vi.fn(),
+          } as Parameters<typeof streamFn>[2],
+        ),
+      );
+      await stream.result();
 
-      expect(
-        hasGoogleVertexAuthorizedUserAdcSync({
-          GOOGLE_APPLICATION_CREDENTIALS: credentialsPath,
-        }),
-      ).toBe(true);
-    }
-
-    expect(
-      hasGoogleVertexAuthorizedUserAdcSync({
-        HOME: path.join(tempDir, "empty-home"),
-        KUBERNETES_SERVICE_HOST: "10.0.0.1",
-      }),
-    ).toBe(false);
-  });
+      const [url] = requireMockCall(guardedFetchMock, 0, "guarded fetch");
+      expect(String(url)).toBe(
+        `${origin}/v1/projects/demo/locations/${location}/publishers/google/models/gemini-3.1-pro-preview:streamGenerateContent?alt=sse`,
+      );
+    },
+  );
 
   it("resolves non-file Vertex ADC through google-auth-library without OAuth refresh fetch", async () => {
     const tempDir = await mkdtemp(path.join(os.tmpdir(), "openclaw-google-vertex-authlib-"));
@@ -1303,8 +1274,6 @@ describe("google transport stream", () => {
         },
       ]),
     );
-
-    expect(hasGoogleVertexAuthorizedUserAdcSync()).toBe(true);
 
     const model = buildGoogleVertexModel();
 
@@ -1578,8 +1547,6 @@ describe("google transport stream", () => {
         },
       ]),
     );
-
-    expect(hasGoogleVertexAuthorizedUserAdcSync()).toBe(true);
 
     const streamFn = createGoogleVertexTransportStreamFn();
     const stream = await Promise.resolve(

--- a/extensions/google/transport-stream.ts
+++ b/extensions/google/transport-stream.ts
@@ -367,10 +367,7 @@ function resolveGoogleVertexLocation(options: GoogleTransportOptions | undefined
   return location;
 }
 
-export function resolveGoogleVertexBaseOrigin(
-  model: GoogleTransportModel,
-  location: string,
-): string {
+function resolveGoogleVertexBaseOrigin(model: GoogleTransportModel, location: string): string {
   const configured = normalizeOptionalString(model.baseUrl);
   if (configured && !configured.includes("{location}")) {
     try {
@@ -884,7 +881,7 @@ function isOfficialGoogleGenerativeAiBaseUrl(baseUrl: string | undefined): boole
   }
 }
 
-export function resolveGoogleGemini3FirstResponseRetryMs(env = process.env): number {
+function resolveGoogleGemini3FirstResponseRetryMs(env = process.env): number {
   const raw = env[GOOGLE_GEMINI3_FIRST_RESPONSE_RETRY_ENV];
   if (raw === undefined || raw.trim() === "") {
     return GOOGLE_GEMINI3_FIRST_RESPONSE_RETRY_DEFAULT_MS;
@@ -922,7 +919,7 @@ function cloneGoogleGenerateContentRequest(
   return JSON.parse(serialized) as GoogleGenerateContentRequest;
 }
 
-export function buildGoogleGemini3FirstResponseRetryParams(params: {
+function buildGoogleGemini3FirstResponseRetryParams(params: {
   model: GoogleTransportModel;
   request: GoogleGenerateContentRequest;
 }): GoogleGenerateContentRequest | undefined {

--- a/extensions/google/vertex-adc.ts
+++ b/extensions/google/vertex-adc.ts
@@ -51,6 +51,7 @@ const GOOGLE_VERTEX_TOKEN_EXPIRY_BUFFER_MS = 60_000;
 const GOOGLE_VERTEX_DEFAULT_TOKEN_LIFETIME_SECONDS = 3600;
 const GOOGLE_VERTEX_AUTHLIB_TOKEN_CACHE_MS = 5 * 60_000;
 const GOOGLE_OAUTH_TOKEN_RESPONSE_MAX_BYTES = 1024 * 1024;
+const VERTEX_ADC_TEST_API_KEY = Symbol.for("openclaw.google.vertexAdcTestApi");
 
 let cachedGoogleVertexAuthorizedUserToken: GoogleVertexAuthorizedUserToken | undefined;
 let cachedGoogleAuthClient:
@@ -94,10 +95,16 @@ function resolveGoogleAuthLibraryTokenExpiresAtMs(nowRaw = Date.now()): number |
     : resolveExpiresAtMsFromDurationMs(GOOGLE_VERTEX_AUTHLIB_TOKEN_CACHE_MS, { nowMs });
 }
 
-export function resetGoogleVertexAuthorizedUserTokenCacheForTest(): void {
+function resetGoogleVertexAuthorizedUserTokenCacheForTest(): void {
   cachedGoogleVertexAuthorizedUserToken = undefined;
   cachedGoogleAuthClient = undefined;
   cachedGoogleVertexAdcToken = undefined;
+}
+
+if (process.env.VITEST) {
+  (globalThis as Record<PropertyKey, unknown>)[VERTEX_ADC_TEST_API_KEY] = {
+    reset: resetGoogleVertexAuthorizedUserTokenCacheForTest,
+  };
 }
 
 export function isGoogleVertexCredentialsMarker(
@@ -194,9 +201,7 @@ function readGoogleAdcCredentialsTypeSync(credentialsPath: string): string | und
  * probes the default metadata hosts asynchronously at request time, and the
  * provider wires the Vertex transport without this sync predicate.
  */
-export function hasGoogleVertexAuthorizedUserAdcSync(
-  env: NodeJS.ProcessEnv = process.env,
-): boolean {
+function hasGoogleVertexAuthorizedUserAdcSync(env: NodeJS.ProcessEnv = process.env): boolean {
   const credentialsPath = resolveGoogleApplicationCredentialsPath(env);
   if (credentialsPath) {
     const type = readGoogleAdcCredentialsTypeSync(credentialsPath);

--- a/extensions/google/vertex-multi-region-host.test.ts
+++ b/extensions/google/vertex-multi-region-host.test.ts
@@ -1,54 +1,5 @@
-import type { Model } from "openclaw/plugin-sdk/llm";
 import { describe, expect, it } from "vitest";
 import { isGoogleVertexHostname } from "./provider-policy.js";
-import { resolveGoogleVertexBaseOrigin } from "./transport-stream.js";
-
-// Minimal Vertex model whose baseUrl carries the {location} template, so the
-// base-origin resolver falls through to location-based host construction
-// (the configured-baseUrl early return only fires for a literal host).
-function buildModel(overrides: Partial<Model<"google-vertex">> = {}): Model<"google-vertex"> {
-  return {
-    id: "gemini-3.5-flash",
-    name: "Gemini 3.5 Flash",
-    api: "google-vertex",
-    provider: "google-vertex",
-    baseUrl: "https://{location}-aiplatform.googleapis.com",
-    reasoning: true,
-    input: ["text"],
-    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-    contextWindow: 128000,
-    maxTokens: 8192,
-    ...overrides,
-  };
-}
-
-describe("Google Vertex multi-region host construction", () => {
-  const model = buildModel();
-
-  it("routes the eu multi-region to the dedicated .rep.googleapis.com host", () => {
-    expect(resolveGoogleVertexBaseOrigin(model, "eu")).toBe(
-      "https://aiplatform.eu.rep.googleapis.com",
-    );
-  });
-
-  it("routes the us multi-region to the dedicated .rep.googleapis.com host", () => {
-    expect(resolveGoogleVertexBaseOrigin(model, "us")).toBe(
-      "https://aiplatform.us.rep.googleapis.com",
-    );
-  });
-
-  it("keeps the unprefixed host for the global location", () => {
-    expect(resolveGoogleVertexBaseOrigin(model, "global")).toBe(
-      "https://aiplatform.googleapis.com",
-    );
-  });
-
-  it("keeps the regional prefix for normal regions", () => {
-    expect(resolveGoogleVertexBaseOrigin(model, "europe-west1")).toBe(
-      "https://europe-west1-aiplatform.googleapis.com",
-    );
-  });
-});
 
 describe("Google Vertex hostname recognition", () => {
   it("recognizes the multi-region rep host as a Vertex host", () => {

--- a/extensions/xai/realtime-voice-config.ts
+++ b/extensions/xai/realtime-voice-config.ts
@@ -18,7 +18,7 @@ import { XAI_BASE_URL } from "./model-definitions.js";
 type XaiRealtimeVoice = "eve" | "ara" | "rex" | "sal" | "leo";
 type XaiRealtimeReasoningEffort = "high" | "none";
 
-export type XaiRealtimeVoiceProviderConfig = {
+type XaiRealtimeVoiceProviderConfig = {
   apiKey?: string;
   baseUrl?: string;
   model?: string;

--- a/extensions/xai/stream.test.ts
+++ b/extensions/xai/stream.test.ts
@@ -9,11 +9,7 @@ import {
 } from "openclaw/plugin-sdk/llm";
 import { describe, expect, it } from "vitest";
 import { applyXaiRuntimeModelCompat } from "./runtime-model-compat.js";
-import {
-  createXaiFastModeWrapper,
-  createXaiToolPayloadCompatibilityWrapper,
-  wrapXaiProviderStream,
-} from "./stream.js";
+import { wrapXaiProviderStream } from "./stream.js";
 import {
   createXaiPayloadCaptureStream,
   expectXaiFastToolStreamShaping,
@@ -60,8 +56,11 @@ function captureWrappedModelId(params: {
     return {} as ReturnType<StreamFn>;
   };
 
-  const wrapped = createXaiFastModeWrapper(baseStreamFn, params.fastMode);
-  void wrapped(
+  const wrapped = wrapXaiProviderStream({
+    streamFn: baseStreamFn,
+    extraParams: { fastMode: params.fastMode, tool_stream: false },
+  } as never);
+  void wrapped?.(
     {
       api: params.api ?? "openai-responses",
       provider: params.provider ?? "xai",
@@ -85,10 +84,13 @@ function runXaiToolPayloadWrapper(params: {
     options?.onPayload?.(params.payload, {} as Model<XaiStreamApi>);
     return {} as ReturnType<StreamFn>;
   };
-  const wrapped = createXaiToolPayloadCompatibilityWrapper(baseStreamFn);
+  const wrapped = wrapXaiProviderStream({
+    streamFn: baseStreamFn,
+    extraParams: { tool_stream: false },
+  } as never);
   const api = params.api ?? "openai-responses";
 
-  void wrapped(
+  void wrapped?.(
     {
       api,
       provider: params.provider ?? "xai",
@@ -182,16 +184,19 @@ describe("xai stream wrappers", () => {
       } as unknown as ReturnType<StreamFn>;
     };
     let enabled = true;
-    const wrapped = createXaiFastModeWrapper(baseStreamFn, () => enabled);
+    const wrapped = wrapXaiProviderStream({
+      streamFn: baseStreamFn,
+      extraParams: { fastMode: () => enabled, tool_stream: false },
+    } as never);
     const model = {
       api: "openai-responses",
       provider: "xai",
       id: "grok-4",
     } as Model<XaiStreamApi>;
 
-    void wrapped(model, { messages: [] } as Context, {});
+    void wrapped?.(model, { messages: [] } as Context, {});
     enabled = false;
-    void wrapped(model, { messages: [] } as Context, {});
+    void wrapped?.(model, { messages: [] } as Context, {});
 
     expect(capturedModelIds).toEqual(["grok-4-fast", "grok-4"]);
   });
@@ -391,9 +396,12 @@ describe("xai stream wrappers", () => {
       options?.onPayload?.(payload, model);
       return {} as ReturnType<StreamFn>;
     };
-    const wrapped = createXaiToolPayloadCompatibilityWrapper(baseStreamFn);
+    const wrapped = wrapXaiProviderStream({
+      streamFn: baseStreamFn,
+      extraParams: { tool_stream: false },
+    } as never);
 
-    void wrapped(
+    void wrapped?.(
       {
         api: "openai-responses",
         provider: "xai",
@@ -421,9 +429,12 @@ describe("xai stream wrappers", () => {
         options?.onPayload?.(payload, model);
         return {} as ReturnType<StreamFn>;
       };
-      const wrapped = createXaiToolPayloadCompatibilityWrapper(baseStreamFn);
+      const wrapped = wrapXaiProviderStream({
+        streamFn: baseStreamFn,
+        extraParams: { tool_stream: false },
+      } as never);
 
-      void wrapped(
+      void wrapped?.(
         {
           api: "openai-responses",
           provider,

--- a/extensions/xai/stream.ts
+++ b/extensions/xai/stream.ts
@@ -214,9 +214,7 @@ function normalizeXaiResponsesToolResultPayload(
   payloadObj.input = normalizedInput;
 }
 
-export function createXaiToolPayloadCompatibilityWrapper(
-  baseStreamFn: StreamFn | undefined,
-): StreamFn {
+function createXaiToolPayloadCompatibilityWrapper(baseStreamFn: StreamFn | undefined): StreamFn {
   const underlying = baseStreamFn ?? streamSimple;
   return (model, context, options) => {
     const originalOnPayload = options?.onPayload;
@@ -241,7 +239,7 @@ export function createXaiToolPayloadCompatibilityWrapper(
   };
 }
 
-export function createXaiFastModeWrapper(
+function createXaiFastModeWrapper(
   baseStreamFn: StreamFn | undefined,
   fastMode: DynamicFastMode,
 ): StreamFn {

--- a/extensions/xai/stt.test.ts
+++ b/extensions/xai/stt.test.ts
@@ -1,6 +1,6 @@
 // Xai tests cover stt plugin behavior.
 import { describe, expect, it, vi } from "vitest";
-import { buildXaiMediaUnderstandingProvider, transcribeXaiAudio } from "./stt.js";
+import { buildXaiMediaUnderstandingProvider } from "./stt.js";
 
 const { postTranscriptionRequestMock } = vi.hoisted(() => ({
   postTranscriptionRequestMock: vi.fn(
@@ -49,7 +49,8 @@ vi.mock("openclaw/plugin-sdk/provider-http", async (importOriginal) => {
 
 describe("xai stt", () => {
   it("posts audio files to the xAI STT endpoint", async () => {
-    const result = await transcribeXaiAudio({
+    const provider = buildXaiMediaUnderstandingProvider();
+    const result = await provider.transcribeAudio?.({
       buffer: Buffer.from("audio-bytes"),
       fileName: "sample.wav",
       mime: "audio/wav",

--- a/extensions/xai/stt.ts
+++ b/extensions/xai/stt.ts
@@ -23,7 +23,7 @@ function resolveXaiSttBaseUrl(value?: string): string {
   return normalizeOptionalString(value ?? process.env.XAI_BASE_URL) ?? XAI_BASE_URL;
 }
 
-export async function transcribeXaiAudio(
+async function transcribeXaiAudio(
   params: AudioTranscriptionRequest,
 ): Promise<AudioTranscriptionResult> {
   const fetchFn = params.fetchFn ?? fetch;

--- a/extensions/xai/tts.test.ts
+++ b/extensions/xai/tts.test.ts
@@ -1,13 +1,9 @@
 // Xai tests cover tts plugin behavior.
 import { mockPinnedHostnameResolution } from "openclaw/plugin-sdk/test-env";
 import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
-import type { RawData } from "ws";
 import {
-  assertXaiNativeTtsStreamEndpoint,
-  decodeWebSocketTextMessage,
   isValidXaiTtsVoice,
   listXaiTtsVoices,
-  toXaiTtsWsUrl,
   XAI_BASE_URL,
   XAI_TTS_FALLBACK_VOICES,
   xaiTTS,
@@ -138,53 +134,6 @@ describe("xai tts", () => {
     });
   });
 
-  describe("decodeWebSocketTextMessage", () => {
-    it("decodes supported WebSocket payload shapes", () => {
-      expect(decodeWebSocketTextMessage(Buffer.from('{"type":"audio.done"}'))).toBe(
-        '{"type":"audio.done"}',
-      );
-      expect(decodeWebSocketTextMessage(Buffer.from("buf", "utf8"))).toBe("buf");
-      expect(decodeWebSocketTextMessage(new TextEncoder().encode("view").buffer)).toBe("view");
-      expect(decodeWebSocketTextMessage([Buffer.from("a"), Buffer.from("b")])).toBe("ab");
-    });
-
-    it("rejects unsupported WebSocket payload shapes", () => {
-      expect(() => decodeWebSocketTextMessage(42 as unknown as RawData)).toThrow(
-        "unsupported WebSocket message payload",
-      );
-    });
-  });
-
-  describe("assertXaiNativeTtsStreamEndpoint", () => {
-    it("accepts the native api.x.ai host", () => {
-      expect(() => assertXaiNativeTtsStreamEndpoint(XAI_BASE_URL)).not.toThrow();
-    });
-
-    it("rejects the native host over HTTP", () => {
-      expect(() => assertXaiNativeTtsStreamEndpoint("http://api.x.ai/v1")).toThrow(
-        'only supports HTTPS for the native api.x.ai endpoint; got protocol "http:"',
-      );
-    });
-
-    it("rejects non-native streaming hosts", () => {
-      expect(() => assertXaiNativeTtsStreamEndpoint("https://proxy.example/v1")).toThrow(
-        'only supports the native api.x.ai endpoint; got host "proxy.example"',
-      );
-    });
-
-    it.each([
-      "https://api.x.ai:8443/v1",
-      ["https://user", "password@api.x.ai/v1"].join(":"),
-      "https://api.x.ai/custom",
-      "https://api.x.ai/v1?existing=value",
-      "https://api.x.ai/v1#fragment",
-    ])("rejects non-canonical native endpoint shape %s", (baseUrl) => {
-      expect(() => assertXaiNativeTtsStreamEndpoint(baseUrl)).toThrow(
-        `requires the canonical ${XAI_BASE_URL} base URL`,
-      );
-    });
-  });
-
   describe("listXaiTtsVoices", () => {
     it("maps the authenticated catalog and sends the expected request", async () => {
       vi.stubEnv("OPENCLAW_VERSION", "2026.7.9");
@@ -289,26 +238,6 @@ describe("xai tts", () => {
     });
   });
 
-  describe("toXaiTtsWsUrl", () => {
-    it("builds a websocket URL with voice, language, codec, and speed", () => {
-      const url = new URL(
-        toXaiTtsWsUrl({
-          baseUrl: XAI_BASE_URL,
-          voiceId: "eve",
-          language: "en",
-          responseFormat: "mp3",
-          speed: 1.1,
-        }),
-      );
-      expect(url.protocol).toBe("wss:");
-      expect(url.pathname).toBe("/v1/tts");
-      expect(url.searchParams.get("voice")).toBe("eve");
-      expect(url.searchParams.get("language")).toBe("en");
-      expect(url.searchParams.get("codec")).toBe("mp3");
-      expect(url.searchParams.get("speed")).toBe("1.1");
-    });
-  });
-
   describe("xaiTTSStream", () => {
     it("streams decoded audio chunks without buffering the full body", async () => {
       const resultPromise = xaiTTSStream({
@@ -318,11 +247,18 @@ describe("xai tts", () => {
         voiceId: "eve",
         language: "en",
         responseFormat: "mp3",
+        speed: 1.1,
         timeoutMs: 5_000,
         maxBytes: 3_000,
       });
       const ws = FakeWebSocket.instances.at(0);
-      expect(ws?.url).toContain("wss://api.x.ai/v1/tts");
+      const wsUrl = new URL(ws?.url ?? "");
+      expect(wsUrl.protocol).toBe("wss:");
+      expect(wsUrl.pathname).toBe("/v1/tts");
+      expect(wsUrl.searchParams.get("voice")).toBe("eve");
+      expect(wsUrl.searchParams.get("language")).toBe("en");
+      expect(wsUrl.searchParams.get("codec")).toBe("mp3");
+      expect(wsUrl.searchParams.get("speed")).toBe("1.1");
       expect(ws?.headers?.Authorization).toBe(["Bearer", "dummy"].join(" "));
       expect(ws?.maxPayload).toBe(5_024);
       ws?.emit("open");
@@ -464,6 +400,25 @@ describe("xai tts", () => {
           timeoutMs: 5_000,
         }),
       ).rejects.toThrow("only supports HTTPS for the native api.x.ai endpoint");
+      expect(FakeWebSocket.instances).toHaveLength(0);
+    });
+
+    it.each([
+      "https://api.x.ai:8443/v1",
+      ["https://user", "password@api.x.ai/v1"].join(":"),
+      "https://api.x.ai/custom",
+      "https://api.x.ai/v1?existing=value",
+      "https://api.x.ai/v1#fragment",
+    ])("rejects non-canonical native endpoint shape %s", async (baseUrl) => {
+      await expect(
+        xaiTTSStream({
+          text: "hello",
+          apiKey: "dummy",
+          baseUrl,
+          voiceId: "eve",
+          timeoutMs: 5_000,
+        }),
+      ).rejects.toThrow(`requires the canonical ${XAI_BASE_URL} base URL`);
       expect(FakeWebSocket.instances).toHaveLength(0);
     });
 

--- a/extensions/xai/tts.ts
+++ b/extensions/xai/tts.ts
@@ -104,7 +104,7 @@ type XaiTtsStreamServerEvent = {
   message?: string;
 };
 
-export function toXaiTtsWsUrl(params: {
+function toXaiTtsWsUrl(params: {
   baseUrl: string;
   voiceId: string;
   language: string;
@@ -138,7 +138,7 @@ function parseXaiTtsStreamBaseUrl(baseUrl: string): URL {
   }
 }
 
-export function assertXaiNativeTtsStreamEndpoint(baseUrl: string): void {
+function assertXaiNativeTtsStreamEndpoint(baseUrl: string): void {
   const url = parseXaiTtsStreamBaseUrl(baseUrl);
   if (url.protocol !== "https:") {
     throw new Error(
@@ -157,7 +157,7 @@ export function assertXaiNativeTtsStreamEndpoint(baseUrl: string): void {
   }
 }
 
-export function decodeWebSocketTextMessage(data: RawData): string {
+function decodeWebSocketTextMessage(data: RawData): string {
   if (typeof data === "string") {
     return data;
   }

--- a/extensions/xai/xai-oauth.test.ts
+++ b/extensions/xai/xai-oauth.test.ts
@@ -9,14 +9,12 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   createXaiDeviceCodeAuthMethod,
   createXaiOAuthAuthMethod,
-  fetchXaiOAuthDiscovery,
-  isTrustedXaiOAuthEndpoint,
-  loginXaiDeviceCode,
   refreshXaiOAuthCredential,
-  XAI_OAUTH_CLIENT_ID,
-  XAI_OAUTH_DISCOVERY_URL,
-  XAI_OAUTH_SCOPE,
 } from "./xai-oauth.js";
+
+const XAI_OAUTH_CLIENT_ID = "b1a00492-073a-47ea-816f-4c329264a828";
+const XAI_OAUTH_SCOPE = "openid profile email offline_access grok-cli:access api:access";
+const XAI_OAUTH_DISCOVERY_URL = "https://auth.x.ai/.well-known/openid-configuration";
 
 function jsonResponse(value: unknown, init?: ResponseInit): Response {
   return new Response(JSON.stringify(value), {
@@ -56,14 +54,6 @@ describe("xAI OAuth", () => {
     vi.useRealTimers();
   });
 
-  it("accepts only trusted xAI OAuth endpoints", () => {
-    expect(isTrustedXaiOAuthEndpoint("https://auth.x.ai/oauth2/token")).toBe(true);
-    expect(isTrustedXaiOAuthEndpoint("https://accounts.x.ai/oauth2/token")).toBe(true);
-    expect(isTrustedXaiOAuthEndpoint("http://auth.x.ai/oauth2/token")).toBe(false);
-    expect(isTrustedXaiOAuthEndpoint("https://x.ai.evil.test/oauth2/token")).toBe(false);
-    expect(isTrustedXaiOAuthEndpoint("not a url")).toBe(false);
-  });
-
   it("keeps the public auth method named OAuth while using device code", () => {
     const method = createXaiOAuthAuthMethod();
 
@@ -83,34 +73,25 @@ describe("xAI OAuth", () => {
     expect(method.wizard?.assistantVisibility).toBe("manual-only");
   });
 
-  it("validates discovered endpoints before using them", async () => {
-    vi.stubEnv("OPENCLAW_VERSION", "2026.3.22");
-    const fetchImpl = vi.fn<typeof fetch>(async () =>
-      jsonResponse({
-        authorization_endpoint: "https://auth.x.ai/oauth2/authorize",
-        token_endpoint: "https://auth.x.ai/oauth2/token",
-      }),
-    );
-
-    await expect(fetchXaiOAuthDiscovery({ fetchImpl })).resolves.toEqual({
-      tokenEndpoint: "https://auth.x.ai/oauth2/token",
-    });
-
-    const discoveryInit = fetchImpl.mock.calls.at(0)?.[1];
-    const discoveryHeaders = new Headers(discoveryInit?.headers ?? {});
-    expect(discoveryHeaders.get("user-agent")).toBe("openclaw/2026.3.22");
-    vi.unstubAllEnvs();
-
+  it("rejects untrusted discovered endpoints through credential refresh", async () => {
     const poisonedFetch = vi.fn<typeof fetch>(async () =>
       jsonResponse({
         authorization_endpoint: "https://auth.x.ai/oauth2/authorize",
         token_endpoint: "https://evil.test/oauth2/token",
       }),
     );
+    const credential = {
+      type: "oauth",
+      provider: "xai",
+      access: "access-1",
+      refresh: "refresh-1",
+      expires: 100,
+      tokenEndpoint: "https://auth.x.ai/oauth/token",
+    } satisfies OAuthCredential & { tokenEndpoint: string };
 
-    await expect(fetchXaiOAuthDiscovery({ fetchImpl: poisonedFetch })).rejects.toThrow(
-      "untrusted token endpoint",
-    );
+    await expect(
+      refreshXaiOAuthCredential(credential, { fetchImpl: poisonedFetch }),
+    ).rejects.toThrow("untrusted token endpoint");
   });
 
   it("refreshes with the cached token endpoint and preserves refresh fallback", async () => {
@@ -477,7 +458,7 @@ describe("xAI OAuth", () => {
       },
     };
 
-    const result = await loginXaiDeviceCode(ctx);
+    const result = await createXaiOAuthAuthMethod().run(ctx);
 
     expect(openUrl).toHaveBeenCalledWith("https://accounts.x.ai/oauth2/device?user_code=ABCD-1234");
     expect(deviceCode).toHaveBeenCalledWith({
@@ -571,7 +552,7 @@ describe("xAI OAuth", () => {
       },
     };
 
-    await loginXaiDeviceCode(ctx);
+    await createXaiOAuthAuthMethod().run(ctx);
 
     expect(note).toHaveBeenCalledWith(
       expect.stringContaining("Code expires in 5 minutes."),

--- a/extensions/xai/xai-oauth.ts
+++ b/extensions/xai/xai-oauth.ts
@@ -22,10 +22,10 @@ const XAI_OAUTH_METHOD_ID = "oauth";
 const XAI_OAUTH_CHOICE_ID = "xai-oauth";
 const XAI_DEVICE_CODE_METHOD_ID = "device-code";
 const XAI_DEVICE_CODE_CHOICE_ID = "xai-device-code";
-export const XAI_OAUTH_CLIENT_ID = "b1a00492-073a-47ea-816f-4c329264a828";
-export const XAI_OAUTH_SCOPE = "openid profile email offline_access grok-cli:access api:access";
+const XAI_OAUTH_CLIENT_ID = "b1a00492-073a-47ea-816f-4c329264a828";
+const XAI_OAUTH_SCOPE = "openid profile email offline_access grok-cli:access api:access";
 const XAI_OAUTH_ISSUER = "https://auth.x.ai";
-export const XAI_OAUTH_DISCOVERY_URL = `${XAI_OAUTH_ISSUER}/.well-known/openid-configuration`;
+const XAI_OAUTH_DISCOVERY_URL = `${XAI_OAUTH_ISSUER}/.well-known/openid-configuration`;
 const XAI_LEGACY_OAUTH_TOKEN_ENDPOINT = `${XAI_OAUTH_ISSUER}/oauth/token`;
 
 const XAI_OAUTH_TIMEOUT_MS = 5 * 60 * 1000;
@@ -94,7 +94,7 @@ function getFetchImpl(fetchImpl?: typeof fetch): typeof fetch {
   return fetchImpl ?? fetch;
 }
 
-export function isTrustedXaiOAuthEndpoint(endpoint: string): boolean {
+function isTrustedXaiOAuthEndpoint(endpoint: string): boolean {
   try {
     const url = new URL(endpoint);
     if (url.protocol !== "https:") {
@@ -158,7 +158,7 @@ async function fetchXaiOAuthDiscoveryDocument(
   return readStringRecord(await readJsonResponse(response, "xAI OAuth discovery"));
 }
 
-export async function fetchXaiOAuthDiscovery(
+async function fetchXaiOAuthDiscovery(
   options: XaiOAuthFetchOptions = {},
 ): Promise<XaiOAuthDiscovery> {
   const json = await fetchXaiOAuthDiscoveryDocument(options);
@@ -612,7 +612,7 @@ async function noteXaiDeviceCode(
   );
 }
 
-export async function loginXaiDeviceCode(ctx: ProviderAuthContext): Promise<ProviderAuthResult> {
+async function loginXaiDeviceCode(ctx: ProviderAuthContext): Promise<ProviderAuthResult> {
   const progress = ctx.prompter.progress("Starting xAI OAuth...");
   try {
     const discovery = await fetchXaiDeviceCodeDiscovery(

--- a/test/scripts/check-deadcode-exports.test.ts
+++ b/test/scripts/check-deadcode-exports.test.ts
@@ -41,6 +41,7 @@ describe("check-deadcode-exports", () => {
   });
 
   it.each([
+    "acpx",
     "amazon-bedrock-mantle",
     "azure-speech",
     "cloudflare-ai-gateway",
@@ -49,9 +50,11 @@ describe("check-deadcode-exports", () => {
     "elevenlabs",
     "featherless",
     "fireworks",
+    "google",
     "huggingface",
     "kilocode",
     "kimi-coding",
+    "lmstudio",
     "microsoft",
     "minimax",
     "mistral",
@@ -65,6 +68,7 @@ describe("check-deadcode-exports", () => {
     "tencent",
     "vllm",
     "xiaomi",
+    "xai",
   ])("removes the bundled-plugin root catch-all from migrated %s workspace", (pluginId) => {
     const workspace = (
       knipConfig.workspaces as Record<string, { readonly entry: readonly string[] }>


### PR DESCRIPTION
## Summary

- make ACPX, Google, LM Studio, and xAI use strict bundled-plugin Knip roots
- remove or privatize 32 previously hidden Google and xAI exports
- preserve OAuth, embedding, Vertex, speech, streaming, and xAI behavior through retained production boundaries

## Evidence

- production unused-export Knip: 0 entries
- dead-code config regression tests: 42 passed
- ACPX: 166 tests passed
- Google, xAI, and LM Studio: 900 tests passed
- type-aware lint, extension types, core types, and test types passed
- fresh autoreview completed; one sanitizer-only module-name artifact rejected after verifying the real imports match the real test-support filename

## Metrics

- production source and config: net reduction; full patch 318 additions, 432 deletions
- baseline: absent on current main; hard-zero gate remains enforced
