### PR TITLE
fix(discord): resolve forum thread activity targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Discord Activity forum threads:** resolve provider-prefixed thread channel targets through the canonical Discord target parser so `discord_widget` posts its launch button inside forum posts instead of rejecting the session. Fixes #108595.
 - **Tlon SSE connect cleanup:** disarm opening deadlines after failed HTTP responses and rejected stream opens so reconnect attempts cannot leave stale timers behind. (#104585) Thanks @hugenshen.
 - **LINE reply-token media kinds:** honor video and audio metadata on inbound replies, share the canonical media builder with proactive sends, and fail visibly instead of recording empty media-only deliveries. (#106515) Thanks @edenfunf.
 - **Mattermost websocket connection deadlines:** bound opening handshakes so stalled TCP peers cannot hang channel startup indefinitely and reconnect control resumes after timeout. (#105553) Thanks @hugenshen.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Discord Activity forum threads:** resolve provider-prefixed thread channel targets through the canonical Discord target parser so `discord_widget` posts its launch button inside forum posts instead of rejecting the session. Fixes #108595.
 - **Tlon SSE connect cleanup:** disarm opening deadlines after failed HTTP responses and rejected stream opens so reconnect attempts cannot leave stale timers behind. (#104585) Thanks @hugenshen.
 - **LINE reply-token media kinds:** honor video and audio metadata on inbound replies, share the canonical media builder with proactive sends, and fail visibly instead of recording empty media-only deliveries. (#106515) Thanks @edenfunf.
 - **Mattermost websocket connection deadlines:** bound opening handshakes so stalled TCP peers cannot hang channel startup indefinitely and reconnect control resumes after timeout. (#105553) Thanks @hugenshen.

--- a/extensions/discord/src/activities/tool.test.ts
+++ b/extensions/discord/src/activities/tool.test.ts
@@ -71,6 +71,36 @@ describe("discord_widget", () => {
     });
   });
 
+  it("resolves a provider-prefixed forum thread target", async () => {
+    const runtime = createActivityTestRuntime();
+    const send = vi.fn(async (..._args: Parameters<typeof sendMessageDiscord>) => ({
+      messageId: "message-1",
+      channelId: "987654321",
+      receipt: {},
+    }));
+    const tool = createDiscordWidgetTool(
+      discordContext({
+        nativeChannelId: undefined,
+        deliveryContext: { channel: "discord", to: "discord:channel:987654321" },
+      }),
+      {
+        runtime,
+        sendMessage: send as unknown as typeof sendMessageDiscord,
+      },
+    );
+    if (!tool) {
+      throw new Error("expected Discord widget tool");
+    }
+
+    const result = await tool.execute("forum-widget", {
+      html: "<p>Forum widget</p>",
+      title: "Forum widget",
+    });
+
+    expect(result.details).toMatchObject({ channelId: "987654321" });
+    expect(send).toHaveBeenCalledWith("channel:987654321", "Forum widget", expect.any(Object));
+  });
+
   it("keeps full documents unchanged and rejects oversized HTML", async () => {
     const document = "<!doctype html><html><body>full</body></html>";
     const runtime = createActivityTestRuntime();
@@ -138,5 +168,24 @@ describe("discord_widget", () => {
     await expect(
       tool.execute("missing-channel", { html: "hello", title: "No channel" }),
     ).rejects.toThrow("requires a concrete Discord channel");
+  });
+
+  it("rejects direct-message targets without a channel", async () => {
+    const tool = createDiscordWidgetTool(
+      discordContext({
+        nativeChannelId: undefined,
+        deliveryContext: { channel: "discord", to: "discord:user:987654321" },
+      }),
+      {
+        runtime: createActivityTestRuntime(),
+        sendMessage: vi.fn() as unknown as typeof sendMessageDiscord,
+      },
+    );
+    if (!tool) {
+      throw new Error("expected Discord widget tool");
+    }
+    await expect(tool.execute("dm-target", { html: "hello", title: "No channel" })).rejects.toThrow(
+      "requires a concrete Discord channel",
+    );
   });
 });

--- a/extensions/discord/src/activities/tool.ts
+++ b/extensions/discord/src/activities/tool.ts
@@ -7,6 +7,7 @@ import { resolveDiscordAccount } from "../accounts.js";
 import { buildDiscordActivityCustomId } from "../component-custom-id.js";
 import { Button, Row } from "../internal/discord.js";
 import { sendMessageDiscord } from "../send.js";
+import { resolveDiscordChannelId as resolveDiscordTargetChannelId } from "../target-parsing.js";
 import type { DiscordActivitiesRuntime } from "./runtime.js";
 
 const DISCORD_WIDGET_HTML_MAX_BYTES = 48 * 1024;
@@ -47,8 +48,11 @@ function resolveDiscordChannelId(context: OpenClawPluginToolContext): string | u
   if (!raw) {
     return undefined;
   }
-  const normalized = raw.replace(/^channel:/i, "");
-  return /^\d+$/.test(normalized) ? normalized : undefined;
+  try {
+    return resolveDiscordTargetChannelId(raw);
+  } catch {
+    return undefined;
+  }
 }
 
 function buildDiscordWidgetDocument(title: string, html: string): string {


### PR DESCRIPTION
Closes #108595

## What Problem This Solves

Fixes an issue where users invoking `discord_widget` from a Discord forum-post thread would receive `discord_widget requires a concrete Discord channel in the current session` when the session carried a provider-prefixed thread target.

## Why This Change Was Made

The Activity tool now delegates channel target normalization to the Discord plugin's canonical target parser instead of maintaining a narrower local parser. Non-channel targets, including Discord DMs without a concrete channel, remain rejected.

This is the bounded owner-level fix: the parser already owns `discord:channel:<id>`, `channel:<id>`, and raw channel target normalization for the plugin, so the Activity tool no longer duplicates that contract.

## User Impact

Discord Activities widgets can now post their launch button inside forum-post threads whose session target is provider-prefixed. Existing behavior outside Discord and for sessions without a concrete channel is unchanged.

## Evidence

- Before the implementation change, the new focused regression failed with the reported `requires a concrete Discord channel` error while the five existing tests passed.
- After the change, `node scripts/run-vitest.mjs extensions/discord/src/activities/tool.test.ts` passes all 7 tests, including provider-prefixed forum-thread resolution and DM rejection.
- `node scripts/check-changed.mjs` passed on the synced patch in Blacksmith Testbox: formatting, both extension typechecks, extension lint (0 warnings/errors), plugin boundaries, and runtime import cycles. Run: https://github.com/openclaw/openclaw/actions/runs/29470236755
- Mandatory Codex autoreview reported no accepted or actionable findings (patch correctness confidence 0.98).

AI-assisted: yes. The implementation, tests, parser contract, callers, and generated diff were reviewed before submission.
