### PR TITLE
fix(prompt-probe): bound Anthropic upstream proxy fetch requests

### DIFF
--- a/scripts/anthropic-prompt-probe.ts
+++ b/scripts/anthropic-prompt-probe.ts
@@ -397,6 +397,7 @@ async function startAnthropicProxy(params: { port: number; upstreamBaseUrl: stri
               ? undefined
               : Uint8Array.from(requestBody),
           duplex: "half",
+          signal: AbortSignal.timeout(120_000),
         } as RequestInit & { duplex: "half" };
         const upstreamRes = await fetch(upstreamUrl, upstreamInit);
         const responseHeaders: Record<string, string> = {};
@@ -988,6 +989,7 @@ export const testing = {
   readRequestBody,
   resolveAnthropicUpstreamUrl,
   runDirectPrompt,
+  startAnthropicProxy,
   stopGatewayPromptChild,
   summarizeCapture,
   summarizeText,

--- a/scripts/anthropic-prompt-probe.ts
+++ b/scripts/anthropic-prompt-probe.ts
@@ -366,7 +366,11 @@ function extractProxyCapture(rawBody: string, req: http.IncomingMessage): ProxyC
   };
 }
 
-async function startAnthropicProxy(params: { port: number; upstreamBaseUrl: string }) {
+async function startAnthropicProxy(params: {
+  port: number;
+  upstreamBaseUrl: string;
+  timeoutMs: number;
+}) {
   let lastCapture: ProxyCapture | undefined;
   const sockets = new Set<import("node:net").Socket>();
   const server = http.createServer((req, res) => {
@@ -397,7 +401,7 @@ async function startAnthropicProxy(params: { port: number; upstreamBaseUrl: stri
               ? undefined
               : Uint8Array.from(requestBody),
           duplex: "half",
-          signal: AbortSignal.timeout(120_000),
+          signal: AbortSignal.timeout(params.timeoutMs),
         } as RequestInit & { duplex: "half" };
         const upstreamRes = await fetch(upstreamUrl, upstreamInit);
         const responseHeaders: Record<string, string> = {};
@@ -435,7 +439,12 @@ async function startAnthropicProxy(params: { port: number; upstreamBaseUrl: stri
     server.once("error", reject);
     server.listen(params.port, "127.0.0.1", () => resolve());
   });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("Anthropic capture proxy did not bind to a TCP port");
+  }
   return {
+    port: address.port,
     getLastCapture() {
       return lastCapture;
     },
@@ -470,11 +479,16 @@ async function runDirectPrompt(
     timeoutMs?: number;
   } = {},
 ): Promise<PromptResult> {
+  const timeoutMs = options.timeoutMs ?? TIMEOUT_MS;
   const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-direct-prompt-probe-"));
   const proxyPort = ENABLE_CAPTURE ? await getFreePort() : undefined;
   const proxy =
     ENABLE_CAPTURE && proxyPort
-      ? await startAnthropicProxy({ port: proxyPort, upstreamBaseUrl: "https://api.anthropic.com" })
+      ? await startAnthropicProxy({
+          port: proxyPort,
+          upstreamBaseUrl: "https://api.anthropic.com",
+          timeoutMs,
+        })
       : undefined;
 
   try {
@@ -523,7 +537,7 @@ async function runDirectPrompt(
           void stopDirectChild("SIGKILL").finally(() => {
             resolve({ code: null, signal: "SIGKILL" });
           });
-        }, options.timeoutMs ?? TIMEOUT_MS);
+        }, timeoutMs);
       }),
     ]).finally(() => {
       if (timeoutTimer) {
@@ -811,7 +825,11 @@ async function runGatewayPrompt(prompt: string): Promise<PromptResult> {
   const proxyPort = ENABLE_CAPTURE ? await getFreePort() : undefined;
   const proxy =
     ENABLE_CAPTURE && proxyPort
-      ? await startAnthropicProxy({ port: proxyPort, upstreamBaseUrl: "https://api.anthropic.com" })
+      ? await startAnthropicProxy({
+          port: proxyPort,
+          upstreamBaseUrl: "https://api.anthropic.com",
+          timeoutMs: GATEWAY_TIMEOUT_MS,
+        })
       : undefined;
   let gateway: Awaited<ReturnType<typeof startGatewayProcess>> | undefined;
 

--- a/test/scripts/dev-tooling-safety.test.ts
+++ b/test/scripts/dev-tooling-safety.test.ts
@@ -1202,16 +1202,9 @@ describe("script-specific dev tooling hardening", () => {
     ).rejects.toThrow(`Claude usage test response body exceeded ${maxBytes} bytes`);
   });
 
-  it("proxies upstream Anthropic requests through a timeout-bounded fetch", async () => {
-    const { testing: promptProbeTesting } = await import("../../scripts/anthropic-prompt-probe.ts");
-    const { startAnthropicProxy } = promptProbeTesting;
-    expect(typeof startAnthropicProxy).toBe("function");
-
-    // Start a stub upstream that the proxy will forward to
-    const upstream = http.createServer((_req, res) => {
-      res.writeHead(200, { "content-type": "application/json" });
-      res.end(JSON.stringify({ type: "message", content: "ok" }));
-    });
+  it("aborts a stalled Anthropic proxy upstream at the configured deadline", async () => {
+    const nativeFetch = globalThis.fetch;
+    const upstream = http.createServer(() => {});
     await new Promise<void>((resolve, reject) => {
       upstream.once("error", reject);
       upstream.listen(0, "127.0.0.1", () => {
@@ -1219,21 +1212,41 @@ describe("script-specific dev tooling hardening", () => {
         resolve();
       });
     });
-    const upstreamAddr = upstream.address();
-    if (!upstreamAddr || typeof upstreamAddr === "string") {
+    const upstreamAddress = upstream.address();
+    if (!upstreamAddress || typeof upstreamAddress === "string") {
       throw new Error("upstream did not bind to a TCP port");
     }
+    const upstreamUrl = `http://127.0.0.1:${upstreamAddress.port}/v1/messages`;
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation((_input, init) => nativeFetch(upstreamUrl, init));
+    let proxy: Awaited<ReturnType<typeof promptProbeTesting.startAnthropicProxy>> | undefined;
 
     try {
-      const proxy = await startAnthropicProxy({
+      proxy = await promptProbeTesting.startAnthropicProxy({
         port: 0,
-        upstreamBaseUrl: `http://127.0.0.1:${upstreamAddr.port}`,
+        upstreamBaseUrl: "https://api.anthropic.com",
+        timeoutMs: 100,
       });
-      expect(typeof proxy.getLastCapture).toBe("function");
-      expect(typeof proxy.stop).toBe("function");
-      await proxy.stop();
+      const startedAt = Date.now();
+      const response = await nativeFetch(`http://127.0.0.1:${proxy.port}/v1/messages`, {
+        method: "POST",
+        body: "{}",
+      });
+
+      expect(response.status).toBe(502);
+      await expect(response.text()).resolves.toMatch(/TimeoutError/u);
+      expect(Date.now() - startedAt).toBeLessThan(2_000);
+      expect(fetchSpy).toHaveBeenCalledWith(
+        "https://api.anthropic.com/v1/messages",
+        expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      );
     } finally {
-      upstream.close();
+      fetchSpy.mockRestore();
+      await proxy?.stop();
+      await new Promise<void>((resolve, reject) => {
+        upstream.close((error) => (error ? reject(error) : resolve()));
+      });
     }
   });
 });

--- a/test/scripts/dev-tooling-safety.test.ts
+++ b/test/scripts/dev-tooling-safety.test.ts
@@ -3,6 +3,7 @@ import { spawn } from "node:child_process";
 import { EventEmitter } from "node:events";
 import { existsSync, readFileSync } from "node:fs";
 import fs from "node:fs/promises";
+import http from "node:http";
 import os from "node:os";
 import path from "node:path";
 import { Readable } from "node:stream";
@@ -1199,5 +1200,40 @@ describe("script-specific dev tooling hardening", () => {
         maxBytes,
       ),
     ).rejects.toThrow(`Claude usage test response body exceeded ${maxBytes} bytes`);
+  });
+
+  it("proxies upstream Anthropic requests through a timeout-bounded fetch", async () => {
+    const { testing: promptProbeTesting } = await import("../../scripts/anthropic-prompt-probe.ts");
+    const { startAnthropicProxy } = promptProbeTesting;
+    expect(typeof startAnthropicProxy).toBe("function");
+
+    // Start a stub upstream that the proxy will forward to
+    const upstream = http.createServer((_req, res) => {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ type: "message", content: "ok" }));
+    });
+    await new Promise<void>((resolve, reject) => {
+      upstream.once("error", reject);
+      upstream.listen(0, "127.0.0.1", () => {
+        upstream.off("error", reject);
+        resolve();
+      });
+    });
+    const upstreamAddr = upstream.address();
+    if (!upstreamAddr || typeof upstreamAddr === "string") {
+      throw new Error("upstream did not bind to a TCP port");
+    }
+
+    try {
+      const proxy = await startAnthropicProxy({
+        port: 0,
+        upstreamBaseUrl: `http://127.0.0.1:${upstreamAddr.port}`,
+      });
+      expect(typeof proxy.getLastCapture).toBe("function");
+      expect(typeof proxy.stop).toBe("function");
+      await proxy.stop();
+    } finally {
+      upstream.close();
+    }
   });
 });


### PR DESCRIPTION
## Summary

Bound Anthropic prompt-probe proxy requests with the deadline already configured by each caller. Direct capture uses `OPENCLAW_PROMPT_TIMEOUT_MS`; gateway capture uses `OPENCLAW_PROMPT_GATEWAY_TIMEOUT_MS`.

## What Problem This Solves

The capture proxy's upstream Fetch request had no abort signal. An upstream that accepted the connection and then stopped responding could leave the interactive probe hanging.

## Fix

- Require the common proxy owner to receive a timeout budget.
- Share the direct caller's existing timeout between its child lifecycle and proxy request.
- Use the gateway caller's existing timeout for gateway capture requests.
- Keep the exact Anthropic upstream-origin restriction unchanged.
- Return the actual bound proxy port so the regression can use port `0` without a free-port race.

This avoids a new hardcoded timeout, environment variable, fallback, or fetch abstraction.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/dev-tooling-safety.test.ts` — 59 tests passed. The regression sends a real request through the proxy to a loopback server that accepts the request and never responds; a 100 ms configured deadline returns a redacted 502 `TimeoutError` under 2 seconds.
- `node scripts/check-changed.mjs -- scripts/anthropic-prompt-probe.ts test/scripts/dev-tooling-safety.test.ts` — hosted format, scripts types, root-test types, tooling lint, and guards passed: https://github.com/openclaw/openclaw/actions/runs/29512289502
- Exact-head CI and `openclaw/ci-gate` passed: https://github.com/openclaw/openclaw/actions/runs/29512954594
- `git diff --check` — clean.
- Fresh branch autoreview — clean, patch correct, confidence 0.93.

Node documents that `AbortSignal.timeout(delay)` aborts after the supplied delay: https://nodejs.org/api/globals.html#static-method-abortsignaltimeoutdelay
