### PR TITLE
fix(zai): backport documented transport payloads

### DIFF
--- a/packages/ai/src/providers/openai-completions.test.ts
+++ b/packages/ai/src/providers/openai-completions.test.ts
@@ -667,12 +667,13 @@ describe("OpenAI-compatible completions params", () => {
     expect(capturedMaxTokens).toBe(32_000);
   });
 
-  it("uses max_tokens for Z.AI requests", async () => {
+  it("uses Z.AI max_tokens and disables thinking by default", async () => {
     const stream = streamOpenAICompletions(
       {
         ...createModel(32_000),
         provider: "zai",
         baseUrl: "https://api.z.ai/api/paas/v4",
+        reasoning: true,
       },
       context,
       {
@@ -683,8 +684,35 @@ describe("OpenAI-compatible completions params", () => {
 
     await stream.result();
 
-    expect(mockOpenAIOptionsRef.payloads[0]).toMatchObject({ max_tokens: 1_024 });
+    expect(mockOpenAIOptionsRef.payloads[0]).toMatchObject({
+      max_tokens: 1_024,
+      thinking: { type: "disabled" },
+    });
     expect(mockOpenAIOptionsRef.payloads[0]).not.toHaveProperty("max_completion_tokens");
+    expect(mockOpenAIOptionsRef.payloads[0]).not.toHaveProperty("enable_thinking");
+  });
+
+  it("enables Z.AI thinking with the documented payload when requested", async () => {
+    const stream = streamOpenAICompletions(
+      {
+        ...createModel(32_000),
+        provider: "zai",
+        baseUrl: "https://api.z.ai/api/paas/v4",
+        reasoning: true,
+      },
+      context,
+      {
+        apiKey: "sk-test",
+        reasoningEffort: "high",
+      },
+    );
+
+    await stream.result();
+
+    expect(mockOpenAIOptionsRef.payloads[0]).toMatchObject({
+      thinking: { type: "enabled" },
+    });
+    expect(mockOpenAIOptionsRef.payloads[0]).not.toHaveProperty("enable_thinking");
   });
 
   it("forwards simple stop sequences to request params", async () => {

--- a/packages/ai/src/providers/openai-completions.test.ts
+++ b/packages/ai/src/providers/openai-completions.test.ts
@@ -667,6 +667,26 @@ describe("OpenAI-compatible completions params", () => {
     expect(capturedMaxTokens).toBe(32_000);
   });
 
+  it("uses max_tokens for Z.AI requests", async () => {
+    const stream = streamOpenAICompletions(
+      {
+        ...createModel(32_000),
+        provider: "zai",
+        baseUrl: "https://api.z.ai/api/paas/v4",
+      },
+      context,
+      {
+        apiKey: "sk-test",
+        maxTokens: 1_024,
+      },
+    );
+
+    await stream.result();
+
+    expect(mockOpenAIOptionsRef.payloads[0]).toMatchObject({ max_tokens: 1_024 });
+    expect(mockOpenAIOptionsRef.payloads[0]).not.toHaveProperty("max_completion_tokens");
+  });
+
   it("forwards simple stop sequences to request params", async () => {
     let capturedStop: unknown;
     const stream = streamSimpleOpenAICompletions(createModel(32_000), context, {

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -766,7 +766,7 @@ function buildParams(
   }
 
   if (compat.thinkingFormat === "zai" && model.reasoning) {
-    params.enable_thinking = Boolean(options?.reasoningEffort);
+    params.thinking = { type: options?.reasoningEffort ? "enabled" : "disabled" };
   } else if (compat.thinkingFormat === "qwen" && model.reasoning) {
     params.enable_thinking = Boolean(options?.reasoningEffort);
   } else if (compat.thinkingFormat === "qwen-chat-template" && model.reasoning) {

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -1375,7 +1375,7 @@ function detectCompat(model: Model<"openai-completions">): ResolvedOpenAIComplet
     isCloudflareAiGateway;
 
   const useMaxTokens =
-    baseUrl.includes("chutes.ai") || isMoonshot || isCloudflareAiGateway || isTogether;
+    baseUrl.includes("chutes.ai") || isMoonshot || isCloudflareAiGateway || isTogether || isZai;
 
   const isGrok = provider === "xai" || baseUrl.includes("api.x.ai");
   const isDeepSeek = provider === "deepseek" || baseUrl.includes("deepseek.com");

--- a/src/agents/openai-completions-compat.test.ts
+++ b/src/agents/openai-completions-compat.test.ts
@@ -83,6 +83,16 @@ describe("resolveOpenAICompletionsCompatDefaults", () => {
     expect(defaults.maxTokensField).toBe("max_tokens");
   });
 
+  it("uses Z.AI's documented max_tokens field", () => {
+    const defaults = resolveOpenAICompletionsCompatDefaults({
+      provider: "zai",
+      endpointClass: "zai-native",
+      knownProviderFamily: "zai",
+    });
+
+    expect(defaults.maxTokensField).toBe("max_tokens");
+  });
+
   it("requires a non-empty user or assistant turn for ModelStudio-compatible providers", () => {
     expect(
       resolveOpenAICompletionsCompatDefaults({

--- a/src/agents/openai-completions-compat.ts
+++ b/src/agents/openai-completions-compat.ts
@@ -92,6 +92,7 @@ function resolveOpenAICompletionsCompatDefaults(
     endpointClass === "chutes-native" ||
     endpointClass === "mistral-public" ||
     knownProviderFamily === "mistral" ||
+    isZai ||
     isTogether ||
     (isDefaultRoute && isDefaultRouteProvider(provider, "chutes"));
   return {

--- a/src/agents/zai.live.test.ts
+++ b/src/agents/zai.live.test.ts
@@ -35,21 +35,16 @@ async function expectModelReturnsAssistantText(
     contextWindow: modelId === "glm-5.2" ? 1_000_000 : 202_800,
     maxTokens: modelId === "glm-5.2" ? 131_072 : 131_100,
   };
-  const runProbe = (maxTokens: number) =>
-    completeSimple(
-      model,
-      {
-        messages: createSingleUserPromptMessage(),
-      },
-      { apiKey: ZAI_KEY, maxTokens },
-    );
-  const res = await runProbe(64);
-  let text = extractNonEmptyAssistantText(res.content);
-  // GLM can spend a tiny cap entirely on hidden reasoning. Retry only a
-  // provider-declared truncation; other empty responses remain failures.
-  if (text.length === 0 && res.stopReason === "length") {
-    text = extractNonEmptyAssistantText((await runProbe(256)).content);
-  }
+  // GLM-5 reasoning is enabled by default and consumes the same output budget.
+  // Keep enough headroom for a visible answer while retaining a bounded probe.
+  const res = await completeSimple(
+    model,
+    {
+      messages: createSingleUserPromptMessage(),
+    },
+    { apiKey: ZAI_KEY, maxTokens: 1_024 },
+  );
+  const text = extractNonEmptyAssistantText(res.content);
   expect(text.length).toBeGreaterThan(0);
 }
 


### PR DESCRIPTION
Backports #108612 and #108633 to `release/2026.7.2`.

## What Problem This Solves

The July beta branch changed its Z.AI live probe to a bounded 1024-token request but never received the matching transport fixes. Both OpenAI-compatible stacks still sent `max_completion_tokens`, and the package transport still sent unsupported `enable_thinking`. Z.AI could ignore those fields, default to compulsory thinking, consume the bounded output budget, and return no visible assistant text.

## Why This Change Was Made

This applies the exact main patches in dependency order:

1. `72e89a1c43cfd74777278442341b22eb44b9f123` — use Z.AI's documented `max_tokens` field in both transports and keep the live probe bounded.
2. `4b61b02d5ba6a38142272677dbe6e9fdd5da1b35` — use the documented `thinking.type` object and remove `enable_thinking` from Z.AI requests.

AI-assisted backport. No transcript attached.

## User Impact

Beta Z.AI requests honor token budgets and reasoning selection. Default-off requests can return visible text without compulsory-thinking budget exhaustion; explicit reasoning remains enabled.

## Evidence

- Both backport patch-ids exactly match main: `6c48e082e3d3a0326acd6a0405e25c8ee96d2de2` and `9e4c9e3b94c6af0a37f04654c5f2efb217952f0a`.
- Blacksmith Testbox https://github.com/openclaw/openclaw/actions/runs/29474157778: 63 focused transport tests passed across the package and agent stacks.
- Fresh autoreview: clean, 0.97 confidence.
- `git diff --check`: passed.
- Exact hosted PR CI and post-land Full Release Validation will provide the release-base and live-provider gates.
