### PR TITLE
fix(gateway): keep channels suppressed in skip mode

### DIFF
--- a/src/gateway/server-runtime-services.test.ts
+++ b/src/gateway/server-runtime-services.test.ts
@@ -54,7 +54,8 @@ vi.mock("../sessions/session-upstream-monitor.js", () => ({
   startSessionUpstreamMonitor: hoisted.startSessionUpstreamMonitor,
 }));
 
-vi.mock("../infra/env.js", () => ({
+vi.mock("../infra/env.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../infra/env.js")>()),
   isVitestRuntimeEnv: hoisted.isVitestRuntimeEnv,
 }));
 
@@ -128,6 +129,7 @@ describe("server-runtime-services", () => {
 
   afterEach(() => {
     vi.useRealTimers();
+    vi.unstubAllEnvs();
     resetGatewayWorkAdmission();
   });
 
@@ -171,6 +173,27 @@ describe("server-runtime-services", () => {
     services.heartbeatRunner.stop();
     expect(hoisted.heartbeatRunner.stop).not.toHaveBeenCalled();
   });
+
+  it.each(["OPENCLAW_SKIP_CHANNELS", "OPENCLAW_SKIP_PROVIDERS"] as const)(
+    "keeps channel health monitoring disabled when %s is enabled",
+    (envKey) => {
+      vi.stubEnv(envKey, "true");
+
+      const services = startGatewayRuntimeServices({
+        minimalTestGateway: false,
+        cfgAtStart: {} as never,
+        channelManager: {
+          getRuntimeSnapshot: vi.fn(),
+          isHealthMonitorEnabled: vi.fn(),
+          isManuallyStopped: vi.fn(),
+        } as never,
+        log: createLog(),
+      });
+
+      expect(hoisted.startChannelHealthMonitor).not.toHaveBeenCalled();
+      expect(services.channelHealthMonitor).toBeNull();
+    },
+  );
 
   it("starts model pricing refresh after scheduled services activate", async () => {
     const pluginLookUpTable = {

--- a/src/gateway/server-runtime-startup-services.ts
+++ b/src/gateway/server-runtime-startup-services.ts
@@ -1,6 +1,7 @@
 // Gateway startup-time runtime services.
 // Starts mode-dependent background monitors with inert handles for disabled paths.
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { isTruthyEnvValue } from "../infra/env.js";
 import type { ChannelHealthMonitor } from "./channel-health-monitor.js";
 import { startChannelHealthMonitor } from "./channel-health-monitor.js";
 import {
@@ -15,11 +16,17 @@ export type GatewayChannelManager = Parameters<
   typeof startChannelHealthMonitor
 >[0]["channelManager"];
 
-/** Starts channel health monitoring when gateway config enables it. */
+/** Starts channel health monitoring when the gateway mode and config enable it. */
 export function startGatewayChannelHealthMonitor(params: {
   cfg: OpenClawConfig;
   channelManager: GatewayChannelManager;
 }): ChannelHealthMonitor | null {
+  if (
+    isTruthyEnvValue(process.env.OPENCLAW_SKIP_CHANNELS) ||
+    isTruthyEnvValue(process.env.OPENCLAW_SKIP_PROVIDERS)
+  ) {
+    return null;
+  }
   const healthCheckMinutes = params.cfg.gateway?.channelHealthCheckMinutes;
   if (healthCheckMinutes === 0) {
     return null;


### PR DESCRIPTION
Closes #108786

AI-assisted: Codex

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where operators starting a gateway with `OPENCLAW_SKIP_CHANNELS=1` or `OPENCLAW_SKIP_PROVIDERS=1` could still have configured channels started later by the channel health monitor.

## Why This Change Was Made

Channel health-monitor startup now honors the same process-level skip modes as initial channel startup and hot reload. The guard lives in the Gateway lifecycle wrapper, so the generic monitor remains independent of process policy and every monitor creation path shares the invariant.

## User Impact

Gateways started in skip-channel or skip-provider mode now keep external channel transports suppressed for the lifetime of the process, including after the health-monitor startup grace period.

## Evidence

- Regression-first proof: the two new skip-mode cases failed before the implementation because `startChannelHealthMonitor` was called once for each environment variable.
- `node scripts/run-vitest.mjs src/gateway/server-runtime-services.test.ts src/gateway/channel-health-monitor.test.ts` — 2 files passed, 64 tests passed.
- `./node_modules/.bin/oxfmt --check src/gateway/server-runtime-startup-services.ts src/gateway/server-runtime-services.test.ts` — passed.
- `./node_modules/.bin/oxlint src/gateway/server-runtime-startup-services.ts src/gateway/server-runtime-services.test.ts` — passed.
- Autoreview (`--mode branch --base upstream/main`) — no findings; patch correct with 0.98 confidence.
- PR CI is currently blocked by an unrelated `main` regression: the PR and [current main run](https://github.com/openclaw/openclaw/actions/runs/29486328686) both fail broad shards with `Canonical SQLite schema contains non-STRICT tables: apns_registration_tombstones`. All non-CI workflows completed successfully.
