### PR TITLE
feat(channels): render live plan checklists from typed update_plan snapshots

### DIFF
--- a/extensions/codex/src/app-server/event-projector-reasoning.ts
+++ b/extensions/codex/src/app-server/event-projector-reasoning.ts
@@ -1,4 +1,5 @@
 import type { EmbeddedRunAttemptParams } from "openclaw/plugin-sdk/agent-harness-runtime";
+import type { AgentPlanStep, AgentPlanStepStatus } from "openclaw/plugin-sdk/channel-outbound";
 import {
   readNonNegativeInteger,
   readNullableString,
@@ -67,7 +68,10 @@ export class CodexReasoningProjection {
     }
     const text = `${this.planTextByItem.get(itemId) ?? ""}${delta}`;
     this.planTextByItem.set(itemId, text);
-    this.emitPlanUpdate({ explanation: undefined, steps: splitPlanText(text) });
+    this.emitPlanUpdate({
+      explanation: undefined,
+      steps: splitPlanText(text).map((step) => ({ step, status: "pending" })),
+    });
   }
 
   handleTurnPlanUpdated(params: JsonObject): void {
@@ -78,11 +82,10 @@ export class CodexReasoningProjection {
           }
           const record = entry as JsonObject;
           const step = readString(record, "step");
-          const status = readString(record, "status");
           if (!step) {
             return [];
           }
-          return status ? [`${step} (${status})`] : [step];
+          return [{ step, status: normalizePlanStepStatus(readString(record, "status")) }];
         })
       : undefined;
     this.emitPlanUpdate({
@@ -94,7 +97,10 @@ export class CodexReasoningProjection {
   recordItem(item: CodexThreadItem | undefined): void {
     if (item?.type === "plan" && typeof item.text === "string" && item.text) {
       this.planTextByItem.set(item.id, item.text);
-      this.emitPlanUpdate({ explanation: undefined, steps: splitPlanText(item.text) });
+      this.emitPlanUpdate({
+        explanation: undefined,
+        steps: splitPlanText(item.text).map((step) => ({ step, status: "pending" })),
+      });
     }
   }
 
@@ -116,7 +122,7 @@ export class CodexReasoningProjection {
     return [...this.planTextByItem.values()].filter((text) => text.trim().length > 0).join("\n\n");
   }
 
-  private emitPlanUpdate(params: { explanation?: string | null; steps?: string[] }): void {
+  private emitPlanUpdate(params: { explanation?: string | null; steps?: AgentPlanStep[] }): void {
     if (!params.explanation && (!params.steps || params.steps.length === 0)) {
       return;
     }
@@ -131,6 +137,13 @@ export class CodexReasoningProjection {
       },
     });
   }
+}
+
+function normalizePlanStepStatus(status: string | undefined): AgentPlanStepStatus {
+  if (status === "inProgress" || status === "in_progress") {
+    return "in_progress";
+  }
+  return status === "completed" ? "completed" : "pending";
 }
 
 function collectReasoningTextValues(

--- a/extensions/codex/src/app-server/event-projector.test.ts
+++ b/extensions/codex/src/app-server/event-projector.test.ts
@@ -207,7 +207,7 @@ function findAgentEvent(
   throw new Error(`Expected agent event ${params.stream}`);
 }
 
-function findPlanEventWithSteps(mock: unknown, steps: string[]) {
+function findPlanEventWithSteps(mock: unknown, steps: Array<{ step: string; status: string }>) {
   const calls = (mock as { mock?: { calls?: unknown[][] } }).mock?.calls;
   if (!Array.isArray(calls)) {
     throw new Error("Expected onAgentEvent mock calls");
@@ -222,7 +222,7 @@ function findPlanEventWithSteps(mock: unknown, steps: string[]) {
       return data;
     }
   }
-  throw new Error(`Expected plan event ${steps.join(", ")}`);
+  throw new Error(`Expected plan event ${JSON.stringify(steps)}`);
 }
 
 function forCurrentTurn(
@@ -2512,7 +2512,7 @@ describe("CodexAppServerEventProjector", () => {
     await projector.handleNotification(
       forCurrentTurn("turn/plan/updated", {
         explanation: "next",
-        plan: [{ step: "patch", status: "in_progress" }],
+        plan: [{ step: "patch", status: "inProgress" }],
       }),
     );
     await projector.handleNotification(
@@ -2546,9 +2546,12 @@ describe("CodexAppServerEventProjector", () => {
       isReasoningSnapshot: true,
     });
     expect(onReasoningEnd).toHaveBeenCalledTimes(1);
-    expect(findPlanEventWithSteps(onAgentEvent, ["patch (in_progress)"]).steps).toEqual([
-      "patch (in_progress)",
-    ]);
+    expect(
+      findPlanEventWithSteps(onAgentEvent, [{ step: "inspect", status: "pending" }]).steps,
+    ).toEqual([{ step: "inspect", status: "pending" }]);
+    expect(
+      findPlanEventWithSteps(onAgentEvent, [{ step: "patch", status: "in_progress" }]).steps,
+    ).toEqual([{ step: "patch", status: "in_progress" }]);
     expect(findAgentEvent(onAgentEvent, { stream: "compaction", phase: "start" }).data.itemId).toBe(
       "compact-1",
     );
@@ -6003,8 +6006,8 @@ describe("CodexAppServerEventProjector", () => {
     const result = projector.buildResult(buildEmptyToolTelemetry());
 
     expect(findAgentEvent(onAgentEvent, { stream: "plan" }).data.steps).toEqual([
-      "step one",
-      "step two",
+      { step: "step one", status: "pending" },
+      { step: "step two", status: "pending" },
     ]);
     expect(result.assistantTexts).toEqual(["final answer"]);
     expect(JSON.stringify(result.messagesSnapshot)).toContain("Codex plan");

--- a/extensions/copilot/src/event-bridge.test.ts
+++ b/extensions/copilot/src/event-bridge.test.ts
@@ -554,7 +554,11 @@ describe("attachEventBridge", () => {
         title: "Plan updated",
         source: "copilot-sdk",
         explanation: "Plan ready",
-        steps: ["# Plan", "inspect", "patch"],
+        steps: [
+          { step: "# Plan", status: "pending" },
+          { step: "inspect", status: "pending" },
+          { step: "patch", status: "pending" },
+        ],
         actions: ["approve", "edit"],
         requestId: "request-1",
         recommendedAction: "approve",

--- a/extensions/copilot/src/event-bridge.ts
+++ b/extensions/copilot/src/event-bridge.ts
@@ -242,7 +242,10 @@ export function attachEventBridge(
   });
 
   registerListener(session, unsubscribeFns, "exit_plan_mode.requested", (event) => {
-    const steps = splitPlanText(event.data.planContent);
+    const steps = splitPlanText(event.data.planContent).map((step) => ({
+      step,
+      status: "pending" as const,
+    }));
     enqueueAgentEvent({
       stream: "plan",
       data: {

--- a/extensions/discord/src/monitor/message-handler.draft-preview.ts
+++ b/extensions/discord/src/monitor/message-handler.draft-preview.ts
@@ -1,5 +1,6 @@
 import { EmbeddedBlockChunker } from "openclaw/plugin-sdk/agent-runtime";
 import {
+  type AgentPlanStep,
   type ChannelProgressDraftLine,
   createChannelProgressDraftCompositor,
   resolveChannelProgressDraftConfig,
@@ -213,6 +214,9 @@ export function createDiscordDraftPreviewController(params: {
       options?: { toolName?: string },
     ) {
       await progressDraft.pushToolProgress(line, options);
+    },
+    async pushPlanProgress(steps?: AgentPlanStep[], options?: { explanation?: string }) {
+      await progressDraft.pushPlanProgress(steps, options);
     },
     async pushReasoningProgress(text?: string, options?: { snapshot?: boolean }) {
       await progressDraft.pushReasoningProgress(text, options);

--- a/extensions/discord/src/monitor/message-handler.process.test.ts
+++ b/extensions/discord/src/monitor/message-handler.process.test.ts
@@ -165,6 +165,7 @@ type DispatchInboundParams = {
       phase?: string;
       explanation?: string;
       steps?: string[];
+      planSteps?: Array<{ step: string; status: "pending" | "in_progress" | "completed" }>;
     }) => Promise<void> | void;
     onApprovalEvent?: (payload: { phase?: string; command?: string }) => Promise<void> | void;
     onCommandOutput?: (payload: {
@@ -3203,6 +3204,37 @@ describe("processDiscordMessage draft streaming", () => {
     );
     expectFinalWithProgressReceipt("done", "🛠️ 1 tool call");
     expect(getDeliveredFinalTexts()[0]).not.toContain("💬");
+  });
+
+  it("renders plan updates as an immediate Discord checklist", async () => {
+    const draftStream = createMockDraftStreamForTest();
+
+    dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
+      await params?.replyOptions?.onPlanUpdate?.({
+        phase: "update",
+        explanation: "Implementing the change.",
+        steps: ["Inspect", "Patch", "Test"],
+        planSteps: [
+          { step: "Inspect", status: "completed" },
+          { step: "Patch", status: "in_progress" },
+          { step: "Test", status: "pending" },
+        ],
+      });
+      return createNoQueuedDispatchResult();
+    });
+
+    const ctx = await createAutomaticSourceDeliveryContext({
+      discordConfig: {
+        streaming: { mode: "progress", progress: { label: false } },
+      },
+    });
+
+    await runProcessDiscordMessage(ctx);
+
+    expect(draftStream.update).toHaveBeenCalledWith(
+      "Implementing the change.\n\n✅ Inspect\n▸ Patch\n▢ Test",
+    );
+    expect(draftStream.flush).toHaveBeenCalledTimes(1);
   });
 
   it("keeps opt-in commentary receipts independent from hidden tool progress", async () => {

--- a/extensions/discord/src/monitor/message-handler.process.ts
+++ b/extensions/discord/src/monitor/message-handler.process.ts
@@ -1191,15 +1191,9 @@ async function processDiscordMessageInner(
           if (payload.phase !== "update") {
             return;
           }
-          await draftPreview.pushToolProgress(
-            buildChannelProgressDraftLine({
-              event: "plan",
-              phase: payload.phase,
-              title: payload.title,
-              explanation: payload.explanation,
-              steps: payload.steps,
-            }),
-          );
+          await draftPreview.pushPlanProgress(payload.planSteps, {
+            explanation: payload.explanation,
+          });
         },
         onApprovalEvent: async (payload) => {
           if (payload.phase !== "requested") {

--- a/extensions/matrix/src/matrix/monitor/handler.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.test.ts
@@ -2922,6 +2922,7 @@ describe("matrix monitor handler draft streaming", () => {
       phase: string;
       explanation?: string;
       steps?: string[];
+      planSteps?: Array<{ step: string; status: "pending" | "in_progress" | "completed" }>;
     }) => Promise<void>;
     onApprovalEvent?: (payload: { phase: string; command?: string }) => Promise<void>;
     onCommandOutput?: (payload: {
@@ -3078,6 +3079,46 @@ describe("matrix monitor handler draft streaming", () => {
     expectFinalizedPreviewEdit("$draft1", "Done");
     expect(deliverMatrixRepliesMock).not.toHaveBeenCalled();
     expect(redactEventMock).not.toHaveBeenCalled();
+    await finish();
+  });
+
+  it("replaces Matrix plan snapshots and keeps the explanation", async () => {
+    const { dispatch } = createStreamingHarness({
+      streaming: "progress",
+      previewToolProgressEnabled: true,
+      accountConfig: {
+        streaming: { mode: "progress", progress: { label: false } },
+      } as never,
+    });
+    const { opts, finish } = await dispatch();
+
+    await opts.onPlanUpdate?.({
+      phase: "update",
+      explanation: "Initial plan",
+      planSteps: [{ step: "Inspect", status: "in_progress" }],
+    });
+    await vi.waitFor(() => {
+      expect(singleTextMessageBody()).toBe("`Initial plan`\n\n`▸ Inspect`");
+    });
+
+    await opts.onPlanUpdate?.({
+      phase: "update",
+      explanation: "Revised plan",
+      planSteps: [
+        { step: "Inspect", status: "completed" },
+        { step: "Patch", status: "in_progress" },
+      ],
+    });
+    await vi.waitFor(
+      () => {
+        expect(editMessageMatrixMock).toHaveBeenCalled();
+      },
+      { timeout: 3_000 },
+    );
+    expect(lastCallArg(editMessageMatrixMock, 2, "Matrix plan edit body")).toBe(
+      "`Revised plan`\n\n`✅ Inspect`\n`▸ Patch`",
+    );
+
     await finish();
   });
 

--- a/extensions/matrix/src/matrix/monitor/handler.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.ts
@@ -12,6 +12,7 @@ import {
   type MessageReceipt,
 } from "openclaw/plugin-sdk/channel-outbound";
 import {
+  type AgentPlanStep,
   buildChannelProgressDraftLineForEntry,
   createChannelProgressDraftGate,
   type ChannelProgressDraftLine,
@@ -1779,13 +1780,15 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
       let currentDraftReplyToId = draftReplyToId;
       let previewToolProgressSuppressed = false;
       let previewToolProgressLines: Array<string | ChannelProgressDraftLine> = [];
+      let latestPlan: AgentPlanStep[] | undefined;
+      let latestPlanExplanation: string | undefined;
       const progressConfigEntry = params.accountConfig ?? cfg.channels?.matrix;
       const progressSeed = `${_route.accountId}:${roomId}`;
       // Set after the first final payload consumes or discards the draft event
       // so subsequent finals go through normal delivery.
 
       const renderProgressDraft = () => {
-        if (!draftStream || !progressDraftStreaming) {
+        if (!draftStream) {
           return;
         }
         const previewText = formatChannelProgressDraftText({
@@ -1794,6 +1797,8 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
           seed: progressSeed,
           formatLine: formatMatrixToolProgressMarkdownCode,
           bullet: "-",
+          narration: latestPlanExplanation,
+          plan: latestPlan,
         });
         if (!previewText) {
           return;
@@ -1837,6 +1842,8 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
               seed: progressSeed,
               formatLine: formatMatrixToolProgressMarkdownCode,
               bullet: "-",
+              narration: latestPlanExplanation,
+              plan: latestPlan,
             }),
           );
           return;
@@ -1857,17 +1864,41 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
         }
       };
 
+      const pushPlanProgress = async (steps?: AgentPlanStep[], explanation?: string) => {
+        latestPlan = steps?.length ? steps.map((entry) => ({ ...entry })) : undefined;
+        latestPlanExplanation = explanation?.replace(/\s+/g, " ").trim() || undefined;
+        if (!draftStream || previewToolProgressSuppressed) {
+          return;
+        }
+        if (!progressDraftStreaming) {
+          renderProgressDraft();
+          return;
+        }
+        const alreadyStarted = progressDraftGate.hasStarted;
+        await progressDraftGate.startNow();
+        if (alreadyStarted && progressDraftGate.hasStarted) {
+          // An empty-render clear keeps the prior draft visible on purpose:
+          // deleting mid-turn drops the edit anchor, and zero-step snapshots
+          // only arrive from label:false configs with retracting producers.
+          renderProgressDraft();
+        }
+      };
+
       const suppressPreviewToolProgressForAnswerText = (text: string | undefined) => {
         if (!text?.trim()) {
           return;
         }
         previewToolProgressSuppressed = true;
         previewToolProgressLines = [];
+        latestPlan = undefined;
+        latestPlanExplanation = undefined;
       };
 
       const resetPreviewToolProgress = () => {
         previewToolProgressSuppressed = false;
         previewToolProgressLines = [];
+        latestPlan = undefined;
+        latestPlanExplanation = undefined;
       };
 
       const buildPreviewToolProgressReplyOptions = (): Partial<GetReplyOptions> => {
@@ -1921,15 +1952,7 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
             if (payload.phase !== "update") {
               return;
             }
-            await pushPreviewToolProgress(
-              formatChannelProgressDraftLine({
-                event: "plan",
-                phase: payload.phase,
-                title: payload.title,
-                explanation: payload.explanation,
-                steps: payload.steps,
-              }),
-            );
+            await pushPlanProgress(payload.planSteps, payload.explanation);
           },
           onApprovalEvent: async (payload) => {
             if (payload.phase !== "requested") {

--- a/extensions/msteams/src/reply-dispatcher.ts
+++ b/extensions/msteams/src/reply-dispatcher.ts
@@ -459,20 +459,9 @@ export function createMSTeamsReplyDispatcher(params: {
           if (payload?.phase !== "update") {
             return;
           }
-          await streamController.pushProgressLine(
-            buildChannelProgressDraftLine({
-              event: "plan",
-              phase: payload.phase as string,
-              ...(typeof payload?.title === "string" ? { title: payload.title } : {}),
-              ...(typeof payload?.explanation === "string"
-                ? { explanation: payload.explanation }
-                : {}),
-              ...(Array.isArray(payload?.steps) &&
-              payload.steps.every((s: unknown) => typeof s === "string")
-                ? { steps: payload.steps }
-                : {}),
-            }),
-          );
+          await streamController.pushPlanProgress(payload.planSteps, {
+            explanation: typeof payload.explanation === "string" ? payload.explanation : undefined,
+          });
         },
         onApprovalEvent: async (payload: PipelinePayload) => {
           if (payload?.phase !== "requested") {

--- a/extensions/msteams/src/reply-dispatcher.ts
+++ b/extensions/msteams/src/reply-dispatcher.ts
@@ -2,6 +2,7 @@
 import {
   buildChannelProgressDraftLine,
   buildChannelProgressDraftLineForEntry,
+  normalizeAgentPlanSteps,
   resolveChannelPreviewStreamMode,
   resolveChannelStreamingBlockEnabled,
   resolveChannelStreamingPreviewToolProgress,
@@ -459,7 +460,7 @@ export function createMSTeamsReplyDispatcher(params: {
           if (payload?.phase !== "update") {
             return;
           }
-          await streamController.pushPlanProgress(payload.planSteps, {
+          await streamController.pushPlanProgress(normalizeAgentPlanSteps(payload.planSteps), {
             explanation: typeof payload.explanation === "string" ? payload.explanation : undefined,
           });
         },

--- a/extensions/msteams/src/reply-stream-controller.test.ts
+++ b/extensions/msteams/src/reply-stream-controller.test.ts
@@ -297,6 +297,31 @@ describe("createTeamsReplyStreamController", () => {
     }
   });
 
+  it("replaces Teams plan snapshots and keeps the explanation", async () => {
+    const stream = makeStream();
+    const ctrl = createTeamsReplyStreamController({
+      conversationType: "personal",
+      context: makeContext(stream),
+      feedbackLoopEnabled: false,
+      msteamsConfig: {
+        streaming: { mode: "progress", progress: { label: false } },
+      } as never,
+    });
+
+    await ctrl.pushPlanProgress([{ step: "Inspect", status: "in_progress" }], {
+      explanation: "Initial plan",
+    });
+    await ctrl.pushPlanProgress(
+      [
+        { step: "Inspect", status: "completed" },
+        { step: "Patch", status: "in_progress" },
+      ],
+      { explanation: "Revised plan" },
+    );
+
+    expect(stream.update).toHaveBeenLastCalledWith("Revised plan\n\n✅ Inspect\n▸ Patch");
+  });
+
   it("cancels the pending progress gate at finalize so no stale card posts after close", async () => {
     vi.useFakeTimers();
     const stream = makeStream();
@@ -337,6 +362,21 @@ describe("createTeamsReplyStreamController", () => {
 
     expect(ctrl.preparePayload({ text: "complete final answer" })).toBeUndefined();
     expect(stream.emit).toHaveBeenCalledWith("complete final answer");
+  });
+
+  it("ignores plan updates after final answer streaming starts", async () => {
+    const stream = makeStream();
+    const ctrl = createTeamsReplyStreamController({
+      conversationType: "personal",
+      context: makeContext(stream),
+      feedbackLoopEnabled: false,
+      msteamsConfig: { streaming: { mode: "progress" } } as never,
+    });
+
+    expect(ctrl.preparePayload({ text: "complete final answer" })).toBeUndefined();
+    await ctrl.pushPlanProgress([{ step: "Late plan", status: "in_progress" }]);
+
+    expect(stream.update).not.toHaveBeenCalled();
   });
 
   it("falls back to normal delivery when progress final streaming fails", () => {

--- a/extensions/msteams/src/reply-stream-controller.ts
+++ b/extensions/msteams/src/reply-stream-controller.ts
@@ -1,5 +1,6 @@
 // Msteams plugin module implements reply stream controller behavior.
 import {
+  type AgentPlanStep,
   createChannelProgressDraftGate,
   type ChannelProgressDraftLine,
   formatChannelProgressDraftText,
@@ -75,6 +76,8 @@ export function createTeamsReplyStreamController(params: {
   let streamFailed = false;
   let lastInformativeText = "";
   let progressLines: Array<string | ChannelProgressDraftLine> = [];
+  let latestPlan: AgentPlanStep[] | undefined;
+  let latestPlanExplanation: string | undefined;
   let pendingFinalPayload: Maybe<ReplyPayload>;
   // openclaw's reply pipeline calls onPartialReply with the cumulative text on
   // each chunk, but the SDK's HttpStream appends each emit() to its internal
@@ -109,7 +112,13 @@ export function createTeamsReplyStreamController(params: {
       lines: shouldStreamPreviewToolProgress ? progressLines : [],
       seed: params.progressSeed,
       bullet: "-",
+      narration: latestPlanExplanation,
+      plan: latestPlan,
     });
+    // Empty render after a cleared plan intentionally keeps the previous
+    // card: Teams streams cannot delete or blank an update mid-stream, and
+    // the final answer settles the card at turn end. Default label configs
+    // re-render immediately, so this only lingers with `label: false`.
     if (!informativeText || informativeText === lastInformativeText) {
       return;
     }
@@ -260,6 +269,22 @@ export function createTeamsReplyStreamController(params: {
       const hadStarted = progressDraftGate.hasStarted;
       const progressActive = await progressDraftGate.noteWork();
       if ((hadStarted || progressActive) && progressDraftGate.hasStarted) {
+        renderInformativeUpdate();
+      }
+    },
+
+    async pushPlanProgress(
+      steps?: AgentPlanStep[],
+      options?: { explanation?: string },
+    ): Promise<void> {
+      if (!stream || streamMode !== "progress" || streamFinalizationPending) {
+        return;
+      }
+      latestPlan = steps?.length ? steps.map((entry) => ({ ...entry })) : undefined;
+      latestPlanExplanation = options?.explanation?.replace(/\s+/g, " ").trim() || undefined;
+      const hadStarted = progressDraftGate.hasStarted;
+      await progressDraftGate.startNow();
+      if (hadStarted && progressDraftGate.hasStarted) {
         renderInformativeUpdate();
       }
     },

--- a/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
@@ -563,6 +563,7 @@ vi.mock("openclaw/plugin-sdk/channel-outbound", async (importOriginal) => {
       toolCallId?: string;
       progressText?: string;
       summary?: string;
+      explanation?: string;
       title?: string;
       name?: string;
       status?: string;

--- a/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
@@ -100,6 +100,15 @@ let capturedReplyOptions:
         deleted?: string[];
         summary?: string;
       }) => Promise<void> | void;
+      onPlanUpdate?: (payload: {
+        phase?: string;
+        explanation?: string;
+        steps?: string[];
+        planSteps?: Array<{
+          step: string;
+          status: "pending" | "in_progress" | "completed";
+        }>;
+      }) => Promise<void> | void;
       onPartialReply?: (payload: { text: string }) => Promise<void> | void;
       onQueuedFollowupAdmitted?: () => Promise<void> | void;
     }
@@ -189,8 +198,15 @@ let mockedReplyOptionEvents: Array<
       phase?: string;
       title?: string;
       name?: string;
+      explanation?: string;
       status?: string;
       exitCode?: number | null;
+    }
+  | {
+      kind: "plan";
+      phase?: string;
+      explanation?: string;
+      steps: Array<{ step: string; status: "pending" | "in_progress" | "completed" }>;
     }
   | { kind: "concurrent_items"; progressTexts: string[] }
   | { kind: "partial"; text: string }
@@ -273,7 +289,11 @@ function planUpdate(title: string) {
   return { type: "plan_update", title };
 }
 
-function taskUpdate(id: unknown, title: string, status: "in_progress" | "complete" | "error") {
+function taskUpdate(
+  id: unknown,
+  title: string,
+  status: "pending" | "in_progress" | "complete" | "error",
+) {
   return { type: "task_update", id, title, status };
 }
 
@@ -548,6 +568,17 @@ vi.mock("openclaw/plugin-sdk/channel-outbound", async (importOriginal) => {
       status?: string;
       exitCode?: number | null;
     }) => {
+      if (params.event === "plan") {
+        return params.explanation
+          ? {
+              kind: "plan",
+              text: `🗺️ Update Plan: ${params.explanation}`,
+              label: "Update Plan",
+              detail: params.explanation,
+              toolName: "update_plan",
+            }
+          : undefined;
+      }
       if (params.event === "command-output") {
         const status =
           params.exitCode === 0
@@ -1025,6 +1056,15 @@ vi.mock("../reply.runtime.js", () => ({
         deleted?: string[];
         summary?: string;
       }) => Promise<void> | void;
+      onPlanUpdate?: (payload: {
+        phase?: string;
+        explanation?: string;
+        steps?: string[];
+        planSteps?: Array<{
+          step: string;
+          status: "pending" | "in_progress" | "completed";
+        }>;
+      }) => Promise<void> | void;
       onAssistantMessageStart?: () => Promise<void> | void;
       onReasoningEnd?: () => Promise<void> | void;
       onReasoningStream?: (payload?: {
@@ -1080,6 +1120,13 @@ vi.mock("../reply.runtime.js", () => ({
             modified: entry.modified,
             deleted: entry.deleted,
             summary: entry.summary,
+          });
+        } else if (entry.kind === "plan") {
+          await params.replyOptions?.onPlanUpdate?.({
+            phase: entry.phase,
+            explanation: entry.explanation,
+            steps: entry.steps.map((step) => step.step),
+            planSteps: entry.steps,
           });
         } else if (entry.kind === "concurrent_items") {
           await Promise.all(
@@ -1175,6 +1222,15 @@ vi.mock("../reply.runtime.js", () => ({
         deleted?: string[];
         summary?: string;
       }) => Promise<void> | void;
+      onPlanUpdate?: (payload: {
+        phase?: string;
+        explanation?: string;
+        steps?: string[];
+        planSteps?: Array<{
+          step: string;
+          status: "pending" | "in_progress" | "completed";
+        }>;
+      }) => Promise<void> | void;
       onPartialReply?: (payload: { text: string }) => Promise<void> | void;
     };
     dispatcher: {
@@ -1216,6 +1272,13 @@ vi.mock("../reply.runtime.js", () => ({
             modified: entry.modified,
             deleted: entry.deleted,
             summary: entry.summary,
+          });
+        } else if (entry.kind === "plan") {
+          await params.replyOptions?.onPlanUpdate?.({
+            phase: entry.phase,
+            explanation: entry.explanation,
+            steps: entry.steps.map((step) => step.step),
+            planSteps: entry.steps,
           });
         } else if (entry.kind === "concurrent_items") {
           await Promise.all(
@@ -2956,6 +3019,70 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
     expect(stopSlackStreamMock).not.toHaveBeenCalled();
     expect(deliverRepliesMock).toHaveBeenCalledTimes(1);
     expectDeliverReplyCall(0, FINAL_REPLY_TEXT);
+  });
+
+  it("starts native Slack progress from typed plan steps", async () => {
+    await dispatchNativeProgressScenario({
+      finalPayload: { text: FINAL_REPLY_TEXT },
+      events: [
+        {
+          kind: "plan",
+          phase: "update",
+          explanation: "Executing the checklist.",
+          steps: [
+            { step: "Inspect", status: "completed" },
+            { step: "Patch", status: "in_progress" },
+            { step: "Test", status: "pending" },
+          ],
+        },
+      ],
+    });
+
+    expectNativeProgressStart([
+      planUpdate("Executing the checklist."),
+      taskUpdate("plan_step_1", "Inspect", "complete"),
+      taskUpdate("plan_step_2", "Patch", "in_progress"),
+      taskUpdate("plan_step_3", "Test", "pending"),
+    ]);
+  });
+
+  it("starts native Slack progress from an explanation-only plan", async () => {
+    await dispatchNativeProgressScenario({
+      finalPayload: { text: FINAL_REPLY_TEXT },
+      events: [
+        {
+          kind: "plan",
+          phase: "update",
+          explanation: "Reviewing the implementation.",
+          steps: [],
+        },
+      ],
+    });
+
+    expectNativeProgressStart([
+      planUpdate("Reviewing the implementation."),
+      taskUpdate(expect.any(String), "Update Plan — Reviewing the implementation.", "in_progress"),
+    ]);
+  });
+
+  it("does not replace answer text with a late plan update", async () => {
+    const draftStream = createDraftStreamStub();
+    createSlackDraftStreamMock.mockReturnValueOnce(draftStream);
+    mockedDispatchSequence = [];
+    mockedReplyOptionEvents = [
+      { kind: "partial", text: "Answer started" },
+      {
+        kind: "plan",
+        phase: "update",
+        explanation: "Late plan",
+        steps: [{ step: "Should stay hidden", status: "in_progress" }],
+      },
+    ];
+
+    await dispatchPreparedSlackMessage(createPreparedSlackMessage());
+
+    expect(draftStream.update).toHaveBeenCalledTimes(1);
+    expect(draftStream.update).toHaveBeenLastCalledWith("Answer started");
   });
 
   it("starts native Slack progress from the first running tool callback before final text", async () => {

--- a/extensions/slack/src/monitor/message-handler/dispatch.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.ts
@@ -1,7 +1,6 @@
 // Slack plugin module implements dispatch behavior.
 import { resolveHumanDelayConfig } from "openclaw/plugin-sdk/agent-runtime";
 import {
-  type AgentPlanStep,
   createStatusReactionController,
   DEFAULT_TIMING,
   logAckFailure,
@@ -25,6 +24,7 @@ import {
 } from "openclaw/plugin-sdk/channel-outbound";
 import { resolveAgentOutboundIdentity } from "openclaw/plugin-sdk/channel-outbound";
 import {
+  type AgentPlanStep,
   buildChannelProgressDraftLine,
   buildChannelProgressDraftLineForEntry,
   createChannelProgressDraftGate,
@@ -1773,7 +1773,6 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
       // Commit only after Slack accepted the chunks; a failed emit must retry
       // the same reconciliation against the previous snapshot.
       nativeTaskState = reconciled.tasks;
-      return;
     } catch (err) {
       runtime.error?.(
         danger(

--- a/extensions/slack/src/monitor/message-handler/dispatch.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.ts
@@ -1,6 +1,7 @@
 // Slack plugin module implements dispatch behavior.
 import { resolveHumanDelayConfig } from "openclaw/plugin-sdk/agent-runtime";
 import {
+  type AgentPlanStep,
   createStatusReactionController,
   DEFAULT_TIMING,
   logAckFailure,
@@ -69,6 +70,8 @@ import {
   buildSlackProgressStreamCompletionChunks,
   buildSlackProgressStreamStartChunks,
   buildSlackProgressStreamUpdateChunks,
+  reconcileSlackNativeTaskChunks,
+  type SlackNativeTaskSnapshot,
 } from "../../progress-blocks.js";
 import { resolveSlackReplyRenderPlan } from "../../reply-blocks.js";
 import { recordSlackThreadParticipation } from "../../sent-thread-cache.js";
@@ -1161,13 +1164,22 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
       const completionChunks =
         useNativeProgressStreaming &&
         !nativeProgressCompletionSent &&
-        previewToolProgressLines.length > 0
-          ? buildSlackProgressStreamCompletionChunks({
-              title: explicitProgressTitle,
-              lines: previewToolProgressLines,
-              maxLineChars: progressDraftMaxLineChars,
-              finalInProgressStatus: params.payload.isError ? "error" : "complete",
-            })
+        (previewToolProgressLines.length > 0 ||
+          Boolean(latestPlan?.length) ||
+          Boolean(latestPlanExplanation) ||
+          [...nativeTaskState.values()].some(
+            (task) => task.status !== "complete" && task.status !== "error",
+          ))
+          ? reconcileSlackNativeTaskChunks({
+              previousTasks: nativeTaskState,
+              chunks: buildSlackProgressStreamCompletionChunks({
+                title: resolveNativeProgressTitle(),
+                lines: resolveNativeProgressLines(),
+                plan: resolveNativeProgressPlan(),
+                maxLineChars: progressDraftMaxLineChars,
+                finalInProgressStatus: params.payload.isError ? "error" : "complete",
+              }),
+            }).chunks
           : undefined;
       if (useNativeProgressStreaming) {
         if (completionChunks?.length) {
@@ -1542,6 +1554,11 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
   let previewToolProgressSuppressed = false;
   let previewToolProgressLines: ChannelProgressDraftLine[] = [];
   let lastNonEmptyPreviewToolProgressLines: ChannelProgressDraftLine[] = [];
+  let latestPlan: AgentPlanStep[] | undefined;
+  let latestPlanExplanation: string | undefined;
+  // Last task rows emitted to the native stream; reconciliation terminalizes
+  // ids that drop out (plan shrinks, tool-line <-> plan source switches).
+  let nativeTaskState: SlackNativeTaskSnapshot = new Map();
   let appendRenderedText = "";
   let appendSourceText = "";
   let reasoningProgressRawText = "";
@@ -1567,6 +1584,8 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
       lines: progressLines,
       seed: progressSeed,
       formatLine: escapeSlackMrkdwn,
+      narration: latestPlanExplanation,
+      plan: latestPlan,
     });
     if (!previewText) {
       return;
@@ -1575,6 +1594,8 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
       ? buildSlackProgressDraftBlocks({
           title: explicitProgressTitle,
           lines: progressLines,
+          plan: latestPlan,
+          narration: latestPlanExplanation,
           maxLineChars: resolveChannelProgressDraftMaxLineChars(account.config),
         })
       : undefined;
@@ -1602,16 +1623,44 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
     return !streamFailed;
   };
 
+  // Empty/cleared plans fall back to line-derived tasks; the reconciler
+  // terminalizes any previously emitted plan rows on that switch.
+  const resolveNativeProgressPlan = (): AgentPlanStep[] | undefined =>
+    latestPlan?.length ? latestPlan : undefined;
+
+  const resolveNativeProgressLines = (): ChannelProgressDraftLine[] => {
+    if (latestPlan?.length || !latestPlanExplanation) {
+      return previewToolProgressLines;
+    }
+    const explanationLine = buildChannelProgressDraftLine({
+      event: "plan",
+      phase: "update",
+      explanation: latestPlanExplanation,
+    });
+    return explanationLine
+      ? [...previewToolProgressLines, explanationLine]
+      : previewToolProgressLines;
+  };
+
+  // A configured title must not hide the model's plan explanation: typed-plan
+  // chunks carry no narration field, so the title is its only native surface.
+  const resolveNativeProgressTitle = () =>
+    explicitProgressTitle && latestPlanExplanation
+      ? `${explicitProgressTitle} — ${latestPlanExplanation}`
+      : (explicitProgressTitle ?? latestPlanExplanation);
+
   const buildNativeProgressChunks = () =>
     streamSession
       ? buildSlackProgressStreamUpdateChunks({
-          title: explicitProgressTitle,
-          lines: previewToolProgressLines,
+          title: resolveNativeProgressTitle(),
+          lines: resolveNativeProgressLines(),
+          plan: resolveNativeProgressPlan(),
           maxLineChars: progressDraftMaxLineChars,
         })
       : buildSlackProgressStreamStartChunks({
-          title: explicitProgressTitle,
-          lines: previewToolProgressLines,
+          title: resolveNativeProgressTitle(),
+          lines: resolveNativeProgressLines(),
+          plan: resolveNativeProgressPlan(),
           maxLineChars: progressDraftMaxLineChars,
         });
 
@@ -1686,14 +1735,28 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
   };
 
   const updateNativeProgressStream = async () => {
-    if (!useNativeProgressStreaming || streamFailed || previewToolProgressLines.length === 0) {
+    const hasRetirableNativeTasks = [...nativeTaskState.values()].some(
+      (task) => task.status !== "complete" && task.status !== "error",
+    );
+    if (
+      !useNativeProgressStreaming ||
+      streamFailed ||
+      (previewToolProgressLines.length === 0 &&
+        !latestPlan?.length &&
+        !latestPlanExplanation &&
+        !hasRetirableNativeTasks)
+    ) {
       return;
     }
     const canContinue = await waitForNativeProgressStreamStart();
     if (!canContinue) {
       return;
     }
-    const chunks = buildNativeProgressChunks();
+    const reconciled = reconcileSlackNativeTaskChunks({
+      previousTasks: nativeTaskState,
+      chunks: buildNativeProgressChunks(),
+    });
+    const chunks = reconciled.chunks;
     if (!chunks?.length) {
       return;
     }
@@ -1704,9 +1767,13 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
     try {
       if (!streamSession) {
         await startNativeProgressStream(chunks, chunkKey);
-        return;
+      } else {
+        await appendNativeProgressStream(chunks, chunkKey);
       }
-      await appendNativeProgressStream(chunks, chunkKey);
+      // Commit only after Slack accepted the chunks; a failed emit must retry
+      // the same reconciliation against the previous snapshot.
+      nativeTaskState = reconciled.tasks;
+      return;
     } catch (err) {
       runtime.error?.(
         danger(
@@ -1720,6 +1787,43 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
   const progressDraftGate = createChannelProgressDraftGate({
     onStart: useNativeProgressStreaming ? updateNativeProgressStream : renderProgressDraft,
   });
+
+  const pushPlanProgress = async (steps?: AgentPlanStep[], explanation?: string) => {
+    if (previewToolProgressSuppressed) {
+      return;
+    }
+    // Keep an empty snapshot distinct from "no plan": empty switches the
+    // native task source back to lines and reconciliation retires plan rows.
+    latestPlan = steps ? steps.map((entry) => ({ ...entry })) : undefined;
+    latestPlanExplanation = explanation?.replace(/\s+/g, " ").trim() || undefined;
+    if (!draftStream && !useNativeProgressStreaming) {
+      return;
+    }
+    if (streamMode !== "status_final" && !useNativeProgressStreaming) {
+      const text = formatChannelProgressDraftText({
+        entry: account.config,
+        lines: previewToolProgressLines,
+        seed: progressSeed,
+        formatLine: escapeSlackMrkdwn,
+        narration: latestPlanExplanation,
+        plan: latestPlan,
+      });
+      if (text) {
+        draftStream?.update(text);
+        hasStreamedMessage = true;
+      }
+      // Empty render after a cleared plan intentionally keeps the prior draft:
+      // clear() would kill the stream for the rest of the turn, and an empty
+      // retraction only occurs with label:false plus a zero-step snapshot,
+      // which bundled plan producers cannot emit (minItems: 1).
+      return;
+    }
+    const alreadyStarted = progressDraftGate.hasStarted;
+    await progressDraftGate.startNow();
+    if (alreadyStarted && progressDraftGate.hasStarted) {
+      await refreshStartedProgressDraft();
+    }
+  };
 
   const refreshStartedProgressDraft = async () => {
     if (useNativeProgressStreaming) {
@@ -1905,6 +2009,11 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
         deliveryTracker = createSlackEventDeliveryTracker();
         resetDraftDeliveryState();
         resetDraftProgressState();
+        // Queued follow-ups start a new visible reply; the previous request's
+        // checklist and native row high-water mark must not leak into it.
+        latestPlan = undefined;
+        latestPlanExplanation = undefined;
+        nativeTaskState = new Map();
       };
 
   let dispatchError: unknown;
@@ -2015,15 +2124,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
           if (payload.phase !== "update") {
             return;
           }
-          await pushPreviewProgress(
-            buildChannelProgressDraftLine({
-              event: "plan",
-              phase: payload.phase,
-              title: payload.title,
-              explanation: payload.explanation,
-              steps: payload.steps,
-            }),
-          );
+          await pushPlanProgress(payload.planSteps, payload.explanation);
         },
         onApprovalEvent: async (payload) => {
           if (payload.phase !== "requested") {
@@ -2100,13 +2201,22 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
       const completionChunks =
         useNativeProgressStreaming &&
         !nativeProgressCompletionSent &&
-        previewToolProgressLines.length > 0
-          ? buildSlackProgressStreamCompletionChunks({
-              title: explicitProgressTitle,
-              lines: previewToolProgressLines,
-              maxLineChars: progressDraftMaxLineChars,
-              finalInProgressStatus: dispatchError ? "error" : "complete",
-            })
+        (previewToolProgressLines.length > 0 ||
+          Boolean(latestPlan?.length) ||
+          Boolean(latestPlanExplanation) ||
+          [...nativeTaskState.values()].some(
+            (task) => task.status !== "complete" && task.status !== "error",
+          ))
+          ? reconcileSlackNativeTaskChunks({
+              previousTasks: nativeTaskState,
+              chunks: buildSlackProgressStreamCompletionChunks({
+                title: resolveNativeProgressTitle(),
+                lines: resolveNativeProgressLines(),
+                plan: resolveNativeProgressPlan(),
+                maxLineChars: progressDraftMaxLineChars,
+                finalInProgressStatus: dispatchError ? "error" : "complete",
+              }),
+            }).chunks
           : undefined;
       if (completionChunks?.length) {
         nativeProgressCompletionSent = true;

--- a/extensions/slack/src/progress-blocks.test.ts
+++ b/extensions/slack/src/progress-blocks.test.ts
@@ -1,3 +1,4 @@
+import { formatChannelProgressDraftText } from "openclaw/plugin-sdk/channel-outbound";
 // Slack tests cover progress blocks plugin behavior.
 import { describe, expect, it } from "vitest";
 import {
@@ -5,6 +6,7 @@ import {
   buildSlackProgressStreamCompletionChunks,
   buildSlackProgressStreamStartChunks,
   buildSlackProgressStreamUpdateChunks,
+  reconcileSlackNativeTaskChunks,
 } from "./progress-blocks.js";
 
 function progressLine(index: number) {
@@ -36,7 +38,11 @@ function planUpdate(title: string) {
   return { type: "plan_update", title };
 }
 
-function taskUpdate(id: unknown, title: string, status: "in_progress" | "complete" | "error") {
+function taskUpdate(
+  id: unknown,
+  title: string,
+  status: "pending" | "in_progress" | "complete" | "error",
+) {
   return { type: "task_update", id, title, status };
 }
 
@@ -71,6 +77,21 @@ function expectTaskUpdate(task: unknown, fields: { id: string; title: string; st
 }
 
 describe("buildSlackProgressDraftBlocks", () => {
+  it("keeps a typed checklist below Slack status draft text", () => {
+    expect(
+      formatChannelProgressDraftText({
+        entry: { streaming: { mode: "progress", progress: { label: "Shelling" } } },
+        lines: [toolLine("hidden while status exists")],
+        narration: "Implementing the change.",
+        plan: [
+          { step: "Inspect", status: "completed" },
+          { step: "Patch", status: "in_progress" },
+          { step: "Test", status: "pending" },
+        ],
+      }),
+    ).toBe("Shelling\n\nImplementing the change.\n\n✅ Inspect\n▸ Patch\n▢ Test");
+  });
+
   it("keeps legacy rich draft rendering as section field blocks", () => {
     expect(
       buildSlackProgressDraftBlocks({
@@ -144,7 +165,9 @@ describe("buildSlackProgressDraftBlocks", () => {
       lines: Array.from({ length: 60 }, (_value, index) => progressLine(index)),
     });
     expect(blocksWithLabel).toHaveLength(50);
-    expectLegacyLineBlock(blocksWithLabel?.[0], "🛠️ *Exec 10*", "run 10");
+    // The label block survives capping; tool lines yield the remaining budget.
+    expect(JSON.stringify(blocksWithLabel?.[0])).toContain("Shelling...");
+    expectLegacyLineBlock(blocksWithLabel?.[1], "🛠️ *Exec 11*", "run 11");
     expectLegacyLineBlock(blocksWithLabel?.at(-1), "🛠️ *Exec 59*", "run 59");
 
     const blocksWithoutTitle = buildSlackProgressDraftBlocks({
@@ -181,6 +204,137 @@ describe("buildSlackProgressDraftBlocks", () => {
 });
 
 describe("native Slack progress stream chunks", () => {
+  it("uses typed plan steps instead of tool lines when a plan exists", () => {
+    const chunks = buildSlackProgressStreamStartChunks({
+      title: "Implementation",
+      lines: [toolLine("legacy fallback")],
+      plan: [
+        { step: "Inspect code", status: "completed" },
+        { step: "Patch code", status: "in_progress" },
+        { step: "Run tests", status: "pending" },
+      ],
+    });
+
+    expect(chunks).toEqual([
+      planUpdate("Implementation"),
+      taskUpdate("plan_step_1", "Inspect code", "complete"),
+      taskUpdate("plan_step_2", "Patch code", "in_progress"),
+      taskUpdate("plan_step_3", "Run tests", "pending"),
+    ]);
+  });
+
+  it("reconciles renamed and reordered plan steps by rewriting position-keyed tasks", () => {
+    const initial = buildSlackProgressStreamStartChunks({
+      title: "Implementation",
+      lines: [],
+      plan: [
+        { step: "Inspect code", status: "completed" },
+        { step: "Run tests", status: "pending" },
+      ],
+    });
+    const revised = buildSlackProgressStreamUpdateChunks({
+      title: "Implementation",
+      lines: [],
+      plan: [
+        { step: "Inspect code", status: "completed" },
+        { step: "Fix parser bug", status: "in_progress" },
+        { step: "Run tests", status: "pending" },
+      ],
+    });
+
+    expect(initial).toEqual([
+      planUpdate("Implementation"),
+      taskUpdate("plan_step_1", "Inspect code", "complete"),
+      taskUpdate("plan_step_2", "Run tests", "pending"),
+    ]);
+    expect(revised).toEqual([
+      planUpdate("Implementation"),
+      taskUpdate("plan_step_1", "Inspect code", "complete"),
+      taskUpdate("plan_step_2", "Fix parser bug", "in_progress"),
+      taskUpdate("plan_step_3", "Run tests", "pending"),
+    ]);
+  });
+
+  it("renders the plan checklist in rich draft blocks", () => {
+    const blocks = buildSlackProgressDraftBlocks({
+      title: "Implementation",
+      lines: [],
+      plan: [
+        { step: "Inspect code", status: "completed" },
+        { step: "Run tests", status: "in_progress" },
+      ],
+    });
+
+    expect(JSON.stringify(blocks)).toContain("✅ Inspect code");
+    expect(JSON.stringify(blocks)).toContain("▸ Run tests");
+  });
+
+  it("terminalizes orphaned rows when a plan snapshot shrinks", () => {
+    const first = reconcileSlackNativeTaskChunks({
+      previousTasks: new Map(),
+      chunks: buildSlackProgressStreamUpdateChunks({
+        title: "Implementation",
+        lines: [],
+        plan: [
+          { step: "Inspect code", status: "completed" },
+          { step: "Patch code", status: "in_progress" },
+          { step: "Run tests", status: "pending" },
+        ],
+      }),
+    });
+    const shrunk = reconcileSlackNativeTaskChunks({
+      previousTasks: first.tasks,
+      chunks: buildSlackProgressStreamUpdateChunks({
+        title: "Implementation",
+        lines: [],
+        plan: [{ step: "Inspect code", status: "in_progress" }],
+      }),
+    });
+
+    expect(shrunk.chunks).toEqual([
+      planUpdate("Implementation"),
+      taskUpdate("plan_step_1", "Inspect code", "in_progress"),
+      taskUpdate("plan_step_2", "Patch code", "complete"),
+      taskUpdate("plan_step_3", "Run tests", "complete"),
+    ]);
+  });
+
+  it("terminalizes tool-line tasks when the source switches to a typed plan", () => {
+    const lineChunks = reconcileSlackNativeTaskChunks({
+      previousTasks: new Map(),
+      chunks: buildSlackProgressStreamStartChunks({
+        lines: [itemLine("run tests", "Running tests")],
+      }),
+    });
+    const planChunks = reconcileSlackNativeTaskChunks({
+      previousTasks: lineChunks.tasks,
+      chunks: buildSlackProgressStreamUpdateChunks({
+        title: "Implementation",
+        lines: [],
+        plan: [{ step: "Inspect code", status: "in_progress" }],
+      }),
+    });
+
+    const tasks = (planChunks.chunks ?? []).filter((chunk) => chunk.type === "task_update");
+    expect(tasks).toHaveLength(2);
+    expect(tasks[0]).toMatchObject({ id: "plan_step_1", status: "in_progress" });
+    expect(tasks[1]).toMatchObject({ status: "complete" });
+  });
+
+  it("keeps chunks untouched when no previous tasks are orphaned", () => {
+    const chunks = buildSlackProgressStreamUpdateChunks({
+      title: "Implementation",
+      lines: [],
+      plan: [{ step: "Inspect code", status: "in_progress" }],
+    });
+    const reconciled = reconcileSlackNativeTaskChunks({
+      previousTasks: new Map([["plan_step_1", { title: "Inspect code", status: "in_progress" }]]),
+      chunks,
+    });
+
+    expect(reconciled.chunks).toEqual(chunks);
+  });
+
   it("starts native Slack progress with plan/task chunks instead of a static blocks plan", () => {
     expect(
       buildSlackProgressStreamStartChunks({

--- a/extensions/slack/src/progress-blocks.ts
+++ b/extensions/slack/src/progress-blocks.ts
@@ -2,7 +2,11 @@
 import { createHash } from "node:crypto";
 import type { AnyChunk } from "@slack/types";
 import type { Block, KnownBlock } from "@slack/web-api";
-import type { ChannelProgressDraftLine } from "openclaw/plugin-sdk/channel-outbound";
+import {
+  type AgentPlanStep,
+  type ChannelProgressDraftLine,
+  formatPlanChecklistLines,
+} from "openclaw/plugin-sdk/channel-outbound";
 import { SLACK_MAX_BLOCKS } from "./blocks-input.js";
 import { escapeSlackMrkdwn } from "./monitor/mrkdwn.js";
 import { truncateSlackText } from "./truncate.js";
@@ -14,7 +18,7 @@ const SLACK_PROGRESS_CHUNK_TEXT_MAX = 256;
 const SLACK_PROGRESS_TASK_TITLE_MAX = 120;
 const SLACK_PROGRESS_PLAN_FALLBACK_TITLE = "Thinking";
 
-type SlackPlanTaskStatus = "in_progress" | "complete" | "error";
+type SlackPlanTaskStatus = "pending" | "in_progress" | "complete" | "error";
 
 type SlackPlanTask = {
   id: string;
@@ -135,8 +139,20 @@ function stableTaskIdPart(value: string): string {
 
 function buildPlanTasks(params: {
   lines: readonly ChannelProgressDraftLine[];
+  plan?: readonly AgentPlanStep[];
   maxLineChars?: number;
 }): SlackPlanTask[] {
+  if (params.plan) {
+    // Slack keys task_update chunks by id with no removal primitive, so
+    // position-keyed ids make each snapshot rewrite row i in place: renames,
+    // reorders, and insertions reconcile in place. Dropped ids (shrinks, mode
+    // switches) are terminalized by reconcileSlackNativeTaskChunks.
+    return params.plan.slice(-SLACK_MAX_BLOCKS).map((entry, index) => ({
+      id: `plan_step_${index + 1}`,
+      title: compactTitle(entry.step),
+      status: entry.status === "completed" ? ("complete" as const) : entry.status,
+    }));
+  }
   const maxLineChars = resolveMaxLineChars(
     params.maxLineChars,
     DEFAULT_SLACK_PROGRESS_TASK_DETAIL_MAX_CHARS,
@@ -167,11 +183,16 @@ function buildSlackProgressStreamChunks(params: {
   label?: string;
   title?: string;
   lines: readonly ChannelProgressDraftLine[];
+  plan?: readonly AgentPlanStep[];
   maxLineChars?: number;
   completeInProgress?: boolean;
   finalInProgressStatus?: SlackPlanTaskStatus;
 }): AnyChunk[] | undefined {
-  const tasks = buildPlanTasks({ lines: params.lines, maxLineChars: params.maxLineChars });
+  const tasks = buildPlanTasks({
+    lines: params.lines,
+    plan: params.plan,
+    maxLineChars: params.maxLineChars,
+  });
   if (tasks.length === 0) {
     return undefined;
   }
@@ -198,6 +219,8 @@ export function buildSlackProgressDraftBlocks(params: {
   label?: string;
   title?: string;
   lines: readonly ChannelProgressDraftLine[];
+  plan?: readonly AgentPlanStep[];
+  narration?: string;
   maxLineChars?: number;
 }): (Block | KnownBlock)[] | undefined {
   const label = params.label?.trim() || params.title?.trim();
@@ -205,7 +228,15 @@ export function buildSlackProgressDraftBlocks(params: {
     params.maxLineChars,
     DEFAULT_SLACK_PROGRESS_DETAIL_MAX_CHARS,
   );
-  const renderedBlocks: (Block | KnownBlock)[] = [
+  const planLines = formatPlanChecklistLines(params.plan ?? [], {
+    maxLines: SLACK_MAX_BLOCKS,
+    maxLineChars,
+  });
+  const narration = params.narration?.replace(/\s+/g, " ").trim();
+  // Status blocks (label, narration, checklist) take priority over rolling
+  // tool lines inside Slack's 50-block budget; the tail slice would otherwise
+  // silently drop the checklist first.
+  const headBlocks: (Block | KnownBlock)[] = [
     ...(label
       ? [
           {
@@ -214,18 +245,92 @@ export function buildSlackProgressDraftBlocks(params: {
           },
         ]
       : []),
-    ...params.lines.map((line) => ({
+    ...(narration
+      ? [
+          {
+            type: "section" as const,
+            text: field(`_${escapeSlackMrkdwn(narration)}_`),
+          },
+        ]
+      : []),
+    ...(planLines.length > 0
+      ? [
+          {
+            type: "section" as const,
+            text: field(planLines.map((line) => escapeSlackMrkdwn(line)).join("\n")),
+          },
+        ]
+      : []),
+  ].slice(0, SLACK_MAX_BLOCKS);
+  const lineBudget = Math.max(0, SLACK_MAX_BLOCKS - headBlocks.length);
+  const renderedBlocks: (Block | KnownBlock)[] = [
+    ...headBlocks,
+    ...params.lines.slice(-lineBudget).map((line) => ({
       type: "section" as const,
       fields: [field(legacyLineTitle(line)), field(legacyLineDetail(line, maxLineChars))],
     })),
-  ].slice(-SLACK_MAX_BLOCKS);
+  ];
   return renderedBlocks.length ? renderedBlocks : undefined;
+}
+
+export type SlackNativeTaskSnapshot = ReadonlyMap<
+  string,
+  { title: string; status: SlackPlanTaskStatus }
+>;
+
+/**
+ * Slack native streams key task rows by persistent id with no removal chunk.
+ * When the task source switches representation (tool lines <-> typed plan) or
+ * a snapshot drops ids, previously emitted non-terminal rows must receive a
+ * final update or they linger in_progress forever.
+ */
+export function reconcileSlackNativeTaskChunks(params: {
+  previousTasks: SlackNativeTaskSnapshot;
+  chunks: AnyChunk[] | undefined;
+}): { chunks: AnyChunk[] | undefined; tasks: SlackNativeTaskSnapshot } {
+  const nextTasks = new Map<string, { title: string; status: SlackPlanTaskStatus }>();
+  for (const chunk of params.chunks ?? []) {
+    if (chunk.type === "task_update") {
+      nextTasks.set(chunk.id, {
+        title: chunk.title,
+        status: chunk.status as SlackPlanTaskStatus,
+      });
+    }
+  }
+  const orphaned = [...params.previousTasks].filter(
+    ([id, task]) => !nextTasks.has(id) && task.status !== "complete" && task.status !== "error",
+  );
+  const terminalized = orphaned.map(([id, task]) => {
+    const entry = { title: task.title, status: "complete" as const };
+    nextTasks.set(id, entry);
+    return {
+      type: "task_update" as const,
+      id,
+      title: task.title,
+      status: "complete" as const,
+    };
+  });
+  // Carry forward already-terminal rows so a later reappearance diffs correctly.
+  for (const [id, task] of params.previousTasks) {
+    if (!nextTasks.has(id)) {
+      nextTasks.set(id, task);
+    }
+  }
+  // An explicitly cleared source still needs its previous rows retired even
+  // when the current build produced no chunks of its own.
+  const chunks = params.chunks?.length
+    ? [...params.chunks, ...terminalized]
+    : terminalized.length
+      ? terminalized
+      : params.chunks;
+  return { chunks, tasks: nextTasks };
 }
 
 export function buildSlackProgressStreamStartChunks(params: {
   label?: string;
   title?: string;
   lines: readonly ChannelProgressDraftLine[];
+  plan?: readonly AgentPlanStep[];
   maxLineChars?: number;
 }): AnyChunk[] | undefined {
   return buildSlackProgressStreamChunks(params);
@@ -235,6 +340,7 @@ export function buildSlackProgressStreamUpdateChunks(params: {
   label?: string;
   title?: string;
   lines: readonly ChannelProgressDraftLine[];
+  plan?: readonly AgentPlanStep[];
   maxLineChars?: number;
 }): AnyChunk[] | undefined {
   return buildSlackProgressStreamChunks(params);
@@ -244,6 +350,7 @@ export function buildSlackProgressStreamCompletionChunks(params: {
   label?: string;
   title?: string;
   lines: readonly ChannelProgressDraftLine[];
+  plan?: readonly AgentPlanStep[];
   maxLineChars?: number;
   finalInProgressStatus?: SlackPlanTaskStatus;
 }): AnyChunk[] | undefined {

--- a/extensions/telegram/src/bot-message-dispatch-progress.ts
+++ b/extensions/telegram/src/bot-message-dispatch-progress.ts
@@ -65,7 +65,10 @@ export function createTelegramProgressController(params: {
     mode: params.streamMode,
     active: Boolean(answerLane.stream),
     seed: `${params.accountId}:${params.chatId}:${params.threadId ?? ""}`,
-    formatLine: (text) => (compositor.hasStatusHeadline ? text : formatTelegramProgressLine(text)),
+    formatLine: (text) =>
+      compositor.hasStatusHeadline || compositor.hasPlanProgress
+        ? text
+        : formatTelegramProgressLine(text),
     reasoningGate: params.streamReasoningInProgressDraft,
     reasoningLinePrefix: "🧠 ",
     commentaryLinePrefix: "💬 ",
@@ -81,7 +84,7 @@ export function createTelegramProgressController(params: {
           streamText,
           options?.lines ?? [],
           params.telegramCfg.richMessages === true,
-          compositor.hasStatusHeadline,
+          compositor.hasStatusHeadline || compositor.hasPlanProgress,
         ),
       );
       if (options?.flush) {
@@ -253,16 +256,10 @@ export function createTelegramProgressController(params: {
     );
   };
   const handlePlanUpdate = async (payload: CallbackPayload<"onPlanUpdate">) => {
-    if (payload.phase === "update") {
-      await pushToolProgress(
-        buildChannelProgressDraftLine({
-          event: "plan",
-          phase: payload.phase,
-          title: payload.title,
-          explanation: payload.explanation,
-          steps: payload.steps,
-        }),
-      );
+    if (payload.phase === "update" && canPushToolProgress()) {
+      await compositor.pushPlanProgress(payload.planSteps, {
+        explanation: payload.explanation,
+      });
     }
   };
   const handleApprovalEvent = async (payload: CallbackPayload<"onApprovalEvent">) => {

--- a/extensions/telegram/src/bot-message-dispatch.progress-rendering.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.progress-rendering.test.ts
@@ -30,6 +30,61 @@ import {
 import type { TelegramMessageContext } from "./bot-message-dispatch.test-harness.js";
 
 describeTelegramDispatch("dispatchTelegramMessage progress-rendering", () => {
+  it("renders typed plan updates as a live checklist", async () => {
+    const draftStream = createSequencedDraftStream(2001);
+    createTelegramDraftStream.mockReturnValue(draftStream);
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ replyOptions }) => {
+      await replyOptions?.onPlanUpdate?.({
+        phase: "update",
+        explanation: "Implementing the change.",
+        planSteps: [
+          { step: "Inspect", status: "completed" },
+          { step: "Patch", status: "in_progress" },
+          { step: "Test", status: "pending" },
+        ],
+      });
+      return { queuedFinal: false };
+    });
+
+    await dispatchWithContext({
+      context: createContext(),
+      streamMode: "progress",
+      telegramCfg: { streaming: { mode: "progress", progress: { label: false } } },
+    });
+
+    expect(draftStream.updatePreview).toHaveBeenLastCalledWith(
+      telegramProgressPreview(
+        "Implementing the change.\n\n✅ Inspect\n▸ Patch\n▢ Test",
+        "<b>Implementing the change.</b><br>✅ Inspect<br>▸ Patch<br>▢ Test",
+      ),
+    );
+  });
+
+  it("renders plan checklists when the explanation is omitted", async () => {
+    const draftStream = createSequencedDraftStream(2001);
+    createTelegramDraftStream.mockReturnValue(draftStream);
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ replyOptions }) => {
+      await replyOptions?.onPlanUpdate?.({
+        phase: "update",
+        planSteps: [
+          { step: "Patch", status: "in_progress" },
+          { step: "Test", status: "pending" },
+        ],
+      });
+      return { queuedFinal: false };
+    });
+
+    await dispatchWithContext({
+      context: createContext(),
+      streamMode: "progress",
+      telegramCfg: { streaming: { mode: "progress", progress: { label: false } } },
+    });
+
+    expect(draftStream.updatePreview).toHaveBeenLastCalledWith(
+      telegramProgressPreview("▸ Patch\n▢ Test", "<b>▸ Patch</b><br>▢ Test"),
+    );
+  });
+
   it("renders the headline immediately when the preamble arrives after tool progress", async () => {
     const draftStream = createSequencedDraftStream(2001);
     createTelegramDraftStream.mockReturnValue(draftStream);

--- a/scripts/plugin-sdk-surface-report.mjs
+++ b/scripts/plugin-sdk-surface-report.mjs
@@ -105,7 +105,7 @@ const defaultPublicDeprecatedExportsByEntrypointBudget = Object.freeze({
   "secret-provider-integration": 4,
   "setup-adapter-runtime": 1,
   "skills-runtime": 5,
-  "channel-streaming": 49,
+  "channel-streaming": 55,
   "approval-gateway-runtime": 1,
   "approval-handler-runtime": 1,
   "approval-reply-runtime": 3,
@@ -157,8 +157,8 @@ const defaultPublicDeprecatedExportsByEntrypointBudget = Object.freeze({
   "channel-lifecycle": 23,
   // Registry sweep: 77 packages, zero fetch failures; channel-ingress and dead aliases
   // had zero consumers.
-  "channel-message": 224,
-  "channel-message-runtime": 221,
+  "channel-message": 230,
+  "channel-message-runtime": 227,
   "channel-pairing-paths": 1,
   // Deprecated pairing/conversation exports from the SQLite pairing migration
   // landed on main (#105802) without entrypoint pins; not touched by this PR.
@@ -223,7 +223,10 @@ export function readPluginSdkSurfaceBudgets(env = process.env) {
       // +4: group scope encoder/key builder (channel-policy + compat mirror).
       // Harvest: channel-ingress -64; dead channel-message dispatch aliases -23.
       // Harvest: retired qa-live-transport-scenarios subpath -6.
-      10606,
+      // +12: typed plan step/status and checklist formatter across channel barrels.
+      // +8: plan-step ingress union and normalizer across channel barrels.
+      // +4: dual-field plan payload builder for the steps deprecation window.
+      10630,
       env,
     ),
     publicFunctionExports: readPluginSdkSurfaceBudgetEnv(
@@ -232,7 +235,10 @@ export function readPluginSdkSurfaceBudgets(env = process.env) {
       // +4: group scope encoder/key builder (channel-policy + compat mirror).
       // Harvest: channel-ingress -19; dead channel-message dispatch aliases -23.
       // Harvest: retired qa-live-transport-scenarios subpath -3.
-      5341,
+      // +4: shared plan checklist formatter across channel barrels.
+      // +4: plan-step normalizer across channel barrels.
+      // +4: dual-field plan payload builder for the steps deprecation window.
+      5353,
       env,
     ),
     publicDeprecatedExports: readPluginSdkSurfaceBudgetEnv(
@@ -240,7 +246,10 @@ export function readPluginSdkSurfaceBudgets(env = process.env) {
       // +2: group scope encoder/key builder mirrored by deprecated compat.
       // Harvest: channel-ingress -8; dead channel-message dispatch aliases -23.
       // +77: five zero-consumer subpaths enter their removal window.
-      3339,
+      // +9: typed plan exports and formatter through deprecated channel barrels.
+      // +6: plan-step ingress union and normalizer through deprecated channel barrels.
+      // +3: dual-field plan payload builder through deprecated channel barrels.
+      3357,
       env,
     ),
     publicWildcardReexports: readPluginSdkSurfaceBudgetEnv(

--- a/src/agents/cli-output.test.ts
+++ b/src/agents/cli-output.test.ts
@@ -1089,6 +1089,38 @@ describe("parseCliOutput", () => {
 });
 
 describe("createCliJsonlStreamingParser", () => {
+  it("surfaces codex-exec todo snapshots as typed plan updates", () => {
+    const plans: Array<{ steps: Array<{ step: string; status: string }> }> = [];
+    const parser = createCliJsonlStreamingParser({
+      backend: { command: "codex", output: "jsonl", sessionIdFields: ["thread_id"] },
+      providerId: "codex-cli",
+      onAssistantDelta: () => {},
+      onPlanUpdate: (plan) => plans.push(plan),
+    });
+
+    parser.push(
+      `${JSON.stringify({
+        type: "item.updated",
+        item: {
+          type: "todo_list",
+          items: [
+            { text: "Inspect", completed: true },
+            { text: "Patch", completed: false },
+          ],
+        },
+      })}\n`,
+    );
+
+    expect(plans).toEqual([
+      {
+        steps: [
+          { step: "Inspect", status: "completed" },
+          { step: "Patch", status: "pending" },
+        ],
+      },
+    ]);
+  });
+
   it("streams Claude stream-json deltas for an explicit backend dialect", () => {
     const deltas: Array<{ text: string; delta: string; sessionId?: string }> = [];
     const sessionIds: string[] = [];

--- a/src/agents/cli-output.ts
+++ b/src/agents/cli-output.ts
@@ -5,6 +5,7 @@
  */
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
+import type { AgentPlanStep } from "../channels/streaming.js";
 import type { CliBackendConfig } from "../config/types.js";
 import { extractBalancedJsonFragments } from "../shared/balanced-json.js";
 import { isRecord } from "../utils.js";
@@ -121,6 +122,10 @@ export type CliThinkingDelta = {
 
 export type CliThinkingProgress = {
   progressTokens: number;
+};
+
+export type CliPlanUpdate = {
+  steps: AgentPlanStep[];
 };
 
 /** Tool-call start event reconstructed from CLI stream output. */
@@ -1199,6 +1204,7 @@ export function createCliJsonlStreamingParser(params: {
   onAssistantDelta: (delta: CliStreamingDelta) => void;
   onThinkingDelta?: (delta: CliThinkingDelta) => void;
   onThinkingProgress?: (progress: CliThinkingProgress) => void;
+  onPlanUpdate?: (update: CliPlanUpdate) => void;
   onToolUseStart?: (delta: CliToolUseStartDelta) => void;
   onToolResult?: (delta: CliToolResultDelta) => void;
   onCommentaryText?: (text: string) => void;
@@ -1320,6 +1326,23 @@ export function createCliJsonlStreamingParser(params: {
     }
 
     const item = isRecord(parsed.item) ? parsed.item : null;
+    if (item?.type === "todo_list" && Array.isArray(item.items)) {
+      const steps = item.items.flatMap((entry) => {
+        if (!isRecord(entry) || typeof entry.text !== "string") {
+          return [];
+        }
+        return [
+          {
+            step: entry.text,
+            // codex exec JSONL exposes only a completed boolean for todo items.
+            status: entry.completed === true ? ("completed" as const) : ("pending" as const),
+          },
+        ];
+      });
+      if (steps.length > 0) {
+        params.onPlanUpdate?.({ steps });
+      }
+    }
     if (item && typeof item.text === "string") {
       const type = normalizeLowercaseStringOrEmpty(item.type);
       if (!type || type.includes("message")) {

--- a/src/agents/cli-runner/execute.ts
+++ b/src/agents/cli-runner/execute.ts
@@ -48,6 +48,7 @@ import {
   extractCliErrorMessage,
   parseCliOutput,
   type CliOutput,
+  type CliPlanUpdate,
   type CliStreamingDelta,
   type CliThinkingDelta,
   type CliThinkingProgress,
@@ -1513,6 +1514,22 @@ export async function executePreparedCliRun(
             data: { progressTokens },
           });
         };
+        const emitCliPlanUpdate = ({ steps }: CliPlanUpdate) => {
+          observedCliActivity = true;
+          if (!emitLiveEvents) {
+            return;
+          }
+          emitAgentEvent({
+            runId: params.runId,
+            stream: "plan",
+            data: {
+              phase: "update",
+              title: "Plan updated",
+              source: "codex-exec",
+              steps,
+            },
+          });
+        };
         if (useManagedClaudeLiveSession) {
           if (!hasJsonlOutput) {
             throw new Error("Claude live session requires JSONL streaming parser");
@@ -1578,6 +1595,7 @@ export async function executePreparedCliRun(
                 onAssistantDelta: emitCliAssistantDelta,
                 onThinkingDelta: emitCliThinkingDelta,
                 onThinkingProgress: emitCliThinkingProgress,
+                onPlanUpdate: emitCliPlanUpdate,
                 onToolUseStart: emitParsedToolUseStart,
                 onToolResult: emitParsedToolResult,
                 onCommentaryText:

--- a/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
@@ -151,6 +151,52 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+describe("update_plan progress events", () => {
+  it("emits the typed full plan snapshot after a successful result", async () => {
+    const { ctx, onAgentEvent } = createTestContext();
+    const emitted: CapturedAgentEvent[] = [];
+    const unsubscribe = registerAgentEventListener((event) => emitted.push(event));
+    try {
+      await handleToolExecutionEnd(ctx, {
+        type: "tool_execution_end",
+        toolName: "update_plan",
+        toolCallId: "plan-1",
+        isError: false,
+        result: {
+          content: [],
+          details: {
+            status: "updated",
+            explanation: "Implementation underway",
+            plan: [
+              { step: "Inspect", status: "completed" },
+              { step: "Patch", status: "in_progress" },
+            ],
+          },
+        },
+      });
+      await Promise.resolve();
+
+      const expected = {
+        stream: "plan",
+        data: {
+          phase: "update",
+          title: "Plan updated",
+          source: "openclaw",
+          explanation: "Implementation underway",
+          steps: [
+            { step: "Inspect", status: "completed" },
+            { step: "Patch", status: "in_progress" },
+          ],
+        },
+      };
+      expect(onAgentEvent).toHaveBeenCalledWith(expected);
+      expect(emitted).toContainEqual(expect.objectContaining(expected));
+    } finally {
+      unsubscribe();
+    }
+  });
+});
+
 function requireRecord(value: unknown, label: string): Record<string, unknown> {
   if (!isRecord(value)) {
     throw new Error(`expected ${label} to be an object`);

--- a/src/agents/embedded-agent-subscribe.handlers.tools.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.ts
@@ -15,6 +15,7 @@ import {
   HEARTBEAT_RESPONSE_TOOL_NAME,
   normalizeHeartbeatToolResponse,
 } from "../auto-reply/heartbeat-tool-response.js";
+import type { AgentPlanStep } from "../channels/streaming.js";
 import { parseSessionThreadInfoFast } from "../config/sessions/thread-info.js";
 import type {
   AgentApprovalEventData,
@@ -113,6 +114,31 @@ const TRACE_REQUIRED_PARAM_GROUPS = {
   write: REQUIRED_PARAM_GROUPS.write,
   edit: REQUIRED_PARAM_GROUPS.edit,
 } satisfies Record<string, readonly RequiredParamGroup[]>;
+
+function readUpdatePlanResult(
+  result: unknown,
+): { explanation?: string; steps: AgentPlanStep[] } | undefined {
+  const details = readToolResultDetails(result);
+  if (details?.status !== "updated" || !Array.isArray(details.plan)) {
+    return undefined;
+  }
+  const steps = details.plan.flatMap((entry) => {
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+      return [];
+    }
+    const step = (entry as { step?: unknown }).step;
+    const status = (entry as { status?: unknown }).status;
+    if (
+      typeof step !== "string" ||
+      (status !== "pending" && status !== "in_progress" && status !== "completed")
+    ) {
+      return [];
+    }
+    return [{ step, status }];
+  });
+  const explanation = readStringValue(details.explanation);
+  return { ...(explanation ? { explanation } : {}), steps };
+}
 
 function isMiddlewareToolResultError(result: unknown): boolean {
   if (!result || typeof result !== "object") {
@@ -1454,6 +1480,22 @@ export async function handleToolExecutionEnd(
         });
       }
     }
+  }
+
+  const planUpdate =
+    !isToolError && toolName === "update_plan" ? readUpdatePlanResult(sanitizedResult) : undefined;
+  if (planUpdate) {
+    const planEvent = {
+      stream: "plan" as const,
+      data: {
+        phase: "update",
+        title: "Plan updated",
+        source: "openclaw",
+        ...planUpdate,
+      },
+    };
+    emitAgentEvent({ runId: ctx.params.runId, ...planEvent });
+    emitAgentEventCallbackBestEffort(ctx, planEvent);
   }
 
   emitAgentEvent({

--- a/src/agents/embedded-agent-subscribe.handlers.tools.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.ts
@@ -15,7 +15,7 @@ import {
   HEARTBEAT_RESPONSE_TOOL_NAME,
   normalizeHeartbeatToolResponse,
 } from "../auto-reply/heartbeat-tool-response.js";
-import type { AgentPlanStep } from "../channels/streaming.js";
+import { type AgentPlanStep, normalizeAgentPlanSteps } from "../channels/streaming.js";
 import { parseSessionThreadInfoFast } from "../config/sessions/thread-info.js";
 import type {
   AgentApprovalEventData,
@@ -122,20 +122,7 @@ function readUpdatePlanResult(
   if (details?.status !== "updated" || !Array.isArray(details.plan)) {
     return undefined;
   }
-  const steps = details.plan.flatMap((entry) => {
-    if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
-      return [];
-    }
-    const step = (entry as { step?: unknown }).step;
-    const status = (entry as { status?: unknown }).status;
-    if (
-      typeof step !== "string" ||
-      (status !== "pending" && status !== "in_progress" && status !== "completed")
-    ) {
-      return [];
-    }
-    return [{ step, status }];
-  });
+  const steps = normalizeAgentPlanSteps(details.plan) ?? [];
   const explanation = readStringValue(details.explanation);
   return { ...(explanation ? { explanation } : {}), steps };
 }

--- a/src/agents/execution-contract.ts
+++ b/src/agents/execution-contract.ts
@@ -41,8 +41,7 @@ const STRICT_AGENTIC_MODEL_ID_PATTERN = /^gpt-5(?:[.o-]|$)/i;
 /**
  * Supported provider + model combinations where strict-agentic is the intended
  * runtime contract. Kept as a narrow helper so both the execution-contract
- * resolver and the `update_plan` auto-enable gate converge on the same
- * definition of "GPT-5-family OpenAI run". The embedded
+ * resolver uses for the GPT-5-family OpenAI strict-agentic default. The embedded
  * `mock-openai` QA lane intentionally piggybacks on that contract so repo QA
  * can exercise the same incomplete-turn recovery rules end to end.
  */

--- a/src/agents/openclaw-tools.registration.ts
+++ b/src/agents/openclaw-tools.registration.ts
@@ -5,7 +5,6 @@
  */
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { isStrictAgenticExecutionContractActive } from "./execution-contract.js";
 import { isToolAllowedByPolicyName } from "./tool-policy-match.js";
 import type { AnyAgentTool } from "./tools/common.js";
 
@@ -22,7 +21,7 @@ export function collectPresentOpenClawTools(
   return candidates.filter((tool): tool is AnyAgentTool => tool !== null && tool !== undefined);
 }
 
-/** Resolves the default update_plan switch from explicit config or strict execution contract. */
+/** Resolves the default-on update_plan switch with an explicit kill switch. */
 function isUpdatePlanToolEnabledForOpenClawTools(params: {
   config?: OpenClawConfig;
   agentSessionKey?: string;
@@ -30,36 +29,7 @@ function isUpdatePlanToolEnabledForOpenClawTools(params: {
   modelProvider?: string;
   modelId?: string;
 }): boolean {
-  const configured = params.config?.tools?.experimental?.planTool;
-  if (configured !== undefined) {
-    return configured;
-  }
-  return isStrictAgenticExecutionContractActive({
-    config: params.config,
-    sessionKey: params.agentSessionKey,
-    agentId: params.agentId,
-    provider: params.modelProvider,
-    modelId: params.modelId,
-  });
-}
-
-function mergeOpenClawToolPolicyList(...lists: Array<string[] | undefined>): string[] | undefined {
-  const merged = lists.flatMap((list) => (Array.isArray(list) ? list : []));
-  return merged.length > 0 ? uniqueStrings(merged) : undefined;
-}
-
-function isToolExplicitlyAllowedByOpenClawToolPolicy(params: {
-  toolName: string;
-  allowlist?: string[];
-  denylist?: string[];
-}): boolean {
-  if (!params.allowlist?.some((entry) => typeof entry === "string" && entry.trim().length > 0)) {
-    return false;
-  }
-  return isToolAllowedByPolicyName(params.toolName, {
-    allow: params.allowlist,
-    deny: params.denylist,
-  });
+  return params.config?.tools?.experimental?.planTool !== false;
 }
 
 /** Decides whether update_plan should be included in the assembled OpenClaw tool set. */
@@ -72,27 +42,12 @@ export function shouldIncludeUpdatePlanToolForOpenClawTools(params: {
   pluginToolAllowlist?: string[];
   pluginToolDenylist?: string[];
 }): boolean {
-  const allowlist = mergeOpenClawToolPolicyList(
-    params.config?.tools?.allow,
-    params.config?.tools?.alsoAllow,
-    params.pluginToolAllowlist,
-  );
-  const denylist = mergeOpenClawToolPolicyList(
-    params.config?.tools?.deny,
-    params.pluginToolDenylist,
-  );
+  const deny = uniqueStrings([
+    ...(params.config?.tools?.deny ?? []),
+    ...(params.pluginToolDenylist ?? []),
+  ]);
   return (
-    isToolExplicitlyAllowedByOpenClawToolPolicy({
-      toolName: "update_plan",
-      allowlist,
-      denylist,
-    }) ||
-    isUpdatePlanToolEnabledForOpenClawTools({
-      config: params.config,
-      agentSessionKey: params.agentSessionKey,
-      agentId: params.agentId,
-      modelProvider: params.modelProvider,
-      modelId: params.modelId,
-    })
+    isUpdatePlanToolEnabledForOpenClawTools(params) &&
+    isToolAllowedByPolicyName("update_plan", { deny })
   );
 }

--- a/src/agents/openclaw-tools.update-plan.test.ts
+++ b/src/agents/openclaw-tools.update-plan.test.ts
@@ -42,24 +42,6 @@ function expectToolNamed(
   return tool;
 }
 
-function openAiGpt5Params(
-  config: OpenClawConfig,
-  overrides: Partial<UpdatePlanGatingParams> = {},
-): UpdatePlanGatingParams {
-  // Common OpenAI GPT-5 selection used by model-aware update_plan gates.
-  const params: UpdatePlanGatingParams = {
-    config,
-    agentSessionKey: "agent:main:main",
-    modelProvider: "openai",
-    modelId: "gpt-5.4",
-    ...overrides,
-  };
-  if ("agentId" in overrides && !("agentSessionKey" in overrides)) {
-    delete params.agentSessionKey;
-  }
-  return params;
-}
-
 describe("openclaw-tools update_plan gating", () => {
   afterEach(() => {
     setEmbeddedMode(false);
@@ -82,11 +64,11 @@ describe("openclaw-tools update_plan gating", () => {
     ).toEqual([]);
   });
 
-  it("keeps update_plan disabled by default", () => {
-    expectUpdatePlanEnabled({ config: {} as OpenClawConfig }, false);
+  it("enables update_plan by default", () => {
+    expectUpdatePlanEnabled({ config: {} as OpenClawConfig }, true);
   });
 
-  it("does not expose update_plan from default tool construction", () => {
+  it("exposes update_plan from default tool construction for every embedded model", () => {
     const defaultTools = createFastToolNames({
       config: {} as OpenClawConfig,
       modelProvider: "anthropic",
@@ -99,8 +81,8 @@ describe("openclaw-tools update_plan gating", () => {
       modelId: "claude-sonnet-4-6",
     };
 
-    expect(defaultTools).not.toContain("update_plan");
-    expect(shouldIncludeUpdatePlanToolForOpenClawTools(emptyAllowlistParams)).toBe(false);
+    expect(defaultTools).toContain("update_plan");
+    expect(shouldIncludeUpdatePlanToolForOpenClawTools(emptyAllowlistParams)).toBe(true);
   });
 
   it("wraps constructed tools with before-tool-call hooks by default", () => {
@@ -282,8 +264,8 @@ describe("openclaw-tools update_plan gating", () => {
     expect(includeUpdatePlan).toBe(true);
   });
 
-  it("respects deny policy for grouped allowlists", () => {
-    const includeUpdatePlan = shouldIncludeUpdatePlanToolForOpenClawTools({
+  it("leaves normal deny policy enforcement to the assembled tool set", () => {
+    const tools = createFastToolNames({
       config: {} as OpenClawConfig,
       pluginToolAllowlist: ["group:agents"],
       pluginToolDenylist: ["update_plan"],
@@ -291,152 +273,27 @@ describe("openclaw-tools update_plan gating", () => {
       modelId: "claude-sonnet-4-6",
     });
 
-    expect(includeUpdatePlan).toBe(false);
+    expect(tools).not.toContain("update_plan");
   });
 
-  it("auto-enables update_plan for unconfigured GPT-5 openai runs", () => {
-    // Unspecified executionContract on a supported provider/model enables the
-    // structured plan tool by default. Explicit "default" still opts out.
-    const cfg = {
-      agents: {
-        list: [{ id: "main" }],
-      },
-    } as OpenClawConfig;
-
-    expectUpdatePlanEnabled(openAiGpt5Params(cfg), true);
-  });
-
-  it("respects explicit default contract opt-out on GPT-5 runs", () => {
-    // Users who explicitly set executionContract: "default" are saying they
-    // want the old pre-parity-program behavior. Honor that opt-out.
-    const cfg = {
-      agents: {
-        defaults: {
-          embeddedAgent: {
-            executionContract: "default",
-          },
-        },
-        list: [{ id: "main" }],
-      },
-    } as OpenClawConfig;
-
-    expectUpdatePlanEnabled(openAiGpt5Params(cfg), false);
-  });
-
-  it("does not auto-enable update_plan for non-openai providers even when unconfigured", () => {
-    const cfg = {
-      agents: {
-        list: [{ id: "main" }],
-      },
-    } as OpenClawConfig;
-
-    expectUpdatePlanEnabled(
-      openAiGpt5Params(cfg, { modelProvider: "anthropic", modelId: "claude-sonnet-4-6" }),
-      false,
-    );
-    expectUpdatePlanEnabled(openAiGpt5Params(cfg, { modelId: "gpt-4.1" }), false);
-  });
-
-  it("auto-enables update_plan for strict-agentic GPT-5 agents", () => {
-    const cfg = {
-      agents: {
-        defaults: {
-          embeddedAgent: {
-            executionContract: "strict-agentic",
-          },
-        },
-        list: [{ id: "main" }],
-      },
-    } as OpenClawConfig;
-
-    expectUpdatePlanEnabled(openAiGpt5Params(cfg), true);
-  });
-
-  it("does not auto-enable update_plan for unsupported providers or models", () => {
-    const cfg = {
-      agents: {
-        defaults: {
-          embeddedAgent: {
-            executionContract: "strict-agentic",
-          },
-        },
-        list: [{ id: "main" }],
-      },
-    } as OpenClawConfig;
-
-    expectUpdatePlanEnabled(
-      openAiGpt5Params(cfg, { modelProvider: "anthropic", modelId: "claude-sonnet-4-6" }),
-      false,
-    );
-    expectUpdatePlanEnabled(openAiGpt5Params(cfg, { modelId: "gpt-4.1" }), false);
-  });
-
-  it("lets explicit planTool false override strict-agentic auto-enable", () => {
+  it("lets explicit planTool false disable every model and override allowlists", () => {
     const cfg = {
       tools: {
         experimental: {
           planTool: false,
         },
       },
-      agents: {
-        defaults: {
-          embeddedAgent: {
-            executionContract: "strict-agentic",
-          },
-        },
-        list: [{ id: "main" }],
-      },
     } as OpenClawConfig;
 
-    expectUpdatePlanEnabled(openAiGpt5Params(cfg), false);
-  });
-
-  it("resolves strict-agentic gating from explicit agentId when no session key is available", () => {
-    const cfg = {
-      agents: {
-        defaults: {
-          embeddedAgent: {
-            executionContract: "default",
-          },
-        },
-        list: [
-          { id: "main" },
-          {
-            id: "research",
-            embeddedAgent: {
-              executionContract: "strict-agentic",
-            },
-          },
-        ],
+    expectUpdatePlanEnabled({ config: cfg, modelProvider: "openai", modelId: "gpt-5.4" }, false);
+    expectUpdatePlanEnabled(
+      {
+        config: cfg,
+        modelProvider: "anthropic",
+        modelId: "claude-sonnet-4-6",
+        pluginToolAllowlist: ["update_plan"],
       },
-    } as OpenClawConfig;
-
-    expectUpdatePlanEnabled(openAiGpt5Params(cfg, { agentId: "research" }), true);
-  });
-
-  it("applies per-agent overrides without leaking the contract to other agents", () => {
-    const cfg = {
-      agents: {
-        defaults: {
-          embeddedAgent: {
-            executionContract: "strict-agentic",
-          },
-        },
-        list: [
-          {
-            id: "main",
-            embeddedAgent: {
-              executionContract: "default",
-            },
-          },
-          {
-            id: "research",
-          },
-        ],
-      },
-    } as OpenClawConfig;
-
-    expectUpdatePlanEnabled(openAiGpt5Params(cfg, { agentId: "main" }), false);
-    expectUpdatePlanEnabled(openAiGpt5Params(cfg, { agentId: "research" }), true);
+      false,
+    );
   });
 });

--- a/src/agents/tool-description-presets.ts
+++ b/src/agents/tool-description-presets.ts
@@ -94,8 +94,5 @@ export function describeSessionStatusTool(): string {
 
 /** Describes the update_plan tool for model-facing instructions. */
 export function describeUpdatePlanTool(): string {
-  return [
-    "Update run plan for non-trivial multi-step work; keep current.",
-    "Short steps; max one `in_progress`; skip simple one-step.",
-  ].join(" ");
+  return "Use for multi-step work. Send the full list each call; keep statuses current and exactly one `in_progress` until done.";
 }

--- a/src/auto-reply/get-reply-options.types.ts
+++ b/src/auto-reply/get-reply-options.types.ts
@@ -1,5 +1,6 @@
 import type { FastMode } from "@openclaw/normalization-core/string-coerce";
 /** Public option types for reply generation callbacks, streaming, and delivery policy. */
+import type { AgentPlanStep } from "../channels/streaming.js";
 import type { ImageContent } from "../llm/types.js";
 import type { PromptImageOrderEntry } from "../media/prompt-image-order.js";
 import type { UserTurnTranscriptRecorder } from "../sessions/user-turn-transcript.types.js";
@@ -225,7 +226,14 @@ export type GetReplyOptions = {
     phase?: string;
     title?: string;
     explanation?: string;
+    /**
+     * @deprecated Shipped pre-2026.8 shape: plain step text without statuses.
+     * Still populated for existing consumers; migrate to `planSteps` and
+     * remove with the deprecation window.
+     */
     steps?: string[];
+    /** Canonical typed checklist snapshot; replaces `steps`. */
+    planSteps?: AgentPlanStep[];
     source?: string;
   }) => Promise<void> | void;
   /** Called when an approval becomes pending or resolves. */

--- a/src/auto-reply/reply/agent-event-bridge.ts
+++ b/src/auto-reply/reply/agent-event-bridge.ts
@@ -1,0 +1,79 @@
+// Generic agent-event bridge machinery shared by the CLI runner's per-stream
+// delivery bridges (assistant, reasoning, commentary, plan).
+import { type AgentEventPayload, onAgentEvent } from "../../infra/agent-events.js";
+
+export type AgentEventDeliveryStartOrder = {
+  schedule: (deliver: () => Promise<void>) => Promise<void>;
+};
+
+export function createAgentEventDeliveryStartOrder(): AgentEventDeliveryStartOrder {
+  let startTail = Promise.resolve();
+  return {
+    schedule: async (deliver) => {
+      // Reserve at raw event receipt, then release at callback invocation. CLI streams drain
+      // independently, so waiting for callback completion here would reorder later streams.
+      const previousStart = startTail;
+      let releaseStart: (() => void) | undefined;
+      startTail = new Promise<void>((resolve) => {
+        releaseStart = resolve;
+      });
+      await previousStart;
+      let delivery: Promise<void>;
+      try {
+        delivery = deliver();
+      } finally {
+        releaseStart?.();
+      }
+      await delivery;
+    },
+  };
+}
+
+export function createAgentEventBridge<T>(params: {
+  runId: string;
+  suppressed?: boolean;
+  read: (evt: AgentEventPayload) => T | undefined;
+  deliver?: (payload: T) => Promise<void>;
+  startOrder?: AgentEventDeliveryStartOrder;
+}) {
+  const deliver = params.deliver;
+  if (!deliver) {
+    return {
+      unsubscribe: () => undefined,
+      drain: async (): Promise<void> => undefined,
+    };
+  }
+  let unsubscribed = false;
+  let delivery = Promise.resolve();
+  const rawUnsubscribe = onAgentEvent((evt) => {
+    if (evt.runId !== params.runId) {
+      return;
+    }
+    if (params.suppressed) {
+      return;
+    }
+    const payload = params.read(evt);
+    if (payload === undefined) {
+      return;
+    }
+    if (!params.startOrder) {
+      delivery = delivery.then(() => deliver(payload)).catch(() => undefined);
+      return;
+    }
+    const scheduled = params.startOrder.schedule(() => deliver(payload)).catch(() => undefined);
+    // Start ordering stays global; each bridge still owns and drains its callback completion.
+    delivery = Promise.all([delivery, scheduled]).then(() => undefined);
+  });
+  return {
+    unsubscribe() {
+      if (unsubscribed) {
+        return;
+      }
+      unsubscribed = true;
+      rawUnsubscribe();
+    },
+    async drain(): Promise<void> {
+      await delivery;
+    },
+  };
+}

--- a/src/auto-reply/reply/agent-runner-cli-candidate.ts
+++ b/src/auto-reply/reply/agent-runner-cli-candidate.ts
@@ -161,6 +161,7 @@ export async function runCliFallbackCandidate(params: {
             );
           },
           onReasoningText: createCliReasoningStreamBridge(turn.opts?.onReasoningStream),
+          onPlanUpdate: turn.opts?.onPlanUpdate,
           onReasoningProgress: async (payload) => {
             await turn.opts?.onReasoningProgress?.(payload);
           },

--- a/src/auto-reply/reply/agent-runner-cli-dispatch.test.ts
+++ b/src/auto-reply/reply/agent-runner-cli-dispatch.test.ts
@@ -38,6 +38,99 @@ afterEach(() => {
 });
 
 describe("runCliAgentWithLifecycle", () => {
+  it("bridges typed CLI plan events", async () => {
+    cliDispatchState.runCliAgentMock.mockImplementationOnce(async (params: { runId: string }) => {
+      emitAgentEvent({
+        runId: params.runId,
+        stream: "plan",
+        data: {
+          phase: "update",
+          title: "Plan updated",
+          source: "codex-exec",
+          steps: [
+            { step: "Inspect", status: "completed" },
+            { step: "Patch", status: "pending" },
+          ],
+        },
+      });
+      return { payloads: [], meta: { durationMs: 1 } };
+    });
+    const onPlanUpdate = vi.fn(async () => undefined);
+
+    await runCliAgentWithLifecycle({
+      runId: "run-plan-bridge",
+      provider: "codex-cli",
+      onPlanUpdate,
+      runParams: {
+        sessionId: "session-1",
+        sessionFile: "/tmp/session.jsonl",
+        workspaceDir: "/tmp/workspace",
+        prompt: "hello",
+        provider: "codex-cli",
+        model: "codex",
+        thinkLevel: "high",
+        timeoutMs: 1_000,
+        runId: "run-plan-bridge",
+      },
+    });
+
+    expect(onPlanUpdate).toHaveBeenCalledWith({
+      phase: "update",
+      title: "Plan updated",
+      explanation: undefined,
+      source: "codex-exec",
+      steps: ["Inspect", "Patch"],
+      planSteps: [
+        { step: "Inspect", status: "completed" },
+        { step: "Patch", status: "pending" },
+      ],
+    });
+  });
+
+  it("normalizes shipped string-step plan events to pending typed steps", async () => {
+    cliDispatchState.runCliAgentMock.mockImplementationOnce(async (params: { runId: string }) => {
+      emitAgentEvent({
+        runId: params.runId,
+        stream: "plan",
+        data: {
+          phase: "update",
+          title: "Plan updated",
+          source: "codex-exec",
+          steps: ["Inspect", "  ", "Patch"],
+        },
+      });
+      return { payloads: [], meta: { durationMs: 1 } };
+    });
+    const onPlanUpdate = vi.fn(async () => undefined);
+
+    await runCliAgentWithLifecycle({
+      runId: "run-plan-legacy",
+      provider: "codex-cli",
+      onPlanUpdate,
+      runParams: {
+        sessionId: "session-1",
+        sessionFile: "/tmp/session.jsonl",
+        workspaceDir: "/tmp/workspace",
+        prompt: "hello",
+        provider: "codex-cli",
+        model: "codex",
+        thinkLevel: "high",
+        timeoutMs: 1_000,
+        runId: "run-plan-legacy",
+      },
+    });
+
+    expect(onPlanUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        steps: ["Inspect", "Patch"],
+        planSteps: [
+          { step: "Inspect", status: "pending" },
+          { step: "Patch", status: "pending" },
+        ],
+      }),
+    );
+  });
+
   it("bridges thinking events to reasoning text and dedupes identical snapshots", async () => {
     cliDispatchState.runCliAgentMock.mockImplementationOnce(async (params: { runId: string }) => {
       emitAgentEvent({

--- a/src/auto-reply/reply/agent-runner-cli-dispatch.ts
+++ b/src/auto-reply/reply/agent-runner-cli-dispatch.ts
@@ -22,91 +22,16 @@ import { buildPlanUpdateStepFields } from "../../channels/streaming.js";
 import type { SessionEntry } from "../../config/sessions.js";
 import { updateSessionEntry } from "../../config/sessions/session-accessor.js";
 import type { AgentEventPayload } from "../../infra/agent-events.js";
-import {
-  emitAgentEvent,
-  onAgentEvent,
-  withAgentRunLifecycleGeneration,
-} from "../../infra/agent-events.js";
+import { emitAgentEvent, withAgentRunLifecycleGeneration } from "../../infra/agent-events.js";
 import { FAST_MODE_AUTO_PROGRESS_KIND, type ReplyPayload } from "../reply-payload.js";
 import { formatToolAggregate } from "../tool-meta.js";
 import type { GetReplyOptions } from "../types.js";
+import {
+  type AgentEventDeliveryStartOrder,
+  createAgentEventBridge,
+  createAgentEventDeliveryStartOrder,
+} from "./agent-event-bridge.js";
 import { resolveAgentLifecycleTerminalMetadata } from "./agent-lifecycle-terminal.js";
-
-type AgentEventDeliveryStartOrder = {
-  schedule: (deliver: () => Promise<void>) => Promise<void>;
-};
-
-function createAgentEventDeliveryStartOrder(): AgentEventDeliveryStartOrder {
-  let startTail = Promise.resolve();
-  return {
-    schedule: async (deliver) => {
-      // Reserve at raw event receipt, then release at callback invocation. CLI streams drain
-      // independently, so waiting for callback completion here would reorder later streams.
-      const previousStart = startTail;
-      let releaseStart: (() => void) | undefined;
-      startTail = new Promise<void>((resolve) => {
-        releaseStart = resolve;
-      });
-      await previousStart;
-      let delivery: Promise<void>;
-      try {
-        delivery = deliver();
-      } finally {
-        releaseStart?.();
-      }
-      await delivery;
-    },
-  };
-}
-
-function createAgentEventBridge<T>(params: {
-  runId: string;
-  suppressed?: boolean;
-  read: (evt: AgentEventPayload) => T | undefined;
-  deliver?: (payload: T) => Promise<void>;
-  startOrder?: AgentEventDeliveryStartOrder;
-}) {
-  const deliver = params.deliver;
-  if (!deliver) {
-    return {
-      unsubscribe: () => undefined,
-      drain: async (): Promise<void> => undefined,
-    };
-  }
-  let unsubscribed = false;
-  let delivery = Promise.resolve();
-  const rawUnsubscribe = onAgentEvent((evt) => {
-    if (evt.runId !== params.runId) {
-      return;
-    }
-    if (params.suppressed) {
-      return;
-    }
-    const payload = params.read(evt);
-    if (payload === undefined) {
-      return;
-    }
-    if (!params.startOrder) {
-      delivery = delivery.then(() => deliver(payload)).catch(() => undefined);
-      return;
-    }
-    const scheduled = params.startOrder.schedule(() => deliver(payload)).catch(() => undefined);
-    // Start ordering stays global; each bridge still owns and drains its callback completion.
-    delivery = Promise.all([delivery, scheduled]).then(() => undefined);
-  });
-  return {
-    unsubscribe() {
-      if (unsubscribed) {
-        return;
-      }
-      unsubscribed = true;
-      rawUnsubscribe();
-    },
-    async drain(): Promise<void> {
-      await delivery;
-    },
-  };
-}
 
 type AgentEventBridge = {
   unsubscribe: () => void;
@@ -440,7 +365,7 @@ function createPlanUpdateBridge(params: {
     suppressed: params.suppressed,
     // GetReplyOptions callbacks may return void; the bridge awaits promises.
     deliver: deliver
-      ? async (payload) => {
+      ? async (payload: Parameters<NonNullable<GetReplyOptions["onPlanUpdate"]>>[0]) => {
           await deliver(payload);
         }
       : undefined,

--- a/src/auto-reply/reply/agent-runner-cli-dispatch.ts
+++ b/src/auto-reply/reply/agent-runner-cli-dispatch.ts
@@ -18,6 +18,7 @@ import {
   resolveAgentRunAbortLifecycleFields,
   resolveAgentRunErrorLifecycleFields,
 } from "../../agents/run-termination.js";
+import { buildPlanUpdateStepFields } from "../../channels/streaming.js";
 import type { SessionEntry } from "../../config/sessions.js";
 import { updateSessionEntry } from "../../config/sessions/session-accessor.js";
 import type { AgentEventPayload } from "../../infra/agent-events.js";
@@ -427,6 +428,32 @@ function createCommentaryEventBridge(params: {
   });
 }
 
+function createPlanUpdateBridge(params: {
+  runId: string;
+  suppressed?: boolean;
+  deliver?: GetReplyOptions["onPlanUpdate"];
+  startOrder?: AgentEventDeliveryStartOrder;
+}) {
+  return createAgentEventBridge({
+    runId: params.runId,
+    suppressed: params.suppressed,
+    deliver: params.deliver,
+    startOrder: params.startOrder,
+    read: (evt) => {
+      if (evt.stream !== "plan") {
+        return undefined;
+      }
+      return {
+        phase: normalizeOptionalString(evt.data.phase),
+        title: normalizeOptionalString(evt.data.title),
+        explanation: normalizeOptionalString(evt.data.explanation),
+        ...buildPlanUpdateStepFields(evt.data.steps),
+        source: normalizeOptionalString(evt.data.source),
+      };
+    },
+  });
+}
+
 function createToolBoundaryBridge(params: {
   runId: string;
   suppressed?: boolean;
@@ -469,6 +496,7 @@ type RunCliAgentWithLifecycleParams = {
   onReasoningProgress?: (payload: ReasoningProgressPayload) => Promise<void>;
   onToolEvent?: (payload: CliToolEventPayload) => Promise<void>;
   onCommentaryText?: (payload: CommentaryTextPayload) => Promise<void>;
+  onPlanUpdate?: GetReplyOptions["onPlanUpdate"];
   onFastModeAutoProgress?: (payload: ReplyPayload) => Promise<void>;
   onErrorBeforeLifecycle?: (err: unknown) => Promise<void>;
   transformResult?: (result: EmbeddedAgentRunResult) => EmbeddedAgentRunResult;
@@ -619,6 +647,12 @@ async function runCliAgentWithLifecycleInternal(
     deliver: params.onCommentaryText,
     startOrder: progressStartOrder,
   });
+  const planBridge = createPlanUpdateBridge({
+    runId: params.runId,
+    suppressed: params.suppressAssistantBridge,
+    deliver: params.onPlanUpdate,
+    startOrder: progressStartOrder,
+  });
   const toolBoundaryBridge = createToolBoundaryBridge({
     runId: params.runId,
     suppressed: params.suppressAssistantBridge,
@@ -631,6 +665,7 @@ async function runCliAgentWithLifecycleInternal(
     reasoningProgressBridge,
     toolBridge,
     commentaryBridge,
+    planBridge,
     toolBoundaryBridge,
   ].filter((bridge): bridge is AgentEventBridge => bridge !== undefined);
   let lifecycleTerminalEmitted = false;

--- a/src/auto-reply/reply/agent-runner-cli-dispatch.ts
+++ b/src/auto-reply/reply/agent-runner-cli-dispatch.ts
@@ -434,10 +434,16 @@ function createPlanUpdateBridge(params: {
   deliver?: GetReplyOptions["onPlanUpdate"];
   startOrder?: AgentEventDeliveryStartOrder;
 }) {
+  const deliver = params.deliver;
   return createAgentEventBridge({
     runId: params.runId,
     suppressed: params.suppressed,
-    deliver: params.deliver,
+    // GetReplyOptions callbacks may return void; the bridge awaits promises.
+    deliver: deliver
+      ? async (payload) => {
+          await deliver(payload);
+        }
+      : undefined,
     startOrder: params.startOrder,
     read: (evt) => {
       if (evt.stream !== "plan") {

--- a/src/auto-reply/reply/agent-runner-event-handler.ts
+++ b/src/auto-reply/reply/agent-runner-event-handler.ts
@@ -1,6 +1,7 @@
 import { readStringValue } from "@openclaw/normalization-core/string-coerce";
 import { isMessagingToolSendAction } from "../../agents/embedded-agent-messaging.js";
 import type { RunEmbeddedAgentParams } from "../../agents/embedded-agent-runner/run/params.js";
+import { buildPlanUpdateStepFields } from "../../channels/streaming.js";
 import { logVerbose } from "../../globals.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import type { ReplyPayload } from "../types.js";
@@ -202,9 +203,7 @@ export function createAgentRunEventHandler(params: {
         phase: readStringValue(evt.data.phase),
         title: readStringValue(evt.data.title),
         explanation: readStringValue(evt.data.explanation),
-        steps: Array.isArray(evt.data.steps)
-          ? evt.data.steps.filter((step): step is string => typeof step === "string")
-          : undefined,
+        ...buildPlanUpdateStepFields(evt.data.steps),
         source: readStringValue(evt.data.source),
       });
     }

--- a/src/auto-reply/reply/agent-runner-execution-command-events.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution-command-events.test.ts
@@ -24,7 +24,13 @@ describe("runAgentTurnWithFallback: command events", () => {
           phase: "update",
           title: "Assistant proposed a plan",
           explanation: "Inspect code, patch it, run tests.",
-          steps: ["Inspect code", "Patch code", "Run tests"],
+          steps: [
+            { step: "Inspect code", status: "completed" },
+            { step: "Patch code", status: "in_progress" },
+            { step: "Run tests", status: "pending" },
+            { step: "Malformed", status: "unknown" },
+            "legacy string",
+          ],
         },
       });
       await params.onAgentEvent?.({
@@ -97,7 +103,13 @@ describe("runAgentTurnWithFallback: command events", () => {
       phase: "update",
       title: "Assistant proposed a plan",
       explanation: "Inspect code, patch it, run tests.",
-      steps: ["Inspect code", "Patch code", "Run tests"],
+      steps: ["Inspect code", "Patch code", "Run tests", "legacy string"],
+      planSteps: [
+        { step: "Inspect code", status: "completed" },
+        { step: "Patch code", status: "in_progress" },
+        { step: "Run tests", status: "pending" },
+        { step: "legacy string", status: "pending" },
+      ],
       source: undefined,
     });
     expect(onApprovalEvent).toHaveBeenCalledWith({

--- a/src/auto-reply/reply/dispatch-from-config.abort-and-dedupe.test-utils.ts
+++ b/src/auto-reply/reply/dispatch-from-config.abort-and-dedupe.test-utils.ts
@@ -63,7 +63,7 @@ describe("dispatchReplyFromConfig", () => {
       await opts?.onPlanUpdate?.({
         phase: "update",
         explanation: "Inspect code.",
-        steps: ["Patch code"],
+        planSteps: [{ step: "Patch code", status: "in_progress" }],
       });
       await opts?.onApprovalEvent?.({
         phase: "requested",
@@ -82,7 +82,7 @@ describe("dispatchReplyFromConfig", () => {
     });
 
     expect(dispatcher.sendToolResult).toHaveBeenNthCalledWith(1, {
-      text: "1. Patch code",
+      text: "▸ Patch code",
       isStatusNotice: true,
     });
     expect(dispatcher.sendToolResult).toHaveBeenCalledTimes(1);

--- a/src/auto-reply/reply/dispatch-from-config.progress.test-utils.ts
+++ b/src/auto-reply/reply/dispatch-from-config.progress.test-utils.ts
@@ -668,7 +668,11 @@ describe("dispatchReplyFromConfig", () => {
       await opts?.onPlanUpdate?.({
         phase: "update",
         explanation: "Inspect code, patch it, run tests.",
-        steps: ["Inspect code", "Patch code", "Run tests"],
+        planSteps: [
+          { step: "Inspect code", status: "completed" },
+          { step: "Patch code", status: "in_progress" },
+          { step: "Run tests", status: "pending" },
+        ],
       });
       await opts?.onApprovalEvent?.({
         phase: "requested",
@@ -681,7 +685,7 @@ describe("dispatchReplyFromConfig", () => {
     await dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyResolver });
 
     expect(firstToolResultPayload(dispatcher)).toMatchObject({
-      text: "1. Inspect code\n2. Patch code\n3. Run tests",
+      text: "✅ Inspect code\n▸ Patch code\n▢ Run tests",
       isStatusNotice: true,
     });
     expect(dispatcher.sendToolResult).toHaveBeenCalledTimes(1);
@@ -707,11 +711,14 @@ describe("dispatchReplyFromConfig", () => {
     ) => {
       await opts?.onPlanUpdate?.({
         phase: "update",
-        steps: ["Inspect code"],
+        planSteps: [{ step: "Inspect code", status: "in_progress" }],
       });
       await opts?.onPlanUpdate?.({
         phase: "update",
-        steps: ["Inspect code", "Patch code"],
+        planSteps: [
+          { step: "Inspect code", status: "completed" },
+          { step: "Patch code", status: "in_progress" },
+        ],
       });
       return { text: "done" } satisfies ReplyPayload;
     };
@@ -720,7 +727,7 @@ describe("dispatchReplyFromConfig", () => {
 
     expect(dispatcher.sendToolResult).toHaveBeenCalledTimes(1);
     expect(firstToolResultPayload(dispatcher)).toMatchObject({
-      text: "1. Inspect code",
+      text: "▸ Inspect code",
       isStatusNotice: true,
     });
     expect(dispatcher.sendFinalReply).toHaveBeenCalledWith({ text: "done" });
@@ -787,7 +794,11 @@ describe("dispatchReplyFromConfig", () => {
       await opts?.onPlanUpdate?.({
         phase: "update",
         explanation: "Inspect code, patch it, run tests.",
-        steps: ["Inspect code", "Patch code", "Run tests"],
+        planSteps: [
+          { step: "Inspect code", status: "completed" },
+          { step: "Patch code", status: "in_progress" },
+          { step: "Run tests", status: "pending" },
+        ],
       });
       await opts?.onPatchSummary?.({
         phase: "end",
@@ -837,7 +848,11 @@ describe("dispatchReplyFromConfig", () => {
       await opts?.onPlanUpdate?.({
         phase: "update",
         explanation: "Inspect code, patch it, run tests.",
-        steps: ["Inspect code", "Patch code", "Run tests"],
+        planSteps: [
+          { step: "Inspect code", status: "completed" },
+          { step: "Patch code", status: "in_progress" },
+          { step: "Run tests", status: "pending" },
+        ],
       });
       await opts?.onApprovalEvent?.({
         phase: "requested",
@@ -890,7 +905,11 @@ describe("dispatchReplyFromConfig", () => {
       await opts?.onPlanUpdate?.({
         phase: "update",
         explanation: "Inspect code, patch it, run tests.",
-        steps: ["Inspect code", "Patch code", "Run tests"],
+        planSteps: [
+          { step: "Inspect code", status: "completed" },
+          { step: "Patch code", status: "in_progress" },
+          { step: "Run tests", status: "pending" },
+        ],
       });
       await opts?.onApprovalEvent?.({
         phase: "requested",
@@ -912,7 +931,7 @@ describe("dispatchReplyFromConfig", () => {
     expect(sessionStoreMocks.loadSessionStore).not.toHaveBeenCalled();
     expect(sessionStoreMocks.resolveSessionStoreEntry).not.toHaveBeenCalled();
     expect(firstToolResultPayload(dispatcher)).toMatchObject({
-      text: "1. Inspect code\n2. Patch code\n3. Run tests",
+      text: "✅ Inspect code\n▸ Patch code\n▢ Run tests",
       isStatusNotice: true,
     });
     expect(dispatcher.sendFinalReply).toHaveBeenCalledWith({ text: "done" });

--- a/src/auto-reply/reply/dispatch-from-config.routing.test-utils.ts
+++ b/src/auto-reply/reply/dispatch-from-config.routing.test-utils.ts
@@ -752,7 +752,11 @@ describe("dispatchReplyFromConfig", () => {
     ) => {
       await opts?.onToolStart?.({ name: "exec", phase: "start" });
       await opts?.onItemEvent?.({ itemId: "1", kind: "tool", progressText: "running exec" });
-      await opts?.onPlanUpdate?.({ phase: "update", steps: ["Run command"] });
+      // Shipped pre-2026.8 producer shape: plain string steps.
+      await opts?.onPlanUpdate?.({
+        phase: "update",
+        steps: ["Run command"],
+      });
       await opts?.onApprovalEvent?.({ phase: "requested", command: "pnpm test" });
       await opts?.onCommandOutput?.({ phase: "end", name: "exec", status: "ok", exitCode: 0 });
       await opts?.onPatchSummary?.({ phase: "end", summary: "1 modified" });
@@ -787,7 +791,11 @@ describe("dispatchReplyFromConfig", () => {
       kind: "tool",
       progressText: "running exec",
     });
-    expect(onPlanUpdate).toHaveBeenCalledWith({ phase: "update", steps: ["Run command"] });
+    expect(onPlanUpdate).toHaveBeenCalledWith({
+      phase: "update",
+      steps: ["Run command"],
+      planSteps: [{ step: "Run command", status: "pending" }],
+    });
     expect(onApprovalEvent).toHaveBeenCalledWith({
       phase: "requested",
       command: "pnpm test",

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -1694,7 +1694,7 @@ async function dispatchReplyFromConfigInner(
     const formatPlanUpdateText = (payload: { explanation?: string; steps?: AgentPlanStep[] }) => {
       const explanation = payload.explanation?.replace(/\s+/g, " ").trim();
       const steps = (payload.steps ?? [])
-        .map((entry) => ({ ...entry, step: entry.step.replace(/\s+/g, " ").trim() }))
+        .map((entry) => ({ step: entry.step.replace(/\s+/g, " ").trim(), status: entry.status }))
         .filter((entry) => entry.step);
       if (steps.length > 0) {
         return formatPlanChecklistLines(steps, {

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -34,6 +34,11 @@ import {
 } from "../../bindings/records.js";
 import { normalizeChatType } from "../../channels/chat-type.js";
 import { shouldSuppressLocalExecApprovalPrompt } from "../../channels/plugins/exec-approval-local.js";
+import {
+  type AgentPlanStep,
+  formatPlanChecklistLines,
+  normalizeAgentPlanSteps,
+} from "../../channels/streaming.js";
 import { applyMergePatch } from "../../config/merge-patch.js";
 import { normalizeExplicitSessionKey } from "../../config/sessions/explicit-session-key-normalization.js";
 import { resolveGroupSessionKey } from "../../config/sessions/group.js";
@@ -1686,13 +1691,16 @@ async function dispatchReplyFromConfigInner(
       }
       return `${truncateUtf16Safe(collapsed, 77).trimEnd()}...`;
     };
-    const formatPlanUpdateText = (payload: { explanation?: string; steps?: string[] }) => {
+    const formatPlanUpdateText = (payload: { explanation?: string; steps?: AgentPlanStep[] }) => {
       const explanation = payload.explanation?.replace(/\s+/g, " ").trim();
       const steps = (payload.steps ?? [])
-        .map((step) => step.replace(/\s+/g, " ").trim())
-        .filter(Boolean);
+        .map((entry) => ({ ...entry, step: entry.step.replace(/\s+/g, " ").trim() }))
+        .filter((entry) => entry.step);
       if (steps.length > 0) {
-        return steps.map((step, index) => `${index + 1}. ${step}`).join("\n");
+        return formatPlanChecklistLines(steps, {
+          maxLines: steps.length,
+          maxLineChars: 120,
+        }).join("\n");
       }
       return explanation || "Planning next steps.";
     };
@@ -1724,7 +1732,7 @@ async function dispatchReplyFromConfigInner(
     };
     const sendPlanUpdate = async (payload: {
       explanation?: string;
-      steps?: string[];
+      steps?: AgentPlanStep[];
     }): Promise<void> => {
       if (
         shouldSuppressProgressDelivery() ||
@@ -2273,6 +2281,17 @@ async function dispatchReplyFromConfigInner(
                     if (isDispatchOperationAborted()) {
                       return;
                     }
+                    // External resolvers call this SDK callback directly and may
+                    // send only the shipped string form; normalize once so
+                    // channel forwards and fallback notices see both fields.
+                    const planSteps =
+                      normalizeAgentPlanSteps(payload.planSteps) ??
+                      normalizeAgentPlanSteps(payload.steps);
+                    const normalized = {
+                      ...payload,
+                      steps: planSteps?.map((entry) => entry.step) ?? payload.steps,
+                      planSteps,
+                    };
                     markProgress();
                     await waitForPendingDirectBlockReplyDelivery(
                       getDispatchAbortOperation()?.abortSignal,
@@ -2287,7 +2306,7 @@ async function dispatchReplyFromConfigInner(
                         requiresToolSummaryVisibility: true,
                       })
                     ) {
-                      await onPlanUpdateFromReplyOptions?.(payload);
+                      await onPlanUpdateFromReplyOptions?.(normalized);
                     }
                     if (isDispatchOperationAborted()) {
                       return;
@@ -2296,8 +2315,8 @@ async function dispatchReplyFromConfigInner(
                       return;
                     }
                     await sendPlanUpdate({
-                      explanation: payload.explanation,
-                      steps: payload.steps,
+                      explanation: normalized.explanation,
+                      steps: planSteps,
                     });
                   },
                   onApprovalEvent: async (payload) => {

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -43,6 +43,7 @@ import {
 import { withLocalSessionPlacementTurnAdmission } from "../../agents/session-placement-admission.js";
 import { resolveSessionRuntimeOverrideForProvider } from "../../agents/session-runtime-compat.js";
 import { resolveCandidateThinkingLevel } from "../../agents/thinking-runtime.js";
+import { buildPlanUpdateStepFields } from "../../channels/streaming.js";
 import type { SessionEntry } from "../../config/sessions.js";
 import { loadSessionEntry, updateSessionEntry } from "../../config/sessions/session-accessor.js";
 import type { TypingMode } from "../../config/types.js";
@@ -195,12 +196,6 @@ function readApprovalScopeValue(value: unknown): "turn" | "session" | undefined 
   return value === "turn" || value === "session" ? value : undefined;
 }
 
-function filterStringArray(value: unknown): string[] | undefined {
-  return Array.isArray(value)
-    ? value.filter((entry): entry is string => typeof entry === "string")
-    : undefined;
-}
-
 function hasFailedFollowupProgressEvent(evt: FollowupAgentEvent): boolean {
   const commandOutput = buildCommandOutputFromToolResultEvent(evt);
   if (commandOutput) {
@@ -295,7 +290,7 @@ async function forwardFollowupProgressEvent(params: {
       phase: readStringValue(evt.data.phase),
       title: readStringValue(evt.data.title),
       explanation: readStringValue(evt.data.explanation),
-      steps: filterStringArray(evt.data.steps),
+      ...buildPlanUpdateStepFields(evt.data.steps),
       source: readStringValue(evt.data.source),
     });
   }
@@ -1186,6 +1181,7 @@ export function createFollowupRunner(params: {
                       onReasoningText: createCliReasoningStreamBridge(
                         progressOpts?.onReasoningStream,
                       ),
+                      onPlanUpdate: progressOpts?.onPlanUpdate,
                       onReasoningProgress: async (payload) => {
                         await progressOpts?.onReasoningProgress?.(payload);
                       },

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -196,6 +196,12 @@ function readApprovalScopeValue(value: unknown): "turn" | "session" | undefined 
   return value === "turn" || value === "session" ? value : undefined;
 }
 
+function filterStringArray(value: unknown): string[] | undefined {
+  return Array.isArray(value)
+    ? value.filter((entry): entry is string => typeof entry === "string")
+    : undefined;
+}
+
 function hasFailedFollowupProgressEvent(evt: FollowupAgentEvent): boolean {
   const commandOutput = buildCommandOutputFromToolResultEvent(evt);
   if (commandOutput) {

--- a/src/channels/progress-draft-compositor.test.ts
+++ b/src/channels/progress-draft-compositor.test.ts
@@ -7,6 +7,39 @@ import {
 import { DEFAULT_PROGRESS_DRAFT_INITIAL_DELAY_MS } from "./streaming.js";
 
 describe("createChannelProgressDraftCompositor", () => {
+  it("starts immediately for plans, replaces snapshots, and clears them on reset", async () => {
+    const update = vi.fn();
+    const progress = createChannelProgressDraftCompositor({
+      entry: { streaming: { mode: "progress", progress: { label: false } } },
+      mode: "progress",
+      active: true,
+      seed: "test",
+      update,
+    });
+
+    await progress.pushPreambleHeadline("Implementing the change.");
+    await progress.pushPlanProgress([
+      { step: "Inspect", status: "completed" },
+      { step: "Patch", status: "in_progress" },
+    ]);
+
+    expect(progress.hasStarted).toBe(true);
+    expect(update).toHaveBeenLastCalledWith(
+      "Implementing the change.\n\n✅ Inspect\n▸ Patch",
+      expect.objectContaining({ flush: true }),
+    );
+
+    await progress.pushPlanProgress([{ step: "Test", status: "in_progress" }]);
+    expect(update).toHaveBeenLastCalledWith(
+      "Implementing the change.\n\n▸ Test",
+      expect.anything(),
+    );
+
+    progress.reset();
+    await progress.pushToolProgress("🛠️ Next", { startImmediately: true });
+    expect(update).toHaveBeenLastCalledWith("🛠️ Next", expect.anything());
+  });
+
   it("keeps the progress label visible when tool lines are hidden", async () => {
     const update = vi.fn();
     const progress = createChannelProgressDraftCompositor({
@@ -495,6 +528,31 @@ describe("createChannelProgressDraftCompositor", () => {
 
     expect(update).toHaveBeenLastCalledWith(
       "Shelling\n\nComparing the configuration now.",
+      expect.anything(),
+    );
+  });
+
+  it("uses a plan explanation after the preamble becomes stale", async () => {
+    let nowMs = 0;
+    const update = vi.fn();
+    const progress = createChannelProgressDraftCompositor({
+      entry: { streaming: { mode: "progress", progress: { label: "Shelling" } } },
+      mode: "progress",
+      active: true,
+      seed: "test",
+      now: () => nowMs,
+      update,
+    });
+
+    await progress.start();
+    await progress.pushPreambleHeadline("Reading the workspace.");
+    nowMs += PROGRESS_STATUS_PREAMBLE_FRESH_MS;
+    await progress.pushPlanProgress([{ step: "Patch", status: "in_progress" }], {
+      explanation: "Applying the revised plan.",
+    });
+
+    expect(update).toHaveBeenLastCalledWith(
+      "Shelling\n\nApplying the revised plan.\n\n▸ Patch",
       expect.anything(),
     );
   });

--- a/src/channels/progress-draft-compositor.ts
+++ b/src/channels/progress-draft-compositor.ts
@@ -10,6 +10,7 @@ import {
 } from "./progress-draft-status-text.js";
 import {
   createChannelProgressDraftGate,
+  type AgentPlanStep,
   type ChannelProgressDraftLine,
   formatChannelProgressDraftText,
   isChannelProgressDraftWorkToolName,
@@ -96,6 +97,8 @@ export function createChannelProgressDraftCompositor(params: {
   let preambleItemId: string | undefined;
   let preambleAt: number | undefined;
   let narrationText = "";
+  let planSteps: AgentPlanStep[] | undefined;
+  let planExplanation = "";
   let finalReplyStarted = false;
   let finalReplyDelivered = false;
   let preambleExpiryTimer: ReturnType<typeof setTimeout> | undefined;
@@ -110,7 +113,10 @@ export function createChannelProgressDraftCompositor(params: {
   const resolveStatusText = () => {
     const preambleIsFresh =
       preambleAt !== undefined && now() - preambleAt < PROGRESS_STATUS_PREAMBLE_FRESH_MS;
-    return preambleText && (preambleIsFresh || !narrationText) ? preambleText : narrationText;
+    const effectiveNarration = narrationText || planExplanation;
+    return preambleText && (preambleIsFresh || !effectiveNarration)
+      ? preambleText
+      : effectiveNarration;
   };
 
   const formatDraftText = (draftLines = lines, options?: { formatted?: boolean }) =>
@@ -120,6 +126,7 @@ export function createChannelProgressDraftCompositor(params: {
       seed: params.seed,
       formatLine: options?.formatted === false ? undefined : params.formatLine,
       narration: resolveStatusText() || undefined,
+      plan: planSteps,
     });
 
   const clearProgressState = (suppressed: boolean) => {
@@ -133,6 +140,8 @@ export function createChannelProgressDraftCompositor(params: {
     preambleItemId = undefined;
     preambleAt = undefined;
     narrationText = "";
+    planSteps = undefined;
+    planExplanation = "";
   };
 
   const render = async (options?: { flush?: boolean }): Promise<boolean> => {
@@ -290,7 +299,10 @@ export function createChannelProgressDraftCompositor(params: {
       return gate.hasStarted && !finalReplyStarted && !finalReplyDelivered;
     },
     get hasStatusHeadline() {
-      return Boolean(preambleText);
+      return Boolean(resolveStatusText());
+    },
+    get hasPlanProgress() {
+      return Boolean(planSteps?.length);
     },
     markFinalReplyStarted() {
       finalReplyStarted = true;
@@ -354,6 +366,43 @@ export function createChannelProgressDraftCompositor(params: {
       return false;
     },
     pushToolProgress: noteProgress,
+    async pushPlanProgress(
+      steps?: AgentPlanStep[],
+      options?: { explanation?: string },
+    ): Promise<boolean> {
+      if (
+        !params.active ||
+        params.mode !== "progress" ||
+        progressSuppressed ||
+        finalReplyStarted ||
+        finalReplyDelivered
+      ) {
+        return false;
+      }
+      planSteps = steps && steps.length > 0 ? steps.map((entry) => ({ ...entry })) : undefined;
+      planExplanation = options?.explanation?.replace(/\s+/g, " ").trim() ?? "";
+      if (!planSteps && !planExplanation) {
+        if (!gate.hasStarted) {
+          return false;
+        }
+        const rendered = await render();
+        if (rendered || formatDraftText()) {
+          return rendered;
+        }
+        lastRenderedText = "";
+        await params.deleteCurrent?.();
+        return true;
+      }
+      const alreadyStarted = gate.hasStarted;
+      await gate.startNow();
+      if (!gate.hasStarted) {
+        return false;
+      }
+      if (alreadyStarted) {
+        await render();
+      }
+      return true;
+    },
     async pushPreambleHeadline(text?: string, options?: { itemId?: string }) {
       if (!params.active || params.mode !== "progress" || progressSuppressed) {
         return false;

--- a/src/channels/streaming.test.ts
+++ b/src/channels/streaming.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from "vitest";
 import {
   buildChannelProgressDraftLine,
+  buildPlanUpdateStepFields,
   formatChannelProgressDraftText,
+  formatPlanChecklistLines,
+  normalizeAgentPlanSteps,
+  isChannelProgressDraftWorkToolName,
   resolveChannelPreviewStreamMode,
   resolveChannelStreamingBlockCoalesce,
   resolveChannelStreamingBlockEnabled,
@@ -12,6 +16,10 @@ import {
 } from "./streaming.js";
 
 describe("buildChannelProgressDraftLine", () => {
+  it("suppresses update_plan from generic work-tool progress", () => {
+    expect(isChannelProgressDraftWorkToolName("update_plan")).toBe(false);
+  });
+
   it("omits generic completed status from successful command output with title", () => {
     const line = buildChannelProgressDraftLine(
       {
@@ -94,6 +102,32 @@ describe("buildChannelProgressDraftLine", () => {
   });
 });
 
+describe("normalizeAgentPlanSteps", () => {
+  it("normalizes legacy strings and typed entries, dropping blanks", () => {
+    expect(
+      normalizeAgentPlanSteps([
+        "Inspect",
+        "  ",
+        { step: "  Patch  ", status: "in_progress" },
+        { step: "   ", status: "pending" },
+        { step: "Test", status: "bogus" },
+      ]),
+    ).toEqual([
+      { step: "Inspect", status: "pending" },
+      { step: "Patch", status: "in_progress" },
+    ]);
+    expect(normalizeAgentPlanSteps(undefined)).toBeUndefined();
+  });
+
+  it("builds both deprecation-window payload fields", () => {
+    expect(buildPlanUpdateStepFields([{ step: "Inspect", status: "completed" }])).toEqual({
+      steps: ["Inspect"],
+      planSteps: [{ step: "Inspect", status: "completed" }],
+    });
+    expect(buildPlanUpdateStepFields(undefined)).toEqual({});
+  });
+});
+
 describe("streaming config resolution", () => {
   // Flat delivery keys remain external SDK compatibility fallbacks. Bundled
   // schemas are nested-only; mode-family aliases stay doctor-only.
@@ -143,6 +177,72 @@ describe("streaming config resolution", () => {
 });
 
 describe("progress narration", () => {
+  it("renders plan markers and keeps the checklist under narration", () => {
+    const plan = [
+      { step: "Inspect", status: "completed" as const },
+      { step: "Patch", status: "in_progress" as const },
+      { step: "Test", status: "pending" as const },
+    ];
+
+    expect(formatPlanChecklistLines(plan, { maxLines: 5, maxLineChars: 80 })).toEqual([
+      "✅ Inspect",
+      "▸ Patch",
+      "▢ Test",
+    ]);
+    expect(
+      formatChannelProgressDraftText({
+        entry: { streaming: { mode: "progress", progress: { label: false } } },
+        lines: ["🛠️ hidden"],
+        narration: "Working through the plan.",
+        plan,
+      }),
+    ).toBe("Working through the plan.\n\n✅ Inspect\n▸ Patch\n▢ Test");
+  });
+
+  it("summarizes overflowing plans and prioritizes unfinished steps", () => {
+    expect(
+      formatPlanChecklistLines(
+        [
+          { step: "One", status: "completed" },
+          { step: "Two", status: "completed" },
+          { step: "Three", status: "in_progress" },
+          { step: "Four", status: "pending" },
+        ],
+        { maxLines: 3, maxLineChars: 80 },
+      ),
+    ).toEqual(["✅ 2/4 done", "▸ Three", "▢ Four"]);
+  });
+
+  it("keeps the active step when later pending work fills the checklist", () => {
+    expect(
+      formatPlanChecklistLines(
+        [
+          { step: "Done", status: "completed" },
+          { step: "Active", status: "in_progress" },
+          { step: "Next", status: "pending" },
+          { step: "Later", status: "pending" },
+          { step: "Last", status: "pending" },
+        ],
+        { maxLines: 3, maxLineChars: 80 },
+      ),
+    ).toEqual(["✅ 1/5 done", "▸ Active", "▢ Last"]);
+  });
+
+  it("shares the line budget between tool progress and the checklist", () => {
+    expect(
+      formatChannelProgressDraftText({
+        entry: {
+          streaming: { mode: "progress", progress: { label: false, maxLines: 3 } },
+        },
+        lines: ["tool one", "tool two", "tool three"],
+        plan: [
+          { step: "Active", status: "in_progress" },
+          { step: "Next", status: "pending" },
+        ],
+      }),
+    ).toBe("• tool three\n▸ Active\n▢ Next");
+  });
+
   it("omits the implicit progress label when narration is available", () => {
     const text = formatChannelProgressDraftText({
       entry: { streaming: { mode: "progress" } },

--- a/src/channels/streaming.ts
+++ b/src/channels/streaming.ts
@@ -103,6 +103,7 @@ const NON_WORK_PROGRESS_TOOL_NAMES = new Set([
   "reaction",
   "react",
   "typing",
+  "update_plan",
 ]);
 
 export function isChannelProgressDraftWorkToolName(name: string | null | undefined): boolean {
@@ -178,6 +179,62 @@ export type ChannelProgressLineOptions = {
 
 export type ChannelProgressDraftRenderMode = "text" | "rich";
 
+export type AgentPlanStepStatus = "pending" | "in_progress" | "completed";
+
+export type AgentPlanStep = {
+  step: string;
+  status: AgentPlanStepStatus;
+};
+
+/**
+ * Plan-event ingress shape for the SDK deprecation window: shipped producers
+ * through 2026.7.x sent `steps: string[]`. Remove with the string form.
+ */
+export type AgentPlanStepInput = AgentPlanStep | string;
+
+function isAgentPlanStepStatus(value: unknown): value is AgentPlanStepStatus {
+  return value === "pending" || value === "in_progress" || value === "completed";
+}
+
+/**
+ * Normalizes plan-event steps at public ingress boundaries. Legacy string
+ * steps become pending typed steps; malformed entries are dropped.
+ */
+/**
+ * Builds both plan-step payload fields for `onPlanUpdate` during the SDK
+ * deprecation window: canonical `planSteps` plus the shipped pre-2026.8
+ * `steps: string[]` form. Collapse to `planSteps` when the window closes.
+ */
+export function buildPlanUpdateStepFields(value: unknown): {
+  steps?: string[];
+  planSteps?: AgentPlanStep[];
+} {
+  const planSteps = normalizeAgentPlanSteps(value);
+  if (!planSteps) {
+    return {};
+  }
+  return { steps: planSteps.map((entry) => entry.step), planSteps };
+}
+
+export function normalizeAgentPlanSteps(value: unknown): AgentPlanStep[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+  return value.flatMap((entry) => {
+    if (typeof entry === "string") {
+      const step = entry.trim();
+      return step ? [{ step, status: "pending" as const }] : [];
+    }
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+      return [];
+    }
+    const rawStep = (entry as { step?: unknown }).step;
+    const status = (entry as { status?: unknown }).status;
+    const step = typeof rawStep === "string" ? rawStep.trim() : "";
+    return step && isAgentPlanStepStatus(status) ? [{ step, status }] : [];
+  });
+}
+
 const EMOJI_PREFIX_RE = /^\p{Extended_Pictographic}/u;
 
 export type ChannelProgressDraftLineInput =
@@ -207,7 +264,7 @@ export type ChannelProgressDraftLineInput =
       phase?: string;
       title?: string;
       explanation?: string;
-      steps?: string[];
+      steps?: readonly AgentPlanStepInput[];
     }
   | {
       event: "approval";
@@ -566,7 +623,11 @@ export function buildChannelProgressDraftLine(
       return buildNamedProgressLine(
         input.event,
         "update_plan",
-        [input.explanation, input.steps?.[0], input.title ?? "planning"],
+        [
+          input.explanation,
+          normalizeAgentPlanSteps(input.steps)?.[0]?.step,
+          input.title ?? "planning",
+        ],
         options,
       );
     }
@@ -1002,6 +1063,60 @@ function compactChannelProgressDraftLine(line: string, maxChars: number): string
   return repairCompactedProgressMarkdown(compactPlainProgressLine(normalized, maxChars));
 }
 
+export function formatPlanChecklistLines(
+  steps: readonly AgentPlanStep[],
+  options: { maxLines: number; maxLineChars: number },
+): string[] {
+  const normalizedSteps = steps
+    .map((entry, index) => ({ ...entry, step: entry.step.replace(/\s+/g, " ").trim(), index }))
+    .filter((entry) => entry.step);
+  if (normalizedSteps.length === 0 || options.maxLines <= 0) {
+    return [];
+  }
+  const maxLines = Math.max(1, options.maxLines);
+  const marker = (status: AgentPlanStepStatus) =>
+    status === "completed" ? "✅" : status === "in_progress" ? "▸" : "▢";
+  const formatStep = (entry: (typeof normalizedSteps)[number]) =>
+    compactChannelProgressDraftLine(`${marker(entry.status)} ${entry.step}`, options.maxLineChars);
+  if (normalizedSteps.length <= maxLines) {
+    return normalizedSteps.map(formatStep);
+  }
+
+  const availableSteps = maxLines - 1;
+  if (availableSteps === 0) {
+    const completedCount = normalizedSteps.filter((entry) => entry.status === "completed").length;
+    return [
+      compactChannelProgressDraftLine(
+        `✅ ${completedCount}/${normalizedSteps.length} done`,
+        options.maxLineChars,
+      ),
+    ];
+  }
+  const pendingSteps = normalizedSteps.filter((entry) => entry.status !== "completed");
+  const activeStep = pendingSteps.find((entry) => entry.status === "in_progress");
+  const pendingSlots = Math.max(0, availableSteps - (activeStep ? 1 : 0));
+  // slice(-0) would return the whole array and blow past the line cap.
+  const pendingTail =
+    pendingSlots === 0
+      ? []
+      : pendingSteps.filter((entry) => entry !== activeStep).slice(-pendingSlots);
+  const visiblePending = [...(activeStep ? [activeStep] : []), ...pendingTail];
+  const completedSlots = Math.max(0, availableSteps - visiblePending.length);
+  const recentCompleted =
+    completedSlots > 0
+      ? normalizedSteps.filter((entry) => entry.status === "completed").slice(-completedSlots)
+      : [];
+  const visibleSteps = [...recentCompleted, ...visiblePending].sort((a, b) => a.index - b.index);
+  const completedCount = normalizedSteps.length - pendingSteps.length;
+  return [
+    compactChannelProgressDraftLine(
+      `✅ ${completedCount}/${normalizedSteps.length} done`,
+      options.maxLineChars,
+    ),
+    ...visibleSteps.map(formatStep),
+  ];
+}
+
 function getProgressDraftLineText(line: string | ChannelProgressDraftLine): string {
   if (typeof line === "string") {
     return line;
@@ -1152,9 +1267,17 @@ export function formatChannelProgressDraftText(params: {
   bullet?: string;
   /** Short narration paragraph; when present it replaces the tool lines. */
   narration?: string;
+  /** Latest full plan snapshot, rendered independently from rolling tool lines. */
+  plan?: readonly AgentPlanStep[];
 }): string {
   const narration = params.narration ? compactChannelProgressDraftNarration(params.narration) : "";
   const progress = resolveChannelProgressDraftConfig(params.entry);
+  const maxLines = resolveChannelProgressDraftMaxLines(params.entry);
+  const maxLineChars = resolveChannelProgressDraftMaxLineChars(params.entry);
+  const formatLine = params.formatLine ?? ((line: string) => line);
+  const planLines = formatPlanChecklistLines(params.plan ?? [], { maxLines, maxLineChars }).map(
+    formatLine,
+  );
   const hasConfiguredLabel = progress.label !== undefined || progress.labels !== undefined;
   const resolvedLabel =
     narration && !hasConfiguredLabel
@@ -1165,16 +1288,23 @@ export function formatChannelProgressDraftText(params: {
           random: params.random,
         });
   if (narration) {
-    const formatted = (params.formatLine ?? ((line: string) => line))(narration);
-    return resolvedLabel ? `${resolvedLabel}\n\n${formatted}` : formatted;
+    const formatted = formatLine(narration);
+    const status = resolvedLabel ? `${resolvedLabel}\n\n${formatted}` : formatted;
+    return planLines.length > 0 ? `${status}\n\n${planLines.join("\n")}` : status;
   }
-  const maxLines = resolveChannelProgressDraftMaxLines(params.entry);
-  const maxLineChars = resolveChannelProgressDraftMaxLineChars(params.entry);
-  const formatLine = params.formatLine ?? ((line: string) => line);
   const bullet = params.bullet ?? "•";
+  const toolLineBudget = planLines.length > 0 ? Math.max(0, maxLines - planLines.length) : maxLines;
+  const visibleToolLines =
+    planLines.length === 0
+      ? params.lines
+      : toolLineBudget === 0
+        ? []
+        : params.lines.slice(-toolLineBudget);
   const rawLines: Array<string | ChannelProgressDraftLine | { draftLabel: string }> = resolvedLabel
-    ? [{ draftLabel: resolvedLabel }, ...params.lines]
-    : params.lines;
+    ? [{ draftLabel: resolvedLabel }, ...visibleToolLines]
+    : visibleToolLines;
+  const rollingLineLimit =
+    planLines.length > 0 ? toolLineBudget + (resolvedLabel ? 1 : 0) : maxLines;
   const lines = rawLines
     .map((line) => {
       const isLabelLine = typeof line === "object" && line !== null && "draftLabel" in line;
@@ -1191,7 +1321,7 @@ export function formatChannelProgressDraftText(params: {
     .filter((line): line is { text: string; isLabelLine: boolean; prefix: boolean } =>
       Boolean(line),
     )
-    .slice(-maxLines)
+    .slice(-rollingLineLimit)
     .map(({ text, isLabelLine, prefix }) => {
       const formatted = isLabelLine ? text : formatLine(text);
       return {
@@ -1203,6 +1333,9 @@ export function formatChannelProgressDraftText(params: {
       };
     });
   const renderedLines = lines.map((line) => line.text).filter((line) => Boolean(line));
+  if (planLines.length > 0) {
+    renderedLines.push(...planLines);
+  }
   if (renderedLines.length > 1 && lines[0]?.isLabelLine) {
     return `${renderedLines[0]}\n\n${renderedLines.slice(1).join("\n")}`;
   }

--- a/src/channels/streaming.ts
+++ b/src/channels/streaming.ts
@@ -1106,7 +1106,9 @@ export function formatPlanChecklistLines(
     completedSlots > 0
       ? normalizedSteps.filter((entry) => entry.status === "completed").slice(-completedSlots)
       : [];
-  const visibleSteps = [...recentCompleted, ...visiblePending].sort((a, b) => a.index - b.index);
+  const visibleSteps = [...recentCompleted, ...visiblePending].toSorted(
+    (a, b) => a.index - b.index,
+  );
   const completedCount = normalizedSteps.length - pendingSteps.length;
   return [
     compactChannelProgressDraftLine(

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -514,9 +514,9 @@ export const FIELD_HELP: Record<string, string> = {
   "tools.agentToAgent.allow":
     "Allowlist of target agent IDs permitted for agent_to_agent calls when orchestration is enabled. Use explicit allowlists to avoid uncontrolled cross-agent call graphs.",
   "tools.experimental":
-    "Experimental built-in tool flags. Keep these off by default and enable only when you are intentionally testing a preview surface.",
+    "Experimental built-in tool flags. Use each tool's switch to opt in or out of its documented default.",
   "tools.experimental.planTool":
-    "Enable the experimental structured `update_plan` tool for non-trivial multi-step work tracking. Leave this off unless you explicitly want the tool outside strict-agentic embedded OpenClaw runs.",
+    "Structured `update_plan` checklist tool for non-trivial multi-step work. Enabled by default for embedded models; set false to opt out.",
   "tools.toolSearch":
     "Compact large OpenClaw, MCP, and client tool catalogs. Set to true for the default code bridge or use the object form to choose structured controls or a compact visible tool directory.",
   "tools.toolSearch.enabled":

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -745,9 +745,9 @@ export type ToolsConfig = {
       deny?: string[];
     };
   };
-  /** Experimental tool flags. Default off unless explicitly enabled, except strict-agentic GPT-5 OpenAI/Codex runs may auto-enable `planTool`. */
+  /** Experimental tool flags. */
   experimental?: {
-    /** Enable the structured `update_plan` tool explicitly outside strict-agentic execution mode. */
+    /** Structured checklist tool; enabled by default. Set false to opt out. */
     planTool?: boolean;
   };
 };


### PR DESCRIPTION
## What Problem This Solves

Agents already maintain structured work plans through the `update_plan` tool — typed `{step, status}` checklists with at most one `in_progress` step — but OpenClaw destroyed that structure twice on the way to chat channels. The Codex app-server projector flattened typed steps into `"step (in_progress)"` strings, and every channel rendered the whole plan as a single `🗺️ update_plan: <first step>` line. Slack's opt-in native task cards (`plan_update`/`task_update` chunks) rendered fake "tasks" synthesized from tool activity lines while the model's real checklist was discarded upstream. Users watching a long-running agent turn saw rolling tool noise instead of the agent's actual plan and progress.

## Why This Change Was Made

Live checklists are the industry-converged progress UX for chat agents (Claude Tag's edited-in-place checklist, GitHub Copilot's PR checklist, Linear's Agent Plans). All the pieces existed in OpenClaw — the typed tool, the events, Slack's native plan renderer — they just weren't connected. This PR carries the typed snapshot end to end and renders it everywhere:

- **Typed pipe**: `turn/plan/updated` steps survive the Codex projector (camelCase `inProgress` wire values normalized); `onPlanUpdate` carries canonical `planSteps: AgentPlanStep[]`; the codex-exec JSONL `todo_list` path and Copilot bridge feed the same lane.
- **Every model**: the embedded `update_plan` tool is now default-on (was strict-agentic-only; `tools.experimental.planTool: false` remains the kill switch) and emits the same plan events; its raw tool row is suppressed so the checklist lane replaces it.
- **Channel rendering**: shared `formatPlanChecklistLines` (✅/▸/▢ with overflow summarization) renders under the status headline via the compositor plan lane (Discord, Telegram) and the channel draft paths (Slack, Matrix, MS Teams). Slack native task cards now display the real plan: position-keyed rows so full snapshots rewrite in place, plus `reconcileSlackNativeTaskChunks` which retires dropped/renamed rows (Slack has no task-removal primitive) across shrinks, source switches, and completion.
- **SDK compatibility window**: the shipped `onPlanUpdate.steps: string[]` field stays populated (derived step text) alongside `planSteps`; string-step producers are normalized at the public ingress boundaries (`normalizeAgentPlanSteps`). Marked `@deprecated` with a removal note.

Compatibility/config notes: one default flip (embedded `update_plan` default-on; existing key is the opt-out — no new config surface), one additive SDK field + deprecation window, no protocol or storage changes. Rich Slack drafts keep status blocks (label/narration/checklist) inside the 50-block budget with tool lines yielding the remainder; all new section texts flow through the existing 1,800-char `field()` truncation.

## User Impact

For any multi-step task where the model maintains a plan, channel progress drafts now show a live checklist — e.g. in Slack (text draft or native task cards), Discord, and Telegram:

```
Implementing the change.

✅ Inspect code
▸ Patch the parser
▢ Run tests
```

updated in place as steps complete, for Codex-, Copilot-, and embedded-model agents alike. Short single-step turns are unchanged (models only emit plans for multi-step work; the 5s progress gate still applies). Operators can opt out per config (`tools.experimental.planTool: false`; channel `progress.*` knobs unchanged).

## Evidence

- Focused suites (local, `node scripts/run-vitest.mjs`): `src/channels/streaming.test.ts` (30), `progress-draft-compositor.test.ts` (17), `dispatch-from-config.test.ts` (267), `agent-runner-cli-dispatch.test.ts` (22), `agent-runner-execution-command-events.test.ts` (4), `embedded-agent-subscribe.handlers.tools.test.ts` + `openclaw-tools.update-plan.test.ts` (189), `cli-output.test.ts` (67), codex `event-projector.test.ts` (153), copilot `event-bridge.test.ts` (36), slack `progress-blocks.test.ts` + `dispatch.preview-fallback.test.ts` (131), discord `message-handler.process.test.ts` (133), telegram `bot-message-dispatch.progress-rendering.test.ts` (24), matrix `handler.test.ts` (119), msteams controller + dispatcher (113), `followup-runner.test.ts` (150). All green.
- `pnpm plugin-sdk:surface:check` green (budgets bumped with rationale comments for the new plan-step exports).
- Codex contract verified directly in `openai/codex` @ `3f74f00`: `codex-rs/protocol/src/plan_tool.rs` (typed args, one in_progress), `core/src/tools/handlers/plan.rs:92` (EventMsg::PlanUpdate), `app-server-protocol/src/protocol/v2/turn.rs:414` (camelCase `TurnPlanStepStatus`), `exec/src/exec_events.rs:309` (JSONL todo items expose only `completed: boolean` → mapped completed/pending).
- Structured autoreview (Codex gpt-5.6-sol) run to convergence across 10 rounds; all accepted findings fixed (typed-pipe SDK window, Slack native row reconciliation, queued-followup state reset, formatter `slice(-0)` cap, rich-block priority budget). Final three reported findings consciously rejected with inline invariant comments: aggregate section length (factually bounded by `field()` → `truncateSlackText(…, 1800)`), and two `label: false` + zero-step-retraction display edges that bundled producers cannot emit (`minItems: 1`).
- Full CI/Testbox gates run on this PR head (see checks).
