### PR TITLE
fix(ai): preserve tool-result text for payload-less media

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - **Control UI cloud session thinking:** expose reasoning level in the New Session model picker and persist the selected level before cloud dispatch.
+- **Tool-result media replay:** require inline payload bytes before provider transports advertise or emit image and audio attachments, so URL/path-only media husks fall back to real text or no-output handling instead of replacing tool results with `(see attached image)`. Fixes #104721. Thanks @amknight, @SunnyShu0925, @Cleymo, and @clawdieclawdita.
 - **Tlon SSE connect cleanup:** disarm opening deadlines after failed HTTP responses and rejected stream opens so reconnect attempts cannot leave stale timers behind. (#104585) Thanks @hugenshen.
 - **LINE reply-token media kinds:** honor video and audio metadata on inbound replies, share the canonical media builder with proactive sends, and fail visibly instead of recording empty media-only deliveries. (#106515) Thanks @edenfunf.
 - **Mattermost websocket connection deadlines:** bound opening handshakes so stalled TCP peers cannot hang channel startup indefinitely and reconnect control resumes after timeout. (#105553) Thanks @hugenshen.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,6 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - **Control UI cloud session thinking:** expose reasoning level in the New Session model picker and persist the selected level before cloud dispatch.
-- **Tool-result media replay:** require inline payload bytes before provider transports advertise or emit image and audio attachments, so URL/path-only media husks fall back to real text or no-output handling instead of replacing tool results with `(see attached image)`. Fixes #104721. Thanks @amknight, @SunnyShu0925, @Cleymo, and @clawdieclawdita.
 - **Tlon SSE connect cleanup:** disarm opening deadlines after failed HTTP responses and rejected stream opens so reconnect attempts cannot leave stale timers behind. (#104585) Thanks @hugenshen.
 - **LINE reply-token media kinds:** honor video and audio metadata on inbound replies, share the canonical media builder with proactive sends, and fail visibly instead of recording empty media-only deliveries. (#106515) Thanks @edenfunf.
 - **Mattermost websocket connection deadlines:** bound opening handshakes so stalled TCP peers cannot hang channel startup indefinitely and reconnect control resumes after timeout. (#105553) Thanks @hugenshen.

--- a/extensions/amazon-bedrock/stream.runtime.test.ts
+++ b/extensions/amazon-bedrock/stream.runtime.test.ts
@@ -52,6 +52,44 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
+describe("Bedrock tool-result replay", () => {
+  it("drops payload-less image husks from consecutive tool results", () => {
+    const messages = testing.convertMessages(
+      {
+        messages: [
+          {
+            role: "toolResult",
+            toolCallId: "call_husk",
+            toolName: "screenshot",
+            content: [{ type: "image", mimeType: "image/png", data: "" }],
+            isError: false,
+          },
+          {
+            role: "toolResult",
+            toolCallId: "call_text",
+            toolName: "read",
+            content: [{ type: "text", text: "actual tool output" }],
+            isError: false,
+          },
+        ],
+      } as never,
+      bedrockModel({ input: ["text", "image"] }),
+      "none",
+    );
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0]).toMatchObject({
+      role: ConversationRole.USER,
+      content: [
+        { toolResult: { toolUseId: "call_husk", content: [{ text: "(no output)" }] } },
+        { toolResult: { toolUseId: "call_text", content: [{ text: "actual tool output" }] } },
+      ],
+    });
+    expect(JSON.stringify(messages)).not.toContain('"image"');
+    expect(JSON.stringify(messages)).not.toContain("see attached image");
+  });
+});
+
 describe("Bedrock reasoning replay", () => {
   it("preserves signed reasoning for Claude profile descriptors", () => {
     const modelId =

--- a/extensions/amazon-bedrock/stream.runtime.ts
+++ b/extensions/amazon-bedrock/stream.runtime.ts
@@ -22,6 +22,7 @@ import {
   type Tool as BedrockTool,
   type ToolChoice,
   type ToolConfiguration,
+  type ToolResultContentBlock,
   ToolResultStatus,
 } from "@aws-sdk/client-bedrock-runtime";
 import { NodeHttpHandler } from "@smithy/node-http-handler";
@@ -51,6 +52,7 @@ import {
   type ThinkingLevel,
   type Tool,
   type ToolCall,
+  type ToolResultMessage,
 } from "openclaw/plugin-sdk/llm";
 import {
   resolveClaudeFable5ModelIdentity,
@@ -66,6 +68,7 @@ import {
   createDeferredEventBuffer,
   notifyLlmRequestActivity,
 } from "openclaw/plugin-sdk/provider-stream-shared";
+import { describeToolResultMediaPlaceholder } from "openclaw/plugin-sdk/provider-transport-runtime";
 import { supportsBedrockPromptCaching, type BedrockOptions } from "./bedrock-options.js";
 import { supportsBedrockNativeMaxEffort } from "./thinking-policy.js";
 
@@ -784,6 +787,27 @@ function normalizeToolCallId(id: string): string {
   return sanitized.length > 64 ? sanitized.slice(0, 64) : sanitized;
 }
 
+function createBedrockToolResult(message: ToolResultMessage): ContentBlock.ToolResultMember {
+  const content: ToolResultContentBlock[] = [];
+  for (const block of message.content) {
+    if (block.type === "text") {
+      content.push({ text: sanitizeSurrogates(block.text) });
+      continue;
+    }
+    if (describeToolResultMediaPlaceholder([block])) {
+      content.push({ image: createImageBlock(block.mimeType, block.data) });
+    }
+  }
+
+  return {
+    toolResult: {
+      toolUseId: message.toolCallId,
+      content: content.length > 0 ? content : [{ text: "(no output)" }],
+      status: message.isError ? ToolResultStatus.ERROR : ToolResultStatus.SUCCESS,
+    },
+  };
+}
+
 function convertMessages(
   context: Context,
   model: Model<"bedrock-converse-stream">,
@@ -902,17 +926,7 @@ function convertMessages(
         const toolResults: ContentBlock.ToolResultMember[] = [];
 
         // Add current tool result with all content blocks combined
-        toolResults.push({
-          toolResult: {
-            toolUseId: m.toolCallId,
-            content: m.content.map((c) =>
-              c.type === "image"
-                ? { image: createImageBlock(c.mimeType, c.data) }
-                : { text: sanitizeSurrogates(c.text) },
-            ),
-            status: m.isError ? ToolResultStatus.ERROR : ToolResultStatus.SUCCESS,
-          },
-        });
+        toolResults.push(createBedrockToolResult(m));
 
         // Look ahead for consecutive toolResult messages
         let j = i + 1;
@@ -921,17 +935,7 @@ function convertMessages(
           if (nextMsg?.role !== "toolResult") {
             break;
           }
-          toolResults.push({
-            toolResult: {
-              toolUseId: nextMsg.toolCallId,
-              content: nextMsg.content.map((c) =>
-                c.type === "image"
-                  ? { image: createImageBlock(c.mimeType, c.data) }
-                  : { text: sanitizeSurrogates(c.text) },
-              ),
-              status: nextMsg.isError ? ToolResultStatus.ERROR : ToolResultStatus.SUCCESS,
-            },
-          });
+          toolResults.push(createBedrockToolResult(nextMsg));
           j++;
         }
 

--- a/extensions/google/transport-stream.test.ts
+++ b/extensions/google/transport-stream.test.ts
@@ -2631,6 +2631,30 @@ describe("google transport stream", () => {
     });
   });
 
+  it("does not emit inline data or media placeholders for payload-less tool images", () => {
+    const params = buildGoogleGenerativeAiParams(
+      buildGeminiModel({ id: "gemini-3-flash", input: ["text", "image"] }),
+      {
+        messages: [
+          googleToolCallAssistantTurn(),
+          {
+            role: "toolResult",
+            toolCallId: "call_1",
+            toolName: "screenshot",
+            content: [{ type: "image", mimeType: "image/png", data: "" }],
+            isError: false,
+            timestamp: 1,
+          },
+        ],
+      } as never,
+    );
+
+    const serialized = JSON.stringify(params.contents);
+    expect(serialized).toContain('"output":""');
+    expect(serialized).not.toContain("inlineData");
+    expect(serialized).not.toContain("see attached image");
+  });
+
   it.each([
     ["bare Gemini 2.5 image first", "gemini-2.5-flash", ["screenshot", "weather"]],
     ["bare Gemini 2.5 image last", "gemini-2.5-flash", ["weather", "screenshot"]],

--- a/extensions/google/transport-stream.ts
+++ b/extensions/google/transport-stream.ts
@@ -658,7 +658,7 @@ function convertGoogleMessages(model: GoogleTransportModel, context: Context) {
       const imageContent = model.input.includes("image")
         ? msg.content.filter(
             (item): item is Extract<(typeof msg.content)[number], { type: "image" }> =>
-              item.type === "image",
+              item.type === "image" && describeToolResultMediaPlaceholder([item]) !== undefined,
           )
         : [];
       const mediaPlaceholder = describeToolResultMediaPlaceholder(msg.content);

--- a/packages/ai/src/providers/anthropic.test.ts
+++ b/packages/ai/src/providers/anthropic.test.ts
@@ -889,6 +889,60 @@ describe("Anthropic provider", () => {
     ]);
   });
 
+  it("does not emit Anthropic image blocks or placeholders for payload-less tool media", async () => {
+    let capturedPayload: unknown;
+    const stream = streamAnthropic(
+      makeAnthropicModel({ input: ["text", "image"] }),
+      {
+        messages: [
+          {
+            role: "assistant",
+            provider: "anthropic",
+            api: "anthropic-messages",
+            model: "claude-sonnet-4-6",
+            stopReason: "toolUse",
+            timestamp: 0,
+            usage: {
+              input: 0,
+              output: 0,
+              cacheRead: 0,
+              cacheWrite: 0,
+              totalTokens: 0,
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+            },
+            content: [{ type: "toolCall", id: "call_husk", name: "screenshot", arguments: {} }],
+          },
+          {
+            role: "toolResult",
+            toolCallId: "call_husk",
+            toolName: "screenshot",
+            content: [{ type: "image", data: "", mimeType: "image/png" }],
+            isError: false,
+            timestamp: 0,
+          },
+        ],
+      },
+      {
+        apiKey: "fixture",
+        onPayload: (payload) => {
+          capturedPayload = payload;
+          throw new Error("stop before network");
+        },
+      },
+    );
+
+    await stream.result();
+
+    const payload = capturedPayload as {
+      messages: Array<{ role: string; content: Array<Record<string, unknown>> }>;
+    };
+    const userMessage = payload.messages.find((message) => message.role === "user");
+    const toolResult = userMessage?.content.find((entry) => entry.type === "tool_result");
+    expect(toolResult?.content).toBe("");
+    expect(JSON.stringify(toolResult)).not.toContain('"source"');
+    expect(JSON.stringify(toolResult)).not.toContain("see attached image");
+  });
+
   it.each([
     ["empty", ""],
     ["whitespace-only", " \n\t "],

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -90,6 +90,7 @@ import {
   describeToolResultMediaPlaceholder,
   extractToolResultBlockText,
   extractToolResultText,
+  hasMediaPayload,
 } from "./tool-result-text.js";
 import { transformMessages } from "./transform-messages.js";
 
@@ -169,7 +170,10 @@ function convertContentBlocks(
     Array.isArray(content) &&
     content.some(
       (item) =>
-        item && typeof item === "object" && (item as Record<string, unknown>).type === "image",
+        item &&
+        typeof item === "object" &&
+        (item as Record<string, unknown>).type === "image" &&
+        hasMediaPayload(item),
     );
 
   if (!hasImages) {
@@ -202,7 +206,7 @@ function convertContentBlocks(
       blocks.push({ type: "text" as const, text: sanitizeSurrogates(blockText) });
       hasTextBlock = true;
     }
-    if (record.type !== "image") {
+    if (record.type !== "image" || !hasMediaPayload(record)) {
       continue;
     }
     blocks.push({
@@ -214,7 +218,7 @@ function convertContentBlocks(
           | "image/png"
           | "image/gif"
           | "image/webp",
-        data: typeof record.data === "string" ? record.data : "",
+        data: record.data,
       },
     });
   }

--- a/packages/ai/src/providers/google-shared.convert.test.ts
+++ b/packages/ai/src/providers/google-shared.convert.test.ts
@@ -402,4 +402,25 @@ describe("google-shared convertMessages", () => {
       '{"type":"json","payload":{"sessionKey":"current","status":"ok"}}',
     );
   });
+
+  it("does not emit inline data or media placeholders for payload-less tool images", () => {
+    const model = makeModel("gemini-3-flash");
+    const contents = convertMessagesForTest(model, {
+      messages: [
+        {
+          role: "toolResult",
+          toolCallId: "call_husk",
+          toolName: "screenshot",
+          content: [{ type: "image", mimeType: "image/png", data: "" }],
+          isError: false,
+          timestamp: 0,
+        },
+      ],
+    } as unknown as Context);
+
+    const serialized = JSON.stringify(contents);
+    expect(serialized).toContain('"output":""');
+    expect(serialized).not.toContain("inlineData");
+    expect(serialized).not.toContain("see attached image");
+  });
 });

--- a/packages/ai/src/providers/google-shared.ts
+++ b/packages/ai/src/providers/google-shared.ts
@@ -33,7 +33,11 @@ import type {
 import type { AssistantMessageEventStream } from "../utils/event-stream.js";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
 import { stripSystemPromptCacheBoundary } from "../utils/system-prompt-cache-boundary.js";
-import { describeToolResultMediaPlaceholder, extractToolResultText } from "./tool-result-text.js";
+import {
+  describeToolResultMediaPlaceholder,
+  extractToolResultText,
+  hasMediaPayload,
+} from "./tool-result-text.js";
 import { transformMessages } from "./transform-messages.js";
 
 type GoogleApiType = "google-generative-ai" | "google-vertex";
@@ -277,7 +281,7 @@ export function convertMessages<T extends GoogleApiType>(
       // Extract text and image content
       const textResult = extractToolResultText(msg.content);
       const imageContent = model.input.includes("image")
-        ? msg.content.filter((c): c is ImageContent => c.type === "image")
+        ? msg.content.filter((c): c is ImageContent => c.type === "image" && hasMediaPayload(c))
         : [];
 
       const hasText = textResult.length > 0;

--- a/packages/ai/src/providers/mistral.test.ts
+++ b/packages/ai/src/providers/mistral.test.ts
@@ -831,6 +831,43 @@ describe("Mistral provider", () => {
     expect(textBlock?.text).not.toContain('{\\"key\\":\\"value\\"}');
   });
 
+  it("does not emit image chunks or placeholders for payload-less tool media", async () => {
+    const testContext = {
+      messages: [
+        {
+          role: "assistant",
+          provider: "mistral",
+          api: "mistral-conversations",
+          model: "mistral-large-latest",
+          stopReason: "toolUse",
+          timestamp: 0,
+          content: [{ type: "toolCall", id: "tool_husk", name: "screenshot", arguments: {} }],
+        },
+        {
+          role: "toolResult",
+          toolCallId: "tool_husk",
+          toolName: "screenshot",
+          content: [{ type: "image", mimeType: "image/png", data: "" }],
+          isError: false,
+          timestamp: 0,
+        },
+      ],
+    } as unknown as Context;
+
+    const stream = streamMistral({ ...makeMistralModel(), input: ["text", "image"] }, testContext, {
+      apiKey: "fake",
+    });
+    await stream.result();
+
+    const payload = mistralMockState.payloads[0] as {
+      messages: Array<{ role: string; content: Array<{ type: string; text?: string }> }>;
+    };
+    const toolMessage = payload.messages.find((message) => message.role === "tool");
+    expect(toolMessage?.content).toEqual([{ type: "text", text: "(no tool output)" }]);
+    expect(JSON.stringify(toolMessage)).not.toContain("image_url");
+    expect(JSON.stringify(toolMessage)).not.toContain("see attached image");
+  });
+
   it("serializes structured-only tool results instead of empty fallback", async () => {
     const testContext = {
       messages: [

--- a/packages/ai/src/providers/mistral.ts
+++ b/packages/ai/src/providers/mistral.ts
@@ -33,7 +33,11 @@ import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
 import { createSseByteGuard } from "../utils/streaming-byte-guard.js";
 import { stripSystemPromptCacheBoundary } from "../utils/system-prompt-cache-boundary.js";
 import { buildBaseOptions } from "./simple-options.js";
-import { describeToolResultMediaPlaceholder, extractToolResultText } from "./tool-result-text.js";
+import {
+  describeToolResultMediaPlaceholder,
+  extractToolResultText,
+  hasMediaPayload,
+} from "./tool-result-text.js";
 import { transformMessages } from "./transform-messages.js";
 
 const MISTRAL_TOOL_CALL_ID_LENGTH = 9;
@@ -871,7 +875,7 @@ function toChatMessages(
     const toolContent: ContentChunk[] = [];
     const textResult = extractToolResultText(msg.content);
     const mediaPlaceholder = describeToolResultMediaPlaceholder(msg.content);
-    const hasImages = msg.content.some((part) => part.type === "image");
+    const hasImages = msg.content.some((part) => part.type === "image" && hasMediaPayload(part));
     const toolText = buildToolResultText(
       textResult,
       mediaPlaceholder,
@@ -884,7 +888,7 @@ function toChatMessages(
       if (!supportsImages) {
         continue;
       }
-      if (part.type !== "image") {
+      if (part.type !== "image" || !hasMediaPayload(part)) {
         continue;
       }
       toolContent.push({

--- a/packages/ai/src/providers/openai-completions.test.ts
+++ b/packages/ai/src/providers/openai-completions.test.ts
@@ -565,6 +565,62 @@ describe("OpenAI-compatible completions params", () => {
     });
   });
 
+  it("does not emit image turns or placeholders for payload-less tool media", async () => {
+    let capturedMessages:
+      | Array<{ role?: string; content?: unknown; tool_call_id?: string }>
+      | undefined;
+    const stream = streamOpenAICompletions(
+      { ...model, input: ["text", "image"] },
+      {
+        messages: [
+          {
+            role: "assistant",
+            api: model.api,
+            provider: model.provider,
+            model: model.id,
+            usage: {
+              input: 0,
+              output: 0,
+              cacheRead: 0,
+              cacheWrite: 0,
+              totalTokens: 0,
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+            },
+            stopReason: "toolUse",
+            content: [{ type: "toolCall", id: "call_husk", name: "screenshot", arguments: {} }],
+            timestamp: 1,
+          },
+          {
+            role: "toolResult",
+            toolCallId: "call_husk",
+            toolName: "screenshot",
+            content: [{ type: "image", mimeType: "image/png", data: "" }],
+            isError: false,
+            timestamp: 2,
+          },
+        ],
+      } as never,
+      {
+        apiKey: "sk-test",
+        onPayload(payload) {
+          capturedMessages = (payload as { messages?: typeof capturedMessages }).messages;
+          throw new Error("stop before network");
+        },
+      },
+    );
+
+    const result = await stream.result();
+
+    expect(result.stopReason).toBe("error");
+    expect(capturedMessages?.find((message) => message.role === "tool")).toMatchObject({
+      role: "tool",
+      content: "(no output)",
+      tool_call_id: "call_husk",
+    });
+    expect(JSON.stringify(capturedMessages)).not.toContain("image_url");
+    expect(JSON.stringify(capturedMessages)).not.toContain("see attached image");
+  });
+
   it("preserves image-bearing tool results with image placeholders and attachments", async () => {
     let capturedMessages:
       | Array<{ role?: string; content?: unknown; tool_call_id?: string }>

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -61,7 +61,11 @@ import {
   type OpenAIToolProjection,
 } from "./openai-tool-projection.js";
 import { buildBaseOptions } from "./simple-options.js";
-import { describeToolResultMediaPlaceholder, extractToolResultText } from "./tool-result-text.js";
+import {
+  describeToolResultMediaPlaceholder,
+  extractToolResultText,
+  hasMediaPayload,
+} from "./tool-result-text.js";
 import { transformMessages } from "./transform-messages.js";
 
 /**
@@ -98,7 +102,7 @@ function isToolCallBlock(block: { type: string }): block is ToolCall {
 }
 
 function isImageContentBlock(block: { type: string }): block is ImageContent {
-  return block.type === "image";
+  return block.type === "image" && hasMediaPayload(block);
 }
 
 const EMPTY_TOOL_RESULT_TEXT = "(no output)";
@@ -1210,7 +1214,7 @@ export function convertMessages(
         // Extract text and image content
         const textResult = extractToolResultText(toolMsg.content);
         const mediaPlaceholder = describeToolResultMediaPlaceholder(toolMsg.content);
-        const hasImages = toolMsg.content.some((c) => c.type === "image");
+        const hasImages = toolMsg.content.some(isImageContentBlock);
 
         // Always send tool result with text (or placeholder if only images)
         const content = sanitizeToolResultText(

--- a/packages/ai/src/providers/openai-responses-shared.test.ts
+++ b/packages/ai/src/providers/openai-responses-shared.test.ts
@@ -724,6 +724,32 @@ describe("convertResponsesMessages", () => {
     expect(functionOutput?.output).not.toBe("(no output)");
   });
 
+  it("does not emit image parts or placeholders for payload-less tool media", () => {
+    const input = convertResponsesMessages(
+      { ...nativeOpenAIModel, input: ["text", "image"] },
+      {
+        systemPrompt: "system",
+        messages: [
+          {
+            role: "toolResult",
+            toolCallId: "call_husk",
+            toolName: "screenshot",
+            content: [{ type: "image", mimeType: "image/png", data: "" }],
+            isError: false,
+            timestamp: 2,
+          },
+        ],
+      } as unknown as Context,
+      allowedToolCallProviders,
+      { includeSystemPrompt: false },
+    ) as unknown as Array<Record<string, unknown>>;
+
+    const functionOutput = input.find((item) => item.type === "function_call_output");
+    expect(functionOutput?.output).toBe("(no output)");
+    expect(JSON.stringify(functionOutput)).not.toContain("input_image");
+    expect(JSON.stringify(functionOutput)).not.toContain("see attached image");
+  });
+
   it("keeps encrypted reasoning replay item ids when requested", () => {
     const input = convertResponsesMessages(
       nativeOpenAIModel,

--- a/packages/ai/src/providers/openai-responses-shared.ts
+++ b/packages/ai/src/providers/openai-responses-shared.ts
@@ -58,7 +58,11 @@ import {
   resolveResponsesMessageSnapshotCollapse,
 } from "./openai-responses-stream-compat.js";
 import { convertResponsesToolPayload } from "./openai-responses-tools.js";
-import { describeToolResultMediaPlaceholder, extractToolResultText } from "./tool-result-text.js";
+import {
+  describeToolResultMediaPlaceholder,
+  extractToolResultText,
+  hasMediaPayload,
+} from "./tool-result-text.js";
 import { transformMessages } from "./transform-messages.js";
 
 // =============================================================================
@@ -441,7 +445,9 @@ export function convertResponsesMessages<TApi extends Api>(
     } else if (msg.role === "toolResult") {
       const textResult = extractToolResultText(msg.content);
       const sanitizedTextResult = sanitizeSurrogates(textResult);
-      const hasImages = msg.content.some((c): c is ImageContent => c.type === "image");
+      const hasImages = msg.content.some(
+        (c): c is ImageContent => c.type === "image" && hasMediaPayload(c),
+      );
       const mediaPlaceholder = describeToolResultMediaPlaceholder(msg.content);
       const hasText = sanitizedTextResult.trim().length > 0;
       const [callId] = splitResponsesToolCallId(msg.toolCallId);
@@ -463,7 +469,7 @@ export function convertResponsesMessages<TApi extends Api>(
         }
 
         for (const block of msg.content) {
-          if (block.type === "image") {
+          if (block.type === "image" && hasMediaPayload(block)) {
             contentParts.push({
               type: "input_image",
               detail: "auto",

--- a/packages/ai/src/providers/tool-result-text.test.ts
+++ b/packages/ai/src/providers/tool-result-text.test.ts
@@ -1,5 +1,20 @@
 import { describe, expect, it } from "vitest";
-import { describeToolResultMediaPlaceholder, extractToolResultText } from "./tool-result-text.js";
+import {
+  describeToolResultMediaPlaceholder,
+  extractToolResultText,
+  hasMediaPayload,
+} from "./tool-result-text.js";
+
+describe("hasMediaPayload", () => {
+  it("requires non-empty inline data instead of media metadata", () => {
+    expect(hasMediaPayload({ type: "image", data: "aW1n", mimeType: "image/png" })).toBe(true);
+    expect(hasMediaPayload({ type: "audio", data: "YXVkaW8=", mimeType: "audio/mpeg" })).toBe(true);
+    expect(hasMediaPayload({ type: "image", data: "", mimeType: "image/png" })).toBe(false);
+    expect(hasMediaPayload({ type: "image", data: "  ", mimeType: "image/png" })).toBe(false);
+    expect(hasMediaPayload({ type: "image", path: "/tmp/image.png" })).toBe(false);
+    expect(hasMediaPayload({ type: "image", url: "https://example.test/image.png" })).toBe(false);
+  });
+});
 
 describe("extractToolResultText", () => {
   it("keeps media-only blocks out of provider replay text", () => {
@@ -114,5 +129,23 @@ describe("describeToolResultMediaPlaceholder", () => {
         { type: "audio", mimeType: "audio/mpeg", data: "audio" },
       ]),
     ).toBe("(see attached media)");
+  });
+
+  it("does not advertise payload-less media husks", () => {
+    expect(
+      describeToolResultMediaPlaceholder([
+        { type: "image", mimeType: "image/png", data: "" },
+        { type: "image", path: "/tmp/image.png" },
+        { type: "audio", mimeType: "audio/mpeg" },
+      ]),
+    ).toBeUndefined();
+  });
+
+  it("does not treat text MIME metadata as attached media", () => {
+    expect(
+      describeToolResultMediaPlaceholder([
+        { type: "text", text: "actual tool output", mimeType: "image/svg+xml" },
+      ]),
+    ).toBeUndefined();
   });
 });

--- a/packages/ai/src/providers/tool-result-text.ts
+++ b/packages/ai/src/providers/tool-result-text.ts
@@ -121,15 +121,22 @@ function truncateProviderToolText(text: string): string {
   return `${truncateUtf16Safe(text, PROVIDER_TOOL_RESULT_MAX_CHARS)}\n…(truncated)…`;
 }
 
+/** Media metadata alone is not an attachment; provider emitters need inline bytes. */
+export function hasMediaPayload(
+  block: unknown,
+): block is Record<string, unknown> & { data: string } {
+  return isRecord(block) && typeof block.data === "string" && block.data.trim().length > 0;
+}
+
 export function describeToolResultMediaPlaceholder(blocks: readonly unknown[]): string | undefined {
   let hasImage = false;
   let hasAudio = false;
 
   for (const block of blocks) {
-    if (!block || typeof block !== "object") {
+    if (!hasMediaPayload(block)) {
       continue;
     }
-    const record = block as Record<string, unknown>;
+    const record = block;
     const type = typeof record.type === "string" ? record.type : undefined;
     const mimeType = readMimeType(record);
 

--- a/packages/ai/src/providers/transform-messages.ts
+++ b/packages/ai/src/providers/transform-messages.ts
@@ -10,6 +10,7 @@ import type {
   ToolResultMessage,
 } from "../types.js";
 import { resolveModelBoundThinkingReplayMode } from "./anthropic-model-contract.js";
+import { hasMediaPayload } from "./tool-result-text.js";
 
 const NON_VISION_USER_IMAGE_PLACEHOLDER = "(image omitted: model does not support images)";
 const NON_VISION_TOOL_IMAGE_PLACEHOLDER = "(tool image omitted: model does not support images)";
@@ -23,6 +24,9 @@ function replaceImagesWithPlaceholder(
 
   for (const block of content) {
     if (block.type === "image") {
+      if (!hasMediaPayload(block)) {
+        continue;
+      }
       if (!previousWasPlaceholder) {
         result.push({ type: "text", text: placeholder });
       }

--- a/src/agents/anthropic-transport-stream.test.ts
+++ b/src/agents/anthropic-transport-stream.test.ts
@@ -3212,6 +3212,45 @@ describe("anthropic transport stream", () => {
     expect(toolResult.is_error).toBe(false);
   });
 
+  it("replays payload-less tool images as no output without Anthropic image blocks", async () => {
+    await runTransportStream(
+      makeAnthropicTransportModel({ input: ["text", "image"] }),
+      {
+        messages: [
+          {
+            role: "assistant",
+            provider: "anthropic",
+            api: "anthropic-messages",
+            model: "claude-sonnet-4-6",
+            stopReason: "toolUse",
+            timestamp: 0,
+            content: [{ type: "toolCall", id: "tool_husk", name: "screenshot", arguments: {} }],
+          },
+          {
+            role: "toolResult",
+            toolCallId: "tool_husk",
+            toolName: "screenshot",
+            content: [{ type: "image", data: "", mimeType: "image/png" }],
+            isError: false,
+          },
+        ],
+      } as AnthropicStreamContext,
+      { apiKey: "fake" } as AnthropicStreamOptions,
+    );
+
+    const userMessage = findRecord(
+      latestAnthropicRequest().payload.messages,
+      (record) => record.role === "user",
+    );
+    const toolResult = findRecord(
+      userMessage.content,
+      (record) => record.type === "tool_result" && record.tool_use_id === "tool_husk",
+    );
+    expect(toolResult.content).toBe("(no output)");
+    expect(JSON.stringify(toolResult)).not.toContain('"source"');
+    expect(JSON.stringify(toolResult)).not.toContain("see attached image");
+  });
+
   it("drops empty text blocks from image tool results before Anthropic payloads", async () => {
     const imageData = Buffer.from("image").toString("base64");
 

--- a/src/agents/anthropic-transport-stream.ts
+++ b/src/agents/anthropic-transport-stream.ts
@@ -44,6 +44,7 @@ import {
   describeToolResultMediaPlaceholder,
   extractToolResultBlockText,
   extractToolResultText,
+  hasMediaPayload,
 } from "@openclaw/ai/internal/shared";
 /**
  * Native Anthropic Messages streaming transport.
@@ -346,7 +347,10 @@ function convertContentBlocks(content: readonly unknown[]) {
     Array.isArray(content) &&
     content.some(
       (item) =>
-        item && typeof item === "object" && (item as Record<string, unknown>).type === "image",
+        item &&
+        typeof item === "object" &&
+        (item as Record<string, unknown>).type === "image" &&
+        hasMediaPayload(item),
     );
   if (!hasImages) {
     return sanitizeNonEmptyTransportPayloadText(text, mediaPlaceholder ?? "(no output)");
@@ -369,7 +373,7 @@ function convertContentBlocks(content: readonly unknown[]) {
       blocks.push({ type: "text", text: sanitizeTransportPayloadText(blockText) });
       hasTextBlock = true;
     }
-    if (record.type !== "image") {
+    if (record.type !== "image" || !hasMediaPayload(record)) {
       continue;
     }
     blocks.push({
@@ -377,7 +381,7 @@ function convertContentBlocks(content: readonly unknown[]) {
       source: {
         type: "base64",
         media_type: typeof record.mimeType === "string" ? record.mimeType : "image/png",
-        data: typeof record.data === "string" ? record.data : "",
+        data: record.data,
       },
     });
   }

--- a/src/agents/openai-responses-transport.ts
+++ b/src/agents/openai-responses-transport.ts
@@ -29,6 +29,7 @@ import {
 import {
   describeToolResultMediaPlaceholder,
   extractToolResultText,
+  hasMediaPayload,
   stripSystemPromptCacheBoundary,
 } from "@openclaw/ai/internal/shared";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
@@ -46,7 +47,7 @@ import type {
   ResponseReasoningItem,
 } from "openai/resources/responses/responses.js";
 import { sha256HexPrefix } from "../infra/crypto-digest.js";
-import type { Api, Context, Model } from "../llm/types.js";
+import type { Api, Context, ImageContent, Model } from "../llm/types.js";
 import "../llm/ai-transport-host.js";
 import { createAssistantMessageEventStream } from "../llm/utils/event-stream.js";
 import { redactIdentifier } from "../logging/redact-identifier.js";
@@ -1131,7 +1132,7 @@ function convertResponsesMessages(
       const sanitizedTextResult = sanitizeTransportPayloadText(textResult);
       const hasText = sanitizedTextResult.trim().length > 0;
       const mediaPlaceholder = describeToolResultMediaPlaceholder(msg.content);
-      const hasImages = msg.content.some((item) => item.type === "image");
+      const hasImages = msg.content.some((item) => item.type === "image" && hasMediaPayload(item));
       const separatorIndex = msg.toolCallId.indexOf("|");
       const callId =
         separatorIndex === -1 ? msg.toolCallId : msg.toolCallId.slice(0, separatorIndex);
@@ -1147,7 +1148,9 @@ function convertResponsesMessages(
                     ? [{ type: "input_text", text: mediaPlaceholder }]
                     : []),
                 ...msg.content
-                  .filter((item) => item.type === "image")
+                  .filter(
+                    (item): item is ImageContent => item.type === "image" && hasMediaPayload(item),
+                  )
                   .map((item) => ({
                     type: "input_image",
                     detail: "auto",

--- a/src/agents/openai-transport-stream.replay-and-tools.test-utils.ts
+++ b/src/agents/openai-transport-stream.replay-and-tools.test-utils.ts
@@ -1012,6 +1012,55 @@ describe("openai transport stream", () => {
     });
   });
 
+  it("replays payload-less Responses tool images as no output without image parts", () => {
+    const params = buildOpenAIResponsesParams(
+      makeResponsesModel({
+        id: "gpt-5.5",
+        name: "GPT-5.5",
+        input: ["text", "image"],
+      }),
+      {
+        systemPrompt: "system",
+        messages: [
+          {
+            role: "assistant",
+            api: "openai-responses",
+            provider: "openai",
+            model: "gpt-5.5",
+            usage: {
+              input: 0,
+              output: 0,
+              cacheRead: 0,
+              cacheWrite: 0,
+              totalTokens: 0,
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+            },
+            stopReason: "toolUse",
+            timestamp: 1,
+            content: [{ type: "toolCall", id: "call_husk", name: "screenshot", arguments: {} }],
+          },
+          {
+            role: "toolResult",
+            toolCallId: "call_husk",
+            toolName: "screenshot",
+            content: [{ type: "image", mimeType: "image/png", data: "" }],
+            isError: false,
+            timestamp: 2,
+          },
+        ],
+        tools: [],
+      } as never,
+      { sessionId: "session-123" },
+    ) as {
+      input?: Array<{ type?: string; call_id?: string; output?: unknown }>;
+    };
+
+    const output = params.input?.find((item) => item.type === "function_call_output");
+    expect(output).toMatchObject({ call_id: "call_husk", output: "(no output)" });
+    expect(JSON.stringify(output)).not.toContain("input_image");
+    expect(JSON.stringify(output)).not.toContain("see attached image");
+  });
+
   it("preserves image-bearing Responses tool results as image input parts", () => {
     const params = buildOpenAIResponsesParams(
       makeResponsesModel({


### PR DESCRIPTION
Closes #104721

## What Problem This Solves

Fixes an issue where replaying tool results with image-shaped metadata but no inline image bytes could replace useful text with `(see attached image)` even though no attachment existed.

## Why This Change Was Made

Defines one canonical non-empty inline-payload invariant and applies it to placeholder detection and native media emission across Anthropic, OpenAI Responses, OpenAI Completions, Google, Mistral, Bedrock, and the native transport paths. Payload-less media husks now follow each provider's normal text or no-output behavior, while valid inline images remain unchanged.

The plugin paths reuse the existing provider-transport descriptor contract, avoiding a new public Plugin SDK surface. The Bedrock replay path is also consolidated so current and consecutive tool results use the same conversion logic.

## User Impact

Users keep real tool-result text instead of seeing a misleading attachment placeholder. URL-only, path-only, MIME-only, empty, and whitespace-only media metadata cannot produce provider image payloads; genuine inline image data still replays.

## Evidence

- Blacksmith Testbox focused behavior proof: 774 tests passed across package providers (211), native Anthropic/OpenAI transports (438), and Google/Bedrock plugins (125).
- Source-blind behavior contract passed payload-less husk, text preservation, empty-result, and valid-base64 control clauses.
- `pnpm check:changed` passed the full changed-surface format, API baseline, boundary, typecheck, lint, and database/runtime guards on the frozen base.
- Fresh structured autoreview after final fixes: clean, no accepted or actionable findings; confidence 0.91.
