### PR TITLE
fix(minimax): ignore blank environment API key

### DIFF
--- a/extensions/minimax/speech-provider.test.ts
+++ b/extensions/minimax/speech-provider.test.ts
@@ -611,6 +611,22 @@ describe("buildMinimaxSpeechProvider", () => {
           timeoutMs: 30000,
         }),
       ).rejects.toThrow("MiniMax TTS auth missing");
+      expect(globalThis.fetch).not.toHaveBeenCalled();
+    });
+
+    it("does not send a request for a blank environment API key", async () => {
+      process.env.MINIMAX_API_KEY = "   ";
+
+      await expect(
+        provider.synthesize({
+          text: "Test",
+          cfg: {} as never,
+          providerConfig: {},
+          target: "audio-file",
+          timeoutMs: 30000,
+        }),
+      ).rejects.toThrow("MiniMax TTS auth missing");
+      expect(globalThis.fetch).not.toHaveBeenCalled();
     });
 
     it("throws on API error with response body", async () => {

--- a/extensions/minimax/speech-provider.test.ts
+++ b/extensions/minimax/speech-provider.test.ts
@@ -147,6 +147,11 @@ describe("buildMinimaxSpeechProvider", () => {
       expect(provider.isConfigured({ providerConfig: {}, timeoutMs: 30000 })).toBe(true);
     });
 
+    it("returns false when MINIMAX_API_KEY env var is blank", () => {
+      process.env.MINIMAX_API_KEY = "   ";
+      expect(provider.isConfigured({ providerConfig: {}, timeoutMs: 30000 })).toBe(false);
+    });
+
     it("returns true when a MiniMax Token Plan env var is set", () => {
       expect(tokenPlanEnvConfigured).toBe(true);
     });

--- a/extensions/minimax/speech-provider.ts
+++ b/extensions/minimax/speech-provider.ts
@@ -282,7 +282,7 @@ export function buildMinimaxSpeechProvider(): SpeechProviderPlugin {
         readMinimaxProviderConfig(providerConfig, cfg).apiKey ||
         isProviderAuthProfileConfigured({ cfg, provider: MINIMAX_PORTAL_PROVIDER_ID }) ||
         resolveMinimaxTokenPlanEnvKey() ||
-        process.env.MINIMAX_API_KEY,
+        trimToUndefined(process.env.MINIMAX_API_KEY),
       ),
     synthesize: async (req) => {
       const config = readMinimaxProviderConfig(req.providerConfig, req.cfg);

--- a/extensions/minimax/speech-provider.ts
+++ b/extensions/minimax/speech-provider.ts
@@ -15,6 +15,7 @@ import type {
 import {
   asObject,
   parseSpeechDirectiveNumberOverride,
+  resolveSpeechProviderApiKey,
   trimToUndefined,
 } from "openclaw/plugin-sdk/speech-core";
 import { asFiniteNumberInRange } from "openclaw/plugin-sdk/string-coerce-runtime";
@@ -59,13 +60,9 @@ function resolveConfiguredPortalTtsBaseUrl(cfg: OpenClawConfig | undefined): str
 }
 
 function resolveMinimaxTokenPlanEnvKey(): string | undefined {
-  for (const envVar of MINIMAX_TOKEN_PLAN_ENV_VARS) {
-    const value = trimToUndefined(process.env[envVar]);
-    if (value) {
-      return value;
-    }
-  }
-  return undefined;
+  return resolveSpeechProviderApiKey(
+    ...MINIMAX_TOKEN_PLAN_ENV_VARS.map((envVar) => process.env[envVar]),
+  );
 }
 
 async function resolveMinimaxPortalProfileToken(
@@ -81,11 +78,18 @@ async function resolveMinimaxTtsApiKey(params: {
   cfg: OpenClawConfig | undefined;
   configApiKey?: string;
 }): Promise<string | undefined> {
-  return (
-    params.configApiKey ??
-    (await resolveMinimaxPortalProfileToken(params.cfg)) ??
-    resolveMinimaxTokenPlanEnvKey() ??
-    trimToUndefined(process.env.MINIMAX_API_KEY)
+  return resolveSpeechProviderApiKey(
+    params.configApiKey,
+    await resolveMinimaxPortalProfileToken(params.cfg),
+    resolveMinimaxDirectTtsApiKey(),
+  );
+}
+
+function resolveMinimaxDirectTtsApiKey(configApiKey?: string): string | undefined {
+  return resolveSpeechProviderApiKey(
+    configApiKey,
+    resolveMinimaxTokenPlanEnvKey(),
+    process.env.MINIMAX_API_KEY,
   );
 }
 
@@ -279,10 +283,8 @@ export function buildMinimaxSpeechProvider(): SpeechProviderPlugin {
     listVoices: async () => MINIMAX_TTS_VOICES.map((voice) => ({ id: voice, name: voice })),
     isConfigured: ({ cfg, providerConfig }) =>
       Boolean(
-        readMinimaxProviderConfig(providerConfig, cfg).apiKey ||
-        isProviderAuthProfileConfigured({ cfg, provider: MINIMAX_PORTAL_PROVIDER_ID }) ||
-        resolveMinimaxTokenPlanEnvKey() ||
-        trimToUndefined(process.env.MINIMAX_API_KEY),
+        resolveMinimaxDirectTtsApiKey(readMinimaxProviderConfig(providerConfig, cfg).apiKey) ||
+        isProviderAuthProfileConfigured({ cfg, provider: MINIMAX_PORTAL_PROVIDER_ID }),
       ),
     synthesize: async (req) => {
       const config = readMinimaxProviderConfig(req.providerConfig, req.cfg);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users with a blank `MINIMAX_API_KEY` value could have the MiniMax speech provider treated as configured even though synthesis would later fail without usable credentials.

## Why This Change Was Made

MiniMax speech provider configuration now normalizes the direct environment API key before reporting provider availability. This keeps `isConfigured` aligned with the synthesis auth resolver, which already ignores blank environment values.

## User Impact

Users and operators can leave `MINIMAX_API_KEY` unset or blank without accidentally selecting MiniMax as a configured speech provider.

## Evidence

- Real production-module negative-control proof: `./node_modules/.bin/tsx proof-live.ts` imports the MiniMax provider entrypoint, rejects a blank environment key before fetch, and still reports a nonblank environment key as configured.
- `node scripts/run-vitest.mjs extensions/minimax/speech-provider.test.ts`: MiniMax speech provider tests pass.

```text
$ ./node_modules/.bin/tsx proof-live.ts
entrypoint: buildMinimaxSpeechProvider().isConfigured + synthesize
blank-env-configured: false
blank-env-synthesize: MiniMax TTS auth missing
blank-env-fetch-calls: 0
valid-env-configured: true
```

```text
$ node scripts/run-vitest.mjs extensions/minimax/speech-provider.test.ts
Test Files  1 passed (1)
Tests  40 passed (40)
```

<details>
<summary>proof-live.ts</summary>

```ts
import { buildMinimaxSpeechProvider } from "./extensions/minimax/speech-provider.ts";

const originalApiKey = process.env.MINIMAX_API_KEY;

function restoreEnv() {
  if (originalApiKey === undefined) {
    delete process.env.MINIMAX_API_KEY;
  } else {
    process.env.MINIMAX_API_KEY = originalApiKey;
  }
}

async function main() {
  const provider = buildMinimaxSpeechProvider();

  process.env.MINIMAX_API_KEY = "   ";
  let blankError = "";
  let blankFetchCalls = 0;
  const originalFetch = globalThis.fetch;
  globalThis.fetch = ((() => {
    blankFetchCalls += 1;
    throw new Error("blank env should not call fetch");
  }) as unknown) as typeof fetch;

  try {
    await provider.synthesize({
      text: "OpenClaw proof",
      cfg: {} as never,
      providerConfig: {},
      target: "audio-file",
      timeoutMs: 30_000,
    });
  } catch (error) {
    blankError = error instanceof Error ? error.message : String(error);
  } finally {
    globalThis.fetch = originalFetch;
  }

  console.log("entrypoint: buildMinimaxSpeechProvider().isConfigured + synthesize");
  console.log(
    `blank-env-configured: ${provider.isConfigured({ providerConfig: {}, timeoutMs: 30_000 })}`,
  );
  console.log(`blank-env-synthesize: ${blankError}`);
  console.log(`blank-env-fetch-calls: ${blankFetchCalls}`);

  process.env.MINIMAX_API_KEY = "sk-live-proof";
  console.log(
    `valid-env-configured: ${provider.isConfigured({ providerConfig: {}, timeoutMs: 30_000 })}`,
  );

  restoreEnv();
}

main().catch((error) => {
  restoreEnv();
  console.error(error);
  process.exitCode = 1;
});
```

</details>

AI-assisted: built with Codex
