### PR TITLE
feat(cli): claw-snip spinner for wizard long-running steps

### DIFF
--- a/src/wizard/clack-prompter.test.ts
+++ b/src/wizard/clack-prompter.test.ts
@@ -1,5 +1,16 @@
 // Clack prompter tests cover prompt rendering, validation, and cancellation.
+import type { SpinnerOptions } from "@clack/prompts";
 import { afterEach, describe, expect, it, vi } from "vitest";
+
+const themeMocks = vi.hoisted(() => ({
+  isRich: vi.fn(() => false),
+}));
+
+const stdoutIsTTYDescriptor = Object.getOwnPropertyDescriptor(process.stdout, "isTTY");
+
+function stubStdoutIsTTY(value: boolean): void {
+  Object.defineProperty(process.stdout, "isTTY", { configurable: true, value });
+}
 
 const clackMocks = vi.hoisted(() => ({
   autocomplete: vi.fn(),
@@ -13,7 +24,7 @@ const clackMocks = vi.hoisted(() => ({
   password: vi.fn(),
   select: vi.fn(),
   settings: { actions: new Set(["left", "right"]) },
-  spinner: vi.fn(() => ({
+  spinner: vi.fn((_options?: SpinnerOptions) => ({
     start: vi.fn(),
     message: vi.fn(),
     clear: vi.fn(),
@@ -31,6 +42,14 @@ const navigationPromptMocks = vi.hoisted(() => ({
   selectWithNavigationFooter: vi.fn(),
   textWithNavigationFooter: vi.fn(),
 }));
+
+vi.mock("../../packages/terminal-core/src/theme.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../packages/terminal-core/src/theme.js")>();
+  return {
+    ...actual,
+    isRich: themeMocks.isRich,
+  };
+});
 
 vi.mock("@clack/prompts", () => ({
   autocomplete: clackMocks.autocomplete,
@@ -59,12 +78,20 @@ vi.mock("./clack-navigation-prompts.js", () => ({
   textWithNavigationFooter: navigationPromptMocks.textWithNavigationFooter,
 }));
 
+import { theme } from "../../packages/terminal-core/src/theme.js";
 import { createClackPrompter, tokenizedOptionFilter } from "./clack-prompter.js";
 import { WizardNavigationError } from "./prompts.js";
 
 afterEach(() => {
   vi.restoreAllMocks();
   vi.clearAllMocks();
+  vi.unstubAllEnvs();
+  if (stdoutIsTTYDescriptor) {
+    Object.defineProperty(process.stdout, "isTTY", stdoutIsTTYDescriptor);
+  } else {
+    Reflect.deleteProperty(process.stdout, "isTTY");
+  }
+  themeMocks.isRich.mockReturnValue(false);
   clackMocks.settings.actions = new Set(["left", "right"]);
 });
 
@@ -102,6 +129,34 @@ describe("tokenizedOptionFilter", () => {
 });
 
 describe("createClackPrompter", () => {
+  it("uses the claw spinner on rich interactive terminals", () => {
+    stubStdoutIsTTY(true);
+    vi.stubEnv("CI", "");
+    vi.stubEnv("VITEST", "");
+    themeMocks.isRich.mockReturnValue(true);
+    const prompter = createClackPrompter();
+
+    prompter.progress("Loading");
+
+    expect(clackMocks.spinner).toHaveBeenCalledWith({
+      frames: ["(\\/)", "(||)", "(--)", "(||)"],
+      delay: 120,
+      styleFrame: theme.accent,
+    });
+  });
+
+  it("keeps Clack's default spinner on non-rich terminals", () => {
+    stubStdoutIsTTY(true);
+    vi.stubEnv("CI", "");
+    vi.stubEnv("VITEST", "");
+    themeMocks.isRich.mockReturnValue(false);
+    const prompter = createClackPrompter();
+
+    prompter.progress("Loading");
+
+    expect(clackMocks.spinner).toHaveBeenCalledWith();
+  });
+
   it("prints plain output without note framing", async () => {
     const write = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
     const prompter = createClackPrompter();

--- a/src/wizard/clack-prompter.ts
+++ b/src/wizard/clack-prompter.ts
@@ -23,7 +23,7 @@ import {
   stylePromptMessage,
   stylePromptTitle,
 } from "../../packages/terminal-core/src/prompt-style.js";
-import { theme } from "../../packages/terminal-core/src/theme.js";
+import { isRich, theme } from "../../packages/terminal-core/src/theme.js";
 import { createCliProgress } from "../cli/progress.js";
 import {
   autocompleteMultiselectWithNavigationFooter,
@@ -36,6 +36,10 @@ import {
 } from "./clack-navigation-prompts.js";
 import type { WizardProgress, WizardPrompter, WizardPromptNavigation } from "./prompts.js";
 import { WizardCancelledError, WizardNavigationError } from "./prompts.js";
+
+// Same species as the pixel-mascot banner, compressed into a four-column
+// spinner for long-running wizard steps.
+const CLAW_SPINNER_FRAMES = ["(\\/)", "(||)", "(--)", "(||)"];
 
 // Clack-backed WizardPrompter implementation for interactive CLI setup. It
 // converts the generic wizard prompt contract into styled Clack prompts.
@@ -311,7 +315,15 @@ export function createClackPrompter(): WizardPrompter {
           }),
       ),
     progress: (label: string): WizardProgress => {
-      const spin = spinner();
+      const useClawSpinner =
+        Boolean(process.stdout.isTTY) && isRich() && !process.env.CI && !process.env.VITEST;
+      const spin = useClawSpinner
+        ? spinner({
+            frames: CLAW_SPINNER_FRAMES,
+            delay: 120,
+            styleFrame: theme.accent,
+          })
+        : spinner();
       spin.start(theme.accent(label));
       const osc = createCliProgress({
         label,

--- a/src/wizard/clack-prompter.ts
+++ b/src/wizard/clack-prompter.ts
@@ -316,7 +316,7 @@ export function createClackPrompter(): WizardPrompter {
       ),
     progress: (label: string): WizardProgress => {
       const useClawSpinner =
-        Boolean(process.stdout.isTTY) && isRich() && !process.env.CI && !process.env.VITEST;
+        process.stdout.isTTY && isRich() && !process.env.CI && !process.env.VITEST;
       const spin = useClawSpinner
         ? spinner({
             frames: CLAW_SPINNER_FRAMES,


### PR DESCRIPTION
## What Problem This Solves

Wizard flows (`openclaw onboard`, `configure`, `doctor`) show long-running steps — installing the Gateway, probing services — with clack's stock braille-dots spinner. The startup banner already has a playful pixel-mascot animation, but the moments where users actually *wait* are generic and brandless.

## Why This Change Was Made

On rich interactive terminals, the wizard spinner becomes a tiny snipping crab claw, tinted in the mascot's coral accent:

```
(\/)  →  (||)  →  (--)  →  (||)  →  (\/)   snip-snip…
```

- Implemented at the single seam every wizard progress spinner flows through (`createClackPrompter().progress`), using clack 1.6's `frames`/`delay`/`styleFrame` options.
- Gated exactly like the banner animation: TTY + rich terminal + not CI + not test env. CI, dumb terminals, and non-TTY keep clack's default spinner untouched.
- Pure ASCII frames (equal width) — renders correctly in any monospace font, no emoji-width surprises.
- OSC progress reporting and all other spinner behavior unchanged.

## User Impact

Every long-running wizard step now has the little guy working alongside you — a rhythmic claw snip in OpenClaw coral — instead of anonymous dots. Purely cosmetic; no behavior, flags, or output-format changes for scripts/CI.

## Evidence

- `node scripts/run-vitest.mjs src/wizard/clack-prompter.test.ts` — 13/13 pass, including new coverage: rich TTY passes claw frames + accent styleFrame + 120ms delay to clack; non-rich path passes no custom options. Test env stubs (`isTTY` descriptor, env) restored in afterEach.
- `git diff --check` clean; oxfmt clean on touched files.
- Two-file diff (`src/wizard/clack-prompter.ts` + test), no new dependencies, no string/i18n changes.
