### PR TITLE
fix(cron): detect configured Brave search during preflight

### DIFF
--- a/src/cron/isolated-agent/run.test-harness.ts
+++ b/src/cron/isolated-agent/run.test-harness.ts
@@ -95,9 +95,7 @@ export const getChannelPluginMock = createMock();
 export const retireSessionMcpRuntimeMock = createMock();
 export const callGatewayMock = createMock();
 export const ensureRuntimePluginsLoadedMock = createMock();
-export const getActiveSecretsRuntimeConfigSnapshotMock = createMock();
-export const listWebSearchProvidersMock = createMock();
-export const resolveWebSearchProviderIdMock = createMock();
+export const hasUsableWebSearchProviderMock = createMock();
 export const classifyEmbeddedAgentRunResultForModelFallbackMock = createMock();
 export const mergeEmbeddedAgentRunResultForModelFallbackExhaustionMock = createMock();
 
@@ -187,13 +185,8 @@ vi.mock("../../plugins/runtime-plugins.runtime.js", () => ({
   ensureRuntimePluginsLoaded: ensureRuntimePluginsLoadedMock,
 }));
 
-vi.mock("../../secrets/runtime-state.js", () => ({
-  getActiveSecretsRuntimeConfigSnapshot: getActiveSecretsRuntimeConfigSnapshotMock,
-}));
-
 vi.mock("../../web-search/runtime.js", () => ({
-  listWebSearchProviders: listWebSearchProvidersMock,
-  resolveWebSearchProviderId: resolveWebSearchProviderIdMock,
+  hasUsableWebSearchProvider: hasUsableWebSearchProviderMock,
 }));
 
 vi.mock("../../skills/runtime/cron-snapshot.runtime.js", () => ({
@@ -819,12 +812,11 @@ export function resetRunCronIsolatedAgentTurnHarness(): void {
   setSessionRuntimeModelMock.mockReturnValue(undefined);
   logWarnMock.mockReset();
   ensureRuntimePluginsLoadedMock.mockReset();
-  getActiveSecretsRuntimeConfigSnapshotMock.mockReset();
-  getActiveSecretsRuntimeConfigSnapshotMock.mockReturnValue(null);
-  listWebSearchProvidersMock.mockReset();
-  listWebSearchProvidersMock.mockReturnValue([{ id: "duckduckgo" }]);
-  resolveWebSearchProviderIdMock.mockReset();
-  resolveWebSearchProviderIdMock.mockReturnValue("duckduckgo");
+  hasUsableWebSearchProviderMock.mockReset();
+  hasUsableWebSearchProviderMock.mockImplementation(
+    (params?: { runtimeWebSearch?: { selectedProvider?: string } }) =>
+      Boolean(params?.runtimeWebSearch?.selectedProvider),
+  );
 }
 
 export function clearFastTestEnv(): string | undefined {

--- a/src/cron/isolated-agent/run.test-harness.ts
+++ b/src/cron/isolated-agent/run.test-harness.ts
@@ -95,6 +95,7 @@ export const getChannelPluginMock = createMock();
 export const retireSessionMcpRuntimeMock = createMock();
 export const callGatewayMock = createMock();
 export const ensureRuntimePluginsLoadedMock = createMock();
+export const getActiveSecretsRuntimeConfigSnapshotMock = createMock();
 export const listWebSearchProvidersMock = createMock();
 export const resolveWebSearchProviderIdMock = createMock();
 export const classifyEmbeddedAgentRunResultForModelFallbackMock = createMock();
@@ -184,6 +185,10 @@ vi.mock("./run-model-catalog.runtime.js", () => ({
 
 vi.mock("../../plugins/runtime-plugins.runtime.js", () => ({
   ensureRuntimePluginsLoaded: ensureRuntimePluginsLoadedMock,
+}));
+
+vi.mock("../../secrets/runtime-state.js", () => ({
+  getActiveSecretsRuntimeConfigSnapshot: getActiveSecretsRuntimeConfigSnapshotMock,
 }));
 
 vi.mock("../../web-search/runtime.js", () => ({
@@ -814,6 +819,8 @@ export function resetRunCronIsolatedAgentTurnHarness(): void {
   setSessionRuntimeModelMock.mockReturnValue(undefined);
   logWarnMock.mockReset();
   ensureRuntimePluginsLoadedMock.mockReset();
+  getActiveSecretsRuntimeConfigSnapshotMock.mockReset();
+  getActiveSecretsRuntimeConfigSnapshotMock.mockReturnValue(null);
   listWebSearchProvidersMock.mockReset();
   listWebSearchProvidersMock.mockReturnValue([{ id: "duckduckgo" }]);
   resolveWebSearchProviderIdMock.mockReset();

--- a/src/cron/isolated-agent/run.tools-allow.test.ts
+++ b/src/cron/isolated-agent/run.tools-allow.test.ts
@@ -2,6 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import "../../agents/test-helpers/fast-coding-tools.js";
 import {
+  getActiveSecretsRuntimeConfigSnapshotMock,
   listWebSearchProvidersMock,
   loadModelCatalogMock,
   loadRunCronIsolatedAgentTurn,
@@ -175,6 +176,32 @@ describe("runCronIsolatedAgentTurn toolsAllow passthrough", () => {
           toolName: "web_search",
         },
       ]);
+    },
+  );
+
+  it(
+    "uses active secrets config for plugin-owned web_search auto-detection",
+    { timeout: RUN_TOOLS_ALLOW_TIMEOUT_MS },
+    async () => {
+      const runtimeConfig = {
+        plugins: {
+          entries: {
+            brave: {
+              enabled: true,
+              config: { webSearch: { apiKey: "brave-test-key" } },
+            },
+          },
+        },
+      };
+      getActiveSecretsRuntimeConfigSnapshotMock.mockReturnValue({ config: runtimeConfig });
+
+      const result = await runCronIsolatedAgentTurn(makeParamsWithToolsAllow(["web_search"]));
+
+      expect(result.diagnostics).toBeUndefined();
+      expect(listWebSearchProvidersMock).toHaveBeenCalledWith({ config: runtimeConfig });
+      expect(resolveWebSearchProviderIdMock).toHaveBeenCalledWith(
+        expect.objectContaining({ config: runtimeConfig }),
+      );
     },
   );
 

--- a/src/cron/isolated-agent/run.tools-allow.test.ts
+++ b/src/cron/isolated-agent/run.tools-allow.test.ts
@@ -2,14 +2,16 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import "../../agents/test-helpers/fast-coding-tools.js";
 import {
-  getActiveSecretsRuntimeConfigSnapshotMock,
-  listWebSearchProvidersMock,
+  clearActiveRuntimeWebToolsMetadata,
+  setActiveRuntimeWebToolsMetadata,
+} from "../../secrets/runtime-web-tools-state.js";
+import {
+  hasUsableWebSearchProviderMock,
   loadModelCatalogMock,
   loadRunCronIsolatedAgentTurn,
   resolveConfiguredModelRefMock,
   resetRunCronIsolatedAgentTurnHarness,
   resolveDeliveryTargetMock,
-  resolveWebSearchProviderIdMock,
   runEmbeddedAgentMock,
   runWithModelFallbackMock,
 } from "./run.test-harness.js";
@@ -94,6 +96,7 @@ describe("runCronIsolatedAgentTurn toolsAllow passthrough", () => {
     previousFastTestEnv = process.env.OPENCLAW_TEST_FAST;
     vi.stubEnv("OPENCLAW_TEST_FAST", "1");
     resetRunCronIsolatedAgentTurnHarness();
+    clearActiveRuntimeWebToolsMetadata();
     resolveDeliveryTargetMock.mockResolvedValue({
       channel: "forum",
       to: "123",
@@ -107,6 +110,7 @@ describe("runCronIsolatedAgentTurn toolsAllow passthrough", () => {
   });
 
   afterEach(() => {
+    clearActiveRuntimeWebToolsMetadata();
     if (previousFastTestEnv == null) {
       vi.unstubAllEnvs();
       delete process.env.OPENCLAW_TEST_FAST;
@@ -157,9 +161,6 @@ describe("runCronIsolatedAgentTurn toolsAllow passthrough", () => {
     "adds cron diagnostics when web_search is allowed without a selected provider",
     { timeout: RUN_TOOLS_ALLOW_TIMEOUT_MS },
     async () => {
-      listWebSearchProvidersMock.mockReturnValue([{ id: "duckduckgo" }]);
-      resolveWebSearchProviderIdMock.mockReturnValue("");
-
       const result = await runCronIsolatedAgentTurn(makeParamsWithToolsAllow(["web_search"]));
 
       expect(result.status).toBe("ok");
@@ -180,27 +181,45 @@ describe("runCronIsolatedAgentTurn toolsAllow passthrough", () => {
   );
 
   it(
-    "uses active secrets config for plugin-owned web_search auto-detection",
+    "uses the prepared provider selected from a plugin-scoped web search key",
     { timeout: RUN_TOOLS_ALLOW_TIMEOUT_MS },
     async () => {
-      const runtimeConfig = {
+      setActiveRuntimeWebToolsMetadata({
+        search: {
+          providerSource: "auto-detect",
+          selectedProvider: "brave",
+          selectedProviderKeySource: "config",
+          diagnostics: [],
+        },
+        fetch: { providerSource: "none", diagnostics: [] },
+        diagnostics: [],
+      });
+      const cfg = {
         plugins: {
           entries: {
             brave: {
               enabled: true,
-              config: { webSearch: { apiKey: "brave-test-key" } },
+              config: {
+                webSearch: { apiKey: "token-oversized" },
+              },
             },
           },
         },
       };
-      getActiveSecretsRuntimeConfigSnapshotMock.mockReturnValue({ config: runtimeConfig });
 
-      const result = await runCronIsolatedAgentTurn(makeParamsWithToolsAllow(["web_search"]));
+      const result = await runCronIsolatedAgentTurn({
+        ...makeParamsWithToolsAllow(["web_search"]),
+        cfg,
+      });
 
+      expect(result.status).toBe("ok");
       expect(result.diagnostics).toBeUndefined();
-      expect(listWebSearchProvidersMock).toHaveBeenCalledWith({ config: runtimeConfig });
-      expect(resolveWebSearchProviderIdMock).toHaveBeenCalledWith(
-        expect.objectContaining({ config: runtimeConfig }),
+      expect(hasUsableWebSearchProviderMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          agentDir: "/tmp/agent-dir",
+          preferRuntimeProviders: true,
+          runtimeWebSearch: expect.objectContaining({ selectedProvider: "brave" }),
+        }),
       );
     },
   );
@@ -209,8 +228,6 @@ describe("runCronIsolatedAgentTurn toolsAllow passthrough", () => {
     "does not warn for default-derived toolsAllow that includes web_search",
     { timeout: RUN_TOOLS_ALLOW_TIMEOUT_MS },
     async () => {
-      listWebSearchProvidersMock.mockReturnValue([]);
-
       const result = await runCronIsolatedAgentTurn(
         makeParamsWithDefaultToolsAllow(["web_search"]),
       );
@@ -224,7 +241,6 @@ describe("runCronIsolatedAgentTurn toolsAllow passthrough", () => {
     "does not warn when native web_search suppresses the managed provider tool",
     { timeout: RUN_TOOLS_ALLOW_TIMEOUT_MS },
     async () => {
-      listWebSearchProvidersMock.mockReturnValue([]);
       resolveConfiguredModelRefMock.mockReturnValue({
         provider: "gateway",
         model: "gpt-5.5",
@@ -264,8 +280,6 @@ describe("runCronIsolatedAgentTurn toolsAllow passthrough", () => {
     "keeps web_search provider diagnostics when the run aborts",
     { timeout: RUN_TOOLS_ALLOW_TIMEOUT_MS },
     async () => {
-      listWebSearchProvidersMock.mockReturnValue([]);
-      resolveWebSearchProviderIdMock.mockReturnValue("");
       runWithModelFallbackMock.mockResolvedValueOnce({
         result: {
           payloads: [],

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -38,7 +38,6 @@ import { createDiagnosticMessageLifecycle } from "../../logging/message-lifecycl
 import { isCommandLaneTaskTimeoutError } from "../../process/command-queue.js";
 import { CommandLane } from "../../process/lanes.js";
 import { isCronSessionKey } from "../../routing/session-key.js";
-import { getActiveSecretsRuntimeConfigSnapshot } from "../../secrets/runtime-state.js";
 import {
   AGENT_HARNESS_SESSION_ID_LOCKED_MESSAGE,
   AGENT_HARNESS_SESSION_KEY_RESERVED_MESSAGE,
@@ -156,6 +155,9 @@ const runtimePluginsLoader = createLazyImportLoader(
 const codexNativeWebSearchLoader = createLazyImportLoader(
   () => import("../../agents/codex-native-web-search.js"),
 );
+const webToolRuntimeContextLoader = createLazyImportLoader(
+  () => import("../../agents/tools/web-tool-runtime-context.js"),
+);
 const webSearchRuntimeLoader = createLazyImportLoader(() => import("../../web-search/runtime.js"));
 
 async function loadSessionAccessorRuntime() {
@@ -196,6 +198,10 @@ async function loadRuntimePlugins() {
 
 async function loadCodexNativeWebSearch() {
   return await codexNativeWebSearchLoader.load();
+}
+
+async function loadWebToolRuntimeContext() {
+  return await webToolRuntimeContextLoader.load();
 }
 
 async function loadWebSearchRuntime() {
@@ -390,24 +396,27 @@ async function createCronToolsAllowPreflightDiagnostics(params: {
     ) {
       return undefined;
     }
-    const { listWebSearchProviders, resolveWebSearchProviderId } = await loadWebSearchRuntime();
-    // Match agent-side web_search: plugin-owned credentials live in the active
-    // secrets snapshot and may be absent from the general runtime config.
-    const webSearchConfig = getActiveSecretsRuntimeConfigSnapshot()?.config ?? params.cfg;
-    const webSearchProviders = listWebSearchProviders({ config: webSearchConfig });
+    const { resolveWebSearchToolRuntimeContext } = await loadWebToolRuntimeContext();
+    const { config, preferRuntimeProviders, runtimeWebSearch } = resolveWebSearchToolRuntimeContext(
+      {
+        config: params.cfg,
+        lateBindRuntimeConfig: true,
+      },
+    );
+    const { hasUsableWebSearchProvider } = await loadWebSearchRuntime();
+    const hasWebSearchProvider = hasUsableWebSearchProvider({
+      config,
+      agentDir: params.agentDir,
+      runtimeWebSearch,
+      preferRuntimeProviders,
+    });
     return createCronRunDiagnosticsFromMissingWebSearchProvider({
       toolsAllow,
-      hasWebSearchProvider: Boolean(
-        resolveWebSearchProviderId({
-          config: webSearchConfig,
-          agentDir: params.agentDir,
-          providers: webSearchProviders,
-        }),
-      ),
+      hasWebSearchProvider,
     });
   } catch (error) {
     logWarn(
-      `[cron:${params.jobId}] Failed to inspect web_search providers for toolsAllow diagnostics: ${String(error)}`,
+      `[cron:${params.jobId}] Failed to inspect web_search provider state for toolsAllow diagnostics: ${String(error)}`,
     );
     return undefined;
   }

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -38,6 +38,7 @@ import { createDiagnosticMessageLifecycle } from "../../logging/message-lifecycl
 import { isCommandLaneTaskTimeoutError } from "../../process/command-queue.js";
 import { CommandLane } from "../../process/lanes.js";
 import { isCronSessionKey } from "../../routing/session-key.js";
+import { getActiveSecretsRuntimeConfigSnapshot } from "../../secrets/runtime-state.js";
 import {
   AGENT_HARNESS_SESSION_ID_LOCKED_MESSAGE,
   AGENT_HARNESS_SESSION_KEY_RESERVED_MESSAGE,
@@ -390,12 +391,15 @@ async function createCronToolsAllowPreflightDiagnostics(params: {
       return undefined;
     }
     const { listWebSearchProviders, resolveWebSearchProviderId } = await loadWebSearchRuntime();
-    const webSearchProviders = listWebSearchProviders({ config: params.cfg });
+    // Match agent-side web_search: plugin-owned credentials live in the active
+    // secrets snapshot and may be absent from the general runtime config.
+    const webSearchConfig = getActiveSecretsRuntimeConfigSnapshot()?.config ?? params.cfg;
+    const webSearchProviders = listWebSearchProviders({ config: webSearchConfig });
     return createCronRunDiagnosticsFromMissingWebSearchProvider({
       toolsAllow,
       hasWebSearchProvider: Boolean(
         resolveWebSearchProviderId({
-          config: params.cfg,
+          config: webSearchConfig,
           agentDir: params.agentDir,
           providers: webSearchProviders,
         }),

--- a/src/web-search/runtime.test.ts
+++ b/src/web-search/runtime.test.ts
@@ -165,6 +165,7 @@ function createDuckDuckGoSearchProvider(
 }
 
 describe("web search runtime", () => {
+  let hasUsableWebSearchProvider: typeof import("./runtime.js").hasUsableWebSearchProvider;
   let runWebSearch: typeof import("./runtime.js").runWebSearch;
   let activateSecretsRuntimeSnapshot: typeof import("../secrets/runtime.js").activateSecretsRuntimeSnapshot;
   let clearSecretsRuntimeSnapshot: typeof import("../secrets/runtime.js").clearSecretsRuntimeSnapshot;
@@ -172,7 +173,7 @@ describe("web search runtime", () => {
   const tempDirs: string[] = [];
 
   beforeAll(async () => {
-    ({ runWebSearch } = await import("./runtime.js"));
+    ({ hasUsableWebSearchProvider, runWebSearch } = await import("./runtime.js"));
     ({ activateSecretsRuntimeSnapshot, clearSecretsRuntimeSnapshot } =
       await import("../secrets/runtime.js"));
     ({ setRuntimeConfigSnapshot } = await import("../config/config.js"));
@@ -220,6 +221,23 @@ describe("web search runtime", () => {
       provider: "custom",
       result: { query: "hello", ok: true },
     });
+  });
+
+  it("accepts the prepared provider selection without rediscovering providers", () => {
+    expect(
+      hasUsableWebSearchProvider({
+        config: {},
+        runtimeWebSearch: {
+          providerSource: "auto-detect",
+          selectedProvider: "brave",
+          selectedProviderKeySource: "config",
+          diagnostics: [],
+        },
+        preferRuntimeProviders: true,
+      }),
+    ).toBe(true);
+    expect(resolveRuntimeWebSearchProvidersMock).not.toHaveBeenCalled();
+    expect(resolvePluginWebSearchProvidersMock).not.toHaveBeenCalled();
   });
 
   it("passes the run abort signal to provider execution", async () => {
@@ -474,18 +492,27 @@ describe("web search runtime", () => {
       provider,
       createDuckDuckGoSearchProvider(),
     ]);
+    const config = {
+      agents: {
+        list: [
+          { id: "main", default: true, agentDir: defaultAgentDir },
+          { id: "side", agentDir: activeAgentDir },
+        ],
+      },
+    } satisfies OpenClawConfig;
+
+    expect(
+      hasUsableWebSearchProvider({
+        agentDir: activeAgentDir,
+        config,
+        preferRuntimeProviders: true,
+      }),
+    ).toBe(true);
 
     await expect(
       runWebSearch({
         agentDir: activeAgentDir,
-        config: {
-          agents: {
-            list: [
-              { id: "main", default: true, agentDir: defaultAgentDir },
-              { id: "side", agentDir: activeAgentDir },
-            ],
-          },
-        },
+        config,
         args: { query: "active-agent oauth-backed web search" },
       }),
     ).resolves.toEqual({

--- a/src/web-search/runtime.ts
+++ b/src/web-search/runtime.ts
@@ -406,6 +406,16 @@ function resolveWebSearchCandidates(
   return orderedProviders;
 }
 
+/** Reports whether web_search can use the prepared selection or resolve an agent-scoped provider. */
+export function hasUsableWebSearchProvider(options?: ResolveWebSearchDefinitionParams): boolean {
+  // Prepared metadata owns config/secret selection. Candidate resolution remains necessary for
+  // credentials scoped to the active agent, such as provider auth profiles.
+  if (normalizeOptionalLowercaseString(options?.runtimeWebSearch?.selectedProvider)) {
+    return true;
+  }
+  return resolveWebSearchCandidates(options).length > 0;
+}
+
 function hasExplicitWebSearchSelection(params: {
   search?: WebSearchConfig;
   runtimeWebSearch?: RuntimeWebSearchMetadata;


### PR DESCRIPTION
Closes #108598

## What Problem This Solves

Fixes a false missing-provider diagnostic for isolated cron jobs that allow `web_search` when Brave is auto-detected from `plugins.entries.brave.config.webSearch.apiKey`.

## Why This Change Was Made

Cron preflight now consumes the prepared web-search provider selection through the same late-bound runtime context as the agent tool. When no prepared provider exists, it reuses the web-search runtime candidate path with the target agent directory, preserving agent-scoped auth such as xAI OAuth.

This removes raw-config provider selection from cron while keeping one canonical selection path for config secrets and agent auth.

## User Impact

Operators can run isolated cron jobs with auto-detected Brave search without a false warning. Non-default agents using provider auth profiles keep the same provider availability behavior as the actual `web_search` tool.

## Evidence

- `node scripts/run-vitest.mjs src/cron/isolated-agent/run.tools-allow.test.ts src/web-search/runtime.test.ts`: 41 tests passed.
- `node scripts/run-vitest.mjs src/agents/tools/web-tool-runtime-context.test.ts src/secrets/runtime-web-tools.test.ts`: 50 tests passed.
- Fresh autoreview after the agent-scoped auth fix: no actionable findings.
- `git diff --check`: passed.
