### PR TITLE
fix(ci): bound Android SDK downloads

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -197,7 +197,7 @@ jobs:
           URL="https://dl.google.com/android/repository/${ARCHIVE}"
           if [[ ! -x "${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager" ]]; then
             mkdir -p "${ANDROID_SDK_ROOT}/cmdline-tools"
-            curl -fsSL "${URL}" -o "${RUNNER_TEMP}/${ARCHIVE}"
+            curl -fsSL --connect-timeout 10 --max-time 300 "${URL}" -o "${RUNNER_TEMP}/${ARCHIVE}"
             rm -rf "${ANDROID_SDK_ROOT}/cmdline-tools/latest"
             unzip -q "${RUNNER_TEMP}/${ARCHIVE}" -d "${ANDROID_SDK_ROOT}/cmdline-tools"
             mv "${ANDROID_SDK_ROOT}/cmdline-tools/cmdline-tools" "${ANDROID_SDK_ROOT}/cmdline-tools/latest"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2765,7 +2765,7 @@ jobs:
 
           if [ ! -x "$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager" ]; then
             mkdir -p "$ANDROID_SDK_ROOT/cmdline-tools"
-            curl -fsSL "$URL" -o "/tmp/${ARCHIVE}"
+            curl -fsSL --connect-timeout 10 --max-time 300 "$URL" -o "/tmp/${ARCHIVE}"
             rm -rf "$ANDROID_SDK_ROOT/cmdline-tools/latest"
             unzip -q "/tmp/${ARCHIVE}" -d "$ANDROID_SDK_ROOT/cmdline-tools"
             mv "$ANDROID_SDK_ROOT/cmdline-tools/cmdline-tools" "$ANDROID_SDK_ROOT/cmdline-tools/latest"

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -1438,6 +1438,23 @@ describe("ci workflow guards", () => {
     }
   });
 
+  it("bounds Android SDK command-line tools downloads", () => {
+    const workflow = readCiWorkflow();
+    const releaseWorkflow = readAndroidReleaseWorkflow();
+    const sdkJobs = [workflow.jobs.android, releaseWorkflow.jobs.publish_signed_android_apk];
+
+    for (const job of sdkJobs) {
+      const setupStep = expectDefined(
+        job.steps.find((step: WorkflowStep) =>
+          step.run?.includes("commandlinetools-linux-${CMDLINE_TOOLS_VERSION}_latest.zip"),
+        ),
+        "Android SDK setup step",
+      );
+
+      expect(setupStep.run).toContain("curl -fsSL --connect-timeout 10 --max-time 300");
+    }
+  });
+
   it("covers Android app variants, lint, and benchmark compilation", () => {
     const workflow = readCiWorkflow();
     const source = readFileSync(".github/workflows/ci.yml", "utf8");


### PR DESCRIPTION
## What Problem This Solves

The Android CI and signed-release jobs download the roughly 173 MB Android command-line tools archive with an unbounded `curl`. A stalled connection or response can therefore occupy the runner until the surrounding job timeout.

## Why This Change Was Made

Add a 10-second connection timeout and a 300-second total transfer deadline to both copies of the download. A shared workflow guard covers both jobs so one path cannot silently lose the deadline later.

## User Impact

Android CI and release jobs now fail within a bounded interval when Google's SDK endpoint stalls, while retaining the existing successful download and extraction behavior.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/ci-workflow-guards.test.ts --run`: 61 passed.
- `actionlint` and `zizmor` passed for both changed workflow files; YAML parsing, shell syntax checks, formatting, and `git diff --check` passed.
- A live request to the exact Google SDK archive returned HTTP 200 with `Content-Length: 172789259`; the archive downloaded successfully with the new flags.
- A controlled partial-response stall with `--max-time 2` exited with curl code 28 after about 2.0 seconds, demonstrating the bounded failure mode.
- Fresh Claude autoreview reported no findings (confidence 0.87).
