### PR TITLE
refactor(ai): centralize tool image payload guard

### DIFF
--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -90,7 +90,7 @@ import {
   describeToolResultMediaPlaceholder,
   extractToolResultBlockText,
   extractToolResultText,
-  hasMediaPayload,
+  isImageWithMediaPayload,
 } from "./tool-result-text.js";
 import { transformMessages } from "./transform-messages.js";
 
@@ -166,15 +166,7 @@ function convertContentBlocks(
     > {
   const text = extractToolResultText(content);
   const mediaPlaceholder = describeToolResultMediaPlaceholder(content);
-  const hasImages =
-    Array.isArray(content) &&
-    content.some(
-      (item) =>
-        item &&
-        typeof item === "object" &&
-        (item as Record<string, unknown>).type === "image" &&
-        hasMediaPayload(item),
-    );
+  const hasImages = content.some(isImageWithMediaPayload);
 
   if (!hasImages) {
     const sanitized = sanitizeSurrogates(text);
@@ -196,7 +188,7 @@ function convertContentBlocks(
   > = [];
   let hasTextBlock = false;
 
-  for (const block of Array.isArray(content) ? content : []) {
+  for (const block of content) {
     if (!block || typeof block !== "object") {
       continue;
     }
@@ -206,7 +198,7 @@ function convertContentBlocks(
       blocks.push({ type: "text" as const, text: sanitizeSurrogates(blockText) });
       hasTextBlock = true;
     }
-    if (record.type !== "image" || !hasMediaPayload(record)) {
+    if (!isImageWithMediaPayload(record)) {
       continue;
     }
     blocks.push({

--- a/packages/ai/src/providers/google-shared.ts
+++ b/packages/ai/src/providers/google-shared.ts
@@ -18,7 +18,6 @@ import type {
   Api,
   AssistantMessage,
   Context,
-  ImageContent,
   Model,
   SimpleStreamOptions,
   StopReason,
@@ -36,7 +35,7 @@ import { stripSystemPromptCacheBoundary } from "../utils/system-prompt-cache-bou
 import {
   describeToolResultMediaPlaceholder,
   extractToolResultText,
-  hasMediaPayload,
+  isImageWithMediaPayload,
 } from "./tool-result-text.js";
 import { transformMessages } from "./transform-messages.js";
 
@@ -281,7 +280,7 @@ export function convertMessages<T extends GoogleApiType>(
       // Extract text and image content
       const textResult = extractToolResultText(msg.content);
       const imageContent = model.input.includes("image")
-        ? msg.content.filter((c): c is ImageContent => c.type === "image" && hasMediaPayload(c))
+        ? msg.content.filter(isImageWithMediaPayload)
         : [];
 
       const hasText = textResult.length > 0;

--- a/packages/ai/src/providers/mistral.ts
+++ b/packages/ai/src/providers/mistral.ts
@@ -36,7 +36,7 @@ import { buildBaseOptions } from "./simple-options.js";
 import {
   describeToolResultMediaPlaceholder,
   extractToolResultText,
-  hasMediaPayload,
+  isImageWithMediaPayload,
 } from "./tool-result-text.js";
 import { transformMessages } from "./transform-messages.js";
 
@@ -875,7 +875,7 @@ function toChatMessages(
     const toolContent: ContentChunk[] = [];
     const textResult = extractToolResultText(msg.content);
     const mediaPlaceholder = describeToolResultMediaPlaceholder(msg.content);
-    const hasImages = msg.content.some((part) => part.type === "image" && hasMediaPayload(part));
+    const hasImages = msg.content.some(isImageWithMediaPayload);
     const toolText = buildToolResultText(
       textResult,
       mediaPlaceholder,
@@ -888,7 +888,7 @@ function toChatMessages(
       if (!supportsImages) {
         continue;
       }
-      if (part.type !== "image" || !hasMediaPayload(part)) {
+      if (!isImageWithMediaPayload(part)) {
         continue;
       }
       toolContent.push({

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -22,7 +22,6 @@ import type {
   AssistantMessage,
   CacheRetention,
   Context,
-  ImageContent,
   Message,
   Model,
   OpenAICompletionsCompat,
@@ -64,7 +63,7 @@ import { buildBaseOptions } from "./simple-options.js";
 import {
   describeToolResultMediaPlaceholder,
   extractToolResultText,
-  hasMediaPayload,
+  isImageWithMediaPayload,
 } from "./tool-result-text.js";
 import { transformMessages } from "./transform-messages.js";
 
@@ -99,10 +98,6 @@ function isThinkingContentBlock(block: { type: string }): block is ThinkingConte
 
 function isToolCallBlock(block: { type: string }): block is ToolCall {
   return block.type === "toolCall";
-}
-
-function isImageContentBlock(block: { type: string }): block is ImageContent {
-  return block.type === "image" && hasMediaPayload(block);
 }
 
 const EMPTY_TOOL_RESULT_TEXT = "(no output)";
@@ -1214,7 +1209,7 @@ export function convertMessages(
         // Extract text and image content
         const textResult = extractToolResultText(toolMsg.content);
         const mediaPlaceholder = describeToolResultMediaPlaceholder(toolMsg.content);
-        const hasImages = toolMsg.content.some(isImageContentBlock);
+        const hasImages = toolMsg.content.some(isImageWithMediaPayload);
 
         // Always send tool result with text (or placeholder if only images)
         const content = sanitizeToolResultText(
@@ -1234,7 +1229,7 @@ export function convertMessages(
 
         if (hasImages && model.input.includes("image")) {
           for (const block of toolMsg.content) {
-            if (isImageContentBlock(block)) {
+            if (isImageWithMediaPayload(block)) {
               imageBlocks.push({
                 type: "image_url",
                 image_url: {

--- a/packages/ai/src/providers/openai-responses-shared.ts
+++ b/packages/ai/src/providers/openai-responses-shared.ts
@@ -19,7 +19,6 @@ import type {
   Api,
   AssistantMessage,
   Context,
-  ImageContent,
   Model,
   SimpleStreamOptions,
   StopReason,
@@ -66,7 +65,7 @@ import { convertResponsesToolPayload } from "./openai-responses-tools.js";
 import {
   describeToolResultMediaPlaceholder,
   extractToolResultText,
-  hasMediaPayload,
+  isImageWithMediaPayload,
 } from "./tool-result-text.js";
 import { transformMessages } from "./transform-messages.js";
 
@@ -450,9 +449,7 @@ export function convertResponsesMessages<TApi extends Api>(
     } else if (msg.role === "toolResult") {
       const textResult = extractToolResultText(msg.content);
       const sanitizedTextResult = sanitizeSurrogates(textResult);
-      const hasImages = msg.content.some(
-        (c): c is ImageContent => c.type === "image" && hasMediaPayload(c),
-      );
+      const hasImages = msg.content.some(isImageWithMediaPayload);
       const mediaPlaceholder = describeToolResultMediaPlaceholder(msg.content);
       const hasText = sanitizedTextResult.trim().length > 0;
       const [callId] = splitResponsesToolCallId(msg.toolCallId);
@@ -474,7 +471,7 @@ export function convertResponsesMessages<TApi extends Api>(
         }
 
         for (const block of msg.content) {
-          if (block.type === "image" && hasMediaPayload(block)) {
+          if (isImageWithMediaPayload(block)) {
             contentParts.push({
               type: "input_image",
               detail: "auto",

--- a/packages/ai/src/providers/tool-result-text.test.ts
+++ b/packages/ai/src/providers/tool-result-text.test.ts
@@ -3,6 +3,7 @@ import {
   describeToolResultMediaPlaceholder,
   extractToolResultText,
   hasMediaPayload,
+  isImageWithMediaPayload,
 } from "./tool-result-text.js";
 
 describe("hasMediaPayload", () => {
@@ -13,6 +14,18 @@ describe("hasMediaPayload", () => {
     expect(hasMediaPayload({ type: "image", data: "  ", mimeType: "image/png" })).toBe(false);
     expect(hasMediaPayload({ type: "image", path: "/tmp/image.png" })).toBe(false);
     expect(hasMediaPayload({ type: "image", url: "https://example.test/image.png" })).toBe(false);
+  });
+});
+
+describe("isImageWithMediaPayload", () => {
+  it("requires both the image type and inline payload bytes", () => {
+    expect(isImageWithMediaPayload({ type: "image", data: "aW1n", mimeType: "image/png" })).toBe(
+      true,
+    );
+    expect(isImageWithMediaPayload({ type: "image", data: "", mimeType: "image/png" })).toBe(false);
+    expect(
+      isImageWithMediaPayload({ type: "audio", data: "YXVkaW8=", mimeType: "audio/mpeg" }),
+    ).toBe(false);
   });
 });
 

--- a/packages/ai/src/providers/tool-result-text.ts
+++ b/packages/ai/src/providers/tool-result-text.ts
@@ -128,6 +128,11 @@ export function hasMediaPayload(
   return isRecord(block) && typeof block.data === "string" && block.data.trim().length > 0;
 }
 
+/** Image metadata alone is not an attachment; provider emitters need inline bytes. */
+export function isImageWithMediaPayload<T>(block: T): block is T & { type: "image"; data: string } {
+  return isRecord(block) && block.type === "image" && hasMediaPayload(block);
+}
+
 export function describeToolResultMediaPlaceholder(blocks: readonly unknown[]): string | undefined {
   let hasImage = false;
   let hasAudio = false;

--- a/packages/ai/src/providers/transform-messages.ts
+++ b/packages/ai/src/providers/transform-messages.ts
@@ -10,7 +10,7 @@ import type {
   ToolResultMessage,
 } from "../types.js";
 import { resolveModelBoundThinkingReplayMode } from "./anthropic-model-contract.js";
-import { hasMediaPayload } from "./tool-result-text.js";
+import { isImageWithMediaPayload } from "./tool-result-text.js";
 
 const NON_VISION_USER_IMAGE_PLACEHOLDER = "(image omitted: model does not support images)";
 const NON_VISION_TOOL_IMAGE_PLACEHOLDER = "(tool image omitted: model does not support images)";
@@ -24,7 +24,7 @@ function replaceImagesWithPlaceholder(
 
   for (const block of content) {
     if (block.type === "image") {
-      if (!hasMediaPayload(block)) {
+      if (!isImageWithMediaPayload(block)) {
         continue;
       }
       if (!previousWasPlaceholder) {

--- a/src/agents/anthropic-transport-stream.ts
+++ b/src/agents/anthropic-transport-stream.ts
@@ -44,7 +44,7 @@ import {
   describeToolResultMediaPlaceholder,
   extractToolResultBlockText,
   extractToolResultText,
-  hasMediaPayload,
+  isImageWithMediaPayload,
 } from "@openclaw/ai/internal/shared";
 /**
  * Native Anthropic Messages streaming transport.
@@ -343,15 +343,7 @@ function toClaudeCodeName(name: string): string {
 function convertContentBlocks(content: readonly unknown[]) {
   const text = extractToolResultText(content);
   const mediaPlaceholder = describeToolResultMediaPlaceholder(content);
-  const hasImages =
-    Array.isArray(content) &&
-    content.some(
-      (item) =>
-        item &&
-        typeof item === "object" &&
-        (item as Record<string, unknown>).type === "image" &&
-        hasMediaPayload(item),
-    );
+  const hasImages = content.some(isImageWithMediaPayload);
   if (!hasImages) {
     return sanitizeNonEmptyTransportPayloadText(text, mediaPlaceholder ?? "(no output)");
   }
@@ -363,7 +355,7 @@ function convertContentBlocks(content: readonly unknown[]) {
       }
   > = [];
   let hasTextBlock = false;
-  for (const block of Array.isArray(content) ? content : []) {
+  for (const block of content) {
     if (!block || typeof block !== "object") {
       continue;
     }
@@ -373,7 +365,7 @@ function convertContentBlocks(content: readonly unknown[]) {
       blocks.push({ type: "text", text: sanitizeTransportPayloadText(blockText) });
       hasTextBlock = true;
     }
-    if (record.type !== "image" || !hasMediaPayload(record)) {
+    if (!isImageWithMediaPayload(record)) {
       continue;
     }
     blocks.push({

--- a/src/agents/openai-responses-transport.ts
+++ b/src/agents/openai-responses-transport.ts
@@ -32,7 +32,7 @@ import {
 import {
   describeToolResultMediaPlaceholder,
   extractToolResultText,
-  hasMediaPayload,
+  isImageWithMediaPayload,
   stripSystemPromptCacheBoundary,
 } from "@openclaw/ai/internal/shared";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
@@ -50,7 +50,7 @@ import type {
   ResponseReasoningItem,
 } from "openai/resources/responses/responses.js";
 import { sha256HexPrefix } from "../infra/crypto-digest.js";
-import type { Api, Context, ImageContent, Model } from "../llm/types.js";
+import type { Api, Context, Model } from "../llm/types.js";
 import "../llm/ai-transport-host.js";
 import { createAssistantMessageEventStream } from "../llm/utils/event-stream.js";
 import { redactIdentifier } from "../logging/redact-identifier.js";
@@ -1135,7 +1135,7 @@ function convertResponsesMessages(
       const sanitizedTextResult = sanitizeTransportPayloadText(textResult);
       const hasText = sanitizedTextResult.trim().length > 0;
       const mediaPlaceholder = describeToolResultMediaPlaceholder(msg.content);
-      const hasImages = msg.content.some((item) => item.type === "image" && hasMediaPayload(item));
+      const hasImages = msg.content.some(isImageWithMediaPayload);
       const separatorIndex = msg.toolCallId.indexOf("|");
       const callId =
         separatorIndex === -1 ? msg.toolCallId : msg.toolCallId.slice(0, separatorIndex);
@@ -1150,15 +1150,11 @@ function convertResponsesMessages(
                   : mediaPlaceholder === "(see attached media)"
                     ? [{ type: "input_text", text: mediaPlaceholder }]
                     : []),
-                ...msg.content
-                  .filter(
-                    (item): item is ImageContent => item.type === "image" && hasMediaPayload(item),
-                  )
-                  .map((item) => ({
-                    type: "input_image",
-                    detail: "auto",
-                    image_url: `data:${item.mimeType};base64,${item.data}`,
-                  })),
+                ...msg.content.filter(isImageWithMediaPayload).map((item) => ({
+                  type: "input_image",
+                  detail: "auto",
+                  image_url: `data:${item.mimeType};base64,${item.data}`,
+                })),
               ] as ResponseFunctionCallOutputItemList)
             : sanitizeNonEmptyTransportPayloadText(textResult, mediaPlaceholder ?? "(no output)"),
       });


### PR DESCRIPTION
Related: #104721

## What Problem This Solves

The fix for payload-less tool-result media now depends on the same image-plus-inline-data condition across multiple provider emitters. Keeping that predicate duplicated makes future provider changes more likely to drift and reintroduce inconsistent attachment handling.

## Why This Change Was Made

Centralize the typed image payload predicate beside `hasMediaPayload`, then reuse it across the package and native provider emitters. This removes one local helper and repeated inline checks without expanding the Plugin SDK or changing provider behavior.

## User Impact

No intended user-visible behavior change. Provider emitters retain the merged fix: only image blocks with non-empty inline bytes are emitted as attachments.

## Evidence

- 335 focused tests passed across Anthropic, Google, Mistral, OpenAI Completions, OpenAI Responses, and native transport paths.
- Core production and core test TypeScript checks passed on the exact patch.
- Targeted formatting, lint, and `git diff --check` passed.
- Fresh autoreview passed with no accepted or actionable findings after addressing its first finding.

AI-assisted; implementation reviewed and understood.
