### PR TITLE
fix(acp): show interrupted turns after gateway outages

### DIFF
--- a/src/acp/translator.prompt-harness.test-support.ts
+++ b/src/acp/translator.prompt-harness.test-support.ts
@@ -4,6 +4,7 @@ import { createInMemorySessionStore } from "@openclaw/acp-core/session";
 import { expect, vi } from "vitest";
 import type { EventFrame } from "../../packages/gateway-protocol/src/index.js";
 import type { GatewayClient } from "../gateway/client.js";
+import type { AcpEventLedger } from "./event-ledger.js";
 import { AcpGatewayAgent } from "./translator.js";
 import { createAcpConnection, createAcpGateway } from "./translator.test-helpers.js";
 
@@ -21,7 +22,13 @@ const DEFAULT_PROMPT_TEXT = "hello";
 /** Creates an ACP translator instance with one preloaded session. */
 export function createSessionAgentHarness(
   request: GatewayClient["request"],
-  options: { sessionId?: string; sessionKey?: string; cwd?: string } = {},
+  options: {
+    sessionId?: string;
+    sessionKey?: string;
+    cwd?: string;
+    connection?: ReturnType<typeof createAcpConnection>;
+    eventLedger?: AcpEventLedger;
+  } = {},
 ) {
   const sessionId = options.sessionId ?? DEFAULT_SESSION_ID;
   const sessionKey = options.sessionKey ?? DEFAULT_SESSION_KEY;
@@ -31,12 +38,15 @@ export function createSessionAgentHarness(
     sessionKey,
     cwd: options.cwd ?? "/tmp",
   });
-  const agent = new AcpGatewayAgent(createAcpConnection(), createAcpGateway(request), {
+  const connection = options.connection ?? createAcpConnection();
+  const agent = new AcpGatewayAgent(connection, createAcpGateway(request), {
+    ...(options.eventLedger ? { eventLedger: options.eventLedger } : {}),
     sessionStore,
   });
 
   return {
     agent,
+    sessionUpdate: connection["__sessionUpdateMock"],
     sessionId,
     sessionKey,
     sessionStore,

--- a/src/acp/translator.stop-reason.test.ts
+++ b/src/acp/translator.stop-reason.test.ts
@@ -237,7 +237,7 @@ describe("acp translator stop reason mapping", () => {
         cwd: "/tmp",
         complete: true,
       });
-      const request = vi.fn(async (method: string) => {
+      const requestMock = vi.fn(async (method: string) => {
         if (method === "chat.send") {
           return {};
         }
@@ -245,7 +245,8 @@ describe("acp translator stop reason mapping", () => {
           throw new Error("gateway closed (1006): connection lost");
         }
         return {};
-      }) as GatewayClient["request"];
+      });
+      const request = requestMock as GatewayClient["request"];
       const { agent, sessionId, sessionUpdate } = createSessionAgentHarness(request, {
         eventLedger,
       });
@@ -254,7 +255,7 @@ describe("acp translator stop reason mapping", () => {
       await vi.waitFor(() => {
         expect(request).toHaveBeenCalledWith("chat.send", expect.any(Object), { timeoutMs: null });
       });
-      const runId = requireFirstRequestIdempotencyKey(request);
+      const runId = requireFirstRequestIdempotencyKey(requestMock);
       await agent.handleGatewayEvent(
         createChatEvent({
           runId,

--- a/src/acp/translator.stop-reason.test.ts
+++ b/src/acp/translator.stop-reason.test.ts
@@ -268,27 +268,25 @@ describe("acp translator stop reason mapping", () => {
       await vi.advanceTimersByTimeAsync(5_000);
 
       await expect(promptPromise).rejects.toThrow("Gateway disconnected: 1006: connection lost");
-      const liveText = sessionUpdatePayloads(sessionUpdate, "agent_message_chunk").map((entry) =>
-        entry.update.content.type === "text" ? entry.update.content.text : "",
-      );
-      expect(liveText).toHaveLength(2);
-      expect(liveText.join("")).toContain(
-        "partial response\n\n[OpenClaw interruption] Gateway disconnected",
-      );
+      const liveUpdates = sessionUpdatePayloads(sessionUpdate, "agent_message_chunk");
+      expect(liveUpdates).toHaveLength(2);
+      expect(liveUpdates[0]?.update.content).toEqual({
+        type: "text",
+        text: "partial response",
+      });
+      expect(liveUpdates[1]?.update.content).toEqual({
+        type: "text",
+        text: expect.stringMatching(/^\n\n\[OpenClaw interruption] Gateway disconnected/),
+      });
 
       const replay = await eventLedger.readReplay({
         sessionId,
         sessionKey: "agent:main:main",
       });
-      const replayText = replay.events
+      const replayUpdates = replay.events
         .filter((event) => event.update.sessionUpdate === "agent_message_chunk")
-        .map((event) =>
-          event.update.sessionUpdate === "agent_message_chunk" &&
-          event.update.content.type === "text"
-            ? event.update.content.text
-            : "",
-        );
-      expect(replayText).toEqual(liveText);
+        .map((event) => event.update);
+      expect(replayUpdates).toEqual(liveUpdates.map((entry) => entry.update));
     } finally {
       vi.useRealTimers();
     }

--- a/src/acp/translator.stop-reason.test.ts
+++ b/src/acp/translator.stop-reason.test.ts
@@ -3,6 +3,8 @@ import type { PromptRequest } from "@agentclientprotocol/sdk";
 import { createInMemorySessionStore } from "@openclaw/acp-core/session";
 import { describe, expect, it, vi } from "vitest";
 import type { GatewayClient } from "../gateway/client.js";
+import { createInMemoryAcpEventLedger } from "./event-ledger.js";
+import { sessionUpdatePayloads } from "./translator.bridge-test-helpers.js";
 import { AcpGatewayAgent } from "./translator.js";
 import {
   createChatEvent,
@@ -169,13 +171,57 @@ describe("acp translator stop reason mapping", () => {
   it("rejects in-flight prompts when the gateway does not reconnect before the grace window", async () => {
     vi.useFakeTimers();
     try {
-      const { agent, promptPromise } = await createPendingPromptHarness();
+      const eventLedger = createInMemoryAcpEventLedger();
+      await eventLedger.startSession({
+        sessionId: "session-1",
+        sessionKey: "agent:main:main",
+        cwd: "/tmp",
+        complete: true,
+      });
+      const request = vi.fn(async (method: string) => {
+        if (method === "chat.send") {
+          return {};
+        }
+        if (method === "agent.wait") {
+          throw new Error("gateway closed (1006): connection lost");
+        }
+        return {};
+      }) as GatewayClient["request"];
+      const { agent, sessionId, sessionUpdate } = createSessionAgentHarness(request, {
+        eventLedger,
+      });
+      const promptPromise = promptAgent(agent, sessionId);
       void promptPromise.catch(() => {});
+      await vi.waitFor(() => {
+        expect(request).toHaveBeenCalledWith("chat.send", expect.any(Object), { timeoutMs: null });
+      });
+      await Promise.resolve();
 
       agent.handleGatewayDisconnect("1006: connection lost");
       await vi.advanceTimersByTimeAsync(5_000);
 
-      await expect(promptPromise).rejects.toThrow("Gateway disconnected: 1006: connection lost");
+      await expect(promptPromise).rejects.toThrow(
+        "This turn was accepted and may still complete after reconnect",
+      );
+      const interruptionUpdates = sessionUpdatePayloads(sessionUpdate, "agent_message_chunk");
+      expect(interruptionUpdates).toHaveLength(1);
+      expect(interruptionUpdates[0]?.update.content).toEqual({
+        type: "text",
+        text: expect.stringContaining(
+          "[OpenClaw interruption] Gateway disconnected: 1006: connection lost. This turn was accepted",
+        ),
+      });
+      expect(JSON.stringify(interruptionUpdates)).not.toContain("resend");
+
+      const replay = await eventLedger.readReplay({
+        sessionId,
+        sessionKey: "agent:main:main",
+      });
+      const recordedInterruptions = replay.events.filter(
+        (event) => event.update.sessionUpdate === "agent_message_chunk",
+      );
+      expect(recordedInterruptions).toHaveLength(1);
+      expect(recordedInterruptions[0]?.runId).toBeTypeOf("string");
     } finally {
       vi.useRealTimers();
     }
@@ -190,7 +236,7 @@ describe("acp translator stop reason mapping", () => {
         }
         return {};
       }) as GatewayClient["request"];
-      const { agent, sessionId } = createSessionAgentHarness(request);
+      const { agent, sessionId, sessionUpdate } = createSessionAgentHarness(request);
       const promptPromise = promptAgent(agent, sessionId);
       const settleSpy = observeSettlement(promptPromise);
 
@@ -203,6 +249,13 @@ describe("acp translator stop reason mapping", () => {
 
       await vi.advanceTimersByTimeAsync(1);
       await expect(promptPromise).rejects.toThrow("Gateway disconnected: 1006: connection lost");
+      const interruptionUpdates = sessionUpdatePayloads(sessionUpdate, "agent_message_chunk");
+      expect(interruptionUpdates).toHaveLength(1);
+      expect(interruptionUpdates[0]?.update.content).toEqual({
+        type: "text",
+        text: expect.stringContaining("did not confirm whether this turn was accepted"),
+      });
+      expect(JSON.stringify(interruptionUpdates)).not.toContain("resend");
     } finally {
       vi.useRealTimers();
     }

--- a/src/acp/translator.stop-reason.test.ts
+++ b/src/acp/translator.stop-reason.test.ts
@@ -227,6 +227,73 @@ describe("acp translator stop reason mapping", () => {
     }
   });
 
+  it("separates a disconnect interruption from partial assistant output", async () => {
+    vi.useFakeTimers();
+    try {
+      const eventLedger = createInMemoryAcpEventLedger();
+      await eventLedger.startSession({
+        sessionId: "session-1",
+        sessionKey: "agent:main:main",
+        cwd: "/tmp",
+        complete: true,
+      });
+      const request = vi.fn(async (method: string) => {
+        if (method === "chat.send") {
+          return {};
+        }
+        if (method === "agent.wait") {
+          throw new Error("gateway closed (1006): connection lost");
+        }
+        return {};
+      }) as GatewayClient["request"];
+      const { agent, sessionId, sessionUpdate } = createSessionAgentHarness(request, {
+        eventLedger,
+      });
+      const promptPromise = promptAgent(agent, sessionId);
+      void promptPromise.catch(() => {});
+      await vi.waitFor(() => {
+        expect(request).toHaveBeenCalledWith("chat.send", expect.any(Object), { timeoutMs: null });
+      });
+      const runId = requireFirstRequestIdempotencyKey(request);
+      await agent.handleGatewayEvent(
+        createChatEvent({
+          runId,
+          sessionKey: "agent:main:main",
+          state: "delta",
+          message: { content: [{ type: "text", text: "partial response" }] },
+        }),
+      );
+
+      agent.handleGatewayDisconnect("1006: connection lost");
+      await vi.advanceTimersByTimeAsync(5_000);
+
+      await expect(promptPromise).rejects.toThrow("Gateway disconnected: 1006: connection lost");
+      const liveText = sessionUpdatePayloads(sessionUpdate, "agent_message_chunk").map((entry) =>
+        entry.update.content.type === "text" ? entry.update.content.text : "",
+      );
+      expect(liveText).toHaveLength(2);
+      expect(liveText.join("")).toContain(
+        "partial response\n\n[OpenClaw interruption] Gateway disconnected",
+      );
+
+      const replay = await eventLedger.readReplay({
+        sessionId,
+        sessionKey: "agent:main:main",
+      });
+      const replayText = replay.events
+        .filter((event) => event.update.sessionUpdate === "agent_message_chunk")
+        .map((event) =>
+          event.update.sessionUpdate === "agent_message_chunk" &&
+          event.update.content.type === "text"
+            ? event.update.content.text
+            : "",
+        );
+      expect(replayText).toEqual(liveText);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("keeps pre-ack send disconnects inside the reconnect grace window", async () => {
     vi.useFakeTimers();
     try {

--- a/src/acp/translator.ts
+++ b/src/acp/translator.ts
@@ -1336,6 +1336,7 @@ export class AcpGatewayAgent implements Agent {
         this.clearDisconnectTimer();
       }
       try {
+        const interruptionPrefix = (pending.sentTextLength ?? 0) > 0 ? "\n\n" : "";
         await this.sessionUpdates.emit({
           sessionId: pending.sessionId,
           sessionKey: pending.sessionKey,
@@ -1344,7 +1345,10 @@ export class AcpGatewayAgent implements Agent {
           record: true,
           update: {
             sessionUpdate: "agent_message_chunk",
-            content: { type: "text", text: `[OpenClaw interruption] ${error.message}` },
+            content: {
+              type: "text",
+              text: `${interruptionPrefix}[OpenClaw interruption] ${error.message}`,
+            },
           },
         });
       } catch (err) {

--- a/src/acp/translator.ts
+++ b/src/acp/translator.ts
@@ -155,6 +155,16 @@ type PendingPrompt = {
   toolCalls?: Map<string, PendingToolCall>;
 };
 
+function buildGatewayDisconnectError(
+  pending: PendingPrompt,
+  disconnectContext: DisconnectContext,
+): Error {
+  const guidance = pending.sendAccepted
+    ? "This turn was accepted and may still complete after reconnect; check the session before retrying."
+    : "The Gateway did not confirm whether this turn was accepted; check the session before retrying.";
+  return new Error(`Gateway disconnected: ${disconnectContext.reason}. ${guidance}`);
+}
+
 type PendingApprovalRelay = {
   approvalId: string;
   runId: string;
@@ -702,11 +712,13 @@ export class AcpGatewayAgent implements Agent {
       }
 
       const sendWithProvenanceFallback = async () => {
-        const markSendAccepted = () => {
+        const markSendAccepted = (): boolean => {
           const pending = this.getPendingPrompt(params.sessionId, runId);
-          if (pending) {
-            pending.sendAccepted = true;
+          if (!pending) {
+            return false;
           }
+          pending.sendAccepted = true;
+          return true;
         };
         const applyTerminalAck = async (ack: ChatSendAck | undefined): Promise<boolean> => {
           const status = normalizedChatSendAckStatus(ack?.status);
@@ -721,7 +733,7 @@ export class AcpGatewayAgent implements Agent {
           if (status === "error") {
             const current = pending();
             if (current) {
-              this.rejectPendingPrompt(
+              await this.rejectPendingPrompt(
                 current,
                 new Error("Chat failed before the run started; try again."),
               );
@@ -729,7 +741,9 @@ export class AcpGatewayAgent implements Agent {
             return true;
           }
           if (status === "ok") {
-            markSendAccepted();
+            if (!markSendAccepted()) {
+              return true;
+            }
             await this.sessionUpdates.recordUserPrompt(session, runId, params.prompt);
             const current = pending();
             if (current) {
@@ -756,7 +770,9 @@ export class AcpGatewayAgent implements Agent {
           if (terminal) {
             return;
           }
-          markSendAccepted();
+          if (!markSendAccepted()) {
+            return;
+          }
           await this.sessionUpdates.recordUserPrompt(session, runId, params.prompt);
         } catch (err) {
           if (
@@ -767,7 +783,9 @@ export class AcpGatewayAgent implements Agent {
             if (terminal) {
               return;
             }
-            markSendAccepted();
+            if (!markSendAccepted()) {
+              return;
+            }
             await this.sessionUpdates.recordUserPrompt(session, runId, params.prompt);
             return;
           }
@@ -1299,20 +1317,43 @@ export class AcpGatewayAgent implements Agent {
     this.disconnectTimer.unref?.();
   }
 
-  private rejectPendingPrompt(pending: PendingPrompt, error: Error): void {
+  private async rejectPendingPrompt(pending: PendingPrompt, error: Error): Promise<void> {
     const currentPending = this.getPendingPrompt(pending.sessionId, pending.idempotencyKey);
     if (currentPending !== pending) {
       return;
     }
-    this.clearApprovalRelaysForPrompt(pending.sessionId, pending.idempotencyKey, {
-      denyActive: true,
-    });
-    this.pendingPrompts.delete(pending.sessionId);
-    this.sessionStore.clearActiveRun(pending.sessionId);
-    if (this.pendingPrompts.size === 0) {
-      this.clearDisconnectTimer();
+    const promptKey = this.pendingPromptKey(pending.sessionId, pending.idempotencyKey);
+    this.settlingPromptKeys.add(promptKey);
+    try {
+      this.clearApprovalRelaysForPrompt(pending.sessionId, pending.idempotencyKey, {
+        denyActive: true,
+      });
+      // Retire the prompt before yielding so reconnect, deadline, and send-failure
+      // paths cannot emit duplicate terminal notices for the same turn.
+      this.pendingPrompts.delete(pending.sessionId);
+      this.sessionStore.clearActiveRun(pending.sessionId);
+      if (this.pendingPrompts.size === 0) {
+        this.clearDisconnectTimer();
+      }
+      try {
+        await this.sessionUpdates.emit({
+          sessionId: pending.sessionId,
+          sessionKey: pending.sessionKey,
+          ...(pending.ledgerSessionId ? { ledgerSessionId: pending.ledgerSessionId } : {}),
+          runId: pending.idempotencyKey,
+          record: true,
+          update: {
+            sessionUpdate: "agent_message_chunk",
+            content: { type: "text", text: `[OpenClaw interruption] ${error.message}` },
+          },
+        });
+      } catch (err) {
+        this.log(`prompt interruption update failed for ${pending.sessionId}: ${String(err)}`);
+      }
+      pending.reject(error);
+    } finally {
+      this.settlingPromptKeys.delete(promptKey);
     }
-    pending.reject(error);
   }
 
   private clearPendingDisconnectState(
@@ -1394,9 +1435,9 @@ export class AcpGatewayAgent implements Agent {
       this.log(`agent.wait reconcile failed for ${pending.idempotencyKey}: ${String(err)}`);
       if (deadlineExpired) {
         if (this.shouldRejectPendingAtDisconnectDeadline(pending, disconnectContext)) {
-          this.rejectPendingPrompt(
+          await this.rejectPendingPrompt(
             pending,
-            new Error(`Gateway disconnected: ${disconnectContext.reason}`),
+            buildGatewayDisconnectError(pending, disconnectContext),
           );
           return false;
         }
@@ -1424,9 +1465,9 @@ export class AcpGatewayAgent implements Agent {
         if (!currentDisconnectContext) {
           return false;
         }
-        this.rejectPendingPrompt(
+        await this.rejectPendingPrompt(
           currentPending,
-          new Error(`Gateway disconnected: ${currentDisconnectContext.reason}`),
+          buildGatewayDisconnectError(currentPending, currentDisconnectContext),
         );
         return false;
       }


### PR DESCRIPTION
Closes #108587

## What Problem This Solves

Fixes an issue where an ACP prompt left in flight through a Gateway outage longer than the reconnect grace period ended with only a generic JSON-RPC error. The ACP update stream and replay ledger contained no terminal explanation, leaving the user's turn visibly unanswered.

## Why This Change Was Made

The ACP bridge now settles rejected prompts through its existing recorded session-update path, emitting one clearly labeled interruption before returning the protocol error. The notice distinguishes confirmed Gateway acceptance from an unconfirmed send, and the prompt is retired before the asynchronous update so reconnect and send-failure races cannot duplicate it. The main risk is duplicate notices or unsafe retry guidance during concurrent settlement; focused race coverage asserts one recorded update for both acceptance states.

## User Impact

ACP clients now show why a turn stopped after a prolonged Gateway outage, and reloading the session preserves that explanation. Turns already accepted by the Gateway warn that they may still complete instead of telling users to resend them.

## Evidence

- Before/premise on current main: `rejectPendingPrompt` removed the pending turn and rejected the ACP request without calling the recorded session-update abstraction. The installed ACP SDK 1.1.0 contract defines `agent_message_chunk` as the client-visible response stream notification, and its generic rejected-request fallback maps to JSON-RPC `-32603 Internal error`.
- After, real local behavior: built the source checkout, started an actual Gateway and `openclaw acp` process with isolated temporary state, sent a real prompt through the configured `deepseek/deepseek-v4-pro` provider, killed the Gateway after send acceptance, waited past the five-second grace, restarted it, and loaded the same ACP session. Redacted harness result:

```json
{"promptError":{"code":-32603,"message":"Internal error"},"liveInterruptionCount":1,"replayInterruptionCount":1,"acceptedGuidance":true,"replayMatchesLive":true}
```

- Focused regression suite:

```text
node scripts/run-vitest.mjs src/acp/translator.stop-reason.test.ts src/acp/translator.lifecycle.test.ts src/acp/translator.event-ledger.test.ts src/acp/translator.session-updates.test.ts src/acp/translator.cancel-scoping.test.ts src/acp/translator.prompt-prefix.test.ts
[test] passed 3 Vitest shards
Test Files  6 passed (6)
Tests       51 passed (51)
```

- `oxfmt --check` on the three changed files, direct `oxlint` on the same files, and `git diff --check` all passed. The local changed-check classifier attempted to delegate its broader type/lint plan to unavailable maintainer-only Testbox infrastructure, so the fork CI run is the broad type/build gate.

AI-assisted: implementation and review; proof run manually.
