### PR TITLE
fix(plugins): recover after a stale managed generation is removed

### DIFF
--- a/src/plugins/installed-plugin-index-record-reader.ts
+++ b/src/plugins/installed-plugin-index-record-reader.ts
@@ -4,8 +4,14 @@ import path from "node:path";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import type { PluginInstallRecord } from "../config/types.plugins.js";
 import { tryReadJsonSync } from "../infra/json-files.js";
+import { parseRegistryNpmSpec } from "../infra/npm-registry-spec.js";
+import { compareValidSemver } from "../infra/semver.js";
 import { withOpenClawStateDatabaseReadOnly } from "../state/openclaw-state-db-readonly.js";
-import { resolveDefaultPluginNpmDir, validatePluginId } from "./install-paths.js";
+import {
+  resolveDefaultPluginNpmDir,
+  resolvePluginNpmProjectsDir,
+  validatePluginId,
+} from "./install-paths.js";
 import {
   getInstalledPluginIndexInstallRecordsCache,
   getInstalledPluginIndexInstallRecordsCacheGeneration,
@@ -16,7 +22,10 @@ import {
   resolveInstalledPluginIndexStorePath,
   type InstalledPluginIndexStoreOptions,
 } from "./installed-plugin-index-store-path.js";
-import { hasRetainedManagedNpmInstallMarker } from "./managed-npm-retention.js";
+import {
+  hasRetainedManagedNpmInstallMarker,
+  resolveRetainedManagedNpmInstallPackageInfo,
+} from "./managed-npm-retention.js";
 import { listManagedPluginNpmProjectRootsSync } from "./npm-project-roots.js";
 
 export { clearLoadInstalledPluginIndexInstallRecordsCache } from "./installed-plugin-index-record-cache.js";
@@ -177,10 +186,75 @@ function readInstallRecordVersion(record: PluginInstallRecord | undefined): stri
   return record?.resolvedVersion ?? record?.version;
 }
 
+function isUnavailableManagedNpmInstallRecord(params: {
+  npmRoot: string;
+  persisted: PluginInstallRecord | undefined;
+  recovered: PluginInstallRecord;
+}): boolean {
+  const installPath = params.persisted?.installPath;
+  if (params.persisted?.source !== "npm" || !installPath) {
+    return false;
+  }
+  try {
+    if (fs.statSync(installPath).isDirectory()) {
+      return false;
+    }
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code !== "ENOENT" && code !== "ENOTDIR") {
+      return false;
+    }
+  }
+
+  const packageInfo = resolveRetainedManagedNpmInstallPackageInfo(installPath);
+  if (!packageInfo || packageInfo.packageName !== params.recovered.resolvedName) {
+    return false;
+  }
+  const npmRoot = path.resolve(params.npmRoot);
+  const projectRoot = path.resolve(packageInfo.projectRoot);
+  return (
+    projectRoot === npmRoot ||
+    path.dirname(projectRoot) === path.resolve(resolvePluginNpmProjectsDir(npmRoot))
+  );
+}
+
+function mergeRecoveredManagedNpmMetadata(
+  persisted: PluginInstallRecord,
+  recovered: PluginInstallRecord,
+  options: { preservePersistedSpec?: boolean } = {},
+): PluginInstallRecord {
+  const next: PluginInstallRecord = {
+    ...persisted,
+    ...recovered,
+  };
+  if (options.preservePersistedSpec) {
+    const persistedSpec = persisted.spec ? parseRegistryNpmSpec(persisted.spec) : null;
+    const selectorIsCompatible =
+      persistedSpec?.selectorKind !== "exact-version" ||
+      (persistedSpec.selector !== undefined &&
+        recovered.resolvedVersion !== undefined &&
+        compareValidSemver(persistedSpec.selector, recovered.resolvedVersion) === 0);
+    if (persistedSpec?.name === recovered.resolvedName && selectorIsCompatible) {
+      next.spec = persisted.spec;
+    }
+  }
+  delete next.integrity;
+  delete next.shasum;
+  delete next.resolvedAt;
+  delete next.installedAt;
+  return next;
+}
+
 function mergeRecoveredManagedNpmRecord(params: {
+  npmRoot: string;
   persisted: PluginInstallRecord | undefined;
   recovered: PluginInstallRecord;
 }): PluginInstallRecord {
+  if (params.persisted && isUnavailableManagedNpmInstallRecord(params)) {
+    return mergeRecoveredManagedNpmMetadata(params.persisted, params.recovered, {
+      preservePersistedSpec: true,
+    });
+  }
   const persistedVersion = readInstallRecordVersion(params.persisted);
   const recoveredVersion = readInstallRecordVersion(params.recovered);
   if (
@@ -189,15 +263,7 @@ function mergeRecoveredManagedNpmRecord(params: {
     recoveredVersion &&
     persistedVersion !== recoveredVersion
   ) {
-    const next: PluginInstallRecord = {
-      ...params.persisted,
-      ...params.recovered,
-    };
-    delete next.integrity;
-    delete next.shasum;
-    delete next.resolvedAt;
-    delete next.installedAt;
-    return next;
+    return mergeRecoveredManagedNpmMetadata(params.persisted, params.recovered);
   }
   return params.persisted ?? params.recovered;
 }
@@ -206,10 +272,12 @@ function mergeRecoveredManagedNpmInstallRecords(
   persisted: Record<string, PluginInstallRecord> | null,
   options: InstalledPluginIndexStoreOptions,
 ): Record<string, PluginInstallRecord> {
+  const npmRoot = resolveRecoveredManagedNpmRoot(options);
   const recovered = buildRecoveredManagedNpmInstallRecords(options);
   const merged: Record<string, PluginInstallRecord> = { ...persisted };
   for (const [pluginId, record] of Object.entries(recovered)) {
     merged[pluginId] = mergeRecoveredManagedNpmRecord({
+      npmRoot,
       persisted: merged[pluginId],
       recovered: record,
     });

--- a/src/plugins/installed-plugin-index-records.test.ts
+++ b/src/plugins/installed-plugin-index-records.test.ts
@@ -11,6 +11,10 @@ import {
 } from "../state/openclaw-state-db.js";
 import type { PluginCandidate } from "./discovery.js";
 import {
+  resolvePluginNpmGenerationProjectDir,
+  resolvePluginNpmProjectDir,
+} from "./install-paths.js";
+import {
   clearLoadInstalledPluginIndexInstallRecordsCache,
   loadInstalledPluginIndexInstallRecords,
   loadInstalledPluginIndexInstallRecordsSync,
@@ -412,6 +416,104 @@ describe("plugin index install records store", () => {
       integrity: "sha512-persisted",
     });
   });
+
+  it.each([
+    {
+      expectedSpec: "@openclaw/discord",
+      label: "bare",
+      persistedVersion: "2026.7.1",
+      spec: "@openclaw/discord",
+    },
+    {
+      expectedSpec: "@openclaw/discord@latest",
+      label: "latest",
+      persistedVersion: "2026.7.1",
+      spec: "@openclaw/discord@latest",
+    },
+    {
+      expectedSpec: "@openclaw/discord@beta",
+      label: "dist-tag",
+      persistedVersion: "2026.7.1",
+      spec: "@openclaw/discord@beta",
+    },
+    {
+      expectedSpec: "@openclaw/discord@2026.7.1",
+      label: "obsolete exact-version",
+      persistedVersion: "2026.6.4",
+      spec: "@openclaw/discord@2026.6.4",
+    },
+  ])(
+    "recovers a valid managed generation with a compatible $label selector",
+    async ({ expectedSpec, persistedVersion, spec }) => {
+      const stateDir = makeStateDir();
+      const packageName = "@openclaw/discord";
+      const fixtureProjectRoot = resolvePluginNpmProjectDir({
+        npmDir: path.join(stateDir, "npm"),
+        packageName,
+      });
+      writeManagedNpmPlugin({
+        stateDir,
+        packageName,
+        pluginId: "discord",
+        version: "2026.7.1",
+      });
+      const staleProjectRoot = resolvePluginNpmGenerationProjectDir({
+        npmDir: path.join(stateDir, "npm"),
+        packageName,
+        generationKey: "discord-2026.6.4",
+      });
+      const activeProjectRoot = resolvePluginNpmGenerationProjectDir({
+        npmDir: path.join(stateDir, "npm"),
+        packageName,
+        generationKey: "discord-2026.7.1",
+      });
+      fs.renameSync(fixtureProjectRoot, activeProjectRoot);
+      const stalePackageDir = path.join(
+        staleProjectRoot,
+        "node_modules",
+        ...packageName.split("/"),
+      );
+      const activePackageDir = path.join(
+        activeProjectRoot,
+        "node_modules",
+        ...packageName.split("/"),
+      );
+
+      await writePersistedInstalledPluginIndexInstallRecords(
+        {
+          discord: {
+            source: "npm",
+            spec,
+            installPath: stalePackageDir,
+            version: persistedVersion,
+            resolvedName: packageName,
+            resolvedVersion: persistedVersion,
+            resolvedSpec: `${packageName}@${persistedVersion}`,
+            integrity: "sha512-stale",
+          },
+        },
+        { stateDir, candidates: [] },
+      );
+
+      const loaded = await loadInstalledPluginIndexInstallRecords({ stateDir });
+      const record = expectRecordFields(loaded.discord, {
+        source: "npm",
+        spec: expectedSpec,
+        installPath: activePackageDir,
+        version: "2026.7.1",
+        resolvedName: packageName,
+        resolvedVersion: "2026.7.1",
+        resolvedSpec: `${packageName}@2026.7.1`,
+      });
+      expect(record.integrity).toBeUndefined();
+
+      clearLoadInstalledPluginIndexInstallRecordsCache();
+      expectRecordFields(loadInstalledPluginIndexInstallRecordsSync({ stateDir }).discord, {
+        installPath: activePackageDir,
+        resolvedVersion: "2026.7.1",
+      });
+    },
+  );
 
   it("recovers managed npm metadata when the persisted record points at an older package version", async () => {
     const stateDir = makeStateDir();


### PR DESCRIPTION
## What Problem This Solves

Managed npm plugin updates install into generation-specific project roots, but a persisted install record can still point at a removed prior generation. The record loader currently prefers that stale SQLite record over a valid generation recovered from disk, leaving plugin lifecycle commands unable to self-heal and forcing users to edit `install_records_json` manually.

Closes #107467

## Why This Change Was Made

- Detect persisted npm install paths that are unavailable with `ENOENT`/`ENOTDIR` only when they belong to OpenClaw's managed npm root and match the recovered package identity.
- Replace the stale path and resolution metadata with the valid managed generation discovered on disk.
- Preserve compatible user selector intent for bare specs and dist-tags such as `latest` or `beta`, while replacing an obsolete exact-version selector with the recovered version.
- Keep external/custom npm install records authoritative, even when their paths are temporarily missing.
- Clear integrity and timestamp fields that no longer describe the recovered artifact.

## User Impact

Plugin install, update, list, and doctor flows can recover from a removed stale managed generation without requiring direct SQLite surgery. Recovery remains constrained to OpenClaw-owned npm layouts and does not take over user-managed install paths.

## Evidence

- Baseline regression proof on unmodified code: `src/plugins/installed-plugin-index-records.test.ts` failed the stale-generation recovery case (1 failed, 20 passed).
- Focused regression suite: `node scripts/run-vitest.mjs src/plugins/installed-plugin-index-records.test.ts` (24 passed).
- Targeted formatting: `oxfmt --check` passed for both changed files.
- Targeted core lint: `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json ...` passed for both changed files.
- Repository `autoreview`: clean, no accepted/actionable findings.
- Rebased onto current `origin/main` and reran the focused suite (24 passed).

<!-- agent-transcript:start -->
## Agent Transcript

<details>
<summary>Redacted Codex session transcript</summary>

````text
source: local Codex session
omitted: system/developer prompts, reasoning, raw tool output, environment, local paths, credentials, and unrelated turns

[user]
彻底 review OpenClaw 代码并结合社区反馈，找出重要改进方向，完成改进并对开源社区作出实际贡献。

[assistant]
Reviewed current community issues, duplicate/in-flight pull requests, release behavior, and the plugin lifecycle implementation. Selected open P0 issue #107467 because it blocks plugin lifecycle commands after a stale managed generation is removed, requires manual SQLite repair, and had no existing repair PR.

Added a regression fixture with a missing persisted generation and a valid active generation. Before the production change, the focused suite failed because the stale SQLite record remained authoritative.

Implemented constrained recovery: only an unavailable path inside OpenClaw's managed npm layout can be replaced, and the recovered package identity must match. Custom/external install paths remain authoritative.

Independent autoreview identified selector edge cases. The merge now preserves compatible bare/latest/dist-tag intent, replaces obsolete exact-version selectors, and keeps the pre-existing same-path version-drift behavior from causing downgrades.

Final proof: 24 focused tests passed, targeted formatting and lint passed, and repository autoreview reported no accepted/actionable findings. The branch was rebased onto current upstream main and the focused suite passed again.

[user]
Approved including the reviewed, redacted transcript and requested creating the PR directly.

[tool summary]
GitHub issue/PR duplicate checks, focused Vitest reproduction, targeted formatting/lint, repeated structured autoreview, fork creation, commit, rebase, and branch push completed successfully.
````

</details>
<!-- agent-transcript:end -->
