### PR TITLE
fix(codex): add WebSocket handshake timeout to app-server transport

### DIFF
--- a/extensions/codex/src/app-server/client.ts
+++ b/extensions/codex/src/app-server/client.ts
@@ -291,7 +291,10 @@ export class CodexAppServerClient {
 
   /** Starts a new app-server client using resolved runtime start options. */
   static start(options?: Partial<CodexAppServerStartOptions>): CodexAppServerClient {
-    const defaults = resolveCodexAppServerRuntimeOptions().start;
+    // One resolve owns start defaults and the operator request-timeout budget so
+    // websocket/unix upgrades do not invent a second fixed handshake policy.
+    const runtime = resolveCodexAppServerRuntimeOptions();
+    const defaults = runtime.start;
     const startOptions = {
       ...defaults,
       ...options,
@@ -301,7 +304,11 @@ export class CodexAppServerClient {
       throw new Error("Managed Codex app-server start options must be resolved before spawn.");
     }
     if (startOptions.transport === "websocket" || startOptions.transport === "unix") {
-      return new CodexAppServerClient(createWebSocketTransport(startOptions));
+      return new CodexAppServerClient(
+        createWebSocketTransport(startOptions, {
+          handshakeTimeoutMs: runtime.requestTimeoutMs,
+        }),
+      );
     }
     return new CodexAppServerClient(createStdioTransport(startOptions));
   }

--- a/extensions/codex/src/app-server/transport-websocket.test.ts
+++ b/extensions/codex/src/app-server/transport-websocket.test.ts
@@ -1,23 +1,39 @@
 // Codex tests cover transport websocket plugin behavior.
 import { mkdtemp, rm } from "node:fs/promises";
 import http from "node:http";
+import net from "node:net";
+import type { AddressInfo } from "node:net";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { WebSocketServer, type RawData } from "ws";
+import WebSocket, { WebSocketServer, type RawData } from "ws";
 import { CodexAppServerClient } from "./client.js";
+import { createWebSocketTransport } from "./transport-websocket.js";
+
+/** Matches production CODEX_APP_SERVER_WS_HANDSHAKE_TIMEOUT_MS / requestTimeoutMs default. */
+const EXPECTED_HANDSHAKE_TIMEOUT_MS = 60_000;
 
 describe("Codex app-server websocket transport", () => {
   const clients: CodexAppServerClient[] = [];
+  const transports: Array<ReturnType<typeof createWebSocketTransport>> = [];
   const servers: WebSocketServer[] = [];
   const httpServers: http.Server[] = [];
   const tempDirs: string[] = [];
+  const rawServers: net.Server[] = [];
+  const acceptedSockets: net.Socket[] = [];
 
   afterEach(async () => {
     for (const client of clients) {
       client.close();
     }
     clients.length = 0;
+    for (const transport of transports) {
+      transport.kill?.();
+    }
+    transports.length = 0;
+    for (const socket of acceptedSockets.splice(0)) {
+      socket.destroy();
+    }
     await Promise.all(
       servers.splice(0).map(
         (server) =>
@@ -31,6 +47,14 @@ describe("Codex app-server websocket transport", () => {
         (server) =>
           new Promise<void>((resolve) => {
             server.close(() => resolve());
+          }),
+      ),
+    );
+    await Promise.all(
+      rawServers.splice(0).map(
+        (server) =>
+          new Promise<void>((resolve, reject) => {
+            server.close((error) => (error ? reject(error) : resolve()));
           }),
       ),
     );
@@ -114,6 +138,237 @@ describe("Codex app-server websocket transport", () => {
     await expect(client.initialize()).resolves.toBeUndefined();
     await expect(client.request("thread/list", {})).resolves.toEqual({ data: [] });
     expect(upgradeExtensions).toEqual([undefined]);
+  });
+
+  it("negative control: ws without handshakeTimeout stays CONNECTING on never-upgrade peer", async () => {
+    // Pre-fix shape: plain `ws.WebSocket` with no handshakeTimeout against a
+    // TCP-accept / never-upgrade peer stays CONNECTING and never emits open.
+    const accepted: net.Socket[] = [];
+    const server = net.createServer((socket) => {
+      accepted.push(socket);
+      acceptedSockets.push(socket);
+    });
+    rawServers.push(server);
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(0, "127.0.0.1", () => resolve());
+    });
+    const { port } = server.address() as AddressInfo;
+
+    const socket = new WebSocket(`ws://127.0.0.1:${port}`);
+    const outcome = await Promise.race([
+      new Promise<"opened">((resolve) => {
+        socket.once("open", () => resolve("opened"));
+      }),
+      new Promise<"still-pending">((resolve) => {
+        setTimeout(() => resolve("still-pending"), 300);
+      }),
+    ]);
+    expect(outcome).toBe("still-pending");
+    expect(socket.readyState).toBe(WebSocket.CONNECTING);
+    console.log(
+      `[codex handshake negative control] outcome=${outcome} readyState=${String(socket.readyState)} wait_ms=300 without_handshakeTimeout=true`,
+    );
+    // terminate() aborts the handshake which can emit 'error' from the
+    // underlying request; suppress so it does not surface as an unhandled error.
+    socket.on("error", () => {});
+    socket.terminate();
+    for (const peer of accepted) {
+      peer.destroy();
+    }
+  });
+
+  it("emits exit when the websocket handshake never completes", async () => {
+    // Accept TCP but never complete the websocket upgrade so missing
+    // handshakeTimeout would leave initialize/RPC waiting forever for open.
+    const accepted: net.Socket[] = [];
+    const server = net.createServer((socket) => {
+      accepted.push(socket);
+      acceptedSockets.push(socket);
+    });
+    rawServers.push(server);
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(0, "127.0.0.1", () => resolve());
+    });
+    const { port } = server.address() as AddressInfo;
+
+    // Short non-default floor for hang repro; production uses resolved
+    // requestTimeoutMs (default 60s) via CodexAppServerClient.start.
+    const transport = createWebSocketTransport(
+      {
+        transport: "websocket",
+        url: `ws://127.0.0.1:${port}`,
+      },
+      { handshakeTimeoutMs: 200 },
+    );
+    transports.push(transport);
+
+    const startedAt = Date.now();
+    const exitResult = await new Promise<{ code: number | null; reason: string }>((resolve) => {
+      transport.once("exit", (code, reason) => {
+        resolve({
+          code: typeof code === "number" ? code : null,
+          reason: typeof reason === "string" ? reason : "",
+        });
+      });
+    });
+    const elapsedMs = Date.now() - startedAt;
+
+    expect(elapsedMs).toBeLessThan(2_000);
+    expect(transport.killed).toBe(true);
+    expect(exitResult.code).toBe(1006);
+    console.log(
+      `[codex handshake proof] timed_out=true elapsed_ms=${elapsedMs} code=${String(exitResult.code)} handshakeTimeout_ms=200 production_ms=${EXPECTED_HANDSHAKE_TIMEOUT_MS}`,
+    );
+
+    for (const socket of accepted) {
+      socket.destroy();
+    }
+  });
+
+  it("honors a non-default handshake budget on the TCP transport path", async () => {
+    // Non-default budget (not the 60s requestTimeoutMs default) on the shared
+    // builder used by both TCP and Unix construction paths.
+    const accepted: net.Socket[] = [];
+    const server = net.createServer((socket) => {
+      accepted.push(socket);
+      acceptedSockets.push(socket);
+    });
+    rawServers.push(server);
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(0, "127.0.0.1", () => resolve());
+    });
+    const { port } = server.address() as AddressInfo;
+
+    const transport = createWebSocketTransport(
+      {
+        transport: "websocket",
+        url: `ws://127.0.0.1:${port}`,
+      },
+      { handshakeTimeoutMs: 250 },
+    );
+    transports.push(transport);
+
+    const startedAt = Date.now();
+    const exitResult = await new Promise<{ code: number | null; reason: string }>((resolve) => {
+      transport.once("exit", (code, reason) => {
+        resolve({
+          code: typeof code === "number" ? code : null,
+          reason: typeof reason === "string" ? reason : "",
+        });
+      });
+    });
+    const elapsedMs = Date.now() - startedAt;
+
+    expect(elapsedMs).toBeLessThan(2_000);
+    expect(elapsedMs).toBeGreaterThanOrEqual(150);
+    expect(transport.killed).toBe(true);
+    expect(exitResult.code).toBe(1006);
+    console.log(
+      `[codex handshake tcp non-default] timed_out=true elapsed_ms=${elapsedMs} code=${String(exitResult.code)} handshakeTimeout_ms=250`,
+    );
+
+    for (const socket of accepted) {
+      socket.destroy();
+    }
+  });
+
+  it("honors a non-default handshake budget on the Unix transport path", async () => {
+    // ws.handshakeTimeout alone does not abort createConnection upgrades; the
+    // explicit CONNECTING deadline must fire on this path too.
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), "openclaw-codex-unix-hs-"));
+    tempDirs.push(tempDir);
+    const socketPath = path.join(tempDir, "never-upgrade.sock");
+    const accepted: net.Socket[] = [];
+    const server = net.createServer((socket) => {
+      accepted.push(socket);
+      acceptedSockets.push(socket);
+    });
+    rawServers.push(server);
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(socketPath, () => resolve());
+    });
+
+    const transport = createWebSocketTransport(
+      {
+        transport: "unix",
+        url: `unix://${socketPath}`,
+      },
+      { handshakeTimeoutMs: 250 },
+    );
+    transports.push(transport);
+
+    const startedAt = Date.now();
+    const exitResult = await new Promise<{ code: number | null; reason: string }>((resolve) => {
+      transport.once("exit", (code, reason) => {
+        resolve({
+          code: typeof code === "number" ? code : null,
+          reason: typeof reason === "string" ? reason : "",
+        });
+      });
+    });
+    const elapsedMs = Date.now() - startedAt;
+
+    expect(elapsedMs).toBeLessThan(2_000);
+    expect(elapsedMs).toBeGreaterThanOrEqual(150);
+    expect(transport.killed).toBe(true);
+    expect(exitResult.code).toBe(1006);
+    console.log(
+      `[codex handshake unix non-default] timed_out=true elapsed_ms=${elapsedMs} code=${String(exitResult.code)} handshakeTimeout_ms=250`,
+    );
+
+    for (const socket of accepted) {
+      socket.destroy();
+    }
+  });
+
+  it("fails initialize when the websocket handshake never completes", async () => {
+    const accepted: net.Socket[] = [];
+    const server = net.createServer((socket) => {
+      accepted.push(socket);
+      acceptedSockets.push(socket);
+    });
+    rawServers.push(server);
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(0, "127.0.0.1", () => resolve());
+    });
+    const { port } = server.address() as AddressInfo;
+
+    const transport = createWebSocketTransport(
+      {
+        transport: "websocket",
+        url: `ws://127.0.0.1:${port}`,
+      },
+      { handshakeTimeoutMs: 200 },
+    );
+    const client = CodexAppServerClient.fromTransportForTests(transport);
+    clients.push(client);
+
+    const startedAt = Date.now();
+    const outcome = await client.initialize().then(
+      () => ({ ok: true as const }),
+      (error: unknown) => ({ ok: false as const, error }),
+    );
+    const elapsedMs = Date.now() - startedAt;
+
+    expect(outcome.ok).toBe(false);
+    expect(elapsedMs).toBeLessThan(2_000);
+    if (!outcome.ok) {
+      expect(outcome.error).toBeInstanceOf(Error);
+      console.log(
+        `[codex handshake initialize proof] timed_out=true elapsed_ms=${elapsedMs} message=${
+          outcome.error instanceof Error ? outcome.error.message : String(outcome.error)
+        }`,
+      );
+    }
+
+    for (const socket of accepted) {
+      socket.destroy();
+    }
   });
 });
 

--- a/extensions/codex/src/app-server/transport-websocket.ts
+++ b/extensions/codex/src/app-server/transport-websocket.ts
@@ -10,9 +10,39 @@ import WebSocket, { type RawData } from "ws";
 import { resolveCodexAppServerUserHomeDir, type CodexAppServerStartOptions } from "./config.js";
 import type { CodexAppServerTransport } from "./transport.js";
 
+// Default matches resolveCodexAppServerRuntimeOptions().requestTimeoutMs (60s).
+// Production callers pass the resolved budget via testHooks-shaped override from
+// CodexAppServerClient.start; without a bound, TCP accept without upgrade leaves
+// initialize/RPC waiting forever for `open`.
+const CODEX_APP_SERVER_WS_HANDSHAKE_TIMEOUT_MS = 60_000;
+
+/** Fields `createWebSocketTransport` actually reads from start options. */
+type CodexWebSocketTransportStartOptions = Pick<
+  CodexAppServerStartOptions,
+  "url" | "transport" | "authToken" | "env"
+> & {
+  headers?: Record<string, string>;
+};
+
+function buildCodexAppServerWebSocketOptions(params: {
+  headers: Record<string, string>;
+  handshakeTimeoutMs: number;
+}): WebSocket.ClientOptions {
+  return {
+    headers: params.headers,
+    // Codex app-server closes Unix upgrade handshakes that offer compression.
+    perMessageDeflate: false,
+    handshakeTimeout: params.handshakeTimeoutMs,
+  };
+}
+
 /** Opens a WebSocket app-server transport and maps newline-delimited frames to stdout/stdin. */
 export function createWebSocketTransport(
-  options: CodexAppServerStartOptions,
+  options: CodexWebSocketTransportStartOptions,
+  // Override the handshake timeout budget. Tests supply short floors to keep
+  // stalled-handshake regression proofs fast; production passes the resolved
+  // requestTimeoutMs from CodexAppServerClient.start.
+  handshakeOpts?: { handshakeTimeoutMs?: number },
 ): CodexAppServerTransport {
   if (!options.url) {
     throw new Error(
@@ -26,11 +56,12 @@ export function createWebSocketTransport(
     ...options.headers,
     ...(options.authToken ? { Authorization: `Bearer ${options.authToken}` } : {}),
   };
-  const websocketOptions: WebSocket.ClientOptions = {
+  const handshakeTimeoutMs =
+    handshakeOpts?.handshakeTimeoutMs ?? CODEX_APP_SERVER_WS_HANDSHAKE_TIMEOUT_MS;
+  const websocketOptions = buildCodexAppServerWebSocketOptions({
     headers,
-    // Codex app-server closes Unix upgrade handshakes that offer compression.
-    perMessageDeflate: false,
-  };
+    handshakeTimeoutMs,
+  });
   const unixSocketPath = resolveCodexAppServerUnixSocketPath(options);
   const socket = unixSocketPath
     ? new WebSocket("ws://localhost/", {
@@ -40,6 +71,16 @@ export function createWebSocketTransport(
     : new WebSocket(options.url, websocketOptions);
   const pendingFrames: string[] = [];
   let killed = false;
+
+  // ws.handshakeTimeout does not abort custom createConnection (Unix) upgrades.
+  // Mirror the same budget with an explicit CONNECTING deadline for both paths.
+  const clearHandshakeDeadline = () => clearTimeout(handshakeDeadline);
+  const handshakeDeadline = setTimeout(() => {
+    if (socket.readyState === WebSocket.CONNECTING) {
+      socket.terminate();
+    }
+  }, handshakeTimeoutMs);
+  handshakeDeadline.unref?.();
 
   const sendFrame = (frame: string) => {
     const trimmed = frame.trim();
@@ -56,12 +97,21 @@ export function createWebSocketTransport(
   // `initialize` can be written before the WebSocket open event fires. Buffer
   // whole JSON-RPC frames so stdio and websocket transports share call timing.
   socket.once("open", () => {
+    clearHandshakeDeadline();
     for (const frame of pendingFrames.splice(0)) {
       socket.send(frame);
     }
   });
-  socket.once("error", (error) => events.emit("error", error));
+  // EventEmitter throws on unhandled `error` emits. Callers like CodexAppServerClient
+  // subscribe; raw transport consumers (and handshake timeouts) may only wait on exit.
+  socket.once("error", (error) => {
+    clearHandshakeDeadline();
+    if (events.listenerCount("error") > 0) {
+      events.emit("error", error);
+    }
+  });
   socket.once("close", (code, reason) => {
+    clearHandshakeDeadline();
     killed = true;
     events.emit("exit", code, reason.toString("utf8"));
   });
@@ -79,6 +129,7 @@ export function createWebSocketTransport(
     },
   });
   const closeSocket = () => {
+    clearHandshakeDeadline();
     if (socket.readyState === WebSocket.CLOSED || socket.readyState === WebSocket.CLOSING) {
       return;
     }
@@ -95,6 +146,7 @@ export function createWebSocketTransport(
       return killed;
     },
     kill: () => {
+      clearHandshakeDeadline();
       killed = true;
       socket.close();
     },


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the Codex app-server WebSocket transport could hang indefinitely when a peer accepts TCP but never completes the HTTP upgrade — blocking `initialize` / RPC with no error or recovery.

## Why This Change Was Made

The `ws` library defaults to no handshake deadline. A TCP-accept / never-upgrade peer leaves `open` / `close` unfired, so the parent client can wait forever.

This change:

- Threads `handshakeTimeoutMs` through `createWebSocketTransport` (default `CODEX_APP_SERVER_WS_HANDSHAKE_TIMEOUT_MS`, production wiring uses `runtime.requestTimeoutMs`).
- Adds a CONNECTING-side deadline for custom `createConnection` (Unix) upgrades, because `ws.handshakeTimeout` alone does not abort that path.
- Keeps already-open sockets unaffected; the budget only bounds the upgrade.

## User Impact

Codex app-server tool calls fail within the request timeout budget on a stalled handshake instead of hanging the session indefinitely.

## Evidence

- Exact head: `275ae2f22808c2ece270d1ae472985803db9b5e4`.
- Colocated hang-floor tests in `extensions/codex/src/app-server/transport-websocket.test.ts` (no root `proof-*.mts`).
- Real `node:net` / TCP loopback peers that accept and never complete the WebSocket upgrade.
- Negative control: bare `ws.WebSocket` without `handshakeTimeout` stays `CONNECTING` past 300 ms (`still-pending`).
- Production path: `createWebSocketTransport(..., { handshakeTimeoutMs: 200 })` emits `exit` with code `1006` and `elapsed_ms < 2000` (scaled floor; production uses resolved `requestTimeoutMs`).
- Same scaled floor proven for non-default TCP and Unix `createConnection` upgrades.
- `node scripts/run-vitest.mjs extensions/codex/src/app-server/transport-websocket.test.ts` → `Test Files 1 passed (1)`, `Tests 7 passed (7)`.
- Live open-PR search: no competing Codex app-server handshakeTimeout PR.