### PR TITLE
test(release): harden QA and live validation

### DIFF
--- a/extensions/qa-lab/src/scenario-catalog.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog.test.ts
@@ -623,7 +623,7 @@ describe("qa scenario catalog", () => {
     const scenario = readQaScenarioById("luna-thinking-visibility-switch");
     const config = readQaScenarioExecutionConfig("luna-thinking-visibility-switch") as
       | {
-          requiredProvider?: string;
+          liveProvider?: string;
           requiredModel?: string;
           offDirective?: string;
           maxDirective?: string;
@@ -632,7 +632,7 @@ describe("qa scenario catalog", () => {
       | undefined;
 
     expect(scenario.sourcePath).toBe("qa/scenarios/models/luna-thinking-visibility-switch.yaml");
-    expect(config?.requiredProvider).toBe("openai");
+    expect(config?.liveProvider).toBe("openai");
     expect(config?.requiredModel).toBe("gpt-5.6-luna");
     expect(config?.offDirective).toBe("/think off");
     expect(config?.maxDirective).toBe("/think medium");
@@ -937,6 +937,19 @@ describe("qa scenario catalog", () => {
 
     expect(channelBaseline.execution.suiteIsolation).toBe("isolated");
     expect(subagentFanout.execution.suiteIsolation).toBe("isolated");
+  });
+
+  it("settles subagent completions before reading the SQLite session store", () => {
+    const scenario = requireFlowScenario(readQaScenarioById("subagent-fanout-synthesis"));
+    const flow = JSON.stringify(scenario.execution.flow);
+    const completionWaits = [...flow.matchAll(/expectedChildCompletionMarkers/gu)].map(
+      (match) => match.index,
+    );
+    const storeReads = [...flow.matchAll(/readRawQaSessionStore/gu)].map((match) => match.index);
+
+    expect(completionWaits).toHaveLength(2);
+    expect(storeReads).toHaveLength(2);
+    expect(completionWaits.every((wait, index) => wait < (storeReads[index] ?? -1))).toBe(true);
   });
 
   it("adds a dreaming shadow trial report scenario", () => {

--- a/extensions/qa-lab/src/suite-runtime-flow.test.ts
+++ b/extensions/qa-lab/src/suite-runtime-flow.test.ts
@@ -60,7 +60,6 @@ const hasDiscoveryLabels = vi.hoisted(() => vi.fn());
 const reportsDiscoveryScopeLeak = vi.hoisted(() => vi.fn());
 const reportsMissingDiscoveryFiles = vi.hoisted(() => vi.fn());
 const hasModelSwitchContinuitySignal = vi.hoisted(() => vi.fn());
-const qaChannelPlugin = vi.hoisted(() => ({ id: "qa-channel" }));
 const scanGatewayLogSentinels = vi.hoisted(() => vi.fn());
 const assertNoGatewayLogSentinels = vi.hoisted(() => vi.fn());
 
@@ -157,10 +156,6 @@ vi.mock("./runtime-tool-fixture.js", () => ({
 
 vi.mock("./model-switch-eval.js", () => ({
   hasModelSwitchContinuitySignal,
-}));
-
-vi.mock("./runtime-api.js", () => ({
-  qaChannelPlugin,
 }));
 
 vi.mock("./gateway-log-sentinel.js", () => ({
@@ -296,7 +291,6 @@ describe("qa suite runtime flow", () => {
           envArg: typeof env,
           configArg: Record<string, unknown>,
         ) => Promise<unknown>;
-        qaChannelPlugin: typeof qaChannelPlugin;
         webOpenPage: (params: { url: string }) => Promise<unknown>;
       };
       constants: {
@@ -330,7 +324,6 @@ describe("qa suite runtime flow", () => {
         ensureImageGenerationConfigured,
       },
     );
-    expect(call.deps.qaChannelPlugin).toBe(qaChannelPlugin);
     expect(call.constants).toEqual({
       imageUnderstandingPngBase64: "small",
       imageUnderstandingLargePngBase64: "large",

--- a/qa/scenarios/agents/subagent-fanout-synthesis.yaml
+++ b/qa/scenarios/agents/subagent-fanout-synthesis.yaml
@@ -112,6 +112,23 @@ flow:
                               - expr: "30000"
                               - expr: "env.providerMode === 'mock-openai' ? 100 : 250"
                           - if:
+                              # The parent reply can arrive before child transcript writes finish.
+                              # Wait before opening the store so its integrity check sees settled FTS state.
+                              expr: "Boolean(env.mock) && env.gateway.runtimeEnv.OPENCLAW_QA_FORCE_RUNTIME !== 'codex'"
+                              then:
+                                - forEach:
+                                    items:
+                                      expr: "config.expectedChildCompletionMarkers"
+                                    item: childCompletionMarker
+                                    actions:
+                                      - call: waitForOutboundMessage
+                                        args:
+                                          - ref: state
+                                          - lambda:
+                                              params: [candidate]
+                                              expr: "String(candidate.text ?? '').trim() === childCompletionMarker"
+                                          - 30000
+                          - if:
                               expr: "Boolean(env.mock)"
                               then:
                                 - call: readRawQaSessionStore
@@ -163,6 +180,21 @@ flow:
                           - if:
                               expr: "/timed out after/i.test(formatErrorMessage(attemptError))"
                               then:
+                                - if:
+                                    expr: "Boolean(env.mock) && env.gateway.runtimeEnv.OPENCLAW_QA_FORCE_RUNTIME !== 'codex'"
+                                    then:
+                                      - forEach:
+                                          items:
+                                            expr: "config.expectedChildCompletionMarkers"
+                                          item: childCompletionMarker
+                                          actions:
+                                            - call: waitForOutboundMessage
+                                              args:
+                                                - ref: state
+                                                - lambda:
+                                                    params: [candidate]
+                                                    expr: "String(candidate.text ?? '').trim() === childCompletionMarker"
+                                                - 30000
                                 - call: readRawQaSessionStore
                                   saveAs: timeoutStore
                                   args:
@@ -240,23 +272,4 @@ flow:
             expr: "lastError === '__done__'"
             message:
               expr: "lastError instanceof Error ? formatErrorMessage(lastError) : String(lastError ?? 'fanout retry exhausted')"
-        - if:
-            # Codex completes child sessions through its app-server path but
-            # does not relay the child marker back onto the parent QA channel.
-            # The shared assertions above already prove both child tool calls
-            # and child session rows; keep this transport-only proof OpenClaw-specific.
-            expr: "Boolean(env.mock) && env.gateway.runtimeEnv.OPENCLAW_QA_FORCE_RUNTIME !== 'codex'"
-            then:
-              - forEach:
-                  items:
-                    expr: "config.expectedChildCompletionMarkers"
-                  item: childCompletionMarker
-                  actions:
-                    - call: waitForOutboundMessage
-                      args:
-                        - ref: state
-                        - lambda:
-                            params: [candidate]
-                            expr: "String(candidate.text ?? '').trim() === childCompletionMarker"
-                        - 30000
       detailsExpr: "details"

--- a/qa/scenarios/models/luna-thinking-visibility-switch.yaml
+++ b/qa/scenarios/models/luna-thinking-visibility-switch.yaml
@@ -29,7 +29,7 @@ scenario:
     kind: flow
     summary: Toggle reasoning display and GPT-5.6 Luna thinking between off/none and medium, then verify visible reasoning only on the medium turn.
     config:
-      requiredProvider: openai
+      liveProvider: openai
       requiredModel: gpt-5.6-luna
       offDirective: /think off
       maxDirective: /think medium
@@ -57,7 +57,7 @@ flow:
           value:
             expr: splitModelRef(env.primaryModel)
         - assert:
-            expr: "env.providerMode !== 'live-frontier' || (selected?.provider === config.requiredProvider && selected?.model === config.requiredModel)"
+            expr: "env.providerMode !== 'live-frontier' || (selected?.provider === config.liveProvider && selected?.model === config.requiredModel)"
             message:
               expr: "`expected live GPT-5.6 Luna, got ${env.primaryModel}`"
         - sendInbound:

--- a/src/agents/zai.live.test.ts
+++ b/src/agents/zai.live.test.ts
@@ -35,14 +35,21 @@ async function expectModelReturnsAssistantText(
     contextWindow: modelId === "glm-5.2" ? 1_000_000 : 202_800,
     maxTokens: modelId === "glm-5.2" ? 131_072 : 131_100,
   };
-  const res = await completeSimple(
-    model,
-    {
-      messages: createSingleUserPromptMessage(),
-    },
-    { apiKey: ZAI_KEY, maxTokens: 64 },
-  );
-  const text = extractNonEmptyAssistantText(res.content);
+  const runProbe = (maxTokens: number) =>
+    completeSimple(
+      model,
+      {
+        messages: createSingleUserPromptMessage(),
+      },
+      { apiKey: ZAI_KEY, maxTokens },
+    );
+  const res = await runProbe(64);
+  let text = extractNonEmptyAssistantText(res.content);
+  // GLM can spend a tiny cap entirely on hidden reasoning. Retry only a
+  // provider-declared truncation; other empty responses remain failures.
+  if (text.length === 0 && res.stopReason === "length") {
+    text = extractNonEmptyAssistantText((await runProbe(256)).content);
+  }
   expect(text.length).toBeGreaterThan(0);
 }
 

--- a/src/plugins/compat/registry.test.ts
+++ b/src/plugins/compat/registry.test.ts
@@ -33,7 +33,7 @@ const publicSdkContractNarrowingTiers = [
   {
     name: "bundled-only public export",
     codeSuffix: "-public-demotion",
-    count: 158,
+    count: 157,
     replacement:
       "subpath becomes internal (private-local-only); no external successor — no known external consumers",
     releaseNote: /public export.*module stays available for bundled plugins.*private-local-only/u,


### PR DESCRIPTION
## What Problem This Solves

Full Release Validation found four deterministic release-test failures at the exact main and beta heads:

- QA suite runtime tests still mocked a dependency removed by the package Telegram harness refactor.
- The subagent fanout scenario opened the SQLite session store while child transcript FTS writes could still be in flight, producing an integrity-check checksum mismatch.
- The QA smoke planner silently dropped the Luna scenario because a live-provider constraint was modeled as a universal provider constraint.
- Z.AI live smoke probes could spend a 64-token cap entirely on hidden reasoning and return no visible text.

Main evidence: https://github.com/openclaw/openclaw/actions/runs/29467929304

Beta evidence: https://github.com/openclaw/openclaw/actions/runs/29467824681

## Why This Change Was Made

This removes the retired QA runtime mock, waits for child completion markers before each raw session-store integrity read, preserves mock Luna smoke coverage while retaining the live OpenAI assertion, refreshes the deliberate plugin SDK demotion count, and gives Z.AI one larger retry only when the provider explicitly reports token truncation.

The Z.AI retry remains fail-closed for empty non-truncated responses.

## User Impact

No product behavior change. Release validation becomes deterministic and continues to catch real QA store corruption, smoke-coverage loss, and live-provider failures.

## Evidence

- `pnpm test extensions/qa-lab/src/suite-runtime-flow.test.ts extensions/qa-lab/src/scenario-catalog.test.ts extensions/qa-lab/src/ci-smoke-plan.test.ts src/plugins/compat/registry.test.ts src/agents/zai.live.test.ts` — focused non-live suites green (50 tests; live file correctly excluded without credentials)
- Mock `subagent-fanout-synthesis` QA suite — passed 1/1 on Testbox lease `tbx_01kxmec71p40avwcre567wjf4m`
- `pnpm check:changed` — green on the same Testbox lease (typecheck, format, lint, import-cycle and repository guards)
- Fresh autoreview — clean, no actionable findings (0.87 confidence)

No changelog: test and release-harness reliability only.
