### PR TITLE
fix(ci): bound OpenGrep and OpenShell install script downloads

### DIFF
--- a/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
+++ b/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
@@ -851,7 +851,12 @@ jobs:
         run: |
           set -euo pipefail
           export OPENSHELL_VERSION=v0.0.68
-          curl -LsSf https://raw.githubusercontent.com/NVIDIA/OpenShell/d64542f69d06694cbd203b64929d286dd0533bbb/install.sh | sh
+          # Keep script download bounded if the raw.githubusercontent.com
+          # endpoint stalls during workflow startup.
+          curl -LsSf \
+            --connect-timeout 10 \
+            --max-time 60 \
+            https://raw.githubusercontent.com/NVIDIA/OpenShell/d64542f69d06694cbd203b64929d286dd0533bbb/install.sh | sh
           openshell --version
 
       - name: Bootstrap OpenShell gateway

--- a/.github/workflows/opengrep-precise-full.yml
+++ b/.github/workflows/opengrep-precise-full.yml
@@ -38,7 +38,12 @@ jobs:
           OPENGREP_VERSION: v1.22.0
           OPENGREP_INSTALL_SHA: f458d7f0d52cc58eae1ca3cf3d5caf101e637519
         run: |
-          curl -fsSL "https://raw.githubusercontent.com/opengrep/opengrep/${OPENGREP_INSTALL_SHA}/install.sh" \
+          # Keep script download bounded if the raw.githubusercontent.com
+          # endpoint stalls during workflow startup.
+          curl -fsSL \
+            --connect-timeout 10 \
+            --max-time 60 \
+            "https://raw.githubusercontent.com/opengrep/opengrep/${OPENGREP_INSTALL_SHA}/install.sh" \
             | bash -s -- -v "$OPENGREP_VERSION"
           echo "$HOME/.opengrep/cli/latest" >> "$GITHUB_PATH"
 

--- a/.github/workflows/opengrep-precise.yml
+++ b/.github/workflows/opengrep-precise.yml
@@ -64,7 +64,12 @@ jobs:
           OPENGREP_VERSION: v1.22.0
           OPENGREP_INSTALL_SHA: f458d7f0d52cc58eae1ca3cf3d5caf101e637519
         run: |
-          curl -fsSL "https://raw.githubusercontent.com/opengrep/opengrep/${OPENGREP_INSTALL_SHA}/install.sh" \
+          # Keep script download bounded if the raw.githubusercontent.com
+          # endpoint stalls during workflow startup.
+          curl -fsSL \
+            --connect-timeout 10 \
+            --max-time 60 \
+            "https://raw.githubusercontent.com/opengrep/opengrep/${OPENGREP_INSTALL_SHA}/install.sh" \
             | bash -s -- -v "$OPENGREP_VERSION"
           echo "$HOME/.opengrep/cli/latest" >> "$GITHUB_PATH"
 

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -1430,6 +1430,36 @@ describe("ci workflow guards", () => {
     }
   });
 
+  it("bounds OpenGrep and OpenShell install script downloads", () => {
+    const fullWorkflow = parse(readFileSync(OPENGREP_FULL_WORKFLOW, "utf8"));
+    const prDiffWorkflow = parse(readFileSync(OPENGREP_PR_DIFF_WORKFLOW, "utf8"));
+    const liveAndE2eWorkflow = parse(
+      readFileSync(".github/workflows/openclaw-live-and-e2e-checks-reusable.yml", "utf8"),
+    );
+
+    const fullInstallStep = fullWorkflow.jobs.scan.steps.find((step: WorkflowStep) =>
+      step.run?.includes("install.sh"),
+    );
+    const prDiffInstallStep = prDiffWorkflow.jobs.scan.steps.find((step: WorkflowStep) =>
+      step.run?.includes("install.sh"),
+    );
+    const openShellInstallStep = liveAndE2eWorkflow.jobs["live-e2e-matrix"].steps.find(
+      (step: WorkflowStep) =>
+        step.name?.includes("Install OpenShell") && step.run?.includes("install.sh"),
+    );
+
+    expectDefined(fullInstallStep, "OpenGrep full install step");
+    expectDefined(prDiffInstallStep, "OpenGrep PR diff install step");
+    expectDefined(openShellInstallStep, "OpenShell install step");
+
+    expect(fullInstallStep.run).toContain("--connect-timeout 10");
+    expect(fullInstallStep.run).toContain("--max-time 60");
+    expect(prDiffInstallStep.run).toContain("--connect-timeout 10");
+    expect(prDiffInstallStep.run).toContain("--max-time 60");
+    expect(openShellInstallStep.run).toContain("--connect-timeout 10");
+    expect(openShellInstallStep.run).toContain("--max-time 60");
+  });
+
   it("runs real behavior proof from the trusted workflow revision", () => {
     const workflow = readRealBehaviorProofWorkflow();
     const source = readFileSync(".github/workflows/real-behavior-proof.yml", "utf8");


### PR DESCRIPTION
## What Problem This Solves
Three workflow jobs download install scripts from raw.githubusercontent.com during startup without connection or transfer timeouts:
- OpenGrep full scan (manual workflow dispatch)
- OpenGrep PR diff scan (PR-triggered)
- OpenShell CLI install (live/E2E matrix)

A stalled GitHub raw content endpoint could hold these downloads indefinitely, consuming the entire job deadline and blocking CI feedback.

## Why This Change Was Made
Add `--connect-timeout 10 --max-time 60` to curl commands that fetch install scripts. This matches the pattern from recent timeout fixes (#108741, #108766) and keeps script downloads bounded within a small fraction of typical 15-30 minute job timeouts.

The 10-second connection timeout handles transient network issues or DNS resolution delays. The 60-second max-time covers the full transfer including any TLS handshake, redirect, or script download latency while staying well below job-level deadlines.

## User Impact
Workflow runs now fail fast with a bounded curl error if raw.githubusercontent.com stalls during script download. Successful downloads and subsequent tool installations are unchanged. The timeout values are generous enough for normal GitHub API response times.

## Evidence
*   Workflow syntax validated via GitHub Actions YAML schema
*   curl timeout flags (`--connect-timeout`, `--max-time`) are standard Alpine Linux curl options
*   Pattern matches existing Android SDK download timeout test at `test/scripts/ci-workflow-guards.test.ts:1500-1515`
*   Added test verification in `test/scripts/ci-workflow-guards.test.ts` ensuring install steps include `--connect-timeout 10 --max-time 60`
