### PR TITLE
fix(agents): use fatal UTF-8 decoding for provider JSON responses

### DIFF
--- a/src/agents/provider-http-errors.test.ts
+++ b/src/agents/provider-http-errors.test.ts
@@ -360,18 +360,6 @@ describe("provider error utils", () => {
     expect(streamed.getReadCount()).toBeLessThan(20);
   });
 
-  it("rejects provider text responses with invalid UTF-8 bytes instead of silently replacing them", async () => {
-    const invalidUtf8Bytes = new Uint8Array([0x48, 0x65, 0x6c, 0x6c, 0x6f, 0xff, 0x21]);
-    const response = new Response(invalidUtf8Bytes.buffer, {
-      status: 200,
-      headers: { "Content-Type": "text/plain" },
-    });
-
-    await expect(readProviderTextResponse(response, "Provider text failed")).rejects.toThrow(
-      TypeError,
-    );
-  });
-
   it("rejects provider JSON responses with invalid UTF-8 bytes instead of silently replacing them", async () => {
     const invalidUtf8Bytes = new Uint8Array([0x7b, 0x22, 0x6b, 0x65, 0x79, 0x22, 0x3a, 0xff, 0x7d]);
     const response = new Response(invalidUtf8Bytes.buffer, {

--- a/src/agents/provider-http-errors.test.ts
+++ b/src/agents/provider-http-errors.test.ts
@@ -360,6 +360,31 @@ describe("provider error utils", () => {
     expect(streamed.getReadCount()).toBeLessThan(20);
   });
 
+  it("rejects provider text responses with invalid UTF-8 bytes instead of silently replacing them", async () => {
+    const invalidUtf8Bytes = new Uint8Array([0x48, 0x65, 0x6c, 0x6c, 0x6f, 0xff, 0x21]);
+    const response = new Response(invalidUtf8Bytes.buffer, {
+      status: 200,
+      headers: { "Content-Type": "text/plain" },
+    });
+
+    await expect(readProviderTextResponse(response, "Provider text failed")).rejects.toThrow(
+      TypeError,
+    );
+  });
+
+  it("rejects provider JSON responses with invalid UTF-8 bytes instead of silently replacing them", async () => {
+    const invalidUtf8Bytes = new Uint8Array([0x7b, 0x22, 0x6b, 0x65, 0x79, 0x22, 0x3a, 0xff, 0x7d]);
+    const response = new Response(invalidUtf8Bytes.buffer, {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+
+    await expect(readProviderJsonResponse(response, "Provider JSON failed")).rejects.toMatchObject({
+      message: "Provider JSON failed: malformed JSON response",
+      cause: expect.any(TypeError) as unknown,
+    });
+  });
+
   it("caps successful text responses instead of buffering oversized bodies", async () => {
     const streamed = createStreamingTextResponse({
       chunkCount: 20,

--- a/src/agents/provider-http-errors.ts
+++ b/src/agents/provider-http-errors.ts
@@ -86,7 +86,7 @@ export async function readProviderTextResponse(
     onOverflow: ({ maxBytes: maxBytesLocal }) =>
       new Error(`${label}: text response exceeds ${maxBytesLocal} bytes`),
   });
-  return new TextDecoder().decode(bytes);
+  return new TextDecoder("utf-8", { fatal: true }).decode(bytes);
 }
 
 /** Formats common provider JSON error payload shapes into one readable detail string. */
@@ -341,7 +341,7 @@ export async function readProviderJsonResponse<T>(
       new Error(`${label}: JSON response exceeds ${maxBytesLocal} bytes`),
   });
   try {
-    return JSON.parse(new TextDecoder().decode(bytes)) as T;
+    return JSON.parse(new TextDecoder("utf-8", { fatal: true }).decode(bytes)) as T;
   } catch (cause) {
     throw new Error(`${label}: malformed JSON response`, { cause });
   }

--- a/src/agents/provider-http-errors.ts
+++ b/src/agents/provider-http-errors.ts
@@ -86,7 +86,7 @@ export async function readProviderTextResponse(
     onOverflow: ({ maxBytes: maxBytesLocal }) =>
       new Error(`${label}: text response exceeds ${maxBytesLocal} bytes`),
   });
-  return new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  return new TextDecoder().decode(bytes);
 }
 
 /** Formats common provider JSON error payload shapes into one readable detail string. */


### PR DESCRIPTION
## Summary
Use `TextDecoder("utf-8", { fatal: true })` in `readProviderJsonResponse` so invalid UTF-8 bytes from provider JSON responses are caught as a clear `TypeError` (wrapped as the `cause` on the existing `"malformed JSON response"` error) instead of silently producing U+FFFD replacement characters that fail `JSON.parse` with a misleading error. The generic `readProviderTextResponse` intentionally retains compatible forgiving decoding.

## What Problem This Solves
When a provider JSON endpoint returns malformed UTF-8 byte sequences, the forgiving `TextDecoder()` silently inserts U+FFFD replacement characters. The subsequent `JSON.parse` then fails with `SyntaxError: Unexpected token '�'`, which is misleading — it says JSON is malformed when the real root cause is invalid UTF-8 encoding.

**Code evidence**: [provider-http-errors.ts:344](src/agents/provider-http-errors.ts#L344) — `new TextDecoder().decode(bytes)` in `readProviderJsonResponse`.

## Root Cause
- `TextDecoder()` defaults to `fatal: false` per the WHATWG Encoding standard
- JSON is required to be UTF-8 by RFC 8259, so fatal decoding is the correct wire contract
- The existing try/catch already wraps errors as `"malformed JSON response"` — with `{ fatal: true }`, the `cause` is now a precise `TypeError` instead of a confusing `SyntaxError`

## Why This Fix
- **JSON path only**: Fatal decoding applied only to `readProviderJsonResponse` where UTF-8 is the wire contract. Generic `readProviderTextResponse` keeps compatible forgiving behavior.
- **Better diagnostics**: The `cause` chain now preserves the real root cause (`TypeError: The encoded data was not valid for encoding utf-8`) instead of the misleading `SyntaxError` from U+FFFD-in-JSON
- **Minimal change**: 1 line changed in source, 1 test added

## User Impact
- **Before**: Provider returns JSON with invalid UTF-8 byte → `readProviderJsonResponse` throws `Error: Provider JSON: malformed JSON response` (cause: `SyntaxError` about `�`)
- **After**: Provider returns JSON with invalid UTF-8 byte → `readProviderJsonResponse` throws `Error: Provider JSON: malformed JSON response` (cause: `TypeError: The encoded data was not valid for encoding utf-8`)

## Evidence
- **Before** (upstream/main): JSON path fails with misleading `SyntaxError` on U+FFFD
- **After** (with fix): JSON path wraps precise `TypeError` as cause on the existing error

## Real Behavior Proof

```bash
$ node --import tsx scripts/proof-textdecoder-fatal.mjs
=== Test 1: readProviderTextResponse (valid UTF-8) ===
Result: "Hello, world!"
PASS

=== Test 2: readProviderJsonResponse (valid JSON) ===
Result: {"ok":true}
PASS

=== Test 3: readProviderJsonResponse (invalid UTF-8) ===
PASS: Error wraps TypeError cause for invalid UTF-8
  message: Provider JSON: malformed JSON response
  cause: The encoded data was not valid for encoding utf-8

ALL PASS
```

## Tests and Validation
- `npx vitest run src/agents/provider-http-errors.test.ts` — 36 passed
- Test added: `rejects provider JSON responses with invalid UTF-8 bytes instead of silently replacing them`