### PR TITLE
fix(agents): stop prematurely ending StringDecoder in decodeCapturedOutput

### DIFF
--- a/src/agents/sessions/exec.ts
+++ b/src/agents/sessions/exec.ts
@@ -44,7 +44,7 @@ type OutputCapture = {
 };
 
 function decodeCapturedOutput(decoder: StringDecoder, chunk: Buffer | string): string {
-  return Buffer.isBuffer(chunk) ? decoder.write(chunk) : `${decoder.end()}${chunk}`;
+  return Buffer.isBuffer(chunk) ? decoder.write(chunk) : chunk;
 }
 
 function clampMaxOutputChars(value: number | undefined): number {


### PR DESCRIPTION
## What Problem This Solves

`decodeCapturedOutput` in `src/agents/sessions/exec.ts:47` called `decoder.end()` when receiving a string chunk, permanently finishing the decoder. After `end()` is called, the decoder cannot decode any more data — subsequent `Buffer` chunks would return empty strings, silently dropping output.

## Why This Change Was Made

The function was designed to handle mixed `Buffer` and `string` chunks from child process output streams. When a string chunk arrives, the data is already decoded UTF-8, so the decoder is not needed. The original code called `decoder.end()` to flush any buffered incomplete bytes, but this permanently finishes the decoder, breaking all subsequent Buffer chunk decoding.

The `finish` handler at lines 132-138 already calls `stdoutDecoder.end()` and `stderrDecoder.end()` at process exit to flush remaining incomplete bytes. There is no need to flush mid-stream; any incomplete bytes held by the decoder will be properly flushed at exit.

String chunks bypass the decoder entirely since they are already decoded — just return them directly.

## User Impact

In the current configuration (`stdio: ["ignore", "pipe", "pipe"]` with `buffer: false`), child process output arrives as `Buffer` chunks, so this bug is latent. However, if the spawn mechanism changes or a stream encoding is set, mixed Buffer/string chunks would permanently break the decoder after the first string chunk, silently dropping all subsequent stdout/stderr output.

## Evidence

- `decodeCapturedOutput` at `src/agents/sessions/exec.ts:47` calls `decoder.end()` on string chunks.
- Node.js `StringDecoder.end()` documentation states it permanently finishes the decoder.
- The `finish` handler at `src/agents/sessions/exec.ts:132-138` already properly calls `decoder.end()` at process exit.

### Real behavior proof

proof: logic — Node.js StringDecoder contract guarantees `end()` permanently finishes the decoder. Removing the mid-stream `end()` call ensures the decoder remains functional for subsequent Buffer chunks. The exit-time `end()` call in `finish()` flushes any remaining bytes.