### PR TITLE
fix(resolve-system-bin): cap binary resolution caches with eviction

### DIFF
--- a/src/infra/resolve-system-bin.test.ts
+++ b/src/infra/resolve-system-bin.test.ts
@@ -176,6 +176,62 @@ describe("resolveSystemBin", () => {
       expect(resolveSystemBin("ffmpeg", { trust: "standard" })).toBe("/usr/bin/ffmpeg");
     });
   }
+
+  it.each([
+    { name: "Unix strict", platform: "linux", trust: "strict", extension: "" },
+    { name: "Unix standard", platform: "linux", trust: "standard", extension: "" },
+    { name: "Windows extensionless strict", platform: "win32", trust: "strict", extension: "" },
+    {
+      name: "Windows explicit-extension standard",
+      platform: "win32",
+      trust: "standard",
+      extension: ".exe",
+    },
+  ] as const)(
+    "bounds $name success entries with LRU eviction and retries failures",
+    ({ platform, trust, extension }) => {
+      const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue(platform);
+      const systemDir =
+        platform === "win32" ? path.win32.join("C:\\Windows", "System32") : "/usr/bin";
+      const commandFor = (label: string) => `${label}${extension}`;
+      const candidateFor = (command: string) =>
+        platform === "win32" && !extension
+          ? path.win32.join(systemDir, `${command}.exe`)
+          : path.join(systemDir, command);
+      const addCommand = (command: string) => {
+        const candidate = candidateFor(command);
+        addExecutables(path.resolve(candidate));
+        return candidate;
+      };
+      const cold = commandFor("cold");
+      const hot = commandFor("hot");
+
+      try {
+        expect(resolveSystemBin(cold, { trust })).toBeNull();
+        const coldCandidate = addCommand(cold);
+        const hotCandidate = addCommand(hot);
+        expect(resolveSystemBin(cold, { trust })).toBe(coldCandidate);
+        expect(resolveSystemBin(hot, { trust })).toBe(hotCandidate);
+        for (let index = 0; index < 510; index += 1) {
+          const filler = commandFor(`filler-${index}`);
+          const fillerCandidate = addCommand(filler);
+          expect(resolveSystemBin(filler, { trust })).toBe(fillerCandidate);
+        }
+
+        expect(resolveSystemBin(hot, { trust })).toBe(hotCandidate);
+        const newest = commandFor("newest");
+        const newestCandidate = addCommand(newest);
+        expect(resolveSystemBin(newest, { trust })).toBe(newestCandidate);
+        executables.delete(path.resolve(coldCandidate));
+        executables.delete(path.resolve(hotCandidate));
+
+        expect(resolveSystemBin(hot, { trust })).toBe(hotCandidate);
+        expect(resolveSystemBin(cold, { trust })).toBeNull();
+      } finally {
+        platformSpy.mockRestore();
+      }
+    },
+  );
 });
 
 describe("trusted directory list", () => {

--- a/src/infra/resolve-system-bin.ts
+++ b/src/infra/resolve-system-bin.ts
@@ -1,6 +1,7 @@
 // Resolves trusted system binaries from platform-managed directories.
 import fs from "node:fs";
 import path from "node:path";
+import { pruneMapToMaxSize } from "./map-size.js";
 import { getWindowsInstallRoots, getWindowsProgramFilesRoots } from "./windows-install-roots.js";
 
 /**
@@ -34,6 +35,11 @@ const WINDOWS_PROGRAM_FILES_TOOL_DIRS = ["ImageMagick", "GraphicsMagick"] as con
 const RESOLVED_BIN_CACHE_LIMIT = 512;
 const resolvedCacheStrict = new Map<string, string>();
 const resolvedCacheStandard = new Map<string, string>();
+
+function cacheResolvedSystemBin(cache: Map<string, string>, name: string, candidate: string): void {
+  cache.set(name, candidate);
+  pruneMapToMaxSize(cache, RESOLVED_BIN_CACHE_LIMIT);
+}
 
 function defaultIsExecutable(filePath: string): boolean {
   try {
@@ -173,6 +179,10 @@ export function resolveSystemBin(
   if (!hasExtra) {
     const cached = cache.get(name);
     if (cached !== undefined) {
+      // Trusted-directory probes hit the filesystem repeatedly; keep active binaries ahead of
+      // colder entries when the shared insertion-order pruning helper enforces the bound.
+      cache.delete(name);
+      cache.set(name, cached);
       return cached;
     }
   }
@@ -187,11 +197,7 @@ export function resolveSystemBin(
         const candidate = path.win32.join(dir, name + ext);
         if (isExecutableFn(candidate)) {
           if (!hasExtra) {
-            if (cache.size >= RESOLVED_BIN_CACHE_LIMIT) {
-              const oldest = cache.keys().next().value;
-              if (oldest !== undefined) cache.delete(oldest);
-            }
-            cache.set(name, candidate);
+            cacheResolvedSystemBin(cache, name, candidate);
           }
           return candidate;
         }
@@ -200,7 +206,7 @@ export function resolveSystemBin(
       const candidate = path.join(dir, name);
       if (isExecutableFn(candidate)) {
         if (!hasExtra) {
-          cache.set(name, candidate);
+          cacheResolvedSystemBin(cache, name, candidate);
         }
         return candidate;
       }

--- a/src/infra/resolve-system-bin.ts
+++ b/src/infra/resolve-system-bin.ts
@@ -31,6 +31,7 @@ const WIN_PATHEXT = [".exe", ".cmd", ".bat", ".com"] as const;
 const WINDOWS_PROGRAM_FILES_TOOL_DIR_PREFIXES = ["ImageMagick-", "GraphicsMagick-"] as const;
 const WINDOWS_PROGRAM_FILES_TOOL_DIRS = ["ImageMagick", "GraphicsMagick"] as const;
 
+const RESOLVED_BIN_CACHE_LIMIT = 512;
 const resolvedCacheStrict = new Map<string, string>();
 const resolvedCacheStandard = new Map<string, string>();
 
@@ -186,6 +187,10 @@ export function resolveSystemBin(
         const candidate = path.win32.join(dir, name + ext);
         if (isExecutableFn(candidate)) {
           if (!hasExtra) {
+            if (cache.size >= RESOLVED_BIN_CACHE_LIMIT) {
+              const oldest = cache.keys().next().value;
+              if (oldest !== undefined) cache.delete(oldest);
+            }
             cache.set(name, candidate);
           }
           return candidate;


### PR DESCRIPTION
## What Problem This Solves

`resolvedCacheStrict` and `resolvedCacheStandard` Maps in `src/infra/resolve-system-bin.ts:34-35` grow with every distinct binary name resolved via `resolveSystemBin()`. While the doc comment states results are "cached for the lifetime of the process," no size bound exists. In long-running gateway processes that resolve many different system binaries (ffmpeg, ffprobe, openssl, python, node, imagemagick, etc.), both caches can accumulate entries without bound.

## Why This Change Was Made

A 512-entry eviction cap (`RESOLVED_BIN_CACHE_LIMIT`) per cache prevents unbounded growth. Before each `cache.set()`, if the cache has reached the limit, the oldest entry (via `Map.keys().next().value`) is evicted. The cap is generous (512 distinct binary names) to avoid evicting frequently-used entries while still preventing unbounded growth.

## User Impact

No user-visible behavior change. The cache still avoids repeated filesystem scans for frequently-used binaries. After 512 distinct binary names per trust level, the oldest entries are silently replaced.

## Evidence

- `node scripts/run-vitest.mjs src/infra/resolve-system-bin.test.ts` — **15/15 passed**
- Eviction: oldest Map entry removed when inserting past 512-entry cap
- `git diff --check` passed
- Targeted formatting passed on changed file