### PR TITLE
test(release): backport QA validation hardening

### DIFF
--- a/extensions/qa-lab/src/scenario-catalog.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog.test.ts
@@ -950,6 +950,19 @@ describe("qa scenario catalog", () => {
     expect(subagentFanout.execution.suiteIsolation).toBe("isolated");
   });
 
+  it("settles subagent completions before reading the SQLite session store", () => {
+    const scenario = requireFlowScenario(readQaScenarioById("subagent-fanout-synthesis"));
+    const flow = JSON.stringify(scenario.execution.flow);
+    const completionWaits = [...flow.matchAll(/expectedChildCompletionMarkers/gu)].map(
+      (match) => match.index,
+    );
+    const storeReads = [...flow.matchAll(/readRawQaSessionStore/gu)].map((match) => match.index);
+
+    expect(completionWaits).toHaveLength(2);
+    expect(storeReads).toHaveLength(2);
+    expect(completionWaits.every((wait, index) => wait < (storeReads[index] ?? -1))).toBe(true);
+  });
+
   it("adds a dreaming shadow trial report scenario", () => {
     const scenario = readQaScenarioById("dreaming-shadow-trial-report");
     const config = readQaScenarioExecutionConfig("dreaming-shadow-trial-report") as

--- a/extensions/qa-lab/src/suite-runtime-flow.test.ts
+++ b/extensions/qa-lab/src/suite-runtime-flow.test.ts
@@ -60,7 +60,6 @@ const hasDiscoveryLabels = vi.hoisted(() => vi.fn());
 const reportsDiscoveryScopeLeak = vi.hoisted(() => vi.fn());
 const reportsMissingDiscoveryFiles = vi.hoisted(() => vi.fn());
 const hasModelSwitchContinuitySignal = vi.hoisted(() => vi.fn());
-const qaChannelPlugin = vi.hoisted(() => ({ id: "qa-channel" }));
 const scanGatewayLogSentinels = vi.hoisted(() => vi.fn());
 const assertNoGatewayLogSentinels = vi.hoisted(() => vi.fn());
 
@@ -157,10 +156,6 @@ vi.mock("./runtime-tool-fixture.js", () => ({
 
 vi.mock("./model-switch-eval.js", () => ({
   hasModelSwitchContinuitySignal,
-}));
-
-vi.mock("./runtime-api.js", () => ({
-  qaChannelPlugin,
 }));
 
 vi.mock("./gateway-log-sentinel.js", () => ({
@@ -296,7 +291,6 @@ describe("qa suite runtime flow", () => {
           envArg: typeof env,
           configArg: Record<string, unknown>,
         ) => Promise<unknown>;
-        qaChannelPlugin: typeof qaChannelPlugin;
         webOpenPage: (params: { url: string }) => Promise<unknown>;
       };
       constants: {
@@ -330,7 +324,6 @@ describe("qa suite runtime flow", () => {
         ensureImageGenerationConfigured,
       },
     );
-    expect(call.deps.qaChannelPlugin).toBe(qaChannelPlugin);
     expect(call.constants).toEqual({
       imageUnderstandingPngBase64: "small",
       imageUnderstandingLargePngBase64: "large",

--- a/qa/scenarios/agents/subagent-fanout-synthesis.yaml
+++ b/qa/scenarios/agents/subagent-fanout-synthesis.yaml
@@ -112,6 +112,23 @@ flow:
                               - expr: "30000"
                               - expr: "env.providerMode === 'mock-openai' ? 100 : 250"
                           - if:
+                              # The parent reply can arrive before child transcript writes finish.
+                              # Wait before opening the store so its integrity check sees settled FTS state.
+                              expr: "Boolean(env.mock) && env.gateway.runtimeEnv.OPENCLAW_QA_FORCE_RUNTIME !== 'codex'"
+                              then:
+                                - forEach:
+                                    items:
+                                      expr: "config.expectedChildCompletionMarkers"
+                                    item: childCompletionMarker
+                                    actions:
+                                      - call: waitForOutboundMessage
+                                        args:
+                                          - ref: state
+                                          - lambda:
+                                              params: [candidate]
+                                              expr: "String(candidate.text ?? '').trim() === childCompletionMarker"
+                                          - 30000
+                          - if:
                               expr: "Boolean(env.mock)"
                               then:
                                 - call: readRawQaSessionStore
@@ -163,6 +180,21 @@ flow:
                           - if:
                               expr: "/timed out after/i.test(formatErrorMessage(attemptError))"
                               then:
+                                - if:
+                                    expr: "Boolean(env.mock) && env.gateway.runtimeEnv.OPENCLAW_QA_FORCE_RUNTIME !== 'codex'"
+                                    then:
+                                      - forEach:
+                                          items:
+                                            expr: "config.expectedChildCompletionMarkers"
+                                          item: childCompletionMarker
+                                          actions:
+                                            - call: waitForOutboundMessage
+                                              args:
+                                                - ref: state
+                                                - lambda:
+                                                    params: [candidate]
+                                                    expr: "String(candidate.text ?? '').trim() === childCompletionMarker"
+                                                - 30000
                                 - call: readRawQaSessionStore
                                   saveAs: timeoutStore
                                   args:
@@ -240,23 +272,4 @@ flow:
             expr: "lastError === '__done__'"
             message:
               expr: "lastError instanceof Error ? formatErrorMessage(lastError) : String(lastError ?? 'fanout retry exhausted')"
-        - if:
-            # Codex completes child sessions through its app-server path but
-            # does not relay the child marker back onto the parent QA channel.
-            # The shared assertions above already prove both child tool calls
-            # and child session rows; keep this transport-only proof OpenClaw-specific.
-            expr: "Boolean(env.mock) && env.gateway.runtimeEnv.OPENCLAW_QA_FORCE_RUNTIME !== 'codex'"
-            then:
-              - forEach:
-                  items:
-                    expr: "config.expectedChildCompletionMarkers"
-                  item: childCompletionMarker
-                  actions:
-                    - call: waitForOutboundMessage
-                      args:
-                        - ref: state
-                        - lambda:
-                            params: [candidate]
-                            expr: "String(candidate.text ?? '').trim() === childCompletionMarker"
-                        - 30000
       detailsExpr: "details"

--- a/src/agents/zai.live.test.ts
+++ b/src/agents/zai.live.test.ts
@@ -35,14 +35,21 @@ async function expectModelReturnsAssistantText(
     contextWindow: modelId === "glm-5.2" ? 1_000_000 : 202_800,
     maxTokens: modelId === "glm-5.2" ? 131_072 : 131_100,
   };
-  const res = await completeSimple(
-    model,
-    {
-      messages: createSingleUserPromptMessage(),
-    },
-    { apiKey: ZAI_KEY, maxTokens: 64 },
-  );
-  const text = extractNonEmptyAssistantText(res.content);
+  const runProbe = (maxTokens: number) =>
+    completeSimple(
+      model,
+      {
+        messages: createSingleUserPromptMessage(),
+      },
+      { apiKey: ZAI_KEY, maxTokens },
+    );
+  const res = await runProbe(64);
+  let text = extractNonEmptyAssistantText(res.content);
+  // GLM can spend a tiny cap entirely on hidden reasoning. Retry only a
+  // provider-declared truncation; other empty responses remain failures.
+  if (text.length === 0 && res.stopReason === "length") {
+    text = extractNonEmptyAssistantText((await runProbe(256)).content);
+  }
   expect(text.length).toBeGreaterThan(0);
 }
 


### PR DESCRIPTION
## What Problem This Solves

The exact beta head failed Full Release Validation in Plugin Prerelease and Release Checks:

- QA suite runtime tests still mocked a dependency removed by the package Telegram harness backport.
- The subagent fanout scenario could run SQLite integrity checks while child transcript FTS writes were still in flight.
- Z.AI live probes can exhaust a tiny output budget in hidden reasoning before visible text.

Failure evidence: https://github.com/openclaw/openclaw/actions/runs/29467824681

## Why This Change Was Made

This is the release-branch subset of main PR #108589. It removes the stale mock, waits for child completion before each raw store read, and retries Z.AI only when the provider explicitly reports `length` truncation.

Main-only Luna lane and plugin SDK demotion-count changes are intentionally excluded because those contracts are not present on `release/2026.7.2`.

## User Impact

No product behavior change. Beta release validation becomes deterministic without weakening corruption or live-provider assertions.

## Evidence

- Focused Testbox suites: 43 tests green
- Mock `subagent-fanout-synthesis` QA suite: 1/1 green
- Exact release-base Testbox `pnpm check:changed --base 5f2c5422ae75396155435cacb641c4e08768f65c --head HEAD`: green
- Fresh autoreview: clean, no actionable findings (0.87 confidence)

No changelog: test and release-harness reliability only.
