### PR TITLE
fix(inworld): treat blank env API key as unconfigured in speech provider

### DIFF
--- a/extensions/inworld/speech-provider.test.ts
+++ b/extensions/inworld/speech-provider.test.ts
@@ -63,15 +63,49 @@ describe("buildInworldSpeechProvider", () => {
     ).toBe(false);
   });
 
-  it("reports not configured when INWORLD_API_KEY is whitespace only", () => {
+  it("rejects blank API keys across every request entrypoint", async () => {
     vi.stubEnv("INWORLD_API_KEY", "   ");
     const provider = buildInworldSpeechProvider();
+    const listVoices = provider.listVoices;
+    const synthesizeTelephony = provider.synthesizeTelephony;
+    if (!listVoices || !synthesizeTelephony) {
+      throw new Error("expected Inworld voice listing and telephony synthesis");
+    }
+
     expect(
       provider.isConfigured({
-        providerConfig: {},
+        providerConfig: { apiKey: "   " },
         timeoutMs: 30_000,
       }),
     ).toBe(false);
+
+    await expect(
+      listVoices({
+        providerConfig: {},
+        apiKey: "   ",
+        timeoutMs: 5_000,
+      }),
+    ).rejects.toThrow("Inworld API key missing");
+    await expect(
+      provider.synthesize({
+        text: "test",
+        cfg: {} as never,
+        providerConfig: {},
+        target: "audio-file",
+        timeoutMs: 5_000,
+      }),
+    ).rejects.toThrow("Inworld API key missing");
+    await expect(
+      synthesizeTelephony({
+        text: "test",
+        cfg: {} as never,
+        providerConfig: {},
+        timeoutMs: 5_000,
+      }),
+    ).rejects.toThrow("Inworld API key missing");
+
+    expect(listInworldVoicesMock).not.toHaveBeenCalled();
+    expect(inworldTTSMock).not.toHaveBeenCalled();
   });
 
   it("has correct provider metadata", () => {
@@ -290,19 +324,5 @@ describe("buildInworldSpeechProvider", () => {
       outputFormat: "pcm",
       sampleRate: 22_050,
     });
-  });
-
-  it("throws when INWORLD_API_KEY is whitespace only", async () => {
-    vi.stubEnv("INWORLD_API_KEY", "   ");
-    const provider = buildInworldSpeechProvider();
-    await expect(
-      provider.synthesize({
-        text: "test",
-        cfg: {} as never,
-        providerConfig: {},
-        target: "audio-file",
-        timeoutMs: 5_000,
-      }),
-    ).rejects.toThrow("Inworld API key missing");
   });
 });

--- a/extensions/inworld/speech-provider.test.ts
+++ b/extensions/inworld/speech-provider.test.ts
@@ -63,6 +63,17 @@ describe("buildInworldSpeechProvider", () => {
     ).toBe(false);
   });
 
+  it("reports not configured when INWORLD_API_KEY is whitespace only", () => {
+    vi.stubEnv("INWORLD_API_KEY", "   ");
+    const provider = buildInworldSpeechProvider();
+    expect(
+      provider.isConfigured({
+        providerConfig: {},
+        timeoutMs: 30_000,
+      }),
+    ).toBe(false);
+  });
+
   it("has correct provider metadata", () => {
     const provider = buildInworldSpeechProvider();
     expect(provider.id).toBe("inworld");
@@ -279,5 +290,19 @@ describe("buildInworldSpeechProvider", () => {
       outputFormat: "pcm",
       sampleRate: 22_050,
     });
+  });
+
+  it("throws when INWORLD_API_KEY is whitespace only", async () => {
+    vi.stubEnv("INWORLD_API_KEY", "   ");
+    const provider = buildInworldSpeechProvider();
+    await expect(
+      provider.synthesize({
+        text: "test",
+        cfg: {} as never,
+        providerConfig: {},
+        target: "audio-file",
+        timeoutMs: 5_000,
+      }),
+    ).rejects.toThrow("Inworld API key missing");
   });
 });

--- a/extensions/inworld/speech-provider.ts
+++ b/extensions/inworld/speech-provider.ts
@@ -164,7 +164,7 @@ export function buildInworldSpeechProvider(): SpeechProviderPlugin {
     }),
     listVoices: async (req) => {
       const config = req.providerConfig ? readInworldProviderConfig(req.providerConfig) : undefined;
-      const apiKey = req.apiKey || config?.apiKey || process.env.INWORLD_API_KEY;
+      const apiKey = req.apiKey || config?.apiKey || trimToUndefined(process.env.INWORLD_API_KEY);
       if (!apiKey) {
         throw new Error("Inworld API key missing");
       }
@@ -175,11 +175,14 @@ export function buildInworldSpeechProvider(): SpeechProviderPlugin {
       });
     },
     isConfigured: ({ providerConfig }) =>
-      Boolean(readInworldProviderConfig(providerConfig).apiKey || process.env.INWORLD_API_KEY),
+      Boolean(
+        readInworldProviderConfig(providerConfig).apiKey ||
+        trimToUndefined(process.env.INWORLD_API_KEY),
+      ),
     synthesize: async (req) => {
       const config = readInworldProviderConfig(req.providerConfig);
       const overrides = readInworldOverrides(req.providerOverrides);
-      const apiKey = config.apiKey || process.env.INWORLD_API_KEY;
+      const apiKey = config.apiKey || trimToUndefined(process.env.INWORLD_API_KEY);
       if (!apiKey) {
         throw new Error("Inworld API key missing");
       }
@@ -208,7 +211,7 @@ export function buildInworldSpeechProvider(): SpeechProviderPlugin {
     synthesizeTelephony: async (req) => {
       const config = readInworldProviderConfig(req.providerConfig);
       const overrides = readInworldOverrides(req.providerOverrides);
-      const apiKey = config.apiKey || process.env.INWORLD_API_KEY;
+      const apiKey = config.apiKey || trimToUndefined(process.env.INWORLD_API_KEY);
       if (!apiKey) {
         throw new Error("Inworld API key missing");
       }

--- a/extensions/inworld/speech-provider.ts
+++ b/extensions/inworld/speech-provider.ts
@@ -9,6 +9,7 @@ import type {
 import {
   asObject,
   parseSpeechDirectiveNumberOverride,
+  resolveSpeechProviderApiKey,
   trimToUndefined,
 } from "openclaw/plugin-sdk/speech-core";
 import { asFiniteNumberInRange } from "openclaw/plugin-sdk/string-coerce-runtime";
@@ -64,6 +65,10 @@ function readInworldProviderConfig(config: SpeechProviderConfig): InworldProvide
     modelId: trimToUndefined(config.modelId) ?? defaults.modelId,
     temperature: normalizeInworldTemperature(config.temperature) ?? defaults.temperature,
   };
+}
+
+function resolveInworldApiKey(primary?: string, fallback?: string): string | undefined {
+  return resolveSpeechProviderApiKey(primary, fallback, process.env.INWORLD_API_KEY);
 }
 
 function readInworldOverrides(
@@ -164,7 +169,7 @@ export function buildInworldSpeechProvider(): SpeechProviderPlugin {
     }),
     listVoices: async (req) => {
       const config = req.providerConfig ? readInworldProviderConfig(req.providerConfig) : undefined;
-      const apiKey = req.apiKey || config?.apiKey || trimToUndefined(process.env.INWORLD_API_KEY);
+      const apiKey = resolveInworldApiKey(req.apiKey, config?.apiKey);
       if (!apiKey) {
         throw new Error("Inworld API key missing");
       }
@@ -175,14 +180,11 @@ export function buildInworldSpeechProvider(): SpeechProviderPlugin {
       });
     },
     isConfigured: ({ providerConfig }) =>
-      Boolean(
-        readInworldProviderConfig(providerConfig).apiKey ||
-        trimToUndefined(process.env.INWORLD_API_KEY),
-      ),
+      Boolean(resolveInworldApiKey(readInworldProviderConfig(providerConfig).apiKey)),
     synthesize: async (req) => {
       const config = readInworldProviderConfig(req.providerConfig);
       const overrides = readInworldOverrides(req.providerOverrides);
-      const apiKey = config.apiKey || trimToUndefined(process.env.INWORLD_API_KEY);
+      const apiKey = resolveInworldApiKey(config.apiKey);
       if (!apiKey) {
         throw new Error("Inworld API key missing");
       }
@@ -211,7 +213,7 @@ export function buildInworldSpeechProvider(): SpeechProviderPlugin {
     synthesizeTelephony: async (req) => {
       const config = readInworldProviderConfig(req.providerConfig);
       const overrides = readInworldOverrides(req.providerOverrides);
-      const apiKey = config.apiKey || trimToUndefined(process.env.INWORLD_API_KEY);
+      const apiKey = resolveInworldApiKey(config.apiKey);
       if (!apiKey) {
         throw new Error("Inworld API key missing");
       }


### PR DESCRIPTION
## What Problem This Solves

A whitespace-only `INWORLD_API_KEY` made the Inworld speech provider report configured, then sent an unusable HTTP Basic credential from synthesis, telephony synthesis, and voice listing.

## Why This Change Was Made

- Route request, provider-config, and environment credentials through one Inworld resolver backed by the shared speech-provider API-key normalizer.
- Use that resolver from all four entrypoints: `listVoices`, `isConfigured`, `synthesize`, and `synthesizeTelephony`.
- Reject blank credentials before the Inworld provider clients or network layer run.

## User Impact

Whitespace-only credentials no longer select Inworld or reach request construction. Nonblank request/config/environment precedence is unchanged.

## Evidence

Production-entrypoint probe, importing `buildInworldSpeechProvider` and replacing global fetch with a call counter:

```text
$ mise exec node@24 -- node --import tsx .local/inworld-blank-key-proof.ts
configured=false
voices=Inworld API key missing
synthesis=Inworld API key missing
telephony=Inworld API key missing
fetchCalls=0
```

Focused regression:

```text
$ node scripts/run-vitest.mjs extensions/inworld/speech-provider.test.ts
Test Files  1 passed (1)
Tests  13 passed (13)
```

Hosted changed-file gate: format, SDK API baseline, extension and extension-test typechecks, lint, plugin boundaries, and runtime guards passed in [Blacksmith Testbox](https://github.com/openclaw/openclaw/actions/runs/29498972577).

## Risk / Compatibility

Low. The change only normalizes credential presence at the provider owner boundary and preserves existing precedence and HTTP Basic credential handling.

AI-assisted: contributor patch and maintainer rewrite used coding agents.
