### PR TITLE
fix(device-identity): warn on non-ENOENT errors when loading identity

### DIFF
--- a/src/infra/device-identity.test.ts
+++ b/src/infra/device-identity.test.ts
@@ -1,7 +1,7 @@
 // Covers device identity creation, conversion, signing, and verification.
 import fs from "node:fs";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { withTempDir } from "../test-utils/temp-dir.js";
 import {
   deriveDeviceIdFromPublicKey,
@@ -232,5 +232,39 @@ describe("device identity crypto helpers", () => {
       expect(verifyDeviceSignature("%%%invalid%%%", payload, signature)).toBe(false);
       expect(verifyDeviceSignature(identity.publicKeyPem, payload, "%%%invalid%%%")).toBe(false);
     });
+  });
+});
+
+describe("loadDeviceIdentityIfPresent error handling", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns null without warning when the file does not exist (ENOENT)", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    await withTempDir("openclaw-device-identity-", async (dir) => {
+      const identityPath = path.join(dir, "nonexistent", "device.json");
+      const result = loadDeviceIdentityIfPresent(identityPath);
+      expect(result).toBeNull();
+    });
+    expect(warnSpy).not.toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  it("warns and returns null on corrupt identity files", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    await withTempDir("openclaw-device-identity-", async (dir) => {
+      const identityDir = path.join(dir, "identity");
+      fs.mkdirSync(identityDir, { recursive: true });
+      const identityPath = path.join(identityDir, "device.json");
+      // Write invalid JSON that is not valid identity data
+      fs.writeFileSync(identityPath, "not-valid-json{{{", "utf-8");
+      const result = loadDeviceIdentityIfPresent(identityPath);
+      expect(result).toBeNull();
+    });
+    // Should have warned about the corrupt file
+    expect(warnSpy).toHaveBeenCalled();
+    expect(warnSpy.mock.calls[0]?.[0]).toContain("Failed to load device identity");
+    warnSpy.mockRestore();
   });
 });

--- a/src/infra/device-identity.ts
+++ b/src/infra/device-identity.ts
@@ -269,7 +269,10 @@ export function loadDeviceIdentityIfPresent(
       return null;
     }
     return normalized.identity;
-  } catch {
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+      console.warn("Failed to load device identity:", err);
+    }
     return null;
   }
 }


### PR DESCRIPTION
## What Problem This Solves

`loadDeviceIdentityIfPresent` (`src/infra/device-identity.ts:260`) silently returned `null` for all errors via an empty `catch {}` block. This made corrupt identity files, permission errors, and disk errors indistinguishable from a genuinely missing file. Operators had no way to detect that an existing identity file was damaged.

## Why This Change Was Made

Only `ENOENT` (file not found) is expected and should return null silently. All other errors (corruption, `EACCES`, `EIO`) are now logged via `console.warn` before returning null. This preserves the existing "return null on failure" contract while making non-trivial failures observable.

## User Impact

**Before**: Corrupt identity files were silently ignored. The function returned null and callers generated a new identity with no indication that the old file was damaged.

**After**: Corrupt or inaccessible device identity files now produce a visible warning on stderr. No behavior change — the function still returns null on failure and callers fall through to generating a new identity.

## Evidence

- `node scripts/run-vitest.mjs src/infra/device-identity.test.ts` — **11/11 passed** (+2 new error handling tests)
  - Missing file (ENOENT): returns null silently, no warning
  - Corrupt file (invalid JSON): warns via console.warn, returns null
- `git diff --check` passed
- Targeted formatting passed on changed files