### PR TITLE
fix(ui): throttle usage refreshes on reconnect with focus/TTL policy

### DIFF
--- a/ui/src/e2e/usage-reconnect.e2e.test.ts
+++ b/ui/src/e2e/usage-reconnect.e2e.test.ts
@@ -3,6 +3,7 @@ import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import { chromium, type Browser, type BrowserContext, type Page } from "playwright";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { USAGE_PAYLOAD_TTL_MS } from "../pages/usage/refresh-policy.ts";
 import {
   canRunPlaywrightChromium,
   installMockGateway,
@@ -192,15 +193,47 @@ describeControlUiE2e("Control UI usage proxy reconnect lifecycle", () => {
         expect(await requestCount(gateway, "usage.cost")).toBe(1);
       }
 
-      await gateway.deferNext("sessions.usage");
-      await gateway.deferNext("usage.cost");
-      await page.getByRole("button", { name: "Refresh", exact: true }).click();
+      await page.evaluate((ttlMs) => {
+        const staleNow = Date.now() + ttlMs;
+        Date.now = () => staleNow;
+        Object.defineProperty(document, "visibilityState", {
+          configurable: true,
+          get: () => "hidden",
+        });
+        Object.defineProperty(document, "hasFocus", {
+          configurable: true,
+          value: () => false,
+        });
+        document.dispatchEvent(new Event("visibilitychange"));
+      }, USAGE_PAYLOAD_TTL_MS);
+      await proxyReconnect(page, gateway, 5);
+      expect(await requestCount(gateway, "sessions.usage")).toBe(1);
+      expect(await requestCount(gateway, "usage.cost")).toBe(1);
+
+      await page.evaluate(() => {
+        Object.defineProperty(document, "visibilityState", {
+          configurable: true,
+          get: () => "visible",
+        });
+        Object.defineProperty(document, "hasFocus", {
+          configurable: true,
+          value: () => true,
+        });
+        document.dispatchEvent(new Event("visibilitychange"));
+        window.dispatchEvent(new Event("focus"));
+      });
       await waitForRequestCount(gateway, "sessions.usage", 2);
       await waitForRequestCount(gateway, "usage.cost", 2);
 
-      await proxyReconnect(page, gateway, 5);
+      await gateway.deferNext("sessions.usage");
+      await gateway.deferNext("usage.cost");
+      await page.getByRole("button", { name: "Refresh", exact: true }).click();
       await waitForRequestCount(gateway, "sessions.usage", 3);
       await waitForRequestCount(gateway, "usage.cost", 3);
+
+      await proxyReconnect(page, gateway, 6);
+      await waitForRequestCount(gateway, "sessions.usage", 4);
+      await waitForRequestCount(gateway, "usage.cost", 4);
       await page.locator(".daily-chart-compact").waitFor({ timeout: 10_000 });
       await expect.poll(() => usageBadges(page)).toEqual(["120 Tokens", "$0.01 Cost", "1 session"]);
       await captureProof(page, "usage-after-interrupted-retry.png");
@@ -209,7 +242,7 @@ describeControlUiE2e("Control UI usage proxy reconnect lifecycle", () => {
     }
   });
 
-  it("resumes Profile cache settlement once and then preserves the settled result", async () => {
+  it("keeps fresh Profile settlement quiet and preserves a manual refresh", async () => {
     const context = await createContext();
     const page = await context.newPage();
     const refreshing = {
@@ -235,6 +268,10 @@ describeControlUiE2e("Control UI usage proxy reconnect lifecycle", () => {
       await gateway.setMethodResponse("sessions.usage", sessionsUsage());
       await gateway.setMethodResponse("usage.cost", costSummary());
       await proxyReconnect(page, gateway, 2);
+      expect(await requestCount(gateway, "sessions.usage")).toBe(1);
+      expect(await requestCount(gateway, "usage.cost")).toBe(1);
+
+      await page.getByRole("button", { name: "Refresh", exact: true }).click();
       await waitForRequestCount(gateway, "sessions.usage", 2);
       await waitForRequestCount(gateway, "usage.cost", 2);
       await page.locator(".profile-stats").waitFor();

--- a/ui/src/pages/gateway-source-replacement.test.ts
+++ b/ui/src/pages/gateway-source-replacement.test.ts
@@ -6,6 +6,7 @@ import type { GatewayBrowserClient } from "../api/gateway.ts";
 import type { ApplicationContext, ApplicationGatewaySnapshot } from "../app/context.ts";
 import type { SessionsRouteData } from "./sessions/sessions-page.ts";
 import type { SkillsRouteData } from "./skills/skills-page.ts";
+import { USAGE_PAYLOAD_TTL_MS, type UsageRefreshReason } from "./usage/refresh-policy.ts";
 import type { UsageRouteData } from "./usage/usage-page.ts";
 import "./cron/cron-page.ts";
 import "./debug/debug-page.ts";
@@ -23,10 +24,12 @@ type TestPage = HTMLElement & {
 
 function deferred<T>() {
   let resolve!: (value: T) => void;
-  const promise = new Promise<T>((nextResolve) => {
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((nextResolve, nextReject) => {
     resolve = nextResolve;
+    reject = nextReject;
   });
-  return { promise, resolve };
+  return { promise, reject, resolve };
 }
 
 function gatewayWithClient(
@@ -88,6 +91,32 @@ function contextWithClient(
     navigate: vi.fn(),
     preload: vi.fn(async () => undefined),
   } as unknown as ApplicationContext;
+}
+
+function contextWithMutableGateway(client: GatewayBrowserClient) {
+  const context = contextWithClient(client, { connected: true });
+  let currentSnapshot = context.gateway.snapshot;
+  const listeners = new Set<(snapshot: ApplicationGatewaySnapshot) => void>();
+  const gateway = {
+    ...context.gateway,
+    get snapshot() {
+      return currentSnapshot;
+    },
+    subscribe: (listener: (snapshot: ApplicationGatewaySnapshot) => void) => {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+  } as ApplicationContext["gateway"];
+  Object.defineProperty(context, "gateway", { value: gateway });
+  return {
+    context,
+    emitConnected(connected: boolean) {
+      currentSnapshot = { ...currentSnapshot, connected };
+      for (const listener of listeners) {
+        listener(currentSnapshot);
+      }
+    },
+  };
 }
 
 function createPage(tagName: string, context: ApplicationContext): TestPage {
@@ -156,6 +185,7 @@ describe("gateway source replacement across reconnect with a reused client", () 
       result,
       costSummary: null,
       providerUsageSummary: null,
+      loadedAtMs: Date.now(),
       error: null,
     } satisfies UsageRouteData;
     const page = createPage("openclaw-usage-page", context) as TestPage & {
@@ -199,6 +229,7 @@ describe("gateway source replacement across reconnect with a reused client", () 
       result: staleResult,
       costSummary: null,
       providerUsageSummary: null,
+      loadedAtMs: Date.now(),
       error: null,
     };
 
@@ -211,6 +242,8 @@ describe("gateway source replacement across reconnect with a reused client", () 
   });
 
   it("keeps loaded usage data across a same-client reconnect", async () => {
+    vi.spyOn(document, "hasFocus").mockReturnValue(true);
+    vi.spyOn(document, "visibilityState", "get").mockReturnValue("visible");
     const request = vi.fn();
     const client = { request } as unknown as GatewayBrowserClient;
     const context = contextWithClient(client, { connected: true });
@@ -232,6 +265,7 @@ describe("gateway source replacement across reconnect with a reused client", () 
       result,
       costSummary: null,
       providerUsageSummary: null,
+      loadedAtMs: Date.now(),
       error: null,
     };
 
@@ -245,6 +279,8 @@ describe("gateway source replacement across reconnect with a reused client", () 
   });
 
   it("retries a usage load interrupted by a same-client disconnect", async () => {
+    vi.spyOn(document, "hasFocus").mockReturnValue(true);
+    vi.spyOn(document, "visibilityState", "get").mockReturnValue("visible");
     const request = vi.fn(async (method: string) =>
       method === "sessions.usage" ? { sessions: [] } : {},
     );
@@ -268,6 +304,7 @@ describe("gateway source replacement across reconnect with a reused client", () 
       result: { sessions: [{ key: "cached" }] } as unknown as UsageRouteData["result"],
       costSummary: null,
       providerUsageSummary: null,
+      loadedAtMs: Date.now(),
       error: null,
     };
 
@@ -282,6 +319,82 @@ describe("gateway source replacement across reconnect with a reused client", () 
     );
   });
 
+  it("gates same-client usage reconnects by payload age and page visibility", async () => {
+    vi.spyOn(document, "hasFocus").mockReturnValue(true);
+    const visibility = vi.spyOn(document, "visibilityState", "get").mockReturnValue("visible");
+    const request = vi.fn(async (method: string) => {
+      if (method === "sessions.usage") {
+        return { sessions: [] };
+      }
+      if (method === "usage.status") {
+        return { providers: [] };
+      }
+      return { daily: [] };
+    });
+    const client = { request } as unknown as GatewayBrowserClient;
+    const harness = contextWithMutableGateway(client);
+    const result = { sessions: [] } as unknown as UsageRouteData["result"];
+    const page = createPage("openclaw-usage-page", harness.context) as TestPage & {
+      routeData: UsageRouteData;
+      lastUsageLoadedAtMs: number | null;
+      usageLoading: boolean;
+      requestUsageRefresh: (reason: UsageRefreshReason) => void;
+    };
+    page.routeData = {
+      gateway: harness.context.gateway,
+      gatewaySnapshot: harness.context.gateway.snapshot,
+      query: {
+        startDate: "2026-07-08",
+        endDate: "2026-07-08",
+        scope: "family",
+        timeZone: "local",
+        agentId: null,
+      },
+      result,
+      costSummary: null,
+      providerUsageSummary: null,
+      loadedAtMs: Date.now(),
+      error: null,
+    };
+
+    document.body.append(page);
+    await page.updateComplete;
+
+    harness.emitConnected(false);
+    harness.emitConnected(true);
+    expect(request).not.toHaveBeenCalled();
+
+    page.lastUsageLoadedAtMs = Date.now() - USAGE_PAYLOAD_TTL_MS;
+    visibility.mockReturnValue("hidden");
+    harness.emitConnected(false);
+    harness.emitConnected(true);
+    expect(request).not.toHaveBeenCalled();
+
+    visibility.mockReturnValue("visible");
+    document.dispatchEvent(new Event("visibilitychange"));
+    window.dispatchEvent(new Event("focus"));
+    await vi.waitFor(() => expect(page.usageLoading).toBe(false));
+    expect(request.mock.calls.map(([method]) => method)).toEqual([
+      "sessions.usage",
+      "usage.cost",
+      "usage.status",
+    ]);
+
+    page.usageLoading = true;
+    page.requestUsageRefresh("manual");
+    await vi.waitFor(() => expect(page.usageLoading).toBe(false));
+    expect(request).toHaveBeenCalledTimes(6);
+
+    const failedRefresh = deferred<never>();
+    request.mockImplementationOnce(() => failedRefresh.promise);
+    page.lastUsageLoadedAtMs = Date.now() - USAGE_PAYLOAD_TTL_MS;
+    page.requestUsageRefresh("manual");
+    expect(request).toHaveBeenCalledTimes(9);
+    page.requestUsageRefresh("focus");
+    failedRefresh.reject(new Error("connection interrupted"));
+    await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(12));
+    await vi.waitFor(() => expect(page.usageLoading).toBe(false));
+  });
   it("preserves matching skills route data on the first bind", async () => {
     const request = vi.fn();
     const client = { request } as unknown as GatewayBrowserClient;

--- a/ui/src/pages/gateway-source-replacement.test.ts
+++ b/ui/src/pages/gateway-source-replacement.test.ts
@@ -250,7 +250,9 @@ describe("gateway source replacement across reconnect with a reused client", () 
     const result = { sessions: [{ key: "cached" }] } as unknown as UsageRouteData["result"];
     const page = createPage("openclaw-usage-page", context) as TestPage & {
       routeData: UsageRouteData;
-      applyGatewaySnapshot: (snapshot: ApplicationGatewaySnapshot) => void;
+      refreshRuntime: {
+        applyGatewaySnapshot: (snapshot: ApplicationGatewaySnapshot) => void;
+      };
     };
     page.routeData = {
       gateway: context.gateway,
@@ -271,8 +273,11 @@ describe("gateway source replacement across reconnect with a reused client", () 
 
     document.body.append(page);
     await page.updateComplete;
-    page.applyGatewaySnapshot({ ...context.gateway.snapshot, connected: false });
-    page.applyGatewaySnapshot(context.gateway.snapshot);
+    page.refreshRuntime.applyGatewaySnapshot({
+      ...context.gateway.snapshot,
+      connected: false,
+    });
+    page.refreshRuntime.applyGatewaySnapshot(context.gateway.snapshot);
     await Promise.resolve();
 
     expect(request).not.toHaveBeenCalled();
@@ -289,7 +294,9 @@ describe("gateway source replacement across reconnect with a reused client", () 
     const page = createPage("openclaw-usage-page", context) as TestPage & {
       routeData: UsageRouteData;
       usageLoading: boolean;
-      applyGatewaySnapshot: (snapshot: ApplicationGatewaySnapshot) => void;
+      refreshRuntime: {
+        applyGatewaySnapshot: (snapshot: ApplicationGatewaySnapshot) => void;
+      };
     };
     page.routeData = {
       gateway: context.gateway,
@@ -311,8 +318,11 @@ describe("gateway source replacement across reconnect with a reused client", () 
     document.body.append(page);
     await page.updateComplete;
     page.usageLoading = true;
-    page.applyGatewaySnapshot({ ...context.gateway.snapshot, connected: false });
-    page.applyGatewaySnapshot(context.gateway.snapshot);
+    page.refreshRuntime.applyGatewaySnapshot({
+      ...context.gateway.snapshot,
+      connected: false,
+    });
+    page.refreshRuntime.applyGatewaySnapshot(context.gateway.snapshot);
 
     await vi.waitFor(() =>
       expect(request).toHaveBeenCalledWith("sessions.usage", expect.any(Object)),
@@ -336,9 +346,11 @@ describe("gateway source replacement across reconnect with a reused client", () 
     const result = { sessions: [] } as unknown as UsageRouteData["result"];
     const page = createPage("openclaw-usage-page", harness.context) as TestPage & {
       routeData: UsageRouteData;
-      lastUsageLoadedAtMs: number | null;
       usageLoading: boolean;
-      requestUsageRefresh: (reason: UsageRefreshReason) => void;
+      refreshRuntime: {
+        request: (reason: UsageRefreshReason) => void;
+        setLastLoadedAtMs: (value: number | null) => void;
+      };
     };
     page.routeData = {
       gateway: harness.context.gateway,
@@ -364,7 +376,7 @@ describe("gateway source replacement across reconnect with a reused client", () 
     harness.emitConnected(true);
     expect(request).not.toHaveBeenCalled();
 
-    page.lastUsageLoadedAtMs = Date.now() - USAGE_PAYLOAD_TTL_MS;
+    page.refreshRuntime.setLastLoadedAtMs(Date.now() - USAGE_PAYLOAD_TTL_MS);
     visibility.mockReturnValue("hidden");
     harness.emitConnected(false);
     harness.emitConnected(true);
@@ -381,16 +393,16 @@ describe("gateway source replacement across reconnect with a reused client", () 
     ]);
 
     page.usageLoading = true;
-    page.requestUsageRefresh("manual");
+    page.refreshRuntime.request("manual");
     await vi.waitFor(() => expect(page.usageLoading).toBe(false));
     expect(request).toHaveBeenCalledTimes(6);
 
     const failedRefresh = deferred<never>();
     request.mockImplementationOnce(() => failedRefresh.promise);
-    page.lastUsageLoadedAtMs = Date.now() - USAGE_PAYLOAD_TTL_MS;
-    page.requestUsageRefresh("manual");
+    page.refreshRuntime.setLastLoadedAtMs(Date.now() - USAGE_PAYLOAD_TTL_MS);
+    page.refreshRuntime.request("manual");
     expect(request).toHaveBeenCalledTimes(9);
-    page.requestUsageRefresh("focus");
+    page.refreshRuntime.request("focus");
     failedRefresh.reject(new Error("connection interrupted"));
     await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(12));
     await vi.waitFor(() => expect(page.usageLoading).toBe(false));

--- a/ui/src/pages/profile/profile-page.test.ts
+++ b/ui/src/pages/profile/profile-page.test.ts
@@ -157,12 +157,13 @@ it("gates profile usage refreshes by payload age and page visibility", async () 
   expect(request).toHaveBeenCalledTimes(2);
 
   let reconnectPollDelayMs: number | undefined;
-  const reconnectTimerSpy = vi
-    .spyOn(window, "setTimeout")
-    .mockImplementation((_handler, timeout) => {
-      reconnectPollDelayMs = Number(timeout);
-      return 1;
-    });
+  const reconnectTimerSpy = vi.spyOn(window, "setTimeout").mockImplementation(((
+    _handler: TimerHandler,
+    timeout?: number,
+  ) => {
+    reconnectPollDelayMs = Number(timeout);
+    return 1;
+  }) as unknown as typeof window.setTimeout);
   page.costSummary = {
     ...EMPTY_COST_SUMMARY,
     cacheStatus: { status: "refreshing" },
@@ -192,11 +193,14 @@ it("gates profile usage refreshes by payload age and page visibility", async () 
 
   let settlePoll: TimerHandler | null = null;
   let settleDelayMs: number | undefined;
-  const setTimeoutSpy = vi.spyOn(window, "setTimeout").mockImplementation((handler, timeout) => {
+  const setTimeoutSpy = vi.spyOn(window, "setTimeout").mockImplementation(((
+    handler: TimerHandler,
+    timeout?: number,
+  ) => {
     settlePoll = handler;
     settleDelayMs = Number(timeout);
     return 1;
-  });
+  }) as unknown as typeof window.setTimeout);
   page.costSummary = {
     ...EMPTY_COST_SUMMARY,
     cacheStatus: { status: "refreshing" },

--- a/ui/src/pages/profile/profile-page.test.ts
+++ b/ui/src/pages/profile/profile-page.test.ts
@@ -20,28 +20,13 @@ type ProfilePageElement = HTMLElement & {
   updateComplete: Promise<boolean>;
 };
 
-const EMPTY_COST_SUMMARY = {
-  totals: { totalTokens: 0, totalCost: 0 },
-  daily: [],
-} as unknown as CostUsageSummary;
-
-const EMPTY_SESSIONS_USAGE = {
-  sessions: [],
-  aggregates: {
-    messages: { total: 0, user: 0, assistant: 0, toolCalls: 0, toolResults: 0, errors: 0 },
-    tools: { totalCalls: 0, uniqueTools: 0, tools: [] },
-    byModel: [],
-    byProvider: [],
-    byAgent: [],
-    byChannel: [],
-    daily: [],
-  },
-} as unknown as SessionsUsageResult;
-
-function createContext(): ApplicationContext<RouteId> {
+function createContext(
+  client: GatewayBrowserClient | null = null,
+  connected = false,
+): ApplicationContext<RouteId> {
   const snapshot: ApplicationGatewaySnapshot = {
-    client: null,
-    connected: false,
+    client,
+    connected,
     reconnecting: false,
     hello: null,
     assistantAgentId: "main",
@@ -52,9 +37,51 @@ function createContext(): ApplicationContext<RouteId> {
   const subscribe = () => () => undefined;
   return {
     gateway: { snapshot, subscribe },
-    agents: { subscribe },
-    agentIdentity: { subscribe },
+    agents: { subscribe, ensureList: vi.fn(async () => null) },
+    agentIdentity: { subscribe, ensure: vi.fn(async () => undefined) },
   } as unknown as ApplicationContext<RouteId>;
+}
+
+function createCostSummary(cacheStatus?: CostUsageSummary["cacheStatus"]): CostUsageSummary {
+  return {
+    updatedAt: 0,
+    days: 0,
+    daily: [],
+    totals: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      totalCost: 1,
+      inputCost: 0,
+      outputCost: 0,
+      cacheReadCost: 0,
+      cacheWriteCost: 0,
+      missingCostEntries: 0,
+    },
+    ...(cacheStatus ? { cacheStatus } : {}),
+  };
+}
+
+function createSessionsResult(): SessionsUsageResult {
+  const totals = createCostSummary().totals;
+  return {
+    updatedAt: 0,
+    startDate: "2026-07-08",
+    endDate: "2026-07-08",
+    sessions: [],
+    totals,
+    aggregates: {
+      messages: { total: 0, user: 0, assistant: 0, toolCalls: 0, toolResults: 0, errors: 0 },
+      tools: { totalCalls: 0, uniqueTools: 0, tools: [] },
+      byModel: [],
+      byProvider: [],
+      byAgent: [],
+      byChannel: [],
+      daily: [],
+    },
+  };
 }
 
 function createConnectedContext(request: GatewayBrowserClient["request"]) {
@@ -134,9 +161,9 @@ it("gates profile usage refreshes by payload age and page visibility", async () 
   const visibility = vi.spyOn(document, "visibilityState", "get").mockReturnValue("visible");
   const request = vi.fn(async (method: string) => {
     if (method === "usage.cost") {
-      return EMPTY_COST_SUMMARY;
+      return createCostSummary();
     }
-    return EMPTY_SESSIONS_USAGE;
+    return createSessionsResult();
   });
   const harness = createConnectedContext(request as GatewayBrowserClient["request"]);
   const provider = createApplicationContextProvider(harness.context);
@@ -164,10 +191,12 @@ it("gates profile usage refreshes by payload age and page visibility", async () 
     reconnectPollDelayMs = Number(timeout);
     return 1;
   }) as unknown as typeof window.setTimeout);
-  page.costSummary = {
-    ...EMPTY_COST_SUMMARY,
-    cacheStatus: { status: "refreshing" },
-  } as CostUsageSummary;
+  page.costSummary = createCostSummary({
+    status: "refreshing",
+    cachedFiles: 0,
+    pendingFiles: 1,
+    staleFiles: 0,
+  });
   harness.emitConnected(false);
   harness.emitConnected(true);
   expect(request).toHaveBeenCalledTimes(2);
@@ -201,10 +230,12 @@ it("gates profile usage refreshes by payload age and page visibility", async () 
     settleDelayMs = Number(timeout);
     return 1;
   }) as unknown as typeof window.setTimeout);
-  page.costSummary = {
-    ...EMPTY_COST_SUMMARY,
-    cacheStatus: { status: "refreshing" },
-  } as CostUsageSummary;
+  page.costSummary = createCostSummary({
+    status: "refreshing",
+    cachedFiles: 0,
+    pendingFiles: 1,
+    staleFiles: 0,
+  });
   page.lastProfileLoadedAtMs = Date.now();
   page.scheduleCacheSettleRefresh();
   expect(settleDelayMs).toBe(USAGE_PAYLOAD_TTL_MS);

--- a/ui/src/pages/profile/profile-page.test.ts
+++ b/ui/src/pages/profile/profile-page.test.ts
@@ -7,6 +7,7 @@ import type { RouteId } from "../../app-route-paths.ts";
 import type { ApplicationContext, ApplicationGatewaySnapshot } from "../../app/context.ts";
 import { i18n, t } from "../../i18n/index.ts";
 import { createApplicationContextProvider } from "../../test-helpers/application-context.ts";
+import { USAGE_PAYLOAD_TTL_MS, type UsageRefreshReason } from "../usage/refresh-policy.ts";
 import { ProfilePage } from "./profile-page.ts";
 
 const PROFILE_PAGE_TEST_TAG = "test-openclaw-profile-page";
@@ -19,22 +20,28 @@ type ProfilePageElement = HTMLElement & {
   updateComplete: Promise<boolean>;
 };
 
-type ProfilePageLifecycle = HTMLElement & {
-  context: ApplicationContext<RouteId>;
-  client: GatewayBrowserClient | null;
-  connected: boolean;
-  costSummary: CostUsageSummary | null;
-  sessionsResult: SessionsUsageResult | null;
-  applyGatewaySnapshot: (snapshot: ApplicationGatewaySnapshot) => void;
-};
+const EMPTY_COST_SUMMARY = {
+  totals: { totalTokens: 0, totalCost: 0 },
+  daily: [],
+} as unknown as CostUsageSummary;
 
-function createContext(
-  client: GatewayBrowserClient | null = null,
-  connected = false,
-): ApplicationContext<RouteId> {
+const EMPTY_SESSIONS_USAGE = {
+  sessions: [],
+  aggregates: {
+    messages: { total: 0, user: 0, assistant: 0, toolCalls: 0, toolResults: 0, errors: 0 },
+    tools: { totalCalls: 0, uniqueTools: 0, tools: [] },
+    byModel: [],
+    byProvider: [],
+    byAgent: [],
+    byChannel: [],
+    daily: [],
+  },
+} as unknown as SessionsUsageResult;
+
+function createContext(): ApplicationContext<RouteId> {
   const snapshot: ApplicationGatewaySnapshot = {
-    client,
-    connected,
+    client: null,
+    connected: false,
     reconnecting: false,
     hello: null,
     assistantAgentId: "main",
@@ -45,49 +52,52 @@ function createContext(
   const subscribe = () => () => undefined;
   return {
     gateway: { snapshot, subscribe },
-    agents: { subscribe, ensureList: vi.fn(async () => null) },
-    agentIdentity: { subscribe, ensure: vi.fn(async () => undefined) },
+    agents: { subscribe },
+    agentIdentity: { subscribe },
   } as unknown as ApplicationContext<RouteId>;
 }
 
-function createCostSummary(cacheStatus?: CostUsageSummary["cacheStatus"]): CostUsageSummary {
-  return {
-    updatedAt: 0,
-    days: 0,
-    daily: [],
-    totals: {
-      input: 0,
-      output: 0,
-      cacheRead: 0,
-      cacheWrite: 0,
-      totalTokens: 0,
-      totalCost: 1,
-      inputCost: 0,
-      outputCost: 0,
-      cacheReadCost: 0,
-      cacheWriteCost: 0,
-      missingCostEntries: 0,
-    },
-    ...(cacheStatus ? { cacheStatus } : {}),
+function createConnectedContext(request: GatewayBrowserClient["request"]) {
+  let snapshot: ApplicationGatewaySnapshot = {
+    client: { request } as GatewayBrowserClient,
+    connected: true,
+    reconnecting: false,
+    hello: null,
+    assistantAgentId: "main",
+    sessionKey: "agent:main:main",
+    lastError: null,
+    lastErrorCode: null,
   };
-}
-
-function createSessionsResult(): SessionsUsageResult {
-  const totals = createCostSummary().totals;
+  const listeners = new Set<(next: ApplicationGatewaySnapshot) => void>();
+  const subscribe = () => () => undefined;
+  const context = {
+    gateway: {
+      get snapshot() {
+        return snapshot;
+      },
+      subscribe(listener: (next: ApplicationGatewaySnapshot) => void) {
+        listeners.add(listener);
+        return () => listeners.delete(listener);
+      },
+    },
+    agents: {
+      state: { agentsList: null },
+      ensureList: async () => null,
+      subscribe,
+    },
+    agentIdentity: {
+      get: () => null,
+      ensure: async () => undefined,
+      subscribe,
+    },
+  } as unknown as ApplicationContext<RouteId>;
   return {
-    updatedAt: 0,
-    startDate: "2026-07-08",
-    endDate: "2026-07-08",
-    sessions: [],
-    totals,
-    aggregates: {
-      messages: { total: 0, user: 0, assistant: 0, toolCalls: 0, toolResults: 0, errors: 0 },
-      tools: { totalCalls: 0, uniqueTools: 0, tools: [] },
-      byModel: [],
-      byProvider: [],
-      byAgent: [],
-      byChannel: [],
-      daily: [],
+    context,
+    emitConnected(connected: boolean) {
+      snapshot = { ...snapshot, connected };
+      for (const listener of listeners) {
+        listener(snapshot);
+      }
     },
   };
 }
@@ -119,44 +129,89 @@ it("refreshes translated copy when the locale changes while mounted", async () =
   expect(note?.textContent?.trim()).not.toBe(englishNote);
 });
 
-it("keeps settled profile usage across a same-client reconnect", async () => {
-  const request = vi.fn();
-  const client = { request } as unknown as GatewayBrowserClient;
-  const context = createContext(client, true);
-  const page = new ProfilePage() as unknown as ProfilePageLifecycle;
-  page.context = context;
-  page.client = client;
-  page.connected = true;
-  page.costSummary = createCostSummary();
-  page.sessionsResult = createSessionsResult();
-
-  page.applyGatewaySnapshot({ ...context.gateway.snapshot, connected: false });
-  page.applyGatewaySnapshot(context.gateway.snapshot);
-  await Promise.resolve();
-
-  expect(request).not.toHaveBeenCalled();
-});
-
-it("resumes a settling profile cache after a same-client reconnect", async () => {
-  const request = vi.fn(async (method: string) =>
-    method === "sessions.usage" ? { sessions: [] } : createCostSummary(),
-  );
-  const client = { request } as unknown as GatewayBrowserClient;
-  const context = createContext(client, true);
-  const page = new ProfilePage() as unknown as ProfilePageLifecycle;
-  page.context = context;
-  page.client = client;
-  page.connected = true;
-  page.costSummary = createCostSummary({
-    status: "refreshing",
-    cachedFiles: 0,
-    pendingFiles: 1,
-    staleFiles: 0,
+it("gates profile usage refreshes by payload age and page visibility", async () => {
+  vi.spyOn(document, "hasFocus").mockReturnValue(true);
+  const visibility = vi.spyOn(document, "visibilityState", "get").mockReturnValue("visible");
+  const request = vi.fn(async (method: string) => {
+    if (method === "usage.cost") {
+      return EMPTY_COST_SUMMARY;
+    }
+    return EMPTY_SESSIONS_USAGE;
   });
-  page.sessionsResult = createSessionsResult();
+  const harness = createConnectedContext(request as GatewayBrowserClient["request"]);
+  const provider = createApplicationContextProvider(harness.context);
+  const page = document.createElement(PROFILE_PAGE_TEST_TAG) as ProfilePageElement & {
+    costSummary: CostUsageSummary | null;
+    lastProfileLoadedAtMs: number | null;
+    loading: boolean;
+    requestProfileRefresh: (reason: UsageRefreshReason) => void;
+    scheduleCacheSettleRefresh: () => void;
+  };
+  provider.append(page);
+  document.body.append(provider);
+  await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(2));
+  await vi.waitFor(() => expect(page.loading).toBe(false));
 
-  page.applyGatewaySnapshot({ ...context.gateway.snapshot, connected: false });
-  page.applyGatewaySnapshot(context.gateway.snapshot);
+  harness.emitConnected(false);
+  harness.emitConnected(true);
+  expect(request).toHaveBeenCalledTimes(2);
 
-  await vi.waitFor(() => expect(request).toHaveBeenCalledWith("usage.cost", expect.any(Object)));
+  let reconnectPollDelayMs: number | undefined;
+  const reconnectTimerSpy = vi
+    .spyOn(window, "setTimeout")
+    .mockImplementation((_handler, timeout) => {
+      reconnectPollDelayMs = Number(timeout);
+      return 1;
+    });
+  page.costSummary = {
+    ...EMPTY_COST_SUMMARY,
+    cacheStatus: { status: "refreshing" },
+  } as CostUsageSummary;
+  harness.emitConnected(false);
+  harness.emitConnected(true);
+  expect(request).toHaveBeenCalledTimes(2);
+  expect(reconnectPollDelayMs).toBeGreaterThan(0);
+  expect(reconnectPollDelayMs).toBeLessThanOrEqual(USAGE_PAYLOAD_TTL_MS);
+  reconnectTimerSpy.mockRestore();
+
+  page.lastProfileLoadedAtMs = Date.now() - USAGE_PAYLOAD_TTL_MS;
+  visibility.mockReturnValue("hidden");
+  harness.emitConnected(false);
+  harness.emitConnected(true);
+  expect(request).toHaveBeenCalledTimes(2);
+
+  visibility.mockReturnValue("visible");
+  document.dispatchEvent(new Event("visibilitychange"));
+  window.dispatchEvent(new Event("focus"));
+  await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(4));
+  await vi.waitFor(() => expect(page.loading).toBe(false));
+
+  page.querySelector<HTMLButtonElement>(".profile-refresh")?.click();
+  await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(6));
+  await vi.waitFor(() => expect(page.loading).toBe(false));
+
+  let settlePoll: TimerHandler | null = null;
+  let settleDelayMs: number | undefined;
+  const setTimeoutSpy = vi.spyOn(window, "setTimeout").mockImplementation((handler, timeout) => {
+    settlePoll = handler;
+    settleDelayMs = Number(timeout);
+    return 1;
+  });
+  page.costSummary = {
+    ...EMPTY_COST_SUMMARY,
+    cacheStatus: { status: "refreshing" },
+  } as CostUsageSummary;
+  page.lastProfileLoadedAtMs = Date.now();
+  page.scheduleCacheSettleRefresh();
+  expect(settleDelayMs).toBe(USAGE_PAYLOAD_TTL_MS);
+
+  page.lastProfileLoadedAtMs = Date.now() - USAGE_PAYLOAD_TTL_MS;
+  visibility.mockReturnValue("hidden");
+  (settlePoll as (() => void) | null)?.();
+  expect(request).toHaveBeenCalledTimes(6);
+
+  setTimeoutSpy.mockRestore();
+  visibility.mockReturnValue("visible");
+  window.dispatchEvent(new Event("focus"));
+  await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(8));
 });

--- a/ui/src/pages/profile/profile-page.ts
+++ b/ui/src/pages/profile/profile-page.ts
@@ -28,6 +28,11 @@ import { buildSessionUsageDateParams, requestSessionsUsage } from "../../lib/ses
 import { OpenClawLightDomElement } from "../../lit/openclaw-element.ts";
 import "../../styles/profile.css";
 import {
+  decideUsageRefresh,
+  USAGE_PAYLOAD_TTL_MS,
+  type UsageRefreshReason,
+} from "../usage/refresh-policy.ts";
+import {
   buildHeatmap,
   buildInsights,
   computeStreaks,
@@ -45,10 +50,6 @@ const HEATMAP_GAP = 3;
 const HEATMAP_PITCH = HEATMAP_CELL + HEATMAP_GAP;
 const HEATMAP_LEFT = 30;
 const HEATMAP_TOP = 18;
-
-const CACHE_SETTLE_POLL_MS = 5000;
-const CACHE_SETTLE_SLOW_POLL_MS = 60_000;
-const MAX_FAST_SETTLE_POLLS = 24;
 
 // Fixed reference week (2024-01-01 is a Monday) for localized weekday labels.
 const WEEKDAY_LABEL_ROWS = [
@@ -96,7 +97,7 @@ export class ProfilePage extends OpenClawLightDomElement {
   @consume({ context: applicationContext, subscribe: false })
   private context!: ApplicationContext;
 
-  @state() private loading = true;
+  @state() private loading = false;
   @state() private error: string | null = null;
   @state() private costSummary: CostUsageSummary | null = null;
   @state() private sessionsResult: SessionsUsageResult | null = null;
@@ -105,8 +106,16 @@ export class ProfilePage extends OpenClawLightDomElement {
   private connected = false;
   private requestId = 0;
   private refreshTimer: number | null = null;
-  private refreshAttempts = 0;
+  private lastProfileLoadedAtMs: number | null = null;
+  private pendingAutomaticProfileRefresh = false;
+  // Set only when a disconnect invalidates active work. The shared refresh
+  // policy decides when the retry is allowed to run.
+  private profileReloadPending = false;
   private subscriptions: Array<() => void> = [];
+
+  private readonly handlePageActivation = () => {
+    this.requestProfileRefresh("focus");
+  };
 
   override connectedCallback() {
     super.connectedCallback();
@@ -115,6 +124,8 @@ export class ProfilePage extends OpenClawLightDomElement {
       this.context.agents.subscribe(() => this.requestUpdate()),
       this.context.agentIdentity.subscribe(() => this.requestUpdate()),
     ];
+    document.addEventListener("visibilitychange", this.handlePageActivation);
+    globalThis.addEventListener("focus", this.handlePageActivation);
     this.applyGatewaySnapshot(this.context.gateway.snapshot);
   }
 
@@ -123,9 +134,12 @@ export class ProfilePage extends OpenClawLightDomElement {
       unsubscribe();
     }
     this.subscriptions = [];
+    document.removeEventListener("visibilitychange", this.handlePageActivation);
+    globalThis.removeEventListener("focus", this.handlePageActivation);
     this.requestId += 1;
     this.clearRefreshTimer();
-    this.refreshAttempts = 0;
+    this.pendingAutomaticProfileRefresh = false;
+    this.profileReloadPending = false;
     this.client = null;
     this.connected = false;
     super.disconnectedCallback();
@@ -140,12 +154,17 @@ export class ProfilePage extends OpenClawLightDomElement {
       // Never keep one gateway's stats on screen while another gateway loads
       // (or fails to load); the render branches key off costSummary presence.
       this.clearRefreshTimer();
-      this.refreshAttempts = 0;
+      this.requestId += 1;
+      this.loading = false;
+      this.lastProfileLoadedAtMs = null;
+      this.pendingAutomaticProfileRefresh = false;
+      this.profileReloadPending = false;
       this.costSummary = null;
       this.sessionsResult = null;
       this.error = null;
     }
     if (!snapshot.connected || !snapshot.client) {
+      this.profileReloadPending ||= this.loading;
       this.requestId += 1;
       this.clearRefreshTimer();
       this.loading = false;
@@ -156,20 +175,18 @@ export class ProfilePage extends OpenClawLightDomElement {
         void this.context.agentIdentity.ensure([list.defaultId]);
       }
     });
-    if (
-      clientChanged ||
-      (becameConnected && (!this.costSummary || this.isCacheSettling())) ||
-      (!this.costSummary && !this.loading && !this.error)
-    ) {
-      void this.loadProfile();
+    if (clientChanged || becameConnected || (!this.costSummary && !this.loading && !this.error)) {
+      this.requestProfileRefresh("reconnect");
     }
   }
 
   private async loadProfile() {
     const client = this.client;
     if (!client || !this.connected) {
+      this.profileReloadPending = true;
       return;
     }
+    this.profileReloadPending = false;
     const requestId = ++this.requestId;
     this.loading = true;
     this.error = null;
@@ -197,6 +214,7 @@ export class ProfilePage extends OpenClawLightDomElement {
       }
       this.costSummary = costSummary;
       this.sessionsResult = sessionsResult;
+      this.lastProfileLoadedAtMs = Date.now();
       this.scheduleCacheSettleRefresh();
     } catch (error) {
       if (requestId !== this.requestId) {
@@ -206,6 +224,7 @@ export class ProfilePage extends OpenClawLightDomElement {
     } finally {
       if (requestId === this.requestId) {
         this.loading = false;
+        this.flushPendingAutomaticProfileRefresh();
       }
     }
   }
@@ -224,20 +243,14 @@ export class ProfilePage extends OpenClawLightDomElement {
   private scheduleCacheSettleRefresh() {
     this.clearRefreshTimer();
     if (!this.isCacheSettling()) {
-      this.refreshAttempts = 0;
       return;
     }
-    // Large cold rebuilds can take many minutes; back off to a slow poll
-    // instead of stopping, so the page converges rather than freezing a
-    // partial snapshot as final.
-    const interval =
-      this.refreshAttempts < MAX_FAST_SETTLE_POLLS
-        ? CACHE_SETTLE_POLL_MS
-        : CACHE_SETTLE_SLOW_POLL_MS;
-    this.refreshAttempts += 1;
+    const loadedAtMs = this.lastProfileLoadedAtMs ?? Date.now();
+    const ageMs = Math.max(0, Date.now() - loadedAtMs);
+    const interval = Math.max(0, USAGE_PAYLOAD_TTL_MS - ageMs);
     this.refreshTimer = window.setTimeout(() => {
       this.refreshTimer = null;
-      void this.loadProfile();
+      this.requestProfileRefresh("poll");
     }, interval);
   }
 
@@ -246,6 +259,35 @@ export class ProfilePage extends OpenClawLightDomElement {
       window.clearTimeout(this.refreshTimer);
       this.refreshTimer = null;
     }
+  }
+
+  private requestProfileRefresh(reason: UsageRefreshReason) {
+    if (this.loading && reason !== "manual") {
+      this.pendingAutomaticProfileRefresh = true;
+      return;
+    }
+    this.pendingAutomaticProfileRefresh = false;
+    const decision = decideUsageRefresh({
+      reason,
+      visible: document.visibilityState === "visible" && document.hasFocus(),
+      interrupted: this.profileReloadPending,
+      nowMs: Date.now(),
+      lastLoadedAtMs: this.lastProfileLoadedAtMs,
+    });
+    if (decision === "fetch") {
+      this.clearRefreshTimer();
+      void this.loadProfile();
+    } else if (decision === "skip" && this.isCacheSettling()) {
+      this.scheduleCacheSettleRefresh();
+    }
+  }
+
+  private flushPendingAutomaticProfileRefresh() {
+    if (!this.pendingAutomaticProfileRefresh) {
+      return;
+    }
+    this.pendingAutomaticProfileRefresh = false;
+    this.requestProfileRefresh("focus");
   }
 
   private featuredAgent() {
@@ -536,6 +578,9 @@ export class ProfilePage extends OpenClawLightDomElement {
         <div>
           <div class="page-title">${titleForRoute("profile")}</div>
         </div>
+        <button class="btn profile-refresh" @click=${() => this.requestProfileRefresh("manual")}>
+          ${this.loading ? t("common.refreshing") : t("common.refresh")}
+        </button>
       </section>
       ${renderSettingsWorkspace(this.renderBody())}
     `;

--- a/ui/src/pages/usage/refresh-policy.test.ts
+++ b/ui/src/pages/usage/refresh-policy.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { decideUsageRefresh, USAGE_PAYLOAD_TTL_MS } from "./refresh-policy.ts";
+
+const NOW_MS = 1_000_000;
+
+describe("decideUsageRefresh", () => {
+  it("skips a reconnect while the cached payload is within the TTL", () => {
+    expect(
+      decideUsageRefresh({
+        reason: "reconnect",
+        visible: true,
+        interrupted: false,
+        nowMs: NOW_MS,
+        lastLoadedAtMs: NOW_MS - USAGE_PAYLOAD_TTL_MS + 1,
+      }),
+    ).toBe("skip");
+  });
+
+  it("defers a stale reconnect until the page is visible", () => {
+    const stale = {
+      nowMs: NOW_MS,
+      lastLoadedAtMs: NOW_MS - USAGE_PAYLOAD_TTL_MS,
+    };
+    expect(
+      decideUsageRefresh({ reason: "reconnect", visible: false, interrupted: false, ...stale }),
+    ).toBe("defer");
+    expect(
+      decideUsageRefresh({ reason: "focus", visible: true, interrupted: false, ...stale }),
+    ).toBe("fetch");
+  });
+
+  it("always fetches for a manual refresh", () => {
+    expect(
+      decideUsageRefresh({
+        reason: "manual",
+        visible: false,
+        interrupted: false,
+        nowMs: NOW_MS,
+        lastLoadedAtMs: NOW_MS,
+      }),
+    ).toBe("fetch");
+  });
+
+  it("fetches on a visible reconnect after the TTL", () => {
+    expect(
+      decideUsageRefresh({
+        reason: "reconnect",
+        visible: true,
+        interrupted: false,
+        nowMs: NOW_MS,
+        lastLoadedAtMs: NOW_MS - USAGE_PAYLOAD_TTL_MS,
+      }),
+    ).toBe("fetch");
+  });
+
+  it("defers interrupted work while hidden, then fetches once active despite a fresh payload", () => {
+    const fresh = {
+      reason: "reconnect" as const,
+      nowMs: NOW_MS,
+      lastLoadedAtMs: NOW_MS,
+      interrupted: true,
+    };
+    expect(decideUsageRefresh({ ...fresh, visible: false })).toBe("defer");
+    expect(decideUsageRefresh({ ...fresh, reason: "focus", visible: true })).toBe("fetch");
+  });
+});

--- a/ui/src/pages/usage/refresh-policy.test.ts
+++ b/ui/src/pages/usage/refresh-policy.test.ts
@@ -52,7 +52,6 @@ describe("decideUsageRefresh", () => {
       }),
     ).toBe("fetch");
   });
-
   it("defers interrupted work while hidden, then fetches once active despite a fresh payload", () => {
     const fresh = {
       reason: "reconnect" as const,
@@ -62,5 +61,17 @@ describe("decideUsageRefresh", () => {
     };
     expect(decideUsageRefresh({ ...fresh, visible: false })).toBe("defer");
     expect(decideUsageRefresh({ ...fresh, reason: "focus", visible: true })).toBe("fetch");
+  });
+
+  it("applies the same TTL to automatic settle polling", () => {
+    expect(
+      decideUsageRefresh({
+        reason: "poll",
+        visible: true,
+        interrupted: false,
+        nowMs: NOW_MS,
+        lastLoadedAtMs: NOW_MS - USAGE_PAYLOAD_TTL_MS + 1,
+      }),
+    ).toBe("skip");
   });
 });

--- a/ui/src/pages/usage/refresh-policy.ts
+++ b/ui/src/pages/usage/refresh-policy.ts
@@ -1,7 +1,7 @@
 export const USAGE_PAYLOAD_TTL_MS = 5 * 60_000;
 
 export type UsageRefreshReason = "focus" | "manual" | "poll" | "reconnect";
-export type UsageRefreshDecision = "defer" | "fetch" | "skip";
+type UsageRefreshDecision = "defer" | "fetch" | "skip";
 
 export function decideUsageRefresh(params: {
   reason: UsageRefreshReason;

--- a/ui/src/pages/usage/refresh-policy.ts
+++ b/ui/src/pages/usage/refresh-policy.ts
@@ -1,0 +1,30 @@
+export const USAGE_PAYLOAD_TTL_MS = 5 * 60_000;
+
+export type UsageRefreshReason = "focus" | "manual" | "reconnect";
+export type UsageRefreshDecision = "defer" | "fetch" | "skip";
+
+export function decideUsageRefresh(params: {
+  reason: UsageRefreshReason;
+  visible: boolean;
+  interrupted: boolean;
+  nowMs: number;
+  lastLoadedAtMs: number | null;
+  ttlMs?: number;
+}): UsageRefreshDecision {
+  if (params.reason === "manual") {
+    return "fetch";
+  }
+  if (!params.visible) {
+    return "defer";
+  }
+  // A disconnect invalidates in-flight work. Once active, retry it even when
+  // the prior payload is still fresh.
+  if (params.interrupted) {
+    return "fetch";
+  }
+  const ttlMs = params.ttlMs ?? USAGE_PAYLOAD_TTL_MS;
+  if (params.lastLoadedAtMs !== null && params.nowMs - params.lastLoadedAtMs < ttlMs) {
+    return "skip";
+  }
+  return "fetch";
+}

--- a/ui/src/pages/usage/refresh-policy.ts
+++ b/ui/src/pages/usage/refresh-policy.ts
@@ -1,6 +1,6 @@
 export const USAGE_PAYLOAD_TTL_MS = 5 * 60_000;
 
-export type UsageRefreshReason = "focus" | "manual" | "reconnect";
+export type UsageRefreshReason = "focus" | "manual" | "poll" | "reconnect";
 export type UsageRefreshDecision = "defer" | "fetch" | "skip";
 
 export function decideUsageRefresh(params: {

--- a/ui/src/pages/usage/route.ts
+++ b/ui/src/pages/usage/route.ts
@@ -44,6 +44,7 @@ async function loadUsageRouteData(context: ApplicationContext): Promise<UsageRou
       result: null,
       costSummary: null,
       providerUsageSummary: null,
+      loadedAtMs: null,
       error: null,
     };
   }
@@ -69,6 +70,7 @@ async function loadUsageRouteData(context: ApplicationContext): Promise<UsageRou
       result,
       costSummary,
       providerUsageSummary,
+      loadedAtMs: Date.now(),
       error: null,
     };
   } catch (error) {
@@ -79,6 +81,7 @@ async function loadUsageRouteData(context: ApplicationContext): Promise<UsageRou
       result: null,
       costSummary: null,
       providerUsageSummary: null,
+      loadedAtMs: null,
       error: errorMessage(error),
     };
   }

--- a/ui/src/pages/usage/usage-page.test.ts
+++ b/ui/src/pages/usage/usage-page.test.ts
@@ -10,8 +10,6 @@ import "./usage-page.ts";
 
 type TestUsagePage = HTMLElement & {
   context: ApplicationContext;
-  client: GatewayBrowserClient | null;
-  connected: boolean;
   usageSelectedSessions: string[];
   usageTimeSeries: SessionUsageTimeSeries | null;
   usageTimeSeriesLoading: boolean;
@@ -73,8 +71,6 @@ async function createPage(client: GatewayBrowserClient): Promise<TestUsagePage> 
   page.render = () => nothing;
   document.body.append(page);
   await page.updateComplete;
-  page.client = client;
-  page.connected = true;
   page.usageSelectedSessions = ["agent:main:detail"];
   return page;
 }

--- a/ui/src/pages/usage/usage-page.ts
+++ b/ui/src/pages/usage/usage-page.ts
@@ -40,6 +40,7 @@ import {
   toUsageErrorMessage,
 } from "./helpers.ts";
 import { renderUsagePageShell } from "./page-shell.ts";
+import { decideUsageRefresh, type UsageRefreshReason } from "./refresh-policy.ts";
 import {
   DEFAULT_VISIBLE_COLUMNS,
   type SessionLogEntry,
@@ -62,6 +63,7 @@ export type UsageRouteData = {
   result: SessionsUsageResult | null;
   costSummary: CostUsageSummary | null;
   providerUsageSummary: ProviderUsageSummary | null;
+  loadedAtMs: number | null;
   error: string | null;
 };
 
@@ -123,6 +125,10 @@ class UsagePage extends OpenClawLightDomElement {
   private queryDebounceTimer: number | null = null;
   private routeDataInitialized = false;
   private routeDataEnabled = true;
+  private lastUsageLoadedAtMs: number | null = null;
+  private pendingAutomaticUsageRefresh = false;
+  // Set only when a disconnect invalidates active work. The shared refresh
+  // policy decides when the retry is allowed to run.
   private usageReloadPending = false;
   private hasBoundGatewaySource = false;
   private observedAgentScopeId: string | null | undefined;
@@ -167,7 +173,19 @@ class UsagePage extends OpenClawLightDomElement {
     }
   }
 
+  private readonly handlePageActivation = () => {
+    this.requestUsageRefresh("focus");
+  };
+
+  override connectedCallback() {
+    super.connectedCallback();
+    document.addEventListener("visibilitychange", this.handlePageActivation);
+    globalThis.addEventListener("focus", this.handlePageActivation);
+  }
+
   override disconnectedCallback() {
+    document.removeEventListener("visibilitychange", this.handlePageActivation);
+    globalThis.removeEventListener("focus", this.handlePageActivation);
     this.subscriptions.clear();
     this.clearDateDebounce();
     this.clearQueryDebounce();
@@ -193,11 +211,8 @@ class UsagePage extends OpenClawLightDomElement {
     }
 
     void this.context.agents.ensureList();
-    if (
-      this.routeDataInitialized &&
-      (clientChanged || (becameConnected && (this.usageReloadPending || this.usageResult === null)))
-    ) {
-      void this.loadUsage();
+    if (this.routeDataInitialized && (clientChanged || becameConnected)) {
+      this.requestUsageRefresh("reconnect");
     }
   }
 
@@ -237,6 +252,7 @@ class UsagePage extends OpenClawLightDomElement {
     this.usageResult = data.result;
     this.usageCostSummary = data.costSummary;
     this.providerUsageSummary = data.providerUsageSummary;
+    this.lastUsageLoadedAtMs = data.loadedAtMs;
     this.usageError = data.error;
     this.usageLoading = false;
   }
@@ -263,6 +279,7 @@ class UsagePage extends OpenClawLightDomElement {
     this.usageResult = null;
     this.usageCostSummary = null;
     this.providerUsageSummary = null;
+    this.lastUsageLoadedAtMs = null;
     this.usageError = null;
     this.usageReloadPending = false;
     this.usageAgentId = this.context.agentSelection.state.scopeId;
@@ -350,6 +367,7 @@ class UsagePage extends OpenClawLightDomElement {
       this.usageResult = sessionsResult;
       this.usageCostSummary = costSummary;
       this.providerUsageSummary = providerUsageSummary;
+      this.lastUsageLoadedAtMs = Date.now();
     } catch (error) {
       if (!this.isCurrentRequest(requestId, client)) {
         return;
@@ -364,6 +382,7 @@ class UsagePage extends OpenClawLightDomElement {
     } finally {
       if (this.isCurrentRequest(requestId, client)) {
         this.usageLoading = false;
+        this.flushPendingAutomaticUsageRefresh();
       }
     }
   }
@@ -485,9 +504,36 @@ class UsagePage extends OpenClawLightDomElement {
   }
 
   private reloadUsage() {
+    this.pendingAutomaticUsageRefresh = false;
     this.clearDateDebounce();
     this.invalidateUsageRequest();
     void this.loadUsage();
+  }
+
+  private requestUsageRefresh(reason: UsageRefreshReason) {
+    if (this.usageLoading && reason !== "manual") {
+      this.pendingAutomaticUsageRefresh = true;
+      return;
+    }
+    this.pendingAutomaticUsageRefresh = false;
+    const decision = decideUsageRefresh({
+      reason,
+      visible: document.visibilityState === "visible" && document.hasFocus(),
+      interrupted: this.usageReloadPending,
+      nowMs: Date.now(),
+      lastLoadedAtMs: this.lastUsageLoadedAtMs,
+    });
+    if (decision === "fetch") {
+      this.reloadUsage();
+    }
+  }
+
+  private flushPendingAutomaticUsageRefresh() {
+    if (!this.pendingAutomaticUsageRefresh) {
+      return;
+    }
+    this.pendingAutomaticUsageRefresh = false;
+    this.requestUsageRefresh("focus");
   }
 
   private clearQueryDebounce() {
@@ -602,7 +648,7 @@ class UsagePage extends OpenClawLightDomElement {
           onAgentChange: (agentId) => {
             this.context.agentSelection.setScope(agentId);
           },
-          onRefresh: () => this.reloadUsage(),
+          onRefresh: () => this.requestUsageRefresh("manual"),
           onTimeZoneChange: (timeZone) => {
             this.usageTimeZone = timeZone;
             this.clearSelectionsAndDetails();

--- a/ui/src/pages/usage/usage-page.ts
+++ b/ui/src/pages/usage/usage-page.ts
@@ -40,13 +40,13 @@ import {
   toUsageErrorMessage,
 } from "./helpers.ts";
 import { renderUsagePageShell } from "./page-shell.ts";
-import { decideUsageRefresh, type UsageRefreshReason } from "./refresh-policy.ts";
 import {
   DEFAULT_VISIBLE_COLUMNS,
   type SessionLogEntry,
   type SessionLogRole,
   type UsageProps,
 } from "./types.ts";
+import { UsageRefreshRuntime } from "./usage-refresh-runtime.ts";
 import { renderUsage } from "./view.ts";
 
 export type UsageRouteData = {
@@ -116,8 +116,6 @@ class UsagePage extends OpenClawLightDomElement {
   @state() private usageLogFilterHasTools = false;
   @state() private usageLogFilterQuery = "";
 
-  private client: GatewayBrowserClient | null = null;
-  private connected = false;
   private usageRequestId = 0;
   private timeSeriesRequestId = 0;
   private logsRequestId = 0;
@@ -125,24 +123,17 @@ class UsagePage extends OpenClawLightDomElement {
   private queryDebounceTimer: number | null = null;
   private routeDataInitialized = false;
   private routeDataEnabled = true;
-  private lastUsageLoadedAtMs: number | null = null;
-  private pendingAutomaticUsageRefresh = false;
-  // Set only when a disconnect invalidates active work. The shared refresh
-  // policy decides when the retry is allowed to run.
-  private usageReloadPending = false;
-  private hasBoundGatewaySource = false;
   private observedAgentScopeId: string | null | undefined;
+  private readonly refreshRuntime = new UsageRefreshRuntime(this, {
+    getGateway: () => this.context?.gateway,
+    isLoading: () => this.usageLoading,
+    isRouteDataInitialized: () => this.routeDataInitialized,
+    ensureAgents: () => void this.context.agents.ensureList(),
+    invalidateRequests: () => this.invalidateRequests(),
+    resetForClientChange: () => this.resetForClientChange(),
+    reload: () => this.performUsageReload(),
+  });
   private readonly subscriptions = new SubscriptionsController(this)
-    .effect(
-      () => this.context?.gateway,
-      (gateway) => {
-        const resetForSourceBind = this.hasBoundGatewaySource;
-        this.hasBoundGatewaySource = true;
-        const cleanup = gateway.subscribe((snapshot) => this.applyGatewaySnapshot(snapshot));
-        this.applyGatewaySnapshot(gateway.snapshot, resetForSourceBind);
-        return cleanup;
-      },
-    )
     .effect(
       () => this.context?.agentSelection,
       (selection) => {
@@ -153,7 +144,7 @@ class UsagePage extends OpenClawLightDomElement {
           if (changed && this.routeDataInitialized && this.usageAgentId !== nextScopeId) {
             this.usageAgentId = nextScopeId;
             this.clearSelectionsAndDetails();
-            this.reloadUsage();
+            this.refreshRuntime.reload();
           }
           this.requestUpdate();
         };
@@ -173,47 +164,18 @@ class UsagePage extends OpenClawLightDomElement {
     }
   }
 
-  private readonly handlePageActivation = () => {
-    this.requestUsageRefresh("focus");
-  };
-
   override connectedCallback() {
     super.connectedCallback();
-    document.addEventListener("visibilitychange", this.handlePageActivation);
-    globalThis.addEventListener("focus", this.handlePageActivation);
+    this.refreshRuntime.connect();
   }
 
   override disconnectedCallback() {
-    document.removeEventListener("visibilitychange", this.handlePageActivation);
-    globalThis.removeEventListener("focus", this.handlePageActivation);
+    this.refreshRuntime.disconnect();
     this.subscriptions.clear();
     this.clearDateDebounce();
     this.clearQueryDebounce();
     this.invalidateRequests();
-    this.client = null;
-    this.connected = false;
     super.disconnectedCallback();
-  }
-
-  private applyGatewaySnapshot(snapshot: ApplicationGatewaySnapshot, resetForSourceBind = false) {
-    const clientChanged = resetForSourceBind || snapshot.client !== this.client;
-    const becameConnected = snapshot.connected && !this.connected;
-    this.client = snapshot.client;
-    this.connected = snapshot.connected;
-
-    if (clientChanged) {
-      this.resetForClientChange();
-    }
-    if (!snapshot.connected || !snapshot.client) {
-      this.usageReloadPending ||= this.usageLoading;
-      this.invalidateRequests();
-      return;
-    }
-
-    void this.context.agents.ensureList();
-    if (this.routeDataInitialized && (clientChanged || becameConnected)) {
-      this.requestUsageRefresh("reconnect");
-    }
   }
 
   private applyRouteData() {
@@ -227,8 +189,7 @@ class UsagePage extends OpenClawLightDomElement {
     }
     const gateway = this.context.gateway;
     const snapshot = gateway.snapshot;
-    this.client = snapshot.client;
-    this.connected = snapshot.connected;
+    this.refreshRuntime.adoptGatewaySnapshot(snapshot);
     if (data.gateway !== gateway || data.gatewaySnapshot !== snapshot) {
       this.routeDataEnabled = false;
       this.usageLoading = false;
@@ -240,7 +201,7 @@ class UsagePage extends OpenClawLightDomElement {
       // stale result and restart from the current scope in one operation.
       this.usageAgentId = currentAgentId;
       this.clearSelectionsAndDetails();
-      this.reloadUsage();
+      this.refreshRuntime.reload();
       return;
     }
 
@@ -252,7 +213,7 @@ class UsagePage extends OpenClawLightDomElement {
     this.usageResult = data.result;
     this.usageCostSummary = data.costSummary;
     this.providerUsageSummary = data.providerUsageSummary;
-    this.lastUsageLoadedAtMs = data.loadedAtMs;
+    this.refreshRuntime.setLastLoadedAtMs(data.loadedAtMs);
     this.usageError = data.error;
     this.usageLoading = false;
   }
@@ -261,8 +222,8 @@ class UsagePage extends OpenClawLightDomElement {
     if (
       this.routeDataEnabled ||
       !this.routeDataInitialized ||
-      !this.client ||
-      !this.connected ||
+      !this.refreshRuntime.client ||
+      !this.refreshRuntime.connected ||
       this.usageLoading
     ) {
       return;
@@ -279,9 +240,8 @@ class UsagePage extends OpenClawLightDomElement {
     this.usageResult = null;
     this.usageCostSummary = null;
     this.providerUsageSummary = null;
-    this.lastUsageLoadedAtMs = null;
+    this.refreshRuntime.resetPayload();
     this.usageError = null;
-    this.usageReloadPending = false;
     this.usageAgentId = this.context.agentSelection.state.scopeId;
     this.clearSelectionsAndDetails();
   }
@@ -330,16 +290,16 @@ class UsagePage extends OpenClawLightDomElement {
   }
 
   private async loadUsage() {
-    const client = this.client;
-    if (!client || !this.connected) {
-      this.usageReloadPending = true;
+    const client = this.refreshRuntime.client;
+    if (!client || !this.refreshRuntime.connected) {
+      this.refreshRuntime.markLoadDeferred();
       return;
     }
     if (this.usageLoading) {
       return;
     }
 
-    this.usageReloadPending = false;
+    this.refreshRuntime.beginLoad();
     this.routeDataEnabled = false;
     const requestId = ++this.usageRequestId;
     const startDate = this.usageStartDate;
@@ -367,7 +327,7 @@ class UsagePage extends OpenClawLightDomElement {
       this.usageResult = sessionsResult;
       this.usageCostSummary = costSummary;
       this.providerUsageSummary = providerUsageSummary;
-      this.lastUsageLoadedAtMs = Date.now();
+      this.refreshRuntime.markLoaded();
     } catch (error) {
       if (!this.isCurrentRequest(requestId, client)) {
         return;
@@ -382,14 +342,14 @@ class UsagePage extends OpenClawLightDomElement {
     } finally {
       if (this.isCurrentRequest(requestId, client)) {
         this.usageLoading = false;
-        this.flushPendingAutomaticUsageRefresh();
+        this.refreshRuntime.flushPending();
       }
     }
   }
 
   private async loadSessionTimeSeries(sessionKey: string) {
-    const client = this.client;
-    if (!client || !this.connected) {
+    const client = this.refreshRuntime.client;
+    if (!client || !this.refreshRuntime.connected) {
       return;
     }
     // Never render another session's retained timeline as stale.
@@ -425,8 +385,8 @@ class UsagePage extends OpenClawLightDomElement {
   }
 
   private async loadSessionLogs(sessionKey: string) {
-    const client = this.client;
-    if (!client || !this.connected) {
+    const client = this.refreshRuntime.client;
+    if (!client || !this.refreshRuntime.connected) {
       return;
     }
     // Never render another session's retained conversation as stale.
@@ -503,37 +463,10 @@ class UsagePage extends OpenClawLightDomElement {
     }, 400);
   }
 
-  private reloadUsage() {
-    this.pendingAutomaticUsageRefresh = false;
+  private performUsageReload() {
     this.clearDateDebounce();
     this.invalidateUsageRequest();
     void this.loadUsage();
-  }
-
-  private requestUsageRefresh(reason: UsageRefreshReason) {
-    if (this.usageLoading && reason !== "manual") {
-      this.pendingAutomaticUsageRefresh = true;
-      return;
-    }
-    this.pendingAutomaticUsageRefresh = false;
-    const decision = decideUsageRefresh({
-      reason,
-      visible: document.visibilityState === "visible" && document.hasFocus(),
-      interrupted: this.usageReloadPending,
-      nowMs: Date.now(),
-      lastLoadedAtMs: this.lastUsageLoadedAtMs,
-    });
-    if (decision === "fetch") {
-      this.reloadUsage();
-    }
-  }
-
-  private flushPendingAutomaticUsageRefresh() {
-    if (!this.pendingAutomaticUsageRefresh) {
-      return;
-    }
-    this.pendingAutomaticUsageRefresh = false;
-    this.requestUsageRefresh("focus");
   }
 
   private clearQueryDebounce() {
@@ -643,16 +576,16 @@ class UsagePage extends OpenClawLightDomElement {
           onScopeChange: (scope) => {
             this.usageScope = scope;
             this.clearSelectionsAndDetails();
-            this.reloadUsage();
+            this.refreshRuntime.reload();
           },
           onAgentChange: (agentId) => {
             this.context.agentSelection.setScope(agentId);
           },
-          onRefresh: () => this.requestUsageRefresh("manual"),
+          onRefresh: () => this.refreshRuntime.request("manual"),
           onTimeZoneChange: (timeZone) => {
             this.usageTimeZone = timeZone;
             this.clearSelectionsAndDetails();
-            this.reloadUsage();
+            this.refreshRuntime.reload();
           },
           onToggleHeaderPinned: () => {
             this.usageHeaderPinned = !this.usageHeaderPinned;

--- a/ui/src/pages/usage/usage-refresh-runtime.ts
+++ b/ui/src/pages/usage/usage-refresh-runtime.ts
@@ -1,0 +1,142 @@
+import type { ReactiveControllerHost } from "lit";
+import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import type { ApplicationContext, ApplicationGatewaySnapshot } from "../../app/context.ts";
+import { SubscriptionsController } from "../../lit/subscriptions-controller.ts";
+import { decideUsageRefresh, type UsageRefreshReason } from "./refresh-policy.ts";
+
+type UsageRefreshRuntimeOptions = {
+  getGateway: () => ApplicationContext["gateway"] | null | undefined;
+  isLoading: () => boolean;
+  isRouteDataInitialized: () => boolean;
+  ensureAgents: () => void;
+  invalidateRequests: () => void;
+  resetForClientChange: () => void;
+  reload: () => void;
+};
+
+export class UsageRefreshRuntime {
+  private currentClient: GatewayBrowserClient | null = null;
+  private currentConnected = false;
+  private lastLoadedAtMs: number | null = null;
+  private pendingAutomaticRefresh = false;
+  // Disconnects invalidate active work; keep this set until policy permits a
+  // visible-page retry, even while the prior payload remains fresh.
+  private reloadPending = false;
+  private hasBoundGatewaySource = false;
+  private readonly subscriptions: SubscriptionsController;
+
+  private readonly handlePageActivation = () => {
+    this.request("focus");
+  };
+
+  constructor(
+    host: ReactiveControllerHost,
+    private readonly options: UsageRefreshRuntimeOptions,
+  ) {
+    this.subscriptions = new SubscriptionsController(host).effect(options.getGateway, (gateway) => {
+      const resetForSourceBind = this.hasBoundGatewaySource;
+      this.hasBoundGatewaySource = true;
+      const cleanup = gateway.subscribe((snapshot) => this.applyGatewaySnapshot(snapshot, false));
+      this.applyGatewaySnapshot(gateway.snapshot, resetForSourceBind);
+      return cleanup;
+    });
+  }
+
+  get client(): GatewayBrowserClient | null {
+    return this.currentClient;
+  }
+
+  get connected(): boolean {
+    return this.currentConnected;
+  }
+
+  connect(): void {
+    document.addEventListener("visibilitychange", this.handlePageActivation);
+    globalThis.addEventListener("focus", this.handlePageActivation);
+  }
+
+  disconnect(): void {
+    document.removeEventListener("visibilitychange", this.handlePageActivation);
+    globalThis.removeEventListener("focus", this.handlePageActivation);
+    this.subscriptions.clear();
+    this.currentClient = null;
+    this.currentConnected = false;
+  }
+
+  applyGatewaySnapshot(snapshot: ApplicationGatewaySnapshot, resetForSourceBind = false): void {
+    const clientChanged = resetForSourceBind || snapshot.client !== this.currentClient;
+    const becameConnected = snapshot.connected && !this.currentConnected;
+    this.adoptGatewaySnapshot(snapshot);
+
+    if (clientChanged) {
+      this.options.resetForClientChange();
+    }
+    if (!snapshot.connected || !snapshot.client) {
+      this.reloadPending ||= this.options.isLoading();
+      this.options.invalidateRequests();
+      return;
+    }
+
+    this.options.ensureAgents();
+    if (this.options.isRouteDataInitialized() && (clientChanged || becameConnected)) {
+      this.request("reconnect");
+    }
+  }
+
+  adoptGatewaySnapshot(snapshot: ApplicationGatewaySnapshot): void {
+    this.currentClient = snapshot.client;
+    this.currentConnected = snapshot.connected;
+  }
+
+  setLastLoadedAtMs(value: number | null): void {
+    this.lastLoadedAtMs = value;
+  }
+
+  markLoaded(): void {
+    this.lastLoadedAtMs = Date.now();
+  }
+
+  resetPayload(): void {
+    this.lastLoadedAtMs = null;
+    this.reloadPending = false;
+  }
+
+  markLoadDeferred(): void {
+    this.reloadPending = true;
+  }
+
+  beginLoad(): void {
+    this.reloadPending = false;
+  }
+
+  reload(): void {
+    this.pendingAutomaticRefresh = false;
+    this.options.reload();
+  }
+
+  request(reason: UsageRefreshReason): void {
+    if (this.options.isLoading() && reason !== "manual") {
+      this.pendingAutomaticRefresh = true;
+      return;
+    }
+    this.pendingAutomaticRefresh = false;
+    const decision = decideUsageRefresh({
+      reason,
+      visible: document.visibilityState === "visible" && document.hasFocus(),
+      interrupted: this.reloadPending,
+      nowMs: Date.now(),
+      lastLoadedAtMs: this.lastLoadedAtMs,
+    });
+    if (decision === "fetch") {
+      this.reload();
+    }
+  }
+
+  flushPending(): void {
+    if (!this.pendingAutomaticRefresh) {
+      return;
+    }
+    this.pendingAutomaticRefresh = false;
+    this.request("focus");
+  }
+}


### PR DESCRIPTION
## What Problem This Solves

The Control UI refetches the full usage dataset on every websocket reconnect; flappy connections hammer the expensive `sessions.usage` RPC (#107917). The Profile page had the identical pattern (`usage.cost` + `sessions.usage` per reconnect, plus cache-settle polling).

## Why This Change Was Made

Client-side request discipline, independent of the server-side rollup work (#108834): a pure decision helper (`ui/src/pages/usage/refresh-policy.ts`) gates automatic refreshes on reconnect/focus/visibility with a five-minute successful-payload TTL. Reconnect within TTL: no fetch. Stale while hidden: deferred until the panel is visible+focused. Manual Refresh always bypasses TTL and coalescing. Usage and Profile share the one policy owner; in-flight requests coalesce and re-evaluate on completion.

## User Impact

Reconnect storms no longer trigger redundant expensive scans; data freshness is preserved via focus-triggered refresh and an always-working manual Refresh. Payload can intentionally be up to five minutes old between automatic refreshes.

## Evidence

- Focused tests: refresh-policy matrix + usage/profile page tests + gateway source replacement — 22+19 tests green (`node scripts/run-vitest.mjs ...`).
- Browser contract (both pages): fresh reconnect 0 requests; hidden stale reconnect 0; activation 1; manual Refresh 1. Screenshots: `.artifacts/control-ui-e2e/usage-refresh-discipline/final.png`, `.artifacts/control-ui-e2e/profile-refresh-discipline/final.png`.
- Production UI build green (496 sidecars, performance budgets pass); exact-diff changed gate green; autoreview clean (two findings fixed during review: manual-refresh suppression, in-flight reconnect recovery).
- Sibling audit: other reconnect-refresh pages (Sessions, Plugins, Worktrees, Nodes, Approval, Agent Memory, Skills, Debug, Logs) use different, cheaper RPCs with reconciliation requirements — listed as potential follow-ups, intentionally untouched.

Fixes #107917
