### PR TITLE
refactor(discord): extract channel test helpers

### DIFF
--- a/extensions/discord/src/channel.test.ts
+++ b/extensions/discord/src/channel.test.ts
@@ -11,6 +11,7 @@ import type { OpenClawConfig } from "./runtime-api.js";
 import * as sendModule from "./send.js";
 import { createDiscordSendReceipt } from "./send.receipt.js";
 import { EMPTY_DISCORD_TEST_CONFIG } from "./test-support/config.js";
+import { argAt, objectArgAt, recordField } from "./test-support/mock-calls.js";
 let discordPlugin: typeof import("./channel.js").discordPlugin;
 let setDiscordRuntime: typeof import("./runtime.js").setDiscordRuntime;
 
@@ -150,37 +151,6 @@ async function expectStaleProbeMetadataCleared(statusPatches: Array<Record<strin
         })),
     ).toEqual([{ bot: undefined, application: undefined }]),
   );
-}
-
-type MockWithCalls = {
-  mock: { calls: unknown[][] };
-};
-
-function objectArgAt(
-  mock: MockWithCalls,
-  callIndex: number,
-  argIndex: number,
-): Record<string, unknown> {
-  const value = mock.mock.calls[callIndex]?.[argIndex];
-  if (value === undefined || value === null || typeof value !== "object" || Array.isArray(value)) {
-    throw new Error(`expected call ${callIndex} argument ${argIndex} to be an object`);
-  }
-  return value as Record<string, unknown>;
-}
-
-function argAt(mock: MockWithCalls, callIndex: number, argIndex: number): unknown {
-  const call = mock.mock.calls[callIndex];
-  if (!call || !(argIndex in call)) {
-    throw new Error(`expected call ${callIndex} argument ${argIndex}`);
-  }
-  return call[argIndex];
-}
-
-function recordField(value: unknown, field: string): Record<string, unknown> {
-  if (value === undefined || value === null || typeof value !== "object" || Array.isArray(value)) {
-    throw new Error(`expected ${field} to be an object`);
-  }
-  return value as Record<string, unknown>;
 }
 
 afterEach(() => {

--- a/extensions/discord/src/test-support/mock-calls.ts
+++ b/extensions/discord/src/test-support/mock-calls.ts
@@ -1,0 +1,30 @@
+type MockWithCalls = {
+  mock: { calls: unknown[][] };
+};
+
+export function objectArgAt(
+  mock: MockWithCalls,
+  callIndex: number,
+  argIndex: number,
+): Record<string, unknown> {
+  const value = mock.mock.calls[callIndex]?.[argIndex];
+  if (value === undefined || value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`expected call ${callIndex} argument ${argIndex} to be an object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+export function argAt(mock: MockWithCalls, callIndex: number, argIndex: number): unknown {
+  const call = mock.mock.calls[callIndex];
+  if (!call || !(argIndex in call)) {
+    throw new Error(`expected call ${callIndex} argument ${argIndex}`);
+  }
+  return call[argIndex];
+}
+
+export function recordField(value: unknown, field: string): Record<string, unknown> {
+  if (value === undefined || value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`expected ${field} to be an object`);
+  }
+  return value as Record<string, unknown>;
+}


### PR DESCRIPTION
Related: #108584

## What Problem This Solves

The Discord channel test exceeded the repository max-lines limit on current main, failing hosted lint for every unrelated pull request that merges against it.

## Why This Change Was Made

Move the existing mock-call argument helpers into the Discord test-support directory and import them from the channel test. Their implementation is unchanged; no baseline suppression is added.

AI-assisted: yes. The final behavior-neutral extraction received a fresh clean autoreview.

## User Impact

No user-visible change. Maintainers regain green hosted lint, and the channel test returns below its enforced line limit.

## Evidence

- Reproduced in #108822 hosted CI: channel.test.ts reported 1002 counted lines.
- Blacksmith Testbox: max-lines ratchet passes and all 38 Discord channel tests pass.
- Full changed-surface gate passes: extension/extension-test typechecks, changed-file lint, formatting, boundary guards, and runtime import cycles.
- Fresh autoreview: no accepted or actionable findings.
