### PR TITLE
fix(ui): hide empty offline nodes from native session groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Control UI native session hosts:** group Codex and Claude Code sessions under their provider and host while hiding paired nodes with no available sessions, and collapse duplicate discovery warnings without masking actionable failures. (#108610)
 - **Tlon SSE connect cleanup:** disarm opening deadlines after failed HTTP responses and rejected stream opens so reconnect attempts cannot leave stale timers behind. (#104585) Thanks @hugenshen.
 - **LINE reply-token media kinds:** honor video and audio metadata on inbound replies, share the canonical media builder with proactive sends, and fail visibly instead of recording empty media-only deliveries. (#106515) Thanks @edenfunf.
 - **Mattermost websocket connection deadlines:** bound opening handshakes so stalled TCP peers cannot hang channel startup indefinitely and reconnect control resumes after timeout. (#105553) Thanks @hugenshen.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Control UI native session hosts:** group Codex and Claude Code sessions under their provider and host while hiding paired nodes with no available sessions, and collapse duplicate discovery warnings without masking actionable failures. (#108610)
 - **Tlon SSE connect cleanup:** disarm opening deadlines after failed HTTP responses and rejected stream opens so reconnect attempts cannot leave stale timers behind. (#104585) Thanks @hugenshen.
 - **LINE reply-token media kinds:** honor video and audio metadata on inbound replies, share the canonical media builder with proactive sends, and fail visibly instead of recording empty media-only deliveries. (#106515) Thanks @edenfunf.
 - **Mattermost websocket connection deadlines:** bound opening handshakes so stalled TCP peers cannot hang channel startup indefinitely and reconnect control resumes after timeout. (#105553) Thanks @hugenshen.

--- a/ui/src/components/app-sidebar-session-catalogs.ts
+++ b/ui/src/components/app-sidebar-session-catalogs.ts
@@ -127,6 +127,24 @@ function renderCatalogHeaderStatus(hasActiveRun: boolean, hasUnread: boolean) {
     : nothing;
 }
 
+function catalogErrorMessages(catalog: SessionCatalog): string[] {
+  const messages = new Set<string>();
+  const add = (error: SessionCatalog["error"]) => {
+    if (error) {
+      messages.add(`[${error.code}] ${error.message}`);
+    }
+  };
+  add(catalog.error);
+  for (const host of catalog.hosts) {
+    // A disconnected empty host is normal fleet state, not a provider failure.
+    // Cached rows still expose the host-level offline badge when the host is visible.
+    if (host.error?.code !== "NODE_OFFLINE") {
+      add(host.error);
+    }
+  }
+  return [...messages];
+}
+
 export function renderSessionCatalogGroups(params: SessionCatalogGroupsParams) {
   // Adopted rows reuse the live session row so activity, unread state, and
   // the session menu behave exactly like the regular list.
@@ -140,7 +158,10 @@ export function renderSessionCatalogGroups(params: SessionCatalogGroupsParams) {
     const sectionId = `catalog:${catalog.id}`;
     const collapsed = params.collapsedSections.has(sectionId);
     const hosts = catalog.hosts;
-    const rows = hosts.flatMap((host) => host.sessions.map((session) => ({ host, session })));
+    const visibleHosts = hosts.filter((host) => host.sessions.length > 0);
+    const rows = visibleHosts.flatMap((host) =>
+      host.sessions.map((session) => ({ host, session })),
+    );
     const liveRows = rows.flatMap(({ session }) => {
       const row = session.openClawSessionKey
         ? liveRowsByKey.get(session.openClawSessionKey)
@@ -152,12 +173,7 @@ export function renderSessionCatalogGroups(params: SessionCatalogGroupsParams) {
     const loadingMore = params.loadingMoreCatalogIds.has(catalog.id);
     const hasMore = hosts.some((host) => Boolean(host.nextCursor));
     const canCreateSession = catalog.capabilities.createSession !== undefined;
-    const errorMessages = [
-      ...(catalog.error ? [`[${catalog.error.code}] ${catalog.error.message}`] : []),
-      ...hosts.flatMap((host) =>
-        host.error ? [`[${host.error.code}] ${host.error.message}`] : [],
-      ),
-    ];
+    const errorMessages = catalogErrorMessages(catalog);
     const hasError = errorMessages.length > 0;
     // Keep provider failures distinguishable from successful empty results.
     // Hiding both states would silently mask unavailable session sources.
@@ -210,7 +226,9 @@ export function renderSessionCatalogGroups(params: SessionCatalogGroupsParams) {
         ${collapsed
           ? nothing
           : html`<div class="sidebar-recent-sessions__list">
-                ${hosts.map((host) => renderCatalogHostGroup(catalog, host, liveRowsByKey, params))}
+                ${visibleHosts.map((host) =>
+                  renderCatalogHostGroup(catalog, host, liveRowsByKey, params),
+                )}
               </div>
               ${hasMore
                 ? html`<button
@@ -235,9 +253,6 @@ function renderCatalogHostGroup(
   liveRowsByKey: ReadonlyMap<string, GatewaySessionRow>,
   params: SessionCatalogGroupsParams,
 ) {
-  if (host.sessions.length === 0 && !host.nextCursor && !host.error) {
-    return nothing;
-  }
   const errorHelp = host.error ? `[${host.error.code}] ${host.error.message}` : undefined;
   return html`
     <section class="sidebar-session-catalog-host" data-session-catalog-host=${host.hostId}>

--- a/ui/src/components/app-sidebar.test.ts
+++ b/ui/src/components/app-sidebar.test.ts
@@ -876,6 +876,15 @@ describe("AppSidebar session catalog pagination", () => {
             ],
           },
           {
+            hostId: "node:offline",
+            label: "Offline Node",
+            kind: "node",
+            connected: false,
+            nodeId: "offline",
+            sessions: [],
+            error: { code: "NODE_OFFLINE", message: "Paired node is offline" },
+          },
+          {
             hostId: "node:build",
             label: "Build Node",
             kind: "node",
@@ -911,6 +920,7 @@ describe("AppSidebar session catalog pagination", () => {
     expect(remote?.textContent).toContain("Build Node");
     expect(remote?.textContent).toContain("Remote review");
     expect(remote?.textContent).not.toContain("Local plan");
+    expect(section?.textContent).not.toContain("Offline Node");
   });
 
   it("shows a catalog-owned OpenClaw session only in its catalog section", async () => {
@@ -1127,10 +1137,9 @@ describe("AppSidebar session catalog pagination", () => {
     }
   });
 
-  it("shows catalog errors as warnings instead of empty counts", async () => {
+  it("shows actionable catalog errors once and hides empty offline hosts", async () => {
     vi.useFakeTimers();
     try {
-      const hostError = catalogErrorPage("Claude host unavailable", "claude").catalogs[0];
       const request = vi.fn().mockResolvedValue({
         catalogs: [
           {
@@ -1140,7 +1149,55 @@ describe("AppSidebar session catalog pagination", () => {
             hosts: [],
             error: { code: "unavailable", message: "Codex provider unavailable" },
           },
-          hostError,
+          {
+            id: "claude",
+            label: "Claude",
+            capabilities: {
+              continueSession: true,
+              archive: true,
+              createSession: { model: "anthropic/claude-opus-4-8" },
+            },
+            hosts: [
+              {
+                hostId: "node:offline-a",
+                label: "Offline A",
+                kind: "node",
+                connected: false,
+                sessions: [],
+                error: { code: "NODE_OFFLINE", message: "Paired node is offline" },
+              },
+              {
+                hostId: "node:offline-b",
+                label: "Offline B",
+                kind: "node",
+                connected: false,
+                sessions: [],
+                error: { code: "NODE_OFFLINE", message: "Paired node is offline" },
+              },
+              {
+                hostId: "node:registry",
+                label: "Paired nodes",
+                kind: "node",
+                connected: false,
+                sessions: [],
+                error: {
+                  code: "NODE_LIST_FAILED",
+                  message: "Paired nodes could not be listed",
+                },
+              },
+              {
+                hostId: "node:registry-duplicate",
+                label: "Paired nodes",
+                kind: "node",
+                connected: false,
+                sessions: [],
+                error: {
+                  code: "NODE_LIST_FAILED",
+                  message: "Paired nodes could not be listed",
+                },
+              },
+            ],
+          },
         ],
       });
       const gateway = createGatewayHarness({ request } as unknown as GatewayBrowserClient);
@@ -1173,7 +1230,12 @@ describe("AppSidebar session catalog pagination", () => {
       ).toContain("[unavailable] Codex provider unavailable");
       expect(
         claudeSection?.querySelector(".sidebar-session-group-toggle")?.getAttribute("aria-label"),
-      ).toContain("[unavailable] Claude host unavailable");
+      ).toContain("[NODE_LIST_FAILED] Paired nodes could not be listed");
+      const claudeTitle =
+        claudeSection?.querySelector(".sidebar-session-group-toggle")?.getAttribute("title") ?? "";
+      expect(claudeTitle).not.toContain("NODE_OFFLINE");
+      expect(claudeTitle.match(/NODE_LIST_FAILED/g)).toHaveLength(1);
+      expect(claudeSection?.querySelectorAll("[data-session-catalog-host]")).toHaveLength(0);
       expect(
         codexSection?.querySelector(".sidebar-session-group-toggle")?.getAttribute("title"),
       ).toContain("Settings > Automation > Plugins");

--- a/ui/src/e2e/codex-sessions.e2e.test.ts
+++ b/ui/src/e2e/codex-sessions.e2e.test.ts
@@ -88,6 +88,100 @@ suite("Codex native session catalog", () => {
     await page.close();
   });
 
+  it("groups sessions by host and hides empty offline nodes", async () => {
+    const page = await browser.newPage({ viewport: { height: 1100, width: 1440 } });
+    await installMockGateway(page, {
+      featureMethods: ["chat.metadata", "chat.startup", "sessions.catalog.list"],
+      methodResponses: {
+        "sessions.catalog.list": {
+          catalogs: [
+            {
+              id: "codex",
+              label: "Codex",
+              capabilities: { continueSession: true, archive: true },
+              hosts: [
+                {
+                  hostId: "gateway:local",
+                  label: "Local Codex",
+                  kind: "gateway",
+                  connected: true,
+                  sessions: [
+                    {
+                      threadId: "thread-local",
+                      name: "Local planning session",
+                      status: "idle",
+                      archived: false,
+                      canContinue: true,
+                      canArchive: true,
+                    },
+                  ],
+                },
+                {
+                  hostId: "node:offline-a",
+                  label: "Offline Workstation",
+                  kind: "node",
+                  connected: false,
+                  sessions: [],
+                  error: { code: "NODE_OFFLINE", message: "Paired node is offline" },
+                },
+                {
+                  hostId: "node:build",
+                  label: "Build Node",
+                  kind: "node",
+                  connected: true,
+                  sessions: [
+                    {
+                      threadId: "thread-remote",
+                      name: "Remote review session",
+                      status: "idle",
+                      archived: false,
+                      canContinue: true,
+                      canArchive: true,
+                    },
+                  ],
+                },
+                {
+                  hostId: "node:offline-b",
+                  label: "Offline Laptop",
+                  kind: "node",
+                  connected: false,
+                  sessions: [],
+                  error: { code: "NODE_OFFLINE", message: "Paired node is offline" },
+                },
+              ],
+            },
+          ],
+        },
+      },
+    });
+
+    try {
+      await page.goto(`${server.baseUrl}chat`);
+      const section = page.locator('[data-session-section="catalog:codex"]');
+      await section.waitFor({ state: "visible" });
+      await expect.poll(() => section.locator("[data-session-catalog-host]").count()).toBe(2);
+      expect(await section.locator('[data-session-catalog-host="gateway:local"]').count()).toBe(1);
+      expect(await section.locator('[data-session-catalog-host="node:build"]').count()).toBe(1);
+      expect(await section.getByText("Offline Workstation", { exact: true }).count()).toBe(0);
+      expect(await section.getByText("Offline Laptop", { exact: true }).count()).toBe(0);
+      const toggle = section.locator(".sidebar-session-group-toggle");
+      expect(await toggle.getAttribute("title")).toBeNull();
+      await expect
+        .poll(() => section.locator(".sidebar-session-group-count").textContent())
+        .toBe("2");
+
+      if (captureUiProofEnabled) {
+        await mkdir(uiProofArtifactDir, { recursive: true });
+        await section.screenshot({
+          animations: "disabled",
+          path: path.join(uiProofArtifactDir, "03-content-bearing-session-hosts.png"),
+        });
+      }
+    } finally {
+      await page.close();
+    }
+  });
+
   it("explains node-list failures and exposes independent discovery settings", async () => {
     const page = await browser.newPage({ viewport: { height: 1100, width: 1440 } });
     await installMockGateway(page, {
@@ -205,6 +299,7 @@ suite("Codex native session catalog", () => {
       await expect
         .poll(() => warning.getAttribute("title"))
         .toContain("Settings > Automation > Plugins");
+      expect(await page.locator('[data-session-catalog-host="node:registry"]').count()).toBe(0);
 
       if (captureUiProofEnabled) {
         await mkdir(uiProofArtifactDir, { recursive: true });


### PR DESCRIPTION
Closes #108610

AI-assisted: Codex implementation, focused tests, source-blind behavior validation, and autoreview.

## What Problem This Solves

Fixes an issue where users with several paired nodes saw empty node headings and long repeated `NODE_OFFLINE` warnings in the Control UI native Codex and Claude Code session groups whenever routine fleet nodes were offline.

## Why This Change Was Made

Keeps the provider-first hierarchy, then renders host subgroups only when that host has sessions. Routine empty offline nodes no longer turn the whole provider into a warning, duplicate discovery failures collapse to one message, and actionable provider or node-list failures remain visible. Pagination and create-session entry points remain reachable for empty catalogs.

## User Impact

Codex and Claude Code groups now show only useful session-bearing hosts. Multi-node installations no longer fill the sidebar or warning tooltip with empty offline nodes, while real discovery failures still surface with setup guidance.

## Evidence

Sanitized before/after screenshots will be attached below.

- `node scripts/run-vitest.mjs ui/src/components/app-sidebar.test.ts` — 78 passed on Linux Node 24 Testbox
- `OPENCLAW_CAPTURE_UI_PROOF=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/codex-sessions.e2e.test.ts` — 5 passed
- `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 CI=1 corepack pnpm check:changed` — formatting, i18n, typecheck, lint, and repository guards passed
- `autoreview --mode uncommitted` — clean, no accepted/actionable findings
