### PR TITLE
fix(tui): show compact model and reasoning

### DIFF
--- a/src/system-agent/tui-backend.test.ts
+++ b/src/system-agent/tui-backend.test.ts
@@ -228,7 +228,7 @@ describe("runSystemAgentTui", () => {
           };
 
           await expect(backend.listSessions()).resolves.toMatchObject({
-            sessions: [{ model: "gpt-5.6-sol", thinkingLevel: "low" }],
+            sessions: [{ model: "gpt-5.6-sol", thinkingLevel: "medium" }],
           });
           return { exitReason: "exit" };
         },

--- a/src/system-agent/tui-backend.test.ts
+++ b/src/system-agent/tui-backend.test.ts
@@ -64,13 +64,16 @@ function configSnapshot(config: OpenClawConfig) {
   };
 }
 
-async function createVerifiedTuiOptions(deps: SystemAgentCommandDeps = {}) {
-  const fixture = await createSystemAgentVerifiedInferenceTestFixture(verifiedConfig);
+async function createVerifiedTuiOptions(
+  deps: SystemAgentCommandDeps = {},
+  config: OpenClawConfig = verifiedConfig,
+) {
+  const fixture = await createSystemAgentVerifiedInferenceTestFixture(config);
   return {
     verifiedInference: fixture.binding,
     deps: {
       ...fixture.deps,
-      readConfigFileSnapshot: vi.fn(async () => configSnapshot(verifiedConfig)) as never,
+      readConfigFileSnapshot: vi.fn(async () => configSnapshot(config)) as never,
       ...deps,
     },
   };
@@ -146,6 +149,92 @@ describe("runSystemAgentTui", () => {
     if (!options.backend || typeof options.backend !== "object") {
       throw new Error("expected openclaw TUI backend");
     }
+  });
+
+  it("reports the verified model without its auth profile and the effective thinking level", async () => {
+    const config = {
+      ...verifiedConfig,
+      agents: {
+        defaults: {
+          model: "openai/gpt-5.5",
+          thinkingDefault: "high",
+        },
+      },
+    } satisfies OpenClawConfig;
+    const profileQualifiedOverview = {
+      ...overview,
+      defaultModel: "openai/gpt-5.5@openai:setup-test",
+    } satisfies SystemAgentOverview;
+    const verified = await createVerifiedTuiOptions(
+      { loadOverview: async () => profileQualifiedOverview },
+      config,
+    );
+
+    await runSystemAgentTui(
+      {
+        ...verified,
+        runTui: async (opts) => {
+          const backend = opts.backend as unknown as {
+            loadHistory: () => Promise<{ thinkingLevel: string }>;
+            listSessions: () => Promise<{
+              sessions: Array<{
+                model?: string;
+                modelProvider?: string;
+                thinkingLevel?: string;
+              }>;
+            }>;
+          };
+
+          await expect(backend.loadHistory()).resolves.toMatchObject({ thinkingLevel: "high" });
+          await expect(backend.listSessions()).resolves.toMatchObject({
+            sessions: [
+              {
+                model: "gpt-5.5",
+                modelProvider: "openai",
+                thinkingLevel: "high",
+              },
+            ],
+          });
+          return { exitReason: "exit" };
+        },
+      },
+      createRuntime(),
+    );
+  });
+
+  it("uses the verified model's default thinking level", async () => {
+    const config = {
+      ...verifiedConfig,
+      agents: { defaults: { model: "openai/gpt-5.6-sol" } },
+    } satisfies OpenClawConfig;
+    const verified = await createVerifiedTuiOptions(
+      {
+        loadOverview: async () => ({
+          ...overview,
+          defaultModel: "openai/gpt-5.6-sol@openai:setup-test",
+        }),
+      },
+      config,
+    );
+
+    await runSystemAgentTui(
+      {
+        ...verified,
+        runTui: async (opts) => {
+          const backend = opts.backend as unknown as {
+            listSessions: () => Promise<{
+              sessions: Array<{ model?: string; thinkingLevel?: string }>;
+            }>;
+          };
+
+          await expect(backend.listSessions()).resolves.toMatchObject({
+            sessions: [{ model: "gpt-5.6-sol", thinkingLevel: "low" }],
+          });
+          return { exitReason: "exit" };
+        },
+      },
+      createRuntime(),
+    );
   });
 
   it("isolates event consumer failures during sendChat", async () => {

--- a/src/system-agent/tui-backend.ts
+++ b/src/system-agent/tui-backend.ts
@@ -64,6 +64,12 @@ type SystemAgentHistoryMessage = {
   timestamp: number;
 };
 
+type SystemAgentTuiRoute = {
+  model?: string;
+  modelProvider?: string;
+  thinkingLevel: string;
+};
+
 const SYSTEM_AGENT_SESSION_KEY = buildAgentMainSessionKey({ agentId: SYSTEM_AGENT_ID });
 
 function createChatEngine(opts: SystemAgentTuiOptions): SystemAgentChatEngine {
@@ -128,6 +134,7 @@ class SystemAgentTuiBackend implements TuiBackend {
     private readonly opts: SystemAgentTuiOptions,
     welcome: string,
     engine: SystemAgentChatEngine,
+    private readonly route: SystemAgentTuiRoute,
   ) {
     this.engine = engine;
     this.messages.push(message("assistant", welcome));
@@ -180,21 +187,19 @@ class SystemAgentTuiBackend implements TuiBackend {
     return {
       sessionId: "openclaw",
       messages: this.messages,
-      thinkingLevel: "off",
+      thinkingLevel: this.route.thinkingLevel,
       verboseLevel: "off",
     };
   }
 
   async listSessions(): Promise<TuiSessionList> {
-    const overview = await loadOverviewForTui(this.opts);
-    const model = splitModelRef(overview.defaultModel);
     return {
       ts: Date.now(),
       path: "openclaw",
       count: 1,
       defaults: {
-        model: model.model ?? null,
-        modelProvider: model.provider ?? null,
+        model: this.route.model ?? null,
+        modelProvider: this.route.modelProvider ?? null,
         contextTokens: null,
       },
       sessions: [
@@ -203,10 +208,10 @@ class SystemAgentTuiBackend implements TuiBackend {
           sessionId: "openclaw",
           displayName: "OpenClaw",
           updatedAt: Date.now(),
-          thinkingLevel: "off",
+          thinkingLevel: this.route.thinkingLevel,
           verboseLevel: "off",
-          model: model.model,
-          modelProvider: model.provider,
+          model: this.route.model,
+          modelProvider: this.route.modelProvider,
         },
       ],
     };
@@ -427,7 +432,7 @@ export async function runSystemAgentTui(
   let nextInput: string | undefined;
   let welcomeVariant = boundOpts.welcomeVariant;
   for (;;) {
-    await requireTuiVerifiedInference(boundOpts);
+    const route = await requireTuiVerifiedInference(boundOpts);
     // A returned agent request is single-use; a later wizard handoff must not
     // replay it when OpenClaw re-enters the chat shell.
     const initialMessage = nextInput;
@@ -445,7 +450,7 @@ export async function runSystemAgentTui(
     // The onboarding greeting applies to the first shell only; re-entry after
     // an agent handoff uses the normal repair-oriented startup message.
     welcomeVariant = undefined;
-    const backend = new SystemAgentTuiBackend(boundOpts, welcome, engine);
+    const backend = new SystemAgentTuiBackend(boundOpts, welcome, engine, route);
     const runTui = boundOpts.runTui ?? defaultRunTui;
     try {
       await runTui({
@@ -486,7 +491,9 @@ export async function runSystemAgentTui(
   }
 }
 
-async function requireTuiVerifiedInference(opts: SystemAgentTuiOptions): Promise<void> {
+async function requireTuiVerifiedInference(
+  opts: SystemAgentTuiOptions,
+): Promise<SystemAgentTuiRoute> {
   const binding = opts?.verifiedInference;
   if (!binding) {
     throw new SystemAgentInferenceUnavailableError("conversation");
@@ -494,7 +501,26 @@ async function requireTuiVerifiedInference(opts: SystemAgentTuiOptions): Promise
   try {
     const route = await resolveSystemAgentVerifiedInferenceRoute(binding, opts.deps);
     if (route) {
-      return;
+      const [{ loadModelCatalog }, { resolveThinkingDefault }] = await Promise.all([
+        import("../agents/model-catalog.js"),
+        import("../agents/model-thinking-default.js"),
+      ]);
+      // Catalog metadata improves the label but must not become a new startup
+      // dependency after this exact inference route has already been verified.
+      const catalog = await loadModelCatalog({ config: route.runConfig, readOnly: true }).catch(
+        () => undefined,
+      );
+      const model = splitModelRef(route.modelLabel);
+      return {
+        model: model.model,
+        modelProvider: model.provider,
+        thinkingLevel: resolveThinkingDefault({
+          cfg: route.runConfig,
+          provider: route.provider,
+          model: route.model,
+          catalog,
+        }),
+      };
     }
   } catch (error) {
     throw new SystemAgentInferenceUnavailableError("conversation", [error]);

--- a/src/tui/tui-command-handlers.test.ts
+++ b/src/tui/tui-command-handlers.test.ts
@@ -1688,9 +1688,8 @@ describe("tui command handlers", () => {
   it("preserves provider prefix for nested model ids in /model confirmation", async () => {
     // Some providers route to nested model ids that themselves contain a slash
     // (e.g. resolved.model: "moonshotai/kimi-k2.5" with modelProvider: "nvidia").
-    // The confirmation must still show the full nvidia/moonshotai/kimi-k2.5 ref
-    // to match the footer/status bar, not strip the provider just because the
-    // model id already contains a slash.
+    // The confirmation must still show the full nvidia/moonshotai/kimi-k2.5 ref,
+    // not strip the provider just because the model id already contains a slash.
     const patchSession = vi.fn().mockResolvedValue({
       ok: true,
       path: "/sessions/patch",

--- a/src/tui/tui-formatters.test.ts
+++ b/src/tui/tui-formatters.test.ts
@@ -5,11 +5,23 @@ import {
   extractContentFromMessage,
   extractTextFromMessage,
   extractThinkingFromMessage,
+  formatModelFooter,
   formatGoalFooter,
   formatRemoteConnectionHostFooter,
   isCommandMessage,
   sanitizeRenderableText,
 } from "./tui-formatters.js";
+
+describe("formatModelFooter", () => {
+  it("shows a compact model name and its active thinking level", () => {
+    expect(
+      formatModelFooter({
+        model: "gpt-5.6-sol@openai:setup-64cddea3-938c-431e-be3b-aa47090577c7",
+        thinkingLevel: "high",
+      }),
+    ).toBe("gpt-5.6-sol high");
+  });
+});
 
 describe("formatGoalFooter", () => {
   it("renders active goal usage", () => {

--- a/src/tui/tui-formatters.ts
+++ b/src/tui/tui-formatters.ts
@@ -1,5 +1,6 @@
 // Formats terminal-safe strings for TUI messages and status surfaces.
 import { stripAnsi } from "../../packages/terminal-core/src/ansi.js";
+import { splitTrailingAuthProfile } from "../agents/model-ref-profile.js";
 import { stripLeadingInboundMetadata } from "../auto-reply/reply/strip-inbound-meta.js";
 import type { SessionGoal } from "../config/sessions/types.js";
 import { isLoopbackHost } from "../gateway/net.js";
@@ -29,6 +30,16 @@ const RTL_ISOLATE_END = "\u2069";
 const FENCED_CODE_RE = /(```|~~~)[^\n]*\n[\s\S]*?\n\1[^\n]*/g;
 // Inline code spans with balanced backtick run (`code`, ``co`de``, ...).
 const INLINE_CODE_RE = /(`+)(?:(?!\1).)+?\1/g;
+
+/** Keep routing/provider/profile details in session state, not the compact footer. */
+export function formatModelFooter(params: {
+  model?: string | null;
+  thinkingLevel?: string | null;
+}): string {
+  const model = splitTrailingAuthProfile(params.model ?? "").model || "unknown";
+  const thinkingLevel = params.thinkingLevel?.trim();
+  return thinkingLevel && thinkingLevel !== "off" ? `${model} ${thinkingLevel}` : model;
+}
 
 function hasControlChars(text: string): boolean {
   for (const char of text) {

--- a/src/tui/tui-pty-harness.e2e.test.ts
+++ b/src/tui/tui-pty-harness.e2e.test.ts
@@ -85,8 +85,10 @@ async function writeTuiPtyFixtureScript(dir: string) {
       const actionLogPath = process.env.OPENCLAW_TUI_PTY_LOG_PATH;
       const gatewayStatus = process.env.OPENCLAW_TUI_PTY_GATEWAY_STATUS ?? "fixture gateway ok";
       const startupDelayMs = Number(process.env.OPENCLAW_TUI_PTY_STARTUP_DELAY_MS ?? 0);
+      const footerModel = process.env.OPENCLAW_TUI_PTY_MODEL;
+      const footerThinkingLevel = process.env.OPENCLAW_TUI_PTY_THINKING_LEVEL;
       const xaiLimitError = '403 {"code":"The caller does not have permission to execute the specified operation","error":"Your team team-redacted has either used all available credits or reached its monthly spending limit. To continue making API requests, please purchase more credits or raise your spending limit."}';
-      let currentModel = "fixture-provider/fixture-model";
+      let currentModel = footerModel ?? "fixture-provider/fixture-model";
       let fastMode = process.env.OPENCLAW_TUI_PTY_FAST_MODE === "true";
       let pendingPluginApproval: {
         id: string;
@@ -127,6 +129,7 @@ async function writeTuiPtyFixtureScript(dir: string) {
           modelProvider: "fixture-provider",
           contextTokens: 128,
           fastMode,
+          ...(footerThinkingLevel ? { thinkingLevel: footerThinkingLevel } : {}),
           thinkingLevels: [],
         };
       }
@@ -329,7 +332,16 @@ async function writeTuiPtyFixtureScript(dir: string) {
               messages: [{ role: "user", content: rapidSwitchMarker + "_HISTORY_MARKER" }],
             };
           }
-          return { messages: [], fastMode };
+          return {
+            messages: [],
+            fastMode,
+            ...(footerModel
+              ? {
+                  thinkingLevel: footerThinkingLevel,
+                  sessionInfo: sessionEntry(sessionKey),
+                }
+              : {}),
+          };
         }
 
         async listSessions() {
@@ -527,6 +539,25 @@ describe.sequential("TUI PTY harness", () => {
     expect(fixture.run.output()).toContain("local ready");
     expect(fixture.run.output()).not.toContain("host local");
   });
+
+  it(
+    "renders a compact model and active thinking level in the footer",
+    async () => {
+      const compactFooter = await startTuiFixture({
+        env: {
+          OPENCLAW_TUI_PTY_MODEL: "gpt-5.6-sol@openai:setup-64cddea3-938c-431e-be3b-aa47090577c7",
+          OPENCLAW_TUI_PTY_THINKING_LEVEL: "high",
+        },
+      });
+      try {
+        await compactFooter.run.waitForOutput("gpt-5.6-sol high", STARTUP_TIMEOUT_MS);
+        expect(compactFooter.run.output()).not.toContain("openai:setup-64cddea3");
+      } finally {
+        await compactFooter.cleanup();
+      }
+    },
+    STARTUP_TEST_TIMEOUT_MS,
+  );
 
   it(
     "shows startup activity while post-connect initialization is pending",

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -45,6 +45,7 @@ import { createCommandHandlers } from "./tui-command-handlers.js";
 import { createEventHandlers } from "./tui-event-handlers.js";
 import {
   formatGoalFooter,
+  formatModelFooter,
   formatRemoteConnectionHostFooter,
   sanitizeRenderableText,
   formatTokens,
@@ -1229,13 +1230,8 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
       ? `${sessionKeyLabel} (${sessionInfo.displayName})`
       : sessionKeyLabel;
     const agentLabel = formatAgentLabel(currentAgentId);
-    const modelLabel = sessionInfo.model
-      ? sessionInfo.modelProvider
-        ? `${sessionInfo.modelProvider}/${sessionInfo.model}`
-        : sessionInfo.model
-      : "unknown";
+    const modelLabel = formatModelFooter(sessionInfo);
     const tokens = formatTokens(sessionInfo.totalTokens ?? null, sessionInfo.contextTokens ?? null);
-    const think = sessionInfo.thinkingLevel ?? "off";
     const fastLabel =
       sessionInfo.fastMode === "auto" ? "fast:auto" : sessionInfo.fastMode === true ? "fast" : null;
     const verbose = sessionInfo.verboseLevel ?? "off";
@@ -1249,7 +1245,6 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
       `session ${sessionLabel}`,
       modelLabel,
       formatGoalFooter(sessionInfo.goal),
-      think !== "off" ? `think ${think}` : null,
       fastLabel,
       verbose !== "off" ? `verbose ${verbose}` : null,
       reasoningLabel,


### PR DESCRIPTION
## Summary

- render the TUI footer as a compact model name plus its active thinking level
- derive the system-agent footer state from the verified inference route instead of a profile-qualified overview string
- keep canonical provider and auth-profile details in routing state while hiding them from the footer

## Verification

- `node scripts/run-vitest.mjs src/tui/tui-formatters.test.ts src/tui/tui-command-handlers.test.ts src/system-agent/tui-backend.test.ts`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.tui-pty.config.ts`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base upstream/main --stream-engine-output` (clean; no actionable findings)

## Real behavior proof

Behavior addressed: The TUI exposed a profile-qualified model route and reported no active reasoning level.

Real environment tested: The real OpenClaw TUI render loop running in a PTY with the repository fake backend.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs run --config test/vitest/vitest.tui-pty.config.ts`

Evidence after fix: The PTY assertion observed `gpt-5.6-sol high` and rejected the `openai:setup-64cddea3` profile identifier.

Observed result after fix: GPT-5.6 Sol renders with its effective level; current `main` resolves the default to `medium`, while explicit overrides such as `high` are reflected automatically.

What was not tested: Live provider authentication, Gateway transport, and inference quality were not exercised by the footer PTY proof.
