### PR TITLE
fix(codex): explain sessionKey/sessionId lifecycle when a session generation is stale

### DIFF
--- a/extensions/codex/src/app-server/run-attempt-connection.ts
+++ b/extensions/codex/src/app-server/run-attempt-connection.ts
@@ -43,6 +43,7 @@ import {
 } from "./session-binding.js";
 import { getLeasedSharedCodexAppServerClient } from "./shared-client.js";
 import { rotateOversizedCodexAppServerStartupBinding } from "./startup-binding.js";
+import { CodexSessionGenerationNotCurrentError } from "./thread-lifecycle-errors.js";
 
 export async function prepareCodexAttemptConnection({ params, options }: CodexRunAttemptInput) {
   const attemptStartedAt = Date.now();
@@ -119,9 +120,7 @@ export async function prepareCodexAttemptConnection({ params, options }: CodexRu
       config: params.config,
     });
     if (!reclaimed) {
-      throw new Error(
-        `Codex session generation is no longer current: ${bindingIdentity.sessionId}`,
-      );
+      throw new CodexSessionGenerationNotCurrentError(bindingIdentity);
     }
     startupBinding = await bindingStore.read(bindingIdentity);
   }

--- a/extensions/codex/src/app-server/thread-lifecycle-errors.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle-errors.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { CodexSessionGenerationNotCurrentError } from "./thread-lifecycle-errors.js";
+
+describe("CodexSessionGenerationNotCurrentError", () => {
+  it("keeps the stable prefix so existing callers and matchers still recognize it", () => {
+    const error = new CodexSessionGenerationNotCurrentError({
+      sessionId: "isolated-task-42",
+      sessionKey: "tool:isolated-task",
+    });
+    expect(error).toBeInstanceOf(Error);
+    expect(error.name).toBe("CodexSessionGenerationNotCurrentError");
+    expect(error.message).toContain(
+      "Codex session generation is no longer current: isolated-task-42",
+    );
+  });
+
+  it("guides embedded callers to omit sessionKey or reuse sessionId", () => {
+    // Regression #108769: a stable sessionKey with a rotating sessionId used to fail
+    // opaquely, so the message must name the offending key and both escape hatches.
+    const error = new CodexSessionGenerationNotCurrentError({
+      sessionId: "isolated-task-42",
+      sessionKey: "tool:isolated-task",
+    });
+    expect(error.message).toContain('sessionKey "tool:isolated-task"');
+    expect(error.message).toContain("omit sessionKey");
+    expect(error.message).toContain("reuse the same sessionId");
+  });
+
+  it("omits key-specific guidance when no sessionKey is involved", () => {
+    const error = new CodexSessionGenerationNotCurrentError({ sessionId: "isolated-task-42" });
+    expect(error.message).toBe("Codex session generation is no longer current: isolated-task-42.");
+    expect(error.message).not.toContain("sessionKey");
+  });
+});

--- a/extensions/codex/src/app-server/thread-lifecycle-errors.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle-errors.ts
@@ -29,3 +29,17 @@ export class CodexAdoptedThreadActiveError extends Error {
     this.name = "CodexAdoptedThreadActiveError";
   }
 }
+
+export class CodexSessionGenerationNotCurrentError extends Error {
+  constructor(identity: { sessionId: string; sessionKey?: string }) {
+    const sessionKey = identity.sessionKey?.trim();
+    // A stable sessionKey pins one OpenClaw session generation, so a run whose sessionId
+    // no longer owns that generation cannot reclaim the key. Give embedded callers an
+    // actionable identity choice instead of the bare reclaim failure.
+    const guidance = sessionKey
+      ? ` A newer OpenClaw session generation owns sessionKey "${sessionKey}", so this run's sessionId is no longer that key's current generation. For isolated embedded runs that rotate sessionId per call, omit sessionKey so each run keeps its own identity; to continue one logical session, reuse the same sessionId instead of rotating it.`
+      : "";
+    super(`Codex session generation is no longer current: ${identity.sessionId}.${guidance}`);
+    this.name = "CodexSessionGenerationNotCurrentError";
+  }
+}

--- a/extensions/codex/src/app-server/thread-lifecycle-run.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle-run.ts
@@ -45,7 +45,10 @@ import {
   legacyFingerprintUserMcpServersConfigPatch,
   shouldStartTransientNoToolThread,
 } from "./thread-fingerprints.js";
-import { CodexThreadBindingConflictError } from "./thread-lifecycle-errors.js";
+import {
+  CodexSessionGenerationNotCurrentError,
+  CodexThreadBindingConflictError,
+} from "./thread-lifecycle-errors.js";
 import { resumeExistingCodexThread, startFreshCodexThread } from "./thread-lifecycle-io.js";
 import { createCodexThreadLifecycleTimingTracker } from "./thread-lifecycle-timing.js";
 import type {
@@ -194,9 +197,7 @@ export async function startOrResumeThread(
         }),
       );
       if (!reclaimed) {
-        throw new Error(
-          `Codex session generation is no longer current: ${bindingIdentity.sessionId}`,
-        );
+        throw new CodexSessionGenerationNotCurrentError(bindingIdentity);
       }
     }
     if (binding?.pendingSupervisionBranch) {

--- a/extensions/codex/src/command-handlers.ts
+++ b/extensions/codex/src/command-handlers.ts
@@ -38,6 +38,7 @@ import {
   type CodexAppServerBindingStore,
   type CodexAppServerThreadBinding,
 } from "./app-server/session-binding.js";
+import { CodexSessionGenerationNotCurrentError } from "./app-server/thread-lifecycle-errors.js";
 import { readCodexAccountAuthOverview } from "./command-account.js";
 import { canMutateCodexHost, CODEX_NATIVE_EXECUTION_AUTH_ERROR } from "./command-authorization.js";
 import {
@@ -911,7 +912,7 @@ async function resumeThread(
       config: ctx.config,
     });
     if (!reclaimed) {
-      throw new Error(`Codex session generation is no longer current: ${identity.sessionId}`);
+      throw new CodexSessionGenerationNotCurrentError(identity);
     }
     const currentBinding = await deps.bindingStore.read(identity);
     assertCodexBindingMayBeReplaced(currentBinding, "attaching a different resumed thread");


### PR DESCRIPTION
Related: #108769

## What Problem This Solves

Resolves a problem where a plugin using the Codex harness calls `runEmbeddedAgent` twice with a stable `sessionKey` but a freshly generated `sessionId` per run (a valid, publicly typed `RunEmbeddedAgentParams` combination) and the second call fails before model execution with a bare `Codex session generation is no longer current: <sessionId>`. The message names neither the `sessionKey` that collided nor how to proceed, so plugin authors cannot tell whether to omit `sessionKey`, reuse the `sessionId`, or do something else. The first call succeeds and a single post-upgrade smoke run passes, so the regression (#108769, also surfaced in #106957) is easy to miss.

## Why This Change Was Made

Three reclaim call sites (`run-attempt-connection.ts`, `thread-lifecycle-run.ts`, `command-handlers.ts`) each threw the same hand-written string when `reclaimCurrentCodexSessionGeneration(...)` returns `false`. This routes all three through one `CodexSessionGenerationNotCurrentError` in `thread-lifecycle-errors.ts` that keeps the original leading sentence — so existing callers and matchers still recognize it — and appends actionable guidance naming the offending `sessionKey` plus both supported identity choices.

Scope note: this delivers option 2 from #108769 (reject the incompatible combination with actionable guidance). It deliberately does not loosen the generation fence (option 1). Restoring cross-generation reclaim for a rotating `sessionId` is a compatibility / session-state product decision, so I left that to maintainers rather than changing fail-closed behavior in a contributor PR.

## User Impact

Plugin and embedded-agent authors who hit the stale-generation rejection now get an error that names the colliding `sessionKey` and tells them to omit `sessionKey` for isolated runs, or reuse the `sessionId` for one logical session — instead of an opaque failure with no next step. There is no runtime behavior change: the same runs still fail; only the message is clearer.

## Evidence

- New colocated unit test `extensions/codex/src/app-server/thread-lifecycle-errors.test.ts` asserts the preserved prefix, the actionable guidance (names the key and both escape hatches), and the keyless fallback message.
- The existing assertion in `run-attempt.test.ts` (`toThrow("Codex session generation is no longer current")`) still matches, because the leading sentence is unchanged.
- Proof gap (stated plainly): I could not run the codex suite locally — this is a sparse fork checkout without installed dependencies — so I am relying on CI for the full run.
