### PR TITLE
fix(discord): resolve named agent delivery targets

### DIFF
--- a/extensions/discord/src/channel.test.ts
+++ b/extensions/discord/src/channel.test.ts
@@ -319,6 +319,56 @@ describe("discordPlugin outbound", () => {
     });
   });
 
+  it("rejects unresolved Discord names after the shared directory lookup misses", async () => {
+    vi.spyOn(directoryLive, "listDiscordDirectoryPeersLive").mockResolvedValue([]);
+    const resolveTarget = discordPlugin.messaging?.targetResolver?.resolveTarget;
+    if (!resolveTarget) {
+      throw new Error(
+        "Expected discordPlugin.messaging.targetResolver.resolveTarget to be defined",
+      );
+    }
+
+    await expect(
+      resolveTarget({
+        cfg: createCfg(),
+        accountId: "default",
+        input: "channel:missing",
+        normalized: "channel:missing",
+        preferredKind: "channel",
+      }),
+    ).resolves.toBeNull();
+    await expect(
+      resolveTarget({
+        cfg: createCfg(),
+        accountId: "default",
+        input: "user:missing",
+        normalized: "user:missing",
+        preferredKind: "user",
+      }),
+    ).resolves.toBeNull();
+  });
+
+  it("does not reinterpret a bare channel name as a Discord username on fallback", async () => {
+    vi.spyOn(directoryLive, "listDiscordDirectoryPeersLive").mockResolvedValueOnce([
+      { kind: "user", id: "user:999", name: "General" } as const,
+    ]);
+    const resolveTarget = discordPlugin.messaging?.targetResolver?.resolveTarget;
+    if (!resolveTarget) {
+      throw new Error(
+        "Expected discordPlugin.messaging.targetResolver.resolveTarget to be defined",
+      );
+    }
+
+    await expect(
+      resolveTarget({
+        cfg: createCfg(),
+        accountId: "default",
+        input: "general",
+        normalized: "channel:general",
+      }),
+    ).resolves.toBeNull();
+  });
+
   it("preserves the normalized channel kind for bare current-channel ids", async () => {
     const resolveTarget = discordPlugin.messaging?.targetResolver?.resolveTarget;
     if (!resolveTarget) {

--- a/extensions/discord/src/channel.ts
+++ b/extensions/discord/src/channel.ts
@@ -384,6 +384,18 @@ export const discordPlugin: ChannelPlugin<ResolvedDiscordAccount, DiscordProbe> 
             if (!resolved) {
               return null;
             }
+            // Shared directory lookup owns mutable names. Fallback may only return
+            // a canonical Discord snowflake, never an unresolved channel/user name.
+            if (!looksLikeDiscordTargetId(resolved.normalized)) {
+              return null;
+            }
+            if (
+              !looksLikeDiscordTargetId(input) &&
+              defaultKind === "channel" &&
+              resolved.kind === "user"
+            ) {
+              return null;
+            }
             return {
               to: resolved.normalized,
               kind: resolved.kind === "user" ? "user" : "channel",

--- a/extensions/discord/src/normalize.test.ts
+++ b/extensions/discord/src/normalize.test.ts
@@ -51,7 +51,12 @@ describe("discord target normalization", () => {
     expect(looksLikeDiscordTargetId("<@!123456>")).toBe(true);
     expect(looksLikeDiscordTargetId("user:123456")).toBe(true);
     expect(looksLikeDiscordTargetId("discord:123456")).toBe(true);
+    expect(looksLikeDiscordTargetId("discord:user:123456")).toBe(true);
+    expect(looksLikeDiscordTargetId("discord:channel:123456")).toBe(true);
     expect(looksLikeDiscordTargetId("123456")).toBe(true);
+    expect(looksLikeDiscordTargetId("channel:general")).toBe(false);
+    expect(looksLikeDiscordTargetId("user:jane")).toBe(false);
+    expect(looksLikeDiscordTargetId("discord:channel:general")).toBe(false);
     expect(looksLikeDiscordTargetId("hello world")).toBe(false);
   });
 });

--- a/extensions/discord/src/normalize.ts
+++ b/extensions/discord/src/normalize.ts
@@ -77,7 +77,7 @@ export function looksLikeDiscordTargetId(raw: string): boolean {
   if (/^<@!?\d+>$/.test(trimmed)) {
     return true;
   }
-  if (/^(user|channel|discord):/i.test(trimmed)) {
+  if (/^(?:(?:user|channel|discord):\d+|discord:(?:user|channel):\d+)$/i.test(trimmed)) {
     return true;
   }
   if (/^\d{6,}$/.test(trimmed)) {

--- a/src/agents/agent-command.live-model-switch.test.ts
+++ b/src/agents/agent-command.live-model-switch.test.ts
@@ -61,6 +61,7 @@ const state = vi.hoisted(() => ({
   updateSessionStoreAfterAgentRunMock: vi.fn(),
   deliverAgentCommandResultMock: vi.fn(),
   resolveAgentDeliveryPlanMock: vi.fn(),
+  resolveAgentDeliveryPlanWithSessionRouteMock: vi.fn(),
   resolveAgentOutboundTargetMock: vi.fn(),
   resolveMessageChannelSelectionMock: vi.fn(),
   createTrajectoryRuntimeRecorderMock: vi.fn(),
@@ -329,6 +330,8 @@ vi.mock("../infra/outbound/session-context.js", () => ({
 
 vi.mock("../infra/outbound/agent-delivery.js", () => ({
   resolveAgentDeliveryPlan: (...args: unknown[]) => state.resolveAgentDeliveryPlanMock(...args),
+  resolveAgentDeliveryPlanWithSessionRoute: (...args: unknown[]) =>
+    state.resolveAgentDeliveryPlanWithSessionRouteMock(...args),
   resolveAgentOutboundTarget: (...args: unknown[]) => state.resolveAgentOutboundTargetMock(...args),
 }));
 
@@ -1144,6 +1147,9 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
           deliveryTargetMode: params.explicitTo ? "explicit" : to ? "implicit" : undefined,
         };
       },
+    );
+    state.resolveAgentDeliveryPlanWithSessionRouteMock.mockImplementation((params: unknown) =>
+      state.resolveAgentDeliveryPlanMock(params),
     );
     state.updateSessionStoreAfterAgentRunMock.mockResolvedValue(undefined);
     state.trajectoryFlushMock.mockResolvedValue(undefined);
@@ -3252,6 +3258,9 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
     await agentCommand({
       message: "hello",
       sessionKey: "agent:main:main",
+      channel: "discord",
+      to: "discord:dm:123",
+      accountId: "main",
       deliver: true,
       runId: "stale-run",
     });
@@ -3404,7 +3413,7 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
     expect(sessionStore["agent:main:main"]).toEqual(laterRunEntry);
   });
 
-  it("stores pending final delivery with the current run delivery context", async () => {
+  it("stores and delivers with the prepared canonical current-run target", async () => {
     setupSingleAttemptFallback();
     state.runAgentAttemptMock.mockResolvedValue(makeSuccessResult("openai", "gpt-5.4"));
     const sessionEntry: SessionEntry = {
@@ -3415,11 +3424,18 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
     state.sessionStoreMock = { "agent:main:main": sessionEntry };
     state.storePathMock = "/tmp/openclaw-sessions.json";
     state.deliverAgentCommandResultMock.mockResolvedValue({ deliverySucceeded: false });
+    state.resolveAgentDeliveryPlanWithSessionRouteMock.mockResolvedValueOnce({
+      baseDelivery: {},
+      resolvedChannel: "discord",
+      resolvedTo: "channel:1524410080953634829",
+      resolvedAccountId: "main",
+      deliveryTargetMode: "explicit",
+    });
 
     await agentCommand({
       message: "hello",
       channel: "discord",
-      to: "discord:dm:123",
+      to: "channel:general",
       accountId: "main",
       deliver: true,
     });
@@ -3432,10 +3448,71 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
         pendingFinalDeliveryText: "ok",
         pendingFinalDeliveryContext: {
           channel: "discord",
-          to: "discord:dm:123",
+          to: "channel:1524410080953634829",
           accountId: "main",
         },
       }),
+    );
+    expect(state.deliverAgentCommandResultMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        opts: expect.objectContaining({
+          replyChannel: "discord",
+          replyTo: "channel:1524410080953634829",
+          replyAccountId: "main",
+          deliveryTargetMode: "explicit",
+        }),
+      }),
+    );
+  });
+
+  it("rejects a strict delivery target before the model run", async () => {
+    setupSingleAttemptFallback();
+    const targetError = new Error('Unknown Discord target "channel:missing"');
+    state.resolveAgentDeliveryPlanWithSessionRouteMock.mockResolvedValueOnce({
+      baseDelivery: {},
+      resolvedChannel: "discord",
+      resolvedTo: "channel:missing",
+      deliveryTargetMode: "explicit",
+      targetResolutionError: targetError,
+    });
+
+    await expect(
+      agentCommand({
+        message: "hello",
+        channel: "discord",
+        to: "channel:missing",
+        deliver: true,
+      }),
+    ).rejects.toBe(targetError);
+
+    expect(state.runAgentAttemptMock).not.toHaveBeenCalled();
+    expect(state.deliverAgentCommandResultMock).not.toHaveBeenCalled();
+  });
+
+  it("downgrades a rejected best-effort target to session-only before the model run", async () => {
+    setupSingleAttemptFallback();
+    state.runAgentAttemptMock.mockResolvedValue(makeSuccessResult("openai", "gpt-5.4"));
+    state.resolveAgentDeliveryPlanWithSessionRouteMock.mockResolvedValueOnce({
+      baseDelivery: {},
+      resolvedChannel: "discord",
+      resolvedTo: "channel:missing",
+      deliveryTargetMode: "explicit",
+      targetResolutionError: new Error('Unknown Discord target "channel:missing"'),
+    });
+
+    await expect(
+      agentCommand({
+        message: "hello",
+        channel: "discord",
+        to: "channel:missing",
+        deliver: true,
+        bestEffortDeliver: true,
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(state.runAgentAttemptMock).toHaveBeenCalled();
+    expect(state.deliverAgentCommandResultMock).toHaveBeenCalledWith(
+      expect.objectContaining({ opts: expect.objectContaining({ deliver: false }) }),
     );
   });
 
@@ -3461,6 +3538,7 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
 
     await agentCommand({
       message: "hello",
+      channel: "whatsapp",
       to: "+1234567890",
       deliver: true,
     });

--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -42,10 +42,7 @@ import {
 } from "./command/prepare.js";
 import { runEmbeddedAgentAttempt } from "./command/run-embedded-attempt.js";
 import { loadSessionStoreRuntime, resolveAgentCommandDeps } from "./command/runtime-loaders.js";
-import {
-  persistSessionEntry,
-  resolveCurrentRunDeliveryContext,
-} from "./command/session-helpers.js";
+import { persistSessionEntry, prepareCurrentRunDelivery } from "./command/session-helpers.js";
 import { prepareEmbeddedSessionState } from "./command/session-preparation.js";
 import { clearRotatedSessionMetadata } from "./command/session.js";
 import type { AgentCommandIngressOpts, AgentCommandOpts } from "./command/types.js";
@@ -100,7 +97,7 @@ async function agentCommandInternal(
       "internal delivery media constraints require automatic delivery with restart-safe tools and no message tool",
     );
   }
-  const opts = {
+  let opts: AgentCommandOpts = {
     ...preparedOpts,
     abortSignal: preparedOpts.abortSignal
       ? AbortSignal.any([preparedOpts.abortSignal, lifecycleAbortController.signal])
@@ -237,6 +234,46 @@ async function agentCommandInternal(
         throw acpResolution.error;
       }
 
+      let currentRunDeliveryPrepared = false;
+      const prepareDeliveryForRun = async (candidateSessionEntry?: SessionEntry) => {
+        if (currentRunDeliveryPrepared || opts.deliver !== true) {
+          return;
+        }
+        currentRunDeliveryPrepared = true;
+        let preparedDelivery: Awaited<ReturnType<typeof prepareCurrentRunDelivery>>;
+        try {
+          preparedDelivery = await prepareCurrentRunDelivery({
+            cfg,
+            opts,
+            agentId: sessionAgentId,
+            currentSessionKey: sessionKey,
+            sessionEntry: candidateSessionEntry,
+          });
+        } catch (error) {
+          if (opts.bestEffortDeliver !== true) {
+            throw error;
+          }
+          log.warn(
+            `delivery preflight failed; continuing session-only because bestEffortDeliver is enabled: ${
+              error instanceof Error ? error.message : String(error)
+            }`,
+          );
+          opts = { ...opts, deliver: false };
+        }
+        assertAgentRunLifecycleGenerationCurrent(lifecycleGeneration);
+        if (preparedDelivery) {
+          currentRunDeliveryContext = preparedDelivery.context;
+          opts = {
+            ...opts,
+            replyChannel: preparedDelivery.context.channel,
+            replyTo: preparedDelivery.context.to,
+            replyAccountId: preparedDelivery.context.accountId,
+            threadId: preparedDelivery.context.threadId,
+            deliveryTargetMode: preparedDelivery.targetMode,
+          };
+        }
+      };
+
       if (
         sessionStore &&
         sessionKey &&
@@ -251,11 +288,7 @@ async function agentCommandInternal(
           sessionEntry ?? { sessionId, updatedAt: now, sessionStartedAt: now };
         const isSessionRollover = isNewSession && initialEntry.sessionId !== sessionId;
         const entry = isSessionRollover ? clearRotatedSessionMetadata(initialEntry) : initialEntry;
-        currentRunDeliveryContext = await resolveCurrentRunDeliveryContext({
-          cfg,
-          opts,
-          sessionEntry: entry,
-        });
+        await prepareDeliveryForRun(entry);
         const generatedMediaSourceRunId =
           opts.internalDeliveryMediaUrls !== undefined &&
           opts.inputProvenance?.kind === "inter_session" &&
@@ -301,6 +334,7 @@ async function agentCommandInternal(
         sessionEntry = persisted;
         trackedRestartRecoveryDeliveryClaim = persisted?.restartRecoveryDeliveryRunId === runId;
       }
+      await prepareDeliveryForRun(sessionEntry);
 
       if (!isRawModelRun && acpResolution?.kind === "ready" && sessionKey) {
         assertAgentRunLifecycleGenerationCurrent(lifecycleGeneration);

--- a/src/agents/command/session-helpers.ts
+++ b/src/agents/command/session-helpers.ts
@@ -57,7 +57,7 @@ export function clearPendingFinalDeliveryFields(
   };
 }
 
-export type PreparedCurrentRunDelivery = {
+type PreparedCurrentRunDelivery = {
   context: DeliveryContext;
   targetMode: ChannelOutboundTargetMode;
 };

--- a/src/agents/command/session-helpers.ts
+++ b/src/agents/command/session-helpers.ts
@@ -1,8 +1,9 @@
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import type { ChannelOutboundTargetMode } from "../../channels/plugins/types.public.js";
 import type { SessionEntry } from "../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import {
-  resolveAgentDeliveryPlan,
+  resolveAgentDeliveryPlanWithSessionRoute,
   resolveAgentOutboundTarget,
 } from "../../infra/outbound/agent-delivery.js";
 import { resolveMessageChannelSelection } from "../../infra/outbound/channel-selection.js";
@@ -56,75 +57,85 @@ export function clearPendingFinalDeliveryFields(
   };
 }
 
-export async function resolveCurrentRunDeliveryContext(params: {
+export type PreparedCurrentRunDelivery = {
+  context: DeliveryContext;
+  targetMode: ChannelOutboundTargetMode;
+};
+
+export async function prepareCurrentRunDelivery(params: {
   cfg: OpenClawConfig;
   opts: AgentCommandOpts;
+  agentId: string;
+  currentSessionKey?: string;
   sessionEntry?: SessionEntry;
-}): Promise<DeliveryContext | undefined> {
+}): Promise<PreparedCurrentRunDelivery | undefined> {
   const { cfg, opts, sessionEntry } = params;
   if (opts.deliver !== true) {
     return undefined;
   }
-  // Restart recovery only needs durable route fields; final delivery resolves plugin-specific routes.
-  const deliveryPlan = resolveAgentDeliveryPlan({
-    sessionEntry,
-    requestedChannel: opts.replyChannel ?? opts.channel,
-    explicitTo: opts.replyTo ?? opts.to,
-    explicitThreadId: opts.threadId,
-    accountId: opts.replyAccountId ?? opts.accountId,
-    wantsDelivery: true,
-    turnSourceChannel: opts.runContext?.messageChannel ?? opts.messageChannel,
-    turnSourceTo: opts.runContext?.currentChannelId ?? opts.to,
-    turnSourceAccountId: opts.runContext?.accountId ?? opts.accountId,
-    turnSourceThreadId: opts.runContext?.currentThreadTs ?? opts.threadId,
-  });
+  const buildPlan = async (requestedChannel: string | undefined) =>
+    await resolveAgentDeliveryPlanWithSessionRoute({
+      cfg,
+      agentId: params.agentId,
+      currentSessionKey: params.currentSessionKey,
+      sessionEntry,
+      requestedChannel,
+      explicitTo: opts.replyTo ?? opts.to,
+      explicitThreadId: opts.threadId,
+      accountId: opts.replyAccountId ?? opts.accountId,
+      wantsDelivery: true,
+      turnSourceChannel: opts.runContext?.messageChannel ?? opts.messageChannel,
+      turnSourceTo: opts.runContext?.currentChannelId ?? opts.to,
+      turnSourceAccountId: opts.runContext?.accountId ?? opts.accountId,
+      turnSourceThreadId: opts.runContext?.currentThreadTs ?? opts.threadId,
+    });
+  let deliveryPlan = await buildPlan(opts.replyChannel ?? opts.channel);
   const explicitChannelHint = normalizeOptionalString(opts.replyChannel ?? opts.channel);
   const explicitThreadId =
     opts.threadId != null && opts.threadId !== "" ? opts.threadId : undefined;
-  let effectivePlan = deliveryPlan;
   if (deliveryPlan.resolvedChannel === INTERNAL_MESSAGE_CHANNEL && !explicitChannelHint) {
-    try {
-      const selection = await resolveMessageChannelSelection({ cfg });
-      effectivePlan = {
-        ...deliveryPlan,
-        resolvedChannel: selection.channel,
-        deliveryTargetMode: deliveryPlan.deliveryTargetMode ?? "implicit",
-      };
-    } catch {
-      return undefined;
-    }
+    const selection = await resolveMessageChannelSelection({ cfg });
+    deliveryPlan = await buildPlan(selection.channel);
   }
-  if (!isDeliverableMessageChannel(effectivePlan.resolvedChannel)) {
-    return undefined;
+  if (deliveryPlan.targetResolutionError) {
+    throw deliveryPlan.targetResolutionError;
+  }
+  if (!isDeliverableMessageChannel(deliveryPlan.resolvedChannel)) {
+    throw new Error(
+      "delivery channel is required: pass --channel/--reply-channel or use a main session with a previous channel",
+    );
   }
   const targetMode =
     opts.deliveryTargetMode ??
-    effectivePlan.deliveryTargetMode ??
-    (opts.to ? "explicit" : "implicit");
-  const resolvedTo =
-    effectivePlan.resolvedTo ??
-    resolveAgentOutboundTarget({
-      cfg,
-      plan: effectivePlan,
-      targetMode,
-      validateExplicitTarget: false,
-    }).resolvedTo;
+    deliveryPlan.deliveryTargetMode ??
+    ((opts.replyTo ?? opts.to) ? "explicit" : "implicit");
+  const resolved = resolveAgentOutboundTarget({
+    cfg,
+    plan: deliveryPlan,
+    targetMode,
+    validateExplicitTarget: true,
+  });
+  if (resolved.resolvedTarget && !resolved.resolvedTarget.ok) {
+    throw resolved.resolvedTarget.error;
+  }
+  const resolvedTo = resolved.resolvedTo;
   if (!resolvedTo) {
-    return undefined;
+    throw new Error(`delivery target is required for ${deliveryPlan.resolvedChannel}`);
   }
   const threadId =
     targetMode === "explicit"
       ? (explicitThreadId ??
-        (effectivePlan.baseDelivery.threadIdSource === "explicit"
-          ? effectivePlan.resolvedThreadId
+        (deliveryPlan.baseDelivery.threadIdSource === "explicit"
+          ? deliveryPlan.resolvedThreadId
           : undefined))
-      : effectivePlan.resolvedThreadId;
-  return normalizeDeliveryContext({
-    channel: effectivePlan.resolvedChannel,
+      : deliveryPlan.resolvedThreadId;
+  const context = normalizeDeliveryContext({
+    channel: deliveryPlan.resolvedChannel,
     to: resolvedTo,
-    accountId: effectivePlan.resolvedAccountId,
+    accountId: deliveryPlan.resolvedAccountId,
     threadId,
   });
+  return context ? { context, targetMode } : undefined;
 }
 
 export function createAgentCommandSessionWorkingCopy(params: {

--- a/src/infra/outbound/agent-delivery.target-resolution.test.ts
+++ b/src/infra/outbound/agent-delivery.target-resolution.test.ts
@@ -87,7 +87,10 @@ describe("agent delivery target resolution", () => {
 
   it("resolves named targets through the shared directory resolver", async () => {
     const plugin = {
-      messaging: { resolveOutboundSessionRoute: vi.fn(), targetResolver: {} },
+      messaging: {
+        resolveOutboundSessionRoute: vi.fn(),
+        targetResolver: { resolveTarget: vi.fn() },
+      },
     };
     mocks.resolveOutboundChannelPlugin.mockReturnValue(plugin);
     mocks.resolveOutboundTarget.mockReturnValue({ ok: true, to: "channel:general" });
@@ -125,7 +128,10 @@ describe("agent delivery target resolution", () => {
   it("rejects named targets when directory and plugin resolution miss", async () => {
     const targetError = new Error('Unknown target "channel:missing"');
     mocks.resolveOutboundChannelPlugin.mockReturnValue({
-      messaging: { resolveOutboundSessionRoute: vi.fn(), targetResolver: {} },
+      messaging: {
+        resolveOutboundSessionRoute: vi.fn(),
+        targetResolver: { resolveTarget: vi.fn() },
+      },
     });
     mocks.resolveOutboundTarget.mockReturnValue({ ok: true, to: "channel:missing" });
     mocks.resolveChannelTarget.mockResolvedValue({ ok: false, error: targetError });
@@ -144,7 +150,7 @@ describe("agent delivery target resolution", () => {
   });
 
   it("resolves plugin default targets before returning the delivery plan", async () => {
-    const plugin = { messaging: { targetResolver: {} } };
+    const plugin = { messaging: { targetResolver: { resolveTarget: vi.fn() } } };
     mocks.resolveOutboundChannelPlugin.mockReturnValue(plugin);
     mocks.resolveOutboundTarget.mockReturnValue({ ok: true, to: "channel:default-room" });
     mocks.resolveChannelTarget.mockResolvedValue({
@@ -213,5 +219,44 @@ describe("agent delivery target resolution", () => {
       plugin,
     });
     expect(plan.resolvedTo).toBe("some-channel");
+  });
+
+  it("preserves normalized fallback for heuristic-only target resolvers", async () => {
+    const plugin = {
+      messaging: {
+        resolveOutboundSessionRoute: vi.fn(),
+        targetResolver: { looksLikeId: vi.fn() },
+      },
+    };
+    mocks.resolveOutboundChannelPlugin.mockReturnValue(plugin);
+    mocks.resolveOutboundTarget.mockReturnValue({ ok: true, to: "some-channel" });
+    mocks.resolveChannelTarget.mockResolvedValue({
+      ok: true,
+      target: {
+        to: "some-channel",
+        kind: "group",
+        source: "normalized",
+        resolutionSource: "normalized",
+      },
+    });
+
+    const plan = await resolveAgentDeliveryPlanWithSessionRoute({
+      cfg: {} as OpenClawConfig,
+      agentId: "agent",
+      requestedChannel: "workspace",
+      explicitTo: "some-channel",
+      wantsDelivery: true,
+    });
+
+    expect(mocks.resolveChannelTarget).toHaveBeenCalledWith({
+      cfg: {},
+      channel: "workspace",
+      input: "some-channel",
+      accountId: undefined,
+      unknownTargetMode: "normalized",
+      plugin,
+    });
+    expect(plan.resolvedTo).toBe("some-channel");
+    expect(plan.targetResolutionError).toBeUndefined();
   });
 });

--- a/src/infra/outbound/agent-delivery.target-resolution.test.ts
+++ b/src/infra/outbound/agent-delivery.target-resolution.test.ts
@@ -1,0 +1,217 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  resolveOutboundChannelPlugin: vi.fn<() => unknown>(),
+  resolveChannelTarget: vi.fn<(params: { input: string }) => Promise<unknown>>(),
+  resolveOutboundTarget: vi.fn<() => { ok: true; to: string } | { ok: false; error: Error }>(),
+  resolveOutboundSessionRoute: vi.fn<() => Promise<unknown>>(),
+  resolveSessionDeliveryTarget: vi.fn(
+    (params: { requestedChannel?: string; explicitTo?: string }) => ({
+      channel: params.requestedChannel,
+      to: params.explicitTo,
+      mode: params.explicitTo ? "explicit" : "implicit",
+    }),
+  ),
+}));
+
+vi.mock("./targets.js", () => ({
+  resolveOutboundTarget: mocks.resolveOutboundTarget,
+  resolveSessionDeliveryTarget: mocks.resolveSessionDeliveryTarget,
+}));
+
+vi.mock("./channel-resolution.js", () => ({
+  resolveOutboundChannelPlugin: mocks.resolveOutboundChannelPlugin,
+}));
+
+vi.mock("./outbound-session.js", () => ({
+  resolveOutboundSessionRoute: mocks.resolveOutboundSessionRoute,
+}));
+
+vi.mock("./target-resolver.js", () => ({
+  resolveChannelTarget: mocks.resolveChannelTarget,
+}));
+
+vi.mock("../../utils/message-channel.js", () => ({
+  INTERNAL_MESSAGE_CHANNEL: "webchat",
+  isDeliverableMessageChannel: (channel: string) => channel === "workspace",
+  isGatewayMessageChannel: (channel: string) => ["webchat", "workspace"].includes(channel),
+  normalizeMessageChannel: (value: string) => value.trim().toLowerCase(),
+}));
+
+import type { OpenClawConfig } from "../../config/config.js";
+
+let resolveAgentDeliveryPlanWithSessionRoute: typeof import("./agent-delivery.js").resolveAgentDeliveryPlanWithSessionRoute;
+
+beforeAll(async () => {
+  ({ resolveAgentDeliveryPlanWithSessionRoute } = await import("./agent-delivery.js"));
+});
+
+beforeEach(() => {
+  mocks.resolveOutboundChannelPlugin.mockReset();
+  mocks.resolveChannelTarget.mockReset();
+  mocks.resolveOutboundTarget.mockReset();
+  mocks.resolveOutboundSessionRoute.mockReset();
+  mocks.resolveOutboundSessionRoute.mockResolvedValue(null);
+  mocks.resolveSessionDeliveryTarget.mockClear();
+});
+
+describe("agent delivery target resolution", () => {
+  it("does not session-route targets when outbound validation fails", async () => {
+    const targetError = new Error("ambiguous target");
+    mocks.resolveOutboundChannelPlugin.mockReturnValue({
+      messaging: { resolveOutboundSessionRoute: vi.fn() },
+    });
+    mocks.resolveOutboundTarget.mockReturnValue({ ok: false, error: targetError });
+    mocks.resolveChannelTarget.mockResolvedValue({
+      ok: true,
+      target: {
+        to: "1470130713209602050",
+        kind: "group",
+        source: "normalized",
+        resolutionSource: "normalized",
+      },
+    });
+
+    const plan = await resolveAgentDeliveryPlanWithSessionRoute({
+      cfg: {} as OpenClawConfig,
+      agentId: "agent",
+      requestedChannel: "workspace",
+      explicitTo: "1470130713209602050",
+      wantsDelivery: true,
+    });
+
+    expect(mocks.resolveOutboundSessionRoute).not.toHaveBeenCalled();
+    expect(plan.resolvedTo).toBe("1470130713209602050");
+    expect(plan.targetResolutionError).toBe(targetError);
+  });
+
+  it("resolves named targets through the shared directory resolver", async () => {
+    const plugin = {
+      messaging: { resolveOutboundSessionRoute: vi.fn(), targetResolver: {} },
+    };
+    mocks.resolveOutboundChannelPlugin.mockReturnValue(plugin);
+    mocks.resolveOutboundTarget.mockReturnValue({ ok: true, to: "channel:general" });
+    mocks.resolveChannelTarget.mockResolvedValue({
+      ok: true,
+      target: {
+        to: "channel:1524410080953634829",
+        kind: "channel",
+        source: "directory",
+        resolutionSource: "directory",
+      },
+    });
+
+    const plan = await resolveAgentDeliveryPlanWithSessionRoute({
+      cfg: {} as OpenClawConfig,
+      agentId: "agent",
+      currentSessionKey: "agent:main",
+      requestedChannel: "workspace",
+      explicitTo: "channel:general",
+      wantsDelivery: true,
+    });
+
+    expect(mocks.resolveChannelTarget).toHaveBeenCalledWith({
+      cfg: {},
+      channel: "workspace",
+      input: "channel:general",
+      accountId: undefined,
+      unknownTargetMode: "error",
+      plugin,
+    });
+    expect(plan.resolvedTo).toBe("channel:1524410080953634829");
+    expect(plan.targetResolutionError).toBeUndefined();
+  });
+
+  it("rejects named targets when directory and plugin resolution miss", async () => {
+    const targetError = new Error('Unknown target "channel:missing"');
+    mocks.resolveOutboundChannelPlugin.mockReturnValue({
+      messaging: { resolveOutboundSessionRoute: vi.fn(), targetResolver: {} },
+    });
+    mocks.resolveOutboundTarget.mockReturnValue({ ok: true, to: "channel:missing" });
+    mocks.resolveChannelTarget.mockResolvedValue({ ok: false, error: targetError });
+
+    const plan = await resolveAgentDeliveryPlanWithSessionRoute({
+      cfg: {} as OpenClawConfig,
+      agentId: "agent",
+      requestedChannel: "workspace",
+      explicitTo: "channel:missing",
+      wantsDelivery: true,
+    });
+
+    expect(mocks.resolveOutboundSessionRoute).not.toHaveBeenCalled();
+    expect(plan.resolvedTo).toBe("channel:missing");
+    expect(plan.targetResolutionError).toBe(targetError);
+  });
+
+  it("resolves plugin default targets before returning the delivery plan", async () => {
+    const plugin = { messaging: { targetResolver: {} } };
+    mocks.resolveOutboundChannelPlugin.mockReturnValue(plugin);
+    mocks.resolveOutboundTarget.mockReturnValue({ ok: true, to: "channel:default-room" });
+    mocks.resolveChannelTarget.mockResolvedValue({
+      ok: true,
+      target: {
+        to: "channel:1524410080953634830",
+        kind: "channel",
+        source: "directory",
+        resolutionSource: "directory",
+      },
+    });
+
+    const plan = await resolveAgentDeliveryPlanWithSessionRoute({
+      cfg: {} as OpenClawConfig,
+      agentId: "agent",
+      requestedChannel: "workspace",
+      wantsDelivery: true,
+    });
+
+    expect(mocks.resolveOutboundTarget).toHaveBeenCalledWith({
+      channel: "workspace",
+      to: undefined,
+      cfg: {},
+      accountId: undefined,
+      mode: "implicit",
+    });
+    expect(mocks.resolveChannelTarget).toHaveBeenCalledWith({
+      cfg: {},
+      channel: "workspace",
+      input: "channel:default-room",
+      accountId: undefined,
+      unknownTargetMode: "error",
+      plugin,
+    });
+    expect(plan.resolvedTo).toBe("channel:1524410080953634830");
+  });
+
+  it("preserves normalized fallback for session-route-only plugins", async () => {
+    const plugin = { messaging: { resolveOutboundSessionRoute: vi.fn() } };
+    mocks.resolveOutboundChannelPlugin.mockReturnValue(plugin);
+    mocks.resolveOutboundTarget.mockReturnValue({ ok: true, to: "some-channel" });
+    mocks.resolveChannelTarget.mockResolvedValue({
+      ok: true,
+      target: {
+        to: "some-channel",
+        kind: "group",
+        source: "normalized",
+        resolutionSource: "normalized",
+      },
+    });
+
+    const plan = await resolveAgentDeliveryPlanWithSessionRoute({
+      cfg: {} as OpenClawConfig,
+      agentId: "agent",
+      requestedChannel: "workspace",
+      explicitTo: "some-channel",
+      wantsDelivery: true,
+    });
+
+    expect(mocks.resolveChannelTarget).toHaveBeenCalledWith({
+      cfg: {},
+      channel: "workspace",
+      input: "some-channel",
+      accountId: undefined,
+      unknownTargetMode: "normalized",
+      plugin,
+    });
+    expect(plan.resolvedTo).toBe("some-channel");
+  });
+});

--- a/src/infra/outbound/agent-delivery.test.ts
+++ b/src/infra/outbound/agent-delivery.test.ts
@@ -769,7 +769,7 @@ describe("agent delivery helpers", () => {
       channel: "telegram",
       input: "current",
       accountId: "work",
-      unknownTargetMode: "error",
+      unknownTargetMode: "normalized",
       plugin: {
         messaging: { resolveOutboundSessionRoute: expect.any(Function), targetResolver: {} },
       },
@@ -825,7 +825,7 @@ describe("agent delivery helpers", () => {
       channel: "telegram",
       input: "current",
       accountId: undefined,
-      unknownTargetMode: "error",
+      unknownTargetMode: "normalized",
       plugin: {
         messaging: { resolveOutboundSessionRoute: expect.any(Function), targetResolver: {} },
       },

--- a/src/infra/outbound/agent-delivery.test.ts
+++ b/src/infra/outbound/agent-delivery.test.ts
@@ -4,10 +4,10 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   resolveOutboundChannelPlugin: vi.fn<() => unknown>(() => null),
-  resolveChannelTarget: vi.fn<() => Promise<unknown>>(async () => ({
+  resolveChannelTarget: vi.fn<(params: { input: string }) => Promise<unknown>>(async (params) => ({
     ok: true,
     target: {
-      to: "+1999",
+      to: params.input,
       kind: "group",
       source: "normalized",
       resolutionSource: "normalized",
@@ -132,15 +132,15 @@ beforeEach(() => {
   mocks.resolveOutboundChannelPlugin.mockReset();
   mocks.resolveOutboundChannelPlugin.mockReturnValue(null);
   mocks.resolveChannelTarget.mockReset();
-  mocks.resolveChannelTarget.mockResolvedValue({
+  mocks.resolveChannelTarget.mockImplementation(async (params: { input: string }) => ({
     ok: true,
     target: {
-      to: "+1999",
+      to: params.input,
       kind: "group",
       source: "normalized",
       resolutionSource: "normalized",
     },
-  });
+  }));
   mocks.resolveOutboundTarget.mockReset();
   mocks.resolveOutboundTarget.mockReturnValue({ ok: true, to: "+1999" });
   mocks.resolveOutboundSessionRoute.mockReset();
@@ -727,29 +727,6 @@ describe("agent delivery helpers", () => {
     expect(result.sessionKey).toBe("agent:ops:whatsapp:work:direct:+15551234567");
   });
 
-  it("does not session-route explicit targets before outbound normalization succeeds", async () => {
-    mocks.resolveOutboundChannelPlugin.mockReturnValue({
-      messaging: { resolveOutboundSessionRoute: vi.fn() },
-    });
-    mocks.resolveOutboundTarget.mockReturnValueOnce({
-      ok: false,
-      error: new Error("ambiguous target"),
-    });
-
-    const plan = await resolveAgentDeliveryPlanWithSessionRoute({
-      cfg: {} as OpenClawConfig,
-      agentId: "agent",
-      sessionEntry: undefined,
-      requestedChannel: "workspace",
-      explicitTo: "1470130713209602050",
-      accountId: undefined,
-      wantsDelivery: true,
-    });
-
-    expect(mocks.resolveOutboundSessionRoute).not.toHaveBeenCalled();
-    expect(plan.resolvedTo).toBe("1470130713209602050");
-  });
-
   it("resolves reserved explicit targets through directory-capable resolution before session routing", async () => {
     mocks.resolveOutboundChannelPlugin.mockReturnValue({
       messaging: { resolveOutboundSessionRoute: vi.fn(), targetResolver: {} },
@@ -792,7 +769,7 @@ describe("agent delivery helpers", () => {
       channel: "telegram",
       input: "current",
       accountId: "work",
-      unknownTargetMode: "normalized",
+      unknownTargetMode: "error",
       plugin: {
         messaging: { resolveOutboundSessionRoute: expect.any(Function), targetResolver: {} },
       },
@@ -848,7 +825,7 @@ describe("agent delivery helpers", () => {
       channel: "telegram",
       input: "current",
       accountId: undefined,
-      unknownTargetMode: "normalized",
+      unknownTargetMode: "error",
       plugin: {
         messaging: { resolveOutboundSessionRoute: expect.any(Function), targetResolver: {} },
       },

--- a/src/infra/outbound/agent-delivery.test.ts
+++ b/src/infra/outbound/agent-delivery.test.ts
@@ -114,14 +114,12 @@ vi.mock("../../utils/message-channel.js", () => ({
 }));
 
 import type { OpenClawConfig } from "../../config/config.js";
-let resolveAgentDeliveryPlan: typeof import("./agent-delivery.js").resolveAgentDeliveryPlan;
 let resolveAgentDeliveryPlanWithSessionRoute: typeof import("./agent-delivery.js").resolveAgentDeliveryPlanWithSessionRoute;
 let resolveAgentExplicitRecipientSession: typeof import("./agent-delivery.js").resolveAgentExplicitRecipientSession;
 let resolveAgentOutboundTarget: typeof import("./agent-delivery.js").resolveAgentOutboundTarget;
 
 beforeAll(async () => {
   ({
-    resolveAgentDeliveryPlan,
     resolveAgentDeliveryPlanWithSessionRoute,
     resolveAgentExplicitRecipientSession,
     resolveAgentOutboundTarget,
@@ -148,8 +146,14 @@ beforeEach(() => {
   mocks.resolveSessionDeliveryTarget.mockClear();
 });
 
-function expectDeliveryPlan(params: Parameters<typeof resolveAgentDeliveryPlan>[0]) {
-  return resolveAgentDeliveryPlan(params);
+async function buildDeliveryPlan(
+  params: Omit<Parameters<typeof resolveAgentDeliveryPlanWithSessionRoute>[0], "cfg" | "agentId">,
+) {
+  return await resolveAgentDeliveryPlanWithSessionRoute({
+    cfg: {} as OpenClawConfig,
+    agentId: "agent",
+    ...params,
+  });
 }
 
 describe("agent delivery helpers", () => {
@@ -223,15 +227,15 @@ describe("agent delivery helpers", () => {
         resolvedTo: undefined,
       },
     },
-  ])("builds delivery plan for %j", ({ params, expected }) => {
-    const plan = expectDeliveryPlan(params);
+  ])("builds delivery plan for %j", async ({ params, expected }) => {
+    const plan = await buildDeliveryPlan(params);
     for (const [key, value] of Object.entries(expected)) {
       expect((plan as Record<string, unknown>)[key]).toEqual(value);
     }
   });
 
-  it("resolves fallback targets when no explicit destination is provided", () => {
-    const plan = resolveAgentDeliveryPlan({
+  it("resolves fallback targets when no explicit destination is provided", async () => {
+    const plan = await buildDeliveryPlan({
       sessionEntry: {
         sessionId: "s2",
         updatedAt: 2,
@@ -254,8 +258,8 @@ describe("agent delivery helpers", () => {
     expect(resolved.resolvedTo).toBe("+1999");
   });
 
-  it("skips outbound target resolution when explicit target validation is disabled", () => {
-    const plan = expectDeliveryPlan({
+  it("skips outbound target resolution when explicit target validation is disabled", async () => {
+    const plan = await buildDeliveryPlan({
       sessionEntry: {
         sessionId: "s3",
         updatedAt: 3,

--- a/src/infra/outbound/agent-delivery.ts
+++ b/src/infra/outbound/agent-delivery.ts
@@ -187,6 +187,9 @@ export async function resolveAgentDeliveryPlanWithSessionRoute(
   }
   const hasPluginSessionRoute = Boolean(plugin?.messaging?.resolveOutboundSessionRoute);
   const hasPluginTargetResolver = Boolean(plugin?.messaging?.targetResolver);
+  // Only concrete plugin resolution makes a directory miss authoritative.
+  // Heuristic-only resolvers preserve the shipped normalized fallback.
+  const hasPluginConcreteTargetResolver = Boolean(plugin?.messaging?.targetResolver?.resolveTarget);
   if (
     !hasPluginSessionRoute &&
     !hasPluginTargetResolver &&
@@ -219,7 +222,7 @@ export async function resolveAgentDeliveryPlanWithSessionRoute(
     channel: resolvedChannel as ChannelId,
     input: targetInput,
     accountId: routedPlan.resolvedAccountId,
-    unknownTargetMode: hasPluginTargetResolver ? "error" : "normalized",
+    unknownTargetMode: hasPluginConcreteTargetResolver ? "error" : "normalized",
     plugin,
   });
   if (!resolvedTarget.ok) {

--- a/src/infra/outbound/agent-delivery.ts
+++ b/src/infra/outbound/agent-delivery.ts
@@ -60,7 +60,7 @@ function rebaseOutboundSessionRoute(
   };
 }
 
-export function resolveAgentDeliveryPlan(params: {
+function resolveAgentDeliveryPlan(params: {
   sessionEntry?: SessionEntry;
   requestedChannel?: string;
   explicitTo?: string;

--- a/src/infra/outbound/agent-delivery.ts
+++ b/src/infra/outbound/agent-delivery.ts
@@ -20,7 +20,6 @@ import {
 } from "../../utils/message-channel.js";
 import { resolveOutboundChannelPlugin } from "./channel-resolution.js";
 import { resolveOutboundSessionRoute, type OutboundSessionRoute } from "./outbound-session.js";
-import { isReservedTargetLiteralError } from "./target-errors.js";
 import { resolveChannelTarget, type ResolvedMessagingTarget } from "./target-resolver.js";
 import type { OutboundTargetResolution } from "./targets.js";
 import {
@@ -174,8 +173,8 @@ export async function resolveAgentDeliveryPlanWithSessionRoute(
   },
 ): Promise<AgentDeliveryPlan> {
   const plan = resolveAgentDeliveryPlan(params);
-  const { resolvedChannel, resolvedTo } = plan;
-  if (!params.wantsDelivery || !resolvedTo || !isDeliverableMessageChannel(resolvedChannel)) {
+  const { resolvedChannel } = plan;
+  if (!params.wantsDelivery || !isDeliverableMessageChannel(resolvedChannel)) {
     return plan;
   }
   const plugin = resolveOutboundChannelPlugin({
@@ -183,45 +182,63 @@ export async function resolveAgentDeliveryPlanWithSessionRoute(
     cfg: params.cfg,
     allowBootstrap: true,
   });
+  if (!plugin) {
+    return plan;
+  }
   const hasPluginSessionRoute = Boolean(plugin?.messaging?.resolveOutboundSessionRoute);
-  if (!hasPluginSessionRoute && params.sessionRouteMode !== "allow-fallback") {
+  const hasPluginTargetResolver = Boolean(plugin?.messaging?.targetResolver);
+  if (
+    !hasPluginSessionRoute &&
+    !hasPluginTargetResolver &&
+    params.sessionRouteMode !== "allow-fallback"
+  ) {
     return plan;
   }
   const resolvedAccountId =
     plan.resolvedAccountId ??
-    (plugin && params.sessionRouteMode === "allow-fallback"
+    (params.sessionRouteMode === "allow-fallback"
       ? resolveChannelDefaultAccountId({ plugin, cfg: params.cfg })
       : undefined);
   const routedPlan =
     resolvedAccountId === plan.resolvedAccountId ? plan : { ...plan, resolvedAccountId };
   const normalizedTarget = resolveOutboundTarget({
     channel: resolvedChannel,
-    to: resolvedTo,
+    to: routedPlan.resolvedTo,
     cfg: params.cfg,
     accountId: routedPlan.resolvedAccountId,
     mode: routedPlan.deliveryTargetMode ?? "explicit",
   });
-  let sessionRouteTarget: string;
-  let resolvedSessionRouteTarget: ResolvedMessagingTarget | undefined;
-  if (normalizedTarget.ok) {
-    sessionRouteTarget = normalizedTarget.to;
-  } else {
-    if (!isReservedTargetLiteralError(normalizedTarget.error)) {
-      return { ...routedPlan, targetResolutionError: normalizedTarget.error };
-    }
-    const resolvedTarget = await resolveChannelTarget({
-      cfg: params.cfg,
-      channel: resolvedChannel as ChannelId,
-      input: resolvedTo,
-      accountId: routedPlan.resolvedAccountId,
-      unknownTargetMode: "normalized",
-      plugin,
-    });
-    if (!resolvedTarget.ok) {
-      return { ...routedPlan, targetResolutionError: resolvedTarget.error };
-    }
-    sessionRouteTarget = resolvedTarget.target.to;
-    resolvedSessionRouteTarget = resolvedTarget.target;
+  const targetInput = normalizedTarget.ok ? normalizedTarget.to : routedPlan.resolvedTo;
+  if (!targetInput) {
+    return normalizedTarget.ok
+      ? routedPlan
+      : { ...routedPlan, targetResolutionError: normalizedTarget.error };
+  }
+  const resolvedTarget = await resolveChannelTarget({
+    cfg: params.cfg,
+    channel: resolvedChannel as ChannelId,
+    input: targetInput,
+    accountId: routedPlan.resolvedAccountId,
+    unknownTargetMode: hasPluginTargetResolver ? "error" : "normalized",
+    plugin,
+  });
+  if (!resolvedTarget.ok) {
+    return { ...routedPlan, targetResolutionError: resolvedTarget.error };
+  }
+  // An async normalized fallback cannot erase an earlier synchronous validation error.
+  if (!normalizedTarget.ok && resolvedTarget.target.resolutionSource === "normalized") {
+    return { ...routedPlan, targetResolutionError: normalizedTarget.error };
+  }
+  const sessionRouteTarget = resolvedTarget.target.to;
+  const resolvedSessionRouteTarget: ResolvedMessagingTarget | undefined =
+    !normalizedTarget.ok ||
+    normalizedTarget.to !== resolvedTarget.target.to ||
+    resolvedTarget.target.resolutionSource === "directory"
+      ? resolvedTarget.target
+      : undefined;
+  const resolvedPlan = { ...routedPlan, resolvedTo: sessionRouteTarget };
+  if (!hasPluginSessionRoute && params.sessionRouteMode !== "allow-fallback") {
+    return resolvedPlan;
   }
   const explicitThreadId =
     params.explicitThreadId != null && params.explicitThreadId !== ""
@@ -241,7 +258,7 @@ export async function resolveAgentDeliveryPlanWithSessionRoute(
         threadId:
           routedPlan.deliveryTargetMode === "explicit"
             ? explicitThreadId
-            : routedPlan.resolvedThreadId,
+            : resolvedPlan.resolvedThreadId,
       });
     } catch {
       return null;
@@ -310,18 +327,18 @@ export async function resolveAgentDeliveryPlanWithSessionRoute(
   if (!selectedRoute) {
     if (resolvedSessionRouteTarget) {
       return {
-        ...routedPlan,
+        ...resolvedPlan,
         resolvedTo: resolvedSessionRouteTarget.to,
         resolvedThreadId:
-          routedPlan.deliveryTargetMode === "explicit"
+          resolvedPlan.deliveryTargetMode === "explicit"
             ? explicitThreadId
-            : routedPlan.resolvedThreadId,
+            : resolvedPlan.resolvedThreadId,
       };
     }
-    return routedPlan;
+    return resolvedPlan;
   }
   return {
-    ...routedPlan,
+    ...resolvedPlan,
     resolvedSessionKey: selectedRoute.sessionKey,
     // Generic routes use portable user/channel prefixes. Delivery still needs the
     // plugin-normalized target; only provider-owned route hooks may replace it.
@@ -330,9 +347,9 @@ export async function resolveAgentDeliveryPlanWithSessionRoute(
       : (resolvedSessionRouteTarget?.to ?? sessionRouteTarget),
     resolvedThreadId:
       selectedRoute.threadId ??
-      (routedPlan.deliveryTargetMode === "explicit"
+      (resolvedPlan.deliveryTargetMode === "explicit"
         ? explicitThreadId
-        : routedPlan.resolvedThreadId),
+        : resolvedPlan.resolvedThreadId),
   };
 }
 

--- a/src/infra/outbound/target-resolver.test.ts
+++ b/src/infra/outbound/target-resolver.test.ts
@@ -609,6 +609,51 @@ describe("resolveMessagingTarget (directory fallback)", () => {
     expect(firstMockArg(mocks.resolveTarget, "target resolver").input).toBe("+15551234567");
   });
 
+  it("fails closed after directory and plugin misses unless normalized fallback is explicit", async () => {
+    mocks.listGroups.mockResolvedValue([]);
+    mocks.listGroupsLive.mockResolvedValue([]);
+    mocks.resolveTarget.mockResolvedValue(null);
+
+    const rejected = await resolveMessagingTarget({
+      cfg,
+      channel: "richchat",
+      input: "missing",
+    });
+    expect(rejected.ok).toBe(false);
+
+    const fallback = await expectOkResolution({
+      cfg,
+      channel: "richchat",
+      input: "missing",
+      unknownTargetMode: "normalized",
+    });
+    expect(fallback.target).toMatchObject({
+      to: "missing",
+      source: "normalized",
+      resolutionSource: "normalized",
+    });
+  });
+
+  it("fails closed when a name matches more than one directory destination", async () => {
+    mocks.listGroups.mockResolvedValue([
+      { kind: "group", id: "channel:1", name: "general" },
+      { kind: "group", id: "channel:2", name: "general-archive" },
+    ] satisfies ChannelDirectoryEntry[]);
+
+    const result = await resolveMessagingTarget({
+      cfg,
+      channel: "richchat",
+      input: "general",
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.candidates).toHaveLength(2);
+      expect(result.error.message).toContain("Ambiguous");
+    }
+    expect(mocks.resolveTarget).not.toHaveBeenCalled();
+  });
+
   it("keeps plugin-owned id casing when resolver returns a normalized target", async () => {
     mocks.getChannelPlugin.mockReturnValue({
       messaging: {


### PR DESCRIPTION
Closes #107628

Alternative implementation to #107934.

## What Problem This Solves

Fixes an issue where users delivering an agent reply or subagent announcement to a named Discord channel would receive `Invalid Form Body`, even though the model run completed successfully. The unresolved name could also be persisted for restart recovery, causing later delivery attempts to repeat the same failure.

## Why This Change Was Made

Agent delivery now resolves and validates its destination once through the shared outbound target resolver before model execution, then carries that canonical destination through delivery and restart-recovery state. Discord normalization preserves numeric-ID behavior while leaving mutable names to directory lookup, and the Discord fallback resolver may return only canonical IDs rather than unresolved names.

Compared with #107934, this version performs strict target preparation before the model run, fails unknown or ambiguous strict targets before spending model work, and explicitly preserves `bestEffortDeliver` by downgrading a failed preflight to session-only execution. Plugins without a target resolver retain their existing normalized fallback behavior.

## User Impact

`openclaw agent --deliver`, configured default targets, and inherited subagent announcement destinations can use bare, `#`-prefixed, or `channel:`-prefixed channel names. Numeric targets remain compatible. Unknown and ambiguous names fail with a useful resolver error instead of reaching Discord as malformed IDs, and persisted pending-delivery context uses the resolved destination.

## Evidence

- Final exact-head Discord before/after: [AWS Crabbox run `run_06090d86ddf2`](https://crabbox.openclaw.ai/portal/runs/run_06090d86ddf2) used one Linux host, one temporary Discord channel on `josh's server`, and `openai/gpt-5.6-luna` for both baseline `9f0ceb9e5ea1038e720616a1513b83ef9c595ed7` and final head `c3881acaaf5bcf103a97aee1a5b2fcf9fd6d5af8`. The baseline reproduced Discord's invalid channel-ID rejection with no delivered marker; the final head resolved the same name and delivered the marker successfully.
- Final exact-head non-Discord sibling matrix: [AWS Crabbox run `run_3d408f00b888`](https://crabbox.openclaw.ai/portal/runs/run_3d408f00b888) used an official Mattermost preview service and a mock model endpoint against the same baseline and final head. Accepted opaque channel IDs delivered on both refs; the baseline resolver miss reached the model, while the final head's strict miss stopped before model execution; `bestEffortDeliver` continued session-only with no delivery or pending recovery entry.
- Additional Discord target matrix: [AWS Crabbox run `run_dbff9d9d75c1`](https://crabbox.openclaw.ai/portal/runs/run_dbff9d9d75c1) passed bare, `channel:`-prefixed, and `#`-prefixed names; bare and prefixed numeric IDs; a named configured default; unknown-name rejection; and duplicate-name rejection. This ran on a patch-identical pre-rebase commit.
- Exact-head focused tests: 212 tests passed on Blacksmith Testbox across Discord normalization/resolution, shared outbound target resolution, agent delivery, agent command delivery preparation, and the rebased restart-recovery contract. Two narrow local files separately passed 10 assertions.
- Exact-head static and CI proof: `pnpm check:changed` passed on Blacksmith Testbox, including core/extension production and test typechecks, lint, formatting, and architectural guards. PR CI settled with 81 passed checks, 33 intentional skips, and zero failures or pending checks.
- Final branch review: `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` reported no accepted/actionable findings (`overall: patch is correct`, confidence 0.84).
- Cleanup verification: both AWS leases were released, the Blacksmith Testbox was stopped, and the temporary Discord channel count on `josh's server` returned to zero. Credential handoff files remain intact.

AI-assisted: implementation, review, and evidence collection were performed with Codex. I understand the change and verified the user-visible behavior through live Discord E2E proof.
