### PR TITLE
fix: Claude catalog terminals bypass failed npm shims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Claude catalog terminal binaries:** bypass Anthropic's failed npm placeholder when opening catalog sessions, prefer the native installer or newest Claude Desktop binary, and hide terminal availability when no working replacement exists. Fixes #108608.
 - **Tlon SSE connect cleanup:** disarm opening deadlines after failed HTTP responses and rejected stream opens so reconnect attempts cannot leave stale timers behind. (#104585) Thanks @hugenshen.
 - **LINE reply-token media kinds:** honor video and audio metadata on inbound replies, share the canonical media builder with proactive sends, and fail visibly instead of recording empty media-only deliveries. (#106515) Thanks @edenfunf.
 - **Mattermost websocket connection deadlines:** bound opening handshakes so stalled TCP peers cannot hang channel startup indefinitely and reconnect control resumes after timeout. (#105553) Thanks @hugenshen.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Claude catalog terminal binaries:** bypass Anthropic's failed npm placeholder when opening catalog sessions, prefer the native installer or newest Claude Desktop binary, and hide terminal availability when no working replacement exists. Fixes #108608.
 - **Tlon SSE connect cleanup:** disarm opening deadlines after failed HTTP responses and rejected stream opens so reconnect attempts cannot leave stale timers behind. (#104585) Thanks @hugenshen.
 - **LINE reply-token media kinds:** honor video and audio metadata on inbound replies, share the canonical media builder with proactive sends, and fail visibly instead of recording empty media-only deliveries. (#106515) Thanks @edenfunf.
 - **Mattermost websocket connection deadlines:** bound opening handshakes so stalled TCP peers cannot hang channel startup indefinitely and reconnect control resumes after timeout. (#105553) Thanks @hugenshen.

--- a/extensions/anthropic/session-catalog-executable.ts
+++ b/extensions/anthropic/session-catalog-executable.ts
@@ -1,11 +1,153 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { resolveNodeHostExecutable } from "openclaw/plugin-sdk/node-host";
 
-// Claude's npm shim can remain executable after its postinstall failed. Prefer
-// the operator's login-shell command, then carry that PATH into the PTY.
+const BROKEN_NPM_SHIM_MARKER = "Error: claude native binary not installed.";
+const BROKEN_NPM_INSTALL_HINT = "node_modules/@anthropic-ai/claude-code/install.cjs";
+const CLAUDE_PACKAGE_SHIM_TARGET =
+  /(?:\$basedir|%dp0%)\/([^"'\r\n]*?node_modules\/@anthropic-ai\/claude-code\/bin\/claude\.exe)/giu;
+const MAX_SHIM_PROBE_BYTES = 4096;
+
+let cachedNativeReplacement: { key: string; executable: string | null } | undefined;
+
+function currentHomeDir(env: NodeJS.ProcessEnv): string {
+  return env.HOME?.trim() || env.USERPROFILE?.trim() || os.homedir();
+}
+
+function readSmallExecutableSource(executable: string):
+  | {
+      realPath: string;
+      source: string;
+    }
+  | undefined {
+  try {
+    const realPath = fs.realpathSync(executable);
+    if (fs.statSync(realPath).size > MAX_SHIM_PROBE_BYTES) {
+      return undefined;
+    }
+    return { realPath, source: fs.readFileSync(realPath, "utf8") };
+  } catch {
+    return undefined;
+  }
+}
+
+function isFailedClaudeNpmPlaceholder(source: string): boolean {
+  return source.includes(BROKEN_NPM_SHIM_MARKER) && source.includes(BROKEN_NPM_INSTALL_HINT);
+}
+
+function isBrokenClaudeNpmShim(executable: string): boolean {
+  const shim = readSmallExecutableSource(executable);
+  if (!shim) {
+    return false;
+  }
+  if (isFailedClaudeNpmPlaceholder(shim.source)) {
+    return true;
+  }
+  // npm's cross-platform command shims call the package binary through
+  // $basedir or %dp0%; inspect that bounded target without executing the shim.
+  const normalizedSource = shim.source.replaceAll("\\", "/");
+  const baseDirectories = new Set([path.dirname(executable), path.dirname(shim.realPath)]);
+  for (const match of normalizedSource.matchAll(CLAUDE_PACKAGE_SHIM_TARGET)) {
+    const relativeTarget = match[1];
+    if (!relativeTarget) {
+      continue;
+    }
+    for (const baseDirectory of baseDirectories) {
+      const target = readSmallExecutableSource(path.resolve(baseDirectory, relativeTarget));
+      if (target && isFailedClaudeNpmPlaceholder(target.source)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+function resolveExecutableFromDirectory(
+  directory: string,
+  env: NodeJS.ProcessEnv,
+): string | undefined {
+  const resolution = resolveNodeHostExecutable("claude", {
+    env,
+    pathEnv: directory,
+    strategy: "direct",
+  });
+  return resolution && !isBrokenClaudeNpmShim(resolution.executable)
+    ? resolution.executable
+    : undefined;
+}
+
+function resolveClaudeDesktopExecutable(
+  homeDir: string,
+  env: NodeJS.ProcessEnv,
+): string | undefined {
+  if (process.platform !== "darwin") {
+    return undefined;
+  }
+  const versionsRoot = path.join(
+    homeDir,
+    "Library",
+    "Application Support",
+    "Claude",
+    "claude-code",
+  );
+  let versions: fs.Dirent[];
+  try {
+    versions = fs.readdirSync(versionsRoot, { withFileTypes: true });
+  } catch {
+    return undefined;
+  }
+  versions.sort((left, right) =>
+    right.name.localeCompare(left.name, undefined, { numeric: true, sensitivity: "base" }),
+  );
+  for (const version of versions) {
+    if (!version.isDirectory()) {
+      continue;
+    }
+    const executable = resolveExecutableFromDirectory(
+      path.join(versionsRoot, version.name, "claude.app", "Contents", "MacOS"),
+      env,
+    );
+    if (executable) {
+      return executable;
+    }
+  }
+  return undefined;
+}
+
+function resolveNativeReplacement(env: NodeJS.ProcessEnv): string | undefined {
+  const homeDir = currentHomeDir(env);
+  const cacheKey = `${process.platform}\0${homeDir}`;
+  if (cachedNativeReplacement?.key === cacheKey) {
+    return cachedNativeReplacement.executable ?? undefined;
+  }
+  // Claude installations are process-stable metadata. Cache the lookup so
+  // catalog requests do not poll the filesystem; installs take effect on restart.
+  const executable =
+    resolveExecutableFromDirectory(path.join(homeDir, ".local", "bin"), env) ??
+    resolveClaudeDesktopExecutable(homeDir, env);
+  cachedNativeReplacement = { key: cacheKey, executable: executable ?? null };
+  return executable;
+}
+
+// Anthropic's failed npm postinstall leaves an executable placeholder that can
+// never launch. Keep normal shell wrappers, but replace that known failure with
+// a native installer or Claude Desktop binary and retain the user's shell PATH.
 export function resolveClaudeTerminalExecutable(env: NodeJS.ProcessEnv = process.env) {
-  return resolveNodeHostExecutable("claude", {
+  const shellResolution = resolveNodeHostExecutable("claude", {
     env,
     pathEnv: env.PATH ?? env.Path ?? "",
     strategy: "prefer",
   });
+  if (shellResolution && !isBrokenClaudeNpmShim(shellResolution.executable)) {
+    return shellResolution;
+  }
+  const nativeExecutable = resolveNativeReplacement(env);
+  if (!nativeExecutable) {
+    return undefined;
+  }
+  return {
+    executable: nativeExecutable,
+    ...(shellResolution?.pathEnv ? { pathEnv: shellResolution.pathEnv } : {}),
+  };
 }

--- a/extensions/anthropic/session-catalog.test.ts
+++ b/extensions/anthropic/session-catalog.test.ts
@@ -138,6 +138,40 @@ async function writeDesktopMetadata(
   await fs.writeFile(path.join(dir, `local_${name}.json`), JSON.stringify(metadata));
 }
 
+async function writeBrokenClaudeNpmShim(binDir: string): Promise<string> {
+  await fs.mkdir(binDir, { recursive: true });
+  const executable = path.join(binDir, process.platform === "win32" ? "claude.cmd" : "claude");
+  const packageExecutable = path.join(
+    binDir,
+    "node_modules",
+    "@anthropic-ai",
+    "claude-code",
+    "bin",
+    "claude.exe",
+  );
+  await fs.mkdir(path.dirname(packageExecutable), { recursive: true });
+  await fs.writeFile(
+    packageExecutable,
+    [
+      'echo "Error: claude native binary not installed." >&2',
+      'echo "node node_modules/@anthropic-ai/claude-code/install.cjs" >&2',
+      "exit 1",
+      "",
+    ].join("\n"),
+  );
+  await fs.writeFile(
+    executable,
+    process.platform === "win32"
+      ? '@ECHO off\r\n"%dp0%\\node_modules\\@anthropic-ai\\claude-code\\bin\\claude.exe" %*\r\n'
+      : '#!/bin/sh\nexec "$basedir/node_modules/@anthropic-ai/claude-code/bin/claude.exe" "$@"\n',
+  );
+  if (process.platform !== "win32") {
+    await fs.chmod(executable, 0o755);
+    await fs.chmod(packageExecutable, 0o755);
+  }
+  return executable;
+}
+
 function message(
   sessionId: string,
   type: "user" | "assistant",
@@ -159,6 +193,7 @@ function message(
 }
 
 afterEach(async () => {
+  vi.restoreAllMocks();
   nodeHostMocks.runNodePtyCommand.mockClear();
   nodeHostMocks.userShellPaths.clear();
   process.env.HOME = originalHome;
@@ -1089,7 +1124,8 @@ describe("Claude session catalog", () => {
     ).rejects.toThrow("Claude session cannot be resumed in a terminal");
   });
 
-  it("prefers the login-shell Claude binary for local terminal capability and plans", async () => {
+  it("replaces a broken npm shim with Claude Desktop's newest native binary", async () => {
+    vi.spyOn(process, "platform", "get").mockReturnValue("darwin");
     const home = await createHome();
     process.env.HOME = home;
     const sessionId = "claude-session-1";
@@ -1135,9 +1171,35 @@ describe("Claude session catalog", () => {
       },
     } as unknown as OpenClawPluginApi);
 
-    await fs.writeFile(path.join(shellBinDir, "claude"), "#!/bin/sh\n");
-    await fs.chmod(path.join(shellBinDir, "claude"), 0o755);
+    await writeBrokenClaudeNpmShim(shellBinDir);
     nodeHostMocks.userShellPaths.set("claude", shellBinDir);
+    const desktopVersionRoot = path.join(
+      home,
+      "Library",
+      "Application Support",
+      "Claude",
+      "claude-code",
+    );
+    for (const version of ["2.1.9", "2.1.10"]) {
+      const desktopBinDir = path.join(
+        desktopVersionRoot,
+        version,
+        "claude.app",
+        "Contents",
+        "MacOS",
+      );
+      await fs.mkdir(desktopBinDir, { recursive: true });
+      await fs.writeFile(path.join(desktopBinDir, "claude"), "#!/bin/sh\nexit 0\n");
+      await fs.chmod(path.join(desktopBinDir, "claude"), 0o755);
+    }
+    const desktopExecutable = path.join(
+      desktopVersionRoot,
+      "2.1.10",
+      "claude.app",
+      "Contents",
+      "MacOS",
+      "claude",
+    );
     await expect(provider?.list({})).resolves.toMatchObject([
       { sessions: [{ threadId: sessionId, canOpenTerminal: true }] },
     ]);
@@ -1145,13 +1207,47 @@ describe("Claude session catalog", () => {
       provider?.openTerminal?.({ hostId: "gateway:local", threadId: sessionId }),
     ).resolves.toMatchObject({
       kind: "local",
-      argv: [path.join(shellBinDir, "claude"), "--resume", sessionId],
+      argv: [desktopExecutable, "--resume", sessionId],
       cwd: home,
       pathEnv: shellBinDir,
     });
     await expect(
       provider?.openTerminal?.({ hostId: "gateway:local", threadId: "missing" }),
     ).rejects.toThrow("Claude session is unavailable");
+  });
+
+  it("hides terminal capability when the failed npm shim has no native replacement", async () => {
+    vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+    const home = await createHome();
+    process.env.HOME = home;
+    const sessionId = "claude-session-broken-shim";
+    await writeProject({
+      home,
+      entries: [
+        {
+          sessionId,
+          fullPath: path.join(home, ".claude", "projects", "-workspace", `${sessionId}.jsonl`),
+          projectPath: home,
+          summary: "Broken shim session",
+        },
+      ],
+      transcripts: { [sessionId]: [message(sessionId, "user", "hello", 1)] },
+    });
+    const shellBinDir = path.join(home, "shell-bin");
+    await writeBrokenClaudeNpmShim(shellBinDir);
+    process.env.PATH = shellBinDir;
+    nodeHostMocks.userShellPaths.set("claude", shellBinDir);
+    const provider = captureCatalogProvider({
+      config: { current: () => ({}) },
+      nodes: { list: async () => ({ nodes: [] }) },
+    } as unknown as PluginRuntime);
+
+    await expect(provider.list({})).resolves.toMatchObject([
+      { sessions: [{ threadId: sessionId, canOpenTerminal: false }] },
+    ]);
+    await expect(
+      provider.openTerminal?.({ hostId: "gateway:local", threadId: sessionId }),
+    ).rejects.toThrow("Claude CLI is unavailable");
   });
 
   it("keeps one failed node isolated from healthy hosts", async () => {


### PR DESCRIPTION
Fixes #108608

## What Problem This Solves

Fixes an issue where users opening a local Claude Code catalog session in Control UI would get `Error: claude native binary not installed.` when their login shell selected Anthropic's failed npm placeholder even though a working native Claude installation was available.

## Why This Change Was Made

The Anthropic plugin now recognizes the exact failed npm placeholder, including npm-style cross-platform command shims, without executing it. It prefers the native installer at `~/.local/bin/claude`, then the newest Claude Desktop-managed binary on macOS, while preserving the user's login-shell `PATH`; if no working replacement exists, terminal capability is hidden instead of launching a guaranteed failure.

## User Impact

**Open in terminal** now resumes Claude sessions with a working native executable on affected machines. Machines that only have the failed npm placeholder no longer offer a terminal action that cannot succeed.

## Evidence

- Before: live verification reproduced the exact npm-placeholder error from the selected login-shell `claude`; the Claude Desktop native executable on the same host returned `2.1.209 (Claude Code)`.
- End to end: an isolated Gateway on the affected macOS host exposed a synthetic Claude session in Control UI. Opening its context menu and choosing **Open in terminal** created a connected terminal, and the matching host process was `~/Library/Application Support/Claude/claude-code/2.1.209/claude.app/Contents/MacOS/claude --resume 10860800-0000-4000-8000-000000000001` rather than `/opt/homebrew/bin/claude`.
- Negative probe: removing the isolated native executable and restarting the Gateway changed **Open in terminal** to disabled with `Terminal opening is unavailable for this session.`
- Focused regression: `node scripts/run-vitest.mjs extensions/anthropic/session-catalog.test.ts` — 21/21 passed.
- Changed-surface proof: [Blacksmith Testbox run](https://github.com/openclaw/openclaw/actions/runs/29472282634) — format, lint, extension/test typechecks, plugin boundaries, import cycles, and policy guards passed.
- Autoreview: clean after accepting and fixing the package-manager shim portability finding.
