### PR TITLE
fix(update): repair obsolete managed Gateway Node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- **Gateway update Node repair:** let restart-enabled package updates replace an obsolete Node path recorded in an owned managed service with the compatible current CLI Node, while keeping no-restart updates fail-before-mutation.
 - **ClickClack guided setup:** configure ClickClack from `openclaw onboard` or `openclaw channels add clickclack` with URL, token, and workspace prompts, default-account env fallback, nonfatal live connection validation, and gateway-aware next steps that connect automatically when OpenClaw is already running. Thanks @shakkernerd.
 - **ClickClack command menus:** publish each bot's native OpenClaw commands to ClickClack composer autocomplete at gateway startup, with per-account opt-out and nonfatal compatibility handling for older tokens and servers. Thanks @shakkernerd.
 - **Skill Workshop approvals:** run agent-initiated apply, reject, and quarantine actions without an additional approval prompt by default while preserving `skills.workshop.approvalPolicy: "pending"` as an opt-in approval gate. Thanks @shakkernerd.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
-- **Gateway update Node repair:** let restart-enabled package updates replace an obsolete Node path recorded in an owned managed service with the compatible current CLI Node, while keeping no-restart updates fail-before-mutation.
 - **ClickClack guided setup:** configure ClickClack from `openclaw onboard` or `openclaw channels add clickclack` with URL, token, and workspace prompts, default-account env fallback, nonfatal live connection validation, and gateway-aware next steps that connect automatically when OpenClaw is already running. Thanks @shakkernerd.
 - **ClickClack command menus:** publish each bot's native OpenClaw commands to ClickClack composer autocomplete at gateway startup, with per-account opt-out and nonfatal compatibility handling for older tokens and servers. Thanks @shakkernerd.
 - **Skill Workshop approvals:** run agent-initiated apply, reject, and quarantine actions without an additional approval prompt by default while preserving `skills.workshop.approvalPolicy: "pending"` as an opt-in approval gate. Thanks @shakkernerd.

--- a/docs/cli/update.md
+++ b/docs/cli/update.md
@@ -174,6 +174,13 @@ Package-manager updates additionally verify the restarted Gateway reports the
 expected package version; git-checkout updates verify gateway health and
 service readiness after the rebuild.
 
+Package-manager updates normally keep using the Node binary recorded in the
+managed service. If that Node cannot run the target release, but the current
+CLI Node can and the service is proven to belong to the package being updated,
+a restart-enabled update uses the current Node for finalization and rewrites
+the service metadata to that runtime. `--no-restart` cannot repair service
+metadata, so the same runtime mismatch stops before package mutation.
+
 On macOS, the post-update check also verifies the LaunchAgent is
 loaded/running for the active profile and the configured loopback port is
 healthy. If the plist is installed but launchd is not supervising it, OpenClaw

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -4859,7 +4859,7 @@ describe("update-cli", () => {
     expect(logs).toContain(`Managed gateway service Node: ${serviceNode}`);
   });
 
-  it("checks the managed service Node runtime before updating a redirected package root", async () => {
+  it("blocks a stale managed service Node before a no-restart package update", async () => {
     const shellRoot = createCaseDir("openclaw-shell-root");
     const serviceRoot = await createTrackedTempDir("openclaw-service-root-");
     const serviceNode = path.join(path.dirname(serviceRoot), "bin", "node");
@@ -4902,7 +4902,7 @@ describe("update-cli", () => {
     });
     nodeVersionSatisfiesEngine.mockReturnValue(false);
 
-    await updateCommand({ yes: true });
+    await updateCommand({ yes: true, restart: false });
 
     expect(nodeVersionSatisfiesEngine).toHaveBeenCalledWith("22.18.0", ">=22.19.0");
     expect(packageInstallCommandCall()).toBeUndefined();
@@ -5041,7 +5041,7 @@ describe("update-cli", () => {
     );
   });
 
-  it("uses the managed service Node for follow-up commands when roots match but nodes differ", async () => {
+  it("refreshes the managed service to current Node when its baked Node cannot run the target", async () => {
     const servicePrefix = await createTrackedTempDir("openclaw-service-prefix-");
     const nodeModules = path.join(servicePrefix, "lib", "node_modules");
     const root = path.join(nodeModules, "openclaw");
@@ -5066,6 +5066,14 @@ describe("update-cli", () => {
       programArguments: [serviceNode, entrypoint, "gateway"],
     });
     serviceLoaded.mockResolvedValue(true);
+    vi.mocked(fetchNpmPackageTargetStatus).mockResolvedValue({
+      target: "latest",
+      version: "2026.7.1",
+      nodeEngine: ">=24.15.0 <25",
+    });
+    nodeVersionSatisfiesEngine.mockImplementation(
+      (version: string | null) => version === "24.15.0",
+    );
     pathExists.mockImplementation(async (candidate: string) => {
       try {
         await fs.access(candidate);
@@ -5078,6 +5086,16 @@ describe("update-cli", () => {
       if (Array.isArray(argv) && argv[0] === serviceNode && argv[1] === "--version") {
         return {
           stdout: "v24.14.0\n",
+          stderr: "",
+          code: 0,
+          signal: null,
+          killed: false,
+          termination: "exit",
+        };
+      }
+      if (Array.isArray(argv) && argv[0] === process.execPath && argv[1] === "--version") {
+        return {
+          stdout: "v24.15.0\n",
           stderr: "",
           code: 0,
           signal: null,
@@ -5133,13 +5151,20 @@ describe("update-cli", () => {
 
     await updateCommand({ yes: true });
 
-    // Follow-up commands should use the service Node, not process.execPath.
-    expect(doctorCommandCall()?.[0][0]).toBe(serviceNode);
-    expect(spawnCall()?.[0]).toBe(serviceNode);
+    expect(nodeVersionSatisfiesEngine).toHaveBeenCalledWith("24.14.0", ">=24.15.0 <25");
+    expect(nodeVersionSatisfiesEngine).toHaveBeenCalledWith("24.15.0", ">=24.15.0 <25");
+    expect(doctorCommandCall()?.[0][0]).toBe(process.execPath);
+    expect(spawnCall()?.[0]).toBe(process.execPath);
     const serviceInstallCall = commandCalls().find(
       ([argv]) => argv[2] === "gateway" && argv[3] === "install",
     );
-    expect(serviceInstallCall?.[0][0]).toBe(serviceNode);
+    expect(serviceInstallCall?.[0][0]).toBe(process.execPath);
+    const logs = vi
+      .mocked(defaultRuntime.log)
+      .mock.calls.map((call) => String(call[0]))
+      .join("\n");
+    expect(logs).toContain(`Managed gateway service Node (${serviceNode}) cannot run`);
+    expect(logs).toContain(`Using current Node (${process.execPath})`);
   });
 
   it("pins package install to the service root when nodes differ and no owning npm exists at the prefix", async () => {

--- a/src/cli/update-cli/update-command-service.ts
+++ b/src/cli/update-cli/update-command-service.ts
@@ -720,7 +720,7 @@ export function tryResolveInvocationCwd(): string | undefined {
   }
 }
 
-export type PackageRuntimePreflightResult = {
+type PackageRuntimePreflightResult = {
   error: string | null;
   nodeRunner?: string;
   replacedNodeRunner?: string;

--- a/src/cli/update-cli/update-command-service.ts
+++ b/src/cli/update-cli/update-command-service.ts
@@ -720,24 +720,37 @@ export function tryResolveInvocationCwd(): string | undefined {
   }
 }
 
-export async function resolvePackageRuntimePreflightError(params: {
+export type PackageRuntimePreflightResult = {
+  error: string | null;
+  nodeRunner?: string;
+  replacedNodeRunner?: string;
+  targetVersion?: string;
+};
+
+export async function resolvePackageRuntimePreflight(params: {
   tag: string;
   timeoutMs?: number;
   nodeRunner?: string;
+  fallbackNodeRunner?: string;
   spec?: string;
   command?: string;
   cwd?: string;
   env?: NodeJS.ProcessEnv;
-}): Promise<string | null> {
+}): Promise<PackageRuntimePreflightResult> {
+  const nodeRunner = normalizeOptionalString(params.nodeRunner);
+  const unchanged = (): PackageRuntimePreflightResult => ({
+    error: null,
+    ...(nodeRunner ? { nodeRunner } : {}),
+  });
   if (!canResolveRegistryVersionForPackageTarget(params.tag)) {
-    return null;
+    return unchanged();
   }
   if (params.spec && !canResolveRegistryVersionForPackageTarget(params.spec)) {
-    return null;
+    return unchanged();
   }
   const target = params.tag.trim();
   if (!target) {
-    return null;
+    return unchanged();
   }
   const status = await fetchNpmPackageTargetStatus({
     target,
@@ -748,29 +761,63 @@ export async function resolvePackageRuntimePreflightError(params: {
     env: params.env,
   });
   if (status.error) {
-    return null;
+    return unchanged();
   }
   const runtime = await resolvePackageRuntimeForPreflight({
-    nodeRunner: params.nodeRunner,
+    nodeRunner,
     timeoutMs: params.timeoutMs,
   });
   const satisfies = nodeVersionSatisfiesEngine(runtime.version, status.nodeEngine);
-  if (satisfies !== false) {
-    return null;
+  const targetVersion = status.version ?? target;
+  if (satisfies === true) {
+    return {
+      error: null,
+      ...(nodeRunner ? { nodeRunner } : {}),
+      targetVersion,
+    };
   }
-  const targetLabel = status.version ?? target;
+  const fallbackNodeRunner = normalizeOptionalString(params.fallbackNodeRunner);
+  if (nodeRunner && fallbackNodeRunner && fallbackNodeRunner !== nodeRunner) {
+    const fallbackRuntime = await resolvePackageRuntimeForPreflight({
+      nodeRunner: fallbackNodeRunner,
+      timeoutMs: params.timeoutMs,
+    });
+    const fallbackSatisfies = nodeVersionSatisfiesEngine(
+      fallbackRuntime.version,
+      status.nodeEngine,
+    );
+    if (fallbackSatisfies === true) {
+      return {
+        error: null,
+        nodeRunner: fallbackNodeRunner,
+        replacedNodeRunner: nodeRunner,
+        targetVersion,
+      };
+    }
+  }
+  if (satisfies !== false) {
+    return {
+      error: null,
+      ...(nodeRunner ? { nodeRunner } : {}),
+      targetVersion,
+    };
+  }
   const runtimeLabel = runtime.nodeRunner
     ? `Node ${runtime.version ?? "unknown"} at ${runtime.nodeRunner}`
     : `Node ${runtime.version ?? "unknown"}`;
-  return [
-    `${runtimeLabel} is too old for openclaw@${targetLabel}.`,
-    `The requested package requires ${status.nodeEngine}.`,
-    runtime.nodeRunner
-      ? "Upgrade the Node runtime that owns the managed Gateway service, then rerun `openclaw update`."
-      : "Upgrade to Node 22.22.3+, Node 24.15.0+, or Node 25.9.0+, then rerun `openclaw update`.",
-    "Bare `npm i -g openclaw` can silently install an older compatible release.",
-    "After upgrading Node, use `npm i -g openclaw@latest`.",
-  ].join("\n");
+  return {
+    error: [
+      `${runtimeLabel} is too old for openclaw@${targetVersion}.`,
+      `The requested package requires ${status.nodeEngine}.`,
+      runtime.nodeRunner
+        ? "Upgrade the Node runtime that owns the managed Gateway service, then rerun `openclaw update`."
+        : "Upgrade to Node 22.22.3+, Node 24.15.0+, or Node 25.9.0+, then rerun `openclaw update`.",
+      "Bare `npm i -g openclaw` can silently install an older compatible release.",
+      "After upgrading Node, use `npm i -g openclaw@latest`.",
+    ].join("\n"),
+    ...(nodeRunner ? { nodeRunner } : {}),
+    targetVersion,
+  };
 }
 
 async function resolvePackageRuntimeForPreflight(params: {

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -125,7 +125,7 @@ import {
   maybeStopManagedServiceBeforeMutableUpdate,
   resolveManagedServiceNodeRunnerOverride,
   resolveManagedServicePackageUpdateRoot,
-  resolvePackageRuntimePreflightError,
+  resolvePackageRuntimePreflight,
   resolvePostInstallDoctorEnv,
   resolvePostUpdateServiceStateReadEnv,
   resolveUpdatedGatewayRestartPort,
@@ -736,6 +736,7 @@ async function updateCommandInternal(
   // where the package root is the same but the user's PATH-resolved node
   // differs from the node baked into the managed gateway service unit.
   let managedServiceNodeRunner: string | undefined;
+  let packageUpdateNodeRunner: string | undefined;
 
   if (updateInstallKind === "package") {
     managedServiceRootRedirect = await resolveManagedServicePackageUpdateRoot({ root });
@@ -781,6 +782,7 @@ async function updateCommandInternal(
         );
       }
     }
+    packageUpdateNodeRunner = managedServiceNodeRunner;
   }
 
   if (updateInstallKind !== "git") {
@@ -983,19 +985,39 @@ async function updateCommandInternal(
   }
 
   if (updateInstallKind === "package") {
-    const runtimePreflightError = await resolvePackageRuntimePreflightError({
+    // Changing runners is safe only when this update owns and will rewrite the
+    // service; otherwise the unchanged unit could still restart on the stale Node.
+    const canRefreshManagedServiceNode =
+      shouldRestart &&
+      managedServiceNodeRunner !== undefined &&
+      (await gatewayServiceCommandUsesRoot({ root })) === true;
+    const runtimePreflight = await resolvePackageRuntimePreflight({
       tag,
       spec: packageInstallSpec ?? undefined,
       timeoutMs,
       nodeRunner: managedServiceNodeRunner,
+      fallbackNodeRunner: canRefreshManagedServiceNode ? resolveNodeRunner() : undefined,
       command: packageInstallTarget?.manager === "npm" ? packageInstallTarget.command : undefined,
       cwd: packageInstallCwd,
       env: packageInstallEnv,
     });
-    if (runtimePreflightError) {
-      defaultRuntime.error(runtimePreflightError);
+    if (runtimePreflight.error) {
+      defaultRuntime.error(runtimePreflight.error);
       defaultRuntime.exit(1);
       return;
+    }
+    packageUpdateNodeRunner = runtimePreflight.nodeRunner;
+    if (runtimePreflight.replacedNodeRunner && !opts.json) {
+      defaultRuntime.log(
+        theme.warn(
+          `Managed gateway service Node (${runtimePreflight.replacedNodeRunner}) cannot run openclaw@${runtimePreflight.targetVersion ?? tag}.`,
+        ),
+      );
+      defaultRuntime.log(
+        theme.muted(
+          `Using current Node (${packageUpdateNodeRunner}) and refreshing the managed service runtime after the update.`,
+        ),
+      );
     }
   }
 
@@ -1109,7 +1131,7 @@ async function updateCommandInternal(
             invocationCwd,
             honorPackageRoot:
               managedServiceRootRedirect !== null || managedServiceNodeRunner !== undefined,
-            nodeRunner: managedServiceNodeRunner,
+            nodeRunner: packageUpdateNodeRunner,
             installEnv: packageInstallEnv,
             installTarget: packageInstallTarget,
           })
@@ -1278,7 +1300,7 @@ async function updateCommandInternal(
       opts,
       pluginInstallRecords: preUpdatePluginInstallRecords,
       updateStartedAtMs: startedAt,
-      nodeRunner: managedServiceNodeRunner,
+      nodeRunner: packageUpdateNodeRunner,
       preUpdateConfig: configSnapshot.valid
         ? {
             sourceConfig: configSnapshot.sourceConfig,
@@ -1472,7 +1494,7 @@ async function updateCommandInternal(
     gatewayPort,
     restartScriptPath,
     invocationCwd,
-    nodeRunner: managedServiceNodeRunner,
+    nodeRunner: packageUpdateNodeRunner,
     skipLegacyServiceRestart,
     requireRunningServiceAfterRestart:
       resultWithPostUpdate.mode === "git" && preManagedServiceStop?.stopped === true,


### PR DESCRIPTION
Closes #106920

## What Problem This Solves

Fixes an issue where users running `openclaw update` could be left with a Gateway service pinned to an older Node runtime that cannot start the target OpenClaw release, even when the foreground CLI already runs on a compatible Node.

## Why This Change Was Made

Package updates continue to preserve the managed service Node while it satisfies the target release. When that recorded Node is incompatible, a restart-enabled update may switch to the compatible current CLI Node only after proving the service owns the package root being updated; finalization then rewrites the service metadata to the new runtime. `--no-restart`, unowned services, and hosts without a compatible runtime still stop before package mutation.

## User Impact

Operators can update through Node version-manager changes without manually reinstalling an owned Gateway service when the shell already provides a compatible Node. Package-root pinning, fail-before-mutation safety, restart health checks, and target-version verification remain intact.

## Release Note

`openclaw update` now repairs an owned managed Gateway service when its recorded Node runtime is too old for the target release and the current CLI Node is compatible.

AI-assisted: yes, with Codex. I reviewed the runtime ownership flow, tests, docs, and resulting patch.

## Evidence

- Focused exact-head tests: 221 passed across `src/cli/update-cli.test.ts` and `src/cli/update-cli/update-command.test.ts`.
- Blacksmith Testbox `tbx_01kxmrapxjxzx69pbb1jc2yzvt`: core/core-test typechecks, targeted lint, package/API/architecture guards, and the same 221 focused tests passed. Run: https://github.com/openclaw/openclaw/actions/runs/29475565618
- Final-head Blacksmith Testbox `tbx_01kxmsnke0g30vnmq8s6kgbefq`: dead-export validation and the 221 focused tests passed. Run: https://github.com/openclaw/openclaw/actions/runs/29476703830
- Packaged multi-Node Docker E2E on Blacksmith Testbox `tbx_01kxmrr50hewcdngqvarj64347`: update stayed in the managed package root, avoided a split install, refreshed the service, restarted, and passed the Gateway health probe. Run: https://github.com/openclaw/openclaw/actions/runs/29475927178
- Fresh rebased-head autoreview reported no accepted or actionable findings (confidence 0.86).
- Exact-head hosted CI passed, including the aggregate gate. Run: https://github.com/openclaw/openclaw/actions/runs/29479383526
