### PR TITLE
fix(voice-call): ignore blank provider environment values

### DIFF
--- a/extensions/voice-call/src/config.test.ts
+++ b/extensions/voice-call/src/config.test.ts
@@ -54,6 +54,8 @@ describe("validateProviderConfig", () => {
     delete process.env.TELNYX_PUBLIC_KEY;
     delete process.env.PLIVO_AUTH_ID;
     delete process.env.PLIVO_AUTH_TOKEN;
+    delete process.env.NGROK_AUTHTOKEN;
+    delete process.env.NGROK_DOMAIN;
   };
 
   beforeEach(() => {
@@ -98,6 +100,66 @@ describe("validateProviderConfig", () => {
         }
         const fromEnv = resolveVoiceCallConfig(createBaseConfig(provider));
         expect(validateProviderConfig(fromEnv)).toEqual({ valid: true, errors: [] });
+      }
+    });
+
+    it("ignores blank provider and tunnel environment values", () => {
+      for (const provider of ["twilio", "telnyx", "plivo"] as const) {
+        clearProviderEnv();
+        process.env.TWILIO_ACCOUNT_SID = "   ";
+        process.env.TWILIO_AUTH_TOKEN = "   ";
+        process.env.TWILIO_FROM_NUMBER = "   ";
+        process.env.TELNYX_API_KEY = "   ";
+        process.env.TELNYX_CONNECTION_ID = "   ";
+        process.env.TELNYX_PUBLIC_KEY = "   ";
+        process.env.PLIVO_AUTH_ID = "   ";
+        process.env.PLIVO_AUTH_TOKEN = "   ";
+        process.env.NGROK_AUTHTOKEN = "   ";
+        process.env.NGROK_DOMAIN = "   ";
+
+        const config = resolveVoiceCallConfig({
+          ...createBaseConfig(provider),
+          fromNumber: undefined,
+          tunnel: { provider: "ngrok" },
+        });
+        const result = validateProviderConfig(config);
+
+        expect(result.valid).toBe(false);
+        expect(config.tunnel.ngrokAuthToken).toBeUndefined();
+        expect(config.tunnel.ngrokDomain).toBeUndefined();
+        if (provider === "twilio") {
+          expect(config.fromNumber).toBeUndefined();
+          expect(config.twilio?.accountSid).toBeUndefined();
+          expect(config.twilio?.authToken).toBeUndefined();
+          expect(result.errors).toContain(
+            "plugins.entries.voice-call.config.twilio.accountSid is required (or set TWILIO_ACCOUNT_SID env)",
+          );
+          expect(result.errors).toContain(
+            "plugins.entries.voice-call.config.twilio.authToken is required (or set TWILIO_AUTH_TOKEN env)",
+          );
+          expect(result.errors).toContain(
+            "plugins.entries.voice-call.config.fromNumber is required (or set TWILIO_FROM_NUMBER env)",
+          );
+        } else if (provider === "telnyx") {
+          expect(config.telnyx?.apiKey).toBeUndefined();
+          expect(config.telnyx?.connectionId).toBeUndefined();
+          expect(config.telnyx?.publicKey).toBeUndefined();
+          expect(result.errors).toContain(
+            "plugins.entries.voice-call.config.telnyx.apiKey is required (or set TELNYX_API_KEY env)",
+          );
+          expect(result.errors).toContain(
+            "plugins.entries.voice-call.config.telnyx.connectionId is required (or set TELNYX_CONNECTION_ID env)",
+          );
+        } else {
+          expect(config.plivo?.authId).toBeUndefined();
+          expect(config.plivo?.authToken).toBeUndefined();
+          expect(result.errors).toContain(
+            "plugins.entries.voice-call.config.plivo.authId is required (or set PLIVO_AUTH_ID env)",
+          );
+          expect(result.errors).toContain(
+            "plugins.entries.voice-call.config.plivo.authToken is required (or set PLIVO_AUTH_TOKEN env)",
+          );
+        }
       }
     });
   });

--- a/extensions/voice-call/src/config.ts
+++ b/extensions/voice-call/src/config.ts
@@ -12,6 +12,7 @@ import {
   canonicalizeMainSessionAlias,
   type SessionScope,
 } from "openclaw/plugin-sdk/session-store-runtime";
+import { resolveSpeechProviderApiKey } from "openclaw/plugin-sdk/speech-core";
 import { normalizeWebhookPath } from "openclaw/plugin-sdk/webhook-ingress";
 import { z } from "zod";
 import { TtsConfigSchema } from "../api.js";
@@ -527,11 +528,6 @@ function cloneDefaultVoiceCallConfig(): VoiceCallConfig {
   return structuredClone(DEFAULT_VOICE_CALL_CONFIG);
 }
 
-function envValue(name: string): string | undefined {
-  const value = process.env[name]?.trim();
-  return value ? value : undefined;
-}
-
 function defaultRealtimeStreamPathForServePath(servePath: string): string {
   const normalized = normalizeWebhookPath(servePath);
   if (normalized.endsWith("/webhook")) {
@@ -800,24 +796,32 @@ export function resolveVoiceCallConfig(config: VoiceCallConfigInput): VoiceCallC
   // Telnyx
   if (resolved.provider === "telnyx") {
     resolved.telnyx = resolved.telnyx ?? {};
-    resolved.telnyx.apiKey = resolved.telnyx.apiKey ?? envValue("TELNYX_API_KEY");
-    resolved.telnyx.connectionId = resolved.telnyx.connectionId ?? envValue("TELNYX_CONNECTION_ID");
-    resolved.telnyx.publicKey = resolved.telnyx.publicKey ?? envValue("TELNYX_PUBLIC_KEY");
+    resolved.telnyx.apiKey =
+      resolved.telnyx.apiKey ?? resolveSpeechProviderApiKey(process.env.TELNYX_API_KEY);
+    resolved.telnyx.connectionId =
+      resolved.telnyx.connectionId ?? resolveSpeechProviderApiKey(process.env.TELNYX_CONNECTION_ID);
+    resolved.telnyx.publicKey =
+      resolved.telnyx.publicKey ?? resolveSpeechProviderApiKey(process.env.TELNYX_PUBLIC_KEY);
   }
 
   // Twilio
   if (resolved.provider === "twilio") {
-    resolved.fromNumber = resolved.fromNumber ?? envValue("TWILIO_FROM_NUMBER");
+    resolved.fromNumber =
+      resolved.fromNumber ?? resolveSpeechProviderApiKey(process.env.TWILIO_FROM_NUMBER);
     resolved.twilio = resolved.twilio ?? {};
-    resolved.twilio.accountSid = resolved.twilio.accountSid ?? envValue("TWILIO_ACCOUNT_SID");
-    resolved.twilio.authToken = resolved.twilio.authToken ?? envValue("TWILIO_AUTH_TOKEN");
+    resolved.twilio.accountSid =
+      resolved.twilio.accountSid ?? resolveSpeechProviderApiKey(process.env.TWILIO_ACCOUNT_SID);
+    resolved.twilio.authToken =
+      resolved.twilio.authToken ?? resolveSpeechProviderApiKey(process.env.TWILIO_AUTH_TOKEN);
   }
 
   // Plivo
   if (resolved.provider === "plivo") {
     resolved.plivo = resolved.plivo ?? {};
-    resolved.plivo.authId = resolved.plivo.authId ?? envValue("PLIVO_AUTH_ID");
-    resolved.plivo.authToken = resolved.plivo.authToken ?? envValue("PLIVO_AUTH_TOKEN");
+    resolved.plivo.authId =
+      resolved.plivo.authId ?? resolveSpeechProviderApiKey(process.env.PLIVO_AUTH_ID);
+    resolved.plivo.authToken =
+      resolved.plivo.authToken ?? resolveSpeechProviderApiKey(process.env.PLIVO_AUTH_TOKEN);
   }
 
   // Tunnel Config
@@ -827,8 +831,10 @@ export function resolveVoiceCallConfig(config: VoiceCallConfigInput): VoiceCallC
   };
   resolved.tunnel.allowNgrokFreeTierLoopbackBypass =
     resolved.tunnel.allowNgrokFreeTierLoopbackBypass ?? false;
-  resolved.tunnel.ngrokAuthToken = resolved.tunnel.ngrokAuthToken ?? envValue("NGROK_AUTHTOKEN");
-  resolved.tunnel.ngrokDomain = resolved.tunnel.ngrokDomain ?? envValue("NGROK_DOMAIN");
+  resolved.tunnel.ngrokAuthToken =
+    resolved.tunnel.ngrokAuthToken ?? resolveSpeechProviderApiKey(process.env.NGROK_AUTHTOKEN);
+  resolved.tunnel.ngrokDomain =
+    resolved.tunnel.ngrokDomain ?? resolveSpeechProviderApiKey(process.env.NGROK_DOMAIN);
 
   // Webhook Security Config
   resolved.webhookSecurity = resolved.webhookSecurity ?? {

--- a/extensions/voice-call/src/config.ts
+++ b/extensions/voice-call/src/config.ts
@@ -527,6 +527,11 @@ function cloneDefaultVoiceCallConfig(): VoiceCallConfig {
   return structuredClone(DEFAULT_VOICE_CALL_CONFIG);
 }
 
+function envValue(name: string): string | undefined {
+  const value = process.env[name]?.trim();
+  return value ? value : undefined;
+}
+
 function defaultRealtimeStreamPathForServePath(servePath: string): string {
   const normalized = normalizeWebhookPath(servePath);
   if (normalized.endsWith("/webhook")) {
@@ -795,24 +800,24 @@ export function resolveVoiceCallConfig(config: VoiceCallConfigInput): VoiceCallC
   // Telnyx
   if (resolved.provider === "telnyx") {
     resolved.telnyx = resolved.telnyx ?? {};
-    resolved.telnyx.apiKey = resolved.telnyx.apiKey ?? process.env.TELNYX_API_KEY;
-    resolved.telnyx.connectionId = resolved.telnyx.connectionId ?? process.env.TELNYX_CONNECTION_ID;
-    resolved.telnyx.publicKey = resolved.telnyx.publicKey ?? process.env.TELNYX_PUBLIC_KEY;
+    resolved.telnyx.apiKey = resolved.telnyx.apiKey ?? envValue("TELNYX_API_KEY");
+    resolved.telnyx.connectionId = resolved.telnyx.connectionId ?? envValue("TELNYX_CONNECTION_ID");
+    resolved.telnyx.publicKey = resolved.telnyx.publicKey ?? envValue("TELNYX_PUBLIC_KEY");
   }
 
   // Twilio
   if (resolved.provider === "twilio") {
-    resolved.fromNumber = resolved.fromNumber ?? process.env.TWILIO_FROM_NUMBER;
+    resolved.fromNumber = resolved.fromNumber ?? envValue("TWILIO_FROM_NUMBER");
     resolved.twilio = resolved.twilio ?? {};
-    resolved.twilio.accountSid = resolved.twilio.accountSid ?? process.env.TWILIO_ACCOUNT_SID;
-    resolved.twilio.authToken = resolved.twilio.authToken ?? process.env.TWILIO_AUTH_TOKEN;
+    resolved.twilio.accountSid = resolved.twilio.accountSid ?? envValue("TWILIO_ACCOUNT_SID");
+    resolved.twilio.authToken = resolved.twilio.authToken ?? envValue("TWILIO_AUTH_TOKEN");
   }
 
   // Plivo
   if (resolved.provider === "plivo") {
     resolved.plivo = resolved.plivo ?? {};
-    resolved.plivo.authId = resolved.plivo.authId ?? process.env.PLIVO_AUTH_ID;
-    resolved.plivo.authToken = resolved.plivo.authToken ?? process.env.PLIVO_AUTH_TOKEN;
+    resolved.plivo.authId = resolved.plivo.authId ?? envValue("PLIVO_AUTH_ID");
+    resolved.plivo.authToken = resolved.plivo.authToken ?? envValue("PLIVO_AUTH_TOKEN");
   }
 
   // Tunnel Config
@@ -822,8 +827,8 @@ export function resolveVoiceCallConfig(config: VoiceCallConfigInput): VoiceCallC
   };
   resolved.tunnel.allowNgrokFreeTierLoopbackBypass =
     resolved.tunnel.allowNgrokFreeTierLoopbackBypass ?? false;
-  resolved.tunnel.ngrokAuthToken = resolved.tunnel.ngrokAuthToken ?? process.env.NGROK_AUTHTOKEN;
-  resolved.tunnel.ngrokDomain = resolved.tunnel.ngrokDomain ?? process.env.NGROK_DOMAIN;
+  resolved.tunnel.ngrokAuthToken = resolved.tunnel.ngrokAuthToken ?? envValue("NGROK_AUTHTOKEN");
+  resolved.tunnel.ngrokDomain = resolved.tunnel.ngrokDomain ?? envValue("NGROK_DOMAIN");
 
   // Webhook Security Config
   resolved.webhookSecurity = resolved.webhookSecurity ?? {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where blank Voice Call provider environment variables could be copied into resolved Telnyx, Twilio, Plivo, or ngrok configuration instead of being treated as absent.

## Why This Change Was Made

Voice Call now trims environment-sourced provider and tunnel values before applying them as config fallbacks. Blank environment values no longer satisfy credential fields or tunnel settings, while nonblank values still work as before.

## User Impact

Operators can leave Voice Call credential and tunnel environment variables unset or blank without accidentally masking missing configuration.

## Evidence

- Real production-module negative-control proof: `./node_modules/.bin/tsx proof-live.ts` imports `resolveVoiceCallConfig` and `validateProviderConfig`, verifies blank provider/tunnel env values stay absent, and verifies nonblank Twilio/ngrok env values still configure successfully.
- `node scripts/run-vitest.mjs extensions/voice-call/src/config.test.ts`: Voice Call config tests pass.

```text
$ ./node_modules/.bin/tsx proof-live.ts
entrypoint: resolveVoiceCallConfig + validateProviderConfig
blank-twilio-valid: false
blank-twilio-from-number: undefined
blank-twilio-auth-token: undefined
blank-telnyx-api-key: undefined
blank-plivo-auth-token: undefined
blank-ngrok-token: undefined
valid-twilio-valid: true
valid-twilio-from-number: +15550001234
valid-ngrok-domain: voice.example.com
```

```text
$ node scripts/run-vitest.mjs extensions/voice-call/src/config.test.ts
Test Files  1 passed (1)
Tests  38 passed (38)
```

<details>
<summary>proof-live.ts</summary>

```ts
import { resolveVoiceCallConfig, validateProviderConfig } from "./extensions/voice-call/src/config.ts";

const envNames = [
  "TWILIO_ACCOUNT_SID",
  "TWILIO_AUTH_TOKEN",
  "TWILIO_FROM_NUMBER",
  "TELNYX_API_KEY",
  "TELNYX_CONNECTION_ID",
  "TELNYX_PUBLIC_KEY",
  "PLIVO_AUTH_ID",
  "PLIVO_AUTH_TOKEN",
  "NGROK_AUTHTOKEN",
  "NGROK_DOMAIN",
] as const;

const originalEnv = Object.fromEntries(envNames.map((name) => [name, process.env[name]]));

function restoreEnv() {
  for (const name of envNames) {
    const value = originalEnv[name];
    if (value === undefined) {
      delete process.env[name];
    } else {
      process.env[name] = value;
    }
  }
}

function setEnv(value: string) {
  for (const name of envNames) {
    process.env[name] = value;
  }
}

function summarizeBlank() {
  setEnv("   ");
  const twilio = resolveVoiceCallConfig({
    enabled: true,
    provider: "twilio",
    tunnel: { provider: "ngrok" },
  });
  const telnyx = resolveVoiceCallConfig({
    enabled: true,
    provider: "telnyx",
    tunnel: { provider: "ngrok" },
  });
  const plivo = resolveVoiceCallConfig({
    enabled: true,
    provider: "plivo",
    tunnel: { provider: "ngrok" },
  });

  console.log(`blank-twilio-valid: ${validateProviderConfig(twilio).valid}`);
  console.log(`blank-twilio-from-number: ${twilio.fromNumber ?? "undefined"}`);
  console.log(`blank-twilio-auth-token: ${twilio.twilio?.authToken ?? "undefined"}`);
  console.log(`blank-telnyx-api-key: ${telnyx.telnyx?.apiKey ?? "undefined"}`);
  console.log(`blank-plivo-auth-token: ${plivo.plivo?.authToken ?? "undefined"}`);
  console.log(`blank-ngrok-token: ${twilio.tunnel.ngrokAuthToken ?? "undefined"}`);
}

function summarizeValid() {
  process.env.TWILIO_ACCOUNT_SID = "AC123";
  process.env.TWILIO_AUTH_TOKEN = "secret";
  process.env.TWILIO_FROM_NUMBER = "+15550001234";
  process.env.NGROK_AUTHTOKEN = "ngrok-token";
  process.env.NGROK_DOMAIN = "voice.example.com";
  const twilio = resolveVoiceCallConfig({
    enabled: true,
    provider: "twilio",
    tunnel: { provider: "ngrok" },
  });
  console.log(`valid-twilio-valid: ${validateProviderConfig(twilio).valid}`);
  console.log(`valid-twilio-from-number: ${twilio.fromNumber}`);
  console.log(`valid-ngrok-domain: ${twilio.tunnel.ngrokDomain}`);
}

try {
  console.log("entrypoint: resolveVoiceCallConfig + validateProviderConfig");
  summarizeBlank();
  summarizeValid();
} finally {
  restoreEnv();
}
```

</details>

AI-assisted: built with Codex
