### PR TITLE
fix(gradium): treat blank env API key as unconfigured in synthesis paths

### DIFF
--- a/extensions/gradium/speech-provider.test.ts
+++ b/extensions/gradium/speech-provider.test.ts
@@ -18,6 +18,7 @@ describe("gradium speech provider", () => {
 
   afterEach(() => {
     vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
     vi.restoreAllMocks();
   });
 
@@ -214,25 +215,35 @@ describe("gradium speech provider", () => {
     }
   });
 
-  it("throws when GRADIUM_API_KEY is whitespace only", async () => {
-    const original = process.env.GRADIUM_API_KEY;
-    try {
-      process.env.GRADIUM_API_KEY = "   ";
-      await expect(
-        provider.synthesize({
-          text: "test",
-          cfg: {} as never,
-          providerConfig: {},
-          target: "audio-file",
-          timeoutMs: 5_000,
-        }),
-      ).rejects.toThrow("Gradium API key missing");
-    } finally {
-      if (original === undefined) {
-        delete process.env.GRADIUM_API_KEY;
-      } else {
-        process.env.GRADIUM_API_KEY = original;
-      }
+  it("rejects a blank environment key before normal or telephony requests", async () => {
+    vi.stubEnv("GRADIUM_API_KEY", "   ");
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    expect(provider.isConfigured({ providerConfig: {}, timeoutMs: 5_000 })).toBe(false);
+    await expect(
+      provider.synthesize({
+        text: "test",
+        cfg: {} as never,
+        providerConfig: {},
+        target: "audio-file",
+        timeoutMs: 5_000,
+      }),
+    ).rejects.toThrow("Gradium API key missing");
+
+    const synthesizeTelephony = provider.synthesizeTelephony;
+    if (!synthesizeTelephony) {
+      throw new Error("Expected Gradium provider synthesizeTelephony");
     }
+    await expect(
+      synthesizeTelephony({
+        text: "test",
+        cfg: {} as never,
+        providerConfig: {},
+        timeoutMs: 5_000,
+      }),
+    ).rejects.toThrow("Gradium API key missing");
+
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/extensions/gradium/speech-provider.test.ts
+++ b/extensions/gradium/speech-provider.test.ts
@@ -213,4 +213,26 @@ describe("gradium speech provider", () => {
       }
     }
   });
+
+  it("throws when GRADIUM_API_KEY is whitespace only", async () => {
+    const original = process.env.GRADIUM_API_KEY;
+    try {
+      process.env.GRADIUM_API_KEY = "   ";
+      await expect(
+        provider.synthesize({
+          text: "test",
+          cfg: {} as never,
+          providerConfig: {},
+          target: "audio-file",
+          timeoutMs: 5_000,
+        }),
+      ).rejects.toThrow("Gradium API key missing");
+    } finally {
+      if (original === undefined) {
+        delete process.env.GRADIUM_API_KEY;
+      } else {
+        process.env.GRADIUM_API_KEY = original;
+      }
+    }
+  });
 });

--- a/extensions/gradium/speech-provider.ts
+++ b/extensions/gradium/speech-provider.ts
@@ -99,7 +99,7 @@ export function buildGradiumSpeechProvider(): SpeechProviderPlugin {
     synthesize: async (req) => {
       const config = readGradiumProviderConfig(req.providerConfig);
       const overrides = req.providerOverrides ?? {};
-      const apiKey = config.apiKey || process.env.GRADIUM_API_KEY;
+      const apiKey = config.apiKey || trimToUndefined(process.env.GRADIUM_API_KEY);
       if (!apiKey) {
         throw new Error("Gradium API key missing");
       }
@@ -124,7 +124,7 @@ export function buildGradiumSpeechProvider(): SpeechProviderPlugin {
     synthesizeTelephony: async (req) => {
       const config = readGradiumProviderConfig(req.providerConfig);
       const overrides = req.providerOverrides ?? {};
-      const apiKey = config.apiKey || process.env.GRADIUM_API_KEY;
+      const apiKey = config.apiKey || trimToUndefined(process.env.GRADIUM_API_KEY);
       if (!apiKey) {
         throw new Error("Gradium API key missing");
       }

--- a/extensions/gradium/speech-provider.ts
+++ b/extensions/gradium/speech-provider.ts
@@ -6,6 +6,7 @@ import type {
   SpeechProviderPlugin,
 } from "openclaw/plugin-sdk/speech";
 import { asObject, trimToUndefined } from "openclaw/plugin-sdk/speech";
+import { resolveSpeechProviderApiKey } from "openclaw/plugin-sdk/speech-core";
 import { DEFAULT_GRADIUM_VOICE_ID, GRADIUM_VOICES, normalizeGradiumBaseUrl } from "./shared.js";
 import { gradiumTTS } from "./tts.js";
 
@@ -39,8 +40,12 @@ function readGradiumProviderConfig(config: SpeechProviderConfig): GradiumProvide
   };
 }
 
+function resolveGradiumApiKey(configApiKey: unknown): string | undefined {
+  return resolveSpeechProviderApiKey(trimToUndefined(configApiKey), process.env.GRADIUM_API_KEY);
+}
+
 function isGradiumProviderConfigured(config: SpeechProviderConfig): boolean {
-  const apiKey = trimToUndefined(config.apiKey) ?? trimToUndefined(process.env.GRADIUM_API_KEY);
+  const apiKey = resolveGradiumApiKey(config.apiKey);
   if (!apiKey) {
     return false;
   }
@@ -99,7 +104,7 @@ export function buildGradiumSpeechProvider(): SpeechProviderPlugin {
     synthesize: async (req) => {
       const config = readGradiumProviderConfig(req.providerConfig);
       const overrides = req.providerOverrides ?? {};
-      const apiKey = config.apiKey || trimToUndefined(process.env.GRADIUM_API_KEY);
+      const apiKey = resolveGradiumApiKey(config.apiKey);
       if (!apiKey) {
         throw new Error("Gradium API key missing");
       }
@@ -124,7 +129,7 @@ export function buildGradiumSpeechProvider(): SpeechProviderPlugin {
     synthesizeTelephony: async (req) => {
       const config = readGradiumProviderConfig(req.providerConfig);
       const overrides = req.providerOverrides ?? {};
-      const apiKey = config.apiKey || trimToUndefined(process.env.GRADIUM_API_KEY);
+      const apiKey = resolveGradiumApiKey(config.apiKey);
       if (!apiKey) {
         throw new Error("Gradium API key missing");
       }


### PR DESCRIPTION
## What Problem This Solves

A whitespace-only `GRADIUM_API_KEY` could be treated differently by readiness, normal synthesis, and telephony synthesis. The synthesis paths could pass unusable credentials toward the Gradium API.

## Why This Change Was Made

- Add one Gradium API-key resolver backed by the shared speech-provider key helper
- Use it for readiness, normal synthesis, and telephony synthesis
- Normalize config and environment candidates consistently
- Reject blank credentials before building or dispatching a request

## User Impact

- Before: whitespace-only credentials could pass a synthesis key guard and fail later as a request
- After: all Gradium entrypoints treat blank credentials as missing

## Evidence

- `node scripts/run-vitest.mjs extensions/gradium/speech-provider.test.ts` — 10 tests passed
- Production-path probe: readiness false; normal synthesis and telephony both report `Gradium API key missing`; fetch count 0
- `node scripts/check-changed.mjs -- extensions/gradium/speech-provider.ts extensions/gradium/speech-provider.test.ts` — passed on Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/29501438267
- Autoreview: clean, patch correct (0.97)

## Risk / Compatibility

Low. Only surrounding whitespace and blank credential values are normalized. Valid config credentials still take precedence over the environment.
