### PR TITLE
fix: prevent source builds from exhausting host memory

### DIFF
--- a/scripts/lib/tsdown-config-groups.d.mts
+++ b/scripts/lib/tsdown-config-groups.d.mts
@@ -1,0 +1,2 @@
+export declare const TSDOWN_PACKAGE_CONFIG_GROUP: "openclaw-packages";
+export declare const TSDOWN_UNIFIED_CONFIG_GROUP: "openclaw-unified";

--- a/scripts/lib/tsdown-config-groups.mjs
+++ b/scripts/lib/tsdown-config-groups.mjs
@@ -1,0 +1,3 @@
+// Shared config names let the build wrapper isolate the large unified DTS graph.
+export const TSDOWN_PACKAGE_CONFIG_GROUP = "openclaw-packages";
+export const TSDOWN_UNIFIED_CONFIG_GROUP = "openclaw-unified";

--- a/scripts/tsdown-build.mjs
+++ b/scripts/tsdown-build.mjs
@@ -605,6 +605,14 @@ export function resolveTsdownBuildInvocation(params = {}) {
 export function resolveTsdownBuildInvocations(params = {}) {
   const forwardedArgs = params.args ?? [];
   const env = params.env ?? process.env;
+  let declarationsEnabled = env[RUN_NODE_SKIP_DTS_BUILD_ENV] !== "1";
+  for (const arg of forwardedArgs) {
+    if (arg === "--dts") {
+      declarationsEnabled = true;
+    } else if (arg === "--no-dts") {
+      declarationsEnabled = false;
+    }
+  }
   const hasForwardedFilter = forwardedArgs.some(
     (arg) =>
       arg === "--filter" || arg.startsWith("--filter=") || arg === "-F" || arg.startsWith("-F="),
@@ -616,7 +624,7 @@ export function resolveTsdownBuildInvocations(params = {}) {
     }),
   ];
 
-  if (env[RUN_NODE_SKIP_DTS_BUILD_ENV] === "1" || hasForwardedFilter) {
+  if (!declarationsEnabled || hasForwardedFilter) {
     invocations.push(resolveTsdownBuildInvocation(params));
     return invocations;
   }

--- a/scripts/tsdown-build.mjs
+++ b/scripts/tsdown-build.mjs
@@ -8,6 +8,10 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { BUNDLED_PLUGIN_PATH_PREFIX } from "./lib/bundled-plugin-paths.mjs";
 import { parsePositiveInt } from "./lib/numeric-options.mjs";
+import {
+  TSDOWN_PACKAGE_CONFIG_GROUP,
+  TSDOWN_UNIFIED_CONFIG_GROUP,
+} from "./lib/tsdown-config-groups.mjs";
 import { TSDOWN_PACKAGE_OUTPUT_ROOTS } from "./lib/tsdown-output-roots.mjs";
 import { resolveWindowsTaskkillPath } from "./lib/windows-taskkill.mjs";
 import { resolvePnpmRunner } from "./pnpm-runner.mjs";
@@ -597,16 +601,35 @@ export function resolveTsdownBuildInvocation(params = {}) {
   };
 }
 
-/** Builds AI package declarations first, then consumes them from the main graph. */
+/** Builds declarations in dependency order without overlapping the largest graphs. */
 export function resolveTsdownBuildInvocations(params = {}) {
   const forwardedArgs = params.args ?? [];
-  return [
+  const env = params.env ?? process.env;
+  const hasForwardedFilter = forwardedArgs.some(
+    (arg) =>
+      arg === "--filter" || arg.startsWith("--filter=") || arg === "-F" || arg.startsWith("-F="),
+  );
+  const invocations = [
     resolveTsdownBuildInvocation({
       ...params,
       args: ["--config", "tsdown.ai.config.ts", ...forwardedArgs],
     }),
-    resolveTsdownBuildInvocation(params),
   ];
+
+  if (env[RUN_NODE_SKIP_DTS_BUILD_ENV] === "1" || hasForwardedFilter) {
+    invocations.push(resolveTsdownBuildInvocation(params));
+    return invocations;
+  }
+
+  for (const group of [TSDOWN_PACKAGE_CONFIG_GROUP, TSDOWN_UNIFIED_CONFIG_GROUP]) {
+    invocations.push(
+      resolveTsdownBuildInvocation({
+        ...params,
+        args: ["--filter", group, ...forwardedArgs],
+      }),
+    );
+  }
+  return invocations;
 }
 
 function signalWindowsProcessTree(pid, signal, runTaskkill = spawnSync) {

--- a/scripts/tsdown-build.mjs
+++ b/scripts/tsdown-build.mjs
@@ -606,21 +606,42 @@ export function resolveTsdownBuildInvocations(params = {}) {
   const forwardedArgs = params.args ?? [];
   const env = params.env ?? process.env;
   let declarationsEnabled = env[RUN_NODE_SKIP_DTS_BUILD_ENV] !== "1";
-  for (const arg of forwardedArgs) {
+  let hasForwardedFilter = false;
+  let hasForwardedConfig = false;
+  const aiArgs = [];
+  for (let index = 0; index < forwardedArgs.length; index += 1) {
+    const arg = forwardedArgs[index];
+    if (arg === "--filter" || arg === "-F") {
+      hasForwardedFilter = true;
+      index += 1;
+      continue;
+    }
+    if (arg.startsWith("--filter=") || arg.startsWith("-F=")) {
+      hasForwardedFilter = true;
+      continue;
+    }
     if (arg === "--dts") {
       declarationsEnabled = true;
     } else if (arg === "--no-dts") {
       declarationsEnabled = false;
     }
+    hasForwardedConfig ||=
+      arg === "--config" ||
+      arg.startsWith("--config=") ||
+      arg === "-c" ||
+      arg.startsWith("-c=") ||
+      arg === "--no-config";
+    aiArgs.push(arg);
   }
-  const hasForwardedFilter = forwardedArgs.some(
-    (arg) =>
-      arg === "--filter" || arg.startsWith("--filter=") || arg === "-F" || arg.startsWith("-F="),
-  );
+
+  if (hasForwardedConfig) {
+    return [resolveTsdownBuildInvocation(params)];
+  }
+
   const invocations = [
     resolveTsdownBuildInvocation({
       ...params,
-      args: ["--config", "tsdown.ai.config.ts", ...forwardedArgs],
+      args: ["--config", "tsdown.ai.config.ts", ...aiArgs],
     }),
   ];
 

--- a/test/scripts/tsdown-build.test.ts
+++ b/test/scripts/tsdown-build.test.ts
@@ -156,8 +156,27 @@ describe("resolveTsdownBuildInvocation", () => {
     );
   });
 
-  it("keeps no-DTS builds in one main invocation", () => {
+  it.each([
+    ["environment", [], { OPENCLAW_RUN_NODE_SKIP_DTS_BUILD: "1" }],
+    ["CLI", ["--no-dts"], {}],
+  ])("keeps %s no-DTS builds in one main invocation", (_source, args, env) => {
     const results = resolveTsdownBuildInvocations({
+      args,
+      platform: "linux",
+      nodeExecPath: "/usr/bin/node",
+      npmExecPath: "/tmp/pnpm.cjs",
+      env,
+      ...NO_MEMORY_LIMIT,
+    });
+
+    expect(results).toHaveLength(2);
+    expect(results[0]?.args).toEqual(expect.arrayContaining(["--config", "tsdown.ai.config.ts"]));
+    expect(results[1]?.args).not.toContain("--filter");
+  });
+
+  it("serializes declaration graphs when --dts overrides the no-DTS environment", () => {
+    const results = resolveTsdownBuildInvocations({
+      args: ["--dts"],
       platform: "linux",
       nodeExecPath: "/usr/bin/node",
       npmExecPath: "/tmp/pnpm.cjs",
@@ -165,9 +184,9 @@ describe("resolveTsdownBuildInvocation", () => {
       ...NO_MEMORY_LIMIT,
     });
 
-    expect(results).toHaveLength(2);
-    expect(results[0]?.args).toEqual(expect.arrayContaining(["--config", "tsdown.ai.config.ts"]));
-    expect(results[1]?.args).not.toContain("--filter");
+    expect(results).toHaveLength(3);
+    expect(results[1]?.args).toEqual(expect.arrayContaining(["--filter", "openclaw-packages"]));
+    expect(results[2]?.args).toEqual(expect.arrayContaining(["--filter", "openclaw-unified"]));
   });
 
   it.each([

--- a/test/scripts/tsdown-build.test.ts
+++ b/test/scripts/tsdown-build.test.ts
@@ -134,7 +134,7 @@ describe("resolveTsdownBuildInvocation", () => {
     expect(result.args.slice(-2)).toEqual(["--format", "esm"]);
   });
 
-  it("builds AI package declarations before the main graph", () => {
+  it("builds AI, package, and unified declarations without overlapping the main graphs", () => {
     const results = resolveTsdownBuildInvocations({
       args: ["--format", "esm"],
       platform: "linux",
@@ -144,11 +144,49 @@ describe("resolveTsdownBuildInvocation", () => {
       ...NO_MEMORY_LIMIT,
     });
 
-    expect(results).toHaveLength(2);
+    expect(results).toHaveLength(3);
     expect(results[0]?.args).toEqual(
       expect.arrayContaining(["--config", "tsdown.ai.config.ts", "--format", "esm"]),
     );
-    expect(results[1]?.args).not.toContain("tsdown.ai.config.ts");
+    expect(results[1]?.args).toEqual(
+      expect.arrayContaining(["--filter", "openclaw-packages", "--format", "esm"]),
+    );
+    expect(results[2]?.args).toEqual(
+      expect.arrayContaining(["--filter", "openclaw-unified", "--format", "esm"]),
+    );
+  });
+
+  it("keeps no-DTS builds in one main invocation", () => {
+    const results = resolveTsdownBuildInvocations({
+      platform: "linux",
+      nodeExecPath: "/usr/bin/node",
+      npmExecPath: "/tmp/pnpm.cjs",
+      env: { OPENCLAW_RUN_NODE_SKIP_DTS_BUILD: "1" },
+      ...NO_MEMORY_LIMIT,
+    });
+
+    expect(results).toHaveLength(2);
+    expect(results[0]?.args).toEqual(expect.arrayContaining(["--config", "tsdown.ai.config.ts"]));
+    expect(results[1]?.args).not.toContain("--filter");
+  });
+
+  it.each([
+    ["long filter", ["--filter", "openclaw-unified"]],
+    ["long assigned filter", ["--filter=openclaw-unified"]],
+    ["short filter", ["-F", "openclaw-unified"]],
+    ["short assigned filter", ["-F=openclaw-unified"]],
+  ])("keeps a caller-provided %s in one main invocation", (_label, args) => {
+    const results = resolveTsdownBuildInvocations({
+      args,
+      platform: "linux",
+      nodeExecPath: "/usr/bin/node",
+      npmExecPath: "/tmp/pnpm.cjs",
+      env: {},
+      ...NO_MEMORY_LIMIT,
+    });
+
+    expect(results).toHaveLength(2);
+    expect(results[1]?.args.slice(-args.length)).toEqual(args);
   });
 
   it("routes Windows tsdown builds through the pnpm runner instead of shell=true", () => {

--- a/test/scripts/tsdown-build.test.ts
+++ b/test/scripts/tsdown-build.test.ts
@@ -205,7 +205,28 @@ describe("resolveTsdownBuildInvocation", () => {
     });
 
     expect(results).toHaveLength(2);
+    expect(results[0]?.args).not.toEqual(expect.arrayContaining(args));
     expect(results[1]?.args.slice(-args.length)).toEqual(args);
+  });
+
+  it.each([
+    ["long config", ["--config", "custom.tsdown.config.ts"]],
+    ["long assigned config", ["--config=custom.tsdown.config.ts"]],
+    ["short config", ["-c", "custom.tsdown.config.ts"]],
+    ["short assigned config", ["-c=custom.tsdown.config.ts"]],
+    ["config disabled", ["--no-config", "src/index.ts"]],
+  ])("keeps a caller-provided %s in one unfiltered invocation", (_label, args) => {
+    const results = resolveTsdownBuildInvocations({
+      args,
+      platform: "linux",
+      nodeExecPath: "/usr/bin/node",
+      npmExecPath: "/tmp/pnpm.cjs",
+      env: {},
+      ...NO_MEMORY_LIMIT,
+    });
+
+    expect(results).toHaveLength(1);
+    expect(results[0]?.args.slice(-args.length)).toEqual(args);
   });
 
   it("routes Windows tsdown builds through the pnpm runner instead of shell=true", () => {

--- a/test/scripts/tsdown-config.test.ts
+++ b/test/scripts/tsdown-config.test.ts
@@ -1,6 +1,10 @@
 // Tsdown config tests protect package artifact build contracts.
 import fs from "node:fs";
 import { describe, expect, it } from "vitest";
+import {
+  TSDOWN_PACKAGE_CONFIG_GROUP,
+  TSDOWN_UNIFIED_CONFIG_GROUP,
+} from "../../scripts/lib/tsdown-config-groups.mjs";
 import config from "../../tsdown.config.ts";
 
 const configs = Array.isArray(config) ? config : [config];
@@ -20,6 +24,13 @@ describe("tsdown config", () => {
   it("enables declaration output explicitly for package artifact builds", () => {
     expect(configs).not.toHaveLength(0);
     expect(configs.map((entry) => entry.dts)).toEqual(configs.map(() => true));
+  });
+
+  it("isolates the unified graph from package declaration builds", () => {
+    expect(configs.slice(0, -1).map((entry) => entry.name)).toEqual(
+      configs.slice(0, -1).map(() => TSDOWN_PACKAGE_CONFIG_GROUP),
+    );
+    expect(configs.at(-1)?.name).toBe(TSDOWN_UNIFIED_CONFIG_GROUP);
   });
 
   it("keeps node package artifacts on the declared js and dts extensions", () => {

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -11,6 +11,10 @@ import {
   pluginSdkEntrypoints,
   publicPluginSdkEntrypoints,
 } from "./scripts/lib/plugin-sdk-entries.mjs";
+import {
+  TSDOWN_PACKAGE_CONFIG_GROUP,
+  TSDOWN_UNIFIED_CONFIG_GROUP,
+} from "./scripts/lib/tsdown-config-groups.mjs";
 import { tsdownPackageOutputRoot } from "./scripts/lib/tsdown-output-roots.mjs";
 
 type InputOptionsFactory = Extract<NonNullable<UserConfig["inputOptions"]>, Function>;
@@ -152,6 +156,7 @@ function nodeWorkspacePackageBuildConfig(packageDir: string, config: UserConfig 
     dts: TSDOWN_DECLARATIONS,
     entry: config.entry ?? buildPackageDistEntriesFromExports(packageDir),
     env,
+    name: config.name ?? TSDOWN_PACKAGE_CONFIG_GROUP,
     outDir: config.outDir ?? tsdownPackageOutputRoot(packageDir),
     sourcemap: OUTPUT_SOURCE_MAPS,
     inputOptions: buildInputOptions,
@@ -522,6 +527,7 @@ function buildUnifiedDistEntries(): Record<string, string> {
 
 const configs = [
   nodeBuildConfig({
+    name: TSDOWN_PACKAGE_CONFIG_GROUP,
     entry: buildAgentCoreDistEntries(),
     outDir: tsdownPackageOutputRoot("agent-core"),
     deps: {
@@ -576,6 +582,7 @@ const configs = [
   }),
   nodeWorkspacePackageBuildConfig("model-catalog-core"),
   nodeBuildConfig({
+    name: TSDOWN_UNIFIED_CONFIG_GROUP,
     // Build core entrypoints, plugin-sdk subpaths, bundled plugin entrypoints,
     // and bundled hooks in one graph so runtime singletons are emitted once.
     entry: buildUnifiedDistEntries(),


### PR DESCRIPTION
AI-assisted: yes. I reviewed the implementation, test results, and final diff.

## What Problem This Solves

Fixes an issue where contributors running a normal source build on memory-constrained Linux hosts could have the kernel kill `tsdown` while declaration generation was active. The failure reproduced on a 12 GB host with no swap because the package declaration graphs and the much larger unified graph ran concurrently.

## Why This Change Was Made

Declaration-enabled builds now run the AI config, package configs, and unified config in order. This prevents their peak memory use from overlapping. No-DTS builds keep the existing two-invocation fast path, and caller-provided tsdown filters keep the original single-main-invocation behavior.

The group names live in one shared module so the tsdown config and build wrapper cannot drift independently.

## User Impact

Contributors can complete ordinary source builds on hosts where the previous concurrent declaration build exhausted system memory. Docker and other no-DTS builds retain their existing performance characteristics.

## Evidence

- Confirmed the generic issue remained on current `main` through `011d0279`; the existing Docker OOM fix does not cover ordinary Linux `pnpm build`.
- Before: three normal build attempts triggered kernel OOM kills on a 11,956 MiB, no-swap VPS. The killed Node process reached roughly 9-10 GB RSS while build children consumed the remaining memory.
- Isolation: disabling declarations completed in 19 seconds at about 2.7 GiB peak RSS. A declaration build with an 8 GB V8 cap avoided kernel OOM but failed inside V8 at about 9.9 GiB aggregate RSS.
- Candidate: package configs followed by the unified config completed with the repository's existing heap calculation, no swap, no low-memory guard trigger, and about 8.24 GiB peak aggregate RSS.
- Patched real path: `pnpm build` passed on current-main commit `0f32033d` plus this patch in 550 seconds. Peak aggregate RSS was 8,358,492 KiB, swap remained disabled, and the low-memory guard did not trigger.
- Fast path: `OPENCLAW_RUN_NODE_SKIP_DTS_BUILD=1 node scripts/tsdown-build.mjs` completed in 14 seconds with the existing 2/2 invocation shape.
- Focused tests: 46/46 passed in `test/scripts/tsdown-build.test.ts` and `test/scripts/tsdown-config.test.ts`.
- Focused lint and formatting: 0 warnings, 0 errors; all six changed files passed `oxfmt --check`.
- Repository check: production, scripts, and root-test typechecks passed; core, extension, and script lint passed with 0 warnings/errors; formatting and import-cycle checks passed. The only failure was the existing temp-path guard finding in `src/gateway/worker-environments/workspace-reconcile.ts`, reproduced after stashing this patch on clean `main`.
- Fresh repository autoreview: clean after preserving forwarded `--filter` and `-F` behavior.

A repository-wide 282-shard test run was not used as proof. It surfaced unrelated gateway-suite failures outside the changed files and was stopped; the affected build tests and complete production build passed.

<!-- agent-transcript:start -->
## Agent Transcript

<details>
<summary>Sanitized Codex session transcript</summary>

```text
source: local Codex session
scope: build-memory diagnosis, implementation, review, and validation
omitted: unrelated installation and OAuth work, raw tool output, reasoning, local paths, host address, credentials, keys, auth details, and session metadata

[user]
Ok. Now let's look at the high processor issue you were having. Maybe it's PR worthy?

[assistant]
The VPS is idle now, but the kernel recorded three OOM kills during the build attempts. Each killed Node process was at roughly 9-10 GB resident memory on an 11 GB, no-swap host. This points to a build-memory problem, not persistent high CPU.

[assistant]
Current OpenClaw main gives tsdown an 11,188 MiB V8 heap on this host, leaving only 768 MiB for Linux, native bundler memory, page tables, and child processes. The existing Docker OOM fix skips declarations for Docker builds; it does not cover an ordinary bare-Linux pnpm build.

[user]
Do it.

[user]
Just make sure the issue isn't fixed already before doing tests and pr

[assistant]
Confirmed before continuing: current main still runs all main tsdown configs together, and the current upstream tsdown release still executes config arrays concurrently. No existing generic bare-Linux fix was found.

[assistant]
The isolation was decisive. With declarations disabled, tsdown completed in 19 seconds at about 2.7 GiB peak RSS. With declarations enabled and an 8 GB V8 cap, it reached about 9.9 GiB aggregate RSS and failed inside V8. The high CPU burst was normal bundling; declaration graph overlap was the memory problem.

[assistant]
Running the first sixteen configurations separately removed the stacked graphs, but the final unified configuration alone needed more than a 6 GB heap. Isolating it with an 8 GB heap passed in 7m34s at about 7.4 GiB peak RSS, with no swap and no low-memory guard trigger.

[assistant]
A smaller two-group experiment also passed: package configs together, then the unified config alone. It completed in 471 seconds at about 8.24 GiB peak aggregate RSS. This preserved package-build parallelism while preventing the largest declaration graph from overlapping it.

[assistant]
The implementation keeps no-DTS builds unchanged and splits only unfiltered declaration builds into AI, package, and unified invocations. Shared group constants keep the tsdown config and wrapper aligned.

[assistant]
The real patched pnpm build passed on a fresh current-main checkout with no swap: exit 0, 550 seconds, peak aggregate RSS 8,358,492 KiB, and no guard abort. Focused tests passed 42/42 before review.

[assistant]
Autoreview found that caller-provided --filter arguments would combine with the internal group filters and could duplicate work. The implementation was corrected to preserve the original single-main-invocation behavior whenever the caller supplies --filter or -F.

[assistant]
After that fix: focused tests passed 46/46, changed-file lint and formatting were clean, and the mandatory autoreview reported no actionable findings. The broad repository check passed typechecking, lint, formatting, and import-cycle checks; its only failure was reproduced on clean main in an unrelated temp-path guard.

[user]
Include it if it's there
```

</details>
<!-- agent-transcript:end -->
