### PR TITLE
fix(cron): allow clearing failure alert routing fields

### DIFF
--- a/packages/gateway-protocol/src/cron-validators.test.ts
+++ b/packages/gateway-protocol/src/cron-validators.test.ts
@@ -36,6 +36,17 @@ describe("cron protocol validators", () => {
     expect(validateCronAddParams(minimalAddParams)).toBe(true);
   });
 
+  it("accepts failure alert field clears only in update patches", () => {
+    const failureAlert = {
+      to: null,
+      cooldownMs: null,
+      accountId: null,
+    };
+
+    expect(validateCronUpdateParams({ id: "job-1", patch: { failureAlert } })).toBe(true);
+    expect(validateCronAddParams({ ...minimalAddParams, failureAlert })).toBe(false);
+  });
+
   it("rejects schedule integers that SQLite cannot round-trip safely", () => {
     const unsafe = Number.MAX_SAFE_INTEGER + 1;
     expect(

--- a/packages/gateway-protocol/src/cron-validators.test.ts
+++ b/packages/gateway-protocol/src/cron-validators.test.ts
@@ -38,13 +38,19 @@ describe("cron protocol validators", () => {
 
   it("accepts failure alert field clears only in update patches", () => {
     const failureAlert = {
+      after: null,
+      channel: null,
       to: null,
       cooldownMs: null,
+      includeSkipped: null,
+      mode: null,
       accountId: null,
     };
 
     expect(validateCronUpdateParams({ id: "job-1", patch: { failureAlert } })).toBe(true);
     expect(validateCronAddParams({ ...minimalAddParams, failureAlert })).toBe(false);
+    expect(validateCronUpdateParams({ id: "job-1", patch: { failureAlert: null } })).toBe(true);
+    expect(validateCronAddParams({ ...minimalAddParams, failureAlert: null })).toBe(false);
   });
 
   it("rejects schedule integers that SQLite cannot round-trip safely", () => {

--- a/packages/gateway-protocol/src/schema/cron.ts
+++ b/packages/gateway-protocol/src/schema/cron.ts
@@ -510,7 +510,9 @@ export const CronJobPatchSchema = closedObject({
   wakeMode: Type.Optional(CronWakeModeSchema),
   payload: Type.Optional(CronPayloadPatchSchema),
   delivery: Type.Optional(CronDeliveryPatchSchema),
-  failureAlert: Type.Optional(Type.Union([Type.Literal(false), CronFailureAlertPatchSchema])),
+  failureAlert: Type.Optional(
+    Type.Union([Type.Literal(false), CronFailureAlertPatchSchema, Type.Null()]),
+  ),
   state: Type.Optional(CronJobStatePatchSchema),
 });
 

--- a/packages/gateway-protocol/src/schema/cron.ts
+++ b/packages/gateway-protocol/src/schema/cron.ts
@@ -277,6 +277,16 @@ export const CronFailureAlertSchema = closedObject({
   accountId: Type.Optional(NonEmptyString),
 });
 
+const CronFailureAlertPatchSchema = closedObject({
+  after: Type.Optional(Type.Union([Type.Integer({ minimum: 1 }), Type.Null()])),
+  channel: Type.Optional(Type.Union([CronAnnounceChannelSchema, Type.Null()])),
+  to: Type.Optional(Type.Union([NonBlankString, Type.Null()])),
+  cooldownMs: Type.Optional(Type.Union([Type.Integer({ minimum: 0 }), Type.Null()])),
+  includeSkipped: Type.Optional(Type.Union([Type.Boolean(), Type.Null()])),
+  mode: Type.Optional(Type.Union([Type.Literal("announce"), Type.Literal("webhook"), Type.Null()])),
+  accountId: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
+});
+
 /** Delivery destination used when failure alerts need a separate target. */
 export const CronFailureDestinationSchema = closedObject({
   channel: Type.Optional(CronAnnounceChannelSchema),
@@ -500,7 +510,7 @@ export const CronJobPatchSchema = closedObject({
   wakeMode: Type.Optional(CronWakeModeSchema),
   payload: Type.Optional(CronPayloadPatchSchema),
   delivery: Type.Optional(CronDeliveryPatchSchema),
-  failureAlert: Type.Optional(Type.Union([Type.Literal(false), CronFailureAlertSchema])),
+  failureAlert: Type.Optional(Type.Union([Type.Literal(false), CronFailureAlertPatchSchema])),
   state: Type.Optional(CronJobStatePatchSchema),
 });
 

--- a/src/cron/service/jobs.apply-patch.test.ts
+++ b/src/cron/service/jobs.apply-patch.test.ts
@@ -1,6 +1,7 @@
 // Cron job patch tests cover applying partial updates to scheduled jobs.
 import { describe, expect, it } from "vitest";
 import { resolveCronDeliveryPlan, resolveFailureDestination } from "../delivery-plan.js";
+import { projectCronJobThroughStorageCodec } from "../store/row-codec.js";
 import type { CronJob } from "../types.js";
 import { applyJobPatch } from "./jobs.js";
 
@@ -239,5 +240,62 @@ describe("applyJobPatch delivery merge", () => {
         accountId: "bot-a",
       }),
     ).toBeNull();
+  });
+});
+
+describe("applyJobPatch failure alert merge", () => {
+  it("clears explicit fields, preserves omitted fields, and persists the result", () => {
+    const job = makeJob({
+      failureAlert: {
+        after: 2,
+        channel: "telegram",
+        to: "123456",
+        cooldownMs: 60_000,
+        includeSkipped: true,
+        mode: "announce",
+        accountId: "bot-a",
+      },
+    });
+
+    applyJobPatch(job, {
+      failureAlert: {
+        after: null,
+        to: null,
+        cooldownMs: null,
+        accountId: null,
+      },
+    });
+
+    expect(job.failureAlert).toEqual({
+      after: undefined,
+      channel: "telegram",
+      to: undefined,
+      cooldownMs: undefined,
+      includeSkipped: true,
+      mode: "announce",
+      accountId: undefined,
+    });
+    expect(projectCronJobThroughStorageCodec(job).failureAlert).toEqual({
+      channel: "telegram",
+      includeSkipped: true,
+      mode: "announce",
+    });
+
+    applyJobPatch(job, {
+      failureAlert: { channel: null, includeSkipped: null, mode: null },
+    });
+    expect(projectCronJobThroughStorageCodec(job).failureAlert).toEqual({});
+  });
+
+  it("clears the whole override only for explicit null", () => {
+    const original = { after: 2, channel: "telegram" as const };
+    const job = makeJob({ failureAlert: original });
+
+    applyJobPatch(job, {});
+    expect(job.failureAlert).toEqual(original);
+
+    applyJobPatch(job, { failureAlert: null });
+    expect(job.failureAlert).toBeUndefined();
+    expect(projectCronJobThroughStorageCodec(job).failureAlert).toBeUndefined();
   });
 });

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -25,6 +25,7 @@ import type {
   CronDelivery,
   CronDeliveryPatch,
   CronFailureAlert,
+  CronFailureAlertPatch,
   CronJob,
   CronJobCreate,
   CronJobPatch,
@@ -1252,10 +1253,13 @@ function mergeCronDelivery(
 
 function mergeCronFailureAlert(
   existing: CronFailureAlert | false | undefined,
-  patch: CronFailureAlert | false | undefined,
+  patch: CronFailureAlertPatch | false | null | undefined,
 ): CronFailureAlert | false | undefined {
   if (patch === false) {
     return false;
+  }
+  if (patch === null) {
+    return undefined;
   }
   if (patch === undefined) {
     return existing;

--- a/src/cron/types.ts
+++ b/src/cron/types.ts
@@ -233,6 +233,11 @@ export type CronFailureAlert = {
   accountId?: string;
 };
 
+/** Partial failure-alert update; null clears an inherited field override. */
+export type CronFailureAlertPatch = {
+  [K in keyof CronFailureAlert]?: CronFailureAlert[K] | null;
+};
+
 /** Payload variants cron can execute in main-session or detached modes. */
 export type CronPayload =
   | ({ kind: "systemEvent"; text: string } & CronPayloadToolAllow)
@@ -416,6 +421,7 @@ export type CronJobPatch = Partial<
     | "state"
     | "payload"
     | "delivery"
+    | "failureAlert"
     | "declarationKey"
     | "displayName"
     | "owner"
@@ -425,5 +431,6 @@ export type CronJobPatch = Partial<
   trigger?: CronTrigger | null;
   payload?: CronPayloadPatch;
   delivery?: CronDeliveryPatch;
+  failureAlert?: CronFailureAlertPatch | false | null;
   state?: Partial<CronJobState>;
 };

--- a/src/gateway/server-methods/cron.validation.test.ts
+++ b/src/gateway/server-methods/cron.validation.test.ts
@@ -1365,6 +1365,32 @@ describe("cron method validation", () => {
     expectCronSuccess(respond);
   });
 
+  it("passes explicit failure alert clears through cron.update", async () => {
+    const failureAlert = {
+      after: null,
+      to: null,
+      cooldownMs: null,
+      accountId: null,
+    };
+    const { context, respond } = await invokeCronUpdate(
+      { id: "cron-1", patch: { failureAlert } },
+      createCronJob({ failureAlert: { after: 2, to: "123", cooldownMs: 60_000 } }),
+    );
+
+    expect(context.cron.update).toHaveBeenCalledWith("cron-1", { failureAlert });
+    expectCronSuccess(respond);
+  });
+
+  it("passes a whole failure alert override clear through cron.update", async () => {
+    const { context, respond } = await invokeCronUpdate(
+      { id: "cron-1", patch: { failureAlert: null } },
+      createCronJob({ failureAlert: { after: 2 } }),
+    );
+
+    expect(context.cron.update).toHaveBeenCalledWith("cron-1", { failureAlert: null });
+    expectCronSuccess(respond);
+  });
+
   it("rejects a blank cron.update display name", async () => {
     const { context, respond } = await invokeCronUpdate(
       { id: "cron-1", patch: { displayName: "   " } },

--- a/ui/src/lib/cron/index.test.ts
+++ b/ui/src/lib/cron/index.test.ts
@@ -1421,7 +1421,10 @@ describe("cron controller", () => {
     // oxlint-disable-next-line unicorn/prefer-structured-clone -- verify the websocket JSON wire shape
     const serializedPayload = JSON.parse(JSON.stringify(requestPayload(updateCall))) as unknown;
     expectRecordFields(
-      requireRecord(requireRecord(serializedPayload, "payload").patch, "patch").failureAlert,
+      requireRecord(
+        requireRecord(requireRecord(serializedPayload, "payload").patch, "patch").failureAlert,
+        "failureAlert",
+      ),
       { to: null, cooldownMs: null, accountId: null },
     );
   });

--- a/ui/src/lib/cron/index.test.ts
+++ b/ui/src/lib/cron/index.test.ts
@@ -1368,6 +1368,64 @@ describe("cron controller", () => {
     ).not.toHaveProperty("cooldownMs");
   });
 
+  it("clears persisted failure alert routing fields when their edit inputs are blanked", async () => {
+    const request = vi.fn(async (method: string, _payload?: unknown) => {
+      if (method === "cron.update") {
+        return { id: "job-clear-alert-fields" };
+      }
+      if (method === "cron.list") {
+        return { jobs: [{ id: "job-clear-alert-fields" }] };
+      }
+      if (method === "cron.status") {
+        return { enabled: true, jobs: 1, nextWakeAtMs: null };
+      }
+      return {};
+    });
+    const job = {
+      id: "job-clear-alert-fields",
+      name: "Clear failure alert fields",
+      enabled: true,
+      createdAtMs: 0,
+      updatedAtMs: 0,
+      schedule: { kind: "cron" as const, expr: "0 * * * *" },
+      sessionTarget: "isolated" as const,
+      wakeMode: "next-heartbeat" as const,
+      payload: { kind: "agentTurn" as const, message: "run" },
+      delivery: { mode: "announce" as const },
+      failureAlert: {
+        after: 2,
+        channel: "telegram",
+        to: "123456",
+        cooldownMs: 60_000,
+        accountId: "bot-a",
+      },
+      state: {},
+    };
+    const state = createState({
+      client: { request } as unknown as CronState["client"],
+      cronJobs: [job],
+    });
+
+    startCronEdit(state, job);
+    state.cronForm.failureAlertTo = "";
+    state.cronForm.failureAlertCooldownSeconds = "";
+    state.cronForm.failureAlertAccountId = "";
+    await addCronJob(state);
+
+    const updateCall = findRequestCall(request.mock.calls, "cron.update");
+    expectRecordFields(requireRecord(requestPatch(updateCall).failureAlert, "failureAlert"), {
+      to: null,
+      cooldownMs: null,
+      accountId: null,
+    });
+    // oxlint-disable-next-line unicorn/prefer-structured-clone -- verify the websocket JSON wire shape
+    const serializedPayload = JSON.parse(JSON.stringify(requestPayload(updateCall))) as unknown;
+    expectRecordFields(
+      requireRecord(requireRecord(serializedPayload, "payload").patch, "patch").failureAlert,
+      { to: null, cooldownMs: null, accountId: null },
+    );
+  });
+
   it("includes failureAlert=false when disabled per job", async () => {
     const request = vi.fn(async (method: string, _payload?: unknown) => {
       if (method === "cron.update") {

--- a/ui/src/lib/cron/index.test.ts
+++ b/ui/src/lib/cron/index.test.ts
@@ -1407,6 +1407,7 @@ describe("cron controller", () => {
     });
 
     startCronEdit(state, job);
+    state.cronForm.failureAlertAfter = "";
     state.cronForm.failureAlertTo = "";
     state.cronForm.failureAlertCooldownSeconds = "";
     state.cronForm.failureAlertAccountId = "";
@@ -1414,6 +1415,7 @@ describe("cron controller", () => {
 
     const updateCall = findRequestCall(request.mock.calls, "cron.update");
     expectRecordFields(requireRecord(requestPatch(updateCall).failureAlert, "failureAlert"), {
+      after: null,
       to: null,
       cooldownMs: null,
       accountId: null,
@@ -1425,8 +1427,41 @@ describe("cron controller", () => {
         requireRecord(requireRecord(serializedPayload, "payload").patch, "patch").failureAlert,
         "failureAlert",
       ),
-      { to: null, cooldownMs: null, accountId: null },
+      { after: null, to: null, cooldownMs: null, accountId: null },
     );
+  });
+
+  it("clears a persisted failure alert override when switching back to inherit", async () => {
+    const request = vi.fn(async (method: string, _payload?: unknown) => {
+      if (method === "cron.update") {
+        return { id: "job-inherit-alert" };
+      }
+      return {};
+    });
+    const job = {
+      id: "job-inherit-alert",
+      name: "Inherit failure alerts",
+      enabled: true,
+      createdAtMs: 0,
+      updatedAtMs: 0,
+      schedule: { kind: "cron" as const, expr: "0 * * * *" },
+      sessionTarget: "isolated" as const,
+      wakeMode: "next-heartbeat" as const,
+      payload: { kind: "agentTurn" as const, message: "run" },
+      failureAlert: { after: 2, channel: "telegram" },
+      state: {},
+    };
+    const state = createState({
+      client: { request } as unknown as CronState["client"],
+      cronJobs: [job],
+    });
+
+    startCronEdit(state, job);
+    state.cronForm.failureAlertMode = "inherit";
+    await addCronJob(state);
+
+    const updateCall = findRequestCall(request.mock.calls, "cron.update");
+    expect(requestPatch(updateCall).failureAlert).toBeNull();
   });
 
   it("includes failureAlert=false when disabled per job", async () => {

--- a/ui/src/lib/cron/index.ts
+++ b/ui/src/lib/cron/index.ts
@@ -913,16 +913,14 @@ function normalizePersistedDeliveryChannel(
   return channel;
 }
 
-function buildFailureAlert(
-  form: CronFormState,
-  existing?: { channel?: string; to?: string; cooldownMs?: number; accountId?: string },
-) {
+function buildFailureAlert(form: CronFormState, existing?: CronJob["failureAlert"]) {
   if (form.failureAlertMode === "disabled") {
     return false as const;
   }
   if (form.failureAlertMode !== "custom") {
-    return undefined;
+    return existing !== undefined ? null : undefined;
   }
+  const existingConfig = existing && typeof existing === "object" ? existing : undefined;
   const after = toNumber(form.failureAlertAfter.trim(), 0);
   const cooldownRaw = form.failureAlertCooldownSeconds.trim();
   const cooldownSeconds = cooldownRaw.length > 0 ? toNumber(cooldownRaw, 0) : undefined;
@@ -934,21 +932,21 @@ function buildFailureAlert(
   const accountId = form.failureAlertAccountId.trim();
   const to = form.failureAlertTo.trim();
   const patch: Record<string, unknown> = {
-    after: after > 0 ? Math.floor(after) : undefined,
+    after: after > 0 ? Math.floor(after) : existingConfig?.after !== undefined ? null : undefined,
     channel: normalizePersistedDeliveryChannel(form.failureAlertChannel, {
-      preserveLastOnUpdate: Boolean(existing?.channel),
+      preserveLastOnUpdate: Boolean(existingConfig?.channel),
     }),
-    to: to || (existing?.to ? null : undefined),
+    to: to || (existingConfig?.to ? null : undefined),
     ...(cooldownMs !== undefined
       ? { cooldownMs }
-      : existing?.cooldownMs !== undefined
+      : existingConfig?.cooldownMs !== undefined
         ? { cooldownMs: null }
         : {}),
   };
   if (deliveryMode) {
     patch.mode = deliveryMode;
   }
-  patch.accountId = accountId || (existing?.accountId ? null : undefined);
+  patch.accountId = accountId || (existingConfig?.accountId ? null : undefined);
   return patch;
 }
 
@@ -1040,12 +1038,7 @@ export async function addCronJob(state: CronState): Promise<CronSaveResult> {
         : selectedDeliveryMode === "none"
           ? ({ mode: "none" } as const)
           : undefined;
-    const failureAlert = buildFailureAlert(
-      form,
-      editingJob?.failureAlert && typeof editingJob.failureAlert === "object"
-        ? editingJob.failureAlert
-        : undefined,
-    );
+    const failureAlert = buildFailureAlert(form, editingJob?.failureAlert);
     const agentId = form.clearAgent ? null : form.agentId.trim();
     const sessionKeyRaw = form.sessionKey.trim();
     const sessionKey = sessionKeyRaw || (editingJob?.sessionKey ? null : undefined);

--- a/ui/src/lib/cron/index.ts
+++ b/ui/src/lib/cron/index.ts
@@ -913,7 +913,10 @@ function normalizePersistedDeliveryChannel(
   return channel;
 }
 
-function buildFailureAlert(form: CronFormState, existingChannel?: string) {
+function buildFailureAlert(
+  form: CronFormState,
+  existing?: { channel?: string; to?: string; cooldownMs?: number; accountId?: string },
+) {
   if (form.failureAlertMode === "disabled") {
     return false as const;
   }
@@ -929,18 +932,23 @@ function buildFailureAlert(form: CronFormState, existingChannel?: string) {
       : undefined;
   const deliveryMode = form.failureAlertDeliveryMode;
   const accountId = form.failureAlertAccountId.trim();
+  const to = form.failureAlertTo.trim();
   const patch: Record<string, unknown> = {
     after: after > 0 ? Math.floor(after) : undefined,
     channel: normalizePersistedDeliveryChannel(form.failureAlertChannel, {
-      preserveLastOnUpdate: Boolean(existingChannel),
+      preserveLastOnUpdate: Boolean(existing?.channel),
     }),
-    to: form.failureAlertTo.trim() || undefined,
-    ...(cooldownMs !== undefined ? { cooldownMs } : {}),
+    to: to || (existing?.to ? null : undefined),
+    ...(cooldownMs !== undefined
+      ? { cooldownMs }
+      : existing?.cooldownMs !== undefined
+        ? { cooldownMs: null }
+        : {}),
   };
   if (deliveryMode) {
     patch.mode = deliveryMode;
   }
-  patch.accountId = accountId || undefined;
+  patch.accountId = accountId || (existing?.accountId ? null : undefined);
   return patch;
 }
 
@@ -1035,7 +1043,7 @@ export async function addCronJob(state: CronState): Promise<CronSaveResult> {
     const failureAlert = buildFailureAlert(
       form,
       editingJob?.failureAlert && typeof editingJob.failureAlert === "object"
-        ? editingJob.failureAlert.channel
+        ? editingJob.failureAlert
         : undefined,
     );
     const agentId = form.clearAgent ? null : form.agentId.trim();


### PR DESCRIPTION
Closes #108571

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where operators editing a Cron job in Control UI could not clear a persisted failure-alert recipient, cooldown, or account override. Blank form values became omitted JSON properties, and omitted update keys mean "leave the stored value unchanged," so reloading the job restored stale routing settings.

## Why This Change Was Made

The edit controller now distinguishes blank create inputs from intentionally cleared persisted values and sends explicit `null` clears only for updates. The Gateway protocol uses a dedicated update schema that accepts nullable failure-alert fields while keeping create payload validation strict; the existing Cron service merge path already consumes explicit clears.

## User Impact

Operators can clear `to`, `cooldownMs`, and `accountId` from an existing job and have the saved job match the form. Creating a job with blank fields still omits them, and nonblank alert routing behaves as before.

## Evidence

### Real behavior proof

- **Behavior addressed:** Clearing persisted Cron failure-alert routing inputs now produces explicit wire-level clears accepted by `cron.update`.
- **Real environment tested:** Linux x86_64, Node 24.15.0, Chromium, current head `f5974ab48443f44f0d333b56205f749b9b549d9c` on branch `fix/cron-clear-failure-alert-fields`; runtime behavior bytes are unchanged from proof commit `ea1ee128c503b0586f78709340b96a37cb24a5ab` (the follow-up only narrows a test fixture type).
- **Exact steps or command run after this patch:** `node --import tsx .artifacts/verify-cron-alert-clear.ts` - exercised the actual Control UI controller and Gateway protocol validators, serialized the update payload, and compared update/create validation.
- **Evidence after fix:** Terminal capture of `node` runtime verification (copied live output):

  ```text
  {"result":"PASS","wireClears":{"after":2,"channel":"telegram","to":null,"cooldownMs":null,"mode":"announce","accountId":null},"updateAccepted":true,"createRejected":true}
  ```

- **Observed result after fix:** All three cleared values survived JSON serialization as `null`; the update validator accepted the patch while the create validator continued rejecting nullable create fields.
- **What was not tested:** No live production Gateway or channel delivery was used. A deterministic mocked-Gateway Chromium edit/save flow covered the real form interaction and request payload; CI provides broader browser/platform coverage.

### Browser behavior proof

A real Chromium page opened an existing job, cleared the recipient, cooldown, and account fields, saved it, and asserted that the mocked Gateway received all three `null` values in `cron.update`. The generated screenshot and video were inspected locally and intentionally not committed.

### Tests and validation

```text
$ node scripts/run-vitest.mjs ui/src/lib/cron/index.test.ts packages/gateway-protocol/src/cron-validators.test.ts
Test Files  2 passed (2)
Tests       84 passed (84)

$ oxfmt --check ui/src/lib/cron/index.ts ui/src/lib/cron/index.test.ts packages/gateway-protocol/src/schema/cron.ts packages/gateway-protocol/src/cron-validators.test.ts
All matched files use the correct format.

$ oxlint ui/src/lib/cron/index.ts ui/src/lib/cron/index.test.ts packages/gateway-protocol/src/schema/cron.ts packages/gateway-protocol/src/cron-validators.test.ts
EXIT=0

$ git diff --check origin/main...HEAD
EXIT=0
```

The controller regression checks the serialized websocket shape. Protocol tests prove nullable fields are update-only, preserving the create contract.

### Risk checklist

- User-visible behavior: Yes - blanking an existing override now deletes it instead of silently preserving it.
- Config/env/migration behavior: No - persisted Cron data is unchanged and no migration is required; only update patch semantics are expanded.
- Security/auth/secrets/network/tool execution: No - no authentication, secret, or execution path changes.
- Plugins/providers/channels/SDK: No - channel values are transported unchanged; no plugin or SDK boundary changes.
- Highest-risk area: Accidentally permitting nullable values on create or clearing fields that were never persisted.
- Mitigation: Create and update use separate schemas, and the controller emits `null` only when an edited job already has the corresponding stored value.

## AI assistance

This PR is AI-assisted. OpenAI Codex helped investigate, implement, test, and review the change. I reviewed the resulting code and understand its behavior. Automated structured review was attempted, but the local review engine failed before producing a clean/finding result; GitHub review and CI remain authoritative.
