### PR TITLE
fix(e2e): bound macOS Discord host requests

### DIFF
--- a/scripts/e2e/parallels/macos-discord.ts
+++ b/scripts/e2e/parallels/macos-discord.ts
@@ -136,6 +136,10 @@ ${this.input.guestNode} ${this.input.guestOpenClawEntry} channels status --probe
   private async discordApi(method: string, apiPath: string, payload?: unknown): Promise<string> {
     const args = [
       "-fsS",
+      "--connect-timeout",
+      "10",
+      "--max-time",
+      "30",
       "-X",
       method,
       "-H",
@@ -145,7 +149,8 @@ ${this.input.guestNode} ${this.input.guestOpenClawEntry} channels status --probe
         : ["-H", "Content-Type: application/json", "--data", JSON.stringify(payload)]),
       `https://discord.com/api/v10${apiPath}`,
     ];
-    return run("curl", args, { quiet: true }).stdout;
+    // Keep smoke phase deadlines enforceable even if curl itself fails to terminate promptly.
+    return run("curl", args, { quiet: true, timeoutMs: 45_000 }).stdout;
   }
 
   private async waitForHostVisibility(nonce: string, messageId: string): Promise<void> {

--- a/test/scripts/parallels-macos-discord.test.ts
+++ b/test/scripts/parallels-macos-discord.test.ts
@@ -1,0 +1,61 @@
+// Parallels macOS Discord tests cover host-side Discord API requests.
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+
+const { runMock } = vi.hoisted(() => ({
+  runMock: vi.fn(),
+}));
+
+vi.mock("../../scripts/e2e/parallels/host-command.ts", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../../scripts/e2e/parallels/host-command.ts")>();
+  return {
+    ...actual,
+    run: runMock,
+  };
+});
+
+import { MacosDiscordSmoke } from "../../scripts/e2e/parallels/macos-discord.ts";
+
+describe("Parallels macOS Discord smoke", () => {
+  it("bounds host Discord API connections, transfers, and processes", async () => {
+    const runDir = await mkdtemp(path.join(tmpdir(), "openclaw-parallels-macos-discord-"));
+    await writeFile(path.join(runDir, "fresh.discord-sent-message-id"), "message-id\n", "utf8");
+    runMock.mockReturnValue({ status: 0, stderr: "", stdout: "" });
+
+    try {
+      const smoke = new MacosDiscordSmoke({
+        config: { channelId: "channel-id", guildId: "guild-id", token: "" },
+        guest: {} as never,
+        guestNode: "node",
+        guestOpenClaw: "openclaw",
+        guestOpenClawEntry: "openclaw.mjs",
+        runDir,
+        vmName: "macos-vm",
+      });
+
+      await smoke.cleanupMessages();
+
+      expect(runMock).toHaveBeenCalledOnce();
+      const [command, args, options] = runMock.mock.calls[0] ?? [];
+      expect(command).toBe("curl");
+      expect(args?.slice(0, 7)).toEqual([
+        "-fsS",
+        "--connect-timeout",
+        "10",
+        "--max-time",
+        "30",
+        "-X",
+        "DELETE",
+      ]);
+      expect(args?.at(-1)).toBe(
+        "https://discord.com/api/v10/channels/channel-id/messages/message-id",
+      );
+      expect(options).toEqual({ quiet: true, timeoutMs: 45_000 });
+    } finally {
+      await rm(runDir, { force: true, recursive: true });
+    }
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the Parallels macOS Discord smoke could hang beyond its phase deadline when a host-side Discord API request stopped connecting or transferring data.

## Why This Change Was Made

Adds curl connection and transfer deadlines plus a slightly longer host-process deadline. A focused behavior test verifies the complete timeout contract through the public cleanup path.

## User Impact

No product behavior change. Maintainer macOS Discord smoke runs now fail within a bounded time when Discord or the local network stalls.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/parallels-macos-discord.test.ts` — 1 passed
- `node scripts/run-vitest.mjs test/scripts/parallels-smoke-model.test.ts` — 87 passed
- `node scripts/check-changed.mjs -- scripts/e2e/parallels/macos-discord.ts test/scripts/parallels-macos-discord.test.ts` — passed on Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/29488726355
- `git diff --check` — passed
- Fresh autoreview after rebase — no findings, 0.98 confidence

AI-assisted; behavior and proof reviewed by an authorized maintainer agent.
