### PR TITLE
chore(protocol): regenerate Swift gateway models for sessions.create thinkingLevel

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -4587,6 +4587,7 @@ public struct SessionsCreateParams: Codable, Sendable {
     public let agentid: String?
     public let label: String?
     public let model: String?
+    public let thinkinglevel: String?
     public let catalogid: String?
     public let parentsessionkey: String?
     public let fork: Bool?
@@ -4605,6 +4606,7 @@ public struct SessionsCreateParams: Codable, Sendable {
         agentid: String? = nil,
         label: String? = nil,
         model: String? = nil,
+        thinkinglevel: String? = nil,
         catalogid: String? = nil,
         parentsessionkey: String? = nil,
         fork: Bool? = nil,
@@ -4622,6 +4624,7 @@ public struct SessionsCreateParams: Codable, Sendable {
         self.agentid = agentid
         self.label = label
         self.model = model
+        self.thinkinglevel = thinkinglevel
         self.catalogid = catalogid
         self.parentsessionkey = parentsessionkey
         self.fork = fork
@@ -4641,6 +4644,7 @@ public struct SessionsCreateParams: Codable, Sendable {
         case agentid = "agentId"
         case label
         case model
+        case thinkinglevel = "thinkingLevel"
         case catalogid = "catalogId"
         case parentsessionkey = "parentSessionKey"
         case fork


### PR DESCRIPTION
## What Problem This Solves

`checks-fast-bundled-protocol` fails on every open PR: PR #108679 added `thinkingLevel` to the `sessions.create` gateway schema but did not regenerate `GatewayModels.swift`. The generated-artifact drift gate only runs on pull requests, so `main` drifted silently and now blocks unrelated PRs (observed on PR #108683, job 87556972862).

## Why This Change Was Made

Sync the generated Swift model with the schema. Output of `pnpm protocol:gen && pnpm protocol:gen:swift && pnpm protocol:gen:kotlin` on current `main` — Kotlin and the JSON schema were already in sync; only the Swift file drifted (4 added lines: the optional `thinkingLevel` field on `SessionsCreateParams`).

## User Impact

None at runtime (generated client model gains the already-shipped optional field). Unblocks CI for all open PRs.

## Evidence

- Regenerated with the repo generators; `git diff` after this commit is empty for all three generated targets.
- Additive optional field only — no protocol version impact.
