### PR TITLE
fix(installer): bound PowerShell download stalls

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -306,9 +306,30 @@ function Ensure-PortableNodeOnUserPath {
     }
 }
 
+function Get-WebRequestTimeoutParameters {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$CommandName,
+        [Parameter(Mandatory = $true)]
+        [int]$LegacyTimeoutSec
+    )
+
+    $command = Get-Command $CommandName -ErrorAction Stop
+    # PowerShell 7.4+ exposes a per-read limit, which bounds body stalls without rejecting slow
+    # connections. Earlier versions only expose TimeoutSec, so downloads keep a longer allowance.
+    if ($command.Parameters.ContainsKey("OperationTimeoutSeconds")) {
+        return @{
+            OperationTimeoutSeconds = 30
+        }
+    }
+
+    return @{ TimeoutSec = $LegacyTimeoutSec }
+}
+
 function Resolve-PortableNodeDownload {
     $architecture = Get-WindowsPortableArchitecture
-    $index = Invoke-RestMethod -Uri "https://nodejs.org/dist/index.json"
+    $requestTimeouts = Get-WebRequestTimeoutParameters -CommandName "Invoke-RestMethod" -LegacyTimeoutSec 30
+    $index = Invoke-RestMethod -Uri "https://nodejs.org/dist/index.json" @requestTimeouts
     $release = $index |
         Where-Object { $_.version -match '^v24\.' } |
         Select-Object -First 1
@@ -396,7 +417,8 @@ function Install-PortableNode {
 
     try {
         Write-Host "  Downloading Node.js $($download.Version)..." -ForegroundColor Gray
-        Invoke-WebRequest -UseBasicParsing -Uri $download.Url -OutFile $tmpZip
+        $downloadTimeouts = Get-WebRequestTimeoutParameters -CommandName "Invoke-WebRequest" -LegacyTimeoutSec 600
+        Invoke-WebRequest -UseBasicParsing -Uri $download.Url -OutFile $tmpZip @downloadTimeouts
         Expand-PortableNodeArchive -ZipPath $tmpZip -DestinationPath $portableRoot
     } finally {
         if (Test-Path $tmpZip) {
@@ -652,7 +674,8 @@ function Resolve-PortableGitDownload {
         "User-Agent" = "openclaw-installer"
         "Accept" = "application/vnd.github+json"
     }
-    $release = Invoke-RestMethod -Uri $releaseApi -Headers $headers
+    $requestTimeouts = Get-WebRequestTimeoutParameters -CommandName "Invoke-RestMethod" -LegacyTimeoutSec 30
+    $release = Invoke-RestMethod -Uri $releaseApi -Headers $headers @requestTimeouts
     if (-not $release -or -not $release.assets) {
         throw "Could not resolve latest git-for-windows release metadata."
     }
@@ -708,7 +731,8 @@ function Install-PortableGit {
 
     try {
         Write-Host "  Downloading $($download.Tag)..." -ForegroundColor Gray
-        Invoke-WebRequest -Uri $download.Url -OutFile $tmpZip
+        $downloadTimeouts = Get-WebRequestTimeoutParameters -CommandName "Invoke-WebRequest" -LegacyTimeoutSec 600
+        Invoke-WebRequest -Uri $download.Url -OutFile $tmpZip @downloadTimeouts
         Expand-Archive -Path $tmpZip -DestinationPath $tmpExtract -Force
         Move-Item -Path (Join-Path $tmpExtract "*") -Destination $portableRoot -Force
     } finally {

--- a/test/scripts/install-ps1.test.ts
+++ b/test/scripts/install-ps1.test.ts
@@ -156,6 +156,8 @@ describe("install.ps1 failure handling", () => {
           "$env:PROCESSOR_ARCHITEW6432 = $null",
           "$env:PROCESSOR_ARCHITECTURE = 'ARM64'",
           "function Invoke-RestMethod {",
+          "  param([string]$Uri, [object]$Headers, [int]$TimeoutSec)",
+          '  if ($TimeoutSec -ne 30) { throw "TimeoutSec=$TimeoutSec" }',
           "  [pscustomobject]@{",
           "    tag_name = 'v2.54.0.windows.1'",
           "    assets = @(",
@@ -186,7 +188,8 @@ describe("install.ps1 failure handling", () => {
           '  throw "Unexpected CIM class $ClassName"',
           "}",
           "function Invoke-RestMethod {",
-          "  param([string]$Uri, [object]$Headers)",
+          "  param([string]$Uri, [object]$Headers, [int]$OperationTimeoutSeconds)",
+          '  if ($OperationTimeoutSeconds -ne 30) { throw "OperationTimeoutSeconds=$OperationTimeoutSeconds" }',
           "  if ($Uri -eq 'https://nodejs.org/dist/index.json') {",
           "    return @(",
           "      [pscustomobject]@{ version = 'v24.17.0'; files = @('win-arm64-zip', 'win-x64-zip') }",
@@ -648,6 +651,7 @@ describe("install.ps1 failure handling", () => {
     const depsRootBody = extractFunctionBody(source, "Get-OpenClawDepsRoot");
     const resolveNodeBody = extractFunctionBody(source, "Resolve-PortableNodeDownload");
     const expandNodeBody = extractFunctionBody(source, "Expand-PortableNodeArchive");
+    const timeoutParametersBody = extractFunctionBody(source, "Get-WebRequestTimeoutParameters");
 
     expect(installNodeBody).toContain("Install-PortableNode");
     expect(installNodeBody).toContain("Portable Node.js bootstrap failed");
@@ -665,6 +669,10 @@ describe("install.ps1 failure handling", () => {
       '[Environment]::SetEnvironmentVariable("Path", $newUserPath, "User")',
     );
     expect(portableNodeBody).toContain("Invoke-WebRequest -UseBasicParsing");
+    expect(portableNodeBody).toContain(
+      'Get-WebRequestTimeoutParameters -CommandName "Invoke-WebRequest" -LegacyTimeoutSec 600',
+    );
+    expect(portableNodeBody).toContain("@downloadTimeouts");
     expect(portableNodeBody).toContain("Expand-PortableNodeArchive");
     expect(portableNodeBody).not.toContain("Expand-Archive");
     expect(portableNodeBody).not.toContain("New-Item -ItemType Directory -Force -Path $tmpExtract");
@@ -675,8 +683,15 @@ describe("install.ps1 failure handling", () => {
     );
     expect(expandNodeBody).toContain("System.IO.Compression.ZipFile");
     expect(resolveNodeBody).toContain("https://nodejs.org/dist/index.json");
+    expect(resolveNodeBody).toContain(
+      'Get-WebRequestTimeoutParameters -CommandName "Invoke-RestMethod" -LegacyTimeoutSec 30',
+    );
+    expect(resolveNodeBody).toContain("@requestTimeouts");
     expect(resolveNodeBody).toContain("win-$architecture-zip");
     expect(resolveNodeBody).toContain("node-$($release.version)-win-$architecture.zip");
+    expect(timeoutParametersBody).toContain('ContainsKey("OperationTimeoutSeconds")');
+    expect(timeoutParametersBody).toContain("OperationTimeoutSeconds = 30");
+    expect(timeoutParametersBody).toContain("TimeoutSec = $LegacyTimeoutSec");
   });
 
   it("persists user-local portable Git for future git-backed updates", () => {
@@ -704,6 +719,14 @@ describe("install.ps1 failure handling", () => {
     expect(portableArchitectureBody).toContain("PROCESSOR_ARCHITEW6432");
     expect(portableArchitectureBody).toContain("PROCESSOR_ARCHITECTURE");
     expect(portableGitDownloadBody).toContain("Get-WindowsPortableArchitecture");
+    expect(portableGitDownloadBody).toContain(
+      'Get-WebRequestTimeoutParameters -CommandName "Invoke-RestMethod" -LegacyTimeoutSec 30',
+    );
+    expect(portableGitDownloadBody).toContain("@requestTimeouts");
+    expect(portableGitBody).toContain(
+      'Get-WebRequestTimeoutParameters -CommandName "Invoke-WebRequest" -LegacyTimeoutSec 600',
+    );
+    expect(portableGitBody).toContain("@downloadTimeouts");
     expect(portableGitDownloadBody).toContain("'^MinGit-.*-arm64\\.zip$'");
     expect(portableGitDownloadBody).toContain("'^MinGit-.*-64-bit\\.zip$'");
   });


### PR DESCRIPTION
## What Problem This Solves

The Windows installer can wait indefinitely when a portable Node or Git metadata/download response connects but stops delivering body data. Its four `Invoke-RestMethod` / `Invoke-WebRequest` calls did not configure request timeouts.

## Why This Change Was Made

PowerShell 7.4+ now uses `OperationTimeoutSeconds=30`, which is a per-read idle deadline rather than a total download deadline. This deliberately leaves DNS/TCP/TLS/header tolerance unchanged, matching the post-connect-only policy used by the shell installers.

Older PowerShell versions do not expose the operation timeout separately, so the installer feature-detects the cmdlet parameter and falls back to `TimeoutSec`: 30 seconds for small metadata responses and 600 seconds for portable archives.

## User Impact

A portable Node or Git response that stops transferring data now fails through the installer's existing fallback/error path. Large or slow archives can still complete as long as data keeps arriving; supported PowerShell versions do not get a new connection or total wall-clock cap.

## Evidence

- Microsoft documents `OperationTimeoutSeconds` as a per-stream-read timeout and notes that large downloads continue unless the stream stalls: https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/invoke-webrequest?view=powershell-7.6#-operationtimeoutseconds
- Exact-head focused test with official PowerShell 7.6.3: `PATH=/tmp/openclaw-pwsh-7.6.3:$PATH node scripts/test-projects.mjs test/scripts/install-ps1.test.ts` -> 27 passed.
- Controlled real `Invoke-WebRequest -OutFile` proof against a local HTTP server, scaled to 2 seconds: a response that sent headers and then stalled failed after 2.21s; a response that delivered one byte per second completed in 4.01s with all 4 bytes.
- Live resolver proof: Node metadata selected `v24.18.0` with both Windows x64/ARM64 zip assets; Git for Windows selected `v2.55.0.windows.3` with matching MinGit assets.
- Fresh independent Codex adversarial review found no accepted/actionable findings after removing the connection-stage deadline.
- `git diff --check upstream/main...HEAD` passes.
- Crabbox/Testbox was unavailable in this checkout, so the focused test used the repository's narrow local test wrapper; hosted exact-head CI remains the remote proof gate.
