### PR TITLE
fix(ci): bound native tool downloads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2438,7 +2438,9 @@ jobs:
             esac
             swiftformat_archive="$RUNNER_TEMP/swiftformat-$swiftformat_version.zip"
             swift_tools_dir="$RUNNER_TEMP/openclaw-legacy-swift-tools"
-            curl --fail --location --silent --show-error --retry 3 \
+            curl --fail --location --silent --show-error \
+              --connect-timeout 10 --max-time 120 \
+              --retry 3 --retry-max-time 120 \
               --output "$swiftformat_archive" \
               "https://github.com/nicklockwood/SwiftFormat/releases/download/$swiftformat_version/swiftformat.zip"
             if [[ "$(shasum -a 256 "$swiftformat_archive" | awk '{print $1}')" != "$swiftformat_checksum" ]]; then
@@ -2643,7 +2645,9 @@ jobs:
             esac
             swiftformat_archive="$RUNNER_TEMP/swiftformat-$swiftformat_version.zip"
             swift_tools_dir="$RUNNER_TEMP/openclaw-legacy-swift-tools"
-            curl --fail --location --silent --show-error --retry 3 \
+            curl --fail --location --silent --show-error \
+              --connect-timeout 10 --max-time 120 \
+              --retry 3 --retry-max-time 120 \
               --output "$swiftformat_archive" \
               "https://github.com/nicklockwood/SwiftFormat/releases/download/$swiftformat_version/swiftformat.zip"
             if [[ "$(shasum -a 256 "$swiftformat_archive" | awk '{print $1}')" != "$swiftformat_checksum" ]]; then

--- a/scripts/install-swift-tools.sh
+++ b/scripts/install-swift-tools.sh
@@ -18,7 +18,12 @@ install_archive() {
   local archive="$temp_dir/$name.zip"
   local extract_dir="$temp_dir/$name"
 
-  curl --fail --location --silent --show-error --retry 3 --output "$archive" "$url"
+  # Bound individual transfers and the retry window. curl resets --max-time for
+  # each retry, while a started retry can outlive --retry-max-time.
+  curl --fail --location --silent --show-error \
+    --connect-timeout 10 --max-time 120 \
+    --retry 3 --retry-max-time 120 \
+    --output "$archive" "$url"
   if [[ "$(shasum -a 256 "$archive" | awk '{print $1}')" != "$checksum" ]]; then
     echo "$name archive checksum mismatch" >&2
     exit 1

--- a/scripts/install-xcodegen.sh
+++ b/scripts/install-xcodegen.sh
@@ -17,7 +17,11 @@ trap 'rm -rf "$temp_dir"' EXIT
 archive="$temp_dir/xcodegen.zip"
 extract_dir="$temp_dir/extract"
 
-curl --fail --location --silent --show-error --retry 3 \
+# Bound individual transfers and the retry window. curl resets --max-time for
+# each retry, while a started retry can outlive --retry-max-time.
+curl --fail --location --silent --show-error \
+  --connect-timeout 10 --max-time 120 \
+  --retry 3 --retry-max-time 120 \
   --output "$archive" \
   "https://github.com/yonaskolb/XcodeGen/releases/download/$xcodegen_version/xcodegen.zip"
 if [[ "$(shasum -a 256 "$archive" | awk '{print $1}')" != "$xcodegen_checksum" ]]; then

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -2024,6 +2024,8 @@ describe("ci workflow guards", () => {
       expect(installStep.run).toContain(
         "https://github.com/nicklockwood/SwiftFormat/releases/download/$swiftformat_version/swiftformat.zip",
       );
+      expect(installStep.run).toContain("--connect-timeout 10 --max-time 120");
+      expect(installStep.run).toContain("--retry 3 --retry-max-time 120");
       expect(installStep.run).toContain(
         'swiftformat_checksum="b990400779aceb7d7020796eb9ba814d4480543f671d38fc0ff48cb72f04c584"',
       );

--- a/test/scripts/install-native-tools.test.ts
+++ b/test/scripts/install-native-tools.test.ts
@@ -1,0 +1,62 @@
+import { spawnSync } from "node:child_process";
+import { chmodSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+const installers = [
+  {
+    script: "scripts/install-xcodegen.sh",
+    url: "https://github.com/yonaskolb/XcodeGen/releases/download/2.45.4/xcodegen.zip",
+  },
+  {
+    script: "scripts/install-swift-tools.sh",
+    url: "https://github.com/nicklockwood/SwiftFormat/releases/download/0.62.1/swiftformat.zip",
+  },
+] as const;
+
+function expectOption(args: string[], option: string, value: string): void {
+  const index = args.indexOf(option);
+  expect(index, `missing curl option ${option}`).toBeGreaterThanOrEqual(0);
+  expect(args[index + 1]).toBe(value);
+}
+
+describe.runIf(process.platform !== "win32")("native tool installers", () => {
+  it.each(installers)("bounds stalled downloads in $script", ({ script, url }) => {
+    const root = tempDirs.make("openclaw-native-tool-installer-");
+    const binDir = path.join(root, "bin");
+    const argsPath = path.join(root, "curl-args.txt");
+    const curlPath = path.join(binDir, "curl");
+    mkdirSync(binDir);
+    writeFileSync(
+      curlPath,
+      [
+        "#!/usr/bin/env bash",
+        'printf "%s\\n" "$@" >"$OPENCLAW_TEST_CURL_ARGS_PATH"',
+        "exit 28",
+        "",
+      ].join("\n"),
+    );
+    chmodSync(curlPath, 0o755);
+
+    const result = spawnSync("bash", [script, path.join(root, "install")], {
+      cwd: process.cwd(),
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        OPENCLAW_TEST_CURL_ARGS_PATH: argsPath,
+        PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+      },
+    });
+
+    expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(28);
+    const args = readFileSync(argsPath, "utf8").trimEnd().split("\n");
+    expectOption(args, "--connect-timeout", "10");
+    expectOption(args, "--max-time", "120");
+    expectOption(args, "--retry", "3");
+    expectOption(args, "--retry-max-time", "120");
+    expect(args).toContain(url);
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Apple-platform CI could remain stuck until its job-level limit when a pinned XcodeGen, SwiftFormat, or SwiftLint archive transfer connected but stopped making progress. This also covers the two historical-target SwiftFormat fallbacks embedded in the macOS and iOS CI jobs.

## Why This Change Was Made

The two canonical native-tool installers and both historical SwiftFormat fallback downloads now use a 10-second connection deadline, a 120-second per-attempt deadline, and a 120-second retry-start window while retaining three retries and the existing SHA-256 verification.

## User Impact

Contributors and maintainers receive a bounded, actionable native-tool installation failure instead of waiting on the broader macOS or iOS job timeout. Frozen release-target validation receives the same bounded behavior as current targets.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/install-native-tools.test.ts test/scripts/ci-workflow-guards.test.ts` passed: 63 passed, 1 skipped.
- `bash -n scripts/install-xcodegen.sh scripts/install-swift-tools.sh` passed.
- `node scripts/check-changed.mjs -- .github/workflows/ci.yml scripts/install-xcodegen.sh scripts/install-swift-tools.sh test/scripts/install-native-tools.test.ts test/scripts/ci-workflow-guards.test.ts` passed on Blacksmith Testbox `tbx_01kxmz3d3xw3zx89e91xh5a8pc`: https://github.com/openclaw/openclaw/actions/runs/29481940213
- A controlled HTTP body stall exited with curl 28 after 1.025 seconds at a one-second scaled deadline.
- The table-driven test intercepts both installers' real curl invocations, verifies every timeout/retry flag and pinned asset URL, and proves curl timeout exit 28 propagates.
- Structured workflow guards verify the same timeout/retry contract in both historical SwiftFormat fallback branches.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` reported no accepted/actionable findings and rated the combined patch correct (confidence 0.96).
- `git diff --check origin/main...HEAD` passed.
- curl documents that `--max-time` applies per transfer attempt while `--retry-max-time` controls whether another retry may start: https://curl.se/docs/manpage.html#--max-time and https://curl.se/docs/manpage.html#--retry-max-time
- Live open-PR search found no duplicate.
