### PR TITLE
test(reply): align queued Sol retarget default with medium reasoning

### DIFF
--- a/src/auto-reply/reply/queue/state.test.ts
+++ b/src/auto-reply/reply/queue/state.test.ts
@@ -181,7 +181,7 @@ describe("refreshQueuedFollowupSession", () => {
       nextThinking: { agentRuntime: "codex" },
     });
 
-    expect(queue.items[0]?.run.thinkLevel).toBe("low");
+    expect(queue.items[0]?.run.thinkLevel).toBe("medium");
   });
 });
 


### PR DESCRIPTION
## What Problem This Solves
Main is red: e9c6c150e65 (fix(openai): default Sol reasoning to medium) updated the provider policy and its extension tests but missed the downstream consumer expectation in src/auto-reply/reply/queue/state.test.ts:184, which still asserted the old "low" default. Every PR's checks-node-compact-large-1 shard fails on it (e.g. run 29476940262).

## Why This Change Was Made
One-line test alignment with the intended behavior change: retargeting a queued follow-up to gpt-5.6-sol without a session override now recomputes the model default as "medium".

## User Impact
None; test-only. Unblocks CI for all in-flight PRs.

## Evidence
Focused run: node scripts/run-vitest.mjs src/auto-reply/reply/queue/state.test.ts — green locally against origin/main. Failure reproduced deterministically on main by PR #108440's landing loop before this fix.