### PR TITLE
fix(os-summary): cap OS summary caches with eviction

### DIFF
--- a/src/infra/os-summary.ts
+++ b/src/infra/os-summary.ts
@@ -12,6 +12,7 @@ type OsSummary = {
 
 const cachedOsSummaryByKey = new Map<string, OsSummary>();
 const cachedRuntimeOsLabelByKey = new Map<string, string>();
+const OS_SUMMARY_CACHE_LIMIT = 16;
 
 /**
  * Resolve Darwin product version via sw_vers.
@@ -43,6 +44,10 @@ export function resolveRuntimeOsLabel(): string {
   }
   const label =
     platform === "darwin" ? `macOS ${resolveDarwinProductVersion()}` : `${os.type()} ${release}`;
+  if (cachedRuntimeOsLabelByKey.size >= OS_SUMMARY_CACHE_LIMIT) {
+    const oldest = cachedRuntimeOsLabelByKey.keys().next().value;
+    if (oldest !== undefined) cachedRuntimeOsLabelByKey.delete(oldest);
+  }
   cachedRuntimeOsLabelByKey.set(cacheKey, label);
   return label;
 }
@@ -71,6 +76,10 @@ export function resolveOsSummary(): OsSummary {
     return `${platform} ${release} (${arch})`;
   })();
   const summary = { platform, arch, release, label };
+  if (cachedOsSummaryByKey.size >= OS_SUMMARY_CACHE_LIMIT) {
+    const oldest = cachedOsSummaryByKey.keys().next().value;
+    if (oldest !== undefined) cachedOsSummaryByKey.delete(oldest);
+  }
   cachedOsSummaryByKey.set(cacheKey, summary);
   return summary;
 }


### PR DESCRIPTION
## What Problem This Solves

`cachedOsSummaryByKey` and `cachedRuntimeOsLabelByKey` Maps in `src/infra/os-summary.ts:13-14` grow with each unique `platform\0release\0arch` combination. While naturally small (typically 1–2 entries per process), no size bound exists.

## Why This Change Was Made

A 16-entry eviction cap (`OS_SUMMARY_CACHE_LIMIT`) per cache prevents unbounded growth in edge cases (e.g., processes that observe varying platform identities in containerized or virtualized environments). Before each `cache.set()`, if the cache has reached the limit, the oldest entry is evicted.

## User Impact

No user-visible behavior change. The cache still avoids repeated OS queries; after 16 distinct entries the oldest is silently replaced.

## Evidence

- `node scripts/run-vitest.mjs src/infra/os-summary.test.ts` — **9/9 passed**
- `git diff --check` passed
- Targeted formatting passed on changed file