### PR TITLE
fix(ci): bound workflow ShellCheck download

### DIFF
--- a/.github/workflows/workflow-sanity.yml
+++ b/.github/workflows/workflow-sanity.yml
@@ -168,7 +168,8 @@ jobs:
           set -euo pipefail
           SHELLCHECK_VERSION="0.11.0"
           archive="shellcheck-v${SHELLCHECK_VERSION}.linux.x86_64.tar.xz"
-          curl --retry 5 --retry-delay 2 --retry-all-errors -sSfL \
+          curl --connect-timeout 10 --max-time 120 \
+            --retry 5 --retry-delay 2 --retry-all-errors -sSfL \
             -o "${archive}" \
             "https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/${archive}"
           echo "8c3be12b05d5c177a04c29e3c78ce89ac86f1595681cab149b65b97c4e227198  ${archive}" | sha256sum -c -

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -1860,6 +1860,19 @@ describe("ci workflow guards", () => {
     }
   });
 
+  it("bounds the workflow sanity ShellCheck download", () => {
+    const workflow = readWorkflowSanityWorkflow();
+    const installStep = expectDefined(
+      workflow.jobs.actionlint.steps.find(
+        (step: WorkflowStep) => step.name === "Install ShellCheck",
+      ),
+      "ShellCheck install step",
+    );
+
+    expect(installStep.run).toContain("curl --connect-timeout 10 --max-time 120");
+    expect(installStep.run).toContain("--retry 5 --retry-delay 2 --retry-all-errors");
+  });
+
   it("runs generated baseline drift checks in workflow sanity", () => {
     const workflow = readWorkflowSanityWorkflow();
     const steps = workflow.jobs["generated-doc-baselines"].steps;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the Workflow Sanity job could remain stuck until its job-level limit when the pinned ShellCheck release download connected but stopped transferring data.

## Why This Change Was Made

The ShellCheck transfer now has a 10-second connection deadline and a 120-second per-attempt deadline while retaining the existing five retries and checksum verification. This is limited to the ShellCheck download; the adjacent actionlint installation is being changed independently in #108444.

## User Impact

Contributors and maintainers receive a bounded, actionable workflow failure when the ShellCheck release endpoint stalls, rather than waiting on the much broader CI job timeout.

## Evidence

- `pnpm test test/scripts/ci-workflow-guards.test.ts --run` passed.
- `actionlint` passed for the updated workflow.
- `zizmor` passed for the updated workflow.
- `oxfmt --check test/scripts/ci-workflow-guards.test.ts` passed.
- `git diff --check upstream/main...HEAD` passed.
- The added structured workflow test resolves the named `Install ShellCheck` step and verifies both timeout flags and the retained retry policy.
- Controlled curl proof: a no-deadline request to a server that sent headers and then stalled required an outer watchdog and exited 124; the same request with scaled production timeout flags exited on its own with curl 28; a responsive request still succeeded.
- curl documents `--connect-timeout` as bounding DNS/connection handshakes and `--max-time` as bounding each transfer attempt: https://curl.se/docs/manpage.html#--connect-timeout and https://curl.se/docs/manpage.html#--max-time
- Fresh full-branch Claude autoreview against `upstream/main@29475988dac` reported no accepted or actionable findings and rated the patch correct (confidence 0.92).
- Live open-PR search found no duplicate for the ShellCheck download timeout. #108444 changes the separate actionlint installation path.
