### PR TITLE
refactor(discord): split channel target resolver tests

### DIFF
--- a/extensions/discord/src/channel.target-resolver.test.ts
+++ b/extensions/discord/src/channel.target-resolver.test.ts
@@ -1,0 +1,85 @@
+// Discord channel target-resolver tests cover normalized and directory-backed routing.
+import { describe, expect, it, vi } from "vitest";
+import { discordPlugin } from "./channel.js";
+import * as directoryLive from "./directory-live.js";
+import type { OpenClawConfig } from "./runtime-api.js";
+
+function createCfg(): OpenClawConfig {
+  return {
+    channels: {
+      discord: {
+        enabled: true,
+        token: "test-token-placeholder",
+      },
+    },
+  } as OpenClawConfig;
+}
+
+function requireResolveTarget() {
+  const resolveTarget = discordPlugin.messaging?.targetResolver?.resolveTarget;
+  if (!resolveTarget) {
+    throw new Error("Expected discordPlugin.messaging.targetResolver.resolveTarget to be defined");
+  }
+  return resolveTarget;
+}
+
+describe("discordPlugin messaging target resolver", () => {
+  it("resolves Discord usernames through the messaging target resolver", async () => {
+    vi.spyOn(directoryLive, "listDiscordDirectoryPeersLive").mockResolvedValueOnce([
+      { kind: "user", id: "user:999", name: "Jane" } as const,
+    ]);
+
+    await expect(
+      requireResolveTarget()({
+        cfg: createCfg(),
+        accountId: "default",
+        input: "jane",
+        normalized: "channel:jane",
+        preferredKind: "user",
+      }),
+    ).resolves.toEqual({
+      to: "user:999",
+      kind: "user",
+      display: "jane",
+      source: "directory",
+    });
+  });
+
+  it("rejects unresolved Discord names after the shared directory lookup misses", async () => {
+    vi.spyOn(directoryLive, "listDiscordDirectoryPeersLive").mockResolvedValue([]);
+
+    await expect(
+      requireResolveTarget()({
+        cfg: createCfg(),
+        accountId: "default",
+        input: "channel:missing",
+        normalized: "channel:missing",
+        preferredKind: "channel",
+      }),
+    ).resolves.toBeNull();
+    await expect(
+      requireResolveTarget()({
+        cfg: createCfg(),
+        accountId: "default",
+        input: "user:missing",
+        normalized: "user:missing",
+        preferredKind: "user",
+      }),
+    ).resolves.toBeNull();
+  });
+
+  it("does not reinterpret a bare channel name as a Discord username on fallback", async () => {
+    vi.spyOn(directoryLive, "listDiscordDirectoryPeersLive").mockResolvedValueOnce([
+      { kind: "user", id: "user:999", name: "General" } as const,
+    ]);
+
+    await expect(
+      requireResolveTarget()({
+        cfg: createCfg(),
+        accountId: "default",
+        input: "general",
+        normalized: "channel:general",
+      }),
+    ).resolves.toBeNull();
+  });
+});

--- a/extensions/discord/src/channel.test.ts
+++ b/extensions/discord/src/channel.test.ts
@@ -6,7 +6,6 @@ import { createStartAccountContext } from "openclaw/plugin-sdk/channel-test-help
 import type { PluginRuntime } from "openclaw/plugin-sdk/core";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ResolvedDiscordAccount } from "./accounts.js";
-import * as directoryLive from "./directory-live.js";
 import type { OpenClawConfig } from "./runtime-api.js";
 import * as sendModule from "./send.js";
 import { createDiscordSendReceipt } from "./send.receipt.js";
@@ -290,83 +289,6 @@ describe("discordPlugin outbound", () => {
     expect(messaging.inferTargetChatType({ to: "channel:789" })).toBe("channel");
     expect(messaging.normalizeTarget("1470130713209602050")).toBe("channel:1470130713209602050");
     expect(messaging.inferTargetChatType({ to: "1470130713209602050" })).toBe("channel");
-  });
-
-  it("resolves Discord usernames through the messaging target resolver", async () => {
-    vi.spyOn(directoryLive, "listDiscordDirectoryPeersLive").mockResolvedValueOnce([
-      { kind: "user", id: "user:999", name: "Jane" } as const,
-    ]);
-    const resolveTarget = discordPlugin.messaging?.targetResolver?.resolveTarget;
-    if (!resolveTarget) {
-      throw new Error(
-        "Expected discordPlugin.messaging.targetResolver.resolveTarget to be defined",
-      );
-    }
-
-    await expect(
-      resolveTarget({
-        cfg: createCfg(),
-        accountId: "default",
-        input: "jane",
-        normalized: "channel:jane",
-        preferredKind: "user",
-      }),
-    ).resolves.toEqual({
-      to: "user:999",
-      kind: "user",
-      display: "jane",
-      source: "directory",
-    });
-  });
-
-  it("rejects unresolved Discord names after the shared directory lookup misses", async () => {
-    vi.spyOn(directoryLive, "listDiscordDirectoryPeersLive").mockResolvedValue([]);
-    const resolveTarget = discordPlugin.messaging?.targetResolver?.resolveTarget;
-    if (!resolveTarget) {
-      throw new Error(
-        "Expected discordPlugin.messaging.targetResolver.resolveTarget to be defined",
-      );
-    }
-
-    await expect(
-      resolveTarget({
-        cfg: createCfg(),
-        accountId: "default",
-        input: "channel:missing",
-        normalized: "channel:missing",
-        preferredKind: "channel",
-      }),
-    ).resolves.toBeNull();
-    await expect(
-      resolveTarget({
-        cfg: createCfg(),
-        accountId: "default",
-        input: "user:missing",
-        normalized: "user:missing",
-        preferredKind: "user",
-      }),
-    ).resolves.toBeNull();
-  });
-
-  it("does not reinterpret a bare channel name as a Discord username on fallback", async () => {
-    vi.spyOn(directoryLive, "listDiscordDirectoryPeersLive").mockResolvedValueOnce([
-      { kind: "user", id: "user:999", name: "General" } as const,
-    ]);
-    const resolveTarget = discordPlugin.messaging?.targetResolver?.resolveTarget;
-    if (!resolveTarget) {
-      throw new Error(
-        "Expected discordPlugin.messaging.targetResolver.resolveTarget to be defined",
-      );
-    }
-
-    await expect(
-      resolveTarget({
-        cfg: createCfg(),
-        accountId: "default",
-        input: "general",
-        normalized: "channel:general",
-      }),
-    ).resolves.toBeNull();
   });
 
   it("preserves the normalized channel kind for bare current-channel ids", async () => {


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the Discord channel test file exceeded the enforced 1,000-line lint budget after the named-target regression cases landed, leaving current `main` and unrelated pull requests with a deterministic `check-lint` failure.

## Why This Change Was Made

Move the three directory-backed messaging target-resolver cases into a focused test file and share their resolver-presence guard. Runtime code, assertions, and coverage stay unchanged.

## User Impact

No product behavior changes. Maintainer CI returns to a green lint baseline, and the resolver cases have a smaller owner-focused test surface.

## Evidence

- Before: `extensions/discord/src/channel.test.ts` reports `File has too many lines (1002)`.
- Focused Discord tests: 38/38 passed across the original and extracted files.
- Blacksmith changed-surface gate: passed formatting, max-lines ratchet, extension test types, lint, boundaries, dependency guards, and import-cycle checks.
- Fresh uncommitted autoreview: clean, confidence 0.98.
- `git diff --check`: passed.

AI-assisted: yes. This is a test-only split with no runtime changes.
