### PR TITLE
fix(config): cap missing-provider group-policy warning cache with shared dedupe helper

### DIFF
--- a/src/config/runtime-group-policy.test.ts
+++ b/src/config/runtime-group-policy.test.ts
@@ -1,5 +1,5 @@
 // Covers runtime group-policy resolution from config and context.
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   GROUP_POLICY_BLOCKED_LABEL,
   resolveAllowlistProviderRuntimeGroupPolicy,
@@ -62,5 +62,42 @@ describe("warnMissingProviderGroupPolicyFallbackOnce", () => {
     expect(lines).toHaveLength(1);
     expect(lines[0]).toContain("channels.runtime-policy-test is missing");
     expect(lines[0]).toContain("room messages blocked");
+  });
+
+  describe("warning dedupe cache bounds", () => {
+    let warnOnceFn: typeof warnMissingProviderGroupPolicyFallbackOnce;
+
+    // Fresh module instance so the module-level cache starts empty for this block.
+    beforeEach(async () => {
+      vi.resetModules();
+      const mod = await import("./runtime-group-policy.js");
+      warnOnceFn = mod.warnMissingProviderGroupPolicyFallbackOnce;
+    });
+
+    it("refreshes recent keys and re-warns evicted keys once the cap overflows", () => {
+      const lines: string[] = [];
+      const warnForAccount = (accountId: string) =>
+        warnOnceFn({
+          providerMissingFallbackApplied: true,
+          providerKey: "runtime-policy-evict-test",
+          accountId,
+          log: (message) => lines.push(message),
+        });
+
+      for (let i = 0; i < 4096; i++) {
+        warnForAccount(`account-${i}`);
+      }
+      expect(lines).toHaveLength(4096);
+
+      // Recent duplicate stays deduped and refreshes its recency.
+      expect(warnForAccount("account-0")).toBe(false);
+      expect(lines).toHaveLength(4096);
+
+      // Overflow evicts the oldest untouched key (account-1), not the refreshed one.
+      expect(warnForAccount("account-overflow")).toBe(true);
+      expect(warnForAccount("account-0")).toBe(false);
+      expect(warnForAccount("account-1")).toBe(true);
+      expect(lines).toHaveLength(4098);
+    });
   });
 });

--- a/src/config/runtime-group-policy.ts
+++ b/src/config/runtime-group-policy.ts
@@ -1,5 +1,6 @@
 // Resolves runtime group-policy settings for channels and sessions.
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { createDedupeCache } from "../infra/dedupe.js";
 import type { GroupPolicy } from "./types.base.js";
 
 type RuntimeGroupPolicyResolution = {
@@ -90,7 +91,13 @@ export function resolveAllowlistProviderRuntimeGroupPolicy(
   });
 }
 
-const warnedMissingProviderGroupPolicy = new Set<string>();
+const MAX_WARNED_MISSING_PROVIDER_GROUP_POLICY_KEYS = 4096;
+// Warn-once keys accumulate per provider/account for the process lifetime;
+// bounding them means evicted keys can re-warn instead of growing without limit.
+const warnedMissingProviderGroupPolicy = createDedupeCache({
+  ttlMs: 0,
+  maxSize: MAX_WARNED_MISSING_PROVIDER_GROUP_POLICY_KEYS,
+});
 
 /**
  * Log the missing-provider fail-closed fallback once per provider/account.
@@ -107,10 +114,9 @@ export function warnMissingProviderGroupPolicyFallbackOnce(params: {
     return false;
   }
   const key = `${params.providerKey}:${params.accountId ?? "*"}`;
-  if (warnedMissingProviderGroupPolicy.has(key)) {
+  if (warnedMissingProviderGroupPolicy.check(key)) {
     return false;
   }
-  warnedMissingProviderGroupPolicy.add(key);
   const blockedLabel = normalizeOptionalString(params.blockedLabel) || "group messages";
   params.log(
     `${params.providerKey}: channels.${params.providerKey} is missing; defaulting groupPolicy to "allowlist" (${blockedLabel} blocked until explicitly configured).`,


### PR DESCRIPTION
## What Problem This Solves

Fixes unbounded memory growth in the runtime group-policy warn-once cache. `warnMissingProviderGroupPolicyFallbackOnce` in `src/config/runtime-group-policy.ts` records one `provider:accountId` key per missing-provider fallback warning in a module-level `Set` that is never pruned, so a long-lived gateway that cycles through many providers/accounts keeps every key for the whole process lifetime.

## Why This Change Was Made

The sibling warn-once cache in `src/config/group-policy.ts` was already capped with the shared `createDedupeCache` helper (#101696); this applies the same bound (4096 keys, LRU recency) to the missing-provider group-policy warning cache. Warn-once behavior is unchanged below the cap; past the cap the oldest untouched key is evicted and can re-warn instead of the cache growing without limit.

## User Impact

Long-running gateways no longer accumulate unbounded warn-dedupe state for missing-provider group-policy fallbacks; repeated warnings for the same provider/account stay suppressed exactly as before.

## Evidence

- Before fix (same script, base commit): keys are never evicted — the bounded-cap check fails and the set retains every key.
- After fix: `NODE_OPTIONS=--expose-gc npx tsx proof-runtime-group-policy-dedupe.ts` imports the real production module; warn-once dedupe preserved, cap enforced at 4096 with LRU recency, retained heap stays flat under a 500k-distinct-key flood.
- Focused test: `node scripts/run-vitest.mjs src/config/runtime-group-policy.test.ts` — 5/5 passed, including a new eviction/recency regression test mirroring the capped sibling cache test in `src/config/group-policy.test.ts`.

```text
$ NODE_OPTIONS=--expose-gc npx tsx proof-runtime-group-policy-dedupe.ts   # base commit
PASS: warn-once dedupe preserved (repeat key logged once)
FAIL: oldest evicted key must re-warn (cache is bounded)

$ NODE_OPTIONS=--expose-gc npx tsx proof-runtime-group-policy-dedupe.ts   # this PR
PASS: warn-once dedupe preserved (repeat key logged once)
PASS: cap enforced at 4096 — oldest key evicted and re-warns, refreshed key survives
retained heap after 500k distinct keys: ~0.1 MiB
PASS: memory bounded under 500k-key flood
all checks passed
```

<details>
<summary>proof-runtime-group-policy-dedupe.ts (save in repo root, run with NODE_OPTIONS=--expose-gc npx tsx proof-runtime-group-policy-dedupe.ts)</summary>

```ts
// Proof: warnMissingProviderGroupPolicyFallbackOnce keeps warn-once dedupe and
// bounds its provider/account key cache at 4096 entries with LRU eviction.
// Run from repo root: NODE_OPTIONS=--expose-gc npx tsx proof-runtime-group-policy-dedupe.ts
import { warnMissingProviderGroupPolicyFallbackOnce } from "./src/config/runtime-group-policy.js";

const LIMIT = 4096;
let logs = 0;
const warn = (accountId: string) =>
  warnMissingProviderGroupPolicyFallbackOnce({
    providerMissingFallbackApplied: true,
    providerKey: "proof-provider",
    accountId,
    log: () => {
      logs += 1;
    },
  });

const fail = (message: string): never => {
  console.error(`FAIL: ${message}`);
  process.exit(1);
};

// 1) Legitimate warn-once behavior is preserved.
if (!warn("dup-account")) fail("first call must warn");
if (warn("dup-account") || logs !== 1) fail("repeat call must stay deduped");
console.log("PASS: warn-once dedupe preserved (repeat key logged once)");

// 2) Fill the cache to the cap, keep one key refreshed, then overflow.
for (let i = 0; i < LIMIT; i++) {
  warn(`acct-${i}`);
}
// "dup-account" was the oldest untouched key; refresh acct-0 so recency matters.
if (warn("acct-0")) fail("recent key must stay deduped at the cap");
if (!warn("overflow-a")) fail("new key past the cap must warn");
if (warn("acct-0")) fail("refreshed key must survive overflow (LRU recency)");
if (!warn("dup-account")) fail("oldest evicted key must re-warn (cache is bounded)");
console.log("PASS: cap enforced at 4096 — oldest key evicted and re-warns, refreshed key survives");

// 3) Memory boundedness: flood 500k distinct provider/account keys through the
// production module and assert retained heap stays flat (cache holds <= 4096).
if (typeof globalThis.gc !== "function") fail("run with NODE_OPTIONS=--expose-gc");
const fullGc = () => {
  for (let i = 0; i < 3; i++) {
    globalThis.gc?.();
  }
};
fullGc();
const beforeBounded = process.memoryUsage().heapUsed;
for (let i = 0; i < 500_000; i++) {
  warn(`flood-acct-${i}`);
}
fullGc();
const boundedDelta = process.memoryUsage().heapUsed - beforeBounded;
console.log(
  `retained heap after 500k distinct keys: ~${(boundedDelta / 1024 / 1024).toFixed(1)} MiB`,
);
if (boundedDelta >= 5 * 1024 * 1024) fail("bounded cache must keep retained heap flat");
console.log("PASS: memory bounded under 500k-key flood");
console.log("all checks passed");
```

</details>

AI-assisted: built with Codex
