### PR TITLE
fix(ci): bound full release validation evidence dispatch

### DIFF
--- a/.github/workflows/full-release-validation.yml
+++ b/.github/workflows/full-release-validation.yml
@@ -1906,6 +1906,8 @@ jobs:
           )"
 
           if ! curl --fail-with-body \
+            --connect-timeout 10 \
+            --max-time 30 \
             -X POST \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer ${RELEASES_DISPATCH_TOKEN}" \

--- a/test/scripts/release-no-push-workflow.test.ts
+++ b/test/scripts/release-no-push-workflow.test.ts
@@ -337,6 +337,9 @@ describe("release validation no-push transport", () => {
     expect(verify.run).toContain('"openclaw-release-checks.yml"');
     expect(dispatch.run).not.toContain('GITHUB_RUN_ID_VALUE="$EVIDENCE_ROOT_RUN_ID"');
     expect(dispatch.run).toContain("reused green product evidence from chain-root run");
+    expect(dispatch.run).toContain("--connect-timeout 10");
+    expect(dispatch.run).toContain("--max-time 30");
+    expect(dispatch.run).toContain("https://api.github.com/repos/openclaw/releases/dispatches");
   });
 
   it("publishes an attempt-qualified canonical manifest plus a temporary legacy alias", () => {


### PR DESCRIPTION
## What Problem This Solves

The repository dispatch POST that forwards full release validation evidence to `openclaw/releases` had no finite curl connection or whole-transfer deadline. A stalled GitHub API request could therefore hold the release validation summary job open indefinitely.

## Solution

Add `--connect-timeout 10` and `--max-time 30` to the existing authenticated POST. Payload construction, endpoint, token use, and dispatch semantics remain unchanged. Timeout or API failure continues through the existing warning and manual backfill instructions, while child workflow validation remains authoritative.

The regression assertions live in the existing full-release workflow contract test.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/release-no-push-workflow.test.ts` — 14 passed.
- `node scripts/check-changed.mjs -- .github/workflows/full-release-validation.yml test/scripts/release-no-push-workflow.test.ts` — Testbox passed: https://github.com/openclaw/openclaw/actions/runs/29523894276
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted` — clean; no accepted/actionable findings.
- `git diff --check` — passed.

AI-assisted; maintainer-reviewed and understood.
