### PR TITLE
fix(status): preserve thinking level for discovered Ollama models

### DIFF
--- a/src/agents/openclaw-tools.session-status.test.ts
+++ b/src/agents/openclaw-tools.session-status.test.ts
@@ -22,6 +22,23 @@ const callGatewayMock = vi.fn();
 const buildStatusMessageMock = vi.hoisted(() =>
   vi.fn((_params?: unknown) => "OpenClaw\n🧠 Model: GPT-5.4"),
 );
+const loadModelCatalogMock = vi.hoisted(() =>
+  vi.fn(async () => [
+    {
+      provider: "anthropic",
+      id: "claude-sonnet-4-6",
+      name: "Claude Sonnet 4.6",
+      contextWindow: 200000,
+    },
+    {
+      provider: "openai",
+      id: "gpt-5.4",
+      name: "GPT-5.4",
+      reasoning: true,
+      contextWindow: 400000,
+    },
+  ]),
+);
 const resolveQueueSettingsMock = vi.hoisted(() =>
   vi.fn((_params?: unknown) => ({ mode: "interrupt" })),
 );
@@ -198,21 +215,7 @@ function createConfigModuleMock() {
 
 function createModelCatalogModuleMock() {
   return {
-    loadModelCatalog: async () => [
-      {
-        provider: "anthropic",
-        id: "claude-sonnet-4-6",
-        name: "Claude Sonnet 4.6",
-        contextWindow: 200000,
-      },
-      {
-        provider: "openai",
-        id: "gpt-5.4",
-        name: "GPT-5.4",
-        reasoning: true,
-        contextWindow: 400000,
-      },
-    ],
+    loadModelCatalog: loadModelCatalogMock,
   };
 }
 
@@ -267,6 +270,7 @@ function createCommandsStatusRuntimeModuleMock() {
       includeTranscriptUsage?: boolean;
       taskLineOverride?: string;
       resolveDefaultThinkingLevel?: () => unknown;
+      thinkingCatalog?: Array<{ provider: string; id: string; reasoning?: boolean }>;
     }) => {
       resolveQueueSettingsMock({
         channel: params.statusChannel,
@@ -304,6 +308,7 @@ function createCommandsStatusRuntimeModuleMock() {
         modelAuth,
         includeTranscriptUsage: params.includeTranscriptUsage,
         workspaceDir: params.workspaceDir,
+        thinkingCatalog: params.thinkingCatalog,
       });
       return formatStatusLines(primary, params.taskLineOverride);
     },
@@ -529,6 +534,7 @@ function getSessionStatusTool(
 describe("session_status tool", () => {
   beforeEach(() => {
     buildStatusMessageMock.mockClear();
+    loadModelCatalogMock.mockClear();
     clearInternalHooks();
   });
 
@@ -548,6 +554,12 @@ describe("session_status tool", () => {
     expect(details.statusText).toContain("OpenClaw");
     expect(details.statusText).toContain("🧠 Model:");
     expect(details.statusText).not.toContain("OAuth/token status");
+    expect(loadModelCatalogMock).toHaveBeenCalledWith({ config: mockConfig, readOnly: true });
+    expectRecordFields(mockCallArg(buildStatusMessageMock), {
+      thinkingCatalog: expect.arrayContaining([
+        expect.objectContaining({ provider: "openai", id: "gpt-5.4", reasoning: true }),
+      ]),
+    });
     expect(tool.outputSchema).toBeDefined();
     expect(Value.Check(tool.outputSchema!, result.details)).toBe(true);
     expect(compactToolOutputHint(tool.outputSchema)).toBe(

--- a/src/agents/tools/session-status-tool.ts
+++ b/src/agents/tools/session-status-tool.ts
@@ -948,6 +948,8 @@ export function createSessionStatusTool(opts?: {
         relatedSessionKey: resolved.key,
         callerOwnerKey: visibilityRequesterKey,
       });
+      // Tool status may read persisted/configured facts, but must not start provider discovery.
+      const thinkingCatalog = await loadModelCatalog({ config: cfg, readOnly: true });
       const { buildStatusText } = await loadCommandsStatusRuntime();
       const statusText = await buildStatusText({
         cfg,
@@ -964,6 +966,7 @@ export function createSessionStatusTool(opts?: {
         workspaceDir: statusSessionEntry.spawnedWorkspaceDir,
         provider: providerForCard,
         model: defaultModelForCard,
+        thinkingCatalog,
         resolvedThinkLevel: statusSessionEntry.thinkingLevel as ThinkLevel | undefined,
         resolvedFastMode: statusSessionEntry.fastMode,
         resolvedVerboseLevel: (statusSessionEntry.verboseLevel ?? "off") as VerboseLevel,

--- a/src/auto-reply/reply/commands-info.ts
+++ b/src/auto-reply/reply/commands-info.ts
@@ -291,6 +291,7 @@ export const handleStatusCommand: CommandHandler = async (params, allowTextComma
     provider: params.provider,
     model: params.model,
     contextTokens: params.contextTokens,
+    thinkingCatalog: params.thinkingCatalog,
     workspaceDir: params.workspaceDir,
     resolvedThinkLevel: params.resolvedThinkLevel,
     resolvedFastMode: params.resolvedFastMode,

--- a/src/auto-reply/reply/commands-types.ts
+++ b/src/auto-reply/reply/commands-types.ts
@@ -6,7 +6,13 @@ import type { SessionEntry, SessionScope } from "../../config/sessions.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { SkillCommandSpec } from "../../skills/types.js";
 import type { MsgContext } from "../templating.js";
-import type { ElevatedLevel, ReasoningLevel, ThinkLevel, VerboseLevel } from "../thinking.js";
+import type {
+  ElevatedLevel,
+  ReasoningLevel,
+  ThinkLevel,
+  ThinkingCatalogEntry,
+  VerboseLevel,
+} from "../thinking.js";
 import type { GetReplyOptions, ReplyPayload } from "../types.js";
 import type { InlineDirectives } from "./directive-handling.parse.js";
 import type { TypingController } from "./typing.js";
@@ -61,6 +67,8 @@ export type HandleCommandsParams = {
   workspaceDir: string;
   opts?: GetReplyOptions;
   defaultGroupActivation: () => "always" | "mention";
+  /** Catalog snapshot prepared by model selection for status rendering. */
+  thinkingCatalog?: ThinkingCatalogEntry[];
   resolvedThinkLevel?: ThinkLevel;
   resolvedFastMode?: FastMode;
   resolvedVerboseLevel: VerboseLevel;

--- a/src/auto-reply/reply/get-reply-directives-apply.ts
+++ b/src/auto-reply/reply/get-reply-directives-apply.ts
@@ -435,6 +435,7 @@ export async function applyInlineDirectiveOverrides(params: {
         provider,
         model,
         contextTokens,
+        thinkingCatalog,
         workspaceDir,
         resolvedThinkLevel: resolvedDefaultThinkLevel,
         resolvedVerboseLevel: currentVerboseLevel ?? "off",

--- a/src/auto-reply/reply/get-reply-inline-actions.ts
+++ b/src/auto-reply/reply/get-reply-inline-actions.ts
@@ -20,7 +20,13 @@ import {
 import type { SkillCommandSpec } from "../../skills/types.js";
 import { markCommandReplyForDelivery } from "../reply-payload.js";
 import type { MsgContext, TemplateContext } from "../templating.js";
-import type { ElevatedLevel, ReasoningLevel, ThinkLevel, VerboseLevel } from "../thinking.js";
+import type {
+  ElevatedLevel,
+  ReasoningLevel,
+  ThinkLevel,
+  ThinkingCatalogEntry,
+  VerboseLevel,
+} from "../thinking.js";
 import type { GetReplyOptions, ReplyPayload } from "../types.js";
 import {
   readAbortCutoffFromSessionEntry,
@@ -200,6 +206,7 @@ export async function handleInlineActions(params: {
   elevatedAllowed: boolean;
   elevatedFailures: Array<{ gate: string; key: string }>;
   defaultActivation: Parameters<typeof buildStatusReply>[0]["defaultGroupActivation"];
+  thinkingCatalog?: ThinkingCatalogEntry[];
   resolvedThinkLevel: ThinkLevel | undefined;
   resolvedVerboseLevel: VerboseLevel | undefined;
   resolvedReasoningLevel: ReasoningLevel;
@@ -244,6 +251,7 @@ export async function handleInlineActions(params: {
     elevatedAllowed,
     elevatedFailures,
     defaultActivation,
+    thinkingCatalog,
     resolvedThinkLevel,
     resolvedVerboseLevel,
     resolvedReasoningLevel,
@@ -502,6 +510,7 @@ export async function handleInlineActions(params: {
       model,
       contextTokens,
       workspaceDir,
+      thinkingCatalog,
       resolvedThinkLevel,
       resolvedVerboseLevel: resolvedVerboseLevel ?? "off",
       resolvedReasoningLevel,
@@ -544,6 +553,7 @@ export async function handleInlineActions(params: {
       workspaceDir,
       opts,
       defaultGroupActivation: defaultActivation,
+      thinkingCatalog,
       resolvedThinkLevel,
       resolvedVerboseLevel: resolvedVerboseLevel ?? "off",
       resolvedReasoningLevel,

--- a/src/auto-reply/reply/get-reply-native-slash-fast-path.ts
+++ b/src/auto-reply/reply/get-reply-native-slash-fast-path.ts
@@ -188,6 +188,8 @@ export async function maybeResolveNativeSlashCommandFastReply(params: {
       return resolvedDefaultThinkingLevel;
     };
     const resolvedThinkLevel = normalizeThinkLevel(targetSessionEntry?.thinkingLevel);
+    // This fast path has no model-state owner; prepare side-effect-free catalog facts directly.
+    const thinkingCatalog = await loadModelCatalog({ config: params.cfg, readOnly: true });
     const { buildStatusReply } = await loadStatusCommandRuntime();
     return {
       handled: true,
@@ -203,6 +205,7 @@ export async function maybeResolveNativeSlashCommandFastReply(params: {
           provider: params.provider,
           model: params.model,
           workspaceDir: params.workspaceDir,
+          thinkingCatalog,
           resolvedThinkLevel,
           resolvedVerboseLevel: "off",
           resolvedReasoningLevel: "off",
@@ -315,6 +318,14 @@ export async function maybeResolveNativeSlashCommandFastReply(params: {
     return { handled: true, reply: markCommandReplyForDelivery(directiveResult.reply) };
   }
 
+  const shouldPrepareStatusThinkingCatalog =
+    directiveResult.result.inlineStatusRequested ||
+    directiveResult.result.directives.hasStatusDirective ||
+    directiveResult.result.command.commandBodyNormalized.trim() === "/status";
+  const thinkingCatalog = shouldPrepareStatusThinkingCatalog
+    ? await directiveResult.result.modelState.resolveThinkingCatalog()
+    : undefined;
+
   const inlineActionResult = await handleInlineActions({
     ctx: params.ctx,
     sessionCtx: sessionState.sessionCtx,
@@ -345,6 +356,7 @@ export async function maybeResolveNativeSlashCommandFastReply(params: {
     elevatedAllowed: directiveResult.result.elevatedAllowed,
     elevatedFailures: directiveResult.result.elevatedFailures,
     defaultActivation: () => directiveResult.result.defaultActivation,
+    thinkingCatalog,
     resolvedThinkLevel: directiveResult.result.resolvedThinkLevel,
     resolvedVerboseLevel: directiveResult.result.resolvedVerboseLevel,
     resolvedReasoningLevel: directiveResult.result.resolvedReasoningLevel,

--- a/src/auto-reply/reply/get-reply.fast-path.test.ts
+++ b/src/auto-reply/reply/get-reply.fast-path.test.ts
@@ -524,7 +524,7 @@ describe("getReplyFromConfig fast test bootstrap", () => {
       throw new Error("expected single reply payload");
     }
     expect(reply.text).toContain("Think: high");
-    expect(mocks.loadModelCatalog).not.toHaveBeenCalled();
+    expect(mocks.loadModelCatalog).toHaveBeenCalledExactlyOnceWith({ config: cfg, readOnly: true });
     expect(mocks.ensureAgentWorkspace).not.toHaveBeenCalled();
     expect(mocks.initSessionState).not.toHaveBeenCalled();
     expect(mocks.resolveReplyDirectives).not.toHaveBeenCalled();
@@ -578,7 +578,7 @@ describe("getReplyFromConfig fast test bootstrap", () => {
     }
     expect(reply.text).toContain("Think: xhigh");
     expect(getReplyPayloadMetadata(reply)?.deliverDespiteSourceReplySuppression).toBe(true);
-    expect(mocks.loadModelCatalog).not.toHaveBeenCalled();
+    expect(mocks.loadModelCatalog).toHaveBeenCalledExactlyOnceWith({ config: cfg, readOnly: true });
     expect(mocks.ensureAgentWorkspace).not.toHaveBeenCalled();
     expect(mocks.initSessionState).not.toHaveBeenCalled();
     expect(mocks.resolveReplyDirectives).not.toHaveBeenCalled();

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -882,6 +882,16 @@ export async function getReplyFromConfig(
     });
   };
 
+  const shouldPrepareStatusThinkingCatalog =
+    inlineStatusRequested ||
+    directives.hasStatusDirective ||
+    command.commandBodyNormalized.trim() === "/status";
+  const statusThinkingCatalog = shouldPrepareStatusThinkingCatalog
+    ? await traceGetReplyPhase("reply.prepare_status_thinking_catalog", () =>
+        modelState.resolveThinkingCatalog(),
+      )
+    : undefined;
+
   const inlineActionResult = await traceGetReplyPhase("reply.handle_inline_actions", () =>
     handleInlineActions({
       ctx,
@@ -911,6 +921,7 @@ export async function getReplyFromConfig(
       elevatedAllowed,
       elevatedFailures,
       defaultActivation: () => defaultActivation,
+      thinkingCatalog: statusThinkingCatalog,
       resolvedThinkLevel,
       resolvedVerboseLevel,
       resolvedReasoningLevel,

--- a/src/plugin-sdk/command-status.runtime.test.ts
+++ b/src/plugin-sdk/command-status.runtime.test.ts
@@ -87,6 +87,7 @@ describe("resolveDirectStatusReplyForSession", () => {
     resolveDefaultModelForAgent.mockReturnValue({ provider: "openai", model: "gpt-5.4" });
     resolveDefaultModel.mockReturnValue({ defaultProvider: "openai", defaultModel: "gpt-5.4" });
     createModelSelectionState.mockResolvedValue({
+      resolveThinkingCatalog: vi.fn(async () => []),
       resolveDefaultThinkingLevel: vi.fn(async () => "off"),
       resolveDefaultReasoningLevel: vi.fn(async () => "on"),
     });

--- a/src/plugin-sdk/command-status.runtime.ts
+++ b/src/plugin-sdk/command-status.runtime.ts
@@ -96,6 +96,7 @@ export async function resolveDirectStatusReplyForSession(
     agentCfg,
     resolveDefaultThinkingLevel: () => modelState.resolveDefaultThinkingLevel(),
   });
+  const thinkingCatalog = await modelState.resolveThinkingCatalog();
   let resolvedReasoningLevel = currentReasoningLevel;
   const hasAgentReasoningDefault =
     (agentEntry?.reasoningDefault !== undefined && agentEntry.reasoningDefault !== null) ||
@@ -135,6 +136,7 @@ export async function resolveDirectStatusReplyForSession(
     provider: selectedProvider,
     model: selectedModel,
     contextTokens: statusEntry?.contextTokens ?? 0,
+    thinkingCatalog,
     resolvedThinkLevel: currentThinkLevel,
     resolvedFastMode: currentFastMode,
     resolvedVerboseLevel: currentVerboseLevel ?? "off",

--- a/src/status/status-text.test.ts
+++ b/src/status/status-text.test.ts
@@ -307,3 +307,46 @@ describe("session status cost line", () => {
     );
   });
 });
+
+describe("buildStatusText thinking facts", () => {
+  it("keeps the prepared thinking level for a discovered Ollama reasoning model", async () => {
+    const text = await buildStatusText({
+      cfg: {},
+      sessionEntry: {
+        sessionId: "wa-ollama-think",
+        updatedAt: 0,
+        thinkingLevel: "high",
+        modelOverride: "glm-5.2:cloud",
+        providerOverride: "ollama",
+      },
+      sessionKey: "agent:main:main",
+      statusChannel: "whatsapp",
+      provider: "ollama",
+      model: "glm-5.2:cloud",
+      thinkingCatalog: [
+        {
+          provider: "ollama",
+          id: "glm-5.2:cloud",
+          reasoning: true,
+        },
+      ],
+      resolvedHarness: "openclaw",
+      resolvedThinkLevel: "high",
+      resolvedVerboseLevel: "off",
+      resolvedReasoningLevel: "on",
+      resolveDefaultThinkingLevel: async () => "high",
+      isGroup: false,
+      defaultGroupActivation: () => "mention",
+      pluginHealthLineOverride: "Plugins: test",
+      taskLineOverride: "",
+      skipDefaultTaskLookup: true,
+      primaryModelLabelOverride: "ollama/glm-5.2:cloud",
+      modelAuthOverride: "local",
+      activeModelAuthOverride: "local",
+      includeTranscriptUsage: false,
+    });
+
+    expect(text).toContain("Think: high");
+    expect(text).not.toMatch(/Think:\s*off\b/);
+  });
+});

--- a/src/status/status-text.ts
+++ b/src/status/status-text.ts
@@ -317,6 +317,7 @@ export async function buildStatusText(params: BuildStatusTextParams): Promise<st
     provider,
     model,
     contextTokens,
+    thinkingCatalog,
     resolvedThinkLevel,
     resolvedFastMode,
     resolvedVerboseLevel,
@@ -646,6 +647,7 @@ export async function buildStatusText(params: BuildStatusTextParams): Promise<st
           provider: selectedLookupProvider,
           model: selectedLookupModel,
           level: requestedThinkLevel,
+          catalog: thinkingCatalog,
           agentRuntime: effectiveHarness,
           // Status uses loaded provider facts unless Codex needs OpenAI's static thinking contract.
           providerPolicySource:

--- a/src/status/status-text.types.ts
+++ b/src/status/status-text.types.ts
@@ -4,6 +4,7 @@ import type {
   ElevatedLevel,
   ReasoningLevel,
   ThinkLevel,
+  ThinkingCatalogEntry,
   VerboseLevel,
 } from "../auto-reply/thinking.js";
 import type { SessionEntry, SessionScope } from "../config/sessions.js";
@@ -25,6 +26,8 @@ export type BuildStatusTextParams = {
   provider: string;
   model: string;
   contextTokens?: number;
+  /** Model metadata prepared by the caller; status rendering never loads a catalog. */
+  thinkingCatalog?: ThinkingCatalogEntry[];
   resolvedThinkLevel?: ThinkLevel;
   resolvedFastMode?: FastMode;
   resolvedHarness?: string;


### PR DESCRIPTION
Closes #108337

## What Problem This Solves

Fixes an issue where users running a live-discovered Ollama reasoning model could see `Think: off` in generic `/status` and `session_status` cards even though the active session was using a supported thinking level.

## Why This Change Was Made

Status rendering now consumes model capability facts prepared by its caller. Reply paths carry their existing resolved catalog forward; standalone native and tool status paths perform one read-only catalog load that can use persisted, configured, and manifest facts without starting provider discovery. This replaces the earlier ordered cache/read-only/configured fallback proposal with one explicit fact and keeps rendering free of catalog discovery policy.

## User Impact

WhatsApp and other generic text status surfaces now preserve the active thinking level for discovered Ollama reasoning models. Unrelated reply paths do not load a model catalog, and status reads do not trigger provider discovery.

## Evidence

- `node scripts/run-vitest.mjs src/status/status-text.test.ts src/auto-reply/reply/commands-status.test.ts src/plugin-sdk/command-status.runtime.test.ts src/agents/openclaw-tools.session-status.test.ts src/auto-reply/reply/get-reply-native-slash-fast-path.test.ts` — 139 tests passed across four Vitest shards.
- `node scripts/run-vitest.mjs src/auto-reply/reply/get-reply.fast-path.test.ts` — 22 tests passed, including the two native `/status` assertions identified by the first exact-head CI run.
- `node scripts/check-changed.mjs -- <13 changed files>` — all core/core-test/extension/extension-test typechecks, lint, formatting, plugin-SDK surface guards, import-cycle checks, and database-first guards passed on Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/29670567379
- The regression drives `ollama/glm-5.2:cloud` with `reasoning: true` and a stored `thinkingLevel: high` through the real status formatter, asserting `Think: high` and rejecting `Think: off`.

Contributor diagnosis and reproduction retained from @Bartok9; the branch was rewritten in-house around the prepared-fact owner boundary.
