### PR TITLE
fix(acp): record interruption notice when pending prompts are rejected

### DIFF
--- a/src/acp/translator.stop-reason.test.ts
+++ b/src/acp/translator.stop-reason.test.ts
@@ -295,6 +295,91 @@ describe("acp translator stop reason mapping", () => {
     }
   });
 
+  it("does not emit interruption after concurrent completion while rejection notice is delayed", async () => {
+    vi.useFakeTimers();
+    try {
+      let runId: string | undefined;
+      const request = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+        if (method === "chat.send") {
+          runId = params?.idempotencyKey as string | undefined;
+          return new Promise<never>(() => {});
+        }
+        return {};
+      }) as GatewayClient["request"];
+      const connection = createAcpConnection();
+      const sessionUpdate = connection["__sessionUpdateMock"];
+      let releaseInterruptionEmit: (() => void) | undefined;
+      const interruptionEmitGate = new Promise<void>((resolve) => {
+        releaseInterruptionEmit = resolve;
+      });
+      sessionUpdate.mockImplementation(async (payload: unknown) => {
+        const update = (
+          payload as { update?: { sessionUpdate?: string; content?: { text?: string } } }
+        )?.update;
+        if (
+          update?.sessionUpdate === "agent_message_chunk" &&
+          typeof update.content?.text === "string" &&
+          update.content.text.startsWith("Interrupted:")
+        ) {
+          await interruptionEmitGate;
+        }
+      });
+      const sessionStore = createInMemorySessionStore();
+      sessionStore.createSession({
+        sessionId: "session-1",
+        sessionKey: "agent:main:main",
+        cwd: "/tmp",
+      });
+      const agent = new AcpGatewayAgent(connection, createAcpGateway(request), { sessionStore });
+      const promptPromise = promptAgent(agent, "session-1");
+      const settleSpy = observeSettlement(promptPromise);
+
+      await vi.waitFor(() => {
+        expect(runId).toBeTypeOf("string");
+      });
+      sessionUpdate.mockClear();
+
+      // Start grace rejection; emit hangs so settlement ownership is claimed mid-flight.
+      agent.handleGatewayDisconnect("1006: connection lost");
+      const rejectStarted = vi.advanceTimersByTimeAsync(5_000);
+      await vi.waitFor(() => {
+        expect(sessionUpdate).toHaveBeenCalled();
+      });
+
+      // Concurrent completion arrives while the interruption emit is still pending.
+      await agent.handleGatewayEvent(
+        createChatEvent({
+          runId,
+          sessionKey: "agent:main:main",
+          seq: 1,
+          state: "final",
+        }),
+      );
+      releaseInterruptionEmit?.();
+      await rejectStarted;
+
+      await expect(promptPromise).rejects.toThrow("Gateway disconnected: 1006: connection lost");
+      expect(settleSpy).toHaveBeenCalledTimes(1);
+      expect(settleSpy.mock.calls[0]?.[0]).toMatchObject({ kind: "reject" });
+      // Exactly one interruption notice; completion must not also resolve the turn.
+      const interruptions = sessionUpdate.mock.calls
+        .map((call) => call[0])
+        .filter((payload) => {
+          const update = (
+            payload as { update?: { sessionUpdate?: string; content?: { text?: string } } }
+          )?.update;
+          return (
+            update?.sessionUpdate === "agent_message_chunk" &&
+            typeof update.content?.text === "string" &&
+            update.content.text.startsWith("Interrupted:")
+          );
+        });
+      expect(interruptions).toHaveLength(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("keeps pre-ack send disconnects inside the reconnect grace window", async () => {
     vi.useFakeTimers();
     try {

--- a/src/acp/translator.stop-reason.test.ts
+++ b/src/acp/translator.stop-reason.test.ts
@@ -181,6 +181,120 @@ describe("acp translator stop reason mapping", () => {
     }
   });
 
+  it("records a resend-aware interruption notice when an unaccepted prompt is rejected after grace", async () => {
+    vi.useFakeTimers();
+    try {
+      let runId: string | undefined;
+      const request = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+        if (method === "chat.send") {
+          runId = params?.idempotencyKey as string | undefined;
+          return new Promise<never>(() => {});
+        }
+        return {};
+      }) as GatewayClient["request"];
+      const connection = createAcpConnection();
+      const sessionUpdate = connection["__sessionUpdateMock"];
+      const sessionStore = createInMemorySessionStore();
+      sessionStore.createSession({
+        sessionId: "session-1",
+        sessionKey: "agent:main:main",
+        cwd: "/tmp",
+      });
+      const agent = new AcpGatewayAgent(connection, createAcpGateway(request), { sessionStore });
+      const promptPromise = promptAgent(agent, "session-1");
+      void promptPromise.catch(() => {});
+
+      await vi.waitFor(() => {
+        expect(runId).toBeTypeOf("string");
+      });
+      sessionUpdate.mockClear();
+
+      agent.handleGatewayDisconnect("1006: connection lost");
+      await vi.advanceTimersByTimeAsync(5_000);
+
+      await expect(promptPromise).rejects.toThrow("Gateway disconnected: 1006: connection lost");
+      const interruption = sessionUpdate.mock.calls
+        .map((call) => call[0])
+        .find(
+          (payload) =>
+            payload &&
+            typeof payload === "object" &&
+            (payload as { update?: { sessionUpdate?: string } }).update?.sessionUpdate ===
+              "agent_message_chunk",
+        ) as
+        | {
+            sessionId?: string;
+            update?: { sessionUpdate?: string; content?: { type?: string; text?: string } };
+          }
+        | undefined;
+      expect(interruption?.sessionId).toBe("session-1");
+      expect(interruption?.update?.content?.type).toBe("text");
+      expect(interruption?.update?.content?.text).toContain(
+        "Gateway disconnected: 1006: connection lost",
+      );
+      expect(interruption?.update?.content?.text).toContain("please resend");
+      expect(interruption?.update?.content?.text).not.toContain("do not resend");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("records a non-resend interruption notice when an accepted prompt is rejected after grace", async () => {
+    vi.useFakeTimers();
+    try {
+      const request = vi.fn(async (method: string) => {
+        if (method === "chat.send") {
+          return {};
+        }
+        if (method === "agent.wait") {
+          return { status: "timeout" };
+        }
+        return {};
+      }) as GatewayClient["request"];
+      const connection = createAcpConnection();
+      const sessionUpdate = connection["__sessionUpdateMock"];
+      const sessionStore = createInMemorySessionStore();
+      sessionStore.createSession({
+        sessionId: "session-1",
+        sessionKey: "agent:main:main",
+        cwd: "/tmp",
+      });
+      const agent = new AcpGatewayAgent(connection, createAcpGateway(request), { sessionStore });
+      const promptPromise = promptAgent(agent, "session-1");
+      void promptPromise.catch(() => {});
+
+      await Promise.resolve();
+      await Promise.resolve();
+      sessionUpdate.mockClear();
+
+      // Accepted but never reconnects: deadline recheck keeps reject when still disconnected.
+      agent.handleGatewayDisconnect("1006: connection lost");
+      await vi.advanceTimersByTimeAsync(5_000);
+
+      await expect(promptPromise).rejects.toThrow("Gateway disconnected: 1006: connection lost");
+      const interruption = sessionUpdate.mock.calls
+        .map((call) => call[0])
+        .find(
+          (payload) =>
+            payload &&
+            typeof payload === "object" &&
+            (payload as { update?: { sessionUpdate?: string } }).update?.sessionUpdate ===
+              "agent_message_chunk",
+        ) as
+        | {
+            update?: { content?: { text?: string } };
+          }
+        | undefined;
+      expect(interruption?.update?.content?.text).toContain(
+        "Gateway disconnected: 1006: connection lost",
+      );
+      expect(interruption?.update?.content?.text).toContain("do not resend");
+      expect(interruption?.update?.content?.text).not.toContain("please resend");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("keeps pre-ack send disconnects inside the reconnect grace window", async () => {
     vi.useFakeTimers();
     try {

--- a/src/acp/translator.ts
+++ b/src/acp/translator.ts
@@ -1314,35 +1314,43 @@ export class AcpGatewayAgent implements Agent {
     if (currentPending !== pending) {
       return;
     }
-    // Record one user-visible interruption before reject so grace-expired
-    // turns are not silent loss in the session stream / replay ledger.
+    // Claim exclusive settlement before any await so a concurrent Gateway
+    // completion cannot finishPrompt while the interruption notice is in flight.
+    const promptKey = this.pendingPromptKey(pending.sessionId, pending.idempotencyKey);
+    this.settlingPromptKeys.add(promptKey);
     try {
-      await this.sessionUpdates.emit({
-        sessionId: pending.sessionId,
-        sessionKey: pending.sessionKey,
-        ...(pending.ledgerSessionId ? { ledgerSessionId: pending.ledgerSessionId } : {}),
-        runId: pending.idempotencyKey,
-        record: true,
-        update: {
-          sessionUpdate: "agent_message_chunk",
-          content: {
-            type: "text",
-            text: this.formatPendingPromptRejectionNotice(pending, error),
-          },
-        },
+      this.clearApprovalRelaysForPrompt(pending.sessionId, pending.idempotencyKey, {
+        denyActive: true,
       });
-    } catch (err) {
-      this.log(`pending prompt rejection notice failed for ${pending.sessionId}: ${String(err)}`);
+      this.pendingPrompts.delete(pending.sessionId);
+      this.sessionStore.clearActiveRun(pending.sessionId);
+      if (this.pendingPrompts.size === 0) {
+        this.clearDisconnectTimer();
+      }
+      // Record one user-visible interruption before reject so grace-expired
+      // turns are not silent loss in the session stream / replay ledger.
+      try {
+        await this.sessionUpdates.emit({
+          sessionId: pending.sessionId,
+          sessionKey: pending.sessionKey,
+          ...(pending.ledgerSessionId ? { ledgerSessionId: pending.ledgerSessionId } : {}),
+          runId: pending.idempotencyKey,
+          record: true,
+          update: {
+            sessionUpdate: "agent_message_chunk",
+            content: {
+              type: "text",
+              text: this.formatPendingPromptRejectionNotice(pending, error),
+            },
+          },
+        });
+      } catch (err) {
+        this.log(`pending prompt rejection notice failed for ${pending.sessionId}: ${String(err)}`);
+      }
+      pending.reject(error);
+    } finally {
+      this.settlingPromptKeys.delete(promptKey);
     }
-    this.clearApprovalRelaysForPrompt(pending.sessionId, pending.idempotencyKey, {
-      denyActive: true,
-    });
-    this.pendingPrompts.delete(pending.sessionId);
-    this.sessionStore.clearActiveRun(pending.sessionId);
-    if (this.pendingPrompts.size === 0) {
-      this.clearDisconnectTimer();
-    }
-    pending.reject(error);
   }
 
   private clearPendingDisconnectState(

--- a/src/acp/translator.ts
+++ b/src/acp/translator.ts
@@ -721,7 +721,7 @@ export class AcpGatewayAgent implements Agent {
           if (status === "error") {
             const current = pending();
             if (current) {
-              this.rejectPendingPrompt(
+              await this.rejectPendingPrompt(
                 current,
                 new Error("Chat failed before the run started; try again."),
               );
@@ -1299,10 +1299,40 @@ export class AcpGatewayAgent implements Agent {
     this.disconnectTimer.unref?.();
   }
 
-  private rejectPendingPrompt(pending: PendingPrompt, error: Error): void {
+  private formatPendingPromptRejectionNotice(pending: PendingPrompt, error: Error): string {
+    const reason = error.message.trim() || "turn interrupted";
+    // Only invite a resend when the gateway never accepted the prompt. A
+    // post-accept "please resend" would double-send turns that already landed.
+    if (pending.sendAccepted) {
+      return `Interrupted: ${reason}. Your message was already accepted; do not resend — reconnect or start a new turn.`;
+    }
+    return `Interrupted: ${reason}. Your message was not accepted; please resend.`;
+  }
+
+  private async rejectPendingPrompt(pending: PendingPrompt, error: Error): Promise<void> {
     const currentPending = this.getPendingPrompt(pending.sessionId, pending.idempotencyKey);
     if (currentPending !== pending) {
       return;
+    }
+    // Record one user-visible interruption before reject so grace-expired
+    // turns are not silent loss in the session stream / replay ledger.
+    try {
+      await this.sessionUpdates.emit({
+        sessionId: pending.sessionId,
+        sessionKey: pending.sessionKey,
+        ...(pending.ledgerSessionId ? { ledgerSessionId: pending.ledgerSessionId } : {}),
+        runId: pending.idempotencyKey,
+        record: true,
+        update: {
+          sessionUpdate: "agent_message_chunk",
+          content: {
+            type: "text",
+            text: this.formatPendingPromptRejectionNotice(pending, error),
+          },
+        },
+      });
+    } catch (err) {
+      this.log(`pending prompt rejection notice failed for ${pending.sessionId}: ${String(err)}`);
     }
     this.clearApprovalRelaysForPrompt(pending.sessionId, pending.idempotencyKey, {
       denyActive: true,
@@ -1394,7 +1424,7 @@ export class AcpGatewayAgent implements Agent {
       this.log(`agent.wait reconcile failed for ${pending.idempotencyKey}: ${String(err)}`);
       if (deadlineExpired) {
         if (this.shouldRejectPendingAtDisconnectDeadline(pending, disconnectContext)) {
-          this.rejectPendingPrompt(
+          await this.rejectPendingPrompt(
             pending,
             new Error(`Gateway disconnected: ${disconnectContext.reason}`),
           );
@@ -1424,7 +1454,7 @@ export class AcpGatewayAgent implements Agent {
         if (!currentDisconnectContext) {
           return false;
         }
-        this.rejectPendingPrompt(
+        await this.rejectPendingPrompt(
           currentPending,
           new Error(`Gateway disconnected: ${currentDisconnectContext.reason}`),
         );


### PR DESCRIPTION
Closes #108587

## What Problem This Solves

Fixes an issue where users with an in-flight ACP turn would experience silent turn loss when the gateway stayed disconnected longer than the disconnect grace window: the ACP client only saw a generic JSON-RPC `-32603 Internal error`, and nothing was written to the session-update stream or replay ledger.

## Why This Change Was Made

When pending ACP prompts are rejected after grace expiry (or other terminal reject paths through the same helper), OpenClaw now emits one recorded `agent_message_chunk` interruption notice before rejecting the prompt. The notice is send-acceptance aware: it invites resend only when the gateway never accepted the message, so already-accepted turns are not double-sent.

Settlement is exclusive: `rejectPendingPrompt` claims ownership (settling key + remove from `pendingPrompts`) synchronously before awaiting the notice write, matching `finishPrompt`, so a concurrent Gateway completion cannot also settle the same turn. Compatibility stays on the existing reject path (no new config/API). Performance impact is a single optional session-update write on the rare reject path. No channel or security boundary changes.

## User Impact

ACP clients and chat transcripts show a durable, user-visible interruption when a turn is force-rejected after disconnect grace, instead of a silent dangling user message. Resend guidance only appears when the message was never accepted. Concurrent completion during a delayed notice write cannot produce both a normal completion and an Interrupted message for the same turn.

## Evidence

Verification host: local macOS (Crabbox not used).

```text
$ node scripts/run-vitest.mjs src/acp/translator.stop-reason.test.ts
 ✓ |unit-fast-fake-timers| src/acp/translator.stop-reason.test.ts (21 tests) 121ms
 Test Files  1 passed (1)
      Tests  21 passed (21)
```

Focused coverage includes:

- unaccepted prompt after grace → notice contains `please resend`
- accepted prompt after grace (still disconnected) → notice contains `do not resend`
- delayed interruption emit while a concurrent `final` chat event arrives → prompt rejects once with exactly one Interrupted notice (no dual settle)

## Real behavior proof

- Behavior addressed: ACP pending-prompt rejection after disconnect grace records a resend-aware interruption chunk; settlement is exclusive before the durable notice await so concurrent Gateway completion cannot double-settle.
- Environment: local macOS, openclaw checkout at this PR head, focused Vitest harness under `src/acp/translator.stop-reason.test.ts`.
- Current-main contrast: on main, `rejectPendingPrompt` only `pending.reject(error)` with no `sessionUpdates.emit`. The first PR revision also awaited the notice while the prompt remained in `pendingPrompts`, allowing a late completion to race. This revision claims settlement before the first await (same pattern as `finishPrompt`).
- Exact steps or command run after this patch:
  1. `node scripts/run-vitest.mjs src/acp/translator.stop-reason.test.ts`
  2. Observe rejection-notice cases plus `does not emit interruption after concurrent completion while rejection notice is delayed`.
- Evidence after fix: all 21 stop-reason tests pass; race case settles once as reject with a single Interrupted chunk while a delayed emit is in flight under a concurrent final event.
- Control check: reconnect-within-grace and agent.wait recovery cases remain green and do not emit the interruption notice when settlement is not taken by reject.
- Observed result after fix: rejected turns leave a durable user-visible interruption; concurrent completion during notice write does not also resolve the prompt as a normal end_turn.
- What was not tested: live `openclaw acp` client against a real Gateway outage; multi-session concurrent reject fan-out; non-ACP channel disconnect paths (out of scope for this ACP settlement helper).

## AI disclosure

This PR was authored with AI assistance (Grok).