### PR TITLE
fix(clawhub): avoid misleading reset hints from malformed headers

### DIFF
--- a/src/infra/clawhub.test.ts
+++ b/src/infra/clawhub.test.ts
@@ -1016,6 +1016,40 @@ describe("clawhub helpers", () => {
     ).rejects.toThrow(/Rate limit exceeded Sign in for higher rate limits\.$/);
   });
 
+  it.each(["0x10", "1e3", "-1", "0.5", "9007199254740993"])(
+    "does not describe malformed RateLimit-Reset values as seconds: %s",
+    async (reset) => {
+      process.env.CLAWHUB_CONFIG_PATH = path.join(os.tmpdir(), "openclaw-no-clawhub-config");
+      await expect(
+        searchClawHubSkills({
+          query: "calendar",
+          fetchImpl: async () =>
+            new Response("Rate limit exceeded", {
+              status: 429,
+              headers: { "RateLimit-Reset": reset },
+            }),
+        }),
+      ).rejects.toThrow(/Rate limit exceeded Sign in for higher rate limits\.$/);
+    },
+  );
+
+  it("uses a valid Retry-After hint when RateLimit-Reset is malformed", async () => {
+    process.env.CLAWHUB_CONFIG_PATH = path.join(os.tmpdir(), "openclaw-no-clawhub-config");
+    await expect(
+      searchClawHubSkills({
+        query: "calendar",
+        fetchImpl: async () =>
+          new Response("Rate limit exceeded", {
+            status: 429,
+            headers: {
+              "RateLimit-Reset": "invalid",
+              "Retry-After": "7",
+            },
+          }),
+      }),
+    ).rejects.toThrow(/Rate limit exceeded \(resets in 7s\) Sign in for higher rate limits\.$/);
+  });
+
   it("retries transient ClawHub reads and honors Retry-After", async () => {
     const cancel = vi.fn();
     let attempts = 0;

--- a/src/infra/clawhub.test.ts
+++ b/src/infra/clawhub.test.ts
@@ -1016,7 +1016,7 @@ describe("clawhub helpers", () => {
     ).rejects.toThrow(/Rate limit exceeded Sign in for higher rate limits\.$/);
   });
 
-  it.each(["0x10", "1e3", "-1", "0.5", "9007199254740993"])(
+  it.each(["0x10", "1e3", "-1", "-0", "+7", "0.5", "9007199254740993"])(
     "does not describe malformed RateLimit-Reset values as seconds: %s",
     async (reset) => {
       process.env.CLAWHUB_CONFIG_PATH = path.join(os.tmpdir(), "openclaw-no-clawhub-config");
@@ -1033,22 +1033,25 @@ describe("clawhub helpers", () => {
     },
   );
 
-  it("uses a valid Retry-After hint when RateLimit-Reset is malformed", async () => {
-    process.env.CLAWHUB_CONFIG_PATH = path.join(os.tmpdir(), "openclaw-no-clawhub-config");
-    await expect(
-      searchClawHubSkills({
-        query: "calendar",
-        fetchImpl: async () =>
-          new Response("Rate limit exceeded", {
-            status: 429,
-            headers: {
-              "RateLimit-Reset": "invalid",
-              "Retry-After": "7",
-            },
-          }),
-      }),
-    ).rejects.toThrow(/Rate limit exceeded \(resets in 7s\) Sign in for higher rate limits\.$/);
-  });
+  it.each(["invalid", "+7", "-0"])(
+    "uses a valid Retry-After hint when RateLimit-Reset is malformed: %s",
+    async (reset) => {
+      process.env.CLAWHUB_CONFIG_PATH = path.join(os.tmpdir(), "openclaw-no-clawhub-config");
+      await expect(
+        searchClawHubSkills({
+          query: "calendar",
+          fetchImpl: async () =>
+            new Response("Rate limit exceeded", {
+              status: 429,
+              headers: {
+                "RateLimit-Reset": reset,
+                "Retry-After": "7",
+              },
+            }),
+        }),
+      ).rejects.toThrow(/Rate limit exceeded \(resets in 7s\) Sign in for higher rate limits\.$/);
+    },
+  );
 
   it("retries transient ClawHub reads and honors Retry-After", async () => {
     const cancel = vi.fn();

--- a/src/infra/clawhub.ts
+++ b/src/infra/clawhub.ts
@@ -718,12 +718,12 @@ async function buildClawHubError(
 }
 
 function formatRateLimitSuffix(headers: Headers, hasToken: boolean): string {
-  const reset =
-    normalizeHeaderValue(headers.get("RateLimit-Reset")) ??
-    normalizeHeaderValue(headers.get("Retry-After"));
+  const resetSeconds =
+    parseStrictNonNegativeInteger(headers.get("RateLimit-Reset")) ??
+    parseStrictNonNegativeInteger(headers.get("Retry-After"));
   const segments: string[] = [];
-  if (reset && Number.isFinite(Number(reset))) {
-    segments.push(`(resets in ${reset}s)`);
+  if (resetSeconds !== undefined) {
+    segments.push(`(resets in ${resetSeconds}s)`);
   }
   if (!hasToken) {
     segments.push("Sign in for higher rate limits.");

--- a/src/infra/clawhub.ts
+++ b/src/infra/clawhub.ts
@@ -719,8 +719,8 @@ async function buildClawHubError(
 
 function formatRateLimitSuffix(headers: Headers, hasToken: boolean): string {
   const resetSeconds =
-    parseStrictNonNegativeInteger(headers.get("RateLimit-Reset")) ??
-    parseStrictNonNegativeInteger(headers.get("Retry-After"));
+    parseRateLimitDeltaSeconds(headers.get("RateLimit-Reset")) ??
+    parseRateLimitDeltaSeconds(headers.get("Retry-After"));
   const segments: string[] = [];
   if (resetSeconds !== undefined) {
     segments.push(`(resets in ${resetSeconds}s)`);
@@ -729,6 +729,14 @@ function formatRateLimitSuffix(headers: Headers, hasToken: boolean): string {
     segments.push("Sign in for higher rate limits.");
   }
   return segments.join(" ");
+}
+
+function parseRateLimitDeltaSeconds(value: string | null): number | undefined {
+  const normalized = normalizeHeaderValue(value);
+  if (!normalized || !/^\d+$/.test(normalized)) {
+    return undefined;
+  }
+  return parseStrictNonNegativeInteger(normalized);
 }
 
 async function fetchJson<T>(params: ClawHubRequestParams): Promise<T> {


### PR DESCRIPTION
Related: #105479

## What Problem This Solves

ClawHub 429 errors could present malformed reset headers as valid second counts because the formatter used JavaScript numeric coercion. Hexadecimal, exponent, signed, fractional, and unsafe integer strings could therefore produce misleading guidance. A malformed preferred `RateLimit-Reset` value could also hide a valid numeric `Retry-After` fallback.

## Why This Change Was Made

One local HTTP delta-seconds parser now requires ASCII decimal digits before applying the shared safe-integer validation. Both headers use it, with `RateLimit-Reset` still preferred and `Retry-After` retained as fallback. HTTP-date display behavior, retry scheduling, authentication guidance, and request behavior remain unchanged.

Maintainer cleanup also closes the signed-token gap identified during review: `+7` and `-0` are invalid HTTP delay values and no longer render as seconds.

## User Impact

ClawHub rate-limit errors no longer claim malformed values are reset durations. When the preferred header is malformed, users still receive a valid numeric fallback hint when available.

## Evidence

- Focused test: `src/infra/clawhub.test.ts` — 81/81 passed.
- Regression coverage includes hexadecimal, exponent, negative, negative zero, signed positive, fractional, and unsafe integers, plus valid fallback behavior.
- Exact-head Blacksmith changed gate passed on `0b879385e9ea5`: formatting, core and core-test typechecks, lint, storage guards, import-cycle checks, and the test-temp report.
- Blacksmith proof: https://github.com/openclaw/openclaw/actions/runs/29494274204
- Live ClawHub search returned a decimal `RateLimit-Reset` value, matching the production contract.
- HTTP contract: RFC 9110 defines numeric `Retry-After` as non-negative decimal `delay-seconds`; the RateLimit field specification uses delta-seconds for `RateLimit-Reset`.
- Fresh exact-branch Autoreview: clean, confidence 0.96.

AI-assisted: built with Codex
