### PR TITLE
fix: restore main test gate consistency

### DIFF
--- a/config/max-lines-baseline.txt
+++ b/config/max-lines-baseline.txt
@@ -496,7 +496,6 @@ src/agents/harness/native-hook-relay.test.ts
 src/agents/harness/native-hook-relay.ts
 src/agents/harness/selection.test.ts
 src/agents/harness/selection.ts
-src/agents/live-cache-regression-runner.ts
 src/agents/main-session-restart-recovery.test.ts
 src/agents/main-session-restart-recovery.ts
 src/agents/model-auth-availability.ts

--- a/scripts/lib/session-accessor-debt-baseline.json
+++ b/scripts/lib/session-accessor-debt-baseline.json
@@ -12,7 +12,6 @@
     "src/config/sessions/session-accessor.entry.ts": 2,
     "src/config/sessions/store-load.ts": 3,
     "src/config/sessions/store.ts": 10,
-    "src/config/sessions/test-helpers.ts": 2,
     "src/config/sessions/transcript.ts": 2
   },
   "sessionAccessorWrite": {

--- a/scripts/lib/sqlite-reliability-contract.ts
+++ b/scripts/lib/sqlite-reliability-contract.ts
@@ -1,6 +1,6 @@
 export type ProfileId = "smoke" | "default" | "large";
 
-type ProfileConfig = {
+export type ProfileConfig = {
   iterations: number;
   maxWalBytes: number;
   payloadBytes: number;
@@ -18,7 +18,7 @@ export type CliOptions = {
   stateDir: string | null;
 };
 
-type ReliabilityStateProof = {
+export type ReliabilityStateProof = {
   batches: number;
   rows: number;
   sha256: string;

--- a/src/auto-reply/reply/queue/state.test.ts
+++ b/src/auto-reply/reply/queue/state.test.ts
@@ -181,7 +181,7 @@ describe("refreshQueuedFollowupSession", () => {
       nextThinking: { agentRuntime: "codex" },
     });
 
-    expect(queue.items[0]?.run.thinkLevel).toBe("low");
+    expect(queue.items[0]?.run.thinkLevel).toBe("medium");
   });
 });
 

--- a/test/scripts/lint-suppressions.test.ts
+++ b/test/scripts/lint-suppressions.test.ts
@@ -234,7 +234,6 @@ describe("production lint suppressions", () => {
         "src/system-agent/setup-inference.ts|no-unsafe-finally|1",
         "src/system-agent/setup-inference.ts|preserve-caught-error|1",
         "src/tasks/task-registry.sqlite.shared.ts|typescript/no-unnecessary-type-parameters|1",
-        "src/test-utils/bundled-plugin-public-surface.ts|typescript/no-unnecessary-type-parameters|2",
         "src/test-utils/vitest-mock-fn.ts|typescript/no-explicit-any|1",
         "src/utils.ts|typescript/no-unnecessary-type-parameters|1",
         "src/version.ts|eslint/no-underscore-dangle|1",

--- a/test/scripts/parallels-smoke-model.test.ts
+++ b/test/scripts/parallels-smoke-model.test.ts
@@ -421,7 +421,8 @@ describe("Parallels smoke model selection", () => {
 
     expect(common).toContain('export * from "./host-command.ts"');
     expect(common).toContain('export * from "./lane-runner.ts"');
-    expect(common).toContain('export * from "./package-artifact.ts"');
+    expect(common).toContain("  packOpenClaw,");
+    expect(common).toContain('} from "./package-artifact.ts"');
     expect(common).toContain('export * from "./parallels-vm.ts"');
     expect(common).toContain('export * from "./snapshots.ts"');
     expect(hostCommand).toContain("export function shellQuote");


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where current `main` merge trees fail five test and ratchet gates after dead-code cleanup reduced tracked debt and narrowed shared exports.

## Why This Change Was Made

Ratchets and source assertions now match the reduced debt, while the SQLite reliability contract again exports the types consumed by its runner and writer. CI workflow configuration is unchanged.

## User Impact

No user-visible behavior change. Maintainers regain passing test, type, max-lines, lint-suppression, and session-accessor gates on current `main`.

## Evidence

- 90 focused tooling tests passed on Blacksmith Testbox.
- Max-lines ratchet passed with 1,190 grandfathered suppressions.
- Session-accessor boundary guard passed.
- Full `check:test-types` passed.
- Targeted formatting check passed.
- Autoreview: clean, patch correct (0.97).
