### PR TITLE
fix(workboard): use actual provider engine instead of hardcoded codex (#108362)

### DIFF
--- a/extensions/workboard/src/dispatcher.ts
+++ b/extensions/workboard/src/dispatcher.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import type {
   WorkboardCard,
   WorkboardExecution,
+  WorkboardExecutionEngine,
   WorkboardWorkspace,
 } from "@openclaw/workboard-contract";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
@@ -90,17 +91,25 @@ function buildSessionKey(card: WorkboardCard): string {
   return card.agentId ? `agent:${sanitizeSessionSegment(card.agentId, "agent")}:${suffix}` : suffix;
 }
 
+function resolveExecutionEngine(provider?: string): WorkboardExecutionEngine {
+  if (provider === "anthropic" || provider === "claude") {
+    return "claude";
+  }
+  return "codex";
+}
+
 function buildExecution(params: {
   card: WorkboardCard;
   sessionKey: string;
   runId: string;
   model: string;
+  engine: WorkboardExecutionEngine;
   now: number;
 }): WorkboardExecution {
   return {
-    id: params.card.execution?.id ?? `${params.card.id}:codex`,
+    id: params.card.execution?.id ?? `${params.card.id}:${params.engine}`,
     kind: "agent-session",
-    engine: "codex",
+    engine: params.engine,
     mode: "autonomous",
     status: "running",
     model: params.model,
@@ -431,6 +440,7 @@ export async function dispatchAndStartWorkboardCards(params: {
           sessionKey,
           runId: run.runId,
           model,
+          engine: resolveExecutionEngine(params.options?.provider),
           now,
         }),
         ...(materializedWorkspace ? { workspace: materializedWorkspace } : {}),


### PR DESCRIPTION
## Summary

- Replace hardcoded `engine: "codex"` in workboard dispatcher with dynamic engine resolution based on the actual provider.

## What Problem This Solves

`buildExecution` in `extensions/workboard/src/dispatcher.ts` hardcoded `engine: "codex"` and execution id suffix `:codex` for all dispatched agent runs, even when the agent runs through Anthropic Claude. This caused workboard records to show incorrect execution metadata for Claude agent runs.

## User Impact

- **Why it matters:** Workboard records now reflect the actual engine (codex or claude) used for each dispatched run.
- **What did NOT change:** Dispatch logic, subagent.run parameters, and execution status tracking are unchanged.

## Origin / follow-up

Fixes #108362.

## Evidence

```bash
node scripts/run-vitest.mjs extensions/workboard/src/dispatcher.test.ts
# 24/24 tests passed
```

Fixes #108362
