### PR TITLE
fix(ci): add --connect-timeout and --max-time to actionlint curl down

### DIFF
--- a/.github/workflows/workflow-sanity.yml
+++ b/.github/workflows/workflow-sanity.yml
@@ -185,9 +185,10 @@ jobs:
           base_url="https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}"
           # GitHub release downloads occasionally return transient 5xx responses.
           # Retry all curl errors here so workflow-sanity does not fail closed on
-          # a one-off release edge outage.
-          curl --retry 5 --retry-delay 2 --retry-all-errors -sSfL -o "${archive}" "${base_url}/${archive}"
-          curl --retry 5 --retry-delay 2 --retry-all-errors -sSfL -o checksums.txt "${base_url}/actionlint_${ACTIONLINT_VERSION}_checksums.txt"
+          # a one-off release edge outage.  --connect-timeout and --max-time
+          # prevent individual retries from blocking forever on hung connections.
+          curl --retry 5 --retry-delay 2 --retry-all-errors --connect-timeout 10 --max-time 60 -sSfL -o "${archive}" "${base_url}/${archive}"
+          curl --retry 5 --retry-delay 2 --retry-all-errors --connect-timeout 10 --max-time 60 -sSfL -o checksums.txt "${base_url}/actionlint_${ACTIONLINT_VERSION}_checksums.txt"
           grep " ${archive}\$" checksums.txt | sha256sum -c -
           tar -xzf "${archive}" actionlint
           sudo install -m 0755 actionlint /usr/local/bin/actionlint

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -3743,4 +3743,20 @@ describe("ci workflow guards", () => {
       'call.getFile().getRelativePath() = "extensions/codex/src/app-server/transport-websocket.ts"',
     );
   });
+
+  it("bounds actionlint release download curls with connection and transfer deadlines", () => {
+    const source = readFileSync(".github/workflows/workflow-sanity.yml", "utf8");
+    const actionlintCurls =
+      source.match(
+        /curl --retry[^\n]*-o[^\n]*\$\{archive\}[^\n]*|curl --retry[^\n]*-o checksums\.txt[^\n]*/g,
+      ) ?? [];
+
+    expect(actionlintCurls.length).toBeGreaterThanOrEqual(2);
+    for (const line of actionlintCurls) {
+      expect(line).toContain("--retry");
+      expect(line).toContain("--retry-all-errors");
+      expect(line).toContain("--connect-timeout");
+      expect(line).toContain("--max-time");
+    }
+  });
 });


### PR DESCRIPTION
## What Problem This Solves

The actionlint download curls in `workflow-sanity.yml` (lines 189-190) already have `--retry 5 --retry-delay 2 --retry-all-errors` for transient 5xx responses (added by commit a7a89fb680), but still lacked `--connect-timeout` and `--max-time`. A single retry attempt could block forever on a hung TCP connection, stalling the CI runner indefinitely even with retries configured — retry only helps with transient errors that return quickly, not with connections that never complete.

## Why This Change Was Made

Add `--connect-timeout 10 --max-time 60` so each retry attempt is bounded. The 5-retry policy now has a worst-case ceiling of ~5 minutes (5 × 60s + retry delays) while still tolerating transient outages. A workflow guard in `ci-workflow-guards.test.ts` pins the contract: every actionlint release download curl must carry `--retry`, `--retry-all-errors`, `--connect-timeout`, and `--max-time`.

## User Impact

**Before:** A hung GitHub release endpoint could pin each retry attempt forever; the `--retry 5` policy only retries fast failures (5xx, connection refused), not TCP connections that accept but never complete. The workflow-sanity job could consume the full job timeout without reaching actionlint.

**After:** Each retry attempt fails within 60 seconds, so the 5-retry budget stays bounded and the job can report a clear failure within ~5 minutes.

## Evidence

- Changed: `.github/workflows/workflow-sanity.yml` (2 curl calls)
- Guard: `test/scripts/ci-workflow-guards.test.ts` → "bounds actionlint release download curls with connection and transfer deadlines"
- Complements: commit a7a89fb680 (`fix(ci): retry actionlint release downloads`) that added `--retry` flags.
- Sibling pattern: merged PRs #108755, #108723, #108699 apply the same bounding to other workflow curls.

### Workflow guard

```bash
node scripts/run-vitest.mjs test/scripts/ci-workflow-guards.test.ts --run
```

Expected: all existing tests pass plus the new actionlint guard.

## Real behavior proof

**Commands run:**
```bash
node scripts/run-vitest.mjs test/scripts/ci-workflow-guards.test.ts --run
```

**Before fix:**
Both actionlint download curls had `--retry 5 --retry-delay 2 --retry-all-errors` but no per-attempt timeout. A single hung connection could block indefinitely inside a retry attempt.

**After fix:**
Both calls now use `curl --retry 5 --retry-delay 2 --retry-all-errors --connect-timeout 10 --max-time 60`, bounding each retry attempt to ≤ 60 seconds.

**What was not tested:**
Live GitHub release download with actual network stall; the guard only verifies the flag contract.

## AI Assistance

AI-assisted (Claude Code). Author reviewed the workflow structure, retry+timeout interaction, guard test, and matching upstream pattern.
