### PR TITLE
fix(sessions): stop leaking file path as prompt content on read failure

### DIFF
--- a/src/agents/sessions/resource-loader.test.ts
+++ b/src/agents/sessions/resource-loader.test.ts
@@ -3,10 +3,37 @@
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { DefaultResourceLoader } from "./resource-loader.js";
 
 describe("DefaultResourceLoader", () => {
+  it("does not use unreadable prompt file paths as prompt content", async () => {
+    const root = mkdtempSync(join(tmpdir(), "openclaw-resource-loader-"));
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const loader = new DefaultResourceLoader({
+        cwd: root,
+        agentDir: root,
+        noExtensions: true,
+        noSkills: true,
+        noPromptTemplates: true,
+        noThemes: true,
+        noContextFiles: true,
+        systemPrompt: root,
+        appendSystemPrompt: [root],
+      });
+
+      await loader.reload();
+
+      expect(loader.getSystemPrompt()).toBeUndefined();
+      expect(loader.getAppendSystemPrompt()).toEqual([]);
+      expect(consoleError).toHaveBeenCalledTimes(2);
+    } finally {
+      consoleError.mockRestore();
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
   it("keeps deprecated SDK prompt override aliases wired to prompt transforms", async () => {
     // These aliases are deprecated but shipped SDK surface, so they still map
     // through the same transform path as the current options.

--- a/src/agents/sessions/resource-loader.test.ts
+++ b/src/agents/sessions/resource-loader.test.ts
@@ -1,14 +1,14 @@
 // Resource loader tests cover compatibility wiring for SDK prompt transform
 // aliases.
-import { mkdtempSync, rmSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import { DefaultResourceLoader } from "./resource-loader.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 describe("DefaultResourceLoader", () => {
   it("does not use unreadable prompt file paths as prompt content", async () => {
-    const root = mkdtempSync(join(tmpdir(), "openclaw-resource-loader-"));
+    const root = tempDirs.make("openclaw-resource-loader-");
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
     try {
       const loader = new DefaultResourceLoader({
@@ -30,35 +30,30 @@ describe("DefaultResourceLoader", () => {
       expect(consoleError).toHaveBeenCalledTimes(2);
     } finally {
       consoleError.mockRestore();
-      rmSync(root, { force: true, recursive: true });
     }
   });
 
   it("keeps deprecated SDK prompt override aliases wired to prompt transforms", async () => {
     // These aliases are deprecated but shipped SDK surface, so they still map
     // through the same transform path as the current options.
-    const root = mkdtempSync(join(tmpdir(), "openclaw-resource-loader-"));
-    try {
-      const loader = new DefaultResourceLoader({
-        cwd: root,
-        agentDir: root,
-        noExtensions: true,
-        noSkills: true,
-        noPromptTemplates: true,
-        noThemes: true,
-        noContextFiles: true,
-        systemPrompt: "base",
-        appendSystemPrompt: ["tail"],
-        systemPromptOverride: (base) => `${base ?? ""} legacy`,
-        appendSystemPromptOverride: (base) => [...base, "legacy"],
-      });
+    const root = tempDirs.make("openclaw-resource-loader-");
+    const loader = new DefaultResourceLoader({
+      cwd: root,
+      agentDir: root,
+      noExtensions: true,
+      noSkills: true,
+      noPromptTemplates: true,
+      noThemes: true,
+      noContextFiles: true,
+      systemPrompt: "base",
+      appendSystemPrompt: ["tail"],
+      systemPromptOverride: (base) => `${base ?? ""} legacy`,
+      appendSystemPromptOverride: (base) => [...base, "legacy"],
+    });
 
-      await loader.reload();
+    await loader.reload();
 
-      expect(loader.getSystemPrompt()).toBe("base legacy");
-      expect(loader.getAppendSystemPrompt()).toEqual(["tail", "legacy"]);
-    } finally {
-      rmSync(root, { force: true, recursive: true });
-    }
+    expect(loader.getSystemPrompt()).toBe("base legacy");
+    expect(loader.getAppendSystemPrompt()).toEqual(["tail", "legacy"]);
   });
 });

--- a/src/agents/sessions/resource-loader.ts
+++ b/src/agents/sessions/resource-loader.ts
@@ -64,7 +64,7 @@ function resolvePromptInput(input: string | undefined, description: string): str
       console.error(
         chalk.yellow(`Warning: Could not read ${description} file ${input}: ${String(error)}`),
       );
-      return input;
+      return undefined;
     }
   }
 


### PR DESCRIPTION
## What Problem This Solves

When an existing system-prompt path could not be read, `resolvePromptInput` logged the failure but then treated the filesystem path itself as literal prompt content. Both the primary and appended system-prompt paths could therefore leak into the model prompt.

## Why This Change Was Made

An existing-but-unreadable path now returns `undefined`, matching the adjacent context-file loader's fail-closed behavior. Literal prompt strings remain unchanged because the path-existence check still distinguishes them.

## User Impact

Unreadable prompt files are skipped after the existing diagnostic instead of injecting their local paths into the system prompt.

## Evidence

- Regression suite: `src/agents/sessions/resource-loader.test.ts` uses an existing unreadable path and proves the primary prompt becomes `undefined`, appended prompts become empty, and both diagnostics fire. Test temp directories use the shared auto-cleanup tracker.
- Exact reviewed head: `1932d8275e52d5c4c19a113d8aa41116f3d443be`, based on current `main` `957cc81175a3f993118951e352fd2b13e3982487`.
- Exact-head autoreview: clean, no accepted/actionable findings.
- Hosted gates: [CI run 29468372729](https://github.com/openclaw/openclaw/actions/runs/29468372729), green.
