### PR TITLE
fix(memory): avoid gateway crash loops on legacy index conflicts

### DIFF
--- a/extensions/memory-core/doctor-contract-api.test.ts
+++ b/extensions/memory-core/doctor-contract-api.test.ts
@@ -1369,7 +1369,7 @@ describe("memory-core doctor dreaming migration", () => {
     await expect(fs.access(retryPath)).resolves.toBeUndefined();
   });
 
-  it("leaves the legacy memory sidecar in place when metadata conflicts", async () => {
+  it("keeps canonical metadata and archives a conflicting derived legacy index", async () => {
     const stateDir = path.join(rootDir, "state");
     const legacyPath = path.join(stateDir, "memory", "main.sqlite");
     const agentPath = path.join(stateDir, "agents", "main", "agent", "openclaw-agent.sqlite");
@@ -1378,17 +1378,50 @@ describe("memory-core doctor dreaming migration", () => {
 
     const result = await legacyMemoryIndexMigration().migrateLegacyState(migrationParams());
 
-    expect(result.warnings).toEqual([
-      expect.stringContaining(
-        "Skipped Memory Core legacy memory index import for agent main because legacy rows could not be imported: Error: legacy memory meta rows conflict with canonical memory index rows",
-      ),
+    expect(result.warnings).toEqual([]);
+    expect(result.changes).toEqual([
+      "Resolved Memory Core legacy memory index conflict for agent main by keeping canonical per-agent SQLite rows",
+      expect.stringContaining("Archived Memory Core legacy memory index sidecar"),
     ]);
-    expect(result.changes).toEqual([]);
     expect(readMemoryRows(agentPath).chunks).toEqual([
       { id: "canonical-other-chunk", text: "canonical unrelated memory" },
     ]);
-    await expect(fs.access(legacyPath)).resolves.toBeUndefined();
-    await expect(fs.access(`${legacyPath}.migrated`)).rejects.toThrow();
+    await expect(fs.access(legacyPath)).rejects.toThrow();
+    await expect(fs.access(`${legacyPath}.migrated`)).resolves.toBeUndefined();
+
+    const secondRun = await legacyMemoryIndexMigration().migrateLegacyState(migrationParams());
+    expect(secondRun).toEqual({ changes: [], warnings: [] });
+  });
+
+  it("keeps canonical chunks and archives a conflicting derived legacy index", async () => {
+    const stateDir = path.join(rootDir, "state");
+    const legacyPath = path.join(stateDir, "memory", "main.sqlite");
+    const agentPath = path.join(stateDir, "agents", "main", "agent", "openclaw-agent.sqlite");
+    await writeLegacyMemorySidecar(legacyPath);
+    await createCanonicalLegacyMemoryRowsWithFts(agentPath, "remember this");
+    const canonicalDb = new DatabaseSync(agentPath);
+    try {
+      canonicalDb
+        .prepare("UPDATE memory_index_chunks SET text = ? WHERE id = ?")
+        .run("canonical memory remains authoritative", "chunk-1");
+    } finally {
+      canonicalDb.close();
+    }
+
+    const result = await legacyMemoryIndexMigration().migrateLegacyState(migrationParams());
+
+    expect(result.warnings).toEqual([]);
+    expect(result.changes).toEqual([
+      "Resolved Memory Core legacy memory index conflict for agent main by keeping canonical per-agent SQLite rows",
+      expect.stringContaining("Archived Memory Core legacy memory index sidecar"),
+    ]);
+    expect(readMemoryRows(agentPath)).toEqual({
+      sources: [{ path: "MEMORY.md", source: "memory", hash: "file-hash" }],
+      chunks: [{ id: "chunk-1", text: "canonical memory remains authoritative" }],
+      cache: [],
+    });
+    await expect(fs.access(legacyPath)).rejects.toThrow();
+    await expect(fs.access(`${legacyPath}.migrated`)).resolves.toBeUndefined();
   });
 
   it("merges legacy sidecar rows into a non-empty canonical index when rows do not conflict", async () => {
@@ -1529,7 +1562,7 @@ describe("memory-core doctor dreaming migration", () => {
       legacyDims: null,
     },
   ])(
-    "leaves legacy sidecars in place when cache collision $reason",
+    "keeps canonical cache rows when a legacy collision has $reason",
     async ({ canonicalEmbedding, canonicalDims, legacyEmbedding, legacyDims }) => {
       const stateDir = path.join(rootDir, "state");
       const legacyPath = path.join(stateDir, "memory", "main.sqlite");
@@ -1552,12 +1585,11 @@ describe("memory-core doctor dreaming migration", () => {
 
       const result = await legacyMemoryIndexMigration().migrateLegacyState(migrationParams());
 
-      expect(result.warnings).toEqual([
-        expect.stringContaining(
-          "Skipped Memory Core legacy memory index import for agent main because legacy rows could not be imported: Error: legacy memory embedding_cache rows conflict with canonical memory index rows",
-        ),
+      expect(result.warnings).toEqual([]);
+      expect(result.changes).toEqual([
+        "Resolved Memory Core legacy memory index conflict for agent main by keeping canonical per-agent SQLite rows",
+        expect.stringContaining("Archived Memory Core legacy memory index sidecar"),
       ]);
-      expect(result.changes).toEqual([]);
       expect(readMemoryRows(agentPath)).toEqual({
         sources: [{ path: "OTHER.md", source: "memory", hash: "canonical-other-file-hash" }],
         chunks: [{ id: "canonical-other-chunk", text: "canonical unrelated memory" }],
@@ -1574,8 +1606,8 @@ describe("memory-core doctor dreaming migration", () => {
           updated_at: 99,
         },
       ]);
-      await expect(fs.access(legacyPath)).resolves.toBeUndefined();
-      await expect(fs.access(`${legacyPath}.migrated`)).rejects.toThrow();
+      await expect(fs.access(legacyPath)).rejects.toThrow();
+      await expect(fs.access(`${legacyPath}.migrated`)).resolves.toBeUndefined();
     },
   );
 
@@ -1598,7 +1630,7 @@ describe("memory-core doctor dreaming migration", () => {
     await expect(fs.access(`${legacyPath}.migrated`)).rejects.toThrow();
   });
 
-  it("leaves legacy vector sidecars in place when canonical vector rows conflict", async () => {
+  it("keeps canonical vector rows and archives a conflicting derived legacy index", async () => {
     const stateDir = path.join(rootDir, "state");
     const legacyPath = path.join(stateDir, "memory", "main.sqlite");
     const agentPath = path.join(stateDir, "agents", "main", "agent", "openclaw-agent.sqlite");
@@ -1607,14 +1639,13 @@ describe("memory-core doctor dreaming migration", () => {
 
     const result = await legacyMemoryIndexMigration().migrateLegacyState(migrationParams());
 
-    expect(result.warnings).toEqual([
-      expect.stringContaining(
-        "Skipped Memory Core legacy memory index import for agent main because legacy rows could not be imported: Error: legacy memory chunks_vec rows conflict with canonical memory index rows",
-      ),
+    expect(result.warnings).toEqual([]);
+    expect(result.changes).toEqual([
+      "Resolved Memory Core legacy memory index conflict for agent main by keeping canonical per-agent SQLite rows",
+      expect.stringContaining("Archived Memory Core legacy memory index sidecar"),
     ]);
-    expect(result.changes).toEqual([]);
-    await expect(fs.access(legacyPath)).resolves.toBeUndefined();
-    await expect(fs.access(`${legacyPath}.migrated`)).rejects.toThrow();
+    await expect(fs.access(legacyPath)).rejects.toThrow();
+    await expect(fs.access(`${legacyPath}.migrated`)).resolves.toBeUndefined();
   });
 
   it("leaves legacy vector sidecars in place when vector rows have no chunk", async () => {
@@ -1632,7 +1663,7 @@ describe("memory-core doctor dreaming migration", () => {
 
     expect(result.warnings).toEqual([
       expect.stringContaining(
-        "Skipped Memory Core legacy memory index import for agent main because legacy rows could not be imported: Error: legacy memory chunks_vec chunk references rows conflict",
+        "Skipped Memory Core legacy memory index import for agent main because legacy rows could not be imported: Error: legacy memory chunks_vec rows reference missing chunks",
       ),
     ]);
     expect(result.changes).toEqual([]);
@@ -1640,7 +1671,7 @@ describe("memory-core doctor dreaming migration", () => {
     await expect(fs.access(`${legacyPath}.migrated`)).rejects.toThrow();
   });
 
-  it("leaves legacy sidecars in place when canonical FTS rows conflict", async () => {
+  it("keeps canonical FTS rows and archives a conflicting derived legacy index", async () => {
     const stateDir = path.join(rootDir, "state");
     const legacyPath = path.join(stateDir, "memory", "main.sqlite");
     const agentPath = path.join(stateDir, "agents", "main", "agent", "openclaw-agent.sqlite");
@@ -1649,17 +1680,18 @@ describe("memory-core doctor dreaming migration", () => {
 
     const result = await legacyMemoryIndexMigration().migrateLegacyState(migrationParams());
 
-    expect(result.warnings).toEqual([
-      expect.stringContaining(
-        "Skipped Memory Core legacy memory index import for agent main because legacy rows could not be imported: Error: legacy memory fts rows conflict",
-      ),
+    expect(result.warnings).toEqual([]);
+    expect(result.changes).toEqual([
+      "Resolved Memory Core legacy memory index conflict for agent main by keeping canonical per-agent SQLite rows",
+      expect.stringContaining("Archived Memory Core legacy memory index sidecar"),
     ]);
-    expect(result.changes).toEqual([]);
-    await expect(fs.access(legacyPath)).resolves.toBeUndefined();
-    await expect(fs.access(`${legacyPath}.migrated`)).rejects.toThrow();
+    const keywordRows = await searchMigratedKeywordRows(agentPath, "stale");
+    expect(keywordRows.map((row) => row.id)).toEqual(["chunk-1"]);
+    await expect(fs.access(legacyPath)).rejects.toThrow();
+    await expect(fs.access(`${legacyPath}.migrated`)).resolves.toBeUndefined();
   });
 
-  it("leaves legacy vector sidecars in place when canonical metadata dimensions conflict", async () => {
+  it("keeps canonical vector metadata and archives a conflicting derived legacy index", async () => {
     const stateDir = path.join(rootDir, "state");
     const legacyPath = path.join(stateDir, "memory", "main.sqlite");
     const agentPath = path.join(stateDir, "agents", "main", "agent", "openclaw-agent.sqlite");
@@ -1668,17 +1700,16 @@ describe("memory-core doctor dreaming migration", () => {
 
     const result = await legacyMemoryIndexMigration().migrateLegacyState(migrationParams());
 
-    expect(result.warnings).toEqual([
-      expect.stringContaining(
-        "Skipped Memory Core legacy memory index import for agent main because legacy rows could not be imported: Error: legacy memory meta rows conflict with canonical memory index rows",
-      ),
+    expect(result.warnings).toEqual([]);
+    expect(result.changes).toEqual([
+      "Resolved Memory Core legacy memory index conflict for agent main by keeping canonical per-agent SQLite rows",
+      expect.stringContaining("Archived Memory Core legacy memory index sidecar"),
     ]);
-    expect(result.changes).toEqual([]);
     expect(readMemoryRows(agentPath).chunks).toEqual([
       { id: "canonical-other-chunk", text: "canonical unrelated memory" },
     ]);
-    await expect(fs.access(legacyPath)).resolves.toBeUndefined();
-    await expect(fs.access(`${legacyPath}.migrated`)).rejects.toThrow();
+    await expect(fs.access(legacyPath)).rejects.toThrow();
+    await expect(fs.access(`${legacyPath}.migrated`)).resolves.toBeUndefined();
   });
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/extensions/memory-core/doctor-contract-api.ts
+++ b/extensions/memory-core/doctor-contract-api.ts
@@ -106,7 +106,7 @@ type LegacyMemorySidecarImportResult = {
 
 type MemoryFtsTokenizer = "unicode61" | "trigram";
 
-class LegacyMemoryRowsConflictError extends Error {
+class LegacyMemoryDerivedRowsConflictError extends Error {
   constructor(readonly tableName: string) {
     super(`legacy memory ${tableName} rows conflict with canonical memory index rows`);
   }
@@ -211,10 +211,26 @@ function formatLegacyVectorRows(count: number | undefined): string {
   return count === undefined ? "legacy vector rows" : `${count} vector row(s)`;
 }
 
-function assertLegacyRowsCopied(db: DatabaseSync, query: string, tableName: string): void {
+function assertLegacyDerivedRowsCopied(db: DatabaseSync, query: string, tableName: string): void {
   const row = db.prepare(query).get() as { missing?: unknown } | undefined;
   if (Number(row?.missing ?? 0) > 0) {
-    throw new LegacyMemoryRowsConflictError(tableName);
+    throw new LegacyMemoryDerivedRowsConflictError(tableName);
+  }
+}
+
+function assertLegacyVectorRowsReferenceChunks(db: DatabaseSync, schema: string): void {
+  const row = db
+    .prepare(
+      `SELECT COUNT(*) AS missing
+       FROM ${schema}.${LEGACY_MEMORY_VECTOR_TABLE} AS legacy
+       WHERE NOT EXISTS (
+         SELECT 1 FROM main.${MEMORY_INDEX_CHUNKS_TABLE} AS chunk
+         WHERE chunk.id = legacy.id
+       )`,
+    )
+    .get() as { missing?: unknown } | undefined;
+  if (Number(row?.missing ?? 0) > 0) {
+    throw new Error(`legacy memory ${LEGACY_MEMORY_VECTOR_TABLE} rows reference missing chunks`);
   }
 }
 
@@ -340,17 +356,8 @@ function copyLegacyMemoryVectorRows(db: DatabaseSync, schema: string): void {
   if (!tableExists(db, "main", MEMORY_INDEX_VECTOR_TABLE)) {
     return;
   }
-  assertLegacyRowsCopied(
-    db,
-    `SELECT COUNT(*) AS missing
-     FROM ${schema}.${LEGACY_MEMORY_VECTOR_TABLE} AS legacy
-     WHERE NOT EXISTS (
-       SELECT 1 FROM main.${MEMORY_INDEX_CHUNKS_TABLE} AS chunk
-       WHERE chunk.id = legacy.id
-     )`,
-    `${LEGACY_MEMORY_VECTOR_TABLE} chunk references`,
-  );
-  assertLegacyRowsCopied(
+  assertLegacyVectorRowsReferenceChunks(db, schema);
+  assertLegacyDerivedRowsCopied(
     db,
     `SELECT COUNT(*) AS missing
      FROM ${schema}.${LEGACY_MEMORY_VECTOR_TABLE} AS legacy
@@ -368,7 +375,7 @@ function copyLegacyMemoryVectorRows(db: DatabaseSync, schema: string): void {
       WHERE canonical.id = legacy.id
     );
   `);
-  assertLegacyRowsCopied(
+  assertLegacyDerivedRowsCopied(
     db,
     `SELECT COUNT(*) AS missing
      FROM ${schema}.${LEGACY_MEMORY_VECTOR_TABLE} AS legacy
@@ -398,7 +405,7 @@ function copyLegacyMemoryFtsRows(db: DatabaseSync, schema: string): void {
       WHERE canonical.id = legacy.id
     );
   `);
-  assertLegacyRowsCopied(
+  assertLegacyDerivedRowsCopied(
     db,
     `SELECT COUNT(*) AS missing
      FROM ${schema}.chunks AS legacy
@@ -435,7 +442,7 @@ function copyLegacyMemoryIndexRows(
     SELECT id, path, source, start_line, end_line, hash, model, text, embedding, updated_at
     FROM ${schema}.chunks;
   `);
-  assertLegacyRowsCopied(
+  assertLegacyDerivedRowsCopied(
     db,
     `SELECT COUNT(*) AS missing
      FROM ${schema}.meta AS legacy
@@ -445,7 +452,7 @@ function copyLegacyMemoryIndexRows(
      )`,
     "meta",
   );
-  assertLegacyRowsCopied(
+  assertLegacyDerivedRowsCopied(
     db,
     `SELECT COUNT(*) AS missing
      FROM ${schema}.files AS legacy
@@ -459,7 +466,7 @@ function copyLegacyMemoryIndexRows(
      )`,
     "files",
   );
-  assertLegacyRowsCopied(
+  assertLegacyDerivedRowsCopied(
     db,
     `SELECT COUNT(*) AS missing
      FROM ${schema}.chunks AS legacy
@@ -500,8 +507,9 @@ function copyLegacyMemoryIndexRows(
       SELECT provider, model, provider_key, hash, embedding, dims, updated_at
       FROM ${schema}.embedding_cache;
     `);
-    // Canonical derived payloads win only when both rows match their shared dimensions.
-    assertLegacyRowsCopied(
+    // Matching cache keys are derived rows. Validate shape before deciding whether the
+    // entire stale sidecar should yield to the canonical index.
+    assertLegacyDerivedRowsCopied(
       db,
       `SELECT COUNT(*) AS missing
        FROM ${schema}.embedding_cache AS legacy
@@ -939,9 +947,9 @@ async function migrateLegacyMemorySidecarSource(params: {
         requireVectorRows: vectorEnabled,
       });
     } catch (err) {
-      if (err instanceof LegacyMemoryRowsConflictError && err.tableName === "files") {
-        // Memory index rows are derived from canonical memory sources. Keep the
-        // current per-agent index and let normal sync rebuild any stale entries.
+      if (err instanceof LegacyMemoryDerivedRowsConflictError) {
+        // Every imported table is a derived search index. A same-identity mismatch means the
+        // current per-agent row wins; normal sync rebuilds any rows skipped with the sidecar.
         params.changes.push(
           `Resolved Memory Core legacy memory index conflict for agent ${params.source.agentId} by keeping canonical per-agent SQLite rows`,
         );


### PR DESCRIPTION
Closes #107220

## What Problem This Solves

Fixes an issue where upgrades from the legacy Memory Core sidecar could leave Doctor and Gateway readiness in a permanent retry loop when stale metadata, chunk, cache, vector, or FTS rows collided with the current per-agent index.

## Why This Change Was Made

Memory index tables are derived search state, so a same-identity mismatch now keeps the canonical per-agent row, rolls back the attempted sidecar merge, and archives the stale sidecar. Structural failures remain separate: orphan vector rows, incompatible vector dimensions, invalid schemas, and database setup failures still retain the sidecar and report a retryable warning.

This preserves the useful non-conflicting merge path while making the canonical-wins rule consistent across every derived index table.

## User Impact

Affected operators can run Doctor or restart the Gateway normally without manually moving `memory/main.sqlite`. Canonical memory index rows remain intact, and repeated Doctor runs are idempotent.

## Evidence

- Focused Memory Core migration suite: 36/36 tests passed, covering metadata, chunk, cache, vector-row, and FTS collisions plus vector-dimension and orphan-reference negative cases.
- Live operator flow on Blacksmith Testbox: released-state fixture, `openclaw doctor --fix --yes --non-interactive`, canonical SQLite before/after assertion, second Doctor run, Gateway start, and `/readyz` response `{"ready":true,"failing":[]}`. [Run](https://github.com/openclaw/openclaw/actions/runs/29474731853)
- Changed extension lanes passed: formatting, production and test typechecks, lint, Plugin SDK baseline, plugin boundaries, database-first guard, runtime-sidecar loader guard, and import-cycle check. [Run](https://github.com/openclaw/openclaw/actions/runs/29475109424)
- Fresh Codex autoreview returned no findings twice at 0.90 confidence.

AI-assisted: yes. I reviewed the ownership boundary, current and shipped behavior, related fixes, SQLite conflict/transaction contracts, tests, and the live operator path.
