### PR TITLE
docs(lobster): enumerate injected workflow env vars and clarify step-output access

### DIFF
--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -9855,6 +9855,7 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
   - H2: JSON-only LLM steps (llm-task)
   - H3: Important limitation: embedded Lobster vs openclaw.invoke
   - H2: Workflow files (.lobster)
+  - H3: Injected environment variables
   - H2: Tool parameters
   - H3: run
   - H3: resume

--- a/docs/tools/lobster.md
+++ b/docs/tools/lobster.md
@@ -261,12 +261,12 @@ raw values into the command string:
 - `LOBSTER_ARGS_JSON` - every resolved arg as a single JSON string.
 
 That is the complete injected set. There are **no** per-step output variables
-such as `LOBSTER_STEP_<id>_STDOUT` or `LOBSTER_STEP_<id>_JSON_<field>`; those
-names do not exist and a shell reading them silently falls through to your
-default, misrouting logic. Read a prior step's output through the step-ref
-templates instead - `$step.stdout`, `$step.json`, or `$step.json.<field>` - in a
-`stdin:`, `env:`, or `condition:` value. (`LOBSTER_STATE_DIR` is a separate
-runtime setting for the state directory, not a per-run arg.)
+such as `LOBSTER_STEP_<id>_STDOUT` or `LOBSTER_STEP_<id>_JSON_<field>`; shells
+treat those names as unset, so parameter-expansion defaults can hide the error.
+Read a prior step's output through step references instead - `$step.stdout`,
+`$step.json`, or `$step.json.<field>` - in a `stdin:`, `env:`, or `condition:`
+value. (`LOBSTER_STATE_DIR` is a separate runtime setting for the state
+directory, not a per-run arg.)
 
 ## Tool parameters
 

--- a/docs/tools/lobster.md
+++ b/docs/tools/lobster.md
@@ -249,6 +249,25 @@ Notes:
 - `stdin: $step.stdout` and `stdin: $step.json` pass a prior step's output.
 - `condition` (or `when`) can gate steps on `$step.approved`.
 
+### Injected environment variables
+
+Every step shell inherits the parent environment plus these Lobster-injected
+variables, so commands can reference resolved workflow args without embedding
+raw values into the command string:
+
+- `LOBSTER_ARG_<NAME>` - one per workflow arg. The name is uppercased with each
+  run of non-alphanumeric characters collapsed to `_`, so arg `user-id` becomes
+  `LOBSTER_ARG_USER_ID`.
+- `LOBSTER_ARGS_JSON` - every resolved arg as a single JSON string.
+
+That is the complete injected set. There are **no** per-step output variables
+such as `LOBSTER_STEP_<id>_STDOUT` or `LOBSTER_STEP_<id>_JSON_<field>`; those
+names do not exist and a shell reading them silently falls through to your
+default, misrouting logic. Read a prior step's output through the step-ref
+templates instead - `$step.stdout`, `$step.json`, or `$step.json.<field>` - in a
+`stdin:`, `env:`, or `condition:` value. (`LOBSTER_STATE_DIR` is a separate
+runtime setting for the state directory, not a per-run arg.)
+
 ## Tool parameters
 
 ### `run`


### PR DESCRIPTION
## What Problem This Solves

`docs/tools/lobster.md` documents step references but did not enumerate the environment variables Lobster injects into workflow step shells. Authors could infer unsupported names such as `LOBSTER_STEP_<id>_STDOUT`, which remain unset and can make shell defaults hide a workflow mistake.

Fixes #82281.

## Why This Change Was Made

This adds the injected workflow-argument variables to the existing Lobster workflow-file reference and points prior-step output access to the supported step-reference syntax. It also regenerates `docs/docs_map.md` for the new heading.

## User Impact

Workflow authors now have the complete injected argument-variable set and explicit guidance for accessing prior-step output. Runtime behavior is unchanged.

## Evidence

Verified against the dependency pinned by current main, `@clawdbot/lobster@2026.6.11`, and its exact `v2026.6.11` source tag (`86b8cc20a867f18c08ae8e3f4fec9ee7d52bf8c9`):

- `mergeEnv` injects `LOBSTER_ARGS_JSON` plus `LOBSTER_ARG_<NAME>` for each resolved argument.
- `normalizeArgEnvKey` trims, uppercases, converts runs outside `[A-Z0-9]` to `_`, and trims surrounding underscores.
- `resolveInputValue`, `resolveTemplate`, `resolveStepRefs`, and the condition parser support `$step.stdout`, `$step.json`, and nested paths such as `$step.json.field` in `stdin:`, `env:`, and conditions.
- No `LOBSTER_STEP_*` output-variable namespace exists.

OpenClaw's embedded runner passes its inherited environment to Lobster; it does not add per-step output variables.

Validation:

- `git diff --check`
- `node scripts/generate-docs-map.mjs --check`
- `node scripts/check-docs-mdx.mjs docs/tools/lobster.md`

`CHANGELOG.md` untouched per maintainer policy.
