### PR TITLE
fix(message): reject invalid read targets without fallback

### DIFF
--- a/extensions/discord/src/actions/runtime.messaging.messages.ts
+++ b/extensions/discord/src/actions/runtime.messaging.messages.ts
@@ -112,6 +112,7 @@ export async function handleDiscordMessageManagementAction(ctx: DiscordMessaging
       );
       return jsonResult({
         ok: true,
+        channelId,
         messages: messages.map((message) => ctx.normalizeMessage(message)),
       });
     }

--- a/extensions/discord/src/actions/runtime.test.ts
+++ b/extensions/discord/src/actions/runtime.test.ts
@@ -1248,9 +1248,11 @@ describe("handleDiscordMessagingAction", () => {
       enableAllActions,
     );
     const payload = result.details as {
+      channelId?: string;
       messages: Array<{ timestampMs?: number; timestampUtc?: string }>;
     };
 
+    expect(payload.channelId).toBe("C1");
     const expectedMs = Date.parse("2026-01-15T10:00:00.000Z");
     const message = expectDefined(payload.messages[0], "Discord message result");
     expect(message.timestampMs).toBe(expectedMs);

--- a/extensions/matrix/src/tool-actions.test.ts
+++ b/extensions/matrix/src/tool-actions.test.ts
@@ -8,6 +8,7 @@ const mocks = vi.hoisted(() => ({
   reactMatrixMessage: vi.fn(),
   editMatrixMessage: vi.fn(),
   deleteMatrixMessage: vi.fn(),
+  readMatrixMessages: vi.fn(),
   listMatrixReactions: vi.fn(),
   removeMatrixReactions: vi.fn(),
   sendMatrixMessage: vi.fn(),
@@ -36,6 +37,7 @@ vi.mock("./matrix/actions.js", () => {
     unpinMatrixMessage: mocks.unpinMatrixMessage,
     listMatrixPins: mocks.listMatrixPins,
     removeMatrixReactions: mocks.removeMatrixReactions,
+    readMatrixMessages: mocks.readMatrixMessages,
     sendMatrixMessage: mocks.sendMatrixMessage,
     voteMatrixPoll: mocks.voteMatrixPoll,
   };
@@ -77,6 +79,10 @@ describe("handleMatrixAction pollVote", () => {
     mocks.pinMatrixMessage.mockResolvedValue({ pinned: ["$existing", "$pin"] });
     mocks.unpinMatrixMessage.mockResolvedValue({ pinned: ["$existing"] });
     mocks.removeMatrixReactions.mockResolvedValue({ removed: 1 });
+    mocks.readMatrixMessages.mockResolvedValue({
+      messages: [{ eventId: "$message" }],
+      nextBatch: "next",
+    });
     mocks.sendMatrixMessage.mockResolvedValue({
       messageId: "$sent",
       roomId: "!room:example",
@@ -364,6 +370,37 @@ describe("handleMatrixAction pollVote", () => {
       mediaLocalRoots: ["/tmp/openclaw-matrix-test"],
       replyToId: undefined,
       threadId: "$thread",
+    });
+  });
+
+  it("returns the authorized room and thread with message reads", async () => {
+    const cfg = { channels: { matrix: { actions: { messages: true } } } } as CoreConfig;
+    const result = await handleMatrixAction(
+      {
+        action: "readMessages",
+        accountId: "ops",
+        roomId: "room:!room:example",
+        threadId: "$thread",
+        limit: 5,
+      },
+      cfg,
+    );
+
+    expect(mocks.readMatrixMessages).toHaveBeenCalledWith("!room:example", {
+      cfg,
+      accountId: "ops",
+      client: mocks.matrixClient,
+      limit: 5,
+      before: undefined,
+      after: undefined,
+      threadId: "$thread",
+    });
+    expect(result.details).toEqual({
+      ok: true,
+      roomId: "!room:example",
+      threadId: "$thread",
+      messages: [{ eventId: "$message" }],
+      nextBatch: "next",
     });
   });
 

--- a/extensions/matrix/src/tool-actions.ts
+++ b/extensions/matrix/src/tool-actions.ts
@@ -310,7 +310,7 @@ export async function handleMatrixAction(
         const after = readStringParam(params, "after");
         const threadId = readStringParam(params, "threadId");
         const result = await withReadTarget(roomId, async (target) => {
-          return await readMatrixMessages(target.roomId, {
+          const messages = await readMatrixMessages(target.roomId, {
             limit: limit ?? undefined,
             before: before ?? undefined,
             after: after ?? undefined,
@@ -318,6 +318,11 @@ export async function handleMatrixAction(
             ...clientOpts,
             client: target.client,
           });
+          return {
+            ...messages,
+            roomId: target.roomId,
+            ...(threadId ? { threadId } : {}),
+          };
         });
         return jsonResult({ ok: true, ...result });
       }

--- a/extensions/slack/src/action-runtime.test.ts
+++ b/extensions/slack/src/action-runtime.test.ts
@@ -1231,6 +1231,10 @@ describe("handleSlackAction", () => {
     const details = requireDetails(result);
     expect(details.ok).toBe(true);
     expect(details.hasMore).toBe(false);
+    expectRecordFields(details, {
+      channelId: "C1",
+    });
+    expect(details).not.toHaveProperty("threadId");
     const messages = requireArray(details.messages, "read messages");
     expectRecordFields(requireRecord(messages[0], "first message"), {
       ts: "1712345678.123456",
@@ -1242,10 +1246,15 @@ describe("handleSlackAction", () => {
     readSlackMessages.mockResolvedValueOnce({ messages: [], hasMore: false });
 
     const cfg = slackConfig();
-    await handleSlackAction(
+    const result = await handleSlackAction(
       { action: "readMessages", channelId: "C1", threadId: "1712345678.123456" },
       cfg,
     );
+
+    expectRecordFields(requireDetails(result), {
+      channelId: "C1",
+      threadId: "1712345678.123456",
+    });
 
     expect(requireMockArg(readSlackMessages, "readSlackMessages", 0, 0)).toBe("C1");
     expectRecordFields(requireRecordArg(readSlackMessages, "readSlackMessages", 0, 1), {

--- a/extensions/slack/src/action-runtime.ts
+++ b/extensions/slack/src/action-runtime.ts
@@ -801,7 +801,13 @@ export async function handleSlackAction(
             (message as { ts?: unknown }).ts,
           ),
         );
-        return jsonResult({ ok: true, messages, hasMore: result.hasMore });
+        return jsonResult({
+          ok: true,
+          channelId,
+          ...(threadId ? { threadId } : {}),
+          messages,
+          hasMore: result.hasMore,
+        });
       }
       case "downloadFile": {
         const fileId = readStringParam(params, "fileId", { required: true });

--- a/src/infra/outbound/channel-selection.test.ts
+++ b/src/infra/outbound/channel-selection.test.ts
@@ -282,9 +282,32 @@ describe("resolveMessageChannelSelection", () => {
         cfg: {} as never,
         channel: "channel:C123",
         fallbackChannel: "beta",
-        rejectUnknownExplicitChannel: true,
+        requireExplicitChannelAvailable: true,
       }),
     ).rejects.toThrow("Unknown channel: channel:c123");
+  });
+
+  it("rejects an explicit unavailable channel instead of using the tool context", async () => {
+    const cfg = {} as never;
+    mocks.resolveOutboundChannelPlugin.mockImplementation(({ channel }: { channel: string }) =>
+      channel === "beta" ? { id: "beta" } : undefined,
+    );
+
+    await expect(
+      expectResolvedSelection({
+        cfg,
+        channel: "alpha",
+        fallbackChannel: "beta",
+        requireExplicitChannelAvailable: true,
+      }),
+    ).rejects.toThrow("Channel is unavailable: alpha");
+
+    expect(mocks.resolveOutboundChannelPlugin).toHaveBeenCalledTimes(1);
+    expect(mocks.resolveOutboundChannelPlugin).toHaveBeenCalledWith({
+      channel: "alpha",
+      cfg,
+      allowBootstrap: true,
+    });
   });
 
   it.each([

--- a/src/infra/outbound/channel-selection.test.ts
+++ b/src/infra/outbound/channel-selection.test.ts
@@ -199,14 +199,6 @@ describe("resolveMessageChannelSelection", () => {
       },
     },
     {
-      params: { cfg: {} as never, channel: "channel:C123", fallbackChannel: "beta" },
-      expected: {
-        channel: "beta",
-        configured: [],
-        source: "tool-context-fallback",
-      },
-    },
-    {
       params: { cfg: {} as never, fallbackChannel: "gamma" },
       expected: {
         channel: "gamma",
@@ -274,6 +266,16 @@ describe("resolveMessageChannelSelection", () => {
       cfg,
       allowBootstrap: true,
     });
+  });
+
+  it("rejects an explicit unknown channel instead of using the tool context", async () => {
+    await expect(
+      expectResolvedSelection({
+        cfg: {} as never,
+        channel: "channel:C123",
+        fallbackChannel: "beta",
+      }),
+    ).rejects.toThrow("Unknown channel: channel:c123");
   });
 
   it.each([

--- a/src/infra/outbound/channel-selection.test.ts
+++ b/src/infra/outbound/channel-selection.test.ts
@@ -199,6 +199,14 @@ describe("resolveMessageChannelSelection", () => {
       },
     },
     {
+      params: { cfg: {} as never, channel: "channel:C123", fallbackChannel: "beta" },
+      expected: {
+        channel: "beta",
+        configured: [],
+        source: "tool-context-fallback",
+      },
+    },
+    {
       params: { cfg: {} as never, fallbackChannel: "gamma" },
       expected: {
         channel: "gamma",
@@ -274,6 +282,7 @@ describe("resolveMessageChannelSelection", () => {
         cfg: {} as never,
         channel: "channel:C123",
         fallbackChannel: "beta",
+        rejectUnknownExplicitChannel: true,
       }),
     ).rejects.toThrow("Unknown channel: channel:c123");
   });

--- a/src/infra/outbound/channel-selection.ts
+++ b/src/infra/outbound/channel-selection.ts
@@ -226,6 +226,9 @@ export async function resolveMessageChannelSelection(params: {
 }> {
   const normalized = normalizeMessageChannel(params.channel);
   if (normalized) {
+    if (!isKnownChannel(normalized)) {
+      throw new Error(`Unknown channel: ${normalized}`);
+    }
     const availableExplicit = resolveAvailableKnownChannel({
       cfg: params.cfg,
       value: normalized,
@@ -241,9 +244,6 @@ export async function resolveMessageChannelSelection(params: {
           configured: [],
           source: "tool-context-fallback",
         };
-      }
-      if (!isKnownChannel(normalized)) {
-        throw new Error(`Unknown channel: ${normalized}`);
       }
       const repairHint = isConfiguredChannel(params.cfg, normalized)
         ? resolveMissingOfficialExternalChannelPluginRepairHint({

--- a/src/infra/outbound/channel-selection.ts
+++ b/src/infra/outbound/channel-selection.ts
@@ -219,7 +219,7 @@ export async function resolveMessageChannelSelection(params: {
   cfg: OpenClawConfig;
   channel?: string | null;
   fallbackChannel?: string | null;
-  rejectUnknownExplicitChannel?: boolean;
+  requireExplicitChannelAvailable?: boolean;
 }): Promise<{
   channel: MessageChannelId;
   configured: MessageChannelId[];
@@ -227,7 +227,7 @@ export async function resolveMessageChannelSelection(params: {
 }> {
   const normalized = normalizeMessageChannel(params.channel);
   if (normalized) {
-    if (params.rejectUnknownExplicitChannel && !isKnownChannel(normalized)) {
+    if (params.requireExplicitChannelAvailable && !isKnownChannel(normalized)) {
       throw new Error(`Unknown channel: ${normalized}`);
     }
     const availableExplicit = resolveAvailableKnownChannel({
@@ -235,16 +235,18 @@ export async function resolveMessageChannelSelection(params: {
       value: normalized,
     });
     if (!availableExplicit) {
-      const fallback = resolveAvailableKnownChannel({
-        cfg: params.cfg,
-        value: params.fallbackChannel,
-      });
-      if (fallback) {
-        return {
-          channel: fallback,
-          configured: [],
-          source: "tool-context-fallback",
-        };
+      if (!params.requireExplicitChannelAvailable) {
+        const fallback = resolveAvailableKnownChannel({
+          cfg: params.cfg,
+          value: params.fallbackChannel,
+        });
+        if (fallback) {
+          return {
+            channel: fallback,
+            configured: [],
+            source: "tool-context-fallback",
+          };
+        }
       }
       if (!isKnownChannel(normalized)) {
         throw new Error(`Unknown channel: ${normalized}`);

--- a/src/infra/outbound/channel-selection.ts
+++ b/src/infra/outbound/channel-selection.ts
@@ -219,6 +219,7 @@ export async function resolveMessageChannelSelection(params: {
   cfg: OpenClawConfig;
   channel?: string | null;
   fallbackChannel?: string | null;
+  rejectUnknownExplicitChannel?: boolean;
 }): Promise<{
   channel: MessageChannelId;
   configured: MessageChannelId[];
@@ -226,7 +227,7 @@ export async function resolveMessageChannelSelection(params: {
 }> {
   const normalized = normalizeMessageChannel(params.channel);
   if (normalized) {
-    if (!isKnownChannel(normalized)) {
+    if (params.rejectUnknownExplicitChannel && !isKnownChannel(normalized)) {
       throw new Error(`Unknown channel: ${normalized}`);
     }
     const availableExplicit = resolveAvailableKnownChannel({
@@ -244,6 +245,9 @@ export async function resolveMessageChannelSelection(params: {
           configured: [],
           source: "tool-context-fallback",
         };
+      }
+      if (!isKnownChannel(normalized)) {
+        throw new Error(`Unknown channel: ${normalized}`);
       }
       const repairHint = isConfiguredChannel(params.cfg, normalized)
         ? resolveMissingOfficialExternalChannelPluginRepairHint({

--- a/src/infra/outbound/message-action-normalization.test.ts
+++ b/src/infra/outbound/message-action-normalization.test.ts
@@ -302,11 +302,15 @@ describe("normalizeMessageActionInput", () => {
     ).toThrow(/requires a target/);
   });
 
-  it("does not replace read targets with the current conversation", () => {
+  it.each([
+    { name: "a nonempty targets array", targets: ["C_TARGET"] },
+    { name: "an empty targets array", targets: [] },
+    { name: "a malformed targets value", targets: "C_TARGET" },
+  ])("does not replace $name with the current conversation", ({ targets }) => {
     expect(() =>
       normalizeMessageActionInput({
         action: "read",
-        args: { targets: ["C_TARGET"] },
+        args: { targets },
         toolContext: {
           currentChannelId: "C_CURRENT",
           currentChannelProvider: "workspace",

--- a/src/infra/outbound/message-action-normalization.test.ts
+++ b/src/infra/outbound/message-action-normalization.test.ts
@@ -302,6 +302,19 @@ describe("normalizeMessageActionInput", () => {
     ).toThrow(/requires a target/);
   });
 
+  it("does not replace read targets with the current conversation", () => {
+    expect(() =>
+      normalizeMessageActionInput({
+        action: "read",
+        args: { targets: ["C_TARGET"] },
+        toolContext: {
+          currentChannelId: "C_CURRENT",
+          currentChannelProvider: "workspace",
+        },
+      }),
+    ).toThrow(/requires a target/);
+  });
+
   it.each([
     { action: "react" as const, args: { channel: "imessage", messageId: "msg_123" } },
     { action: "poll-vote" as const, args: { channel: "imessage", pollId: "poll_123" } },

--- a/src/infra/outbound/message-action-normalization.ts
+++ b/src/infra/outbound/message-action-normalization.ts
@@ -32,9 +32,7 @@ export function normalizeMessageActionInput(params: {
     explicitChannel || normalizeMessageChannel(toolContext?.currentChannelProvider) || "";
 
   const explicitTarget = normalizeOptionalString(normalizedArgs.target) ?? "";
-  const hasExplicitTargets =
-    Array.isArray(normalizedArgs.targets) &&
-    normalizedArgs.targets.some((value) => Boolean(normalizeOptionalString(value)));
+  const hasExplicitTargets = Object.hasOwn(normalizedArgs, "targets");
   const hasLegacyTargetFields =
     typeof normalizedArgs.to === "string" || typeof normalizedArgs.channelId === "string";
   const hasLegacyTarget =

--- a/src/infra/outbound/message-action-normalization.ts
+++ b/src/infra/outbound/message-action-normalization.ts
@@ -32,6 +32,9 @@ export function normalizeMessageActionInput(params: {
     explicitChannel || normalizeMessageChannel(toolContext?.currentChannelProvider) || "";
 
   const explicitTarget = normalizeOptionalString(normalizedArgs.target) ?? "";
+  const hasExplicitTargets =
+    Array.isArray(normalizedArgs.targets) &&
+    normalizedArgs.targets.some((value) => Boolean(normalizeOptionalString(value)));
   const hasLegacyTargetFields =
     typeof normalizedArgs.to === "string" || typeof normalizedArgs.channelId === "string";
   const hasLegacyTarget =
@@ -69,6 +72,7 @@ export function normalizeMessageActionInput(params: {
 
   if (
     !explicitTarget &&
+    !hasExplicitTargets &&
     !hasLegacyTarget &&
     !deliveryAliasTarget &&
     actionRequiresTarget(action) &&

--- a/src/infra/outbound/message-action-runner.context.test.ts
+++ b/src/infra/outbound/message-action-runner.context.test.ts
@@ -1,6 +1,7 @@
 // Covers message-action cross-context policy, markers, and presentation
 // decoration behavior.
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { jsonResult } from "../../agents/tools/common.js";
 import type { ChannelPlugin } from "../../channels/plugins/types.public.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { setActivePluginRegistry } from "../../plugins/runtime.js";
@@ -8,6 +9,7 @@ import {
   createChannelTestPluginBase,
   createTestRegistry,
 } from "../../test-utils/channel-plugins.js";
+import { runMessageAction } from "./message-action-runner.js";
 import {
   directChatConfig,
   directChatTestPlugin,
@@ -18,6 +20,16 @@ import {
   workspaceConfig,
   workspaceTestPlugin,
 } from "./message-action-runner.test-helpers.js";
+
+const handleWorkspaceAction = vi.fn(async () => jsonResult({ ok: true }));
+
+const readWorkspaceTestPlugin: ChannelPlugin = {
+  ...workspaceTestPlugin,
+  actions: {
+    describeMessageTool: () => ({ actions: ["read"] }),
+    handleAction: handleWorkspaceAction,
+  },
+};
 
 const localChatTestPlugin: ChannelPlugin = {
   ...createChannelTestPluginBase({
@@ -87,7 +99,7 @@ describe("runMessageAction context isolation", () => {
         {
           pluginId: "workspace",
           source: "test",
-          plugin: workspaceTestPlugin,
+          plugin: readWorkspaceTestPlugin,
         },
         {
           pluginId: "directchat",
@@ -111,6 +123,37 @@ describe("runMessageAction context isolation", () => {
         },
       ]),
     );
+    handleWorkspaceAction.mockClear();
+  });
+
+  it.each([
+    {
+      name: "a channel id passed as channel",
+      actionParams: { channel: "C_TARGET" },
+      expectedError: "Unknown channel: c_target",
+    },
+    {
+      name: "targets passed instead of target",
+      actionParams: { targets: ["C_TARGET"] },
+      expectedError: "Action read requires a target.",
+    },
+  ])("rejects read with $name before plugin dispatch", async ({ actionParams, expectedError }) => {
+    await expect(
+      runMessageAction({
+        cfg: workspaceConfig,
+        action: "read",
+        params: actionParams,
+        defaultAccountId: "default",
+        requesterAccountId: "default",
+        conversationReadOrigin: "delegated",
+        toolContext: {
+          currentChannelId: "C_CURRENT",
+          currentChannelProvider: "workspace",
+        },
+        dryRun: false,
+      }),
+    ).rejects.toThrow(expectedError);
+    expect(handleWorkspaceAction).not.toHaveBeenCalled();
   });
 
   afterEach(() => {

--- a/src/infra/outbound/message-action-runner.context.test.ts
+++ b/src/infra/outbound/message-action-runner.context.test.ts
@@ -2,7 +2,10 @@
 // decoration behavior.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { jsonResult } from "../../agents/tools/common.js";
-import type { ChannelPlugin } from "../../channels/plugins/types.public.js";
+import type {
+  ChannelMessageActionContext,
+  ChannelPlugin,
+} from "../../channels/plugins/types.public.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { setActivePluginRegistry } from "../../plugins/runtime.js";
 import {
@@ -21,7 +24,9 @@ import {
   workspaceTestPlugin,
 } from "./message-action-runner.test-helpers.js";
 
-const handleWorkspaceAction = vi.fn(async () => jsonResult({ ok: true }));
+const handleWorkspaceAction = vi.fn(async (_ctx: ChannelMessageActionContext) =>
+  jsonResult({ ok: true }),
+);
 
 const readWorkspaceTestPlugin: ChannelPlugin = {
   ...workspaceTestPlugin,
@@ -137,6 +142,11 @@ describe("runMessageAction context isolation", () => {
       actionParams: { targets: ["C_TARGET"] },
       expectedError: "Action read requires a target.",
     },
+    {
+      name: "an empty targets array",
+      actionParams: { targets: [] },
+      expectedError: "Action read requires a target.",
+    },
   ])("rejects read with $name before plugin dispatch", async ({ actionParams, expectedError }) => {
     await expect(
       runMessageAction({
@@ -154,6 +164,32 @@ describe("runMessageAction context isolation", () => {
       }),
     ).rejects.toThrow(expectedError);
     expect(handleWorkspaceAction).not.toHaveBeenCalled();
+  });
+
+  it("uses the current conversation for an implicit read", async () => {
+    await runMessageAction({
+      cfg: workspaceConfig,
+      action: "read",
+      params: {},
+      defaultAccountId: "default",
+      requesterAccountId: "default",
+      conversationReadOrigin: "delegated",
+      toolContext: {
+        currentChannelId: "C12345678",
+        currentChannelProvider: "workspace",
+      },
+      dryRun: false,
+    });
+
+    expect(handleWorkspaceAction).toHaveBeenCalledOnce();
+    expect(handleWorkspaceAction.mock.calls[0]?.[0]).toMatchObject({
+      action: "read",
+      params: {
+        channel: "workspace",
+        target: "C12345678",
+        to: "C12345678",
+      },
+    });
   });
 
   afterEach(() => {

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -407,7 +407,7 @@ async function resolveChannel(
     cfg,
     channel: readStringParam(params, "channel"),
     fallbackChannel: toolContext?.currentChannelProvider,
-    rejectUnknownExplicitChannel: action === "read",
+    requireExplicitChannelAvailable: action === "read",
   });
   if (selection.source === "tool-context-fallback") {
     params.channel = selection.channel;

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -401,11 +401,13 @@ async function resolveChannel(
   cfg: OpenClawConfig,
   params: Record<string, unknown>,
   toolContext?: { currentChannelProvider?: string },
+  action?: ChannelMessageActionName,
 ) {
   const selection = await resolveMessageChannelSelection({
     cfg,
     channel: readStringParam(params, "channel"),
     fallbackChannel: toolContext?.currentChannelProvider,
+    rejectUnknownExplicitChannel: action === "read",
   });
   if (selection.source === "tool-context-fallback") {
     params.channel = selection.channel;
@@ -1728,7 +1730,7 @@ export async function runMessageAction(
   if (actionRequiresTarget(action) && !hasPotentialActionTargetInput(input, params)) {
     throw new Error(`Action ${action} requires a target.`);
   }
-  const channel = await resolveChannel(cfg, params, input.toolContext);
+  const channel = await resolveChannel(cfg, params, input.toolContext, action);
   params.channel = channel;
   const channelPlugin = resolveOutboundChannelPlugin({ channel, cfg });
   const pluginOwnedAction = action !== "send" && action !== "poll";


### PR DESCRIPTION
Closes #108447

## What Problem This Solves

Fixes an issue where `message(action=read)` could silently fall back to the current conversation when an explicit target or channel was invalid. Read results also did not consistently report the channel and thread that were actually queried.

## Why This Change Was Made

Read actions now fail closed before plugin dispatch when explicit target input is unusable or the selected channel is unknown. Existing send and broadcast context fallback remains unchanged. Slack read results include the resolved channel and optional thread identifiers.

## User Impact

Agents no longer read from an unintended current-context channel after a malformed explicit read request, and callers can verify the scope represented by Slack read results.

## Evidence

- Added runner-level regressions for both reported failure modes and asserted that plugin dispatch does not occur.
- Preserved existing send and broadcast fallback tests.
- Focused core suites: 73 tests passed.
- Focused Slack suite: 79 tests passed.
- `node scripts/run-tsgo.mjs -p tsconfig.core.json`: passed.
- `node scripts/run-tsgo.mjs -p tsconfig.extensions.json`: passed.
- Independent re-review: no findings.
- `git diff --check`: passed.