### PR TITLE
fix(deadcode): keep production scan test-free

### DIFF
--- a/config/knip.config.ts
+++ b/config/knip.config.ts
@@ -78,6 +78,10 @@ const repositoryScriptEntries = [
 
 const rootEntries = [
   ...repositoryScriptEntries,
+  // Knip loads these audit configurations directly by command-line path.
+  "config/knip.config.ts!",
+  "config/knip.all-exports.config.ts!",
+  "config/knip.scripts-exports.config.ts!",
   "openclaw.mjs!",
   "src/index.ts!",
   "src/entry.ts!",
@@ -339,11 +343,12 @@ const config = {
       project: [
         "src/**/*.ts!",
         "scripts/**/*.{js,mjs,cjs,ts,mts,cts}!",
+        "config/**/*.{ts,mts,cts}!",
         "test/**/*.{js,mjs,cjs,ts,mts,cts}!",
         "*.config.{js,mjs,cjs,ts,mts,cts}!",
         "*.mjs!",
       ],
-      entry: [...rootEntries, "test/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts}!"],
+      entry: rootEntries,
     },
     ui: {
       entry: [

--- a/test/scripts/check-deadcode-exports.test.ts
+++ b/test/scripts/check-deadcode-exports.test.ts
@@ -45,6 +45,17 @@ describe("check-deadcode-exports", () => {
   });
 
   it("makes tests in every workspace roots of the full-tree export audit", () => {
+    expect(knipConfig.workspaces["."].entry).not.toContain(
+      "test/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts}!",
+    );
+    expect(knipConfig.workspaces["."].entry).toEqual(
+      expect.arrayContaining([
+        "config/knip.config.ts!",
+        "config/knip.all-exports.config.ts!",
+        "config/knip.scripts-exports.config.ts!",
+      ]),
+    );
+    expect(knipConfig.workspaces["."].project).toContain("config/**/*.{ts,mts,cts}!");
     const rootWorkspace = allExportsKnipConfig.workspaces["."];
     const extensionWorkspace = allExportsKnipConfig.workspaces["extensions/*"];
     const uiWorkspace = allExportsKnipConfig.workspaces.ui;


### PR DESCRIPTION
## What Problem This Solves

The newly landed hard-zero production Knip config still marked root test files as production entries. Test-only imports could therefore hide dead production exports. The three Knip configuration modules were also only loaded by command-line path and were not represented as scan roots.

## Why This Change Was Made

This keeps test roots exclusively in the full-tree audit, roots the three directly loaded Knip configurations, and adds a regression assertion for both boundaries.

AI-assisted maintainer follow-up. No runtime behavior change.

## User Impact

Maintainers now get a production dead-code result that cannot be satisfied by test-only consumers, while the separate full-tree scan still checks test support.

## Evidence

- Blacksmith Testbox `tbx_01kxmqrfjw0aaw96p230zyysd4`, Actions run 29475085791.
- Deadcode config tests: 20/20 green.
- Production unused exports: 0.
- Full-tree unused exports: 0.
- Script entry exports: 0.
- Production unused files: 0.
- Full-tree unused files: 0.
- Full production and full-tree Knip issue scans: 0 findings.
- Fresh autoreview: no accepted/actionable findings; confidence 0.93.
