### PR TITLE
improve: speed up timeout and pairing tests

### DIFF
--- a/extensions/active-memory/index.test.ts
+++ b/extensions/active-memory/index.test.ts
@@ -3323,10 +3323,10 @@ describe("active-memory plugin", () => {
   it("returns partial transcript text on timeout when transcripts are temporary by default", async () => {
     testing.setMinimumTimeoutMsForTests(1);
     testing.setSetupGraceTimeoutMsForTests(0);
-    testing.setTimeoutPartialDataGraceMsForTests(100);
+    testing.setTimeoutPartialDataGraceMsForTests(50);
     api.pluginConfig = {
       agents: ["main"],
-      timeoutMs: 250,
+      timeoutMs: 100,
       maxSummaryChars: 80,
       logging: true,
     };
@@ -3370,10 +3370,10 @@ describe("active-memory plugin", () => {
   it("returns partial transcript text on timeout from SQLite runtime transcript rows", async () => {
     testing.setMinimumTimeoutMsForTests(1);
     testing.setSetupGraceTimeoutMsForTests(0);
-    testing.setTimeoutPartialDataGraceMsForTests(100);
+    testing.setTimeoutPartialDataGraceMsForTests(50);
     api.pluginConfig = {
       agents: ["main"],
-      timeoutMs: 250,
+      timeoutMs: 100,
       maxSummaryChars: 80,
       logging: true,
     };
@@ -4373,10 +4373,10 @@ describe("active-memory plugin", () => {
   it("does not recover transcript partials after a later unavailable search times out", async () => {
     testing.setMinimumTimeoutMsForTests(1);
     testing.setSetupGraceTimeoutMsForTests(0);
-    testing.setTimeoutPartialDataGraceMsForTests(100);
+    testing.setTimeoutPartialDataGraceMsForTests(50);
     api.pluginConfig = {
       agents: ["main"],
-      timeoutMs: 250,
+      timeoutMs: 100,
       logging: true,
     };
     plugin.register(api as unknown as OpenClawPluginApi);
@@ -4432,10 +4432,10 @@ describe("active-memory plugin", () => {
   it("does not recover a timeout partial when unavailable debug arrives after the last poll", async () => {
     testing.setMinimumTimeoutMsForTests(1);
     testing.setSetupGraceTimeoutMsForTests(0);
-    testing.setTimeoutPartialDataGraceMsForTests(100);
+    testing.setTimeoutPartialDataGraceMsForTests(50);
     api.pluginConfig = {
       agents: ["main"],
-      timeoutMs: 250,
+      timeoutMs: 100,
       logging: true,
     };
     plugin.register(api as unknown as OpenClawPluginApi);
@@ -4492,7 +4492,7 @@ describe("active-memory plugin", () => {
     testing.setTimeoutPartialDataGraceMsForTests(50);
     api.pluginConfig = {
       agents: ["main"],
-      timeoutMs: 250,
+      timeoutMs: 100,
       logging: true,
     };
     plugin.register(api as unknown as OpenClawPluginApi);
@@ -4560,10 +4560,10 @@ describe("active-memory plugin", () => {
   it("does not recover a timeout partial after an unmirrored custom memory tool fails", async () => {
     testing.setMinimumTimeoutMsForTests(1);
     testing.setSetupGraceTimeoutMsForTests(0);
-    testing.setTimeoutPartialDataGraceMsForTests(100);
+    testing.setTimeoutPartialDataGraceMsForTests(50);
     api.pluginConfig = {
       agents: ["main"],
-      timeoutMs: 250,
+      timeoutMs: 100,
       toolsAllow: ["memory_lookup_custom"],
       logging: true,
     };

--- a/src/agents/agent-bundle-lsp-runtime.test.ts
+++ b/src/agents/agent-bundle-lsp-runtime.test.ts
@@ -277,7 +277,7 @@ describe("bundle LSP runtime", () => {
     ["lsp_references_typescript", "textDocument/references"],
   ])("cancels pending %s requests when the tool signal aborts", async (toolName, method) => {
     configureSingleLspServer();
-    const child = new MockChildProcess("", new Set(["initialize"]));
+    const child = new MockChildProcess("", new Set(["initialize", "shutdown"]));
     spawnMock.mockReturnValue(child);
 
     const runtime = await createBundleLspToolRuntime({ workspaceDir: "/tmp/workspace" });

--- a/src/gateway/test-helpers.lan-pairing.ts
+++ b/src/gateway/test-helpers.lan-pairing.ts
@@ -123,13 +123,15 @@ export async function withLanNodePairingAttempt(params: {
           deviceIdentityPath: loaded.identityPath,
         });
       } finally {
-        ws.close();
+        // These tests cover pairing, not the WebSocket close handshake. Terminate so
+        // gateway cleanup never waits on a client that has already returned its result.
+        ws.terminate();
       }
     };
     await params.run({ lanIp, loaded, connectNode });
   } finally {
     for (const ws of openSockets) {
-      ws.close();
+      ws.terminate();
     }
     await started.server.close();
     started.envSnapshot.restore();


### PR DESCRIPTION
## What Problem This Solves

Several focused test paths keep waiting after the behavior under test has already completed: LSP teardown waits for the real shutdown grace, pairing helpers wait for WebSocket close handshakes, and duplicated active-memory timeout fixtures use wider budgets than the established equivalent cases.

## Why This Change Was Made

The LSP mock now acknowledges shutdown, pairing-only WebSockets terminate during cleanup, and six duplicated timeout cases use the already-proven 100 ms timeout and 50 ms partial-read grace. Production behavior and CI configuration are unchanged.

## User Impact

No user-visible behavior change. Developers and CI spend less time in these focused test suites while retaining the same assertions and coverage.

## Evidence

- Controlled focused proof: 196 tests passed; test-body time fell from 28.370 s to 16.499 s, a 41.8% reduction.
- LSP suite: 1.571 s to 0.040 s test-body time.
- SSH pairing suite: 8.913 s to 3.137 s test-body time.
- Active-memory suite: 14.645 s to 10.067 s test-body time.
- Rebased exact-head Testbox proof: all 196 tests passed across the LSP, two LAN pairing, and active-memory suites. Run: https://github.com/openclaw/openclaw/actions/runs/29488956775
- Changed gate: formatting, guards, SDK baseline, core/test/extension typechecks, and core lint passed. Its old-base failures were the unrelated APNs schema and Discord max-lines regressions; both fixes are included in the rebased head.
- Autoreview: clean, no accepted or actionable findings.
