### PR TITLE
fix(plugins): allow runtime.llm.complete to pass reasoning effort

### DIFF
--- a/docs/plugins/sdk-runtime.md
+++ b/docs/plugins/sdk-runtime.md
@@ -223,6 +223,10 @@ two-party event loops that do not go through the shared inbound reply runner.
       purpose: "my-plugin.summary",
       maxTokens: 512,
       temperature: 0.2,
+      // Optional: same thinking-level vocabulary as agent simple completion
+      // (`off` | `minimal` | `low` | `medium` | `high` | `xhigh` | `adaptive` | `max` | …).
+      // Required for some reasoning-mandatory models; omit to keep prior behavior.
+      reasoning: "medium",
     });
     ```
 

--- a/src/plugins/runtime/runtime-llm.runtime.test.ts
+++ b/src/plugins/runtime/runtime-llm.runtime.test.ts
@@ -591,6 +591,7 @@ describe("runtime.llm.complete", () => {
       maxTokens: 64,
       temperature: 0.2,
     });
+    expect(completionArg.options).not.toHaveProperty("reasoning");
     expectFields(requireRecord(result, "completion result"), {
       text: "done",
       provider: "openai",
@@ -613,6 +614,34 @@ describe("runtime.llm.complete", () => {
       },
     );
     expectFields(requireRecord(logPayload.usage, "log usage"), { costUsd: 0.0042 });
+  });
+
+  it("forwards optional reasoning into the host simple-completion options", async () => {
+    const logger = createLogger();
+    const llm = createRuntimeLlm({
+      getConfig: () => cfg,
+      logger,
+      authority: {
+        caller: { kind: "host", id: "runtime-test" },
+        allowComplete: true,
+      },
+    });
+
+    await llm.complete({
+      messages: [{ role: "user", content: "Think carefully." }],
+      purpose: "test-reasoning",
+      reasoning: "high",
+    });
+
+    const completionArg = expectSingleCallFirstArg(
+      hoisted.completeWithPreparedSimpleCompletionModel,
+      {
+        cfg,
+      },
+    );
+    expectFields(requireRecord(completionArg.options, "completion options"), {
+      reasoning: "high",
+    });
   });
 
   it("uses scoped plugin identity and ignores caller-shaped spoofing input", async () => {

--- a/src/plugins/runtime/runtime-llm.runtime.ts
+++ b/src/plugins/runtime/runtime-llm.runtime.ts
@@ -447,6 +447,9 @@ export function createRuntimeLlm(
         options: {
           maxTokens: finiteOption(params.maxTokens),
           temperature: finiteOption(params.temperature),
+          // Forward plugin-requested reasoning so catalog-routed complete can
+          // satisfy reasoning-mandatory models (see #108255).
+          ...(params.reasoning !== undefined ? { reasoning: params.reasoning } : {}),
           signal: params.signal,
         },
       });

--- a/src/plugins/runtime/types-core.ts
+++ b/src/plugins/runtime/types-core.ts
@@ -215,6 +215,14 @@ export type LlmCompleteParams = {
   model?: string;
   maxTokens?: number;
   temperature?: number;
+  /**
+   * Optional reasoning effort for the host simple-completion path.
+   * Uses the same level vocabulary as agent thinking / simple completion so
+   * plugins can satisfy reasoning-mandatory models without a parallel type.
+   */
+  reasoning?:
+    | import("../../auto-reply/thinking.js").ThinkLevel
+    | import("../../llm/types.js").ThinkingLevel;
   systemPrompt?: string;
   signal?: AbortSignal;
   /** Human-readable reason for audit/debug output. */


### PR DESCRIPTION
Closes #108255

## What Problem This Solves

Fixes an issue where plugins calling `api.runtime.llm.complete` could not request a reasoning effort. Catalog-routed host completions always omitted reasoning, so reasoning-mandatory models could hard-fail or silently return weak/non-reasoning output even though the lower simple-completion layer already supported the option.

## Why This Change Was Made

Add an optional `reasoning` field to `LlmCompleteParams` using the existing thinking-level vocabulary, and forward it into `completeWithPreparedSimpleCompletionModel` options. Omitted `reasoning` keeps prior behavior. Docs for `api.runtime.llm.complete` show the new parameter.

Compatibility: additive optional API field only. Performance: single optional option forward, no new discovery. Usability: documented on the public runtime helper. Security: no change to auth/policy; no new secrets/logging.

## User Impact

Plugin authors can pass `reasoning` on host-owned `runtime.llm.complete` calls so reasoning-required models work through the catalog/auth path without reimplementing provider prep.

## Evidence

Verification host: local macOS (Crabbox bypass).

```text
node scripts/run-vitest.mjs src/plugins/runtime/runtime-llm.runtime.test.ts
# 22 tests passed (includes "forwards optional reasoning into the host simple-completion options")

git diff --check origin/main
# clean

oxfmt --check <touched files>
# All matched files use the correct format.

oxlint <touched ts files>
# Found 0 warnings and 0 errors.

pnpm plugin-sdk:surface:check
# pass
```

Path-scoped `check-changed` was started but stalled after tsgo child exit with no further progress (~31m); quality floor covered via focused Vitest + format/lint/SDK surface checks above.

## Real behavior proof

- Behavior addressed: `api.runtime.llm.complete` can pass reasoning effort through to the host simple-completion options so reasoning-mandatory models are not always invoked without a reasoning field.
- Environment: local macOS, openclaw checkout on branch `fix/108255-llm-complete-reasoning`, Node/Vitest via `node scripts/run-vitest.mjs`.
- Current-main contrast: `LlmCompleteParams` had no `reasoning` field; `createRuntimeLlm().complete` built options as `{ maxTokens, temperature, signal }` only, so plugins could not influence prepared-completion `options.reasoning` even though `completeWithPreparedSimpleCompletionModel` already accepts it.
- Exact steps or command run after this patch:
  1. Inspect types: `LlmCompleteParams.reasoning` is optional ThinkLevel/ThinkingLevel.
  2. Run `node scripts/run-vitest.mjs src/plugins/runtime/runtime-llm.runtime.test.ts`.
  3. Confirm new case `forwards optional reasoning into the host simple-completion options` asserts `options.reasoning === "high"`.
  4. Confirm existing host dispatch case still omits `reasoning` when the param is not set.
- Evidence after fix: Vitest output — 22/22 passed; new test greened; omission path asserts `not.toHaveProperty("reasoning")` when unset.
- Control check: mocks capture args to `completeWithPreparedSimpleCompletionModel` only; no live provider call required for this source-level contract (matches ClawSweeper source-repro acceptance).
- Observed result after fix: plugin `complete({ reasoning: "high" })` forwards `reasoning: "high"` into host completion options; omitting reasoning leaves options without a reasoning key (backward compatible).
- What was not tested: live OpenRouter/provider turn against a reasoning-mandatory model (issue report already covered live impact; ClawSweeper accepted source-repro merge path).

## AI disclosure

This PR was authored with AI assistance (Grok).
