### PR TITLE
fix(cron): tighten cron tool schema to prevent llama.cpp GBNF grammar overflow (#108690)

### DIFF
--- a/src/agents/tools/cron-tool.ts
+++ b/src/agents/tools/cron-tool.ts
@@ -132,7 +132,7 @@ function cronPayloadObjectSchema(params: {
       fallbacks: params.fallbacks,
       toolsAllow: params.toolsAllow,
     },
-    { additionalProperties: true },
+    { additionalProperties: false },
   );
 }
 
@@ -160,7 +160,7 @@ function createCronScheduleSchema(): TSchema {
         ),
         staggerMs: optionalNonNegativeIntegerSchema({ description: "Jitter ms (kind=cron)" }),
       },
-      { additionalProperties: true },
+      { additionalProperties: false },
     ),
   );
 }
@@ -203,7 +203,7 @@ function cronDeliverySchema(params: { nullableClears: boolean }) {
       }),
       mode: failureDestinationModeSchema({ nullableClears: params.nullableClears }),
     },
-    { additionalProperties: true },
+    { additionalProperties: false },
   );
 
   return Type.Optional(
@@ -232,7 +232,7 @@ function cronDeliverySchema(params: { nullableClears: boolean }) {
             )
           : Type.Optional(failureDestinationObject),
       },
-      { additionalProperties: true },
+      { additionalProperties: false },
     ),
   );
 }
@@ -263,7 +263,7 @@ function createCronFailureAlertSchema(): TSchema {
         mode: optionalStringEnum(["announce", "webhook"] as const),
         accountId: Type.Optional(Type.String()),
       },
-      additionalProperties: true,
+      additionalProperties: false,
       description: "Failure alert; false disables.",
     }),
   );
@@ -311,7 +311,7 @@ function createCronJobObjectSchema(): TSchema {
         sessionKey: nullableStringSchema("Explicit session key, or null to clear it"),
         failureAlert: createCronFailureAlertSchema(),
       },
-      { additionalProperties: true },
+      { additionalProperties: false },
     ),
   );
 }
@@ -345,7 +345,7 @@ function createCronPatchObjectSchema(): TSchema {
         sessionKey: nullableStringSchema("Explicit session key, or null to clear it"),
         failureAlert: createCronFailureAlertSchema(),
       },
-      { additionalProperties: true },
+      { additionalProperties: false },
     ),
   );
 }
@@ -383,7 +383,7 @@ function createCronToolSchema(): TSchema {
         }),
       ),
     },
-    { additionalProperties: true },
+    { additionalProperties: false },
   );
 }
 


### PR DESCRIPTION
Fixes #108690.

## Problem

The cron tool JSON schema in `src/agents/tools/cron-tool.ts` declared `additionalProperties: true` on **eight** nested objects. When OpenClaw sends the built-in tool schemas to a local llama.cpp server for grammar-constrained tool calling, llama.cpp converts each JSON Schema into a GBNF grammar. Every `additionalProperties: true` expands into a full recursive "any-key → any-JSON-value" matcher, and nested siblings multiply the rule count.

Per the reporter's analysis:

- **cron tool alone**: ~1236 GBNF rules (largest contributor)
- **remaining ~25 built-in tools combined**: ~3070 rules
- **total**: past llama.cpp's implicit ~5000-rule grammar ceiling

llama.cpp silently builds the oversized grammar and then fails at sampler init:

```
400 Bad Request — Failed to initialize samplers: failed to parse grammar
```

Because the cron tool ships in the default tool list, this failure blocks **every** chat turn against local llama.cpp — not just cron-related turns — starting from v2026.7.1 when the total schema surface crossed the ceiling. Users currently mitigate by adding `tools.deny: ["cron"]` in `openclaw.json`, which loses cron entirely.

## Fix

Flip all 8 `additionalProperties: true` → `false` in the cron tool schema. Reporter projects **1236 → ~350–400 rules** for cron, which comfortably restores headroom for the aggregate grammar.

### Changed sites (`src/agents/tools/cron-tool.ts`)

| Line | Object |
|-----:|--------|
| 135 | `cronPayloadObjectSchema` (payload body used by both job.payload and patch.payload) |
| 163 | `createCronScheduleSchema` (schedule) |
| 206 | `cronDeliverySchema` → `failureDestinationObject` (delivery.failureDestination) |
| 235 | `cronDeliverySchema` outer (delivery) |
| 266 | `createCronFailureAlertSchema` (failureAlert) |
| 314 | `createCronJobObjectSchema` (job) |
| 348 | `createCronPatchObjectSchema` (patch) |
| 386 | `createCronToolSchema` (top-level tool params) |

Two sites already at `false` (`trigger` at line 184 and `owner` at line 294) were untouched.

## Behavior preserved

- **No runtime behavior change.** The cron tool's `execute` handler does not run TypeBox `Value.Check` against the parameters schema before dispatching; the schema exists to constrain provider output. Unknown top-level keys were never processed by cron runtime code.
- The tool's own flat-parameter recovery path (`recoverCronObjectFromFlatParams` in `cron-tool-canonicalize.ts`) explicitly whitelists known keys and reconstructs the nested object shape from flat params emitted by weaker local models — it does not depend on `additionalProperties: true` on the outer schema.
- Existing schema tests in `cron-tool.schema.test.ts` (including the nullable-clear regression cases at lines 222 and 239) only supply declared fields, so they continue to pass with the stricter shape.

## Context

Complements the parallel llama.cpp compat work already in flight for cron patterns and `maxLength` (PRs #107939, #108469, #108624, #108360, #108671). Those PRs address per-field GBNF issues (unanchored patterns, `\S` shorthand, oversized repetition ceilings). This PR is orthogonal — it targets the **aggregate rule count** that was the actual trigger for the "failed to parse grammar" failure — and can land alongside them without conflict.

Reporter's other mitigations (per-provider tool deny, pattern anchoring) remain useful for defense-in-depth but are no longer required to keep cron in the default tool list once this lands.
