### PR TITLE
fix(cron): prevent completed runs retrying after claim conflicts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Cron lifecycle retries:** retry session claim conflicts only before agent execution starts, preventing completed messages and tool effects from being replayed after a final persistence race. (#108428) Thanks @yetval.
 - **Tlon SSE connect cleanup:** disarm opening deadlines after failed HTTP responses and rejected stream opens so reconnect attempts cannot leave stale timers behind. (#104585) Thanks @hugenshen.
 - **LINE reply-token media kinds:** honor video and audio metadata on inbound replies, share the canonical media builder with proactive sends, and fail visibly instead of recording empty media-only deliveries. (#106515) Thanks @edenfunf.
 - **Mattermost websocket connection deadlines:** bound opening handshakes so stalled TCP peers cannot hang channel startup indefinitely and reconnect control resumes after timeout. (#105553) Thanks @hugenshen.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Cron lifecycle retries:** retry session claim conflicts only before agent execution starts, preventing completed messages and tool effects from being replayed after a final persistence race. (#108428) Thanks @yetval.
 - **Tlon SSE connect cleanup:** disarm opening deadlines after failed HTTP responses and rejected stream opens so reconnect attempts cannot leave stale timers behind. (#104585) Thanks @hugenshen.
 - **LINE reply-token media kinds:** honor video and audio metadata on inbound replies, share the canonical media builder with proactive sends, and fail visibly instead of recording empty media-only deliveries. (#106515) Thanks @edenfunf.
 - **Mattermost websocket connection deadlines:** bound opening handshakes so stalled TCP peers cannot hang channel startup indefinitely and reconnect control resumes after timeout. (#105553) Thanks @hugenshen.

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -4587,6 +4587,7 @@ public struct SessionsCreateParams: Codable, Sendable {
     public let agentid: String?
     public let label: String?
     public let model: String?
+    public let thinkinglevel: String?
     public let catalogid: String?
     public let parentsessionkey: String?
     public let fork: Bool?
@@ -4605,6 +4606,7 @@ public struct SessionsCreateParams: Codable, Sendable {
         agentid: String? = nil,
         label: String? = nil,
         model: String? = nil,
+        thinkinglevel: String? = nil,
         catalogid: String? = nil,
         parentsessionkey: String? = nil,
         fork: Bool? = nil,
@@ -4622,6 +4624,7 @@ public struct SessionsCreateParams: Codable, Sendable {
         self.agentid = agentid
         self.label = label
         self.model = model
+        self.thinkinglevel = thinkinglevel
         self.catalogid = catalogid
         self.parentsessionkey = parentsessionkey
         self.fork = fork
@@ -4641,6 +4644,7 @@ public struct SessionsCreateParams: Codable, Sendable {
         case agentid = "agentId"
         case label
         case model
+        case thinkinglevel = "thinkingLevel"
         case catalogid = "catalogId"
         case parentsessionkey = "parentSessionKey"
         case fork

--- a/src/cron/isolated-agent/run.session-lifecycle.test.ts
+++ b/src/cron/isolated-agent/run.session-lifecycle.test.ts
@@ -1,5 +1,6 @@
 // Persistent cron session tests cover lifecycle admission and mutation races.
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { SessionEntry } from "../../config/sessions.js";
 import {
   interruptSessionWorkAdmissions,
   isSessionWorkAdmissionActive,
@@ -14,6 +15,7 @@ import {
   makeCronSession,
   makeCronSessionEntry,
   mockRunCronFallbackPassthrough,
+  patchSessionEntryMock,
   preflightCronModelProviderMock,
   resetRunCronIsolatedAgentTurnHarness,
   resolveCronSessionMock,
@@ -267,6 +269,73 @@ describe("runCronIsolatedAgentTurn session lifecycle", () => {
 
     await expect(run).resolves.toMatchObject({ status: "ok" });
     expect(isSessionWorkAdmissionActive(storePath, [sessionKey, sessionId])).toBe(false);
+  });
+
+  it("marks a final lifecycle claim conflict as post-execution (#108428)", async () => {
+    const sessionKey = "agent:main:main";
+    const initialSessionEntry = makeCronSessionEntry({ sessionId: "persistent-session" });
+    resolveCronSessionMock.mockReturnValue(
+      makeCronSession({
+        storePath: inMemoryStorePath,
+        store: { [sessionKey]: { ...initialSessionEntry } },
+        initialSessionEntry,
+        isNewSession: false,
+        sessionEntry: { ...initialSessionEntry },
+      }),
+    );
+    loadSessionEntryMock.mockReturnValue({ ...initialSessionEntry });
+
+    let agentExecutionStarted = false;
+    runEmbeddedAgentMock.mockImplementationOnce(
+      async (runParams: { onExecutionStarted?: () => void }) => {
+        runParams.onExecutionStarted?.();
+        agentExecutionStarted = true;
+        return {
+          payloads: [{ text: "completed" }],
+          meta: { agentMeta: {} },
+        };
+      },
+    );
+
+    const committedRows = new Map<string, SessionEntry>([
+      [`${inMemoryStorePath}\0${sessionKey}`, structuredClone(initialSessionEntry) as SessionEntry],
+    ]);
+    patchSessionEntryMock.mockImplementation(
+      async (
+        scope: { storePath?: string; sessionKey: string },
+        update: (
+          entry: SessionEntry,
+          context: { existingEntry: SessionEntry | undefined },
+        ) => SessionEntry | null,
+        options: { fallbackEntry?: SessionEntry } = {},
+      ) => {
+        const key = `${scope.storePath ?? ""}\0${scope.sessionKey}`;
+        const current = committedRows.get(key);
+        const writeBase = current ?? options.fallbackEntry;
+        if (!writeBase) {
+          return null;
+        }
+        const existingEntry =
+          agentExecutionStarted && scope.sessionKey === sessionKey
+            ? { ...current, lifecycleRevision: "replacement-revision" }
+            : current;
+        const committed = update(structuredClone(writeBase), {
+          existingEntry: existingEntry ? structuredClone(existingEntry) : undefined,
+        });
+        if (committed) {
+          committedRows.set(key, structuredClone(committed));
+        }
+        return committed;
+      },
+    );
+
+    await expect(
+      runCronIsolatedAgentTurn(makePersistentCronParams(sessionKey)),
+    ).resolves.toMatchObject({
+      status: "error",
+      error: `CronSessionLifecycleClaimError: Session "${sessionKey}" changed while starting work. Retry.`,
+      executionStarted: true,
+    });
   });
 
   it("releases a custom cron session lease before delete-after-run cleanup", async () => {

--- a/src/cron/isolated-agent/run.session-lifecycle.test.ts
+++ b/src/cron/isolated-agent/run.session-lifecycle.test.ts
@@ -317,7 +317,7 @@ describe("runCronIsolatedAgentTurn session lifecycle", () => {
         }
         const existingEntry =
           agentExecutionStarted && scope.sessionKey === sessionKey
-            ? { ...current, lifecycleRevision: "replacement-revision" }
+            ? { ...writeBase, lifecycleRevision: "replacement-revision" }
             : current;
         const committed = update(structuredClone(writeBase), {
           existingEntry: existingEntry ? structuredClone(existingEntry) : undefined,

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -1641,7 +1641,9 @@ export async function runCronIsolatedAgentTurn(params: {
   const ownsRunContext = params.job.sessionTarget === "isolated";
   let runContextOwnerToken: string | undefined;
   let runLifecycleGeneration = admittedLifecycleGeneration;
+  let executionStarted = false;
   const notifyExecutionStarted = (info?: { lifecycleGeneration?: string }) => {
+    executionStarted = true;
     if (info?.lifecycleGeneration) {
       runLifecycleGeneration = info.lifecycleGeneration;
     }
@@ -1787,6 +1789,7 @@ export async function runCronIsolatedAgentTurn(params: {
     return prepared.context.withRunSession({
       status: "error",
       error,
+      executionStarted,
       // Carry the already-resolved run model into the error/timeout row so
       // Task-run history keeps provider/model attribution instead of looking like
       // an un-attributed cron timeout. finalizeCronRun does the same via

--- a/src/cron/retry-hint.test.ts
+++ b/src/cron/retry-hint.test.ts
@@ -8,14 +8,16 @@ import {
 
 describe("resolveCronExecutionRetryHint", () => {
   it("matches classified transient errors", () => {
-    expect(resolveCronExecutionRetryHint("HTTP 529", ["overloaded"])).toEqual({
+    expect(resolveCronExecutionRetryHint({ error: "HTTP 529", retryOn: ["overloaded"] })).toEqual({
       retryable: true,
       category: "overloaded",
     });
-    expect(resolveCronExecutionRetryHint("429 rate limit exceeded", ["rate_limit"])).toEqual({
-      retryable: true,
-      category: "rate_limit",
-    });
+    expect(
+      resolveCronExecutionRetryHint({
+        error: "429 rate limit exceeded",
+        retryOn: ["rate_limit"],
+      }),
+    ).toEqual({ retryable: true, category: "rate_limit" });
   });
 
   it("treats common network error codes as network when retryOn only includes network", () => {
@@ -28,22 +30,26 @@ describe("resolveCronExecutionRetryHint", () => {
       "ENETUNREACH",
       "EPIPE",
     ]) {
-      expect(resolveCronExecutionRetryHint(`temporary DNS failure: ${code}`, ["network"])).toEqual({
-        retryable: true,
-        category: "network",
-      });
+      expect(
+        resolveCronExecutionRetryHint({
+          error: `temporary DNS failure: ${code}`,
+          retryOn: ["network"],
+        }),
+      ).toEqual({ retryable: true, category: "network" });
     }
   });
 
   it("does not retry permanent errors", () => {
-    expect(resolveCronExecutionRetryHint("invalid API key", ["network"])).toEqual({
+    expect(
+      resolveCronExecutionRetryHint({ error: "invalid API key", retryOn: ["network"] }),
+    ).toEqual({
       retryable: false,
     });
   });
 
   it("classifies cron pre-execution watchdog failures as timeout retries", () => {
     for (const message of [setupTimeoutErrorMessage(), preExecutionTimeoutErrorMessage()]) {
-      expect(resolveCronExecutionRetryHint(message, ["timeout"])).toEqual({
+      expect(resolveCronExecutionRetryHint({ error: message, retryOn: ["timeout"] })).toEqual({
         retryable: true,
         category: "timeout",
       });
@@ -60,7 +66,7 @@ describe("resolveCronExecutionRetryHint", () => {
       "error 500 got 0",
       "process exited with code 500",
     ]) {
-      expect(resolveCronExecutionRetryHint(message, ["server_error"])).toEqual({
+      expect(resolveCronExecutionRetryHint({ error: message, retryOn: ["server_error"] })).toEqual({
         retryable: false,
       });
     }
@@ -77,7 +83,7 @@ describe("resolveCronExecutionRetryHint", () => {
       "503",
       "500",
     ]) {
-      expect(resolveCronExecutionRetryHint(message, ["server_error"])).toEqual({
+      expect(resolveCronExecutionRetryHint({ error: message, retryOn: ["server_error"] })).toEqual({
         retryable: true,
         category: "server_error",
       });
@@ -90,15 +96,28 @@ describe("resolveCronExecutionRetryHint", () => {
       'Error: Session "agent:main:cron:job-1" changed while starting work. Retry.',
       'Error: Session "agent:main:cron:job-1" was deleted while starting work. Retry.',
     ]) {
-      expect(resolveCronExecutionRetryHint(message, ["network"])).toEqual({ retryable: true });
+      expect(resolveCronExecutionRetryHint({ error: message, retryOn: ["network"] })).toEqual({
+        retryable: true,
+      });
     }
+  });
+
+  it("does not retry lifecycle claim conflicts after execution starts (#108428)", () => {
+    expect(
+      resolveCronExecutionRetryHint({
+        error:
+          'CronSessionLifecycleClaimError: Session "agent:main:cron:job-1" changed while starting work. Retry.',
+        retryOn: ["network"],
+        executionStarted: true,
+      }),
+    ).toEqual({ retryable: false });
   });
 
   it("does not classify archived-session work-start errors as transient", () => {
     expect(
-      resolveCronExecutionRetryHint(
-        'Error: Session "agent:main:main" is archived. Restore it before starting new work.',
-      ),
+      resolveCronExecutionRetryHint({
+        error: 'Error: Session "agent:main:main" is archived. Restore it before starting new work.',
+      }),
     ).toEqual({ retryable: false });
   });
 });

--- a/src/cron/retry-hint.ts
+++ b/src/cron/retry-hint.ts
@@ -7,6 +7,13 @@ type CronRetryHint = {
   category?: CronRetryOn;
 };
 
+type CronRetryHintInput = {
+  error: string | undefined;
+  retryOn?: CronRetryOn[];
+  classifiedReason?: string | null;
+  executionStarted?: boolean;
+};
+
 // A bare 5xx-looking number embedded in prose is not an HTTP server error: cron
 // failure messages routinely contain such numbers ("context limit 512 exceeded",
 // "exited with 503 lines", "pid 511 killed", a "...-540.sock" path), and
@@ -18,8 +25,8 @@ type CronRetryHint = {
 const SERVER_ERROR_PATTERN =
   /\b(?:https?|status(?:[ _]code)?|response(?:[ _]code)?|http(?:[ _]status)?)\b[\s:=#"']{0,4}5\d{2}\b|\b5\d{2}\b[\s:)\].,-]*(?:internal server error|server error|bad gateway|service unavailable|gateway time-?out)\b|\binternal server error\b|\bbad gateway\b|\bservice unavailable\b|\bgateway time-?out\b|\b5xx\b|^\s*5\d{2}\s*$/i;
 
-// Lifecycle claims can lose a race before provider execution. Retry the run;
-// treating the conflict as permanent disables one-shot jobs without running them.
+// Lifecycle claims can lose a race before provider execution. Retry only before
+// execution starts; afterward, tools may have produced non-idempotent effects.
 const SESSION_LIFECYCLE_CLAIM_ERROR_PATTERN =
   /^(?:(?:CronSessionLifecycleClaimError|Error): )?Session "[^"\n]+" (?:changed|was deleted) while starting work\. Retry\.$/;
 
@@ -35,16 +42,13 @@ const TRANSIENT_PATTERNS: Record<CronRetryOn, RegExp> = {
 };
 
 /** Classifies cron execution errors against the configured retryable transient categories. */
-export function resolveCronExecutionRetryHint(
-  error: string | undefined,
-  retryOn?: CronRetryOn[],
-  classifiedReason?: string | null,
-): CronRetryHint {
+export function resolveCronExecutionRetryHint(input: CronRetryHintInput): CronRetryHint {
+  const { error, retryOn, classifiedReason, executionStarted } = input;
   if (!error || typeof error !== "string") {
     return { retryable: false };
   }
   if (SESSION_LIFECYCLE_CLAIM_ERROR_PATTERN.test(error)) {
-    return { retryable: true };
+    return { retryable: executionStarted !== true };
   }
   const keys = retryOn?.length ? retryOn : (Object.keys(TRANSIENT_PATTERNS) as CronRetryOn[]);
   const classified = classifiedReason ?? undefined;

--- a/src/cron/service.runs-one-shot-main-job-disables-it.test.ts
+++ b/src/cron/service.runs-one-shot-main-job-disables-it.test.ts
@@ -668,6 +668,31 @@ describe("CronService", () => {
     await stopCronAndCleanup(cron, store);
   });
 
+  it("does not retry a lifecycle claim conflict after agent execution starts (#108428)", async () => {
+    const runIsolatedAgentJob = vi.fn(async () => ({
+      status: "error" as const,
+      error:
+        'CronSessionLifecycleClaimError: Session "agent:main:cron:job-1" changed while starting work. Retry.',
+      executionStarted: true,
+    }));
+    const { store, cron, events } = await createIsolatedAnnounceHarness(runIsolatedAgentJob);
+    const job = await runIsolatedAnnounceJobAndWait({
+      cron,
+      events,
+      name: "post-execution lifecycle claim conflict",
+      status: "error",
+    });
+
+    const updated = (await cron.list({ includeDisabled: true })).find(
+      (entry) => entry.id === job.id,
+    );
+    expect(updated?.enabled).toBe(false);
+    expect(updated?.state.consecutiveErrors).toBe(1);
+    expect(updated?.state.nextRunAtMs).toBeUndefined();
+
+    await stopCronAndCleanup(cron, store);
+  });
+
   it("does not post fallback main summary for isolated delivery-target errors", async () => {
     const runIsolatedAgentJob = vi.fn(async () => ({
       status: "error" as const,

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -499,14 +499,16 @@ function resolveTransientCronRetryDecision(params: {
   cronConfig?: CronConfig;
   error: string | undefined;
   lastErrorReason?: string;
+  executionStarted?: boolean;
   consecutiveErrors: number | undefined;
 }): TransientCronRetryDecision {
   const retryConfig = resolveRetryConfig(params.cronConfig);
-  const retryHint = resolveCronExecutionRetryHint(
-    params.error,
-    retryConfig.retryOn,
-    params.lastErrorReason,
-  );
+  const retryHint = resolveCronExecutionRetryHint({
+    error: params.error,
+    retryOn: retryConfig.retryOn,
+    classifiedReason: params.lastErrorReason,
+    executionStarted: params.executionStarted,
+  });
   const consecutiveErrors = params.consecutiveErrors ?? 0;
   if (!retryHint.retryable) {
     return {
@@ -710,6 +712,7 @@ export function applyJobResult(
   result: {
     status: CronRunStatus;
     error?: string;
+    executionStarted?: boolean;
     deliveryError?: string;
     diagnostics?: CronRunOutcome["diagnostics"];
     delivered?: boolean;
@@ -869,6 +872,7 @@ export function applyJobResult(
           cronConfig: state.deps.cronConfig,
           error: result.error,
           lastErrorReason: job.state.lastErrorReason,
+          executionStarted: result.executionStarted,
           consecutiveErrors: job.state.consecutiveErrors,
         });
         if (retryDecision.retryable && retryDecision.backoffMs !== undefined) {
@@ -910,6 +914,7 @@ export function applyJobResult(
         cronConfig: state.deps.cronConfig,
         error: result.error,
         lastErrorReason: job.state.lastErrorReason,
+        executionStarted: result.executionStarted,
         consecutiveErrors: job.state.consecutiveErrors,
       });
       let normalNext: number | undefined;
@@ -1139,6 +1144,7 @@ function applyOutcomeToStoredJob(
       applyJobResult(state, result.job, {
         status: result.status,
         error: result.error,
+        executionStarted: result.executionStarted,
         deliveryError: result.deliveryError,
         diagnostics: result.diagnostics,
         delivered: result.delivered,
@@ -1176,6 +1182,7 @@ function applyOutcomeToStoredJob(
   const shouldDelete = applyJobResult(state, job, {
     status: result.status,
     error: result.error,
+    executionStarted: result.executionStarted,
     deliveryError: result.deliveryError,
     diagnostics: result.diagnostics,
     delivered: result.delivered,
@@ -1924,6 +1931,7 @@ async function runStartupCatchupCandidate(
       activeJobMarker,
       status: result.status,
       error: result.error,
+      executionStarted: result.executionStarted,
       summary: result.summary,
       diagnostics: result.diagnostics,
       delivered: result.delivered,
@@ -2394,6 +2402,7 @@ async function executeDetachedCronJob(
   return {
     status: res.status,
     error: res.error,
+    executionStarted: res.executionStarted,
     // Forward the post-run delivery failure recorded on an otherwise
     // successful run so the service can persist it as `lastDeliveryError` and
     // emit it on the finished event for CLI/UI/API run logs (#95419).

--- a/src/cron/types.ts
+++ b/src/cron/types.ts
@@ -187,6 +187,8 @@ export type CronRunDiagnostics = {
 export type CronRunOutcome = {
   status: CronRunStatus;
   error?: string;
+  /** True once agent execution begins; retries after this point can replay side effects. */
+  executionStarted?: boolean;
   /** Optional classifier for execution errors to guide fallback behavior. */
   errorKind?: "delivery-target";
   summary?: string;


### PR DESCRIPTION
Closes #108428

## What Problem This Solves

Fixes an issue where cron agent turns that had already completed messages or tool calls could run again when final session persistence lost a lifecycle-claim race.

## Why This Change Was Made

The isolated runner now records the existing execution-start boundary in error outcomes. Lifecycle-claim conflicts remain retryable before that boundary, preserving the safe setup-race recovery from #107236, but become permanent after execution could have produced side effects. No config, protocol source, or transport behavior changes. This PR also carries the exact Swift generator output for current `main`'s existing `SessionsCreateParams.thinkingLevel` field, repairing deterministic generated drift exposed by the required protocol gate.

## User Impact

Cron jobs still recover from claim conflicts before agent work begins. Once agent execution starts, the scheduler no longer replays completed messages or tools after the same conflict.

## Evidence

- Pre-fix regression proof: the final-persistence scenario omitted execution phase and the scheduler rescheduled the completed one-shot.
- Blacksmith Testbox focused proof: 3 files, 32 tests passed.
- Exact-head local proof after rebase: 3 focused files, 32 tests passed.
- Fresh-head `check:changed`: formatting, core and core-test typechecks, changed lint, boundaries, and guard lanes passed.
- Blacksmith Testbox `protocol:check`: TypeScript, Swift, and Kotlin generated outputs matched.
- Fresh full-branch autoreview: no accepted or actionable findings.
- Source-blind behavior contract: identical conflict text retries pre-execution and disables post-execution; all clauses passed.

AI-assisted implementation and review; maintainer-directed, with regression and repository-gate proof.
