### PR TITLE
fix(discord): Activities open correctly from packaged builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Discord Activities packaged SDK:** resolve the embedded SDK from the loaded Discord plugin root in built distributions and retry transient asset-read failures instead of caching a rejected read until gateway restart.
 - **Control UI cloud session thinking:** expose reasoning level in the New Session model picker and persist the selected level before cloud dispatch.
 - **Tlon SSE connect cleanup:** disarm opening deadlines after failed HTTP responses and rejected stream opens so reconnect attempts cannot leave stale timers behind. (#104585) Thanks @hugenshen.
 - **LINE reply-token media kinds:** honor video and audio metadata on inbound replies, share the canonical media builder with proactive sends, and fail visibly instead of recording empty media-only deliveries. (#106515) Thanks @edenfunf.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Discord Activities packaged SDK:** resolve the embedded SDK from the loaded Discord plugin root in built distributions and retry transient asset-read failures instead of caching a rejected read until gateway restart.
 - **Control UI cloud session thinking:** expose reasoning level in the New Session model picker and persist the selected level before cloud dispatch.
 - **Tlon SSE connect cleanup:** disarm opening deadlines after failed HTTP responses and rejected stream opens so reconnect attempts cannot leave stale timers behind. (#104585) Thanks @hugenshen.
 - **LINE reply-token media kinds:** honor video and audio metadata on inbound replies, share the canonical media builder with proactive sends, and fail visibly instead of recording empty media-only deliveries. (#106515) Thanks @edenfunf.

--- a/docs/channels/discord-activities.md
+++ b/docs/channels/discord-activities.md
@@ -122,3 +122,7 @@ Add the user's stable Discord ID to `allowFrom` or `dm.allowFrom` on the same Di
 ### “Widget unavailable”
 
 Launch the button from the channel where the agent posted it. If Discord does not carry the button's custom ID into the Activity, OpenClaw falls back only when that channel has exactly one live widget; multiple widgets fail closed as unavailable.
+
+### “You cannot launch Activities in this channel”
+
+Discord does not launch Activities from forum-post threads. OpenClaw can post the widget message and button there, but launch the Activity from a regular text channel instead. This restriction comes from Discord, not OpenClaw.

--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -335,6 +335,7 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
   - H3: Discord opens a blank page or reports blocked:csp
   - H3: “Not authorized”
   - H3: “Widget unavailable”
+  - H3: “You cannot launch Activities in this channel”
 
 ## channels/discord.md
 

--- a/extensions/discord/src/activities/discord-api.ts
+++ b/extensions/discord/src/activities/discord-api.ts
@@ -1,4 +1,3 @@
-import fs from "node:fs/promises";
 import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 
@@ -93,23 +92,4 @@ export async function resolveActivityInstanceChannel(params: {
   }
   const channelId = (result.body.location as Record<string, unknown>).channel_id;
   return typeof channelId === "string" && /^\d+$/.test(channelId) ? channelId : undefined;
-}
-
-// Source layout nests this file under src/activities/; the bundled dist flattens the
-// plugin next to its assets dir. Try both so the asset resolves in either layout.
-const VENDOR_ASSET_CANDIDATE_RELATIVE_PATHS = [
-  "../../assets/embedded-app-sdk.mjs",
-  "./assets/embedded-app-sdk.mjs",
-] as const;
-
-export async function defaultReadVendorAsset(): Promise<Buffer> {
-  let lastError: unknown;
-  for (const relativePath of VENDOR_ASSET_CANDIDATE_RELATIVE_PATHS) {
-    try {
-      return await fs.readFile(new URL(relativePath, import.meta.url));
-    } catch (error) {
-      lastError = error;
-    }
-  }
-  throw lastError instanceof Error ? lastError : new Error("embedded-app-sdk asset missing");
 }

--- a/extensions/discord/src/activities/http.test.ts
+++ b/extensions/discord/src/activities/http.test.ts
@@ -1,5 +1,8 @@
+import fs from "node:fs/promises";
 import { createServer, type Server } from "node:http";
 import type { AddressInfo } from "node:net";
+import os from "node:os";
+import path from "node:path";
 import type { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { buildDiscordActivityCustomId } from "../component-custom-id.js";
@@ -31,10 +34,16 @@ async function startServer(
   options: {
     fetchGuard?: typeof fetchWithSsrFGuard;
     now?: () => number;
-    readVendorAsset?: () => Promise<Buffer>;
+    vendorAssetPath?: string;
+    readVendorAsset?: (assetPath: string) => Promise<Buffer>;
   } = {},
 ): Promise<string> {
-  const route = createDiscordActivityHttpHandler({ runtime, ...options });
+  const route = createDiscordActivityHttpHandler({
+    runtime,
+    ...options,
+    vendorAssetPath:
+      options.vendorAssetPath ?? path.join(os.tmpdir(), "missing-discord-activity-sdk.mjs"),
+  });
   const server = createServer((req, res) => {
     void route.handleHttpRequest(req, res).then((handled) => {
       if (!handled) {
@@ -577,6 +586,29 @@ describe("Discord Activity widget routes", () => {
 });
 
 describe("Discord Activity shell assets", () => {
+  it("serves the generated SDK from a dist plugin root", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-discord-activity-dist-"));
+    const vendorAssetPath = path.join(
+      root,
+      "dist",
+      "extensions",
+      "discord",
+      "assets",
+      "embedded-app-sdk.mjs",
+    );
+    try {
+      await fs.mkdir(path.dirname(vendorAssetPath), { recursive: true });
+      await fs.writeFile(vendorAssetPath, "export class DiscordSDK {}\n");
+      const base = await startServer(createActivityTestRuntime(), { vendorAssetPath });
+
+      const vendor = await fetch(`${base}/discord/activity/vendor/embedded-app-sdk.mjs`);
+      expect(vendor.status).toBe(200);
+      await expect(vendor.text()).resolves.toContain("DiscordSDK");
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
   it("serves the shell, module, and generated SDK asset", async () => {
     // The SDK bundle is a gitignored build artifact absent from synced checkouts, so
     // the vendor read is injected; generation is covered by bundled-plugin-assets tests.
@@ -606,5 +638,20 @@ describe("Discord Activity shell assets", () => {
     });
     const vendor = await fetch(`${base}/discord/activity/vendor/embedded-app-sdk.mjs`);
     expect(vendor.status).toBe(404);
+  });
+
+  it("retries the vendor asset read after a transient failure", async () => {
+    const readVendorAsset = vi
+      .fn<(assetPath: string) => Promise<Buffer>>()
+      .mockRejectedValueOnce(new Error("transient read failure"))
+      .mockResolvedValue(Buffer.from("export class DiscordSDK {}\n"));
+    const base = await startServer(createActivityTestRuntime(), { readVendorAsset });
+
+    const first = await fetch(`${base}/discord/activity/vendor/embedded-app-sdk.mjs`);
+    expect(first.status).toBe(404);
+    const second = await fetch(`${base}/discord/activity/vendor/embedded-app-sdk.mjs`);
+    expect(second.status).toBe(200);
+    await expect(second.text()).resolves.toContain("DiscordSDK");
+    expect(readVendorAsset).toHaveBeenCalledTimes(2);
   });
 });

--- a/extensions/discord/src/activities/http.ts
+++ b/extensions/discord/src/activities/http.ts
@@ -1,9 +1,9 @@
+import fs from "node:fs/promises";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { resolveRequestClientIp } from "openclaw/plugin-sdk/webhook-ingress";
 import { parseDiscordActivityCustomId } from "../component-custom-id.js";
 import { resolveActivityUserAuthorized } from "./allowlist.js";
 import {
-  defaultReadVendorAsset,
   DISCORD_TOKEN_URL,
   DISCORD_USER_URL,
   fetchDiscordJson,
@@ -34,9 +34,10 @@ const DISCORD_ACTIVITY_WIDGET_CSP =
 
 type DiscordActivityHttpDeps = {
   runtime: DiscordActivitiesRuntime;
+  vendorAssetPath: string;
   fetchGuard?: FetchGuard;
   now?: () => number;
-  readVendorAsset?: () => Promise<Buffer>;
+  readVendorAsset?: (assetPath: string) => Promise<Buffer>;
 };
 
 type DiscordOauthUser = {
@@ -142,7 +143,7 @@ export function createDiscordActivityHttpHandler(deps: DiscordActivityHttpDeps):
 } {
   const fetchGuard = deps.fetchGuard ?? fetchWithSsrFGuard;
   const limiter = new TokenRateLimiter(deps.now ?? Date.now);
-  const readVendorAsset = deps.readVendorAsset ?? defaultReadVendorAsset;
+  const readVendorAsset = deps.readVendorAsset ?? ((assetPath: string) => fs.readFile(assetPath));
   let vendorAsset: Promise<Buffer> | undefined;
 
   async function handleToken(req: IncomingMessage, res: ServerResponse): Promise<true> {
@@ -335,10 +336,14 @@ export function createDiscordActivityHttpHandler(deps: DiscordActivityHttpDeps):
         return respond(res, 200, DISCORD_ACTIVITY_SHELL_JS, "text/javascript; charset=utf-8");
       }
       if (req.method === "GET" && relative === "/vendor/embedded-app-sdk.mjs") {
+        const pendingAsset = (vendorAsset ??= readVendorAsset(deps.vendorAssetPath));
         try {
-          vendorAsset ??= readVendorAsset();
-          return respond(res, 200, await vendorAsset, "text/javascript; charset=utf-8");
+          return respond(res, 200, await pendingAsset, "text/javascript; charset=utf-8");
         } catch {
+          // Clear only the failed read. A later request may already have installed a retry.
+          if (vendorAsset === pendingAsset) {
+            vendorAsset = undefined;
+          }
           return notFound(res);
         }
       }

--- a/extensions/discord/src/activities/register.test.ts
+++ b/extensions/discord/src/activities/register.test.ts
@@ -13,6 +13,7 @@ function createApi(config: Record<string, unknown>) {
   const routes: unknown[] = [];
   const tools: unknown[] = [];
   const warn = vi.fn();
+  const resolvePath = vi.fn((input: string) => `/plugin-root/${input}`);
   const api = {
     config,
     logger: { warn },
@@ -22,8 +23,9 @@ function createApi(config: Record<string, unknown>) {
     },
     registerHttpRoute: vi.fn((route) => routes.push(route)),
     registerTool: vi.fn((tool) => tools.push(tool)),
+    resolvePath,
   } as unknown as OpenClawPluginApi;
-  return { api, routes, tools, warn };
+  return { api, routes, tools, warn, resolvePath };
 }
 
 describe("Discord Activities registration", () => {
@@ -78,6 +80,7 @@ describe("Discord Activities registration", () => {
       auth: "plugin",
       match: "prefix",
     });
+    expect(test.resolvePath).toHaveBeenCalledWith("assets/embedded-app-sdk.mjs");
     expect(test.tools).toHaveLength(1);
     const factory = test.tools[0] as (context: { messageChannel?: string }) => unknown;
     expect(factory({ messageChannel: "slack" })).toBeNull();

--- a/extensions/discord/src/activities/register.ts
+++ b/extensions/discord/src/activities/register.ts
@@ -48,7 +48,10 @@ export function registerDiscordActivities(api: OpenClawPluginApi): void {
       : undefined,
   );
   setDiscordActivitiesRuntime(runtime);
-  const http = createDiscordActivityHttpHandler({ runtime });
+  const http = createDiscordActivityHttpHandler({
+    runtime,
+    vendorAssetPath: api.resolvePath("assets/embedded-app-sdk.mjs"),
+  });
   api.registerHttpRoute({
     path: DISCORD_ACTIVITY_ROUTE_PREFIX,
     auth: "plugin",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users opening a Discord Activity from a packaged OpenClaw gateway could remain stuck on “Connecting to Discord…” because the embedded SDK route returned 404. A transient SDK read failure could also keep returning 404 until the gateway restarted.

## Why This Change Was Made

The Activity route now resolves its SDK asset through the loaded Discord plugin root, matching the package manifest's static-asset contract in built distributions. Failed reads clear only their own cached promise, allowing the next request to retry safely. The Discord Activities troubleshooting guide also records the forum-post launch restriction.

## User Impact

Discord Activities can load their embedded SDK from packaged core distributions without a manual asset copy. Temporary filesystem failures recover on a later request without a gateway restart. Operators also get clear guidance when Discord rejects launches from forum-post threads.

## Evidence

- Production `pnpm build` passed on Blacksmith Testbox and emitted `dist/extensions/discord/assets/embedded-app-sdk.mjs`; built root chunks contain neither retired chunk-relative lookup.
- Focused Discord Activities suite: 2 files, 26 tests passed, including dist-like serving and rejection-then-retry coverage.
- `pnpm check:changed` passed: extension production/test typechecks, lint (0 warnings/errors), boundaries, generated baselines, storage and import-cycle guards.
- `pnpm check:docs` passed: formatting, Markdown lint, MDX, glossary, links (0 broken), generated docs map.
- Two Codex autoreview passes reported no accepted/actionable findings; final confidence 0.95.
- AI-assisted with Codex; behavior and generated artifact validated against a separate black-box contract.