### PR TITLE
chore(qa): remove retired Matrix package guards

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,7 +129,6 @@
     "!dist/extensions/pixverse/**",
     "!dist/extensions/qa-channel/**",
     "!dist/extensions/qa-lab/**",
-    "!dist/extensions/qa-matrix/**",
     "!dist/extensions/openshell/**",
     "!dist/extensions/qwen/**",
     "!dist/extensions/searxng/**",

--- a/src/infra/package-dist-inventory.test.ts
+++ b/src/infra/package-dist-inventory.test.ts
@@ -83,13 +83,6 @@ describe("package dist inventory", () => {
       );
       const omittedQaChunk = path.join(packageRoot, "dist", "extensions", "qa-channel", "cli.js");
       const omittedQaLabChunk = path.join(packageRoot, "dist", "extensions", "qa-lab", "cli.js");
-      const omittedQaMatrixChunk = path.join(
-        packageRoot,
-        "dist",
-        "extensions",
-        "qa-matrix",
-        "index.js",
-      );
       const omittedQaLabPluginSdk = path.join(packageRoot, "dist", "plugin-sdk", "qa-lab.js");
       const omittedQaChannelPluginSdk = path.join(
         packageRoot,
@@ -132,7 +125,6 @@ describe("package dist inventory", () => {
       const omittedMap = path.join(packageRoot, "dist", "feature.runtime.js.map");
       await fs.mkdir(path.dirname(packagedQaChannelRuntime), { recursive: true });
       await fs.mkdir(path.dirname(packagedQaLabRuntime), { recursive: true });
-      await fs.mkdir(path.dirname(omittedQaMatrixChunk), { recursive: true });
       await fs.mkdir(path.dirname(omittedQaLabTypes), { recursive: true });
       await fs.mkdir(path.join(packageRoot, "dist", "plugin-sdk"), { recursive: true });
       await fs.mkdir(path.dirname(omittedDeepPluginSdkDeclaration), { recursive: true });
@@ -140,7 +132,6 @@ describe("package dist inventory", () => {
       await fs.writeFile(packagedQaLabRuntime, "export {};\n", "utf8");
       await fs.writeFile(omittedQaChunk, "export {};\n", "utf8");
       await fs.writeFile(omittedQaLabChunk, "export {};\n", "utf8");
-      await fs.writeFile(omittedQaMatrixChunk, "export {};\n", "utf8");
       await fs.writeFile(omittedQaLabPluginSdk, "export {};\n", "utf8");
       await fs.writeFile(omittedQaChannelPluginSdk, "export {};\n", "utf8");
       await fs.writeFile(omittedQaChannelProtocolPluginSdk, "export {};\n", "utf8");

--- a/src/infra/package-dist-inventory.ts
+++ b/src/infra/package-dist-inventory.ts
@@ -13,7 +13,6 @@ const LEGACY_QA_LAB_DIR = ["qa", "lab"].join("-");
 const OMITTED_QA_EXTENSION_PREFIXES = [
   `dist/extensions/${LEGACY_QA_CHANNEL_DIR}/`,
   `dist/extensions/${LEGACY_QA_LAB_DIR}/`,
-  "dist/extensions/qa-matrix/",
 ];
 const OMITTED_PRIVATE_QA_PLUGIN_SDK_PREFIXES = [
   `dist/plugin-sdk/extensions/${LEGACY_QA_CHANNEL_DIR}/`,
@@ -72,7 +71,6 @@ const OMITTED_PLUGIN_SDK_TEST_PREFIXES = [
 const OMITTED_DIST_SUBTREE_PATTERNS = [
   /^dist\/extensions\/node_modules(?:\/|$)/u,
   /^dist\/extensions\/[^/]+\/node_modules(?:\/|$)/u,
-  /^dist\/extensions\/qa-matrix(?:\/|$)/u,
   /^dist\/plugin-sdk\/src(?:\/|$)/u,
   new RegExp(`^dist/plugin-sdk/extensions/${LEGACY_QA_CHANNEL_DIR}(?:/|$)`, "u"),
   new RegExp(`^dist/plugin-sdk/extensions/${LEGACY_QA_LAB_DIR}(?:/|$)`, "u"),

--- a/test/scripts/bundled-plugin-build-entries.test.ts
+++ b/test/scripts/bundled-plugin-build-entries.test.ts
@@ -162,10 +162,8 @@ describe("bundled plugin build entries", () => {
   });
 
   it("keeps private QA bundles out of required npm pack artifacts", () => {
-    const entries = listBundledPluginBuildEntries();
     const artifacts = listBundledPluginPackArtifacts();
 
-    expectNoPrefixMatches(Object.keys(entries), "extensions/qa-matrix/");
     expectNoPrefixMatches(artifacts, "dist/extensions/qa-channel/");
     expectNoPrefixMatches(artifacts, "dist/extensions/qa-lab/");
   });


### PR DESCRIPTION
Related: #103589

## What Problem This Solves

The completed Matrix QA migration removed the private `qa-matrix` plugin, but current package assembly still carried explicit exclusions, inventory omissions, and a build-entry assertion for that deleted source tree. Those retired special cases made the package path maintain an owner that can no longer produce build entries.

## Why This Change Was Made

Remove only current-output `qa-matrix` package and inventory guards. Tracked-file plugin discovery already excludes deleted directories generically. Historical tarball compatibility, release-workflow Matrix lane selectors, public docs redirects, and release records remain unchanged because they still serve distinct contracts.

## User Impact

There is no runtime or messaging behavior change. Maintainers get a smaller package contract without a hard-coded denylist for a retired private plugin.

This PR is AI-assisted; the change and its ownership boundaries were reviewed against the repository instructions and current package/build callers.

## Evidence

- `node scripts/run-vitest.mjs src/infra/package-dist-inventory.test.ts test/scripts/bundled-plugin-build-entries.test.ts` — 2 files / 36 tests passed before commit and again after the patch-identical rebase.
- Blacksmith Testbox `tbx_01kxm61ahpv3zmqy4h4r792z4a` — remote `check:changed` and full `pnpm build` passed: https://github.com/openclaw/openclaw/actions/runs/29462205090
- `git diff --check origin/main...HEAD` passed.
- Rebase patch identity remained `238c12d6ea6fbe763611d2fb62ceb1ea501fb6da`.
- Fresh `.agents/skills/autoreview/scripts/autoreview --mode uncommitted` completed cleanly with no accepted/actionable findings.
