### PR TITLE
fix(ci): bound actionlint downloads in workflow sanity

### DIFF
--- a/.github/workflows/workflow-sanity.yml
+++ b/.github/workflows/workflow-sanity.yml
@@ -185,9 +185,14 @@ jobs:
           base_url="https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}"
           # GitHub release downloads occasionally return transient 5xx responses.
           # Retry all curl errors here so workflow-sanity does not fail closed on
-          # a one-off release edge outage.
-          curl --retry 5 --retry-delay 2 --retry-all-errors -sSfL -o "${archive}" "${base_url}/${archive}"
-          curl --retry 5 --retry-delay 2 --retry-all-errors -sSfL -o checksums.txt "${base_url}/actionlint_${ACTIONLINT_VERSION}_checksums.txt"
+          # a one-off release edge outage, and bound each transfer so a stalled
+          # connection cannot hold the actionlint job open indefinitely.
+          curl --connect-timeout 10 --max-time 120 \
+            --retry 5 --retry-delay 2 --retry-all-errors -sSfL \
+            -o "${archive}" "${base_url}/${archive}"
+          curl --connect-timeout 10 --max-time 120 \
+            --retry 5 --retry-delay 2 --retry-all-errors -sSfL \
+            -o checksums.txt "${base_url}/actionlint_${ACTIONLINT_VERSION}_checksums.txt"
           grep " ${archive}\$" checksums.txt | sha256sum -c -
           tar -xzf "${archive}" actionlint
           sudo install -m 0755 actionlint /usr/local/bin/actionlint

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -1949,6 +1949,21 @@ describe("ci workflow guards", () => {
     expect(installStep.run).toContain("--retry 5 --retry-delay 2 --retry-all-errors");
   });
 
+  it("bounds the workflow sanity actionlint downloads", () => {
+    const workflow = readWorkflowSanityWorkflow();
+    const installStep = expectDefined(
+      workflow.jobs.actionlint.steps.find(
+        (step: WorkflowStep) => step.name === "Install actionlint",
+      ),
+      "actionlint install step",
+    );
+
+    expect(installStep.run).toContain("curl --connect-timeout 10 --max-time 120");
+    expect(installStep.run).toContain("--retry 5 --retry-delay 2 --retry-all-errors");
+    expect(installStep.run).toContain("${base_url}/${archive}");
+    expect(installStep.run).toContain("checksums.txt");
+  });
+
   it("runs generated baseline drift checks in workflow sanity", () => {
     const workflow = readWorkflowSanityWorkflow();
     const steps = workflow.jobs["generated-doc-baselines"].steps;

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -1958,7 +1958,9 @@ describe("ci workflow guards", () => {
       "actionlint install step",
     );
 
-    expect(installStep.run).toContain("curl --connect-timeout 10 --max-time 120");
+    const boundedCurlPattern = /curl --connect-timeout 10 --max-time 120/gu;
+    const boundedCurlCount = (installStep.run!.match(boundedCurlPattern) ?? []).length;
+    expect(boundedCurlCount).toBe(2);
     expect(installStep.run).toContain("--retry 5 --retry-delay 2 --retry-all-errors");
     expect(installStep.run).toContain("${base_url}/${archive}");
     expect(installStep.run).toContain("checksums.txt");


### PR DESCRIPTION
## What Problem This Solves

The actionlint archive and checksums downloads in `workflow-sanity.yml` retried transient errors but did not bound each transfer, so a stalled connection could hold the workflow-sanity `actionlint` job open indefinitely. This is the same class of issue as #108723 (Android SDK downloads) and #108444 (workflow sanity tool installation).

## Solution

Add `--connect-timeout 10 --max-time 120` to both actionlint `curl` downloads, matching the existing ShellCheck download guard in the same job. The regression test now counts exactly two bounded curl invocations to enforce the two-download invariant.

## Evidence

**Successful real download with the new bounds:**

```
$ curl --connect-timeout 10 --max-time 120 -sSfL -o /dev/null -w "HTTP %{http_code}, connect: %{time_connect}s, total: %{time_total}s, size: %{size_download} bytes\n"   "https://github.com/rhysd/actionlint/releases/download/v1.7.11/actionlint_1.7.11_linux_amd64.tar.gz"
HTTP 200, connect: 0.089363s, total: 19.198259s, size: 2265519 bytes

$ curl --connect-timeout 10 --max-time 120 -sSfL -o /dev/null -w "HTTP %{http_code}, connect: %{time_connect}s, total: %{time_total}s, size: %{size_download} bytes\n"   "https://github.com/rhysd/actionlint/releases/download/v1.7.11/actionlint_1.7.11_checksums.txt"
HTTP 200, connect: 0.101191s, total: 1.711440s, size: 1130 bytes
```

**Controlled stall terminates within the bound:**

```
$ curl --connect-timeout 5 --max-time 8 -o /dev/null -w "HTTP %{http_code}, connect: %{time_connect}s, total: %{time_total}s\n" "http://192.0.2.1/"
HTTP 000, connect: 0.049022s, total: 8.001970s
curl: (28) Operation timed out after 8001 milliseconds with 0 bytes received
```

Without `--max-time`, this stalled connection would hang indefinitely. With the bound, curl exits with code 28 after the deadline, allowing the retry policy to recover or the job to fail fast.

- YAML parses cleanly.
- Test `bounds the workflow sanity actionlint downloads` asserts exactly two bounded curl invocations.
- All CI checks pass.

🤖 Generated with [OpenClaw](https://github.com/openclaw/openclaw)