### PR TITLE
fix(ci): bound plugin npm release artifact download

### DIFF
--- a/.github/workflows/plugin-npm-release.yml
+++ b/.github/workflows/plugin-npm-release.yml
@@ -1126,6 +1126,7 @@ jobs:
             "repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/attempts/${producer_attempt}/jobs?per_page=100" |
             jq -s '{total_count: ([.[].jobs[]] | length), jobs: [.[].jobs[]]}' > "$workflow_jobs"
           curl --fail --location --silent --show-error \
+            --connect-timeout 10 \
             --retry 2 \
             --retry-all-errors \
             --max-time 120 \


### PR DESCRIPTION
## What Problem This Solves

A stalled TCP connection to the GitHub API during immutable npm publication artifact download can hold the workflow step open indefinitely. The existing `--max-time 120` caps the transfer duration once data starts flowing, but curl's default connect timeout (`--connect-timeout`) is 120 seconds behind the scenes — a remote that silently drops SYN packets stalls for two minutes before the outer max-time fires, and longer if retries compound the delay.

## Why This Change Was Made

An explicit `--connect-timeout 10` is added to the artifact download curl invocation so that curl aborts the connection attempt after 10 seconds rather than waiting for the system TCP timeout. The existing `--retry 2 --retry-all-errors --max-time 120` remain in place; the connect timeout operates on a shorter clock, failing fast when the remote is unreachable and giving retries something meaningful to retry against.

## User Impact

A stalled GitHub API connection can no longer block the plugin npm release artifact download. After 10 seconds the connection attempt fails, and curl either retries or (after exhausting retries) exits with a clear curl error message.

## Evidence

- Exact head: `68d7fc643f167ba385342e0da30e119a3d56dec8`
- Workflow contract: `.github/workflows/plugin-npm-release.yml` — the artifact download `curl` invocation uses `--connect-timeout 10` (10-second connect timeout) paired with `--max-time 120` (2-minute transfer cap)
- `git diff --check origin/main...HEAD` — passed
