### PR TITLE
fix(ui): honor UTC in usage session detail timelines

### DIFF
--- a/ui/src/pages/usage/view-details.test.ts
+++ b/ui/src/pages/usage/view-details.test.ts
@@ -1,8 +1,12 @@
 // Control UI tests cover usage detail behavior through the rendered panel.
 import { render } from "lit";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { TimeSeriesPoint, UsageSessionEntry } from "./types.ts";
 import { renderSessionDetailPanel } from "./view-details.ts";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 function point(overrides: Partial<TimeSeriesPoint> = {}): TimeSeriesPoint {
   return {
@@ -99,6 +103,31 @@ function mount(
 }
 
 describe("renderSessionDetailPanel filtered usage", () => {
+  it("formats timeline labels in the selected UTC time zone", () => {
+    vi.spyOn(Date.prototype, "toLocaleTimeString").mockImplementation((_locales, options) =>
+      options?.timeZone === "UTC" ? "utc-time" : "local-time",
+    );
+    vi.spyOn(Date.prototype, "toLocaleString").mockImplementation((_locales, options) =>
+      options?.timeZone === "UTC" ? "utc-date-time" : "local-date-time",
+    );
+
+    const container = mount(
+      [
+        point({ timestamp: Date.parse("2026-05-13T18:00:00.000Z") }),
+        point({ timestamp: Date.parse("2026-05-13T23:59:59.999Z") }),
+      ],
+      null,
+      null,
+      "total",
+      { timeZone: "utc" },
+    );
+
+    expect(
+      [...container.querySelectorAll(".ts-axis-label")].map((label) => label.textContent),
+    ).toEqual(expect.arrayContaining(["utc-time", "utc-time"]));
+    expect(container.querySelector(".ts-bar title")?.textContent).toContain("utc-date-time");
+  });
+
   it("filters detail points by the selected UTC day and keeps the final millisecond", () => {
     const localOffsetMs = 8 * 60 * 60 * 1000;
     const localYear = vi
@@ -135,6 +164,32 @@ describe("renderSessionDetailPanel filtered usage", () => {
       localYear.mockRestore();
       localMonth.mockRestore();
       localDay.mockRestore();
+    }
+  });
+
+  it("ends a local range at the next calendar midnight after a skipped midnight", () => {
+    const previousTimeZone = process.env.TZ;
+    process.env.TZ = "America/Santiago";
+    try {
+      const container = mount(
+        [
+          point({ timestamp: new Date(2026, 8, 6, 1).getTime() }),
+          point({ timestamp: new Date(2026, 8, 6, 12).getTime() }),
+          point({ timestamp: new Date(2026, 8, 7, 0, 30).getTime() }),
+        ],
+        null,
+        null,
+        "total",
+        { startDate: "2026-09-06", endDate: "2026-09-06", timeZone: "local" },
+      );
+
+      expect(container.querySelectorAll(".ts-bar")).toHaveLength(2);
+    } finally {
+      if (previousTimeZone === undefined) {
+        delete process.env.TZ;
+      } else {
+        process.env.TZ = previousTimeZone;
+      }
     }
   });
 

--- a/ui/src/pages/usage/view-details.test.ts
+++ b/ui/src/pages/usage/view-details.test.ts
@@ -101,13 +101,17 @@ function mount(
 describe("renderSessionDetailPanel filtered usage", () => {
   it("filters detail points by the selected UTC day and keeps the final millisecond", () => {
     const localOffsetMs = 8 * 60 * 60 * 1000;
-    const localYear = vi.spyOn(Date.prototype, "getFullYear").mockImplementation(function () {
-      return new Date(this.getTime() + localOffsetMs).getUTCFullYear();
-    });
-    const localMonth = vi.spyOn(Date.prototype, "getMonth").mockImplementation(function () {
-      return new Date(this.getTime() + localOffsetMs).getUTCMonth();
-    });
-    const localDay = vi.spyOn(Date.prototype, "getDate").mockImplementation(function () {
+    const localYear = vi
+      .spyOn(Date.prototype, "getFullYear")
+      .mockImplementation(function (this: Date) {
+        return new Date(this.getTime() + localOffsetMs).getUTCFullYear();
+      });
+    const localMonth = vi
+      .spyOn(Date.prototype, "getMonth")
+      .mockImplementation(function (this: Date) {
+        return new Date(this.getTime() + localOffsetMs).getUTCMonth();
+      });
+    const localDay = vi.spyOn(Date.prototype, "getDate").mockImplementation(function (this: Date) {
       return new Date(this.getTime() + localOffsetMs).getUTCDate();
     });
     try {

--- a/ui/src/pages/usage/view-details.test.ts
+++ b/ui/src/pages/usage/view-details.test.ts
@@ -100,8 +100,16 @@ function mount(
 
 describe("renderSessionDetailPanel filtered usage", () => {
   it("filters detail points by the selected UTC day and keeps the final millisecond", () => {
-    const previousTimeZone = process.env.TZ;
-    process.env.TZ = "Asia/Shanghai";
+    const localOffsetMs = 8 * 60 * 60 * 1000;
+    const localYear = vi.spyOn(Date.prototype, "getFullYear").mockImplementation(function () {
+      return new Date(this.getTime() + localOffsetMs).getUTCFullYear();
+    });
+    const localMonth = vi.spyOn(Date.prototype, "getMonth").mockImplementation(function () {
+      return new Date(this.getTime() + localOffsetMs).getUTCMonth();
+    });
+    const localDay = vi.spyOn(Date.prototype, "getDate").mockImplementation(function () {
+      return new Date(this.getTime() + localOffsetMs).getUTCDate();
+    });
     try {
       const points = [
         point({ timestamp: Date.parse("2026-05-13T18:00:00.000Z") }),
@@ -120,11 +128,9 @@ describe("renderSessionDetailPanel filtered usage", () => {
       expect(local.querySelectorAll(".ts-bar")).toHaveLength(0);
       expect(local.querySelector(".usage-empty-block")).not.toBeNull();
     } finally {
-      if (previousTimeZone === undefined) {
-        delete process.env.TZ;
-      } else {
-        process.env.TZ = previousTimeZone;
-      }
+      localYear.mockRestore();
+      localMonth.mockRestore();
+      localDay.mockRestore();
     }
   });
 

--- a/ui/src/pages/usage/view-details.test.ts
+++ b/ui/src/pages/usage/view-details.test.ts
@@ -55,6 +55,12 @@ function mount(
   start: number | null,
   end: number | null,
   breakdownMode: "total" | "by-type" = "total",
+  filters: {
+    startDate?: string;
+    endDate?: string;
+    selectedDays?: string[];
+    timeZone?: "local" | "utc";
+  } = {},
 ) {
   const container = document.createElement("div");
   render(
@@ -69,9 +75,10 @@ function mount(
       start,
       end,
       vi.fn(),
-      "",
-      "",
-      [],
+      filters.startDate ?? "",
+      filters.endDate ?? "",
+      filters.selectedDays ?? [],
+      filters.timeZone ?? "local",
       [],
       false,
       false,
@@ -92,6 +99,35 @@ function mount(
 }
 
 describe("renderSessionDetailPanel filtered usage", () => {
+  it("filters detail points by the selected UTC day and keeps the final millisecond", () => {
+    const previousTimeZone = process.env.TZ;
+    process.env.TZ = "Asia/Shanghai";
+    try {
+      const points = [
+        point({ timestamp: Date.parse("2026-05-13T18:00:00.000Z") }),
+        point({ timestamp: Date.parse("2026-05-13T23:59:59.999Z") }),
+      ];
+      const filters = {
+        startDate: "2026-05-13",
+        endDate: "2026-05-13",
+        selectedDays: ["2026-05-13"],
+      };
+
+      const utc = mount(points, null, null, "total", { ...filters, timeZone: "utc" });
+      const local = mount(points, null, null, "total", { ...filters, timeZone: "local" });
+
+      expect(utc.querySelectorAll(".ts-bar")).toHaveLength(2);
+      expect(local.querySelectorAll(".ts-bar")).toHaveLength(0);
+      expect(local.querySelector(".usage-empty-block")).not.toBeNull();
+    } finally {
+      if (previousTimeZone === undefined) {
+        delete process.env.TZ;
+      } else {
+        process.env.TZ = previousTimeZone;
+      }
+    }
+  });
+
   it("aggregates token, cost, type, message, and duration data inside the selected range", () => {
     const container = mount(
       [

--- a/ui/src/pages/usage/view-details.ts
+++ b/ui/src/pages/usage/view-details.ts
@@ -37,16 +37,12 @@ function normalizeLogTimestamp(ts: number): number {
   return ts < 1e12 ? ts * 1000 : ts;
 }
 
-function dateBoundaryMs(date: string, timeZone: "local" | "utc", nextDay: boolean): number {
-  const value = new Date(`${date}T00:00:00${timeZone === "utc" ? "Z" : ""}`);
-  if (nextDay) {
-    if (timeZone === "utc") {
-      value.setUTCDate(value.getUTCDate() + 1);
-    } else {
-      value.setDate(value.getDate() + 1);
-    }
-  }
-  return value.getTime();
+function dateBoundaryMs(date: string, timeZone: "local" | "utc", dayOffset: 0 | 1): number {
+  const year = Number(date.slice(0, 4));
+  const month = Number(date.slice(5, 7)) - 1;
+  const day = Number(date.slice(8, 10)) + dayOffset;
+  // Build the target date directly; advancing a normalized skipped midnight can retain 01:00.
+  return timeZone === "utc" ? Date.UTC(year, month, day) : new Date(year, month, day).getTime();
 }
 
 function dateKey(timestamp: number, timeZone: "local" | "utc"): string {
@@ -423,8 +419,8 @@ function renderTimeSeriesCompact(
   // Filter and recalculate (same logic as main function)
   let points = timeSeries.points;
   if (startDate || endDate || (selectedDays && selectedDays.length > 0)) {
-    const startTs = startDate ? dateBoundaryMs(startDate, timeZone, false) : 0;
-    const endTs = endDate ? dateBoundaryMs(endDate, timeZone, true) : Infinity;
+    const startTs = startDate ? dateBoundaryMs(startDate, timeZone, 0) : 0;
+    const endTs = endDate ? dateBoundaryMs(endDate, timeZone, 1) : Infinity;
     const selectedDaySet = selectedDays?.length ? new Set(selectedDays) : undefined;
     points = timeSeries.points.filter((p) => {
       if (p.timestamp < startTs || p.timestamp >= endTs) {
@@ -495,6 +491,7 @@ function renderTimeSeriesCompact(
   const chartHeight = height - padding.top - padding.bottom;
   const isCumulative = mode === "cumulative";
   const breakdownByType = mode === "per-turn" && breakdownMode === "by-type";
+  const timeZoneOptions: Intl.DateTimeFormatOptions = timeZone === "utc" ? { timeZone: "UTC" } : {};
 
   const totalTypeTokens = filteredOutput + filteredInput + filteredCacheRead + filteredCacheWrite;
   const barTotals = points.map((p) =>
@@ -606,8 +603,8 @@ function renderTimeSeriesCompact(
           <!-- X axis labels (first and last) -->
           ${points.length > 0
             ? svg`
-            <text x="${padding.left}" y="${padding.top + chartHeight + 10}" text-anchor="start" class="ts-axis-label">${formatTimeMs(expectDefined(points[0], "time series first point").timestamp, { hour: "2-digit", minute: "2-digit" }, "")}</text>
-            <text x="${width - padding.right}" y="${padding.top + chartHeight + 10}" text-anchor="end" class="ts-axis-label">${formatTimeMs(expectDefined(points.at(-1), "time series last point").timestamp, { hour: "2-digit", minute: "2-digit" }, "")}</text>
+            <text x="${padding.left}" y="${padding.top + chartHeight + 10}" text-anchor="start" class="ts-axis-label">${formatTimeMs(expectDefined(points[0], "time series first point").timestamp, { hour: "2-digit", minute: "2-digit", ...timeZoneOptions }, "")}</text>
+            <text x="${width - padding.right}" y="${padding.top + chartHeight + 10}" text-anchor="end" class="ts-axis-label">${formatTimeMs(expectDefined(points.at(-1), "time series last point").timestamp, { hour: "2-digit", minute: "2-digit", ...timeZoneOptions }, "")}</text>
           `
             : nothing}
           <!-- Bars -->
@@ -624,6 +621,7 @@ function renderTimeSeriesCompact(
                   day: "numeric",
                   hour: "2-digit",
                   minute: "2-digit",
+                  ...timeZoneOptions,
                 },
                 "",
               ),
@@ -782,9 +780,13 @@ function renderTimeSeriesCompact(
               ·
               ${formatTimeMs(
                 rangeStartTs,
-                { hour: "2-digit", minute: "2-digit" },
+                { hour: "2-digit", minute: "2-digit", ...timeZoneOptions },
                 "",
-              )}–${formatTimeMs(rangeEndTs, { hour: "2-digit", minute: "2-digit" }, "")}
+              )}–${formatTimeMs(
+                rangeEndTs,
+                { hour: "2-digit", minute: "2-digit", ...timeZoneOptions },
+                "",
+              )}
               ·
               ${formatTokens(
                 filteredOutput + filteredInput + filteredCacheRead + filteredCacheWrite,

--- a/ui/src/pages/usage/view-details.ts
+++ b/ui/src/pages/usage/view-details.ts
@@ -37,6 +37,26 @@ function normalizeLogTimestamp(ts: number): number {
   return ts < 1e12 ? ts * 1000 : ts;
 }
 
+function dateBoundaryMs(date: string, timeZone: "local" | "utc", nextDay: boolean): number {
+  const value = new Date(`${date}T00:00:00${timeZone === "utc" ? "Z" : ""}`);
+  if (nextDay) {
+    if (timeZone === "utc") {
+      value.setUTCDate(value.getUTCDate() + 1);
+    } else {
+      value.setDate(value.getDate() + 1);
+    }
+  }
+  return value.getTime();
+}
+
+function dateKey(timestamp: number, timeZone: "local" | "utc"): string {
+  const value = new Date(timestamp);
+  const year = timeZone === "utc" ? value.getUTCFullYear() : value.getFullYear();
+  const month = (timeZone === "utc" ? value.getUTCMonth() : value.getMonth()) + 1;
+  const day = timeZone === "utc" ? value.getUTCDate() : value.getDate();
+  return `${year}-${String(month).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
+}
+
 /** Filter session logs by a timestamp range. */
 function filterLogsByRange(
   logs: SessionLogEntry[],
@@ -241,6 +261,7 @@ function renderSessionDetailPanel(
   startDate: string,
   endDate: string,
   selectedDays: string[],
+  timeZone: "local" | "utc",
   sessionLogs: SessionLogEntry[] | null,
   sessionLogsLoading: boolean,
   sessionLogsExpanded: boolean,
@@ -336,6 +357,7 @@ function renderSessionDetailPanel(
             startDate,
             endDate,
             selectedDays,
+            timeZone,
             timeSeriesCursorStart,
             timeSeriesCursorEnd,
             onTimeSeriesCursorRangeChange,
@@ -378,6 +400,7 @@ function renderTimeSeriesCompact(
   startDate?: string,
   endDate?: string,
   selectedDays?: string[],
+  timeZone: "local" | "utc" = "local",
   cursorStart?: number | null,
   cursorEnd?: number | null,
   onCursorRangeChange?: (start: number | null, end: number | null) => void,
@@ -400,17 +423,15 @@ function renderTimeSeriesCompact(
   // Filter and recalculate (same logic as main function)
   let points = timeSeries.points;
   if (startDate || endDate || (selectedDays && selectedDays.length > 0)) {
-    const startTs = startDate ? new Date(startDate + "T00:00:00").getTime() : 0;
-    const endTs = endDate ? new Date(endDate + "T23:59:59").getTime() : Infinity;
+    const startTs = startDate ? dateBoundaryMs(startDate, timeZone, false) : 0;
+    const endTs = endDate ? dateBoundaryMs(endDate, timeZone, true) : Infinity;
     const selectedDaySet = selectedDays?.length ? new Set(selectedDays) : undefined;
     points = timeSeries.points.filter((p) => {
-      if (p.timestamp < startTs || p.timestamp > endTs) {
+      if (p.timestamp < startTs || p.timestamp >= endTs) {
         return false;
       }
       if (selectedDaySet) {
-        const d = new Date(p.timestamp);
-        const dateStr = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
-        return selectedDaySet.has(dateStr);
+        return selectedDaySet.has(dateKey(p.timestamp, timeZone));
       }
       return true;
     });

--- a/ui/src/pages/usage/view.ts
+++ b/ui/src/pages/usage/view.ts
@@ -865,6 +865,7 @@ export function renderUsage(props: UsageProps) {
                         filters.startDate,
                         filters.endDate,
                         filters.selectedDays,
+                        filters.timeZone,
                         detail.sessionLogs,
                         detail.sessionLogsLoading,
                         detail.sessionLogsExpanded,


### PR DESCRIPTION
Closes #108572

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where Usage viewers outside UTC could select UTC but still see the session-detail timeline filtered by local calendar days. The detail renderer did not receive the selected time zone and used a `23:59:59` inclusive end boundary, also dropping the final 999 milliseconds of the selected end date.

## Why This Change Was Made

The selected time zone is now carried into the session-detail renderer, which derives both date keys and day boundaries with matching UTC or local calendar methods. The end boundary is the exclusive start of the next day, avoiding millisecond truncation and remaining correct across local DST transitions.

## User Impact

The session-detail timeline now agrees with the UTC/Local selector and the top-level Usage filters. UTC points stay on their UTC date, local mode retains local-calendar behavior, and the entire selected end date is included.

## Evidence

### Real behavior proof

- **Behavior addressed:** Session-detail timeline points are filtered using the selected UTC/local calendar and include the final millisecond of the end date.
- **Real environment tested:** Linux x86_64, Node 24.15.0, Chromium running in `Asia/Shanghai`, current head `fd850f616fc8067af3dc89423dbb4e7db7b93b50` on branch `fix/ui-usage-detail-timezone`; runtime behavior bytes are unchanged from proof commit `8c4fc5cef27e45da753bb7c2c40c0676b007840b` (follow-ups only make the regression test timezone-independent and type-safe).
- **Exact steps or command run after this patch:** `TZ=Asia/Shanghai node --import tsx .artifacts/verify-usage-timezone.ts` - rendered the actual Lit session-detail panel with two May 13 UTC points, including `23:59:59.999Z`, under UTC and Local filters.
- **Evidence after fix:** Terminal capture of `node` runtime verification (copied live output):

  ```text
  {"result":"PASS","runtimeTimeZone":"Asia/Shanghai","utcBars":2,"localBars":0,"includedFinalUtcMillisecond":true}
  ```

- **Observed result after fix:** UTC mode rendered both May 13 bars, including the final millisecond; Local mode correctly rendered no bars because both timestamps fall on May 14 in Shanghai.
- **What was not tested:** No production Usage dataset or live Gateway was used. A deterministic mocked-Gateway Chromium flow covered routing, filter selection, session selection, and visible rendering; CI provides broader browser/platform coverage.

### Browser behavior proof

A real Chromium page in `Asia/Shanghai` loaded mocked Usage data, selected the session, showed two timeline bars in UTC, then showed the no-data state after switching to Local. Screenshots and video for both states were inspected locally and intentionally not committed.

### Tests and validation

```text
$ TZ=Asia/Shanghai node scripts/run-vitest.mjs ui/src/pages/usage/view-details.test.ts
Test Files  1 passed (1)
Tests       4 passed (4)

$ oxfmt --check ui/src/pages/usage/view.ts ui/src/pages/usage/view-details.ts ui/src/pages/usage/view-details.test.ts
All matched files use the correct format.

$ oxlint ui/src/pages/usage/view.ts ui/src/pages/usage/view-details.ts ui/src/pages/usage/view-details.test.ts
EXIT=0

$ git diff --check origin/main...HEAD
EXIT=0
```

The regression forces a non-UTC runtime zone, compares UTC and Local rendering, and includes a point at `23:59:59.999Z` to protect the end boundary.

### Risk checklist

- User-visible behavior: Yes - detail timelines now follow the selected time zone and include the complete end day.
- Config/env/migration behavior: No - no configuration or persisted data changes.
- Security/auth/secrets/network/tool execution: No - rendering and client-side timestamp filtering only.
- Plugins/providers/channels/SDK: No - no plugin, provider, channel, or SDK surface changes.
- Highest-risk area: Local date boundaries around DST and off-by-one errors at the exclusive end boundary.
- Mitigation: UTC/local getters and setters stay paired, the next-day boundary follows calendar arithmetic, and tests cover a non-UTC zone plus the final millisecond.

## AI assistance

This PR is AI-assisted. OpenAI Codex helped investigate, implement, test, and review the change. I reviewed the resulting code and understand its behavior. Automated structured review was attempted, but the local review engine failed before producing a clean/finding result; GitHub review and CI remain authoritative.
