### PR TITLE
fix(anthropic): align exact Claude 1M model limits

### DIFF
--- a/extensions/anthropic/cli-catalog.ts
+++ b/extensions/anthropic/cli-catalog.ts
@@ -14,7 +14,14 @@ const CLAUDE_CLI_CONTEXT_WINDOWS: Record<string, number> = {
   "claude-sonnet-5": 1_000_000,
   "claude-sonnet-4-6": 1_000_000,
 };
-const CLAUDE_CLI_MAX_OUTPUT_TOKENS = 128_000;
+const CLAUDE_CLI_DEFAULT_MAX_OUTPUT_TOKENS = 64_000;
+const CLAUDE_CLI_MAX_OUTPUT_TOKENS: Record<string, number> = {
+  "claude-opus-4-8": 128_000,
+  "claude-opus-4-7": 128_000,
+  "claude-opus-4-6": 128_000,
+  "claude-sonnet-5": 128_000,
+  "claude-sonnet-4-6": 128_000,
+};
 
 const CLAUDE_CLI_MODEL_LABELS: Record<string, string> = {
   "claude-opus-4-8": "Claude Opus 4.8 (Claude CLI)",
@@ -64,7 +71,7 @@ export function buildClaudeCliCatalogEntries(): ModelCatalogEntry[] {
       input: ["text", "image"],
       mediaInput: resolveClaudeCliImageMediaInput(id),
       contextWindow: CLAUDE_CLI_CONTEXT_WINDOWS[id] ?? CLAUDE_CLI_DEFAULT_CONTEXT_WINDOW,
-      maxTokens: CLAUDE_CLI_MAX_OUTPUT_TOKENS,
+      maxTokens: CLAUDE_CLI_MAX_OUTPUT_TOKENS[id] ?? CLAUDE_CLI_DEFAULT_MAX_OUTPUT_TOKENS,
     };
   });
 }

--- a/extensions/anthropic/cli-catalog.ts
+++ b/extensions/anthropic/cli-catalog.ts
@@ -8,11 +8,7 @@ import { CLAUDE_CLI_BACKEND_ID, CLAUDE_CLI_DEFAULT_ALLOWLIST_REFS } from "./cli-
 // Claude CLI auth is subscription-backed, so catalog rows only need picker metadata.
 const CLAUDE_CLI_DEFAULT_CONTEXT_WINDOW = 200_000;
 const CLAUDE_CLI_CONTEXT_WINDOWS: Record<string, number> = {
-  "claude-opus-4-8": 1_000_000,
-  "claude-opus-4-7": 1_000_000,
-  "claude-opus-4-6": 1_000_000,
   "claude-sonnet-5": 1_000_000,
-  "claude-sonnet-4-6": 1_000_000,
 };
 const CLAUDE_CLI_DEFAULT_MAX_OUTPUT_TOKENS = 64_000;
 const CLAUDE_CLI_MAX_OUTPUT_TOKENS: Record<string, number> = {

--- a/extensions/anthropic/cli-catalog.ts
+++ b/extensions/anthropic/cli-catalog.ts
@@ -8,9 +8,13 @@ import { CLAUDE_CLI_BACKEND_ID, CLAUDE_CLI_DEFAULT_ALLOWLIST_REFS } from "./cli-
 // Claude CLI auth is subscription-backed, so catalog rows only need picker metadata.
 const CLAUDE_CLI_DEFAULT_CONTEXT_WINDOW = 200_000;
 const CLAUDE_CLI_CONTEXT_WINDOWS: Record<string, number> = {
-  "claude-opus-4-8": 1_048_576,
+  "claude-opus-4-8": 1_000_000,
+  "claude-opus-4-7": 1_000_000,
+  "claude-opus-4-6": 1_000_000,
   "claude-sonnet-5": 1_000_000,
+  "claude-sonnet-4-6": 1_000_000,
 };
+const CLAUDE_CLI_MAX_OUTPUT_TOKENS = 128_000;
 
 const CLAUDE_CLI_MODEL_LABELS: Record<string, string> = {
   "claude-opus-4-8": "Claude Opus 4.8 (Claude CLI)",
@@ -60,6 +64,7 @@ export function buildClaudeCliCatalogEntries(): ModelCatalogEntry[] {
       input: ["text", "image"],
       mediaInput: resolveClaudeCliImageMediaInput(id),
       contextWindow: CLAUDE_CLI_CONTEXT_WINDOWS[id] ?? CLAUDE_CLI_DEFAULT_CONTEXT_WINDOW,
+      maxTokens: CLAUDE_CLI_MAX_OUTPUT_TOKENS,
     };
   });
 }

--- a/extensions/anthropic/index.test.ts
+++ b/extensions/anthropic/index.test.ts
@@ -132,7 +132,7 @@ describe("anthropic provider replay hooks", () => {
     });
   });
 
-  it("publishes exact GA 1M Claude CLI limits", () => {
+  it("keeps bare Claude CLI context plan-safe while publishing output limits", () => {
     const models = buildClaudeCliCatalogEntries();
     for (const id of [
       "claude-opus-4-8",
@@ -141,7 +141,7 @@ describe("anthropic provider replay hooks", () => {
       "claude-sonnet-4-6",
     ]) {
       expect(models.find((model) => model.id === id)).toMatchObject({
-        contextWindow: 1_000_000,
+        contextWindow: 200_000,
         maxTokens: 128_000,
       });
     }
@@ -1103,24 +1103,23 @@ describe("anthropic provider replay hooks", () => {
     });
   });
 
-  it("normalizes GA 1M Claude variants to their exact context and output limits", async () => {
+  it("normalizes direct Anthropic GA models to exact context and output limits", async () => {
     const provider = await registerSingleProviderPlugin(anthropicPlugin);
 
-    for (const [runtimeProvider, modelId] of [
-      ["anthropic", "claude-opus-4-8"],
-      ["anthropic", "claude-opus-4-7"],
-      ["claude-cli", "claude-opus-4.7-20260219"],
-      ["anthropic", "claude-opus-4-6"],
-      ["anthropic", "claude-sonnet-4-6"],
-    ] as const) {
+    for (const modelId of [
+      "claude-opus-4-8",
+      "claude-opus-4-7",
+      "claude-opus-4-6",
+      "claude-sonnet-4-6",
+    ]) {
       expectFields(
         provider.normalizeResolvedModel?.({
-          provider: runtimeProvider,
+          provider: "anthropic",
           modelId,
           model: {
             id: modelId,
             name: "Claude Opus 4.7",
-            provider: runtimeProvider,
+            provider: "anthropic",
             api: "anthropic-messages",
             reasoning: true,
             input: ["text", "image"],
@@ -1137,6 +1136,47 @@ describe("anthropic provider replay hooks", () => {
         },
       );
     }
+  });
+
+  it("keeps bare Claude CLI context plan-safe and honors explicit 1M variants", async () => {
+    const provider = await registerSingleProviderPlugin(anthropicPlugin);
+    const baseModel = {
+      id: "claude-opus-4-7",
+      name: "Claude Opus 4.7",
+      provider: "claude-cli",
+      api: "anthropic-messages",
+      reasoning: true,
+      input: ["text", "image"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 200_000,
+      contextTokens: 200_000,
+      maxTokens: 64_000,
+    } as ProviderRuntimeModel;
+
+    expectFields(
+      provider.normalizeResolvedModel?.({
+        provider: "claude-cli",
+        modelId: baseModel.id,
+        model: baseModel,
+      } as never),
+      {
+        contextWindow: 200_000,
+        contextTokens: 200_000,
+        maxTokens: 128_000,
+      },
+    );
+    expectFields(
+      provider.normalizeResolvedModel?.({
+        provider: "claude-cli",
+        modelId: `${baseModel.id}[1m]`,
+        model: { ...baseModel, id: `${baseModel.id}[1m]` },
+      } as never),
+      {
+        contextWindow: 1_000_000,
+        contextTokens: 1_000_000,
+        maxTokens: 128_000,
+      },
+    );
   });
 
   it("normalizes Claude Opus 4.8 to 128k max output tokens", async () => {

--- a/extensions/anthropic/index.test.ts
+++ b/extensions/anthropic/index.test.ts
@@ -125,10 +125,26 @@ describe("anthropic provider replay hooks", () => {
       id: "claude-sonnet-5",
       name: "Claude Sonnet 5 (Claude CLI)",
       contextWindow: 1_000_000,
+      maxTokens: 128_000,
       mediaInput: {
         image: { maxSidePx: 2576, preferredSidePx: 2576, tokenMode: "provider" },
       },
     });
+  });
+
+  it("publishes exact GA 1M Claude CLI limits", () => {
+    const models = buildClaudeCliCatalogEntries();
+    for (const id of [
+      "claude-opus-4-8",
+      "claude-opus-4-7",
+      "claude-opus-4-6",
+      "claude-sonnet-4-6",
+    ]) {
+      expect(models.find((model) => model.id === id)).toMatchObject({
+        contextWindow: 1_000_000,
+        maxTokens: 128_000,
+      });
+    }
   });
 
   it("owns native reasoning output mode for Claude transports", async () => {
@@ -585,8 +601,8 @@ describe("anthropic provider replay hooks", () => {
       id: "claude-opus-4-8",
       api: "anthropic-messages",
       reasoning: true,
-      contextWindow: 1_048_576,
-      contextTokens: 1_048_576,
+      contextWindow: 1_000_000,
+      contextTokens: 1_000_000,
       maxTokens: 128_000,
     });
     const opus48Profile = provider.resolveThinkingProfile?.({
@@ -949,8 +965,8 @@ describe("anthropic provider replay hooks", () => {
       } as never),
       {
         reasoning: false,
-        contextWindow: 1_048_576,
-        contextTokens: 1_048_576,
+        contextWindow: 1_000_000,
+        contextTokens: 1_000_000,
         maxTokens: 128_000,
         thinkingLevelMap: {
           xhigh: "xhigh",
@@ -1087,7 +1103,7 @@ describe("anthropic provider replay hooks", () => {
     });
   });
 
-  it("normalizes GA 1M Claude variants to 1M context", async () => {
+  it("normalizes GA 1M Claude variants to their exact context and output limits", async () => {
     const provider = await registerSingleProviderPlugin(anthropicPlugin);
 
     for (const [runtimeProvider, modelId] of [
@@ -1115,8 +1131,9 @@ describe("anthropic provider replay hooks", () => {
           },
         } as never),
         {
-          contextWindow: 1_048_576,
-          contextTokens: 1_048_576,
+          contextWindow: 1_000_000,
+          contextTokens: 1_000_000,
+          maxTokens: 128_000,
         },
       );
     }
@@ -1142,8 +1159,8 @@ describe("anthropic provider replay hooks", () => {
     } as never);
 
     expectFields(normalized, {
-      contextWindow: 1_048_576,
-      contextTokens: 1_048_576,
+      contextWindow: 1_000_000,
+      contextTokens: 1_000_000,
       maxTokens: 128_000,
     });
   });

--- a/extensions/anthropic/openclaw.plugin.json
+++ b/extensions/anthropic/openclaw.plugin.json
@@ -36,7 +36,7 @@
             "mediaInput": {
               "image": { "maxSidePx": 2576, "preferredSidePx": 2576, "tokenMode": "provider" }
             },
-            "contextWindow": 1000000,
+            "contextWindow": 200000,
             "maxTokens": 128000
           },
           {
@@ -47,7 +47,7 @@
             "mediaInput": {
               "image": { "maxSidePx": 2576, "preferredSidePx": 2576, "tokenMode": "provider" }
             },
-            "contextWindow": 1000000,
+            "contextWindow": 200000,
             "maxTokens": 128000
           },
           {
@@ -58,7 +58,7 @@
             "mediaInput": {
               "image": { "maxSidePx": 1568, "preferredSidePx": 1568, "tokenMode": "provider" }
             },
-            "contextWindow": 1000000,
+            "contextWindow": 200000,
             "maxTokens": 128000
           },
           {
@@ -69,7 +69,7 @@
             "mediaInput": {
               "image": { "maxSidePx": 1568, "preferredSidePx": 1568, "tokenMode": "provider" }
             },
-            "contextWindow": 1000000,
+            "contextWindow": 200000,
             "maxTokens": 128000
           }
         ]

--- a/extensions/anthropic/openclaw.plugin.json
+++ b/extensions/anthropic/openclaw.plugin.json
@@ -47,7 +47,7 @@
             "mediaInput": {
               "image": { "maxSidePx": 2576, "preferredSidePx": 2576, "tokenMode": "provider" }
             },
-            "contextWindow": 200000,
+            "contextWindow": 1048576,
             "maxTokens": 64000
           },
           {
@@ -58,7 +58,7 @@
             "mediaInput": {
               "image": { "maxSidePx": 1568, "preferredSidePx": 1568, "tokenMode": "provider" }
             },
-            "contextWindow": 200000,
+            "contextWindow": 1048576,
             "maxTokens": 64000
           },
           {
@@ -69,7 +69,7 @@
             "mediaInput": {
               "image": { "maxSidePx": 1568, "preferredSidePx": 1568, "tokenMode": "provider" }
             },
-            "contextWindow": 200000,
+            "contextWindow": 1048576,
             "maxTokens": 64000
           }
         ]
@@ -150,7 +150,7 @@
             "mediaInput": {
               "image": { "maxSidePx": 2576, "preferredSidePx": 2576, "tokenMode": "provider" }
             },
-            "contextWindow": 200000,
+            "contextWindow": 1048576,
             "maxTokens": 64000
           },
           {
@@ -183,7 +183,7 @@
             "mediaInput": {
               "image": { "maxSidePx": 1568, "preferredSidePx": 1568, "tokenMode": "provider" }
             },
-            "contextWindow": 200000,
+            "contextWindow": 1048576,
             "maxTokens": 64000
           },
           {
@@ -194,7 +194,7 @@
             "mediaInput": {
               "image": { "maxSidePx": 1568, "preferredSidePx": 1568, "tokenMode": "provider" }
             },
-            "contextWindow": 200000,
+            "contextWindow": 1048576,
             "maxTokens": 64000
           }
         ]

--- a/extensions/anthropic/openclaw.plugin.json
+++ b/extensions/anthropic/openclaw.plugin.json
@@ -36,7 +36,7 @@
             "mediaInput": {
               "image": { "maxSidePx": 2576, "preferredSidePx": 2576, "tokenMode": "provider" }
             },
-            "contextWindow": 1048576,
+            "contextWindow": 1000000,
             "maxTokens": 128000
           },
           {
@@ -47,8 +47,8 @@
             "mediaInput": {
               "image": { "maxSidePx": 2576, "preferredSidePx": 2576, "tokenMode": "provider" }
             },
-            "contextWindow": 1048576,
-            "maxTokens": 64000
+            "contextWindow": 1000000,
+            "maxTokens": 128000
           },
           {
             "id": "claude-sonnet-4-6",
@@ -58,8 +58,8 @@
             "mediaInput": {
               "image": { "maxSidePx": 1568, "preferredSidePx": 1568, "tokenMode": "provider" }
             },
-            "contextWindow": 1048576,
-            "maxTokens": 64000
+            "contextWindow": 1000000,
+            "maxTokens": 128000
           },
           {
             "id": "claude-opus-4-6",
@@ -69,8 +69,8 @@
             "mediaInput": {
               "image": { "maxSidePx": 1568, "preferredSidePx": 1568, "tokenMode": "provider" }
             },
-            "contextWindow": 1048576,
-            "maxTokens": 64000
+            "contextWindow": 1000000,
+            "maxTokens": 128000
           }
         ]
       },
@@ -139,7 +139,7 @@
             "mediaInput": {
               "image": { "maxSidePx": 2576, "preferredSidePx": 2576, "tokenMode": "provider" }
             },
-            "contextWindow": 1048576,
+            "contextWindow": 1000000,
             "maxTokens": 128000
           },
           {
@@ -150,8 +150,8 @@
             "mediaInput": {
               "image": { "maxSidePx": 2576, "preferredSidePx": 2576, "tokenMode": "provider" }
             },
-            "contextWindow": 1048576,
-            "maxTokens": 64000
+            "contextWindow": 1000000,
+            "maxTokens": 128000
           },
           {
             "id": "claude-haiku-4-5",
@@ -183,8 +183,8 @@
             "mediaInput": {
               "image": { "maxSidePx": 1568, "preferredSidePx": 1568, "tokenMode": "provider" }
             },
-            "contextWindow": 1048576,
-            "maxTokens": 64000
+            "contextWindow": 1000000,
+            "maxTokens": 128000
           },
           {
             "id": "claude-opus-4-6",
@@ -194,8 +194,8 @@
             "mediaInput": {
               "image": { "maxSidePx": 1568, "preferredSidePx": 1568, "tokenMode": "provider" }
             },
-            "contextWindow": 1048576,
-            "maxTokens": 64000
+            "contextWindow": 1000000,
+            "maxTokens": 128000
           }
         ]
       }

--- a/extensions/anthropic/openclaw.plugin.test.ts
+++ b/extensions/anthropic/openclaw.plugin.test.ts
@@ -56,6 +56,17 @@ describe("Anthropic plugin manifest", () => {
     });
   });
 
+  it("declares GA 1M context window for opus-4-7 / sonnet-4-6 / opus-4-6 (issue #108152)", () => {
+    const models = manifest.modelCatalog?.providers?.anthropic?.models ?? [];
+    for (const id of ["claude-opus-4-7", "claude-sonnet-4-6", "claude-opus-4-6"]) {
+      expect(models.find((model) => model.id === id)?.contextWindow).toBe(1_048_576);
+    }
+    const cliModels = manifest.modelCatalog?.providers?.["claude-cli"]?.models ?? [];
+    for (const id of ["claude-opus-4-7", "claude-sonnet-4-6", "claude-opus-4-6"]) {
+      expect(cliModels.find((model) => model.id === id)?.contextWindow).toBe(1_048_576);
+    }
+  });
+
   it("resolves both official Claude Haiku 4.5 API identifiers from the static catalog", () => {
     expect(manifest.modelCatalog?.discovery?.anthropic).toBe("static");
 

--- a/extensions/anthropic/openclaw.plugin.test.ts
+++ b/extensions/anthropic/openclaw.plugin.test.ts
@@ -57,14 +57,20 @@ describe("Anthropic plugin manifest", () => {
     });
   });
 
-  it("declares GA 1M context window for opus-4-7 / sonnet-4-6 / opus-4-6 (issue #108152)", () => {
+  it("declares the exact GA 1M contract for opus-4-7 / sonnet-4-6 / opus-4-6", () => {
     const models = manifest.modelCatalog?.providers?.anthropic?.models ?? [];
     for (const id of ["claude-opus-4-7", "claude-sonnet-4-6", "claude-opus-4-6"]) {
-      expect(models.find((model) => model.id === id)?.contextWindow).toBe(1_048_576);
+      expect(models.find((model) => model.id === id)).toMatchObject({
+        contextWindow: 1_000_000,
+        maxTokens: 128_000,
+      });
     }
     const cliModels = manifest.modelCatalog?.providers?.["claude-cli"]?.models ?? [];
     for (const id of ["claude-opus-4-7", "claude-sonnet-4-6", "claude-opus-4-6"]) {
-      expect(cliModels.find((model) => model.id === id)?.contextWindow).toBe(1_048_576);
+      expect(cliModels.find((model) => model.id === id)).toMatchObject({
+        contextWindow: 1_000_000,
+        maxTokens: 128_000,
+      });
     }
   });
 

--- a/extensions/anthropic/openclaw.plugin.test.ts
+++ b/extensions/anthropic/openclaw.plugin.test.ts
@@ -2,33 +2,34 @@
 import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 
+type AnthropicCatalogModel = {
+  id?: string;
+  name?: string;
+  reasoning?: boolean;
+  input?: string[];
+  mediaInput?: {
+    image?: {
+      maxSidePx?: number;
+      preferredSidePx?: number;
+      tokenMode?: string;
+    };
+  };
+  contextWindow?: number;
+  maxTokens?: number;
+  cost?: {
+    input?: number;
+    output?: number;
+    cacheRead?: number;
+    cacheWrite?: number;
+  };
+  thinkingLevelMap?: Record<string, string | null>;
+};
+
 type AnthropicManifest = {
   modelCatalog?: {
     providers?: {
-      anthropic?: {
-        models?: Array<{
-          id?: string;
-          name?: string;
-          reasoning?: boolean;
-          input?: string[];
-          mediaInput?: {
-            image?: {
-              maxSidePx?: number;
-              preferredSidePx?: number;
-              tokenMode?: string;
-            };
-          };
-          contextWindow?: number;
-          maxTokens?: number;
-          cost?: {
-            input?: number;
-            output?: number;
-            cacheRead?: number;
-            cacheWrite?: number;
-          };
-          thinkingLevelMap?: Record<string, string | null>;
-        }>;
-      };
+      anthropic?: { models?: AnthropicCatalogModel[] };
+      "claude-cli"?: { models?: AnthropicCatalogModel[] };
     };
     discovery?: Record<string, string>;
   };

--- a/extensions/anthropic/openclaw.plugin.test.ts
+++ b/extensions/anthropic/openclaw.plugin.test.ts
@@ -57,7 +57,7 @@ describe("Anthropic plugin manifest", () => {
     });
   });
 
-  it("declares the exact GA 1M contract for opus-4-7 / sonnet-4-6 / opus-4-6", () => {
+  it("declares direct API limits without overstating bare Claude CLI context", () => {
     const models = manifest.modelCatalog?.providers?.anthropic?.models ?? [];
     for (const id of ["claude-opus-4-7", "claude-sonnet-4-6", "claude-opus-4-6"]) {
       expect(models.find((model) => model.id === id)).toMatchObject({
@@ -68,10 +68,14 @@ describe("Anthropic plugin manifest", () => {
     const cliModels = manifest.modelCatalog?.providers?.["claude-cli"]?.models ?? [];
     for (const id of ["claude-opus-4-7", "claude-sonnet-4-6", "claude-opus-4-6"]) {
       expect(cliModels.find((model) => model.id === id)).toMatchObject({
-        contextWindow: 1_000_000,
+        contextWindow: 200_000,
         maxTokens: 128_000,
       });
     }
+    expect(cliModels.find((model) => model.id === "claude-opus-4-8")).toMatchObject({
+      contextWindow: 200_000,
+      maxTokens: 128_000,
+    });
   });
 
   it("resolves both official Claude Haiku 4.5 API identifiers from the static catalog", () => {

--- a/extensions/anthropic/register.runtime.ts
+++ b/extensions/anthropic/register.runtime.ts
@@ -319,7 +319,7 @@ function buildAnthropicForwardCompatModel(
       : isAnthropicSonnet5Model(trimmedModelId) && provider === PROVIDER_ID
         ? resolveAnthropicSonnet5Cost()
         : { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-    contextWindow: resolveAnthropicFixedContextWindow(trimmedModelId) ?? 200_000,
+    contextWindow: resolveAnthropicFixedContextWindow(provider, trimmedModelId) ?? 200_000,
     maxTokens: isAnthropic128kOutputModel(trimmedModelId)
       ? ANTHROPIC_MODERN_MAX_OUTPUT_TOKENS
       : 64_000,
@@ -399,10 +399,12 @@ function isAnthropicSonnet5Model(modelId: string): boolean {
   return resolveClaudeSonnet5ModelIdentity({ id: modelId }) !== undefined;
 }
 
-function resolveAnthropicFixedContextWindow(modelId: string): number | undefined {
+function resolveAnthropicFixedContextWindow(provider: string, modelId: string): number | undefined {
   return isAnthropicMandatoryClaude5Model(modelId) ||
     isAnthropicSonnet5Model(modelId) ||
-    isAnthropicGa1MModel(modelId)
+    (isAnthropicGa1MModel(modelId) &&
+      (normalizeLowercaseStringOrEmpty(provider) !== CLAUDE_CLI_BACKEND_ID ||
+        normalizeLowercaseStringOrEmpty(modelId).endsWith("[1m]")))
     ? ANTHROPIC_1M_CONTEXT_TOKENS
     : undefined;
 }
@@ -472,7 +474,10 @@ function applyAnthropicFixedContextWindow(params: {
   contractModelId: string;
   model: ProviderRuntimeModel;
 }): ProviderRuntimeModel | undefined {
-  const fixedContextWindow = resolveAnthropicFixedContextWindow(params.contractModelId);
+  const fixedContextWindow = resolveAnthropicFixedContextWindow(
+    params.provider,
+    params.contractModelId,
+  );
   if (fixedContextWindow === undefined) {
     return undefined;
   }

--- a/extensions/anthropic/register.runtime.ts
+++ b/extensions/anthropic/register.runtime.ts
@@ -78,8 +78,7 @@ const ANTHROPIC_OPUS_48_MODEL_ID = "claude-opus-4-8";
 const ANTHROPIC_OPUS_48_DOT_MODEL_ID = "claude-opus-4.8";
 const ANTHROPIC_OPUS_47_MODEL_ID = "claude-opus-4-7";
 const ANTHROPIC_OPUS_47_DOT_MODEL_ID = "claude-opus-4.7";
-const ANTHROPIC_GA_1M_CONTEXT_TOKENS = 1_048_576;
-const ANTHROPIC_EXACT_1M_CONTEXT_TOKENS = 1_000_000;
+const ANTHROPIC_1M_CONTEXT_TOKENS = 1_000_000;
 const ANTHROPIC_MODERN_MAX_OUTPUT_TOKENS = 128_000;
 // Anthropic's introductory rate expires at the documented UTC month boundary.
 const ANTHROPIC_SONNET_5_STANDARD_PRICING_START_MS = Date.UTC(2026, 8, 1);
@@ -401,17 +400,19 @@ function isAnthropicSonnet5Model(modelId: string): boolean {
 }
 
 function resolveAnthropicFixedContextWindow(modelId: string): number | undefined {
-  if (isAnthropicMandatoryClaude5Model(modelId) || isAnthropicSonnet5Model(modelId)) {
-    return ANTHROPIC_EXACT_1M_CONTEXT_TOKENS;
-  }
-  return isAnthropicGa1MModel(modelId) ? ANTHROPIC_GA_1M_CONTEXT_TOKENS : undefined;
+  return isAnthropicMandatoryClaude5Model(modelId) ||
+    isAnthropicSonnet5Model(modelId) ||
+    isAnthropicGa1MModel(modelId)
+    ? ANTHROPIC_1M_CONTEXT_TOKENS
+    : undefined;
 }
 
 function isAnthropic128kOutputModel(modelId: string): boolean {
-  if (isAnthropicMandatoryClaude5Model(modelId) || isAnthropicSonnet5Model(modelId)) {
-    return true;
-  }
-  return /^claude-opus-4-8(?=$|[^a-z0-9])/.test(resolveClaudeModelIdentity({ id: modelId }));
+  return (
+    isAnthropicMandatoryClaude5Model(modelId) ||
+    isAnthropicSonnet5Model(modelId) ||
+    isAnthropicGa1MModel(modelId)
+  );
 }
 
 function isAnthropicLargeImageModel(modelId: string): boolean {

--- a/src/agents/cli-runner/prepare.test.ts
+++ b/src/agents/cli-runner/prepare.test.ts
@@ -4620,7 +4620,7 @@ describe("prepareCliRunContext", () => {
     }
   });
 
-  it("uses the automatic Claude CLI cap before mapping canonical models to CLI aliases", async () => {
+  it("uses the plan-safe Claude CLI cap before mapping canonical models to CLI aliases", async () => {
     const { dir, sessionFile } = createSessionFile();
     try {
       cliBackendsTesting.setDepsForTest({
@@ -4645,7 +4645,7 @@ describe("prepareCliRunContext", () => {
       });
 
       const summaryMarker = "RESEED_ALIAS_SUMMARY_MARKER_KEEP";
-      const padding = "x".repeat(90_000);
+      const padding = "x".repeat(40_000);
       fs.appendFileSync(
         sessionFile,
         `${JSON.stringify({

--- a/src/agents/context-resolution.ts
+++ b/src/agents/context-resolution.ts
@@ -7,6 +7,7 @@ import {
   minPositiveContextTokens,
   providerContextTokenCacheKey,
 } from "./context-cache.js";
+import { resolveModelExtraParamSources } from "./model-extra-params.js";
 import { normalizeProviderId } from "./model-selection.js";
 
 type ConfigModelEntry = { id?: string; contextWindow?: number; contextTokens?: number };
@@ -187,6 +188,7 @@ function resolveModelFamilyId(modelId: string): string {
 export function resolveAnthropicFixedContextWindow(
   provider: string,
   model: string,
+  options?: { claudeCli1M?: boolean },
 ): number | undefined {
   const modelId = resolveModelFamilyId(model);
   const isAnthropicProvider =
@@ -210,6 +212,9 @@ export function resolveAnthropicFixedContextWindow(
     return ANTHROPIC_SONNET_5_CONTEXT_TOKENS;
   }
   if (!ANTHROPIC_GA_1M_MODEL_PREFIXES.some((prefix) => modelId.startsWith(prefix))) {
+    return undefined;
+  }
+  if (provider === "claude-cli" && !modelId.endsWith("[1m]") && options?.claudeCli1M !== true) {
     return undefined;
   }
   return provider === "anthropic-vertex"
@@ -245,7 +250,18 @@ export function resolveContextTokensForModelFromCache(
       params.modelProvider,
       ref.model,
     );
-    const fixedContextWindow = resolveAnthropicFixedContextWindow(ref.provider, ref.model);
+    const extraParamSources = resolveModelExtraParamSources({
+      config: params.cfg,
+      provider: ref.provider,
+      modelId: ref.model,
+    });
+    const effectiveContext1M =
+      extraParamSources.modelParams && Object.hasOwn(extraParamSources.modelParams, "context1m")
+        ? extraParamSources.modelParams.context1m
+        : extraParamSources.defaultParams?.context1m;
+    const fixedContextWindow = resolveAnthropicFixedContextWindow(ref.provider, ref.model, {
+      claudeCli1M: effectiveContext1M === true,
+    });
     const providerResult = lookupContextTokens(
       providerContextTokenCacheKey(normalizeProviderId(ref.provider), ref.model),
     );

--- a/src/agents/context-resolution.ts
+++ b/src/agents/context-resolution.ts
@@ -43,7 +43,7 @@ const ANTHROPIC_GA_1M_MODEL_PREFIXES = [
   "claude-sonnet-4-6",
   "claude-sonnet-4.6",
 ] as const;
-export const ANTHROPIC_CONTEXT_1M_TOKENS = 1_048_576;
+export const ANTHROPIC_CONTEXT_1M_TOKENS = 1_000_000;
 export const ANTHROPIC_VERTEX_CONTEXT_1M_TOKENS = 1_000_000;
 export const ANTHROPIC_FABLE_CONTEXT_TOKENS = 1_000_000;
 export const ANTHROPIC_MYTHOS_5_CONTEXT_TOKENS = 1_000_000;

--- a/src/agents/context.lookup.test.ts
+++ b/src/agents/context.lookup.test.ts
@@ -2,6 +2,7 @@
 // model resolution.
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { ANTHROPIC_CONTEXT_1M_TOKENS } from "./context-resolution.js";
 import { CONTEXT_WINDOW_RUNTIME_STATE } from "./context-runtime-state.js";
 
 type DiscoveredModel = {
@@ -342,7 +343,9 @@ describe("lookupContextTokens", () => {
       config,
       readOnly: true,
     });
-    expect(lookupContextTokens("anthropic/claude-opus-4.7-20260219")).toBe(1_048_576);
+    expect(lookupContextTokens("anthropic/claude-opus-4.7-20260219")).toBe(
+      ANTHROPIC_CONTEXT_1M_TOKENS,
+    );
   });
 
   it("uses caller config when gateway startup starts cache warming", async () => {
@@ -364,7 +367,7 @@ describe("lookupContextTokens", () => {
     });
     expect(
       lookupContextTokens("anthropic/claude-opus-4.7-20260219", { allowAsyncLoad: false }),
-    ).toBe(1_048_576);
+    ).toBe(ANTHROPIC_CONTEXT_1M_TOKENS);
   });
 
   it("warms fresh caches instead of reusing a pre-generation load promise", async () => {

--- a/src/agents/context.test.ts
+++ b/src/agents/context.test.ts
@@ -81,7 +81,7 @@ describe("applyDiscoveredContextWindows", () => {
     expect(cache.get("gpt-5.4")).toBe(272_000);
   });
 
-  it("upgrades claude-cli GA 1M variants when discovery still reports 200k", () => {
+  it("keeps bare claude-cli GA variants at the discovered window", () => {
     const cache = new Map<string, number>();
     applyDiscoveredContextWindows({
       cache,
@@ -92,9 +92,9 @@ describe("applyDiscoveredContextWindows", () => {
       ],
     });
 
-    expect(cache.get("claude-cli/claude-opus-4.8-20260514")).toBe(ANTHROPIC_CONTEXT_1M_TOKENS);
-    expect(cache.get("claude-cli/claude-opus-4.7-20260219")).toBe(ANTHROPIC_CONTEXT_1M_TOKENS);
-    expect(cache.get("claude-cli/claude-sonnet-4-6")).toBe(ANTHROPIC_CONTEXT_1M_TOKENS);
+    expect(cache.get("claude-cli/claude-opus-4.8-20260514")).toBe(200_000);
+    expect(cache.get("claude-cli/claude-opus-4.7-20260219")).toBe(200_000);
+    expect(cache.get("claude-cli/claude-sonnet-4-6")).toBe(200_000);
   });
 
   it("does not upgrade non-Anthropic GA 1M model ids from discovery", () => {
@@ -311,9 +311,6 @@ describe("resolveContextTokensForModel", () => {
     ["anthropic", "claude-opus-4-7"],
     ["anthropic", "claude-sonnet-4-6"],
     ["anthropic", "claude-opus-4-6"],
-    ["claude-cli", "claude-opus-4-7"],
-    ["claude-cli", "claude-sonnet-4-6"],
-    ["claude-cli", "claude-opus-4-6"],
   ])("resolves the corrected %s/%s context window", (provider, model) => {
     resetContextWindowCacheForTest();
     try {
@@ -334,6 +331,38 @@ describe("resolveContextTokensForModel", () => {
       resetContextWindowCacheForTest();
     }
   });
+
+  it.each(["claude-opus-4-7", "claude-sonnet-4-6", "claude-opus-4-6"])(
+    "keeps bare claude-cli/%s at its discovered window",
+    (model) => {
+      resetContextWindowCacheForTest();
+      try {
+        MODEL_CONTEXT_TOKEN_CACHE.set(providerContextTokenCacheKey("claude-cli", model), 200_000);
+        expect(
+          resolveContextTokensForModel({
+            provider: "claude-cli",
+            model,
+            allowAsyncLoad: false,
+          }),
+        ).toBe(200_000);
+      } finally {
+        resetContextWindowCacheForTest();
+      }
+    },
+  );
+
+  it.each(["claude-opus-4-7[1m]", "claude-sonnet-4-6[1m]", "claude-opus-4-6[1m]"])(
+    "resolves explicit claude-cli/%s to 1M",
+    (model) => {
+      expect(
+        resolveContextTokensForModel({
+          provider: "claude-cli",
+          model,
+          allowAsyncLoad: false,
+        }),
+      ).toBe(ANTHROPIC_CONTEXT_1M_TOKENS);
+    },
+  );
 
   it("can exclude unscoped cache entries from provider-owned lookup", () => {
     resetContextWindowCacheForTest();
@@ -449,6 +478,29 @@ describe("resolveContextTokensForModel", () => {
     });
 
     expect(result).toBe(ANTHROPIC_CONTEXT_1M_TOKENS);
+  });
+
+  it("lets a claude-cli model disable the global context1m default", () => {
+    const result = resolveContextTokensForModel({
+      cfg: {
+        agents: {
+          defaults: {
+            params: { context1m: true },
+            models: {
+              "claude-cli/claude-opus-4-7": {
+                params: { context1m: false },
+              },
+            },
+          },
+        },
+      },
+      provider: "claude-cli",
+      model: "claude-opus-4-7",
+      fallbackContextTokens: 200_000,
+      allowAsyncLoad: false,
+    });
+
+    expect(result).toBe(200_000);
   });
 
   it.each(["claude-cli", "fixture-cli"])(
@@ -763,7 +815,7 @@ describe("resolveContextTokensForModel", () => {
     expect(result).toBe(200_000);
   });
 
-  it("returns 1M context for claude opus 4.7 variants without context1m", () => {
+  it("keeps bare claude-cli opus 4.7 variants at the fallback without context1m", () => {
     const result = resolveContextTokensForModel({
       provider: "claude-cli",
       model: "claude-opus-4.7-20260219",
@@ -771,7 +823,7 @@ describe("resolveContextTokensForModel", () => {
       allowAsyncLoad: false,
     });
 
-    expect(result).toBe(ANTHROPIC_CONTEXT_1M_TOKENS);
+    expect(result).toBe(200_000);
   });
 
   it("does not force 1M context for non-Anthropic providers with opus 4.7 ids", () => {

--- a/src/agents/context.test.ts
+++ b/src/agents/context.test.ts
@@ -307,6 +307,34 @@ describe("createSessionManagerRuntimeRegistry", () => {
 });
 
 describe("resolveContextTokensForModel", () => {
+  it.each([
+    ["anthropic", "claude-opus-4-7"],
+    ["anthropic", "claude-sonnet-4-6"],
+    ["anthropic", "claude-opus-4-6"],
+    ["claude-cli", "claude-opus-4-7"],
+    ["claude-cli", "claude-sonnet-4-6"],
+    ["claude-cli", "claude-opus-4-6"],
+  ])("resolves the corrected %s/%s context window", (provider, model) => {
+    resetContextWindowCacheForTest();
+    try {
+      MODEL_CONTEXT_TOKEN_CACHE.set(model, 200_000);
+      MODEL_CONTEXT_TOKEN_CACHE.set(
+        providerContextTokenCacheKey(provider, model),
+        ANTHROPIC_CONTEXT_1M_TOKENS,
+      );
+
+      expect(
+        resolveContextTokensForModel({
+          provider,
+          model,
+          allowAsyncLoad: false,
+        }),
+      ).toBe(ANTHROPIC_CONTEXT_1M_TOKENS);
+    } finally {
+      resetContextWindowCacheForTest();
+    }
+  });
+
   it("can exclude unscoped cache entries from provider-owned lookup", () => {
     resetContextWindowCacheForTest();
     try {

--- a/src/auto-reply/status.test.ts
+++ b/src/auto-reply/status.test.ts
@@ -934,7 +934,7 @@ describe("buildStatusMessage", () => {
     expect(normalizeTestText(text)).toContain("Context: 200k/1.0m");
   });
 
-  it("shows 1M context window for claude opus 4.7 variants", () => {
+  it("keeps bare Claude CLI opus 4.7 variants at the plan-safe context window", () => {
     const text = buildStatusMessage({
       agent: {
         model: "claude-cli/claude-opus-4.7-20260219",
@@ -951,8 +951,8 @@ describe("buildStatusMessage", () => {
     });
 
     const normalized = normalizeTestText(text);
-    expect(normalized).toContain("Context: 200k/1.0m");
-    expect(normalized).not.toContain("Context: 200k/200k");
+    expect(normalized).toContain("Context: 200k/200k");
+    expect(normalized).not.toContain("Context: 200k/1.0m");
   });
 
   it("recomputes context window from the active model after switching away from a smaller session override", () => {
@@ -1137,7 +1137,7 @@ describe("buildStatusMessage", () => {
     expect(normalized).toContain("oauth (anthropic:claude-cli)");
     expect(normalized).not.toContain("Fallback: claude-cli/claude-opus-4-7");
     expect(normalized).not.toContain("unknown");
-    expect(normalized).toContain("Context: 36k/1.0m (4%)");
+    expect(normalized).toContain("Context: 36k/200k (18%)");
   });
 
   it("prefers active CLI OAuth over selected env API-key labels for runtime aliases", () => {

--- a/src/commands/status.summary.runtime.test.ts
+++ b/src/commands/status.summary.runtime.test.ts
@@ -1,5 +1,6 @@
 // Status summary runtime tests cover model context-token resolution.
 import { describe, expect, it } from "vitest";
+import { ANTHROPIC_CONTEXT_1M_TOKENS } from "../agents/context-resolution.js";
 import { statusSummaryRuntime } from "./status.summary.runtime.js";
 
 describe("statusSummaryRuntime.resolveContextTokensForModel", () => {
@@ -157,12 +158,12 @@ describe("statusSummaryRuntime.resolveContextTokensForModel", () => {
         model: "claude-sonnet-4-6",
         contextTokensOverride: 1_200_000,
       }),
-    ).toBe(1_048_576);
+    ).toBe(ANTHROPIC_CONTEXT_1M_TOKENS);
   });
 
   it.each([
     { contextTokens: 200_000, expected: 200_000 },
-    { contextTokens: 2_000_000, expected: 1_048_576 },
+    { contextTokens: 2_000_000, expected: ANTHROPIC_CONTEXT_1M_TOKENS },
   ])(
     "bounds Anthropic contextTokens=$contextTokens by the fixed native window",
     ({ contextTokens, expected }) => {
@@ -175,7 +176,7 @@ describe("statusSummaryRuntime.resolveContextTokensForModel", () => {
                   models: [
                     {
                       id: "claude-sonnet-4-6",
-                      contextWindow: 1_048_576,
+                      contextWindow: ANTHROPIC_CONTEXT_1M_TOKENS,
                       contextTokens,
                     },
                   ],

--- a/src/gateway/session-utils.search.test.ts
+++ b/src/gateway/session-utils.search.test.ts
@@ -5,6 +5,7 @@ import os from "node:os";
 import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeAll, describe, expect, test } from "vitest";
+import { ANTHROPIC_CONTEXT_1M_TOKENS } from "../agents/context-resolution.js";
 import {
   addSubagentRunForTests,
   resetSubagentRegistryForTests,
@@ -29,7 +30,6 @@ const MAIN_SESSION_ID = "sess-main";
 const TRANSCRIPT_TOTAL_TOKENS = 3_200;
 const TRANSCRIPT_COST_USD = 0.007725;
 const ANTHROPIC_MODEL = "claude-sonnet-4-6";
-const ANTHROPIC_CONTEXT_TOKENS = 1_048_576;
 const FREE_OPENAI_MODEL = "gpt-5.3-codex-spark";
 
 type TranscriptUsageFixture = {
@@ -317,7 +317,7 @@ function transcriptFallbackEntry(now: number, overrides: Partial<SessionEntry> =
 
 function expectAnthropicBackfill(session: ListedSession | undefined) {
   expectTranscriptBackfill(session, {
-    contextTokens: ANTHROPIC_CONTEXT_TOKENS,
+    contextTokens: ANTHROPIC_CONTEXT_1M_TOKENS,
     estimatedCostUsd: TRANSCRIPT_COST_USD,
   });
 }


### PR DESCRIPTION
## What Problem This Solves

The bundled Anthropic plugin manifest declared a 200,000-token context window for Claude Opus 4.7, Claude Opus 4.6, and Claude Sonnet 4.6. The catalog cache could therefore cap direct Anthropic API sessions on these GA 1M models at 200k.

Claude CLI is different: 1M availability depends on account plan, usage credits, explicit model selection, and the `CLAUDE_CODE_DISABLE_1M_CONTEXT` setting. Bare Claude CLI model rows therefore must not advertise unconditional 1M context.

## Evidence

- Anthropic's current [context-window documentation](https://platform.claude.com/docs/en/build-with-claude/context-windows) lists the affected direct API models with a 1M-token context window enabled by default.
- Anthropic's live models endpoint reported `max_input_tokens: 1000000` and `max_tokens: 128000` for Claude Opus 4.7, Claude Opus 4.6, and Claude Sonnet 4.6 on 2026-07-16.
- Claude Code's [model configuration documentation](https://code.claude.com/docs/en/model-config#extended-context) documents plan-dependent automatic upgrades plus explicit `[1m]` variants and opt-out behavior.

## Fix

- Set the three affected direct Anthropic manifest rows to the exact 1,000,000-token context limit and 128,000-token output limit.
- Keep bare Claude CLI context metadata at the plan-safe 200,000-token limit while correcting the affected output limits.
- Honor explicit Claude CLI `[1m]` variants and effective `context1m: true` configuration.
- Preserve configuration precedence: a model-level `context1m: false` overrides a global true default.
- Add static catalog, runtime normalization, discovery, configuration-precedence, and resolver coverage.

## Validation

- Focused resolver/provider/status/gateway tests: 160 passed; lookup-cache tests: 25 passed; auto-reply status tests: 85 passed; CLI-runner preparation tests: 74 passed.
- Hosted changed gate: [run 29498589039](https://github.com/openclaw/openclaw/actions/runs/29498589039), exit 0.
- Maintainer autoreview: clean.

Closes #108152

Thanks @LavyaTandel for the original fix and report follow-through.
