### PR TITLE
refactor: reuse plugin toggle mutation after update failures

### DIFF
--- a/src/plugins/update.test.ts
+++ b/src/plugins/update.test.ts
@@ -2958,6 +2958,35 @@ describe("updateNpmInstalledPlugins", () => {
     ]);
   });
 
+  it("does not create trust policy when disabling a failed plugin", async () => {
+    installPluginFromNpmSpecMock.mockResolvedValue({
+      ok: false,
+      error: "registry timeout",
+    });
+
+    const result = await updateNpmInstalledPlugins({
+      config: {
+        plugins: {
+          entries: { demo: { enabled: true } },
+          installs: {
+            demo: {
+              source: "npm",
+              spec: "@acme/demo",
+              installPath: "/tmp/demo",
+            },
+          },
+        },
+      },
+      pluginIds: ["demo"],
+      disableOnFailure: true,
+    });
+
+    expect(result.changed).toBe(true);
+    expect(result.config.plugins?.entries?.demo?.enabled).toBe(false);
+    expect(result.config.plugins?.allow).toBeUndefined();
+    expect(result.config.plugins?.deny).toBeUndefined();
+  });
+
   it("keeps an existing ClawHub plugin enabled when a risky update is not acknowledged", async () => {
     installPluginFromClawHubMock.mockResolvedValue({
       ok: false,
@@ -3170,7 +3199,7 @@ describe("updateNpmInstalledPlugins", () => {
     ]);
   });
 
-  it("disables an existing ClawHub plugin when its current release is blocked", async () => {
+  it("disables a blocked ClawHub plugin without changing trust policy", async () => {
     const warn = vi.fn();
     installPluginFromClawHubMock.mockResolvedValue({
       ok: false,

--- a/src/plugins/update.ts
+++ b/src/plugins/update.ts
@@ -73,6 +73,7 @@ import { resolvePackagePluginApiRange } from "./package-compat.js";
 import { validatePackageExtensionEntriesForInstall } from "./package-entry-resolution.js";
 import { linkOpenClawPeerDependencies } from "./plugin-peer-link.js";
 import { defaultSlotIdForKey } from "./slots.js";
+import { setPluginEnabledInConfig } from "./toggle-config.js";
 
 /** Logger surface used by plugin update flows. */
 type PluginUpdateLogger = {
@@ -1311,22 +1312,16 @@ function resetDisabledPluginSlots(
 }
 
 function disablePluginAfterUpdateFailure(config: OpenClawConfig, pluginId: string): OpenClawConfig {
-  const pluginsConfig = config.plugins ?? {};
-  const existingEntry = pluginsConfig.entries?.[pluginId];
+  const disabled = setPluginEnabledInConfig(config, pluginId, false, {
+    updateChannelConfig: false,
+  });
+  const pluginsConfig = disabled.plugins ?? {};
   return {
-    ...config,
+    ...disabled,
     plugins: {
       ...pluginsConfig,
-      // Update failure changes activation, not operator-authored trust policy.
-      // Removing the final allow entry would widen discovery to other plugins.
+      // Failed updates are reversible activation changes; only explicit uninstall removes trust policy.
       slots: resetDisabledPluginSlots(pluginsConfig.slots, pluginId),
-      entries: {
-        ...pluginsConfig.entries,
-        [pluginId]: {
-          ...existingEntry,
-          enabled: false,
-        },
-      },
     },
   };
 }


### PR DESCRIPTION
Follow-up to #108661, which closed #107224 while this PR was being prepared.

## What Problem This Solves

The behavioral fix on `main` preserves plugin trust policy after update failures, but its failure helper duplicates the shared plugin enable-state mutation. This follow-up leaves one canonical activation path and adds explicit coverage that disabling a failed plugin does not synthesize allowlist or denylist policy.

## Why This Change Was Made

Failed updates now call `setPluginEnabledInConfig` with channel-config synchronization disabled, then reset plugin-owned slots. Explicit uninstall remains the only operation that removes trust-policy entries.

## User Impact

No behavior change from the landed fix. The implementation is smaller and shares the same enable-state invariant as ordinary plugin toggles.

## Evidence

- `pnpm test src/plugins/update.test.ts` on the post-#108661 diff: 121 passed via Testbox `tbx_01kxmy61z9x5pdszy0m40ehb02`.
- Fresh staged autoreview: no accepted or actionable findings (0.94 confidence).
- `git diff --check`: passed.
- Repo-native exact-head CI: run 29481153611 passed on `ebb5640f234`.

AI-assisted: yes. I reviewed the complete update-failure, toggle, uninstall, and trust-policy paths and understand the resulting behavior.
