### PR TITLE
fix(cron): preserve same-id run history across stores

### DIFF
--- a/src/tasks/cron-history-retention.ts
+++ b/src/tasks/cron-history-retention.ts
@@ -1,4 +1,5 @@
 /** Enforces the task-ledger retention bound for terminal cron history. */
+import { cronTaskRecordStoreKey } from "../cron/task-run-detail.js";
 import type { TaskRecord } from "./task-registry.types.js";
 import { resolveEffectiveTaskCleanupAfter } from "./task-retention.js";
 
@@ -10,9 +11,9 @@ function isTerminalTask(task: TaskRecord): boolean {
 }
 
 export function collectCronHistoryOverflowTaskIds(tasks: readonly TaskRecord[]): Set<string> {
-  // sourceId is the ledger's global cron-job owner key; storeKey remains only
-  // a history-read partition and must not split the per-source retention cap.
-  const bySource = new Map<string, TaskRecord[]>();
+  // Cron job ids are unique only within a configured store. Retention must
+  // use the same storeKey/sourceId partition as history reads.
+  const byStore = new Map<string | undefined, Map<string, TaskRecord[]>>();
   for (const task of tasks) {
     if (
       task.runtime !== "cron" ||
@@ -22,19 +23,24 @@ export function collectCronHistoryOverflowTaskIds(tasks: readonly TaskRecord[]):
     ) {
       continue;
     }
+    const storeKey = cronTaskRecordStoreKey(task);
+    const bySource = byStore.get(storeKey) ?? new Map<string, TaskRecord[]>();
     const rows = bySource.get(task.sourceId) ?? [];
     rows.push(task);
     bySource.set(task.sourceId, rows);
+    byStore.set(storeKey, bySource);
   }
   const overflow = new Set<string>();
-  for (const rows of bySource.values()) {
-    rows.sort((left, right) => {
-      const leftAt = left.endedAt ?? left.lastEventAt ?? left.createdAt;
-      const rightAt = right.endedAt ?? right.lastEventAt ?? right.createdAt;
-      return rightAt - leftAt || right.taskId.localeCompare(left.taskId);
-    });
-    for (const task of rows.slice(CRON_HISTORY_KEEP_PER_JOB)) {
-      overflow.add(task.taskId);
+  for (const bySource of byStore.values()) {
+    for (const rows of bySource.values()) {
+      rows.sort((left, right) => {
+        const leftAt = left.endedAt ?? left.lastEventAt ?? left.createdAt;
+        const rightAt = right.endedAt ?? right.lastEventAt ?? right.createdAt;
+        return rightAt - leftAt || right.taskId.localeCompare(left.taskId);
+      });
+      for (const task of rows.slice(CRON_HISTORY_KEEP_PER_JOB)) {
+        overflow.add(task.taskId);
+      }
     }
   }
   return overflow;

--- a/src/tasks/task-registry.maintenance.issue-60299.test.ts
+++ b/src/tasks/task-registry.maintenance.issue-60299.test.ts
@@ -889,7 +889,7 @@ describe("task-registry maintenance issue #60299", () => {
     expect(hookNow).toBeGreaterThanOrEqual(beforeMaintenance);
   });
 
-  it("keeps the newest 2000 terminal cron rows per source", async () => {
+  it("keeps the newest 2000 terminal cron rows per store and source", async () => {
     const now = Date.now();
     const tasks = Array.from({ length: CRON_HISTORY_KEEP_PER_JOB + 1 }, (_, index) =>
       makeStaleTask({
@@ -921,6 +921,41 @@ describe("task-registry maintenance issue #60299", () => {
     expect(currentTasks.has("cron-history-0")).toBe(false);
     expect(currentTasks.has("cron-history-1")).toBe(true);
     expect(currentTasks.has(lostTask.taskId)).toBe(true);
+  });
+
+  it("scopes same-id cron history retention to each store", async () => {
+    const now = Date.now();
+    const storeATasks = Array.from({ length: CRON_HISTORY_KEEP_PER_JOB }, (_, index) =>
+      makeStaleTask({
+        taskId: `cron-store-a-${index}`,
+        runtime: "cron",
+        sourceId: "shared-job-id",
+        status: "succeeded",
+        endedAt: now + index + 2,
+        lastEventAt: now + index + 2,
+        cleanupAfter: 0,
+        detail: { storeKey: "store:a" },
+      }),
+    );
+    const storeBTask = makeStaleTask({
+      taskId: "cron-store-b-only-row",
+      runtime: "cron",
+      sourceId: "shared-job-id",
+      status: "succeeded",
+      endedAt: now + 1,
+      lastEventAt: now + 1,
+      cleanupAfter: 0,
+      detail: { storeKey: "store:b" },
+    });
+    const { currentTasks } = createTaskRegistryMaintenanceHarness({
+      tasks: [...storeATasks, storeBTask],
+    });
+
+    const result = await runTaskRegistryMaintenance();
+
+    expect(result.pruned).toBe(0);
+    expect(currentTasks.size).toBe(CRON_HISTORY_KEEP_PER_JOB + 1);
+    expect(currentTasks.has(storeBTask.taskId)).toBe(true);
   });
 
   it("still stamps non-cron terminal rows with default retention", async () => {


### PR DESCRIPTION
Closes #108427

## What Problem This Solves

Fixes an issue where operators using multiple cron stores could lose run history when jobs in different stores shared the same explicit job ID. A busy store could push the only history row from another store past the 2,000-row retention cap.

## Why This Change Was Made

Cron history reads already identify a job by both its normalized store key and job ID. Retention now uses that same partition instead of treating `sourceId` as globally unique. Rows without a recorded store key remain grouped together, preserving retention behavior for older detail-less records.

## User Impact

Each cron store now retains up to 2,000 terminal rows for its own job IDs. Activity in one configured store no longer deletes same-ID history belonging to another store.

## Evidence

- Regression red: the new maintenance test reported `pruned: 1` and removed the only row from the second store on the pre-fix implementation.
- Focused green: the original per-job cap test and new cross-store regression both pass.
- Affected suites: `src/tasks/task-registry.maintenance.issue-60299.test.ts` and `src/cron/task-run-history.test.ts` — 34 tests passed on Node 24.15.0.
- Additional review run: the full maintenance file — 27 tests passed.
- `git diff --check` passed.
- `oxlint` passed for both changed files.
- `codex review --base origin/main` found no concrete regression.

Not completed locally: repository-wide `check:changed` could not start because the dependency status check retried unavailable large optional platform packages; full `tsc` exceeded the default 4 GB heap and did not complete within the bounded 8 GB retry. The task-boundary test also hit the host's `EMFILE` limit during collection before executing tests. CI remains authoritative for those lanes.
