### PR TITLE
fix(onboarding): save OAuth credentials on fresh installs

### DIFF
--- a/src/system-agent/setup-inference.test.ts
+++ b/src/system-agent/setup-inference.test.ts
@@ -1796,6 +1796,98 @@ describe("activateSetupInference", () => {
     }
   });
 
+  it("persists provider OAuth when runtime config materializes an empty auth shell", async () => {
+    const stateDir = await makeTempDir();
+    const agentDir = path.join(stateDir, "agent");
+    const sourceConfig = {
+      agents: { list: [{ id: "main", default: true, agentDir }] },
+    } satisfies OpenClawConfig;
+    const runtimeConfig = {
+      ...sourceConfig,
+      auth: { profiles: {} },
+    } satisfies OpenClawConfig;
+    resolveAgentDir(sourceConfig, "main");
+    const runAuth = vi.fn(async () => ({
+      profiles: [
+        {
+          profileId: "openai:default",
+          credential: {
+            type: "oauth" as const,
+            provider: "openai",
+            access: "access-token",
+            refresh: "refresh-token",
+            expires: Date.now() + 60_000,
+          },
+        },
+      ],
+      defaultModel: "openai/gpt-5.6-sol",
+      configPatch: {
+        agents: { defaults: { models: { "openai/gpt-5.6-sol": {} } } },
+      },
+    }));
+    const provider: ProviderPlugin = {
+      id: "openai",
+      label: "OpenAI",
+      pluginId: "openai",
+      auth: [{ id: "oauth", label: "OAuth", kind: "oauth", run: runAuth }],
+    };
+    const runEmbeddedAgent = vi.fn(
+      async (params: SuccessfulRunParams & { authProfileId?: string }) =>
+        successfulRun("openai", "gpt-5.6-sol", params),
+    );
+    const configHarness = createConfigTransformHarness(sourceConfig, runtimeConfig);
+
+    try {
+      const result = await activateSetupInference({
+        kind: "provider-auth",
+        authChoice: "openai",
+        workspace: "/tmp/openclaw-workspace",
+        surface: "gateway",
+        runtime,
+        prompter: { note: vi.fn(async () => {}) } as never,
+        deps: {
+          readConfigFileSnapshot: vi.fn(async () => ({
+            exists: true,
+            valid: true,
+            path: "/tmp/openclaw.json",
+            issues: [],
+            config: runtimeConfig,
+            sourceConfig,
+            runtimeConfig,
+          })) as never,
+          resolvePluginProviders: () => [provider],
+          resolveManifestProviderAuthChoice: () => ({
+            pluginId: "openai",
+            providerId: "openai",
+            methodId: "oauth",
+            choiceId: "openai",
+            choiceLabel: "ChatGPT Login",
+            appGuidedAuth: "oauth",
+          }),
+          runEmbeddedAgent: runEmbeddedAgent as never,
+          transformConfigWithPendingPluginInstalls: configHarness.transform as never,
+          createTempDir: makeTempDir,
+        },
+      });
+
+      expect(result).toMatchObject({ ok: true, modelRef: "openai/gpt-5.6-sol" });
+      const activatedProfileId = runEmbeddedAgent.mock.calls[0]?.[0].authProfileId;
+      if (!activatedProfileId) {
+        throw new Error("expected setup auth profile");
+      }
+      expect(configHarness.current()).toMatchObject({
+        agents: { defaults: { model: `openai/gpt-5.6-sol@${activatedProfileId}` } },
+        auth: {
+          profiles: {
+            [activatedProfileId]: { provider: "openai", mode: "oauth" },
+          },
+        },
+      });
+    } finally {
+      await removeOAuthTestTempRoot(stateDir);
+    }
+  });
+
   it("does not probe or persist an interactive login after session cancellation", async () => {
     const runAuth = vi.fn(async () => ({ profiles: [], defaultModel: "openai/gpt-5.5" }));
     const runEmbeddedAgent = vi.fn();

--- a/src/system-agent/setup-inference.ts
+++ b/src/system-agent/setup-inference.ts
@@ -1651,7 +1651,21 @@ async function activateSetupInferenceUnredacted(
             ...(plan.manualAuth && plan.authProfileId ? { authProfileId: plan.authProfileId } : {}),
           })
         : undefined;
-      const stageCandidate = (current: OpenClawConfig): OpenClawConfig => {
+      let manualAuthSourceBase = sourceCfg;
+      if (plan.manualAuth?.pluginId) {
+        const enableResult = (deps.enablePluginInConfig ?? enablePluginInConfig)(
+          sourceCfg,
+          plan.manualAuth.pluginId,
+        );
+        if (!enableResult.enabled) {
+          throw new Error(`Provider plugin ${plan.manualAuth.pluginId} is ${enableResult.reason}.`);
+        }
+        manualAuthSourceBase = enableResult.config;
+      }
+      const stageCandidate = (
+        current: OpenClawConfig,
+        options: { manualAuthConflictBase?: OpenClawConfig } = {},
+      ): OpenClawConfig => {
         let next =
           codexPluginPatch === undefined ? current : stripPendingPluginInstallRecords(current);
         if (plan.manualAuth) {
@@ -1659,6 +1673,7 @@ async function activateSetupInferenceUnredacted(
             next,
             plan.manualAuth,
             deps.enablePluginInConfig ?? enablePluginInConfig,
+            options.manualAuthConflictBase,
           );
         }
         if (codexPluginPatch !== undefined) {
@@ -1697,7 +1712,7 @@ async function activateSetupInferenceUnredacted(
       // absent from authored config. Compare source writes against the candidate
       // produced from the original source shape, without ignoring concurrent rows.
       const expectedSourceCandidateRoute = await projectDefaultInferenceRoute(
-        stageCandidate(sourceCfg),
+        stageCandidate(sourceCfg, { manualAuthConflictBase: manualAuthSourceBase }),
       );
       // Resolve every fallible config-commit dependency before writing a
       // credential into the real agent store. From this point onward, any
@@ -1805,7 +1820,9 @@ async function activateSetupInferenceUnredacted(
                 "The authored target model metadata changed during its live inference test, so the verified candidate was not saved. Review the current model settings and retry.",
               );
             }
-            const nextConfig = stageCandidate(current);
+            const nextConfig = stageCandidate(current, {
+              manualAuthConflictBase: manualAuthSourceBase,
+            });
             const nextRouteProjection = await projectDefaultInferenceRoute(nextConfig);
             const nextResolvedRoute = await resolveSystemAgentConfiguredRouteFromConfig(nextConfig);
             if (
@@ -2501,6 +2518,7 @@ function applyManualAuthConfig(
   config: OpenClawConfig,
   manualAuth: NonNullable<SetupInferenceTestPlan["manualAuth"]>,
   enablePlugin: typeof enablePluginInConfig = enablePluginInConfig,
+  conflictBase: OpenClawConfig = manualAuth.configBase,
 ): OpenClawConfig {
   let enabledConfig = config;
   if (manualAuth.pluginId) {
@@ -2510,7 +2528,7 @@ function applyManualAuthConfig(
     }
     enabledConfig = enableResult.config;
   }
-  if (mergePatchConflicts(manualAuth.configBase, enabledConfig, manualAuth.configPatch)) {
+  if (mergePatchConflicts(conflictBase, enabledConfig, manualAuth.configPatch)) {
     throw new Error(
       "Provider configuration changed during the live inference test, so the verified credential was not saved. Review the current provider settings and retry.",
     );


### PR DESCRIPTION
Closes #108526

AI-assisted: yes

## What Problem This Solves

Fresh `2026.7.2-beta.1` installs can complete ChatGPT OAuth and the live inference probe, then fail before the verified credential is saved:

```
Provider configuration changed during the live inference test, so the verified credential was not saved. Review the current provider settings and retry.
```

The failure stops onboarding before gateway setup.

## Why This Change Was Made

Runtime normalization can materialize `auth.profiles` while the authored config omits `auth`. Manual-auth activation used the normalized config as its conflict baseline, then compared it with the authored source at commit time. The shape difference was reported as a provider edit.

This change keeps separate runtime and authored-source baselines. The live probe still rejects provider changes against the latest runtime config. The config commit also rejects edits against the original authored source. Applying the verified patch no longer compares a normalized object shell with a source-only omission.

## User Impact

Fresh installs can finish ChatGPT OAuth when runtime defaults add empty config containers. Provider or model changes made during the live probe still stop credential persistence.

## Evidence

- Regression range: absent from `2026.7.1`; present in `2026.7.2-beta.1` (`a911e58`).
- VPS reproduction before the production change: the new regression test failed with the reported configuration-change error; the other 106 tests passed.
- VPS focused test on the rebased PR head: `107 passed`.
- VPS `pnpm build`: passed, including declarations, plugin SDK exports, runtime postbuild, UI, and startup metadata.
- VPS `pnpm check`: typechecks, lint, formatting, import-cycle checks, and all relevant guards passed. The existing temp-path guard still reports unchanged `src/gateway/worker-environments/workspace-reconcile.ts`.
- VPS `pnpm test`: the exhaustive monorepo run kept the onboarding coverage green. Unrelated VPS-only failures appeared in gateway worktree/SSH timing tests, workspace quiescence scripts, and Vitest workers under memory pressure; the run was stopped after those failures were recorded.
- Repository autoreview: clean, with no accepted or actionable findings.

<details>
<summary>Sanitized implementation transcript</summary>

> User: The beta is installed on a secondary VPS. Monitor onboarding and help prepare a fix if it fails.

> Onboarding: ChatGPT OAuth completed, then OpenClaw reported that provider configuration changed during the live inference test and did not save the verified credential.

> User: Run the full test suite and prepare a stable PR. Include the transcript, with real credentials and OAuth details removed.

> Investigation: The authored config omitted `auth`; runtime normalization materialized `auth.profiles` as an empty object. A regression test reproduced the same rollback before any production change.

> Review: An early comparator change weakened the reverse conflict case and was discarded. A second draft skipped the authored-source conflict check and was also discarded.

> Final change: Keep the runtime conflict check, capture an authored-source baseline, and validate the source being committed against that baseline.

> Verification: The focused test passed after the final change. The repository build, static checks, full tests, and autoreview were run against the PR branch.

Redacted: OAuth URLs and callback values, credentials, account identifiers, host addresses, local paths, SSH details, and raw tool output.

</details>
