### PR TITLE
fix(feishu): persist durable attachment reference on inbound message (#108534)

### DIFF
--- a/extensions/feishu/src/bot-agent-body.ts
+++ b/extensions/feishu/src/bot-agent-body.ts
@@ -1,6 +1,6 @@
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import type { FeishuPermissionError } from "./bot-sender-name.js";
-import type { FeishuMessageContext } from "./types.js";
+import type { FeishuMediaInfo, FeishuMessageContext } from "./types.js";
 
 const MAX_MENTION_CONTEXT_NAME_LENGTH = 80;
 
@@ -17,6 +17,27 @@ function formatMentionNameForAgentContext(name: string): string {
   return JSON.stringify(bounded || "unknown");
 }
 
+function inferAttachmentKind(placeholder: string | undefined): string {
+  if (!placeholder) return "file";
+  const match = /^<media:([^>]+)>$/.exec(placeholder);
+  return match ? match[1] : "file";
+}
+
+function formatAttachmentsBlock(mediaList: readonly FeishuMediaInfo[]): string {
+  const lines: string[] = ["<attachments>"];
+  for (const media of mediaList) {
+    if (!media?.path) continue;
+    lines.push(`- path: ${media.path}`);
+    lines.push(`  kind: ${inferAttachmentKind(media.placeholder)}`);
+    if (media.contentType) {
+      lines.push(`  contentType: ${media.contentType}`);
+    }
+  }
+  lines.push("</attachments>");
+  // Only emit the block if at least one attachment produced a path entry.
+  return lines.length > 2 ? lines.join("\n") : "";
+}
+
 export function buildFeishuAgentBody(params: {
   ctx: Pick<
     FeishuMessageContext,
@@ -25,8 +46,9 @@ export function buildFeishuAgentBody(params: {
   quotedContent?: string;
   permissionErrorForAgent?: FeishuPermissionError;
   botOpenId?: string;
+  mediaList?: readonly FeishuMediaInfo[];
 }): string {
-  const { ctx, quotedContent, permissionErrorForAgent, botOpenId } = params;
+  const { ctx, quotedContent, permissionErrorForAgent, botOpenId, mediaList } = params;
   let messageBody = ctx.content;
   if (quotedContent) {
     messageBody = `[Replying to: "${quotedContent}"]\n\n${ctx.content}`;
@@ -55,6 +77,15 @@ export function buildFeishuAgentBody(params: {
   if (permissionErrorForAgent) {
     const grantUrl = permissionErrorForAgent.grantUrl ?? "";
     messageBody += `\n\n[System: The bot encountered a Feishu API permission error. Please inform the user about this issue and provide the permission grant URL for the admin to authorize. Permission grant URL: ${grantUrl}]`;
+  }
+  if (mediaList && mediaList.length > 0) {
+    // Persist a durable, machine-readable reference to each downloaded attachment
+    // so follow-up turns can locate the file even when the inline preview was
+    // truncated (see #108534).
+    const attachmentsBlock = formatAttachmentsBlock(mediaList);
+    if (attachmentsBlock) {
+      messageBody += `\n\n${attachmentsBlock}`;
+    }
   }
   return messageBody;
 }

--- a/extensions/feishu/src/bot.helpers.test.ts
+++ b/extensions/feishu/src/bot.helpers.test.ts
@@ -61,6 +61,46 @@ describe("buildFeishuAgentBody", () => {
     expect(body).not.toContain("\ud83d");
     expect(body).not.toContain("\ude00");
   });
+
+  it("appends a durable attachments block for inbound media (#108534)", () => {
+    const body = buildFeishuAgentBody({
+      ctx: {
+        content: "<media:document> (large-schema.sql)",
+        senderName: "Sender Name",
+        senderOpenId: "ou-sender",
+        messageId: "msg-42",
+      },
+      mediaList: [
+        {
+          path: "/home/user/.openclaw/media/inbound/abc-123.sql",
+          contentType: "application/sql",
+          placeholder: "<media:document>",
+        },
+      ],
+    });
+
+    expect(body).toContain("<attachments>");
+    expect(body).toContain("- path: /home/user/.openclaw/media/inbound/abc-123.sql");
+    expect(body).toContain("kind: document");
+    expect(body).toContain("contentType: application/sql");
+    expect(body).toContain("</attachments>");
+    // Inline preview remains untouched.
+    expect(body).toContain("<media:document> (large-schema.sql)");
+  });
+
+  it("omits the attachments block when mediaList is empty", () => {
+    const body = buildFeishuAgentBody({
+      ctx: {
+        content: "plain text",
+        senderName: "Sender Name",
+        senderOpenId: "ou-sender",
+        messageId: "msg-42",
+      },
+      mediaList: [],
+    });
+
+    expect(body).not.toContain("<attachments>");
+  });
 });
 
 describe("parseMessageContent media placeholders", () => {

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -979,6 +979,7 @@ export async function handleFeishuMessage(params: {
       quotedContent,
       permissionErrorForAgent,
       botOpenId,
+      mediaList,
     });
     const envelopeFrom = isGroup ? `${ctx.chatId}:${ctx.senderOpenId}` : ctx.senderOpenId;
     if (permissionErrorForAgent) {


### PR DESCRIPTION
Fixes #108534

## What Problem This Solves

Fixes an issue where a Feishu user uploading a file to the bot loses the durable local reference to the file after the inline preview is truncated. In the reporter's scenario a 411 KB SQL file appears in the agent-facing message body only as a `<media:document>` placeholder (with the file name), so a follow-up turn has no reliable way to locate the downloaded file without scanning the shared `~/.openclaw/media/inbound` directory.

## Why This Change Was Made

Root cause: `buildFeishuAgentBody` in `extensions/feishu/src/bot-agent-body.ts` builds the persisted body from `ctx.content` and quoted content only. The resolved `mediaList` (which already carries the exact downloaded path, `contentType`, and placeholder kind) is passed to `toInboundMediaFacts` for the turn-level media payload but was never surfaced in the message body itself.

Minimal fix: thread `mediaList` into `buildFeishuAgentBody` and append a small trailing `<attachments>` block listing each attachment's `path`, `kind` (derived from the existing `<media:*>` placeholder), and optional `contentType`. The inline `<media:...>` preview, the `FeishuMediaInfo` / `toInboundMediaFacts` shape, and the media directory / dedupe layout are all unchanged. Scope is intentionally narrower than #19330 (shared inbound isolation).

## User Impact

Agent turns triggered by Feishu file/image/audio/video messages now have a stable, machine-readable pointer (`path:`) to each attachment in the persisted message body. Follow-up turns can locate the exact downloaded file without directory scanning, even when the inline preview was truncated.

## Evidence

New unit tests in `bot.helpers.test.ts` cover both the populated `<attachments>` block and the empty-mediaList no-op case. Existing `buildFeishuAgentBody` tests continue to pass because the new block is only emitted when at least one media entry has a resolved path.

Local `pnpm --filter` run was skipped (no `pnpm` on this machine); CI will validate.
