### PR TITLE
fix: restore queued Sol default CI coverage

### DIFF
--- a/src/auto-reply/reply/queue/state.test.ts
+++ b/src/auto-reply/reply/queue/state.test.ts
@@ -181,7 +181,7 @@ describe("refreshQueuedFollowupSession", () => {
       nextThinking: { agentRuntime: "codex" },
     });
 
-    expect(queue.items[0]?.run.thinkLevel).toBe("low");
+    expect(queue.items[0]?.run.thinkLevel).toBe("medium");
   });
 });
 


### PR DESCRIPTION
## What Problem This Solves

Fixes the current `main` CI failure where the queued-followup default-thinking test still expected Sol to default to `low` after the OpenAI model policy changed that default to `medium`.

## Why This Change Was Made

Aligns the focused queue regression test with the canonical model-default resolver. Runtime behavior is unchanged.

AI-assisted: yes.

## User Impact

No user-visible behavior change. Restores accurate CI coverage for queued Sol followups.

## Evidence

- Failing main CI: https://github.com/openclaw/openclaw/actions/runs/29476419968/job/87550677286
- Focused proof: `node scripts/run-vitest.mjs src/auto-reply/reply/queue/state.test.ts` (1 file, 7 tests passed)
- `git diff --check`
- Autoreview: clean; no accepted/actionable findings
