### PR TITLE
fix(deepgram): treat blank env API key as unconfigured in realtime transcription

### DIFF
--- a/extensions/deepgram/realtime-transcription-provider.test.ts
+++ b/extensions/deepgram/realtime-transcription-provider.test.ts
@@ -88,6 +88,38 @@ describe("buildDeepgramRealtimeTranscriptionProvider", () => {
     );
   });
 
+  it("rejects a whitespace-only DEEPGRAM_API_KEY in createSession", () => {
+    vi.stubEnv("DEEPGRAM_API_KEY", "   ");
+    const provider = buildDeepgramRealtimeTranscriptionProvider();
+    expect(() => provider.createSession({ providerConfig: {} })).toThrow(
+      "Deepgram API key missing",
+    );
+  });
+
+  describe("isConfigured", () => {
+    it("reports not configured when DEEPGRAM_API_KEY is unset", () => {
+      const provider = buildDeepgramRealtimeTranscriptionProvider();
+      expect(provider.isConfigured({ providerConfig: {} })).toBe(false);
+    });
+
+    it("reports configured when DEEPGRAM_API_KEY is set", () => {
+      vi.stubEnv("DEEPGRAM_API_KEY", "dg-key");
+      const provider = buildDeepgramRealtimeTranscriptionProvider();
+      expect(provider.isConfigured({ providerConfig: {} })).toBe(true);
+    });
+
+    it("reports not configured when DEEPGRAM_API_KEY is whitespace only", () => {
+      vi.stubEnv("DEEPGRAM_API_KEY", "   ");
+      const provider = buildDeepgramRealtimeTranscriptionProvider();
+      expect(provider.isConfigured({ providerConfig: {} })).toBe(false);
+    });
+
+    it("reports configured via provider config apiKey", () => {
+      const provider = buildDeepgramRealtimeTranscriptionProvider();
+      expect(provider.isConfigured({ providerConfig: { apiKey: "dg-key" } })).toBe(true);
+    });
+  });
+
   it.each(["not a url", "ftp://files.example.com"])("rejects invalid endpoint %s", (baseUrl) => {
     const provider = buildDeepgramRealtimeTranscriptionProvider();
     expect(() => provider.createSession({ providerConfig: { apiKey: "dg-key", baseUrl } })).toThrow(

--- a/extensions/deepgram/realtime-transcription-provider.ts
+++ b/extensions/deepgram/realtime-transcription-provider.ts
@@ -247,10 +247,13 @@ export function buildDeepgramRealtimeTranscriptionProvider(): RealtimeTranscript
     autoSelectOrder: 35,
     resolveConfig: ({ rawConfig }) => normalizeProviderConfig(rawConfig),
     isConfigured: ({ providerConfig }) =>
-      Boolean(normalizeProviderConfig(providerConfig).apiKey || process.env.DEEPGRAM_API_KEY),
+      Boolean(
+        normalizeProviderConfig(providerConfig).apiKey ||
+        normalizeOptionalString(process.env.DEEPGRAM_API_KEY),
+      ),
     createSession: (req) => {
       const config = normalizeProviderConfig(req.providerConfig);
-      const apiKey = config.apiKey || process.env.DEEPGRAM_API_KEY;
+      const apiKey = config.apiKey || normalizeOptionalString(process.env.DEEPGRAM_API_KEY);
       if (!apiKey) {
         throw new Error("Deepgram API key missing");
       }


### PR DESCRIPTION
## What Problem This Solves

A whitespace-only `DEEPGRAM_API_KEY` made the Deepgram realtime transcription provider report configured, then sent an unusable bearer credential from `createSession`.

This is the same class of blank-credential defect that was fixed for the OpenAI speech provider in #108212 and the Xiaomi MiMo provider in #108558.

## Why This Change Was Made

- Reuse the already-imported `normalizeOptionalString` (semantically `trimToUndefined`) to normalize `process.env.DEEPGRAM_API_KEY` in `isConfigured` and `createSession`
- No new imports required — `normalizeOptionalString` was already in scope
- Reject blank credentials locally before opening a WebSocket connection

## User Impact

- Before: whitespace-only credentials looked configured and failed later during realtime transcription
- After: blank credentials fail locally as missing; valid padded credentials work with the normalized value

## Verification

- Focused suite: `extensions/deepgram/realtime-transcription-provider.test.ts`
  - New `isConfigured` test suite: unset → false, set → true, whitespace → false, config apiKey → true
  - New `createSession` test: whitespace env key → throws "Deepgram API key missing"
  - All existing tests remain passing

## Risk / Compatibility

Low. Existing explicit-config precedence remains unchanged. Only surrounding whitespace and blank env values are normalized. No config, SDK, or persistence surface changes.

## Changelog

Release-note context only; no contributor-owned root changelog edit.
