### PR TITLE
fix(acp): show durable notice after gateway disconnect

### DIFF
--- a/src/acp/translator.event-ledger.test.ts
+++ b/src/acp/translator.event-ledger.test.ts
@@ -115,6 +115,15 @@ describe("ACP translator event ledger replay", () => {
 
     const promptPromise = firstAgent.prompt(createPromptRequest(created.sessionId, "Question"));
     await waitForChatSend(firstRequestMock);
+    await vi.waitFor(async () => {
+      const replay = await eventLedger.readReplay({
+        sessionId: created.sessionId,
+        sessionKey: firstSession.sessionKey,
+      });
+      expect(
+        replay.events.some((event) => event.update.sessionUpdate === "user_message_chunk"),
+      ).toBe(true);
+    });
     const runId = firstSessionStore.getSession(created.sessionId)?.activeRunId;
     if (!runId) {
       throw new Error("Expected active ACP run");

--- a/src/acp/translator.session-updates.test.ts
+++ b/src/acp/translator.session-updates.test.ts
@@ -34,7 +34,7 @@ const update: SessionUpdate = {
   availableCommands: [],
 };
 
-describe("AcpTranslatorSessionUpdates shutdown", () => {
+describe("AcpTranslatorSessionUpdates", () => {
   it("blocks ledger reads and writes after shutdown starts", async () => {
     const ledger = createLedger();
     const sessionUpdate = vi.fn(async () => {});
@@ -100,5 +100,57 @@ describe("AcpTranslatorSessionUpdates shutdown", () => {
     await emitPromise;
 
     expect(ledger.recordUpdate).not.toHaveBeenCalled();
+  });
+
+  it("preserves ledger order without waiting for ACP delivery", async () => {
+    let releaseFirstDelivery!: () => void;
+    const firstDelivery = new Promise<void>((resolve) => {
+      releaseFirstDelivery = resolve;
+    });
+    let deliveryCount = 0;
+    const ledger = createLedger();
+    const updates = createUpdates({
+      ledger,
+      sessionUpdate: vi.fn(async () => {
+        deliveryCount += 1;
+        if (deliveryCount === 1) {
+          await firstDelivery;
+        }
+      }),
+    });
+    const firstUpdate: SessionUpdate = {
+      sessionUpdate: "agent_message_chunk",
+      content: { type: "text", text: "first" },
+    };
+    const interruptionUpdate: SessionUpdate = {
+      sessionUpdate: "agent_message_chunk",
+      content: { type: "text", text: "interrupted" },
+    };
+
+    const firstEmit = updates.emit({
+      sessionId: "session-1",
+      sessionKey: "agent:main:session-1",
+      record: true,
+      update: firstUpdate,
+    });
+    await vi.waitFor(() => {
+      expect(ledger.recordUpdate).toHaveBeenCalledTimes(1);
+    });
+
+    await updates.emit({
+      sessionId: "session-1",
+      sessionKey: "agent:main:session-1",
+      record: true,
+      waitForDelivery: false,
+      update: interruptionUpdate,
+    });
+
+    expect(vi.mocked(ledger.recordUpdate).mock.calls.map(([params]) => params.update)).toEqual([
+      firstUpdate,
+      interruptionUpdate,
+    ]);
+    await expect(Promise.race([firstEmit, Promise.resolve("pending")])).resolves.toBe("pending");
+    releaseFirstDelivery();
+    await firstEmit;
   });
 });

--- a/src/acp/translator.session-updates.test.ts
+++ b/src/acp/translator.session-updates.test.ts
@@ -153,4 +153,56 @@ describe("AcpTranslatorSessionUpdates", () => {
     releaseFirstDelivery();
     await firstEmit;
   });
+
+  it("does not let a stalled ledger session block another session", async () => {
+    let releaseFirstWrite!: () => void;
+    const firstWrite = new Promise<void>((resolve) => {
+      releaseFirstWrite = resolve;
+    });
+    const ledger = createLedger();
+    vi.mocked(ledger.recordUpdate).mockImplementation(async ({ sessionId }) => {
+      if (sessionId === "session-1") {
+        await firstWrite;
+      }
+    });
+    const updates = createUpdates({ ledger });
+
+    const stalledEmit = updates.emit({
+      sessionId: "session-1",
+      sessionKey: "agent:main:session-1",
+      record: true,
+      waitForDelivery: false,
+      update,
+    });
+    await vi.waitFor(() => {
+      expect(ledger.recordUpdate).toHaveBeenCalledTimes(1);
+    });
+
+    const queuedSameSessionEmit = updates.emit({
+      sessionId: "session-1",
+      sessionKey: "agent:main:session-1",
+      record: true,
+      waitForDelivery: false,
+      update,
+    });
+    await updates.emit({
+      sessionId: "session-2",
+      sessionKey: "agent:main:session-2",
+      record: true,
+      waitForDelivery: false,
+      update,
+    });
+
+    expect(vi.mocked(ledger.recordUpdate).mock.calls.map(([params]) => params.sessionId)).toEqual([
+      "session-1",
+      "session-2",
+    ]);
+    releaseFirstWrite();
+    await Promise.all([stalledEmit, queuedSameSessionEmit]);
+    expect(vi.mocked(ledger.recordUpdate).mock.calls.map(([params]) => params.sessionId)).toEqual([
+      "session-1",
+      "session-2",
+      "session-1",
+    ]);
+  });
 });

--- a/src/acp/translator.session-updates.ts
+++ b/src/acp/translator.session-updates.ts
@@ -33,6 +33,9 @@ function resolveLedgerSessionId(session: { sessionId: string; ledgerSessionId?: 
 /** Helper that keeps ACP client updates and replay ledger writes in sync. */
 export class AcpTranslatorSessionUpdates {
   private stopped = false;
+  // Queue ledger mutations at emission time so a detached disconnect notice
+  // cannot overtake an older update whose ACP delivery is backpressured.
+  private ledgerMutationTail: Promise<void> = Promise.resolve();
 
   constructor(private options: AcpTranslatorSessionUpdatesOptions) {}
 
@@ -108,22 +111,24 @@ export class AcpTranslatorSessionUpdates {
     runId: string,
     prompt: PromptRequest["prompt"],
   ): Promise<void> {
-    if (this.stopped) {
-      return;
-    }
-    try {
-      await this.options.eventLedger.recordUserPrompt({
-        sessionId: resolveLedgerSessionId(session),
-        sessionKey: session.sessionKey,
-        runId,
-        prompt,
-      });
-    } catch (err) {
-      this.options.log(
-        `event ledger prompt record failed for ${session.sessionId}: ${String(err)}`,
-      );
-      await this.markLedgerIncomplete(session);
-    }
+    await this.enqueueLedgerMutation(async () => {
+      if (this.stopped) {
+        return;
+      }
+      try {
+        await this.options.eventLedger.recordUserPrompt({
+          sessionId: resolveLedgerSessionId(session),
+          sessionKey: session.sessionKey,
+          runId,
+          prompt,
+        });
+      } catch (err) {
+        this.options.log(
+          `event ledger prompt record failed for ${session.sessionId}: ${String(err)}`,
+        );
+        await this.markLedgerIncomplete(session);
+      }
+    });
   }
 
   async emit(params: {
@@ -142,6 +147,16 @@ export class AcpTranslatorSessionUpdates {
       sessionId: params.sessionId,
       update: params.update,
     });
+    const recording =
+      params.record && params.sessionKey
+        ? this.recordLedgerUpdate({
+            sessionId: params.sessionId,
+            sessionKey: params.sessionKey,
+            ...(params.ledgerSessionId ? { ledgerSessionId: params.ledgerSessionId } : {}),
+            ...(params.runId ? { runId: params.runId } : {}),
+            update: params.update,
+          })
+        : undefined;
     if (params.waitForDelivery === false) {
       void delivery.catch((err: unknown) => {
         this.options.log(`session update delivery failed for ${params.sessionId}: ${String(err)}`);
@@ -149,15 +164,7 @@ export class AcpTranslatorSessionUpdates {
     } else {
       await delivery;
     }
-    if (params.record && params.sessionKey) {
-      await this.recordLedgerUpdate({
-        sessionId: params.sessionId,
-        sessionKey: params.sessionKey,
-        ...(params.ledgerSessionId ? { ledgerSessionId: params.ledgerSessionId } : {}),
-        ...(params.runId ? { runId: params.runId } : {}),
-        update: params.update,
-      });
-    }
+    await recording;
   }
 
   async sendAvailableCommands(
@@ -183,24 +190,34 @@ export class AcpTranslatorSessionUpdates {
     runId?: string;
     update: SessionUpdate;
   }): Promise<void> {
-    if (this.stopped) {
-      return;
-    }
-    try {
-      await this.options.eventLedger.recordUpdate({
-        sessionId: params.ledgerSessionId ?? params.sessionId,
-        sessionKey: params.sessionKey,
-        ...(params.runId ? { runId: params.runId } : {}),
-        update: params.update,
-      });
-    } catch (err) {
-      this.options.log(`event ledger update record failed for ${params.sessionId}: ${String(err)}`);
-      await this.markLedgerIncomplete({
-        sessionId: params.sessionId,
-        sessionKey: params.sessionKey,
-        ...(params.ledgerSessionId ? { ledgerSessionId: params.ledgerSessionId } : {}),
-      });
-    }
+    await this.enqueueLedgerMutation(async () => {
+      if (this.stopped) {
+        return;
+      }
+      try {
+        await this.options.eventLedger.recordUpdate({
+          sessionId: params.ledgerSessionId ?? params.sessionId,
+          sessionKey: params.sessionKey,
+          ...(params.runId ? { runId: params.runId } : {}),
+          update: params.update,
+        });
+      } catch (err) {
+        this.options.log(
+          `event ledger update record failed for ${params.sessionId}: ${String(err)}`,
+        );
+        await this.markLedgerIncomplete({
+          sessionId: params.sessionId,
+          sessionKey: params.sessionKey,
+          ...(params.ledgerSessionId ? { ledgerSessionId: params.ledgerSessionId } : {}),
+        });
+      }
+    });
+  }
+
+  private enqueueLedgerMutation(mutation: () => Promise<void>): Promise<void> {
+    const pending = this.ledgerMutationTail.then(mutation, mutation);
+    this.ledgerMutationTail = pending.catch(() => {});
+    return pending;
   }
 
   private async markLedgerIncomplete(session: AcpTranslatorSessionRef): Promise<void> {

--- a/src/acp/translator.session-updates.ts
+++ b/src/acp/translator.session-updates.ts
@@ -133,14 +133,22 @@ export class AcpTranslatorSessionUpdates {
     runId?: string;
     update: SessionUpdate;
     record?: boolean;
+    waitForDelivery?: boolean;
   }): Promise<void> {
     if (this.stopped) {
       return;
     }
-    await this.options.connection.sessionUpdate({
+    const delivery = this.options.connection.sessionUpdate({
       sessionId: params.sessionId,
       update: params.update,
     });
+    if (params.waitForDelivery === false) {
+      void delivery.catch((err: unknown) => {
+        this.options.log(`session update delivery failed for ${params.sessionId}: ${String(err)}`);
+      });
+    } else {
+      await delivery;
+    }
     if (params.record && params.sessionKey) {
       await this.recordLedgerUpdate({
         sessionId: params.sessionId,

--- a/src/acp/translator.session-updates.ts
+++ b/src/acp/translator.session-updates.ts
@@ -33,9 +33,9 @@ function resolveLedgerSessionId(session: { sessionId: string; ledgerSessionId?: 
 /** Helper that keeps ACP client updates and replay ledger writes in sync. */
 export class AcpTranslatorSessionUpdates {
   private stopped = false;
-  // Queue ledger mutations at emission time so a detached disconnect notice
-  // cannot overtake an older update whose ACP delivery is backpressured.
-  private ledgerMutationTail: Promise<void> = Promise.resolve();
+  // Queue each ledger session at emission time so a detached disconnect notice
+  // cannot overtake its older update or block unrelated session settlement.
+  private ledgerMutationTails = new Map<string, Promise<void>>();
 
   constructor(private options: AcpTranslatorSessionUpdatesOptions) {}
 
@@ -111,7 +111,7 @@ export class AcpTranslatorSessionUpdates {
     runId: string,
     prompt: PromptRequest["prompt"],
   ): Promise<void> {
-    await this.enqueueLedgerMutation(async () => {
+    await this.enqueueLedgerMutation(resolveLedgerSessionId(session), async () => {
       if (this.stopped) {
         return;
       }
@@ -190,7 +190,7 @@ export class AcpTranslatorSessionUpdates {
     runId?: string;
     update: SessionUpdate;
   }): Promise<void> {
-    await this.enqueueLedgerMutation(async () => {
+    await this.enqueueLedgerMutation(params.ledgerSessionId ?? params.sessionId, async () => {
       if (this.stopped) {
         return;
       }
@@ -214,9 +214,19 @@ export class AcpTranslatorSessionUpdates {
     });
   }
 
-  private enqueueLedgerMutation(mutation: () => Promise<void>): Promise<void> {
-    const pending = this.ledgerMutationTail.then(mutation, mutation);
-    this.ledgerMutationTail = pending.catch(() => {});
+  private enqueueLedgerMutation(
+    ledgerSessionId: string,
+    mutation: () => Promise<void>,
+  ): Promise<void> {
+    const previous = this.ledgerMutationTails.get(ledgerSessionId) ?? Promise.resolve();
+    const pending = previous.then(mutation, mutation);
+    const tail = pending.catch(() => {});
+    this.ledgerMutationTails.set(ledgerSessionId, tail);
+    void tail.then(() => {
+      if (this.ledgerMutationTails.get(ledgerSessionId) === tail) {
+        this.ledgerMutationTails.delete(ledgerSessionId);
+      }
+    });
     return pending;
   }
 

--- a/src/acp/translator.stop-reason.test.ts
+++ b/src/acp/translator.stop-reason.test.ts
@@ -1,8 +1,9 @@
 /** Tests Gateway final/error states to ACP prompt stopReason mapping. */
-import type { PromptRequest } from "@agentclientprotocol/sdk";
+import type { LoadSessionRequest, PromptRequest } from "@agentclientprotocol/sdk";
 import { createInMemorySessionStore } from "@openclaw/acp-core/session";
 import { describe, expect, it, vi } from "vitest";
 import type { GatewayClient } from "../gateway/client.js";
+import { createInMemoryAcpEventLedger } from "./event-ledger.js";
 import { AcpGatewayAgent } from "./translator.js";
 import {
   createChatEvent,
@@ -36,6 +37,67 @@ function requireFirstRequestIdempotencyKey(requestMock: {
     throw new Error("expected request idempotency key");
   }
   return idempotencyKey;
+}
+
+async function createDisconnectNoticeHarness(params: { sendAccepted: boolean }) {
+  const sessionId = "session-1";
+  const sessionKey = "agent:main:main";
+  const sessionStore = createInMemorySessionStore();
+  sessionStore.createSession({ sessionId, sessionKey, cwd: "/tmp" });
+  const eventLedger = createInMemoryAcpEventLedger();
+  await eventLedger.startSession({
+    sessionId,
+    sessionKey,
+    cwd: "/tmp",
+    complete: true,
+  });
+  const connection = createAcpConnection();
+  const sessionUpdate = vi.fn(
+    async (_params: Parameters<typeof connection.sessionUpdate>[0]) => {},
+  );
+  connection.sessionUpdate = sessionUpdate as typeof connection.sessionUpdate;
+  let runId: string | undefined;
+  const request = vi.fn(async (method: string, requestParams?: Record<string, unknown>) => {
+    if (method === "chat.send") {
+      runId = requestParams?.idempotencyKey as string | undefined;
+      if (!params.sendAccepted) {
+        throw new Error("gateway closed (1006): connection lost");
+      }
+      return {};
+    }
+    if (method === "agent.wait") {
+      throw new Error("gateway closed (1006): connection lost");
+    }
+    return {};
+  }) as GatewayClient["request"];
+  const agent = new AcpGatewayAgent(connection, createAcpGateway(request), {
+    eventLedger,
+    sessionStore,
+  });
+  const promptPromise = promptAgent(agent, sessionId);
+  void promptPromise.catch(() => {});
+  await vi.waitFor(() => {
+    expect(request).toHaveBeenCalledWith("chat.send", expect.objectContaining({ sessionKey }), {
+      timeoutMs: null,
+    });
+  });
+  if (params.sendAccepted) {
+    await vi.waitFor(async () => {
+      const replay = await eventLedger.readReplay({ sessionId, sessionKey });
+      expect(
+        replay.events.some((event) => event.update.sessionUpdate === "user_message_chunk"),
+      ).toBe(true);
+    });
+  }
+  return {
+    agent,
+    eventLedger,
+    promptPromise,
+    runId: requireValue(runId, "chat.send run id"),
+    sessionId,
+    sessionKey,
+    sessionUpdate,
+  };
 }
 
 describe("acp translator stop reason mapping", () => {
@@ -169,14 +231,120 @@ describe("acp translator stop reason mapping", () => {
   it("rejects in-flight prompts when the gateway does not reconnect before the grace window", async () => {
     vi.useFakeTimers();
     try {
-      const { agent, promptPromise } = await createPendingPromptHarness();
-      void promptPromise.catch(() => {});
+      const { agent, eventLedger, promptPromise, runId, sessionId, sessionKey, sessionUpdate } =
+        await createDisconnectNoticeHarness({ sendAccepted: true });
 
       agent.handleGatewayDisconnect("1006: connection lost");
       await vi.advanceTimersByTimeAsync(5_000);
 
       await expect(promptPromise).rejects.toThrow("Gateway disconnected: 1006: connection lost");
+      const expectedText =
+        "[OpenClaw interruption] The Gateway disconnected after accepting this message, so its final outcome is unknown. Check the session before retrying.";
+      expect(sessionUpdate).toHaveBeenCalledWith({
+        sessionId,
+        update: {
+          sessionUpdate: "agent_message_chunk",
+          content: { type: "text", text: expectedText },
+        },
+      });
+      const replay = await eventLedger.readReplay({ sessionId, sessionKey });
+      const recordedNotices = replay.events.filter(
+        (event) =>
+          event.update.sessionUpdate === "agent_message_chunk" &&
+          event.update.content.type === "text" &&
+          event.update.content.text === expectedText,
+      );
+      expect(recordedNotices).toHaveLength(1);
+
+      agent.handleGatewayReconnect();
+      await agent.handleGatewayEvent(
+        createChatEvent({
+          runId,
+          sessionKey,
+          seq: 1,
+          state: "final",
+        }),
+      );
+      expect(
+        sessionUpdate.mock.calls.filter(
+          ([notification]) =>
+            notification?.update?.sessionUpdate === "agent_message_chunk" &&
+            notification.update.content.type === "text" &&
+            notification.update.content.text === expectedText,
+        ),
+      ).toHaveLength(1);
+
+      const replayConnection = createAcpConnection();
+      const replaySessionUpdate = vi.fn(
+        async (_params: Parameters<typeof replayConnection.sessionUpdate>[0]) => {},
+      );
+      replayConnection.sessionUpdate = replaySessionUpdate as typeof replayConnection.sessionUpdate;
+      const replayRequest = vi.fn(async (method: string) => {
+        if (method === "sessions.list") {
+          return { sessions: [], hasMore: false };
+        }
+        return {};
+      }) as GatewayClient["request"];
+      const replayAgent = new AcpGatewayAgent(replayConnection, createAcpGateway(replayRequest), {
+        eventLedger,
+        sessionStore: createInMemorySessionStore(),
+      });
+      await replayAgent.loadSession({
+        sessionId,
+        cwd: "/tmp",
+        mcpServers: [],
+        _meta: {},
+      } as unknown as LoadSessionRequest);
+      expect(
+        replaySessionUpdate.mock.calls.filter(
+          ([notification]) =>
+            notification?.update?.sessionUpdate === "agent_message_chunk" &&
+            notification.update.content.type === "text" &&
+            notification.update.content.text === expectedText,
+        ),
+      ).toHaveLength(1);
     } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("makes the disconnect notice durable without waiting for ACP delivery", async () => {
+    vi.useFakeTimers();
+    let releaseDelivery: (() => void) | undefined;
+    try {
+      const { agent, eventLedger, promptPromise, sessionUpdate } =
+        await createDisconnectNoticeHarness({ sendAccepted: true });
+      const settleSpy = observeSettlement(promptPromise);
+      const originalRecordUpdate = eventLedger.recordUpdate;
+      let releaseRecord: (() => void) | undefined;
+      const recordBlocked = new Promise<void>((resolve) => {
+        releaseRecord = resolve;
+      });
+      let noticeRecordStarted = false;
+      eventLedger.recordUpdate = async (params) => {
+        if (params.update.sessionUpdate === "agent_message_chunk") {
+          noticeRecordStarted = true;
+          await recordBlocked;
+        }
+        await originalRecordUpdate(params);
+      };
+      const deliveryBlocked = new Promise<void>((resolve) => {
+        releaseDelivery = resolve;
+      });
+      sessionUpdate.mockImplementation(async () => await deliveryBlocked);
+
+      agent.handleGatewayDisconnect("1006: connection lost");
+      await vi.advanceTimersByTimeAsync(5_000);
+      await vi.waitFor(() => {
+        expect(noticeRecordStarted).toBe(true);
+        expect(sessionUpdate).toHaveBeenCalledTimes(1);
+      });
+      expect(settleSpy).not.toHaveBeenCalled();
+
+      releaseRecord?.();
+      await expect(promptPromise).rejects.toThrow("Gateway disconnected: 1006: connection lost");
+    } finally {
+      releaseDelivery?.();
       vi.useRealTimers();
     }
   });
@@ -184,17 +352,10 @@ describe("acp translator stop reason mapping", () => {
   it("keeps pre-ack send disconnects inside the reconnect grace window", async () => {
     vi.useFakeTimers();
     try {
-      const request = vi.fn(async (method: string) => {
-        if (method === "chat.send") {
-          throw new Error("gateway closed (1006): connection lost");
-        }
-        return {};
-      }) as GatewayClient["request"];
-      const { agent, sessionId } = createSessionAgentHarness(request);
-      const promptPromise = promptAgent(agent, sessionId);
+      const { agent, eventLedger, promptPromise, sessionId, sessionKey, sessionUpdate } =
+        await createDisconnectNoticeHarness({ sendAccepted: false });
       const settleSpy = observeSettlement(promptPromise);
 
-      await Promise.resolve();
       expect(settleSpy).not.toHaveBeenCalled();
 
       agent.handleGatewayDisconnect("1006: connection lost");
@@ -203,6 +364,24 @@ describe("acp translator stop reason mapping", () => {
 
       await vi.advanceTimersByTimeAsync(1);
       await expect(promptPromise).rejects.toThrow("Gateway disconnected: 1006: connection lost");
+      const expectedText =
+        "[OpenClaw interruption] The Gateway disconnected before OpenClaw could confirm whether this message was accepted, so its final outcome is unknown. Check the session before retrying.";
+      expect(sessionUpdate).toHaveBeenCalledWith({
+        sessionId,
+        update: {
+          sessionUpdate: "agent_message_chunk",
+          content: { type: "text", text: expectedText },
+        },
+      });
+      const replay = await eventLedger.readReplay({ sessionId, sessionKey });
+      expect(
+        replay.events.filter(
+          (event) =>
+            event.update.sessionUpdate === "agent_message_chunk" &&
+            event.update.content.type === "text" &&
+            event.update.content.text === expectedText,
+        ),
+      ).toHaveLength(1);
     } finally {
       vi.useRealTimers();
     }
@@ -618,6 +797,83 @@ describe("acp translator stop reason mapping", () => {
 
     releaseSessionUpdate?.();
     await expect(promptPromise).resolves.toEqual({ stopReason: "end_turn" });
+  });
+
+  it("keeps a replacement prompt while a stale send failure races disconnect rejection", async () => {
+    vi.useFakeTimers();
+    try {
+      let rejectFirstSend: ((error: Error) => void) | undefined;
+      const firstSend = new Promise<never>((_, reject) => {
+        rejectFirstSend = reject;
+      });
+      const runIds: string[] = [];
+      const request = vi.fn(
+        (method: string, params?: Record<string, unknown>): Promise<unknown> => {
+          if (method === "chat.send") {
+            const runId = params?.idempotencyKey;
+            if (typeof runId === "string") {
+              runIds.push(runId);
+            }
+            return runIds.length === 1 ? firstSend : Promise.resolve({});
+          }
+          if (method === "agent.wait") {
+            return Promise.reject(new Error("gateway closed (1006): connection lost"));
+          }
+          return Promise.resolve({});
+        },
+      ) as GatewayClient["request"];
+      let releaseNotice: (() => void) | undefined;
+      const blockedNotice = new Promise<void>((resolve) => {
+        releaseNotice = resolve;
+      });
+      const connection = createAcpConnection();
+      const sessionUpdate = vi.fn(async () => await blockedNotice);
+      connection.sessionUpdate = sessionUpdate as typeof connection.sessionUpdate;
+      const sessionStore = createInMemorySessionStore();
+      const sessionId = "session-1";
+      const sessionKey = "agent:main:main";
+      sessionStore.createSession({ sessionId, sessionKey, cwd: "/tmp" });
+      const agent = new AcpGatewayAgent(connection, createAcpGateway(request), {
+        sessionStore,
+      });
+
+      const firstPrompt = promptAgent(agent, sessionId, "first");
+      void firstPrompt.catch(() => {});
+      await vi.waitFor(() => {
+        expect(runIds).toHaveLength(1);
+      });
+      agent.handleGatewayDisconnect("1006: connection lost");
+      await vi.advanceTimersByTimeAsync(5_000);
+      await vi.waitFor(() => {
+        expect(sessionUpdate).toHaveBeenCalledTimes(1);
+      });
+      await expect(firstPrompt).rejects.toThrow("Gateway disconnected: 1006: connection lost");
+
+      rejectFirstSend?.(new Error("gateway closed (1006): connection lost"));
+      await Promise.resolve();
+      const secondPrompt = promptAgent(agent, sessionId, "second");
+      await vi.waitFor(() => {
+        expect(runIds).toHaveLength(2);
+      });
+
+      releaseNotice?.();
+      await expect(Promise.race([secondPrompt, Promise.resolve("pending")])).resolves.toBe(
+        "pending",
+      );
+
+      await agent.handleGatewayEvent(
+        createChatEvent({
+          runId: runIds[1],
+          sessionKey,
+          seq: 1,
+          state: "final",
+        }),
+      );
+      await expect(secondPrompt).resolves.toEqual({ stopReason: "end_turn" });
+      expect(sessionUpdate).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("does not let a stale disconnect deadline reject a newer prompt on the same session", async () => {

--- a/src/acp/translator.stop-reason.test.ts
+++ b/src/acp/translator.stop-reason.test.ts
@@ -1,5 +1,5 @@
 /** Tests Gateway final/error states to ACP prompt stopReason mapping. */
-import type { LoadSessionRequest, PromptRequest } from "@agentclientprotocol/sdk";
+import type { PromptRequest } from "@agentclientprotocol/sdk";
 import { createInMemorySessionStore } from "@openclaw/acp-core/session";
 import { describe, expect, it, vi } from "vitest";
 import type { GatewayClient } from "../gateway/client.js";
@@ -56,10 +56,8 @@ async function createDisconnectNoticeHarness(params: { sendAccepted: boolean }) 
     async (_params: Parameters<typeof connection.sessionUpdate>[0]) => {},
   );
   connection.sessionUpdate = sessionUpdate as typeof connection.sessionUpdate;
-  let runId: string | undefined;
-  const request = vi.fn(async (method: string, requestParams?: Record<string, unknown>) => {
+  const request = vi.fn(async (method: string) => {
     if (method === "chat.send") {
-      runId = requestParams?.idempotencyKey as string | undefined;
       if (!params.sendAccepted) {
         throw new Error("gateway closed (1006): connection lost");
       }
@@ -93,7 +91,6 @@ async function createDisconnectNoticeHarness(params: { sendAccepted: boolean }) 
     agent,
     eventLedger,
     promptPromise,
-    runId: requireValue(runId, "chat.send run id"),
     sessionId,
     sessionKey,
     sessionUpdate,
@@ -231,7 +228,7 @@ describe("acp translator stop reason mapping", () => {
   it("rejects in-flight prompts when the gateway does not reconnect before the grace window", async () => {
     vi.useFakeTimers();
     try {
-      const { agent, eventLedger, promptPromise, runId, sessionId, sessionKey, sessionUpdate } =
+      const { agent, eventLedger, promptPromise, sessionId, sessionKey, sessionUpdate } =
         await createDisconnectNoticeHarness({ sendAccepted: true });
 
       agent.handleGatewayDisconnect("1006: connection lost");
@@ -255,54 +252,6 @@ describe("acp translator stop reason mapping", () => {
           event.update.content.text === expectedText,
       );
       expect(recordedNotices).toHaveLength(1);
-
-      agent.handleGatewayReconnect();
-      await agent.handleGatewayEvent(
-        createChatEvent({
-          runId,
-          sessionKey,
-          seq: 1,
-          state: "final",
-        }),
-      );
-      expect(
-        sessionUpdate.mock.calls.filter(
-          ([notification]) =>
-            notification?.update?.sessionUpdate === "agent_message_chunk" &&
-            notification.update.content.type === "text" &&
-            notification.update.content.text === expectedText,
-        ),
-      ).toHaveLength(1);
-
-      const replayConnection = createAcpConnection();
-      const replaySessionUpdate = vi.fn(
-        async (_params: Parameters<typeof replayConnection.sessionUpdate>[0]) => {},
-      );
-      replayConnection.sessionUpdate = replaySessionUpdate as typeof replayConnection.sessionUpdate;
-      const replayRequest = vi.fn(async (method: string) => {
-        if (method === "sessions.list") {
-          return { sessions: [], hasMore: false };
-        }
-        return {};
-      }) as GatewayClient["request"];
-      const replayAgent = new AcpGatewayAgent(replayConnection, createAcpGateway(replayRequest), {
-        eventLedger,
-        sessionStore: createInMemorySessionStore(),
-      });
-      await replayAgent.loadSession({
-        sessionId,
-        cwd: "/tmp",
-        mcpServers: [],
-        _meta: {},
-      } as unknown as LoadSessionRequest);
-      expect(
-        replaySessionUpdate.mock.calls.filter(
-          ([notification]) =>
-            notification?.update?.sessionUpdate === "agent_message_chunk" &&
-            notification.update.content.type === "text" &&
-            notification.update.content.text === expectedText,
-        ),
-      ).toHaveLength(1);
     } finally {
       vi.useRealTimers();
     }
@@ -822,18 +771,11 @@ describe("acp translator stop reason mapping", () => {
           return Promise.resolve({});
         },
       ) as GatewayClient["request"];
-      let releaseNotice: (() => void) | undefined;
-      const blockedNotice = new Promise<void>((resolve) => {
-        releaseNotice = resolve;
-      });
-      const connection = createAcpConnection();
-      const sessionUpdate = vi.fn(async () => await blockedNotice);
-      connection.sessionUpdate = sessionUpdate as typeof connection.sessionUpdate;
       const sessionStore = createInMemorySessionStore();
       const sessionId = "session-1";
       const sessionKey = "agent:main:main";
       sessionStore.createSession({ sessionId, sessionKey, cwd: "/tmp" });
-      const agent = new AcpGatewayAgent(connection, createAcpGateway(request), {
+      const agent = new AcpGatewayAgent(createAcpConnection(), createAcpGateway(request), {
         sessionStore,
       });
 
@@ -844,19 +786,15 @@ describe("acp translator stop reason mapping", () => {
       });
       agent.handleGatewayDisconnect("1006: connection lost");
       await vi.advanceTimersByTimeAsync(5_000);
-      await vi.waitFor(() => {
-        expect(sessionUpdate).toHaveBeenCalledTimes(1);
-      });
       await expect(firstPrompt).rejects.toThrow("Gateway disconnected: 1006: connection lost");
 
-      rejectFirstSend?.(new Error("gateway closed (1006): connection lost"));
-      await Promise.resolve();
       const secondPrompt = promptAgent(agent, sessionId, "second");
       await vi.waitFor(() => {
         expect(runIds).toHaveLength(2);
       });
 
-      releaseNotice?.();
+      rejectFirstSend?.(new Error("gateway closed (1006): connection lost"));
+      await Promise.resolve();
       await expect(Promise.race([secondPrompt, Promise.resolve("pending")])).resolves.toBe(
         "pending",
       );
@@ -870,7 +808,6 @@ describe("acp translator stop reason mapping", () => {
         }),
       );
       await expect(secondPrompt).resolves.toEqual({ stopReason: "end_turn" });
-      expect(sessionUpdate).toHaveBeenCalledTimes(2);
     } finally {
       vi.useRealTimers();
     }

--- a/src/acp/translator.ts
+++ b/src/acp/translator.ts
@@ -721,7 +721,7 @@ export class AcpGatewayAgent implements Agent {
           if (status === "error") {
             const current = pending();
             if (current) {
-              this.rejectPendingPrompt(
+              await this.rejectPendingPrompt(
                 current,
                 new Error("Chat failed before the run started; try again."),
               );
@@ -775,21 +775,21 @@ export class AcpGatewayAgent implements Agent {
         }
       };
 
-      void sendWithProvenanceFallback().catch((err: unknown) => {
+      void sendWithProvenanceFallback().catch(async (err: unknown) => {
         const promptKey = this.pendingPromptKey(params.sessionId, runId);
-        if (
-          isGatewayCloseError(err) &&
-          (this.getPendingPrompt(params.sessionId, runId) || this.settlingPromptKeys.has(promptKey))
-        ) {
+        if (this.settlingPromptKeys.has(promptKey)) {
           return;
         }
-        this.clearApprovalRelaysForPrompt(params.sessionId, runId, { denyActive: true });
-        this.pendingPrompts.delete(params.sessionId);
-        this.sessionStore.clearActiveRun(params.sessionId);
-        if (this.pendingPrompts.size === 0) {
-          this.clearDisconnectTimer();
+        if (isGatewayCloseError(err) && this.getPendingPrompt(params.sessionId, runId)) {
+          return;
         }
-        reject(err instanceof Error ? err : new Error(String(err)));
+        const error = err instanceof Error ? err : new Error(String(err));
+        const current = this.getPendingPrompt(params.sessionId, runId);
+        if (current) {
+          await this.rejectPendingPrompt(current, error);
+          return;
+        }
+        reject(error);
       });
     });
   }
@@ -1299,11 +1299,19 @@ export class AcpGatewayAgent implements Agent {
     this.disconnectTimer.unref?.();
   }
 
-  private rejectPendingPrompt(pending: PendingPrompt, error: Error): void {
+  private async rejectPendingPrompt(
+    pending: PendingPrompt,
+    error: Error,
+    options: { recordDisconnectNotice?: boolean } = {},
+  ): Promise<void> {
     const currentPending = this.getPendingPrompt(pending.sessionId, pending.idempotencyKey);
     if (currentPending !== pending) {
       return;
     }
+
+    const promptKey = this.pendingPromptKey(pending.sessionId, pending.idempotencyKey);
+    // Claim before emitting so late Gateway events cannot settle this prompt twice.
+    this.settlingPromptKeys.add(promptKey);
     this.clearApprovalRelaysForPrompt(pending.sessionId, pending.idempotencyKey, {
       denyActive: true,
     });
@@ -1312,7 +1320,33 @@ export class AcpGatewayAgent implements Agent {
     if (this.pendingPrompts.size === 0) {
       this.clearDisconnectTimer();
     }
-    pending.reject(error);
+
+    try {
+      if (options.recordDisconnectNotice) {
+        const text = pending.sendAccepted
+          ? "[OpenClaw interruption] The Gateway disconnected after accepting this message, so its final outcome is unknown. Check the session before retrying."
+          : "[OpenClaw interruption] The Gateway disconnected before OpenClaw could confirm whether this message was accepted, so its final outcome is unknown. Check the session before retrying.";
+        // Make replay durable before rejecting, but do not let ACP client backpressure
+        // extend the disconnect deadline indefinitely.
+        await this.sessionUpdates.emit({
+          sessionId: pending.sessionId,
+          sessionKey: pending.sessionKey,
+          ...(pending.ledgerSessionId ? { ledgerSessionId: pending.ledgerSessionId } : {}),
+          runId: pending.idempotencyKey,
+          record: true,
+          waitForDelivery: false,
+          update: {
+            sessionUpdate: "agent_message_chunk",
+            content: { type: "text", text },
+          },
+        });
+      }
+    } catch (noticeError) {
+      this.log(`disconnect notice failed for ${pending.idempotencyKey}: ${String(noticeError)}`);
+    } finally {
+      pending.reject(error);
+      this.settlingPromptKeys.delete(promptKey);
+    }
   }
 
   private clearPendingDisconnectState(
@@ -1394,9 +1428,10 @@ export class AcpGatewayAgent implements Agent {
       this.log(`agent.wait reconcile failed for ${pending.idempotencyKey}: ${String(err)}`);
       if (deadlineExpired) {
         if (this.shouldRejectPendingAtDisconnectDeadline(pending, disconnectContext)) {
-          this.rejectPendingPrompt(
+          await this.rejectPendingPrompt(
             pending,
             new Error(`Gateway disconnected: ${disconnectContext.reason}`),
+            { recordDisconnectNotice: true },
           );
           return false;
         }
@@ -1424,9 +1459,10 @@ export class AcpGatewayAgent implements Agent {
         if (!currentDisconnectContext) {
           return false;
         }
-        this.rejectPendingPrompt(
+        await this.rejectPendingPrompt(
           currentPending,
           new Error(`Gateway disconnected: ${currentDisconnectContext.reason}`),
+          { recordDisconnectNotice: true },
         );
         return false;
       }


### PR DESCRIPTION
Closes #108587

AI-assisted: Yes (Codex). I reviewed the implementation and understand the changed ACP reconnect, prompt-settlement, session-update ordering, and event-ledger paths.

## What Problem This Solves

Fixes an issue where ACP users could lose a visible turn after a Gateway disconnect outlasted the reconnect grace period: the prompt ended as a generic JSON-RPC error, while the session stream and replay ledger contained no durable explanation.

## Why This Change Was Made

When the grace deadline rejects a pending prompt, OpenClaw now starts a labeled `agent_message_chunk` notification and ledger record before settling the prompt. The wording distinguishes confirmed Gateway acceptance from an unconfirmed pre-ACK outcome without telling users to resend a message that may already be running, and stale send failures are scoped to their original run so they cannot clear a replacement prompt.

Notice delivery starts immediately but is detached from settlement, while rejection waits for the local ledger write to finish. Ledger mutations are serialized per ledger session at emission time, so the interruption cannot overtake an older update whose ACP delivery is backpressured or let one session block another.

## User Impact

ACP clients now show a durable interruption notice after an unrecovered Gateway disconnect. The notice remains replayable, prompt settlement stays bounded by the five-second grace rather than client backpressure, and earlier replay events retain causal order.

## Evidence

- `node scripts/run-vitest.mjs src/acp/translator.stop-reason.test.ts src/acp/translator.session-updates.test.ts src/acp/translator.event-ledger.test.ts src/acp/event-ledger.test.ts src/acp/translator.cancel-scoping.test.ts src/acp/translator.prompt-prefix.test.ts` — 54 tests passed across 3 shards on rebased head `19f0e59bfc95`.
- [Final-head real outage Testbox proof](https://github.com/openclaw/openclaw/actions/runs/29517259809): an actual `GatewayClient` WebSocket was terminated after `chat.send` acceptance; the prompt rejected in 5007 ms while ACP delivery remained blocked; SQLite close/reopen replayed the user update before the interruption notice.
- [Exact-head changed gate](https://github.com/openclaw/openclaw/actions/runs/29516679388) — passed against the final rebased tree.
- Fresh full-branch and incremental autoreviews: accepted replay-order and cross-session queue findings were repaired; final review reported no accepted/actionable findings.
- `git diff --check` and targeted `oxfmt` — passed.
