### PR TITLE
fix(codex): guard state-dependent registration for lightweight CLI runtime

### DIFF
--- a/extensions/codex/index.ts
+++ b/extensions/codex/index.ts
@@ -107,6 +107,12 @@ export default definePluginEntry({
     };
     const bindingStore = createLazyCodexAppServerBindingStore(lazyBindingStateStore);
     registerCodexCliMetadata(api);
+    // Lightweight CLI commands (help, status) use a reduced runtime where
+    // api.runtime.state is absent. Skip state-dependent registration so
+    // the plugin does not crash with "Cannot read properties of undefined".
+    if (typeof api.runtime.state?.openSyncKeyedStore !== "function") {
+      return;
+    }
     const sessionCatalogControl = createCodexSessionCatalogControl({
       getPluginConfig: resolveCurrentPluginConfig,
       getRuntimeConfig: resolveCurrentConfig,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the Codex plugin crashes during `register()` in lightweight CLI runtimes (e.g. `openclaw nodes --help`) because `api.runtime.state` is absent and state-dependent registration code attempts to access `openSyncKeyedStore`.

## Why This Change Was Made

Main already has a lazy `lazyBindingStateStore` proxy (which defers state access until first use), but the code after `registerCodexCliMetadata(api)` unconditionally registers commands and event handlers that eventually dereference `api.runtime.state`. This PR adds a feature guard immediately after CLI metadata registration: if `api.runtime.state?.openSyncKeyedStore` is unavailable, the plugin returns early after registering only the CLI metadata, skipping all state-dependent registration (session catalog, commands, event listeners).

The lazy proxy and existing `bindingStore` initialization are preserved exactly as-is from main.

## User Impact

Lightweight CLI invocations no longer log `[plugins] codex failed during register ... TypeError: Cannot read properties of undefined`. Full gateway runtime behavior is unchanged.

## Evidence

- Regression: `pnpm test:extension codex` ??passed. Existing tests continue to pass; the guard short-circuits only when the state facade is absent, which does not affect integration/unit test environments.

- Controlled runtime proof: standalone Node.js proof confirmed that when `api.runtime.state` is `undefined`, the function exits early after `registerCodexCliMetadata(api)` without throwing. When `api.runtime.state` is present (normal gateway), all registration proceeds as before.

- `pnpm exec oxfmt --check` passed for the changed file; `git diff --check` passed.

- The complete codex extension test suite was also attempted: all tests passed. The affected focused regression is green.