### PR TITLE
fix(protocol): regenerate Swift session thinking level

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -4587,6 +4587,7 @@ public struct SessionsCreateParams: Codable, Sendable {
     public let agentid: String?
     public let label: String?
     public let model: String?
+    public let thinkinglevel: String?
     public let catalogid: String?
     public let parentsessionkey: String?
     public let fork: Bool?
@@ -4605,6 +4606,7 @@ public struct SessionsCreateParams: Codable, Sendable {
         agentid: String? = nil,
         label: String? = nil,
         model: String? = nil,
+        thinkinglevel: String? = nil,
         catalogid: String? = nil,
         parentsessionkey: String? = nil,
         fork: Bool? = nil,
@@ -4622,6 +4624,7 @@ public struct SessionsCreateParams: Codable, Sendable {
         self.agentid = agentid
         self.label = label
         self.model = model
+        self.thinkinglevel = thinkinglevel
         self.catalogid = catalogid
         self.parentsessionkey = parentsessionkey
         self.fork = fork
@@ -4641,6 +4644,7 @@ public struct SessionsCreateParams: Codable, Sendable {
         case agentid = "agentId"
         case label
         case model
+        case thinkinglevel = "thinkingLevel"
         case catalogid = "catalogId"
         case parentsessionkey = "parentSessionKey"
         case fork


### PR DESCRIPTION
## What Problem This Solves

Fixes current-main CI where `pnpm protocol:check` regenerates an uncommitted `SessionsCreateParams.thinkingLevel` field in the Swift gateway models after #108679 added the schema field.

## Why This Change Was Made

Regenerates the checked-in Swift protocol model from the current schema. This is a generated-artifact-only repair; runtime behavior and protocol version are unchanged.

## User Impact

Swift clients receive the already-declared optional session thinking-level field, and bundled protocol CI becomes clean again.

## Evidence

- Current-main CI failure reproduced in run 29478461580 and again on PR #108697: `pnpm protocol:check` generated exactly these four lines.
- Local and Blacksmith Testbox generators produced the same SHA-256: `e5802dfdb49bdb0c438ca407a55047a483dabffc013b92b216f63794b9ad8f9e`.
- Fresh structured autoreview: clean, no accepted/actionable findings; confidence 0.99.
