### PR TITLE
fix(state): declare apns_registration_tombstones STRICT

### DIFF
--- a/src/state/openclaw-state-schema.generated.ts
+++ b/src/state/openclaw-state-schema.generated.ts
@@ -645,7 +645,7 @@ CREATE INDEX IF NOT EXISTS idx_apns_registrations_updated
 CREATE TABLE IF NOT EXISTS apns_registration_tombstones (
   node_id TEXT NOT NULL PRIMARY KEY,
   deleted_at_ms INTEGER NOT NULL
-);
+) STRICT;
 
 CREATE TABLE IF NOT EXISTS node_host_config (
   config_key TEXT NOT NULL PRIMARY KEY,

--- a/src/state/openclaw-state-schema.sql
+++ b/src/state/openclaw-state-schema.sql
@@ -640,7 +640,7 @@ CREATE INDEX IF NOT EXISTS idx_apns_registrations_updated
 CREATE TABLE IF NOT EXISTS apns_registration_tombstones (
   node_id TEXT NOT NULL PRIMARY KEY,
   deleted_at_ms INTEGER NOT NULL
-);
+) STRICT;
 
 CREATE TABLE IF NOT EXISTS node_host_config (
   config_key TEXT NOT NULL PRIMARY KEY,


### PR DESCRIPTION
## What Problem This Solves

Main is broken: gateway startup migration throws `Canonical SQLite schema contains non-STRICT tables: apns_registration_tombstones`, failing every gateway-boot test across the node/contract/QA-smoke shards.

## Why This Change Was Made

`src/infra/sqlite-strict.ts` requires every OpenClaw-owned canonical table to be declared `STRICT` (no allowlist). `apns_registration_tombstones`, added in #108543, was declared without `STRICT` while its sibling `apns_registrations` (and `node_host_config`, etc.) are `STRICT`. This regenerates the canonical schema with `) STRICT;`.

## User Impact

Unblocks CI for all open PRs and restores clean gateway startup. No behavior change beyond the table now enforcing STRICT column typing, consistent with every other canonical table.

## Evidence

- `src/state/openclaw-state-schema.sql` + regenerated `openclaw-state-schema.generated.ts` now declare the table `STRICT`.
- `node scripts/run-vitest.mjs src/infra/sqlite-strict.test.ts` → 14/14 passed.
- `node scripts/generate-kysely-types.mjs --verify` clean (generated matches source).