### PR TITLE
fix(ci): bound release resume tarball downloads

### DIFF
--- a/.github/workflows/openclaw-release-publish.yml
+++ b/.github/workflows/openclaw-release-publish.yml
@@ -1323,7 +1323,14 @@ jobs:
             fi
             published_tarball_url="$(npm view "openclaw@${release_version}" dist.tarball)"
             published_tarball_path="${manifest_dir}/published.tgz"
-            curl -fsSL --retry 3 -o "${published_tarball_path}" "${published_tarball_url}"
+            # Keep registry identity verification bounded if a connected
+            # tarball endpoint stops transferring during a release resume.
+            curl -fsSL \
+              --connect-timeout 10 \
+              --max-time 120 \
+              --retry 3 \
+              --retry-max-time 180 \
+              -o "${published_tarball_path}" "${published_tarball_url}"
             published_sha="$(sha256sum "${published_tarball_path}" | awk '{print $1}')"
             if [[ "${published_sha}" != "${manifest_tarball_sha}" ]]; then
               {

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -4309,6 +4309,25 @@ describe("package artifact reuse", () => {
     expect(releaseWorkflow).toContain("finished with ${conclusion} in ${duration_label}");
   });
 
+  it("bounds the npm registry tarball download used for release resume", () => {
+    const publishRun =
+      workflowStep(workflowJob(RELEASE_PUBLISH_WORKFLOW, "publish"), "Dispatch publish workflows")
+        .run ?? "";
+    const resolvePublishState = shellFunctionSource(
+      publishRun,
+      "resolve_openclaw_npm_publish_state",
+    );
+    const registryDownload = resolvePublishState.match(
+      /curl -fsSL[\s\S]*?"\$\{published_tarball_url\}"/u,
+    )?.[0];
+
+    expect(registryDownload).toContain("--connect-timeout 10");
+    expect(registryDownload).toContain("--max-time 120");
+    expect(registryDownload).toContain("--retry 3");
+    expect(registryDownload).toContain("--retry-max-time 180");
+    expect(registryDownload).toContain('-o "${published_tarball_path}"');
+  });
+
   it("fails closed when child environment identity or approval mutation fails", () => {
     const publishRun =
       workflowStep(workflowJob(RELEASE_PUBLISH_WORKFLOW, "publish"), "Dispatch publish workflows")


### PR DESCRIPTION
## What Problem This Solves

Release resume verifies an already-published npm tarball with curl, but the transfer has no connection, read, or aggregate retry deadline. A registry endpoint that accepts the connection and then stalls, or returns a long `Retry-After`, can hold the publish-state resolver for an excessive period.

## Why This Change Was Made

The owner-local tarball download now has a 10-second connect timeout, a 120-second per-transfer deadline, and a 180-second retry-start budget while preserving the existing three retries and SHA-256 identity check.

## User Impact

A resumed release now fails clearly when the published tarball cannot be retrieved within a bounded window instead of waiting on a stalled registry transfer. Normal release behavior and artifact verification are unchanged.

## Evidence

- Focused package-acceptance workflow test: 1 passed, 78 skipped.
- Full test-file comparison: the new test passed; the same seven unrelated environment-dependent failures reproduced on clean `main`.
- `oxfmt`, YAML parsing, workflow sanity, and `git diff --check`: passed.
- Live `openclaw@2026.7.1` npm tarball download with the exact flags: 19,887,736 bytes; SHA-256 matched the registry artifact.
- Controlled stalled-response proof: curl exited 28 at the scaled transfer deadline. A retry sequence that took about 11 seconds with only `--max-time 1` fell to about 3 seconds with `--retry-max-time 2`.
- Independent Codex adversarial review found and required the aggregate retry cap; after the fix, it found no remaining actionable issue and estimated 97% merge likelihood.
