### PR TITLE
fix(qa): keep beta package harness off private runtime

### DIFF
--- a/extensions/qa-lab/api.ts
+++ b/extensions/qa-lab/api.ts
@@ -57,11 +57,7 @@ export {
   QA_BASE_RUNTIME_PLUGIN_IDS,
   type QaThinkingLevel,
 } from "./src/qa-gateway-config.js";
-export {
-  renderQaMarkdownReport,
-  type QaReportCheck,
-  type QaReportScenario,
-} from "openclaw/plugin-sdk/qa-runtime";
+export { renderQaMarkdownReport, type QaReportCheck, type QaReportScenario } from "./src/report.js";
 export {
   type QaScenarioDefinition,
   type QaScenarioResult,

--- a/extensions/qa-lab/src/live-transports/shared/live-transport-cli.ts
+++ b/extensions/qa-lab/src/live-transports/shared/live-transport-cli.ts
@@ -1,15 +1,143 @@
 // Qa Lab plugin module implements live transport cli behavior.
-import {
-  createLiveTransportQaCliRegistration as createSharedLiveTransportQaCliRegistration,
-  type LiveTransportQaCliRegistrationOptions,
-} from "openclaw/plugin-sdk/qa-runtime";
+import type { Command } from "commander";
+import type { QaRunnerCliRegistration } from "openclaw/plugin-sdk/qa-runner-runtime";
 import { DEFAULT_QA_LIVE_PROVIDER_MODE, formatQaProviderModeHelp } from "../../providers/index.js";
 
-export {
-  createLazyCliRuntimeLoader,
-  type LiveTransportQaCliRegistration,
-  type LiveTransportQaCommandOptions,
-} from "openclaw/plugin-sdk/qa-runtime";
+export type LiveTransportQaCommandOptions = {
+  repoRoot?: string;
+  outputDir?: string;
+  providerMode?: string;
+  primaryModel?: string;
+  alternateModel?: string;
+  fastMode?: boolean;
+  allowFailures?: boolean;
+  failFast?: boolean;
+  profile?: string;
+  scenarioIds?: string[];
+  listScenarios?: boolean;
+  sutAccountId?: string;
+  credentialSource?: string;
+  credentialRole?: string;
+};
+
+type LiveTransportQaCommanderOptions = {
+  repoRoot?: string;
+  outputDir?: string;
+  providerMode?: string;
+  model?: string;
+  altModel?: string;
+  scenario?: string[];
+  listScenarios?: boolean;
+  fast?: boolean;
+  allowFailures?: boolean;
+  failFast?: boolean;
+  profile?: string;
+  sutAccount?: string;
+  credentialSource?: string;
+  credentialRole?: string;
+};
+
+export type LiveTransportQaCliRegistration = QaRunnerCliRegistration;
+
+type LiveTransportQaCliRegistrationOptions = {
+  commandName: string;
+  credentialOptions?: {
+    sourceDescription?: string;
+    roleDescription?: string;
+  };
+  defaultProviderMode: string;
+  description: string;
+  providerModeHelp: string;
+  listScenariosHelp?: string;
+  outputDirHelp: string;
+  profileHelp?: string;
+  failFastHelp?: string;
+  allowFailuresHelp?: string;
+  scenarioHelp: string;
+  sutAccountHelp: string;
+  adapterFactory?: QaRunnerCliRegistration["adapterFactory"];
+  run: (opts: LiveTransportQaCommandOptions) => Promise<void>;
+};
+
+export function createLazyCliRuntimeLoader<T>(load: () => Promise<T>) {
+  let promise: Promise<T> | null = null;
+  return async () => {
+    promise ??= load();
+    return await promise;
+  };
+}
+
+function collectStringOption(value: string, previous: string[]) {
+  const trimmed = value.trim();
+  return trimmed ? [...previous, trimmed] : previous;
+}
+
+function mapCommanderOptions(opts: LiveTransportQaCommanderOptions): LiveTransportQaCommandOptions {
+  return {
+    repoRoot: opts.repoRoot,
+    outputDir: opts.outputDir,
+    providerMode: opts.providerMode,
+    primaryModel: opts.model,
+    alternateModel: opts.altModel,
+    fastMode: opts.fast,
+    allowFailures: opts.allowFailures,
+    failFast: opts.failFast,
+    profile: opts.profile,
+    scenarioIds: opts.scenario,
+    listScenarios: opts.listScenarios,
+    sutAccountId: opts.sutAccount,
+    credentialSource: opts.credentialSource,
+    credentialRole: opts.credentialRole,
+  };
+}
+
+function createSharedLiveTransportQaCliRegistration(
+  params: LiveTransportQaCliRegistrationOptions,
+): LiveTransportQaCliRegistration {
+  return {
+    commandName: params.commandName,
+    adapterFactory: params.adapterFactory,
+    register(qa: Command) {
+      const command = qa
+        .command(params.commandName)
+        .description(params.description)
+        .option("--repo-root <path>", "Repository root to target when running from a neutral cwd")
+        .option("--output-dir <path>", params.outputDirHelp)
+        .option("--provider-mode <mode>", params.providerModeHelp, params.defaultProviderMode)
+        .option("--model <ref>", "Primary provider/model ref")
+        .option("--alt-model <ref>", "Alternate provider/model ref")
+        .option("--scenario <id>", params.scenarioHelp, collectStringOption, [])
+        .option("--fast", "Enable provider fast mode where supported", false);
+
+      if (params.allowFailuresHelp) {
+        command.option("--allow-failures", params.allowFailuresHelp, false);
+      }
+      command.option("--sut-account <id>", params.sutAccountHelp, "sut");
+      if (params.listScenariosHelp) {
+        command.option("--list-scenarios", params.listScenariosHelp, false);
+      }
+      if (params.profileHelp) {
+        command.option("--profile <profile>", params.profileHelp);
+      }
+      if (params.failFastHelp) {
+        command.option("--fail-fast", params.failFastHelp, false);
+      }
+      if (params.credentialOptions) {
+        command.option(
+          "--credential-source <source>",
+          params.credentialOptions.sourceDescription ??
+            "Credential source for live lanes: env or convex (default: env)",
+        );
+        if (params.credentialOptions.roleDescription) {
+          command.option("--credential-role <role>", params.credentialOptions.roleDescription);
+        }
+      }
+      command.action(async (opts: LiveTransportQaCommanderOptions) => {
+        await params.run(mapCommanderOptions(opts));
+      });
+    },
+  };
+}
 
 type QaLabLiveTransportQaCliRegistrationOptions = Omit<
   LiveTransportQaCliRegistrationOptions,

--- a/extensions/qa-lab/src/report.ts
+++ b/extensions/qa-lab/src/report.ts
@@ -1,0 +1,100 @@
+export type QaReportCheck = {
+  name: string;
+  status: "pass" | "fail" | "skip";
+  details?: string;
+};
+
+export type QaReportScenario = {
+  name: string;
+  status: "pass" | "fail" | "skip";
+  details?: string;
+  steps?: QaReportCheck[];
+};
+
+function pushQaReportDetailsBlock(lines: string[], label: string, details: string, indent = "") {
+  if (!details.includes("\n")) {
+    lines.push(`${indent}- ${label}: ${details}`);
+    return;
+  }
+  lines.push(`${indent}- ${label}:`);
+  lines.push("", "```text", details, "```");
+}
+
+export function renderQaMarkdownReport(params: {
+  title: string;
+  startedAt: Date;
+  finishedAt: Date;
+  checks?: QaReportCheck[];
+  scenarios?: QaReportScenario[];
+  timeline?: string[];
+  notes?: string[];
+}) {
+  const checks = params.checks ?? [];
+  const scenarios = params.scenarios ?? [];
+  const passCount =
+    checks.filter((check) => check.status === "pass").length +
+    scenarios.filter((scenario) => scenario.status === "pass").length;
+  const failCount =
+    checks.filter((check) => check.status === "fail").length +
+    scenarios.filter((scenario) => scenario.status === "fail").length;
+
+  const lines = [
+    `# ${params.title}`,
+    "",
+    `- Started: ${params.startedAt.toISOString()}`,
+    `- Finished: ${params.finishedAt.toISOString()}`,
+    `- Duration ms: ${params.finishedAt.getTime() - params.startedAt.getTime()}`,
+    `- Passed: ${passCount}`,
+    `- Failed: ${failCount}`,
+    "",
+  ];
+
+  if (checks.length > 0) {
+    lines.push("## Checks", "");
+    for (const check of checks) {
+      lines.push(`- [${check.status === "pass" ? "x" : " "}] ${check.name}`);
+      if (check.details) {
+        pushQaReportDetailsBlock(lines, "Details", check.details, "  ");
+      }
+    }
+  }
+
+  if (scenarios.length > 0) {
+    lines.push("", "## Scenarios", "");
+    for (const scenario of scenarios) {
+      lines.push(`### ${scenario.name}`);
+      lines.push("");
+      lines.push(`- Status: ${scenario.status}`);
+      if (scenario.details) {
+        pushQaReportDetailsBlock(lines, "Details", scenario.details);
+      }
+      if (scenario.steps?.length) {
+        lines.push("- Steps:");
+        for (const step of scenario.steps) {
+          lines.push(`  - [${step.status === "pass" ? "x" : " "}] ${step.name}`);
+          if (step.details) {
+            pushQaReportDetailsBlock(lines, "Details", step.details, "    ");
+          }
+        }
+      }
+      lines.push("");
+    }
+  }
+
+  if (params.timeline && params.timeline.length > 0) {
+    lines.push("## Timeline", "");
+    for (const item of params.timeline) {
+      lines.push(`- ${item}`);
+    }
+  }
+
+  if (params.notes && params.notes.length > 0) {
+    lines.push("", "## Notes", "");
+    for (const note of params.notes) {
+      lines.push(`- ${note}`);
+    }
+  }
+
+  lines.push("");
+  return lines.join("\n");
+}

--- a/extensions/qa-lab/src/self-check.ts
+++ b/extensions/qa-lab/src/self-check.ts
@@ -2,10 +2,10 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import { renderQaMarkdownReport } from "openclaw/plugin-sdk/qa-runtime";
 import { createQaArtifactRunId } from "./artifact-run-id.js";
 import type { QaBusState } from "./bus-state.js";
 import { createQaTransportAdapter, type QaTransportId } from "./qa-transport-registry.js";
+import { renderQaMarkdownReport } from "./report.js";
 import { runQaScenario, type QaScenarioResult } from "./scenario.js";
 import { createQaSelfCheckScenario } from "./self-check-scenario.js";
 

--- a/extensions/qa-lab/src/suite-launch.runtime.ts
+++ b/extensions/qa-lab/src/suite-launch.runtime.ts
@@ -1,7 +1,6 @@
 // Qa Lab plugin module implements suite launch behavior.
 import fs from "node:fs/promises";
 import path from "node:path";
-import { renderQaMarkdownReport, type QaReportScenario } from "openclaw/plugin-sdk/qa-runtime";
 import { isRepoRootRelativeRef, toRepoRelativePath } from "./cli-paths.js";
 import {
   QA_EVIDENCE_FILENAME,
@@ -16,6 +15,7 @@ import {
   defaultQaSuiteConcurrencyForTransport,
   normalizeQaTransportId,
 } from "./qa-transport-registry.js";
+import { renderQaMarkdownReport, type QaReportScenario } from "./report.js";
 import { defaultQaModelForMode, normalizeQaProviderMode } from "./run-config.js";
 import {
   readQaBootstrapScenarioCatalog,

--- a/extensions/qa-lab/src/suite.ts
+++ b/extensions/qa-lab/src/suite.ts
@@ -7,11 +7,6 @@ import { disposeRegisteredAgentHarnesses } from "openclaw/plugin-sdk/agent-harne
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { parseStrictPositiveInteger } from "openclaw/plugin-sdk/number-runtime";
-import {
-  renderQaMarkdownReport,
-  type QaReportCheck,
-  type QaReportScenario,
-} from "openclaw/plugin-sdk/qa-runtime";
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import { assertQaSuiteArtifactWritten } from "./artifact-assertion.js";
 import {
@@ -53,6 +48,7 @@ import {
   type QaTransportId,
 } from "./qa-transport-registry.js";
 import type { QaTransportAdapter } from "./qa-transport.js";
+import { renderQaMarkdownReport, type QaReportCheck, type QaReportScenario } from "./report.js";
 import {
   captureRuntimeParityCell,
   isRuntimeParityResultPass,

--- a/test/scripts/npm-telegram-live.test.ts
+++ b/test/scripts/npm-telegram-live.test.ts
@@ -246,6 +246,13 @@ describe("package Telegram live Docker E2E", () => {
       path.resolve(TEST_DIR, "../../extensions/qa-lab/src/runtime-api.ts"),
       "utf8",
     );
+    const qaHarnessSources = [
+      "extensions/qa-lab/api.ts",
+      "extensions/qa-lab/src/self-check.ts",
+      "extensions/qa-lab/src/live-transports/shared/live-transport-cli.ts",
+      "extensions/qa-lab/src/suite-launch.runtime.ts",
+      "extensions/qa-lab/src/suite.ts",
+    ].map((relativePath) => readFileSync(path.resolve(TEST_DIR, "../..", relativePath), "utf8"));
 
     expect(script).toContain('ln -sfnT "$openclaw_package_dir/dist" /app/dist');
     expect(script).toContain('cp "$openclaw_package_dir/package.json" /app/package.json');
@@ -258,6 +265,9 @@ describe("package Telegram live Docker E2E", () => {
     expect(preparePackage).toContain('"./dist/plugin-sdk/gateway-runtime.js"');
     expect(gatewayRpcClient).toContain('from "openclaw/plugin-sdk/gateway-runtime"');
     expect(qaRuntimeApi).toContain('from "openclaw/plugin-sdk/gateway-runtime"');
+    for (const source of qaHarnessSources) {
+      expect(source).not.toContain('from "openclaw/plugin-sdk/qa-runtime"');
+    }
   });
 
   it("exposes installed package dependencies to the mounted QA harness", () => {


### PR DESCRIPTION
Backport of #108476 to `release/2026.7.2`.

## What Problem This Solves

Fixes beta package acceptance failing when the mounted QA Lab harness imports the private, intentionally unpublished `openclaw/plugin-sdk/qa-runtime` subpath.

Exact failure: https://github.com/openclaw/openclaw/actions/runs/29470915380/job/87534836015

## Why This Change Was Made

This applies the exact main patch from `484ad52f376e5725356d8ed08ff7198dbad3b398`: QA Lab owns its report renderer and live transport CLI helpers locally, while continuing to use published SDK contracts where available. A package-harness regression assertion prevents private QA-runtime imports from returning.

AI-assisted backport. No transcript attached.

## User Impact

The July beta package can run Telegram package acceptance and QA Lab from an installed tarball without depending on private package files. No config, protocol, or product behavior change.

## Evidence

- Backport patch-id exactly matches main #108476: `2d6d822578acb55c767c1d335ea052a4de4da9f4`.
- Blacksmith Testbox https://github.com/openclaw/openclaw/actions/runs/29471772478: 48 focused package-harness, suite-launch, and live-transport CLI tests passed.
- Fresh autoreview: no actionable findings, 0.93 confidence.
- A direct release-base `check:changed` attempt exposed a sparse-wrapper history bug: the remote checkout lacked exact beta base `7f2db2b201be9309abd2b8e52bc3b4a0641bcbf1`. Exact hosted PR CI is the authoritative full gate.
