### PR TITLE
fix(ui): hydrate Skills security verdicts after route preload

### DIFF
--- a/ui/src/e2e/skills-security-verdicts.e2e.test.ts
+++ b/ui/src/e2e/skills-security-verdicts.e2e.test.ts
@@ -1,0 +1,165 @@
+// Control UI E2E: route-preloaded Skills hydrates ClawHub security verdicts.
+import { mkdir, rm } from "node:fs/promises";
+import path from "node:path";
+import { chromium, type Browser, type BrowserContext, type Page } from "playwright";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  canRunPlaywrightChromium,
+  installMockGateway,
+  resolvePlaywrightChromiumExecutablePath,
+  startControlUiE2eServer,
+  type ControlUiE2eServer,
+} from "../test-helpers/control-ui-e2e.ts";
+
+const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
+const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
+const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
+const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+const updateScreenshots = process.env.OPENCLAW_UPDATE_E2E_SCREENSHOTS === "1";
+const artifactDir = path.resolve(
+  process.cwd(),
+  ".artifacts/control-ui-e2e/skills-security-verdicts",
+);
+const desktopViewport = { height: 1000, width: 1440 };
+
+const linkedSkillStatusReport = {
+  workspaceDir: "/tmp/openclaw-e2e/workspace",
+  managedSkillsDir: "/tmp/openclaw-e2e/skills",
+  skills: [
+    {
+      name: "AgentReceipt",
+      description: "Linked ClawHub skill used for security badge proof.",
+      source: "workspace",
+      filePath: "/tmp/openclaw-e2e/workspace/skills/agentreceipt/SKILL.md",
+      baseDir: "/tmp/openclaw-e2e/workspace/skills/agentreceipt",
+      skillKey: "agentreceipt",
+      bundled: false,
+      primaryEnv: undefined,
+      homepage: "https://clawhub.ai/openclaw/skills/agentreceipt",
+      always: false,
+      disabled: false,
+      blockedByAllowlist: false,
+      blockedByAgentFilter: false,
+      eligible: true,
+      requirements: { bins: [], env: [], config: [], os: [] },
+      missing: { bins: [], env: [], config: [], os: [] },
+      configChecks: [],
+      install: [],
+      clawhub: {
+        status: "linked",
+        valid: true,
+        registry: "https://clawhub.ai",
+        slug: "agentreceipt",
+        installedVersion: "1.2.3",
+        installedAt: 1_700_000_000_000,
+      },
+    },
+  ],
+};
+
+const cleanSecurityVerdicts = {
+  schema: "openclaw.skills.security-verdicts.v1",
+  items: [
+    {
+      registry: "https://clawhub.ai",
+      ok: true,
+      decision: "pass",
+      reasons: [],
+      requestedSlug: "agentreceipt",
+      requestedVersion: "1.2.3",
+      slug: "agentreceipt",
+      version: "1.2.3",
+      securityStatus: "clean",
+      securityPassed: true,
+    },
+  ],
+};
+
+let browser: Browser;
+let server: ControlUiE2eServer;
+
+async function captureScreenshot(page: Page, name: string): Promise<void> {
+  if (!updateScreenshots) {
+    return;
+  }
+  await mkdir(artifactDir, { recursive: true });
+  await page.locator(".content").screenshot({
+    animations: "disabled",
+    caret: "hide",
+    path: path.join(artifactDir, name),
+  });
+}
+
+async function newContext(viewport = desktopViewport): Promise<BrowserContext> {
+  return browser.newContext({
+    locale: "en-US",
+    serviceWorkers: "block",
+    viewport,
+  });
+}
+
+describeControlUiE2e("Control UI Skills security verdicts route-preload E2E", () => {
+  beforeAll(async () => {
+    if (!chromiumAvailable) {
+      throw new Error(
+        `Playwright Chromium is not installed at ${chromiumExecutablePath}. Run \`pnpm --dir ui exec playwright install chromium\`, or set OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM=1 only when intentionally skipping this lane.`,
+      );
+    }
+    if (updateScreenshots) {
+      await rm(artifactDir, { force: true, recursive: true });
+      await mkdir(artifactDir, { recursive: true });
+    }
+    server = await startControlUiE2eServer();
+    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
+  });
+
+  afterAll(async () => {
+    await browser?.close();
+    await server?.close();
+  });
+
+  it("shows Clean for linked skills after route-preloaded skills.status hydrates securityVerdicts", async () => {
+    const context = await newContext();
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page, {
+      featureMethods: ["skills.status", "skills.securityVerdicts", "agents.list"],
+      methodResponses: {
+        "skills.status": linkedSkillStatusReport,
+        "skills.securityVerdicts": cleanSecurityVerdicts,
+      },
+    });
+
+    try {
+      const response = await page.goto(`${server.baseUrl}skills`);
+      expect(response?.status()).toBe(200);
+
+      // Route loader preloads skills.status; page then hydrates bulk verdicts.
+      await gateway.waitForRequest("skills.status");
+      await gateway.waitForRequest("skills.securityVerdicts");
+
+      await page.locator("openclaw-skills-page").waitFor({ state: "attached" });
+      await page.locator(".settings-row__title", { hasText: "AgentReceipt" }).waitFor({
+        state: "visible",
+        timeout: 10_000,
+      });
+      // English locale (context locale en-US): clean pass → "Clean", not "Unavailable".
+      const cleanBadge = page.locator(".settings-row__control").getByText("Clean", { exact: true });
+      await cleanBadge.waitFor({ state: "visible", timeout: 10_000 });
+      await expect
+        .poll(async () =>
+          page.locator(".settings-row__control").getByText("Unavailable", { exact: true }).count(),
+        )
+        .toBe(0);
+
+      await captureScreenshot(page, "01-skills-route-preload-clean.png");
+
+      // Route path must not re-fetch skills.status after the loader already provided it.
+      const statusRequests = await gateway.getRequests("skills.status");
+      const verdictRequests = await gateway.getRequests("skills.securityVerdicts");
+      expect(statusRequests.length).toBe(1);
+      expect(verdictRequests.length).toBe(1);
+    } finally {
+      await context.close().catch(() => {});
+    }
+  });
+});

--- a/ui/src/lib/skills/index.ts
+++ b/ui/src/lib/skills/index.ts
@@ -463,7 +463,12 @@ export async function loadSkillCard(state: SkillsState, skillKey: string) {
   }
 }
 
-async function loadClawHubSecurityVerdicts(state: SkillsState, report: SkillStatusReport) {
+/**
+ * Load bulk ClawHub security verdicts for linked skills in a status report.
+ * Call this after route-preloaded `skills.status` so first paint does not leave
+ * the security badge stuck on Unavailable while agents/report already exist.
+ */
+export async function loadClawHubSecurityVerdicts(state: SkillsState, report: SkillStatusReport) {
   const client = state.client;
   const agentScope = captureSkillsAgentScope(state);
   if (!client || !state.connected || !reportHasLinkedClawHubSkills(report)) {

--- a/ui/src/pages/gateway-source-replacement.test.ts
+++ b/ui/src/pages/gateway-source-replacement.test.ts
@@ -235,7 +235,86 @@ describe("gateway source replacement across reconnect with a reused client", () 
     await page.updateComplete;
 
     expect(page.skillsReport).toBe(report);
+    // No linked ClawHub skills → no skills.securityVerdicts request either.
     expect(request).not.toHaveBeenCalled();
+  });
+
+  it("hydrates skills.securityVerdicts when route data preloads linked skills", async () => {
+    const request = vi.fn(async (method: string) => {
+      if (method === "skills.securityVerdicts") {
+        return {
+          schema: "openclaw.skills.security-verdicts.v1",
+          items: [
+            {
+              registry: "https://clawhub.ai",
+              ok: true,
+              decision: "pass",
+              reasons: [],
+              requestedSlug: "agentreceipt",
+              requestedVersion: "1.2.3",
+              slug: "agentreceipt",
+              version: "1.2.3",
+              securityStatus: "clean",
+              securityPassed: true,
+            },
+          ],
+        };
+      }
+      return {};
+    });
+    const client = { request } as unknown as GatewayBrowserClient;
+    const agentsList = { defaultId: "main", agents: [{ id: "main" }] };
+    const context = contextWithClient(client, { connected: true, agentsList });
+    const report = {
+      skills: [
+        {
+          skillKey: "agentreceipt",
+          name: "AgentReceipt",
+          source: "workspace",
+          clawhub: {
+            status: "linked",
+            valid: true,
+            registry: "https://clawhub.ai",
+            slug: "agentreceipt",
+            installedVersion: "1.2.3",
+            installedAt: 123,
+          },
+        },
+      ],
+    } as unknown as SkillsRouteData["report"];
+    const page = createPage("openclaw-skills-page", context) as TestPage & {
+      routeData: SkillsRouteData;
+      skillsReport: SkillsRouteData["report"];
+      clawhubVerdicts: Record<string, { securityStatus?: string; decision?: string }>;
+    };
+    page.routeData = {
+      gateway: context.gateway,
+      gatewaySnapshot: context.gateway.snapshot,
+      agents: context.agents,
+      agentsList,
+      selectedAgentId: "main",
+      report,
+      error: null,
+    } as unknown as SkillsRouteData;
+
+    document.body.append(page);
+    await page.updateComplete;
+    await vi.waitFor(() =>
+      expect(request).toHaveBeenCalledWith("skills.securityVerdicts", expect.anything()),
+    );
+    await vi.waitFor(() => expect(Object.keys(page.clawhubVerdicts).length).toBeGreaterThan(0));
+
+    // Route loader already provided skills.status; do not re-fetch it on first paint.
+    expect(request).not.toHaveBeenCalledWith("skills.status", expect.anything());
+    expect(page.skillsReport).toBe(report);
+    expect(page.clawhubVerdicts).toEqual(
+      expect.objectContaining({
+        "https://clawhub.ai\u0000agentreceipt\u00001.2.3": expect.objectContaining({
+          decision: "pass",
+          securityStatus: "clean",
+        }),
+      }),
+    );
   });
 
   it("rejects skills route data from an earlier same-client gateway epoch", async () => {

--- a/ui/src/pages/skills/skills-page.ts
+++ b/ui/src/pages/skills/skills-page.ts
@@ -16,6 +16,7 @@ import {
   installFromClawHub,
   installSkill,
   loadClawHubDetail,
+  loadClawHubSecurityVerdicts,
   loadSkillCard,
   loadSkills,
   refreshSkills,
@@ -95,6 +96,8 @@ class SkillsPage extends OpenClawLightDomElement {
   private clawhubSearchTimer: ReturnType<typeof setTimeout> | null = null;
   private routeDataInitialized = false;
   private routeDataEnabled = true;
+  /** True after a hydrate attempt for the current skills report/source epoch. */
+  private clawhubVerdictsHydrated = false;
   private hasBoundGatewaySource = false;
   private sourceGeneration = 0;
   private readonly subscriptions = new SubscriptionsController(this)
@@ -197,6 +200,7 @@ class SkillsPage extends OpenClawLightDomElement {
     this.clawhubVerdicts = {};
     this.clawhubVerdictsLoading = false;
     this.clawhubVerdictsError = null;
+    this.clawhubVerdictsHydrated = false;
     this.skillCardContents = {};
     this.skillCardContentKeys = {};
     this.skillCardLoadingKey = null;
@@ -232,6 +236,24 @@ class SkillsPage extends OpenClawLightDomElement {
     this.skillsLoading = false;
     this.skillsReport = data.report;
     this.skillsError = data.error;
+    // Route data supplies skills.status only; security verdicts still need a
+    // separate hydrate so linked ClawHub skills are not stuck on Unavailable.
+    this.clawhubVerdictsHydrated = false;
+  }
+
+  /**
+   * Route loader + ensureInitialData used to stop after agents/report were
+   * present, which skipped loadSkills and left clawhubVerdicts empty forever.
+   */
+  private hydrateSecurityVerdictsIfNeeded() {
+    if (!this.connected || !this.client || !this.skillsReport) {
+      return;
+    }
+    if (this.clawhubVerdictsLoading || this.clawhubVerdictsHydrated) {
+      return;
+    }
+    this.clawhubVerdictsHydrated = true;
+    void loadClawHubSecurityVerdicts(this, this.skillsReport);
   }
 
   private ensureInitialData() {
@@ -242,6 +264,7 @@ class SkillsPage extends OpenClawLightDomElement {
       this.routeDataEnabled &&
       (this.routeData?.agentsList || this.routeData?.report || this.routeData?.error)
     ) {
+      this.hydrateSecurityVerdictsIfNeeded();
       return;
     }
     if (!this.agentsList && !this.agentsLoading) {
@@ -317,6 +340,7 @@ class SkillsPage extends OpenClawLightDomElement {
     if (previousAgentId !== this.skillsAgentId) {
       this.skillsDetailKey = null;
       this.skillsDetailTab = "overview";
+      this.clawhubVerdictsHydrated = false;
     }
     void loadSkills(this, { clearMessages: true });
   }


### PR DESCRIPTION
## What Problem This Solves

Control UI → Skills shows a yellow **Unavailable** security badge for linked ClawHub skills on first paint even when Gateway `skills.securityVerdicts` returns `ok=true`, `decision=pass`, `securityStatus=clean`. The skill remains usable; only the badge is wrong.

Closes #108647

## Why This Change Was Made

The Skills route loader preloads `agents` + `skills.status`, then `ensureInitialData()` short-circuits because route data already has a report. That skip path never called `loadSkills()`, which is the only place that requested `skills.securityVerdicts`. Empty `clawhubVerdicts` maps to `verdictLabel` → Unavailable.

## User Impact

- Linked ClawHub skills now hydrate security verdicts on first Skills page load without an extra `skills.status` round-trip.
- Operators see **Clean** (or the real security status) instead of a false **Unavailable** badge.
- No config, protocol, or Gateway API changes.

## Evidence

### Real behavior proof

| Field | Value |
|---|---|
| **Required proof class** | unit/source + Control UI browser session |
| **Preconditions** | Local openclaw checkout; Node/Vitest via `node scripts/run-vitest.mjs`; Playwright Chromium for Control UI E2E |
| **Verification ladder** | 1) Source repro: route data path left `clawhubVerdicts` empty → Unavailable. 2) Fix hydrates `skills.securityVerdicts` when route preloads a linked-skill report. 3) Focused Vitest proves the RPC and map populate without re-fetching `skills.status`. 4) Control UI browser session navigates to `/skills` with route-preloaded linked skill + clean verdict and shows the **Clean** badge (not Unavailable). |
| **Acceptance criteria** | With route-preloaded linked skill report, page requests `skills.securityVerdicts` once, fills `clawhubVerdicts` with clean pass item, does **not** re-fetch `skills.status` on that first paint; non-linked report still makes zero RPC calls; browser Skills page shows **Clean** for the linked skill after initial navigation. |
| **Artifact bar** | Focused Vitest pass log + Control UI E2E pass + screenshot of Clean badge after route-preloaded Skills navigation. |
| **Fail/stop conditions** | If hydrate skipped for linked reports, route path re-fetches `skills.status` unnecessarily, Clean badge missing / Unavailable remains, or focused/E2E tests fail. |

**Commands run (local macOS):**

```text
node scripts/run-vitest.mjs \
  ui/src/lib/skills/index.test.ts \
  ui/src/pages/gateway-source-replacement.test.ts \
  ui/src/pages/skills/view.test.ts

OPENCLAW_UPDATE_E2E_SCREENSHOTS=1 node scripts/run-vitest.mjs run \
  --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner \
  ui/src/e2e/skills-security-verdicts.e2e.test.ts
```

**Result:** unit/source 3 files, 62 tests passed; Control UI E2E 1 file, 1 test passed.

New regressions:
- `hydrates skills.securityVerdicts when route data preloads linked skills` in `ui/src/pages/gateway-source-replacement.test.ts`
- Control UI E2E: `shows Clean for linked skills after route-preloaded skills.status hydrates securityVerdicts` in `ui/src/e2e/skills-security-verdicts.e2e.test.ts`

**Browser visual proof (route-preload Skills → Clean badge):**

![Skills page after route-preload navigation: AgentReceipt shows Ready + Clean](https://litter.catbox.moe/bczu3l.png)

Observed: direct navigation to Skills with a linked ClawHub skill hydrates `skills.securityVerdicts` and renders **Clean** (green) instead of a false **Unavailable** badge. Gateway traffic: one `skills.status` (route loader) + one `skills.securityVerdicts` (page hydrate).

### Fix quality

- **compatibility:** UI-only; no config/defaults/protocol change.
- **performance:** one intended `skills.securityVerdicts` RPC on first Skills paint (same as non-route `loadSkills` path); no extra `skills.status`.
- **usability:** security badge matches Gateway verdict instead of false Unavailable.
- **security:** surfaces real verdict hydration rather than a missing-state Unavailable placeholder.

### ClawSweeper / rating

- Labels: `clawsweeper:queueable-fix`, `clawsweeper:fix-shape-clear`, `clawsweeper:source-repro`, `issue-rating: 🦞 diamond lobster`
- Direction followed: hydrate security verdicts when route data supplies skills report; do not leave first paint without the bulk verdict path.

