### PR TITLE
refactor(channels): share retry helpers and remove dead state probes

### DIFF
--- a/config/knip.config.ts
+++ b/config/knip.config.ts
@@ -169,7 +169,6 @@ const bundledPluginEntries = [
   "cli-metadata.ts!",
   "channel-entry.ts!",
   // Manifest and SDK loaders resolve these public artifacts by basename.
-  "configured-state.ts!",
   "auth-presence.ts!",
   "thread-bindings-runtime.ts!",
   "document-extractor.ts!",

--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-a946f69b8ec03ed5b3ff26301b70e4adfe8e78574f6afa147accf92c2b314b11  plugin-sdk-api-baseline.json
-363f06ea86f4b1cc2f7a065c7db74290cc13df7cc1f427b37928109d92ddd8f6  plugin-sdk-api-baseline.jsonl
+2713341b4e458d22f23a993423ee60ba20734b0c90f6792134941c5830b863f5  plugin-sdk-api-baseline.json
+041a52f9ff06f3cdebccf6704960de02142abec68266daff37b0399795c212d1  plugin-sdk-api-baseline.jsonl

--- a/docs/plugins/manifest.md
+++ b/docs/plugins/manifest.md
@@ -1207,7 +1207,7 @@ Runtime entrypoint fields do not override package-boundary checks for source ent
 
 Use it when setup, doctor, status, or read-only presence flows need a cheap yes/no auth probe before the full channel plugin loads. Persisted auth state is not configured channel state: do not use this metadata to auto-enable plugins, repair runtime dependencies, or decide whether a channel runtime should load. The target export should be a small function that reads persisted state only; do not route it through the full channel runtime barrel.
 
-`openclaw.channel.configuredState` follows the same shape for cheap env-only configured checks:
+`openclaw.channel.configuredState` supports cheap configured checks. Prefer declarative env metadata when environment variables are sufficient:
 
 ```json
 {
@@ -1215,15 +1215,16 @@ Use it when setup, doctor, status, or read-only presence flows need a cheap yes/
     "channel": {
       "id": "telegram",
       "configuredState": {
-        "specifier": "./configured-state",
-        "exportName": "hasTelegramConfiguredState"
+        "env": {
+          "allOf": ["TELEGRAM_BOT_TOKEN"]
+        }
       }
     }
   }
 }
 ```
 
-Use it when a channel can answer configured-state from env or other tiny non-runtime inputs. If the check needs full config resolution or the real channel runtime, keep that logic in the plugin `config.hasConfiguredState` hook instead.
+Use `env.allOf` when every listed variable is required and `env.anyOf` when any one non-empty variable is enough. If a tiny non-runtime check needs more than environment metadata, use `specifier` plus `exportName` as shown for `persistedAuthState`; when `env` is present, OpenClaw uses it without loading that module. If the check needs full config resolution or the real channel runtime, keep that logic in the plugin `config.hasConfiguredState` hook instead.
 
 ## Discovery precedence (duplicate plugin ids)
 

--- a/extensions/discord/configured-state.ts
+++ b/extensions/discord/configured-state.ts
@@ -1,7 +1,0 @@
-// Discord helper module supports configured state behavior.
-export function hasDiscordConfiguredState(params: { env?: NodeJS.ProcessEnv }): boolean {
-  return (
-    typeof params.env?.DISCORD_BOT_TOKEN === "string" &&
-    params.env.DISCORD_BOT_TOKEN.trim().length > 0
-  );
-}

--- a/extensions/discord/package.json
+++ b/extensions/discord/package.json
@@ -57,9 +57,7 @@
           "allOf": [
             "DISCORD_BOT_TOKEN"
           ]
-        },
-        "specifier": "./configured-state",
-        "exportName": "hasDiscordConfiguredState"
+        }
       }
     },
     "install": {

--- a/extensions/discord/src/api.ts
+++ b/extensions/discord/src/api.ts
@@ -4,12 +4,13 @@ import { resolveTimerTimeoutMs } from "openclaw/plugin-sdk/number-runtime";
 import { readResponseTextLimited } from "openclaw/plugin-sdk/provider-http";
 import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
 import {
+  parseRetryAfterHeaderSeconds,
   resolveRetryConfig,
   retryAsync,
   type RetryConfig,
 } from "openclaw/plugin-sdk/retry-runtime";
 import { isDiscordHtmlResponseBody, summarizeDiscordResponseBody } from "./error-body.js";
-import { parseDiscordRetryAfterBodySeconds, parseRetryAfterHeaderSeconds } from "./retry-after.js";
+import { parseDiscordRetryAfterBodySeconds } from "./retry-after.js";
 
 const DISCORD_API_BASE = "https://discord.com/api/v10";
 const DISCORD_API_RETRY_DEFAULTS = {

--- a/extensions/discord/src/internal/rest-errors.ts
+++ b/extensions/discord/src/internal/rest-errors.ts
@@ -1,7 +1,8 @@
 // Discord plugin module implements rest errors behavior.
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { parseStrictNonNegativeInteger } from "openclaw/plugin-sdk/number-runtime";
-import { parseDiscordRetryAfterBodySeconds, parseRetryAfterHeaderSeconds } from "../retry-after.js";
+import { parseRetryAfterHeaderSeconds } from "openclaw/plugin-sdk/retry-runtime";
+import { parseDiscordRetryAfterBodySeconds } from "../retry-after.js";
 
 const DISCORD_UNKNOWN_VOICE_STATE = 10065;
 

--- a/extensions/discord/src/retry-after.ts
+++ b/extensions/discord/src/retry-after.ts
@@ -1,36 +1,8 @@
 // Discord plugin module implements retry after behavior.
-import {
-  asFiniteNumberInRange,
-  parseStrictFiniteNumber,
-  parseStrictNonNegativeInteger,
-} from "openclaw/plugin-sdk/number-runtime";
+import { asFiniteNumberInRange, parseStrictFiniteNumber } from "openclaw/plugin-sdk/number-runtime";
 
-const RETRY_AFTER_HEADER_DELAY_RE = /^\d+$/;
 const RETRY_AFTER_BODY_SECONDS_RE = /^(?:\d+\.?\d*|\.\d+)$/;
-const RETRY_AFTER_HTTP_DATE_RE =
-  /^(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun), \d{2} (?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) \d{4} \d{2}:\d{2}:\d{2} GMT$/;
 const MAX_SAFE_RETRY_AFTER_SECONDS = Number.MAX_SAFE_INTEGER / 1000;
-
-export function parseRetryAfterHeaderSeconds(
-  value: string | null | undefined,
-  now = Date.now(),
-): number | undefined {
-  if (!value) {
-    return undefined;
-  }
-  const trimmed = value.trim();
-  if (RETRY_AFTER_HEADER_DELAY_RE.test(trimmed)) {
-    return asFiniteNumberInRange(parseStrictNonNegativeInteger(trimmed), {
-      min: 0,
-      max: MAX_SAFE_RETRY_AFTER_SECONDS,
-    });
-  }
-  if (!RETRY_AFTER_HTTP_DATE_RE.test(trimmed)) {
-    return undefined;
-  }
-  const retryAt = Date.parse(trimmed);
-  return Number.isFinite(retryAt) ? Math.max(0, (retryAt - now) / 1000) : undefined;
-}
 
 export function parseDiscordRetryAfterBodySeconds(value: unknown): number | undefined {
   const seconds =

--- a/extensions/discord/src/retry.ts
+++ b/extensions/discord/src/retry.ts
@@ -7,11 +7,10 @@ import {
 } from "openclaw/plugin-sdk/error-runtime";
 import { parseStrictNonNegativeInteger } from "openclaw/plugin-sdk/number-runtime";
 import {
+  createChannelApiRetryRunner,
   resolveRetryConfig,
-  retryAsync,
   type RetryConfig,
 } from "openclaw/plugin-sdk/retry-runtime";
-import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
 import { RateLimitError } from "./internal/discord.js";
 
 const DISCORD_RETRY_DEFAULTS = {
@@ -45,8 +44,6 @@ const DISCORD_PRECONNECT_ERROR_CODES = new Set([
   "ENOTFOUND",
   "UND_ERR_CONNECT_TIMEOUT",
 ]);
-const log = createSubsystemLogger("discord/retry");
-
 type DiscordRetrySafety = "idempotent" | "nonce-protected-create" | "non-idempotent-create";
 
 export type DiscordRetryRunner = <T>(
@@ -160,24 +157,16 @@ export function createDiscordRetryRunner(params: {
         throw err;
       }
     };
-    return retryAsync(runRequest, {
-      ...retryConfig,
-      attempts,
-      label,
+    const runWithRetry = createChannelApiRetryRunner({
+      retry: { ...retryConfig, attempts },
       shouldRetry: (err, attempt) =>
         isRetryable(err) &&
         (attempt < retryConfig.attempts ||
           (observedGatewayDisconnect && isRetryableDiscordGatewayTransportError(err))),
+      strictShouldRetry: true,
       retryAfterMs: (err) => (err instanceof RateLimitError ? err.retryAfter * 1000 : undefined),
-      onRetry: params.verbose
-        ? (info) => {
-            const maxAttempts = observedGatewayDisconnect ? attempts : retryConfig.attempts;
-            const maxRetries = Math.max(1, maxAttempts - 1);
-            log.warn(
-              `discord ${info.label ?? "request"} retry ${info.attempt}/${maxRetries} in ${info.delayMs}ms: ${formatErrorMessage(info.err)}`,
-            );
-          }
-        : undefined,
+      verbose: params.verbose,
     });
+    return runWithRetry(runRequest, label);
   };
 }

--- a/extensions/irc/configured-state.ts
+++ b/extensions/irc/configured-state.ts
@@ -1,9 +1,0 @@
-// Irc helper module supports configured state behavior.
-export function hasIrcConfiguredState(params: { env?: NodeJS.ProcessEnv }): boolean {
-  return (
-    typeof params.env?.IRC_HOST === "string" &&
-    params.env.IRC_HOST.trim().length > 0 &&
-    typeof params.env?.IRC_NICK === "string" &&
-    params.env.IRC_NICK.trim().length > 0
-  );
-}

--- a/extensions/irc/package.json
+++ b/extensions/irc/package.json
@@ -36,9 +36,7 @@
             "IRC_HOST",
             "IRC_NICK"
           ]
-        },
-        "specifier": "./configured-state",
-        "exportName": "hasIrcConfiguredState"
+        }
       }
     },
     "compat": {

--- a/extensions/msteams/src/errors.ts
+++ b/extensions/msteams/src/errors.ts
@@ -1,5 +1,6 @@
 // Msteams plugin module implements errors behavior.
 import { asFiniteNumberInRange, parseStrictFiniteNumber } from "openclaw/plugin-sdk/number-runtime";
+import { parseRetryAfterHeaderSeconds } from "openclaw/plugin-sdk/retry-runtime";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 
 const MAX_SAFE_RETRY_AFTER_SECONDS = Number.MAX_SAFE_INTEGER / 1000;
@@ -136,7 +137,7 @@ function extractRetryAfterMs(err: unknown): number | null {
   if (isRecord(headers)) {
     const raw = headers["retry-after"] ?? headers["Retry-After"];
     if (typeof raw === "string") {
-      const parsed = parseNonNegativeRetryAfterSeconds(raw);
+      const parsed = parseRetryAfterHeaderSeconds(raw);
       if (parsed !== undefined) {
         return parsed * 1000;
       }
@@ -152,7 +153,7 @@ function extractRetryAfterMs(err: unknown): number | null {
   ) {
     const raw = (headers as { get: (name: string) => string | null }).get("retry-after");
     if (raw) {
-      const parsed = parseNonNegativeRetryAfterSeconds(raw);
+      const parsed = parseRetryAfterHeaderSeconds(raw);
       if (parsed !== undefined) {
         return parsed * 1000;
       }

--- a/extensions/qqbot/src/engine/api/retry.test.ts
+++ b/extensions/qqbot/src/engine/api/retry.test.ts
@@ -23,22 +23,67 @@ beforeEach(() => {
 
 describe("withRetry", () => {
   it("uses the shared runner without changing exponential schedules", async () => {
+    vi.useFakeTimers();
+    const operation = vi
+      .fn<() => Promise<string>>()
+      .mockRejectedValueOnce(new Error("first"))
+      .mockRejectedValueOnce(new Error("second"))
+      .mockResolvedValueOnce("ok");
+    const logger = createLogger();
+
+    try {
+      const promise = withRetry(
+        operation,
+        { maxRetries: 2, baseDelayMs: 100, backoff: "exponential" },
+        undefined,
+        logger,
+      );
+      await vi.advanceTimersByTimeAsync(99);
+      expect(operation).toHaveBeenCalledOnce();
+      await vi.advanceTimersByTimeAsync(1);
+      expect(operation).toHaveBeenCalledTimes(2);
+      await vi.advanceTimersByTimeAsync(199);
+      expect(operation).toHaveBeenCalledTimes(2);
+      await vi.advanceTimersByTimeAsync(1);
+      await expect(promise).resolves.toBe("ok");
+      expect(operation).toHaveBeenCalledTimes(3);
+      expect(logger.debug).toHaveBeenNthCalledWith(
+        1,
+        "[qqbot:retry] Attempt 1 failed, retrying in 100ms: first",
+      );
+      expect(logger.debug).toHaveBeenNthCalledWith(
+        2,
+        "[qqbot:retry] Attempt 2 failed, retrying in 200ms: second",
+      );
+    } finally {
+      vi.clearAllTimers();
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps fixed retry schedules flat", async () => {
+    vi.useFakeTimers();
     const operation = vi
       .fn<() => Promise<string>>()
       .mockRejectedValueOnce(new Error("first"))
       .mockRejectedValueOnce(new Error("second"))
       .mockResolvedValueOnce("ok");
 
-    await expect(
-      withRetry(
-        operation,
-        { maxRetries: 2, baseDelayMs: 100, backoff: "exponential" },
-        undefined,
-        createLogger(),
-      ),
-    ).resolves.toBe("ok");
-    expect(mocks.sleep).toHaveBeenNthCalledWith(1, 100);
-    expect(mocks.sleep).toHaveBeenNthCalledWith(2, 200);
+    try {
+      const promise = withRetry(operation, {
+        maxRetries: 2,
+        baseDelayMs: 75,
+        backoff: "fixed",
+      });
+      await vi.advanceTimersByTimeAsync(75);
+      expect(operation).toHaveBeenCalledTimes(2);
+      await vi.advanceTimersByTimeAsync(75);
+      await expect(promise).resolves.toBe("ok");
+      expect(operation).toHaveBeenCalledTimes(3);
+    } finally {
+      vi.clearAllTimers();
+      vi.useRealTimers();
+    }
   });
 
   it("preserves the policy's zero-based attempt index", async () => {

--- a/extensions/qqbot/src/engine/api/retry.ts
+++ b/extensions/qqbot/src/engine/api/retry.ts
@@ -10,7 +10,7 @@
  * parameterized by `RetryPolicy` and optional `PersistentRetryPolicy`.
  */
 
-import { retryAsync } from "openclaw/plugin-sdk/retry-runtime";
+import { createChannelApiRetryRunner, resolveRetryConfig } from "openclaw/plugin-sdk/retry-runtime";
 import { sleep } from "openclaw/plugin-sdk/runtime-env";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import type { EngineLogger } from "../types.js";
@@ -66,51 +66,55 @@ export async function withRetry<T>(
   // A persistent loop owns its terminal failure. Mark that Error so the outer
   // bounded runner does not accidentally restart the completed deadline loop.
   const persistentFailures = new WeakSet<Error>();
-  return await retryAsync(
-    async () => {
-      try {
-        return await fn();
-      } catch (err) {
-        const error = err instanceof Error ? err : new Error(formatErrorMessage(err));
-        if (!persistentPolicy?.shouldPersistRetry(error)) {
-          throw error;
-        }
-        (logger?.warn ?? logger?.error)?.(
-          `[qqbot:retry] Hit persistent-retry trigger, entering persistent loop (timeout=${persistentPolicy.timeoutMs / 1000}s)`,
-        );
-        try {
-          return await persistentRetryLoop(fn, persistentPolicy, logger);
-        } catch (persistentError) {
-          const terminal =
-            persistentError instanceof Error
-              ? persistentError
-              : new Error(formatErrorMessage(persistentError));
-          persistentFailures.add(terminal);
-          throw terminal;
-        }
-      }
-    },
-    {
-      attempts: policy.maxRetries + 1,
-      minDelayMs: 0,
-      maxDelayMs: 2_147_000_000,
-      delayMs: ({ attempt }) =>
-        policy.backoff === "exponential"
-          ? policy.baseDelayMs * 2 ** (attempt - 1)
-          : policy.baseDelayMs,
-      shouldRetry: (err, attempt) => {
-        const error = err instanceof Error ? err : new Error(formatErrorMessage(err));
-        return !persistentFailures.has(error) && policy.shouldRetry?.(error, attempt - 1) !== false;
-      },
-      onRetry: ({ attempt, delayMs, err }) => {
-        const error = err instanceof Error ? err : new Error(formatErrorMessage(err));
+  const retryConfig = resolveRetryConfig(undefined, {
+    attempts: policy.maxRetries + 1,
+    minDelayMs: policy.baseDelayMs,
+    maxDelayMs: policy.backoff === "fixed" ? policy.baseDelayMs : 2_147_000_000,
+    jitter: 0,
+  });
+  const runWithRetry = createChannelApiRetryRunner({
+    retry: retryConfig,
+    strictShouldRetry: true,
+    retryAfterMs: () => undefined,
+    shouldRetry: (err, attempt) => {
+      const error = err instanceof Error ? err : new Error(formatErrorMessage(err));
+      const shouldRetry =
+        !persistentFailures.has(error) && policy.shouldRetry?.(error, attempt - 1) !== false;
+      if (shouldRetry) {
+        const delayMs =
+          policy.backoff === "fixed"
+            ? retryConfig.minDelayMs
+            : Math.min(retryConfig.minDelayMs * 2 ** (attempt - 1), retryConfig.maxDelayMs);
         logger?.debug?.(
           `[qqbot:retry] Attempt ${attempt} failed, retrying in ${delayMs}ms: ${truncateUtf16Safe(error.message, 100)}`,
         );
-      },
-      sleep,
+      }
+      return shouldRetry;
     },
-  );
+  });
+  return await runWithRetry(async () => {
+    try {
+      return await fn();
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(formatErrorMessage(err));
+      if (!persistentPolicy?.shouldPersistRetry(error)) {
+        throw error;
+      }
+      (logger?.warn ?? logger?.error)?.(
+        `[qqbot:retry] Hit persistent-retry trigger, entering persistent loop (timeout=${persistentPolicy.timeoutMs / 1000}s)`,
+      );
+      try {
+        return await persistentRetryLoop(fn, persistentPolicy, logger);
+      } catch (persistentError) {
+        const terminal =
+          persistentError instanceof Error
+            ? persistentError
+            : new Error(formatErrorMessage(persistentError));
+        persistentFailures.add(terminal);
+        throw terminal;
+      }
+    }
+  });
 }
 
 /**

--- a/extensions/slack/configured-state.ts
+++ b/extensions/slack/configured-state.ts
@@ -1,8 +1,0 @@
-// Slack helper module supports configured state behavior.
-const SLACK_CONFIGURED_ENV_KEYS = ["SLACK_APP_TOKEN", "SLACK_BOT_TOKEN", "SLACK_USER_TOKEN"];
-
-export function hasSlackConfiguredState(params: { env?: NodeJS.ProcessEnv }): boolean {
-  return SLACK_CONFIGURED_ENV_KEYS.some(
-    (key) => typeof params.env?.[key] === "string" && params.env[key]?.trim().length > 0,
-  );
-}

--- a/extensions/slack/package.json
+++ b/extensions/slack/package.json
@@ -54,9 +54,7 @@
             "SLACK_BOT_TOKEN",
             "SLACK_USER_TOKEN"
           ]
-        },
-        "specifier": "./configured-state",
-        "exportName": "hasSlackConfiguredState"
+        }
       }
     },
     "install": {

--- a/extensions/telegram/configured-state.ts
+++ b/extensions/telegram/configured-state.ts
@@ -1,7 +1,0 @@
-// Telegram helper module supports configured state behavior.
-export function hasTelegramConfiguredState(params: { env?: NodeJS.ProcessEnv }): boolean {
-  return (
-    typeof params.env?.TELEGRAM_BOT_TOKEN === "string" &&
-    params.env.TELEGRAM_BOT_TOKEN.trim().length > 0
-  );
-}

--- a/extensions/telegram/package.json
+++ b/extensions/telegram/package.json
@@ -47,9 +47,7 @@
           "allOf": [
             "TELEGRAM_BOT_TOKEN"
           ]
-        },
-        "specifier": "./configured-state",
-        "exportName": "hasTelegramConfiguredState"
+        }
       }
     }
   }

--- a/extensions/telegram/src/bot/delivery.send.ts
+++ b/extensions/telegram/src/bot/delivery.send.ts
@@ -1,7 +1,7 @@
 // Telegram plugin module implements delivery.send behavior.
 import type { Bot } from "grammy";
 import type { MarkdownTableMode } from "openclaw/plugin-sdk/config-contracts";
-import { createTelegramRetryRunner } from "openclaw/plugin-sdk/retry-runtime";
+import { createChannelApiRetryRunner } from "openclaw/plugin-sdk/retry-runtime";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { formatErrorMessage } from "openclaw/plugin-sdk/ssrf-runtime";
 import { withTelegramApiErrorLogging } from "../api-logging.js";
@@ -35,7 +35,7 @@ export { buildTelegramSendParams } from "../reply-parameters.js";
 
 const EMPTY_TEXT_ERR_RE = /message text is empty/i;
 function createTelegramDeliverySendRetry() {
-  return createTelegramRetryRunner({
+  return createChannelApiRetryRunner({
     shouldRetry: (err) => isSafeToRetrySendError(err) || isTelegramRateLimitError(err),
     strictShouldRetry: true,
     retryAfterMaxDelayMs: TELEGRAM_OUTBOUND_RETRY_AFTER_CAP_MS,

--- a/extensions/telegram/src/send.ts
+++ b/extensions/telegram/src/send.ts
@@ -19,7 +19,7 @@ import { redactSensitiveText } from "openclaw/plugin-sdk/logging-core";
 import { parseStrictInteger } from "openclaw/plugin-sdk/number-runtime";
 import { resolveTextChunkLimit } from "openclaw/plugin-sdk/reply-chunking";
 import { isSingleUseReplyToMode } from "openclaw/plugin-sdk/reply-reference";
-import { createTelegramRetryRunner, type RetryConfig } from "openclaw/plugin-sdk/retry-runtime";
+import { createChannelApiRetryRunner, type RetryConfig } from "openclaw/plugin-sdk/retry-runtime";
 import { createSubsystemLogger, logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { formatErrorMessage } from "openclaw/plugin-sdk/ssrf-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
@@ -719,7 +719,7 @@ function createTelegramRequestWithDiag(params: {
   strictShouldRetry?: boolean;
   useApiErrorLogging?: boolean;
 }): TelegramRequestWithDiag {
-  const request = createTelegramRetryRunner({
+  const request = createChannelApiRetryRunner({
     retry: params.retry,
     configRetry: params.account.config.retry,
     verbose: params.verbose,

--- a/extensions/whatsapp/src/outbound-retry.ts
+++ b/extensions/whatsapp/src/outbound-retry.ts
@@ -1,5 +1,5 @@
 // WhatsApp plugin module implements outbound retry behavior.
-import { retryAsync } from "openclaw/plugin-sdk/retry-runtime";
+import { createChannelApiRetryRunner } from "openclaw/plugin-sdk/retry-runtime";
 import { formatError } from "./session-errors.js";
 import { isWhatsAppSocketOperationTimeoutError } from "./socket-timing.js";
 
@@ -35,39 +35,45 @@ export async function sendWhatsAppOutboundWithRetry<T>(params: {
   send: () => Promise<T>;
   onRetry?: (info: WhatsAppOutboundRetryInfo) => void;
 }): Promise<T> {
+  const runWithRetry = createChannelApiRetryRunner({
+    retry: {
+      attempts: WHATSAPP_OUTBOUND_MAX_ATTEMPTS,
+      minDelayMs: WHATSAPP_OUTBOUND_MIN_DELAY_MS,
+      maxDelayMs: WHATSAPP_OUTBOUND_MAX_DELAY_MS,
+      jitter: 0,
+    },
+    strictShouldRetry: true,
+    retryAfterMs: () => undefined,
+    shouldRetry: (error, attempt) => {
+      if (
+        !(error instanceof WhatsAppOutboundRetryError) ||
+        !isRetryableWhatsAppOutboundError(error.original)
+      ) {
+        return false;
+      }
+      params.onRetry?.({
+        attempt,
+        maxAttempts: WHATSAPP_OUTBOUND_MAX_ATTEMPTS,
+        backoffMs: Math.min(
+          WHATSAPP_OUTBOUND_MIN_DELAY_MS * 2 ** (attempt - 1),
+          WHATSAPP_OUTBOUND_MAX_DELAY_MS,
+        ),
+        error: error.original,
+        errorText: formatError(error.original),
+      });
+      return true;
+    },
+  });
   try {
-    return await retryAsync(
-      async () => {
-        try {
-          return await params.send();
-        } catch (error) {
-          // retryAsync normalizes non-Error throws. Keep the original value in
-          // an Error wrapper so the WhatsApp adapter can restore exact identity.
-          throw new WhatsAppOutboundRetryError(error);
-        }
-      },
-      {
-        attempts: WHATSAPP_OUTBOUND_MAX_ATTEMPTS,
-        minDelayMs: WHATSAPP_OUTBOUND_MIN_DELAY_MS,
-        maxDelayMs: WHATSAPP_OUTBOUND_MAX_DELAY_MS,
-        jitter: 0,
-        shouldRetry: (error) =>
-          error instanceof WhatsAppOutboundRetryError &&
-          isRetryableWhatsAppOutboundError(error.original),
-        onRetry: ({ attempt, maxAttempts, delayMs, err }) => {
-          if (!(err instanceof WhatsAppOutboundRetryError)) {
-            return;
-          }
-          params.onRetry?.({
-            attempt,
-            maxAttempts,
-            backoffMs: delayMs,
-            error: err.original,
-            errorText: formatError(err.original),
-          });
-        },
-      },
-    );
+    return await runWithRetry(async () => {
+      try {
+        return await params.send();
+      } catch (error) {
+        // The shared runner normalizes non-Error throws. Keep the original in
+        // an Error wrapper so the WhatsApp adapter can restore exact identity.
+        throw new WhatsAppOutboundRetryError(error);
+      }
+    });
   } catch (error) {
     if (error instanceof WhatsAppOutboundRetryError) {
       throw error.original;

--- a/scripts/plugin-sdk-surface-report.mjs
+++ b/scripts/plugin-sdk-surface-report.mjs
@@ -100,6 +100,8 @@ const defaultPublicDeprecatedExportsByEntrypointBudget = Object.freeze({
   "self-hosted-provider-setup": 14,
   routing: 1,
   runtime: 3,
+  // Deprecated Telegram-named alias retained for plugin SDK compatibility.
+  "retry-runtime": 1,
   "runtime-logger": 3,
   "runtime-secret-resolution": 5,
   "secret-provider-integration": 4,
@@ -234,7 +236,8 @@ export function readPluginSdkSurfaceBudgets(env = process.env) {
       // +3: widget HTML validation helpers and tool input error.
       // Used-union narrowing: 31 wildcard barrels drop to explicit used exports;
       // proxy stream API and codex marker/scaffold pins retained.
-      7949,
+      // +2: generic channel retry runner and Retry-After parser.
+      7951,
       env,
     ),
     publicFunctionExports: readPluginSdkSurfaceBudgetEnv(
@@ -251,7 +254,8 @@ export function readPluginSdkSurfaceBudgets(env = process.env) {
       // +6: active plan-step helpers pinned through channel-outbound and mirrors.
       // +2: widget HTML document detection and size assertion.
       // Used-union narrowing of the 31 wildcard barrels.
-      4437,
+      // +2: generic channel retry runner and Retry-After parser.
+      4439,
       env,
     ),
     publicDeprecatedExports: readPluginSdkSurfaceBudgetEnv(
@@ -264,7 +268,8 @@ export function readPluginSdkSurfaceBudgets(env = process.env) {
       // +3: dual-field plan payload builder through deprecated channel barrels.
       // +8: channel-outbound plan pins mirrored through deprecated barrels.
       // Used-union narrowing drops inherited deprecated exports.
-      2977,
+      // +1: Telegram runner alias retained for plugin SDK compatibility.
+      2978,
       env,
     ),
     publicWildcardReexports: readPluginSdkSurfaceBudgetEnv(

--- a/src/channels/plugins/package-state-probes.test.ts
+++ b/src/channels/plugins/package-state-probes.test.ts
@@ -86,6 +86,42 @@ describe("channel package-state probes", () => {
     ).toBe(false);
   });
 
+  it("uses manifest env metadata without loading a configured-state module", () => {
+    listChannelCatalogEntriesMock.mockReturnValue([
+      {
+        ...makeBundledChannelCatalogEntry({
+          pluginId: "env-chat",
+          channelId: "env-chat",
+        }),
+        channel: {
+          id: "env-chat",
+          configuredState: {
+            env: { allOf: ["ENV_CHAT_TOKEN"] },
+            specifier: "./missing-configured-state",
+            exportName: "missingConfiguredState",
+          },
+        },
+      } satisfies PluginChannelCatalogEntry,
+    ]);
+
+    expect(
+      hasBundledChannelPackageState({
+        metadataKey: "configuredState",
+        channelId: "env-chat",
+        cfg: {},
+        env: { ENV_CHAT_TOKEN: "token" },
+      }),
+    ).toBe(true);
+    expect(
+      hasBundledChannelPackageState({
+        metadataKey: "configuredState",
+        channelId: "env-chat",
+        cfg: {},
+        env: { ENV_CHAT_TOKEN: " " },
+      }),
+    ).toBe(false);
+  });
+
   it("prefers built bundled package-state probes when the catalog root is source", () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-package-state-probe-"));
     tempDirs.push(root);

--- a/src/infra/retry-after.ts
+++ b/src/infra/retry-after.ts
@@ -1,11 +1,10 @@
+import { parseRetryAfterHttpDateMs } from "@openclaw/ai/internal/retry-after";
 import { asFiniteNumberInRange, parseStrictNonNegativeInteger } from "../shared/number-coercion.js";
 
 const RETRY_AFTER_HEADER_DELAY_RE = /^\d+$/;
-const RETRY_AFTER_HTTP_DATE_RE =
-  /^(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun), \d{2} (?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) \d{4} \d{2}:\d{2}:\d{2} GMT$/;
 const MAX_SAFE_RETRY_AFTER_SECONDS = Number.MAX_SAFE_INTEGER / 1000;
 
-/** Parses an RFC Retry-After header as delay seconds or an IMF-fixdate. */
+/** Parses an RFC Retry-After header as delay seconds or any valid HTTP-date form. */
 export function parseRetryAfterHeaderSeconds(
   value: string | null | undefined,
   now = Date.now(),
@@ -20,11 +19,9 @@ export function parseRetryAfterHeaderSeconds(
       max: MAX_SAFE_RETRY_AFTER_SECONDS,
     });
   }
-  if (!RETRY_AFTER_HTTP_DATE_RE.test(trimmed)) {
+  if (!Number.isFinite(now)) {
     return undefined;
   }
-  const retryAt = Date.parse(trimmed);
-  return Number.isFinite(retryAt) && Number.isFinite(now)
-    ? Math.max(0, (retryAt - now) / 1000)
-    : undefined;
+  const retryAt = parseRetryAfterHttpDateMs(trimmed, now);
+  return retryAt === undefined ? undefined : Math.max(0, (retryAt - now) / 1000);
 }

--- a/src/infra/retry-after.ts
+++ b/src/infra/retry-after.ts
@@ -1,0 +1,30 @@
+import { asFiniteNumberInRange, parseStrictNonNegativeInteger } from "../shared/number-coercion.js";
+
+const RETRY_AFTER_HEADER_DELAY_RE = /^\d+$/;
+const RETRY_AFTER_HTTP_DATE_RE =
+  /^(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun), \d{2} (?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) \d{4} \d{2}:\d{2}:\d{2} GMT$/;
+const MAX_SAFE_RETRY_AFTER_SECONDS = Number.MAX_SAFE_INTEGER / 1000;
+
+/** Parses an RFC Retry-After header as delay seconds or an IMF-fixdate. */
+export function parseRetryAfterHeaderSeconds(
+  value: string | null | undefined,
+  now = Date.now(),
+): number | undefined {
+  if (!value) {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  if (RETRY_AFTER_HEADER_DELAY_RE.test(trimmed)) {
+    return asFiniteNumberInRange(parseStrictNonNegativeInteger(trimmed), {
+      min: 0,
+      max: MAX_SAFE_RETRY_AFTER_SECONDS,
+    });
+  }
+  if (!RETRY_AFTER_HTTP_DATE_RE.test(trimmed)) {
+    return undefined;
+  }
+  const retryAt = Date.parse(trimmed);
+  return Number.isFinite(retryAt) && Number.isFinite(now)
+    ? Math.max(0, (retryAt - now) / 1000)
+    : undefined;
+}

--- a/src/infra/retry-policy.test.ts
+++ b/src/infra/retry-policy.test.ts
@@ -286,6 +286,8 @@ describe("parseRetryAfterHeaderSeconds", () => {
   it.each([
     ["delay seconds", " 15 ", Date.UTC(2026, 4, 1, 12, 0, 0), 15],
     ["HTTP date", "Fri, 01 May 2026 12:00:05 GMT", Date.UTC(2026, 4, 1, 12, 0, 0), 5],
+    ["RFC 850 date", "Friday, 01-May-26 12:00:05 GMT", Date.UTC(2026, 4, 1, 12, 0, 0), 5],
+    ["asctime date", "Fri May  1 12:00:05 2026", Date.UTC(2026, 4, 1, 12, 0, 0), 5],
     ["past HTTP date", "Fri, 01 May 2026 11:59:55 GMT", Date.UTC(2026, 4, 1, 12, 0, 0), 0],
   ])("parses $name", (_name, value, now, expected) => {
     expect(parseRetryAfterHeaderSeconds(value, now)).toBe(expected);

--- a/src/infra/retry-policy.test.ts
+++ b/src/infra/retry-policy.test.ts
@@ -1,5 +1,6 @@
 // Covers channel API retry policy behavior.
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { parseRetryAfterHeaderSeconds } from "./retry-after.js";
 import { createChannelApiRetryRunner } from "./retry-policy.js";
 
 const ZERO_DELAY_RETRY = { attempts: 3, minDelayMs: 0, maxDelayMs: 0, jitter: 0 };
@@ -204,6 +205,31 @@ describe("createChannelApiRetryRunner", () => {
     expect(fn).toHaveBeenCalledTimes(2);
   });
 
+  it("uses an injected retry-after reader instead of the Telegram body default", async () => {
+    vi.useFakeTimers();
+
+    const retryAfterMs = vi.fn(() => 250);
+    const runner = createChannelApiRetryRunner({
+      retry: { attempts: 2, minDelayMs: 0, maxDelayMs: 1_000, jitter: 0 },
+      retryAfterMs,
+    });
+    const error = {
+      message: "429 Too Many Requests",
+      parameters: { retry_after: 1 },
+    };
+    const fn = vi.fn().mockRejectedValueOnce(error).mockResolvedValue("ok");
+
+    const promise = runner(fn, "test");
+
+    await vi.advanceTimersByTimeAsync(249);
+    expect(fn).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(1);
+    await expect(promise).resolves.toBe("ok");
+    expect(retryAfterMs).toHaveBeenCalledWith(error);
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
   it("keeps retry_after hints capped by maxDelayMs by default", async () => {
     vi.useFakeTimers();
 
@@ -253,5 +279,28 @@ describe("createChannelApiRetryRunner", () => {
     await vi.advanceTimersByTimeAsync(1);
     await expect(promise).resolves.toBe("ok");
     expect(fn).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("parseRetryAfterHeaderSeconds", () => {
+  it.each([
+    ["delay seconds", " 15 ", Date.UTC(2026, 4, 1, 12, 0, 0), 15],
+    ["HTTP date", "Fri, 01 May 2026 12:00:05 GMT", Date.UTC(2026, 4, 1, 12, 0, 0), 5],
+    ["past HTTP date", "Fri, 01 May 2026 11:59:55 GMT", Date.UTC(2026, 4, 1, 12, 0, 0), 0],
+  ])("parses $name", (_name, value, now, expected) => {
+    expect(parseRetryAfterHeaderSeconds(value, now)).toBe(expected);
+  });
+
+  it.each([
+    null,
+    "",
+    "1.5",
+    "+1",
+    "1 second",
+    "9007199254741",
+    "Sun Nov 99 99:99:99 9999",
+    "Friday, 01 May 2026 12:00:05 GMT",
+  ])("rejects invalid value %j", (value) => {
+    expect(parseRetryAfterHeaderSeconds(value)).toBeUndefined();
   });
 });

--- a/src/infra/retry-policy.ts
+++ b/src/infra/retry-policy.ts
@@ -1,7 +1,7 @@
 // Defines reusable retry envelopes for channel and network operations.
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { formatErrorMessage } from "./errors.js";
-import { type RetryConfig, resolveRetryConfig, retryAsync } from "./retry.js";
+import { type RetryConfig, type RetryOptions, resolveRetryConfig, retryAsync } from "./retry.js";
 
 /** Runs an async operation with a policy-specific retry wrapper and optional log label. */
 export type RetryRunner = <T>(fn: () => Promise<T>, label?: string) => Promise<T>;
@@ -19,9 +19,9 @@ const CHANNEL_API_RETRY_RE =
 const log = createSubsystemLogger("retry-policy");
 
 function resolveChannelApiShouldRetry(params: {
-  shouldRetry?: (err: unknown) => boolean;
+  shouldRetry?: RetryOptions["shouldRetry"];
   strictShouldRetry?: boolean;
-}) {
+}): NonNullable<RetryOptions["shouldRetry"]> {
   if (!params.shouldRetry) {
     return (err: unknown) => CHANNEL_API_RETRY_RE.test(formatErrorMessage(err));
   }
@@ -30,8 +30,8 @@ function resolveChannelApiShouldRetry(params: {
   }
   // Channel APIs often wrap network failures differently by provider. Keep the
   // fallback regex unless callers opt into strict idempotency control.
-  return (err: unknown) =>
-    params.shouldRetry?.(err) || CHANNEL_API_RETRY_RE.test(formatErrorMessage(err));
+  return (err: unknown, attempt: number) =>
+    params.shouldRetry?.(err, attempt) || CHANNEL_API_RETRY_RE.test(formatErrorMessage(err));
 }
 
 function getChannelApiRetryAfterMs(err: unknown): number | undefined {
@@ -96,7 +96,8 @@ export function createChannelApiRetryRunner(params: {
   configRetry?: RetryConfig;
   verbose?: boolean;
   retryAfterMaxDelayMs?: number;
-  shouldRetry?: (err: unknown) => boolean;
+  shouldRetry?: RetryOptions["shouldRetry"];
+  retryAfterMs?: RetryOptions["retryAfterMs"];
   /**
    * When true, the custom shouldRetry predicate is used exclusively —
    * the default channel API fallback regex is NOT OR'd in.
@@ -116,7 +117,7 @@ export function createChannelApiRetryRunner(params: {
       ...retryConfig,
       label,
       shouldRetry,
-      retryAfterMs: getChannelApiRetryAfterMs,
+      retryAfterMs: params.retryAfterMs ?? getChannelApiRetryAfterMs,
       ...(params.retryAfterMaxDelayMs !== undefined
         ? { retryAfterMaxDelayMs: params.retryAfterMaxDelayMs }
         : {}),

--- a/src/plugin-sdk/retry-runtime.ts
+++ b/src/plugin-sdk/retry-runtime.ts
@@ -8,8 +8,11 @@ export {
   type RetryOptions,
 } from "../infra/retry.js";
 export {
+  createChannelApiRetryRunner,
   createRateLimitRetryRunner,
+  /** @deprecated Use createChannelApiRetryRunner. */
   createChannelApiRetryRunner as createTelegramRetryRunner,
   CHANNEL_API_RETRY_DEFAULTS as TELEGRAM_RETRY_DEFAULTS,
   type RetryRunner,
 } from "../infra/retry-policy.js";
+export { parseRetryAfterHeaderSeconds } from "../infra/retry-after.js";

--- a/src/plugins/bundled-plugin-metadata.test.ts
+++ b/src/plugins/bundled-plugin-metadata.test.ts
@@ -496,7 +496,7 @@ describe("bundled plugin metadata", () => {
     });
   });
 
-  it("keeps bundled configured-state metadata on channel package manifests", () => {
+  it("keeps bundled configured-state env metadata on channel package manifests", () => {
     const configuredChannels = listRepoBundledPluginMetadata()
       .filter((entry) => ["discord", "irc", "slack", "telegram"].includes(entry.dirName))
       .map((entry) => ({
@@ -510,8 +510,6 @@ describe("bundled plugin metadata", () => {
           env: {
             allOf: ["DISCORD_BOT_TOKEN"],
           },
-          specifier: "./configured-state",
-          exportName: "hasDiscordConfiguredState",
         },
       },
       {
@@ -520,8 +518,6 @@ describe("bundled plugin metadata", () => {
           env: {
             allOf: ["IRC_HOST", "IRC_NICK"],
           },
-          specifier: "./configured-state",
-          exportName: "hasIrcConfiguredState",
         },
       },
       {
@@ -530,8 +526,6 @@ describe("bundled plugin metadata", () => {
           env: {
             anyOf: ["SLACK_APP_TOKEN", "SLACK_BOT_TOKEN", "SLACK_USER_TOKEN"],
           },
-          specifier: "./configured-state",
-          exportName: "hasSlackConfiguredState",
         },
       },
       {
@@ -540,8 +534,6 @@ describe("bundled plugin metadata", () => {
           env: {
             allOf: ["TELEGRAM_BOT_TOKEN"],
           },
-          specifier: "./configured-state",
-          exportName: "hasTelegramConfiguredState",
         },
       },
     ]);


### PR DESCRIPTION
## What Problem This Solves

Channel plugins carried duplicate retry runners and Retry-After parsing, while bundled Discord, IRC, Slack, and Telegram packages retained configured-state modules that duplicated their declarative environment metadata. That made retry behavior and plugin state discovery harder to keep consistent.

## Why This Change Was Made

This moves the shared channel retry policy and strict RFC Retry-After parsing behind the public plugin SDK, then migrates Discord, Microsoft Teams, QQBot, Telegram, and WhatsApp to that common path while keeping provider-specific retry predicates and schedules. The deprecated Telegram-named runner remains as a compatibility alias. The four redundant configured-state modules are removed in favor of manifest environment metadata, with docs and metadata assertions updated.

## User Impact

No user-visible behavior change is intended. Channel retries keep their existing attempt counts, delay schedules, and provider-specific rate-limit handling; HTTP-date Retry-After headers now accept all protocol-defined date forms. Plugin developers also get a generic channel retry runner instead of a Telegram-specific name.

## Evidence

- Rebased-branch Blacksmith Testbox `tbx_01kxn5w51t9z0qf8y0fsyyrznf`: full `pnpm check:changed` and `pnpm build` passed. Run: https://github.com/openclaw/openclaw/actions/runs/29489196007
- Focused retry, channel, SDK-surface, and configured-state coverage: 13 files / 222 tests passed; post-rebase affected coverage: 4 files / 109 tests passed.
- `node scripts/check-deadcode-exports.mjs`: production, full-tree, and script scans passed with zero entries.
- `node scripts/check-deadcode-unused-files.mjs`: production and full-tree scans passed with zero entries.
- Plugin SDK API baseline and surface report passed at 328 public entrypoints, 7,951 exports, 4,439 callable exports, 2,978 deprecated exports, and 106 wildcard re-exports.
- Fresh branch autoreview after the final rebase: no accepted/actionable findings (correct, confidence 0.92).
- `git diff --check`: passed.

AI-assisted: implementation and validation were completed with Codex; no agent transcript attached.
