### PR TITLE
fix(shell-env): cap login shell env probe cache with eviction

### DIFF
--- a/src/infra/shell-env.test.ts
+++ b/src/infra/shell-env.test.ts
@@ -367,13 +367,27 @@ describe("shell env fallback", () => {
       name: "successful",
       oldest: Buffer.from("PROBE_RESULT=oldest\0"),
       newest: new Error("newest failure"),
+      refreshOldest: false,
     },
     {
       name: "failed",
       oldest: new Error("oldest failure"),
       newest: Buffer.from("PROBE_RESULT=newest\0"),
+      refreshOldest: false,
     },
-  ])("evicts the oldest $name probe across success and failure entries", ({ oldest, newest }) => {
+    {
+      name: "recent successful",
+      oldest: Buffer.from("PROBE_RESULT=oldest\0"),
+      newest: new Error("newest failure"),
+      refreshOldest: true,
+    },
+    {
+      name: "recent failed",
+      oldest: new Error("oldest failure"),
+      newest: Buffer.from("PROBE_RESULT=newest\0"),
+      refreshOldest: true,
+    },
+  ])("bounds $name probe entries with LRU eviction", ({ oldest, newest, refreshOldest }) => {
     const logger = { warn: vi.fn() };
     const makeExec = (outcome: Buffer | Error) =>
       vi.fn(() => {
@@ -391,20 +405,31 @@ describe("shell env fallback", () => {
         logger,
       });
     const oldestExec = makeExec(oldest);
-    const fillerExecs = Array.from({ length: 63 }, (_, index) =>
-      makeExec(Buffer.from(`PROBE_RESULT=filler-${index}\0`)),
-    );
+    const oldestFillerExec = makeExec(Buffer.from("PROBE_RESULT=filler-0\0"));
+    const fillerExecs = [
+      oldestFillerExec,
+      ...Array.from({ length: 62 }, (_, index) =>
+        makeExec(Buffer.from(`PROBE_RESULT=filler-${index + 1}\0`)),
+      ),
+    ];
     const newestExec = makeExec(newest);
 
     for (const exec of [oldestExec, ...fillerExecs]) {
       runProbe(exec);
+    }
+    if (refreshOldest) {
+      runProbe(oldestExec);
     }
     runProbe(newestExec);
     runProbe(newestExec);
     runProbe(oldestExec);
 
     expect(newestExec).toHaveBeenCalledOnce();
-    expect(oldestExec).toHaveBeenCalledTimes(2);
+    expect(oldestExec).toHaveBeenCalledTimes(refreshOldest ? 1 : 2);
+    if (refreshOldest) {
+      runProbe(oldestFillerExec);
+      expect(oldestFillerExec).toHaveBeenCalledTimes(2);
+    }
   });
 
   it("tracks last applied keys across success, skip, and failure paths", () => {

--- a/src/infra/shell-env.test.ts
+++ b/src/infra/shell-env.test.ts
@@ -68,6 +68,7 @@ describe("shell env fallback", () => {
     env: NodeJS.ProcessEnv;
     expectedKeys: string[];
     exec: ReturnType<typeof vi.fn>;
+    logger?: Pick<typeof console, "warn">;
     platform?: NodeJS.Platform;
   }) {
     return loadShellEnvFallback({
@@ -75,6 +76,7 @@ describe("shell env fallback", () => {
       env: params.env,
       expectedKeys: params.expectedKeys,
       exec: params.exec as unknown as Parameters<typeof loadShellEnvFallback>[0]["exec"],
+      logger: params.logger,
       platform: params.platform,
     });
   }
@@ -358,6 +360,51 @@ describe("shell env fallback", () => {
 
     expect(exec).toHaveBeenCalledTimes(1);
     expect(logger.warn).toHaveBeenCalledTimes(2);
+  });
+
+  it.each([
+    {
+      name: "successful",
+      oldest: Buffer.from("PROBE_RESULT=oldest\0"),
+      newest: new Error("newest failure"),
+    },
+    {
+      name: "failed",
+      oldest: new Error("oldest failure"),
+      newest: Buffer.from("PROBE_RESULT=newest\0"),
+    },
+  ])("evicts the oldest $name probe across success and failure entries", ({ oldest, newest }) => {
+    const logger = { warn: vi.fn() };
+    const makeExec = (outcome: Buffer | Error) =>
+      vi.fn(() => {
+        if (outcome instanceof Error) {
+          throw outcome;
+        }
+        return outcome;
+      });
+    const runProbe = (exec: ReturnType<typeof vi.fn>) =>
+      runShellEnvFallback({
+        enabled: true,
+        env: {},
+        expectedKeys: ["PROBE_RESULT"],
+        exec,
+        logger,
+      });
+    const oldestExec = makeExec(oldest);
+    const fillerExecs = Array.from({ length: 63 }, (_, index) =>
+      makeExec(Buffer.from(`PROBE_RESULT=filler-${index}\0`)),
+    );
+    const newestExec = makeExec(newest);
+
+    for (const exec of [oldestExec, ...fillerExecs]) {
+      runProbe(exec);
+    }
+    runProbe(newestExec);
+    runProbe(newestExec);
+    runProbe(oldestExec);
+
+    expect(newestExec).toHaveBeenCalledOnce();
+    expect(oldestExec).toHaveBeenCalledTimes(2);
   });
 
   it("tracks last applied keys across success, skip, and failure paths", () => {

--- a/src/infra/shell-env.ts
+++ b/src/infra/shell-env.ts
@@ -21,6 +21,7 @@ const loginShellEnvProbeCache = new Map<
   string,
   { ok: true; entries: Array<[string, string]> } | { ok: false; error: string }
 >();
+const LOGIN_SHELL_ENV_CACHE_LIMIT = 64;
 const execCacheIds = new WeakMap<object, number>();
 
 function resolveShellExecEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
@@ -198,10 +199,18 @@ function probeLoginShellEnv(params: {
   try {
     const stdout = execLoginShellEnvZero({ shell, env: execEnv, exec, timeoutMs });
     const shellEnv = parseShellEnv(stdout);
+    if (loginShellEnvProbeCache.size >= LOGIN_SHELL_ENV_CACHE_LIMIT) {
+      const oldest = loginShellEnvProbeCache.keys().next().value;
+      if (oldest !== undefined) loginShellEnvProbeCache.delete(oldest);
+    }
     loginShellEnvProbeCache.set(cacheKey, { ok: true, entries: [...shellEnv.entries()] });
     return { ok: true, shellEnv };
   } catch (err) {
     const result = { ok: false as const, error: formatErrorMessage(err) };
+    if (loginShellEnvProbeCache.size >= LOGIN_SHELL_ENV_CACHE_LIMIT) {
+      const oldest = loginShellEnvProbeCache.keys().next().value;
+      if (oldest !== undefined) loginShellEnvProbeCache.delete(oldest);
+    }
     loginShellEnvProbeCache.set(cacheKey, result);
     return result;
   }

--- a/src/infra/shell-env.ts
+++ b/src/infra/shell-env.ts
@@ -8,6 +8,7 @@ import { isTruthyEnvValue } from "./env.js";
 import { formatErrorMessage } from "./errors.js";
 import { resolveExecutableFromPathEnv } from "./executable-path.js";
 import { sanitizeHostExecEnv } from "./host-env-security.js";
+import { pruneMapToMaxSize } from "./map-size.js";
 import { parseStrictNonNegativeInteger } from "./parse-finite-number.js";
 
 const DEFAULT_TIMEOUT_MS = 15_000;
@@ -17,10 +18,10 @@ let lastAppliedKeys: string[] = [];
 let cachedShellPath: string | null | undefined;
 let cachedEtcShells: Set<string> | null | undefined;
 let nextExecCacheId = 1;
-const loginShellEnvProbeCache = new Map<
-  string,
-  { ok: true; entries: Array<[string, string]> } | { ok: false; error: string }
->();
+type CachedLoginShellEnvProbeResult =
+  | { ok: true; entries: Array<[string, string]> }
+  | { ok: false; error: string };
+const loginShellEnvProbeCache = new Map<string, CachedLoginShellEnvProbeResult>();
 const LOGIN_SHELL_ENV_CACHE_LIMIT = 64;
 const execCacheIds = new WeakMap<object, number>();
 
@@ -170,6 +171,11 @@ type LoginShellEnvProbeResult =
   | { ok: true; shellEnv: Map<string, string> }
   | { ok: false; error: string };
 
+function cacheLoginShellEnvProbe(cacheKey: string, result: CachedLoginShellEnvProbeResult): void {
+  loginShellEnvProbeCache.set(cacheKey, result);
+  pruneMapToMaxSize(loginShellEnvProbeCache, LOGIN_SHELL_ENV_CACHE_LIMIT);
+}
+
 function probeLoginShellEnv(params: {
   env: NodeJS.ProcessEnv;
   timeoutMs?: number;
@@ -199,19 +205,11 @@ function probeLoginShellEnv(params: {
   try {
     const stdout = execLoginShellEnvZero({ shell, env: execEnv, exec, timeoutMs });
     const shellEnv = parseShellEnv(stdout);
-    if (loginShellEnvProbeCache.size >= LOGIN_SHELL_ENV_CACHE_LIMIT) {
-      const oldest = loginShellEnvProbeCache.keys().next().value;
-      if (oldest !== undefined) loginShellEnvProbeCache.delete(oldest);
-    }
-    loginShellEnvProbeCache.set(cacheKey, { ok: true, entries: [...shellEnv.entries()] });
+    cacheLoginShellEnvProbe(cacheKey, { ok: true, entries: [...shellEnv.entries()] });
     return { ok: true, shellEnv };
   } catch (err) {
     const result = { ok: false as const, error: formatErrorMessage(err) };
-    if (loginShellEnvProbeCache.size >= LOGIN_SHELL_ENV_CACHE_LIMIT) {
-      const oldest = loginShellEnvProbeCache.keys().next().value;
-      if (oldest !== undefined) loginShellEnvProbeCache.delete(oldest);
-    }
-    loginShellEnvProbeCache.set(cacheKey, result);
+    cacheLoginShellEnvProbe(cacheKey, result);
     return result;
   }
 }

--- a/src/infra/shell-env.ts
+++ b/src/infra/shell-env.ts
@@ -199,6 +199,10 @@ function probeLoginShellEnv(params: {
   });
   const cached = loginShellEnvProbeCache.get(cacheKey);
   if (cached) {
+    // Login-shell probes can consume the full timeout; keep active configurations ahead of
+    // colder entries when the shared insertion-order pruning helper enforces the bound.
+    loginShellEnvProbeCache.delete(cacheKey);
+    loginShellEnvProbeCache.set(cacheKey, cached);
     return cached.ok ? { ok: true, shellEnv: new Map(cached.entries) } : cached;
   }
 


### PR DESCRIPTION
## What Problem This Solves

`loginShellEnvProbeCache` Map in `src/infra/shell-env.ts:20-23` keys include the exec function reference and environment snapshot, which can vary across calls with different configurations. No size bound existed — each unique combination of shell, timeout, exec function, and filtered environment variables (`HOME`, `PATH`, `TERM`, `LANG`, `LC_*`, `USER`, `LOGNAME`, `TMPDIR`, `XDG_*`, `OPENCLAW_*`) creates a permanent cache entry.

## Why This Change Was Made

A 64-entry eviction cap (`LOGIN_SHELL_ENV_CACHE_LIMIT`) prevents unbounded growth. Before each `cache.set()`, if the cache has reached the limit, the oldest entry (via `Map.keys().next().value`) is evicted.

## User Impact

No user-visible behavior change. The cache still avoids repeated login-shell probes; after 64 distinct configurations the oldest is silently replaced.

## Evidence

- `node scripts/run-vitest.mjs src/infra/shell-env.test.ts` — **27/27 passed**
- `git diff --check` passed
- Targeted formatting passed on changed file