### PR TITLE
refactor(agents): share OAuth file-lock mock factory

### DIFF
--- a/src/agents/auth-profiles/oauth-file-lock-passthrough.test-support.ts
+++ b/src/agents/auth-profiles/oauth-file-lock-passthrough.test-support.ts
@@ -5,17 +5,14 @@
  */
 import { afterAll, vi } from "vitest";
 
-vi.mock("../../infra/file-lock.js", () => ({
+const fileLockPassthroughMock = vi.hoisted(() => ({
   drainFileLockStateForTest: async () => undefined,
   resetFileLockStateForTest: () => undefined,
   withFileLock: async <T>(_filePath: string, _options: unknown, run: () => Promise<T>) => run(),
 }));
 
-vi.mock("../../plugin-sdk/file-lock.js", () => ({
-  drainFileLockStateForTest: async () => undefined,
-  resetFileLockStateForTest: () => undefined,
-  withFileLock: async <T>(_filePath: string, _options: unknown, run: () => Promise<T>) => run(),
-}));
+vi.mock("../../infra/file-lock.js", () => fileLockPassthroughMock);
+vi.mock("../../plugin-sdk/file-lock.js", () => fileLockPassthroughMock);
 
 afterAll(() => {
   vi.doUnmock("../../infra/file-lock.js");


### PR DESCRIPTION
Follow-up to #108674.

## What Problem This Solves

The OAuth file-lock test support duplicated the same explicit mock exports for the infra and plugin SDK module IDs. That duplication made the two mocks easier to drift apart during future export changes.

## Why This Change Was Made

Defines one `vi.hoisted` passthrough export object and returns it from both explicit mock factories. Both module IDs remain mocked, while their re-export identity and export list now stay aligned.

## User Impact

No user-visible impact. Test support is smaller and less likely to regress when the file-lock test surface changes.

## Evidence

- `node scripts/run-vitest.mjs src/agents/auth-profiles/oauth-refresh-queue.test.ts` — 2 passed
- `node scripts/run-vitest.mjs src/agents/auth-profiles/oauth.adopt-identity.test.ts` — 3 passed
- `node scripts/run-vitest.mjs src/agents/auth-profiles/oauth.mirror-refresh.test.ts` — 8 passed
- `pnpm check:changed` — passed on Blacksmith Testbox
- Autoreview — clean

AI-assisted: yes. I understand the change and validated the affected standalone suites and changed gate.
