### PR TITLE
fix(ui): skip expensive usage refetch on pure websocket reconnect

### DIFF
--- a/ui/src/lib/usage-reconnect-refresh.test.ts
+++ b/ui/src/lib/usage-reconnect-refresh.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import {
+  USAGE_RECONNECT_STALE_MS,
+  shouldRefreshUsageOnReconnect,
+} from "./usage-reconnect-refresh.ts";
+
+describe("shouldRefreshUsageOnReconnect", () => {
+  const base = {
+    loadedAtMs: 1_000_000,
+    nowMs: 1_000_000,
+    visible: true,
+  };
+
+  it("loads when no retained usage/cost data is available", () => {
+    expect(
+      shouldRefreshUsageOnReconnect({
+        ...base,
+        hasRetainedData: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("loads when retained data exists but has no load timestamp", () => {
+    expect(
+      shouldRefreshUsageOnReconnect({
+        ...base,
+        hasRetainedData: true,
+        loadedAtMs: null,
+      }),
+    ).toBe(true);
+  });
+
+  it("reuses fresh retained data on reconnect", () => {
+    expect(
+      shouldRefreshUsageOnReconnect({
+        ...base,
+        hasRetainedData: true,
+        nowMs: base.loadedAtMs! + USAGE_RECONNECT_STALE_MS - 1,
+        visible: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("refreshes stale retained data only when the document is visible", () => {
+    expect(
+      shouldRefreshUsageOnReconnect({
+        ...base,
+        hasRetainedData: true,
+        nowMs: base.loadedAtMs! + USAGE_RECONNECT_STALE_MS,
+        visible: true,
+      }),
+    ).toBe(true);
+    expect(
+      shouldRefreshUsageOnReconnect({
+        ...base,
+        hasRetainedData: true,
+        nowMs: base.loadedAtMs! + USAGE_RECONNECT_STALE_MS,
+        visible: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("honors a custom stale window", () => {
+    expect(
+      shouldRefreshUsageOnReconnect({
+        ...base,
+        hasRetainedData: true,
+        nowMs: base.loadedAtMs! + 1_000,
+        visible: true,
+        staleMs: 500,
+      }),
+    ).toBe(true);
+  });
+});

--- a/ui/src/lib/usage-reconnect-refresh.test.ts
+++ b/ui/src/lib/usage-reconnect-refresh.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it } from "vitest";
 import {
-  USAGE_RECONNECT_STALE_MS,
   shouldRefreshUsageOnReconnect,
+  shouldRefreshUsageOnVisibilityResume,
 } from "./usage-reconnect-refresh.ts";
+
+/** Matches the default stale window in usage-reconnect-refresh.ts. */
+const USAGE_RECONNECT_STALE_MS = 5 * 60 * 1000;
 
 describe("shouldRefreshUsageOnReconnect", () => {
   const base = {
@@ -68,6 +71,42 @@ describe("shouldRefreshUsageOnReconnect", () => {
         nowMs: base.loadedAtMs! + 1_000,
         visible: true,
         staleMs: 500,
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("shouldRefreshUsageOnVisibilityResume", () => {
+  const base = {
+    loadedAtMs: 1_000_000,
+    nowMs: 1_000_000,
+  };
+
+  it("loads when no retained usage/cost data is available", () => {
+    expect(
+      shouldRefreshUsageOnVisibilityResume({
+        ...base,
+        hasRetainedData: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("reuses fresh retained data when the tab becomes visible", () => {
+    expect(
+      shouldRefreshUsageOnVisibilityResume({
+        ...base,
+        hasRetainedData: true,
+        nowMs: base.loadedAtMs! + USAGE_RECONNECT_STALE_MS - 1,
+      }),
+    ).toBe(false);
+  });
+
+  it("refreshes stale retained data when the tab becomes visible", () => {
+    expect(
+      shouldRefreshUsageOnVisibilityResume({
+        ...base,
+        hasRetainedData: true,
+        nowMs: base.loadedAtMs! + USAGE_RECONNECT_STALE_MS,
       }),
     ).toBe(true);
   });

--- a/ui/src/lib/usage-reconnect-refresh.ts
+++ b/ui/src/lib/usage-reconnect-refresh.ts
@@ -5,17 +5,26 @@
  *
  * Refresh on reconnect only when there is no retained payload yet, or when the
  * retained payload is past the stale window and the document is visible.
- * Explicit operator refresh always bypasses this policy.
+ * If reconnect skips while hidden, visibility-resume reevaluates the same
+ * freshness policy once the tab is visible again so stale values are not kept
+ * indefinitely. Explicit operator refresh always bypasses this policy.
  */
 
 /** Default TTL for reconnect-time auto-refresh of usage/cost payloads. */
-export const USAGE_RECONNECT_STALE_MS = 5 * 60 * 1000;
+const USAGE_RECONNECT_STALE_MS = 5 * 60 * 1000;
 
-export type UsageReconnectRefreshInput = {
+type UsageReconnectRefreshInput = {
   hasRetainedData: boolean;
   loadedAtMs: number | null;
   nowMs: number;
   visible: boolean;
+  staleMs?: number;
+};
+
+type UsageVisibilityResumeInput = {
+  hasRetainedData: boolean;
+  loadedAtMs: number | null;
+  nowMs: number;
   staleMs?: number;
 };
 
@@ -30,6 +39,15 @@ export function shouldRefreshUsageOnReconnect(input: UsageReconnectRefreshInput)
   const staleMs = input.staleMs ?? USAGE_RECONNECT_STALE_MS;
   const stale = input.nowMs - input.loadedAtMs >= staleMs;
   return stale && input.visible;
+}
+
+/**
+ * Decide whether becoming visible should re-fetch usage/cost data.
+ * Shared with Usage and Profile: complements reconnect suppression so a stale
+ * payload skipped while hidden is refreshed on the next visible resume.
+ */
+export function shouldRefreshUsageOnVisibilityResume(input: UsageVisibilityResumeInput): boolean {
+  return shouldRefreshUsageOnReconnect({ ...input, visible: true });
 }
 
 export function isDocumentVisible(): boolean {

--- a/ui/src/lib/usage-reconnect-refresh.ts
+++ b/ui/src/lib/usage-reconnect-refresh.ts
@@ -1,0 +1,37 @@
+/**
+ * Control UI usage/cost loads are expensive on the gateway. After a transient
+ * websocket drop, reconnect rehydration should reuse already-loaded data
+ * instead of reissuing sessions.usage + usage.cost on every connect.
+ *
+ * Refresh on reconnect only when there is no retained payload yet, or when the
+ * retained payload is past the stale window and the document is visible.
+ * Explicit operator refresh always bypasses this policy.
+ */
+
+/** Default TTL for reconnect-time auto-refresh of usage/cost payloads. */
+export const USAGE_RECONNECT_STALE_MS = 5 * 60 * 1000;
+
+export type UsageReconnectRefreshInput = {
+  hasRetainedData: boolean;
+  loadedAtMs: number | null;
+  nowMs: number;
+  visible: boolean;
+  staleMs?: number;
+};
+
+/**
+ * Decide whether a gateway reconnect should re-fetch usage/cost data.
+ * Client identity changes still force a full reset/load outside this helper.
+ */
+export function shouldRefreshUsageOnReconnect(input: UsageReconnectRefreshInput): boolean {
+  if (!input.hasRetainedData || input.loadedAtMs == null) {
+    return true;
+  }
+  const staleMs = input.staleMs ?? USAGE_RECONNECT_STALE_MS;
+  const stale = input.nowMs - input.loadedAtMs >= staleMs;
+  return stale && input.visible;
+}
+
+export function isDocumentVisible(): boolean {
+  return typeof document === "undefined" || document.visibilityState === "visible";
+}

--- a/ui/src/pages/profile/profile-page.ts
+++ b/ui/src/pages/profile/profile-page.ts
@@ -28,6 +28,7 @@ import { buildSessionUsageDateParams, requestSessionsUsage } from "../../lib/ses
 import {
   isDocumentVisible,
   shouldRefreshUsageOnReconnect,
+  shouldRefreshUsageOnVisibilityResume,
 } from "../../lib/usage-reconnect-refresh.ts";
 import { OpenClawLightDomElement } from "../../lit/openclaw-element.ts";
 import "../../styles/profile.css";
@@ -113,9 +114,25 @@ export class ProfilePage extends OpenClawLightDomElement {
   /** Wall time of the last retained profile usage/cost payload. */
   private profileLoadedAtMs: number | null = null;
   private subscriptions: Array<() => void> = [];
+  private readonly handleVisibilityChange = () => {
+    // Reconnect may skip a stale refresh while hidden; reevaluate on resume.
+    if (!isDocumentVisible() || !this.connected || !this.client) {
+      return;
+    }
+    if (
+      shouldRefreshUsageOnVisibilityResume({
+        hasRetainedData: Boolean(this.costSummary || this.sessionsResult || this.error),
+        loadedAtMs: this.profileLoadedAtMs,
+        nowMs: Date.now(),
+      })
+    ) {
+      void this.loadProfile();
+    }
+  };
 
   override connectedCallback() {
     super.connectedCallback();
+    document.addEventListener("visibilitychange", this.handleVisibilityChange);
     this.subscriptions = [
       this.context.gateway.subscribe((snapshot) => this.applyGatewaySnapshot(snapshot)),
       this.context.agents.subscribe(() => this.requestUpdate()),
@@ -125,6 +142,7 @@ export class ProfilePage extends OpenClawLightDomElement {
   }
 
   override disconnectedCallback() {
+    document.removeEventListener("visibilitychange", this.handleVisibilityChange);
     for (const unsubscribe of this.subscriptions) {
       unsubscribe();
     }

--- a/ui/src/pages/profile/profile-page.ts
+++ b/ui/src/pages/profile/profile-page.ts
@@ -25,6 +25,10 @@ import {
   isMissingOperatorReadScopeError,
 } from "../../lib/gateway-errors.ts";
 import { buildSessionUsageDateParams, requestSessionsUsage } from "../../lib/sessions/index.ts";
+import {
+  isDocumentVisible,
+  shouldRefreshUsageOnReconnect,
+} from "../../lib/usage-reconnect-refresh.ts";
 import { OpenClawLightDomElement } from "../../lit/openclaw-element.ts";
 import "../../styles/profile.css";
 import {
@@ -106,6 +110,8 @@ export class ProfilePage extends OpenClawLightDomElement {
   private requestId = 0;
   private refreshTimer: number | null = null;
   private refreshAttempts = 0;
+  /** Wall time of the last retained profile usage/cost payload. */
+  private profileLoadedAtMs: number | null = null;
   private subscriptions: Array<() => void> = [];
 
   override connectedCallback() {
@@ -144,6 +150,7 @@ export class ProfilePage extends OpenClawLightDomElement {
       this.costSummary = null;
       this.sessionsResult = null;
       this.error = null;
+      this.profileLoadedAtMs = null;
     }
     if (!snapshot.connected || !snapshot.client) {
       this.requestId += 1;
@@ -156,7 +163,25 @@ export class ProfilePage extends OpenClawLightDomElement {
         void this.context.agentIdentity.ensure([list.defaultId]);
       }
     });
-    if (clientChanged || becameConnected || (!this.costSummary && !this.loading && !this.error)) {
+    // First connect / missing payload still loads. Pure reconnect reuses retained
+    // cost/usage unless stale and the tab is visible (same policy as Usage page).
+    if (clientChanged) {
+      void this.loadProfile();
+      return;
+    }
+    if (!this.costSummary && !this.loading && !this.error) {
+      void this.loadProfile();
+      return;
+    }
+    if (
+      becameConnected &&
+      shouldRefreshUsageOnReconnect({
+        hasRetainedData: Boolean(this.costSummary || this.sessionsResult || this.error),
+        loadedAtMs: this.profileLoadedAtMs,
+        nowMs: Date.now(),
+        visible: isDocumentVisible(),
+      })
+    ) {
       void this.loadProfile();
     }
   }
@@ -193,12 +218,14 @@ export class ProfilePage extends OpenClawLightDomElement {
       }
       this.costSummary = costSummary;
       this.sessionsResult = sessionsResult;
+      this.profileLoadedAtMs = Date.now();
       this.scheduleCacheSettleRefresh();
     } catch (error) {
       if (requestId !== this.requestId) {
         return;
       }
       this.error = toErrorMessage(error);
+      this.profileLoadedAtMs = Date.now();
     } finally {
       if (requestId === this.requestId) {
         this.loading = false;

--- a/ui/src/pages/usage/usage-page.ts
+++ b/ui/src/pages/usage/usage-page.ts
@@ -26,6 +26,10 @@ import {
   requestSessionUsageTimeSeries,
 } from "../../lib/sessions/index.ts";
 import { normalizeLowercaseStringOrEmpty } from "../../lib/string-coerce.ts";
+import {
+  isDocumentVisible,
+  shouldRefreshUsageOnReconnect,
+} from "../../lib/usage-reconnect-refresh.ts";
 import { OpenClawLightDomElement } from "../../lit/openclaw-element.ts";
 import { SubscriptionsController } from "../../lit/subscriptions-controller.ts";
 import { mergeUsageCacheStatus } from "./cache-status.ts";
@@ -117,6 +121,8 @@ class UsagePage extends OpenClawLightDomElement {
   private routeDataEnabled = true;
   private hasBoundGatewaySource = false;
   private observedAgentScopeId: string | null | undefined;
+  /** Wall time of the last retained usage/cost payload (route data or load). */
+  private usageLoadedAtMs: number | null = null;
   private readonly subscriptions = new SubscriptionsController(this)
     .effect(
       () => this.context?.gateway,
@@ -183,7 +189,25 @@ class UsagePage extends OpenClawLightDomElement {
     }
 
     void this.context.agents.ensureList();
-    if (this.routeDataInitialized && (clientChanged || becameConnected)) {
+    if (!this.routeDataInitialized) {
+      return;
+    }
+    // Client identity/source changes still force a full reload after reset.
+    // Pure reconnect reuses retained usage unless the payload is stale and the
+    // tab is visible — otherwise idle proxy drops re-scan the gateway every minute.
+    if (clientChanged) {
+      void this.loadUsage();
+      return;
+    }
+    if (
+      becameConnected &&
+      shouldRefreshUsageOnReconnect({
+        hasRetainedData: Boolean(this.usageResult || this.usageCostSummary || this.usageError),
+        loadedAtMs: this.usageLoadedAtMs,
+        nowMs: Date.now(),
+        visible: isDocumentVisible(),
+      })
+    ) {
       void this.loadUsage();
     }
   }
@@ -226,6 +250,9 @@ class UsagePage extends OpenClawLightDomElement {
     this.providerUsageSummary = data.providerUsageSummary;
     this.usageError = data.error;
     this.usageLoading = false;
+    if (data.result || data.costSummary || data.error) {
+      this.usageLoadedAtMs = Date.now();
+    }
   }
 
   private ensureInitialData() {
@@ -251,6 +278,7 @@ class UsagePage extends OpenClawLightDomElement {
     this.usageCostSummary = null;
     this.providerUsageSummary = null;
     this.usageError = null;
+    this.usageLoadedAtMs = null;
     this.usageAgentId = this.context.agentSelection.state.scopeId;
     this.clearSelectionsAndDetails();
   }
@@ -331,6 +359,7 @@ class UsagePage extends OpenClawLightDomElement {
       this.usageResult = sessionsResult;
       this.usageCostSummary = costSummary;
       this.providerUsageSummary = providerUsageSummary;
+      this.usageLoadedAtMs = Date.now();
     } catch (error) {
       if (!this.isCurrentRequest(requestId, client)) {
         return;
@@ -342,6 +371,7 @@ class UsagePage extends OpenClawLightDomElement {
       } else {
         this.usageError = toUsageErrorMessage(error);
       }
+      this.usageLoadedAtMs = Date.now();
     } finally {
       if (this.isCurrentRequest(requestId, client)) {
         this.usageLoading = false;

--- a/ui/src/pages/usage/usage-page.ts
+++ b/ui/src/pages/usage/usage-page.ts
@@ -29,6 +29,7 @@ import { normalizeLowercaseStringOrEmpty } from "../../lib/string-coerce.ts";
 import {
   isDocumentVisible,
   shouldRefreshUsageOnReconnect,
+  shouldRefreshUsageOnVisibilityResume,
 } from "../../lib/usage-reconnect-refresh.ts";
 import { OpenClawLightDomElement } from "../../lit/openclaw-element.ts";
 import { SubscriptionsController } from "../../lit/subscriptions-controller.ts";
@@ -123,6 +124,21 @@ class UsagePage extends OpenClawLightDomElement {
   private observedAgentScopeId: string | null | undefined;
   /** Wall time of the last retained usage/cost payload (route data or load). */
   private usageLoadedAtMs: number | null = null;
+  private readonly handleVisibilityChange = () => {
+    // Reconnect may skip a stale refresh while hidden; reevaluate on resume.
+    if (!isDocumentVisible() || !this.connected || !this.client || !this.routeDataInitialized) {
+      return;
+    }
+    if (
+      shouldRefreshUsageOnVisibilityResume({
+        hasRetainedData: Boolean(this.usageResult || this.usageCostSummary || this.usageError),
+        loadedAtMs: this.usageLoadedAtMs,
+        nowMs: Date.now(),
+      })
+    ) {
+      void this.loadUsage();
+    }
+  };
   private readonly subscriptions = new SubscriptionsController(this)
     .effect(
       () => this.context?.gateway,
@@ -157,6 +173,11 @@ class UsagePage extends OpenClawLightDomElement {
       (agents, notify) => agents.subscribe(notify),
     );
 
+  override connectedCallback() {
+    super.connectedCallback();
+    document.addEventListener("visibilitychange", this.handleVisibilityChange);
+  }
+
   override willUpdate(changed: PropertyValues<this>) {
     if (changed.has("routeData")) {
       this.applyRouteData();
@@ -165,6 +186,7 @@ class UsagePage extends OpenClawLightDomElement {
   }
 
   override disconnectedCallback() {
+    document.removeEventListener("visibilitychange", this.handleVisibilityChange);
     this.subscriptions.clear();
     this.clearDateDebounce();
     this.clearQueryDebounce();

--- a/ui/src/pages/usage/usage-reconnect.test.ts
+++ b/ui/src/pages/usage/usage-reconnect.test.ts
@@ -83,6 +83,7 @@ function createContext(gateway: ReturnType<typeof createMutableGateway>): Applic
 
 afterEach(() => {
   document.body.replaceChildren();
+  vi.useRealTimers();
   vi.restoreAllMocks();
 });
 
@@ -186,5 +187,77 @@ describe("usage page reconnect refresh policy", () => {
     await vi.waitFor(() => expect(request).toHaveBeenCalled());
     expect(request).toHaveBeenCalledWith("sessions.usage", expect.any(Object));
     expect(request).toHaveBeenCalledWith("usage.cost", expect.any(Object));
+  });
+
+  it("refreshes stale retained data on hidden-to-visible resume after reconnect skip", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-15T12:00:00.000Z"));
+    let visibilityState: DocumentVisibilityState = "visible";
+    vi.spyOn(document, "visibilityState", "get").mockImplementation(() => visibilityState);
+
+    const request = vi.fn(async (method: string) => {
+      if (method === "sessions.usage") {
+        return { sessions: [{ key: "live" }] };
+      }
+      if (method === "usage.cost") {
+        return { totals: { totalCost: 1 } };
+      }
+      if (method === "usage.status") {
+        return null;
+      }
+      return {};
+    });
+    const client = { request } as unknown as GatewayBrowserClient;
+    const gateway = createMutableGateway(client, true);
+    const context = createContext(gateway);
+    const retained = {
+      sessions: [{ key: "retained" }],
+    } as unknown as UsageRouteData["result"];
+    const page = document.createElement("openclaw-usage-page") as TestPage;
+    page.context = context;
+    page.render = () => nothing;
+    page.routeData = {
+      gateway: context.gateway,
+      gatewaySnapshot: gateway.snapshot,
+      query: {
+        startDate: "2026-07-15",
+        endDate: "2026-07-15",
+        scope: "family",
+        timeZone: "local",
+        agentId: null,
+      },
+      result: retained,
+      costSummary: { totals: { totalCost: 2 } } as unknown as UsageRouteData["costSummary"],
+      providerUsageSummary: null,
+      error: null,
+    };
+
+    document.body.append(page);
+    await page.updateComplete;
+    expect(page.usageResult).toBe(retained);
+    request.mockClear();
+
+    // Payload ages past the five-minute stale window while the tab is hidden.
+    visibilityState = "hidden";
+    vi.setSystemTime(new Date("2026-07-15T12:06:00.000Z"));
+
+    // Same-client reconnect while hidden must not re-scan the gateway.
+    gateway.publish({ connected: false, reconnecting: true });
+    await page.updateComplete;
+    gateway.publish({ connected: true, reconnecting: false, client });
+    await page.updateComplete;
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(request).not.toHaveBeenCalled();
+    expect(page.usageResult).toBe(retained);
+
+    // Returning to the tab reevaluates freshness and refreshes stale data.
+    visibilityState = "visible";
+    document.dispatchEvent(new Event("visibilitychange"));
+    await vi.waitFor(() => expect(request).toHaveBeenCalled());
+    expect(request).toHaveBeenCalledWith("sessions.usage", expect.any(Object));
+    expect(request).toHaveBeenCalledWith("usage.cost", expect.any(Object));
+
+    vi.useRealTimers();
   });
 });

--- a/ui/src/pages/usage/usage-reconnect.test.ts
+++ b/ui/src/pages/usage/usage-reconnect.test.ts
@@ -1,0 +1,190 @@
+/* @vitest-environment jsdom */
+
+import { nothing } from "lit";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import type { ApplicationContext, ApplicationGatewaySnapshot } from "../../app/context.ts";
+import type { UsageRouteData } from "./usage-page.ts";
+import "./usage-page.ts";
+
+type TestPage = HTMLElement & {
+  context: ApplicationContext;
+  routeData?: UsageRouteData;
+  usageResult: UsageRouteData["result"];
+  usageCostSummary: UsageRouteData["costSummary"];
+  usageLoading: boolean;
+  render: () => unknown;
+  readonly updateComplete: Promise<boolean>;
+};
+
+function createMutableGateway(client: GatewayBrowserClient, connected: boolean) {
+  let snapshot: ApplicationGatewaySnapshot = {
+    client,
+    connected,
+    reconnecting: false,
+    hello: null,
+    assistantAgentId: null,
+    sessionKey: "main",
+    lastError: null,
+    lastErrorCode: null,
+  };
+  const listeners = new Set<(next: ApplicationGatewaySnapshot) => void>();
+  return {
+    get snapshot() {
+      return snapshot;
+    },
+    eventLog: [],
+    subscribe(listener: (next: ApplicationGatewaySnapshot) => void) {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+    subscribeEvents: () => () => undefined,
+    subscribeEventLog: () => () => undefined,
+    publish(next: Partial<ApplicationGatewaySnapshot>) {
+      snapshot = { ...snapshot, ...next };
+      for (const listener of listeners) {
+        listener(snapshot);
+      }
+    },
+  };
+}
+
+function createContext(gateway: ReturnType<typeof createMutableGateway>): ApplicationContext {
+  const subscribe = () => () => undefined;
+  return {
+    basePath: "",
+    gateway,
+    agents: {
+      state: { agentsList: null, agentsLoading: false, agentsError: null },
+      ensureList: vi.fn(async () => null),
+      subscribe,
+    },
+    agentIdentity: { get: () => undefined, ensure: vi.fn(async () => undefined), subscribe },
+    agentSelection: {
+      state: { selectedId: null, scopeId: null },
+      set: vi.fn(),
+      setScope: vi.fn(),
+      subscribe,
+    },
+    channels: { subscribe },
+    runtimeConfig: { state: { configSnapshot: null }, subscribe },
+    sessions: {
+      state: { result: null, loading: false },
+      list: vi.fn(async () => null),
+      subscribe,
+    },
+    workboard: { subscribe },
+    navigate: vi.fn(),
+    preload: vi.fn(async () => undefined),
+  } as unknown as ApplicationContext;
+}
+
+afterEach(() => {
+  document.body.replaceChildren();
+  vi.restoreAllMocks();
+});
+
+describe("usage page reconnect refresh policy", () => {
+  it("does not re-fetch sessions.usage or usage.cost on pure reconnect with fresh retained data", async () => {
+    const request = vi.fn(async (method: string) => {
+      if (method === "sessions.usage") {
+        return { sessions: [{ key: "live" }] };
+      }
+      if (method === "usage.cost") {
+        return { totals: { totalCost: 1 } };
+      }
+      if (method === "usage.status") {
+        return null;
+      }
+      return {};
+    });
+    const client = { request } as unknown as GatewayBrowserClient;
+    const gateway = createMutableGateway(client, true);
+    const context = createContext(gateway);
+    const retained = {
+      sessions: [{ key: "retained" }],
+    } as unknown as UsageRouteData["result"];
+    const page = document.createElement("openclaw-usage-page") as TestPage;
+    page.context = context;
+    page.render = () => nothing;
+    page.routeData = {
+      gateway: context.gateway,
+      gatewaySnapshot: gateway.snapshot,
+      query: {
+        startDate: "2026-07-15",
+        endDate: "2026-07-15",
+        scope: "family",
+        timeZone: "local",
+        agentId: null,
+      },
+      result: retained,
+      costSummary: { totals: { totalCost: 2 } } as unknown as UsageRouteData["costSummary"],
+      providerUsageSummary: null,
+      error: null,
+    };
+
+    document.body.append(page);
+    await page.updateComplete;
+    expect(page.usageResult).toBe(retained);
+    request.mockClear();
+
+    // Transient drop keeps the same client identity (proxy idle timeout path).
+    gateway.publish({ connected: false, reconnecting: true });
+    await page.updateComplete;
+    gateway.publish({ connected: true, reconnecting: false, client });
+    await page.updateComplete;
+    // Allow any accidental async load to schedule.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(request).not.toHaveBeenCalled();
+    expect(page.usageResult).toBe(retained);
+  });
+
+  it("still loads usage on first connect when no retained data exists", async () => {
+    const request = vi.fn(async (method: string) => {
+      if (method === "sessions.usage") {
+        return { sessions: [{ key: "fresh" }] };
+      }
+      if (method === "usage.cost") {
+        return { totals: { totalCost: 3 } };
+      }
+      if (method === "usage.status") {
+        return null;
+      }
+      return {};
+    });
+    const client = { request } as unknown as GatewayBrowserClient;
+    const gateway = createMutableGateway(client, false);
+    const context = createContext(gateway);
+    const page = document.createElement("openclaw-usage-page") as TestPage;
+    page.context = context;
+    page.render = () => nothing;
+    page.routeData = {
+      gateway: context.gateway,
+      gatewaySnapshot: gateway.snapshot,
+      query: {
+        startDate: "2026-07-15",
+        endDate: "2026-07-15",
+        scope: "family",
+        timeZone: "local",
+        agentId: null,
+      },
+      result: null,
+      costSummary: null,
+      providerUsageSummary: null,
+      error: null,
+    };
+
+    document.body.append(page);
+    await page.updateComplete;
+    request.mockClear();
+
+    gateway.publish({ connected: true, client });
+    await vi.waitFor(() => expect(request).toHaveBeenCalled());
+    expect(request).toHaveBeenCalledWith("sessions.usage", expect.any(Object));
+    expect(request).toHaveBeenCalledWith("usage.cost", expect.any(Object));
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators leaving the Control UI **Usage** (or **Profile**) tab open behind a proxy with idle websocket timeouts would re-issue full `sessions.usage` + `usage.cost` requests on every reconnect. That created a per-minute scan loop, amplified gateway heap pressure, and could contribute to watchdog restarts / lost turns.

Closes #107917

## Why This Change Was Made

Keep first-load and explicit refresh behavior, but stop treating a pure websocket reconnect as a cold usage load. Retained usage/cost payloads are reused after reconnect; auto-refresh on reconnect runs only when the retained payload is past a 5-minute stale window **and** the document is visible. If reconnect skips while the tab is hidden, a shared visibility-resume path reevaluates the same freshness policy when the tab becomes visible again so stale Usage/Profile values are not kept indefinitely. Gateway client/source identity changes still reset and reload so a real gateway swap cannot show another host’s stats.

Fix quality: **compatibility** — no config/API changes; **performance** — removes accidental reconnect-triggered expensive RPCs; **usability** — manual refresh and first connect still work; **security** — no trust-boundary change.

## User Impact

Idle Control UI tabs no longer hammer the gateway with full usage scans after routine proxy disconnects. Operators still get fresh data on first open, after a real gateway client change, via explicit refresh, when retained data is stale while the tab is visible, or when returning to a tab that held stale data skipped during a hidden reconnect.

## Evidence

Verification host: local macOS (Crabbox bypass)

```text
node scripts/run-vitest.mjs \
  ui/src/lib/usage-reconnect-refresh.test.ts \
  ui/src/pages/usage/usage-reconnect.test.ts \
  ui/src/pages/profile/profile-page.test.ts
# 3 files, 12 tests passed

./node_modules/.bin/oxfmt <touched files>
./node_modules/.bin/oxlint ui/src/lib/usage-reconnect-refresh.ts \
  ui/src/pages/usage/usage-page.ts ui/src/pages/profile/profile-page.ts
# 0 warnings, 0 errors
git diff --check
```

Also addresses CI `check-dependencies` knip unused-export failures on the previous head (`USAGE_RECONNECT_STALE_MS` / `UsageReconnectRefreshInput`) by keeping those symbols module-local.

## Real behavior proof

- Behavior addressed: Control UI must not re-fetch full usage/cost on every pure websocket reconnect when retained data is still fresh, and must refresh stale retained data when a tab becomes visible after a reconnect that skipped while hidden.
- Environment: local macOS openclaw checkout; jsdom-focused Vitest for Control UI usage page + shared reconnect/visibility policy helper.
- Current-main contrast: `UsagePage.applyGatewaySnapshot` and `ProfilePage.applyGatewaySnapshot` treated `becameConnected` like a cold load and always called `loadUsage` / `loadProfile`, so idle proxy reconnect loops re-scanned the gateway. The reconnect-only skip also left no path to reevaluate stale data after a hidden reconnect.
- Exact steps or command run after this patch:
  1. Unit policy cases: `shouldRefreshUsageOnReconnect` for no-data / fresh / stale+visible / stale+hidden.
  2. Unit policy cases: `shouldRefreshUsageOnVisibilityResume` for missing / fresh / stale retained data.
  3. Page harness: mount Usage with retained route data, publish `connected:false` then `connected:true` with the same client, assert `client.request` is **not** called for `sessions.usage` / `usage.cost`.
  4. Page harness hidden-to-visible: age retained data past five minutes while `document.visibilityState` is `hidden`, reconnect same-client (no RPCs), then fire `visibilitychange` to visible and assert both usage RPCs run.
  5. Control: first connect with no retained data still issues both RPCs.
- Evidence after fix: focused Vitest output above (12/12 pass), including `refreshes stale retained data on hidden-to-visible resume after reconnect skip`.
- Control check: same-client reconnect path only; client/source replacement path still reloads after reset; manual refresh path unchanged; fresh retained data still not refreshed on mere visibility resume.
- Observed result after fix: pure reconnect reuses retained usage payload; first connect and explicit/stale-visible refresh still load; stale hidden reconnect is repaired on visibility resume.
- What was not tested: live Tailscale/proxy idle-drop against a production-sized session store (backend scan cost remains #107916); interactive browser recording of the Usage tab.

## AI disclosure

This PR was authored with AI assistance (Grok).