### PR TITLE
fix: retain tool arguments when Responses item IDs rotate

### DIFF
--- a/packages/ai/src/providers/openai-responses-shared.test.ts
+++ b/packages/ai/src/providers/openai-responses-shared.test.ts
@@ -1492,6 +1492,66 @@ describe("processResponsesStream", () => {
     expect(events.filter((event) => event.type === "toolcall_end")).toHaveLength(2);
   });
 
+  it("routes indexed argument events when providers rotate item ids", async () => {
+    const output = createAssistantOutput();
+    const stream = new AssistantMessageEventStream();
+    const item = {
+      type: "function_call",
+      id: "fc_rotating",
+      call_id: "call_rotating",
+      name: "read",
+    };
+
+    await processResponsesStream(
+      responseEvents([
+        {
+          type: "response.output_item.added",
+          output_index: 0,
+          item: { ...item, arguments: "" },
+        },
+        {
+          type: "response.function_call_arguments.delta",
+          output_index: 0,
+          item_id: "fc_rotating_delta_1",
+          delta: '{"path":',
+        },
+        {
+          type: "response.function_call_arguments.delta",
+          output_index: 0,
+          item_id: "fc_rotating_delta_2",
+          delta: '"README.md"}',
+        },
+        {
+          type: "response.function_call_arguments.done",
+          output_index: 0,
+          item_id: "fc_rotating_done",
+          arguments: '{"path":"README.md"}',
+        },
+        {
+          type: "response.output_item.done",
+          output_index: 0,
+          item: { ...item, arguments: "" },
+        },
+        {
+          type: "response.completed",
+          response: { id: "resp_rotating_item_ids", status: "completed" },
+        },
+      ]),
+      output,
+      stream,
+      nativeOpenAIModel,
+    );
+
+    expect(output.content).toEqual([
+      {
+        type: "toolCall",
+        id: "call_rotating|fc_rotating",
+        name: "read",
+        arguments: { path: "README.md" },
+      },
+    ]);
+  });
+
   it("rejects a completed Responses tool call whose function name changed", async () => {
     const output = createAssistantOutput();
 

--- a/packages/ai/src/providers/openai-responses-shared.ts
+++ b/packages/ai/src/providers/openai-responses-shared.ts
@@ -785,9 +785,9 @@ export async function processResponsesStream<TApi extends Api>(
     if (outputIndex !== undefined) {
       const indexed = toolCallsByOutputIndex.get(outputIndex);
       if (indexed) {
-        return !identitiesConflict(indexed, identity)
-          ? adoptToolCallIdentity(indexed, identity)
-          : undefined;
+        // Once the stream binds an output index, it is authoritative for later
+        // indexed events. Compatible providers may rotate item ids between events.
+        return adoptToolCallIdentity(indexed, identity);
       }
       // A compatibility stream may add calls without indices, then start
       // including them. Bind only the one identity-matched (or sole) candidate.

--- a/src/agents/openai-responses-transport.ts
+++ b/src/agents/openai-responses-transport.ts
@@ -1319,9 +1319,9 @@ async function processResponsesStream(
     if (outputIndex !== undefined) {
       const indexed = toolCallsByOutputIndex.get(outputIndex);
       if (indexed) {
-        return !identitiesConflict(indexed, identity)
-          ? adoptToolCallIdentity(indexed, identity)
-          : undefined;
+        // Once the stream binds an output index, it is authoritative for later
+        // indexed events. Compatible providers may rotate item ids between events.
+        return adoptToolCallIdentity(indexed, identity);
       }
       // A compatibility stream may add calls without indices, then start
       // including them. Bind only the one identity-matched (or sole) candidate.

--- a/src/agents/openai-transport-stream.streaming.test-utils.ts
+++ b/src/agents/openai-transport-stream.streaming.test-utils.ts
@@ -1619,6 +1619,66 @@ describe("openai transport stream", () => {
     expect(events.filter((event) => event.type === "toolcall_end")).toHaveLength(2);
   });
 
+  it("routes indexed Responses arguments when providers rotate item ids", async () => {
+    const model = createAzureResponsesModel();
+    const output = createResponsesAssistantOutput(model);
+    const item = {
+      type: "function_call",
+      id: "fc_rotating",
+      call_id: "call_rotating",
+      name: "read",
+    };
+
+    await testing.processResponsesStream(
+      streamChunks([
+        {
+          type: "response.output_item.added",
+          output_index: 0,
+          item: { ...item, arguments: "" },
+        },
+        {
+          type: "response.function_call_arguments.delta",
+          output_index: 0,
+          item_id: "fc_rotating_delta_1",
+          delta: '{"path":',
+        },
+        {
+          type: "response.function_call_arguments.delta",
+          output_index: 0,
+          item_id: "fc_rotating_delta_2",
+          delta: '"README.md"}',
+        },
+        {
+          type: "response.function_call_arguments.done",
+          output_index: 0,
+          item_id: "fc_rotating_done",
+          arguments: '{"path":"README.md"}',
+        },
+        {
+          type: "response.output_item.done",
+          output_index: 0,
+          item: { ...item, arguments: "" },
+        },
+        {
+          type: "response.completed",
+          response: { id: "resp_rotating_item_ids", status: "completed" },
+        },
+      ]),
+      output,
+      { push: vi.fn() },
+      model,
+    );
+
+    expect(output.content).toMatchObject([
+      {
+        type: "toolCall",
+        id: "call_rotating|fc_rotating",
+        name: "read",
+        arguments: { path: "README.md" },
+      },
+    ]);
+  });
+
   it("rejects a completed Responses tool call whose function name changed", async () => {
     const model = createAzureResponsesModel();
     const output = createResponsesAssistantOutput(model);


### PR DESCRIPTION
Closes #108511

## What Problem This Solves

Fixes an issue where users running tool calls through the OpenAI Responses transport could lose every streamed argument when a compatible provider rotated the event `item_id`. On GitHub Copilot `gpt-5.6-sol`, calls such as `read` then ran with empty arguments and could stall until the agent timed out.

## Why This Change Was Made

The draft treats an already-bound Responses `output_index` as the routing key for later indexed argument events, allowing provider-specific `item_id` rotation without discarding their deltas. It applies the same behavior to the shared AI package and the agent transport, with mirrored regression coverage.

One-pass autoreview identified an unresolved edge in this draft: the same indexed path also accepts a conflicting `call_id` supplied by `response.output_item.done`. The intended follow-up is to allow only `item_id` variation while preserving the stable `call_id` conflict check. This is intentionally disclosed rather than silently changed after the requested review stop.

## User Impact

GitHub Copilot `gpt-5.6-sol` tool calls can retain their streamed JSON arguments when the provider rotates or obfuscates per-event item IDs. The PR remains a draft pending resolution of the narrower `call_id` review finding and live provider verification.

## Evidence

- Added focused rotating-`item_id` regressions for both Responses stream implementations. Both reproduced the unresolved-tool-call failure before the implementation change and pass afterward.
- `packages/ai/src/providers/openai-responses-shared.test.ts`: 52 tests passed.
- `src/agents/openai-transport-stream.test.ts`: 330 tests passed.
- Targeted formatting and `git diff --check` passed.
- Autoreview command: `.agents/skills/autoreview/scripts/autoreview --mode uncommitted --stream-engine-output`.
- Autoreview result: two mirrored P1 findings for the unresolved `call_id` conflict described above.
- Live GitHub Copilot verification was not run: the Blacksmith CLI was unavailable and the AWS Crabbox broker was not configured in this environment.

AI-assisted: Codex implemented and reviewed this change; the contributor inspected the resulting patch and proof before publication.
