### PR TITLE
fix(feishu): lock timeoutMs preflight abort for stalled DNS lookup

### DIFF
--- a/extensions/feishu/src/app-registration.test.ts
+++ b/extensions/feishu/src/app-registration.test.ts
@@ -375,6 +375,42 @@ describe("Feishu app registration", () => {
       },
     );
   });
+
+  // Locks #105549's guard-owned timeoutMs at the beginAppRegistration entry point.
+  // Shared SSRF tests cover stalled DNS; this asserts Feishu still forwards timeoutMs
+  // into that owner so preflight abort happens before HTTP dispatch. Do not rewrite
+  // this to AbortSignal.timeout() — that would regress the guard-owned contract.
+  it("rejects with timeout when preflight lookup stalls (DNS/proxy stall protection)", async () => {
+    const stalledLookup: LookupFn = (() => new Promise<never>(() => {})) as LookupFn;
+    const fetchSpy = vi.fn() as unknown as FeishuAppRegistrationFetch;
+
+    const started = Date.now();
+    const outcome = await beginAppRegistration("feishu", {
+      fetchImpl: fetchSpy,
+      lookupFn: stalledLookup,
+      timeoutMs: 80,
+    }).then(
+      (value) => ({ ok: true as const, value }),
+      (error: unknown) => ({ ok: false as const, error }),
+    );
+    const elapsedMs = Date.now() - started;
+
+    expect(outcome.ok).toBe(false);
+    if (!outcome.ok) {
+      expect(outcome.error).toMatchObject({
+        name: "TimeoutError",
+        message: "request timed out",
+      });
+    }
+    expect(elapsedMs).toBeGreaterThanOrEqual(60);
+    expect(elapsedMs).toBeLessThan(2_000);
+    expect(fetchSpy).not.toHaveBeenCalled();
+    console.log(
+      `[feishu preflight stall proof] timed_out=${!outcome.ok} name=${
+        outcome.ok ? "n/a" : (outcome.error as Error).name
+      } message=${outcome.ok ? "n/a" : (outcome.error as Error).message} elapsed_ms=${elapsedMs} fetch_called=${vi.mocked(fetchSpy).mock.calls.length}`,
+    );
+  });
 });
 
 describe("feishu bound reads — local HTTP server", () => {


### PR DESCRIPTION
## What Problem This Solves

Feishu app registration can hang when SSRF DNS/proxy preflight never completes. Without an entry-point regression on `beginAppRegistration`, a future change can stop forwarding `timeoutMs` into `fetchWithSsrFGuard` and leave onboarding stuck before HTTP dispatch.

## Why This Change Was Made

Current `main` (after [#105549](https://github.com/openclaw/openclaw/pull/105549)) owns registration deadlines via **guard top-level `timeoutMs`**, not `AbortSignal.timeout()` in `RequestInit`. `beginAppRegistration(domain, options?)` still accepts test-only `fetchImpl` / `lookupFn` / `timeoutMs`.

This PR is test-only: it locks that contract for a never-resolving `lookupFn`, asserting `TimeoutError` + `message: "request timed out"` and that `fetchImpl` is never called. Shared SSRF suites already cover stalled DNS; this asserts the Feishu entry point still forwards `timeoutMs` into that owner.

**Note for review:** Rewriting this regression to `AbortSignal.timeout()` would regress #105549 and does not match current `main` (`extensions/feishu/src/app-registration.ts` still forwards `timeoutMs` into `fetchWithSsrFGuard`).

## User Impact

No runtime change. Contributors get a Feishu-local regression that fails if registration stops honoring the guard-owned preflight deadline.

## Evidence

| Layer | Proof |
| --- | --- |
| Head | `fc27e5dacd53197e5ac8a770a2bceed491ff5d65` (1 commit on latest `main` `282879b…`) |
| Scope | 1 file test-only (`app-registration.test.ts`) |
| Contract on main | `beginAppRegistration` options still include `lookupFn` / `timeoutMs` / `fetchImpl` |
| L1 | focused vitest: stall DNS + hang headers |

```text
pnpm exec vitest run extensions/feishu/src/app-registration.test.ts -t "preflight lookup stalls|never return headers"
→ 2 passed

[feishu preflight stall proof] timed_out=true name=TimeoutError message=request timed out elapsed_ms=81 fetch_called=0
[feishu fetchFeishuJson hang proof] timed_out=true name=TimeoutError elapsed_ms=100
```

Sibling on main already covers post-connect hang (`times out registration POSTs when accounts never return headers`). This PR adds the **preflight/DNS stall before fetch** path (`fetch_called=0`).