### PR TITLE
fix(mantis): stop stalled evidence uploads from hanging

### DIFF
--- a/scripts/mantis/publish-pr-evidence.d.mts
+++ b/scripts/mantis/publish-pr-evidence.d.mts
@@ -56,12 +56,13 @@ export function publishArtifactFiles({
   fetchImpl,
   manifest,
   storageConfig,
+  timeoutMs,
 }: {
   artifactRoot: string;
   fetchImpl?:
     | ((
         url: URL,
-        init: { body: Buffer; headers: HeadersInit; method: string },
+        init: { body: Buffer; headers: HeadersInit; method: string; signal: AbortSignal },
       ) => Promise<Response>)
     | undefined;
   manifest: EvidenceManifest;
@@ -75,6 +76,7 @@ export function publishArtifactFiles({
         secretAccessKey: string;
       }
     | undefined;
+  timeoutMs?: number | undefined;
 }): Promise<{
   artifactRoot: string;
   rawBase: string;

--- a/scripts/mantis/publish-pr-evidence.mjs
+++ b/scripts/mantis/publish-pr-evidence.mjs
@@ -7,6 +7,9 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+// Evidence bundles can include full videos, so allow slow transfers while bounding each PUT.
+const MANTIS_ARTIFACT_UPLOAD_TIMEOUT_MS = 300_000;
+
 function parseArgs(argv) {
   const args = {};
   for (let index = 0; index < argv.length; index += 1) {
@@ -436,11 +439,40 @@ function run(command, args, options = {}) {
   });
 }
 
+async function uploadArtifact({ artifact, fetchImpl, request, timeoutMs }) {
+  const signal = AbortSignal.timeout(timeoutMs);
+  let response;
+  try {
+    response = await fetchImpl(request.url, {
+      body: request.body,
+      headers: request.headers,
+      method: request.method,
+      signal,
+    });
+  } catch (error) {
+    if (signal.aborted) {
+      throw new Error(
+        `Timed out uploading Mantis artifact ${artifact.targetPath} after ${timeoutMs}ms.`,
+        { cause: error },
+      );
+    }
+    throw error;
+  }
+  if (response.ok) {
+    return;
+  }
+  const responseText = await response.text();
+  throw new Error(
+    `Failed to upload Mantis artifact ${artifact.targetPath}: ${response.status} ${response.statusText}\n${responseText}`,
+  );
+}
+
 export async function publishArtifactFiles({
   artifactRoot,
   fetchImpl = fetch,
   manifest,
   storageConfig = objectStorageConfig(),
+  timeoutMs = MANTIS_ARTIFACT_UPLOAD_TIMEOUT_MS,
 }) {
   const safeArtifactRoot = normalizeTargetPath(artifactRoot);
   const publicRoot = `${storageConfig.publicBaseUrl}/${encodePathForUrl(safeArtifactRoot)}`;
@@ -452,17 +484,7 @@ export async function publishArtifactFiles({
       config: storageConfig,
       key,
     });
-    const response = await fetchImpl(request.url, {
-      body: request.body,
-      headers: request.headers,
-      method: request.method,
-    });
-    if (!response.ok) {
-      const responseText = await response.text();
-      throw new Error(
-        `Failed to upload Mantis artifact ${artifact.targetPath}: ${response.status} ${response.statusText}\n${responseText}`,
-      );
-    }
+    await uploadArtifact({ artifact, fetchImpl, request, timeoutMs });
   }
   const indexArtifact = {
     targetPath: "index.json",
@@ -493,17 +515,7 @@ export async function publishArtifactFiles({
     config: storageConfig,
     key: normalizeTargetPath(`${safeArtifactRoot}/${indexArtifact.targetPath}`),
   });
-  const indexResponse = await fetchImpl(indexRequest.url, {
-    body: indexRequest.body,
-    headers: indexRequest.headers,
-    method: indexRequest.method,
-  });
-  if (!indexResponse.ok) {
-    const responseText = await indexResponse.text();
-    throw new Error(
-      `Failed to upload Mantis artifact ${indexArtifact.targetPath}: ${indexResponse.status} ${indexResponse.statusText}\n${responseText}`,
-    );
-  }
+  await uploadArtifact({ artifact: indexArtifact, fetchImpl, request: indexRequest, timeoutMs });
   return {
     artifactRoot: safeArtifactRoot,
     rawBase: publicRoot,

--- a/test/scripts/mantis-publish-pr-evidence.test.ts
+++ b/test/scripts/mantis-publish-pr-evidence.test.ts
@@ -108,15 +108,22 @@ describe("scripts/mantis/publish-pr-evidence", () => {
 
   it("uploads manifest artifacts to R2-compatible object storage", async () => {
     const manifest = loadEvidenceManifest(writeFixtureManifest());
-    const requests: Array<{ body: Buffer; headers: HeadersInit; method: string; url: string }> = [];
+    const requests: Array<{
+      body: Buffer;
+      headers: HeadersInit;
+      method: string;
+      signal: AbortSignal;
+      url: string;
+    }> = [];
     const fetchImpl = async (
       url: URL,
-      init: { body: Buffer; headers: HeadersInit; method: string },
+      init: { body: Buffer; headers: HeadersInit; method: string; signal: AbortSignal },
     ) => {
       requests.push({
         body: init.body,
         headers: init.headers,
         method: init.method,
+        signal: init.signal,
         url: url.toString(),
       });
       return new Response("", { status: 200 });
@@ -142,6 +149,7 @@ describe("scripts/mantis/publish-pr-evidence", () => {
       treeUrl: "https://qa.openclaw.ai/mantis/discord/pr-1/run-1/index.json",
     });
     expect(requests.map((request) => request.method)).toEqual(["PUT", "PUT", "PUT", "PUT", "PUT"]);
+    expect(requests.every((request) => request.signal instanceof AbortSignal)).toBe(true);
     expect(requests.map((request) => request.url)).toEqual([
       "https://example.r2.cloudflarestorage.com/qa-artifacts/mantis/discord/pr-1/run-1/baseline.png",
       "https://example.r2.cloudflarestorage.com/qa-artifacts/mantis/discord/pr-1/run-1/candidate.png",
@@ -159,6 +167,37 @@ describe("scripts/mantis/publish-pr-evidence", () => {
     expect(String(requests[4]?.body)).toContain(
       '"url": "https://qa.openclaw.ai/mantis/discord/pr-1/run-1/baseline.png"',
     );
+  });
+
+  it("aborts a stalled artifact upload after the per-object timeout", async () => {
+    const manifest = loadEvidenceManifest(writeFixtureManifest());
+    let observedSignal: AbortSignal | undefined;
+
+    const upload = publishArtifactFiles({
+      artifactRoot: "mantis/discord/pr-1/run-1",
+      fetchImpl: (_url, init) => {
+        observedSignal = init.signal;
+        return new Promise<Response>((_resolve, reject) => {
+          init.signal.addEventListener("abort", () => reject(init.signal.reason), { once: true });
+        });
+      },
+      manifest,
+      storageConfig: {
+        accessKeyId: "access",
+        bucket: "qa-artifacts",
+        endpoint: "https://example.r2.cloudflarestorage.com",
+        publicBaseUrl: "https://qa.openclaw.ai",
+        region: "auto",
+        secretAccessKey: "secret",
+      },
+      timeoutMs: 5,
+    });
+
+    await expect(upload).rejects.toMatchObject({
+      cause: { name: "TimeoutError" },
+      message: "Timed out uploading Mantis artifact baseline.png after 5ms.",
+    });
+    expect(observedSignal?.aborted).toBe(true);
   });
 
   it("allows failure manifests to omit optional visual artifacts", () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Mantis evidence publishing could hang indefinitely when an R2 upload accepted the connection but never completed.

## Why This Change Was Made

Each artifact PUT, including the final `index.json`, now gets an independent five-minute deadline. The budget is deliberately per object because evidence bundles can contain full videos, while timeout failures identify the affected artifact and preserve the original error.

## User Impact

QA evidence publishing now fails with an actionable error instead of holding the workflow open forever when object storage stalls.

## Evidence

- Added focused coverage that supplies a 5 ms budget, stalls the upload, and verifies a `TimeoutError`, the artifact path, and the aborted signal.
- Existing upload coverage now verifies that all five PUT requests receive abort signals.
- Exact-head [fork CI run 29471709378](https://github.com/openclaw/openclaw/actions/runs/29471709378) passed at `c5da88de881650913ff78b49893ae95ecbd34dd6`.
- Focused [checks-node-compact-small-7 job](https://github.com/openclaw/openclaw/actions/runs/29471709378/job/87536072084) ran `test/scripts/mantis-publish-pr-evidence.test.ts` successfully: 7 tests in 14 ms.
- `git diff --check upstream/main...HEAD` passes.
- Fresh Claude autoreview passes after its only diagnostic finding was fixed; no accepted or actionable findings remain.
- Per repository policy, contributor code was not executed locally; the proof above comes from exact-head secretless fork CI.
- Runtime contract: Node's `AbortSignal.timeout(delay)` aborts with a `TimeoutError`; Node 24 implements its timer as weak and unreferenced so it does not keep the process alive.
