### PR TITLE
fix(zai): use documented thinking payload

### DIFF
--- a/packages/ai/src/providers/openai-completions.test.ts
+++ b/packages/ai/src/providers/openai-completions.test.ts
@@ -667,12 +667,13 @@ describe("OpenAI-compatible completions params", () => {
     expect(capturedMaxTokens).toBe(32_000);
   });
 
-  it("uses max_tokens for Z.AI requests", async () => {
+  it("uses Z.AI max_tokens and disables thinking by default", async () => {
     const stream = streamOpenAICompletions(
       {
         ...createModel(32_000),
         provider: "zai",
         baseUrl: "https://api.z.ai/api/paas/v4",
+        reasoning: true,
       },
       context,
       {
@@ -683,8 +684,35 @@ describe("OpenAI-compatible completions params", () => {
 
     await stream.result();
 
-    expect(mockOpenAIOptionsRef.payloads[0]).toMatchObject({ max_tokens: 1_024 });
+    expect(mockOpenAIOptionsRef.payloads[0]).toMatchObject({
+      max_tokens: 1_024,
+      thinking: { type: "disabled" },
+    });
     expect(mockOpenAIOptionsRef.payloads[0]).not.toHaveProperty("max_completion_tokens");
+    expect(mockOpenAIOptionsRef.payloads[0]).not.toHaveProperty("enable_thinking");
+  });
+
+  it("enables Z.AI thinking with the documented payload when requested", async () => {
+    const stream = streamOpenAICompletions(
+      {
+        ...createModel(32_000),
+        provider: "zai",
+        baseUrl: "https://api.z.ai/api/paas/v4",
+        reasoning: true,
+      },
+      context,
+      {
+        apiKey: "sk-test",
+        reasoningEffort: "high",
+      },
+    );
+
+    await stream.result();
+
+    expect(mockOpenAIOptionsRef.payloads[0]).toMatchObject({
+      thinking: { type: "enabled" },
+    });
+    expect(mockOpenAIOptionsRef.payloads[0]).not.toHaveProperty("enable_thinking");
   });
 
   it("forwards simple stop sequences to request params", async () => {

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -766,7 +766,7 @@ function buildParams(
   }
 
   if (compat.thinkingFormat === "zai" && model.reasoning) {
-    params.enable_thinking = Boolean(options?.reasoningEffort);
+    params.thinking = { type: options?.reasoningEffort ? "enabled" : "disabled" };
   } else if (compat.thinkingFormat === "qwen" && model.reasoning) {
     params.enable_thinking = Boolean(options?.reasoningEffort);
   } else if (compat.thinkingFormat === "qwen-chat-template" && model.reasoning) {


### PR DESCRIPTION
## What Problem This Solves

Z.AI live validation returned no visible assistant text for GLM-5-Turbo and GLM-5.1 even after switching to the provider's documented `max_tokens` field. The provider ignored the remaining unsupported `enable_thinking` flag, defaulted both models to compulsory thinking, and exhausted the bounded probe budget before visible output.

Exact failure: https://github.com/openclaw/openclaw/actions/runs/29471692355

## Why This Change Was Made

Z.AI's current Chat Completions contract controls reasoning with `thinking.type` (`enabled` or `disabled`). The canonical OpenAI-compatible transport now sends that documented object and no longer sends `enable_thinking` for Z.AI. Tests cover default-disabled and explicitly-enabled requests.

Official contract: https://docs.z.ai/api-reference/llm/chat-completion

AI-assisted fix. No transcript attached.

## User Impact

Z.AI requests honor OpenClaw's reasoning selection instead of silently falling back to provider-default compulsory thinking. Small bounded requests can return visible text reliably; explicitly requested reasoning remains enabled.

## Evidence

- Blacksmith Testbox https://github.com/openclaw/openclaw/actions/runs/29472714785: focused transport suite, 45/45 tests passed.
- Blacksmith Testbox lease `tbx_01kxmmq80aehxtqncdh1ww9z0c`: full `pnpm check:changed` passed, including formatting, production/test type checks, lint, SDK baseline, dependency and architecture guards.
- Fresh autoreview: clean, 0.98 confidence.
- `git diff --check`: passed.
- Live provider proof will be rerun through exact-head Full Release Validation after landing; PR CI is secretless by design.
