### PR TITLE
fix(protocol): restore generated Swift protocol parity

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -4587,6 +4587,7 @@ public struct SessionsCreateParams: Codable, Sendable {
     public let agentid: String?
     public let label: String?
     public let model: String?
+    public let thinkinglevel: String?
     public let catalogid: String?
     public let parentsessionkey: String?
     public let fork: Bool?
@@ -4605,6 +4606,7 @@ public struct SessionsCreateParams: Codable, Sendable {
         agentid: String? = nil,
         label: String? = nil,
         model: String? = nil,
+        thinkinglevel: String? = nil,
         catalogid: String? = nil,
         parentsessionkey: String? = nil,
         fork: Bool? = nil,
@@ -4622,6 +4624,7 @@ public struct SessionsCreateParams: Codable, Sendable {
         self.agentid = agentid
         self.label = label
         self.model = model
+        self.thinkinglevel = thinkinglevel
         self.catalogid = catalogid
         self.parentsessionkey = parentsessionkey
         self.fork = fork
@@ -4641,6 +4644,7 @@ public struct SessionsCreateParams: Codable, Sendable {
         case agentid = "agentId"
         case label
         case model
+        case thinkinglevel = "thinkingLevel"
         case catalogid = "catalogId"
         case parentsessionkey = "parentSessionKey"
         case fork


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the bundled-protocol CI gate fails because the generated Swift session-create model is behind the canonical gateway schema.

## Why This Change Was Made

Regenerates the Swift protocol model so the optional thinking-level field added to session creation is represented consistently in storage, initialization, and wire coding.

## User Impact

No direct user-facing behavior change. Protocol generation and CI are consistent again.

## Evidence

- Exact hosted bundled-protocol command: 186 tests passed.
- Protocol generation check: clean for JSON, Swift, and Kotlin artifacts.
- Changed gate: passed all selected app checks.
- Autoreview: no accepted or actionable findings, confidence 0.99.
