### PR TITLE
fix(vault): reject oversized credential files

### DIFF
--- a/extensions/vault/src/secret-ref-resolver.test.ts
+++ b/extensions/vault/src/secret-ref-resolver.test.ts
@@ -285,6 +285,7 @@ describe("plugin manifest", () => {
     expect(resolverSource).toContain("#!/usr/bin/env node");
     const pluginSdkRootImport = ["openclaw", "plugin-sdk"].join("/");
     expect(resolverSource).not.toContain(pluginSdkRootImport);
+    expect(resolverSource).toContain("@openclaw/fs-safe/secret");
     expect(packageJson.openclaw?.build?.staticAssets).toContainEqual({
       source: "./vault-secret-ref-resolver.js",
       output: "vault-secret-ref-resolver.js",
@@ -448,6 +449,35 @@ describe("vault SecretRef resolver", () => {
     ]);
   });
 
+  it("rejects oversized Vault token files before sending a request", async () => {
+    const fixture = await startVaultFixture();
+    const tokenFile = await writeTempFile("vault-token", "x".repeat(16 * 1024 + 1));
+    const result = await runResolver({
+      request: {
+        protocolVersion: 1,
+        provider: "vault",
+        ids: ["providers/openai/apiKey"],
+      },
+      env: {
+        VAULT_ADDR: fixture.vaultAddr,
+        VAULT_TOKEN_FILE: tokenFile,
+        OPENCLAW_VAULT_AUTH_METHOD: "token_file",
+      },
+    });
+
+    expect(result).toMatchObject({ code: 0, stderr: "" });
+    expect(JSON.parse(result.stdout)).toEqual({
+      protocolVersion: 1,
+      values: {},
+      errors: {
+        "providers/openai/apiKey": {
+          message: expect.stringContaining("exceeds 16384 bytes"),
+        },
+      },
+    });
+    expect(fixture.requests).toEqual([]);
+  });
+
   it("exchanges a workload JWT for a Vault token before reading KV secrets", async () => {
     const fixture = await startVaultJwtFixture();
     const jwtFile = await writeTempFile("vault-jwt", "not-a-real-workload-jwt\n");
@@ -495,6 +525,39 @@ describe("vault SecretRef resolver", () => {
       },
     ]);
   });
+
+  it.each(["jwt", "kubernetes"])(
+    "rejects oversized Vault JWT files before %s login",
+    async (authMethod) => {
+      const fixture = await startVaultJwtFixture();
+      const jwtFile = await writeTempFile("vault-jwt", "x".repeat(16 * 1024 + 1));
+      const result = await runResolver({
+        request: {
+          protocolVersion: 1,
+          provider: "vault",
+          ids: ["providers/openai/apiKey"],
+        },
+        env: {
+          VAULT_ADDR: fixture.vaultAddr,
+          OPENCLAW_VAULT_AUTH_METHOD: authMethod,
+          OPENCLAW_VAULT_AUTH_ROLE: "openclaw",
+          OPENCLAW_VAULT_JWT_FILE: jwtFile,
+        },
+      });
+
+      expect(result).toMatchObject({ code: 0, stderr: "" });
+      expect(JSON.parse(result.stdout)).toEqual({
+        protocolVersion: 1,
+        values: {},
+        errors: {
+          "providers/openai/apiKey": {
+            message: expect.stringContaining("exceeds 16384 bytes"),
+          },
+        },
+      });
+      expect(fixture.requests).toEqual([]);
+    },
+  );
 
   it("uses Vault kubernetes auth defaults with a service account JWT file", async () => {
     const fixture = await startVaultJwtFixture();

--- a/extensions/vault/vault-secret-ref-resolver.js
+++ b/extensions/vault/vault-secret-ref-resolver.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { readFile } from "node:fs/promises";
+import { readSecretFileSync } from "@openclaw/fs-safe/secret";
 import { parseVaultSecretId } from "./vault-secret-id.js";
 
 const KUBERNETES_SERVICE_ACCOUNT_TOKEN_PATH = "/var/run/secrets/kubernetes.io/serviceaccount/token";
@@ -55,6 +55,20 @@ function normalizeOptionalString(value) {
   return value?.trim() || undefined;
 }
 
+function readVaultCredentialFile(filePath, label, emptyMessage) {
+  try {
+    return readSecretFileSync(filePath, label, { rejectHardlinks: false });
+  } catch (error) {
+    if (error?.code === "not-found" && error.cause) {
+      throw error.cause;
+    }
+    if (error?.code === "invalid-path" && error.message?.endsWith(" is empty.")) {
+      throw new Error(emptyMessage, { cause: error });
+    }
+    throw error;
+  }
+}
+
 function resolveVaultAuthMethod() {
   const method = normalizeOptionalString(process.env.OPENCLAW_VAULT_AUTH_METHOD) ?? "token";
   if (
@@ -76,16 +90,16 @@ function resolveVaultTokenEnv() {
   return token;
 }
 
-async function resolveVaultTokenFile() {
+function resolveVaultTokenFile() {
   const tokenFile = normalizeOptionalString(process.env.VAULT_TOKEN_FILE);
   if (!tokenFile) {
     throw new Error("VAULT_TOKEN_FILE is required.");
   }
-  const token = (await readFile(tokenFile, "utf8")).trim();
-  if (!token) {
-    throw new Error("VAULT_TOKEN_FILE did not contain a token.");
-  }
-  return token;
+  return readVaultCredentialFile(
+    tokenFile,
+    "Vault token",
+    "VAULT_TOKEN_FILE did not contain a token.",
+  );
 }
 
 function resolveKvMount() {
@@ -164,18 +178,18 @@ function resolveVaultAuthRole(method) {
   return role;
 }
 
-async function resolveVaultJwt(method) {
+function resolveVaultJwt(method) {
   const jwtFile =
     normalizeOptionalString(process.env.OPENCLAW_VAULT_JWT_FILE) ??
     (method === "kubernetes" ? KUBERNETES_SERVICE_ACCOUNT_TOKEN_PATH : undefined);
   if (!jwtFile) {
     throw new Error("OPENCLAW_VAULT_JWT_FILE is required for jwt auth.");
   }
-  const jwt = (await readFile(jwtFile, "utf8")).trim();
-  if (!jwt) {
-    throw new Error("OPENCLAW_VAULT_JWT_FILE did not contain a JWT.");
-  }
-  return jwt;
+  return readVaultCredentialFile(
+    jwtFile,
+    "Vault JWT",
+    "OPENCLAW_VAULT_JWT_FILE did not contain a JWT.",
+  );
 }
 
 function readVaultLoginToken(payload, method) {

--- a/extensions/vault/vault-secret-ref-resolver.js
+++ b/extensions/vault/vault-secret-ref-resolver.js
@@ -211,7 +211,7 @@ async function resolveVaultTokenFromJwt(baseUrl, method) {
     headers,
     body: JSON.stringify({
       role: resolveVaultAuthRole(method),
-      jwt: await resolveVaultJwt(method),
+      jwt: resolveVaultJwt(method),
     }),
   });
   if (!response.ok) {
@@ -225,7 +225,7 @@ async function resolveVaultClientToken(baseUrl) {
     case "token":
       return resolveVaultTokenEnv();
     case "token_file":
-      return await resolveVaultTokenFile();
+      return resolveVaultTokenFile();
     case "jwt":
       return await resolveVaultTokenFromJwt(baseUrl, "jwt");
     case "kubernetes":


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators using Vault token-file, JWT, or Kubernetes authentication could have an oversized credential file read in full and forwarded to Vault before authentication failed. A mistakenly selected large file could therefore allocate and transmit unbounded credential input through the bundled Vault resolver.

## Why This Change Was Made

Vault credential-file reads now use the existing `@openclaw/fs-safe` 16 KiB pinned-file contract before constructing any Vault request, while retaining the resolver's existing missing/empty errors and symlink/hardlink behavior. This is an auth-sensitive path; the main failure risk was rejecting normal deployed credential paths, so the proof includes normal, symlink, hardlink, missing, and empty controls alongside both oversized token and JWT cases.

## User Impact

Operators still use `VAULT_TOKEN_FILE` and `OPENCLAW_VAULT_JWT_FILE` as before for normal credentials. Files larger than 16 KiB now fail through the resolver's per-id error response without sending a Vault authentication or secret request.

## Evidence

Real behavior proof used Linux with Node `v24.18.0`, the production resolver in a real OS child process, and a real loopback HTTP server. No real credential or external Vault instance was used, and proof output records only byte counts and redacted result state.

Before, on exact current base `9f6b3aa118d11926393962b058c07b23b77b0f4f`, a 20,480-byte `VAULT_TOKEN_FILE` reached the loopback server intact:

```text
{"head":"9f6b3aa118d11926393962b058c07b23b77b0f4f","node":"v24.18.0","platform":"linux","tokenFileBytes":20480,"requests":1,"forwardedTokenChars":20480,"returnedValue":true,"resolverErrors":0,"childCode":0,"stderrBytes":0}
```

After, on exact head `d065d496a0b6ad890af68147654ab45d33c92b0e`, the same 20,480-byte token and JWT files were rejected at the 16,384-byte bound with zero HTTP requests. Normal, symlink, and hardlink token paths still reached the server with the same 12-character trimmed value, while missing and empty files retained their prior error categories:

```text
{"head":"d065d496a0b6ad890af68147654ab45d33c92b0e","base":"9f6b3aa118d11926393962b058c07b23b77b0f4f","node":"v24.18.0","platform":"linux","oversizedBytes":20480,"receivedTokenLengths":[12,12,12],"results":[{"name":"oversized-token","code":0,"stderrBytes":0,"requests":0,"returnedValue":false,"errorKind":"too-large-16384"},{"name":"normal-token","code":0,"stderrBytes":0,"requests":1,"returnedValue":true,"errorKind":"none"},{"name":"symlink-token","code":0,"stderrBytes":0,"requests":1,"returnedValue":true,"errorKind":"none"},{"name":"hardlink-token","code":0,"stderrBytes":0,"requests":1,"returnedValue":true,"errorKind":"none"},{"name":"empty-token","code":0,"stderrBytes":0,"requests":0,"returnedValue":false,"errorKind":"empty-preserved"},{"name":"missing-token","code":0,"stderrBytes":0,"requests":0,"returnedValue":false,"errorKind":"missing-preserved"},{"name":"oversized-jwt","code":0,"stderrBytes":0,"requests":0,"returnedValue":false,"errorKind":"too-large-16384"}]}
```

Focused validation on the rebased head:

```text
node scripts/run-vitest.mjs extensions/vault/src/secret-ref-resolver.test.ts
Test Files  1 passed (1)
Tests       16 passed (16)

node scripts/run-vitest.mjs src/plugins/contracts/extension-runtime-dependencies.contract.test.ts
Test Files  1 passed (1)
Tests       436 passed (436)

oxfmt --check: passed
targeted oxlint: passed
git diff --check: passed
autoreview --mode uncommitted: clean, no accepted/actionable findings
```

Full build/check/test coverage is left to the fork PR's GitHub Actions. The repository lint wrapper's local plugin-SDK declaration preparation hit pre-existing `packages/net-policy/src/ip.ts` type errors; the touched files passed direct targeted oxlint.

AI-assisted: Codex helped implement and review this patch; the before/after child-process and loopback-server proof was run manually.


Co-authored-by: ZengWen-DT <ceng.wen@xydigit.com>