### PR TITLE
fix(ci): resolve QA Lab web model-selection import

### DIFF
--- a/extensions/qa-lab/web/src/app.ts
+++ b/extensions/qa-lab/web/src/app.ts
@@ -1,5 +1,5 @@
 // Qa Lab plugin module implements app behavior.
-import { defaultQaModelForMode, isQaFastModeEnabled } from "../../model-selection.js";
+import { defaultQaModelForMode, isQaFastModeEnabled } from "../../src/model-selection.js";
 import { normalizeCaptureSavedView, normalizeCaptureSavedViews } from "./capture-saved-view.js";
 import { formatErrorMessage } from "./errors.js";
 import { getJson, getJsonNoStore, postJson } from "./http.js";


### PR DESCRIPTION
## What Problem This Solves

`check-prod-types` is failing on refreshed PRs because `extensions/qa-lab/web/src/app.ts` imports `../../model-selection.js`, which resolves to `extensions/qa-lab/model-selection.js`. The actual shared QA Lab model-selection module lives under `extensions/qa-lab/src/model-selection.js`.

This patch keeps the baseline fix isolated from unrelated feature PRs and updates the web app import to `../../src/model-selection.js`.

## Evidence

Exact-head proof for `5d74252d526d7b202d7b7f6fc191ff5eefb3657c`:

- `PATH="..." node scripts/run-tsgo.mjs -p tsconfig.extensions.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions.tsbuildinfo` -> passed
- `PATH="..." ./node_modules/.bin/oxfmt --check --threads=1 extensions/qa-lab/web/src/app.ts` -> passed
- `PATH="..." ./node_modules/.bin/oxlint extensions/qa-lab/web/src/app.ts` -> passed
- `git diff --check upstream/main...HEAD` -> passed
