### PR TITLE
docs(ai): add PowerShell instructions to the minimal chat example

### DIFF
--- a/examples/ai-chat/README.md
+++ b/examples/ai-chat/README.md
@@ -6,11 +6,28 @@ completion. No OpenClaw application code is involved — inside this repo the
 workspace link resolves to the package's built `dist`, the same artifact npm
 consumers install, so `pnpm build` must have run first.
 
+Choose a provider and replace its placeholder with a real API key.
+
+POSIX shell commands (the Ollama command also works in PowerShell):
+
 ```sh
-ANTHROPIC_API_KEY=sk-ant-... node index.mjs "Say hello"
-OPENAI_API_KEY=sk-... node index.mjs --provider openai "Say hello"
+ANTHROPIC_API_KEY=example-anthropic-key-not-real node index.mjs "Say hello"
+OPENAI_API_KEY=example-openai-key-not-real node index.mjs --provider openai "Say hello"
 # keyless, against a local Ollama server (OLLAMA_MODEL overrides the model id)
 node index.mjs --provider ollama "Say hello"
+```
+
+PowerShell (assignments remain in this session until removed or the shell closes):
+
+```powershell
+$env:ANTHROPIC_API_KEY = "example-anthropic-key-not-real"
+node index.mjs "Say hello"
+
+$env:OPENAI_API_KEY = "example-openai-key-not-real"
+node index.mjs --provider openai "Say hello"
+
+# Clear whichever key was set.
+Remove-Item Env:ANTHROPIC_API_KEY, Env:OPENAI_API_KEY -ErrorAction SilentlyContinue
 ```
 
 Text deltas stream to stdout; stop reason and token usage go to stderr.

--- a/examples/ai-chat/README.md
+++ b/examples/ai-chat/README.md
@@ -26,8 +26,9 @@ node index.mjs "Say hello"
 $env:OPENAI_API_KEY = "example-openai-key-not-real"
 node index.mjs --provider openai "Say hello"
 
-# Clear whichever key was set.
-Remove-Item Env:ANTHROPIC_API_KEY, Env:OPENAI_API_KEY -ErrorAction SilentlyContinue
+# Clear the session-scoped keys.
+$env:ANTHROPIC_API_KEY = $null
+$env:OPENAI_API_KEY = $null
 ```
 
 Text deltas stream to stdout; stop reason and token usage go to stderr.

--- a/examples/ai-chat/index.mjs
+++ b/examples/ai-chat/index.mjs
@@ -1,8 +1,6 @@
 // Minimal @openclaw/ai consumer: one isolated runtime, built-in providers,
 // one streamed completion. Uses only the public package surface — no OpenClaw
-// application code. Run with:
-//   ANTHROPIC_API_KEY=... node index.mjs "your prompt"
-//   OPENAI_API_KEY=... node index.mjs --provider openai "your prompt"
+// application code. See README.md for build prerequisites and run commands.
 import { createLlmRuntime } from "@openclaw/ai";
 import { registerBuiltInApiProviders } from "@openclaw/ai/providers";
 


### PR DESCRIPTION
## What Problem This Solves

Resolves a documentation gap where developers following the minimal `@openclaw/ai` example from native PowerShell could not directly use the documented environment-variable commands.

The existing `KEY=value command` syntax is valid in POSIX shells, but PowerShell treats `ANTHROPIC_API_KEY=...` as an executable name and exits before Node starts.

## Why This Change Was Made

The example now provides separate POSIX and PowerShell commands, uses the repository's secret-scanner-safe placeholders, states how long PowerShell assignments remain in scope, and shows how to clear both session-scoped keys with `$env:KEY = $null`. The script header points to the README as the canonical command reference so the shell-specific instructions do not drift.

Runtime behavior, provider selection, and the keyless Ollama command are unchanged.

## User Impact

Developers can run the example from either a POSIX shell or native PowerShell without translating environment-variable syntax. PowerShell users are also shown how to remove the session-scoped API keys without waiting for the shell to close.

## Evidence

User-realistic path:

```text
@openclaw/ai reference -> examples/ai-chat -> native PowerShell
  -> copy environment-variable command -> PowerShell command parsing
  -> Node process
```

Before, the POSIX form fails before Node starts:

```text
ANTHROPIC_API_KEY=example-anthropic-key-not-real : The term ... is not recognized
CommandNotFoundException
exit 1
```

After, a no-network Node probe receives both the PowerShell environment variable and the quoted prompt:

```json
{"key":"example-anthropic-key-not-real","argv":["Say hello"]}
```

The cleanup now uses Microsoft's documented PowerShell 5.1 environment-variable contract: `$env:KEY = $null` removes that variable from the current process session, while child processes inherit assigned environment variables. See [about_Environment_Variables](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_environment_variables?view=powershell-5.1).

Validation:

- `node --check examples/ai-chat/index.mjs` - passed
- `git diff --check` - passed
- `node scripts/check-changed.mjs -- examples/ai-chat/README.md examples/ai-chat/index.mjs` - passed all fail-safe lanes on Blacksmith Testbox ([run 29494981621](https://github.com/openclaw/openclaw/actions/runs/29494981621), exit 0)
- Contributor Windows PowerShell 5.1 environment assignment and child-process probe - passed
- No real credentials or provider requests were used
