### PR TITLE
fix(discord): strip inbound runtime-context wrappers from message text

### DIFF
--- a/extensions/discord/src/monitor/message-text.ts
+++ b/extensions/discord/src/monitor/message-text.ts
@@ -85,30 +85,42 @@ export function resolveDiscordEmbedText(
 
 /**
  * Resolve Discord user-visible body text for ingress.
- * Strip OpenClaw internal runtime-context envelopes after assembling text and
- * resolving mentions so wrapper-only events become empty and never look user-authored.
+ * Sanitize each textual candidate before fallback precedence so wrapper-only
+ * content cannot displace attachment/embed/component/fallback text, then resolve
+ * mentions on the selected body.
  */
 export function resolveDiscordMessageText(
   message: Message,
   options?: { fallbackText?: string; includeForwarded?: boolean },
 ): string {
-  const embedText = resolveDiscordEmbedText(
-    (message.embeds?.[0] as { title?: string | null; description?: string | null } | undefined) ??
-      null,
+  // Strip wrappers before precedence: non-empty wrapper content must not win the
+  // candidate chain and later become empty, suppressing legitimate media/rich text.
+  const contentText = stripDiscordInternalRuntimeContext(
+    normalizeOptionalString(message.content) ?? "",
   );
-  const componentText = extractDiscordComponentsV2Text(resolveDiscordMessageComponents(message));
+  const embedText = stripDiscordInternalRuntimeContext(
+    resolveDiscordEmbedText(
+      (message.embeds?.[0] as { title?: string | null; description?: string | null } | undefined) ??
+        null,
+    ),
+  );
+  const componentText = stripDiscordInternalRuntimeContext(
+    extractDiscordComponentsV2Text(resolveDiscordMessageComponents(message)),
+  );
+  const fallbackText = stripDiscordInternalRuntimeContext(
+    normalizeOptionalString(options?.fallbackText) ?? "",
+  );
   const rawText =
-    normalizeOptionalString(message.content) ||
+    normalizeOptionalString(contentText) ||
     buildDiscordMediaPlaceholder({
       attachments: message.attachments ?? undefined,
       stickers: resolveDiscordMessageStickers(message),
     }) ||
-    embedText ||
-    componentText ||
-    normalizeOptionalString(options?.fallbackText) ||
+    normalizeOptionalString(embedText) ||
+    normalizeOptionalString(componentText) ||
+    normalizeOptionalString(fallbackText) ||
     "";
-  // Mentions first so labels stay human-readable, then strip internal envelopes.
-  const baseText = stripDiscordInternalRuntimeContext(resolveDiscordMentions(rawText, message));
+  const baseText = resolveDiscordMentions(rawText, message);
   if (!options?.includeForwarded) {
     return baseText;
   }
@@ -117,10 +129,9 @@ export function resolveDiscordMessageText(
     return baseText;
   }
   if (!baseText) {
-    // Snapshot/forward helpers strip their own bodies; keep a final pass for safety.
-    return stripDiscordInternalRuntimeContext(forwardedText);
+    return forwardedText;
   }
-  return stripDiscordInternalRuntimeContext(`${baseText}\n${forwardedText}`);
+  return `${baseText}\n${forwardedText}`;
 }
 
 function resolveDiscordMentions(text: string, message: Message): string {
@@ -227,15 +238,26 @@ function buildDiscordForwardedMessageBlock(
 }
 
 function resolveDiscordSnapshotMessageText(snapshot: DiscordSnapshotMessage): string {
-  const content = normalizeOptionalString(snapshot.content) ?? "";
+  // Same pre-precedence strip as resolveDiscordMessageText so wrapper-only snapshot
+  // content does not suppress attachment/embed/component fallbacks.
+  const content = stripDiscordInternalRuntimeContext(
+    normalizeOptionalString(snapshot.content) ?? "",
+  );
   const attachmentText = buildDiscordMediaPlaceholder({
     attachments: snapshot.attachments ?? undefined,
     stickers: resolveDiscordSnapshotStickers(snapshot),
   });
-  const embedText = resolveDiscordEmbedText(snapshot.embeds?.[0]);
-  const componentText = extractDiscordComponentsV2Text(snapshot.components);
-  // Same ingress invariant as resolveDiscordMessageText: strip internal wrappers.
-  return stripDiscordInternalRuntimeContext(
-    content || attachmentText || embedText || componentText || "",
+  const embedText = stripDiscordInternalRuntimeContext(
+    resolveDiscordEmbedText(snapshot.embeds?.[0]),
+  );
+  const componentText = stripDiscordInternalRuntimeContext(
+    extractDiscordComponentsV2Text(snapshot.components),
+  );
+  return (
+    normalizeOptionalString(content) ||
+    attachmentText ||
+    normalizeOptionalString(embedText) ||
+    normalizeOptionalString(componentText) ||
+    ""
   );
 }

--- a/extensions/discord/src/monitor/message-text.ts
+++ b/extensions/discord/src/monitor/message-text.ts
@@ -13,6 +13,65 @@ import {
 } from "./message-forwarded.js";
 import { buildDiscordMediaPlaceholder } from "./message-media.js";
 
+// Wire-protocol markers from core internal-runtime-context. Keep in lockstep with
+// src/agents/internal-runtime-context.ts so ingress strips the same envelopes.
+const INTERNAL_RUNTIME_CONTEXT_BEGIN = "<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>";
+const INTERNAL_RUNTIME_CONTEXT_END = "<<<END_OPENCLAW_INTERNAL_CONTEXT>>>";
+
+/**
+ * Strip protected OpenClaw runtime-context envelopes from ingress text.
+ * Line-anchored begin/end markers only (same delimiter contract as core).
+ * Avoids a new plugin-sdk surface export for this single channel fix.
+ */
+function stripDiscordInternalRuntimeContext(text: string): string {
+  if (!text || !text.includes(INTERNAL_RUNTIME_CONTEXT_BEGIN)) {
+    return text;
+  }
+  let next = text;
+  for (;;) {
+    const start = findLineAnchoredTokenIndex(next, INTERNAL_RUNTIME_CONTEXT_BEGIN, 0);
+    if (start === -1) {
+      return next;
+    }
+    let cursor = start + INTERNAL_RUNTIME_CONTEXT_BEGIN.length;
+    let depth = 1;
+    let finish = -1;
+    while (depth > 0) {
+      const nextBegin = findLineAnchoredTokenIndex(next, INTERNAL_RUNTIME_CONTEXT_BEGIN, cursor);
+      const nextEnd = findLineAnchoredTokenIndex(next, INTERNAL_RUNTIME_CONTEXT_END, cursor);
+      if (nextEnd === -1) {
+        break;
+      }
+      if (nextBegin !== -1 && nextBegin < nextEnd) {
+        depth += 1;
+        cursor = nextBegin + INTERNAL_RUNTIME_CONTEXT_BEGIN.length;
+        continue;
+      }
+      depth -= 1;
+      finish = nextEnd;
+      cursor = nextEnd + INTERNAL_RUNTIME_CONTEXT_END.length;
+    }
+    const before = next.slice(0, start).trimEnd();
+    if (finish === -1 || depth !== 0) {
+      return before;
+    }
+    const after = next.slice(finish + INTERNAL_RUNTIME_CONTEXT_END.length).trimStart();
+    next = before && after ? `${before}\n\n${after}` : `${before}${after}`;
+  }
+}
+
+function findLineAnchoredTokenIndex(text: string, token: string, from: number): number {
+  const escaped = token.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const tokenRe = new RegExp(`(?:^|\\r?\\n)${escaped}(?=\\r?\\n|$)`, "g");
+  tokenRe.lastIndex = Math.max(0, from);
+  const match = tokenRe.exec(text);
+  if (!match) {
+    return -1;
+  }
+  const prefixLength = match[0].length - token.length;
+  return match.index + prefixLength;
+}
+
 export function resolveDiscordEmbedText(
   embed?: { title?: string | null; description?: string | null } | null,
 ): string {
@@ -24,6 +83,11 @@ export function resolveDiscordEmbedText(
   return title || description || "";
 }
 
+/**
+ * Resolve Discord user-visible body text for ingress.
+ * Strip OpenClaw internal runtime-context envelopes after assembling text and
+ * resolving mentions so wrapper-only events become empty and never look user-authored.
+ */
 export function resolveDiscordMessageText(
   message: Message,
   options?: { fallbackText?: string; includeForwarded?: boolean },
@@ -43,7 +107,8 @@ export function resolveDiscordMessageText(
     componentText ||
     normalizeOptionalString(options?.fallbackText) ||
     "";
-  const baseText = resolveDiscordMentions(rawText, message);
+  // Mentions first so labels stay human-readable, then strip internal envelopes.
+  const baseText = stripDiscordInternalRuntimeContext(resolveDiscordMentions(rawText, message));
   if (!options?.includeForwarded) {
     return baseText;
   }
@@ -52,9 +117,10 @@ export function resolveDiscordMessageText(
     return baseText;
   }
   if (!baseText) {
-    return forwardedText;
+    // Snapshot/forward helpers strip their own bodies; keep a final pass for safety.
+    return stripDiscordInternalRuntimeContext(forwardedText);
   }
-  return `${baseText}\n${forwardedText}`;
+  return stripDiscordInternalRuntimeContext(`${baseText}\n${forwardedText}`);
 }
 
 function resolveDiscordMentions(text: string, message: Message): string {
@@ -168,5 +234,8 @@ function resolveDiscordSnapshotMessageText(snapshot: DiscordSnapshotMessage): st
   });
   const embedText = resolveDiscordEmbedText(snapshot.embeds?.[0]);
   const componentText = extractDiscordComponentsV2Text(snapshot.components);
-  return content || attachmentText || embedText || componentText || "";
+  // Same ingress invariant as resolveDiscordMessageText: strip internal wrappers.
+  return stripDiscordInternalRuntimeContext(
+    content || attachmentText || embedText || componentText || "",
+  );
 }

--- a/extensions/discord/src/monitor/message-utils.test.ts
+++ b/extensions/discord/src/monitor/message-utils.test.ts
@@ -1260,6 +1260,91 @@ describe("resolveDiscordMessageText", () => {
     expect(text).toContain("forwarded hello");
     expect(text).not.toContain("BEGIN_OPENCLAW_INTERNAL_CONTEXT");
   });
+
+  it("falls back to attachment media when content is only an internal runtime-context wrapper", () => {
+    const text = resolveDiscordMessageText(
+      asMessage({
+        content: [
+          "<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>",
+          '{"message_id":"m-media"}',
+          "<<<END_OPENCLAW_INTERNAL_CONTEXT>>>",
+        ].join("\n"),
+        attachments: [
+          {
+            id: "a1",
+            filename: "photo.png",
+            url: "https://cdn.discordapp.com/attachments/1/2/photo.png",
+            content_type: "image/png",
+          },
+        ],
+      }),
+    );
+
+    expect(text).toBe("<media:image> (1 image)");
+    expect(text).not.toContain("BEGIN_OPENCLAW_INTERNAL_CONTEXT");
+  });
+
+  it("falls back to embed text when content is only an internal runtime-context wrapper", () => {
+    const text = resolveDiscordMessageText(
+      asMessage({
+        content: [
+          "<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>",
+          '{"message_id":"m-embed"}',
+          "<<<END_OPENCLAW_INTERNAL_CONTEXT>>>",
+        ].join("\n"),
+        embeds: [{ title: "Breaking", description: "Details" }],
+      }),
+    );
+
+    expect(text).toBe("Breaking\nDetails");
+    expect(text).not.toContain("BEGIN_OPENCLAW_INTERNAL_CONTEXT");
+  });
+
+  it("falls back to sticker media when content is only an internal runtime-context wrapper", () => {
+    const text = resolveDiscordMessageText(
+      asMessage({
+        content: [
+          "<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>",
+          '{"message_id":"m-sticker"}',
+          "<<<END_OPENCLAW_INTERNAL_CONTEXT>>>",
+        ].join("\n"),
+        stickers: [
+          {
+            id: "sticker-wrapper",
+            name: "party",
+            format_type: StickerFormatType.PNG,
+          },
+        ],
+      }),
+    );
+
+    expect(text).toBe("<media:sticker> (1 sticker)");
+    expect(text).not.toContain("BEGIN_OPENCLAW_INTERNAL_CONTEXT");
+  });
+
+  it("keeps visible user text when mixed with a wrapper and an attachment", () => {
+    const text = resolveDiscordMessageText(
+      asMessage({
+        content: [
+          "caption with photo",
+          "<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>",
+          '{"message_id":"m-mixed-media"}',
+          "<<<END_OPENCLAW_INTERNAL_CONTEXT>>>",
+        ].join("\n"),
+        attachments: [
+          {
+            id: "a2",
+            filename: "photo.png",
+            url: "https://cdn.discordapp.com/attachments/1/2/photo.png",
+            content_type: "image/png",
+          },
+        ],
+      }),
+    );
+
+    expect(text).toBe("caption with photo");
+    expect(text).not.toContain("BEGIN_OPENCLAW_INTERNAL_CONTEXT");
+  });
 });
 
 describe("resolveDiscordChannelInfo", () => {

--- a/extensions/discord/src/monitor/message-utils.test.ts
+++ b/extensions/discord/src/monitor/message-utils.test.ts
@@ -1196,6 +1196,70 @@ describe("resolveDiscordMessageText", () => {
     expect(text).toContain("[Forwarded message from @Bob]");
     expect(text).toContain("Forwarded component text");
   });
+
+  it("strips OpenClaw internal runtime-context wrappers from mixed user content", () => {
+    const text = resolveDiscordMessageText(
+      asMessage({
+        content: [
+          "hello from the user",
+          "",
+          "<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>",
+          '{"message_id":"1527004847054913566","inbound_event_kind":"message"}',
+          "<<<END_OPENCLAW_INTERNAL_CONTEXT>>>",
+        ].join("\n"),
+      }),
+    );
+
+    expect(text).toBe("hello from the user");
+    expect(text).not.toContain("BEGIN_OPENCLAW_INTERNAL_CONTEXT");
+    expect(text).not.toContain("message_id");
+  });
+
+  it("returns empty text when content is only an internal runtime-context wrapper", () => {
+    const text = resolveDiscordMessageText(
+      asMessage({
+        content: [
+          "<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>",
+          '{"chat_id":"c1","message_id":"m1"}',
+          "<<<END_OPENCLAW_INTERNAL_CONTEXT>>>",
+        ].join("\n"),
+      }),
+    );
+
+    expect(text.trim()).toBe("");
+  });
+
+  it("strips internal runtime-context wrappers from fallback text", () => {
+    const text = resolveDiscordMessageText(asMessage({ content: "" }), {
+      fallbackText: [
+        "visible fallback",
+        "<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>",
+        "secret",
+        "<<<END_OPENCLAW_INTERNAL_CONTEXT>>>",
+      ].join("\n"),
+    });
+
+    expect(text).toBe("visible fallback");
+  });
+
+  it("strips internal runtime-context wrappers from forwarded snapshot content", () => {
+    const text = resolveDiscordMessageText(
+      asForwardedSnapshotMessage({
+        content: [
+          "forwarded hello",
+          "<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>",
+          '{"forwarded":true}',
+          "<<<END_OPENCLAW_INTERNAL_CONTEXT>>>",
+        ].join("\n"),
+        embeds: [],
+      }),
+      { includeForwarded: true },
+    );
+
+    expect(text).toContain("[Forwarded message from @Bob]");
+    expect(text).toContain("forwarded hello");
+    expect(text).not.toContain("BEGIN_OPENCLAW_INTERNAL_CONTEXT");
+  });
 });
 
 describe("resolveDiscordChannelInfo", () => {


### PR DESCRIPTION
Closes #108409

## What Problem This Solves

Fixes an issue where Discord inbound user messages that include an OpenClaw internal runtime-context block (`<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>` … `<<<END_OPENCLAW_INTERNAL_CONTEXT>>>`) were treated as user-authored text. That wrapper could be persisted into the session, re-broadcast as empty-looking standalone user events, and pollute model context.

## Why This Change Was Made

Discord's canonical visible-text resolver assembled raw `message.content` (plus mentions, embeds, components, and forwarded snapshots) without stripping internal runtime-context envelopes. This change strips those line-anchored envelopes from each textual candidate **before** fallback precedence (content → media → embed → component → explicit fallback), so wrapper-only content does not win the chain and later become empty (which would suppress legitimate attachment, embed, sticker, or component text). Mentions are resolved on the selected body afterward. The same pre-precedence strip applies to forwarded snapshot bodies.

Compatibility: delimiter markers match the existing core runtime-context protocol; no config or API change. Performance: strip runs only when the begin marker is present. Usability: sessions no longer store internal scaffolding as user text, and media/rich Discord events remain deliverable when content is wrapper-only. Security: internal metadata is kept out of user turns at the Discord ingress boundary.

## User Impact

Discord turns that accidentally carry OpenClaw runtime-context wrappers no longer appear as user messages or get re-broadcast as empty user events. Real user text is preserved; wrapper-only payloads fall through to attachment/embed/component/fallback text when present, or resolve empty when there is no other candidate.

## Evidence

Focused Vitest on the Discord message text resolver (57 tests, including runtime-context and wrapper-plus-media regression cases):

```text
node scripts/run-vitest.mjs extensions/discord/src/monitor/message-utils.test.ts
 ✓ |extension-discord| extensions/discord/src/monitor/message-utils.test.ts (57 tests)
 Test Files  1 passed (1)
```

Runtime-context / fallback cases cover:
- mixed user text + wrapper → user text only
- wrapper-only content → empty
- fallback text with wrapper → visible fallback only
- forwarded snapshot content with wrapper → forwarded user text only
- **wrapper-only content + attachment → `<media:image> (1 image)`** (pre-precedence strip preserves media)
- **wrapper-only content + embed → embed title/description**
- **wrapper-only content + sticker → sticker placeholder**
- **mixed visible caption + wrapper + attachment → caption only**

Static checks on touched files: `git diff --check` clean; `oxfmt --check` clean on both files.

Verification host: local macOS (focused unit proof).

## Real behavior proof

- Behavior addressed: Discord ingress no longer treats OpenClaw internal runtime-context wrappers as user-authored message content, and no longer suppresses attachment/embed/sticker/component fallbacks when content is wrapper-only.
- Environment: local macOS openclaw checkout on branch `fix/108409-discord-strip-inbound-runtime-context`; focused Vitest via `node scripts/run-vitest.mjs`.
- Current-main contrast: on main, `resolveDiscordMessageText` returns raw content including `<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>` blocks (no strip). The prior branch revision stripped after candidate selection, so wrapper-only content could win the `||` chain and then become empty, suppressing media/embed/component fallbacks.
- Exact steps or command run after this patch:
  1. `node scripts/run-vitest.mjs extensions/discord/src/monitor/message-utils.test.ts -t "runtime-context|wrapper"`
  2. `node scripts/run-vitest.mjs extensions/discord/src/monitor/message-utils.test.ts`
- Evidence after fix: eight runtime-context / wrapper-plus-media cases pass; full `message-utils` suite 57/57 green. Wrapper-only content with an image attachment resolves to `<media:image> (1 image)`; wrapper-only + embed resolves to embed text; mixed caption + wrapper keeps the caption.
- Control check: existing mention, embed, component, and forwarded-message cases still pass; only paths containing the internal begin marker invoke strip work.
- Observed result after fix: user-visible Discord body text excludes internal runtime-context envelopes on primary, fallback, and forwarded snapshot paths, and media/rich fallbacks remain available when sanitized content is empty.
- What was not tested: live Discord guild/DM send/receive (no live tenant in this verification path). Source-level acceptance covers the CS-named candidate-order regression (wrapper-only + attachment/embed/sticker) and mixed text cases. Legacy non-delimited runtime-context formats are not re-parsed in this plugin-local strip (current BEGIN/END envelope is the reported failure mode).

## AI disclosure

This PR was authored with AI assistance (Grok).