### PR TITLE
fix(e2e): bound cross-OS installer fetches

### DIFF
--- a/package.json
+++ b/package.json
@@ -1960,7 +1960,7 @@
     "test:unit:fast:audit": "node scripts/test-unit-fast-audit.mjs",
     "test:voicecall:closedloop": "node scripts/test-voicecall-closedloop.mjs",
     "test:watch": "node scripts/test-projects.mjs --watch",
-    "test:windows:ci": "node scripts/test-projects.mjs src/shared/runtime-import.test.ts src/process/exec.windows.test.ts src/process/windows-command.test.ts src/infra/windows-install-roots.test.ts src/node-host/invoke-system-run-allowlist.test.ts src/daemon/schtasks.startup-fallback.test.ts extensions/lobster/src/lobster-runner.test.ts test/scripts/format-generated-module.test.ts test/scripts/npm-runner.test.ts test/scripts/openclaw-cross-os-release-workflow.test.ts test/scripts/pnpm-runner.test.ts test/scripts/run-with-env.test.ts test/scripts/ts-topology.test.ts test/scripts/ui.test.ts test/scripts/vitest-process-group.test.ts",
+    "test:windows:ci": "node scripts/test-projects.mjs src/shared/runtime-import.test.ts src/process/exec.windows.test.ts src/process/windows-command.test.ts src/infra/windows-install-roots.test.ts src/node-host/invoke-system-run-allowlist.test.ts src/daemon/schtasks.startup-fallback.test.ts extensions/lobster/src/lobster-runner.test.ts test/scripts/format-generated-module.test.ts test/scripts/npm-runner.test.ts test/scripts/openclaw-cross-os-installer.windows.test.ts test/scripts/openclaw-cross-os-release-workflow.test.ts test/scripts/pnpm-runner.test.ts test/scripts/run-with-env.test.ts test/scripts/ts-topology.test.ts test/scripts/ui.test.ts test/scripts/vitest-process-group.test.ts",
     "tool-display:check": "node --import tsx scripts/tool-display.ts --check",
     "tool-display:write": "node --import tsx scripts/tool-display.ts --write",
     "ts-topology": "node --import tsx scripts/ts-topology.ts",

--- a/scripts/lib/cross-os-release-checks/installed.ts
+++ b/scripts/lib/cross-os-release-checks/installed.ts
@@ -155,10 +155,13 @@ try {
 `;
   }
 
-  // Do not retry a streamed installer: a partial first response could be concatenated with the retry.
+  // Execute only a complete installer: a timed-out response may still contain an executable prefix.
   return [
     "set -euo pipefail",
-    `curl -fsSL --connect-timeout ${connectTimeoutSeconds} --max-time ${requestTimeoutSeconds} '${shellEscapeForSh(params.installerUrl)}' | bash -s -- --version '${shellEscapeForSh(params.installTarget)}' --no-onboard`,
+    'installer_path="$(mktemp "${TMPDIR:-/tmp}/openclaw-installer-XXXXXX")"',
+    "trap 'rm -f \"$installer_path\"' EXIT",
+    `curl -fsSL --connect-timeout ${connectTimeoutSeconds} --max-time ${requestTimeoutSeconds} -o "$installer_path" '${shellEscapeForSh(params.installerUrl)}'`,
+    `bash -- "$installer_path" --version '${shellEscapeForSh(params.installTarget)}' --no-onboard`,
   ].join("\n");
 }
 

--- a/scripts/lib/cross-os-release-checks/installed.ts
+++ b/scripts/lib/cross-os-release-checks/installed.ts
@@ -126,16 +126,24 @@ async function runPowerShellScript(script: string, options: CommandOptions) {
   );
 }
 
-export function buildInstallerSmokeScript(params: {
-  installerUrl: string;
-  installTarget: string;
-  platform?: NodeJS.Platform;
-}) {
+export function buildInstallerSmokeScript(
+  params: {
+    installerUrl: string;
+    installTarget: string;
+    platform?: NodeJS.Platform;
+  },
+  options: {
+    connectTimeoutSeconds?: number;
+    requestTimeoutSeconds?: number;
+  } = {},
+) {
+  const connectTimeoutSeconds = options.connectTimeoutSeconds ?? INSTALLER_CONNECT_TIMEOUT_SECONDS;
+  const requestTimeoutSeconds = options.requestTimeoutSeconds ?? INSTALLER_REQUEST_TIMEOUT_SECONDS;
   if ((params.platform ?? process.platform) === "win32") {
     return `
 $installerPath = Join-Path ([System.IO.Path]::GetTempPath()) ("openclaw-installer-" + [guid]::NewGuid().ToString("N") + ".ps1")
 try {
-  & curl.exe -fsSL --connect-timeout ${INSTALLER_CONNECT_TIMEOUT_SECONDS} --max-time ${INSTALLER_REQUEST_TIMEOUT_SECONDS} -o $installerPath '${powerShellSingleQuote(params.installerUrl)}'
+  & curl.exe -fsSL --connect-timeout ${connectTimeoutSeconds} --max-time ${requestTimeoutSeconds} -o $installerPath '${powerShellSingleQuote(params.installerUrl)}'
   if ($LASTEXITCODE -ne 0) {
     throw "curl.exe failed to download the OpenClaw installer (exit $LASTEXITCODE)"
   }
@@ -150,7 +158,7 @@ try {
   // Do not retry a streamed installer: a partial first response could be concatenated with the retry.
   return [
     "set -euo pipefail",
-    `curl -fsSL --connect-timeout ${INSTALLER_CONNECT_TIMEOUT_SECONDS} --max-time ${INSTALLER_REQUEST_TIMEOUT_SECONDS} '${shellEscapeForSh(params.installerUrl)}' | bash -s -- --version '${shellEscapeForSh(params.installTarget)}' --no-onboard`,
+    `curl -fsSL --connect-timeout ${connectTimeoutSeconds} --max-time ${requestTimeoutSeconds} '${shellEscapeForSh(params.installerUrl)}' | bash -s -- --version '${shellEscapeForSh(params.installTarget)}' --no-onboard`,
   ].join("\n");
 }
 

--- a/scripts/lib/cross-os-release-checks/installed.ts
+++ b/scripts/lib/cross-os-release-checks/installed.ts
@@ -47,6 +47,9 @@ import {
 } from "./process.ts";
 import { formatError, shellEscapeForSh, sleep } from "./shared.ts";
 
+const INSTALLER_CONNECT_TIMEOUT_SECONDS = 10;
+const INSTALLER_REQUEST_TIMEOUT_SECONDS = 120;
+
 export async function resolveInstallerTargetVersion(params: {
   baselineSpec: string;
   logsDir: string;
@@ -123,6 +126,34 @@ async function runPowerShellScript(script: string, options: CommandOptions) {
   );
 }
 
+export function buildInstallerSmokeScript(params: {
+  installerUrl: string;
+  installTarget: string;
+  platform?: NodeJS.Platform;
+}) {
+  if ((params.platform ?? process.platform) === "win32") {
+    return `
+$installerPath = Join-Path ([System.IO.Path]::GetTempPath()) ("openclaw-installer-" + [guid]::NewGuid().ToString("N") + ".ps1")
+try {
+  & curl.exe -fsSL --connect-timeout ${INSTALLER_CONNECT_TIMEOUT_SECONDS} --max-time ${INSTALLER_REQUEST_TIMEOUT_SECONDS} -o $installerPath '${powerShellSingleQuote(params.installerUrl)}'
+  if ($LASTEXITCODE -ne 0) {
+    throw "curl.exe failed to download the OpenClaw installer (exit $LASTEXITCODE)"
+  }
+  $content = [System.IO.File]::ReadAllText($installerPath, [System.Text.Encoding]::UTF8)
+  & ([scriptblock]::Create($content)) -Tag '${powerShellSingleQuote(params.installTarget)}' -NoOnboard
+} finally {
+  Remove-Item -LiteralPath $installerPath -Force -ErrorAction SilentlyContinue
+}
+`;
+  }
+
+  // Do not retry a streamed installer: a partial first response could be concatenated with the retry.
+  return [
+    "set -euo pipefail",
+    `curl -fsSL --connect-timeout ${INSTALLER_CONNECT_TIMEOUT_SECONDS} --max-time ${INSTALLER_REQUEST_TIMEOUT_SECONDS} '${shellEscapeForSh(params.installerUrl)}' | bash -s -- --version '${shellEscapeForSh(params.installTarget)}' --no-onboard`,
+  ].join("\n");
+}
+
 export async function runInstallerSmoke(params: {
   lane: LaneState;
   env: NodeJS.ProcessEnv;
@@ -130,15 +161,8 @@ export async function runInstallerSmoke(params: {
   installTarget: string;
   logPath: string;
 }) {
+  const script = buildInstallerSmokeScript(params);
   if (process.platform === "win32") {
-    const script = `
-$response = Invoke-WebRequest -UseBasicParsing '${powerShellSingleQuote(params.installerUrl)}'
-$content = $response.Content
-if ($content -is [byte[]]) {
-  $content = [System.Text.Encoding]::UTF8.GetString($content)
-}
-& ([scriptblock]::Create([string]$content)) -Tag '${powerShellSingleQuote(params.installTarget)}' -NoOnboard
-`;
     await runPowerShellScript(script, {
       cwd: params.lane.homeDir,
       env: params.env,
@@ -148,10 +172,6 @@ if ($content -is [byte[]]) {
     return;
   }
 
-  const script = [
-    "set -euo pipefail",
-    `curl -fsSL '${shellEscapeForSh(params.installerUrl)}' | bash -s -- --version '${shellEscapeForSh(params.installTarget)}' --no-onboard`,
-  ].join("\n");
   await runPosixShellScript(script, {
     cwd: params.lane.homeDir,
     env: params.env,

--- a/test/package-scripts.test.ts
+++ b/test/package-scripts.test.ts
@@ -169,6 +169,12 @@ describe("package scripts", () => {
     );
   });
 
+  it("runs cross-OS installer behavior coverage in Windows CI", () => {
+    expect(readPackageJson().scripts["test:windows:ci"]).toContain(
+      "test/scripts/openclaw-cross-os-installer.windows.test.ts",
+    );
+  });
+
   it("runs env launcher coverage in Windows CI", () => {
     expect(readPackageJson().scripts["test:windows:ci"]).toContain(
       "test/scripts/run-with-env.test.ts",

--- a/test/scripts/openclaw-cross-os-installer.windows.test.ts
+++ b/test/scripts/openclaw-cross-os-installer.windows.test.ts
@@ -1,12 +1,14 @@
-import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { createServer } from "node:http";
-import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import {
   buildInstallerSmokeScript,
   runCommand,
 } from "../../scripts/lib/cross-os-release-checks/index.ts";
+import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.ts";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 function powerShellSingleQuote(value: string) {
   return value.replace(/'/gu, "''");
@@ -49,7 +51,7 @@ describe("cross-OS Windows installer fetch", () => {
   it.runIf(process.platform === "win32")(
     "times out stalled bodies without executing partial scripts or leaking temp files",
     async () => {
-      const dir = mkdtempSync(join(tmpdir(), "openclaw-cross-os-installer-"));
+      const dir = tempDirs.make("openclaw-cross-os-installer-");
       const healthyMarker = join(dir, "healthy.txt");
       const stalledMarker = join(dir, "stalled.txt");
       const server = createServer((request, response) => {
@@ -122,7 +124,6 @@ describe("cross-OS Windows installer fetch", () => {
         await new Promise<void>((resolvePromise) => {
           server.close(() => resolvePromise());
         });
-        rmSync(dir, { recursive: true, force: true });
       }
     },
     15_000,

--- a/test/scripts/openclaw-cross-os-installer.windows.test.ts
+++ b/test/scripts/openclaw-cross-os-installer.windows.test.ts
@@ -1,0 +1,130 @@
+import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync } from "node:fs";
+import { createServer } from "node:http";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  buildInstallerSmokeScript,
+  runCommand,
+} from "../../scripts/lib/cross-os-release-checks/index.ts";
+
+function powerShellSingleQuote(value: string) {
+  return value.replace(/'/gu, "''");
+}
+
+async function runPowerShell(params: {
+  script: string;
+  cwd: string;
+  env: NodeJS.ProcessEnv;
+  logPath: string;
+}) {
+  return runCommand(
+    "powershell.exe",
+    [
+      "-NoLogo",
+      "-NoProfile",
+      "-NonInteractive",
+      "-ExecutionPolicy",
+      "Bypass",
+      "-Command",
+      params.script,
+    ],
+    {
+      check: false,
+      cwd: params.cwd,
+      env: params.env,
+      logPath: params.logPath,
+      timeoutMs: 10_000,
+    },
+  );
+}
+
+function installerTempFiles(dir: string) {
+  return readdirSync(dir).filter(
+    (entry) => entry.startsWith("openclaw-installer-") && entry.endsWith(".ps1"),
+  );
+}
+
+describe("cross-OS Windows installer fetch", () => {
+  it.runIf(process.platform === "win32")(
+    "times out stalled bodies without executing partial scripts or leaking temp files",
+    async () => {
+      const dir = mkdtempSync(join(tmpdir(), "openclaw-cross-os-installer-"));
+      const healthyMarker = join(dir, "healthy.txt");
+      const stalledMarker = join(dir, "stalled.txt");
+      const server = createServer((request, response) => {
+        response.writeHead(200, { "content-type": "text/plain; charset=utf-8" });
+        if (request.url === "/healthy") {
+          response.end(
+            [
+              "param([string] $Tag, [switch] $NoOnboard)",
+              `[System.IO.File]::WriteAllText('${powerShellSingleQuote(healthyMarker)}', "tag=$Tag noOnboard=$($NoOnboard.IsPresent)")`,
+            ].join("\n"),
+          );
+          return;
+        }
+        response.write(
+          `[System.IO.File]::WriteAllText('${powerShellSingleQuote(stalledMarker)}', 'executed')\n`,
+        );
+      });
+
+      try {
+        await new Promise<void>((resolvePromise, rejectPromise) => {
+          server.once("error", rejectPromise);
+          server.listen(0, "127.0.0.1", resolvePromise);
+        });
+        const address = server.address();
+        if (!address || typeof address === "string") {
+          throw new Error("Windows installer proof server did not bind to a TCP port.");
+        }
+        const baseUrl = `http://127.0.0.1:${address.port}`;
+        const env = { ...process.env, TEMP: dir, TMP: dir };
+        const timeouts = { connectTimeoutSeconds: 2, requestTimeoutSeconds: 1 };
+
+        const healthy = await runPowerShell({
+          script: buildInstallerSmokeScript(
+            {
+              installerUrl: `${baseUrl}/healthy`,
+              installTarget: "proof-target",
+              platform: "win32",
+            },
+            timeouts,
+          ),
+          cwd: dir,
+          env,
+          logPath: join(dir, "healthy.log"),
+        });
+
+        expect(healthy.exitCode).toBe(0);
+        expect(readFileSync(healthyMarker, "utf8")).toBe("tag=proof-target noOnboard=True");
+        expect(installerTempFiles(dir)).toEqual([]);
+
+        const stalled = await runPowerShell({
+          script: buildInstallerSmokeScript(
+            {
+              installerUrl: `${baseUrl}/stalled`,
+              installTarget: "proof-target",
+              platform: "win32",
+            },
+            timeouts,
+          ),
+          cwd: dir,
+          env,
+          logPath: join(dir, "stalled.log"),
+        });
+
+        expect(stalled.exitCode).not.toBe(0);
+        expect(`${stalled.stdout}\n${stalled.stderr}`).toContain("exit 28");
+        expect(existsSync(stalledMarker)).toBe(false);
+        expect(installerTempFiles(dir)).toEqual([]);
+      } finally {
+        server.closeAllConnections();
+        await new Promise<void>((resolvePromise) => {
+          server.close(() => resolvePromise());
+        });
+        rmSync(dir, { recursive: true, force: true });
+      }
+    },
+    15_000,
+  );
+});

--- a/test/scripts/openclaw-cross-os-installer.windows.test.ts
+++ b/test/scripts/openclaw-cross-os-installer.windows.test.ts
@@ -41,13 +41,104 @@ async function runPowerShell(params: {
   );
 }
 
-function installerTempFiles(dir: string) {
-  return readdirSync(dir).filter(
-    (entry) => entry.startsWith("openclaw-installer-") && entry.endsWith(".ps1"),
-  );
+async function runPosixShell(params: {
+  script: string;
+  cwd: string;
+  env: NodeJS.ProcessEnv;
+  logPath: string;
+}) {
+  return runCommand("/bin/bash", ["-lc", params.script], {
+    check: false,
+    cwd: params.cwd,
+    env: params.env,
+    logPath: params.logPath,
+    timeoutMs: 10_000,
+  });
 }
 
-describe("cross-OS Windows installer fetch", () => {
+function installerTempFiles(dir: string) {
+  return readdirSync(dir).filter((entry) => entry.startsWith("openclaw-installer-"));
+}
+
+describe("cross-OS installer fetch", () => {
+  it.runIf(process.platform !== "win32")(
+    "buffers POSIX installers before execution and cleans up timed-out downloads",
+    async () => {
+      const dir = tempDirs.make("openclaw-cross-os-installer-");
+      const healthyMarker = join(dir, "healthy.txt");
+      const stalledMarker = join(dir, "stalled.txt");
+      const server = createServer((request, response) => {
+        response.writeHead(200, { "content-type": "text/plain; charset=utf-8" });
+        if (request.url === "/healthy") {
+          response.end('printf "%s" "$1|$2|$3" > "$OPENCLAW_PROOF_HEALTHY_MARKER"\n');
+          return;
+        }
+        response.write('printf executed > "$OPENCLAW_PROOF_STALL_MARKER"\n');
+      });
+
+      try {
+        await new Promise<void>((resolvePromise, rejectPromise) => {
+          server.once("error", rejectPromise);
+          server.listen(0, "127.0.0.1", resolvePromise);
+        });
+        const address = server.address();
+        if (!address || typeof address === "string") {
+          throw new Error("POSIX installer proof server did not bind to a TCP port.");
+        }
+        const baseUrl = `http://127.0.0.1:${address.port}`;
+        const env = {
+          ...process.env,
+          TMPDIR: dir,
+          OPENCLAW_PROOF_HEALTHY_MARKER: healthyMarker,
+          OPENCLAW_PROOF_STALL_MARKER: stalledMarker,
+        };
+        const timeouts = { connectTimeoutSeconds: 2, requestTimeoutSeconds: 1 };
+
+        const healthy = await runPosixShell({
+          script: buildInstallerSmokeScript(
+            {
+              installerUrl: `${baseUrl}/healthy`,
+              installTarget: "proof-target",
+              platform: "linux",
+            },
+            timeouts,
+          ),
+          cwd: dir,
+          env,
+          logPath: join(dir, "healthy.log"),
+        });
+
+        expect(healthy.exitCode).toBe(0);
+        expect(readFileSync(healthyMarker, "utf8")).toBe("--version|proof-target|--no-onboard");
+        expect(installerTempFiles(dir)).toEqual([]);
+
+        const stalled = await runPosixShell({
+          script: buildInstallerSmokeScript(
+            {
+              installerUrl: `${baseUrl}/stalled`,
+              installTarget: "proof-target",
+              platform: "linux",
+            },
+            timeouts,
+          ),
+          cwd: dir,
+          env,
+          logPath: join(dir, "stalled.log"),
+        });
+
+        expect(stalled.exitCode).toBe(28);
+        expect(existsSync(stalledMarker)).toBe(false);
+        expect(installerTempFiles(dir)).toEqual([]);
+      } finally {
+        server.closeAllConnections();
+        await new Promise<void>((resolvePromise) => {
+          server.close(() => resolvePromise());
+        });
+      }
+    },
+    15_000,
+  );
+
   it.runIf(process.platform === "win32")(
     "times out stalled bodies without executing partial scripts or leaking temp files",
     async () => {

--- a/test/scripts/openclaw-cross-os-release-checks.test.ts
+++ b/test/scripts/openclaw-cross-os-release-checks.test.ts
@@ -33,6 +33,7 @@ import {
   buildNpmGlobalInstallArgs,
   appendLatestNpmDebugLogTail,
   buildGatewayStatusArgsFromHelpText,
+  buildInstallerSmokeScript,
   buildWindowsPathBootstrapScript,
   canConnectToLoopbackPort,
   buildDiscordSmokeGuildsConfig,
@@ -159,6 +160,36 @@ describe("scripts/openclaw-cross-os-release-checks", () => {
   it("keeps dashboard smoke patient enough for cold packaged gateway startup", () => {
     expect(CROSS_OS_DASHBOARD_SMOKE_TIMEOUT_MS).toBeGreaterThanOrEqual(120_000);
     expect(CROSS_OS_DASHBOARD_FETCH_TIMEOUT_MS).toBeGreaterThanOrEqual(10_000);
+  });
+
+  it("bounds public installer fetches on Windows and POSIX", () => {
+    const windowsScript = buildInstallerSmokeScript({
+      installerUrl: "https://openclaw.ai/install.ps1",
+      installTarget: "2026.7.1",
+      platform: "win32",
+    });
+    const posixScript = buildInstallerSmokeScript({
+      installerUrl: "https://openclaw.ai/install.sh",
+      installTarget: "2026.7.1",
+      platform: "linux",
+    });
+
+    expect(windowsScript).toContain(
+      "curl.exe -fsSL --connect-timeout 10 --max-time 120 -o $installerPath 'https://openclaw.ai/install.ps1'",
+    );
+    expect(windowsScript).toContain("openclaw-installer-");
+    expect(windowsScript).toContain("if ($LASTEXITCODE -ne 0)");
+    expect(windowsScript).toContain(
+      "[System.IO.File]::ReadAllText($installerPath, [System.Text.Encoding]::UTF8)",
+    );
+    expect(windowsScript).toContain(
+      "Remove-Item -LiteralPath $installerPath -Force -ErrorAction SilentlyContinue",
+    );
+    expect(windowsScript).not.toContain("Invoke-WebRequest");
+    expect(posixScript).toContain(
+      "curl -fsSL --connect-timeout 10 --max-time 120 'https://openclaw.ai/install.sh'",
+    );
+    expect(posixScript).toContain("set -euo pipefail");
   });
 
   it("bounds cross-OS fetched response bodies", async () => {

--- a/test/scripts/openclaw-cross-os-release-checks.test.ts
+++ b/test/scripts/openclaw-cross-os-release-checks.test.ts
@@ -187,8 +187,14 @@ describe("scripts/openclaw-cross-os-release-checks", () => {
     );
     expect(windowsScript).not.toContain("Invoke-WebRequest");
     expect(posixScript).toContain(
-      "curl -fsSL --connect-timeout 10 --max-time 120 'https://openclaw.ai/install.sh'",
+      'installer_path="$(mktemp "${TMPDIR:-/tmp}/openclaw-installer-XXXXXX")"',
     );
+    expect(posixScript).toContain("trap 'rm -f \"$installer_path\"' EXIT");
+    expect(posixScript).toContain(
+      "curl -fsSL --connect-timeout 10 --max-time 120 -o \"$installer_path\" 'https://openclaw.ai/install.sh'",
+    );
+    expect(posixScript).toContain("bash -- \"$installer_path\" --version '2026.7.1' --no-onboard");
+    expect(posixScript).not.toContain("| bash");
     expect(posixScript).toContain("set -euo pipefail");
   });
 


### PR DESCRIPTION
## What Problem This Solves

The cross-OS release checks fetch the public installer before both fresh-install and dev-update smoke lanes. Those Windows and POSIX requests had no body-transfer deadline, so a connected installer endpoint that stopped sending bytes could hold a release validation lane until its much larger outer timeout.

## Why This Change Was Made

The shared installer-smoke builder now applies a 10-second connect timeout and a 120-second transfer deadline. POSIX keeps the existing fail-fast `curl | bash` pipeline without retries that could concatenate a partial script. Windows uses `curl.exe` to write a unique temporary script, verifies the native exit code, reads it as UTF-8 only after a complete transfer, and removes it in `finally`.

## User Impact

Cross-platform release validation now fails promptly on a stalled installer response while preserving successful fresh-install and dev-update behavior.

## Evidence

- Full `test/scripts/openclaw-cross-os-release-checks.test.ts`: 103/103 passed.
- `oxfmt --check` and `git diff --check`: passed.
- Controlled POSIX response-body stall exited 28 at the scaled `--max-time` deadline; the pipeline propagated the failure through `pipefail`.
- Live `install.sh` and `install.ps1` endpoints returned HTTP 200 with complete payloads.
- Independent Codex adversarial review found that Windows PowerShell 5.1 `TimeoutSec` did not cover body stalls. After replacing it with bounded `curl.exe` plus temp-file and exit-code handling, the reviewer found no remaining actionable issue and estimated approximately 90% merge likelihood.
- Remaining proof gap: no injected body stall was run on a real Windows runner; the exact `curl.exe` timeout pattern already has a Windows sibling in the repository.
