### PR TITLE
fix(sandbox): keep CDP probes within startup deadline

### DIFF
--- a/src/agents/sandbox/browser.create.test.ts
+++ b/src/agents/sandbox/browser.create.test.ts
@@ -1,6 +1,8 @@
 // Sandbox browser creation tests cover Docker args, bridge auth, noVNC access,
 // config hashing, and cached bridge invalidation.
 import { mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { createServer } from "node:http";
+import type { AddressInfo, Socket } from "node:net";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
@@ -773,24 +775,36 @@ describe("ensureSandboxBrowser create args", () => {
   });
 
   it("keeps a stalled CDP request inside the browser startup deadline", async () => {
-    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
-    let requestTimeoutMs: number | undefined;
-    let observedSignal: AbortSignal | undefined;
-    vi.spyOn(globalThis, "fetch").mockImplementation(
-      async (_input, init) =>
-        await new Promise<Response>((_resolve, reject) => {
-          requestTimeoutMs = setTimeoutSpy.mock.calls.at(-1)?.[1];
-          const signal = init?.signal;
-          if (!signal) {
-            reject(new Error("expected a CDP request abort signal"));
-            return;
-          }
-          observedSignal = signal;
-          signal.addEventListener("abort", () => reject(new Error("CDP request aborted")), {
-            once: true,
-          });
-        }),
-    );
+    const sockets = new Set<Socket>();
+    let requestPath: string | undefined;
+    let resolveRequestReceived: (() => void) | undefined;
+    const requestReceived = new Promise<void>((resolve) => {
+      resolveRequestReceived = resolve;
+    });
+    const server = createServer((req, _res) => {
+      requestPath = req.url;
+      req.resume();
+      resolveRequestReceived?.();
+      // Accept the CDP request but never send response headers.
+    });
+    server.on("connection", (socket) => {
+      sockets.add(socket);
+      socket.on("close", () => sockets.delete(socket));
+    });
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(0, "127.0.0.1", resolve);
+    });
+    const cdpPort = (server.address() as AddressInfo).port;
+    dockerMocks.readDockerPort.mockImplementation(async (_containerName: string, port: number) => {
+      if (port === 9222) {
+        return cdpPort;
+      }
+      if (port === 6080) {
+        return 49101;
+      }
+      return null;
+    });
     bridgeMocks.startBrowserBridgeServer.mockImplementationOnce(async (params) => {
       await params.onEnsureAttachTarget?.({});
       throw new Error("expected CDP startup to time out before bridge creation");
@@ -799,19 +813,55 @@ describe("ensureSandboxBrowser create args", () => {
     const cfg = buildConfig(false);
     cfg.browser.autoStartTimeoutMs = 25;
 
-    await expect(
-      ensureTestSandboxBrowser({
+    const originalSetTimeout = globalThis.setTimeout;
+    let requestTimeoutMs: number | undefined;
+    let fireRequestTimeout: (() => void) | undefined;
+    // Fire the production request timer only after the real loopback server sees
+    // the request, keeping the stalled-fetch proof deterministic and fast.
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout").mockImplementation(((
+      callback: (...args: unknown[]) => void,
+      timeout?: number,
+      ...args: unknown[]
+    ) => {
+      if (requestTimeoutMs === undefined) {
+        requestTimeoutMs = timeout;
+        fireRequestTimeout = () => callback(...args);
+        return 0 as unknown as ReturnType<typeof setTimeout>;
+      }
+      return originalSetTimeout(() => callback(...args), timeout);
+    }) as typeof setTimeout);
+
+    try {
+      const startup = ensureTestSandboxBrowser({
         scopeKey: "session:test",
         workspaceDir: "/tmp/workspace",
         agentWorkspaceDir: "/tmp/workspace",
         cfg,
-      }),
-    ).rejects.toThrow("hung container has been forcefully removed");
+      });
+      await Promise.race([
+        requestReceived,
+        new Promise<never>((_resolve, reject) => {
+          originalSetTimeout(
+            () => reject(new Error("CDP request was not received")),
+            1_000,
+          ).unref();
+        }),
+      ]);
 
-    expect(observedSignal).toBeDefined();
-    expect(observedSignal?.aborted).toBe(true);
-    expect(requestTimeoutMs).toBeGreaterThanOrEqual(1);
-    expect(requestTimeoutMs).toBeLessThanOrEqual(cfg.browser.autoStartTimeoutMs);
+      expect(requestPath).toBe("/json/version");
+      expect(requestTimeoutMs).toBeGreaterThanOrEqual(1);
+      expect(requestTimeoutMs).toBeLessThanOrEqual(cfg.browser.autoStartTimeoutMs);
+      fireRequestTimeout?.();
+      await expect(startup).rejects.toThrow("hung container has been forcefully removed");
+    } finally {
+      setTimeoutSpy.mockRestore();
+      for (const socket of sockets) {
+        socket.destroy();
+      }
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
   });
 
   it("requires auth for the sandbox CDP relay without auto-derived source ranges", async () => {

--- a/src/agents/sandbox/browser.create.test.ts
+++ b/src/agents/sandbox/browser.create.test.ts
@@ -772,6 +772,48 @@ describe("ensureSandboxBrowser create args", () => {
     );
   });
 
+  it("keeps a stalled CDP request inside the browser startup deadline", async () => {
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    let requestTimeoutMs: number | undefined;
+    let observedSignal: AbortSignal | undefined;
+    vi.spyOn(globalThis, "fetch").mockImplementation(
+      async (_input, init) =>
+        await new Promise<Response>((_resolve, reject) => {
+          requestTimeoutMs = setTimeoutSpy.mock.calls.at(-1)?.[1];
+          const signal = init?.signal;
+          if (!signal) {
+            reject(new Error("expected a CDP request abort signal"));
+            return;
+          }
+          observedSignal = signal;
+          signal.addEventListener("abort", () => reject(new Error("CDP request aborted")), {
+            once: true,
+          });
+        }),
+    );
+    bridgeMocks.startBrowserBridgeServer.mockImplementationOnce(async (params) => {
+      await params.onEnsureAttachTarget?.({});
+      throw new Error("expected CDP startup to time out before bridge creation");
+    });
+
+    const cfg = buildConfig(false);
+    cfg.browser.autoStartTimeoutMs = 25;
+
+    await expect(
+      ensureTestSandboxBrowser({
+        scopeKey: "session:test",
+        workspaceDir: "/tmp/workspace",
+        agentWorkspaceDir: "/tmp/workspace",
+        cfg,
+      }),
+    ).rejects.toThrow("hung container has been forcefully removed");
+
+    expect(observedSignal).toBeDefined();
+    expect(observedSignal?.aborted).toBe(true);
+    expect(requestTimeoutMs).toBeGreaterThanOrEqual(1);
+    expect(requestTimeoutMs).toBeLessThanOrEqual(cfg.browser.autoStartTimeoutMs);
+  });
+
   it("requires auth for the sandbox CDP relay without auto-derived source ranges", async () => {
     await ensureTestSandboxBrowser({
       scopeKey: "session:test",

--- a/src/agents/sandbox/browser.ts
+++ b/src/agents/sandbox/browser.ts
@@ -90,8 +90,10 @@ async function waitForSandboxCdp(params: {
   const url = `http://127.0.0.1:${params.cdpPort}/json/version`;
   while (Date.now() < deadline) {
     try {
+      // Keep a stalled request inside the outer browser startup deadline.
+      const requestTimeoutMs = Math.max(1, Math.min(1000, deadline - Date.now()));
       const ctrl = new AbortController();
-      const t = setTimeout(ctrl.abort.bind(ctrl), 1000);
+      const t = setTimeout(ctrl.abort.bind(ctrl), requestTimeoutMs);
       try {
         const res = await fetch(url, {
           headers: { Authorization: buildSandboxCdpAuthHeader(params.authToken) },


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where sandbox browser startup could wait up to one extra second past `autoStartTimeoutMs` when the final Chrome DevTools Protocol version probe stalled.

## Why This Change Was Made

Each `/json/version` probe now uses the smaller of the existing one-second request timeout and the time remaining in the overall startup budget. The existing retry cadence and behavior away from the deadline are unchanged.

## User Impact

Sandbox browser startup failures now return within the configured startup deadline instead of overshooting it on a stalled final probe.

## Evidence

- `pnpm test src/agents/sandbox/browser.create.test.ts --run`: 23 tests passed.
- The new focused test invokes `createSandboxBrowser`, stalls the production CDP fetch, observes the actual abort timer, verifies it is no greater than the configured 25 ms startup budget, and confirms the request signal aborts. The old fixed 1000 ms behavior fails this assertion.
- Type-aware oxlint passed for the touched files.
- `oxfmt --check` passed for the touched files.
- `git diff --check upstream/main...HEAD` passed.
- Fresh full-branch Claude autoreview against current `upstream/main` reported no accepted or actionable findings and rated the patch correct (confidence 0.85).
- Live open-PR search found no duplicate covering the sandbox CDP startup probe deadline.
