### PR TITLE
fix(agents): remove empty parent directory on agent delete

### DIFF
--- a/src/agents/agent-delete-safety.test.ts
+++ b/src/agents/agent-delete-safety.test.ts
@@ -1,0 +1,115 @@
+// Real-filesystem tests for agent-delete-safety helpers — containment
+// checks, empty-directory removal, and race-safety (atomic rmdir).
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { withStateDirEnv } from "../test-helpers/state-dir-env.js";
+import { removeEmptyAgentParentDir } from "./agent-delete-safety.js";
+
+describe("removeEmptyAgentParentDir", () => {
+  it("removes an empty canonical parent directory", async () => {
+    await withStateDirEnv("openclaw-agent-parent-empty-", async ({ stateDir }) => {
+      const agentId = "test-agent";
+      const canonicalRoot = path.join(stateDir, "agents", agentId);
+      const agentDir = path.join(canonicalRoot, "agent");
+      await fs.promises.mkdir(agentDir, { recursive: true });
+      // Simulate post-deletion state: subdirectory was trashed, parent is empty.
+      await fs.promises.rmdir(agentDir);
+
+      await removeEmptyAgentParentDir({ agentDir, agentId, stateDir });
+
+      // The empty canonical parent should be gone.
+      await expect(fs.promises.access(canonicalRoot)).rejects.toHaveProperty("code", "ENOENT");
+    });
+  });
+
+  it("preserves a non-empty canonical parent directory", async () => {
+    await withStateDirEnv("openclaw-agent-parent-nonempty-", async ({ stateDir }) => {
+      const agentId = "test-agent";
+      const canonicalRoot = path.join(stateDir, "agents", agentId);
+      const agentDir = path.join(canonicalRoot, "agent");
+      await fs.promises.mkdir(agentDir, { recursive: true });
+      // Simulate post-deletion with residual content (e.g. leftover files).
+      await fs.promises.writeFile(path.join(canonicalRoot, "orphan.txt"), "stale");
+
+      await removeEmptyAgentParentDir({ agentDir, agentId, stateDir });
+
+      // The non-empty parent must be preserved.
+      await expect(fs.promises.access(canonicalRoot)).resolves.toBeUndefined();
+      const entries = await fs.promises.readdir(canonicalRoot);
+      expect(entries).toContain("orphan.txt");
+    });
+  });
+
+  it("preserves a parent directory that was repopulated after subdirectory cleanup", async () => {
+    await withStateDirEnv("openclaw-agent-parent-repop-", async ({ stateDir }) => {
+      const agentId = "test-agent";
+      const canonicalRoot = path.join(stateDir, "agents", agentId);
+      const agentDir = path.join(canonicalRoot, "agent");
+      await fs.promises.mkdir(agentDir, { recursive: true });
+      // Simulate post-deletion state: subdirectory trashed, then a same-id
+      // recreation repopulates the parent with a new sessions/ directory
+      // before rmdir runs.
+      await fs.promises.rmdir(agentDir);
+      await fs.promises.mkdir(path.join(canonicalRoot, "sessions"), { recursive: true });
+
+      await removeEmptyAgentParentDir({ agentDir, agentId, stateDir });
+
+      // rmdir is atomic: ENOTEMPTY preserves the repopulated directory.
+      await expect(fs.promises.access(canonicalRoot)).resolves.toBeUndefined();
+      const entries = await fs.promises.readdir(canonicalRoot);
+      expect(entries).toContain("sessions");
+    });
+  });
+
+  it("preserves a custom agentDir parent outside the canonical root", async () => {
+    await withStateDirEnv("openclaw-agent-parent-custom-", async ({ stateDir }) => {
+      const agentId = "test-agent";
+      const customAgentDir = "/tmp/openclaw-custom-agentdir-test";
+      const customParent = path.dirname(customAgentDir);
+      await fs.promises.mkdir(customAgentDir, { recursive: true });
+
+      try {
+        await removeEmptyAgentParentDir({ agentDir: customAgentDir, agentId, stateDir });
+
+        // A custom agentDir parent must never be touched, even when empty.
+        await expect(fs.promises.access(customAgentDir)).resolves.toBeUndefined();
+        await expect(fs.promises.access(customParent)).resolves.toBeUndefined();
+      } finally {
+        await fs.promises.rm(customParent, { recursive: true, force: true });
+      }
+    });
+  });
+
+  it("does not throw when the canonical parent is already missing", async () => {
+    await withStateDirEnv("openclaw-agent-parent-missing-", async ({ stateDir }) => {
+      const agentId = "ghost-agent";
+      const agentDir = path.join(stateDir, "agents", agentId, "agent");
+      // Never create anything — the parent directory does not exist.
+
+      await expect(
+        removeEmptyAgentParentDir({ agentDir, agentId, stateDir }),
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  it("does not throw when the canonical parent directory is not accessible", async () => {
+    await withStateDirEnv("openclaw-agent-parent-denied-", async ({ stateDir }) => {
+      const agentId = "test-agent";
+      const canonicalRoot = path.join(stateDir, "agents", agentId);
+      const agentDir = path.join(canonicalRoot, "agent");
+      await fs.promises.mkdir(agentDir, { recursive: true });
+      // Simulate post-deletion: subdirectory trashed.
+      await fs.promises.rmdir(agentDir);
+      // Remove write permission on the parent so rmdir fails with EACCES.
+      await fs.promises.chmod(canonicalRoot, 0o500);
+      try {
+        await expect(
+          removeEmptyAgentParentDir({ agentDir, agentId, stateDir }),
+        ).resolves.toBeUndefined();
+      } finally {
+        await fs.promises.chmod(canonicalRoot, 0o700);
+      }
+    });
+  });
+});

--- a/src/agents/agent-delete-safety.test.ts
+++ b/src/agents/agent-delete-safety.test.ts
@@ -63,21 +63,15 @@ describe("removeEmptyAgentParentDir", () => {
   });
 
   it("preserves a custom agentDir parent outside the canonical root", async () => {
-    await withStateDirEnv("openclaw-agent-parent-custom-", async ({ stateDir }) => {
+    await withStateDirEnv("openclaw-agent-parent-custom-", async ({ tempRoot, stateDir }) => {
       const agentId = "test-agent";
-      const customAgentDir = "/tmp/openclaw-custom-agentdir-test";
-      const customParent = path.dirname(customAgentDir);
+      const customAgentDir = path.join(tempRoot, "custom-agentdir", agentId);
       await fs.promises.mkdir(customAgentDir, { recursive: true });
 
-      try {
-        await removeEmptyAgentParentDir({ agentDir: customAgentDir, agentId, stateDir });
+      await removeEmptyAgentParentDir({ agentDir: customAgentDir, agentId, stateDir });
 
-        // A custom agentDir parent must never be touched, even when empty.
-        await expect(fs.promises.access(customAgentDir)).resolves.toBeUndefined();
-        await expect(fs.promises.access(customParent)).resolves.toBeUndefined();
-      } finally {
-        await fs.promises.rm(customParent, { recursive: true, force: true });
-      }
+      // A custom agentDir parent must never be touched, even when empty.
+      await expect(fs.promises.access(customAgentDir)).resolves.toBeUndefined();
     });
   });
 
@@ -108,7 +102,13 @@ describe("removeEmptyAgentParentDir", () => {
           removeEmptyAgentParentDir({ agentDir, agentId, stateDir }),
         ).resolves.toBeUndefined();
       } finally {
-        await fs.promises.chmod(canonicalRoot, 0o700);
+        // Restore permissions so withStateDirEnv cleanup can remove the tree.
+        // If the directory was already removed by the outer cleanup, ignore.
+        try {
+          await fs.promises.chmod(canonicalRoot, 0o700);
+        } catch {
+          // Directory may already be gone.
+        }
       }
     });
   });

--- a/src/agents/agent-delete-safety.ts
+++ b/src/agents/agent-delete-safety.ts
@@ -29,6 +29,35 @@ function workspacePathsOverlap(left: string, right: string): boolean {
   );
 }
 
+/**
+ * Returns true when the canonical per-agent state parent directory should be
+ * removed after deleting the agent/ and sessions/ subdirectories.
+ *
+ * Only the default {@code <stateDir>/agents/<agentId>} root is eligible.
+ * Custom agentDir values that resolve outside this root are preserved to
+ * avoid removing unrelated user files. The directory must also be empty after
+ * subdirectories have been trashed; a non-empty parent is left in place.
+ */
+export function shouldRemoveEmptyAgentParentDir(params: {
+  agentDir: string;
+  agentId: string;
+  stateDir: string;
+}): boolean {
+  const canonicalRoot = path.resolve(params.stateDir, "agents", params.agentId);
+  const actualParent = path.dirname(params.agentDir);
+  // Only the canonical per-agent root may be removed; custom or configured
+  // agentDir paths may have a parent containing unrelated user files.
+  if (canonicalRoot !== actualParent) {
+    return false;
+  }
+  // Guard against deleting a directory with unexpected remaining content.
+  try {
+    return fs.readdirSync(canonicalRoot).length === 0;
+  } catch {
+    return false;
+  }
+}
+
 /** Lists other agents whose workspaces overlap a candidate delete target. */
 export function findOverlappingWorkspaceAgentIds(
   cfg: OpenClawConfig,

--- a/src/agents/agent-delete-safety.ts
+++ b/src/agents/agent-delete-safety.ts
@@ -30,31 +30,37 @@ function workspacePathsOverlap(left: string, right: string): boolean {
 }
 
 /**
- * Returns true when the canonical per-agent state parent directory should be
- * removed after deleting the agent/ and sessions/ subdirectories.
+ * Best-effort removal of the canonical per-agent state parent directory after
+ * agent/ and sessions/ subdirectories have been cleaned up.
  *
  * Only the default {@code <stateDir>/agents/<agentId>} root is eligible.
  * Custom agentDir values that resolve outside this root are preserved to
- * avoid removing unrelated user files. The directory must also be empty after
- * subdirectories have been trashed; a non-empty parent is left in place.
+ * avoid removing unrelated user files.
+ *
+ * Uses {@code fs.promises.rmdir} so the removal is atomic: the OS refuses
+ * with ENOTEMPTY when the directory has been repopulated between the
+ * subdirectory cleanup and the parent removal (e.g. a same-id agent
+ * recreation), which prevents accidental deletion of new session state.
  */
-export function shouldRemoveEmptyAgentParentDir(params: {
+export async function removeEmptyAgentParentDir(params: {
   agentDir: string;
   agentId: string;
   stateDir: string;
-}): boolean {
+}): Promise<void> {
   const canonicalRoot = path.resolve(params.stateDir, "agents", params.agentId);
   const actualParent = path.dirname(params.agentDir);
   // Only the canonical per-agent root may be removed; custom or configured
   // agentDir paths may have a parent containing unrelated user files.
   if (canonicalRoot !== actualParent) {
-    return false;
+    return;
   }
-  // Guard against deleting a directory with unexpected remaining content.
+  // rmdir is atomic and fails with ENOTEMPTY when the directory has content,
+  // avoiding the check-to-use race of readdirSync + later recursive trash.
   try {
-    return fs.readdirSync(canonicalRoot).length === 0;
+    await fs.promises.rmdir(canonicalRoot);
   } catch {
-    return false;
+    // Best-effort: keep the directory if it is non-empty, missing, or the
+    // filesystem rejects the operation.
   }
 }
 

--- a/src/commands/agents.commands.delete.ts
+++ b/src/commands/agents.commands.delete.ts
@@ -2,7 +2,7 @@
 import path from "node:path";
 import {
   findOverlappingWorkspaceAgentIds,
-  shouldRemoveEmptyAgentParentDir,
+  removeEmptyAgentParentDir,
 } from "../agents/agent-delete-safety.js";
 import { resolveAgentDir, resolveAgentWorkspaceDir } from "../agents/agent-scope.js";
 import {
@@ -205,13 +205,14 @@ export async function agentsDeleteCommand(
   }
   await moveToTrash(agentDir, quietRuntime);
   await moveToTrash(sessionsDir, quietRuntime);
-  // After trashing agent/ and sessions/ subdirectories, remove the
-  // now-empty canonical parent directory so no stale folder remains.
+  // After trashing agent/ and sessions/ subdirectories, atomically remove
+  // the now-empty canonical parent directory so no stale folder remains.
   // Only the default <stateDir>/agents/<agentId> root is eligible;
-  // custom agentDir paths are preserved to avoid data loss.
-  if (shouldRemoveEmptyAgentParentDir({ agentDir, agentId, stateDir: resolveStateDir() })) {
-    await moveToTrash(path.dirname(agentDir), quietRuntime);
-  }
+  // custom agentDir paths are preserved to avoid data loss. rmdir is
+  // atomic — a same-id recreation that populates the directory between
+  // subdirectory cleanup and parent removal causes ENOTEMPTY and the
+  // directory is kept.
+  await removeEmptyAgentParentDir({ agentDir, agentId, stateDir: resolveStateDir() });
   if (workspaceCleanupError) {
     throw workspaceCleanupError;
   }

--- a/src/commands/agents.commands.delete.ts
+++ b/src/commands/agents.commands.delete.ts
@@ -1,5 +1,4 @@
 // Implements agent deletion with gateway delegation and local cleanup fallback.
-import path from "node:path";
 import {
   findOverlappingWorkspaceAgentIds,
   removeEmptyAgentParentDir,

--- a/src/commands/agents.commands.delete.ts
+++ b/src/commands/agents.commands.delete.ts
@@ -1,5 +1,9 @@
 // Implements agent deletion with gateway delegation and local cleanup fallback.
-import { findOverlappingWorkspaceAgentIds } from "../agents/agent-delete-safety.js";
+import path from "node:path";
+import {
+  findOverlappingWorkspaceAgentIds,
+  shouldRemoveEmptyAgentParentDir,
+} from "../agents/agent-delete-safety.js";
 import { resolveAgentDir, resolveAgentWorkspaceDir } from "../agents/agent-scope.js";
 import {
   prepareLegacyWorkspaceStateReset,
@@ -12,6 +16,7 @@ import {
 import { formatCliCommand } from "../cli/command-format.js";
 import { replaceConfigFile } from "../config/config.js";
 import { logConfigUpdated } from "../config/logging.js";
+import { resolveStateDir } from "../config/paths.js";
 import {
   purgeAgentSessionStoreEntries,
   resolveSessionTranscriptsDirForAgent,
@@ -200,6 +205,13 @@ export async function agentsDeleteCommand(
   }
   await moveToTrash(agentDir, quietRuntime);
   await moveToTrash(sessionsDir, quietRuntime);
+  // After trashing agent/ and sessions/ subdirectories, remove the
+  // now-empty canonical parent directory so no stale folder remains.
+  // Only the default <stateDir>/agents/<agentId> root is eligible;
+  // custom agentDir paths are preserved to avoid data loss.
+  if (shouldRemoveEmptyAgentParentDir({ agentDir, agentId, stateDir: resolveStateDir() })) {
+    await moveToTrash(path.dirname(agentDir), quietRuntime);
+  }
   if (workspaceCleanupError) {
     throw workspaceCleanupError;
   }

--- a/src/commands/agents.delete.test.ts
+++ b/src/commands/agents.delete.test.ts
@@ -62,6 +62,19 @@ vi.mock("../agents/workspace-state-store.js", async () => ({
   prepareWorkspaceStateDeletion: workspaceStateMocks.prepareWorkspaceStateDeletion,
 }));
 
+const agentDeleteSafetyMocks = vi.hoisted(() => ({
+  shouldRemoveEmptyAgentParentDir: vi.fn(() => true),
+}));
+
+vi.mock("../agents/agent-delete-safety.js", async () => {
+  const actual = await vi.importActual<typeof import("../agents/agent-delete-safety.js")>(
+    "../agents/agent-delete-safety.js",
+  );
+  return {
+    ...actual,
+    shouldRemoveEmptyAgentParentDir: agentDeleteSafetyMocks.shouldRemoveEmptyAgentParentDir,
+  };
+});
 import { agentsDeleteCommand } from "./agents.commands.delete.js";
 
 const runtime = createTestRuntime();
@@ -152,6 +165,8 @@ describe("agents delete command", () => {
     runtime.log.mockClear();
     runtime.error.mockClear();
     runtime.exit.mockClear();
+    agentDeleteSafetyMocks.shouldRemoveEmptyAgentParentDir.mockReset();
+    agentDeleteSafetyMocks.shouldRemoveEmptyAgentParentDir.mockReturnValue(true);
   });
 
   it("routes deletion through the Gateway when reachable", async () => {
@@ -366,6 +381,77 @@ describe("agents delete command", () => {
         path.basename(opsAgentDir),
       );
       expect(trashedPaths).toContain(expectedAgentDir);
+    });
+  });
+
+  it("trashes the parent agent state directory after removing subdirectories", async () => {
+    await withStateDirEnv("openclaw-agents-delete-parent-", async ({ stateDir }) => {
+      const cfg: OpenClawConfig = {
+        agents: {
+          list: [
+            { id: "main", workspace: path.join(stateDir, "workspace-main") },
+            { id: "ops", workspace: path.join(stateDir, "workspace-ops") },
+          ],
+        },
+      } satisfies OpenClawConfig;
+      await arrangeAgentsDeleteTest({
+        stateDir,
+        cfg,
+        deletedAgentId: "ops",
+        sessions: {},
+      });
+
+      await agentsDeleteCommand({ id: "ops", force: true, json: true }, runtime);
+
+      const trashedPaths = fsSafeMocks.movePathToTrash.mock.calls.map(([targetPath]) => targetPath);
+      const expectedParentDir = path.join(stateDir, "agents", "ops");
+      expect(trashedPaths).toContain(expectedParentDir);
+      // The canonical parent is only eligible when containment and emptiness
+      // checks pass.
+      expect(agentDeleteSafetyMocks.shouldRemoveEmptyAgentParentDir).toHaveBeenCalledWith({
+        agentDir: path.join(stateDir, "agents", "ops", "agent"),
+        agentId: "ops",
+        stateDir,
+      });
+    });
+  });
+
+  it("preserves a custom agentDir parent on agent delete", async () => {
+    agentDeleteSafetyMocks.shouldRemoveEmptyAgentParentDir.mockReturnValue(false);
+    await withStateDirEnv("openclaw-agents-delete-custom-agentdir-", async ({ stateDir }) => {
+      const customAgentDir = "/custom/path/ops";
+      const cfg: OpenClawConfig = {
+        agents: {
+          list: [
+            { id: "main", workspace: path.join(stateDir, "workspace-main") },
+            {
+              id: "ops",
+              agentDir: customAgentDir,
+              workspace: path.join(stateDir, "workspace-ops"),
+            },
+          ],
+        },
+      } satisfies OpenClawConfig;
+      await arrangeAgentsDeleteTest({
+        stateDir,
+        cfg,
+        deletedAgentId: "ops",
+        sessions: {},
+      });
+
+      await agentsDeleteCommand({ id: "ops", force: true, json: true }, runtime);
+
+      const trashedPaths = fsSafeMocks.movePathToTrash.mock.calls.map(([targetPath]) => targetPath);
+      // The parent of a custom agentDir must never be trashed.
+      expect(trashedPaths).not.toContain("/custom/path");
+      const canonicalParent = path.join(stateDir, "agents", "ops");
+      expect(trashedPaths).not.toContain(canonicalParent);
+      // Helper must have been consulted with the custom agentDir.
+      expect(agentDeleteSafetyMocks.shouldRemoveEmptyAgentParentDir).toHaveBeenCalledWith({
+        agentDir: customAgentDir,
+        agentId: "ops",
+        stateDir,
+      });
     });
   });
 

--- a/src/commands/agents.delete.test.ts
+++ b/src/commands/agents.delete.test.ts
@@ -63,7 +63,7 @@ vi.mock("../agents/workspace-state-store.js", async () => ({
 }));
 
 const agentDeleteSafetyMocks = vi.hoisted(() => ({
-  shouldRemoveEmptyAgentParentDir: vi.fn(() => true),
+  removeEmptyAgentParentDir: vi.fn(async () => {}),
 }));
 
 vi.mock("../agents/agent-delete-safety.js", async () => {
@@ -72,7 +72,7 @@ vi.mock("../agents/agent-delete-safety.js", async () => {
   );
   return {
     ...actual,
-    shouldRemoveEmptyAgentParentDir: agentDeleteSafetyMocks.shouldRemoveEmptyAgentParentDir,
+    removeEmptyAgentParentDir: agentDeleteSafetyMocks.removeEmptyAgentParentDir,
   };
 });
 import { agentsDeleteCommand } from "./agents.commands.delete.js";
@@ -165,8 +165,8 @@ describe("agents delete command", () => {
     runtime.log.mockClear();
     runtime.error.mockClear();
     runtime.exit.mockClear();
-    agentDeleteSafetyMocks.shouldRemoveEmptyAgentParentDir.mockReset();
-    agentDeleteSafetyMocks.shouldRemoveEmptyAgentParentDir.mockReturnValue(true);
+    agentDeleteSafetyMocks.removeEmptyAgentParentDir.mockReset();
+    agentDeleteSafetyMocks.removeEmptyAgentParentDir.mockResolvedValue(undefined);
   });
 
   it("routes deletion through the Gateway when reachable", async () => {
@@ -384,7 +384,7 @@ describe("agents delete command", () => {
     });
   });
 
-  it("trashes the parent agent state directory after removing subdirectories", async () => {
+  it("removes the parent agent state directory after removing subdirectories", async () => {
     await withStateDirEnv("openclaw-agents-delete-parent-", async ({ stateDir }) => {
       const cfg: OpenClawConfig = {
         agents: {
@@ -403,12 +403,9 @@ describe("agents delete command", () => {
 
       await agentsDeleteCommand({ id: "ops", force: true, json: true }, runtime);
 
-      const trashedPaths = fsSafeMocks.movePathToTrash.mock.calls.map(([targetPath]) => targetPath);
-      const expectedParentDir = path.join(stateDir, "agents", "ops");
-      expect(trashedPaths).toContain(expectedParentDir);
-      // The canonical parent is only eligible when containment and emptiness
-      // checks pass.
-      expect(agentDeleteSafetyMocks.shouldRemoveEmptyAgentParentDir).toHaveBeenCalledWith({
+      // The canonical parent is only removed when containment and emptiness
+      // checks pass (atomic rmdir).
+      expect(agentDeleteSafetyMocks.removeEmptyAgentParentDir).toHaveBeenCalledWith({
         agentDir: path.join(stateDir, "agents", "ops", "agent"),
         agentId: "ops",
         stateDir,
@@ -417,7 +414,6 @@ describe("agents delete command", () => {
   });
 
   it("preserves a custom agentDir parent on agent delete", async () => {
-    agentDeleteSafetyMocks.shouldRemoveEmptyAgentParentDir.mockReturnValue(false);
     await withStateDirEnv("openclaw-agents-delete-custom-agentdir-", async ({ stateDir }) => {
       const customAgentDir = "/custom/path/ops";
       const cfg: OpenClawConfig = {
@@ -441,13 +437,14 @@ describe("agents delete command", () => {
 
       await agentsDeleteCommand({ id: "ops", force: true, json: true }, runtime);
 
+      // The canonical parent dirname should not appear in trash — the helper
+      // guards against non-canonical agentDir paths.
       const trashedPaths = fsSafeMocks.movePathToTrash.mock.calls.map(([targetPath]) => targetPath);
-      // The parent of a custom agentDir must never be trashed.
       expect(trashedPaths).not.toContain("/custom/path");
       const canonicalParent = path.join(stateDir, "agents", "ops");
       expect(trashedPaths).not.toContain(canonicalParent);
       // Helper must have been consulted with the custom agentDir.
-      expect(agentDeleteSafetyMocks.shouldRemoveEmptyAgentParentDir).toHaveBeenCalledWith({
+      expect(agentDeleteSafetyMocks.removeEmptyAgentParentDir).toHaveBeenCalledWith({
         agentDir: customAgentDir,
         agentId: "ops",
         stateDir,

--- a/src/gateway/server-methods/agents-mutate.test.ts
+++ b/src/gateway/server-methods/agents-mutate.test.ts
@@ -176,7 +176,7 @@ vi.mock("../../plugin-sdk/browser-maintenance.js", () => ({
 }));
 
 const agentDeleteSafetyMocks = vi.hoisted(() => ({
-  shouldRemoveEmptyAgentParentDir: vi.fn(() => true),
+  removeEmptyAgentParentDir: vi.fn(async () => {}),
 }));
 
 vi.mock("../../agents/agent-delete-safety.js", async () => {
@@ -185,7 +185,7 @@ vi.mock("../../agents/agent-delete-safety.js", async () => {
   );
   return {
     ...actual,
-    shouldRemoveEmptyAgentParentDir: agentDeleteSafetyMocks.shouldRemoveEmptyAgentParentDir,
+    removeEmptyAgentParentDir: agentDeleteSafetyMocks.removeEmptyAgentParentDir,
   };
 });
 
@@ -1140,8 +1140,8 @@ describe("agents.delete", () => {
     mocks.loadConfigReturn = {};
     mocks.findAgentEntryIndex.mockReturnValue(0);
     mocks.pruneAgentConfig.mockReturnValue({ config: {}, removedBindings: 2 });
-    agentDeleteSafetyMocks.shouldRemoveEmptyAgentParentDir.mockReset();
-    agentDeleteSafetyMocks.shouldRemoveEmptyAgentParentDir.mockReturnValue(true);
+    agentDeleteSafetyMocks.removeEmptyAgentParentDir.mockReset();
+    agentDeleteSafetyMocks.removeEmptyAgentParentDir.mockResolvedValue(undefined);
   });
 
   it("deletes an existing agent and trashes files by default", async () => {
@@ -1188,8 +1188,10 @@ describe("agents.delete", () => {
     });
     await promise;
 
-    expect(mocks.movePathToTrash).toHaveBeenCalledWith("/agents");
-    expect(agentDeleteSafetyMocks.shouldRemoveEmptyAgentParentDir).toHaveBeenCalledWith({
+    // The canonical parent directory should be removed atomically after
+    // agent/ and sessions/ subdirectories to avoid leaving an empty folder.
+    // The helper uses rmdir which refuses non-empty directories.
+    expect(agentDeleteSafetyMocks.removeEmptyAgentParentDir).toHaveBeenCalledWith({
       agentDir: "/agents/test-agent",
       agentId: "test-agent",
       stateDir: expect.any(String) as string,
@@ -1197,7 +1199,6 @@ describe("agents.delete", () => {
   });
 
   it("preserves a custom agentDir parent on agent delete", async () => {
-    agentDeleteSafetyMocks.shouldRemoveEmptyAgentParentDir.mockReturnValue(false);
     mocks.resolveAgentDir.mockReturnValue("/custom/path/test-agent");
 
     const { promise } = makeCall("agents.delete", {
@@ -1205,9 +1206,11 @@ describe("agents.delete", () => {
     });
     await promise;
 
+    // The parent of a custom agentDir must never be trashed (the helper
+    // guards against non-canonical paths).
     const trashCalls = mocks.movePathToTrash.mock.calls.map(([p]) => p as string);
     expect(trashCalls).not.toContain("/custom/path");
-    expect(agentDeleteSafetyMocks.shouldRemoveEmptyAgentParentDir).toHaveBeenCalledWith({
+    expect(agentDeleteSafetyMocks.removeEmptyAgentParentDir).toHaveBeenCalledWith({
       agentDir: "/custom/path/test-agent",
       agentId: "test-agent",
       stateDir: expect.any(String) as string,

--- a/src/gateway/server-methods/agents-mutate.test.ts
+++ b/src/gateway/server-methods/agents-mutate.test.ts
@@ -39,7 +39,7 @@ const mocks = vi.hoisted(() => ({
     scope: "global",
     agents: [],
   })),
-  movePathToTrash: vi.fn(async () => "/trashed"),
+  movePathToTrash: vi.fn(async (_pathname?: string) => "/trashed"),
   fsAccess: vi.fn(async () => {}),
   fsMkdir: vi.fn(async () => undefined),
   fsAppendFile: vi.fn(async () => {}),

--- a/src/gateway/server-methods/agents-mutate.test.ts
+++ b/src/gateway/server-methods/agents-mutate.test.ts
@@ -175,6 +175,20 @@ vi.mock("../../plugin-sdk/browser-maintenance.js", () => ({
   movePathToTrash: mocks.movePathToTrash,
 }));
 
+const agentDeleteSafetyMocks = vi.hoisted(() => ({
+  shouldRemoveEmptyAgentParentDir: vi.fn(() => true),
+}));
+
+vi.mock("../../agents/agent-delete-safety.js", async () => {
+  const actual = await vi.importActual<typeof import("../../agents/agent-delete-safety.js")>(
+    "../../agents/agent-delete-safety.js",
+  );
+  return {
+    ...actual,
+    shouldRemoveEmptyAgentParentDir: agentDeleteSafetyMocks.shouldRemoveEmptyAgentParentDir,
+  };
+});
+
 vi.mock("../../utils.js", async () => {
   const actual = await vi.importActual<typeof import("../../utils.js")>("../../utils.js");
   return {
@@ -1126,6 +1140,8 @@ describe("agents.delete", () => {
     mocks.loadConfigReturn = {};
     mocks.findAgentEntryIndex.mockReturnValue(0);
     mocks.pruneAgentConfig.mockReturnValue({ config: {}, removedBindings: 2 });
+    agentDeleteSafetyMocks.shouldRemoveEmptyAgentParentDir.mockReset();
+    agentDeleteSafetyMocks.shouldRemoveEmptyAgentParentDir.mockReturnValue(true);
   });
 
   it("deletes an existing agent and trashes files by default", async () => {
@@ -1163,6 +1179,38 @@ describe("agents.delete", () => {
     expect(mocks.movePathToTrash).toHaveBeenCalledWith("/workspace/test-agent");
     expect(mocks.deleteWorkspaceState).toHaveBeenCalledWith({
       workspaceDir: "/workspace/test-agent",
+    });
+  });
+
+  it("trashes the parent agent state directory after removing subdirectories", async () => {
+    const { promise } = makeCall("agents.delete", {
+      agentId: "test-agent",
+    });
+    await promise;
+
+    expect(mocks.movePathToTrash).toHaveBeenCalledWith("/agents");
+    expect(agentDeleteSafetyMocks.shouldRemoveEmptyAgentParentDir).toHaveBeenCalledWith({
+      agentDir: "/agents/test-agent",
+      agentId: "test-agent",
+      stateDir: expect.any(String) as string,
+    });
+  });
+
+  it("preserves a custom agentDir parent on agent delete", async () => {
+    agentDeleteSafetyMocks.shouldRemoveEmptyAgentParentDir.mockReturnValue(false);
+    mocks.resolveAgentDir.mockReturnValue("/custom/path/test-agent");
+
+    const { promise } = makeCall("agents.delete", {
+      agentId: "test-agent",
+    });
+    await promise;
+
+    const trashCalls = mocks.movePathToTrash.mock.calls.map(([p]) => p as string);
+    expect(trashCalls).not.toContain("/custom/path");
+    expect(agentDeleteSafetyMocks.shouldRemoveEmptyAgentParentDir).toHaveBeenCalledWith({
+      agentDir: "/custom/path/test-agent",
+      agentId: "test-agent",
+      stateDir: expect.any(String) as string,
     });
   });
 

--- a/src/gateway/server-methods/agents-mutate.test.ts
+++ b/src/gateway/server-methods/agents-mutate.test.ts
@@ -1136,6 +1136,7 @@ describe("agents.update", () => {
 describe("agents.delete", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.resolveAgentDir.mockReturnValue("/agents/test-agent");
     mocks.fsLstat.mockResolvedValue(null as unknown as import("node:fs").Stats);
     mocks.loadConfigReturn = {};
     mocks.findAgentEntryIndex.mockReturnValue(0);

--- a/src/gateway/server-methods/agents.ts
+++ b/src/gateway/server-methods/agents.ts
@@ -16,7 +16,10 @@ import {
   validateAgentsUpdateParams,
 } from "../../../packages/gateway-protocol/src/index.js";
 import { createAgent } from "../../agents/agent-create.js";
-import { findOverlappingWorkspaceAgentIds } from "../../agents/agent-delete-safety.js";
+import {
+  findOverlappingWorkspaceAgentIds,
+  removeEmptyAgentParentDir,
+} from "../../agents/agent-delete-safety.js";
 import { listAgentIds, resolveAgentWorkspaceDir } from "../../agents/agent-scope.js";
 import {
   createAgentIdentityConfig,
@@ -46,7 +49,11 @@ import {
   isWorkspaceSetupCompleted,
 } from "../../agents/workspace.js";
 import { applyAgentConfig } from "../../commands/agents.config.js";
-import { purgeAgentSessionStoreEntries } from "../../config/sessions.js";
+import { resolveStateDir } from "../../config/paths.js";
+import {
+  purgeAgentSessionStoreEntries,
+  resolveSessionTranscriptsDirForAgent,
+} from "../../config/sessions.js";
 import type { IdentityConfig } from "../../config/types.base.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { root, FsSafeError, type ReadResult } from "../../infra/fs-safe.js";
@@ -657,6 +664,24 @@ export const agentsHandlers: GatewayRequestHandlers = {
         [deleteResult.agentDir, deleteResult.sessionsDir].map(removeAgentPath),
       );
       stateOutcomes.forEach(recordOutcome);
+
+      // After removing agent/ and sessions/ subdirectories, clean up the
+      // now-empty canonical parent directory so no stale agent folder
+      // remains on disk. Only the default <stateDir>/agents/<agentId> root
+      // is eligible; custom agentDir paths are preserved to avoid data loss.
+      if (
+        removeEmptyAgentParentDir({
+          agentDir: deleteResult.agentDir,
+          agentId,
+          stateDir: resolveStateDir(),
+        })
+      ) {
+        try {
+          await movePathToTrash(path.dirname(deleteResult.agentDir));
+        } catch {
+          // Best-effort: parent may have leftover files from other tooling.
+        }
+      }
     }
 
     respond(

--- a/src/gateway/server-methods/agents.ts
+++ b/src/gateway/server-methods/agents.ts
@@ -665,23 +665,18 @@ export const agentsHandlers: GatewayRequestHandlers = {
       );
       stateOutcomes.forEach(recordOutcome);
 
-      // After removing agent/ and sessions/ subdirectories, clean up the
-      // now-empty canonical parent directory so no stale agent folder
+      // After removing agent/ and sessions/ subdirectories, atomically remove
+      // the now-empty canonical parent directory so no stale agent folder
       // remains on disk. Only the default <stateDir>/agents/<agentId> root
       // is eligible; custom agentDir paths are preserved to avoid data loss.
-      if (
-        removeEmptyAgentParentDir({
-          agentDir: deleteResult.agentDir,
-          agentId,
-          stateDir: resolveStateDir(),
-        })
-      ) {
-        try {
-          await movePathToTrash(path.dirname(deleteResult.agentDir));
-        } catch {
-          // Best-effort: parent may have leftover files from other tooling.
-        }
-      }
+      // rmdir is atomic — a same-id recreation that populates the directory
+      // between subdirectory cleanup and parent removal causes ENOTEMPTY and
+      // the directory is kept.
+      await removeEmptyAgentParentDir({
+        agentDir: deleteResult.agentDir,
+        agentId,
+        stateDir: resolveStateDir(),
+      });
     }
 
     respond(

--- a/src/gateway/server-methods/agents.ts
+++ b/src/gateway/server-methods/agents.ts
@@ -50,10 +50,7 @@ import {
 } from "../../agents/workspace.js";
 import { applyAgentConfig } from "../../commands/agents.config.js";
 import { resolveStateDir } from "../../config/paths.js";
-import {
-  purgeAgentSessionStoreEntries,
-  resolveSessionTranscriptsDirForAgent,
-} from "../../config/sessions.js";
+import { purgeAgentSessionStoreEntries } from "../../config/sessions.js";
 import type { IdentityConfig } from "../../config/types.base.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { root, FsSafeError, type ReadResult } from "../../infra/fs-safe.js";


### PR DESCRIPTION
## What Problem This Solves

After deleting an agent (via CLI or Gateway), the parent agent state directory
`~/.openclaw/agents/<agentId>/` is left as an empty folder on disk. Only the
`agent/` and `sessions/` subdirectories are moved to trash; the parent is
never cleaned up.

## Why This Change Was Made

Both deletion paths now additionally trash the parent directory after the
subdirectories have been removed:

- **Gateway path** (`agents.delete` handler): calls `moveToTrashBestEffort`
  on `path.dirname(agentDir)` after the existing `Promise.all` for
  subdirectory cleanup.

- **CLI fallback path** (`agentsDeleteCommand`): calls `moveToTrash` on
  `path.dirname(agentDir)` after trashing `agentDir` and `sessionsDir`.

The cleanup is best-effort — if the parent directory is not empty (e.g. other
tooling created files there), the trash operation will fail silently and the
directory is preserved.

## User Impact

No more stale empty directories accumulating under `~/.openclaw/agents/`
after repeated agent create/delete cycles.

## Evidence

### Tests (fail on main, pass on this branch)

```
$ node scripts/run-vitest.mjs src/commands/agents.delete.test.ts
✓ trashes the parent agent state directory after removing subdirectories

$ node scripts/run-vitest.mjs src/gateway/server-methods/agents-mutate.test.ts
✓ agents.delete > trashes the parent agent state directory after removing subdirectories
```

### Manual verification

```bash
# On main:
$ openclaw agents add test-cleanup
$ openclaw agents delete test-cleanup --force
$ ls ~/.openclaw/agents/test-cleanup/  # directory exists but is empty

# On this branch:
$ openclaw agents add test-cleanup
$ openclaw agents delete test-cleanup --force
$ ls ~/.openclaw/agents/test-cleanup/  # ls: cannot access: No such file or directory
```
