### PR TITLE
fix: transcribe filename-only audio in locked harness sessions

### DIFF
--- a/src/auto-reply/reply/get-reply.message-hooks.test.ts
+++ b/src/auto-reply/reply/get-reply.message-hooks.test.ts
@@ -82,6 +82,25 @@ function buildCtx(overrides: Partial<MsgContext> = {}): MsgContext {
   });
 }
 
+function buildConfiguredAudioCfg() {
+  return withFastReplyConfig({
+    tools: {
+      media: {
+        audio: {
+          enabled: true,
+          models: [
+            {
+              type: "cli",
+              command: "/usr/local/bin/stt-transcribe",
+              args: ["{{MediaPath}}"],
+            },
+          ],
+        },
+      },
+    },
+  });
+}
+
 function hookEventCall(index: number): [string, string, string, Record<string, unknown>] {
   const call = mocks.createInternalHookEvent.mock.calls[index];
   if (!call) {
@@ -276,22 +295,7 @@ describe("getReplyFromConfig message hooks", () => {
     await getReplyFromConfig(
       buildCtx({ SessionKey: sessionKey }),
       undefined,
-      withFastReplyConfig({
-        tools: {
-          media: {
-            audio: {
-              enabled: true,
-              models: [
-                {
-                  type: "cli",
-                  command: "/usr/local/bin/stt-transcribe",
-                  args: ["{{MediaPath}}"],
-                },
-              ],
-            },
-          },
-        },
-      }),
+      buildConfiguredAudioCfg(),
     );
 
     expect(mocks.resolveReplySessionPreprocessingState).toHaveBeenCalledOnce();
@@ -314,27 +318,41 @@ describe("getReplyFromConfig message hooks", () => {
     );
   });
 
-  it("runs normal media understanding for an unlocked voice note", async () => {
+  it("recognizes locked-harness audio from its filename when MIME metadata is missing", async () => {
+    const sessionKey = "agent:main:harness:claude-cli:locked-audio-filename";
+    mocks.resolveReplySessionPreprocessingState.mockReturnValueOnce({
+      sessionEntry: {
+        sessionId: "locked-filename-session",
+        updatedAt: 1,
+        agentHarnessId: "claude-cli",
+        modelSelectionLocked: true,
+      },
+      sessionKey,
+      storePath: "/tmp/sessions.json",
+    });
+
     await getReplyFromConfig(
-      buildCtx(),
-      undefined,
-      withFastReplyConfig({
-        tools: {
-          media: {
-            audio: {
-              enabled: true,
-              models: [
-                {
-                  type: "cli",
-                  command: "/usr/local/bin/stt-transcribe",
-                  args: ["{{MediaPath}}"],
-                },
-              ],
-            },
-          },
-        },
+      buildCtx({
+        SessionKey: sessionKey,
+        Body: "<media:file>",
+        BodyForAgent: "<media:file>",
+        BodyForCommands: "<media:file>",
+        RawBody: "<media:file>",
+        CommandBody: "<media:file>",
+        MediaType: undefined,
       }),
+      undefined,
+      buildConfiguredAudioCfg(),
     );
+
+    expect(mocks.applyMediaUnderstanding).toHaveBeenCalledOnce();
+    expect(mocks.applyMediaUnderstanding.mock.calls[0]?.[0]).toEqual(
+      expect.objectContaining({ processingMode: "audio-only" }),
+    );
+  });
+
+  it("runs normal media understanding for an unlocked voice note", async () => {
+    await getReplyFromConfig(buildCtx(), undefined, buildConfiguredAudioCfg());
 
     expect(mocks.applyMediaUnderstanding).toHaveBeenCalledOnce();
     expect(mocks.applyMediaUnderstanding.mock.calls[0]?.[0]).not.toHaveProperty("processingMode");

--- a/src/auto-reply/reply/inbound-media.ts
+++ b/src/auto-reply/reply/inbound-media.ts
@@ -1,4 +1,5 @@
 /** Detects inbound media and audio markers in channel message context. */
+import { isAudioFileName } from "@openclaw/media-core/mime";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 
 /** Minimal inbound media fields used by media/audio detection. */
@@ -62,6 +63,18 @@ export function hasInboundAudio(ctx: InboundMediaContext): boolean {
       : []),
   ].filter((type): type is string => Boolean(type));
   if (mediaTypes.some((type) => type === "audio" || type.startsWith("audio/"))) {
+    return true;
+  }
+
+  // Keep the locked-session gate aligned with media-understanding attachment
+  // classification when a channel omits MIME metadata.
+  const mediaLocations = [
+    ctx.MediaPath,
+    ctx.MediaUrl,
+    ...(Array.isArray(ctx.MediaPaths) ? ctx.MediaPaths : []),
+    ...(Array.isArray(ctx.MediaUrls) ? ctx.MediaUrls : []),
+  ];
+  if (mediaLocations.some((value) => isAudioFileName(normalizeOptionalString(value)))) {
     return true;
   }
 


### PR DESCRIPTION
Related: #108244
Follow-up to #108714

## What Problem This Solves

Fixes an issue where users sending a supported audio attachment without MIME metadata to a model-locked native harness would still miss explicitly configured transcription, even when the attachment path or URL clearly identified an audio file.

## Why This Change Was Made

The locked-session gate now uses the shared media-core audio filename classifier for singular and plural attachment paths and URLs. This matches the media-understanding runner's existing fallback while preserving native-harness ownership of image, video, and file inputs.

The related voice-note tests now share one configured-audio fixture instead of repeating the full config.

## User Impact

Configured STT now also runs for locked native-harness audio attachments identified by filenames such as `.ogg` or `.mp3` when a channel omits MIME metadata.

## Evidence

- `node scripts/run-vitest.mjs src/auto-reply/reply/get-reply.message-hooks.test.ts` — 18 tests passed.
- `node scripts/check-changed.mjs` — Blacksmith Testbox changed gate passed with `exitCode: 0` (core production/test types, lint, format, architecture and boundary guards): https://github.com/openclaw/openclaw/actions/runs/29482395233
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted --stream-engine-output` — clean; no accepted/actionable findings.
