### PR TITLE
fix(scripts): explain retained pr-operation locks and malformed review artifacts

### DIFF
--- a/scripts/pr-lib/process-group-runner.mjs
+++ b/scripts/pr-lib/process-group-runner.mjs
@@ -1,6 +1,6 @@
 import { spawn, spawnSync } from "node:child_process";
 import { constants } from "node:os";
-import { resolve } from "node:path";
+import { basename, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const SIGNAL_GRACE_MS = 5000;
@@ -33,6 +33,10 @@ let killDeadline;
 const operationGroup = { pid: undefined };
 let operationGroupGone = false;
 let hadLingeringGroup = false;
+let lingeringGroupProcesses = [];
+let drainFailure;
+let drainFailureGroupStatus;
+let drainFailureNotificationOpen = false;
 
 function delay(ms) {
   return new Promise((resolveDelay) => {
@@ -68,6 +72,28 @@ function processGroupStatus(pgid) {
     }
     return "indeterminate";
   }
+}
+
+function processGroupRows(pgid) {
+  if (!Number.isSafeInteger(pgid) || pgid <= 1 || pgid > 0x7fffffff) {
+    return [];
+  }
+  const result = spawnSync("ps", ["ax", "-o", "pid=,pgid=,command="], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "ignore"],
+  });
+  if (result.status !== 0) {
+    return [];
+  }
+  return result.stdout
+    .split("\n")
+    .map((line) => /^\s*(\d+)\s+(\d+)\s+(.*)$/u.exec(line))
+    .filter((match) => match && Number(match[2]) === pgid)
+    .slice(0, 10)
+    .map((match) => {
+      const executable = match[3].trim().split(/\s+/u)[0] ?? "unknown";
+      return `${match[1]} ${match[2]} ${basename(executable)}`.slice(0, 200);
+    });
 }
 
 function signalProcessGroup(signal) {
@@ -247,6 +273,7 @@ if (postExitGroupStatus === "indeterminate") {
   // A wrapper exit does not end same-group background work. Bound and drain
   // forgotten jobs, but keep the lock because their terminal state is unknown.
   hadLingeringGroup = true;
+  lingeringGroupProcesses = processGroupRows(child.pid);
   notificationFailure ??= new Error("scripts/pr process group remained active after wrapper exit");
   signalProcessGroup("SIGTERM");
   escalationTimer ??= setTimeout(escalateSignal, SIGNAL_GRACE_MS);
@@ -266,6 +293,8 @@ async function waitForOperationDrain() {
       return;
     }
     if (killDeadline && Date.now() >= killDeadline) {
+      drainFailureGroupStatus = groupStatus;
+      drainFailureNotificationOpen = !notificationEnded;
       throw new Error(
         `scripts/pr operation lifetime did not drain (group=${groupStatus}, pipe=${notificationEnded ? "closed" : "open"})`,
       );
@@ -306,11 +335,74 @@ function releaseLock({ lockRef, ownerOid }) {
   }
 }
 
-function reportRetainedLock({ lockRef, ownerOid }) {
+function retainedLockReason(releaseError, releaseFailures) {
+  const reasons = [];
+  const addReason = (reason) => {
+    if (reason && !reasons.includes(reason)) {
+      reasons.push(reason);
+    }
+  };
+  if (childResult.code !== null && childResult.code !== 0) {
+    addReason(`child exited with code ${childResult.code}`);
+  }
+  if (childResult.signal) {
+    addReason(`child terminated by signal ${childResult.signal}`);
+  }
+  if (receivedSignal) {
+    addReason(`wrapper received ${receivedSignal}`);
+  }
+  if (hadLingeringGroup) {
+    addReason("process group remained active after wrapper exit");
+  }
+  if (drainFailureGroupStatus === "live") {
+    addReason("process group remained active after drain deadline");
+  }
+  if (drainFailureNotificationOpen) {
+    addReason("notification pipe still open after drain deadline");
+  }
+  if (
+    notificationFailure &&
+    notificationFailure !== drainFailure &&
+    !releaseFailures.has(notificationFailure) &&
+    !(
+      hadLingeringGroup &&
+      notificationFailure.message === "scripts/pr process group remained active after wrapper exit"
+    )
+  ) {
+    addReason(notificationFailure.message);
+  }
+  if (drainFailure && !drainFailureGroupStatus && !drainFailureNotificationOpen) {
+    addReason(drainFailure.message);
+  }
+  if (releaseError) {
+    addReason(`lock release failed: ${releaseError.message}`);
+  }
+  return reasons.join("; ") || "clean-exit invariant failed";
+}
+
+function reportRetainedLock({ lockRef, ownerOid }, releaseError, releaseFailures) {
   const pr = lockRef.split("/").at(-1);
   console.error(
     `Retaining the operation lock for PR #${pr}; detached child tools cannot be ruled out.`,
   );
+  console.error(`reason: ${retainedLockReason(releaseError, releaseFailures)}`);
+  if (hadLingeringGroup || drainFailureGroupStatus === "live") {
+    const currentProcesses = processGroupRows(child.pid);
+    if (currentProcesses.length > 0) {
+      console.error(`surviving processes in group ${child.pid}:`);
+      for (const row of currentProcesses) {
+        console.error(`  ${row}`);
+      }
+    } else {
+      if (lingeringGroupProcesses.length > 0) {
+        console.error(`surviving processes in group ${child.pid} when wrapper exited:`);
+        for (const row of lingeringGroupProcesses) {
+          console.error(`  ${row}`);
+        }
+      }
+      console.error("  process group appears empty at report time");
+    }
+  }
   console.error(`After verifying that no PR #${pr} tools remain, recover the exact owner with:`);
   console.error(`  scripts/pr lock-recover ${pr} ${ownerOid} --confirmed-no-running-tools`);
 }
@@ -320,7 +412,8 @@ try {
   await waitForOperationDrain();
   drained = true;
 } catch (error) {
-  notificationFailure ??= toError(error, "scripts/pr operation drain failed");
+  drainFailure = toError(error, "scripts/pr operation drain failed");
+  notificationFailure ??= drainFailure;
   // An out-of-group descendant can inherit the write end indefinitely. Once
   // the bounded drain fails, close our read end so that sentinel cannot keep
   // the controller alive; the exact lock remains sticky for manual recovery.
@@ -345,20 +438,23 @@ const completedCleanly =
   !notificationFailure &&
   !hadLingeringGroup;
 const retainedLocks = [];
+const releaseFailures = new Set();
 if (drained && completedCleanly) {
   for (const lock of locks.values()) {
     try {
       releaseLock(lock);
     } catch (error) {
-      notificationFailure ??= toError(error, "Unable to release a scripts/pr operation lock");
-      retainedLocks.push(lock);
+      const releaseError = toError(error, "Unable to release a scripts/pr operation lock");
+      releaseFailures.add(releaseError);
+      notificationFailure ??= releaseError;
+      retainedLocks.push({ lock, releaseError });
     }
   }
 } else {
-  retainedLocks.push(...locks.values());
+  retainedLocks.push(...Array.from(locks.values(), (lock) => ({ lock })));
 }
-for (const lock of retainedLocks) {
-  reportRetainedLock(lock);
+for (const { lock, releaseError } of retainedLocks) {
+  reportRetainedLock(lock, releaseError, releaseFailures);
 }
 
 if (notificationFailure) {

--- a/scripts/pr-lib/review.sh
+++ b/scripts/pr-lib/review.sh
@@ -198,6 +198,15 @@ EOF_JSON
   echo "files=.local/review.md .local/review.json"
 }
 
+review_json_require() {
+  local expression="$1"
+  local message="$2"
+  if ! jq -e "$expression" .local/review.json >/dev/null 2>&1; then
+    echo "$message"
+    exit 1
+  fi
+}
+
 review_validate_artifacts() {
   local pr="$1"
   enter_worktree "$pr" false
@@ -209,6 +218,14 @@ review_validate_artifacts() {
   review_guard "$pr"
 
   jq . .local/review.json >/dev/null
+  review_json_require 'type == "object"' "Invalid .local/review.json: top-level value must be an object"
+  review_json_require '(.recommendation | type) == "string"' "Invalid recommendation in .local/review.json: recommendation must be a string"
+  review_json_require '(.findings | type) == "array"' "Invalid findings in .local/review.json: findings must be an array"
+  review_json_require 'all(.findings[]; type == "object")' "Invalid finding entry in .local/review.json: each finding must be an object"
+  review_json_require '(.nitSweep | type) == "object"' "Invalid nit sweep in .local/review.json: nitSweep must be an object"
+  review_json_require '(.issueValidation | type) == "object"' "Invalid issue validation in .local/review.json: issueValidation must be an object"
+  review_json_require '(.behavioralSweep | type) == "object"' "Invalid behavioral sweep in .local/review.json: behavioralSweep must be an object"
+  review_json_require '(.tests | type) == "object"' "Invalid tests in .local/review.json: tests must be an object"
 
   local section
   for section in "A)" "B)" "C)" "D)" "E)" "F)" "G)" "H)" "I)" "J)"; do
@@ -224,7 +241,7 @@ review_validate_artifacts() {
     "READY FOR /prepare-pr"|"NEEDS WORK"|"NEEDS DISCUSSION"|"NOT USEFUL (CLOSE)")
       ;;
     *)
-      echo "Invalid recommendation in .local/review.json: $recommendation"
+      printf 'Invalid recommendation in .local/review.json: %s (allowed: READY FOR /prepare-pr|NEEDS WORK|NEEDS DISCUSSION|NOT USEFUL (CLOSE))\n' "$(jq -c '.recommendation' .local/review.json)"
       exit 1
       ;;
   esac
@@ -232,7 +249,7 @@ review_validate_artifacts() {
   local invalid_severity_count
   invalid_severity_count=$(jq '[.findings[]? | select((.severity // "") != "BLOCKER" and (.severity // "") != "IMPORTANT" and (.severity // "") != "NIT")] | length' .local/review.json)
   if [ "$invalid_severity_count" -gt 0 ]; then
-    echo "Invalid finding severity in .local/review.json"
+    printf 'Invalid finding severity in .local/review.json: %s (allowed: BLOCKER|IMPORTANT|NIT)\n' "$(jq -c 'first(.findings[] | select((.severity // "") != "BLOCKER" and (.severity // "") != "IMPORTANT" and (.severity // "") != "NIT")).severity' .local/review.json)"
     exit 1
   fi
 
@@ -247,6 +264,7 @@ review_validate_artifacts() {
   nit_findings_count=$(jq '[.findings[]? | select((.severity // "") == "NIT")] | length' .local/review.json)
 
   local nit_sweep_performed
+  review_json_require '(.nitSweep.performed | type) == "boolean"' "Invalid nit sweep in .local/review.json: nitSweep.performed must be a boolean"
   nit_sweep_performed=$(jq -r '.nitSweep.performed // empty' .local/review.json)
   if [ "$nit_sweep_performed" != "true" ]; then
     echo "Invalid nit sweep in .local/review.json: nitSweep.performed must be true"
@@ -254,6 +272,7 @@ review_validate_artifacts() {
   fi
 
   local nit_sweep_status
+  review_json_require '(.nitSweep.status | type) == "string"' "Invalid nit sweep status in .local/review.json: nitSweep.status must be a string"
   nit_sweep_status=$(jq -r '.nitSweep.status // ""' .local/review.json)
   case "$nit_sweep_status" in
     "none")
@@ -269,12 +288,13 @@ review_validate_artifacts() {
       fi
       ;;
     *)
-      echo "Invalid nit sweep status in .local/review.json: $nit_sweep_status"
+      printf 'Invalid nit sweep status in .local/review.json: %s (allowed: none|has_nits)\n' "$(jq -c '.nitSweep.status' .local/review.json)"
       exit 1
       ;;
   esac
 
   local invalid_nit_summary_count
+  review_json_require '(.nitSweep.summary | type) == "string"' "Invalid nit sweep summary in .local/review.json: nitSweep.summary must be a string"
   invalid_nit_summary_count=$(jq '[.nitSweep.summary | select((type != "string") or (gsub("^\\s+|\\s+$";"") | length == 0))] | length' .local/review.json)
   if [ "$invalid_nit_summary_count" -gt 0 ]; then
     echo "Invalid nit sweep summary in .local/review.json: nitSweep.summary must be a non-empty string"
@@ -282,6 +302,7 @@ review_validate_artifacts() {
   fi
 
   local issue_validation_performed
+  review_json_require '(.issueValidation.performed | type) == "boolean"' "Invalid issue validation in .local/review.json: issueValidation.performed must be a boolean"
   issue_validation_performed=$(jq -r '.issueValidation.performed // empty' .local/review.json)
   if [ "$issue_validation_performed" != "true" ]; then
     echo "Invalid issue validation in .local/review.json: issueValidation.performed must be true"
@@ -289,28 +310,31 @@ review_validate_artifacts() {
   fi
 
   local issue_validation_source
+  review_json_require '(.issueValidation.source | type) == "string"' "Invalid issue validation source in .local/review.json: issueValidation.source must be a string"
   issue_validation_source=$(jq -r '.issueValidation.source // ""' .local/review.json)
   case "$issue_validation_source" in
     "linked_issue"|"pr_body"|"both")
       ;;
     *)
-      echo "Invalid issue validation source in .local/review.json: $issue_validation_source"
+      printf 'Invalid issue validation source in .local/review.json: %s (allowed: linked_issue|pr_body|both)\n' "$(jq -c '.issueValidation.source' .local/review.json)"
       exit 1
       ;;
   esac
 
   local issue_validation_status
+  review_json_require '(.issueValidation.status | type) == "string"' "Invalid issue validation status in .local/review.json: issueValidation.status must be a string"
   issue_validation_status=$(jq -r '.issueValidation.status // ""' .local/review.json)
   case "$issue_validation_status" in
     "valid"|"unclear"|"invalid"|"already_fixed_on_main")
       ;;
     *)
-      echo "Invalid issue validation status in .local/review.json: $issue_validation_status"
+      printf 'Invalid issue validation status in .local/review.json: %s (allowed: valid|unclear|invalid|already_fixed_on_main)\n' "$(jq -c '.issueValidation.status' .local/review.json)"
       exit 1
       ;;
   esac
 
   local invalid_issue_summary_count
+  review_json_require '(.issueValidation.summary | type) == "string"' "Invalid issue validation summary in .local/review.json: issueValidation.summary must be a string"
   invalid_issue_summary_count=$(jq '[.issueValidation.summary | select((type != "string") or (gsub("^\\s+|\\s+$";"") | length == 0))] | length' .local/review.json)
   if [ "$invalid_issue_summary_count" -gt 0 ]; then
     echo "Invalid issue validation summary in .local/review.json: issueValidation.summary must be a non-empty string"
@@ -318,6 +342,10 @@ review_validate_artifacts() {
   fi
 
   local runtime_file_count
+  if ! jq -e 'type == "object" and (.files | type) == "array" and all(.files[]; type == "object" and (.path | type) == "string")' .local/pr-meta.json >/dev/null 2>&1; then
+    echo "Invalid .local/pr-meta.json: files must be an array of objects with string path"
+    exit 1
+  fi
   runtime_file_count=$(jq '[.files[]? | (.path // "") | select(test("^(src|extensions|apps)/")) | select(test("(^|/)__tests__/|\\.test\\.|\\.spec\\.") | not) | select(test("\\.(md|mdx)$") | not)] | length' .local/pr-meta.json)
 
   local runtime_review_required="false"
@@ -326,6 +354,7 @@ review_validate_artifacts() {
   fi
 
   local behavioral_sweep_performed
+  review_json_require '(.behavioralSweep.performed | type) == "boolean"' "Invalid behavioral sweep in .local/review.json: behavioralSweep.performed must be a boolean"
   behavioral_sweep_performed=$(jq -r '.behavioralSweep.performed // empty' .local/review.json)
   if [ "$behavioral_sweep_performed" != "true" ]; then
     echo "Invalid behavioral sweep in .local/review.json: behavioralSweep.performed must be true"
@@ -333,28 +362,31 @@ review_validate_artifacts() {
   fi
 
   local behavioral_sweep_status
+  review_json_require '(.behavioralSweep.status | type) == "string"' "Invalid behavioral sweep status in .local/review.json: behavioralSweep.status must be a string"
   behavioral_sweep_status=$(jq -r '.behavioralSweep.status // ""' .local/review.json)
   case "$behavioral_sweep_status" in
     "pass"|"needs_work"|"not_applicable")
       ;;
     *)
-      echo "Invalid behavioral sweep status in .local/review.json: $behavioral_sweep_status"
+      printf 'Invalid behavioral sweep status in .local/review.json: %s (allowed: pass|needs_work|not_applicable)\n' "$(jq -c '.behavioralSweep.status' .local/review.json)"
       exit 1
       ;;
   esac
 
   local behavioral_sweep_risk
+  review_json_require '(.behavioralSweep.silentDropRisk | type) == "string"' "Invalid behavioral sweep risk in .local/review.json: behavioralSweep.silentDropRisk must be a string"
   behavioral_sweep_risk=$(jq -r '.behavioralSweep.silentDropRisk // ""' .local/review.json)
   case "$behavioral_sweep_risk" in
     "none"|"present"|"unknown")
       ;;
     *)
-      echo "Invalid behavioral sweep risk in .local/review.json: $behavioral_sweep_risk"
+      printf 'Invalid behavioral sweep risk in .local/review.json: %s (allowed: none|present|unknown)\n' "$(jq -c '.behavioralSweep.silentDropRisk' .local/review.json)"
       exit 1
       ;;
   esac
 
   local invalid_behavioral_summary_count
+  review_json_require '(.behavioralSweep.summary | type) == "string"' "Invalid behavioral sweep summary in .local/review.json: behavioralSweep.summary must be a string"
   invalid_behavioral_summary_count=$(jq '[.behavioralSweep.summary | select((type != "string") or (gsub("^\\s+|\\s+$";"") | length == 0))] | length' .local/review.json)
   if [ "$invalid_behavioral_summary_count" -gt 0 ]; then
     echo "Invalid behavioral sweep summary in .local/review.json: behavioralSweep.summary must be a non-empty string"
@@ -369,9 +401,10 @@ review_validate_artifacts() {
   fi
 
   local invalid_behavioral_branch_count
+  review_json_require 'all(.behavioralSweep.branches[]; type == "object")' "Invalid behavioral sweep branch entry in .local/review.json: each entry must be an object with string path/decision/outcome"
   invalid_behavioral_branch_count=$(jq '[.behavioralSweep.branches[]? | select((.path|type)!="string" or (.decision|type)!="string" or (.outcome|type)!="string")] | length' .local/review.json)
   if [ "$invalid_behavioral_branch_count" -gt 0 ]; then
-    echo "Invalid behavioral sweep branch entry in .local/review.json: each branch needs string path/decision/outcome"
+    echo "Invalid behavioral sweep branch entry in .local/review.json: each entry must be an object with string path/decision/outcome"
     exit 1
   fi
 
@@ -418,24 +451,43 @@ review_validate_artifacts() {
     exit 1
   fi
 
+  review_json_require '(.tests.ran | type) == "array"' "Invalid tests in .local/review.json: tests.ran must be an array of strings"
+  review_json_require 'all(.tests.ran[]; type == "string")' "Invalid tests in .local/review.json: tests.ran must be an array of strings"
+  review_json_require '(.tests.gaps | type) == "array"' "Invalid tests in .local/review.json: tests.gaps must be an array of strings"
+  review_json_require 'all(.tests.gaps[]; type == "string")' "Invalid tests in .local/review.json: tests.gaps must be an array of strings"
+
+  local tests_result
+  review_json_require '(.tests.result | type) == "string"' "Invalid tests result in .local/review.json: tests.result must be a string"
+  tests_result=$(jq -r '.tests.result // ""' .local/review.json)
+  case "$tests_result" in
+    "pass"|"fail"|"not_run")
+      ;;
+    *)
+      printf 'Invalid tests result in .local/review.json: %s (allowed: pass|fail|not_run)\n' "$(jq -c '.tests.result' .local/review.json)"
+      exit 1
+      ;;
+  esac
+
   local docs_status
+  review_json_require '(.docs | type) == "string"' "Invalid docs status in .local/review.json: docs must be a string"
   docs_status=$(jq -r '.docs // ""' .local/review.json)
   case "$docs_status" in
     "up_to_date"|"missing"|"not_applicable")
       ;;
     *)
-      echo "Invalid docs status in .local/review.json: $docs_status"
+      printf 'Invalid docs status in .local/review.json: %s (allowed: up_to_date|missing|not_applicable)\n' "$(jq -c '.docs' .local/review.json)"
       exit 1
       ;;
   esac
 
   local changelog_status
+  review_json_require '(.changelog | type) == "string"' "Invalid changelog status in .local/review.json: changelog must be a string"
   changelog_status=$(jq -r '.changelog // ""' .local/review.json)
   case "$changelog_status" in
     "required"|"not_required")
       ;;
     *)
-      echo "Invalid changelog status in .local/review.json: $changelog_status (must be \"required\" or \"not_required\")"
+      printf 'Invalid changelog status in .local/review.json: %s (allowed: required|not_required)\n' "$(jq -c '.changelog' .local/review.json)"
       exit 1
       ;;
   esac

--- a/test/scripts/pr-operation-lock.test.ts
+++ b/test/scripts/pr-operation-lock.test.ts
@@ -1001,6 +1001,27 @@ describePosix("scripts/pr per-PR operation lock", () => {
 
     expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
     expect(refExists(repoDir)).toBe(false);
+    expect(result.stderr).not.toContain("Retaining the operation lock");
+  });
+
+  it("reports the child exit code when retaining a failed operation", async () => {
+    const repoDir = createRepo();
+    const fixture = writeOperationFixture(repoDir, "failed-operation.sh", [
+      "acquire_pr_operation_lock 42",
+      "exit 3",
+    ]);
+    const result = await runSupervisedFixture(repoDir, fixture);
+    const ownerOid = refOid(repoDir);
+
+    expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(3);
+    expect(result.stderr).toContain("reason: child exited with code 3");
+    expect(refOid(repoDir)).toBe(ownerOid);
+
+    const recovered = runLockShell(repoDir, [
+      `recover_pr_operation_lock 42 '${ownerOid}' --confirmed-no-running-tools`,
+    ]);
+    expect(recovered.status, `${recovered.stdout}\n${recovered.stderr}`).toBe(0);
+    expect(refExists(repoDir)).toBe(false);
   });
 
   it("retains the exact owner when supervisor release cannot take the ref lock", async () => {
@@ -1440,6 +1461,9 @@ describePosix("scripts/pr per-PR operation lock", () => {
       expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(1);
       expect(processGroupExists(operationPgid)).toBe(false);
       expect(result.stderr).toContain("process group remained active after wrapper exit");
+      expect(result.stderr).toContain(`surviving processes in group ${operationPgid}`);
+      expect(result.stderr).toMatch(/^\s+\d+ \d+ sleep$/mu);
+      expect(result.stderr).toContain("process group appears empty at report time");
       expect(result.stderr).toContain(
         `scripts/pr lock-recover 42 ${ownerOid} --confirmed-no-running-tools`,
       );

--- a/test/scripts/pr-review-artifact-validation.test.ts
+++ b/test/scripts/pr-review-artifact-validation.test.ts
@@ -1,0 +1,109 @@
+import { spawnSync } from "node:child_process";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+const reviewScript = join(process.cwd(), "scripts/pr-lib/review.sh");
+const describePosix = process.platform === "win32" ? describe.skip : describe;
+
+function validReview() {
+  return {
+    recommendation: "NEEDS WORK",
+    findings: [],
+    nitSweep: {
+      performed: true,
+      status: "none",
+      summary: "No optional nits identified.",
+    },
+    behavioralSweep: {
+      performed: true,
+      status: "not_applicable",
+      summary: "No runtime behavior changed.",
+      silentDropRisk: "none",
+      branches: [] as unknown[],
+    },
+    issueValidation: {
+      performed: true,
+      source: "pr_body",
+      status: "unclear",
+      summary: "Review fixture.",
+    },
+    tests: {
+      ran: [],
+      gaps: [],
+      result: "pass",
+    },
+    docs: "not_applicable",
+    changelog: "not_required",
+  };
+}
+
+function runValidation(review: ReturnType<typeof validReview>) {
+  const fixtureRoot = tempDirs.make("openclaw-pr-review-validation-");
+  const localDir = join(fixtureRoot, ".local");
+  mkdirSync(localDir);
+  writeFileSync(join(localDir, "review.json"), `${JSON.stringify(review)}\n`);
+  writeFileSync(
+    join(localDir, "review.md"),
+    ["A)", "B)", "C)", "D)", "E)", "F)", "G)", "H)", "I)", "J)"].join("\n"),
+  );
+  writeFileSync(join(localDir, "pr-meta.env"), "PR_URL=https://example.invalid/pr/42\n");
+  writeFileSync(join(localDir, "pr-meta.json"), '{"files":[]}\n');
+
+  return spawnSync(
+    "bash",
+    [
+      "-c",
+      [
+        "set -euo pipefail",
+        'source "$1"',
+        'fixture_root="$2"',
+        'enter_worktree() { cd "$fixture_root"; }',
+        'require_artifact() { [ -s "$1" ]; }',
+        "review_guard() { :; }",
+        "print_review_stdout_summary() { :; }",
+        "review_validate_artifacts 42",
+      ].join("\n"),
+      "pr-review-artifact-validation",
+      reviewScript,
+      fixtureRoot,
+    ],
+    { encoding: "utf8" },
+  );
+}
+
+describePosix("scripts/pr review artifact validation", () => {
+  it("accepts a valid review artifact", () => {
+    const result = runValidation(validReview());
+
+    expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+    expect(result.stdout).toContain("review artifacts validated");
+  });
+
+  it("reports the required branch entry shape without a raw jq error", () => {
+    const review = validReview();
+    review.behavioralSweep.branches = ["src/example.ts"];
+    const result = runValidation(review);
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toContain(
+      "Invalid behavioral sweep branch entry in .local/review.json: each entry must be an object with string path/decision/outcome",
+    );
+    expect(`${result.stdout}\n${result.stderr}`).not.toContain(
+      'Cannot index string with string ("path")',
+    );
+  });
+
+  it("lists allowed values for an invalid enum", () => {
+    const review = validReview();
+    review.behavioralSweep.status = "performed";
+    const result = runValidation(review);
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toContain(
+      'Invalid behavioral sweep status in .local/review.json: "performed" (allowed: pass|needs_work|not_applicable)',
+    );
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators (and agents) running `scripts/pr` on machines where a helper process outlives the command saw every run end with "Retaining the operation lock … detached child tools cannot be ruled out" — with zero evidence of what lingered or why. The only path forward was reflexively running `lock-recover --confirmed-no-running-tools` before every command, which is exactly the confirmation-theater the fail-closed lock is supposed to prevent. Separately, `review-validate-artifacts` greeted malformed `review.json` files with raw jq crashes (`Cannot index string with string ("path")`) and enum rejections that did not name the allowed values.

Both were hit repeatedly while landing #108611 and #108651.

## Why This Change Was Made

The fail-closed release policy is correct and is not changed — the conditions for releasing vs retaining the lock are byte-for-byte equivalent. What changes is the evidence when a lock is retained:

- The retain report now prints a `reason:` line naming the exact failed condition(s): child exit code/signal, forwarded wrapper signal, lingering process group, notification pipe still open after the drain deadline, or lock-release failure.
- When a process group lingers, the report enumerates surviving group members (pid, pgid, executable basename; capped at 10 rows) — both at report time and, if they since died, the snapshot captured when the wrapper exited. Executable basenames only, so command-line arguments (which can carry tokens) never reach logs; the printed PIDs allow live inspection when needed.
- `review-validate-artifacts` now type-guards every field it reads before indexing (via a small `review_json_require` helper), so wrong-shaped artifacts get a message naming the field and required shape instead of a jq crash, and every enum rejection lists the allowed values (e.g. `"performed" (allowed: pass|needs_work|not_applicable)`).
- One intentional tightening: `tests.result` was previously read but never enum-validated; it now must be `pass|fail|not_run`. These artifacts are agent-written under this repo's own landing workflow, so a crisp contract beats silent acceptance of junk values.

## User Impact

Maintainers and agents using the `scripts/pr` landing flow get actionable diagnostics instead of a dead-end warning: the retained-lock report says why and who, and artifact validation errors say what shape is required. No behavior change for clean runs or valid artifacts.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/pr-operation-lock.test.ts test/scripts/pr-review-artifact-validation.test.ts` — 52 passed, 1 skipped (platform guard). Includes new tests: retain report carries the child exit code; a same-group sleeper appears under `surviving processes in group <pgid>`; clean runs emit no retain output; string branch entries produce the explicit shape message with no raw jq error; bad enums list allowed values.
- Sample retain output (from the test run): `reason: child exited with code 3`; `surviving processes in group 7612 when wrapper exited: 7653 7612 sleep`.
- Autoreview (Codex gpt-5.6-sol, xhigh): one P2 finding ("branches object bypasses array check") rejected with live proof — the pre-existing container check four lines above the flagged line already rejects object-valued `branches` (`Invalid behavioral sweep … must be an array`, exit 1), verified by running the validator against such a fixture.
- `git diff --check` clean; oxfmt applied.
