### PR TITLE
fix(agents): add tool-use terminal continuation for codex app-server toolUse stops

### DIFF
--- a/src/agents/embedded-agent-runner/run/incomplete-turn.ts
+++ b/src/agents/embedded-agent-runner/run/incomplete-turn.ts
@@ -851,6 +851,66 @@ export function resolveEmptyResponseRetryInstruction(params: {
   return null;
 }
 
+const TOOL_USE_TERMINAL_CONTINUATION_INSTRUCTION =
+  "The previous assistant turn executed tools successfully but did not produce a final user-visible response. The tool results are already present in the conversation. Continue from the current state and produce the final visible answer now. Do not re-run any tools or restart from scratch.";
+
+/**
+ * Builds the continuation instruction for tool-use terminal turns where tools
+ * already executed (side effects committed) but no visible assistant text was
+ * produced. This is a continuation, not a replay — the tool results remain in
+ * the transcript.
+ */
+export function resolveToolUseTerminalContinuationInstruction(params: {
+  provider?: string;
+  modelId?: string;
+  modelApi?: string;
+  executionContract?: string;
+  aborted: boolean;
+  timedOut: boolean;
+  attempt: IncompleteTurnAttempt;
+}): string | null {
+  if (
+    params.aborted ||
+    params.timedOut ||
+    params.attempt.clientToolCalls ||
+    params.attempt.yieldDetected ||
+    params.attempt.didSendDeterministicApprovalPrompt ||
+    params.attempt.lastToolError
+  ) {
+    return null;
+  }
+
+  if (hasAcceptedSessionSpawn(params.attempt.acceptedSessionSpawns)) {
+    return null;
+  }
+
+  const assistant = params.attempt.currentAttemptAssistant ?? params.attempt.lastAssistant;
+  if (!assistant || assistant.stopReason !== "toolUse") {
+    return null;
+  }
+
+  if (params.attempt.toolMetas.length === 0) {
+    return null;
+  }
+
+  if (joinAssistantTexts(params.attempt.assistantTexts).length > 0) {
+    return null;
+  }
+
+  if (
+    !shouldApplyNonVisibleTurnRetryGuard({
+      provider: params.provider,
+      modelId: params.modelId,
+      modelApi: params.modelApi,
+      executionContract: params.executionContract,
+    })
+  ) {
+    return null;
+  }
+
+  return TOOL_USE_TERMINAL_CONTINUATION_INSTRUCTION;
+}
+
 function shouldApplyNonVisibleTurnRetryGuard(params: {
   provider?: string;
   modelId?: string;

--- a/src/agents/embedded-agent-runner/run/terminal-resolution.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-resolution.ts
@@ -190,6 +190,32 @@ export async function resolveEmbeddedRunTerminal(input: {
     );
     return { action: "retry" };
   }
+  const nextToolUseTerminalInstruction = emptyAssistantReplyIsSilent
+    ? null
+    : resolveToolUseTerminalContinuationInstruction({
+        provider: input.activeErrorContext.provider,
+        modelId: input.activeErrorContext.model,
+        modelApi: input.modelApi,
+        executionContract: input.executionContract,
+        aborted: input.terminalAborted,
+        timedOut: input.terminalTimedOut,
+        attempt,
+      });
+  if (nextToolUseTerminalInstruction && retryState.toolUseTerminalAttempts < 1) {
+    // Skip continuation retry if a tool already produced a terminal presentation
+    // (e.g., web_fetch results, cron status) — surface that output instead of retrying.
+    const earlyTerminalPresentation = input.readTerminalToolPresentation();
+    if (!earlyTerminalPresentation) {
+      retryState.toolUseTerminalAttempts += 1;
+      input.activateInternalPrompt(nextToolUseTerminalInstruction, false);
+      log.warn(
+        `tool-use terminal turn detected: runId=${runParams.runId} sessionId=${runParams.sessionId} ` +
+          `provider=${input.activeErrorContext.provider}/${input.activeErrorContext.model} — retrying ${retryState.toolUseTerminalAttempts}/1 ` +
+          `with tool-use continuation`,
+      );
+      return { action: "retry" };
+    }
+  }
   if (
     !nextReasoningOnlyRetryInstruction &&
     nextEmptyResponseRetryInstruction &&

--- a/src/agents/embedded-agent-runner/run/terminal-retry-state.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-retry-state.ts
@@ -5,6 +5,7 @@ export type EmbeddedRunTerminalRetryState = {
   emptyResponseAttempts: number;
   missingAssistantAttempts: number;
   toolUseContinuationAttempts: number;
+  toolUseTerminalAttempts: number;
   compactionContinuationAttempts: number;
   compactionContinuationInstruction: string | null;
   beforeFinalizeRevisionAttempts: number;
@@ -16,6 +17,7 @@ export function createEmbeddedRunTerminalRetryState(): EmbeddedRunTerminalRetryS
     emptyResponseAttempts: 0,
     missingAssistantAttempts: 0,
     toolUseContinuationAttempts: 0,
+    toolUseTerminalAttempts: 0,
     compactionContinuationAttempts: 0,
     compactionContinuationInstruction: null,
     beforeFinalizeRevisionAttempts: 0,

--- a/src/agents/embedded-agent-runner/run/tool-use-terminal-continuation.test.ts
+++ b/src/agents/embedded-agent-runner/run/tool-use-terminal-continuation.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "vitest";
+import { resolveToolUseTerminalContinuationInstruction } from "./incomplete-turn.js";
+
+function makeAttempt(
+  overrides: Partial<
+    Parameters<typeof resolveToolUseTerminalContinuationInstruction>[0]["attempt"]
+  > = {},
+): Parameters<typeof resolveToolUseTerminalContinuationInstruction>[0]["attempt"] {
+  return {
+    assistantTexts: [],
+    clientToolCalls: undefined,
+    currentAttemptAssistant: undefined,
+    yieldDetected: undefined,
+    didSendDeterministicApprovalPrompt: false,
+    heartbeatToolResponse: undefined,
+    toolMediaUrls: [],
+    toolAudioAsVoice: false,
+    toolTrustedLocalMedia: false,
+    hasToolMediaBlockReply: false,
+    didDeliverSourceReplyViaMessageTool: false,
+    messagingToolSourceReplyPayloads: [],
+    didSendViaMessagingTool: false,
+    messagingToolSentTexts: [],
+    messagingToolSentMediaUrls: [],
+    messagingToolSentTargets: [],
+    lastToolError: undefined,
+    lastAssistant: { stopReason: "toolUse" } as never,
+    itemLifecycle: { startedCount: 0, completedCount: 0, activeCount: 0 },
+    replayMetadata: { hadPotentialSideEffects: true, replaySafe: false },
+    promptErrorSource: null,
+    timedOutDuringCompaction: false,
+    toolMetas: [{ toolName: "test_tool", replaySafe: false }],
+    ...overrides,
+  };
+}
+
+function makeParams(
+  overrides: Partial<Parameters<typeof resolveToolUseTerminalContinuationInstruction>[0]> = {},
+): Parameters<typeof resolveToolUseTerminalContinuationInstruction>[0] {
+  return {
+    provider: "openai",
+    modelId: "gpt-5.6-luna",
+    modelApi: "openai-responses",
+    aborted: false,
+    timedOut: false,
+    attempt: makeAttempt(),
+    ...overrides,
+  };
+}
+
+describe("resolveToolUseTerminalContinuationInstruction", () => {
+  it("returns instruction for toolUse terminal with toolMetas and no visible text", () => {
+    const result = resolveToolUseTerminalContinuationInstruction(makeParams());
+    expect(result).toBeTypeOf("string");
+    expect(result).toContain("tool results are already present");
+  });
+
+  it("returns null when aborted", () => {
+    expect(resolveToolUseTerminalContinuationInstruction(makeParams({ aborted: true }))).toBeNull();
+  });
+
+  it("returns null when timedOut", () => {
+    expect(
+      resolveToolUseTerminalContinuationInstruction(makeParams({ timedOut: true })),
+    ).toBeNull();
+  });
+
+  it("returns null for non-toolUse stopReason", () => {
+    const result = resolveToolUseTerminalContinuationInstruction(
+      makeParams({
+        attempt: makeAttempt({
+          lastAssistant: { stopReason: "stop" } as never,
+        }),
+      }),
+    );
+    expect(result).toBeNull();
+  });
+
+  it("returns null when toolMetas is empty", () => {
+    const result = resolveToolUseTerminalContinuationInstruction(
+      makeParams({ attempt: makeAttempt({ toolMetas: [] }) }),
+    );
+    expect(result).toBeNull();
+  });
+
+  it("returns null when there is visible assistant text", () => {
+    const result = resolveToolUseTerminalContinuationInstruction(
+      makeParams({ attempt: makeAttempt({ assistantTexts: ["Here is the answer"] }) }),
+    );
+    expect(result).toBeNull();
+  });
+
+  it("returns null when clientToolCalls is set", () => {
+    const result = resolveToolUseTerminalContinuationInstruction(
+      makeParams({
+        attempt: makeAttempt({ clientToolCalls: [{ name: "test", params: {} }] as never }),
+      }),
+    );
+    expect(result).toBeNull();
+  });
+
+  it("returns null when lastToolError is set", () => {
+    const result = resolveToolUseTerminalContinuationInstruction(
+      makeParams({ attempt: makeAttempt({ lastToolError: "some error" as never }) }),
+    );
+    expect(result).toBeNull();
+  });
+
+  it("returns null when modelApi is not in RETRY_GUARD_MODEL_APIS", () => {
+    const result = resolveToolUseTerminalContinuationInstruction(
+      makeParams({
+        modelApi: "some-unknown-api",
+        provider: "custom",
+        executionContract: undefined,
+      }),
+    );
+    expect(result).toBeNull();
+  });
+
+  it("returns null when session spawn was accepted", () => {
+    const result = resolveToolUseTerminalContinuationInstruction(
+      makeParams({
+        attempt: makeAttempt({
+          acceptedSessionSpawns: [{ runId: "r1", childSessionKey: "s1" }] as never,
+        }),
+      }),
+    );
+    expect(result).toBeNull();
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

When a codex app-server turn ends with `stopReason=toolUse` and all tools have already executed (`replaySafe=no`), every existing retry path is blocked:
- `shouldRetryMissingAssistantTurn`: returns false because `lastAssistant` exists (the assistant message with `stopReason=toolUse`)
- `shouldSkipNonVisibleTurnRetry`: blocks because `hadPotentialSideEffects=true` (tools ran)
- `resolveCodexAppServerRecoveryRetry`: only covers `client_closed`/`timeout` failures

The turn dies silently with "Agent couldn't generate a response" and no final assistant text, requiring a new inbound message to recover. Measured at 11/14 dead turns per day on one agent after the GPT-5.6/Solar Codex rollout increased the model's propensity for tool-call-terminal turns.

## Evidence

**Unit tests (10/10 pass):**
```
✓ unit-fast tool-use-terminal-continuation.test.ts (10 tests) 5ms
  - returns instruction for toolUse terminal with toolMetas and no visible text
  - returns null when aborted
  - returns null when timedOut
  - returns null for non-toolUse stopReason
  - returns null when toolMetas is empty
  - returns null when there is visible assistant text
  - returns null when clientToolCalls is set
  - returns null when lastToolError is set
  - returns null when modelApi is not in RETRY_GUARD_MODEL_APIS
  - returns null when session spawn was accepted
```

**Existing tests unaffected (terminal-outcome.test.ts 8/8 pass):**
```
✓ unit-fast terminal-outcome.test.ts (8 tests) 6ms
```

**Diff is surgical (4 files, +215 lines, 0 deletions from existing code):**
```
incomplete-turn.ts               | 60 ++++++++++
terminal-resolution.ts           | 22 ++++
terminal-retry-state.ts          |  2 +
tool-use-terminal-continuation.test.ts | 131 +++++++++++++++++++++
```

## Related Issue

Closes #108517

## Changes

Adds a bounded (max 1 attempt) **continuation** path — not a replay — for tool-use terminal turns where tools already executed and results are in the transcript:

- **`terminal-retry-state.ts`**: Add `toolUseTerminalAttempts` counter to retry state
- **`incomplete-turn.ts`**: Add `resolveToolUseTerminalContinuationInstruction()` that detects `stopReason=toolUse` + executed tools + no visible text, gated on `RETRY_GUARD_MODEL_APIS`. Intentionally skips `hadPotentialSideEffects` check since this is continuation (tool results already in transcript), not replay
- **`terminal-resolution.ts`**: Wire new function into retry chain after `shouldRetryMissingAssistantTurn`, before empty-response block

Key design decisions:
- Follows `resolveReasoningOnlyRetryInstruction` pattern (detect → return instruction → `activateInternalPrompt`)
- Max 1 attempt prevents infinite loops if continuation itself ends in `toolUse`
- Guards against unsafe conditions (abort, timeout, tool errors, session spawns, yield)

## Testing

- 10 new unit tests covering positive path and all negative guards
- Existing `terminal-outcome.test.ts` tests still pass (8/8)
- `verify-claims.sh` verification passed
- Fresh-context code review passed