### PR TITLE
refactor(plugins): centralize slot reset policy

### DIFF
--- a/src/plugins/slots.test.ts
+++ b/src/plugins/slots.test.ts
@@ -2,7 +2,30 @@
 import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import type { PluginKind } from "./plugin-kind.types.js";
-import { applyExclusiveSlotSelection, hasKind, kindsEqual } from "./slots.js";
+import {
+  applyExclusiveSlotSelection,
+  hasKind,
+  kindsEqual,
+  resetPluginSlotsToDefaults,
+} from "./slots.js";
+
+describe("resetPluginSlotsToDefaults", () => {
+  it("resets every slot owned by the plugin", () => {
+    expect(
+      resetPluginSlotsToDefaults(
+        { memory: "dual-plugin", contextEngine: "dual-plugin" },
+        "dual-plugin",
+      ),
+    ).toEqual({ memory: "memory-core", contextEngine: "legacy" });
+  });
+
+  it("preserves slot state when the plugin owns no slot", () => {
+    const slots = { memory: "memory-core", contextEngine: "legacy" };
+
+    expect(resetPluginSlotsToDefaults(slots, "other-plugin")).toBe(slots);
+    expect(resetPluginSlotsToDefaults(undefined, "other-plugin")).toBeUndefined();
+  });
+});
 
 describe("applyExclusiveSlotSelection", () => {
   const createMemoryConfig = (plugins?: OpenClawConfig["plugins"]): OpenClawConfig => ({

--- a/src/plugins/slots.ts
+++ b/src/plugins/slots.ts
@@ -20,6 +20,8 @@ const DEFAULT_SLOT_BY_KEY: Record<PluginSlotKey, string> = {
   contextEngine: "legacy",
 };
 
+const PLUGIN_SLOT_KEYS = Object.keys(DEFAULT_SLOT_BY_KEY) as PluginSlotKey[];
+
 /** Normalize a kind field to an array for uniform iteration. */
 function normalizeKinds(kind?: PluginKind | PluginKind[]): PluginKind[] {
   if (!kind) {
@@ -56,6 +58,26 @@ function slotKeysForPluginKind(kind?: PluginKind | PluginKind[]): PluginSlotKey[
 /** Returns the implicit plugin id that owns a slot before config overrides it. */
 export function defaultSlotIdForKey(slotKey: PluginSlotKey): string {
   return DEFAULT_SLOT_BY_KEY[slotKey];
+}
+
+/** Resets every slot currently owned by a plugin to that slot's implicit default. */
+export function resetPluginSlotsToDefaults(
+  slots: PluginSlotsConfig | undefined,
+  pluginId: string,
+): PluginSlotsConfig | undefined {
+  if (!slots) {
+    return slots;
+  }
+  const next = { ...slots };
+  let changed = false;
+  for (const slotKey of PLUGIN_SLOT_KEYS) {
+    if (slots[slotKey] !== pluginId) {
+      continue;
+    }
+    next[slotKey] = defaultSlotIdForKey(slotKey);
+    changed = true;
+  }
+  return changed ? next : slots;
 }
 
 type SlotSelectionResult = {

--- a/src/plugins/uninstall.ts
+++ b/src/plugins/uninstall.ts
@@ -18,7 +18,7 @@ import {
   resolvePluginNpmProjectsDir,
 } from "./install-paths.js";
 import { relinkOpenClawPeerDependenciesInManagedNpmRoot } from "./plugin-peer-link.js";
-import { defaultSlotIdForKey } from "./slots.js";
+import { defaultSlotIdForKey, resetPluginSlotsToDefaults } from "./slots.js";
 
 type UninstallActions = {
   entry: boolean;
@@ -437,19 +437,12 @@ export function removePluginFromConfig(
   // Reset slots if this plugin was selected.
   let slots = pluginsConfig.slots;
   if (slots?.memory === pluginId) {
-    slots = {
-      ...slots,
-      memory: defaultSlotIdForKey("memory"),
-    };
     actions.memorySlot = true;
   }
   if (slots?.contextEngine === pluginId) {
-    slots = {
-      ...slots,
-      contextEngine: defaultSlotIdForKey("contextEngine"),
-    };
     actions.contextEngineSlot = true;
   }
+  slots = resetPluginSlotsToDefaults(slots, pluginId);
   if (slots && Object.keys(slots).length === 0) {
     slots = undefined;
   }

--- a/src/plugins/update.ts
+++ b/src/plugins/update.ts
@@ -72,7 +72,7 @@ import {
 import { resolvePackagePluginApiRange } from "./package-compat.js";
 import { validatePackageExtensionEntriesForInstall } from "./package-entry-resolution.js";
 import { linkOpenClawPeerDependencies } from "./plugin-peer-link.js";
-import { defaultSlotIdForKey } from "./slots.js";
+import { resetPluginSlotsToDefaults } from "./slots.js";
 import { setPluginEnabledInConfig } from "./toggle-config.js";
 
 /** Logger surface used by plugin update flows. */
@@ -1288,29 +1288,6 @@ function createPluginUpdateIntegrityDriftHandler(params: {
   };
 }
 
-function resetDisabledPluginSlots(
-  slots: NonNullable<OpenClawConfig["plugins"]>["slots"] | undefined,
-  pluginId: string,
-): NonNullable<OpenClawConfig["plugins"]>["slots"] | undefined {
-  if (!slots) {
-    return slots;
-  }
-  let next = slots;
-  if (next.memory === pluginId) {
-    next = {
-      ...next,
-      memory: defaultSlotIdForKey("memory"),
-    };
-  }
-  if (next.contextEngine === pluginId) {
-    next = {
-      ...next,
-      contextEngine: defaultSlotIdForKey("contextEngine"),
-    };
-  }
-  return next;
-}
-
 function disablePluginAfterUpdateFailure(config: OpenClawConfig, pluginId: string): OpenClawConfig {
   const disabled = setPluginEnabledInConfig(config, pluginId, false, {
     updateChannelConfig: false,
@@ -1321,7 +1298,7 @@ function disablePluginAfterUpdateFailure(config: OpenClawConfig, pluginId: strin
     plugins: {
       ...pluginsConfig,
       // Failed updates are reversible activation changes; only explicit uninstall removes trust policy.
-      slots: resetDisabledPluginSlots(pluginsConfig.slots, pluginId),
+      slots: resetPluginSlotsToDefaults(pluginsConfig.slots, pluginId),
     },
   };
 }


### PR DESCRIPTION
Related: #107224

AI-assisted: Codex implementation and review.

## What Problem This Solves

Plugin-update failure handling and explicit uninstall independently encoded how memory and context-engine slots return to their defaults. That duplication could let the two lifecycle paths drift when slot policy changes.

## Why This Change Was Made

Centralize plugin-owned slot resets in the slot-policy module, then reuse the helper from updater failure recovery and uninstall. Existing trust-policy, action-reporting, and default-slot behavior stays unchanged.

## User Impact

No user-visible behavior change. Maintainers now have one canonical slot-reset path for reversible update failure and explicit uninstall flows.

## Evidence

- Blacksmith Testbox `tbx_01kxmz3dcn9bvcs08qs4ew5hxv`: `pnpm test src/plugins/slots.test.ts src/plugins/uninstall.test.ts src/plugins/update.test.ts` — 198 tests passed.
- Same Testbox: `pnpm check:changed` — formatting, production/test typechecks, lint, plugin boundaries, and guards passed.
- `git diff --check` passed.
- Autoreview: clean, no accepted/actionable findings; patch correctness 0.98.
