### PR TITLE
fix(discord): bound Activity shell requests

### DIFF
--- a/extensions/discord/src/activities/shell.timeout.test.ts
+++ b/extensions/discord/src/activities/shell.timeout.test.ts
@@ -1,0 +1,141 @@
+/* @vitest-environment jsdom */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { DISCORD_ACTIVITY_SHELL_JS } from "./shell.js";
+
+const IMPORT_LINE = 'import { DiscordSDK } from "./vendor/embedded-app-sdk.mjs";';
+
+type ScheduledTimeout = {
+  callback: () => void;
+  delayMs: number;
+  id: number;
+};
+
+function executeShell(fetchMock: ReturnType<typeof vi.fn>) {
+  const scheduledTimeouts: ScheduledTimeout[] = [];
+  const activeTimeouts = new Map<number, ScheduledTimeout>();
+  const clearTimeoutSpy = vi.fn((id: number) => {
+    activeTimeouts.delete(id);
+  });
+  const ready = vi.fn(async () => {});
+  const authorize = vi.fn(async () => ({ code: "authorization-code" }));
+  const authenticate = vi.fn(async () => ({}));
+  const scheduleTimeout = (callback: () => void, delayMs: number) => {
+    const id = scheduledTimeouts.length + 1;
+    const timeout = { callback, delayMs, id };
+    scheduledTimeouts.push(timeout);
+    activeTimeouts.set(id, timeout);
+    return id;
+  };
+  class DiscordSDK {
+    customId = "widget-1";
+    instanceId = "instance-1";
+    commands = { authorize, authenticate };
+
+    ready = ready;
+  }
+  const activityWindow = {
+    location: {
+      hostname: "123.discordsays.com",
+      origin: "https://123.discordsays.com",
+    },
+  };
+  const bootstrap = DISCORD_ACTIVITY_SHELL_JS.replace(IMPORT_LINE, "");
+  if (bootstrap === DISCORD_ACTIVITY_SHELL_JS) {
+    throw new Error("Discord Activity shell import did not match the test harness");
+  }
+
+  // oxlint-disable-next-line typescript/no-implied-eval -- Execute the generated shell itself so timeout coverage cannot drift into a reimplementation.
+  new Function(
+    "DiscordSDK",
+    "window",
+    "document",
+    "AbortController",
+    "setTimeout",
+    "clearTimeout",
+    "fetch",
+    bootstrap,
+  )(
+    DiscordSDK,
+    activityWindow,
+    document,
+    AbortController,
+    scheduleTimeout,
+    clearTimeoutSpy,
+    fetchMock,
+  );
+
+  const fireTimeout = (id: number) => {
+    const timeout = activeTimeouts.get(id);
+    if (!timeout) {
+      throw new Error(`timeout ${id} is no longer active`);
+    }
+    timeout.callback();
+  };
+
+  return { scheduledTimeouts, clearTimeoutSpy, fireTimeout };
+}
+
+function expectGatewayOffline() {
+  expect(document.querySelector("h1")?.textContent).toBe("Gateway offline");
+  expect(document.querySelector("iframe")).toBeNull();
+}
+
+describe("Discord Activity shell request timeout", () => {
+  beforeEach(() => {
+    document.body.innerHTML = '<div id="app"></div>';
+  });
+
+  it("expires a request that stalls before response headers", async () => {
+    const fetchMock = vi.fn((_input: string, init: { signal: AbortSignal }) => {
+      return new Promise((_resolve, reject) => {
+        init.signal.addEventListener("abort", () => reject(init.signal.reason), { once: true });
+      });
+    });
+    const { scheduledTimeouts, clearTimeoutSpy, fireTimeout } = executeShell(fetchMock);
+
+    await vi.waitFor(() => expect(scheduledTimeouts).toHaveLength(1));
+    const requestTimeout = scheduledTimeouts[0];
+    expect(requestTimeout?.delayMs).toBe(15_000);
+    fireTimeout(requestTimeout?.id ?? -1);
+
+    await vi.waitFor(expectGatewayOffline);
+    expect(clearTimeoutSpy).toHaveBeenCalledWith(scheduledTimeouts[0]?.id);
+  });
+
+  it("expires a successful response whose body stalls", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ access_token: "access-token", session_token: "session-token" }),
+          { headers: { "Content-Type": "application/json" } },
+        ),
+      )
+      .mockImplementationOnce((_input: string, init: { signal: AbortSignal }) => {
+        const body = new ReadableStream<Uint8Array>({
+          start(controller) {
+            init.signal.addEventListener("abort", () => controller.error(init.signal.reason), {
+              once: true,
+            });
+          },
+        });
+        return Promise.resolve(
+          new Response(body, { status: 200, headers: { "Content-Type": "application/json" } }),
+        );
+      });
+    const { scheduledTimeouts, clearTimeoutSpy, fireTimeout } = executeShell(fetchMock);
+
+    await vi.waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      expect(scheduledTimeouts).toHaveLength(2);
+    });
+    const bodyTimeout = scheduledTimeouts[1];
+    expect(bodyTimeout?.delayMs).toBe(15_000);
+    expect(clearTimeoutSpy).not.toHaveBeenCalledWith(bodyTimeout?.id);
+    fireTimeout(bodyTimeout?.id ?? -1);
+
+    await vi.waitFor(expectGatewayOffline);
+    expect(clearTimeoutSpy).toHaveBeenCalledWith(scheduledTimeouts[1]?.id);
+  });
+});

--- a/extensions/discord/src/activities/shell.timeout.test.ts
+++ b/extensions/discord/src/activities/shell.timeout.test.ts
@@ -89,7 +89,16 @@ describe("Discord Activity shell request timeout", () => {
   it("expires a request that stalls before response headers", async () => {
     const fetchMock = vi.fn((_input: string, init: { signal: AbortSignal }) => {
       return new Promise((_resolve, reject) => {
-        init.signal.addEventListener("abort", () => reject(init.signal.reason), { once: true });
+        init.signal.addEventListener(
+          "abort",
+          () =>
+            reject(
+              init.signal.reason instanceof Error
+                ? init.signal.reason
+                : new Error("request aborted"),
+            ),
+          { once: true },
+        );
       });
     });
     const { scheduledTimeouts, clearTimeoutSpy, fireTimeout } = executeShell(fetchMock);

--- a/extensions/discord/src/activities/shell.ts
+++ b/extensions/discord/src/activities/shell.ts
@@ -17,6 +17,7 @@ h1{font-size:18px;margin:0 0 8px;color:#f2f3f5}p{margin:0;color:#b5bac1;line-hei
 export const DISCORD_ACTIVITY_SHELL_JS = `import { DiscordSDK } from "./vendor/embedded-app-sdk.mjs";
 
 const app = document.querySelector("#app");
+const ACTIVITY_API_TIMEOUT_MS = 15_000;
 function show(message, detail) {
   app.className = "";
   app.innerHTML = "";
@@ -40,14 +41,36 @@ function proxiedDocUrl(value) {
   }
   return url.pathname + url.search;
 }
-async function readJson(response) {
-  const body = await response.json().catch(() => ({}));
+async function readJson(response, signal) {
+  let body;
+  try {
+    body = await response.json();
+  } catch (error) {
+    // A successful response needs a usable body, and an aborted error body still
+    // belongs to the request deadline. Only malformed HTTP error bodies may be empty.
+    if (response.ok || signal.aborted) {
+      throw error;
+    }
+    body = {};
+  }
   if (!response.ok) {
     const error = new Error(typeof body.error === "string" ? body.error : "request failed");
     error.status = response.status;
     throw error;
   }
   return body;
+}
+async function fetchActivityJson(input, init) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), ACTIVITY_API_TIMEOUT_MS);
+  try {
+    return await readJson(
+      await fetch(input, { ...init, signal: controller.signal }),
+      controller.signal,
+    );
+  } finally {
+    clearTimeout(timeout);
+  }
 }
 async function run() {
   const match = window.location.hostname.match(/^(\\d+)\\.discordsays\\.com$/i);
@@ -65,19 +88,19 @@ async function run() {
     prompt: "none",
     scope: ["identify"],
   });
-  const auth = await readJson(await fetch("./api/token", {
+  const auth = await fetchActivityJson("./api/token", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ code }),
-  }));
+  });
   await sdk.commands.authenticate({ access_token: auth.access_token });
   const query = new URLSearchParams({
     custom_id: sdk.customId ?? "",
     instance_id: sdk.instanceId,
   });
-  const widget = await readJson(await fetch("./api/widget?" + query, {
+  const widget = await fetchActivityJson("./api/widget?" + query, {
     headers: { Authorization: "Bearer " + auth.session_token },
-  }));
+  });
   app.className = "widget";
   app.innerHTML = "";
   const bar = document.createElement("div");


### PR DESCRIPTION
## What Problem This Solves

The Discord Activity shell fetches its token and widget metadata without a deadline. If the gateway stalls before headers or while streaming a JSON body, the embedded Activity can remain stuck on its opening state indefinitely.

## Why This Change Was Made

Route both shell API calls through one 15-second `AbortController` helper whose timer remains active through `response.json()`. Successful responses require a usable JSON body, aborted error bodies propagate to the existing Gateway offline state, and malformed non-2xx bodies retain the existing HTTP status mapping.

The regression tests execute the generated `DISCORD_ACTIVITY_SHELL_JS` itself. They cover a pre-header token stall and a post-header widget-body stall, and model active timers so an implementation that clears the deadline after headers cannot pass.

## User Impact

A stalled Discord Activity gateway request now resolves to the existing retryable Gateway offline UI after 15 seconds instead of leaving the widget indefinitely stuck or rendering an invalid iframe.

## Evidence

### Exact revision and CI

- Exact head: `659b835fbb63b7adf6a5950bcf9b65cadf7a51dd`.
- GitHub `openclaw/ci-gate`: passed on the exact head ([run 29491455379](https://github.com/openclaw/openclaw/actions/runs/29491455379)).
- Fresh focused run on Node 22.22.0: `node scripts/run-vitest.mjs extensions/discord/src/activities/shell.timeout.test.ts extensions/discord/src/activities/http.test.ts` -> 2 files, 24 tests passed.
- Targeted `oxlint`, `oxfmt --check`, and `git diff --check`: passed.
- Mutation proof: clearing the body timer immediately after response headers makes the behavior harness fail with `timer is no longer active`.

### Real Chromium request-boundary proof

Chrome 149 loaded the exact generated HTML/JS from this revision. A real Node HTTP server then controlled the two failure modes while the production shell used the browser's real `fetch`, `AbortController`, JSON body reader, and DOM rendering path.

- **Before headers:** the token request arrived at `+25467 ms`; the browser closed the still-headerless socket at `+40467 ms` (exactly `15000 ms` later). The rendered state was `Gateway offline`, with zero iframes.
- **During the JSON body:** the widget response sent `200` headers plus an unfinished JSON prefix at `+25487 ms`; the browser closed the unfinished socket at `+40490 ms` (`15003 ms` later, `writableEnded=false`). The rendered state was `Gateway offline`, with zero iframes.
- **Recovery:** after each failure, reloading the same browser page against healthy token and widget responses rendered `Recovered widget` with one iframe in `64 ms` and `62 ms`, respectively. The iframe document loaded successfully and the browser console was clean.

The initial absolute timestamps include Chrome startup and first navigation; the deadline assertion is request/partial-body event to socket close.

### Proof boundary

The harness substitutes only the Discord SDK handshake (`ready`, `authorize`, and `authenticate`) so it can reach the Activity shell's outbound request boundary without a Discord account. The pinned `@discord/embedded-app-sdk@2.5.0` contract was checked: its documented sequence is `ready` -> `authorize` -> application token fetch -> `authenticate`, which is the boundary used here. The network timeout, streaming body abort, offline UI, and recovery path are not mocked.

This is real-browser diagnostic proof of the changed behavior, but it is not a Discord-hosted Activity recording. No live Discord Activity was deliberately stalled.
