### PR TITLE
fix(sandbox): reject remote hardlinks under localized shells

### DIFF
--- a/src/agents/sandbox/remote-fs-bridge.test.ts
+++ b/src/agents/sandbox/remote-fs-bridge.test.ts
@@ -11,6 +11,35 @@ import {
   type RemoteShellSandboxHandle,
 } from "./remote-fs-bridge.js";
 
+function shellResult(stdout: string) {
+  return { stdout: Buffer.from(stdout), stderr: Buffer.alloc(0), code: 0 };
+}
+
+function createStatRuntime(
+  workspaceDir: string,
+  outputs: { hardlinks: (script: string) => string; stat: (script: string) => string },
+): RemoteShellSandboxHandle {
+  return {
+    remoteWorkspaceDir: workspaceDir,
+    remoteAgentWorkspaceDir: workspaceDir,
+    runRemoteShellScript: async (command) => {
+      if (command.script.includes('if [ -e "$1" ] || [ -L "$1" ]')) {
+        return shellResult("1\n");
+      }
+      if (command.script.includes('readlink -f -- "$cursor"')) {
+        return shellResult(`${workspaceDir}/note.txt\n`);
+      }
+      if (command.script.includes('stat -c "%F|%h"')) {
+        return shellResult(`${outputs.hardlinks(command.script)}\n`);
+      }
+      if (command.script.includes('stat -c "%F|%s|%y"')) {
+        return shellResult(`${outputs.stat(command.script)}\n`);
+      }
+      throw new Error(`unexpected remote script: ${command.script}`);
+    },
+  };
+}
+
 function createLocalRemoteRuntime(params: {
   remoteWorkspaceDir: string;
   remoteAgentWorkspaceDir: string;
@@ -194,40 +223,11 @@ describe("remote sandbox fs bridge", () => {
     await withTempDir("openclaw-remote-fs-bridge-stat-", async (stateDir) => {
       const workspaceDir = path.join(stateDir, "workspace");
       await fs.mkdir(workspaceDir, { recursive: true });
-      const runtime: RemoteShellSandboxHandle = {
-        remoteWorkspaceDir: workspaceDir,
-        remoteAgentWorkspaceDir: workspaceDir,
-        runRemoteShellScript: async (command) => {
-          if (command.script.includes('if [ -e "$1" ] || [ -L "$1" ]')) {
-            return { stdout: Buffer.from("1\n"), stderr: Buffer.alloc(0), code: 0 };
-          }
-          if (command.script.includes('readlink -f -- "$cursor"')) {
-            return {
-              stdout: Buffer.from(`${workspaceDir}/note.txt\n`),
-              stderr: Buffer.alloc(0),
-              code: 0,
-            };
-          }
-          if (command.script.includes('stat -c "%F|%h"')) {
-            return {
-              stdout: Buffer.from("regular file|1\n"),
-              stderr: Buffer.alloc(0),
-              code: 0,
-            };
-          }
-          if (command.script.includes('stat -c "%F|%s|%y"')) {
-            const kind = command.script.includes('LC_ALL=C stat -c "%F|%s|%y"')
-              ? "regular file"
-              : "reguläre Datei";
-            return {
-              stdout: Buffer.from(`${kind}|9007199254740992|8640000000001\n`),
-              stderr: Buffer.alloc(0),
-              code: 0,
-            };
-          }
-          throw new Error(`unexpected remote script: ${command.script}`);
-        },
-      };
+      const runtime = createStatRuntime(workspaceDir, {
+        hardlinks: () => "regular file|1",
+        stat: (script) =>
+          `${script.includes('LC_ALL=C stat -c "%F|%s|%y"') ? "regular file" : "reguläre Datei"}|9007199254740992|8640000000001`,
+      });
       const bridge = createRemoteShellSandboxFsBridge({
         sandbox: createSandbox({
           workspaceDir,
@@ -244,41 +244,35 @@ describe("remote sandbox fs bridge", () => {
     });
   });
 
+  it("rejects hardlinked files under localized remote shells", async () => {
+    await withTempDir("openclaw-remote-fs-bridge-hardlink-locale-", async (stateDir) => {
+      const workspaceDir = path.join(stateDir, "workspace");
+      await fs.mkdir(workspaceDir, { recursive: true });
+      const runtime = createStatRuntime(workspaceDir, {
+        hardlinks: (script) =>
+          `${script.includes('LC_ALL=C stat -c "%F|%h"') ? "regular file" : "reguläre Datei"}|2`,
+        stat: () => "regular file|12|2026-05-29 12:00:00.000000000 +0000",
+      });
+      const bridge = createRemoteShellSandboxFsBridge({
+        sandbox: createSandbox({
+          workspaceDir,
+          agentWorkspaceDir: workspaceDir,
+        }),
+        runtime,
+      });
+
+      await expect(bridge.stat({ filePath: "note.txt" })).rejects.toThrow(/Hardlinked path/);
+    });
+  });
+
   it("does not reject malformed non-decimal hardlink counts", async () => {
     await withTempDir("openclaw-remote-fs-bridge-hardlink-", async (stateDir) => {
       const workspaceDir = path.join(stateDir, "workspace");
       await fs.mkdir(workspaceDir, { recursive: true });
-      const runtime: RemoteShellSandboxHandle = {
-        remoteWorkspaceDir: workspaceDir,
-        remoteAgentWorkspaceDir: workspaceDir,
-        runRemoteShellScript: async (command) => {
-          if (command.script.includes('if [ -e "$1" ] || [ -L "$1" ]')) {
-            return { stdout: Buffer.from("1\n"), stderr: Buffer.alloc(0), code: 0 };
-          }
-          if (command.script.includes('readlink -f -- "$cursor"')) {
-            return {
-              stdout: Buffer.from(`${workspaceDir}/note.txt\n`),
-              stderr: Buffer.alloc(0),
-              code: 0,
-            };
-          }
-          if (command.script.includes('stat -c "%F|%h"')) {
-            return {
-              stdout: Buffer.from("regular file|0x2\n"),
-              stderr: Buffer.alloc(0),
-              code: 0,
-            };
-          }
-          if (command.script.includes('stat -c "%F|%s|%y"')) {
-            return {
-              stdout: Buffer.from("regular file|12|2026-05-29 12:00:00.000000000 +0000\n"),
-              stderr: Buffer.alloc(0),
-              code: 0,
-            };
-          }
-          throw new Error(`unexpected remote script: ${command.script}`);
-        },
-      };
+      const runtime = createStatRuntime(workspaceDir, {
+        hardlinks: () => "regular file|0x2",
+        stat: () => "regular file|12|2026-05-29 12:00:00.000000000 +0000",
+      });
       const bridge = createRemoteShellSandboxFsBridge({
         sandbox: createSandbox({
           workspaceDir,

--- a/src/agents/sandbox/remote-fs-bridge.ts
+++ b/src/agents/sandbox/remote-fs-bridge.ts
@@ -529,7 +529,7 @@ class RemoteShellSandboxFsBridge implements SandboxFsBridge {
     const result = await this.runRemoteScript({
       script: [
         'if [ ! -e "$1" ] && [ ! -L "$1" ]; then exit 0; fi',
-        'stats=$(stat -c "%F|%h" -- "$1")',
+        'stats=$(LC_ALL=C stat -c "%F|%h" -- "$1")',
         'printf "%s\\n" "$stats"',
       ].join("\n"),
       args: [params.containerPath],


### PR DESCRIPTION
Related: #105263

## What Problem This Solves

Fixes an issue where users running SSH or remote OpenShell sandboxes under a non-English locale could have hardlinked regular files treated as another file type during filesystem bridge stat checks.

## Why This Change Was Made

The remaining hardlink metadata probe now forces the stable C locale before parsing GNU `stat` file-type output. The repeated remote-stat test runtime setup is also consolidated, and a localized-shell regression covers the hardlink rejection path.

## User Impact

Remote sandbox filesystem bridges now reject hardlinked regular files consistently regardless of the remote shell locale.

## Evidence

- Before fix: focused Testbox run reproduced the bypass; the new regression resolved a file stat instead of rejecting it (7 passed, 1 failed): https://github.com/openclaw/openclaw/actions/runs/29487283325
- After fix: `node scripts/run-vitest.mjs src/agents/sandbox/remote-fs-bridge.test.ts` — 8 passed.
- Changed gate: `node scripts/check-changed.mjs -- src/agents/sandbox/remote-fs-bridge.ts src/agents/sandbox/remote-fs-bridge.test.ts` — passed all selected core/coreTests format, guard, typecheck, lint, and architecture checks: https://github.com/openclaw/openclaw/actions/runs/29488054985
- Exact-head CI: attempt 2 passed at `fbd32d18c221e11f1991d48bbf311cde694f1b9d` after rerunning one unrelated Bun process-cleanup flake: https://github.com/openclaw/openclaw/actions/runs/29489014562/attempts/2
- Autoreview: clean; no accepted/actionable findings.

AI-assisted: yes. The implementation and proof were reviewed by the maintainer agent.
