### PR TITLE
fix(state): make APNs tombstones strict

### DIFF
--- a/src/state/openclaw-state-schema.generated.ts
+++ b/src/state/openclaw-state-schema.generated.ts
@@ -645,7 +645,7 @@ CREATE INDEX IF NOT EXISTS idx_apns_registrations_updated
 CREATE TABLE IF NOT EXISTS apns_registration_tombstones (
   node_id TEXT NOT NULL PRIMARY KEY,
   deleted_at_ms INTEGER NOT NULL
-);
+) STRICT;
 
 CREATE TABLE IF NOT EXISTS node_host_config (
   config_key TEXT NOT NULL PRIMARY KEY,

--- a/src/state/openclaw-state-schema.sql
+++ b/src/state/openclaw-state-schema.sql
@@ -640,7 +640,7 @@ CREATE INDEX IF NOT EXISTS idx_apns_registrations_updated
 CREATE TABLE IF NOT EXISTS apns_registration_tombstones (
   node_id TEXT NOT NULL PRIMARY KEY,
   deleted_at_ms INTEGER NOT NULL
-);
+) STRICT;
 
 CREATE TABLE IF NOT EXISTS node_host_config (
   config_key TEXT NOT NULL PRIMARY KEY,


### PR DESCRIPTION
Related: #108543

## What Problem This Solves

Fixes an issue where opening the shared state database aborts after the APNs SQLite migration because the canonical schema contains one non-STRICT tombstone table. The regression currently fails 23 CI shards through the shared schema guard.

## Why This Change Was Made

Declare the APNs tombstone table STRICT in the source SQL and regenerate the committed schema module. This restores the invariant already enforced for every canonical shared-state table.

AI-assisted: yes. The final two-line generated/source diff received a fresh clean autoreview.

## User Impact

Shared state database initialization works again on current main. No shipped migration or data shape changes; the offending table was introduced on main immediately before this fix.

## Evidence

- Reproduced in #108797 CI: 23 shards failed with the same non-STRICT canonical-table error.
- Blacksmith Testbox: 77 shared-state database tests and 19 infra-store tests pass.
- Generator verification and the full changed-surface gate pass, including core/core-test typechecks, lint, schema guards, and runtime import cycles.
- Fresh autoreview: no accepted or actionable findings.
