### PR TITLE
fix(update): avoid hanging on stalled registry responses

### DIFF
--- a/src/infra/update-check.test.ts
+++ b/src/infra/update-check.test.ts
@@ -235,6 +235,51 @@ describe("resolveNpmChannelTag", () => {
     });
   });
 
+  it("times out when the public registry response body stalls after headers", async () => {
+    vi.useFakeTimers();
+    try {
+      const fetchMock = vi.fn<typeof fetch>(async (_input, init) => {
+        const signal = init?.signal;
+        if (!signal) {
+          throw new Error("missing registry request signal");
+        }
+        return new Response(
+          new ReadableStream({
+            start(controller) {
+              signal.addEventListener("abort", () => controller.error(signal.reason), {
+                once: true,
+              });
+            },
+          }),
+          { headers: { "content-type": "application/json" } },
+        );
+      });
+      vi.stubGlobal("fetch", fetchMock);
+
+      const resultPromise = Promise.race([
+        fetchNpmPackageTargetStatus({ target: "latest", timeoutMs: 50 }),
+        new Promise<never>((_resolve, reject) => {
+          setTimeout(() => reject(new Error("registry response body exceeded timeoutMs")), 2000);
+        }),
+      ]);
+      await vi.advanceTimersByTimeAsync(2000);
+
+      await expect(resultPromise).resolves.toMatchObject({
+        target: "latest",
+        version: null,
+        nodeEngine: null,
+        error: "TimeoutError: request timed out",
+      });
+      expect(fetchMock).toHaveBeenCalledWith(
+        "https://registry.npmjs.org/openclaw/latest",
+        expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      );
+    } finally {
+      vi.unstubAllGlobals();
+      vi.useRealTimers();
+    }
+  });
+
   it("cancels public registry HTTP failure bodies", async () => {
     const cancel = vi.spyOn(ReadableStream.prototype, "cancel");
     mockHttp.intercept({

--- a/src/infra/update-check.ts
+++ b/src/infra/update-check.ts
@@ -3,7 +3,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { readProviderJsonResponse } from "../agents/provider-http-errors.js";
 import { runCommandWithTimeout } from "../process/exec.js";
-import { fetchWithTimeout } from "../utils/fetch-timeout.js";
+import { buildTimeoutAbortSignal } from "../utils/fetch-timeout.js";
 import { detectPackageManager as detectPackageManagerImpl } from "./detect-package-manager.js";
 import { compareOpenClawReleaseVersions } from "./npm-registry-spec.js";
 import { compareValidSemver, normalizeLegacyDotBetaVersion } from "./semver.js";
@@ -186,17 +186,19 @@ async function fetchNpmPackageTargetStatusFromRegistry(params: {
   registryUrl?: string;
   packageName?: string;
 }): Promise<NpmPackageTargetStatus> {
+  const url = npmRegistryTargetUrl({
+    registryUrl: params.registryUrl ?? PUBLIC_NPM_REGISTRY_URL,
+    packageName: params.packageName ?? PUBLIC_NPM_PACKAGE_NAME,
+    target: params.target,
+  });
+  const { signal, cleanup } = buildTimeoutAbortSignal({
+    timeoutMs: Math.max(250, params.timeoutMs),
+    operation: "npm-registry-update-check",
+    url,
+  });
   let res: Response | undefined;
   try {
-    res = await fetchWithTimeout(
-      npmRegistryTargetUrl({
-        registryUrl: params.registryUrl ?? PUBLIC_NPM_REGISTRY_URL,
-        packageName: params.packageName ?? PUBLIC_NPM_PACKAGE_NAME,
-        target: params.target,
-      }),
-      {},
-      Math.max(250, params.timeoutMs),
-    );
+    res = await fetch(url, { signal });
     if (!res.ok) {
       return {
         target: params.target,
@@ -205,6 +207,8 @@ async function fetchNpmPackageTargetStatusFromRegistry(params: {
         error: `HTTP ${res.status}`,
       };
     }
+    // Keep the deadline active through body consumption. Fetch resolves at
+    // headers, so clearing it earlier would leave a stalled registry body unbounded.
     const json = await readProviderJsonResponse<{
       version?: unknown;
       engines?: { node?: unknown };
@@ -220,6 +224,7 @@ async function fetchNpmPackageTargetStatusFromRegistry(params: {
     if (res?.bodyUsed !== true) {
       await res?.body?.cancel().catch(() => undefined);
     }
+    cleanup();
   }
 }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where update checks could hang indefinitely when the npm registry returned response headers but stalled before completing the JSON response body.

## Why This Change Was Made

The existing request timeout ended as soon as `fetch()` returned the headers. This keeps the same deadline active through response-body consumption and cancels an unread body during cleanup, without adding configuration or changing the normal update result.

## User Impact

Update status and dry-run checks now fail within their existing time budget instead of remaining stuck on a stalled registry response.

## Evidence

- Added a focused regression test whose mock registry returns HTTP 200 headers and then leaves its `ReadableStream` body pending.
- The test advances the configured deadline and asserts a bounded `TimeoutError: request timed out` result.
- Controlled live proof used Node `v22.22.0`, a standalone `node:http` server bound only to `127.0.0.1`, and native `fetch` without loading repository code or accessing external networks or credentials:
  - Stalled body: headers arrived in 65 ms; the incomplete JSON body aborted with `TimeoutError` after 255 ms under a 250 ms scaled deadline.
  - Normal body: HTTP 200 JSON completed successfully in 13 ms under a 1-second deadline.
  - Result: `{"stall":"PASS","normal":"PASS"}`.
- Exact-head CI [run 29470889413](https://github.com/openclaw/openclaw/actions/runs/29470889413) passed with no failed or pending checks.
- The focused [checks-node-compact-small-11 job](https://github.com/openclaw/openclaw/actions/runs/29470889413/job/87533756848) ran `src/infra/update-check.test.ts`: 33 tests passed in 731 ms.
- `git diff --check upstream/main...HEAD` passes, and fresh branch autoreview reports no accepted or actionable findings.
- Contributor-source policy intentionally excludes local repository test execution; exact-head fork CI is the executable repository proof, and the isolated live probe validates the native timeout contract.
