### PR TITLE
fix(cli): reject oversized --file input before reading in config patch

### DIFF
--- a/src/cli/config-cli.test.ts
+++ b/src/cli/config-cli.test.ts
@@ -3819,5 +3819,39 @@ describe("config cli", () => {
       expect(mockLog).toHaveBeenCalledWith("/home/user/.openclaw/openclaw.json");
     });
   });
+
+  describe("config patch --file size guard", () => {
+    it("rejects oversized --file input before reading", async () => {
+      const largeContent = "x".repeat(2 * 1024 * 1024);
+      const pathname = writeTempJson5File("openclaw-config-patch-oversize", {
+        channels: { slack: { botToken: largeContent } },
+      });
+      try {
+        await expect(
+          runConfigCommand(["config", "patch", "--file", pathname, "--dry-run"]),
+        ).rejects.toThrow(/exceeds maximum size/);
+      } finally {
+        fs.rmSync(pathname, { force: true });
+      }
+    });
+
+    it("accepts normal-sized --file input", async () => {
+      const resolved = {
+        channels: { slack: { enabled: true } },
+      } as unknown as OpenClawConfig;
+      setSnapshot(resolved, resolved);
+
+      const pathname = writeTempJson5File("openclaw-config-patch-small", {
+        channels: { slack: { enabled: true } },
+      });
+      try {
+        await expect(
+          runConfigCommand(["config", "patch", "--file", pathname, "--dry-run"]),
+        ).resolves.not.toThrow();
+      } finally {
+        fs.rmSync(pathname, { force: true });
+      }
+    });
+  });
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/cli/config-cli.ts
+++ b/src/cli/config-cli.ts
@@ -1494,6 +1494,16 @@ async function readConfigPatchInput(opts: ConfigPatchOptions): Promise<unknown> 
     throw configPatchModeError("provide exactly one of --file <path> or --stdin.");
   }
   const sourceLabel = stdin ? "--stdin" : "--file";
+  if (!stdin) {
+    const configPath = file as string;
+    const stat = fs.statSync(configPath);
+    if (!stat.isFile()) {
+      throw new Error(`--file path is not a regular file: ${configPath}`);
+    }
+    if (stat.size > 1024 * 1024) {
+      throw new Error(`--file exceeds maximum size of 1 MB: ${configPath} (${stat.size} bytes)`);
+    }
+  }
   const raw = stdin ? await readStdinText() : fs.readFileSync(file as string, "utf8");
   try {
     return JSON5.parse(raw);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where `openclaw config patch --file <path>` reads the file body before any size check. A user could hand the CLI an oversized file and have its entire content loaded into memory before a size check rejects it. Same pattern as #108130 (cron trigger script).

## Changes

- `src/cli/config-cli.ts:1497`: Add `statSync` check before `readFileSync` — rejects non-regular files and files > 1 MB before reading
- `src/cli/config-cli.test.ts`: 2 new tests (oversized rejection + normal acceptance)

## Evidence

### 🐚 Real terminal output — `npx tsx proof/config-file-size-guard.proof.ts`

```
Hostname: LIN-66D8BD4EA2C
PID:      294245
Timestamp: 2026-07-16 06:29:06

─── 1. Source code: size guard in readConfigPatchInput ───
  ✅ statSync() (line 1499) called BEFORE readFileSync() (line 1507)

─── 2. Unit tests (vitest) ───
 ✓ |cli| config patch --file size guard > rejects oversized --file input before reading
 ✓ |cli| config patch --file size guard > accepts normal-sized --file input
 Test Files  1 passed (1)  |  Tests  2 passed | 129 skipped (131)

─── 3. Behavior demo (standalone Node.js fs) ───
  ✅ Small file (39 bytes) — passes size check ✓
  ✅ Large file (2.0 MB) — correctly identified as oversized ✓
  ✅ Non-regular file (directory) — correctly rejected ✓

─── 4. Diff summary ───
 2 files changed, 44 insertions(+)
============================================================
 Result: ✅ ALL PASSED (9/9)
============================================================
```

### Before/After

**Before（修复前）：**
```typescript
// readFileSync 先读取全部内容到内存
const raw = fs.readFileSync(file as string, "utf8");
// ... 后续可能校验大小
```

**After（修复后）：**
```typescript
// statSync 先检查，超限直接拒绝，不读内容
const stat = fs.statSync(configPath);
if (!stat.isFile()) throw ...;
if (stat.size > 1024 * 1024) throw ...;
const raw = fs.readFileSync(file as string, "utf8");
```

**Diff:**
```diff
+  if (!stdin) {
+    const configPath = file as string;
+    const stat = fs.statSync(configPath);
+    if (!stat.isFile()) {
+      throw new Error("--file path is not a regular file: " + configPath);
+    }
+    if (stat.size > 1024 * 1024) {
+      throw new Error("--file exceeds maximum size of 1 MB: " + configPath + " (" + stat.size + " bytes)");
+    }
+  }
```

## Review
- Manually reviewed and verified
- AI-assisted: Yes