### PR TITLE
fix(skills): keep blank env requirements unsatisfied

### DIFF
--- a/src/skills/discovery/status.test.ts
+++ b/src/skills/discovery/status.test.ts
@@ -13,6 +13,30 @@ type SkillStatus = ReturnType<typeof buildWorkspaceSkillStatus>["skills"][number
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 describe("buildWorkspaceSkillStatus", () => {
+  it("reports blank env requirements as missing", () => {
+    const envName = "OPENCLAW_TEST_BLANK_SKILL_STATUS";
+    const original = process.env[envName];
+    process.env[envName] = "   ";
+    try {
+      const report = buildWorkspaceSkillStatus("/tmp/ws", {
+        entries: [
+          createEntry("blank-env", {
+            metadata: { primaryEnv: envName, requires: { env: [envName] } },
+          }),
+        ],
+      });
+
+      expect(report.skills[0]?.eligible).toBe(false);
+      expect(report.skills[0]?.missing.env).toEqual([envName]);
+    } finally {
+      if (original === undefined) {
+        delete process.env[envName];
+      } else {
+        process.env[envName] = original;
+      }
+    }
+  });
+
   it("surfaces valid ClawHub linkage and local Skill Card metadata", async () => {
     const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-skill-status-"));
     try {

--- a/src/skills/discovery/status.ts
+++ b/src/skills/discovery/status.ts
@@ -16,6 +16,7 @@ import { resolveBundledSkillsContext } from "../loading/bundled-context.js";
 import {
   hasBinary,
   isBundledSkillAllowed,
+  isSkillEnvRequirementSatisfied,
   isSkillConfigPathTruthy,
   resolveBundledAllowlist,
   resolveSkillConfig,
@@ -269,11 +270,11 @@ function buildSkillStatus(
   const blockedByAgentFilter = agentSkillFilter !== undefined && !indexed.agentAllowed;
   const always = entry.metadata?.always === true;
   const isEnvSatisfied = (envName: string) =>
-    Boolean(
-      process.env[envName] ||
-      skillConfig?.env?.[envName] ||
-      (skillConfig?.apiKey && entry.metadata?.primaryEnv === envName),
-    );
+    isSkillEnvRequirementSatisfied({
+      envName,
+      skillConfig,
+      primaryEnv: entry.metadata?.primaryEnv,
+    });
   const isConfigSatisfied = (pathStr: string) => isSkillConfigPathTruthy(config, pathStr);
   const skillSource = indexed.source;
   const bundled = indexed.bundled;

--- a/src/skills/loading/config.ts
+++ b/src/skills/loading/config.ts
@@ -56,6 +56,22 @@ export function resolveSkillConfig(
   return entry;
 }
 
+export function isSkillEnvRequirementSatisfied(params: {
+  envName: string;
+  skillConfig?: SkillConfig;
+  primaryEnv?: string;
+}): boolean {
+  const { envName, skillConfig, primaryEnv } = params;
+  return (
+    normalizeOptionalString(process.env[envName]) !== undefined ||
+    normalizeOptionalString(skillConfig?.env?.[envName]) !== undefined ||
+    (primaryEnv === envName &&
+      (typeof skillConfig?.apiKey === "string"
+        ? normalizeOptionalString(skillConfig.apiKey) !== undefined
+        : skillConfig?.apiKey !== undefined))
+  );
+}
+
 function normalizeAllowlist(input: unknown): ReadonlySet<string> | undefined {
   if (!input) {
     return undefined;
@@ -113,11 +129,11 @@ export function shouldIncludeSkill(params: {
     hasRemoteBin: eligibility?.remote?.hasBin,
     hasAnyRemoteBin: eligibility?.remote?.hasAnyBin,
     hasEnv: (envName) =>
-      Boolean(
-        process.env[envName] ||
-        skillConfig?.env?.[envName] ||
-        (skillConfig?.apiKey && entry.metadata?.primaryEnv === envName),
-      ),
+      isSkillEnvRequirementSatisfied({
+        envName,
+        skillConfig,
+        primaryEnv: entry.metadata?.primaryEnv,
+      }),
     isConfigPathTruthy: (configPath) => isSkillConfigPathTruthy(config, configPath),
   });
 }

--- a/src/skills/loading/config.ts
+++ b/src/skills/loading/config.ts
@@ -5,6 +5,7 @@ import {
 } from "@openclaw/normalization-core/string-coerce";
 import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { hasConfiguredSecretInput } from "../../config/types.secrets.js";
 import type { SkillConfig } from "../../config/types.skills.js";
 import {
   evaluateRuntimeEligibility,
@@ -65,10 +66,7 @@ export function isSkillEnvRequirementSatisfied(params: {
   return (
     normalizeOptionalString(process.env[envName]) !== undefined ||
     normalizeOptionalString(skillConfig?.env?.[envName]) !== undefined ||
-    (primaryEnv === envName &&
-      (typeof skillConfig?.apiKey === "string"
-        ? normalizeOptionalString(skillConfig.apiKey) !== undefined
-        : skillConfig?.apiKey !== undefined))
+    (primaryEnv === envName && hasConfiguredSecretInput(skillConfig?.apiKey))
   );
 }
 

--- a/src/skills/loading/skills.test.ts
+++ b/src/skills/loading/skills.test.ts
@@ -540,6 +540,7 @@ describe("shouldIncludeSkill", () => {
     withClearedEnv([envName], () => {
       expect(shouldInclude(resolvedSkillApiKeyConfig("env-skill", "   "))).toBe(false);
       expect(shouldInclude(resolvedSkillApiKeyConfig("env-skill", " example "))).toBe(true);
+      expect(shouldInclude(rawSkillApiKeyRefConfig("env-skill"))).toBe(true);
     });
   });
 

--- a/src/skills/loading/skills.test.ts
+++ b/src/skills/loading/skills.test.ts
@@ -24,6 +24,7 @@ import {
   type SkillsHomeEnvSnapshot,
 } from "../test-support/home-env.test-support.js";
 import type { SkillEntry, SkillSnapshot } from "../types.js";
+import { shouldIncludeSkill } from "./config.js";
 import { buildWorkspaceSkillsPrompt } from "./workspace.js";
 
 vi.mock("./plugin-skills.js", () => ({
@@ -499,6 +500,61 @@ describe("buildWorkspaceSkillsPrompt", () => {
     expect(prompt).not.toContain("hidden-skill");
     expect(prompt).not.toContain("Hidden from the prompt");
     expect(prompt).not.toContain(path.join(hiddenSkillDir, "SKILL.md"));
+  });
+});
+
+describe("shouldIncludeSkill", () => {
+  const envName = "OPENCLAW_TEST_SKILL_REQUIREMENT";
+  const entry = makeSkillEntry("env-skill", {
+    primaryEnv: envName,
+    requires: { env: [envName] },
+  });
+
+  function shouldInclude(config?: OpenClawConfig): boolean {
+    return shouldIncludeSkill({ entry, config, bundledAllowlist: undefined });
+  }
+
+  it("requires non-blank host and configured env values", () => {
+    withClearedEnv([envName], () => {
+      expect(shouldInclude()).toBe(false);
+
+      process.env[envName] = "   ";
+      expect(shouldInclude()).toBe(false);
+
+      process.env[envName] = " example ";
+      expect(shouldInclude()).toBe(true);
+
+      delete process.env[envName];
+      expect(
+        shouldInclude({ skills: { entries: { "env-skill": { env: { [envName]: "   " } } } } }),
+      ).toBe(false);
+      expect(
+        shouldInclude({
+          skills: { entries: { "env-skill": { env: { [envName]: " example " } } } },
+        }),
+      ).toBe(true);
+    });
+  });
+
+  it("requires a non-blank primary apiKey", () => {
+    withClearedEnv([envName], () => {
+      expect(shouldInclude(resolvedSkillApiKeyConfig("env-skill", "   "))).toBe(false);
+      expect(shouldInclude(resolvedSkillApiKeyConfig("env-skill", " example "))).toBe(true);
+    });
+  });
+
+  it("keeps always-on skills eligible without credentials", () => {
+    withClearedEnv([envName], () => {
+      expect(
+        shouldIncludeSkill({
+          entry: makeSkillEntry("always-skill", {
+            always: true,
+            requires: { env: [envName] },
+          }),
+          bundledAllowlist: undefined,
+        }),
+      ).toBe(true);
+    });
   });
 });
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users with whitespace-only skill credential environment values could have those skills loaded and reported as eligible even though no usable credential was available.

## Why This Change Was Made

Skill loading and skill status now share one non-blank requirement check for host environment values, per-skill environment overrides, and primary API keys. The change preserves configured SecretRef eligibility and does not alter always-on, bundled allowlist, remote platform, or binary requirement behavior.

## User Impact

Skills that require credentials are no longer exposed to agents or reported as ready when their configured value contains only whitespace. Valid credentials continue to work as before.

## Evidence

AI-assisted.

Real production-path proof was run on a real Linux x86_64 host (`Linux 6.8.0-134-generic`, Node `v24.18.0`) by directly invoking the exported production loading and status functions. No mocks or network substitutes were used.

Exact harness command (run once in a detached latest-main worktree and once on this branch):

```bash
node --import tsx --input-type=module - <<'EOF'
import { shouldIncludeSkill } from "./src/skills/loading/config.ts";
import { buildWorkspaceSkillStatus } from "./src/skills/discovery/status.ts";
const key = "HUNT_BLANK_ENV";
const entry = {
  skill: {
    name: "proof-skill", description: "proof",
    filePath: "/tmp/proof-skill/SKILL.md", baseDir: "/tmp/proof-skill",
    source: "test",
    sourceInfo: { path: "/tmp/proof-skill/SKILL.md", source: "test", scope: "temporary", origin: "top-level" },
    disableModelInvocation: false,
  },
  frontmatter: {},
  metadata: { primaryEnv: key, requires: { env: [key] } },
};
for (const [label, value] of [["missing", undefined], ["blank", "   "], ["valid", " token "]]) {
  if (value === undefined) delete process.env[key]; else process.env[key] = value;
  const included = shouldIncludeSkill({ entry, bundledAllowlist: undefined });
  const status = buildWorkspaceSkillStatus("/tmp/proof-workspace", { entries: [entry] }).skills[0];
  console.log(JSON.stringify({ label, included, eligible: status?.eligible, missingEnv: status?.missing.env }));
}
delete process.env[key];
EOF
```

Before, on latest `upstream/main` `57ae43a89`:

```text
{"label":"missing","included":false,"eligible":false,"missingEnv":["HUNT_BLANK_ENV"]}
{"label":"blank","included":true,"eligible":true,"missingEnv":[]}
{"label":"valid","included":true,"eligible":true,"missingEnv":[]}
```

Premise: the shared normalization contract turns whitespace-only strings into no value while trimming valid padded strings:

```bash
node --import tsx --input-type=module -e 'import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce"; console.log(JSON.stringify({ blank: normalizeOptionalString("   "), padded: normalizeOptionalString(" token ") }));'
```

```text
{"padded":"token"}
```

(`blank` is omitted by `JSON.stringify` because it is `undefined`.)

After, on this branch at `bc66063d5`:

```text
{"label":"missing","included":false,"eligible":false,"missingEnv":["HUNT_BLANK_ENV"]}
{"label":"blank","included":false,"eligible":false,"missingEnv":["HUNT_BLANK_ENV"]}
{"label":"valid","included":true,"eligible":true,"missingEnv":[]}
```

The missing and valid cases are negative controls: missing remains blocked, while a valid padded value remains eligible. Focused regression coverage also exercises blank and valid per-skill env values, blank and valid primary API keys, status reporting, always-on behavior, and the existing SecretRef path.

```bash
node scripts/run-vitest.mjs src/skills/loading/skills.test.ts src/skills/discovery/status.test.ts
```

```text
Test Files  2 passed (2)
Tests       40 passed (40)
```

Final structured review:

```text
autoreview clean: no accepted/actionable findings reported
overall: patch is correct (0.96)
```

Not tested: no external skill execution was attempted because this change is entirely in pre-execution eligibility and status projection; the proof drives both exported production decision paths directly.
