### PR TITLE
refactor(diagnostics): unify heartbeat recovery dispatch

### DIFF
--- a/src/logging/diagnostic.ts
+++ b/src/logging/diagnostic.ts
@@ -1332,47 +1332,36 @@ export function startDiagnosticHeartbeat(
           thresholdMs: stuckSessionWarnMs,
           abortThresholdMs: stuckSessionAbortMs,
         });
-        if (classification?.recoveryEligible && !shouldDeferRecovery) {
-          requestStuckSessionRecovery({
-            recover: opts?.recoverStuckSession ?? recoverStuckSession,
-            classification,
-            request: {
-              sessionId: state.sessionId,
-              sessionKey: state.sessionKey,
-              sessionFile: state.sessionFile,
-              ageMs: attentionAgeMs,
-              queueDepth: state.queueDepth,
-              expectedState: state.state,
-              stateGeneration: state.generation,
-              staleActiveProgressAbortMs: stuckSessionAbortMs,
-              compactionSafetyTimeoutMs,
-            },
-          });
-        } else if (
-          classification &&
-          !shouldDeferRecovery &&
+        if (!classification || shouldDeferRecovery) {
+          continue;
+        }
+        const activeAbortEligible =
+          !classification.recoveryEligible &&
           isActiveAbortRecoveryEligible({
             classification,
             activity,
             stuckSessionAbortMs,
-          })
-        ) {
-          requestStuckSessionRecovery({
-            recover: opts?.recoverStuckSession ?? recoverStuckSession,
-            classification,
-            request: {
-              sessionId: state.sessionId,
-              sessionKey: state.sessionKey,
-              sessionFile: state.sessionFile,
-              ageMs: attentionAgeMs,
-              queueDepth: state.queueDepth,
-              allowActiveAbort: true,
-              expectedState: state.state,
-              stateGeneration: state.generation,
-              compactionSafetyTimeoutMs,
-            },
           });
+        if (!classification.recoveryEligible && !activeAbortEligible) {
+          continue;
         }
+        requestStuckSessionRecovery({
+          recover: opts?.recoverStuckSession ?? recoverStuckSession,
+          classification,
+          request: {
+            sessionId: state.sessionId,
+            sessionKey: state.sessionKey,
+            sessionFile: state.sessionFile,
+            ageMs: attentionAgeMs,
+            queueDepth: state.queueDepth,
+            expectedState: state.state,
+            stateGeneration: state.generation,
+            ...(activeAbortEligible
+              ? { allowActiveAbort: true }
+              : { staleActiveProgressAbortMs: stuckSessionAbortMs }),
+            compactionSafetyTimeoutMs,
+          },
+        });
       }
     }
   }, DIAGNOSTIC_HEARTBEAT_INTERVAL_MS);


### PR DESCRIPTION
Related: #108455

## What Problem This Solves

The diagnostics heartbeat had two nearly identical recovery-dispatch branches for classic stale-session recovery and active-run abort recovery. The duplicate gates and request construction made the recently fixed behavior easier to drift during future maintenance.

## Why This Change Was Made

Collapse both modes into one guarded recovery request while keeping their mutually exclusive options: classic recovery supplies the stale-progress threshold, and active abort explicitly opts into aborting an active run. No recovery eligibility or deferral semantics change.

## User Impact

No user-visible behavior change. This is a focused follow-up cleanup to keep diagnostics recovery easier to reason about and maintain.

## Evidence

- Blacksmith Testbox: `src/logging/diagnostic.test.ts` — 83/83 passed
- `oxfmt --check src/logging/diagnostic.ts` — clean
- targeted oxlint — clean
- `git diff --check` — clean
- fresh autoreview on the rebased branch — no accepted/actionable findings
