### PR TITLE
fix(xiaomi): treat blank env API key as unconfigured in speech provider

### DIFF
--- a/extensions/xiaomi/speech-provider.test.ts
+++ b/extensions/xiaomi/speech-provider.test.ts
@@ -64,6 +64,16 @@ describe("buildXiaomiSpeechProvider", () => {
       process.env.XIAOMI_API_KEY = "sk-env";
       expect(provider.isConfigured({ providerConfig: {}, timeoutMs: 30000 })).toBe(true);
     });
+
+    it("returns false when XIAOMI_API_KEY env var is whitespace only", () => {
+      process.env.XIAOMI_API_KEY = "   ";
+      expect(provider.isConfigured({ providerConfig: {}, timeoutMs: 30000 })).toBe(false);
+    });
+
+    it("returns false when XIAOMI_API_KEY env var is blank", () => {
+      process.env.XIAOMI_API_KEY = "";
+      expect(provider.isConfigured({ providerConfig: {}, timeoutMs: 30000 })).toBe(false);
+    });
   });
 
   describe("resolveConfig", () => {
@@ -392,6 +402,28 @@ describe("buildXiaomiSpeechProvider", () => {
     it("throws when API key is missing", async () => {
       const savedKey = process.env.XIAOMI_API_KEY;
       delete process.env.XIAOMI_API_KEY;
+      try {
+        await expect(
+          provider.synthesize({
+            text: "Test",
+            cfg: {} as never,
+            providerConfig: {},
+            target: "audio-file",
+            timeoutMs: 30000,
+          }),
+        ).rejects.toThrow("Xiaomi API key missing");
+      } finally {
+        if (savedKey === undefined) {
+          delete process.env.XIAOMI_API_KEY;
+        } else {
+          process.env.XIAOMI_API_KEY = savedKey;
+        }
+      }
+    });
+
+    it("throws when XIAOMI_API_KEY env var is whitespace only", async () => {
+      const savedKey = process.env.XIAOMI_API_KEY;
+      process.env.XIAOMI_API_KEY = "   ";
       try {
         await expect(
           provider.synthesize({

--- a/extensions/xiaomi/speech-provider.test.ts
+++ b/extensions/xiaomi/speech-provider.test.ts
@@ -65,13 +65,8 @@ describe("buildXiaomiSpeechProvider", () => {
       expect(provider.isConfigured({ providerConfig: {}, timeoutMs: 30000 })).toBe(true);
     });
 
-    it("returns false when XIAOMI_API_KEY env var is whitespace only", () => {
-      process.env.XIAOMI_API_KEY = "   ";
-      expect(provider.isConfigured({ providerConfig: {}, timeoutMs: 30000 })).toBe(false);
-    });
-
-    it("returns false when XIAOMI_API_KEY env var is blank", () => {
-      process.env.XIAOMI_API_KEY = "";
+    it.each(["", "   "])("returns false when XIAOMI_API_KEY is blank", (apiKey) => {
+      process.env.XIAOMI_API_KEY = apiKey;
       expect(provider.isConfigured({ providerConfig: {}, timeoutMs: 30000 })).toBe(false);
     });
   });
@@ -421,19 +416,57 @@ describe("buildXiaomiSpeechProvider", () => {
       }
     });
 
-    it("throws when XIAOMI_API_KEY env var is whitespace only", async () => {
+    it("rejects blank keys before building request credentials", async () => {
+      const blank = "   ";
       const savedKey = process.env.XIAOMI_API_KEY;
-      process.env.XIAOMI_API_KEY = "   ";
+      process.env.XIAOMI_API_KEY = blank;
       try {
+        const mockFetch = vi.mocked(globalThis.fetch);
         await expect(
           provider.synthesize({
             text: "Test",
             cfg: {} as never,
-            providerConfig: {},
+            providerConfig: { apiKey: blank },
             target: "audio-file",
             timeoutMs: 30000,
           }),
         ).rejects.toThrow("Xiaomi API key missing");
+        expect(mockFetch).not.toHaveBeenCalled();
+        expect(
+          mockFetch.mock.calls.map(([, init]) => new Headers(init?.headers).get("api-key")),
+        ).toEqual([]);
+      } finally {
+        if (savedKey === undefined) {
+          delete process.env.XIAOMI_API_KEY;
+        } else {
+          process.env.XIAOMI_API_KEY = savedKey;
+        }
+      }
+    });
+
+    it("trims a padded environment key before building the credential header", async () => {
+      const padded = "  fake  ";
+      const savedKey = process.env.XIAOMI_API_KEY;
+      process.env.XIAOMI_API_KEY = padded;
+      const audio = Buffer.from("fake-mp3-audio").toString("base64");
+      const mockFetch = vi.mocked(globalThis.fetch);
+      mockFetch.mockResolvedValueOnce(
+        new Response(JSON.stringify({ choices: [{ message: { audio: { data: audio } } }] }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+      try {
+        await provider.synthesize({
+          text: "Test",
+          cfg: {} as never,
+          providerConfig: {},
+          target: "audio-file",
+          timeoutMs: 30000,
+        });
+
+        const [, init] = mockFetch.mock.calls[0] ?? [];
+        expect(new Headers(init?.headers).get("api-key")).toBe("fake");
       } finally {
         if (savedKey === undefined) {
           delete process.env.XIAOMI_API_KEY;

--- a/extensions/xiaomi/speech-provider.ts
+++ b/extensions/xiaomi/speech-provider.ts
@@ -295,11 +295,14 @@ export function buildXiaomiSpeechProvider(): SpeechProviderPlugin {
     parseDirectiveToken,
     listVoices: async () => XIAOMI_TTS_VOICES.map((voice) => ({ id: voice, name: voice })),
     isConfigured: ({ providerConfig }) =>
-      Boolean(readXiaomiTtsProviderConfig(providerConfig).apiKey || process.env.XIAOMI_API_KEY),
+      Boolean(
+        readXiaomiTtsProviderConfig(providerConfig).apiKey ||
+        trimToUndefined(process.env.XIAOMI_API_KEY),
+      ),
     synthesize: async (req) => {
       const config = readXiaomiTtsProviderConfig(req.providerConfig);
       const overrides = readXiaomiTtsOverrides(req.providerOverrides);
-      const apiKey = config.apiKey || process.env.XIAOMI_API_KEY;
+      const apiKey = config.apiKey || trimToUndefined(process.env.XIAOMI_API_KEY);
       if (!apiKey) {
         throw new Error("Xiaomi API key missing");
       }

--- a/extensions/xiaomi/speech-provider.ts
+++ b/extensions/xiaomi/speech-provider.ts
@@ -12,7 +12,11 @@ import type {
   SpeechProviderOverrides,
   SpeechProviderPlugin,
 } from "openclaw/plugin-sdk/speech-core";
-import { asObject, trimToUndefined } from "openclaw/plugin-sdk/speech-core";
+import {
+  asObject,
+  resolveSpeechProviderApiKey,
+  trimToUndefined,
+} from "openclaw/plugin-sdk/speech-core";
 import {
   fetchWithSsrFGuard,
   ssrfPolicyFromHttpBaseUrlAllowedHostname,
@@ -126,6 +130,18 @@ function readXiaomiTtsProviderConfig(config: SpeechProviderConfig): XiaomiTtsPro
       normalized.voice,
     format: normalizeXiaomiTtsFormat(config.format) ?? normalized.format,
     style: trimToUndefined(config.style) ?? normalized.style,
+  };
+}
+
+function resolveXiaomiTtsProviderConfig(config: SpeechProviderConfig): XiaomiTtsProviderConfig {
+  const providerConfig = readXiaomiTtsProviderConfig(config);
+  const resolvedKey = resolveSpeechProviderApiKey(
+    providerConfig.apiKey,
+    process.env.XIAOMI_API_KEY,
+  );
+  return {
+    ...providerConfig,
+    apiKey: resolvedKey,
   };
 }
 
@@ -295,21 +311,17 @@ export function buildXiaomiSpeechProvider(): SpeechProviderPlugin {
     parseDirectiveToken,
     listVoices: async () => XIAOMI_TTS_VOICES.map((voice) => ({ id: voice, name: voice })),
     isConfigured: ({ providerConfig }) =>
-      Boolean(
-        readXiaomiTtsProviderConfig(providerConfig).apiKey ||
-        trimToUndefined(process.env.XIAOMI_API_KEY),
-      ),
+      Boolean(resolveXiaomiTtsProviderConfig(providerConfig).apiKey),
     synthesize: async (req) => {
-      const config = readXiaomiTtsProviderConfig(req.providerConfig);
+      const config = resolveXiaomiTtsProviderConfig(req.providerConfig);
       const overrides = readXiaomiTtsOverrides(req.providerOverrides);
-      const apiKey = config.apiKey || trimToUndefined(process.env.XIAOMI_API_KEY);
-      if (!apiKey) {
+      if (!config.apiKey) {
         throw new Error("Xiaomi API key missing");
       }
       const outputFormat = overrides.format ?? config.format;
       const audioBuffer = await xiaomiTTS({
         text: req.text,
-        apiKey,
+        apiKey: config.apiKey,
         baseUrl: config.baseUrl,
         model: overrides.model ?? config.model,
         voice: overrides.voice ?? config.voice,


### PR DESCRIPTION
## What Problem This Solves

A whitespace-only `XIAOMI_API_KEY` made the Xiaomi MiMo speech provider report configured, then allowed an unusable credential into request construction.

This is the same blank-credential class fixed for sibling speech providers.

## Why This Change Was Made

- Use the shared `resolveSpeechProviderApiKey` contract for trimming and blank rejection.
- Keep one Xiaomi runtime resolver for configured-key-over-environment precedence.
- Make readiness and synthesis consume the same resolved configuration.
- Reject blank credentials before the guarded fetch or `api-key` header arguments are built.

## User Impact

- Before: whitespace-only credentials looked configured and failed later as a TTS request.
- After: blank credentials fail locally as missing; padded valid credentials are trimmed before the request header is built.

## Evidence

Focused production-module tests:

```text
$ node scripts/run-vitest.mjs extensions/xiaomi/speech-provider.test.ts
Test Files  1 passed (1)
Tests  22 passed (22)
```

Redacted production-module negative probe:

```text
configured=false
error=Xiaomi API key missing
fetchCalls=0
```

Hosted changed-file gate passed formatting, SDK baseline, plugin boundaries, dependency guards, extension and extension-test types, lint, storage guards, and import cycles:

- https://github.com/openclaw/openclaw/actions/runs/29495175199

## Risk / Compatibility

Low. Existing configured-key precedence remains unchanged. Only surrounding whitespace and blank values are normalized. No config, persistence, or dependency surface changes.

## Changelog

Release-note context only; no contributor-owned root changelog edit.
