### PR TITLE
fix(agents): keep not_required delivery status when completion_announced_at exists

### DIFF
--- a/src/agents/subagent-registry.store.sqlite.test.ts
+++ b/src/agents/subagent-registry.store.sqlite.test.ts
@@ -3,6 +3,8 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { executeSqliteQuerySync, getNodeSqliteKysely } from "../infra/kysely-sync.js";
+import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
 import {
   closeOpenClawStateDatabaseForTest,
   openOpenClawStateDatabase,
@@ -13,6 +15,8 @@ import {
   saveSubagentRegistryToSqlite,
 } from "./subagent-registry.store.sqlite.js";
 import type { SubagentRunRecord } from "./subagent-registry.types.js";
+
+type SubagentRegistryDatabase = Pick<OpenClawStateKyselyDatabase, "subagent_runs">;
 
 function createRun(overrides: Partial<SubagentRunRecord> = {}): SubagentRunRecord {
   return {
@@ -121,23 +125,6 @@ describe("subagent registry sqlite store", () => {
     });
   });
 
-  it("does not mark not_required delivery as delivered when completion_announced_at exists", async () => {
-    await withTempStateEnv(async () => {
-      const run = createRun({
-        expectsCompletionMessage: false,
-        completion: { required: false },
-        delivery: { status: "not_required" },
-      });
-
-      saveSubagentRegistryToSqlite(new Map([[run.runId, run]]));
-
-      const restored = loadSubagentRegistryFromSqlite();
-      const restoredRun = restored.get(run.runId)!;
-      expect(restoredRun.delivery?.status).toBe("not_required");
-      expect(restoredRun.delivery?.announcedAt).toBeUndefined();
-    });
-  });
-
   it("preserves announcedAt for not_required delivery when completion was announced", async () => {
     await withTempStateEnv(async () => {
       const run = createRun({
@@ -153,6 +140,39 @@ describe("subagent registry sqlite store", () => {
       expect(restoredRun.delivery?.status).toBe("not_required");
       expect(restoredRun.delivery?.announcedAt).toBe(300);
       expect(restoredRun.delivery?.deliveredAt).toBeUndefined();
+    });
+  });
+
+  it("repairs a tainted delivered status when completion is not required", async () => {
+    await withTempStateEnv(async () => {
+      const run = createRun({
+        expectsCompletionMessage: false,
+        completion: { required: false },
+        delivery: { status: "not_required", announcedAt: 300 },
+      });
+      saveSubagentRegistryToSqlite(new Map([[run.runId, run]]));
+
+      const { db } = openOpenClawStateDatabase();
+      const stateDb = getNodeSqliteKysely<SubagentRegistryDatabase>(db);
+      executeSqliteQuerySync(
+        db,
+        stateDb
+          .updateTable("subagent_runs")
+          .set({
+            payload_json: JSON.stringify({
+              ...run,
+              delivery: { status: "delivered", announcedAt: 300, deliveredAt: 300 },
+            }),
+          })
+          .where("run_id", "=", run.runId),
+      );
+
+      const restoredRun = loadSubagentRegistryFromSqlite().get(run.runId)!;
+      expect(restoredRun.delivery).toMatchObject({
+        status: "not_required",
+        announcedAt: 300,
+        deliveredAt: 300,
+      });
     });
   });
 

--- a/src/agents/subagent-registry.store.sqlite.test.ts
+++ b/src/agents/subagent-registry.store.sqlite.test.ts
@@ -121,6 +121,41 @@ describe("subagent registry sqlite store", () => {
     });
   });
 
+  it("does not mark not_required delivery as delivered when completion_announced_at exists", async () => {
+    await withTempStateEnv(async () => {
+      const run = createRun({
+        expectsCompletionMessage: false,
+        completion: { required: false },
+        delivery: { status: "not_required" },
+      });
+
+      saveSubagentRegistryToSqlite(new Map([[run.runId, run]]));
+
+      const restored = loadSubagentRegistryFromSqlite();
+      const restoredRun = restored.get(run.runId)!;
+      expect(restoredRun.delivery?.status).toBe("not_required");
+      expect(restoredRun.delivery?.announcedAt).toBeUndefined();
+    });
+  });
+
+  it("preserves announcedAt for not_required delivery when completion was announced", async () => {
+    await withTempStateEnv(async () => {
+      const run = createRun({
+        expectsCompletionMessage: false,
+        completion: { required: false },
+        delivery: { status: "not_required", announcedAt: 300 },
+      });
+
+      saveSubagentRegistryToSqlite(new Map([[run.runId, run]]));
+
+      const restored = loadSubagentRegistryFromSqlite();
+      const restoredRun = restored.get(run.runId)!;
+      expect(restoredRun.delivery?.status).toBe("not_required");
+      expect(restoredRun.delivery?.announcedAt).toBe(300);
+      expect(restoredRun.delivery?.deliveredAt).toBeUndefined();
+    });
+  });
+
   it("does not read or delete the retired JSON registry at runtime", async () => {
     await withTempStateEnv(async () => {
       const legacyRun = createRun({

--- a/src/agents/subagent-registry.store.sqlite.ts
+++ b/src/agents/subagent-registry.store.sqlite.ts
@@ -98,6 +98,7 @@ function createDeliveryFromTypedColumns(
       : row.completion_announced_at !== null
         ? { announcedAt: row.completion_announced_at }
         : {}),
+    ...(row.expects_completion_message === 0 ? { status: "not_required" } : {}),
   };
 }
 

--- a/src/agents/subagent-registry.store.sqlite.ts
+++ b/src/agents/subagent-registry.store.sqlite.ts
@@ -89,13 +89,15 @@ function createDeliveryFromTypedColumns(
     ...(row.pending_final_delivery_last_error !== null
       ? { lastError: row.pending_final_delivery_last_error }
       : {}),
-    ...(row.completion_announced_at !== null
+    ...(row.completion_announced_at !== null && row.expects_completion_message === 1
       ? {
           status: "delivered",
           announcedAt: row.completion_announced_at,
           deliveredAt: delivery?.deliveredAt ?? row.completion_announced_at,
         }
-      : {}),
+      : row.completion_announced_at !== null
+        ? { announcedAt: row.completion_announced_at }
+        : {}),
   };
 }
 


### PR DESCRIPTION
## What Problem This Solves

`createDeliveryFromTypedColumns` in `subagent-registry.store.sqlite.ts` unconditionally overrode delivery `status` to `"delivered"` whenever `completion_announced_at` was present, even for runs where `expectsCompletionMessage` is `false`. This produced a contradictory delivery state: a run that does not require completion delivery was marked as delivered.

## Why This Change Was Made

When restoring subagent run records from SQLite typed columns, the hydration at lines 92-98 spread `status: "delivered"` whenever `completion_announced_at !== null`, without checking whether the run actually requires completion delivery. For `expectsCompletionMessage === false` runs, the correct status is `"not_required"` — the `completion_announced_at` timestamp may exist for informational logging but should not override delivery semantics.

This contradicts the normalization logic in `buildDeliveryState` (subagent-delivery-state.ts:238) which correctly returns `{ status: "not_required" }` when `expectsCompletionMessage === false`, bypassing all delivery state checks.

## User Impact

Subagent runs with `expectsCompletionMessage === false` that have their completion timestamp recorded would get incorrect `status: "delivered"` after gateway restart (which reloads from SQLite). Downstream delivery logic checking `status === "delivered"` could attempt unnecessary delivery retries for runs that should be dormant.

## Evidence

- `createDeliveryFromTypedColumns` at `src/agents/subagent-registry.store.sqlite.ts:92-98` unconditionally spreads `status: "delivered"` based on `completion_announced_at`.
- `buildDeliveryState` at `src/agents/subagent-delivery-state.ts:238-239` correctly returns `{ status: "not_required" }` for the same scenario.
- Added two test cases verifying `not_required` status is preserved and `announcedAt` is kept for informational purposes.

### Real behavior proof

proof: test — SQLite round-trip tests directly assert delivery status after save+load. Local execution blocked by Node 22.22.0 SQLite WAL version gate; CI validates.