### PR TITLE
fix(ci): bound actionlint, OCM, and plugin-release downloads

### DIFF
--- a/.github/workflows/openclaw-performance.yml
+++ b/.github/workflows/openclaw-performance.yml
@@ -277,7 +277,7 @@ jobs:
           # retry-max-time only gates new retries; cap an active transfer separately
           # so a stalled release asset cannot consume the entire Kova job deadline.
           curl -fsSL --proto '=https' --tlsv1.2 \
-            --max-time 180 \
+            --connect-timeout 10 --max-time 180 \
             --retry 8 --retry-max-time 180 --retry-all-errors --retry-connrefused \
             -o "$ocm_archive" \
             "https://github.com/shakkernerd/ocm/releases/download/${OCM_VERSION}/ocm-x86_64-unknown-linux-gnu.tar.gz"

--- a/.github/workflows/plugin-npm-release.yml
+++ b/.github/workflows/plugin-npm-release.yml
@@ -1125,7 +1125,7 @@ jobs:
           gh api --paginate \
             "repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/attempts/${producer_attempt}/jobs?per_page=100" |
             jq -s '{total_count: ([.[].jobs[]] | length), jobs: [.[].jobs[]]}' > "$workflow_jobs"
-          curl --fail --location --silent --show-error \
+          curl --connect-timeout 10 --fail --location --silent --show-error \
             --retry 2 \
             --retry-all-errors \
             --max-time 120 \

--- a/.github/workflows/workflow-sanity.yml
+++ b/.github/workflows/workflow-sanity.yml
@@ -185,9 +185,13 @@ jobs:
           base_url="https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}"
           # GitHub release downloads occasionally return transient 5xx responses.
           # Retry all curl errors here so workflow-sanity does not fail closed on
-          # a one-off release edge outage.
-          curl --retry 5 --retry-delay 2 --retry-all-errors -sSfL -o "${archive}" "${base_url}/${archive}"
-          curl --retry 5 --retry-delay 2 --retry-all-errors -sSfL -o checksums.txt "${base_url}/actionlint_${ACTIONLINT_VERSION}_checksums.txt"
+          # a one-off release edge outage. Bound individual transfers and the
+          # retry window so stalled release assets cannot keep the job alive
+          # until the step-level timeout.
+          curl --connect-timeout 10 --max-time 120 --retry-max-time 300 \
+            --retry 5 --retry-delay 2 --retry-all-errors -sSfL -o "${archive}" "${base_url}/${archive}"
+          curl --connect-timeout 10 --max-time 120 --retry-max-time 300 \
+            --retry 5 --retry-delay 2 --retry-all-errors -sSfL -o checksums.txt "${base_url}/actionlint_${ACTIONLINT_VERSION}_checksums.txt"
           grep " ${archive}\$" checksums.txt | sha256sum -c -
           tar -xzf "${archive}" actionlint
           sudo install -m 0755 actionlint /usr/local/bin/actionlint

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -1949,6 +1949,21 @@ describe("ci workflow guards", () => {
     expect(installStep.run).toContain("--retry 5 --retry-delay 2 --retry-all-errors");
   });
 
+  it("bounds the workflow sanity actionlint downloads", () => {
+    const workflow = readWorkflowSanityWorkflow();
+    const installStep = expectDefined(
+      workflow.jobs.actionlint.steps.find(
+        (step: WorkflowStep) => step.name === "Install actionlint",
+      ),
+      "actionlint install step",
+    );
+
+    expect(installStep.run).toContain(
+      "curl --connect-timeout 10 --max-time 120 --retry-max-time 300",
+    );
+    expect(installStep.run).toContain("--retry 5 --retry-delay 2 --retry-all-errors");
+  });
+
   it("runs generated baseline drift checks in workflow sanity", () => {
     const workflow = readWorkflowSanityWorkflow();
     const steps = workflow.jobs["generated-doc-baselines"].steps;

--- a/test/scripts/openclaw-performance-workflow.test.ts
+++ b/test/scripts/openclaw-performance-workflow.test.ts
@@ -117,6 +117,7 @@ describe("OpenClaw performance workflow", () => {
       '"https://github.com/shakkernerd/ocm/releases/download/${OCM_VERSION}/ocm-x86_64-unknown-linux-gnu.tar.gz"',
     );
     expect(installRun).toContain("--max-time 180");
+    expect(installRun).toContain("--connect-timeout 10");
     expect(installRun).toContain(
       "--retry 8 --retry-max-time 180 --retry-all-errors --retry-connrefused",
     );


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the workflow-sanity actionlint download, the openclaw-performance OCM download, and the plugin-npm-release GitHub API call could remain stuck until their step-level or job-level timeout when a release asset or API endpoint connected but stopped making progress. The workflow-sanity ShellCheck download was already bounded in a prior change; the two adjacent actionlint curls were not.

## Why This Change Was Made

The two actionlint download curls now use a 10-second connection deadline, a 120-second per-attempt deadline, and a 300-second retry-start window while retaining five retries, a two-second delay, and the checksum-verified archive. The OCM download and the plugin-release API call each gain a 10-second connection deadline alongside the existing `--max-time` and `--retry` parameters.

## User Impact

Contributors and maintainers receive a bounded, actionable release-asset download or API failure instead of waiting on the broader workflow-sanity, Kova performance, or npm release job timeout. The install-cli and install-sh changes covered in prior PRs already apply the same contract to end-user installer downloads.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/ci-workflow-guards.test.ts -- -t "actionlint"` passed: 1 passed, 64 skipped.
- `node scripts/run-vitest.mjs test/scripts/openclaw-performance-workflow.test.ts -- -t "OCM"` passed: 3 passed, 27 skipped.
- `git diff --check origin/main...HEAD` passed.
- curl documents that `--connect-timeout` applies to the TCP and TLS handshake while `--max-time` caps the total transfer: https://curl.se/docs/manpage.html#--connect-timeout and https://curl.se/docs/manpage.html#--max-time
- Live open-PR search found no duplicate.