### PR TITLE
fix(ci): isolate bounded metadata retries

### DIFF
--- a/.github/workflows/mantis-slack-desktop-smoke.yml
+++ b/.github/workflows/mantis-slack-desktop-smoke.yml
@@ -266,8 +266,29 @@ jobs:
           require_var OPENCLAW_QA_CONVEX_SECRET_CI
           require_var CRABBOX_COORDINATOR_TOKEN
           if [[ -z "${CRABBOX_LEASE_ID:-}" && "$CRABBOX_PROVIDER" == "aws" ]]; then
-            runner_ip="$(curl -fsS --connect-timeout 5 --max-time 15 --retry 2 https://checkip.amazonaws.com | tr -d '[:space:]')"
-            if [[ -z "$runner_ip" ]]; then
+            runner_ip=""
+            for attempt in 1 2 3; do
+              if runner_ip="$(curl -fsS --connect-timeout 5 --max-time 15 https://checkip.amazonaws.com | tr -d '[:space:]')"; then
+                break
+              fi
+              runner_ip=""
+              if [[ "$attempt" != "3" ]]; then
+                sleep "$attempt"
+              fi
+            done
+            valid_runner_ip=true
+            IFS=. read -r -a runner_ip_octets <<<"$runner_ip"
+            if ((${#runner_ip_octets[@]} != 4)); then
+              valid_runner_ip=false
+            else
+              for octet in "${runner_ip_octets[@]}"; do
+                if [[ ! "$octet" =~ ^(0|[1-9][0-9]{0,2})$ ]] || ((10#$octet > 255)); then
+                  valid_runner_ip=false
+                  break
+                fi
+              done
+            fi
+            if [[ "$valid_runner_ip" != "true" ]]; then
               echo "Could not resolve GitHub runner public IPv4 for AWS SSH ingress." >&2
               exit 1
             fi

--- a/.github/workflows/mantis-slack-desktop-smoke.yml
+++ b/.github/workflows/mantis-slack-desktop-smoke.yml
@@ -277,12 +277,12 @@ jobs:
               fi
             done
             valid_runner_ip=true
-            IFS=. read -r -a runner_ip_octets <<<"$runner_ip"
-            if ((${#runner_ip_octets[@]} != 4)); then
+            if [[ ! "$runner_ip" =~ ^(0|[1-9][0-9]{0,2})\.(0|[1-9][0-9]{0,2})\.(0|[1-9][0-9]{0,2})\.(0|[1-9][0-9]{0,2})$ ]]; then
               valid_runner_ip=false
             else
+              IFS=. read -r -a runner_ip_octets <<<"$runner_ip"
               for octet in "${runner_ip_octets[@]}"; do
-                if [[ ! "$octet" =~ ^(0|[1-9][0-9]{0,2})$ ]] || ((10#$octet > 255)); then
+                if ((10#$octet > 255)); then
                   valid_runner_ip=false
                   break
                 fi

--- a/scripts/e2e/parallels-windows-prepare.sh
+++ b/scripts/e2e/parallels-windows-prepare.sh
@@ -95,7 +95,18 @@ require_host_tools() {
 
 fetch_host_metadata() {
   # Keep host metadata lookups bounded like the guest download paths below.
-  curl -fsSL --connect-timeout 10 --max-time 120 --retry 2 "$@"
+  local attempt output
+  for attempt in 1 2 3; do
+    if output="$(curl -fsSL --connect-timeout 10 --max-time 120 "$@")"; then
+      printf '%s' "$output"
+      return 0
+    fi
+    output=""
+    if [[ "$attempt" != "3" ]]; then
+      sleep "$attempt"
+    fi
+  done
+  return 1
 }
 
 vm_exists() {

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -2114,9 +2114,77 @@ describe("ci workflow guards", () => {
       (step) => step.name === "Run Slack desktop scenario",
     );
 
+    expect(runStep?.run).toContain("for attempt in 1 2 3");
     expect(runStep?.run).toContain(
-      "curl -fsS --connect-timeout 5 --max-time 15 --retry 2 https://checkip.amazonaws.com",
+      "curl -fsS --connect-timeout 5 --max-time 15 https://checkip.amazonaws.com",
     );
+    expect(runStep?.run).not.toContain("--retry");
+    expect(runStep?.run).toContain('runner_ip=""');
+    expect(runStep?.run).toContain("((${#runner_ip_octets[@]} != 4))");
+    expect(runStep?.run).toContain("((10#$octet > 255))");
+
+    const discoveryBlock = runStep?.run?.match(
+      /runner_ip=""[\s\S]*?echo "Using AWS SSH CIDR \$\{CRABBOX_AWS_SSH_CIDRS\}"/u,
+    )?.[0];
+    expect(discoveryBlock).toBeTruthy();
+
+    const root = mkdtempSync(path.join(tmpdir(), "openclaw-mantis-runner-ip-"));
+    try {
+      const fakeBin = path.join(root, "bin");
+      const callCount = path.join(root, "curl-calls");
+      mkdirSync(fakeBin);
+      writeFileSync(callCount, "0\n");
+      writeFileSync(
+        path.join(fakeBin, "curl"),
+        `#!/bin/bash
+count="$(<"$CURL_CALL_COUNT")"
+count=$((count + 1))
+printf '%s\n' "$count" >"$CURL_CALL_COUNT"
+if [[ "$count" == "1" ]]; then
+  printf '198.51.'
+  exit 28
+fi
+printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
+`,
+        { mode: 0o755 },
+      );
+      writeFileSync(path.join(fakeBin, "sleep"), "#!/bin/sh\nexit 0\n", { mode: 0o755 });
+
+      const result = spawnSync(
+        "bash",
+        [
+          "-c",
+          `set -euo pipefail\n${discoveryBlock}\nprintf 'result=%s\\n' "$CRABBOX_AWS_SSH_CIDRS"`,
+        ],
+        {
+          encoding: "utf8",
+          env: {
+            CURL_CALL_COUNT: callCount,
+            PATH: `${fakeBin}:${process.env.PATH}`,
+          },
+        },
+      );
+      expect(result.status, result.stderr).toBe(0);
+      expect(result.stdout).toContain("result=203.0.113.7/32");
+      expect(result.stdout).not.toContain("198.51.");
+      expect(readFileSync(callCount, "utf8")).toBe("2\n");
+
+      writeFileSync(callCount, "0\n");
+      const invalidResult = spawnSync("bash", ["-c", `set -euo pipefail\n${discoveryBlock}`], {
+        encoding: "utf8",
+        env: {
+          CURL_CALL_COUNT: callCount,
+          CURL_SUCCESS_IP: "999.0.0.1",
+          PATH: `${fakeBin}:${process.env.PATH}`,
+        },
+      });
+      expect(invalidResult.status).toBe(1);
+      expect(invalidResult.stderr).toContain(
+        "Could not resolve GitHub runner public IPv4 for AWS SSH ingress.",
+      );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 
   it("fails Windows Testbox setup when Blacksmith phone-home is not accepted", () => {

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -2120,7 +2120,7 @@ describe("ci workflow guards", () => {
     );
     expect(runStep?.run).not.toContain("--retry");
     expect(runStep?.run).toContain('runner_ip=""');
-    expect(runStep?.run).toContain("((${#runner_ip_octets[@]} != 4))");
+    expect(runStep?.run).toContain('[[ ! "$runner_ip" =~ ^(0|[1-9][0-9]{0,2})\\.');
     expect(runStep?.run).toContain("((10#$octet > 255))");
 
     const discoveryBlock = runStep?.run?.match(
@@ -2169,19 +2169,21 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
       expect(result.stdout).not.toContain("198.51.");
       expect(readFileSync(callCount, "utf8")).toBe("2\n");
 
-      writeFileSync(callCount, "0\n");
-      const invalidResult = spawnSync("bash", ["-c", `set -euo pipefail\n${discoveryBlock}`], {
-        encoding: "utf8",
-        env: {
-          CURL_CALL_COUNT: callCount,
-          CURL_SUCCESS_IP: "999.0.0.1",
-          PATH: `${fakeBin}:${process.env.PATH}`,
-        },
-      });
-      expect(invalidResult.status).toBe(1);
-      expect(invalidResult.stderr).toContain(
-        "Could not resolve GitHub runner public IPv4 for AWS SSH ingress.",
-      );
+      for (const invalidIp of ["999.0.0.1", "203.0.113.7."]) {
+        writeFileSync(callCount, "0\n");
+        const invalidResult = spawnSync("bash", ["-c", `set -euo pipefail\n${discoveryBlock}`], {
+          encoding: "utf8",
+          env: {
+            CURL_CALL_COUNT: callCount,
+            CURL_SUCCESS_IP: invalidIp,
+            PATH: `${fakeBin}:${process.env.PATH}`,
+          },
+        });
+        expect(invalidResult.status).toBe(1);
+        expect(invalidResult.stderr).toContain(
+          "Could not resolve GitHub runner public IPv4 for AWS SSH ingress.",
+        );
+      }
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/test/scripts/parallels-smoke-model.test.ts
+++ b/test/scripts/parallels-smoke-model.test.ts
@@ -318,14 +318,43 @@ describe("Parallels smoke model selection", () => {
       "10",
       "--max-time",
       "120",
-      "--retry",
-      "2",
       "https://example.test/metadata",
     ]);
 
     const controller = readFileSync(WINDOWS_PREPARE_WRAPPER, "utf8");
     expect(controller.match(/\bcurl -fsSL\b/g)).toHaveLength(1);
     expect(controller.match(/\bfetch_host_metadata\b/g)).toHaveLength(5);
+    expect(controller).toContain("for attempt in 1 2 3");
+    expect(controller).not.toContain("--retry 2");
+
+    const tempDir = makeTempDir(tempDirs, "openclaw-windows-metadata-retry-");
+    const callCount = join(tempDir, "curl-calls");
+    writeFileSync(callCount, "0\n");
+    const retryResult = spawnSync(
+      "bash",
+      [
+        "-c",
+        `OPENCLAW_PARALLELS_WINDOWS_LIBRARY_ONLY=1 source "$1"
+curl() {
+  count="$(<"$CURL_CALL_COUNT")"
+  count=$((count + 1))
+  printf '%s\\n' "$count" >"$CURL_CALL_COUNT"
+  if [[ "$count" == "1" ]]; then
+    printf 'partial-'
+    return 28
+  fi
+  printf 'complete'
+}
+sleep() { :; }
+fetch_host_metadata "https://example.test/metadata"`,
+        "bash",
+        WINDOWS_PREPARE_WRAPPER,
+      ],
+      { encoding: "utf8", env: { ...process.env, CURL_CALL_COUNT: callCount } },
+    );
+    expect(retryResult.status, retryResult.stderr).toBe(0);
+    expect(retryResult.stdout).toBe("complete");
+    expect(readFileSync(callCount, "utf8")).toBe("2\n");
   });
 
   it("accepts leading package-manager separators and still honors later terminators", () => {


### PR DESCRIPTION
## Summary

- replace curl's streaming retries with explicit three-attempt loops
- discard partial response bodies after failed attempts
- validate all four IPv4 octets before opening AWS SSH ingress
- keep all four Windows prerequisite metadata lookups behind one isolated helper

## Problem

PRs #108699 and #108698 added per-attempt curl timeouts, but curl can honor retry delays outside `--max-time` and can stream a failed attempt's partial body before retrying. That made the complete operations less tightly bounded and could concatenate partial IP, JSON, or YAML data with a later successful response.

## Solution

Keep the intended two retries, but own them in Bash: three attempts, each independently capped, with fixed one- and two-second delays. Capture each attempt separately and clear failed output before retrying. For Mantis, accept only four decimal octets in the 0-255 range before constructing the `/32` CIDR.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/ci-workflow-guards.test.ts --run -t 'bounds Mantis Slack runner IP discovery'` — pass
- `node scripts/run-vitest.mjs test/scripts/parallels-smoke-model.test.ts --run -t 'bounds Windows prerequisite metadata downloads'` — pass
- executable regressions cover partial-body failure followed by success; Mantis also covers exact CIDR and out-of-range rejection
- `bash -n scripts/e2e/parallels-windows-prepare.sh` — pass
- `git diff --check origin/main...HEAD` — pass
- fresh autoreviews — clean, confidence 0.98

Follow-up to #108699 and #108698. Thanks @Alix-007 for the original bounded-fetch fixes and guards.
