### PR TITLE
perf(ci): parallel format check and build-input-precise artifact gating

### DIFF
--- a/package.json
+++ b/package.json
@@ -1626,7 +1626,7 @@
     "dup:check:json": "node scripts/check-duplicates.mjs --json",
     "format": "oxfmt --write --threads=1",
     "format:all": "pnpm format && pnpm format:swift",
-    "format:check": "oxfmt --check --threads=1",
+    "format:check": "oxfmt --check",
     "format:diff": "oxfmt --write --threads=1 && git --no-pager diff",
     "format:docs": "node scripts/format-docs.mjs",
     "format:docs:check": "node scripts/format-docs.mjs --check",

--- a/scripts/lib/ci-changed-node-test-plan.mjs
+++ b/scripts/lib/ci-changed-node-test-plan.mjs
@@ -35,13 +35,23 @@ function isTestOnlyPath(changedPath) {
   return isTestFileTarget(changedPath) || changedPath.startsWith("test/");
 }
 
+// Inputs `build:ci-artifacts` consumes: runtime/plugin/package sources plus
+// the build pipeline itself (mirrors the build-all cache key in ci.yml).
+// Paths outside this set — repo scripts, workflows, qa scenarios, docs mixes —
+// cannot change dist or bundled plugin asset bytes.
+const BUILD_INPUT_RE =
+  /^(?:src|extensions|packages)\/|^(?:openclaw\.mjs|package\.json|pnpm-lock\.yaml|npm-shrinkwrap\.json|pnpm-workspace\.yaml)$|^tsconfig[^/]*\.json$|^scripts\/(?:build-[^/]+|write-plugin-sdk-entry-dts\.ts|copy-export-html-templates\.ts)$|^scripts\/lib\/(?:copy-assets\.ts|plugin-sdk-entries\.mjs)$/u;
+
 /**
- * True when any changed path can influence built dist/packaging bytes.
- * Test-only diffs cannot change what `build:ci-artifacts` produces, so the
- * manifest may skip the build-artifacts lane for them.
+ * True when a changed path can influence built dist/packaging bytes: a
+ * non-test build-input source or the build pipeline itself. Diffs entirely
+ * outside that set (tests, repo scripts, workflows, qa scenarios) let the
+ * manifest skip the build-artifacts lane.
  */
 export function hasBuildArtifactAffectingChange(changedPaths) {
-  return changedPaths.some((changedPath) => !isTestOnlyPath(changedPath));
+  return changedPaths.some(
+    (changedPath) => BUILD_INPUT_RE.test(changedPath) && !isTestOnlyPath(changedPath),
+  );
 }
 
 // Surfaces the CI smoke scenarios exercise outside the core runtime import

--- a/test/scripts/ci-changed-node-test-plan.test.ts
+++ b/test/scripts/ci-changed-node-test-plan.test.ts
@@ -54,6 +54,14 @@ describe("CI changed Node test plan", () => {
       false,
     );
     expect(hasBuildArtifactAffectingChange(["src/agents/foo.ts"])).toBe(true);
+    // Build-input classification: only sources and the build pipeline can
+    // change dist bytes; repo scripts, workflows, and qa scenarios cannot.
+    expect(hasBuildArtifactAffectingChange(["scripts/build-all.mjs"])).toBe(true);
+    expect(hasBuildArtifactAffectingChange(["tsconfig.json"])).toBe(true);
+    expect(hasBuildArtifactAffectingChange(["scripts/run-vitest.mjs"])).toBe(false);
+    expect(hasBuildArtifactAffectingChange([".github/workflows/ci.yml"])).toBe(false);
+    expect(hasBuildArtifactAffectingChange(["qa/scenarios/index.yaml"])).toBe(false);
+    expect(hasBuildArtifactAffectingChange(["ui/src/app.ts"])).toBe(false);
     expect(hasQaSmokeAffectingChange(["extensions/qa-lab/src/ci-smoke-plan.ts"])).toBe(true);
     expect(hasQaSmokeAffectingChange(["ui/src/app.ts"])).toBe(true);
     // Inside the packaged CLI's import graph -> the smoke scenarios can see it.


### PR DESCRIPTION
## What Problem This Solves

Two measured wall-clock floors in PR CI: `oxfmt --check --threads=1` burns ~37s single-threaded on 22.5k files inside the check-lint lane, and `build-artifacts` (~200s) runs for any non-test diff even when the change cannot alter dist bytes (repo scripts, workflows, qa scenarios, ui-only diffs — dist is built from src/extensions/packages plus the build pipeline).

## Why This Change Was Made

1. `format:check` drops the `--threads=1` cap (read-only path only; `format`/`format:fix` write paths stay capped). Locally: 22.4s -> 9.7s with identical exit semantics; the CI lane's 37s should drop to ~10s.
2. `hasBuildArtifactAffectingChange` classifies by actual build inputs (mirroring the build-all cache key): `src/`, `extensions/`, `packages/`, root manifests, `tsconfig*`, and the build pipeline scripts. Diffs entirely outside that set skip the build-artifacts lane (boundary coverage still guaranteed: the plan appends the nondist `changed-boundary` shard whenever build-artifacts is skipped, unchanged from #108091). Fail-safe unchanged: full-scope PRs (targeting bailed) always build.

Deferred from this pass: refreshing `COMPACT_GROUP_SECONDS_HINTS` from serial-run timings (blocked on Actions-API secondary rate limits today; current hints are contention-inflated which under-fills bins — conservative).

## User Impact

No product change. check-lint shortens by ~25-30s on every PR; targeted PRs touching only scripts/workflows/qa/ui skip the ~200s build-artifacts lane (they previously paid it despite it proving nothing about their diff).

## Evidence

- oxfmt benchmark (this repo, 22509 files): `--threads=1` 22.4s vs default 9.7s, both exit 0; CI job log 29467456986 shows the 37s single-threaded run.
- Classification probes: `scripts/build-all.mjs`/`tsconfig.json`/`src|extensions|packages` -> build; `scripts/run-vitest.mjs`/`.github/workflows/ci.yml`/`qa/`/`ui/` -> skip (asserted in `test/scripts/ci-changed-node-test-plan.test.ts`).
- Focused tests green: `ci-changed-node-test-plan.test.ts`, `ci-workflow-guards.test.ts`.
