### PR TITLE
fix(docker): bound Docker GPG key download

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -313,7 +313,8 @@ RUN --mount=type=cache,id=openclaw-bookworm-apt-cache,target=/var/cache/apt,shar
       # Require exactly one primary key (`pub` in --with-colons; subkeys use `sub`) so we
       # never pin the first fingerprint while apt trusts extra keys from the same file.
       # Update OPENCLAW_DOCKER_GPG_FINGERPRINT when Docker rotates release keys.
-      curl -fsSL https://download.docker.com/linux/debian/gpg -o /tmp/docker.gpg.asc && \
+      curl -fsSL --connect-timeout 10 --max-time 120 \
+        https://download.docker.com/linux/debian/gpg -o /tmp/docker.gpg.asc && \
       expected_fingerprint="$(printf '%s' "$OPENCLAW_DOCKER_GPG_FINGERPRINT" | tr '[:lower:]' '[:upper:]' | tr -d '[:space:]')" && \
       docker_gpg_pub_count="$(gpg --batch --show-keys --with-colons /tmp/docker.gpg.asc | awk -F: '$1 == "pub" { c++ } END { print c+0 }')" && \
       if [ "$docker_gpg_pub_count" != "1" ]; then \

--- a/src/dockerfile.test.ts
+++ b/src/dockerfile.test.ts
@@ -540,8 +540,11 @@ describe("Dockerfile", () => {
 
   it("counts primary pub keys before Docker apt fingerprint compare and dearmor", async () => {
     const dockerfile = collapseDockerContinuations(await readFile(dockerfilePath, "utf8"));
+    expect(dockerfile).toMatch(
+      /curl -fsSL --connect-timeout 10 --max-time 120\s+https:\/\/download\.docker\.com\/linux\/debian\/gpg -o \/tmp\/docker\.gpg\.asc/u,
+    );
     const anchor = dockerfile.indexOf(
-      "curl -fsSL https://download.docker.com/linux/debian/gpg -o /tmp/docker.gpg.asc",
+      "https://download.docker.com/linux/debian/gpg -o /tmp/docker.gpg.asc",
     );
     expect(anchor).toBeGreaterThan(-1);
     const slice = dockerfile.slice(anchor);


### PR DESCRIPTION
## What Problem This Solves

When `OPENCLAW_INSTALL_DOCKER_CLI=1`, the main Dockerfile downloads Docker's apt signing key with an unbounded `curl`. A DNS, connect, or body stall can leave the optional Docker CLI image stage hanging indefinitely.

## Why This Change Was Made

Apply the repository's established download bounds to the single Docker GPG key fetch: a 10-second connection timeout and a 120-second total timeout. The existing fingerprint verification, command ordering, and failure propagation remain unchanged.

The Dockerfile contract test locks the timeout parameters to the stable key URL while preserving the fingerprint-verification anchor.

## User Impact

Optional Docker CLI image builds now fail within a bounded interval when Docker's key endpoint stalls, allowing CI or operators to retry instead of waiting indefinitely.

## Evidence

- `node scripts/test-projects.mjs src/dockerfile.test.ts -- --reporter=dot` on Node 24.15.0: 1 file, 30 tests passed.
- Targeted `oxlint`, `oxfmt --check`, and `git diff --check`: passed.
- Controlled loopback stall: `curl --connect-timeout 1 --max-time 1` exited 28 after about 1 second and did not execute the following command.
- Fresh non-author Codex adversarial review: no actionable findings; estimated landability 88%.
- Testbox/Crabbox was unavailable. The focused suite used the documented local fallback on the data volume; a full modern BuildKit build of the optional stage remains a proof gap because the local Docker endpoint failed during TLS setup.
