### PR TITLE
feat(mac): mascot accessory pack — nightcap, grad cap, hat-tip exit

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -31731,7 +31731,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 359,
+      "line": 362,
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Layout.swift",
       "source": "Back",
       "surface": "apple",
@@ -36347,7 +36347,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 588,
+      "line": 586,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/OpenClawMascotView.swift",
       "source": "z",
       "surface": "apple",

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -36347,7 +36347,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 586,
+      "line": 588,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/OpenClawMascotView.swift",
       "source": "z",
       "surface": "apple",

--- a/apps/macos/Sources/OpenClaw/OnboardingView+Layout.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingView+Layout.swift
@@ -12,7 +12,10 @@ extension OnboardingView {
             let contentHeight = self.contentHeight(for: windowGeometry.size.height)
             VStack(spacing: 0) {
                 // Chat-heavy pages shrink the mascot so the content gets the room.
-                GlowingOpenClawIcon(size: self.heroSize, mood: self.mascotMood)
+                GlowingOpenClawIcon(
+                    size: self.heroSize,
+                    mood: self.mascotMood,
+                    accessory: self.mascotAccessory)
                     .offset(y: self.usesCompactHero ? 4 : 10)
                     .frame(height: self.heroFrameHeight)
                     .animation(.spring(response: 0.45, dampingFraction: 0.85), value: self.usesCompactHero)

--- a/apps/macos/Sources/OpenClaw/OnboardingWidgets.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingWidgets.swift
@@ -10,14 +10,20 @@ struct GlowingOpenClawIcon: View {
 
     let size: CGFloat
     let mood: OpenClawMascotMood
+    let accessory: OpenClawMascotAccessory
 
-    init(size: CGFloat = 148, mood: OpenClawMascotMood = .idle) {
+    init(
+        size: CGFloat = 148,
+        mood: OpenClawMascotMood = .idle,
+        accessory: OpenClawMascotAccessory = .none)
+    {
         self.size = size
         self.mood = mood
+        self.accessory = accessory
     }
 
     var body: some View {
-        OpenClawMascotView(mood: self.mood, interactive: true)
+        OpenClawMascotView(mood: self.mood, accessory: self.accessory, interactive: true)
             .frame(width: self.size, height: self.size)
             .shadow(
                 color: OpenClawMascotView.heroGlowColor(for: self.colorScheme),
@@ -65,6 +71,10 @@ extension OnboardingView {
             remoteProbeState: self.remoteProbeState,
             allPermissionsGranted: Capability.importanceOrdered
                 .allSatisfy { self.permissionMonitor.status[$0] ?? false }))
+    }
+
+    var mascotAccessory: OpenClawMascotAccessory {
+        Self.mascotAccessory(for: self.mascotPage)
     }
 
     private var mascotPage: MascotPage {
@@ -127,6 +137,13 @@ extension OnboardingView {
             .attentive
         case .ready:
             .celebrating
+        }
+    }
+
+    static func mascotAccessory(for page: MascotPage) -> OpenClawMascotAccessory {
+        switch page {
+        case .ready: .gradCap
+        case .welcome, .connection, .cli, .ai, .permissions, .chat: .none
         }
     }
 }

--- a/apps/macos/Tests/OpenClawIPCTests/OnboardingMascotMoodTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/OnboardingMascotMoodTests.swift
@@ -8,6 +8,10 @@ struct OnboardingMascotMoodTests {
         OnboardingView.mascotMood(for: snapshot)
     }
 
+    private func accessory(_ page: OnboardingView.MascotPage) -> OpenClawMascotAccessory {
+        OnboardingView.mascotAccessory(for: page)
+    }
+
     @Test func `welcome page idles`() {
         #expect(self.mood(.init(page: .welcome)) == .idle)
     }
@@ -50,5 +54,15 @@ struct OnboardingMascotMoodTests {
 
     @Test func `fresh AI setup model does not look failed`() {
         #expect(!OnboardingView.aiSetupLooksFailed(OnboardingAISetupModel()))
+    }
+
+    @Test func `only the ready page wears a graduation cap`() {
+        #expect(self.accessory(.ready) == .gradCap)
+        #expect(self.accessory(.welcome) == .none)
+        #expect(self.accessory(.connection) == .none)
+        #expect(self.accessory(.cli) == .none)
+        #expect(self.accessory(.ai) == .none)
+        #expect(self.accessory(.permissions) == .none)
+        #expect(self.accessory(.chat) == .none)
     }
 }

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/OpenClawMascotAnimator.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/OpenClawMascotAnimator.swift
@@ -89,6 +89,10 @@ final class OpenClawMascotAnimator {
     private var dizzyUntil: TimeInterval = 0
     private var dizzyRecoveryQueued = false
 
+    // Explicit consumer headwear overrides the mood-owned accessory channel.
+    private var requestedAccessory: OpenClawMascotAccessory = .none
+    private var accessorySetAt: TimeInterval = 0
+
     // Auto-sleep: idle mascots doze off and need a click to wake up. Night
     // owls (23:00-05:00 local) nod off about twice as fast. Only mascots with
     // a tap handler may sleep — a non-interactive view has no wake path and
@@ -109,12 +113,21 @@ final class OpenClawMascotAnimator {
 
     func setMood(_ mood: OpenClawMascotMood, at time: TimeInterval) {
         guard mood != self.mood else { return }
+        let wasWorking = self.mood == .working
         self.mood = mood
         self.lastInteractionAt = time
         self.rescheduleMoodBeat(at: time)
-        if let entrance = Self.entranceGesture(for: mood) {
+        if wasWorking {
+            self.startGesture(.hatTip, at: time)
+        } else if let entrance = Self.entranceGesture(for: mood) {
             self.startGesture(entrance, at: time)
         }
+    }
+
+    func setAccessory(_ accessory: OpenClawMascotAccessory, at time: TimeInterval) {
+        guard accessory != self.requestedAccessory else { return }
+        self.requestedAccessory = accessory
+        self.accessorySetAt = time
     }
 
     /// Pointer direction from the view center, roughly unit-scaled; nil when
@@ -176,6 +189,7 @@ final class OpenClawMascotAnimator {
         self.advanceSchedules(at: time)
 
         let dozing = self.isDozing(at: time)
+        // Auto-doze reuses the sleepy base pose, including its nightcap.
         let effectiveMood: OpenClawMascotMood = dozing ? .sleepy : self.mood
         var pose = self.basePose(for: effectiveMood, at: time)
         self.applyGaze(&pose, mood: effectiveMood, at: time, dt: dt)
@@ -189,6 +203,12 @@ final class OpenClawMascotAnimator {
             } else {
                 gesture.apply(to: &pose, progress: CGFloat(progress))
             }
+        }
+
+        if self.requestedAccessory != .none {
+            pose.accessory = self.requestedAccessory
+            let progress = CGFloat((time - self.accessorySetAt) / 0.5).clamped(to: 0...1)
+            pose.accessoryAmount = OpenClawMascotGesture.easeOut(progress)
         }
 
         pose.clampChannels()
@@ -437,6 +457,8 @@ final class OpenClawMascotAnimator {
             pose.mouthRound = 0.15
             // Slow head-bob as it nods off.
             pose.bodyTilt = 2.5 * sin(2 * .pi * Self.cyclePhase(time, period: 6))
+            pose.accessory = .nightcap
+            pose.accessoryAmount = 1
             pose.effect = .zzz
             pose.effectPhase = Self.cyclePhase(time, period: 3)
         case .attentive:
@@ -538,6 +560,7 @@ enum OpenClawMascotGesture: Equatable {
     case clawSnap
     case donHardHat
     case wipeBrow
+    case hatTip
 
     static let blinkDuration: TimeInterval = 0.16
 
@@ -558,6 +581,7 @@ enum OpenClawMascotGesture: Equatable {
         case .clawSnap: 0.6
         case .donHardHat: 1.0
         case .wipeBrow: 2.0
+        case .hatTip: 0.9
         }
     }
 
@@ -686,6 +710,15 @@ enum OpenClawMascotGesture: Equatable {
             pose.gaze = CGSize(width: pose.gaze.width * (1 - env), height: pose.gaze.height * (1 - env))
             pose.effect = .sweat
             pose.effectPhase = p
+        case .hatTip:
+            let reach = Self.plateau(p, attack: 0.22, release: 0.82)
+            let brimAngle = -33 + 3 * sin(p * 4 * .pi)
+            pose.rightClawDegrees = pose.rightClawDegrees * (1 - reach) + brimAngle * reach
+            let bow = Self.bell(p)
+            pose.bodyTilt += 3 * bow
+            pose.bodyStretch -= 0.02 * bow
+            // Non-working base poses have no hard hat; this clip keeps it seated until the lift-away.
+            pose.hardHat = max(pose.hardHat, 1 - Self.easeInOut((p - 0.55) / 0.45))
         }
     }
 
@@ -694,6 +727,11 @@ enum OpenClawMascotGesture: Equatable {
     static func easeInOut(_ t: CGFloat) -> CGFloat {
         let clamped = t.clamped(to: 0...1)
         return clamped * clamped * (3 - 2 * clamped)
+    }
+
+    static func easeOut(_ t: CGFloat) -> CGFloat {
+        let remaining = 1 - t.clamped(to: 0...1)
+        return 1 - remaining * remaining * remaining
     }
 
     /// Smooth 0→1→0 bump peaking at 0.5.

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/OpenClawMascotAnimator.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/OpenClawMascotAnimator.swift
@@ -92,6 +92,8 @@ final class OpenClawMascotAnimator {
     // Explicit consumer headwear overrides the mood-owned accessory channel.
     private var requestedAccessory: OpenClawMascotAccessory = .none
     private var accessorySetAt: TimeInterval = 0
+    /// Hard-hat amount from the last rendered frame; gates the hat-tip exit.
+    private var lastHardHat: CGFloat = 0
 
     // Auto-sleep: idle mascots doze off and need a click to wake up. Night
     // owls (23:00-05:00 local) nod off about twice as fast. Only mascots with
@@ -117,7 +119,9 @@ final class OpenClawMascotAnimator {
         self.mood = mood
         self.lastInteractionAt = time
         self.rescheduleMoodBeat(at: time)
-        if wasWorking {
+        // Tip only a hat that actually seated: a working state cancelled
+        // mid-don would otherwise synthesize a full hard hat just to lift it.
+        if wasWorking, self.lastHardHat >= 0.9 {
             self.startGesture(.hatTip, at: time)
         } else if let entrance = Self.entranceGesture(for: mood) {
             self.startGesture(entrance, at: time)
@@ -210,8 +214,15 @@ final class OpenClawMascotAnimator {
             let progress = CGFloat((time - self.accessorySetAt) / 0.5).clamped(to: 0...1)
             pose.accessoryAmount = OpenClawMascotGesture.easeOut(progress)
         }
+        // One hat at a time: the working hard hat (including its hat-tip exit)
+        // owns the crown; any mood- or consumer-requested accessory waits
+        // until the hard hat is fully gone.
+        if pose.hardHat > 0.01 {
+            pose.accessoryAmount = 0
+        }
 
         pose.clampChannels()
+        self.lastHardHat = pose.hardHat
         return pose
     }
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/OpenClawMascotCanvas+Accessories.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/OpenClawMascotCanvas+Accessories.swift
@@ -1,0 +1,120 @@
+import SwiftUI
+
+extension OpenClawMascotCanvas {
+    static func drawAccessory(context: GraphicsContext, pose: OpenClawMascotPose) {
+        guard pose.accessoryAmount > 0.01 else { return }
+        var accessoryContext = context
+        accessoryContext.opacity = Double(pose.accessoryAmount)
+        accessoryContext.translateBy(x: 0, y: -14 * (1 - pose.accessoryAmount))
+
+        switch pose.accessory {
+        case .none:
+            return
+        case .nightcap:
+            self.drawNightcap(context: accessoryContext)
+        case .gradCap:
+            self.drawGradCap(context: accessoryContext, bodyTilt: pose.bodyTilt)
+        }
+    }
+
+    static func drawHardHat(context: GraphicsContext, amount: CGFloat) {
+        guard amount > 0.01 else { return }
+        var dome = Path()
+        dome.move(to: CGPoint(x: 45, y: 15))
+        dome.addCurve(
+            to: CGPoint(x: 60, y: 3),
+            control1: CGPoint(x: 47, y: 7),
+            control2: CGPoint(x: 54, y: 3))
+        dome.addCurve(
+            to: CGPoint(x: 75, y: 15),
+            control1: CGPoint(x: 66, y: 3),
+            control2: CGPoint(x: 73, y: 7))
+        dome.addLine(to: CGPoint(x: 45, y: 15))
+        dome.closeSubpath()
+        let brim = Path(roundedRect: CGRect(x: 41, y: 14, width: 38, height: 5), cornerRadius: 2)
+        var hatContext = context
+        hatContext.opacity = Double(amount)
+        hatContext.translateBy(x: 60, y: 15 - 14 * (1 - amount))
+        hatContext.rotate(by: .degrees(-5))
+        hatContext.translateBy(x: -60, y: -15)
+        hatContext.fill(
+            dome,
+            with: .linearGradient(
+                Gradient(colors: [Color(red: 1, green: 0.84, blue: 0.35), self.hatAmber]),
+                startPoint: CGPoint(x: 60, y: 3),
+                endPoint: CGPoint(x: 60, y: 16)))
+        let outline = Color(red: 0.72, green: 0.45, blue: 0.12).opacity(0.7)
+        hatContext.stroke(dome, with: .color(outline), style: StrokeStyle(lineWidth: 0.8))
+        hatContext.fill(brim, with: .color(self.hatAmber))
+        hatContext.stroke(brim, with: .color(outline), style: StrokeStyle(lineWidth: 0.8))
+    }
+
+    private static func drawNightcap(context: GraphicsContext) {
+        let capBlue = Color(red: 168 / 255, green: 199 / 255, blue: 232 / 255)
+        let bandBlue = Color(red: 120 / 255, green: 163 / 255, blue: 207 / 255)
+        let outline = Color(red: 72 / 255, green: 108 / 255, blue: 146 / 255).opacity(0.7)
+
+        var cone = Path()
+        cone.move(to: CGPoint(x: 47, y: 14))
+        cone.addCurve(
+            to: CGPoint(x: 86, y: 8),
+            control1: CGPoint(x: 53, y: 1),
+            control2: CGPoint(x: 70, y: 0))
+        cone.addCurve(
+            to: CGPoint(x: 72, y: 14),
+            control1: CGPoint(x: 82, y: 11),
+            control2: CGPoint(x: 77, y: 13))
+        cone.closeSubpath()
+        let brim = Path(roundedRect: CGRect(x: 44, y: 12, width: 32, height: 5), cornerRadius: 2)
+        let pompom = Path(ellipseIn: CGRect(x: 83, y: 5, width: 6, height: 6))
+
+        context.fill(cone, with: .color(capBlue))
+        context.stroke(cone, with: .color(outline), style: StrokeStyle(lineWidth: 0.8))
+        context.fill(brim, with: .color(bandBlue))
+        context.stroke(brim, with: .color(outline), style: StrokeStyle(lineWidth: 0.8))
+        context.fill(pompom, with: .color(capBlue))
+        context.stroke(pompom, with: .color(outline), style: StrokeStyle(lineWidth: 0.8))
+    }
+
+    private static func drawGradCap(context: GraphicsContext, bodyTilt: CGFloat) {
+        let capColor = Color(red: 28 / 255, green: 31 / 255, blue: 38 / 255)
+        let outline = Color.black.opacity(0.75)
+
+        var skullCap = Path()
+        skullCap.move(to: CGPoint(x: 50, y: 8))
+        skullCap.addLine(to: CGPoint(x: 70, y: 8))
+        skullCap.addLine(to: CGPoint(x: 68, y: 15))
+        skullCap.addLine(to: CGPoint(x: 52, y: 15))
+        skullCap.closeSubpath()
+
+        var board = Path()
+        board.move(to: CGPoint(x: 60, y: 3))
+        board.addLine(to: CGPoint(x: 77, y: 8))
+        board.addLine(to: CGPoint(x: 60, y: 13))
+        board.addLine(to: CGPoint(x: 43, y: 8))
+        board.closeSubpath()
+
+        context.fill(skullCap, with: .color(capColor))
+        context.stroke(skullCap, with: .color(outline), style: StrokeStyle(lineWidth: 0.8))
+        context.fill(board, with: .color(capColor))
+        context.stroke(board, with: .color(outline), style: StrokeStyle(lineWidth: 0.8))
+
+        let tasselAngle = (26.565 + bodyTilt * 1.5) * .pi / 180
+        let tasselEnd = CGPoint(
+            x: 60 + cos(tasselAngle) * 13.416,
+            y: 8 + sin(tasselAngle) * 13.416)
+        var tassel = Path()
+        tassel.move(to: CGPoint(x: 60, y: 8))
+        tassel.addLine(to: tasselEnd)
+        context.stroke(
+            tassel,
+            with: .color(self.hatAmber),
+            style: StrokeStyle(lineWidth: 1.2, lineCap: .round))
+        context.fill(
+            Path(ellipseIn: CGRect(x: 58.5, y: 6.5, width: 3, height: 3)),
+            with: .color(self.hatAmber))
+        context.fill(
+            Path(ellipseIn: CGRect(x: tasselEnd.x - 2, y: tasselEnd.y - 2, width: 4, height: 4)),
+            with: .color(self.hatAmber))
+    }
+}

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/OpenClawMascotView.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/OpenClawMascotView.swift
@@ -27,7 +27,9 @@ public struct OpenClawMascotView: View {
 
     private var staticPose: OpenClawMascotPose {
         var pose = OpenClawMascotPose.staticPose(for: self.mood)
-        if self.accessory != .none {
+        // One hat at a time: the working static pose already wears the hard
+        // hat, so a requested accessory stays off (mirrors the animator).
+        if self.accessory != .none, pose.hardHat == 0 {
             pose.accessory = self.accessory
             pose.accessoryAmount = 1
         }

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/OpenClawMascotView.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/OpenClawMascotView.swift
@@ -1,5 +1,11 @@
 import SwiftUI
 
+public enum OpenClawMascotAccessory: Equatable, Sendable {
+    case none
+    case nightcap
+    case gradCap
+}
+
 /// Animated OpenClaw mascot. Redraws the canonical 120x120 vector from
 /// `ui/public/favicon.svg` so individual parts (claws, antennae, eyes) can
 /// animate like the openclaw.ai hero mark; the bundled PNG asset cannot.
@@ -16,22 +22,35 @@ public struct OpenClawMascotView: View {
 
     private let floats: Bool
     private let mood: OpenClawMascotMood
+    private let accessory: OpenClawMascotAccessory
     private let interactive: Bool
+
+    private var staticPose: OpenClawMascotPose {
+        var pose = OpenClawMascotPose.staticPose(for: self.mood)
+        if self.accessory != .none {
+            pose.accessory = self.accessory
+            pose.accessoryAmount = 1
+        }
+        return pose
+    }
 
     /// - Parameters:
     ///   - floats: allow whole-body vertical travel (float loop, hops). Turn
     ///     off in tight layouts; bounces then show as squash-and-stretch only.
     ///   - mood: emotional state; transitions play an entrance gesture.
+    ///   - accessory: optional headwear layered over the mood pose.
     ///   - interactive: enables click reactions and auto-sleep (waking takes
     ///     a click). Off by default so the mascot never swallows taps meant
     ///     for an enclosing control.
     public init(
         floats: Bool = true,
         mood: OpenClawMascotMood = .idle,
+        accessory: OpenClawMascotAccessory = .none,
         interactive: Bool = false)
     {
         self.floats = floats
         self.mood = mood
+        self.accessory = accessory
         self.interactive = interactive
         self._animator = State(initialValue: OpenClawMascotAnimator(allowsAutoSleep: interactive))
     }
@@ -39,7 +58,7 @@ public struct OpenClawMascotView: View {
     public var body: some View {
         let palette = OpenClawMascotPalette.forScheme(self.colorScheme)
         if self.reduceMotion {
-            OpenClawMascotCanvas(pose: .staticPose(for: self.mood), palette: palette)
+            OpenClawMascotCanvas(pose: self.staticPose, palette: palette)
         } else {
             self.animatedMascot(palette: palette)
         }
@@ -66,8 +85,12 @@ public struct OpenClawMascotView: View {
         .onChange(of: self.mood) { _, newMood in
             self.animator.setMood(newMood, at: self.now())
         }
+        .onChange(of: self.accessory) { _, newAccessory in
+            self.animator.setAccessory(newAccessory, at: self.now())
+        }
         .onAppear {
             self.animator.setMood(self.mood, at: self.now())
+            self.animator.setAccessory(self.accessory, at: self.now())
         }
 
         if self.interactive {
@@ -173,6 +196,9 @@ struct OpenClawMascotPose: Equatable {
     var blush: CGFloat = 0
     /// 0..1: hard hat drops from above until seated on the head.
     var hardHat: CGFloat = 0
+    var accessory: OpenClawMascotAccessory = .none
+    /// 0..1: requested headwear slides from above until seated.
+    var accessoryAmount: CGFloat = 0
     /// Degrees around the canvas center.
     var bodyTilt: CGFloat = 0
     /// Vertical squash-and-stretch about the feet; x compensates slightly.
@@ -216,6 +242,8 @@ struct OpenClawMascotPose: Equatable {
             pose.rightEyeOpenness = 0.25
             pose.eyeGlowOpacity = 0.5
             pose.antennaDroop = 0.35
+            pose.accessory = .nightcap
+            pose.accessoryAmount = 1
         }
         return pose
     }
@@ -240,6 +268,7 @@ struct OpenClawMascotPose: Equatable {
         self.mouthRound = self.mouthRound.clamped(to: 0...1)
         self.blush = self.blush.clamped(to: 0...1)
         self.hardHat = self.hardHat.clamped(to: 0...1)
+        self.accessoryAmount = self.accessoryAmount.clamped(to: 0...1)
         self.bodyTilt = self.bodyTilt.clamped(to: -8...8)
         self.bodyStretch = self.bodyStretch.clamped(to: 0.86...1.05)
         self.dizzy = self.dizzy.clamped(to: 0...1)
@@ -263,7 +292,7 @@ struct OpenClawMascotCanvas: View {
     private static let eyeGlowColor = Color(red: 0, green: 229 / 255, blue: 204 / 255)
     private static let blushColor = Color(red: 1, green: 0.62, blue: 0.68)
     private static let heartColor = Color(red: 1, green: 0.45, blue: 0.55)
-    private static let hatAmber = Color(red: 0.95, green: 0.66, blue: 0.20)
+    static let hatAmber = Color(red: 0.95, green: 0.66, blue: 0.20)
     // Rotation pivots: claws hinge on their body-facing edge, antennae on their own center.
     private static let leftClawPivot = CGPoint(x: 26, y: 53)
     private static let rightClawPivot = CGPoint(x: 94, y: 53)
@@ -382,6 +411,7 @@ struct OpenClawMascotCanvas: View {
         }
 
         self.drawHardHat(context: context, amount: pose.hardHat)
+        self.drawAccessory(context: context, pose: pose)
         self.drawBlush(context: context, pose: pose)
         self.drawEye(context: context, center: self.leftEyeCenter, openness: pose.leftEyeOpenness, pose: pose)
         self.drawEye(context: context, center: self.rightEyeCenter, openness: pose.rightEyeOpenness, pose: pose)
@@ -500,38 +530,6 @@ struct OpenClawMascotCanvas: View {
                 Path(ellipseIn: CGRect(x: x - 4.5, y: 42.5, width: 9, height: 5)),
                 with: .color(self.blushColor))
         }
-    }
-
-    private static func drawHardHat(context: GraphicsContext, amount: CGFloat) {
-        guard amount > 0.01 else { return }
-        var dome = Path()
-        dome.move(to: CGPoint(x: 45, y: 15))
-        dome.addCurve(
-            to: CGPoint(x: 60, y: 3),
-            control1: CGPoint(x: 47, y: 7),
-            control2: CGPoint(x: 54, y: 3))
-        dome.addCurve(
-            to: CGPoint(x: 75, y: 15),
-            control1: CGPoint(x: 66, y: 3),
-            control2: CGPoint(x: 73, y: 7))
-        dome.addLine(to: CGPoint(x: 45, y: 15))
-        dome.closeSubpath()
-        let brim = Path(roundedRect: CGRect(x: 41, y: 14, width: 38, height: 5), cornerRadius: 2)
-        var hatContext = context
-        hatContext.opacity = Double(amount)
-        hatContext.translateBy(x: 60, y: 15 - 14 * (1 - amount))
-        hatContext.rotate(by: .degrees(-5))
-        hatContext.translateBy(x: -60, y: -15)
-        hatContext.fill(
-            dome,
-            with: .linearGradient(
-                Gradient(colors: [Color(red: 1, green: 0.84, blue: 0.35), self.hatAmber]),
-                startPoint: CGPoint(x: 60, y: 3),
-                endPoint: CGPoint(x: 60, y: 16)))
-        let outline = Color(red: 0.72, green: 0.45, blue: 0.12).opacity(0.7)
-        hatContext.stroke(dome, with: .color(outline), style: StrokeStyle(lineWidth: 0.8))
-        hatContext.fill(brim, with: .color(self.hatAmber))
-        hatContext.stroke(brim, with: .color(outline), style: StrokeStyle(lineWidth: 0.8))
     }
 
     private static func drawEffect(

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/OpenClawMascotAnimatorTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/OpenClawMascotAnimatorTests.swift
@@ -25,6 +25,7 @@ struct OpenClawMascotAnimatorTests {
                 #expect((-45...45).contains(pose.leftClawDegrees), "\(mood)")
                 #expect((-45...45).contains(pose.rightClawDegrees), "\(mood)")
                 #expect((0...1).contains(pose.hardHat), "\(mood)")
+                #expect((0...1).contains(pose.accessoryAmount), "\(mood)")
                 #expect(abs(pose.gaze.width) <= 1.2 && abs(pose.gaze.height) <= 1.2, "\(mood)")
                 time += 1.0 / 30
             }
@@ -108,6 +109,51 @@ struct OpenClawMascotAnimatorTests {
             time += 1.0 / 30
         }
         #expect(wiped)
+    }
+
+    @Test func `sleepy mood wears the nightcap`() {
+        let animator = self.makeAnimator()
+        _ = animator.pose(at: 0)
+        animator.setMood(.sleepy, at: 1)
+        let animated = animator.pose(at: 4)
+        #expect(animated.accessory == .nightcap)
+        #expect(animated.accessoryAmount == 1)
+
+        let staticPose = OpenClawMascotPose.staticPose(for: .sleepy)
+        #expect(staticPose.accessory == .nightcap)
+        #expect(staticPose.accessoryAmount == 1)
+    }
+
+    @Test func `requested graduation cap eases into the pose`() {
+        let animator = self.makeAnimator()
+        _ = animator.pose(at: 0)
+        animator.setAccessory(.gradCap, at: 1)
+
+        let initial = animator.pose(at: 1)
+        #expect(initial.accessory == .gradCap)
+        #expect(initial.accessoryAmount == 0)
+        let entering = animator.pose(at: 1.25)
+        #expect((0..<1).contains(entering.accessoryAmount))
+        let settled = animator.pose(at: 1.5)
+        #expect(settled.accessory == .gradCap)
+        #expect(settled.accessoryAmount == 1)
+    }
+
+    @Test func `leaving working tips then removes the hard hat`() {
+        let animator = self.makeAnimator()
+        _ = animator.pose(at: 0)
+        animator.setMood(.working, at: 0.1)
+        _ = animator.pose(at: 2)
+        animator.setMood(.happy, at: 2)
+
+        var keptHat = false
+        var time: TimeInterval = 2
+        while time < 2.9 {
+            keptHat = keptHat || animator.pose(at: time).hardHat > 0.3
+            time += 1.0 / 30
+        }
+        #expect(keptHat)
+        #expect(animator.pose(at: 3.5).hardHat == 0)
     }
 
     @Test func `affection taps trigger hearts`() {
@@ -207,6 +253,7 @@ struct OpenClawMascotAnimatorTests {
         pose.bodyTilt = -90
         pose.leftClawDegrees = 400
         pose.hardHat = 4
+        pose.accessoryAmount = 4
         pose.gaze = CGSize(width: 9, height: -9)
         pose.clampChannels()
         #expect(pose.floatOffset == -12)
@@ -214,6 +261,10 @@ struct OpenClawMascotAnimatorTests {
         #expect(pose.bodyTilt == -8)
         #expect(pose.leftClawDegrees == 45)
         #expect(pose.hardHat == 1)
+        #expect(pose.accessoryAmount == 1)
+        pose.accessoryAmount = -4
+        pose.clampChannels()
+        #expect(pose.accessoryAmount == 0)
         #expect(pose.gaze == CGSize(width: 1.2, height: -1.2))
     }
 }

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/OpenClawMascotAnimatorTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/OpenClawMascotAnimatorTests.swift
@@ -156,6 +156,51 @@ struct OpenClawMascotAnimatorTests {
         #expect(animator.pose(at: 3.5).hardHat == 0)
     }
 
+    @Test func `hard hat suppresses requested headwear until the tip finishes`() {
+        let animator = self.makeAnimator()
+        _ = animator.pose(at: 0)
+        animator.setMood(.working, at: 0)
+        animator.setAccessory(.gradCap, at: 0)
+
+        // While working (and through the hat-tip exit) the hard hat owns the
+        // crown: the requested cap must not co-render.
+        var time: TimeInterval = 0.2
+        while time < 3 {
+            let pose = animator.pose(at: time)
+            if pose.hardHat > 0.01 {
+                #expect(pose.accessoryAmount == 0, "two hats at t=\(time)")
+            }
+            time += 1.0 / 30
+        }
+        animator.setMood(.happy, at: 3)
+        while time < 4.4 {
+            let pose = animator.pose(at: time)
+            if pose.hardHat > 0.01 {
+                #expect(pose.accessoryAmount == 0, "two hats at t=\(time)")
+            }
+            time += 1.0 / 30
+        }
+        let after = animator.pose(at: 4.5)
+        #expect(after.hardHat == 0)
+        #expect(after.accessory == .gradCap)
+        #expect(after.accessoryAmount == 1)
+    }
+
+    @Test func `cancelled working exit skips the phantom hat tip`() {
+        let animator = self.makeAnimator()
+        _ = animator.pose(at: 0)
+        animator.setMood(.working, at: 0)
+        // The don is still in flight; the hat never seated.
+        _ = animator.pose(at: 0.15)
+        animator.setMood(.happy, at: 0.15)
+
+        var time: TimeInterval = 0.16
+        while time < 1.5 {
+            #expect(animator.pose(at: time).hardHat < 0.05, "phantom hat at t=\(time)")
+            time += 1.0 / 30
+        }
+    }
+
     @Test func `affection taps trigger hearts`() {
         let animator = self.makeAnimator()
         _ = animator.pose(at: 0)


### PR DESCRIPTION
## What Problem This Solves

The mascot's new working mood proved the pose-channel system extends well ([#108735](https://github.com/openclaw/openclaw/pull/108735)), but headwear was hardwired to one hat and one mood. Sleepy Clawd sleeps bare-headed, finishing onboarding has no payoff moment, and leaving the working mood just pops the hard hat off with no ceremony.

## Why This Change Was Made

A small accessory system in shared `OpenClawChatUI`, plus three delights built on it:

- **Accessory channel**: `accessory` (`none`/`nightcap`/`gradCap`) + clamped `accessoryAmount` slide-in. Consumers can request headwear via a new optional `OpenClawMascotView(accessory:)` parameter (additive public API, defaulted); moods can own it too.
- **Nightcap**: sleepy Clawd wears a floppy blue nightcap with a pompom — and because auto-doze reuses the sleepy base pose, an idle interactive mascot that nods off gets tucked in for free.
- **Graduation cap**: the final onboarding page ("ready") tops the existing celebration with a mortarboard whose amber tassel swings with the body tilt. Setup complete = graduation.
- **Hat-tip exit**: leaving `.working` now plays a 0.9s hat-tip — right claw to the brim, a small bow, and the hard hat lifts away — instead of the hat blinking out of existence. The gesture keeps the hat channel alive across the mood switch (non-working base poses have no hat; the clip owns it until the lift).
- Headwear drawing moved to a new `OpenClawMascotCanvas+Accessories.swift` so the main view file stays under its size budget.

## User Impact

Sleepy/dozing mascots wear a nightcap; completing onboarding earns a graduation cap on the celebrating hero; setup's hard-hat worker tips its hat when the job is done. Reduce Motion static poses include the accessories. No behavior changes elsewhere; all existing call sites compile unchanged via defaults.

| Nightcap (sleepy + zzz) | Grad cap (ready page celebration) | Hat-tip (leaving working) |
| --- | --- | --- |
| ![nightcap](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/mascot-accessories/01-nightcap-sleepy.png) | ![gradcap](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/mascot-accessories/02-gradcap-celebrating.png) | ![hattip](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/mascot-accessories/03-hattip-mid.png) |

## Evidence

- `swift test --package-path apps/shared/OpenClawKit --filter OpenClawMascotAnimatorTests` — 18/18 pass (new: sleepy nightcap base+static, requested gradCap ramp, hat-tip keeps the hat through the working→happy switch then releases it, accessoryAmount clamp; all-moods bounds sweep extended).
- `swift test --package-path apps/macos --filter OnboardingMascotMoodTests` — 8/8 pass (ready → gradCap, other pages → none).
- `swiftformat --lint` (repo config) 0/7 files; `node --import tsx scripts/native-app-i18n.ts check` passes with the synced inventory (`changed=false`); `git diff --check` clean.
- Renders above are drawn from the real animator/canvas at fixed timestamps (seeded ImageRenderer harness, not committed).
