### PR TITLE
fix(line): validate generic batch media URLs

### DIFF
--- a/extensions/line/src/auto-reply-delivery.test.ts
+++ b/extensions/line/src/auto-reply-delivery.test.ts
@@ -92,7 +92,6 @@ describe("deliverLineAutoReply", () => {
       createQuickReplyItems: createQuickReplyItems as LineAutoReplyDeps["createQuickReplyItems"],
       pushMessagesLine,
       createFlexMessage: createFlexMessage as LineAutoReplyDeps["createFlexMessage"],
-      createImageMessage,
       buildMediaMessage,
       createLocationMessage,
       ...overrides,
@@ -562,10 +561,9 @@ describe("deliverLineAutoReply", () => {
   });
 
   it("keeps the image route for generic media without LINE-specific options", async () => {
-    // Parity with the push path (docs/channels/line.md): a bare media URL with no
-    // LINE media options stays on the image route and does not attempt resolution.
-    // A .mp4 proves it: if the generic path wrongly resolved by kind it would infer
-    // "video" (missing preview → build failure), so an image bubble means image route.
+    // A bare media URL stays on the image route, but shares validation with
+    // LINE-specific media. A .mp4 proves the explicit image fallback prevents
+    // extension-based video inference.
     const { deps, replyMessageLine, buildMediaMessage } = createDeps({
       processLineMessage: () => ({ text: "", flexMessages: [] }),
       chunkMarkdownText: () => [],
@@ -582,7 +580,16 @@ describe("deliverLineAutoReply", () => {
     });
 
     expect(result.status).toBe("delivered");
-    expect(buildMediaMessage).not.toHaveBeenCalled();
+    expect(buildMediaMessage).toHaveBeenCalledWith(
+      "https://example.com/clip.mp4",
+      {
+        mediaKind: "image",
+        previewImageUrl: undefined,
+        durationMs: undefined,
+        trackingId: undefined,
+      },
+      "line:user:1",
+    );
     expect(replyMessageLine).toHaveBeenCalledWith(
       "token",
       [createImageMessage("https://example.com/clip.mp4")],
@@ -643,7 +650,7 @@ describe("deliverLineAutoReply", () => {
   });
 
   it("does not expose credentials from media-only validation failures", async () => {
-    const lineData = { mediaKind: "image" as const };
+    const lineData = {};
     const mediaUrl = new URL("http://example.com/image.jpg");
     mediaUrl.username = ["line", "user"].join("-");
     mediaUrl.password = ["line", "fixture"].join("-");

--- a/extensions/line/src/auto-reply-delivery.ts
+++ b/extensions/line/src/auto-reply-delivery.ts
@@ -26,10 +26,6 @@ type LineAutoReplyDeps = {
     opts: { cfg: OpenClawConfig; accountId?: string },
   ) => Promise<unknown>;
   createFlexMessage: (altText: string, contents: FlexContainer) => messagingApi.FlexMessage;
-  createImageMessage: (
-    originalContentUrl: string,
-    previewImageUrl?: string,
-  ) => messagingApi.ImageMessage;
   buildMediaMessage: (
     mediaUrl: string,
     opts: Pick<LineChannelData, "mediaKind" | "previewImageUrl" | "durationMs" | "trackingId">,
@@ -190,13 +186,13 @@ export async function deliverLineAutoReply(params: {
 
   // Match the push path (outbound.ts): honor channelData.line.mediaKind and the
   // other LINE media options so a reply-token video/audio is not silently
-  // downgraded to an image. Generic media sends without LINE-specific options
-  // keep the image route. A media build failure is partial only after another
-  // visible part lands; media-only failures remain full failures.
+  // downgraded to an image. Generic media stays image-only but still goes
+  // through the same validation boundary. A media build failure is partial only
+  // after another visible part lands; media-only failures remain full failures.
   const mediaUrls = resolveSendableOutboundReplyParts(payload).mediaUrls;
   const useLineSpecificMedia = hasLineSpecificMediaOptions(lineData);
-  const mediaOpts = {
-    mediaKind: lineData.mediaKind,
+  const mediaOpts: Parameters<LineAutoReplyDeps["buildMediaMessage"]>[1] = {
+    mediaKind: useLineSpecificMedia ? lineData.mediaKind : "image",
     previewImageUrl: lineData.previewImageUrl,
     durationMs: lineData.durationMs,
     trackingId: lineData.trackingId,
@@ -206,10 +202,6 @@ export async function deliverLineAutoReply(params: {
   for (const rawUrl of mediaUrls) {
     const url = rawUrl?.trim();
     if (!url) {
-      continue;
-    }
-    if (!useLineSpecificMedia) {
-      mediaMessages.push(deps.createImageMessage(url));
       continue;
     }
     try {

--- a/extensions/line/src/channel.sendPayload.test.ts
+++ b/extensions/line/src/channel.sendPayload.test.ts
@@ -62,6 +62,14 @@ function lineResult(messageId: string, chatId = "c1") {
   };
 }
 
+function createCredentialBearingHttpUrl(): string {
+  const url = new URL("http://example.com/image.jpg");
+  url.username = ["line", "user"].join("-");
+  url.password = ["line", "fixture"].join("-");
+  url.searchParams.set("auth", ["line", "query"].join("-"));
+  return url.href;
+}
+
 function createRuntime(): { runtime: PluginRuntime; mocks: LineRuntimeMocks } {
   const pushMessageLine = vi.fn(async () => lineResult("m-text"));
   const pushMessagesLine = vi.fn(async () => lineResult("m-batch"));
@@ -500,6 +508,60 @@ describe("line outbound sendPayload", () => {
       ],
       { verbose: false, accountId: "default", cfg },
     );
+  });
+
+  it("keeps generic quick-reply media on the validated image route", async () => {
+    const { runtime, mocks } = createRuntime();
+    setLineRuntime(runtime);
+    const cfg = { channels: { line: {} } } as OpenClawConfig;
+
+    await lineOutboundAdapter.sendPayload!({
+      to: "line:user:U123",
+      text: "",
+      payload: {
+        mediaUrl: "https://example.com/clip.mp4",
+        channelData: { line: { quickReplies: ["One"] } },
+      },
+      accountId: "default",
+      cfg,
+    });
+
+    expect(mocks.pushMessagesLine).toHaveBeenCalledWith(
+      "line:user:U123",
+      [
+        {
+          type: "image",
+          originalContentUrl: "https://example.com/clip.mp4",
+          previewImageUrl: "https://example.com/clip.mp4",
+          quickReply: { items: ["One"] },
+        },
+      ],
+      { verbose: false, accountId: "default", cfg },
+    );
+    expect(ssrfMocks.resolvePinnedHostnameWithPolicy).toHaveBeenCalledWith("example.com", {
+      policy: { allowPrivateNetwork: false },
+    });
+  });
+
+  it("rejects insecure generic media before quick-reply batch sends", async () => {
+    const { runtime, mocks } = createRuntime();
+    setLineRuntime(runtime);
+    const cfg = { channels: { line: {} } } as OpenClawConfig;
+
+    await expect(
+      lineOutboundAdapter.sendPayload!({
+        to: "line:user:U123",
+        text: "",
+        payload: {
+          mediaUrl: createCredentialBearingHttpUrl(),
+          channelData: { line: { quickReplies: ["One"] } },
+        },
+        accountId: "default",
+        cfg,
+      }),
+    ).rejects.toThrow(new Error("LINE outbound media URL must use HTTPS"));
+
+    expect(mocks.pushMessagesLine).not.toHaveBeenCalled();
   });
 
   it("keeps trackingId for user quick-reply inline video media", async () => {

--- a/extensions/line/src/monitor.ts
+++ b/extensions/line/src/monitor.ts
@@ -32,7 +32,6 @@ import { sendLineReplyChunks } from "./reply-chunks.js";
 import { getLineRuntime } from "./runtime.js";
 import {
   createFlexMessage,
-  createImageMessage,
   createLocationMessage,
   createQuickReplyItems,
   createTextMessageWithQuickReplies,
@@ -232,7 +231,6 @@ export async function monitorLineProvider(
                       createTextMessageWithQuickReplies,
                       pushMessagesLine,
                       createFlexMessage,
-                      createImageMessage,
                       buildMediaMessage: buildLineMediaMessage,
                       createLocationMessage,
                       onReplyError: (replyErr) => {

--- a/extensions/line/src/outbound.ts
+++ b/extensions/line/src/outbound.ts
@@ -93,6 +93,12 @@ export const lineOutboundAdapter: NonNullable<ChannelPlugin<ResolvedLineAccount>
       : [];
     const mediaUrls = resolveOutboundMediaUrls(payload);
     const useLineSpecificMedia = hasLineSpecificMediaOptions(lineData);
+    const mediaOptions = {
+      mediaKind: useLineSpecificMedia ? lineData.mediaKind : ("image" as const),
+      previewImageUrl: lineData.previewImageUrl,
+      durationMs: lineData.durationMs,
+      trackingId: lineData.trackingId,
+    };
     const shouldSendQuickRepliesInline = chunks.length === 0 && hasQuickReplies;
     const sendMediaMessages = async () => {
       for (const url of mediaUrls) {
@@ -111,12 +117,7 @@ export const lineOutboundAdapter: NonNullable<ChannelPlugin<ResolvedLineAccount>
           );
           continue;
         }
-        const resolved = await resolveLineOutboundMedia(trimmed, {
-          mediaKind: lineData.mediaKind,
-          previewImageUrl: lineData.previewImageUrl,
-          durationMs: lineData.durationMs,
-          trackingId: lineData.trackingId,
-        });
+        const resolved = await resolveLineOutboundMedia(trimmed, mediaOptions);
         await recordResult(
           (lineRuntime?.sendMessageLine ?? outboundRuntime.sendMessageLine)(to, "", {
             verbose: false,
@@ -241,26 +242,7 @@ export const lineOutboundAdapter: NonNullable<ChannelPlugin<ResolvedLineAccount>
         if (!trimmed) {
           continue;
         }
-        if (!useLineSpecificMedia) {
-          quickReplyMessages.push({
-            type: "image",
-            originalContentUrl: trimmed,
-            previewImageUrl: trimmed,
-          });
-          continue;
-        }
-        quickReplyMessages.push(
-          await buildLineMediaMessage(
-            trimmed,
-            {
-              mediaKind: lineData.mediaKind,
-              previewImageUrl: lineData.previewImageUrl,
-              durationMs: lineData.durationMs,
-              trackingId: lineData.trackingId,
-            },
-            to,
-          ),
-        );
+        quickReplyMessages.push(await buildLineMediaMessage(trimmed, mediaOptions, to));
       }
       if (quickReplyMessages.length > 0 && quickReply) {
         const lastIndex = quickReplyMessages.length - 1;


### PR DESCRIPTION
Follow-up to #108657.

## What Problem This Solves

Generic LINE media attached to quick-reply batches or inbound auto-replies bypassed the outbound media URL validation used by direct and LINE-specific sends. Malformed or credential-bearing non-HTTPS URLs could therefore reach the LINE SDK error path instead of failing at the plugin boundary.

## Why This Change Was Made

Both batch paths now use the existing `buildLineMediaMessage` boundary. Generic payloads explicitly select the existing image fallback, preserving valid-message behavior while sharing HTTPS, length, and SSRF validation. The obsolete raw-image dependency and duplicate message construction branches are removed.

## User Impact

Valid generic media remains image-only. Invalid generic media now fails before the LINE SDK receives it, with the same stable reason-only errors as other LINE outbound media paths.

AI-assisted: yes.

## Evidence

- `node scripts/run-vitest.mjs extensions/line/src/outbound-media.test.ts extensions/line/src/channel.sendPayload.test.ts extensions/line/src/auto-reply-delivery.test.ts extensions/line/src/monitor.lifecycle.test.ts` — 4 files, 70 tests passed.
- `git diff --check origin/main...HEAD` — passed.
- `node scripts/check-changed.mjs -- extensions/line/src/outbound.ts extensions/line/src/auto-reply-delivery.ts extensions/line/src/monitor.ts extensions/line/src/channel.sendPayload.test.ts extensions/line/src/auto-reply-delivery.test.ts` — LINE formatting and repository guards passed on Testbox; the only failure was the unrelated current-main Plugin SDK API baseline mismatch. The generator roots are `src/plugin-sdk/*`; this PR changes only private `extensions/line/src/*` files.
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted` — clean; no accepted/actionable findings.
