### PR TITLE
fix(release): retry empty live provider responses

### DIFF
--- a/scripts/ci-live-command-retry.sh
+++ b/scripts/ci-live-command-retry.sh
@@ -14,9 +14,9 @@ fi
 attempts="${OPENCLAW_LIVE_COMMAND_ATTEMPTS:-2}"
 delay_seconds="${OPENCLAW_LIVE_COMMAND_RETRY_DELAY_SECONDS:-10}"
 rate_limit_delay_seconds="${OPENCLAW_LIVE_COMMAND_RATE_LIMIT_RETRY_DELAY_SECONDS:-60}"
-# Live provider 5xx responses and one-off test timeouts get one retry; deterministic
-# hangs still fail the second attempt. Keep auth and input failures fail-fast.
-retry_pattern="${OPENCLAW_LIVE_COMMAND_RETRY_PATTERN:-ECONNRESET|ETIMEDOUT|ENOTFOUND|EAI_AGAIN|fetch failed|TLS connection|socket hang up|UND_ERR|gateway request timeout|HTTP 5[0-9][0-9]|Test timed out in [0-9]+ms|terminal timeout after [0-9]+ms|MiniMax image generation API error \\(1000\\)|model idle timeout|did not produce a response before the model idle timeout|\\b429\\b|\\b529\\b}"
+# Live provider 5xx responses, empty responses, and one-off test timeouts get one
+# retry; deterministic failures still fail the second attempt. Keep auth and input failures fail-fast.
+retry_pattern="${OPENCLAW_LIVE_COMMAND_RETRY_PATTERN:-ECONNRESET|ETIMEDOUT|ENOTFOUND|EAI_AGAIN|fetch failed|TLS connection|socket hang up|UND_ERR|gateway request timeout|HTTP 5[0-9][0-9]|expected 0 to be greater than 0|Test timed out in [0-9]+ms|terminal timeout after [0-9]+ms|MiniMax image generation API error \\(1000\\)|model idle timeout|did not produce a response before the model idle timeout|\\b429\\b|\\b529\\b}"
 rate_limit_pattern="${OPENCLAW_LIVE_COMMAND_RATE_LIMIT_PATTERN:-Rate limit reached|rate.?limit|tokens per min|requests per min|\\bTPM\\b|\\bRPM\\b}"
 
 if ! [[ "$attempts" =~ ^[1-9][0-9]*$ ]]; then

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -1782,6 +1782,7 @@ describe("package artifact reuse", () => {
     expect(workflow).toContain("inputs.live_suite_filter == 'native-live-extensions-media-video'");
     expect(workflow).not.toContain("needs_ffmpeg: true");
     expect(retryHelper).toContain("OPENCLAW_LIVE_COMMAND_ATTEMPTS:-2");
+    expect(retryHelper).toContain("expected 0 to be greater than 0");
     expect(retryHelper).toContain("ECONNRESET");
     expect(retryHelper).toContain("fetch failed");
     expect(retryHelper).toContain("gateway request timeout");


### PR DESCRIPTION
## What Problem This Solves

Full Release Validation run #29459405489 failed its native live-agent shard after Z.AI returned structurally valid responses with no assistant text for two models. The same provider test had timed out and then passed on the existing retry in current-main Release Checks run #29457978136, showing this is another transient live-provider response shape rather than a Docker or candidate regression.

## Why This Change Was Made

The trusted live-command wrapper already retries transient provider failures once. Extend that existing classifier to recognize the exact Vitest empty-text assertion. A persistent empty response still fails on the second attempt, while auth, input, and unrelated deterministic failures remain fail-fast.

## User Impact

No runtime, package, provider adapter, or release-candidate behavior changes. Release validation gets one bounded retry when a live provider returns an empty assistant response, reducing false-negative release failures without weakening the final gate.

## Evidence

- Failing release parent: https://github.com/openclaw/openclaw/actions/runs/29459405489
- Root-cause child/job: https://github.com/openclaw/openclaw/actions/runs/29461289518/job/87505441327
- Earlier retry-then-pass child: https://github.com/openclaw/openclaw/actions/runs/29457978136/job/87495631453
- `bash -n scripts/ci-live-command-retry.sh`
- Behavioral shell proof: the empty-text assertion retries once and succeeds on attempt 2; an unrelated deterministic exit 7 runs once and remains exit 7.
- `git diff --check`
- Focused Vitest was attempted through `node scripts/run-vitest.mjs test/scripts/package-acceptance-workflow.test.ts`, but the fresh worktree has no dependencies (`ERR_MODULE_NOT_FOUND: p-map`); PR CI owns that remaining proof.
