### PR TITLE
fix(oc-path): reject oversized non-ASCII path URIs

### DIFF
--- a/extensions/oc-path/src/oc-path/oc-path.ts
+++ b/extensions/oc-path/src/oc-path/oc-path.ts
@@ -133,9 +133,10 @@ export function parseOcPath(input: string): OcPath {
     fail("oc:// path must be a string", String(input), "OC_PATH_NOT_STRING");
   }
 
-  if (input.length > MAX_PATH_LENGTH) {
+  const inputBytes = Buffer.byteLength(input, "utf8");
+  if (inputBytes > MAX_PATH_LENGTH) {
     fail(
-      `oc:// path exceeds ${MAX_PATH_LENGTH} bytes (length: ${input.length})`,
+      `oc:// path exceeds ${MAX_PATH_LENGTH} bytes (length: ${inputBytes})`,
       truncateUtf16Safe(input, 80) + "…",
       "OC_PATH_TOO_LONG",
     );
@@ -146,9 +147,10 @@ export function parseOcPath(input: string): OcPath {
   let normalized = input.startsWith(BOM) ? input.slice(BOM.length) : input;
   normalized = normalized.normalize("NFC");
 
-  if (normalized.length > MAX_PATH_LENGTH) {
+  const normalizedBytes = Buffer.byteLength(normalized, "utf8");
+  if (normalizedBytes > MAX_PATH_LENGTH) {
     fail(
-      `oc:// path exceeds ${MAX_PATH_LENGTH} bytes after NFC (length: ${normalized.length})`,
+      `oc:// path exceeds ${MAX_PATH_LENGTH} bytes after NFC (length: ${normalizedBytes})`,
       truncateUtf16Safe(input, 80) + "…",
       "OC_PATH_TOO_LONG",
     );
@@ -315,9 +317,10 @@ export function formatOcPath(path: OcPath): string {
     out += "?session=" + path.session;
   }
 
-  if (out.length > MAX_PATH_LENGTH) {
+  const outputBytes = Buffer.byteLength(out, "utf8");
+  if (outputBytes > MAX_PATH_LENGTH) {
     fail(
-      `Formatted oc:// exceeds ${MAX_PATH_LENGTH} bytes (length: ${out.length})`,
+      `Formatted oc:// exceeds ${MAX_PATH_LENGTH} bytes (length: ${outputBytes})`,
       truncateUtf16Safe(out, 80) + "…",
       "OC_PATH_TOO_LONG",
     );

--- a/extensions/oc-path/src/oc-path/tests/scenarios/security-and-limits.test.ts
+++ b/extensions/oc-path/src/oc-path/tests/scenarios/security-and-limits.test.ts
@@ -102,6 +102,15 @@ describe("path-string and traversal caps", () => {
     expect(() => formatOcPath({ file: multibyteFile })).toThrow(`length: ${pathBytes}`);
   });
 
+  it("accepts multibyte paths exactly at MAX_PATH_LENGTH bytes", () => {
+    const multibyteFile = `${"界".repeat(1363)}ab`;
+    const exactPath = `oc://${multibyteFile}`;
+
+    expect(Buffer.byteLength(exactPath, "utf8")).toBe(PATH_LENGTH_LIMIT);
+    expect(parseOcPath(exactPath)).toEqual({ file: multibyteFile });
+    expect(formatOcPath({ file: multibyteFile })).toBe(exactPath);
+  });
+
   it("keeps overlong parse input UTF-16 safe", () => {
     const prefix = `oc://${"a".repeat(74)}`;
     expectUtf16SafeLimitError(

--- a/extensions/oc-path/src/oc-path/tests/scenarios/security-and-limits.test.ts
+++ b/extensions/oc-path/src/oc-path/tests/scenarios/security-and-limits.test.ts
@@ -91,6 +91,17 @@ describe("path-string and traversal caps", () => {
     );
   });
 
+  it("rejects multibyte paths above MAX_PATH_LENGTH bytes", () => {
+    const multibyteFile = "界".repeat(1400);
+    const oversizedPath = `oc://${multibyteFile}`;
+    const pathBytes = Buffer.byteLength(oversizedPath, "utf8");
+
+    expect(oversizedPath.length).toBeLessThan(PATH_LENGTH_LIMIT);
+    expect(pathBytes).toBeGreaterThan(PATH_LENGTH_LIMIT);
+    expect(() => parseOcPath(oversizedPath)).toThrow(`length: ${pathBytes}`);
+    expect(() => formatOcPath({ file: multibyteFile })).toThrow(`length: ${pathBytes}`);
+  });
+
   it("keeps overlong parse input UTF-16 safe", () => {
     const prefix = `oc://${"a".repeat(74)}`;
     expectUtf16SafeLimitError(
@@ -101,9 +112,16 @@ describe("path-string and traversal caps", () => {
 
   it("keeps post-NFC overlong parse input UTF-16 safe", () => {
     const prefix = `oc://${"a".repeat(74)}`;
-    const input = `${prefix}😀${"\u0344".repeat(PATH_LENGTH_LIMIT - prefix.length - 2)}`;
-    expect(input).toHaveLength(PATH_LENGTH_LIMIT);
-    expect(input.normalize("NFC").length).toBeGreaterThan(PATH_LENGTH_LIMIT);
+    const prefixBytes = Buffer.byteLength(prefix, "utf8");
+    const emoji = "😀";
+    const emojiBytes = Buffer.byteLength(emoji, "utf8");
+    const expandingCombiningMark = "\u0344";
+    const markBytes = Buffer.byteLength(expandingCombiningMark, "utf8");
+    const markCount = Math.floor((PATH_LENGTH_LIMIT - prefixBytes - emojiBytes) / markBytes);
+    const input = `${prefix}${emoji}${expandingCombiningMark.repeat(markCount)}`;
+
+    expect(Buffer.byteLength(input, "utf8")).toBeLessThanOrEqual(PATH_LENGTH_LIMIT);
+    expect(Buffer.byteLength(input.normalize("NFC"), "utf8")).toBeGreaterThan(PATH_LENGTH_LIMIT);
 
     expectUtf16SafeLimitError(() => parseOcPath(input), `${prefix}…`);
   });


### PR DESCRIPTION
<!--
Optional linked context:
Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
below this comment.

Required PR title:
type: user-facing description
Use a parenthesized scope only when it adds clarity:
fix(auth): login redirect loops when session cookie is expired

Types: feat, fix, improve, refactor, docs, chore.
For fixes, describe the user-visible symptom and trigger:
fix: task list fails to load when user has no environments
Avoid implementation details such as:
fix: add null check to task query
-->

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

<!--
Describe the concrete user, product, or operational problem.
For fixes, begin with:
"Fixes an issue where users <do X> would <experience Y> when <condition>."
or:
"Resolves a problem where..."

Name the affected UI surface or workflow. Do not describe the code-level cause here.
-->

Fixes an issue where users passing a non-ASCII `oc://` URI to OC Path could
have a value larger than the documented 4096-byte ceiling accepted as valid.
For example, the real `openclaw path validate` command accepted a 4205-byte
CJK URI because the URI occupied only 1405 JavaScript string units.

## Why This Change Was Made

<!--
In one or two sentences, explain the complete shipped solution, key design
decisions, and relevant boundaries or non-goals. Include implementation detail
only when it helps reviewers understand user-visible behavior or risk.
Avoid file-by-file narration.
-->

The canonical OC Path parser and formatter now measure the raw URI,
post-NFC URI, and formatted URI in UTF-8 bytes, and limit errors report that
same byte count. This is a root-cause correction of the existing byte-limit
contract; it does not change the URI grammar, configuration, schema, protocol,
or persistence format.

ASCII behavior is unchanged. JSONC source-size handling is intentionally out
of scope because it is a separate boundary covered by #104140.

## User Impact

<!--
State what users, operators, or developers can now do or expect. Lead with the
concrete benefit and use user-facing language. If there is no user-visible
impact, say so plainly.
-->

OC Path CLI operations now reject non-ASCII URIs whose UTF-8 representation
exceeds 4096 bytes, while continuing to accept an exactly 4096-byte multibyte
URI. Non-ASCII URIs that were previously accepted above the declared byte cap
will now fail with `OC_PATH_TOO_LONG` and an accurate byte length.

## Evidence

<!--
Show the most useful proof that this change works. Screenshots, screencasts,
terminal output, focused tests, CI results, live observations, redacted logs,
and artifact links are all useful. Include before/after evidence for visual
changes when it clarifies the result.

Reviewers will inspect the code, tests, and CI. Use this section to make the
validation easy to understand, not to restate the diff.
-->

- Before the fix, the real CLI reported a 4205-byte CJK URI as `valid: true`;
  the same invariant was still present on the immutable latest-main snapshot.
- After the fix, the real source-checkout CLI accepts an exactly 4096-byte
  multibyte URI, then rejects the 4205-byte URI with exit code 1:

  ```json
  {
    "valid": false,
    "code": "OC_PATH_TOO_LONG",
    "message": "oc:// path exceeds 4096 bytes (length: 4205)"
  }
  ```

- The affected OC Path security-and-limits test file passed: 1 file, 35 tests.
- Scoped `oxlint`, `oxfmt --check`, and `git diff --check` all passed.
- Impact-surface review covered the OC Path CLI consumers and the universal,
  edit, and YAML edit formatter callers. The regression suite covers raw UTF-8
  length, post-NFC byte growth, formatted output, exactly-at-cap behavior, and
  UTF-16-safe diagnostic truncation.
