### PR TITLE
fix(plugin-sdk): let runtime completions request reasoning

### DIFF
--- a/docs/plugins/sdk-runtime.md
+++ b/docs/plugins/sdk-runtime.md
@@ -223,6 +223,7 @@ two-party event loops that do not go through the shared inbound reply runner.
       purpose: "my-plugin.summary",
       maxTokens: 512,
       temperature: 0.2,
+      reasoning: "high",
     });
     ```
 
@@ -264,6 +265,11 @@ two-party event loops that do not go through the shared inbound reply runner.
     active session's agent and do not silently fall back to the default agent. The
     result includes provider/model/agent attribution plus normalized token,
     cache, and estimated cost usage when available.
+
+    Set `reasoning` to request a reasoning effort for the selected model. The
+    host normalizes the canonical thinking levels (`off`, `minimal`, `low`,
+    `medium`, `high`, `xhigh`, `adaptive`, `max`, and `ultra`) for the selected
+    provider and model before dispatching the completion.
 
     <Warning>
     Model overrides require operator opt-in via `plugins.entries.<id>.llm.allowModelOverride: true` in config. Use `plugins.entries.<id>.llm.allowedModels` to restrict trusted plugins to specific canonical `provider/model` targets. Cross-agent completions require `plugins.entries.<id>.llm.allowAgentIdOverride: true`.

--- a/docs/plugins/sdk-runtime.md
+++ b/docs/plugins/sdk-runtime.md
@@ -269,7 +269,8 @@ two-party event loops that do not go through the shared inbound reply runner.
     Set `reasoning` to request a reasoning effort for the selected model. The
     host normalizes the canonical thinking levels (`off`, `minimal`, `low`,
     `medium`, `high`, `xhigh`, `adaptive`, `max`, and `ultra`) for the selected
-    provider and model before dispatching the completion.
+    provider and model before dispatching the completion. `adaptive` becomes
+    `medium`; `max` and `ultra` become `max` when supported, otherwise `xhigh`.
 
     <Warning>
     Model overrides require operator opt-in via `plugins.entries.<id>.llm.allowModelOverride: true` in config. Use `plugins.entries.<id>.llm.allowedModels` to restrict trusted plugins to specific canonical `provider/model` targets. Cross-agent completions require `plugins.entries.<id>.llm.allowAgentIdOverride: true`.

--- a/src/plugins/runtime/runtime-llm.runtime.test.ts
+++ b/src/plugins/runtime/runtime-llm.runtime.test.ts
@@ -567,6 +567,7 @@ describe("runtime.llm.complete", () => {
       ],
       temperature: 0.2,
       maxTokens: 64,
+      reasoning: "high",
       purpose: "test-purpose",
     });
 
@@ -590,6 +591,7 @@ describe("runtime.llm.complete", () => {
     expectFields(requireRecord(completionArg.options, "completion options"), {
       maxTokens: 64,
       temperature: 0.2,
+      reasoning: "high",
     });
     expectFields(requireRecord(result, "completion result"), {
       text: "done",

--- a/src/plugins/runtime/runtime-llm.runtime.test.ts
+++ b/src/plugins/runtime/runtime-llm.runtime.test.ts
@@ -617,6 +617,25 @@ describe("runtime.llm.complete", () => {
     expectFields(requireRecord(logPayload.usage, "log usage"), { costUsd: 0.0042 });
   });
 
+  it("preserves the completion options shape when reasoning is omitted", async () => {
+    const llm = createRuntimeLlm({
+      getConfig: () => cfg,
+      authority: { allowComplete: true },
+    });
+
+    await llm.complete({
+      messages: [{ role: "user", content: "Ping" }],
+    });
+
+    const completionArg = expectSingleCallFirstArg(
+      hoisted.completeWithPreparedSimpleCompletionModel,
+      { cfg },
+    );
+    expect(requireRecord(completionArg.options, "completion options")).not.toHaveProperty(
+      "reasoning",
+    );
+  });
+
   it("uses scoped plugin identity and ignores caller-shaped spoofing input", async () => {
     const logger = createLogger();
     const llm = createRuntimeLlm({

--- a/src/plugins/runtime/runtime-llm.runtime.test.ts
+++ b/src/plugins/runtime/runtime-llm.runtime.test.ts
@@ -567,7 +567,7 @@ describe("runtime.llm.complete", () => {
       ],
       temperature: 0.2,
       maxTokens: 64,
-      reasoning: "high",
+      reasoning: "ultra",
       purpose: "test-purpose",
     });
 
@@ -591,7 +591,7 @@ describe("runtime.llm.complete", () => {
     expectFields(requireRecord(completionArg.options, "completion options"), {
       maxTokens: 64,
       temperature: 0.2,
-      reasoning: "high",
+      reasoning: "ultra",
     });
     expectFields(requireRecord(result, "completion result"), {
       text: "done",

--- a/src/plugins/runtime/runtime-llm.runtime.ts
+++ b/src/plugins/runtime/runtime-llm.runtime.ts
@@ -447,6 +447,7 @@ export function createRuntimeLlm(
         options: {
           maxTokens: finiteOption(params.maxTokens),
           temperature: finiteOption(params.temperature),
+          reasoning: params.reasoning,
           signal: params.signal,
         },
       });

--- a/src/plugins/runtime/runtime-llm.runtime.ts
+++ b/src/plugins/runtime/runtime-llm.runtime.ts
@@ -447,7 +447,7 @@ export function createRuntimeLlm(
         options: {
           maxTokens: finiteOption(params.maxTokens),
           temperature: finiteOption(params.temperature),
-          reasoning: params.reasoning,
+          ...(params.reasoning !== undefined ? { reasoning: params.reasoning } : {}),
           signal: params.signal,
         },
       });

--- a/src/plugins/runtime/types-core.ts
+++ b/src/plugins/runtime/types-core.ts
@@ -215,6 +215,8 @@ export type LlmCompleteParams = {
   model?: string;
   maxTokens?: number;
   temperature?: number;
+  /** Requested reasoning effort; the host normalizes it for the selected model. */
+  reasoning?: import("../../auto-reply/thinking.js").ThinkLevel;
   systemPrompt?: string;
   signal?: AbortSignal;
   /** Human-readable reason for audit/debug output. */


### PR DESCRIPTION
Closes #108255

## What Problem This Solves

Fixes an issue where plugins using `api.runtime.llm.complete` could not request a reasoning effort, causing reasoning-mandatory models to reject the completion or run without the requested reasoning behavior.

## Why This Change Was Made

Expose the existing canonical reasoning level on the public runtime completion parameters and pass it to the already-supported prepared completion path. No provider-specific logic, configuration, routing, or auth behavior changes. Calls that omit `reasoning` preserve the previous completion-options shape and provider defaults.

## User Impact

Plugin authors can pass `reasoning` to host-routed completions and retain catalog, auth-profile, and attribution behavior while the host normalizes that effort for the chosen model.

## Evidence

- `node scripts/run-vitest.mjs src/plugins/runtime/runtime-llm.runtime.test.ts` — 22/22 passed, including explicit forwarding and omitted-field compatibility.
- `node scripts/check-changed.mjs -- docs/plugins/sdk-runtime.md src/plugins/runtime/types-core.ts src/plugins/runtime/runtime-llm.runtime.ts src/plugins/runtime/runtime-llm.runtime.test.ts` — hosted Testbox passed.
- `pnpm plugin-sdk:surface:check` and `pnpm plugin-sdk:api:check` — hosted Testbox passed; generated SDK baseline remains current.
- Exact-head CI — green, including `openclaw/ci-gate`.
- Autoreview — uncommitted and branch-wide reviews clean.
- Direct sibling Codex source inspection confirmed that reasoning effort is optional, `ultra` is canonical, and omitted effort does not update the existing setting.

Co-authored-by: LZY3538 <liu.zhenye@xydigit.com>
