### PR TITLE
fix(ci): bound OCM download in performance workflow

### DIFF
--- a/.github/workflows/openclaw-performance.yml
+++ b/.github/workflows/openclaw-performance.yml
@@ -277,7 +277,7 @@ jobs:
           # retry-max-time only gates new retries; cap an active transfer separately
           # so a stalled release asset cannot consume the entire Kova job deadline.
           curl -fsSL --proto '=https' --tlsv1.2 \
-            --max-time 180 \
+            --connect-timeout 10 --max-time 180 \
             --retry 8 --retry-max-time 180 --retry-all-errors --retry-connrefused \
             -o "$ocm_archive" \
             "https://github.com/shakkernerd/ocm/releases/download/${OCM_VERSION}/ocm-x86_64-unknown-linux-gnu.tar.gz"


### PR DESCRIPTION
## What Problem This Solves

A stalled TCP connection to GitHub Releases during OCM binary download can block the performance CI workflow. The curl invocation already has `--max-time 180` (3-minute transfer cap) and `--retry 8 --retry-max-time 180` for resilient retries, but neither a transfer cap nor a retry budget protects against a connection that never completes handshaking — curl's default connect timeout can let a silent remote stall the step for minutes before any timeout fires.

## Why This Change Was Made

An explicit `--connect-timeout 10` is added to the OCM release asset download curl invocation. This causes curl to abort the TCP connection attempt within 10 seconds when the remote is unreachable, rather than waiting for the system TCP timeout. The existing `--max-time 180` transfer cap and `--retry 8 --retry-max-time 180 --retry-all-errors --retry-connrefused` retry policy remain; the connect timeout provides a fast-failure layer that gives retries a realistic chance of succeeding against a transiently unreachable endpoint.

## User Impact

A stalled GitHub Releases connection can no longer block the OpenClaw performance CI workflow. After 10 seconds the connection attempt exits with a clear curl error, and the retry mechanism can proceed against the next attempt rather than waiting through a silent stall.

## Evidence

- Exact head: `97d9eb9b4c355aae7cbd4bc98de1c113475c546f`
- Workflow contract: `.github/workflows/openclaw-performance.yml` — the OCM release download `curl` invocation uses `--connect-timeout 10` (10-second connect timeout) paired with `--max-time 180` (3-minute transfer cap) and `--retry 8 --retry-max-time 180 --retry-connrefused`
- `git diff --check origin/main...HEAD` — passed
