### PR TITLE
fix: keep isolated gateways quiet and Codex terminals interactive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,8 +42,6 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - **Cron lifecycle conflict retries:** preserve execution-phase retry decisions across scheduled, manual, and startup-recovered runs so post-execution claim conflicts cannot replay completed messages or tools. Fixes #108428. Thanks @yetval.
-- **Gateway channel-skip isolation:** keep channel health recovery disabled when `OPENCLAW_SKIP_CHANNELS` or `OPENCLAW_SKIP_PROVIDERS` suppresses startup so test and maintenance gateways cannot resurrect configured transports after the startup grace period. (#108786)
-- **Gateway terminal PTY environment:** upgrade inherited non-interactive `TERM` values for real PTYs so Codex and other interactive CLIs can start from local and paired-node web terminals. (#108824)
 - **Discord gateway metadata deadline:** carry the existing lookup deadline through DNS and proxy preflight, request headers, and response bodies so stalled gateway startup aborts cleanly. (#104580) Thanks @hugenshen.
 - **Control UI cloud session thinking:** expose reasoning level in the New Session model picker and persist the selected level before cloud dispatch.
 - **Tlon SSE connect cleanup:** disarm opening deadlines after failed HTTP responses and rejected stream opens so reconnect attempts cannot leave stale timers behind. (#104585) Thanks @hugenshen.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - **Cron lifecycle conflict retries:** preserve execution-phase retry decisions across scheduled, manual, and startup-recovered runs so post-execution claim conflicts cannot replay completed messages or tools. Fixes #108428. Thanks @yetval.
+- **Gateway channel-skip isolation:** keep channel health recovery disabled when `OPENCLAW_SKIP_CHANNELS` or `OPENCLAW_SKIP_PROVIDERS` suppresses startup so test and maintenance gateways cannot resurrect configured transports after the startup grace period. (#108786)
+- **Gateway terminal PTY environment:** upgrade inherited non-interactive `TERM` values for real PTYs so Codex and other interactive CLIs can start from local and paired-node web terminals. (#108824)
 - **Discord gateway metadata deadline:** carry the existing lookup deadline through DNS and proxy preflight, request headers, and response bodies so stalled gateway startup aborts cleanly. (#104580) Thanks @hugenshen.
 - **Control UI cloud session thinking:** expose reasoning level in the New Session model picker and persist the selected level before cloud dispatch.
 - **Tlon SSE connect cleanup:** disarm opening deadlines after failed HTTP responses and rejected stream opens so reconnect attempts cannot leave stale timers behind. (#104585) Thanks @hugenshen.

--- a/src/gateway/server-runtime-services.test.ts
+++ b/src/gateway/server-runtime-services.test.ts
@@ -55,6 +55,8 @@ vi.mock("../sessions/session-upstream-monitor.js", () => ({
 }));
 
 vi.mock("../infra/env.js", () => ({
+  isTruthyEnvValue: (value?: string) =>
+    ["1", "true", "yes", "on"].includes(value?.trim().toLowerCase() ?? ""),
   isVitestRuntimeEnv: hoisted.isVitestRuntimeEnv,
 }));
 
@@ -98,6 +100,7 @@ const {
   runGatewayPostReadyMaintenance,
   scheduleGatewayIdleTask,
   scheduleGatewayPostReadyMaintenance,
+  startGatewayChannelHealthMonitor,
   startGatewayCronWithLogging,
   startGatewayRuntimeServices,
 } = await import("./server-runtime-services.js");
@@ -171,6 +174,20 @@ describe("server-runtime-services", () => {
     services.heartbeatRunner.stop();
     expect(hoisted.heartbeatRunner.stop).not.toHaveBeenCalled();
   });
+
+  it.each(["OPENCLAW_SKIP_CHANNELS", "OPENCLAW_SKIP_PROVIDERS"])(
+    "keeps channel health recovery disabled when %s suppresses startup",
+    (envKey) => {
+      const monitor = startGatewayChannelHealthMonitor({
+        cfg: {} as never,
+        channelManager: {} as never,
+        env: { [envKey]: "1" },
+      });
+
+      expect(monitor).toBeNull();
+      expect(hoisted.startChannelHealthMonitor).not.toHaveBeenCalled();
+    },
+  );
 
   it("starts model pricing refresh after scheduled services activate", async () => {
     const pluginLookUpTable = {

--- a/src/gateway/server-runtime-startup-services.ts
+++ b/src/gateway/server-runtime-startup-services.ts
@@ -1,6 +1,7 @@
 // Gateway startup-time runtime services.
 // Starts mode-dependent background monitors with inert handles for disabled paths.
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { isTruthyEnvValue } from "../infra/env.js";
 import type { ChannelHealthMonitor } from "./channel-health-monitor.js";
 import { startChannelHealthMonitor } from "./channel-health-monitor.js";
 import {
@@ -19,7 +20,17 @@ export type GatewayChannelManager = Parameters<
 export function startGatewayChannelHealthMonitor(params: {
   cfg: OpenClawConfig;
   channelManager: GatewayChannelManager;
+  env?: NodeJS.ProcessEnv;
 }): ChannelHealthMonitor | null {
+  const env = params.env ?? process.env;
+  // Process-level channel suppression also owns recovery: otherwise the health
+  // monitor restarts configured transports after the startup grace period.
+  if (
+    isTruthyEnvValue(env.OPENCLAW_SKIP_CHANNELS) ||
+    isTruthyEnvValue(env.OPENCLAW_SKIP_PROVIDERS)
+  ) {
+    return null;
+  }
   const healthCheckMinutes = params.cfg.gateway?.channelHealthCheckMinutes;
   if (healthCheckMinutes === 0) {
     return null;

--- a/src/process/terminal-pty.test.ts
+++ b/src/process/terminal-pty.test.ts
@@ -75,7 +75,7 @@ describe("terminal PTY invocation", () => {
     vi.restoreAllMocks();
   });
 
-  it.each([{}, { TERM: "" }, { TERM: "dumb" }, { TERM: "DUMB" }])(
+  it.each([{}, { TERM: "" }, { TERM: "dumb" }, { TERM: "DUMB" }, { TERM: " dumb " }])(
     "upgrades non-interactive TERM for a real PTY: %o",
     async (env) => {
       mocks.spawn.mockReturnValueOnce(fakePty());

--- a/src/process/terminal-pty.test.ts
+++ b/src/process/terminal-pty.test.ts
@@ -67,6 +67,14 @@ describe("terminal PTY teardown", () => {
 });
 
 describe("terminal PTY invocation", () => {
+  const nonInteractiveEnvironments: Array<Record<string, string>> = [
+    {},
+    { TERM: "" },
+    { TERM: "dumb" },
+    { TERM: "DUMB" },
+    { TERM: " dumb " },
+  ];
+
   beforeEach(() => {
     mocks.spawn.mockReset();
   });
@@ -75,7 +83,7 @@ describe("terminal PTY invocation", () => {
     vi.restoreAllMocks();
   });
 
-  it.each([{}, { TERM: "" }, { TERM: "dumb" }, { TERM: "DUMB" }, { TERM: " dumb " }])(
+  it.each(nonInteractiveEnvironments)(
     "upgrades non-interactive TERM for a real PTY: %o",
     async (env) => {
       mocks.spawn.mockReturnValueOnce(fakePty());

--- a/src/process/terminal-pty.test.ts
+++ b/src/process/terminal-pty.test.ts
@@ -75,6 +75,51 @@ describe("terminal PTY invocation", () => {
     vi.restoreAllMocks();
   });
 
+  it.each([{}, { TERM: "" }, { TERM: "dumb" }, { TERM: "DUMB" }])(
+    "upgrades non-interactive TERM for a real PTY: %o",
+    async (env) => {
+      mocks.spawn.mockReturnValueOnce(fakePty());
+
+      await spawnTerminalPty({
+        file: "/usr/bin/codex",
+        args: ["resume", "thread"],
+        env,
+        cols: 80,
+        rows: 24,
+      });
+
+      expect(mocks.spawn).toHaveBeenCalledWith(
+        "/usr/bin/codex",
+        ["resume", "thread"],
+        expect.objectContaining({
+          name: "xterm-256color",
+          env: expect.objectContaining({ TERM: "xterm-256color" }),
+        }),
+      );
+    },
+  );
+
+  it("preserves an interactive TERM", async () => {
+    mocks.spawn.mockReturnValueOnce(fakePty());
+
+    await spawnTerminalPty({
+      file: "/usr/bin/codex",
+      args: [],
+      env: { TERM: "screen-256color" },
+      cols: 80,
+      rows: 24,
+    });
+
+    expect(mocks.spawn).toHaveBeenCalledWith(
+      "/usr/bin/codex",
+      [],
+      expect.objectContaining({
+        name: "screen-256color",
+        env: expect.objectContaining({ TERM: "screen-256color" }),
+      }),
+    );
+  });
+
   it.each([".cmd", ".bat"])("wraps Windows %s shims through ComSpec", async (extension) => {
     vi.spyOn(process, "platform", "get").mockReturnValue("win32");
     mocks.spawn.mockReturnValueOnce(fakePty());

--- a/src/process/terminal-pty.ts
+++ b/src/process/terminal-pty.ts
@@ -46,9 +46,9 @@ export async function spawnTerminalPty(params: {
   const env = { ...params.env };
   // Ambient TERM=dumb describes the gateway/node host, not this real PTY.
   // Passing it through makes interactive CLIs refuse to start in the web terminal.
-  if (!env.TERM?.trim() || env.TERM.toLowerCase() === "dumb") {
-    env.TERM = "xterm-256color";
-  }
+  const inheritedTerm = env.TERM?.trim();
+  env.TERM =
+    !inheritedTerm || inheritedTerm.toLowerCase() === "dumb" ? "xterm-256color" : inheritedTerm;
   const comSpec = env.ComSpec ?? env.COMSPEC;
   const invocation = resolveTerminalPtyInvocation({
     file: params.file,

--- a/src/process/terminal-pty.ts
+++ b/src/process/terminal-pty.ts
@@ -43,18 +43,24 @@ export async function spawnTerminalPty(params: {
   rows: number;
 }): Promise<TerminalPtyHandle> {
   const { spawn } = await import("@lydell/node-pty");
-  const comSpec = params.env.ComSpec ?? params.env.COMSPEC;
+  const env = { ...params.env };
+  // Ambient TERM=dumb describes the gateway/node host, not this real PTY.
+  // Passing it through makes interactive CLIs refuse to start in the web terminal.
+  if (!env.TERM?.trim() || env.TERM.toLowerCase() === "dumb") {
+    env.TERM = "xterm-256color";
+  }
+  const comSpec = env.ComSpec ?? env.COMSPEC;
   const invocation = resolveTerminalPtyInvocation({
     file: params.file,
     args: params.args,
     ...(comSpec ? { comSpec } : {}),
   });
   const pty = spawn(invocation.file, invocation.args, {
-    name: params.env.TERM ?? "xterm-256color",
+    name: env.TERM,
     cols: params.cols,
     rows: params.rows,
     cwd: params.cwd,
-    env: params.env,
+    env,
   });
   return {
     get pid() {


### PR DESCRIPTION
Closes #108786
Closes #108824

## What Problem This Solves

Fixes two issues found during live Gateway and paired-node session testing:

- gateways started with channel/provider suppression could restart configured channels after the health-monitor grace period;
- users opening a Codex session in the local or paired-node web terminal could see Codex refuse to start when the host process inherited `TERM=dumb`.

## Why This Change Was Made

Channel recovery now honors the same process-level suppression flags as startup. Real PTY creation also normalizes missing, blank, or non-interactive terminal names while preserving valid interactive values, covering both local and node-host terminal paths at their shared owner boundary.

## User Impact

Test and maintenance gateways remain isolated for their full lifetime. Users can open eligible Codex or Claude sessions from the Control UI terminal and command them even when the gateway or node host was launched from a non-interactive environment.

## Evidence

- Reproduced configured Discord restart after the 60-second health grace on current `main`; patched isolated gateway remained quiet for more than seven minutes.
- Reproduced Codex refusal from the real Chrome Control UI through a paired node with `TERM=dumb`.
- After the fix, selected the paired-node Codex row, loaded its transcript, opened its terminal, sent a unique command, received the exact response, and read the new user/agent items back through `sessions.catalog.read`.
- Verified 40 local plus 40 paired-node rows for both Codex and Claude catalogs; paired-node rows correctly offered Terminal but not dangerous Continue.
- Focused exact-head proof: 174 tests passed across gateway runtime, terminal, session catalog, Codex catalog, and Anthropic catalog suites.
- Remote Blacksmith proof: 201 core/catalog tests, 8 Control UI E2E tests, changed checks, and production build passed.
- Structured autoreview completed cleanly with no accepted/actionable findings.
