### PR TITLE
test(ci): repair release validation gates

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -4587,6 +4587,7 @@ public struct SessionsCreateParams: Codable, Sendable {
     public let agentid: String?
     public let label: String?
     public let model: String?
+    public let thinkinglevel: String?
     public let catalogid: String?
     public let parentsessionkey: String?
     public let fork: Bool?
@@ -4605,6 +4606,7 @@ public struct SessionsCreateParams: Codable, Sendable {
         agentid: String? = nil,
         label: String? = nil,
         model: String? = nil,
+        thinkinglevel: String? = nil,
         catalogid: String? = nil,
         parentsessionkey: String? = nil,
         fork: Bool? = nil,
@@ -4622,6 +4624,7 @@ public struct SessionsCreateParams: Codable, Sendable {
         self.agentid = agentid
         self.label = label
         self.model = model
+        self.thinkinglevel = thinkinglevel
         self.catalogid = catalogid
         self.parentsessionkey = parentsessionkey
         self.fork = fork
@@ -4641,6 +4644,7 @@ public struct SessionsCreateParams: Codable, Sendable {
         case agentid = "agentId"
         case label
         case model
+        case thinkinglevel = "thinkingLevel"
         case catalogid = "catalogId"
         case parentsessionkey = "parentSessionKey"
         case fork

--- a/src/agents/anthropic-transport-stream.live.test.ts
+++ b/src/agents/anthropic-transport-stream.live.test.ts
@@ -9,6 +9,7 @@ import type { Model } from "openclaw/plugin-sdk/llm";
 import { describe, expect, it } from "vitest";
 import { createAnthropicMessagesTransportStreamFn } from "./anthropic-transport-stream.js";
 import { isLiveTestEnabled } from "./live-test-helpers.js";
+import { shouldSkipLiveProviderDrift } from "./live-test-provider-drift.js";
 import { isLiveBillingDrift } from "./live-test-provider-drift.test-support.js";
 
 const LIVE = isLiveTestEnabled(["ANTHROPIC_TRANSPORT_LIVE_TEST"]);
@@ -77,6 +78,23 @@ function skipAnthropicBillingDrift(
   }
   console.warn(`[anthropic:live] skip ${label}: billing drift`);
   return true;
+}
+
+function classifyProviderError(errorMessage: string | undefined): string {
+  if (!errorMessage) {
+    return "none";
+  }
+  return (
+    shouldSkipLiveProviderDrift({
+      allowAuth: true,
+      allowBilling: true,
+      allowModelNotFound: true,
+      allowProviderUnavailable: true,
+      allowRateLimit: true,
+      allowTimeout: true,
+      error: errorMessage,
+    })?.reason ?? "unclassified"
+  );
 }
 
 describeLive("anthropic transport stream live", () => {
@@ -217,7 +235,10 @@ describeOpusTupleLive("anthropic Opus tuple schema provider live", () => {
       (block) => block.type === "toolCall" && block.name === "tuple_probe",
     );
 
-    expect(result.stopReason).toBe("toolUse");
+    expect(
+      result.stopReason,
+      `tuple tool projection failed; errorClass=${classifyProviderError(result.errorMessage)}`,
+    ).toBe("toolUse");
     expect(toolCall).toMatchObject({
       type: "toolCall",
       name: "tuple_probe",
@@ -282,7 +303,10 @@ describeProviderLive("anthropic transport stream provider live", () => {
       (block) => block.type === "toolCall" && block.name === "healthy_probe",
     );
 
-    expect(result.stopReason).toBe("toolUse");
+    expect(
+      result.stopReason,
+      `forced tool projection failed; errorClass=${classifyProviderError(result.errorMessage)}`,
+    ).toBe("toolUse");
     expect(toolCall).toMatchObject({
       type: "toolCall",
       name: "healthy_probe",
@@ -344,7 +368,10 @@ describeProviderLive("anthropic transport stream provider live", () => {
       (block) => block.type === "toolCall" && block.name === "healthy_probe",
     );
 
-    expect(result.stopReason).toBe("toolUse");
+    expect(
+      result.stopReason,
+      `SDK forced tool projection failed; errorClass=${classifyProviderError(result.errorMessage)}`,
+    ).toBe("toolUse");
     expect(toolCall).toMatchObject({
       type: "toolCall",
       name: "healthy_probe",

--- a/src/agents/zai.live.test.ts
+++ b/src/agents/zai.live.test.ts
@@ -8,6 +8,7 @@ import {
   extractNonEmptyAssistantText,
   isLiveTestEnabled,
 } from "./live-test-helpers.js";
+import { shouldSkipLiveProviderDrift } from "./live-test-provider-drift.js";
 
 const ZAI_KEY = process.env.ZAI_API_KEY ?? process.env.Z_AI_API_KEY ?? "";
 const LIVE = isLiveTestEnabled(["ZAI_LIVE_TEST"]);
@@ -53,11 +54,19 @@ async function expectModelReturnsAssistantText(
     final = await complete(8_192);
     text = extractNonEmptyAssistantText(final.content);
   }
-  const summarize = (res: typeof final) =>
-    `stopReason=${res.stopReason}; contentTypes=${res.content.map((block) => block.type).join(",") || "none"}`;
+  const drift = shouldSkipLiveProviderDrift({
+    allowAuth: true,
+    allowBilling: true,
+    allowModelNotFound: true,
+    allowProviderUnavailable: true,
+    allowRateLimit: true,
+    allowTimeout: true,
+    error: final.errorMessage ?? "",
+  });
+  const errorClass = final.errorMessage ? (drift?.reason ?? "unclassified") : "none";
   expect(
     text.length,
-    `${modelId} returned no assistant text; initial(${summarize(initial)}); final(${summarize(final)})`,
+    `${modelId} returned no assistant text; initialStopReason=${initial.stopReason}; finalStopReason=${final.stopReason}; errorClass=${errorClass}; contentTypes=${final.content.map((block) => block.type).join(",") || "none"}`,
   ).toBeGreaterThan(0);
 }
 

--- a/src/agents/zai.live.test.ts
+++ b/src/agents/zai.live.test.ts
@@ -35,17 +35,30 @@ async function expectModelReturnsAssistantText(
     contextWindow: modelId === "glm-5.2" ? 1_000_000 : 202_800,
     maxTokens: modelId === "glm-5.2" ? 131_072 : 131_100,
   };
-  // GLM-5 reasoning is enabled by default and consumes the same output budget.
-  // Keep enough headroom for a visible answer while retaining a bounded probe.
-  const res = await completeSimple(
-    model,
-    {
-      messages: createSingleUserPromptMessage(),
-    },
-    { apiKey: ZAI_KEY, maxTokens: 1_024 },
-  );
-  const text = extractNonEmptyAssistantText(res.content);
-  expect(text.length).toBeGreaterThan(0);
+  const complete = (maxTokens: number) =>
+    completeSimple(
+      model,
+      {
+        messages: createSingleUserPromptMessage(),
+      },
+      { apiKey: ZAI_KEY, maxTokens },
+    );
+
+  // A small probe cap can occasionally yield only hidden reasoning even though
+  // production allows much more output. Retry once, but still require visible text.
+  const initial = await complete(1_024);
+  let final = initial;
+  let text = extractNonEmptyAssistantText(final.content);
+  if (!text && (initial.stopReason === "stop" || initial.stopReason === "length")) {
+    final = await complete(8_192);
+    text = extractNonEmptyAssistantText(final.content);
+  }
+  const summarize = (res: typeof final) =>
+    `stopReason=${res.stopReason}; contentTypes=${res.content.map((block) => block.type).join(",") || "none"}`;
+  expect(
+    text.length,
+    `${modelId} returned no assistant text; initial(${summarize(initial)}); final(${summarize(final)})`,
+  ).toBeGreaterThan(0);
 }
 
 describeCodingLive("zai Coding Plan live", () => {

--- a/test/scripts/parallels-smoke-model.test.ts
+++ b/test/scripts/parallels-smoke-model.test.ts
@@ -421,10 +421,16 @@ describe("Parallels smoke model selection", () => {
 
     expect(common).toContain('export * from "./host-command.ts"');
     expect(common).toContain('export * from "./lane-runner.ts"');
-    // The deadcode hard-zero sweep narrowed this barrel to named exports; the
-    // shared contract is that package helpers stay routed through common.
-    expect(common).toContain('} from "./package-artifact.ts"');
-    expect(common).toContain("packOpenClaw");
+    const packageArtifactExports = new Set(
+      (common.match(/export \{([^}]*)\} from "\.\/package-artifact\.ts";/)?.[1] ?? "")
+        .split(",")
+        .map((name) => name.trim())
+        .filter(Boolean),
+    );
+    expect(packageArtifactExports).toContain("packOpenClaw");
+    expect(packageArtifactExports).toContain("packageVersionFromTgz");
+    expect(packageArtifactExports).toContain("resolveOpenClawRegistryVersion");
+    expect(common).not.toContain('export * from "./package-artifact.ts"');
     expect(common).toContain('export * from "./parallels-vm.ts"');
     expect(common).toContain('export * from "./snapshots.ts"');
     expect(hostCommand).toContain("export function shellQuote");


### PR DESCRIPTION
## What Problem This Solves

Full Release Validation at `4b61b02d5ba6a38142272677dbe6e9fdd5da1b35` failed the standard Z.AI native-agent probes with no visible assistant text. The same release-prep sequence exposed live-provider failures that reported only `stopReason=error`, a weak package-artifact barrel assertion after main narrowed that barrel to named exports, and a stale generated Swift session-create model after main added `thinkingLevel`.

## Why This Change Was Made

Keep the fast 1,024-token Z.AI probe first. Retry once with an 8,192-token cap only when the first request ends normally or at the length limit without visible text. Provider errors still fail immediately. Failure messages classify the safe provider-error category and report stop reasons and content block types without printing raw provider responses.

Verify the three required package-artifact helpers as exact named exports and reject a wildcard regression. Synchronize the generated Swift `SessionsCreateParams` model with the existing optional `thinkingLevel` schema. Main independently landed the same generated-model repair in #108715 while this PR was validating; the merge therefore retains that canonical main result.

## User Impact

No product runtime behavior change. Release validation gains bounded resilience and privacy-safe diagnostics. CI now enforces the intended package barrel and generated protocol contracts without masking deterministic provider, transport, authentication, or inference failures.

## Evidence

- Source release-check failure: https://github.com/openclaw/openclaw/actions/runs/29473560800
- Exact live diagnostic: https://github.com/openclaw/openclaw/actions/runs/29475942698; both Z.AI probes classified as billing and both Anthropic forced-tool probes classified as provider unavailable
- Current-main focused Testbox: https://github.com/openclaw/openclaw/actions/runs/29479042729; 86 passed and 7 live tests compiled/skipped with provider flags unset
- Current-main remote formatting: https://github.com/openclaw/openclaw/actions/runs/29478842982
- Current-main `pnpm protocol:check`: https://github.com/openclaw/openclaw/actions/runs/29479473743
- Prior focused Testbox: https://github.com/openclaw/openclaw/actions/runs/29476816678; 93 passed
- Prior remote `pnpm tsgo:test`: https://github.com/openclaw/openclaw/actions/runs/29475320917
- Refreshed exact-head hosted CI green for `1b51ea25176b344466b4effa0cf394670e662539`: https://github.com/openclaw/openclaw/actions/runs/29479634751
- Fresh final branch autoreview: clean, confidence 0.93
- Repo-native review artifacts: validated recommendation `READY FOR /prepare-pr`, zero findings
