### PR TITLE
fix(imessage): clear stop timeout after child closes

### DIFF
--- a/extensions/imessage/src/client.test.ts
+++ b/extensions/imessage/src/client.test.ts
@@ -86,6 +86,36 @@ describe("IMessageRpcClient child stream error handling", () => {
     },
   );
 
+  it("clears the stop fallback timer when the child closes first", async () => {
+    const realSetTimeout = globalThis.setTimeout;
+    const realClearTimeout = globalThis.clearTimeout;
+    const scheduledTimers: NodeJS.Timeout[] = [];
+    vi.spyOn(globalThis, "setTimeout").mockImplementation(((handler, timeout, ...args) => {
+      const timer = realSetTimeout(handler, timeout, ...args);
+      scheduledTimers.push(timer);
+      return timer;
+    }) as typeof setTimeout);
+    const clearTimeoutSpy = vi.spyOn(globalThis, "clearTimeout");
+
+    try {
+      const { IMessageRpcClient } = await import("./client.js");
+      const client = new IMessageRpcClient({ cliPath: "imsg" });
+      await client.start();
+      child.stdin.end = () => child.emit("close", 0, null);
+
+      await client.stop();
+
+      expect(scheduledTimers).toHaveLength(1);
+      expect(clearTimeoutSpy).toHaveBeenCalledWith(scheduledTimers[0]);
+      expect(child.kill).not.toHaveBeenCalled();
+    } finally {
+      for (const timer of scheduledTimers) {
+        realClearTimeout(timer);
+      }
+      vi.restoreAllMocks();
+    }
+  });
+
   it("settles the client after a real child stdout stream failure", async () => {
     const childProcess =
       await vi.importActual<typeof import("node:child_process")>("node:child_process");

--- a/extensions/imessage/src/client.test.ts
+++ b/extensions/imessage/src/client.test.ts
@@ -96,10 +96,15 @@ describe("IMessageRpcClient child stream error handling", () => {
       const { IMessageRpcClient } = await import("./client.js");
       const client = new IMessageRpcClient({ cliPath: "imsg" });
       await client.start();
-      child.stdin.end = () => child.emit("close", 0, null);
+      const endMock = vi.fn(() => {
+        child.emit("close", 0, null);
+        return child.stdin;
+      });
+      child.stdin.end = endMock;
 
       await client.stop();
 
+      expect(endMock).toHaveReturnedWith(child.stdin);
       expect(setTimeoutSpy).toHaveBeenCalledOnce();
       scheduledTimer = setTimeoutSpy.mock.results[0]?.value as NodeJS.Timeout | undefined;
       expect(scheduledTimer).toBeDefined();

--- a/extensions/imessage/src/client.test.ts
+++ b/extensions/imessage/src/client.test.ts
@@ -87,15 +87,10 @@ describe("IMessageRpcClient child stream error handling", () => {
   );
 
   it("clears the stop fallback timer when the child closes first", async () => {
-    const realSetTimeout = globalThis.setTimeout;
     const realClearTimeout = globalThis.clearTimeout;
-    const scheduledTimers: NodeJS.Timeout[] = [];
-    vi.spyOn(globalThis, "setTimeout").mockImplementation(((handler, timeout, ...args) => {
-      const timer = realSetTimeout(handler, timeout, ...args);
-      scheduledTimers.push(timer);
-      return timer;
-    }) as typeof setTimeout);
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
     const clearTimeoutSpy = vi.spyOn(globalThis, "clearTimeout");
+    let scheduledTimer: NodeJS.Timeout | undefined;
 
     try {
       const { IMessageRpcClient } = await import("./client.js");
@@ -105,12 +100,14 @@ describe("IMessageRpcClient child stream error handling", () => {
 
       await client.stop();
 
-      expect(scheduledTimers).toHaveLength(1);
-      expect(clearTimeoutSpy).toHaveBeenCalledWith(scheduledTimers[0]);
+      expect(setTimeoutSpy).toHaveBeenCalledOnce();
+      scheduledTimer = setTimeoutSpy.mock.results[0]?.value as NodeJS.Timeout | undefined;
+      expect(scheduledTimer).toBeDefined();
+      expect(clearTimeoutSpy).toHaveBeenCalledWith(scheduledTimer);
       expect(child.kill).not.toHaveBeenCalled();
     } finally {
-      for (const timer of scheduledTimers) {
-        realClearTimeout(timer);
+      if (scheduledTimer) {
+        realClearTimeout(scheduledTimer);
       }
       vi.restoreAllMocks();
     }

--- a/extensions/imessage/src/client.ts
+++ b/extensions/imessage/src/client.ts
@@ -156,17 +156,24 @@ export class IMessageRpcClient {
     const child = this.child;
     this.child = null;
 
-    await Promise.race([
-      this.closed,
-      new Promise<void>((resolve) => {
-        setTimeout(() => {
-          if (!child.killed) {
-            child.kill("SIGTERM");
-          }
-          resolve();
-        }, 500);
-      }),
-    ]);
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    try {
+      await Promise.race([
+        this.closed,
+        new Promise<void>((resolve) => {
+          timeout = setTimeout(() => {
+            if (!child.killed) {
+              child.kill("SIGTERM");
+            }
+            resolve();
+          }, 500);
+        }),
+      ]);
+    } finally {
+      if (timeout) {
+        clearTimeout(timeout);
+      }
+    }
   }
 
   async waitForClose(): Promise<void> {

--- a/extensions/imessage/src/client.ts
+++ b/extensions/imessage/src/client.ts
@@ -170,6 +170,8 @@ export class IMessageRpcClient {
         }),
       ]);
     } finally {
+      // A losing fallback still holds Node's event loop open; clear it when
+      // the child closes first so short-lived RPC clients can exit promptly.
       if (timeout) {
         clearTimeout(timeout);
       }


### PR DESCRIPTION
<!--
Optional linked context:
Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
below this comment.

Required PR title:
type: user-facing description
Use a parenthesized scope only when it adds clarity:
fix(auth): login redirect loops when session cookie is expired

Types: feat, fix, improve, refactor, docs, chore.
For fixes, describe the user-visible symptom and trigger:
fix: task list fails to load when user has no environments
Avoid implementation details such as:
fix: add null check to task query
-->

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where stopping a promptly closed iMessage RPC helper left its 500 ms termination timer scheduled after shutdown had already completed. Short-lived iMessage processes and gateway shutdown could therefore remain alive until the unused timer expired.

## Why This Change Was Made

The iMessage RPC client now owns the fallback timer across the complete close race and clears it in `finally`. The existing 500 ms grace period and SIGTERM fallback remain unchanged when the helper does not close promptly. The regression test's `Writable.end()` stub also preserves the writable return contract while triggering the simulated close.

## User Impact

iMessage shutdown no longer waits on a stale termination timer after the helper closes normally. Slow or stuck helpers retain the same bounded termination behavior.

## Evidence

- `node scripts/run-vitest.mjs extensions/imessage/src/client.test.ts` — 8 tests passed, including the explicit `Writable.end()` return-contract assertion.
- `pnpm exec oxfmt --check extensions/imessage/src/client.ts extensions/imessage/src/client.test.ts` — clean.
- Before the production fix, the focused regression observed one scheduled fallback timer and zero `clearTimeout` calls after child-close-first shutdown.
- Production-path local process proof used the real `IMessageRpcClient.start()` and `stop()` child-process transport with a deterministic local `imsg` substitute. Clean child close completed `stop()` in 87 ms and the owning Node process exited in 120 ms, below the stale 500 ms timer window.
- Immediately before the original review, the same production-path proof on then-latest `main` at `5bb905caa82e` still took 533 ms to exit, confirming the stale timer remained unfixed upstream.
- Full open-PR competition recall found no same-problem iMessage shutdown timer fix.

The Linux proof does not exercise the macOS Messages database or the real `imsg` binary; those do not affect ownership of the process-local fallback timer. The repository-wide test typecheck could not be run locally because the bounded validation guard could not attest resource limits, so the updated head relies on the corresponding remote CI check.
