### PR TITLE
fix(zai): return text from constrained GLM completions

### DIFF
--- a/packages/ai/src/providers/openai-completions.test.ts
+++ b/packages/ai/src/providers/openai-completions.test.ts
@@ -667,6 +667,26 @@ describe("OpenAI-compatible completions params", () => {
     expect(capturedMaxTokens).toBe(32_000);
   });
 
+  it("uses max_tokens for Z.AI requests", async () => {
+    const stream = streamOpenAICompletions(
+      {
+        ...createModel(32_000),
+        provider: "zai",
+        baseUrl: "https://api.z.ai/api/paas/v4",
+      },
+      context,
+      {
+        apiKey: "sk-test",
+        maxTokens: 1_024,
+      },
+    );
+
+    await stream.result();
+
+    expect(mockOpenAIOptionsRef.payloads[0]).toMatchObject({ max_tokens: 1_024 });
+    expect(mockOpenAIOptionsRef.payloads[0]).not.toHaveProperty("max_completion_tokens");
+  });
+
   it("forwards simple stop sequences to request params", async () => {
     let capturedStop: unknown;
     const stream = streamSimpleOpenAICompletions(createModel(32_000), context, {

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -1375,7 +1375,7 @@ function detectCompat(model: Model<"openai-completions">): ResolvedOpenAIComplet
     isCloudflareAiGateway;
 
   const useMaxTokens =
-    baseUrl.includes("chutes.ai") || isMoonshot || isCloudflareAiGateway || isTogether;
+    baseUrl.includes("chutes.ai") || isMoonshot || isCloudflareAiGateway || isTogether || isZai;
 
   const isGrok = provider === "xai" || baseUrl.includes("api.x.ai");
   const isDeepSeek = provider === "deepseek" || baseUrl.includes("deepseek.com");

--- a/src/agents/openai-completions-compat.test.ts
+++ b/src/agents/openai-completions-compat.test.ts
@@ -83,6 +83,16 @@ describe("resolveOpenAICompletionsCompatDefaults", () => {
     expect(defaults.maxTokensField).toBe("max_tokens");
   });
 
+  it("uses Z.AI's documented max_tokens field", () => {
+    const defaults = resolveOpenAICompletionsCompatDefaults({
+      provider: "zai",
+      endpointClass: "zai-native",
+      knownProviderFamily: "zai",
+    });
+
+    expect(defaults.maxTokensField).toBe("max_tokens");
+  });
+
   it("requires a non-empty user or assistant turn for ModelStudio-compatible providers", () => {
     expect(
       resolveOpenAICompletionsCompatDefaults({

--- a/src/agents/openai-completions-compat.ts
+++ b/src/agents/openai-completions-compat.ts
@@ -92,6 +92,7 @@ function resolveOpenAICompletionsCompatDefaults(
     endpointClass === "chutes-native" ||
     endpointClass === "mistral-public" ||
     knownProviderFamily === "mistral" ||
+    isZai ||
     isTogether ||
     (isDefaultRoute && isDefaultRouteProvider(provider, "chutes"));
   return {

--- a/src/agents/zai.live.test.ts
+++ b/src/agents/zai.live.test.ts
@@ -35,21 +35,16 @@ async function expectModelReturnsAssistantText(
     contextWindow: modelId === "glm-5.2" ? 1_000_000 : 202_800,
     maxTokens: modelId === "glm-5.2" ? 131_072 : 131_100,
   };
-  const runProbe = (maxTokens: number) =>
-    completeSimple(
-      model,
-      {
-        messages: createSingleUserPromptMessage(),
-      },
-      { apiKey: ZAI_KEY, maxTokens },
-    );
-  const res = await runProbe(64);
-  let text = extractNonEmptyAssistantText(res.content);
-  // GLM can spend a tiny cap entirely on hidden reasoning. Retry only a
-  // provider-declared truncation; other empty responses remain failures.
-  if (text.length === 0 && res.stopReason === "length") {
-    text = extractNonEmptyAssistantText((await runProbe(256)).content);
-  }
+  // GLM-5 reasoning is enabled by default and consumes the same output budget.
+  // Keep enough headroom for a visible answer while retaining a bounded probe.
+  const res = await completeSimple(
+    model,
+    {
+      messages: createSingleUserPromptMessage(),
+    },
+    { apiKey: ZAI_KEY, maxTokens: 1_024 },
+  );
+  const text = extractNonEmptyAssistantText(res.content);
   expect(text.length).toBeGreaterThan(0);
 }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Z.AI GLM users could receive an empty assistant response when a constrained completion spent its output budget on reasoning. The same mismatch blocked Full Release Validation for both `glm-5-turbo` and `glm-5.1`.

## Why This Change Was Made

Both OpenAI-compatible transport stacks now send Z.AI's documented `max_tokens` field. The live availability probe uses one bounded 1024-token request, enough for GLM-5's default reasoning plus visible text, instead of a 64-token request followed by a still-too-small retry.

Official contract: https://docs.z.ai/api-reference/llm/chat-completion

AI-assisted. No transcript attached.

## User Impact

Z.AI completion limits now use the provider-supported request field, improving reliable visible responses for constrained GLM calls. No config, protocol, or migration changes.

## Evidence

- Before: exact main Full Release Validation https://github.com/openclaw/openclaw/actions/runs/29469793077 failed both Z.AI live probes after empty 64-token and 256-token responses.
- Blacksmith Testbox https://github.com/openclaw/openclaw/actions/runs/29470768098: 62 focused transport/compat tests passed.
- Blacksmith Testbox: touched-surface `pnpm check:changed` passed, including formatting, API baseline, type checks, lint, boundaries, and import cycles.
- Fresh autoreview: no actionable findings, 0.96 confidence.
- Exact hosted live-provider validation will run after landing through Full Release Validation.
