### PR TITLE
fix(qqbot): bound channel API response reads

### DIFF
--- a/extensions/qqbot/src/engine/tools/channel-api.test.ts
+++ b/extensions/qqbot/src/engine/tools/channel-api.test.ts
@@ -44,6 +44,7 @@ function cancelTrackedResponse(
 
 describe("executeChannelApi", () => {
   afterEach(() => {
+    vi.useRealTimers();
     vi.restoreAllMocks();
     fetchWithSsrFGuardMock.mockReset();
   });
@@ -83,6 +84,47 @@ describe("executeChannelApi", () => {
         allowRfc2544BenchmarkRange: true,
       },
     });
+  });
+
+  it.each([
+    { label: "successful", responseInit: { status: 200 } },
+    {
+      label: "error",
+      responseInit: { status: 503, statusText: "Service Unavailable" },
+    },
+  ])("keeps the request deadline through $label response body reads", async ({ responseInit }) => {
+    vi.useFakeTimers();
+    const release = vi.fn(async () => {});
+    fetchWithSsrFGuardMock.mockImplementationOnce(async ({ init }: { init?: RequestInit }) => {
+      const signal = init?.signal;
+      if (!(signal instanceof AbortSignal)) {
+        throw new Error("expected channel API request signal");
+      }
+      const body = new ReadableStream<Uint8Array>({
+        start(controller) {
+          signal.addEventListener("abort", () => controller.error(signal.reason), {
+            once: true,
+          });
+        },
+      });
+      return {
+        response: new Response(body, responseInit),
+        release,
+      };
+    });
+
+    const resultPromise = executeChannelApi(
+      { method: "GET", path: "/guilds/123/channels" },
+      { accessToken: "token-1" },
+    );
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    const result = await resultPromise;
+    expect(result.details).toEqual({
+      error: "Request timed out after 30000ms",
+      path: "/guilds/123/channels",
+    });
+    expect(release).toHaveBeenCalledTimes(1);
   });
 
   it("blocks guild listing when qqbot groups are scoped", async () => {

--- a/extensions/qqbot/src/engine/tools/channel-api.test.ts
+++ b/extensions/qqbot/src/engine/tools/channel-api.test.ts
@@ -127,6 +127,50 @@ describe("executeChannelApi", () => {
     expect(release).toHaveBeenCalledTimes(1);
   });
 
+  it("clears the request deadline when guarded fetch fails before headers", async () => {
+    vi.useFakeTimers();
+    fetchWithSsrFGuardMock.mockRejectedValueOnce(new Error("offline"));
+
+    const result = await executeChannelApi(
+      { method: "GET", path: "/guilds/123/channels" },
+      { accessToken: "token-1" },
+    );
+
+    expect(result.details).toEqual({
+      error: "Network error: offline",
+      path: "/guilds/123/channels",
+    });
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("does not label an unrelated body abort as a request timeout", async () => {
+    const release = vi.fn(async () => {});
+    const bodyError = new Error("upstream body aborted");
+    bodyError.name = "AbortError";
+    fetchWithSsrFGuardMock.mockResolvedValueOnce({
+      response: new Response(
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.error(bodyError);
+          },
+        }),
+        { status: 200 },
+      ),
+      release,
+    });
+
+    const result = await executeChannelApi(
+      { method: "GET", path: "/guilds/123/channels" },
+      { accessToken: "token-1" },
+    );
+
+    expect(result.details).toEqual({
+      error: "upstream body aborted",
+      path: "/guilds/123/channels",
+    });
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+
   it("blocks guild listing when qqbot groups are scoped", async () => {
     const result = await executeChannelApi(
       { method: "GET", path: "/users/@me/guilds" },

--- a/extensions/qqbot/src/engine/tools/channel-api.ts
+++ b/extensions/qqbot/src/engine/tools/channel-api.ts
@@ -348,8 +348,6 @@ export async function executeChannelApi(
         error: `Network error: ${formatErrorMessage(err)}`,
         path: params.path,
       });
-    } finally {
-      clearTimeout(timeoutId);
     }
 
     try {
@@ -397,9 +395,17 @@ export async function executeChannelApi(
         data: parsed,
       });
     } finally {
+      clearTimeout(timeoutId);
       await release?.();
     }
   } catch (err) {
+    if (err instanceof Error && err.name === "AbortError") {
+      debugError(`[qqbot-channel-api] <<< Request timeout after ${DEFAULT_TIMEOUT_MS}ms`);
+      return json({
+        error: `Request timed out after ${DEFAULT_TIMEOUT_MS}ms`,
+        path: params.path,
+      });
+    }
     return json({
       error: formatErrorMessage(err),
       path: params.path,

--- a/extensions/qqbot/src/engine/tools/channel-api.ts
+++ b/extensions/qqbot/src/engine/tools/channel-api.ts
@@ -323,8 +323,8 @@ export async function executeChannelApi(
 
     debugLog(`[qqbot-channel-api] >>> ${method} ${url} (timeout: ${DEFAULT_TIMEOUT_MS}ms)`);
 
-    let res: Response;
     let release: (() => Promise<void>) | undefined;
+    let receivedResponse = false;
     try {
       const guarded = await fetchWithSsrFGuard({
         url,
@@ -332,25 +332,10 @@ export async function executeChannelApi(
         auditContext: "qqbot-channel-api",
         policy: resolveChannelApiSsrfPolicy(url),
       });
-      res = guarded.response;
       release = guarded.release;
-    } catch (err) {
-      clearTimeout(timeoutId);
-      if (err instanceof Error && err.name === "AbortError") {
-        debugError(`[qqbot-channel-api] <<< Request timeout after ${DEFAULT_TIMEOUT_MS}ms`);
-        return json({
-          error: `Request timed out after ${DEFAULT_TIMEOUT_MS}ms`,
-          path: params.path,
-        });
-      }
-      debugError("[qqbot-channel-api] <<< Network error:", err);
-      return json({
-        error: `Network error: ${formatErrorMessage(err)}`,
-        path: params.path,
-      });
-    }
+      receivedResponse = true;
+      const res = guarded.response;
 
-    try {
       debugLog(`[qqbot-channel-api] <<< Status: ${res.status} ${res.statusText}`);
 
       const rawBody = res.ok
@@ -394,18 +379,30 @@ export async function executeChannelApi(
         path: params.path,
         data: parsed,
       });
+    } catch (err) {
+      if (controller.signal.aborted && err instanceof Error && err.name === "AbortError") {
+        debugError(`[qqbot-channel-api] <<< Request timeout after ${DEFAULT_TIMEOUT_MS}ms`);
+        return json({
+          error: `Request timed out after ${DEFAULT_TIMEOUT_MS}ms`,
+          path: params.path,
+        });
+      }
+      if (!receivedResponse) {
+        debugError("[qqbot-channel-api] <<< Network error:", err);
+        return json({
+          error: `Network error: ${formatErrorMessage(err)}`,
+          path: params.path,
+        });
+      }
+      return json({
+        error: formatErrorMessage(err),
+        path: params.path,
+      });
     } finally {
       clearTimeout(timeoutId);
       await release?.();
     }
   } catch (err) {
-    if (err instanceof Error && err.name === "AbortError") {
-      debugError(`[qqbot-channel-api] <<< Request timeout after ${DEFAULT_TIMEOUT_MS}ms`);
-      return json({
-        error: `Request timed out after ${DEFAULT_TIMEOUT_MS}ms`,
-        path: params.path,
-      });
-    }
     return json({
       error: formatErrorMessage(err),
       path: params.path,


### PR DESCRIPTION
## What Problem This Solves

The `qqbot_channel_api` tool starts a 30-second request deadline, but clears it as soon as response headers arrive. A QQ API response that sends headers and then stalls can therefore leave either the success or error body reader pending indefinitely.

## Why This Change Was Made

Keep the existing controller active through response-body consumption and guarded-response release. Post-header aborts use the tool's established timeout payload, while non-abort body errors keep their existing formatting.

The regression test covers both a stalled 200 body and a stalled 503 body, including one-time response release. This is a separate channel-tool surface from #103855, which changes only the QQBot `ApiClient`.

## User Impact

QQBot channel API tool calls now fail predictably after 30 seconds when a response body stalls instead of hanging the agent run indefinitely.

## Evidence

- `node scripts/test-projects.mjs extensions/qqbot/src/engine/tools/channel-api.test.ts -- --reporter=dot` on Node 24.15.0: 1 file, 16 tests passed.
- Targeted `oxlint`, `oxfmt --check`, and `git diff --check`: passed.
- Controlled Undici probe: stalled 200 and 503 bodies both rejected with `AbortError`, set the request signal to aborted, and closed the server connection.
- Fresh non-author Codex adversarial review: no actionable findings; estimated landability 91%.
- Testbox/Crabbox was unavailable, so the focused suite used the documented local fallback with its temporary directory on the data volume.
