### PR TITLE
refactor(cron): share task history timestamp

### DIFF
--- a/src/cron/service/task-runs.ts
+++ b/src/cron/service/task-runs.ts
@@ -24,6 +24,7 @@ import {
   cronTaskRecordStoreKey,
   cronTaskRecordToRunLogEntry,
   cronTaskRecordToTriggerEval,
+  resolveCronTaskRecordTimestamp,
 } from "../task-run-detail.js";
 import { cronRunLogEntryFromEvent } from "../task-run-event-codec.js";
 import type { CronJob, CronRunStatus } from "../types.js";
@@ -130,8 +131,7 @@ function findLatestCronTaskRunForRecovery(
     .toSorted(
       (left, right) =>
         Number(left.endedAt !== undefined) - Number(right.endedAt !== undefined) ||
-        (right.endedAt ?? right.lastEventAt ?? right.createdAt) -
-          (left.endedAt ?? left.lastEventAt ?? left.createdAt) ||
+        resolveCronTaskRecordTimestamp(right) - resolveCronTaskRecordTimestamp(left) ||
         right.createdAt - left.createdAt ||
         right.taskId.localeCompare(left.taskId),
     )[0];

--- a/src/cron/task-run-detail.ts
+++ b/src/cron/task-run-detail.ts
@@ -210,6 +210,13 @@ export function cronTaskRecordStoreKey(task: TaskRecord): string | undefined {
     : undefined;
 }
 
+/** Keeps history projection, recovery, and retention on one task-row timestamp. */
+export function resolveCronTaskRecordTimestamp(
+  task: Pick<TaskRecord, "endedAt" | "lastEventAt" | "createdAt">,
+): number {
+  return task.endedAt ?? task.lastEventAt ?? task.createdAt;
+}
+
 /** Reads internal trigger recovery data without adding it to run-history responses. */
 export function cronTaskRecordToTriggerEval(
   task: TaskRecord,
@@ -250,7 +257,7 @@ export function cronTaskRecordToRunLogEntry(task: TaskRecord): CronRunLogEntry |
   const entry = parseCronRunLogEntryObject(
     {
       ...wireDetail,
-      ts: task.endedAt ?? task.lastEventAt ?? task.createdAt,
+      ts: resolveCronTaskRecordTimestamp(task),
       jobId: task.sourceId,
       action: "finished",
       status: isCronRunStatus(task.detail.status) ? task.detail.status : undefined,

--- a/src/tasks/cron-history-retention.ts
+++ b/src/tasks/cron-history-retention.ts
@@ -1,5 +1,5 @@
 /** Enforces the task-ledger retention bound for terminal cron history. */
-import { cronTaskRecordStoreKey } from "../cron/task-run-detail.js";
+import { cronTaskRecordStoreKey, resolveCronTaskRecordTimestamp } from "../cron/task-run-detail.js";
 import type { TaskRecord } from "./task-registry.types.js";
 import { resolveEffectiveTaskCleanupAfter } from "./task-retention.js";
 
@@ -34,9 +34,10 @@ export function collectCronHistoryOverflowTaskIds(tasks: readonly TaskRecord[]):
   for (const bySource of byStore.values()) {
     for (const rows of bySource.values()) {
       rows.sort((left, right) => {
-        const leftAt = left.endedAt ?? left.lastEventAt ?? left.createdAt;
-        const rightAt = right.endedAt ?? right.lastEventAt ?? right.createdAt;
-        return rightAt - leftAt || right.taskId.localeCompare(left.taskId);
+        return (
+          resolveCronTaskRecordTimestamp(right) - resolveCronTaskRecordTimestamp(left) ||
+          right.taskId.localeCompare(left.taskId)
+        );
       });
       for (const task of rows.slice(CRON_HISTORY_KEEP_PER_JOB)) {
         overflow.add(task.taskId);

--- a/src/tasks/task-registry.maintenance.ts
+++ b/src/tasks/task-registry.maintenance.ts
@@ -19,6 +19,7 @@ import {
 } from "../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { isCronJobActive } from "../cron/active-jobs.js";
+import { resolveCronTaskRecordTimestamp } from "../cron/task-run-detail.js";
 import { getAgentRunContext } from "../infra/agent-events.js";
 import { getSessionBindingService } from "../infra/outbound/session-binding-service.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
@@ -364,7 +365,7 @@ function resolveDurableCronTaskRecovery(
   if (!row || !isCronTerminalTaskStatus(row.status)) {
     return undefined;
   }
-  const endedAt = row.endedAt ?? row.lastEventAt ?? row.createdAt;
+  const endedAt = resolveCronTaskRecordTimestamp(row);
   return {
     status: row.status,
     endedAt,


### PR DESCRIPTION
## What Problem This Solves

Cron task-row timestamp precedence was repeated across history projection, retention, crash recovery, and maintenance recovery. Those copies had to remain manually synchronized even though they represent one storage contract.

## Why This Change Was Made

This maintainer-requested follow-up centralizes `endedAt -> lastEventAt -> createdAt` in the cron task-detail codec and reuses it at all four decision surfaces. Storage, ordering, retention limits, and wire output remain unchanged.

## User Impact

No user-visible behavior change. The cron history paths now share one timestamp invariant, reducing future drift risk.

## Evidence

- `node scripts/run-vitest.mjs src/cron/task-run-history.test.ts src/cron/service/task-runs.test.ts src/tasks/task-registry.maintenance.issue-60299.test.ts` — 3 files, 44 tests passed.
- `node scripts/check-changed.mjs -- src/cron/task-run-detail.ts src/cron/service/task-runs.ts src/tasks/cron-history-retention.ts src/tasks/task-registry.maintenance.ts` — changed-surface checks reached the Plugin SDK baseline gate; the same baseline mismatch reproduces on clean current `main` and is unrelated to these paths.
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted --stream-engine-output` — clean, no findings, correctness confidence 0.98.

AI-assisted: Codex. Maintainer-requested refactor follow-up.
