### PR TITLE
chore(plugin-sdk): refresh merged API baseline

### DIFF
--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-b8431b55f28440c269cec5afd95c3ef7cd7eb2b443c5cf713fcbaefacc5e0634  plugin-sdk-api-baseline.json
-6dc1e7d7015b7cd5451d0e716bea212f6824da0e71f311f62aad46948d039524  plugin-sdk-api-baseline.jsonl
+a946f69b8ec03ed5b3ff26301b70e4adfe8e78574f6afa147accf92c2b314b11  plugin-sdk-api-baseline.json
+363f06ea86f4b1cc2f7a065c7db74290cc13df7cc1f427b37928109d92ddd8f6  plugin-sdk-api-baseline.jsonl


### PR DESCRIPTION
Related: #107734

## What Problem This Solves

Resolves a post-merge generated-baseline mismatch where `pnpm plugin-sdk:api:check` fails on current `main` after #107734 and #106638 landed across the same moving mainline window.

## Why This Change Was Made

Regenerates the committed Plugin SDK API baseline hashes from the combined current-main surface. This changes generated metadata only; it does not change runtime behavior or the public API.

## User Impact

No user-visible behavior change. The Plugin SDK API baseline gate is restored for subsequent pull requests and mainline validation.

## Evidence

- `pnpm plugin-sdk:api:gen`
- `pnpm plugin-sdk:api:check`
- `pnpm plugin-sdk:surface:check` — 7,949 public exports and 4,437 public callable exports
- `pnpm docs:map:check`
- `git diff --check`
- AutoReview: no accepted/actionable findings
