### PR TITLE
fix(discord): preserve forum targets for CLI plugin tools

### DIFF
--- a/src/agents/openclaw-plugin-tools.ts
+++ b/src/agents/openclaw-plugin-tools.ts
@@ -20,7 +20,6 @@ import type { AnyAgentTool } from "./tools/common.js";
 type ResolveOpenClawPluginToolsOptions = OpenClawPluginToolOptions & {
   pluginToolAllowlist?: string[];
   pluginToolDenylist?: string[];
-  currentMessagingTarget?: string;
   currentThreadTs?: string;
   currentMessageId?: string | number;
   sandboxRoot?: string;

--- a/src/agents/openclaw-plugin-tools.ts
+++ b/src/agents/openclaw-plugin-tools.ts
@@ -6,7 +6,6 @@
  */
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolvePluginTools } from "../plugins/tools.js";
-import { normalizeDeliveryContext } from "../utils/delivery-context.js";
 import { resolveApiKeyForProfile, resolveAuthProfileOrder } from "./auth-profiles.js";
 import type { AuthProfileStore } from "./auth-profiles/types.js";
 import { createNodePluginTools } from "./node-plugin-tools.js";
@@ -21,7 +20,6 @@ import type { AnyAgentTool } from "./tools/common.js";
 type ResolveOpenClawPluginToolsOptions = OpenClawPluginToolOptions & {
   pluginToolAllowlist?: string[];
   pluginToolDenylist?: string[];
-  currentChannelId?: string;
   currentMessagingTarget?: string;
   currentThreadTs?: string;
   currentMessageId?: string | number;
@@ -46,13 +44,6 @@ export function resolveOpenClawPluginToolsForOptions(params: {
   if (params.options?.disablePluginTools) {
     return [];
   }
-
-  const deliveryContext = normalizeDeliveryContext({
-    channel: params.options?.agentChannel,
-    to: params.options?.agentTo,
-    accountId: params.options?.agentAccountId,
-    threadId: params.options?.agentThreadId,
-  });
 
   const resolveCurrentRuntimeConfig = () => {
     // Re-resolve on demand so auth/profile lookups see the active runtime config
@@ -121,6 +112,6 @@ export function resolveOpenClawPluginToolsForOptions(params: {
 
   return applyPluginToolDeliveryDefaults({
     tools: pluginTools,
-    deliveryContext,
+    deliveryContext: pluginToolInputs.context.deliveryContext,
   });
 }

--- a/src/agents/openclaw-tools.plugin-context.test.ts
+++ b/src/agents/openclaw-tools.plugin-context.test.ts
@@ -240,6 +240,36 @@ describe("openclaw plugin tool context", () => {
     });
   });
 
+  it("uses the current conversation target when agentTo is unavailable", () => {
+    const result = resolveOpenClawPluginToolInputs({
+      options: {
+        config: {} as never,
+        agentChannel: "discord",
+        currentChannelId: "discord:channel:987654321",
+        agentAccountId: "molty",
+      },
+    });
+
+    expect(result.context.deliveryContext).toStrictEqual({
+      channel: "discord",
+      to: "discord:channel:987654321",
+      accountId: "molty",
+    });
+  });
+
+  it("keeps an explicit agent target ahead of the current conversation target", () => {
+    const result = resolveOpenClawPluginToolInputs({
+      options: {
+        config: {} as never,
+        agentChannel: "discord",
+        agentTo: "channel:111",
+        currentChannelId: "channel:222",
+      },
+    });
+
+    expect(result.context.deliveryContext?.to).toBe("channel:111");
+  });
+
   it("does not inject ambient thread defaults into plugin tools", async () => {
     const executeMock = vi.fn(async () => ({
       content: [{ type: "text" as const, text: "ok" }],

--- a/src/agents/openclaw-tools.plugin-context.test.ts
+++ b/src/agents/openclaw-tools.plugin-context.test.ts
@@ -263,11 +263,25 @@ describe("openclaw plugin tool context", () => {
         config: {} as never,
         agentChannel: "discord",
         agentTo: "channel:111",
-        currentChannelId: "channel:222",
+        currentMessagingTarget: "channel:222",
+        currentChannelId: "333",
       },
     });
 
     expect(result.context.deliveryContext?.to).toBe("channel:111");
+  });
+
+  it("keeps the routable conversation target ahead of the native channel id", () => {
+    const result = resolveOpenClawPluginToolInputs({
+      options: {
+        config: {} as never,
+        agentChannel: "slack",
+        currentMessagingTarget: "user:U123",
+        currentChannelId: "D123",
+      },
+    });
+
+    expect(result.context.deliveryContext?.to).toBe("user:U123");
   });
 
   it("does not inject ambient thread defaults into plugin tools", async () => {

--- a/src/agents/openclaw-tools.plugin-context.ts
+++ b/src/agents/openclaw-tools.plugin-context.ts
@@ -21,6 +21,8 @@ export type OpenClawPluginToolOptions = {
   agentChannel?: GatewayMessageChannel;
   agentAccountId?: string;
   agentTo?: string;
+  /** Routable target for the current conversation when it differs from the native channel ID. */
+  currentMessagingTarget?: string;
   /** Current routable conversation target when no explicit agent target is available. */
   currentChannelId?: string;
   agentThreadId?: string | number;
@@ -79,7 +81,7 @@ export function resolveOpenClawPluginToolInputs(params: {
   // channel/account/thread shape as gateway-delivered agent tools.
   const deliveryContext = normalizeDeliveryContext({
     channel: options?.agentChannel,
-    to: options?.agentTo ?? options?.currentChannelId,
+    to: options?.agentTo ?? options?.currentMessagingTarget ?? options?.currentChannelId,
     accountId: options?.agentAccountId,
     threadId: options?.agentThreadId,
   });

--- a/src/agents/openclaw-tools.plugin-context.ts
+++ b/src/agents/openclaw-tools.plugin-context.ts
@@ -21,6 +21,8 @@ export type OpenClawPluginToolOptions = {
   agentChannel?: GatewayMessageChannel;
   agentAccountId?: string;
   agentTo?: string;
+  /** Current routable conversation target when no explicit agent target is available. */
+  currentChannelId?: string;
   agentThreadId?: string | number;
   nativeChannelId?: string;
   agentDir?: string;
@@ -77,7 +79,7 @@ export function resolveOpenClawPluginToolInputs(params: {
   // channel/account/thread shape as gateway-delivered agent tools.
   const deliveryContext = normalizeDeliveryContext({
     channel: options?.agentChannel,
-    to: options?.agentTo,
+    to: options?.agentTo ?? options?.currentChannelId,
     accountId: options?.agentAccountId,
     threadId: options?.agentThreadId,
   });


### PR DESCRIPTION
Closes #108595

## What Problem This Solves

Fixes an issue where `discord_widget` in a Discord forum-post session still rejected the current thread as non-concrete when the agent ran through the CLI/MCP plugin-tool surface. This remained after #108603 normalized the target grammar.

## Why This Change Was Made

The routed current conversation target now feeds the canonical plugin `deliveryContext` when no explicit `agentTo` exists. Target precedence is explicit `agentTo`, then the routable `currentMessagingTarget`, then the native `currentChannelId`. Plugin tool context and delivery defaults share that one normalized value.

## User Impact

CLI-backed agents can launch Discord Activities from forum-post sessions. Other plugin tools on the same runner path also receive the ambient routed target already available to core tools.

## Evidence

- Deployed before-fix proof: the target parser change from #108603 was present, but the live forum-session call still returned `discord_widget requires a concrete Discord channel in the current session`.
- Focused tests: `node scripts/run-vitest.mjs src/agents/openclaw-tools.plugin-context.test.ts extensions/discord/src/activities/tool.test.ts` (29 passed).
- Changed gate: format, SDK surface, core and core-test typechecks, lint, boundaries, and import-cycle checks passed in [Blacksmith Testbox](https://github.com/openclaw/openclaw/actions/runs/29472367286).
- Autoreview: clean, no accepted or actionable findings.
