### PR TITLE
feat: add Baseten Model API provider

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -411,6 +411,11 @@
       - any-glob-to-any-file:
           - "extensions/cerebras/**"
           - "docs/providers/cerebras.md"
+"extensions: baseten":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "extensions/baseten/**"
+          - "docs/providers/baseten.md"
 "extensions: clawrouter":
   - changed-files:
       - any-glob-to-any-file:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- **Baseten provider:** add an official external plugin with API-key onboarding, authenticated discovery for every Baseten Model API, Inkling as the default, and provider-owned reasoning, vision, tool-use, pricing, and context metadata.
 - **ClickClack guided setup:** configure ClickClack from `openclaw onboard` or `openclaw channels add clickclack` with URL, token, and workspace prompts, default-account env fallback, nonfatal live connection validation, and gateway-aware next steps that connect automatically when OpenClaw is already running. Thanks @shakkernerd.
 - **ClickClack command menus:** publish each bot's native OpenClaw commands to ClickClack composer autocomplete at gateway startup, with per-account opt-out and nonfatal compatibility handling for older tokens and servers. Thanks @shakkernerd.
 - **Skill Workshop approvals:** run agent-initiated apply, reject, and quarantine actions without an additional approval prompt by default while preserving `skills.workshop.approvalPolicy: "pending"` as an opt-in approval gate. Thanks @shakkernerd.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
-- **Baseten provider:** add an official external plugin with API-key onboarding, authenticated discovery for every Baseten Model API, Inkling as the default, and provider-owned reasoning, vision, tool-use, pricing, and context metadata.
 - **ClickClack guided setup:** configure ClickClack from `openclaw onboard` or `openclaw channels add clickclack` with URL, token, and workspace prompts, default-account env fallback, nonfatal live connection validation, and gateway-aware next steps that connect automatically when OpenClaw is already running. Thanks @shakkernerd.
 - **ClickClack command menus:** publish each bot's native OpenClaw commands to ClickClack composer autocomplete at gateway startup, with per-account opt-out and nonfatal compatibility handling for older tokens and servers. Thanks @shakkernerd.
 - **Skill Workshop approvals:** run agent-initiated apply, reject, and quarantine actions without an additional approval prompt by default while preserving `skills.workshop.approvalPolicy: "pending"` as an opt-in approval gate. Thanks @shakkernerd.

--- a/docs/.i18n/glossary.zh-CN.json
+++ b/docs/.i18n/glossary.zh-CN.json
@@ -1530,5 +1530,21 @@
   {
     "source": "Linux Canvas plugin",
     "target": "Linux Canvas plugin"
+  },
+  {
+    "source": "Baseten",
+    "target": "Baseten"
+  },
+  {
+    "source": "Baseten plugin",
+    "target": "Baseten 插件"
+  },
+  {
+    "source": "baseten",
+    "target": "baseten"
+  },
+  {
+    "source": "Baseten (Inkling + Model APIs)",
+    "target": "Baseten（Inkling + Model APIs）"
   }
 ]

--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -6103,6 +6103,15 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
   - H2: Surface
   - H2: Related docs
 
+## plugins/reference/baseten.md
+
+- Route: /plugins/reference/baseten
+- Headings:
+  - H1: Baseten plugin
+  - H2: Distribution
+  - H2: Surface
+  - H2: Related docs
+
 ## plugins/reference/bonjour.md
 
 - Route: /plugins/reference/bonjour
@@ -7661,6 +7670,17 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
   - H2: Getting started
   - H2: Configuration options
   - H2: Notes
+  - H2: Related
+
+## providers/baseten.md
+
+- Route: /providers/baseten
+- Headings:
+  - H2: Install plugin
+  - H2: Getting started
+  - H2: Inkling
+  - H2: Bundled fallback catalog
+  - H2: Manual config
   - H2: Related
 
 ## providers/bedrock-mantle.md

--- a/docs/plugins/plugin-inventory.md
+++ b/docs/plugins/plugin-inventory.md
@@ -191,7 +191,7 @@ Each entry lists the package, distribution route, and description.
 
 ## Official external packages
 
-71 plugins
+72 plugins
 
 - **[acpx](/plugins/reference/acpx)** (`@openclaw/acpx`) - npm; ClawHub. OpenClaw ACP runtime backend with plugin-owned session and transport management.
 
@@ -203,6 +203,8 @@ Each entry lists the package, distribution route, and description.
 
 - **[arcee](/plugins/reference/arcee)** (`@openclaw/arcee-provider`) - npm; ClawHub: `clawhub:@openclaw/arcee-provider`. Adds Arcee model provider support to OpenClaw.
 
+- **[baseten](/plugins/reference/baseten)** (`@openclaw/baseten-provider`) - npm; ClawHub: `clawhub:@openclaw/baseten-provider`. OpenClaw Baseten provider plugin.
+
 - **[brave](/plugins/reference/brave)** (`@openclaw/brave-plugin`) - npm; ClawHub. OpenClaw Brave Search provider plugin for web search.
 
 - **[cerebras](/plugins/reference/cerebras)** (`@openclaw/cerebras-provider`) - npm; ClawHub: `clawhub:@openclaw/cerebras-provider`. Adds Cerebras model provider support to OpenClaw.
@@ -213,7 +215,7 @@ Each entry lists the package, distribution route, and description.
 
 - **[cloudflare-ai-gateway](/plugins/reference/cloudflare-ai-gateway)** (`@openclaw/cloudflare-ai-gateway-provider`) - npm; ClawHub: `clawhub:@openclaw/cloudflare-ai-gateway-provider`. Adds Cloudflare AI Gateway model provider support to OpenClaw.
 
-- **[codex](/plugins/reference/codex)** (`@openclaw/codex`) - npm; ClawHub. Codex app-server harness, model provider, and native session catalog.
+- **[codex](/plugins/reference/codex)** (`@openclaw/codex`) - npm; ClawHub. Codex app-server harness and native session catalog.
 
 - **[copilot](/plugins/reference/copilot)** (`@openclaw/copilot`) - npm; ClawHub: `clawhub:@openclaw/copilot`. Registers the GitHub Copilot agent runtime.
 

--- a/docs/plugins/reference.md
+++ b/docs/plugins/reference.md
@@ -15,5 +15,5 @@ This page is generated from `extensions/*/package.json` and
 pnpm plugins:inventory:gen
 ```
 
-Use [Plugin inventory](/plugins/plugin-inventory) to browse all 140
+Use [Plugin inventory](/plugins/plugin-inventory) to browse all 141
 generated plugin reference pages by distribution, package, and description.

--- a/docs/plugins/reference/baseten.md
+++ b/docs/plugins/reference/baseten.md
@@ -1,0 +1,23 @@
+---
+summary: "OpenClaw Baseten provider plugin."
+read_when:
+  - You are installing, configuring, or auditing the baseten plugin
+title: "Baseten plugin"
+---
+
+# Baseten plugin
+
+OpenClaw Baseten provider plugin.
+
+## Distribution
+
+- Package: `@openclaw/baseten-provider`
+- Install route: npm; ClawHub: `clawhub:@openclaw/baseten-provider`
+
+## Surface
+
+providers: `baseten`
+
+## Related docs
+
+- [baseten](/providers/baseten)

--- a/docs/plugins/reference/codex.md
+++ b/docs/plugins/reference/codex.md
@@ -1,5 +1,5 @@
 ---
-summary: "Codex app-server harness, model provider, and native session catalog."
+summary: "Codex app-server harness and native session catalog."
 read_when:
   - You are installing, configuring, or auditing the codex plugin
 title: "Codex plugin"
@@ -7,7 +7,7 @@ title: "Codex plugin"
 
 # Codex plugin
 
-Codex app-server harness, model provider, and native session catalog.
+Codex app-server harness and native session catalog.
 
 ## Distribution
 
@@ -16,7 +16,7 @@ Codex app-server harness, model provider, and native session catalog.
 
 ## Surface
 
-providers: `codex`; contracts: `mediaUnderstandingProviders`, `migrationProviders`, `tools`, `webSearchProviders`
+contracts: `mediaUnderstandingProviders`, `migrationProviders`, `tools`, `webSearchProviders`
 
 ## Related docs
 

--- a/docs/plugins/reference/discord.md
+++ b/docs/plugins/reference/discord.md
@@ -16,7 +16,7 @@ OpenClaw Discord channel plugin for channels, DMs, commands, and app events.
 
 ## Surface
 
-channels: `discord`; contracts: `transcriptSourceProviders`; skills
+channels: `discord`; contracts: `tools`, `transcriptSourceProviders`; skills
 
 ## Related docs
 

--- a/docs/providers/baseten.md
+++ b/docs/providers/baseten.md
@@ -1,0 +1,176 @@
+---
+summary: "Baseten setup for Inkling and hosted Model APIs"
+title: "Baseten"
+read_when:
+  - You want to run Thinking Machines Lab's Inkling in OpenClaw
+  - You want one OpenAI-compatible API for Baseten's hosted models
+---
+
+[Baseten Model APIs](https://docs.baseten.co/inference/model-apis/overview) provide hosted, OpenAI-compatible access to frontier models. The official external plugin uses authenticated discovery, so OpenClaw follows the complete model set enabled for your Baseten account. Its offline fallback contains every Model API available when this OpenClaw release was built.
+
+| Property        | Value                                                    |
+| --------------- | -------------------------------------------------------- |
+| Provider id     | `baseten`                                                |
+| Plugin          | official external package (`@openclaw/baseten-provider`) |
+| Auth env var    | `BASETEN_API_KEY`                                        |
+| Onboarding flag | `--auth-choice baseten-api-key`                          |
+| Direct CLI flag | `--baseten-api-key <key>`                                |
+| API             | OpenAI-compatible (`openai-completions`)                 |
+| Base URL        | `https://inference.baseten.co/v1`                        |
+| Default model   | `baseten/thinkingmachines/inkling`                       |
+
+## Install plugin
+
+```bash
+openclaw plugins install @openclaw/baseten-provider
+openclaw gateway restart
+```
+
+## Getting started
+
+<Steps>
+  <Step title="Create a Baseten account and API key">
+    Baseten's Basic plan has no monthly platform fee; Model API calls are usage-priced. Create a key in [Baseten API key settings](https://app.baseten.co/settings/api_keys) and check current rates on the [pricing page](https://www.baseten.co/pricing).
+  </Step>
+  <Step title="Run onboarding">
+    <CodeGroup>
+
+```bash Onboarding
+openclaw onboard --auth-choice baseten-api-key
+```
+
+```bash Direct flag
+openclaw onboard --non-interactive \
+  --auth-choice baseten-api-key \
+  --baseten-api-key "$BASETEN_API_KEY"
+```
+
+```bash Env only
+export BASETEN_API_KEY=...
+```
+
+    </CodeGroup>
+
+  </Step>
+  <Step title="Verify the live catalog">
+    ```bash
+    openclaw models list --provider baseten
+    ```
+
+    With usable auth, the plugin requests `GET /v1/models` and lists every model returned for the account. Without auth, it stays offline and uses the bundled fallback.
+
+  </Step>
+</Steps>
+
+## Inkling
+
+[Thinking Machines Lab's Inkling](https://thinkingmachines.ai/news/introducing-inkling/) is the default model. In OpenClaw it supports text and image input, tool calling, structured tool schemas, configurable reasoning effort, a 1.048M-token context window, and up to 32k output tokens:
+
+```json5
+{
+  agents: {
+    defaults: {
+      model: { primary: "baseten/thinkingmachines/inkling" },
+    },
+  },
+}
+```
+
+Use `/model baseten/thinkingmachines/inkling` to switch an existing chat.
+
+## Bundled fallback catalog
+
+The authenticated live catalog is authoritative. These rows keep setup and model selection useful before discovery succeeds:
+
+| Model ref                                          | Input       | Context | Max output |
+| -------------------------------------------------- | ----------- | ------: | ---------: |
+| `baseten/deepseek-ai/DeepSeek-V4-Pro`              | text        |    262k |       262k |
+| `baseten/zai-org/GLM-4.7`                          | text        |    200k |       200k |
+| `baseten/zai-org/GLM-5`                            | text        |    202k |       202k |
+| `baseten/zai-org/GLM-5.1`                          | text        |    202k |       202k |
+| `baseten/zai-org/GLM-5.2`                          | text        |    202k |       202k |
+| `baseten/thinkingmachines/inkling`                 | text, image |  1.048M |        32k |
+| `baseten/moonshotai/Kimi-K2.5`                     | text, image |    262k |       262k |
+| `baseten/moonshotai/Kimi-K2.6`                     | text, image |    262k |       262k |
+| `baseten/moonshotai/Kimi-K2.7-Code`                | text, image |    262k |       262k |
+| `baseten/nvidia/Nemotron-120B-A12B`                | text        |    202k |       202k |
+| `baseten/nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B` | text        |    202k |       202k |
+| `baseten/openai/gpt-oss-120b`                      | text        |    128k |       128k |
+
+All bundled models support tool calling and reasoning. OpenClaw maps its thinking levels to models with native `reasoning_effort`; for GLM, Kimi, and Nemotron models it sends Baseten's `chat_template_args.enable_thinking` control.
+
+<Note>
+Baseten can add, remove, or change Model APIs independently of OpenClaw releases. The plugin refreshes model ids, context limits, output limits, and input, cached-input, and output pricing from the authenticated API while retaining model-specific OpenClaw transport policy.
+</Note>
+
+## Manual config
+
+Most setups only need the API key. To pin the provider explicitly:
+
+```json5
+{
+  env: { BASETEN_API_KEY: "..." },
+  agents: {
+    defaults: {
+      model: { primary: "baseten/thinkingmachines/inkling" },
+    },
+  },
+  models: {
+    mode: "merge",
+    providers: {
+      baseten: {
+        baseUrl: "https://inference.baseten.co/v1",
+        apiKey: "${BASETEN_API_KEY}",
+        api: "openai-completions",
+        models: [
+          {
+            id: "thinkingmachines/inkling",
+            name: "Inkling",
+            reasoning: true,
+            input: ["text", "image"],
+            contextWindow: 1048000,
+            maxTokens: 32000,
+            compat: {
+              supportsStore: false,
+              supportsDeveloperRole: false,
+              supportsUsageInStreaming: true,
+              supportsStrictMode: true,
+              supportsTools: true,
+              supportsReasoningEffort: true,
+              supportedReasoningEfforts: ["none", "minimal", "low", "medium", "high", "xhigh"],
+              reasoningEffortMap: {
+                off: "none",
+                none: "none",
+                adaptive: "xhigh",
+                max: "xhigh",
+              },
+              maxTokensField: "max_tokens",
+            },
+          },
+        ],
+      },
+    },
+  },
+}
+```
+
+<Note>
+If the Gateway runs as a daemon (launchd, systemd, Docker), make sure `BASETEN_API_KEY` is available to that process. A key exported only in an interactive shell is not visible to an already-running managed service.
+</Note>
+
+## Related
+
+<CardGroup cols={2}>
+  <Card title="Model providers" href="/concepts/model-providers" icon="layers">
+    Choosing providers, model refs, and failover behavior.
+  </Card>
+  <Card title="Thinking modes" href="/tools/thinking" icon="brain">
+    Select OpenClaw reasoning effort levels.
+  </Card>
+  <Card title="Models CLI" href="/cli/models" icon="terminal">
+    List, inspect, and select discovered models.
+  </Card>
+  <Card title="Models FAQ" href="/help/faq-models" icon="circle-question">
+    Auth profiles and model-selection troubleshooting.
+  </Card>
+</CardGroup>

--- a/docs/providers/baseten.md
+++ b/docs/providers/baseten.md
@@ -97,7 +97,7 @@ The authenticated live catalog is authoritative. These rows keep setup and model
 | `baseten/nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B` | text        |    202k |       202k |
 | `baseten/openai/gpt-oss-120b`                      | text        |    128k |       128k |
 
-All bundled models support tool calling and reasoning. OpenClaw maps its thinking levels to models with native `reasoning_effort`; for GLM, Kimi, and Nemotron models it sends Baseten's `chat_template_args.enable_thinking` control.
+All bundled models support tool calling and reasoning. OpenClaw maps its thinking levels to models with native `reasoning_effort`. Baseten's opt-in GLM, Kimi, and Nemotron models default to thinking off; most expose a binary off/on control, while GLM 5.2 exposes off, high, and max. OpenClaw sends these choices through Baseten's `chat_template_args.enable_thinking` control and, for GLM 5.2, the validated top-level `reasoning_effort` parameter.
 
 <Note>
 Baseten can add, remove, or change Model APIs independently of OpenClaw releases. The plugin refreshes model ids, context limits, output limits, and input, cached-input, and output pricing from the authenticated API while retaining model-specific OpenClaw transport policy.

--- a/docs/providers/index.md
+++ b/docs/providers/index.md
@@ -30,6 +30,7 @@ Looking for chat channel docs (WhatsApp/Telegram/Discord/Slack/Mattermost (plugi
 - [Anthropic (API + Claude CLI)](/providers/anthropic)
 - [Arcee AI (Trinity models)](/providers/arcee)
 - [Azure Speech](/providers/azure-speech)
+- [Baseten (Inkling + Model APIs)](/providers/baseten)
 - [BytePlus (International)](/concepts/model-providers#byteplus-international)
 - [Cerebras](/providers/cerebras)
 - [Chutes](/providers/chutes)

--- a/docs/providers/models.md
+++ b/docs/providers/models.md
@@ -24,6 +24,7 @@ Pick a provider, authenticate, then set the default model as `provider/model`.
 - [Alibaba Model Studio](/providers/alibaba)
 - [Amazon Bedrock](/providers/bedrock)
 - [Anthropic (API + Claude CLI)](/providers/anthropic)
+- [Baseten (Inkling + Model APIs)](/providers/baseten)
 - [BytePlus (International)](/concepts/model-providers#byteplus-international)
 - [Chutes](/providers/chutes)
 - [Cloudflare AI Gateway](/providers/cloudflare-ai-gateway)

--- a/extensions/baseten/README.md
+++ b/extensions/baseten/README.md
@@ -1,0 +1,12 @@
+# OpenClaw Baseten Provider
+
+Official OpenClaw provider plugin for Baseten Model APIs, including Thinking Machines Lab's Inkling.
+
+Install from OpenClaw:
+
+```bash
+openclaw plugins install @openclaw/baseten-provider
+openclaw gateway restart
+```
+
+See <https://docs.openclaw.ai/providers/baseten> for setup and configuration.

--- a/extensions/baseten/api.ts
+++ b/extensions/baseten/api.ts
@@ -1,0 +1,16 @@
+/** Public Baseten provider plugin API exports. */
+export {
+  BASETEN_BASE_URL,
+  BASETEN_DEFAULT_MODEL_ID,
+  BASETEN_DEFAULT_MODEL_REF,
+  BASETEN_MODEL_CATALOG,
+  buildBasetenModelCompat,
+  buildBasetenModelDefinition,
+  buildStaticBasetenModels,
+  discoverBasetenModels,
+  projectBasetenLiveModels,
+  resolveBasetenDynamicModel,
+  usesBasetenChatTemplateThinking,
+} from "./models.js";
+export { applyBasetenConfig } from "./onboard.js";
+export { buildBasetenProvider, buildStaticBasetenProvider } from "./provider-catalog.js";

--- a/extensions/baseten/baseten.live.test.ts
+++ b/extensions/baseten/baseten.live.test.ts
@@ -92,10 +92,11 @@ describeLive("Baseten plugin live", () => {
       const failures: string[] = [];
       for (const model of models) {
         try {
+          const thinkingLevel = model.id === "moonshotai/Kimi-K2.6" ? "low" : "off";
           const wrappedStream = provider.wrapStreamFn?.({
             provider: "baseten",
             modelId: model.id,
-            thinkingLevel: "off",
+            thinkingLevel,
             streamFn: streamSimple,
           } as never);
           if (!wrappedStream) {
@@ -137,7 +138,7 @@ describeLive("Baseten plugin live", () => {
           }
           if (usesBasetenChatTemplateThinking(model.id)) {
             expect(payload?.chat_template_args, model.id).toMatchObject({
-              enable_thinking: false,
+              enable_thinking: thinkingLevel !== "off",
             });
           }
           console.info(`[baseten:live] ${model.id}: ok`);

--- a/extensions/baseten/baseten.live.test.ts
+++ b/extensions/baseten/baseten.live.test.ts
@@ -1,0 +1,286 @@
+import {
+  streamSimple,
+  type AssistantMessage,
+  type Context,
+  type Model,
+  type Tool,
+} from "openclaw/plugin-sdk/llm";
+import { registerSingleProviderPlugin } from "openclaw/plugin-sdk/plugin-test-runtime";
+import type { ModelDefinitionConfig } from "openclaw/plugin-sdk/provider-model-shared";
+import { isLiveTestEnabled } from "openclaw/plugin-sdk/test-env";
+import { Type } from "typebox";
+import { describe, expect, it } from "vitest";
+import { runSingleProviderCatalog } from "../test-support/provider-model-test-helpers.js";
+import basetenPlugin from "./index.js";
+import {
+  BASETEN_BASE_URL,
+  BASETEN_DEFAULT_MODEL_ID,
+  BASETEN_MODEL_CATALOG,
+  usesBasetenChatTemplateThinking,
+} from "./models.js";
+
+const LIVE_VALUE = process.env.BASETEN_API_KEY?.trim() ?? "";
+const LIVE = isLiveTestEnabled(["BASETEN_LIVE_TEST"]) && LIVE_VALUE.length > 0;
+const describeLive = LIVE ? describe : describe.skip;
+
+function restoreEnvVar(name: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[name];
+  } else {
+    process.env[name] = value;
+  }
+}
+
+async function runLiveBasetenCatalog(provider: Parameters<typeof runSingleProviderCatalog>[0]) {
+  const oldNodeEnv = process.env.NODE_ENV;
+  const oldVitest = process.env.VITEST;
+  delete process.env.NODE_ENV;
+  delete process.env.VITEST;
+  try {
+    return await runSingleProviderCatalog(provider, {
+      resolveProviderAuth: () => ({
+        apiKey: LIVE_VALUE,
+        discoveryApiKey: LIVE_VALUE,
+        mode: "api_key",
+        source: "env",
+      }),
+    });
+  } finally {
+    restoreEnvVar("NODE_ENV", oldNodeEnv);
+    restoreEnvVar("VITEST", oldVitest);
+  }
+}
+
+function asLiveModel(model: ModelDefinitionConfig) {
+  return {
+    ...model,
+    provider: "baseten",
+    baseUrl: BASETEN_BASE_URL,
+    api: "openai-completions",
+  } as Model<"openai-completions">;
+}
+
+function liveProbeTool(): Tool {
+  return {
+    name: "live_probe",
+    description: "Return the supplied value.",
+    parameters: Type.Object({ value: Type.String() }, { additionalProperties: false }),
+  };
+}
+
+function requireToolCall(message: AssistantMessage) {
+  const toolCall = message.content.find((block) => block.type === "toolCall");
+  if (toolCall?.type !== "toolCall") {
+    throw new Error(`Inkling did not call the live probe: ${message.stopReason}`);
+  }
+  return toolCall;
+}
+
+describeLive("Baseten plugin live", () => {
+  it(
+    "discovers and completes through every Baseten Model API",
+    async () => {
+      const provider = await registerSingleProviderPlugin(basetenPlugin);
+      const catalog = await runLiveBasetenCatalog(provider);
+      const models = catalog.models;
+      const ids = new Set(models.map((model) => model.id));
+      for (const staticModel of BASETEN_MODEL_CATALOG) {
+        expect(ids.has(staticModel.id), `missing live model ${staticModel.id}`).toBe(true);
+      }
+
+      console.info(`[baseten:live] discovered ${models.length} models`);
+      const failures: string[] = [];
+      for (const model of models) {
+        try {
+          const wrappedStream = provider.wrapStreamFn?.({
+            provider: "baseten",
+            modelId: model.id,
+            thinkingLevel: "off",
+            streamFn: streamSimple,
+          } as never);
+          if (!wrappedStream) {
+            throw new Error("Baseten provider did not register a stream wrapper");
+          }
+          const context: Context = {
+            messages: [
+              {
+                role: "user",
+                content: "Say hello in one word.",
+                timestamp: Date.now(),
+              },
+            ],
+          };
+          let payload: Record<string, unknown> | undefined;
+          let stream = await wrappedStream(asLiveModel(model), context, {
+            apiKey: LIVE_VALUE,
+            maxTokens: 64,
+            reasoning: "off",
+            onPayload: (value) => {
+              payload = value as Record<string, unknown>;
+            },
+          });
+          let response = await stream.result();
+          if (response.stopReason === "length" && response.content.length === 0) {
+            console.info(`[baseten:live] ${model.id}: retrying with 512 output tokens`);
+            stream = await wrappedStream(asLiveModel(model), context, {
+              apiKey: LIVE_VALUE,
+              maxTokens: 512,
+              reasoning: "off",
+              onPayload: (value) => {
+                payload = value as Record<string, unknown>;
+              },
+            });
+            response = await stream.result();
+          }
+          if (response.stopReason === "error" || response.content.length === 0) {
+            throw new Error(response.errorMessage || `empty ${response.stopReason} response`);
+          }
+          if (usesBasetenChatTemplateThinking(model.id)) {
+            expect(payload?.chat_template_args, model.id).toMatchObject({
+              enable_thinking: false,
+            });
+          }
+          console.info(`[baseten:live] ${model.id}: ok`);
+        } catch (error) {
+          failures.push(`${model.id}: ${error instanceof Error ? error.message : String(error)}`);
+        }
+      }
+      expect(failures).toEqual([]);
+    },
+    20 * 60_000,
+  );
+
+  it("runs an Inkling tool call through OpenClaw's completions transport", async () => {
+    const provider = await registerSingleProviderPlugin(basetenPlugin);
+    const catalog = await runLiveBasetenCatalog(provider);
+    const inkling = catalog.models.find((model) => model.id === BASETEN_DEFAULT_MODEL_ID);
+    if (!inkling) {
+      throw new Error("Baseten live catalog did not include Inkling");
+    }
+
+    const wrappedStream = provider.wrapStreamFn?.({
+      provider: "baseten",
+      modelId: inkling.id,
+      thinkingLevel: "low",
+      streamFn: streamSimple,
+    } as never);
+    if (!wrappedStream) {
+      throw new Error("Baseten provider did not register a stream wrapper");
+    }
+    let payload: Record<string, unknown> | undefined;
+    const stream = await wrappedStream(
+      asLiveModel(inkling),
+      {
+        systemPrompt: "Call the requested function exactly once.",
+        messages: [
+          {
+            role: "user",
+            content: "Call live_probe with value exactly inkling.",
+            timestamp: Date.now(),
+          },
+        ],
+        tools: [liveProbeTool()],
+      },
+      {
+        apiKey: LIVE_VALUE,
+        maxTokens: 256,
+        reasoning: "low",
+        onPayload: (value) => {
+          payload = {
+            ...(value as Record<string, unknown>),
+            tool_choice: { type: "function", function: { name: "live_probe" } },
+          };
+          return payload;
+        },
+      },
+    );
+    const response = await stream.result();
+    if (response.stopReason === "error") {
+      throw new Error(response.errorMessage || "Inkling live tool call failed");
+    }
+    expect(payload?.reasoning_effort).toBe("low");
+    const toolCall = requireToolCall(response);
+    expect(toolCall).toMatchObject({ name: "live_probe", arguments: { value: "inkling" } });
+  }, 120_000);
+
+  it("accepts a DeepSeek V4 replay after a cross-provider tool call", async () => {
+    const provider = await registerSingleProviderPlugin(basetenPlugin);
+    const catalog = await runLiveBasetenCatalog(provider);
+    const deepseek = catalog.models.find((model) => model.id === "deepseek-ai/DeepSeek-V4-Pro");
+    if (!deepseek) {
+      throw new Error("Baseten live catalog did not include DeepSeek V4 Pro");
+    }
+
+    const toolCallId = "call_baseten_live_replay_1";
+    const wrappedStream = provider.wrapStreamFn?.({
+      provider: "baseten",
+      modelId: deepseek.id,
+      thinkingLevel: "high",
+      streamFn: streamSimple,
+    } as never);
+    if (!wrappedStream) {
+      throw new Error("Baseten provider did not register a stream wrapper");
+    }
+
+    let payload: Record<string, unknown> | undefined;
+    const stream = await wrappedStream(
+      asLiveModel(deepseek),
+      {
+        messages: [
+          { role: "user", content: "Call live_probe.", timestamp: Date.now() - 3 },
+          {
+            role: "assistant",
+            api: "openai-completions",
+            provider: "openai",
+            model: "gpt-5.5",
+            content: [
+              {
+                type: "toolCall",
+                id: toolCallId,
+                name: "live_probe",
+                arguments: { value: "replay" },
+              },
+            ],
+            usage: {
+              input: 0,
+              output: 0,
+              cacheRead: 0,
+              cacheWrite: 0,
+              totalTokens: 0,
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+            },
+            stopReason: "toolUse",
+            timestamp: Date.now() - 2,
+          } as AssistantMessage,
+          {
+            role: "toolResult",
+            toolCallId,
+            toolName: "live_probe",
+            content: [{ type: "text", text: "ok" }],
+            isError: false,
+            timestamp: Date.now() - 1,
+          },
+          { role: "user", content: "Reply with exactly ok.", timestamp: Date.now() },
+        ],
+        tools: [liveProbeTool()],
+      },
+      {
+        apiKey: LIVE_VALUE,
+        maxTokens: 512,
+        reasoning: "high",
+        onPayload: (value) => {
+          payload = value as Record<string, unknown>;
+        },
+      },
+    );
+    const response = await stream.result();
+    if (response.stopReason === "error") {
+      throw new Error(response.errorMessage || "DeepSeek V4 live replay failed");
+    }
+
+    const messages = payload?.messages;
+    expect(Array.isArray(messages)).toBe(true);
+    expect((messages as Array<Record<string, unknown>>)[1]?.reasoning_content).toBe("");
+    expect(response.content.length).toBeGreaterThan(0);
+  }, 120_000);
+});

--- a/extensions/baseten/index.test.ts
+++ b/extensions/baseten/index.test.ts
@@ -61,7 +61,7 @@ function captureThinkingPayload(modelId: string, thinkingLevel: "off" | "high" |
   return captured;
 }
 
-function captureDeepSeekReplayPayload(thinkingLevel: "off" | "high") {
+function captureDeepSeekReplayPayload(thinkingLevel: "off" | "high" | undefined) {
   let captured: Record<string, unknown> | undefined;
   const streamFn: NonNullable<ProviderWrapStreamFnContext["streamFn"]> = (
     model,
@@ -69,7 +69,9 @@ function captureDeepSeekReplayPayload(thinkingLevel: "off" | "high") {
     options,
   ) => {
     const payload: Record<string, unknown> = {
-      reasoning_effort: thinkingLevel === "off" ? "none" : "high",
+      ...(thinkingLevel === undefined
+        ? {}
+        : { reasoning_effort: thinkingLevel === "off" ? "none" : "high" }),
       messages: [
         {
           role: "assistant",
@@ -201,6 +203,23 @@ describe("Baseten provider registration", () => {
   });
 
   it("normalizes DeepSeek V4 replay while preserving Baseten reasoning effort", () => {
+    expect(captureDeepSeekReplayPayload(undefined)).toEqual({
+      messages: [
+        {
+          role: "assistant",
+          tool_calls: [
+            {
+              id: "call_1",
+              type: "function",
+              function: { name: "read", arguments: "{}" },
+            },
+          ],
+          reasoning_content: "",
+        },
+        { role: "assistant", content: "done", reasoning_content: "preserve me" },
+        { role: "tool", tool_call_id: "call_1", content: "ok" },
+      ],
+    });
     expect(captureDeepSeekReplayPayload("high")).toEqual({
       reasoning_effort: "high",
       messages: [

--- a/extensions/baseten/index.test.ts
+++ b/extensions/baseten/index.test.ts
@@ -31,7 +31,7 @@ function basetenModel(id: string): OpenAICompletionsModel {
   };
 }
 
-function captureThinkingPayload(modelId: string, thinkingLevel: "off" | "high") {
+function captureThinkingPayload(modelId: string, thinkingLevel: "off" | "high" | undefined) {
   let captured: Record<string, unknown> | undefined;
   const streamFn: NonNullable<ProviderWrapStreamFnContext["streamFn"]> = (
     model,
@@ -127,6 +127,7 @@ describe("Baseten provider registration", () => {
       docsPath: "/providers/baseten",
       envVars: ["BASETEN_API_KEY"],
       resolveDynamicModel: expect.any(Function),
+      resolveThinkingProfile: expect.any(Function),
       wrapStreamFn: expect.any(Function),
     });
     expect(choice?.provider.id).toBe("baseten");
@@ -156,6 +157,41 @@ describe("Baseten provider registration", () => {
     expect(captureThinkingPayload("moonshotai/Kimi-K2.6", "off")).toMatchObject({
       chat_template_args: { preserve_me: true, enable_thinking: false },
     });
+    expect(captureThinkingPayload("NVIDIA/Nemotron-120B-A12B", undefined)).toMatchObject({
+      chat_template_args: { preserve_me: true, enable_thinking: false },
+    });
+  });
+
+  it("exposes opt-in thinking without duplicate reasoning levels", async () => {
+    const provider = await registerSingleProviderPlugin(basetenPlugin);
+
+    expect(
+      provider.resolveThinkingProfile?.({
+        provider: "baseten",
+        modelId: "moonshotai/Kimi-K2.6",
+        reasoning: true,
+      } as never),
+    ).toEqual({
+      levels: [{ id: "off" }, { id: "low", label: "on" }],
+      defaultLevel: "off",
+    });
+    expect(
+      provider.resolveThinkingProfile?.({
+        provider: "baseten",
+        modelId: "zai-org/GLM-5.2",
+        reasoning: true,
+      } as never),
+    ).toEqual({
+      levels: [{ id: "off" }, { id: "high" }, { id: "max" }],
+      defaultLevel: "off",
+    });
+    expect(
+      provider.resolveThinkingProfile?.({
+        provider: "baseten",
+        modelId: "thinkingmachines/inkling",
+        reasoning: true,
+      } as never),
+    ).toBeUndefined();
   });
 
   it("leaves default-thinking models untouched", () => {

--- a/extensions/baseten/index.test.ts
+++ b/extensions/baseten/index.test.ts
@@ -1,4 +1,4 @@
-import type { Context, Model } from "openclaw/plugin-sdk/llm";
+import type { Model } from "openclaw/plugin-sdk/llm";
 import { createAssistantMessageEventStream } from "openclaw/plugin-sdk/llm";
 import type { ProviderWrapStreamFnContext } from "openclaw/plugin-sdk/plugin-entry";
 import {

--- a/extensions/baseten/index.test.ts
+++ b/extensions/baseten/index.test.ts
@@ -1,0 +1,233 @@
+import type { Context, Model } from "openclaw/plugin-sdk/llm";
+import { createAssistantMessageEventStream } from "openclaw/plugin-sdk/llm";
+import type { ProviderWrapStreamFnContext } from "openclaw/plugin-sdk/plugin-entry";
+import {
+  registerSingleProviderPlugin,
+  resolveProviderPluginChoice,
+} from "openclaw/plugin-sdk/plugin-test-runtime";
+import { resolveAgentModelPrimaryValue } from "openclaw/plugin-sdk/provider-onboard";
+import { buildOpenAICompletionsParams } from "openclaw/plugin-sdk/provider-transport-runtime";
+import { describe, expect, it } from "vitest";
+import { runSingleProviderCatalog } from "../test-support/provider-model-test-helpers.js";
+import basetenPlugin from "./index.js";
+import { applyBasetenConfig } from "./onboard.js";
+import { createBasetenThinkingWrapper } from "./stream.js";
+
+type OpenAICompletionsModel = Model<"openai-completions">;
+const TEST_VALUE = "resolved-marker";
+
+function basetenModel(id: string): OpenAICompletionsModel {
+  return {
+    id,
+    name: id,
+    provider: "baseten",
+    api: "openai-completions",
+    baseUrl: "https://inference.baseten.co/v1",
+    reasoning: true,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 202_000,
+    maxTokens: 202_000,
+  };
+}
+
+function captureThinkingPayload(modelId: string, thinkingLevel: "off" | "high") {
+  let captured: Record<string, unknown> | undefined;
+  const streamFn: NonNullable<ProviderWrapStreamFnContext["streamFn"]> = (
+    model,
+    _context,
+    options,
+  ) => {
+    const payload: Record<string, unknown> = {
+      chat_template_args: { preserve_me: true },
+    };
+    options?.onPayload?.(payload, model);
+    captured = payload;
+    const stream = createAssistantMessageEventStream();
+    queueMicrotask(() => stream.end());
+    return stream;
+  };
+  const wrapperContext: ProviderWrapStreamFnContext = {
+    provider: "baseten",
+    modelId,
+    thinkingLevel,
+    streamFn,
+  };
+  const wrapped = createBasetenThinkingWrapper(wrapperContext);
+  if (!wrapped) {
+    throw new Error("Baseten thinking wrapper missing");
+  }
+  void wrapped(basetenModel(modelId), { messages: [] }, {});
+  return captured;
+}
+
+function captureDeepSeekReplayPayload(thinkingLevel: "off" | "high") {
+  let captured: Record<string, unknown> | undefined;
+  const streamFn: NonNullable<ProviderWrapStreamFnContext["streamFn"]> = (
+    model,
+    _context,
+    options,
+  ) => {
+    const payload: Record<string, unknown> = {
+      reasoning_effort: thinkingLevel === "off" ? "none" : "high",
+      messages: [
+        {
+          role: "assistant",
+          tool_calls: [
+            {
+              id: "call_1",
+              type: "function",
+              function: { name: "read", arguments: "{}" },
+            },
+          ],
+        },
+        { role: "assistant", content: "done", reasoning_content: "preserve me" },
+        { role: "tool", tool_call_id: "call_1", content: "ok" },
+      ],
+    };
+    options?.onPayload?.(payload, model);
+    captured = payload;
+    const stream = createAssistantMessageEventStream();
+    queueMicrotask(() => stream.end());
+    return stream;
+  };
+  const modelId = "deepseek-ai/DeepSeek-V4-Pro";
+  const wrapped = createBasetenThinkingWrapper({
+    provider: "baseten",
+    modelId,
+    thinkingLevel,
+    streamFn,
+  });
+  if (!wrapped) {
+    throw new Error("Baseten thinking wrapper missing");
+  }
+  void wrapped(basetenModel(modelId), { messages: [] }, {});
+  return captured;
+}
+
+describe("Baseten provider registration", () => {
+  it("registers authenticated live and network-free static catalogs", async () => {
+    const provider = await registerSingleProviderPlugin(basetenPlugin);
+    const choice = resolveProviderPluginChoice({
+      providers: [provider],
+      choice: "baseten-api-key",
+    });
+    const catalog = await runSingleProviderCatalog(provider, {
+      resolveProviderAuth: () => ({
+        apiKey: TEST_VALUE,
+        discoveryApiKey: undefined,
+        mode: "api_key",
+        source: "env",
+      }),
+    });
+
+    expect(provider).toMatchObject({
+      id: "baseten",
+      label: "Baseten",
+      docsPath: "/providers/baseten",
+      envVars: ["BASETEN_API_KEY"],
+      resolveDynamicModel: expect.any(Function),
+      wrapStreamFn: expect.any(Function),
+    });
+    expect(choice?.provider.id).toBe("baseten");
+    expect(choice?.method.id).toBe("api-key");
+    expect(resolveAgentModelPrimaryValue(applyBasetenConfig({}).agents?.defaults?.model)).toBe(
+      "baseten/thinkingmachines/inkling",
+    );
+    expect(catalog).toMatchObject({
+      apiKey: TEST_VALUE,
+      baseUrl: "https://inference.baseten.co/v1",
+      api: "openai-completions",
+    });
+    expect(catalog.models).toHaveLength(12);
+    expect(provider.staticCatalog).toBeDefined();
+    expect(
+      provider.buildReplayPolicy?.({
+        modelApi: "openai-completions",
+        modelId: "deepseek-ai/DeepSeek-V4-Pro",
+      } as never)?.dropReasoningFromHistory,
+    ).not.toBe(true);
+  });
+
+  it("sets and clears chat-template thinking while preserving caller arguments", () => {
+    expect(captureThinkingPayload("zai-org/GLM-5", "high")).toMatchObject({
+      chat_template_args: { preserve_me: true, enable_thinking: true },
+    });
+    expect(captureThinkingPayload("moonshotai/Kimi-K2.6", "off")).toMatchObject({
+      chat_template_args: { preserve_me: true, enable_thinking: false },
+    });
+  });
+
+  it("leaves default-thinking models untouched", () => {
+    expect(captureThinkingPayload("thinkingmachines/inkling", "high")).toEqual({
+      chat_template_args: { preserve_me: true },
+    });
+  });
+
+  it("normalizes DeepSeek V4 replay while preserving Baseten reasoning effort", () => {
+    expect(captureDeepSeekReplayPayload("high")).toEqual({
+      reasoning_effort: "high",
+      messages: [
+        {
+          role: "assistant",
+          tool_calls: [
+            {
+              id: "call_1",
+              type: "function",
+              function: { name: "read", arguments: "{}" },
+            },
+          ],
+          reasoning_content: "",
+        },
+        { role: "assistant", content: "done", reasoning_content: "preserve me" },
+        { role: "tool", tool_call_id: "call_1", content: "ok" },
+      ],
+    });
+    expect(captureDeepSeekReplayPayload("off")).toEqual({
+      reasoning_effort: "none",
+      messages: [
+        {
+          role: "assistant",
+          tool_calls: [
+            {
+              id: "call_1",
+              type: "function",
+              function: { name: "read", arguments: "{}" },
+            },
+          ],
+        },
+        { role: "assistant", content: "done" },
+        { role: "tool", tool_call_id: "call_1", content: "ok" },
+      ],
+    });
+  });
+
+  it("uses Baseten's supported system role instead of developer", () => {
+    const model = {
+      ...basetenModel("thinkingmachines/inkling"),
+      compat: { supportsDeveloperRole: false, maxTokensField: "max_tokens" as const },
+    };
+    const payload = buildOpenAICompletionsParams(
+      model,
+      {
+        systemPrompt: "You are a helpful assistant.",
+        messages: [{ role: "user", content: "hello", timestamp: 1 }],
+      },
+      { reasoning: "high", maxTokens: 32 },
+    );
+
+    const messages = payload.messages;
+    expect(Array.isArray(messages)).toBe(true);
+    if (!Array.isArray(messages)) {
+      throw new Error("expected messages payload");
+    }
+    expect(messages[0]).toMatchObject({
+      role: "system",
+      content: "You are a helpful assistant.",
+    });
+    expect(messages).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ role: "developer" })]),
+    );
+    expect(payload.max_tokens).toBe(32);
+  });
+});

--- a/extensions/baseten/index.ts
+++ b/extensions/baseten/index.ts
@@ -6,6 +6,7 @@ import { BASETEN_DEFAULT_MODEL_REF, resolveBasetenDynamicModel } from "./models.
 import { applyBasetenConfig } from "./onboard.js";
 import { buildBasetenProvider, buildStaticBasetenProvider } from "./provider-catalog.js";
 import { createBasetenThinkingWrapper } from "./stream.js";
+import { resolveBasetenThinkingProfile } from "./thinking.js";
 
 const PROVIDER_ID = "baseten";
 
@@ -60,6 +61,7 @@ export default defineSingleProviderPluginEntry({
       dropReasoningFromHistory: false,
     }),
     wrapStreamFn: (ctx) => createBasetenThinkingWrapper(ctx),
+    resolveThinkingProfile: ({ modelId }) => resolveBasetenThinkingProfile(modelId),
     isModernModelRef: () => true,
   },
 });

--- a/extensions/baseten/index.ts
+++ b/extensions/baseten/index.ts
@@ -1,0 +1,65 @@
+/** Baseten provider plugin entrypoint. */
+import type { ProviderCatalogContext } from "openclaw/plugin-sdk/provider-catalog-shared";
+import { defineSingleProviderPluginEntry } from "openclaw/plugin-sdk/provider-entry";
+import { buildProviderReplayFamilyHooks } from "openclaw/plugin-sdk/provider-model-shared";
+import { BASETEN_DEFAULT_MODEL_REF, resolveBasetenDynamicModel } from "./models.js";
+import { applyBasetenConfig } from "./onboard.js";
+import { buildBasetenProvider, buildStaticBasetenProvider } from "./provider-catalog.js";
+import { createBasetenThinkingWrapper } from "./stream.js";
+
+const PROVIDER_ID = "baseten";
+
+export default defineSingleProviderPluginEntry({
+  id: PROVIDER_ID,
+  name: "Baseten Provider",
+  description: "Official Baseten Model APIs provider plugin",
+  provider: {
+    label: "Baseten",
+    docsPath: "/providers/baseten",
+    auth: [
+      {
+        methodId: "api-key",
+        label: "Baseten API key",
+        hint: "Hosted Model APIs, including Inkling",
+        optionKey: "basetenApiKey",
+        flagName: "--baseten-api-key",
+        envVar: "BASETEN_API_KEY",
+        promptMessage: "Enter Baseten API key",
+        defaultModel: BASETEN_DEFAULT_MODEL_REF,
+        applyConfig: (cfg) => applyBasetenConfig(cfg),
+        noteTitle: "Baseten",
+        noteMessage: [
+          "Baseten hosts Thinking Machines Lab's Inkling and other frontier models behind one OpenAI-compatible API.",
+          "Get your API key at: https://app.baseten.co/settings/api_keys",
+        ].join("\n"),
+        wizard: {
+          groupLabel: "Baseten",
+          groupHint: "Hosted Model APIs, including Inkling",
+        },
+      },
+    ],
+    catalog: {
+      order: "simple",
+      run: async (ctx: ProviderCatalogContext) => {
+        const { apiKey, discoveryApiKey } = ctx.resolveProviderAuth(PROVIDER_ID);
+        if (!apiKey) {
+          return null;
+        }
+        return {
+          provider: {
+            ...(await buildBasetenProvider(discoveryApiKey)),
+            apiKey,
+          },
+        };
+      },
+      staticRun: async () => ({ provider: buildStaticBasetenProvider() }),
+    },
+    resolveDynamicModel: ({ modelId }) => resolveBasetenDynamicModel(modelId),
+    ...buildProviderReplayFamilyHooks({
+      family: "openai-compatible",
+      dropReasoningFromHistory: false,
+    }),
+    wrapStreamFn: (ctx) => createBasetenThinkingWrapper(ctx),
+    isModernModelRef: () => true,
+  },
+});

--- a/extensions/baseten/models.test.ts
+++ b/extensions/baseten/models.test.ts
@@ -1,0 +1,194 @@
+import {
+  clearLiveCatalogCacheForTests,
+  type LiveModelCatalogFetchGuard,
+} from "openclaw/plugin-sdk/provider-catalog-live-runtime";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  BASETEN_DEFAULT_MODEL_REF,
+  BASETEN_MODEL_CATALOG,
+  buildStaticBasetenModels,
+  discoverBasetenModels,
+  projectBasetenLiveModels,
+  resolveBasetenDynamicModel,
+} from "./models.js";
+
+const TEST_VALUE = "fixture";
+
+describe("Baseten model catalog", () => {
+  beforeEach(() => {
+    clearLiveCatalogCacheForTests();
+  });
+
+  it("ships every current Baseten Model API with Inkling as the default", () => {
+    const models = buildStaticBasetenModels();
+
+    expect(BASETEN_DEFAULT_MODEL_REF).toBe("baseten/thinkingmachines/inkling");
+    expect(models).toHaveLength(12);
+    expect(models.map((model) => model.id)).toEqual(BASETEN_MODEL_CATALOG.map((model) => model.id));
+    expect(models.find((model) => model.id === "thinkingmachines/inkling")).toMatchObject({
+      reasoning: true,
+      input: ["text", "image"],
+      contextWindow: 1_048_000,
+      maxTokens: 32_000,
+      cost: { input: 1, output: 4.05, cacheRead: 0.17, cacheWrite: 0 },
+      compat: {
+        supportsStore: false,
+        supportsDeveloperRole: false,
+        supportsUsageInStreaming: true,
+        supportsStrictMode: true,
+        supportsTools: true,
+        supportsReasoningEffort: true,
+        supportedReasoningEfforts: ["none", "minimal", "low", "medium", "high", "xhigh"],
+        maxTokensField: "max_tokens",
+      },
+    });
+  });
+
+  it("projects authenticated live rows while retaining curated capability metadata", () => {
+    const models = projectBasetenLiveModels([
+      {
+        id: "thinkingmachines/inkling",
+        object: "model",
+        name: "Inkling live",
+        context_length: 1_048_576,
+        max_completion_tokens: 32_768,
+        pricing: {
+          prompt: "0.0000011",
+          completion: "0.0000042",
+          input_cache_read: "0.00000018",
+        },
+        supported_features: ["vision", "reasoning", "reasoning_effort"],
+      },
+      {
+        id: "future/model",
+        object: "model",
+        context_length: 64_000,
+        max_completion_tokens: 4_000,
+        pricing: { prompt: 0.0000002, completion: 0.0000008, input_cache_read: 0.00000004 },
+        supported_features: ["vision", "reasoning_effort"],
+      },
+      { id: "future/model", object: "model" },
+      { id: "ignored", object: "not-a-model" },
+    ]);
+
+    expect(models).toHaveLength(2);
+    expect(models[0]).toMatchObject({
+      id: "thinkingmachines/inkling",
+      name: "Inkling live",
+      contextWindow: 1_048_576,
+      maxTokens: 32_768,
+      cost: { input: 1.1, output: 4.2, cacheRead: 0.18, cacheWrite: 0 },
+      compat: { supportsReasoningEffort: true, maxTokensField: "max_tokens" },
+    });
+    expect(models[1]).toMatchObject({
+      id: "future/model",
+      reasoning: true,
+      input: ["text", "image"],
+      contextWindow: 64_000,
+      maxTokens: 4_000,
+      cost: { input: 0.2, output: 0.8, cacheRead: 0.04, cacheWrite: 0 },
+      compat: {
+        supportsReasoningEffort: true,
+        supportsTools: true,
+        supportsStrictMode: true,
+      },
+    });
+  });
+
+  it("uses live capability metadata when present and curated metadata when absent", () => {
+    const liveCapabilities = projectBasetenLiveModels([
+      {
+        id: "thinkingmachines/inkling",
+        object: "model",
+        supported_features: [],
+      },
+    ])[0];
+    const curatedCapabilities = projectBasetenLiveModels([
+      {
+        id: "thinkingmachines/inkling",
+        object: "model",
+      },
+    ])[0];
+
+    expect(liveCapabilities).toMatchObject({ reasoning: false, input: ["text"] });
+    expect(liveCapabilities?.compat?.supportsReasoningEffort).toBeUndefined();
+    expect(liveCapabilities?.compat?.supportedReasoningEfforts).toBeUndefined();
+    expect(liveCapabilities?.compat?.reasoningEffortMap).toBeUndefined();
+    expect(curatedCapabilities).toMatchObject({
+      reasoning: true,
+      input: ["text", "image"],
+      compat: { supportsReasoningEffort: true },
+    });
+  });
+
+  it("keeps discovery offline without resolved auth", async () => {
+    await expect(discoverBasetenModels()).resolves.toHaveLength(12);
+  });
+
+  it("authenticates live discovery and does not cache unusable rows", async () => {
+    const release = vi.fn(async () => undefined);
+    const fetchGuard: LiveModelCatalogFetchGuard = vi
+      .fn()
+      .mockImplementationOnce(async () => ({
+        response: Response.json({ data: [{ object: "not-a-model" }] }),
+        finalUrl: "https://inference.baseten.co/v1/models",
+        release,
+      }))
+      .mockImplementationOnce(async () => ({
+        response: Response.json({
+          data: [
+            {
+              id: "thinkingmachines/inkling",
+              object: "model",
+              context_length: 1_048_576,
+              max_completion_tokens: 32_768,
+              supported_features: ["vision", "reasoning", "reasoning_effort"],
+            },
+          ],
+        }),
+        finalUrl: "https://inference.baseten.co/v1/models",
+        release,
+      }));
+
+    await expect(
+      discoverBasetenModels({
+        discoveryApiKey: TEST_VALUE,
+        forceLive: true,
+        fetchGuard,
+      }),
+    ).resolves.toHaveLength(12);
+    await expect(
+      discoverBasetenModels({
+        discoveryApiKey: TEST_VALUE,
+        forceLive: true,
+        fetchGuard,
+      }),
+    ).resolves.toEqual([
+      expect.objectContaining({
+        id: "thinkingmachines/inkling",
+        contextWindow: 1_048_576,
+        maxTokens: 32_768,
+      }),
+    ]);
+
+    expect(fetchGuard).toHaveBeenCalledTimes(2);
+    const headers = vi.mocked(fetchGuard).mock.calls[0]?.[0].init?.headers;
+    expect(headers).toBeInstanceOf(Headers);
+    if (!(headers instanceof Headers)) {
+      throw new Error("expected fetch headers");
+    }
+    expect(headers.get("Authorization")).toBe(`Bearer ${TEST_VALUE}`);
+    expect(release).toHaveBeenCalledTimes(2);
+  });
+
+  it("resolves future model ids without shadowing bundled rows", () => {
+    expect(resolveBasetenDynamicModel("thinkingmachines/inkling")).toBeUndefined();
+    expect(resolveBasetenDynamicModel("future/model")).toMatchObject({
+      id: "future/model",
+      provider: "baseten",
+      api: "openai-completions",
+      baseUrl: "https://inference.baseten.co/v1",
+      compat: { supportsTools: true, maxTokensField: "max_tokens" },
+    });
+  });
+});

--- a/extensions/baseten/models.ts
+++ b/extensions/baseten/models.ts
@@ -286,7 +286,7 @@ export async function discoverBasetenModels(
       ttlMs: CACHE_TTL_MS,
       policy: ssrfPolicyFromHttpBaseUrlAllowedHostname(BASETEN_BASE_URL),
       auditContext: "baseten-model-discovery",
-      shouldCacheRows: (rows) => projectBasetenLiveModels(rows).length > 0,
+      shouldCacheRows: (candidateRows) => projectBasetenLiveModels(candidateRows).length > 0,
     });
     const models = projectBasetenLiveModels(rows);
     if (models.length > 0) {

--- a/extensions/baseten/models.ts
+++ b/extensions/baseten/models.ts
@@ -1,0 +1,321 @@
+/**
+ * Baseten model catalog, compat metadata, and authenticated live discovery.
+ */
+import {
+  getCachedLiveProviderModelRows,
+  type LiveModelCatalogFetchGuard,
+} from "openclaw/plugin-sdk/provider-catalog-live-runtime";
+import { buildManifestModelProviderConfig } from "openclaw/plugin-sdk/provider-catalog-shared";
+import type {
+  ModelCompatConfig,
+  ModelDefinitionConfig,
+} from "openclaw/plugin-sdk/provider-model-shared";
+import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
+import { ssrfPolicyFromHttpBaseUrlAllowedHostname } from "openclaw/plugin-sdk/ssrf-runtime";
+import manifest from "./openclaw.plugin.json" with { type: "json" };
+
+const log = createSubsystemLogger("baseten-models");
+const BASETEN_MANIFEST_CATALOG = manifest.modelCatalog.providers.baseten;
+const CACHE_TTL_MS = 5 * 60 * 1000;
+const DEFAULT_CONTEXT_WINDOW = 128_000;
+const DEFAULT_MAX_TOKENS = 8_192;
+
+const CHAT_TEMPLATE_THINKING_MODEL_IDS = new Set([
+  "zai-org/GLM-4.7",
+  "zai-org/GLM-5",
+  "zai-org/GLM-5.1",
+  "zai-org/GLM-5.2",
+  "moonshotai/Kimi-K2.5",
+  "moonshotai/Kimi-K2.6",
+  "moonshotai/Kimi-K2.7-Code",
+  "nvidia/Nemotron-120B-A12B",
+  "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B",
+]);
+
+const FULL_REASONING_EFFORT_MODEL_IDS = new Set([
+  "deepseek-ai/DeepSeek-V4-Pro",
+  "openai/gpt-oss-120b",
+]);
+
+const INKLING_REASONING_EFFORTS = ["none", "minimal", "low", "medium", "high", "xhigh"];
+const FULL_REASONING_EFFORTS = [...INKLING_REASONING_EFFORTS, "max"];
+
+const BASE_COMPAT: ModelCompatConfig = {
+  supportsStore: false,
+  supportsDeveloperRole: false,
+  supportsUsageInStreaming: true,
+  supportsStrictMode: true,
+  supportsTools: true,
+  maxTokensField: "max_tokens",
+};
+
+/** Base URL for Baseten's OpenAI-compatible Model APIs. */
+export const BASETEN_BASE_URL = BASETEN_MANIFEST_CATALOG.baseUrl;
+/** Default Baseten model id used for onboarding. */
+export const BASETEN_DEFAULT_MODEL_ID = "thinkingmachines/inkling";
+/** Default Baseten model ref used for onboarding. */
+export const BASETEN_DEFAULT_MODEL_REF = `baseten/${BASETEN_DEFAULT_MODEL_ID}`;
+/** Bundled fallback rows for all Baseten Model APIs available at release time. */
+export const BASETEN_MODEL_CATALOG = BASETEN_MANIFEST_CATALOG.models;
+
+/** Whether Baseten requires chat-template thinking control for this model. */
+export function usesBasetenChatTemplateThinking(modelId: string): boolean {
+  return CHAT_TEMPLATE_THINKING_MODEL_IDS.has(modelId);
+}
+
+function buildBasetenReasoningCompat(modelId: string): ModelCompatConfig {
+  if (FULL_REASONING_EFFORT_MODEL_IDS.has(modelId)) {
+    return {
+      supportsReasoningEffort: true,
+      supportedReasoningEfforts: FULL_REASONING_EFFORTS,
+      reasoningEffortMap: {
+        off: "none",
+        none: "none",
+        adaptive: "max",
+      },
+    };
+  }
+  if (modelId === BASETEN_DEFAULT_MODEL_ID) {
+    return {
+      supportsReasoningEffort: true,
+      supportedReasoningEfforts: INKLING_REASONING_EFFORTS,
+      reasoningEffortMap: {
+        off: "none",
+        none: "none",
+        adaptive: "xhigh",
+        max: "xhigh",
+      },
+    };
+  }
+  if (modelId === "zai-org/GLM-5.2") {
+    return {
+      supportsReasoningEffort: true,
+      supportedReasoningEfforts: ["none", "high", "max"],
+      reasoningEffortMap: {
+        off: "none",
+        none: "none",
+        minimal: "high",
+        low: "high",
+        medium: "high",
+        xhigh: "high",
+        adaptive: "max",
+      },
+    };
+  }
+  return {};
+}
+
+/** Complete OpenAI-compatible transport policy for one Baseten model. */
+export function buildBasetenModelCompat(modelId: string): ModelCompatConfig {
+  return {
+    ...BASE_COMPAT,
+    ...buildBasetenReasoningCompat(modelId),
+  };
+}
+
+/** Builds one normalized Baseten model definition from a manifest entry. */
+export function buildBasetenModelDefinition(
+  model: (typeof BASETEN_MODEL_CATALOG)[number],
+): ModelDefinitionConfig {
+  const provider = buildManifestModelProviderConfig({
+    providerId: "baseten",
+    catalog: { ...BASETEN_MANIFEST_CATALOG, models: [model] },
+  });
+  const normalized = provider.models[0];
+  if (!normalized) {
+    throw new Error(`Missing normalized Baseten model ${model.id}`);
+  }
+  return {
+    ...normalized,
+    compat: buildBasetenModelCompat(normalized.id),
+  };
+}
+
+/** Builds the network-free fallback catalog. */
+export function buildStaticBasetenModels(): ModelDefinitionConfig[] {
+  return BASETEN_MODEL_CATALOG.map(buildBasetenModelDefinition);
+}
+
+type BasetenLiveModelRow = {
+  id?: unknown;
+  object?: unknown;
+  name?: unknown;
+  context_length?: unknown;
+  max_completion_tokens?: unknown;
+  pricing?: unknown;
+  supported_features?: unknown;
+};
+
+function readPositiveInteger(value: unknown): number | undefined {
+  const number = typeof value === "number" ? value : Number(value);
+  return Number.isSafeInteger(number) && number > 0 ? number : undefined;
+}
+
+function readPerTokenPrice(value: unknown): number | undefined {
+  if (typeof value !== "number" && (typeof value !== "string" || !value.trim())) {
+    return undefined;
+  }
+  const number = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(number) && number >= 0
+    ? Number((number * 1_000_000).toFixed(9))
+    : undefined;
+}
+
+function readStringArray(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === "string")
+    : [];
+}
+
+function applyLiveReasoningEffortCompat(
+  fallbackCompat: ModelCompatConfig,
+  supportsReasoningEffort: boolean,
+): ModelCompatConfig {
+  if (supportsReasoningEffort) {
+    return { ...fallbackCompat, supportsReasoningEffort: true };
+  }
+  const compat = { ...fallbackCompat };
+  delete compat.supportsReasoningEffort;
+  delete compat.supportedReasoningEfforts;
+  delete compat.reasoningEffortMap;
+  return compat;
+}
+
+function projectLiveModel(
+  row: BasetenLiveModelRow,
+  fallback: ModelDefinitionConfig | undefined,
+): ModelDefinitionConfig | undefined {
+  if (row.object !== undefined && row.object !== "model") {
+    return undefined;
+  }
+  const id = typeof row.id === "string" ? row.id.trim() : "";
+  if (!id) {
+    return undefined;
+  }
+
+  const hasLiveFeatures = Array.isArray(row.supported_features);
+  const features = new Set(readStringArray(row.supported_features));
+  const pricing =
+    row.pricing && typeof row.pricing === "object" && !Array.isArray(row.pricing)
+      ? (row.pricing as Record<string, unknown>)
+      : {};
+  const inputPrice = readPerTokenPrice(pricing.prompt);
+  const outputPrice = readPerTokenPrice(pricing.completion);
+  const cacheReadPrice = readPerTokenPrice(pricing.input_cache_read);
+  const supportsReasoningEffort = features.has("reasoning_effort");
+  const fallbackCompat = fallback?.compat ?? buildBasetenModelCompat(id);
+  const compat = hasLiveFeatures
+    ? applyLiveReasoningEffortCompat(fallbackCompat, supportsReasoningEffort)
+    : fallbackCompat;
+
+  return {
+    id,
+    name:
+      typeof row.name === "string" && row.name.trim() ? row.name.trim() : (fallback?.name ?? id),
+    reasoning: hasLiveFeatures
+      ? features.has("reasoning") || supportsReasoningEffort
+      : (fallback?.reasoning ?? false),
+    input: hasLiveFeatures
+      ? features.has("vision")
+        ? ["text", "image"]
+        : ["text"]
+      : (fallback?.input ?? ["text"]),
+    cost: {
+      input: inputPrice ?? fallback?.cost.input ?? 0,
+      output: outputPrice ?? fallback?.cost.output ?? 0,
+      cacheRead: cacheReadPrice ?? fallback?.cost.cacheRead ?? 0,
+      cacheWrite: fallback?.cost.cacheWrite ?? 0,
+    },
+    contextWindow:
+      readPositiveInteger(row.context_length) ?? fallback?.contextWindow ?? DEFAULT_CONTEXT_WINDOW,
+    maxTokens:
+      readPositiveInteger(row.max_completion_tokens) ?? fallback?.maxTokens ?? DEFAULT_MAX_TOKENS,
+    compat,
+  };
+}
+
+/** Projects Baseten's authenticated `/models` response into OpenClaw model rows. */
+export function projectBasetenLiveModels(rows: readonly unknown[]): ModelDefinitionConfig[] {
+  const fallbacks = new Map(buildStaticBasetenModels().map((model) => [model.id, model]));
+  const seen = new Set<string>();
+  const models: ModelDefinitionConfig[] = [];
+  for (const row of rows) {
+    if (!row || typeof row !== "object" || Array.isArray(row)) {
+      continue;
+    }
+    const model = projectLiveModel(
+      row as BasetenLiveModelRow,
+      fallbacks.get(String((row as BasetenLiveModelRow).id)),
+    );
+    if (!model || seen.has(model.id)) {
+      continue;
+    }
+    seen.add(model.id);
+    models.push(model);
+  }
+  return models;
+}
+
+/** Discovers every model enabled for a Baseten account, with a static fallback. */
+export async function discoverBasetenModels(
+  params: {
+    discoveryApiKey?: string;
+    env?: Record<string, string | undefined>;
+    forceLive?: boolean;
+    fetchGuard?: LiveModelCatalogFetchGuard;
+    signal?: AbortSignal;
+  } = {},
+): Promise<ModelDefinitionConfig[]> {
+  const staticModels = buildStaticBasetenModels();
+  const env = params.env ?? process.env;
+  if (
+    !params.discoveryApiKey?.trim() ||
+    (!params.forceLive && (env.NODE_ENV === "test" || env.VITEST === "true"))
+  ) {
+    return staticModels;
+  }
+
+  try {
+    const rows = await getCachedLiveProviderModelRows({
+      providerId: "baseten",
+      endpoint: `${BASETEN_BASE_URL}/models`,
+      discoveryApiKey: params.discoveryApiKey,
+      fetchGuard: params.fetchGuard,
+      signal: params.signal,
+      timeoutMs: 10_000,
+      ttlMs: CACHE_TTL_MS,
+      policy: ssrfPolicyFromHttpBaseUrlAllowedHostname(BASETEN_BASE_URL),
+      auditContext: "baseten-model-discovery",
+      shouldCacheRows: (rows) => projectBasetenLiveModels(rows).length > 0,
+    });
+    const models = projectBasetenLiveModels(rows);
+    if (models.length > 0) {
+      return models;
+    }
+    log.warn("Baseten returned no usable models; using bundled catalog");
+  } catch (error) {
+    log.warn(`Baseten model discovery failed; using bundled catalog: ${String(error)}`);
+  }
+  return staticModels;
+}
+
+/** Resolves a forward-compatible Baseten model id not yet in the bundled catalog. */
+export function resolveBasetenDynamicModel(modelId: string) {
+  const id = modelId.trim();
+  if (!id || BASETEN_MODEL_CATALOG.some((model) => model.id === id)) {
+    return undefined;
+  }
+  return {
+    id,
+    name: id,
+    provider: "baseten",
+    api: "openai-completions" as const,
+    baseUrl: BASETEN_BASE_URL,
+    reasoning: false,
+    input: ["text"] as Array<"text" | "image">,
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: DEFAULT_CONTEXT_WINDOW,
+    maxTokens: DEFAULT_MAX_TOKENS,
+    compat: buildBasetenModelCompat(id),
+  };
+}

--- a/extensions/baseten/models.ts
+++ b/extensions/baseten/models.ts
@@ -21,15 +21,15 @@ const DEFAULT_CONTEXT_WINDOW = 128_000;
 const DEFAULT_MAX_TOKENS = 8_192;
 
 const CHAT_TEMPLATE_THINKING_MODEL_IDS = new Set([
-  "zai-org/GLM-4.7",
-  "zai-org/GLM-5",
-  "zai-org/GLM-5.1",
-  "zai-org/GLM-5.2",
-  "moonshotai/Kimi-K2.5",
-  "moonshotai/Kimi-K2.6",
-  "moonshotai/Kimi-K2.7-Code",
-  "nvidia/Nemotron-120B-A12B",
-  "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B",
+  "zai-org/glm-4.7",
+  "zai-org/glm-5",
+  "zai-org/glm-5.1",
+  "zai-org/glm-5.2",
+  "moonshotai/kimi-k2.5",
+  "moonshotai/kimi-k2.6",
+  "moonshotai/kimi-k2.7-code",
+  "nvidia/nemotron-120b-a12b",
+  "nvidia/nvidia-nemotron-3-ultra-550b-a55b",
 ]);
 
 const FULL_REASONING_EFFORT_MODEL_IDS = new Set([
@@ -60,7 +60,7 @@ export const BASETEN_MODEL_CATALOG = BASETEN_MANIFEST_CATALOG.models;
 
 /** Whether Baseten requires chat-template thinking control for this model. */
 export function usesBasetenChatTemplateThinking(modelId: string): boolean {
-  return CHAT_TEMPLATE_THINKING_MODEL_IDS.has(modelId);
+  return CHAT_TEMPLATE_THINKING_MODEL_IDS.has(modelId.trim().toLowerCase());
 }
 
 function buildBasetenReasoningCompat(modelId: string): ModelCompatConfig {

--- a/extensions/baseten/npm-shrinkwrap.json
+++ b/extensions/baseten/npm-shrinkwrap.json
@@ -1,0 +1,12 @@
+{
+  "name": "@openclaw/baseten-provider",
+  "version": "2026.7.2",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@openclaw/baseten-provider",
+      "version": "2026.7.2"
+    }
+  }
+}

--- a/extensions/baseten/onboard.ts
+++ b/extensions/baseten/onboard.ts
@@ -1,0 +1,22 @@
+/** Baseten onboarding config helpers. */
+import {
+  createModelCatalogPresetAppliers,
+  type OpenClawConfig,
+} from "openclaw/plugin-sdk/provider-onboard";
+import { BASETEN_BASE_URL, BASETEN_DEFAULT_MODEL_REF, buildStaticBasetenModels } from "./models.js";
+
+const basetenPresetAppliers = createModelCatalogPresetAppliers({
+  primaryModelRef: BASETEN_DEFAULT_MODEL_REF,
+  resolveParams: (_cfg: OpenClawConfig) => ({
+    providerId: "baseten",
+    api: "openai-completions",
+    baseUrl: BASETEN_BASE_URL,
+    catalogModels: buildStaticBasetenModels(),
+    aliases: [{ modelRef: BASETEN_DEFAULT_MODEL_REF, alias: "Inkling" }],
+  }),
+});
+
+/** Applies Baseten's provider catalog, Inkling alias, and default model. */
+export function applyBasetenConfig(cfg: OpenClawConfig): OpenClawConfig {
+  return basetenPresetAppliers.applyConfig(cfg);
+}

--- a/extensions/baseten/openclaw.plugin.json
+++ b/extensions/baseten/openclaw.plugin.json
@@ -1,0 +1,230 @@
+{
+  "id": "baseten",
+  "name": "Baseten",
+  "description": "OpenClaw Baseten provider plugin.",
+  "activation": {
+    "onStartup": false
+  },
+  "enabledByDefault": true,
+  "providers": ["baseten"],
+  "providerRequest": {
+    "providers": {
+      "baseten": {
+        "family": "baseten",
+        "openAICompletions": {
+          "supportsStreamingUsage": true
+        }
+      }
+    }
+  },
+  "modelCatalog": {
+    "providers": {
+      "baseten": {
+        "baseUrl": "https://inference.baseten.co/v1",
+        "api": "openai-completions",
+        "models": [
+          {
+            "id": "deepseek-ai/DeepSeek-V4-Pro",
+            "name": "DeepSeek V4 Pro",
+            "reasoning": true,
+            "input": ["text"],
+            "contextWindow": 262000,
+            "maxTokens": 262000,
+            "cost": {
+              "input": 1.74,
+              "output": 3.48,
+              "cacheRead": 0.145,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "zai-org/GLM-4.7",
+            "name": "GLM 4.7",
+            "reasoning": true,
+            "input": ["text"],
+            "contextWindow": 200000,
+            "maxTokens": 200000,
+            "cost": {
+              "input": 0.6,
+              "output": 2.2,
+              "cacheRead": 0.12,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "zai-org/GLM-5",
+            "name": "GLM 5",
+            "reasoning": true,
+            "input": ["text"],
+            "contextWindow": 202000,
+            "maxTokens": 202000,
+            "cost": {
+              "input": 0.95,
+              "output": 3.15,
+              "cacheRead": 0.2,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "zai-org/GLM-5.1",
+            "name": "GLM 5.1",
+            "reasoning": true,
+            "input": ["text"],
+            "contextWindow": 202000,
+            "maxTokens": 202000,
+            "cost": {
+              "input": 1.3,
+              "output": 4.3,
+              "cacheRead": 0.26,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "zai-org/GLM-5.2",
+            "name": "GLM 5.2",
+            "reasoning": true,
+            "input": ["text"],
+            "contextWindow": 202000,
+            "maxTokens": 202000,
+            "cost": {
+              "input": 1.4,
+              "output": 4.4,
+              "cacheRead": 0.26,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "thinkingmachines/inkling",
+            "name": "Inkling",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "contextWindow": 1048000,
+            "maxTokens": 32000,
+            "cost": {
+              "input": 1,
+              "output": 4.05,
+              "cacheRead": 0.17,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "moonshotai/Kimi-K2.5",
+            "name": "Kimi K2.5",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "contextWindow": 262000,
+            "maxTokens": 262000,
+            "cost": {
+              "input": 0.6,
+              "output": 3,
+              "cacheRead": 0.12,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "moonshotai/Kimi-K2.6",
+            "name": "Kimi K2.6",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "contextWindow": 262000,
+            "maxTokens": 262000,
+            "cost": {
+              "input": 0.95,
+              "output": 4,
+              "cacheRead": 0.16,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "moonshotai/Kimi-K2.7-Code",
+            "name": "Kimi K2.7 Code",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "contextWindow": 262000,
+            "maxTokens": 262000,
+            "cost": {
+              "input": 0.95,
+              "output": 4,
+              "cacheRead": 0.16,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "nvidia/Nemotron-120B-A12B",
+            "name": "Nemotron Super",
+            "reasoning": true,
+            "input": ["text"],
+            "contextWindow": 202000,
+            "maxTokens": 202000,
+            "cost": {
+              "input": 0.3,
+              "output": 0.75,
+              "cacheRead": 0.06,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B",
+            "name": "Nemotron Ultra",
+            "reasoning": true,
+            "input": ["text"],
+            "contextWindow": 202000,
+            "maxTokens": 202000,
+            "cost": {
+              "input": 0.6,
+              "output": 2.4,
+              "cacheRead": 0.12,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "openai/gpt-oss-120b",
+            "name": "GPT OSS 120B",
+            "reasoning": true,
+            "input": ["text"],
+            "contextWindow": 128000,
+            "maxTokens": 128000,
+            "cost": {
+              "input": 0.1,
+              "output": 0.5,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            }
+          }
+        ]
+      }
+    },
+    "discovery": {
+      "baseten": "refreshable"
+    }
+  },
+  "setup": {
+    "providers": [
+      {
+        "id": "baseten",
+        "envVars": ["BASETEN_API_KEY"]
+      }
+    ]
+  },
+  "providerAuthChoices": [
+    {
+      "provider": "baseten",
+      "method": "api-key",
+      "choiceId": "baseten-api-key",
+      "appGuidedSecret": true,
+      "choiceLabel": "Baseten API key",
+      "groupId": "baseten",
+      "groupLabel": "Baseten",
+      "groupHint": "Hosted Model APIs, including Inkling",
+      "optionKey": "basetenApiKey",
+      "cliFlag": "--baseten-api-key",
+      "cliOption": "--baseten-api-key <key>",
+      "cliDescription": "Baseten API key"
+    }
+  ],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/extensions/baseten/package.json
+++ b/extensions/baseten/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@openclaw/baseten-provider",
+  "version": "2026.7.2",
+  "description": "OpenClaw Baseten provider plugin.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/openclaw/openclaw"
+  },
+  "type": "module",
+  "devDependencies": {
+    "@openclaw/plugin-sdk": "workspace:*"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ],
+    "install": {
+      "clawhubSpec": "clawhub:@openclaw/baseten-provider",
+      "npmSpec": "@openclaw/baseten-provider",
+      "defaultChoice": "npm",
+      "minHostVersion": ">=2026.7.2"
+    },
+    "compat": {
+      "pluginApi": ">=2026.7.2"
+    },
+    "build": {
+      "openclawVersion": "2026.7.2",
+      "bundledDist": false
+    },
+    "release": {
+      "publishToClawHub": true,
+      "publishToNpm": true
+    }
+  }
+}

--- a/extensions/baseten/provider-catalog.ts
+++ b/extensions/baseten/provider-catalog.ts
@@ -1,0 +1,21 @@
+/** Baseten static and authenticated provider catalog builders. */
+import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-shared";
+import { BASETEN_BASE_URL, buildStaticBasetenModels, discoverBasetenModels } from "./models.js";
+
+/** Builds Baseten's network-free fallback provider catalog. */
+export function buildStaticBasetenProvider(): ModelProviderConfig {
+  return {
+    baseUrl: BASETEN_BASE_URL,
+    api: "openai-completions",
+    models: buildStaticBasetenModels(),
+  };
+}
+
+/** Builds Baseten's account-scoped live catalog. */
+export async function buildBasetenProvider(discoveryApiKey?: string): Promise<ModelProviderConfig> {
+  return {
+    baseUrl: BASETEN_BASE_URL,
+    api: "openai-completions",
+    models: await discoverBasetenModels({ discoveryApiKey }),
+  };
+}

--- a/extensions/baseten/stream.ts
+++ b/extensions/baseten/stream.ts
@@ -1,0 +1,67 @@
+/** Baseten request payload policy for models with opt-in chat-template reasoning. */
+import type { ProviderWrapStreamFnContext } from "openclaw/plugin-sdk/plugin-entry";
+import { createPayloadPatchStreamWrapper } from "openclaw/plugin-sdk/provider-stream-shared";
+import { usesBasetenChatTemplateThinking } from "./models.js";
+
+const BASETEN_DEEPSEEK_V4_MODEL_ID = "deepseek-ai/deepseek-v4-pro";
+
+function isThinkingEnabled(level: ProviderWrapStreamFnContext["thinkingLevel"]): boolean {
+  return level !== "off";
+}
+
+function isBasetenDeepSeekV4ModelId(modelId: string): boolean {
+  return modelId.trim().toLowerCase() === BASETEN_DEEPSEEK_V4_MODEL_ID;
+}
+
+function patchBasetenDeepSeekV4Replay(
+  payload: Record<string, unknown>,
+  thinkingEnabled: boolean,
+): void {
+  if (!Array.isArray(payload.messages)) {
+    return;
+  }
+  for (const message of payload.messages) {
+    if (!message || typeof message !== "object" || Array.isArray(message)) {
+      continue;
+    }
+    const record = message as Record<string, unknown>;
+    if (record.role !== "assistant") {
+      continue;
+    }
+    // DeepSeek V4 requires reasoning_content on replayed assistant turns.
+    // Cross-provider turns lack it, so backfill while thinking is enabled.
+    if (thinkingEnabled) {
+      record.reasoning_content ??= "";
+    } else {
+      delete record.reasoning_content;
+    }
+  }
+}
+
+/** Adds Baseten's `chat_template_args.enable_thinking` without dropping caller args. */
+export function createBasetenThinkingWrapper(
+  ctx: ProviderWrapStreamFnContext,
+): ProviderWrapStreamFnContext["streamFn"] {
+  return createPayloadPatchStreamWrapper(ctx.streamFn, ({ payload, model }) => {
+    if (model.provider !== "baseten" || model.api !== "openai-completions") {
+      return;
+    }
+    const thinkingEnabled = isThinkingEnabled(ctx.thinkingLevel);
+    if (isBasetenDeepSeekV4ModelId(model.id)) {
+      patchBasetenDeepSeekV4Replay(payload, thinkingEnabled);
+    }
+    if (!usesBasetenChatTemplateThinking(model.id)) {
+      return;
+    }
+    const existing =
+      payload.chat_template_args &&
+      typeof payload.chat_template_args === "object" &&
+      !Array.isArray(payload.chat_template_args)
+        ? (payload.chat_template_args as Record<string, unknown>)
+        : {};
+    payload.chat_template_args = {
+      ...existing,
+      enable_thinking: thinkingEnabled,
+    };
+  });
+}

--- a/extensions/baseten/stream.ts
+++ b/extensions/baseten/stream.ts
@@ -46,9 +46,10 @@ export function createBasetenThinkingWrapper(
     if (model.provider !== "baseten" || model.api !== "openai-completions") {
       return;
     }
-    const thinkingEnabled = isThinkingEnabled(ctx.thinkingLevel);
     if (isBasetenDeepSeekV4ModelId(model.id)) {
-      patchBasetenDeepSeekV4Replay(payload, thinkingEnabled);
+      // DeepSeek reasoning defaults on when no level is supplied. Only an
+      // explicit `off` may remove its required replay metadata.
+      patchBasetenDeepSeekV4Replay(payload, ctx.thinkingLevel !== "off");
     }
     if (!usesBasetenChatTemplateThinking(model.id)) {
       return;
@@ -61,7 +62,7 @@ export function createBasetenThinkingWrapper(
         : {};
     payload.chat_template_args = {
       ...existing,
-      enable_thinking: thinkingEnabled,
+      enable_thinking: isThinkingEnabled(ctx.thinkingLevel),
     };
   });
 }

--- a/extensions/baseten/stream.ts
+++ b/extensions/baseten/stream.ts
@@ -6,7 +6,7 @@ import { usesBasetenChatTemplateThinking } from "./models.js";
 const BASETEN_DEEPSEEK_V4_MODEL_ID = "deepseek-ai/deepseek-v4-pro";
 
 function isThinkingEnabled(level: ProviderWrapStreamFnContext["thinkingLevel"]): boolean {
-  return level !== "off";
+  return level !== undefined && level !== "off";
 }
 
 function isBasetenDeepSeekV4ModelId(modelId: string): boolean {

--- a/extensions/baseten/thinking.ts
+++ b/extensions/baseten/thinking.ts
@@ -1,0 +1,24 @@
+/** Baseten model-specific thinking controls. */
+import type { ProviderThinkingProfile } from "openclaw/plugin-sdk/plugin-entry";
+import { usesBasetenChatTemplateThinking } from "./models.js";
+
+const BASETEN_BINARY_THINKING_PROFILE = {
+  levels: [{ id: "off" }, { id: "low", label: "on" }],
+  defaultLevel: "off",
+} as const satisfies ProviderThinkingProfile;
+
+const BASETEN_GLM_52_THINKING_PROFILE = {
+  levels: [{ id: "off" }, { id: "high" }, { id: "max" }],
+  defaultLevel: "off",
+} as const satisfies ProviderThinkingProfile;
+
+/** Exposes only the thinking levels that Baseten actually accepts for opt-in models. */
+export function resolveBasetenThinkingProfile(
+  modelId: string,
+): ProviderThinkingProfile | undefined {
+  const normalized = modelId.trim().toLowerCase();
+  if (normalized === "zai-org/glm-5.2") {
+    return BASETEN_GLM_52_THINKING_PROFILE;
+  }
+  return usesBasetenChatTemplateThinking(normalized) ? BASETEN_BINARY_THINKING_PROFILE : undefined;
+}

--- a/extensions/baseten/tsconfig.json
+++ b/extensions/baseten/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../tsconfig.package-boundary.base.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "include": ["./*.ts", "./src/**/*.ts"],
+  "exclude": [
+    "./**/*.test.ts",
+    "./dist/**",
+    "./node_modules/**",
+    "./src/test-support/**",
+    "./src/**/*test-helpers.ts",
+    "./src/**/*test-harness.ts",
+    "./src/**/*test-support.ts"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "!dist/extensions/node_modules/**",
     "!dist/extensions/*/node_modules/**",
     "!dist/extensions/arcee/**",
+    "!dist/extensions/baseten/**",
     "!dist/extensions/brave/**",
     "!dist/extensions/cerebras/**",
     "!dist/extensions/chutes/**",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -452,6 +452,12 @@ importers:
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
 
+  extensions/baseten:
+    devDependencies:
+      '@openclaw/plugin-sdk':
+        specifier: workspace:*
+        version: link:../../packages/plugin-sdk
+
   extensions/bonjour:
     dependencies:
       '@homebridge/ciao':

--- a/scripts/lib/official-external-provider-catalog.json
+++ b/scripts/lib/official-external-provider-catalog.json
@@ -142,6 +142,55 @@
       }
     },
     {
+      "name": "@openclaw/baseten-provider",
+      "description": "OpenClaw Baseten provider plugin.",
+      "source": "official",
+      "kind": "provider",
+      "openclaw": {
+        "plugin": {
+          "id": "baseten",
+          "label": "Baseten"
+        },
+        "providers": [
+          {
+            "id": "baseten",
+            "name": "Baseten",
+            "docs": "/providers/baseten",
+            "categories": [
+              "cloud",
+              "llm"
+            ],
+            "envVars": [
+              "BASETEN_API_KEY"
+            ],
+            "authChoices": [
+              {
+                "method": "api-key",
+                "choiceId": "baseten-api-key",
+                "choiceLabel": "Baseten API key",
+                "groupId": "baseten",
+                "groupLabel": "Baseten",
+                "groupHint": "Hosted Model APIs, including Inkling",
+                "optionKey": "basetenApiKey",
+                "cliFlag": "--baseten-api-key",
+                "cliOption": "--baseten-api-key <key>",
+                "cliDescription": "Baseten API key",
+                "onboardingScopes": [
+                  "text-inference"
+                ]
+              }
+            ]
+          }
+        ],
+        "install": {
+          "clawhubSpec": "clawhub:@openclaw/baseten-provider",
+          "npmSpec": "@openclaw/baseten-provider",
+          "defaultChoice": "npm",
+          "minHostVersion": ">=2026.7.2"
+        }
+      }
+    },
+    {
       "name": "@openclaw/cerebras-provider",
       "description": "OpenClaw Cerebras provider plugin.",
       "source": "official",


### PR DESCRIPTION
Closes #108665

## What Problem This Solves

OpenClaw users cannot currently configure or call Baseten Model APIs through a supported provider plugin. That blocks first-class access to Thinking Machines Inkling and requires manual custom-provider routing without authenticated discovery, provider-specific reasoning behavior, or setup documentation.

## Why This Change Was Made

Adds the external official `@openclaw/baseten` provider plugin, keeping Baseten policy at the plugin owner boundary. It authenticates with `BASETEN_API_KEY`, discovers the account's live catalog with a current 12-model offline fallback, defaults to `baseten/thinkingmachines/inkling`, and adapts reasoning, tool replay, vision, streaming, pricing, onboarding, packaging, labels, and docs through existing plugin seams.

## User Impact

Users can install the Baseten plugin, add an API key, select Inkling or any Baseten model enabled for their account, and use OpenClaw streaming, tools, images, and reasoning controls. The provider documentation covers key creation, setup, the full fallback catalog, model selection, and manual configuration.

## Evidence

- Authenticated AWS live run: https://crabbox.openclaw.ai/portal/runs/run_d83f90d6e253
  - discovered exactly 12 current Baseten models;
  - completed through the registered OpenClaw wrapper on all 12;
  - completed a forced Inkling tool call;
  - completed a DeepSeek V4 cross-provider tool replay.
- Focused tests on the rebased head: 2 files, 12 tests passed, including unset-level DeepSeek replay.
- Full changed-surface Testbox gate: https://github.com/openclaw/openclaw/actions/runs/29482445831
  - all typecheck, lint, packaging, SDK, plugin-boundary, cycle, format, and shrinkwrap gates passed;
  - all lint shards reported 0 warnings and 0 errors.
- Autoreview: all accepted findings fixed; final whole-branch review clean.
- Behavior validation: 5/5 public behavior contract checks passed.

AI-assisted: yes.
