### PR TITLE
fix(telegram): socket-level timeouts for getUpdates to prevent TCP half-open deadlock

### DIFF
--- a/extensions/telegram/src/fetch.ts
+++ b/extensions/telegram/src/fetch.ts
@@ -56,6 +56,20 @@ const TELEGRAM_TRANSPORT_ATTEMPT_FAILURE_THRESHOLD = 5;
 const TELEGRAM_TRANSPORT_ATTEMPT_INITIAL_COOLDOWN_MS = 10_000;
 const TELEGRAM_TRANSPORT_ATTEMPT_MAX_COOLDOWN_MS = 60_000;
 
+// Socket-level body timeout for getUpdates requests. When the network path
+// changes (proxy restart, TUN switch, VPN flap), undici's keep-alive sockets
+// can become TCP Half-Open. The JS-level AbortController.abort() only rejects
+// the Promise – it does not close the OS socket. A bodyTimeout tells undici to
+// close the TCP connection if no data arrives within this window, preventing
+// the polling loop from hanging indefinitely on a dead connection.
+const TELEGRAM_POLLING_BODY_TIMEOUT_MS = 90_000;
+
+// Socket-level headers timeout for getUpdates requests. When a network path
+// change leaves the connection in a TCP Half-Open state where even HTTP headers
+// never arrive, undici's headersTimeout ensures the connection is physically
+// closed rather than hanging indefinitely.
+const TELEGRAM_POLLING_HEADERS_TIMEOUT_MS = 60_000;
+
 type TelegramAgentPoolOptions = {
   allowH2: false;
   keepAliveTimeout: number;
@@ -90,7 +104,10 @@ type TelegramDispatcherAttempt = {
 };
 
 type TelegramTransportAttempt = {
-  createDispatcher: () => TelegramDispatcher;
+  createDispatcher: (timeouts?: {
+    bodyTimeout?: number;
+    headersTimeout?: number;
+  }) => TelegramDispatcher;
   exportAttempt: TelegramDispatcherAttempt;
   logLevel?: "debug" | "warn";
   logMessage?: string;
@@ -126,6 +143,8 @@ const FALLBACK_RETRY_ERROR_CODES = [
   "EHOSTUNREACH",
   "UND_ERR_CONNECT_TIMEOUT",
   "UND_ERR_SOCKET",
+  "UND_ERR_BODY_TIMEOUT",
+  "UND_ERR_HEADERS_TIMEOUT",
 ] as const;
 
 type TelegramTransportFallbackContext = {
@@ -209,6 +228,26 @@ function buildTelegramConnectOptions(params: {
   return connect;
 }
 
+function isTelegramGetUpdatesRequest(input: RequestInfo | URL): boolean {
+  try {
+    let urlStr: string;
+    if (typeof input === "string") {
+      urlStr = input;
+    } else if (input instanceof URL) {
+      urlStr = input.toString();
+    } else if (input instanceof Request) {
+      urlStr = input.url;
+    } else {
+      return false;
+    }
+    const pathname = new URL(urlStr).pathname;
+    const segments = pathname.split("/").filter(Boolean);
+    return segments.at(-1)?.toLowerCase() === "getupdates";
+  } catch {
+    return false;
+  }
+}
+
 function hasEnvHttpProxyForTelegramApi(env: NodeJS.ProcessEnv = process.env): boolean {
   return hasEnvHttpProxyAgentConfigured(env);
 }
@@ -278,7 +317,10 @@ function withPinnedLookup(
   return options ? { ...options, lookup } : { lookup };
 }
 
-function createTelegramDispatcher(policy: PinnedDispatcherPolicy): {
+function createTelegramDispatcher(
+  policy: PinnedDispatcherPolicy,
+  timeouts?: { bodyTimeout?: number; headersTimeout?: number },
+): {
   dispatcher: TelegramDispatcher;
   mode: TelegramDispatcherMode;
   effectivePolicy: PinnedDispatcherPolicy;
@@ -286,7 +328,11 @@ function createTelegramDispatcher(policy: PinnedDispatcherPolicy): {
   // Telegram polling uses long-lived connections. Undici 8 enables HTTP/2 ALPN
   // by default, which can stall Telegram long-polling on Windows/IPv6 networks.
   // Force HTTP/1.1 for every dispatcher while keeping bounded pool defaults.
-  const poolOptions = telegramAgentPoolOptions();
+  const poolOptions = {
+    ...telegramAgentPoolOptions(),
+    ...(timeouts?.bodyTimeout != null ? { bodyTimeout: timeouts.bodyTimeout } : {}),
+    ...(timeouts?.headersTimeout != null ? { headersTimeout: timeouts.headersTimeout } : {}),
+  };
 
   if (policy.mode === "explicit-proxy") {
     const requestTlsOptions = withPinnedLookup(policy.proxyTls, policy.pinnedHostname);
@@ -484,10 +530,23 @@ function createTelegramTransportAttempts(params: {
 }): TelegramTransportAttempt[] {
   params.ownedDispatchers.add(params.defaultDispatcher.dispatcher);
 
+  const defaultPolicy = params.defaultDispatcher.effectivePolicy;
+  let getUpdatesDefaultDispatcher: TelegramDispatcher | null = null;
+
   const attempts: TelegramTransportAttempt[] = [
     {
-      createDispatcher: () => params.defaultDispatcher.dispatcher,
-      exportAttempt: { dispatcherPolicy: params.defaultDispatcher.effectivePolicy },
+      createDispatcher: (timeouts) => {
+        if (timeouts) {
+          if (!getUpdatesDefaultDispatcher) {
+            const fresh = createTelegramDispatcher(defaultPolicy, timeouts);
+            getUpdatesDefaultDispatcher = fresh.dispatcher;
+            params.ownedDispatchers.add(getUpdatesDefaultDispatcher);
+          }
+          return getUpdatesDefaultDispatcher;
+        }
+        return params.defaultDispatcher.dispatcher;
+      },
+      exportAttempt: { dispatcherPolicy: defaultPolicy },
     },
   ];
 
@@ -499,7 +558,12 @@ function createTelegramTransportAttempts(params: {
 
   let ipv4Dispatcher: TelegramDispatcher | null = null;
   attempts.push({
-    createDispatcher: () => {
+    createDispatcher: (timeouts) => {
+      if (timeouts) {
+        const fresh = createTelegramDispatcher(fallbackPolicy, timeouts);
+        ownedDispatchers.add(fresh.dispatcher);
+        return fresh.dispatcher;
+      }
       if (!ipv4Dispatcher) {
         ipv4Dispatcher = createTelegramDispatcher(fallbackPolicy).dispatcher;
         ownedDispatchers.add(ipv4Dispatcher);
@@ -524,7 +588,12 @@ function createTelegramTransportAttempts(params: {
   };
   let fallbackIpDispatcher: TelegramDispatcher | null = null;
   attempts.push({
-    createDispatcher: () => {
+    createDispatcher: (timeouts) => {
+      if (timeouts) {
+        const fresh = createTelegramDispatcher(fallbackIpPolicy, timeouts);
+        ownedDispatchers.add(fresh.dispatcher);
+        return fresh.dispatcher;
+      }
       if (!fallbackIpDispatcher) {
         fallbackIpDispatcher = createTelegramDispatcher(fallbackIpPolicy).dispatcher;
         ownedDispatchers.add(fallbackIpDispatcher);
@@ -738,6 +807,13 @@ export function resolveTelegramTransport(
     const callerProvidedDispatcher = Boolean(
       (init as RequestInitWithDispatcher | undefined)?.dispatcher,
     );
+    const isGetUpdatesRequest = !callerProvidedDispatcher && isTelegramGetUpdatesRequest(input);
+    const getUpdatesTimeouts = isGetUpdatesRequest
+      ? {
+          bodyTimeout: TELEGRAM_POLLING_BODY_TIMEOUT_MS,
+          headersTimeout: TELEGRAM_POLLING_HEADERS_TIMEOUT_MS,
+        }
+      : undefined;
     const stickyStartIndex = Math.min(stickyAttemptIndex, transportAttempts.length - 1);
     const stickyCooldownError = callerProvidedDispatcher
       ? null
@@ -798,7 +874,7 @@ export function resolveTelegramTransport(
       try {
         const response = await sourceFetch(
           input,
-          withDispatcherIfMissing(init, attempt.createDispatcher()),
+          withDispatcherIfMissing(init, attempt.createDispatcher(getUpdatesTimeouts)),
         );
         captureHttpExchange({
           url: resolveRequestUrl(input),


### PR DESCRIPTION
## What Problem This Solves

When the network path changes (proxy restart, TUN switch, VPN flap), undici keep-alive sockets used by the Telegram `getUpdates` long-polling loop can enter a **TCP Half-Open** state — the OS believes the connection is alive, but no data will ever arrive.

The existing JS-level `AbortController.abort()` (45s timeout) only rejects the Promise; **it does not close the underlying OS socket**. After the abort fires, undici returns the dead socket to its keep-alive pool. The next polling cycle reuses the same half-open socket and hangs again. This creates a **silent deadlock** that:

- Evades the polling stall watchdog (which monitors `getUpdates` activity at the JS level, not the socket level)
- Persists until a full process restart (SIGTERM)
- Affects all Telegram bots on the same gateway simultaneously

This has been observed in production on WSL2/Windows environments with proxy or VPN configurations. Related reports: #86031, #108562, #56061, #57743.

## Root Cause

```
getUpdates fetch initiated
  → proxy/TUN switch
  → TCP connection half-open (no FIN/RST received)
  → server never replies
  → AbortController.abort() fires (45s JS timeout)
  → JS Promise rejected ✓
  → but TCP socket remains ESTABLISHED at OS level
  → undici socket pool does not receive a close event
  → next getUpdates cycle reuses the same dead socket
  → infinite deadlock loop
```

## Solution

Inject undici `bodyTimeout` (90s) and `headersTimeout` (60s) **into the existing transport-attempt dispatcher chain**, preserving full fallback, health tracking, and sticky promotion behavior.

### Design (Rev 2 — addresses clawsweeper P1 feedback)

The timeout injection happens **inside** the transport-attempt loop, not as a bypass:

1. **`createTelegramDispatcher(policy, timeouts?)`** — extended signature spreads optional `timeouts` into pool options for all dispatcher modes (direct / env-proxy / explicit-proxy)

2. **`TelegramTransportAttempt.createDispatcher(timeouts?)`** — each attempt factory accepts optional timeouts and creates a timeout-protected dispatcher via `createTelegramDispatcher(policy, timeouts)`. When no timeouts are passed, the existing dispatcher is reused unchanged.

3. **`resolvedFetch` routing** — for `getUpdates` requests, passes `{ bodyTimeout, headersTimeout }` to `attempt.createDispatcher()`. All other requests call `attempt.createDispatcher()` with no arguments. **getUpdates stays fully within the transport-attempt loop** — failure recording, cooldown, sticky promotion, and pinned-address/IPv4 fallback all work as before.

4. **Fallback error codes** — `UND_ERR_BODY_TIMEOUT` and `UND_ERR_HEADERS_TIMEOUT` added to `FALLBACK_RETRY_ERROR_CODES`, so socket-level timeouts trigger transport failover to the next attempt.

### Recovery path when a timeout fires

```
bodyTimeout/headersTimeout fires on half-open socket
  → undici calls util.destroy(socket) — TCP connection physically closed
  → undici throws error with code UND_ERR_BODY_TIMEOUT or UND_ERR_HEADERS_TIMEOUT
  → resolvedFetch catch block: shouldUseTelegramTransportFallback() → true (error code in whitelist)
  → recordAttemptFailure() increments failure count
  → after threshold: promoteStickyAttempt() → next attempt (IPv4-only or pinned-IP fallback)
  → new attempt creates fresh dispatcher with timeouts
  → getUpdates resumes on healthy connection
```

### Timeout hierarchy

```
45s  → JS AbortController (normal request timeout)
60s  → undici headersTimeout (headers never received — new)
90s  → undici bodyTimeout (body data never received — new)
120s → polling stall watchdog (transport rebuild)
300s → undici default headersTimeout (unchanged for non-getUpdates)
```

## Proxy Compatibility

Timeouts are applied through `createTelegramDispatcher(policy, timeouts)`, which routes through the correct dispatcher factory based on the resolved policy mode:

| Mode | Dispatcher Factory | Timeouts Applied |
|------|-------------------|-----------------|
| direct | `new Agent(...)` | ✅ |
| env-proxy | `createHttp1EnvHttpProxyAgent(...)` | ✅ |
| explicit-proxy | `createHttp1ProxyAgent(...)` | ✅ |

## Evidence

### Production incident (2026-07-16 09:41–10:00 GMT+8, before fix)

All Telegram bots on a WSL2/Windows gateway with proxy configuration entered silent deadlock simultaneously after a network path change:

- **09:41** — health-monitor detected all bots stopped, triggered restart
- **09:46** — user messages saved to session memory but no bot response
- **09:50–10:00** — gateway logs completely blank, no inbound/outbound events
- **10:00** — only supervisor SIGTERM broke the deadlock → full restart → recovered at 10:00:54

The 20-minute silent period matches TCP Half-Open behavior: OS never received FIN/RST, socket appeared healthy while no data could flow. AbortController fired but could not close the socket. Stall watchdog triggered transport rebuild, but new transport reused the same polluted socket pool.

### Code analysis

- `request-timeouts.ts`: JS-level timeout is 45s via `TELEGRAM_GET_UPDATES_REQUEST_TIMEOUT_MS`
- `polling-liveness.ts`: stall detection only tracks `lastGetUpdatesActivityAt`, not socket health
- `undici/lib/dispatcher/client-h1.js:808-810`: `bodyTimeout` triggers `util.destroy(socket)` — only path that physically closes TCP sockets
- `fetch.ts` fallback loop: `shouldUseTelegramTransportFallback()` checks error codes; the two new codes route into the existing recovery chain

### Rev 2 changes (addressing clawsweeper review)

| clawsweeper feedback | Fix |
|---|---|
| [P1] getUpdates bypasses transport fallback loop | Removed bypass dispatcher. Timeouts now injected via `attempt.createDispatcher(timeouts)` within the existing loop |
| [P1] Missing after-fix behavior proof | Added detailed recovery path analysis showing timeout → socket destroy → fallback → resume chain |

Closes #86031
Related: #108562 #56061 #57743 #78079