### PR TITLE
refactor(qa): make channel drivers run-level

### DIFF
--- a/docs/concepts/qa-e2e-automation.md
+++ b/docs/concepts/qa-e2e-automation.md
@@ -194,8 +194,9 @@ precedence over `--profile`.
 | `e2ee-deep`  | 18        | State-loss, backup, key recovery, device hygiene, and SAS/QR/DM verification.                                                            |
 | `e2ee-cli`   | 9         | `openclaw matrix encryption setup`, recovery-key, multi-account, gateway round-trip, and self-verification commands through the harness. |
 
-Profile membership and channel/driver requirements live with the declarative
-Matrix scenarios under `qa/scenarios/channels/`. Their live implementations live under
+Profile membership and channel requirements live with the declarative Matrix
+scenarios under `qa/scenarios/channels/`. The run chooses the channel driver.
+Their live implementations live under
 `extensions/qa-lab/src/live-transports/matrix/scenarios/`.
 
 The adapter provisions a disposable Tuwunel homeserver in Docker (default
@@ -395,15 +396,17 @@ when the maintainer secret is present.
 
 The root `taxonomy.yaml` defines semantic coverage IDs. Scenario YAML files
 under `qa/scenarios/` map each scenario to those IDs and own execution
-metadata: `channel` is the only channel requirement, `driver` constrains the
-runner when needed, and `profiles` declare named run membership. TypeScript
+metadata: `channel` is the only channel requirement, and `profiles` declare
+named run membership. The channel driver is an interchangeable run-level
+implementation choice. TypeScript
 runners query that catalog; they do not maintain parallel scenario or coverage
 inventories.
 
 Static `qa coverage` output reports the taxonomy-to-scenario mapping. Actual
 proof comes from `qa-evidence.json`, which records the executed scenario,
-coverage IDs, channel, driver, and result. Channel and driver are report
-dimensions, not additional coverage-ID vocabularies.
+coverage IDs, channel, driver actually used, and result. Channel and driver are
+report dimensions, not additional coverage-ID vocabularies or scenario
+eligibility axes.
 
 For a disposable Linux VM lane without bringing Docker into the QA path, run:
 

--- a/extensions/qa-lab/src/cli.runtime.test.ts
+++ b/extensions/qa-lab/src/cli.runtime.test.ts
@@ -3,7 +3,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { listQaScenariosForExecutionProfile, type QaScenarioPack } from "./scenario-catalog.js";
+import type { QaScenarioPack } from "./scenario-catalog.js";
 
 const {
   runQaManualLane,
@@ -586,6 +586,21 @@ describe("qa cli runtime", () => {
     );
   });
 
+  it("dispatches the Matrix restart scenario through the Crabline smoke profile", async () => {
+    await runQaProfileCommand({
+      repoRoot: "/tmp/openclaw-repo",
+      profile: "smoke-ci",
+      scenarioIds: ["matrix-restart-resume"],
+    });
+
+    const suiteArgs = mockFirstObjectArg(runQaSuite);
+    expect(suiteArgs).toMatchObject({
+      channelDriver: "crabline",
+      channelDriverSelection: { channel: "matrix", channelDriver: "crabline" },
+      scenarioIds: ["matrix-restart-resume"],
+    });
+  });
+
   it("rejects qa profile runs that do not match taxonomy categories", async () => {
     await expect(
       runQaProfileCommand({
@@ -677,18 +692,54 @@ describe("qa cli runtime", () => {
     );
   });
 
-  it("uses the selected live adapter's YAML profile by default", async () => {
+  it("dispatches one declared-channel scenario through either driver", async () => {
+    for (const channelDriver of ["crabline", "live"] as const) {
+      await runQaSuiteCommand({
+        channelDriver,
+        channel: "telegram",
+        providerMode: "mock-openai",
+        scenarioIds: ["telegram-help-command"],
+      });
+    }
+
+    const [crablineArgs, liveArgs] = runQaSuite.mock.calls.map(([args]) => args);
+    expect(crablineArgs).toMatchObject({
+      channelDriver: "crabline",
+      channelDriverSelection: { channel: "telegram" },
+      scenarioIds: ["telegram-help-command"],
+    });
+    expect(liveArgs).toMatchObject({
+      channelDriver: "live",
+      channelId: "telegram",
+      scenarioIds: ["telegram-help-command"],
+    });
+  });
+
+  it("keeps implicit channel membership identical for live and Crabline drivers", async () => {
     await runQaSuiteCommand({
       channelDriver: "live",
       channel: "telegram",
     });
+    await runQaSuiteCommand({
+      channelDriver: "crabline",
+      channel: "telegram",
+    });
 
-    expect(runQaSuite).toHaveBeenCalledWith(
+    expect(runQaSuite).toHaveBeenNthCalledWith(
+      1,
       expect.objectContaining({
         adapterOptions: expect.objectContaining({ explicitScenarioSelection: false }),
-        scenarioIds: listQaScenariosForExecutionProfile("telegram:adapter").map(
-          (scenario) => scenario.id,
-        ),
+        channelDriver: "live",
+        channelId: "telegram",
+        scenarioIds: [],
+      }),
+    );
+    expect(runQaSuite).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        channelDriver: "crabline",
+        channelDriverSelection: expect.objectContaining({ channel: "telegram" }),
+        scenarioIds: [],
       }),
     );
   });

--- a/extensions/qa-lab/src/cli.runtime.ts
+++ b/extensions/qa-lab/src/cli.runtime.ts
@@ -70,7 +70,6 @@ import {
 } from "./run-config.js";
 import type { RuntimeId } from "./runtime-parity.js";
 import {
-  listQaScenariosForExecutionProfile,
   QA_RUNTIME_PARITY_TIERS,
   readQaScenarioPack,
   type QaRuntimeParityTier,
@@ -788,15 +787,29 @@ export async function runQaProfileCommand(opts: QaProfileCommandOptions) {
   const providerMode = opts.providerMode ?? defaultQaRunProfileProviderMode(profile);
   const normalizedProviderMode = normalizeQaProviderMode(providerMode);
   const primaryModel = opts.primaryModel?.trim() || defaultQaModelForMode(normalizedProviderMode);
-  const scenarios = taxonomyScenarios.filter((scenario) =>
-    scenarioMatchesQaProviderLane({
+  const scenarios = taxonomyScenarios.filter((scenario) => {
+    // qa-channel is the built-in harness channel, so another driver cannot implement it.
+    if (
+      scenario.execution.channel === "qa-channel" &&
+      profileReport.channelDriver !== "qa-channel"
+    ) {
+      return false;
+    }
+    const channel =
+      profileReport.channelDriver === "qa-channel"
+        ? "qa-channel"
+        : (scenario.execution.channel ??
+          (profileReport.channelDriver === "crabline"
+            ? OPENCLAW_CRABLINE_DEFAULT_CHANNEL
+            : undefined));
+    return scenarioMatchesQaProviderLane({
       scenario,
       providerMode: normalizedProviderMode,
       primaryModel,
       channelDriver: profileReport.channelDriver,
-      channel: scenario.execution.channel,
-    }),
-  );
+      channel,
+    });
+  });
   if (scenarios.length === 0) {
     throw new Error(
       `qa run --qa-profile ${profile} did not resolve any executable QA scenarios for provider mode ${normalizedProviderMode}.`,
@@ -847,6 +860,7 @@ function selectQaScenarioDefinitionsForChannelResolution(params: {
   providerMode: QaProviderMode;
   primaryModel: string;
   channelDriver?: QaScorecardChannelDriver | null;
+  channel?: string | null;
   claudeCliAuthMode?: QaCliBackendAuthMode;
 }) {
   const scenarios = readQaScenarioPack().scenarios;
@@ -863,7 +877,7 @@ function selectQaScenarioDefinitionsForChannelResolution(params: {
       providerMode: params.providerMode,
       primaryModel: params.primaryModel,
       channelDriver: params.channelDriver,
-      channel: scenario.execution.channel,
+      channel: params.channel ?? scenario.execution.channel,
       claudeCliAuthMode: params.claudeCliAuthMode,
     }),
   );
@@ -987,14 +1001,6 @@ export async function runQaSuiteCommand(opts: QaSuiteCommandOptions) {
   if (liveChannelId && !liveAdapterFactory) {
     throw new Error(`unknown live QA adapter: ${liveChannelId}`);
   }
-  // liveChannelId exists only for the live driver, and explicit IDs always win.
-  // This keeps adapter profiles out of non-live and explicit-selection paths.
-  const liveScenarioIds =
-    liveAdapterFactory && scenarioIds.length === 0
-      ? listQaScenariosForExecutionProfile(`${liveChannelId}:adapter`).map(
-          (scenario) => scenario.id,
-        )
-      : scenarioIds;
   if (runner !== "host" && runner !== "multipass") {
     throw new Error(`--runner must be one of host or multipass, got "${opts.runner}".`);
   }
@@ -1008,6 +1014,9 @@ export async function runQaSuiteCommand(opts: QaSuiteCommandOptions) {
           providerMode,
           primaryModel: primaryModel ?? defaultQaModelForMode(providerMode),
           channelDriver,
+          // Without an override, discover every declared channel here; the host suite launcher
+          // owns partitioning mixed Crabline runs, while explicit scenario IDs bypass this filter.
+          channel: opts.channel,
           claudeCliAuthMode,
         })
       : [];
@@ -1138,7 +1147,7 @@ export async function runQaSuiteCommand(opts: QaSuiteCommandOptions) {
       failFast: opts.failFast,
       ...(thinkingDefault ? { thinkingDefault } : {}),
       ...(claudeCliAuthMode ? { claudeCliAuthMode } : {}),
-      scenarioIds: liveChannelId ? liveScenarioIds : hostScenarioIds,
+      scenarioIds: liveChannelId ? scenarioIds : hostScenarioIds,
       ...(opts.enabledPluginIds !== undefined ? { enabledPluginIds: opts.enabledPluginIds } : {}),
       ...(liveChannelId
         ? { concurrency: 1 }

--- a/extensions/qa-lab/src/coverage-report.test.ts
+++ b/extensions/qa-lab/src/coverage-report.test.ts
@@ -327,7 +327,7 @@ describe("qa coverage report", () => {
     expect(report).not.toContain("Native test refs");
   });
 
-  it("includes required channel driver flags in scenario match commands", () => {
+  it("includes a runnable channel driver choice in scenario match commands", () => {
     const matches = findQaScenarioMatches(
       readQaScenarioPack().scenarios,
       "whatsapp-access-control-group-disabled",
@@ -342,7 +342,23 @@ describe("qa coverage report", () => {
     );
   });
 
-  it("uses the live lane for channel scenarios without a driver restriction", () => {
+  it("keeps qa-channel scenario commands on the default driver", () => {
+    const matches = findQaScenarioMatches(
+      readQaScenarioPack().scenarios,
+      "instruction-followthrough-repo-contract",
+    );
+    const report = renderQaScenarioMatchesMarkdownReport({
+      query: "instruction-followthrough-repo-contract",
+      matches,
+    });
+
+    expect(report).toContain(
+      "- Suite command: `pnpm openclaw qa suite --scenario instruction-followthrough-repo-contract`",
+    );
+    expect(report).not.toContain("--channel-driver live --channel qa-channel");
+  });
+
+  it("uses the live lane as the coverage-report default for channel scenarios", () => {
     const matches = findQaScenarioMatches(readQaScenarioPack().scenarios, "dm-per-room-session");
     const report = renderQaScenarioMatchesMarkdownReport({
       query: "dm-per-room-session",

--- a/extensions/qa-lab/src/coverage-report.ts
+++ b/extensions/qa-lab/src/coverage-report.ts
@@ -24,7 +24,6 @@ type QaScenarioSearchMatch = QaCoverageScenarioSummary & {
   executionPath?: string;
   runtimeParityTier?: string;
   requiredProviderMode?: string;
-  driver?: string;
   requiredProvider?: string;
   requiredModel?: string;
 };
@@ -163,7 +162,6 @@ function summarizeScenarioSearchMatch(scenario: QaSeedScenarioWithSource): QaSce
     ...(scenario.execution.kind !== "flow" ? { executionPath: scenario.execution.path } : {}),
     runtimeParityTier: scenario.runtimeParityTier,
     requiredProviderMode: stringifyConfigValue(config.requiredProviderMode),
-    driver: scenario.execution.driver,
     requiredProvider: stringifyConfigValue(config.requiredProvider),
     requiredModel: stringifyConfigValue(config.requiredModel),
   };
@@ -440,7 +438,6 @@ function formatOptionalScenarioMetadata(match: QaScenarioSearchMatch) {
   const metadata = [
     match.runtimeParityTier ? `runtimeParityTier=${match.runtimeParityTier}` : "",
     match.requiredProviderMode ? `providerMode=${match.requiredProviderMode}` : "",
-    match.driver ? `channelDriver=${match.driver}` : "",
     match.requiredProvider ? `provider=${match.requiredProvider}` : "",
     match.requiredModel ? `model=${match.requiredModel}` : "",
   ].filter(Boolean);
@@ -453,20 +450,18 @@ function uniqueScenarioValues(values: (string | undefined)[]) {
 
 function formatSuiteCommand(matches: readonly QaScenarioSearchMatch[]) {
   const scenarioArgs = matches.map((match) => `--scenario ${match.id}`).join(" ");
-  const requiredDrivers = uniqueScenarioValues(matches.map((match) => match.driver));
   const channels = uniqueScenarioValues(matches.map((match) => match.channel));
-  const selectedDriver =
-    requiredDrivers.length === 1 ? requiredDrivers[0] : channels.length === 1 ? "live" : undefined;
-  const driverArg =
-    selectedDriver && selectedDriver !== "qa-channel" ? ` --channel-driver ${selectedDriver}` : "";
-  const channelArg = driverArg && channels.length === 1 ? ` --channel ${channels[0]}` : "";
+  const [channel] = channels;
+  const selectedDriver = channels.length === 1 && channel !== "qa-channel" ? "live" : undefined;
+  const driverArg = selectedDriver ? ` --channel-driver ${selectedDriver}` : "";
+  const channelArg = driverArg && channel ? ` --channel ${channel}` : "";
   return `pnpm openclaw qa suite${driverArg}${channelArg} ${scenarioArgs}`;
 }
 
 function scenarioMatchCommandGroups(matches: readonly QaScenarioSearchMatch[]) {
   const groups = new Map<string, QaScenarioSearchMatch[]>();
   for (const match of matches) {
-    const key = JSON.stringify([match.executionKind, match.channel, match.driver]);
+    const key = JSON.stringify([match.executionKind, match.channel]);
     const group = groups.get(key) ?? [];
     group.push(match);
     groups.set(key, group);

--- a/extensions/qa-lab/src/scenario-catalog.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog.test.ts
@@ -846,23 +846,28 @@ describe("qa scenario catalog", () => {
       "Mission: prove you followed the repo contract.",
     );
     expect(config?.prompt).toContain("Repo contract followthrough check.");
-    expect(scenario.execution.driver).toBe("qa-channel");
+    expect(scenario.execution.channel).toBe("qa-channel");
     expect(config?.expectedReplyAll).toEqual(["read:", "wrote:", "status:"]);
     expect(config?.expectedArtifactAll).toEqual(["repo contract"]);
     expect(config?.expectedArtifactAny).toContain("evidence path");
     expect(scenario.title).toBe("Instruction followthrough repo contract");
   });
 
-  it("keeps native QA-channel fixtures out of Crabline profile selection", () => {
+  it("declares native QA-channel fixtures by channel", () => {
     const scenarioIds = [
+      "instruction-followthrough-repo-contract",
       "subagent-forked-context",
       "subagent-handoff",
+      "a2a-message-tool-mirror-dedupe",
       "group-message-tool-unavailable-fallback",
       "qa-channel-reconnect-dedupe",
       "reaction-edit-delete",
       "image-generation-roundtrip",
       "image-understanding-attachment",
       "native-image-generation",
+      "goal-context-next-turn",
+      "goal-context-survives-compaction",
+      "goal-followthrough-live",
       "active-memory-preprompt-recall",
       "memory-recall",
       "session-memory-ranking",
@@ -870,15 +875,17 @@ describe("qa scenario catalog", () => {
       "personal-channel-thread-reply",
       "personal-memory-preference-recall",
       "personal-reminder-roundtrip",
+      "cron-condition-watcher",
       "cron-natural-fire-no-duplicate",
       "cron-one-minute-ping",
       "cron-single-run-no-duplicate",
       "control-ui-qa-channel-image-roundtrip",
+      "control-ui-assistant-transcript-role-boundary",
       "config-apply-restart-wakeup",
     ];
 
     for (const scenarioId of scenarioIds) {
-      expect(readQaScenarioById(scenarioId).execution.driver, scenarioId).toBe("qa-channel");
+      expect(readQaScenarioById(scenarioId).execution.channel, scenarioId).toBe("qa-channel");
     }
   });
 
@@ -887,7 +894,6 @@ describe("qa scenario catalog", () => {
       const scenario = readQaScenarioById(scenarioId);
 
       expect(scenario.execution.channel, scenarioId).toBeUndefined();
-      expect(scenario.execution.driver, scenarioId).toBeUndefined();
       expect(Object.keys(scenario.execution.profiles ?? {}), scenarioId).toEqual(
         expect.arrayContaining(["matrix:adapter", "slack:adapter"]),
       );
@@ -898,7 +904,6 @@ describe("qa scenario catalog", () => {
     const scenario = readQaScenarioById("subagent-thread-spawn");
 
     expect(scenario.execution.channel).toBe("matrix");
-    expect(scenario.execution.driver).toBe("live");
   });
 
   it("routes native command session targeting through Crabline Telegram", () => {
@@ -910,24 +915,23 @@ describe("qa scenario catalog", () => {
       | undefined;
 
     expect(scenario.execution.channel).toBe("telegram");
-    expect(scenario.execution.driver).toBeUndefined();
     expect(config?.requiredProviderMode).toBe("mock-openai");
   });
 
-  it("marks channel-owned scenarios that require the live driver", () => {
-    const liveScenarioIds = [
-      "slack-restart-resume",
-      "whatsapp-restart-resume",
-      "whatsapp-access-control-dm-disabled",
-      "whatsapp-access-control-dm-open",
-      "whatsapp-access-control-group-disabled",
-      "whatsapp-access-control-group-open",
-      "whatsapp-pairing-block",
-      "matrix-allowlist-hot-reload",
-    ];
+  it("keeps channel-owned scenarios independent from the driver implementation", () => {
+    const channelByScenarioId = new Map([
+      ["slack-restart-resume", "slack"],
+      ["whatsapp-restart-resume", "whatsapp"],
+      ["whatsapp-access-control-dm-disabled", "whatsapp"],
+      ["whatsapp-access-control-dm-open", "whatsapp"],
+      ["whatsapp-access-control-group-disabled", "whatsapp"],
+      ["whatsapp-access-control-group-open", "whatsapp"],
+      ["whatsapp-pairing-block", "whatsapp"],
+      ["matrix-allowlist-hot-reload", "matrix"],
+    ]);
 
-    for (const scenarioId of liveScenarioIds) {
-      expect(readQaScenarioById(scenarioId).execution.driver, scenarioId).toBe("live");
+    for (const [scenarioId, channel] of channelByScenarioId) {
+      expect(readQaScenarioById(scenarioId).execution.channel, scenarioId).toBe(channel);
     }
   });
 

--- a/extensions/qa-lab/src/scenario-catalog.ts
+++ b/extensions/qa-lab/src/scenario-catalog.ts
@@ -66,7 +66,6 @@ const qaScenarioChannelSchema = z
     message: "scenario execution channel ids must use lowercase dotted or dashed tokens",
   });
 
-const qaScenarioDriverSchema = z.enum(["qa-channel", "crabline", "live"]);
 const qaScenarioProfileSchema = z
   .string()
   .trim()
@@ -85,7 +84,6 @@ const qaFlowScenarioExecutionSchema = z
     kind: z.literal("flow").default("flow"),
     summary: z.string().trim().min(1).optional(),
     channel: qaScenarioChannelSchema.optional(),
-    driver: qaScenarioDriverSchema.optional(),
     profiles: z.record(qaScenarioProfileSchema, z.number().int().nonnegative()).optional(),
     suiteIsolation: z.literal("isolated").optional(),
     isolationReason: z.string().trim().min(1).optional(),
@@ -97,7 +95,6 @@ const qaFlowScenarioExecutionSchema = z
 const qaTestFileScenarioExecutionBaseSchema = z.object({
   summary: z.string().trim().min(1).optional(),
   channel: qaScenarioChannelSchema.optional(),
-  driver: qaScenarioDriverSchema.optional(),
   profiles: z.record(qaScenarioProfileSchema, z.number().int().nonnegative()).optional(),
   path: qaScenarioRepoRefSchema,
   config: qaScenarioConfigSchema.optional(),

--- a/extensions/qa-lab/src/scenario-lane.test.ts
+++ b/extensions/qa-lab/src/scenario-lane.test.ts
@@ -10,7 +10,6 @@ describe("QA scenario lane matching", () => {
   it("reports every declared mismatch in one decision", () => {
     const scenario = makeQaSuiteTestScenario("strict-live-lane", {
       channel: "matrix",
-      driver: "live",
       runtimeParityTier: "live-only",
       config: {
         requiredProviderMode: "live-frontier",
@@ -32,12 +31,56 @@ describe("QA scenario lane matching", () => {
     ).toEqual([
       "live provider mode",
       "providerMode=live-frontier",
-      "channelDriver=live",
       "channel=matrix",
       "provider=claude-cli",
       "model=claude-sonnet-4-6",
       "authMode=subscription",
     ]);
+  });
+
+  it("keeps provider contracts independent from the selected channel driver", () => {
+    const scenario = makeQaSuiteTestScenario("portable-telegram", {
+      channel: "telegram",
+      config: {
+        requiredProvider: "openai",
+        requiredModel: "gpt-5.6-luna",
+      },
+    });
+
+    expect(
+      scenarioMatchesQaProviderLane({
+        scenario,
+        providerMode: "live-frontier",
+        primaryModel: "openai/gpt-5.6-luna",
+        channelDriver: "crabline",
+        channel: "telegram",
+      }),
+    ).toBe(true);
+    expect(
+      scenarioMatchesQaProviderLane({
+        scenario,
+        providerMode: "mock-openai",
+        primaryModel: "openai/gpt-5.6-luna",
+        channelDriver: "live",
+        channel: "telegram",
+      }),
+    ).toBe(true);
+  });
+
+  it("keeps the built-in driver bound to the qa-channel channel", () => {
+    const scenario = makeQaSuiteTestScenario("telegram-only", {
+      channel: "telegram",
+    });
+
+    expect(
+      scenarioMatchesQaProviderLane({
+        scenario,
+        providerMode: "mock-openai",
+        primaryModel: "mock-openai/gpt-5.6-luna",
+        channelDriver: "qa-channel",
+        channel: "telegram",
+      }),
+    ).toBe(false);
   });
 
   it("accepts a mock lane only when its selected provider and model satisfy the contract", () => {

--- a/extensions/qa-lab/src/scenario-lane.ts
+++ b/extensions/qa-lab/src/scenario-lane.ts
@@ -28,16 +28,13 @@ export function describeQaProviderLaneMismatches(params: {
   if (requiredProviderMode && params.providerMode !== requiredProviderMode) {
     mismatches.push(`providerMode=${requiredProviderMode}`);
   }
-  const requiredDriver = params.scenario.execution.driver;
   const effectiveChannelDriver = params.channelDriver ?? "qa-channel";
-  if (requiredDriver && effectiveChannelDriver !== requiredDriver) {
-    mismatches.push(`channelDriver=${requiredDriver}`);
-  }
+  const effectiveChannel =
+    effectiveChannelDriver === "qa-channel"
+      ? "qa-channel"
+      : params.channel?.trim().toLowerCase() || undefined;
   const scenarioChannel = params.scenario.execution.channel?.trim().toLowerCase();
-  if (
-    scenarioChannel &&
-    (effectiveChannelDriver === "qa-channel" || params.channel !== scenarioChannel)
-  ) {
+  if (scenarioChannel && effectiveChannel !== scenarioChannel) {
     mismatches.push(`channel=${scenarioChannel}`);
   }
   const selected = splitQaModelRef(params.primaryModel);

--- a/extensions/qa-lab/src/suite-planning.test.ts
+++ b/extensions/qa-lab/src/suite-planning.test.ts
@@ -371,7 +371,6 @@ describe("qa suite planning helpers", () => {
     const scenarios = [
       makeQaSuiteTestScenario("strict-live-lane", {
         channel: "matrix",
-        driver: "live",
         runtimeParityTier: "live-only",
         config: {
           requiredProviderMode: "live-frontier",
@@ -804,40 +803,35 @@ describe("qa suite planning helpers", () => {
     ).toEqual(["generic", "live-only"]);
   });
 
-  it("filters channel-driver-specific scenarios from implicit suite selections", () => {
+  it("keeps implicit scenario membership identical across channel drivers", () => {
     const scenarios = [
       makeQaSuiteTestScenario("generic"),
-      makeQaSuiteTestScenario("qa-channel-only", {
-        driver: "qa-channel",
+      makeQaSuiteTestScenario("telegram", {
+        channel: "telegram",
       }),
-      makeQaSuiteTestScenario("crabline-only", {
-        driver: "crabline",
+      makeQaSuiteTestScenario("matrix", {
+        channel: "matrix",
       }),
     ];
 
-    expect(
+    const selectForDriver = (channelDriver: "crabline" | "live") =>
       selectQaFlowSuiteScenarios({
         scenarios,
         providerMode: "mock-openai",
         primaryModel: "mock-openai/gpt-5.6-luna",
-      }).map((scenario) => scenario.id),
-    ).toEqual(["generic", "qa-channel-only"]);
+        channelDriver,
+        channel: "telegram",
+      }).map((scenario) => scenario.id);
 
-    expect(
-      selectQaFlowSuiteScenarios({
-        scenarios,
-        providerMode: "mock-openai",
-        primaryModel: "mock-openai/gpt-5.6-luna",
-        channelDriver: "crabline",
-      }).map((scenario) => scenario.id),
-    ).toEqual(["generic", "crabline-only"]);
+    expect(selectForDriver("crabline")).toEqual(["generic", "telegram"]);
+    expect(selectForDriver("live")).toEqual(selectForDriver("crabline"));
   });
 
   it("rejects explicitly requested scenarios that do not match the current lane", () => {
     const scenarios = [
       makeQaSuiteTestScenario("generic"),
       makeQaSuiteTestScenario("qa-channel-only", {
-        driver: "qa-channel",
+        channel: "qa-channel",
       }),
     ];
 
@@ -848,9 +842,10 @@ describe("qa suite planning helpers", () => {
         providerMode: "mock-openai",
         primaryModel: "mock-openai/gpt-5.6-luna",
         channelDriver: "crabline",
+        channel: "telegram",
       }),
     ).toThrow(
-      "selected QA scenario(s) do not match the current QA lane: qa-channel-only (channelDriver=qa-channel)",
+      "selected QA scenario(s) do not match the current QA lane: qa-channel-only (channel=qa-channel)",
     );
 
     expect(

--- a/extensions/qa-lab/src/suite-test-helpers.ts
+++ b/extensions/qa-lab/src/suite-test-helpers.ts
@@ -8,7 +8,6 @@ export function makeQaSuiteTestScenario(
   id: string,
   params: {
     channel?: string;
-    driver?: QaSuiteTestScenario["execution"]["driver"];
     config?: Record<string, unknown>;
     plugins?: string[];
     gatewayConfigPatch?: Record<string, unknown>;
@@ -33,7 +32,6 @@ export function makeQaSuiteTestScenario(
     execution: {
       kind: "flow",
       ...(params.channel ? { channel: params.channel } : {}),
-      ...(params.driver ? { driver: params.driver } : {}),
       ...(params.suiteIsolation ? { suiteIsolation: params.suiteIsolation } : {}),
       ...(params.transportPolicy ? { transportPolicy: params.transportPolicy } : {}),
       ...(params.config ? { config: params.config } : {}),

--- a/extensions/qa-lab/src/suite.test.ts
+++ b/extensions/qa-lab/src/suite.test.ts
@@ -496,7 +496,7 @@ describe("qa suite", () => {
     }
   });
 
-  it("writes Crabline channel-driver smoke artifacts when selected", async () => {
+  it("writes the selected Crabline driver with an honest failed result", async () => {
     const outputDir = await tempDirs.makeTempDir("qa-suite-crabline-");
     try {
       fetchWithSsrFGuardMock.mockResolvedValue({
@@ -517,7 +517,14 @@ describe("qa suite", () => {
         outputDir,
         startedAt: new Date("2026-04-11T00:00:00.000Z"),
         finishedAt: new Date("2026-04-11T00:01:00.000Z"),
-        scenarios: [{ name: "Telegram DM", status: "pass", steps: [] }],
+        scenarios: [
+          {
+            name: "Telegram DM",
+            status: "fail",
+            details: "active transport does not implement this scenario",
+            steps: [],
+          },
+        ],
         scenarioDefinitions: [
           {
             ...makeQaSuiteTestScenario("telegram-dm", {
@@ -576,11 +583,18 @@ describe("qa suite", () => {
       ) as { smoke?: { result?: { ok?: boolean; provider?: string } } };
       expect(smoke.smoke?.result).toMatchObject({ ok: true, provider: "telegram" });
       const evidence = JSON.parse(await fs.readFile(artifacts.evidencePath, "utf8")) as {
-        entries?: Array<{ execution?: { channel?: { driver?: string; id?: string } } }>;
+        entries?: Array<{
+          execution?: { channel?: { driver?: string; id?: string } };
+          result?: { failure?: { reason?: string }; status?: string };
+        }>;
       };
       expect(evidence.entries?.[0]?.execution?.channel).toMatchObject({
         driver: "crabline",
         id: "telegram",
+      });
+      expect(evidence.entries?.[0]?.result).toMatchObject({
+        failure: { reason: "active transport does not implement this scenario" },
+        status: "fail",
       });
     } finally {
       await fs.rm(outputDir, { recursive: true, force: true });

--- a/qa/scenarios/agents/instruction-followthrough-repo-contract.yaml
+++ b/qa/scenarios/agents/instruction-followthrough-repo-contract.yaml
@@ -24,7 +24,7 @@ scenario:
   execution:
     kind: flow
     summary: Verify the agent reads repo instructions first, then completes the first bounded followthrough task without stalling.
-    driver: qa-channel
+    channel: qa-channel
     config:
       workspaceFiles:
         AGENT.md: |-

--- a/qa/scenarios/agents/subagent-forked-context.yaml
+++ b/qa/scenarios/agents/subagent-forked-context.yaml
@@ -21,7 +21,7 @@ scenario:
   execution:
     kind: flow
     summary: Ask the agent to delegate work that depends on the current transcript and assert sessions_spawn carries context=fork.
-    driver: qa-channel
+    channel: qa-channel
     config:
       contextNeedle: FORKED-CONTEXT-ALPHA
       prompt: "Forked subagent context QA check. The visible code in this current conversation is FORKED-CONTEXT-ALPHA. Delegate to a native subagent to report the visible code from the requester transcript. Do not include the visible code in the child task text; the child must recover it from forked transcript context. Use forked context if the child needs the current transcript; otherwise it will not know the code. A spawn-accepted result is not the answer. Wait for the child completion, then make sure user-visible output includes the visible code."

--- a/qa/scenarios/agents/subagent-handoff.yaml
+++ b/qa/scenarios/agents/subagent-handoff.yaml
@@ -20,7 +20,7 @@ scenario:
   execution:
     kind: flow
     summary: Verify the agent can delegate a bounded task to a subagent and fold the result back into the main thread.
-    driver: qa-channel
+    channel: qa-channel
     config:
       prompt: "Delegate one bounded QA task to a subagent. Wait for the subagent to finish. Then reply with three labeled sections exactly once: Delegated task, Result, Evidence. Include the child result itself, not 'waiting'."
 

--- a/qa/scenarios/channels/a2a-message-tool-mirror-dedupe.yaml
+++ b/qa/scenarios/channels/a2a-message-tool-mirror-dedupe.yaml
@@ -37,7 +37,7 @@ scenario:
     - src/shared/transcript-only-openclaw-assistant.ts
   execution:
     kind: flow
-    driver: qa-channel
+    channel: qa-channel
     summary: Run a real QA Gateway/qa-channel A2A source-reply turn and assert the message-tool delivery mirror is not announced again.
     config:
       requiredProviderMode: mock-openai

--- a/qa/scenarios/channels/group-message-tool-unavailable-fallback.yaml
+++ b/qa/scenarios/channels/group-message-tool-unavailable-fallback.yaml
@@ -34,7 +34,7 @@ scenario:
   execution:
     kind: flow
     summary: Verify message_tool visible replies degrade to automatic delivery when the active group policy removes message.
-    driver: qa-channel
+    channel: qa-channel
     config:
       conversationId: qa-fallback-room
       promptSnippet: qa group message unavailable fallback check

--- a/qa/scenarios/channels/matrix-allowbots-default-block.yaml
+++ b/qa/scenarios/channels/matrix-allowbots-default-block.yaml
@@ -11,7 +11,6 @@ scenario:
     channel: matrix
     timeoutMs: 8000
     retryCount: 0
-    driver: live
     config:
       matrixConfigOverrides:
         configuredBotRoles:

--- a/qa/scenarios/channels/matrix-allowbots-mentions-dm-unmentioned.yaml
+++ b/qa/scenarios/channels/matrix-allowbots-mentions-dm-unmentioned.yaml
@@ -11,7 +11,6 @@ scenario:
     channel: matrix
     timeoutMs: 45000
     retryCount: 0
-    driver: live
     config:
       matrixConfigOverrides:
         allowBots: mentions

--- a/qa/scenarios/channels/matrix-allowbots-mentions-mentioned-room.yaml
+++ b/qa/scenarios/channels/matrix-allowbots-mentions-mentioned-room.yaml
@@ -11,7 +11,6 @@ scenario:
     channel: matrix
     timeoutMs: 45000
     retryCount: 0
-    driver: live
     config:
       matrixConfigOverrides:
         allowBots: mentions

--- a/qa/scenarios/channels/matrix-allowbots-mentions-unmentioned-open-room-block.yaml
+++ b/qa/scenarios/channels/matrix-allowbots-mentions-unmentioned-open-room-block.yaml
@@ -11,7 +11,6 @@ scenario:
     channel: matrix
     timeoutMs: 8000
     retryCount: 0
-    driver: live
     config:
       matrixConfigOverrides:
         allowBots: mentions

--- a/qa/scenarios/channels/matrix-allowbots-room-override-blocks-account-true.yaml
+++ b/qa/scenarios/channels/matrix-allowbots-room-override-blocks-account-true.yaml
@@ -11,7 +11,6 @@ scenario:
     channel: matrix
     timeoutMs: 8000
     retryCount: 0
-    driver: live
     config:
       matrixConfigOverrides:
         allowBots: true

--- a/qa/scenarios/channels/matrix-allowbots-room-override-enables-account-off.yaml
+++ b/qa/scenarios/channels/matrix-allowbots-room-override-enables-account-off.yaml
@@ -11,7 +11,6 @@ scenario:
     channel: matrix
     timeoutMs: 45000
     retryCount: 0
-    driver: live
     config:
       matrixConfigOverrides:
         configuredBotRoles:

--- a/qa/scenarios/channels/matrix-allowbots-self-sender-ignored.yaml
+++ b/qa/scenarios/channels/matrix-allowbots-self-sender-ignored.yaml
@@ -11,7 +11,6 @@ scenario:
     channel: matrix
     timeoutMs: 8000
     retryCount: 0
-    driver: live
     config:
       matrixConfigOverrides:
         allowBots: true

--- a/qa/scenarios/channels/matrix-allowbots-true-unmentioned-open-room.yaml
+++ b/qa/scenarios/channels/matrix-allowbots-true-unmentioned-open-room.yaml
@@ -11,7 +11,6 @@ scenario:
     channel: matrix
     timeoutMs: 45000
     retryCount: 0
-    driver: live
     config:
       matrixConfigOverrides:
         allowBots: true

--- a/qa/scenarios/channels/matrix-allowlist-hot-reload.yaml
+++ b/qa/scenarios/channels/matrix-allowlist-hot-reload.yaml
@@ -22,7 +22,6 @@ scenario:
     retryCount: 0
     suiteIsolation: isolated
     summary: Exercise Matrix observer-role allowlist hot reload through normalized transport state.
-    driver: live
     config:
       accountId: sut
 

--- a/qa/scenarios/channels/matrix-approval-channel-target-both.yaml
+++ b/qa/scenarios/channels/matrix-approval-channel-target-both.yaml
@@ -11,7 +11,6 @@ scenario:
     channel: matrix
     timeoutMs: 90000
     retryCount: 0
-    driver: live
     config:
       matrixConfigOverrides:
         approvalForwarding:

--- a/qa/scenarios/channels/matrix-approval-deny-reaction.yaml
+++ b/qa/scenarios/channels/matrix-approval-deny-reaction.yaml
@@ -11,7 +11,6 @@ scenario:
     channel: matrix
     timeoutMs: 75000
     retryCount: 0
-    driver: live
     config:
       matrixConfigOverrides:
         approvalForwarding:

--- a/qa/scenarios/channels/matrix-approval-exec-metadata-chunked.yaml
+++ b/qa/scenarios/channels/matrix-approval-exec-metadata-chunked.yaml
@@ -11,7 +11,6 @@ scenario:
     channel: matrix
     timeoutMs: 90000
     retryCount: 0
-    driver: live
     config:
       matrixConfigOverrides:
         approvalForwarding:

--- a/qa/scenarios/channels/matrix-approval-exec-metadata-single-event.yaml
+++ b/qa/scenarios/channels/matrix-approval-exec-metadata-single-event.yaml
@@ -11,7 +11,6 @@ scenario:
     channel: matrix
     timeoutMs: 75000
     retryCount: 0
-    driver: live
     config:
       matrixConfigOverrides:
         approvalForwarding:

--- a/qa/scenarios/channels/matrix-approval-plugin-metadata-single-event.yaml
+++ b/qa/scenarios/channels/matrix-approval-plugin-metadata-single-event.yaml
@@ -11,7 +11,6 @@ scenario:
     channel: matrix
     timeoutMs: 75000
     retryCount: 0
-    driver: live
     config:
       matrixConfigOverrides:
         approvalForwarding:

--- a/qa/scenarios/channels/matrix-approval-thread-target.yaml
+++ b/qa/scenarios/channels/matrix-approval-thread-target.yaml
@@ -11,7 +11,6 @@ scenario:
     channel: matrix
     timeoutMs: 75000
     retryCount: 0
-    driver: live
     config:
       matrixConfigOverrides:
         approvalForwarding:

--- a/qa/scenarios/channels/matrix-attachment-only-ignored.yaml
+++ b/qa/scenarios/channels/matrix-attachment-only-ignored.yaml
@@ -13,7 +13,6 @@ scenario:
     channel: matrix
     timeoutMs: 8000
     retryCount: 0
-    driver: live
     config:
       matrixTopology:
         defaultRoomKey: main

--- a/qa/scenarios/channels/matrix-dm-thread-reply-override.yaml
+++ b/qa/scenarios/channels/matrix-dm-thread-reply-override.yaml
@@ -13,7 +13,6 @@ scenario:
     channel: matrix
     timeoutMs: 45000
     retryCount: 0
-    driver: live
     config:
       matrixConfigOverrides:
         dm:

--- a/qa/scenarios/channels/matrix-e2ee-artifact-redaction.yaml
+++ b/qa/scenarios/channels/matrix-e2ee-artifact-redaction.yaml
@@ -11,7 +11,6 @@ scenario:
     channel: matrix
     timeoutMs: 150000
     retryCount: 0
-    driver: live
     config:
       matrixConfigOverrides:
         encryption: true

--- a/qa/scenarios/channels/matrix-e2ee-basic-reply.yaml
+++ b/qa/scenarios/channels/matrix-e2ee-basic-reply.yaml
@@ -11,7 +11,6 @@ scenario:
     channel: matrix
     timeoutMs: 75000
     retryCount: 0
-    driver: live
     config:
       matrixConfigOverrides:
         encryption: true

--- a/qa/scenarios/channels/matrix-e2ee-bootstrap-success.yaml
+++ b/qa/scenarios/channels/matrix-e2ee-bootstrap-success.yaml
@@ -11,7 +11,6 @@ scenario:
     channel: matrix
     timeoutMs: 90000
     retryCount: 0
-    driver: live
     config:
       matrixConfigOverrides:
         encryption: true

--- a/qa/scenarios/channels/matrix-e2ee-cli-account-add-enable-e2ee.yaml
+++ b/qa/scenarios/channels/matrix-e2ee-cli-account-add-enable-e2ee.yaml
@@ -11,7 +11,6 @@ scenario:
     channel: matrix
     timeoutMs: 120000
     retryCount: 0
-    driver: live
     config:
       matrixConfigOverrides:
         encryption: true

--- a/qa/scenarios/channels/matrix-e2ee-cli-encryption-setup-bootstrap-failure.yaml
+++ b/qa/scenarios/channels/matrix-e2ee-cli-encryption-setup-bootstrap-failure.yaml
@@ -11,7 +11,6 @@ scenario:
     channel: matrix
     timeoutMs: 120000
     retryCount: 0
-    driver: live
     config:
       matrixConfigOverrides:
         encryption: true

--- a/qa/scenarios/channels/matrix-e2ee-cli-encryption-setup-idempotent.yaml
+++ b/qa/scenarios/channels/matrix-e2ee-cli-encryption-setup-idempotent.yaml
@@ -11,7 +11,6 @@ scenario:
     channel: matrix
     timeoutMs: 120000
     retryCount: 0
-    driver: live
     config:
       matrixConfigOverrides:
         encryption: true

--- a/qa/scenarios/channels/matrix-e2ee-cli-encryption-setup-multi-account.yaml
+++ b/qa/scenarios/channels/matrix-e2ee-cli-encryption-setup-multi-account.yaml
@@ -11,7 +11,6 @@ scenario:
     channel: matrix
     timeoutMs: 120000
     retryCount: 0
-    driver: live
     config:
       matrixConfigOverrides:
         encryption: true

--- a/qa/scenarios/channels/matrix-e2ee-cli-encryption-setup.yaml
+++ b/qa/scenarios/channels/matrix-e2ee-cli-encryption-setup.yaml
@@ -11,7 +11,6 @@ scenario:
     channel: matrix
     timeoutMs: 120000
     retryCount: 0
-    driver: live
     config:
       matrixConfigOverrides:
         encryption: true

--- a/qa/scenarios/channels/matrix-e2ee-cli-recovery-key-invalid.yaml
+++ b/qa/scenarios/channels/matrix-e2ee-cli-recovery-key-invalid.yaml
@@ -11,7 +11,6 @@ scenario:
     channel: matrix
     timeoutMs: 120000
     retryCount: 0
-    driver: live
     config:
       matrixConfigOverrides:
         encryption: true

--- a/qa/scenarios/channels/matrix-e2ee-cli-recovery-key-setup.yaml
+++ b/qa/scenarios/channels/matrix-e2ee-cli-recovery-key-setup.yaml
@@ -11,7 +11,6 @@ scenario:
     channel: matrix
     timeoutMs: 120000
     retryCount: 0
-    driver: live
     config:
       matrixConfigOverrides:
         encryption: true

--- a/qa/scenarios/channels/matrix-e2ee-cli-self-verification.yaml
+++ b/qa/scenarios/channels/matrix-e2ee-cli-self-verification.yaml
@@ -11,7 +11,6 @@ scenario:
     channel: matrix
     timeoutMs: 180000
     retryCount: 0
-    driver: live
     config:
       matrixTopology:
         defaultRoomKey: main

--- a/qa/scenarios/channels/matrix-e2ee-cli-setup-then-gateway-reply.yaml
+++ b/qa/scenarios/channels/matrix-e2ee-cli-setup-then-gateway-reply.yaml
@@ -11,7 +11,6 @@ scenario:
     channel: matrix
     timeoutMs: 180000
     retryCount: 0
-    driver: live
     config:
       matrixConfigOverrides:
         encryption: false

--- a/qa/scenarios/channels/matrix-e2ee-corrupt-crypto-idb-snapshot.yaml
+++ b/qa/scenarios/channels/matrix-e2ee-corrupt-crypto-idb-snapshot.yaml
@@ -11,7 +11,6 @@ scenario:
     channel: matrix
     timeoutMs: 180000
     retryCount: 0
-    driver: live
     config:
       matrixConfigOverrides:
         encryption: true

--- a/qa/scenarios/channels/matrix-e2ee-device-sas-verification.yaml
+++ b/qa/scenarios/channels/matrix-e2ee-device-sas-verification.yaml
@@ -11,7 +11,6 @@ scenario:
     channel: matrix
     timeoutMs: 90000
     retryCount: 0
-    driver: live
     config:
       matrixConfigOverrides:
         encryption: true

--- a/qa/scenarios/channels/matrix-e2ee-dm-sas-verification.yaml
+++ b/qa/scenarios/channels/matrix-e2ee-dm-sas-verification.yaml
@@ -11,7 +11,6 @@ scenario:
     channel: matrix
     timeoutMs: 90000
     retryCount: 0
-    driver: live
     config:
       matrixConfigOverrides:
         encryption: true

--- a/qa/scenarios/channels/matrix-e2ee-history-exists-backup-empty.yaml
+++ b/qa/scenarios/channels/matrix-e2ee-history-exists-backup-empty.yaml
@@ -11,7 +11,6 @@ scenario:
     channel: matrix
     timeoutMs: 180000
     retryCount: 0
-    driver: live
     config:
       matrixConfigOverrides:
         encryption: true

--- a/qa/scenarios/channels/matrix-e2ee-key-bootstrap-failure.yaml
+++ b/qa/scenarios/channels/matrix-e2ee-key-bootstrap-failure.yaml
@@ -11,7 +11,6 @@ scenario:
     channel: matrix
     timeoutMs: 90000
     retryCount: 0
-    driver: live
     config:
       matrixConfigOverrides:
         encryption: true

--- a/qa/scenarios/channels/matrix-e2ee-media-image.yaml
+++ b/qa/scenarios/channels/matrix-e2ee-media-image.yaml
@@ -11,7 +11,6 @@ scenario:
     channel: matrix
     timeoutMs: 180000
     retryCount: 0
-    driver: live
     config:
       matrixConfigOverrides:
         encryption: true

--- a/qa/scenarios/channels/matrix-e2ee-qr-verification.yaml
+++ b/qa/scenarios/channels/matrix-e2ee-qr-verification.yaml
@@ -11,7 +11,6 @@ scenario:
     channel: matrix
     timeoutMs: 90000
     retryCount: 0
-    driver: live
     config:
       matrixConfigOverrides:
         encryption: true

--- a/qa/scenarios/channels/matrix-e2ee-recovery-key-lifecycle.yaml
+++ b/qa/scenarios/channels/matrix-e2ee-recovery-key-lifecycle.yaml
@@ -11,7 +11,6 @@ scenario:
     channel: matrix
     timeoutMs: 90000
     retryCount: 0
-    driver: live
     config:
       matrixConfigOverrides:
         encryption: true

--- a/qa/scenarios/channels/matrix-e2ee-recovery-owner-verification-required.yaml
+++ b/qa/scenarios/channels/matrix-e2ee-recovery-owner-verification-required.yaml
@@ -11,7 +11,6 @@ scenario:
     channel: matrix
     timeoutMs: 90000
     retryCount: 0
-    driver: live
     config:
       matrixConfigOverrides:
         encryption: true

--- a/qa/scenarios/channels/matrix-e2ee-restart-resume.yaml
+++ b/qa/scenarios/channels/matrix-e2ee-restart-resume.yaml
@@ -11,7 +11,6 @@ scenario:
     channel: matrix
     timeoutMs: 150000
     retryCount: 0
-    driver: live
     config:
       matrixConfigOverrides:
         encryption: true

--- a/qa/scenarios/channels/matrix-e2ee-server-backup-deleted-local-reupload-restores.yaml
+++ b/qa/scenarios/channels/matrix-e2ee-server-backup-deleted-local-reupload-restores.yaml
@@ -11,7 +11,6 @@ scenario:
     channel: matrix
     timeoutMs: 180000
     retryCount: 0
-    driver: live
     config:
       matrixConfigOverrides:
         encryption: true

--- a/qa/scenarios/channels/matrix-e2ee-server-backup-deleted-local-state-intact.yaml
+++ b/qa/scenarios/channels/matrix-e2ee-server-backup-deleted-local-state-intact.yaml
@@ -11,7 +11,6 @@ scenario:
     channel: matrix
     timeoutMs: 120000
     retryCount: 0
-    driver: live
     config:
       matrixConfigOverrides:
         encryption: true

--- a/qa/scenarios/channels/matrix-e2ee-server-device-deleted-local-state-intact.yaml
+++ b/qa/scenarios/channels/matrix-e2ee-server-device-deleted-local-state-intact.yaml
@@ -11,7 +11,6 @@ scenario:
     channel: matrix
     timeoutMs: 120000
     retryCount: 0
-    driver: live
     config:
       matrixConfigOverrides:
         encryption: true

--- a/qa/scenarios/channels/matrix-e2ee-server-device-deleted-relogin-recovers.yaml
+++ b/qa/scenarios/channels/matrix-e2ee-server-device-deleted-relogin-recovers.yaml
@@ -11,7 +11,6 @@ scenario:
     channel: matrix
     timeoutMs: 180000
     retryCount: 0
-    driver: live
     config:
       matrixConfigOverrides:
         encryption: true

--- a/qa/scenarios/channels/matrix-e2ee-stale-device-hygiene.yaml
+++ b/qa/scenarios/channels/matrix-e2ee-stale-device-hygiene.yaml
@@ -11,7 +11,6 @@ scenario:
     channel: matrix
     timeoutMs: 90000
     retryCount: 0
-    driver: live
     config:
       matrixConfigOverrides:
         encryption: true

--- a/qa/scenarios/channels/matrix-e2ee-stale-recovery-key-after-backup-reset.yaml
+++ b/qa/scenarios/channels/matrix-e2ee-stale-recovery-key-after-backup-reset.yaml
@@ -11,7 +11,6 @@ scenario:
     channel: matrix
     timeoutMs: 180000
     retryCount: 0
-    driver: live
     config:
       matrixConfigOverrides:
         encryption: true

--- a/qa/scenarios/channels/matrix-e2ee-state-after-missing-encryption.yaml
+++ b/qa/scenarios/channels/matrix-e2ee-state-after-missing-encryption.yaml
@@ -11,7 +11,6 @@ scenario:
     channel: matrix
     timeoutMs: 150000
     retryCount: 0
-    driver: live
     config:
       matrixConfigOverrides:
         encryption: true

--- a/qa/scenarios/channels/matrix-e2ee-state-loss-external-recovery-key.yaml
+++ b/qa/scenarios/channels/matrix-e2ee-state-loss-external-recovery-key.yaml
@@ -11,7 +11,6 @@ scenario:
     channel: matrix
     timeoutMs: 180000
     retryCount: 0
-    driver: live
     config:
       matrixConfigOverrides:
         encryption: true

--- a/qa/scenarios/channels/matrix-e2ee-state-loss-no-recovery-key.yaml
+++ b/qa/scenarios/channels/matrix-e2ee-state-loss-no-recovery-key.yaml
@@ -11,7 +11,6 @@ scenario:
     channel: matrix
     timeoutMs: 120000
     retryCount: 0
-    driver: live
     config:
       matrixConfigOverrides:
         encryption: true

--- a/qa/scenarios/channels/matrix-e2ee-state-loss-stored-recovery-key.yaml
+++ b/qa/scenarios/channels/matrix-e2ee-state-loss-stored-recovery-key.yaml
@@ -11,7 +11,6 @@ scenario:
     channel: matrix
     timeoutMs: 180000
     retryCount: 0
-    driver: live
     config:
       matrixConfigOverrides:
         encryption: true

--- a/qa/scenarios/channels/matrix-e2ee-sync-state-loss-crypto-intact.yaml
+++ b/qa/scenarios/channels/matrix-e2ee-sync-state-loss-crypto-intact.yaml
@@ -11,7 +11,6 @@ scenario:
     channel: matrix
     timeoutMs: 150000
     retryCount: 0
-    driver: live
     config:
       matrixConfigOverrides:
         encryption: true

--- a/qa/scenarios/channels/matrix-e2ee-thread-follow-up.yaml
+++ b/qa/scenarios/channels/matrix-e2ee-thread-follow-up.yaml
@@ -11,7 +11,6 @@ scenario:
     channel: matrix
     timeoutMs: 75000
     retryCount: 0
-    driver: live
     config:
       matrixConfigOverrides:
         encryption: true

--- a/qa/scenarios/channels/matrix-e2ee-verification-notice-no-trigger.yaml
+++ b/qa/scenarios/channels/matrix-e2ee-verification-notice-no-trigger.yaml
@@ -11,7 +11,6 @@ scenario:
     channel: matrix
     timeoutMs: 30000
     retryCount: 0
-    driver: live
     config:
       matrixConfigOverrides:
         encryption: true

--- a/qa/scenarios/channels/matrix-e2ee-wrong-account-recovery-key.yaml
+++ b/qa/scenarios/channels/matrix-e2ee-wrong-account-recovery-key.yaml
@@ -11,7 +11,6 @@ scenario:
     channel: matrix
     timeoutMs: 180000
     retryCount: 0
-    driver: live
     config:
       matrixConfigOverrides:
         encryption: true

--- a/qa/scenarios/channels/matrix-homeserver-restart-resume.yaml
+++ b/qa/scenarios/channels/matrix-homeserver-restart-resume.yaml
@@ -11,7 +11,6 @@ scenario:
     channel: matrix
     timeoutMs: 75000
     retryCount: 0
-    driver: live
     config:
       matrixTopology:
         defaultRoomKey: main

--- a/qa/scenarios/channels/matrix-inbound-edit-ignored.yaml
+++ b/qa/scenarios/channels/matrix-inbound-edit-ignored.yaml
@@ -11,7 +11,6 @@ scenario:
     channel: matrix
     timeoutMs: 8000
     retryCount: 0
-    driver: live
 
 flow:
   module: ./live-transports/matrix/scenarios/scenario-runtime-edit.js

--- a/qa/scenarios/channels/matrix-inbound-edit-no-duplicate-trigger.yaml
+++ b/qa/scenarios/channels/matrix-inbound-edit-no-duplicate-trigger.yaml
@@ -11,7 +11,6 @@ scenario:
     channel: matrix
     timeoutMs: 45000
     retryCount: 0
-    driver: live
 
 flow:
   module: ./live-transports/matrix/scenarios/scenario-runtime-edit.js

--- a/qa/scenarios/channels/matrix-initial-catchup-then-incremental.yaml
+++ b/qa/scenarios/channels/matrix-initial-catchup-then-incremental.yaml
@@ -11,7 +11,6 @@ scenario:
     channel: matrix
     timeoutMs: 90000
     retryCount: 0
-    driver: live
     config:
       matrixTopology:
         defaultRoomKey: main

--- a/qa/scenarios/channels/matrix-media-type-coverage.yaml
+++ b/qa/scenarios/channels/matrix-media-type-coverage.yaml
@@ -11,7 +11,6 @@ scenario:
     channel: matrix
     timeoutMs: 90000
     retryCount: 0
-    driver: live
     config:
       matrixTopology:
         defaultRoomKey: main

--- a/qa/scenarios/channels/matrix-mention-metadata-spoof-block.yaml
+++ b/qa/scenarios/channels/matrix-mention-metadata-spoof-block.yaml
@@ -11,7 +11,6 @@ scenario:
     channel: matrix
     timeoutMs: 8000
     retryCount: 0
-    driver: live
 
 flow:
   module: ./live-transports/matrix/scenarios/scenario-runtime-policy.js

--- a/qa/scenarios/channels/matrix-mxid-prefixed-command-block.yaml
+++ b/qa/scenarios/channels/matrix-mxid-prefixed-command-block.yaml
@@ -13,7 +13,6 @@ scenario:
     channel: matrix
     timeoutMs: 8000
     retryCount: 0
-    driver: live
     config:
       matrixConfigOverrides:
         groupPolicy: open

--- a/qa/scenarios/channels/matrix-reaction-not-a-reply.yaml
+++ b/qa/scenarios/channels/matrix-reaction-not-a-reply.yaml
@@ -11,7 +11,6 @@ scenario:
     channel: matrix
     timeoutMs: 8000
     retryCount: 0
-    driver: live
     config:
       matrixRequireCanary: true
 

--- a/qa/scenarios/channels/matrix-reaction-notification.yaml
+++ b/qa/scenarios/channels/matrix-reaction-notification.yaml
@@ -11,7 +11,6 @@ scenario:
     channel: matrix
     timeoutMs: 45000
     retryCount: 0
-    driver: live
     config:
       matrixRequireCanary: true
 

--- a/qa/scenarios/channels/matrix-reaction-redaction-observed.yaml
+++ b/qa/scenarios/channels/matrix-reaction-redaction-observed.yaml
@@ -11,7 +11,6 @@ scenario:
     channel: matrix
     timeoutMs: 45000
     retryCount: 0
-    driver: live
     config:
       matrixRequireCanary: true
 

--- a/qa/scenarios/channels/matrix-reaction-threaded.yaml
+++ b/qa/scenarios/channels/matrix-reaction-threaded.yaml
@@ -11,7 +11,6 @@ scenario:
     channel: matrix
     timeoutMs: 45000
     retryCount: 0
-    driver: live
     config:
       matrixRequireCanary: true
 

--- a/qa/scenarios/channels/matrix-room-autojoin-invite.yaml
+++ b/qa/scenarios/channels/matrix-room-autojoin-invite.yaml
@@ -11,7 +11,6 @@ scenario:
     channel: matrix
     timeoutMs: 60000
     retryCount: 0
-    driver: live
     config:
       matrixConfigOverrides:
         autoJoin: always

--- a/qa/scenarios/channels/matrix-room-block-streaming.yaml
+++ b/qa/scenarios/channels/matrix-room-block-streaming.yaml
@@ -11,7 +11,6 @@ scenario:
     providerMode: mock-openai
     timeoutMs: 75000
     retryCount: 0
-    driver: live
     config:
       matrixConfigOverrides:
         agentDefaults:

--- a/qa/scenarios/channels/matrix-room-generated-image-delivery.yaml
+++ b/qa/scenarios/channels/matrix-room-generated-image-delivery.yaml
@@ -11,7 +11,6 @@ scenario:
     channel: matrix
     timeoutMs: 180000
     retryCount: 0
-    driver: live
     config:
       matrixConfigOverrides:
         streaming: quiet

--- a/qa/scenarios/channels/matrix-room-image-understanding-attachment.yaml
+++ b/qa/scenarios/channels/matrix-room-image-understanding-attachment.yaml
@@ -15,7 +15,6 @@ scenario:
     channel: matrix
     timeoutMs: 60000
     retryCount: 0
-    driver: live
     config:
       matrixTopology:
         defaultRoomKey: main

--- a/qa/scenarios/channels/matrix-room-membership-loss.yaml
+++ b/qa/scenarios/channels/matrix-room-membership-loss.yaml
@@ -11,7 +11,6 @@ scenario:
     channel: matrix
     timeoutMs: 75000
     retryCount: 0
-    driver: live
     config:
       matrixTopology:
         defaultRoomKey: main

--- a/qa/scenarios/channels/matrix-room-partial-streaming-preview.yaml
+++ b/qa/scenarios/channels/matrix-room-partial-streaming-preview.yaml
@@ -13,7 +13,6 @@ scenario:
     channel: matrix
     timeoutMs: 45000
     retryCount: 0
-    driver: live
     config:
       matrixConfigOverrides:
         streaming: partial

--- a/qa/scenarios/channels/matrix-room-quiet-streaming-preview.yaml
+++ b/qa/scenarios/channels/matrix-room-quiet-streaming-preview.yaml
@@ -13,7 +13,6 @@ scenario:
     channel: matrix
     timeoutMs: 45000
     retryCount: 0
-    driver: live
     config:
       matrixConfigOverrides:
         streaming: quiet

--- a/qa/scenarios/channels/matrix-room-tool-progress-command-preview.yaml
+++ b/qa/scenarios/channels/matrix-room-tool-progress-command-preview.yaml
@@ -11,7 +11,6 @@ scenario:
     channel: matrix
     timeoutMs: 60000
     retryCount: 0
-    driver: live
     config:
       matrixConfigOverrides:
         streaming: quiet

--- a/qa/scenarios/channels/matrix-room-tool-progress-error.yaml
+++ b/qa/scenarios/channels/matrix-room-tool-progress-error.yaml
@@ -11,7 +11,6 @@ scenario:
     channel: matrix
     timeoutMs: 60000
     retryCount: 0
-    driver: live
     config:
       matrixConfigOverrides:
         streaming: quiet

--- a/qa/scenarios/channels/matrix-room-tool-progress-mention-safety.yaml
+++ b/qa/scenarios/channels/matrix-room-tool-progress-mention-safety.yaml
@@ -11,7 +11,6 @@ scenario:
     channel: matrix
     timeoutMs: 60000
     retryCount: 0
-    driver: live
     config:
       matrixConfigOverrides:
         streaming: partial

--- a/qa/scenarios/channels/matrix-room-tool-progress-preview-opt-out.yaml
+++ b/qa/scenarios/channels/matrix-room-tool-progress-preview-opt-out.yaml
@@ -11,7 +11,6 @@ scenario:
     channel: matrix
     timeoutMs: 60000
     retryCount: 0
-    driver: live
     config:
       matrixConfigOverrides:
         streaming:

--- a/qa/scenarios/channels/matrix-room-tool-progress-preview.yaml
+++ b/qa/scenarios/channels/matrix-room-tool-progress-preview.yaml
@@ -11,7 +11,6 @@ scenario:
     channel: matrix
     timeoutMs: 60000
     retryCount: 0
-    driver: live
     config:
       matrixConfigOverrides:
         streaming: quiet

--- a/qa/scenarios/channels/matrix-secondary-room-open-trigger.yaml
+++ b/qa/scenarios/channels/matrix-secondary-room-open-trigger.yaml
@@ -11,7 +11,6 @@ scenario:
     channel: matrix
     timeoutMs: 45000
     retryCount: 0
-    driver: live
     config:
       matrixConfigOverrides:
         groupsByKey:

--- a/qa/scenarios/channels/matrix-stale-sync-replay-dedupe.yaml
+++ b/qa/scenarios/channels/matrix-stale-sync-replay-dedupe.yaml
@@ -11,7 +11,6 @@ scenario:
     channel: matrix
     timeoutMs: 90000
     retryCount: 0
-    driver: live
     config:
       matrixTopology:
         defaultRoomKey: main

--- a/qa/scenarios/channels/matrix-thread-nested-reply-shape.yaml
+++ b/qa/scenarios/channels/matrix-thread-nested-reply-shape.yaml
@@ -11,7 +11,6 @@ scenario:
     channel: matrix
     timeoutMs: 60000
     retryCount: 0
-    driver: live
 
 flow:
   module: ./live-transports/matrix/scenarios/scenario-runtime-room.js

--- a/qa/scenarios/channels/matrix-thread-root-preservation.yaml
+++ b/qa/scenarios/channels/matrix-thread-root-preservation.yaml
@@ -11,7 +11,6 @@ scenario:
     channel: matrix
     timeoutMs: 60000
     retryCount: 0
-    driver: live
 
 flow:
   module: ./live-transports/matrix/scenarios/scenario-runtime-room.js

--- a/qa/scenarios/channels/matrix-unsupported-media-safe.yaml
+++ b/qa/scenarios/channels/matrix-unsupported-media-safe.yaml
@@ -13,7 +13,6 @@ scenario:
     channel: matrix
     timeoutMs: 45000
     retryCount: 0
-    driver: live
     config:
       matrixTopology:
         defaultRoomKey: main

--- a/qa/scenarios/channels/matrix-voice-preflight-mention.yaml
+++ b/qa/scenarios/channels/matrix-voice-preflight-mention.yaml
@@ -12,7 +12,6 @@ scenario:
     providerMode: live-frontier
     timeoutMs: 180000
     retryCount: 0
-    driver: live
     config:
       matrixConfigOverrides:
         audio:

--- a/qa/scenarios/channels/qa-channel-reconnect-dedupe.yaml
+++ b/qa/scenarios/channels/qa-channel-reconnect-dedupe.yaml
@@ -24,7 +24,7 @@ scenario:
   execution:
     kind: flow
     summary: Verify qa-channel readiness recovery does not duplicate old outbound delivery.
-    driver: qa-channel
+    channel: qa-channel
     config:
       firstPrompt: "@openclaw Reconnect dedupe setup marker. Reply exactly: RECONNECT-FIRST-OK"
       secondPrompt: "@openclaw Reconnect dedupe follow-up marker. Reply exactly: RECONNECT-SECOND-OK"

--- a/qa/scenarios/channels/reaction-edit-delete.yaml
+++ b/qa/scenarios/channels/reaction-edit-delete.yaml
@@ -21,7 +21,7 @@ scenario:
   execution:
     kind: flow
     summary: Verify the agent can use channel-owned message actions and that the QA transcript reflects them.
-    driver: qa-channel
+    channel: qa-channel
     config:
       target: "channel:qa-room"
       seedText: "seed message"

--- a/qa/scenarios/channels/slack-restart-resume.yaml
+++ b/qa/scenarios/channels/slack-restart-resume.yaml
@@ -20,7 +20,6 @@ scenario:
     channel: slack
     suiteIsolation: isolated
     summary: Exercise normalized restart and continuation delivery.
-    driver: live
     config:
       conversationKind: group
       conversationId: C0123456789

--- a/qa/scenarios/channels/subagent-thread-spawn.yaml
+++ b/qa/scenarios/channels/subagent-thread-spawn.yaml
@@ -38,7 +38,6 @@ scenario:
     kind: flow
     channel: matrix
     summary: Spawn a bound Matrix child session and require native thread relation evidence on completion.
-    driver: live
     config:
       conversationId: main
       childMarker: QA-MATRIX-SUBAGENT-THREAD-OK
@@ -48,9 +47,6 @@ flow:
   steps:
     - name: delivers the child result in the spawned Matrix thread
       actions:
-        - assert:
-            expr: transport.id === 'matrix'
-            message: subagent thread spawn requires the live Matrix adapter
         - resetTransport: true
         - sendInbound:
             conversation:

--- a/qa/scenarios/channels/telegram-current-session-status-tool.yaml
+++ b/qa/scenarios/channels/telegram-current-session-status-tool.yaml
@@ -19,7 +19,6 @@ scenario:
     kind: flow
     channel: telegram
     summary: Ask the model to resolve the current Telegram group session through session_status.
-    driver: live
     config:
       requiredProviderMode: mock-openai
 

--- a/qa/scenarios/channels/telegram-long-final-reuses-preview.yaml
+++ b/qa/scenarios/channels/telegram-long-final-reuses-preview.yaml
@@ -20,7 +20,6 @@ scenario:
     kind: flow
     channel: telegram
     summary: Run the scripted long final and verify preview reuse and chunk count.
-    driver: live
     config:
       requiredProviderMode: mock-openai
 

--- a/qa/scenarios/channels/telegram-long-final-three-chunks.yaml
+++ b/qa/scenarios/channels/telegram-long-final-three-chunks.yaml
@@ -20,7 +20,6 @@ scenario:
     kind: flow
     channel: telegram
     summary: Run the scripted three-chunk final and verify final chunk accounting.
-    driver: live
     config:
       requiredProviderMode: mock-openai
 

--- a/qa/scenarios/channels/telegram-other-bot-command-gating.yaml
+++ b/qa/scenarios/channels/telegram-other-bot-command-gating.yaml
@@ -24,7 +24,6 @@ scenario:
     kind: flow
     channel: telegram
     summary: Address a command to another bot and verify OpenClaw ignores it.
-    driver: live
 
 flow:
   steps:

--- a/qa/scenarios/channels/telegram-repeated-command-authorization.yaml
+++ b/qa/scenarios/channels/telegram-repeated-command-authorization.yaml
@@ -26,7 +26,6 @@ scenario:
     suiteIsolation: isolated
     isolationReason: Mutates the live Telegram group allowlist and restarts the QA gateway.
     summary: Remove and restore the Telegram operator allowlist, then run repeated commands.
-    driver: live
 
 flow:
   steps:

--- a/qa/scenarios/channels/telegram-stream-final-single-message.yaml
+++ b/qa/scenarios/channels/telegram-stream-final-single-message.yaml
@@ -19,7 +19,6 @@ scenario:
     profiles: { "telegram:adapter": 14, "telegram:all": 13 }
     kind: flow
     channel: telegram
-    driver: live
     summary: Run the scripted quiet-streaming reply and verify one final message.
     config:
       marker: QA-TELEGRAM-STREAM-SINGLE-OK

--- a/qa/scenarios/channels/telegram-tool-only-usage-footer.yaml
+++ b/qa/scenarios/channels/telegram-tool-only-usage-footer.yaml
@@ -21,7 +21,6 @@ scenario:
     kind: flow
     channel: telegram
     summary: Enable token usage mode, then verify the next Telegram reply footer.
-    driver: live
     config:
       marker: QA-TELEGRAM-USAGE-FOOTER-OK
 

--- a/qa/scenarios/channels/thread-reply-override.yaml
+++ b/qa/scenarios/channels/thread-reply-override.yaml
@@ -27,7 +27,6 @@ scenario:
     kind: flow
     channel: matrix
     summary: Require the canonical Matrix adapter to surface the native m.thread relation through threadId.
-    driver: live
     config:
       conversationId: main
       marker: QA-MATRIX-THREAD-OVERRIDE-OK
@@ -36,9 +35,6 @@ flow:
   steps:
     - name: exposes the native thread override relation
       actions:
-        - assert:
-            expr: transport.id === 'matrix'
-            message: Matrix thread reply override requires the live Matrix adapter
         - resetTransport: true
         - sendInbound:
             conversation:

--- a/qa/scenarios/channels/whatsapp-access-control-dm-disabled.yaml
+++ b/qa/scenarios/channels/whatsapp-access-control-dm-disabled.yaml
@@ -18,7 +18,6 @@ scenario:
     channel: whatsapp
     suiteIsolation: isolated
     summary: Verify WhatsApp dmPolicy disabled behavior through the canonical adapter.
-    driver: live
     config:
       policyKey: dmPolicy
       policyValue: disabled

--- a/qa/scenarios/channels/whatsapp-access-control-dm-open.yaml
+++ b/qa/scenarios/channels/whatsapp-access-control-dm-open.yaml
@@ -18,7 +18,6 @@ scenario:
     channel: whatsapp
     suiteIsolation: isolated
     summary: Verify WhatsApp dmPolicy open behavior through the canonical adapter.
-    driver: live
     config:
       policyKey: dmPolicy
       policyValue: open

--- a/qa/scenarios/channels/whatsapp-access-control-group-disabled.yaml
+++ b/qa/scenarios/channels/whatsapp-access-control-group-disabled.yaml
@@ -18,7 +18,6 @@ scenario:
     channel: whatsapp
     suiteIsolation: isolated
     summary: Verify WhatsApp groupPolicy disabled behavior through the canonical adapter.
-    driver: live
     config:
       policyKey: groupPolicy
       policyValue: disabled

--- a/qa/scenarios/channels/whatsapp-access-control-group-open.yaml
+++ b/qa/scenarios/channels/whatsapp-access-control-group-open.yaml
@@ -18,7 +18,6 @@ scenario:
     channel: whatsapp
     suiteIsolation: isolated
     summary: Verify WhatsApp groupPolicy open behavior through the canonical adapter.
-    driver: live
     config:
       policyKey: groupPolicy
       policyValue: open

--- a/qa/scenarios/channels/whatsapp-commands-command.yaml
+++ b/qa/scenarios/channels/whatsapp-commands-command.yaml
@@ -17,7 +17,6 @@ scenario:
     profiles: { "whatsapp:mock-default": 33 }
     kind: flow
     channel: whatsapp
-    driver: live
     config:
       expectedAny: [/session, /verbose]
     summary: Request the WhatsApp command catalog and verify representative entries.

--- a/qa/scenarios/channels/whatsapp-context-command.yaml
+++ b/qa/scenarios/channels/whatsapp-context-command.yaml
@@ -17,7 +17,6 @@ scenario:
     profiles: { "whatsapp:mock-default": 36 }
     kind: flow
     channel: whatsapp
-    driver: live
     config:
       requiredProviderMode: mock-openai
       expectedAny: [Context breakdown, "Workspace:", Tool schemas]

--- a/qa/scenarios/channels/whatsapp-help-command.yaml
+++ b/qa/scenarios/channels/whatsapp-help-command.yaml
@@ -17,7 +17,6 @@ scenario:
     profiles: { "whatsapp:adapter": 5, "whatsapp:default": 7, "whatsapp:mock-default": 32 }
     kind: flow
     channel: whatsapp
-    driver: live
     summary: Send WhatsApp help and verify command guidance.
 
 flow:

--- a/qa/scenarios/channels/whatsapp-native-new-command.yaml
+++ b/qa/scenarios/channels/whatsapp-native-new-command.yaml
@@ -17,7 +17,6 @@ scenario:
     profiles: { "whatsapp:mock-default": 38 }
     kind: flow
     channel: whatsapp
-    driver: live
     config:
       requiredProviderMode: mock-openai
     summary: Run `/new` through WhatsApp and verify the new-session acknowledgement.

--- a/qa/scenarios/channels/whatsapp-pairing-block.yaml
+++ b/qa/scenarios/channels/whatsapp-pairing-block.yaml
@@ -19,7 +19,6 @@ scenario:
     channel: whatsapp
     suiteIsolation: isolated
     summary: Verify pairing gate output through the canonical WhatsApp adapter.
-    driver: live
     config:
       accountId: sut
       conversationId: 15550000001@s.whatsapp.net

--- a/qa/scenarios/channels/whatsapp-restart-resume.yaml
+++ b/qa/scenarios/channels/whatsapp-restart-resume.yaml
@@ -20,7 +20,6 @@ scenario:
     channel: whatsapp
     suiteIsolation: isolated
     summary: Exercise normalized restart and continuation delivery.
-    driver: live
     config:
       conversationKind: direct
       conversationId: 15550000001@s.whatsapp.net

--- a/qa/scenarios/channels/whatsapp-status-command.yaml
+++ b/qa/scenarios/channels/whatsapp-status-command.yaml
@@ -16,7 +16,6 @@ scenario:
   execution:
     kind: flow
     channel: whatsapp
-    driver: live
     summary: Run WhatsApp status and verify session text.
 
 flow:

--- a/qa/scenarios/channels/whatsapp-tool-only-usage-footer.yaml
+++ b/qa/scenarios/channels/whatsapp-tool-only-usage-footer.yaml
@@ -18,7 +18,6 @@ scenario:
     profiles: { "whatsapp:mock-default": 37 }
     kind: flow
     channel: whatsapp
-    driver: live
     config:
       requiredProviderMode: mock-openai
       marker: WHATSAPP-QA-USAGE-FOOTER-OK

--- a/qa/scenarios/channels/whatsapp-tools-compact-command.yaml
+++ b/qa/scenarios/channels/whatsapp-tools-compact-command.yaml
@@ -17,7 +17,6 @@ scenario:
     profiles: { "whatsapp:mock-default": 34 }
     kind: flow
     channel: whatsapp
-    driver: live
     config:
       requiredProviderMode: mock-openai
       expectedAny: [exec, Use /tools verbose for descriptions]

--- a/qa/scenarios/channels/whatsapp-whoami-command.yaml
+++ b/qa/scenarios/channels/whatsapp-whoami-command.yaml
@@ -17,7 +17,6 @@ scenario:
     profiles: { "whatsapp:mock-default": 35 }
     kind: flow
     channel: whatsapp
-    driver: live
     config:
       requiredProviderMode: mock-openai
       expectedAny: [Identity, "Channel: whatsapp", "AllowFrom:"]

--- a/qa/scenarios/config/config-apply-restart-wakeup.yaml
+++ b/qa/scenarios/config/config-apply-restart-wakeup.yaml
@@ -22,7 +22,7 @@ scenario:
   execution:
     kind: flow
     summary: Verify a restart-required config.apply restarts cleanly and delivers the post-restart wake message back into the QA channel.
-    driver: qa-channel
+    channel: qa-channel
     config:
       channelId: qa-room
       announcePrompt: "Acknowledge restart wake-up setup in qa-room."

--- a/qa/scenarios/goals/goal-context-next-turn.yaml
+++ b/qa/scenarios/goals/goal-context-next-turn.yaml
@@ -25,7 +25,7 @@ scenario:
   execution:
     kind: flow
     summary: Start a goal, send an unrelated next turn, and inspect the exact mock-provider request payload.
-    driver: qa-channel
+    channel: qa-channel
     config:
       requiredProviderMode: mock-openai
       conversationId: goal-context-next-turn

--- a/qa/scenarios/goals/goal-context-survives-compaction.yaml
+++ b/qa/scenarios/goals/goal-context-survives-compaction.yaml
@@ -33,7 +33,7 @@ scenario:
   execution:
     kind: flow
     summary: Start a goal, compact the session, then inspect the next mock-provider request for active-goal context.
-    driver: qa-channel
+    channel: qa-channel
     config:
       requiredProviderMode: mock-openai
       conversationId: goal-context-compaction

--- a/qa/scenarios/goals/goal-followthrough-live.yaml
+++ b/qa/scenarios/goals/goal-followthrough-live.yaml
@@ -28,7 +28,7 @@ scenario:
   execution:
     kind: flow
     summary: Stage a two-step active goal, then require a bare continue turn to write the next artifact without replanning.
-    driver: qa-channel
+    channel: qa-channel
     config:
       conversationId: goal-followthrough-live
       senderId: qa-goal-operator

--- a/qa/scenarios/index.yaml
+++ b/qa/scenarios/index.yaml
@@ -7,7 +7,7 @@ title: OpenClaw QA Scenario Pack
 # - each nested `*.yaml` scenario defines one runnable test via `scenario`
 # - flow scenarios add top-level `flow`; native test scenarios use `scenario.execution.path`
 # - scenario YAML may also define coverage IDs, category metadata, required plugins,
-#   lane filters, runtime parity tiers, and gateway config patching
+#   channel constraints, provider/runtime filters, runtime parity tiers, and gateway config patching
 #
 # - kickoff mission
 # - QA operator identity

--- a/qa/scenarios/media/image-generation-roundtrip.yaml
+++ b/qa/scenarios/media/image-generation-roundtrip.yaml
@@ -24,7 +24,7 @@ scenario:
   execution:
     kind: flow
     summary: Verify a generated image is saved as media, reattached on the next turn, and described correctly through the vision path.
-    driver: qa-channel
+    channel: qa-channel
     config:
       generatePrompt: "Image generation check: generate a QA lighthouse image and summarize it in one short sentence."
       generatePromptSnippet: "Image generation check"

--- a/qa/scenarios/media/image-understanding-attachment.yaml
+++ b/qa/scenarios/media/image-understanding-attachment.yaml
@@ -23,7 +23,7 @@ scenario:
   execution:
     kind: flow
     summary: Verify an attached image reaches the agent model and the agent can describe what it sees.
-    driver: qa-channel
+    channel: qa-channel
     config:
       prompt: "Image understanding check: describe the top and bottom colors in the attached image in one short sentence."
       requiredColorGroups:

--- a/qa/scenarios/media/native-image-generation.yaml
+++ b/qa/scenarios/media/native-image-generation.yaml
@@ -22,7 +22,7 @@ scenario:
   execution:
     kind: flow
     summary: Verify image_generate appears when configured and returns a real saved media artifact.
-    driver: qa-channel
+    channel: qa-channel
     config:
       prompt: "Image generation check: generate a QA lighthouse image and summarize it in one short sentence."
       promptSnippet: "Image generation check"

--- a/qa/scenarios/memory/active-memory-preprompt-recall.yaml
+++ b/qa/scenarios/memory/active-memory-preprompt-recall.yaml
@@ -42,7 +42,7 @@ scenario:
   execution:
     kind: flow
     summary: Verify Active Memory stays off when session-toggled off, runs memory search/get when enabled, and helps a live model answer with the recalled preference in the first visible reply.
-    driver: qa-channel
+    channel: qa-channel
     config:
       baselineConversationId: qa-active-memory-off
       activeConversationId: qa-active-memory-on

--- a/qa/scenarios/memory/memory-recall.yaml
+++ b/qa/scenarios/memory/memory-recall.yaml
@@ -47,7 +47,7 @@ scenario:
   execution:
     kind: flow
     summary: Verify the agent can store a fact, switch topics, then recall the fact accurately later.
-    driver: qa-channel
+    channel: qa-channel
     config:
       resetDurableMemory: true
       rememberPrompt: "Please remember this fact for later: the QA canary code is ALPHA-7. Use your normal memory mechanism, avoid manual repo cleanup, and reply exactly `Remembered ALPHA-7.` once stored."

--- a/qa/scenarios/memory/session-memory-ranking.yaml
+++ b/qa/scenarios/memory/session-memory-ranking.yaml
@@ -23,7 +23,7 @@ scenario:
   execution:
     kind: flow
     summary: Verify session-transcript memory can outrank stale durable notes and drive the final answer toward the newer fact.
-    driver: qa-channel
+    channel: qa-channel
     config:
       staleFact: ORBIT-9
       currentFact: ORBIT-10

--- a/qa/scenarios/memory/thread-memory-isolation.yaml
+++ b/qa/scenarios/memory/thread-memory-isolation.yaml
@@ -24,7 +24,7 @@ scenario:
   execution:
     kind: flow
     summary: Verify a memory-backed answer requested inside a thread stays in-thread and does not leak into the root channel.
-    driver: qa-channel
+    channel: qa-channel
     config:
       memoryFact: "Thread-hidden codename: ORBIT-22."
       memoryQuery: "hidden thread codename ORBIT-22"

--- a/qa/scenarios/personal/channel-thread-reply.yaml
+++ b/qa/scenarios/personal/channel-thread-reply.yaml
@@ -29,7 +29,7 @@ scenario:
   execution:
     kind: flow
     summary: Verify fake personal replies stay routed to the requested QA conversation and thread.
-    driver: qa-channel
+    channel: qa-channel
     config:
       dmUserId: qa-alice
       dmUserName: QA Alice

--- a/qa/scenarios/personal/memory-preference-recall.yaml
+++ b/qa/scenarios/personal/memory-preference-recall.yaml
@@ -29,7 +29,7 @@ scenario:
   execution:
     kind: flow
     summary: Verify fake personal preference recall through the local QA memory path.
-    driver: qa-channel
+    channel: qa-channel
     config:
       sessionKey: agent:qa:personal-memory
       rememberPrompt: "Please remember this fact for later: my fake personal QA preference is that my preferred reminder label code is ORBIT-9. Use your normal memory mechanism and reply exactly `Remembered ORBIT-9.` once stored."

--- a/qa/scenarios/personal/reminder-roundtrip.yaml
+++ b/qa/scenarios/personal/reminder-roundtrip.yaml
@@ -29,7 +29,7 @@ scenario:
   execution:
     kind: flow
     summary: Verify a fake personal reminder roundtrip stays local to the QA channel.
-    driver: qa-channel
+    channel: qa-channel
     config:
       channelId: qa-personal-room
       channelTitle: QA Personal Room

--- a/qa/scenarios/scheduling/cron-condition-watcher.yaml
+++ b/qa/scenarios/scheduling/cron-condition-watcher.yaml
@@ -28,7 +28,7 @@ scenario:
   execution:
     kind: flow
     summary: Poll a stateful headless condition, prove quiet ticks stay artifact-free, then observe one natural fired command payload and once disarm.
-    driver: qa-channel
+    channel: qa-channel
 
 flow:
   steps:

--- a/qa/scenarios/scheduling/cron-natural-fire-no-duplicate.yaml
+++ b/qa/scenarios/scheduling/cron-natural-fire-no-duplicate.yaml
@@ -26,7 +26,7 @@ scenario:
   execution:
     kind: flow
     summary: Let one cron job fire from the natural scheduler timer and assert qa-channel does not receive a duplicate delivery for the same marker.
-    driver: qa-channel
+    channel: qa-channel
     config:
       channelId: qa-room
       channelTitle: QA Room

--- a/qa/scenarios/scheduling/cron-one-minute-ping.yaml
+++ b/qa/scenarios/scheduling/cron-one-minute-ping.yaml
@@ -24,7 +24,7 @@ scenario:
   execution:
     kind: flow
     summary: Verify the agent can schedule a cron reminder one minute in the future and receive the follow-up in the QA channel.
-    driver: qa-channel
+    channel: qa-channel
     config:
       channelId: qa-room
       channelTitle: QA Room

--- a/qa/scenarios/scheduling/cron-single-run-no-duplicate.yaml
+++ b/qa/scenarios/scheduling/cron-single-run-no-duplicate.yaml
@@ -25,7 +25,7 @@ scenario:
   execution:
     kind: flow
     summary: Force one cron run and assert qa-channel does not receive a duplicate delivery for the same marker.
-    driver: qa-channel
+    channel: qa-channel
     config:
       channelId: qa-room
       channelTitle: QA Room

--- a/qa/scenarios/ui/control-ui-assistant-transcript-role-boundary.yaml
+++ b/qa/scenarios/ui/control-ui-assistant-transcript-role-boundary.yaml
@@ -30,7 +30,7 @@ scenario:
     suiteIsolation: isolated
     isolationReason: The flow appends assistant fixtures to one dedicated session before opening a fresh Control UI transcript.
     summary: Drive one assistant reply through Gateway and qa-channel, append parser anti-cheat fixtures, then verify role-aware rendering in a real Control UI browser.
-    driver: qa-channel
+    channel: qa-channel
     config:
       conversationId: assistant-transcript-role-boundary
       assistantReply: user[Thu 2026-07-02] check this

--- a/qa/scenarios/ui/control-ui-qa-channel-image-roundtrip.yaml
+++ b/qa/scenarios/ui/control-ui-qa-channel-image-roundtrip.yaml
@@ -29,7 +29,7 @@ scenario:
   execution:
     kind: flow
     summary: Open the Control UI on a qa-channel session with the generic QA web driver, inject text and image turns through qa-channel, and verify the replies in both the transport log and the UI transcript.
-    driver: qa-channel
+    channel: qa-channel
     config:
       conversationId: control-ui-e2e
       textPrompt: "Control UI bridge check. Marker exact marker: `ui bridge armed`"


### PR DESCRIPTION
Related: #108537 (merged)

## What Problem This Solves

QA channel scenarios currently declare a driver as scenario eligibility, coupling scenario membership to one transport implementation. That prevents the same portable channel scenario from being selected consistently with Crabline and live adapters.

## Why This Change Was Made

Moves channel-driver choice entirely to the run while retaining `execution.channel` and independent provider/model/auth/runtime constraints. It removes all 133 scenario driver declarations, keeps native Matrix module implementations intact, makes explicit and implicit live/Crabline selection share channel-based membership, and records only the driver actually used in evidence.

This intentionally does not change taxonomy or scorecard fulfillment. #108537 has merged, so failed or skipped unsupported-driver evidence cannot fulfill coverage.

## User Impact

No end-user product behavior changes. QA operators can select portable declared-channel scenarios with either `--channel-driver crabline` or `--channel-driver live`; unsupported implementations remain honest non-passes instead of satisfying coverage.

## Evidence

- Audited and dispositioned all 133 declarations: 106 `live`, 27 `qa-channel`.
- Directly inspected published `@openclaw/crabline@0.1.11`: Matrix is a registered server and OpenClaw provider bridge.
- Exact CI failure reproduction: `smoke-ci --scenario matrix-restart-resume` dispatches `channelDriver=crabline channel=matrix` and passes with zero failed/skipped scenarios.
- Focused final-base QA Lab proof: 238/238 tests passed across seven affected files; post-final-rebase CLI/smoke rerun: 103/103 passed.
- `pnpm docs:list` and `pnpm docs:check-mdx` — passed; relevant docs reviewed.
- `pnpm check:changed` — passed all selected lanes, including format, all-project typecheck, lint shards, structural guards, and zero runtime import cycles.
- Fresh full branch autoreview against `origin/main` — clean; no accepted/actionable findings.
- Exact proved head: `b660130fcb146fa9ebfc998f3fec3444a55290da`.
