### PR TITLE
fix(ci): stop stalled performance health probes from hanging

### DIFF
--- a/.github/workflows/openclaw-performance.yml
+++ b/.github/workflows/openclaw-performance.yml
@@ -745,8 +745,22 @@ jobs:
             >"$gateway_log" 2>&1 &
           gateway_pid="$!"
 
-          for _ in $(seq 1 120); do
-            if curl -fsS "http://127.0.0.1:${gateway_port}/healthz" >/dev/null; then
+          gateway_ready_timeout_seconds=120
+          gateway_probe_timeout_seconds=5
+          gateway_ready_deadline=$((SECONDS + gateway_ready_timeout_seconds))
+          while true; do
+            gateway_ready_remaining=$((gateway_ready_deadline - SECONDS))
+            if (( gateway_ready_remaining <= 0 )); then
+              cat "$gateway_log" >&2
+              echo "Timed out after ${gateway_ready_timeout_seconds}s waiting for gateway health." >&2
+              exit 1
+            fi
+            # Clamp each probe to the remaining startup budget so a stalled response cannot multiply the wait.
+            gateway_probe_timeout="$gateway_ready_remaining"
+            if (( gateway_probe_timeout > gateway_probe_timeout_seconds )); then
+              gateway_probe_timeout="$gateway_probe_timeout_seconds"
+            fi
+            if curl -fsS --connect-timeout 2 --max-time "$gateway_probe_timeout" "http://127.0.0.1:${gateway_port}/healthz" >/dev/null; then
               break
             fi
             if ! kill -0 "$gateway_pid" 2>/dev/null; then
@@ -755,7 +769,6 @@ jobs:
             fi
             sleep 1
           done
-          curl -fsS "http://127.0.0.1:${gateway_port}/healthz" >/dev/null
 
           OPENCLAW_HOME="$gateway_home" OPENCLAW_STATE_DIR="$gateway_state" OPENCLAW_CONFIG_PATH="$gateway_config" OPENCLAW_GATEWAY_PORT="$gateway_port" \
             node --import tsx scripts/bench-cli-startup.ts \

--- a/test/scripts/openclaw-performance-workflow.test.ts
+++ b/test/scripts/openclaw-performance-workflow.test.ts
@@ -191,6 +191,40 @@ describe("OpenClaw performance workflow", () => {
     expect(run.indexOf("pnpm build")).toBeLessThan(run.indexOf("pnpm test:gateway:cpu-scenarios"));
   });
 
+  it("keeps source gateway health waits within one startup budget", () => {
+    const run = findStep("Run OpenClaw source performance probes", "source_performance").run ?? "";
+    const deadline = "gateway_ready_deadline=$((SECONDS + gateway_ready_timeout_seconds))";
+    const remaining = "gateway_ready_remaining=$((gateway_ready_deadline - SECONDS))";
+    const deadlineFailure = [
+      "  if (( gateway_ready_remaining <= 0 )); then",
+      '    cat "$gateway_log" >&2',
+      '    echo "Timed out after ${gateway_ready_timeout_seconds}s waiting for gateway health." >&2',
+      "    exit 1",
+      "  fi",
+    ].join("\n");
+    const probeCap = [
+      '  gateway_probe_timeout="$gateway_ready_remaining"',
+      "  if (( gateway_probe_timeout > gateway_probe_timeout_seconds )); then",
+      '    gateway_probe_timeout="$gateway_probe_timeout_seconds"',
+      "  fi",
+    ].join("\n");
+    const boundedProbe =
+      'curl -fsS --connect-timeout 2 --max-time "$gateway_probe_timeout" "http://127.0.0.1:${gateway_port}/healthz"';
+
+    expect(run).toContain("gateway_ready_timeout_seconds=120");
+    expect(run).toContain("gateway_probe_timeout_seconds=5");
+    expect(run).toContain(deadline);
+    expect(run).toContain(remaining);
+    expect(run).toContain(deadlineFailure);
+    expect(run).toContain(probeCap);
+    expect(run).toContain(boundedProbe);
+    expect(run.split("/healthz")).toHaveLength(2);
+    expect(run.indexOf(deadline)).toBeLessThan(run.indexOf(remaining));
+    expect(run.indexOf(remaining)).toBeLessThan(run.indexOf(deadlineFailure));
+    expect(run.indexOf(deadlineFailure)).toBeLessThan(run.indexOf(probeCap));
+    expect(run.indexOf(probeCap)).toBeLessThan(run.indexOf(boundedProbe));
+  });
+
   it("isolates required publication in a fresh artifact-consuming job", () => {
     const workflow = readWorkflow();
     const publisher = workflow.jobs?.publish;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the source performance workflow could hang on a gateway health request even though its readiness loop appeared to allow only 120 attempts.

## Why This Change Was Made

Gateway readiness now uses one 120-second wall-clock deadline. Each health request has a two-second connection timeout and a five-second request cap that is clamped to the remaining startup budget; the redundant unbounded health request after the loop is removed.

## User Impact

Performance runs now fail within a predictable startup window and print the gateway log when a health endpoint stalls, instead of consuming runner time indefinitely.

## Evidence

- Added focused workflow coverage for the deadline calculation, remaining-budget guard, per-probe clamp, bounded curl invocation, diagnostic failure path, ordering, and the single health endpoint occurrence.
- Exact-head [fork CI run 29472090124](https://github.com/openclaw/openclaw/actions/runs/29472090124) passed at `76d7430ddda71f9fad5f094705dd0b1e1b43dc11`.
- Focused [checks-node-compact-small-5 job](https://github.com/openclaw/openclaw/actions/runs/29472090124/job/87537156299) ran `test/scripts/openclaw-performance-workflow.test.ts` successfully: 30 tests in 685 ms.
- The workflow parses as YAML and its embedded Bash passes `bash -n`.
- `git diff --check upstream/main...HEAD` passes.
- Fresh Claude autoreview caught one test-indentation issue; it was fixed, and the subsequent fresh review reports no accepted or actionable findings.
- Per repository policy, contributor code was not executed locally; the proof above comes from exact-head fork CI.
- curl documents `--connect-timeout` as bounding connection setup and `--max-time` as bounding the whole transfer.
