### PR TITLE
fix(discord): keep voice participant label UTF-16 safe at truncation boundary

### DIFF
--- a/extensions/discord/src/voice/participant-context.test.ts
+++ b/extensions/discord/src/voice/participant-context.test.ts
@@ -1,0 +1,67 @@
+import type { APIVoiceState } from "discord-api-types/v10";
+// Discord voice participant labels are untrusted display names (nick / global_name /
+// username) that a user can set to arbitrary text, including emoji. normalizeLabel
+// caps them at 100 UTF-16 code units; a raw .slice(0, 100) can land inside a
+// surrogate pair, leaving a lone high surrogate that JSON.stringify then emits as
+// an escaped \udXXX in the voice roster prompt.
+import { describe, expect, it } from "vitest";
+import { formatDiscordVoiceParticipantStateLine } from "./participant-context.js";
+
+const EMOJI = "😀"; // two UTF-16 code units: high 0xD83D + low 0xDE00
+
+function hasLoneSurrogate(value: string): boolean {
+  for (let i = 0; i < value.length; i++) {
+    const code = value.charCodeAt(i);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      const next = value.charCodeAt(i + 1);
+      if (!(next >= 0xdc00 && next <= 0xdfff)) {
+        return true;
+      }
+      i += 1;
+    } else if (code >= 0xdc00 && code <= 0xdfff) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function stateWithNick(nick: string): APIVoiceState {
+  return {
+    member: { nick, user: { id: "u1", username: "user", global_name: "User" } },
+  } as unknown as APIVoiceState;
+}
+
+describe("formatDiscordVoiceParticipantStateLine: UTF-16 safe label truncation", () => {
+  it("does not split a surrogate pair at the 100-unit truncation boundary", () => {
+    // nick = 99 "a" + emoji = 101 code units. A raw .slice(0, 100) keeps the high
+    // surrogate at index 99 and drops its low half, leaving a lone surrogate.
+    const nick = "a".repeat(99) + EMOJI;
+    const line = formatDiscordVoiceParticipantStateLine({
+      userId: "123",
+      state: stateWithNick(nick),
+    });
+    expect(hasLoneSurrogate(line)).toBe(false);
+    // The emoji is dropped cleanly rather than split; the display name is 99 "a".
+    expect(line).toContain(`display_name="${"a".repeat(99)}"`);
+  });
+
+  it("keeps an emoji intact when the nick fits under the limit", () => {
+    const line = formatDiscordVoiceParticipantStateLine({
+      userId: "123",
+      state: stateWithNick(`hello ${EMOJI} world`),
+    });
+    expect(line).toContain(`display_name="hello ${EMOJI} world"`);
+    expect(hasLoneSurrogate(line)).toBe(false);
+  });
+
+  it("truncates global_name and username surrogate-safely when nick is absent", () => {
+    // global_name overflows the limit with a trailing surrogate pair.
+    const state = {
+      member: {
+        user: { id: "u1", username: "a".repeat(99) + EMOJI, global_name: "b".repeat(99) + EMOJI },
+      },
+    } as unknown as APIVoiceState;
+    const line = formatDiscordVoiceParticipantStateLine({ userId: "123", state });
+    expect(hasLoneSurrogate(line)).toBe(false);
+  });
+});

--- a/extensions/discord/src/voice/participant-context.ts
+++ b/extensions/discord/src/voice/participant-context.ts
@@ -1,4 +1,5 @@
 import type { DiscordAccountConfig, OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import type { APIVoiceState, Client } from "../internal/discord.js";
 import type { GatewayPlugin } from "../internal/gateway.js";
 import { type DiscordVoiceIngressContext, resolveDiscordVoiceIngressContext } from "./ingress.js";
@@ -23,7 +24,7 @@ function normalizeLabel(value: unknown): string | undefined {
     return undefined;
   }
   const normalized = value.replace(/\s+/g, " ").trim();
-  return normalized ? normalized.slice(0, 100) : undefined;
+  return normalized ? truncateUtf16Safe(normalized, 100) : undefined;
 }
 
 function memberLabel(state: APIVoiceState): string | undefined {


### PR DESCRIPTION
## What Problem This Solves

Discord voice participant display names (`member.nick`, `user.global_name`, `user.username`) are untrusted, user-settable labels that can contain emoji or other non-BMP characters. `normalizeLabel` in `extensions/discord/src/voice/participant-context.ts` caps these at 100 UTF-16 code units before they are formatted into the live voice roster prompt.

The cap used a raw `.slice(0, 100)`, which can land inside a UTF-16 surrogate pair: for a 101-unit label like `"a"×99 + 😀`, `slice(0, 100)` keeps the high surrogate at index 99 and drops its low half. The truncated label then flows through `formatDiscordVoiceParticipantLine` -> `JSON.stringify(label)`, so the lone surrogate is emitted as an escaped `\ud83d` inside the `display_name=` field of the roster prompt fed to the agent.

This is the same class of truncation bug already fixed in #104901 (control-ui branch labels), #107717 / #107718 / #107719 (stderr/search/worker UTF-16 safe), and the skill experience-review transcript fix - `participant-context.ts` was the one remaining site in the discord voice path that had not been migrated.

## Evidence

- `normalizeLabel` now uses `truncateUtf16Safe(normalized, 100)` from `openclaw/plugin-sdk/text-utility-runtime` - the same helper already adopted across 16 other files in the discord package (`error-body.ts`, `gateway-plugin.ts`, `message-handler.context.ts`, `native-command.options.ts`, `voice/log-preview.ts`, `voice-message.ts`, ...). `participant-context.ts` was the lone holdout.
- Added `extensions/discord/src/voice/participant-context.test.ts` (no same-name test existed before) covering:
  - **boundary split**: `"a"×99 + 😀` (101 units) -> output has no lone surrogate and `display_name` is cleanly 99 `a`s (the pair is dropped, not split);
  - **fits intact**: a short nick `hello 😀 world` is preserved whole;
  - **fallback paths**: `global_name`/`username` truncation is also surrogate-safe when `nick` is absent.

Local verification (node v22.22.3):

```
node scripts/run-vitest.mjs participant-context.test
# Test Files  1 passed (1)
# Tests       3 passed (3)

node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json   # exit 0
node scripts/run-tsgo.mjs -p tsconfig.extensions.json                       # exit 0
oxlint extensions/discord/src/voice/participant-context.ts extensions/discord/src/voice/participant-context.test.ts   # exit 0
```
