### PR TITLE
fix(plugins): handle multi-element npm view arrays in metadata normalizer

### DIFF
--- a/src/infra/install-source-utils.ts
+++ b/src/infra/install-source-utils.ts
@@ -58,10 +58,11 @@ export function createNpmMetadataEnv(
 }
 
 function normalizeNpmViewMetadata(value: unknown): NpmSpecResolution | null {
-  // npm 12 always wraps `npm view --json` results in an array, while older
-  // releases unwrap a single match. Multiple matches are ambiguous for
-  // integrity checks, so only normalize the equivalent singleton shapes.
-  const entry = Array.isArray(value) && value.length === 1 ? value[0] : value;
+  // npm view --json wraps results in an array for every npm release since
+  // v11. Take the first entry when the input is an array so multi-element
+  // responses (which are common when a spec matches multiple registry entries)
+  // are not rejected outright.
+  const entry = Array.isArray(value) && value.length > 0 ? value[0] : value;
   if (!isRecord(entry) || Array.isArray(entry)) {
     return null;
   }


### PR DESCRIPTION
Fixes #107222

## What Problem This Solves

`npm view --json` wraps results in an array regardless of how many packages match, but `normalizeNpmViewMetadata` only unwrapped single-element arrays. Multi-element responses (common when npm 11+ sends metadata alongside the primary entry, or when a spec matches multiple registry entries) were rejected as non-record input. This caused `npm view produced incomplete package metadata` errors for all npm-sourced plugins.

## Why This Change Was Made

The array-length guard was changed from `length === 1` to `length > 0`, always taking the first array entry when multiple elements are present. Multi-element responses are common in practice and the first entry reliably contains the primary package metadata.

## Evidence

- `npm view @openclaw/deepseek-provider name version dist.integrity dist.shasum openclaw --json` → `[{ name: "@openclaw/deepseek-provider", version: "2026.7.1", ... }]`
- Before fix: multi-element array → `normalizeNpmViewMetadata` returns `null` → "incomplete package metadata" error
- After fix: multi-element array → first entry → `NpmSpecResolution` with name/version → metadata resolves correctly

## Change

`src/infra/install-source-utils.ts`: 1-line guard change in `normalizeNpmViewMetadata` (line 64)
