### PR TITLE
fix(qa): label static scorecard data as inventory

### DIFF
--- a/extensions/qa-lab/src/coverage-report.test.ts
+++ b/extensions/qa-lab/src/coverage-report.test.ts
@@ -207,9 +207,9 @@ describe("qa coverage report", () => {
       inventory.scorecardTaxonomy.categoryCount,
     );
     expect(inventory.scorecardTaxonomy.requiredCoverageIdCount).toBeGreaterThan(0);
-    expect(inventory.scorecardTaxonomy.fulfilledCoverageIdCount).toBeGreaterThan(0);
-    expect(inventory.scorecardTaxonomy.coverageIdFulfillmentPercent).toBeGreaterThan(0);
-    expect(inventory.scorecardTaxonomy.evidenceRefCount).toBeGreaterThan(0);
+    expect(inventory.scorecardTaxonomy.inventoriedCoverageIdCount).toBeGreaterThan(0);
+    expect(inventory.scorecardTaxonomy.coverageIdInventoryPercent).toBeGreaterThan(0);
+    expect(inventory.scorecardTaxonomy.inventoryRefCount).toBeGreaterThan(0);
     expect(inventory.scorecardTaxonomy.scenarioCoverageIdCount).toBeGreaterThan(0);
     expect(inventory.scorecardTaxonomy.unknownCoverageIdCount).toBe(0);
     expect(
@@ -225,13 +225,13 @@ describe("qa coverage report", () => {
     ).toBe(false);
     expect(
       inventory.scorecardTaxonomy.validationIssues.some(
-        (issue) => issue.code === "coverage-id-missing-primary-evidence",
+        (issue) => issue.code === "coverage-id-missing-primary-inventory",
       ),
     ).toBe(true);
     expect(
       inventory.scorecardTaxonomy.categories.find(
         (category) => category.id === TEST_BROWSER_CATEGORY_ID,
-      )?.evidence,
+      )?.inventoryRefs,
     ).toContainEqual({
       coverageId: TEST_BROWSER_COVERAGE_ID,
       kind: "playwright",
@@ -302,9 +302,9 @@ describe("qa coverage report", () => {
     expect(report).toContain("personal-share-safe-diagnostics-artifact");
     expect(report).toContain("## Scorecard Taxonomy");
     expect(report).toContain("- Taxonomy: taxonomy.yaml");
-    expect(report).toContain("- Fulfilled taxonomy categories:");
-    expect(report).toContain("- Fulfilled taxonomy coverage IDs:");
-    expect(report).toContain("- Evidence refs:");
+    expect(report).toContain("- Inventoried taxonomy categories:");
+    expect(report).toContain("- Inventoried taxonomy coverage IDs:");
+    expect(report).toContain("- Inventory refs:");
     expect(report).toContain("- Scenario coverage IDs:");
     expect(report).toContain(
       "- browser-automation-and-exec-sandbox-tools.tool-invocation-and-execution (browser-automation-and-exec-sandbox-tools / Tool Invocation and Execution; partial): profiles: all, release, smoke-ci; coverage IDs:",
@@ -439,7 +439,7 @@ describe("qa coverage report", () => {
     );
   });
 
-  it("reports missing taxonomy coverage refs without treating them as fulfilled", () => {
+  it("reports missing taxonomy coverage refs without treating them as inventoried", () => {
     const report = buildQaScorecardTaxonomyReport({
       taxonomy: testMaturityTaxonomy(),
       repoRoot: process.cwd(),
@@ -450,16 +450,16 @@ describe("qa coverage report", () => {
       ],
     });
 
-    expect(report.fulfilledCoverageIdCount).toBe(0);
-    expect(report.categories[0]?.coverageStatus).toBe("missing");
+    expect(report.inventoriedCoverageIdCount).toBe(0);
+    expect(report.categories[0]?.inventoryStatus).toBe("missing");
     expect(report.validationIssues.map((issue) => issue.code)).toEqual([
       "coverage-id-not-found",
-      "coverage-id-missing-primary-evidence",
-      "profile-category-missing-evidence",
+      "coverage-id-missing-primary-inventory",
+      "profile-category-missing-inventory",
     ]);
   });
 
-  it("uses explicit native test evidence as coverage fulfillment", () => {
+  it("inventories explicit native test declarations", () => {
     const report = buildQaScorecardTaxonomyReport({
       taxonomy: testMaturityTaxonomy({
         categoryId: TEST_BROWSER_CATEGORY_ID,
@@ -477,13 +477,13 @@ describe("qa coverage report", () => {
     });
 
     expect(report.validationIssues).toStrictEqual([]);
-    expect(report.fulfilledCategoryCount).toBe(1);
-    expect(report.fulfilledCoverageIdCount).toBe(1);
-    expect(report.categories[0]?.coverageStatus).toBe("covered");
+    expect(report.inventoriedCategoryCount).toBe(1);
+    expect(report.inventoriedCoverageIdCount).toBe(1);
+    expect(report.categories[0]?.inventoryStatus).toBe("complete");
     expect(report.categories[0]?.scenarioRefs).toStrictEqual([
       "qa/scenarios/ui/control-ui-chat-flow-playwright.yaml",
     ]);
-    expect(report.categories[0]?.evidence).toStrictEqual([
+    expect(report.categories[0]?.inventoryRefs).toStrictEqual([
       {
         coverageId: TEST_BROWSER_COVERAGE_ID,
         kind: "playwright",
@@ -494,7 +494,7 @@ describe("qa coverage report", () => {
     ]);
   });
 
-  it("counts partial coverage IDs proportionately for taxonomy fulfillment", () => {
+  it("counts partial coverage IDs proportionately for taxonomy inventory", () => {
     const report = buildQaScorecardTaxonomyReport({
       taxonomy: testMaturityTaxonomy({
         featureCoverageIds: [[TEST_EXECUTABLE_COVERAGE_ID, TEST_WEBCHAT_COVERAGE_ID]],
@@ -509,15 +509,17 @@ describe("qa coverage report", () => {
       ],
     });
 
-    expect(report.fulfilledCategoryCount).toBe(0);
+    expect(report.inventoriedCategoryCount).toBe(0);
     expect(report.requiredCoverageIdCount).toBe(2);
-    expect(report.fulfilledCoverageIdCount).toBe(1);
-    expect(report.coverageIdFulfillmentPercent).toBe(50);
-    expect(report.categories[0]?.coverageStatus).toBe("partial");
-    expect(report.categories[0]?.fulfilledCoverageIds).toStrictEqual([TEST_EXECUTABLE_COVERAGE_ID]);
+    expect(report.inventoriedCoverageIdCount).toBe(1);
+    expect(report.coverageIdInventoryPercent).toBe(50);
+    expect(report.categories[0]?.inventoryStatus).toBe("partial");
+    expect(report.categories[0]?.inventoriedCoverageIds).toStrictEqual([
+      TEST_EXECUTABLE_COVERAGE_ID,
+    ]);
     expect(report.validationIssues).toContainEqual(
       expect.objectContaining({
-        code: "coverage-id-missing-primary-evidence",
+        code: "coverage-id-missing-primary-inventory",
         ref: TEST_WEBCHAT_COVERAGE_ID,
       }),
     );
@@ -588,11 +590,11 @@ describe("qa coverage report", () => {
     });
 
     expect(report.requiredCoverageIdCount).toBe(2);
-    expect(report.fulfilledCoverageIdCount).toBe(1);
-    expect(report.coverageIdFulfillmentPercent).toBe(50);
+    expect(report.inventoriedCoverageIdCount).toBe(1);
+    expect(report.coverageIdInventoryPercent).toBe(50);
   });
 
-  it("uses script producer evidence as coverage fulfillment", () => {
+  it("inventories script producer declarations", () => {
     const report = buildQaScorecardTaxonomyReport({
       taxonomy: testMaturityTaxonomy({
         categoryId: TEST_BROWSER_CATEGORY_ID,
@@ -610,9 +612,9 @@ describe("qa coverage report", () => {
     });
 
     expect(report.validationIssues).toStrictEqual([]);
-    expect(report.fulfilledCategoryCount).toBe(1);
-    expect(report.fulfilledCoverageIdCount).toBe(1);
-    expect(report.categories[0]?.evidence).toStrictEqual([
+    expect(report.inventoriedCategoryCount).toBe(1);
+    expect(report.inventoriedCoverageIdCount).toBe(1);
+    expect(report.categories[0]?.inventoryRefs).toStrictEqual([
       {
         coverageId: TEST_BROWSER_COVERAGE_ID,
         kind: "script",
@@ -643,7 +645,7 @@ describe("qa coverage report", () => {
     );
   });
 
-  it("reports profile categories missing primary coverage evidence", () => {
+  it("reports profile categories missing primary coverage inventory", () => {
     const report = buildQaScorecardTaxonomyReport({
       taxonomy: testMaturityTaxonomy(),
       repoRoot: process.cwd(),
@@ -651,12 +653,12 @@ describe("qa coverage report", () => {
     });
 
     expect(report.validationIssues.map((issue) => issue.code)).toEqual([
-      "coverage-id-missing-primary-evidence",
-      "profile-category-missing-evidence",
+      "coverage-id-missing-primary-inventory",
+      "profile-category-missing-inventory",
     ]);
   });
 
-  it("reports native test evidence refs outside the repository", () => {
+  it("reports native test inventory targets outside the repository", () => {
     const report = buildQaScorecardTaxonomyReport({
       taxonomy: testMaturityTaxonomy(),
       repoRoot: process.cwd(),
@@ -670,13 +672,13 @@ describe("qa coverage report", () => {
     });
 
     expect(report.validationIssues.map((issue) => issue.code)).toEqual([
-      "evidence-ref-not-found",
-      "coverage-id-missing-primary-evidence",
-      "profile-category-missing-evidence",
+      "inventory-ref-not-found",
+      "coverage-id-missing-primary-inventory",
+      "profile-category-missing-inventory",
     ]);
   });
 
-  it("uses scenario coverage metadata as runnable scenario evidence", () => {
+  it("inventories runnable scenario coverage metadata", () => {
     const report = buildQaScorecardTaxonomyReport({
       taxonomy: testMaturityTaxonomy(),
       repoRoot: process.cwd(),
@@ -692,7 +694,7 @@ describe("qa coverage report", () => {
     expect(report.categories[0]?.scenarioRefs).toStrictEqual([
       "qa/scenarios/channels/dm-chat-baseline.yaml",
     ]);
-    expect(report.categories[0]?.evidence).toStrictEqual([
+    expect(report.categories[0]?.inventoryRefs).toStrictEqual([
       {
         coverageId: TEST_EXECUTABLE_COVERAGE_ID,
         kind: "qa-scenario",
@@ -703,7 +705,7 @@ describe("qa coverage report", () => {
     ]);
   });
 
-  it("counts secondary scenario metadata as evidence but not fulfillment", () => {
+  it("counts secondary scenario metadata as inventory but not primary inventory", () => {
     const report = buildQaScorecardTaxonomyReport({
       taxonomy: testMaturityTaxonomy(),
       repoRoot: process.cwd(),
@@ -715,12 +717,12 @@ describe("qa coverage report", () => {
       ],
     });
 
-    expect(report.fulfilledCoverageIdCount).toBe(0);
-    expect(report.categories[0]?.coverageStatus).toBe("partial");
+    expect(report.inventoriedCoverageIdCount).toBe(0);
+    expect(report.categories[0]?.inventoryStatus).toBe("partial");
     expect(report.validationIssues.map((issue) => issue.code)).toEqual([
       "coverage-id-not-found",
-      "coverage-id-missing-primary-evidence",
-      "profile-category-missing-evidence",
+      "coverage-id-missing-primary-inventory",
+      "profile-category-missing-inventory",
     ]);
   });
 });

--- a/extensions/qa-lab/src/coverage-report.ts
+++ b/extensions/qa-lab/src/coverage-report.ts
@@ -323,12 +323,12 @@ function pushScorecardTaxonomyLines(lines: string[], report: QaScorecardTaxonomy
   lines.push(`- Categories: ${report.categoryCount}`);
   lines.push(`- Profiles: ${report.profileCount}`);
   lines.push(
-    `- Fulfilled taxonomy categories: ${report.fulfilledCategoryCount}/${report.requiredCategoryCount} (${report.categoryFulfillmentPercent}%)`,
+    `- Inventoried taxonomy categories: ${report.inventoriedCategoryCount}/${report.requiredCategoryCount} (${report.categoryInventoryPercent}%)`,
   );
   lines.push(
-    `- Fulfilled taxonomy coverage IDs: ${report.fulfilledCoverageIdCount}/${report.requiredCoverageIdCount} (${report.coverageIdFulfillmentPercent}%)`,
+    `- Inventoried taxonomy coverage IDs: ${report.inventoriedCoverageIdCount}/${report.requiredCoverageIdCount} (${report.coverageIdInventoryPercent}%)`,
   );
-  lines.push(`- Evidence refs: ${report.evidenceRefCount}`);
+  lines.push(`- Inventory refs: ${report.inventoryRefCount}`);
   lines.push(`- Scenario coverage IDs: ${report.scenarioCoverageIdCount}`);
   lines.push(`- Unknown scenario coverage IDs: ${report.unknownCoverageIdCount}`);
   lines.push(`- Validation warnings: ${report.validationIssueCount}`, "");
@@ -343,13 +343,13 @@ function pushScorecardTaxonomyLines(lines: string[], report: QaScorecardTaxonomy
   }
 
   if (report.categories.length > 0) {
-    lines.push("### Category Coverage", "");
+    lines.push("### Category Inventory", "");
     for (const category of report.categories) {
       const coverageIds =
         category.coverageIds.length > 0 ? category.coverageIds.join(", ") : "none";
-      const evidence =
-        category.evidence.length > 0
-          ? category.evidence
+      const inventoryRefs =
+        category.inventoryRefs.length > 0
+          ? category.inventoryRefs
               .map((ref) => {
                 const target = ref.path ?? (ref.scenarioRefs.join("|") || "discovered");
                 return `${ref.role}:${ref.kind}:${target} (${ref.coverageId})`;
@@ -358,7 +358,7 @@ function pushScorecardTaxonomyLines(lines: string[], report: QaScorecardTaxonomy
           : "none";
       const profiles = category.profiles.length > 0 ? category.profiles.join(", ") : "none";
       lines.push(
-        `- ${category.id} (${category.taxonomySurfaceId} / ${category.taxonomyCategoryName}; ${category.coverageStatus}): profiles: ${profiles}; coverage IDs: ${coverageIds}; evidence: ${evidence}`,
+        `- ${category.id} (${category.taxonomySurfaceId} / ${category.taxonomyCategoryName}; ${category.inventoryStatus}): profiles: ${profiles}; coverage IDs: ${coverageIds}; inventory refs: ${inventoryRefs}`,
       );
     }
     lines.push("");

--- a/extensions/qa-lab/src/scorecard-evidence.test.ts
+++ b/extensions/qa-lab/src/scorecard-evidence.test.ts
@@ -45,15 +45,15 @@ function categoryInventory(coverageIds: string[]): QaScorecardCategoryCoverageRe
     id: "surface.category",
     taxonomySurfaceId: "surface",
     taxonomyCategoryName: "Category",
-    coverageStatus: "covered",
+    inventoryStatus: "complete",
     profiles: ["release"],
     features: coverageIds.map((coverageId) => ({ name: coverageId, coverageIds: [coverageId] })),
     coverageIds,
-    fulfilledCoverageIds: coverageIds,
-    evidence: [],
+    inventoriedCoverageIds: coverageIds,
+    inventoryRefs: [],
     scenarioRefs: [],
     missingCoverageIds: [],
-    missingEvidenceRefs: [],
+    missingInventoryRefs: [],
   };
 }
 
@@ -87,15 +87,15 @@ describe("profile scorecard evidence", () => {
       id: "surface.category",
       taxonomySurfaceId: "surface",
       taxonomyCategoryName: "Category",
-      coverageStatus: "partial",
+      inventoryStatus: "partial",
       profiles: ["release"],
       features: [{ name: "Multi-id feature", coverageIds: ["coverage.one", "coverage.two"] }],
       coverageIds: ["coverage.one", "coverage.two"],
-      fulfilledCoverageIds: ["coverage.one"],
-      evidence: [],
+      inventoriedCoverageIds: ["coverage.one"],
+      inventoryRefs: [],
       scenarioRefs: [],
       missingCoverageIds: ["coverage.two"],
-      missingEvidenceRefs: [],
+      missingInventoryRefs: [],
     };
 
     const { scorecard } = await buildQaProfileScorecardEvidence({
@@ -150,18 +150,18 @@ describe("profile scorecard evidence", () => {
       id: "surface.first",
       taxonomySurfaceId: "surface",
       taxonomyCategoryName: "First",
-      coverageStatus: "partial",
+      inventoryStatus: "partial",
       profiles: ["release"],
       features: [
         { name: "Shared", coverageIds: ["coverage.shared"] },
         { name: "Unique", coverageIds: ["coverage.unique"] },
       ],
       coverageIds: ["coverage.shared", "coverage.unique"],
-      fulfilledCoverageIds: ["coverage.shared"],
-      evidence: [],
+      inventoriedCoverageIds: ["coverage.shared"],
+      inventoryRefs: [],
       scenarioRefs: [],
       missingCoverageIds: ["coverage.unique"],
-      missingEvidenceRefs: [],
+      missingInventoryRefs: [],
     };
     const secondCategory: QaScorecardCategoryCoverageReport = {
       ...firstCategory,

--- a/extensions/qa-lab/src/scorecard-taxonomy.ts
+++ b/extensions/qa-lab/src/scorecard-taxonomy.ts
@@ -314,13 +314,13 @@ export type QaMaturityCoverageScores = {
 };
 
 type QaScorecardValidationIssueCode =
-  | "coverage-id-missing-primary-evidence"
+  | "coverage-id-missing-primary-inventory"
   | "coverage-id-not-found"
-  | "evidence-ref-not-found"
+  | "inventory-ref-not-found"
   | "taxonomy-ref-not-found"
   | "taxonomy-category-ref-not-found"
   | "profile-category-ref-not-found"
-  | "profile-category-missing-evidence";
+  | "profile-category-missing-inventory";
 
 type QaScorecardValidationIssue = {
   code: QaScorecardValidationIssueCode;
@@ -330,7 +330,7 @@ type QaScorecardValidationIssue = {
   message: string;
 };
 
-type QaScorecardEvidenceReport = {
+type QaScorecardInventoryRef = {
   coverageId: string;
   kind: QaScorecardEvidenceKind;
   path: string | null;
@@ -342,15 +342,15 @@ export type QaScorecardCategoryCoverageReport = {
   id: string;
   taxonomySurfaceId: string;
   taxonomyCategoryName: string;
-  coverageStatus: "covered" | "partial" | "missing";
+  inventoryStatus: "complete" | "partial" | "missing";
   profiles: string[];
   features: QaScorecardCategoryFeatureCoverageReport[];
   coverageIds: string[];
-  fulfilledCoverageIds: string[];
-  evidence: QaScorecardEvidenceReport[];
+  inventoriedCoverageIds: string[];
+  inventoryRefs: QaScorecardInventoryRef[];
   scenarioRefs: string[];
   missingCoverageIds: string[];
-  missingEvidenceRefs: string[];
+  missingInventoryRefs: string[];
 };
 
 type QaScorecardCategoryFeatureCoverageReport = {
@@ -375,12 +375,12 @@ export type QaScorecardTaxonomyReport = {
   profiles: QaScorecardProfileReport[];
   categoryCount: number;
   requiredCategoryCount: number;
-  fulfilledCategoryCount: number;
-  categoryFulfillmentPercent: number;
+  inventoriedCategoryCount: number;
+  categoryInventoryPercent: number;
   requiredCoverageIdCount: number;
-  fulfilledCoverageIdCount: number;
-  coverageIdFulfillmentPercent: number;
-  evidenceRefCount: number;
+  inventoriedCoverageIdCount: number;
+  coverageIdInventoryPercent: number;
+  inventoryRefCount: number;
   scenarioCoverageIdCount: number;
   unknownCoverageIdCount: number;
   unknownCoverageIds: string[];
@@ -497,25 +497,25 @@ function scenarioCoverageIds(scenario: QaSeedScenarioWithSource) {
   return [...(scenario.coverage?.primary ?? []), ...(scenario.coverage?.secondary ?? [])];
 }
 
-type ScenarioEvidenceRef = {
+type ScenarioInventoryRef = {
   sourcePath: string;
   kind: QaScorecardEvidenceKind;
   path: string | null;
 };
 
-function scenarioEvidenceKind(scenario: QaSeedScenarioWithSource): QaScorecardEvidenceKind {
+function scenarioInventoryKind(scenario: QaSeedScenarioWithSource): QaScorecardEvidenceKind {
   return scenario.execution.kind === "flow" ? "qa-scenario" : scenario.execution.kind;
 }
 
-function scenarioEvidencePath(scenario: QaSeedScenarioWithSource) {
+function scenarioInventoryPath(scenario: QaSeedScenarioWithSource) {
   return scenario.execution.kind === "flow" ? null : scenario.execution.path;
 }
 
-function collectScenarioEvidenceByCoverageId(params: {
+function collectScenarioInventoryByCoverageId(params: {
   scenarios: readonly QaSeedScenarioWithSource[];
   role: QaCoverageEvidenceRole;
 }) {
-  const refsByCoverageId = new Map<string, ScenarioEvidenceRef[]>();
+  const refsByCoverageId = new Map<string, ScenarioInventoryRef[]>();
   for (const scenario of params.scenarios) {
     const coverageIds =
       params.role === "primary"
@@ -525,8 +525,8 @@ function collectScenarioEvidenceByCoverageId(params: {
       const refs = refsByCoverageId.get(coverageId) ?? [];
       refs.push({
         sourcePath: scenario.sourcePath,
-        kind: scenarioEvidenceKind(scenario),
-        path: scenarioEvidencePath(scenario),
+        kind: scenarioInventoryKind(scenario),
+        path: scenarioInventoryPath(scenario),
       });
       refsByCoverageId.set(coverageId, refs);
     }
@@ -802,22 +802,22 @@ export function readQaScorecardProfileOptions(profileId: string | undefined, rep
   };
 }
 
-function pushMissingPrimaryIssues(params: {
+function pushMissingPrimaryInventoryIssues(params: {
   issues: QaScorecardValidationIssue[];
   category: MaturityCategoryRef;
-  coverageIdsWithPrimaryEvidence: ReadonlySet<string>;
-  coverageIdsWithSecondaryEvidence: ReadonlySet<string>;
+  coverageIdsWithPrimaryInventory: ReadonlySet<string>;
+  coverageIdsWithSecondaryInventory: ReadonlySet<string>;
 }) {
   for (const feature of params.category.features) {
     for (const coverageId of feature.coverageIds) {
-      if (params.coverageIdsWithPrimaryEvidence.has(coverageId)) {
+      if (params.coverageIdsWithPrimaryInventory.has(coverageId)) {
         continue;
       }
-      const reason = params.coverageIdsWithSecondaryEvidence.has(coverageId)
-        ? "only has secondary evidence"
-        : "has no primary evidence";
+      const reason = params.coverageIdsWithSecondaryInventory.has(coverageId)
+        ? "only has a secondary inventory entry"
+        : "has no primary inventory entry";
       params.issues.push({
-        code: "coverage-id-missing-primary-evidence",
+        code: "coverage-id-missing-primary-inventory",
         severity: "warning",
         categoryId: params.category.id,
         ref: coverageId,
@@ -827,28 +827,28 @@ function pushMissingPrimaryIssues(params: {
   }
 }
 
-function collectEvidenceReportsForCoverageId(params: {
+function collectInventoryRefsForCoverageId(params: {
   coverageId: string;
   role: QaCoverageEvidenceRole;
-  refs: readonly ScenarioEvidenceRef[];
+  refs: readonly ScenarioInventoryRef[];
   repoRoot?: string;
   categoryId: string;
   issues: QaScorecardValidationIssue[];
-  missingEvidenceRefsByCategoryId: Map<string, Set<string>>;
+  missingInventoryRefsByCategoryId: Map<string, Set<string>>;
 }) {
-  const grouped = new Map<string, QaScorecardEvidenceReport>();
+  const grouped = new Map<string, QaScorecardInventoryRef>();
   for (const ref of params.refs) {
     if (ref.path && !pathExists(params.repoRoot, ref.path)) {
       const missingRefs =
-        params.missingEvidenceRefsByCategoryId.get(params.categoryId) ?? new Set();
+        params.missingInventoryRefsByCategoryId.get(params.categoryId) ?? new Set();
       missingRefs.add(ref.path);
-      params.missingEvidenceRefsByCategoryId.set(params.categoryId, missingRefs);
+      params.missingInventoryRefsByCategoryId.set(params.categoryId, missingRefs);
       params.issues.push({
-        code: "evidence-ref-not-found",
+        code: "inventory-ref-not-found",
         severity: "warning",
         categoryId: params.categoryId,
         ref: ref.path,
-        message: `${params.categoryId} references missing ${ref.kind} evidence ${ref.path}`,
+        message: `${params.categoryId} references missing ${ref.kind} inventory target ${ref.path}`,
       });
       continue;
     }
@@ -862,7 +862,7 @@ function collectEvidenceReportsForCoverageId(params: {
         path: ref.path,
         role: params.role,
         scenarioRefs: [],
-      } satisfies QaScorecardEvidenceReport);
+      } satisfies QaScorecardInventoryRef);
     report.scenarioRefs.push(ref.sourcePath);
     grouped.set(key, report);
   }
@@ -882,16 +882,16 @@ function buildQaScorecardTaxonomyReport(params: {
   const maturityRefs = buildMaturityRefs(params.taxonomy);
   const issues: QaScorecardValidationIssue[] = [];
   const categories: QaScorecardCategoryCoverageReport[] = [];
-  const primaryScenarioRefsByCoverageId = collectScenarioEvidenceByCoverageId({
+  const primaryInventoryRefsByCoverageId = collectScenarioInventoryByCoverageId({
     scenarios: params.scenarios,
     role: "primary",
   });
-  const secondaryScenarioRefsByCoverageId = collectScenarioEvidenceByCoverageId({
+  const secondaryInventoryRefsByCoverageId = collectScenarioInventoryByCoverageId({
     scenarios: params.scenarios,
     role: "secondary",
   });
   const allScenarioCoverageIds = uniqueSorted(params.scenarios.flatMap(scenarioCoverageIds));
-  const missingEvidenceRefsByCategoryId = new Map<string, Set<string>>();
+  const missingInventoryRefsByCategoryId = new Map<string, Set<string>>();
 
   if (!pathExists(params.repoRoot, QA_MATURITY_TAXONOMY_PATH) || !params.taxonomy) {
     issues.push({
@@ -943,23 +943,23 @@ function buildQaScorecardTaxonomyReport(params: {
       };
     }) ?? [];
 
-  const categoryIdsWithEvidence = new Set<string>();
+  const categoryIdsWithInventory = new Set<string>();
   for (const coverageId of [
-    ...primaryScenarioRefsByCoverageId.keys(),
-    ...secondaryScenarioRefsByCoverageId.keys(),
+    ...primaryInventoryRefsByCoverageId.keys(),
+    ...secondaryInventoryRefsByCoverageId.keys(),
   ]) {
     const coverageRefs = maturityRefs.coverageIds.get(coverageId) ?? [];
     for (const coverageRef of coverageRefs) {
-      categoryIdsWithEvidence.add(coverageRef.categoryId);
+      categoryIdsWithInventory.add(coverageRef.categoryId);
     }
   }
   const relevantCategoryIds = uniqueSorted([
     ...profileCategoryIdsByCategoryId.keys(),
-    ...categoryIdsWithEvidence,
+    ...categoryIdsWithInventory,
   ]);
 
   const requiredCoverageIds = new Set<string>();
-  const fulfilledRequiredCoverageIds = new Set<string>();
+  const inventoriedRequiredCoverageIds = new Set<string>();
   for (const categoryId of relevantCategoryIds) {
     const category = maturityRefs.categories.get(categoryId);
     if (!category) {
@@ -974,92 +974,90 @@ function buildQaScorecardTaxonomyReport(params: {
 
     const profileIds = uniqueSorted(profileCategoryIdsByCategoryId.get(categoryId) ?? []);
     const required = profileIds.length > 0;
-    const evidenceReports: QaScorecardEvidenceReport[] = [];
+    const inventoryRefs: QaScorecardInventoryRef[] = [];
     const categoryScenarioRefs = new Set<string>();
-    const fulfilledCoverageIds = new Set<string>();
+    const inventoriedCoverageIds = new Set<string>();
     const secondaryOnlyCoverageIds = new Set<string>();
-    const coverageIdsWithAnyEvidence = new Set<string>();
+    const coverageIdsWithAnyInventory = new Set<string>();
 
     for (const coverageId of category.coverageIds) {
-      const primaryScenarioRefs = primaryScenarioRefsByCoverageId.get(coverageId) ?? [];
-      const secondaryScenarioRefs = secondaryScenarioRefsByCoverageId.get(coverageId) ?? [];
-      const primaryEvidenceReports = collectEvidenceReportsForCoverageId({
+      const primaryScenarioRefs = primaryInventoryRefsByCoverageId.get(coverageId) ?? [];
+      const secondaryScenarioRefs = secondaryInventoryRefsByCoverageId.get(coverageId) ?? [];
+      const primaryInventoryRefs = collectInventoryRefsForCoverageId({
         coverageId,
         role: "primary",
         refs: primaryScenarioRefs,
         repoRoot: params.repoRoot,
         categoryId,
         issues,
-        missingEvidenceRefsByCategoryId,
+        missingInventoryRefsByCategoryId,
       });
-      const secondaryEvidenceReports = collectEvidenceReportsForCoverageId({
+      const secondaryInventoryRefs = collectInventoryRefsForCoverageId({
         coverageId,
         role: "secondary",
         refs: secondaryScenarioRefs,
         repoRoot: params.repoRoot,
         categoryId,
         issues,
-        missingEvidenceRefsByCategoryId,
+        missingInventoryRefsByCategoryId,
       });
 
-      if (primaryEvidenceReports.length > 0) {
-        for (const scenarioRef of primaryEvidenceReports.flatMap((report) => report.scenarioRefs)) {
+      if (primaryInventoryRefs.length > 0) {
+        for (const scenarioRef of primaryInventoryRefs.flatMap((report) => report.scenarioRefs)) {
           categoryScenarioRefs.add(scenarioRef);
         }
-        fulfilledCoverageIds.add(coverageId);
-        coverageIdsWithAnyEvidence.add(coverageId);
-        evidenceReports.push(...primaryEvidenceReports);
+        inventoriedCoverageIds.add(coverageId);
+        coverageIdsWithAnyInventory.add(coverageId);
+        inventoryRefs.push(...primaryInventoryRefs);
       }
 
-      if (secondaryEvidenceReports.length > 0) {
-        for (const scenarioRef of secondaryEvidenceReports.flatMap(
-          (report) => report.scenarioRefs,
-        )) {
+      if (secondaryInventoryRefs.length > 0) {
+        for (const scenarioRef of secondaryInventoryRefs.flatMap((report) => report.scenarioRefs)) {
           categoryScenarioRefs.add(scenarioRef);
         }
-        if (!fulfilledCoverageIds.has(coverageId)) {
+        if (!inventoriedCoverageIds.has(coverageId)) {
           secondaryOnlyCoverageIds.add(coverageId);
         }
-        coverageIdsWithAnyEvidence.add(coverageId);
-        evidenceReports.push(...secondaryEvidenceReports);
+        coverageIdsWithAnyInventory.add(coverageId);
+        inventoryRefs.push(...secondaryInventoryRefs);
       }
     }
 
-    const fulfilledCoverageIdCountForCategory = category.coverageIds.filter((coverageId) =>
-      fulfilledCoverageIds.has(coverageId),
+    const inventoriedCoverageIdCountForCategory = category.coverageIds.filter((coverageId) =>
+      inventoriedCoverageIds.has(coverageId),
     ).length;
     if (required) {
       for (const coverageId of category.coverageIds) {
         requiredCoverageIds.add(coverageId);
-        if (fulfilledCoverageIds.has(coverageId)) {
-          fulfilledRequiredCoverageIds.add(coverageId);
+        if (inventoriedCoverageIds.has(coverageId)) {
+          inventoriedRequiredCoverageIds.add(coverageId);
         }
       }
-      pushMissingPrimaryIssues({
+      pushMissingPrimaryInventoryIssues({
         issues,
         category,
-        coverageIdsWithPrimaryEvidence: fulfilledCoverageIds,
-        coverageIdsWithSecondaryEvidence: secondaryOnlyCoverageIds,
+        coverageIdsWithPrimaryInventory: inventoriedCoverageIds,
+        coverageIdsWithSecondaryInventory: secondaryOnlyCoverageIds,
       });
-      if (fulfilledCoverageIdCountForCategory === 0) {
+      if (inventoriedCoverageIdCountForCategory === 0) {
         issues.push({
-          code: "profile-category-missing-evidence",
+          code: "profile-category-missing-inventory",
           severity: "warning",
           categoryId,
-          message: `${categoryId} is selected by a runnable profile but has no primary coverage evidence`,
+          message: `${categoryId} is selected by a runnable profile but has no primary coverage inventory`,
         });
       }
     }
 
     const missingCoverageIds = required
-      ? category.coverageIds.filter((coverageId) => !coverageIdsWithAnyEvidence.has(coverageId))
+      ? category.coverageIds.filter((coverageId) => !coverageIdsWithAnyInventory.has(coverageId))
       : [];
-    const coverageStatus =
+    const inventoryStatus =
       required &&
       category.coverageIds.length > 0 &&
-      fulfilledCoverageIdCountForCategory === category.coverageIds.length
-        ? "covered"
-        : evidenceReports.length > 0
+      inventoriedCoverageIdCountForCategory === category.coverageIds.length
+        ? "complete"
+        : inventoryRefs.length > 0
           ? "partial"
           : "missing";
 
@@ -1067,25 +1065,25 @@ function buildQaScorecardTaxonomyReport(params: {
       id: category.id,
       taxonomySurfaceId: category.surfaceId,
       taxonomyCategoryName: category.categoryName,
-      coverageStatus,
+      inventoryStatus,
       profiles: profileIds,
       features: category.features,
       coverageIds: category.coverageIds,
-      fulfilledCoverageIds: uniqueSorted(fulfilledCoverageIds),
-      evidence: evidenceReports.toSorted((left, right) =>
+      inventoriedCoverageIds: uniqueSorted(inventoriedCoverageIds),
+      inventoryRefs: inventoryRefs.toSorted((left, right) =>
         `${left.coverageId}:${left.kind}:${left.path ?? ""}:${left.role}`.localeCompare(
           `${right.coverageId}:${right.kind}:${right.path ?? ""}:${right.role}`,
         ),
       ),
       scenarioRefs: uniqueSorted(categoryScenarioRefs),
       missingCoverageIds: uniqueSorted(missingCoverageIds),
-      missingEvidenceRefs: uniqueSorted(missingEvidenceRefsByCategoryId.get(categoryId) ?? []),
+      missingInventoryRefs: uniqueSorted(missingInventoryRefsByCategoryId.get(categoryId) ?? []),
     });
   }
 
   const requiredCategories = categories.filter((category) => category.profiles.length > 0);
-  const fulfilledCategoryCount = requiredCategories.filter(
-    (category) => category.coverageStatus === "covered",
+  const inventoriedCategoryCount = requiredCategories.filter(
+    (category) => category.inventoryStatus === "complete",
   ).length;
   const unknownCoverageIds = allScenarioCoverageIds.filter(
     (coverageId) => !maturityRefs.coverageIds.has(coverageId),
@@ -1104,15 +1102,18 @@ function buildQaScorecardTaxonomyReport(params: {
     profiles,
     categoryCount: maturityRefs.categories.size,
     requiredCategoryCount: requiredCategories.length,
-    fulfilledCategoryCount,
-    categoryFulfillmentPercent: percent(fulfilledCategoryCount, requiredCategories.length),
+    inventoriedCategoryCount,
+    categoryInventoryPercent: percent(inventoriedCategoryCount, requiredCategories.length),
     requiredCoverageIdCount: requiredCoverageIds.size,
-    fulfilledCoverageIdCount: fulfilledRequiredCoverageIds.size,
-    coverageIdFulfillmentPercent: percent(
-      fulfilledRequiredCoverageIds.size,
+    inventoriedCoverageIdCount: inventoriedRequiredCoverageIds.size,
+    coverageIdInventoryPercent: percent(
+      inventoriedRequiredCoverageIds.size,
       requiredCoverageIds.size,
     ),
-    evidenceRefCount: categories.reduce((count, category) => count + category.evidence.length, 0),
+    inventoryRefCount: categories.reduce(
+      (count, category) => count + category.inventoryRefs.length,
+      0,
+    ),
     scenarioCoverageIdCount: allScenarioCoverageIds.length,
     unknownCoverageIdCount: unknownCoverageIds.length,
     unknownCoverageIds,


### PR DESCRIPTION
## What Problem This Solves

Resolves a QA reporting problem where the static scorecard taxonomy described declared scenario and test references as fulfilled evidence. That wording implied successful execution even though this path only inventories configured coverage references.

## Why This Change Was Made

The static scorecard contract, diagnostics, and Markdown renderer now consistently use inventory terminology. Executed pass-only fulfillment remains unchanged in the separate scorecard-evidence path; taxonomy IDs, scenario membership, and QA lane behavior are intentionally unchanged.

AI-assisted: yes. The static report contract, sole renderer, executed-evidence boundary, and typed fixtures were inspected directly.

## User Impact

QA maintainers can read scorecard inventory output without mistaking declared coverage references for successful runtime evidence. Existing category totals, coverage-ID accounting, scenario selection, and missing-inventory diagnostics keep the same behavior.

## Evidence

- Focused QA Lab proof: `node scripts/run-vitest.mjs extensions/qa-lab/src/coverage-report.test.ts extensions/qa-lab/src/scorecard-evidence.test.ts` — 2 files, 26 tests passed.
- Changed gate: Blacksmith Testbox `tbx_01kxn5m3429s7rtt68d4bnkqhj`, [Actions run 29488928962](https://github.com/openclaw/openclaw/actions/runs/29488928962) — extension production/test typechecks, formatting, lint, repository guards, and import-cycle checks passed.
- Fresh autoreview: no accepted/actionable findings; patch correct at 0.98 and accounting behavior unchanged.
- Scope check: exactly four QA Lab source/test files; no `taxonomy.yaml`, scenario YAML, lane/planning, docs, UI, compatibility alias, or executed-evidence production changes.
