### PR TITLE
fix(clickclack): prevent reconnect from skipping in-flight events

### DIFF
--- a/extensions/clickclack/src/gateway.test.ts
+++ b/extensions/clickclack/src/gateway.test.ts
@@ -335,6 +335,92 @@ describe("ClickClack gateway", () => {
     expect(runError).toBeUndefined();
   });
 
+  it("processes websocket events in order before reconnecting from their cursor", async () => {
+    const firstSocket = new FakeSocket();
+    const secondSocket = new FakeSocket();
+    mocks.client.websocket.mockReturnValueOnce(firstSocket).mockReturnValueOnce(secondSocket);
+    let finishFirstEvent: (() => void) | undefined;
+    mocks.handleClickClackInbound.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          finishFirstEvent = resolve;
+        }),
+    );
+    const abort = new AbortController();
+    const ctx = createGatewayContext(abort.signal);
+    const run = startClickClackGatewayAccount(ctx);
+
+    await vi.waitFor(() => expect(mocks.client.websocket).toHaveBeenCalledTimes(1));
+
+    for (const index of [1, 2]) {
+      firstSocket.emit(
+        "message",
+        Buffer.from(
+          JSON.stringify({
+            id: `evt-${index}`,
+            cursor: `cursor-${index}`,
+            type: "message.created",
+            workspace_id: "workspace-1",
+            channel_id: "chan-1",
+            seq: index + 1,
+            created_at: "2026-01-01T00:00:00.000Z",
+            payload: { message_id: "msg-1", author_id: "human-1" },
+          }),
+        ),
+      );
+    }
+    firstSocket.emit("close");
+
+    await vi.waitFor(() => expect(finishFirstEvent).toBeTypeOf("function"));
+    expect(mocks.handleClickClackInbound).toHaveBeenCalledTimes(1);
+    expect(mocks.client.websocket).toHaveBeenCalledTimes(1);
+
+    finishFirstEvent?.();
+    await vi.waitFor(() => expect(mocks.client.websocket).toHaveBeenCalledTimes(2));
+
+    expect(mocks.handleClickClackInbound).toHaveBeenCalledTimes(2);
+    expect(mocks.client.eventPage).toHaveBeenLastCalledWith("workspace-1", {
+      afterCursor: "cursor-2",
+      limit: 500,
+    });
+
+    abort.abort();
+    await run;
+  });
+
+  it("does not process or commit events queued after a failed websocket event", async () => {
+    const socket = new FakeSocket();
+    mocks.client.websocket.mockReturnValue(socket);
+    mocks.handleClickClackInbound.mockRejectedValueOnce(new Error("dispatch failed"));
+    const abort = new AbortController();
+    const ctx = createGatewayContext(abort.signal);
+    const run = startClickClackGatewayAccount(ctx);
+
+    await vi.waitFor(() => expect(mocks.client.websocket).toHaveBeenCalledTimes(1));
+
+    for (const index of [1, 2]) {
+      socket.emit(
+        "message",
+        Buffer.from(
+          JSON.stringify({
+            id: `evt-${index}`,
+            cursor: `cursor-${index}`,
+            type: "message.created",
+            workspace_id: "workspace-1",
+            channel_id: "chan-1",
+            seq: index + 1,
+            created_at: "2026-01-01T00:00:00.000Z",
+            payload: { message_id: "msg-1", author_id: "human-1" },
+          }),
+        ),
+      );
+    }
+
+    await expect(run).rejects.toThrow("dispatch failed");
+    expect(mocks.handleClickClackInbound).toHaveBeenCalledTimes(1);
+    expect(socket.close).toHaveBeenCalledOnce();
+  });
+
   it("drops messages denied by ClickClack sender access before inbound handling", async () => {
     const socket = new FakeSocket();
     mocks.client.websocket.mockReturnValue(socket);

--- a/extensions/clickclack/src/gateway.test.ts
+++ b/extensions/clickclack/src/gateway.test.ts
@@ -102,6 +102,15 @@ function createBacklogEvent(index: number, type = "channel.updated") {
   };
 }
 
+function emitMessageEvent(socket: FakeSocket, index: number) {
+  socket.emit(
+    "message",
+    Buffer.from(
+      JSON.stringify({ ...createBacklogEvent(index, "message.created"), seq: index + 1 }),
+    ),
+  );
+}
+
 describe("ClickClack gateway", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -388,9 +397,18 @@ describe("ClickClack gateway", () => {
     await run;
   });
 
-  it("does not process or commit events queued after a failed websocket event", async () => {
-    const socket = new FakeSocket();
-    mocks.client.websocket.mockReturnValue(socket);
+  it("replays a failed websocket event on reconnect without processing later queued events", async () => {
+    const firstSocket = new FakeSocket();
+    const secondSocket = new FakeSocket();
+    const events = [
+      createBacklogEvent(1, "message.created"),
+      createBacklogEvent(2, "message.created"),
+    ];
+    mocks.client.eventPage
+      .mockResolvedValueOnce({ events: [], tailCursor: "" })
+      .mockResolvedValueOnce({ events })
+      .mockResolvedValueOnce({ events: [] });
+    mocks.client.websocket.mockReturnValueOnce(firstSocket).mockReturnValueOnce(secondSocket);
     mocks.handleClickClackInbound.mockRejectedValueOnce(new Error("dispatch failed"));
     const abort = new AbortController();
     const ctx = createGatewayContext(abort.signal);
@@ -399,26 +417,55 @@ describe("ClickClack gateway", () => {
     await vi.waitFor(() => expect(mocks.client.websocket).toHaveBeenCalledTimes(1));
 
     for (const index of [1, 2]) {
-      socket.emit(
-        "message",
-        Buffer.from(
-          JSON.stringify({
-            id: `evt-${index}`,
-            cursor: `cursor-${index}`,
-            type: "message.created",
-            workspace_id: "workspace-1",
-            channel_id: "chan-1",
-            seq: index + 1,
-            created_at: "2026-01-01T00:00:00.000Z",
-            payload: { message_id: "msg-1", author_id: "human-1" },
-          }),
-        ),
-      );
+      emitMessageEvent(firstSocket, index);
     }
 
-    await expect(run).rejects.toThrow("dispatch failed");
-    expect(mocks.handleClickClackInbound).toHaveBeenCalledTimes(1);
-    expect(socket.close).toHaveBeenCalledOnce();
+    await vi.waitFor(() => expect(mocks.client.websocket).toHaveBeenCalledTimes(2));
+
+    expect(mocks.handleClickClackInbound).toHaveBeenCalledTimes(3);
+    expect(firstSocket.close).toHaveBeenCalledOnce();
+    expect(mocks.client.eventPage).toHaveBeenNthCalledWith(2, "workspace-1", {
+      afterCursor: "",
+      limit: 500,
+    });
+    expect(mocks.client.websocket).toHaveBeenLastCalledWith("workspace-1", "cursor-2");
+    expect(ctx.log?.warn).toHaveBeenCalledWith(
+      "[default] ClickClack event processing failed; reconnecting: dispatch failed",
+    );
+
+    abort.abort();
+    await run;
+  });
+
+  it("does not serialize unrelated gateway streams", async () => {
+    const slowSocket = new FakeSocket();
+    const fastSocket = new FakeSocket();
+    mocks.client.websocket.mockReturnValueOnce(slowSocket).mockReturnValueOnce(fastSocket);
+    let finishSlowEvent: (() => void) | undefined;
+    mocks.handleClickClackInbound.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          finishSlowEvent = resolve;
+        }),
+    );
+    const slowAbort = new AbortController();
+    const fastAbort = new AbortController();
+    const slowRun = startClickClackGatewayAccount(createGatewayContext(slowAbort.signal));
+    const fastRun = startClickClackGatewayAccount(createGatewayContext(fastAbort.signal));
+
+    await vi.waitFor(() => expect(mocks.client.websocket).toHaveBeenCalledTimes(2));
+
+    emitMessageEvent(slowSocket, 1);
+    await vi.waitFor(() => expect(finishSlowEvent).toBeTypeOf("function"));
+    emitMessageEvent(fastSocket, 2);
+
+    await vi.waitFor(() => expect(mocks.handleClickClackInbound).toHaveBeenCalledTimes(2));
+    expect(finishSlowEvent).toBeTypeOf("function");
+
+    finishSlowEvent?.();
+    slowAbort.abort();
+    fastAbort.abort();
+    await Promise.all([slowRun, fastRun]);
   });
 
   it("drops messages denied by ClickClack sender access before inbound handling", async () => {
@@ -628,41 +675,32 @@ describe("ClickClack gateway", () => {
     });
   });
 
-  it("wraps non-Error ws message rejections with the original value in the message", async () => {
-    const socket = new FakeSocket();
-    mocks.client.websocket.mockReturnValue(socket);
+  it("logs non-Error websocket failures before replaying them", async () => {
+    const firstSocket = new FakeSocket();
+    const secondSocket = new FakeSocket();
+    const event = createBacklogEvent(1, "message.created");
+    mocks.client.eventPage
+      .mockResolvedValueOnce({ events: [], tailCursor: "" })
+      .mockResolvedValueOnce({ events: [event] })
+      .mockResolvedValueOnce({ events: [] });
+    mocks.client.websocket.mockReturnValueOnce(firstSocket).mockReturnValueOnce(secondSocket);
     const rejection = { code: "ECONNRESET", retryable: true };
-    mocks.resolveClickClackInboundAccess.mockRejectedValue(rejection);
+    mocks.resolveClickClackInboundAccess.mockRejectedValueOnce(rejection);
     const abort = new AbortController();
     const ctx = createGatewayContext(abort.signal);
     const run = startClickClackGatewayAccount(ctx);
 
     await vi.waitFor(() => expect(mocks.client.websocket).toHaveBeenCalledTimes(1));
 
-    socket.emit(
-      "message",
-      Buffer.from(
-        JSON.stringify({
-          id: "evt-1",
-          cursor: "cursor-1",
-          type: "message.created",
-          workspace_id: "workspace-1",
-          channel_id: "chan-1",
-          seq: 2,
-          created_at: "2026-01-01T00:00:00.000Z",
-          payload: { message_id: "msg-1", author_id: "human-1" },
-        }),
-      ),
-    );
+    emitMessageEvent(firstSocket, 1);
 
-    await expect(run).rejects.toMatchObject({
-      message: 'ClickClack ws message failed: {"code":"ECONNRESET","retryable":true}',
-      cause: rejection,
-    });
-    expect(socket.close).toHaveBeenCalledOnce();
-    expect(ctx.setStatus).toHaveBeenLastCalledWith({
-      accountId: "default",
-      running: false,
-    });
+    await vi.waitFor(() => expect(mocks.client.websocket).toHaveBeenCalledTimes(2));
+    expect(ctx.log?.warn).toHaveBeenCalledWith(
+      '[default] ClickClack event processing failed; reconnecting: {"code":"ECONNRESET","retryable":true}',
+    );
+    expect(mocks.client.websocket).toHaveBeenLastCalledWith("workspace-1", "cursor-1");
+
+    abort.abort();
+    await run;
   });
 });

--- a/extensions/clickclack/src/gateway.ts
+++ b/extensions/clickclack/src/gateway.ts
@@ -239,6 +239,9 @@ export async function startClickClackGatewayAccount(
       const socket = client.websocket(workspaceId, afterCursor);
       await new Promise<void>((resolve, reject) => {
         let settled = false;
+        let closing = false;
+        let pendingMessages = 0;
+        let messageQueue = Promise.resolve();
         let removeAbortListener: (() => void) | undefined;
         const finishSocketCycle = (error?: unknown) => {
           if (settled) {
@@ -269,22 +272,39 @@ export async function startClickClackGatewayAccount(
         ctx.abortSignal.addEventListener("abort", abort, { once: true });
         removeAbortListener = () => ctx.abortSignal.removeEventListener("abort", abort);
         socket.on("message", (data) => {
-          void (async () => {
-            const event = parseSocketEvent(data);
-            if (!event) {
-              ctx.log?.warn?.(
-                `[${account.accountId}] skipped malformed ClickClack websocket event`,
-              );
-              return;
-            }
-            afterCursor = event.cursor || afterCursor;
-            await processIncomingEvent(event);
-          })().catch(finishSocketCycle);
+          // Preserve server event order and commit each cursor only after its
+          // handler succeeds, so reconnect backlog can retry a failed event.
+          pendingMessages += 1;
+          messageQueue = messageQueue
+            .then(async () => {
+              const event = parseSocketEvent(data);
+              if (!event) {
+                ctx.log?.warn?.(
+                  `[${account.accountId}] skipped malformed ClickClack websocket event`,
+                );
+                return;
+              }
+              await processIncomingEvent(event);
+              afterCursor = event.cursor || afterCursor;
+            })
+            .finally(() => {
+              pendingMessages -= 1;
+            });
+          void messageQueue.catch(finishSocketCycle);
         });
-        socket.on("close", () => finishSocketCycle());
+        socket.on("close", () => {
+          if (pendingMessages === 0) {
+            finishSocketCycle();
+            return;
+          }
+          void messageQueue.then(() => finishSocketCycle(), finishSocketCycle);
+        });
         socket.on("error", (error) => {
           if (settled || ctx.abortSignal.aborted) {
             finishSocketCycle();
+            return;
+          }
+          if (closing) {
             return;
           }
           ctx.log?.warn?.(
@@ -292,7 +312,7 @@ export async function startClickClackGatewayAccount(
               error instanceof Error ? error.message : String(error)
             }`,
           );
-          finishSocketCycle();
+          closing = true;
           socket.close();
         });
       });

--- a/extensions/clickclack/src/gateway.ts
+++ b/extensions/clickclack/src/gateway.ts
@@ -237,33 +237,47 @@ export async function startClickClackGatewayAccount(
         break;
       }
       const socket = client.websocket(workspaceId, afterCursor);
-      await new Promise<void>((resolve, reject) => {
+      await new Promise<void>((resolve) => {
         let settled = false;
         let closing = false;
-        let pendingMessages = 0;
+        let loggedMessageFailure = false;
         let messageQueue = Promise.resolve();
         let removeAbortListener: (() => void) | undefined;
-        const finishSocketCycle = (error?: unknown) => {
+        const finishSocketCycle = () => {
           if (settled) {
             return;
           }
           settled = true;
           removeAbortListener?.();
           removeAbortListener = undefined;
-          if (error === undefined) {
-            resolve();
+          resolve();
+        };
+        const finishAfterQueuedMessages = () => {
+          // The queue is scoped to this account/socket. Waiting here preserves
+          // its contiguous cursor without blocking unrelated account streams.
+          void messageQueue.then(
+            () => finishSocketCycle(),
+            () => finishSocketCycle(),
+          );
+        };
+        const reconnectAfterMessageFailure = (error: unknown) => {
+          if (settled || ctx.abortSignal.aborted) {
             return;
           }
-          // A failed message ends this socket's ownership. Closing it prevents
-          // the old connection from surviving beside the supervisor's restart.
-          socket.close();
-          reject(
-            error instanceof Error
-              ? error
-              : new Error(`ClickClack ws message failed: ${formatErrorMessage(error)}`, {
-                  cause: error,
-                }),
-          );
+          if (!loggedMessageFailure) {
+            loggedMessageFailure = true;
+            ctx.log?.warn?.(
+              `[${account.accountId}] ClickClack event processing failed; reconnecting: ${
+                error instanceof Error ? error.message : formatErrorMessage(error)
+              }`,
+            );
+          }
+          if (!closing) {
+            // Keep the last successful cursor. Reconnect backlog will replay
+            // this event; a repeated failure there remains a surfaced error.
+            closing = true;
+            socket.close();
+          }
         };
         const abort = () => {
           socket.close();
@@ -272,32 +286,27 @@ export async function startClickClackGatewayAccount(
         ctx.abortSignal.addEventListener("abort", abort, { once: true });
         removeAbortListener = () => ctx.abortSignal.removeEventListener("abort", abort);
         socket.on("message", (data) => {
-          // Preserve server event order and commit each cursor only after its
-          // handler succeeds, so reconnect backlog can retry a failed event.
-          pendingMessages += 1;
-          messageQueue = messageQueue
-            .then(async () => {
-              const event = parseSocketEvent(data);
-              if (!event) {
-                ctx.log?.warn?.(
-                  `[${account.accountId}] skipped malformed ClickClack websocket event`,
-                );
-                return;
-              }
-              await processIncomingEvent(event);
-              afterCursor = event.cursor || afterCursor;
-            })
-            .finally(() => {
-              pendingMessages -= 1;
-            });
-          void messageQueue.catch(finishSocketCycle);
-        });
-        socket.on("close", () => {
-          if (pendingMessages === 0) {
-            finishSocketCycle();
+          if (closing || settled) {
             return;
           }
-          void messageQueue.then(() => finishSocketCycle(), finishSocketCycle);
+          // Preserve server event order and commit each cursor only after its
+          // handler succeeds, so reconnect backlog can retry a failed event.
+          messageQueue = messageQueue.then(async () => {
+            const event = parseSocketEvent(data);
+            if (!event) {
+              ctx.log?.warn?.(
+                `[${account.accountId}] skipped malformed ClickClack websocket event`,
+              );
+              return;
+            }
+            await processIncomingEvent(event);
+            afterCursor = event.cursor || afterCursor;
+          });
+          void messageQueue.catch(reconnectAfterMessageFailure);
+        });
+        socket.on("close", () => {
+          closing = true;
+          finishAfterQueuedMessages();
         });
         socket.on("error", (error) => {
           if (settled || ctx.abortSignal.aborted) {


### PR DESCRIPTION
Closes #108570

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where ClickClack users could lose an inbound event when a websocket disconnect overlapped slow event processing. The gateway advanced its reconnect cursor before the event handler completed and started each message handler independently, so a reconnect could skip an in-flight or failed event.

## Why This Change Was Made

The websocket cycle is the ownership boundary for event order and cursor commitment. It now serializes message processing, commits each cursor only after that event succeeds, waits for queued handlers before a normal reconnect, and terminates the queue on the first processing failure so backlog recovery can retry from the last successful cursor.

## User Impact

ClickClack reconnects no longer acknowledge work that has not completed. Normal ordered delivery, malformed-frame skipping, shutdown aborts, and empty-queue reconnects retain their existing behavior.

## Evidence

### Real behavior proof

- **Behavior addressed:** A websocket reconnect no longer skips an event whose inbound handler is still running or has failed.
- **Real environment tested:** Linux x86_64, Node 24.15.0, commit `ac8bb62b702d92f7535068b872abc72bd10a9873` on branch `fix/clickclack-commit-cursor-after-processing`.
- **Exact steps or command run after this patch:** `node --import tsx .artifacts/verify-clickclack-cursor.ts` - started a real local HTTP/WebSocket server, delayed the first inbound handler, closed the first socket, and inspected the reconnect cursor and timing.
- **Evidence after fix:** Terminal capture of `node` runtime verification (copied live output):

  ```text
  {"result":"PASS","reconnectCursor":"cursor-1","processingAndBackoffMs":355,"websocketConnections":2}
  ```

- **Observed result after fix:** The second websocket connection opened only after the delayed handler and reconnect backoff completed, and it resumed from the successfully processed `cursor-1`.
- **What was not tested:** A production ClickClack tenant was not used; the proof used the actual gateway against a local protocol-compatible HTTP/WebSocket server. Cross-platform execution is left to CI.

### Tests and validation

```text
$ node scripts/run-vitest.mjs extensions/clickclack/src/gateway.test.ts
Test Files  1 passed (1)
Tests       19 passed (19)

$ oxfmt --check extensions/clickclack/src/gateway.ts extensions/clickclack/src/gateway.test.ts
All matched files use the correct format.

$ oxlint extensions/clickclack/src/gateway.ts extensions/clickclack/src/gateway.test.ts
EXIT=0

$ git diff --check origin/main...HEAD
EXIT=0
```

The regressions defer the first event to prove strict ordering and reconnect waiting, then reject an event to prove later queued events are neither processed nor committed.

### Risk checklist

- User-visible behavior: Yes - reconnect waits for in-flight processing and failed events remain eligible for backlog recovery.
- Config/env/migration behavior: No - no configuration, persisted schema, or migration changes.
- Security/auth/secrets/network/tool execution: No - the existing ClickClack connection and inbound authorization paths are unchanged.
- Plugins/providers/channels/SDK: Yes - this is isolated to the bundled ClickClack plugin; no SDK or cross-plugin contract changes.
- Highest-risk area: Socket close/error/abort ordering could otherwise leave a cycle unsettled or process later events after a failure.
- Mitigation: Focused tests cover delayed processing, failure, close, error, abort, malformed frames, reconnect, and backlog cursor behavior; the real server proof covers reconnect timing and cursor selection.

## AI assistance

This PR is AI-assisted. OpenAI Codex helped investigate, implement, test, and review the change. I reviewed the resulting code and understand its behavior. Automated structured review was attempted, but the local review engine failed before producing a clean/finding result; GitHub review and CI remain authoritative.
