### PR TITLE
test(e2e): synchronize npm upstream body timeout

### DIFF
--- a/test/scripts/plugins-assertions.test.ts
+++ b/test/scripts/plugins-assertions.test.ts
@@ -751,8 +751,32 @@ test -d "$OPENCLAW_PLUGINS_TMP_DIR"
     writeFileSync(
       preloadPath,
       [
-        "const nativeTimeout = AbortSignal.timeout.bind(AbortSignal);",
-        "AbortSignal.timeout = () => nativeTimeout(50);",
+        "const nativeFetch = globalThis.fetch;",
+        "let timeoutController;",
+        "let timeoutWatchdog;",
+        "AbortSignal.timeout = () => {",
+        "  timeoutController = new AbortController();",
+        "  timeoutWatchdog = setTimeout(() => process.exit(86), 5_000);",
+        "  timeoutWatchdog.unref();",
+        "  return timeoutController.signal;",
+        "};",
+        "globalThis.fetch = async (...args) => {",
+        "  const response = await nativeFetch(...args);",
+        "  let firstChunk = true;",
+        "  const body = response.body.pipeThrough(",
+        "    new TransformStream({",
+        "      transform(chunk, controller) {",
+        "        controller.enqueue(chunk);",
+        "        if (firstChunk) {",
+        "          firstChunk = false;",
+        "          clearTimeout(timeoutWatchdog);",
+        '          queueMicrotask(() => timeoutController.abort(new DOMException("timeout", "TimeoutError")));',
+        "        }",
+        "      },",
+        "    }),",
+        "  );",
+        "  return new Response(body, response);",
+        "};",
         "",
       ].join("\n"),
       "utf8",
@@ -761,7 +785,10 @@ test -d "$OPENCLAW_PLUGINS_TMP_DIR"
 
     const upstream = createServer((_request, response) => {
       upstreamHits += 1;
-      response.writeHead(200, { "content-type": "application/json" });
+      response.writeHead(200, {
+        "content-length": "1024",
+        "content-type": "application/json",
+      });
       response.write('{"partial":');
     });
     await new Promise<void>((resolve) => {


### PR DESCRIPTION
## Summary

- make the npm fixture partial-body regression abort only after body consumption begins
- preserve TimeoutError semantics and add a fail-closed watchdog
- explicitly advertise a larger body than the emitted prefix

Follow-up to #108718. Thanks @Alix-007 for the production timeout and original regression coverage.

## Validation

- node scripts/run-vitest.mjs test/scripts/plugins-assertions.test.ts --run (28 passed)
- git diff --check
- autoreview clean (0.98)

## Scope

Test-only reliability hardening. No changelog entry required.