### PR TITLE
fix(memory-host): accept repeated content length values

### DIFF
--- a/packages/memory-host-sdk/src/host/response-snippet.test.ts
+++ b/packages/memory-host-sdk/src/host/response-snippet.test.ts
@@ -96,4 +96,32 @@ describe("readMemoryHostResponseTextSnippet", () => {
     await expect(read).rejects.toThrow("json aborted");
     expect(canceled).toBe(true);
   });
+
+  it("accepts matching repeated content-length values on JSON responses", async () => {
+    await expect(
+      readResponseJsonWithLimit(
+        new Response("{}", {
+          headers: { "content-length": "0002, 0002" },
+        }),
+        {
+          errorPrefix: "remote memory",
+          maxBytes: 8,
+        },
+      ),
+    ).resolves.toEqual({});
+  });
+
+  it("rejects mismatched repeated content-length values on JSON responses", async () => {
+    await expect(
+      readResponseJsonWithLimit(
+        new Response("{}", {
+          headers: { "content-length": "0002, 2" },
+        }),
+        {
+          errorPrefix: "remote memory",
+          maxBytes: 8,
+        },
+      ),
+    ).rejects.toThrow("remote memory: invalid content-length header: 0002, 2");
+  });
 });

--- a/packages/memory-host-sdk/src/host/response-snippet.ts
+++ b/packages/memory-host-sdk/src/host/response-snippet.ts
@@ -216,18 +216,19 @@ async function cancelResponseBody(res: Response): Promise<void> {
 }
 
 function parseContentLength(raw: string | null, errorPrefix: string): number | undefined {
-  const trimmed = raw?.trim();
-  if (!trimmed) {
+  if (!raw?.trim()) {
     return undefined;
   }
-  if (!/^\d+$/.test(trimmed)) {
+  const values = raw.split(",").map((value) => value.replace(/^[\t ]+|[\t ]+$/g, ""));
+  const value = values[0] ?? "";
+  if (!/^\d+$/.test(value) || values.some((candidate) => candidate !== value)) {
     throw new Error(`${errorPrefix}: invalid content-length header: ${raw}`);
   }
-  const value = Number(trimmed);
-  if (!Number.isSafeInteger(value)) {
+  const size = Number(value);
+  if (!Number.isSafeInteger(size)) {
     throw new Error(`${errorPrefix}: invalid content-length header: ${raw}`);
   }
-  return value;
+  return size;
 }
 
 function responseTooLarge(errorPrefix: string, size: number, maxBytes: number): Error {


### PR DESCRIPTION
## What Problem This Solves

Memory Host remote JSON helpers rejected a successful response when Fetch exposed matching repeated `Content-Length` headers as a comma-combined value such as `0002, 0002`. That could make small valid JSON responses return a parser-boundary error before `postJson` or `uploadBatchJsonlFile` consumed the body.

## Why This Change Was Made

The fix stays inside the shared Memory Host response reader. It now splits comma-combined `Content-Length` values, trims HTTP optional whitespace, and trusts the declared length only when every value uses the same decimal spelling. Mismatched, malformed, or unsafe values still keep the existing invalid-header rejection, and the streaming byte cap remains unchanged.

## User Impact

Remote Memory Host calls can accept valid successful JSON responses with matching repeated length metadata while still rejecting ambiguous or malformed length headers.

## Evidence

- Claim proved: Memory Host JSON response reads accept Fetch-style comma-combined matching `Content-Length` values and reject mismatched repeats at the shared `response-snippet` boundary.
- Current-head proof at `94db7e5d8d88ffe97cc354dd985acba66b84678a`: `node scripts/run-vitest.mjs packages/memory-host-sdk/src/host/response-snippet.test.ts` passed with 7 tests.
- SDK helper path proof at `94db7e5d8d88ffe97cc354dd985acba66b84678a`: a one-off `tsx` script invoked `postJson` through its `fetchImpl` boundary with a successful `Response` carrying `Content-Length: 0002, 0002`; observed output was `{result:{},ok:true}`.
- Current-base diff hygiene at `94db7e5d8d88ffe97cc354dd985acba66b84678a`: `git diff --check upstream/main...HEAD` passed.
- Focused format check: `node_modules\.bin\oxfmt.cmd --check packages\memory-host-sdk\src\host\response-snippet.ts packages\memory-host-sdk\src\host\response-snippet.test.ts` passed.
- GitHub refreshed-head CI: `Real behavior proof`, `Critical Quality (memory-runtime-boundary)`, and `openclaw/ci-gate` all passed on the refreshed PR head.