### PR TITLE
feat(ui): animated Clawd mascot on the new-session welcome hero

### DIFF
--- a/test/scripts/lint-suppressions.test.ts
+++ b/test/scripts/lint-suppressions.test.ts
@@ -238,6 +238,8 @@ describe("production lint suppressions", () => {
         "src/utils.ts|typescript/no-unnecessary-type-parameters|1",
         "src/version.ts|eslint/no-underscore-dangle|1",
         "ui/public/sw.js|unicorn/require-post-message-target-origin|1",
+        // oxlint misreads CanvasRenderingContext2D.fill(path) as Array.fill.
+        "ui/src/components/mascot-canvas.ts|unicorn/no-array-fill-with-reference-type|1",
       ]),
     );
   });

--- a/ui/src/components/mascot-animator.test.ts
+++ b/ui/src/components/mascot-animator.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "vitest";
+import { MascotAnimator } from "./mascot-animator.ts";
+import { staticMascotPose, type MascotMood, type MascotPose } from "./mascot-pose.ts";
+
+const MOODS: MascotMood[] = [
+  "idle",
+  "curious",
+  "thinking",
+  "working",
+  "happy",
+  "celebrating",
+  "sad",
+  "sleepy",
+  "attentive",
+];
+
+function expectPoseInBounds(pose: MascotPose): void {
+  expect(pose.floatOffset).toBeGreaterThanOrEqual(-12);
+  expect(pose.floatOffset).toBeLessThanOrEqual(2);
+  expect(pose.antennaDegrees).toBeGreaterThanOrEqual(-14);
+  expect(pose.antennaDegrees).toBeLessThanOrEqual(14);
+  expect(pose.antennaDroop).toBeGreaterThanOrEqual(0);
+  expect(pose.antennaDroop).toBeLessThanOrEqual(1);
+  expect(pose.leftClawDegrees).toBeGreaterThanOrEqual(-45);
+  expect(pose.leftClawDegrees).toBeLessThanOrEqual(45);
+  expect(pose.rightClawDegrees).toBeGreaterThanOrEqual(-45);
+  expect(pose.rightClawDegrees).toBeLessThanOrEqual(45);
+  expect(pose.eyeGlowOpacity).toBeGreaterThanOrEqual(0);
+  expect(pose.eyeGlowOpacity).toBeLessThanOrEqual(1);
+  expect(pose.glowScale).toBeGreaterThanOrEqual(0.5);
+  expect(pose.glowScale).toBeLessThanOrEqual(1.6);
+  expect(pose.leftEyeOpenness).toBeGreaterThanOrEqual(0);
+  expect(pose.leftEyeOpenness).toBeLessThanOrEqual(1);
+  expect(pose.rightEyeOpenness).toBeGreaterThanOrEqual(0);
+  expect(pose.rightEyeOpenness).toBeLessThanOrEqual(1);
+  expect(pose.happyEyes).toBeGreaterThanOrEqual(0);
+  expect(pose.happyEyes).toBeLessThanOrEqual(1);
+  expect(pose.gaze.x).toBeGreaterThanOrEqual(-1.2);
+  expect(pose.gaze.x).toBeLessThanOrEqual(1.2);
+  expect(pose.gaze.y).toBeGreaterThanOrEqual(-1.2);
+  expect(pose.gaze.y).toBeLessThanOrEqual(1.2);
+  expect(pose.mouthCurve).toBeGreaterThanOrEqual(-1);
+  expect(pose.mouthCurve).toBeLessThanOrEqual(1);
+  expect(pose.mouthOpen).toBeGreaterThanOrEqual(0);
+  expect(pose.mouthOpen).toBeLessThanOrEqual(1);
+  expect(pose.mouthRound).toBeGreaterThanOrEqual(0);
+  expect(pose.mouthRound).toBeLessThanOrEqual(1);
+  expect(pose.blush).toBeGreaterThanOrEqual(0);
+  expect(pose.blush).toBeLessThanOrEqual(1);
+  expect(pose.hardHat).toBeGreaterThanOrEqual(0);
+  expect(pose.hardHat).toBeLessThanOrEqual(1);
+  expect(pose.bodyTilt).toBeGreaterThanOrEqual(-8);
+  expect(pose.bodyTilt).toBeLessThanOrEqual(8);
+  expect(pose.bodyStretch).toBeGreaterThanOrEqual(0.86);
+  expect(pose.bodyStretch).toBeLessThanOrEqual(1.05);
+  expect(pose.dizzy).toBeGreaterThanOrEqual(0);
+  expect(pose.dizzy).toBeLessThanOrEqual(1);
+}
+
+describe("MascotAnimator", () => {
+  it("keeps every mood inside drawable channel bounds for 30 seconds", () => {
+    for (const [index, mood] of MOODS.entries()) {
+      const animator = new MascotAnimator(1_000 + index);
+      animator.setMood(mood, 0);
+      for (let frame = 0; frame <= 30 * 30; frame += 1) {
+        expectPoseInBounds(animator.poseAt(frame / 30));
+      }
+    }
+  });
+
+  it("produces identical pose streams from the same seed", () => {
+    const first = new MascotAnimator(0x5eed);
+    const second = new MascotAnimator(0x5eed);
+    first.setMood("thinking", 0);
+    second.setMood("thinking", 0);
+
+    for (let frame = 0; frame <= 20 * 30; frame += 1) {
+      const time = frame / 30;
+      expect(first.poseAt(time)).toEqual(second.poseAt(time));
+    }
+  });
+
+  it("runs the working hard-hat, hammer, impact, and brow-wipe cycle", () => {
+    const animator = new MascotAnimator(42);
+    animator.setMood("working", 0);
+    const rightClawAngles: number[] = [];
+    const effects = new Set<string>();
+    let seatedHat = 0;
+
+    for (let frame = 0; frame <= 30 * 30; frame += 1) {
+      const pose = animator.poseAt(frame / 30);
+      rightClawAngles.push(pose.rightClawDegrees);
+      effects.add(pose.effect);
+      if (frame >= 33) {
+        seatedHat = Math.max(seatedHat, pose.hardHat);
+      }
+    }
+
+    expect(seatedHat).toBe(1);
+    expect(Math.max(...rightClawAngles) - Math.min(...rightClawAngles)).toBeGreaterThan(25);
+    expect(effects).toContain("sparks");
+    expect(effects).toContain("sweat");
+  });
+
+  it("keeps sleepy z's visible through its yawn entrance", () => {
+    const animator = new MascotAnimator(7);
+    animator.setMood("sleepy", 0);
+    const pose = animator.poseAt(0.8);
+
+    expect(pose.effect).toBe("zzz");
+    expect(pose.mouthRound).toBeGreaterThan(0.8);
+    expect(pose.leftEyeOpenness).toBeLessThan(0.1);
+  });
+});
+
+describe("staticMascotPose", () => {
+  it("preserves the identifying expression for each motionless mood", () => {
+    expect(staticMascotPose("thinking").gaze.y).toBeLessThan(0);
+    expect(staticMascotPose("working")).toMatchObject({ hardHat: 1, rightClawDegrees: -28 });
+    expect(staticMascotPose("happy").mouthCurve).toBeGreaterThan(0.5);
+    expect(staticMascotPose("celebrating").leftClawDegrees).toBeGreaterThan(25);
+    expect(staticMascotPose("celebrating").rightClawDegrees).toBeLessThan(-25);
+    expect(staticMascotPose("sad")).toMatchObject({ antennaDroop: 0.75, mouthCurve: -0.55 });
+    expect(staticMascotPose("sleepy").leftEyeOpenness).toBe(0.25);
+    expect(staticMascotPose("attentive")).toEqual(staticMascotPose("idle"));
+  });
+});

--- a/ui/src/components/mascot-animator.test.ts
+++ b/ui/src/components/mascot-animator.test.ts
@@ -102,6 +102,22 @@ describe("MascotAnimator", () => {
     expect(effects).toContain("sweat");
   });
 
+  it("cancels stale gestures when the mood changes", () => {
+    // Begin as idle (queues the hello wave at +0.9s), then switch mood before
+    // it fires — mirrors the element lifecycle where firstUpdated precedes the
+    // first `updated()` mood application.
+    const animator = new MascotAnimator(9);
+    animator.poseAt(0);
+    animator.setMood("thinking", 0.1);
+
+    for (let frame = 3; frame <= 4 * 30; frame += 1) {
+      const pose = animator.poseAt(frame / 30);
+      // The wave raises the right claw far past anything thinking's base loop
+      // (claw ~0°) or a scheduled claw snap (-8°) can produce.
+      expect(pose.rightClawDegrees).toBeGreaterThan(-15);
+    }
+  });
+
   it("keeps sleepy z's visible through its yawn entrance", () => {
     const animator = new MascotAnimator(7);
     animator.setMood("sleepy", 0);

--- a/ui/src/components/mascot-animator.ts
+++ b/ui/src/components/mascot-animator.ts
@@ -125,6 +125,10 @@ export class MascotAnimator {
       return;
     }
     this.currentMood = mood;
+    // A queued hello-wave or a mid-flight gesture from the previous mood would
+    // otherwise keep animating into the new mood's body language.
+    this.pendingGesture = null;
+    this.activeGesture = null;
     this.rescheduleMoodBeat(time);
     const entrance = this.entranceGesture(mood);
     if (entrance) {

--- a/ui/src/components/mascot-animator.ts
+++ b/ui/src/components/mascot-animator.ts
@@ -1,0 +1,513 @@
+// Pure deterministic mascot motion model. Times are seconds.
+import {
+  clampMascotPose,
+  createMascotPose,
+  type MascotMood,
+  type MascotPose,
+} from "./mascot-pose.ts";
+
+type Gesture =
+  | "wave"
+  | "hop"
+  | "celebrate"
+  | "sigh"
+  | "yawn"
+  | "clawSnap"
+  | "donHardHat"
+  | "wipeBrow";
+
+const MASK_64 = (1n << 64n) - 1n;
+const NONZERO_SEED = 0x9e37_79b9_7f4a_7c15n;
+const XORSHIFT_MULTIPLIER = 2_685_821_657_736_338_717n;
+const TAU = Math.PI * 2;
+const BLINK_DURATION = 0.16;
+
+function clamp(value: number, min = 0, max = 1): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+function cyclePhase(time: number, period: number): number {
+  const normalized = (time / period) % 1;
+  return normalized < 0 ? normalized + 1 : normalized;
+}
+
+function easeInOut(value: number): number {
+  const t = clamp(value);
+  return t * t * (3 - 2 * t);
+}
+
+function bell(value: number): number {
+  const t = clamp(value);
+  return easeInOut(t < 0.5 ? t * 2 : (1 - t) * 2);
+}
+
+function plateau(value: number, attack: number, release: number): number {
+  const t = clamp(value);
+  if (t < attack) {
+    return easeInOut(t / attack);
+  }
+  if (t > release) {
+    return easeInOut((1 - t) / (1 - release));
+  }
+  return 1;
+}
+
+function gestureDuration(gesture: Gesture): number {
+  switch (gesture) {
+    case "wave":
+      return 1.5;
+    case "hop":
+      return 0.7;
+    case "celebrate":
+      return 2.4;
+    case "sigh":
+      return 1.8;
+    case "yawn":
+    case "wipeBrow":
+      return 2;
+    case "clawSnap":
+      return 0.6;
+    case "donHardHat":
+      return 1;
+  }
+  return 0;
+}
+
+class SeededGenerator {
+  private state: bigint;
+
+  constructor(seed: bigint | number) {
+    const normalized = BigInt.asUintN(64, BigInt(seed));
+    this.state = normalized === 0n ? NONZERO_SEED : normalized;
+  }
+
+  next(): bigint {
+    this.state ^= this.state >> 12n;
+    this.state = BigInt.asUintN(64, this.state);
+    this.state ^= this.state << 25n;
+    this.state = BigInt.asUintN(64, this.state);
+    this.state ^= this.state >> 27n;
+    this.state = BigInt.asUintN(64, this.state);
+    return (this.state * XORSHIFT_MULTIPLIER) & MASK_64;
+  }
+
+  unit(): number {
+    return Number(this.next() >> 11n) / 9_007_199_254_740_992;
+  }
+}
+
+/** Mood loops plus randomized blink, gaze, claw-snap, and mood-beat schedules. */
+export class MascotAnimator {
+  private readonly rng: SeededGenerator;
+  private currentMood: MascotMood = "idle";
+  private startTime: number | null = null;
+  private lastPoseTime = 0;
+  private activeGesture: Gesture | null = null;
+  private activeGestureStart = 0;
+  private pendingGesture: Gesture | null = null;
+  private pendingGestureAt = 0;
+  private nextBlinkAt = 0;
+  private pendingDoubleBlink = false;
+  private blinkStarts: number[] = [];
+  private nextGlanceAt = 0;
+  private gazeHoldUntil = 0;
+  private gazeTarget = { x: 0, y: 0 };
+  private currentGaze = { x: 0, y: 0 };
+  private nextClawSnapAt = 0;
+  private nextMoodBeatAt = 0;
+
+  constructor(seed: bigint | number = BigInt(Date.now())) {
+    this.rng = new SeededGenerator(seed);
+  }
+
+  setMood(mood: MascotMood, time: number): void {
+    if (mood === this.currentMood) {
+      return;
+    }
+    this.currentMood = mood;
+    this.rescheduleMoodBeat(time);
+    const entrance = this.entranceGesture(mood);
+    if (entrance) {
+      this.startGesture(entrance, time);
+    }
+  }
+
+  poseAt(time: number): MascotPose {
+    if (this.startTime === null) {
+      this.begin(time);
+    }
+    const dt = clamp(time - this.lastPoseTime, 0, 0.1);
+    this.lastPoseTime = time;
+    this.advanceSchedules(time);
+
+    const pose = this.basePose(this.currentMood, time);
+    this.applyGaze(pose, this.currentMood, time, dt);
+    this.applyBlinks(pose, time);
+
+    if (this.activeGesture) {
+      const progress = (time - this.activeGestureStart) / gestureDuration(this.activeGesture);
+      if (progress >= 1) {
+        this.activeGesture = null;
+      } else {
+        this.applyGesture(this.activeGesture, pose, progress);
+      }
+    }
+
+    return clampMascotPose(pose);
+  }
+
+  private begin(time: number): void {
+    this.startTime = time;
+    this.lastPoseTime = time;
+    this.nextBlinkAt = time + this.random(0.8, 2.4);
+    this.nextGlanceAt = time + this.random(1.5, 4);
+    this.nextClawSnapAt = time + this.random(2, 5);
+    this.rescheduleMoodBeat(time);
+    if (
+      this.currentMood === "idle" ||
+      this.currentMood === "curious" ||
+      this.currentMood === "happy"
+    ) {
+      this.pendingGesture = "wave";
+      this.pendingGestureAt = time + 0.9;
+    }
+  }
+
+  private advanceSchedules(time: number): void {
+    if (time >= this.nextBlinkAt) {
+      this.blinkStarts.push(time);
+      if (this.pendingDoubleBlink) {
+        this.pendingDoubleBlink = false;
+        this.nextBlinkAt = time + this.blinkInterval();
+      } else if (this.random(0, 1) < 0.14) {
+        this.pendingDoubleBlink = true;
+        this.nextBlinkAt = time + 0.34;
+      } else {
+        this.nextBlinkAt = time + this.blinkInterval();
+      }
+    }
+    this.blinkStarts = this.blinkStarts.filter((start) => time - start <= BLINK_DURATION);
+
+    if (time >= this.nextGlanceAt) {
+      this.gazeTarget = this.randomGlanceTarget();
+      this.gazeHoldUntil = time + this.random(0.7, 1.9);
+      this.nextGlanceAt = this.gazeHoldUntil + this.glanceInterval();
+    } else if (time >= this.gazeHoldUntil) {
+      this.gazeTarget = { x: 0, y: 0 };
+    }
+
+    if (time >= this.nextClawSnapAt) {
+      if (
+        this.activeGesture === null &&
+        this.currentMood !== "sad" &&
+        this.currentMood !== "working"
+      ) {
+        this.startGesture("clawSnap", time);
+      }
+      this.nextClawSnapAt = time + this.random(4, 9);
+    }
+
+    if (time >= this.nextMoodBeatAt) {
+      if (this.activeGesture === null) {
+        if (this.currentMood === "sad") {
+          this.startGesture("sigh", time);
+        } else if (this.currentMood === "sleepy") {
+          this.startGesture("yawn", time);
+        } else if (this.currentMood === "working") {
+          this.startGesture("wipeBrow", time);
+        }
+      }
+      this.rescheduleMoodBeat(time);
+    }
+
+    if (this.pendingGesture && time >= this.pendingGestureAt && this.activeGesture === null) {
+      const pending = this.pendingGesture;
+      this.pendingGesture = null;
+      this.startGesture(pending, time);
+    }
+  }
+
+  private basePose(mood: MascotMood, time: number): MascotPose {
+    const pose = createMascotPose();
+    switch (mood) {
+      case "idle":
+        pose.floatOffset = -4.8 * (1 - Math.cos(TAU * cyclePhase(time, 4)));
+        pose.antennaDegrees = -3 * Math.sin(TAU * cyclePhase(time, 2));
+        break;
+      case "curious":
+        pose.floatOffset = -4.2 * (1 - Math.cos(TAU * cyclePhase(time, 3.4)));
+        pose.antennaDegrees = -4 * Math.sin(TAU * cyclePhase(time, 1.7));
+        pose.bodyTilt = 1.6 * Math.sin(TAU * cyclePhase(time, 5.2));
+        break;
+      case "thinking":
+        pose.floatOffset = -3.2 * (1 - Math.cos(TAU * cyclePhase(time, 5)));
+        pose.antennaDegrees = -5 * Math.sin(TAU * cyclePhase(time, 1.3));
+        pose.bodyTilt = 2 * Math.sin(TAU * cyclePhase(time, 6));
+        pose.eyeGlowOpacity = 0.9 + 0.1 * Math.sin(TAU * cyclePhase(time, 0.8));
+        break;
+      case "working": {
+        const phase = cyclePhase(time, 0.95);
+        if (phase < 0.05) {
+          pose.rightClawDegrees = -6;
+        } else if (phase < 0.6) {
+          pose.rightClawDegrees = -6 - 28 * easeInOut((phase - 0.05) / 0.55);
+        } else if (phase < 0.72) {
+          const strike = clamp((phase - 0.6) / 0.12);
+          pose.rightClawDegrees = -34 + 46 * strike * strike;
+        } else {
+          pose.rightClawDegrees = 12 - 18 * easeInOut((phase - 0.72) / 0.28);
+        }
+        pose.leftClawDegrees = 4 + 2 * Math.sin(TAU * phase);
+        const impact = bell(clamp((phase - 0.72) / 0.14));
+        pose.floatOffset = -2 * (1 - Math.cos(TAU * cyclePhase(time, 3.8))) + 0.8 * impact;
+        pose.bodyStretch = 1 - 0.03 * impact;
+        pose.bodyTilt = 2.2 + 0.6 * Math.sin(TAU * cyclePhase(time, 5));
+        if (phase >= 0.72) {
+          const recoil = clamp((phase - 0.72) / 0.28);
+          pose.antennaDegrees = 6 * (1 - recoil) * Math.sin(recoil * 3 * Math.PI);
+        }
+        pose.leftEyeOpenness = 0.85;
+        pose.rightEyeOpenness = 0.85;
+        pose.mouthCurve = 0.18;
+        pose.hardHat = 1;
+        pose.effect = "sparks";
+        const strikePhase = (phase - 0.72) % 1;
+        pose.effectPhase = strikePhase < 0 ? strikePhase + 1 : strikePhase;
+        break;
+      }
+      case "happy":
+        pose.floatOffset = -6 * (1 - Math.cos(TAU * cyclePhase(time, 3)));
+        pose.antennaDegrees = -4.5 * Math.sin(TAU * cyclePhase(time, 1.6));
+        pose.mouthCurve = 0.55 + 0.1 * Math.sin(TAU * cyclePhase(time, 3));
+        pose.happyEyes = 0.35;
+        break;
+      case "celebrating": {
+        const hop = Math.abs(Math.sin(TAU * cyclePhase(time, 1.6)));
+        pose.floatOffset = -9 * hop;
+        pose.bodyStretch = 1 + 0.03 * hop;
+        pose.antennaDegrees = -6 * Math.sin(TAU * cyclePhase(time, 0.8));
+        const clawWave = Math.sin(TAU * cyclePhase(time, 0.9));
+        pose.leftClawDegrees = 20 + 8 * clawWave;
+        pose.rightClawDegrees = -20 + 8 * clawWave;
+        pose.mouthCurve = 0.9;
+        pose.mouthOpen = 0.35;
+        pose.happyEyes = 0.7;
+        pose.glowScale = 1.1;
+        pose.effect = "sparkles";
+        pose.effectPhase = cyclePhase(time, 2.2);
+        break;
+      }
+      case "sad":
+        pose.floatOffset = -2.4 * (1 - Math.cos(TAU * cyclePhase(time, 5.5)));
+        pose.antennaDegrees = -1.5 * Math.sin(TAU * cyclePhase(time, 3));
+        pose.antennaDroop = 0.75;
+        pose.mouthCurve = -0.55;
+        pose.eyeGlowOpacity = 0.6;
+        break;
+      case "sleepy":
+        pose.floatOffset = -2 * (1 - Math.cos(TAU * cyclePhase(time, 6)));
+        pose.antennaDroop = 0.35;
+        pose.leftEyeOpenness = 0.22 + 0.08 * Math.sin(TAU * cyclePhase(time, 3));
+        pose.rightEyeOpenness = pose.leftEyeOpenness;
+        pose.eyeGlowOpacity = 0.5;
+        pose.mouthRound = 0.15;
+        pose.bodyTilt = 2.5 * Math.sin(TAU * cyclePhase(time, 6));
+        pose.effect = "zzz";
+        pose.effectPhase = cyclePhase(time, 3);
+        break;
+      case "attentive":
+        pose.floatOffset = -3 * (1 - Math.cos(TAU * cyclePhase(time, 4)));
+        pose.antennaDegrees = -2.5 * Math.sin(TAU * cyclePhase(time, 2));
+        pose.mouthCurve = 0.25;
+        break;
+    }
+    return pose;
+  }
+
+  private applyGaze(pose: MascotPose, mood: MascotMood, time: number, dt: number): void {
+    let target = this.gazeTarget;
+    switch (mood) {
+      case "thinking":
+        target = { x: 0.4 * Math.sin(TAU * cyclePhase(time, 3.8)), y: -0.55 };
+        break;
+      case "working":
+        target = {
+          x: 0.55 + 0.04 * Math.sin(TAU * cyclePhase(time, 4.6)),
+          y: 0.45 + 0.02 * Math.cos(TAU * cyclePhase(time, 3.9)),
+        };
+        break;
+      case "attentive":
+        target = { x: target.x * 0.5, y: 0.35 };
+        break;
+      case "sad":
+        target = { x: target.x * 0.3, y: 0.5 };
+        break;
+      case "sleepy":
+        target = { x: 0, y: 0.4 };
+        break;
+      case "idle":
+      case "curious":
+      case "happy":
+      case "celebrating":
+        break;
+    }
+    const blend = 1 - Math.exp(-dt * 9);
+    this.currentGaze.x += (target.x - this.currentGaze.x) * blend;
+    this.currentGaze.y += (target.y - this.currentGaze.y) * blend;
+    pose.gaze = { ...this.currentGaze };
+  }
+
+  private applyBlinks(pose: MascotPose, time: number): void {
+    if (pose.happyEyes >= 0.6) {
+      return;
+    }
+    for (const start of this.blinkStarts) {
+      const progress = (time - start) / BLINK_DURATION;
+      if (progress < 0 || progress > 1) {
+        continue;
+      }
+      const closure = bell(progress);
+      pose.leftEyeOpenness = Math.min(pose.leftEyeOpenness, 1 - closure);
+      pose.rightEyeOpenness = Math.min(pose.rightEyeOpenness, 1 - closure);
+      pose.eyeGlowOpacity *= Math.max(0.3, 1 - closure);
+    }
+  }
+
+  private applyGesture(gesture: Gesture, pose: MascotPose, progress: number): void {
+    const p = clamp(progress);
+    switch (gesture) {
+      case "wave": {
+        const raised = plateau(p, 0.18, 0.82);
+        pose.rightClawDegrees += raised * (-28 + 9 * Math.sin(p * 6 * Math.PI));
+        pose.bodyTilt += -2 * raised;
+        pose.mouthCurve = Math.max(pose.mouthCurve, 0.5 * raised);
+        break;
+      }
+      case "hop": {
+        const air = bell(clamp((p - 0.2) / 0.6));
+        pose.floatOffset += -9 * air;
+        pose.bodyStretch +=
+          0.045 * air - 0.1 * bell(clamp(p / 0.2)) - 0.06 * bell(clamp((p - 0.82) / 0.18));
+        pose.mouthCurve = Math.max(pose.mouthCurve, 0.4 * air);
+        break;
+      }
+      case "celebrate": {
+        const envelope = plateau(p, 0.12, 0.88);
+        const hops = Math.abs(Math.sin(p * 4 * Math.PI));
+        pose.floatOffset += -11 * hops * envelope;
+        pose.bodyStretch += 0.035 * hops * envelope;
+        pose.leftClawDegrees += 38 * envelope;
+        pose.rightClawDegrees += -38 * envelope;
+        pose.happyEyes = Math.max(pose.happyEyes, envelope);
+        pose.mouthCurve = Math.max(pose.mouthCurve, envelope);
+        pose.mouthOpen = Math.max(pose.mouthOpen, 0.6 * bell(p));
+        pose.antennaDroop = 0;
+        pose.glowScale = Math.max(pose.glowScale, 1 + 0.2 * envelope);
+        pose.effect = "sparkles";
+        pose.effectPhase = p;
+        break;
+      }
+      case "sigh": {
+        const rise = easeInOut(clamp(p / 0.3));
+        const fall = easeInOut(clamp((p - 0.3) / 0.45));
+        pose.bodyStretch += 0.025 * rise - 0.08 * fall * (1 - clamp((p - 0.85) / 0.15));
+        pose.gaze = { x: pose.gaze.x, y: 0.5 * fall };
+        pose.antennaDroop = Math.min(1, pose.antennaDroop + 0.15 * fall);
+        break;
+      }
+      case "yawn": {
+        const openness = plateau(p, 0.3, 0.75);
+        pose.mouthRound = Math.max(pose.mouthRound, 0.9 * openness);
+        pose.leftEyeOpenness = Math.min(pose.leftEyeOpenness, 1 - 0.9 * openness);
+        pose.rightEyeOpenness = Math.min(pose.rightEyeOpenness, 1 - 0.9 * openness);
+        pose.bodyStretch += 0.03 * openness;
+        pose.bodyTilt += -2 * openness;
+        break;
+      }
+      case "clawSnap":
+        pose.leftClawDegrees += -8 * bell(clamp(p / 0.7));
+        pose.rightClawDegrees += -8 * bell(clamp((p - 0.25) / 0.7));
+        break;
+      case "donHardHat": {
+        const drop = easeInOut(clamp(p / 0.55));
+        pose.hardHat = Math.min(pose.hardHat, drop);
+        if (p < 0.55) {
+          pose.gaze = { x: 0, y: -0.9 * (1 - p) };
+        }
+        pose.bodyStretch -= 0.04 * bell(clamp((p - 0.5) / 0.2));
+        const ready = bell(clamp((p - 0.7) / 0.3));
+        pose.leftClawDegrees += -8 * ready;
+        pose.rightClawDegrees += 8 * ready;
+        break;
+      }
+      case "wipeBrow": {
+        const envelope = plateau(p, 0.2, 0.8);
+        pose.leftClawDegrees *= 1 - envelope;
+        pose.rightClawDegrees *= 1 - envelope;
+        pose.leftClawDegrees += 38 * envelope * (0.9 + 0.1 * Math.sin(p * 5 * Math.PI));
+        pose.bodyTilt *= 1 - envelope;
+        pose.bodyStretch += 0.02 * envelope;
+        pose.happyEyes = Math.max(pose.happyEyes, 0.7 * envelope);
+        pose.mouthCurve = Math.max(pose.mouthCurve, 0.5 * envelope);
+        pose.gaze = { x: pose.gaze.x * (1 - envelope), y: pose.gaze.y * (1 - envelope) };
+        pose.effect = "sweat";
+        pose.effectPhase = p;
+        break;
+      }
+    }
+  }
+
+  private entranceGesture(mood: MascotMood): Gesture | null {
+    switch (mood) {
+      case "happy":
+        return "hop";
+      case "celebrating":
+        return "celebrate";
+      case "sad":
+        return "sigh";
+      case "sleepy":
+        return "yawn";
+      case "working":
+        return "donHardHat";
+      case "idle":
+      case "curious":
+      case "thinking":
+      case "attentive":
+        return null;
+    }
+    return null;
+  }
+
+  private startGesture(gesture: Gesture, time: number): void {
+    this.activeGesture = gesture;
+    this.activeGestureStart = time;
+  }
+
+  private random(min: number, max: number): number {
+    return min + (max - min) * this.rng.unit();
+  }
+
+  private blinkInterval(): number {
+    return this.currentMood === "attentive" ? this.random(1.8, 4) : this.random(2.2, 5.5);
+  }
+
+  private glanceInterval(): number {
+    if (this.currentMood === "curious") {
+      return this.random(1.6, 4);
+    }
+    if (this.currentMood === "thinking") {
+      return this.random(1.2, 3);
+    }
+    return this.random(3, 8);
+  }
+
+  private randomGlanceTarget(): { x: number; y: number } {
+    const magnitude = this.random(0.5, 1);
+    const angle = this.random(0, TAU);
+    return { x: Math.cos(angle) * magnitude, y: Math.sin(angle) * magnitude * 0.6 };
+  }
+
+  private rescheduleMoodBeat(time: number): void {
+    this.nextMoodBeatAt = time + this.random(6, 12);
+  }
+}

--- a/ui/src/components/mascot-canvas.ts
+++ b/ui/src/components/mascot-canvas.ts
@@ -1,0 +1,472 @@
+/* oxlint-disable unicorn/no-array-fill-with-reference-type -- CanvasRenderingContext2D.fill is not Array.fill. */
+// Canvas-only rendering for the canonical 120x120 Clawd vector.
+import type { MascotPalette, MascotPose } from "./mascot-pose.ts";
+
+const ART_SIZE = 120;
+const TAU = Math.PI * 2;
+const EYE = "#050810";
+const EYE_GLOW = "#00e5cc";
+const BLUSH = "#ff9eae";
+const HAT_AMBER = "#f2a833";
+const HAT_LIGHT = "#ffd659";
+const HAT_OUTLINE = "rgba(184, 115, 31, 0.7)";
+
+type Point = { x: number; y: number };
+type Bounds = { minX: number; minY: number; maxX: number; maxY: number };
+type Shape = { path: Path2D; bounds: Bounds };
+type MascotPaths = {
+  body: Shape;
+  leftClaw: Shape;
+  rightClaw: Shape;
+  leftAntenna: Path2D;
+  rightAntenna: Path2D;
+};
+
+let cachedPaths: MascotPaths | null = null;
+
+function mascotPaths(): MascotPaths {
+  if (cachedPaths) {
+    return cachedPaths;
+  }
+
+  const body = new Path2D();
+  body.moveTo(60, 10);
+  body.bezierCurveTo(30, 10, 15, 35, 15, 55);
+  body.bezierCurveTo(15, 75, 30, 95, 45, 100);
+  body.lineTo(45, 110);
+  body.lineTo(55, 110);
+  body.lineTo(55, 100);
+  body.bezierCurveTo(55, 100, 60, 102, 65, 100);
+  body.lineTo(65, 110);
+  body.lineTo(75, 110);
+  body.lineTo(75, 100);
+  body.bezierCurveTo(90, 95, 105, 75, 105, 55);
+  body.bezierCurveTo(105, 35, 90, 10, 60, 10);
+  body.closePath();
+
+  const leftClaw = new Path2D();
+  leftClaw.moveTo(20, 45);
+  leftClaw.bezierCurveTo(5, 40, 0, 50, 5, 60);
+  leftClaw.bezierCurveTo(10, 70, 20, 65, 25, 55);
+  leftClaw.bezierCurveTo(28, 48, 25, 45, 20, 45);
+  leftClaw.closePath();
+
+  const rightClaw = new Path2D();
+  rightClaw.moveTo(100, 45);
+  rightClaw.bezierCurveTo(115, 40, 120, 50, 115, 60);
+  rightClaw.bezierCurveTo(110, 70, 100, 65, 95, 55);
+  rightClaw.bezierCurveTo(92, 48, 95, 45, 100, 45);
+  rightClaw.closePath();
+
+  const leftAntenna = new Path2D();
+  leftAntenna.moveTo(45, 15);
+  leftAntenna.quadraticCurveTo(35, 5, 30, 8);
+
+  const rightAntenna = new Path2D();
+  rightAntenna.moveTo(75, 15);
+  rightAntenna.quadraticCurveTo(85, 5, 90, 8);
+
+  cachedPaths = {
+    body: { path: body, bounds: { minX: 15, minY: 10, maxX: 105, maxY: 110 } },
+    leftClaw: {
+      path: leftClaw,
+      bounds: {
+        minX: 3.125,
+        minY: 43.670_068_381_445_48,
+        maxX: 26.196_938_456_699_073,
+        maxY: 65.450_849_718_747_38,
+      },
+    },
+    rightClaw: {
+      path: rightClaw,
+      bounds: {
+        minX: 93.803_061_543_300_93,
+        minY: 43.670_068_381_445_48,
+        maxX: 116.875,
+        maxY: 65.450_849_718_747_38,
+      },
+    },
+    leftAntenna,
+    rightAntenna,
+  };
+  return cachedPaths;
+}
+
+function gradient(ctx: CanvasRenderingContext2D, shape: Shape, palette: MascotPalette) {
+  const { bounds } = shape;
+  const fill = ctx.createLinearGradient(bounds.minX, bounds.minY, bounds.maxX, bounds.maxY);
+  fill.addColorStop(0, palette.gradientTop);
+  fill.addColorStop(1, palette.gradientBottom);
+  return fill;
+}
+
+function radians(degrees: number): number {
+  return (degrees * Math.PI) / 180;
+}
+
+function easeInOut(value: number): number {
+  const t = clamp(value, 0, 1);
+  return t * t * (3 - 2 * t);
+}
+
+function bell(value: number): number {
+  const t = clamp(value, 0, 1);
+  return easeInOut(t < 0.5 ? t * 2 : (1 - t) * 2);
+}
+
+function rotated(
+  ctx: CanvasRenderingContext2D,
+  degrees: number,
+  pivot: Point,
+  draw: () => void,
+): void {
+  ctx.save();
+  ctx.translate(pivot.x, pivot.y);
+  ctx.rotate(radians(degrees));
+  ctx.translate(-pivot.x, -pivot.y);
+  draw();
+  ctx.restore();
+}
+
+function ellipsePath(center: Point, radiusX: number, radiusY: number): Path2D {
+  const path = new Path2D();
+  path.ellipse(center.x, center.y, radiusX, radiusY, 0, 0, TAU);
+  return path;
+}
+
+function roundedRectPath(x: number, y: number, width: number, height: number, radius: number) {
+  const path = new Path2D();
+  const right = x + width;
+  const bottom = y + height;
+  path.moveTo(x + radius, y);
+  path.lineTo(right - radius, y);
+  path.quadraticCurveTo(right, y, right, y + radius);
+  path.lineTo(right, bottom - radius);
+  path.quadraticCurveTo(right, bottom, right - radius, bottom);
+  path.lineTo(x + radius, bottom);
+  path.quadraticCurveTo(x, bottom, x, bottom - radius);
+  path.lineTo(x, y + radius);
+  path.quadraticCurveTo(x, y, x + radius, y);
+  path.closePath();
+  return path;
+}
+
+function drawEye(ctx: CanvasRenderingContext2D, center: Point, openness: number, pose: MascotPose) {
+  const shifted = {
+    x: center.x + pose.gaze.x * 2,
+    y: center.y + pose.gaze.y * 1.5,
+  };
+
+  if (pose.happyEyes < 1) {
+    const height = Math.max(1.2, 12 * openness * (1 - 0.6 * pose.happyEyes));
+    ctx.save();
+    ctx.globalAlpha *= 1 - pose.happyEyes;
+    ctx.fillStyle = EYE;
+    ctx.fill(
+      ellipsePath(
+        { x: shifted.x, y: shifted.y - 6 + (12 - height) * 0.65 + height / 2 },
+        6,
+        height / 2,
+      ),
+    );
+    ctx.restore();
+  }
+
+  if (pose.happyEyes > 0) {
+    const arc = new Path2D();
+    arc.moveTo(shifted.x - 6, shifted.y + 2);
+    arc.quadraticCurveTo(shifted.x, shifted.y - 5.5, shifted.x + 6, shifted.y + 2);
+    ctx.save();
+    ctx.globalAlpha *= pose.happyEyes;
+    ctx.strokeStyle = EYE;
+    ctx.lineWidth = 2.6;
+    ctx.lineCap = "round";
+    ctx.stroke(arc);
+    ctx.restore();
+  }
+
+  if (pose.dizzy > 0) {
+    const angle = pose.dizzyPhase * TAU + (center.x > 60 ? Math.PI : 0);
+    const dot = {
+      x: shifted.x + Math.cos(angle) * 3.4,
+      y: shifted.y + Math.sin(angle) * 2.6,
+    };
+    ctx.save();
+    ctx.globalAlpha *= pose.dizzy;
+    ctx.fillStyle = EYE_GLOW;
+    ctx.fill(ellipsePath(dot, 1.8, 1.8));
+    ctx.restore();
+  }
+
+  const glowVisibility = pose.eyeGlowOpacity * openness * (1 - pose.happyEyes) * (1 - pose.dizzy);
+  if (glowVisibility <= 0.01) {
+    return;
+  }
+  const glowRadius = 2 * pose.glowScale;
+  const glowCenter = {
+    x: shifted.x + 1 + pose.gaze.x * 1.2,
+    y: shifted.y - 1 + pose.gaze.y * 0.9,
+  };
+  ctx.save();
+  ctx.globalAlpha *= glowVisibility;
+  ctx.fillStyle = EYE_GLOW;
+  ctx.fill(ellipsePath(glowCenter, glowRadius, glowRadius));
+  ctx.restore();
+}
+
+function drawMouth(ctx: CanvasRenderingContext2D, pose: MascotPose): void {
+  ctx.fillStyle = EYE;
+  ctx.strokeStyle = EYE;
+  ctx.lineCap = "round";
+  if (pose.mouthRound > 0.05) {
+    const radiusX = 1 + 3.2 * pose.mouthRound;
+    const radiusY = 1 + 4.2 * pose.mouthRound;
+    ctx.fill(ellipsePath({ x: 60, y: 51 }, radiusX, radiusY));
+    return;
+  }
+  if (pose.mouthOpen > 0.05) {
+    const grin = new Path2D();
+    grin.moveTo(52.5, 48.5);
+    grin.quadraticCurveTo(60, 48.5 + 14 * pose.mouthOpen, 67.5, 48.5);
+    grin.closePath();
+    ctx.fill(grin);
+    return;
+  }
+  if (Math.abs(pose.mouthCurve) <= 0.05) {
+    return;
+  }
+  const curve = new Path2D();
+  curve.moveTo(52.5, 49);
+  curve.quadraticCurveTo(60, 49 + 8 * pose.mouthCurve, 67.5, 49);
+  ctx.lineWidth = 2.2;
+  ctx.stroke(curve);
+}
+
+function drawBlush(ctx: CanvasRenderingContext2D, pose: MascotPose): void {
+  if (pose.blush <= 0.02) {
+    return;
+  }
+  ctx.save();
+  ctx.globalAlpha *= pose.blush * 0.55;
+  ctx.fillStyle = BLUSH;
+  ctx.fill(ellipsePath({ x: 37, y: 45 }, 4.5, 2.5));
+  ctx.fill(ellipsePath({ x: 83, y: 45 }, 4.5, 2.5));
+  ctx.restore();
+}
+
+function drawHardHat(ctx: CanvasRenderingContext2D, amount: number): void {
+  if (amount <= 0.01) {
+    return;
+  }
+  const dome = new Path2D();
+  dome.moveTo(45, 15);
+  dome.bezierCurveTo(47, 7, 54, 3, 60, 3);
+  dome.bezierCurveTo(66, 3, 73, 7, 75, 15);
+  dome.lineTo(45, 15);
+  dome.closePath();
+  const brim = roundedRectPath(41, 14, 38, 5, 2);
+
+  ctx.save();
+  ctx.globalAlpha *= amount;
+  ctx.translate(60, 15 - 14 * (1 - amount));
+  ctx.rotate(radians(-5));
+  ctx.translate(-60, -15);
+  const fill = ctx.createLinearGradient(60, 3, 60, 16);
+  fill.addColorStop(0, HAT_LIGHT);
+  fill.addColorStop(1, HAT_AMBER);
+  ctx.fillStyle = fill;
+  ctx.fill(dome);
+  ctx.strokeStyle = HAT_OUTLINE;
+  ctx.lineWidth = 0.8;
+  ctx.stroke(dome);
+  ctx.fillStyle = HAT_AMBER;
+  ctx.fill(brim);
+  ctx.stroke(brim);
+  ctx.restore();
+}
+
+function sparklePath(center: Point, size: number): Path2D {
+  const path = new Path2D();
+  path.moveTo(center.x, center.y - size);
+  for (const [dx, dy] of [
+    [1, 0],
+    [0, 1],
+    [-1, 0],
+    [0, -1],
+  ] as const) {
+    path.quadraticCurveTo(center.x, center.y, center.x + size * dx, center.y + size * dy);
+  }
+  path.closePath();
+  return path;
+}
+
+function drawZ(ctx: CanvasRenderingContext2D, position: Point, size: number, alpha: number): void {
+  const path = new Path2D();
+  const width = size * 0.62;
+  const height = size * 0.78;
+  path.moveTo(position.x - width / 2, position.y - height / 2);
+  path.lineTo(position.x + width / 2, position.y - height / 2);
+  path.lineTo(position.x - width / 2, position.y + height / 2);
+  path.lineTo(position.x + width / 2, position.y + height / 2);
+  ctx.save();
+  ctx.globalAlpha *= alpha * 0.9;
+  ctx.strokeStyle = EYE_GLOW;
+  ctx.lineWidth = Math.max(1.2, size * 0.16);
+  ctx.lineCap = "round";
+  ctx.lineJoin = "round";
+  ctx.stroke(path);
+  ctx.restore();
+}
+
+function drawEffect(ctx: CanvasRenderingContext2D, pose: MascotPose, palette: MascotPalette): void {
+  switch (pose.effect) {
+    case "none":
+      return;
+    case "sparkles":
+      for (let index = 0; index < 6; index += 1) {
+        const phase = (pose.effectPhase + index * 0.37) % 1;
+        const alpha = bell(phase);
+        if (alpha <= 0.05) {
+          continue;
+        }
+        const angle = Math.PI + (Math.PI * (index + 0.5)) / 6;
+        const center = {
+          x: 60 + Math.cos(angle) * (50 + (index % 3) * 4),
+          y: 55 + Math.sin(angle) * (40 + ((index * 5) % 3) * 4),
+        };
+        ctx.save();
+        ctx.globalAlpha *= alpha;
+        ctx.fillStyle = index % 2 === 0 ? EYE_GLOW : palette.antenna;
+        ctx.fill(sparklePath(center, 2.5 + 2 * alpha));
+        ctx.restore();
+      }
+      return;
+    case "zzz":
+      for (let index = 0; index < 3; index += 1) {
+        const phase = (pose.effectPhase + index * 0.33) % 1;
+        const alpha = phase < 0.2 ? phase / 0.2 : 1 - (phase - 0.2) / 0.8;
+        if (alpha <= 0.05) {
+          continue;
+        }
+        drawZ(
+          ctx,
+          {
+            x: 86 + 14 * phase + 2 * Math.sin(phase * 4 * Math.PI),
+            y: 24 - 20 * phase,
+          },
+          6 + 4 * phase,
+          alpha,
+        );
+      }
+      return;
+    case "sparks":
+      for (let index = 0; index < 5; index += 1) {
+        const rawPhase = pose.effectPhase - index * 0.025;
+        if (rawPhase < 0 || rawPhase >= 0.45) {
+          continue;
+        }
+        const alpha = rawPhase < 0.08 ? rawPhase / 0.08 : 1 - (rawPhase - 0.08) / 0.37;
+        const angle = radians(-160 + index * 35);
+        const radius = 5 + (12 * rawPhase) / 0.45;
+        const particleSize = 2.2 + (index % 3) * 0.8;
+        const center = {
+          x: clamp(106 + Math.cos(angle) * radius, particleSize, ART_SIZE - particleSize),
+          y: clamp(66 + Math.sin(angle) * radius, particleSize, ART_SIZE - particleSize),
+        };
+        ctx.save();
+        ctx.globalAlpha *= alpha;
+        ctx.fillStyle = index % 2 === 0 ? EYE_GLOW : HAT_AMBER;
+        ctx.fill(sparklePath(center, particleSize));
+        ctx.restore();
+      }
+      return;
+    case "sweat": {
+      const alpha = bell(pose.effectPhase);
+      if (alpha <= 0.02) {
+        return;
+      }
+      const center = { x: 42, y: 24 + 7 * pose.effectPhase };
+      const drop = new Path2D();
+      drop.moveTo(center.x, center.y - 3);
+      drop.bezierCurveTo(
+        center.x - 4,
+        center.y + 1,
+        center.x - 2,
+        center.y + 3,
+        center.x,
+        center.y + 3,
+      );
+      drop.bezierCurveTo(
+        center.x + 2,
+        center.y + 3,
+        center.x + 4,
+        center.y + 1,
+        center.x,
+        center.y - 3,
+      );
+      ctx.save();
+      ctx.globalAlpha *= alpha;
+      ctx.fillStyle = "#80d4ff";
+      ctx.fill(drop);
+      ctx.restore();
+    }
+  }
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+/** Draw one pose. Whole-body float is applied by the host to avoid canvas clipping. */
+export function drawMascot(
+  pose: MascotPose,
+  palette: MascotPalette,
+  ctx: CanvasRenderingContext2D,
+  size: number,
+): void {
+  const paths = mascotPaths();
+  ctx.save();
+  ctx.scale(size / ART_SIZE, size / ART_SIZE);
+
+  if (pose.bodyStretch !== 1) {
+    const stretchX = clamp(1 + (1 - pose.bodyStretch) * 0.5, 0.97, 1.03);
+    ctx.translate(60, 110);
+    ctx.scale(stretchX, pose.bodyStretch);
+    ctx.translate(-60, -110);
+  }
+  if (pose.bodyTilt !== 0) {
+    ctx.translate(60, 60);
+    ctx.rotate(radians(pose.bodyTilt));
+    ctx.translate(-60, -60);
+  }
+
+  ctx.fillStyle = gradient(ctx, paths.body, palette);
+  ctx.fill(paths.body.path);
+  rotated(ctx, pose.leftClawDegrees, { x: 26, y: 53 }, () => {
+    ctx.fillStyle = gradient(ctx, paths.leftClaw, palette);
+    ctx.fill(paths.leftClaw.path);
+  });
+  rotated(ctx, pose.rightClawDegrees, { x: 94, y: 53 }, () => {
+    ctx.fillStyle = gradient(ctx, paths.rightClaw, palette);
+    ctx.fill(paths.rightClaw.path);
+  });
+
+  const wiggle = pose.antennaDegrees * (1 - pose.antennaDroop);
+  ctx.strokeStyle = palette.antenna;
+  ctx.lineWidth = 2;
+  ctx.lineCap = "round";
+  rotated(ctx, -pose.antennaDroop * 40, { x: 45, y: 15 }, () => {
+    rotated(ctx, wiggle, { x: 37.5, y: 11 }, () => ctx.stroke(paths.leftAntenna));
+  });
+  rotated(ctx, pose.antennaDroop * 40, { x: 75, y: 15 }, () => {
+    rotated(ctx, wiggle, { x: 82.5, y: 11 }, () => ctx.stroke(paths.rightAntenna));
+  });
+
+  drawHardHat(ctx, pose.hardHat);
+  drawBlush(ctx, pose);
+  drawEye(ctx, { x: 45, y: 35 }, pose.leftEyeOpenness, pose);
+  drawEye(ctx, { x: 75, y: 35 }, pose.rightEyeOpenness, pose);
+  drawMouth(ctx, pose);
+  drawEffect(ctx, pose, palette);
+  ctx.restore();
+}

--- a/ui/src/components/mascot-pose.ts
+++ b/ui/src/components/mascot-pose.ts
@@ -11,7 +11,7 @@ export type MascotMood =
   | "sleepy"
   | "attentive";
 
-export type MascotEffect = "none" | "sparkles" | "zzz" | "sparks" | "sweat";
+type MascotEffect = "none" | "sparkles" | "zzz" | "sparks" | "sweat";
 
 export type MascotPose = {
   floatOffset: number;

--- a/ui/src/components/mascot-pose.ts
+++ b/ui/src/components/mascot-pose.ts
@@ -1,0 +1,162 @@
+// Pure pose model shared by the mascot animator and canvas renderer.
+
+export type MascotMood =
+  | "idle"
+  | "curious"
+  | "thinking"
+  | "working"
+  | "happy"
+  | "celebrating"
+  | "sad"
+  | "sleepy"
+  | "attentive";
+
+export type MascotEffect = "none" | "sparkles" | "zzz" | "sparks" | "sweat";
+
+export type MascotPose = {
+  floatOffset: number;
+  antennaDegrees: number;
+  antennaDroop: number;
+  leftClawDegrees: number;
+  rightClawDegrees: number;
+  eyeGlowOpacity: number;
+  glowScale: number;
+  leftEyeOpenness: number;
+  rightEyeOpenness: number;
+  happyEyes: number;
+  gaze: { x: number; y: number };
+  mouthCurve: number;
+  mouthOpen: number;
+  mouthRound: number;
+  blush: number;
+  hardHat: number;
+  bodyTilt: number;
+  bodyStretch: number;
+  dizzy: number;
+  dizzyPhase: number;
+  effect: MascotEffect;
+  effectPhase: number;
+};
+
+export type MascotPalette = {
+  gradientTop: string;
+  gradientBottom: string;
+  antenna: string;
+};
+
+const DARK_PALETTE: MascotPalette = {
+  gradientTop: "#ff4d4d",
+  gradientBottom: "#991b1b",
+  antenna: "#ff4d4d",
+};
+
+const LIGHT_PALETTE: MascotPalette = {
+  gradientTop: "#ff7079",
+  gradientBottom: "#ea4c59",
+  antenna: "#ef4b58",
+};
+
+export function createMascotPose(): MascotPose {
+  return {
+    floatOffset: 0,
+    antennaDegrees: 0,
+    antennaDroop: 0,
+    leftClawDegrees: 0,
+    rightClawDegrees: 0,
+    eyeGlowOpacity: 1,
+    glowScale: 1,
+    leftEyeOpenness: 1,
+    rightEyeOpenness: 1,
+    happyEyes: 0,
+    gaze: { x: 0, y: 0 },
+    mouthCurve: 0,
+    mouthOpen: 0,
+    mouthRound: 0,
+    blush: 0,
+    hardHat: 0,
+    bodyTilt: 0,
+    bodyStretch: 1,
+    dizzy: 0,
+    dizzyPhase: 0,
+    effect: "none",
+    effectPhase: 0,
+  };
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+/** Keep every channel inside the drawable 120x120 art-space bounds. */
+export function clampMascotPose(pose: MascotPose): MascotPose {
+  pose.floatOffset = clamp(pose.floatOffset, -12, 2);
+  pose.antennaDegrees = clamp(pose.antennaDegrees, -14, 14);
+  pose.antennaDroop = clamp(pose.antennaDroop, 0, 1);
+  pose.leftClawDegrees = clamp(pose.leftClawDegrees, -45, 45);
+  pose.rightClawDegrees = clamp(pose.rightClawDegrees, -45, 45);
+  pose.eyeGlowOpacity = clamp(pose.eyeGlowOpacity, 0, 1);
+  pose.glowScale = clamp(pose.glowScale, 0.5, 1.6);
+  pose.leftEyeOpenness = clamp(pose.leftEyeOpenness, 0, 1);
+  pose.rightEyeOpenness = clamp(pose.rightEyeOpenness, 0, 1);
+  pose.happyEyes = clamp(pose.happyEyes, 0, 1);
+  pose.gaze.x = clamp(pose.gaze.x, -1.2, 1.2);
+  pose.gaze.y = clamp(pose.gaze.y, -1.2, 1.2);
+  pose.mouthCurve = clamp(pose.mouthCurve, -1, 1);
+  pose.mouthOpen = clamp(pose.mouthOpen, 0, 1);
+  pose.mouthRound = clamp(pose.mouthRound, 0, 1);
+  pose.blush = clamp(pose.blush, 0, 1);
+  pose.hardHat = clamp(pose.hardHat, 0, 1);
+  pose.bodyTilt = clamp(pose.bodyTilt, -8, 8);
+  pose.bodyStretch = clamp(pose.bodyStretch, 0.86, 1.05);
+  pose.dizzy = clamp(pose.dizzy, 0, 1);
+  return pose;
+}
+
+/** Motionless mood expression used when reduced motion is requested. */
+export function staticMascotPose(mood: MascotMood): MascotPose {
+  const pose = createMascotPose();
+  switch (mood) {
+    case "idle":
+    case "curious":
+    case "attentive":
+      break;
+    case "thinking":
+      pose.gaze = { x: 0.3, y: -0.5 };
+      break;
+    case "working":
+      pose.hardHat = 1;
+      pose.rightClawDegrees = -28;
+      pose.gaze = { x: 0.4, y: 0.35 };
+      pose.mouthCurve = 0.15;
+      pose.bodyTilt = 2;
+      break;
+    case "happy":
+      pose.mouthCurve = 0.6;
+      pose.happyEyes = 0.4;
+      break;
+    case "celebrating":
+      pose.mouthCurve = 0.9;
+      pose.mouthOpen = 0.4;
+      pose.happyEyes = 0.8;
+      pose.leftClawDegrees = 30;
+      pose.rightClawDegrees = -30;
+      break;
+    case "sad":
+      pose.antennaDroop = 0.75;
+      pose.mouthCurve = -0.55;
+      pose.eyeGlowOpacity = 0.6;
+      pose.gaze = { x: 0, y: 0.5 };
+      break;
+    case "sleepy":
+      pose.leftEyeOpenness = 0.25;
+      pose.rightEyeOpenness = 0.25;
+      pose.eyeGlowOpacity = 0.5;
+      pose.antennaDroop = 0.35;
+      break;
+  }
+  return pose;
+}
+
+export function mascotPalette(light: boolean): MascotPalette {
+  return light ? LIGHT_PALETTE : DARK_PALETTE;
+}

--- a/ui/src/components/openclaw-mascot.ts
+++ b/ui/src/components/openclaw-mascot.ts
@@ -1,0 +1,217 @@
+import { css, html, LitElement, type PropertyValues } from "lit";
+import { property } from "lit/decorators.js";
+import { MascotAnimator } from "./mascot-animator.ts";
+import { drawMascot } from "./mascot-canvas.ts";
+import {
+  mascotPalette,
+  staticMascotPose,
+  type MascotMood,
+  type MascotPose,
+} from "./mascot-pose.ts";
+
+const DEFAULT_SIZE = 120;
+const MASCOT_MOODS = new Set<MascotMood>([
+  "idle",
+  "curious",
+  "thinking",
+  "working",
+  "happy",
+  "celebrating",
+  "sad",
+  "sleepy",
+  "attentive",
+]);
+
+function currentSeconds(): number {
+  return performance.now() / 1_000;
+}
+
+class OpenClawMascot extends LitElement {
+  static override styles = css`
+    :host {
+      display: inline-block;
+      width: var(--openclaw-mascot-size, 120px);
+      height: var(--openclaw-mascot-size, 120px);
+      overflow: visible;
+      contain: layout style;
+      pointer-events: none;
+      line-height: 0;
+    }
+
+    canvas {
+      display: block;
+      width: 100%;
+      height: 100%;
+      will-change: transform;
+    }
+  `;
+
+  @property({ reflect: true }) mood: MascotMood = "idle";
+  @property({ type: Number }) size = DEFAULT_SIZE;
+
+  private readonly animator = new MascotAnimator();
+  private animationFrame = 0;
+  private visible = true;
+  private reducedMotion = false;
+  private lastPose: MascotPose = staticMascotPose("idle");
+  private intersectionObserver: IntersectionObserver | null = null;
+  private themeObserver: MutationObserver | null = null;
+  private motionQuery: MediaQueryList | null = null;
+
+  private readonly handleVisibilityChange = () => this.syncPlayback();
+
+  private readonly handleMotionChange = (event: MediaQueryListEvent) => {
+    this.reducedMotion = event.matches;
+    this.syncPlayback();
+  };
+
+  override connectedCallback(): void {
+    super.connectedCallback();
+    this.setAttribute("aria-hidden", "true");
+    document.addEventListener("visibilitychange", this.handleVisibilityChange);
+
+    this.motionQuery = window.matchMedia?.("(prefers-reduced-motion: reduce)") ?? null;
+    this.reducedMotion = this.motionQuery?.matches ?? false;
+    this.motionQuery?.addEventListener("change", this.handleMotionChange);
+
+    if (typeof IntersectionObserver !== "undefined") {
+      this.intersectionObserver = new IntersectionObserver((entries) => {
+        this.visible = entries.some((entry) => entry.isIntersecting);
+        this.syncPlayback();
+      });
+      this.intersectionObserver.observe(this);
+    }
+
+    if (typeof MutationObserver !== "undefined") {
+      this.themeObserver = new MutationObserver(() => this.drawPose(this.lastPose));
+      this.themeObserver.observe(document.documentElement, {
+        attributes: true,
+        attributeFilter: ["data-theme-mode"],
+      });
+    }
+  }
+
+  override disconnectedCallback(): void {
+    this.stopAnimation();
+    document.removeEventListener("visibilitychange", this.handleVisibilityChange);
+    this.motionQuery?.removeEventListener("change", this.handleMotionChange);
+    this.motionQuery = null;
+    this.intersectionObserver?.disconnect();
+    this.intersectionObserver = null;
+    this.themeObserver?.disconnect();
+    this.themeObserver = null;
+    super.disconnectedCallback();
+  }
+
+  protected override firstUpdated(): void {
+    this.drawCurrentFrame(currentSeconds());
+    this.syncPlayback();
+  }
+
+  protected override updated(changed: PropertyValues<this>): void {
+    if (changed.has("size")) {
+      this.style.setProperty("--openclaw-mascot-size", `${this.resolvedSize}px`);
+    }
+    if (changed.has("mood")) {
+      this.animator.setMood(this.resolvedMood, currentSeconds());
+    }
+    if (changed.has("size") || changed.has("mood")) {
+      this.drawCurrentFrame(currentSeconds());
+      this.syncPlayback();
+    }
+  }
+
+  override render() {
+    return html`<canvas></canvas>`;
+  }
+
+  private get resolvedMood(): MascotMood {
+    return MASCOT_MOODS.has(this.mood) ? this.mood : "idle";
+  }
+
+  private get resolvedSize(): number {
+    return Number.isFinite(this.size) && this.size > 0 ? this.size : DEFAULT_SIZE;
+  }
+
+  private get shouldAnimate(): boolean {
+    return (
+      this.isConnected &&
+      this.visible &&
+      !this.reducedMotion &&
+      document.visibilityState !== "hidden"
+    );
+  }
+
+  private readonly renderAnimationFrame = (timestamp: number) => {
+    this.animationFrame = 0;
+    if (!this.shouldAnimate) {
+      return;
+    }
+    this.drawCurrentFrame(timestamp / 1_000);
+    this.animationFrame = window.requestAnimationFrame(this.renderAnimationFrame);
+  };
+
+  private syncPlayback(): void {
+    if (!this.renderRoot.querySelector("canvas")) {
+      return;
+    }
+    if (this.reducedMotion) {
+      this.stopAnimation();
+      this.lastPose = staticMascotPose(this.resolvedMood);
+      this.drawPose(this.lastPose);
+      return;
+    }
+    if (!this.shouldAnimate) {
+      this.stopAnimation();
+      return;
+    }
+    if (this.animationFrame === 0) {
+      this.animationFrame = window.requestAnimationFrame(this.renderAnimationFrame);
+    }
+  }
+
+  private stopAnimation(): void {
+    if (this.animationFrame !== 0) {
+      window.cancelAnimationFrame(this.animationFrame);
+      this.animationFrame = 0;
+    }
+  }
+
+  private drawCurrentFrame(time: number): void {
+    this.lastPose = this.reducedMotion
+      ? staticMascotPose(this.resolvedMood)
+      : this.animator.poseAt(time);
+    this.drawPose(this.lastPose);
+  }
+
+  private drawPose(pose: MascotPose): void {
+    const canvas = this.renderRoot.querySelector("canvas");
+    if (!(canvas instanceof HTMLCanvasElement) || typeof Path2D === "undefined") {
+      return;
+    }
+    const context = canvas.getContext("2d");
+    if (!context) {
+      return;
+    }
+    const size = this.resolvedSize;
+    const pixelRatio = Math.max(1, window.devicePixelRatio || 1);
+    const pixelSize = Math.round(size * pixelRatio);
+    if (canvas.width !== pixelSize || canvas.height !== pixelSize) {
+      canvas.width = pixelSize;
+      canvas.height = pixelSize;
+    }
+    context.setTransform(pixelRatio, 0, 0, pixelRatio, 0, 0);
+    context.clearRect(0, 0, size, size);
+    drawMascot(
+      pose,
+      mascotPalette(document.documentElement.dataset.themeMode === "light"),
+      context,
+      size,
+    );
+    canvas.style.transform = `translate3d(0, ${(pose.floatOffset * size) / 120}px, 0)`;
+  }
+}
+
+if (!customElements.get("openclaw-mascot")) {
+  customElements.define("openclaw-mascot", OpenClawMascot);
+}

--- a/ui/src/components/openclaw-mascot.ts
+++ b/ui/src/components/openclaw-mascot.ts
@@ -104,6 +104,9 @@ class OpenClawMascot extends LitElement {
   }
 
   protected override firstUpdated(): void {
+    // Seed the animator's mood before the first pose so `begin()` schedules
+    // for the real mood; `updated()` runs after this and would be too late.
+    this.animator.setMood(this.resolvedMood, currentSeconds());
     this.drawCurrentFrame(currentSeconds());
     this.syncPlayback();
   }

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -3933,7 +3933,7 @@ describe("chat welcome", () => {
 
     const clawd = container.querySelector(".agent-chat__welcome-clawd");
     expect(clawd).not.toBeNull();
-    expect(clawd?.querySelector(".lobster-pet__svg")).not.toBeNull();
+    expect(clawd?.querySelector("openclaw-mascot")?.getAttribute("mood")).toBe("idle");
     expect(container.querySelector(".agent-chat__badge")).toBeNull();
   });
 

--- a/ui/src/pages/chat/components/chat-welcome.ts
+++ b/ui/src/pages/chat/components/chat-welcome.ts
@@ -1,12 +1,7 @@
 // Control UI chat module implements chat welcome behavior.
-import { expectDefined } from "@openclaw/normalization-core";
 import { html, nothing } from "lit";
 import type { GatewaySessionRow, SessionsListResult } from "../../../api/types.ts";
-import {
-  canonicalLobsterLook,
-  LOBSTER_PET_PALETTES,
-  renderLobsterSvg,
-} from "../../../components/lobster-pet.ts";
+import "../../../components/openclaw-mascot.ts";
 import { t } from "../../../i18n/index.ts";
 import { resolveAssistantTextAvatar, resolveChatAvatarRenderUrl } from "../../../lib/avatar.ts";
 import { formatRelativeTimestamp } from "../../../lib/format.ts";
@@ -96,20 +91,10 @@ function selectWelcomeRecentSessions(
   );
 }
 
-// The default Clawd mascot: same species as the sidebar lobster pet, rendered
-// big and borderless with its own gentle idle loop (see layout.css).
 function renderWelcomeClawd() {
-  const palette =
-    LOBSTER_PET_PALETTES.find((entry) => entry.id === "crimson") ??
-    expectDefined(LOBSTER_PET_PALETTES[0], "welcome lobster palette");
-  const look = canonicalLobsterLook(palette);
   return html`
-    <div
-      class="agent-chat__welcome-clawd"
-      style=${`--lob-shell:${look.palette.shell};--lob-claw:${look.palette.claw}`}
-      aria-hidden="true"
-    >
-      ${renderLobsterSvg(look)}
+    <div class="agent-chat__welcome-clawd" aria-hidden="true">
+      <openclaw-mascot mood="idle" .size=${112}></openclaw-mascot>
     </div>
   `;
 }

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -3933,54 +3933,14 @@ openclaw-chat-pane:has(> .chat-pane__header) .chat-thread {
   object-fit: cover;
 }
 
-/* The hero Clawd: the lobster-pet sprite, big and borderless. Idle loop
-   (breathe/blink keyframes) lives in lobster-pet.css; only the periodic
-   wave is welcome-specific. */
+/* The 120x120 Clawd canvas stays centered in the existing hero slot. */
 .agent-chat__welcome-clawd {
   width: 128px;
   height: 112px;
   margin-bottom: 2px;
-}
-
-.agent-chat__welcome-clawd .lobster-pet__svg {
-  animation: lobster-pet-breathe 3.4s ease-in-out infinite;
-}
-
-.agent-chat__welcome-clawd .lob-eye-open {
-  animation: lobster-pet-blink-open 5.2s linear infinite;
-}
-
-.agent-chat__welcome-clawd .lob-eye-closed {
-  opacity: 0;
-  animation: lobster-pet-blink-closed 5.2s linear infinite;
-}
-
-.agent-chat__welcome-clawd .lob-claw--r {
-  animation: agent-chat-welcome-wave 9s ease-in-out infinite;
-}
-
-@keyframes agent-chat-welcome-wave {
-  0%,
-  82%,
-  100% {
-    transform: translateY(0) rotate(0deg);
-  }
-  86%,
-  94% {
-    transform: translateY(-6px) rotate(-30deg);
-  }
-  90% {
-    transform: translateY(-6px) rotate(-6deg);
-  }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .agent-chat__welcome-clawd .lobster-pet__svg,
-  .agent-chat__welcome-clawd .lob-eye-open,
-  .agent-chat__welcome-clawd .lob-eye-closed,
-  .agent-chat__welcome-clawd .lob-claw--r {
-    animation: none;
-  }
+  display: grid;
+  place-items: center;
+  overflow: visible;
 }
 
 /* Phones (and short landscape): scale the welcome hero down so the composer
@@ -4003,6 +3963,10 @@ openclaw-chat-pane:has(> .chat-pane__header) .chat-thread {
   .agent-chat__welcome-clawd {
     width: 88px;
     height: 77px;
+  }
+
+  .agent-chat__welcome-clawd openclaw-mascot {
+    transform: scale(0.6875);
   }
 
   .agent-chat__welcome .agent-chat__avatar--text {


### PR DESCRIPTION
## What Problem This Solves

The Control UI's brand presence is a static sprite: the new-session welcome hero shows a fixed lobster image while the native apps ship a fully animated vector mascot (moods, gestures, blinks, effects). The web surface had no way to reuse any of it — no component, no pose model, no animation loop.

## Why This Change Was Made

Ports the native mascot to the web as a reusable, canvas-backed `<openclaw-mascot>` Lit component, architected exactly like the Swift original so the two stay in sync:

- `mascot-pose.ts` — pure pose model: channels (float, antennae, claws, eyes, gaze, mouth, blush, hard hat, tilt, stretch, effects), clamping, per-mood static poses, light/dark palettes.
- `mascot-animator.ts` — deterministic seeded xorshift64* RNG, per-mood base loops (idle/curious/thinking/working/happy/celebrating/sad/sleepy/attentive), randomized blinks and glances, entrance gestures (hop, celebrate, hard-hat don, yawn), the working mood's hammer cycle with impact sparks and periodic brow-wipe beat.
- `mascot-canvas.ts` — exact 120×120 vector geometry from the canonical favicon paths, per-shape gradients, face, hard hat, sparkle/spark/sweat/zzz effects (Path2D, no fonts).
- `openclaw-mascot.ts` — Lit lifecycle: DPR-aware canvas, rAF loop paused when hidden (IntersectionObserver + visibilitychange), theme-reactive palette (`data-theme-mode` observer), `prefers-reduced-motion` static pose, `aria-hidden` decorative.

First consumer: the new-session welcome hero swaps its static lobster sprite for the living mascot (`mood="idle"`), same slot and sizing; the sidebar lobster pet is untouched. A follow-up will wire more surfaces (empty states, working states), which is also why the mood set ships complete.

The review pass caught a real lifecycle bug — Lit's `firstUpdated` ran before the first `updated()`, so the animator began as idle and could leak its queued hello-wave into a later mood — fixed by seeding the mood before the first pose and cancelling stale gestures on every mood change (regression-tested).

## User Impact

The web app's start screen now greets you with the same living Clawd as the Mac app: it floats, blinks, glances around, occasionally waves — and honors Reduce Motion with a calm static pose. No new strings, no i18n changes, no behavior changes beyond the hero visual.

| Welcome hero (dark) | Working mood (hat + sparks) | Light theme |
| --- | --- | --- |
| ![idle dark](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/web-mascot-port/web-welcome-idle-dark.png) | ![working dark](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/web-mascot-port/web-welcome-working-dark.png) | ![idle light](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/web-mascot-port/web-welcome-idle-light.png) |

## Evidence

- `node scripts/run-vitest.mjs ui/src/components/mascot-animator.test.ts` — 6/6 pass (30s bounds sweep across all moods, seed determinism, working hammer/hat/sparks/sweat cycle, sleepy zzz, static-pose signatures, stale-gesture cancellation regression).
- `pnpm ui:i18n:verify` — clean (no copy changes); targeted oxfmt/oxlint clean; remote `tsgo:ui` + `tsgo:test:ui` passed (exit 0); `git diff --check` clean.
- Live verification in the mock-dev harness (Playwright + in-app browser): idle hero, hard-hat working mood with impact sparks, light palette, and the hat-drop entrance (eyes track the falling hat) — screenshots above are from the running app.
- Autoreview (Codex, gpt-5.6-sol, xhigh): first pass surfaced the gesture-leak bug (fixed + regression test); rerun in flight at push time.
