### PR TITLE
fix(synology-chat): avoid phantom accounts from blank tokens

### DIFF
--- a/extensions/synology-chat/src/accounts.ts
+++ b/extensions/synology-chat/src/accounts.ts
@@ -5,6 +5,7 @@
 
 import {
   DEFAULT_ACCOUNT_ID,
+  hasConfiguredAccountValue,
   listCombinedAccountIds,
   resolveMergedAccountConfig,
   type OpenClawConfig,
@@ -24,7 +25,10 @@ function getChannelConfig(cfg: OpenClawConfig): SynologyChatChannelConfig | unde
 }
 
 function resolveImplicitAccountId(channelCfg: SynologyChatChannelConfig): string | undefined {
-  return channelCfg.token || process.env.SYNOLOGY_CHAT_TOKEN ? DEFAULT_ACCOUNT_ID : undefined;
+  return hasConfiguredAccountValue(channelCfg.token) ||
+    hasConfiguredAccountValue(process.env.SYNOLOGY_CHAT_TOKEN)
+    ? DEFAULT_ACCOUNT_ID
+    : undefined;
 }
 
 function getRawAccountConfig(

--- a/extensions/synology-chat/src/core.test.ts
+++ b/extensions/synology-chat/src/core.test.ts
@@ -181,6 +181,17 @@ describe("synology-chat account resolution", () => {
     expect(listAccountIds(cfg)).toEqual(["default"]);
   });
 
+  it("does not list an implicit default account for a blank env token", () => {
+    process.env.SYNOLOGY_CHAT_TOKEN = "   ";
+    const cfg = {
+      channels: {
+        "synology-chat": { accounts: { office: {} } },
+      },
+    };
+
+    expect(listAccountIds(cfg)).toEqual(["office"]);
+  });
+
   it("lists named and default accounts together", () => {
     const cfg = {
       channels: {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users with `SYNOLOGY_CHAT_TOKEN` set to whitespace would see a phantom default Synology Chat account even though no usable token was configured. This inflated account counts and sent status/startup flows down an unconfigured account path.

## Why This Change Was Made

The implicit default-account predicate now uses the existing shared configured-value contract for both config and environment tokens, so whitespace-only strings are treated as absent while valid tokens and explicitly named accounts keep their existing behavior. The change stays within Synology Chat account discovery and does not alter named-account merging or credential resolution.

## User Impact

Synology Chat no longer reports or attempts to use a default account created only by a blank environment token. Valid environment tokens, explicit base tokens, and named accounts continue to be listed normally.

## Evidence

AI-assisted.

Real production-path proof was run on Linux with Node `v24.18.0`, directly importing and invoking `extensions/synology-chat/src/accounts.ts` through the repository's `tsx` loader (no mocked account resolver).

Command used for the failing-before and fixed-after blank-token check:

```bash
SYNOLOGY_CHAT_TOKEN='   ' node --import tsx --input-type=module -e 'import { listAccountIds } from "./extensions/synology-chat/src/accounts.ts"; console.log(JSON.stringify(listAccountIds({ channels: { "synology-chat": {} } })))'
```

- Before (`upstream/main` at `0b97e22a10feafdbe4c346f8ef531acf7424961a`): `["default"]`
- After (`e6d63998d`): `[]`
- Negative control: the same production-function harness returned `[]` with the env var missing, `["default"]` with `SYNOLOGY_CHAT_TOKEN=env-token`, and `["office"]` for a named `office` account plus a blank env token.

Focused validation:

```text
node scripts/run-vitest.mjs extensions/synology-chat/src/core.test.ts
Test Files  1 passed (1)
Tests       25 passed (25)

node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json extensions/synology-chat/src/accounts.ts extensions/synology-chat/src/core.test.ts
passed

git diff --check
passed

.agents/skills/autoreview/scripts/autoreview --mode uncommitted
autoreview clean: no accepted/actionable findings reported
overall: patch is correct (0.94)
```

The full Synology Chat network/webhook path was not exercised because the defect occurs during local account enumeration before any network request.
