### PR TITLE
fix(ci): bound non-root NodeSource setup download

### DIFF
--- a/scripts/docker/install-sh-nonroot/Dockerfile
+++ b/scripts/docker/install-sh-nonroot/Dockerfile
@@ -28,7 +28,10 @@ RUN --mount=type=cache,id=openclaw-install-sh-nonroot-apt-cache,target=/var/cach
 RUN --mount=type=cache,id=openclaw-install-sh-nonroot-apt-cache,target=/var/cache/apt,sharing=locked \
   --mount=type=cache,id=openclaw-install-sh-nonroot-apt-lists,target=/var/lib/apt,sharing=locked \
   set -eux; \
-  curl -fsSL https://deb.nodesource.com/setup_24.x | bash -; \
+  installer="$(mktemp)"; \
+  curl -fsSL --connect-timeout 10 --max-time 120 -o "$installer" https://deb.nodesource.com/setup_24.x; \
+  bash "$installer"; \
+  rm -f "$installer"; \
   DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends nodejs
 
 RUN useradd -m -s /bin/bash app \

--- a/test/scripts/test-install-sh-docker.test.ts
+++ b/test/scripts/test-install-sh-docker.test.ts
@@ -463,6 +463,13 @@ describe("test-install-sh-docker", () => {
     expect(nonrootDockerfile).toContain("USER app");
     expect(nonrootDockerfile).toContain("WORKDIR /home/app");
     expect(nonrootDockerfile).toContain("NPM_CONFIG_UPDATE_NOTIFIER=false");
+    expect(nonrootDockerfile).toContain('installer="$(mktemp)"');
+    expect(nonrootDockerfile).toContain(
+      'curl -fsSL --connect-timeout 10 --max-time 120 -o "$installer" https://deb.nodesource.com/setup_24.x',
+    );
+    expect(nonrootDockerfile).toContain('bash "$installer"');
+    expect(nonrootDockerfile).toContain('rm -f "$installer"');
+    expect(nonrootDockerfile).not.toMatch(/curl[^\n]+\|\s*bash/u);
   });
 
   it("keeps shared install helpers parsing and verifying installed CLI versions", () => {


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where CI and contributors building the non-root installer smoke image could wait indefinitely when the NodeSource setup script endpoint stalled. The existing pipeline could also execute a partial response before the download completed.

## Why This Change Was Made

Download the NodeSource setup script to a unique temporary file with a 10-second connection timeout and a 120-second transfer limit, then execute it only after curl succeeds. This bounds only the setup-script fetch; the subsequent NodeSource setup and apt operations are unchanged.

## User Impact

Non-root installer smoke image builds now fail within a bounded time when the NodeSource script download stalls, and they no longer execute a partially downloaded setup script.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/test-install-sh-docker.test.ts` on Node 24.15.0: 73 tests passed.
- `oxfmt --check test/scripts/test-install-sh-docker.test.ts`: passed.
- `git diff --check`: passed.
- Controlled stalled-response proof:
  - Before: curl timed out, but the pipeline returned status 0 and both the partial script and the following command ran.
  - After: the command returned curl status 28; neither the script nor the following command ran.
  - Successful response: the script ran and the temporary download was removed.
