### PR TITLE
refactor(windows): remove launcher encoding test seam

### DIFF
--- a/src/daemon/schtasks.test.ts
+++ b/src/daemon/schtasks.test.ts
@@ -231,7 +231,7 @@ describe("readScheduledTaskCommand", () => {
         const scriptPath = resolveTaskScriptPath(env);
         const script = options.scriptLines.join("\r\n");
         await fs.mkdir(path.dirname(scriptPath), { recursive: true });
-        let scriptBytes = Buffer.from(script, "utf8");
+        let scriptBytes: Buffer = Buffer.from(script, "utf8");
         if (options.scriptEncoding === "gbk") {
           // Production bytes for a code-page install: marker line + GBK body.
           resolveWindowsSystemEncodingMock.mockReturnValueOnce("gbk");

--- a/src/daemon/schtasks.test.ts
+++ b/src/daemon/schtasks.test.ts
@@ -13,13 +13,26 @@ import {
 const schtasksResponses = vi.hoisted(
   (): Array<{ code: number; stdout: string; stderr: string }> => [],
 );
+const resolveWindowsSystemEncodingMock = vi.hoisted(() => vi.fn((): string | null => null));
 
 vi.mock("./schtasks-exec.js", () => ({
   execSchtasks: async () => schtasksResponses.shift() ?? { code: 0, stdout: "", stderr: "" },
 }));
 
+vi.mock("../infra/windows-encoding.js", async () => {
+  const actual = await vi.importActual<typeof import("../infra/windows-encoding.js")>(
+    "../infra/windows-encoding.js",
+  );
+  return {
+    ...actual,
+    resolveWindowsSystemEncoding: () => resolveWindowsSystemEncodingMock(),
+  };
+});
+
 beforeEach(() => {
   schtasksResponses.length = 0;
+  resolveWindowsSystemEncodingMock.mockReset();
+  resolveWindowsSystemEncodingMock.mockReturnValue(null);
 });
 
 describe("scheduled task runtime derivation", () => {
@@ -218,17 +231,13 @@ describe("readScheduledTaskCommand", () => {
         const scriptPath = resolveTaskScriptPath(env);
         const script = options.scriptLines.join("\r\n");
         await fs.mkdir(path.dirname(scriptPath), { recursive: true });
-        await fs.writeFile(
-          scriptPath,
-          options.scriptEncoding === "gbk"
-            ? // Production bytes for a code-page install: marker line + GBK body.
-              encodeWindowsLauncherScript({
-                format: "cmd",
-                content: script,
-                windowsEncoding: "gbk",
-              })
-            : Buffer.from(script, "utf8"),
-        );
+        let scriptBytes = Buffer.from(script, "utf8");
+        if (options.scriptEncoding === "gbk") {
+          // Production bytes for a code-page install: marker line + GBK body.
+          resolveWindowsSystemEncodingMock.mockReturnValueOnce("gbk");
+          scriptBytes = encodeWindowsLauncherScript({ format: "cmd", content: script });
+        }
+        await fs.writeFile(scriptPath, scriptBytes);
       }
       await run(env);
     } finally {

--- a/src/infra/windows-launcher-encoding.test.ts
+++ b/src/infra/windows-launcher-encoding.test.ts
@@ -44,24 +44,18 @@ describe("encodeWindowsLauncherScript", () => {
     expect(encoded.subarray(2).toString("utf16le")).toBe(content);
   });
 
-  it("keeps ASCII cmd scripts byte-identical to UTF-8 regardless of code page", () => {
+  it("keeps ASCII cmd scripts byte-identical without resolving a code page", () => {
     const content = '@echo off\r\ncd /d "C:\\temp"\r\nnode gateway.js\r\n';
-    const encoded = encodeWindowsLauncherScript({
-      format: "cmd",
-      content,
-      windowsEncoding: "gbk",
-    });
+    const encoded = encodeWindowsLauncherScript({ format: "cmd", content });
 
     expect(encoded.equals(Buffer.from(content, "utf8"))).toBe(true);
+    expect(resolveWindowsSystemEncodingMock).not.toHaveBeenCalled();
   });
 
   it("encodes non-ASCII cmd scripts with a marker line plus CJK code page bytes", () => {
+    resolveWindowsSystemEncodingMock.mockReturnValue("gbk");
     const content = `@echo off\r\ncd /d "C:\\Users\\苗振\\.openclaw"\r\nnode gateway.js\r\n`;
-    const encoded = encodeWindowsLauncherScript({
-      format: "cmd",
-      content,
-      windowsEncoding: "gbk",
-    });
+    const encoded = encodeWindowsLauncherScript({ format: "cmd", content });
 
     expect(encoded.equals(Buffer.from(content, "utf8"))).toBe(false);
     expect(encoded.equals(iconv.encode(GBK_MARKER + content, "gbk"))).toBe(true);
@@ -69,17 +63,14 @@ describe("encodeWindowsLauncherScript", () => {
   });
 
   it("round-trips cmd content whose GBK bytes are also valid UTF-8 (隆 -> C2 A1 -> ¡)", () => {
+    resolveWindowsSystemEncodingMock.mockReturnValue("gbk");
     // Verify the trap on this iconv build: valid UTF-8, wrong string, no U+FFFD.
     const collisionBytes = iconv.encode("隆", "gbk");
     expect(collisionBytes.toString("utf8")).not.toBe("隆");
     expect(collisionBytes.toString("utf8")).not.toContain(REPLACEMENT_CHAR);
 
     const content = `@echo off\r\ncd /d "C:\\Users\\隆\\.openclaw"\r\nnode gateway.js\r\n`;
-    const encoded = encodeWindowsLauncherScript({
-      format: "cmd",
-      content,
-      windowsEncoding: "gbk",
-    });
+    const encoded = encodeWindowsLauncherScript({ format: "cmd", content });
 
     expect(encoded.equals(iconv.encode(GBK_MARKER + content, "gbk"))).toBe(true);
     // Locks the regression: a raw UTF-8 readback of these bytes decodes
@@ -90,6 +81,7 @@ describe("encodeWindowsLauncherScript", () => {
   });
 
   it("encodes cp949 extension syllables that Node ICU's euc-kr decoder rejects", () => {
+    resolveWindowsSystemEncodingMock.mockReturnValue("euc-kr");
     // Windows code page 949 is cp949/UHC; "똠" (8C 63) is a UHC extension syllable
     // iconv encodes and round-trips, but new TextDecoder("euc-kr") cannot decode
     // (KS X 1001 only). The guard must verify euc-kr with iconv, not ICU.
@@ -98,11 +90,7 @@ describe("encodeWindowsLauncherScript", () => {
     expect(new TextDecoder("euc-kr").decode(extensionBytes)).not.toBe("똠");
 
     const content = `@echo off\r\ncd /d "C:\\Users\\똠이\\.openclaw"\r\nnode gateway.js\r\n`;
-    const encoded = encodeWindowsLauncherScript({
-      format: "cmd",
-      content,
-      windowsEncoding: "euc-kr",
-    });
+    const encoded = encodeWindowsLauncherScript({ format: "cmd", content });
 
     expect(encoded.equals(iconv.encode(EUC_KR_MARKER + content, "euc-kr"))).toBe(true);
     expect(decodeWindowsLauncherScript({ buffer: encoded })).toBe(content);
@@ -110,40 +98,26 @@ describe("encodeWindowsLauncherScript", () => {
 
   it("falls back to UTF-8 when no system code page is available", () => {
     const content = `@echo off\r\ncd /d "C:\\Users\\苗振"\r\n`;
-    const encoded = encodeWindowsLauncherScript({
-      format: "cmd",
-      content,
-      windowsEncoding: null,
-    });
+    const encoded = encodeWindowsLauncherScript({ format: "cmd", content });
 
     expect(encoded.equals(Buffer.from(content, "utf8"))).toBe(true);
   });
 
   it("falls back to UTF-8 on windows-125x hosts whose console page differs from ANSI", () => {
+    resolveWindowsSystemEncodingMock.mockReturnValue("windows-1252");
     const content = '@echo off\r\ncd /d "C:\\Users\\café"\r\n';
-    const encoded = encodeWindowsLauncherScript({
-      format: "cmd",
-      content,
-      windowsEncoding: "windows-1252",
-    });
+    const encoded = encodeWindowsLauncherScript({ format: "cmd", content });
 
     expect(encoded.equals(Buffer.from(content, "utf8"))).toBe(true);
   });
 
-  it("resolves the system code page when no override is given", () => {
-    resolveWindowsSystemEncodingMock.mockReturnValue("gbk");
-    const content = `@echo off\r\ncd /d "C:\\Users\\苗振"\r\n`;
-    const encoded = encodeWindowsLauncherScript({ format: "cmd", content });
-
-    expect(encoded.equals(iconv.encode(GBK_MARKER + content, "gbk"))).toBe(true);
-  });
-
   it("fails the install instead of writing unrepresentable cmd content", () => {
+    resolveWindowsSystemEncodingMock.mockReturnValue("gbk");
     const content = '@echo off\r\nset "OC_LABEL=🚀"\r\n';
 
-    expect(() =>
-      encodeWindowsLauncherScript({ format: "cmd", content, windowsEncoding: "gbk" }),
-    ).toThrow(/cannot be represented in the Windows system code page \(gbk\)/);
+    expect(() => encodeWindowsLauncherScript({ format: "cmd", content })).toThrow(
+      /cannot be represented in the Windows system code page \(gbk\)/,
+    );
   });
 });
 

--- a/src/infra/windows-launcher-encoding.ts
+++ b/src/infra/windows-launcher-encoding.ts
@@ -43,7 +43,6 @@ function isAsciiOnly(value: string): boolean {
 export function encodeWindowsLauncherScript(params: {
   format: WindowsLauncherScriptFormat;
   content: string;
-  windowsEncoding?: string | null;
 }): Buffer {
   if (params.format === "vbs") {
     // UTF-16 LE with BOM is the one wscript encoding that works on every locale.
@@ -54,8 +53,7 @@ export function encodeWindowsLauncherScript(params: {
     // legacy byte-for-byte output so non-CJK installs see no change.
     return Buffer.from(params.content, "utf8");
   }
-  const encoding =
-    params.windowsEncoding !== undefined ? params.windowsEncoding : resolveWindowsSystemEncoding();
+  const encoding = resolveWindowsSystemEncoding();
   if (
     !encoding ||
     !CMD_ANSI_EQUALS_OEM_ENCODINGS.has(encoding) ||


### PR DESCRIPTION
Related: #107751

## What Problem This Solves

The Windows launcher encoding fix exposed a test-only override on the production encoder API. That extra branch was not used by any production caller and made the runtime contract broader than necessary.

## Why This Change Was Made

Remove the override and make the encoder always resolve the Windows system encoding through its existing owner. Tests now mock that owner boundary, so they exercise the same production call shape without changing launcher behavior.

AI-assisted by Codex. Maintainer-requested follow-up to the landed fix.

## User Impact

No user-visible behavior change. The launcher encoder has one canonical production path and a smaller API.

## Evidence

- Blacksmith Testbox: 5 focused files, 130 tests passed across the infra and daemon Vitest shards.
- Fresh autoreview: no accepted or actionable findings; correctness confidence 0.94.
- Formatting and `git diff --check` passed.
