### PR TITLE
fix(cli): add 10s timeout to port-inspection subprocess calls

### DIFF
--- a/src/cli/ports.ts
+++ b/src/cli/ports.ts
@@ -105,6 +105,7 @@ function killPortWithFuser(port: number, signal: "SIGTERM" | "SIGKILL"): PortPro
     const stdout = execFileSync("fuser", args, {
       encoding: "utf-8",
       stdio: ["ignore", "pipe", "pipe"],
+      timeout: 10_000,
     });
     return parseFuserPidList(stdout).map((pid) => ({ pid }));
   } catch (err: unknown) {
@@ -175,6 +176,7 @@ function listPortListeners(port: number): PortProcess[] {
     try {
       const out = execFileSync(getWindowsSystem32ExePath("netstat.exe"), ["-ano"], {
         encoding: "utf-8",
+        timeout: 10_000,
       });
       const listeners = parseWindowsNetstatListeners(out, port);
       const seenPids = new Set<number>();
@@ -196,6 +198,7 @@ function listPortListeners(port: number): PortProcess[] {
     const lsof = resolveLsofCommandSync();
     const out = execFileSync(lsof, ["-nP", `-iTCP:${port}`, "-sTCP:LISTEN", "-FpFc"], {
       encoding: "utf-8",
+      timeout: 10_000,
     });
     return parseLsofOutput(out);
   } catch (err: unknown) {

--- a/src/cli/ports.ts
+++ b/src/cli/ports.ts
@@ -29,6 +29,9 @@ const FUSER_SIGNALS: Record<"SIGTERM" | "SIGKILL", string> = {
   SIGTERM: "TERM",
   SIGKILL: "KILL",
 };
+// Node waits for synchronous children to exit after a timeout signal.
+// SIGKILL keeps a tool from ignoring the startup deadline.
+const PORT_TOOL_TIMEOUT_MS = 10_000;
 
 function readExecOutput(value: string | Buffer | undefined): string {
   if (typeof value === "string") {
@@ -105,7 +108,8 @@ function killPortWithFuser(port: number, signal: "SIGTERM" | "SIGKILL"): PortPro
     const stdout = execFileSync("fuser", args, {
       encoding: "utf-8",
       stdio: ["ignore", "pipe", "pipe"],
-      timeout: 10_000,
+      timeout: PORT_TOOL_TIMEOUT_MS,
+      killSignal: "SIGKILL",
     });
     return parseFuserPidList(stdout).map((pid) => ({ pid }));
   } catch (err: unknown) {
@@ -176,7 +180,8 @@ function listPortListeners(port: number): PortProcess[] {
     try {
       const out = execFileSync(getWindowsSystem32ExePath("netstat.exe"), ["-ano"], {
         encoding: "utf-8",
-        timeout: 10_000,
+        timeout: PORT_TOOL_TIMEOUT_MS,
+        killSignal: "SIGKILL",
       });
       const listeners = parseWindowsNetstatListeners(out, port);
       const seenPids = new Set<number>();
@@ -198,7 +203,8 @@ function listPortListeners(port: number): PortProcess[] {
     const lsof = resolveLsofCommandSync();
     const out = execFileSync(lsof, ["-nP", `-iTCP:${port}`, "-sTCP:LISTEN", "-FpFc"], {
       encoding: "utf-8",
-      timeout: 10_000,
+      timeout: PORT_TOOL_TIMEOUT_MS,
+      killSignal: "SIGKILL",
     });
     return parseLsofOutput(out);
   } catch (err: unknown) {

--- a/src/cli/program.force.test.ts
+++ b/src/cli/program.force.test.ts
@@ -47,6 +47,11 @@ describe("gateway --force helpers", () => {
 
     const parsed = forceFreePort(18789);
 
+    expect(execFileSync).toHaveBeenCalledWith(
+      expect.stringContaining("lsof"),
+      ["-nP", "-iTCP:18789", "-sTCP:LISTEN", "-FpFc"],
+      { encoding: "utf-8", killSignal: "SIGKILL", timeout: 10_000 },
+    );
     expect(parsed).toEqual<PortProcess[]>([
       { pid: 123, command: "node" },
       { pid: 456, command: "python" },
@@ -307,7 +312,12 @@ describe("gateway --force helpers", () => {
       ([cmd, args]) => cmd === "fuser" && Array.isArray(args) && args.includes("-TERM"),
     );
     expect(termCall?.[1]).toEqual(["-k", "-TERM", "18789/tcp"]);
-    expect((termCall?.[2] as { encoding?: string } | undefined)?.encoding).toBe("utf-8");
+    expect(termCall?.[2]).toEqual({
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "pipe"],
+      killSignal: "SIGKILL",
+      timeout: 10_000,
+    });
   });
 
   it("uses fuser SIGKILL escalation when port stays busy", async () => {
@@ -416,6 +426,8 @@ describe("gateway --force helpers (Windows netstat path)", () => {
     expect(forceFreeWindowsPort(18789)).toEqual<PortProcess[]>([{ pid: 42 }, { pid: 99 }]);
     expect(execFileSync).toHaveBeenCalledWith(getWindowsSystem32ExePath("netstat.exe"), ["-ano"], {
       encoding: "utf-8",
+      killSignal: "SIGKILL",
+      timeout: 10_000,
     });
   });
 


### PR DESCRIPTION
## What Problem This Solves

`fuser`, `netstat`, and `lsof` can hang indefinitely on a busy or misbehaving system. During forced gateway startup, an unbounded subprocess blocks the CLI with no recovery path.

## What Changed

- Apply one 10-second deadline to all three system-tool paths.
- Use `SIGKILL` because Node's synchronous timeout waits for the child to exit after sending the configured signal; a child that ignores `SIGTERM` would remain unbounded.
- Cover the exact `lsof`, `fuser`, and Windows `netstat` options in the force-helper regression test.

## User Impact

Forced gateway startup now escapes an ordinary hung port-inspection or port-cleanup tool after ten seconds. Existing successful behavior and error handling remain unchanged.

## Evidence

- `node scripts/run-vitest.mjs src/cli/program.force.test.ts`: 26 tests passed.
- `node scripts/check-changed.mjs -- src/cli/ports.ts src/cli/program.force.test.ts`: hosted changed gates passed ([run](https://github.com/openclaw/openclaw/actions/runs/29493221637)).
- Native Node probe: a child that ignored `SIGTERM` timed out after 104 ms with `ETIMEDOUT` and `SIGKILL`.
- Autoreview: no accepted or actionable findings.

## Merge Risk

Low. The patch only bounds fixed-argv subprocess calls inside `src/cli/ports.ts`; callers already handle subprocess failures. An OS process stuck in uninterruptible sleep can outlive any kill request, which is a kernel limitation rather than a fallback this CLI can safely add.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
