### PR TITLE
fix(ignore-rules): re-throw non-ENOENT errors from ignore file reads

### DIFF
--- a/src/shared/ignore-rules.test.ts
+++ b/src/shared/ignore-rules.test.ts
@@ -1,0 +1,79 @@
+// Tests ignore-rules file loading: empty catch, ENOENT suppression, and non-ENOENT re-throw.
+import path from "node:path";
+import ignore from "ignore";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { existsSyncMock, readFileSyncMock } = vi.hoisted(() => ({
+  existsSyncMock: vi.fn<(p: import("node:fs").PathLike) => boolean>(),
+  readFileSyncMock: vi.fn<(p: import("node:fs").PathLike, ...rest: unknown[]) => string>(),
+}));
+
+vi.mock("node:fs", async () => {
+  const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
+  return {
+    ...actual,
+    existsSync: existsSyncMock,
+    readFileSync: readFileSyncMock,
+  };
+});
+
+let addIgnoreRules: typeof import("./ignore-rules.js").addIgnoreRules;
+
+beforeAll(async () => {
+  ({ addIgnoreRules } = await import("./ignore-rules.js"));
+});
+
+beforeEach(() => {
+  existsSyncMock.mockReset();
+  readFileSyncMock.mockReset();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("addIgnoreRules", () => {
+  it("returns the matcher unchanged when no ignore files exist", () => {
+    existsSyncMock.mockReturnValue(false);
+    const ig = ignore();
+    expect(addIgnoreRules("/root/sub", "/root", ig)).toBe(ig);
+  });
+
+  it("silently skips a file that vanishes between exists and read (ENOENT)", () => {
+    existsSyncMock.mockReturnValue(true);
+    readFileSyncMock.mockImplementation(() => {
+      const err = new Error("ENOENT: no such file") as NodeJS.ErrnoException;
+      err.code = "ENOENT";
+      throw err;
+    });
+    expect(() => addIgnoreRules("/root", "/root", ignore())).not.toThrow();
+  });
+
+  it("re-throws permission-denied errors (EACCES)", () => {
+    existsSyncMock.mockReturnValue(true);
+    readFileSyncMock.mockImplementation(() => {
+      const err = new Error("EACCES: permission denied") as NodeJS.ErrnoException;
+      err.code = "EACCES";
+      throw err;
+    });
+    expect(() => addIgnoreRules("/root", "/root", ignore())).toThrow("EACCES");
+  });
+
+  it("re-throws disk I/O errors (EIO)", () => {
+    existsSyncMock.mockReturnValue(true);
+    readFileSyncMock.mockImplementation(() => {
+      const err = new Error("EIO: i/o error") as NodeJS.ErrnoException;
+      err.code = "EIO";
+      throw err;
+    });
+    expect(() => addIgnoreRules("/root", "/root", ignore())).toThrow("EIO");
+  });
+
+  it("loads and applies rules from an existing .gitignore file", () => {
+    existsSyncMock.mockImplementation((p) => path.basename(String(p)) === ".gitignore");
+    readFileSyncMock.mockReturnValue("*.log\n");
+    const ig = ignore();
+    addIgnoreRules("/root/sub", "/root", ig);
+    expect(ig.ignores("sub/app.log")).toBe(true);
+  });
+});

--- a/src/shared/ignore-rules.ts
+++ b/src/shared/ignore-rules.ts
@@ -21,7 +21,11 @@ export function addIgnoreRules(dir: string, rootDir: string, ig = ignore()) {
     try {
       const content = readFileSync(ignorePath, "utf-8");
       ig.add(content.split(/\r?\n/).map((line) => prefixIgnorePattern(line, prefix)));
-    } catch {}
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+        throw err;
+      }
+    }
   }
   return ig;
 }


### PR DESCRIPTION
## What Problem This Solves

The empty catch block in `addIgnoreRules` (`src/shared/ignore-rules.ts:24`) silently swallowed all `readFileSync` errors — including permission denials (`EACCES`), disk errors (`EIO`), and corrupted files. If `existsSync` returned true but `readFileSync` subsequently failed, the error was invisible and the ignore file's rules were silently omitted.

## Why This Change Was Made

Only `ENOENT` (file vanished between `existsSync` and `readFileSync` due to a race condition) should be suppressed. This is the expected and harmless race: the file existed during the `existsSync` check but was deleted before `readFileSync`. All other errors — `EACCES`, `EIO`, corrupted files — indicate real problems that callers must be able to handle.

The fix checks `(err as NodeJS.ErrnoException).code !== "ENOENT"` and re-throws non-ENOENT errors.

## User Impact

**Before**: Permission errors and disk I/O failures during ignore-file loading were silently discarded. Operators had no way to detect that their `.gitignore` or `.ignore` files couldn't be read.

**After**: Non-ENOENT errors propagate to callers, making real filesystem failures visible. The common case (file deleted between the exists check and the read) continues to be silently handled.

## Evidence

- `node scripts/run-vitest.mjs src/shared/ignore-rules.test.ts` — **5/5 passed** (new test file)
  - ENOENT: silently suppressed (race condition handled)
  - EACCES: re-thrown with descriptive error
  - EIO: re-thrown with descriptive error
  - No ignore files: matcher returned unchanged
  - Valid .gitignore: rules loaded and applied correctly
- `git diff --check` passed
- Targeted formatting passed on changed files