### PR TITLE
fix(tail): flush incomplete UTF-8 bytes from StringDecoder in trajectory snapshot read

### DIFF
--- a/src/commands/sessions-tail.ts
+++ b/src/commands/sessions-tail.ts
@@ -319,8 +319,12 @@ function readTrajectorySnapshot(filePath: string): TrajectorySnapshot {
       filePath,
       maxBytes: TRAJECTORY_RUNTIME_FILE_MAX_BYTES,
     });
+    const snapshotDecoder = new StringDecoder("utf8");
+    const decoded = snapshotDecoder.write(buffer) + snapshotDecoder.end();
+    // Replace with a fresh decoder for follow-mode continuation; end()
+    // permanently finishes a decoder, so it cannot decode subsequent chunks.
     const fileDecoder = new StringDecoder("utf8");
-    const lines = fileDecoder.write(buffer).split(/\r?\n/u);
+    const lines = decoded.split(/\r?\n/u);
     const trailing = lines.pop() ?? "";
     const trailingEvent = parseTrajectoryEventLine(trailing);
     return {


### PR DESCRIPTION
## What Problem This Solves

`readTrajectorySnapshot` in `src/commands/sessions-tail.ts:322-323` used `fileDecoder.write(buffer)` to decode the initial trajectory file but never called `fileDecoder.end()` to flush remaining incomplete UTF-8 bytes held in the decoder internal buffer. If the file ends with a partial multi-byte UTF-8 sequence (e.g. mid-write truncation), those bytes would be silently lost from the initial snapshot display.

## Why This Change Was Made

Node.js `StringDecoder` buffers incomplete multi-byte sequences internally until more data arrives. The `end()` method flushes any remaining buffered bytes as a best-effort replacement character. Without calling `end()`, those bytes stay in the decoder and never reach the parsed event lines.

Since `end()` permanently finishes the decoder (it cannot decode subsequent chunks), the fix uses a throwaway `snapshotDecoder` for the initial read, calls both `write()` and `end()` on it, then replaces it with a fresh `fileDecoder` for follow-mode continuation where incremental chunk decoding is needed.

## User Impact

Trajectory files ending with an incomplete UTF-8 character (truncated writes, mid-write reads) could silently lose the final event in the initial `openclaw sessions tail` display. The follow-mode incremental read would eventually complete the partial character, but the initial snapshot would be incomplete.

## Evidence

- `readTrajectorySnapshot` at `src/commands/sessions-tail.ts:322-323` calls `fileDecoder.write(buffer)` without `end()`.
- The same file at `src/commands/sessions-tail.ts:551` properly uses `state.decoder.write()` for incremental follow-mode reads, where `end()` is not called until stream close (handled by follow-mode lifecycle).
- The `execCommand` finish handler at `src/agents/sessions/exec.ts:132-138` correctly calls `decoder.end()` at process exit to flush remaining bytes.

### Real behavior proof

proof: logic — the StringDecoder contract guarantees that `end()` flushes any incomplete multi-byte UTF-8 sequence held in the internal buffer. Without `end()`, those bytes are silently retained and never emitted. CI validates via existing sessions-tail tests.