### PR TITLE
fix(ci): bound actionlint download in workflow-sanity

### DIFF
--- a/.github/workflows/workflow-sanity.yml
+++ b/.github/workflows/workflow-sanity.yml
@@ -186,8 +186,10 @@ jobs:
           # GitHub release downloads occasionally return transient 5xx responses.
           # Retry all curl errors here so workflow-sanity does not fail closed on
           # a one-off release edge outage.
-          curl --retry 5 --retry-delay 2 --retry-all-errors -sSfL -o "${archive}" "${base_url}/${archive}"
-          curl --retry 5 --retry-delay 2 --retry-all-errors -sSfL -o checksums.txt "${base_url}/actionlint_${ACTIONLINT_VERSION}_checksums.txt"
+          curl --connect-timeout 10 --max-time 120 \
+            --retry 5 --retry-delay 2 --retry-all-errors -sSfL -o "${archive}" "${base_url}/${archive}"
+          curl --connect-timeout 10 --max-time 120 \
+            --retry 5 --retry-delay 2 --retry-all-errors -sSfL -o checksums.txt "${base_url}/actionlint_${ACTIONLINT_VERSION}_checksums.txt"
           grep " ${archive}\$" checksums.txt | sha256sum -c -
           tar -xzf "${archive}" actionlint
           sudo install -m 0755 actionlint /usr/local/bin/actionlint


### PR DESCRIPTION
## What Problem This Solves

Stalled TCP connections to GitHub Releases during actionlint binary and checksums download can block the workflow-sanity CI job. The two curl calls had no connection timeout and no transfer cap — a remote endpoint that fails to complete TCP handshaking could hold each download open indefinitely (default system connect timeout often exceeds 2 minutes), stalling the entire actionlint setup step.

## Why This Change Was Made

Both curl invocations (binary archive and checksums file) now carry `--connect-timeout 10` and `--max-time 120`. The connect timeout aborts the TCP handshake after 10 seconds when the remote is unreachable; the max-time caps the full transfer to 2 minutes. These bounds sit alongside the existing `--retry 5 --retry-delay 2 --retry-all-errors` retry policy, so transient failures still get retries but a permanently unreachable endpoint fails fast.

## User Impact

A stalled GitHub Releases connection can no longer block the workflow-sanity CI job. After 10 seconds (connect) or 2 minutes (transfer) the curl invocation exits with a clear error, and the step fails fast rather than consuming runner time against a silent remote.

## Evidence

- Exact head: `c2c7f3f962f6d493973984c8a8e281cc73a4317a`
- Workflow contract: `.github/workflows/workflow-sanity.yml` — both actionlint download `curl` invocations use `--connect-timeout 10` (10-second connect timeout) and `--max-time 120` (2-minute transfer cap) alongside `--retry 5 --retry-delay 2 --retry-all-errors`
- `git diff --check origin/main...HEAD` — passed
