### PR TITLE
fix(ci): bound OCM asset transfers

### DIFF
--- a/.github/workflows/openclaw-performance.yml
+++ b/.github/workflows/openclaw-performance.yml
@@ -273,7 +273,10 @@ jobs:
           mkdir -p "$HOME/.local/bin" "$(dirname "$KOVA_SRC")" "${RUNNER_TEMP}/ocm-install"
 
           ocm_archive="${RUNNER_TEMP}/ocm-${OCM_VERSION}-x86_64-unknown-linux-gnu.tar.gz"
+          # retry-max-time only gates new retries; cap an active transfer separately
+          # so a stalled release asset cannot consume the entire Kova job deadline.
           curl -fsSL --proto '=https' --tlsv1.2 \
+            --max-time 180 \
             --retry 8 --retry-max-time 180 --retry-all-errors --retry-connrefused \
             -o "$ocm_archive" \
             "https://github.com/shakkernerd/ocm/releases/download/${OCM_VERSION}/ocm-x86_64-unknown-linux-gnu.tar.gz"

--- a/test/scripts/openclaw-performance-workflow.test.ts
+++ b/test/scripts/openclaw-performance-workflow.test.ts
@@ -116,6 +116,10 @@ describe("OpenClaw performance workflow", () => {
     expect(installRun).toContain(
       '"https://github.com/shakkernerd/ocm/releases/download/${OCM_VERSION}/ocm-x86_64-unknown-linux-gnu.tar.gz"',
     );
+    expect(installRun).toContain("--max-time 180");
+    expect(installRun).toContain(
+      "--retry 8 --retry-max-time 180 --retry-all-errors --retry-connrefused",
+    );
     expect(installRun).toContain('echo "${OCM_LINUX_X64_SHA256}  ${ocm_archive}" | sha256sum -c -');
   });
 


### PR DESCRIPTION
## What Problem This Solves

The performance workflow downloads the OCM release archive with a retry window but no deadline for an active transfer. `--retry-max-time` controls whether curl starts another retry; it does not stop a response that connects and then stalls.

## Why This Change Was Made

Add a 180-second per-transfer `--max-time` alongside the existing 180-second retry window. Keep the existing HTTPS restrictions, retries, and SHA-256 verification. The workflow test now asserts both timeout layers.

## User Impact

A stalled OCM asset transfer can no longer consume the full performance job deadline. Healthy downloads and integrity verification are unchanged.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/openclaw-performance-workflow.test.ts --run` — 30 passed
- actionlint and zizmor checks passed
- Live OCM v0.2.25 asset: 2,691,064 bytes; SHA-256 matched the pinned workflow value
- Controlled stalled transfer: curl exited 28 after 1.01s with a scaled `--max-time`
- `pnpm exec oxfmt --check test/scripts/openclaw-performance-workflow.test.ts`
- `git diff --check`
- Fresh autoreview: clean, correctness confidence 0.93
