### PR TITLE
fix(ios): stop fresh setup from failing after pairing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Docs: https://docs.openclaw.ai
 - **Cron lifecycle conflict retries:** preserve execution-phase retry decisions across scheduled, manual, and startup-recovered runs so post-execution claim conflicts cannot replay completed messages or tools. Fixes #108428. Thanks @yetval.
 - **Discord gateway metadata deadline:** carry the existing lookup deadline through DNS and proxy preflight, request headers, and response bodies so stalled gateway startup aborts cleanly. (#104580) Thanks @hugenshen.
 - **Control UI cloud session thinking:** expose reasoning level in the New Session model picker and persist the selected level before cloud dispatch.
+- **iOS fresh-install setup:** atomically redact spent setup credentials before Keychain cleanup so a deferred item deletion no longer disconnects a successfully paired device. Fixes #107591. Thanks @dagmarjeeves-lab.
 - **Tlon SSE connect cleanup:** disarm opening deadlines after failed HTTP responses and rejected stream opens so reconnect attempts cannot leave stale timers behind. (#104585) Thanks @hugenshen.
 - **LINE reply-token media kinds:** honor video and audio metadata on inbound replies, share the canonical media builder with proactive sends, and fail visibly instead of recording empty media-only deliveries. (#106515) Thanks @edenfunf.
 - **Mattermost websocket connection deadlines:** bound opening handshakes so stalled TCP peers cannot hang channel startup indefinitely and reconnect control resumes after timeout. (#105553) Thanks @hugenshen.

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -22411,7 +22411,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 649,
+      "line": 623,
       "path": "apps/ios/Sources/Gateway/GatewaySettingsStore.swift",
       "source": "\\(host):\\(port)",
       "surface": "apple",
@@ -22419,7 +22419,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 712,
+      "line": 686,
       "path": "apps/ios/Sources/Gateway/GatewaySettingsStore.swift",
       "source": "\\(legacy.host ?? \"\"):\\(legacy.port ?? 0)",
       "surface": "apple",
@@ -22883,7 +22883,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 4497,
+      "line": 4519,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Connecting...",
       "surface": "apple",
@@ -22891,7 +22891,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 4498,
+      "line": 4520,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Reconnecting...",
       "surface": "apple",
@@ -22899,7 +22899,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 4842,
+      "line": 4864,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Connected",
       "surface": "apple",
@@ -22907,7 +22907,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 4842,
+      "line": 4864,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Offline",
       "surface": "apple",
@@ -22915,7 +22915,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 5984,
+      "line": 6006,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "No chat messages yet",
       "surface": "apple",
@@ -22923,7 +22923,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 6183,
+      "line": 6205,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Connecting…",
       "surface": "apple",
@@ -22931,7 +22931,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 6183,
+      "line": 6205,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Reconnecting…",
       "surface": "apple",
@@ -22939,7 +22939,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 8468,
+      "line": 8490,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Approval",
       "surface": "apple",
@@ -22947,7 +22947,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 8468,
+      "line": 8490,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "This approval was already",
       "surface": "apple",
@@ -22955,7 +22955,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 8474,
+      "line": 8496,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "This approval was already set to Always Allow.",
       "surface": "apple",
@@ -22963,7 +22963,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 8475,
+      "line": 8497,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Approval set to Always Allow.",
       "surface": "apple",
@@ -22971,7 +22971,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 9779,
+      "line": 9801,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "\\(urlText.prefix(500))…",
       "surface": "apple",

--- a/apps/ios/Sources/Gateway/GatewaySettingsStore.swift
+++ b/apps/ios/Sources/Gateway/GatewaySettingsStore.swift
@@ -2,6 +2,23 @@ import Foundation
 import OpenClawKit
 import os
 
+enum GatewayCredentialPersistenceError: Error, Equatable, LocalizedError {
+    case invalidOwner
+    case encodingFailed
+    case keychain(GenericPasswordKeychainStore.MutationError)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidOwner:
+            "Gateway credential owner is invalid."
+        case .encodingFailed:
+            "Gateway credential encoding failed."
+        case let .keychain(error):
+            error.localizedDescription
+        }
+    }
+}
+
 enum GatewaySettingsStore {
     private static let productionGatewayService = "ai.openclawfoundation.app.gateway"
     private static var gatewayService: String {
@@ -91,6 +108,10 @@ enum GatewaySettingsStore {
         let token: String?
         let bootstrapToken: String?
         let password: String?
+
+        var hasCredentials: Bool {
+            self.token != nil || self.bootstrapToken != nil || self.password != nil
+        }
     }
 
     struct GatewayCredentials: Equatable {
@@ -224,47 +245,19 @@ enum GatewaySettingsStore {
         suppressStoredDeviceAuth: Bool,
         instanceId: String) -> Bool
     {
-        let stableID = self.authenticationOwnerID(routeStableID: gatewayStableID)
-        let trimmedInstanceID = instanceId.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !stableID.isEmpty, !trimmedInstanceID.isEmpty else { return false }
-        let bundle = GatewayCredentialBundle(
-            gatewayStableID: stableID,
-            suppressStoredDeviceAuth: suppressStoredDeviceAuth,
-            token: self.normalizedCredential(token),
-            bootstrapToken: self.normalizedCredential(bootstrapToken),
-            password: self.normalizedCredential(password))
-        let account = self.gatewayCredentialBundleAccount(
-            instanceId: trimmedInstanceID,
-            stableID: stableID)
-        let hasCredentials = bundle.token != nil || bundle.bootstrapToken != nil || bundle.password != nil
-        guard hasCredentials || suppressStoredDeviceAuth else {
-            let deleted = KeychainStore.delete(service: self.gatewayService, account: account)
-            self.deleteLegacyScopedCredentialBundleIfOwned(
-                instanceId: trimmedInstanceID,
-                stableID: stableID)
-            self.deleteLegacyGatewayCredentials(instanceId: trimmedInstanceID)
-            return deleted || KeychainStore.loadString(service: self.gatewayService, account: account) == nil
-        }
-        guard let data = try? JSONEncoder().encode(bundle),
-              let json = String(data: data, encoding: .utf8)
-        else {
-            _ = KeychainStore.delete(service: self.gatewayService, account: account)
+        do {
+            try self.persistGatewayCredentials(
+                token: token,
+                bootstrapToken: bootstrapToken,
+                password: password,
+                gatewayStableID: gatewayStableID,
+                suppressStoredDeviceAuth: suppressStoredDeviceAuth,
+                instanceId: instanceId)
+            return true
+        } catch {
+            GatewayDiagnostics.log("gateway credential persistence failed: \(error.localizedDescription)")
             return false
         }
-        guard KeychainStore.saveString(
-            json,
-            service: self.gatewayService,
-            account: account)
-        else {
-            // The Keychain helper restores the prior item when replacement fails. Keep that
-            // known-good bundle; callers already treat this attempted update as uncommitted.
-            return false
-        }
-        self.deleteLegacyScopedCredentialBundleIfOwned(
-            instanceId: trimmedInstanceID,
-            stableID: stableID)
-        self.deleteLegacyGatewayCredentials(instanceId: trimmedInstanceID)
-        return true
     }
 
     @discardableResult
@@ -284,25 +277,6 @@ enum GatewaySettingsStore {
             password: password,
             gatewayStableID: stableID,
             suppressStoredDeviceAuth: existing?.suppressStoredDeviceAuth == true,
-            instanceId: instanceId)
-    }
-
-    @discardableResult
-    static func completeGatewayCredentialHandoff(instanceId: String, gatewayStableID: String) -> Bool {
-        let stableID = self.authenticationOwnerID(routeStableID: gatewayStableID)
-        guard let bundle = self.loadGatewayCredentialBundle(
-            instanceId: instanceId,
-            gatewayStableID: stableID),
-            bundle.suppressStoredDeviceAuth
-        else { return false }
-        // Device-token issuance and bootstrap consumption are one durable handoff. A relaunch
-        // must never observe a spent bootstrap token while stored device auth remains disabled.
-        return self.saveGatewayCredentials(
-            token: bundle.token,
-            bootstrapToken: nil,
-            password: bundle.password,
-            gatewayStableID: stableID,
-            suppressStoredDeviceAuth: false,
             instanceId: instanceId)
     }
 
@@ -1005,6 +979,125 @@ enum GatewaySettingsStore {
 
         if let stored = self.loadLastDiscoveredGatewayStableID(), !stored.isEmpty {
             defaults.set(stored, forKey: self.lastDiscoveredGatewayStableIDDefaultsKey)
+        }
+    }
+}
+
+extension GatewaySettingsStore {
+    @discardableResult
+    static func completeGatewayCredentialHandoff(
+        instanceId: String,
+        gatewayStableID: String,
+        deleteCredentialBundle: (String, String) -> Result<
+            Void,
+            GenericPasswordKeychainStore.MutationError,
+        > = { service, account in
+            KeychainStore.deleteResult(service: service, account: account)
+        }) throws -> Bool
+    {
+        let stableID = self.authenticationOwnerID(routeStableID: gatewayStableID)
+        guard let bundle = self.loadGatewayCredentialBundle(
+            instanceId: instanceId,
+            gatewayStableID: stableID),
+            bundle.suppressStoredDeviceAuth
+        else { return false }
+        // Device-token issuance and bootstrap consumption are one durable handoff. A relaunch
+        // must never observe a spent bootstrap token while stored device auth remains disabled.
+        let completedBundle = GatewayCredentialBundle(
+            gatewayStableID: stableID,
+            suppressStoredDeviceAuth: false,
+            token: bundle.token,
+            bootstrapToken: nil,
+            password: bundle.password)
+        let trimmedInstanceID = instanceId.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !stableID.isEmpty, !trimmedInstanceID.isEmpty else {
+            throw GatewayCredentialPersistenceError.invalidOwner
+        }
+        let account = self.gatewayCredentialBundleAccount(
+            instanceId: trimmedInstanceID,
+            stableID: stableID)
+        try self.saveGatewayCredentialBundle(completedBundle, account: account)
+        self.deleteLegacyScopedCredentialBundleIfOwned(
+            instanceId: trimmedInstanceID,
+            stableID: stableID)
+        self.deleteLegacyGatewayCredentials(instanceId: trimmedInstanceID)
+
+        guard !completedBundle.hasCredentials else { return true }
+        switch deleteCredentialBundle(self.gatewayService, account) {
+        case .success:
+            return true
+        case let .failure(error):
+            // Deletion is cleanup after the atomic overwrite. Only continue when readback
+            // proves that no bootstrap or shared credential survived in the retained item.
+            guard let retained = self.loadGatewayCredentialBundle(
+                instanceId: trimmedInstanceID,
+                gatewayStableID: stableID),
+                !retained.hasCredentials,
+                !retained.suppressStoredDeviceAuth
+            else {
+                throw GatewayCredentialPersistenceError.keychain(error)
+            }
+            GatewayDiagnostics.log("gateway credential cleanup deferred: \(error.localizedDescription)")
+            return true
+        }
+    }
+
+    private static func persistGatewayCredentials(
+        token: String?,
+        bootstrapToken: String?,
+        password: String?,
+        gatewayStableID: String,
+        suppressStoredDeviceAuth: Bool,
+        instanceId: String) throws
+    {
+        let stableID = self.authenticationOwnerID(routeStableID: gatewayStableID)
+        let trimmedInstanceID = instanceId.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !stableID.isEmpty, !trimmedInstanceID.isEmpty else {
+            throw GatewayCredentialPersistenceError.invalidOwner
+        }
+        let bundle = GatewayCredentialBundle(
+            gatewayStableID: stableID,
+            suppressStoredDeviceAuth: suppressStoredDeviceAuth,
+            token: self.normalizedCredential(token),
+            bootstrapToken: self.normalizedCredential(bootstrapToken),
+            password: self.normalizedCredential(password))
+        let account = self.gatewayCredentialBundleAccount(
+            instanceId: trimmedInstanceID,
+            stableID: stableID)
+        if bundle.hasCredentials || suppressStoredDeviceAuth {
+            try self.saveGatewayCredentialBundle(bundle, account: account)
+        } else {
+            switch KeychainStore.deleteResult(service: self.gatewayService, account: account) {
+            case .success:
+                break
+            case let .failure(error):
+                guard KeychainStore.loadString(service: self.gatewayService, account: account) == nil else {
+                    throw GatewayCredentialPersistenceError.keychain(error)
+                }
+            }
+        }
+        self.deleteLegacyScopedCredentialBundleIfOwned(
+            instanceId: trimmedInstanceID,
+            stableID: stableID)
+        self.deleteLegacyGatewayCredentials(instanceId: trimmedInstanceID)
+    }
+
+    private static func saveGatewayCredentialBundle(
+        _ bundle: GatewayCredentialBundle,
+        account: String) throws
+    {
+        guard let data = try? JSONEncoder().encode(bundle),
+              let json = String(data: data, encoding: .utf8)
+        else {
+            throw GatewayCredentialPersistenceError.encodingFailed
+        }
+        do {
+            try KeychainStore.saveStringResult(
+                json,
+                service: self.gatewayService,
+                account: account).get()
+        } catch {
+            throw GatewayCredentialPersistenceError.keychain(error)
         }
     }
 }

--- a/apps/ios/Sources/Gateway/KeychainStore.swift
+++ b/apps/ios/Sources/Gateway/KeychainStore.swift
@@ -11,8 +11,23 @@ enum KeychainStore {
         GenericPasswordKeychainStore.saveString(value, service: service, account: account)
     }
 
+    static func saveStringResult(
+        _ value: String,
+        service: String,
+        account: String) -> Result<Void, GenericPasswordKeychainStore.MutationError>
+    {
+        GenericPasswordKeychainStore.saveStringResult(value, service: service, account: account)
+    }
+
     static func delete(service: String, account: String) -> Bool {
         GenericPasswordKeychainStore.delete(service: service, account: account)
+    }
+
+    static func deleteResult(
+        service: String,
+        account: String) -> Result<Void, GenericPasswordKeychainStore.MutationError>
+    {
+        GenericPasswordKeychainStore.deleteResult(service: service, account: account)
     }
 
     static func deleteAll(service: String) -> Bool {

--- a/apps/ios/Sources/Model/NodeAppModel.swift
+++ b/apps/ios/Sources/Model/NodeAppModel.swift
@@ -3936,7 +3936,7 @@ extension NodeAppModel {
         stableID: String,
         routeGeneration: UInt64,
         issuedRoles: Set<String>,
-        nodeOptions: GatewayConnectOptions) -> GatewayConnectOptions?
+        nodeOptions: GatewayConnectOptions) throws -> GatewayConnectOptions?
     {
         guard self.isCurrentGatewayRoute(generation: routeGeneration, stableID: stableID) else { return nil }
 
@@ -3953,12 +3953,12 @@ extension NodeAppModel {
         if let metadata = GatewaySettingsStore.loadGatewayCredentialMetadata(
             instanceId: instanceID,
             gatewayStableID: deviceAuthGatewayID),
-            metadata.suppressStoredDeviceAuth,
-            !GatewaySettingsStore.completeGatewayCredentialHandoff(
+            metadata.suppressStoredDeviceAuth
+        {
+            guard try GatewaySettingsStore.completeGatewayCredentialHandoff(
                 instanceId: instanceID,
                 gatewayStableID: deviceAuthGatewayID)
-        {
-            return nil
+            else { return nil }
         }
         var reconnectOptions = nodeOptions
         reconnectOptions.allowStoredDeviceAuth = true
@@ -4010,12 +4010,21 @@ extension NodeAppModel {
         }
         let issuedRoles = await nodeGateway.currentIssuedDeviceAuthRoles()
         guard self.isCurrentGatewayRoute(generation: routeGeneration, stableID: stableID) else { return nil }
-        guard let reconnectOptions = completeSuccessfulGatewayAuthHandoff(
-            stableID: stableID,
-            routeGeneration: routeGeneration,
-            issuedRoles: issuedRoles,
-            nodeOptions: nodeOptions)
-        else {
+        let reconnectOptions: GatewayConnectOptions?
+        do {
+            reconnectOptions = try self.completeSuccessfulGatewayAuthHandoff(
+                stableID: stableID,
+                routeGeneration: routeGeneration,
+                issuedRoles: issuedRoles,
+                nodeOptions: nodeOptions)
+        } catch {
+            await self.handleGatewayCredentialHandoffPersistenceFailure(
+                stableID: stableID,
+                routeGeneration: routeGeneration,
+                error: error)
+            return nil
+        }
+        guard let reconnectOptions else {
             await self.handleGatewayCredentialHandoffPersistenceFailure(
                 stableID: stableID,
                 routeGeneration: routeGeneration)
@@ -4026,7 +4035,8 @@ extension NodeAppModel {
 
     private func handleGatewayCredentialHandoffPersistenceFailure(
         stableID: String,
-        routeGeneration: UInt64) async
+        routeGeneration: UInt64,
+        error: Error? = nil) async
     {
         guard self.isCurrentGatewayRoute(generation: routeGeneration, stableID: stableID) else { return }
         guard self.credentialHandoffFailureGeneration != routeGeneration else { return }
@@ -4039,6 +4049,10 @@ extension NodeAppModel {
         await self.nodeGateway.disconnect()
         await self.operatorGateway.disconnect()
         guard self.isCurrentGatewayRoute(generation: routeGeneration, stableID: stableID) else { return }
+        let technicalDetails = error.map {
+            "Gateway credential handoff persistence failed: \($0.localizedDescription)"
+        } ?? "Gateway credential handoff persistence failed."
+        GatewayDiagnostics.log(technicalDetails)
         self.applyGatewayConnectionProblem(GatewayConnectionProblem(
             kind: .unknown,
             owner: .iphone,
@@ -4046,7 +4060,7 @@ extension NodeAppModel {
             message: "OpenClaw disconnected because it could not securely save the new gateway credential.",
             retryable: true,
             pauseReconnect: true,
-            technicalDetails: "Gateway credential handoff persistence failed."))
+            technicalDetails: technicalDetails))
     }
 
     private func refreshBackgroundReconnectSuppressionIfNeeded(source: String) {
@@ -4173,15 +4187,23 @@ extension NodeAppModel {
         if usedBootstrapToken {
             let issuedRoles = await nodeGateway.currentIssuedDeviceAuthRoles()
             guard self.isCurrentGatewayRoute(generation: routeGeneration, stableID: stableID) else { return }
-            guard self.completeSuccessfulGatewayAuthHandoff(
-                stableID: stableID,
-                routeGeneration: routeGeneration,
-                issuedRoles: issuedRoles,
-                nodeOptions: nodeOptions) != nil
-            else {
+            do {
+                guard try self.completeSuccessfulGatewayAuthHandoff(
+                    stableID: stableID,
+                    routeGeneration: routeGeneration,
+                    issuedRoles: issuedRoles,
+                    nodeOptions: nodeOptions) != nil
+                else {
+                    await self.handleGatewayCredentialHandoffPersistenceFailure(
+                        stableID: stableID,
+                        routeGeneration: routeGeneration)
+                    return
+                }
+            } catch {
                 await self.handleGatewayCredentialHandoffPersistenceFailure(
                     stableID: stableID,
-                    routeGeneration: routeGeneration)
+                    routeGeneration: routeGeneration,
+                    error: error)
                 return
             }
         }
@@ -10709,10 +10731,10 @@ extension NodeAppModel {
 
     func _test_completeSuccessfulGatewayAuthHandoff(
         issuedRoles: Set<String>,
-        nodeOptions: GatewayConnectOptions) -> GatewayConnectOptions?
+        nodeOptions: GatewayConnectOptions) throws -> GatewayConnectOptions?
     {
         guard let stableID = activeGatewayConnectConfig?.effectiveStableID else { return nil }
-        return self.completeSuccessfulGatewayAuthHandoff(
+        return try self.completeSuccessfulGatewayAuthHandoff(
             stableID: stableID,
             routeGeneration: self.gatewayRouteGeneration,
             issuedRoles: issuedRoles,

--- a/apps/ios/Tests/GatewayConnectionControllerTests.swift
+++ b/apps/ios/Tests/GatewayConnectionControllerTests.swift
@@ -1055,13 +1055,13 @@ private func waitForActiveGateway(stableID: String, appModel: NodeAppModel) asyn
         defer { appModel.disconnectGateway() }
         appModel.applyGatewayConnectConfig(config)
 
-        let emptyIssuanceOptions = appModel._test_completeSuccessfulGatewayAuthHandoff(
+        let emptyIssuanceOptions = try appModel._test_completeSuccessfulGatewayAuthHandoff(
             issuedRoles: [],
             nodeOptions: nodeOptions)
-        let operatorOnlyOptions = appModel._test_completeSuccessfulGatewayAuthHandoff(
+        let operatorOnlyOptions = try appModel._test_completeSuccessfulGatewayAuthHandoff(
             issuedRoles: ["operator"],
             nodeOptions: nodeOptions)
-        let nodeOnlyOptions = appModel._test_completeSuccessfulGatewayAuthHandoff(
+        let nodeOnlyOptions = try appModel._test_completeSuccessfulGatewayAuthHandoff(
             issuedRoles: ["node"],
             nodeOptions: nodeOptions)
         #expect(emptyIssuanceOptions == nil)
@@ -1084,9 +1084,10 @@ private func waitForActiveGateway(stableID: String, appModel: NodeAppModel) asyn
             gatewayID: stableID)
         let bootstrapOptions = nodeOptions
         appModel._test_setGatewayLoopTasks(node: nil, operator: Task {})
-        nodeOptions = try #require(appModel._test_completeSuccessfulGatewayAuthHandoff(
+        let completedOptions = try appModel._test_completeSuccessfulGatewayAuthHandoff(
             issuedRoles: ["node", "operator"],
-            nodeOptions: nodeOptions))
+            nodeOptions: nodeOptions)
+        nodeOptions = try #require(completedOptions)
 
         #expect(nodeOptions.allowStoredDeviceAuth)
         #expect(appModel.activeGatewayConnectConfig?.nodeOptions.allowStoredDeviceAuth == true)

--- a/apps/ios/Tests/GatewaySettingsStoreTests.swift
+++ b/apps/ios/Tests/GatewaySettingsStoreTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import OpenClawKit
+import Security
 import Testing
 @testable import OpenClaw
 
@@ -465,7 +466,7 @@ private func withLastGatewaySnapshot(_ body: () -> Void) {
             gatewayStableID: gatewayID) == .empty)
     }
 
-    @Test func `credentialless setup suppresses stored auth until handoff completes`() {
+    @Test func `credentialless setup suppresses stored auth until handoff completes`() throws {
         let instanceID = "credentialless-owner-\(UUID().uuidString)"
         defer { GatewaySettingsStore.deleteAllGatewayCredentials(instanceId: instanceID) }
         let gatewayID = "manual|gateway.example.com|443"
@@ -484,7 +485,7 @@ private func withLastGatewaySnapshot(_ body: () -> Void) {
         #expect(!pending.hasCredentials)
         #expect(pending.suppressStoredDeviceAuth)
 
-        GatewaySettingsStore.completeGatewayCredentialHandoff(
+        try GatewaySettingsStore.completeGatewayCredentialHandoff(
             instanceId: instanceID,
             gatewayStableID: gatewayID)
         #expect(GatewaySettingsStore.loadGatewayCredentials(
@@ -495,7 +496,7 @@ private func withLastGatewaySnapshot(_ body: () -> Void) {
             gatewayStableID: gatewayID) == nil)
     }
 
-    @Test func `bootstrap handoff clears bootstrap while enabling stored auth`() {
+    @Test func `bootstrap handoff clears bootstrap while enabling stored auth`() throws {
         let instanceID = "bootstrap-handoff-\(UUID().uuidString)"
         defer { GatewaySettingsStore.deleteAllGatewayCredentials(instanceId: instanceID) }
         let gatewayID = "manual|gateway.example.com|443"
@@ -508,7 +509,7 @@ private func withLastGatewaySnapshot(_ body: () -> Void) {
             suppressStoredDeviceAuth: true,
             instanceId: instanceID)
 
-        #expect(GatewaySettingsStore.completeGatewayCredentialHandoff(
+        #expect(try GatewaySettingsStore.completeGatewayCredentialHandoff(
             instanceId: instanceID,
             gatewayStableID: gatewayID))
         let completed = GatewaySettingsStore.loadGatewayCredentials(
@@ -517,6 +518,40 @@ private func withLastGatewaySnapshot(_ body: () -> Void) {
         #expect(completed.token == "shared-token")
         #expect(completed.bootstrapToken == nil)
         #expect(!completed.suppressStoredDeviceAuth)
+    }
+
+    @Test func `credentialless handoff survives deferred keychain deletion after redaction`() throws {
+        let instanceID = "deferred-handoff-cleanup-\(UUID().uuidString)"
+        defer { GatewaySettingsStore.deleteAllGatewayCredentials(instanceId: instanceID) }
+        let gatewayID = "manual|gateway.example.com|443"
+        let bootstrapToken = "one-time-bootstrap"
+
+        #expect(GatewaySettingsStore.saveGatewayCredentials(
+            token: nil,
+            bootstrapToken: bootstrapToken,
+            password: nil,
+            gatewayStableID: gatewayID,
+            suppressStoredDeviceAuth: true,
+            instanceId: instanceID))
+
+        #expect(try GatewaySettingsStore.completeGatewayCredentialHandoff(
+            instanceId: instanceID,
+            gatewayStableID: gatewayID,
+            deleteCredentialBundle: { _, _ in
+                .failure(.init(operation: .delete, status: errSecInteractionNotAllowed))
+            }))
+
+        let completed = GatewaySettingsStore.loadGatewayCredentials(
+            instanceId: instanceID,
+            gatewayStableID: gatewayID)
+        #expect(completed == .empty)
+        #expect(GatewaySettingsStore.loadGatewayCredentialMetadata(
+            instanceId: instanceID,
+            gatewayStableID: gatewayID)?.suppressStoredDeviceAuth == false)
+        let storageComponent = try #require(GatewayStableIdentifier.storageComponent(gatewayID))
+        let account = "gateway-credentials.\(instanceID).v2.\(storageComponent)"
+        let retainedJSON = KeychainStore.loadString(service: gatewayService, account: account)
+        #expect(retainedJSON?.contains(bootstrapToken) == false)
     }
 
     @Test func `field edits preserve pending bootstrap handoff for the same gateway`() {

--- a/apps/ios/UITests/OpenClawSnapshotUITests.swift
+++ b/apps/ios/UITests/OpenClawSnapshotUITests.swift
@@ -634,6 +634,19 @@ final class OpenClawSnapshotUITests: XCTestCase {
         self.attachScreenshot(named: "agent-toolbar-filter")
     }
 
+    func testLiveGatewayFreshInstallSetupAndRelaunch() throws {
+        try XCTSkipIf(UIDevice.current.userInterfaceIdiom != .phone, "Phone setup proof only")
+        let app = try self.launchPairedLiveGatewayApp(initialTab: "chat", initialDestination: "chat")
+        XCTAssertEqual(app.state, .runningForeground)
+
+        let controlApp = self.relaunchConnectedLiveGatewayApp(
+            initialTab: "control",
+            initialDestination: "control")
+        let overview = controlApp.buttons.containing(.staticText, identifier: "Overview").firstMatch
+        XCTAssertTrue(overview.waitForExistence(timeout: 8))
+        XCTAssertEqual(controlApp.state, .runningForeground)
+    }
+
     func testLiveGatewayChatRoundTripAndControlOverview() throws {
         try XCTSkipIf(UIDevice.current.userInterfaceIdiom != .phone, "Phone chat proof only")
         let app = try launchPairedLiveGatewayApp(initialTab: "chat", initialDestination: "chat")

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GenericPasswordKeychainStore.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GenericPasswordKeychainStore.swift
@@ -2,6 +2,28 @@ import Foundation
 import Security
 
 public enum GenericPasswordKeychainStore {
+    public struct MutationError: Error, Equatable, LocalizedError, Sendable {
+        public enum Operation: String, Equatable, Sendable {
+            case update
+            case add
+            case updateAfterAddConflict
+            case delete
+        }
+
+        public let operation: Operation
+        public let status: OSStatus
+
+        public init(operation: Operation, status: OSStatus) {
+            self.operation = operation
+            self.status = status
+        }
+
+        public var errorDescription: String? {
+            let message = SecCopyErrorMessageString(self.status, nil) as String? ?? "Unknown Security error"
+            return "Keychain \(self.operation.rawValue) failed (OSStatus \(self.status)): \(message)"
+        }
+    }
+
     public static func loadString(service: String, account: String) -> String? {
         guard let data = self.loadData(service: service, account: account) else { return nil }
         return String(data: data, encoding: .utf8)
@@ -14,14 +36,44 @@ public enum GenericPasswordKeychainStore {
         account: String,
         accessible: CFString = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly) -> Bool
     {
-        self.saveData(Data(value.utf8), service: service, account: account, accessible: accessible)
+        switch self.saveStringResult(value, service: service, account: account, accessible: accessible) {
+        case .success: true
+        case .failure: false
+        }
+    }
+
+    public static func saveStringResult(
+        _ value: String,
+        service: String,
+        account: String,
+        accessible: CFString = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly)
+        -> Result<Void, MutationError>
+    {
+        self.saveDataResult(
+            Data(value.utf8),
+            service: service,
+            account: account,
+            accessible: accessible,
+            updateItem: { SecItemUpdate($0, $1) },
+            addItem: { SecItemAdd($0, nil) })
     }
 
     @discardableResult
     public static func delete(service: String, account: String) -> Bool {
-        let query = self.baseQuery(service: service, account: account)
-        let status = SecItemDelete(query as CFDictionary)
-        return status == errSecSuccess || status == errSecItemNotFound
+        switch self.deleteResult(service: service, account: account) {
+        case .success: true
+        case .failure: false
+        }
+    }
+
+    public static func deleteResult(
+        service: String,
+        account: String) -> Result<Void, MutationError>
+    {
+        self.deleteResult(
+            service: service,
+            account: account,
+            deleteItem: { SecItemDelete($0) })
     }
 
     @discardableResult
@@ -45,36 +97,57 @@ public enum GenericPasswordKeychainStore {
         return data
     }
 
-    @discardableResult
-    private static func saveData(
+    static func saveDataResult(
         _ data: Data,
         service: String,
         account: String,
-        accessible: CFString) -> Bool
+        accessible: CFString,
+        updateItem: (CFDictionary, CFDictionary) -> OSStatus,
+        addItem: (CFDictionary) -> OSStatus) -> Result<Void, MutationError>
     {
         let query = self.baseQuery(service: service, account: account)
-        let previousData = self.loadData(service: service, account: account)
-
-        let deleteStatus = SecItemDelete(query as CFDictionary)
-        guard deleteStatus == errSecSuccess || deleteStatus == errSecItemNotFound else {
-            return false
+        let updates: [String: Any] = [
+            kSecValueData as String: data,
+            kSecAttrAccessible as String: accessible,
+        ]
+        let updateStatus = updateItem(query as CFDictionary, updates as CFDictionary)
+        if updateStatus == errSecSuccess {
+            return .success(())
+        }
+        guard updateStatus == errSecItemNotFound else {
+            return .failure(MutationError(operation: .update, status: updateStatus))
         }
 
         var insert = query
         insert[kSecValueData as String] = data
         insert[kSecAttrAccessible as String] = accessible
-        if SecItemAdd(insert as CFDictionary, nil) == errSecSuccess {
-            return true
+        let addStatus = addItem(insert as CFDictionary)
+        if addStatus == errSecSuccess {
+            return .success(())
+        }
+        guard addStatus == errSecDuplicateItem else {
+            return .failure(MutationError(operation: .add, status: addStatus))
         }
 
-        // Best-effort rollback: preserve prior value if replacement fails.
-        guard let previousData else { return false }
-        var rollback = query
-        rollback[kSecValueData as String] = previousData
-        rollback[kSecAttrAccessible as String] = accessible
-        _ = SecItemDelete(query as CFDictionary)
-        _ = SecItemAdd(rollback as CFDictionary, nil)
-        return false
+        // Another writer can create the item between update and add. Retry the
+        // canonical update so the replacement stays atomic and no value is deleted.
+        let retryStatus = updateItem(query as CFDictionary, updates as CFDictionary)
+        guard retryStatus == errSecSuccess else {
+            return .failure(MutationError(operation: .updateAfterAddConflict, status: retryStatus))
+        }
+        return .success(())
+    }
+
+    static func deleteResult(
+        service: String,
+        account: String,
+        deleteItem: (CFDictionary) -> OSStatus) -> Result<Void, MutationError>
+    {
+        let status = deleteItem(self.baseQuery(service: service, account: account) as CFDictionary)
+        guard status != errSecSuccess, status != errSecItemNotFound else {
+            return .success(())
+        }
+        return .failure(MutationError(operation: .delete, status: status))
     }
 
     private static func baseQuery(service: String, account: String) -> [String: Any] {

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GenericPasswordKeychainStoreTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GenericPasswordKeychainStoreTests.swift
@@ -1,0 +1,107 @@
+import Foundation
+import Security
+import Testing
+@testable import OpenClawKit
+
+struct GenericPasswordKeychainStoreTests {
+    @Test func `existing item is replaced with update only`() {
+        var updateCalls = 0
+        var addCalls = 0
+
+        let result = GenericPasswordKeychainStore.saveDataResult(
+            Data("replacement".utf8),
+            service: "test-service",
+            account: "test-account",
+            accessible: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
+            updateItem: { _, _ in
+                updateCalls += 1
+                return errSecSuccess
+            },
+            addItem: { _ in
+                addCalls += 1
+                return errSecSuccess
+            })
+
+        guard case .success = result else {
+            Issue.record("expected successful update")
+            return
+        }
+        #expect(updateCalls == 1)
+        #expect(addCalls == 0)
+    }
+
+    @Test func `missing item is added after update miss`() {
+        var addCalls = 0
+
+        let result = GenericPasswordKeychainStore.saveDataResult(
+            Data("new-value".utf8),
+            service: "test-service",
+            account: "test-account",
+            accessible: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
+            updateItem: { _, _ in errSecItemNotFound },
+            addItem: { _ in
+                addCalls += 1
+                return errSecSuccess
+            })
+
+        guard case .success = result else {
+            Issue.record("expected successful add")
+            return
+        }
+        #expect(addCalls == 1)
+    }
+
+    @Test func `add race retries atomic update`() {
+        var updateCalls = 0
+
+        let result = GenericPasswordKeychainStore.saveDataResult(
+            Data("raced-value".utf8),
+            service: "test-service",
+            account: "test-account",
+            accessible: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
+            updateItem: { _, _ in
+                updateCalls += 1
+                return updateCalls == 1 ? errSecItemNotFound : errSecSuccess
+            },
+            addItem: { _ in errSecDuplicateItem })
+
+        guard case .success = result else {
+            Issue.record("expected retry update to succeed")
+            return
+        }
+        #expect(updateCalls == 2)
+    }
+
+    @Test func `update failure preserves exact operation and status`() {
+        let result = GenericPasswordKeychainStore.saveDataResult(
+            Data("replacement".utf8),
+            service: "test-service",
+            account: "test-account",
+            accessible: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
+            updateItem: { _, _ in errSecInteractionNotAllowed },
+            addItem: { _ in
+                Issue.record("add must not run after a non-missing update failure")
+                return errSecSuccess
+            })
+
+        guard case let .failure(error) = result else {
+            Issue.record("expected update failure")
+            return
+        }
+        #expect(error == .init(operation: .update, status: errSecInteractionNotAllowed))
+        #expect(error.localizedDescription.contains("OSStatus \(errSecInteractionNotAllowed)"))
+    }
+
+    @Test func `delete failure preserves exact status`() {
+        let result = GenericPasswordKeychainStore.deleteResult(
+            service: "test-service",
+            account: "test-account",
+            deleteItem: { _ in errSecAuthFailed })
+
+        guard case let .failure(error) = result else {
+            Issue.record("expected delete failure")
+            return
+        }
+        #expect(error == .init(operation: .delete, status: errSecAuthFailed))
+    }
+}


### PR DESCRIPTION
Closes #107591

## What Problem This Solves

Fixes an issue where a fresh iOS setup could pair successfully and then disconnect with “Credential save failed” while completing the one-time setup credential handoff.

## Why This Change Was Made

Keychain replacements now use atomic update-or-add semantics with typed OSStatus diagnostics. After device auth succeeds, iOS first overwrites the pending setup bundle with its safe completed state, then treats deletion as cleanup only when readback proves no reusable setup credential remains.

The change also adds a focused live fresh-setup/relaunch UI smoke test, deterministic Keychain mutation tests, and a deferred-deletion regression test.

## User Impact

Fresh iOS installs can finish setup and reconnect after relaunch without being disconnected solely because Keychain cleanup was deferred.

## Evidence

- Live iOS simulator + isolated real gateway: `testLiveGatewayFreshInstallSetupAndRelaunch` passed (1/1), including setup-code pairing and relaunch with stored device auth.
- `swift test --package-path apps/shared/OpenClawKit --filter GenericPasswordKeychainStoreTests` — 5/5 passed.
- Focused Xcode run for `GatewaySettingsStoreTests` and `GatewayConnectionControllerTests` — 100/100 passed.
- `./scripts/lint-swift.sh ios` — 0 violations.
- Blacksmith Testbox `pnpm check:changed` — passed: https://github.com/openclaw/openclaw/actions/runs/29483711780
- Autoreview — clean, no accepted/actionable findings.
