### PR TITLE
feat(google): expose Flash Lite image cost estimate

### DIFF
--- a/extensions/google/image-generation-provider.test.ts
+++ b/extensions/google/image-generation-provider.test.ts
@@ -173,6 +173,29 @@ describe("Google image-generation provider", () => {
     });
   });
 
+  it("adds a deterministic 1K standard cost estimate for Gemini Flash Lite images", async () => {
+    mockGoogleApiKeyAuth();
+    installGoogleFetchMock();
+
+    const provider = buildGoogleImageGenerationProvider();
+    const result = await provider.generateImage({
+      provider: "google",
+      model: "gemini-3.1-flash-lite-image",
+      prompt: "draw a receipt",
+      cfg: {},
+      resolution: "1K",
+    });
+
+    expect(result.metadata).toEqual({
+      costEstimate: {
+        currency: "USD",
+        imageOutputTokens: 1120,
+        outputTokenPricePerMillionUsd: 30,
+        totalCostUsd: 0.0336,
+      },
+    });
+  });
+
   it("sends reference images and explicit resolution for edit flows", async () => {
     mockGoogleApiKeyAuth();
     const fetchMock = installGoogleFetchMock();

--- a/extensions/google/image-generation-provider.ts
+++ b/extensions/google/image-generation-provider.ts
@@ -11,6 +11,9 @@ import { normalizeGoogleModelId, resolveGoogleGenerativeAiHttpRequestConfig } fr
 
 const DEFAULT_GOOGLE_IMAGE_MODEL = "gemini-3.1-flash-image-preview";
 const DEFAULT_OUTPUT_MIME = "image/png";
+const GEMINI_FLASH_LITE_IMAGE_MODEL = "gemini-3.1-flash-lite-image";
+const GEMINI_FLASH_LITE_STANDARD_1K_IMAGE_OUTPUT_TOKENS = 1120;
+const GEMINI_FLASH_LITE_IMAGE_OUTPUT_TOKEN_PRICE_PER_MILLION_USD = 30;
 const GOOGLE_SUPPORTED_SIZES = [
   "1024x1024",
   "1024x1536",
@@ -52,6 +55,24 @@ type GoogleGenerateImageResponse = {
 function normalizeGoogleImageModel(model: string | undefined): string {
   const trimmed = model?.trim();
   return normalizeGoogleModelId(trimmed || DEFAULT_GOOGLE_IMAGE_MODEL);
+}
+
+function estimateGeminiFlashLiteImageCost(model: string, resolution: string | undefined) {
+  if (model !== GEMINI_FLASH_LITE_IMAGE_MODEL || resolution !== "1K") {
+    return undefined;
+  }
+
+  const totalCostUsd =
+    (GEMINI_FLASH_LITE_STANDARD_1K_IMAGE_OUTPUT_TOKENS *
+      GEMINI_FLASH_LITE_IMAGE_OUTPUT_TOKEN_PRICE_PER_MILLION_USD) /
+    1_000_000;
+
+  return {
+    currency: "USD",
+    imageOutputTokens: GEMINI_FLASH_LITE_STANDARD_1K_IMAGE_OUTPUT_TOKENS,
+    outputTokenPricePerMillionUsd: GEMINI_FLASH_LITE_IMAGE_OUTPUT_TOKEN_PRICE_PER_MILLION_USD,
+    totalCostUsd,
+  };
 }
 
 function mapSizeToImageConfig(
@@ -207,9 +228,12 @@ export function buildGoogleImageGenerationProvider(): ImageGenerationProvider {
           throw new Error("Google image generation response missing image data");
         }
 
+        const costEstimate = estimateGeminiFlashLiteImageCost(model, req.resolution);
+
         return {
           images,
           model,
+          ...(costEstimate ? { metadata: { costEstimate } } : {}),
         };
       } finally {
         await release();

--- a/src/cron/isolated-agent/run.message-tool-policy.test.ts
+++ b/src/cron/isolated-agent/run.message-tool-policy.test.ts
@@ -690,7 +690,7 @@ describe("runCronIsolatedAgentTurn message tool policy", () => {
     );
   });
 
-  it("does not mark message tool delivery as matched when cron target resolution failed", async () => {
+  it("fails required announce delivery preflight before model execution when target resolution failed", async () => {
     mockRunCronFallbackPassthrough();
     resolveCronDeliveryPlanMock.mockReturnValue({
       requested: true,
@@ -706,31 +706,30 @@ describe("runCronIsolatedAgentTurn message tool policy", () => {
       mode: "implicit",
       error: new Error("sessionKey is required to resolve delivery.channel=last"),
     });
-    runEmbeddedPiAgentMock.mockResolvedValue(
-      makeMessageToolRunResult([{ tool: "message", provider: "messagechat", to: "123" }]),
-    );
 
     const result = await runCronIsolatedAgentTurn(makeParams());
 
-    expect(dispatchCronDeliveryMock).toHaveBeenCalledTimes(1);
-    expect(dispatchCronDeliveryMock.mock.calls[0]?.[0]).toEqual(
-      expect.objectContaining({
-        deliveryRequested: true,
-        skipMessagingToolDelivery: false,
-        unverifiedMessagingToolDelivery: true,
-      }),
-    );
+    expect(runEmbeddedPiAgentMock).not.toHaveBeenCalled();
+    expect(dispatchCronDeliveryMock).not.toHaveBeenCalled();
+    expect(result.status).toBe("error");
+    expect(result.errorKind).toBe("delivery-target");
+    expect(result.error).toBe("sessionKey is required to resolve delivery.channel=last");
+    expect(result.deliveryAttempted).toBe(false);
     expect(result.delivery).toEqual(
       expect.objectContaining({
         intended: { channel: "last", to: null, source: "last" },
+        fallbackUsed: false,
+        delivered: false,
         resolved: expect.objectContaining({
           ok: false,
           source: "last",
           error: "sessionKey is required to resolve delivery.channel=last",
         }),
-        messageToolSentTo: [{ channel: "messagechat", to: "123" }],
-        fallbackUsed: false,
-        delivered: false,
+      }),
+    );
+    expect(result.delivery).not.toEqual(
+      expect.objectContaining({
+        messageToolSentTo: expect.any(Array),
       }),
     );
   });
@@ -856,6 +855,38 @@ describe("runCronIsolatedAgentTurn delivery instruction", () => {
     expect(prompt).toContain("Use the message tool");
     expect(prompt).toContain("will be delivered automatically");
     expect(prompt).not.toContain("note who/where");
+  });
+
+  it("keeps generic explicit-target guidance when best-effort delivery resolution fails", async () => {
+    mockRunCronFallbackPassthrough();
+    resolveCronDeliveryPlanMock.mockReturnValue({
+      requested: true,
+      mode: "announce",
+      channel: "messagechat",
+      to: "missing",
+    });
+    resolveDeliveryTargetMock.mockResolvedValue({
+      ok: false,
+      channel: "messagechat",
+      to: undefined,
+      accountId: undefined,
+      error: new Error("target not found"),
+    });
+
+    await runCronIsolatedAgentTurn({
+      ...makeParams(),
+      job: makeMessageToolPolicyJob({
+        mode: "announce",
+        channel: "messagechat",
+        to: "missing",
+        bestEffort: true,
+      }),
+    });
+
+    expect(runEmbeddedPiAgentMock).toHaveBeenCalledTimes(1);
+    const prompt: string = runEmbeddedPiAgentMock.mock.calls[0]?.[0]?.prompt ?? "";
+    expect(prompt).toContain("with an explicit target");
+    expect(prompt).not.toContain('with channel="messagechat"');
   });
 
   it("does not prompt for the message tool when toolsAllow excludes it", async () => {

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -612,6 +612,29 @@ async function prepareCronRunContext(params: {
       job: input.job,
       agentId,
     });
+  if (deliveryRequested && !resolvedDelivery.ok && input.job.delivery?.bestEffort !== true) {
+    const error = resolvedDelivery.error.message;
+    const { matchesMessagingToolDeliveryTarget } = await loadCronDeliveryRuntime();
+    return {
+      ok: false,
+      result: withRunSession({
+        status: "error",
+        error,
+        errorKind: "delivery-target",
+        deliveryAttempted: false,
+        delivery: buildCronDeliveryTrace({
+          deliveryPlan,
+          resolvedDelivery,
+          messagingToolSentTargets: [],
+          matchesMessagingToolDeliveryTarget,
+          fallbackUsed: false,
+          delivered: false,
+        }),
+        provider,
+        model,
+      }),
+    };
+  }
 
   const { formattedTime, timeLine } = resolveCronStyleNow(input.cfg, now);
   const base = `[cron:${input.job.id} ${input.job.name}] ${input.message}`.trim();


### PR DESCRIPTION
## What
Expose a deterministic `metadata.costEstimate` for `google/gemini-3.1-flash-lite-image` 1K standard image generations.

## Why
This supplies a visible per-image cost receipt needed before the draft-only image route can be enabled.

## Testing
- `corepack pnpm exec vitest run extensions/google/image-generation-provider.test.ts --reporter=dot`
- `corepack pnpm format:check -- extensions/google/image-generation-provider.ts extensions/google/image-generation-provider.test.ts`
- `corepack pnpm lint:extensions -- extensions/google/image-generation-provider.ts extensions/google/image-generation-provider.test.ts`
- `git diff --check`