### PR TITLE
feat(mac): playful hard-hat working mascot during setup and updates

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -36355,7 +36355,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 545,
+      "line": 588,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/OpenClawMascotView.swift",
       "source": "z",
       "surface": "apple",

--- a/apps/macos/Sources/OpenClaw/OnboardingWidgets.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingWidgets.swift
@@ -51,8 +51,8 @@ extension OnboardingView {
     }
 
     /// The hero mascot mirrors what setup is doing: curious while choosing,
-    /// thinking while work is in flight, sad on failures, celebrating once
-    /// the AI answers and on the final page.
+    /// hard-hat working while setup is in flight, sad on failures,
+    /// celebrating once the AI answers and on the final page.
     var mascotMood: OpenClawMascotMood {
         Self.mascotMood(for: MascotMoodSnapshot(
             page: self.mascotPage,
@@ -109,7 +109,7 @@ extension OnboardingView {
                 // Mirrors the page's install-failed card.
                 .sad
             } else {
-                .thinking
+                .working
             }
         case .ai:
             if snapshot.aiPhase == .connected {

--- a/apps/macos/Sources/OpenClaw/PostUpdate.swift
+++ b/apps/macos/Sources/OpenClaw/PostUpdate.swift
@@ -212,7 +212,7 @@ final class PostUpdateModel {
 
     var mood: OpenClawMascotMood {
         switch self.phase {
-        case .checking, .updating, .verifying, .notifying: .thinking
+        case .checking, .updating, .verifying, .notifying: .working
         case .complete: .celebrating
         case .failed: .sad
         }

--- a/apps/macos/Tests/OpenClawIPCTests/OnboardingMascotMoodTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/OnboardingMascotMoodTests.swift
@@ -22,8 +22,8 @@ struct OnboardingMascotMoodTests {
     }
 
     @Test func `cli page tracks install lifecycle`() {
-        #expect(self.mood(.init(page: .cli, installingCLI: true)) == .thinking)
-        #expect(self.mood(.init(page: .cli)) == .thinking, "status probe still deciding")
+        #expect(self.mood(.init(page: .cli, installingCLI: true)) == .working)
+        #expect(self.mood(.init(page: .cli)) == .working, "status probe still deciding")
         #expect(self.mood(.init(page: .cli, cliStatusKnown: true)) == .sad, "install failed")
         #expect(self.mood(.init(page: .cli, cliInstalled: true, cliStatusKnown: true)) == .happy)
     }

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/OpenClawMascotAnimator.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/OpenClawMascotAnimator.swift
@@ -11,6 +11,8 @@ public enum OpenClawMascotMood: String, CaseIterable, Equatable, Sendable {
     case curious
     /// Eyes drift up and scan, antennae twitch asymmetrically — work in flight.
     case thinking
+    /// Hard-hat construction loop — hammering claw, impact sparks, periodic brow wipes (setup/install work in flight).
+    case working
     /// Perky antennae, soft smile, happy-squint eyes.
     case happy
     /// One big jump-and-claw-raise entrance, then sparkly happy loop.
@@ -29,6 +31,8 @@ enum OpenClawMascotEffect: Equatable {
     case sparkles
     case hearts
     case zzz
+    case sparks
+    case sweat
 }
 
 /// Drives the mascot's behavior over time: per-mood base loops, randomized
@@ -251,7 +255,9 @@ final class OpenClawMascotAnimator {
 
         let dozing = self.isDozing(at: time)
         if time >= self.nextClawSnapAt {
-            if self.activeGesture == nil, !dozing, self.mood != .sad, time >= self.dizzyUntil {
+            if self.activeGesture == nil, !dozing, self.mood != .sad, self.mood != .working,
+               time >= self.dizzyUntil
+            {
                 self.startGesture(.clawSnap, at: time)
             }
             self.nextClawSnapAt = time + self.random(in: 4...9)
@@ -270,6 +276,8 @@ final class OpenClawMascotAnimator {
                     self.startGesture(.sigh, at: time)
                 } else if dozing || self.mood == .sleepy {
                     self.startGesture(.yawn, at: time)
+                } else if self.mood == .working {
+                    self.startGesture(.wipeBrow, at: time)
                 }
             }
             self.rescheduleMoodBeat(at: time)
@@ -292,7 +300,7 @@ final class OpenClawMascotAnimator {
     private var quirkEligible: Bool {
         switch self.mood {
         case .idle, .curious, .happy, .attentive: true
-        case .thinking, .celebrating, .sad, .sleepy: false
+        case .thinking, .working, .celebrating, .sad, .sleepy: false
         }
     }
 
@@ -342,6 +350,7 @@ final class OpenClawMascotAnimator {
         case .celebrating: .celebrate
         case .sad: .sigh
         case .sleepy: .yawn
+        case .working: .donHardHat
         case .idle, .curious, .thinking, .attentive: nil
         }
     }
@@ -366,6 +375,34 @@ final class OpenClawMascotAnimator {
             pose.antennaDegrees = -5 * sin(2 * .pi * Self.cyclePhase(time, period: 1.3))
             pose.bodyTilt = 2 * sin(2 * .pi * Self.cyclePhase(time, period: 6))
             pose.eyeGlowOpacity = 0.9 + 0.1 * sin(2 * .pi * Self.cyclePhase(time, period: 0.8))
+        case .working:
+            let phase = Self.cyclePhase(time, period: 0.95)
+            if phase < 0.05 {
+                pose.rightClawDegrees = -6
+            } else if phase < 0.60 {
+                pose.rightClawDegrees = -6 - 28 * OpenClawMascotGesture.easeInOut((phase - 0.05) / 0.55)
+            } else if phase < 0.72 {
+                let strike = ((phase - 0.60) / 0.12).clamped(to: 0...1)
+                pose.rightClawDegrees = -34 + 46 * strike * strike
+            } else {
+                pose.rightClawDegrees = 12 - 18 * OpenClawMascotGesture.easeInOut((phase - 0.72) / 0.28)
+            }
+            pose.leftClawDegrees = 4 + 2 * sin(2 * .pi * phase)
+            let impact = OpenClawMascotGesture.bell(((phase - 0.72) / 0.14).clamped(to: 0...1))
+            pose.floatOffset = -2 * (1 - cos(2 * .pi * Self.cyclePhase(time, period: 3.8))) + 0.8 * impact
+            pose.bodyStretch = 1 - 0.03 * impact
+            pose.bodyTilt = 2.2 + 0.6 * sin(2 * .pi * Self.cyclePhase(time, period: 5))
+            if phase >= 0.72 {
+                let recoil = ((phase - 0.72) / 0.28).clamped(to: 0...1)
+                pose.antennaDegrees = 6 * (1 - recoil) * sin(recoil * 3 * .pi)
+            }
+            pose.leftEyeOpenness = 0.85
+            pose.rightEyeOpenness = 0.85
+            pose.mouthCurve = 0.18
+            pose.hardHat = 1
+            pose.effect = .sparks
+            let strikePhase = (phase - 0.72).truncatingRemainder(dividingBy: 1)
+            pose.effectPhase = strikePhase < 0 ? strikePhase + 1 : strikePhase
         case .happy:
             pose.floatOffset = -6 * (1 - cos(2 * .pi * Self.cyclePhase(time, period: 3)))
             pose.antennaDegrees = -4.5 * sin(2 * .pi * Self.cyclePhase(time, period: 1.6))
@@ -424,6 +461,12 @@ final class OpenClawMascotAnimator {
                 target = CGSize(
                     width: 0.4 * sin(2 * .pi * Self.cyclePhase(time, period: 3.8)),
                     height: -0.55)
+            }
+        case .working:
+            if self.pointerTarget == nil {
+                target = CGSize(
+                    width: 0.55 + 0.04 * sin(2 * .pi * Self.cyclePhase(time, period: 4.6)),
+                    height: 0.45 + 0.02 * cos(2 * .pi * Self.cyclePhase(time, period: 3.9)))
             }
         case .attentive:
             if self.pointerTarget == nil {
@@ -493,6 +536,8 @@ enum OpenClawMascotGesture: Equatable {
     case startle
     case shake
     case clawSnap
+    case donHardHat
+    case wipeBrow
 
     static let blinkDuration: TimeInterval = 0.16
 
@@ -511,6 +556,8 @@ enum OpenClawMascotGesture: Equatable {
         case .startle: 0.8
         case .shake: 0.8
         case .clawSnap: 0.6
+        case .donHardHat: 1.0
+        case .wipeBrow: 2.0
         }
     }
 
@@ -617,6 +664,28 @@ enum OpenClawMascotGesture: Equatable {
             // snap to -8° and back, right claw trailing slightly.
             pose.leftClawDegrees += -8 * Self.bell((p / 0.7).clamped(to: 0...1))
             pose.rightClawDegrees += -8 * Self.bell(((p - 0.25) / 0.7).clamped(to: 0...1))
+        case .donHardHat:
+            let drop = Self.easeInOut((p / 0.55).clamped(to: 0...1))
+            pose.hardHat = min(pose.hardHat, drop)
+            if p < 0.55 {
+                pose.gaze = CGSize(width: 0, height: -0.9 * (1 - p))
+            }
+            pose.bodyStretch -= 0.04 * Self.bell(((p - 0.5) / 0.2).clamped(to: 0...1))
+            let ready = Self.bell(((p - 0.7) / 0.3).clamped(to: 0...1))
+            pose.leftClawDegrees += -8 * ready
+            pose.rightClawDegrees += 8 * ready
+        case .wipeBrow:
+            let env = Self.plateau(p, attack: 0.2, release: 0.8)
+            pose.leftClawDegrees *= 1 - env
+            pose.rightClawDegrees *= 1 - env
+            pose.leftClawDegrees += 38 * env * (0.9 + 0.1 * sin(p * 5 * .pi))
+            pose.bodyTilt *= 1 - env
+            pose.bodyStretch += 0.02 * env
+            pose.happyEyes = max(pose.happyEyes, 0.7 * env)
+            pose.mouthCurve = max(pose.mouthCurve, 0.5 * env)
+            pose.gaze = CGSize(width: pose.gaze.width * (1 - env), height: pose.gaze.height * (1 - env))
+            pose.effect = .sweat
+            pose.effectPhase = p
         }
     }
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/OpenClawMascotView.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/OpenClawMascotView.swift
@@ -171,6 +171,8 @@ struct OpenClawMascotPose: Equatable {
     /// 0..1 surprised/yawning "o" (takes over from both mouth channels).
     var mouthRound: CGFloat = 0
     var blush: CGFloat = 0
+    /// 0..1: hard hat drops from above until seated on the head.
+    var hardHat: CGFloat = 0
     /// Degrees around the canvas center.
     var bodyTilt: CGFloat = 0
     /// Vertical squash-and-stretch about the feet; x compensates slightly.
@@ -189,6 +191,12 @@ struct OpenClawMascotPose: Equatable {
             break
         case .thinking:
             pose.gaze = CGSize(width: 0.3, height: -0.5)
+        case .working:
+            pose.hardHat = 1
+            pose.rightClawDegrees = -28
+            pose.gaze = CGSize(width: 0.4, height: 0.35)
+            pose.mouthCurve = 0.15
+            pose.bodyTilt = 2
         case .happy:
             pose.mouthCurve = 0.6
             pose.happyEyes = 0.4
@@ -231,6 +239,7 @@ struct OpenClawMascotPose: Equatable {
         self.mouthOpen = self.mouthOpen.clamped(to: 0...1)
         self.mouthRound = self.mouthRound.clamped(to: 0...1)
         self.blush = self.blush.clamped(to: 0...1)
+        self.hardHat = self.hardHat.clamped(to: 0...1)
         self.bodyTilt = self.bodyTilt.clamped(to: -8...8)
         self.bodyStretch = self.bodyStretch.clamped(to: 0.86...1.05)
         self.dizzy = self.dizzy.clamped(to: 0...1)
@@ -254,6 +263,7 @@ struct OpenClawMascotCanvas: View {
     private static let eyeGlowColor = Color(red: 0, green: 229 / 255, blue: 204 / 255)
     private static let blushColor = Color(red: 1, green: 0.62, blue: 0.68)
     private static let heartColor = Color(red: 1, green: 0.45, blue: 0.55)
+    private static let hatAmber = Color(red: 0.95, green: 0.66, blue: 0.20)
     // Rotation pivots: claws hinge on their body-facing edge, antennae on their own center.
     private static let leftClawPivot = CGPoint(x: 26, y: 53)
     private static let rightClawPivot = CGPoint(x: 94, y: 53)
@@ -371,6 +381,7 @@ struct OpenClawMascotCanvas: View {
             }
         }
 
+        self.drawHardHat(context: context, amount: pose.hardHat)
         self.drawBlush(context: context, pose: pose)
         self.drawEye(context: context, center: self.leftEyeCenter, openness: pose.leftEyeOpenness, pose: pose)
         self.drawEye(context: context, center: self.rightEyeCenter, openness: pose.rightEyeOpenness, pose: pose)
@@ -491,6 +502,38 @@ struct OpenClawMascotCanvas: View {
         }
     }
 
+    private static func drawHardHat(context: GraphicsContext, amount: CGFloat) {
+        guard amount > 0.01 else { return }
+        var dome = Path()
+        dome.move(to: CGPoint(x: 45, y: 15))
+        dome.addCurve(
+            to: CGPoint(x: 60, y: 3),
+            control1: CGPoint(x: 47, y: 7),
+            control2: CGPoint(x: 54, y: 3))
+        dome.addCurve(
+            to: CGPoint(x: 75, y: 15),
+            control1: CGPoint(x: 66, y: 3),
+            control2: CGPoint(x: 73, y: 7))
+        dome.addLine(to: CGPoint(x: 45, y: 15))
+        dome.closeSubpath()
+        let brim = Path(roundedRect: CGRect(x: 41, y: 14, width: 38, height: 5), cornerRadius: 2)
+        var hatContext = context
+        hatContext.opacity = Double(amount)
+        hatContext.translateBy(x: 60, y: 15 - 14 * (1 - amount))
+        hatContext.rotate(by: .degrees(-5))
+        hatContext.translateBy(x: -60, y: -15)
+        hatContext.fill(
+            dome,
+            with: .linearGradient(
+                Gradient(colors: [Color(red: 1, green: 0.84, blue: 0.35), self.hatAmber]),
+                startPoint: CGPoint(x: 60, y: 3),
+                endPoint: CGPoint(x: 60, y: 16)))
+        let outline = Color(red: 0.72, green: 0.45, blue: 0.12).opacity(0.7)
+        hatContext.stroke(dome, with: .color(outline), style: StrokeStyle(lineWidth: 0.8))
+        hatContext.fill(brim, with: .color(self.hatAmber))
+        hatContext.stroke(brim, with: .color(outline), style: StrokeStyle(lineWidth: 0.8))
+    }
+
     private static func drawEffect(
         context: GraphicsContext,
         pose: OpenClawMascotPose,
@@ -552,6 +595,40 @@ struct OpenClawMascotCanvas: View {
                 zContext.opacity = Double(alpha * 0.9)
                 zContext.draw(text, at: position)
             }
+        case .sparks:
+            for index in 0..<5 {
+                let rawPhase = pose.effectPhase - CGFloat(index) * 0.025
+                guard rawPhase >= 0, rawPhase < 0.45 else { continue }
+                let alpha = rawPhase < 0.08 ? rawPhase / 0.08 : 1 - (rawPhase - 0.08) / 0.37
+                let angle = (-160 + CGFloat(index) * 35) * .pi / 180
+                let radius = 5 + 12 * rawPhase / 0.45
+                let particleSize = 2.2 + CGFloat(index % 3) * 0.8
+                let center = CGPoint(
+                    x: (106 + cos(angle) * radius).clamped(to: particleSize...(120 - particleSize)),
+                    y: (66 + sin(angle) * radius).clamped(to: particleSize...(120 - particleSize)))
+                var sparkContext = context
+                sparkContext.opacity = Double(alpha)
+                sparkContext.fill(
+                    self.sparklePath(center: center, size: particleSize),
+                    with: .color(index.isMultiple(of: 2) ? self.eyeGlowColor : self.hatAmber))
+            }
+        case .sweat:
+            let alpha = OpenClawMascotGesture.bell(pose.effectPhase)
+            guard alpha > 0.02 else { return }
+            let center = CGPoint(x: 42, y: 24 + 7 * pose.effectPhase)
+            var drop = Path()
+            drop.move(to: CGPoint(x: center.x, y: center.y - 3))
+            drop.addCurve(
+                to: CGPoint(x: center.x, y: center.y + 3),
+                control1: CGPoint(x: center.x - 4, y: center.y + 1),
+                control2: CGPoint(x: center.x - 2, y: center.y + 3))
+            drop.addCurve(
+                to: CGPoint(x: center.x, y: center.y - 3),
+                control1: CGPoint(x: center.x + 2, y: center.y + 3),
+                control2: CGPoint(x: center.x + 4, y: center.y + 1))
+            var sweatContext = context
+            sweatContext.opacity = Double(alpha)
+            sweatContext.fill(drop, with: .color(Color(red: 0.5, green: 0.83, blue: 1)))
         }
     }
 

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/OpenClawMascotAnimatorTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/OpenClawMascotAnimatorTests.swift
@@ -24,6 +24,7 @@ struct OpenClawMascotAnimatorTests {
                 #expect((0...1).contains(pose.eyeGlowOpacity), "\(mood)")
                 #expect((-45...45).contains(pose.leftClawDegrees), "\(mood)")
                 #expect((-45...45).contains(pose.rightClawDegrees), "\(mood)")
+                #expect((0...1).contains(pose.hardHat), "\(mood)")
                 #expect(abs(pose.gaze.width) <= 1.2 && abs(pose.gaze.height) <= 1.2, "\(mood)")
                 time += 1.0 / 30
             }
@@ -71,6 +72,42 @@ struct OpenClawMascotAnimatorTests {
         #expect(pose.antennaDroop > 0.5)
         #expect(pose.mouthCurve < 0)
         #expect(pose.eyeGlowOpacity < 0.9)
+    }
+
+    @Test func `working mood hammers with hat and sparks`() {
+        let animator = self.makeAnimator()
+        _ = animator.pose(at: 0)
+        animator.setMood(.working, at: 0)
+        var minimumClaw: CGFloat = 45
+        var maximumClaw: CGFloat = -45
+        var wearsHat = false
+        var sparks = false
+        var time: TimeInterval = 0
+        while time < 4 {
+            let pose = animator.pose(at: time)
+            minimumClaw = min(minimumClaw, pose.rightClawDegrees)
+            maximumClaw = max(maximumClaw, pose.rightClawDegrees)
+            wearsHat = wearsHat || (time > 1 && pose.hardHat == 1)
+            sparks = sparks || pose.effect == .sparks
+            time += 1.0 / 30
+        }
+        #expect(wearsHat)
+        #expect(maximumClaw - minimumClaw > 25)
+        #expect(sparks)
+    }
+
+    @Test func `working brow wipe interrupts hammering`() {
+        let animator = self.makeAnimator()
+        _ = animator.pose(at: 0)
+        animator.setMood(.working, at: 0)
+        var wiped = false
+        var time: TimeInterval = 0
+        while time < 14 {
+            let pose = animator.pose(at: time)
+            wiped = wiped || (pose.effect == .sweat && pose.happyEyes > 0.5)
+            time += 1.0 / 30
+        }
+        #expect(wiped)
     }
 
     @Test func `affection taps trigger hearts`() {
@@ -158,6 +195,9 @@ struct OpenClawMascotAnimatorTests {
         #expect(celebrating.mouthCurve > 0)
         let idle = OpenClawMascotPose.staticPose(for: .idle)
         #expect(idle == OpenClawMascotPose())
+        let working = OpenClawMascotPose.staticPose(for: .working)
+        #expect(working.hardHat == 1)
+        #expect(working.rightClawDegrees < 0)
     }
 
     @Test func `clamp channels bounds every channel`() {
@@ -166,12 +206,14 @@ struct OpenClawMascotAnimatorTests {
         pose.bodyStretch = 3
         pose.bodyTilt = -90
         pose.leftClawDegrees = 400
+        pose.hardHat = 4
         pose.gaze = CGSize(width: 9, height: -9)
         pose.clampChannels()
         #expect(pose.floatOffset == -12)
         #expect(pose.bodyStretch == 1.05)
         #expect(pose.bodyTilt == -8)
         #expect(pose.leftClawDegrees == 45)
+        #expect(pose.hardHat == 1)
         #expect(pose.gaze == CGSize(width: 1.2, height: -1.2))
     }
 }


### PR DESCRIPTION
## What Problem This Solves

The onboarding "Getting things ready" page and the post-update window show long-running setup work (installing the bundled Gateway, starting the background service, finishing updates), but the hero mascot just plays the generic `thinking` loop — nothing communicates that OpenClaw is actively *building* something for you. The step can take up to a minute; it deserved more charm.

## Why This Change Was Made

Add playfulness to onboarding with a purpose-built **`.working` mascot mood** ("Clawd the builder") in shared `OpenClawChatUI`:

- **Entrance**: a little safety hard hat drops onto Clawd's head (body squashes as it lands), then a quick claw snap — ready to work.
- **Loop**: the right claw winds up and hammers on a 0.95s cycle; the body bobs and squashes on impact; teal/amber **sparks burst** at the strike point; antennae recoil; eyes narrow in determination and track the work.
- **Charm beat**: every 6–12s Clawd pauses, wipes its brow with a claw while a sweat droplet slides down, relieved happy eyes — then back to hammering.
- Reduce Motion gets a calm static pose: hat on, claw mid-windup.

Wired in on macOS: onboarding CLI-install page (installing / probe-deciding states) and the post-update working phases. The mood lives in the shared kit, so the iOS app can adopt it wherever it fits; Android/web have separate mascot implementations and are untouched.

## User Impact

During setup and updates, the mascot visibly works — hard hat, hammering, sparks, brow wipes — instead of idly pondering. Failure (`sad`) and success (`happy`/`celebrating`) states are unchanged.

![working mood animation](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/working-mascot-mood/working-mood.gif)

| Hat drop (entrance) | Windup (light) | Strike + sparks | Brow wipe | Reduce Motion static |
| --- | --- | --- | --- | --- |
| ![hat drop](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/working-mascot-mood/01-hat-drop-dark.png) | ![windup](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/working-mascot-mood/03-windup-light.png) | ![sparks](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/working-mascot-mood/04-strike-sparks-dark.png) | ![brow wipe](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/working-mascot-mood/07-brow-wipe-dark.png) | ![static](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/working-mascot-mood/08-static-reduce-motion-dark.png) |

## Evidence

- `swift test --package-path apps/shared/OpenClawKit --filter OpenClawMascotAnimatorTests` — 15/15 pass (new: hammer range + hat + sparks, brow-wipe beat, static pose, hardHat clamp; the all-moods bounds test covers `.working` via `CaseIterable`).
- `swift test --package-path apps/macos --filter OnboardingMascotMoodTests` — 7/7 pass (CLI page installing/probe states now expect `.working`).
- `swiftformat --lint` (repo config) clean on all six touched files; `git diff --check` clean.
- Visuals above are rendered from the real animator/canvas at fixed timestamps (seeded, deterministic) — the GIF is 30fps animator output including the located first brow-wipe beat.
- Autoreview (Codex, gpt-5.6-sol, xhigh): clean, no findings.
