### PR TITLE
fix(cron): stop post-execution retries across recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Cron lifecycle conflict retries:** preserve execution-phase retry decisions across scheduled, manual, and startup-recovered runs so post-execution claim conflicts cannot replay completed messages or tools. Fixes #108428. Thanks @yetval.
 - **Discord gateway metadata deadline:** carry the existing lookup deadline through DNS and proxy preflight, request headers, and response bodies so stalled gateway startup aborts cleanly. (#104580) Thanks @hugenshen.
 - **Control UI cloud session thinking:** expose reasoning level in the New Session model picker and persist the selected level before cloud dispatch.
 - **Tlon SSE connect cleanup:** disarm opening deadlines after failed HTTP responses and rejected stream opens so reconnect attempts cannot leave stale timers behind. (#104585) Thanks @hugenshen.

--- a/src/cron/service/ops.test.ts
+++ b/src/cron/service/ops.test.ts
@@ -481,6 +481,56 @@ describe("cron service ops seam coverage", () => {
     });
   });
 
+  it("keeps a finalized one-shot disabled when startup restores its stale marker", async () => {
+    const { storePath } = await makeStorePath();
+    const now = Date.parse("2026-03-23T12:00:00.000Z");
+    const startedAt = now - 30_000;
+    const endedAt = startedAt + 4_000;
+
+    await withStateDirForStorePath(storePath, async () => {
+      const job = createDueIsolatedJob(now);
+      job.id = "startup-post-execution-conflict";
+      job.name = "startup post-execution conflict";
+      job.schedule = { kind: "at", at: new Date(startedAt).toISOString() };
+      job.state = { runningAtMs: startedAt, nextRunAtMs: startedAt };
+      await writeCronStoreSnapshot({ storePath, jobs: [job] });
+      const state = createCronServiceState({
+        storePath,
+        cronEnabled: true,
+        log: logger,
+        nowMs: () => now,
+        enqueueSystemEvent: vi.fn(),
+        requestHeartbeat: vi.fn(),
+        runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
+      });
+      const taskRunId = tryCreateCronTaskRun({ state, job, startedAt });
+      if (!taskRunId) {
+        throw new Error("expected cron task run");
+      }
+      tryFinishCronTaskRun(state, {
+        taskRunId,
+        job,
+        event: {
+          jobId: job.id,
+          action: "finished",
+          job,
+          status: "error",
+          error:
+            'CronSessionLifecycleClaimError: Session "agent:main:cron:job-1" changed while starting work. Retry.',
+          runAtMs: startedAt,
+          durationMs: endedAt - startedAt,
+        },
+      });
+
+      await start(state);
+
+      const persisted = await loadCronStore(storePath);
+      expect(persisted.jobs[0]?.enabled).toBe(false);
+      expect(persisted.jobs[0]?.state.nextRunAtMs).toBeUndefined();
+      stop(state);
+    });
+  });
+
   it("restores finalized failure-alert cooldown without redelivery", async () => {
     const { storePath } = await makeStorePath();
     const now = Date.parse("2026-03-23T12:00:00.000Z");
@@ -667,6 +717,45 @@ describe("cron service ops seam coverage", () => {
           durationMs: 0,
         },
       });
+    });
+  });
+
+  it("does not reschedule a manual lifecycle conflict after execution starts", async () => {
+    const { storePath } = await makeStorePath();
+    const now = Date.parse("2026-03-23T12:00:00.000Z");
+    const job = createDueIsolatedJob(now);
+    job.id = "manual-post-execution-conflict";
+    job.name = "manual post-execution conflict";
+    job.schedule = { kind: "at", at: new Date(now - 1).toISOString() };
+
+    await withStateDirForStorePath(storePath, async () => {
+      await writeCronStoreSnapshot({ storePath, jobs: [job] });
+      const state = createCronServiceState({
+        storePath,
+        cronEnabled: true,
+        log: logger,
+        nowMs: () => now,
+        enqueueSystemEvent: vi.fn(),
+        requestHeartbeat: vi.fn(),
+        runIsolatedAgentJob: vi.fn(async () => ({
+          status: "error" as const,
+          error:
+            'CronSessionLifecycleClaimError: Session "agent:main:cron:job-1" changed while starting work. Retry.',
+          executionStarted: true,
+        })),
+      });
+
+      await expect(run(state, job.id)).resolves.toEqual({ ok: true, ran: true });
+
+      const persisted = await loadCronStore(storePath);
+      expect(persisted.jobs[0]).toMatchObject({
+        id: job.id,
+        enabled: false,
+        state: {
+          consecutiveErrors: 1,
+        },
+      });
+      expect(persisted.jobs[0]?.state.nextRunAtMs).toBeUndefined();
     });
   });
 

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -1057,12 +1057,7 @@ async function finishPreparedManualRun(
           state,
           job,
           {
-            status: coreResult.status,
-            error: coreResult.error,
-            deliveryError: coreResult.deliveryError,
-            diagnostics: coreResult.diagnostics,
-            delivered: coreResult.delivered,
-            provider: coreResult.provider,
+            ...coreResult,
             startedAt,
             endedAt,
           },

--- a/src/cron/service/startup-run-repair.ts
+++ b/src/cron/service/startup-run-repair.ts
@@ -93,12 +93,7 @@ export function restoreFinalizedStartupRun(params: {
     state,
     job,
     {
-      status: entry.status,
-      error: entry.error,
-      deliveryError: entry.deliveryError,
-      diagnostics: entry.diagnostics,
-      delivered: entry.delivered,
-      provider: entry.provider,
+      ...entry,
       startedAt,
       endedAt: entry.ts,
     },
@@ -115,6 +110,11 @@ export function restoreFinalizedStartupRun(params: {
   job.state.lastFailureNotificationDeliveryStatus = entry.failureNotificationDelivery?.status;
   job.state.lastFailureNotificationDeliveryError = entry.failureNotificationDelivery?.error;
   job.state.nextRunAtMs = entry.nextRunAtMs;
+  // The finalized ledger row owns the schedule decision made before the stale
+  // store write. No next run means that one-shot was permanently disabled.
+  if (job.schedule.kind === "at" && entry.nextRunAtMs === undefined) {
+    job.enabled = false;
+  }
   if (params.triggerEval) {
     applyTriggerRunResult(job, {
       status: entry.status,

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -132,6 +132,14 @@ type TimedCronRunOutcome = CronRunOutcome &
     triggerEval?: CronTriggerEvalOutcome;
   };
 
+type CronJobRunResult = CronRunOutcome &
+  Pick<CronRunTelemetry, "provider"> & {
+    deliveryError?: string;
+    delivered?: boolean;
+    startedAt: number;
+    endedAt: number;
+  };
+
 export type CronTriggerEvalOutcome = {
   fired: boolean;
   stateChanged: boolean;
@@ -709,17 +717,7 @@ function resolveDeliveryState(params: {
 export function applyJobResult(
   state: CronServiceState,
   job: CronJob,
-  result: {
-    status: CronRunStatus;
-    error?: string;
-    executionStarted?: boolean;
-    deliveryError?: string;
-    diagnostics?: CronRunOutcome["diagnostics"];
-    delivered?: boolean;
-    provider?: string;
-    startedAt: number;
-    endedAt: number;
-  },
+  result: CronJobRunResult,
   opts?: {
     // Preserve recurring "every" anchors for manual force runs.
     preserveSchedule?: boolean;
@@ -1141,17 +1139,7 @@ function applyOutcomeToStoredJob(
     if (result.status === "ok") {
       // A manual/queued run may finish after the job was removed. Preserve the
       // successful run-history state without resurrecting the job in the store.
-      applyJobResult(state, result.job, {
-        status: result.status,
-        error: result.error,
-        executionStarted: result.executionStarted,
-        deliveryError: result.deliveryError,
-        diagnostics: result.diagnostics,
-        delivered: result.delivered,
-        provider: result.provider,
-        startedAt: result.startedAt,
-        endedAt: result.endedAt,
-      });
+      applyJobResult(state, result.job, result);
       emitJobFinished(state, result.job, result, result.startedAt);
       state.deps.log.info(
         { jobId: result.jobId },
@@ -1179,17 +1167,7 @@ function applyOutcomeToStoredJob(
     return undefined;
   }
 
-  const shouldDelete = applyJobResult(state, job, {
-    status: result.status,
-    error: result.error,
-    executionStarted: result.executionStarted,
-    deliveryError: result.deliveryError,
-    diagnostics: result.diagnostics,
-    delivered: result.delivered,
-    provider: result.provider,
-    startedAt: result.startedAt,
-    endedAt: result.endedAt,
-  });
+  const shouldDelete = applyJobResult(state, job, result);
   applyTriggerRunResult(job, result);
   state.pendingCatchupDeferralJobIds.delete(job.id);
 


### PR DESCRIPTION
Related: #108428
Follow-up to #108682

## What Problem This Solves

Fixes an issue where users running one-shot cron jobs manually, or restarting after a finalized run, could have a session lifecycle claim conflict retried after agent execution had already begun. That retry could replay completed messages or tool side effects.

## Why This Change Was Made

The scheduler now passes the canonical run outcome intact through manual completion and shared result application, preserving the execution phase without duplicated field mappings. Startup recovery restores the finalized task ledger's durable schedule decision, so a completed one-shot with no next run stays disabled.

## User Impact

Manual, scheduled, and startup-recovered cron runs now make the same phase-aware retry decision. Pre-execution claim conflicts remain retryable; post-execution conflicts stop without replaying work.

## Evidence

- Blacksmith Testbox: 4 focused files, 65 tests passed, including new manual-run and startup-recovery regressions.
- Blacksmith Testbox: changed core/core-test gates passed with exit 0, including typechecks, lint, formatting, database-first guards, and import-cycle checks.
- `node scripts/check-changelog-attributions.mjs` and `git diff --check` passed.
- Fresh autoreview reported no accepted/actionable findings (0.90 correctness confidence).

AI-assisted; implementation and proof reviewed before submission.