### PR TITLE
fix: prevent Telegram migration no-op loops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Legacy plugin-state migrations:** preflight namespace capacity before importing, keep capped sources intact with a clear warning instead of partially migrating, and drop Telegram sent-message entries at the TTL boundary. Fixes #108286. Thanks @jamiezigelbaum.
 - **Tlon SSE connect cleanup:** disarm opening deadlines after failed HTTP responses and rejected stream opens so reconnect attempts cannot leave stale timers behind. (#104585) Thanks @hugenshen.
 - **LINE reply-token media kinds:** honor video and audio metadata on inbound replies, share the canonical media builder with proactive sends, and fail visibly instead of recording empty media-only deliveries. (#106515) Thanks @edenfunf.
 - **Mattermost websocket connection deadlines:** bound opening handshakes so stalled TCP peers cannot hang channel startup indefinitely and reconnect control resumes after timeout. (#105553) Thanks @hugenshen.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Legacy plugin-state migrations:** preflight namespace capacity before importing, keep capped sources intact with a clear warning instead of partially migrating, and drop Telegram sent-message entries at the TTL boundary. Fixes #108286. Thanks @jamiezigelbaum.
 - **Tlon SSE connect cleanup:** disarm opening deadlines after failed HTTP responses and rejected stream opens so reconnect attempts cannot leave stale timers behind. (#104585) Thanks @hugenshen.
 - **LINE reply-token media kinds:** honor video and audio metadata on inbound replies, share the canonical media builder with proactive sends, and fail visibly instead of recording empty media-only deliveries. (#106515) Thanks @edenfunf.
 - **Mattermost websocket connection deadlines:** bound opening handshakes so stalled TCP peers cannot hang channel startup indefinitely and reconnect control resumes after timeout. (#105553) Thanks @hugenshen.

--- a/extensions/telegram/src/sent-message-cache.ts
+++ b/extensions/telegram/src/sent-message-cache.ts
@@ -105,7 +105,7 @@ function readLegacySentMessages(filePath: string): SentMessageStore {
         if (
           typeof timestamp === "number" &&
           Number.isFinite(timestamp) &&
-          now - timestamp <= TTL_MS
+          now - timestamp < TTL_MS
         ) {
           messages.set(messageId, timestamp);
         }
@@ -224,10 +224,17 @@ export function listTelegramLegacySentMessageCacheEntries(params: {
     ? readLegacySentMessages(filePath)
     : createSentMessageStore();
   return [...legacy.entries()].flatMap(([chatId, messages]) =>
-    [...messages.entries()].map(([messageId, timestamp]) => ({
-      key: sentMessageEntryKey(scopeKey, chatId, messageId),
-      value: { scopeKey, chatId, messageId, timestamp },
-      ttlMs: Math.max(1, TTL_MS - Math.max(0, Date.now() - timestamp)),
-    })),
+    [...messages.entries()].flatMap(([messageId, timestamp]) => {
+      const ttlMs = TTL_MS - Math.max(0, Date.now() - timestamp);
+      return ttlMs > 0
+        ? [
+            {
+              key: sentMessageEntryKey(scopeKey, chatId, messageId),
+              value: { scopeKey, chatId, messageId, timestamp },
+              ttlMs,
+            },
+          ]
+        : [];
+    }),
   );
 }

--- a/extensions/telegram/src/state-migrations.test.ts
+++ b/extensions/telegram/src/state-migrations.test.ts
@@ -493,10 +493,7 @@ describe("telegram state migrations", () => {
     const boundaryAt = Date.now() - 24 * 60 * 60 * 1000;
     try {
       await mkdir(path.dirname(sentMessagePath), { recursive: true });
-      await writeFile(
-        sentMessagePath,
-        JSON.stringify({ 7: { 42: expiredAt, 43: boundaryAt } }),
-      );
+      await writeFile(sentMessagePath, JSON.stringify({ 7: { 42: expiredAt, 43: boundaryAt } }));
       await writeFile(
         dispatchPath,
         JSON.stringify({ [JSON.stringify(["message", "7", 42])]: expiredAt }),

--- a/extensions/telegram/src/state-migrations.test.ts
+++ b/extensions/telegram/src/state-migrations.test.ts
@@ -478,7 +478,9 @@ describe("telegram state migrations", () => {
     }
   });
 
-  it("cleans up expired Telegram TTL cache sidecars with no importable entries", async () => {
+  it("cleans up expired and boundary Telegram TTL cache sidecars", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-15T12:00:00.000Z"));
     const dir = await mkdtemp(path.join(os.tmpdir(), "openclaw-telegram-state-migration-"));
     const env = { ...process.env, OPENCLAW_STATE_DIR: dir };
     const storePath = resolveStorePath(undefined, { env });
@@ -488,9 +490,13 @@ describe("telegram state migrations", () => {
       namespace: "ops",
     });
     const expiredAt = Date.now() - 8 * 24 * 60 * 60 * 1000;
+    const boundaryAt = Date.now() - 24 * 60 * 60 * 1000;
     try {
       await mkdir(path.dirname(sentMessagePath), { recursive: true });
-      await writeFile(sentMessagePath, JSON.stringify({ 7: { 42: expiredAt } }));
+      await writeFile(
+        sentMessagePath,
+        JSON.stringify({ 7: { 42: expiredAt, 43: boundaryAt } }),
+      );
       await writeFile(
         dispatchPath,
         JSON.stringify({ [JSON.stringify(["message", "7", 42])]: expiredAt }),
@@ -522,37 +528,6 @@ describe("telegram state migrations", () => {
         }
         expect(await plan.readEntries()).toStrictEqual([]);
       }
-    } finally {
-      await rm(dir, { recursive: true, force: true });
-    }
-  });
-
-  it("drops sent-message entries at the TTL boundary instead of clamping their TTL", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-07-15T12:00:00.000Z"));
-    const dir = await mkdtemp(path.join(os.tmpdir(), "openclaw-telegram-state-migration-"));
-    const env = { ...process.env, OPENCLAW_STATE_DIR: dir };
-    const storePath = resolveStorePath(undefined, { env });
-    const sentMessagePath = `${storePath}.telegram-sent-messages.json`;
-    try {
-      await mkdir(path.dirname(sentMessagePath), { recursive: true });
-      await writeFile(
-        sentMessagePath,
-        JSON.stringify({ 7: { 42: Date.now() - 24 * 60 * 60 * 1000 } }),
-      );
-
-      const plans = await detectTelegramLegacyStateMigrations({ cfg: {}, env });
-      const plan = plans.find(
-        (candidate) =>
-          candidate.kind === "plugin-state-import" &&
-          candidate.label === "Telegram sent-message cache" &&
-          candidate.sourcePath === sentMessagePath,
-      );
-      if (!plan || plan.kind !== "plugin-state-import") {
-        throw new Error("expected Telegram sent-message cache import plan");
-      }
-
-      expect(await plan.readEntries()).toStrictEqual([]);
     } finally {
       vi.useRealTimers();
       await rm(dir, { recursive: true, force: true });

--- a/extensions/telegram/src/state-migrations.test.ts
+++ b/extensions/telegram/src/state-migrations.test.ts
@@ -10,7 +10,7 @@ import {
   resetPluginStateStoreForTests,
 } from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import { resolveStorePath } from "openclaw/plugin-sdk/session-store-runtime";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { resolveTelegramBotInfoCachePath } from "./bot-info-cache.js";
 import { resolveTelegramMessageCachePath } from "./message-cache.js";
 import {
@@ -523,6 +523,38 @@ describe("telegram state migrations", () => {
         expect(await plan.readEntries()).toStrictEqual([]);
       }
     } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("drops sent-message entries at the TTL boundary instead of clamping their TTL", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-15T12:00:00.000Z"));
+    const dir = await mkdtemp(path.join(os.tmpdir(), "openclaw-telegram-state-migration-"));
+    const env = { ...process.env, OPENCLAW_STATE_DIR: dir };
+    const storePath = resolveStorePath(undefined, { env });
+    const sentMessagePath = `${storePath}.telegram-sent-messages.json`;
+    try {
+      await mkdir(path.dirname(sentMessagePath), { recursive: true });
+      await writeFile(
+        sentMessagePath,
+        JSON.stringify({ 7: { 42: Date.now() - 24 * 60 * 60 * 1000 } }),
+      );
+
+      const plans = await detectTelegramLegacyStateMigrations({ cfg: {}, env });
+      const plan = plans.find(
+        (candidate) =>
+          candidate.kind === "plugin-state-import" &&
+          candidate.label === "Telegram sent-message cache" &&
+          candidate.sourcePath === sentMessagePath,
+      );
+      if (!plan || plan.kind !== "plugin-state-import") {
+        throw new Error("expected Telegram sent-message cache import plan");
+      }
+
+      expect(await plan.readEntries()).toStrictEqual([]);
+    } finally {
+      vi.useRealTimers();
       await rm(dir, { recursive: true, force: true });
     }
   });

--- a/src/commands/doctor-state-migrations.test.ts
+++ b/src/commands/doctor-state-migrations.test.ts
@@ -1740,6 +1740,103 @@ describe("doctor legacy state migrations", () => {
     expect(fs.existsSync(`${sourcePath}.migrated`)).toBe(false);
   });
 
+  it("skips plugin-state imports when the namespace lacks room for every missing entry", async () => {
+    const root = await makeTempRoot();
+    const sourcePath = path.join(root, "legacy-cache.json");
+    fs.writeFileSync(sourcePath, "legacy", "utf-8");
+    mockedChannelMigrationPlans.plans = [
+      {
+        kind: "plugin-state-import",
+        label: "Test namespace-capped cache",
+        sourcePath,
+        targetPath: "plugin state:test.namespace-capped-cache",
+        pluginId: "telegram",
+        namespace: "test.namespace-capped-cache",
+        maxEntries: 2,
+        scopeKey: "",
+        cleanupSource: "rename",
+        readEntries: () => [
+          { key: "legacy-first", value: { body: "first" } },
+          { key: "legacy-second", value: { body: "second" } },
+        ],
+      },
+    ];
+
+    await withStateDir(root, async () => {
+      const store = createPluginStateKeyedStore<{ body: string }>("telegram", {
+        namespace: "test.namespace-capped-cache",
+        maxEntries: 2,
+      });
+      await store.register("current", { body: "current" });
+    });
+    resetPluginStateStoreForTests();
+
+    const detected = await detectLegacyStateMigrations({
+      cfg: {},
+      env: { OPENCLAW_STATE_DIR: root } as NodeJS.ProcessEnv,
+    });
+    const result = await runLegacyStateMigrations({ detected });
+
+    expect(result.changes).toStrictEqual([]);
+    expect(result.warnings).toStrictEqual([
+      "Skipped migrating Test namespace-capped cache because plugin state namespace test.namespace-capped-cache has room for 1 of 2 missing entries; left legacy source in place",
+    ]);
+    expect(fs.existsSync(sourcePath)).toBe(true);
+    expect(fs.existsSync(`${sourcePath}.migrated`)).toBe(false);
+
+    await withStateDir(root, async () => {
+      const store = createPluginStateKeyedStore<{ body: string }>("telegram", {
+        namespace: "test.namespace-capped-cache",
+        maxEntries: 2,
+      });
+      expect(await store.lookup("current")).toStrictEqual({ body: "current" });
+      expect(await store.lookup("legacy-first")).toBeUndefined();
+      expect(await store.lookup("legacy-second")).toBeUndefined();
+    });
+  });
+
+  it("archives fully covered plugin-state imports when the namespace is full", async () => {
+    const root = await makeTempRoot();
+    const sourcePath = path.join(root, "legacy-cache.json");
+    fs.writeFileSync(sourcePath, "legacy", "utf-8");
+    mockedChannelMigrationPlans.plans = [
+      {
+        kind: "plugin-state-import",
+        label: "Test covered cache",
+        sourcePath,
+        targetPath: "plugin state:test.covered-cache",
+        pluginId: "telegram",
+        namespace: "test.covered-cache",
+        maxEntries: 1,
+        scopeKey: "",
+        cleanupSource: "rename",
+        readEntries: () => [{ key: "covered", value: { body: "legacy" } }],
+      },
+    ];
+
+    await withStateDir(root, async () => {
+      const store = createPluginStateKeyedStore<{ body: string }>("telegram", {
+        namespace: "test.covered-cache",
+        maxEntries: 1,
+      });
+      await store.register("covered", { body: "current" });
+    });
+    resetPluginStateStoreForTests();
+
+    const detected = await detectLegacyStateMigrations({
+      cfg: {},
+      env: { OPENCLAW_STATE_DIR: root } as NodeJS.ProcessEnv,
+    });
+    const result = await runLegacyStateMigrations({ detected });
+
+    expect(result.warnings).toStrictEqual([]);
+    expect(result.changes).toContain(
+      `Archived Test covered cache legacy source → ${sourcePath}.migrated`,
+    );
+    expect(fs.existsSync(sourcePath)).toBe(false);
+    expect(fs.existsSync(`${sourcePath}.migrated`)).toBe(true);
+  });
+
   it("keeps plugin-state import source when plugin cap eviction drops an imported row", async () => {
     const root = await makeTempRoot();
     const maxPluginStateEntries = 40;

--- a/src/infra/state-migrations.plugin-state.ts
+++ b/src/infra/state-migrations.plugin-state.ts
@@ -289,7 +289,7 @@ export async function runLegacyMigrationPlans(
         const existingKeys = new Set(storeEntries.map(({ key }) => key));
         const existingValuesByKey = new Map(storeEntries.map(({ key, value }) => [key, value]));
         const expectedKeys = new Set(existingKeys);
-        let remainingCapacity = Math.max(0, plan.maxEntries - storeEntries.length);
+        const namespaceRemainingCapacity = Math.max(0, plan.maxEntries - storeEntries.length);
         let entries: Awaited<ReturnType<typeof plan.readEntries>>;
         try {
           entries = await plan.readEntries();
@@ -325,6 +325,12 @@ export async function runLegacyMigrationPlans(
           candidateEntries.push({ ...entry, targetKey, existedBefore: false });
           missingEntryCount++;
         }
+        if (missingEntryCount > namespaceRemainingCapacity) {
+          warnings.push(
+            `Skipped migrating ${plan.label} because plugin state namespace ${plan.namespace} has room for ${namespaceRemainingCapacity} of ${missingEntryCount} missing entries; left legacy source in place`,
+          );
+          return;
+        }
         const pluginRemainingCapacity = Math.max(
           0,
           MAX_PLUGIN_STATE_ENTRIES_PER_PLUGIN - pluginEntryCount,
@@ -338,9 +344,6 @@ export async function runLegacyMigrationPlans(
         let imported = 0;
         const changedKeys: string[] = [];
         for (const entry of candidateEntries) {
-          if (!entry.existedBefore && remainingCapacity <= 0) {
-            break;
-          }
           try {
             await store.register(
               entry.targetKey,
@@ -372,9 +375,6 @@ export async function runLegacyMigrationPlans(
             expectedKeys.add(entry.targetKey);
             existingKeys.add(entry.targetKey);
             changedKeys.push(entry.targetKey);
-            if (!entry.existedBefore) {
-              remainingCapacity--;
-            }
             imported++;
           } catch (err) {
             failedTargetKeys.add(entry.targetKey);


### PR DESCRIPTION
Closes #108286

AI-assisted: yes. I understand the migration and cache behavior changed here.

## What Problem This Solves

Fixes an issue where operators running `openclaw doctor --fix` could repeatedly retain a Telegram legacy sent-message source when plugin-state capacity was exhausted, without a clear explanation that none of the remaining records fit.

## Why This Change Was Made

Legacy plugin-state imports now preflight all genuinely missing rows against namespace and plugin capacity. An import either has room for the full missing set or is skipped with an explicit warning; already covered sources remain eligible for cleanup. Telegram sent-message migration also drops records at the exact TTL boundary instead of manufacturing a one-millisecond lifetime.

## User Impact

Expired Telegram sent-message rows no longer consume migration capacity. Capacity-blocked migrations stay retryable, avoid partial progress, and tell operators exactly how many missing records fit. Fully covered sources can still be archived.

## Evidence

- `src/commands/doctor-state-migrations.test.ts` — 89 tests passed on Blacksmith Testbox ([run](https://github.com/openclaw/openclaw/actions/runs/29478368236)).
- `node scripts/run-vitest.mjs extensions/telegram/src/state-migrations.test.ts` — 9 tests passed on the current head.
- Path-scoped `pnpm check:changed` — format, typechecks, core/extension lint, database-first guards, import-cycle checks, and related static gates passed (21m13s, Testbox).
- Source-blind `openclaw doctor --fix --non-interactive` proof: TTL-boundary source archived without a cap warning; a full namespace with one missing row warned `room for 0 of 1`, left the source in place, and produced the same warning on rerun.
- `git diff --check` passed.
- Fresh local autoreview: no accepted/actionable findings.
