### PR TITLE
fix(gateway): agent model overrides cannot be cleared

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -8080,7 +8080,7 @@ public struct AgentsUpdateParams: Codable, Sendable {
     public let agentid: String
     public let name: String?
     public let workspace: String?
-    public let model: String?
+    public let model: AnyCodable?
     public let emoji: String?
     public let avatar: String?
 
@@ -8088,7 +8088,7 @@ public struct AgentsUpdateParams: Codable, Sendable {
         agentid: String,
         name: String? = nil,
         workspace: String? = nil,
-        model: String? = nil,
+        model: AnyCodable? = nil,
         emoji: String? = nil,
         avatar: String? = nil)
     {

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -8080,7 +8080,8 @@ public struct AgentsUpdateParams: Codable, Sendable {
     public let agentid: String
     public let name: String?
     public let workspace: String?
-    public let model: AnyCodable?
+    public let modelvalue: AnyCodable?
+    public var model: String? { modelvalue?.value as? String }
     public let emoji: String?
     public let avatar: String?
 
@@ -8088,23 +8089,40 @@ public struct AgentsUpdateParams: Codable, Sendable {
         agentid: String,
         name: String? = nil,
         workspace: String? = nil,
-        model: AnyCodable? = nil,
+        modelvalue: AnyCodable?,
         emoji: String? = nil,
         avatar: String? = nil)
     {
         self.agentid = agentid
         self.name = name
         self.workspace = workspace
-        self.model = model
+        self.modelvalue = modelvalue
         self.emoji = emoji
         self.avatar = avatar
+    }
+
+    public init(
+        agentid: String,
+        name: String? = nil,
+        workspace: String? = nil,
+        model: String? = nil,
+        emoji: String? = nil,
+        avatar: String? = nil)
+    {
+        self.init(
+            agentid: agentid,
+            name: name,
+            workspace: workspace,
+            modelvalue: model.map { AnyCodable($0) },
+            emoji: emoji,
+            avatar: avatar)
     }
 
     private enum CodingKeys: String, CodingKey {
         case agentid = "agentId"
         case name
         case workspace
-        case model
+        case modelvalue = "model"
         case emoji
         case avatar
     }

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -8126,6 +8126,28 @@ public struct AgentsUpdateParams: Codable, Sendable {
         case emoji
         case avatar
     }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.agentid = try container.decode(String.self, forKey: .agentid)
+        self.name = try container.decodeIfPresent(String.self, forKey: .name)
+        self.workspace = try container.decodeIfPresent(String.self, forKey: .workspace)
+        self.modelvalue = container.contains(.modelvalue)
+            ? try container.decode(AnyCodable.self, forKey: .modelvalue)
+            : nil
+        self.emoji = try container.decodeIfPresent(String.self, forKey: .emoji)
+        self.avatar = try container.decodeIfPresent(String.self, forKey: .avatar)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(agentid, forKey: .agentid)
+        try container.encodeIfPresent(name, forKey: .name)
+        try container.encodeIfPresent(workspace, forKey: .workspace)
+        try container.encodeIfPresent(modelvalue, forKey: .modelvalue)
+        try container.encodeIfPresent(emoji, forKey: .emoji)
+        try container.encodeIfPresent(avatar, forKey: .avatar)
+    }
 }
 
 public struct AgentsUpdateResult: Codable, Sendable {

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayModelsCompatibilityTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayModelsCompatibilityTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import OpenClawProtocol
 import Testing
 
@@ -47,5 +48,29 @@ struct GatewayModelsCompatibilityTests {
         #expect(params.agentid == nil)
         #expect(params.fastmodevalue == nil)
         #expect(legacyParams.fastmode == true)
+    }
+
+    @Test
+    func `agent update model keeps legacy source compatibility and nullable wire semantics`() throws {
+        let legacyParams = AgentsUpdateParams(agentid: "work", model: "openai/gpt-5.6")
+        let omittedParams = AgentsUpdateParams(agentid: "work")
+        let clearedParams = AgentsUpdateParams(agentid: "work", modelvalue: AnyCodable(NSNull()))
+
+        #expect(legacyParams.model == "openai/gpt-5.6")
+        #expect(omittedParams.modelvalue == nil)
+
+        let legacyJSON = try #require(
+            JSONSerialization.jsonObject(with: JSONEncoder().encode(legacyParams))
+                as? [String: Any])
+        let omittedJSON = try #require(
+            JSONSerialization.jsonObject(with: JSONEncoder().encode(omittedParams))
+                as? [String: Any])
+        let clearedJSON = try #require(
+            JSONSerialization.jsonObject(with: JSONEncoder().encode(clearedParams))
+                as? [String: Any])
+
+        #expect(legacyJSON["model"] as? String == "openai/gpt-5.6")
+        #expect(omittedJSON["model"] == nil)
+        #expect(clearedJSON["model"] is NSNull)
     }
 }

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayModelsCompatibilityTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayModelsCompatibilityTests.swift
@@ -72,5 +72,19 @@ struct GatewayModelsCompatibilityTests {
         #expect(legacyJSON["model"] as? String == "openai/gpt-5.6")
         #expect(omittedJSON["model"] == nil)
         #expect(clearedJSON["model"] is NSNull)
+
+        let decodedOmitted = try JSONDecoder().decode(
+            AgentsUpdateParams.self,
+            from: Data(#"{"agentId":"work"}"#.utf8))
+        let decodedCleared = try JSONDecoder().decode(
+            AgentsUpdateParams.self,
+            from: Data(#"{"agentId":"work","model":null}"#.utf8))
+        let reencodedCleared = try #require(
+            JSONSerialization.jsonObject(with: JSONEncoder().encode(decodedCleared))
+                as? [String: Any])
+
+        #expect(decodedOmitted.modelvalue == nil)
+        #expect(decodedCleared.modelvalue?.value is NSNull)
+        #expect(reencodedCleared["model"] is NSNull)
     }
 }

--- a/packages/gateway-protocol/src/schema/agents-models-skills.test.ts
+++ b/packages/gateway-protocol/src/schema/agents-models-skills.test.ts
@@ -3,6 +3,7 @@ import { Value } from "typebox/value";
 import { describe, expect, it } from "vitest";
 import {
   AgentsListResultSchema,
+  AgentsUpdateParamsSchema,
   ModelsListParamsSchema,
   ModelsListResultSchema,
   ModelsProbeParamsSchema,
@@ -67,6 +68,17 @@ describe("AgentsListResultSchema", () => {
     };
 
     expect(Value.Check(AgentsListResultSchema, result)).toBe(true);
+  });
+});
+
+describe("AgentsUpdateParamsSchema", () => {
+  it("accepts null to clear a model override", () => {
+    expect(
+      Value.Check(AgentsUpdateParamsSchema, {
+        agentId: "work",
+        model: null,
+      }),
+    ).toBe(true);
   });
 });
 

--- a/packages/gateway-protocol/src/schema/agents-models-skills.test.ts
+++ b/packages/gateway-protocol/src/schema/agents-models-skills.test.ts
@@ -72,13 +72,15 @@ describe("AgentsListResultSchema", () => {
 });
 
 describe("AgentsUpdateParamsSchema", () => {
-  it("accepts null to clear a model override", () => {
+  it("distinguishes omitted, cleared, and invalid model values", () => {
+    expect(Value.Check(AgentsUpdateParamsSchema, { agentId: "work" })).toBe(true);
     expect(
       Value.Check(AgentsUpdateParamsSchema, {
         agentId: "work",
         model: null,
       }),
     ).toBe(true);
+    expect(Value.Check(AgentsUpdateParamsSchema, { agentId: "work", model: "" })).toBe(false);
   });
 });
 

--- a/packages/gateway-protocol/src/schema/agents-models-skills.ts
+++ b/packages/gateway-protocol/src/schema/agents-models-skills.ts
@@ -115,12 +115,12 @@ export const AgentsCreateResultSchema = closedObject({
   model: Type.Optional(NonEmptyString),
 });
 
-/** Updates mutable agent identity, workspace, and model fields. */
+/** Updates mutable agent identity, workspace, and model fields; null clears the model override. */
 export const AgentsUpdateParamsSchema = closedObject({
   agentId: NonEmptyString,
   name: Type.Optional(NonEmptyString),
   workspace: Type.Optional(NonEmptyString),
-  model: Type.Optional(NonEmptyString),
+  model: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
   emoji: Type.Optional(Type.String()),
   avatar: Type.Optional(Type.String()),
 });

--- a/packages/sdk/src/index.e2e.test.ts
+++ b/packages/sdk/src/index.e2e.test.ts
@@ -425,6 +425,10 @@ describe("OpenClaw SDK websocket e2e", () => {
       );
       expect(updateAgent.method).toBe("agents.update");
       expect(updateAgent.params).toEqual({ agentId: "sdk-agent", name: "Renamed SDK Agent" });
+      const clearAgentModel = expectJsonObject(
+        await oc.agents.update({ agentId: "sdk-agent", model: null }),
+      );
+      expect(clearAgentModel.params).toEqual({ agentId: "sdk-agent", model: null });
       const deleteAgent = expectJsonObject(await oc.agents.delete({ agentId: "sdk-agent" }));
       expect(deleteAgent.method).toBe("agents.delete");
       expect(deleteAgent.params).toEqual({ agentId: "sdk-agent" });
@@ -492,6 +496,7 @@ describe("OpenClaw SDK websocket e2e", () => {
         "agents.list",
         "agent.identity.get",
         "agents.create",
+        "agents.update",
         "agents.update",
         "agents.delete",
         "sessions.list",

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -379,7 +379,7 @@ export type AgentsUpdateParams = {
   agentId: string;
   name?: string;
   workspace?: string;
-  model?: string;
+  model?: string | null;
   emoji?: string;
   avatar?: string;
 };

--- a/scripts/protocol-gen-swift.ts
+++ b/scripts/protocol-gen-swift.ts
@@ -104,6 +104,9 @@ function swiftStoredPropertyName(structName: string, key: string): string {
   if (structName === "ChatSendParams" && key === "fastMode") {
     return "fastmodevalue";
   }
+  if (structName === "AgentsUpdateParams" && key === "model") {
+    return "modelvalue";
+  }
   if (structName === "ChatSendParams" && key === "fast_seconds") {
     return "fastseconds";
   }
@@ -114,6 +117,9 @@ function swiftInitializerName(structName: string, key: string): string {
   if (structName === "ChatSendParams" && key === "fastMode") {
     return "fastmodevalue";
   }
+  if (structName === "AgentsUpdateParams" && key === "model") {
+    return "modelvalue";
+  }
   if (structName === "ChatSendParams" && key === "fast_seconds") {
     return "fastseconds";
   }
@@ -123,6 +129,9 @@ function swiftInitializerName(structName: string, key: string): string {
 function swiftCompatibilityPropertyLines(structName: string, key: string): string[] {
   if (structName === "ChatSendParams" && key === "fastMode") {
     return ["    public var fastmode: Bool? { fastmodevalue?.value as? Bool }"];
+  }
+  if (structName === "AgentsUpdateParams" && key === "model") {
+    return ["    public var model: String? { modelvalue?.value as? String }"];
   }
   return [];
 }
@@ -412,6 +421,11 @@ function emitStruct(name: string, schema: JsonSchema): string {
         .map(([key, prop]) => {
           const propName = swiftInitializerName(name, key);
           const req = required.has(key);
+          if (name === "AgentsUpdateParams" && key === "model") {
+            // Keep the raw nullable value explicit so the source-compatible initializer stays
+            // unambiguous when callers omit model.
+            return "        modelvalue: AnyCodable?";
+          }
           return `        ${swiftInitializerParam({
             name: propName,
             schema: prop,
@@ -444,6 +458,36 @@ function emitStructCompatibilityInitializer(
   props: Record<string, JsonSchema>,
   required: Set<string>,
 ): string {
+  if (name === "AgentsUpdateParams" && props.model) {
+    const initializerParams = Object.entries(props).map(([key, prop]) => {
+      const propName = swiftInitializerName(name, key);
+      if (key === "model") {
+        return "        model: String? = nil";
+      }
+      return `        ${swiftInitializerParam({
+        name: propName,
+        schema: prop,
+        required: required.has(key),
+      })}`;
+    });
+    const delegatedArgs = Object.keys(props).map((key) => {
+      const propName = swiftInitializerName(name, key);
+      if (key === "model") {
+        return "            modelvalue: model.map { AnyCodable($0) }";
+      }
+      return `            ${propName}: ${propName}`;
+    });
+    return (
+      "\n\n    public init(\n" +
+      initializerParams.join(",\n") +
+      ")\n" +
+      "    {\n" +
+      "        self.init(\n" +
+      delegatedArgs.join(",\n") +
+      ")\n" +
+      "    }"
+    );
+  }
   if (name !== "ChatSendParams" || !props.fastMode) {
     return "";
   }

--- a/scripts/protocol-gen-swift.ts
+++ b/scripts/protocol-gen-swift.ts
@@ -447,10 +447,51 @@ function emitStruct(name: string, schema: JsonSchema): string {
       "\n\n" +
       "    private enum CodingKeys: String, CodingKey {\n" +
       codingKeys.join("\n") +
-      "\n    }\n}",
+      "\n    }" +
+      emitStructCustomCodable(name, props, required) +
+      "\n}",
   );
   lines.push("");
   return lines.join("\n");
+}
+
+function emitStructCustomCodable(
+  name: string,
+  props: Record<string, JsonSchema>,
+  required: Set<string>,
+): string {
+  if (name !== "AgentsUpdateParams" || !props.model) {
+    return "";
+  }
+  const decodedProperties = Object.entries(props).map(([key, propSchema]) => {
+    const propName = swiftStoredPropertyName(name, key);
+    if (key === "model") {
+      // decodeIfPresent collapses an explicit JSON null into nil. Presence-aware decoding
+      // preserves the Gateway patch distinction between clearing and omitting the model.
+      return `        self.${propName} = container.contains(.${propName})\n            ? try container.decode(AnyCodable.self, forKey: .${propName})\n            : nil`;
+    }
+    if (required.has(key)) {
+      return `        self.${propName} = try container.decode(${swiftType(propSchema, true, true)}.self, forKey: .${propName})`;
+    }
+    return `        self.${propName} = try container.decodeIfPresent(${swiftType(propSchema, true, true)}.self, forKey: .${propName})`;
+  });
+  const encodedProperties = Object.keys(props).map((key) => {
+    const propName = swiftStoredPropertyName(name, key);
+    if (required.has(key)) {
+      return `        try container.encode(${propName}, forKey: .${propName})`;
+    }
+    return `        try container.encodeIfPresent(${propName}, forKey: .${propName})`;
+  });
+  return (
+    "\n\n    public init(from decoder: Decoder) throws {\n" +
+    "        let container = try decoder.container(keyedBy: CodingKeys.self)\n" +
+    decodedProperties.join("\n") +
+    "\n    }\n\n" +
+    "    public func encode(to encoder: Encoder) throws {\n" +
+    "        var container = encoder.container(keyedBy: CodingKeys.self)\n" +
+    encodedProperties.join("\n") +
+    "\n    }"
+  );
 }
 
 function emitStructCompatibilityInitializer(

--- a/src/commands/agents.config.ts
+++ b/src/commands/agents.config.ts
@@ -133,12 +133,13 @@ export function applyAgentConfig(
     ...(name ? { name } : {}),
     ...(params.workspace ? { workspace: params.workspace } : {}),
     ...(params.agentDir ? { agentDir: params.agentDir } : {}),
-    ...(params.model ? { model: params.model } : {}),
     ...(mergedIdentity ? { identity: mergedIdentity } : {}),
   };
-  // Omission preserves the override; explicit null restores the inherited default.
+  // Model is tri-state: omission preserves the override, null restores inheritance.
   if (params.model === null) {
     delete nextEntry.model;
+  } else if (params.model !== undefined) {
+    nextEntry.model = params.model;
   }
   const nextList = [...list];
   if (index >= 0) {

--- a/src/commands/agents.config.ts
+++ b/src/commands/agents.config.ts
@@ -118,7 +118,7 @@ export function applyAgentConfig(
     name?: string;
     workspace?: string;
     agentDir?: string;
-    model?: string;
+    model?: string | null;
     identity?: IdentityConfig;
   },
 ): OpenClawConfig {
@@ -136,6 +136,10 @@ export function applyAgentConfig(
     ...(params.model ? { model: params.model } : {}),
     ...(mergedIdentity ? { identity: mergedIdentity } : {}),
   };
+  // Omission preserves the override; explicit null restores the inherited default.
+  if (params.model === null) {
+    delete nextEntry.model;
+  }
   const nextList = [...list];
   if (index >= 0) {
     nextList[index] = nextEntry;

--- a/src/commands/agents.test.ts
+++ b/src/commands/agents.test.ts
@@ -82,6 +82,23 @@ describe("agents helpers", () => {
     expect(work?.model).toBe("anthropic/claude");
   });
 
+  it("applyAgentConfig clears a model override", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: { model: { primary: "openai/gpt-5.6-luna" } },
+        list: [{ id: "work", workspace: "/work-ws", model: "anthropic/claude" }],
+      },
+    };
+
+    const next = applyAgentConfig(cfg, { agentId: "work", model: null });
+    const work = next.agents?.list?.find((agent) => agent.id === "work");
+
+    expect(work).not.toHaveProperty("model");
+    expect(requireAgentSummary(buildAgentSummaries(next), "work").model).toBe(
+      "openai/gpt-5.6-luna",
+    );
+  });
+
   it("applyAgentConfig merges identity with existing", () => {
     const cfg: OpenClawConfig = {
       agents: {

--- a/src/gateway/server-methods/agents-config-mutations.ts
+++ b/src/gateway/server-methods/agents-config-mutations.ts
@@ -72,7 +72,7 @@ export async function updateAgentConfigEntry(params: {
   agentId: string;
   name?: string;
   workspace?: string;
-  model?: string;
+  model?: string | null;
   identity?: IdentityConfig;
 }): Promise<void> {
   await mutateConfigFileWithRetry({
@@ -85,7 +85,7 @@ export async function updateAgentConfigEntry(params: {
         agentId: params.agentId,
         ...(params.name ? { name: params.name } : {}),
         ...(params.workspace ? { workspace: params.workspace } : {}),
-        ...(params.model ? { model: params.model } : {}),
+        ...(params.model !== undefined ? { model: params.model } : {}),
         ...(params.identity ? { identity: params.identity } : {}),
       });
       Object.assign(draft, latestNextConfig);

--- a/src/gateway/server-methods/agents-mutate.test.ts
+++ b/src/gateway/server-methods/agents-mutate.test.ts
@@ -400,7 +400,7 @@ function mergeAgentConfig(cfg: unknown, opts: unknown): MockConfig {
     name?: string;
     workspace?: string;
     agentDir?: string;
-    model?: string;
+    model?: string | null;
     identity?: MockIdentity;
   }) ?? { agentId: "" };
   const list = getAgentList(config);
@@ -415,6 +415,9 @@ function mergeAgentConfig(cfg: unknown, opts: unknown): MockConfig {
     ...(params.model ? { model: params.model } : {}),
     ...(params.identity ? { identity: { ...base.identity, ...params.identity } } : {}),
   };
+  if (params.model === null) {
+    delete nextEntry.model;
+  }
   if (index >= 0) {
     list[index] = nextEntry;
   } else {
@@ -816,6 +819,34 @@ describe("agents.update", () => {
     await promise;
 
     expectNotFoundResponseAndNoWrite(respond);
+  });
+
+  it("clears an existing model override", async () => {
+    mocks.loadConfigReturn = {
+      agents: {
+        defaults: { model: { primary: "openai/gpt-5.6-luna" } },
+        list: [
+          {
+            id: "test-agent",
+            workspace: "/workspace/test-agent",
+            model: "anthropic/claude-sonnet-4-6",
+          },
+        ],
+      },
+    };
+
+    const { respond, promise } = makeCall("agents.update", {
+      agentId: "test-agent",
+      model: null,
+    });
+    await promise;
+
+    expectRespondOk(respond, { ok: true, agentId: "test-agent" });
+    expectRecordFields(mockCallArg(mocks.applyAgentConfig, 0, 1), { model: null });
+    const persisted = expectRecordFields(mockCallArg(mocks.writeConfigFile), {});
+    const agents = expectRecordFields(persisted.agents, {});
+    const [agent] = agents.list as MockAgentEntry[];
+    expect(agent).not.toHaveProperty("model");
   });
 
   it("ensures workspace when workspace changes", async () => {

--- a/src/gateway/server-methods/agents.ts
+++ b/src/gateway/server-methods/agents.ts
@@ -412,14 +412,14 @@ function buildAgentConfigUpdate(params: {
   agentId: string;
   safeName?: string;
   workspaceDir?: string;
-  model?: string;
+  model?: string | null;
   identity?: IdentityConfig;
 }): Parameters<typeof updateAgentConfigEntry>[0] {
   return {
     agentId: params.agentId,
     ...(params.safeName ? { name: params.safeName } : {}),
     ...(params.workspaceDir ? { workspace: params.workspaceDir } : {}),
-    ...(params.model ? { model: params.model } : {}),
+    ...(params.model !== undefined ? { model: params.model } : {}),
     ...(params.identity ? { identity: params.identity } : {}),
   };
 }
@@ -617,7 +617,7 @@ export const agentsHandlers: GatewayRequestHandlers = {
         ? resolveUserPath(params.workspace.trim())
         : undefined;
 
-    const model = resolveOptionalStringParam(params.model);
+    const model = params.model === null ? null : resolveOptionalStringParam(params.model);
 
     const safeName =
       typeof params.name === "string" && params.name.trim()


### PR DESCRIPTION
Closes #108277

## What Problem This Solves

Operators could set an agent-specific model through `agents.update` but could not later remove that override. Omitting `model` correctly left the agent unchanged, while sending `model: null` was rejected, leaving the agent pinned instead of inheriting the configured default model.

## Why This Change Was Made

The update contract now treats an omitted model as no change and an explicit `null` as removal of the stored override, matching patch semantics without widening canonical config storage. The value stays distinct through strict protocol validation, SDK encoding, the Gateway handler, and the retrying config mutation path. Generated Swift clients keep their existing string-facing initializer/property API and gain an explicit nullable wire-value route, so the additive Gateway change does not break source callers.

## User Impact

Gateway and SDK clients can remove an agent-specific model override with `agents.update({ agentId, model: null })`. The agent then inherits the configured default model without changing identity, workspace, or other settings.

## Evidence

Before the change, current main rejected the clear request and retained the override:

```text
omittedValid: true
nullValid: false
null error: /model must be string
before model: anthropic/claude-sonnet-4-6
after model: anthropic/claude-sonnet-4-6
```

After the change, the same protocol/config path accepts the request, removes the stored field, and resolves the inherited default:

```text
omittedValid: true
nullValid: true
stored agent: { "id": "proof-agent" }
effective model: openai/gpt-5.6-luna
```

Focused regression proof:

```text
node scripts/run-vitest.mjs packages/gateway-protocol/src/schema/agents-models-skills.test.ts
1 file passed, 16 tests passed

node scripts/run-vitest.mjs src/commands/agents.test.ts
1 file passed, 11 tests passed

node scripts/run-vitest.mjs src/gateway/server-methods/agents-mutate.test.ts
1 file passed, 50 tests passed

node scripts/run-vitest.mjs packages/sdk/src/index.e2e.test.ts
1 file passed, 4 tests passed, 1 skipped
```

The hosted changed gate passed on Blacksmith Testbox, and protocol generation reproduced the checked-in Swift model byte-for-byte while leaving JSON and Kotlin outputs unchanged. Two structured autoreview passes reported no accepted or actionable findings. Exact-head CI remains the landing gate.

AI-assisted; implementation review and proof were run manually.
