### PR TITLE
fix(ui): terminal tab close button floats detached from its tab

### DIFF
--- a/ui/src/components/terminal/terminal-panel-styles.ts
+++ b/ui/src/components/terminal/terminal-panel-styles.ts
@@ -73,7 +73,6 @@ export const terminalPanelStyles = css`
   .tp-tabs::part(nav) {
     display: flex;
     align-items: stretch;
-    gap: 1px;
   }
   .tp-tabs::part(body) {
     display: none;
@@ -85,7 +84,7 @@ export const terminalPanelStyles = css`
     display: flex;
     align-items: center;
     gap: 7px;
-    padding: 0 10px;
+    padding: 0 4px 0 10px;
     height: 36px;
     color: var(--muted, #8a919e);
     white-space: nowrap;
@@ -123,27 +122,62 @@ export const terminalPanelStyles = css`
     font-size: 11px;
     color: var(--muted, #8a919e);
   }
+  /* Each close button sits right after its tab in the nav slot; the pair is
+     styled as one surface (shared hover background, shared active underline)
+     while the X keeps its own inner highlight. */
   .tp-tab__close {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    align-self: center;
-    flex: 0 0 26px;
-    width: 26px;
-    height: 26px;
+    align-self: stretch;
+    flex: 0 0 auto;
+    width: 24px;
+    margin-right: 1px;
+    padding: 0 4px 0 0;
     opacity: 0;
     border: none;
+    border-bottom: 2px solid transparent;
     background: transparent;
     color: var(--muted, #8a919e);
-    border-radius: 6px;
-    padding: 0;
+    transition:
+      color 0.12s ease,
+      background 0.12s ease,
+      opacity 0.12s ease;
   }
-  :where(.tp-tab:hover, .tp-tab[active]) + .tp-tab__close {
-    opacity: 0.7;
+  .tp-tab__close-box {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 18px;
+    height: 18px;
+    border-radius: 5px;
   }
+  :where(.tp-tab:hover, .tp-tab[active]) + .tp-tab__close,
   .tp-tab__close:hover,
   .tp-tab__close:focus-visible {
     opacity: 1;
+  }
+  .tp-tab:hover + .tp-tab__close,
+  .tp-tab__close:hover,
+  .tp-tab__close:focus-visible {
+    background: color-mix(in srgb, var(--text, #d7dae0) 6%, transparent);
+  }
+  /* Back-propagate hover from the X to its tab so the pair lights up together. */
+  .tp-tab:has(+ .tp-tab__close:hover)::part(base),
+  .tp-tab:has(+ .tp-tab__close:focus-visible)::part(base) {
+    color: var(--text, #d7dae0);
+    background: color-mix(in srgb, var(--text, #d7dae0) 6%, transparent);
+  }
+  .tp-tab[active] + .tp-tab__close {
+    border-bottom-color: var(--accent, #ff5c5c);
+  }
+  .tp-tab__close:hover,
+  .tp-tab__close:focus-visible {
+    color: var(--text, #d7dae0);
+  }
+  .tp-tab__close:hover .tp-tab__close-box,
+  .tp-tab__close:focus-visible .tp-tab__close-box {
+    background: color-mix(in srgb, var(--text, #d7dae0) 14%, transparent);
   }
   .tp-new,
   .tp-icon {
@@ -161,7 +195,6 @@ export const terminalPanelStyles = css`
   .tp-new {
     align-self: center;
   }
-  .tp-tab__close:hover,
   .tp-new:hover,
   .tp-icon:hover {
     background: color-mix(in srgb, var(--text, #d7dae0) 12%, transparent);

--- a/ui/src/components/terminal/terminal-panel-tabs.ts
+++ b/ui/src/components/terminal/terminal-panel-tabs.ts
@@ -98,7 +98,7 @@ export function renderTerminalPanelTabs(params: {
             aria-label=${`${t("terminal.closeSession")}: ${terminalTabLabel(tab)}`}
             @click=${() => params.onClose(tab.id)}
           >
-            ${CLOSE_GLYPH}
+            <span class="tp-tab__close-box">${CLOSE_GLYPH}</span>
           </button>
         `;
       })}

--- a/ui/src/e2e/terminal-embedded.e2e.test.ts
+++ b/ui/src/e2e/terminal-embedded.e2e.test.ts
@@ -32,7 +32,7 @@ describeControlUiE2e("embedded terminal document", () => {
     await server?.close();
   });
 
-  it("renders only the terminal with a centered close control while native auth connects", async () => {
+  it("renders only the terminal with a tab-attached close control while native auth connects", async () => {
     const context = await browser.newContext({ serviceWorkers: "block" });
     const page = await context.newPage();
     await page.addInitScript(() => {
@@ -118,8 +118,8 @@ describeControlUiE2e("embedded terminal document", () => {
             width: closeBounds.width,
           };
         });
-      expect(closeControlMetrics.width).toBe(26);
-      expect(closeControlMetrics.height).toBe(26);
+      expect(closeControlMetrics.width).toBe(24);
+      expect(closeControlMetrics.height).toBe(36);
       expect(closeControlMetrics.centerOffset).toBeLessThanOrEqual(0.5);
       const closeControl = page.locator("openclaw-terminal-panel").locator(".tp-tab__close");
       expect(await closeControl.getAttribute("aria-label")).toBe("Close terminal session: bash");


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the web terminal's per-tab close button rendered as a detached floating square next to the tab. On hover it showed its own dark rounded island between the tab and the new-session button, making it ambiguous which tab it closes and whether it belongs to a tab at all.

## Why This Change Was Made

The close button is slotted into the tab strip as a sibling of its `wa-tab`, and its old styling (self-centered 26x26 rounded square, separate nav gap) visually disconnected it from the tab it operates on. This change styles each tab + close pair as one surface, the way browser tabs do it: the close control spans the full tab height, shares the tab's hover background (hover propagates both ways via `:has()`), and the active tab's accent underline continues beneath it. The X keeps its own affordance through a small rounded inner highlight on hover. Tab markup gains only a wrapper span for that inner highlight; behavior, accessibility labels, and click handling are unchanged.

## User Impact

Terminal tab close buttons now read as part of their tab while still being clearly clickable on their own. Inactive tabs continue to hide the X until hovered.

| State | Before | After |
| --- | --- | --- |
| At rest | ![before base](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/terminal-tab-close/before-base.png) | ![after base](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/terminal-tab-close/after-base.png) |
| Close button hovered | ![before close hover](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/terminal-tab-close/before-close-hover.png) | ![after close hover](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/terminal-tab-close/after-close-hover.png) |
| Tab hovered | | ![after tab hover](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/terminal-tab-close/after-tab-hover.png) |

## Evidence

- Screenshots above captured with the Playwright mock-gateway e2e harness (`installMockGateway` + `?view=terminal`, dark color scheme, two tabs).
- `node scripts/run-vitest.mjs ui/src/components/terminal` — `terminal-panel-tabs.test.ts` (the changed render module) passes. The `terminal-panel*`/readiness/upload jsdom failures in that folder reproduce identically on clean HEAD in this local environment (Node jsdom storage breakage) and are unrelated; hosted CI is the gate for those.
- `ui/src/e2e/terminal-embedded.e2e.test.ts` metrics assertions updated (close control now 24px wide, full 36px tab height, still center-aligned in the header) — verified via the same harness.
- Autoreview (Codex, gpt-5.6-sol, xhigh): clean, no findings.
