### PR TITLE
fix(installer): time out stalled runtime downloads

### DIFF
--- a/scripts/install-cli.sh
+++ b/scripts/install-cli.sh
@@ -137,7 +137,11 @@ download_file() {
     detect_downloader
   fi
   if [[ "$DOWNLOADER" == "curl" ]]; then
-    curl -fsSL --proto '=https' --tlsv1.2 --retry 3 --retry-delay 1 --retry-connrefused -o "$output" "$url"
+    # Match wget's stall protection without capping slow, progressing archives.
+    curl -fsSL --proto '=https' --tlsv1.2 \
+      --connect-timeout 10 --speed-limit 1024 --speed-time 30 \
+      --retry 3 --retry-delay 1 --retry-connrefused \
+      -o "$output" "$url"
     return
   fi
   wget -q --https-only --secure-protocol=TLSv1_2 --tries=3 --timeout=20 -O "$output" "$url"

--- a/scripts/install-cli.sh
+++ b/scripts/install-cli.sh
@@ -137,9 +137,9 @@ download_file() {
     detect_downloader
   fi
   if [[ "$DOWNLOADER" == "curl" ]]; then
-    # Match wget's stall protection without rejecting slow, progressing archives.
+    # Bound post-connect stalls without imposing a total download duration.
     curl -fsSL --proto '=https' --tlsv1.2 \
-      --connect-timeout 10 --speed-limit 1 --speed-time 30 \
+      --speed-limit 1 --speed-time 30 \
       --retry 3 --retry-delay 1 --retry-connrefused \
       -o "$output" "$url"
     return

--- a/scripts/install-cli.sh
+++ b/scripts/install-cli.sh
@@ -137,9 +137,9 @@ download_file() {
     detect_downloader
   fi
   if [[ "$DOWNLOADER" == "curl" ]]; then
-    # Match wget's stall protection without capping slow, progressing archives.
+    # Match wget's stall protection without rejecting slow, progressing archives.
     curl -fsSL --proto '=https' --tlsv1.2 \
-      --connect-timeout 10 --speed-limit 1024 --speed-time 30 \
+      --connect-timeout 10 --speed-limit 1 --speed-time 30 \
       --retry 3 --retry-delay 1 --retry-connrefused \
       -o "$output" "$url"
     return

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -114,7 +114,11 @@ download_file() {
         detect_downloader
     fi
     if [[ "$DOWNLOADER" == "curl" ]]; then
-        curl -fsSL --proto '=https' --tlsv1.2 --retry 3 --retry-delay 1 --retry-connrefused -o "$output" "$url"
+        # Match wget's stall protection without capping slow, progressing archives.
+        curl -fsSL --proto '=https' --tlsv1.2 \
+            --connect-timeout 10 --speed-limit 1024 --speed-time 30 \
+            --retry 3 --retry-delay 1 --retry-connrefused \
+            -o "$output" "$url"
         return
     fi
     wget -q --https-only --secure-protocol=TLSv1_2 --tries=3 --timeout=20 -O "$output" "$url"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -114,9 +114,9 @@ download_file() {
         detect_downloader
     fi
     if [[ "$DOWNLOADER" == "curl" ]]; then
-        # Match wget's stall protection without capping slow, progressing archives.
+        # Match wget's stall protection without rejecting slow, progressing archives.
         curl -fsSL --proto '=https' --tlsv1.2 \
-            --connect-timeout 10 --speed-limit 1024 --speed-time 30 \
+            --connect-timeout 10 --speed-limit 1 --speed-time 30 \
             --retry 3 --retry-delay 1 --retry-connrefused \
             -o "$output" "$url"
         return

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -114,9 +114,9 @@ download_file() {
         detect_downloader
     fi
     if [[ "$DOWNLOADER" == "curl" ]]; then
-        # Match wget's stall protection without rejecting slow, progressing archives.
+        # Bound post-connect stalls without imposing a total download duration.
         curl -fsSL --proto '=https' --tlsv1.2 \
-            --connect-timeout 10 --speed-limit 1 --speed-time 30 \
+            --speed-limit 1 --speed-time 30 \
             --retry 3 --retry-delay 1 --retry-connrefused \
             -o "$output" "$url"
         return

--- a/test/scripts/install-cli.test.ts
+++ b/test/scripts/install-cli.test.ts
@@ -41,6 +41,28 @@ function linkRequiredShellTools(bin: string) {
 describe("install-cli.sh", () => {
   const script = readFileSync(SCRIPT_PATH, "utf8");
 
+  it("bounds curl downloads and propagates timeout failures", () => {
+    const result = runInstallCliShell(`
+      set -euo pipefail
+      source "${SCRIPT_PATH}"
+      curl() {
+        printf 'curl=%s\n' "$*"
+        return 28
+      }
+      DOWNLOADER=curl
+      set +e
+      download_file "https://example.invalid/node.tar.gz" "/tmp/node.tar.gz"
+      printf 'status=%s\n' "$?"
+    `);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain(
+      "--connect-timeout 10 --speed-limit 1024 --speed-time 30",
+    );
+    expect(result.stdout).toContain("--retry 3 --retry-delay 1 --retry-connrefused");
+    expect(result.stdout).toContain("status=28");
+  });
+
   it("does not clean an unrelated legacy checkout during the default npm install", () => {
     const main = script.slice(script.indexOf("\nmain() {"));
     expect(main).not.toContain("cleanup_legacy_submodules");

--- a/test/scripts/install-cli.test.ts
+++ b/test/scripts/install-cli.test.ts
@@ -56,7 +56,7 @@ describe("install-cli.sh", () => {
     `);
 
     expect(result.status).toBe(0);
-    expect(result.stdout).toContain("--connect-timeout 10 --speed-limit 1024 --speed-time 30");
+    expect(result.stdout).toContain("--connect-timeout 10 --speed-limit 1 --speed-time 30");
     expect(result.stdout).toContain("--retry 3 --retry-delay 1 --retry-connrefused");
     expect(result.stdout).toContain("status=28");
   });

--- a/test/scripts/install-cli.test.ts
+++ b/test/scripts/install-cli.test.ts
@@ -41,7 +41,7 @@ function linkRequiredShellTools(bin: string) {
 describe("install-cli.sh", () => {
   const script = readFileSync(SCRIPT_PATH, "utf8");
 
-  it("bounds curl downloads and propagates timeout failures", () => {
+  it("bounds stalled curl downloads and propagates timeout failures", () => {
     const result = runInstallCliShell(`
       set -euo pipefail
       source "${SCRIPT_PATH}"
@@ -56,7 +56,8 @@ describe("install-cli.sh", () => {
     `);
 
     expect(result.status).toBe(0);
-    expect(result.stdout).toContain("--connect-timeout 10 --speed-limit 1 --speed-time 30");
+    expect(result.stdout).toContain("--speed-limit 1 --speed-time 30");
+    expect(result.stdout).not.toContain("--connect-timeout");
     expect(result.stdout).toContain("--retry 3 --retry-delay 1 --retry-connrefused");
     expect(result.stdout).toContain("status=28");
   });

--- a/test/scripts/install-cli.test.ts
+++ b/test/scripts/install-cli.test.ts
@@ -56,9 +56,7 @@ describe("install-cli.sh", () => {
     `);
 
     expect(result.status).toBe(0);
-    expect(result.stdout).toContain(
-      "--connect-timeout 10 --speed-limit 1024 --speed-time 30",
-    );
+    expect(result.stdout).toContain("--connect-timeout 10 --speed-limit 1024 --speed-time 30");
     expect(result.stdout).toContain("--retry 3 --retry-delay 1 --retry-connrefused");
     expect(result.stdout).toContain("status=28");
   });

--- a/test/scripts/install-sh.test.ts
+++ b/test/scripts/install-sh.test.ts
@@ -82,6 +82,28 @@ describe("install.sh", () => {
     }
   });
 
+  it("bounds curl downloads and propagates timeout failures", () => {
+    const result = runInstallShell(`
+      set -euo pipefail
+      source "${SCRIPT_PATH}"
+      curl() {
+        printf 'curl=%s\n' "$*"
+        return 28
+      }
+      DOWNLOADER=curl
+      set +e
+      download_file "https://example.invalid/archive.tgz" "/tmp/archive.tgz"
+      printf 'status=%s\n' "$?"
+    `);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain(
+      "--connect-timeout 10 --speed-limit 1024 --speed-time 30",
+    );
+    expect(result.stdout).toContain("--retry 3 --retry-delay 1 --retry-connrefused");
+    expect(result.stdout).toContain("status=28");
+  });
+
   it("runs apt-get through noninteractive wrappers", () => {
     expect(script).toContain("apt_get()");
     expect(script).toContain('DEBIAN_FRONTEND="${DEBIAN_FRONTEND:-noninteractive}"');

--- a/test/scripts/install-sh.test.ts
+++ b/test/scripts/install-sh.test.ts
@@ -82,7 +82,7 @@ describe("install.sh", () => {
     }
   });
 
-  it("bounds curl downloads and propagates timeout failures", () => {
+  it("bounds stalled curl downloads and propagates timeout failures", () => {
     const result = runInstallShell(`
       set -euo pipefail
       source "${SCRIPT_PATH}"
@@ -97,7 +97,8 @@ describe("install.sh", () => {
     `);
 
     expect(result.status).toBe(0);
-    expect(result.stdout).toContain("--connect-timeout 10 --speed-limit 1 --speed-time 30");
+    expect(result.stdout).toContain("--speed-limit 1 --speed-time 30");
+    expect(result.stdout).not.toContain("--connect-timeout");
     expect(result.stdout).toContain("--retry 3 --retry-delay 1 --retry-connrefused");
     expect(result.stdout).toContain("status=28");
   });

--- a/test/scripts/install-sh.test.ts
+++ b/test/scripts/install-sh.test.ts
@@ -97,9 +97,7 @@ describe("install.sh", () => {
     `);
 
     expect(result.status).toBe(0);
-    expect(result.stdout).toContain(
-      "--connect-timeout 10 --speed-limit 1024 --speed-time 30",
-    );
+    expect(result.stdout).toContain("--connect-timeout 10 --speed-limit 1024 --speed-time 30");
     expect(result.stdout).toContain("--retry 3 --retry-delay 1 --retry-connrefused");
     expect(result.stdout).toContain("status=28");
   });

--- a/test/scripts/install-sh.test.ts
+++ b/test/scripts/install-sh.test.ts
@@ -97,7 +97,7 @@ describe("install.sh", () => {
     `);
 
     expect(result.status).toBe(0);
-    expect(result.stdout).toContain("--connect-timeout 10 --speed-limit 1024 --speed-time 30");
+    expect(result.stdout).toContain("--connect-timeout 10 --speed-limit 1 --speed-time 30");
     expect(result.stdout).toContain("--retry 3 --retry-delay 1 --retry-connrefused");
     expect(result.stdout).toContain("status=28");
   });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running either shell installer could wait indefinitely when a curl download connected successfully but then stopped transferring data.

## Why This Change Was Made

Both shell installers now abort curl transfers that remain below 1 byte/s for 30 seconds. The change is intentionally limited to post-connect transfer stalls: it does not impose a fixed wall-clock cap or change DNS, TCP, or TLS connection tolerance.

## User Impact

Installer downloads now fail and surface curl's timeout status instead of hanging forever after a server stops sending data; slow downloads that continue making progress remain supported.

## Evidence

- Added shell-level coverage for both `install.sh` and `install-cli.sh` that captures the curl invocation, verifies `--speed-limit 1 --speed-time 30`, simulates curl exit 28, and verifies that status is propagated.
- Controlled real-curl proof used a local HTTP server and the production 1 byte/s threshold with a 2-second observation window (scaled down from 30 seconds):
  - A response that sent headers and then no body exited 28 with `Operation too slow. Less than 1 bytes/sec transferred the last 2 seconds`.
  - A deliberately slow response that sent 1 byte every 500 ms completed successfully in 4.02 seconds.
- Exact-head [fork CI run 29473899108](https://github.com/openclaw/openclaw/actions/runs/29473899108) passed at `3203ef19f37cdf71047a3547eace3f1e09ca869a` with 77 passing and no failed or pending checks.
- Focused [checks-node-compact-small-5 job](https://github.com/openclaw/openclaw/actions/runs/29473899108/job/87542736557) ran `test/scripts/install-sh.test.ts`: 81 tests passed in 2367 ms.
- Focused [checks-node-compact-small-4 job](https://github.com/openclaw/openclaw/actions/runs/29473899108/job/87542736525) ran `test/scripts/install-cli.test.ts`: 31 tests passed in 782 ms.
- Exact-head [Website Installer Sync run 29473899114](https://github.com/openclaw/openclaw/actions/runs/29473899114) passed its static, Linux Docker, macOS installer, and Windows installer jobs.
- `bash -n scripts/install.sh scripts/install-cli.sh` passes.
- `git diff --check upstream/main...HEAD` passes.
- Fresh full-branch Claude autoreview against `upstream/main@9f5609382b5464c9df2a6c81b1ee12d650367730` reports the patch correct with no accepted or actionable findings (confidence 0.88).
- Per repository policy, contributor repository code was not executed locally; exact-head repository proof comes from fork CI. The controlled curl probe exercised the documented command-line contract against a standalone local server without executing repository code.
- curl's documented contract states that `--speed-limit` and `--speed-time` abort a transfer that remains below the configured rate for the configured period.
