### PR TITLE
fix: Feishu drops inbound messages when reply session initialization conflicts

### DIFF
--- a/extensions/feishu/src/bot.session-conflict-retry.test.ts
+++ b/extensions/feishu/src/bot.session-conflict-retry.test.ts
@@ -1,0 +1,255 @@
+// Feishu tests cover inbound dispatch retry/notice parity for reply session init conflicts.
+import { createRuntimeEnv } from "openclaw/plugin-sdk/plugin-test-runtime";
+import type { ResolvedAgentRoute } from "openclaw/plugin-sdk/routing";
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ClawdbotConfig, PluginRuntime } from "../runtime-api.js";
+import type { FeishuMessageEvent } from "./bot.js";
+import { handleFeishuMessage } from "./bot.js";
+import { setFeishuRuntime } from "./runtime.js";
+
+const {
+  mockCreateFeishuReplyDispatcher,
+  mockSendMessageFeishu,
+  mockCreateFeishuClient,
+  mockResolveFeishuReasoningPreviewEnabled,
+  mockMaybeCreateDynamicAgent,
+} = vi.hoisted(() => ({
+  mockCreateFeishuReplyDispatcher: vi.fn(() => ({
+    dispatcher: {
+      sendToolResult: vi.fn(),
+      sendBlockReply: vi.fn(),
+      sendFinalReply: vi.fn(),
+      waitForIdle: vi.fn(),
+      getQueuedCounts: vi.fn(() => ({ tool: 0, block: 0, final: 0 })),
+      getFailedCounts: vi.fn(() => ({ tool: 0, block: 0, final: 0 })),
+      markComplete: vi.fn(),
+    },
+    replyOptions: {},
+    markDispatchIdle: vi.fn(),
+    ensureNoVisibleReplyFallback: vi.fn(),
+  })),
+  mockSendMessageFeishu: vi.fn(),
+  mockCreateFeishuClient: vi.fn(),
+  mockResolveFeishuReasoningPreviewEnabled: vi.fn(() => false),
+  mockMaybeCreateDynamicAgent: vi.fn(),
+}));
+
+vi.mock("./reply-dispatcher.js", () => ({
+  createFeishuReplyDispatcher: mockCreateFeishuReplyDispatcher,
+}));
+
+vi.mock("./reasoning-preview.js", () => ({
+  resolveFeishuReasoningPreviewEnabled: mockResolveFeishuReasoningPreviewEnabled,
+}));
+
+vi.mock("./send.js", () => ({
+  sendMessageFeishu: mockSendMessageFeishu,
+  getMessageFeishu: vi.fn().mockResolvedValue(null),
+  listFeishuThreadMessages: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock("./client.js", () => ({
+  createFeishuClient: mockCreateFeishuClient,
+}));
+
+vi.mock("./dynamic-agent.js", () => ({
+  maybeCreateDynamicAgent: mockMaybeCreateDynamicAgent,
+}));
+
+vi.mock("openclaw/plugin-sdk/conversation-runtime", async () => {
+  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/conversation-runtime")>(
+    "openclaw/plugin-sdk/conversation-runtime",
+  );
+  return {
+    ...actual,
+    resolveConfiguredBindingRoute: ({ route }: { route: ResolvedAgentRoute }) => ({
+      bindingResolution: null,
+      route,
+    }),
+    resolveRuntimeConversationBindingRoute: ({ route }: { route: ResolvedAgentRoute }) => ({
+      bindingRecord: null,
+      route,
+    }),
+    ensureConfiguredBindingRouteReady: async () => ({ ok: true }),
+    getSessionBindingService: () => ({
+      resolveByConversation: () => null,
+      touch: () => {},
+    }),
+  };
+});
+
+afterAll(() => {
+  vi.doUnmock("./reply-dispatcher.js");
+  vi.doUnmock("./reasoning-preview.js");
+  vi.doUnmock("./send.js");
+  vi.doUnmock("./client.js");
+  vi.doUnmock("./dynamic-agent.js");
+  vi.doUnmock("openclaw/plugin-sdk/conversation-runtime");
+  vi.resetModules();
+});
+
+const CONFLICT_ERROR = new Error(
+  "reply session initialization conflicted for agent:main:feishu:direct:ou_sender_1",
+);
+
+const CFG = {
+  session: { mainKey: "main", scope: "per-sender" },
+  channels: {
+    feishu: {
+      enabled: true,
+      dmPolicy: "open",
+      allowFrom: ["*"],
+      resolveSenderNames: false,
+    },
+  },
+} as ClawdbotConfig;
+
+let messageCounter = 0;
+
+function createDmEvent(): FeishuMessageEvent {
+  messageCounter += 1;
+  return {
+    sender: { sender_id: { open_id: "ou_sender_1" } },
+    message: {
+      message_id: `msg-conflict-${messageCounter}`,
+      chat_id: "oc_dm",
+      chat_type: "p2p",
+      message_type: "text",
+      content: JSON.stringify({ text: "hello" }),
+    },
+  };
+}
+
+function createFeishuBotRuntime(
+  inboundRun: PluginRuntime["channel"]["inbound"]["run"],
+): PluginRuntime {
+  return {
+    config: {
+      current: vi.fn(() => CFG),
+    },
+    channel: {
+      routing: {
+        resolveAgentRoute: vi.fn(
+          (): ResolvedAgentRoute => ({
+            agentId: "main",
+            channel: "feishu",
+            accountId: "default",
+            sessionKey: "agent:main:feishu:direct:ou_sender_1",
+            mainSessionKey: "agent:main:main",
+            lastRoutePolicy: "session",
+            matchedBy: "default",
+          }),
+        ),
+      },
+      session: {
+        readSessionUpdatedAt: vi.fn(() => undefined),
+        resolveStorePath: vi.fn(() => "/tmp/feishu-sessions.json"),
+        recordInboundSession: vi.fn(async () => undefined),
+      },
+      reply: {
+        resolveEnvelopeFormatOptions: vi.fn(() => ({})),
+        formatAgentEnvelope: vi.fn((params: { body: string }) => params.body),
+        finalizeInboundContext: vi.fn((ctx: Record<string, unknown>) => ctx),
+        dispatchReplyFromConfig: vi
+          .fn()
+          .mockResolvedValue({ queuedFinal: false, counts: { final: 1 } }),
+        withReplyDispatcher: vi.fn(async ({ run }: { run: () => Promise<unknown> }) => await run()),
+        settleReplyDispatcher: vi.fn(async () => undefined),
+      },
+      commands: {
+        shouldComputeCommandAuthorized: vi.fn(() => false),
+        resolveCommandAuthorizedFromAuthorizers: vi.fn(() => false),
+      },
+      pairing: {
+        readAllowFromStore: vi.fn(async () => ["ou_sender_1"]),
+        upsertPairingRequest: vi.fn(),
+        buildPairingReply: vi.fn(),
+      },
+      inbound: {
+        run: inboundRun,
+      },
+    },
+  } as unknown as PluginRuntime;
+}
+
+async function dispatchDmMessage(inboundRun: PluginRuntime["channel"]["inbound"]["run"]) {
+  setFeishuRuntime(createFeishuBotRuntime(inboundRun));
+  const runtime = createRuntimeEnv();
+  const settled = handleFeishuMessage({ cfg: CFG, event: createDmEvent(), runtime });
+  // Drain the retry backoff ladder (1s + 2s + 4s) plus slack for other timers.
+  for (let i = 0; i < 8; i += 1) {
+    await vi.advanceTimersByTimeAsync(1_000);
+  }
+  await settled;
+  return runtime;
+}
+
+describe("feishu reply session init conflict retry", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    mockMaybeCreateDynamicAgent.mockImplementation(async ({ cfg }: { cfg: ClawdbotConfig }) => ({
+      created: false,
+      updatedCfg: cfg,
+    }));
+    mockSendMessageFeishu.mockResolvedValue({ messageId: "notice-msg", chatId: "oc_dm" });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("retries dispatch after a reply session init conflict and recovers", async () => {
+    const inboundRun = vi
+      .fn()
+      .mockRejectedValueOnce(CONFLICT_ERROR)
+      .mockResolvedValueOnce({
+        dispatched: true,
+        dispatchResult: { queuedFinal: false, counts: { final: 1 } },
+      });
+
+    const runtime = await dispatchDmMessage(inboundRun);
+
+    expect(inboundRun).toHaveBeenCalledTimes(2);
+    expect(mockSendMessageFeishu).not.toHaveBeenCalled();
+    expect(runtime.error).not.toHaveBeenCalled();
+  });
+
+  it("notifies the sender instead of dropping silently when the conflict persists", async () => {
+    const inboundRun = vi.fn().mockRejectedValue(CONFLICT_ERROR);
+
+    const runtime = await dispatchDmMessage(inboundRun);
+
+    // Initial attempt plus the bounded retry ladder.
+    expect(inboundRun).toHaveBeenCalledTimes(4);
+    expect(mockSendMessageFeishu).toHaveBeenCalledTimes(1);
+    const notice = mockSendMessageFeishu.mock.calls[0]?.[0] as {
+      to?: string;
+      text?: string;
+      replyToMessageId?: string;
+    };
+    expect(notice.to).toBe("user:ou_sender_1");
+    expect(notice.text).toContain("session stayed busy");
+    // The loss notice must land as a reply to the dropped message, not detached.
+    expect(notice.replyToMessageId).toMatch(/^msg-conflict-/);
+    expect(
+      (runtime.error as ReturnType<typeof vi.fn>).mock.calls.some((call) =>
+        String(call[0]).includes("reply session init conflict"),
+      ),
+    ).toBe(true);
+  });
+
+  it("does not retry or notify for non-conflict dispatch failures", async () => {
+    const inboundRun = vi.fn().mockRejectedValue(new Error("feishu api unavailable"));
+
+    const runtime = await dispatchDmMessage(inboundRun);
+
+    expect(inboundRun).toHaveBeenCalledTimes(1);
+    expect(mockSendMessageFeishu).not.toHaveBeenCalled();
+    expect(
+      (runtime.error as ReturnType<typeof vi.fn>).mock.calls.some((call) =>
+        String(call[0]).includes("failed to dispatch message"),
+      ),
+    ).toBe(true);
+  });
+});

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -66,6 +66,11 @@ import { resolveFeishuReasoningPreviewEnabled } from "./reasoning-preview.js";
 import { createFeishuReplyDispatcher } from "./reply-dispatcher.js";
 import { getFeishuRuntime } from "./runtime.js";
 import { getMessageFeishu, listFeishuThreadMessages, sendMessageFeishu } from "./send.js";
+import {
+  FEISHU_SESSION_CONFLICT_FAILURE_TEXT,
+  FeishuSessionConflictExhaustedError,
+  runFeishuDispatchWithSessionInitConflictRetry,
+} from "./session-conflict-retry.js";
 export type { FeishuBotAddedEvent, FeishuMessageEvent } from "./event-types.js";
 import type { FeishuMessageEvent } from "./event-types.js";
 import {
@@ -1346,6 +1351,28 @@ export async function handleFeishuMessage(params: {
       };
     };
 
+    // Exhausted session-init retries would otherwise drop the inbound message
+    // silently (parity gap vs Slack/Signal/Discord/WhatsApp) — tell the sender.
+    const notifySessionConflictLoss = async (noticeCfg: ClawdbotConfig, cause: unknown) => {
+      error(
+        `feishu[${account.accountId}]: dropping inbound message after reply session init conflict retries: ${String(cause)}`,
+      );
+      try {
+        await sendMessageFeishu({
+          cfg: noticeCfg,
+          to: feishuTo,
+          text: FEISHU_SESSION_CONFLICT_FAILURE_TEXT,
+          replyToMessageId: replyTargetMessageId,
+          replyInThread,
+          accountId: account.accountId,
+        });
+      } catch (noticeErr) {
+        error(
+          `feishu[${account.accountId}]: failed to send session-conflict notice: ${String(noticeErr)}`,
+        );
+      }
+    };
+
     if (broadcastAgents) {
       // Cross-account dedup: in multi-account setups, Feishu delivers the same
       // event to every bot account in the group. Only one account should handle
@@ -1543,27 +1570,45 @@ export async function handleFeishuMessage(params: {
         }
       };
 
+      // Broadcast keeps its per-agent isolation catch, but each agent attempt
+      // gets the same conflict retry as single-agent dispatch so a transient
+      // session-init race does not silently drop that agent's turn.
+      const dispatchForAgentWithRetry = (agentId: string) =>
+        runFeishuDispatchWithSessionInitConflictRetry({
+          dispatch: () => dispatchForAgent(agentId),
+          onRetry: (attempt, delayMs) => {
+            log(
+              `feishu[${account.accountId}]: broadcast reply session init conflict for agent=${agentId}; retrying in ${delayMs}ms (attempt ${attempt})`,
+            );
+          },
+        });
+      // Only the active agent replies on Feishu, so only its exhausted
+      // conflict owes the sender a loss notice; observer failures stay logged.
+      const handleBroadcastDispatchFailure = async (agentId: string, err: unknown) => {
+        log(
+          `feishu[${account.accountId}]: broadcast dispatch failed for agent=${agentId}: ${String(err)}`,
+        );
+        if (err instanceof FeishuSessionConflictExhaustedError && agentId === activeAgentId) {
+          await notifySessionConflictLoss(cfg, err);
+        }
+      };
       if (strategy === "sequential") {
         for (const agentId of broadcastAgents) {
           try {
-            await dispatchForAgent(agentId);
+            await dispatchForAgentWithRetry(agentId);
           } catch (err) {
-            log(
-              `feishu[${account.accountId}]: broadcast dispatch failed for agent=${agentId}: ${String(err)}`,
-            );
+            await handleBroadcastDispatchFailure(agentId, err);
           }
         }
       } else {
-        const results = await Promise.allSettled(broadcastAgents.map(dispatchForAgent));
+        const results = await Promise.allSettled(broadcastAgents.map(dispatchForAgentWithRetry));
         for (const [i, result] of results.entries()) {
           if (result.status === "rejected") {
             const agentId = broadcastAgents.at(i);
             if (agentId === undefined) {
               continue;
             }
-            log(
-              `feishu[${account.accountId}]: broadcast dispatch failed for agent=${agentId}: ${String(result.reason)}`,
-            );
+            await handleBroadcastDispatchFailure(agentId, result.reason);
           }
         }
       }
@@ -1597,104 +1642,123 @@ export async function handleFeishuMessage(params: {
         storePath,
         sessionKey: route.sessionKey,
       });
-      const { dispatcher, replyOptions, markDispatchIdle, ensureNoVisibleReplyFallback } =
-        createFeishuReplyDispatcher({
-          cfg: effectiveCfg,
-          agentId: route.agentId,
-          runtime: runtime as RuntimeEnv,
-          chatId: ctx.chatId,
-          sendTarget: feishuTo,
-          allowReasoningPreview,
-          replyToMessageId: replyTargetMessageId,
-          typingTargetMessageId,
-          skipReplyToInMessages: !isGroup && !directThreadReply,
-          replyInThread,
-          rootId: ctx.rootId,
-          threadReply,
-          accountId: account.accountId,
-          identity,
-          mentionTargets: ctx.mentionTargets,
-          messageCreateTimeMs,
-          sessionKey: route.sessionKey,
-        });
+      // Each attempt rebuilds the dispatcher: a settled dispatcher must not
+      // carry queued/settled state into a session-init-conflict retry.
+      const runSingleAgentDispatch = async () => {
+        const { dispatcher, replyOptions, markDispatchIdle, ensureNoVisibleReplyFallback } =
+          createFeishuReplyDispatcher({
+            cfg: effectiveCfg,
+            agentId: route.agentId,
+            runtime: runtime as RuntimeEnv,
+            chatId: ctx.chatId,
+            sendTarget: feishuTo,
+            allowReasoningPreview,
+            replyToMessageId: replyTargetMessageId,
+            typingTargetMessageId,
+            skipReplyToInMessages: !isGroup && !directThreadReply,
+            replyInThread,
+            rootId: ctx.rootId,
+            threadReply,
+            accountId: account.accountId,
+            identity,
+            mentionTargets: ctx.mentionTargets,
+            messageCreateTimeMs,
+            sessionKey: route.sessionKey,
+          });
 
-      log(`feishu[${account.accountId}]: dispatching to agent (session=${route.sessionKey})`);
-      const turnResult = await core.channel.inbound.run({
-        channel: "feishu",
-        accountId: route.accountId,
-        raw: ctx,
-        adapter: {
-          ingest: () => ({
-            id: ctx.messageId,
-            timestamp: messageCreateTimeMs,
-            rawText: ctx.content,
-            textForAgent: ctxPayload.BodyForAgent,
-            textForCommands: ctxPayload.CommandBody,
-            raw: ctx,
-          }),
-          resolveTurn: () => ({
-            channel: "feishu",
-            accountId: route.accountId,
-            routeSessionKey: route.sessionKey,
-            storePath,
-            ctxPayload,
-            recordInboundSession: core.channel.session.recordInboundSession,
-            record: {
-              updateLastRoute: buildFeishuInboundLastRouteUpdate({
-                sessionKey: route.sessionKey,
-                accountId: route.accountId,
-              }),
-              onRecordError: (err) => {
-                log(
-                  `feishu[${account.accountId}]: failed to record inbound session ${route.sessionKey}: ${String(err)}`,
-                );
-              },
-            },
-            history: {
-              isGroup,
-              historyKey,
-              historyMap: chatHistories,
-              limit: historyLimit,
-            },
-            onPreDispatchFailure: () =>
-              core.channel.reply.settleReplyDispatcher({
-                dispatcher,
-                onSettled: () => markDispatchIdle(),
-              }),
-            runDispatch: () =>
-              core.channel.reply.withReplyDispatcher({
-                dispatcher,
-                onSettled: () => {
-                  markDispatchIdle();
+        log(`feishu[${account.accountId}]: dispatching to agent (session=${route.sessionKey})`);
+        const turnResult = await core.channel.inbound.run({
+          channel: "feishu",
+          accountId: route.accountId,
+          raw: ctx,
+          adapter: {
+            ingest: () => ({
+              id: ctx.messageId,
+              timestamp: messageCreateTimeMs,
+              rawText: ctx.content,
+              textForAgent: ctxPayload.BodyForAgent,
+              textForCommands: ctxPayload.CommandBody,
+              raw: ctx,
+            }),
+            resolveTurn: () => ({
+              channel: "feishu",
+              accountId: route.accountId,
+              routeSessionKey: route.sessionKey,
+              storePath,
+              ctxPayload,
+              recordInboundSession: core.channel.session.recordInboundSession,
+              record: {
+                updateLastRoute: buildFeishuInboundLastRouteUpdate({
+                  sessionKey: route.sessionKey,
+                  accountId: route.accountId,
+                }),
+                onRecordError: (err) => {
+                  log(
+                    `feishu[${account.accountId}]: failed to record inbound session ${route.sessionKey}: ${String(err)}`,
+                  );
                 },
-                run: () =>
-                  core.channel.reply.dispatchReplyFromConfig({
-                    ctx: ctxPayload,
-                    cfg: effectiveCfg,
-                    dispatcher,
-                    replyOptions,
-                  }),
-              }),
-          }),
-        },
-      });
-      if (!turnResult.dispatched) {
-        return;
-      }
-      const { dispatchResult } = turnResult;
-      const { queuedFinal, counts } = dispatchResult;
-      if (
-        shouldSendNoVisibleReplyFallback({
-          ...dispatchResult,
-          failedCounts: dispatcher.getFailedCounts?.() ?? { tool: 0, block: 0, final: 0 },
-        })
-      ) {
-        await ensureNoVisibleReplyFallback("dispatch-complete-no-visible-reply");
-      }
+              },
+              history: {
+                isGroup,
+                historyKey,
+                historyMap: chatHistories,
+                limit: historyLimit,
+              },
+              onPreDispatchFailure: () =>
+                core.channel.reply.settleReplyDispatcher({
+                  dispatcher,
+                  onSettled: () => markDispatchIdle(),
+                }),
+              runDispatch: () =>
+                core.channel.reply.withReplyDispatcher({
+                  dispatcher,
+                  onSettled: () => {
+                    markDispatchIdle();
+                  },
+                  run: () =>
+                    core.channel.reply.dispatchReplyFromConfig({
+                      ctx: ctxPayload,
+                      cfg: effectiveCfg,
+                      dispatcher,
+                      replyOptions,
+                    }),
+                }),
+            }),
+          },
+        });
+        if (!turnResult.dispatched) {
+          return;
+        }
+        const { dispatchResult } = turnResult;
+        const { queuedFinal, counts } = dispatchResult;
+        if (
+          shouldSendNoVisibleReplyFallback({
+            ...dispatchResult,
+            failedCounts: dispatcher.getFailedCounts?.() ?? { tool: 0, block: 0, final: 0 },
+          })
+        ) {
+          await ensureNoVisibleReplyFallback("dispatch-complete-no-visible-reply");
+        }
 
-      log(
-        `feishu[${account.accountId}]: dispatch complete (queuedFinal=${queuedFinal}, replies=${counts.final})`,
-      );
+        log(
+          `feishu[${account.accountId}]: dispatch complete (queuedFinal=${queuedFinal}, replies=${counts.final})`,
+        );
+      };
+      try {
+        await runFeishuDispatchWithSessionInitConflictRetry({
+          dispatch: runSingleAgentDispatch,
+          onRetry: (attempt, delayMs) => {
+            log(
+              `feishu[${account.accountId}]: reply session init conflict; retrying dispatch in ${delayMs}ms (attempt ${attempt})`,
+            );
+          },
+        });
+      } catch (err) {
+        if (!(err instanceof FeishuSessionConflictExhaustedError)) {
+          throw err;
+        }
+        await notifySessionConflictLoss(effectiveCfg, err);
+      }
     }
   } catch (err) {
     error(`feishu[${account.accountId}]: failed to dispatch message: ${String(err)}`);

--- a/extensions/feishu/src/session-conflict-retry.test.ts
+++ b/extensions/feishu/src/session-conflict-retry.test.ts
@@ -1,0 +1,80 @@
+// Feishu tests cover the session-init conflict matcher and bounded retry ladder.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  FeishuSessionConflictExhaustedError,
+  isFeishuReplySessionInitConflictError,
+  runFeishuDispatchWithSessionInitConflictRetry,
+} from "./session-conflict-retry.js";
+
+const CONFLICT_ERROR = new Error(
+  "reply session initialization conflicted for agent:main:feishu:direct:ou_sender_1",
+);
+
+describe("isFeishuReplySessionInitConflictError", () => {
+  it("matches direct, cause-nested, and error-property-nested conflicts", () => {
+    expect(isFeishuReplySessionInitConflictError(CONFLICT_ERROR)).toBe(true);
+    expect(
+      isFeishuReplySessionInitConflictError(new Error("wrapper", { cause: CONFLICT_ERROR })),
+    ).toBe(true);
+    expect(
+      isFeishuReplySessionInitConflictError(
+        new Error("wrapper", { cause: { error: CONFLICT_ERROR } }),
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects unrelated errors", () => {
+    expect(isFeishuReplySessionInitConflictError(new Error("rate limited"))).toBe(false);
+    expect(isFeishuReplySessionInitConflictError(undefined)).toBe(false);
+  });
+});
+
+describe("runFeishuDispatchWithSessionInitConflictRetry", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("retries conflicts on the 1s/2s/4s ladder and returns the first success", async () => {
+    const dispatch = vi
+      .fn()
+      .mockRejectedValueOnce(CONFLICT_ERROR)
+      .mockRejectedValueOnce(CONFLICT_ERROR)
+      .mockResolvedValueOnce("ok");
+    const onRetry = vi.fn();
+
+    const result = runFeishuDispatchWithSessionInitConflictRetry({ dispatch, onRetry });
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(dispatch).toHaveBeenCalledTimes(2);
+    await vi.advanceTimersByTimeAsync(2_000);
+    await expect(result).resolves.toBe("ok");
+    expect(dispatch).toHaveBeenCalledTimes(3);
+    expect(onRetry.mock.calls).toEqual([
+      [1, 1_000],
+      [2, 2_000],
+    ]);
+  });
+
+  it("throws a typed exhausted error carrying the conflict after the ladder is spent", async () => {
+    const dispatch = vi.fn().mockRejectedValue(CONFLICT_ERROR);
+
+    const result = runFeishuDispatchWithSessionInitConflictRetry({ dispatch });
+    const rejection = result.catch((err: unknown) => err);
+    await vi.advanceTimersByTimeAsync(7_000);
+    const err = await rejection;
+    expect(err).toBeInstanceOf(FeishuSessionConflictExhaustedError);
+    expect((err as FeishuSessionConflictExhaustedError).cause).toBe(CONFLICT_ERROR);
+    expect(dispatch).toHaveBeenCalledTimes(4);
+  });
+
+  it("rethrows non-conflict failures without retrying", async () => {
+    const failure = new Error("feishu api unavailable");
+    const dispatch = vi.fn().mockRejectedValue(failure);
+
+    await expect(runFeishuDispatchWithSessionInitConflictRetry({ dispatch })).rejects.toBe(failure);
+    expect(dispatch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/extensions/feishu/src/session-conflict-retry.ts
+++ b/extensions/feishu/src/session-conflict-retry.ts
@@ -1,0 +1,53 @@
+// Feishu plugin module implements inbound dispatch retry for reply-session init conflicts.
+import { collectErrorGraphCandidates, formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import { sleepWithAbort } from "openclaw/plugin-sdk/runtime-env";
+
+// The message shape is the cross-channel retry classification contract raised
+// by core reply-session initialization (see ReplySessionInitConflictError).
+const REPLY_SESSION_INIT_CONFLICT_MESSAGE_RE = /reply session initialization conflicted for \S+/u;
+// Parity with the Signal/Discord inbound retry ladders: bounded backoff before
+// declaring the inbound message lost.
+const FEISHU_SESSION_INIT_CONFLICT_RETRY_DELAYS_MS = [1_000, 2_000, 4_000] as const;
+
+export const FEISHU_SESSION_CONFLICT_FAILURE_TEXT =
+  "⚠️ Couldn't process this message because the session stayed busy. Please try again in a moment.";
+
+export function isFeishuReplySessionInitConflictError(error: unknown): boolean {
+  return collectErrorGraphCandidates(error, (current) => [current.cause, current.error]).some(
+    (candidate) => REPLY_SESSION_INIT_CONFLICT_MESSAGE_RE.test(formatErrorMessage(candidate)),
+  );
+}
+
+/** Raised when a session-init conflict survives every channel retry delay; callers owe the sender a visible loss notice. */
+export class FeishuSessionConflictExhaustedError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "FeishuSessionConflictExhaustedError";
+  }
+}
+
+// Retries only reply-session init conflicts; other failures propagate as-is so
+// the dispatch catch keeps its existing logging behavior.
+export async function runFeishuDispatchWithSessionInitConflictRetry<T>(params: {
+  dispatch: () => Promise<T>;
+  onRetry?: (attempt: number, delayMs: number) => void;
+}): Promise<T> {
+  for (let retryIndex = 0; ; retryIndex += 1) {
+    try {
+      return await params.dispatch();
+    } catch (error) {
+      if (!isFeishuReplySessionInitConflictError(error)) {
+        throw error;
+      }
+      const delayMs = FEISHU_SESSION_INIT_CONFLICT_RETRY_DELAYS_MS[retryIndex];
+      if (delayMs === undefined) {
+        throw new FeishuSessionConflictExhaustedError(
+          `reply session init conflict persisted after channel retries: ${formatErrorMessage(error)}`,
+          { cause: error },
+        );
+      }
+      params.onRetry?.(retryIndex + 1, delayMs);
+      await sleepWithAbort(delayMs);
+    }
+  }
+}


### PR DESCRIPTION
Closes #108320

## What Problem This Solves

Fixes an issue where Feishu users could have an inbound message silently dropped when reply-session initialization remained conflicted after the shared retry path finished. The sender received no reply or failure notice, so the bot appeared unresponsive and the message was lost.

## Why This Change Was Made

The Feishu inbound path now retries only reply-session initialization conflicts with a bounded 1s/2s/4s backoff. Each attempt creates a fresh reply dispatcher; if the conflict persists, the active single-agent or broadcast path replies to the affected message with a concise request to try again. Other dispatch failures keep their existing behavior.

## User Impact

Feishu users can expect transient session conflicts to recover automatically. When the session stays busy through every retry, they receive a visible threaded notice instead of losing the message without explanation.

## Evidence

- Focused retry-helper coverage passes all 5 tests: direct and nested conflict detection, successful retry, exhausted retries, and non-conflict propagation.
- Existing Feishu handler control coverage passes all 22 tests.
- All four changed files pass `oxfmt --check`, extension `oxlint`, and `git diff --check`.
- Added handler coverage for recovery after a conflict, a visible reply after exhausted retries, and unchanged handling of unrelated failures.
- AI-assisted: yes. The implementation and its retry/error-handling behavior were reviewed before submission.
