### PR TITLE
fix(plugin-sdk): refresh generated API baseline

### DIFF
--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-b8431b55f28440c269cec5afd95c3ef7cd7eb2b443c5cf713fcbaefacc5e0634  plugin-sdk-api-baseline.json
-6dc1e7d7015b7cd5451d0e716bea212f6824da0e71f311f62aad46948d039524  plugin-sdk-api-baseline.jsonl
+a946f69b8ec03ed5b3ff26301b70e4adfe8e78574f6afa147accf92c2b314b11  plugin-sdk-api-baseline.json
+363f06ea86f4b1cc2f7a065c7db74290cc13df7cc1f427b37928109d92ddd8f6  plugin-sdk-api-baseline.jsonl


### PR DESCRIPTION
## What Problem This Solves

Restores the generated Plugin SDK API baseline gate on current `main`. The Codex catalog move in #107979 changed generated plugin metadata, but the checked-in SHA-256 manifest still described the previous generated artifacts.

## Why This Change Was Made

`pnpm plugin-sdk:api:check` now fails on a clean `main` checkout before unrelated changed-file gates reach typecheck. This PR refreshes only the generated digest manifest using the repository generator.

## User Impact

No runtime or public API behavior changes. Maintainer changed gates stop failing on unrelated PRs because the checked-in baseline again matches current source metadata.

## Evidence

- Clean `origin/main` reproduced the hash mismatch.
- `pnpm plugin-sdk:api:gen` changed one tracked file and exactly two digest lines.
- `pnpm plugin-sdk:api:check` passes after regeneration.
- `git diff --check` passes.
- Mandatory Autoreview clean with no actionable findings.

Support-only repair; not a changelog item.
