### PR TITLE
fix(infra): add .catch() to proxy validation response body cancel

### DIFF
--- a/src/infra/net/proxy/proxy-validation.ts
+++ b/src/infra/net/proxy/proxy-validation.ts
@@ -230,7 +230,7 @@ async function defaultProxyValidationFetchCheck({
       dispatcher,
       redirect: "manual",
     });
-    void response.body?.cancel();
+    void response.body?.cancel().catch(() => undefined);
     return {
       ok: response.ok,
       status: response.status,


### PR DESCRIPTION
## Summary
Add `.catch(() => undefined)` to `void response.body?.cancel()` in proxy validation.

## What Problem This Solves
Proxy validation discards the response body with `void response.body?.cancel()`. If the stream is already terminal, `cancel()` rejects as unhandled.

**Code evidence**: [proxy-validation.ts:233](src/infra/net/proxy/proxy-validation.ts#L233)

## Evidence
- **Before**: `void response.body?.cancel()` — unhandled rejection risk
- **After**: `void response.body?.cancel().catch(() => undefined)` — safe

## Real Behavior Proof

```diff
-    void response.body?.cancel();
+    void response.body?.cancel().catch(() => undefined);
```

Matches established codebase pattern.