### PR TITLE
fix: standalone OAuth test teardown failures

### DIFF
--- a/src/agents/auth-profiles/oauth-file-lock-passthrough.test-support.ts
+++ b/src/agents/auth-profiles/oauth-file-lock-passthrough.test-support.ts
@@ -6,11 +6,13 @@
 import { afterAll, vi } from "vitest";
 
 vi.mock("../../infra/file-lock.js", () => ({
+  drainFileLockStateForTest: async () => undefined,
   resetFileLockStateForTest: () => undefined,
   withFileLock: async <T>(_filePath: string, _options: unknown, run: () => Promise<T>) => run(),
 }));
 
 vi.mock("../../plugin-sdk/file-lock.js", () => ({
+  drainFileLockStateForTest: async () => undefined,
   resetFileLockStateForTest: () => undefined,
   withFileLock: async <T>(_filePath: string, _options: unknown, run: () => Promise<T>) => run(),
 }));


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where developers running OAuth auth-profile suites standalone would see otherwise-passing tests fail during global teardown.

## Why This Change Was Made

The shared OAuth file-lock passthrough now exports an async no-op drain helper from both explicit mock factories. Both factories need the binding because the infra facade re-exports the plugin-SDK implementation.

## User Impact

No production behavior change. Maintainers can run the affected OAuth suites standalone without depending on shared-worker module order.

## Evidence

- Before: standalone oauth-refresh-queue.test.ts failed 2/2 during teardown with drainFileLockStateForTest is not a function.
- After: standalone oauth-refresh-queue.test.ts (2), oauth.adopt-identity.test.ts (3), and oauth.mirror-refresh.test.ts (8) all pass.
- pnpm check:changed passes on Blacksmith Testbox.
- Full unchanged agents-support shard passed 118 files / 1,870 tests before the fix, confirming its shared non-isolated worker masked the missing export.
- Autoreview clean; no accepted/actionable findings.

AI-assisted: Codex implemented and validated the focused test-only fix under maintainer direction.