### PR TITLE
fix(codex): prevent corrupted UTF-8 in sandbox exec server output

### DIFF
--- a/extensions/codex/src/app-server/sandbox-exec-server.http.test.ts
+++ b/extensions/codex/src/app-server/sandbox-exec-server.http.test.ts
@@ -24,6 +24,32 @@ function testExecEnv(): NodeJS.ProcessEnv {
   };
 }
 
+function splitUtf8ChildScript(params: {
+  stream: "stdout" | "stderr";
+  value: string;
+  stdoutPrefix?: string;
+  exitCode?: number;
+}): string {
+  const target = `process.${params.stream}`;
+  const finish =
+    params.exitCode === undefined
+      ? `${target}.end(rest);`
+      : `${target}.write(rest, () => process.exit(${params.exitCode}));`;
+  return [
+    `const value = Buffer.from(${JSON.stringify(params.value)});`,
+    'const marker = Buffer.from("猫");',
+    "const splitAt = value.indexOf(marker) + 1;",
+    ...(params.stdoutPrefix
+      ? [`process.stdout.write(${JSON.stringify(params.stdoutPrefix)});`]
+      : []),
+    `${target}.write(value.subarray(0, splitAt));`,
+    "setTimeout(() => {",
+    "  const rest = value.subarray(splitAt);",
+    `  ${finish}`,
+    "}, 25);",
+  ].join("\n");
+}
+
 describe("OpenClaw Codex sandbox exec-server HTTP", () => {
   it("routes HTTP requests through the sandbox backend", async () => {
     const runShellCommand = vi.fn(async () => ({
@@ -204,6 +230,100 @@ describe("OpenClaw Codex sandbox exec-server HTTP", () => {
         deltaBase64: "",
         done: true,
       }),
+    ]);
+    socket.close();
+  });
+
+  it("preserves split UTF-8 in streaming HTTP response headers", async () => {
+    const headerLine = `${JSON.stringify({
+      type: "headers",
+      status: 200,
+      headers: [{ name: "X-Test", value: "猫-value" }],
+    })}\n`;
+    const sandbox = createSandboxContext({
+      buildExecSpec: async () => ({
+        argv: [
+          process.execPath,
+          "-e",
+          splitUtf8ChildScript({ stream: "stdout", value: headerLine }),
+        ],
+        env: testExecEnv(),
+        stdinMode: "pipe-closed",
+      }),
+    });
+    const client = createClient();
+    await ensureCodexSandboxExecServerEnvironment({
+      client: client as never,
+      sandbox,
+    });
+    const socket = await openSocket(execServerUrlFromClient(client));
+    await rpc(socket, "initialize", { clientName: "test" });
+    socket.send(JSON.stringify({ method: "initialized" }));
+
+    await expect(
+      rpc(socket, "http/request", {
+        requestId: "http-split-stdout",
+        method: "GET",
+        url: "https://example.test/sse",
+        streamResponse: true,
+      }),
+    ).resolves.toEqual({
+      status: 200,
+      headers: [{ name: "X-Test", value: "猫-value" }],
+      bodyBase64: "",
+    });
+    socket.close();
+  });
+
+  it("preserves split UTF-8 in streaming HTTP failure diagnostics", async () => {
+    const headerLine = `${JSON.stringify({
+      type: "headers",
+      status: 200,
+      headers: [],
+    })}\n`;
+    const sandbox = createSandboxContext({
+      buildExecSpec: async () => ({
+        argv: [
+          process.execPath,
+          "-e",
+          splitUtf8ChildScript({
+            stream: "stderr",
+            value: "sandbox failed: 猫 not found\n",
+            stdoutPrefix: headerLine,
+            exitCode: 17,
+          }),
+        ],
+        env: testExecEnv(),
+        stdinMode: "pipe-closed",
+      }),
+    });
+    const client = createClient();
+    await ensureCodexSandboxExecServerEnvironment({
+      client: client as never,
+      sandbox,
+    });
+    const socket = await openSocket(execServerUrlFromClient(client));
+    const notifications = collectNotifications(socket);
+    await rpc(socket, "initialize", { clientName: "test" });
+    socket.send(JSON.stringify({ method: "initialized" }));
+
+    await expect(
+      rpc(socket, "http/request", {
+        requestId: "http-split-stderr",
+        method: "GET",
+        url: "https://example.test/sse",
+        streamResponse: true,
+      }),
+    ).resolves.toEqual({ status: 200, headers: [], bodyBase64: "" });
+
+    await expect(waitForHttpBodyDeltas(notifications, 1)).resolves.toEqual([
+      {
+        requestId: "http-split-stderr",
+        seq: 1,
+        deltaBase64: "",
+        done: true,
+        error: "sandbox failed: 猫 not found",
+      },
     ]);
     socket.close();
   });

--- a/extensions/codex/src/app-server/sandbox-exec-server/http.ts
+++ b/extensions/codex/src/app-server/sandbox-exec-server/http.ts
@@ -6,6 +6,7 @@ import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
 import { embeddedAgentLog } from "openclaw/plugin-sdk/agent-harness-runtime";
 import type { SandboxContext } from "openclaw/plugin-sdk/sandbox";
 import { SsrFBlockedError, isBlockedHostnameOrIp } from "openclaw/plugin-sdk/ssrf-runtime";
+import { sliceUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import type { WebSocket } from "ws";
 import type { JsonObject, JsonValue } from "../protocol.js";
 import { readHttpHeaders, requireNumber, requireObject, requireString } from "./json-rpc.js";
@@ -204,8 +205,9 @@ function readStreamingSandboxHttpResponse(params: {
       }
       reject(new Error(message));
     };
-    params.child.stdout.on("data", (chunk: Buffer) => {
-      stdoutBuffer += chunk.toString("utf8");
+    params.child.stdout.setEncoding("utf8");
+    params.child.stdout.on("data", (chunk: string) => {
+      stdoutBuffer += chunk;
       let newline = stdoutBuffer.indexOf("\n");
       while (newline >= 0) {
         const line = stdoutBuffer.slice(0, newline).trim();
@@ -246,8 +248,9 @@ function readStreamingSandboxHttpResponse(params: {
         );
       }
     });
-    params.child.stderr.on("data", (chunk: Buffer) => {
-      stderr = `${stderr}${chunk.toString("utf8")}`.slice(-4096);
+    params.child.stderr.setEncoding("utf8");
+    params.child.stderr.on("data", (chunk: string) => {
+      stderr = sliceUtf16Safe(`${stderr}${chunk}`, -4096);
     });
     params.child.once("error", (error) => {
       // ChildProcess error can precede close while the helper is still alive.


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Codex sandbox HTTP requests could corrupt Unicode response headers or failure diagnostics when the child-process pipe split a UTF-8 code point across reads.

This sandbox exec-server path is distinct from the app-server client stderr path fixed by #108335 and #109013.

## Why This Change Was Made

The sandbox HTTP bridge now lets Node decode each child stream statefully with `setEncoding("utf8")`, matching the canonical client fix, and bounds stderr with `sliceUtf16Safe`. The duplicate client changes and mocked lifecycle tests were removed; real spawned-child/WebSocket tests cover both split response headers and the Codex-visible terminal failure diagnostic.

## User Impact

Codex sandbox HTTP responses and error messages preserve Unicode characters across arbitrary OS pipe boundaries. No API or configuration changes.

## Evidence

- `node scripts/run-vitest.mjs extensions/codex/src/app-server/sandbox-exec-server.http.test.ts extensions/codex/src/app-server/sandbox-exec-server.lifecycle.test.ts` — 2 files, 14 tests passed.
- `node scripts/check-changed.mjs -- extensions/codex/src/app-server/sandbox-exec-server/http.ts extensions/codex/src/app-server/sandbox-exec-server.http.test.ts extensions/codex/src/app-server/sandbox-exec-server.lifecycle.test.ts` — Testbox typechecks, lint, format, SDK/boundary guards passed.
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted` — clean; no accepted/actionable findings.
