### PR TITLE
fix(qa-lab): failed evidence no longer fulfills scorecard coverage

### DIFF
--- a/extensions/qa-lab/src/scorecard-evidence.test.ts
+++ b/extensions/qa-lab/src/scorecard-evidence.test.ts
@@ -3,21 +3,28 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
-import type { QaEvidenceSummaryJson, QaEvidenceSummaryEntry } from "./evidence-summary.js";
+import {
+  validateQaEvidenceSummaryJson,
+  type QaEvidenceSummaryJson,
+  type QaEvidenceSummaryEntry,
+} from "./evidence-summary.js";
 import { attachQaProfileScorecardEvidenceToFile } from "./scorecard-evidence.js";
 import type { QaScorecardCategoryCoverageReport } from "./scorecard-taxonomy.js";
 
-function evidenceEntry(coverage: QaEvidenceSummaryEntry["coverage"]): QaEvidenceSummaryEntry {
+function evidenceEntry(
+  coverage: QaEvidenceSummaryEntry["coverage"],
+  status: QaEvidenceSummaryEntry["result"]["status"] = "pass",
+): QaEvidenceSummaryEntry {
   return {
     test: {
       kind: "flow",
-      id: "partial-coverage",
-      title: "Partial coverage",
+      id: `${status}-coverage`,
+      title: `${status} coverage`,
     },
     coverage,
     refs: [],
     result: {
-      status: "pass",
+      status,
     },
   };
 }
@@ -32,6 +39,23 @@ function evidenceSummary(entries: QaEvidenceSummaryEntry[]): QaEvidenceSummaryJs
   };
 }
 
+function categoryInventory(coverageIds: string[]): QaScorecardCategoryCoverageReport {
+  return {
+    id: "surface.category",
+    taxonomySurfaceId: "surface",
+    taxonomyCategoryName: "Category",
+    coverageStatus: "covered",
+    profiles: ["release"],
+    features: coverageIds.map((coverageId) => ({ name: coverageId, coverageIds: [coverageId] })),
+    coverageIds,
+    fulfilledCoverageIds: coverageIds,
+    evidence: [],
+    scenarioRefs: [],
+    missingCoverageIds: [],
+    missingEvidenceRefs: [],
+  };
+}
+
 async function buildQaProfileScorecardEvidence(params: {
   evidence: QaEvidenceSummaryJson;
   filters: { surface?: string; category?: string };
@@ -41,12 +65,16 @@ async function buildQaProfileScorecardEvidence(params: {
   const evidencePath = path.join(tempRoot, "qa-evidence-summary.json");
   await fs.writeFile(evidencePath, `${JSON.stringify(params.evidence)}\n`, "utf8");
   try {
-    return await attachQaProfileScorecardEvidenceToFile({
+    const scorecard = await attachQaProfileScorecardEvidenceToFile({
       evidencePath,
       profile: "release",
       filters: params.filters,
       categories: params.categories,
     });
+    const writtenEvidence = validateQaEvidenceSummaryJson(
+      JSON.parse(await fs.readFile(evidencePath, "utf8")),
+    );
+    return { scorecard, writtenEvidence };
   } finally {
     await fs.rm(tempRoot, { recursive: true, force: true });
   }
@@ -69,7 +97,7 @@ describe("profile scorecard evidence", () => {
       missingEvidenceRefs: [],
     };
 
-    const scorecard = await buildQaProfileScorecardEvidence({
+    const { scorecard } = await buildQaProfileScorecardEvidence({
       evidence: evidenceSummary([
         evidenceEntry([
           {
@@ -143,7 +171,7 @@ describe("profile scorecard evidence", () => {
       missingCoverageIds: [],
     };
 
-    const scorecard = await buildQaProfileScorecardEvidence({
+    const { scorecard } = await buildQaProfileScorecardEvidence({
       evidence: evidenceSummary([
         evidenceEntry([
           {
@@ -171,6 +199,100 @@ describe("profile scorecard evidence", () => {
       partial: 0,
       missing: 1,
       fulfillmentPercent: 66.7,
+    });
+  });
+
+  it.each([
+    ["pass", 1, "fulfilled"],
+    ["fail", 0, "missing"],
+    ["blocked", 0, "missing"],
+    ["skipped", 0, "missing"],
+  ] as const)(
+    "scores %s primary evidence from its execution result",
+    async (status, fulfilled, categoryStatus) => {
+      const { scorecard } = await buildQaProfileScorecardEvidence({
+        evidence: evidenceSummary([
+          evidenceEntry([{ id: "coverage.one", role: "primary" }], status),
+        ]),
+        filters: {},
+        categories: [categoryInventory(["coverage.one"])],
+      });
+
+      expect(scorecard.categoryReports[0]?.status).toBe(categoryStatus);
+      expect(scorecard.categoryReports[0]?.coverageIds).toMatchObject({
+        total: 1,
+        fulfilled,
+        missing: 1 - fulfilled,
+      });
+      expect(scorecard.coverageIds).toMatchObject({
+        total: 1,
+        fulfilled,
+        missing: 1 - fulfilled,
+      });
+    },
+  );
+
+  it("fulfills mixed evidence only from passes while preserving diagnostics", async () => {
+    const coverageIds = [
+      "coverage.pass",
+      "coverage.fail",
+      "coverage.blocked",
+      "coverage.skipped",
+      "coverage.diagnostic",
+    ];
+    const statuses = ["pass", "fail", "blocked", "skipped"] as const;
+
+    const { scorecard, writtenEvidence } = await buildQaProfileScorecardEvidence({
+      evidence: evidenceSummary([
+        evidenceEntry([{ id: "coverage.pass", role: "primary" }], "pass"),
+        evidenceEntry(
+          [
+            { id: "coverage.fail", role: "primary" },
+            { id: "coverage.diagnostic", role: "secondary" },
+          ],
+          "fail",
+        ),
+        evidenceEntry([{ id: "coverage.blocked", role: "primary" }], "blocked"),
+        evidenceEntry([{ id: "coverage.skipped", role: "primary" }], "skipped"),
+      ]),
+      filters: {},
+      categories: [categoryInventory(coverageIds)],
+    });
+
+    expect(scorecard.run.evidenceEntryCount).toBe(4);
+    expect(scorecard.categoryReports[0]).toMatchObject({
+      status: "partial",
+      features: {
+        total: 5,
+        fulfilled: 1,
+        partial: 0,
+        missing: 4,
+        fulfillmentPercent: 20,
+      },
+      coverageIds: {
+        total: 5,
+        fulfilled: 1,
+        secondaryOnly: 1,
+        missing: 4,
+        fulfillmentPercent: 20,
+      },
+      missingCoverageIds: [
+        "coverage.blocked",
+        "coverage.diagnostic",
+        "coverage.fail",
+        "coverage.skipped",
+      ],
+    });
+    expect(scorecard.coverageIds).toMatchObject({
+      total: 5,
+      fulfilled: 1,
+      missing: 4,
+      fulfillmentPercent: 20,
+    });
+    expect(writtenEvidence.entries.map((entry) => entry.result.status)).toStrictEqual(statuses);
+    expect(writtenEvidence.entries[1]?.coverage).toContainEqual({
+      id: "coverage.diagnostic",
+      role: "secondary",
     });
   });
 });

--- a/extensions/qa-lab/src/scorecard-evidence.test.ts
+++ b/extensions/qa-lab/src/scorecard-evidence.test.ts
@@ -14,12 +14,13 @@ import type { QaScorecardCategoryCoverageReport } from "./scorecard-taxonomy.js"
 function evidenceEntry(
   coverage: QaEvidenceSummaryEntry["coverage"],
   status: QaEvidenceSummaryEntry["result"]["status"] = "pass",
+  testId = "coverage-fixture",
 ): QaEvidenceSummaryEntry {
   return {
     test: {
       kind: "flow",
-      id: `${status}-coverage`,
-      title: `${status} coverage`,
+      id: testId,
+      title: "Coverage fixture",
     },
     coverage,
     refs: [],
@@ -210,7 +211,7 @@ describe("profile scorecard evidence", () => {
   ] as const)(
     "scores %s primary evidence from its execution result",
     async (status, fulfilled, categoryStatus) => {
-      const { scorecard } = await buildQaProfileScorecardEvidence({
+      const { scorecard, writtenEvidence } = await buildQaProfileScorecardEvidence({
         evidence: evidenceSummary([
           evidenceEntry([{ id: "coverage.one", role: "primary" }], status),
         ]),
@@ -229,6 +230,7 @@ describe("profile scorecard evidence", () => {
         fulfilled,
         missing: 1 - fulfilled,
       });
+      expect(writtenEvidence.entries[0]?.test.id).toBe("coverage-fixture");
     },
   );
 
@@ -244,16 +246,17 @@ describe("profile scorecard evidence", () => {
 
     const { scorecard, writtenEvidence } = await buildQaProfileScorecardEvidence({
       evidence: evidenceSummary([
-        evidenceEntry([{ id: "coverage.pass", role: "primary" }], "pass"),
+        evidenceEntry([{ id: "coverage.pass", role: "primary" }], "pass", "scenario-a"),
         evidenceEntry(
           [
             { id: "coverage.fail", role: "primary" },
             { id: "coverage.diagnostic", role: "secondary" },
           ],
           "fail",
+          "scenario-b",
         ),
-        evidenceEntry([{ id: "coverage.blocked", role: "primary" }], "blocked"),
-        evidenceEntry([{ id: "coverage.skipped", role: "primary" }], "skipped"),
+        evidenceEntry([{ id: "coverage.blocked", role: "primary" }], "blocked", "scenario-c"),
+        evidenceEntry([{ id: "coverage.skipped", role: "primary" }], "skipped", "scenario-d"),
       ]),
       filters: {},
       categories: [categoryInventory(coverageIds)],

--- a/extensions/qa-lab/src/scorecard-evidence.ts
+++ b/extensions/qa-lab/src/scorecard-evidence.ts
@@ -89,7 +89,9 @@ function buildQaProfileScorecardEvidence(params: {
   filters: QaProfileScorecardFilters;
   categories: readonly QaScorecardCategoryCoverageReport[];
 }): QaEvidenceScorecardJson {
-  const primaryCoverageIds = coverageIdsForRole(params.evidence.entries, "primary");
+  // Only passing primary evidence fulfills coverage; secondary evidence remains diagnostic.
+  const passingEntries = params.evidence.entries.filter((entry) => entry.result.status === "pass");
+  const primaryCoverageIds = coverageIdsForRole(passingEntries, "primary");
   const secondaryCoverageIds = coverageIdsForRole(params.evidence.entries, "secondary");
   const categoryInputs = params.categories.map((category) => ({
     category,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where QA profile scorecards marked a primary coverage ID fulfilled when its only executed evidence failed, was blocked, or was skipped.

## Why This Change Was Made

Executed scorecard fulfillment now uses only primary evidence whose result status is `pass`. Static taxonomy inventory remains separate, while non-passing entries and secondary evidence remain available for diagnostics. This does not change taxonomy IDs, scenarios, or lane selection.

AI-assisted: yes. The bounded patch was source-audited and passed a fresh structured Codex autoreview with no actionable findings.

## User Impact

QA operators can trust profile scorecard fulfillment percentages and missing-coverage lists to represent successful execution. Failed, blocked, and skipped attempts remain visible in the evidence artifact without overstating coverage.

## Evidence

- Focused QA Lab test and formatting: passed after rebasing onto current `main` on Blacksmith Testbox ([run](https://github.com/openclaw/openclaw/actions/runs/29468041986)). Covers `pass`, `fail`, `blocked`, `skipped`, mixed evidence, persisted diagnostics, and stable evidence identity. The prior full changed gate also passed extension production/test typechecks, lint, boundary guards, and import cycles ([run](https://github.com/openclaw/openclaw/actions/runs/29466823109)).
- Fresh branch autoreview against current `origin/main`: no accepted/actionable findings; patch judged correct with 0.99 confidence.
