### PR TITLE
test telegram rich model browse channel data

### DIFF
--- a/scripts/release-candidate-checklist.d.mts
+++ b/scripts/release-candidate-checklist.d.mts
@@ -25,11 +25,6 @@ export function parseArgs(argv: unknown): {
 };
 export function releaseBranchForTag(tag: string): string;
 export function run(command: unknown, args: unknown, options?: Record<string, unknown>): string;
-export const isDirectReleaseCandidateExecution: (
-  directPath: string | undefined,
-  modulePath: string,
-  resolveRealPath?: (path: string) => string,
-) => boolean;
 export function buildReleaseCandidateState(
   options: unknown,
   {

--- a/scripts/release-candidate-checklist.d.mts
+++ b/scripts/release-candidate-checklist.d.mts
@@ -25,11 +25,11 @@ export function parseArgs(argv: unknown): {
 };
 export function releaseBranchForTag(tag: string): string;
 export function run(command: unknown, args: unknown, options?: Record<string, unknown>): string;
-export function isDirectReleaseCandidateExecution(
+export const isDirectReleaseCandidateExecution: (
   directPath: string | undefined,
   modulePath: string,
   resolveRealPath?: (path: string) => string,
-): boolean;
+) => boolean;
 export function buildReleaseCandidateState(
   options: unknown,
   {

--- a/scripts/release-candidate-checklist.d.mts
+++ b/scripts/release-candidate-checklist.d.mts
@@ -25,6 +25,11 @@ export function parseArgs(argv: unknown): {
 };
 export function releaseBranchForTag(tag: string): string;
 export function run(command: unknown, args: unknown, options?: Record<string, unknown>): string;
+export function isDirectReleaseCandidateExecution(
+  directPath: string | undefined,
+  modulePath: string,
+  resolveRealPath?: (path: string) => string,
+): boolean;
 export function buildReleaseCandidateState(
   options: unknown,
   {

--- a/src/auto-reply/reply/directive-handling.model.test.ts
+++ b/src/auto-reply/reply/directive-handling.model.test.ts
@@ -287,6 +287,7 @@ import {
   replaceRuntimeAuthProfileStoreSnapshots,
 } from "../../agents/auth-profiles.js";
 import type { ModelAliasIndex } from "../../agents/model-selection.js";
+import type { ChannelPlugin } from "../../channels/plugins/types.public.js";
 import type { ModelDefinitionConfig, OpenClawConfig } from "../../config/config.js";
 import type { SessionEntry } from "../../config/sessions.js";
 import { loadSessionEntry, replaceSessionEntry } from "../../config/sessions/session-accessor.js";
@@ -299,6 +300,7 @@ import { enqueueSystemEvent } from "../../infra/system-events.js";
 import { createEmptyPluginRegistry } from "../../plugins/registry-empty.js";
 import { setActivePluginRegistry } from "../../plugins/runtime.js";
 import type { ProviderPlugin } from "../../plugins/types.js";
+import { createChannelTestPluginBase } from "../../test-utils/channel-plugins.js";
 import { withEnvAsync } from "../../test-utils/env.js";
 import type { ElevatedLevel } from "../thinking.js";
 
@@ -410,11 +412,43 @@ function createSessionEntry(overrides?: Partial<SessionEntry>): SessionEntry {
   };
 }
 
-function setDirectiveTestProviders(providers: ProviderPlugin[]): void {
+const telegramModelBrowseTestPlugin: ChannelPlugin = {
+  ...createChannelTestPluginBase({
+    id: "telegram",
+    label: "Telegram",
+    docsPath: "/channels/telegram",
+    capabilities: {
+      chatTypes: ["direct", "group", "channel", "thread"],
+      reactions: true,
+      threads: true,
+      media: true,
+      polls: true,
+      nativeCommands: true,
+      blockStreaming: true,
+    },
+  }),
+  commands: {
+    buildModelBrowseChannelData: () => ({
+      telegram: {
+        buttons: [[{ text: "Browse providers", callback_data: "mdl_prov" }]],
+      },
+    }),
+  },
+};
+
+function setDirectiveTestProviders(
+  providers: ProviderPlugin[],
+  channels: ChannelPlugin[] = [],
+): void {
   const registry = createEmptyPluginRegistry();
   registry.providers = providers.map((provider) => ({
     pluginId: "test",
     provider,
+    source: "test",
+  }));
+  registry.channels = channels.map((plugin) => ({
+    pluginId: plugin.id,
+    plugin,
     source: "test",
   }));
   setActivePluginRegistry(registry);
@@ -641,6 +675,21 @@ describe("/model chat UX", () => {
     expect(reply?.text).toContain("Current:");
     expect(reply?.text).toContain("Browse: /models");
     expect(reply?.text).toContain("Switch: /model <provider/model>");
+  });
+
+  it("preserves Telegram rich model browse channel data for /model summary", async () => {
+    setDirectiveTestProviders([], [telegramModelBrowseTestPlugin]);
+
+    const reply = await resolveModelInfoReply({
+      surface: "telegram",
+    });
+
+    expect(reply?.text).toContain("Tap below to browse models");
+    expect(reply?.channelData).toEqual({
+      telegram: {
+        buttons: [[{ text: "Browse providers", callback_data: "mdl_prov" }]],
+      },
+    });
   });
 
   it("treats /model list as a models browser alias, not a model id", async () => {


### PR DESCRIPTION
## What Problem This Solves

Telegram `/model` summary replies should preserve the rich model browse inline button so users can tap `Browse providers` instead of falling back to plain text. The previous regression test asserted the right behavior but did not register a Telegram channel-plugin fixture, so the isolated suite could not actually exercise `buildModelBrowseChannelData`.

This PR adds an explicit Telegram channel fixture for the `/model` summary test and verifies the `mdl_prov` callback payload is preserved through the same channel plugin path used by production Telegram model browsing.

## Summary

- Adds regression coverage that `/model` summary replies on Telegram preserve rich model browse `channelData`.
- Registers an explicit Telegram channel-plugin fixture for the directive test so `getChannelPlugin("telegram")` can produce the rich browse payload.
- Guards the Telegram `Browse providers` inline button contract (`mdl_prov`) so future plain-text compatibility fixes do not strip the rich browse path.

## Evidence

The live sovereign runtime patch that temporarily skipped Telegram channel data was reverted, restoring the same production path this test protects:

```js
const channelData = (params.surface ? getChannelPlugin(params.surface) : null)?.commands?.buildModelBrowseChannelData?.();
```

Sovereign live gateway after restoring rich browse data:

```text
openclaw_gateway_1: healthy
Config valid: ~/.openclaw/openclaw.json
Telegram: configured
[telegram] [default] starting provider (@Lebowski_TheDude_Bot)
[gateway] ready
```

## Validation

Rebased onto `origin/main` at `7e410bdb52b1` and pushed as `34f3a291ae7e`.

```text
$ node scripts/run-vitest.mjs src/auto-reply/reply/directive-handling.model.test.ts

Test Files  1 passed (1)
Tests       91 passed (91)
```

```text
$ git diff --check
# passed
```
