### PR TITLE
refactor: make update runtime preflight result explicit

### DIFF
--- a/src/cli/update-cli/update-command-service.ts
+++ b/src/cli/update-cli/update-command-service.ts
@@ -3,6 +3,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { Writable } from "node:stream";
 import { confirm, isCancel } from "@clack/prompts";
+import { err as resultError, ok, type Result } from "@openclaw/normalization-core/result";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { stylePromptMessage } from "../../../packages/terminal-core/src/prompt-style.js";
 import { theme } from "../../../packages/terminal-core/src/theme.js";
@@ -720,8 +721,7 @@ export function tryResolveInvocationCwd(): string | undefined {
   }
 }
 
-type PackageRuntimePreflightResult = {
-  error: string | null;
+type PackageRuntimePreflight = {
   nodeRunner?: string;
   replacedNodeRunner?: string;
   targetVersion?: string;
@@ -736,21 +736,18 @@ export async function resolvePackageRuntimePreflight(params: {
   command?: string;
   cwd?: string;
   env?: NodeJS.ProcessEnv;
-}): Promise<PackageRuntimePreflightResult> {
+}): Promise<Result<PackageRuntimePreflight, string>> {
   const nodeRunner = normalizeOptionalString(params.nodeRunner);
-  const unchanged = (): PackageRuntimePreflightResult => ({
-    error: null,
-    ...(nodeRunner ? { nodeRunner } : {}),
-  });
+  const unchanged = (): PackageRuntimePreflight => (nodeRunner ? { nodeRunner } : {});
   if (!canResolveRegistryVersionForPackageTarget(params.tag)) {
-    return unchanged();
+    return ok(unchanged());
   }
   if (params.spec && !canResolveRegistryVersionForPackageTarget(params.spec)) {
-    return unchanged();
+    return ok(unchanged());
   }
   const target = params.tag.trim();
   if (!target) {
-    return unchanged();
+    return ok(unchanged());
   }
   const status = await fetchNpmPackageTargetStatus({
     target,
@@ -761,7 +758,7 @@ export async function resolvePackageRuntimePreflight(params: {
     env: params.env,
   });
   if (status.error) {
-    return unchanged();
+    return ok(unchanged());
   }
   const runtime = await resolvePackageRuntimeForPreflight({
     nodeRunner,
@@ -770,11 +767,10 @@ export async function resolvePackageRuntimePreflight(params: {
   const satisfies = nodeVersionSatisfiesEngine(runtime.version, status.nodeEngine);
   const targetVersion = status.version ?? target;
   if (satisfies === true) {
-    return {
-      error: null,
+    return ok({
       ...(nodeRunner ? { nodeRunner } : {}),
       targetVersion,
-    };
+    });
   }
   const fallbackNodeRunner = normalizeOptionalString(params.fallbackNodeRunner);
   if (nodeRunner && fallbackNodeRunner && fallbackNodeRunner !== nodeRunner) {
@@ -787,26 +783,24 @@ export async function resolvePackageRuntimePreflight(params: {
       status.nodeEngine,
     );
     if (fallbackSatisfies === true) {
-      return {
-        error: null,
+      return ok({
         nodeRunner: fallbackNodeRunner,
         replacedNodeRunner: nodeRunner,
         targetVersion,
-      };
+      });
     }
   }
   if (satisfies !== false) {
-    return {
-      error: null,
+    return ok({
       ...(nodeRunner ? { nodeRunner } : {}),
       targetVersion,
-    };
+    });
   }
   const runtimeLabel = runtime.nodeRunner
     ? `Node ${runtime.version ?? "unknown"} at ${runtime.nodeRunner}`
     : `Node ${runtime.version ?? "unknown"}`;
-  return {
-    error: [
+  return resultError(
+    [
       `${runtimeLabel} is too old for openclaw@${targetVersion}.`,
       `The requested package requires ${status.nodeEngine}.`,
       runtime.nodeRunner
@@ -815,9 +809,7 @@ export async function resolvePackageRuntimePreflight(params: {
       "Bare `npm i -g openclaw` can silently install an older compatible release.",
       "After upgrading Node, use `npm i -g openclaw@latest`.",
     ].join("\n"),
-    ...(nodeRunner ? { nodeRunner } : {}),
-    targetVersion,
-  };
+  );
 }
 
 async function resolvePackageRuntimeForPreflight(params: {

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -1001,16 +1001,17 @@ async function updateCommandInternal(
       cwd: packageInstallCwd,
       env: packageInstallEnv,
     });
-    if (runtimePreflight.error) {
+    if (!runtimePreflight.ok) {
       defaultRuntime.error(runtimePreflight.error);
       defaultRuntime.exit(1);
       return;
     }
-    packageUpdateNodeRunner = runtimePreflight.nodeRunner;
-    if (runtimePreflight.replacedNodeRunner && !opts.json) {
+    const runtimeSelection = runtimePreflight.value;
+    packageUpdateNodeRunner = runtimeSelection.nodeRunner;
+    if (runtimeSelection.replacedNodeRunner && !opts.json) {
       defaultRuntime.log(
         theme.warn(
-          `Managed gateway service Node (${runtimePreflight.replacedNodeRunner}) cannot run openclaw@${runtimePreflight.targetVersion ?? tag}.`,
+          `Managed gateway service Node (${runtimeSelection.replacedNodeRunner}) cannot run openclaw@${runtimeSelection.targetVersion ?? tag}.`,
         ),
       );
       defaultRuntime.log(


### PR DESCRIPTION
Related: #106920

## What Problem This Solves

The package runtime preflight has a binary success/failure contract, but its return type represented failure with a nullable field beside optional success metadata. That permitted invalid mixed states and made future callers responsible for remembering which fields were safe to read.

## Why This Change Was Made

Use the shared normalization-core `Result` contract at the preflight boundary. Successful runtime selection now lives only in the success arm; the blocking message lives only in the failure arm. Existing updater behavior and messages remain unchanged.

## User Impact

No user-visible behavior change. This is the maintainer-requested cleanup after #108668: a smaller, explicit contract for the updater path fixed by that PR.

## Evidence

- Blacksmith Testbox `tbx_01kxmz45zmnebnd2hv7vtg1cvn`: `src/cli/update-cli.test.ts` passed 181/181 tests.
- Same Testbox: `pnpm check:changed` passed core and core-test typechecks, formatting, lint, and guards.
- Testbox run: https://github.com/openclaw/openclaw/actions/runs/29481965701
- `git diff --check` passed.
- Autoreview: clean; no accepted/actionable findings.

AI-assisted: Codex. The implementation and proof were reviewed before submission.
