### PR TITLE
fix: deliver sessions_yield message on empty-payload turns

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/Resources/tool-display.json
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/Resources/tool-display.json
@@ -1056,7 +1056,8 @@
       "emoji": "⏸️",
       "title": "Yield",
       "detailKeys": [
-        "message"
+        "message",
+        "acknowledgment"
       ]
     },
     "tts": {

--- a/extensions/codex/src/app-server/dynamic-tool-build.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.ts
@@ -99,8 +99,11 @@ type DynamicToolBuildParams = {
   ignoreRuntimePlan?: boolean;
   /** Host fact resolver; injectable only for focused plugin contract tests. */
   isHostScopedToolActive?: (toolName: string) => boolean;
-  /** Called when sessions_yield fires; message is the user-facing acknowledgment. */
-  onYieldDetected: (message?: string) => void;
+  /**
+   * Called when sessions_yield fires. Only the explicit user-visible
+   * acknowledgment is passed; hidden `message` context stays on the tool event.
+   */
+  onYieldDetected: (acknowledgment?: string) => void;
   onCodexAppServerEvent?: (event: CodexDynamicToolBuildEvent) => void;
   onPersistentWebSearchPolicyResolved?: (allowed: boolean) => void;
   onWebSearchPolicyResolved?: (allowed: boolean) => void;
@@ -316,12 +319,16 @@ export async function buildDynamicTools(input: DynamicToolBuildParams) {
     forceMessageTool: shouldForceMessageTool(messagePolicyParams),
     enableHeartbeatTool: params.trigger === "heartbeat" || input.forceHeartbeatTool === true,
     forceHeartbeatTool: params.trigger === "heartbeat" || input.forceHeartbeatTool === true,
-    onYield: (message) => {
-      // Preserve the yield text so the reply pipeline can deliver an empty-turn ack.
-      input.onYieldDetected(message);
+    onYield: (message, acknowledgment) => {
+      // Only the explicit acknowledgment is user-visible; message stays hidden context.
+      input.onYieldDetected(acknowledgment);
       input.onCodexAppServerEvent?.({
         stream: "codex_app_server.tool",
-        data: { name: "sessions_yield", message },
+        data: {
+          name: "sessions_yield",
+          message,
+          ...(acknowledgment ? { acknowledgment } : {}),
+        },
       });
     },
     recordToolPrepStage: (name) => {

--- a/extensions/codex/src/app-server/dynamic-tool-build.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.ts
@@ -99,7 +99,8 @@ type DynamicToolBuildParams = {
   ignoreRuntimePlan?: boolean;
   /** Host fact resolver; injectable only for focused plugin contract tests. */
   isHostScopedToolActive?: (toolName: string) => boolean;
-  onYieldDetected: () => void;
+  /** Called when sessions_yield fires; message is the user-facing acknowledgment. */
+  onYieldDetected: (message?: string) => void;
   onCodexAppServerEvent?: (event: CodexDynamicToolBuildEvent) => void;
   onPersistentWebSearchPolicyResolved?: (allowed: boolean) => void;
   onWebSearchPolicyResolved?: (allowed: boolean) => void;
@@ -316,7 +317,8 @@ export async function buildDynamicTools(input: DynamicToolBuildParams) {
     enableHeartbeatTool: params.trigger === "heartbeat" || input.forceHeartbeatTool === true,
     forceHeartbeatTool: params.trigger === "heartbeat" || input.forceHeartbeatTool === true,
     onYield: (message) => {
-      input.onYieldDetected();
+      // Preserve the yield text so the reply pipeline can deliver an empty-turn ack.
+      input.onYieldDetected(message);
       input.onCodexAppServerEvent?.({
         stream: "codex_app_server.tool",
         data: { name: "sessions_yield", message },

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -281,7 +281,7 @@ export class CodexAppServerEventProjector {
 
   buildResult(
     toolTelemetry: CodexAppServerToolTelemetry,
-    options?: { yieldDetected?: boolean },
+    options?: { yieldDetected?: boolean; yieldMessage?: string },
   ): EmbeddedRunAttemptResult {
     // Result construction runs after the notification queue drains. Close any
     // tool lacking a terminal item so audit consumers never retain an open action.
@@ -417,6 +417,9 @@ export class CodexAppServerEventProjector {
           : {}),
       },
       yieldDetected: options?.yieldDetected || false,
+      ...(options?.yieldDetected && options.yieldMessage
+        ? { yieldMessage: options.yieldMessage }
+        : {}),
       didSendDeterministicApprovalPrompt:
         this.eventProjection.guardianReviewCount > 0 ? false : undefined,
     };

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -281,7 +281,7 @@ export class CodexAppServerEventProjector {
 
   buildResult(
     toolTelemetry: CodexAppServerToolTelemetry,
-    options?: { yieldDetected?: boolean; yieldMessage?: string },
+    options?: { yieldDetected?: boolean; yieldAcknowledgment?: string },
   ): EmbeddedRunAttemptResult {
     // Result construction runs after the notification queue drains. Close any
     // tool lacking a terminal item so audit consumers never retain an open action.
@@ -417,8 +417,8 @@ export class CodexAppServerEventProjector {
           : {}),
       },
       yieldDetected: options?.yieldDetected || false,
-      ...(options?.yieldDetected && options.yieldMessage
-        ? { yieldMessage: options.yieldMessage }
+      ...(options?.yieldDetected && options.yieldAcknowledgment
+        ? { yieldAcknowledgment: options.yieldAcknowledgment }
         : {}),
       didSendDeterministicApprovalPrompt:
         this.eventProjection.guardianReviewCount > 0 ? false : undefined,

--- a/extensions/codex/src/app-server/run-attempt-finalize.ts
+++ b/extensions/codex/src/app-server/run-attempt-finalize.ts
@@ -144,8 +144,8 @@ export async function finalizeCodexAttempt(
   }
   const result = activeProjector.buildResult(toolBridge.telemetry, {
     yieldDetected: toolState.yieldDetected,
-    ...(toolState.yieldDetected && toolState.yieldMessage
-      ? { yieldMessage: toolState.yieldMessage }
+    ...(toolState.yieldDetected && toolState.yieldAcknowledgment
+      ? { yieldAcknowledgment: toolState.yieldAcknowledgment }
       : {}),
   });
   const effectiveTimedOut = state.timedOut && !recoveredTurnWatchTimeout;

--- a/extensions/codex/src/app-server/run-attempt-finalize.ts
+++ b/extensions/codex/src/app-server/run-attempt-finalize.ts
@@ -144,6 +144,9 @@ export async function finalizeCodexAttempt(
   }
   const result = activeProjector.buildResult(toolBridge.telemetry, {
     yieldDetected: toolState.yieldDetected,
+    ...(toolState.yieldDetected && toolState.yieldMessage
+      ? { yieldMessage: toolState.yieldMessage }
+      : {}),
   });
   const effectiveTimedOut = state.timedOut && !recoveredTurnWatchTimeout;
   const effectiveTurnCompletionIdleTimedOut =

--- a/extensions/codex/src/app-server/run-attempt-tool-setup.ts
+++ b/extensions/codex/src/app-server/run-attempt-tool-setup.ts
@@ -63,7 +63,7 @@ export async function prepareCodexAttemptTools(runtime: CodexAttemptRuntime) {
   }
   const toolState = {
     yieldDetected: false,
-    yieldMessage: undefined as string | undefined,
+    yieldAcknowledgment: undefined as string | undefined,
     persistentWebSearchAllowed: undefined as boolean | undefined,
     webSearchAllowed: false,
   };
@@ -122,11 +122,11 @@ export async function prepareCodexAttemptTools(runtime: CodexAttemptRuntime) {
     sessionAgentId,
     pluginConfig,
     profilerEnabled,
-    onYieldDetected: (message?: string) => {
+    onYieldDetected: (acknowledgment?: string) => {
       toolState.yieldDetected = true;
-      const trimmed = typeof message === "string" ? message.trim() : "";
+      const trimmed = typeof acknowledgment === "string" ? acknowledgment.trim() : "";
       if (trimmed) {
-        toolState.yieldMessage = trimmed;
+        toolState.yieldAcknowledgment = trimmed;
       }
     },
     onCodexAppServerEvent: (event: Parameters<typeof emitCodexAppServerEvent>[1]) => {

--- a/extensions/codex/src/app-server/run-attempt-tool-setup.ts
+++ b/extensions/codex/src/app-server/run-attempt-tool-setup.ts
@@ -63,6 +63,7 @@ export async function prepareCodexAttemptTools(runtime: CodexAttemptRuntime) {
   }
   const toolState = {
     yieldDetected: false,
+    yieldMessage: undefined as string | undefined,
     persistentWebSearchAllowed: undefined as boolean | undefined,
     webSearchAllowed: false,
   };
@@ -121,8 +122,12 @@ export async function prepareCodexAttemptTools(runtime: CodexAttemptRuntime) {
     sessionAgentId,
     pluginConfig,
     profilerEnabled,
-    onYieldDetected: () => {
+    onYieldDetected: (message?: string) => {
       toolState.yieldDetected = true;
+      const trimmed = typeof message === "string" ? message.trim() : "";
+      if (trimmed) {
+        toolState.yieldMessage = trimmed;
+      }
     },
     onCodexAppServerEvent: (event: Parameters<typeof emitCodexAppServerEvent>[1]) => {
       void emitCodexAppServerEvent(params, event);

--- a/extensions/copilot/src/tool-bridge.ts
+++ b/extensions/copilot/src/tool-bridge.ts
@@ -427,14 +427,16 @@ function buildOpenClawCodingToolsOptions(
     // recordToolPrepStage intentionally omitted: copilot does not
     // surface attempt-stage telemetry yet. Codex omits this too.
     onToolOutcome: a.onToolOutcome,
-    onYield: (message) => {
+    onYield: (message, _acknowledgment) => {
       // Notify the caller first so the final attempt result can carry
       // yieldDetected even if the abort below races a concurrent
       // settle path. Errors thrown by the caller's handler must not
       // skip the abort, so wrap defensively. Mirrors PI (`attempt.ts`
-      // sets `yieldDetected = true; yieldMessage = message;` before
-      // calling abort) and codex (`onYieldDetected()` runs before the
-      // run-abort controller fires).
+      // sets yieldDetected + hidden message before abort) and codex
+      // (`onYieldDetected` runs before the run-abort controller fires).
+      // Copilot currently uses this signal for yieldDetected only; user-
+      // visible empty-turn ack is owned by the reply pipeline + codex/
+      // embedded paths that thread `acknowledgment` explicitly.
       try {
         input.onYieldDetected?.(message);
       } catch (error) {

--- a/src/agents/agent-tools.ts
+++ b/src/agents/agent-tools.ts
@@ -431,7 +431,7 @@ type OpenClawCodingToolsOptions = {
   /** Auth profiles already loaded for this run; used for prompt-time tool availability. */
   authProfileStore?: AuthProfileStore;
   /** Callback invoked when sessions_yield tool is called. */
-  onYield?: (message: string) => Promise<void> | void;
+  onYield?: (message: string, acknowledgment?: string) => Promise<void> | void;
   /** Optional instrumentation callback for tool preparation stage timing. */
   recordToolPrepStage?: (name: string) => void;
   /** Lower routine policy-removal audits for diagnostic-only tool probes. */

--- a/src/agents/embedded-agent-runner/run/attempt-execution-phase.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-execution-phase.test.ts
@@ -116,6 +116,7 @@ function createFixture() {
         yieldAbortSettled: null,
         yieldDetected: true,
         yieldMessage: "yield",
+        yieldAcknowledgment: null,
       }),
       setToolSearchCatalogExecutor,
     },

--- a/src/agents/embedded-agent-runner/run/attempt-execution-settle.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-execution-settle.test.ts
@@ -180,6 +180,7 @@ function createFixture() {
         yieldAbortSettled: null,
         yieldDetected: true,
         yieldMessage: "yield",
+        yieldAcknowledgment: null,
       }),
     },
     getRepairedRejectedThinkingReplay: () => true,

--- a/src/agents/embedded-agent-runner/run/attempt-execution-settle.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-execution-settle.ts
@@ -391,6 +391,7 @@ export async function runEmbeddedAttemptSettledPhase(
       promptCache: sessionRuntimeState.promptCache,
       contextBudgetStatus,
       yieldDetected: input.lifecycle.readYieldState().yieldDetected,
+      yieldMessage: input.lifecycle.readYieldState().yieldMessage ?? undefined,
       didDeliverSourceReplyViaMessageTool: hasDeliveredSourceReply(),
     },
     clientToolCallSlots,

--- a/src/agents/embedded-agent-runner/run/attempt-execution-settle.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-execution-settle.ts
@@ -392,6 +392,7 @@ export async function runEmbeddedAttemptSettledPhase(
       contextBudgetStatus,
       yieldDetected: input.lifecycle.readYieldState().yieldDetected,
       yieldMessage: input.lifecycle.readYieldState().yieldMessage ?? undefined,
+      yieldAcknowledgment: input.lifecycle.readYieldState().yieldAcknowledgment ?? undefined,
       didDeliverSourceReplyViaMessageTool: hasDeliveredSourceReply(),
     },
     clientToolCallSlots,

--- a/src/agents/embedded-agent-runner/run/attempt-execution-types.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-execution-types.ts
@@ -82,6 +82,7 @@ export type EmbeddedAttemptExecutionPhaseInput = {
       yieldAbortSettled: Promise<void> | null;
       yieldDetected: boolean;
       yieldMessage: string | null;
+      yieldAcknowledgment: string | null;
     };
     setToolSearchCatalogExecutor: StreamRuntimeInput["lifecycle"]["setToolSearchCatalogExecutor"];
   };

--- a/src/agents/embedded-agent-runner/run/attempt-result.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-result.ts
@@ -64,6 +64,7 @@ type EmbeddedAttemptResultState = Pick<
   | "contextBudgetStatus"
   | "yieldDetected"
   | "yieldMessage"
+  | "yieldAcknowledgment"
   | "didDeliverSourceReplyViaMessageTool"
 > & {
   diagnosticTrace: DiagnosticTraceContext;
@@ -407,7 +408,10 @@ export function completeEmbeddedAttemptResult(
     compactionTokensAfter: getLastCompactionTokensAfter(),
     clientToolCalls,
     yieldDetected: state.yieldDetected || undefined,
-    ...(state.yieldDetected && state.yieldMessage ? { yieldMessage: state.yieldMessage } : {}),
+    // Only the explicit acknowledgment is attempt-result surface for reply delivery.
+    ...(state.yieldDetected && state.yieldAcknowledgment
+      ? { yieldAcknowledgment: state.yieldAcknowledgment }
+      : {}),
   };
   return finalizeEmbeddedAttempt({
     result,

--- a/src/agents/embedded-agent-runner/run/attempt-result.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-result.ts
@@ -63,6 +63,7 @@ type EmbeddedAttemptResultState = Pick<
   | "promptCache"
   | "contextBudgetStatus"
   | "yieldDetected"
+  | "yieldMessage"
   | "didDeliverSourceReplyViaMessageTool"
 > & {
   diagnosticTrace: DiagnosticTraceContext;
@@ -406,6 +407,7 @@ export function completeEmbeddedAttemptResult(
     compactionTokensAfter: getLastCompactionTokensAfter(),
     clientToolCalls,
     yieldDetected: state.yieldDetected || undefined,
+    ...(state.yieldDetected && state.yieldMessage ? { yieldMessage: state.yieldMessage } : {}),
   };
   return finalizeEmbeddedAttempt({
     result,

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -181,9 +181,12 @@ export async function runEmbeddedAttempt(
       effectiveCwd,
       effectiveWorkspace,
       markCoreToolStage: (name) => corePluginToolStages.mark(name),
-      onYield: (message) => {
+      onYield: (message, acknowledgment) => {
         yieldDetected = true;
+        // message stays hidden next-turn context; acknowledgment alone is user-visible.
         yieldMessage = message;
+        const trimmedAck = typeof acknowledgment === "string" ? acknowledgment.trim() : "";
+        yieldAcknowledgment = trimmedAck || null;
         queueYieldInterruptForSession?.();
         runAbortController.abort(SESSIONS_YIELD_ABORT_REASON);
         abortSessionForYield?.();
@@ -233,6 +236,7 @@ export async function runEmbeddedAttempt(
     // Track sessions_yield tool invocation (callback pattern, like clientToolCallDetected)
     let yieldDetected = false;
     let yieldMessage: string | null = null;
+    let yieldAcknowledgment: string | null = null;
     // Late-binding reference so onYield can abort the session (declared after tool creation)
     let abortSessionForYield: (() => void) | null = null;
     let queueYieldInterruptForSession: (() => void) | null = null;
@@ -433,7 +437,12 @@ export async function runEmbeddedAttempt(
         diagnostics: { diagnosticTrace, runTrace },
         state: executionState,
         lifecycle: {
-          readYieldState: () => ({ yieldAbortSettled, yieldDetected, yieldMessage }),
+          readYieldState: () => ({
+            yieldAbortSettled,
+            yieldDetected,
+            yieldMessage,
+            yieldAcknowledgment,
+          }),
           setToolSearchCatalogExecutor: (executor) => {
             toolSearchCatalogExecutor = executor;
           },

--- a/src/agents/embedded-agent-runner/run/terminal-resolution.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-resolution.ts
@@ -460,8 +460,8 @@ function completeEmbeddedRun(
         livenessState,
         agentHarnessResultClassification: input.attempt.agentHarnessResultClassification,
         ...(input.attempt.yieldDetected ? { yielded: true } : {}),
-        ...(input.attempt.yieldDetected && input.attempt.yieldMessage
-          ? { yieldMessage: input.attempt.yieldMessage }
+        ...(input.attempt.yieldDetected && input.attempt.yieldAcknowledgment
+          ? { yieldAcknowledgment: input.attempt.yieldAcknowledgment }
           : {}),
         ...(input.emptyAssistantReplyIsSilent
           ? { terminalReplyKind: "silent-empty" as const }

--- a/src/agents/embedded-agent-runner/run/terminal-resolution.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-resolution.ts
@@ -460,6 +460,9 @@ function completeEmbeddedRun(
         livenessState,
         agentHarnessResultClassification: input.attempt.agentHarnessResultClassification,
         ...(input.attempt.yieldDetected ? { yielded: true } : {}),
+        ...(input.attempt.yieldDetected && input.attempt.yieldMessage
+          ? { yieldMessage: input.attempt.yieldMessage }
+          : {}),
         ...(input.emptyAssistantReplyIsSilent
           ? { terminalReplyKind: "silent-empty" as const }
           : {}),

--- a/src/agents/embedded-agent-runner/run/types.ts
+++ b/src/agents/embedded-agent-runner/run/types.ts
@@ -266,6 +266,11 @@ export type EmbeddedRunAttemptResult = {
   clientToolCalls?: Array<{ name: string; params: Record<string, unknown> }>;
   /** True when sessions_yield tool was called during this attempt. */
   yieldDetected?: boolean;
+  /**
+   * sessions_yield message for this attempt only. Carried into run meta so the
+   * reply pipeline can deliver an acknowledgment when no other visible payload exists.
+   */
+  yieldMessage?: string;
   replayMetadata: EmbeddedRunReplayMetadata;
   /**
    * Replay metadata for this attempt before prior session state is accumulated.

--- a/src/agents/embedded-agent-runner/run/types.ts
+++ b/src/agents/embedded-agent-runner/run/types.ts
@@ -267,10 +267,11 @@ export type EmbeddedRunAttemptResult = {
   /** True when sessions_yield tool was called during this attempt. */
   yieldDetected?: boolean;
   /**
-   * sessions_yield message for this attempt only. Carried into run meta so the
-   * reply pipeline can deliver an acknowledgment when no other visible payload exists.
+   * Explicit sessions_yield.acknowledgment for this attempt only. Carried into
+   * run meta so the reply pipeline can deliver a user-visible empty-turn ack.
+   * Hidden `message` context is never placed here.
    */
-  yieldMessage?: string;
+  yieldAcknowledgment?: string;
   replayMetadata: EmbeddedRunReplayMetadata;
   /**
    * Replay metadata for this attempt before prior session state is accumulated.

--- a/src/agents/embedded-agent-runner/sessions-yield.orchestration.test.ts
+++ b/src/agents/embedded-agent-runner/sessions-yield.orchestration.test.ts
@@ -38,6 +38,7 @@ describe("sessions_yield orchestration", () => {
         promptError: null,
         sessionIdUsed: sessionId,
         yieldDetected: true,
+        yieldMessage: "Research started, I'll send results shortly",
       }),
     );
 
@@ -53,10 +54,14 @@ describe("sessions_yield orchestration", () => {
     // 2. No pending tool calls (yield is NOT a client tool call)
     expect(result.meta.pendingToolCalls).toBeUndefined();
 
-    // 3. Parent session is IDLE (not in ACTIVE_EMBEDDED_RUNS)
+    // 3. Yield message is carried on meta for the reply pipeline
+    expect(result.meta.yielded).toBe(true);
+    expect(result.meta.yieldMessage).toBe("Research started, I'll send results shortly");
+
+    // 4. Parent session is IDLE (not in ACTIVE_EMBEDDED_RUNS)
     expect(isEmbeddedAgentRunActive(sessionId)).toBe(false);
 
-    // 4. Steer would fail (message delivery must take direct path, not steer)
+    // 5. Steer would fail (message delivery must take direct path, not steer)
     const queueResult = queueEmbeddedAgentMessageWithOutcome(sessionId, "subagent result");
     expect(queueResult.queued).toBe(false);
     if (queueResult.queued) {

--- a/src/agents/embedded-agent-runner/sessions-yield.orchestration.test.ts
+++ b/src/agents/embedded-agent-runner/sessions-yield.orchestration.test.ts
@@ -32,13 +32,13 @@ describe("sessions_yield orchestration", () => {
   it("parent session is idle after yield — end_turn, no pendingToolCalls", async () => {
     const sessionId = "yield-parent-session";
 
-    // Simulate an attempt where sessions_yield was called
+    // Simulate an attempt where sessions_yield was called with an explicit ack
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(
       makeAttemptResult({
         promptError: null,
         sessionIdUsed: sessionId,
         yieldDetected: true,
-        yieldMessage: "Research started, I'll send results shortly",
+        yieldAcknowledgment: "Research started, I'll send results shortly",
       }),
     );
 
@@ -54,9 +54,9 @@ describe("sessions_yield orchestration", () => {
     // 2. No pending tool calls (yield is NOT a client tool call)
     expect(result.meta.pendingToolCalls).toBeUndefined();
 
-    // 3. Yield message is carried on meta for the reply pipeline
+    // 3. Explicit acknowledgment is carried on meta for the reply pipeline
     expect(result.meta.yielded).toBe(true);
-    expect(result.meta.yieldMessage).toBe("Research started, I'll send results shortly");
+    expect(result.meta.yieldAcknowledgment).toBe("Research started, I'll send results shortly");
 
     // 4. Parent session is IDLE (not in ACTIVE_EMBEDDED_RUNS)
     expect(isEmbeddedAgentRunActive(sessionId)).toBe(false);

--- a/src/agents/embedded-agent-runner/types.ts
+++ b/src/agents/embedded-agent-runner/types.ts
@@ -171,6 +171,11 @@ export type EmbeddedAgentRunMeta = {
   agentHarnessResultClassification?: "empty" | "reasoning-only" | "planning-only";
   terminalReplyKind?: "silent-empty";
   yielded?: boolean;
+  /**
+   * User-facing acknowledgment from sessions_yield for this attempt only.
+   * Reply pipeline may emit this when the turn has no other visible payload.
+   */
+  yieldMessage?: string;
   error?: {
     kind:
       | "context_overflow"

--- a/src/agents/embedded-agent-runner/types.ts
+++ b/src/agents/embedded-agent-runner/types.ts
@@ -172,10 +172,11 @@ export type EmbeddedAgentRunMeta = {
   terminalReplyKind?: "silent-empty";
   yielded?: boolean;
   /**
-   * User-facing acknowledgment from sessions_yield for this attempt only.
+   * Explicit user-facing acknowledgment from sessions_yield.acknowledgment.
    * Reply pipeline may emit this when the turn has no other visible payload.
+   * Hidden `message` context is never exposed here.
    */
-  yieldMessage?: string;
+  yieldAcknowledgment?: string;
   error?: {
     kind:
       | "context_overflow"

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -212,7 +212,7 @@ export function createOpenClawTools(
     /** Current runtime directory used as the default project for follow-up suggestions. */
     cwd?: string;
     /** Callback invoked when sessions_yield tool is called. */
-    onYield?: (message: string) => Promise<void> | void;
+    onYield?: (message: string, acknowledgment?: string) => Promise<void> | void;
     /** Allow plugin tools for this tool set to late-bind the gateway subagent. */
     allowGatewaySubagentBinding?: boolean;
   } & SpawnedToolContext,

--- a/src/agents/tools/sessions-yield-tool.test.ts
+++ b/src/agents/tools/sessions-yield-tool.test.ts
@@ -6,6 +6,7 @@ import { createSessionsYieldTool } from "./sessions-yield-tool.js";
 type SessionsYieldDetails = {
   status?: string;
   message?: string;
+  acknowledgment?: string;
   error?: string;
 };
 
@@ -20,19 +21,21 @@ describe("sessions_yield tool", () => {
     expect(onYield).not.toHaveBeenCalled();
   });
 
-  it("invokes onYield callback with default message", async () => {
+  it("invokes onYield callback with default message and no acknowledgment", async () => {
     const onYield = vi.fn();
     const tool = createSessionsYieldTool({ sessionId: "test-session", onYield });
     const result = await tool.execute("call-1", {});
     const details = result.details as SessionsYieldDetails;
     expect(details.status).toBe("yielded");
     expect(details.message).toBe("Turn yielded.");
+    expect(details.acknowledgment).toBeUndefined();
     expect(onYield).toHaveBeenCalledOnce();
-    expect(onYield).toHaveBeenCalledWith("Turn yielded.");
+    // Hidden default only — no user-visible acknowledgment inferred.
+    expect(onYield).toHaveBeenCalledWith("Turn yielded.", undefined);
   });
 
-  it("passes the custom message through the yield callback", async () => {
-    // The callback message becomes operator-visible scheduler context, so the
+  it("passes the custom message through the yield callback as hidden context only", async () => {
+    // The callback message becomes hidden scheduler/next-turn context, so the
     // tool must not replace a supplied reason with the default text.
     const onYield = vi.fn();
     const tool = createSessionsYieldTool({ sessionId: "test-session", onYield });
@@ -40,8 +43,27 @@ describe("sessions_yield tool", () => {
     const details = result.details as SessionsYieldDetails;
     expect(details.status).toBe("yielded");
     expect(details.message).toBe("Waiting for fact-checker");
+    expect(details.acknowledgment).toBeUndefined();
     expect(onYield).toHaveBeenCalledOnce();
-    expect(onYield).toHaveBeenCalledWith("Waiting for fact-checker");
+    expect(onYield).toHaveBeenCalledWith("Waiting for fact-checker", undefined);
+  });
+
+  it("passes an explicit acknowledgment separately from hidden message", async () => {
+    const onYield = vi.fn();
+    const tool = createSessionsYieldTool({ sessionId: "test-session", onYield });
+    const result = await tool.execute("call-1", {
+      message: "internal: wait for fact-checker",
+      acknowledgment: "Research started, I'll send results shortly",
+    });
+    const details = result.details as SessionsYieldDetails;
+    expect(details.status).toBe("yielded");
+    expect(details.message).toBe("internal: wait for fact-checker");
+    expect(details.acknowledgment).toBe("Research started, I'll send results shortly");
+    expect(onYield).toHaveBeenCalledOnce();
+    expect(onYield).toHaveBeenCalledWith(
+      "internal: wait for fact-checker",
+      "Research started, I'll send results shortly",
+    );
   });
 
   it("returns error without onYield callback", async () => {

--- a/src/agents/tools/sessions-yield-tool.ts
+++ b/src/agents/tools/sessions-yield-tool.ts
@@ -2,28 +2,40 @@
  * sessions_yield built-in tool.
  *
  * Ends the current turn after subagent spawning so completion events can resume the session later.
+ *
+ * Contract:
+ * - `message` is optional hidden follow-up context for the next turn (shipped semantics).
+ * - `acknowledgment` is optional user-visible text delivered only when the turn has no
+ *   other visible payload (explicit empty-turn ack; never inferred from `message`).
  */
 import { Type } from "typebox";
 import type { AnyAgentTool } from "./common.js";
 import { jsonResult, readStringParam } from "./common.js";
 
 const SessionsYieldToolSchema = Type.Object({
+  /** Hidden continuation context for the next turn; not user-visible channel text. */
   message: Type.Optional(Type.String()),
+  /** Optional user-visible acknowledgment for otherwise empty spawn-and-yield turns. */
+  acknowledgment: Type.Optional(Type.String()),
 });
 
 /** Creates the sessions_yield tool for runtimes that support yield callbacks. */
 export function createSessionsYieldTool(opts?: {
   sessionId?: string;
-  onYield?: (message: string) => Promise<void> | void;
+  onYield?: (message: string, acknowledgment?: string) => Promise<void> | void;
 }): AnyAgentTool {
   return {
     label: "Yield",
     name: "sessions_yield",
-    description: "End turn after subagent spawn; results arrive next message.",
+    description:
+      "End turn after subagent spawn; results arrive next message. " +
+      "`message` stays hidden context; optional `acknowledgment` is user-visible on empty turns.",
     parameters: SessionsYieldToolSchema,
     execute: async (_toolCallId, args) => {
       const params = args as Record<string, unknown>;
+      // Default keeps the shipped hidden-context contract when the model omits message.
       const message = readStringParam(params, "message") || "Turn yielded.";
+      const acknowledgment = readStringParam(params, "acknowledgment");
       if (!opts?.sessionId) {
         return jsonResult({ status: "error", error: "No session context" });
       }
@@ -31,8 +43,12 @@ export function createSessionsYieldTool(opts?: {
         return jsonResult({ status: "error", error: "Yield not supported in this context" });
       }
       // The runtime owns the actual pause/end-turn behavior; this tool records intent.
-      await opts.onYield(message);
-      return jsonResult({ status: "yielded", message });
+      await opts.onYield(message, acknowledgment || undefined);
+      return jsonResult({
+        status: "yielded",
+        message,
+        ...(acknowledgment ? { acknowledgment } : {}),
+      });
     },
   };
 }

--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -1952,12 +1952,12 @@ describe("runReplyAgent typing (heartbeat)", () => {
     await expect(run()).resolves.toBeUndefined();
   });
 
-  it("delivers sessions_yield message when the turn has no other visible payload", async () => {
+  it("delivers sessions_yield acknowledgment when the turn has no other visible payload", async () => {
     state.runEmbeddedAgentMock.mockResolvedValueOnce({
       payloads: [],
       meta: {
         yielded: true,
-        yieldMessage: "Research started, I'll send results shortly",
+        yieldAcknowledgment: "Research started, I'll send results shortly",
       },
     });
     const { run } = createMinimalRun();
@@ -1966,6 +1966,20 @@ describe("runReplyAgent typing (heartbeat)", () => {
 
     expect(payloads).toHaveLength(1);
     expect(payloads[0]?.text).toBe("Research started, I'll send results shortly");
+  });
+
+  it("keeps hidden sessions_yield message silent without an explicit acknowledgment", async () => {
+    // Regression: yielded with only the shipped hidden-message contract must
+    // not synthesize user-visible text from that field.
+    state.runEmbeddedAgentMock.mockResolvedValueOnce({
+      payloads: [],
+      meta: {
+        yielded: true,
+      },
+    });
+    const { run } = createMinimalRun();
+
+    await expect(run()).resolves.toBeUndefined();
   });
 
   it.each([

--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -1937,7 +1937,10 @@ describe("runReplyAgent typing (heartbeat)", () => {
         acceptedSessionSpawns: [{ runId: "child", childSessionKey: "agent:main:child" }],
       },
     },
-    { label: "yielded continuation", result: { payloads: [], meta: { yielded: true } } },
+    {
+      label: "yielded continuation without message",
+      result: { payloads: [], meta: { yielded: true } },
+    },
     {
       label: "pending tool continuation",
       result: { payloads: [], meta: { pendingToolCalls: [{ name: "hosted_tool" }] } },
@@ -1947,6 +1950,22 @@ describe("runReplyAgent typing (heartbeat)", () => {
     const { run } = createMinimalRun();
 
     await expect(run()).resolves.toBeUndefined();
+  });
+
+  it("delivers sessions_yield message when the turn has no other visible payload", async () => {
+    state.runEmbeddedAgentMock.mockResolvedValueOnce({
+      payloads: [],
+      meta: {
+        yielded: true,
+        yieldMessage: "Research started, I'll send results shortly",
+      },
+    });
+    const { run } = createMinimalRun();
+    const res = await run();
+    const payloads = Array.isArray(res) ? res : res ? [res] : [];
+
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]?.text).toBe("Research started, I'll send results shortly");
   });
 
   it.each([

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -1975,12 +1975,13 @@ export async function runReplyAgent(params: {
         directlySentBlockPayloads,
       }) || hasCompletedTerminalDeliveryEvidence(runResult);
     // sessions_yield ack: deliver once when the turn otherwise has no visible payload.
+    // Only the explicit acknowledgment field is eligible — hidden message stays internal.
     // Skip when block/message-tool delivery already happened (no duplicate), and never
     // surface yield text for heartbeat or subagent sessions (internal context only).
     if (payloadArray.length === 0) {
       const yieldAckPayload = resolveSessionsYieldAckPayload({
         yielded: runResult.meta?.yielded === true,
-        yieldMessage: runResult.meta?.yieldMessage,
+        yieldAcknowledgment: runResult.meta?.yieldAcknowledgment,
         isHeartbeat,
         isSubagentSession: isSubagentSessionKey(sessionKey ?? followupRun.run.sessionKey),
         hasVisibleDelivery:

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -52,6 +52,7 @@ import {
 import { measureDiagnosticsTimelineSpan } from "../../infra/diagnostics-timeline.js";
 import { enqueueSystemEvent } from "../../infra/system-events.js";
 import { CommandLaneClearedError, GatewayDrainingError } from "../../process/command-queue.js";
+import { isSubagentSessionKey } from "../../routing/session-key.js";
 import { shouldPreserveUserFacingSessionStateForInputProvenance } from "../../sessions/input-provenance.js";
 import { resolveSendPolicy } from "../../sessions/send-policy.js";
 import {
@@ -144,6 +145,7 @@ import { buildReplyUsageState, recordReplyUsageState } from "./reply-usage-state
 import { createReplyRestartRecoveryClaimController } from "./restart-recovery-claim.js";
 import { resolveRoutedDeliveryThreadId } from "./routed-delivery-thread.js";
 import { incrementRunCompactionCount, persistRunSessionUsage } from "./session-run-accounting.js";
+import { resolveSessionsYieldAckPayload } from "./sessions-yield-ack.js";
 import { resolveSourceReplyVisibilityPolicy } from "./source-reply-delivery-mode.js";
 import {
   buildStrandedReplyDeliveryFailurePayload,
@@ -1784,7 +1786,7 @@ export async function runReplyAgent(params: {
       }
     }
 
-    const payloadArray = runResult.payloads ?? [];
+    let payloadArray = runResult.payloads ?? [];
 
     if (blockReplyPipeline) {
       await blockReplyPipeline.flush({ force: true });
@@ -1972,6 +1974,24 @@ export async function runReplyAgent(params: {
         blockReplyPipeline,
         directlySentBlockPayloads,
       }) || hasCompletedTerminalDeliveryEvidence(runResult);
+    // sessions_yield ack: deliver once when the turn otherwise has no visible payload.
+    // Skip when block/message-tool delivery already happened (no duplicate), and never
+    // surface yield text for heartbeat or subagent sessions (internal context only).
+    if (payloadArray.length === 0) {
+      const yieldAckPayload = resolveSessionsYieldAckPayload({
+        yielded: runResult.meta?.yielded === true,
+        yieldMessage: runResult.meta?.yieldMessage,
+        isHeartbeat,
+        isSubagentSession: isSubagentSessionKey(sessionKey ?? followupRun.run.sessionKey),
+        hasVisibleDelivery:
+          successfulSideEffectDelivery ||
+          successfulTerminalDelivery ||
+          (directlySentBlockPayloads?.length ?? 0) > 0,
+      });
+      if (yieldAckPayload) {
+        payloadArray = [yieldAckPayload];
+      }
+    }
     // Compaction notices are progress, not a terminal reply. Dispatcher-backed
     // delivery settles after this run returns, so it cannot prove turn completion here.
     const shouldDeliverTerminalFailure = Boolean(

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -1881,10 +1881,11 @@ export function createFollowupRunner(params: {
         );
       let finalPayloads = resolveDeliveryPayloads(runResult.payloads ?? []);
       // Mirror agent-runner: synthesize sessions_yield ack when empty and no other delivery.
+      // Only explicit acknowledgment is eligible; hidden message is never outbound text.
       if (finalPayloads.length === 0) {
         const yieldAckPayload = resolveSessionsYieldAckPayload({
           yielded: runResult.meta?.yielded === true,
-          yieldMessage: runResult.meta?.yieldMessage,
+          yieldAcknowledgment: runResult.meta?.yieldAcknowledgment,
           isHeartbeat: opts?.isHeartbeat === true,
           isSubagentSession: isSubagentSessionKey(replySessionKey ?? run.sessionKey),
           hasVisibleDelivery: hasCommittedDelivery || hasCompletedTerminalDelivery,

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -55,6 +55,7 @@ import {
   registerAgentRunContext,
 } from "../../infra/agent-events.js";
 import { formatErrorMessage } from "../../infra/errors.js";
+import { isSubagentSessionKey } from "../../routing/session-key.js";
 import { defaultRuntime } from "../../runtime.js";
 import { shouldPreserveUserFacingSessionStateForInputProvenance } from "../../sessions/input-provenance.js";
 import { resolveSendPolicy } from "../../sessions/send-policy.js";
@@ -127,6 +128,7 @@ import { admitReplyTurn } from "./reply-turn-admission.js";
 import { buildReplyUsageState } from "./reply-usage-state.js";
 import { isRoutableChannel, routeReply } from "./route-reply.js";
 import { incrementRunCompactionCount, persistRunSessionUsage } from "./session-run-accounting.js";
+import { resolveSessionsYieldAckPayload } from "./sessions-yield-ack.js";
 import { resolveSourceReplyVisibilityPolicy } from "./source-reply-delivery-mode.js";
 import {
   buildStrandedReplyDeliveryFailurePayload,
@@ -1878,6 +1880,19 @@ export function createFollowupRunner(params: {
           (payload) => hasOutboundReplyContent(payload) && !deliveryPlan.isSilentPayload(payload),
         );
       let finalPayloads = resolveDeliveryPayloads(runResult.payloads ?? []);
+      // Mirror agent-runner: synthesize sessions_yield ack when empty and no other delivery.
+      if (finalPayloads.length === 0) {
+        const yieldAckPayload = resolveSessionsYieldAckPayload({
+          yielded: runResult.meta?.yielded === true,
+          yieldMessage: runResult.meta?.yieldMessage,
+          isHeartbeat: opts?.isHeartbeat === true,
+          isSubagentSession: isSubagentSessionKey(replySessionKey ?? run.sessionKey),
+          hasVisibleDelivery: hasCommittedDelivery || hasCompletedTerminalDelivery,
+        });
+        if (yieldAckPayload) {
+          finalPayloads = resolveDeliveryPayloads([yieldAckPayload]);
+        }
+      }
       const hasTerminalReplyPayload = finalPayloads.some(
         (payload) =>
           payload.isReasoning !== true &&

--- a/src/auto-reply/reply/sessions-yield-ack.test.ts
+++ b/src/auto-reply/reply/sessions-yield-ack.test.ts
@@ -2,11 +2,11 @@ import { describe, expect, it } from "vitest";
 import { resolveSessionsYieldAckPayload } from "./sessions-yield-ack.js";
 
 describe("resolveSessionsYieldAckPayload", () => {
-  it("emits the yield message when the turn has no other visible delivery", () => {
+  it("emits the explicit acknowledgment when the turn has no other visible delivery", () => {
     expect(
       resolveSessionsYieldAckPayload({
         yielded: true,
-        yieldMessage: "Research started, I'll send results shortly",
+        yieldAcknowledgment: "Research started, I'll send results shortly",
         isHeartbeat: false,
         isSubagentSession: false,
         hasVisibleDelivery: false,
@@ -14,11 +14,11 @@ describe("resolveSessionsYieldAckPayload", () => {
     ).toEqual({ text: "Research started, I'll send results shortly" });
   });
 
-  it("trims whitespace from the yield message", () => {
+  it("trims whitespace from the acknowledgment", () => {
     expect(
       resolveSessionsYieldAckPayload({
         yielded: true,
-        yieldMessage: "  waiting on workers  ",
+        yieldAcknowledgment: "  waiting on workers  ",
         isHeartbeat: false,
         isSubagentSession: false,
         hasVisibleDelivery: false,
@@ -30,7 +30,7 @@ describe("resolveSessionsYieldAckPayload", () => {
     expect(
       resolveSessionsYieldAckPayload({
         yielded: false,
-        yieldMessage: "should not show",
+        yieldAcknowledgment: "should not show",
         isHeartbeat: false,
         isSubagentSession: false,
         hasVisibleDelivery: false,
@@ -38,11 +38,21 @@ describe("resolveSessionsYieldAckPayload", () => {
     ).toBeUndefined();
   });
 
-  it("stays silent when yield has no message", () => {
+  it("stays silent when yield has no acknowledgment (hidden message is not used)", () => {
+    // Regression: shipped `message` remains hidden continuation context and
+    // must never be inferred as user-visible text by this resolver.
     expect(
       resolveSessionsYieldAckPayload({
         yielded: true,
-        yieldMessage: "   ",
+        yieldAcknowledgment: "   ",
+        isHeartbeat: false,
+        isSubagentSession: false,
+        hasVisibleDelivery: false,
+      }),
+    ).toBeUndefined();
+    expect(
+      resolveSessionsYieldAckPayload({
+        yielded: true,
         isHeartbeat: false,
         isSubagentSession: false,
         hasVisibleDelivery: false,
@@ -54,7 +64,7 @@ describe("resolveSessionsYieldAckPayload", () => {
     expect(
       resolveSessionsYieldAckPayload({
         yielded: true,
-        yieldMessage: "Research started",
+        yieldAcknowledgment: "Research started",
         isHeartbeat: false,
         isSubagentSession: false,
         hasVisibleDelivery: true,
@@ -66,7 +76,7 @@ describe("resolveSessionsYieldAckPayload", () => {
     expect(
       resolveSessionsYieldAckPayload({
         yielded: true,
-        yieldMessage: "heartbeat yield",
+        yieldAcknowledgment: "heartbeat yield",
         isHeartbeat: true,
         isSubagentSession: false,
         hasVisibleDelivery: false,
@@ -78,7 +88,7 @@ describe("resolveSessionsYieldAckPayload", () => {
     expect(
       resolveSessionsYieldAckPayload({
         yielded: true,
-        yieldMessage: "child yield",
+        yieldAcknowledgment: "child yield",
         isHeartbeat: false,
         isSubagentSession: true,
         hasVisibleDelivery: false,

--- a/src/auto-reply/reply/sessions-yield-ack.test.ts
+++ b/src/auto-reply/reply/sessions-yield-ack.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import { resolveSessionsYieldAckPayload } from "./sessions-yield-ack.js";
+
+describe("resolveSessionsYieldAckPayload", () => {
+  it("emits the yield message when the turn has no other visible delivery", () => {
+    expect(
+      resolveSessionsYieldAckPayload({
+        yielded: true,
+        yieldMessage: "Research started, I'll send results shortly",
+        isHeartbeat: false,
+        isSubagentSession: false,
+        hasVisibleDelivery: false,
+      }),
+    ).toEqual({ text: "Research started, I'll send results shortly" });
+  });
+
+  it("trims whitespace from the yield message", () => {
+    expect(
+      resolveSessionsYieldAckPayload({
+        yielded: true,
+        yieldMessage: "  waiting on workers  ",
+        isHeartbeat: false,
+        isSubagentSession: false,
+        hasVisibleDelivery: false,
+      }),
+    ).toEqual({ text: "waiting on workers" });
+  });
+
+  it("stays silent without a yield flag", () => {
+    expect(
+      resolveSessionsYieldAckPayload({
+        yielded: false,
+        yieldMessage: "should not show",
+        isHeartbeat: false,
+        isSubagentSession: false,
+        hasVisibleDelivery: false,
+      }),
+    ).toBeUndefined();
+  });
+
+  it("stays silent when yield has no message", () => {
+    expect(
+      resolveSessionsYieldAckPayload({
+        yielded: true,
+        yieldMessage: "   ",
+        isHeartbeat: false,
+        isSubagentSession: false,
+        hasVisibleDelivery: false,
+      }),
+    ).toBeUndefined();
+  });
+
+  it("does not duplicate when the turn already has visible delivery", () => {
+    expect(
+      resolveSessionsYieldAckPayload({
+        yielded: true,
+        yieldMessage: "Research started",
+        isHeartbeat: false,
+        isSubagentSession: false,
+        hasVisibleDelivery: true,
+      }),
+    ).toBeUndefined();
+  });
+
+  it("keeps heartbeat yields internal", () => {
+    expect(
+      resolveSessionsYieldAckPayload({
+        yielded: true,
+        yieldMessage: "heartbeat yield",
+        isHeartbeat: true,
+        isSubagentSession: false,
+        hasVisibleDelivery: false,
+      }),
+    ).toBeUndefined();
+  });
+
+  it("keeps subagent-session yields internal", () => {
+    expect(
+      resolveSessionsYieldAckPayload({
+        yielded: true,
+        yieldMessage: "child yield",
+        isHeartbeat: false,
+        isSubagentSession: true,
+        hasVisibleDelivery: false,
+      }),
+    ).toBeUndefined();
+  });
+});

--- a/src/auto-reply/reply/sessions-yield-ack.ts
+++ b/src/auto-reply/reply/sessions-yield-ack.ts
@@ -1,0 +1,26 @@
+/**
+ * Resolve a one-shot user-facing sessions_yield acknowledgment payload.
+ *
+ * Only emits when the attempt yielded with a non-empty message and the turn
+ * produced no other visible delivery. Heartbeat and subagent sessions keep the
+ * message as internal context only.
+ */
+export function resolveSessionsYieldAckPayload(params: {
+  yieldMessage?: string | null;
+  yielded?: boolean;
+  isHeartbeat: boolean;
+  isSubagentSession: boolean;
+  hasVisibleDelivery: boolean;
+}): { text: string } | undefined {
+  if (params.yielded !== true) {
+    return undefined;
+  }
+  if (params.isHeartbeat || params.isSubagentSession || params.hasVisibleDelivery) {
+    return undefined;
+  }
+  const text = typeof params.yieldMessage === "string" ? params.yieldMessage.trim() : "";
+  if (!text) {
+    return undefined;
+  }
+  return { text };
+}

--- a/src/auto-reply/reply/sessions-yield-ack.ts
+++ b/src/auto-reply/reply/sessions-yield-ack.ts
@@ -1,12 +1,14 @@
 /**
  * Resolve a one-shot user-facing sessions_yield acknowledgment payload.
  *
- * Only emits when the attempt yielded with a non-empty message and the turn
- * produced no other visible delivery. Heartbeat and subagent sessions keep the
- * message as internal context only.
+ * Only emits when the attempt yielded with an explicit non-empty acknowledgment
+ * and the turn produced no other visible delivery. Hidden `message` context is
+ * never used here — that field remains internal continuation text.
+ * Heartbeat and subagent sessions keep yields as internal context only.
  */
 export function resolveSessionsYieldAckPayload(params: {
-  yieldMessage?: string | null;
+  /** Explicit user-visible acknowledgment only; never the hidden yield message. */
+  yieldAcknowledgment?: string | null;
   yielded?: boolean;
   isHeartbeat: boolean;
   isSubagentSession: boolean;
@@ -18,7 +20,8 @@ export function resolveSessionsYieldAckPayload(params: {
   if (params.isHeartbeat || params.isSubagentSession || params.hasVisibleDelivery) {
     return undefined;
   }
-  const text = typeof params.yieldMessage === "string" ? params.yieldMessage.trim() : "";
+  const text =
+    typeof params.yieldAcknowledgment === "string" ? params.yieldAcknowledgment.trim() : "";
   if (!text) {
     return undefined;
   }

--- a/src/gateway/mcp-http.loopback-runtime.ts
+++ b/src/gateway/mcp-http.loopback-runtime.ts
@@ -23,7 +23,7 @@ export type McpLoopbackToolCallStart = Pick<McpLoopbackToolCallResult, "toolName
 
 type McpLoopbackToolCallCapture = {
   generation: number;
-  onYield?: (message: string) => Promise<void> | void;
+  onYield?: (message: string, acknowledgment?: string) => Promise<void> | void;
   onRequestStart?: () => void;
   onRequestClassified?: () => void;
   onRequestFinish?: () => void;
@@ -80,7 +80,7 @@ function notifyMcpLoopbackToolCallCaptureActivity(capture: McpLoopbackToolCallCa
 /** Start loopback tool-call result capture for one serialized CLI invocation. */
 export function beginMcpLoopbackToolCallCapture(params: {
   captureKey: string;
-  onYield?: (message: string) => Promise<void> | void;
+  onYield?: (message: string, acknowledgment?: string) => Promise<void> | void;
   onRequestStart?: () => void;
   onRequestClassified?: () => void;
   onRequestFinish?: () => void;
@@ -116,15 +116,20 @@ export function beginMcpLoopbackToolCallCapture(params: {
 /** Resolve yield state bound to the request's admitted CLI capture generation. */
 export function resolveMcpLoopbackYieldContext(
   captureHandle: McpLoopbackRequestCaptureHandle | undefined,
-): { cacheKey: string; onYield: (message: string) => Promise<void> } | undefined {
+):
+  | {
+      cacheKey: string;
+      onYield: (message: string, acknowledgment?: string) => Promise<void>;
+    }
+  | undefined {
   const capture = captureHandle?.capture;
   if (!capture?.onYield) {
     return undefined;
   }
   return {
     cacheKey: String(capture.generation),
-    onYield: async (message: string) => {
-      await capture.onYield?.(message);
+    onYield: async (message: string, acknowledgment?: string) => {
+      await capture.onYield?.(message, acknowledgment);
     },
   };
 }

--- a/src/gateway/mcp-http.runtime.ts
+++ b/src/gateway/mcp-http.runtime.ts
@@ -40,7 +40,7 @@ type McpLoopbackScopeParams = {
   modelProvider?: string;
   modelId?: string;
   yieldContextCacheKey?: string;
-  onYield?: (message: string) => Promise<void> | void;
+  onYield?: (message: string, acknowledgment?: string) => Promise<void> | void;
   messageProvider: string | undefined;
   clientCaps?: string[];
   currentChannelId: string | undefined;

--- a/src/gateway/mcp-http.test.ts
+++ b/src/gateway/mcp-http.test.ts
@@ -48,7 +48,7 @@ type ScopedToolsCall = {
   modelProvider?: string;
   modelId?: string;
   yieldContextCacheKey?: string;
-  onYield?: (message: string) => Promise<void> | void;
+  onYield?: (message: string, acknowledgment?: string) => Promise<void> | void;
   accountId?: string;
   messageProvider?: string;
   clientCaps?: string[];

--- a/src/gateway/tool-resolution.ts
+++ b/src/gateway/tool-resolution.ts
@@ -69,7 +69,7 @@ export function resolveGatewayScopedTools(params: {
   sessionId?: string;
   modelProvider?: string;
   modelId?: string;
-  onYield?: (message: string) => Promise<void> | void;
+  onYield?: (message: string, acknowledgment?: string) => Promise<void> | void;
   messageProvider?: string;
   currentChannelId?: string;
   currentThreadTs?: string;


### PR DESCRIPTION
Fixes #107788

## What Problem This Solves

Fixes an issue where users on spawn-and-yield turns would see no interim acknowledgment when the model intended a user-visible yield notice, leaving the chat silent until the subagent announce arrived minutes later.

## Why This Change Was Made

`sessions_yield.message` shipped as hidden follow-up context for the next turn. This PR keeps that contract and adds an explicit optional `acknowledgment` field for user-visible empty-turn text.

Both harnesses (embedded runner and Codex app-server) carry the acknowledgment as an attempt-local fact, and the shared reply pipeline emits it once when the turn has no other visible delivery. Heartbeat and subagent sessions keep yields internal. Compatibility is additive: optional tool param + optional `meta.yieldAcknowledgment` only; no config/env changes.

## User Impact

When an agent yields after spawning background work and supplies `acknowledgment` (for example "Research started…"), users receive that notice immediately instead of sitting through multi-minute silence until the subagent announces results. Existing `message`-only yields stay hidden continuation context and do not become channel text.

## Evidence

Verification host: local macOS (Crabbox bypass).

Focused tests:
```text
node scripts/run-vitest.mjs \
  src/auto-reply/reply/sessions-yield-ack.test.ts \
  src/agents/tools/sessions-yield-tool.test.ts \
  src/agents/embedded-agent-runner/sessions-yield.orchestration.test.ts
# 7 + 5 + 4 passed

node scripts/run-vitest.mjs run --config test/vitest/vitest.e2e.config.ts \
  src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts \
  -t 'sessions_yield'
# 2 passed (ack delivery + silent without acknowledgment)
```

Static: `git diff --check` clean on touched files; oxfmt applied via committer.

## Real behavior proof

- Behavior addressed: empty spawn-and-yield turns deliver only an explicit `sessions_yield.acknowledgment`; shipped `message` remains hidden continuation context and is never synthesized into outbound reply text.
- Environment: local macOS openclaw checkout at the PR head; focused Vitest unit + e2e harness (no live channel tenant required for the contract split).
- Current-main contrast: yield paths set only `meta.yielded` / `yieldDetected` and the reply runner early-exits on an empty payload array, so no user-visible empty-turn acknowledgment exists.
- Exact steps or command run after this patch:
  1. `node scripts/run-vitest.mjs src/agents/tools/sessions-yield-tool.test.ts` — tool passes `message` and `acknowledgment` separately; message-only yields do not invent an acknowledgment.
  2. `node scripts/run-vitest.mjs src/auto-reply/reply/sessions-yield-ack.test.ts` — resolver emits only for non-empty `yieldAcknowledgment`; heartbeat/subagent/visible-delivery suppress.
  3. `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/sessions-yield.orchestration.test.ts` — attempt result carries `meta.yieldAcknowledgment` with `yielded: true`.
  4. `node scripts/run-vitest.mjs run --config test/vitest/vitest.e2e.config.ts src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts -t 'sessions_yield'` — empty payloads + `meta.yieldAcknowledgment` produce a reply payload; yielded without acknowledgment stays silent.
- Evidence after fix: orchestration asserts `result.meta.yieldAcknowledgment === "Research started, I'll send results shortly"`; e2e asserts delivery of that text and silence when only `yielded: true`; unit tests cover no-duplicate / heartbeat / subagent silence and no inference from hidden message.
- Control check: yielded without acknowledgment stays silent; presence of visible delivery, heartbeat, or subagent session suppresses synthesis; hidden `message` alone never becomes channel text.
- Observed result after fix: empty spawn-and-yield turns with an explicit acknowledgment surface that text through the canonical reply path; silent continuation with only hidden `message` is preserved.
- What was not tested: live Telegram/channel recording of a multi-minute subagent wait (still available via Mantis if maintainers want chat-visible timing proof after the contract split).

## AI disclosure

This PR was authored with AI assistance (Grok).