### PR TITLE
fix(e2e): bound npm registry upstream requests

### DIFF
--- a/scripts/e2e/lib/plugins/npm-registry-server.mjs
+++ b/scripts/e2e/lib/plugins/npm-registry-server.mjs
@@ -25,6 +25,9 @@ function normalizeUpstreamRegistry(raw) {
 }
 
 const upstreamRegistry = normalizeUpstreamRegistry(process.env.OPENCLAW_NPM_REGISTRY_UPSTREAM);
+// Match other E2E package-download budgets while keeping a stalled public-registry hop
+// from consuming the much larger install phase deadline.
+const UPSTREAM_REQUEST_TIMEOUT_MS = 120_000;
 
 if (!portFile || packageArgs.length === 0 || packageArgs.length % 3 !== 0) {
   console.error(
@@ -139,7 +142,10 @@ async function proxyUpstream(rawRequestUrl, response) {
   }
   try {
     const upstreamUrl = resolveUpstreamRequestUrl(rawRequestUrl);
-    const upstreamResponse = await fetch(upstreamUrl, { redirect: "manual" });
+    const upstreamResponse = await fetch(upstreamUrl, {
+      redirect: "manual",
+      signal: AbortSignal.timeout(UPSTREAM_REQUEST_TIMEOUT_MS),
+    });
     const body = Buffer.from(await upstreamResponse.arrayBuffer());
     // Fetch decodes compressed bodies but preserves upstream length metadata.
     // Emit the decoded size so npm clients do not truncate proxied responses.

--- a/test/scripts/plugins-assertions.test.ts
+++ b/test/scripts/plugins-assertions.test.ts
@@ -12,6 +12,7 @@ import {
 import { createServer, request as httpRequest } from "node:http";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import { gzipSync } from "node:zlib";
 import { describe, expect, it } from "vitest";
 import { createBoundedChildOutput } from "../helpers/bounded-child-output.js";
@@ -733,6 +734,90 @@ test -d "$OPENCLAW_PLUGINS_TMP_DIR"
           child.once("close", resolve);
         });
       }
+      await new Promise<void>((resolve) => {
+        upstream.close(() => resolve());
+      });
+      cleanupTempDirs(tempDirs);
+    }
+  });
+
+  it("times out stalled upstream response bodies without stopping the fixture registry", async () => {
+    const tempDirs: string[] = [];
+    const root = makeTempDir(tempDirs, "openclaw-plugin-npm-fixture-proxy-timeout-");
+    const portFile = path.join(root, "port");
+    const preloadPath = path.join(root, "shorten-abort-timeout.mjs");
+    const tarballPath = path.join(root, "demo-plugin.tgz");
+    let upstreamHits = 0;
+    writeFileSync(
+      preloadPath,
+      [
+        "const nativeTimeout = AbortSignal.timeout.bind(AbortSignal);",
+        "AbortSignal.timeout = () => nativeTimeout(50);",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+    writeFileSync(tarballPath, "fixture package archive", "utf8");
+
+    const upstream = createServer((_request, response) => {
+      upstreamHits += 1;
+      response.writeHead(200, { "content-type": "application/json" });
+      response.write('{"partial":');
+    });
+    await new Promise<void>((resolve) => {
+      upstream.listen(0, "127.0.0.1", resolve);
+    });
+    const upstreamAddress = upstream.address();
+    if (!upstreamAddress || typeof upstreamAddress === "string") {
+      throw new Error("expected upstream registry address");
+    }
+
+    const child = spawn(
+      process.execPath,
+      [
+        "--import",
+        pathToFileURL(preloadPath).href,
+        "scripts/e2e/lib/plugins/npm-registry-server.mjs",
+        portFile,
+        "@openclaw/demo-plugin-npm",
+        "1.0.0",
+        tarballPath,
+      ],
+      {
+        cwd: process.cwd(),
+        env: {
+          ...process.env,
+          OPENCLAW_NPM_REGISTRY_UPSTREAM: `http://127.0.0.1:${upstreamAddress.port}`,
+        },
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    );
+    const stderr = createBoundedChildOutput();
+    child.stderr.setEncoding("utf8");
+    child.stderr.on("data", (chunk) => {
+      stderr.append(chunk);
+    });
+
+    try {
+      const port = await waitForPortFile(portFile);
+      const stalled = await requestFixtureRegistry(port, "/stalled-package");
+
+      expect(stalled.statusCode, stderr.text()).toBe(502);
+      expect(stalled.body).toContain("upstream registry request failed");
+      expect(upstreamHits).toBe(1);
+
+      const local = await requestFixtureRegistry(port, "/@openclaw%2Fdemo-plugin-npm");
+
+      expect(local.statusCode, stderr.text()).toBe(200);
+      expect(child.exitCode, stderr.text()).toBeNull();
+    } finally {
+      if (child.exitCode === null) {
+        child.kill();
+        await new Promise((resolve) => {
+          child.once("close", resolve);
+        });
+      }
+      upstream.closeAllConnections();
       await new Promise<void>((resolve) => {
         upstream.close(() => resolve());
       });


### PR DESCRIPTION
## What Problem This Solves

The E2E fixture registry proxies packages it does not serve locally to the configured public npm registry. That fetch had no deadline, so an upstream that returned headers or a partial body and then stalled could hold the entire plugin install scenario indefinitely.

## Why This Change Was Made

Apply a 120-second `AbortSignal.timeout()` to each upstream request. This matches the existing E2E package-download budget and stays well below the 10–20 minute install/lane deadlines. The regression test uses a short test-only timeout, stalls after a partial response body, and verifies the proxy returns 502 while remaining able to serve its local fixture package.

## User Impact

Plugin E2E runs now fail with a bounded upstream-registry error instead of hanging when the public registry stops responding. Healthy registry responses and existing full-body buffering behavior are unchanged.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/plugins-assertions.test.ts --run` — 28 passed after rebasing latest `main`
- Controlled partial-body stall returned 502 in about 210ms with the shortened test deadline; fixture process remained live
- Live proxy request to `registry.npmjs.org` resolved `is-number@7.0.0` and its 15-version metadata
- Node syntax, production/test oxlint, oxfmt, and `git diff --check` passed
- Node documents `AbortSignal.timeout(delay)` as returning a signal that aborts after the requested active-time delay: https://nodejs.org/download/release/latest-v24.x/docs/api/globals.html#static-method-abortsignaltimeoutdelay
- Fresh Claude autoreview: clean, correctness confidence 0.87; Codex review attempts could not authenticate in the isolated reviewer environment
- No live timeout duplicate found. #99102 changes package-path encoding in the same files but touches different hunks and behavior.
