### PR TITLE
refactor(msteams): simplify SharePoint timeout cancellation

### DIFF
--- a/extensions/msteams/src/request-timeout.ts
+++ b/extensions/msteams/src/request-timeout.ts
@@ -68,29 +68,16 @@ export async function withMSTeamsAbortableRequestTimeout<T>(params: {
   work: (signal: AbortSignal) => Promise<T>;
 }): Promise<T> {
   const controller = new AbortController();
-  let timeoutError: Error | undefined;
-  let timer: ReturnType<typeof setTimeout> | undefined;
   const timeoutMs = resolveTimerTimeoutMs(params.timeoutMs, MSTEAMS_REQUEST_TIMEOUT_MS, 1);
-  const timeoutPromise = new Promise<never>((_resolve, reject) => {
-    timer = setTimeout(() => {
-      timeoutError = createMSTeamsRequestTimeoutError(params.label, timeoutMs);
-      controller.abort(timeoutError);
-      reject(timeoutError);
-    }, timeoutMs);
-    (timer as { unref?: () => void }).unref?.();
-  });
-  const workPromise = params.work(controller.signal);
-
+  // Defer callback setup so withTimeout arms first; synchronous token-provider
+  // work must count against the request deadline.
+  const work = Promise.resolve().then(() => params.work(controller.signal));
   try {
-    return await Promise.race([workPromise, timeoutPromise]);
+    return await withTimeout(work, timeoutMs, {
+      createError: () => createMSTeamsRequestTimeoutError(params.label, timeoutMs),
+    });
   } catch (error) {
-    if (controller.signal.aborted && timeoutError) {
-      throw timeoutError;
-    }
+    controller.abort(error);
     throw error;
-  } finally {
-    if (timer) {
-      clearTimeout(timer);
-    }
   }
 }


### PR DESCRIPTION
Related: #104288

## What Problem This Solves

The SharePoint deadline fix in #104288 worked, but its Teams-specific helper duplicated the generic wall-clock race and timer cleanup already provided by the shared timeout utility. That left more concurrency code than the cancellation boundary needs.

## Why This Change Was Made

Reuse the shared `withTimeout` helper for the wall-clock deadline, defer request setup until that timer is armed, and abort the request controller when the operation rejects. This preserves the existing timeout labels, size-aware upload budgets, token-acquisition bounds, and fetch/body cancellation while removing the custom timer promise.

AI-assisted follow-up, explicitly requested by a maintainer after #104288 landed.

## User Impact

No user-visible behavior change. SharePoint file sends keep the same deadlines and error messages with a smaller timeout implementation.

## Evidence

- `node scripts/run-vitest.mjs extensions/msteams/src/graph-upload.test.ts extensions/msteams/src/request-timeout.test.ts` — 22 tests passed.
- `./node_modules/.bin/oxfmt --check extensions/msteams/src/request-timeout.ts` — clean.
- `git diff --check -- extensions/msteams/src/request-timeout.ts` — clean.
- Autoreview accepted one deadline-ordering finding, the patch deferred callback setup accordingly, and the final review reported no accepted/actionable findings.
