### PR TITLE
feat(slack): statusReactions activation mode for work-gated lifecycle

### DIFF
--- a/extensions/slack/src/monitor.tool-result.test.ts
+++ b/extensions/slack/src/monitor.tool-result.test.ts
@@ -738,6 +738,59 @@ describe("monitorSlackProvider tool results", () => {
     });
   });
 
+  function setWorkActivationConfig(options: { requireMention?: boolean } = {}) {
+    slackTestState.config = {
+      messages: {
+        responsePrefix: "PFX",
+        ackReaction: "👀",
+        ackReactionScope: "group-mentions",
+        groupChat: { visibleReplies: "automatic" },
+        removeAckAfterReply: true,
+        statusReactions: {
+          enabled: true,
+          activation: "work",
+          timing: { debounceMs: 0, doneHoldMs: 0, errorHoldMs: 0 },
+        },
+      },
+      channels: {
+        slack: {
+          dm: { enabled: true, policy: "open", allowFrom: ["*"] },
+          groupPolicy: "open",
+          ...(options.requireMention === undefined
+            ? {}
+            : { requireMention: options.requireMention }),
+        },
+      },
+    };
+  }
+
+  it("work activation adds no reaction to an un-mentioned turn without work signals", async () => {
+    // The lifecycle is armed for the un-mentioned turn but never engages (no
+    // reasoning/tool events), so neither queued nor terminal reactions appear.
+    replyMock.mockResolvedValue({ text: "hi" });
+    setWorkActivationConfig({ requireMention: false });
+    mockGeneralChannelInfo();
+
+    await runSlackMessageOnce(monitorSlackProvider, {
+      event: makeSlackMessageEvent({ ts: "456", channel_type: "channel" }),
+    });
+    await flush();
+
+    expect(replyMock).toHaveBeenCalledTimes(1);
+    expect(reactionAddMock).not.toHaveBeenCalled();
+  });
+
+  it("work activation keeps the queued ack flow for mentioned turns", async () => {
+    replyMock.mockResolvedValue({ text: "hi" });
+    setWorkActivationConfig();
+    mockGeneralChannelInfo();
+    await runMentionGatedChannelMessageAndFlush();
+
+    expect(reactionAddMock).toHaveBeenCalledWith(
+      expect.objectContaining({ channel: "C1", timestamp: "456", name: "eyes" }),
+    );
+  });
+
   it("replies with pairing code when dmPolicy is pairing and no allowFrom is set", async () => {
     setPairingOnlyDirectMessages();
 

--- a/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
@@ -114,10 +114,22 @@ let capturedReplyOptions:
     }
   | undefined;
 let capturedStatusReactionOptions: { enabled?: boolean; initialEmoji?: string } | undefined;
+let statusReactionControllerEngaged = false;
 const statusReactionControllerMock = {
-  setQueued: vi.fn(async () => {}),
-  setThinking: vi.fn(async () => {}),
-  setTool: vi.fn(async () => {}),
+  // Mirrors the real controller: any requested transition marks engagement,
+  // which the dispatch terminal block checks before done/error/restore.
+  get engaged() {
+    return statusReactionControllerEngaged;
+  },
+  setQueued: vi.fn(async () => {
+    statusReactionControllerEngaged = true;
+  }),
+  setThinking: vi.fn(async () => {
+    statusReactionControllerEngaged = true;
+  }),
+  setTool: vi.fn(async () => {
+    statusReactionControllerEngaged = true;
+  }),
   setError: vi.fn(async () => {}),
   setDone: vi.fn(async () => {}),
   clear: vi.fn(async () => {}),
@@ -1342,8 +1354,11 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
     reactSlackMessageMock.mockReset();
     removeSlackReactionMock.mockReset();
     logVerboseMock.mockReset();
+    statusReactionControllerEngaged = false;
     for (const value of Object.values(statusReactionControllerMock)) {
-      value.mockClear();
+      if (typeof value === "function") {
+        value.mockClear();
+      }
     }
     mockedNativeStreaming = false;
     mockedBlockStreamingEnabled = false;
@@ -1511,8 +1526,11 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
       }),
     );
 
+    statusReactionControllerEngaged = false;
     for (const value of Object.values(statusReactionControllerMock)) {
-      value.mockClear();
+      if (typeof value === "function") {
+        value.mockClear();
+      }
     }
 
     await dispatchPreparedSlackMessage(

--- a/extensions/slack/src/monitor/message-handler/dispatch.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.ts
@@ -536,9 +536,14 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
   const messageTs = message.ts ?? message.event_ts;
   const incomingThreadTs = message.thread_ts;
   let didSetStatus = false;
+  // activation "work" arms the lifecycle for any eligible run; the reaction
+  // itself only appears once the run produces a work signal (reasoning/tool),
+  // mirroring the progress-draft work gate. Default "ack" keeps lifecycle
+  // updates limited to runs that sent an ack reaction.
+  const statusReactionsActivation = cfg.messages?.statusReactions?.activation ?? "ack";
   const statusReactionsEnabled =
     prepared.ctxPayload.InboundEventKind !== "room_event" &&
-    Boolean(prepared.ackReactionPromise) &&
+    (Boolean(prepared.ackReactionPromise) || statusReactionsActivation === "work") &&
     Boolean(reactionMessageTs) &&
     cfg.messages?.statusReactions?.enabled === true;
   const slackStatusAdapter: StatusReactionAdapter = {
@@ -585,7 +590,10 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
     },
   });
 
-  if (statusReactionsEnabled) {
+  // Only ack-eligible runs show the queued reaction up front; work-activated
+  // runs stay reaction-free until their first work signal engages the
+  // controller via setThinking/setTool.
+  if (statusReactionsEnabled && Boolean(prepared.ackReactionPromise)) {
     void statusReactions.setQueued();
   }
 
@@ -2277,7 +2285,9 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
     },
   );
 
-  if (statusReactionsEnabled) {
+  // engaged: a work-activated run that never produced a work signal must not
+  // gain a reaction at the end (setDone/restoreInitial would add one).
+  if (statusReactionsEnabled && statusReactions.engaged) {
     if (dispatchError) {
       await statusReactions.setError();
       if (ctx.removeAckAfterReply) {

--- a/src/channels/status-reactions.slack-lifecycle.test.ts
+++ b/src/channels/status-reactions.slack-lifecycle.test.ts
@@ -247,6 +247,60 @@ describe("Slack status reaction lifecycle", () => {
     expect(adapter.setReaction).not.toHaveBeenCalled();
   });
 
+  it("engaged stays false until a transition is requested", async () => {
+    const { adapter } = createSlackMockAdapter();
+    const ctrl = createStatusReactionController({
+      enabled: true,
+      adapter,
+      initialEmoji: "eyes",
+      timing: { debounceMs: 0, stallSoftMs: 99999, stallHardMs: 99999 },
+    });
+
+    expect(ctrl.engaged).toBe(false);
+    void ctrl.setThinking();
+    expect(ctrl.engaged).toBe(true);
+  });
+
+  it("engaged stays false when disabled", async () => {
+    const { adapter } = createSlackMockAdapter();
+    const ctrl = createStatusReactionController({
+      enabled: false,
+      adapter,
+      initialEmoji: "eyes",
+    });
+
+    void ctrl.setQueued();
+    void ctrl.setThinking();
+    expect(ctrl.engaged).toBe(false);
+  });
+
+  it("lazy activation: first tool event starts the lifecycle without queued", async () => {
+    // Work-activated runs skip setQueued; the first work signal engages the
+    // controller directly with the tool emoji, then completes normally.
+    const { adapter, active, log } = createSlackMockAdapter();
+    const ctrl = createStatusReactionController({
+      enabled: true,
+      adapter,
+      initialEmoji: "eyes",
+      timing: { debounceMs: 0, stallSoftMs: 99999, stallHardMs: 99999, doneHoldMs: 0 },
+    });
+
+    expect(ctrl.engaged).toBe(false);
+    void ctrl.setTool("exec");
+    await vi.advanceTimersByTimeAsync(10);
+    expect(ctrl.engaged).toBe(true);
+    expect(active.has("eyes")).toBe(false);
+    expect(log[0]).toBe(`+${EXEC_TOOL_EMOJI}`);
+
+    await ctrl.setDone();
+    await vi.advanceTimersByTimeAsync(10);
+    expect(active.has(DEFAULT_EMOJIS.done)).toBe(true);
+
+    await ctrl.clear();
+    await vi.advanceTimersByTimeAsync(10);
+    expect(active.size).toBe(0);
+  });
+
   it("coding tool resolves to coding emoji", async () => {
     const { adapter, active } = createSlackMockAdapter();
     const ctrl = createStatusReactionController({

--- a/src/channels/status-reactions.ts
+++ b/src/channels/status-reactions.ts
@@ -41,6 +41,13 @@ export type StatusReactionTiming = {
 
 /** Controller API for agent status reaction state transitions. */
 export type StatusReactionController = {
+  /**
+   * True once any state transition has been requested while enabled.
+   * Callers using lazy activation can check this before running terminal
+   * transitions (done/error/restore) so a run that never showed a reaction
+   * does not gain one at the end.
+   */
+  readonly engaged: boolean;
   setQueued: () => Promise<void> | void;
   setThinking: () => Promise<void> | void;
   setTool: (toolName?: string) => Promise<void> | void;
@@ -222,6 +229,7 @@ export function createStatusReactionController(params: {
 
   let currentEmoji = "";
   let pendingEmoji = "";
+  let engaged = false;
   let debounceTimer: NodeJS.Timeout | null = null;
   let stallSoftTimer: NodeJS.Timeout | null = null;
   let stallHardTimer: NodeJS.Timeout | null = null;
@@ -320,6 +328,7 @@ export function createStatusReactionController(params: {
     if (!enabled || finished) {
       return;
     }
+    engaged = true;
 
     // Skip duplicate sends while still refreshing stall timers for active phases.
     if (emoji === currentEmoji || emoji === pendingEmoji) {
@@ -454,6 +463,9 @@ export function createStatusReactionController(params: {
   }
 
   return {
+    get engaged() {
+      return engaged;
+    },
     setQueued,
     setThinking,
     setTool,

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -2086,6 +2086,8 @@ export const FIELD_HELP: Record<string, string> = {
     "Lifecycle status reactions that update the emoji on the trigger message as the agent progresses (queued → thinking → tool → done/error).",
   "messages.statusReactions.enabled":
     "Enable lifecycle status reactions on supported channels. Discord treats unset as enabled when ack reactions are active; Slack, Signal, Telegram, and WhatsApp require this to be true before lifecycle reactions are used. Slack uses native assistant thread status for progress by default.",
+  "messages.statusReactions.activation":
+    'When the lifecycle attaches to a run ("ack" default, "work"). "ack" limits lifecycle updates to runs that sent an ack reaction. "work" attaches lazily on the run\'s first work signal (reasoning or tool event) regardless of ack, so any run that starts real work shows the lifecycle; runs that never do work never gain a reaction. Currently honored by Slack.',
   "messages.statusReactions.emojis":
     "Override default status reaction emojis. Keys: queued, thinking, compacting, tool, coding, web, deploy, build, concierge, done, error, stallSoft, stallHard. Telegram chooses the first supported fallback when a configured emoji is not available in the chat.",
   "messages.statusReactions.timing":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -1038,6 +1038,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "messages.removeAckAfterReply": "Remove Ack Reaction After Reply",
   "messages.statusReactions": "Status Reactions",
   "messages.statusReactions.enabled": "Enable Status Reactions",
+  "messages.statusReactions.activation": "Status Reaction Activation",
   "messages.statusReactions.emojis": "Status Reaction Emojis",
   "messages.statusReactions.timing": "Status Reaction Timing",
   "messages.inbound.debounceMs": "Inbound Message Debounce (ms)",

--- a/src/config/types.messages.ts
+++ b/src/config/types.messages.ts
@@ -102,6 +102,14 @@ export type StatusReactionsTimingConfig = {
 export type StatusReactionsConfig = {
   /** Enable lifecycle status reactions (default: false). */
   enabled?: boolean;
+  /**
+   * When the lifecycle attaches to a run (default: "ack").
+   * - "ack": only runs that sent an ack reaction get lifecycle updates.
+   * - "work": any eligible run gets lifecycle updates, attached lazily on its
+   *   first work signal (reasoning or tool event) — runs that never do work
+   *   never gain a reaction. Mirrors the progress-draft work gate.
+   */
+  activation?: "ack" | "work";
   /** Override default emojis. */
   emojis?: StatusReactionsEmojiConfig;
   /** Override default timing. */

--- a/src/config/zod-schema.session.ts
+++ b/src/config/zod-schema.session.ts
@@ -167,6 +167,7 @@ export const MessagesSchema = z
     statusReactions: z
       .object({
         enabled: z.boolean().optional(),
+        activation: z.enum(["ack", "work"]).optional(),
         emojis: z
           .object({
             queued: z.string().optional(),


### PR DESCRIPTION
## What Problem This Solves

`messages.statusReactions` gives great lifecycle feedback (queued → thinking → tool → done/error), but on Slack it only attaches to runs that sent an ack reaction. Operators who scope acks tightly (e.g. `ackReactionScope: "group-mentions"` so the bot doesn't react to every message it merely observes) lose the lifecycle entirely for legitimate un-mentioned runs — allowlisted bot wakes, `requireMention: false` channels, ambient automations. Widening the ack scope isn't an answer: the ack fires at wake time, before the run has done anything, so `group-all` reacts to every observed message including the ones the agent stays silent on.

## Why This Change Was Made

The progress-draft system already solved this exact problem with a work gate (draft appears only once the run produces real work). This PR gives status reactions the same option:

- `messages.statusReactions.activation: "ack" | "work"` (default `"ack"`, zero behavior change).
- `"work"` arms the lifecycle for any eligible run but attaches it lazily on the run's first work signal (reasoning or tool event). No queued reaction up front; the first reaction a bystander sees is the run actually doing something. Runs that never do work never gain a reaction.
- The controller now exposes an `engaged` latch (true once any transition was requested while enabled). The Slack dispatch terminal block checks it so `setDone`/`restoreInitial` can't add a first-ever reaction at the end of a run that never engaged.

Framed as a generic activation policy — nothing here is specific to any particular bot workflow, and other channel extensions can adopt the same mode later (this PR wires Slack only; the config help says so).

## User Impact

- Default (`"ack"` or unset): no change.
- Opt-in `"work"`: un-mentioned/ack-less runs show the same lifecycle reactions mentioned runs get, appearing only once real work starts. Combined with `removeAckAfterReply`, threads end clean.

## Evidence

- New controller tests: `engaged` latch semantics + lazy activation flow (tool-first, no queued) in `src/channels/status-reactions.slack-lifecycle.test.ts`.
- New dispatch tests in `extensions/slack/src/monitor.tool-result.test.ts`: work activation adds **no** reaction to an un-mentioned turn with no work signals; mentioned turns keep the exact queued-ack flow.
- `pnpm check` passes; `pnpm test:extension slack` passes (1868 tests); `src/config` suite passes except the pre-existing `entry-freshness` time-of-day flake (fails identically on a clean checkout).
- Live validation: running this policy (hand-applied to the 2026.6.11 dist) on our own Slack workspace gateway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DsnFJwNsDoBNG4bBmKcqRU