### PR TITLE
perf(ci): split QA smoke into four profile parts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1399,15 +1399,21 @@ jobs:
     timeout-minutes: 60
     strategy:
       fail-fast: false
-      max-parallel: 2
+      max-parallel: 4
       matrix:
         include:
-          - name: profile 1/2
+          - name: profile 1/4
             lane: profile-1
-            slug: profile-1-of-2
-          - name: profile 2/2
+            slug: profile-1-of-4
+          - name: profile 2/4
             lane: profile-2
-            slug: profile-2-of-2
+            slug: profile-2-of-4
+          - name: profile 3/4
+            lane: profile-3
+            slug: profile-3-of-4
+          - name: profile 4/4
+            lane: profile-4
+            slug: profile-4-of-4
     steps:
       - *linux_node_checkout_step
       - name: Setup Node environment
@@ -1454,7 +1460,17 @@ jobs:
           const partId = process.env.PROFILE_PART ?? "";
           let runs;
           if (typeof smokePlan.createQaSmokeCiPart === "function") {
-            runs = smokePlan.createQaSmokeCiPart(partId).runs;
+            try {
+              runs = smokePlan.createQaSmokeCiPart(partId).runs;
+            } catch (error) {
+              // Frozen/compat targets ship older planners that declare fewer
+              // profile parts; the declared parts still cover every scenario.
+              if (/unknown QA smoke CI profile part/.test(String(error)) && partId !== "profile-1") {
+                console.log(`[skip] ${partId} is not declared by this checkout's smoke plan`);
+                process.exit(0);
+              }
+              throw error;
+            }
           } else if (typeof smokePlan.createQaSmokeCiMatrix === "function") {
             // Legacy planners select the entire profile and can mix long-lived
             // execution kinds. Reuse the current bounded smoke contract and

--- a/extensions/qa-lab/src/ci-smoke-plan.test.ts
+++ b/extensions/qa-lab/src/ci-smoke-plan.test.ts
@@ -22,18 +22,23 @@ function estimateScenarioCost(scenario: QaScenario | undefined): number {
 }
 
 describe("createQaSmokeCiPart", () => {
-  it("balances the bounded automatic smoke set across two profile parts", () => {
-    const first = createQaSmokeCiPart("profile-1");
-    const second = createQaSmokeCiPart("profile-2");
-    const repeatedSecond = createQaSmokeCiPart("profile-2");
+  it("balances the bounded automatic smoke set across four profile parts", () => {
+    const parts = ["profile-1", "profile-2", "profile-3", "profile-4"].map((partId) =>
+      createQaSmokeCiPart(partId),
+    );
+    const repeatedLast = createQaSmokeCiPart("profile-4");
 
-    expect(repeatedSecond).toEqual(second);
-    expect(first.runs[0]?.channel).toBe(OPENCLAW_CRABLINE_DEFAULT_CHANNEL);
-    expect(second.runs[0]?.channel).toBe(OPENCLAW_CRABLINE_DEFAULT_CHANNEL);
-    expect(first.runs.some((run) => run.channel === "matrix")).toBe(false);
-    expect(second.runs.some((run) => run.channel === "matrix")).toBe(true);
+    expect(repeatedLast).toEqual(parts[3]);
+    for (const part of parts) {
+      expect(part.runs[0]?.channel).toBe(OPENCLAW_CRABLINE_DEFAULT_CHANNEL);
+    }
+    // The matrix channel run rides only on the last part.
+    expect(
+      parts.slice(0, 3).some((part) => part.runs.some((run) => run.channel === "matrix")),
+    ).toBe(false);
+    expect(parts[3]?.runs.some((run) => run.channel === "matrix")).toBe(true);
 
-    const scenarioIds = [...first.runs, ...second.runs].flatMap((run) => run.scenario_ids);
+    const scenarioIds = parts.flatMap((part) => part.runs.flatMap((run) => run.scenario_ids));
     expect(new Set(scenarioIds).size).toBe(scenarioIds.length);
     const scenarioById = new Map(
       readQaScenarioPack().scenarios.map((scenario) => [scenario.id, scenario] as const),
@@ -56,7 +61,7 @@ describe("createQaSmokeCiPart", () => {
       .map((category) => category.id);
     expect(uncoveredCategoryIds).toEqual([]);
 
-    const primaryScenarioIds = [first, second].map(
+    const primaryScenarioIds = parts.map(
       (part) => part.runs.find((run) => run.slug === "primary")?.scenario_ids ?? [],
     );
     const primaryRunCosts = primaryScenarioIds.map((ids) =>
@@ -70,14 +75,23 @@ describe("createQaSmokeCiPart", () => {
         ids.map((scenarioId) => estimateScenarioCost(scenarioById.get(scenarioId))),
       ),
     );
-    const firstRunCost = expectDefined(primaryRunCosts[0], "first QA smoke run cost");
-    const secondRunCost = expectDefined(primaryRunCosts[1], "second QA smoke run cost");
-    expect(Math.abs(firstRunCost - secondRunCost)).toBeLessThanOrEqual(largestScenarioCost);
+    const heaviestRunCost = expectDefined(
+      primaryRunCosts.toSorted((left, right) => right - left)[0],
+      "heaviest QA smoke run cost",
+    );
+    const lightestRunCost = expectDefined(
+      primaryRunCosts.toSorted((left, right) => left - right)[0],
+      "lightest QA smoke run cost",
+    );
+    // Greedy balance: no part carries more than one heaviest-scenario cost
+    // beyond the lightest, and every part runs at least one scenario.
+    expect(heaviestRunCost - lightestRunCost).toBeLessThanOrEqual(largestScenarioCost);
+    expect(primaryScenarioIds.every((ids) => ids.length > 0)).toBe(true);
   });
 
   it("rejects undeclared profile parts", () => {
-    expect(() => createQaSmokeCiPart("profile-3")).toThrow(
-      "unknown QA smoke CI profile part: profile-3",
+    expect(() => createQaSmokeCiPart("profile-5")).toThrow(
+      "unknown QA smoke CI profile part: profile-5",
     );
   });
 });

--- a/extensions/qa-lab/src/ci-smoke-plan.ts
+++ b/extensions/qa-lab/src/ci-smoke-plan.ts
@@ -6,7 +6,9 @@ import { scenarioMatchesQaProviderLane } from "./scenario-lane.js";
 import { readQaScorecardTaxonomyReport } from "./scorecard-taxonomy.js";
 
 const QA_SMOKE_PROFILE = "smoke-ci";
-const QA_SMOKE_CI_PARTS = ["profile-1", "profile-2"] as const;
+// Four parts keep each smoke job near the fixed setup cost (~1min) instead of
+// serializing ~4min of scenarios into one job that owns the PR wall clock.
+const QA_SMOKE_CI_PARTS = ["profile-1", "profile-2", "profile-3", "profile-4"] as const;
 const QA_SMOKE_CI_CHANNELS = ["matrix", OPENCLAW_CRABLINE_DEFAULT_CHANNEL] as const;
 const QA_SMOKE_CI_SCENARIO_IDS = new Set([
   "control-ui-chat-flow-playwright",
@@ -103,22 +105,31 @@ export function createQaSmokeCiPart(partId: string): QaSmokeCiPart {
       (left, right) =>
         estimateScenarioCost(right) - estimateScenarioCost(left) || left.id.localeCompare(right.id),
     );
-  const partitions: [
-    { cost: number; scenarios: typeof scenarios },
-    { cost: number; scenarios: typeof scenarios },
-  ] = [
-    { cost: 0, scenarios: [] },
-    { cost: 0, scenarios: [] },
-  ];
+  const partitions = QA_SMOKE_CI_PARTS.map(() => ({
+    cost: 0,
+    scenarios: [] as typeof scenarios,
+  }));
+  const firstPartition = partitions[0];
+  if (!firstPartition) {
+    throw new Error(`${QA_SMOKE_PROFILE} declares no CI profile parts.`);
+  }
   for (const scenario of defaultChannelScenarios) {
-    const partition = partitions[0].cost <= partitions[1].cost ? partitions[0] : partitions[1];
+    const partition = partitions.reduce(
+      (lightest, candidate) => (candidate.cost < lightest.cost ? candidate : lightest),
+      firstPartition,
+    );
     partition.scenarios.push(scenario);
     partition.cost += estimateScenarioCost(scenario);
   }
 
-  const matrixPartIndex = 1;
+  // The matrix channel run rides on the last part so the greedy cost balance
+  // above stays undisturbed for the shared default-channel scenarios.
+  const matrixPartIndex = QA_SMOKE_CI_PARTS.length - 1;
   const partIndex = QA_SMOKE_CI_PARTS.indexOf(partId);
-  const selectedPartition = partId === QA_SMOKE_CI_PARTS[0] ? partitions[0] : partitions[1];
+  const selectedPartition = partitions[partIndex];
+  if (!selectedPartition) {
+    throw new Error(`unknown QA smoke CI profile part: ${partId}`);
+  }
   const runs: QaSmokeCiRun[] = [
     {
       channel: OPENCLAW_CRABLINE_DEFAULT_CHANNEL,

--- a/scripts/tsdown-build.mjs
+++ b/scripts/tsdown-build.mjs
@@ -859,8 +859,14 @@ if (isMainModule()) {
   cleanTsdownOutputRoots();
   const invocations = resolveTsdownBuildInvocations({ args: args.forwardedArgs });
   let result;
-  for (const invocation of invocations) {
+  for (const [index, invocation] of invocations.entries()) {
+    const startedAt = performance.now();
     result = await runTsdownBuildInvocation(invocation);
+    // Per-invocation timing separates the AI-declarations pass from the main
+    // graph in CI logs; the combined step is otherwise a single opaque cost.
+    console.log(
+      `[tsdown-build] invocation ${index + 1}/${invocations.length} finished in ${((performance.now() - startedAt) / 1000).toFixed(1)}s`,
+    );
     if (result.status !== 0 || result.hasIneffectiveDynamicImport || result.fatalUnresolvedImport) {
       break;
     }

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -3480,10 +3480,10 @@ describe("ci workflow guards", () => {
     expect(workflow.jobs["qa-smoke-ci-artifacts"]).toBeUndefined();
     expect(workflow.jobs["qa-smoke-ci"]).toBeUndefined();
     expect(smokeProfileJob.needs).toEqual(["preflight"]);
-    expect(smokeProfileJob.strategy["max-parallel"]).toBe(2);
+    expect(smokeProfileJob.strategy["max-parallel"]).toBe(4);
     expect(
       smokeProfileJob.strategy.matrix.include.map((entry: { slug: string }) => entry.slug),
-    ).toEqual(["profile-1-of-2", "profile-2-of-2"]);
+    ).toEqual(["profile-1-of-4", "profile-2-of-4", "profile-3-of-4", "profile-4-of-4"]);
     expect(smokeProfileJob["runs-on"]).toContain("blacksmith-16vcpu-ubuntu-2404");
     expect(smokeRunStep.run).toContain("createQaSmokeCiPart");
     expect(smokeRunStep.run).toContain("createQaSmokeCiMatrix");


### PR DESCRIPTION
## What Problem This Solves

When QA smoke runs (any diff visible to the smoke scenarios — roughly 43% of PRs), its slower profile part takes ~5min (~1min fixed setup + ~4min of serialized scenarios) and regularly owns the PR wall clock now that the test shards are balanced. Separately, the `[build-all] tsdown` step (the other wall-clock pole, 113-316s observed) is a single opaque duration in CI logs, so its AI-declarations pass versus main-graph split cannot be measured.

## Why This Change Was Made

1. The CI smoke profile splits into four cost-balanced parts instead of two: `createQaSmokeCiPart` generalizes its greedy partition to N parts (matrix-channel run rides on the last part so the shared-scenario balance is undisturbed), and the workflow matrix runs profile 1-4/4 with max-parallel 4. Expected slowest QA job: ~5min -> ~2.5-3min. Frozen/compat targets ship older two-part planners; the workflow skips undeclared parts for them (declared parts still cover every scenario, same coverage as before this change existed).
2. `scripts/tsdown-build.mjs` logs per-invocation elapsed time so the next build optimization decision (dts scoping, per-entry caching) is data-driven from any CI run instead of requiring instrumented reruns.

## User Impact

No product change. PRs whose diffs trigger QA smoke lose ~2min of wall clock; coverage is byte-identical (same 12 scenarios, same channels, still cost-balanced with each part above the fixed-cost floor).

## Evidence

- `extensions/qa-lab/src/ci-smoke-plan.test.ts` updated: four-part balance bound (heaviest minus lightest <= one heaviest-scenario cost), every part non-empty, matrix only on part 4, coverage/uniqueness/category assertions unchanged and green.
- `test/scripts/ci-workflow-guards.test.ts` green with the new matrix expectations.
- This PR's own CI runs the four-part smoke end to end (its diff touches qa-lab + ci.yml, both QA-forcing surfaces).
