### PR TITLE
fix(gateway): block external webchat checkpoint branches

### DIFF
--- a/src/gateway/server-methods/sessions-compaction-checkpoints.ts
+++ b/src/gateway/server-methods/sessions-compaction-checkpoints.ts
@@ -38,7 +38,7 @@ const MODEL_SELECTION_LOCKED_CHECKPOINT_MESSAGE =
   "Checkpoint branch and restore are unavailable while model selection is locked.";
 
 export const sessionCheckpointHandlers: GatewayRequestHandlers = {
-  "sessions.compaction.branch": async ({ params, respond, context }) => {
+  "sessions.compaction.branch": async ({ params, respond, context, client, isWebchatConnect }) => {
     if (
       !assertValidParams(
         params,
@@ -52,6 +52,9 @@ export const sessionCheckpointHandlers: GatewayRequestHandlers = {
     const p = params;
     const key = requireSessionKey(p.key, respond);
     if (!key) {
+      return;
+    }
+    if (rejectWebchatSessionMutation({ action: "branch", client, isWebchatConnect, respond })) {
       return;
     }
     const checkpointId =

--- a/src/gateway/server-methods/sessions-shared.ts
+++ b/src/gateway/server-methods/sessions-shared.ts
@@ -278,7 +278,7 @@ export function emitSessionOperation(
 }
 
 export function rejectWebchatSessionMutation(params: {
-  action: "patch" | "delete" | "compact" | "restore" | "dispatch" | "reclaim";
+  action: "patch" | "delete" | "compact" | "branch" | "restore" | "dispatch" | "reclaim";
   client: GatewayClient | null;
   isWebchatConnect: (params: GatewayClient["connect"] | null | undefined) => boolean;
   respond: RespondFn;

--- a/src/gateway/server.sessions.permissions-hooks.test.ts
+++ b/src/gateway/server.sessions.permissions-hooks.test.ts
@@ -133,7 +133,7 @@ test("webchat clients cannot mutate sessions", async () => {
   expect(
     listSessionEntries({ storePath })
       .map(({ sessionKey }) => sessionKey)
-      .sort(),
+      .toSorted(),
   ).toEqual(["agent:main:discord:group:dev", "agent:main:main"]);
 
   const restored = await rpcReq(ws, "sessions.compaction.restore", {

--- a/src/gateway/server.sessions.permissions-hooks.test.ts
+++ b/src/gateway/server.sessions.permissions-hooks.test.ts
@@ -13,7 +13,11 @@ import {
   GATEWAY_CLIENT_IDS,
   GATEWAY_CLIENT_MODES,
 } from "../../packages/gateway-protocol/src/client-info.js";
-import { loadSessionEntry } from "../config/sessions/session-accessor.js";
+import {
+  listSessionEntries,
+  loadSessionEntry,
+  upsertSessionEntry,
+} from "../config/sessions/session-accessor.js";
 import { isSessionPatchEvent } from "../hooks/internal-hooks.js";
 import { requireRecord } from "./test-helpers.assertions.js";
 import { connectWebchatClient, rpcReq, testState, writeSessionStore } from "./test-helpers.js";
@@ -48,45 +52,52 @@ function requireFirstCallArg(mock: { mock: { calls: readonly (readonly unknown[]
   return call[0];
 }
 
-test("webchat clients cannot patch, delete, compact, or restore sessions", async () => {
-  const { dir } = await createSessionStoreDir();
+async function createPermissionCheckpointStore() {
+  const { dir, storePath } = await createSessionStoreDir();
   const fixture = await createCheckpointFixture(dir);
   if (!fixture.preCompactionSession || !fixture.preCompactionSessionFile) {
     throw new Error("expected legacy checkpoint fixture");
   }
 
-  await writeSessionStore({
-    entries: {
-      main: sessionStoreEntry(fixture.sessionId, {
-        sessionFile: fixture.sessionFile,
-        compactionCheckpoints: [
-          {
-            checkpointId: "checkpoint-1",
-            sessionKey: "agent:main:main",
-            sessionId: fixture.sessionId,
-            createdAt: Date.now(),
-            reason: "manual",
-            tokensBefore: 123,
-            tokensAfter: 45,
-            summary: "checkpoint summary",
-            firstKeptEntryId: fixture.preCompactionLeafId,
-            preCompaction: {
-              sessionId: fixture.preCompactionSession.getSessionId(),
-              sessionFile: fixture.preCompactionSessionFile,
-              leafId: fixture.preCompactionLeafId,
-            },
-            postCompaction: {
-              sessionId: fixture.sessionId,
-              sessionFile: fixture.sessionFile,
-              leafId: fixture.postCompactionLeafId,
-              entryId: fixture.postCompactionLeafId,
-            },
+  await upsertSessionEntry(
+    { sessionKey: "agent:main:main", storePath },
+    sessionStoreEntry(fixture.sessionId, {
+      sessionFile: fixture.sessionFile,
+      compactionCheckpoints: [
+        {
+          checkpointId: "checkpoint-1",
+          sessionKey: "agent:main:main",
+          sessionId: fixture.sessionId,
+          createdAt: Date.now(),
+          reason: "manual",
+          tokensBefore: 123,
+          tokensAfter: 45,
+          summary: "checkpoint summary",
+          firstKeptEntryId: fixture.preCompactionLeafId,
+          preCompaction: {
+            sessionId: fixture.preCompactionSession.getSessionId(),
+            sessionFile: fixture.preCompactionSessionFile,
+            leafId: fixture.preCompactionLeafId,
           },
-        ],
-      }),
-      "discord:group:dev": sessionStoreEntry("sess-group"),
-    },
-  });
+          postCompaction: {
+            sessionId: fixture.sessionId,
+            sessionFile: fixture.sessionFile,
+            leafId: fixture.postCompactionLeafId,
+            entryId: fixture.postCompactionLeafId,
+          },
+        },
+      ],
+    }),
+  );
+  await upsertSessionEntry(
+    { sessionKey: "agent:main:discord:group:dev", storePath },
+    sessionStoreEntry("sess-group"),
+  );
+  return { storePath };
+}
+
+test("webchat clients cannot mutate sessions", async () => {
+  const { storePath } = await createPermissionCheckpointStore();
 
   const ws = await openPermissionClient({
     id: GATEWAY_CLIENT_IDS.WEBCHAT_UI,
@@ -112,6 +123,18 @@ test("webchat clients cannot patch, delete, compact, or restore sessions", async
   });
   expect(compacted.ok).toBe(false);
   expect(compacted.error?.message ?? "").toMatch(/webchat clients cannot compact sessions/i);
+
+  const branched = await rpcReq(ws, "sessions.compaction.branch", {
+    key: "main",
+    checkpointId: "checkpoint-1",
+  });
+  expect(branched.ok).toBe(false);
+  expect(branched.error?.message ?? "").toMatch(/webchat clients cannot branch sessions/i);
+  expect(
+    listSessionEntries({ storePath })
+      .map(({ sessionKey }) => sessionKey)
+      .sort(),
+  ).toEqual(["agent:main:discord:group:dev", "agent:main:main"]);
 
   const restored = await rpcReq(ws, "sessions.compaction.restore", {
     key: "main",
@@ -304,22 +327,23 @@ test("session:patch hook mutations cannot change the response path", async () =>
   ws.close();
 });
 
-test("control-ui client can delete sessions even in webchat mode", async () => {
-  const dir = makeTempDir(permHookTempDirs, "openclaw-sessions-control-ui-delete-");
-  const storePath = path.join(dir, "sessions.json");
-  testState.sessionStorePath = storePath;
-
-  await writeSessionStore({
-    entries: {
-      main: sessionStoreEntry("sess-main"),
-      "discord:group:dev": sessionStoreEntry("sess-group"),
-    },
-  });
-
+test("control-ui client can mutate sessions even in webchat mode", async () => {
+  const { storePath } = await createPermissionCheckpointStore();
   const ws = await openPermissionClient({
     id: GATEWAY_CLIENT_IDS.CONTROL_UI,
     mode: GATEWAY_CLIENT_MODES.WEBCHAT,
   });
+
+  const branched = await rpcReq<{
+    sourceKey: string;
+    entry: { parentSessionKey?: string };
+  }>(ws, "sessions.compaction.branch", {
+    key: "main",
+    checkpointId: "checkpoint-1",
+  });
+  expect(branched.ok).toBe(true);
+  expect(branched.payload?.sourceKey).toBe("agent:main:main");
+  expect(branched.payload?.entry.parentSessionKey).toBe("agent:main:main");
 
   const deleted = await rpcReq<{ ok: true; deleted: boolean }>(ws, "sessions.delete", {
     key: "agent:main:discord:group:dev",


### PR DESCRIPTION
Closes #107682

## What Problem This Solves

External webchat clients could branch transcript-bearing compaction checkpoints from other sessions because the branch RPC skipped the shared webchat mutation guard.

## Why This Change Was Made

Route checkpoint branching through the existing external-webchat session-mutation guard before checkpoint lookup or mutation. This preserves authenticated Control UI and trusted operator recovery without changing scopes, protocol, or storage.

## User Impact

External webchat clients can no longer materialize another session's checkpoint as a readable child session. Authenticated Control UI checkpoint recovery continues to work.

## Release note

Gateway: prevent external webchat clients from branching transcript-bearing checkpoints from other sessions while preserving authenticated Control UI recovery. Thanks @yetval.

## Evidence

- Before: the focused Gateway regression proved branch bypassed the webchat guard and reached checkpoint lookup.
- After: `pnpm check:changed` passed on AWS Crabbox.
- After: `pnpm test src/gateway/server.sessions.permissions-hooks.test.ts` passed, 7/7 tests, on AWS Crabbox.
- Fresh whole-branch autoreview: clean, no findings.
- AI-assisted: Codex.
