### PR TITLE
fix(thread-ownership): bound conflict response bodies

### DIFF
--- a/extensions/thread-ownership/index.test.ts
+++ b/extensions/thread-ownership/index.test.ts
@@ -1,4 +1,5 @@
 // Thread Ownership tests cover index plugin behavior.
+import http from "node:http";
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawPluginApi } from "./api.js";
@@ -49,6 +50,28 @@ describe("thread-ownership plugin", () => {
       throw new Error(`expected ${label}`);
     }
     return call[0];
+  }
+
+  async function withLocalOwnershipServer<T>(
+    handler: http.RequestListener,
+    run: (url: string) => Promise<T>,
+  ): Promise<T> {
+    const server = http.createServer(handler);
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(0, "127.0.0.1", () => resolve());
+    });
+    try {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("expected TCP server address");
+      }
+      return await run(`http://127.0.0.1:${address.port}`);
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
   }
 
   beforeEach(() => {
@@ -280,6 +303,34 @@ describe("thread-ownership plugin", () => {
       expect(result).toBeUndefined();
       const warningMessage = requireFirstLogMessage(api.logger.warn, "ownership check warning log");
       expect(warningMessage).toContain("ownership check failed");
+    });
+
+    it("fails open when a conflict response body exceeds the ownership error cap", async () => {
+      vi.unstubAllGlobals();
+      await withLocalOwnershipServer(
+        (_req, res) => {
+          res.writeHead(409, { "content-type": "application/json" });
+          res.end(JSON.stringify({ owner: "oversized-owner".repeat(8192) }));
+        },
+        async (forwarderUrl) => {
+          process.env.SLACK_FORWARDER_URL = forwarderUrl;
+          const result = await sendSlackThreadMessage();
+          const infoMessage = vi.mocked(api.logger.info).mock.calls[0]?.[0] ?? "";
+          const warningMessage = vi.mocked(api.logger.warn).mock.calls[0]?.[0] ?? "";
+          console.log(
+            `[thread-ownership oversized conflict proof] result=${JSON.stringify(
+              result,
+            )} info_bytes=${Buffer.byteLength(String(infoMessage), "utf8")} warn=${String(
+              warningMessage,
+            )}`,
+          );
+
+          expect(result).toBeUndefined();
+          expect(api.logger.info).not.toHaveBeenCalled();
+          expect(warningMessage).toContain("ownership check failed");
+          expect(warningMessage).toContain("exceeds");
+        },
+      );
     });
   });
 

--- a/extensions/thread-ownership/index.test.ts
+++ b/extensions/thread-ownership/index.test.ts
@@ -305,7 +305,7 @@ describe("thread-ownership plugin", () => {
       expect(warningMessage).toContain("ownership check failed");
     });
 
-    it("fails open when a conflict response body exceeds the ownership error cap", async () => {
+    it("cancels when a conflict response body exceeds the ownership error cap", async () => {
       vi.unstubAllGlobals();
       await withLocalOwnershipServer(
         (_req, res) => {
@@ -325,10 +325,9 @@ describe("thread-ownership plugin", () => {
             )}`,
           );
 
-          expect(result).toBeUndefined();
-          expect(api.logger.info).not.toHaveBeenCalled();
-          expect(warningMessage).toContain("ownership check failed");
-          expect(warningMessage).toContain("exceeds");
+          expect(result).toEqual({ cancel: true });
+          expect(api.logger.info).toHaveBeenCalled();
+          expect(warningMessage).toContain("conflict response unreadable");
         },
       );
     });

--- a/extensions/thread-ownership/index.ts
+++ b/extensions/thread-ownership/index.ts
@@ -70,6 +70,17 @@ async function readOwnershipConflictOwner(response: Response): Promise<string | 
   return typeof body.owner === "string" ? body.owner : undefined;
 }
 
+function logOwnershipConflictOwner(
+  api: OpenClawPluginApi,
+  channelId: string,
+  threadTs: string,
+  owner: string | undefined,
+): void {
+  api.logger.info?.(
+    `thread-ownership: cancelled send to ${channelId}:${threadTs} — owned by ${owner}`,
+  );
+}
+
 function resolveOwnershipAgent(config: OpenClawConfig): { id: string; name: string } {
   const list = Array.isArray(config.agents?.list)
     ? config.agents.list.filter(
@@ -200,10 +211,15 @@ export default definePluginEntry({
             return undefined;
           }
           if (resp.status === 409) {
-            const owner = await readOwnershipConflictOwner(resp);
-            api.logger.info?.(
-              `thread-ownership: cancelled send to ${channelId}:${threadTs} — owned by ${owner}`,
-            );
+            let owner: string | undefined;
+            try {
+              owner = await readOwnershipConflictOwner(resp);
+            } catch (error) {
+              api.logger.warn?.(
+                `thread-ownership: conflict response unreadable (${String(error)}), keeping cancellation`,
+              );
+            }
+            logOwnershipConflictOwner(api, channelId, threadTs, owner);
             return { cancel: true };
           }
           api.logger.warn?.(`thread-ownership: unexpected status ${resp.status}, allowing send`);

--- a/extensions/thread-ownership/index.ts
+++ b/extensions/thread-ownership/index.ts
@@ -1,5 +1,6 @@
 // Thread Ownership plugin entrypoint registers its OpenClaw integration.
 import { resolveLivePluginConfigObject } from "openclaw/plugin-sdk/plugin-config-runtime";
+import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { escapeRegExp } from "openclaw/plugin-sdk/text-utility-runtime";
 import {
@@ -22,6 +23,7 @@ type ThreadOwnershipMessageSendingResult = { cancel: true } | undefined;
 // Entries expire after 5 minutes.
 const mentionedThreads = new Map<string, number>();
 const MENTION_TTL_MS = 5 * 60 * 1000;
+const OWNERSHIP_CONFLICT_BODY_MAX_BYTES = 64 * 1024;
 
 function isThreadOwnershipConfig(value: unknown): value is ThreadOwnershipConfig {
   return value !== null && typeof value === "object";
@@ -57,6 +59,15 @@ function containsAgentNameMention(text: string, agentName: string): boolean {
     return false;
   }
   return new RegExp(`(^|[^\\w])@${escapeRegExp(trimmedName)}(?=$|[^\\w])`, "i").test(text);
+}
+
+async function readOwnershipConflictOwner(response: Response): Promise<string | undefined> {
+  const bytes = await readResponseWithLimit(response, OWNERSHIP_CONFLICT_BODY_MAX_BYTES, {
+    onOverflow: ({ maxBytes }) =>
+      new Error(`thread-ownership conflict response exceeds ${maxBytes} bytes`),
+  });
+  const body = JSON.parse(new TextDecoder().decode(bytes)) as { owner?: unknown };
+  return typeof body.owner === "string" ? body.owner : undefined;
 }
 
 function resolveOwnershipAgent(config: OpenClawConfig): { id: string; name: string } {
@@ -189,9 +200,9 @@ export default definePluginEntry({
             return undefined;
           }
           if (resp.status === 409) {
-            const body = (await resp.json()) as { owner?: string };
+            const owner = await readOwnershipConflictOwner(resp);
             api.logger.info?.(
-              `thread-ownership: cancelled send to ${channelId}:${threadTs} — owned by ${body.owner}`,
+              `thread-ownership: cancelled send to ${channelId}:${threadTs} — owned by ${owner}`,
             );
             return { cancel: true };
           }


### PR DESCRIPTION
## What Problem This Solves
Fixes a Slack thread-ownership failure where a 409 conflict response with a large JSON body could be read without any size cap before logging the owner.

## Why This Change Was Made
The ownership check now reads conflict bodies through the shared bounded response reader instead of unbounded `resp.json()`. The HTTP 409 status remains authoritative: even if the conflict body is oversized or unreadable, the Slack send is still canceled and only owner logging is degraded.

## User Impact
Slack thread replies stay protected by the ownership service even if the service misbehaves with an oversized conflict payload. Normal 409 ownership responses still cancel cleanly, and oversized 409 responses now cancel without buffering the full body.

## Evidence
Before the original fix:
```text
PATH=/usr/local/node24150/bin:$PATH node scripts/run-vitest.mjs extensions/thread-ownership/index.test.ts -- --testNamePattern 'fails open when a conflict response body exceeds the ownership error cap'
[thread-ownership oversized conflict proof] result={"cancel":true} info_bytes=122944 warn=
AssertionError: expected { cancel: true } to be undefined
```

After reviewer follow-up fix for authoritative 409 cancellation:
```text
PATH=/usr/local/node24150/bin:$PATH node scripts/run-vitest.mjs extensions/thread-ownership/index.test.ts -- --testNamePattern 'cancels when a conflict response body exceeds the ownership error cap'
Test Files  1 passed (1)
Tests  1 passed | 21 skipped (22)
[test] passed 1 Vitest shard in 10.26s
```

Full focused validation:
```text
PATH=/usr/local/node24150/bin:$PATH node scripts/run-vitest.mjs extensions/thread-ownership/index.test.ts
Test Files  1 passed (1)
Tests  22 passed (22)
[test] passed 1 Vitest shard in 12.42s
```

Validation:
- `git diff --check`
- `autoreview --mode uncommitted` attempted, but the codex engine failed in the review tool runtime (`codex engine failed (1)`).
