### PR TITLE
fix(e2e): bound ClickClack fixture plugin fetch requests

### DIFF
--- a/scripts/e2e/lib/release-user-journey/write-clickclack-plugin.mjs
+++ b/scripts/e2e/lib/release-user-journey/write-clickclack-plugin.mjs
@@ -103,6 +103,7 @@ async function requestJson(account, method, pathname, body) {
       ...(body == null ? {} : { "content-type": "application/json" }),
     },
     ...(body == null ? {} : { body: JSON.stringify(body) }),
+    signal: AbortSignal.timeout(30_000),
   });
   if (!response.ok) {
     throw new Error(\`ClickClack fixture \${response.status}: \${await response.text()}\`);

--- a/test/scripts/e2e-helper-env-limits.test.ts
+++ b/test/scripts/e2e-helper-env-limits.test.ts
@@ -10,6 +10,8 @@ import { createBoundedChildOutput } from "../helpers/bounded-child-output.js";
 
 const browserFixturePath = "scripts/e2e/lib/browser-cdp-snapshot/fixture-server.mjs";
 const clickclackFixturePath = "scripts/e2e/lib/release-user-journey/clickclack-fixture.mjs";
+const clickclackPluginWritePath =
+  "scripts/e2e/lib/release-user-journey/write-clickclack-plugin.mjs";
 const httpProbePath = "scripts/e2e/lib/openwebui/http-probe.mjs";
 
 function runScript(scriptPath: string, args: string[] = [], env: Record<string, string> = {}) {
@@ -264,5 +266,17 @@ describe("e2e helper numeric env limits", () => {
         url: "http://127.0.0.1/probe",
       }),
     ).resolves.toBe(true);
+  });
+
+  it("generates ClickClack plugin code with fetch timeout", () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-clickclack-plugin-"));
+    try {
+      const result = runScript(clickclackPluginWritePath, [tempDir]);
+      expect(result.status).toBe(0);
+      const generated = fs.readFileSync(path.join(tempDir, "index.mjs"), "utf8");
+      expect(generated).toContain("AbortSignal.timeout(30_000)");
+    } finally {
+      fs.rmSync(tempDir, { force: true, recursive: true });
+    }
   });
 });

--- a/test/scripts/e2e-helper-env-limits.test.ts
+++ b/test/scripts/e2e-helper-env-limits.test.ts
@@ -4,8 +4,9 @@ import fs from "node:fs";
 import { createServer, type Server } from "node:http";
 import os from "node:os";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coercion";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { createBoundedChildOutput } from "../helpers/bounded-child-output.js";
 
 const browserFixturePath = "scripts/e2e/lib/browser-cdp-snapshot/fixture-server.mjs";
@@ -13,6 +14,16 @@ const clickclackFixturePath = "scripts/e2e/lib/release-user-journey/clickclack-f
 const clickclackPluginWritePath =
   "scripts/e2e/lib/release-user-journey/write-clickclack-plugin.mjs";
 const httpProbePath = "scripts/e2e/lib/openwebui/http-probe.mjs";
+
+type ClickClackFixturePlugin = {
+  outbound: {
+    sendText(ctx: {
+      cfg: { channels: { clickclack: { baseUrl: string; token: string } } };
+      text: string;
+      to: string;
+    }): Promise<unknown>;
+  };
+};
 
 function runScript(scriptPath: string, args: string[] = [], env: Record<string, string> = {}) {
   return spawnSync(process.execPath, [scriptPath, ...args], {
@@ -268,14 +279,56 @@ describe("e2e helper numeric env limits", () => {
     ).resolves.toBe(true);
   });
 
-  it("generates ClickClack plugin code with fetch timeout", () => {
+  it("bounds generated ClickClack plugin response bodies", async () => {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-clickclack-plugin-"));
+    let headersSentResolve: (() => void) | undefined;
+    const headersSent = new Promise<void>((resolve) => {
+      headersSentResolve = resolve;
+    });
+    const server = createServer((_request, response) => {
+      response.writeHead(200, { "content-type": "application/json" });
+      response.flushHeaders();
+      headersSentResolve?.();
+    });
+    const baseUrl = await listen(server);
+    const realTimeout = AbortSignal.timeout;
+    const timeoutSpy = vi.spyOn(AbortSignal, "timeout").mockImplementation(() => realTimeout(200));
     try {
       const result = runScript(clickclackPluginWritePath, [tempDir]);
       expect(result.status).toBe(0);
-      const generated = fs.readFileSync(path.join(tempDir, "index.mjs"), "utf8");
-      expect(generated).toContain("AbortSignal.timeout(30_000)");
+      const generated = (await import(pathToFileURL(path.join(tempDir, "index.mjs")).href)) as {
+        default: {
+          register(api: {
+            registerChannel(entry: { plugin: ClickClackFixturePlugin }): void;
+          }): void;
+        };
+      };
+      let plugin: ClickClackFixturePlugin | undefined;
+      generated.default.register({
+        registerChannel: ({ plugin: registeredPlugin }) => {
+          plugin = registeredPlugin;
+        },
+      });
+      if (!plugin) {
+        throw new Error("generated ClickClack plugin did not register a channel");
+      }
+
+      const startedAt = Date.now();
+      const request = plugin.outbound.sendText({
+        cfg: { channels: { clickclack: { baseUrl, token: "x" } } },
+        text: "hello",
+        to: "channel:general",
+      });
+      const rejection = expect(request).rejects.toMatchObject({ name: "TimeoutError" });
+      await headersSent;
+      await rejection;
+
+      expect(timeoutSpy).toHaveBeenCalledWith(30_000);
+      expect(Date.now() - startedAt).toBeLessThan(2_000);
     } finally {
+      timeoutSpy.mockRestore();
+      server.closeAllConnections();
+      await new Promise<void>((resolve) => server.close(() => resolve()));
       fs.rmSync(tempDir, { force: true, recursive: true });
     }
   });


### PR DESCRIPTION
## Summary

Bound every generated ClickClack fixture HTTP request with a 30-second abort deadline. Replace source-text inspection with a real regression: the generated plugin receives response headers from a loopback server, then the body stalls until the deadline aborts consumption.

## What Problem This Solves

The release-user-journey ClickClack plugin previously called `fetch()` without a signal. A peer that accepted the connection, sent headers, and then stopped sending the JSON body could leave workspace discovery, channel discovery, outbound delivery, thread replies, or inbound event resolution waiting indefinitely.

## Root Cause

All ClickClack JSON operations share `requestJson()`, but that owner had no per-request deadline. Outer CLI timeouts are too broad and do not cover Gateway-owned requests.

## Why This Fix

`requestJson()` is the canonical owner for all affected calls. Passing `AbortSignal.timeout(30_000)` to its existing `fetch()` keeps one policy and applies the same signal while success and error bodies are consumed. No config, dependency, compatibility path, or fallback is added.

## User Impact

Release validation now fails a stalled ClickClack fixture request after 30 seconds instead of waiting for the surrounding lane deadline.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/e2e-helper-env-limits.test.ts` — 10 passed. The regression generates and registers the actual plugin, starts a loopback server that flushes JSON headers and never completes the body, invokes outbound delivery, and observes a timeout rejection. The test accelerates the real signal while asserting the generated plugin requested the production 30,000 ms deadline.
- `node scripts/check-changed.mjs -- scripts/e2e/lib/release-user-journey/write-clickclack-plugin.mjs test/scripts/e2e-helper-env-limits.test.ts` — passed through AWS Crabbox run `run_1f0471afabf1` (`cbx_2c54c1a06fa6`): formatting, test-root types, tooling lint, and guards green.
- `git diff --check` — passed.
- Autoreview — clean for the uncommitted test repair and the complete branch; no accepted/actionable findings.

## Best-Fix Review

The shared request helper is the narrowest correct owner. Per-caller timers duplicate policy; an outer process deadline is too coarse. Existing release-user-journey paths continue to prove normal ClickClack requests.

Authored by @zenglingbiao; maintainer test repair preserves contributor credit for squash merge.
