### PR TITLE
fix(onepassword): reject oversized service account token files

### DIFF
--- a/extensions/onepassword/src/op-client.test.ts
+++ b/extensions/onepassword/src/op-client.test.ts
@@ -125,7 +125,10 @@ describe("OpClient", () => {
 
     await expect(
       client.getItem({ item: "Token", vault: "Automation", field: "credential" }),
-    ).rejects.toMatchObject({ code: "TOKEN_MISSING" });
+    ).rejects.toMatchObject({
+      code: "TOKEN_MISSING",
+      message: "1Password service account token file is too large",
+    });
     expect(runner).not.toHaveBeenCalled();
   });
 

--- a/extensions/onepassword/src/op-client.test.ts
+++ b/extensions/onepassword/src/op-client.test.ts
@@ -118,6 +118,46 @@ describe("OpClient", () => {
     ).rejects.toMatchObject({ code: "TOKEN_MISSING" });
   });
 
+  it("rejects oversized token files before invoking the 1Password CLI", async () => {
+    await fs.writeFile(tokenFile, "x".repeat(16 * 1024 + 1), { mode: 0o600 });
+    const runner = vi.fn<OpProcessRunner>();
+    const client = new OpClient({ opBin, tokenFile, timeoutMs: 1000, runner });
+
+    await expect(
+      client.getItem({ item: "Token", vault: "Automation", field: "credential" }),
+    ).rejects.toMatchObject({ code: "TOKEN_MISSING" });
+    expect(runner).not.toHaveBeenCalled();
+  });
+
+  it.runIf(process.platform !== "win32").each(["symlink", "hardlink"] as const)(
+    "continues to accept a token file through a %s",
+    async (linkType) => {
+      const targetFile = path.join(root, "service-account-token-target");
+      await fs.rename(tokenFile, targetFile);
+      if (linkType === "symlink") {
+        await fs.symlink(targetFile, tokenFile);
+      } else {
+        await fs.link(targetFile, tokenFile);
+      }
+      const runner = vi.fn<OpProcessRunner>(async () => ({
+        stdout: JSON.stringify({ label: "credential", value: "value" }),
+        stderr: "",
+      }));
+      const client = new OpClient({ opBin, tokenFile, timeoutMs: 1000, runner });
+
+      await expect(
+        client.getItem({ item: "Token", vault: "Automation", field: "credential" }),
+      ).resolves.toMatchObject({ value: "value" });
+      expect(runner).toHaveBeenCalledWith(
+        opBin,
+        expect.any(Array),
+        expect.objectContaining({
+          env: expect.objectContaining({ OP_SERVICE_ACCOUNT_TOKEN: fixtureAuth }),
+        }),
+      );
+    },
+  );
+
   it("warns once for token file permissions broader than 0600", async () => {
     await fs.chmod(tokenFile, 0o644);
     const warn = vi.fn();

--- a/extensions/onepassword/src/op-client.ts
+++ b/extensions/onepassword/src/op-client.ts
@@ -2,8 +2,9 @@ import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { tryReadSecretFileSync } from "openclaw/plugin-sdk/core";
 import { runExec } from "openclaw/plugin-sdk/process-runtime";
+import { tryReadSecretFileSync } from "openclaw/plugin-sdk/secret-file-runtime";
+import { FsSafeError } from "openclaw/plugin-sdk/security-runtime";
 import { OnePasswordError } from "./errors.js";
 
 const MAX_STDOUT_BYTES = 1024 * 1024;
@@ -206,13 +207,11 @@ export class OpClient {
         this.warn("1Password service account token file permissions are broader than 0600");
       }
     } catch (error) {
-      throw new OnePasswordError(
-        "TOKEN_MISSING",
-        "1Password service account token file is missing",
-        {
-          cause: error,
-        },
-      );
+      const message =
+        error instanceof FsSafeError && error.code === "too-large"
+          ? "1Password service account token file is too large"
+          : "1Password service account token file is missing";
+      throw new OnePasswordError("TOKEN_MISSING", message, { cause: error });
     }
     if (!contents) {
       throw new OnePasswordError("TOKEN_MISSING", "1Password service account token file is empty");

--- a/extensions/onepassword/src/op-client.ts
+++ b/extensions/onepassword/src/op-client.ts
@@ -2,6 +2,7 @@ import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { tryReadSecretFileSync } from "openclaw/plugin-sdk/core";
 import { runExec } from "openclaw/plugin-sdk/process-runtime";
 import { OnePasswordError } from "./errors.js";
 
@@ -190,13 +191,12 @@ export class OpClient {
   }
 
   private async readToken(): Promise<string> {
-    let contents: string;
+    let contents: string | undefined;
     try {
-      const [raw, stat] = await Promise.all([
-        fs.readFile(this.tokenFile, "utf8"),
-        fs.stat(this.tokenFile),
-      ]);
-      contents = raw.trim();
+      contents = tryReadSecretFileSync(this.tokenFile, "1Password service account token", {
+        rejectHardlinks: false,
+      });
+      const stat = await fs.stat(this.tokenFile);
       if (
         !this.permissionWarningEmitted &&
         process.platform !== "win32" &&


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators using the 1Password plugin could have an arbitrarily large service-account token file loaded in full and placed in `OP_SERVICE_ACCOUNT_TOKEN` before the 1Password CLI was invoked. A mistaken or bogus credential file could therefore allocate and forward arbitrary input on every item lookup.

## Why This Change Was Made

The 1Password client now uses OpenClaw's existing pinned secret-file reader and its 16 KiB credential limit. The plugin-local change preserves the existing missing/empty `TOKEN_MISSING` surface, permission warning, and symlink/hardlink layouts; tokens over 16 KiB now fail closed before process spawn.

AI-assisted: yes. I inspected the complete production client, its plugin registration and broker caller, adjacent tests, sibling SDK consumers, and installed `@openclaw/fs-safe@0.4.1` source/types/docs before making the change.

## User Impact

1Password plugin operators can continue using normal service-account token files, including existing symlink or hardlink layouts, while oversized credential files are rejected before their contents reach the child-process environment.

## Evidence

**Real-machine production-path proof:** Linux `6.8.0-134-generic` x86_64, Node `v24.18.0`. The harness directly imported the production `OpClient`, created a real executable `op` process, and observed the environment received by that OS child process; no mocked client or runner was used.

**Before:** On pre-fix `upstream/main` at `957cc81175a3f993118951e352fd2b13e3982487`, a 20 KiB real token file was read in full and forwarded to the child process:

```bash
node --import tsx --input-type=module <<'NODE'
import fs from 'node:fs/promises'; import os from 'node:os'; import path from 'node:path';
import { OpClient } from './extensions/onepassword/src/op-client.ts';
const root=await fs.mkdtemp(path.join(os.tmpdir(),'openclaw-op-proof-before-'));
try {
  const opBin=path.join(root,'op'), tokenFile=path.join(root,'service-account-token'), marker=path.join(root,'spawned');
  await fs.writeFile(opBin,`#!/usr/bin/env node\nimport fs from 'node:fs';\nfs.writeFileSync(${JSON.stringify(marker)},'spawned');\nprocess.stdout.write(JSON.stringify({label:'credential',value:String(process.env.OP_SERVICE_ACCOUNT_TOKEN?.length??-1)}));\n`,{mode:0o700});
  await fs.writeFile(tokenFile,'x'.repeat(20*1024),{mode:0o600});
  const result=await new OpClient({opBin,tokenFile,timeoutMs:5000,home:root}).getItem({item:'Repository token',vault:'Automation',field:'credential'});
  console.log(JSON.stringify({tokenBytes:20*1024,forwardedTokenChars:Number(result.value),childSpawned:await fs.access(marker).then(()=>true,()=>false)}));
} finally { await fs.rm(root,{recursive:true,force:true}); }
NODE
```

```text
{"tokenBytes":20480,"forwardedTokenChars":20480,"childSpawned":true}
```

Latest main at PR creation is `de3f7925c4c31e7bbf40bcfad7fc036941772e24`; the production client is byte-identical at both bases:

```text
957cc8117:extensions/onepassword/src/op-client.ts  f8ff169db4ef8433fff460eaa4328c57d0e026bb
de3f7925c:extensions/onepassword/src/op-client.ts  f8ff169db4ef8433fff460eaa4328c57d0e026bb
```

**Premise:** I inspected installed `@openclaw/fs-safe@0.4.1` source, types, and `docs/secret-file.md`. `tryReadSecretFileSync` defaults to `DEFAULT_SECRET_FILE_MAX_BYTES = 16 * 1024`, checks size before reading through a pinned descriptor, trims the credential, returns `undefined` only for a missing path, and allows the prior hardlink behavior with `rejectHardlinks: false`. `openclaw/plugin-sdk/core` exports this helper for plugin production code.

**After / negative controls:** On rebased commit `a0f47c2c5b336840fad963fa51cd8274c7d11c8b`, the same production client rejected the 20 KiB file with zero child spawns. A normal trimmed token and existing symlink/hardlink layouts each reached a real child process with the expected 12-character token:

```bash
node --import tsx --input-type=module <<'NODE'
import fs from 'node:fs/promises'; import os from 'node:os'; import path from 'node:path';
import { OpClient } from './extensions/onepassword/src/op-client.ts';
const root=await fs.mkdtemp(path.join(os.tmpdir(),'openclaw-op-proof-after-')), opBin=path.join(root,'op'), log=path.join(root,'spawned.log');
try {
  await fs.writeFile(opBin,`#!/usr/bin/env node\nimport fs from 'node:fs';\nfs.appendFileSync(${JSON.stringify(log)},'spawned\\n');\nprocess.stdout.write(JSON.stringify({label:'credential',value:String(process.env.OP_SERVICE_ACCOUNT_TOKEN?.length??-1)}));\n`,{mode:0o700});
  const run=async(name,tokenFile)=>{try{const result=await new OpClient({opBin,tokenFile,timeoutMs:5000,home:root}).getItem({item:'Repository token',vault:'Automation',field:'credential'});return{name,outcome:'resolved',forwardedTokenChars:Number(result.value)}}catch(error){return{name,outcome:'rejected',code:error?.code}}};
  const oversized=path.join(root,'oversized-token'); await fs.writeFile(oversized,'x'.repeat(20*1024),{mode:0o600}); const oversizedResult=await run('oversized',oversized);
  const spawnsAfterOversized=await fs.readFile(log,'utf8').then(v=>v.trim().split('\n').length,()=>0);
  const target=path.join(root,'normal-target'); await fs.writeFile(target,'  fixture-auth\n',{mode:0o600});
  const normal=await run('normal',target); const symlink=path.join(root,'symlink-token'); await fs.symlink(target,symlink); const symlinkResult=await run('symlink',symlink); const hardlink=path.join(root,'hardlink-token'); await fs.link(target,hardlink); const hardlinkResult=await run('hardlink',hardlink);
  const totalChildSpawns=await fs.readFile(log,'utf8').then(v=>v.trim().split('\n').length,()=>0);
  console.log(JSON.stringify({tokenBytes:20*1024,oversized:oversizedResult,childSpawnsBeforeNegativeControls:spawnsAfterOversized,negativeControls:[normal,symlinkResult,hardlinkResult],totalChildSpawns}));
} finally { await fs.rm(root,{recursive:true,force:true}); }
NODE
```

```text
{"tokenBytes":20480,"oversized":{"name":"oversized","outcome":"rejected","code":"TOKEN_MISSING"},"childSpawnsBeforeNegativeControls":0,"negativeControls":[{"name":"normal","outcome":"resolved","forwardedTokenChars":12},{"name":"symlink","outcome":"resolved","forwardedTokenChars":12},{"name":"hardlink","outcome":"resolved","forwardedTokenChars":12}],"totalChildSpawns":3}
```

**Focused validation:**

```bash
node scripts/run-vitest.mjs extensions/onepassword
```

```text
Test Files  6 passed (6)
Tests       61 passed (61)
```

Targeted `oxfmt`, targeted `oxlint`, and `git diff --check` also passed. After rebasing onto latest main, `.agents/skills/autoreview/scripts/autoreview --mode branch --base upstream/main --stream-engine-output` reported no accepted/actionable findings and rated the patch correct at `0.95` confidence.

Not tested against a live 1Password account because the changed behavior is entirely before the child-process boundary and the CLI request/network path is unchanged. The full `check:changed` lane was not run locally because it can delegate to Blacksmith/Testbox, which is prohibited in this external-contributor workflow; fork CI remains the wide validation path.
