### PR TITLE
fix(qa-lab): preserve Unicode in capped evidence previews

### DIFF
--- a/extensions/qa-lab/src/evidence-gallery.ts
+++ b/extensions/qa-lab/src/evidence-gallery.ts
@@ -398,9 +398,18 @@ async function readPreview(filePath: string, mediaKind: QaEvidenceArtifactView["
   const handle = await fs.open(filePath, "r");
   try {
     const buffer = Buffer.alloc(TEXT_PREVIEW_BYTES + 1);
-    const { bytesRead } = await handle.read(buffer, 0, buffer.length, 0);
+    let bytesRead = 0;
+    while (bytesRead < buffer.length) {
+      const result = await handle.read(buffer, bytesRead, buffer.length - bytesRead, bytesRead);
+      if (result.bytesRead === 0) {
+        break;
+      }
+      bytesRead += result.bytesRead;
+    }
     const decoder = new StringDecoder("utf8");
     let text = decoder.write(buffer.subarray(0, Math.min(bytesRead, TEXT_PREVIEW_BYTES)));
+    // The sentinel distinguishes a capped preview from real EOF. Only real EOF should
+    // flush an incomplete final sequence as a replacement character.
     if (bytesRead <= TEXT_PREVIEW_BYTES) {
       text += decoder.end();
     }

--- a/extensions/qa-lab/src/evidence-gallery.ts
+++ b/extensions/qa-lab/src/evidence-gallery.ts
@@ -2,6 +2,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { StringDecoder } from "node:string_decoder";
 import { pathToFileURL } from "node:url";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import pLimit from "p-limit";
@@ -396,9 +397,13 @@ async function readPreview(filePath: string, mediaKind: QaEvidenceArtifactView["
   }
   const handle = await fs.open(filePath, "r");
   try {
-    const buffer = Buffer.alloc(TEXT_PREVIEW_BYTES);
-    const { bytesRead } = await handle.read(buffer, 0, TEXT_PREVIEW_BYTES, 0);
-    const text = buffer.subarray(0, bytesRead).toString("utf8");
+    const buffer = Buffer.alloc(TEXT_PREVIEW_BYTES + 1);
+    const { bytesRead } = await handle.read(buffer, 0, buffer.length, 0);
+    const decoder = new StringDecoder("utf8");
+    let text = decoder.write(buffer.subarray(0, Math.min(bytesRead, TEXT_PREVIEW_BYTES)));
+    if (bytesRead <= TEXT_PREVIEW_BYTES) {
+      text += decoder.end();
+    }
     if (mediaKind !== "json") {
       return text;
     }

--- a/extensions/qa-lab/src/lab-server.test.ts
+++ b/extensions/qa-lab/src/lab-server.test.ts
@@ -1,5 +1,5 @@
 // Qa Lab tests cover lab server plugin behavior.
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import fs, { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { createServer } from "node:http";
 import os from "node:os";
 import path from "node:path";
@@ -606,9 +606,13 @@ describe("qa-lab server", () => {
     const repoRoot = await createQaLabRepoRootFixture();
     const evidenceDir = path.join(repoRoot, ".artifacts", "qa-e2e", "utf8-preview");
     const previewBytes = 12 * 1024;
+    const shortReadBytes = 1024;
+    const readBoundaryPrefix = "a".repeat(shortReadBytes - 1);
+    const readBoundaryText = `${readBoundaryPrefix}😀tail`;
     const splitPrefix = "a".repeat(previewBytes - 1);
     const completePrefix = "a".repeat(previewBytes - Buffer.byteLength("😀"));
     await mkdir(evidenceDir, { recursive: true });
+    await writeFile(path.join(evidenceDir, "short-read.log"), readBoundaryText, "utf8");
     await writeFile(path.join(evidenceDir, "split.log"), `${splitPrefix}😀tail`, "utf8");
     await writeFile(path.join(evidenceDir, "complete.log"), `${completePrefix}😀tail`, "utf8");
     await writeFile(
@@ -641,6 +645,7 @@ describe("qa-lab server", () => {
                 },
                 packageSource: { kind: "source-checkout" },
                 artifacts: [
+                  { kind: "log", path: "short-read.log", source: "vitest" },
                   { kind: "log", path: "split.log", source: "vitest" },
                   { kind: "log", path: "complete.log", source: "vitest" },
                 ],
@@ -654,6 +659,27 @@ describe("qa-lab server", () => {
       )}\n`,
       "utf8",
     );
+
+    const realOpen = fs.open;
+    const readPositions = new Map<string, number[]>();
+    const openSpy = vi.spyOn(fs, "open").mockImplementation(async (filePath, flags, mode) => {
+      const handle = await realOpen(filePath, flags, mode);
+      const realRead = handle.read.bind(handle);
+      const artifactName = path.basename(filePath.toString());
+      Object.defineProperty(handle, "read", {
+        configurable: true,
+        value: async (buffer: Buffer, offset: number, length: number, position: number) => {
+          const positions = readPositions.get(artifactName) ?? [];
+          positions.push(position);
+          readPositions.set(artifactName, positions);
+          return await realRead(buffer, offset, Math.min(length, shortReadBytes), position);
+        },
+      });
+      return handle;
+    });
+    cleanups.push(async () => {
+      openSpy.mockRestore();
+    });
 
     const lab = await startQaLabServerForTest({
       host: "127.0.0.1",
@@ -672,10 +698,14 @@ describe("qa-lab server", () => {
       evidence: { entries: Array<{ artifacts: Array<{ path: string; preview: string | null }> }> };
     };
     const artifacts = payload.evidence.entries[0]?.artifacts ?? [];
+    const shortRead = artifacts.find((artifact) => artifact.path.endsWith("short-read.log"));
     const split = artifacts.find((artifact) => artifact.path.endsWith("split.log"));
     const complete = artifacts.find((artifact) => artifact.path.endsWith("complete.log"));
+    expect(shortRead?.preview).toBe(readBoundaryText);
     expect(split?.preview).toBe(splitPrefix);
     expect(complete?.preview).toBe(`${completePrefix}😀`);
+    expect(readPositions.get("short-read.log")?.slice(0, 2)).toEqual([0, shortReadBytes]);
+    expect(readPositions.get("short-read.log")?.at(-1)).toBe(Buffer.byteLength(readBoundaryText));
     expect(JSON.stringify(payload)).not.toContain("�");
   });
 

--- a/extensions/qa-lab/src/lab-server.test.ts
+++ b/extensions/qa-lab/src/lab-server.test.ts
@@ -602,6 +602,83 @@ describe("qa-lab server", () => {
     expect(outsideResponse.status).toBe(404);
   });
 
+  it("preserves UTF-8 at the evidence preview byte boundary", async () => {
+    const repoRoot = await createQaLabRepoRootFixture();
+    const evidenceDir = path.join(repoRoot, ".artifacts", "qa-e2e", "utf8-preview");
+    const previewBytes = 12 * 1024;
+    const splitPrefix = "a".repeat(previewBytes - 1);
+    const completePrefix = "a".repeat(previewBytes - Buffer.byteLength("😀"));
+    await mkdir(evidenceDir, { recursive: true });
+    await writeFile(path.join(evidenceDir, "split.log"), `${splitPrefix}😀tail`, "utf8");
+    await writeFile(path.join(evidenceDir, "complete.log"), `${completePrefix}😀tail`, "utf8");
+    await writeFile(
+      path.join(evidenceDir, "qa-evidence.json"),
+      `${JSON.stringify(
+        {
+          kind: "openclaw.qa.evidence-summary",
+          schemaVersion: 2,
+          generatedAt: "2026-07-16T00:00:00.000Z",
+          evidenceMode: "full",
+          entries: [
+            {
+              test: {
+                kind: "vitest-test",
+                id: "qa-lab.utf8-preview-boundary",
+                title: "UTF-8 preview boundary",
+              },
+              coverage: [{ id: "qa.evidence-preview", role: "primary" }],
+              execution: {
+                runner: "vitest",
+                environment: {
+                  ref: "utf8-preview-test",
+                  os: process.platform,
+                  nodeVersion: process.version,
+                },
+                provider: {
+                  id: "mock-openai",
+                  live: false,
+                  model: { name: "mock-openai/gpt-5.6-luna", ref: "mock-openai/gpt-5.6-luna" },
+                },
+                packageSource: { kind: "source-checkout" },
+                artifacts: [
+                  { kind: "log", path: "split.log", source: "vitest" },
+                  { kind: "log", path: "complete.log", source: "vitest" },
+                ],
+              },
+              result: { status: "pass" },
+            },
+          ],
+        },
+        null,
+        2,
+      )}\n`,
+      "utf8",
+    );
+
+    const lab = await startQaLabServerForTest({
+      host: "127.0.0.1",
+      port: 0,
+      repoRoot,
+    });
+    cleanups.push(async () => {
+      await lab.stop();
+    });
+    const evidenceUrl = new URL("/api/evidence", lab.baseUrl);
+    evidenceUrl.searchParams.set("path", ".artifacts/qa-e2e/utf8-preview/qa-evidence.json");
+
+    const response = await fetchWithRetry(evidenceUrl.toString());
+    expect(response.status).toBe(200);
+    const payload = (await response.json()) as {
+      evidence: { entries: Array<{ artifacts: Array<{ path: string; preview: string | null }> }> };
+    };
+    const artifacts = payload.evidence.entries[0]?.artifacts ?? [];
+    const split = artifacts.find((artifact) => artifact.path.endsWith("split.log"));
+    const complete = artifacts.find((artifact) => artifact.path.endsWith("complete.log"));
+    expect(split?.preview).toBe(splitPrefix);
+    expect(complete?.preview).toBe(`${completePrefix}😀`);
+    expect(JSON.stringify(payload)).not.toContain("�");
+  });
+
   it("returns controlled errors for malformed JSON body reads", async () => {
     const lab = await startQaLabServerForTest();
     cleanups.push(async () => {


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where contributors opening the QA Lab Evidence Gallery could see a replacement character in a text or JSON artifact preview when the 12 KiB preview boundary landed inside a valid UTF-8 code point.

## Why This Change Was Made

`readPreview()` previously decoded the fixed byte prefix directly, so a valid multibyte character cut by the cap was converted to `�`. The reader now uses one extra sentinel byte to distinguish truncation from EOF and decodes only complete characters at a truncated boundary.

This is a root-cause fix at the byte-to-text owner. It does not change the 12 KiB returned preview cap, evidence schema, JSON fallback, path sanitization, Evidence Gallery rendering, or full artifact downloads.

## User Impact

QA Lab evidence previews now end at the last complete Unicode character within the byte cap instead of showing corruption. Complete characters at the adjacent boundary remain unchanged.

## Evidence

- Latest-main check: the same real HTTP harness still reproduced the bug on `ab3f057cfd57709c80281a98c32b1b2be6caa701`, with split tail `aaaaaaaaaaa�` and control tail `aaaaaaaaaa😀`.
- Failing-first HTTP regression on unchanged production code: the split-boundary preview ended in `�`, while the adjacent complete-emoji control ended in `😀` (`1 failed`, `15 skipped`).
- Live production-path proof started the real QA Lab server, created declared text artifacts, fetched `GET /api/evidence`, and observed:

  ```text
  {"kind":"openclaw.qa-evidence-preview-utf8-boundary.v1","execution_ok":true,"problem_present":false,"observation":"status=200 split_tail=\"aaaaaaaaaaaa\" control_tail=\"aaaaaaaaaa😀\""}
  ```

- Complete QA Lab server test file: `16 passed`.
- Complete evidence gallery model test file: `5 passed`.
- `oxfmt --check` and `git diff --check` passed.
