### PR TITLE
refactor(plugin-sdk): share widget HTML validation helpers

### DIFF
--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-c4770214933b0ed42066f781c4f18a991af979bc87d2e0ca495a32439b524d1c  plugin-sdk-api-baseline.json
-31459c3d236e28a9474ada640a412796392d1eedf0f71b20c75513d61a6dba39  plugin-sdk-api-baseline.jsonl
+b4512610eb85bd1f2b1298edc93df408e1cff54b344ed9592fe69a4eda047dd1  plugin-sdk-api-baseline.json
+3d108005341642d35ba10a02e1106178e1f20f9d564295704be473006ff35ced  plugin-sdk-api-baseline.jsonl

--- a/docs/plugins/sdk-subpaths.md
+++ b/docs/plugins/sdk-subpaths.md
@@ -337,6 +337,7 @@ usage endpoint failed or returned no usable usage data.
     | `plugin-sdk/string-coerce-runtime` | Narrow primitive record/string coercion and normalization helpers without markdown/logging imports |
     | `plugin-sdk/html-entity-runtime` | Single-pass semicolon-terminated HTML5 entity decoding without broad text utilities |
     | `plugin-sdk/text-utility-runtime` | Low-level text and path helpers, including five-entity HTML escaping |
+    | `plugin-sdk/widget-html` | Complete-document detection, size validation, and tool input errors for self-contained HTML widgets |
     | `plugin-sdk/host-runtime` | Hostname and SCP host normalization helpers |
     | `plugin-sdk/retry-runtime` | Retry config and retry runner helpers |
     | `plugin-sdk/agent-runtime` | Deprecated broad barrel for agent dir/identity/workspace helpers, including `resolveAgentDir`, `resolveDefaultAgentDir`, and the deprecated `resolveOpenClawAgentDir` compatibility export; prefer focused agent/runtime subpaths |

--- a/extensions/canvas/src/widget-tool.ts
+++ b/extensions/canvas/src/widget-tool.ts
@@ -4,6 +4,7 @@ import { jsonResult, readStringParam } from "openclaw/plugin-sdk/channel-actions
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import type { AnyAgentTool } from "openclaw/plugin-sdk/plugin-entry";
 import { escapeHtml } from "openclaw/plugin-sdk/text-utility-runtime";
+import { assertWidgetHtmlSize, WidgetHtmlInputError } from "openclaw/plugin-sdk/widget-html";
 import { resolveCanvasHostConfig } from "./config.js";
 import { createCanvasDocument } from "./documents.js";
 import { SHOW_WIDGET_REQUIRED_CLIENT_CAPS, ShowWidgetToolSchema } from "./tool-schema.js";
@@ -17,13 +18,6 @@ type ShowWidgetToolOptions = {
   agentId?: string;
   stateDir?: string;
 };
-
-class WidgetToolInputError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = "ToolInputError";
-  }
-}
 
 function buildWidgetDocument(title: string, widgetCode: string): string {
   const isSvg = /^<svg/i.test(widgetCode);
@@ -69,13 +63,12 @@ export function createShowWidgetTool(options: ShowWidgetToolOptions = {}): AnyAg
         trim: false,
       });
       if (!rawWidgetCode.trim()) {
-        throw new WidgetToolInputError("widget_code required");
+        throw new WidgetHtmlInputError("widget_code required");
       }
-      if (rawWidgetCode.length > WIDGET_CODE_MAX_CHARS) {
-        throw new WidgetToolInputError(
-          `widget_code exceeds maximum size (${WIDGET_CODE_MAX_CHARS} characters)`,
-        );
-      }
+      assertWidgetHtmlSize(rawWidgetCode, WIDGET_CODE_MAX_CHARS, {
+        inputName: "widget_code",
+        unit: "characters",
+      });
       const widgetCode = rawWidgetCode.trim();
       const canvasRootDir = resolveCanvasHostConfig({ config: options.config }).root;
       const document = await createCanvasDocument(

--- a/extensions/discord/src/activities/tool.ts
+++ b/extensions/discord/src/activities/tool.ts
@@ -2,6 +2,11 @@ import { jsonResult, readStringParam } from "openclaw/plugin-sdk/channel-actions
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import type { AnyAgentTool, OpenClawPluginToolContext } from "openclaw/plugin-sdk/plugin-entry";
 import { escapeHtml } from "openclaw/plugin-sdk/text-utility-runtime";
+import {
+  assertWidgetHtmlSize,
+  isCompleteHtmlDocument,
+  WidgetHtmlInputError,
+} from "openclaw/plugin-sdk/widget-html";
 import { Type } from "typebox";
 import { resolveDiscordAccount } from "../accounts.js";
 import { buildDiscordActivityCustomId } from "../component-custom-id.js";
@@ -17,13 +22,6 @@ const DiscordWidgetParameters = Type.Object({
   title: Type.String({ minLength: 1, maxLength: 80 }),
   button_label: Type.Optional(Type.String({ minLength: 1, maxLength: 80 })),
 });
-
-class DiscordWidgetInputError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = "ToolInputError";
-  }
-}
 
 class DiscordWidgetLaunchButton extends Button {
   constructor(
@@ -56,7 +54,7 @@ function resolveDiscordChannelId(context: OpenClawPluginToolContext): string | u
 }
 
 function buildDiscordWidgetDocument(title: string, html: string): string {
-  if (/^(?:<!doctype\s+html\b|<html\b)/i.test(html.trimStart())) {
+  if (isCompleteHtmlDocument(html)) {
     return html;
   }
   return `<!doctype html>
@@ -98,22 +96,18 @@ export function createDiscordWidgetTool(
       const title = readStringParam(params, "title", { required: true });
       const buttonLabel = readStringParam(params, "button_label") || "Open widget";
       if (!html.trim()) {
-        throw new DiscordWidgetInputError("html is required");
+        throw new WidgetHtmlInputError("html is required");
       }
-      if (Buffer.byteLength(html, "utf8") > DISCORD_WIDGET_HTML_MAX_BYTES) {
-        throw new DiscordWidgetInputError(
-          `html exceeds maximum size (${DISCORD_WIDGET_HTML_MAX_BYTES} bytes)`,
-        );
-      }
+      assertWidgetHtmlSize(html, DISCORD_WIDGET_HTML_MAX_BYTES);
       if (title.length > 80) {
-        throw new DiscordWidgetInputError("title must be 80 characters or fewer");
+        throw new WidgetHtmlInputError("title must be 80 characters or fewer");
       }
       if (!buttonLabel.trim() || buttonLabel.length > 80) {
-        throw new DiscordWidgetInputError("button_label must be 1 to 80 characters");
+        throw new WidgetHtmlInputError("button_label must be 1 to 80 characters");
       }
       const channelId = resolveDiscordChannelId(context);
       if (!channelId) {
-        throw new DiscordWidgetInputError(
+        throw new WidgetHtmlInputError(
           "discord_widget requires a concrete Discord channel in the current session",
         );
       }

--- a/package.json
+++ b/package.json
@@ -1440,6 +1440,10 @@
       "types": "./dist/plugin-sdk/text-utility-runtime.d.ts",
       "default": "./dist/plugin-sdk/text-utility-runtime.js"
     },
+    "./plugin-sdk/widget-html": {
+      "types": "./dist/plugin-sdk/widget-html.d.ts",
+      "default": "./dist/plugin-sdk/widget-html.js"
+    },
     "./plugin-sdk/tool-plugin": {
       "types": "./dist/plugin-sdk/tool-plugin.d.ts",
       "default": "./dist/plugin-sdk/tool-plugin.js"

--- a/scripts/lib/plugin-sdk-doc-metadata.ts
+++ b/scripts/lib/plugin-sdk-doc-metadata.ts
@@ -114,6 +114,9 @@ export const pluginSdkDocMetadata = {
   "tool-results": {
     category: "utilities",
   },
+  "widget-html": {
+    category: "utilities",
+  },
   "provider-selection-runtime": {
     category: "provider",
   },

--- a/scripts/lib/plugin-sdk-entrypoints.json
+++ b/scripts/lib/plugin-sdk-entrypoints.json
@@ -329,6 +329,7 @@
   "telegram-command-config",
   "text-autolink-runtime",
   "text-utility-runtime",
+  "widget-html",
   "tool-plugin",
   "tool-payload",
   "tool-results",

--- a/scripts/plugin-sdk-surface-report.mjs
+++ b/scripts/plugin-sdk-surface-report.mjs
@@ -230,6 +230,7 @@ export function readPluginSdkSurfaceBudgets(env = process.env) {
       // +4: dual-field plan payload builder for the steps deprecation window.
       // +12: active plan-step consumers pinned through channel-outbound and mirrors.
       // +6: app-guided provider setup types retained by plugin-entry and mirrors.
+      // +3: widget HTML validation helpers and tool input error.
       // Used-union narrowing: 31 wildcard barrels drop to explicit used exports;
       // proxy stream API and codex marker/scaffold pins retained.
       7945,
@@ -246,8 +247,9 @@ export function readPluginSdkSurfaceBudgets(env = process.env) {
       // +4: plan-step normalizer across channel barrels.
       // +4: dual-field plan payload builder for the steps deprecation window.
       // +6: active plan-step helpers pinned through channel-outbound and mirrors.
+      // +2: widget HTML document detection and size assertion.
       // Used-union narrowing of the 31 wildcard barrels.
-      4434,
+      4436,
       env,
     ),
     publicDeprecatedExports: readPluginSdkSurfaceBudgetEnv(

--- a/scripts/plugin-sdk-surface-report.mjs
+++ b/scripts/plugin-sdk-surface-report.mjs
@@ -233,7 +233,7 @@ export function readPluginSdkSurfaceBudgets(env = process.env) {
       // +3: widget HTML validation helpers and tool input error.
       // Used-union narrowing: 31 wildcard barrels drop to explicit used exports;
       // proxy stream API and codex marker/scaffold pins retained.
-      7945,
+      7948,
       env,
     ),
     publicFunctionExports: readPluginSdkSurfaceBudgetEnv(

--- a/src/plugin-sdk/widget-html.test.ts
+++ b/src/plugin-sdk/widget-html.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import {
+  assertWidgetHtmlSize,
+  isCompleteHtmlDocument,
+  WidgetHtmlInputError,
+} from "./widget-html.js";
+
+describe("widget HTML helpers", () => {
+  it("detects complete HTML documents after leading whitespace", () => {
+    expect(isCompleteHtmlDocument("  <!DOCTYPE html><html></html>")).toBe(true);
+    expect(isCompleteHtmlDocument('\n<HTML lang="en"></html>')).toBe(true);
+    expect(isCompleteHtmlDocument("<section>fragment</section>")).toBe(false);
+    expect(isCompleteHtmlDocument("<!doctype svg><svg></svg>")).toBe(false);
+  });
+
+  it("enforces UTF-8 byte limits by default", () => {
+    expect(() => assertWidgetHtmlSize("é", 2)).not.toThrow();
+    expect(() => assertWidgetHtmlSize("é", 1)).toThrow("html exceeds maximum size (1 bytes)");
+  });
+
+  it("can preserve character-count limits and custom input names", () => {
+    expect(() =>
+      assertWidgetHtmlSize("é", 1, { inputName: "widget_code", unit: "characters" }),
+    ).not.toThrow();
+    expect(() =>
+      assertWidgetHtmlSize("😀", 1, { inputName: "widget_code", unit: "characters" }),
+    ).toThrow("widget_code exceeds maximum size (1 characters)");
+  });
+
+  it("uses the tool input error identity", () => {
+    let error: unknown;
+    try {
+      assertWidgetHtmlSize("too large", 1);
+    } catch (cause) {
+      error = cause;
+    }
+    expect(error).toBeInstanceOf(WidgetHtmlInputError);
+    expect(error).toMatchObject({ name: "ToolInputError" });
+  });
+});

--- a/src/plugin-sdk/widget-html.ts
+++ b/src/plugin-sdk/widget-html.ts
@@ -1,0 +1,31 @@
+const COMPLETE_HTML_DOCUMENT_PATTERN = /^(?:<!doctype\s+html\b|<html\b)/i;
+
+/** Input error surfaced by tools that accept agent-supplied widget HTML. */
+export class WidgetHtmlInputError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ToolInputError";
+  }
+}
+
+/** Returns true when HTML already contains its own document shell. */
+export function isCompleteHtmlDocument(html: string): boolean {
+  return COMPLETE_HTML_DOCUMENT_PATTERN.test(html.trimStart());
+}
+
+/** Enforces a widget HTML size limit while preserving the caller's input label and unit. */
+export function assertWidgetHtmlSize(
+  html: string,
+  maxSize: number,
+  options: {
+    inputName?: string;
+    unit?: "bytes" | "characters";
+  } = {},
+): void {
+  const inputName = options.inputName ?? "html";
+  const unit = options.unit ?? "bytes";
+  const size = unit === "bytes" ? new TextEncoder().encode(html).byteLength : html.length;
+  if (size > maxSize) {
+    throw new WidgetHtmlInputError(`${inputName} exceeds maximum size (${maxSize} ${unit})`);
+  }
+}


### PR DESCRIPTION
## What Problem This Solves

The canvas plugin (`show_widget`) and the Discord Activities plugin (`discord_widget`) independently implement the same "validate agent-supplied self-contained widget HTML" logic: complete-document detection, a size gate, and a tool-input error class named `ToolInputError`. The duplicates had already begun to drift (UTF-8 bytes vs UTF-16 characters, detection present in one plugin only).

## Why This Change Was Made

Phase 1 of unifying the widget/canvas presentation stack: extract the genuinely shared pieces into one small SDK subpath `openclaw/plugin-sdk/widget-html` (`isCompleteHtmlDocument`, `assertWidgetHtmlSize`, `WidgetHtmlInputError`) and migrate both plugins onto it. Intentional differences stay local: each plugin keeps its own size limit (48KB bytes for Discord, 256K chars for canvas), document shell, and CSP. Zero behavior change — error messages and limits are byte-identical.

## User Impact

None visible. Groundwork for routing widget presentation through typed `web-app` presentation actions next.

## Evidence

- Focused tests: `node scripts/run-vitest.mjs src/plugin-sdk/widget-html.test.ts extensions/discord/src/activities/tool.test.ts extensions/canvas/src/widget-tool.test.ts` — 3 shards green.
- SDK surface gate + API baseline check green (budget +3 exports/+2 callable recorded with rationale; baseline regenerated after rebase).
- Structured autoreview (codex/gpt-5.6-sol, branch vs origin/main): clean, no actionable findings.
- `git diff --numstat`: plugin production files net −13 LOC.
