### PR TITLE
fix(agents): make model-facing tool schemas llama.cpp GBNF-compatible (#108580)

### DIFF
--- a/src/agents/tools/cron-tool.ts
+++ b/src/agents/tools/cron-tool.ts
@@ -178,7 +178,13 @@ function createCronPayloadSchema(): TSchema {
 function createCronTriggerSchema(params: { nullableClears: boolean }): TSchema {
   const trigger = Type.Object(
     {
-      script: Type.String({ minLength: 1, maxLength: 65_536 }),
+      // No `maxLength` here: a bounded length compiles to that many repeated GBNF
+      // rules and 65536 blows past llama.cpp's ~2000 repetition ceiling (#108580).
+      // The 64KB cap stays enforced server-side by the RPC CronTriggerSchema.
+      script: Type.String({
+        minLength: 1,
+        description: "Trigger script source (max 65536 chars).",
+      }),
       once: Type.Optional(Type.Boolean()),
     },
     { additionalProperties: false },
@@ -275,6 +281,9 @@ function createCronJobObjectSchema(): TSchema {
       {
         name: Type.Optional(Type.String({ description: "Job name" })),
         declarationKey: Type.Optional(
+          // No `pattern` here: llama.cpp's regex->GBNF converter rejects PCRE
+          // shorthand (`\S`) and unanchored patterns (#108580). The non-blank
+          // guarantee is enforced server-side (cron gateway handler + RPC schema).
           Type.String({
             description: "Idempotent declaration key.",
             minLength: 1,

--- a/src/agents/tools/sessions-search-tool.ts
+++ b/src/agents/tools/sessions-search-tool.ts
@@ -38,7 +38,12 @@ const SESSIONS_SEARCH_MAX_BYTES = 32 * 1024;
 const SESSIONS_SEARCH_SNIPPET_MAX_CHARS = 300;
 
 const SessionsSearchToolSchema = Type.Object({
-  query: Type.String({ maxLength: SESSIONS_SEARCH_MAX_QUERY_CHARS }),
+  // No `maxLength` here: it compiles to that many repeated GBNF rules and 4096
+  // blows past llama.cpp's ~2000 repetition ceiling (#108580). The cap stays
+  // enforced at runtime in the execute path below.
+  query: Type.String({
+    description: `Search query (max ${SESSIONS_SEARCH_MAX_QUERY_CHARS} chars).`,
+  }),
   sessionKey: Type.Optional(Type.String()),
   limit: optionalPositiveIntegerSchema({ maximum: SESSIONS_SEARCH_MAX_LIMIT }),
 });

--- a/src/agents/tools/task-suggestion-tools.ts
+++ b/src/agents/tools/task-suggestion-tools.ts
@@ -24,7 +24,8 @@ const SpawnTaskToolSchema = Type.Object(
     }),
     prompt: Type.String({
       minLength: 1,
-      description: "Self-contained task prompt with relevant file paths and context.",
+      description:
+        "Self-contained task prompt with relevant file paths and context (max 32768 chars).",
     }),
     tldr: Type.String({
       minLength: 1,
@@ -34,7 +35,8 @@ const SpawnTaskToolSchema = Type.Object(
     cwd: Type.Optional(
       Type.String({
         minLength: 1,
-        description: "Absolute project directory; defaults to the current project.",
+        description:
+          "Absolute project directory; defaults to the current project (max 4096 chars).",
       }),
     ),
   },

--- a/src/agents/tools/task-suggestion-tools.ts
+++ b/src/agents/tools/task-suggestion-tools.ts
@@ -12,6 +12,9 @@ import {
 import { type AnyAgentTool, ToolInputError, jsonResult, readStringParam } from "./common.js";
 import { callGatewayTool } from "./gateway.js";
 
+// No `maxLength` on prompt/cwd: a bounded length compiles to that many repeated
+// GBNF rules and 32768/4096 blow past llama.cpp's ~2000 repetition ceiling
+// (#108580). The gateway RPC schema (task-suggestions params) keeps those caps.
 const SpawnTaskToolSchema = Type.Object(
   {
     title: Type.String({
@@ -21,7 +24,6 @@ const SpawnTaskToolSchema = Type.Object(
     }),
     prompt: Type.String({
       minLength: 1,
-      maxLength: 32_768,
       description: "Self-contained task prompt with relevant file paths and context.",
     }),
     tldr: Type.String({
@@ -32,7 +34,6 @@ const SpawnTaskToolSchema = Type.Object(
     cwd: Type.Optional(
       Type.String({
         minLength: 1,
-        maxLength: 4_096,
         description: "Absolute project directory; defaults to the current project.",
       }),
     ),

--- a/src/agents/tools/tool-schema-llamacpp-compat.test.ts
+++ b/src/agents/tools/tool-schema-llamacpp-compat.test.ts
@@ -1,0 +1,163 @@
+import { normalizeToolParameterSchema } from "@openclaw/ai/internal/openai";
+// Guards model-facing tool schemas against constructs that llama.cpp's
+// JSON-schema -> GBNF grammar converter rejects (issue #108580). Because the
+// whole active tool list compiles into one grammar, a single bad field 400s
+// every request on a grammar-constrained backend, not just calls to that tool.
+import { describe, expect, it } from "vitest";
+import type { AnyAgentTool } from "./common.js";
+import { createCronTool } from "./cron-tool.js";
+import { createSessionsHistoryTool } from "./sessions-history-tool.js";
+import { createSessionsListTool } from "./sessions-list-tool.js";
+import { createSessionsSearchTool } from "./sessions-search-tool.js";
+import { createSessionsSendTool } from "./sessions-send-tool.js";
+import { createTaskSuggestionTools } from "./task-suggestion-tools.js";
+
+// llama.cpp compiles a bounded `maxLength` into repeated grammar rules and caps
+// the repetition count at MAX_REPETITION_THRESHOLD (2000 in src/llama-grammar.cpp);
+// anything larger fails GBNF compilation ("number of repetitions exceeds sane
+// defaults"). Keep this named so a future ceiling change is a one-line edit.
+const LLAMACPP_MAX_REPETITION_THRESHOLD = 2000;
+
+// llama.cpp's regex->GBNF converter only understands a small set of literal
+// escapes; PCRE shorthand character classes (\s \S \d \D \w \W \b \B) are
+// rejected as unknown escapes, so no pattern reaching the model may use them.
+const PCRE_SHORTHAND_ESCAPE = /\\[dDwWsSbB]/;
+
+// JSON Schema keywords whose value is a map of name -> subschema.
+const SCHEMA_MAP_KEYS = new Set([
+  "properties",
+  "patternProperties",
+  "$defs",
+  "definitions",
+  "dependentSchemas",
+]);
+
+// JSON Schema keywords whose value is a subschema or an array of subschemas.
+const SCHEMA_CHILD_KEYS = new Set([
+  "items",
+  "prefixItems",
+  "additionalItems",
+  "additionalProperties",
+  "contains",
+  "propertyNames",
+  "not",
+  "if",
+  "then",
+  "else",
+  "unevaluatedItems",
+  "unevaluatedProperties",
+  "anyOf",
+  "oneOf",
+  "allOf",
+]);
+
+/**
+ * Collects llama.cpp GBNF-incompatible constructs (unanchored or PCRE-shorthand
+ * `pattern`, oversized `maxLength`) reachable in a tool's JSON Schema. Recurses
+ * only through structural schema positions so data literals under `enum`,
+ * `const`, `default`, or `examples` (which may legitimately hold a key named
+ * "pattern" or "maxLength") never trigger a false positive.
+ */
+function collectGbnfViolations(node: unknown, path: string, out: string[]): void {
+  if (!node || typeof node !== "object") {
+    return;
+  }
+  if (Array.isArray(node)) {
+    node.forEach((entry, index) => collectGbnfViolations(entry, `${path}[${index}]`, out));
+    return;
+  }
+
+  const record = node as Record<string, unknown>;
+
+  const pattern = record.pattern;
+  if (typeof pattern === "string") {
+    if (!pattern.startsWith("^") || !pattern.endsWith("$")) {
+      out.push(`${path}.pattern is not fully anchored (^...$): ${JSON.stringify(pattern)}`);
+    }
+    if (PCRE_SHORTHAND_ESCAPE.test(pattern)) {
+      out.push(`${path}.pattern uses PCRE shorthand escapes: ${JSON.stringify(pattern)}`);
+    }
+  }
+
+  const maxLength = record.maxLength;
+  if (typeof maxLength === "number" && maxLength > LLAMACPP_MAX_REPETITION_THRESHOLD) {
+    out.push(
+      `${path}.maxLength ${maxLength} exceeds llama.cpp repetition ceiling ${LLAMACPP_MAX_REPETITION_THRESHOLD}`,
+    );
+  }
+
+  for (const [key, value] of Object.entries(record)) {
+    if (SCHEMA_MAP_KEYS.has(key)) {
+      if (value && typeof value === "object" && !Array.isArray(value)) {
+        for (const [childKey, childValue] of Object.entries(value as Record<string, unknown>)) {
+          collectGbnfViolations(childValue, `${path}.${key}.${childKey}`, out);
+        }
+      }
+      continue;
+    }
+    if (SCHEMA_CHILD_KEYS.has(key)) {
+      collectGbnfViolations(value, `${path}.${key}`, out);
+    }
+    // Every other key (type, enum, const, default, examples, description,
+    // minLength, and the already-checked pattern/maxLength) is a leaf or data
+    // value — do not recurse, so literals never masquerade as constraints.
+  }
+}
+
+/**
+ * Model-facing tools whose parameters are hand-authored TypeBox schemas that
+ * reach a grammar-constrained backend verbatim. New tools in this family (cron,
+ * task suggestions, sessions) should be added here so the GBNF guard covers them.
+ */
+function createModelFacingToolInventory(): AnyAgentTool[] {
+  return [
+    createCronTool(),
+    ...createTaskSuggestionTools({
+      sessionKey: "agent:main:main",
+      agentId: "main",
+      cwd: "/tmp/openclaw-llamacpp-compat",
+    }),
+    createSessionsSearchTool(),
+    createSessionsListTool(),
+    createSessionsSendTool(),
+    createSessionsHistoryTool(),
+  ];
+}
+
+describe("model-facing tool schemas stay llama.cpp GBNF-compatible", () => {
+  const tools = createModelFacingToolInventory();
+
+  it("materializes the llama.cpp-sensitive tools (guards against a vacuous pass)", () => {
+    const names = new Set(tools.map((tool) => tool.name));
+    for (const name of [
+      "cron",
+      "spawn_task",
+      "dismiss_task",
+      "sessions_search",
+      "sessions_list",
+      "sessions_send",
+    ]) {
+      expect(names.has(name), `expected tool "${name}" in the inventory`).toBe(true);
+    }
+  });
+
+  it("raw tool parameter schemas carry no GBNF-breaking pattern or maxLength", () => {
+    const violations: string[] = [];
+    for (const tool of tools) {
+      collectGbnfViolations(tool.parameters, tool.name, violations);
+    }
+    expect(violations).toEqual([]);
+  });
+
+  it("openai-normalized tool schemas carry no GBNF-breaking pattern or maxLength", () => {
+    // llama.cpp servers speak the OpenAI-compatible chat API; that provider path
+    // does not strip pattern/maxLength, so walk the normalized shape too in case
+    // $ref inlining or union flattening ever reintroduces a violation unseen.
+    const violations: string[] = [];
+    for (const tool of tools) {
+      const normalized = normalizeToolParameterSchema(tool.parameters, { modelProvider: "openai" });
+      collectGbnfViolations(normalized, tool.name, violations);
+    }
+    expect(violations).toEqual([]);
+  });
+});

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.discord-group.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.discord-group.json
@@ -722,7 +722,7 @@
                       "type": "boolean"
                     },
                     "script": {
-                      "maxLength": 65536,
+                      "description": "Trigger script source (max 65536 chars).",
                       "minLength": 1,
                       "type": "string"
                     }
@@ -1077,7 +1077,7 @@
                           "type": "boolean"
                         },
                         "script": {
-                          "maxLength": 65536,
+                          "description": "Trigger script source (max 65536 chars).",
                           "minLength": 1,
                           "type": "string"
                         }
@@ -1270,7 +1270,7 @@
               "type": "integer"
             },
             "query": {
-              "maxLength": 4096,
+              "description": "Search query (max 4096 chars).",
               "type": "string"
             },
             "sessionKey": {

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.heartbeat-turn.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.heartbeat-turn.json
@@ -718,7 +718,7 @@
                       "type": "boolean"
                     },
                     "script": {
-                      "maxLength": 65536,
+                      "description": "Trigger script source (max 65536 chars).",
                       "minLength": 1,
                       "type": "string"
                     }
@@ -1073,7 +1073,7 @@
                           "type": "boolean"
                         },
                         "script": {
-                          "maxLength": 65536,
+                          "description": "Trigger script source (max 65536 chars).",
                           "minLength": 1,
                           "type": "string"
                         }
@@ -1302,7 +1302,7 @@
               "type": "integer"
             },
             "query": {
-              "maxLength": 4096,
+              "description": "Search query (max 4096 chars).",
               "type": "string"
             },
             "sessionKey": {

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
@@ -718,7 +718,7 @@
                       "type": "boolean"
                     },
                     "script": {
-                      "maxLength": 65536,
+                      "description": "Trigger script source (max 65536 chars).",
                       "minLength": 1,
                       "type": "string"
                     }
@@ -1073,7 +1073,7 @@
                           "type": "boolean"
                         },
                         "script": {
-                          "maxLength": 65536,
+                          "description": "Trigger script source (max 65536 chars).",
                           "minLength": 1,
                           "type": "string"
                         }
@@ -1266,7 +1266,7 @@
               "type": "integer"
             },
             "query": {
-              "maxLength": 4096,
+              "description": "Search query (max 4096 chars).",
               "type": "string"
             },
             "sessionKey": {

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
@@ -208,8 +208,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 52547,
-    "roughTokens": 13137
+    "chars": 52655,
+    "roughTokens": 13164
   },
   "openClawDeveloperInstructions": {
     "chars": 3559,
@@ -220,8 +220,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 7021
   },
   "totalWithDynamicToolsJson": {
-    "chars": 80633,
-    "roughTokens": 20159
+    "chars": 80741,
+    "roughTokens": 20186
   },
   "userInputText": {
     "chars": 1442,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
@@ -208,8 +208,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 52274,
-    "roughTokens": 13069
+    "chars": 52382,
+    "roughTokens": 13096
   },
   "openClawDeveloperInstructions": {
     "chars": 2450,
@@ -220,8 +220,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6642
   },
   "totalWithDynamicToolsJson": {
-    "chars": 78842,
-    "roughTokens": 19711
+    "chars": 78950,
+    "roughTokens": 19738
   },
   "userInputText": {
     "chars": 1033,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
@@ -209,8 +209,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 53564,
-    "roughTokens": 13391
+    "chars": 53672,
+    "roughTokens": 13418
   },
   "openClawDeveloperInstructions": {
     "chars": 2469,
@@ -221,8 +221,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6777
   },
   "totalWithDynamicToolsJson": {
-    "chars": 80671,
-    "roughTokens": 20168
+    "chars": 80779,
+    "roughTokens": 20195
   },
   "userInputText": {
     "chars": 1271,


### PR DESCRIPTION
# fix(agents): make model-facing tool schemas llama.cpp GBNF-compatible (#108580)

> **Scope note — rebased onto current `main` (`ff1687e04f`).** #108360 (merged) landed the
> cron declaration-key `pattern: "\S"` removal. After rebase this branch carries the **remaining
> fix**: the four model-facing `maxLength` removals (cron `trigger.script` 65536 — in both the
> `job` and `patch` schema sites; `spawn_task.prompt` 32768; `spawn_task.cwd` 4096;
> `sessions_search.query` 4096), the retained-limit **descriptions**, and the **regression
> invariant test**. The refreshed before/after replay (top of the Live-proof section) shows
> **#108360 alone did not restore service** — current `main` still 400s pre-inference on the
> repetition ceiling — so this remaining scope is load-bearing.

## What Problem This Solves

Fixes #108580 (also reported as #107449, #108367, #108473). When OpenClaw runs against a
llama.cpp `llama-server` with grammar-constrained tool calling, **every** chat request on
**every** channel fails with a `400` as soon as the `cron` tool is in the active tool list —
not just cron calls. The whole tool list is compiled into one GBNF grammar, so a single field
llama.cpp's JSON-schema→GBNF converter can't handle takes down all inference.

Three distinct constraints in the model-facing schemas trip the converter:

1. **Unanchored pattern** — `pattern` must be fully `^...$`; `\S` is unanchored → `Pattern must start with '^' and end with '$'`. *(cron `declarationKey`; removed upstream in #108360.)*
2. **PCRE shorthand** — the regex→GBNF converter only understands a few literal escapes; `\S \s \d \w …` are rejected as unknown escapes, so even `^\S+$` fails. *(same field; #108360.)*
3. **Oversized maxLength** — a bounded `maxLength` compiles to that many repeated grammar rules, capped at `MAX_REPETITION_THRESHOLD = 2000`; `65536` (and `32768`, `4096`) exceed it → *number of repetitions exceeds sane defaults*. **← what this branch removes.**

#108360 addressed constraints (1)/(2) for the cron declaration key only. This branch removes the
constraint-(3) offenders that remain across every model-facing tool.

## Why This Change Was Made

These are **server-side validation constraints** (non-blank, byte caps) that were baked into a
schema that also serves as the model's **decoding grammar**. A decoding grammar should only
enforce structure ("this is a string"); "not all whitespace" and "≤ 64 KB" are business rules
that belong in the handler, where they already live. So the fix removes them from the
model-facing schema only — no guarantee is weakened:

| Field (model-facing schema) | Removed | Still enforced by |
|---|---|---|
| `cron` `job.declarationKey` | `pattern: "\S"` *(via #108360)* | cron gateway handler blank-guard + RPC `CronDeclarationKeySchema` |
| `cron` `trigger.script` (job + patch) | `maxLength: 65536` | RPC `CronTriggerSchema` via `validateCronAddParams`/`validateCronUpdateParams` |
| `spawn_task` `prompt` / `cwd` | `maxLength: 32768` / `4096` | RPC `TaskPromptSchema`/`TaskCwdSchema` via `validateTaskSuggestionsCreateParams` (+ `path.isAbsolute(cwd)`) |
| `sessions_search` `query` | `maxLength: 4096` | runtime guard in the tool's execute path (`ToolInputError`) |

The reported cron fields are the trigger, but the same class of construct reaches the model
from `spawn_task` and `sessions_search`, so they're swept here too. Each removed byte cap is
preserved in the field's `description`, so the model still sees the limit.

**Scope note — `packages/gateway-protocol/src/schema/cron.ts` is intentionally NOT touched.**
That TypeBox module is the gateway RPC validation contract; it is never serialized into a model
`tools` array (the model-facing cron schema is hand-authored in `src/agents/tools/cron-tool.ts`
and does not import it). Changing it would not affect the GBNF failure.

## User Impact

Users on llama.cpp (and any OpenAI-compatible backend that compiles tool JSON Schema to a
constrained grammar) can keep the cron/spawn_task/sessions tools enabled without the gateway
400-ing before inference. Behavior on providers that already accepted the old schemas is
unchanged for normal inputs; all validation still holds server-side.

## Evidence

- **New regression guard** `src/agents/tools/tool-schema-llamacpp-compat.test.ts`: walks the real
  cron/spawn_task/dismiss_task/sessions tool schemas (**raw and openai-normalized**) and asserts every
  `pattern` is fully anchored with no PCRE shorthand and every `maxLength` ≤ `LLAMACPP_MAX_REPETITION_THRESHOLD` (2000),
  with a vacuous-pass guard. It's a generic schema walker, so future model-facing tools in this
  family are covered too. This **extends** #108360's `cron-tool.schema.test.ts` assertion (which
  checks only that cron `declarationKey` drops its `pattern`) to anchoring + PCRE-shorthand +
  maxLength-ceiling across the whole built-in inventory, on both schema shapes.
- Verified on the rebased head (`36588df428`): new test + `cron-tool.schema.test.ts` green;
  prompt-snapshot comparison suite green (12/12); `oxlint` clean; `tsgo -p tsconfig.core.json` clean.
- **Prompt snapshot fixtures** (`test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/*`):
  after rebase the fixture delta vs `main` is only the cron `trigger.script` and `sessions_search`
  `query` `maxLength → description` change plus the matching token-count updates (the
  `declarationKey` `pattern` hunk is now `main`'s). The comparison suite recomputes each prompt from
  source and asserts equality with the committed fixture, so the fixtures are proven consistent with
  the rebased schema.

### Live proof (llama.cpp) — refreshed against current `main`

Reproduced against a real `llama-server` build **b10043 (79bba02a6)**, CPU, `--jinja`, `-c 32768`;
model **Qwen2.5-0.5B-Instruct `q4_k_m`**. Payload = openclaw's **full active built-in tool set
(31 tools)** — `cron`, `spawn_task`, `dismiss_task`, `sessions_search`, … — extracted from the real
factories (`createOpenClawTools(...)`) and serialized through the exact OpenAI-compatible path
openclaw sends (`normalizeToolParameterSchema(schema, { modelProvider: "openai" })`), POSTed
verbatim to `/v1/chat/completions`. The two payloads are identical except the four `maxLength`
bounds this branch removes.

**Before = current `main` @ `ff1687e04f` (already includes #108360) → still HTTP 400, pre-inference.**
The declaration-key pattern is gone, so the grammar compiler advances past it and dies on the next
landmine — the `65536` trigger-script bound:

```
POST /v1/chat/completions  ->  HTTP 400
client body: {"error":{"code":400,"message":"Failed to initialize samplers: failed to parse grammar","type":"invalid_request_error"}}
server.log:  parse: error parsing grammar: number of repetitions exceeds sane defaults, please reduce the number of repetitions
             E failed to parse grammar
             srv send_error: task id = 0, error: Failed to initialize samplers: failed to parse grammar
             srv process_sing: failed to launch slot with task, id_task = 0
```

(No `Pattern must start with '^' and end with '$'` this run — #108360 removed that. Unlike the
pattern check, which surfaces its detail in the client body, the repetition-ceiling failure
returns a generic client message and logs the specific converter error server-side.)

**After = this branch @ `36588df428` → HTTP 200, full 31-tool grammar compiles, turn completes.**

```
POST /v1/chat/completions  ->  HTTP 200
finish_reason "stop", content "Hello! How can I assist you today?"
usage: prompt_tokens 13403, completion_tokens 10  (cached_tokens 0 — fully fresh eval)
server.log: slot launch_slot_: task 2 | processing task
            slot print_timing:  task 2 | prompt eval time = 317575.89 ms / 13403 tokens
            slot print_timing:  task 2 |        eval time =   2662.89 ms /    10 tokens
            slot release:        task 2 | stop processing: n_tokens = 13412  (no grammar exception)
```

**This single before/after proves #108360 alone did not restore service:** with the pattern already
removed on `main`, the same full-tool request still 400s at grammar compile on the repetition
ceiling; removing the remaining `maxLength` bounds (this branch) is what lets the full grammar
compile and the turn complete.

### Method note

The test box can't build the openclaw CLI (Node 22.22.1 < the repo's 22.22.3 engine floor, no
prebuilt `dist/`), so the live proof exercises the failure at the provider boundary — openclaw's
*exact* advertised tool schemas POSTed to llama-server — rather than a full gateway/channel agent
turn. Since the failure is entirely server-side JSON-schema→GBNF grammar compilation
(pre-inference), this is the same chain that 400s for a llama.cpp-backed user.

## Follow-ups (out of scope here)

- A `toolSchemaProfile`-style GBNF cleaner in `applyProviderCleaning`
  (`packages/ai/src/providers/agent-tools-parameter-schema.ts`) for grammar-constrained backends,
  mirroring the existing Gemini path (`clean-for-gemini.ts` already strips `pattern`/`maxLength`).
  Until then, a per-model config workaround exists today:
  `unsupportedToolSchemaKeywords: ["pattern", "maxLength"]`.
- Extension tools with the same class of construct (`extensions/diffs` 2 MB `patch` maxLength;
  `extensions/workspaces` typeless `Type.Unknown` nodes) — worth a separate issue.
