### PR TITLE
refactor(web): narrow runtime context results

### DIFF
--- a/src/agents/tools/web-tool-runtime-context.ts
+++ b/src/agents/tools/web-tool-runtime-context.ts
@@ -88,9 +88,7 @@ export function resolveWebSearchToolRuntimeContext(params: {
   config?: OpenClawConfig;
   lateBindRuntimeConfig?: boolean;
   runtimeWebSearch?: RuntimeWebSearchMetadata;
-}): ResolvedWebToolRuntimeContext<RuntimeWebSearchMetadata> & {
-  runtimeWebSearch?: RuntimeWebSearchMetadata;
-} {
+}) {
   const resolved = resolveWebToolRuntimeContext({
     capturedConfig: params.config,
     capturedRuntimeMetadata: params.runtimeWebSearch,
@@ -100,7 +98,6 @@ export function resolveWebSearchToolRuntimeContext(params: {
   return {
     config: resolved.config,
     preferRuntimeProviders: resolved.preferRuntimeProviders,
-    runtimeMetadata: resolved.runtimeMetadata,
     runtimeWebSearch: resolved.runtimeMetadata,
   };
 }
@@ -110,9 +107,7 @@ export function resolveWebFetchToolRuntimeContext(params: {
   config?: OpenClawConfig;
   lateBindRuntimeConfig?: boolean;
   runtimeWebFetch?: RuntimeWebFetchMetadata;
-}): ResolvedWebToolRuntimeContext<RuntimeWebFetchMetadata> & {
-  runtimeWebFetch?: RuntimeWebFetchMetadata;
-} {
+}) {
   const resolved = resolveWebToolRuntimeContext({
     capturedConfig: params.config,
     capturedRuntimeMetadata: params.runtimeWebFetch,
@@ -122,7 +117,6 @@ export function resolveWebFetchToolRuntimeContext(params: {
   return {
     config: resolved.config,
     preferRuntimeProviders: resolved.preferRuntimeProviders,
-    runtimeMetadata: resolved.runtimeMetadata,
     runtimeWebFetch: resolved.runtimeMetadata,
   };
 }


### PR DESCRIPTION
Related: #108598

## What Problem This Solves

The runtime-context cleanup behind #108636 left each specialized web-tool resolver returning the same metadata twice: once through a generic `runtimeMetadata` property and again through `runtimeWebSearch` or `runtimeWebFetch`.

## Why This Change Was Made

Return only the provider-specific metadata property and let TypeScript infer the narrower internal result shape. This deletes a redundant alias without changing provider selection or late-bound runtime behavior.

## User Impact

No user-visible behavior change. This keeps the internal web-tool context contract smaller and makes generic metadata access impossible at the specialized call sites.

## Evidence

- Blacksmith Testbox `tbx_01kxmwqkmve40558snqrp31w25`: 25 focused search, fetch, context, and cron tests passed ([run](https://github.com/openclaw/openclaw/actions/runs/29479556437)).
- Remote `pnpm check:changed`: passed, including core/core-test typechecks, formatting, lint, boundary guards, and cycle checks.
- Fresh branch autoreview: clean, no accepted/actionable findings (0.93 confidence).
- `git diff --check`: passed.

AI-assisted: Codex. Maintainer-requested refactor follow-up to #108636.
