### PR TITLE
fix(ci): bound plugin npm artifact download connect phase

### DIFF
--- a/.github/workflows/plugin-npm-release.yml
+++ b/.github/workflows/plugin-npm-release.yml
@@ -1128,6 +1128,7 @@ jobs:
           curl --fail --location --silent --show-error \
             --retry 2 \
             --retry-all-errors \
+            --connect-timeout 10 \
             --max-time 120 \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer ${GH_TOKEN}" \

--- a/test/scripts/plugin-npm-extended-stable-workflow.test.ts
+++ b/test/scripts/plugin-npm-extended-stable-workflow.test.ts
@@ -353,6 +353,9 @@ describe("plugin npm extended-stable workflow", () => {
     );
     expect(consume.run).toContain("--workflow-jobs-metadata");
     expect(consume.run).toContain("--source-package-json-sha256");
+    expect(consume.run).toContain("--connect-timeout 10");
+    expect(consume.run).toContain("--max-time 120");
+    expect(consume.run).toContain("actions/artifacts/${artifact_id}/zip");
     expect(consume.run).toContain("sha_pinned_release_publish=false");
     expect(consume.run).toContain(
       '[[ "$WORKFLOW_REF" =~ ^refs/tags/release-publish/([a-f0-9]{12})-[1-9][0-9]*$ ]]',


### PR DESCRIPTION
## What Problem This Solves

The immutable plugin npm publication artifact download already had a 120-second per-attempt transfer deadline. A stalled DNS, proxy, TCP, or TLS connection could therefore consume the full attempt before curl retried it.

## Solution

Add `--connect-timeout 10` to the existing authenticated artifact download. This makes connection-phase failures retry after 10 seconds while preserving the existing `--max-time 120`, `--retry 2`, `--retry-all-errors`, endpoint, authentication, metadata limits, and artifact verification.

The workflow contract assertions are folded into the existing immutable-publication evidence test instead of adding a duplicate test case.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/plugin-npm-extended-stable-workflow.test.ts` — 9 passed.
- `node scripts/check-changed.mjs -- .github/workflows/plugin-npm-release.yml test/scripts/plugin-npm-extended-stable-workflow.test.ts` — Testbox passed: https://github.com/openclaw/openclaw/actions/runs/29522159800
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted` — clean; no accepted/actionable findings.
- `git diff --check` — passed.

AI-assisted; maintainer-reviewed and understood.
