### PR TITLE
fix(line): avoid exposing media URLs in errors

### DIFF
--- a/extensions/line/src/auto-reply-delivery.test.ts
+++ b/extensions/line/src/auto-reply-delivery.test.ts
@@ -2,6 +2,7 @@
 import { expectDefined } from "@openclaw/normalization-core";
 import { describe, expect, it, vi } from "vitest";
 import { deliverLineAutoReply } from "./auto-reply-delivery.js";
+import { buildLineMediaMessage } from "./outbound-media.js";
 import { sendLineReplyChunks } from "./reply-chunks.js";
 import { createLineSendReceipt } from "./send-receipt.js";
 
@@ -636,6 +637,34 @@ describe("deliverLineAutoReply", () => {
         deps,
       }),
     ).rejects.toThrow(/require previewImageUrl/i);
+
+    expect(replyMessageLine).not.toHaveBeenCalled();
+    expect(pushMessagesLine).not.toHaveBeenCalled();
+  });
+
+  it("does not expose credentials from media-only validation failures", async () => {
+    const lineData = { mediaKind: "image" as const };
+    const mediaUrl = new URL("http://example.com/image.jpg");
+    mediaUrl.username = ["line", "user"].join("-");
+    mediaUrl.password = ["line", "fixture"].join("-");
+    mediaUrl.searchParams.set("auth", ["line", "query"].join("-"));
+    const { deps, replyMessageLine, pushMessagesLine } = createDeps({
+      processLineMessage: () => ({ text: "", flexMessages: [] }),
+      chunkMarkdownText: () => [],
+      buildMediaMessage: buildLineMediaMessage,
+    });
+
+    await expect(
+      deliverLineAutoReply({
+        ...baseDeliveryParams,
+        payload: {
+          mediaUrls: [mediaUrl.href],
+          channelData: { line: lineData },
+        },
+        lineData,
+        deps,
+      }),
+    ).rejects.toThrow(new Error("LINE outbound media URL must use HTTPS"));
 
     expect(replyMessageLine).not.toHaveBeenCalled();
     expect(pushMessagesLine).not.toHaveBeenCalled();

--- a/extensions/line/src/outbound-media.test.ts
+++ b/extensions/line/src/outbound-media.test.ts
@@ -21,6 +21,18 @@ import {
   validateLineMediaUrl,
 } from "./outbound-media.js";
 
+async function captureError(run: () => Promise<unknown>): Promise<Error> {
+  try {
+    await run();
+  } catch (error) {
+    if (error instanceof Error) {
+      return error;
+    }
+    throw error;
+  }
+  throw new Error("expected operation to reject");
+}
+
 describe("validateLineMediaUrl", () => {
   beforeEach(() => {
     ssrfMocks.resolvePinnedHostnameWithPolicy.mockReset();
@@ -49,6 +61,20 @@ describe("validateLineMediaUrl", () => {
       /must use HTTPS/i,
     );
     expect(ssrfMocks.resolvePinnedHostnameWithPolicy).not.toHaveBeenCalled();
+  });
+
+  it("does not include credential-bearing URLs in validation errors", async () => {
+    const credentialMarker = "line-media-secret";
+    const invalidUrl = `not a url?token=${credentialMarker}#${credentialMarker}`;
+    const insecureUrl = `http://user:${credentialMarker}@example.com/image.jpg?token=${credentialMarker}#${credentialMarker}`;
+
+    const invalidError = await captureError(() => validateLineMediaUrl(invalidUrl));
+    expect(invalidError.message).toMatch(/must be a valid URL/i);
+    expect(invalidError.message).not.toContain(credentialMarker);
+
+    const insecureError = await captureError(() => validateLineMediaUrl(insecureUrl));
+    expect(insecureError.message).toMatch(/must use HTTPS/i);
+    expect(insecureError.message).not.toContain(credentialMarker);
   });
 
   it("rejects URL longer than 2000 chars", async () => {
@@ -167,9 +193,14 @@ describe("resolveLineOutboundMedia", () => {
   });
 
   it("rejects non-HTTPS URL explicitly", async () => {
-    await expect(resolveLineOutboundMedia("http://example.com/image.jpg")).rejects.toThrow(
-      /must use HTTPS/i,
+    const credentialMarker = "line-media-secret";
+    const error = await captureError(() =>
+      resolveLineOutboundMedia(
+        `http://user:${credentialMarker}@example.com/image.jpg?token=${credentialMarker}`,
+      ),
     );
+    expect(error.message).toMatch(/must use HTTPS/i);
+    expect(error.message).not.toContain(credentialMarker);
   });
 });
 

--- a/extensions/line/src/outbound-media.test.ts
+++ b/extensions/line/src/outbound-media.test.ts
@@ -21,16 +21,15 @@ import {
   validateLineMediaUrl,
 } from "./outbound-media.js";
 
-async function captureError(run: () => Promise<unknown>): Promise<Error> {
-  try {
-    await run();
-  } catch (error) {
-    if (error instanceof Error) {
-      return error;
-    }
-    throw error;
-  }
-  throw new Error("expected operation to reject");
+const HTTPS_URL_ERROR = new Error("LINE outbound media URL must use HTTPS");
+
+function createCredentialBearingHttpUrl(): string {
+  const url = new URL("http://example.com/image.jpg");
+  url.username = ["line", "user"].join("-");
+  url.password = ["line", "fixture"].join("-");
+  url.searchParams.set("auth", ["line", "query"].join("-"));
+  url.hash = ["line", "fragment"].join("-");
+  return url.href;
 }
 
 describe("validateLineMediaUrl", () => {
@@ -56,25 +55,33 @@ describe("validateLineMediaUrl", () => {
     });
   });
 
-  it("rejects HTTP URL", async () => {
-    await expect(validateLineMediaUrl("http://example.com/image.jpg")).rejects.toThrow(
-      /must use HTTPS/i,
-    );
-    expect(ssrfMocks.resolvePinnedHostnameWithPolicy).not.toHaveBeenCalled();
-  });
-
-  it("does not include credential-bearing URLs in validation errors", async () => {
-    const credentialMarker = "line-media-secret";
-    const invalidUrl = `not a url?token=${credentialMarker}#${credentialMarker}`;
-    const insecureUrl = `http://user:${credentialMarker}@example.com/image.jpg?token=${credentialMarker}#${credentialMarker}`;
-
-    const invalidError = await captureError(() => validateLineMediaUrl(invalidUrl));
-    expect(invalidError.message).toMatch(/must be a valid URL/i);
-    expect(invalidError.message).not.toContain(credentialMarker);
-
-    const insecureError = await captureError(() => validateLineMediaUrl(insecureUrl));
-    expect(insecureError.message).toMatch(/must use HTTPS/i);
-    expect(insecureError.message).not.toContain(credentialMarker);
+  it.each([
+    {
+      name: "malformed media URL",
+      run: () => validateLineMediaUrl("not a url?query=fixture#fragment"),
+      expected: new Error("LINE outbound media URL must be a valid URL"),
+    },
+    {
+      name: "insecure media URL",
+      run: () => validateLineMediaUrl(createCredentialBearingHttpUrl()),
+      expected: HTTPS_URL_ERROR,
+    },
+    {
+      name: "insecure preview URL",
+      run: () =>
+        resolveLineOutboundMedia("https://example.com/video.mp4", {
+          mediaKind: "video",
+          previewImageUrl: createCredentialBearingHttpUrl(),
+        }),
+      expected: HTTPS_URL_ERROR,
+    },
+    {
+      name: "insecure resolved media URL",
+      run: () => resolveLineOutboundMedia(createCredentialBearingHttpUrl()),
+      expected: HTTPS_URL_ERROR,
+    },
+  ])("does not expose credentials from a $name", async ({ run, expected }) => {
+    await expect(run()).rejects.toThrow(expected);
   });
 
   it("rejects URL longer than 2000 chars", async () => {
@@ -168,15 +175,6 @@ describe("resolveLineOutboundMedia", () => {
     });
   });
 
-  it("validates previewImageUrl when provided", async () => {
-    await expect(
-      resolveLineOutboundMedia("https://example.com/video.mp4", {
-        mediaKind: "video",
-        previewImageUrl: "http://example.com/preview.jpg",
-      }),
-    ).rejects.toThrow(/must use HTTPS/i);
-  });
-
   it("falls back to image when no explicit LINE media options or known extension are present", async () => {
     await expect(
       resolveLineOutboundMedia("https://example.com/download?id=audio"),
@@ -190,17 +188,6 @@ describe("resolveLineOutboundMedia", () => {
     await expect(resolveLineOutboundMedia("./assets/image.jpg")).rejects.toThrow(
       /requires a public https url/i,
     );
-  });
-
-  it("rejects non-HTTPS URL explicitly", async () => {
-    const credentialMarker = "line-media-secret";
-    const error = await captureError(() =>
-      resolveLineOutboundMedia(
-        `http://user:${credentialMarker}@example.com/image.jpg?token=${credentialMarker}`,
-      ),
-    );
-    expect(error.message).toMatch(/must use HTTPS/i);
-    expect(error.message).not.toContain(credentialMarker);
   });
 });
 

--- a/extensions/line/src/outbound-media.ts
+++ b/extensions/line/src/outbound-media.ts
@@ -95,15 +95,14 @@ export async function resolveLineOutboundMedia(
     };
   }
 
+  let parsed: URL | undefined;
   try {
-    const parsed = new URL(trimmedUrl);
-    if (parsed.protocol !== "https:") {
-      throw new Error("LINE outbound media URL must use HTTPS");
-    }
-  } catch (e) {
-    if (e instanceof Error && e.message.startsWith("LINE outbound")) {
-      throw e;
-    }
+    parsed = new URL(trimmedUrl);
+  } catch {
+    // Local paths reach the generic public-HTTPS error below.
+  }
+  if (parsed) {
+    throw new Error("LINE outbound media URL must use HTTPS");
   }
   throw new Error("LINE outbound media currently requires a public HTTPS URL");
 }

--- a/extensions/line/src/outbound-media.ts
+++ b/extensions/line/src/outbound-media.ts
@@ -30,10 +30,10 @@ export async function validateLineMediaUrl(url: string): Promise<void> {
   try {
     parsed = new URL(url);
   } catch {
-    throw new Error(`LINE outbound media URL must be a valid URL: ${url}`);
+    throw new Error("LINE outbound media URL must be a valid URL");
   }
   if (parsed.protocol !== "https:") {
-    throw new Error(`LINE outbound media URL must use HTTPS: ${url}`);
+    throw new Error("LINE outbound media URL must use HTTPS");
   }
   if (url.length > 2000) {
     throw new Error(`LINE outbound media URL must be 2000 chars or less (got ${url.length})`);
@@ -98,7 +98,7 @@ export async function resolveLineOutboundMedia(
   try {
     const parsed = new URL(trimmedUrl);
     if (parsed.protocol !== "https:") {
-      throw new Error(`LINE outbound media URL must use HTTPS: ${trimmedUrl}`);
+      throw new Error("LINE outbound media URL must use HTTPS");
     }
   } catch (e) {
     if (e instanceof Error && e.message.startsWith("LINE outbound")) {

--- a/extensions/line/src/send.test.ts
+++ b/extensions/line/src/send.test.ts
@@ -94,6 +94,14 @@ const LINE_TEST_CFG = {
   },
 };
 
+function createCredentialBearingHttpUrl(): string {
+  const url = new URL("http://example.com/image.jpg");
+  url.username = ["line", "user"].join("-");
+  url.password = ["line", "fixture"].join("-");
+  url.searchParams.set("auth", ["line", "query"].join("-"));
+  return url.href;
+}
+
 describe("LINE send helpers", () => {
   const fixedSentAt = 1_800_000_000_000;
 
@@ -348,6 +356,48 @@ describe("LINE send helpers", () => {
     ).rejects.toThrow(/private network/i);
 
     expect(pushMessageMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {
+      name: "send media URL",
+      run: () =>
+        sendModule.sendMessageLine("line:user:U200", "Image", {
+          cfg: LINE_TEST_CFG,
+          mediaUrl: createCredentialBearingHttpUrl(),
+        }),
+    },
+    {
+      name: "send preview URL",
+      run: () =>
+        sendModule.sendMessageLine("line:user:U200", "Video", {
+          cfg: LINE_TEST_CFG,
+          mediaUrl: "https://example.com/video.mp4",
+          mediaKind: "video",
+          previewImageUrl: createCredentialBearingHttpUrl(),
+        }),
+    },
+    {
+      name: "push image URL",
+      run: () =>
+        sendModule.pushImageMessage("line:user:U200", createCredentialBearingHttpUrl(), undefined, {
+          cfg: LINE_TEST_CFG,
+        }),
+    },
+    {
+      name: "push image preview URL",
+      run: () =>
+        sendModule.pushImageMessage(
+          "line:user:U200",
+          "https://example.com/image.jpg",
+          createCredentialBearingHttpUrl(),
+          { cfg: LINE_TEST_CFG },
+        ),
+    },
+  ])("does not expose credentials from an insecure $name", async ({ run }) => {
+    await expect(run()).rejects.toThrow(new Error("LINE outbound media URL must use HTTPS"));
+    expect(pushMessageMock).not.toHaveBeenCalled();
+    expect(replyMessageMock).not.toHaveBeenCalled();
   });
 
   it("omits trackingId for non-user destinations", async () => {


### PR DESCRIPTION
## What Problem This Solves

LINE outbound media validation included the complete caller-provided URL in invalid-URL and non-HTTPS errors. Signed media URLs commonly carry temporary credentials in userinfo, query parameters, or fragments, so propagating those errors could expose credential material in logs or user-visible tool results.

## Why This Change Was Made

Keeps the existing validation decisions and actionable reason text while removing the raw URL from error messages. The oversized-URL error remains unchanged because it reports only the input length. The change stays within the LINE plugin and adds no dependency, configuration, compatibility behavior, or public API.

## User Impact

Invalid and non-HTTPS LINE media URLs continue to be rejected with the same reason. Their full credential-bearing value is no longer included in the resulting error.

## Evidence

Exact head: `d11acb9a6c045d23ed08c73d4c12facfac86ff6e`.

- Node `24.18.0`, Vitest `4.1.9`
- `node scripts/run-vitest.mjs extensions/line/src/outbound-media.test.ts --reporter=verbose` -> 21 passed
- `oxfmt --check extensions/line/src/outbound-media.ts extensions/line/src/outbound-media.test.ts` -> passed
- `git diff --check` -> passed

Testbox and brokered Crabbox are unavailable to this external contributor, so the focused repository test wrapper was used as the documented local fallback. Fresh Claude autoreview was attempted but timed out without output; no clean autoreview result is claimed. GitHub CI and normal maintainer review remain required.

## Agent Transcript

<details>
<summary>Redacted Codex session transcript</summary>

```text
User requested another independently branched security contribution after the previous Zalo hardening PR merged.

Codex synchronized a clean worktree to official main at c92481929 and screened credential comparisons, response limits, redirect handling, and diagnostic exposure. Reef response limiting was rejected because open PR #106456 already covers it; local nonce and loopback bearer candidates were rejected because they do not cross the documented trust boundary.

Codex selected LINE media URL error exposure because signed media URLs can carry temporary credentials and the validation errors reproduced the complete input. The approved design preserves validation and reason text while removing the raw URL.

Implementation changed extensions/line/src/outbound-media.ts and extensions/line/src/outbound-media.test.ts. The focused LINE shard passed 21/21 on Node 24.18.0 and Vitest 4.1.9; formatting and git diff checks passed. Autoreview timed out, and that proof gap is recorded above.
```

</details>
