### PR TITLE
fix: show config mutations in migrate text previews

### DIFF
--- a/src/commands/migrate/output.test.ts
+++ b/src/commands/migrate/output.test.ts
@@ -76,17 +76,17 @@ describe("formatMigrationPreview", () => {
     expect(output).toContain("• gmail");
   });
 
-  it("hides config items from display and excludes them from the count", () => {
+  it("shows config items in the preview and includes them in the count", () => {
     const output = formatMigrationPreview(plan([skillItem(1), configItem()]))
       .map(stripAnsi)
       .join("\n");
 
-    expect(output).toContain("1 item, 0 conflicts, 0 sensitive items");
-    expect(output).not.toContain("Config:");
-    expect(output).not.toContain("codex-plugins-root");
+    expect(output).toContain("2 items, 0 conflicts, 0 sensitive items");
+    expect(output).toContain("Config:");
+    expect(output).toContain("codex-plugins-root");
   });
 
-  it("counts hidden config conflicts in the preview header", () => {
+  it("shows config conflicts in the preview header and config section", () => {
     const output = formatMigrationPreview({
       ...plan([skillItem(1), { ...configItem(), status: "conflict", sensitive: true }]),
       summary: {
@@ -102,9 +102,9 @@ describe("formatMigrationPreview", () => {
       .map(stripAnsi)
       .join("\n");
 
-    expect(output).toContain("1 item, 1 conflict, 1 sensitive item");
-    expect(output).not.toContain("Config:");
-    expect(output).not.toContain("codex-plugins-root");
+    expect(output).toContain("2 items, 1 conflict, 1 sensitive item");
+    expect(output).toContain("Config:");
+    expect(output).toContain("codex-plugins-root");
   });
 
   it("renders migration warnings with a warning glyph", () => {
@@ -183,6 +183,16 @@ describe("formatMigrationResult", () => {
     expect(output).toContain(
       'google-calendar (Codex plugin "google-calendar" could not be migrated automatically)',
     );
+  });
+
+  it("renders config items in the migration result", () => {
+    const output = formatMigrationResult(plan([{ ...configItem(), status: "migrated" }]))
+      .map(stripAnsi)
+      .join("\n");
+
+    expect(output).toContain("Config:");
+    expect(output).toContain("codex-plugins-root");
+    expect(output).toContain("✅");
   });
 
   it("renders warning-backed next steps with a warning glyph", () => {

--- a/src/commands/migrate/output.test.ts
+++ b/src/commands/migrate/output.test.ts
@@ -1,6 +1,10 @@
 // Migration output tests cover preview and apply result formatting plus conflict validation.
 import { describe, expect, it } from "vitest";
 import { stripAnsi } from "../../../packages/terminal-core/src/ansi.js";
+import {
+  createMigrationConfigPatchItem,
+  summarizeMigrationItems,
+} from "../../plugin-sdk/migration.js";
 import type { MigrationItem, MigrationPlan } from "../../plugins/types.js";
 import { formatMigrationPreview, formatMigrationResult } from "./output.js";
 
@@ -30,13 +34,18 @@ function pluginItem(name: string): MigrationItem {
   };
 }
 
-function configItem(): MigrationItem {
-  return {
+function configItem(
+  options: { conflict?: boolean; sensitive?: boolean; value?: unknown } = {},
+): MigrationItem {
+  return createMigrationConfigPatchItem({
     id: "config:codex-plugins-root",
-    kind: "config",
-    action: "update",
-    status: "planned",
-  };
+    target: "plugins.entries.codex.config.codexPlugins",
+    path: ["plugins", "entries", "codex", "config", "codexPlugins"],
+    value: options.value ?? { enabled: true },
+    message: "Update the Codex plugin configuration.",
+    conflict: options.conflict,
+    sensitive: options.sensitive,
+  });
 }
 
 function fakeSecret(label: string): string {
@@ -47,15 +56,7 @@ function plan(items: MigrationItem[]): MigrationPlan {
   return {
     providerId: "codex",
     source: "/tmp/codex",
-    summary: {
-      total: items.length,
-      planned: items.length,
-      migrated: 0,
-      skipped: 0,
-      conflicts: 0,
-      errors: 0,
-      sensitive: 0,
-    },
+    summary: summarizeMigrationItems(items),
     items,
   };
 }
@@ -87,24 +88,35 @@ describe("formatMigrationPreview", () => {
   });
 
   it("shows config conflicts in the preview header and config section", () => {
-    const output = formatMigrationPreview({
-      ...plan([skillItem(1), { ...configItem(), status: "conflict", sensitive: true }]),
-      summary: {
-        total: 2,
-        planned: 1,
-        migrated: 0,
-        skipped: 0,
-        conflicts: 1,
-        errors: 0,
-        sensitive: 1,
-      },
-    })
+    const output = formatMigrationPreview(
+      plan([skillItem(1), configItem({ conflict: true, sensitive: true })]),
+    )
       .map(stripAnsi)
       .join("\n");
 
     expect(output).toContain("2 items, 1 conflict, 1 sensitive item");
     expect(output).toContain("Config:");
     expect(output).toContain("codex-plugins-root");
+  });
+
+  it("never exposes sensitive config mutation values", () => {
+    const hiddenValueOne = fakeSecret("config-preview");
+    const hiddenValueTwo = fakeSecret("config-argument");
+    const output = formatMigrationPreview(
+      plan([
+        configItem({
+          sensitive: true,
+          value: { first: hiddenValueOne, args: ["--value", hiddenValueTwo] },
+        }),
+      ]),
+    )
+      .map(stripAnsi)
+      .join("\n");
+
+    expect(output).toContain("1 item, 0 conflicts, 1 sensitive item");
+    expect(output).toContain("codex-plugins-root [sensitive]");
+    expect(output).not.toContain(hiddenValueOne);
+    expect(output).not.toContain(hiddenValueTwo);
   });
 
   it("renders migration warnings with a warning glyph", () => {

--- a/src/commands/migrate/output.ts
+++ b/src/commands/migrate/output.ts
@@ -16,10 +16,9 @@ function formatPlanHeader(plan: MigrationPlan, heading: string): string[] {
   if (plan.target) {
     lines.push(`Target: ${plan.target}`);
   }
-  const visible = plan.items.filter((item) => !HIDDEN_KINDS.has(item.kind));
   lines.push(
     [
-      formatCount(visible.length, "item"),
+      formatCount(plan.items.length, "item"),
       formatCount(plan.summary.conflicts, "conflict"),
       formatCount(plan.summary.sensitive, "sensitive item"),
     ].join(", "),
@@ -36,13 +35,13 @@ const ITEM_GROUPS: ItemGroup[] = [
   { kind: "auth", heading: "Auth credentials:" },
   { kind: "skill", heading: "Skills:" },
   { kind: "plugin", heading: "Plugins:" },
+  { kind: "config", heading: "Config:" },
   { kind: "memory", heading: "Memory:" },
   { kind: "secret", heading: "Secrets:" },
   { kind: "archive", heading: "Archive:" },
   { kind: "manual", heading: "Manual review:" },
 ];
 
-const HIDDEN_KINDS = new Set(["config"]);
 const KNOWN_KINDS = new Set(ITEM_GROUPS.map((group) => group.kind));
 
 type FormatMode = "preview" | "result";
@@ -52,9 +51,6 @@ function formatPlanItems(plan: MigrationPlan, mode: FormatMode): string[] {
   const buckets = new Map<string, MigrationItem[]>();
   const other: MigrationItem[] = [];
   for (const item of plan.items) {
-    if (HIDDEN_KINDS.has(item.kind)) {
-      continue;
-    }
     if (KNOWN_KINDS.has(item.kind)) {
       const list = buckets.get(item.kind) ?? [];
       list.push(item);


### PR DESCRIPTION
Closes #108524

## What Problem This Solves

Fixes an issue where users previewing a migration would see an incomplete item count and no configuration mutations when the migration plan contained config changes.

## Why This Change Was Made

The shared migration formatter now renders config items alongside the other item kinds and counts every item in the plan. It formats the existing redacted plan; the CLI then passes that same selected plan to the provider apply path, so preview and apply do not independently re-derive the mutation set.

## User Impact

Hermes, Claude, and Codex migration previews now show the safe config mutation identifier, message, conflict state, and sensitive marker that will be applied. Secret and credential values remain omitted.

## Evidence

- `node scripts/run-vitest.mjs src/commands/migrate/output.test.ts` — 13/13 passed after the final rebase.
- `node scripts/run-vitest.mjs src/plugin-sdk/migration-sensitive-redaction.test.ts` — 1/1 passed after the final rebase.
- `node scripts/run-vitest.mjs extensions/migrate-hermes/config.test.ts` — 26/26 passed after the final rebase.
- `git diff --check origin/main...HEAD` — passed.
- Fresh branch autoreview — clean, no accepted/actionable findings.
- [Blacksmith Testbox proof](https://github.com/openclaw/openclaw/actions/runs/29485943018) — changed gate passed; source-blind CLI fixture showed one sensitive config mutation in preview and apply output, withheld both fixture values, then verified the previewed MCP server command in canonical config. Testbox `tbx_01kxn2vwtkq9wc1smtwgrm5ktp`, exit 0.

Original implementation commit by @JasmineZhangHM; PR maintained by @arkyu2077.
