### PR TITLE
fix: prevent gateway restart loops after APNs migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **APNs shared-state startup:** declare the canonical registration tombstone table as SQLite `STRICT` so fresh and upgraded Gateways pass schema verification instead of restart-looping.
 - **Cron lifecycle conflict retries:** preserve execution-phase retry decisions across scheduled, manual, and startup-recovered runs so post-execution claim conflicts cannot replay completed messages or tools. Fixes #108428. Thanks @yetval.
 - **Discord gateway metadata deadline:** carry the existing lookup deadline through DNS and proxy preflight, request headers, and response bodies so stalled gateway startup aborts cleanly. (#104580) Thanks @hugenshen.
 - **Control UI cloud session thinking:** expose reasoning level in the New Session model picker and persist the selected level before cloud dispatch.

--- a/src/state/openclaw-state-db.test.ts
+++ b/src/state/openclaw-state-db.test.ts
@@ -730,11 +730,51 @@ describe("openclaw state database", () => {
         )
         .all(),
     ).toEqual([]);
+    expect(
+      database.db
+        .prepare("SELECT strict FROM pragma_table_list WHERE name = 'apns_registration_tombstones'")
+        .get(),
+    ).toEqual({ strict: 1 });
     expect(() =>
       database.db
         .prepare("UPDATE schema_meta SET schema_version = ? WHERE meta_key = 'primary'")
         .run("not-an-integer"),
     ).toThrow();
+  });
+
+  it("doctor migrates existing APNs tombstone tables to STRICT without losing rows", () => {
+    const stateDir = createTempStateDir();
+    const options = { env: { OPENCLAW_STATE_DIR: stateDir } };
+    const databasePath = openOpenClawStateDatabase(options).path;
+    closeOpenClawStateDatabaseForTest();
+
+    const { DatabaseSync } = requireNodeSqlite();
+    const legacyDb = new DatabaseSync(databasePath);
+    legacyDb.exec(`
+      ALTER TABLE apns_registration_tombstones RENAME TO apns_registration_tombstones_strict;
+      CREATE TABLE apns_registration_tombstones (
+        node_id TEXT NOT NULL PRIMARY KEY,
+        deleted_at_ms INTEGER NOT NULL
+      );
+      INSERT INTO apns_registration_tombstones VALUES ('ios-node-1', 42);
+      DROP TABLE apns_registration_tombstones_strict;
+    `);
+    legacyDb.close();
+
+    expect(repairOpenClawStateDatabaseSchema(options)).toEqual({
+      changes: ["Migrated shared state tables to SQLite STRICT typing (1)"],
+      warnings: [],
+    });
+    const migrated = openOpenClawStateDatabase(options);
+    expect(
+      migrated.db
+        .prepare("SELECT strict FROM pragma_table_list WHERE name = 'apns_registration_tombstones'")
+        .get(),
+    ).toEqual({ strict: 1 });
+    expect(migrated.db.prepare("SELECT * FROM apns_registration_tombstones").get()).toEqual({
+      node_id: "ios-node-1",
+      deleted_at_ms: 42,
+    });
   });
 
   it("doctor migrates version 2 tables to STRICT without losing rows", () => {

--- a/src/state/openclaw-state-schema.generated.ts
+++ b/src/state/openclaw-state-schema.generated.ts
@@ -645,7 +645,7 @@ CREATE INDEX IF NOT EXISTS idx_apns_registrations_updated
 CREATE TABLE IF NOT EXISTS apns_registration_tombstones (
   node_id TEXT NOT NULL PRIMARY KEY,
   deleted_at_ms INTEGER NOT NULL
-);
+) STRICT;
 
 CREATE TABLE IF NOT EXISTS node_host_config (
   config_key TEXT NOT NULL PRIMARY KEY,

--- a/src/state/openclaw-state-schema.sql
+++ b/src/state/openclaw-state-schema.sql
@@ -640,7 +640,7 @@ CREATE INDEX IF NOT EXISTS idx_apns_registrations_updated
 CREATE TABLE IF NOT EXISTS apns_registration_tombstones (
   node_id TEXT NOT NULL PRIMARY KEY,
   deleted_at_ms INTEGER NOT NULL
-);
+) STRICT;
 
 CREATE TABLE IF NOT EXISTS node_host_config (
   config_key TEXT NOT NULL PRIMARY KEY,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Gateways running the newly merged APNs shared-state schema would restart-loop after a normal shutdown because the canonical tombstone table was not SQLite `STRICT`.

## Why This Change Was Made

Declare `apns_registration_tombstones` as `STRICT` in the canonical SQL and regenerated artifact. The existing doctor-owned transactional strict-table repair then rebuilds affected current-version databases without moving migration logic into the runtime opener.

## User Impact

Fresh Gateways start normally, and affected existing Gateways can complete the startup doctor repair without losing APNs tombstones.

## Evidence

- Reproduced on current `main`: focused state DB test failed with `Canonical SQLite schema contains non-STRICT tables: apns_registration_tombstones`.
- Focused fresh-schema and seeded upgrade-repair tests pass: 2 passed, 76 skipped.
- Seeded non-STRICT tombstone row survives doctor repair and the rebuilt table reports `strict = 1`.
- `node scripts/generate-kysely-types.mjs --verify`
- `git diff --check`
- Structured autoreview clean, patch correct, confidence 0.95.
- Live ClawMac Gateway currently reproduces the same restart loop after a clean SIGTERM; post-merge deployment proof will follow.

AI-assisted: yes. The change and migration behavior were manually verified against the runtime and doctor ownership paths.
