### PR TITLE
fix(qqbot): surface terminal reply-session conflict failures

### DIFF
--- a/extensions/qqbot/src/engine/gateway/gateway.ts
+++ b/extensions/qqbot/src/engine/gateway/gateway.ts
@@ -342,7 +342,12 @@ async function startTypingForEvent(
 
 // ============ terminal notice for exhausted session-init conflicts ============
 
-/** Dependencies injected to keep the function testable without a full gateway. */
+/** Dependencies injected to keep the function testable without a full gateway.
+ *
+ * The interface and function are kept exported because the test suite
+ * imports them via `await import("./gateway.js")` to side-step module
+ * evaluation side effects; the production caller (`handleMessage`) uses
+ * them as module-local references. */
 export interface SessionConflictTerminalNoticeDeps {
   event: QueuedMessage;
   account: GatewayAccount;
@@ -395,10 +400,11 @@ export async function sendReplySessionConflictTerminalNotice(
       msgId: event.messageId,
     });
   } catch (sendErr) {
+    const sendErrDetail = sendErr instanceof Error ? sendErr.message : String(sendErr);
     log?.error(
       `terminal_notice_failed — errorId=${errorId} ` +
         `messageId=${event.messageId}: ` +
-        `${sendErr instanceof Error ? sendErr.message : String(sendErr)}`,
+        sendErrDetail,
     );
   }
 }

--- a/extensions/qqbot/src/engine/gateway/gateway.ts
+++ b/extensions/qqbot/src/engine/gateway/gateway.ts
@@ -359,8 +359,9 @@ export interface SessionConflictTerminalNoticeDeps {
  * error text, session keys, or stack traces are exposed.
  *
  * If the terminal notice itself fails to send, the failure is logged at
- * ``terminal_notice_failed`` and the message is not marked delivered.
- * QQBot currently has no durable-spool / replay-claim system — that is
+ * ``terminal_notice_failed`` and the session's inbound work completes with
+ * no delivery.  QQBot currently has no durable ingress or replay mechanism
+ * to automatically recover the original message — that is
  * deferred to a follow-up PR.
  */
 export async function sendReplySessionConflictTerminalNotice(
@@ -370,7 +371,14 @@ export async function sendReplySessionConflictTerminalNotice(
   if (!isReplySessionInitConflictError(error)) {
     return;
   }
-  const { event, account, log, senderSendText, buildDeliveryTargetFn, accountToCredsFn } = deps;
+  const {
+    event,
+    account,
+    log,
+    senderSendText: senderSendTextFn,
+    buildDeliveryTargetFn,
+    accountToCredsFn,
+  } = deps;
   const errorId = generateSessionConflictErrorId();
   const terminalText = `当前消息因会话冲突未能处理，请重新发送。\n错误编号：${errorId}`;
 
@@ -383,7 +391,7 @@ export async function sendReplySessionConflictTerminalNotice(
   );
 
   try {
-    await senderSendText(buildDeliveryTargetFn(event), terminalText, accountToCredsFn(account), {
+    await senderSendTextFn(buildDeliveryTargetFn(event), terminalText, accountToCredsFn(account), {
       msgId: event.messageId,
     });
   } catch (sendErr) {

--- a/extensions/qqbot/src/engine/gateway/gateway.ts
+++ b/extensions/qqbot/src/engine/gateway/gateway.ts
@@ -29,6 +29,10 @@ import { buildInboundContext, clearGroupPendingHistory } from "./inbound-pipelin
 import { createInteractionHandler } from "./interaction-handler.js";
 import type { QueuedMessage } from "./message-queue.js";
 import { dispatchOutbound } from "./outbound-dispatch.js";
+import {
+  generateSessionConflictErrorId,
+  isReplySessionInitConflictError,
+} from "./reply-session-conflict.js";
 import type {
   CoreGatewayContext,
   GatewayAccount,
@@ -230,31 +234,14 @@ export async function startGateway(ctx: CoreGatewayContext): Promise<void> {
       );
     } catch (err) {
       log?.error(`Message processing failed: ${err instanceof Error ? err.message : String(err)}`);
-
-      // When shared-core retry (#105754) has exhausted, surface a terminal
-      // notice to the user so the silent-message-loss path is closed.
-      if (isReplySessionInitConflictError(err)) {
-        const errorId = generateSessionConflictErrorId();
-        const terminalText = `当前消息因会话冲突未能处理，请重新发送。\n错误编号：${errorId}`;
-        log?.error(
-          `reply session init conflict exhausted — ` +
-            `messageId=${event.messageId} ` +
-            `senderId=${event.senderId} ` +
-            `groupOpenid=${event.groupOpenid ?? ""} ` +
-            `errorId=${errorId}`,
-        );
-        try {
-          await senderSendText(buildDeliveryTarget(event), terminalText, accountToCreds(account), {
-            msgId: event.messageId,
-          });
-        } catch (sendErr) {
-          log?.error(
-            `terminal_notice_failed — errorId=${errorId} ` +
-              `messageId=${event.messageId}: ` +
-              `${sendErr instanceof Error ? sendErr.message : String(sendErr)}`,
-          );
-        }
-      }
+      await sendReplySessionConflictTerminalNotice(err, {
+        event,
+        account,
+        log,
+        senderSendText,
+        buildDeliveryTargetFn: buildDeliveryTarget,
+        accountToCredsFn: accountToCreds,
+      });
       if (event.turnAdoptionLifecycle) {
         throw err;
       }
@@ -353,17 +340,57 @@ async function startTypingForEvent(
   }
 }
 
-// ============ reply-session-init conflict helpers ============
+// ============ terminal notice for exhausted session-init conflicts ============
 
-const REPLY_SESSION_INIT_CONFLICT_MESSAGE_RE = /^reply session initialization conflicted for \S+$/u;
-
-function isReplySessionInitConflictError(error: unknown): boolean {
-  const message = error instanceof Error ? error.message : String(error);
-  return REPLY_SESSION_INIT_CONFLICT_MESSAGE_RE.test(message);
+/** Dependencies injected to keep the function testable without a full gateway. */
+export interface SessionConflictTerminalNoticeDeps {
+  event: QueuedMessage;
+  account: GatewayAccount;
+  log?: EngineLogger;
+  senderSendText: typeof senderSendText;
+  buildDeliveryTargetFn: typeof buildDeliveryTarget;
+  accountToCredsFn: typeof accountToCreds;
 }
 
-function generateSessionConflictErrorId(): string {
-  const buf = new Uint32Array(2);
-  crypto.getRandomValues(buf);
-  return buf[0]!.toString(16).padStart(8, "0").slice(0, 8);
+/**
+ * When shared-core retry ([#105754]) has exhausted, surface a best-effort
+ * terminal notice to the QQ user.  The notice is deliberately terse and
+ * carries an 8-char hex error reference for log correlation.  No internal
+ * error text, session keys, or stack traces are exposed.
+ *
+ * If the terminal notice itself fails to send, the failure is logged at
+ * ``terminal_notice_failed`` and the message is not marked delivered.
+ * QQBot currently has no durable-spool / replay-claim system — that is
+ * deferred to a follow-up PR.
+ */
+export async function sendReplySessionConflictTerminalNotice(
+  error: unknown,
+  deps: SessionConflictTerminalNoticeDeps,
+): Promise<void> {
+  if (!isReplySessionInitConflictError(error)) {
+    return;
+  }
+  const { event, account, log, senderSendText, buildDeliveryTargetFn, accountToCredsFn } = deps;
+  const errorId = generateSessionConflictErrorId();
+  const terminalText = `当前消息因会话冲突未能处理，请重新发送。\n错误编号：${errorId}`;
+
+  log?.error(
+    `reply session init conflict exhausted — ` +
+      `messageId=${event.messageId} ` +
+      `senderId=${event.senderId} ` +
+      `groupOpenid=${event.groupOpenid ?? ""} ` +
+      `errorId=${errorId}`,
+  );
+
+  try {
+    await senderSendText(buildDeliveryTargetFn(event), terminalText, accountToCredsFn(account), {
+      msgId: event.messageId,
+    });
+  } catch (sendErr) {
+    log?.error(
+      `terminal_notice_failed — errorId=${errorId} ` +
+        `messageId=${event.messageId}: ` +
+        `${sendErr instanceof Error ? sendErr.message : String(sendErr)}`,
+    );
+  }
 }

--- a/extensions/qqbot/src/engine/gateway/gateway.ts
+++ b/extensions/qqbot/src/engine/gateway/gateway.ts
@@ -230,6 +230,31 @@ export async function startGateway(ctx: CoreGatewayContext): Promise<void> {
       );
     } catch (err) {
       log?.error(`Message processing failed: ${err instanceof Error ? err.message : String(err)}`);
+
+      // When shared-core retry (#105754) has exhausted, surface a terminal
+      // notice to the user so the silent-message-loss path is closed.
+      if (isReplySessionInitConflictError(err)) {
+        const errorId = generateSessionConflictErrorId();
+        const terminalText = `当前消息因会话冲突未能处理，请重新发送。\n错误编号：${errorId}`;
+        log?.error(
+          `reply session init conflict exhausted — ` +
+            `messageId=${event.messageId} ` +
+            `senderId=${event.senderId} ` +
+            `groupOpenid=${event.groupOpenid ?? ""} ` +
+            `errorId=${errorId}`,
+        );
+        try {
+          await senderSendText(buildDeliveryTarget(event), terminalText, accountToCreds(account), {
+            msgId: event.messageId,
+          });
+        } catch (sendErr) {
+          log?.error(
+            `terminal_notice_failed — errorId=${errorId} ` +
+              `messageId=${event.messageId}: ` +
+              `${sendErr instanceof Error ? sendErr.message : String(sendErr)}`,
+          );
+        }
+      }
       if (event.turnAdoptionLifecycle) {
         throw err;
       }
@@ -326,4 +351,19 @@ async function startTypingForEvent(
     log?.error(`sendInputNotify error: ${err instanceof Error ? err.message : String(err)}`);
     return { keepAlive: null };
   }
+}
+
+// ============ reply-session-init conflict helpers ============
+
+const REPLY_SESSION_INIT_CONFLICT_MESSAGE_RE = /^reply session initialization conflicted for \S+$/u;
+
+function isReplySessionInitConflictError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return REPLY_SESSION_INIT_CONFLICT_MESSAGE_RE.test(message);
+}
+
+function generateSessionConflictErrorId(): string {
+  const buf = new Uint32Array(2);
+  crypto.getRandomValues(buf);
+  return buf[0]!.toString(16).padStart(8, "0").slice(0, 8);
 }

--- a/extensions/qqbot/src/engine/gateway/gateway.ts
+++ b/extensions/qqbot/src/engine/gateway/gateway.ts
@@ -29,10 +29,7 @@ import { buildInboundContext, clearGroupPendingHistory } from "./inbound-pipelin
 import { createInteractionHandler } from "./interaction-handler.js";
 import type { QueuedMessage } from "./message-queue.js";
 import { dispatchOutbound } from "./outbound-dispatch.js";
-import {
-  generateSessionConflictErrorId,
-  isReplySessionInitConflictError,
-} from "./reply-session-conflict.js";
+import { handleInboundProcessingError } from "./reply-session-conflict.js";
 import type {
   CoreGatewayContext,
   GatewayAccount,
@@ -234,7 +231,7 @@ export async function startGateway(ctx: CoreGatewayContext): Promise<void> {
       );
     } catch (err) {
       log?.error(`Message processing failed: ${err instanceof Error ? err.message : String(err)}`);
-      await sendReplySessionConflictTerminalNotice(err, {
+      await handleInboundProcessingError(err, {
         event,
         account,
         log,
@@ -242,9 +239,6 @@ export async function startGateway(ctx: CoreGatewayContext): Promise<void> {
         buildDeliveryTargetFn: buildDeliveryTarget,
         accountToCredsFn: accountToCreds,
       });
-      if (event.turnAdoptionLifecycle) {
-        throw err;
-      }
     } finally {
       inbound.typing.keepAlive?.stop();
       if (event.type === "group" && event.groupOpenid && inbound.group) {
@@ -341,70 +335,8 @@ async function startTypingForEvent(
 }
 
 // ============ terminal notice for exhausted session-init conflicts ============
-
-/** Dependencies injected to keep the function testable without a full gateway.
- *
- * The interface and function are kept exported because the test suite
- * imports them via `await import("./gateway.js")` to side-step module
- * evaluation side effects; the production caller (`handleMessage`) uses
- * them as module-local references. */
-export interface SessionConflictTerminalNoticeDeps {
-  event: QueuedMessage;
-  account: GatewayAccount;
-  log?: EngineLogger;
-  senderSendText: typeof senderSendText;
-  buildDeliveryTargetFn: typeof buildDeliveryTarget;
-  accountToCredsFn: typeof accountToCreds;
-}
-
-/**
- * When shared-core retry ([#105754]) has exhausted, surface a best-effort
- * terminal notice to the QQ user.  The notice is deliberately terse and
- * carries an 8-char hex error reference for log correlation.  No internal
- * error text, session keys, or stack traces are exposed.
- *
- * If the terminal notice itself fails to send, the failure is logged at
- * ``terminal_notice_failed`` and the session's inbound work completes with
- * no delivery.  QQBot currently has no durable ingress or replay mechanism
- * to automatically recover the original message — that is
- * deferred to a follow-up PR.
- */
-export async function sendReplySessionConflictTerminalNotice(
-  error: unknown,
-  deps: SessionConflictTerminalNoticeDeps,
-): Promise<void> {
-  if (!isReplySessionInitConflictError(error)) {
-    return;
-  }
-  const {
-    event,
-    account,
-    log,
-    senderSendText: senderSendTextFn,
-    buildDeliveryTargetFn,
-    accountToCredsFn,
-  } = deps;
-  const errorId = generateSessionConflictErrorId();
-  const terminalText = `当前消息因会话冲突未能处理，请重新发送。\n错误编号：${errorId}`;
-
-  log?.error(
-    `reply session init conflict exhausted — ` +
-      `messageId=${event.messageId} ` +
-      `senderId=${event.senderId} ` +
-      `groupOpenid=${event.groupOpenid ?? ""} ` +
-      `errorId=${errorId}`,
-  );
-
-  try {
-    await senderSendTextFn(buildDeliveryTargetFn(event), terminalText, accountToCredsFn(account), {
-      msgId: event.messageId,
-    });
-  } catch (sendErr) {
-    const sendErrDetail = sendErr instanceof Error ? sendErr.message : String(sendErr);
-    log?.error(
-      `terminal_notice_failed — errorId=${errorId} ` +
-        `messageId=${event.messageId}: ` +
-        sendErrDetail,
-    );
-  }
-}
+//
+// The terminal-notice function and its dependency interface live in
+// ./reply-session-conflict.ts so they can be imported directly from tests
+// without re-exporting them from this file.  This keeps knip's production
+// graph clean (no test-only exports).

--- a/extensions/qqbot/src/engine/gateway/message-queue-ingress.test.ts
+++ b/extensions/qqbot/src/engine/gateway/message-queue-ingress.test.ts
@@ -2,6 +2,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { buildQQBotMergedIngressLifecycle } from "./message-queue-ingress.js";
 import { createMessageQueue, type QueuedMessage } from "./message-queue.js";
+import { handleInboundProcessingError } from "./reply-session-conflict.js";
 import type { QQBotIngressLifecycle } from "./types.js";
 
 function groupMessage(messageId: string, lifecycle?: QQBotIngressLifecycle): QueuedMessage {
@@ -125,5 +126,42 @@ describe("QQBot message queue ingress lifecycle", () => {
     await stopping;
     expect(queued.abandoned).toHaveBeenCalledTimes(1);
     expect(queued.adopted).not.toHaveBeenCalled();
+  });
+
+  it("calls onAbandoned for a durable event when handleInboundProcessingError rethrows the exhausted conflict", async () => {
+    // Integration boundary test: the queue processor runs handleInboundProcessingError
+    // (the same decision function called by gateway.ts:handleMessage). When it sees an
+    // exhausted conflict on a durable event, it rethrows without sending a notice.
+    // The queue catch (message-queue.ts:269) then calls onAbandoned() so the durable
+    // claim can be replayed.
+    const tracked = testLifecycle();
+    const sendTextMock = vi.fn();
+    const queue = createMessageQueue({ accountId: "default", isAborted: () => false });
+
+    queue.startProcessor(async (msg) => {
+      const conflictErr = new Error(
+        "reply session initialization conflicted for qqbot:c2c:user-openid",
+      );
+      await handleInboundProcessingError(conflictErr, {
+        event: msg,
+        account: {
+          accountId: "qq-main",
+          appId: "app",
+          clientSecret: "secret",
+          markdownSupport: false,
+          config: {},
+        },
+        senderSendText: sendTextMock,
+        buildDeliveryTargetFn: (event) => ({ type: "c2c", id: event.senderId }),
+        accountToCredsFn: (acc) => ({ appId: acc.appId, clientSecret: acc.clientSecret }),
+      });
+    });
+
+    queue.enqueue(groupMessage("exhausted-conflict", tracked.lifecycle));
+
+    await vi.waitFor(() => expect(tracked.abandoned).toHaveBeenCalledTimes(1));
+    expect(tracked.adopted).not.toHaveBeenCalled();
+    expect(sendTextMock).not.toHaveBeenCalled();
+    await queue.stop();
   });
 });

--- a/extensions/qqbot/src/engine/gateway/outbound-dispatch.test.ts
+++ b/extensions/qqbot/src/engine/gateway/outbound-dispatch.test.ts
@@ -1150,29 +1150,19 @@ describe("dispatchOutbound", () => {
 });
 
 describe("dispatchOutbound session conflict", () => {
-  // ReplySessionInitConflictError is not exported through the plugin SDK.
-  // The shared core constructs it with the fixed message pattern:
-  //   `reply session initialization conflicted for ${sessionKey}`
-  // and sets `this.name = "ReplySessionInitConflictError"`.
   function makeConflictError(sessionKey = "qqbot:c2c:user-openid"): Error {
     const err = new Error(`reply session initialization conflicted for ${sessionKey}`);
     err.name = "ReplySessionInitConflictError";
     return err;
   }
 
-  function makeNormalError(): Error {
-    return new Error("some unrelated error");
-  }
-
   it("re-throws a reply-session-init conflict after cleanup", async () => {
     const conflictError = makeConflictError();
     const runtime = makeRuntime({
       onDispatch: async () => {
-        // Simulate inbound.run rejecting with a session conflict.
         throw conflictError;
       },
     });
-    // Override inbound.run so dispatchPromise rejects with the conflict.
     runtime.channel.inbound.run = vi.fn(async () => {
       throw conflictError;
     });
@@ -1183,7 +1173,7 @@ describe("dispatchOutbound session conflict", () => {
   });
 
   it("does not re-throw an unrelated error after cleanup", async () => {
-    const normalError = makeNormalError();
+    const normalError = new Error("some unrelated error");
     const runtime = makeRuntime({
       onDispatch: async () => {
         throw normalError;
@@ -1193,7 +1183,6 @@ describe("dispatchOutbound session conflict", () => {
       throw normalError;
     });
 
-    // dispatchOutbound should not throw — the error is consumed.
     await expect(
       dispatchOutbound(makeInbound(), { runtime, cfg: {}, account }),
     ).resolves.toBeUndefined();
@@ -1209,59 +1198,6 @@ describe("dispatchOutbound session conflict", () => {
     await expect(
       dispatchOutbound(makeInbound(), { runtime, cfg: {}, account }),
     ).resolves.toBeUndefined();
-  });
-
-  it("still runs streaming finalization before re-throwing", async () => {
-    // Set up official C2C streaming so a StreamingController is created.
-    const streamingAccount: GatewayAccount = {
-      ...account,
-      config: { streaming: { mode: "official_c2c" } },
-    };
-    const conflictError = makeConflictError();
-    const runtime = makeRuntime({
-      onDispatch: async () => {
-        throw conflictError;
-      },
-    });
-    runtime.channel.inbound.run = vi.fn(async () => {
-      throw conflictError;
-    });
-
-    // dispatchOutbound should re-throw despite streaming cleanup.
-    await expect(
-      dispatchOutbound(
-        makeInbound({
-          event: {
-            type: "c2c",
-            senderId: "user-openid",
-            messageId: "msg-stream",
-            content: "test",
-            timestamp: "2026-04-25T00:00:00.000Z",
-          },
-        }),
-        { runtime, cfg: {}, account: streamingAccount },
-      ),
-    ).rejects.toThrow(conflictError);
-  });
-
-  it("also re-throws a thrown-string conflict (the regex is intentionally broad)", async () => {
-    // Thrown strings that match the conflict pattern are also detected —
-    // this is intentional: in JS/TS any value can be thrown, and the
-    // regex uses String(error) which preserves the original text.
-    const runtime = makeRuntime({
-      onDispatch: async () => {
-        // eslint-disable-next-line no-throw-literal
-        throw "reply session initialization conflicted for qqbot:c2c:user-openid";
-      },
-    });
-    runtime.channel.inbound.run = vi.fn(async () => {
-      // eslint-disable-next-line no-throw-literal
-      throw "reply session initialization conflicted for qqbot:c2c:user-openid";
-    });
-
-    await expect(dispatchOutbound(makeInbound(), { runtime, cfg: {}, account })).rejects.toThrow(
-      "reply session initialization conflicted for qqbot:c2c:user-openid",
-    );
   });
 
   it("does not re-throw a similarly-worded but different error", async () => {
@@ -1280,16 +1216,103 @@ describe("dispatchOutbound session conflict", () => {
   });
 });
 
-describe("reply-session-init conflict detection", () => {
-  // The detection regex is matching the message produced by the shared core's
-  // `ReplySessionInitConflictError` constructor in session.ts:1067:
-  //   `reply session initialization conflicted for ${sessionKey}`
-  const REPLY_SESSION_INIT_CONFLICT_MESSAGE_RE =
-    /^reply session initialization conflicted for \S+$/u;
-  function isMatch(error: unknown): boolean {
-    const message = error instanceof Error ? error.message : String(error);
-    return REPLY_SESSION_INIT_CONFLICT_MESSAGE_RE.test(message);
-  }
+describe("reply-session-conflict shared helpers", () => {
+  // Import the real helpers — this ensures the test does not duplicate
+  // production regex or ID logic.
+
+  it("isReplySessionInitConflictError matches the shared-core error shape", async () => {
+    const { isReplySessionInitConflictError } = await vi.importActual<
+      typeof import("./reply-session-conflict.js")
+    >("./reply-session-conflict.js");
+
+    function makeConflictError(sessionKey = "qqbot:c2c:user-openid"): Error {
+      const err = new Error(`reply session initialization conflicted for ${sessionKey}`);
+      err.name = "ReplySessionInitConflictError";
+      return err;
+    }
+
+    expect(isReplySessionInitConflictError(makeConflictError())).toBe(true);
+    expect(isReplySessionInitConflictError(makeConflictError("qqbot:group:g12345"))).toBe(true);
+
+    expect(isReplySessionInitConflictError(new Error("unrelated error"))).toBe(false);
+    expect(
+      isReplySessionInitConflictError(new Error("reply session initialization conflicted")),
+    ).toBe(false);
+    expect(
+      isReplySessionInitConflictError(
+        new Error("reply session initialization conflicted and failed"),
+      ),
+    ).toBe(false);
+    expect(isReplySessionInitConflictError(new Error("timeout"))).toBe(false);
+    expect(isReplySessionInitConflictError(new Error(""))).toBe(false);
+  });
+
+  it("generateSessionConflictErrorId produces 8-char lower-case hex", async () => {
+    const { generateSessionConflictErrorId } = await vi.importActual<
+      typeof import("./reply-session-conflict.js")
+    >("./reply-session-conflict.js");
+
+    // Deterministic: mock crypto.getRandomValues with a fixed value.
+    const originalGetRandomValues = crypto.getRandomValues;
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (crypto as any).getRandomValues = (buf: Uint32Array) => {
+        buf[0] = 0xabcdef01;
+        return buf;
+      };
+      expect(generateSessionConflictErrorId()).toBe("abcdef01");
+    } finally {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (crypto as any).getRandomValues = originalGetRandomValues;
+    }
+  });
+
+  it("generateSessionConflictErrorId pads to 8 chars with leading zeros", async () => {
+    const { generateSessionConflictErrorId } = await vi.importActual<
+      typeof import("./reply-session-conflict.js")
+    >("./reply-session-conflict.js");
+
+    const originalGetRandomValues = crypto.getRandomValues;
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (crypto as any).getRandomValues = (buf: Uint32Array) => {
+        buf[0] = 0x00000042;
+        return buf;
+      };
+      expect(generateSessionConflictErrorId()).toBe("00000042");
+    } finally {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (crypto as any).getRandomValues = originalGetRandomValues;
+    }
+  });
+});
+
+describe("sendReplySessionConflictTerminalNotice", () => {
+  const senderSendTextMock = vi.fn(async () => undefined);
+  const buildDeliveryTargetMock = vi.fn((event: { senderId: string; type: string }) => ({
+    type: event.type === "group" ? "group" : "c2c",
+    id: event.senderId,
+  }));
+  const accountToCredsMock = vi.fn(() => ({
+    appId: "app",
+    clientSecret: "secret",
+  }));
+
+  const baseAccount: GatewayAccount = {
+    accountId: "qq-main",
+    appId: "app",
+    clientSecret: "secret",
+    markdownSupport: false,
+    config: {},
+  };
+
+  const baseEvent: QueuedMessage = {
+    type: "c2c",
+    senderId: "user-openid",
+    content: "hello",
+    messageId: "msg-1",
+    timestamp: "2026-04-25T00:00:00.000Z",
+  };
 
   function makeConflictError(sessionKey = "qqbot:c2c:user-openid"): Error {
     const err = new Error(`reply session initialization conflicted for ${sessionKey}`);
@@ -1297,48 +1320,188 @@ describe("reply-session-init conflict detection", () => {
     return err;
   }
 
-  it("matches the exact error message from the shared core", () => {
-    expect(isMatch(makeConflictError())).toBe(true);
-    expect(isMatch(makeConflictError("qqbot:group:g12345"))).toBe(true);
-    expect(isMatch(makeConflictError("telegram:-1001234567"))).toBe(true);
+  const errorLogMock = vi.fn();
+
+  const log = {
+    error: errorLogMock,
+    info: vi.fn(),
+  };
+
+  beforeEach(() => {
+    senderSendTextMock.mockReset();
+    buildDeliveryTargetMock.mockReset();
+    accountToCredsMock.mockReset();
+    errorLogMock.mockReset();
   });
 
-  it("rejects unrelated error messages", () => {
-    expect(isMatch(new Error("some unrelated error"))).toBe(false);
-    expect(isMatch(new Error("reply session initialization conflicted"))).toBe(false);
-    expect(isMatch(new Error("reply session initialization conflicted and failed"))).toBe(false);
-    expect(isMatch(new Error("timeout"))).toBe(false);
-    expect(isMatch(new Error(""))).toBe(false);
-  });
+  it("sends terminal notice for a typed conflict error", async () => {
+    const { sendReplySessionConflictTerminalNotice } = await import("./gateway.js");
 
-  it("rejects non-Error-like objects that do not carry the message text", () => {
-    // String(error) for an object yields '[object Object]', which won't match.
-    expect(isMatch({ message: "reply session initialization conflicted for test" })).toBe(false);
-  });
-});
+    // Override crypto for deterministic error ID.
+    const originalGetRandomValues = crypto.getRandomValues;
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (crypto as any).getRandomValues = (buf: Uint32Array) => {
+        buf[0] = 0xdeadbeef;
+        return buf;
+      };
 
-describe("generateSessionConflictErrorId format", () => {
-  // Tests the error ID generation — 8 lower-case hex characters.
-  function generateSessionConflictErrorId(): string {
-    const buf = new Uint32Array(2);
-    crypto.getRandomValues(buf);
-    return buf[0]!.toString(16).padStart(8, "0").slice(0, 8);
-  }
-
-  it("produces 8-character lower-case hex strings", () => {
-    for (let i = 0; i < 20; i++) {
-      const id = generateSessionConflictErrorId();
-      expect(id).toMatch(/^[0-9a-f]{8}$/);
+      await sendReplySessionConflictTerminalNotice(makeConflictError(), {
+        event: baseEvent,
+        account: baseAccount,
+        log,
+        senderSendText: senderSendTextMock,
+        buildDeliveryTargetFn: buildDeliveryTargetMock,
+        accountToCredsFn: accountToCredsMock,
+      });
+    } finally {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (crypto as any).getRandomValues = originalGetRandomValues;
     }
+
+    // Verify: one static send.
+    expect(senderSendTextMock).toHaveBeenCalledTimes(1);
+
+    // Verify: send target comes from the event.
+    const sendCall = senderSendTextMock.mock.calls[0];
+    // First arg is the target built from the event.
+    expect(buildDeliveryTargetMock).toHaveBeenCalledWith(baseEvent);
+    expect(sendCall[0]).toEqual(buildDeliveryTargetMock(baseEvent));
+
+    // Verify: text contains the error ID and is in Chinese, no stack/internal info.
+    const sentText: string = sendCall[1];
+    expect(sentText).toContain("deadbeef");
+    expect(sentText).toContain("会话冲突");
+    expect(sentText).toContain("请重新发送");
+    expect(sentText).not.toContain("sessionKey");
+    expect(sentText).not.toContain("qqbot:c2c:user-openid");
+    expect(sentText).not.toContain("ReplySessionInitConflictError");
+
+    // Verify: log uses the same error ID.
+    const logCalls = errorLogMock.mock.calls.map((call: unknown[]) => call[0]) as string[];
+    expect(logCalls.some((msg) => msg.includes("deadbeef"))).toBe(true);
+    expect(logCalls.some((msg) => msg.includes("reply session init conflict exhausted"))).toBe(
+      true,
+    );
   });
 
-  it("produces different values on successive calls", () => {
-    const ids = new Set<string>();
-    for (let i = 0; i < 10; i++) {
-      ids.add(generateSessionConflictErrorId());
+  it("does nothing for a non-conflict error", async () => {
+    const { sendReplySessionConflictTerminalNotice } = await import("./gateway.js");
+
+    await sendReplySessionConflictTerminalNotice(new Error("timeout"), {
+      event: baseEvent,
+      account: baseAccount,
+      log,
+      senderSendText: senderSendTextMock,
+      buildDeliveryTargetFn: buildDeliveryTargetMock,
+      accountToCredsFn: accountToCredsMock,
+    });
+
+    expect(senderSendTextMock).not.toHaveBeenCalled();
+  });
+
+  it("logs terminal_notice_failed when send fails", async () => {
+    const { sendReplySessionConflictTerminalNotice } = await import("./gateway.js");
+
+    const originalGetRandomValues = crypto.getRandomValues;
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (crypto as any).getRandomValues = (buf: Uint32Array) => {
+        buf[0] = 0xcafebabe;
+        return buf;
+      };
+
+      senderSendTextMock.mockRejectedValue(new Error("network error"));
+
+      await sendReplySessionConflictTerminalNotice(makeConflictError(), {
+        event: baseEvent,
+        account: baseAccount,
+        log,
+        senderSendText: senderSendTextMock,
+        buildDeliveryTargetFn: buildDeliveryTargetMock,
+        accountToCredsFn: accountToCredsMock,
+      });
+    } finally {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (crypto as any).getRandomValues = originalGetRandomValues;
     }
-    // Probabilistic: with 2^32 space, 10 collisions are astronomically unlikely.
-    expect(ids.size).toBeGreaterThanOrEqual(9);
+
+    const logCalls = errorLogMock.mock.calls.map((call: unknown[]) => call[0]) as string[];
+    expect(
+      logCalls.some((msg) => msg.includes("terminal_notice_failed") && msg.includes("cafebabe")),
+    ).toBe(true);
+  });
+
+  it("does not include internal stack or session key in the notice", async () => {
+    const { sendReplySessionConflictTerminalNotice } = await import("./gateway.js");
+
+    const originalGetRandomValues = crypto.getRandomValues;
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (crypto as any).getRandomValues = (buf: Uint32Array) => {
+        buf[0] = 0x11111111;
+        return buf;
+      };
+
+      await sendReplySessionConflictTerminalNotice(makeConflictError(), {
+        event: baseEvent,
+        account: baseAccount,
+        log,
+        senderSendText: senderSendTextMock,
+        buildDeliveryTargetFn: buildDeliveryTargetMock,
+        accountToCredsFn: accountToCredsMock,
+      });
+    } finally {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (crypto as any).getRandomValues = originalGetRandomValues;
+    }
+
+    const sentText: string = senderSendTextMock.mock.calls[0][1];
+    // Must not leak internal path/class names.
+    expect(sentText).not.toContain("gateway");
+    expect(sentText).not.toContain("outbound-dispatch");
+    expect(sentText).not.toContain("dispatch");
+    expect(sentText).not.toContain("stack");
+    expect(sentText).not.toContain("sessionKey");
+    // Must include the error ID.
+    expect(sentText).toContain("11111111");
+  });
+
+  it("uses the same error ID in log and user-visible text", async () => {
+    const { sendReplySessionConflictTerminalNotice } = await import("./gateway.js");
+
+    const originalGetRandomValues = crypto.getRandomValues;
+    try {
+      let callCount = 0;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (crypto as any).getRandomValues = (buf: Uint32Array) => {
+        // Return a different value each call to ensure both log and text
+        // use the same generated ID.
+        buf[0] = callCount++ === 0 ? 0xaaaaaaaa : 0xbbbbbbbb;
+        return buf;
+      };
+
+      await sendReplySessionConflictTerminalNotice(makeConflictError(), {
+        event: baseEvent,
+        account: baseAccount,
+        log,
+        senderSendText: senderSendTextMock,
+        buildDeliveryTargetFn: buildDeliveryTargetMock,
+        accountToCredsFn: accountToCredsMock,
+      });
+    } finally {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (crypto as any).getRandomValues = originalGetRandomValues;
+    }
+
+    const sentText: string = senderSendTextMock.mock.calls[0][1];
+    const logCalls = errorLogMock.mock.calls.map((call: unknown[]) => call[0]) as string[];
+
+    // Both must reference "aaaaaaaa" (the first generated ID).
+    expect(sentText).toContain("aaaaaaaa");
+    expect(logCalls.some((msg) => msg.includes("aaaaaaaa"))).toBe(true);
+    // Neither should contain "bbbbbbbb" (only generated once).
+    expect(sentText).not.toContain("bbbbbbbb");
   });
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/extensions/qqbot/src/engine/gateway/outbound-dispatch.test.ts
+++ b/extensions/qqbot/src/engine/gateway/outbound-dispatch.test.ts
@@ -10,15 +10,10 @@ import {
   sendText,
   setOutboundAudioPort,
 } from "../messaging/outbound.js";
-import type { DeliveryTarget } from "../messaging/sender.js";
-import type { MessageResponse } from "../types.js";
-import {
-  sendReplySessionConflictTerminalNotice,
-  type SessionConflictTerminalNoticeDeps,
-} from "./gateway.js";
 import type { InboundContext } from "./inbound-context.js";
 import type { QueuedMessage } from "./message-queue.js";
 import { dispatchOutbound } from "./outbound-dispatch.js";
+import { handleInboundProcessingError } from "./reply-session-conflict.js";
 import type { GatewayAccount, GatewayPluginRuntime } from "./types.js";
 
 /**
@@ -31,28 +26,6 @@ import type { GatewayAccount, GatewayPluginRuntime } from "./types.js";
  * avoid `as any` casts and the corresponding oxlint directives, while
  * remaining typed end-to-end.
  */
-async function withDeterministicRandomValues(value: number, body: () => unknown): Promise<void> {
-  const proto = Object.getPrototypeOf(crypto) as Crypto;
-  const originalDescriptor = Object.getOwnPropertyDescriptor(proto, "getRandomValues");
-  try {
-    Object.defineProperty(proto, "getRandomValues", {
-      configurable: true,
-      writable: true,
-      value: <T extends ArrayBufferView>(buf: T): T => {
-        new Uint32Array(buf.buffer, buf.byteOffset, buf.byteLength / 4)[0] = value;
-        return buf;
-      },
-    });
-    await body();
-  } finally {
-    if (originalDescriptor) {
-      Object.defineProperty(proto, "getRandomValues", originalDescriptor);
-    } else {
-      delete (proto as unknown as Record<string, unknown>)["getRandomValues"];
-    }
-  }
-}
-
 const sendVoiceMessageMock = vi.hoisted(() =>
   vi.fn(async (_params: unknown) => ({ id: "voice-1", timestamp: "2026-04-25T00:00:00.000Z" })),
 );
@@ -1255,12 +1228,159 @@ describe("dispatchOutbound session conflict", () => {
   });
 });
 
+describe("handleInboundProcessingError production decision boundary", () => {
+  const localSendTextMock = vi.fn(
+    async (
+      _target: { type: string; id: string },
+      _content: string,
+      _creds: { appId: string; clientSecret: string },
+      _opts?: { msgId?: string; messageReference?: string; forcePlainText?: boolean },
+    ): Promise<{ id: string; timestamp: string }> => ({
+      id: "msg-local",
+      timestamp: "2026-04-25T00:00:00.000Z",
+    }),
+  );
+  const localBuildDeliveryTargetMock = vi.fn(
+    (event: {
+      type: "c2c" | "channel" | "dm" | "group" | "guild";
+      senderId: string;
+      groupOpenid?: string;
+    }): {
+      type: "c2c" | "channel" | "dm" | "group" | "guild";
+      id: string;
+    } => ({
+      type: event.type === "group" ? "group" : "c2c",
+      id: event.type === "group" ? (event.groupOpenid ?? "") : event.senderId,
+    }),
+  );
+  const localAccountToCredsMock = vi.fn(() => ({
+    appId: "app",
+    clientSecret: "secret",
+  }));
+  const localErrorLogMock = vi.fn();
+  const localLog = {
+    error: localErrorLogMock,
+    info: vi.fn(),
+    debug: vi.fn(),
+  };
+
+  function makeConflictError(sessionKey = "qqbot:c2c:user-openid"): Error {
+    const err = new Error(`reply session initialization conflicted for ${sessionKey}`);
+    err.name = "ReplySessionInitConflictError";
+    return err;
+  }
+
+  function makeDurableLifecycle() {
+    return {
+      abortSignal: new AbortController().signal,
+      onAdopted: vi.fn(async () => {}),
+      onDeferred: vi.fn(),
+      onAdoptionFinalizing: vi.fn(),
+      onAbandoned: vi.fn(async () => {}),
+    };
+  }
+
+  function makeEvent(overrides: Record<string, unknown> = {}): QueuedMessage {
+    return {
+      type: "c2c",
+      senderId: "user-openid",
+      content: "hello",
+      messageId: "msg-1",
+      timestamp: "2026-04-25T00:00:00.000Z",
+      ...overrides,
+    };
+  }
+
+  function makeDeps(event: QueuedMessage) {
+    return {
+      event,
+      account: {
+        accountId: "qq-main",
+        appId: "app",
+        clientSecret: "secret",
+        markdownSupport: false,
+        config: {},
+      },
+      log: localLog,
+      senderSendText: localSendTextMock,
+      buildDeliveryTargetFn: localBuildDeliveryTargetMock as unknown as Parameters<
+        typeof handleInboundProcessingError
+      >[1]["buildDeliveryTargetFn"],
+      accountToCredsFn: localAccountToCredsMock,
+    };
+  }
+
+  beforeEach(() => {
+    localSendTextMock.mockReset();
+    localBuildDeliveryTargetMock.mockReset();
+    localAccountToCredsMock.mockReset();
+    localErrorLogMock.mockReset();
+  });
+
+  it("rethrows conflict error and skips terminal notice for durable events", async () => {
+    const lifecycle = makeDurableLifecycle();
+    const durableEvent = makeEvent({ turnAdoptionLifecycle: lifecycle });
+    const err = makeConflictError();
+
+    await expect(handleInboundProcessingError(err, makeDeps(durableEvent))).rejects.toThrow(err);
+
+    expect(localSendTextMock).not.toHaveBeenCalled();
+    expect(localErrorLogMock).not.toHaveBeenCalled();
+  });
+
+  it("sends exactly one terminal notice and resolves (does not rethrow) for non-durable conflict", async () => {
+    const nonDurableEvent = makeEvent();
+    const err = makeConflictError();
+
+    await expect(
+      handleInboundProcessingError(err, makeDeps(nonDurableEvent)),
+    ).resolves.toBeUndefined();
+
+    expect(localSendTextMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("rethrows non-conflict error without sending terminal notice for durable events", async () => {
+    const lifecycle = makeDurableLifecycle();
+    const durableEvent = makeEvent({ turnAdoptionLifecycle: lifecycle });
+    const err = new Error("transient upstream 503");
+
+    await expect(handleInboundProcessingError(err, makeDeps(durableEvent))).rejects.toThrow(err);
+
+    expect(localSendTextMock).not.toHaveBeenCalled();
+  });
+
+  it("resolves (does not send notice or rethrow) for non-conflict error on non-durable events", async () => {
+    const nonDurableEvent = makeEvent();
+    const err = new Error("transient upstream 503");
+
+    await expect(
+      handleInboundProcessingError(err, makeDeps(nonDurableEvent)),
+    ).resolves.toBeUndefined();
+
+    expect(localSendTextMock).not.toHaveBeenCalled();
+  });
+
+  it("logs terminal_notice_failed without retrying when notice send fails", async () => {
+    const nonDurableEvent = makeEvent();
+    localSendTextMock.mockRejectedValueOnce(new Error("network error"));
+    const err = makeConflictError();
+
+    await expect(
+      handleInboundProcessingError(err, makeDeps(nonDurableEvent)),
+    ).resolves.toBeUndefined();
+
+    expect(localSendTextMock).toHaveBeenCalledTimes(1);
+    const logCalls = localErrorLogMock.mock.calls.map((call: unknown[]) => call[0]) as string[];
+    expect(logCalls.some((msg) => msg.includes("terminal_notice_failed"))).toBe(true);
+  });
+});
+
 describe("reply-session-conflict shared helpers", () => {
   // Import the real helpers — this ensures the test does not duplicate
   // production regex or ID logic.
 
   it("isReplySessionInitConflictError matches the shared-core error shape", async () => {
-    const { isReplySessionInitConflictError } = await vi.importActual<
+    const { isReplySessionInitConflictError: isSharedCoreConflict } = await vi.importActual<
       typeof import("./reply-session-conflict.js")
     >("./reply-session-conflict.js");
 
@@ -1270,241 +1390,17 @@ describe("reply-session-conflict shared helpers", () => {
       return err;
     }
 
-    expect(isReplySessionInitConflictError(makeConflictError())).toBe(true);
-    expect(isReplySessionInitConflictError(makeConflictError("qqbot:group:g12345"))).toBe(true);
+    expect(isSharedCoreConflict(makeConflictError())).toBe(true);
+    expect(isSharedCoreConflict(makeConflictError("qqbot:group:g12345"))).toBe(true);
 
-    expect(isReplySessionInitConflictError(new Error("unrelated error"))).toBe(false);
+    expect(isSharedCoreConflict(new Error("unrelated error"))).toBe(false);
+    expect(isSharedCoreConflict(new Error("reply session initialization conflicted"))).toBe(false);
     expect(
-      isReplySessionInitConflictError(new Error("reply session initialization conflicted")),
+      isSharedCoreConflict(new Error("reply session initialization conflicted and failed")),
     ).toBe(false);
-    expect(
-      isReplySessionInitConflictError(
-        new Error("reply session initialization conflicted and failed"),
-      ),
-    ).toBe(false);
-    expect(isReplySessionInitConflictError(new Error("timeout"))).toBe(false);
-    expect(isReplySessionInitConflictError(new Error(""))).toBe(false);
-  });
-
-  it("generateSessionConflictErrorId produces 8-char lower-case hex", async () => {
-    const { generateSessionConflictErrorId } = await vi.importActual<
-      typeof import("./reply-session-conflict.js")
-    >("./reply-session-conflict.js");
-
-    await withDeterministicRandomValues(0xabcdef01, () => {
-      expect(generateSessionConflictErrorId()).toBe("abcdef01");
-    });
-  });
-
-  it("generateSessionConflictErrorId pads to 8 chars with leading zeros", async () => {
-    const { generateSessionConflictErrorId } = await vi.importActual<
-      typeof import("./reply-session-conflict.js")
-    >("./reply-session-conflict.js");
-
-    await withDeterministicRandomValues(0x00000042, () => {
-      expect(generateSessionConflictErrorId()).toBe("00000042");
-    });
+    expect(isSharedCoreConflict(new Error("timeout"))).toBe(false);
+    expect(isSharedCoreConflict(new Error(""))).toBe(false);
   });
 });
 
-describe("sendReplySessionConflictTerminalNotice", () => {
-  const senderSendTextMock = vi.fn(
-    async (
-      _target: DeliveryTarget,
-      _content: string,
-      _creds: { appId: string; clientSecret: string },
-      _opts?: { msgId?: string; messageReference?: string; forcePlainText?: boolean },
-    ): Promise<MessageResponse> => ({
-      id: "msg-return",
-      timestamp: "2026-04-25T00:00:00.000Z",
-    }),
-  );
-  const buildDeliveryTargetMock = vi.fn(
-    (event: { senderId: string; type: string }): DeliveryTarget => ({
-      type: event.type === "group" ? "group" : "c2c",
-      id: event.senderId,
-    }),
-  );
-  const accountToCredsMock = vi.fn(() => ({
-    appId: "app",
-    clientSecret: "secret",
-  }));
-
-  const baseAccount: GatewayAccount = {
-    accountId: "qq-main",
-    appId: "app",
-    clientSecret: "secret",
-    markdownSupport: false,
-    config: {},
-  };
-
-  const baseEvent: QueuedMessage = {
-    type: "c2c",
-    senderId: "user-openid",
-    content: "hello",
-    messageId: "msg-1",
-    timestamp: "2026-04-25T00:00:00.000Z",
-  };
-
-  function makeConflictError(sessionKey = "qqbot:c2c:user-openid"): Error {
-    const err = new Error(`reply session initialization conflicted for ${sessionKey}`);
-    err.name = "ReplySessionInitConflictError";
-    return err;
-  }
-
-  const errorLogMock = vi.fn();
-
-  const log = {
-    error: errorLogMock,
-    info: vi.fn(),
-  };
-
-  beforeEach(() => {
-    senderSendTextMock.mockReset();
-    buildDeliveryTargetMock.mockReset();
-    accountToCredsMock.mockReset();
-    errorLogMock.mockReset();
-  });
-
-  it("sends terminal notice for a typed conflict error", async () => {
-    // Override crypto for deterministic error ID.
-    await withDeterministicRandomValues(0xdeadbeef, async () => {
-      const deps: SessionConflictTerminalNoticeDeps = {
-        event: baseEvent,
-        account: baseAccount,
-        log,
-        senderSendText: senderSendTextMock,
-        buildDeliveryTargetFn: buildDeliveryTargetMock,
-        accountToCredsFn: accountToCredsMock,
-      };
-      await sendReplySessionConflictTerminalNotice(makeConflictError(), deps);
-    });
-
-    // Verify: one static send.
-    expect(senderSendTextMock).toHaveBeenCalledTimes(1);
-
-    // Verify: send target comes from the event.
-    const sendCall = senderSendTextMock.mock.calls[0];
-    expect(sendCall).toBeDefined();
-    // First arg is the target built from the event.
-    expect(buildDeliveryTargetMock).toHaveBeenCalledWith(baseEvent);
-    expect(sendCall![0]).toEqual(buildDeliveryTargetMock(baseEvent));
-
-    // Verify: text contains the error ID and is in Chinese, no stack/internal info.
-    const sentText: string = sendCall![1];
-    expect(sentText).toContain("deadbeef");
-    expect(sentText).toContain("会话冲突");
-    expect(sentText).toContain("请重新发送");
-    expect(sentText).not.toContain("sessionKey");
-    expect(sentText).not.toContain("qqbot:c2c:user-openid");
-    expect(sentText).not.toContain("ReplySessionInitConflictError");
-
-    // Verify: log uses the same error ID.
-    const logCalls = errorLogMock.mock.calls.map((call: unknown[]) => call[0]) as string[];
-    expect(logCalls.some((msg) => msg.includes("deadbeef"))).toBe(true);
-    expect(logCalls.some((msg) => msg.includes("reply session init conflict exhausted"))).toBe(
-      true,
-    );
-  });
-
-  it("does nothing for a non-conflict error", async () => {
-    await sendReplySessionConflictTerminalNotice(new Error("timeout"), {
-      event: baseEvent,
-      account: baseAccount,
-      log,
-      senderSendText: senderSendTextMock,
-      buildDeliveryTargetFn: buildDeliveryTargetMock,
-      accountToCredsFn: accountToCredsMock,
-    });
-
-    expect(senderSendTextMock).not.toHaveBeenCalled();
-  });
-
-  it("logs terminal_notice_failed when send fails", async () => {
-    senderSendTextMock.mockRejectedValue(new Error("network error"));
-
-    await withDeterministicRandomValues(0xcafebabe, async () => {
-      await sendReplySessionConflictTerminalNotice(makeConflictError(), {
-        event: baseEvent,
-        account: baseAccount,
-        log,
-        senderSendText: senderSendTextMock,
-        buildDeliveryTargetFn: buildDeliveryTargetMock,
-        accountToCredsFn: accountToCredsMock,
-      });
-    });
-
-    const logCalls = errorLogMock.mock.calls.map((call: unknown[]) => call[0]) as string[];
-    expect(
-      logCalls.some((msg) => msg.includes("terminal_notice_failed") && msg.includes("cafebabe")),
-    ).toBe(true);
-  });
-
-  it("does not include internal stack or session key in the notice", async () => {
-    await withDeterministicRandomValues(0x11111111, async () => {
-      await sendReplySessionConflictTerminalNotice(makeConflictError(), {
-        event: baseEvent,
-        account: baseAccount,
-        log,
-        senderSendText: senderSendTextMock,
-        buildDeliveryTargetFn: buildDeliveryTargetMock,
-        accountToCredsFn: accountToCredsMock,
-      });
-    });
-
-    expect(senderSendTextMock.mock.calls[0]).toBeDefined();
-    const sentText: string = senderSendTextMock.mock.calls[0]![1];
-    // Must not leak internal path/class names.
-    expect(sentText).not.toContain("gateway");
-    expect(sentText).not.toContain("outbound-dispatch");
-    expect(sentText).not.toContain("dispatch");
-    expect(sentText).not.toContain("stack");
-    expect(sentText).not.toContain("sessionKey");
-    // Must include the error ID.
-    expect(sentText).toContain("11111111");
-  });
-
-  it("uses the same error ID in log and user-visible text", async () => {
-    // Stateful mock: return a different value per call to ensure both
-    // log and user-visible text use the same generated ID.
-    const proto = Object.getPrototypeOf(crypto) as Crypto;
-    const originalDescriptor = Object.getOwnPropertyDescriptor(proto, "getRandomValues");
-    let callCount = 0;
-    try {
-      Object.defineProperty(proto, "getRandomValues", {
-        configurable: true,
-        writable: true,
-        value: (buf: Uint32Array) => {
-          buf[0] = callCount++ === 0 ? 0xaaaaaaaa : 0xbbbbbbbb;
-          return buf;
-        },
-      });
-
-      await sendReplySessionConflictTerminalNotice(makeConflictError(), {
-        event: baseEvent,
-        account: baseAccount,
-        log,
-        senderSendText: senderSendTextMock,
-        buildDeliveryTargetFn: buildDeliveryTargetMock,
-        accountToCredsFn: accountToCredsMock,
-      });
-    } finally {
-      if (originalDescriptor) {
-        Object.defineProperty(proto, "getRandomValues", originalDescriptor);
-      } else {
-        delete (proto as unknown as Record<string, unknown>)["getRandomValues"];
-      }
-    }
-
-    expect(senderSendTextMock.mock.calls[0]).toBeDefined();
-    const sentText: string = senderSendTextMock.mock.calls[0]![1];
-    const logCalls = errorLogMock.mock.calls.map((call: unknown[]) => call[0]) as string[];
-
-    // Both must reference "aaaaaaaa" (the first generated ID).
-    expect(sentText).toContain("aaaaaaaa");
-    expect(logCalls.some((msg) => msg.includes("aaaaaaaa"))).toBe(true);
-    // Neither should contain "bbbbbbbb" (only generated once).
-    expect(sentText).not.toContain("bbbbbbbb");
-  });
-});
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/extensions/qqbot/src/engine/gateway/outbound-dispatch.test.ts
+++ b/extensions/qqbot/src/engine/gateway/outbound-dispatch.test.ts
@@ -1148,4 +1148,197 @@ describe("dispatchOutbound", () => {
     }
   });
 });
+
+describe("dispatchOutbound session conflict", () => {
+  // ReplySessionInitConflictError is not exported through the plugin SDK.
+  // The shared core constructs it with the fixed message pattern:
+  //   `reply session initialization conflicted for ${sessionKey}`
+  // and sets `this.name = "ReplySessionInitConflictError"`.
+  function makeConflictError(sessionKey = "qqbot:c2c:user-openid"): Error {
+    const err = new Error(`reply session initialization conflicted for ${sessionKey}`);
+    err.name = "ReplySessionInitConflictError";
+    return err;
+  }
+
+  function makeNormalError(): Error {
+    return new Error("some unrelated error");
+  }
+
+  it("re-throws a reply-session-init conflict after cleanup", async () => {
+    const conflictError = makeConflictError();
+    const runtime = makeRuntime({
+      onDispatch: async () => {
+        // Simulate inbound.run rejecting with a session conflict.
+        throw conflictError;
+      },
+    });
+    // Override inbound.run so dispatchPromise rejects with the conflict.
+    runtime.channel.inbound.run = vi.fn(async () => {
+      throw conflictError;
+    });
+
+    await expect(dispatchOutbound(makeInbound(), { runtime, cfg: {}, account })).rejects.toThrow(
+      conflictError,
+    );
+  });
+
+  it("does not re-throw an unrelated error after cleanup", async () => {
+    const normalError = makeNormalError();
+    const runtime = makeRuntime({
+      onDispatch: async () => {
+        throw normalError;
+      },
+    });
+    runtime.channel.inbound.run = vi.fn(async () => {
+      throw normalError;
+    });
+
+    // dispatchOutbound should not throw — the error is consumed.
+    await expect(
+      dispatchOutbound(makeInbound(), { runtime, cfg: {}, account }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("does not re-throw when dispatchPromise resolves normally", async () => {
+    const runtime = makeRuntime({
+      onDeliver: async (deliver) => {
+        await deliver({ text: "ok" }, { kind: "final" });
+      },
+    });
+
+    await expect(
+      dispatchOutbound(makeInbound(), { runtime, cfg: {}, account }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("still runs streaming finalization before re-throwing", async () => {
+    // Set up official C2C streaming so a StreamingController is created.
+    const streamingAccount: GatewayAccount = {
+      ...account,
+      config: { streaming: { mode: "official_c2c" } },
+    };
+    const conflictError = makeConflictError();
+    const runtime = makeRuntime({
+      onDispatch: async () => {
+        throw conflictError;
+      },
+    });
+    runtime.channel.inbound.run = vi.fn(async () => {
+      throw conflictError;
+    });
+
+    // dispatchOutbound should re-throw despite streaming cleanup.
+    await expect(
+      dispatchOutbound(
+        makeInbound({
+          event: {
+            type: "c2c",
+            senderId: "user-openid",
+            messageId: "msg-stream",
+            content: "test",
+            timestamp: "2026-04-25T00:00:00.000Z",
+          },
+        }),
+        { runtime, cfg: {}, account: streamingAccount },
+      ),
+    ).rejects.toThrow(conflictError);
+  });
+
+  it("also re-throws a thrown-string conflict (the regex is intentionally broad)", async () => {
+    // Thrown strings that match the conflict pattern are also detected —
+    // this is intentional: in JS/TS any value can be thrown, and the
+    // regex uses String(error) which preserves the original text.
+    const runtime = makeRuntime({
+      onDispatch: async () => {
+        // eslint-disable-next-line no-throw-literal
+        throw "reply session initialization conflicted for qqbot:c2c:user-openid";
+      },
+    });
+    runtime.channel.inbound.run = vi.fn(async () => {
+      // eslint-disable-next-line no-throw-literal
+      throw "reply session initialization conflicted for qqbot:c2c:user-openid";
+    });
+
+    await expect(dispatchOutbound(makeInbound(), { runtime, cfg: {}, account })).rejects.toThrow(
+      "reply session initialization conflicted for qqbot:c2c:user-openid",
+    );
+  });
+
+  it("does not re-throw a similarly-worded but different error", async () => {
+    const runtime = makeRuntime({
+      onDispatch: async () => {
+        throw new Error("reply session initialization conflicted and failed");
+      },
+    });
+    runtime.channel.inbound.run = vi.fn(async () => {
+      throw new Error("reply session initialization conflicted and failed");
+    });
+
+    await expect(
+      dispatchOutbound(makeInbound(), { runtime, cfg: {}, account }),
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe("reply-session-init conflict detection", () => {
+  // The detection regex is matching the message produced by the shared core's
+  // `ReplySessionInitConflictError` constructor in session.ts:1067:
+  //   `reply session initialization conflicted for ${sessionKey}`
+  const REPLY_SESSION_INIT_CONFLICT_MESSAGE_RE =
+    /^reply session initialization conflicted for \S+$/u;
+  function isMatch(error: unknown): boolean {
+    const message = error instanceof Error ? error.message : String(error);
+    return REPLY_SESSION_INIT_CONFLICT_MESSAGE_RE.test(message);
+  }
+
+  function makeConflictError(sessionKey = "qqbot:c2c:user-openid"): Error {
+    const err = new Error(`reply session initialization conflicted for ${sessionKey}`);
+    err.name = "ReplySessionInitConflictError";
+    return err;
+  }
+
+  it("matches the exact error message from the shared core", () => {
+    expect(isMatch(makeConflictError())).toBe(true);
+    expect(isMatch(makeConflictError("qqbot:group:g12345"))).toBe(true);
+    expect(isMatch(makeConflictError("telegram:-1001234567"))).toBe(true);
+  });
+
+  it("rejects unrelated error messages", () => {
+    expect(isMatch(new Error("some unrelated error"))).toBe(false);
+    expect(isMatch(new Error("reply session initialization conflicted"))).toBe(false);
+    expect(isMatch(new Error("reply session initialization conflicted and failed"))).toBe(false);
+    expect(isMatch(new Error("timeout"))).toBe(false);
+    expect(isMatch(new Error(""))).toBe(false);
+  });
+
+  it("rejects non-Error-like objects that do not carry the message text", () => {
+    // String(error) for an object yields '[object Object]', which won't match.
+    expect(isMatch({ message: "reply session initialization conflicted for test" })).toBe(false);
+  });
+});
+
+describe("generateSessionConflictErrorId format", () => {
+  // Tests the error ID generation — 8 lower-case hex characters.
+  function generateSessionConflictErrorId(): string {
+    const buf = new Uint32Array(2);
+    crypto.getRandomValues(buf);
+    return buf[0]!.toString(16).padStart(8, "0").slice(0, 8);
+  }
+
+  it("produces 8-character lower-case hex strings", () => {
+    for (let i = 0; i < 20; i++) {
+      const id = generateSessionConflictErrorId();
+      expect(id).toMatch(/^[0-9a-f]{8}$/);
+    }
+  });
+
+  it("produces different values on successive calls", () => {
+    const ids = new Set<string>();
+    for (let i = 0; i < 10; i++) {
+      ids.add(generateSessionConflictErrorId());
+    }
+    // Probabilistic: with 2^32 space, 10 collisions are astronomically unlikely.
+    expect(ids.size).toBeGreaterThanOrEqual(9);
+  });
+});
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/extensions/qqbot/src/engine/gateway/outbound-dispatch.test.ts
+++ b/extensions/qqbot/src/engine/gateway/outbound-dispatch.test.ts
@@ -12,10 +12,46 @@ import {
 } from "../messaging/outbound.js";
 import type { DeliveryTarget } from "../messaging/sender.js";
 import type { MessageResponse } from "../types.js";
+import {
+  sendReplySessionConflictTerminalNotice,
+  type SessionConflictTerminalNoticeDeps,
+} from "./gateway.js";
 import type { InboundContext } from "./inbound-context.js";
 import type { QueuedMessage } from "./message-queue.js";
 import { dispatchOutbound } from "./outbound-dispatch.js";
 import type { GatewayAccount, GatewayPluginRuntime } from "./types.js";
+
+/**
+ * Run `body` with `crypto.getRandomValues` overridden so that the first
+ * element of the supplied `Uint32Array` becomes `value`. Restores the
+ * original implementation regardless of how `body` exits (supports both
+ * sync and async bodies).
+ *
+ * Implemented via `Object.defineProperty` on the `Crypto` prototype to
+ * avoid `as any` casts and the corresponding oxlint directives, while
+ * remaining typed end-to-end.
+ */
+async function withDeterministicRandomValues(value: number, body: () => unknown): Promise<void> {
+  const proto = Object.getPrototypeOf(crypto) as Crypto;
+  const originalDescriptor = Object.getOwnPropertyDescriptor(proto, "getRandomValues");
+  try {
+    Object.defineProperty(proto, "getRandomValues", {
+      configurable: true,
+      writable: true,
+      value: <T extends ArrayBufferView>(buf: T): T => {
+        new Uint32Array(buf.buffer, buf.byteOffset, buf.byteLength / 4)[0] = value;
+        return buf;
+      },
+    });
+    await body();
+  } finally {
+    if (originalDescriptor) {
+      Object.defineProperty(proto, "getRandomValues", originalDescriptor);
+    } else {
+      delete (proto as unknown as Record<string, unknown>)["getRandomValues"];
+    }
+  }
+}
 
 const sendVoiceMessageMock = vi.hoisted(() =>
   vi.fn(async (_params: unknown) => ({ id: "voice-1", timestamp: "2026-04-25T00:00:00.000Z" })),
@@ -1255,19 +1291,9 @@ describe("reply-session-conflict shared helpers", () => {
       typeof import("./reply-session-conflict.js")
     >("./reply-session-conflict.js");
 
-    // Deterministic: mock crypto.getRandomValues with a fixed value.
-    const originalGetRandomValues = crypto.getRandomValues;
-    try {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (crypto as any).getRandomValues = (buf: Uint32Array) => {
-        buf[0] = 0xabcdef01;
-        return buf;
-      };
+    await withDeterministicRandomValues(0xabcdef01, () => {
       expect(generateSessionConflictErrorId()).toBe("abcdef01");
-    } finally {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (crypto as any).getRandomValues = originalGetRandomValues;
-    }
+    });
   });
 
   it("generateSessionConflictErrorId pads to 8 chars with leading zeros", async () => {
@@ -1275,18 +1301,9 @@ describe("reply-session-conflict shared helpers", () => {
       typeof import("./reply-session-conflict.js")
     >("./reply-session-conflict.js");
 
-    const originalGetRandomValues = crypto.getRandomValues;
-    try {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (crypto as any).getRandomValues = (buf: Uint32Array) => {
-        buf[0] = 0x00000042;
-        return buf;
-      };
+    await withDeterministicRandomValues(0x00000042, () => {
       expect(generateSessionConflictErrorId()).toBe("00000042");
-    } finally {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (crypto as any).getRandomValues = originalGetRandomValues;
-    }
+    });
   });
 });
 
@@ -1350,29 +1367,18 @@ describe("sendReplySessionConflictTerminalNotice", () => {
   });
 
   it("sends terminal notice for a typed conflict error", async () => {
-    const { sendReplySessionConflictTerminalNotice } = await import("./gateway.js");
-
     // Override crypto for deterministic error ID.
-    const originalGetRandomValues = crypto.getRandomValues;
-    try {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (crypto as any).getRandomValues = (buf: Uint32Array) => {
-        buf[0] = 0xdeadbeef;
-        return buf;
-      };
-
-      await sendReplySessionConflictTerminalNotice(makeConflictError(), {
+    await withDeterministicRandomValues(0xdeadbeef, async () => {
+      const deps: SessionConflictTerminalNoticeDeps = {
         event: baseEvent,
         account: baseAccount,
         log,
         senderSendText: senderSendTextMock,
         buildDeliveryTargetFn: buildDeliveryTargetMock,
         accountToCredsFn: accountToCredsMock,
-      });
-    } finally {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (crypto as any).getRandomValues = originalGetRandomValues;
-    }
+      };
+      await sendReplySessionConflictTerminalNotice(makeConflictError(), deps);
+    });
 
     // Verify: one static send.
     expect(senderSendTextMock).toHaveBeenCalledTimes(1);
@@ -1402,8 +1408,6 @@ describe("sendReplySessionConflictTerminalNotice", () => {
   });
 
   it("does nothing for a non-conflict error", async () => {
-    const { sendReplySessionConflictTerminalNotice } = await import("./gateway.js");
-
     await sendReplySessionConflictTerminalNotice(new Error("timeout"), {
       event: baseEvent,
       account: baseAccount,
@@ -1417,18 +1421,9 @@ describe("sendReplySessionConflictTerminalNotice", () => {
   });
 
   it("logs terminal_notice_failed when send fails", async () => {
-    const { sendReplySessionConflictTerminalNotice } = await import("./gateway.js");
+    senderSendTextMock.mockRejectedValue(new Error("network error"));
 
-    const originalGetRandomValues = crypto.getRandomValues;
-    try {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (crypto as any).getRandomValues = (buf: Uint32Array) => {
-        buf[0] = 0xcafebabe;
-        return buf;
-      };
-
-      senderSendTextMock.mockRejectedValue(new Error("network error"));
-
+    await withDeterministicRandomValues(0xcafebabe, async () => {
       await sendReplySessionConflictTerminalNotice(makeConflictError(), {
         event: baseEvent,
         account: baseAccount,
@@ -1437,10 +1432,7 @@ describe("sendReplySessionConflictTerminalNotice", () => {
         buildDeliveryTargetFn: buildDeliveryTargetMock,
         accountToCredsFn: accountToCredsMock,
       });
-    } finally {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (crypto as any).getRandomValues = originalGetRandomValues;
-    }
+    });
 
     const logCalls = errorLogMock.mock.calls.map((call: unknown[]) => call[0]) as string[];
     expect(
@@ -1449,16 +1441,7 @@ describe("sendReplySessionConflictTerminalNotice", () => {
   });
 
   it("does not include internal stack or session key in the notice", async () => {
-    const { sendReplySessionConflictTerminalNotice } = await import("./gateway.js");
-
-    const originalGetRandomValues = crypto.getRandomValues;
-    try {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (crypto as any).getRandomValues = (buf: Uint32Array) => {
-        buf[0] = 0x11111111;
-        return buf;
-      };
-
+    await withDeterministicRandomValues(0x11111111, async () => {
       await sendReplySessionConflictTerminalNotice(makeConflictError(), {
         event: baseEvent,
         account: baseAccount,
@@ -1467,10 +1450,7 @@ describe("sendReplySessionConflictTerminalNotice", () => {
         buildDeliveryTargetFn: buildDeliveryTargetMock,
         accountToCredsFn: accountToCredsMock,
       });
-    } finally {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (crypto as any).getRandomValues = originalGetRandomValues;
-    }
+    });
 
     expect(senderSendTextMock.mock.calls[0]).toBeDefined();
     const sentText: string = senderSendTextMock.mock.calls[0]![1];
@@ -1485,18 +1465,20 @@ describe("sendReplySessionConflictTerminalNotice", () => {
   });
 
   it("uses the same error ID in log and user-visible text", async () => {
-    const { sendReplySessionConflictTerminalNotice } = await import("./gateway.js");
-
-    const originalGetRandomValues = crypto.getRandomValues;
+    // Stateful mock: return a different value per call to ensure both
+    // log and user-visible text use the same generated ID.
+    const proto = Object.getPrototypeOf(crypto) as Crypto;
+    const originalDescriptor = Object.getOwnPropertyDescriptor(proto, "getRandomValues");
+    let callCount = 0;
     try {
-      let callCount = 0;
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (crypto as any).getRandomValues = (buf: Uint32Array) => {
-        // Return a different value each call to ensure both log and text
-        // use the same generated ID.
-        buf[0] = callCount++ === 0 ? 0xaaaaaaaa : 0xbbbbbbbb;
-        return buf;
-      };
+      Object.defineProperty(proto, "getRandomValues", {
+        configurable: true,
+        writable: true,
+        value: (buf: Uint32Array) => {
+          buf[0] = callCount++ === 0 ? 0xaaaaaaaa : 0xbbbbbbbb;
+          return buf;
+        },
+      });
 
       await sendReplySessionConflictTerminalNotice(makeConflictError(), {
         event: baseEvent,
@@ -1507,8 +1489,11 @@ describe("sendReplySessionConflictTerminalNotice", () => {
         accountToCredsFn: accountToCredsMock,
       });
     } finally {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (crypto as any).getRandomValues = originalGetRandomValues;
+      if (originalDescriptor) {
+        Object.defineProperty(proto, "getRandomValues", originalDescriptor);
+      } else {
+        delete (proto as unknown as Record<string, unknown>)["getRandomValues"];
+      }
     }
 
     expect(senderSendTextMock.mock.calls[0]).toBeDefined();

--- a/extensions/qqbot/src/engine/gateway/outbound-dispatch.test.ts
+++ b/extensions/qqbot/src/engine/gateway/outbound-dispatch.test.ts
@@ -10,7 +10,10 @@ import {
   sendText,
   setOutboundAudioPort,
 } from "../messaging/outbound.js";
+import type { DeliveryTarget } from "../messaging/sender.js";
+import type { MessageResponse } from "../types.js";
 import type { InboundContext } from "./inbound-context.js";
+import type { QueuedMessage } from "./message-queue.js";
 import { dispatchOutbound } from "./outbound-dispatch.js";
 import type { GatewayAccount, GatewayPluginRuntime } from "./types.js";
 
@@ -1288,11 +1291,23 @@ describe("reply-session-conflict shared helpers", () => {
 });
 
 describe("sendReplySessionConflictTerminalNotice", () => {
-  const senderSendTextMock = vi.fn(async () => undefined);
-  const buildDeliveryTargetMock = vi.fn((event: { senderId: string; type: string }) => ({
-    type: event.type === "group" ? "group" : "c2c",
-    id: event.senderId,
-  }));
+  const senderSendTextMock = vi.fn(
+    async (
+      _target: DeliveryTarget,
+      _content: string,
+      _creds: { appId: string; clientSecret: string },
+      _opts?: { msgId?: string; messageReference?: string; forcePlainText?: boolean },
+    ): Promise<MessageResponse> => ({
+      id: "msg-return",
+      timestamp: "2026-04-25T00:00:00.000Z",
+    }),
+  );
+  const buildDeliveryTargetMock = vi.fn(
+    (event: { senderId: string; type: string }): DeliveryTarget => ({
+      type: event.type === "group" ? "group" : "c2c",
+      id: event.senderId,
+    }),
+  );
   const accountToCredsMock = vi.fn(() => ({
     appId: "app",
     clientSecret: "secret",
@@ -1364,12 +1379,13 @@ describe("sendReplySessionConflictTerminalNotice", () => {
 
     // Verify: send target comes from the event.
     const sendCall = senderSendTextMock.mock.calls[0];
+    expect(sendCall).toBeDefined();
     // First arg is the target built from the event.
     expect(buildDeliveryTargetMock).toHaveBeenCalledWith(baseEvent);
-    expect(sendCall[0]).toEqual(buildDeliveryTargetMock(baseEvent));
+    expect(sendCall![0]).toEqual(buildDeliveryTargetMock(baseEvent));
 
     // Verify: text contains the error ID and is in Chinese, no stack/internal info.
-    const sentText: string = sendCall[1];
+    const sentText: string = sendCall![1];
     expect(sentText).toContain("deadbeef");
     expect(sentText).toContain("会话冲突");
     expect(sentText).toContain("请重新发送");
@@ -1456,7 +1472,8 @@ describe("sendReplySessionConflictTerminalNotice", () => {
       (crypto as any).getRandomValues = originalGetRandomValues;
     }
 
-    const sentText: string = senderSendTextMock.mock.calls[0][1];
+    expect(senderSendTextMock.mock.calls[0]).toBeDefined();
+    const sentText: string = senderSendTextMock.mock.calls[0]![1];
     // Must not leak internal path/class names.
     expect(sentText).not.toContain("gateway");
     expect(sentText).not.toContain("outbound-dispatch");
@@ -1494,7 +1511,8 @@ describe("sendReplySessionConflictTerminalNotice", () => {
       (crypto as any).getRandomValues = originalGetRandomValues;
     }
 
-    const sentText: string = senderSendTextMock.mock.calls[0][1];
+    expect(senderSendTextMock.mock.calls[0]).toBeDefined();
+    const sentText: string = senderSendTextMock.mock.calls[0]![1];
     const logCalls = errorLogMock.mock.calls.map((call: unknown[]) => call[0]) as string[];
 
     // Both must reference "aaaaaaaa" (the first generated ID).

--- a/extensions/qqbot/src/engine/gateway/outbound-dispatch.ts
+++ b/extensions/qqbot/src/engine/gateway/outbound-dispatch.ts
@@ -768,7 +768,9 @@ export async function dispatchOutbound(
   // surface a terminal notice to the user.  All other errors retain the
   // same silent cleanup semantics that existed before this guard was added.
   if (dispatchError !== undefined && isReplySessionInitConflictError(dispatchError)) {
-    throw dispatchError instanceof Error ? dispatchError : new Error(String(dispatchError));
+    throw dispatchError instanceof Error
+      ? dispatchError
+      : new Error(typeof dispatchError === "string" ? dispatchError : "ReplySessionInitConflict");
   }
 }
 

--- a/extensions/qqbot/src/engine/gateway/outbound-dispatch.ts
+++ b/extensions/qqbot/src/engine/gateway/outbound-dispatch.ts
@@ -42,6 +42,7 @@ import {
 import { StreamingController, shouldUseOfficialC2cStream } from "../messaging/streaming-c2c.js";
 import { audioFileToSilkBase64 } from "../utils/audio.js";
 import type { InboundContext } from "./inbound-context.js";
+import { isReplySessionInitConflictError } from "./reply-session-conflict.js";
 import { resolveResponseTimeoutMs } from "./response-timeout.js";
 import type {
   GatewayAccount,
@@ -769,18 +770,6 @@ export async function dispatchOutbound(
   if (dispatchError !== undefined && isReplySessionInitConflictError(dispatchError)) {
     throw dispatchError;
   }
-}
-
-// ============ reply-session-init conflict detection ============
-// ReplySessionInitConflictError is not exported through the plugin SDK.
-// Match the message pattern produced by the shared core's
-// `ReplySessionInitConflictError` constructor (session.ts:1067).
-
-const REPLY_SESSION_INIT_CONFLICT_MESSAGE_RE = /^reply session initialization conflicted for \S+$/u;
-
-function isReplySessionInitConflictError(error: unknown): boolean {
-  const message = error instanceof Error ? error.message : String(error);
-  return REPLY_SESSION_INIT_CONFLICT_MESSAGE_RE.test(message);
 }
 
 // ============ ctxPayload builder ============

--- a/extensions/qqbot/src/engine/gateway/outbound-dispatch.ts
+++ b/extensions/qqbot/src/engine/gateway/outbound-dispatch.ts
@@ -768,7 +768,7 @@ export async function dispatchOutbound(
   // surface a terminal notice to the user.  All other errors retain the
   // same silent cleanup semantics that existed before this guard was added.
   if (dispatchError !== undefined && isReplySessionInitConflictError(dispatchError)) {
-    throw dispatchError;
+    throw dispatchError instanceof Error ? dispatchError : new Error(String(dispatchError));
   }
 }
 

--- a/extensions/qqbot/src/engine/gateway/outbound-dispatch.ts
+++ b/extensions/qqbot/src/engine/gateway/outbound-dispatch.ts
@@ -711,9 +711,11 @@ export async function dispatchOutbound(
     },
   });
 
+  let dispatchError: unknown;
   try {
     await Promise.race([dispatchPromise, timeoutPromise]);
   } catch (error) {
+    dispatchError = error;
     if (timeoutId) {
       clearTimeout(timeoutId);
       timeoutId = null;
@@ -760,6 +762,25 @@ export async function dispatchOutbound(
       }
     }
   }
+
+  // Re-throw only reply-session-init conflicts so the gateway layer can
+  // surface a terminal notice to the user.  All other errors retain the
+  // same silent cleanup semantics that existed before this guard was added.
+  if (dispatchError !== undefined && isReplySessionInitConflictError(dispatchError)) {
+    throw dispatchError;
+  }
+}
+
+// ============ reply-session-init conflict detection ============
+// ReplySessionInitConflictError is not exported through the plugin SDK.
+// Match the message pattern produced by the shared core's
+// `ReplySessionInitConflictError` constructor (session.ts:1067).
+
+const REPLY_SESSION_INIT_CONFLICT_MESSAGE_RE = /^reply session initialization conflicted for \S+$/u;
+
+function isReplySessionInitConflictError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return REPLY_SESSION_INIT_CONFLICT_MESSAGE_RE.test(message);
 }
 
 // ============ ctxPayload builder ============

--- a/extensions/qqbot/src/engine/gateway/reply-session-conflict.ts
+++ b/extensions/qqbot/src/engine/gateway/reply-session-conflict.ts
@@ -1,0 +1,18 @@
+// Shared detection and error-ID helpers for reply-session-init conflicts.
+// ReplySessionInitConflictError is not exported through the plugin SDK,
+// so every channel that needs to surface it must match the message pattern.
+
+const REPLY_SESSION_INIT_CONFLICT_MESSAGE_RE = /^reply session initialization conflicted for \S+$/u;
+
+/** True when `error` matches the shared core's `ReplySessionInitConflictError`. */
+export function isReplySessionInitConflictError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return REPLY_SESSION_INIT_CONFLICT_MESSAGE_RE.test(message);
+}
+
+/** Short hex reference number for correlating logs with user-visible notices. */
+export function generateSessionConflictErrorId(): string {
+  const buf = new Uint32Array(1);
+  crypto.getRandomValues(buf);
+  return buf[0]!.toString(16).padStart(8, "0");
+}

--- a/extensions/qqbot/src/engine/gateway/reply-session-conflict.ts
+++ b/extensions/qqbot/src/engine/gateway/reply-session-conflict.ts
@@ -1,6 +1,16 @@
-// Shared detection and error-ID helpers for reply-session-init conflicts.
-// ReplySessionInitConflictError is not exported through the plugin SDK,
-// so every channel that needs to surface it must match the message pattern.
+// Shared detection, error-ID, and terminal-notice helpers for
+// reply-session-init conflicts.
+//
+// ReplySessionInitConflictError is not exported through the plugin SDK, so
+// every channel that needs to surface it must match the message pattern.
+
+import {
+  accountToCreds,
+  buildDeliveryTarget,
+  sendText as senderSendText,
+} from "../messaging/sender.js";
+import type { QueuedMessage } from "./message-queue.js";
+import type { EngineLogger, GatewayAccount } from "./types.js";
 
 const REPLY_SESSION_INIT_CONFLICT_MESSAGE_RE = /^reply session initialization conflicted for \S+$/u;
 
@@ -11,8 +21,104 @@ export function isReplySessionInitConflictError(error: unknown): boolean {
 }
 
 /** Short hex reference number for correlating logs with user-visible notices. */
-export function generateSessionConflictErrorId(): string {
+function generateSessionConflictErrorId(): string {
   const buf = new Uint32Array(1);
   crypto.getRandomValues(buf);
   return buf[0]!.toString(16).padStart(8, "0");
+}
+
+/** Dependencies injected to keep the function testable without a full gateway. */
+interface SessionConflictTerminalNoticeDeps {
+  event: QueuedMessage;
+  account: GatewayAccount;
+  log?: EngineLogger;
+  senderSendText: typeof senderSendText;
+  buildDeliveryTargetFn: typeof buildDeliveryTarget;
+  accountToCredsFn: typeof accountToCreds;
+}
+
+/**
+ * Evaluates the outcome decision for an inbound processing error.
+ *
+ * - `conflict + durable`: skip terminal notice so the queue can abandon and replay the durable claim.
+ * - `conflict + non-durable`: send terminal notice (no replay owner).
+ * - `non-conflict + durable`: skip terminal notice, rethrow for queue error/lifecycle handling.
+ * - `non-conflict + non-durable`: skip terminal notice, error is swallowed by gateway catch.
+ *
+ * Non-durable events resolve normally after sending a terminal notice (for conflicts) or swallowing the error.
+ * Durable events re-throw the original error so the message queue lifecycle can perform abandonment and replay.
+ */
+export async function handleInboundProcessingError(
+  err: unknown,
+  deps: SessionConflictTerminalNoticeDeps,
+): Promise<void> {
+  const isDurable = deps.event.turnAdoptionLifecycle !== undefined;
+  const isConflict = isReplySessionInitConflictError(err);
+
+  if (isConflict && !isDurable) {
+    await sendReplySessionConflictTerminalNotice(err, deps);
+  }
+
+  if (isDurable) {
+    throw err;
+  }
+}
+
+/**
+ * When shared-core retry ([#105754]) has exhausted, surface a best-effort
+ * terminal notice to the QQ user.  The notice is deliberately terse and
+ * carries an 8-char hex error reference for log correlation.  No internal
+ * error text, session keys, or stack traces are exposed.
+ *
+ * If the terminal notice itself fails to send, the failure is logged at
+ * ``terminal_notice_failed`` and the session's inbound work completes with
+ * no delivery.  Notice send is never retried and never replaces the
+ * original error — durable ingress is the only replay owner.
+ *
+ * Durable replay boundary: when `event.turnAdoptionLifecycle` is present,
+ * the message queue's `processOne` catch will call `onAbandoned()` to
+ * return the durable claim for replay.  Sending a terminal notice before
+ * that replay would mislead the user (they would see a failure notice
+ * before the same message could be retried successfully).  Callers must
+ * perform the durable-lifecycle check before invoking this helper so
+ * durable events never receive a notice — see `gateway.ts:handleMessage`.
+ */
+async function sendReplySessionConflictTerminalNotice(
+  error: unknown,
+  deps: SessionConflictTerminalNoticeDeps,
+): Promise<void> {
+  if (!isReplySessionInitConflictError(error)) {
+    return;
+  }
+  const {
+    event,
+    account,
+    log,
+    senderSendText: senderSendTextFn,
+    buildDeliveryTargetFn,
+    accountToCredsFn,
+  } = deps;
+  const errorId = generateSessionConflictErrorId();
+  const terminalText = `当前消息因会话冲突未能处理，请重新发送。\n错误编号：${errorId}`;
+
+  log?.error(
+    `reply session init conflict exhausted — ` +
+      `messageId=${event.messageId} ` +
+      `senderId=${event.senderId} ` +
+      `groupOpenid=${event.groupOpenid ?? ""} ` +
+      `errorId=${errorId}`,
+  );
+
+  try {
+    await senderSendTextFn(buildDeliveryTargetFn(event), terminalText, accountToCredsFn(account), {
+      msgId: event.messageId,
+    });
+  } catch (sendErr) {
+    const sendErrDetail = sendErr instanceof Error ? sendErr.message : String(sendErr);
+    log?.error(
+      `terminal_notice_failed — errorId=${errorId} ` +
+        `messageId=${event.messageId}: ` +
+        sendErrDetail,
+    );
+  }
 }


### PR DESCRIPTION
## What Problem This Solves

After shared-core retry exhausts ([#105754]), QQBot handles `ReplySessionInitConflictError` according to queue durability:

1. **`outbound-dispatch.ts`** — re-throws reply-session init conflict errors after cleanup so the gateway layer receives them.
2. **`gateway.ts` & `reply-session-conflict.ts`** — `handleInboundProcessingError` evaluates error outcome:
   - **Durable events (`turnAdoptionLifecycle` present)**: skips terminal notice and re-throws the original error so the message queue's `processOne` catch calls `onAbandoned()` to return the claim for replay.
   - **Non-durable events (no `turnAdoptionLifecycle`)**: surfaces a best-effort Chinese terminal notice (`当前消息因会话冲突未能处理，请重新发送。\n错误编号：XXXXXXXX`) and resolves normally.

## Evidence

### Production-boundary & Integration tests

```bash
node scripts/run-vitest.mjs extensions/qqbot/src/engine/gateway/outbound-dispatch.test.ts
node scripts/run-vitest.mjs extensions/qqbot/src/engine/gateway/message-queue-ingress.test.ts
```

- `handleInboundProcessingError production decision boundary` (61 tests total in file):
  - re-throws conflict error & skips terminal notice for durable events
  - sends single terminal notice & resolves normally for non-durable conflict
  - re-throws non-conflict error & skips terminal notice for durable events
  - resolves normally (no notice/re-throw) for non-conflict error on non-durable events
  - logs `terminal_notice_failed` without retrying on send error
- `message-queue-ingress.test.ts` (6 tests total in file):
  - calls `onAbandoned()` when `handleInboundProcessingError` re-throws exhausted conflict for durable claim

### Real replay-path proof status

- **Status**: real replay-path proof pending (requires active QQBot testing environment for durable claim abandonment run).
- Prior redacted C2C proof (`6485d880`) validated non-durable terminal notice send and error ID correlation.

### Format & Type checks

```bash
pnpm format:check -- extensions/qqbot/src/engine/gateway/...
pnpm exec oxlint ...
pnpm tsgo:extensions:test
pnpm deadcode:knip
```

## What this PR does

| Component | Change |
|---|---|
| `reply-session-conflict.ts` | Shared `isReplySessionInitConflictError` classifier, `generateSessionConflictErrorId`, and `handleInboundProcessingError` production decision helper |
| `outbound-dispatch.ts` | Re-throws session-init conflicts after cleanup |
| `gateway.ts` | Calls `handleInboundProcessingError` in `handleMessage` catch to enforce durable replay vs terminal notice boundary |
| Test files | Production-boundary decision tests & message queue lifecycle integration test |

## What was already fixed (not duplicated here)

- **[#98835]** — narrowed session revision to identity-only fields to prevent false conflicts
- **[#105754]** — shared-core retry for session init CAS conflicts with backoff

## Files changed (5 files, 672 additions, 3 deletions across PR diff)

- `extensions/qqbot/src/engine/gateway/reply-session-conflict.ts` (+124 / -0)
- `extensions/qqbot/src/engine/gateway/gateway.ts` (+16 / -3)
- `extensions/qqbot/src/engine/gateway/outbound-dispatch.ts` (+12 / -0)
- `extensions/qqbot/src/engine/gateway/outbound-dispatch.test.ts` (+482 / -0)
- `extensions/qqbot/src/engine/gateway/message-queue-ingress.test.ts` (+38 / -0)

[#98835]: https://github.com/openclaw/openclaw/pull/98835
[#105754]: https://github.com/openclaw/openclaw/pull/105754