### PR TITLE
feat(ios): mascot moods for onboarding and gateway quick setup

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -22259,7 +22259,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 70,
+      "line": 76,
       "path": "apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift",
       "source": "Connecting…",
       "surface": "apple",
@@ -22267,7 +22267,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 74,
+      "line": 80,
       "path": "apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift",
       "source": "Connect to this Gateway",
       "surface": "apple",
@@ -22275,7 +22275,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 100,
+      "line": 106,
       "path": "apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift",
       "source": "Use Manual Setup",
       "surface": "apple",
@@ -22283,7 +22283,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 114,
+      "line": 120,
       "path": "apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift",
       "source": "Not now",
       "surface": "apple",
@@ -22291,7 +22291,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 121,
+      "line": 127,
       "path": "apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift",
       "source": "Don't show this again",
       "surface": "apple",
@@ -22299,7 +22299,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 131,
+      "line": 137,
       "path": "apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift",
       "source": "Quick Setup",
       "surface": "apple",
@@ -22307,7 +22307,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 139,
+      "line": 145,
       "path": "apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift",
       "source": "Close",
       "surface": "apple",
@@ -22315,7 +22315,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 233,
+      "line": 256,
       "path": "apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift",
       "source": "Connect a nearby Gateway",
       "surface": "apple",
@@ -22323,7 +22323,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 283,
+      "line": 306,
       "path": "apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift",
       "source": "Local",
       "surface": "apple",
@@ -22331,7 +22331,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 283,
+      "line": 306,
       "path": "apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift",
       "source": "Secure",
       "surface": "apple",
@@ -22339,7 +22339,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 297,
+      "line": 320,
       "path": "apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift",
       "source": "Discovery",
       "surface": "apple",
@@ -22347,7 +22347,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 298,
+      "line": 321,
       "path": "apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift",
       "source": "Gateway",
       "surface": "apple",
@@ -22355,7 +22355,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 299,
+      "line": 322,
       "path": "apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift",
       "source": "Node",
       "surface": "apple",
@@ -22363,7 +22363,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 300,
+      "line": 323,
       "path": "apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift",
       "source": "Operator",
       "surface": "apple",
@@ -22371,7 +22371,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 406,
+      "line": 429,
       "path": "apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift",
       "source": "Looking for a Gateway",
       "surface": "apple",
@@ -22379,7 +22379,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 408,
+      "line": 431,
       "path": "apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift",
       "source": "Keep your iPhone on the same LAN or tailnet, then start the Gateway on your host machine.",
       "surface": "apple",
@@ -22387,7 +22387,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 415,
+      "line": 438,
       "path": "apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift",
       "source": "Run openclaw gateway --port 18789.",
       "surface": "apple",
@@ -22395,7 +22395,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 416,
+      "line": 439,
       "path": "apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift",
       "source": "Check that Bonjour discovery is enabled.",
       "surface": "apple",
@@ -22403,7 +22403,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 417,
+      "line": 440,
       "path": "apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift",
       "source": "Open Settings if you need a manual host.",
       "surface": "apple",
@@ -23275,7 +23275,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 163,
+      "line": 167,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardSteps.swift",
       "source": "Security notice",
       "surface": "apple",
@@ -23283,7 +23283,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 167,
+      "line": 171,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardSteps.swift",
       "source": "The connected OpenClaw agent can use device capabilities you enable.",
       "surface": "apple",
@@ -23291,7 +23291,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 169,
+      "line": 173,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardSteps.swift",
       "source": "Camera, microphone, photos, contacts, calendar, and location may be available.",
       "surface": "apple",
@@ -23299,7 +23299,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 172,
+      "line": 176,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardSteps.swift",
       "source": "Continue only if you trust the gateway and agent you connect to.",
       "surface": "apple",
@@ -23307,7 +23307,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 206,
+      "line": 210,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardSteps.swift",
       "source": "Copy setup code command",
       "surface": "apple",
@@ -23315,7 +23315,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 207,
+      "line": 211,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardSteps.swift",
       "source": "Copied",
       "surface": "apple",
@@ -23323,7 +23323,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 244,
+      "line": 248,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardSteps.swift",
       "source": "OpenClaw",
       "surface": "apple",
@@ -23331,7 +23331,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 245,
+      "line": 249,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardSteps.swift",
       "source": "Your agent, in your pocket. Pair this iPhone with your gateway to get started.",
       "surface": "apple",
@@ -23339,7 +23339,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 252,
+      "line": 256,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardSteps.swift",
       "source": "Your agent runs on your own computer",
       "surface": "apple",
@@ -23347,7 +23347,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 255,
+      "line": 259,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardSteps.swift",
       "source": "Pair this iPhone by scanning a setup code",
       "surface": "apple",
@@ -23355,7 +23355,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 258,
+      "line": 262,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardSteps.swift",
       "source": "Chat, talk, and approve actions from anywhere",
       "surface": "apple",
@@ -23363,7 +23363,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 272,
+      "line": 276,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardSteps.swift",
       "source": "Continue",
       "surface": "apple",
@@ -23371,7 +23371,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 294,
+      "line": 298,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardSteps.swift",
       "source": "Connect Gateway",
       "surface": "apple",
@@ -23379,7 +23379,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 300,
+      "line": 305,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardSteps.swift",
       "source": "Run this on your gateway host and scan the code",
       "surface": "apple",
@@ -23387,7 +23387,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 310,
+      "line": 315,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardSteps.swift",
       "source": "Connecting…",
       "surface": "apple",
@@ -23395,7 +23395,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 314,
+      "line": 319,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardSteps.swift",
       "source": "Scan QR",
       "surface": "apple",
@@ -23403,7 +23403,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 323,
+      "line": 328,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardSteps.swift",
       "source": "or",
       "surface": "apple",
@@ -23411,7 +23411,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 326,
+      "line": 331,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardSteps.swift",
       "source": "Connect Manually",
       "surface": "apple",
@@ -23419,7 +23419,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 382,
+      "line": 387,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardSteps.swift",
       "source": "You're connected",
       "surface": "apple",
@@ -23427,7 +23427,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 405,
+      "line": 410,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardSteps.swift",
       "source": "Go to Chat",
       "surface": "apple",

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -22315,7 +22315,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 256,
+      "line": 262,
       "path": "apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift",
       "source": "Connect a nearby Gateway",
       "surface": "apple",
@@ -22323,7 +22323,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 306,
+      "line": 312,
       "path": "apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift",
       "source": "Local",
       "surface": "apple",
@@ -22331,7 +22331,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 306,
+      "line": 312,
       "path": "apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift",
       "source": "Secure",
       "surface": "apple",
@@ -22339,7 +22339,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 320,
+      "line": 326,
       "path": "apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift",
       "source": "Discovery",
       "surface": "apple",
@@ -22347,7 +22347,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 321,
+      "line": 327,
       "path": "apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift",
       "source": "Gateway",
       "surface": "apple",
@@ -22355,7 +22355,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 322,
+      "line": 328,
       "path": "apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift",
       "source": "Node",
       "surface": "apple",
@@ -22363,7 +22363,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 323,
+      "line": 329,
       "path": "apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift",
       "source": "Operator",
       "surface": "apple",
@@ -22371,7 +22371,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 429,
+      "line": 435,
       "path": "apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift",
       "source": "Looking for a Gateway",
       "surface": "apple",
@@ -22379,7 +22379,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 431,
+      "line": 437,
       "path": "apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift",
       "source": "Keep your iPhone on the same LAN or tailnet, then start the Gateway on your host machine.",
       "surface": "apple",
@@ -22387,7 +22387,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 438,
+      "line": 444,
       "path": "apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift",
       "source": "Run openclaw gateway --port 18789.",
       "surface": "apple",
@@ -22395,7 +22395,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 439,
+      "line": 445,
       "path": "apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift",
       "source": "Check that Bonjour discovery is enabled.",
       "surface": "apple",
@@ -22403,7 +22403,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 440,
+      "line": 446,
       "path": "apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift",
       "source": "Open Settings if you need a manual host.",
       "surface": "apple",

--- a/apps/ios/Sources/Design/OpenClawBrand.swift
+++ b/apps/ios/Sources/Design/OpenClawBrand.swift
@@ -210,11 +210,12 @@ enum OpenClawBrand {
 
 struct OpenClawActivationGlyph: View {
     let size: CGFloat
+    var mood: OpenClawMascotMood = .idle
     /// Opt-in tap Easter eggs; leave off when the glyph sits inside a control.
     var interactive = false
 
     var body: some View {
-        OpenClawMascotView(floats: false, interactive: self.interactive)
+        OpenClawMascotView(floats: false, mood: self.mood, interactive: self.interactive)
             .frame(width: self.size, height: self.size)
             .shadow(
                 color: OpenClawBrand.activationGlow.opacity(0.18),

--- a/apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift
+++ b/apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift
@@ -30,7 +30,7 @@ struct GatewayQuickSetupSheet: View {
                         hasCandidate: self.bestCandidate != nil,
                         mood: Self.headerMood(
                             connecting: self.connecting,
-                            hasError: self.connectError != nil,
+                            hasError: self.hasVisibleError,
                             hasCandidate: self.bestCandidate != nil))
 
                     if let gatewayProblem = self.appModel.lastGatewayProblem {
@@ -163,6 +163,12 @@ struct GatewayQuickSetupSheet: View {
 
     private var bestCandidate: GatewayDiscoveryModel.DiscoveredGateway? {
         self.gatewayController.preferredDiscoveredGateway()
+    }
+
+    /// The sheet surfaces two error banners — the local connect error and the
+    /// app-level gateway problem — and the mascot mood must match both.
+    private var hasVisibleError: Bool {
+        self.connectError != nil || self.appModel.lastGatewayProblem != nil
     }
 
     static func headerMood(

--- a/apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift
+++ b/apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift
@@ -1,3 +1,4 @@
+import OpenClawChatUI
 import OpenClawKit
 import SwiftUI
 
@@ -25,7 +26,12 @@ struct GatewayQuickSetupSheet: View {
         NavigationStack {
             ScrollView {
                 VStack(alignment: .leading, spacing: 18) {
-                    GatewayQuickSetupHeader(hasCandidate: self.bestCandidate != nil)
+                    GatewayQuickSetupHeader(
+                        hasCandidate: self.bestCandidate != nil,
+                        mood: Self.headerMood(
+                            connecting: self.connecting,
+                            hasError: self.connectError != nil,
+                            hasCandidate: self.bestCandidate != nil))
 
                     if let gatewayProblem = self.appModel.lastGatewayProblem {
                         GatewayProblemBanner(
@@ -159,6 +165,22 @@ struct GatewayQuickSetupSheet: View {
         self.gatewayController.preferredDiscoveredGateway()
     }
 
+    static func headerMood(
+        connecting: Bool,
+        hasError: Bool,
+        hasCandidate: Bool) -> OpenClawMascotMood
+    {
+        if connecting {
+            .working
+        } else if hasError {
+            .sad
+        } else if hasCandidate {
+            .curious
+        } else {
+            .idle
+        }
+    }
+
     private func fullRowToggle(_ title: LocalizedStringKey, isOn: Binding<Bool>) -> some View {
         Toggle(isOn: isOn) {
             Text(title)
@@ -207,11 +229,12 @@ struct GatewayQuickSetupSheet: View {
 
 private struct GatewayQuickSetupHeader: View {
     let hasCandidate: Bool
+    let mood: OpenClawMascotMood
 
     var body: some View {
         VStack(alignment: .leading, spacing: 14) {
             ZStack(alignment: .bottomTrailing) {
-                OpenClawActivationGlyph(size: 70, interactive: true)
+                OpenClawActivationGlyph(size: 70, mood: self.mood, interactive: true)
                     .shadow(color: OpenClawBrand.activationGlow.opacity(0.18), radius: 10, x: 0, y: 5)
 
                 Image(systemName: "antenna.radiowaves.left.and.right")

--- a/apps/ios/Sources/Onboarding/OnboardingWizardSteps.swift
+++ b/apps/ios/Sources/Onboarding/OnboardingWizardSteps.swift
@@ -1,3 +1,4 @@
+import OpenClawChatUI
 import SwiftUI
 import UIKit
 
@@ -26,18 +27,21 @@ struct OnboardingActivationCanvas<Content: View>: View {
 }
 
 private struct OnboardingHeroGlyph: View {
+    var mood: OpenClawMascotMood = .idle
+
     var body: some View {
-        OpenClawActivationGlyph(size: 78, interactive: true)
+        OpenClawActivationGlyph(size: 78, mood: self.mood, interactive: true)
     }
 }
 
 struct OnboardingHeroHeader: View {
     let title: LocalizedStringKey
     let subtitle: LocalizedStringKey?
+    var mood: OpenClawMascotMood = .idle
 
     var body: some View {
         VStack(spacing: 18) {
-            OnboardingHeroGlyph()
+            OnboardingHeroGlyph(mood: self.mood)
 
             VStack(spacing: 8) {
                 Text(self.title)
@@ -292,7 +296,8 @@ struct OnboardingWelcomeStep: View {
             VStack(alignment: .leading, spacing: 0) {
                 OnboardingHeroHeader(
                     title: "Connect Gateway",
-                    subtitle: nil)
+                    subtitle: nil,
+                    mood: self.isConnecting ? .working : .idle)
                     .padding(.top, 18)
 
                 VStack(spacing: 36) {
@@ -361,7 +366,7 @@ struct OnboardingSuccessStep: View {
                 Spacer(minLength: 54)
 
                 ZStack(alignment: .bottomTrailing) {
-                    OpenClawActivationGlyph(size: 86, interactive: true)
+                    OpenClawActivationGlyph(size: 86, mood: .celebrating, interactive: true)
                         .shadow(color: OpenClawBrand.activationGlow.opacity(0.18), radius: 12, x: 0, y: 6)
 
                     Image(systemName: "checkmark")

--- a/apps/ios/Tests/GatewayQuickSetupSheetMoodTests.swift
+++ b/apps/ios/Tests/GatewayQuickSetupSheetMoodTests.swift
@@ -1,0 +1,41 @@
+import OpenClawChatUI
+import Testing
+@testable import OpenClaw
+
+@MainActor
+struct GatewayQuickSetupSheetMoodTests {
+    @Test func `connecting works`() {
+        #expect(GatewayQuickSetupSheet.headerMood(
+            connecting: true,
+            hasError: false,
+            hasCandidate: false) == .working)
+    }
+
+    @Test func `error is sad`() {
+        #expect(GatewayQuickSetupSheet.headerMood(
+            connecting: false,
+            hasError: true,
+            hasCandidate: true) == .sad)
+    }
+
+    @Test func `candidate is curious`() {
+        #expect(GatewayQuickSetupSheet.headerMood(
+            connecting: false,
+            hasError: false,
+            hasCandidate: true) == .curious)
+    }
+
+    @Test func `empty state idles`() {
+        #expect(GatewayQuickSetupSheet.headerMood(
+            connecting: false,
+            hasError: false,
+            hasCandidate: false) == .idle)
+    }
+
+    @Test func `connecting beats error`() {
+        #expect(GatewayQuickSetupSheet.headerMood(
+            connecting: true,
+            hasError: true,
+            hasCandidate: true) == .working)
+    }
+}


### PR DESCRIPTION
## What Problem This Solves

The iOS app renders the animated mascot in onboarding and the gateway quick-setup sheet, but always in its default idle loop — `OpenClawActivationGlyph` never passed a mood. Connecting, failing, and succeeding all look identical while the shared kit already ships purpose-built moods (including the new hard-hat `working`).

## Why This Change Was Made

- `OpenClawActivationGlyph` gains a defaulted `mood` parameter (all existing call sites unchanged).
- Onboarding welcome step: the hero mascot puts on its hard hat and hammers (`.working`) while `isConnecting`; idle otherwise.
- Onboarding success step: `.celebrating` alongside the existing checkmark badge.
- Gateway quick-setup sheet: header mood derived in a testable helper — `connecting → .working`, error → `.sad`, discovered candidate → `.curious`, else `.idle` (precedence in that order).

## User Impact

iOS setup now mirrors the Mac app's personality: the little guy visibly works while your phone connects to a Gateway, looks sad when a connection attempt fails, perks up when a nearby Gateway is discovered, and celebrates when you're connected. No layout or copy changes.

## Evidence

- New `GatewayQuickSetupSheetMoodTests` (Swift Testing, `OpenClawLogicTests` target): 5 cases covering all four moods plus connecting-beats-error precedence.
- `swiftformat --lint` (repo config) clean on all touched files; `node --import tsx scripts/native-app-i18n.ts check` passes with the synced inventory (line-number shifts only, no string changes); `git diff --check` clean.
- Compile proof via the iOS CI lanes (`ios-build`); no repo-side iOS unit-test runner exists to invoke locally.
