### PR TITLE
fix: prevent run-with-env shutdown grace test race

### DIFF
--- a/test/scripts/run-with-env.test.ts
+++ b/test/scripts/run-with-env.test.ts
@@ -391,13 +391,13 @@ describe("run-with-env", () => {
       const grandchildReadyFile = path.join(tempDir, "grandchild-ready");
       const grandchildScript = [
         "const fs = require('node:fs');",
-        "fs.writeFileSync(process.env.GRANDCHILD_READY_FILE, 'ready');",
         "process.on('SIGTERM', () => {",
         "  setTimeout(() => {",
         "    fs.writeFileSync(process.env.GRACEFUL_FILE, 'done');",
         "    process.exit(0);",
         "  }, 75);",
         "});",
+        "fs.writeFileSync(process.env.GRANDCHILD_READY_FILE, 'ready');",
         "setInterval(() => {}, 1000);",
       ].join("\n");
       const childScript = [


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the `run-with-env` shutdown-grace regression test could intermittently fail when it observed a grandchild readiness marker before that process had installed its `SIGTERM` handler.

## Why This Change Was Made

The grandchild now publishes readiness only after registering the signal handler that the test exercises. Production runtime behavior is unchanged.

## User Impact

No user-visible runtime change. Maintainers get deterministic CI coverage for graceful descendant shutdown.

## Evidence

- [Observed hosted failure](https://github.com/openclaw/openclaw/actions/runs/29482194369/job/87568382465): `checks-node-compact-small-6` reported `ENOENT` for the expected graceful-shutdown marker after the readiness marker had already appeared.
- Focused test passed 85/85 assertions across five runs after the ordering fix.
- `oxfmt --check` and `git diff --check` passed.
- Structured autoreview: clean, 0.99 confidence.
- AI-assisted: yes. The change and signal/readiness ordering were reviewed and understood.
