### PR TITLE
fix(mattermost): keep reactions in the selected conversation

### DIFF
--- a/extensions/mattermost/src/channel.test.ts
+++ b/extensions/mattermost/src/channel.test.ts
@@ -591,6 +591,7 @@ describe("mattermostPlugin", () => {
             params,
             cfg,
             accountId: "default",
+            conversationReadOrigin: "direct-operator",
           }),
         );
       });
@@ -744,6 +745,79 @@ describe("mattermostPlugin", () => {
 
       expect(result?.content).toEqual([{ type: "text", text: "Reacted with :thumbsup: on POST1" }]);
       expect(result?.details).toStrictEqual({});
+    });
+
+    it.each([
+      {
+        label: "named channel add",
+        rawTarget: "#town-square",
+        resolvedTarget: "channel:CHAN1",
+        mode: "add" as const,
+        remove: false,
+        postChannelId: "CHAN1",
+        expectedText: "Reacted with :thumbsup: on POST1",
+      },
+      {
+        label: "named channel remove",
+        rawTarget: "#town-square",
+        resolvedTarget: "channel:CHAN1",
+        mode: "remove" as const,
+        remove: true,
+        postChannelId: "CHAN1",
+        expectedText: "Removed reaction :thumbsup: from POST1",
+      },
+      {
+        label: "named user add",
+        rawTarget: "@alice",
+        resolvedTarget: "user:PEER1",
+        mode: "add" as const,
+        remove: false,
+        postChannelId: "DMCHAN1",
+        channelType: "D",
+        channelName: "BOT123__PEER1",
+        expectedText: "Reacted with :thumbsup: on POST1",
+      },
+      {
+        label: "named user remove",
+        rawTarget: "@alice",
+        resolvedTarget: "user:PEER1",
+        mode: "remove" as const,
+        remove: true,
+        postChannelId: "DMCHAN1",
+        channelType: "D",
+        channelName: "BOT123__PEER1",
+        expectedText: "Removed reaction :thumbsup: from POST1",
+      },
+    ])("uses the resolved target for $label", async (fixture) => {
+      const cfg = createMattermostTestConfig(`delegated-reaction-${++reactionActionSequence}`);
+      const fetchImpl = createMattermostReactionFetchMock({
+        mode: fixture.mode,
+        postId: "POST1",
+        postChannelId: fixture.postChannelId,
+        channelType: fixture.channelType,
+        channelName: fixture.channelName,
+        emojiName: "thumbsup",
+      });
+
+      const result = await withMockedGlobalFetch(fetchImpl, async () =>
+        mattermostPlugin.actions?.handleAction?.(
+          createMattermostActionContext({
+            action: "react",
+            params: {
+              target: fixture.rawTarget,
+              to: fixture.resolvedTarget,
+              messageId: "POST1",
+              emoji: "thumbsup",
+              remove: fixture.remove,
+            },
+            cfg,
+            accountId: "default",
+            conversationReadOrigin: "delegated",
+          }),
+        ),
+      );
+
+      expect(result?.content).toEqual([{ type: "text", text: fixture.expectedText }]);
     });
 
     it("only treats boolean remove flag as removal", async () => {

--- a/extensions/mattermost/src/channel.test.ts
+++ b/extensions/mattermost/src/channel.test.ts
@@ -793,6 +793,7 @@ describe("mattermostPlugin", () => {
             cfg,
             accountId: "default",
             input: "disabled12abcd1234abcd1234",
+            normalized: "disabled12abcd1234abcd1234",
           }),
         ),
       ).rejects.toThrow('Mattermost account "default" is disabled');

--- a/extensions/mattermost/src/channel.test.ts
+++ b/extensions/mattermost/src/channel.test.ts
@@ -740,6 +740,36 @@ describe("mattermostPlugin", () => {
       ).rejects.toThrow("Mattermost reactions are disabled in config");
     });
 
+    it("rejects a disabled account before provider access", async () => {
+      const cfg = createMattermostTestConfig(`disabled-reaction-${++reactionActionSequence}`);
+      const mattermostConfig = cfg.channels?.mattermost;
+      if (!mattermostConfig) {
+        throw new Error("expected Mattermost config fixture");
+      }
+      mattermostConfig.accounts = { default: { enabled: false } };
+      const fetchImpl = vi.fn<typeof fetch>();
+
+      await expect(
+        withMockedGlobalFetch(fetchImpl, async () =>
+          mattermostPlugin.actions?.handleAction?.(
+            createMattermostActionContext({
+              action: "react",
+              params: {
+                target: "channel:CHAN1",
+                to: "channel:CHAN1",
+                messageId: "POST1",
+                emoji: "thumbsup",
+              },
+              cfg,
+              accountId: "default",
+              conversationReadOrigin: "direct-operator",
+            }),
+          ),
+        ),
+      ).rejects.toThrow('Mattermost account "default" is disabled');
+      expect(fetchImpl).not.toHaveBeenCalled();
+    });
+
     it("handles react by calling Mattermost reactions API", async () => {
       const result = await runReactAction({ messageId: "POST1", emoji: "thumbsup" }, "add");
 

--- a/extensions/mattermost/src/channel.test.ts
+++ b/extensions/mattermost/src/channel.test.ts
@@ -57,6 +57,14 @@ function requireMattermostNormalizeTarget() {
   return normalize;
 }
 
+function requireMattermostTargetResolver() {
+  const resolveTarget = mattermostPlugin.messaging?.targetResolver?.resolveTarget;
+  if (!resolveTarget) {
+    throw new Error("mattermost messaging.targetResolver.resolveTarget missing");
+  }
+  return resolveTarget;
+}
+
 function requireMattermostPairingNormalizer() {
   const normalize = mattermostPlugin.pairing?.normalizeAllowEntry;
   if (!normalize) {
@@ -765,6 +773,27 @@ describe("mattermostPlugin", () => {
               conversationReadOrigin: "direct-operator",
             }),
           ),
+        ),
+      ).rejects.toThrow('Mattermost account "default" is disabled');
+      expect(fetchImpl).not.toHaveBeenCalled();
+    });
+
+    it("rejects disabled accounts before opaque target resolution provider access", async () => {
+      const cfg = createMattermostTestConfig(`disabled-target-${++reactionActionSequence}`);
+      const mattermostConfig = cfg.channels?.mattermost;
+      if (!mattermostConfig) {
+        throw new Error("expected Mattermost config fixture");
+      }
+      mattermostConfig.accounts = { default: { enabled: false } };
+      const fetchImpl = vi.fn<typeof fetch>();
+
+      await expect(
+        withMockedGlobalFetch(fetchImpl, async () =>
+          requireMattermostTargetResolver()({
+            cfg,
+            accountId: "default",
+            input: "disabled12abcd1234abcd1234",
+          }),
         ),
       ).rejects.toThrow('Mattermost account "default" is disabled');
       expect(fetchImpl).not.toHaveBeenCalled();

--- a/extensions/mattermost/src/channel.ts
+++ b/extensions/mattermost/src/channel.ts
@@ -375,6 +375,7 @@ const mattermostMessageActions: ChannelMessageActionAdapter = {
     mediaAccess,
     mediaLocalRoots,
     mediaReadFile,
+    conversationReadOrigin,
   }) => {
     if (action === "react") {
       const resolvedAccountId = accountId ?? resolveDefaultMattermostAccountId(cfg);
@@ -387,6 +388,9 @@ const mattermostMessageActions: ChannelMessageActionAdapter = {
       }
 
       const { postId, emojiName, remove } = parseMattermostReactActionParams(params);
+      // The runner preserves the caller's spelling in `target` and puts the
+      // directory-resolved provider destination in `to` before dispatch.
+      const authorizedTarget = normalizeOptionalString(params.to);
       if (remove) {
         const result = await (
           await loadMattermostChannelRuntime()
@@ -395,6 +399,8 @@ const mattermostMessageActions: ChannelMessageActionAdapter = {
           postId,
           emojiName,
           accountId: resolvedAccountId,
+          authorizedTarget,
+          conversationReadOrigin,
         });
         if (!result.ok) {
           throw new Error(result.error);
@@ -414,6 +420,8 @@ const mattermostMessageActions: ChannelMessageActionAdapter = {
         postId,
         emojiName,
         accountId: resolvedAccountId,
+        authorizedTarget,
+        conversationReadOrigin,
       });
       if (!result.ok) {
         throw new Error(result.error);

--- a/extensions/mattermost/src/channel.ts
+++ b/extensions/mattermost/src/channel.ts
@@ -381,6 +381,9 @@ const mattermostMessageActions: ChannelMessageActionAdapter = {
       const resolvedAccountId = accountId ?? resolveDefaultMattermostAccountId(cfg);
       const mattermostConfig = cfg.channels?.mattermost as MattermostConfig | undefined;
       const account = resolveMattermostAccount({ cfg, accountId: resolvedAccountId });
+      if (!account.enabled) {
+        throw new Error(`Mattermost account "${resolvedAccountId}" is disabled`);
+      }
       const reactionsEnabled =
         account.config.actions?.reactions ?? mattermostConfig?.actions?.reactions ?? true;
       if (!reactionsEnabled) {

--- a/extensions/mattermost/src/mattermost/reactions.test-helpers.ts
+++ b/extensions/mattermost/src/mattermost/reactions.test-helpers.ts
@@ -34,6 +34,9 @@ export function createMattermostReactionFetchMock(params: {
   emojiName: string;
   mode: "add" | "remove" | "both";
   userId?: string;
+  postChannelId?: string | null;
+  channelType?: string;
+  channelName?: string;
   status?: number;
   body?: unknown;
 }) {
@@ -47,11 +50,27 @@ export function createMattermostReactionFetchMock(params: {
 
   return vi.fn<typeof fetch>(async (url, init) => {
     const urlText = requestUrl(url);
+    if (params.postChannelId !== undefined && urlText.endsWith(`/api/v4/posts/${params.postId}`)) {
+      return new Response(JSON.stringify({ id: params.postId, channel_id: params.postChannelId }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
     if (urlText.endsWith("/api/v4/users/me")) {
       return new Response(JSON.stringify({ id: userId }), {
         status: 200,
         headers: { "content-type": "application/json" },
       });
+    }
+    if (params.postChannelId && urlText.endsWith(`/api/v4/channels/${params.postChannelId}`)) {
+      return new Response(
+        JSON.stringify({
+          id: params.postChannelId,
+          type: params.channelType ?? "O",
+          name: params.channelName ?? "fixture-channel",
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
     }
 
     if (allowAdd && urlText.endsWith("/api/v4/reactions")) {

--- a/extensions/mattermost/src/mattermost/reactions.test.ts
+++ b/extensions/mattermost/src/mattermost/reactions.test.ts
@@ -24,6 +24,7 @@ describe("mattermost reactions", () => {
       cfg: createMattermostTestConfig(cacheKey),
       postId: "POST1",
       emojiName: "thumbsup",
+      conversationReadOrigin: "direct-operator",
       fetchImpl: fetchMock,
     });
   }
@@ -33,9 +34,302 @@ describe("mattermost reactions", () => {
       cfg: createMattermostTestConfig(cacheKey),
       postId: "POST1",
       emojiName: "thumbsup",
+      conversationReadOrigin: "direct-operator",
       fetchImpl: fetchMock,
     });
   }
+
+  it("binds delegated reactions to the authorized channel before mutation", async () => {
+    const fetchMock = createMattermostReactionFetchMock({
+      mode: "add",
+      postId: "POST1",
+      postChannelId: "CHANNEL1",
+      emojiName: "thumbsup",
+    });
+
+    const result = await addMattermostReaction({
+      cfg: createMattermostTestConfig(cacheKey),
+      postId: "POST1",
+      emojiName: "thumbsup",
+      authorizedTarget: "channel:CHANNEL1",
+      conversationReadOrigin: "delegated",
+      fetchImpl: fetchMock,
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(fetchMock.mock.calls.map((call) => requestUrl(call[0]))).toEqual([
+      expect.stringMatching(/\/api\/v4\/posts\/POST1$/),
+      expect.stringMatching(/\/api\/v4\/users\/me$/),
+      expect.stringMatching(/\/api\/v4\/reactions$/),
+    ]);
+  });
+
+  it("rejects crossed delegated channel posts before bot lookup or mutation", async () => {
+    const fetchMock = createMattermostReactionFetchMock({
+      mode: "add",
+      postId: "POST1",
+      postChannelId: "CHANNEL2",
+      emojiName: "thumbsup",
+    });
+
+    const result = await addMattermostReaction({
+      cfg: createMattermostTestConfig(cacheKey),
+      postId: "POST1",
+      emojiName: "thumbsup",
+      authorizedTarget: "channel:CHANNEL1",
+      conversationReadOrigin: "delegated",
+      fetchImpl: fetchMock,
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      error: expect.stringContaining("belongs to a different conversation"),
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("binds delegated reaction removal to the authorized channel", async () => {
+    const fetchMock = createMattermostReactionFetchMock({
+      mode: "remove",
+      postId: "POST1",
+      postChannelId: "CHANNEL1",
+      emojiName: "thumbsup",
+    });
+
+    const result = await removeMattermostReaction({
+      cfg: createMattermostTestConfig(cacheKey),
+      postId: "POST1",
+      emojiName: "thumbsup",
+      authorizedTarget: "group:CHANNEL1",
+      conversationReadOrigin: "delegated",
+      fetchImpl: fetchMock,
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(
+      fetchMock.mock.calls.some((call) =>
+        requestUrl(call[0]).endsWith("/api/v4/users/BOT123/posts/POST1/reactions/thumbsup"),
+      ),
+    ).toBe(true);
+  });
+
+  it.each([undefined, "delegated" as const])(
+    "fails closed for %s origin without a canonical target",
+    async (conversationReadOrigin) => {
+      const fetchMock = createMattermostReactionFetchMock({
+        mode: "add",
+        postId: "POST1",
+        postChannelId: "CHANNEL1",
+        emojiName: "thumbsup",
+      });
+
+      const result = await addMattermostReaction({
+        cfg: createMattermostTestConfig(cacheKey),
+        postId: "POST1",
+        emojiName: "thumbsup",
+        conversationReadOrigin,
+        fetchImpl: fetchMock,
+      });
+
+      expect(result).toEqual({
+        ok: false,
+        error: expect.stringContaining("require a canonical authorized conversation target"),
+      });
+      expect(fetchMock).not.toHaveBeenCalled();
+    },
+  );
+
+  it("binds delegated direct-message reactions to the bot and selected peer", async () => {
+    const fetchMock = createMattermostReactionFetchMock({
+      mode: "add",
+      postId: "POST1",
+      postChannelId: "DMCHANNEL",
+      channelType: "D",
+      channelName: "BOT123__PEER123",
+      userId: "BOT123",
+      emojiName: "thumbsup",
+    });
+
+    const result = await addMattermostReaction({
+      cfg: createMattermostTestConfig(cacheKey),
+      postId: "POST1",
+      emojiName: "thumbsup",
+      authorizedTarget: "user:PEER123",
+      conversationReadOrigin: "delegated",
+      fetchImpl: fetchMock,
+    });
+
+    expect(result).toEqual({ ok: true });
+  });
+
+  it("rejects delegated direct-message posts owned by another peer", async () => {
+    const fetchMock = createMattermostReactionFetchMock({
+      mode: "add",
+      postId: "POST1",
+      postChannelId: "DMCHANNEL",
+      channelType: "D",
+      channelName: "BOT123__OTHER123",
+      userId: "BOT123",
+      emojiName: "thumbsup",
+    });
+
+    const result = await addMattermostReaction({
+      cfg: createMattermostTestConfig(cacheKey),
+      postId: "POST1",
+      emojiName: "thumbsup",
+      authorizedTarget: "user:PEER123",
+      conversationReadOrigin: "delegated",
+      fetchImpl: fetchMock,
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      error: expect.stringContaining("belongs to a different direct conversation"),
+    });
+    expect(
+      fetchMock.mock.calls.some((call) => requestUrl(call[0]).endsWith("/api/v4/reactions")),
+    ).toBe(false);
+  });
+
+  it("binds delegated self-DM reactions without collapsing duplicate participant ids", async () => {
+    const fetchMock = createMattermostReactionFetchMock({
+      mode: "add",
+      postId: "POST1",
+      postChannelId: "DMCHANNEL",
+      channelType: "D",
+      channelName: "BOT123__BOT123",
+      userId: "BOT123",
+      emojiName: "thumbsup",
+    });
+
+    const result = await addMattermostReaction({
+      cfg: createMattermostTestConfig(cacheKey),
+      postId: "POST1",
+      emojiName: "thumbsup",
+      authorizedTarget: "user:BOT123",
+      conversationReadOrigin: "delegated",
+      fetchImpl: fetchMock,
+    });
+
+    expect(result).toEqual({ ok: true });
+  });
+
+  it("rejects another peer's DM when the delegated target is the bot itself", async () => {
+    const fetchMock = createMattermostReactionFetchMock({
+      mode: "add",
+      postId: "POST1",
+      postChannelId: "DMCHANNEL",
+      channelType: "D",
+      channelName: "BOT123__OTHER123",
+      userId: "BOT123",
+      emojiName: "thumbsup",
+    });
+
+    const result = await addMattermostReaction({
+      cfg: createMattermostTestConfig(cacheKey),
+      postId: "POST1",
+      emojiName: "thumbsup",
+      authorizedTarget: "user:BOT123",
+      conversationReadOrigin: "delegated",
+      fetchImpl: fetchMock,
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      error: expect.stringContaining("belongs to a different direct conversation"),
+    });
+    expect(
+      fetchMock.mock.calls.some((call) => requestUrl(call[0]).endsWith("/api/v4/reactions")),
+    ).toBe(false);
+  });
+
+  it("fails closed when delegated post metadata omits the provider channel", async () => {
+    const fetchMock = createMattermostReactionFetchMock({
+      mode: "add",
+      postId: "POST1",
+      postChannelId: null,
+      emojiName: "thumbsup",
+    });
+
+    const result = await addMattermostReaction({
+      cfg: createMattermostTestConfig(cacheKey),
+      postId: "POST1",
+      emojiName: "thumbsup",
+      authorizedTarget: "channel:CHANNEL1",
+      conversationReadOrigin: "delegated",
+      fetchImpl: fetchMock,
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      error: expect.stringContaining("missing its conversation binding"),
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses the selected account for delegated binding and mutation", async () => {
+    const defaultAccount = createMattermostTestConfig("default-account").channels?.mattermost;
+    const workAccount = createMattermostTestConfig("work-account").channels?.mattermost;
+    if (!defaultAccount || !workAccount) {
+      throw new Error("expected Mattermost account fixtures");
+    }
+    const innerFetch = createMattermostReactionFetchMock({
+      mode: "add",
+      postId: "POST1",
+      postChannelId: "CHANNEL1",
+      emojiName: "thumbsup",
+    });
+    const fetchMock = vi.fn<typeof fetch>(async (url, init) => {
+      expect(requestUrl(url)).toContain("https://work-account.chat.example.com/api/v4/");
+      return await innerFetch(url, init);
+    });
+
+    const result = await addMattermostReaction({
+      cfg: {
+        channels: {
+          mattermost: {
+            enabled: true,
+            accounts: {
+              default: defaultAccount,
+              work: workAccount,
+            },
+          },
+        },
+      },
+      accountId: "work",
+      postId: "POST1",
+      emojiName: "thumbsup",
+      authorizedTarget: "channel:CHANNEL1",
+      conversationReadOrigin: "delegated",
+      fetchImpl: fetchMock,
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("preserves direct-operator crossed-post reactions without a provider metadata read", async () => {
+    const fetchMock = createMattermostReactionFetchMock({
+      mode: "add",
+      postId: "POST1",
+      emojiName: "thumbsup",
+    });
+
+    const result = await addMattermostReaction({
+      cfg: createMattermostTestConfig(cacheKey),
+      postId: "POST1",
+      emojiName: "thumbsup",
+      authorizedTarget: "channel:DIFFERENT",
+      conversationReadOrigin: "direct-operator",
+      fetchImpl: fetchMock,
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(fetchMock.mock.calls.map((call) => requestUrl(call[0]))).toEqual([
+      expect.stringMatching(/\/api\/v4\/users\/me$/),
+      expect.stringMatching(/\/api\/v4\/reactions$/),
+    ]);
+  });
 
   it("adds reactions by calling /users/me then POST /reactions", async () => {
     const fetchMock = createMattermostReactionFetchMock({
@@ -92,12 +386,14 @@ describe("mattermost reactions", () => {
       cfg,
       postId: "POST1",
       emojiName: "thumbsup",
+      conversationReadOrigin: "direct-operator",
       fetchImpl: fetchMock,
     });
     const removeResult = await removeMattermostReaction({
       cfg,
       postId: "POST1",
       emojiName: "thumbsup",
+      conversationReadOrigin: "direct-operator",
       fetchImpl: fetchMock,
     });
 
@@ -135,6 +431,7 @@ describe("mattermost reactions", () => {
         cfg,
         postId: "POST1",
         emojiName: "thumbsup",
+        conversationReadOrigin: "direct-operator",
         fetchImpl: firstFetch,
       }),
     ).resolves.toEqual({ ok: true });
@@ -145,6 +442,7 @@ describe("mattermost reactions", () => {
         cfg,
         postId: "POST2",
         emojiName: "thumbsup",
+        conversationReadOrigin: "direct-operator",
         fetchImpl: secondFetch,
       }),
     ).resolves.toEqual({ ok: true });
@@ -155,6 +453,7 @@ describe("mattermost reactions", () => {
         cfg,
         postId: "POST3",
         emojiName: "thumbsup",
+        conversationReadOrigin: "direct-operator",
         fetchImpl: thirdFetch,
       }),
     ).resolves.toEqual({ ok: true });
@@ -181,6 +480,7 @@ describe("mattermost reactions", () => {
         cfg,
         postId: "POST1",
         emojiName: "thumbsup",
+        conversationReadOrigin: "direct-operator",
         fetchImpl: fetchMock,
       }),
     ).resolves.toEqual({ ok: true });
@@ -189,6 +489,7 @@ describe("mattermost reactions", () => {
         cfg,
         postId: "POST1",
         emojiName: "thumbsup",
+        conversationReadOrigin: "direct-operator",
         fetchImpl: fetchMock,
       }),
     ).resolves.toEqual({ ok: true });

--- a/extensions/mattermost/src/mattermost/reactions.ts
+++ b/extensions/mattermost/src/mattermost/reactions.ts
@@ -1,24 +1,33 @@
 // Mattermost plugin module implements reactions behavior.
+import type { ChannelMessageActionContext } from "openclaw/plugin-sdk/channel-contract";
 import {
   asDateTimestampMs,
   resolveExpiresAtMsFromDurationMs,
 } from "openclaw/plugin-sdk/number-runtime";
 import { isPrivateNetworkOptInEnabled } from "openclaw/plugin-sdk/ssrf-runtime";
+import { normalizeMattermostMessagingTarget } from "../normalize.js";
 import { resolveMattermostAccount } from "./accounts.js";
 import {
   createMattermostClient,
+  fetchMattermostChannel,
   fetchMattermostMe,
   type MattermostClient,
   type MattermostFetch,
+  type MattermostPost,
 } from "./client.js";
 import type { OpenClawConfig } from "./runtime-api.js";
 
+type ConversationReadInvocationOrigin = NonNullable<
+  ChannelMessageActionContext["conversationReadOrigin"]
+>;
 type Result = { ok: true } | { ok: false; error: string };
 type ReactionParams = {
   cfg: OpenClawConfig;
   postId: string;
   emojiName: string;
   accountId?: string | null;
+  authorizedTarget?: string;
+  conversationReadOrigin?: ConversationReadInvocationOrigin;
   fetchImpl?: MattermostFetch;
 };
 type ReactionMutation = (client: MattermostClient, params: MutationPayload) => Promise<void>;
@@ -57,6 +66,8 @@ export async function addMattermostReaction(params: {
   postId: string;
   emojiName: string;
   accountId?: string | null;
+  authorizedTarget?: string;
+  conversationReadOrigin?: ConversationReadInvocationOrigin;
   fetchImpl?: MattermostFetch;
 }): Promise<Result> {
   return runMattermostReaction(params, {
@@ -70,12 +81,84 @@ export async function removeMattermostReaction(params: {
   postId: string;
   emojiName: string;
   accountId?: string | null;
+  authorizedTarget?: string;
+  conversationReadOrigin?: ConversationReadInvocationOrigin;
   fetchImpl?: MattermostFetch;
 }): Promise<Result> {
   return runMattermostReaction(params, {
     action: "remove",
     mutation: deleteReaction,
   });
+}
+
+type AuthorizedReactionTarget = { kind: "channel"; id: string } | { kind: "user"; id: string };
+
+function parseAuthorizedReactionTarget(rawTarget?: string): AuthorizedReactionTarget | null {
+  const normalized = rawTarget ? normalizeMattermostMessagingTarget(rawTarget) : undefined;
+  if (!normalized) {
+    return null;
+  }
+  if (normalized.startsWith("channel:")) {
+    const id = normalized.slice("channel:".length).trim();
+    return id ? { kind: "channel", id } : null;
+  }
+  if (normalized.startsWith("user:")) {
+    const id = normalized.slice("user:".length).trim();
+    return id ? { kind: "user", id } : null;
+  }
+  return null;
+}
+
+async function authorizeMattermostReactionResource(params: {
+  client: MattermostClient;
+  cacheKey: string;
+  postId: string;
+  authorizedTarget?: string;
+}): Promise<string | undefined> {
+  const target = parseAuthorizedReactionTarget(params.authorizedTarget);
+  if (!target) {
+    throw new Error(
+      "Mattermost delegated reactions require a canonical authorized conversation target.",
+    );
+  }
+
+  const post = await params.client.request<MattermostPost>(
+    `/posts/${encodeURIComponent(params.postId)}`,
+  );
+  const postChannelId = post.channel_id?.trim();
+  if (!postChannelId) {
+    throw new Error("Mattermost reaction post is missing its conversation binding.");
+  }
+  if (target.kind === "channel") {
+    if (postChannelId !== target.id) {
+      throw new Error("Mattermost reaction post belongs to a different conversation.");
+    }
+    return undefined;
+  }
+
+  const botUserId = await resolveBotUserId(params.client, params.cacheKey);
+  if (!botUserId) {
+    throw new Error("Mattermost reactions failed: could not resolve bot user id.");
+  }
+  const channel = await fetchMattermostChannel(params.client, postChannelId);
+  // Keep both slots: Mattermost permits self-DMs, so a Set would collapse the
+  // duplicate IDs and could authorize a different peer's conversation.
+  const participants =
+    channel.name
+      ?.split("__")
+      .map((entry) => entry.trim())
+      .filter(Boolean)
+      .toSorted() ?? [];
+  const authorizedParticipants = [botUserId, target.id].toSorted();
+  if (
+    channel.type !== "D" ||
+    participants.length !== 2 ||
+    participants[0] !== authorizedParticipants[0] ||
+    participants[1] !== authorizedParticipants[1]
+  ) {
+    throw new Error("Mattermost reaction post belongs to a different direct conversation.");
+  }
+  return botUserId;
 }
 
 async function runMattermostReaction(
@@ -100,12 +183,20 @@ async function runMattermostReaction(
   });
 
   const cacheKey = `${baseUrl}:${botToken}`;
-  const userId = await resolveBotUserId(client, cacheKey);
-  if (!userId) {
-    return { ok: false, error: "Mattermost reactions failed: could not resolve bot user id." };
-  }
-
   try {
+    const authorizedUserId =
+      params.conversationReadOrigin === "direct-operator"
+        ? undefined
+        : await authorizeMattermostReactionResource({
+            client,
+            cacheKey,
+            postId: params.postId,
+            authorizedTarget: params.authorizedTarget,
+          });
+    const userId = authorizedUserId ?? (await resolveBotUserId(client, cacheKey));
+    if (!userId) {
+      return { ok: false, error: "Mattermost reactions failed: could not resolve bot user id." };
+    }
     await options.mutation(client, {
       userId,
       postId: params.postId,

--- a/extensions/mattermost/src/mattermost/target-resolution.test.ts
+++ b/extensions/mattermost/src/mattermost/target-resolution.test.ts
@@ -146,6 +146,8 @@ describe("mattermost target resolution", () => {
 
   it("uses account resolution when token/base url are not passed", async () => {
     resolveMattermostAccount.mockReturnValue({
+      accountId: "acct-1",
+      enabled: true,
       baseUrl: "https://mm.example.com",
       botToken: "token",
     });
@@ -163,5 +165,26 @@ describe("mattermost target resolution", () => {
       cfg: { channels: { mattermost: {} } },
       accountId: "acct-1",
     });
+  });
+
+  it("rejects disabled accounts before cache or provider access", async () => {
+    resolveMattermostAccount.mockReturnValue({
+      accountId: "disabled",
+      enabled: false,
+      baseUrl: "https://mm.example.com",
+      botToken: "token",
+    });
+
+    await expect(
+      resolveMattermostOpaqueTarget({
+        input: "disabled12abcd1234abcd1234",
+        cfg: { channels: { mattermost: {} } },
+        accountId: "disabled",
+      }),
+    ).rejects.toThrow('Mattermost account "disabled" is disabled');
+
+    expect(normalizeMattermostBaseUrl).not.toHaveBeenCalled();
+    expect(createMattermostClient).not.toHaveBeenCalled();
+    expect(fetchMattermostUser).not.toHaveBeenCalled();
   });
 });

--- a/extensions/mattermost/src/mattermost/target-resolution.ts
+++ b/extensions/mattermost/src/mattermost/target-resolution.ts
@@ -143,6 +143,9 @@ export async function resolveMattermostOpaqueTarget(params: {
     params.cfg && (!params.token || !params.baseUrl)
       ? resolveMattermostAccount({ cfg: params.cfg, accountId: params.accountId })
       : null;
+  if (account && !account.enabled) {
+    throw new Error(`Mattermost account "${account.accountId}" is disabled`);
+  }
   const token = normalizeOptionalString(params.token) ?? normalizeOptionalString(account?.botToken);
   const baseUrl = normalizeMattermostBaseUrl(params.baseUrl ?? account?.baseUrl);
   if (!token || !baseUrl) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Mattermost reaction actions could use a post from a different conversation than the selected target. It also prevents disabled Mattermost accounts from entering target resolution or reaction execution.

## Why This Change Was Made

Mattermost now validates the selected post against the authorized channel before mutating it. Direct-message reactions additionally verify the exact bot/peer participant pair, including self-DMs, while direct operator behavior remains unchanged. Disabled accounts reject before provider target resolution.

## User Impact

Agent-selected Mattermost reactions now stay within the intended channel or direct conversation. Valid public/private channels, DMs, self-DMs, group DMs, threads, add/remove reactions, and direct operator workflows continue to work.

## Evidence

- Exact-head focused Blacksmith Testbox run: 84 tests passed.
- Exact-head live provider matrix: 720/720 scenarios passed across add/remove, message-ID aliases, authorization origins, account states, matching/crossed resources, and six conversation topologies.
- Mixed direct/delegated ordering, concurrency, restart, and resumed-session checks passed.
- Disabled opaque targets rejected with zero provider calls.
- Real inbound Mattermost event -> `openai/gpt-5.4` turn -> model-selected `message` tool -> provider-verified reaction and cleanup passed.
- Fresh autoreview found no actionable items; local ClawSweeper found no code findings and cleared its review.
- AI-assisted implementation and validation; the author reviewed the code and proof.
